### PR TITLE
LocalVc: use CommLogData and migrate to FOLLY_EXPECTED_CHECKTHROW_EX

### DIFF
--- a/comms/ctran/backends/ib/CtranIb.cc
+++ b/comms/ctran/backends/ib/CtranIb.cc
@@ -463,8 +463,7 @@ void CtranIb::init(
 
     ibverbx::ibv_device_attr devAttr;
     auto maybeDeviceAttr = devices[device].ibvDevice->queryDevice();
-    FOLLY_EXPECTED_CHECKTHROW_EX(
-        maybeDeviceAttr, this->rank, this->commHash, this->commDesc);
+    FOLLY_EXPECTED_CHECKTHROW_EX(maybeDeviceAttr, ncclLogData);
     devAttr = std::move(*maybeDeviceAttr);
 
     // Found available port for the given device
@@ -539,15 +538,14 @@ void CtranIb::init(
     // access it yet.
     auto maybeCq =
         devices[device].ibvDevice->createCq(maxCqe, nullptr, nullptr, 0);
-    FOLLY_EXPECTED_CHECKTHROW_EX(
-        maybeCq, this->rank, this->commHash, this->commDesc);
+    FOLLY_EXPECTED_CHECKTHROW_EX(maybeCq, ncclLogData);
     cqs.emplace_back(std::move(*maybeCq));
     devices[device].ibvCq = &cqs[device];
     // FIXME: use initRemoteTransStates() to create cq
   }
 
   if (enableLocalFlush) {
-    localVc = std::make_unique<LocalVirtualConn>(devices, commHash, commDesc);
+    localVc = std::make_unique<LocalVirtualConn>(devices, ncclLogData);
   }
 
   // Record reference to CtranIbSingleton
@@ -971,7 +969,7 @@ commResult_t CtranIb::initRemoteTransStates(void) {
   // create local VC
   {
     std::unique_lock<std::mutex> lock(localVcMutex);
-    localVc = std::make_unique<LocalVirtualConn>(devices, commHash, commDesc);
+    localVc = std::make_unique<LocalVirtualConn>(devices, ncclLogData);
   }
 
   cqMutex.unlock();

--- a/comms/ctran/backends/ib/CtranIbLocalVc.h
+++ b/comms/ctran/backends/ib/CtranIbLocalVc.h
@@ -15,8 +15,7 @@ class LocalVirtualConn {
  public:
   LocalVirtualConn(
       std::vector<CtranIbDevice>& devices,
-      const uint64_t commHash,
-      const std::string& commDesc);
+      CommLogData commLogData);
   ~LocalVirtualConn() = default;
 
   commResult_t
@@ -34,8 +33,9 @@ class LocalVirtualConn {
   std::vector<ibverbx::ibv_sge> sgs_;
 
   std::vector<CtranIbDevice> devices_;
-  const uint64_t commHash_;
-  const std::string commDesc_;
+
+  // Diagnostic context for error reporting (communicator-level metadata)
+  CommLogData commLogData_;
 
   // Track completion of outstanding flushes
   std::deque<CtranIbRequest*> outstandingReqs_;

--- a/comms/ctran/utils/tests/ChecksUT.cc
+++ b/comms/ctran/utils/tests/ChecksUT.cc
@@ -282,10 +282,15 @@ TEST_F(CtranUtilsCheckTest, FOLLY_EXPECTED_CHECKTHROW_EX) {
   const uint64_t commHash = 0xCAFEBABE;
   const std::string desc = "testDesc";
 
+  CommLogData logData = {
+      .rank = rank,
+      .commHash = commHash,
+      .commDesc = desc,
+  };
+
   // Success case: no exception thrown
   auto successResult = folly::Expected<int, MockError>(42);
-  EXPECT_NO_THROW(
-      FOLLY_EXPECTED_CHECKTHROW_EX(successResult, rank, commHash, desc));
+  EXPECT_NO_THROW(FOLLY_EXPECTED_CHECKTHROW_EX(successResult, logData));
 
   // Failure case: ctran::utils::Exception thrown with correct properties
   auto errorResult = folly::Expected<int, MockError>(folly::makeUnexpected(
@@ -296,10 +301,11 @@ TEST_F(CtranUtilsCheckTest, FOLLY_EXPECTED_CHECKTHROW_EX) {
 
   bool caughtException = false;
   try {
-    FOLLY_EXPECTED_CHECKTHROW_EX(errorResult, rank, commHash, desc);
+    FOLLY_EXPECTED_CHECKTHROW_EX(errorResult, logData);
   } catch (const ctran::utils::Exception& e) {
     EXPECT_EQ(e.rank(), rank);
     EXPECT_EQ(e.commHash(), commHash);
+    EXPECT_EQ(e.result(), commInternalError);
     EXPECT_THAT(
         std::string(e.what()), ::testing::HasSubstr("COMM internal failure:"));
     EXPECT_THAT(


### PR DESCRIPTION
Summary:
**TL;DR:** Refactors `LocalVirtualConn` to use `CommLogData` instead of separate rank/commHash/commDesc parameters, and completes the migration to `FOLLY_EXPECTED_CHECKTHROW_EX` for improved fault tolerance diagnostics. Also removes the obsolete `FOLLY_EXPECTED_CHECKTHROW` macro.

---

# Detailed Overview

## Context & Motivation

As part of the CTRAN error handling migration), we are replacing usages of `FOLLY_EXPECTED_CHECKTHROW` with `FOLLY_EXPECTED_CHECKTHROW_EX` across the codebase. The `_EX` variant throws `ctran::utils::Exception` instead of `std::runtime_error`, providing richer error context `(rank, commHash, commDesc)` for fault tolerance and debugging.

## Technical Details

This diff makes three key changes:

**1. Refactors `LocalVirtualConn` to use `CommLogData`**:
   - Replaces three separate constructor parameters (`rank`, `commHash`, `commDesc`) with a single `CommLogData` parameter
   - Stores `commLogData_` as a private member instead of individual fields
   - Updates both call sites in `CtranIb.cc` to pass `ncclLogData` when instantiating `LocalVirtualConn`

**2. Migrates all error handling in `LocalVirtualConn` to `FOLLY_EXPECTED_CHECKTHROW_EX`**:
   - Converts all 7 usages of `FOLLY_EXPECTED_CHECKTHROW` to `FOLLY_EXPECTED_CHECKTHROW_EX`
   - All exceptions now include communicator-level diagnostic context

**3. Simplifies the check macros in `Checks.h`**:
   - Removes the obsolete `FOLLY_EXPECTED_CHECKTHROW` macro (no longer needed)
   - Updates `FOLLY_EXPECTED_CHECKTHROW_EX` to accept a single `CommLogData` struct instead of three separate parameters
   - Expands `FOLLY_EXPECTED_CHECKTHROW_EX_NOCOMM` to be a standalone macro (previously delegated to `_EX` with nullopt values)

Differential Revision: D88875662


