### PR TITLE
Add graph.reset() to all CUDA graph tests

### DIFF
--- a/comms/torchcomms/tests/integration/cpp/AllGatherSingleTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/AllGatherSingleTest.cpp
@@ -179,6 +179,8 @@ void AllGatherSingleTest::testGraphAllGatherSingle(
     // Verify the results after each replay
     verifyResults(output);
   }
+
+  graph.reset();
 }
 
 // CUDA Graph test function for all_gather_single with input deleted after graph
@@ -228,6 +230,8 @@ void AllGatherSingleTest::testGraphAllGatherSingleInputDeleted(
     // Verify the results after each replay
     verifyResults(output);
   }
+
+  graph.reset();
 }
 
 // Helper function to create input tensor

--- a/comms/torchcomms/tests/integration/cpp/AllGatherTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/AllGatherTest.cpp
@@ -175,6 +175,8 @@ void AllGatherTest::testGraphAllGather(int count, at::ScalarType dtype) {
     // Verify the results after each replay
     verifyResults(outputs);
   }
+
+  graph.reset();
 }
 
 // CUDA Graph test function for all_gather with input deleted after graph
@@ -230,6 +232,8 @@ void AllGatherTest::testGraphAllGatherInputDeleted(
     // Verify the results after each replay
     verifyResults(outputs);
   }
+
+  graph.reset();
 }
 
 // Helper function to create input tensor

--- a/comms/torchcomms/tests/integration/cpp/AllReduceTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/AllReduceTest.cpp
@@ -181,6 +181,8 @@ void AllReduceTest::testGraphAllReduce(
     // Verify the results after each replay
     verifyResults(input, op);
   }
+
+  graph.reset();
 }
 
 // CUDA Graph test function for all_reduce with input deleted after graph
@@ -226,6 +228,8 @@ void AllReduceTest::testGraphAllReduceInputDeleted(
     // Note: Cannot verify results since input tensor is deleted
     // This test validates that the graph replay completes without crashing
   }
+
+  graph.reset();
 }
 
 // Helper function to create input tensor

--- a/comms/torchcomms/tests/integration/cpp/AllToAllSingleTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/AllToAllSingleTest.cpp
@@ -180,6 +180,8 @@ void AllToAllSingleTest::testGraphAllToAllSingle(
     // Verify the results after each replay
     verifyResults(output);
   }
+
+  graph.reset();
 }
 
 // CUDA Graph test function for all_to_all_single with input deleted after graph
@@ -230,6 +232,8 @@ void AllToAllSingleTest::testGraphAllToAllSingleInputDeleted(
     // Verify the results after each replay
     verifyResults(output);
   }
+
+  graph.reset();
 }
 
 // Helper function to create input tensor

--- a/comms/torchcomms/tests/integration/cpp/AllToAllTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/AllToAllTest.cpp
@@ -174,6 +174,8 @@ void AllToAllTest::testGraphAllToAll(int count, at::ScalarType dtype) {
     // Verify the results after each replay
     verifyResults(output_tensors, expected_output);
   }
+
+  graph.reset();
 }
 
 // CUDA Graph test function for all_to_all with input deleted after graph
@@ -232,6 +234,8 @@ void AllToAllTest::testGraphAllToAllInputDeleted(
     // Verify the results after each replay
     verifyResults(output_tensors, expected_output);
   }
+
+  graph.reset();
 }
 
 // Helper function to create input tensors

--- a/comms/torchcomms/tests/integration/cpp/AllToAllvSingleTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/AllToAllvSingleTest.cpp
@@ -194,6 +194,8 @@ void AllToAllvSingleTest::testGraphAllToAllvSingle(
     // Verify the results after each replay
     verifyResults(output, output_split_sizes);
   }
+
+  graph.reset();
 }
 
 // CUDA Graph test function for all_to_all_v_single with input deleted after
@@ -246,6 +248,8 @@ void AllToAllvSingleTest::testGraphAllToAllvSingleInputDeleted(
     // Verify the results after each replay
     verifyResults(output, output_split_sizes);
   }
+
+  graph.reset();
 }
 
 // Test function for synchronous all_to_all_v_single with work object

--- a/comms/torchcomms/tests/integration/cpp/BarrierTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/BarrierTest.cpp
@@ -96,4 +96,6 @@ void BarrierTest::testGraphBarrier() {
 
     // No explicit verification needed for barrier, just ensure it completes
   }
+
+  graph.reset();
 }

