### PR TITLE
Partial build fix for torchcomms/fb with use_ncclx=stable

### DIFF
--- a/comms/torchcomms/TorchCommLogging.hpp
+++ b/comms/torchcomms/TorchCommLogging.hpp
@@ -21,17 +21,17 @@ inline std::string getRankPrefix(torch::comms::TorchCommBackend* comm) {
   }
 }
 
-#define LOG_METADATA_WITH_FUNC_NAME(comm)                   \
+#define TC_LOG_METADATA_WITH_FUNC_NAME(comm)                \
   "[" << __FUNCTION__ << "()][TC]" << ::getRankPrefix(comm) \
       << ::getCommNamePrefix(comm) << " "
 
-#define LOG_METADATA(comm) \
+#define TC_LOG_METADATA(comm) \
   "[TC]" << ::getRankPrefix(comm) << ::getCommNamePrefix(comm) << " "
 
 // variadic arg definitions for TC_VLOG, TC_LOG, and TC_LOG_IF based on:
 // https://stackoverflow.com/questions/3046889/optional-parameters-with-c-macros
 #define TC_VLOG_WITH_PREFIX_BUILDER(vlevel, comm) \
-  VLOG(vlevel) << LOG_METADATA_WITH_FUNC_NAME(comm)
+  VLOG(vlevel) << TC_LOG_METADATA_WITH_FUNC_NAME(comm)
 #define TC_VLOG_PICKER(x, vlevel, comm, FUNC, ...) FUNC
 #define TC_VLOG(...)                            \
   TC_VLOG_PICKER(                               \
@@ -41,7 +41,7 @@ inline std::string getRankPrefix(torch::comms::TorchCommBackend* comm) {
       TC_VLOG_WITH_PREFIX_BUILDER(__VA_ARGS__, getDefaultCommunicator()))
 
 #define TC_VLOG_EVERY_MS_PREFIX_BUILDER(vlevel, ms, comm) \
-  VLOG_EVERY_MS(vlevel, ms) << LOG_METADATA_WITH_FUNC_NAME(comm)
+  VLOG_EVERY_MS(vlevel, ms) << TC_LOG_METADATA_WITH_FUNC_NAME(comm)
 #define TC_VLOG_EVERY_MS_PICKER(x, vlevel, ms, comm, FUNC, ...) FUNC
 #define TC_VLOG_EVERY_MS(...)                       \
   TC_VLOG_EVERY_MS_PICKER(                          \
@@ -51,7 +51,8 @@ inline std::string getRankPrefix(torch::comms::TorchCommBackend* comm) {
       TC_VLOG_EVERY_MS_PREFIX_BUILDER(__VA_ARGS__, getDefaultCommunicator()))
 
 // level is one of the following: INFO, WARNING, ERROR, FATAL
-#define TC_LOG_WITH_PREFIX_BUILDER(level, comm) LOG(level) << LOG_METADATA(comm)
+#define TC_LOG_WITH_PREFIX_BUILDER(level, comm) \
+  LOG(level) << TC_LOG_METADATA(comm)
 #define TC_LOG_PICKER(x, level, comm, FUNC, ...) FUNC
 #define TC_LOG(...)                            \
   TC_LOG_PICKER(                               \
@@ -61,7 +62,7 @@ inline std::string getRankPrefix(torch::comms::TorchCommBackend* comm) {
       TC_LOG_WITH_PREFIX_BUILDER(__VA_ARGS__, getDefaultCommunicator()))
 
 #define TC_LOG_IF_WITH_PREFIX_BUILDER(level, condition, comm) \
-  LOG_IF(level, condition) << LOG_METADATA_WITH_FUNC_NAME(comm)
+  LOG_IF(level, condition) << TC_LOG_METADATA_WITH_FUNC_NAME(comm)
 #define TC_LOG_IF_PICKER(x, level, condition, comm, FUNC, ...) FUNC
 #define TC_LOG_IF(...)                            \
   TC_LOG_IF_PICKER(                               \
@@ -71,7 +72,7 @@ inline std::string getRankPrefix(torch::comms::TorchCommBackend* comm) {
       TC_LOG_IF_WITH_PREFIX_BUILDER(__VA_ARGS__, getDefaultCommunicator()))
 
 #define TC_LOG_EVERY_MS_PREFIX_BUILDER(level, ms, comm) \
-  LOG_EVERY_MS(level, ms) << LOG_METADATA_WITH_FUNC_NAME(comm)
+  LOG_EVERY_MS(level, ms) << TC_LOG_METADATA_WITH_FUNC_NAME(comm)
 #define TC_LOG_EVERY_MS_PICKER(x, level, ms, comm, FUNC, ...) FUNC
 #define TC_LOG_EVERY_MS(...)                       \
   TC_LOG_EVERY_MS_PICKER(                          \
@@ -82,7 +83,7 @@ inline std::string getRankPrefix(torch::comms::TorchCommBackend* comm) {
 
 // condition should evaluate to a bool, representing the condition to check
 #define TC_CHECK_WITH_PREFIX_BUILDER(condition, comm) \
-  CHECK(condition) << LOG_METADATA(comm)
+  CHECK(condition) << TC_LOG_METADATA(comm)
 #define TC_CHECK_PICKER(x, condition, comm, FUNC, ...) FUNC
 #define TC_CHECK(...)                            \
   TC_CHECK_PICKER(                               \
@@ -92,7 +93,7 @@ inline std::string getRankPrefix(torch::comms::TorchCommBackend* comm) {
       TC_CHECK_WITH_PREFIX_BUILDER(__VA_ARGS__, getDefaultCommunicator()))
 
 #define TC_CHECK_NOTNULL_WITH_PREFIX_BUILDER(condition, comm) \
-  CHECK_NOTNULL(condition) << LOG_METADATA(comm)
+  CHECK_NOTNULL(condition) << TC_LOG_METADATA(comm)
 #define TC_CHECK_NOTNULL_PICKER(x, condition, comm, FUNC, ...) FUNC
 #define TC_CHECK_NOTNULL(...)                            \
   TC_CHECK_NOTNULL_PICKER(                               \


### PR DESCRIPTION
Summary:
This patch partially addresses build failures in
fbcode//comms/torchcomms/fb/... Due to deep dependencies between the hccl
and ncclx codebases, this patch fixes only the parts that are not dependent
on ncclx.

After this patch, the following builds successfully:
  buck2 build -c hpc_comms.use_ncclx=stable fbcode//comms/torchcomms/fb/...

The profiling test still fails; that will be fixed in a follow-up patch.

Changes:
- Add missing dependency on acc_tensor_cpp for pytorch_mtia_flags API
- Add missing deps on torchcomms-cpp and torchcomms-utils-cpp
- Move torchcomms-factory-cpp to exported_deps for proper visibility
- Fix typo: c10::instrusive_ptr -> c10::intrusive_ptr
- Update pytorch_mtia_flags API call from pytorch_mtia_flags() to flags()
- Add missing include for TorchCommLogging.hpp
- Rename LOG_METADATA macros to TC_LOG_METADATA to avoid conflicts with
  other logging macros in the codebase

Reviewed By: ahmd-k

Differential Revision: D91014303
