### PR TITLE
Introduce FB_CUDACHECKTHROW_EX macro for enhanced error reporting

### DIFF
--- a/comms/ctran/algos/CtranAlgo.cc
+++ b/comms/ctran/algos/CtranAlgo.cc
@@ -32,33 +32,41 @@ CtranAlgo::CtranAlgo(CtranComm* comm, ICtran* ctran)
     FB_COMMCHECKIGNORE(initTmpBufs());
   }
 
-  FB_CUDACHECKTHROW(cudaHostAlloc(
-      &this->sendCountsTmpbufCPU,
-      sizeof(size_t) * all2allvDynamicMaxSendcounts,
-      cudaHostAllocDefault));
+  FB_CUDACHECKTHROW_EX(
+      cudaHostAlloc(
+          &this->sendCountsTmpbufCPU,
+          sizeof(size_t) * all2allvDynamicMaxSendcounts,
+          cudaHostAllocDefault),
+      comm->logMetaData_);
   tmpbufSegments[TmpbufType::SENDCOUNTS_TMPBUF_CPU] = this->sendCountsTmpbufCPU;
   tmpbufSegmentOffsets[TmpbufType::SENDCOUNTS_TMPBUF_CPU] = 0;
 
-  FB_CUDACHECKTHROW(cudaHostAlloc(
-      &this->sendIndicesTmpbufCPU,
-      sizeof(size_t) * all2allvDynamicMaxSendcounts,
-      cudaHostAllocDefault));
+  FB_CUDACHECKTHROW_EX(
+      cudaHostAlloc(
+          &this->sendIndicesTmpbufCPU,
+          sizeof(size_t) * all2allvDynamicMaxSendcounts,
+          cudaHostAllocDefault),
+      comm->logMetaData_);
   tmpbufSegments[TmpbufType::SENDINDICES_TMPBUF_CPU] =
       this->sendIndicesTmpbufCPU;
   tmpbufSegmentOffsets[TmpbufType::SENDINDICES_TMPBUF_CPU] = 0;
 
-  FB_CUDACHECKTHROW(cudaHostAlloc(
-      &this->sendIndicesBlockLengthsTmpbufCPU,
-      sizeof(size_t) * comm_->statex_->nRanks(),
-      cudaHostAllocDefault));
+  FB_CUDACHECKTHROW_EX(
+      cudaHostAlloc(
+          &this->sendIndicesBlockLengthsTmpbufCPU,
+          sizeof(size_t) * comm_->statex_->nRanks(),
+          cudaHostAllocDefault),
+      comm->logMetaData_);
   tmpbufSegments[TmpbufType::SENDINDICES_BLOCKLEN_TMPBUF_CPU] =
       this->sendIndicesBlockLengthsTmpbufCPU;
   tmpbufSegmentOffsets[TmpbufType::SENDINDICES_BLOCKLEN_TMPBUF_CPU] = 0;
 
-  FB_CUDACHECKTHROW(cudaHostAlloc(
-      &this->sendbuffsPtrTmpbufCPU,
-      sizeof(void*) * all2allvDynamicMaxSendcounts,
-      cudaHostAllocDefault));
+  FB_CUDACHECKTHROW_EX(
+      cudaHostAlloc(
+          &this->sendbuffsPtrTmpbufCPU,
+          sizeof(void*) * all2allvDynamicMaxSendcounts,
+          cudaHostAllocDefault),
+      comm->logMetaData_);
   tmpbufSegments[TmpbufType::SENDBUFFS_PTR_TMPBUF_CPU] =
       this->sendbuffsPtrTmpbufCPU;
   tmpbufSegmentOffsets[TmpbufType::SENDBUFFS_PTR_TMPBUF_CPU] = 0;