--- a/comms/torchcomms/tests/integration/cpp/BatchSendRecvTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/BatchSendRecvTest.cpp
@@ -270,6 +270,8 @@ void BatchSendRecvTest::testGraphBatchSendRecv(
     // Verify the results after each replay
     verifyResults(params.recv_tensors, params.recv_ranks[0]);
   }
+
+  graph.reset();
 }
 
 // CUDA Graph test function for batch SendRecv operations with input deleted
@@ -356,6 +358,8 @@ void BatchSendRecvTest::testGraphBatchSendRecvInputDeleted(
     // Verify the results after each replay
     verifyResults(recv_tensors, recv_ranks[0]);
   }
+
+  graph.reset();
 }
 
 // Helper function to create send tensor with tensor-specific values

--- a/comms/torchcomms/tests/integration/cpp/BroadcastTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/BroadcastTest.cpp
@@ -192,6 +192,8 @@ void BroadcastTest::testGraphBroadcast(int count, at::ScalarType dtype) {
     // Verify the results after each replay
     verifyBroadcastResults(tensor, root_value);
   }
+
+  graph.reset();
 }
 
 // CUDA Graph test function for broadcast with input deleted after graph
@@ -239,6 +241,8 @@ void BroadcastTest::testGraphBroadcastInputDeleted(
     // Note: Cannot verify results since tensor is deleted
     // This test validates that the graph replay completes without crashing
   }
+
+  graph.reset();
 }
 
 // Helper function to create tensor for broadcast

--- a/comms/torchcomms/tests/integration/cpp/GatherTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/GatherTest.cpp
@@ -200,6 +200,8 @@ void GatherTest::testGraphGather(int count, at::ScalarType dtype) {
     // Verify the results after each replay
     verifyGatherResults(outputs, root_rank);
   }
+
+  graph.reset();
 }
 
 // CUDA Graph test function for gather with input deleted after graph creation
@@ -255,6 +257,8 @@ void GatherTest::testGraphGatherInputDeleted(int count, at::ScalarType dtype) {
     // Verify the results after each replay
     verifyGatherResults(outputs, root_rank);
   }
+
+  graph.reset();
 }
 
 // Helper function to create input tensor

--- a/comms/torchcomms/tests/integration/cpp/ReduceScatterSingleTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/ReduceScatterSingleTest.cpp
@@ -192,6 +192,8 @@ void ReduceScatterSingleTest::testGraphReduceScatterSingle(
     // Verify the results after each replay
     verifyResults(output, op);
   }
+
+  graph.reset();
 }
 
 // CUDA Graph test function for reduce_scatter_single with input deleted after
@@ -244,6 +246,8 @@ void ReduceScatterSingleTest::testGraphReduceScatterSingleInputDeleted(
     // Verify the results after each replay
     verifyResults(output, op);
   }
+
+  graph.reset();
 }
 
 // Helper function to create input tensor

--- a/comms/torchcomms/tests/integration/cpp/ReduceScatterTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/ReduceScatterTest.cpp
@@ -247,6 +247,8 @@ void ReduceScatterTest::testGraphReduceScatter(
     // Verify the results after each replay
     verifyResults(output, op);
   }
+
+  graph.reset();
 }
 
 // CUDA Graph test function for reduce_scatter with input deleted after graph
@@ -300,4 +302,6 @@ void ReduceScatterTest::testGraphReduceScatterInputDeleted(
     // Verify the results after each replay
     verifyResults(output, op);
   }
+
+  graph.reset();
 }

--- a/comms/torchcomms/tests/integration/cpp/ReduceTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/ReduceTest.cpp
@@ -247,6 +247,8 @@ void ReduceTest::testGraphReduce(
     // Verify the results after each replay
     verifyResults(tensor, op, root_rank);
   }
+
+  graph.reset();
 }
 
 // CUDA Graph test function for reduce with input deleted after graph creation
@@ -296,4 +298,6 @@ void ReduceTest::testGraphReduceInputDeleted(
     // Note: Cannot verify results since tensor is deleted
     // This test validates that the graph replay completes without crashing
   }
+
+  graph.reset();
 }

--- a/comms/torchcomms/tests/integration/cpp/ScatterTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/ScatterTest.cpp
@@ -216,6 +216,8 @@ void ScatterTest::testGraphScatter(int count, at::ScalarType dtype) {
     // Verify the results after each replay
     verifyResults(output);
   }
+
+  graph.reset();
 }
 
 // CUDA Graph test function for scatter with input deleted after graph creation
