### PR TITLE
rcclx CI failures

### DIFF
--- a/comms/rcclx/develop/src/include/rccl_float8.h
+++ b/comms/rcclx/develop/src/include/rccl_float8.h
@@ -3,6 +3,7 @@
 #define ROCBLAS_FLOAT8_H
 
 #include <stdint.h>
+#include <ostream>
 #include <hip/hip_version.h>
 
 typedef uint16_t fp8x2_storage_t;
@@ -20,7 +21,7 @@ typedef struct
 } rccl_bfloat8;
 
 // __cplusplus < 201103L || (!defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__))
-#elif HIP_VERSION >= 60300000 && !(defined(__gfx1100__) || defined(__gfx1101__) || defined(__gfx1102__) || defined(__gfx1030__))
+#elif HIP_VERSION >= 60300000 && defined(__HIPCC__) && !(defined(__gfx1100__) || defined(__gfx1101__) || defined(__gfx1102__) || defined(__gfx1030__))
 
 #include <hip/hip_fp8.h>
 

--- a/comms/rcclx/develop/test/common/EnvVars.cpp
+++ b/comms/rcclx/develop/test/common/EnvVars.cpp
@@ -5,6 +5,7 @@
  ************************************************************************/
 
 #include "EnvVars.hpp"
+#include "Float8Hack.hpp"
 #include "CollectiveArgs.hpp"
 #include <cstdlib>
 #include <unistd.h>

--- a/comms/rcclx/develop/test/common/Float8Hack.hpp
+++ b/comms/rcclx/develop/test/common/Float8Hack.hpp
@@ -1,4 +1,8 @@
 #pragma once
 
+#include "rccl/rccl.h"
+
+#if NCCL_VERSION_CODE < 22400
 #define ncclFloat8e4m3 ncclFp8E4M3
 #define ncclFloat8e5m2 ncclFp8E5M2
+#endif


### PR DESCRIPTION
Summary:
T251588545: UTs under //rcclx/develop/test only compatible with rocm-621, but built failed with rocm-64, rocm-70

With the help from Devmate's suggested changes
- V1: compatible with rocm-64
- V2: compatible with rocm-64 & rocm-70

Reviewed By: dmwu

Differential Revision: D90803787


