### PR TITLE
Introduce FB_CHECKTHROW_EX macro for enhanced error reporting

### DIFF
--- a/comms/ctran/algos/AllToAllvDedup/ExecCommon.h
+++ b/comms/ctran/algos/AllToAllvDedup/ExecCommon.h
@@ -687,12 +687,16 @@ waitSyncComplete(ExecCtx& ctx, ProgressState& state, const bool isExec) {
     if (nodeSyncs.size()) {
       const auto myLocalRank = statex->localRank();
       const auto railPeerRank = statex->localRankToRank(myLocalRank, node);
-      FB_CHECKTHROW(
+      FB_CHECKTHROW_EX(
           state.lastTransAck[node] == lastTransAckValue(railPeerRank),
-          "Unexpected lastTransAck value {} from rail peer rank {} on node {}",
-          state.lastTransAck[node],
-          railPeerRank,
-          node);
+          statex->rank(),
+          statex->commHash(),
+          statex->commDesc(),
+          fmt::format(
+              "Unexpected lastTransAck value {} from rail peer rank {} on node {}",
+              state.lastTransAck[node],
+              railPeerRank,
+              node));
     }
   }
 

--- a/comms/ctran/commstate/CommStateX.cc
+++ b/comms/ctran/commstate/CommStateX.cc
@@ -103,8 +103,12 @@ void CommStateX::initRankStatesTopology(
     ctran::bootstrap::IBootstrap* bootstrap) {
   auto myTopo = ctran::commstate::loadTopology(rank_, NCCL_TOPO_FILE_PATH);
   if (!myTopo) {
-    FB_CHECKTHROW(
-        false, "Failed to load topology from {}", NCCL_TOPO_FILE_PATH);
+    FB_CHECKTHROW_EX(
+        false,
+        rank_,
+        commHash_,
+        commDesc_,
+        fmt::format("Failed to load topology from {}", NCCL_TOPO_FILE_PATH));
   } else {
     CLOGF_SUBSYS(
         INFO,

--- a/comms/ctran/utils/Checks.h
+++ b/comms/ctran/utils/Checks.h
@@ -520,6 +520,50 @@
     }                                                                          \
   } while (0)
 
+#define FB_CHECKTHROW_EX_DIRECT(statement, rank, commHash, commDesc, msg) \
+  do {                                                                    \
+    if (!(statement)) {                                                   \
+      CLOGF(ERR, "Check failed: {} - {}", #statement, msg);               \
+      throw ctran::utils::Exception(                                      \
+          fmt::format("Check failed: {} - {}", #statement, msg),          \
+          commInternalError,                                              \
+          rank,                                                           \
+          commHash,                                                       \
+          commDesc);                                                      \
+    }                                                                     \
+  } while (0)
+
+#define FB_CHECKTHROW_EX_LOGDATA(statement, commLogData, msg)    \
+  do {                                                           \
+    if (!(statement)) {                                          \
+      CLOGF(ERR, "Check failed: {} - {}", #statement, msg);      \
+      throw ctran::utils::Exception(                             \
+          fmt::format("Check failed: {} - {}", #statement, msg), \
+          commInternalError,                                     \
+          (commLogData).rank,                                    \
+          (commLogData).commHash,                                \
+          (commLogData).commDesc);                               \
+    }                                                            \
+  } while (0)
+
+// Selector macro, used with FB_CHECKTHROW_EX to delegate
+// based on the number of arguments.
+// The dummy placeholders ensure correct selection for 3 and 5 arguments.
+#define GET_FB_CHECKTHROW_EX_MACRO(_1, _2, _3, _4, _5, NAME, ...) NAME
+
+// Delegates to either FB_CHECKTHROW_EX_DIRECT or
+// FB_CHECKTHROW_EX_LOGDATA based on the number of arguments.
+// - 5 args (statement, rank, commHash, commDesc, msg): uses
+// FB_CHECKTHROW_EX_DIRECT
+// - 3 args (statement, commLogData, msg): uses FB_CHECKTHROW_EX_LOGDATA
+#define FB_CHECKTHROW_EX(...)    \
+  GET_FB_CHECKTHROW_EX_MACRO(    \
+      __VA_ARGS__,               \
+      FB_CHECKTHROW_EX_DIRECT,   \
+      UNUSED_PLACEHOLDER_3_ARGS, \
+      FB_CHECKTHROW_EX_LOGDATA,  \
+      UNUSED_PLACEHOLDER_1_ARG)(__VA_ARGS__)
+
 #define FB_COMMWAIT(call, cond, abortFlagPtr)             \
   do {                                                    \
     uint32_t* tmpAbortFlag = (abortFlagPtr);              \

--- a/comms/ctran/utils/tests/ChecksUT.cc
+++ b/comms/ctran/utils/tests/ChecksUT.cc
@@ -682,3 +682,126 @@ TEST_F(CtranUtilsCheckTest, FB_ERRORTHROW_EX_NOCOMM) {
     ASSERT_TRUE(caughtException) << "Expected ctran::utils::Exception";
   }
 }
+
+TEST_F(CtranUtilsCheckTest, FB_CHECKTHROW_EX_DIRECT) {
+  const int rank = 3;
+  const uint64_t commHash = 0xCAFEBABE;
+  const std::string commDesc = "testDesc";
+
+  // Success case: no exception thrown
+  EXPECT_NO_THROW(FB_CHECKTHROW_EX_DIRECT(
+      true,
+      rank,
+      commHash,
+      commDesc,
+      "test FB_CHECKTHROW_EX_DIRECT -> NO throw"));
+
+  auto res = commSuccess;
+  try {
+    FB_CHECKTHROW_EX_DIRECT(
+        false,
+        rank,
+        commHash,
+        commDesc,
+        "test FB_CHECKTHROW_EX_DIRECT -> throw");
+  } catch (const ctran::utils::Exception& e) {
+    EXPECT_EQ(e.rank(), rank);
+    EXPECT_EQ(e.commHash(), commHash);
+    EXPECT_EQ(e.result(), commInternalError);
+    res = e.result();
+    EXPECT_THAT(
+        std::string(e.what()),
+        ::testing::HasSubstr(
+            "Check failed: false - test FB_CHECKTHROW_EX_DIRECT -> throw"));
+  }
+  EXPECT_NE(res, commSuccess) << "Expected ctran::utils::Exception";
+}
+
+TEST_F(CtranUtilsCheckTest, FB_CHECKTHROW_EX_LOGDATA) {
+  const int rank = 3;
+  const uint64_t commHash = 0xCAFEBABE;
+  const std::string commDesc = "testDesc";
+
+  CommLogData logData = {
+      .rank = rank,
+      .commHash = commHash,
+      .commDesc = commDesc,
+  };
+
+  // Success case: no exception thrown
+  EXPECT_NO_THROW(FB_CHECKTHROW_EX_LOGDATA(
+      true, logData, "test FB_CHECKTHROW_EX_LOGDATA -> NO throw"));
+
+  auto res = commSuccess;
+  try {
+    FB_CHECKTHROW_EX_LOGDATA(
+        false, logData, "test FB_CHECKTHROW_EX_LOGDATA -> throw");
+  } catch (const ctran::utils::Exception& e) {
+    EXPECT_EQ(e.rank(), rank);
+    EXPECT_EQ(e.commHash(), commHash);
+    EXPECT_EQ(e.result(), commInternalError);
+    res = e.result();
+    EXPECT_THAT(
+        std::string(e.what()),
+        ::testing::HasSubstr(
+            "Check failed: false - test FB_CHECKTHROW_EX_LOGDATA -> throw"));
+  }
+  EXPECT_NE(res, commSuccess) << "Expected ctran::utils::Exception";
+}
+
+TEST_F(CtranUtilsCheckTest, FB_CHECKTHROW_EX_5ARGS) {
+  const int rank = 3;
+  const uint64_t commHash = 0xCAFEBABE;
+  const std::string commDesc = "testDesc";
+
+  // Success case: no exception thrown
+  EXPECT_NO_THROW(FB_CHECKTHROW_EX(
+      true, rank, commHash, commDesc, "test FB_CHECKTHROW_EX -> NO throw"));
+
+  auto res = commSuccess;
+  try {
+    FB_CHECKTHROW_EX(
+        false, rank, commHash, commDesc, "test FB_CHECKTHROW_EX -> throw");
+  } catch (const ctran::utils::Exception& e) {
+    EXPECT_EQ(e.rank(), rank);
+    EXPECT_EQ(e.commHash(), commHash);
+    EXPECT_EQ(e.result(), commInternalError);
+    res = e.result();
+    EXPECT_THAT(
+        std::string(e.what()),
+        ::testing::HasSubstr(
+            "Check failed: false - test FB_CHECKTHROW_EX -> throw"));
+  }
+  EXPECT_NE(res, commSuccess) << "Expected ctran::utils::Exception";
+}
+
+TEST_F(CtranUtilsCheckTest, FB_CHECKTHROW_EX_3ARGS) {
+  const int rank = 3;
+  const uint64_t commHash = 0xCAFEBABE;
+  const std::string commDesc = "testDesc";
+
+  CommLogData logData = {
+      .rank = rank,
+      .commHash = commHash,
+      .commDesc = commDesc,
+  };
+
+  // Success case: no exception thrown
+  EXPECT_NO_THROW(
+      FB_CHECKTHROW_EX(true, logData, "test FB_CHECKTHROW_EX -> NO throw"));
+
+  auto res = commSuccess;
+  try {
+    FB_CHECKTHROW_EX_LOGDATA(false, logData, "test FB_CHECKTHROW_EX -> throw");
+  } catch (const ctran::utils::Exception& e) {
+    EXPECT_EQ(e.rank(), rank);
+    EXPECT_EQ(e.commHash(), commHash);
+    EXPECT_EQ(e.result(), commInternalError);
+    res = e.result();
+    EXPECT_THAT(
+        std::string(e.what()),
+        ::testing::HasSubstr(
+            "Check failed: false - test FB_CHECKTHROW_EX -> throw"));
+  }
+  EXPECT_NE(res, commSuccess) << "Expected ctran::utils::Exception";
+}


### PR DESCRIPTION
Summary: Adds a new `FB_CHECKTHROW_EX` macro that throws `ctran::utils::Exception` instead of `std::runtime_error`, enabling richer error context (rank, comm hash) for improved fault tolerance debugging.

Differential Revision: D90205549


