### PR TITLE
Fix PyTorch CUDACachingAllocator::snapshot() API compatibility for conda builds

### DIFF
--- a/comms/torchcomms/nccl/CMakeLists.txt
+++ b/comms/torchcomms/nccl/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(torchcomms_comms_nccl MODULE
     ${TORCHCOMMS_NCCL_SOURCES}
     ${TORCHCOMMS_CUDA_API_SOURCE}
 )
+target_compile_definitions(torchcomms_comms_nccl PRIVATE TORCHCOMMS_CONDA_BUILD)
 set_target_properties(torchcomms_comms_nccl PROPERTIES
     PREFIX ""
     OUTPUT_NAME "_comms_nccl"

--- a/comms/torchcomms/nccl/TorchCommNCCLCCA.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCLCCA.cpp
@@ -38,7 +38,11 @@ void CachingAllocatorHookImpl::registerMemPreHook() {
   int device = c10::cuda::current_device();
   // We assume no mem pool and no comm has been created yet, we just loop up the
   // snapshot of the default pool for the current device.
+#ifdef TORCHCOMMS_CONDA_BUILD
+  auto snapshot = c10::cuda::CUDACachingAllocator::snapshot();
+#else
   auto snapshot = c10::cuda::CUDACachingAllocator::snapshot({device, 0});
+#endif
   for (const auto& segmentInfo : snapshot.segments) {
     // NOLINTNEXTLINE(performance-no-int-to-ptr)
     void* addr = reinterpret_cast<void*>(segmentInfo.address);

--- a/comms/torchcomms/ncclx/CMakeLists.txt
+++ b/comms/torchcomms/ncclx/CMakeLists.txt
@@ -61,7 +61,11 @@ add_library(torchcomms_comms_ncclx MODULE
     ${TORCHCOMMS_NCCLX_SOURCES}
     ${TORCHCOMMS_CUDA_API_SOURCE}
 )
-target_compile_definitions(torchcomms_comms_ncclx PRIVATE MOCK_SCUBA_DATA CTRAN_DISABLE_TCPDM)
+target_compile_definitions(torchcomms_comms_ncclx PRIVATE
+    MOCK_SCUBA_DATA
+    CTRAN_DISABLE_TCPDM
+    TORCHCOMMS_CONDA_BUILD
+)
 set_target_properties(torchcomms_comms_ncclx PROPERTIES
     PREFIX ""
     OUTPUT_NAME "_comms_ncclx"

--- a/comms/torchcomms/ncclx/TorchCommNCCLXCCA.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXCCA.cpp
@@ -38,7 +38,11 @@ void CachingAllocatorHookImpl::registerMemPreHook() {
   int device = c10::cuda::current_device();
   // We assume no mem pool and no comm has been created yet, we just loop up the
   // snapshot of the default pool for the current device.
+#ifdef TORCHCOMMS_CONDA_BUILD
+  auto snapshot = c10::cuda::CUDACachingAllocator::snapshot();
+#else
   auto snapshot = c10::cuda::CUDACachingAllocator::snapshot({device, 0});
+#endif
   for (const auto& segmentInfo : snapshot.segments) {
     // NOLINTNEXTLINE(performance-no-int-to-ptr)
     void* addr = reinterpret_cast<void*>(segmentInfo.address);


### PR DESCRIPTION
Summary:
## Problem
The torchcomms build in the xlformers_llama4_flagship_conda environment is failing with:
```
error: too many arguments to function 'c10::cuda::CUDACachingAllocator::SnapshotInfo c10::cuda::CUDACachingAllocator::snapshot()'
```
D86907322 introduced a new method *registerMemPreHook()* that calls ```c10::cuda::CUDACachingAllocator::snapshot({device, 0})``` with arguments.

This is caused by a **PyTorch API breaking change** in `c10::cuda::CUDACachingAllocator::snapshot()`:
- **Old API** (internal builds): `snapshot({device, pool_id})`
- **New API** (conda builds): `snapshot()` - no arguments

## Root Cause
Torchcomms code was written for the older PyTorch API where `snapshot()` accepted arguments, but conda environments use a newer PyTorch version with the updated API.

## Solution
Added conditional compilation to handle both API versions:
1. **Defined `TORCHCOMMS_CONDA_BUILD` macro** in CMakeLists.txt files for conda builds
2. **Updated affected C++ files** to use the correct API based on build type:
   - `comms/torchcomms/ncclx/TorchCommNCCLXCCA.cpp`
   - `comms/torchcomms/nccl/TorchCommNCCLCCA.cpp`

This follows the same pattern used in `ProcessGroupNCCLX.cpp` with the `NCCLX_CONDA_BUILD` macro.

Differential Revision: D87413411


