### PR TITLE
Use global assignChunkValue|checkChunkValue utils in tests

### DIFF
--- a/comms/ncclx/v2_28/meta/collectives/tests/AllGatherPTest.cc
+++ b/comms/ncclx/v2_28/meta/collectives/tests/AllGatherPTest.cc
@@ -31,36 +31,6 @@ class AllGatherPTest : public ::testing::Test {
     CUDACHECK_TEST(cudaStreamDestroy(stream));
   }
 
-  template <typename T>
-  void assignChunkValue(T* buf, size_t count, T val) {
-    std::vector<T> expectedVals(count, val);
-    CUDACHECK_TEST(cudaMemcpy(
-        buf, expectedVals.data(), count * sizeof(T), cudaMemcpyDefault));
-  }
-
-  template <typename T>
-  int checkChunkValue(T* buf, size_t count, T val) {
-    std::vector<T> observedVals(count, -1);
-    CUDACHECK_TEST(cudaMemcpy(
-        observedVals.data(), buf, count * sizeof(T), cudaMemcpyDefault));
-    int errs = 0;
-    // Use manual print rather than EXPECT_THAT to print failing location
-    for (auto i = 0; i < count; ++i) {
-      if (observedVals[i] != val) {
-        if (errs < 10) {
-          printf(
-              "[%d] observedVals[%d] = %d, expectedVal = %d\n",
-              globalRank,
-              i,
-              observedVals[i],
-              val);
-        }
-        errs++;
-      }
-    }
-    return errs;
-  }
-
   void* prepareBuf(size_t bufSize, MemAllocType memType) {
     void* buf = nullptr;
     if (memType == kMemCudaMalloc) {

--- a/comms/ncclx/v2_28/meta/colltrace/tests/CollTraceDistTest.cc
+++ b/comms/ncclx/v2_28/meta/colltrace/tests/CollTraceDistTest.cc
@@ -1135,16 +1135,6 @@ TEST_F(CollTraceTest, TestIterLimit) {
   EXPECT_EQ(dump.pastColls.size(), 4);
 }
 
-template <typename T>
-void assignChunkValue(T* buf, size_t count, T seed, T inc) {
-  std::vector<T> expectedVals(count, 0);
-  for (size_t i = 0; i < count; ++i) {
-    expectedVals[i] = seed + i * inc;
-  }
-  CUDACHECK_TEST(cudaMemcpy(
-      buf, expectedVals.data(), count * sizeof(T), cudaMemcpyDefault));
-}
-
 TEST_F(CollTraceTest, winPutWait) {
   constexpr auto kNumElements = 1 << 20;
   constexpr auto kNumIters = 10;

--- a/comms/ncclx/v2_28/meta/colltrace/tests/NewCollTraceDistTestLocal.cc
+++ b/comms/ncclx/v2_28/meta/colltrace/tests/NewCollTraceDistTestLocal.cc
@@ -16,6 +16,7 @@
 #include "nccl.h" // @manual
 
 #include "comms/ctran/Ctran.h"
+#include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestXPlatUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
 #include "meta/commDump.h"
@@ -56,48 +57,6 @@ class CollTraceTestLocal : public NcclxBaseTest {
     if (recvBuf) {
       CUDACHECK_TEST(cudaFree(recvBuf));
     }
-  }
-
-  template <typename T>
-  void assignChunkValue(T* buf, size_t count, T seed, T inc) {
-    std::vector<T> expectedVals(count, 0);
-    for (size_t i = 0; i < count; ++i) {
-      expectedVals[i] = seed + i * inc;
-    }
-    CUDACHECK_TEST(cudaMemcpy(
-        buf, expectedVals.data(), count * sizeof(T), cudaMemcpyDefault));
-  }
-
-  template <typename T>
-  int checkChunkValue(
-      T* buf,
-      size_t count,
-      T seed,
-      T inc,
-      cudaStream_t checkStream) {
-    std::vector<T> observedVals(count, -1);
-    CUDACHECK_TEST(cudaMemcpyAsync(
-        observedVals.data(),
-        buf,
-        count * sizeof(T),
-        cudaMemcpyDefault,
-        checkStream));
-    CUDACHECK_TEST(cudaStreamSynchronize(checkStream));
-    int errs = 0;
-    // Use manual print rather than EXPECT_THAT to print failing location.
-    for (auto i = 0; i < count; ++i) {
-      T val = seed + inc * i;
-      if (observedVals[i] != val) {
-        if (errs < 10) {
-          // avoid using formatted string since we don't know the value type
-          std::cout << "[" << this->globalRank << "] observedVals[" << i
-                    << "] = " << observedVals[i] << ", expectedVal = " << val
-                    << std::endl;
-        }
-        errs++;
-      }
-    }
-    return errs;
   }
 
   // Use MPI to ensure that we don't see additional all reduce for that nccl
@@ -167,7 +126,6 @@ TEST_F(CollTraceTestLocal, winSignalAllToAll) {
   }
 
   CUDACHECK_TEST(cudaStreamSynchronize(wait_stream));
-
   int errs = 0;
   for (auto peerRank = 0; peerRank < numRanks; peerRank++) {
     if (peerRank == myrank) {
@@ -178,6 +136,7 @@ TEST_F(CollTraceTestLocal, winSignalAllToAll) {
         kNumElements,
         (uint64_t)peerRank,
         0UL,
+        this->globalRank,
         wait_stream);
   }
   EXPECT_EQ(errs, 0);
@@ -264,12 +223,12 @@ TEST_F(CollTraceTestLocal, winPutOnly) {
   CUDACHECK_TEST(cudaStreamSynchronize(put_stream));
   this->barrier();
 
-  // allreduce ensures all remote puts have finished
   int errs = checkChunkValue(
       (int*)winBase + kNumElements * prevPeer,
       kNumElements,
       prevPeer,
       1,
+      this->globalRank,
       main_stream);
 
   res = ctranWinFree(win);

--- a/comms/ncclx/v2_28/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
+++ b/comms/ncclx/v2_28/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
@@ -557,16 +557,6 @@ TEST_F(CollTraceTest, SimulateCtranPPSendRecv) {
   }
 }
 
-template <typename T>
-void assignChunkValue(T* buf, size_t count, T seed, T inc) {
-  std::vector<T> expectedVals(count, 0);
-  for (size_t i = 0; i < count; ++i) {
-    expectedVals[i] = seed + i * inc;
-  }
-  CUDACHECK_TEST(cudaMemcpy(
-      buf, expectedVals.data(), count * sizeof(T), cudaMemcpyDefault));
-}
-
 TEST_F(CollTraceTest, winPutWait) {
   constexpr auto kNumElements = 1 << 20;
   constexpr auto kNumIters = 10;

--- a/comms/ncclx/v2_28/meta/tests/AllGatherTest.cc
+++ b/comms/ncclx/v2_28/meta/tests/AllGatherTest.cc
@@ -37,36 +37,6 @@ class AllGatherTest : public NcclxBaseTest {
     NcclxBaseTest::TearDown();
   }
 
-  template <typename T>
-  void assignChunkValue(T* buf, size_t count, T val) {
-    std::vector<T> expectedVals(count, val);
-    CUDACHECK_TEST(cudaMemcpy(
-        buf, expectedVals.data(), count * sizeof(T), cudaMemcpyDefault));
-  }
-
-  template <typename T>
-  int checkChunkValue(T* buf, size_t count, T val) {
-    std::vector<T> observedVals(count, -1);
-    CUDACHECK_TEST(cudaMemcpy(
-        observedVals.data(), buf, count * sizeof(T), cudaMemcpyDefault));
-    int errs = 0;
-    // Use manual print rather than EXPECT_THAT to print failing location
-    for (auto i = 0; i < count; ++i) {
-      if (observedVals[i] != val) {
-        if (errs < 10) {
-          printf(
-              "[%d] observedVals[%d] = %d, expectedVal = %d\n",
-              globalRank,
-              i,
-              observedVals[i],
-              val);
-        }
-        errs++;
-      }
-    }
-    return errs;
-  }
-
   void runTest(
       enum NCCL_ALLGATHER_ALGO algo,
       bool inplace,

--- a/comms/ncclx/v2_28/meta/tests/AllReduceNumericOffsetTest.cc
+++ b/comms/ncclx/v2_28/meta/tests/AllReduceNumericOffsetTest.cc
@@ -50,12 +50,6 @@ class AllReduceNumericOffsetTest : public NcclxBaseTest {
     NcclxBaseTest::TearDown();
   }
 
-  void assignChunkValue(TYPE* buf, size_t count, TYPE val) {
-    std::vector<TYPE> expectedVals(count, val);
-    CUDACHECKIGNORE(cudaMemcpy(
-        buf, expectedVals.data(), count * sizeof(TYPE), cudaMemcpyDefault));
-  }
-
   void verifyMaxDiff(
       TYPE* tensorA,
       TYPE* tensorB,

--- a/comms/ncclx/v2_28/meta/tests/AllReduceTest.cc
+++ b/comms/ncclx/v2_28/meta/tests/AllReduceTest.cc
@@ -59,6 +59,7 @@ class AllReduceTest
     NcclxBaseTest::TearDown();
   }
 
+  // TODO: support bf16 in assignChunkValue in TestUtils.h and replace here.
   template <typename T>
   void assignChunkValue(T* buf, size_t count, T val) {
     std::vector<T> expectedVals(count, val);

--- a/comms/ncclx/v2_28/meta/tests/AllToAllTest.cc
+++ b/comms/ncclx/v2_28/meta/tests/AllToAllTest.cc
@@ -38,36 +38,6 @@ class AllToAllTest : public NcclxBaseTest {
     CUDACHECK_TEST(cudaStreamDestroy(this->stream));
   }
 
-  template <typename T>
-  void assignChunkValue(T* buf, size_t count, T val) {
-    std::vector<T> expectedVals(count, val);
-    CUDACHECKIGNORE(cudaMemcpy(
-        buf, expectedVals.data(), count * sizeof(T), cudaMemcpyDefault));
-  }
-
-  template <typename T>
-  int checkChunkValue(T* buf, size_t count, T val) {
-    std::vector<T> observedVals(count, -1);
-    CUDACHECK_TEST(cudaMemcpy(
-        observedVals.data(), buf, count * sizeof(T), cudaMemcpyDefault));
-    int errs = 0;
-    // Use manual print rather than EXPECT_THAT to print failing location
-    for (auto i = 0; i < count; ++i) {
-      if (observedVals[i] != val) {
-        if (errs < 10) {
-          printf(
-              "[%d] observedVals[%d] = %d, expectedVal = %d\n",
-              globalRank,
-              i,
-              observedVals[i],
-              val);
-        }
-        errs++;
-      }
-    }
-    return errs;
-  }
-
   void run(bool registFlag = false) {
 #ifdef NCCL_ALLTOALL_SUPPORTED
 

--- a/comms/ncclx/v2_28/meta/tests/AllToAllvTest.cc
+++ b/comms/ncclx/v2_28/meta/tests/AllToAllvTest.cc
@@ -43,36 +43,6 @@ class AllToAllvTest
     CUDACHECK_TEST(cudaStreamDestroy(this->stream));
   }
 
-  template <typename T>
-  void assignChunkValue(T* buf, size_t count, T val) {
-    if (count == 0) {
-      return;
-    }
-    std::vector<T> expectedVals(count, val);
-    CUDACHECKIGNORE(cudaMemcpy(
-        buf, expectedVals.data(), count * sizeof(T), cudaMemcpyDefault));
-  }
-
-  template <typename T>
-  int checkChunkValue(T* buf, size_t count, T val) {
-    std::vector<T> observedVals(count, -1);
-    CUDACHECK_TEST(cudaMemcpy(
-        observedVals.data(), buf, count * sizeof(T), cudaMemcpyDefault));
-    int errs = 0;
-    // Use manual print rather than EXPECT_THAT to print failing location
-    for (auto i = 0; i < count; ++i) {
-      if (observedVals[i] != val) {
-        if (errs < 10) {
-          std::cout << "[" << this->globalRank << "] observedVals[" << i
-                    << "] = " << observedVals[i] << ", expectedVal = " << val
-                    << "\n";
-        }
-        errs++;
-      }
-    }
-    return errs;
-  }
-
   void runReuseSharedBuffer(bool registFlag = false) {
     if (this->globalRank > 1) {
       return;

--- a/comms/ncclx/v2_28/meta/tests/AllreduceSparseBlockTest.cc
+++ b/comms/ncclx/v2_28/meta/tests/AllreduceSparseBlockTest.cc
@@ -33,13 +33,8 @@ class AllReduceSparseBlockTest : public ::testing::Test {
     CUDACHECK_TEST(cudaStreamDestroy(this->stream));
   }
 
-  template <typename T>
-  void assignChunkValue(T* buf, size_t count, T val) {
-    std::vector<T> expectedVals(count, val);
-    CUDACHECKIGNORE(cudaMemcpy(
-        buf, expectedVals.data(), count * sizeof(T), cudaMemcpyDefault));
-  }
-
+  // TODO [test-cleanup]: port to common checkChunkValue in
+  // testinfra/TestUtils.h
   template <typename T>
   int checkChunkValue(T* buf, size_t count, std::vector<T>& expectedVals) {
     std::vector<T> observedVals(count, -1);

--- a/comms/ncclx/v2_28/meta/tests/MultiStreamTest.cc
+++ b/comms/ncclx/v2_28/meta/tests/MultiStreamTest.cc
@@ -28,36 +28,6 @@ class MultiStreamTest : public NcclxBaseTest {
     NcclxBaseTest::TearDown();
   }
 
-  template <typename T>
-  void assignChunkValue(T* buf, size_t count, T val) {
-    std::vector<T> expectedVals(count, val);
-    CUDACHECK_TEST(cudaMemcpy(
-        buf, expectedVals.data(), count * sizeof(T), cudaMemcpyDefault));
-  }
-
-  template <typename T>
-  int checkChunkValue(T* buf, size_t count, T val) {
-    std::vector<T> observedVals(count, -1);
-    CUDACHECK_TEST(cudaMemcpy(
-        observedVals.data(), buf, count * sizeof(T), cudaMemcpyDefault));
-    int errs = 0;
-    // Use manual print rather than EXPECT_THAT to print failing location
-    for (auto i = 0; i < count; ++i) {
-      if (observedVals[i] != val) {
-        if (errs < 10) {
-          printf(
-              "[%d] observedVals[%d] = %d, expectedVal = %d\n",
-              globalRank,
-              i,
-              observedVals[i],
-              val);
-        }
-        errs++;
-      }
-    }
-    return errs;
-  }
-
  protected:
   ncclComm_t comm;
 };

--- a/comms/ncclx/v2_28/meta/tests/ReduceScatterTest.cc
+++ b/comms/ncclx/v2_28/meta/tests/ReduceScatterTest.cc
@@ -31,39 +31,6 @@ class ReduceScatterTest : public NcclxBaseTest {
     NcclxBaseTest::TearDown();
   }
 
-  template <typename T>
-  void assignChunkValue(T* buf, size_t count, T val) {
-    std::vector<T> expectedVals(count, val);
-    CUDACHECK_TEST(cudaMemcpy(
-        buf, expectedVals.data(), count * sizeof(T), cudaMemcpyDefault));
-  }
-
-  template <typename T>
-  int checkChunkValue(T* buf, size_t count, T val) {
-    std::vector<T> observedVals(count, -1);
-    CUDACHECK_TEST(cudaMemcpy(
-        observedVals.data(), buf, count * sizeof(T), cudaMemcpyDefault));
-    int errs = 0;
-    // Use manual print rather than EXPECT_THAT to print failing location
-    for (auto i = 0; i < count; ++i) {
-      if (observedVals[i] != val) {
-        if (errs < 10) {
-          printf(
-              "[%d] observedVals[%d/%ld] = %d, expectedVal = %d, at buf %p (offset 0x%lx)\n",
-              globalRank,
-              i,
-              count,
-              observedVals[i],
-              val,
-              buf,
-              sizeof(T) * i);
-        }
-        errs++;
-      }
-    }
-    return errs;
-  }
-
  protected:
   ncclComm_t comm;
   cudaStream_t stream;

--- a/comms/ncclx/v2_28/meta/tests/SendRecvTest.cc
+++ b/comms/ncclx/v2_28/meta/tests/SendRecvTest.cc
@@ -42,36 +42,6 @@ class SendRecvTest : public NcclxBaseTest {
     NcclxBaseTest::TearDown();
   }
 
-  template <typename T>
-  void assignChunkValue(T* buf, size_t count, T val) {
-    std::vector<T> expectedVals(count, val);
-    CUDACHECKIGNORE(cudaMemcpy(
-        buf, expectedVals.data(), count * sizeof(T), cudaMemcpyDefault));
-  }
-
-  template <typename T>
-  int checkChunkValue(T* buf, size_t count, T val) {
-    std::vector<T> observedVals(count, -1);
-    CUDACHECK_TEST(cudaMemcpy(
-        observedVals.data(), buf, count * sizeof(T), cudaMemcpyDefault));
-    int errs = 0;
-    // Use manual print rather than EXPECT_THAT to print failing location
-    for (auto i = 0; i < count; ++i) {
-      if (observedVals[i] != val) {
-        if (errs < 10) {
-          printf(
-              "[%d] observedVals[%d] = %d, expectedVal = %d\n",
-              this->globalRank,
-              i,
-              observedVals[i],
-              val);
-        }
-        errs++;
-      }
-    }
-    return errs;
-  }
-
   void prepareBufs(const size_t count, bool registFlag = false) {
     CUDACHECK_TEST(cudaMalloc(&sendBuf, count * sizeof(int)));
     CUDACHECK_TEST(cudaMalloc(&recvBuf, count * sizeof(int)));


### PR DESCRIPTION
Summary:
This diff replaces local implementations of `assignChunkValue` and `checkChunkValue` functions in test files with the global utilities from `TestUtils.h` (added in D90512202).

The local implementations were redundant copies of the same functionality. By using the shared utilities:
- Reduces code duplication across test files
- Ensures consistent buffer value assignment/checking behavior
- Makes test maintenance easier

Also enhanced `checkChunkValue` to accept an optional `cudaStream_t` parameter:
- When stream is specified (not nullptr): uses `cudaMemcpyAsync` + `cudaStreamSynchronize`
- When stream is nullptr (default): uses synchronous `cudaMemcpy`

This allows test files that originally used stream-based async copy (RMATest.cc, NewCollTraceDistTestLocal.cc) to pass the stream parameter directly instead of manual synchronization.

Also fixed a pre-existing bug in NewCollTraceDistTestLocal.cc: `win->winBaseSignalPtr` → `win->winSignalPtr` (the member was renamed but callsite wasn't updated).

Differential Revision: D90552641


