### PR TITLE
Migrate memCacheAllocator.cc to use ctran::utils::Exception

### DIFF
--- a/comms/ctran/memory/memCacheAllocator.cc
+++ b/comms/ctran/memory/memCacheAllocator.cc
@@ -27,7 +27,8 @@ std::shared_ptr<memCacheAllocator> memCacheAllocator::getInstance() {
   }
   auto obj = memCacheAllocatorSingleton.try_get();
   if (!obj) {
-    throw std::runtime_error("Failed to get memCacheAllocator singleton");
+    throw ctran::utils::Exception(
+        "Failed to get memCacheAllocator singleton", commInternalError);
   }
   obj->init();
   return obj;


### PR DESCRIPTION
Summary:
Migrated usage of `std::runtime_error` to `ctran::utils::Exception` within `memCacheAllocator.cc`.

Used `commInternalError` as the `commResult_t`, as singleton initialization failure is an internal error.

Reviewed By: arttianezhu

Differential Revision: D90599518


