### PR TITLE
add lock to ipcMem member variable of CtranNvlRegElem class

### DIFF
--- a/comms/ctran/backends/nvl/CtranNvl.cc
+++ b/comms/ctran/backends/nvl/CtranNvl.cc
@@ -165,9 +165,10 @@ CtranNvl::exportMem(const void* buf, void* nvlRegElem, ControlMsg& msg) {
 
   // Fill ctrl msg content
   msg.setType(ControlMsgType::NVL_EXPORT_MEM);
-  FB_COMMCHECK(reg->ipcMem.ipcExport(msg.nvlExp.ipcDesc));
+  auto ipcMem = reg->ipcMem.wlock();
+  FB_COMMCHECK(ipcMem->ipcExport(msg.nvlExp.ipcDesc));
   msg.nvlExp.offset = reinterpret_cast<size_t>(buf) -
-      reinterpret_cast<size_t>(reg->ipcMem.getBase());
+      reinterpret_cast<size_t>(ipcMem->getBase());
 
   return commSuccess;
 }
@@ -201,7 +202,7 @@ commResult_t
 CtranNvl::remReleaseMem(void* nvlRegElem, int rank, ControlMsg& msg) {
   auto reg = reinterpret_cast<CtranNvlRegElem*>(nvlRegElem);
   msg.setType(ControlMsgType::NVL_RELEASE_MEM);
-  msg.nvlRls.base = reg->ipcMem.getBase();
+  msg.nvlRls.base = reg->ipcMem.rlock()->getBase();
   return commSuccess;
 }
 

--- a/comms/ctran/backends/nvl/tests/CtranNvlDistUT.cc
+++ b/comms/ctran/backends/nvl/tests/CtranNvlDistUT.cc
@@ -266,13 +266,14 @@ TEST_P(CtranNvlTestSuite, ExportImportMem) {
     ControlMsg msg(ControlMsgType::NVL_EXPORT_MEM);
 
     COMMCHECK_TEST(ctranNvl->exportMem(data, regElems, msg));
-    dataRange = nvlRegElem->ipcMem.getRange();
+    auto ipcMem = nvlRegElem->ipcMem.rlock();
+    dataRange = ipcMem->getRange();
 
     EXPECT_EQ(msg.type, ControlMsgType::NVL_EXPORT_MEM);
     EXPECT_EQ(
         reinterpret_cast<void*>(msg.nvlExp.ipcDesc.base),
-        reinterpret_cast<void*>(nvlRegElem->ipcMem.getBase()));
-    EXPECT_EQ(msg.nvlExp.ipcDesc.range, nvlRegElem->ipcMem.getRange());
+        reinterpret_cast<void*>(ipcMem->getBase()));
+    EXPECT_EQ(msg.nvlExp.ipcDesc.range, ipcMem->getRange());
     EXPECT_EQ(msg.nvlExp.ipcDesc.numSegments, 1);
     EXPECT_NE(msg.nvlExp.ipcDesc.segments[0].sharedHandle.fd, 0);
     EXPECT_GT(msg.nvlExp.ipcDesc.segments[0].range, 0);

--- a/comms/ctran/tests/CtranDistAllgatherPTests.cc
+++ b/comms/ctran/tests/CtranDistAllgatherPTests.cc
@@ -126,6 +126,30 @@ class CtranAllgatherPTest : public ctran::CtranDistTestFixture {
     CUDACHECK_TEST(cudaDeviceSynchronize());
   }
 