@@ -272,6 +274,8 @@ void ScatterTest::testGraphScatterInputDeleted(
     // Verify the results after each replay
     verifyResults(output);
   }
+
+  graph.reset();
 }
 
 // Helper function to create input tensors

--- a/comms/torchcomms/tests/integration/cpp/SendRecvTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/SendRecvTest.cpp
@@ -270,6 +270,8 @@ void SendRecvTest::testGraphSendRecv(int count, at::ScalarType dtype) {
     // Verify the results after each replay
     verifyResults(params.recv_tensor, params.recv_rank);
   }
+
+  graph.reset();
 }
 
 // CUDA Graph test function for send/recv with input deleted after graph
@@ -334,4 +336,6 @@ void SendRecvTest::testGraphSendRecvInputDeleted(
     // Verify the results after each replay
     verifyResults(recv_tensor, recv_rank);
   }
+
+  graph.reset();
 }

--- a/comms/torchcomms/tests/integration/py/AllGatherSingleTest.py
+++ b/comms/torchcomms/tests/integration/py/AllGatherSingleTest.py
@@ -167,6 +167,8 @@ class AllGatherSingleTest(unittest.TestCase):
                 # Verify the results after each replay
                 self._verify_results(output_tensor)
 
+            graph.reset()
+
     def _graph_all_gather_single_input_deleted(self, count, dtype):
         """Test CUDA Graph all_gather_single with input deleted after graph creation."""
         print(
@@ -204,6 +206,8 @@ class AllGatherSingleTest(unittest.TestCase):
 
                 # Verify the results after each replay
                 self._verify_results(output_tensor)
+
+            graph.reset()
 
     def _create_input_tensor(self, count, dtype):
         """Create input tensor with rank-specific values."""

--- a/comms/torchcomms/tests/integration/py/AllGatherTest.py
+++ b/comms/torchcomms/tests/integration/py/AllGatherTest.py
@@ -168,6 +168,8 @@ class AllGatherTest(unittest.TestCase):
                 # Verify the results after each replay
                 self._verify_results(output_tensors)
 
+            graph.reset()
+
     def _graph_all_gather_input_deleted(self, count, dtype):
         """Test CUDA Graph all_gather with input deleted after graph creation."""
         print(
@@ -206,6 +208,8 @@ class AllGatherTest(unittest.TestCase):
 
                 # Verify the results after each replay
                 self._verify_results(output_tensors)
+
+            graph.reset()
 
     def _create_input_tensor(self, count, dtype):
         """Create input tensor with rank-specific values."""

--- a/comms/torchcomms/tests/integration/py/AllReduceTest.py
+++ b/comms/torchcomms/tests/integration/py/AllReduceTest.py
@@ -185,6 +185,8 @@ class AllReduceTest(unittest.TestCase):
                 # Verify the results after each replay
                 self._verify_results(input_tensor, op)
 
+            graph.reset()
+
     def _graph_all_reduce_input_deleted(self, count, dtype, op):
         """Test CUDA Graph all_reduce with input deleted after graph creation."""
         print(
@@ -217,6 +219,8 @@ class AllReduceTest(unittest.TestCase):
                 # Note: For all_reduce with deleted input, we can't verify results
                 # since the tensor was deleted. This test primarily validates
                 # that the graph replay completes without crashing.
+
+            graph.reset()
 
     def _create_input_tensor(self, count, dtype):
         """Create input tensor with rank-specific values."""

--- a/comms/torchcomms/tests/integration/py/AllToAllSingleTest.py
+++ b/comms/torchcomms/tests/integration/py/AllToAllSingleTest.py
@@ -167,6 +167,8 @@ class AllToAllSingleTest(unittest.TestCase):
                 # Verify the results after each replay
                 self._verify_results(output_tensor)
 
+            graph.reset()
+
     def _graph_all_to_all_single_input_deleted(self, count, dtype):
         """Test CUDA Graph all_to_all_single with input deleted after graph creation."""
         print(
@@ -205,6 +207,8 @@ class AllToAllSingleTest(unittest.TestCase):
 
                 # Verify the results after each replay
                 self._verify_results(output_tensor)
+
+            graph.reset()
 
     def _create_input_tensor(self, count, dtype):
         """Create input tensor with rank-specific values."""

--- a/comms/torchcomms/tests/integration/py/AllToAllTest.py
+++ b/comms/torchcomms/tests/integration/py/AllToAllTest.py
@@ -176,6 +176,8 @@ class AllToAllTest(unittest.TestCase):
                 # Verify the results after each replay
                 self._verify_results(output_tensors, expected_output)
 
+            graph.reset()
+
     def _graph_all_to_all_input_deleted(self, count, dtype):
         """Test CUDA Graph all_to_all with input deleted after graph creation."""
         print(
@@ -218,6 +220,8 @@ class AllToAllTest(unittest.TestCase):
 
                 # Verify the results after each replay
                 self._verify_results(output_tensors, expected_output)
+
+            graph.reset()
 
     def _create_input_tensors(self, count, dtype):
         """Create input tensors with rank-specific values."""

--- a/comms/torchcomms/tests/integration/py/AllToAllvSingleTest.py
+++ b/comms/torchcomms/tests/integration/py/AllToAllvSingleTest.py
@@ -191,6 +191,8 @@ class AllToAllvSingleTest(unittest.TestCase):
                 # Verify the results after each replay
                 self._verify_results(output_tensor, output_split_sizes)
 
+            graph.reset()
+
     def _graph_all_to_all_v_single_input_deleted(
         self, input_split_sizes, output_split_sizes, dtype
     ):
@@ -242,6 +244,8 @@ class AllToAllvSingleTest(unittest.TestCase):
 
                 # Verify the results after each replay
                 self._verify_results(output_tensor, output_split_sizes)
+
+            graph.reset()
 
     def _sync_all_to_all_v_single_multi_dim_tensor(
         self, input_split_sizes_, output_split_sizes_, dtype

--- a/comms/torchcomms/tests/integration/py/BarrierTest.py
+++ b/comms/torchcomms/tests/integration/py/BarrierTest.py
@@ -95,6 +95,8 @@ class BarrierTest(unittest.TestCase):
 
                 # No explicit verification needed for barrier, just ensure it completes
 
+            graph.reset()
+
     def test_sync_barrier(self):
         """Test synchronous barrier with work object."""
         self._sync_barrier()

--- a/comms/torchcomms/tests/integration/py/BatchSendRecvTest.py
+++ b/comms/torchcomms/tests/integration/py/BatchSendRecvTest.py
@@ -280,6 +280,8 @@ class BatchSendRecvTest(unittest.TestCase):
                 # Verify the results after each replay
                 self._verify_results(recv_tensors, prev_rank)
 
+            graph.reset()
+
     def _graph_batch_sendrecv_input_deleted(self, count, dtype):
         """Test CUDA Graph batch SendRecv operations with input deleted after graph creation."""
         print(
@@ -337,6 +339,8 @@ class BatchSendRecvTest(unittest.TestCase):
 
                 # Verify the results after each replay
                 self._verify_results(recv_tensors, prev_rank)
+
+            graph.reset()
 
     def _create_send_tensor(self, count, dtype, tensor_id):
         """Create send tensor with rank and tensor-specific values."""

--- a/comms/torchcomms/tests/integration/py/BroadcastTest.py
+++ b/comms/torchcomms/tests/integration/py/BroadcastTest.py
@@ -181,6 +181,8 @@ class BroadcastTest(unittest.TestCase):
                 # Verify the results after each replay
                 self._verify_broadcast_results(tensor, root_value)
 
+            graph.reset()
+
     def _graph_broadcast_input_deleted(self, count, dtype):
         """Test CUDA Graph broadcast with input deleted after graph creation."""
         print(
@@ -215,6 +217,8 @@ class BroadcastTest(unittest.TestCase):
 
             # Note: Cannot verify results since tensor is deleted
             # This test validates that the graph replay completes without crashing
+
+        graph.reset()
 
     def _create_broadcast_tensor(self, root_rank, value, count, dtype):
         """Create tensor for broadcast with different values based on rank."""

--- a/comms/torchcomms/tests/integration/py/GatherTest.py
+++ b/comms/torchcomms/tests/integration/py/GatherTest.py
@@ -185,6 +185,8 @@ class GatherTest(unittest.TestCase):
                 # Verify the results on root rank after each replay
                 self._verify_gather_results(output_tensors, root_rank)
 
+            graph.reset()
+
     def _graph_gather_input_deleted(self, count, dtype):
         """Test CUDA Graph gather with input deleted after graph creation."""
         print(
@@ -226,6 +228,8 @@ class GatherTest(unittest.TestCase):
 
                 # Verify the results on root rank after each replay
                 self._verify_gather_results(output_tensors, root_rank)
+
+            graph.reset()
 
     def _create_input_tensor(self, count, dtype):
         """Create input tensor with rank-specific values."""

--- a/comms/torchcomms/tests/integration/py/ReduceScatterSingleTest.py
+++ b/comms/torchcomms/tests/integration/py/ReduceScatterSingleTest.py
@@ -178,6 +178,8 @@ class ReduceScatterSingleTest(unittest.TestCase):
                 # Verify the results after each replay
                 self._verify_results(output_tensor, op)
 
+            graph.reset()
+
     def _graph_reduce_scatter_single_input_deleted(self, count, dtype, op):
         """Test CUDA Graph reduce_scatter_single with input deleted after graph creation."""
         print(
@@ -218,6 +220,8 @@ class ReduceScatterSingleTest(unittest.TestCase):
 
             # Verify the results after each replay
             self._verify_results(output_tensor, op)
+
+        graph.reset()
 
     def _create_input_tensor(self, count, dtype):
         """Create input tensor with rank-specific values."""

--- a/comms/torchcomms/tests/integration/py/ReduceScatterTest.py
+++ b/comms/torchcomms/tests/integration/py/ReduceScatterTest.py
@@ -170,6 +170,8 @@ class ReduceScatterTest(unittest.TestCase):
                 # Verify the results after each replay
                 self._verify_results(output_tensor, op)
 
+            graph.reset()
+
     def _graph_reduce_scatter_input_deleted(self, count, dtype, op):
         """Test CUDA Graph reduce_scatter with input deleted after graph creation."""
         print(
@@ -208,6 +210,8 @@ class ReduceScatterTest(unittest.TestCase):
 
             # Verify the results after each replay
             self._verify_results(output_tensor, op)
+
+        graph.reset()
 
     def _create_input_tensors(self, count, dtype):
         """Create input tensors with rank-specific values."""

--- a/comms/torchcomms/tests/integration/py/ReduceTest.py
+++ b/comms/torchcomms/tests/integration/py/ReduceTest.py
@@ -175,6 +175,8 @@ class ReduceTest(unittest.TestCase):
                 # Verify the results on root rank after each replay
                 self._verify_results(tensor, op, root_rank)
 
+            graph.reset()
+
     def _graph_reduce_input_deleted(self, count, dtype, op):
         """Test CUDA Graph reduce with input deleted after graph creation."""
         print(
@@ -209,6 +211,8 @@ class ReduceTest(unittest.TestCase):
                 # Note: For reduce with deleted input, we can't verify results
                 # since the tensor was deleted. This test primarily validates
                 # that the graph replay completes without crashing.
+
+            graph.reset()
 
     def _create_input_tensor(self, count, dtype):
         """Create input tensor with rank-specific values."""

--- a/comms/torchcomms/tests/integration/py/ScatterTest.py
+++ b/comms/torchcomms/tests/integration/py/ScatterTest.py
@@ -203,6 +203,8 @@ class ScatterTest(unittest.TestCase):
                 # Verify the results after each replay
                 self._verify_results(output)
 
+            graph.reset()
+
     def _graph_scatter_input_deleted(self, count, dtype):
         """Test CUDA Graph scatter with input deleted after graph creation."""
         print(
@@ -247,6 +249,8 @@ class ScatterTest(unittest.TestCase):
 
                 # Verify the results after each replay
                 self._verify_results(output)
+
+            graph.reset()
 
     def _create_input_tensors(self, count, dtype):
         """Create input tensors with rank-specific values."""

--- a/comms/torchcomms/tests/integration/py/SendRecvTest.py
+++ b/comms/torchcomms/tests/integration/py/SendRecvTest.py
@@ -264,6 +264,8 @@ class SendRecvTest(unittest.TestCase):
                 # Verify the results after each replay
                 self._verify_results(recv_tensor, recv_rank)
 
+            graph.reset()
+
     def _graph_send_recv_input_deleted(self, count, dtype):
         """Test CUDA Graph send/recv with input deleted after graph creation."""
         print(
@@ -314,6 +316,8 @@ class SendRecvTest(unittest.TestCase):
 
                 # Verify the results after each replay
                 self._verify_results(recv_tensor, recv_rank)
+
+            graph.reset()
 
     def _create_send_tensor(self, count, dtype):
         """Create send tensor with rank-specific values."""


### PR DESCRIPTION
Summary:
Add graph.reset() calls at the end of all CUDA graph test methods in
both Python and C++ integration tests to ensure proper cleanup of CUDA
graph resources. This prevents potential memory leaks and ensures that
graph resources are properly released after each test completes.

Differential Revision: D88763363


