### PR TITLE
Adding Dynamic Connection (DC) support in ibverbx library

### DIFF
--- a/comms/ctran/ibverbx/IbvAh.cc
+++ b/comms/ctran/ibverbx/IbvAh.cc
@@ -1,0 +1,40 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/ctran/ibverbx/IbvAh.h"
+
+#include <folly/logging/xlog.h>
+#include "comms/ctran/ibverbx/IbverbxSymbols.h"
+
+namespace ibverbx {
+
+extern IbvSymbols ibvSymbols;
+
+/*** IbvAh ***/
+
+IbvAh::IbvAh(ibv_ah* ah) : ah_(ah) {}
+
+IbvAh::IbvAh(IbvAh&& other) noexcept {
+  ah_ = other.ah_;
+  other.ah_ = nullptr;
+}
+
+IbvAh& IbvAh::operator=(IbvAh&& other) noexcept {
+  ah_ = other.ah_;
+  other.ah_ = nullptr;
+  return *this;
+}
+
+IbvAh::~IbvAh() {
+  if (ah_) {
+    int rc = ibvSymbols.ibv_internal_destroy_ah(ah_);
+    if (rc != 0) {
+      XLOGF(ERR, "Failed to destroy AH rc: {}, {}", rc, strerror(errno));
+    }
+  }
+}
+
+ibv_ah* IbvAh::ah() const {
+  return ah_;
+}
+
+} // namespace ibverbx

--- a/comms/ctran/ibverbx/IbvAh.h
+++ b/comms/ctran/ibverbx/IbvAh.h
@@ -1,0 +1,34 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include "comms/ctran/ibverbx/Ibvcore.h"
+
+namespace ibverbx {
+
+// IbvAh: Address Handle
+// Used by DC transport to route messages to remote DCTs
+class IbvAh {
+ public:
+  IbvAh() = default;
+  ~IbvAh();
+
+  // disable copy constructor
+  IbvAh(const IbvAh&) = delete;
+  IbvAh& operator=(const IbvAh&) = delete;
+
+  // move constructor
+  IbvAh(IbvAh&& other) noexcept;
+  IbvAh& operator=(IbvAh&& other) noexcept;
+
+  ibv_ah* ah() const;
+
+ private:
+  friend class IbvPd;
+
+  explicit IbvAh(ibv_ah* ah);
+
+  ibv_ah* ah_{nullptr};
+};
+
+} // namespace ibverbx

--- a/comms/ctran/ibverbx/IbvPd.cc
+++ b/comms/ctran/ibverbx/IbvPd.cc
@@ -80,6 +80,9 @@ folly::Expected<IbvMr, Error> IbvPd::regDmabufMr(
     ibv_access_flags access) const {
   ibv_mr* mr;
   if (dataDirect_) {
+    if (ibvSymbols.mlx5dv_internal_reg_dmabuf_mr == nullptr) {
+      return folly::makeUnexpected(Error(ENOSYS));
+    }
     mr = ibvSymbols.mlx5dv_internal_reg_dmabuf_mr(
         pd_,
         offset,
@@ -89,6 +92,9 @@ folly::Expected<IbvMr, Error> IbvPd::regDmabufMr(
         access,
         MLX5DV_REG_DMABUF_ACCESS_DATA_DIRECT);
   } else {
+    if (ibvSymbols.ibv_internal_reg_dmabuf_mr == nullptr) {
+      return folly::makeUnexpected(Error(ENOSYS));
+    }
     mr = ibvSymbols.ibv_internal_reg_dmabuf_mr(
         pd_, offset, length, iova, fd, access);
   }
@@ -158,6 +164,49 @@ folly::Expected<IbvVirtualQp, Error> IbvPd::createVirtualQp(
       maxMsgCntPerQp,
       maxMsgSize,
       loadBalancingScheme);
+}
+
+folly::Expected<IbvSrq, Error> IbvPd::createSrq(
+    ibv_srq_init_attr* srqInitAttr) const {
+  if (ibvSymbols.ibv_internal_create_srq == nullptr) {
+    return folly::makeUnexpected(Error(ENOSYS));
+  }
+
+  ibv_srq* srq;
+  srq = ibvSymbols.ibv_internal_create_srq(pd_, srqInitAttr);
+  if (!srq) {
+    return folly::makeUnexpected(Error(errno));
+  }
+  return IbvSrq(srq);
+}
+
+folly::Expected<IbvAh, Error> IbvPd::createAh(ibv_ah_attr* ahAttr) const {
+  ibv_ah* ah;
+  ah = ibvSymbols.ibv_internal_create_ah(pd_, ahAttr);
+  if (!ah) {
+    return folly::makeUnexpected(Error(errno));
+  }
+  return IbvAh(ah);
+}
+
+folly::Expected<IbvQp, Error> IbvPd::createDcQp(
+    ibv_qp_init_attr_ex* initAttrEx,
+    mlx5dv_qp_init_attr* mlx5InitAttr) const {
+  if (!ibvSymbols.mlx5dv_internal_create_qp) {
+    return folly::makeUnexpected(
+        Error(ENOTSUP, "mlx5dv_create_qp not available"));
+  }
+
+  // Set the PD in the extended attributes
+  initAttrEx->pd = pd_;
+
+  ibv_qp* qp;
+  qp = ibvSymbols.mlx5dv_internal_create_qp(
+      pd_->context, initAttrEx, mlx5InitAttr);
+  if (!qp) {
+    return folly::makeUnexpected(Error(errno));
+  }
+  return IbvQp(qp, deviceId_);
 }
 
 } // namespace ibverbx

