### PR TITLE
Migrate CtranAlgo to use FB_COMMCHECKTHROW_EX for enhanced error reporting

### DIFF
--- a/comms/ctran/algos/AllReduce/AllReduceRing.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceRing.cc
@@ -121,8 +121,7 @@ inline void prePostRecvRemRecvBuf(
     CtranMapperRequest* req;
     FB_COMMCHECKTHROW_EX(
         resource.comm->ctran_->mapper->irecvCtrl(args.rightRank, &req),
-        resource.comm->statex_->rank(),
-        resource.comm->statex_->commHash());
+        resource.comm->logMetaData_);
     bufSyncRResps.at(round).reset(req);
   }
 }
@@ -150,8 +149,7 @@ inline bool progressSendCheckRemRecvBuf(
     bool isComplete = false;
     FB_COMMCHECKTHROW_EX(
         resource.comm->ctran_->mapper->testRequest(resp.get(), &isComplete),
-        resource.comm->statex_->rank(),
-        resource.comm->statex_->commHash());
+        resource.comm->logMetaData_);
     if (isComplete) {
       int tmpChunkId = getTmpChunkId(algoCtx, round);
       CLOGF_TRACE(
@@ -182,8 +180,7 @@ inline void progressSendCheckTrans(
       bool isComplete = false;
       FB_COMMCHECKTHROW_EX(
           resource.comm->ctran_->mapper->testRequest(resp.get(), &isComplete),
-          resource.comm->statex_->rank(),
-          resource.comm->statex_->commHash());
+          resource.comm->logMetaData_);
       if (isComplete) {
         // FIXME: step might be incorrect
         CLOGF_TRACE(
@@ -263,8 +260,7 @@ inline void progressSendPostTrans(
               .notify_ = true,
               .ibConfig_ = allReduceConfig},
           &req),
-      resource.comm->statex_->rank(),
-      resource.comm->statex_->commHash());
+      resource.comm->logMetaData_);
   dataSResps.at(round).reset(req);
 
   CLOGF_TRACE(
@@ -296,8 +292,7 @@ inline bool progressRecvCheckTrans(
   bool done = false;
   FB_COMMCHECKTHROW_EX(
       resource.comm->ctran_->mapper->checkNotify(args.leftNotify.get(), &done),
-      resource.comm->statex_->rank(),
-      resource.comm->statex_->commHash());
+      resource.comm->logMetaData_);
   if (done) {
     CLOGF_TRACE(
         COLL,
@@ -330,8 +325,7 @@ inline void progressRecvPostFlush(
   FB_COMMCHECKTHROW_EX(
       resource.comm->ctran_->mapper->iflush(
           tmpRecvBuf, resource.tmpRecvBufHdl, &req),
-      resource.comm->statex_->rank(),
-      resource.comm->statex_->commHash());
+      resource.comm->logMetaData_);
   flushResps.at(round).reset(req);
 }
 
@@ -355,8 +349,7 @@ inline bool progressRecvCheckFlush(
   bool isComplete = false;
   FB_COMMCHECKTHROW_EX(
       resource.comm->ctran_->mapper->testRequest(resp.get(), &isComplete),
-      resource.comm->statex_->rank(),
-      resource.comm->statex_->commHash());
+      resource.comm->logMetaData_);
   if (isComplete) {
     CLOGF_TRACE(
         COLL, "{} done", roundLogPrefix<Op::kRecvFlush>(round, step, algoCtx));
@@ -449,8 +442,7 @@ inline void progressRecvPostRecvBuf(
   CtranMapperRequest* req;
   FB_COMMCHECKTHROW_EX(
       resource.comm->ctran_->mapper->isendCtrl(args.leftRank, &req),
-      resource.comm->statex_->rank(),
-      resource.comm->statex_->commHash());
+      resource.comm->logMetaData_);
   bufSyncSResps.at(round).reset(req);
 }
 
@@ -548,9 +540,7 @@ inline int waitAllResps(
     if (req) {
       numComplete++;
       FB_COMMCHECKTHROW_EX(
-          comm->ctran_->mapper->waitRequest(req.get()),
-          comm->statex_->rank(),
-          comm->statex_->commHash());
+          comm->ctran_->mapper->waitRequest(req.get()), comm->logMetaData_);
     }
   }
   return numComplete;

--- a/comms/ctran/algos/tests/CtranDevWaitUT.cc
+++ b/comms/ctran/algos/tests/CtranDevWaitUT.cc
@@ -27,7 +27,8 @@ class CtranDeviceWaitUT : public CtranStandaloneFixture {
         ctran::utils::commCudaMalloc(
             &devState_, 1, /*logMetaData=*/nullptr, "CtranDeviceWaitUT"),
         /*rank=*/0,
-        /*commHash=*/0);
+        /*commHash=*/0,
+        /*commDesc=*/std::string(""));
 
     memset(&args_, 0, sizeof(args_));
     FB_CUDACHECKTHROW(
@@ -42,7 +43,8 @@ class CtranDeviceWaitUT : public CtranStandaloneFixture {
         ctran::utils::commCudaMalloc(
             &args_.d2h, 1, /*logMetaData=*/nullptr, "CtranDeviceWaitUT"),
         /*rank=*/0,
-        /*commHash=*/0);
+        /*commHash=*/0,
+        /*commDesc=*/std::string(""));
     FB_CUDACHECKTHROW(cudaMemset(args_.d2h, 0, sizeof(*args_.d2h)));
 
     d2h_.revoked = false;
@@ -50,10 +52,16 @@ class CtranDeviceWaitUT : public CtranStandaloneFixture {
   }
   void TearDown() override {
     FB_COMMCHECKTHROW_EX(
-        ctran::utils::commCudaFree(args_.d2h), /*rank=*/0, /*commHash=*/0);
+        ctran::utils::commCudaFree(args_.d2h),
+        /*rank=*/0,
+        /*commHash=*/0,
+        /*commDesc=*/std::string(""));
     FB_CUDACHECKTHROW(cudaFreeHost(args_.h2d));
     FB_COMMCHECKTHROW_EX(
-        ctran::utils::commCudaFree(devState_), /*rank=*/0, /*commHash=*/0);
+        ctran::utils::commCudaFree(devState_),
+        /*rank=*/0,
+        /*commHash=*/0,
+        /*commDesc=*/std::string(""));
     FB_CUDACHECKTHROW(cudaFreeHost(flag_));
   }
 

