### PR TITLE
build: use cmake for building ncclx and third-party dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 .lintbin/
 .pyre/
 torch_compile_debug/
+.claude/settings.local.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,10 @@
 cmake_minimum_required(VERSION 3.22)
 project(torchcomms_ncclx)
 set(CMAKE_VERBOSE_MAKEFILE ON)
-set(FETCHCONTENT_BASE_DIR "build/fetchcontent")
+set(FETCHCONTENT_BASE_DIR "${CMAKE_BINARY_DIR}/fetchcontent")
+
+# Add cmake module path
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 # Options
 option(USE_NCCL "Whether to build NCCL or not" ON)
@@ -56,6 +59,19 @@ set(CONDA_LIB "${CONDA_PREFIX}/${LIB_SUFFIX}")
 set(CONDA_INCLUDE "${CONDA_PREFIX}/include")
 set(TORCH_PYTHON_LIB "${TORCH_INSTALL_PREFIX}/lib/libtorch_python.so")
 
+# Build third-party dependencies and NCCLX if needed
+# The cmake modules handle USE_SYSTEM_LIBS and NCCL_BUILD_SKIP_DEPS internally
+if(USE_NCCLX)
+    include(ThirdParty)
+    include(CommsTracingService)
+    include(NCCLX)
+endif()
+
+# Set FMT_INCLUDE for use by sub-CMakeLists
+if(NOT USE_SYSTEM_LIBS)
+    set(FMT_INCLUDE "${CONDA_INCLUDE}")
+endif()
+
 # Core libtorchcomms
 add_library(torchcomms SHARED ${TORCHCOMMS_SOURCES})
 set_target_properties(torchcomms PROPERTIES
@@ -78,13 +94,17 @@ if(USE_SYSTEM_LIBS)
     )
 else()
     target_include_directories(torchcomms PRIVATE
-        ${ROOT}/third-party/fmt/include
+        ${FMT_INCLUDE}
     )
     target_link_libraries(torchcomms PRIVATE
         "-l:libglog.a"
         "-l:libgflags.a"
         "-l:libfmt.a"
     )
+    # Add dependency on third-party build if ncclx is enabled
+    if(USE_NCCLX AND TARGET third_party_deps)
+        add_dependencies(torchcomms third_party_deps)
+    endif()
 endif()
 
 # Extension: torchcomms._comms

