### PR TITLE
make exportMem, remReleaseMem in nvl, and importMem&exportMem in ib to be static for later refactor

### DIFF
--- a/comms/ctran/CtranEx.cc
+++ b/comms/ctran/CtranEx.cc
@@ -210,8 +210,9 @@ commResult_t CtranEx::isendCtrl(
 
   CtranIbEpochRAII epochRAII(impl->ctranIb.get());
   // Fill in ctrl msg
-  FB_COMMCHECK(impl->ctranIb->exportMem(
-      buf, const_cast<void*>(bufRegHdl), reqImpl->sendCtrl.msg));
+  FB_COMMCHECK(
+      CtranIb::exportMem(
+          buf, const_cast<void*>(bufRegHdl), reqImpl->sendCtrl.msg));
 
   FB_COMMCHECK(impl->ctranIb->isendCtrlMsg(
       reqImpl->sendCtrl.msg.type,

--- a/comms/ctran/backends/ib/CtranIb.h
+++ b/comms/ctran/backends/ib/CtranIb.h
@@ -164,7 +164,7 @@ class CtranIb {
   // Output arguments:
   //   - msg: the reference to the control message to be sent to remote rank.
   //          Contents filled at return.
-  inline commResult_t
+  static inline commResult_t
   exportMem(const void* buf, void* ibRegElem, ControlMsg& msg) {
     return exportMemImpl(buf, ibRegElem, msg);
   }
@@ -175,7 +175,7 @@ class CtranIb {
   //   - key: the remoteAccessKey (rkey) of the remote buffer.
   //   - rank: the rank of the remote peer in the current communicator
   //   - msg: the reference to the control message received from remote rank.
-  inline commResult_t
+  static inline commResult_t
   importMem(void** buf, CtranIbRemoteAccessKey* key, const ControlMsg& msg) {
     return importMemImpl(buf, key, msg);
   }
@@ -731,7 +731,7 @@ class CtranIb {
     return commSuccess;
   }
 
-  inline commResult_t
+  static inline commResult_t
   exportMemImpl(const void* buf, void* ibRegElem, ControlMsg& msg) {
     msg.setType(ControlMsgType::IB_EXPORT_MEM);
     msg.ibExp.remoteAddr = reinterpret_cast<uint64_t>(buf);
@@ -741,7 +741,7 @@ class CtranIb {
     return commSuccess;
   }
 
-  inline commResult_t importMemImpl(
+  static inline commResult_t importMemImpl(
       void** buf,
       CtranIbRemoteAccessKey* key,
       const ControlMsg& msg) {

--- a/comms/ctran/backends/ib/tests/CtranIbConnectionTest.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbConnectionTest.cc
@@ -109,7 +109,7 @@ class CtranIbConnectionTest : public ::testing::Test {
       void* remoteRecvBuf = nullptr;
       CtranIbRemoteAccessKey remoteKey;
       EXPECT_EQ(
-          ctranIb->importMem(&remoteRecvBuf, &remoteKey, exportMsg),
+          CtranIb::importMem(&remoteRecvBuf, &remoteKey, exportMsg),
           commSuccess);
 
       // Lock epoch before operations
@@ -155,7 +155,7 @@ class CtranIbConnectionTest : public ::testing::Test {
 
       // Export receive buffer memory and send to sender
       ControlMsg exportMsg;
-      EXPECT_EQ(ctranIb->exportMem(buffer, regElem, exportMsg), commSuccess);
+      EXPECT_EQ(CtranIb::exportMem(buffer, regElem, exportMsg), commSuccess);
       syncObjects.memoryExportPromise.setValue(exportMsg);
 
       // Lock epoch for operations

--- a/comms/ctran/backends/ib/tests/CtranIbDistUT.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbDistUT.cc
@@ -139,7 +139,7 @@ class CtranIbTest : public ctran::CtranDistTestFixture {
     COMMCHECK_TEST(
         CtranIb::regMem(
             buf, bufCount * sizeof(int) * numPuts, this->localRank, &handle));
-    COMMCHECK_TEST(ctranIb->exportMem(buf, handle, msg));
+    COMMCHECK_TEST(CtranIb::exportMem(buf, handle, msg));
     ASSERT_EQ(getIbRegCount(), commIbRegCount + 1);
 
     if (preConnect) {
@@ -331,7 +331,7 @@ class CtranIbTest : public ctran::CtranDistTestFixture {
     // Register and export to a control msg
     COMMCHECK_TEST(
         CtranIb::regMem(buf, bufCount * sizeof(int), this->localRank, &handle));
-    COMMCHECK_TEST(ctranIb->exportMem(buf, handle, msg));
+    COMMCHECK_TEST(CtranIb::exportMem(buf, handle, msg));
     ASSERT_EQ(getIbRegCount(), commIbRegCount + 1);
 
     // Rank whose data will be read sends the remoteAddr and rkey to sender
@@ -519,7 +519,7 @@ class CtranIbTest : public ctran::CtranDistTestFixture {
     // Register and export to a control msg
     COMMCHECK_TEST(
         CtranIb::regMem(buf, bufCount * sizeof(int), this->localRank, &handle));
-    COMMCHECK_TEST(ctranIb->exportMem(buf, handle, msg));
+    COMMCHECK_TEST(CtranIb::exportMem(buf, handle, msg));
     ASSERT_EQ(getIbRegCount(), commIbRegCount + 1);
 
     // Receiver sends the remoteAddr and rkey to sender
@@ -768,7 +768,7 @@ class CtranIbTest : public ctran::CtranDistTestFixture {
     COMMCHECK_TEST(
         CtranIb::regMem(
             buf, bufCount * sizeof(uint64_t), this->localRank, &handle));
-    COMMCHECK_TEST(ctranIb->exportMem(buf, handle, msg));
+    COMMCHECK_TEST(CtranIb::exportMem(buf, handle, msg));
     ASSERT_EQ(getIbRegCount(), commIbRegCount + 1);
 
     // Receiver sends the remoteAddr and rkey to sender
@@ -1119,7 +1119,7 @@ TEST_F(CtranIbTest, ExportMem) {
     EXPECT_NE(handle, nullptr);
     ASSERT_EQ(getIbRegCount(), commIbRegCount + 1);
 
-    COMMCHECK_TEST(ctranIb->exportMem(buf, handle, msg));
+    COMMCHECK_TEST(CtranIb::exportMem(buf, handle, msg));
     EXPECT_EQ(msg.type, ControlMsgType::IB_EXPORT_MEM);
     EXPECT_EQ(msg.ibExp.remoteAddr, reinterpret_cast<uint64_t>(buf));
     auto mrs = reinterpret_cast<std::vector<ibverbx::ibv_mr*>*>(handle);
@@ -1726,7 +1726,7 @@ TEST_F(CtranIbTest, MultiPutTrafficProfiler) {
     }
 
     // All rank sends the remoteAddr and rkey to rootRank
-    COMMCHECK_TEST(ctranIb->exportMem(buf, handle, sendMsg));
+    COMMCHECK_TEST(CtranIb::exportMem(buf, handle, sendMsg));
     COMMCHECK_TEST(ctranIb->isendCtrlMsg(
         sendMsg.type, &sendMsg, sizeof(sendMsg), rootRank, ctrlSReq));
 
@@ -1895,7 +1895,7 @@ TEST_F(CtranIbTest, InvalidMemoryWaitNotify) {
   // Allocate and register memory
   CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
   COMMCHECK_TEST(CtranIb::regMem(buf, bufSize, this->localRank, &handle));
-  COMMCHECK_TEST(ctranIb->exportMem(buf, handle, msg));
+  COMMCHECK_TEST(CtranIb::exportMem(buf, handle, msg));
 
   if (this->globalRank == sendRank) {
     // Use invalid remote address (corrupted)
@@ -2384,7 +2384,7 @@ TEST_P(CtranIbTestParam, InvalidIputFastNotify) {
   // Register and export to a control msg
   COMMCHECK_TEST(
       CtranIb::regMem(buf, bufCount * sizeof(int), this->localRank, &handle));
-  COMMCHECK_TEST(ctranIb->exportMem(buf, handle, msg));
+  COMMCHECK_TEST(CtranIb::exportMem(buf, handle, msg));
   ASSERT_EQ(getIbRegCount(), commIbRegCount + 1);
 
   // Receiver sends the remoteAddr and rkey to sender
@@ -2550,7 +2550,7 @@ TEST_P(CtranIbTestParam, GpuMemPutNoSignalMixedFastRegular) {
   // Register and export to a control msg
   COMMCHECK_TEST(
       CtranIb::regMem(buf, bufCount * sizeof(int), this->localRank, &handle));
-  COMMCHECK_TEST(ctranIb->exportMem(buf, handle, msg));
+  COMMCHECK_TEST(CtranIb::exportMem(buf, handle, msg));
   ASSERT_EQ(getIbRegCount(), commIbRegCount + 1);
 
   // Receiver sends the remoteAddr and rkey to sender
@@ -2651,7 +2651,7 @@ TEST_P(CtranIbTestParam, GpuMemPutNotifyLastMixedFastRegular) {
   // Register and export to a control msg
   COMMCHECK_TEST(
       CtranIb::regMem(buf, bufCount * sizeof(int), this->localRank, &handle));
-  COMMCHECK_TEST(ctranIb->exportMem(buf, handle, msg));
+  COMMCHECK_TEST(CtranIb::exportMem(buf, handle, msg));
   ASSERT_EQ(getIbRegCount(), commIbRegCount + 1);
 
   // Receiver sends the remoteAddr and rkey to sender

--- a/comms/ctran/backends/nvl/CtranNvl.cc
+++ b/comms/ctran/backends/nvl/CtranNvl.cc
@@ -202,8 +202,7 @@ commResult_t CtranNvl::importMem(
   return commSuccess;
 }
 
-commResult_t
-CtranNvl::remReleaseMem(void* nvlRegElem, int rank, ControlMsg& msg) {
+commResult_t CtranNvl::remReleaseMem(void* nvlRegElem, ControlMsg& msg) {
   auto reg = reinterpret_cast<CtranNvlRegElem*>(nvlRegElem);
   msg.setType(ControlMsgType::NVL_RELEASE_MEM);
   msg.nvlRls.base = reg->ipcMem.rlock()->getBase();

--- a/comms/ctran/backends/nvl/CtranNvl.h
+++ b/comms/ctran/backends/nvl/CtranNvl.h
@@ -74,16 +74,16 @@ class CtranNvl {
   // Output arguments:
   //   - msg: the reference to the control message to be sent to remote rank.
   //          Contents filled at return.
-  commResult_t exportMem(const void* buf, void* nvlRegElem, ControlMsg& msg);
+  static commResult_t
+  exportMem(const void* buf, void* nvlRegElem, ControlMsg& msg);
 
   // Release the exported memory on remote rank.
   // Input arguments:
   //   - nvlRegElem: local registration
-  //   - rank: the remote rank
   // Output arguments:
   //   - msg: the reference to the control message to be sent to remote rank.
   //          Contents filled at return.
-  commResult_t remReleaseMem(void* nvlRegElem, int rank, ControlMsg& msg);
+  static commResult_t remReleaseMem(void* nvlRegElem, ControlMsg& msg);
 
   // Callback (CB) function to handle incoming NVL_RELEASE_MEM CB_CTRL msg
   // Input arguments:

--- a/comms/ctran/backends/nvl/tests/CtranNvlDistUT.cc
+++ b/comms/ctran/backends/nvl/tests/CtranNvlDistUT.cc
@@ -265,7 +265,7 @@ TEST_P(CtranNvlTestSuite, ExportImportMem) {
     CtranNvlRegElem* nvlRegElem = reinterpret_cast<CtranNvlRegElem*>(regElems);
     ControlMsg msg(ControlMsgType::NVL_EXPORT_MEM);
 
-    COMMCHECK_TEST(ctranNvl->exportMem(data, regElems, msg));
+    COMMCHECK_TEST(CtranNvl::exportMem(data, regElems, msg));
     auto ipcMem = nvlRegElem->ipcMem.rlock();
     dataRange = ipcMem->getRange();
 
@@ -287,7 +287,7 @@ TEST_P(CtranNvlTestSuite, ExportImportMem) {
 
     // Remote release - check control message content and send to peer
     ControlMsg releaseMsg;
-    ctranNvl->remReleaseMem(nvlRegElem, peer, releaseMsg);
+    CtranNvl::remReleaseMem(nvlRegElem, releaseMsg);
     EXPECT_EQ(releaseMsg.type, ControlMsgType::NVL_RELEASE_MEM);
     EXPECT_EQ(releaseMsg.nvlRls.base, msg.nvlExp.ipcDesc.base);
 

--- a/comms/ctran/mapper/CtranMapper.cc
+++ b/comms/ctran/mapper/CtranMapper.cc
@@ -430,8 +430,7 @@ commResult_t CtranMapper::remReleaseMem(CtranMapperRegElem* regElem) {
       std::unique_ptr<CbCtrlRequest> req =
           std::make_unique<CbCtrlRequest>(peerRank, backend);
 
-      FB_COMMCHECK(this->ctranNvl->remReleaseMem(
-          regElem->nvlRegElem, peerRank, req->msg));
+      FB_COMMCHECK(CtranNvl::remReleaseMem(regElem->nvlRegElem, req->msg));
       if (this->ctranIb) {
         FB_COMMCHECK(this->ctranIb->isendCtrlMsg(
             req->msg.type,

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -1082,13 +1082,13 @@ class CtranMapper {
     }
 
     if (backend == CtranMapperBackend::NVL) {
-      FB_COMMCHECK(this->ctranNvl->exportMem(buf, regElem->nvlRegElem, msg));
+      FB_COMMCHECK(CtranNvl::exportMem(buf, regElem->nvlRegElem, msg));
 
       // Record the exported remote rank to notify at deregistration
       exportRegCache_.wlock()->record(regElem, rank);
 
     } else if (backend == CtranMapperBackend::IB) {
-      FB_COMMCHECK(this->ctranIb->exportMem(buf, regElem->ibRegElem, msg));
+      FB_COMMCHECK(CtranIb::exportMem(buf, regElem->ibRegElem, msg));
     } else if (backend == CtranMapperBackend::TCPDM) {
       // No need to export the buffers, TCP device memory is steered by
       // the receiver.
@@ -1119,7 +1119,7 @@ class CtranMapper {
           return commInternalError;
         }
         remKey->backend = CtranMapperBackend::IB;
-        FB_COMMCHECK(this->ctranIb->importMem(buf, &(remKey->ibKey), msg));
+        FB_COMMCHECK(CtranIb::importMem(buf, &(remKey->ibKey), msg));
         break;
       case ControlMsgType::NVL_EXPORT_MEM:
         if (!this->ctranNvl) {


### PR DESCRIPTION
Summary:
**Diff Summary**


### What
*  refactor `exportMem` and `importMem` in `CtranIb` to be static
*  refactor `exportMem` and `remReleaseMem` in `CtranNvl` to be static
* add peerName(hostname+pid) in nvlExpMem for remote ranks to identify this remote memory. We'll remove `int peerRank` after cleaning all memory import logic in CtranNvlImpl.

Differential Revision: D90626193


