### PR TITLE
Improve self-transport performance with chunked parallelism

### DIFF
--- a/comms/pipes/benchmarks/SelfTransportBench.cc
+++ b/comms/pipes/benchmarks/SelfTransportBench.cc
@@ -1,0 +1,301 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <cuda_runtime.h>
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include <glog/logging.h>
+
+#include "comms/pipes/benchmarks/SelfTransportBench.cuh"
+#include "comms/testinfra/BenchUtils.h"
+#include "comms/testinfra/CudaBenchBase.h"
+#include "comms/utils/CudaRAII.h"
+
+using meta::comms::DeviceBuffer;
+
+namespace comms::pipes::benchmark {
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+// Number of warmup iterations to run before timing (primes GPU clocks, caches)
+constexpr int kWarmupIters = 5;
+
+//------------------------------------------------------------------------------
+// Benchmark Functions
+//------------------------------------------------------------------------------
+
+/**
+ * Benchmark P2pSelfTransportDevice::write() for local memory copies
+ */
+static void selfTransportWrite(
+    uint32_t iters,
+    size_t nBytes,
+    int nBlocks,
+    folly::UserCounters& counters) {
+  const int nRunsPerIter = 50;
+  const int nThreads = 256;
+
+  CHECK_EQ(cudaSetDevice(0), cudaSuccess);
+  CudaBenchBase bench;
+
+  DeviceBuffer srcBuffer(nBytes);
+  DeviceBuffer dstBuffer(nBytes);
+
+  char* srcPtr = static_cast<char*>(srcBuffer.get());
+  char* dstPtr = static_cast<char*>(dstBuffer.get());
+
+  dim3 grid{static_cast<unsigned int>(nBlocks), 1, 1};
+  dim3 blocks{static_cast<unsigned int>(nThreads), 1, 1};
+  void* kernArgs[4] = {
+      (void*)&dstPtr, (void*)&srcPtr, (void*)&nBytes, (void*)&nRunsPerIter};
+
+  // Warmup iterations (not timed) - primes GPU clocks and caches
+  for (int w = 0; w < kWarmupIters; ++w) {
+    CHECK_EQ(
+        cudaLaunchKernel(
+            (const void*)selfTransportWriteKernel,
+            grid,
+            blocks,
+            kernArgs,
+            0,
+            bench.stream),
+        cudaSuccess);
+  }
+  CHECK_EQ(cudaStreamSynchronize(bench.stream), cudaSuccess);
+
+  // Timed iterations
+  bench.startTiming();
+  for (uint32_t i = 0; i < iters; ++i) {
+    CHECK_EQ(
+        cudaLaunchKernel(
+            (const void*)selfTransportWriteKernel,
+            grid,
+            blocks,
+            kernArgs,
+            0,
+            bench.stream),
+        cudaSuccess);
+  }
+  bench.stopTiming();
+  float totalTimeMs = bench.measureTime();
+
+  float avgTimeUs = (totalTimeMs / iters / nRunsPerIter) * 1000.0f;
+  float busBwGBps = (nBytes / 1e9f) / (avgTimeUs / 1e6f);
+
+  counters["latency (us)"] =
+      folly::UserMetric(avgTimeUs, folly::UserMetric::Type::METRIC);
+  counters["bandwidth (GB/s)"] =
+      folly::UserMetric(busBwGBps, folly::UserMetric::Type::METRIC);
+}
+
+/**
+ * Benchmark cudaMemcpyAsync as a baseline for comparison
+ */
+static void cudaMemcpyBaseline(
+    uint32_t iters,
+    size_t nBytes,
+    folly::UserCounters& counters) {
+  const int nRunsPerIter = 50;
+
+  CHECK_EQ(cudaSetDevice(0), cudaSuccess);
+  CudaBenchBase bench;
+
+  DeviceBuffer srcBuffer(nBytes);
+  DeviceBuffer dstBuffer(nBytes);
+
+  char* srcPtr = static_cast<char*>(srcBuffer.get());
+  char* dstPtr = static_cast<char*>(dstBuffer.get());
+
+  // Warmup iterations (not timed) - primes GPU clocks and caches
+  for (int w = 0; w < kWarmupIters; ++w) {
+    for (int run = 0; run < nRunsPerIter; ++run) {
+      CHECK_EQ(
+          cudaMemcpyAsync(
+              dstPtr, srcPtr, nBytes, cudaMemcpyDeviceToDevice, bench.stream),
+          cudaSuccess);
+    }
+  }
+  CHECK_EQ(cudaStreamSynchronize(bench.stream), cudaSuccess);
+
+  // Timed iterations
+  bench.startTiming();
+  for (uint32_t i = 0; i < iters; ++i) {
+    for (int run = 0; run < nRunsPerIter; ++run) {
+      CHECK_EQ(
+          cudaMemcpyAsync(
+              dstPtr, srcPtr, nBytes, cudaMemcpyDeviceToDevice, bench.stream),
+          cudaSuccess);
+    }
+  }
+  bench.stopTiming();
+  float totalTimeMs = bench.measureTime();
+
+  float avgTimeUs = (totalTimeMs / iters / nRunsPerIter) * 1000.0f;
+  float busBwGBps = (nBytes / 1e9f) / (avgTimeUs / 1e6f);
+
+  counters["latency (us)"] =
+      folly::UserMetric(avgTimeUs, folly::UserMetric::Type::METRIC);
+  counters["bandwidth (GB/s)"] =
+      folly::UserMetric(busBwGBps, folly::UserMetric::Type::METRIC);
+}
+
+//------------------------------------------------------------------------------
+// Benchmark Registration
+//------------------------------------------------------------------------------
+
+// Self transport benchmarks - 8MB with different block counts
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportWrite,
+    size_8MB_2blocks,
+    8 * 1024 * 1024,
+    2);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportWrite,
+    size_8MB_4blocks,
+    8 * 1024 * 1024,
+    4);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportWrite,
+    size_8MB_8blocks,
+    8 * 1024 * 1024,
+    8);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportWrite,
+    size_8MB_16blocks,
+    8 * 1024 * 1024,
+    16);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportWrite,
+    size_8MB_32blocks,
+    8 * 1024 * 1024,
+    32);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportWrite,
+    size_8MB_64blocks,
+    8 * 1024 * 1024,
+    64);
+
+// Self transport benchmarks - 64MB with different block counts
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportWrite,
+    size_64MB_2blocks,
+    64 * 1024 * 1024,
+    2);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportWrite,
+    size_64MB_4blocks,
+    64 * 1024 * 1024,
+    4);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportWrite,
+    size_64MB_8blocks,
+    64 * 1024 * 1024,
+    8);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportWrite,
+    size_64MB_16blocks,
+    64 * 1024 * 1024,
+    16);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportWrite,
+    size_64MB_32blocks,
+    64 * 1024 * 1024,
+    32);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportWrite,
+    size_64MB_64blocks,
+    64 * 1024 * 1024,
+    64);
+
+// Self transport benchmarks - 256MB with different block counts
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportWrite,
+    size_256MB_2blocks,
+    256 * 1024 * 1024,
+    2);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportWrite,
+    size_256MB_4blocks,
+    256 * 1024 * 1024,
+    4);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportWrite,
+    size_256MB_8blocks,
+    256 * 1024 * 1024,
+    8);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportWrite,
+    size_256MB_16blocks,
+    256 * 1024 * 1024,
+    16);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportWrite,
+    size_256MB_32blocks,
+    256 * 1024 * 1024,
+    32);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportWrite,
+    size_256MB_64blocks,
+    256 * 1024 * 1024,
+    64);
+
+// Self transport benchmarks - 512MB with different block counts
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportWrite,
+    size_512MB_2blocks,
+    512 * 1024 * 1024,
+    2);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportWrite,
+    size_512MB_4blocks,
+    512 * 1024 * 1024,
+    4);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportWrite,
+    size_512MB_8blocks,
+    512 * 1024 * 1024,
+    8);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportWrite,
+    size_512MB_16blocks,
+    512 * 1024 * 1024,
+    16);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportWrite,
+    size_512MB_32blocks,
+    512 * 1024 * 1024,
+    32);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportWrite,
+    size_512MB_64blocks,
+    512 * 1024 * 1024,
+    64);
+
+BENCHMARK_DRAW_LINE();
+
+// Baseline cudaMemcpy benchmarks for comparison
+BENCHMARK_MULTI_PARAM_COUNTERS(cudaMemcpyBaseline, size_8MB, 8 * 1024 * 1024);
+BENCHMARK_MULTI_PARAM_COUNTERS(cudaMemcpyBaseline, size_64MB, 64 * 1024 * 1024);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    cudaMemcpyBaseline,
+    size_256MB,
+    256 * 1024 * 1024);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    cudaMemcpyBaseline,
+    size_512MB,
+    512 * 1024 * 1024);
+
+} // namespace comms::pipes::benchmark
+
+int main(int argc, char** argv) {
+  CHECK_EQ(cudaSetDevice(0), cudaSuccess);
+
+  folly::Init init(&argc, &argv);
+  folly::runBenchmarks();
+
+  CHECK_EQ(cudaDeviceReset(), cudaSuccess);
+
+  return 0;
+}

