### PR TITLE
Use const reference for function parameters

### DIFF
--- a/comms/torchcomms/TorchCommPy.cpp
+++ b/comms/torchcomms/TorchCommPy.cpp
@@ -740,7 +740,7 @@ Args:
           "all_reduce",
           [](TorchComm& self,
              at::Tensor& tensor,
-             ReduceOp op,
+             const ReduceOp& op,
              bool async_op,
              std::optional<std::unordered_map<std::string, std::string>> hints,
              std::optional<std::chrono::milliseconds> timeout) {
@@ -774,7 +774,7 @@ Args:
           [](TorchComm& self,
              const at::Tensor& tensor,
              int root,
-             ReduceOp op,
+             const ReduceOp& op,
              bool async_op,
              std::optional<std::unordered_map<std::string, std::string>> hints,
              std::optional<std::chrono::milliseconds> timeout) {
@@ -917,7 +917,7 @@ Args:
           [](TorchComm& self,
              at::Tensor& output,
              const std::vector<at::Tensor>& input_list,
-             ReduceOp op,
+             const ReduceOp& op,
              bool async_op,
              std::optional<std::unordered_map<std::string, std::string>> hints,
              std::optional<std::chrono::milliseconds> timeout) {
@@ -953,7 +953,7 @@ Args:
           [](TorchComm& self,
              at::Tensor& output,
              const std::vector<at::Tensor>& input_list,
-             ReduceOp op,
+             const ReduceOp& op,
              bool async_op,
              std::optional<std::unordered_map<std::string, std::string>> hints,
              std::optional<std::chrono::milliseconds> timeout) {
@@ -990,7 +990,7 @@ Args:
           [](TorchComm& self,
              at::Tensor& output,
              const at::Tensor& input,
-             ReduceOp op,
+             const ReduceOp& op,
              bool async_op,
              std::optional<std::unordered_map<std::string, std::string>> hints,
              std::optional<std::chrono::milliseconds> timeout) {

--- a/comms/torchcomms/tests/integration/cpp/AllReduceTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/AllReduceTest.cpp
@@ -28,7 +28,7 @@ void AllReduceTest::TearDown() {
 void AllReduceTest::testSyncAllReduce(
     int count,
     at::ScalarType dtype,
-    torch::comms::ReduceOp op) {
+    const torch::comms::ReduceOp& op) {
   SCOPED_TRACE(
       ::testing::Message() << "Testing sync all_reduce with count=" << count
                            << " and dtype=" << getDtypeName(dtype)
@@ -49,7 +49,7 @@ void AllReduceTest::testSyncAllReduce(
 void AllReduceTest::testSyncAllReduceNoWork(
     int count,
     at::ScalarType dtype,
-    torch::comms::ReduceOp op) {
+    const torch::comms::ReduceOp& op) {
   SCOPED_TRACE(
       ::testing::Message()
       << "Testing sync all_reduce without work object with count=" << count
@@ -69,7 +69,7 @@ void AllReduceTest::testSyncAllReduceNoWork(
 void AllReduceTest::testAsyncAllReduce(
     int count,
     at::ScalarType dtype,
-    torch::comms::ReduceOp op) {
+    const torch::comms::ReduceOp& op) {
   SCOPED_TRACE(
       ::testing::Message() << "Testing async all_reduce with count=" << count
                            << " and dtype=" << getDtypeName(dtype)
@@ -92,7 +92,7 @@ void AllReduceTest::testAsyncAllReduce(
 void AllReduceTest::testAsyncAllReduceEarlyReset(
     int count,
     at::ScalarType dtype,
-    torch::comms::ReduceOp op) {
+    const torch::comms::ReduceOp& op) {
   SCOPED_TRACE(
       ::testing::Message()
       << "Testing async all_reduce with early reset with count=" << count
@@ -118,7 +118,7 @@ void AllReduceTest::testAsyncAllReduceEarlyReset(
 void AllReduceTest::testAllReduceInputDeleted(
     int count,
     at::ScalarType dtype,
-    torch::comms::ReduceOp op) {
+    const torch::comms::ReduceOp& op) {
   SCOPED_TRACE(
       ::testing::Message()
       << "Testing async all_reduce with input deleted after enqueue with count="
@@ -143,7 +143,7 @@ void AllReduceTest::testAllReduceInputDeleted(
 void AllReduceTest::testGraphAllReduce(
     int count,
     at::ScalarType dtype,
-    torch::comms::ReduceOp op) {
+    const torch::comms::ReduceOp& op) {
   SCOPED_TRACE(
       ::testing::Message() << "Testing CUDA Graph all_reduce with count="
                            << count << " and dtype=" << getDtypeName(dtype)
@@ -188,7 +188,7 @@ void AllReduceTest::testGraphAllReduce(
 void AllReduceTest::testGraphAllReduceInputDeleted(
     int count,
     at::ScalarType dtype,
-    torch::comms::ReduceOp op) {
+    const torch::comms::ReduceOp& op) {
   SCOPED_TRACE(
       ::testing::Message()
       << "Testing CUDA Graph all_reduce with input deleted after graph creation with count="
@@ -257,7 +257,8 @@ at::Tensor AllReduceTest::createPreMulFactorTensor(at::ScalarType dtype) {
 }
 
 // Helper function to calculate expected result
-double AllReduceTest::calculateExpectedResult(torch::comms::ReduceOp op) {
+double AllReduceTest::calculateExpectedResult(
+    const torch::comms::ReduceOp& op) {
   if (op == torch::comms::ReduceOp::SUM) {
     return num_ranks_ * (num_ranks_ + 1) / 2;
   } else if (op == torch::comms::ReduceOp::RedOpType::MAX) {
@@ -274,7 +275,7 @@ double AllReduceTest::calculateExpectedResult(torch::comms::ReduceOp op) {
 // Helper function to verify results
 void AllReduceTest::verifyResults(
     const at::Tensor& input,
-    torch::comms::ReduceOp op) {
+    const torch::comms::ReduceOp& op) {
   // Calculate expected result
   double expected = calculateExpectedResult(op);
 

--- a/comms/torchcomms/tests/integration/cpp/AllReduceTest.hpp
+++ b/comms/torchcomms/tests/integration/cpp/AllReduceTest.hpp
@@ -17,32 +17,34 @@ class AllReduceTest
       : rank_(0), num_ranks_(0), device_type_(device_type) {}
 
   // Test function declarations with parameters
-  void
-  testSyncAllReduce(int count, at::ScalarType dtype, torch::comms::ReduceOp op);
+  void testSyncAllReduce(
+      int count,
+      at::ScalarType dtype,
+      const torch::comms::ReduceOp& op);
   void testSyncAllReduceNoWork(
       int count,
       at::ScalarType dtype,
-      torch::comms::ReduceOp op);
+      const torch::comms::ReduceOp& op);
   void testAsyncAllReduce(
       int count,
       at::ScalarType dtype,
-      torch::comms::ReduceOp op);
+      const torch::comms::ReduceOp& op);
   void testAsyncAllReduceEarlyReset(
       int count,
       at::ScalarType dtype,
-      torch::comms::ReduceOp op);
+      const torch::comms::ReduceOp& op);
   void testAllReduceInputDeleted(
       int count,
       at::ScalarType dtype,
-      torch::comms::ReduceOp op);
+      const torch::comms::ReduceOp& op);
   void testGraphAllReduce(
       int count,
       at::ScalarType dtype,
-      torch::comms::ReduceOp op);
+      const torch::comms::ReduceOp& op);
   void testGraphAllReduceInputDeleted(
       int count,
       at::ScalarType dtype,
-      torch::comms::ReduceOp op);
+      const torch::comms::ReduceOp& op);
 
  protected:
   virtual std::unique_ptr<TorchCommTestWrapper> createWrapper();
@@ -62,6 +64,6 @@ class AllReduceTest
   // Helper function declarations with parameters
   virtual at::Tensor createInputTensor(int count, at::ScalarType dtype);
   virtual at::Tensor createPreMulFactorTensor(at::ScalarType dtype);
-  double calculateExpectedResult(torch::comms::ReduceOp op);
-  void verifyResults(const at::Tensor& input, torch::comms::ReduceOp op);
+  double calculateExpectedResult(const torch::comms::ReduceOp& op);
+  void verifyResults(const at::Tensor& input, const torch::comms::ReduceOp& op);
 };

--- a/comms/torchcomms/tests/integration/cpp/MultiCommTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/MultiCommTest.cpp
@@ -94,7 +94,7 @@ class MultiCommTest : public ::testing::Test, public MultiCommTestBase {
 
   void destroyStoreAndSyncStream(
       c10::intrusive_ptr<c10d::Store>&& store,
-      std::shared_ptr<torch::comms::TorchComm> torchcomm) {
+      const std::shared_ptr<torch::comms::TorchComm>& torchcomm) {
     destroyStore(std::move(store), torchcomm);
 
     int rank = torchcomm->getRank();

--- a/comms/torchcomms/tests/integration/cpp/ReduceScatterSingleTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/ReduceScatterSingleTest.cpp
@@ -28,7 +28,7 @@ void ReduceScatterSingleTest::TearDown() {
 void ReduceScatterSingleTest::testSyncReduceScatterSingle(
     int count,
     at::ScalarType dtype,
-    torch::comms::ReduceOp op) {
+    const torch::comms::ReduceOp& op) {
   SCOPED_TRACE(
       ::testing::Message() << "Testing sync reduce_scatter_single with count="
                            << count << " and dtype=" << getDtypeName(dtype)
@@ -50,7 +50,7 @@ void ReduceScatterSingleTest::testSyncReduceScatterSingle(
 void ReduceScatterSingleTest::testSyncReduceScatterSingleNoWork(
     int count,
     at::ScalarType dtype,
-    torch::comms::ReduceOp op) {
+    const torch::comms::ReduceOp& op) {
   SCOPED_TRACE(
       ::testing::Message()
       << "Testing sync reduce_scatter_single without work object with count="
@@ -72,7 +72,7 @@ void ReduceScatterSingleTest::testSyncReduceScatterSingleNoWork(
 void ReduceScatterSingleTest::testAsyncReduceScatterSingle(
     int count,
     at::ScalarType dtype,
-    torch::comms::ReduceOp op) {
+    const torch::comms::ReduceOp& op) {
   SCOPED_TRACE(
       ::testing::Message() << "Testing async reduce_scatter_single with count="
                            << count << " and dtype=" << getDtypeName(dtype)
@@ -96,7 +96,7 @@ void ReduceScatterSingleTest::testAsyncReduceScatterSingle(
 void ReduceScatterSingleTest::testAsyncReduceScatterSingleEarlyReset(
     int count,
     at::ScalarType dtype,
-    torch::comms::ReduceOp op) {
+    const torch::comms::ReduceOp& op) {
   SCOPED_TRACE(
       ::testing::Message()
       << "Testing async reduce_scatter_single with early reset with count="
@@ -125,7 +125,7 @@ void ReduceScatterSingleTest::testAsyncReduceScatterSingleEarlyReset(
 void ReduceScatterSingleTest::testReduceScatterSingleInputDeleted(
     int count,
     at::ScalarType dtype,
-    torch::comms::ReduceOp op) {
+    const torch::comms::ReduceOp& op) {
   SCOPED_TRACE(
       ::testing::Message()
       << "Testing async reduce_scatter_single with input deleted after enqueue with count="
@@ -153,7 +153,7 @@ void ReduceScatterSingleTest::testReduceScatterSingleInputDeleted(
 void ReduceScatterSingleTest::testGraphReduceScatterSingle(
     int count,
     at::ScalarType dtype,
-    torch::comms::ReduceOp op) {
+    const torch::comms::ReduceOp& op) {
   SCOPED_TRACE(
       ::testing::Message()
       << "Testing CUDA Graph reduce_scatter_single with count=" << count
@@ -199,7 +199,7 @@ void ReduceScatterSingleTest::testGraphReduceScatterSingle(
 void ReduceScatterSingleTest::testGraphReduceScatterSingleInputDeleted(
     int count,
     at::ScalarType dtype,
-    torch::comms::ReduceOp op) {
+    const torch::comms::ReduceOp& op) {
   SCOPED_TRACE(
       ::testing::Message()
       << "Testing CUDA Graph reduce_scatter_single with input deleted after graph creation with count="
@@ -279,7 +279,7 @@ at::Tensor ReduceScatterSingleTest::createOutputTensor(
 // Helper function to verify results
 void ReduceScatterSingleTest::verifyResults(
     const at::Tensor& output,
-    torch::comms::ReduceOp op) {
+    const torch::comms::ReduceOp& op) {
   // Calculate expected value based on operation type
   int expected_value = 0;
   if (op == torch::comms::ReduceOp::SUM) {

--- a/comms/torchcomms/tests/integration/cpp/ReduceScatterSingleTest.hpp
+++ b/comms/torchcomms/tests/integration/cpp/ReduceScatterSingleTest.hpp
@@ -19,31 +19,31 @@ class ReduceScatterSingleTest
   void testSyncReduceScatterSingle(
       int count,
       at::ScalarType dtype,
-      torch::comms::ReduceOp op);
+      const torch::comms::ReduceOp& op);
   void testSyncReduceScatterSingleNoWork(
       int count,
       at::ScalarType dtype,
-      torch::comms::ReduceOp op);
+      const torch::comms::ReduceOp& op);
   void testAsyncReduceScatterSingle(
       int count,
       at::ScalarType dtype,
-      torch::comms::ReduceOp op);
+      const torch::comms::ReduceOp& op);
   void testAsyncReduceScatterSingleEarlyReset(
       int count,
       at::ScalarType dtype,
-      torch::comms::ReduceOp op);
+      const torch::comms::ReduceOp& op);
   void testReduceScatterSingleInputDeleted(
       int count,
       at::ScalarType dtype,
-      torch::comms::ReduceOp op);
+      const torch::comms::ReduceOp& op);
   void testGraphReduceScatterSingle(
       int count,
       at::ScalarType dtype,
-      torch::comms::ReduceOp op);
+      const torch::comms::ReduceOp& op);
   void testGraphReduceScatterSingleInputDeleted(
       int count,
       at::ScalarType dtype,
-      torch::comms::ReduceOp op);
+      const torch::comms::ReduceOp& op);
 
  protected:
   virtual std::unique_ptr<TorchCommTestWrapper> createWrapper();
@@ -63,5 +63,7 @@ class ReduceScatterSingleTest
   // Helper function declarations with parameters
   virtual at::Tensor createInputTensor(int count, at::ScalarType dtype);
   virtual at::Tensor createOutputTensor(int count, at::ScalarType dtype);
-  void verifyResults(const at::Tensor& output, torch::comms::ReduceOp op);
+  void verifyResults(
+      const at::Tensor& output,
+      const torch::comms::ReduceOp& op);
 };

--- a/comms/torchcomms/tests/integration/cpp/ReduceScatterTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/ReduceScatterTest.cpp
@@ -30,7 +30,7 @@ void ReduceScatterTest::TearDown() {
 void ReduceScatterTest::testSyncReduceScatter(
     int count,
     at::ScalarType dtype,
-    torch::comms::ReduceOp op) {
+    const torch::comms::ReduceOp& op) {
   SCOPED_TRACE(
       ::testing::Message() << "Testing sync reduce_scatter with count=" << count
                            << " and dtype=" << getDtypeName(dtype)
@@ -52,7 +52,7 @@ void ReduceScatterTest::testSyncReduceScatter(
 void ReduceScatterTest::testSyncReduceScatterNoWork(
     int count,
     at::ScalarType dtype,
-    torch::comms::ReduceOp op) {
+    const torch::comms::ReduceOp& op) {
   SCOPED_TRACE(
       ::testing::Message()
       << "Testing sync reduce_scatter without work object with count=" << count
@@ -73,7 +73,7 @@ void ReduceScatterTest::testSyncReduceScatterNoWork(
 void ReduceScatterTest::testAsyncReduceScatter(
     int count,
     at::ScalarType dtype,
-    torch::comms::ReduceOp op) {
+    const torch::comms::ReduceOp& op) {
   SCOPED_TRACE(
       ::testing::Message() << "Testing async reduce_scatter with count="
                            << count << " and dtype=" << getDtypeName(dtype)
@@ -97,7 +97,7 @@ void ReduceScatterTest::testAsyncReduceScatter(
 void ReduceScatterTest::testAsyncReduceScatterEarlyReset(
     int count,
     at::ScalarType dtype,
-    torch::comms::ReduceOp op) {
+    const torch::comms::ReduceOp& op) {
   SCOPED_TRACE(
       ::testing::Message()
       << "Testing async reduce_scatter with early reset with count=" << count
@@ -125,7 +125,7 @@ void ReduceScatterTest::testAsyncReduceScatterEarlyReset(
 void ReduceScatterTest::testReduceScatterInputDeleted(
     int count,
     at::ScalarType dtype,
-    torch::comms::ReduceOp op) {
+    const torch::comms::ReduceOp& op) {
   SCOPED_TRACE(
       ::testing::Message()
       << "Testing async reduce_scatter with input deleted after enqueue with count="
@@ -182,7 +182,8 @@ at::Tensor ReduceScatterTest::createOutputTensor(
 }
 
 // Helper function to calculate expected result
-int ReduceScatterTest::calculateExpectedResult(torch::comms::ReduceOp op) {
+int ReduceScatterTest::calculateExpectedResult(
+    const torch::comms::ReduceOp& op) {
   if (op == torch::comms::ReduceOp::SUM) {
     return num_ranks_ * (rank_ + 1);
   } else if (op == torch::comms::ReduceOp::MAX) {
@@ -195,7 +196,7 @@ int ReduceScatterTest::calculateExpectedResult(torch::comms::ReduceOp op) {
 // Helper function to verify results
 void ReduceScatterTest::verifyResults(
     const at::Tensor& output,
-    torch::comms::ReduceOp op) {
+    const torch::comms::ReduceOp& op) {
   // Calculate expected result
   int expected = calculateExpectedResult(op);
 
@@ -208,7 +209,7 @@ void ReduceScatterTest::verifyResults(
 void ReduceScatterTest::testGraphReduceScatter(
     int count,
     at::ScalarType dtype,
-    torch::comms::ReduceOp op) {
+    const torch::comms::ReduceOp& op) {
   SCOPED_TRACE(
       ::testing::Message() << "Testing CUDA Graph reduce_scatter with count="
                            << count << " and dtype=" << getDtypeName(dtype)
@@ -254,7 +255,7 @@ void ReduceScatterTest::testGraphReduceScatter(
 void ReduceScatterTest::testGraphReduceScatterInputDeleted(
     int count,
     at::ScalarType dtype,
-    torch::comms::ReduceOp op) {
+    const torch::comms::ReduceOp& op) {
   SCOPED_TRACE(
       ::testing::Message()
       << "Testing CUDA Graph reduce_scatter with input deleted after graph creation with count="

--- a/comms/torchcomms/tests/integration/cpp/ReduceScatterTest.hpp
+++ b/comms/torchcomms/tests/integration/cpp/ReduceScatterTest.hpp
@@ -20,31 +20,31 @@ class ReduceScatterTest
   void testSyncReduceScatter(
       int count,
       at::ScalarType dtype,
-      torch::comms::ReduceOp op);
+      const torch::comms::ReduceOp& op);
   void testSyncReduceScatterNoWork(
       int count,
       at::ScalarType dtype,
-      torch::comms::ReduceOp op);
+      const torch::comms::ReduceOp& op);
   void testAsyncReduceScatter(
       int count,
       at::ScalarType dtype,
-      torch::comms::ReduceOp op);
+      const torch::comms::ReduceOp& op);
   void testAsyncReduceScatterEarlyReset(
       int count,
       at::ScalarType dtype,
-      torch::comms::ReduceOp op);
+      const torch::comms::ReduceOp& op);
   void testReduceScatterInputDeleted(
       int count,
       at::ScalarType dtype,
-      torch::comms::ReduceOp op);
+      const torch::comms::ReduceOp& op);
   void testGraphReduceScatter(
       int count,
       at::ScalarType dtype,
-      torch::comms::ReduceOp op);
+      const torch::comms::ReduceOp& op);
   void testGraphReduceScatterInputDeleted(
       int count,
       at::ScalarType dtype,
-      torch::comms::ReduceOp op);
+      const torch::comms::ReduceOp& op);
 
  protected:
   virtual std::unique_ptr<TorchCommTestWrapper> createWrapper();
@@ -66,6 +66,8 @@ class ReduceScatterTest
       int count,
       at::ScalarType dtype);
   virtual at::Tensor createOutputTensor(int count, at::ScalarType dtype);
-  int calculateExpectedResult(torch::comms::ReduceOp op);
-  void verifyResults(const at::Tensor& output, torch::comms::ReduceOp op);
+  int calculateExpectedResult(const torch::comms::ReduceOp& op);
+  void verifyResults(
+      const at::Tensor& output,
+      const torch::comms::ReduceOp& op);
 };

--- a/comms/torchcomms/tests/integration/cpp/ReduceTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/ReduceTest.cpp
@@ -33,7 +33,7 @@ void ReduceTest::TearDown() {
 void ReduceTest::testSyncReduce(
     int count,
     at::ScalarType dtype,
-    torch::comms::ReduceOp op) {
+    const torch::comms::ReduceOp& op) {
   SCOPED_TRACE(
       ::testing::Message() << "Testing sync reduce with count=" << count
                            << " and dtype=" << getDtypeName(dtype)
@@ -56,7 +56,7 @@ void ReduceTest::testSyncReduce(
 void ReduceTest::testSyncReduceNoWork(
     int count,
     at::ScalarType dtype,
-    torch::comms::ReduceOp op) {
+    const torch::comms::ReduceOp& op) {
   SCOPED_TRACE(
       ::testing::Message()
       << "Testing sync reduce without work object with count=" << count
@@ -78,7 +78,7 @@ void ReduceTest::testSyncReduceNoWork(
 void ReduceTest::testAsyncReduce(
     int count,
     at::ScalarType dtype,
-    torch::comms::ReduceOp op) {
+    const torch::comms::ReduceOp& op) {
   SCOPED_TRACE(
       ::testing::Message() << "Testing async reduce with count=" << count
                            << " and dtype=" << getDtypeName(dtype)
@@ -103,7 +103,7 @@ void ReduceTest::testAsyncReduce(
 void ReduceTest::testAsyncReduceEarlyReset(
     int count,
     at::ScalarType dtype,
-    torch::comms::ReduceOp op) {
+    const torch::comms::ReduceOp& op) {
   SCOPED_TRACE(
       ::testing::Message()
       << "Testing async reduce with early reset with count=" << count
@@ -131,7 +131,7 @@ void ReduceTest::testAsyncReduceEarlyReset(
 void ReduceTest::testReduceInputDeleted(
     int count,
     at::ScalarType dtype,
-    torch::comms::ReduceOp op) {
+    const torch::comms::ReduceOp& op) {
   SCOPED_TRACE(
       ::testing::Message()
       << "Testing async reduce with input deleted after enqueue with count="
@@ -175,7 +175,7 @@ at::Tensor ReduceTest::createInputTensor(int count, at::ScalarType dtype) {
 }
 
 // Helper function to calculate expected result
-int ReduceTest::calculateExpectedResult(torch::comms::ReduceOp op) {
+int ReduceTest::calculateExpectedResult(const torch::comms::ReduceOp& op) {
   if (op == torch::comms::ReduceOp::SUM) {
     return num_ranks_ * (num_ranks_ + 1) / 2;
   } else if (op == torch::comms::ReduceOp::MAX) {
@@ -188,7 +188,7 @@ int ReduceTest::calculateExpectedResult(torch::comms::ReduceOp op) {
 // Helper function to verify results
 void ReduceTest::verifyResults(
     const at::Tensor& output,
-    torch::comms::ReduceOp op,
+    const torch::comms::ReduceOp& op,
     int root_rank) {
   if (rank_ != root_rank) {
     synchronizeStream();
@@ -207,7 +207,7 @@ void ReduceTest::verifyResults(
 void ReduceTest::testGraphReduce(
     int count,
     at::ScalarType dtype,
-    torch::comms::ReduceOp op) {
+    const torch::comms::ReduceOp& op) {
   SCOPED_TRACE(
       ::testing::Message() << "Testing CUDA Graph reduce with count=" << count
                            << " and dtype=" << getDtypeName(dtype)
@@ -253,7 +253,7 @@ void ReduceTest::testGraphReduce(
 void ReduceTest::testGraphReduceInputDeleted(
     int count,
     at::ScalarType dtype,
-    torch::comms::ReduceOp op) {
+    const torch::comms::ReduceOp& op) {
   SCOPED_TRACE(
       ::testing::Message()
       << "Testing CUDA Graph reduce with input deleted after graph creation with count="

--- a/comms/torchcomms/tests/integration/cpp/ReduceTest.hpp
+++ b/comms/torchcomms/tests/integration/cpp/ReduceTest.hpp
@@ -16,28 +16,34 @@ class ReduceTest
       : rank_(0), num_ranks_(0), device_index_(0), device_type_(device_type) {}
 
   // Test function declarations with parameters
-  void
-  testSyncReduce(int count, at::ScalarType dtype, torch::comms::ReduceOp op);
+  void testSyncReduce(
+      int count,
+      at::ScalarType dtype,
+      const torch::comms::ReduceOp& op);
   void testSyncReduceNoWork(
       int count,
       at::ScalarType dtype,
-      torch::comms::ReduceOp op);
-  void
-  testAsyncReduce(int count, at::ScalarType dtype, torch::comms::ReduceOp op);
+      const torch::comms::ReduceOp& op);
+  void testAsyncReduce(
+      int count,
+      at::ScalarType dtype,
+      const torch::comms::ReduceOp& op);
   void testAsyncReduceEarlyReset(
       int count,
       at::ScalarType dtype,
-      torch::comms::ReduceOp op);
+      const torch::comms::ReduceOp& op);
   void testReduceInputDeleted(
       int count,
       at::ScalarType dtype,
-      torch::comms::ReduceOp op);
-  void
-  testGraphReduce(int count, at::ScalarType dtype, torch::comms::ReduceOp op);
+      const torch::comms::ReduceOp& op);
+  void testGraphReduce(
+      int count,
+      at::ScalarType dtype,
+      const torch::comms::ReduceOp& op);
   void testGraphReduceInputDeleted(
       int count,
       at::ScalarType dtype,
-      torch::comms::ReduceOp op);
+      const torch::comms::ReduceOp& op);
 
  protected:
   virtual void synchronizeStream();
@@ -59,9 +65,9 @@ class ReduceTest
 
   // Helper function declarations with parameters
   virtual at::Tensor createInputTensor(int count, at::ScalarType dtype);
-  int calculateExpectedResult(torch::comms::ReduceOp op);
+  int calculateExpectedResult(const torch::comms::ReduceOp& op);
   void verifyResults(
       const at::Tensor& output,
-      torch::comms::ReduceOp op,
+      const torch::comms::ReduceOp& op,
       int root_rank);
 };

--- a/comms/torchcomms/tests/integration/cpp/TorchCommTestHelpers.cpp
+++ b/comms/torchcomms/tests/integration/cpp/TorchCommTestHelpers.cpp
@@ -54,7 +54,7 @@ std::string getDtypeName(at::ScalarType dtype) {
   }
 }
 
-std::string getOpName(torch::comms::ReduceOp op) {
+std::string getOpName(const torch::comms::ReduceOp& op) {
   switch (op) {
     case torch::comms::ReduceOp::RedOpType::SUM:
       return "Sum";
@@ -138,7 +138,7 @@ c10::intrusive_ptr<c10d::Store> createStore() {
 
 void destroyStore(
     c10::intrusive_ptr<c10d::Store>&& store,
-    std::shared_ptr<torch::comms::TorchComm> torchcomm) {
+    const std::shared_ptr<torch::comms::TorchComm>& torchcomm) {
   // Move the store to a local variable that will be destroyed when this
   // function exits
   auto local_store = std::move(store);

--- a/comms/torchcomms/tests/integration/cpp/TorchCommTestHelpers.h
+++ b/comms/torchcomms/tests/integration/cpp/TorchCommTestHelpers.h
@@ -14,12 +14,12 @@
 #include "comms/torchcomms/TorchComm.hpp"
 
 std::string getDtypeName(at::ScalarType dtype);
-std::string getOpName(torch::comms::ReduceOp op);
+std::string getOpName(const torch::comms::ReduceOp& op);
 std::tuple<int, int> getRankAndSize();
 c10::intrusive_ptr<c10d::Store> createStore();
 void destroyStore(
     c10::intrusive_ptr<c10d::Store>&& store,
-    std::shared_ptr<torch::comms::TorchComm> torchcomm);
+    const std::shared_ptr<torch::comms::TorchComm>& torchcomm);
 
 // Convert a tensor to a string representation with nested brackets for each
 // dimension. Supports any N-dimensional tensor.

--- a/comms/torchcomms/transport/RdmaTransport.cpp
+++ b/comms/torchcomms/transport/RdmaTransport.cpp
@@ -132,7 +132,7 @@ bool RdmaTransport::connected() const {
 
 folly::SemiFuture<commResult_t> RdmaTransport::write(
     RdmaMemory::View localBuffer,
-    RdmaRemoteBuffer remoteBuffer,
+    const RdmaRemoteBuffer& remoteBuffer,
     bool notify) {
   CHECK_THROW(connected(), std::runtime_error);
   CHECK_THROW(evb_, std::runtime_error);

--- a/comms/torchcomms/transport/RdmaTransport.h
+++ b/comms/torchcomms/transport/RdmaTransport.h
@@ -243,7 +243,7 @@ class __attribute__((visibility("default"))) RdmaTransport {
    */
   folly::SemiFuture<commResult_t> write(
       RdmaMemory::View localBuffer,
-      RdmaRemoteBuffer remoteBuffer,
+      const RdmaRemoteBuffer& remoteBuffer,
       bool notify);
 
   /*


### PR DESCRIPTION
Summary:
Pass parameters by const reference instead of by value to avoid
unnecessary copies. This includes ReduceOp, RdmaRemoteBuffer, shared_ptr,
and dataType parameters across MCCL, TorchCommPy, and test files.

Differential Revision: D91014295


