### PR TITLE
remove deprecated signal value and displacement arguments in ncclSignal

### DIFF
--- a/comms/ncclx/v2_27/meta/rma/rma.cc
+++ b/comms/ncclx/v2_27/meta/rma/rma.cc
@@ -137,17 +137,10 @@ ncclResult_t ncclWaitSignal(int peer, ncclWindow_t win, cudaStream_t stream) {
 NCCL_API(
     ncclResult_t,
     ncclSignal,
-    size_t signalDisp, // TODO: to be deprecated
-    uint64_t signalVal, // TODO: to be deprecated
     int peer,
     ncclWindow_t win,
     cudaStream_t stream);
-ncclResult_t ncclSignal(
-    size_t signalDisp,
-    uint64_t signalVal,
-    int peer,
-    ncclWindow_t win,
-    cudaStream_t stream) {
+ncclResult_t ncclSignal(int peer, ncclWindow_t win, cudaStream_t stream) {
   ncclWin* ncclWinPtr = nullptr;
   NCCLCHECK(getValidatedNcclWin(win, &ncclWinPtr, "ncclSignal"));
   return metaCommToNccl(ctranSignal(peer, ncclWinPtr->ctranWindow, stream));

--- a/comms/ncclx/v2_27/src/nccl.h.in
+++ b/comms/ncclx/v2_27/src/nccl.h.in
@@ -775,8 +775,6 @@ ncclResult_t pncclWaitSignal(int peer, ncclWindow_t win, cudaStream_t stream);
  * Wait for a signal given the local signal displacement, the signal value, and the comparison op.
  */
 ncclResult_t ncclSignal(
-    size_t signalDisp,
-    uint64_t signalVal,
     int peer,
     ncclWindow_t win,
     cudaStream_t stream

--- a/comms/ncclx/v2_28/meta/rma/rma.cc
+++ b/comms/ncclx/v2_28/meta/rma/rma.cc
@@ -137,17 +137,10 @@ ncclResult_t ncclWaitSignal(int peer, ncclWindow_t win, cudaStream_t stream) {
 NCCL_API(
     ncclResult_t,
     ncclSignal,
-    size_t signalDisp,
-    uint64_t signalVal,
     int peer,
     ncclWindow_t win,
     cudaStream_t stream);
-ncclResult_t ncclSignal(
-    size_t signalDisp,
-    uint64_t signalVal,
-    int peer,
-    ncclWindow_t win,
-    cudaStream_t stream) {
+ncclResult_t ncclSignal(int peer, ncclWindow_t win, cudaStream_t stream) {
   ncclWin* ncclWinPtr = nullptr;
   NCCLCHECK(getValidatedNcclWin(win, &ncclWinPtr, "ncclSignal"));
   return metaCommToNccl(ctranSignal(peer, ncclWinPtr->ctranWindow, stream));

--- a/comms/ncclx/v2_28/src/nccl.h.in
+++ b/comms/ncclx/v2_28/src/nccl.h.in
@@ -847,8 +847,6 @@ ncclResult_t pncclWaitSignal(int peer, ncclWindow_t win, cudaStream_t stream);
  */
 
 ncclResult_t ncclSignal(
-    size_t signalDisp,
-    uint64_t signalVal,
     int peer,
     ncclWindow_t win,
     cudaStream_t stream

--- a/comms/torchcomms/ncclx/NcclxApi.cpp
+++ b/comms/torchcomms/ncclx/NcclxApi.cpp
@@ -365,7 +365,7 @@ ncclResult_t DefaultNcclxApi::winSharedQuery(
 
 ncclResult_t
 DefaultNcclxApi::winSignal(int peer, NcclxWindow win, cudaStream_t stream) {
-  return ncclSignal(peer, 0, peer, win, stream);
+  return ncclSignal(peer, win, stream);
 }
 
 ncclResult_t


### PR DESCRIPTION
Summary: Remove the two deprecated arguments of ncclSignal, and refactor all callsites accordingly.

Reviewed By: tianfengfrank

Differential Revision: D90701741