--- a/comms/ctran/ibverbx/IbvPd.h
+++ b/comms/ctran/ibverbx/IbvPd.h
@@ -3,9 +3,11 @@
 #pragma once
 
 #include <folly/Expected.h>
+#include "comms/ctran/ibverbx/IbvAh.h"
 #include "comms/ctran/ibverbx/IbvCommon.h"
 #include "comms/ctran/ibverbx/IbvMr.h"
 #include "comms/ctran/ibverbx/IbvQp.h"
+#include "comms/ctran/ibverbx/IbvSrq.h"
 #include "comms/ctran/ibverbx/IbvVirtualQp.h"
 #include "comms/ctran/ibverbx/Ibvcore.h"
 
@@ -55,6 +57,21 @@ class IbvPd {
       int maxMsgSize = kIbMaxMsgSizeByte,
       LoadBalancingScheme loadBalancingScheme =
           LoadBalancingScheme::SPRAY) const;
+
+  // Create a Shared Receive Queue (SRQ)
+  // Used for DC transport to receive messages on DCT
+  folly::Expected<IbvSrq, Error> createSrq(
+      ibv_srq_init_attr* srqInitAttr) const;
+
+  // Create an Address Handle (AH)
+  // Used for DC transport to route messages to remote DCTs
+  folly::Expected<IbvAh, Error> createAh(ibv_ah_attr* ahAttr) const;
+
+  // Create a DC QP (DCI or DCT) using mlx5dv_create_qp
+  // This is for Dynamically Connected transport
+  folly::Expected<IbvQp, Error> createDcQp(
+      ibv_qp_init_attr_ex* initAttrEx,
+      mlx5dv_qp_init_attr* mlx5InitAttr) const;
 
  private:
   friend class IbvDevice;

--- a/comms/ctran/ibverbx/IbvSrq.cc
+++ b/comms/ctran/ibverbx/IbvSrq.cc
@@ -1,0 +1,69 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/ctran/ibverbx/IbvSrq.h"
+
+#include <folly/logging/xlog.h>
+#include "comms/ctran/ibverbx/IbverbxSymbols.h"
+
+namespace ibverbx {
+
+extern IbvSymbols ibvSymbols;
+
+/*** IbvSrq ***/
+
+IbvSrq::IbvSrq(ibv_srq* srq) : srq_(srq) {}
+
+IbvSrq::IbvSrq(IbvSrq&& other) noexcept {
+  srq_ = other.srq_;
+  other.srq_ = nullptr;
+}
+
+IbvSrq& IbvSrq::operator=(IbvSrq&& other) noexcept {
+  srq_ = other.srq_;
+  other.srq_ = nullptr;
+  return *this;
+}
+
+IbvSrq::~IbvSrq() {
+  if (srq_) {
+    int rc = ibvSymbols.ibv_internal_destroy_srq(srq_);
+    if (rc != 0) {
+      XLOGF(ERR, "Failed to destroy SRQ rc: {}, {}", rc, strerror(errno));
+    }
+  }
+}
+
+ibv_srq* IbvSrq::srq() const {
+  return srq_;
+}
+
+folly::Expected<folly::Unit, Error> IbvSrq::postRecv(
+    ibv_recv_wr* recvWr,
+    ibv_recv_wr** badRecvWr) {
+  int rc = ibvSymbols.ibv_internal_post_srq_recv(srq_, recvWr, badRecvWr);
+  if (rc != 0) {
+    return folly::makeUnexpected(Error(rc));
+  }
+  return folly::unit;
+}
+
+folly::Expected<folly::Unit, Error> IbvSrq::modifySrq(
+    ibv_srq_attr* srqAttr,
+    int srqAttrMask) {
+  int rc = ibvSymbols.ibv_internal_modify_srq(srq_, srqAttr, srqAttrMask);
+  if (rc != 0) {
+    return folly::makeUnexpected(Error(rc));
+  }
+  return folly::unit;
+}
+
+folly::Expected<ibv_srq_attr, Error> IbvSrq::querySrq() const {
+  ibv_srq_attr srqAttr{};
+  int rc = ibvSymbols.ibv_internal_query_srq(srq_, &srqAttr);
+  if (rc != 0) {
+    return folly::makeUnexpected(Error(rc));
+  }
+  return srqAttr;
+}
+
+} // namespace ibverbx

