### PR TITLE
Introducing ctran::utils::AbortException

### DIFF
--- a/comms/ctran/utils/AbortException.cc
+++ b/comms/ctran/utils/AbortException.cc
@@ -1,0 +1,47 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/ctran/utils/AbortException.h"
+
+#include <vector>
+
+#include <fmt/core.h>
+#include <fmt/format.h>
+
+#include "comms/utils/commSpecs.h"
+
+namespace ctran::utils {
+
+AbortException::AbortException(
+    const std::string context,
+    bool retriable,
+    std::optional<int> rank,
+    std::optional<uint64_t> commHash,
+    std::optional<std::string> desc)
+    : Exception(context, commRemoteError, rank, commHash, desc),
+      retriable_(retriable) {
+  // Override msg to include retriable status
+  std::vector<std::string> vec;
+  if (rank) {
+    vec.emplace_back(fmt::format("rank: {}", *rank));
+  }
+  if (commHash) {
+    vec.emplace_back(fmt::format("commHash: {:x}", *commHash));
+  }
+  if (desc) {
+    vec.emplace_back(fmt::format("desc: {}", *desc));
+  }
+  vec.emplace_back(fmt::format("retriable: {}", retriable_));
+
+  msg = fmt::format(
+      "AbortException: {}, {}, result: {} ({})",
+      context,
+      fmt::join(vec, ", "),
+      meta::comms::commCodeToName(commRemoteError),
+      commRemoteError);
+}
+
+bool AbortException::isRetriable() const {
+  return retriable_;
+}
+
+} // namespace ctran::utils

--- a/comms/ctran/utils/AbortException.h
+++ b/comms/ctran/utils/AbortException.h
@@ -1,0 +1,27 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include "comms/ctran/utils/Exception.h"
+
+namespace ctran::utils {
+
+class AbortException : public Exception {
+ public:
+  explicit AbortException(
+      const std::string context,
+      bool retriable = false,
+      std::optional<int> rank = std::nullopt,
+      std::optional<uint64_t> commHash = std::nullopt,
+      std::optional<std::string> desc = std::nullopt);
+
+  bool isRetriable() const;
+
+ private:
+  bool retriable_;
+};
+
+} // namespace ctran::utils

