### PR TITLE
ci: enable Python Free threading builds 3.13t, 3.14t

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -19,9 +19,6 @@ jobs:
       with-cuda: enable
       with-rocm: disable
       with-cpu: disable
-      # TODO: Python free threading builds are broken due to newer openssl
-      # requirements.
-      python-versions: '["3.10","3.11","3.12","3.13","3.14"]'
   build:
     needs: generate-matrix
     name: ${{ matrix.repository }}

--- a/.github/workflows/build_wheels_linux_aarch64.yml
+++ b/.github/workflows/build_wheels_linux_aarch64.yml
@@ -19,9 +19,6 @@ jobs:
       with-cuda: enable
       with-rocm: disable
       with-cpu: disable
-      # TODO: Python free threading builds are broken due to newer openssl
-      # requirements.
-      python-versions: '["3.10","3.11","3.12","3.13","3.14"]'
   build:
     needs: generate-matrix
     name: ${{ matrix.repository }}


### PR DESCRIPTION
Previously these weren't working due to an openssl issue. With latest changes we now statically link openssl so this should work for free threading.

Builds on https://github.com/meta-pytorch/torchcomms/pull/22

Test plan:

manually enable 3.14t builds + run CI

* x86_64 https://github.com/meta-pytorch/torchcomms/actions/runs/18979209057/job/54207097761?pr=32
* aarch64 https://github.com/meta-pytorch/torchcomms/actions/runs/18979209005/job/54207086738?pr=32

