### PR TITLE
Add scatter-gather unit tests for IbvVirtualQp (#206)

### DIFF
--- a/comms/ctran/ibverbx/IbvCommon.h
+++ b/comms/ctran/ibverbx/IbvCommon.h
@@ -24,6 +24,12 @@ constexpr int kNotifyBit = 31;
 constexpr uint32_t kSeqNumMask = 0xFFFFFF; // 24 bits
 constexpr int kPollCqBatchSize = 32;
 
+// Scatter-gather constants
+constexpr int kMaxScatterGatherElements =
+    256; // Max total scatter-gather elements per operation
+constexpr int kMaxSgBuffersPerWr =
+    32; // Max scatter-gather elements per work request (can be configured)
+
 enum class LoadBalancingScheme { SPRAY = 0, DQPLB = 1 };
 
 struct Error {

--- a/comms/ctran/ibverbx/IbvVirtualQp.h
+++ b/comms/ctran/ibverbx/IbvVirtualQp.h
@@ -4,6 +4,7 @@
 
 #include <folly/Expected.h>
 #include <folly/dynamic.h>
+#include <array>
 #include <deque>
 #include <optional>
 #include <utility>
@@ -208,6 +209,18 @@ class IbvVirtualQp {
       const ActiveVirtualWr& pending,
       int32_t deviceId,
       uint32_t fragLen);
+
+  // SG-aware fragment builder. Walks the ActiveVirtualWr's sgBufs/sgBufLens
+  // starting from `pending.offset`, fills `outSges` with up to
+  // `kMaxSgBuffersPerWr` entries, and returns {numSge, actualBytesPacked}.
+  // The lkey for each SGE is taken from
+  //   pending.perBufferDeviceKeys.value()[bufIdx].deviceIdToKeys[deviceId]
+  // when set, otherwise falls back to pending.deviceKeys[deviceId].lkey.
+  inline std::pair<int, uint64_t> buildScatterGatherList(
+      const ActiveVirtualWr& pending,
+      int32_t deviceId,
+      uint64_t maxBytesToSend,
+      std::array<ibv_sge, kMaxSgBuffersPerWr>& outSges);
   // Returns true if the physical QP at qpIdx has room for more outstanding
   // send WRs (respects maxMsgCntPerQp_ limit).
   inline bool hasQpCapacity(int qpIdx) const;
@@ -422,9 +435,27 @@ inline folly::Expected<folly::Unit, Error> IbvVirtualQp::postSend(
   // ============================================================
 
   // Parameter validation
-  if (wr.length == 0) {
+  uint64_t totalLen = wr.getTotalLength();
+  if (totalLen == 0) {
     return folly::makeUnexpected(Error(
         EINVAL, "[Ibverbx]IbvVirtualQp::postSend, RDMA length cannot be zero"));
+  }
+
+  // Scatter-gather is only supported for RDMA_WRITE / RDMA_WRITE_WITH_IMM.
+  if (wr.isScatterGatherEnabled() && wr.opcode != IBV_WR_RDMA_WRITE &&
+      wr.opcode != IBV_WR_RDMA_WRITE_WITH_IMM) {
+    return folly::makeUnexpected(Error(
+        EINVAL,
+        "[Ibverbx]IbvVirtualQp::postSend, scatter-gather only supports RDMA_WRITE / RDMA_WRITE_WITH_IMM"));
+  }
+
+  // For SG WRs: if multi-NIC and no per-buffer keys provided, the fallback
+  // deviceKeys map must contain at least one entry per device.
+  if (wr.isScatterGatherEnabled() && deviceCnt_ > 1 &&
+      !wr.perBufferDeviceKeys.has_value() && wr.deviceKeys.empty()) {
+    return folly::makeUnexpected(Error(
+        EINVAL,
+        "[Ibverbx]IbvVirtualQp::postSend, multi-NIC scatter-gather requires perBufferDeviceKeys or deviceKeys fallback"));
   }
 
   if (!(wr.sendFlags & IBV_SEND_SIGNALED) &&
@@ -437,7 +468,7 @@ inline folly::Expected<folly::Unit, Error> IbvVirtualQp::postSend(
   bool needsNotify =
       (wr.opcode == IBV_WR_RDMA_WRITE_WITH_IMM &&
        loadBalancingScheme_ == LoadBalancingScheme::SPRAY);
-  int expectedMsgCnt = (wr.length + maxMsgSize_ - 1) / maxMsgSize_;
+  int expectedMsgCnt = (totalLen + maxMsgSize_ - 1) / maxMsgSize_;
 
   sendTracker_.add(
       ActiveVirtualWr{
@@ -445,14 +476,17 @@ inline folly::Expected<folly::Unit, Error> IbvVirtualQp::postSend(
           .remainingMsgCnt = needsNotify ? expectedMsgCnt + 1 : expectedMsgCnt,
           .aggregatedStatus = IBV_WC_SUCCESS,
           .localAddr = wr.localAddr,
-          .length = wr.length,
+          .length = static_cast<uint32_t>(totalLen),
           .remoteAddr = wr.remoteAddr,
           .opcode = wr.opcode,
           .immData = wr.immData,
           .deviceKeys = wr.deviceKeys,
           .offset = 0,
           .needsNotify = needsNotify,
-          .notifyPosted = false});
+          .notifyPosted = false,
+          .sgBufs = wr.sgBufs,
+          .sgBufLens = wr.sgBufLens,
+          .perBufferDeviceKeys = wr.perBufferDeviceKeys});
 
   auto result = dispatchPendingSends();
   if (result.hasError()) {
@@ -663,25 +697,125 @@ inline folly::Expected<folly::Unit, Error> IbvVirtualQp::dispatchPendingSends(
       uint32_t fragLen = std::min(
           maxMsgSize_, static_cast<int>(pending->length - pending->offset));
 
-      auto [sendWr, sendSge] = buildPhysicalSendWr(*pending, deviceId, fragLen);
-      sendWr.sg_list = &sendSge;
-
       ibv_send_wr badWr{};
-      auto maybePost = physicalQps_.at(qpIdx).postSend(&sendWr, &badWr);
-      if (maybePost.hasError()) {
-        return folly::makeUnexpected(maybePost.error());
+
+      if (pending->isScatterGatherEnabled()) {
+        // Pack as many SG fragments as fit within `fragLen` (and within
+        // kMaxSgBuffersPerWr) into a single physical WR.
+        std::array<ibv_sge, kMaxSgBuffersPerWr> sgFragSges{};
+        auto [numSge, actualBytes] =
+            buildScatterGatherList(*pending, deviceId, fragLen, sgFragSges);
+        if (numSge == 0) {
+          // Defensive — shouldn't happen because pending->offset < length.
+          break;
+        }
+
+        ibv_send_wr sendWr{};
+        sendWr.wr_id = nextPhysicalWrId_++;
+        sendWr.next = nullptr;
+        sendWr.sg_list = sgFragSges.data();
+        sendWr.num_sge = numSge;
+        sendWr.send_flags = IBV_SEND_SIGNALED;
+        // rkey is for the DESTINATION buffer — always taken from the original
+        // WR's deviceKeys, never from perBufferDeviceKeys (which only carry
+        // source-side lkeys).
+        sendWr.wr.rdma.remote_addr = pending->remoteAddr + pending->offset;
+        sendWr.wr.rdma.rkey = pending->deviceKeys.at(deviceId).rkey;
+
+        if (pending->opcode == IBV_WR_RDMA_WRITE_WITH_IMM &&
+            loadBalancingScheme_ == LoadBalancingScheme::SPRAY) {
+          sendWr.opcode = IBV_WR_RDMA_WRITE;
+        } else {
+          sendWr.opcode = pending->opcode;
+          if (loadBalancingScheme_ == LoadBalancingScheme::DQPLB) {
+            bool isLastFragment =
+                (pending->offset + actualBytes >= pending->length);
+            sendWr.imm_data = dqplbSeqTracker_.getSendImm(isLastFragment);
+          }
+        }
+
+        auto maybePost = physicalQps_.at(qpIdx).postSend(&sendWr, &badWr);
+        if (maybePost.hasError()) {
+          return folly::makeUnexpected(maybePost.error());
+        }
+        physicalQps_.at(qpIdx).physicalSendWrStatus_.emplace_back(
+            sendWr.wr_id, internalId);
+        pending->offset += actualBytes;
+      } else {
+        auto [sendWr, sendSge] =
+            buildPhysicalSendWr(*pending, deviceId, fragLen);
+        sendWr.sg_list = &sendSge;
+
+        auto maybePost = physicalQps_.at(qpIdx).postSend(&sendWr, &badWr);
+        if (maybePost.hasError()) {
+          return folly::makeUnexpected(maybePost.error());
+        }
+
+        physicalQps_.at(qpIdx).physicalSendWrStatus_.emplace_back(
+            sendWr.wr_id, internalId);
+
+        pending->offset += fragLen;
       }
-
-      physicalQps_.at(qpIdx).physicalSendWrStatus_.emplace_back(
-          sendWr.wr_id, internalId);
-
-      pending->offset += fragLen;
     }
 
     sendTracker_.popPendingPost();
   }
 
   return folly::unit;
+}
+
+inline std::pair<int, uint64_t> IbvVirtualQp::buildScatterGatherList(
+    const ActiveVirtualWr& pending,
+    int32_t deviceId,
+    uint64_t maxBytesToSend,
+    std::array<ibv_sge, kMaxSgBuffersPerWr>& outSges) {
+  int numSge = 0;
+  uint64_t remainingToSend = maxBytesToSend;
+  uint64_t cumulative = 0;
+  uint64_t currentOffset = pending.offset;
+  uint64_t actualBytes = 0;
+
+  // Look up the lkey for `bufIdx` on `deviceId`, falling back to deviceKeys.
+  auto lookupLkey = [&](size_t bufIdx) -> uint32_t {
+    if (pending.perBufferDeviceKeys.has_value() &&
+        bufIdx < pending.perBufferDeviceKeys->size()) {
+      const auto& bufKeys = (*pending.perBufferDeviceKeys)[bufIdx];
+      auto it = bufKeys.deviceIdToKeys.find(deviceId);
+      if (it != bufKeys.deviceIdToKeys.end()) {
+        return it->second.lkey;
+      }
+    }
+    return pending.deviceKeys.at(deviceId).lkey;
+  };
+
+  for (size_t bufIdx = 0; bufIdx < pending.sgBufs.size() &&
+       remainingToSend > 0 && numSge < kMaxSgBuffersPerWr;
+       ++bufIdx) {
+    uint64_t bufLen = pending.sgBufLens[bufIdx];
+
+    // Skip buffers entirely consumed by previous fragments.
+    if (currentOffset >= cumulative + bufLen) {
+      cumulative += bufLen;
+      continue;
+    }
+
+    uint64_t bufStartOffset =
+        currentOffset > cumulative ? currentOffset - cumulative : 0;
+    uint64_t bufRemaining = bufLen - bufStartOffset;
+    uint64_t bufToSend = std::min(bufRemaining, remainingToSend);
+
+    outSges[numSge].addr =
+        reinterpret_cast<uint64_t>(pending.sgBufs[bufIdx]) + bufStartOffset;
+    outSges[numSge].length = static_cast<uint32_t>(bufToSend);
+    outSges[numSge].lkey = lookupLkey(bufIdx);
+
+    remainingToSend -= bufToSend;
+    actualBytes += bufToSend;
+    cumulative += bufLen;
+    ++numSge;
+  }
+
+  return {numSge, actualBytes};
 }
 
 inline std::pair<ibv_send_wr, ibv_sge> IbvVirtualQp::buildPhysicalSendWr(

--- a/comms/ctran/ibverbx/IbvVirtualWr.h
+++ b/comms/ctran/ibverbx/IbvVirtualWr.h
@@ -3,6 +3,8 @@
 #pragma once
 
 #include <deque>
+#include <optional>
+#include <tuple>
 #include <vector>
 
 #include <folly/container/F14Map.h>
@@ -17,6 +19,18 @@ struct MemoryRegionKeys {
 };
 
 // ============================================================
+// Scatter-gather support
+// ============================================================
+
+// Per-buffer device-specific keys for scatter-gather operations.
+// One entry per SG buffer; each entry maps deviceId -> {lkey, rkey} so the
+// SG fragment builder can pick the correct per-NIC keys when fragmenting a
+// multi-buffer payload across the underlying physical QPs.
+struct ScatterGatherBufferKeys {
+  folly::F14FastMap<int32_t, MemoryRegionKeys> deviceIdToKeys;
+};
+
+// ============================================================
 // IbvVirtualSendWr/IbvVirtualRecvWr (input to VirtualQp::postSend/Recv)
 // ============================================================
 
@@ -25,7 +39,8 @@ struct MemoryRegionKeys {
 struct IbvVirtualSendWr {
   uint64_t wrId{0}; // User's work request ID
 
-  // Local buffer
+  // Local buffer (used when the WR is *not* in scatter-gather mode, i.e.
+  // sgBufs.empty()).
   void* localAddr{nullptr}; // Local buffer address
   uint32_t length{0}; // Buffer length
 
@@ -44,7 +59,36 @@ struct IbvVirtualSendWr {
 
   // Per-device memory keys: maps deviceId -> {lkey, rkey}.
   // Mandatory field: 1 entry for single-NIC, N entries for multi-NIC.
+  // Used for non-SG WRs and as a fallback for SG WRs whose
+  // perBufferDeviceKeys is unset.
   folly::F14FastMap<int32_t, MemoryRegionKeys> deviceKeys;
+
+  // Optional scatter-gather payload. When sgBufs is non-empty the WR is
+  // treated as a multi-buffer SG send and (localAddr, length) are ignored;
+  // the fragment builder walks sgBufs/sgBufLens instead.
+  std::vector<void*> sgBufs;
+  std::vector<size_t> sgBufLens;
+  // Optional per-buffer device keys for SG WRs. If unset, the SG fragment
+  // builder falls back to deviceKeys for every buffer.
+  std::optional<std::vector<ScatterGatherBufferKeys>> perBufferDeviceKeys;
+
+  // Helper: true iff this WR carries SG buffers.
+  bool isScatterGatherEnabled() const {
+    return !sgBufs.empty();
+  }
+
+  // Helper: total payload length across the SG buffers (or single-buffer
+  // length when SG is not in use).
+  uint64_t getTotalLength() const {
+    if (!isScatterGatherEnabled()) {
+      return length;
+    }
+    uint64_t total = 0;
+    for (auto bufLen : sgBufLens) {
+      total += bufLen;
+    }
+    return total;
+  }
 };
 
 // Custom recv work request (replaces ibv_recv_wr in IbvVirtualQp::postRecv
@@ -107,6 +151,12 @@ struct ActiveVirtualWr {
   bool needsNotify{false}; // True if this WR requires a notify (SPRAY mode)
   bool notifyPosted{false}; // True after notify has been posted to notifyQp
 
+  // ---- Scatter-gather state (cached from IbvVirtualSendWr) ----
+  // Empty unless the originating WR carried SG buffers.
+  std::vector<void*> sgBufs;
+  std::vector<size_t> sgBufLens;
+  std::optional<std::vector<ScatterGatherBufferKeys>> perBufferDeviceKeys;
+
   // Helper: check if WR is fully complete
   bool isComplete() const {
     return remainingMsgCnt == 0;
@@ -118,6 +168,44 @@ struct ActiveVirtualWr {
         opcode == IBV_WR_RDMA_WRITE_WITH_IMM || opcode == IBV_WR_RDMA_READ ||
         opcode == IBV_WR_ATOMIC_FETCH_AND_ADD ||
         opcode == IBV_WR_ATOMIC_CMP_AND_SWP;
+  }
+
+  // Helper: true iff this active WR has SG buffers.
+  bool isScatterGatherEnabled() const {
+    return !sgBufs.empty();
+  }
+
+  // Helper: total byte length across SG buffers (falls back to `length`).
+  uint64_t getTotalLength() const {
+    if (!isScatterGatherEnabled()) {
+      return length;
+    }
+    uint64_t total = 0;
+    for (auto bufLen : sgBufLens) {
+      total += bufLen;
+    }
+    return total;
+  }
+
+  // Helper: given the current `offset` (bytes already sent across the SG
+  // payload), return the (bufferIndex, offsetWithinBuffer, remainingInBuffer)
+  // that the next physical fragment should start from.
+  // Returns {-1, 0, 0} when offset is beyond the whole payload, or when SG
+  // is not enabled.
+  std::tuple<int, uint64_t, uint64_t> getCurrentBufferPosition() const {
+    if (!isScatterGatherEnabled()) {
+      return {-1, 0, 0};
+    }
+    uint64_t cumulative = 0;
+    for (size_t i = 0; i < sgBufs.size(); ++i) {
+      uint64_t bufLen = sgBufLens[i];
+      if (static_cast<uint64_t>(offset) < cumulative + bufLen) {
+        uint64_t bufferOffset = static_cast<uint64_t>(offset) - cumulative;
+        return {static_cast<int>(i), bufferOffset, bufLen - bufferOffset};
+      }
+      cumulative += bufLen;
+    }
+    return {-1, 0, 0};
   }
 };
 

--- a/comms/ctran/ibverbx/tests/IbverbxDistributedVirtualQpTestSG.cc
+++ b/comms/ctran/ibverbx/tests/IbverbxDistributedVirtualQpTestSG.cc
@@ -1,0 +1,688 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <folly/init/Init.h>
+#include <folly/logging/Init.h>
+#include <gtest/gtest.h>
+#include <numeric>
+
+#include "comms/ctran/ibverbx/Ibverbx.h"
+#include "comms/testinfra/mpi/MpiTestUtils.h"
+#include "comms/utils/checks.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+
+using namespace ibverbx;
+using namespace meta::comms;
+
+FOLLY_INIT_LOGGING_CONFIG(
+    ".=WARNING"
+    ";default:async=true,sync_level=WARNING");
+
+namespace {
+// use broadcom nic for AMD platform, use mellanox nic for NV platform
+#if defined(__HIP_PLATFORM_AMD__) && !defined(USE_FE_NIC)
+const std::string kNicPrefix("bnxt_re");
+#else
+const std::string kNicPrefix("mlx5_");
+#endif
+
+constexpr uint8_t kPortNum = 1;
+
+#if defined(USE_FE_NIC)
+constexpr int kGidIndex = 1;
+#else
+constexpr int kGidIndex = 3;
+#endif
+
+// Number of scatter-gather buffers for all tests
+constexpr int kNumSgBuffers = 4;
+
+struct BusinessCard {
+  enum ibv_mtu mtu { IBV_MTU_4096 };
+  uint32_t qpNum{0};
+  uint8_t port{0};
+  uint64_t subnetPrefix{0};
+  uint64_t interfaceId{0};
+  int32_t rank{-1};
+  // following fields are for RDMA_WRITE
+  uint64_t remoteAddr{0};
+  uint32_t rkey{0};
+};
+
+std::ostream& operator<<(std::ostream& out, BusinessCard const& card) {
+  out << fmt::format(
+      "<rank {} qp-num {}, port {}, gid {:x}/{:x} remoteAddr {:x}, rkey {:x}>",
+      card.rank,
+      card.qpNum,
+      card.port,
+      card.subnetPrefix,
+      card.interfaceId,
+      card.remoteAddr,
+      card.rkey);
+  return out;
+}
+
+// helper functions
+ibv_qp_init_attr makeIbvQpInitAttr(ibv_cq* cq) {
+  ibv_qp_init_attr initAttr{};
+  memset(&initAttr, 0, sizeof(ibv_qp_init_attr));
+  initAttr.send_cq = cq;
+  initAttr.recv_cq = cq;
+  initAttr.qp_type = IBV_QPT_RC; // Reliable Connection
+  initAttr.sq_sig_all = 0;
+  initAttr.cap.max_send_wr = 1024; // maximum outstanding send WRs
+  initAttr.cap.max_recv_wr = 1024; // maximum outstanding recv WRs
+  initAttr.cap.max_send_sge = kNumSgBuffers; // support scatter-gather
+  initAttr.cap.max_recv_sge = 1;
+  initAttr.cap.max_inline_data = 0;
+  return initAttr;
+}
+
+ibv_qp_attr makeQpAttrInit(const BusinessCard& localCard) {
+  ibv_qp_attr qpAttr = {
+      .qp_state = IBV_QPS_INIT,
+      .qp_access_flags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ |
+          IBV_ACCESS_REMOTE_ATOMIC | IBV_ACCESS_REMOTE_WRITE,
+      .pkey_index = 0,
+      .port_num = localCard.port,
+  };
+  return qpAttr;
+}
+
+ibv_qp_attr makeQpAttrRtr(const BusinessCard& remoteCard) {
+  // The Service Level to be used
+  uint8_t kServiceLevel = 0;
+  int kTrafficClass = 0;
+
+  ibv_qp_attr qpAttr{};
+  memset(&qpAttr, 0, sizeof(struct ibv_qp_attr));
+
+  qpAttr.qp_state = IBV_QPS_RTR;
+  qpAttr.path_mtu = remoteCard.mtu;
+  qpAttr.dest_qp_num = remoteCard.qpNum;
+  qpAttr.rq_psn = 0;
+  qpAttr.max_dest_rd_atomic = 1;
+  qpAttr.min_rnr_timer = 12;
+
+  // assume IBV_LINK_LAYER_ETHERNET
+  qpAttr.ah_attr.is_global = 1;
+  qpAttr.ah_attr.grh.dgid.global.subnet_prefix = remoteCard.subnetPrefix;
+  qpAttr.ah_attr.grh.dgid.global.interface_id = remoteCard.interfaceId;
+  qpAttr.ah_attr.grh.flow_label = 0;
+  qpAttr.ah_attr.grh.sgid_index = kGidIndex;
+  qpAttr.ah_attr.grh.hop_limit = 255;
+  qpAttr.ah_attr.grh.traffic_class = kTrafficClass;
+  qpAttr.ah_attr.sl = kServiceLevel;
+  qpAttr.ah_attr.src_path_bits = 0;
+  qpAttr.ah_attr.port_num = remoteCard.port;
+  return qpAttr;
+}
+
+ibv_qp_attr makeQpAttrRts() {
+  // 4us x 2^20 = 4s
+  const uint8_t kTimeout = 20;
+  const uint8_t kRetryCnt = 1;
+
+  struct ibv_qp_attr qpAttr{};
+  memset(&qpAttr, 0, sizeof(struct ibv_qp_attr));
+
+  qpAttr.qp_state = IBV_QPS_RTS;
+  qpAttr.timeout = kTimeout;
+  qpAttr.retry_cnt = kRetryCnt;
+
+  // The value 7 is special and specify to retry infinite times in case of RNR
+  qpAttr.rnr_retry = 7;
+  qpAttr.sq_psn = 0;
+  qpAttr.max_rd_atomic = 1;
+  return qpAttr;
+}
+
+void changeVirtualQpStateToRts(
+    IbvVirtualQp& virtualQp,
+    const BusinessCard& localCard,
+    const BusinessCard& remoteCard,
+    const IbvVirtualQpBusinessCard& remoteVirtualQpBusinessCard) {
+  {
+    // change QP group state to INIT
+    auto qpAttr = makeQpAttrInit(localCard);
+    ASSERT_TRUE(virtualQp.modifyVirtualQp(
+        &qpAttr,
+        IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_ACCESS_FLAGS));
+  }
+  {
+    // change QP group state to RTR
+    auto qpAttr = makeQpAttrRtr(remoteCard);
+    ASSERT_TRUE(virtualQp.modifyVirtualQp(
+        &qpAttr,
+        IBV_QP_STATE | IBV_QP_AV | IBV_QP_PATH_MTU | IBV_QP_DEST_QPN |
+            IBV_QP_RQ_PSN | IBV_QP_MAX_DEST_RD_ATOMIC | IBV_QP_MIN_RNR_TIMER,
+        remoteVirtualQpBusinessCard));
+  }
+  {
+    // change QP group state to RTS
+    auto qpAttr = makeQpAttrRts();
+    ASSERT_TRUE(virtualQp.modifyVirtualQp(
+        &qpAttr,
+        IBV_QP_STATE | IBV_QP_TIMEOUT | IBV_QP_RETRY_CNT | IBV_QP_RNR_RETRY |
+            IBV_QP_SQ_PSN | IBV_QP_MAX_QP_RD_ATOMIC));
+  }
+}
+
+} // namespace
+
+class IbverbxVirtualQpSGTestFixture : public MpiBaseTestFixture {
+ protected:
+  void SetUp() override {
+    MpiBaseTestFixture::SetUp();
+    ncclCvarInit();
+    ASSERT_TRUE(ibvInit());
+  }
+
+  // Setup structure to hold all initialized resources for scatter-gather tests
+  struct VirtualQpSGSetup {
+    std::vector<IbvDevice> devices;
+    IbvPd pd;
+    IbvVirtualCq virtualCq;
+    IbvVirtualQp virtualQp;
+    // Receiver's single destination buffer
+    void* devBufRecv;
+    size_t devBufRecvSize;
+    IbvMr mrRecv;
+    // Sender's 4 scatter-gather source buffers
+    std::array<void*, kNumSgBuffers> sgDevBufs;
+    size_t sgBufSize; // Size of each SG buffer
+    std::vector<IbvMr> sgMrs;
+    BusinessCard localCard;
+    BusinessCard remoteCard;
+    IbvVirtualQpBusinessCard remoteVirtualQpBusinessCard;
+  };
+
+  // Common setup function for scatter-gather tests
+  // perBufferSize: size of each of the 4 scatter-gather buffers
+  template <typename T>
+  VirtualQpSGSetup setupVirtualQpSG(
+      int perBufferSize,
+      int numQp,
+      int maxMsgPerQp = -1,
+      int maxMsgBytes = -1,
+      LoadBalancingScheme loadBalancingScheme = LoadBalancingScheme::SPRAY) {
+    CUDA_CHECK(cudaSetDevice(localRank));
+
+    int myDevId{-1};
+    CUDA_CHECK(cudaGetDevice(&myDevId));
+
+    // get device
+    auto maybeDevices =
+        IbvDevice::ibvGetDeviceList(NCCL_IB_HCA, NCCL_IB_HCA_PREFIX);
+    EXPECT_TRUE(maybeDevices);
+    auto devices = std::move(*maybeDevices);
+    auto& device = devices.at(myDevId);
+    auto maybePd = device.allocPd();
+    EXPECT_TRUE(maybePd);
+    auto pd = std::move(*maybePd);
+
+    // make cq
+    int cqe = 2 * numQp * maxMsgPerQp;
+    auto maybeVirtualCq = device.createVirtualCq(cqe, nullptr, nullptr, 0);
+    EXPECT_TRUE(maybeVirtualCq);
+    EXPECT_NE(maybeVirtualCq->getPhysicalCqsRef().at(0).cq(), nullptr);
+    auto virtualCq = std::move(*maybeVirtualCq);
+
+    // make qp group
+    uint32_t totalQps = numQp;
+    auto initAttr = makeIbvQpInitAttr(virtualCq.getPhysicalCqsRef().at(0).cq());
+    auto maybeVirtualQp = pd.createVirtualQp(
+        totalQps,
+        &initAttr,
+        &virtualCq,
+        maxMsgPerQp,
+        maxMsgBytes,
+        loadBalancingScheme);
+    EXPECT_TRUE(maybeVirtualQp);
+    auto virtualQp = std::move(*maybeVirtualQp);
+
+    // Total size for receiver = 4 * perBufferSize
+    size_t totalRecvSize = kNumSgBuffers * perBufferSize;
+    size_t numElementsPerBuf = perBufferSize / sizeof(T);
+
+    // init device buffers
+    void* devBufRecv{nullptr};
+    CUDA_CHECK(cudaMalloc(&devBufRecv, totalRecvSize));
+
+    std::array<void*, kNumSgBuffers> sgDevBufs{};
+    std::vector<IbvMr> sgMrs;
+
+    ibv_access_flags access = static_cast<ibv_access_flags>(
+        IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE |
+        IBV_ACCESS_REMOTE_READ);
+
+    if (globalRank == 0) {
+      // receiver: fill destination buffer with 0s
+      CUDA_CHECK(cudaMemset(devBufRecv, 0, totalRecvSize));
+    } else if (globalRank == 1) {
+      // sender: allocate and initialize 4 scatter-gather buffers
+      for (int i = 0; i < kNumSgBuffers; ++i) {
+        CUDA_CHECK(cudaMalloc(&sgDevBufs[i], perBufferSize));
+
+        // Initialize each buffer with sequential values starting from
+        // i*numElementsPerBuf + 1
+        std::vector<T> hostBuf(numElementsPerBuf);
+        if constexpr (std::is_integral_v<T>) {
+          std::iota(
+              hostBuf.begin(),
+              hostBuf.end(),
+              static_cast<T>(i * numElementsPerBuf + 1));
+        } else {
+          T val = static_cast<T>(i * numElementsPerBuf + 1);
+          for (auto& elem : hostBuf) {
+            elem = val;
+            val += T(1);
+          }
+        }
+        CUDA_CHECK(cudaMemcpy(
+            sgDevBufs[i], hostBuf.data(), perBufferSize, cudaMemcpyDefault));
+
+        // register memory for each SG buffer
+        auto maybeMr = pd.regMr(sgDevBufs[i], perBufferSize, access);
+        EXPECT_TRUE(maybeMr);
+        sgMrs.push_back(std::move(*maybeMr));
+      }
+    }
+    CUDA_CHECK(cudaDeviceSynchronize());
+
+    // register memory region for receiver
+    auto maybeMrRecv = pd.regMr(devBufRecv, totalRecvSize, access);
+    EXPECT_TRUE(maybeMrRecv);
+    auto mrRecv = std::move(*maybeMrRecv);
+
+    // create local business card and exchange
+    auto gid = device.queryGid(kPortNum, kGidIndex);
+    EXPECT_TRUE(gid);
+
+    BusinessCard localCard = {
+        .mtu = IBV_MTU_4096,
+        .port = kPortNum,
+        .subnetPrefix = gid->global.subnet_prefix,
+        .interfaceId = gid->global.interface_id,
+        .rank = globalRank,
+        .remoteAddr = reinterpret_cast<uint64_t>(devBufRecv),
+        .rkey = mrRecv.mr()->rkey,
+    };
+    std::vector<BusinessCard> cards(numRanks);
+    MPI_CHECK(MPI_Allgather(
+        &localCard,
+        sizeof(BusinessCard),
+        MPI_BYTE,
+        cards.data(),
+        sizeof(BusinessCard),
+        MPI_BYTE,
+        MPI_COMM_WORLD));
+    for (int i = 0; i < numRanks; ++i) {
+      const auto& card = cards.at(i);
+      XLOG(DBG1) << "rank " << globalRank << ": got card " << card;
+    }
+    const auto& remoteCard = globalRank == 0 ? cards.at(1) : cards.at(0);
+
+    // Get the business card and serialize it to JSON
+    std::string serializedCard =
+        virtualQp.getVirtualQpBusinessCard().serialize();
+
+    // Since all hosts have the same number of QPs, the serialized string size
+    // should be consistent Use the local string size directly
+    size_t bufferSize = serializedCard.size();
+
+    // Gather all serialized cards
+    std::vector<char> allSerializedCards(bufferSize * numRanks);
+    MPI_CHECK(MPI_Allgather(
+        serializedCard.data(),
+        bufferSize,
+        MPI_CHAR,
+        allSerializedCards.data(),
+        bufferSize,
+        MPI_CHAR,
+        MPI_COMM_WORLD));
+
+    // Extract remote card's serialized string
+    std::string remoteSerializedCard(
+        allSerializedCards.data() + (globalRank == 0 ? bufferSize : 0),
+        bufferSize);
+
+    auto maybeRemoteVirtualQpBusinessCard =
+        IbvVirtualQpBusinessCard::deserialize(remoteSerializedCard);
+    EXPECT_TRUE(maybeRemoteVirtualQpBusinessCard);
+    auto remoteVirtualQpBusinessCard =
+        std::move(*maybeRemoteVirtualQpBusinessCard);
+
+    // init qp group
+    changeVirtualQpStateToRts(
+        virtualQp, localCard, remoteCard, remoteVirtualQpBusinessCard);
+
+    return VirtualQpSGSetup{
+        .devices = std::move(devices),
+        .pd = std::move(pd),
+        .virtualCq = std::move(virtualCq),
+        .virtualQp = std::move(virtualQp),
+        .devBufRecv = devBufRecv,
+        .devBufRecvSize = totalRecvSize,
+        .mrRecv = std::move(mrRecv),
+        .sgDevBufs = sgDevBufs,
+        .sgBufSize = static_cast<size_t>(perBufferSize),
+        .sgMrs = std::move(sgMrs),
+        .localCard = localCard,
+        .remoteCard = remoteCard,
+        .remoteVirtualQpBusinessCard = std::move(remoteVirtualQpBusinessCard),
+    };
+  }
+};
+
+// Enum for different data types
+enum class DataType { INT8, INT16, INT32, INT64, FLOAT, DOUBLE };
+
+// Helper function to convert DataType enum to string
+std::string dataTypeToString(DataType dataType) {
+  switch (dataType) {
+    case DataType::INT8:
+      return "INT8";
+    case DataType::INT16:
+      return "INT16";
+    case DataType::INT32:
+      return "INT32";
+    case DataType::INT64:
+      return "INT64";
+    case DataType::FLOAT:
+      return "FLOAT";
+    case DataType::DOUBLE:
+      return "DOUBLE";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+// Helper function to get size of data type enum
+size_t getDataTypeSize(DataType dataType) {
+  switch (dataType) {
+    case DataType::INT8:
+      return sizeof(int8_t);
+    case DataType::INT16:
+      return sizeof(int16_t);
+    case DataType::INT32:
+      return sizeof(int32_t);
+    case DataType::INT64:
+      return sizeof(int64_t);
+    case DataType::FLOAT:
+      return sizeof(float);
+    case DataType::DOUBLE:
+      return sizeof(double);
+    default:
+      return sizeof(int64_t);
+  }
+}
+
+// Parameterized test class for virtual QP scatter-gather RDMA write tests
+class IbverbxVirtualQpRdmaWriteSGTestFixture
+    : public IbverbxVirtualQpSGTestFixture,
+      public ::testing::WithParamInterface<
+          std::tuple<int, DataType, int, int, int, LoadBalancingScheme>> {
+ public:
+  // Parameterized test name generator function
+  static std::string getTestName(
+      const testing::TestParamInfo<ParamType>& info) {
+    std::string baseName = fmt::format(
+        "{}_perBufSize_{}_dataType_{}_numQp_",
+        std::get<0>(info.param),
+        dataTypeToString(std::get<1>(info.param)),
+        std::get<2>(info.param));
+
+    // Always include both maxMsgPerQp and maxMsgBytes values to avoid
+    // duplicates
+    std::string maxMsgPerQpStr = std::get<3>(info.param) > 0
+        ? std::to_string(std::get<3>(info.param))
+        : "nolimit";
+    std::string maxMsgBytesStr = std::get<4>(info.param) > 0
+        ? std::to_string(std::get<4>(info.param))
+        : "nolimit";
+
+    std::string loadBalancingStr =
+        std::get<5>(info.param) == LoadBalancingScheme::DQPLB ? "DQPLB"
+                                                              : "SPRAY";
+
+    baseName += fmt::format(
+        "{}_maxMsgPerQp_{}_maxMsgBytes_{}_scheme",
+        maxMsgPerQpStr,
+        maxMsgBytesStr,
+        loadBalancingStr);
+    return baseName;
+  }
+
+ protected:
+  void SetUp() override {
+    IbverbxVirtualQpSGTestFixture::SetUp();
+  }
+
+  // Helper template function to run scatter-gather RDMA write test
+  template <typename T>
+  void runRdmaWriteSGTest(
+      int perBufferSize,
+      int numQp,
+      int maxMsgPerQp = -1,
+      int maxMsgBytes = -1,
+      LoadBalancingScheme loadBalancingScheme = LoadBalancingScheme::SPRAY);
+};
+
+// Template helper function implementation for Virtual QP Scatter-Gather RDMA
+// Write
+template <typename T>
+void IbverbxVirtualQpRdmaWriteSGTestFixture::runRdmaWriteSGTest(
+    int perBufferSize,
+    int numQp,
+    int maxMsgPerQp,
+    int maxMsgBytes,
+    LoadBalancingScheme loadBalancingScheme) {
+  // Use common setup function to initialize IB resources with 4 SG buffers
+  auto setup = setupVirtualQpSG<T>(
+      perBufferSize, numQp, maxMsgPerQp, maxMsgBytes, loadBalancingScheme);
+
+  // post send/recv and poll cq
+  int wr_id = 0;
+  int imm_data = 16384;
+  if (globalRank == 0) {
+    // receiver - post a dummy recv as this is one-sided comm
+    IbvVirtualRecvWr recvWr;
+    recvWr.wrId = wr_id;
+    ASSERT_TRUE(setup.virtualQp.postRecv(recvWr));
+  } else if (globalRank == 1) {
+    // sender - use typed postSend with scatter-gather buffers carried inside
+    // IbvVirtualSendWr (sgBufs/sgBufLens). For a single-NIC test we don't
+    // need perBufferDeviceKeys; the SG fragment builder will fall back to
+    // sendWr.deviceKeys for every buffer.
+    IbvVirtualSendWr sendWr;
+    sendWr.wrId = wr_id;
+    sendWr.remoteAddr = setup.remoteCard.remoteAddr;
+    sendWr.opcode = IBV_WR_RDMA_WRITE_WITH_IMM;
+    sendWr.sendFlags = IBV_SEND_SIGNALED;
+    sendWr.immData = imm_data;
+
+    // Scatter-gather buffers
+    sendWr.sgBufs.reserve(kNumSgBuffers);
+    sendWr.sgBufLens.reserve(kNumSgBuffers);
+    for (int i = 0; i < kNumSgBuffers; ++i) {
+      sendWr.sgBufs.push_back(setup.sgDevBufs[i]);
+      sendWr.sgBufLens.push_back(setup.sgBufSize);
+    }
+
+    int32_t deviceId = setup.virtualQp.getQpsRef().at(0).getDeviceId();
+    // For single-NIC: provide one fallback deviceKeys entry for rkey
+    // (destination) and per-buffer source lkeys via perBufferDeviceKeys.
+    sendWr.deviceKeys[deviceId] = MemoryRegionKeys{
+        .lkey = setup.sgMrs[0].mr()->lkey, .rkey = setup.remoteCard.rkey};
+
+    std::vector<ScatterGatherBufferKeys> perBufferKeys(kNumSgBuffers);
+    for (int i = 0; i < kNumSgBuffers; ++i) {
+      perBufferKeys[i].deviceIdToKeys[deviceId] = MemoryRegionKeys{
+          .lkey = setup.sgMrs[i].mr()->lkey, .rkey = setup.remoteCard.rkey};
+    }
+    sendWr.perBufferDeviceKeys = std::move(perBufferKeys);
+
+    ASSERT_TRUE(setup.virtualQp.postSend(sendWr));
+  }
+
+  // poll cq and check cq
+  bool stop = false;
+  while (!stop) {
+    auto maybeWcsVector = setup.virtualCq.pollCq();
+    ASSERT_TRUE(maybeWcsVector);
+    auto numWc = maybeWcsVector->size();
+    ASSERT_GE(numWc, 0);
+    if (numWc == 0) {
+      // CQ empty, sleep and retry
+      XLOGF(WARN, "rank {}: cq empty, retry in 500ms", globalRank);
+      /* sleep override */
+      std::this_thread::sleep_for(std::chrono::milliseconds(500));
+      continue;
+    }
+
+    ASSERT_EQ(numWc, 1);
+
+    // got a WC
+    const auto wc = maybeWcsVector->at(0);
+    ASSERT_EQ(wc.wrId, wr_id);
+    ASSERT_EQ(wc.status, IBV_WC_SUCCESS);
+    // NOTE: IbvVirtualWc does not propagate immData from physical
+    // completions. The IMM field is consumed internally by the VirtualQp
+    // layer (SPRAY uses it for notify signaling, DQPLB uses it for sequence
+    // tracking). User-level immData is not forwarded through the virtual
+    // completion path.
+    XLOGF(DBG1, "Rank {} got a wc: wr_id {}", globalRank, wc.wrId);
+    stop = true;
+  }
+
+  // receiver check data
+  if (globalRank == 0) {
+    // check data - receiver should have received all 4 buffers concatenated
+    size_t totalElements = setup.devBufRecvSize / sizeof(T);
+    std::vector<T> hostExpectedBuf(totalElements);
+    if constexpr (std::is_integral_v<T>) {
+      std::iota(hostExpectedBuf.begin(), hostExpectedBuf.end(), T(1));
+    } else {
+      // For floating point types, use incremental values
+      T val = T(1);
+      for (auto& elem : hostExpectedBuf) {
+        elem = val;
+        val += T(1);
+      }
+    }
+
+    std::vector<T> hostRecvBuf(totalElements);
+    CUDA_CHECK(cudaMemcpy(
+        hostRecvBuf.data(),
+        setup.devBufRecv,
+        setup.devBufRecvSize,
+        cudaMemcpyDefault));
+    CUDA_CHECK(cudaDeviceSynchronize());
+    ASSERT_EQ(hostExpectedBuf, hostRecvBuf);
+  }
+  XLOGF(DBG1, "rank {} RDMA-WRITE with scatter-gather OK", globalRank);
+
+  // Clean up device buffers
+  CUDA_CHECK(cudaFree(setup.devBufRecv));
+  if (globalRank == 1) {
+    for (int i = 0; i < kNumSgBuffers; ++i) {
+      CUDA_CHECK(cudaFree(setup.sgDevBufs[i]));
+    }
+  }
+}
+
+// Scatter-Gather RDMA Write Virtual QP test using template helper
+TEST_P(IbverbxVirtualQpRdmaWriteSGTestFixture, RdmaWriteSGVirtualQpWithParam) {
+  const auto& [perBufSize, dataType, numQp, maxMsgPerQp, maxMsgBytes, loadBalancingScheme] =
+      GetParam();
+
+  // Dispatch to the appropriate template function based on data type
+  switch (dataType) {
+    case DataType::INT8:
+      runRdmaWriteSGTest<int8_t>(
+          perBufSize, numQp, maxMsgPerQp, maxMsgBytes, loadBalancingScheme);
+      break;
+    case DataType::INT16:
+      runRdmaWriteSGTest<int16_t>(
+          perBufSize, numQp, maxMsgPerQp, maxMsgBytes, loadBalancingScheme);
+      break;
+    case DataType::INT32:
+      runRdmaWriteSGTest<int32_t>(
+          perBufSize, numQp, maxMsgPerQp, maxMsgBytes, loadBalancingScheme);
+      break;
+    case DataType::INT64:
+      runRdmaWriteSGTest<int64_t>(
+          perBufSize, numQp, maxMsgPerQp, maxMsgBytes, loadBalancingScheme);
+      break;
+    case DataType::FLOAT:
+      runRdmaWriteSGTest<float>(
+          perBufSize, numQp, maxMsgPerQp, maxMsgBytes, loadBalancingScheme);
+      break;
+    case DataType::DOUBLE:
+      runRdmaWriteSGTest<double>(
+          perBufSize, numQp, maxMsgPerQp, maxMsgBytes, loadBalancingScheme);
+      break;
+  }
+}
+
+// Instantiate Scatter-Gather RDMA Write tests with different configurations
+// Small buffer configurations - 1KB and 8KB per SG buffer (4KB and 32KB total)
+INSTANTIATE_TEST_SUITE_P(
+    VirtualQpRdmaWriteSGTestSmallBuffer,
+    IbverbxVirtualQpRdmaWriteSGTestFixture,
+    ::testing::Combine(
+        testing::Values(1024, 8192), // Small per-buffer sizes: 1KB, 8KB
+        testing::Values(DataType::INT8, DataType::INT32, DataType::FLOAT),
+        testing::Values(1, 4), // QP numbers: 1, 4
+        testing::Values(64, 128), // maxMsgPerQp: 64, 128
+        testing::Values(128, 256), // maxMsgBytes: 128, 256
+        testing::Values(
+            LoadBalancingScheme::DQPLB,
+            LoadBalancingScheme::SPRAY)), // LoadBalancingScheme
+    IbverbxVirtualQpRdmaWriteSGTestFixture::getTestName);
+
+// Medium buffer configurations - 256KB and 1MB per SG buffer (1MB and 4MB
+// total)
+INSTANTIATE_TEST_SUITE_P(
+    VirtualQpRdmaWriteSGTestMediumBuffer,
+    IbverbxVirtualQpRdmaWriteSGTestFixture,
+    ::testing::Combine(
+        testing::Values(
+            262144,
+            1048576), // Medium per-buffer sizes: 256KB, 1MB
+        testing::Values(DataType::INT8, DataType::INT32, DataType::FLOAT),
+        testing::Values(16, 128), // QP numbers: 16, 128
+        testing::Values(128, 1024), // maxMsgPerQp: 128, 1024
+        testing::Values(1024, 16384), // maxMsgBytes: 1024, 16384
+        testing::Values(
+            LoadBalancingScheme::DQPLB,
+            LoadBalancingScheme::SPRAY)), // LoadBalancingScheme
+    IbverbxVirtualQpRdmaWriteSGTestFixture::getTestName);
+
+// Large buffer configurations - 256MB per SG buffer (1GB total)
+// Note: FLOAT is excluded from large buffer tests because single-precision
+// floats (32-bit) can only represent consecutive integers exactly up to 2^24
+// (16,777,216). With 256MB per buffer (67M+ floats), the total sequence exceeds
+// float precision limits, causing comparison failures.
+INSTANTIATE_TEST_SUITE_P(
+    VirtualQpRdmaWriteSGTestLargeBuffer,
+    IbverbxVirtualQpRdmaWriteSGTestFixture,
+    ::testing::Combine(
+        testing::Values(268435456), // Large per-buffer size: 256MB (1GB total)
+        testing::Values(DataType::INT8, DataType::INT32),
+        testing::Values(16, 128), // High QP number for maximum parallelism
+        testing::Values(128, 1024), // maxMsgPerQp: 128, 1024
+        testing::Values(16384, 1048576), // maxMsgBytes: 16KB, 1MB
+        testing::Values(
+            LoadBalancingScheme::DQPLB,
+            LoadBalancingScheme::SPRAY)), // LoadBalancingScheme
+    IbverbxVirtualQpRdmaWriteSGTestFixture::getTestName);
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new MPIEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Summary:

This diff adds comprehensive unit tests for the scatter-gather support in IbvVirtualQp, testing the `postSendScatterGather()` API with 4 input buffers of equal size.

**Key Test Details:**

1. **Test file** - Added `IbverbxDistributedVirtualQpTestSG.cc` modeled after the existing `IbverbxDistributedVirtualQpTest.cc`

2. **Scatter-gather configuration** - Always uses 4 source buffers (`kNumSgBuffers = 4`) of equal size per transfer

3. **Test methodology**:
   - Sender (rank 1): Allocates 4 separate GPU buffers initialized with sequential data
   - Receiver (rank 0): Allocates a single destination buffer of size `4 * perBufferSize`
   - Uses `postSendScatterGather()` API to send all 4 buffers in a single RDMA WRITE operation
   - Verifies data integrity by comparing received data against expected sequential values

4. **Parameterized test configurations**:
   - Data types: INT8, INT16, INT32, INT64, FLOAT, DOUBLE
   - Per-buffer sizes: Small (1KB, 8KB), Medium (256KB, 1MB), Large (256MB)
   - QP counts: 1, 4, 16, 128
   - Load balancing schemes: SPRAY and DQPLB

5. **Float precision handling** - FLOAT is excluded from large buffer tests (256MB per buffer) because single-precision floats can only represent consecutive integers exactly up to 2^24 (16,777,216). With 256MB per buffer (67M+ floats), the sequential comparison would fail due to precision limits. This is consistent with the existing `IbverbxDistributedVirtualQpTest.cc` which also uses only INT32 for 1GB tests.

Differential Revision: D90625416