--- a/comms/ctran/utils/Exception.h
+++ b/comms/ctran/utils/Exception.h
@@ -34,7 +34,7 @@ class Exception : public std::exception {
     if (desc) {
       vec.emplace_back(fmt::format("desc: {}", *desc));
     }
-    msg_ = fmt::format(
+    msg = fmt::format(
         "Exception: {}, {}, result: {} ({})",
         context,
         fmt::join(vec, ", "),
@@ -43,7 +43,7 @@ class Exception : public std::exception {
   };
 
   const char* what() const noexcept override {
-    return msg_.c_str();
+    return msg.c_str();
   }
 
   int rank() const {
@@ -62,8 +62,10 @@ class Exception : public std::exception {
     return result_;
   }
 
+ protected:
+  std::string msg;
+
  private:
-  std::string msg_;
   commResult_t result_{commSuccess};
   std::optional<int> rank_;
   std::optional<uint64_t> commHash_;

--- a/comms/ctran/utils/tests/AbortExceptionUT.cc
+++ b/comms/ctran/utils/tests/AbortExceptionUT.cc
@@ -1,0 +1,81 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "comms/ctran/utils/AbortException.h"
+#include "comms/ctran/utils/Exception.h"
+
+namespace ctran::utils {
+
+// Test default construction with context only.
+// Verifies default retriable=false, result code, message content, and default
+// optional parameter accessors.
+TEST(AbortExceptionTest, BasicThrow) {
+  try {
+    throw AbortException("test abort context");
+  } catch (const AbortException& e) {
+    EXPECT_FALSE(e.isRetriable());
+    EXPECT_EQ(e.result(), commRemoteError);
+    EXPECT_THAT(e.what(), ::testing::HasSubstr("AbortException"));
+    EXPECT_THAT(e.what(), ::testing::HasSubstr("test abort context"));
+    EXPECT_THAT(e.what(), ::testing::HasSubstr("retriable: false"));
+    EXPECT_EQ(e.rank(), -1);
+    EXPECT_EQ(e.commHash(), static_cast<uint64_t>(-1));
+    EXPECT_EQ(e.desc(), "undefined");
+  }
+}
+
+// Test construction with retriable=true.
+TEST(AbortExceptionTest, RetriableTrue) {
+  try {
+    throw AbortException("retriable context", true);
+  } catch (const AbortException& e) {
+    EXPECT_TRUE(e.isRetriable());
+    EXPECT_THAT(e.what(), ::testing::HasSubstr("retriable: true"));
+  }
+}
+
+// Test with all parameters provided.
+TEST(AbortExceptionTest, ThrowWithFullInfo) {
+  const int rank = 5;
+  const uint64_t commHash = 0xDEADBEEF;
+  const std::string desc = "custom description";
+
+  try {
+    throw AbortException("full info context", true, rank, commHash, desc);
+  } catch (const AbortException& e) {
+    EXPECT_TRUE(e.isRetriable());
+    EXPECT_EQ(e.rank(), rank);
+    EXPECT_EQ(e.commHash(), commHash);
+    EXPECT_EQ(e.desc(), desc);
+    EXPECT_THAT(e.what(), ::testing::HasSubstr("full info context"));
+    EXPECT_THAT(e.what(), ::testing::HasSubstr("rank: 5"));
+    EXPECT_THAT(e.what(), ::testing::HasSubstr("commHash: deadbeef"));
+    EXPECT_THAT(e.what(), ::testing::HasSubstr("desc: custom description"));
+    EXPECT_THAT(e.what(), ::testing::HasSubstr("retriable: true"));
+  }
+}
+
+// Test that result code is always commRemoteError regardless of other params.
+TEST(AbortExceptionTest, ResultCodeIsCommRemoteError) {
+  try {
+    throw AbortException("result code test", true, 3, 0xABC);
+  } catch (const AbortException& e) {
+    EXPECT_EQ(e.result(), commRemoteError);
+  }
+}
+
+// Test that AbortException can be caught as its base class Exception&,
+// confirming the polymorphic inheritance chain works.
+TEST(AbortExceptionTest, CatchAsBaseException) {
+  try {
+    throw AbortException("polymorphic test", true);
+  } catch (const ctran::utils::Exception& e) {
+    EXPECT_THAT(e.what(), ::testing::HasSubstr("AbortException"));
+    EXPECT_THAT(e.what(), ::testing::HasSubstr("polymorphic test"));
+    EXPECT_EQ(e.result(), commRemoteError);
+  }
+}
+
+} // namespace ctran::utils


### PR DESCRIPTION
Summary:
This diff introduces a new `ctran::utills::AbortException` to provide a standardized exception for aborts. It is fully backwards compatible:
- Existing catches for `Exception` still work (catches base class)
- New code can catch `AbortException` specifically

The motivation behind `AbortException` is based in the fact that the current `ctran::utils::Exception` class doesn't distinguish:
- **User-initiated abort** (e.g., `comm->setAbort()` called explicitly)
- **Remote peer abort** (detected via abort flag propagation)
- **Timeout abort** (abort triggered by timeout)
- **System abort** (abort due to resource exhaustion)

Right now, these are all reported as:
```cpp
throw ctran::utils::Exception("comm aborted", commRemoteError);
```

This is not ideal. The `AbortException` class enables:
- **Clear semantic distinction** between abort and non-abort exceptions
- **Type-based catch handling**: `catch (AbortException)` vs. `catch (Exception)`
- **Easier migration**: introduce gradually without touching existing Exception uses
- **Better logging/monitoring**: can filter AbortException separately

# Usage Examples
--------------------

## General Examples
```cpp
// User-initiated abort
if (comm->testAbort() && userInitiated) {
  throw ctran::utils::AbortException(
    "User requested abort",
    AbortCause::USER_INITIATED,
    comm->getRank(),
    comm->getCommHash());
}

// Timeout abort
if (abort_->TimedOut()) {
  throw ctran::utils::AbortException(
    "Operation timed out",
    AbortCause::TIMEOUT,
    comm->getRank(),
    comm->getCommHash(),
    fmt::format("timeout after {}ms", timeout.count()));
}

// Remote peer abort (detected via network)
if (peerDisconnected()) {
  throw ctran::utils::AbortException(
    "Remote peer disconnected",
    AbortCause::REMOTE_PEER,
    comm->getRank(),
    comm->getCommHash(),
    fmt::format("peer rank {} unreachable", peerRank));
}
```

## Catching and Handling

```cpp
try {
  ctranAllReduce(...);
} catch (const ctran::utils::AbortException& e) {
  // Fine-grained error handling based on abort cause
  switch (e.cause()) {
    case AbortCause::TIMEOUT:
      CLOGF(WARN, "Operation timed out, may retry: {}", e.what());
      // Possibly retry with longer timeout
      break;
    case AbortCause::USER_INITIATED:
      CLOGF(INFO, "User cancelled operation: {}", e.what());
      // Clean shutdown
      break;
    case AbortCause::REMOTE_PEER:
      CLOGF(ERR, "Remote peer failed: {}", e.what());
      ErrorStackTraceUtil::logErrorMessage(e.what());
      // Report to monitoring
      break;
    default:
      CLOGF(ERR, "Abort with unknown cause: {}", e.what());
      break;
  }
} catch (const ctran::utils::Exception& e) {
  // Handle non-abort exceptions
}
```

Differential Revision: D87794625


