### PR TITLE
Add memory benchmark

### DIFF
--- a/comms/ctran/memory/benchmarks/NcclCommMemoryBench.cc
+++ b/comms/ctran/memory/benchmarks/NcclCommMemoryBench.cc
@@ -1,0 +1,52 @@
+#include <gtest/gtest.h>
+
+#include "comms/testinfra/TestsDistUtils.h"
+
+namespace {
+
+size_t getGpuMemorySnapshot() {
+  cudaDeviceSynchronize();
+
+  size_t free, total;
+  CUDACHECK_TEST(cudaMemGetInfo(&free, &total));
+
+  return total - free;
+}
+
+} // namespace
+
+class NcclCommMemoryBench : public NcclxBaseTest {
+ public:
+  void SetUp() override {
+    setenv("NCCL_CTRAN_ENABLE", "1", 0);
+    setenv("NCCL_COMM_STATE_DEBUG_TOPO", "vnode", 0);
+    setenv("NCCL_RUNTIME_CONNECT", "0", 0);
+    setenv("NCCL_LAZY_SETUP_CHANNELS", "0", 0);
+    NcclxBaseTest::SetUp();
+
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+  }
+
+  void TearDown() override {
+    NcclxBaseTest::TearDown();
+  }
+};
+
+TEST_F(NcclCommMemoryBench, MeasureCommMemory) {
+  auto before = getGpuMemorySnapshot();
+  NcclCommRAII comm(globalRank, numRanks, localRank);
+  auto after = getGpuMemorySnapshot();
+
+  size_t memoryUsedBytes = after - before;
+  double memoryUsedMB = static_cast<double>(memoryUsedBytes) / (1 << 20);
+
+  if (globalRank == 0) {
+    printf("NCCL Comm Memory: %.2f MB\n", memoryUsedMB);
+  }
+}
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ctran/memory/benchmarks/nccl_comm_memory_runner.py
+++ b/comms/ctran/memory/benchmarks/nccl_comm_memory_runner.py
@@ -1,0 +1,36 @@
+from comms.testinfra.multiproc_benchmark_runner import (  # pyre-ignore
+    run_nccl_distributed_test,
+)
+from windtunnel.benchmarks.python_benchmark_runner.benchmark import (  # pyre-ignore
+    main as servicelab_main,
+    register_benchmark,
+    UserCounters,
+    UserMetric,
+)
+
+
+TARGET_PREFIX = "fbcode//comms/ctran/memory/benchmarks:nccl_comm_memory_bench_ppn"
+SEARCH_PATTERN = r"NCCL Comm Memory:\s*([\d.]+)\s*MB"
+
+
+@register_benchmark(use_counters=True)
+def ncclCommMemoryMB(counters: UserCounters) -> None:  # pyre-ignore
+    for ppn in [1, 4]:
+        target = f"{TARGET_PREFIX}{ppn}"
+        memory_mb = run_nccl_distributed_test(target, SEARCH_PATTERN)
+        counters[f"ncclCommMemoryMB_ppn{ppn}"] = UserMetric(value=int(memory_mb))
+
+
+def run_local() -> None:
+    results = {}
+    ncclCommMemoryMB(results)
+    for key, metric in results.items():
+        print(f"  {key}: {metric.value:.2f} MB")
+
+
+def main() -> None:
+    servicelab_main()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Summary:
Add memory benchmark to measure memory usage from creating a nccl comm.

For accuracy, creating nccl comm through distributed_test in order to mimic real nccl comm creation. This requires mulitprocess, so run the tests from a python runner so that the test only needs to measure gpu memory and create a ncclCommRAII. The python runner will record the memory printed out by the distributed_test to report to servicelab.

Reviewed By: minsii

Differential Revision: D89596473


