### PR TITLE
window based allgather direct prototype (#209)

### DIFF
--- a/comms/ctran/algos/AllGather/AllGather.cc
+++ b/comms/ctran/algos/AllGather/AllGather.cc
@@ -33,6 +33,10 @@ bool ctranAllGatherSupport(CtranComm* comm, enum NCCL_ALLGATHER_ALGO algo) {
     case NCCL_ALLGATHER_ALGO::ctran:
       supported = true;
       break;
+    case NCCL_ALLGATHER_ALGO::ctwindow:
+      // ctwindow requires a window parameter; use ctranAllGatherWindow directly
+      supported = false;
+      break;
     case NCCL_ALLGATHER_ALGO::orig: // invalid query
       supported = false;
       break;
@@ -78,6 +82,10 @@ commResult_t ctranAllGather(
     case NCCL_ALLGATHER_ALGO::ctrd:
       return ctranAllGatherRd(
           sendbuff, recvbuff, sendcount, datatype, comm, stream);
+
+    case NCCL_ALLGATHER_ALGO::ctwindow:
+      // ctwindow requires a window parameter; use ctranAllGatherWindow directly
+      [[fallthrough]];
     case NCCL_ALLGATHER_ALGO::ctdirect:
     default:
       return ctranAllGatherDirect(

--- a/comms/ctran/algos/RMA/AllGather/AllGatherWindow.cc
+++ b/comms/ctran/algos/RMA/AllGather/AllGatherWindow.cc
@@ -1,0 +1,247 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <memory>
+#include <vector>
+
+#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/algos/AllGather/AllGatherImpl.h"
+#include "comms/ctran/algos/CtranAlgo.h"
+#include "comms/ctran/algos/RMA/AllGather/AllGatherWindowTypes.h"
+#include "comms/ctran/gpe/CtranGpe.h"
+#include "comms/ctran/mapper/CtranMapper.h"
+#include "comms/ctran/window/CtranWin.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/logger/LogUtils.h"
+
+using namespace ctran;
+using namespace ctran::allgatherwindow;
+
+namespace ctran::allgatherwindow {
+extern __global__ void ncclKernelAllGatherWindowDirect(
+    int* flag,
+    CtranAlgoDeviceState* devState);
+} // namespace ctran::allgatherwindow
+
+namespace {
+
+/**
+ * Direct algorithm GPE function
+ *
+ * All-to-all PUT: each rank sends its data to all other ranks simultaneously.
+ * Uses mapper->iput() for data transfer and mapper->atomicSet() for signaling.
+ * Each peer is signaled immediately after its PUT completes.
+ *
+ * NVLink peers: Data already copied via nvlCeBcast in caller, synchronized by
+ *               kernel barrier.
+ * IB peers: PUT data via RDMA, signal completion, kernel waits for signals.
+ */
+commResult_t directGpeFn(
+    const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
+  struct OpElem* op = opGroup.front().get();
+  auto* gpeArgs =
+      reinterpret_cast<AllGatherWindowGpeArgs*>(op->allgatherWindow.args);
+  // Take ownership of heap-allocated args (freed when scope exits)
+  std::unique_ptr<AllGatherWindowGpeArgs> gpeArgsOwner(gpeArgs);
+  CtranWin* win = gpeArgs->win;
+  const size_t count = gpeArgs->count;
+  const commDataType_t datatype = gpeArgs->datatype;
+
+  CtranComm* comm = win->comm;
+  const auto statex = comm->statex_.get();
+  const int rank = statex->rank();
+  const size_t sendSize = count * commTypeSize(datatype);
+  const auto& ibPeers = win->ibPeers;
+
+  auto mapper = comm->ctran_->mapper.get();
+
+  CtranAlgoLogger logger("AllGatherWindowDirect", op->opCount, comm);
+
+  // If no IB peers, nothing to do in GPE - all handled by NVLink + kernel
+  if (ibPeers.empty()) {
+    return commSuccess;
+  }
+
+  // Use the window's pre-registered data handle (registered at window
+  // construction) instead of searching per request.
+  void* localMemHdl = win->dataRegHdl;
+
+  // Source is our slot in the recv buffer
+  const void* mySlot =
+      getPtr(win->winDataPtr, static_cast<size_t>(rank) * sendSize);
+
+  // Issue all PUT operations to precomputed IB peers
+  std::vector<CtranMapperRequest> putReqs(ibPeers.size());
+  for (size_t i = 0; i < ibPeers.size(); i++) {
+    const int peer = ibPeers[i];
+    void* dstPtr = getPtr(
+        win->remWinInfo[peer].dataAddr, static_cast<size_t>(rank) * sendSize);
+
+    FB_COMMCHECK(mapper->iput(
+        mySlot,
+        dstPtr,
+        sendSize,
+        peer,
+        CtranMapperConfig{
+            .memHdl_ = localMemHdl,
+            .remoteAccessKey_ = win->remWinInfo[peer].dataRkey,
+        },
+        &putReqs[i]));
+  }
+
+  // Wait for all PUTs to complete
+  FB_COMMCHECK(mapper->waitAllRequests(putReqs));
+
+  // Signal all peers that data has arrived
+  std::vector<CtranMapperRequest> signalReqs(ibPeers.size());
+  for (size_t i = 0; i < ibPeers.size(); i++) {
+    const int peer = ibPeers[i];
+    uint64_t signalVal = win->ctranNextSignalVal(peer);
+    uint64_t* signalAddr = win->remWinInfo[peer].signalAddr + rank;
+
+    FB_COMMCHECK(mapper->atomicSet(
+        signalAddr,
+        signalVal,
+        peer,
+        CtranMapperConfig{.remoteAccessKey_ = win->remWinInfo[peer].signalRkey},
+        &signalReqs[i]));
+  }
+
+  // Wait for all signals to complete
+  FB_COMMCHECK(mapper->waitAllRequests(signalReqs));
+
+  return commSuccess;
+}
+
+/**
+ * Intra-node NVLink broadcast helper
+ *
+ * Copies data from this rank's buffer to the same offset in all local peers'
+ * buffers. Uses NVLink CE copy for efficiency.
+ */
+commResult_t nvlCeBcast(
+    CtranComm* comm,
+    CtranWin* win,
+    const void* sendBuff,
+    const size_t sendSize,
+    const size_t recvOffset,
+    cudaStream_t stream) {
+  const auto statex = comm->statex_.get();
+  const auto nLocalRanks = statex->nLocalRanks();
+  const auto localRank = statex->localRank();
+
+  for (int i = 1; i < nLocalRanks; i++) {
+    const int localPeer = (localRank + i) % nLocalRanks;
+    const int globalPeer = statex->localRankToRank(localPeer);
+
+    // Skip peers without NVLink (e.g., IB-only mode)
+    if (!win->nvlEnabled(globalPeer)) {
+      continue;
+    }
+
+    // Copy to peer's window at the specified offset
+    void* dstPtr = getPtr(win->remWinInfo[globalPeer].dataAddr, recvOffset);
+    FB_CUDACHECK(cudaMemcpyAsync(
+        dstPtr, sendBuff, sendSize, cudaMemcpyDeviceToDevice, stream));
+  }
+
+  return commSuccess;
+}
+
+} // namespace
+
+/**
+ * Window-based AllGather using Direct algorithm
+ *
+ * All-to-all PUT: each rank sends its data to all other ranks simultaneously.
+ * IB peers: PUT via RDMA with atomic signaling.
+ * NVLink peers: CE copy with kernel barrier synchronization.
+ */
+commResult_t ctranAllGatherWindow(
+    const void* sendbuff,
+    size_t sendcount,
+    commDataType_t datatype,
+    CtranWin* win,
+    cudaStream_t stream) {
+  CtranComm* comm = win->comm;
+  auto ctran = comm->ctran_.get();
+  const auto statex = comm->statex_.get();
+  const int rank = statex->rank();
+  const int nRanks = statex->nRanks();
+  const size_t sendSize = sendcount * commTypeSize(datatype);
+  const auto opCount = ctran->getOpCount();
+
+  // The recv buffer is the window's data buffer
+  void* recvbuff = win->winDataPtr;
+
+  CLOGF_SUBSYS(
+      INFO,
+      COLL,
+      "ctranAllGatherWindow: sendbuff {} recvbuff {} sendcount {} "
+      "datatype {} win {} comm {} commHash {:x} [nranks={}, localRanks={}] "
+      "stream={}",
+      sendbuff,
+      recvbuff,
+      sendcount,
+      datatype,
+      (void*)win,
+      (void*)comm,
+      statex->commHash(),
+      nRanks,
+      statex->nLocalRanks(),
+      (void*)stream);
+
+  // Handle trivial case
+  if (nRanks == 1) {
+    char* mySlot = static_cast<char*>(recvbuff);
+    if (sendbuff != mySlot) {
+      FB_CUDACHECK(cudaMemcpyAsync(
+          mySlot, sendbuff, sendSize, cudaMemcpyDefault, stream));
+    }
+    return commSuccess;
+  }
+
+  // Copy local data to our slot in the recv buffer
+  char* mySlot = static_cast<char*>(recvbuff) + rank * sendSize;
+  if (sendbuff != mySlot) {
+    FB_CUDACHECK(
+        cudaMemcpyAsync(mySlot, sendbuff, sendSize, cudaMemcpyDefault, stream));
+  }
+
+  // Copy to local NVLink peers
+  FB_COMMCHECK(
+      nvlCeBcast(comm, win, mySlot, sendSize, rank * sendSize, stream));
+
+  // Prepare GPE args (heap-allocated, ownership transferred to GPE function)
+  auto* gpeArgs = new AllGatherWindowGpeArgs{
+      .win = win,
+      .count = sendcount,
+      .datatype = datatype,
+  };
+
+  // Create operation for GPE submission
+  auto op = std::make_unique<OpElem>(
+      OpElem::opType::ALLGATHERWINDOW, stream, comm, opCount);
+  op->allgatherWindow.args = gpeArgs;
+
+  std::vector<std::unique_ptr<struct OpElem>> opGroup;
+  opGroup.push_back(std::move(op));
+
+  // Kernel config
+  auto config = KernelConfig(
+      KernelConfig::KernelType::ALLGATHERWINDOW,
+      stream,
+      "AllGatherWindowDirect",
+      opCount);
+  config.numBlocks = 1;
+  config.numThreads = 1;
+  config.args.devState_d = ctran->algo->getDevState();
+
+  // Submit to GPE
+  FB_COMMCHECK(ctran->gpe->submit(
+      std::move(opGroup),
+      directGpeFn,
+      config,
+      reinterpret_cast<void*>(ncclKernelAllGatherWindowDirect)));
+
+  return commSuccess;
+}

--- a/comms/ctran/algos/RMA/AllGather/AllGatherWindow.cu
+++ b/comms/ctran/algos/RMA/AllGather/AllGatherWindow.cu
@@ -1,0 +1,37 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/ctran/algos/CtranAlgoDev.h"
+#include "comms/ctran/algos/DevCommon.cuh"
+#include "comms/ctran/algos/barrier.cuh"
+#include "comms/ctran/gpe/CtranGpeDev.h"
+
+namespace ctran::allgatherwindow {
+
+/**
+ * Direct algorithm kernel
+ *
+ * Starts GPE to do all-to-all PUT with atomic signaling, then waits for
+ * signals from all remote peers. Uses barrier for intra-node synchronization.
+ */
+__global__ void ncclKernelAllGatherWindowDirect(
+    int* flag,
+    CtranAlgoDeviceState* devState) {
+  if (flag) {
+    ctran::device::devLoadAbortFlags(flag, devState);
+    ctran::device::KernelStartGpe(flag);
+  }
+
+  devStateLoadToShm(devState);
+
+  const auto localRank = statex->localRank();
+  const auto nLocalRanks = statex->nLocalRanks();
+
+  // Ensure NVLink intra-node copies complete before proceeding
+  barrier(localRank, nLocalRanks);
+
+  if (flag) {
+    ctran::device::KernelWaitGpeTerminate(flag);
+  }
+}
+
+} // namespace ctran::allgatherwindow

--- a/comms/ctran/algos/RMA/AllGather/AllGatherWindowTypes.h
+++ b/comms/ctran/algos/RMA/AllGather/AllGatherWindowTypes.h
@@ -1,0 +1,22 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include "comms/ctran/window/CtranWin.h"
+
+namespace ctran::allgatherwindow {
+
+// Arguments passed to GPE function (heap-allocated, ownership transferred to
+// GPE function which frees it on completion)
+struct AllGatherWindowGpeArgs {
+  CtranWin* win;
+  size_t count;
+  commDataType_t datatype;
+};
+
+// Helper function to get pointer with offset
+inline void* getPtr(void* base, size_t offset) {
+  return reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(base) + offset);
+}
+
+} // namespace ctran::allgatherwindow

--- a/comms/ctran/colltrace/CollTraceWrapper.cc
+++ b/comms/ctran/colltrace/CollTraceWrapper.cc
@@ -166,6 +166,13 @@ CollectiveMetadata getCollectiveMetadata(
           .count = allGatherArgs.count,
       };
     }
+    case KernelConfig::KernelType::ALLGATHERWINDOW: {
+      return CollectiveMetadata{
+          .opName = "AllGatherWindow",
+          .algoName = kernelConfig.algoName,
+          .opCount = opCount,
+      };
+    }
     case KernelConfig::KernelType::ALLGATHERP: {
       // TODO: Need to get overall allgatherp information separately
       return CollectiveMetadata{

--- a/comms/ctran/gpe/CtranGpe.h
+++ b/comms/ctran/gpe/CtranGpe.h
@@ -60,7 +60,8 @@ struct OpElem {
     PUTSIGNAL,
     WAITSIGNAL,
     SIGNAL,
-    GET
+    GET,
+    ALLGATHERWINDOW
   } type;
   cudaStream_t stream;
 
@@ -262,6 +263,9 @@ struct OpElem {
       int peerRank;
       ctran::CtranWin* win;
     } get;
+    struct {
+      void* args;
+    } allgatherWindow;
   };
 
  public:
@@ -320,7 +324,8 @@ struct KernelConfig {
     PUTSIGNAL,
     WAITSIGNAL,
     SIGNAL,
-    GET
+    GET,
+    ALLGATHERWINDOW
   } type;
   unsigned int numBlocks{1};
   unsigned int numThreads{1};

--- a/comms/ctran/tests/CtranDistAllGatherWindowTest.cc
+++ b/comms/ctran/tests/CtranDistAllGatherWindowTest.cc
@@ -1,0 +1,342 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <comm.h>
+#include <folly/init/Init.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <nccl.h>
+#include <stdlib.h>
+
+#include "CtranUtUtils.h"
+#include "comms/ctran/Ctran.h"
+#include "comms/ctran/algos/AllGather/AllGatherImpl.h"
+#include "comms/testinfra/TestUtils.h"
+#include "comms/testinfra/TestsCuUtils.h"
+#include "comms/testinfra/TestsDistUtils.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+
+using namespace ctran;
+
+class CtranAllGatherWindowTest : public CtranDistBaseTest {
+ public:
+  CtranAllGatherWindowTest() = default;
+  ncclComm_t comm{nullptr};
+
+ protected:
+  void SetUp() override {
+    setenv("NCCL_CTRAN_ENABLE", "1", 0);
+    setenv("NCCL_CTRAN_IB_EPOCH_LOCK_ENFORCE_CHECK", "true", 0);
+#ifdef CTRAN_TEST_IB_ONLY_BACKEND
+    setenv("NCCL_CTRAN_BACKENDS", "ib", 1);
+#endif
+    CtranDistBaseTest::SetUp();
+    CUDACHECK_TEST(cudaSetDevice(this->localRank));
+    comm = commWorld;
+    ASSERT_NE(comm, nullptr);
+  }
+
+  void TearDown() override {
+    CtranDistBaseTest::TearDown();
+    // Check that all allocated memory segments have been freed
+    EXPECT_TRUE(segments.empty()) << "Not all memory segments were freed";
+  }
+
+  void barrier(ncclComm_t comm, cudaStream_t stream) {
+    // simple Allreduce as barrier before get data from other ranks
+    void* buf;
+    CUDACHECK_TEST(cudaMalloc(&buf, sizeof(char)));
+    NCCLCHECK_TEST(ncclAllReduce(buf, buf, 1, ncclChar, ncclSum, comm, stream));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    CUDACHECK_TEST(cudaFree(buf));
+  }
+
+  void createWin(
+      bool isUserBuf,
+      MemAllocType bufType,
+      void** winBasePtr,
+      CtranWin** winPtr,
+      size_t sizeBytes,
+      meta::comms::Hints hints) {
+    auto res = commSuccess;
+    if (isUserBuf) {
+      *winBasePtr = commMemAlloc(sizeBytes, bufType, segments);
+      res = ctranWinRegister(
+          (void*)*winBasePtr, sizeBytes, comm->ctranComm_.get(), winPtr, hints);
+    } else {
+      hints.set(
+          "window_buffer_location",
+          bufType == MemAllocType::kMemHostManaged ||
+                  bufType == MemAllocType::kMemHostUnregistered
+              ? "cpu"
+              : "gpu");
+      res = ctranWinAllocate(
+          sizeBytes, comm->ctranComm_.get(), (void**)winBasePtr, winPtr, hints);
+    }
+    ASSERT_EQ(res, commSuccess);
+    ASSERT_NE(*winBasePtr, nullptr);
+  }
+
+  void
+  freeWinBuf(bool isUserBuf, void* ptr, size_t size, MemAllocType bufType) {
+    if (isUserBuf) {
+      commMemFree(ptr, size, bufType);
+      segments.erase(
+          std::remove_if(
+              segments.begin(),
+              segments.end(),
+              [ptr](const TestMemSegment& seg) { return seg.ptr == ptr; }),
+          segments.end());
+    }
+  }
+  std::vector<TestMemSegment> segments;
+};
+
+class AllGatherWindowTestParam
+    : public CtranAllGatherWindowTest,
+      public ::testing::WithParamInterface<
+          std::tuple<size_t, size_t, MemAllocType, bool>> {};
+
+/**
+ * Test: AllGatherWindow
+ *
+ * Tests the window-based allgather implementation that uses RMA put+signal.
+ *
+ * Each rank:
+ * 1. Allocates a window for the recv buffer
+ * 2. Initializes its send buffer with rank-specific values
+ * 3. Calls ctranAllGatherWindow to gather data from all ranks
+ * 4. Verifies that each slot in the recv buffer contains the correct data
+ *
+ * Expected recv buffer layout after allgather:
+ * [rank0_data | rank1_data | ... | rankN-1_data]
+ * where rank_i_data = [i, i+1, i+2, ..., i+numElements-1]
+ */
+TEST_P(AllGatherWindowTestParam, AllGatherWindow) {
+  const auto& [kNumElements, kNumIters, bufType, userBuf] = GetParam();
+  EXPECT_GE(kNumElements, 1);
+  EXPECT_GE(kNumIters, 1);
+
+  auto comm = this->comm;
+  auto statex = comm->ctranComm_->statex_.get();
+  ASSERT_NE(statex, nullptr);
+  EXPECT_EQ(statex->nRanks(), this->numRanks);
+
+  const int rank = statex->rank();
+  const int nRanks = statex->nRanks();
+
+  cudaStream_t main_stream = 0;
+  cudaStream_t ag_stream;
+  CUDACHECK_TEST(cudaStreamCreateWithFlags(&ag_stream, cudaStreamNonBlocking));
+
+  // Window size: sendcount * nRanks * sizeof(int)
+  size_t sendBytes = kNumElements * sizeof(int);
+  size_t sizeBytes = sendBytes * nRanks;
+
+  meta::comms::Hints hints;
+  CtranWin* win = nullptr;
+  void* winBase = nullptr;
+  createWin(userBuf, bufType, &winBase, &win, sizeBytes, hints);
+  int* recvBuf = reinterpret_cast<int*>(winBase);
+
+  // Allocate send buffer
+  int* sendBuf = nullptr;
+  CUDACHECK_TEST(cudaMalloc((void**)&sendBuf, sendBytes));
+
+  EXPECT_THAT(win, ::testing::NotNull());
+
+  // Initialize recv buffer with -1
+  assignChunkValue(recvBuf, kNumElements * nRanks, -1, 0);
+
+  // Initialize send buffer with rank-specific values: [rank, rank+1, rank+2,
+  // ...]
+  assignChunkValue(sendBuf, kNumElements, rank, 1);
+
+  // Barrier to ensure all peers have finished initialization
+  this->barrier(comm, main_stream);
+
+  for (auto iter = 0; iter < kNumIters; iter++) {
+    // Reset recv buffer for each iteration (except first)
+    if (iter > 0) {
+      // Barrier to ensure all peers finished previous iteration before reset
+      this->barrier(comm, main_stream);
+      assignChunkValue(recvBuf, kNumElements * nRanks, -1, 0);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      // Barrier after reset to ensure all ranks finished resetting before
+      // any rank starts the next iteration's puts
+      this->barrier(comm, main_stream);
+    }
+
+    // Call window-based allgather
+    COMMCHECK_TEST(ctranAllGatherWindow(
+        sendBuf, // send buffer
+        kNumElements, // count
+        commInt32, // datatype
+        win, // window (recv buffer is win->winDataPtr)
+        ag_stream)); // stream
+
+    // Sync to ensure this iteration completes
+    CUDACHECK_TEST(cudaStreamSynchronize(ag_stream));
+  }
+
+  // Wait for completion
+  CUDACHECK_TEST(cudaStreamSynchronize(ag_stream));
+
+  // Barrier to ensure all peers have finished
+  this->barrier(comm, main_stream);
+
+  // Verify results: each slot should contain [peer, peer+1, peer+2, ...]
+  int totalErrs = 0;
+  for (int peer = 0; peer < nRanks; peer++) {
+    int errs = checkChunkValue(
+        recvBuf + kNumElements * peer,
+        kNumElements,
+        peer, // seed: peer rank
+        1, // increment
+        rank,
+        main_stream);
+    if (errs > 0) {
+      std::cout << "[" << rank << "] Errors in slot for peer " << peer << ": "
+                << errs << std::endl;
+    }
+    totalErrs += errs;
+  }
+  EXPECT_EQ(totalErrs, 0);
+
+  // Cleanup
+  auto res = ctranWinFree(win);
+  EXPECT_EQ(res, ncclSuccess);
+
+  CUDACHECK_TEST(cudaFree(sendBuf));
+  freeWinBuf(userBuf, winBase, sizeBytes, bufType);
+  CUDACHECK_TEST(cudaStreamDestroy(ag_stream));
+}
+
+/**
+ * Test: AllGatherWindowInPlace
+ *
+ * Tests the window-based allgather with in-place send (send buffer == recv
+ * slot).
+ */
+TEST_P(AllGatherWindowTestParam, AllGatherWindowInPlace) {
+  const auto& [kNumElements, kNumIters, bufType, userBuf] = GetParam();
+  EXPECT_GE(kNumElements, 1);
+  EXPECT_GE(kNumIters, 1);
+
+  auto comm = this->comm;
+  auto statex = comm->ctranComm_->statex_.get();
+  ASSERT_NE(statex, nullptr);
+  EXPECT_EQ(statex->nRanks(), this->numRanks);
+
+  const int rank = statex->rank();
+  const int nRanks = statex->nRanks();
+
+  cudaStream_t main_stream = 0;
+  cudaStream_t ag_stream;
+  CUDACHECK_TEST(cudaStreamCreateWithFlags(&ag_stream, cudaStreamNonBlocking));
+
+  size_t sendBytes = kNumElements * sizeof(int);
+  size_t sizeBytes = sendBytes * nRanks;
+
+  meta::comms::Hints hints;
+  CtranWin* win = nullptr;
+  void* winBase = nullptr;
+  createWin(userBuf, bufType, &winBase, &win, sizeBytes, hints);
+  int* recvBuf = reinterpret_cast<int*>(winBase);
+
+  EXPECT_THAT(win, ::testing::NotNull());
+
+  // Initialize recv buffer with -1
+  assignChunkValue(recvBuf, kNumElements * nRanks, -1, 0);
+
+  // For in-place: send buffer is the rank's slot in recv buffer
+  int* sendBuf = recvBuf + kNumElements * rank;
+  assignChunkValue(sendBuf, kNumElements, rank, 1);
+
+  // Barrier to ensure all peers have finished initialization
+  this->barrier(comm, main_stream);
+
+  for (auto iter = 0; iter < kNumIters; iter++) {
+    // Reset non-local slots for each iteration (except first)
+    if (iter > 0) {
+      // Barrier to ensure all peers finished previous iteration before reset
+      this->barrier(comm, main_stream);
+      for (int p = 0; p < nRanks; p++) {
+        if (p != rank) {
+          assignChunkValue(recvBuf + kNumElements * p, kNumElements, -1, 0);
+        }
+      }
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      // Barrier after reset to ensure all ranks finished resetting before
+      // any rank starts the next iteration's puts
+      this->barrier(comm, main_stream);
+    }
+
+    // Call window-based allgather (in-place: sendBuf points to our slot)
+    COMMCHECK_TEST(
+        ctranAllGatherWindow(sendBuf, kNumElements, commInt32, win, ag_stream));
+
+    // Sync to ensure this iteration completes
+    CUDACHECK_TEST(cudaStreamSynchronize(ag_stream));
+  }
+
+  // Wait for completion
+  CUDACHECK_TEST(cudaStreamSynchronize(ag_stream));
+  this->barrier(comm, main_stream);
+
+  // Verify results
+  int totalErrs = 0;
+  for (int peer = 0; peer < nRanks; peer++) {
+    int errs = checkChunkValue(
+        recvBuf + kNumElements * peer,
+        kNumElements,
+        peer,
+        1,
+        rank,
+        main_stream);
+    if (errs > 0) {
+      std::cout << "[" << rank << "] Errors in slot for peer " << peer << ": "
+                << errs << std::endl;
+    }
+    totalErrs += errs;
+  }
+  EXPECT_EQ(totalErrs, 0);
+
+  // Cleanup
+  auto res = ctranWinFree(win);
+  EXPECT_EQ(res, ncclSuccess);
+  freeWinBuf(userBuf, winBase, sizeBytes, bufType);
+  CUDACHECK_TEST(cudaStreamDestroy(ag_stream));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AllGatherWindowTestInstance,
+    AllGatherWindowTestParam,
+    ::testing::Combine(
+        // kNumElements, kNumIters, bufType, userBuf
+        ::testing::Values(8192, 1024 * 1024),
+        ::testing::Values(1, 10),
+        ::testing::Values(
+            MemAllocType::kMemCuMemAlloc,
+            MemAllocType::kMemCudaMalloc),
+        ::testing::Values(true, false)),
+    [](const ::testing::TestParamInfo<AllGatherWindowTestParam::ParamType>&
+           info) {
+      const auto kNumElements = std::get<0>(info.param);
+      const auto kNumIters = std::get<1>(info.param);
+      const auto bufType = std::get<2>(info.param);
+      const auto userBuf = std::get<3>(info.param);
+      std::string name = fmt::format(
+          "numElem{}_numIters{}_{}_{}",
+          kNumElements,
+          kNumIters,
+          testMemAllocTypeToStr(bufType),
+          userBuf ? "userBuf" : "allocBuf");
+      return name;
+    });
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ctran/tests/CtranUtUtils.h
+++ b/comms/ctran/tests/CtranUtUtils.h
@@ -209,6 +209,54 @@ class CtranBaseTest {
   inline size_t pageAligned(size_t nBytes) {
     return ((nBytes + pageSize_ - 1) / pageSize_) * pageSize_;
   }
+
+  // Assign a linear sequence (seed, seed+inc, seed+2*inc, ...) to a device
+  // buffer synchronously.
+  template <typename T>
+  void assignChunkValue(T* buf, size_t count, T seed, T inc) {
+    std::vector<T> vals(count);
+    for (size_t i = 0; i < count; ++i) {
+      vals[i] = seed + i * inc;
+    }
+    CUDACHECK_ASSERT(
+        cudaMemcpy(buf, vals.data(), count * sizeof(T), cudaMemcpyDefault));
+  }
+
+  // Check that a device buffer contains a linear sequence (seed, seed+inc,
+  // seed+2*inc, ...). Returns the number of mismatches. Prints the first 10
+  // errors with the given rank for identification.
+  template <typename T>
+  int checkChunkValue(
+      T* buf,
+      size_t count,
+      T seed,
+      T inc,
+      int rank,
+      cudaStream_t stream) {
+    std::vector<T> observed(count, -1);
+    CUDACHECK_TEST(cudaMemcpyAsync(
+        observed.data(), buf, count * sizeof(T), cudaMemcpyDefault, stream));
+    CUDACHECK_TEST(cudaStreamSynchronize(stream));
+    int errs = 0;
+    for (size_t i = 0; i < count; ++i) {
+      T expected = seed + inc * i;
+      if (observed[i] != expected) {
+        if (errs < 10) {
+          std::cout << "[" << rank << "] observed[" << i
+                    << "] = " << observed[i] << ", expected = " << expected
+                    << std::endl;
+        }
+        errs++;
+      }
+    }
+    return errs;
+  }
+
+  // Overload without increment — checks for a constant value.
+  template <typename T>
+  int checkChunkValue(T* buf, size_t count, T val) {
+    return checkChunkValue(buf, count, val, T{0}, /*rank=*/0, cudaStream_t{0});
+  }
 };
 
 class CtranDistBaseTest : public NcclxBaseTest, public CtranBaseTest {

--- a/comms/ctran/window/CtranWin.h
+++ b/comms/ctran/window/CtranWin.h
@@ -39,6 +39,9 @@ struct CtranWin {
   // Remote window info (addr, rkey, dataBytes) for all peers in this window
   std::vector<window::RemWinInfo> remWinInfo;
 
+  // Peers that require IB (non-NVLink) transport, computed once at exchange()
+  std::vector<int> ibPeers;
+
   // This rank's local data buffer size in bytes
   size_t dataBytes{0};
   // Signal buffer size in number of uint64_t elements per rank

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -134,6 +134,16 @@ commResult_t CtranWin::exchange() {
         myRank == i ? "(local)" : remWinInfo[i].dataRkey.toString());
   }
 
+  // Precompute the list of IB (non-NVLink) peers — topology is fixed for the
+  // lifetime of the window.
+  ibPeers.clear();
+  for (int p = 1; p < nRanks; p++) {
+    const int peer = (myRank + p) % nRanks;
+    if (statex->node(peer) != statex->node() || !nvlEnabled(peer)) {
+      ibPeers.push_back(peer);
+    }
+  }
+
   // A barrier among ranks after importing handles to prevent accessing window
   // memory space while other ranks are still importing.
   FB_COMMCHECK(mapper->barrier());

--- a/comms/ncclx/meta/algoconf/AlgoConfig.cc
+++ b/comms/ncclx/meta/algoconf/AlgoConfig.cc
@@ -52,8 +52,10 @@ inline const std::string algoValToStr(enum NCCL_ALLGATHER_ALGO val) {
       return "ctrd";
     case NCCL_ALLGATHER_ALGO::ctbrucks:
       return "ctbrucks";
-      break;
+    case NCCL_ALLGATHER_ALGO::ctwindow:
+      return "ctwindow";
   }
+  return "orig";
 }
 
 inline void algoStrToVal(
@@ -69,6 +71,8 @@ inline void algoStrToVal(
     val = NCCL_ALLGATHER_ALGO::ctrd;
   } else if (str == "ctbrucks") {
     val = NCCL_ALLGATHER_ALGO::ctbrucks;
+  } else if (str == "ctwindow") {
+    val = NCCL_ALLGATHER_ALGO::ctwindow;
   } else {
     val = NCCL_ALLGATHER_ALGO::orig;
   }

--- a/comms/ncclx/v2_27/meta/colltrace/CollTraceFunc.cc
+++ b/comms/ncclx/v2_27/meta/colltrace/CollTraceFunc.cc
@@ -356,6 +356,9 @@ bool collTraceRecordCtranKernelInfo(
     case KernelConfig::KernelType::SIGNAL:
       coll.opName = "Signal";
       break;
+    case KernelConfig::KernelType::ALLGATHERWINDOW:
+      coll.opName = "AllGatherWindow";
+      break;
     case KernelConfig::KernelType::GET:
       coll.opName = "Get";
       break;
@@ -590,6 +593,9 @@ bool collTraceRecordCtranCollective(
       break;
     case OpElem::SIGNAL:
       coll.opName = "Signal";
+      break;
+    case OpElem::ALLGATHERWINDOW:
+      coll.opName = "AllGatherWindow";
       break;
     case OpElem::GET:
       coll.opName = "Get";

--- a/comms/ncclx/v2_28/meta/colltrace/CollTraceFunc.cc
+++ b/comms/ncclx/v2_28/meta/colltrace/CollTraceFunc.cc
@@ -443,6 +443,10 @@ bool collTraceRecordCtranKernelInfo(
       coll.count = broadcastArgs.count;
       break;
     }
+    case KernelConfig::KernelType::ALLGATHERWINDOW: {
+      coll.opName = "AllGatherWindow";
+      break;
+    }
   }
   return true;
 }
@@ -590,6 +594,9 @@ bool collTraceRecordCtranCollective(
       break;
     case OpElem::SIGNAL:
       coll.opName = "Signal";
+      break;
+    case OpElem::ALLGATHERWINDOW:
+      coll.opName = "AllGatherWindow";
       break;
     case OpElem::GET:
       coll.opName = "Get";

--- a/comms/ncclx/v2_29/meta/colltrace/CollTraceFunc.cc
+++ b/comms/ncclx/v2_29/meta/colltrace/CollTraceFunc.cc
@@ -356,6 +356,9 @@ bool collTraceRecordCtranKernelInfo(
     case KernelConfig::KernelType::SIGNAL:
       coll.opName = "Signal";
       break;
+    case KernelConfig::KernelType::ALLGATHERWINDOW:
+      coll.opName = "AllGatherWindow";
+      break;
     case KernelConfig::KernelType::GET:
       coll.opName = "Get";
       break;
@@ -590,6 +593,9 @@ bool collTraceRecordCtranCollective(
       break;
     case OpElem::SIGNAL:
       coll.opName = "Signal";
+      break;
+    case OpElem::ALLGATHERWINDOW:
+      coll.opName = "AllGatherWindow";
       break;
     case OpElem::GET:
       coll.opName = "Get";

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2009,10 +2009,18 @@ cvars:
      ctpipeline - Ctran-based pipeline algorithm that pipelines
                   inter-node rail ring and intra-node CopyEngine based copy
 
+ - name        : NCCL_ALLGATHER_WIN_ALGO
+   type        : enum
+   default     : ctdirect
+   choices     : ctdirect
+   description : |-
+     The algorithm to use for window-based AllGather communication
+     ctdirect - All-to-all PUT to all peers
+
  - name        : NCCL_ALLGATHER_ALGO
    type        : enum
    default     : orig
-   choices     : orig, ctran, ctdirect, ctring, ctrd, ctbrucks
+   choices     : orig, ctran, ctdirect, ctring, ctrd, ctbrucks, ctwindow
    description : |-
      The algorithm to use for Allgather communication
      orig - Copy-based ring algorithm
@@ -2020,6 +2028,7 @@ cvars:
      ctdirect - Ctran-based direct point-to-point algorithm
      ctring - Ctran-based ring algorithm
      ctrd - Ctran-based recursive doubling algorithm
+     ctwindow - Ctran-based window RMA put+signal algorithm
 
  - name        : NCCL_REDUCESCATTER_ALGO
    type        : enum


### PR DESCRIPTION
Summary:

We prototyped the window based direct allgather in this diff

```
    Rank 0: sendBuf=[A]     Window: [ _  |  _  |  _  |  _ ]
    Rank 1: sendBuf=[B]     Window: [ _  |  _  |  _  |  _ ]
    Rank 2: sendBuf=[C]     Window: [ _  |  _  |  _  |  _ ]
    Rank 3: sendBuf=[D]     Window: [ _  |  _  |  _  |  _ ]


                       Step 1: Local copy
              Each rank copies sendBuf → own slot in window

    Rank 0: Window: [ A  |  _  |  _  |  _ ]
    Rank 1: Window: [ _  |  B  |  _  |  _ ]
    Rank 2: Window: [ _  |  _  |  C  |  _ ]
    Rank 3: Window: [ _  |  _  |  _  |  D ]


            Step 2: NVLink CE broadcast (intra-node)

    Example (Rank 0,1 on node 0; Rank 2,3 on node 1):

    After step 2:
    Rank 0: Window: [ A  |  B  |  _  |  _ ]
    Rank 1: Window: [ A  |  B  |  _  |  _ ]
    Rank 2: Window: [ _  |  _  |  C  |  D ]
    Rank 3: Window: [ _  |  _  |  C  |  D ]


            Step 3: RDMA PUT + atomic signal (inter-node, via IB put)


                         After AllGather
    Rank 0: Window: [ A  |  B  |  C  |  D ]  ✓
    Rank 1: Window: [ A  |  B  |  C  |  D ]  ✓
    Rank 2: Window: [ A  |  B  |  C  |  D ]  ✓
    Rank 3: Window: [ A  |  B  |  C  |  D ]  ✓
```

Differential Revision: D90702671


