### PR TITLE
Handle multi-segment registration at ctran level

### DIFF
--- a/comms/ctran/mapper/CtranMapperRegMem.h
+++ b/comms/ctran/mapper/CtranMapperRegMem.h
@@ -277,6 +277,8 @@ class CtranMapperRegCache {
   commResult_t destroy();
 
   // Thread-safe functions to cache a buffer range into the global cache.
+  // This function discovers all physical segments underlying the given buffer
+  // and caches each one individually.
   // input:
   //   - buf: the buffer to be cached
   //   - len: the length of the buffer
@@ -286,16 +288,16 @@ class CtranMapperRegCache {
   //               (logging purpose only, since commHash may not be 100%
   //               unique).
   // output:
-  //   - segment: the cached segment
-  //   - segHdl: the handle of the cached segment
+  //   - segments: vector of cached segments (one per physical segment chunk)
+  //   - segHdls: vector of handles for the cached segments
   commResult_t cacheSegment(
       const void* buf,
       const std::size_t len,
       const int cudaDev,
       const bool ncclManaged,
       uint64_t commHash,
-      CtranMapperSegment** segment,
-      void** segHdl);
+      std::vector<CtranMapperSegment*>& segments,
+      std::vector<void*>& segHdls);
 
   // Thread-safe functions to register a given buffer range.
   // If the buffer is already registered and cached, the pre-existing handle is

--- a/comms/torchcomms/ncclx/TorchCommNCCLXCCA.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXCCA.cpp
@@ -1,24 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include "comms/torchcomms/ncclx/TorchCommNCCLXCCA.hpp"
-#include <c10/cuda/driver_api.h>
-
-// Helper function to get allocation granularity for a device
-namespace {
-size_t getAllocationGranularity(int device) {
-  auto driver_api = c10::cuda::DriverAPI::get();
-  CUmemAllocationProp prop = {};
-  prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
-  prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
-  prop.location.id = device;
-
-  size_t granularity;
-  C10_CUDA_DRIVER_CHECK(driver_api->cuMemGetAllocationGranularity_(
-      &granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM));
-
-  return granularity;
-}
-} // namespace
 
 namespace torch {
 namespace comms {
@@ -74,22 +56,23 @@ void CachingAllocatorHookImpl::regDeregMem(
   std::lock_guard<std::mutex> lock(mutex_);
 
   if (te.action_ ==
-      c10::cuda::CUDACachingAllocator::TraceEntry::Action::SEGMENT_ALLOC) {
-    // Memory got allocated, register it with NCCL
+          c10::cuda::CUDACachingAllocator::TraceEntry::Action::SEGMENT_ALLOC ||
+      te.action_ ==
+          c10::cuda::CUDACachingAllocator::TraceEntry::Action::SEGMENT_MAP) {
+    // Memory got allocated/mapped, register it with NCCL
     // NOLINTNEXTLINE(performance-no-int-to-ptr)
     void* addr = reinterpret_cast<void*>(static_cast<uintptr_t>(te.addr_));
     size_t len = te.size_;
 
     if (registeredMemMap_.contains(addr)) {
-      LOG(ERROR) << "[CCA] SEGMENT_ALLOC: Memory already registered at 0x"
+      LOG(ERROR) << "[CCA] SEGMENT_ALLOC/MAP: Memory already registered at 0x"
                  << std::hex << addr << std::dec << " size=" << len
                  << " existing_size=" << registeredMemMap_.at(addr).len;
       throw std::runtime_error("Memory already registered with NCCLX");
-    } else {
-      registeredMemMap_.emplace(addr, MemInfo{len, te.device_});
     }
 
-    // Register the memory through ncclCommRegister and add to commRegHandles_
+    registeredMemMap_.emplace(addr, MemInfo{len, te.device_});
+
     for (auto& comm : registeredComms_) {
       if (te.device_ == comm->getDevice().index()) {
         comm->register_address(TorchCommNCCLX::AddressWithLen(addr, len));
@@ -97,65 +80,18 @@ void CachingAllocatorHookImpl::regDeregMem(
     }
   } else if (
       te.action_ ==
-      c10::cuda::CUDACachingAllocator::TraceEntry::Action::SEGMENT_MAP) {
-    // Memory got mapped, register it with NCCL
-
-    // PyTorch expandable segments can send MAP events covering one or more
-    // chunks. We need to register each chunk separately.
-    // Chunk size is determined by the allocation granularity for the device.
-    size_t total_size = te.size_;
-    size_t chunk_size = getAllocationGranularity(te.device_);
-
-    for (size_t offset = 0; offset < total_size;) {
-      // Determine the chunk size at this offset
-      size_t remaining = total_size - offset;
-
-      if (remaining < chunk_size) {
-        LOG(ERROR) << "[CCA] SEGMENT_MAP: Invalid remaining size=" << remaining
-                   << " at offset=" << offset << " total_size=" << total_size
-                   << " chunk_size=" << chunk_size;
-        throw std::runtime_error(
-            "SEGMENT_MAP: Remaining size must be a multiple of allocation granularity");
-      }
-
-      void* chunk_addr =
-          reinterpret_cast<void*>(  // NOLINT(performance-no-int-to-ptr)
-              static_cast<uintptr_t>(te.addr_) + offset);
-
-      if (registeredMemMap_.contains(chunk_addr)) {
-        LOG(ERROR) << "[CCA] SEGMENT_MAP: Memory already registered at 0x"
-                   << std::hex << chunk_addr << std::dec
-                   << " size=" << chunk_size
-                   << " existing_size=" << registeredMemMap_.at(chunk_addr).len;
-        throw std::runtime_error("Memory already registered with NCCLX");
-      }
-
-      registeredMemMap_.emplace(chunk_addr, MemInfo{chunk_size, te.device_});
-
-      // Register the memory through ncclCommRegister
-      for (auto& comm : registeredComms_) {
-        if (te.device_ == comm->getDevice().index()) {
-          comm->register_address(
-              TorchCommNCCLX::AddressWithLen(chunk_addr, chunk_size));
-        }
-      }
-
-      // Move to the next chunk
-      offset += chunk_size;
-    }
-  } else if (
+          c10::cuda::CUDACachingAllocator::TraceEntry::Action::SEGMENT_FREE ||
       te.action_ ==
-      c10::cuda::CUDACachingAllocator::TraceEntry::Action::SEGMENT_FREE) {
-    // Memory got freed, deregister it with NCCL
+          c10::cuda::CUDACachingAllocator::TraceEntry::Action::SEGMENT_UNMAP) {
+    // Memory got freed/unmapped, deregister it with NCCL
     // NOLINTNEXTLINE(performance-no-int-to-ptr)
     void* addr = reinterpret_cast<void*>(static_cast<uintptr_t>(te.addr_));
 
-    if (!registeredMemMap_.contains(addr)) {
-      LOG(ERROR) << "[CCA] SEGMENT_FREE: Memory not registered at 0x"
+    auto it = registeredMemMap_.find(addr);
+    if (it == registeredMemMap_.end() || it->second.device != te.device_) {
+      LOG(ERROR) << "[CCA] SEGMENT_FREE/UNMAP: Memory not registered at 0x"
                  << std::hex << addr << std::dec << " size=" << te.size_;
       throw std::runtime_error("Memory not registered with NCCLX");
-    } else {
-      registeredMemMap_.erase(addr);
     }
 
     for (auto& comm : registeredComms_) {
@@ -163,48 +99,8 @@ void CachingAllocatorHookImpl::regDeregMem(
         comm->deregister_address(TorchCommNCCLX::Address(addr));
       }
     }
-  } else if (
-      te.action_ ==
-      c10::cuda::CUDACachingAllocator::TraceEntry::Action::SEGMENT_UNMAP) {
-    // Memory got unmapped, deregister it with NCCL
 
-    // PyTorch expandable segments have chunks sized according to the
-    // allocation granularity. UNMAP events can cover multiple chunks.
-    // We iterate through registered chunks within the unmapped range and
-    // deregister each one.
-    size_t total_size = te.size_;
-
-    for (size_t offset = 0; offset < total_size;) {
-      void* chunk_addr =
-          reinterpret_cast<void*>(  // NOLINT(performance-no-int-to-ptr)
-              static_cast<uintptr_t>(te.addr_) + offset);
-
-      // Check if this chunk address is in our registered map
-      auto it = registeredMemMap_.find(chunk_addr);
-      if (it != registeredMemMap_.end() && it->second.device == te.device_) {
-        // Found a registered chunk, deregister it
-        size_t registered_size = it->second.len;
-
-        for (auto& comm : registeredComms_) {
-          if (te.device_ == comm->getDevice().index()) {
-            comm->deregister_address(TorchCommNCCLX::Address(chunk_addr));
-          }
-        }
-
-        registeredMemMap_.erase(it);
-
-        // Move to the next potential chunk by the size we just deregistered
-        offset += registered_size;
-      } else {
-        // No registered chunk found at this address - this indicates a
-        // serious inconsistency between MAP and UNMAP events
-        LOG(ERROR) << "[CCA] SEGMENT_UNMAP: No registered chunk at 0x"
-                   << std::hex << chunk_addr << std::dec << " offset=" << offset
-                   << " total_size=" << total_size;
-        throw std::runtime_error(
-            "SEGMENT_UNMAP: Expected registered chunk not found");
-      }
-    }
+    registeredMemMap_.erase(it);
   }
 }
 

--- a/comms/torchcomms/tests/integration/py/ExpandableSegmentsTest.py
+++ b/comms/torchcomms/tests/integration/py/ExpandableSegmentsTest.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# pyre-unsafe
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+Check that large allocations that span multiple physical caching allocator segment
+chunks are correctly registered. This is the behavior when expandable segments is set.
+"""
+
+import os
+import unittest
+
+os.environ.setdefault("NCCL_DEBUG", "INFO")
+os.environ.setdefault("NCCL_DEBUG_SUBSYS", "ALLOC")
+os.environ.setdefault("NCCL_COMM_STATE_DEBUG_TOPO", "nolocal")
+
+import torch
+from torchcomms import ReduceOp
+from torchcomms.tests.integration.py.TorchCommTestHelpers import TorchCommTestWrapper
+
+
+class ExpandableSegmentsTest(unittest.TestCase):
+    """Test class for expandable segments multi-segment registration."""
+
+    def get_wrapper(self):
+        return TorchCommTestWrapper()
+
+    def setUp(self):
+        self.wrapper = self.get_wrapper()
+        self.torchcomm = self.wrapper.get_torchcomm()
+        self.rank = self.torchcomm.get_rank()
+        self.num_ranks = self.torchcomm.get_size()
+        self.device = self.torchcomm.get_device()
+
+    def tearDown(self):
+        self.torchcomm = None
+        self.wrapper = None
+
+    def _run_large_allocation_test(self):
+        """
+        Test that large allocations spanning multiple physical memory allocations work correctly.
+
+        With expandable segments enabled, PyTorch allocates memory in 20MB segment chunks.
+        A 100MB allocation should span 5 physical 20 MB segment chunks. This test verifies that:
+        1. The CCA hook receives the SEGMENT_MAP event for the full range
+        2. ctran's pinRange() discovers all underlying physical segments and caches them
+        3. At collective time, the elements of the segment cache backing the input tensor are
+           correctly registered with NCCL
+        """
+        count = 100 * 1024 * 1024
+        dtype = torch.uint8
+
+        # Create input tensor - this triggers SEGMENT_MAP for a ~100MB allocation
+        input_tensor = torch.ones(count, dtype=dtype, device=self.device) * float(
+            self.rank + 1
+        )
+
+        # Perform all_reduce - this exercises the full ctran registration path
+        work = self.torchcomm.all_reduce(input_tensor, ReduceOp.SUM, False)
+        work.wait()
+
+        # Check collective result
+        expected = self.num_ranks * (self.num_ranks + 1) // 2
+        expected_tensor = torch.full_like(input_tensor.cpu(), float(expected))
+        torch.testing.assert_close(input_tensor.cpu(), expected_tensor)
+
+    def test_async_registration(self):
+        os.environ["NCCL_CTRAN_REGISTER"] = "async"
+        self._run_large_allocation_test()
+
+    def test_eager_registration(self):
+        os.environ["NCCL_CTRAN_REGISTER"] = "eager"
+        self._run_large_allocation_test()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
When pytorch cuda caching allocator uses expandable segments, 20MB or 2MB segment chunks of physical memory are allocated with cuMemCreate and mapped to virtual address space. An allocator of e.g. 100 MB would be broken into 5 20MB segment chunks.

In ctran, we track the segments in a segment cache on allocation so that we can register them for communication later.

Previously, torchcomms handled breaking up the caching allocator logic and called segment caching logic for each physical allocation. Instead, we can handle this in the ctran level by iterating through all physical segments with cuMemGetAddressRange in the pinRange function. 

So torchcomms only needs to call register logic for the e.g. new 100MB memory allocation and ctran will break it up into the 5 20MB segment chunks and cache them.

Differential Revision: D90899164


