### PR TITLE
torchcomms: add hooks for tracking operations

### DIFF
--- a/comms/torchcomms/RemovableHandle.hpp
+++ b/comms/torchcomms/RemovableHandle.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <functional>
+#include <mutex>
+
+namespace torch::comms {
+
+class RemovableHandle {
+ public:
+  explicit RemovableHandle(std::function<void()>&& callback)
+      : callback_(std::move(callback)) {}
+  ~RemovableHandle() = default;
+
+  RemovableHandle(const RemovableHandle&) = delete;
+  RemovableHandle& operator=(const RemovableHandle&) = delete;
+  RemovableHandle(RemovableHandle&&) = delete;
+  RemovableHandle& operator=(RemovableHandle&&) = delete;
+
+  void remove() {
+    std::call_once(once_, [this]() noexcept {
+      callback_();
+      callback_ = nullptr;
+    });
+  }
+
+ private:
+  std::once_flag once_;
+  std::function<void()> callback_;
+};
+
+} // namespace torch::comms

--- a/comms/torchcomms/TorchComm.cpp
+++ b/comms/torchcomms/TorchComm.cpp
@@ -44,7 +44,23 @@ c10::intrusive_ptr<TorchWork> TorchComm::send(
     int dst,
     bool async_op,
     const SendOptions& options) {
-  return impl_->send(tensor, dst, async_op, options);
+  preHook(
+      PreHookArgs{
+          .name = OpName::send,
+          .async_op = async_op,
+          .input_tensor = &tensor,
+          .root = dst,
+      });
+
+  auto work = impl_->send(tensor, dst, async_op, options);
+
+  postHook(
+      PostHookArgs{
+          .name = OpName::send,
+          .work = c10::weak_intrusive_ptr<TorchWork>(work),
+      });
+
+  return work;
 }
 
 c10::intrusive_ptr<TorchWork> TorchComm::recv(
@@ -52,7 +68,23 @@ c10::intrusive_ptr<TorchWork> TorchComm::recv(
     int src,
     bool async_op,
     const RecvOptions& options) {
-  return impl_->recv(tensor, src, async_op, options);
+  preHook(
+      PreHookArgs{
+          .name = OpName::recv,
+          .async_op = async_op,
+          .output_tensor = &tensor,
+          .root = src,
+      });
+
+  auto work = impl_->recv(tensor, src, async_op, options);
+
+  postHook(
+      PostHookArgs{
+          .name = OpName::recv,
+          .work = c10::weak_intrusive_ptr<TorchWork>(work),
+      });
+
+  return work;
 }
 
 // Collective Operations
@@ -61,7 +93,23 @@ c10::intrusive_ptr<TorchWork> TorchComm::broadcast(
     int root,
     bool async_op,
     const BroadcastOptions& options) {
-  return impl_->broadcast(tensor, root, async_op, options);
+  preHook(
+      PreHookArgs{
+          .name = OpName::broadcast,
+          .async_op = async_op,
+          .input_tensor = &tensor,
+          .root = root,
+      });
+
+  auto work = impl_->broadcast(tensor, root, async_op, options);
+
+  postHook(
+      PostHookArgs{
+          .name = OpName::broadcast,
+          .work = c10::weak_intrusive_ptr<TorchWork>(work),
+      });
+
+  return work;
 }
 
 c10::intrusive_ptr<TorchWork> TorchComm::all_reduce(
@@ -69,7 +117,22 @@ c10::intrusive_ptr<TorchWork> TorchComm::all_reduce(
     const ReduceOp& op,
     bool async_op,
     const AllReduceOptions& options) {
-  return impl_->all_reduce(tensor, op, async_op, options);
+  preHook(
+      PreHookArgs{
+          .name = OpName::all_reduce,
+          .async_op = async_op,
+          .input_tensor = &tensor,
+      });
+
+  auto work = impl_->all_reduce(tensor, op, async_op, options);
+
+  postHook(
+      PostHookArgs{
+          .name = OpName::all_reduce,
+          .work = c10::weak_intrusive_ptr<TorchWork>(work),
+      });
+
+  return work;
 }
 
 c10::intrusive_ptr<TorchWork> TorchComm::reduce(
@@ -78,7 +141,23 @@ c10::intrusive_ptr<TorchWork> TorchComm::reduce(
     const ReduceOp& op,
     bool async_op,
     const ReduceOptions& options) {
-  return impl_->reduce(tensor, root, op, async_op, options);
+  preHook(
+      PreHookArgs{
+          .name = OpName::reduce,
+          .async_op = async_op,
+          .input_tensor = &tensor,
+          .root = root,
+      });
+
+  auto work = impl_->reduce(tensor, root, op, async_op, options);
+
+  postHook(
+      PostHookArgs{
+          .name = OpName::reduce,
+          .work = c10::weak_intrusive_ptr<TorchWork>(work),
+      });
+
+  return work;
 }
 
 c10::intrusive_ptr<TorchWork> TorchComm::all_gather(
@@ -86,7 +165,22 @@ c10::intrusive_ptr<TorchWork> TorchComm::all_gather(
     const at::Tensor& tensor,
     bool async_op,
     const AllGatherOptions& options) {
-  return impl_->all_gather(tensor_list, tensor, async_op, options);
+  preHook(
+      PreHookArgs{
+          .name = OpName::all_gather,
+          .async_op = async_op,
+          .input_tensor = &tensor,
+      });
+
+  auto work = impl_->all_gather(tensor_list, tensor, async_op, options);
+
+  postHook(
+      PostHookArgs{
+          .name = OpName::all_gather,
+          .work = c10::weak_intrusive_ptr<TorchWork>(work),
+      });
+
+  return work;
 }
 
 c10::intrusive_ptr<TorchWork> TorchComm::all_gather_v(
@@ -94,7 +188,22 @@ c10::intrusive_ptr<TorchWork> TorchComm::all_gather_v(
     const at::Tensor& tensor,
     bool async_op,
     const AllGatherOptions& options) {
-  return impl_->all_gather_v(tensor_list, tensor, async_op, options);
+  preHook(
+      PreHookArgs{
+          .name = OpName::all_gather_v,
+          .async_op = async_op,
+          .input_tensor = &tensor,
+      });
+
+  auto work = impl_->all_gather_v(tensor_list, tensor, async_op, options);
+
+  postHook(
+      PostHookArgs{
+          .name = OpName::all_gather_v,
+          .work = c10::weak_intrusive_ptr<TorchWork>(work),
+      });
+
+  return work;
 }
 
 c10::intrusive_ptr<TorchWork> TorchComm::all_gather_single(
@@ -102,7 +211,23 @@ c10::intrusive_ptr<TorchWork> TorchComm::all_gather_single(
     const at::Tensor& input,
     bool async_op,
     const AllGatherSingleOptions& options) {
-  return impl_->all_gather_single(output, input, async_op, options);
+  preHook(
+      PreHookArgs{
+          .name = OpName::all_gather_single,
+          .async_op = async_op,
+          .input_tensor = &input,
+          .output_tensor = &output,
+      });
+
+  auto work = impl_->all_gather_single(output, input, async_op, options);
+
+  postHook(
+      PostHookArgs{
+          .name = OpName::all_gather_single,
+          .work = c10::weak_intrusive_ptr<TorchWork>(work),
+      });
+
+  return work;
 }
 
 c10::intrusive_ptr<TorchWork> TorchComm::reduce_scatter(
@@ -111,7 +236,22 @@ c10::intrusive_ptr<TorchWork> TorchComm::reduce_scatter(
     const ReduceOp& op,
     bool async_op,
     const ReduceScatterOptions& options) {
-  return impl_->reduce_scatter(output, input_list, op, async_op, options);
+  preHook(
+      PreHookArgs{
+          .name = OpName::reduce_scatter,
+          .async_op = async_op,
+          .output_tensor = &output,
+      });
+
+  auto work = impl_->reduce_scatter(output, input_list, op, async_op, options);
+
+  postHook(
+      PostHookArgs{
+          .name = OpName::reduce_scatter,
+          .work = c10::weak_intrusive_ptr<TorchWork>(work),
+      });
+
+  return work;
 }
 
 c10::intrusive_ptr<TorchWork> TorchComm::reduce_scatter_v(
@@ -120,7 +260,23 @@ c10::intrusive_ptr<TorchWork> TorchComm::reduce_scatter_v(
     const ReduceOp& op,
     bool async_op,
     const ReduceScatterOptions& options) {
-  return impl_->reduce_scatter_v(output, input_list, op, async_op, options);
+  preHook(
+      PreHookArgs{
+          .name = OpName::reduce_scatter_v,
+          .async_op = async_op,
+          .output_tensor = &output,
+      });
+
+  auto work =
+      impl_->reduce_scatter_v(output, input_list, op, async_op, options);
+
+  postHook(
+      PostHookArgs{
+          .name = OpName::reduce_scatter_v,
+          .work = c10::weak_intrusive_ptr<TorchWork>(work),
+      });
+
+  return work;
 }
 
 c10::intrusive_ptr<TorchWork> TorchComm::reduce_scatter_single(
@@ -129,7 +285,24 @@ c10::intrusive_ptr<TorchWork> TorchComm::reduce_scatter_single(
     const ReduceOp& op,
     bool async_op,
     const ReduceScatterSingleOptions& options) {
-  return impl_->reduce_scatter_single(output, input, op, async_op, options);
+  preHook(
+      PreHookArgs{
+          .name = OpName::reduce_scatter_single,
+          .async_op = async_op,
+          .input_tensor = &input,
+          .output_tensor = &output,
+      });
+
+  auto work =
+      impl_->reduce_scatter_single(output, input, op, async_op, options);
+
+  postHook(
+      PostHookArgs{
+          .name = OpName::reduce_scatter_single,
+          .work = c10::weak_intrusive_ptr<TorchWork>(work),
+      });
+
+  return work;
 }
 
 c10::intrusive_ptr<TorchWork> TorchComm::all_to_all_single(
@@ -137,7 +310,23 @@ c10::intrusive_ptr<TorchWork> TorchComm::all_to_all_single(
     const at::Tensor& input,
     bool async_op,
     const AllToAllSingleOptions& options) {
-  return impl_->all_to_all_single(output, input, async_op, options);
+  preHook(
+      PreHookArgs{
+          .name = OpName::all_to_all_single,
+          .async_op = async_op,
+          .input_tensor = &input,
+          .output_tensor = &output,
+      });
+
+  auto work = impl_->all_to_all_single(output, input, async_op, options);
+
+  postHook(
+      PostHookArgs{
+          .name = OpName::all_to_all_single,
+          .work = c10::weak_intrusive_ptr<TorchWork>(work),
+      });
+
+  return work;
 }
 
 c10::intrusive_ptr<TorchWork> TorchComm::all_to_all_v_single(
@@ -147,8 +336,26 @@ c10::intrusive_ptr<TorchWork> TorchComm::all_to_all_v_single(
     const std::vector<uint64_t>& input_split_sizes,
     bool async_op,
     const AllToAllvSingleOptions& options) {
-  return impl_->all_to_all_v_single(
+  preHook(
+      PreHookArgs{
+          .name = OpName::all_to_all_v_single,
+          .async_op = async_op,
+          .input_tensor = &input,
+          .output_tensor = &output,
+          .output_split_sizes = &output_split_sizes,
+          .input_split_sizes = &input_split_sizes,
+      });
+
+  auto work = impl_->all_to_all_v_single(
       output, input, output_split_sizes, input_split_sizes, async_op, options);
+
+  postHook(
+      PostHookArgs{
+          .name = OpName::all_to_all_v_single,
+          .work = c10::weak_intrusive_ptr<TorchWork>(work),
+      });
+
+  return work;
 }
 
 c10::intrusive_ptr<TorchWork> TorchComm::all_to_all(
@@ -156,14 +363,42 @@ c10::intrusive_ptr<TorchWork> TorchComm::all_to_all(
     const std::vector<at::Tensor>& input_tensor_list,
     bool async_op,
     const AllToAllOptions& options) {
-  return impl_->all_to_all(
+  preHook(
+      PreHookArgs{
+          .name = OpName::all_to_all,
+          .async_op = async_op,
+      });
+
+  auto work = impl_->all_to_all(
       output_tensor_list, input_tensor_list, async_op, options);
+
+  postHook(
+      PostHookArgs{
+          .name = OpName::all_to_all,
+          .work = c10::weak_intrusive_ptr<TorchWork>(work),
+      });
+
+  return work;
 }
 
 c10::intrusive_ptr<TorchWork> TorchComm::barrier(
     bool async_op,
     const BarrierOptions& options) {
-  return impl_->barrier(async_op, options);
+  preHook(
+      PreHookArgs{
+          .name = OpName::barrier,
+          .async_op = async_op,
+      });
+
+  auto work = impl_->barrier(async_op, options);
+
+  postHook(
+      PostHookArgs{
+          .name = OpName::barrier,
+          .work = c10::weak_intrusive_ptr<TorchWork>(work),
+      });
+
+  return work;
 }
 
 // Scatter and Gather Operations
@@ -173,8 +408,24 @@ c10::intrusive_ptr<TorchWork> TorchComm::scatter(
     int root,
     bool async_op,
     const ScatterOptions& options) {
-  return impl_->scatter(
-      output_tensor, input_tensor_list, root, async_op, options);
+  preHook(
+      PreHookArgs{
+          .name = OpName::scatter,
+          .async_op = async_op,
+          .output_tensor = &output_tensor,
+          .root = root,
+      });
+
+  auto work =
+      impl_->scatter(output_tensor, input_tensor_list, root, async_op, options);
+
+  postHook(
+      PostHookArgs{
+          .name = OpName::scatter,
+          .work = c10::weak_intrusive_ptr<TorchWork>(work),
+      });
+
+  return work;
 }
 
 c10::intrusive_ptr<TorchWork> TorchComm::gather(
@@ -183,12 +434,38 @@ c10::intrusive_ptr<TorchWork> TorchComm::gather(
     int root,
     bool async_op,
     const GatherOptions& options) {
-  return impl_->gather(
-      output_tensor_list, input_tensor, root, async_op, options);
+  preHook(
+      PreHookArgs{
+          .name = OpName::gather,
+          .async_op = async_op,
+          .input_tensor = &input_tensor,
+          .root = root,
+      });
+
+  auto work =
+      impl_->gather(output_tensor_list, input_tensor, root, async_op, options);
+
+  postHook(
+      PostHookArgs{
+          .name = OpName::gather,
+          .work = c10::weak_intrusive_ptr<TorchWork>(work),
+      });
+
+  return work;
 }
 
 std::shared_ptr<TorchCommWindow> TorchComm::new_window() {
-  return impl_->new_window();
+  preHook(
+      PreHookArgs{
+          .name = OpName::new_window,
+      });
+  auto window = impl_->new_window();
+  postHook(
+      PostHookArgs{
+          .name = OpName::new_window,
+          .new_window = std::weak_ptr<TorchCommWindow>(window),
+      });
+  return window;
 }
 
 // Communicator Management
@@ -196,12 +473,24 @@ std::shared_ptr<TorchComm> TorchComm::split(
     const std::vector<int>& ranks,
     const std::string& name,
     const CommOptions& options) {
+  preHook(
+      PreHookArgs{
+          .name = OpName::split,
+          .ranks = &ranks,
+          .split_name = &name,
+      });
   auto new_impl = impl_->split(ranks, name, options);
   if (new_impl == nullptr) {
     return nullptr;
   }
-  return std::shared_ptr<TorchComm>(
-      new TorchComm(backend_, std::move(new_impl)));
+  auto comm =
+      std::shared_ptr<TorchComm>(new TorchComm(backend_, std::move(new_impl)));
+  postHook(
+      PostHookArgs{
+          .name = OpName::split,
+          .new_comm = std::weak_ptr<TorchComm>(comm),
+      });
+  return comm;
 }
 
 const CommOptions& TorchComm::getOptions() const {
@@ -245,6 +534,47 @@ c10::intrusive_ptr<TorchWork> BatchSendRecv::issue(
 // Global memory allocator function implementation
 std::shared_ptr<c10::Allocator> get_mem_allocator(const std::string& backend) {
   return TorchCommFactory::get().get_allocator(backend);
+}
+
+RemovableHandle TorchComm::registerPreHook(TorchComm::PreHook preHook) {
+  auto hookId = nextHookId_++;
+  preHooks_.emplace(hookId, std::move(preHook));
+  return RemovableHandle([self = weak_from_this(), hookId]() {
+    if (auto selfPtr = self.lock()) {
+      selfPtr->preHooks_.erase(hookId);
+    }
+  });
+}
+
+RemovableHandle TorchComm::registerPostHook(TorchComm::PostHook postHook) {
+  auto hookId = nextHookId_++;
+  postHooks_.emplace(hookId, std::move(postHook));
+  return RemovableHandle([self = weak_from_this(), hookId]() {
+    if (auto selfPtr = self.lock()) {
+      selfPtr->postHooks_.erase(hookId);
+    }
+  });
+}
+
+void TorchComm::preHook(PreHookArgs&& args) {
+  for (auto& hook : preHooks_) {
+    hook.second(args);
+  }
+}
+
+void TorchComm::postHook(PostHookArgs&& args) {
+  if (!args.work) {
+    return;
+  }
+  if (auto work = args.work->lock()) {
+    work->setCallback([self = weak_from_this(), args = std::move(args)]() {
+      if (auto selfPtr = self.lock()) {
+        for (auto& hook : selfPtr->postHooks_) {
+          hook.second(args);
+        }
+      }
+    });
+  }
 }
 
 } // namespace comms

--- a/comms/torchcomms/TorchComm.hpp
+++ b/comms/torchcomms/TorchComm.hpp
@@ -5,6 +5,7 @@
 #include <ATen/ATen.h>
 #include <c10/core/Device.h>
 #include <c10/util/intrusive_ptr.h>
+#include <comms/torchcomms/RemovableHandle.hpp>
 #include <comms/torchcomms/TorchCommBackend.hpp>
 #include <comms/torchcomms/TorchCommBatch.hpp>
 #include <comms/torchcomms/TorchCommOptions.hpp>
@@ -22,7 +23,75 @@ class TorchWork;
 class TorchCommNCCLX;
 class TorchWin;
 
-class TorchComm {
+// Enum for collective operation names
+enum class OpName {
+  send,
+  recv,
+  broadcast,
+  all_reduce,
+  reduce,
+  all_gather,
+  all_gather_v,
+  all_gather_single,
+  reduce_scatter,
+  reduce_scatter_v,
+  reduce_scatter_single,
+  all_to_all_single,
+  all_to_all_v_single,
+  all_to_all,
+  barrier,
+  scatter,
+  gather,
+  split,
+  new_window,
+};
+
+// Convert OpName enum to string
+constexpr std::string_view toString(OpName name) {
+  switch (name) {
+    case OpName::send:
+      return "send";
+    case OpName::recv:
+      return "recv";
+    case OpName::broadcast:
+      return "broadcast";
+    case OpName::all_reduce:
+      return "all_reduce";
+    case OpName::reduce:
+      return "reduce";
+    case OpName::all_gather:
+      return "all_gather";
+    case OpName::all_gather_v:
+      return "all_gather_v";
+    case OpName::all_gather_single:
+      return "all_gather_single";
+    case OpName::reduce_scatter:
+      return "reduce_scatter";
+    case OpName::reduce_scatter_v:
+      return "reduce_scatter_v";
+    case OpName::reduce_scatter_single:
+      return "reduce_scatter_single";
+    case OpName::all_to_all_single:
+      return "all_to_all_single";
+    case OpName::all_to_all_v_single:
+      return "all_to_all_v_single";
+    case OpName::all_to_all:
+      return "all_to_all";
+    case OpName::barrier:
+      return "barrier";
+    case OpName::scatter:
+      return "scatter";
+    case OpName::gather:
+      return "gather";
+    case OpName::split:
+      return "split";
+    case OpName::new_window:
+      return "new_window";
+  }
+  return "unknown";
+}
+
+class TorchComm : public std::enable_shared_from_this<TorchComm> {
  public:
   ~TorchComm() = default;
 
@@ -151,6 +220,36 @@ class TorchComm {
 
   std::shared_ptr<TorchCommWindow> new_window();
 
+  // Hooks
+  struct PreHookArgs {
+    OpName name;
+    bool async_op{false};
+    std::vector<at::Tensor>* input_tensors{nullptr};
+    std::vector<at::Tensor>* output_tensors{nullptr};
+    const at::Tensor* input_tensor{nullptr};
+    const at::Tensor* output_tensor{nullptr};
+    int root{-1};
+    // For all_to_all_v_single
+    const std::vector<uint64_t>* output_split_sizes{nullptr};
+    const std::vector<uint64_t>* input_split_sizes{nullptr};
+    // For split
+    const std::vector<int>* ranks{nullptr};
+    const std::string* split_name{nullptr};
+  };
+  using PreHook = std::function<void(PreHookArgs)>;
+  struct PostHookArgs {
+    OpName name;
+    std::optional<c10::weak_intrusive_ptr<TorchWork>> work{};
+    std::weak_ptr<TorchComm> new_comm{};
+    std::weak_ptr<TorchCommWindow> new_window{};
+  };
+  using PostHook = std::function<void(PostHookArgs)>;
+
+  // These are not thread safe and must not be modified while a collective is
+  // in progress.
+  RemovableHandle registerPreHook(PreHook preHook);
+  RemovableHandle registerPostHook(PostHook postHook);
+
   // Disable copy and move semantics
   TorchComm(const TorchComm&) = delete;
   TorchComm& operator=(const TorchComm&) = delete;
@@ -175,10 +274,18 @@ class TorchComm {
       const std::string& backend,
       std::shared_ptr<TorchCommBackend> impl);
 
+  void preHook(PreHookArgs&& args);
+  void postHook(PostHookArgs&& args);
+
+ private:
   // Backend name
   std::string backend_;
   // Implementation object
   std::shared_ptr<TorchCommBackend> impl_;
+
+  int64_t nextHookId_ = 0;
+  std::unordered_map<int64_t, PreHook> preHooks_;
+  std::unordered_map<int64_t, PostHook> postHooks_;
 };
 
 // Constructor that creates the appropriate backend implementation

--- a/comms/torchcomms/TorchWork.hpp
+++ b/comms/torchcomms/TorchWork.hpp
@@ -42,10 +42,33 @@ class TorchWork : public c10::intrusive_ptr_target {
  protected:
   void setStatus(WorkStatus status) {
     status_ = status;
+
+    if (status == WorkStatus::COMPLETED || status == WorkStatus::ERROR ||
+        status == WorkStatus::TIMEDOUT) {
+      runCallback();
+    }
+  }
+
+  friend class TorchComm;
+
+  void setCallback(std::function<void()> callback) {
+    callback_ = std::move(callback);
+  }
+
+  void runCallback() {
+    if (callback_) {
+      std::call_once(callback_once_, [this]() {
+        callback_();
+        callback_ = nullptr;
+      });
+    }
   }
 
  private:
   std::atomic<WorkStatus> status_{WorkStatus::NOT_STARTED};
+
+  std::once_flag callback_once_;
+  std::function<void()> callback_;
 };
 
 class TorchWorkCompleted : public TorchWork {


### PR DESCRIPTION
Summary:
This adds hooks that can be registered on a TorchComm prior and after an operation.

This is intended for a couple of use cases:

1. FlightRecorder integration (logging all in flight collective operations for after the fact debugging)
2. Silent corruption checks (skew across hosts via hashing, nan checking, etc)

This isn't intended for doing manipulations of the tensors (rescaling for torchft?) but in theory it could be.

FlightRecorder integration will be added in a follow up PR.

This is similar to the TracingGuard used in some backends but is generic for all backends and allows registering callbacks. It also captures the returned work for tracking completion.

Differential Revision:
D89421800

Privacy Context Container: L1397144