--- a/comms/pipes/benchmarks/SelfTransportBench.cu
+++ b/comms/pipes/benchmarks/SelfTransportBench.cu
@@ -1,0 +1,21 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/pipes/P2pSelfTransportDevice.cuh"
+#include "comms/pipes/benchmarks/SelfTransportBench.cuh"
+
+namespace comms::pipes::benchmark {
+
+__global__ void selfTransportWriteKernel(
+    char* dst,
+    const char* src,
+    std::size_t nBytes,
+    int nRuns) {
+  P2pSelfTransportDevice transport;
+  auto group = make_warp_group();
+
+  for (int run = 0; run < nRuns; ++run) {
+    transport.write(group, dst, src, nBytes);
+  }
+}
+
+} // namespace comms::pipes::benchmark

--- a/comms/pipes/benchmarks/SelfTransportBench.cuh
+++ b/comms/pipes/benchmarks/SelfTransportBench.cuh
@@ -1,0 +1,19 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <cstddef>
+
+namespace comms::pipes::benchmark {
+
+/**
+ * Kernel that uses P2pSelfTransportDevice to copy data
+ */
+__global__ void selfTransportWriteKernel(
+    char* dst,
+    const char* src,
+    std::size_t nBytes,
+    int nRuns);
+
+} // namespace comms::pipes::benchmark

