### PR TITLE
build: bump third_party_tag to newer version to fix fbthrift regression

### DIFF
--- a/build_ncclx.sh
+++ b/build_ncclx.sh
@@ -132,7 +132,7 @@ function build_third_party {
   if [ "$CLEAN_THIRD_PARTY" == 1 ]; then
     rm -f "${CONDA_PREFIX}"/*.cmake 2>/dev/null || true
   fi
-  local third_party_tag="v2025.09.01.00"
+  local third_party_tag="v2025.12.15.00"
 
   mkdir -p /tmp/third-party
   pushd /tmp/third-party

--- a/build_rcclx.sh
+++ b/build_rcclx.sh
@@ -130,7 +130,7 @@ function build_third_party {
   if [ "$CLEAN_THIRD_PARTY" == 1 ]; then
     rm -f "${CONDA_PREFIX}"/*.cmake 2>/dev/null || true
   fi
-  local third_party_tag="v2025.09.01.00"
+  local third_party_tag="v2025.12.15.00"
 
   mkdir -p /tmp/third-party
   pushd /tmp/third-party


### PR DESCRIPTION
This should fix CI by using a newer version of fbthrift.

https://github.com/meta-pytorch/torchcomms/actions/runs/20150853901/job/57843071402

This broke in D88953852 https://github.com/meta-pytorch/torchcomms/commit/627844ac966ac3c1f52427fa30356874e66ff5e9#diff-f21bec55d37a772c25db7dd9682f86e95b3ab617c3809a7bfadec82d598e87b1

Test plan:

CI