### PR TITLE
change default build mode to RelWithDebInfo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ class build_ext(build_ext_orig):
 
         pybind11_build_flags = _get_pybind11_abi_build_flags()
 
-        cfg = os.environ.get("CMAKE_BUILD_TYPE", "Release")
+        cfg = os.environ.get("CMAKE_BUILD_TYPE", "RelWithDebInfo")
         print(f"- Building with {cfg} configuration")
 
         cmake_args = [


### PR DESCRIPTION
Summary:
Change default build mode to RelWithDebInfo for 2 reasons:
1. having debug symbols by default is nice
2. it brings the debugging to parity with PgNCCLX as well

Differential Revision: D86035424


