### PR TITLE
Correct BW calculation in Ibverbx H100 benchmark code

### DIFF
--- a/comms/ctran/ibverbx/benchmarks/IbverbxVirtualQpBench.cc
+++ b/comms/ctran/ibverbx/benchmarks/IbverbxVirtualQpBench.cc
@@ -377,7 +377,10 @@ static void BM_Ibverbx_VirtualQp_RdmaRead(benchmark::State& state) {
       BenchmarkSetup::pollCqUntilCompletion(setup.receiver->cq, "Receiver");
     }
 
-    state.SetBytesProcessed(state.iterations() * bufferSize);
+    // Calculate and report bandwidth using custom counters
+    double totalBytes = static_cast<double>(state.iterations()) * bufferSize;
+    state.counters["BW_GBps"] =
+        benchmark::Counter(totalBytes / 1e9, benchmark::Counter::kIsRate);
   } catch (const std::exception& e) {
     XLOGF(FATAL, "Benchmark setup failed: {}", e.what());
     return;
@@ -419,7 +422,10 @@ static void BM_Ibverbx_VirtualQp_RdmaWrite(benchmark::State& state) {
       BenchmarkSetup::pollCqUntilCompletion(setup.sender->cq, "Sender");
     }
 
-    state.SetBytesProcessed(state.iterations() * bufferSize);
+    // Calculate and report bandwidth using custom counters
+    double totalBytes = static_cast<double>(state.iterations()) * bufferSize;
+    state.counters["BW_GBps"] =
+        benchmark::Counter(totalBytes / 1e9, benchmark::Counter::kIsRate);
   } catch (const std::exception& e) {
     XLOGF(FATAL, "Benchmark setup failed: {}", e.what());
     return;
@@ -476,7 +482,10 @@ static void BM_Ibverbx_VirtualQp_RdmaWriteWithImm(
       BenchmarkSetup::pollCqUntilCompletion(setup.receiver->cq, "Receiver");
     }
 
-    state.SetBytesProcessed(state.iterations() * bufferSize);
+    // Calculate and report bandwidth using custom counters
+    double totalBytes = static_cast<double>(state.iterations()) * bufferSize;
+    state.counters["BW_GBps"] =
+        benchmark::Counter(totalBytes / 1e9, benchmark::Counter::kIsRate);
   } catch (const std::exception& e) {
     XLOGF(FATAL, "Benchmark setup failed: {}", e.what());
     return;


### PR DESCRIPTION
Summary:
The diff updates the network bandwidth (BW) calculation to use the correct base for gigabytes per second (GBps) in fbcode/comms‎/ctran‎/ibverbx‎/benchmarks‎/‎IbverbxVirtualQpBench.cc, which aligns with other Ctran performance calculation tools, such as rma run script (D90268935).

  - Previously: GBps was calculated using the binary base (1024^3).
  - Now: GBps is calculated using the decimal base (10^9), which aligns with standard network bandwidth conventions.

This ensures accurate bandwidth reporting and consistency with industry standards, and prevents potential misinterpretation of network performance metrics due to base mismatch.

Reviewed By: cenzhaometa

Differential Revision: D90282316


