### PR TITLE
Fix with unused exception in catch

### DIFF
--- a/comms/ctran/mapper/CtranMapper.cc
+++ b/comms/ctran/mapper/CtranMapper.cc
@@ -108,7 +108,7 @@ CtranMapper::CtranMapper(CtranComm* comm) {
       this->ctranIb =
           std::make_unique<class CtranIb>(comm, this->ctrlMgr.get());
       this->ctranIb->regCtrlCb(this->ctrlMgr);
-    } catch (const std::bad_alloc& e) {
+    } catch ([[maybe_unused]] const std::bad_alloc& e) {
       ctranIb = nullptr;
       enableBackends_[CtranMapperBackend::IB] = false;
       CLOGF(WARN, "CTRAN-MAPPER: IB backend not enabled");
@@ -138,7 +138,7 @@ CtranMapper::CtranMapper(CtranComm* comm) {
       try {
         this->ctranNvl = std::make_unique<class CtranNvl>(comm);
         this->ctranNvl->regCtrlCb(this->ctrlMgr);
-      } catch (const std::bad_alloc& e) {
+      } catch ([[maybe_unused]] const std::bad_alloc& e) {
         enableBackends_[CtranMapperBackend::NVL] = false;
         // FIXME: give more specific exception + error message
         CLOGF(

--- a/comms/ctran/mapper/CtranMapperRegMem.cc
+++ b/comms/ctran/mapper/CtranMapperRegMem.cc
@@ -863,7 +863,7 @@ commResult_t CtranMapperRegElem::doRegister(const std::vector<bool>& backends) {
       // the buffer, avoiding any premature deallocation issues.
       FB_COMMCHECK(
           CtranNvl::regMem(buf, len, cudaDev_, &nvlRegElem, ncclManaged_));
-    } catch (const std::bad_alloc& e) {
+    } catch ([[maybe_unused]] const std::bad_alloc& e) {
       CLOGF(
           WARN,
           "CTRAN-MAPPER: NVL backend not enabled. Skip NVL registration for buf {} len {}",
@@ -876,7 +876,7 @@ commResult_t CtranMapperRegElem::doRegister(const std::vector<bool>& backends) {
   if (backends[CommBackend::IB]) {
     try {
       FB_COMMCHECK(CtranIb::regMem(buf, len, cudaDev_, &ibRegElem));
-    } catch (const std::bad_alloc& e) {
+    } catch ([[maybe_unused]] const std::bad_alloc& e) {
       CLOGF(
           WARN,
           "CTRAN-MAPPER: IB backend not enabled. Skip IB registration for buf {} len {}",

--- a/comms/ncclx/v2_27/meta/hints/GlobalHints.cc
+++ b/comms/ncclx/v2_27/meta/hints/GlobalHints.cc
@@ -167,7 +167,7 @@ std::optional<T> getTypedGlobalHint(std::string_view key) {
   T valT;
   try {
     valT = folly::to<T>(*val);
-  } catch (const std::exception& e) {
+  } catch ([[maybe_unused]] const std::exception& e) {
     return std::nullopt;
   }
   return valT;

--- a/comms/ncclx/v2_28/meta/hints/GlobalHints.cc
+++ b/comms/ncclx/v2_28/meta/hints/GlobalHints.cc
@@ -167,7 +167,7 @@ std::optional<T> getTypedGlobalHint(std::string_view key) {
   T valT;
   try {
     valT = folly::to<T>(*val);
-  } catch (const std::exception& e) {
+  } catch ([[maybe_unused]] const std::exception& e) {
     return std::nullopt;
   }
   return valT;


### PR DESCRIPTION
Summary:
The Ctran fails with the unused exception parameter.

Error log:
```
fbcode/comms/ctran/mapper/CtranMapperRegMem.cc:879:36: error: unused exception parameter 'e' [-Werror,-Wunused-exception-parameter]
  879 |     } catch (const std::bad_alloc& e) {
```

This diff mark them as maybe used.

Reviewed By: tanquer

Differential Revision: D91071820


