### PR TITLE
Fix opCount logging

### DIFF
--- a/comms/ncclx/v2_28/src/group.cc
+++ b/comms/ncclx/v2_28/src/group.cc
@@ -326,6 +326,12 @@ static ncclResult_t doLaunches(struct ncclComm* head) {
             } else {
               NCCLCHECKGOTO(ncclLaunchKernel(comm, plan), result, failure);
             }
+            INFO(NCCL_COLL, "comm %s %p opCount %ld launched kernel for plan %p",  ctran::utils::parseCommDesc(comm->config.commDesc), comm, comm->opCount, plan);
+            // NOTE: bump up opCount right after launching kernel as this field is dedicated to track number of kernels
+            // including both p2p and collective kernels, no matter proxyOp existance.
+            // Known limitation: It won't be updated properly under cuda graph replay since it is not captured by the graph.
+            // But it is sufficient to unblock log based debugging in eager mode.
+            comm->opCount++;
           }
           // Barrier reduction input indicates if we require further rounds.
           if (useBarrier) ncclCommIntraBarrierIn(comm, comm->planner.unlaunchedPlansHead != nullptr ? 1 : 0);

--- a/comms/ncclx/v2_28/src/proxy.cc
+++ b/comms/ncclx/v2_28/src/proxy.cc
@@ -1007,7 +1007,6 @@ ncclResult_t ncclProxyStart(struct ncclComm* comm) {
     ops->nextOps = ops->nextOpsEnd = -1;
     ops->count = 0;
   }
-  comm->opCount++;
   TIME_STOP(1);
   return ncclSuccess;
 }


### PR DESCRIPTION
Summary: Port the opCount fix from v2_27 (D83294734) to v2_28. The opCount field was only being incremented in ncclProxyStart, which caused it to always be 0 in debug logs. Moving the increment to right after kernel launch ensures proper tracking of kernel launches for log-based debugging in eager mode.

Differential Revision: D90431656


