### PR TITLE
Delay allocation of tracing objects until tracing is active

### DIFF
--- a/comms/torchcomms/TorchCommTracing.hpp
+++ b/comms/torchcomms/TorchCommTracing.hpp
@@ -57,9 +57,17 @@ class TorchCommTracingGuard {
       const std::vector<int64_t>& input_split_sizes,
       const std::vector<int64_t>& output_split_sizes);
 
+  void initializeTracingCommon(
+      const std::string& comm_name,
+      int comm_size,
+      const std::string& collective_name,
+      int collective_rank,
+      const std::vector<at::Tensor>& input_tensor_list,
+      const std::vector<at::Tensor>& output_tensor_list);
+
  private:
   std::unique_ptr<c10::DebugInfoGuard> debug_info_guard_;
-  std::unique_ptr<at::RecordFunction> record_function_guard_;
+  std::optional<at::RecordFunction> record_function_guard_;
 
   inline static int sequence_number_ = 0;
 };


### PR DESCRIPTION
Summary:
isactive returns true if we're currently under profiling and we're being sampled.
1. This delays allocation of debug objects only if isActive is true
2. Allocates the recordfunction with the TracingGuard to avoid an extra malloc in the fast path

Reviewed By: tanquer

Differential Revision: D85826988