--- a/comms/ctran/ibverbx/IbvSrq.h
+++ b/comms/ctran/ibverbx/IbvSrq.h
@@ -1,0 +1,48 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <folly/Expected.h>
+#include "comms/ctran/ibverbx/IbvCommon.h"
+#include "comms/ctran/ibverbx/Ibvcore.h"
+
+namespace ibverbx {
+
+// IbvSrq: Shared Receive Queue
+// Used by DC transport for receiving messages on DCT
+class IbvSrq {
+ public:
+  ~IbvSrq();
+
+  // disable copy constructor
+  IbvSrq(const IbvSrq&) = delete;
+  IbvSrq& operator=(const IbvSrq&) = delete;
+
+  // move constructor
+  IbvSrq(IbvSrq&& other) noexcept;
+  IbvSrq& operator=(IbvSrq&& other) noexcept;
+
+  ibv_srq* srq() const;
+
+  // Post a receive work request to the SRQ
+  folly::Expected<folly::Unit, Error> postRecv(
+      ibv_recv_wr* recvWr,
+      ibv_recv_wr** badRecvWr);
+
+  // Modify SRQ attributes
+  folly::Expected<folly::Unit, Error> modifySrq(
+      ibv_srq_attr* srqAttr,
+      int srqAttrMask);
+
+  // Query SRQ attributes
+  folly::Expected<ibv_srq_attr, Error> querySrq() const;
+
+ private:
+  friend class IbvPd;
+
+  explicit IbvSrq(ibv_srq* srq);
+
+  ibv_srq* srq_{nullptr};
+};
+
+} // namespace ibverbx

--- a/comms/ctran/ibverbx/IbverbxSymbols.cc
+++ b/comms/ctran/ibverbx/IbverbxSymbols.cc
@@ -269,6 +269,84 @@ struct ibv_mr* linked_mlx5dv_reg_dmabuf_mr(
       access,
       mlx5_access));
 }
