### PR TITLE
allow kernels from multi-streams running in parallel

### DIFF
--- a/comms/ctran/algos/RMA/PutSignal.cc
+++ b/comms/ctran/algos/RMA/PutSignal.cc
@@ -6,6 +6,7 @@
 #include "Types.h"
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/CtranAlgo.h"
+#include "comms/ctran/algos/RMA/WaitSignalImpl.h"
 #include "comms/ctran/colltrace/CollTraceWrapper.h"
 #include "comms/ctran/gpe/CtranGpe.h"
 #include "comms/ctran/mapper/CtranMapper.h"
@@ -380,7 +381,7 @@ waitSignalDriverApi(int peer, CtranWin* win, cudaStream_t stream) {
 #endif
 }
 
-static commResult_t waitSignalSpinningKernel(
+commResult_t waitSignalSpinningKernel(
     int peer,
     CtranWin* win,
     cudaStream_t stream,
@@ -393,6 +394,7 @@ static commResult_t waitSignalSpinningKernel(
   KernelConfig config = KernelConfig(
       KernelConfig::KernelType::WAITSIGNAL, stream, "WaitSignal", waitOpCount);
   config.args.devState_d = comm->ctran_->algo->getDevState();
+  config.canConcurrent = true;
 
   std::vector<std::unique_ptr<struct OpElem>> opGroup;
   opGroup.clear();

--- a/comms/ctran/algos/RMA/WaitSignalImpl.h
+++ b/comms/ctran/algos/RMA/WaitSignalImpl.h
@@ -1,0 +1,11 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include "comms/ctran/CtranComm.h"
+
+commResult_t waitSignalSpinningKernel(
+    int peer,
+    ctran::CtranWin* win,
+    cudaStream_t stream,
+    uint64_t waitOpCount);

--- a/comms/ctran/gpe/CtranGpe.h
+++ b/comms/ctran/gpe/CtranGpe.h
@@ -321,6 +321,11 @@ struct KernelConfig {
   const uint64_t opCount;
   bool isDevice{true};
 
+  // Experimental: allows one-sided communications, waitSignal and
+  // multiWaitSignal, to run in parallel with other kernels when
+  // launched on a single GPE thread.
+  bool canConcurrent{false};
+
  public:
   KernelConfig(
       enum KernelType type,

--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -243,7 +243,8 @@ commResult_t CtranGpe::Impl::submit(
   // FIXME: the multi-stream order enforcement is not compatible with cuda graph
   // capture; disable it under cuda graph capture as a workaround. We'd need
   // proper fix to support the compatibility.
-  if (streamCaptureInfo.status != cudaStreamCaptureStatusActive) {
+  if (streamCaptureInfo.status != cudaStreamCaptureStatusActive &&
+      !kernelConfig.canConcurrent) {
     FB_COMMCHECK(preKernelLaunch(kernelConfig.stream));
   }
 
@@ -365,7 +366,8 @@ commResult_t CtranGpe::Impl::submit(
   // FIXME: the multi-stream order enforcement is not compatible with cuda graph
   // capture; disable it under cuda graph capture as a workaround. We'd need
   // proper fix to support the compatibility.
-  if (streamCaptureInfo.status != cudaStreamCaptureStatusActive) {
+  if (streamCaptureInfo.status != cudaStreamCaptureStatusActive &&
+      !kernelConfig.canConcurrent) {
     FB_COMMCHECK(postKernelLaunch(kernelConfig.stream));
   }
 


### PR DESCRIPTION
Summary:
In D82047198, the execution order of kernels across multiple streams is enforced.

This diff introduces the flexibility to run kernels in parallel on multiple streams.

Differential Revision: D89907804


