### PR TITLE
Fix CollTraceWatchdogTest by extending wait time

### DIFF
--- a/comms/ncclx/v2_27/meta/colltrace/tests/CollTraceWatchdogTest.cc
+++ b/comms/ncclx/v2_27/meta/colltrace/tests/CollTraceWatchdogTest.cc
@@ -232,7 +232,7 @@ TEST_F(CollTraceWatchdogTest, TestAsyncErrorFromGPE) {
   NCCLCHECK_FATAL(
       ncclPutSignal(sendBuff, 32, ncclFloat, dstRank, 0, win, stream.raw()));
   NCCLCHECK_FATAL(ncclWaitSignal(srcRank, win, stream.raw()));
-  waitStreamWithTimeout(stream.raw(), std::chrono::seconds{20});
+  waitStreamWithTimeout(stream.raw(), std::chrono::seconds{80});
 }
 
 TEST_F(CollTraceWatchdogTest, TestAsyncErrorWithGenericAsyncError) {
@@ -265,6 +265,9 @@ TEST_F(CollTraceWatchdogTest, TestAsyncErrorWithGenericAsyncError) {
   ncclCommSetAsyncError(comm.raw(), ncclInternalError);
 
   waitStreamWithTimeout(stream.raw(), std::chrono::seconds{20});
+
+  // Wait for sufficiently long for watchdog to stop waiting and exit
+  sleep(70);
 }
 
 TEST_F(CollTraceWatchdogTest, TestTimeoutBeforeColl) {

--- a/comms/ncclx/v2_28/meta/colltrace/tests/CollTraceWatchdogTest.cc
+++ b/comms/ncclx/v2_28/meta/colltrace/tests/CollTraceWatchdogTest.cc
@@ -232,7 +232,7 @@ TEST_F(CollTraceWatchdogTest, TestAsyncErrorFromGPE) {
   NCCLCHECK_FATAL(
       ncclPutSignal(sendBuff, 32, ncclFloat, dstRank, 0, win, stream.raw()));
   NCCLCHECK_FATAL(ncclWaitSignal(srcRank, win, stream.raw()));
-  waitStreamWithTimeout(stream.raw(), std::chrono::seconds{20});
+  waitStreamWithTimeout(stream.raw(), std::chrono::seconds{80});
 }
 
 TEST_F(CollTraceWatchdogTest, TestAsyncErrorWithGenericAsyncError) {
@@ -265,6 +265,9 @@ TEST_F(CollTraceWatchdogTest, TestAsyncErrorWithGenericAsyncError) {
   ncclCommSetAsyncError(comm.raw(), ncclInternalError);
 
   waitStreamWithTimeout(stream.raw(), std::chrono::seconds{20});
+
+  // Wait for sufficiently long for watchdog to stop waiting and exit
+  sleep(70);
 }
 
 TEST_F(CollTraceWatchdogTest, TestTimeoutBeforeColl) {

--- a/comms/utils/colltrace/plugins/WatchdogPlugin.cc
+++ b/comms/utils/colltrace/plugins/WatchdogPlugin.cc
@@ -3,6 +3,7 @@
 #include "comms/utils/colltrace/plugins/WatchdogPlugin.h"
 
 #include <folly/Unit.h>
+#include <folly/json.h>
 #include <folly/logging/xlog.h>
 
 namespace meta::comms::colltrace {
@@ -63,7 +64,15 @@ CommsMaybeVoid WatchdogPlugin::afterCollKernelStart(
 
 CommsMaybeVoid WatchdogPlugin::collEventProgressing(
     CollTraceEvent& curEvent) noexcept {
+  XLOGF(
+      DBG0,
+      "WatchdogPlugin::collEventProgressing for CollTraceEvent {}",
+      folly::toJson(curEvent.collRecord->toDynamic()));
+
   if (config_.checkAsyncError && config_.funcIfError()) {
+    XLOG(DBG)
+        << "WatchdogPlugin::collEventProgressing: triggering async error handling";
+
     config_.funcTriggerOnError(curEvent);
   }
   if (config_.checkTimeout) {


### PR DESCRIPTION
Summary: Previously we added a 60 second wait time in CollTrace watchdog to ensure we have sufficient time to capture the failure in the Analyzer. Change the test accordingly so it don't timeout before the watchdog does.

Differential Revision: D90663801


