### PR TITLE
Specify backend version

### DIFF
--- a/comms/ncclx/v2_27/meta/tests/Version.cu
+++ b/comms/ncclx/v2_27/meta/tests/Version.cu
@@ -8,6 +8,11 @@ TEST(Version, Code) {
   int ncclVersion{0};
   EXPECT_EQ(ncclGetVersion(&ncclVersion), ncclSuccess);
   EXPECT_EQ(NCCL_VERSION_CODE, ncclVersion);
+  std::cout << "NCCL version: " << NCCL_VERSION_CODE << std::endl;
+  std::cout << "ncclGetVersion: " << ncclVersion << std::endl;
+
+  // Check same as expected version from BUCK
+  EXPECT_EQ(TEST_NCCL_VERSION, ncclVersion);
 }
 
 TEST(Version, NoVer) {


### PR DESCRIPTION
Summary:
Specifies backend version for ncclx/v2_27 tests to ensure they link and run against ncclx 2.27 instead of stable (2.28).

## Changes:
- Adds `BACKEND = ["ncclx", "2.27"]` constant to BUCK files under ncclx/v2_27
- Sets `backend = BACKEND` parameter for all nccl_cpp_unittest and nccl_cpp_distributed_unittest targets
- Removes empty deps arrays where not needed
- Adds a Version.cu test to validate the correct NCCL version at runtime

Differential Revision: D90475753


