### PR TITLE
Move std::runtime_error macros from ctran to comms/utils

### DIFF
--- a/comms/ctran/utils/Checks.h
+++ b/comms/ctran/utils/Checks.h
@@ -43,26 +43,6 @@
 
 #define FB_CUDACHECK(cmd) FB_CUDACHECK_RETURN(cmd, commUnhandledCudaError)
 
-// Note: when writing code for the comms/ctran directory, prefer the
-// FB_CUDACHECKTHROW_EX or FB_CUDACHECKTHROW_EX_NOCOMM macros.
-//
-// TODO(T250777174): Move this definition out of the ctran directory.
-#define FB_CUDACHECKTHROW(cmd)                                      \
-  do {                                                              \
-    cudaError_t err = cmd;                                          \
-    if (err != cudaSuccess) {                                       \
-      CLOGF(                                                        \
-          ERR,                                                      \
-          "{}:{} Cuda failure {}",                                  \
-          __FILE__,                                                 \
-          __LINE__,                                                 \
-          cudaGetErrorString(err));                                 \
-      (void)cudaGetLastError();                                     \
-      throw std::runtime_error(                                     \
-          std::string("Cuda failure: ") + cudaGetErrorString(err)); \
-    }                                                               \
-  } while (false)
-
 #define FB_CUDACHECKTHROW_EX_DIRECT(cmd, rank, commHash, desc)     \
   do {                                                             \
     cudaError_t err = cmd;                                         \
@@ -352,25 +332,6 @@
     }                             \
   } while (0)
 
-// Note: when writing Ctran code, prefer the FOLLY_EXPECTED_CHECKTHROW_EX or
-// FOLLY_EXPECTED_CHECKTHROW_EX_NOCOMM macros instead of this one.
-//
-// TODO(T251293921): Move this definition out of the `comms/ctran` directory.
-#define FOLLY_EXPECTED_CHECKTHROW(RES)                                  \
-  do {                                                                  \
-    if (RES.hasError()) {                                               \
-      CLOGF(                                                            \
-          ERR,                                                          \
-          "{}:{} -> {} ({})",                                           \
-          __FILE__,                                                     \
-          __LINE__,                                                     \
-          RES.error().errNum,                                           \
-          RES.error().errStr);                                          \
-      throw std::runtime_error(                                         \
-          std::string("COMM internal failure: ") + RES.error().errStr); \
-    }                                                                   \
-  } while (0)
-
 #define FOLLY_EXPECTED_CHECKTHROW_EX(RES, commLogData)                 \
   do {                                                                 \
     if (RES.hasError()) {                                              \
@@ -420,28 +381,6 @@
           info);                                   \
       goto label;                                  \
     }                                              \
-  } while (0)
-
-// Note: this macro should NOT be used within Ctran code.
-// Prefer FB_COMMCHECKTHROW_EX or FB_COMMCHECKTHROW_EX_NOCOMM
-// instead when writing code witin the "comms/ctran/" directory.
-//
-// TODO(T250686203): Move this macro's definition somewhere else.
-#define FB_COMMCHECKTHROW(cmd)                         \
-  do {                                                 \
-    commResult_t RES = cmd;                            \
-    if (RES != commSuccess && RES != commInProgress) { \
-      CLOGF(                                           \
-          ERR,                                         \
-          "{}:{} -> {} ({})",                          \
-          __FILE__,                                    \
-          __LINE__,                                    \
-          RES,                                         \
-          ::meta::comms::commCodeToString(RES));       \
-      throw std::runtime_error(                        \
-          std::string("COMM internal failure: ") +     \
-          ::meta::comms::commCodeToString(RES));       \
-    }                                                  \
   } while (0)
 
 #define FB_COMMCHECKTHROW_EX_DIRECT(cmd, rank, commHash, commDesc) \
@@ -537,22 +476,6 @@
       abort();                                    \
     }                                             \
   } while (0);
