### PR TITLE
Add getLastError to the list of APIs

### DIFF
--- a/comms/torchcomms/ncclx/NcclxApi.cpp
+++ b/comms/torchcomms/ncclx/NcclxApi.cpp
@@ -17,6 +17,11 @@ const char* DefaultNcclxApi::getErrorString(ncclResult_t result) {
   return ncclGetErrorString(result);
 }
 
+std::string DefaultNcclxApi::getLastError(ncclComm_t comm) {
+  const char* error = ncclGetLastError(comm);
+  return error != nullptr ? std::string(error) : std::string();
+}
+
 ncclResult_t DefaultNcclxApi::getUniqueId(ncclUniqueId* uniqueId) {
   return ncclGetUniqueId(uniqueId);
 }

--- a/comms/torchcomms/ncclx/NcclxApi.hpp
+++ b/comms/torchcomms/ncclx/NcclxApi.hpp
@@ -22,6 +22,7 @@ class NcclxApi {
 
   // Error handling
   virtual const char* getErrorString(ncclResult_t result) = 0;
+  virtual std::string getLastError(ncclComm_t comm) = 0;
 
   // Unique ID generation
   virtual ncclResult_t getUniqueId(ncclUniqueId* uniqueId) = 0;
@@ -256,6 +257,7 @@ class DefaultNcclxApi : public NcclxApi {
 
   // Error handling
   const char* getErrorString(ncclResult_t result) override;
+  std::string getLastError(ncclComm_t comm) override;
 
   // Unique ID generation
   ncclResult_t getUniqueId(ncclUniqueId* uniqueId) override;

--- a/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.cpp
@@ -16,6 +16,10 @@ void NcclxMock::setupDefaultBehaviors() {
   ON_CALL(*this, getErrorString(_))
       .WillByDefault(Return("mock nccl error string"));
 
+  // Last error - return a default mock last error string
+  ON_CALL(*this, getLastError(_))
+      .WillByDefault(Return("mock nccl last error details"));
+
   // Unique ID generation - return success and set a mock unique ID
   ON_CALL(*this, getUniqueId(_))
       .WillByDefault(

--- a/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.hpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.hpp
@@ -21,6 +21,7 @@ class NcclxMock : public NcclxApi {
 
   // Error handling
   MOCK_METHOD(const char*, getErrorString, (ncclResult_t result), (override));
+  MOCK_METHOD(std::string, getLastError, (ncclComm_t comm), (override));
 
   // Unique ID generation
   MOCK_METHOD(ncclResult_t, getUniqueId, (ncclUniqueId * uniqueId), (override));


### PR DESCRIPTION
Summary:
Add `getLastError` API to the NcclxApi interface, which wraps NCCL's `ncclGetLastError` function. This provides access to detailed error information about the last NCCL error on a communicator, which is more informative than the generic error codes returned by `getErrorString`.

The implementation safely handles null returns by converting them to empty strings.

Differential Revision: D90287086


