### PR TITLE
Update unit tests to catch ctran::utils::Exception

### DIFF
--- a/comms/ctran/backends/ib/tests/CtranIbDistUT.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbDistUT.cc
@@ -2136,7 +2136,7 @@ TEST_F(CtranIbTest, InvalidBeTopology) {
     ctranIb = std::make_unique<CtranIb>(comm, ctrlMgr.get());
   } catch (const std::bad_alloc& e) {
     GTEST_SKIP() << "IB backend not enabled. Skip test";
-  } catch (const std::runtime_error& e) {
+  } catch (const ctran::utils::Exception& e) {
     EXPECT_THAT(
         e.what(), testing::HasSubstr("COMM internal failure: internal error"));
     ASSERT_EQ(ctranIb, nullptr);

--- a/comms/ctran/backends/tcpdevmem/tests/CtranTcpDmDistUT.cc
+++ b/comms/ctran/backends/tcpdevmem/tests/CtranTcpDmDistUT.cc
@@ -17,6 +17,7 @@
 #include "comms/ctran/backends/tcpdevmem/CtranTcpDm.h"
 #include "comms/ctran/backends/tcpdevmem/CtranTcpDmSingleton.h"
 #include "comms/ctran/utils/CudaWrap.h"
+#include "comms/ctran/utils/Exception.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -54,6 +55,8 @@ class CtranTcpTest : public NcclxBaseTest {
     try {
       this->ctranTcpDm =
           std::make_unique<CtranTcpDm>(this->comm, this->ctrlMgr.get());
+    } catch (const ctran::utils::Exception& e) {
+      GTEST_SKIP() << "TCPDM backend not enabled. Skip test";
     } catch (const std::runtime_error& e) {
       GTEST_SKIP() << "TCPDM backend not enabled. Skip test";
     }

--- a/comms/ctran/mapper/tests/CtranMapperTcpdmUT.cc
+++ b/comms/ctran/mapper/tests/CtranMapperTcpdmUT.cc
@@ -29,8 +29,6 @@ class CtranMapperTcpdmTest : public ::testing::Test {
       ncclCvarInit();
       auto commRAII = ctran::createDummyCtranComm();
       commRAII.reset();
-    } catch (const std::runtime_error& e) {
-      GTEST_SKIP() << "TCPDM backend not enabled. Skip test";
     } catch (const ctran::utils::Exception& e) {
       GTEST_SKIP() << "TCPDM backend not enabled. Skip test";
     }

--- a/comms/ctran/mapper/tests/CtranMapperUT.cc
+++ b/comms/ctran/mapper/tests/CtranMapperUT.cc
@@ -120,8 +120,6 @@ TEST(CtranMapperUT, EnableBackendThroughCVARsWithTCPandIB) {
   std::optional<std::exception> ex;
   try {
     ctran::createDummyCtranComm();
-  } catch (const std::runtime_error& e) {
-    ex = e;
   } catch (const ctran::utils::Exception& e) {
     ex = e;
   }

--- a/comms/ctran/tests/CtranExDistUT.cc
+++ b/comms/ctran/tests/CtranExDistUT.cc
@@ -104,7 +104,7 @@ TEST_F(CtranExTest, InitializedWithInvalidPort) {
         globalRank, localRank, hostInfo, defaultBackends_, defaultDesc_);
   } catch (const std::bad_alloc& e) {
     GTEST_SKIP() << "CTRAN-IB: IB backend not enabled. Skip test";
-  } catch (const std::runtime_error& e) {
+  } catch (const ctran::utils::Exception& e) {
     EXPECT_THAT(e.what(), ::testing::HasSubstr("Invalid port number -1"));
     ASSERT_EQ(ctranEx, nullptr);
     return;
@@ -126,7 +126,7 @@ TEST_F(CtranExTest, InitializedWithInvalidIPv6) {
         globalRank, localRank, hostInfo, defaultBackends_, defaultDesc_);
   } catch (const std::bad_alloc& e) {
     GTEST_SKIP() << "CTRAN-IB: IB backend not enabled. Skip test";
-  } catch (const std::runtime_error& e) {
+  } catch (const ctran::utils::Exception& e) {
     // FIXME: we don't have the proper error message when user gives an invalid
     // ipv6. Thus, skip checking error message for now. We need adjust the error
     // reporting first.


### PR DESCRIPTION
Summary:
Migrate unit test catch statements from std::runtime_error to ctran::utils::Exception as part of the ongoing exception migration within the ctran library.

The implementation code has already been migrated to throw ctran::utils::Exception instead of std::runtime_error, but several unit tests still had catch blocks for the old exception type. This updates those tests to match the current exception types thrown by the implementation.

Differential Revision: D91071042


