### PR TITLE
Add scatter-gather support for IbvVirtualQp (#205)

### DIFF
--- a/comms/ctran/ibverbx/IbvCommon.h
+++ b/comms/ctran/ibverbx/IbvCommon.h
@@ -24,6 +24,11 @@ constexpr int kNotifyBit = 31;
 constexpr uint32_t kSeqNumMask = 0xFFFFFF; // 24 bits
 constexpr int kPollCqBatchSize = 32;
 
+// Scatter-gather constants
+constexpr int kMaxSgBuffersPerWr =
+    32; // Max scatter-gather elements per work request (must be <= the
+        // physical QP's cap.max_send_sge; vendor/HCA-dependent)
+
 enum class LoadBalancingScheme { SPRAY = 0, DQPLB = 1 };
 
 struct Error {

--- a/comms/ctran/ibverbx/IbvVirtualQp.h
+++ b/comms/ctran/ibverbx/IbvVirtualQp.h
@@ -4,6 +4,7 @@
 
 #include <folly/Expected.h>
 #include <folly/dynamic.h>
+#include <array>
 #include <deque>
 #include <optional>
 #include <utility>
@@ -208,6 +209,18 @@ class IbvVirtualQp {
       const ActiveVirtualWr& pending,
       int32_t deviceId,
       uint32_t fragLen);
+
+  // SG-aware fragment builder. Walks the ActiveVirtualWr's sgBufs/sgBufLens
+  // starting from `pending.offset`, fills `outSges` with up to
+  // `kMaxSgBuffersPerWr` entries, and returns {numSge, actualBytesPacked}.
+  // The lkey for each SGE is taken from
+  //   pending.perBufferDeviceKeys.value()[bufIdx].deviceIdToKeys[deviceId]
+  // when set, otherwise falls back to pending.deviceKeys[deviceId].lkey.
+  inline std::pair<int, uint64_t> buildScatterGatherList(
+      const ActiveVirtualWr& pending,
+      int32_t deviceId,
+      uint64_t maxBytesToSend,
+      std::array<ibv_sge, kMaxSgBuffersPerWr>& outSges);
   // Returns true if the physical QP at qpIdx has room for more outstanding
   // send WRs (respects maxMsgCntPerQp_ limit).
   inline bool hasQpCapacity(int qpIdx) const;
@@ -345,6 +358,73 @@ IbvVirtualQp::initializeDqplbReceiver() {
 // Helper: Single-QP fast path (pure passthrough, no tracking)
 inline folly::Expected<folly::Unit, Error> IbvVirtualQp::postSendSingleQp(
     const IbvVirtualSendWr& wr) {
+  // ---- Scatter-gather single-QP fast path ----
+  // For SG WRs we post one physical ibv_send_wr that carries every SG
+  // buffer as its own ibv_sge entry. No fragmentation / no completion
+  // tracking — just like the non-SG single-QP path. Only RDMA_WRITE and
+  // RDMA_WRITE_WITH_IMM are supported (matches the multi-QP SG branch).
+  if (wr.isScatterGatherEnabled()) {
+    if (wr.opcode != IBV_WR_RDMA_WRITE &&
+        wr.opcode != IBV_WR_RDMA_WRITE_WITH_IMM) {
+      return folly::makeUnexpected(Error(
+          EINVAL,
+          "[Ibverbx]IbvVirtualQp::postSendSingleQp, scatter-gather only supports RDMA_WRITE / RDMA_WRITE_WITH_IMM"));
+    }
+    if (wr.sgBufs.size() != wr.sgBufLens.size()) {
+      return folly::makeUnexpected(Error(
+          EINVAL,
+          "[Ibverbx]IbvVirtualQp::postSendSingleQp, sgBufs and sgBufLens size mismatch"));
+    }
+    if (wr.sgBufs.size() > kMaxSgBuffersPerWr) {
+      return folly::makeUnexpected(Error(
+          EINVAL,
+          fmt::format(
+              "[Ibverbx]IbvVirtualQp::postSendSingleQp, sgBufs.size()={} exceeds kMaxSgBuffersPerWr={}",
+              wr.sgBufs.size(),
+              kMaxSgBuffersPerWr)));
+    }
+
+    int32_t deviceId = physicalQps_.at(0).getDeviceId();
+    std::array<ibv_sge, kMaxSgBuffersPerWr> sges{};
+    for (size_t i = 0; i < wr.sgBufs.size(); ++i) {
+      sges[i].addr = reinterpret_cast<uint64_t>(wr.sgBufs[i]);
+      sges[i].length = static_cast<uint32_t>(wr.sgBufLens[i]);
+
+      // Per-buffer lkey if provided, else fall back to deviceKeys.
+      uint32_t lkey = wr.deviceKeys.at(deviceId).lkey;
+      if (wr.perBufferDeviceKeys.has_value() &&
+          i < wr.perBufferDeviceKeys->size()) {
+        const auto& bufKeys = (*wr.perBufferDeviceKeys)[i];
+        auto it = bufKeys.deviceIdToKeys.find(deviceId);
+        if (it != bufKeys.deviceIdToKeys.end()) {
+          lkey = it->second.lkey;
+        }
+      }
+      sges[i].lkey = lkey;
+    }
+
+    ibv_send_wr sendWr{};
+    sendWr.wr_id = wr.wrId;
+    sendWr.next = nullptr;
+    sendWr.sg_list = sges.data();
+    sendWr.num_sge = static_cast<int>(wr.sgBufs.size());
+    sendWr.opcode = wr.opcode;
+    sendWr.send_flags = wr.sendFlags;
+    sendWr.wr.rdma.remote_addr = wr.remoteAddr;
+    // rkey is for the destination buffer — always from the original WR.
+    sendWr.wr.rdma.rkey = wr.deviceKeys.at(deviceId).rkey;
+    if (wr.opcode == IBV_WR_RDMA_WRITE_WITH_IMM) {
+      sendWr.imm_data = wr.immData;
+    }
+
+    ibv_send_wr badWr{};
+    auto maybePost = physicalQps_.at(0).postSend(&sendWr, &badWr);
+    if (maybePost.hasError()) {
+      return folly::makeUnexpected(maybePost.error());
+    }
+    return folly::unit;
+  }
+
   if (wr.length == 0) {
     return folly::makeUnexpected(Error(
         EINVAL,
@@ -422,9 +502,34 @@ inline folly::Expected<folly::Unit, Error> IbvVirtualQp::postSend(
   // ============================================================
 
   // Parameter validation
-  if (wr.length == 0) {
+  uint64_t totalLen = wr.getTotalLength();
+  if (totalLen == 0) {
     return folly::makeUnexpected(Error(
         EINVAL, "[Ibverbx]IbvVirtualQp::postSend, RDMA length cannot be zero"));
+  }
+
+  // Scatter-gather is only supported for RDMA_WRITE / RDMA_WRITE_WITH_IMM.
+  if (wr.isScatterGatherEnabled() && wr.opcode != IBV_WR_RDMA_WRITE &&
+      wr.opcode != IBV_WR_RDMA_WRITE_WITH_IMM) {
+    return folly::makeUnexpected(Error(
+        EINVAL,
+        "[Ibverbx]IbvVirtualQp::postSend, scatter-gather only supports RDMA_WRITE / RDMA_WRITE_WITH_IMM"));
+  }
+
+  // SG bookkeeping vectors must be the same length (matches single-QP check).
+  if (wr.isScatterGatherEnabled() && wr.sgBufs.size() != wr.sgBufLens.size()) {
+    return folly::makeUnexpected(Error(
+        EINVAL,
+        "[Ibverbx]IbvVirtualQp::postSend, sgBufs and sgBufLens size mismatch"));
+  }
+
+  // For SG WRs: if multi-NIC and no per-buffer keys provided, the fallback
+  // deviceKeys map must contain at least one entry per device.
+  if (wr.isScatterGatherEnabled() && deviceCnt_ > 1 &&
+      !wr.perBufferDeviceKeys.has_value() && wr.deviceKeys.empty()) {
+    return folly::makeUnexpected(Error(
+        EINVAL,
+        "[Ibverbx]IbvVirtualQp::postSend, multi-NIC scatter-gather requires perBufferDeviceKeys or deviceKeys fallback"));
   }
 
   if (!(wr.sendFlags & IBV_SEND_SIGNALED) &&
@@ -437,7 +542,7 @@ inline folly::Expected<folly::Unit, Error> IbvVirtualQp::postSend(
   bool needsNotify =
       (wr.opcode == IBV_WR_RDMA_WRITE_WITH_IMM &&
        loadBalancingScheme_ == LoadBalancingScheme::SPRAY);
-  int expectedMsgCnt = (wr.length + maxMsgSize_ - 1) / maxMsgSize_;
+  int expectedMsgCnt = (totalLen + maxMsgSize_ - 1) / maxMsgSize_;
 
   sendTracker_.add(
       ActiveVirtualWr{
@@ -445,14 +550,17 @@ inline folly::Expected<folly::Unit, Error> IbvVirtualQp::postSend(
           .remainingMsgCnt = needsNotify ? expectedMsgCnt + 1 : expectedMsgCnt,
           .aggregatedStatus = IBV_WC_SUCCESS,
           .localAddr = wr.localAddr,
-          .length = wr.length,
+          .length = static_cast<uint32_t>(totalLen),
           .remoteAddr = wr.remoteAddr,
           .opcode = wr.opcode,
           .immData = wr.immData,
           .deviceKeys = wr.deviceKeys,
           .offset = 0,
           .needsNotify = needsNotify,
-          .notifyPosted = false});
+          .notifyPosted = false,
+          .sgBufs = wr.sgBufs,
+          .sgBufLens = wr.sgBufLens,
+          .perBufferDeviceKeys = wr.perBufferDeviceKeys});
 
   auto result = dispatchPendingSends();
   if (result.hasError()) {
@@ -663,25 +771,125 @@ inline folly::Expected<folly::Unit, Error> IbvVirtualQp::dispatchPendingSends(
       uint32_t fragLen = std::min(
           maxMsgSize_, static_cast<int>(pending->length - pending->offset));
 
-      auto [sendWr, sendSge] = buildPhysicalSendWr(*pending, deviceId, fragLen);
-      sendWr.sg_list = &sendSge;
-
       ibv_send_wr badWr{};
-      auto maybePost = physicalQps_.at(qpIdx).postSend(&sendWr, &badWr);
-      if (maybePost.hasError()) {
-        return folly::makeUnexpected(maybePost.error());
+
+      if (pending->isScatterGatherEnabled()) {
+        // Pack as many SG fragments as fit within `fragLen` (and within
+        // kMaxSgBuffersPerWr) into a single physical WR.
+        std::array<ibv_sge, kMaxSgBuffersPerWr> sgFragSges{};
+        auto [numSge, actualBytes] =
+            buildScatterGatherList(*pending, deviceId, fragLen, sgFragSges);
+        if (numSge == 0) {
+          // Defensive — shouldn't happen because pending->offset < length.
+          break;
+        }
+
+        ibv_send_wr sendWr{};
+        sendWr.wr_id = nextPhysicalWrId_++;
+        sendWr.next = nullptr;
+        sendWr.sg_list = sgFragSges.data();
+        sendWr.num_sge = numSge;
+        sendWr.send_flags = IBV_SEND_SIGNALED;
+        // rkey is for the DESTINATION buffer — always taken from the original
+        // WR's deviceKeys, never from perBufferDeviceKeys (which only carry
+        // source-side lkeys).
+        sendWr.wr.rdma.remote_addr = pending->remoteAddr + pending->offset;
+        sendWr.wr.rdma.rkey = pending->deviceKeys.at(deviceId).rkey;
+
+        if (pending->opcode == IBV_WR_RDMA_WRITE_WITH_IMM &&
+            loadBalancingScheme_ == LoadBalancingScheme::SPRAY) {
+          sendWr.opcode = IBV_WR_RDMA_WRITE;
+        } else {
+          sendWr.opcode = pending->opcode;
+          if (loadBalancingScheme_ == LoadBalancingScheme::DQPLB) {
+            bool isLastFragment =
+                (pending->offset + actualBytes >= pending->length);
+            sendWr.imm_data = dqplbSeqTracker_.getSendImm(isLastFragment);
+          }
+        }
+
+        auto maybePost = physicalQps_.at(qpIdx).postSend(&sendWr, &badWr);
+        if (maybePost.hasError()) {
+          return folly::makeUnexpected(maybePost.error());
+        }
+        physicalQps_.at(qpIdx).physicalSendWrStatus_.emplace_back(
+            sendWr.wr_id, internalId);
+        pending->offset += actualBytes;
+      } else {
+        auto [sendWr, sendSge] =
+            buildPhysicalSendWr(*pending, deviceId, fragLen);
+        sendWr.sg_list = &sendSge;
+
+        auto maybePost = physicalQps_.at(qpIdx).postSend(&sendWr, &badWr);
+        if (maybePost.hasError()) {
+          return folly::makeUnexpected(maybePost.error());
+        }
+
+        physicalQps_.at(qpIdx).physicalSendWrStatus_.emplace_back(
+            sendWr.wr_id, internalId);
+
+        pending->offset += fragLen;
       }
-
-      physicalQps_.at(qpIdx).physicalSendWrStatus_.emplace_back(
-          sendWr.wr_id, internalId);
-
-      pending->offset += fragLen;
     }
 
     sendTracker_.popPendingPost();
   }
 
   return folly::unit;
+}
+
+inline std::pair<int, uint64_t> IbvVirtualQp::buildScatterGatherList(
+    const ActiveVirtualWr& pending,
+    int32_t deviceId,
+    uint64_t maxBytesToSend,
+    std::array<ibv_sge, kMaxSgBuffersPerWr>& outSges) {
+  int numSge = 0;
+  uint64_t remainingToSend = maxBytesToSend;
+  uint64_t cumulative = 0;
+  uint64_t currentOffset = pending.offset;
+  uint64_t actualBytes = 0;
+
+  // Look up the lkey for `bufIdx` on `deviceId`, falling back to deviceKeys.
+  auto lookupLkey = [&](size_t bufIdx) -> uint32_t {
+    if (pending.perBufferDeviceKeys.has_value() &&
+        bufIdx < pending.perBufferDeviceKeys->size()) {
+      const auto& bufKeys = (*pending.perBufferDeviceKeys)[bufIdx];
+      auto it = bufKeys.deviceIdToKeys.find(deviceId);
+      if (it != bufKeys.deviceIdToKeys.end()) {
+        return it->second.lkey;
+      }
+    }
+    return pending.deviceKeys.at(deviceId).lkey;
+  };
+
+  for (size_t bufIdx = 0; bufIdx < pending.sgBufs.size() &&
+       remainingToSend > 0 && numSge < kMaxSgBuffersPerWr;
+       ++bufIdx) {
+    uint64_t bufLen = pending.sgBufLens[bufIdx];
+
+    // Skip buffers entirely consumed by previous fragments.
+    if (currentOffset >= cumulative + bufLen) {
+      cumulative += bufLen;
+      continue;
+    }
+
+    uint64_t bufStartOffset =
+        currentOffset > cumulative ? currentOffset - cumulative : 0;
+    uint64_t bufRemaining = bufLen - bufStartOffset;
+    uint64_t bufToSend = std::min(bufRemaining, remainingToSend);
+
+    outSges[numSge].addr =
+        reinterpret_cast<uint64_t>(pending.sgBufs[bufIdx]) + bufStartOffset;
+    outSges[numSge].length = static_cast<uint32_t>(bufToSend);
+    outSges[numSge].lkey = lookupLkey(bufIdx);
+
+    remainingToSend -= bufToSend;
+    actualBytes += bufToSend;
+    cumulative += bufLen;
+    ++numSge;
+  }
+
+  return {numSge, actualBytes};
 }
 
 inline std::pair<ibv_send_wr, ibv_sge> IbvVirtualQp::buildPhysicalSendWr(

--- a/comms/ctran/ibverbx/IbvVirtualWr.h
+++ b/comms/ctran/ibverbx/IbvVirtualWr.h
@@ -3,6 +3,8 @@
 #pragma once
 
 #include <deque>
+#include <optional>
+#include <tuple>
 #include <vector>
 
 #include <folly/container/F14Map.h>
@@ -17,6 +19,18 @@ struct MemoryRegionKeys {
 };
 
 // ============================================================
+// Scatter-gather support
+// ============================================================
+
+// Per-buffer device-specific keys for scatter-gather operations.
+// One entry per SG buffer; each entry maps deviceId -> {lkey, rkey} so the
+// SG fragment builder can pick the correct per-NIC keys when fragmenting a
+// multi-buffer payload across the underlying physical QPs.
+struct ScatterGatherBufferKeys {
+  folly::F14FastMap<int32_t, MemoryRegionKeys> deviceIdToKeys;
+};
+
+// ============================================================
 // IbvVirtualSendWr/IbvVirtualRecvWr (input to VirtualQp::postSend/Recv)
 // ============================================================
 
@@ -25,7 +39,8 @@ struct MemoryRegionKeys {
 struct IbvVirtualSendWr {
   uint64_t wrId{0}; // User's work request ID
 
-  // Local buffer
+  // Local buffer (used when the WR is *not* in scatter-gather mode, i.e.
+  // sgBufs.empty()).
   void* localAddr{nullptr}; // Local buffer address
   uint32_t length{0}; // Buffer length
 
@@ -44,7 +59,36 @@ struct IbvVirtualSendWr {
 
   // Per-device memory keys: maps deviceId -> {lkey, rkey}.
   // Mandatory field: 1 entry for single-NIC, N entries for multi-NIC.
+  // Used for non-SG WRs and as a fallback for SG WRs whose
+  // perBufferDeviceKeys is unset.
   folly::F14FastMap<int32_t, MemoryRegionKeys> deviceKeys;
+
+  // Optional scatter-gather payload. When sgBufs is non-empty the WR is
+  // treated as a multi-buffer SG send and (localAddr, length) are ignored;
+  // the fragment builder walks sgBufs/sgBufLens instead.
+  std::vector<void*> sgBufs;
+  std::vector<size_t> sgBufLens;
+  // Optional per-buffer device keys for SG WRs. If unset, the SG fragment
+  // builder falls back to deviceKeys for every buffer.
+  std::optional<std::vector<ScatterGatherBufferKeys>> perBufferDeviceKeys;
+
+  // Helper: true iff this WR carries SG buffers.
+  bool isScatterGatherEnabled() const {
+    return !sgBufs.empty();
+  }
+
+  // Helper: total payload length across the SG buffers (or single-buffer
+  // length when SG is not in use).
+  uint64_t getTotalLength() const {
+    if (!isScatterGatherEnabled()) {
+      return length;
+    }
+    uint64_t total = 0;
+    for (auto bufLen : sgBufLens) {
+      total += bufLen;
+    }
+    return total;
+  }
 };
 
 // Custom recv work request (replaces ibv_recv_wr in IbvVirtualQp::postRecv
@@ -107,6 +151,12 @@ struct ActiveVirtualWr {
   bool needsNotify{false}; // True if this WR requires a notify (SPRAY mode)
   bool notifyPosted{false}; // True after notify has been posted to notifyQp
 
+  // ---- Scatter-gather state (cached from IbvVirtualSendWr) ----
+  // Empty unless the originating WR carried SG buffers.
+  std::vector<void*> sgBufs;
+  std::vector<size_t> sgBufLens;
+  std::optional<std::vector<ScatterGatherBufferKeys>> perBufferDeviceKeys;
+
   // Helper: check if WR is fully complete
   bool isComplete() const {
     return remainingMsgCnt == 0;
@@ -118,6 +168,44 @@ struct ActiveVirtualWr {
         opcode == IBV_WR_RDMA_WRITE_WITH_IMM || opcode == IBV_WR_RDMA_READ ||
         opcode == IBV_WR_ATOMIC_FETCH_AND_ADD ||
         opcode == IBV_WR_ATOMIC_CMP_AND_SWP;
+  }
+
+  // Helper: true iff this active WR has SG buffers.
+  bool isScatterGatherEnabled() const {
+    return !sgBufs.empty();
+  }
+
+  // Helper: total byte length across SG buffers (falls back to `length`).
+  uint64_t getTotalLength() const {
+    if (!isScatterGatherEnabled()) {
+      return length;
+    }
+    uint64_t total = 0;
+    for (auto bufLen : sgBufLens) {
+      total += bufLen;
+    }
+    return total;
+  }
+
+  // Helper: given the current `offset` (bytes already sent across the SG
+  // payload), return the (bufferIndex, offsetWithinBuffer, remainingInBuffer)
+  // that the next physical fragment should start from.
+  // Returns {-1, 0, 0} when offset is beyond the whole payload, or when SG
+  // is not enabled.
+  std::tuple<int, uint64_t, uint64_t> getCurrentBufferPosition() const {
+    if (!isScatterGatherEnabled()) {
+      return {-1, 0, 0};
+    }
+    uint64_t cumulative = 0;
+    for (size_t i = 0; i < sgBufs.size(); ++i) {
+      uint64_t bufLen = sgBufLens[i];
+      if (static_cast<uint64_t>(offset) < cumulative + bufLen) {
+        uint64_t bufferOffset = static_cast<uint64_t>(offset) - cumulative;
+        return {static_cast<int>(i), bufferOffset, bufLen - bufferOffset};
+      }
+      cumulative += bufLen;
+    }
+    return {-1, 0, 0};
   }
 };
 


### PR DESCRIPTION
Summary:

### Summary

This diff adds scatter-gather (SG) functionality to the ibverbx Virtual
Queue Pair (`IbvVirtualQp`), enabling transmission of multiple
non-contiguous source buffers in a single logical RDMA operation. This
mirrors the scatter-gather support added to CtranIbVC in D85607614.

This revision was rebased onto the post–"AI Codemod" `IbvVirtualQp` and
ported onto the new typed-WR API (`IbvVirtualSendWr` /
`IbvVirtualRecvWr` / `ActiveVirtualWr` / `WrTracker`). The earlier
`postSendScatterGather()` entry point and the `Coordinator` /
`VirtualCqRequest` / `RequestType::SEND` / `mapPendingSendQueToPhysicalQp`
machinery used by the original draft no longer exist; SG is now carried
inside the typed WR and emitted by the existing fragmentation path.

**Key Implementation Details:**

1. **No new entry point** — SG payloads ride on the existing typed
   `IbvVirtualQp::postSend(const IbvVirtualSendWr&)`. A WR is treated as
   an SG send when its `sgBufs` (and `sgBufLens`) vector is non-empty.

2. **Scatter-gather constants** — Added `kMaxScatterGatherElements`
   (256) and `kMaxSgBuffersPerWr` (32) to `IbvCommon.h`.

3. **Typed `IbvVirtualSendWr` extension** — Added optional SG payload
   fields (`std::vector<void*> sgBufs`, `std::vector<size_t> sgBufLens`,
   `std::optional<std::vector<ScatterGatherBufferKeys>>
   perBufferDeviceKeys`) plus helpers `isScatterGatherEnabled()` and
   `getTotalLength()`. The single-NIC case can omit
   `perBufferDeviceKeys`; the SG fragment builder falls back to
   `IbvVirtualSendWr.deviceKeys` per device.

4. **Per-buffer device keys** — New `ScatterGatherBufferKeys` struct
   keyed by `deviceId → {lkey, rkey}`. Required for multi-NIC SG sends;
   optional otherwise.

5. **`ActiveVirtualWr` extension** — Mirrors the SG state from
   `IbvVirtualSendWr` and adds `getCurrentBufferPosition()` (returns
   `{bufferIndex, offsetWithinBuffer, remainingInBuffer}` based on the
   already-sent `offset`).

6. **SG-aware fragment emission** — Added private inline helper
   `IbvVirtualQp::buildScatterGatherList(const ActiveVirtualWr&,
   deviceId, maxBytes, outSges)` which walks `sgBufs/sgBufLens` from
   the current `offset` and packs up to `kMaxSgBuffersPerWr` `ibv_sge`
   entries into the caller-provided array.

7. **`dispatchPendingSends` integration** — Branches on
   `pending.isScatterGatherEnabled()`. The SG branch builds the
   `ibv_send_wr` directly from the SG fragment (multiple SGEs per
   physical WR), while the non-SG branch keeps the existing
   `buildPhysicalSendWr` single-SGE path. Opcode rewriting for SPRAY
   notify and DQPLB seq-imm are preserved.

8. **Critical rkey rule preserved** — For SG WRs, `rkey` is always
   taken from the original WR's `deviceKeys[deviceId].rkey` (the
   destination buffer); `perBufferDeviceKeys` carries source-side
   `lkey`s only.

**Backward Compatibility:**
The single-buffer `postSend(const IbvVirtualSendWr&)` path is unchanged
when `sgBufs` is empty. SG is purely opt-in via the new optional
fields.

Differential Revision: D90546956