--- a/comms/pipes/tests/P2pSelfTransportDeviceTest.cc
+++ b/comms/pipes/tests/P2pSelfTransportDeviceTest.cc
@@ -5,7 +5,9 @@
 #include <folly/init/Init.h>
 #include <folly/logging/xlog.h>
 
+#include <algorithm>
 #include <string>
+#include <vector>
 
 #include "comms/pipes/P2pSelfTransportDevice.cuh"
 #include "comms/pipes/tests/P2pSelfTransportDeviceTest.cuh"
@@ -99,7 +101,10 @@ INSTANTIATE_TEST_SUITE_P(
     TransferSizeVariations,
     TransferSizeTestFixture,
     ::testing::Values(
-        // Very small transfer (less than vector size)
+        // Very small transfers (test alignment edge cases)
+        TransferSizeParams{.nbytes = 16, .name = "Size_16B"},
+        TransferSizeParams{.nbytes = 32, .name = "Size_32B"},
+        // Small transfer (less than vector size)
         TransferSizeParams{.nbytes = 64, .name = "Size_64B"},
         // Medium transfer (1KB)
         TransferSizeParams{.nbytes = 1024, .name = "Size_1KB"},
@@ -120,6 +125,272 @@ INSTANTIATE_TEST_SUITE_P(
             .nbytes = 1 * 1024 * 1024 * 1024,
             .name = "Size_1GB"}),
     transferSizeParamName);