@@ -386,11 +394,13 @@ CtranAlgo::SharedResource::SharedResource(CtranComm* comm) {
     for (int j = 0; j < CTRAN_ALGO_MAX_THREAD_BLOCKS; j++) {
       syncInitialVal.syncs[j].stepOnSameBlockIdx = CTRAN_ALGO_STEP_RESET;
     }
-    FB_CUDACHECKTHROW(cudaMemcpy(
-        statePtr_d,
-        &syncInitialVal,
-        sizeof(CtranAlgoDeviceSync),
-        cudaMemcpyHostToDevice));
+    FB_CUDACHECKTHROW_EX(
+        cudaMemcpy(
+            statePtr_d,
+            &syncInitialVal,
+            sizeof(CtranAlgoDeviceSync),
+            cudaMemcpyHostToDevice),
+        comm->logMetaData_);
 
     void* chunkStatePtr_d = reinterpret_cast<char*>(devShmPtr) +
         (nLocalRanks - 1) *
@@ -399,11 +409,13 @@ CtranAlgo::SharedResource::SharedResource(CtranComm* comm) {
         pos * getPerPeerChunkStatesSize();
     std::vector<ChunkState> initStates(
         CTRAN_P2P_NVL_DEVMEM_MAX_CHUNKS, ChunkState());
-    FB_CUDACHECKTHROW(cudaMemcpy(
-        chunkStatePtr_d,
-        initStates.data(),
-        getPerPeerChunkStatesSize(),
-        cudaMemcpyHostToDevice));
+    FB_CUDACHECKTHROW_EX(
+        cudaMemcpy(
+            chunkStatePtr_d,
+            initStates.data(),
+            getPerPeerChunkStatesSize(),
+            cudaMemcpyHostToDevice),
+        comm->logMetaData_);
   }
 
   // Exchange IPC handle with all local ranks

--- a/comms/ctran/backends/ib/CtranIb.cc
+++ b/comms/ctran/backends/ib/CtranIb.cc
@@ -1134,7 +1134,8 @@ commResult_t CtranIb::connectVcDirect(
 
 void CtranIb::bootstrapAccept(CtranIb* ib) {
   // Set cudaDev for logging
-  FB_CUDACHECKTHROW(cudaSetDevice(ib->cudaDev));
+  FB_CUDACHECKTHROW_EX(
+      cudaSetDevice(ib->cudaDev), ib->rank, ib->commHash, ib->commDesc);
   commNamedThreadStart(
       "CTranIbListen", ib->rank, ib->commHash, ib->commDesc.c_str(), __func__);
   while (1) {

--- a/comms/ctran/backends/nvl/CtranNvl.cc
+++ b/comms/ctran/backends/nvl/CtranNvl.cc
@@ -66,8 +66,10 @@ CtranNvl::CtranNvl(CtranComm* comm) {
         continue;
       }
       int canAccessPeer = 1;
-      FB_CUDACHECKTHROW(cudaDeviceCanAccessPeer(
-          &canAccessPeer, statex->cudaDev(), peerDevs[i]));
+      FB_CUDACHECKTHROW_EX(
+          cudaDeviceCanAccessPeer(
+              &canAccessPeer, statex->cudaDev(), peerDevs[i]),
+          comm->logMetaData_);
       if (canAccessPeer) {
         this->pimpl_->nvlRankSupportMode[statex->localRankToRank(i)]
             .nvlIntraHost = true;

--- a/comms/ctran/backends/socket/CtranSocket.cc
+++ b/comms/ctran/backends/socket/CtranSocket.cc
@@ -197,7 +197,7 @@ void CtranSocket::init(const SocketServerAddr& serverAddr) {
 
 void CtranSocket::bootstrapAccept() {
   // Set cudaDev for logging
-  FB_CUDACHECKTHROW(cudaSetDevice(cudaDev_));
+  FB_CUDACHECKTHROW_EX(cudaSetDevice(cudaDev_), comm->logMetaData_);
   commNamedThreadStart(
       "CTranSocketListen", rank_, commHash_, commDesc_, __func__);
   while (1) {

--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
@@ -82,7 +82,7 @@ void CtranTcpDm::bootstrapAddRecvPeer(
 
 void CtranTcpDm::bootstrapAccept() {
   // Set cudaDev for logging
-  FB_CUDACHECKTHROW(cudaSetDevice(cudaDev_));
+  FB_CUDACHECKTHROW_EX(cudaSetDevice(cudaDev_), rank_, commHash_, commDesc_);
   commNamedThreadStart(
       "CTranTcpListen", rank_, commHash_, commDesc_.c_str(), __func__);
 

--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -59,17 +59,19 @@ CtranGpe::Impl::Impl() {
   this->gpeKernelSyncPool =
       std::make_unique<GpeKernelSyncPool>(NCCL_CTRAN_NUM_GPE_KERNEL_SYNCS);
 
-  FB_CUDACHECKTHROW(
-      cudaEventCreateWithFlags(&execEvent_, cudaEventDisableTiming));
-  FB_CUDACHECKTHROW(
-      cudaStreamCreateWithFlags(&execOrderStream_, cudaStreamNonBlocking));
+  FB_CUDACHECKTHROW_EX(
+      cudaEventCreateWithFlags(&execEvent_, cudaEventDisableTiming),
+      comm->logMetaData_);
+  FB_CUDACHECKTHROW_EX(
+      cudaStreamCreateWithFlags(&execOrderStream_, cudaStreamNonBlocking),
+      comm->logMetaData_);
 
   return;
 }
 
 CtranGpe::Impl::~Impl() {
-  FB_CUDACHECKTHROW(cudaEventDestroy(execEvent_));
-  FB_CUDACHECKTHROW(cudaStreamDestroy(execOrderStream_));
+  FB_CUDACHECKTHROW_EX(cudaEventDestroy(execEvent_), comm->logMetaData_);
+  FB_CUDACHECKTHROW_EX(cudaStreamDestroy(execOrderStream_), comm->logMetaData_);
 }
 
 struct cmdCbPlan {
@@ -462,7 +464,7 @@ void CtranGpe::Impl::gpeThreadFn() {
       __func__);
 
   CTRAN_ASYNC_ERR_GUARD(comm->getAsyncError(), {
-    FB_CUDACHECKTHROW(cudaSetDevice(cudaDev));
+    FB_CUDACHECKTHROW_EX(cudaSetDevice(cudaDev), comm->logMetaData_);
 
     while (1) {
       auto cmd = cmdDequeue();

--- a/comms/ctran/utils/Checks.h
+++ b/comms/ctran/utils/Checks.h
@@ -59,6 +59,47 @@
     }                                                               \
   } while (false)
 
+#define FB_CUDACHECKTHROW_EX_DIRECT(cmd, rank, commHash, desc)     \
+  do {                                                             \
+    cudaError_t err = cmd;                                         \
+    if (err != cudaSuccess) {                                      \
+      CLOGF(                                                       \
+          ERR,                                                     \
+          "{}:{} Cuda failure {}",                                 \
+          __FILE__,                                                \
+          __LINE__,                                                \
+          cudaGetErrorString(err));                                \
+      (void)cudaGetLastError();                                    \
+      throw ctran::utils::Exception(                               \
+          std::string("Cuda failure: ") + cudaGetErrorString(err), \
+          commUnhandledCudaError,                                  \
+          rank,                                                    \
+          commHash,                                                \
+          desc);                                                   \
+    }                                                              \
+  } while (false)
+
+#define FB_CUDACHECKTHROW_EX_LOGDATA(cmd, logData) \
+  FB_CUDACHECKTHROW_EX_DIRECT(                     \
+      cmd, (logData).rank, (logData).commHash, (logData).commDesc)
+
+// Selector macro, used with FB_CUDACHECKTHROW_EX to delegate
+// based on the number of arguments.
+// The dummy placeholders ensure correct selection for 2, 3, and 4 arguments.
+#define GET_FB_CUDACHECKTHROW_EX_MACRO(_1, _2, _3, _4, NAME, ...) NAME
+
+// Delegates to either FB_CUDACHECKTHROW_EX_DIRECT or
+// FB_CUDACHECKTHROW_EX_LOGDATA based on the number of arguments.
+// - 4 args (cmd, rank, commHash, desc): uses FB_CUDACHECKTHROW_EX_DIRECT
+// - 2 args (cmd, logData): uses FB_CUDACHECKTHROW_EX_LOGDATA
+#define FB_CUDACHECKTHROW_EX(...)   \
+  GET_FB_CUDACHECKTHROW_EX_MACRO(   \
+      __VA_ARGS__,                  \
+      FB_CUDACHECKTHROW_EX_DIRECT,  \
+      UNUSED_PLACEHOLDER_3_ARGS,    \
+      FB_CUDACHECKTHROW_EX_LOGDATA, \
+      UNUSED_PLACEHOLDER_1_ARG)(__VA_ARGS__)
+
 #define FB_CUDACHECKGOTO(cmd, RES, label)                     \
   do {                                                        \
     cudaError_t err = cmd;                                    \

--- a/comms/ctran/utils/tests/ChecksUT.cc
+++ b/comms/ctran/utils/tests/ChecksUT.cc
@@ -496,3 +496,104 @@ TEST_F(CtranUtilsCheckTest, FB_COMMCHECKTHROW_EX_NOCOMM) {
         << "Expected ctran::utils::Exception for commResult=" << commResult;
   }
 }
+
+TEST_F(CtranUtilsCheckTest, FB_CUDACHECKTHROW_EX_DIRECT) {
+  const int rank = 7;
+  const uint64_t commHash = 0xDEADBEEF;
+  const std::string desc = "testDesc";
+
+  // Success case: no exception thrown
+  EXPECT_NO_THROW(
+      FB_CUDACHECKTHROW_EX_DIRECT(cudaSuccess, rank, commHash, desc));
+
+  // Failure case: ctran::utils::Exception thrown with correct properties
+  bool caughtException = false;
+  try {
+    FB_CUDACHECKTHROW_EX_DIRECT(cudaErrorInvalidValue, rank, commHash, desc);
+  } catch (const ctran::utils::Exception& e) {
+    EXPECT_EQ(e.rank(), rank);
+    EXPECT_EQ(e.commHash(), commHash);
+    EXPECT_EQ(e.result(), cudaErrorInvalidValue);
+    EXPECT_THAT(std::string(e.what()), ::testing::HasSubstr("Cuda failure:"));
+    caughtException = true;
+  }
+  ASSERT_TRUE(caughtException) << "Expected ctran::utils::Exception";
+}
+
+TEST_F(CtranUtilsCheckTest, FB_CUDACHECKTHROW_EX_LOGDATA) {
+  const int rank = 7;
+  const uint64_t commHash = 0xDEADBEEF;
+  const std::string desc = "testDesc";
+
+  CommLogData logData = {
+      .rank = rank,
+      .commHash = commHash,
+      .commDesc = desc,
+  };
+
+  // Success case: no exception thrown
+  EXPECT_NO_THROW(FB_CUDACHECKTHROW_EX_LOGDATA(cudaSuccess, logData));
+
+  // Failure case: ctran::utils::Exception thrown with correct properties
+  bool caughtException = false;
+  try {
+    FB_CUDACHECKTHROW_EX_LOGDATA(cudaErrorInvalidValue, logData);
+  } catch (const ctran::utils::Exception& e) {
+    EXPECT_EQ(e.rank(), rank);
+    EXPECT_EQ(e.commHash(), commHash);
+    EXPECT_EQ(e.result(), cudaErrorInvalidValue);
+    EXPECT_THAT(std::string(e.what()), ::testing::HasSubstr("Cuda failure:"));
+    caughtException = true;
+  }
+  ASSERT_TRUE(caughtException) << "Expected ctran::utils::Exception";
+}
+
+TEST_F(CtranUtilsCheckTest, FB_CUDACHECKTHROW_EX_3ARGS) {
+  const int rank = 7;
+  const uint64_t commHash = 0xDEADBEEF;
+  const std::string desc = "testDesc";
+
+  // Success case: no exception thrown
+  EXPECT_NO_THROW(FB_CUDACHECKTHROW_EX(cudaSuccess, rank, commHash, desc));
+
+  // Failure case: ctran::utils::Exception thrown with correct properties
+  bool caughtException = false;
+  try {
+    FB_CUDACHECKTHROW_EX(cudaErrorInvalidValue, rank, commHash, desc);
+  } catch (const ctran::utils::Exception& e) {
+    EXPECT_EQ(e.rank(), rank);
+    EXPECT_EQ(e.commHash(), commHash);
+    EXPECT_EQ(e.result(), cudaErrorInvalidValue);
+    EXPECT_THAT(std::string(e.what()), ::testing::HasSubstr("Cuda failure:"));
+    caughtException = true;
+  }
+  ASSERT_TRUE(caughtException) << "Expected ctran::utils::Exception";
+}
+
+TEST_F(CtranUtilsCheckTest, FB_CUDACHECKTHROW_EX_2ARGS) {
+  const int rank = 7;
+  const uint64_t commHash = 0xDEADBEEF;
+  const std::string desc = "testDesc";
+
+  CommLogData logData = {
+      .rank = rank,
+      .commHash = commHash,
+      .commDesc = desc,
+  };
+
+  // Success case: no exception thrown
+  EXPECT_NO_THROW(FB_CUDACHECKTHROW_EX(cudaSuccess, logData));
+
+  // Failure case: ctran::utils::Exception thrown with correct properties
+  bool caughtException = false;
+  try {
+    FB_CUDACHECKTHROW_EX(cudaErrorInvalidValue, logData);
+  } catch (const ctran::utils::Exception& e) {
+    EXPECT_EQ(e.rank(), rank);
+    EXPECT_EQ(e.commHash(), commHash);
+    EXPECT_EQ(e.result(), cudaErrorInvalidValue);
+    EXPECT_THAT(std::string(e.what()), ::testing::HasSubstr("Cuda failure:"));
+    caughtException = true;
+  }
+  ASSERT_TRUE(caughtException) << "Expected ctran::utils::Exception";
+}


### PR DESCRIPTION
Summary:
**TL;DR:** Adds a new `FB_CUDACHECKTHROW_EX` macro that throws `ctran::utils::Exception` instead of `std::runtime_error` on CUDA failures, enabling richer error context (rank, comm hash, description) for improved fault tolerance debugging.

---

# Detailed Overview

## Context & Motivation

As part of our fault tolerance efforts, we are migrating error handling in CTRAN from `std::runtime_error` to `ctran::utils::Exception`. This migration enables structured error reporting with additional metadata (rank, comm hash, operation description) that is critical for diagnosing failures in distributed communication workloads.

The existing `FB_CUDACHECKTHROW` macro throws a generic `std::runtime_error` when CUDA calls fail, which lacks the context needed for effective fault tolerance debugging. This diff introduces an extended version that preserves backward compatibility while enabling enhanced error reporting for callers that have access to communicator context.

Differential Revision: D90191648