+  void
+  cumemBufSetup(size_t sendCount, size_t recvCount, char** sBuf, char** rBuf) {
+    expectedVal = globalRank;
+
+    const size_t pageSize = getpagesize();
+    auto sBytes = sendCount * commTypeSize(dt);
+    auto rBytes = recvCount * commTypeSize(dt);
+
+    size_t bufSize;
+    bufSize = ((sBytes + pageSize - 1) / pageSize) * pageSize;
+    *sBuf = prepareBuf(bufSize, kMemNcclMemAlloc);
+    bufSize = ((rBytes + pageSize - 1) / pageSize) * pageSize;
+    *rBuf = prepareBuf(bufSize, kMemNcclMemAlloc);
+
+    CUDACHECK_TEST(cudaMemset(*sBuf, expectedVal, sBytes));
+    CUDACHECK_TEST(cudaMemset(*rBuf, rand(), rBytes));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+  }
+
+  void cumemBufCleanUp(void* sBuf, void* rBuf) {
+    releaseBuf((char*)sBuf, kMemNcclMemAlloc);
+    releaseBuf((char*)rBuf, kMemNcclMemAlloc);
+  }
+
   void memoryCleanUp(MemAllocType memType) {
     releaseBuf((char*)sendbuf, memType);
     releaseBuf((char*)recvbuf, memType);
@@ -470,6 +494,91 @@ TEST_F(CtranAllgatherPTest, InternalRegisteredMemory) {
 
   ASSERT_EQ(ctran::allGatherPDestroy(request), commSuccess);
   delete request;
+}
+
+TEST_F(CtranAllgatherPTest, SharePersistentBuffer) {
+  // Test use case where AGP uses the same persistent buffer for multiple
+  // communicators
+  const auto recvCount = 67108864;
+  const auto sendCount = recvCount / numRanks;
+
+  const auto kComms = 20;
+  const auto kBufs = 3;
+  std::vector<cudaStream_t> streams(kComms);
+  std::vector<std::unique_ptr<CtranComm>> testComms(kComms);
+  std::vector<CtranPersistentRequest*> requests(kComms * kBufs);
+  std::vector<char*> sendBufs(kBufs);
+  std::vector<char*> recvBufs(kBufs);
+  std::vector<void*> sendHdls(kBufs);
+  std::vector<void*> recvHdls(kBufs);
+
+  for (int c = 0; c < kComms; c++) {
+    CUDACHECK_TEST(cudaStreamCreate(&streams[c]));
+    testComms[c] = makeCtranComm();
+  }
+
+  if (ncclIsCuMemSupported() == false) {
+    XLOG(INFO)
+        << "CuMem not supported, skipping InvalidCount test with memType = kMemNcclMemAlloc";
+    ;
+    return;
+  }
+
+  // allocate persistent buffers
+  for (int b = 0; b < kBufs; b++) {
+    cumemBufSetup(sendCount, recvCount, &sendBufs.at(b), &recvBufs.at(b));
+    // use default ctran comm to register buffers once
+    COMMCHECK_TEST(ctranComm->ctran_->commRegister(
+        recvBufs.at(b), recvCount * commTypeSize(dt), &recvHdls.at(b)));
+    COMMCHECK_TEST(ctranComm->ctran_->commRegister(
+        sendBufs.at(b), sendCount * commTypeSize(dt), &sendHdls.at(b)));
+  }
+  // Convert to int8_t for init to mimic FSDP use case
+  const auto initMaxRecvCount =
+      recvCount * commTypeSize(dt) / commTypeSize(commInt8);
+  const auto initDt = commInt8;
+
+  for (int b = 0; b < kBufs; b++) {
+    for (int c = 0; c < kComms; c++) {
+      meta::comms::Hints hints;
+      COMMCHECK_TEST(
+          ctran::allGatherPInit(
+              recvBufs.at(b),
+              initMaxRecvCount,
+              hints,
+              initDt,
+              testComms[c].get(),
+              streams.at(c),
+              requests.at(c * kBufs + b)));
+    }
+  }
+
+  // Run allgather execute in parallel
+  for (int b = 0; b < kBufs; b++) {
+    for (int c = 0; c < kComms; c++) {
+      ASSERT_EQ(
+          ctran::allGatherPExec(
+              sendBufs.at(b), sendCount, dt, requests[c * kBufs + b]),
+          commSuccess);
+    }
+  }
+
+  // synchronize all streams
+  for (int c = 0; c < kComms; c++) {
+    ASSERT_EQ(cudaStreamSynchronize(streams.at(c)), cudaSuccess);
+  }
+
+  // Release resources
+  for (int r = 0; r < requests.size(); r++) {
+    ASSERT_EQ(ctran::allGatherPDestroy(requests[r]), commSuccess);
+  }
+
+  // deregister buffers
+  for (int b = 0; b < kBufs; b++) {
+    COMMCHECK_TEST(ctranComm->ctran_->commDeregister(sendHdls.at(b)));
+    COMMCHECK_TEST(ctranComm->ctran_->commDeregister(recvHdls.at(b)));
+    cumemBufCleanUp(sendBufs.at(b), recvBufs.at(b));
+  }
 }
 
 inline std::string getTestName(

--- a/comms/ctran/utils/CtranIpc.h
+++ b/comms/ctran/utils/CtranIpc.h
@@ -135,6 +135,8 @@ class CtranIpcMem {
   //   - memType: the device memory type. Support kCumem and kCudaMalloc.
   //   - cuMemHandleType: the type of the handle to be used for importing and
   //   exporting the memory. Only used when memType is kCumem.
+  // NOTE: this class need to be accessed in a thread-safe manner; it does not
+  // have any internal locking mechanism. For additional context, see D89740579
   CtranIpcMem(
       const size_t size,
       const int cudaDev,
@@ -184,13 +186,13 @@ class CtranIpcMem {
   commResult_t free();
 
   // Return the base address of the memory range
-  inline void* getBase() {
+  inline void* getBase() const {
     return reinterpret_cast<void*>(pbase_);
   }
 
   // Return the range of the memory range (it may be greater or equal to the
   // user specified size)
-  inline size_t getRange() {
+  inline size_t getRange() const {
     return range_;
   }
 


### PR DESCRIPTION
Summary:
A memory region can be used and exported by multiple communicators and therefore needs thread safety. Since CtranIpc is a util class/function, user should ensure thread safety before using CtranIpc to manage memory.

This diff adds a lock to the ipcMem variable of  CtranNvlRegElem (user of CtranIpc class) as well as an additional test case in ctran AGP distributed test.

Reviewed By: riklas, minsii

Differential Revision: D89740579