+
+struct ibv_qp* linked_mlx5dv_create_qp(
+    struct ibv_context* context,
+    struct ibv_qp_init_attr_ex* qp_attr,
+    struct mlx5dv_qp_init_attr* mlx5_qp_attr) {
+  return reinterpret_cast<struct ibv_qp*>(mlx5dv_create_qp(
+      reinterpret_cast<::ibv_context*>(context),
+      reinterpret_cast<::ibv_qp_init_attr_ex*>(qp_attr),
+      reinterpret_cast<::mlx5dv_qp_init_attr*>(mlx5_qp_attr)));
+}
+
+struct mlx5dv_qp_ex* linked_mlx5dv_qp_ex_from_ibv_qp_ex(struct ibv_qp_ex* qp) {
+  return reinterpret_cast<struct mlx5dv_qp_ex*>(
+      mlx5dv_qp_ex_from_ibv_qp_ex(reinterpret_cast<::ibv_qp_ex*>(qp)));
+}
+
+struct ibv_srq* linked_create_srq(
+    struct ibv_pd* pd,
+    struct ibv_srq_init_attr* srq_init_attr) {
+  return reinterpret_cast<struct ibv_srq*>(ibv_create_srq(
+      reinterpret_cast<::ibv_pd*>(pd),
+      reinterpret_cast<::ibv_srq_init_attr*>(srq_init_attr)));
+}
+
+struct ibv_srq* linked_create_srq_ex(
+    struct ibv_context* context,
+    struct ibv_srq_init_attr_ex* srq_init_attr_ex) {
+  return reinterpret_cast<struct ibv_srq*>(ibv_create_srq_ex(
+      reinterpret_cast<::ibv_context*>(context),
+      reinterpret_cast<::ibv_srq_init_attr_ex*>(srq_init_attr_ex)));
+}
+
+int linked_modify_srq(
+    struct ibv_srq* srq,
+    struct ibv_srq_attr* srq_attr,
+    int srq_attr_mask) {
+  return ibv_modify_srq(
+      reinterpret_cast<::ibv_srq*>(srq),
+      reinterpret_cast<::ibv_srq_attr*>(srq_attr),
+      srq_attr_mask);
+}
+
+int linked_query_srq(struct ibv_srq* srq, struct ibv_srq_attr* srq_attr) {
+  return ibv_query_srq(
+      reinterpret_cast<::ibv_srq*>(srq),
+      reinterpret_cast<::ibv_srq_attr*>(srq_attr));
+}
+
+int linked_destroy_srq(struct ibv_srq* srq) {
+  return ibv_destroy_srq(reinterpret_cast<::ibv_srq*>(srq));
+}
+
+int linked_post_srq_recv(
+    struct ibv_srq* srq,
+    struct ibv_recv_wr* recv_wr,
+    struct ibv_recv_wr** bad_recv_wr) {
+  return ibv_post_srq_recv(
+      reinterpret_cast<::ibv_srq*>(srq),
+      reinterpret_cast<::ibv_recv_wr*>(recv_wr),
+      reinterpret_cast<::ibv_recv_wr**>(bad_recv_wr));
+}
+
+struct ibv_ah* linked_create_ah(struct ibv_pd* pd, struct ibv_ah_attr* attr) {
+  return reinterpret_cast<struct ibv_ah*>(ibv_create_ah(
+      reinterpret_cast<::ibv_pd*>(pd), reinterpret_cast<::ibv_ah_attr*>(attr)));
+}
+
+int linked_destroy_ah(struct ibv_ah* ah) {
+  return ibv_destroy_ah(reinterpret_cast<::ibv_ah*>(ah));
+}
+
+struct ibv_qp* linked_create_qp_ex(
+    struct ibv_context* context,
+    struct ibv_qp_init_attr_ex* qp_init_attr_ex) {
+  return reinterpret_cast<struct ibv_qp*>(ibv_create_qp_ex(
+      reinterpret_cast<::ibv_context*>(context),
+      reinterpret_cast<::ibv_qp_init_attr_ex*>(qp_init_attr_ex)));
+}
 #endif
 
 int buildIbvSymbols(IbvSymbols& symbols, const std::string& ibv_path) {
@@ -316,6 +394,25 @@ int buildIbvSymbols(IbvSymbols& symbols, const std::string& ibv_path) {
   symbols.mlx5dv_internal_get_data_direct_sysfs_path =
       &linked_mlx5dv_get_data_direct_sysfs_path;
   symbols.mlx5dv_internal_reg_dmabuf_mr = &linked_mlx5dv_reg_dmabuf_mr;
+  symbols.mlx5dv_internal_create_qp = &linked_mlx5dv_create_qp;
+  symbols.mlx5dv_internal_qp_ex_from_ibv_qp_ex =
+      &linked_mlx5dv_qp_ex_from_ibv_qp_ex;
+
+  // SRQ symbols
+  symbols.ibv_internal_create_srq = &linked_create_srq;
+  symbols.ibv_internal_create_srq_ex = &linked_create_srq_ex;
+  symbols.ibv_internal_modify_srq = &linked_modify_srq;
+  symbols.ibv_internal_query_srq = &linked_query_srq;
+  symbols.ibv_internal_destroy_srq = &linked_destroy_srq;
+  symbols.ibv_internal_post_srq_recv = &linked_post_srq_recv;
+
+  // AH symbols
+  symbols.ibv_internal_create_ah = &linked_create_ah;
+  symbols.ibv_internal_destroy_ah = &linked_destroy_ah;
+
+  // Extended QP symbols
+  symbols.ibv_internal_create_qp_ex = &linked_create_qp_ex;
+
   return 0;
 #else
   // Dynamic loading mode - use dlopen/dlsym
@@ -469,6 +566,24 @@ int buildIbvSymbols(IbvSymbols& symbols, const std::string& ibv_path) {
       "mlx5dv_reg_dmabuf_mr",
       symbols.mlx5dv_internal_reg_dmabuf_mr,
       "MLX5_1.25");
+
+  // DC transport support
+  LOAD_MLX5DV_SYM_VERSION(
+      "mlx5dv_create_qp", symbols.mlx5dv_internal_create_qp, "MLX5_1.3");
+  LOAD_MLX5DV_SYM_VERSION(
+      "mlx5dv_qp_ex_from_ibv_qp_ex",
+      symbols.mlx5dv_internal_qp_ex_from_ibv_qp_ex,
+      "MLX5_1.6");
+
+  // SRQ support
+  LOAD_IBVERBS_SYM("ibv_create_srq", symbols.ibv_internal_create_srq);
+  LOAD_IBVERBS_SYM("ibv_modify_srq", symbols.ibv_internal_modify_srq);
+  LOAD_IBVERBS_SYM("ibv_query_srq", symbols.ibv_internal_query_srq);
+  LOAD_IBVERBS_SYM("ibv_destroy_srq", symbols.ibv_internal_destroy_srq);
+
+  // AH support
+  LOAD_IBVERBS_SYM("ibv_create_ah", symbols.ibv_internal_create_ah);
+  LOAD_IBVERBS_SYM("ibv_destroy_ah", symbols.ibv_internal_destroy_ah);
 
   // all symbols were loaded successfully, dismiss guard
   guard.dismiss();

--- a/comms/ctran/ibverbx/IbverbxSymbols.h
+++ b/comms/ctran/ibverbx/IbverbxSymbols.h
@@ -119,7 +119,48 @@ struct IbvSymbols {
       int fd,
       int access,
       int mlx5_access) = nullptr;
+
+  /* DC (Dynamically Connected) transport support */
+  struct ibv_qp* (*mlx5dv_internal_create_qp)(
+      struct ibv_context* context,
+      struct ibv_qp_init_attr_ex* qp_attr,
+      struct mlx5dv_qp_init_attr* mlx5_qp_attr) = nullptr;
+  struct mlx5dv_qp_ex* (*mlx5dv_internal_qp_ex_from_ibv_qp_ex)(
+      struct ibv_qp_ex* qp) = nullptr;
+
+  /* SRQ support */
+  struct ibv_srq* (*ibv_internal_create_srq)(
+      struct ibv_pd* pd,
+      struct ibv_srq_init_attr* srq_init_attr) = nullptr;
+  struct ibv_srq* (*ibv_internal_create_srq_ex)(
+      struct ibv_context* context,
+      struct ibv_srq_init_attr_ex* srq_init_attr_ex) = nullptr;
+  int (*ibv_internal_modify_srq)(
+      struct ibv_srq* srq,
+      struct ibv_srq_attr* srq_attr,
+      int srq_attr_mask) = nullptr;
+  int (*ibv_internal_query_srq)(
+      struct ibv_srq* srq,
+      struct ibv_srq_attr* srq_attr) = nullptr;
+  int (*ibv_internal_destroy_srq)(struct ibv_srq* srq) = nullptr;
+  int (*ibv_internal_post_srq_recv)(
+      struct ibv_srq* srq,
+      struct ibv_recv_wr* recv_wr,
+      struct ibv_recv_wr** bad_recv_wr) = nullptr;
+
+  /* Address Handle (AH) support */
+  struct ibv_ah* (*ibv_internal_create_ah)(
+      struct ibv_pd* pd,
+      struct ibv_ah_attr* attr) = nullptr;
+  int (*ibv_internal_destroy_ah)(struct ibv_ah* ah) = nullptr;
+
+  /* Extended QP support */
+  struct ibv_qp* (*ibv_internal_create_qp_ex)(
+      struct ibv_context* context,
+      struct ibv_qp_init_attr_ex* qp_init_attr_ex) = nullptr;
 };
+
+extern IbvSymbols ibvSymbols;
 
 int buildIbvSymbols(IbvSymbols& ibvSymbols, const std::string& ibv_path = "");
 

--- a/comms/ctran/ibverbx/tests/IbverbxDynamicConnectionSupportTest.cc
+++ b/comms/ctran/ibverbx/tests/IbverbxDynamicConnectionSupportTest.cc
@@ -1,0 +1,352 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+
+#include "comms/ctran/ibverbx/Ibverbx.h"
+
+namespace ibverbx {
+
+// DC transport only supports mlx5 NICs
+const std::string kNicPrefix("mlx5_");
+
+constexpr uint8_t kPortNum = 1;
+
+#if defined(USE_FE_NIC)
+constexpr int kGidIndex = 1;
+#else
+constexpr int kGidIndex = 3;
+#endif
+
+// DC Authentication Key
+constexpr uint64_t DC_KEY = 0x1234;
+
+class IbverbxDcTestFixture : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    ASSERT_TRUE(ibvInit());
+  }
+};
+
+// Test SRQ creation and basic operations
+TEST_F(IbverbxDcTestFixture, IbvSrqCreation) {
+  auto devices = IbvDevice::ibvGetDeviceList({kNicPrefix});
+  ASSERT_TRUE(devices);
+  auto& device = devices->at(0);
+
+  auto pd = device.allocPd();
+  ASSERT_TRUE(pd);
+  ASSERT_NE(pd->pd(), nullptr);
+
+  // Create SRQ init attributes
+  ibv_srq_init_attr srqInitAttr{};
+  memset(&srqInitAttr, 0, sizeof(ibv_srq_init_attr));
+  srqInitAttr.attr.max_wr = 256;
+  srqInitAttr.attr.max_sge = 1;
+
+  auto srq = pd->createSrq(&srqInitAttr);
+  // SRQ creation may fail if ibv_create_srq is not available on this platform
+  if (srq.hasError() && srq.error().errNum == ENOSYS) {
+    GTEST_SKIP() << "ibv_create_srq not available on this platform";
+  }
+  ASSERT_TRUE(srq) << "createSrq failed: " << srq.error().errStr;
+  ASSERT_NE(srq->srq(), nullptr);
+
+  // Test querySrq
+  auto queryResult = srq->querySrq();
+  ASSERT_TRUE(queryResult);
+  EXPECT_GT(queryResult->max_wr, 0);
+
+  // Test move constructor
+  auto srqRawPtr = srq->srq();
+  auto srq1 = std::move(*srq);
+  ASSERT_EQ(srq->srq(), nullptr);
+  ASSERT_EQ(srq1.srq(), srqRawPtr);
+
+  IbvSrq srq2(std::move(srq1));
+  ASSERT_EQ(srq1.srq(), nullptr);
+  ASSERT_EQ(srq2.srq(), srqRawPtr);
+}
+
+// Test posting receive work requests to SRQ
+TEST_F(IbverbxDcTestFixture, IbvSrqPostRecv) {
+  auto devices = IbvDevice::ibvGetDeviceList({kNicPrefix});
+  ASSERT_TRUE(devices);
+  auto& device = devices->at(0);
+
+  auto pd = device.allocPd();
+  ASSERT_TRUE(pd);
+
+  // Create SRQ
+  ibv_srq_init_attr srqInitAttr{};
+  memset(&srqInitAttr, 0, sizeof(ibv_srq_init_attr));
+  srqInitAttr.attr.max_wr = 256;
+  srqInitAttr.attr.max_sge = 1;
+
+  auto srq = pd->createSrq(&srqInitAttr);
+  if (srq.hasError() && srq.error().errNum == ENOSYS) {
+    GTEST_SKIP() << "ibv_create_srq not available on this platform";
+  }
+  ASSERT_TRUE(srq) << "createSrq failed: " << srq.error().errStr;
+
+  // Post a receive work request to the SRQ
+  // For DC transport, we typically post receives with no scatter-gather entries
+  // since RDMA_WRITE_WITH_IMM only delivers immediate data, not payload
+  ibv_sge recvSgList{};
+  ibv_recv_wr recvWr{};
+  recvWr.wr_id = 12345;
+  recvWr.next = nullptr;
+  recvWr.sg_list = &recvSgList;
+  recvWr.num_sge = 0;
+
+  ibv_recv_wr* badRecvWr = nullptr;
+  auto postResult = srq->postRecv(&recvWr, &badRecvWr);
+  ASSERT_TRUE(postResult) << "postRecv failed";
+}
+
+// Test DCI (DC Initiator) creation
+TEST_F(IbverbxDcTestFixture, IbvDciCreation) {
+#if defined(__HIP_PLATFORM_AMD__)
+  GTEST_SKIP() << "Skipping DC QP test on AMD platform: mlx5dv not supported";
+#else
+  auto devices = IbvDevice::ibvGetDeviceList({kNicPrefix});
+  ASSERT_TRUE(devices);
+  auto& device = devices->at(0);
+
+  auto pd = device.allocPd();
+  ASSERT_TRUE(pd);
+
+  int cqe = 1024;
+  auto cq = device.createCq(cqe, nullptr, nullptr, 0);
+  ASSERT_TRUE(cq);
+
+  // Create DCI (DC Initiator)
+  ibv_qp_init_attr_ex initAttrEx{};
+  memset(&initAttrEx, 0, sizeof(ibv_qp_init_attr_ex));
+  initAttrEx.qp_type = IBV_QPT_DRIVER;
+  initAttrEx.send_cq = cq->cq();
+  initAttrEx.recv_cq = cq->cq();
+  initAttrEx.comp_mask = IBV_QP_INIT_ATTR_PD;
+  initAttrEx.cap.max_send_wr = 1024;
+  initAttrEx.cap.max_send_sge = 1;
+
+  mlx5dv_qp_init_attr mlx5InitAttr{};
+  memset(&mlx5InitAttr, 0, sizeof(mlx5dv_qp_init_attr));
+  mlx5InitAttr.comp_mask = MLX5DV_QP_INIT_ATTR_MASK_DC;
+  mlx5InitAttr.dc_init_attr.dc_type = MLX5DV_DCTYPE_DCI;
+
+  auto dci = pd->createDcQp(&initAttrEx, &mlx5InitAttr);
+  if (dci.hasError() && dci.error().errNum == ENOTSUP) {
+    GTEST_SKIP() << "mlx5dv_create_qp not available on this platform";
+  }
+  ASSERT_TRUE(dci) << "createDcQp (DCI) failed: " << dci.error().errStr;
+  ASSERT_NE(dci->qp(), nullptr);
+
+  // Test move constructor
+  auto dciRawPtr = dci->qp();
+  auto dci1 = std::move(*dci);
+  ASSERT_EQ(dci->qp(), nullptr);
+  ASSERT_EQ(dci1.qp(), dciRawPtr);
+
+  IbvQp dci2(std::move(dci1));
+  ASSERT_EQ(dci1.qp(), nullptr);
+  ASSERT_EQ(dci2.qp(), dciRawPtr);
+#endif
+}
+
+// Test DCT (DC Target) creation with SRQ
+TEST_F(IbverbxDcTestFixture, IbvDctCreation) {
+#if defined(__HIP_PLATFORM_AMD__)
+  GTEST_SKIP() << "Skipping DC QP test on AMD platform: mlx5dv not supported";
+#else
+  auto devices = IbvDevice::ibvGetDeviceList({kNicPrefix});
+  ASSERT_TRUE(devices);
+  auto& device = devices->at(0);
+
+  auto pd = device.allocPd();
+  ASSERT_TRUE(pd);
+
+  int cqe = 1024;
+  auto cq = device.createCq(cqe, nullptr, nullptr, 0);
+  ASSERT_TRUE(cq);
+
+  // Create SRQ (required for DCT)
+  ibv_srq_init_attr srqInitAttr{};
+  memset(&srqInitAttr, 0, sizeof(ibv_srq_init_attr));
+  srqInitAttr.attr.max_wr = 256;
+  srqInitAttr.attr.max_sge = 1;
+
+  auto srq = pd->createSrq(&srqInitAttr);
+  if (srq.hasError() && srq.error().errNum == ENOSYS) {
+    GTEST_SKIP() << "ibv_create_srq not available on this platform";
+  }
+  ASSERT_TRUE(srq) << "createSrq failed: " << srq.error().errStr;
+
+  // Create DCT (DC Target)
+  ibv_qp_init_attr_ex initAttrEx{};
+  memset(&initAttrEx, 0, sizeof(ibv_qp_init_attr_ex));
+  initAttrEx.qp_type = IBV_QPT_DRIVER;
+  initAttrEx.send_cq = cq->cq();
+  initAttrEx.recv_cq = cq->cq();
+  initAttrEx.srq = srq->srq(); // DCT requires SRQ
+  initAttrEx.comp_mask = IBV_QP_INIT_ATTR_PD;
+
+  mlx5dv_qp_init_attr mlx5InitAttr{};
+  memset(&mlx5InitAttr, 0, sizeof(mlx5dv_qp_init_attr));
+  mlx5InitAttr.comp_mask = MLX5DV_QP_INIT_ATTR_MASK_DC;
+  mlx5InitAttr.dc_init_attr.dc_type = MLX5DV_DCTYPE_DCT;
+  mlx5InitAttr.dc_init_attr.dct_access_key = DC_KEY;
+
+  auto dct = pd->createDcQp(&initAttrEx, &mlx5InitAttr);
+  if (dct.hasError() && dct.error().errNum == ENOTSUP) {
+    GTEST_SKIP() << "mlx5dv_create_qp not available on this platform";
+  }
+  ASSERT_TRUE(dct) << "createDcQp (DCT) failed: " << dct.error().errStr;
+  ASSERT_NE(dct->qp(), nullptr);
+
+  // Test move constructor
+  auto dctRawPtr = dct->qp();
+  auto dct1 = std::move(*dct);
+  ASSERT_EQ(dct->qp(), nullptr);
+  ASSERT_EQ(dct1.qp(), dctRawPtr);
+
+  IbvQp dct2(std::move(dct1));
+  ASSERT_EQ(dct1.qp(), nullptr);
+  ASSERT_EQ(dct2.qp(), dctRawPtr);
+#endif
+}
+
+// Test full DC setup: DCI + DCT + SRQ together
+TEST_F(IbverbxDcTestFixture, IbvDcFullSetup) {
+#if defined(__HIP_PLATFORM_AMD__)
+  GTEST_SKIP() << "Skipping DC QP test on AMD platform: mlx5dv not supported";
+#else
+  auto devices = IbvDevice::ibvGetDeviceList({kNicPrefix});
+  ASSERT_TRUE(devices);
+  auto& device = devices->at(0);
+
+  auto pd = device.allocPd();
+  ASSERT_TRUE(pd);
+
+  int cqe = 1024;
+  auto cq = device.createCq(cqe, nullptr, nullptr, 0);
+  ASSERT_TRUE(cq);
+
+  // Create SRQ
+  ibv_srq_init_attr srqInitAttr{};
+  memset(&srqInitAttr, 0, sizeof(ibv_srq_init_attr));
+  srqInitAttr.attr.max_wr = 256;
+  srqInitAttr.attr.max_sge = 1;
+
+  auto srq = pd->createSrq(&srqInitAttr);
+  if (srq.hasError() && srq.error().errNum == ENOSYS) {
+    GTEST_SKIP() << "ibv_create_srq not available on this platform";
+  }
+  ASSERT_TRUE(srq) << "createSrq failed: " << srq.error().errStr;
+
+  // Create DCI
+  ibv_qp_init_attr_ex initAttrExDci{};
+  memset(&initAttrExDci, 0, sizeof(ibv_qp_init_attr_ex));
+  initAttrExDci.qp_type = IBV_QPT_DRIVER;
+  initAttrExDci.send_cq = cq->cq();
+  initAttrExDci.recv_cq = cq->cq();
+  initAttrExDci.comp_mask = IBV_QP_INIT_ATTR_PD;
+  initAttrExDci.cap.max_send_wr = 1024;
+  initAttrExDci.cap.max_send_sge = 1;
+
+  mlx5dv_qp_init_attr mlx5InitAttrDci{};
+  memset(&mlx5InitAttrDci, 0, sizeof(mlx5dv_qp_init_attr));
+  mlx5InitAttrDci.comp_mask = MLX5DV_QP_INIT_ATTR_MASK_DC;
+  mlx5InitAttrDci.dc_init_attr.dc_type = MLX5DV_DCTYPE_DCI;
+
+  auto dci = pd->createDcQp(&initAttrExDci, &mlx5InitAttrDci);
+  if (dci.hasError() && dci.error().errNum == ENOTSUP) {
+    GTEST_SKIP() << "mlx5dv_create_qp not available on this platform";
+  }
+  ASSERT_TRUE(dci) << "createDcQp (DCI) failed: " << dci.error().errStr;
+  ASSERT_NE(dci->qp(), nullptr);
+
+  // Create DCT
+  ibv_qp_init_attr_ex initAttrExDct{};
+  memset(&initAttrExDct, 0, sizeof(ibv_qp_init_attr_ex));
+  initAttrExDct.qp_type = IBV_QPT_DRIVER;
+  initAttrExDct.send_cq = cq->cq();
+  initAttrExDct.recv_cq = cq->cq();
+  initAttrExDct.srq = srq->srq();
+  initAttrExDct.comp_mask = IBV_QP_INIT_ATTR_PD;
+
+  mlx5dv_qp_init_attr mlx5InitAttrDct{};
+  memset(&mlx5InitAttrDct, 0, sizeof(mlx5dv_qp_init_attr));
+  mlx5InitAttrDct.comp_mask = MLX5DV_QP_INIT_ATTR_MASK_DC;
+  mlx5InitAttrDct.dc_init_attr.dc_type = MLX5DV_DCTYPE_DCT;
+  mlx5InitAttrDct.dc_init_attr.dct_access_key = DC_KEY;
+
+  auto dct = pd->createDcQp(&initAttrExDct, &mlx5InitAttrDct);
+  ASSERT_TRUE(dct) << "createDcQp (DCT) failed: " << dct.error().errStr;
+  ASSERT_NE(dct->qp(), nullptr);
+
+  // Post receives to SRQ
+  for (int i = 0; i < 10; i++) {
+    ibv_sge recvSgList{};
+    ibv_recv_wr recvWr{};
+    recvWr.wr_id = static_cast<uint64_t>(i);
+    recvWr.next = nullptr;
+    recvWr.sg_list = &recvSgList;
+    recvWr.num_sge = 0;
+
+    ibv_recv_wr* badRecvWr = nullptr;
+    auto postResult = srq->postRecv(&recvWr, &badRecvWr);
+    ASSERT_TRUE(postResult) << "postRecv failed for wr_id " << i;
+  }
+
+  // Verify we can query the GID (needed for DC address handles)
+  auto gid = device.queryGid(kPortNum, kGidIndex);
+  ASSERT_TRUE(gid) << "queryGid failed";
+  EXPECT_NE(gid->global.interface_id, 0);
+#endif
+}
+
+// Test Address Handle creation (needed for DC routing)
+TEST_F(IbverbxDcTestFixture, IbvAddressHandleCreation) {
+  auto devices = IbvDevice::ibvGetDeviceList({kNicPrefix});
+  ASSERT_TRUE(devices);
+  auto& device = devices->at(0);
+
+  auto pd = device.allocPd();
+  ASSERT_TRUE(pd);
+
+  // Query GID for address handle
+  auto gid = device.queryGid(kPortNum, kGidIndex);
+  ASSERT_TRUE(gid) << "queryGid failed";
+
+  // Create address handle
+  ibv_ah_attr ahAttr{};
+  memset(&ahAttr, 0, sizeof(ibv_ah_attr));
+  ahAttr.is_global = 1;
+  ahAttr.grh.dgid = *gid; // Use local GID as destination for testing
+  ahAttr.grh.flow_label = 0;
+  ahAttr.grh.sgid_index = kGidIndex;
+  ahAttr.grh.hop_limit = 255;
+  ahAttr.grh.traffic_class = 0;
+  ahAttr.sl = 0;
+  ahAttr.src_path_bits = 0;
+  ahAttr.port_num = kPortNum;
+
+  auto ah = pd->createAh(&ahAttr);
+  if (ah.hasError() && ah.error().errNum == ENOSYS) {
+    GTEST_SKIP() << "ibv_create_ah not available on this platform";
+  }
+  ASSERT_TRUE(ah) << "createAh failed: " << ah.error().errStr;
+  ASSERT_NE(ah->ah(), nullptr);
+
+  // Test move constructor
+  auto ahRawPtr = ah->ah();
+  auto ah1 = std::move(*ah);
+  ASSERT_EQ(ah->ah(), nullptr);
+  ASSERT_EQ(ah1.ah(), ahRawPtr);
+
+  IbvAh ah2(std::move(ah1));
+  ASSERT_EQ(ah1.ah(), nullptr);
+  ASSERT_EQ(ah2.ah(), ahRawPtr);
+}
+
+} // namespace ibverbx


### PR DESCRIPTION
Summary:
Dynamic Connection (DC) is a transport protocol used within RDMA implementations, improving scalability over the widely used Reliably Connected (RC) transport. DC reduces the total number of QPs required system-wide, by having QPs of reliable type dynamically connect and disconnect from any remote node. (see https://docs.nvidia.com/networking/display/rdmacore50/dynamically+connected+(dc)+qps) Currently, we are using RC within RDMA implementations for ctran.

In this diff, we add support for a DC implementation in the ibverbx library. This is an initial effort with the goal of eventually implementing and benchmarking DC as a potential alternative to RC.

Differential Revision: D90424962