--- a/build_ncclx.sh
+++ b/build_ncclx.sh
@@ -1,390 +1,48 @@
 #!/bin/bash
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-
-set -x
-
-function do_cmake_build() {
-  local source_dir="$1"
-  local extra_flags="$2"
-  cmake -G Ninja \
-    -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH" \
-    -DCMAKE_INSTALL_PREFIX="$CMAKE_PREFIX_PATH" \
-    -DCMAKE_MODULE_PATH="$CMAKE_PREFIX_PATH" \
-    -DCMAKE_INSTALL_DIR="$CMAKE_PREFIX_PATH" \
-    -DBIN_INSTALL_DIR="$CMAKE_PREFIX_PATH/bin" \
-    -DLIB_INSTALL_DIR="$CMAKE_PREFIX_PATH/$LIB_SUFFIX" \
-    -DINCLUDE_INSTALL_DIR="$CMAKE_PREFIX_PATH/include" \
-    -DCMAKE_INSTALL_INCLUDEDIR="$CMAKE_PREFIX_PATH/include" \
-    -DCMAKE_INSTALL_LIBDIR="$CMAKE_PREFIX_PATH/$LIB_SUFFIX" \
-    -DBUILD_SHARED_LIBS=OFF \
-    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-    -DCMAKE_CXX_STANDARD=20 \
-    -DCMAKE_POLICY_VERSION_MINIMUM=3.22 \
-    $extra_flags \
-    -S "${source_dir}"
-  ninja
-  ninja install
-}
-
-function clean_third_party {
-  local library_name="$1"
-  if [ "$CLEAN_THIRD_PARTY" == 1 ]; then
-    rm -rf "${CONDA_PREFIX}"/include/"${library_name}"*/
-    rm -rf "${CONDA_PREFIX}"/include/"${library_name}"*.h
-  fi
-}
-
-function build_fb_oss_library() {
-  local repo_url="$1"
-  local repo_tag="$2"
-  local library_name="$3"
-  local extra_flags="$4"
-
-  clean_third_party "$library_name"
-
-  if [ ! -e "$library_name" ]; then
-    git clone --depth 1 -b "$repo_tag" "$repo_url" "$library_name"
-  fi
-
-  local source_dir="../${library_name}/${library_name}"
-  if [ -f ${library_name}/CMakeLists.txt ]; then
-    source_dir="../${library_name}"
-  fi
-  if [ -f ${library_name}/build/cmake/CMakeLists.txt ]; then
-    source_dir="../${library_name}/build/cmake"
-  fi
-  if [ -f ${library_name}/cmake_unofficial/CMakeLists.txt ]; then
-    source_dir="../${library_name}/cmake_unofficial"
-  fi
-
-  export LDFLAGS="-Wl,--allow-shlib-undefined"
-  rm -rf build-output
-  mkdir -p build-output
-  pushd build-output
-  do_cmake_build "$source_dir" "$extra_flags"
-  popd
-}
-
-function build_automake_library() {
-  local repo_url="$1"
-  local repo_tag="$2"
-  local library_name="$3"
-  local extra_flags="$4"
-
-  clean_third_party "$library_name"
-
-  if [ ! -e "$library_name" ]; then
-    git clone --depth 1 -b "$repo_tag" "$repo_url" "$library_name"
-  fi
-
-  export LDFLAGS="-Wl,--allow-shlib-undefined"
-  pushd "$library_name"
-  ./configure --prefix="$CMAKE_PREFIX_PATH" --disable-pie
-
-  make -j
-  make install
-  popd
-}
-
-function build_boost() {
-  local repo_url="https://github.com/boostorg/boost.git"
-  local repo_tag="boost-1.82.0"
-  local library_name="boost"
-  local extra_flags=""
-
-  # clean up existing boost
-  clean_third_party "$library_name"
-
-  if [ ! -e "$library_name" ]; then
-    git clone -j 10 --recurse-submodules --depth 1 -b "$repo_tag" "$repo_url" "$library_name"
-  fi
-
-  export LDFLAGS="-Wl,--allow-shlib-undefined"
-  pushd "$library_name"
-  ./bootstrap.sh --prefix="$CMAKE_PREFIX_PATH" --libdir="$CMAKE_PREFIX_PATH/$LIB_SUFFIX" --without-libraries=python
-  ./b2 -q cxxflags=-fPIC cflags=-fPIC install
-  popd
-}
-
-function build_openssl() {
-  local repo_url="https://github.com/openssl/openssl.git"
-  local repo_tag="openssl-3.5.1"
-  local library_name="openssl"
-  local extra_flags=""
-
-  # clean up existing boost
-  clean_third_party "$library_name"
-
-  if [ ! -e "$library_name" ]; then
-    git clone -j 10 --recurse-submodules --depth 1 -b "$repo_tag" "$repo_url" "$library_name"
-  fi
-
-  pushd "$library_name"
-  ./config no-shared --prefix="$CMAKE_PREFIX_PATH" --openssldir="$CMAKE_PREFIX_PATH" --libdir=lib
-
-  make -j
-  make install
-  popd
-}
-
-function build_third_party {
-  # build third-party libraries
-  if [ "$CLEAN_THIRD_PARTY" == 1 ]; then
-    rm -f "${CONDA_PREFIX}"/*.cmake 2>/dev/null || true
-  fi
-  local third_party_tag="v2025.12.15.00"
-
-  mkdir -p /tmp/third-party
-  pushd /tmp/third-party
-  if [[ -z "${USE_SYSTEM_LIBS}" ]]; then
-    build_fb_oss_library "https://github.com/fmtlib/fmt.git" "11.2.0" fmt "-DFMT_INSTALL=ON -DFMT_TEST=OFF -DFMT_DOC=OFF"
-    build_fb_oss_library "https://github.com/fmtlib/fmt.git" "11.2.0" fmt "-DFMT_INSTALL=ON -DFMT_TEST=OFF -DFMT_DOC=OFF -DBUILD_SHARED_LIBS=ON"
-    build_fb_oss_library "https://github.com/madler/zlib.git" "v1.2.13" zlib "-DZLIB_BUILD_TESTING=OFF"
-    build_boost
-    build_openssl
-    build_fb_oss_library "https://github.com/Cyan4973/xxHash.git" "v0.8.0" xxhash
-    # we need both static and dynamic gflags since thrift generator can't
-    # statically link against glog.
-    build_fb_oss_library "https://github.com/gflags/gflags.git" "v2.2.2" gflags
-    build_fb_oss_library "https://github.com/gflags/gflags.git" "v2.2.2" gflags "-DBUILD_SHARED_LIBS=ON"
-    # we need both static and dynamic glog since thrift generator can't
-    # statically link against glog.
-    build_fb_oss_library "https://github.com/google/glog.git" "v0.4.0" glog
-    build_fb_oss_library "https://github.com/google/glog.git" "v0.4.0" glog "-DBUILD_SHARED_LIBS=ON"
-    build_fb_oss_library "https://github.com/facebook/zstd.git" "v1.5.6" zstd
-    build_automake_library "https://github.com/jedisct1/libsodium.git" "1.0.20-RELEASE" sodium
-    build_fb_oss_library "https://github.com/fastfloat/fast_float.git" "v8.0.2" fast_float "-DFASTFLOAT_INSTALL=ON"
-    build_fb_oss_library "https://github.com/libevent/libevent.git" "release-2.1.12-stable" event
-    build_fb_oss_library "https://github.com/google/double-conversion.git" "v3.3.1" double-conversion
-    build_fb_oss_library "https://github.com/facebook/folly.git" "$third_party_tag" folly "-DUSE_STATIC_DEPS_ON_UNIX=ON -DOPENSSL_USE_STATIC_LIBS=ON"
-  else
-    if [[ -z "${NCCL_SKIP_CONDA_INSTALL}" ]]; then
-      DEPS=(
-        cmake
-        ninja
-        jemalloc
-        gtest
-        boost
-        double-conversion
-        libevent
-        conda-forge::libsodium
-        libunwind
-        snappy
-        conda-forge::fast_float
-        libdwarf-dev
-        gflags
-        glog==0.4.0
-        xxhash
-        zstd
-        conda-forge::zlib
-        conda-forge::libopenssl-static
-        fmt
-      )
-      conda install "${DEPS[@]}" --yes
-    fi
-    build_fb_oss_library "https://github.com/facebook/folly.git" "$third_party_tag" folly
-  fi
-  build_fb_oss_library "https://github.com/facebookincubator/fizz.git" "$third_party_tag" fizz "-DBUILD_TESTS=OFF -DBUILD_EXAMPLES=OFF"
-  build_fb_oss_library "https://github.com/facebook/mvfst" "$third_party_tag" quic
-  build_fb_oss_library "https://github.com/facebook/wangle.git" "$third_party_tag" wangle "-DBUILD_TESTS=OFF"
-  build_fb_oss_library "https://github.com/facebook/fbthrift.git" "$third_party_tag" thrift
-  popd
-}
-
-function build_comms_tracing_service {
-  local include_prefix="comms/analyzer/if"
-  local base_dir="${PWD}"
-  local build_dir=/tmp/build/comms_tracing_service
-
-  mkdir -p "$build_dir"
-  pushd "$build_dir"
-  # set up the directory structure
-  mkdir -p "$include_prefix"
-  cp -r "${base_dir}/${include_prefix}"/* "$include_prefix"
-  mv "$include_prefix"/CMakeLists.txt .
-
-  # set up the build config
-  cp -r /tmp/third-party/thrift/build .
-
-  # build the thrift service library
-  cd build
-  do_cmake_build ..
-
-  popd
-}
-
-if [ -z "$DEV_SIGNATURE" ]; then
-    is_git=$(git rev-parse --is-inside-work-tree)
-    if [ $is_git ]; then
-        DEV_SIGNATURE="git-"$(git rev-parse --short HEAD)
-    else
-        echo "Cannot detect source repository hash. Skip"
-        DEV_SIGNATURE=""
-    fi
-fi
+#
+# This script installs conda dependencies required for building torchcomms
+# when USE_SYSTEM_LIBS is set. The actual build is handled by CMake.
+#
+# Usage:
+#   USE_SYSTEM_LIBS=1 ./build_ncclx.sh
+#
+# To skip conda install (e.g., if deps are already installed):
+#   USE_SYSTEM_LIBS=1 NCCL_SKIP_CONDA_INSTALL=1 ./build_ncclx.sh
 
 set -e
 
-export CMAKE_PREFIX_PATH="$CONDA_PREFIX"
-export LIB_PREFIX="lib64"
-
-BUILDDIR=${BUILDDIR:="${PWD}/build/ncclx"}
-CUDA_HOME=${CUDA_HOME:="/usr/local/cuda"}
-NVCC_ARCH=${NVCC_ARCH:="a100,h100"}
-
-# Add b200 support if CUDA 12.8+ is available
-CUDA_VERSION=$("${CUDA_HOME}/bin/nvcc" --version | grep -oP 'release \K[0-9]+\.[0-9]+')
-CUDA_MAJOR=$(echo "$CUDA_VERSION" | cut -d. -f1)
-CUDA_MINOR=$(echo "$CUDA_VERSION" | cut -d. -f2)
-if [[ "$CUDA_MAJOR" -gt 12 ]] || [[ "$CUDA_MAJOR" -eq 12 && "$CUDA_MINOR" -ge 8 ]]; then
-    NVCC_ARCH="${NVCC_ARCH},b200"
-fi
-NCCL_FP8=${NCCL_FP8:=1}
-CLEAN_BUILD=${CLEAN_BUILD:=0}
-LIB_SUFFIX=${LIB_SUFFIX:-lib}
-CONDA_INCLUDE_DIR="${CONDA_PREFIX}/include"
-CONDA_LIB_DIR="${CONDA_PREFIX}/lib"
-NCCL_HOOK_LIBS=${NCCL_HOOK_LIBS:=0}
-NCCL_HOME=${NCCL_HOME:="${PWD}/comms/ncclx/stable"}
-BASE_DIR=${BASE_DIR:="${PWD}"}
-CUDARTLIB=cudart_static
-THIRD_PARTY_LDFLAGS=""
-
-if [[ -z "${NCCL_BUILD_SKIP_DEPS}" ]]; then
-  echo "Building dependencies"
-  build_third_party
-  build_comms_tracing_service
-fi
-
-# set up the third-party ldflags
-export PKG_CONFIG_PATH="${CONDA_LIB_DIR}"/pkgconfig
-THRIFT_SERVICE_LDFLAGS=(
-  "-l:libcomms_tracing_service.a"
-  "-Wl,--start-group"
-  "-l:libasync.a"
-  "-l:libconcurrency.a"
-  "-l:libthrift-core.a"
-  "-l:libthriftanyrep.a"
-  "-l:libthriftcpp2.a"
-  "-l:libthriftmetadata.a"
-  "-l:libthriftprotocol.a"
-  "-l:libthrifttype.a"
-  "-l:libthrifttyperep.a"
-  "-l:librpcmetadata.a"
-  "-l:libruntime.a"
-  "-l:libserverdbginfo.a"
-  "-l:libtransport.a"
-  "-l:libcommon.a"
-  "-Wl,--end-group"
-  "-l:libwangle.a"
-  "-l:libfizz.a"
-  "-l:libxxhash.a"
-)
-THIRD_PARTY_LDFLAGS+="${THRIFT_SERVICE_LDFLAGS[*]} "
-THIRD_PARTY_LDFLAGS+="$(pkg-config --libs --static libfolly) "
-if [[ -z "${USE_SYSTEM_LIBS}" ]]; then
-  THIRD_PARTY_LDFLAGS+="-l:libglog.a -l:libgflags.a -l:libboost_context.a -l:libfmt.a -l:libssl.a -l:libcrypto.a"
-else
-  THIRD_PARTY_LDFLAGS+="-lglog -lgflags -lboost_context -lfmt -lssl -lcrypto"
-fi
-
-if [[ -z "${NVCC_GENCODE-}" ]]; then
-    IFS=',' read -ra arch_array <<< "$NVCC_ARCH"
-    arch_gencode=""
-    for arch in "${arch_array[@]}"
-    do
-        case "$arch" in
-        "p100")
-        arch_gencode="$arch_gencode -gencode=arch=compute_60,code=sm_60"
-            ;;
-        "v100")
-        arch_gencode="$arch_gencode -gencode=arch=compute_70,code=sm_70"
-            ;;
-        "a100")
-        arch_gencode="$arch_gencode -gencode=arch=compute_80,code=sm_80"
-        ;;
-        "h100")
-            arch_gencode="$arch_gencode -gencode=arch=compute_90,code=sm_90"
-        ;;
-        "b200")
-            arch_gencode="$arch_gencode -gencode=arch=compute_100,code=sm_100"
-        ;;
-        esac
-    done
-    NVCC_GENCODE=$arch_gencode
-fi
-
-if [ "$CLEAN_BUILD" == 1 ]; then
-    rm -rf "$BUILDDIR"
-fi
-
-mkdir -p "$BUILDDIR"
-pushd "${NCCL_HOME}"
-
-function build_nccl {
-  make VERBOSE=1 -j \
-    src.build \
-    BUILDDIR="$BUILDDIR" \
-    NVCC_GENCODE="$NVCC_GENCODE" \
-    CUDA_HOME="$CUDA_HOME" \
-    NCCL_HOME="$NCCL_HOME" \
-    NCCL_SUFFIX="x-${DEV_SIGNATURE}" \
-    NCCL_FP8="$NCCL_FP8" \
-    BASE_DIR="$BASE_DIR" \
-    CONDA_INCLUDE_DIR="$CONDA_INCLUDE_DIR" \
-    CONDA_LIB_DIR="$CONDA_LIB_DIR" \
-    THIRD_PARTY_LDFLAGS="$THIRD_PARTY_LDFLAGS" \
-    NCCL_ENABLE_IN_TRAINER_TUNE="$NCCL_ENABLE_IN_TRAINER_TUNE" \
-    CUDARTLIB="$CUDARTLIB"
-}
-
-function build_and_install_nccl {
-make VERBOSE=1 -j \
-    src.install \
-    BUILDDIR="$BUILDDIR" \
-    NVCC_GENCODE="$NVCC_GENCODE" \
-    CUDA_HOME="$CUDA_HOME" \
-    NCCL_HOME="$NCCL_HOME" \
-    NCCL_SUFFIX="x-${DEV_SIGNATURE}" \
-    NCCL_FP8="$NCCL_FP8" \
-    BASE_DIR="$BASE_DIR" \
-    CONDA_INCLUDE_DIR="$CONDA_INCLUDE_DIR" \
-    CONDA_LIB_DIR="$CONDA_LIB_DIR" \
-    THIRD_PARTY_LDFLAGS="$THIRD_PARTY_LDFLAGS" \
-    NCCL_ENABLE_IN_TRAINER_TUNE="$NCCL_ENABLE_IN_TRAINER_TUNE" \
-    CUDARTLIB="$CUDARTLIB"
-}
-
-if [[ -z "${NCCL_BUILD_INSTALL_NCCL}" ]]; then
-  build_nccl
-else
-  build_and_install_nccl
-fi
-
-# sanity check
-if [ -n "${NCCL_RUN_SANITY_CHECK}" ]; then
-    pushd examples
-    export NCCL_DEBUG=WARN
-    export LD_LIBRARY_PATH=$BUILDDIR/lib
-
-    make all \
-      NVCC_GENCODE="$NVCC_GENCODE" \
-      CUDA_HOME="$CUDA_HOME" \
-      NCCL_HOME="$CONDA_PREFIX" \
-      DEV_SIGNATURE="$DEV_SIGNATURE" \
-      FBCODE_DIR="$FBCODE_DIR" \
-      CONDA_INCLUDE_DIR="$CONDA_INCLUDE_DIR" \
-      CONDA_LIB_DIR="$CONDA_LIB_DIR" \
-      NCCL_ENABLE_IN_TRAINER_TUNE="$NCCL_ENABLE_IN_TRAINER_TUNE"
-
-    set +e
-
-    TIMEOUT=10s
-    timeout $TIMEOUT "$BUILDDIR"/examples/HelloWorld
-    if [ "$?" == "124" ]; then
-        echo "Program TIMEOUT in ${TIMEOUT}. Terminate."
+# Only install conda dependencies when USE_SYSTEM_LIBS is set
+if [[ -n "${USE_SYSTEM_LIBS}" ]]; then
+    if [[ -z "${NCCL_SKIP_CONDA_INSTALL}" ]]; then
+        echo "Installing conda dependencies for USE_SYSTEM_LIBS build..."
+        DEPS=(
+            cmake
+            ninja
+            jemalloc
+            gtest
+            boost
+            double-conversion
+            libevent
+            conda-forge::libsodium
+            libunwind
+            snappy
+            conda-forge::fast_float
+            libdwarf-dev
+            gflags
+            glog==0.4.0
+            xxhash
+            zstd
+            conda-forge::zlib
+            conda-forge::libopenssl-static
+            fmt
+        )
+        conda install "${DEPS[@]}" --yes
+        echo "Conda dependencies installed successfully."
+    else
+        echo "NCCL_SKIP_CONDA_INSTALL is set, skipping conda install."
     fi
-    popd
+else
+    echo "USE_SYSTEM_LIBS is not set. Conda dependencies are not needed."
+    echo "Third-party dependencies will be built from source by CMake."
 fi
-
-popd

--- a/cmake/CommsTracingService.cmake
+++ b/cmake/CommsTracingService.cmake
@@ -1,0 +1,78 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Build the CommsTracingService thrift library.
+# This module sets up the thrift service library that NCCLX depends on.
+
+# This requires thrift to be built first
+if(NOT TARGET third_party_deps)
+    message(FATAL_ERROR "ThirdParty.cmake must be included before CommsTracingService.cmake")
+endif()
+
+# Determine install prefix
+if(DEFINED ENV{CONDA_PREFIX})
+    set(COMMS_TRACING_INSTALL_PREFIX "$ENV{CONDA_PREFIX}" CACHE PATH "CommsTracingService install prefix")
+else()
+    set(COMMS_TRACING_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/conda" CACHE PATH "CommsTracingService install prefix")
+endif()
+
+set(COMMS_TRACING_BUILD_DIR "${CMAKE_BINARY_DIR}/comms_tracing_service")
+set(COMMS_TRACING_LIB_DIR "${COMMS_TRACING_INSTALL_PREFIX}/lib")
+set(COMMS_TRACING_INCLUDE_DIR "${COMMS_TRACING_INSTALL_PREFIX}/include")
+
+# Skip if USE_SYSTEM_LIBS is set
+if(USE_SYSTEM_LIBS)
+    message(STATUS "USE_SYSTEM_LIBS is set, skipping comms_tracing_service build")
+    add_custom_target(comms_tracing_service_deps)
+    return()
+endif()
+
+# Skip if NCCL_BUILD_SKIP_DEPS is set
+if(DEFINED ENV{NCCL_BUILD_SKIP_DEPS})
+    message(STATUS "NCCL_BUILD_SKIP_DEPS is set, skipping comms_tracing_service build")
+    add_custom_target(comms_tracing_service_deps)
+    return()
+endif()
+
+message(STATUS "Building comms_tracing_service to ${COMMS_TRACING_INSTALL_PREFIX}")
+
+# Common CMake args
+set(COMMS_TRACING_CMAKE_ARGS
+    -DCMAKE_PREFIX_PATH=${COMMS_TRACING_INSTALL_PREFIX}
+    -DCMAKE_INSTALL_PREFIX=${COMMS_TRACING_INSTALL_PREFIX}
+    -DCMAKE_MODULE_PATH=${COMMS_TRACING_INSTALL_PREFIX}
+    -DCMAKE_INSTALL_LIBDIR=${COMMS_TRACING_LIB_DIR}
+    -DCMAKE_INSTALL_INCLUDEDIR=${COMMS_TRACING_INCLUDE_DIR}
+    -DBUILD_SHARED_LIBS=OFF
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+    -DCMAKE_CXX_STANDARD=20
+    -DCMAKE_BUILD_TYPE=Release
+)
+
+# Build comms_tracing_service
+# This is more complex because we need to set up the directory structure and copy files
+ExternalProject_Add(comms_tracing_service
+    DOWNLOAD_COMMAND ""
+    SOURCE_DIR ${COMMS_TRACING_BUILD_DIR}/src
+    CONFIGURE_COMMAND ${CMAKE_COMMAND} -E make_directory ${COMMS_TRACING_BUILD_DIR}/src
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${COMMS_TRACING_BUILD_DIR}/src/comms/analyzer/if
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+            ${CMAKE_SOURCE_DIR}/comms/analyzer/if
+            ${COMMS_TRACING_BUILD_DIR}/src/comms/analyzer/if
+        COMMAND ${CMAKE_COMMAND} -E copy
+            ${COMMS_TRACING_BUILD_DIR}/src/comms/analyzer/if/CMakeLists.txt
+            ${COMMS_TRACING_BUILD_DIR}/src/CMakeLists.txt
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+            ${CMAKE_BINARY_DIR}/third-party/thrift/src/thrift-build
+            ${COMMS_TRACING_BUILD_DIR}/src/build
+        COMMAND ${CMAKE_COMMAND} -S ${COMMS_TRACING_BUILD_DIR}/src
+            -B ${COMMS_TRACING_BUILD_DIR}/build
+            ${COMMS_TRACING_CMAKE_ARGS}
+    BUILD_COMMAND ${CMAKE_COMMAND} --build ${COMMS_TRACING_BUILD_DIR}/build
+    INSTALL_COMMAND ${CMAKE_COMMAND} --install ${COMMS_TRACING_BUILD_DIR}/build
+    PREFIX ${COMMS_TRACING_BUILD_DIR}
+    DEPENDS third_party_deps
+)
+
+add_custom_target(comms_tracing_service_deps
+    DEPENDS comms_tracing_service
+)

--- a/cmake/NCCLX.cmake
+++ b/cmake/NCCLX.cmake
@@ -1,0 +1,162 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Build NCCLX using the make-based build system.
+# This module wraps the NCCLX Makefile build via add_custom_target.
+
+# NCCLX source directory
+set(NCCLX_HOME "${CMAKE_SOURCE_DIR}/comms/ncclx/stable" CACHE PATH "NCCLX source directory")
+
+# NCCLX build directory
+set(NCCLX_BUILD_DIR "${CMAKE_BINARY_DIR}/ncclx" CACHE PATH "NCCLX build output directory")
+
+# CUDA settings
+if(DEFINED ENV{CUDA_HOME})
+    set(NCCLX_CUDA_HOME "$ENV{CUDA_HOME}")
+else()
+    set(NCCLX_CUDA_HOME "/usr/local/cuda")
+endif()
+
+# Get CUDA version to determine arch support
+execute_process(
+    COMMAND ${NCCLX_CUDA_HOME}/bin/nvcc --version
+    OUTPUT_VARIABLE NVCC_VERSION_OUTPUT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+)
+string(REGEX MATCH "release ([0-9]+)\\.([0-9]+)" CUDA_VERSION_MATCH "${NVCC_VERSION_OUTPUT}")
+set(CUDA_MAJOR "${CMAKE_MATCH_1}")
+set(CUDA_MINOR "${CMAKE_MATCH_2}")
+
+# Determine NVCC architectures
+if(DEFINED ENV{NVCC_ARCH})
+    set(NCCLX_NVCC_ARCH "$ENV{NVCC_ARCH}")
+else()
+    set(NCCLX_NVCC_ARCH "a100,h100")
+    # Add b200 support if CUDA 12.8+
+    if(CUDA_MAJOR GREATER 12 OR (CUDA_MAJOR EQUAL 12 AND CUDA_MINOR GREATER_EQUAL 8))
+        set(NCCLX_NVCC_ARCH "${NCCLX_NVCC_ARCH},b200")
+    endif()
+endif()
+
+# Convert arch names to NVCC gencode flags
+set(NVCC_GENCODE "")
+string(REPLACE "," ";" ARCH_LIST "${NCCLX_NVCC_ARCH}")
+foreach(arch ${ARCH_LIST})
+    if(arch STREQUAL "p100")
+        string(APPEND NVCC_GENCODE " -gencode=arch=compute_60,code=sm_60")
+    elseif(arch STREQUAL "v100")
+        string(APPEND NVCC_GENCODE " -gencode=arch=compute_70,code=sm_70")
+    elseif(arch STREQUAL "a100")
+        string(APPEND NVCC_GENCODE " -gencode=arch=compute_80,code=sm_80")
+    elseif(arch STREQUAL "h100")
+        string(APPEND NVCC_GENCODE " -gencode=arch=compute_90,code=sm_90")
+    elseif(arch STREQUAL "b200")
+        string(APPEND NVCC_GENCODE " -gencode=arch=compute_100,code=sm_100")
+    endif()
+endforeach()
+string(STRIP "${NVCC_GENCODE}" NVCC_GENCODE)
+
+# Use environment variable if set
+if(DEFINED ENV{NVCC_GENCODE})
+    set(NVCC_GENCODE "$ENV{NVCC_GENCODE}")
+endif()
+
+# Other settings
+if(DEFINED ENV{NCCL_FP8})
+    set(NCCLX_FP8 "$ENV{NCCL_FP8}")
+else()
+    set(NCCLX_FP8 "1")
+endif()
+
+if(DEFINED ENV{NCCL_ENABLE_IN_TRAINER_TUNE})
+    set(NCCLX_IN_TRAINER_TUNE "$ENV{NCCL_ENABLE_IN_TRAINER_TUNE}")
+else()
+    set(NCCLX_IN_TRAINER_TUNE "")
+endif()
+
+# Get dev signature
+execute_process(
+    COMMAND git rev-parse --short HEAD
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_SHORT_HASH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+)
+if(DEFINED ENV{DEV_SIGNATURE})
+    set(NCCLX_DEV_SIGNATURE "$ENV{DEV_SIGNATURE}")
+elseif(GIT_SHORT_HASH)
+    set(NCCLX_DEV_SIGNATURE "git-${GIT_SHORT_HASH}")
+else()
+    set(NCCLX_DEV_SIGNATURE "")
+endif()
+
+# Install prefix - use CONDA_PREFIX if available
+if(DEFINED ENV{CONDA_PREFIX})
+    set(NCCLX_INSTALL_PREFIX "$ENV{CONDA_PREFIX}")
+else()
+    set(NCCLX_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/conda")
+endif()
+
+set(NCCLX_LIB_SUFFIX "lib" CACHE STRING "Library directory suffix")
+set(NCCLX_LIB_DIR "${NCCLX_INSTALL_PREFIX}/${NCCLX_LIB_SUFFIX}")
+set(NCCLX_INCLUDE_DIR "${NCCLX_INSTALL_PREFIX}/include")
+
+# Build THIRD_PARTY_LDFLAGS - base flags that don't require pkg-config
+set(THRIFT_SERVICE_LDFLAGS "-l:libcomms_tracing_service.a -Wl,--start-group -l:libasync.a -l:libconcurrency.a -l:libthrift-core.a -l:libthriftanyrep.a -l:libthriftcpp2.a -l:libthriftmetadata.a -l:libthriftprotocol.a -l:libthrifttype.a -l:libthrifttyperep.a -l:librpcmetadata.a -l:libruntime.a -l:libserverdbginfo.a -l:libtransport.a -l:libcommon.a -Wl,--end-group -l:libwangle.a -l:libfizz.a -l:libxxhash.a")
+set(STATIC_LDFLAGS "-l:libglog.a -l:libgflags.a -l:libboost_context.a -l:libfmt.a -l:libssl.a -l:libcrypto.a")
+
+# Create a build script that handles pkg-config at build time
+set(NCCLX_BUILD_SCRIPT "${CMAKE_BINARY_DIR}/build_ncclx.sh")
+file(WRITE ${NCCLX_BUILD_SCRIPT} "#!/bin/bash
+set -ex
+
+export PKG_CONFIG_PATH=\"${NCCLX_LIB_DIR}/pkgconfig\"
+export LDFLAGS=\"-Wl,--allow-shlib-undefined\"
+
+# Get folly LDFLAGS via pkg-config
+FOLLY_LDFLAGS=\$(pkg-config --libs --static libfolly 2>/dev/null || echo \"\")
+
+# Build THIRD_PARTY_LDFLAGS
+THIRD_PARTY_LDFLAGS=\"${THRIFT_SERVICE_LDFLAGS} \${FOLLY_LDFLAGS} ${STATIC_LDFLAGS}\"
+
+make -C \"${NCCLX_HOME}\" VERBOSE=1 -j \\
+    \"\$1\" \\
+    BUILDDIR=\"${NCCLX_BUILD_DIR}\" \\
+    NVCC_GENCODE=\"${NVCC_GENCODE}\" \\
+    CUDA_HOME=\"${NCCLX_CUDA_HOME}\" \\
+    NCCL_HOME=\"${NCCLX_HOME}\" \\
+    NCCL_SUFFIX=\"x-${NCCLX_DEV_SIGNATURE}\" \\
+    NCCL_FP8=\"${NCCLX_FP8}\" \\
+    BASE_DIR=\"${CMAKE_SOURCE_DIR}\" \\
+    CONDA_INCLUDE_DIR=\"${NCCLX_INCLUDE_DIR}\" \\
+    CONDA_LIB_DIR=\"${NCCLX_LIB_DIR}\" \\
+    THIRD_PARTY_LDFLAGS=\"\${THIRD_PARTY_LDFLAGS}\" \\
+    NCCL_ENABLE_IN_TRAINER_TUNE=\"${NCCLX_IN_TRAINER_TUNE}\" \\
+    CUDARTLIB=cudart_static
+")
+file(CHMOD ${NCCLX_BUILD_SCRIPT} PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+
+# Build NCCLX using the generated script
+add_custom_target(ncclx_build
+    COMMAND ${NCCLX_BUILD_SCRIPT} src.build
+    WORKING_DIRECTORY ${NCCLX_HOME}
+    COMMENT "Building NCCLX with make"
+    DEPENDS comms_tracing_service_deps
+)
+
+# Install target
+add_custom_target(ncclx_install
+    COMMAND ${NCCLX_BUILD_SCRIPT} src.install
+    WORKING_DIRECTORY ${NCCLX_HOME}
+    COMMENT "Installing NCCLX"
+    DEPENDS ncclx_build
+)
+
+# Export paths for consumers
+set(NCCLX_INCLUDE "${NCCLX_BUILD_DIR}/include" CACHE PATH "NCCLX include directory" FORCE)
+set(NCCLX_STATIC_LIB "${NCCLX_BUILD_DIR}/lib/libnccl_static.a" CACHE FILEPATH "NCCLX static library" FORCE)
+set(NCCLX_SHARED_LIB "${NCCLX_BUILD_DIR}/lib/libnccl.so" CACHE FILEPATH "NCCLX shared library" FORCE)
+
+message(STATUS "NCCLX will be built to: ${NCCLX_BUILD_DIR}")
+message(STATUS "NCCLX architectures: ${NCCLX_NVCC_ARCH}")
+message(STATUS "NCCLX CUDA home: ${NCCLX_CUDA_HOME}")

--- a/cmake/ThirdParty.cmake
+++ b/cmake/ThirdParty.cmake
@@ -1,0 +1,339 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Third-party dependency management for torchcomms/NCCLX build.
+# This module fetches and builds all third-party dependencies needed by NCCLX.
+
+include(ExternalProject)
+include(FetchContent)
+
+set(THIRD_PARTY_TAG "v2025.12.15.00" CACHE STRING "FB OSS library version tag")
+set(THIRD_PARTY_BUILD_DIR "${CMAKE_BINARY_DIR}/third-party" CACHE PATH "Third-party build directory")
+
+# Determine install prefix - use CONDA_PREFIX if available, else build directory
+if(DEFINED ENV{CONDA_PREFIX})
+    set(THIRD_PARTY_INSTALL_PREFIX "$ENV{CONDA_PREFIX}" CACHE PATH "Third-party install prefix")
+else()
+    set(THIRD_PARTY_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/conda" CACHE PATH "Third-party install prefix")
+endif()
+
+set(THIRD_PARTY_LIB_SUFFIX "lib" CACHE STRING "Library directory suffix")
+set(THIRD_PARTY_LIB_DIR "${THIRD_PARTY_INSTALL_PREFIX}/${THIRD_PARTY_LIB_SUFFIX}")
+set(THIRD_PARTY_INCLUDE_DIR "${THIRD_PARTY_INSTALL_PREFIX}/include")
+
+# Common CMake args for ExternalProject builds
+set(THIRD_PARTY_CMAKE_ARGS
+    -DCMAKE_PREFIX_PATH=${THIRD_PARTY_INSTALL_PREFIX}
+    -DCMAKE_INSTALL_PREFIX=${THIRD_PARTY_INSTALL_PREFIX}
+    -DCMAKE_MODULE_PATH=${THIRD_PARTY_INSTALL_PREFIX}
+    -DCMAKE_INSTALL_DIR=${THIRD_PARTY_INSTALL_PREFIX}
+    -DBIN_INSTALL_DIR=${THIRD_PARTY_INSTALL_PREFIX}/bin
+    -DLIB_INSTALL_DIR=${THIRD_PARTY_LIB_DIR}
+    -DINCLUDE_INSTALL_DIR=${THIRD_PARTY_INCLUDE_DIR}
+    -DCMAKE_INSTALL_INCLUDEDIR=${THIRD_PARTY_INCLUDE_DIR}
+    -DCMAKE_INSTALL_LIBDIR=${THIRD_PARTY_LIB_DIR}
+    -DBUILD_SHARED_LIBS=OFF
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+    -DCMAKE_CXX_STANDARD=20
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.22
+    -DCMAKE_BUILD_TYPE=Release
+)
+
+# Skip building third-party if USE_SYSTEM_LIBS is set
+if(USE_SYSTEM_LIBS)
+    message(STATUS "USE_SYSTEM_LIBS is set, skipping third-party builds")
+    add_custom_target(third_party_deps)
+    return()
+endif()
+
+# Skip if NCCL_BUILD_SKIP_DEPS is set
+if(DEFINED ENV{NCCL_BUILD_SKIP_DEPS})
+    message(STATUS "NCCL_BUILD_SKIP_DEPS is set, skipping third-party builds")
+    add_custom_target(third_party_deps)
+    return()
+endif()
+
+message(STATUS "Building third-party dependencies to ${THIRD_PARTY_INSTALL_PREFIX}")
+
+# ============================================================================
+# fmt library
+# ============================================================================
+ExternalProject_Add(fmt
+    GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+    GIT_TAG 11.2.0
+    GIT_SHALLOW TRUE
+    PREFIX ${THIRD_PARTY_BUILD_DIR}/fmt
+    CMAKE_ARGS ${THIRD_PARTY_CMAKE_ARGS}
+        -DFMT_INSTALL=ON
+        -DFMT_TEST=OFF
+        -DFMT_DOC=OFF
+    CMAKE_GENERATOR Ninja
+)
+
+# Build shared fmt as well
+ExternalProject_Add(fmt_shared
+    GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+    GIT_TAG 11.2.0
+    GIT_SHALLOW TRUE
+    PREFIX ${THIRD_PARTY_BUILD_DIR}/fmt_shared
+    CMAKE_ARGS ${THIRD_PARTY_CMAKE_ARGS}
+        -DFMT_INSTALL=ON
+        -DFMT_TEST=OFF
+        -DFMT_DOC=OFF
+        -DBUILD_SHARED_LIBS=ON
+    CMAKE_GENERATOR Ninja
+    DEPENDS fmt
+)
+
+# ============================================================================
+# zlib library
+# ============================================================================
+ExternalProject_Add(zlib
+    GIT_REPOSITORY https://github.com/madler/zlib.git
+    GIT_TAG v1.2.13
+    GIT_SHALLOW TRUE
+    PREFIX ${THIRD_PARTY_BUILD_DIR}/zlib
+    CMAKE_ARGS ${THIRD_PARTY_CMAKE_ARGS}
+        -DZLIB_BUILD_TESTING=OFF
+    CMAKE_GENERATOR Ninja
+)
+
+# ============================================================================
+# boost library (uses b2 build system)
+# ============================================================================
+ExternalProject_Add(boost
+    GIT_REPOSITORY https://github.com/boostorg/boost.git
+    GIT_TAG boost-1.82.0
+    GIT_SHALLOW TRUE
+    GIT_SUBMODULES_RECURSE TRUE
+    PREFIX ${THIRD_PARTY_BUILD_DIR}/boost
+    CONFIGURE_COMMAND ./bootstrap.sh
+        --prefix=${THIRD_PARTY_INSTALL_PREFIX}
+        --libdir=${THIRD_PARTY_LIB_DIR}
+        --without-libraries=python
+    BUILD_COMMAND ./b2 -q cxxflags=-fPIC cflags=-fPIC install
+    BUILD_IN_SOURCE TRUE
+    INSTALL_COMMAND ""
+)
+
+# ============================================================================
+# openssl library (uses autoconf)
+# ============================================================================
+ExternalProject_Add(openssl
+    GIT_REPOSITORY https://github.com/openssl/openssl.git
+    GIT_TAG openssl-3.5.1
+    GIT_SHALLOW TRUE
+    GIT_SUBMODULES_RECURSE TRUE
+    PREFIX ${THIRD_PARTY_BUILD_DIR}/openssl
+    CONFIGURE_COMMAND ./config no-shared
+        --prefix=${THIRD_PARTY_INSTALL_PREFIX}
+        --openssldir=${THIRD_PARTY_INSTALL_PREFIX}
+        --libdir=lib
+    BUILD_COMMAND ${CMAKE_COMMAND} -E env make -j
+    INSTALL_COMMAND ${CMAKE_COMMAND} -E env make install
+    BUILD_IN_SOURCE TRUE
+)
+
+# ============================================================================
+# xxHash library
+# ============================================================================
+ExternalProject_Add(xxhash
+    GIT_REPOSITORY https://github.com/Cyan4973/xxHash.git
+    GIT_TAG v0.8.0
+    GIT_SHALLOW TRUE
+    PREFIX ${THIRD_PARTY_BUILD_DIR}/xxhash
+    SOURCE_SUBDIR cmake_unofficial
+    CMAKE_ARGS ${THIRD_PARTY_CMAKE_ARGS}
+    CMAKE_GENERATOR Ninja
+)
+
+# ============================================================================
+# gflags library (static)
+# ============================================================================
+ExternalProject_Add(gflags
+    GIT_REPOSITORY https://github.com/gflags/gflags.git
+    GIT_TAG v2.2.2
+    GIT_SHALLOW TRUE
+    PREFIX ${THIRD_PARTY_BUILD_DIR}/gflags
+    CMAKE_ARGS ${THIRD_PARTY_CMAKE_ARGS}
+    CMAKE_GENERATOR Ninja
+)
+
+# gflags shared (needed by thrift generator)
+ExternalProject_Add(gflags_shared
+    GIT_REPOSITORY https://github.com/gflags/gflags.git
+    GIT_TAG v2.2.2
+    GIT_SHALLOW TRUE
+    PREFIX ${THIRD_PARTY_BUILD_DIR}/gflags_shared
+    CMAKE_ARGS ${THIRD_PARTY_CMAKE_ARGS}
+        -DBUILD_SHARED_LIBS=ON
+    CMAKE_GENERATOR Ninja
+    DEPENDS gflags
+)
+
+# ============================================================================
+# glog library (static)
+# ============================================================================
+ExternalProject_Add(glog
+    GIT_REPOSITORY https://github.com/google/glog.git
+    GIT_TAG v0.4.0
+    GIT_SHALLOW TRUE
+    PREFIX ${THIRD_PARTY_BUILD_DIR}/glog
+    CMAKE_ARGS ${THIRD_PARTY_CMAKE_ARGS}
+    CMAKE_GENERATOR Ninja
+    DEPENDS gflags
+)
+
+# glog shared (needed by thrift generator)
+ExternalProject_Add(glog_shared
+    GIT_REPOSITORY https://github.com/google/glog.git
+    GIT_TAG v0.4.0
+    GIT_SHALLOW TRUE
+    PREFIX ${THIRD_PARTY_BUILD_DIR}/glog_shared
+    CMAKE_ARGS ${THIRD_PARTY_CMAKE_ARGS}
+        -DBUILD_SHARED_LIBS=ON
+    CMAKE_GENERATOR Ninja
+    DEPENDS glog gflags_shared
+)
+
+# ============================================================================
+# zstd library
+# ============================================================================
+ExternalProject_Add(zstd
+    GIT_REPOSITORY https://github.com/facebook/zstd.git
+    GIT_TAG v1.5.6
+    GIT_SHALLOW TRUE
+    PREFIX ${THIRD_PARTY_BUILD_DIR}/zstd
+    SOURCE_SUBDIR build/cmake
+    CMAKE_ARGS ${THIRD_PARTY_CMAKE_ARGS}
+    CMAKE_GENERATOR Ninja
+)
+
+# ============================================================================
+# libsodium library (uses autoconf)
+# ============================================================================
+ExternalProject_Add(sodium
+    GIT_REPOSITORY https://github.com/jedisct1/libsodium.git
+    GIT_TAG 1.0.20-RELEASE
+    GIT_SHALLOW TRUE
+    PREFIX ${THIRD_PARTY_BUILD_DIR}/sodium
+    CONFIGURE_COMMAND ./configure --prefix=${THIRD_PARTY_INSTALL_PREFIX} --disable-pie
+    BUILD_COMMAND ${CMAKE_COMMAND} -E env LDFLAGS=-Wl,--allow-shlib-undefined make -j
+    INSTALL_COMMAND make install
+    BUILD_IN_SOURCE TRUE
+)
+
+# ============================================================================
+# fast_float library
+# ============================================================================
+ExternalProject_Add(fast_float
+    GIT_REPOSITORY https://github.com/fastfloat/fast_float.git
+    GIT_TAG v8.0.2
+    GIT_SHALLOW TRUE
+    PREFIX ${THIRD_PARTY_BUILD_DIR}/fast_float
+    CMAKE_ARGS ${THIRD_PARTY_CMAKE_ARGS}
+        -DFASTFLOAT_INSTALL=ON
+    CMAKE_GENERATOR Ninja
+)
+
+# ============================================================================
+# libevent library
+# ============================================================================
+ExternalProject_Add(libevent
+    GIT_REPOSITORY https://github.com/libevent/libevent.git
+    GIT_TAG release-2.1.12-stable
+    GIT_SHALLOW TRUE
+    PREFIX ${THIRD_PARTY_BUILD_DIR}/libevent
+    CMAKE_ARGS ${THIRD_PARTY_CMAKE_ARGS}
+    CMAKE_GENERATOR Ninja
+    DEPENDS openssl
+)
+
+# ============================================================================
+# double-conversion library
+# ============================================================================
+ExternalProject_Add(double-conversion
+    GIT_REPOSITORY https://github.com/google/double-conversion.git
+    GIT_TAG v3.3.1
+    GIT_SHALLOW TRUE
+    PREFIX ${THIRD_PARTY_BUILD_DIR}/double-conversion
+    CMAKE_ARGS ${THIRD_PARTY_CMAKE_ARGS}
+    CMAKE_GENERATOR Ninja
+)
+
+# ============================================================================
+# folly library
+# ============================================================================
+ExternalProject_Add(folly
+    GIT_REPOSITORY https://github.com/facebook/folly.git
+    GIT_TAG ${THIRD_PARTY_TAG}
+    GIT_SHALLOW TRUE
+    PREFIX ${THIRD_PARTY_BUILD_DIR}/folly
+    SOURCE_SUBDIR folly
+    CMAKE_ARGS ${THIRD_PARTY_CMAKE_ARGS}
+        -DUSE_STATIC_DEPS_ON_UNIX=ON
+        -DOPENSSL_USE_STATIC_LIBS=ON
+    CMAKE_GENERATOR Ninja
+    DEPENDS fmt zlib boost openssl xxhash gflags glog zstd sodium fast_float libevent double-conversion
+)
+
+# ============================================================================
+# fizz library
+# ============================================================================
+ExternalProject_Add(fizz
+    GIT_REPOSITORY https://github.com/facebookincubator/fizz.git
+    GIT_TAG ${THIRD_PARTY_TAG}
+    GIT_SHALLOW TRUE
+    PREFIX ${THIRD_PARTY_BUILD_DIR}/fizz
+    SOURCE_SUBDIR fizz
+    CMAKE_ARGS ${THIRD_PARTY_CMAKE_ARGS}
+        -DBUILD_TESTS=OFF
+        -DBUILD_EXAMPLES=OFF
+    CMAKE_GENERATOR Ninja
+    DEPENDS folly
+)
+
+# ============================================================================
+# mvfst (quic) library
+# ============================================================================
+ExternalProject_Add(quic
+    GIT_REPOSITORY https://github.com/facebook/mvfst.git
+    GIT_TAG ${THIRD_PARTY_TAG}
+    GIT_SHALLOW TRUE
+    PREFIX ${THIRD_PARTY_BUILD_DIR}/quic
+    CMAKE_ARGS ${THIRD_PARTY_CMAKE_ARGS}
+    CMAKE_GENERATOR Ninja
+    DEPENDS fizz
+)
+
+# ============================================================================
+# wangle library
+# ============================================================================
+ExternalProject_Add(wangle
+    GIT_REPOSITORY https://github.com/facebook/wangle.git
+    GIT_TAG ${THIRD_PARTY_TAG}
+    GIT_SHALLOW TRUE
+    PREFIX ${THIRD_PARTY_BUILD_DIR}/wangle
+    SOURCE_SUBDIR wangle
+    CMAKE_ARGS ${THIRD_PARTY_CMAKE_ARGS}
+        -DBUILD_TESTS=OFF
+    CMAKE_GENERATOR Ninja
+    DEPENDS quic
+)
+
+# ============================================================================
+# fbthrift library
+# ============================================================================
+ExternalProject_Add(thrift
+    GIT_REPOSITORY https://github.com/facebook/fbthrift.git
+    GIT_TAG ${THIRD_PARTY_TAG}
+    GIT_SHALLOW TRUE
+    PREFIX ${THIRD_PARTY_BUILD_DIR}/thrift
+    CMAKE_ARGS ${THIRD_PARTY_CMAKE_ARGS}
+    CMAKE_GENERATOR Ninja
+    DEPENDS wangle glog_shared gflags_shared
+)
+
+# Create a target that depends on all third-party libraries
+add_custom_target(third_party_deps
+    DEPENDS thrift
+)

--- a/comms/torchcomms/gloo/CMakeLists.txt
+++ b/comms/torchcomms/gloo/CMakeLists.txt
@@ -1,14 +1,28 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # Extension: torchcomms._comms_gloo
 
-include(FetchContent)
-FetchContent_Declare(
-  gloo
-  GIT_REPOSITORY https://github.com/pytorch/gloo.git
-  GIT_TAG        main
-)
-# fetch but don't build
-FetchContent_Populate(gloo)
+# Allow using a pre-existing gloo source directory via environment variable
+# This avoids network fetching when gloo is already available locally
+if(DEFINED ENV{GLOO_SOURCE_DIR})
+    set(gloo_SOURCE_DIR "$ENV{GLOO_SOURCE_DIR}")
+    message(STATUS "Using GLOO_SOURCE_DIR from environment: ${gloo_SOURCE_DIR}")
+elseif(NOT gloo_SOURCE_DIR)
+    include(FetchContent)
+    # Silence deprecation warning for FetchContent_Populate
+    # We only want the source, not to build gloo as a subproject
+    if(POLICY CMP0169)
+        cmake_policy(SET CMP0169 OLD)
+    endif()
+    FetchContent_Declare(
+      gloo
+      GIT_REPOSITORY https://github.com/pytorch/gloo.git
+      GIT_TAG        main
+    )
+    # Fetch but don't build - we only need the headers
+    FetchContent_Populate(gloo)
+endif()
+
+message(STATUS "Gloo source directory: ${gloo_SOURCE_DIR}")
 
 file(GLOB TORCHCOMMS_GLOO_SOURCES "comms/torchcomms/gloo/*.cpp")
 
@@ -21,7 +35,6 @@ set_target_properties(torchcomms_comms_gloo PROPERTIES
 )
 target_include_directories(torchcomms_comms_gloo PRIVATE
     ${ROOT}
-    ${FMT_INCLUDE}
     ${CONDA_INCLUDE}
     ${Python3_INCLUDE_DIRS}
     ${gloo_SOURCE_DIR}

--- a/comms/torchcomms/nccl/CMakeLists.txt
+++ b/comms/torchcomms/nccl/CMakeLists.txt
@@ -4,21 +4,21 @@ file(GLOB TORCHCOMMS_NCCL_SOURCES "comms/torchcomms/nccl/*.cpp")
 file(GLOB TORCHCOMMS_CUDA_API_SOURCE "comms/torchcomms/device/CudaApi.cpp")
 find_package(CUDA)
 
-if(USE_SYSTEM_LIBS)
-    # Use system installed NCCL
+# Find NCCL - check various locations in order of preference
+if(USE_SYSTEM_LIBS AND EXISTS "${CONDA_INCLUDE}/nccl.h")
+    # Use system installed NCCL from conda
     set(NCCL_INCLUDE "${CONDA_INCLUDE}")
     set(NCCL_SHARED_LIB "${CONDA_LIB}/libnccl.so")
 elseif(EXISTS "${TORCH_INSTALL_PREFIX}/../build/nccl/include/nccl.h")
     # Use NCCL from PyTorch source build
     set(NCCL_INCLUDE "${TORCH_INSTALL_PREFIX}/../build/nccl/include")
-    set(NCCL_STATIC_LIB "${TORCH_INSTALL_PREFIX}/../build/nccl/lib/libnccl_static.a")
+    set(NCCL_SHARED_LIB "${TORCH_INSTALL_PREFIX}/../build/nccl/lib/libnccl.so")
 else()
     # Use NCCL packaged with PyTorch (pip install)
     set(NCCL_INCLUDE "${TORCH_INSTALL_PREFIX}/../nvidia/nccl/include")
-    set(NCCL_SHARED_LIB
-        "${TORCH_INSTALL_PREFIX}/../nvidia/nccl/lib/libnccl.so.2"
-    )
+    set(NCCL_SHARED_LIB "${TORCH_INSTALL_PREFIX}/../nvidia/nccl/lib/libnccl.so.2")
 endif()
+message(STATUS "NCCL include: ${NCCL_INCLUDE}")
 
 add_library(torchcomms_comms_nccl MODULE
     ${TORCHCOMMS_NCCL_SOURCES}
@@ -42,16 +42,8 @@ target_link_libraries(torchcomms_comms_nccl PRIVATE
     ${TORCH_LIBRARIES}
     ${TORCH_PYTHON_LIB}
     torchcomms
+    ${NCCL_SHARED_LIB}
 )
-if(USE_SYSTEM_LIBS)
-    target_link_libraries(torchcomms_comms_nccl PRIVATE
-        ${NCCL_SHARED_LIB}
-    )
-else()
-    target_link_libraries(torchcomms_comms_nccl PRIVATE
-        ${NCCL_STATIC_LIB}
-    )
-endif()
 
 if(CUDA_FOUND)
     target_link_libraries(torchcomms_comms_nccl PRIVATE CUDA::cudart)

--- a/comms/torchcomms/ncclx/CMakeLists.txt
+++ b/comms/torchcomms/ncclx/CMakeLists.txt
@@ -1,5 +1,44 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # Extension: torchcomms._comms_ncclx
+
+# NCCLX handling - paths are set by cmake/NCCLX.cmake or for system libs
+# NCCLX requires Meta's extended NCCL headers, not standard NCCL
+if(USE_SYSTEM_LIBS)
+    # When using system libs, check if NCCLX headers are available in CONDA
+    # NCCLX has types like ncclWinAccessType that don't exist in standard NCCL
+    if(EXISTS "${CONDA_INCLUDE}/nccl.h")
+        file(STRINGS "${CONDA_INCLUDE}/nccl.h" NCCLX_CHECK REGEX "ncclWinAccessType")
+        if(NCCLX_CHECK)
+            set(NCCLX_INCLUDE "${CONDA_INCLUDE}")
+            set(NCCLX_SHARED_LIB "${CONDA_LIB}/libnccl.so")
+            set(HAVE_NCCLX TRUE)
+        else()
+            message(STATUS "NCCL found in CONDA but lacks NCCLX extensions - skipping ncclx module")
+            set(HAVE_NCCLX FALSE)
+        endif()
+    else()
+        message(STATUS "NCCLX headers not found in CONDA - skipping ncclx module (standard NCCL from PyTorch doesn't have NCCLX extensions)")
+        set(HAVE_NCCLX FALSE)
+    endif()
+
+    if(NOT HAVE_NCCLX)
+        return()
+    endif()
+else()
+    # NCCLX_INCLUDE, NCCLX_STATIC_LIB, NCCLX_SHARED_LIB are set by cmake/NCCLX.cmake
+    # and will be built by ncclx_build target
+    if(NOT DEFINED NCCLX_INCLUDE)
+        set(NCCLX_BUILD_DIR $ENV{BUILDDIR})
+        if(NOT NCCLX_BUILD_DIR)
+            set(NCCLX_BUILD_DIR "${CMAKE_BINARY_DIR}/ncclx")
+        endif()
+        set(NCCLX_INCLUDE "${NCCLX_BUILD_DIR}/include")
+        set(NCCLX_STATIC_LIB "${NCCLX_BUILD_DIR}/lib/libnccl_static.a")
+        set(NCCLX_SHARED_LIB "${NCCLX_BUILD_DIR}/lib/libnccl.so")
+    endif()
+endif()
+message(STATUS "NCCLX include: ${NCCLX_INCLUDE}")
+
 file(GLOB TORCHCOMMS_NCCLX_SOURCES
     "comms/torchcomms/ncclx/*.cpp"
 )
@@ -7,53 +46,24 @@ file(GLOB TORCHCOMMS_CUDA_API_SOURCE "comms/torchcomms/device/CudaApi.cpp")
 
 find_package(CUDA)
 
-# NCCLX handling
-if(USE_SYSTEM_LIBS)
-    set(NCCLX_INCLUDE "${CONDA_INCLUDE}")
-    set(NCCLX_STATIC_LIB "${CONDA_LIB}/libnccl_static.a")
-    set(NCCLX_SHARED_LIB "${CONDA_LIB}/libnccl.so")
-else()
-    set(NCCLX_BUILD_DIR $ENV{BUILDDIR})
-    if(NOT NCCLX_BUILD_DIR)
-        set(NCCLX_BUILD_DIR "${ROOT}/build/ncclx")
-    endif()
-    set(NCCLX_INCLUDE "${NCCLX_BUILD_DIR}/include")
-    set(NCCLX_STATIC_LIB "${NCCLX_BUILD_DIR}/lib/libnccl_static.a")
-    set(NCCLX_SHARED_LIB "${NCCLX_BUILD_DIR}/lib/libnccl.so")
-    set(FMT_INCLUDE "${ROOT}/third-party/fmt/include")
-
-    if (NOT EXISTS "${NCCLX_BUILD_DIR}")
-        execute_process(
-            COMMAND ${ROOT}/build_ncclx.sh
-            WORKING_DIRECTORY ${ROOT}
-            RESULT_VARIABLE result
-            OUTPUT_VARIABLE output
-        )
-        if(result)
-            message(FATAL_ERROR "NCCLX build failed: ${result}")
-        endif()
-    endif()
-endif()
-
-# Get folly LDFLAGS using pkg-config
+# Get folly LDFLAGS using pkg-config (will fail during configure if deps not built,
+# but that's okay - deps will be built first due to target dependencies)
 set(ENV{PKG_CONFIG_PATH} "${CONDA_LIB}/pkgconfig")
 execute_process(
     COMMAND pkg-config --libs --static libfolly
     OUTPUT_VARIABLE FOLLY_LDFLAGS_RAW
     OUTPUT_STRIP_TRAILING_WHITESPACE
     RESULT_VARIABLE PKG_RESULT
+    ERROR_QUIET
 )
-if(NOT PKG_RESULT EQUAL 0)
-    message(FATAL_ERROR "pkg-config for libfolly failed")
-endif()
-separate_arguments(FOLLY_LDFLAGS NATIVE_COMMAND "${FOLLY_LDFLAGS_RAW}")
-
-# Remove any -l:libglog.a from FOLLY_LDFLAGS
-list(FILTER FOLLY_LDFLAGS EXCLUDE REGEX ".*libglog.*")
-
-# Check NCCLX include exists
-if(NOT EXISTS "${NCCLX_INCLUDE}")
-    message(FATAL_ERROR "NCCLX include not found at ${NCCLX_INCLUDE}")
+if(PKG_RESULT EQUAL 0)
+    separate_arguments(FOLLY_LDFLAGS NATIVE_COMMAND "${FOLLY_LDFLAGS_RAW}")
+    # Remove any -l:libglog.a from FOLLY_LDFLAGS
+    list(FILTER FOLLY_LDFLAGS EXCLUDE REGEX ".*libglog.*")
+else()
+    # Deps not built yet, will be built before this target
+    set(FOLLY_LDFLAGS "")
+    message(STATUS "pkg-config for libfolly not available yet, deps will be built first")
 endif()
 
 add_library(torchcomms_comms_ncclx MODULE
@@ -86,6 +96,11 @@ if(USE_SYSTEM_LIBS)
         "-lfmt"
     )
 else()
+    # Add dependency on ncclx build target
+    if(TARGET ncclx_build)
+        add_dependencies(torchcomms_comms_ncclx ncclx_build)
+    endif()
+
     target_link_libraries(torchcomms_comms_ncclx PRIVATE
         ${NCCLX_STATIC_LIB}
         "-l:libcomms_tracing_service.a"

--- a/comms/torchcomms/rccl/CMakeLists.txt
+++ b/comms/torchcomms/rccl/CMakeLists.txt
@@ -11,7 +11,6 @@ set(ROCM_INCLUDE "${ROCM_HOME}/include")
 set(RCCL_INCLUDE $ENV{RCCL_INCLUDE})
 message(STATUS "RCCL_INCLUDE is set to ${RCCL_INCLUDE}")
 set(RCCL_SHARED_LIB ${ROCM_HOME}/lib/librccl.so)
-set(FMT_INCLUDE "${ROOT}/third-party/fmt/include")
 
 add_library(torchcomms_comms_rccl MODULE ${TORCHCOMMS_RCCL_SOURCES})
 set_target_properties(torchcomms_comms_rccl PROPERTIES
@@ -24,7 +23,6 @@ set_target_properties(torchcomms_comms_rccl PROPERTIES
 target_include_directories(torchcomms_comms_rccl PRIVATE
     ${ROOT}
     ${RCCL_INCLUDE}
-    ${FMT_INCLUDE}
     ${CONDA_INCLUDE}
     ${Python3_INCLUDE_DIRS}
     ${ROCM_INCLUDE}

--- a/comms/torchcomms/rcclx/CMakeLists.txt
+++ b/comms/torchcomms/rcclx/CMakeLists.txt
@@ -13,8 +13,6 @@ message(STATUS "RCCLX_INCLUDE is set to ${RCCLX_INCLUDE}")
 set(RCCLX_SHARED_LIB $ENV{RCCLX_LIB}/librccl.so)
 message(STATUS "RCCLX_SHARED_LIB is set to ${RCCLX_SHARED_LIB}")
 
-set(FMT_INCLUDE "${ROOT}/third-party/fmt/include")
-
 add_library(torchcomms_comms_rcclx MODULE ${TORCHCOMMS_RCCLX_SOURCES})
 set_target_properties(torchcomms_comms_rcclx PROPERTIES
     PREFIX ""
@@ -26,7 +24,6 @@ set_target_properties(torchcomms_comms_rcclx PROPERTIES
 target_include_directories(torchcomms_comms_rcclx PRIVATE
     ${ROOT}
     ${RCCLX_INCLUDE}
-    ${FMT_INCLUDE}
     ${CONDA_INCLUDE}
     ${Python3_INCLUDE_DIRS}
     ${ROCM_INCLUDE}

--- a/comms/torchcomms/transport/CMakeLists.txt
+++ b/comms/torchcomms/transport/CMakeLists.txt
@@ -26,20 +26,25 @@ add_compile_definitions(MOCK_SCUBA_DATA CTRAN_DISABLE_TCPDM FMT_USE_CONSTEXPR)
 add_subdirectory(comms/utils)
 add_subdirectory(comms/ctran)
 
-# Get folly LDFLAGS using pkg-config
+# Get folly LDFLAGS using pkg-config (will fail during configure if deps not built,
+# but that's okay - deps will be built first due to target dependencies)
 set(ENV{PKG_CONFIG_PATH} "${CONDA_LIB}/pkgconfig")
 execute_process(
     COMMAND pkg-config --libs --static libfolly
     OUTPUT_VARIABLE FOLLY_LDFLAGS_RAW
     OUTPUT_STRIP_TRAILING_WHITESPACE
     RESULT_VARIABLE PKG_RESULT
+    ERROR_QUIET
 )
-if(NOT PKG_RESULT EQUAL 0)
-    message(FATAL_ERROR "pkg-config for libfolly failed")
+if(PKG_RESULT EQUAL 0)
+    separate_arguments(FOLLY_LDFLAGS NATIVE_COMMAND "${FOLLY_LDFLAGS_RAW}")
+    # Remove any -l:libglog.a from FOLLY_LDFLAGS
+    list(FILTER FOLLY_LDFLAGS EXCLUDE REGEX ".*libglog.*")
+else()
+    # Deps not built yet, will be built before this target
+    set(FOLLY_LDFLAGS "")
+    message(STATUS "pkg-config for libfolly not available yet, deps will be built first")
 endif()
-separate_arguments(FOLLY_LDFLAGS NATIVE_COMMAND "${FOLLY_LDFLAGS_RAW}")
-# Remove any -l:libglog.a from FOLLY_LDFLAGS
-list(FILTER FOLLY_LDFLAGS EXCLUDE REGEX ".*libglog.*")
 
 add_library(torchcomms_transport MODULE
     ${TORCHCOMMS_TRANSPORT_SOURCES}
@@ -81,6 +86,10 @@ if(USE_SYSTEM_LIBS)
         "-lfmt"
     )
 else()
+    # Add dependency on third-party build if target exists
+    if(TARGET third_party_deps)
+        add_dependencies(torchcomms_transport third_party_deps)
+    endif()
     target_link_libraries(torchcomms_transport PRIVATE
         "-l:libfolly.a"
         "-l:libgflags.a"


### PR DESCRIPTION
This largely nukes the logic in `build_ncclx.sh` and reduces it to only being needed when building in a conda environment. For standard pip install with no-system dependencies this can now be built entirely using cmake.

Since NCCLX doesn't support cmake we still call out to make but all dependencies are now cmake managed which makes this much easier to integrate with other cmake projects such as PyTorch.

Test plan:

```
pip install -e . -v --no-build-isolation
```

will need to manually test in Meta conda specific environments as well