### PR TITLE
fix feedstock build

### DIFF
--- a/comms/ncclx/v2_27/examples/HelloWorld.cc
+++ b/comms/ncclx/v2_27/examples/HelloWorld.cc
@@ -31,12 +31,6 @@ int main(int argc, char* argv[]) {
   printf("ncclCommHash %lx\n", ncclCommHash);
 #endif
 
-#ifdef NCCL_COMM_DESCRIPTION
-  char commDesc[10];
-  NCCLCHECK(ncclCommGetDesc(comm, commDesc));
-  printf("nccl commDesc %s\n", commDesc);
-#endif
-
 #ifdef NCCL_COMM_DUMP
   std::unordered_map<std::string, std::string> dump;
   NCCLCHECK(ncclCommDump(comm, dump));


### PR DESCRIPTION
Summary:
In `maint/oss_build.sh`, it already calls `make -j` to build ncclx.  

We shouldn't use `make -j install` again; instead, we only need to copy the output to conda.

NOTE: we only see this issue in ncclx2.28, we will move to cmake eventually.

Differential Revision: D89502707


