### PR TITLE
Update tests for FB_COMMCHECKTHROW_EX macro

### DIFF
--- a/comms/ctran/utils/tests/ChecksUT.cc
+++ b/comms/ctran/utils/tests/ChecksUT.cc
@@ -429,6 +429,8 @@ TEST_F(CtranUtilsCheckTest, FB_COMMCHECKTHROW_EX_DIRECT) {
       EXPECT_EQ(e.result(), commResult);
       EXPECT_EQ(e.rank(), rank);
       EXPECT_EQ(e.commHash(), commHash);
+      EXPECT_EQ(e.desc(), commDesc);
+      EXPECT_EQ(e.result(), commResult);
       EXPECT_THAT(
           std::string(e.what()),
           ::testing::HasSubstr("COMM internal failure:"));
@@ -467,6 +469,8 @@ TEST_F(CtranUtilsCheckTest, FB_COMMCHECKTHROW_EX_LOGDATA) {
       EXPECT_EQ(e.result(), commResult);
       EXPECT_EQ(e.rank(), rank);
       EXPECT_EQ(e.commHash(), commHash);
+      EXPECT_EQ(e.desc(), commDesc);
+      EXPECT_EQ(e.result(), commResult);
       EXPECT_THAT(
           std::string(e.what()),
           ::testing::HasSubstr("COMM internal failure:"));
@@ -499,6 +503,8 @@ TEST_F(CtranUtilsCheckTest, FB_COMMCHECKTHROW_EX_3ARGS) {
       EXPECT_EQ(e.result(), commResult);
       EXPECT_EQ(e.rank(), rank);
       EXPECT_EQ(e.commHash(), commHash);
+      EXPECT_EQ(e.desc(), commDesc);
+      EXPECT_EQ(e.result(), commResult);
       EXPECT_THAT(
           std::string(e.what()),
           ::testing::HasSubstr("COMM internal failure:"));
@@ -537,6 +543,8 @@ TEST_F(CtranUtilsCheckTest, FB_COMMCHECKTHROW_EX_2ARGS) {
       EXPECT_EQ(e.result(), commResult);
       EXPECT_EQ(e.rank(), rank);
       EXPECT_EQ(e.commHash(), commHash);
+      EXPECT_EQ(e.desc(), commDesc);
+      EXPECT_EQ(e.result(), commResult);
       EXPECT_THAT(
           std::string(e.what()),
           ::testing::HasSubstr("COMM internal failure:"));


### PR DESCRIPTION
Summary: Updates the unit tests in `ChecksUT.cc` for the `FB_COMMCHECKTHROW_EX` macro to check for the particular `commResult_t` and to compare against `commDesc`.

Differential Revision: D90691884


