### PR TITLE
enable DDA AR, AG, RS, A2A by default, and check NRANKS to avoid DDA assert error

### DIFF
--- a/comms/common/algorithms/AlgoUtils.cc
+++ b/comms/common/algorithms/AlgoUtils.cc
@@ -8,7 +8,11 @@ namespace meta {
 namespace comms {
 
 inline uint32_t divRoundUp(size_t a, size_t b) {
-  return static_cast<uint32_t>((a + b - 1) / b);
+  uint32_t y = static_cast<uint32_t>((a + b - 1) / b);
+  if (y == 0) {
+    y = 1;
+  }
+  return y;
 }
 
 constexpr uint32_t
@@ -18,7 +22,11 @@ calcBlockCount(size_t numThreads, size_t threadsPerBlock, size_t maxBlocks) {
   // Overflow safe variant of (a + b - 1) / b
   const uint64_t blocks =
       uNumThreads / uThreadsPerBlock + (uNumThreads % uThreadsPerBlock != 0);
-  return static_cast<uint32_t>(std::min(blocks, maxBlocks));
+  uint32_t y = static_cast<uint32_t>(std::min(blocks, maxBlocks));
+  if (y == 0) {
+    y = 1;
+  }
+  return y;
 }
 
 std::pair<dim3, dim3>

--- a/comms/rcclx/develop/meta/algorithms/AlgoInit.h
+++ b/comms/rcclx/develop/meta/algorithms/AlgoInit.h
@@ -9,10 +9,11 @@
 #include "param.h"
 
 // Meta custom algorithm configs
+RCCL_PARAM(DdaNRanks, "DDA_NRANKS", 8);
 RCCL_PARAM(DdaMaxBlocks, "DDA_MAX_BLOCKS", 24);
 RCCL_PARAM(DdaSendbufBytes, "DDA_SENDBUF_BYTES", 32 * 1024 * 1024);
 
-RCCL_PARAM(EnableDdaAllReduce, "ENABLE_DDA_ALL_REDUCE", 0);
+RCCL_PARAM(EnableDdaAllReduce, "ENABLE_DDA_ALL_REDUCE", 1);
 RCCL_PARAM(
     DdaAllReduceFlatMaxBytes,
     "DDA_ALL_REDUCE_FLAT_MAX_BYTES",
@@ -22,16 +23,16 @@ RCCL_PARAM(
     "DDA_ALL_REDUCE_TREE_MAX_BYTES",
     29 * 1024 * 1024);
 
-RCCL_PARAM(EnableDdaAllGather, "ENABLE_DDA_ALL_GATHER", 0);
+RCCL_PARAM(EnableDdaAllGather, "ENABLE_DDA_ALL_GATHER", 1);
 RCCL_PARAM(DdaAllGatherMaxBytes, "DDA_ALL_GATHER_MAX_BYTES", 16 * 1024 * 1024);
 
-RCCL_PARAM(EnableDdaReduceScatter, "ENABLE_DDA_REDUCE_SCATTER", 0);
+RCCL_PARAM(EnableDdaReduceScatter, "ENABLE_DDA_REDUCE_SCATTER", 1);
 RCCL_PARAM(
     DdaReduceScatterMaxBytes,
     "DDA_REDUCE_SCATTER_MAX_BYTES",
     8 * 1024 * 1024);
 
-RCCL_PARAM(EnableDdaAllToAll, "ENABLE_DDA_ALL_TO_ALL", 0);
+RCCL_PARAM(EnableDdaAllToAll, "ENABLE_DDA_ALL_TO_ALL", 1);
 RCCL_PARAM(DdaAllToAllMaxBytes, "DDA_ALL_TO_ALL_MAX_BYTES", 2 * 1024 * 1024);
 
 std::unique_ptr<meta::comms::AlgoFactoryDev> initAlgoFactory(ncclComm_t comm) {
@@ -43,6 +44,14 @@ std::unique_ptr<meta::comms::AlgoFactoryDev> initAlgoFactory(ncclComm_t comm) {
         NCCL_INIT,
         "Disabling DDA for multi-node setup (nNodes=%d)",
         comm->nNodes);
+    return nullptr;
+  }
+
+  if (comm->nRanks != rcclParamDdaNRanks()) {
+    INFO(
+        NCCL_INIT,
+        "Disabling DDA for single-node when nRanks != 8 setup (nRanks=%d)",
+        comm->nRanks);
     return nullptr;
   }
 


### PR DESCRIPTION
Summary:
In this diff:
- we enable all DDA collectives (AllReduce, AllGather, ReduceScatter, AllToAll) by default
- To avoid the assert error inside DDA (DDA only supports NRANKS=8), we add the check in AlgoInit.h to disable DDA when comm.nRanks != 8.
- Fix failed test: rccl_allreduce_perf_bench
  - Root-cause: "zgpu_benchmark" --> D90052113
  - In zgpu_benchmark, it sets rccl-tests args "-g 8" which means 8 GPUs per thread, IPC (inter-process communication) does not compile with this scheme
  - So, set "-g 1" in zgpu_benchmark to fix it

Mast jobs: https://fburl.com/network/o2c0v5ov

ToDo: make DDA support nRanks < 8 case?

Differential Revision: D89249175


