### PR TITLE
improve logging when dma-bug is not available

### DIFF
--- a/comms/ctran/ibverbx/IbvPd.cc
+++ b/comms/ctran/ibverbx/IbvPd.cc
@@ -55,6 +55,13 @@ int32_t IbvPd::getDeviceId() const {
   return deviceId_;
 }
 
+std::string IbvPd::getDeviceName() const {
+  if (pd_ && pd_->context && pd_->context->device) {
+    return std::string(pd_->context->device->name);
+  }
+  return "unknown";
+}
+
 folly::Expected<IbvMr, Error>
 IbvPd::regMr(void* addr, size_t length, ibv_access_flags access) const {
   ibv_mr* mr;

--- a/comms/ctran/ibverbx/IbvPd.h
+++ b/comms/ctran/ibverbx/IbvPd.h
@@ -29,6 +29,7 @@ class IbvPd {
   ibv_pd* pd() const;
   bool useDataDirect() const;
   int32_t getDeviceId() const;
+  std::string getDeviceName() const;
 
   folly::Expected<IbvMr, Error>
   regMr(void* addr, size_t length, ibv_access_flags access) const;

--- a/comms/ctran/utils/Checks.h
+++ b/comms/ctran/utils/Checks.h
@@ -327,18 +327,19 @@
 #define FOLLY_EXPECTED_CHECKTHROW_EX_NOCOMM(RES) \
   FOLLY_EXPECTED_CHECKTHROW_EX(RES, std::nullopt, std::nullopt, std::nullopt)
 
-#define FOLLY_EXPECTED_CHECKGOTO(RES, label) \
-  do {                                       \
-    if (RES.hasError()) {                    \
-      CLOGF(                                 \
-          ERR,                               \
-          "{}:{} -> {} ({})",                \
-          __FILE__,                          \
-          __LINE__,                          \
-          RES.error().errNum,                \
-          RES.error().errStr);               \
-      goto label;                            \
-    }                                        \
+#define FOLLY_EXPECTED_CHECKGOTO(RES, label, info) \
+  do {                                             \
+    if (RES.hasError()) {                          \
+      CLOGF(                                       \
+          ERR,                                     \
+          "{}:{} -> {} ({}). {}",                  \
+          __FILE__,                                \
+          __LINE__,                                \
+          RES.error().errNum,                      \
+          RES.error().errStr,                      \
+          info);                                   \
+      goto label;                                  \
+    }                                              \
   } while (0)
 
 // Note: this macro should NOT be used within Ctran code.


### PR DESCRIPTION
Summary:
While running ctran with direct buffer mode enabled, an error may occur if DMA-BUF is not available for the specific GPU and NIC combination. This is because two conditions must be met:

1. The mlx driver must support DMA-BUF.
2. The GPU and NIC must be in the same NUMA domain (i.e., connected to the same PCI switch) so that DMA-BUF can be enabled in the Linux kernel.

During ctran IB initialization, the first condition is checked and stored in a private variable. The second condition is only evaluated at buffer registration time. If the second condition is not satisfied, buffer registration fails and the following error is printed:

```text
E0108 10:38:38.120482 1479096 CtranIb.cc:796] CTRAN ERROR fbcode/comms/ctran/backends/ib/CtranIb.cc:796 -> 524 (Unknown error 524)
E0108 10:38:38.120491 1479096 CtranIb.cc:831] CTRAN ERROR CTRAN-IB: buffer registration failed: buf = 0x640000000, len = 4294967296, dmaBufSupport = true, NCCL_CTRAN_IB_DMABUF_ENABLE = true, useDmaBuf = true
```

This message is misleading because it reports `dmaBufSupport = true`, without clarifying that the NUMA/PCI topology requirement is not met.

I have updated the error message to clearly explain that buffer registration failed because the GPU and NIC are not in the same NUMA domain, and therefore DMA-BUF cannot be used for this configuration.

Reviewed By: mingrany

Differential Revision: D90338136


