### PR TITLE
Migrate ExtUtils.cc to use ctran::utils::Exception

### DIFF
--- a/comms/ctran/utils/ExtUtils.h
+++ b/comms/ctran/utils/ExtUtils.h
@@ -91,8 +91,9 @@ struct SocketServerAddr {
 
 inline folly::SocketAddress toSocketAddress(const SocketServerAddr& addr) {
   if (addr.port < 0) {
-    throw std::runtime_error(
-        "Invalid port number " + std::to_string(addr.port));
+    throw ctran::utils::Exception(
+        "Invalid port number " + std::to_string(addr.port),
+        commInvalidArgument);
   }
   return folly::SocketAddress(
       addr.ipv6.empty() ? addr.ipv4 : addr.ipv6,


### PR DESCRIPTION
Summary:
Migrated usage of `std::runtime_error` to `ctran::utils::Exception` within `ExtUtils.cc`.

Used `commInvalidArgument` as the `commResult_t`, as an invalid port number is an invalid input argument.

Reviewed By: arttianezhu

Differential Revision: D90599907