-
-// Note: when writing code within comms/ctran, prefer FB_CHECKTHROW_EX
-// and FB_CHECKTHROW_EX_NOCOMM to FB_CHECKTHROW.
-//
-// TODO(T250693645): Move this macro definition outside of ctran directory.
-#define FB_CHECKTHROW(statement, ...)                                          \
-  do {                                                                         \
-    if (!(statement)) {                                                        \
-      auto errorMsg =                                                          \
-          fmt::format("Check failed: {} - {}", #statement, __VA_ARGS__);       \
-      CLOGF(ERR, errorMsg);                                                    \
-      throw std::runtime_error(                                                \
-          fmt::format(                                                         \
-              "Check failed: {} - {}", #statement, fmt::format(__VA_ARGS__))); \
-    }                                                                          \
-  } while (0)
 
 #define FB_CHECKTHROW_EX_DIRECT(statement, rank, commHash, commDesc, msg) \
   do {                                                                    \
@@ -675,18 +598,6 @@
     CLOGF(ERR, ##__VA_ARGS__);                                      \
     ErrorStackTraceUtil::logErrorMessage(fmt::format(__VA_ARGS__)); \
     return error;                                                   \
-  } while (0)
-
-// Note: when writing code within the comms/ctran directory,
-// prefer the FB_ERRORTHROW_EX or FB_ERRORTHROW_EX_NOCOMM macros.
-//
-// TODO(T250696492): move this macro definition outside the ctran directory.
-#define FB_ERRORTHROW(error, ...)                \
-  do {                                           \
-    CLOGF(ERR, ##__VA_ARGS__);                   \
-    throw std::runtime_error(                    \
-        std::string("COMM internal failure: ") + \
-        ::meta::comms::commCodeToString(error)); \
   } while (0)
 
 #define FB_ERRORTHROW_EX(error, logData, ...)       \

--- a/comms/ctran/utils/tests/ChecksUT.cc
+++ b/comms/ctran/utils/tests/ChecksUT.cc
@@ -148,32 +148,6 @@ TEST_F(CtranUtilsCheckTest, ErrorReturn) {
   EXPECT_THAT(messages[0], ::testing::HasSubstr("test ErrorReturn failure"));
 }
 
-TEST_F(CtranUtilsCheckTest, ErrorThrow) {
-  auto dummyFn = []() {
-    FB_ERRORTHROW(commInternalError, "test ErrorThrow failure");
-    return commSuccess;
-  };
-
-  bool caughtException = false;
-  try {
-    dummyFn();
-  } catch (const std::runtime_error& e) {
-    auto errMsg = std::string(e.what());
-    EXPECT_THAT(errMsg, ::testing::HasSubstr("COMM internal failure:"));
-    auto errStr =
-        std::string(::meta::comms::commCodeToString(commInternalError));
-    EXPECT_THAT(errMsg, ::testing::HasSubstr(errStr));
-    caughtException = true;
-  }
-
-  ASSERT_TRUE(caughtException) << "Expected std::runtime_error";
-
-  const auto& messages = getMessages();
-  ASSERT_EQ(messages.size(), 1);
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("CTRAN ERROR"));
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("test ErrorThrow failure"));
-}
-
 TEST_F(CtranUtilsCheckTest, ErrorThrowEx) {
   auto dummyFn = [](int rank, uint64_t commHash, std::string commDesc) {
     FB_COMMCHECKTHROW_EX(commSystemError, rank, commHash, commDesc);
@@ -383,12 +357,6 @@ TEST_F(CtranUtilsCheckTest, FOLLY_EXPECTED_CHECKTHROW_EX) {
     caughtException = true;
   }
   ASSERT_TRUE(caughtException) << "Expected ctran::utils::Exception";
-}
-
-TEST_F(CtranUtilsCheckTest, FB_CHECKTHROW) {
-  EXPECT_NO_THROW(FB_CHECKTHROW(true, "test FB_CHECKTHROW -> NO throw"));
-  EXPECT_THROW(
-      FB_CHECKTHROW(false, "test FB_CHECKTHROW -> throw"), std::runtime_error);
 }
 
 TEST_F(CtranUtilsCheckTest, FB_SYSCHECKRETURN) {

--- a/comms/ncclx/v2_27/meta/collectives/pCollectives.cc
+++ b/comms/ncclx/v2_27/meta/collectives/pCollectives.cc
@@ -4,7 +4,7 @@
 #include "nccl.h"
 
 #include "comms/ctran/Ctran.h"
-#include "comms/ctran/utils/Checks.h"
+#include "comms/utils/checks.h"
 
 #include "meta/wrapper/MetaFactory.h"
 

--- a/comms/ncclx/v2_27/meta/colltrace/CollTrace.cc
+++ b/comms/ncclx/v2_27/meta/colltrace/CollTrace.cc
@@ -17,7 +17,7 @@
 #include "comms/utils/StrUtils.h"
 #include "nccl.h"
 
-#include "comms/ctran/utils/Checks.h"
+#include "comms/utils/checks.h"
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "meta/hints/GlobalHints.h"

--- a/comms/ncclx/v2_27/meta/transport/transportProxy.cc
+++ b/comms/ncclx/v2_27/meta/transport/transportProxy.cc
@@ -6,6 +6,7 @@
 
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/utils/Utils.h"
+#include "comms/utils/checks.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/LogUtils.h"
 #include "comms/utils/trainer/TrainerContext.h"

--- a/comms/ncclx/v2_27/meta/wrapper/CtranExComm.cc
+++ b/comms/ncclx/v2_27/meta/wrapper/CtranExComm.cc
@@ -5,7 +5,7 @@
 
 #include "comms/ctran/Ctran.h"
 #include "comms/ctran/CtranEx.h"
-#include "comms/ctran/utils/Checks.h"
+#include "comms/utils/checks.h"
 #include "comms/utils/logger/LogUtils.h"
 
 #include "meta/wrapper/CtranExComm.h"

--- a/comms/ncclx/v2_27/meta/wrapper/MetaFactory.cc
+++ b/comms/ncclx/v2_27/meta/wrapper/MetaFactory.cc
@@ -5,8 +5,8 @@
 #include "comm.h"
 #include "comms/ctran/algos/AllToAll/AllToAllPHintUtils.h"
 #include "comms/ctran/algos/AllToAll/AllToAllvDynamicHintUtils.h"
-#include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/window/WinHintUtils.h"
+#include "comms/utils/checks.h"
 #include "comms/utils/commSpecs.h"
 #include "meta/wrapper/MetaFactory.h"
 

--- a/comms/ncclx/v2_28/meta/collectives/pCollectives.cc
+++ b/comms/ncclx/v2_28/meta/collectives/pCollectives.cc
@@ -4,7 +4,7 @@
 #include "nccl.h"
 
 #include "comms/ctran/Ctran.h"
-#include "comms/ctran/utils/Checks.h"
+#include "comms/utils/checks.h"
 
 #include "meta/wrapper/MetaFactory.h"
 

--- a/comms/ncclx/v2_28/meta/colltrace/CollTrace.cc
+++ b/comms/ncclx/v2_28/meta/colltrace/CollTrace.cc
@@ -17,7 +17,7 @@
 #include "comms/utils/StrUtils.h"
 #include "nccl.h"
 
-#include "comms/ctran/utils/Checks.h"
+#include "comms/utils/checks.h"
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "meta/hints/GlobalHints.h"

--- a/comms/ncclx/v2_28/meta/transport/transportProxy.cc
+++ b/comms/ncclx/v2_28/meta/transport/transportProxy.cc
@@ -6,6 +6,7 @@
 
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/utils/Utils.h"
+#include "comms/utils/checks.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/LogUtils.h"
 #include "comms/utils/trainer/TrainerContext.h"

--- a/comms/ncclx/v2_28/meta/wrapper/CtranExComm.cc
+++ b/comms/ncclx/v2_28/meta/wrapper/CtranExComm.cc
@@ -5,7 +5,7 @@
 
 #include "comms/ctran/Ctran.h"
 #include "comms/ctran/CtranEx.h"
-#include "comms/ctran/utils/Checks.h"
+#include "comms/utils/checks.h"
 #include "comms/utils/logger/LogUtils.h"
 
 #include "meta/wrapper/CtranExComm.h"

--- a/comms/ncclx/v2_28/meta/wrapper/MetaFactory.cc
+++ b/comms/ncclx/v2_28/meta/wrapper/MetaFactory.cc
@@ -5,8 +5,8 @@
 #include "comm.h"
 #include "comms/ctran/algos/AllToAll/AllToAllPHintUtils.h"
 #include "comms/ctran/algos/AllToAll/AllToAllvDynamicHintUtils.h"
-#include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/window/WinHintUtils.h"
+#include "comms/utils/checks.h"
 #include "comms/utils/commSpecs.h"
 #include "meta/wrapper/MetaFactory.h"
 

--- a/comms/rcclx/develop/meta/ctran/MetaFactory.cc
+++ b/comms/rcclx/develop/meta/ctran/MetaFactory.cc
@@ -10,6 +10,7 @@
 #include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/window/WinHintUtils.h"
+#include "comms/utils/checks.h"
 #include "comms/utils/commSpecs.h"
 
 using namespace ctran;

--- a/comms/torchcomms/transport/RdmaTransport.cpp
+++ b/comms/torchcomms/transport/RdmaTransport.cpp
@@ -9,6 +9,7 @@
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/utils/CudaWrap.h"
 #include "comms/ctran/utils/LogInit.h"
+#include "comms/utils/checks.h"
 
 namespace {
 

--- a/comms/utils/MemUtils.cc
+++ b/comms/utils/MemUtils.cc
@@ -1,8 +1,8 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 #include "comms/utils/MemUtils.h"
-#include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/utils/CudaWrap.h"
 #include "comms/ctran/utils/DevMemType.h"
+#include "comms/utils/checks.h"
 
 namespace comms::utils::cumem {
 

--- a/comms/utils/checks.h
+++ b/comms/utils/checks.h
@@ -4,11 +4,15 @@
 
 #include <cuda.h>
 #include <cuda_runtime.h>
+#include <stdexcept>
 
 #include <fmt/format.h>
+#include <folly/String.h>
 #include <folly/logging/xlog.h>
 
+#include "comms/utils/Conversion.h"
 #include "comms/utils/commSpecs.h"
+#include "comms/utils/logger/LogUtils.h"
 
 // Base case
 template <typename... ErrorCodes>
@@ -86,3 +90,103 @@ inline ::meta::comms::CommsError getCommsErrorFromCudaError(
           ncclGetErrorString(err)); \
     }                               \
   }
+
+/**
+ * Checks a CUDA command and throws std::runtime_error on failure.
+ *
+ * Usage:
+ *   FB_CUDACHECKTHROW(cudaMemcpy(dst, src, size, cudaMemcpyDeviceToHost));
+ */
+#define FB_CUDACHECKTHROW(cmd)                                      \
+  do {                                                              \
+    cudaError_t err = cmd;                                          \
+    if (err != cudaSuccess) {                                       \
+      CLOGF(                                                        \
+          ERR,                                                      \
+          "{}:{} Cuda failure {}",                                  \
+          __FILE__,                                                 \
+          __LINE__,                                                 \
+          cudaGetErrorString(err));                                 \
+      (void)cudaGetLastError();                                     \
+      throw std::runtime_error(                                     \
+          std::string("Cuda failure: ") + cudaGetErrorString(err)); \
+    }                                                               \
+  } while (false)
+
+/**
+ * Checks a folly::Expected result and throws std::runtime_error on error.
+ *
+ * Usage:
+ *   auto result = someFunctionReturningExpected();
+ *   FOLLY_EXPECTED_CHECKTHROW(result);
+ */
+#define FOLLY_EXPECTED_CHECKTHROW(RES)                                  \
+  do {                                                                  \
+    if (RES.hasError()) {                                               \
+      CLOGF(                                                            \
+          ERR,                                                          \
+          "{}:{} -> {} ({})",                                           \
+          __FILE__,                                                     \
+          __LINE__,                                                     \
+          RES.error().errNum,                                           \
+          RES.error().errStr);                                          \
+      throw std::runtime_error(                                         \
+          std::string("COMM internal failure: ") + RES.error().errStr); \
+    }                                                                   \
+  } while (0)
+
+/**
+ * Checks a commResult_t and throws std::runtime_error on failure.
+ *
+ * Usage:
+ *   FB_COMMCHECKTHROW(someCommFunction());
+ */
+#define FB_COMMCHECKTHROW(cmd)                         \
+  do {                                                 \
+    commResult_t RES = cmd;                            \
+    if (RES != commSuccess && RES != commInProgress) { \
+      CLOGF(                                           \
+          ERR,                                         \
+          "{}:{} -> {} ({})",                          \
+          __FILE__,                                    \
+          __LINE__,                                    \
+          RES,                                         \
+          ::meta::comms::commCodeToString(RES));       \
+      throw std::runtime_error(                        \
+          std::string("COMM internal failure: ") +     \
+          ::meta::comms::commCodeToString(RES));       \
+    }                                                  \
+  } while (0)
+
+/**
+ * Checks a boolean statement and throws std::runtime_error on failure.
+ *
+ * Usage:
+ *   FB_CHECKTHROW(ptr != nullptr, "Pointer must not be null");
+ *   FB_CHECKTHROW(size > 0, "Size {} must be positive", size);
+ */
+#define FB_CHECKTHROW(statement, ...)                                          \
+  do {                                                                         \
+    if (!(statement)) {                                                        \
+      auto errorMsg =                                                          \
+          fmt::format("Check failed: {} - {}", #statement, __VA_ARGS__);       \
+      CLOGF(ERR, errorMsg);                                                    \
+      throw std::runtime_error(                                                \
+          fmt::format(                                                         \
+              "Check failed: {} - {}", #statement, fmt::format(__VA_ARGS__))); \
+    }                                                                          \
+  } while (0)
+
+/**
+ * Throws std::runtime_error with a commResult_t error code.
+ *
+ * Usage:
+ *   FB_ERRORTHROW(commInternalError, "Failed to initialize resource");
+ */
+#define FB_ERRORTHROW(error, ...)                \
+  do {                                           \
+    CLOGF(ERR, ##__VA_ARGS__);                   \
+    throw std::runtime_error(                    \
+        std::string("COMM internal failure: ") + \
+        ::meta::comms::commCodeToString(error)); \
+  } while (0)

--- a/comms/utils/tests/ChecksUT.cc
+++ b/comms/utils/tests/ChecksUT.cc
@@ -1,0 +1,124 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <string>
+
+#include <fmt/core.h>
+#include <gtest/gtest.h>
+
+#include <gmock/gmock.h>
+#include "comms/utils/checks.h"
+#include "comms/utils/commSpecs.h"
+
+class CommsUtilsCheckTest : public ::testing::Test {};
+
+TEST_F(CommsUtilsCheckTest, FB_CHECKTHROW_Success) {
+  EXPECT_NO_THROW(FB_CHECKTHROW(true, "test FB_CHECKTHROW -> NO throw"));
+}
+
+TEST_F(CommsUtilsCheckTest, FB_CHECKTHROW_Failure) {
+  EXPECT_THROW(
+      FB_CHECKTHROW(false, "test FB_CHECKTHROW -> throw"), std::runtime_error);
+}
+
+TEST_F(CommsUtilsCheckTest, FB_CHECKTHROW_ExceptionMessage) {
+  bool caughtException = false;
+  try {
+    FB_CHECKTHROW(false, "test FB_CHECKTHROW message");
+  } catch (const std::runtime_error& e) {
+    auto errMsg = std::string(e.what());
+    EXPECT_THAT(errMsg, ::testing::HasSubstr("Check failed:"));
+    EXPECT_THAT(errMsg, ::testing::HasSubstr("test FB_CHECKTHROW message"));
+    caughtException = true;
+  }
+  ASSERT_TRUE(caughtException) << "Expected std::runtime_error";
+}
+
+TEST_F(CommsUtilsCheckTest, FB_ERRORTHROW) {
+  auto dummyFn = []() {
+    FB_ERRORTHROW(commInternalError, "test ErrorThrow failure");
+    return commSuccess;
+  };
+
+  bool caughtException = false;
+  try {
+    dummyFn();
+  } catch (const std::runtime_error& e) {
+    auto errMsg = std::string(e.what());
+    EXPECT_THAT(errMsg, ::testing::HasSubstr("COMM internal failure:"));
+    auto errStr =
+        std::string(::meta::comms::commCodeToString(commInternalError));
+    EXPECT_THAT(errMsg, ::testing::HasSubstr(errStr));
+    caughtException = true;
+  }
+
+  ASSERT_TRUE(caughtException) << "Expected std::runtime_error";
+}
+
+TEST_F(CommsUtilsCheckTest, FB_COMMCHECKTHROW_Success) {
+  auto dummyFn = []() {
+    FB_COMMCHECKTHROW(commSuccess);
+    return true;
+  };
+  EXPECT_NO_THROW(dummyFn());
+}
+
+TEST_F(CommsUtilsCheckTest, FB_COMMCHECKTHROW_InProgress) {
+  auto dummyFn = []() {
+    FB_COMMCHECKTHROW(commInProgress);
+    return true;
+  };
+  EXPECT_NO_THROW(dummyFn());
+}
+
+TEST_F(CommsUtilsCheckTest, FB_COMMCHECKTHROW_Failure) {
+  auto dummyFn = []() {
+    FB_COMMCHECKTHROW(commInternalError);
+    return true;
+  };
+
+  bool caughtException = false;
+  try {
+    dummyFn();
+  } catch (const std::runtime_error& e) {
+    auto errMsg = std::string(e.what());
+    EXPECT_THAT(errMsg, ::testing::HasSubstr("COMM internal failure:"));
+    auto errStr =
+        std::string(::meta::comms::commCodeToString(commInternalError));
+    EXPECT_THAT(errMsg, ::testing::HasSubstr(errStr));
+    caughtException = true;
+  }
+
+  ASSERT_TRUE(caughtException) << "Expected std::runtime_error";
+}
+
+namespace {
+struct MockError {
+  int errNum;
+  std::string errStr;
+};
+} // namespace
+
+TEST_F(CommsUtilsCheckTest, FOLLY_EXPECTED_CHECKTHROW_Success) {
+  auto successResult = folly::Expected<int, MockError>(42);
+  EXPECT_NO_THROW(FOLLY_EXPECTED_CHECKTHROW(successResult));
+}
+
+TEST_F(CommsUtilsCheckTest, FOLLY_EXPECTED_CHECKTHROW_Failure) {
+  auto errorResult = folly::Expected<int, MockError>(folly::makeUnexpected(
+      MockError{
+          .errNum = EINVAL,
+          .errStr = "mock error message",
+      }));
+
+  bool caughtException = false;
+  try {
+    FOLLY_EXPECTED_CHECKTHROW(errorResult);
+  } catch (const std::runtime_error& e) {
+    EXPECT_THAT(
+        std::string(e.what()), ::testing::HasSubstr("COMM internal failure:"));
+    EXPECT_THAT(
+        std::string(e.what()), ::testing::HasSubstr("mock error message"));
+    caughtException = true;
+  }
+  ASSERT_TRUE(caughtException) << "Expected std::runtime_error";
+}


### PR DESCRIPTION
Summary:
Part of the migration from `std::runtime_error` to `ctran::utils::Exception` within the Ctran library. The macros that throw `std::runtime_error` (`FB_CUDACHECKTHROW`, `FOLLY_EXPECTED_CHECKTHROW`, `FB_COMMCHECKTHROW`, `FB_CHECKTHROW`, `FB_ERRORTHROW`) are used by code outside Ctran, so they are relocated to `comms/utils/CheckMacros.h` where they can be shared across other libraries.

The `_EX` variants that throw `ctran::utils::Exception` remain in `comms/ctran/utils/Checks.h` for use within ctran code.

Differential Revision: D91075403


