### PR TITLE
Improving ctranwaitsignal with harware accelerated wait.

### DIFF
--- a/comms/ctran/utils/CudaWrap.h
+++ b/comms/ctran/utils/CudaWrap.h
@@ -284,6 +284,7 @@ FB_DECLARE_CUDA_PFN_EXTERN(cuMemGetAllocationPropertiesFromHandle, 10020);
 FB_DECLARE_CUDA_PFN_EXTERN(cuPointerGetAttribute, 4000);
 #if CUDA_VERSION >= 11070
 FB_DECLARE_CUDA_PFN_EXTERN(cuMemGetHandleForAddressRange, 11070);
+FB_DECLARE_CUDA_PFN_EXTERN(cuStreamWaitValue64, 11070);
 #endif
 #if CUDA_VERSION >= 12010
 /* NVSwitch Multicast support */

--- a/comms/utils/commSpecs.h
+++ b/comms/utils/commSpecs.h
@@ -23,7 +23,7 @@ enum commResult_t {
   commInvalidUsage = 5,
   commRemoteError = 6,
   commInProgress = 7,
-  commNumResults = 8
+  commNumResults = 8,
 };
 
 constexpr const char* commResultToString(commResult_t res) {


### PR DESCRIPTION
Summary: In this diff, the waitSignal operation has been enhanced to utilize hardware-based waiting mechanisms, replacing previous busy-wait approaches. This improvement ensures that resources are not unnecessarily occupied during wait periods, leading to more efficient execution.

Reviewed By: elvinlife, function47

Differential Revision: D87307348


