### PR TITLE
fix memPool related build in WindowRmaTest

### DIFF
--- a/comms/torchcomms/tests/integration/cpp/WindowRmaTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/WindowRmaTest.cpp
@@ -71,8 +71,8 @@ void WindowRmaTest::testWindowPutBasic(
   auto cuda_allocator =
       torch::comms::get_mem_allocator(torchcomm_->getBackend());
   auto mem_pool = std::make_unique<at::cuda::MemPool>(
-      static_cast<c10::cuda::CUDACachingAllocator::CUDAAllocator*>(
-          cuda_allocator.get()));
+      std::static_pointer_cast<c10::cuda::CUDACachingAllocator::CUDAAllocator>(
+          cuda_allocator));
   c10::cuda::CUDACachingAllocator::beginAllocateToPool(
       mem_pool->device(), mem_pool->id(), [](cudaStream_t) { return true; });
 


### PR DESCRIPTION
Summary: D90404495 changed the at::cuda::MemPool constructor to accept a std::shared_ptr<CUDAAllocator> instead of a raw pointer. This broke the WindowRmaTest in torchcomm which uses this API. This diff update to use the new shared_ptr API.

Differential Revision: D90944323


