### PR TITLE
Fix device_mesh test to compatible with old pytorch

### DIFF
--- a/comms/torchcomms/device_mesh.py
+++ b/comms/torchcomms/device_mesh.py
@@ -9,9 +9,15 @@ import torch.distributed as dist
 
 from torch.distributed.device_mesh import _mesh_resources
 
-from torch.distributed.distributed_c10d import GroupName
-
 from torchcomms._comms import _BackendWrapper, _get_store, new_comm, TorchComm
+
+try:
+    from torch.distributed.distributed_c10d import GroupName
+except ImportError:
+    print("GroupName is not available.")
+    # Fallback: GroupName is effectively just str when not available from torch
+    # We use cast to satisfy type checkers while keeping runtime behavior simple
+    GroupName = str  # type: ignore[misc]
 
 
 def _create_torchcomm_process_group(


### PR DESCRIPTION
Summary: device_mesh test has to be run with old pytorch, which does not have GroupName. Import GroupName will break the github oss ci: https://github.com/meta-pytorch/torchcomms/commits/main/. Let's make sure it works with old pytorch

Differential Revision: D88823652