+
+// Chunk boundary edge case tests (dynamic chunk sizing)
+INSTANTIATE_TEST_SUITE_P(
+    ChunkBoundaryEdgeCases,
+    TransferSizeTestFixture,
+    ::testing::Values(
+        // Just below 64KB chunk boundary
+        TransferSizeParams{.nbytes = 64 * 1024 - 1, .name = "Size_64KB_Minus1"},
+        // Just above 64KB chunk boundary
+        TransferSizeParams{.nbytes = 64 * 1024 + 1, .name = "Size_64KB_Plus1"},
+        // Just below 128KB (2 chunks)
+        TransferSizeParams{
+            .nbytes = 128 * 1024 - 1,
+            .name = "Size_128KB_Minus1"},
+        // Just above 128KB (2 chunks)
+        TransferSizeParams{
+            .nbytes = 128 * 1024 + 1,
+            .name = "Size_128KB_Plus1"},
+        // Just below 256KB (4 chunks)
+        TransferSizeParams{
+            .nbytes = 256 * 1024 - 1,
+            .name = "Size_256KB_Minus1"},
+        // 3 full chunks
+        TransferSizeParams{.nbytes = 192 * 1024, .name = "Size_192KB"},
+        // Non-power-of-two near chunk boundary
+        TransferSizeParams{
+            .nbytes = 64 * 1024 - 17,
+            .name = "Size_64KB_Minus17"}),
+    transferSizeParamName);
+
+// Test zero bytes edge case
+TEST_F(SelfTransportDeviceTestFixture, WriteZeroBytes) {
+  const size_t nbytes = 1024;
+
+  // Allocate buffers
+  DeviceBuffer sendBuffer(nbytes);
+  DeviceBuffer recvBuffer(nbytes);
+
+  auto send_d = static_cast<int*>(sendBuffer.get());
+  auto recv_d = static_cast<int*>(recvBuffer.get());
+
+  // Initialize send buffer with a test value and recv buffer with zeros
+  test::fillBuffer(send_d, 42, nbytes / sizeof(int));
+  CUDACHECK_TEST(cudaMemset(recv_d, 0, nbytes));
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  // Call write with zero bytes - should be a no-op
+  const int numBlocks = 4;
+  const int blockSize = 256;
+  test::testSelfWrite(
+      reinterpret_cast<char*>(recv_d),
+      reinterpret_cast<const char*>(send_d),
+      0, // zero bytes
+      numBlocks,
+      blockSize);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  // Verify recv buffer is still all zeros (nothing was copied)
+  DeviceBuffer errorCountBuffer(sizeof(int));
+  auto d_errorCount = static_cast<int*>(errorCountBuffer.get());
+  CUDACHECK_TEST(cudaMemset(d_errorCount, 0, sizeof(int)));
+
+  test::verifyBuffer(recv_d, 0, nbytes / sizeof(int), d_errorCount);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  int h_errorCount = 0;
+  CUDACHECK_TEST(cudaMemcpy(
+      &h_errorCount, d_errorCount, sizeof(int), cudaMemcpyDeviceToHost));
+
+  ASSERT_EQ(h_errorCount, 0)
+      << "Zero bytes test: recv buffer should remain unchanged";
+}
+
+// Test same pointer edge case (dst == src)
+TEST_F(SelfTransportDeviceTestFixture, WriteSamePointer) {
+  const size_t nbytes = 1024;
+  const int testValue = 42;
+  const size_t numInts = nbytes / sizeof(int);
+
+  // Allocate a single buffer
+  DeviceBuffer buffer(nbytes);
+  auto buf_d = static_cast<int*>(buffer.get());
+
+  // Initialize buffer with test value
+  test::fillBuffer(buf_d, testValue, numInts);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  // Call write with same src and dst pointer - should be a no-op
+  const int numBlocks = 4;
+  const int blockSize = 256;
+  test::testSelfWrite(
+      reinterpret_cast<char*>(buf_d),
+      reinterpret_cast<const char*>(buf_d),
+      nbytes,
+      numBlocks,
+      blockSize);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  // Verify buffer still has original values
+  DeviceBuffer errorCountBuffer(sizeof(int));
+  auto d_errorCount = static_cast<int*>(errorCountBuffer.get());
+  CUDACHECK_TEST(cudaMemset(d_errorCount, 0, sizeof(int)));
+
+  test::verifyBuffer(buf_d, testValue, numInts, d_errorCount);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  int h_errorCount = 0;
+  CUDACHECK_TEST(cudaMemcpy(
+      &h_errorCount, d_errorCount, sizeof(int), cudaMemcpyDeviceToHost));
+
+  ASSERT_EQ(h_errorCount, 0)
+      << "Same pointer test: buffer should remain unchanged";
+}
+
+// Test very small sizes (smaller than vectorized size of 16 bytes)
+// Uses byte-level verification since int-based helpers require >= 4 bytes
+class SmallSizeTestFixture : public SelfTransportDeviceTestFixture,
+                             public ::testing::WithParamInterface<size_t> {};
+
+TEST_P(SmallSizeTestFixture, WriteSmallSize) {
+  const size_t nbytes = GetParam();
+  const char testValue = 0x42;
+
+  // Allocate buffers (minimum allocation to ensure valid pointers)
+  const size_t allocSize = std::max(nbytes, size_t(16));
+  DeviceBuffer sendBuffer(allocSize);
+  DeviceBuffer recvBuffer(allocSize);
+
+  auto send_d = static_cast<char*>(sendBuffer.get());
+  auto recv_d = static_cast<char*>(recvBuffer.get());
+
+  // Initialize send buffer with test value using cudaMemset
+  CUDACHECK_TEST(cudaMemset(send_d, testValue, nbytes));
+  CUDACHECK_TEST(cudaMemset(recv_d, 0, nbytes));
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  // Launch write kernel
+  const int numBlocks = 4;
+  const int blockSize = 256;
+  test::testSelfWrite(recv_d, send_d, nbytes, numBlocks, blockSize);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  // Copy back to host and verify
+  std::vector<char> h_recv(nbytes);
+  CUDACHECK_TEST(
+      cudaMemcpy(h_recv.data(), recv_d, nbytes, cudaMemcpyDeviceToHost));
+
+  int errorCount = 0;
+  for (size_t i = 0; i < nbytes; ++i) {
+    if (h_recv[i] != testValue) {
+      ++errorCount;
+    }
+  }
+
+  ASSERT_EQ(errorCount, 0) << "Small size test (" << nbytes << " bytes) found "
+                           << errorCount << " errors";
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SmallSizeVariations,
+    SmallSizeTestFixture,
+    ::testing::Values(
+        1, // Single byte
+        2, // Two bytes
+        3, // Three bytes (odd)
+        4, // One int
+        7, // Prime number
+        8, // Two ints
+        15, // Just below vectorized size
+        17 // Just above vectorized size
+        ));
+
+// Parameters for thread configuration tests
+struct ThreadConfigParams {
+  int numBlocks;
+  int blockSize;
+  std::string name;
+};
+
+class ThreadConfigTestFixture
+    : public SelfTransportDeviceTestFixture,
+      public ::testing::WithParamInterface<ThreadConfigParams> {};
+
+TEST_P(ThreadConfigTestFixture, WriteWithDifferentConfig) {
+  const auto& params = GetParam();
+  const size_t nbytes = 256 * 1024; // 256KB - ensures multiple chunks
+  const size_t numInts = nbytes / sizeof(int);
+  const int testValue = 42;
+
+  // Allocate send and receive buffers
+  DeviceBuffer sendBuffer(nbytes);
+  DeviceBuffer recvBuffer(nbytes);
+
+  auto send_d = static_cast<int*>(sendBuffer.get());
+  auto recv_d = static_cast<int*>(recvBuffer.get());
+
+  // Initialize send buffer with test value
+  test::fillBuffer(send_d, testValue, numInts);
+  CUDACHECK_TEST(cudaMemset(recv_d, 0, nbytes));
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  // Launch write kernel with parameterized configuration
+  test::testSelfWrite(
+      reinterpret_cast<char*>(recv_d),
+      reinterpret_cast<const char*>(send_d),
+      nbytes,
+      params.numBlocks,
+      params.blockSize);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  // Verify received data
+  DeviceBuffer errorCountBuffer(sizeof(int));
+  auto d_errorCount = static_cast<int*>(errorCountBuffer.get());
+  CUDACHECK_TEST(cudaMemset(d_errorCount, 0, sizeof(int)));
+
+  test::verifyBuffer(recv_d, testValue, numInts, d_errorCount);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  int h_errorCount = 0;
+  CUDACHECK_TEST(cudaMemcpy(
+      &h_errorCount, d_errorCount, sizeof(int), cudaMemcpyDeviceToHost));
+
+  ASSERT_EQ(h_errorCount, 0) << "Thread config test '" << params.name
+                             << "' found " << h_errorCount << " errors";
+}
+
+std::string threadConfigParamName(
+    const ::testing::TestParamInfo<ThreadConfigParams>& info) {
+  return info.param.name;
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ThreadConfigVariations,
+    ThreadConfigTestFixture,
+    ::testing::Values(
+        // Single block, single warp
+        ThreadConfigParams{.numBlocks = 1, .blockSize = 32, .name = "1B_32T"},
+        // Single block, multiple warps
+        ThreadConfigParams{.numBlocks = 1, .blockSize = 128, .name = "1B_128T"},
+        ThreadConfigParams{.numBlocks = 1, .blockSize = 256, .name = "1B_256T"},
+        // Multiple blocks, small block size
+        ThreadConfigParams{.numBlocks = 2, .blockSize = 64, .name = "2B_64T"},
+        ThreadConfigParams{.numBlocks = 8, .blockSize = 32, .name = "8B_32T"},
+        // Larger configurations
+        ThreadConfigParams{.numBlocks = 8, .blockSize = 256, .name = "8B_256T"},
+        ThreadConfigParams{
+            .numBlocks = 16,
+            .blockSize = 256,
+            .name = "16B_256T"},
+        // Large block size (512 threads)
+        ThreadConfigParams{.numBlocks = 4, .blockSize = 512, .name = "4B_512T"},
+        // High block counts to stress dynamic chunk sizing
+        ThreadConfigParams{
+            .numBlocks = 32,
+            .blockSize = 256,
+            .name = "32B_256T"},
+        ThreadConfigParams{
+            .numBlocks = 64,
+            .blockSize = 256,
+            .name = "64B_256T"},
+        // Many blocks with small block size (tests many small chunks)
+        ThreadConfigParams{
+            .numBlocks = 64,
+            .blockSize = 32,
+            .name = "64B_32T"}),
+    threadConfigParamName);
 
 } // namespace comms::pipes
 


### PR DESCRIPTION
Summary:
The previous implementation used a single copy_chunk_vectorized call for the
entire buffer, which meant every group did the same work. This change
distributes work across ALL thread groups using chunks and
for_each_item_contiguous, matching P2pNvlTransport's approach for better parallelism.

Differential Revision: D90422146
