### PR TITLE
Introduce FB_ERRORTHROW_EX macro for improved error handling

### DIFF
--- a/comms/ctran/algos/CtranAlgo.cc
+++ b/comms/ctran/algos/CtranAlgo.cc
@@ -822,8 +822,9 @@ size_t CtranAlgo::getTmpBufOffset(const TmpbufType type) {
   if (it != tmpbufSegments.end()) {
     offset = tmpbufSegmentOffsets.at(type);
   } else {
-    FB_ERRORTHROW(
+    FB_ERRORTHROW_EX(
         commInternalError,
+        comm_->logMetaData_,
         "Failed to find tmpbuf for type {} during getTmpBufOffset",
         static_cast<int>(type));
   }
@@ -837,8 +838,9 @@ std::tuple<void*, void*> CtranAlgo::getTmpBufInfo(const TmpbufType type) {
 
   auto it = tmpbufSegments.find(type);
   if (it == tmpbufSegments.end()) {
-    FB_ERRORTHROW(
+    FB_ERRORTHROW_EX(
         commInternalError,
+        comm_->logMetaData_,
         "Failed to find tmpbuf for type {} during getTmpBufInfo",
         static_cast<int>(type));
   } else {

--- a/comms/ctran/backends/tcpdevmem/CtranTcpDmSingleton.cc
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDmSingleton.cc
@@ -17,7 +17,8 @@ std::vector<std::vector<std::string>> CtranTcpDmSingleton::getIfNames(
     std::vector<std::string> tokens;
     folly::split(':', s, tokens);
     if (tokens.empty() || tokens[0].empty()) {
-      FB_ERRORTHROW(commInvalidArgument, "TCP-DEVMEM: invalid hcaList");
+      FB_ERRORTHROW_EX_NOCOMM(
+          commInvalidArgument, "TCP-DEVMEM: invalid hcaList");
     }
     std::filesystem::path inputPath =
         "/sys/class/infiniband/" + tokens[0] + "/device/net";
@@ -42,7 +43,8 @@ bool CtranTcpDmSingleton::supportBondTransport() {
   struct utsname uts{};
 
   if (uname(&uts) != 0) {
-    FB_ERRORTHROW(commSystemError, "uname() failed with errno {}", errno);
+    FB_ERRORTHROW_EX_NOCOMM(
+        commSystemError, "uname() failed with errno {}", errno);
   }
 
   if (!std::strcmp("aarch64", uts.machine)) {

--- a/comms/ctran/mapper/CtranMapper.cc
+++ b/comms/ctran/mapper/CtranMapper.cc
@@ -49,7 +49,7 @@ std::vector<CtranMapperBackend> getToEnableBackends(
         "CTRAN-MAPPER: Try to override backends through Ctran Config. Currently it is specific config for MCCL. If you are using NCCL with NCCL_CTRAN_BACKENDS, please report this to MCCL team");
     for (auto& b : overrideBackend) {
       if (b == CommBackend::UNSET) {
-        FB_ERRORTHROW(
+        FB_ERRORTHROW_EX_NOCOMM(
             commInvalidUsage, "CTRAN-MAPPER: Invalid override backend UNSET");
       }
       enableBackends.emplace_back(b);
@@ -94,8 +94,9 @@ CtranMapper::CtranMapper(CtranComm* comm) {
        enableBackends_[CtranMapperBackend::NVL] ||
        enableBackends_[CtranMapperBackend::SOCKET]) &&
       enableBackends_[CtranMapperBackend::TCPDM]) {
-    FB_ERRORTHROW(
+    FB_ERRORTHROW_EX(
         commInvalidArgument,
+        comm->logMetaData_,
         "CTRAN-MAPPER: TCPDM can not be enabled with IB, NVL or Socket backends");
   }
 

--- a/comms/ctran/memory/SlabAllocator.cc
+++ b/comms/ctran/memory/SlabAllocator.cc
@@ -12,7 +12,7 @@ namespace ncclx::memory {
 
 SlabAllocator::SlabAllocator() {
   if (!ctran::utils::getCuMemSysSupported()) {
-    FB_ERRORTHROW(
+    FB_ERRORTHROW_EX_NOCOMM(
         commInvalidUsage,
         "NCCLX slab allocator only works with low-level cuMem APIs. Make sure CUDA Toolkit is 11.3 or higher.");
   }

--- a/comms/ctran/utils/Checks.h
+++ b/comms/ctran/utils/Checks.h
@@ -588,10 +588,36 @@
     return error;                                                   \
   } while (0)
 
+// Note: when writing code within the comms/ctran directory,
+// prefer the FB_ERRORTHROW_EX or FB_ERRORTHROW_EX_NOCOMM macros.
+//
+// TODO(T250696492): move this macro definition outside the ctran directory.
 #define FB_ERRORTHROW(error, ...)                \
   do {                                           \
     CLOGF(ERR, ##__VA_ARGS__);                   \
     throw std::runtime_error(                    \
         std::string("COMM internal failure: ") + \
         ::meta::comms::commCodeToString(error)); \
+  } while (0)
+
+#define FB_ERRORTHROW_EX(error, logData, ...)       \
+  do {                                              \
+    CLOGF(ERR, ##__VA_ARGS__);                      \
+    throw ctran::utils::Exception(                  \
+        std::string("COMM internal failure: ") +    \
+            ::meta::comms::commCodeToString(error), \
+        error,                                      \
+        (logData).rank,                             \
+        (logData).commHash,                         \
+        (logData).commDesc);                        \
+  } while (0)
+
+// For contexts where rank/commHash are not available
+#define FB_ERRORTHROW_EX_NOCOMM(error, ...)         \
+  do {                                              \
+    CLOGF(ERR, ##__VA_ARGS__);                      \
+    throw ctran::utils::Exception(                  \
+        std::string("COMM internal failure: ") +    \
+            ::meta::comms::commCodeToString(error), \
+        error);                                     \
   } while (0)


### PR DESCRIPTION
Summary:
Adds a new `FB_ERRORTHROW_EX` macro that throws `ctran::utils::Exception` instead of `std::runtime_error`, enabling richer error context (rank, comm hash) for improved fault tolerance debugging.

Also adds a new `FB_ERRORTHROW_EX_NOCOMM` macro that throws `ctran::utils::Exception` instead of `std::runtime_error`, enabling richer error context (rank, comm hash) for improved fault tolerance debugging for contexts in which the comm is not available.

For now, we do not adopt the selector macro pattern with optional `CommLogData` usage, as the `FB_ERRORTHROW_EX` is meant to accept a variable number of additional argumenets that are used to format an error message, and this complicates the macro definition.

Reviewed By: arttianezhu

Differential Revision: D90207624


