### PR TITLE
Ensure iputBatch respects the ibFastPath field

### DIFF
--- a/comms/ctran/algos/AllToAll/AllToAllvDynamicCommon.cc
+++ b/comms/ctran/algos/AllToAll/AllToAllvDynamicCommon.cc
@@ -198,7 +198,8 @@ static inline commResult_t peerPutContig(
                   CtranMapperConfig{
                       .memHdl_ = sendMemHdls[peer],
                       .remoteAccessKey_ = remoteAccessKeys[peer],
-                      .notify_ = true /*notify*/},
+                      .notify_ = true /*notify*/,
+                      .ibFastPath_ = true /*ibFastPath*/},
               .req = ibPutReqs.back().get()});
       FB_COMMCHECK(comm->ctran_->mapper->iputBatch(std::move(putMsgs), peer));
       timestamp->putIssued.emplace_back(peer);

--- a/comms/ctran/algos/AllToAll/AllToAllvDynamicCommon.h
+++ b/comms/ctran/algos/AllToAll/AllToAllvDynamicCommon.h
@@ -236,7 +236,8 @@ commResult_t peerPutNonContig(
                     CtranMapperConfig{
                         .memHdl_ = sendcountsTmpbufRegHdl,
                         .remoteAccessKey_ = interNodeRemoteTmpAccessKey,
-                        .notify_ = true /*notify*/},
+                        .notify_ = true /*notify*/,
+                        .ibFastPath_ = true /*ibFastPath*/},
                 .req = ibPutReqs.back().get()});
       }
 

--- a/comms/ctran/backends/ib/CtranIbVc.h
+++ b/comms/ctran/backends/ib/CtranIbVc.h
@@ -173,6 +173,7 @@ struct PutIbMsg {
   bool notify;
   CtranIbConfig* config;
   CtranIbRequest* req;
+  bool ibFastPath;
 };
 
 /**
@@ -398,6 +399,16 @@ class CtranIbVirtualConn {
   // Getter function for qpScalingTh_
   inline size_t getQpScalingTh() {
     return qpScalingTh_;
+  }
+
+  // Getter function for rcvNxt_
+  inline uint32_t getRcvNxt() {
+    return rcvNxt_;
+  }
+
+  // Getter function for sndNxt_
+  inline uint32_t getSndNxt() {
+    return sndNxt_;
   }
 
   // Getter function for vcMode_
@@ -630,7 +641,8 @@ class CtranIbVirtualConn {
     bool sendChained = true;
     // first check if all the messages can be sent over the fast path
     for (auto& put : msgs) {
-      if (!isFastPutValid<PerfConfig>(put.config, put.len, msgs.size())) {
+      if (!put.ibFastPath ||
+          !isFastPutValid<PerfConfig>(put.config, put.len, msgs.size())) {
         // Fallback to slow path and non batched writes
         sendChained = false;
         break;

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -1479,6 +1479,7 @@ class CtranMapper {
           .notify = put.config.notify_,
           .config = put.config.ibConfig_,
           .req = put.req == nullptr ? nullptr : &(put.req->ibReq),
+          .ibFastPath = put.config.ibFastPath_,
       };
       msgs.emplace_back(std::move(msg));
 


### PR DESCRIPTION
Summary: The current implementation of `iputBatch` does not respect the `isFastPath` field. Add support for this so that one-sided communication can use `iputBatch` by disabling `fastPath`, allowing the remote rank to avoid posting WQE.

Differential Revision: D91081207


