### PR TITLE
transport: fix transport cmake

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -59,7 +59,7 @@ jobs:
 
         # Build pybindings
         pip install --no-build-isolation -v '.[dev]'
-        python -c "import torchcomms"
+        python -c "import torchcomms; import torchcomms._transport"
 
         # Run tests
         comms/torchcomms/scripts/run_tests_integration_py.sh

--- a/comms/torchcomms/transport/CMakeLists.txt
+++ b/comms/torchcomms/transport/CMakeLists.txt
@@ -74,15 +74,21 @@ if(USE_SYSTEM_LIBS)
     target_link_libraries(torchcomms_transport PRIVATE
         "-lfolly"
         "-lgflags"
+        "-lglog"
         "-lboost_program_options"
         "-lboost_filesystem"
+        "-lboost_context"
+        "-lfmt"
     )
 else()
     target_link_libraries(torchcomms_transport PRIVATE
         "-l:libfolly.a"
         "-l:libgflags.a"
+        "-l:libglog.a"
         "-l:libboost_program_options.a"
         "-l:libboost_filesystem.a"
+        "-l:libboost_context.a"
+        "-l:libfmt.a"
     )
 endif()
 


### PR DESCRIPTION
This fixes the transport cmake build linking issues and adds a very basic import test to CI.

Test plan:

```
uv pip install -v -e '.[dev]' --no-build-isolation

python -c "import torchcomms; import torchcomms._transport"
```