--- a/comms/ctran/backends/ib/CtranIb.h
+++ b/comms/ctran/backends/ib/CtranIb.h
@@ -492,6 +492,10 @@ class CtranIb {
     return commHash;
   }
 
+  std::string getCommDesc() const {
+    return commDesc;
+  }
+
  private:
   friend class CtranIbRequest;
   void init(
@@ -1148,7 +1152,10 @@ class CtranIbEpochRAII {
   explicit CtranIbEpochRAII(CtranIb* ctranIb) : ctranIb_(ctranIb) {
     if (ctranIb_ != nullptr) {
       FB_COMMCHECKTHROW_EX(
-          ctranIb_->epochLock(), ctranIb_->getRank(), ctranIb_->getCommHash());
+          ctranIb_->epochLock(),
+          ctranIb_->getRank(),
+          ctranIb_->getCommHash(),
+          ctranIb_->getCommDesc());
     }
   }
 

--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -544,9 +544,7 @@ void CtranGpe::Impl::gpeThreadFn() {
         // info at failure or throw exception from bottom.
         CTRAN_ASYNC_ERR_GUARD_FAULT_TOLERANCE(comm, {
           FB_COMMCHECKTHROW_EX(
-              cmd->coll.func(cmd->coll.opGroup),
-              statex->rank(),
-              statex->commHash());
+              cmd->coll.func(cmd->coll.opGroup), comm->logMetaData_);
         });
 
         if (cmd->persistent) {

--- a/comms/ctran/tests/CtranTestUtils.cc
+++ b/comms/ctran/tests/CtranTestUtils.cc
@@ -800,16 +800,14 @@ void workerRoutine(PerRankState& state) {
           CtranIntraProcessFixture::kBufferSize,
           &state.ctranComm->logMetaData_,
           "UT_workerRoutine"),
-      rank,
-      kMultiRankCommHash);
+      state.ctranComm->logMetaData_);
   FB_COMMCHECKTHROW_EX(
       ctran::utils::commCudaMalloc(
           reinterpret_cast<char**>(&state.dstBuffer),
           CtranIntraProcessFixture::kBufferSize,
           &state.ctranComm->logMetaData_,
           "UT_workerRoutine"),
-      rank,
-      kMultiRankCommHash);
+      state.ctranComm->logMetaData_);
 
   CLOGF(INFO, "rank [{}/{}] worker waiting for work", rank, state.nRanks);
 

