### PR TITLE
Migrate CtranSocket to use FB_SYSCHECKTHROW_EX for enhanced error reporting (#128)

### DIFF
--- a/comms/ctran/backends/socket/CtranSocket.cc
+++ b/comms/ctran/backends/socket/CtranSocket.cc
@@ -147,8 +147,9 @@ void CtranSocket::init(const SocketServerAddr& serverAddr) {
     }
 
     folly::SocketAddress ifAddrSockAddr(maybeAddr.value(), 0 /* port */);
-    FB_SYSCHECKTHROW(
-        listenSocket_.bindAndListen(ifAddrSockAddr, NCCL_SOCKET_IFNAME));
+    FB_SYSCHECKTHROW_EX(
+        listenSocket_.bindAndListen(ifAddrSockAddr, NCCL_SOCKET_IFNAME),
+        ncclLogData_);
     CLOGF_SUBSYS(
         INFO,
         INIT,
@@ -159,7 +160,7 @@ void CtranSocket::init(const SocketServerAddr& serverAddr) {
     allListenSocketAddrs_.resize(comm->statex_->nRanks());
     auto maybeListenAddr = listenSocket_.getListenAddress();
     if (maybeListenAddr.hasError()) {
-      FB_SYSCHECKTHROW(maybeListenAddr.error());
+      FB_SYSCHECKTHROW_EX(maybeListenAddr.error(), ncclLogData_);
     }
     maybeListenAddr->getAddress(&allListenSocketAddrs_[rank_]);
 
@@ -208,11 +209,11 @@ void CtranSocket::bootstrapAccept() {
       if (maybeSocket.error() == EBADF || maybeSocket.error() == EINVAL) {
         break; // listen socket is closed
       }
-      FB_SYSCHECKTHROW(maybeSocket.error());
+      FB_SYSCHECKTHROW_EX(maybeSocket.error(), ncclLogData_);
     }
     auto socket = std::make_unique<ctran::bootstrap::Socket>(
         std::move(maybeSocket.value()));
-    FB_SYSCHECKTHROW(socket->recv(&peerRank, sizeof(int)));
+    FB_SYSCHECKTHROW_EX(socket->recv(&peerRank, sizeof(int)), ncclLogData_);
 
     CLOGF_SUBSYS(
         INFO,

--- a/comms/ctran/utils/Checks.h
+++ b/comms/ctran/utils/Checks.h
@@ -218,7 +218,8 @@
       throw std::runtime_error(std::string("System error: ") + errstr);        \
     }                                                                          \
   } while (0)
-#define FB_SYSCHECKTHROW_EX(cmd, rank, commHash, desc)                         \
+
+#define FB_SYSCHECKTHROW_EX_DIRECT(cmd, rank, commHash, desc)                  \
   do {                                                                         \
     int err = cmd;                                                             \
     if (err != 0) {                                                            \
@@ -232,6 +233,27 @@
           desc);                                                               \
     }                                                                          \
   } while (0)
+
+#define FB_SYSCHECKTHROW_EX_LOGDATA(cmd, logData) \
+  FB_SYSCHECKTHROW_EX_DIRECT(                     \
+      cmd, (logData).rank, (logData).commHash, (logData).commDesc)
+
+// Selector macro, used with FB_SYSCHECKTHROW_EX to delegate
+// based on the number of arguments.
+// The dummy placeholders ensure correct selection for 2, 3, and 4 arguments.
+#define GET_FB_SYSCHECKTHROW_EX_MACRO(_1, _2, _3, _4, NAME, ...) NAME
+
+// Delegates to either FB_SYSCHECKTHROW_EX_DIRECT or
+// FB_SYSCHECKTHROW_EX_LOGDATA based on the number of arguments.
+// - 4 args (cmd, rank, commHash, desc): uses FB_SYSCHECKTHROW_EX_DIRECT
+// - 2 args (cmd, logData): uses FB_SYSCHECKTHROW_EX_LOGDATA
+#define FB_SYSCHECKTHROW_EX(...)   \
+  GET_FB_SYSCHECKTHROW_EX_MACRO(   \
+      __VA_ARGS__,                 \
+      FB_SYSCHECKTHROW_EX_DIRECT,  \
+      UNUSED_PLACEHOLDER_3_ARGS,   \
+      FB_SYSCHECKTHROW_EX_LOGDATA, \
+      UNUSED_PLACEHOLDER_1_ARG)(__VA_ARGS__)
 
 #define FB_SYSCHECKRETURN(cmd, retval)                                         \
   do {                                                                         \

--- a/comms/ctran/utils/tests/ChecksUT.cc
+++ b/comms/ctran/utils/tests/ChecksUT.cc
@@ -223,7 +223,55 @@ TEST_F(CtranUtilsCheckTest, FB_SYSCHECKTHROW) {
   EXPECT_THROW(FB_SYSCHECKTHROW(1), std::runtime_error);
 }
 
-TEST_F(CtranUtilsCheckTest, FB_SYSCHECKTHROW_EX) {
+TEST_F(CtranUtilsCheckTest, FB_SYSCHECKTHROW_EX_DIRECT) {
+  const int rank = 7;
+  const uint64_t commHash = 0xDEADBEEF;
+  const std::string desc = "testDesc";
+
+  // Success case: no exception thrown
+  EXPECT_NO_THROW(FB_SYSCHECKTHROW_EX_DIRECT(0, rank, commHash, desc));
+
+  // Failure case: ctran::utils::Exception thrown with correct properties
+  bool caughtException = false;
+  try {
+    FB_SYSCHECKTHROW_EX_DIRECT(EINVAL, rank, commHash, desc);
+  } catch (const ctran::utils::Exception& e) {
+    EXPECT_EQ(e.rank(), rank);
+    EXPECT_EQ(e.commHash(), commHash);
+    EXPECT_THAT(std::string(e.what()), ::testing::HasSubstr("System error:"));
+    caughtException = true;
+  }
+  ASSERT_TRUE(caughtException) << "Expected ctran::utils::Exception";
+}
+
+TEST_F(CtranUtilsCheckTest, FB_SYSCHECKTHROW_EX_LOGDATA) {
+  const int rank = 7;
+  const uint64_t commHash = 0xDEADBEEF;
+  const std::string desc = "testDesc";
+
+  CommLogData logData = {
+      .rank = rank,
+      .commHash = commHash,
+      .commDesc = desc,
+  };
+
+  // Success case: no exception thrown
+  EXPECT_NO_THROW(FB_SYSCHECKTHROW_EX_LOGDATA(cudaSuccess, logData));
+
+  // Failure case: ctran::utils::Exception thrown with correct properties
+  bool caughtException = false;
+  try {
+    FB_SYSCHECKTHROW_EX_LOGDATA(cudaErrorInvalidValue, logData);
+  } catch (const ctran::utils::Exception& e) {
+    EXPECT_EQ(e.rank(), rank);
+    EXPECT_EQ(e.commHash(), commHash);
+    EXPECT_THAT(std::string(e.what()), ::testing::HasSubstr("System error:"));
+    caughtException = true;
+  }
+  ASSERT_TRUE(caughtException) << "Expected ctran::utils::Exception";
+}
+
+TEST_F(CtranUtilsCheckTest, FB_SYSCHECKTHROW_EX_4ARGS) {
   const int rank = 7;
   const uint64_t commHash = 0xDEADBEEF;
   const std::string desc = "testDesc";
@@ -235,6 +283,33 @@ TEST_F(CtranUtilsCheckTest, FB_SYSCHECKTHROW_EX) {
   bool caughtException = false;
   try {
     FB_SYSCHECKTHROW_EX(EINVAL, rank, commHash, desc);
+  } catch (const ctran::utils::Exception& e) {
+    EXPECT_EQ(e.rank(), rank);
+    EXPECT_EQ(e.commHash(), commHash);
+    EXPECT_THAT(std::string(e.what()), ::testing::HasSubstr("System error:"));
+    caughtException = true;
+  }
+  ASSERT_TRUE(caughtException) << "Expected ctran::utils::Exception";
+}
+
+TEST_F(CtranUtilsCheckTest, FB_SYSCHECKTHROW_EX_2ARGS) {
+  const int rank = 7;
+  const uint64_t commHash = 0xDEADBEEF;
+  const std::string desc = "testDesc";
+
+  CommLogData logData = {
+      .rank = rank,
+      .commHash = commHash,
+      .commDesc = desc,
+  };
+
+  // Success case: no exception thrown
+  EXPECT_NO_THROW(FB_SYSCHECKTHROW_EX(cudaSuccess, logData));
+
+  // Failure case: ctran::utils::Exception thrown with correct properties
+  bool caughtException = false;
+  try {
+    FB_SYSCHECKTHROW_EX(cudaErrorInvalidValue, logData);
   } catch (const ctran::utils::Exception& e) {
     EXPECT_EQ(e.rank(), rank);
     EXPECT_EQ(e.commHash(), commHash);


### PR DESCRIPTION
Summary:

**TL;DR:** Migrates `FB_SYSCHECKTHROW` calls in `CtranSocket.cc` to `FB_SYSCHECKTHROW_EX` and introduces a variadic macro overload to support passing `CommLogData` directly, enabling richer fault tolerance error diagnostics with rank, commHash, and commDesc context.

---

# Context & Motivation

When system errors occur in the socket backend, the current `FB_SYSCHECKTHROW` macro only captures the error message without communicator-specific context. For fault tolerance and debugging, it's essential to include rank, communicator hash, and description in error reports to quickly identify which rank and communicator experienced the failure.

Reviewed By: arttianezhu

Differential Revision: D90200751


