### PR TITLE
Fix ctran API mismatch in NewCollTraceDistTestNoLocal

### DIFF
--- a/comms/ncclx/v2_27/meta/colltrace/tests/CollTraceDistTest.cc
+++ b/comms/ncclx/v2_27/meta/colltrace/tests/CollTraceDistTest.cc
@@ -1244,8 +1244,8 @@ TEST_F(CollTraceTest, winPutWait) {
   // 1 put + 1 wait + 1 allreduce per iteration
   EXPECT_EQ(dump.pastColls.size(), 3 * kNumIters);
   for (int i = 0; i < kNumIters; i++) {
-    EXPECT_EQ(dump.pastColls[2 * i].opName, "PutNotify");
-    EXPECT_EQ(dump.pastColls[2 * i + 1].opName, "WaitNotify");
+    EXPECT_EQ(dump.pastColls[2 * i].opName, "PutSignal");
+    EXPECT_EQ(dump.pastColls[2 * i + 1].opName, "WaitSignal");
   }
 
   for (int i = 0; i < kNumIters; i++) {

--- a/comms/ncclx/v2_27/meta/colltrace/tests/NewCollTraceDistTestLocal.cc
+++ b/comms/ncclx/v2_27/meta/colltrace/tests/NewCollTraceDistTestLocal.cc
@@ -143,7 +143,7 @@ TEST_F(CollTraceTestLocal, winSignalAllToAll) {
       0, comm->ctranComm_.get(), (void**)&winBase, &win, hints);
   ASSERT_EQ(res, commSuccess);
   ASSERT_NE(winBase, nullptr);
-  uint64_t* signalBase = win->winBaseSignalPtr;
+  uint64_t* signalBase = win->winSignalPtr;
   ASSERT_NE(signalBase, nullptr);
 
   // initialize with 1000UL, a random number

--- a/comms/ncclx/v2_27/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
+++ b/comms/ncclx/v2_27/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
@@ -670,8 +670,8 @@ TEST_F(CollTraceTest, winPutWait) {
   }
 
   for (int i = 0; i < kNumIters; i++) {
-    EXPECT_EQ(pastCollsJson[2 * i]["opName"].asString(), "PutNotify");
-    EXPECT_EQ(pastCollsJson[2 * i + 1]["opName"].asString(), "WaitNotify");
+    EXPECT_EQ(pastCollsJson[2 * i]["opName"].asString(), "PutSignal");
+    EXPECT_EQ(pastCollsJson[2 * i + 1]["opName"].asString(), "WaitSignal");
   }
 
   for (int i = 0; i < kNumIters; i++) {
@@ -979,10 +979,9 @@ TEST_F(CollTraceTest, CollTraceTestEnqueueMoreThanPendingQueue) {
         nextPeer,
         kNumElements * statex->rank(),
         win,
-        win->comm,
         put_stream,
         true));
-    COMMCHECK_TEST(ctranWaitSignal(prevPeer, win, win->comm, wait_stream));
+    COMMCHECK_TEST(ctranWaitSignal(prevPeer, win, wait_stream));
   }
 
   CUDACHECK_TEST(cudaDeviceSynchronize());

--- a/comms/ncclx/v2_28/meta/colltrace/tests/CollTraceDistTest.cc
+++ b/comms/ncclx/v2_28/meta/colltrace/tests/CollTraceDistTest.cc
@@ -1244,8 +1244,8 @@ TEST_F(CollTraceTest, winPutWait) {
   // 1 put + 1 wait + 1 allreduce per iteration
   EXPECT_EQ(dump.pastColls.size(), 3 * kNumIters);
   for (int i = 0; i < kNumIters; i++) {
-    EXPECT_EQ(dump.pastColls[2 * i].opName, "PutNotify");
-    EXPECT_EQ(dump.pastColls[2 * i + 1].opName, "WaitNotify");
+    EXPECT_EQ(dump.pastColls[2 * i].opName, "PutSignal");
+    EXPECT_EQ(dump.pastColls[2 * i + 1].opName, "WaitSignal");
   }
 
   for (int i = 0; i < kNumIters; i++) {

--- a/comms/ncclx/v2_28/meta/colltrace/tests/NewCollTraceDistTestLocal.cc
+++ b/comms/ncclx/v2_28/meta/colltrace/tests/NewCollTraceDistTestLocal.cc
@@ -143,7 +143,7 @@ TEST_F(CollTraceTestLocal, winSignalAllToAll) {
       0, comm->ctranComm_.get(), (void**)&winBase, &win, hints);
   ASSERT_EQ(res, commSuccess);
   ASSERT_NE(winBase, nullptr);
-  uint64_t* signalBase = win->winBaseSignalPtr;
+  uint64_t* signalBase = win->winSignalPtr;
   ASSERT_NE(signalBase, nullptr);
 
   // initialize with 1000UL, a random number

--- a/comms/ncclx/v2_28/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
+++ b/comms/ncclx/v2_28/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
@@ -670,8 +670,8 @@ TEST_F(CollTraceTest, winPutWait) {
   }
 
   for (int i = 0; i < kNumIters; i++) {
-    EXPECT_EQ(pastCollsJson[2 * i]["opName"].asString(), "PutNotify");
-    EXPECT_EQ(pastCollsJson[2 * i + 1]["opName"].asString(), "WaitNotify");
+    EXPECT_EQ(pastCollsJson[2 * i]["opName"].asString(), "PutSignal");
+    EXPECT_EQ(pastCollsJson[2 * i + 1]["opName"].asString(), "WaitSignal");
   }
 
   for (int i = 0; i < kNumIters; i++) {
@@ -979,10 +979,9 @@ TEST_F(CollTraceTest, CollTraceTestEnqueueMoreThanPendingQueue) {
         nextPeer,
         kNumElements * statex->rank(),
         win,
-        win->comm,
         put_stream,
         true));
-    COMMCHECK_TEST(ctranWaitSignal(prevPeer, win, win->comm, wait_stream));
+    COMMCHECK_TEST(ctranWaitSignal(prevPeer, win, wait_stream));
   }
 
   CUDACHECK_TEST(cudaDeviceSynchronize());


### PR DESCRIPTION
Summary: The `ctranPutSignal` and `ctranWaitSignal` APIs were updated to no longer require the communicator as a separate argument (the `CtranWin` object already contains the communicator reference internally). This test file was not updated accordingly, causing build failures.

Differential Revision: D90557083