--- a/comms/ctran/utils/tests/ChecksUT.cc
+++ b/comms/ctran/utils/tests/ChecksUT.cc
@@ -175,16 +175,17 @@ TEST_F(CtranUtilsCheckTest, ErrorThrow) {
 }
 
 TEST_F(CtranUtilsCheckTest, ErrorThrowEx) {
-  auto dummyFn = [](int rank, uint64_t commHash) {
-    FB_COMMCHECKTHROW_EX(commSystemError, rank, commHash);
+  auto dummyFn = [](int rank, uint64_t commHash, std::string commDesc) {
+    FB_COMMCHECKTHROW_EX(commSystemError, rank, commHash, commDesc);
     return commSuccess;
   };
 
   const auto rank = 1;
   const auto commHash = 0x1234;
+  const std::string commDesc = "testDesc";
   bool caughtException = false;
   try {
-    dummyFn(rank, commHash);
+    dummyFn(rank, commHash, commDesc);
   } catch (const ctran::utils::Exception& e) {
     auto errMsg = std::string(e.what());
     EXPECT_THAT(errMsg, ::testing::HasSubstr("COMM internal failure:"));
@@ -327,4 +328,145 @@ TEST_F(CtranUtilsCheckTest, FB_SYSCHECKRETURN) {
 
   EXPECT_EQ(testFn(false), NOERROR);
   EXPECT_EQ(testFn(true), ERRORCODE2);
+}
+
+TEST_F(CtranUtilsCheckTest, FB_COMMCHECKTHROW_EX_DIRECT) {
+  const int rank = 7;
+  const uint64_t commHash = 0xDEADBEEF;
+  const std::string commDesc = "testDesc";
+
+  // Success case: no exception thrown
+  EXPECT_NO_THROW(
+      FB_COMMCHECKTHROW_EX_DIRECT(commSuccess, rank, commHash, commDesc));
+
+  for (size_t i = 0; i < commNumResults; i++) {
+    const auto commResult = static_cast<commResult_t>(i);
+    if (commResult == commSuccess || commResult == commInProgress) {
+      continue;
+    }
+
+    // Failure case: ctran::utils::Exception thrown with correct properties
+    bool caughtException = false;
+    try {
+      FB_COMMCHECKTHROW_EX_DIRECT(commResult, rank, commHash, commDesc);
+    } catch (const ctran::utils::Exception& e) {
+      EXPECT_EQ(e.result(), commResult);
+      EXPECT_EQ(e.rank(), rank);
+      EXPECT_EQ(e.commHash(), commHash);
+      EXPECT_THAT(
+          std::string(e.what()),
+          ::testing::HasSubstr("COMM internal failure:"));
+      caughtException = true;
+    }
+    ASSERT_TRUE(caughtException)
+        << "Expected ctran::utils::Exception for commResult=" << commResult;
+  }
+}
+
+TEST_F(CtranUtilsCheckTest, FB_COMMCHECKTHROW_EX_LOGDATA) {
+  const int rank = 7;
+  const uint64_t commHash = 0xDEADBEEF;
+  const std::string commDesc = "testDesc";
+
+  CommLogData logData = {
+      .rank = rank,
+      .commHash = commHash,
+      .commDesc = commDesc,
+  };
+
+  // Success case: no exception thrown
+  EXPECT_NO_THROW(FB_COMMCHECKTHROW_EX_LOGDATA(commSuccess, logData));
+
+  for (size_t i = 0; i < commNumResults; i++) {
+    const auto commResult = static_cast<commResult_t>(i);
+    if (commResult == commSuccess || commResult == commInProgress) {
+      continue;
+    }
+
+    // Failure case: ctran::utils::Exception thrown with correct properties
+    bool caughtException = false;
+    try {
+      FB_COMMCHECKTHROW_EX_LOGDATA(commResult, logData);
+    } catch (const ctran::utils::Exception& e) {
+      EXPECT_EQ(e.result(), commResult);
+      EXPECT_EQ(e.rank(), rank);
+      EXPECT_EQ(e.commHash(), commHash);
+      EXPECT_THAT(
+          std::string(e.what()),
+          ::testing::HasSubstr("COMM internal failure:"));
+      caughtException = true;
+    }
+    ASSERT_TRUE(caughtException)
+        << "Expected ctran::utils::Exception for commResult=" << commResult;
+  }
+}
+
+TEST_F(CtranUtilsCheckTest, FB_COMMCHECKTHROW_EX_3ARGS) {
+  const int rank = 7;
+  const uint64_t commHash = 0xDEADBEEF;
+  const std::string commDesc = "testDesc";
+
+  // Success case: no exception thrown
+  EXPECT_NO_THROW(FB_COMMCHECKTHROW_EX(commSuccess, rank, commHash, commDesc));
+
+  for (size_t i = 0; i < commNumResults; i++) {
+    const auto commResult = static_cast<commResult_t>(i);
+    if (commResult == commSuccess || commResult == commInProgress) {
+      continue;
+    }
+
+    // Failure case: ctran::utils::Exception thrown with correct properties
+    bool caughtException = false;
+    try {
+      FB_COMMCHECKTHROW_EX(commResult, rank, commHash, commDesc);
+    } catch (const ctran::utils::Exception& e) {
+      EXPECT_EQ(e.result(), commResult);
+      EXPECT_EQ(e.rank(), rank);
+      EXPECT_EQ(e.commHash(), commHash);
+      EXPECT_THAT(
+          std::string(e.what()),
+          ::testing::HasSubstr("COMM internal failure:"));
+      caughtException = true;
+    }
+    ASSERT_TRUE(caughtException)
+        << "Expected ctran::utils::Exception for commResult=" << commResult;
+  }
+}
+
+TEST_F(CtranUtilsCheckTest, FB_COMMCHECKTHROW_EX_2ARGS) {
+  const int rank = 7;
+  const uint64_t commHash = 0xDEADBEEF;
+  const std::string commDesc = "testDesc";
+
+  CommLogData logData = {
+      .rank = rank,
+      .commHash = commHash,
+      .commDesc = commDesc,
+  };
+
+  // Success case: no exception thrown
+  EXPECT_NO_THROW(FB_COMMCHECKTHROW_EX(commSuccess, logData));
+
+  for (size_t i = 0; i < commNumResults; i++) {
+    const auto commResult = static_cast<commResult_t>(i);
+    if (commResult == commSuccess || commResult == commInProgress) {
+      continue;
+    }
+
+    // Failure case: ctran::utils::Exception thrown with correct properties
+    bool caughtException = false;
+    try {
+      FB_COMMCHECKTHROW_EX(commResult, logData);
+    } catch (const ctran::utils::Exception& e) {
+      EXPECT_EQ(e.result(), commResult);
+      EXPECT_EQ(e.rank(), rank);
+      EXPECT_EQ(e.commHash(), commHash);
+      EXPECT_THAT(
+          std::string(e.what()),
+          ::testing::HasSubstr("COMM internal failure:"));
+      caughtException = true;
+    }
+    ASSERT_TRUE(caughtException)
+        << "Expected ctran::utils::Exception for commResult=" << commResult;
+  }
 }


### PR DESCRIPTION
Summary:
**TL;DR:** Migrates all `FB_COMMCHECKTHROW` usages in `CtranAlgo.cc` to `FB_COMMCHECKTHROW_EX`, adding rank, commHash, and commDesc context for improved fault tolerance error diagnostics.

This also updates existing uses of `FB_COMMCHECKTHROW_EX` to be compatible with the new definition, which includes the `commDesc` field now.

---

# Detailed Overview

## Context & Motivation

As part of our fault tolerance initiative, we are migrating error handling throughout CTRAN from generic exceptions to `ctran::utils::Exception` with rich communicator context. The `FB_COMMCHECKTHROW_EX` macro enables enhanced error reporting by including rank, comm hash, and comm description in thrown exceptions, which is critical for debugging failures in distributed environments.

`CtranAlgo.cc` is a core file that handles algorithm initialization, kernel resource management, IPC memory setup, and temporary buffer allocation, all areas where detailed error context significantly aids fault diagnosis.

## Technical Details

The following operations in `CtranAlgo.cc` have been updated to use `FB_COMMCHECKTHROW_EX` with full communicator context (`comm_->statex_->rank()`, `comm_->statex_->commHash()`, `comm_->statex_->commDesc().c_str()`):

- **Initialization**: `initKernelResources()` and `initializeCommAttributesMap()`
- **Cleanup**: `memCache_->release()` and `ctran::utils::commCudaFree()` for temporary buffer deallocation
- **IPC Memory**: `ipcMem_->ipcExport()` for shared memory export
- **Bootstrap Operations**: `barrierIntraNode()` calls for synchronization
- **Memory Allocation**: `getCachedCuMemById()`, `commCudaMalloc()`, and `mapper->regMem()` for temporary buffer setup
- **Buffer Exchange**: `exchangePeerTmpbuf()` and `exchangeInterNodeTmpbuf()` for on-demand buffer exchange

All changes preserve existing functionality while enriching exception context for better observability and fault attribution.

Reviewed By: arttianezhu

Differential Revision: D90196164


