### PR TITLE
Adding clustered kernel launch option in p2p NVL benchmark

### DIFF
--- a/comms/pipes/benchmarks/BenchmarkKernel.cu
+++ b/comms/pipes/benchmarks/BenchmarkKernel.cu
@@ -89,7 +89,7 @@ __global__ void p2pBidirectional(
   auto group = getThreadGroup(useBlockGroups);
 
   // Partition groups into 2: half for send, half for recv
-  auto [partition_id, subgroup] = group.partition(2);
+  auto [partition_id, subgroup] = group.partition_interleaved(2);
   if (partition_id == 0) {
     p2p.send(subgroup, sendBuff, nBytes);
   } else {

--- a/comms/pipes/tests/ThreadGroupTest.cuh
+++ b/comms/pipes/tests/ThreadGroupTest.cuh
@@ -72,4 +72,18 @@ void testWeightedPartition(
     int numBlocks,
     int blockSize);
 
+// Tests partition_interleaved(num_partitions) - round-robin partition
+// Verifies:
+// - Each group gets partition_id = group_id % num_partitions
+// - subgroup.group_id is renumbered as group_id / num_partitions
+// - subgroup.total_groups is correctly computed for interleaved assignment
+void testPartitionInterleaved(
+    uint32_t* partitionIds_d,
+    uint32_t* subgroupIds_d,
+    uint32_t* subgroupTotalGroups_d,
+    uint32_t numPartitions,
+    uint32_t* errorCount_d,
+    int numBlocks,
+    int blockSize);
+
 } // namespace comms::pipes::test


### PR DESCRIPTION
Summary:
This diff is co-developed with siyengar

We observed that block scheduling can affect SendRecv busbw by 10% in certain cases. This diff adds clustered-launch + interleaved partition option in NVL benchmark for perf tuning.

We also compared the two kinds of launch using NCU in D90657382: the perf gain from clustered launch is by reducing memory stall and L2 cache churn

Differential Revision: D90708629


