### PR TITLE
Fix typos and naming inconsistencies

### DIFF
--- a/comms/torchcomms/TorchCommBackend.hpp
+++ b/comms/torchcomms/TorchCommBackend.hpp
@@ -148,7 +148,7 @@ class TorchCommBackend {
   virtual const CommOptions& getOptions() const = 0;
 
   virtual const at::Device& getDevice() const = 0;
-  // Window & One-sidede Operations, not required for all backends, so we added
+  // Window & One-sided Operations, not required for all backends, so we added
   // default implementation here
   virtual std::shared_ptr<TorchCommWindow> new_window() {
     throw std::logic_error(

--- a/comms/torchcomms/TorchCommDummy.hpp
+++ b/comms/torchcomms/TorchCommDummy.hpp
@@ -129,7 +129,7 @@ class TorchCommDummy : public TorchCommBackend {
       bool async_op,
       const GatherOptions& options = {}) override;
 
-  // Window & One-sidede Operations
+  // Window & One-sided Operations
   std::shared_ptr<TorchCommWindow> new_window() override;
 
   // Communicator Management

--- a/comms/torchcomms/TorchCommPy.cpp
+++ b/comms/torchcomms/TorchCommPy.cpp
@@ -139,14 +139,14 @@ See https://docs.pytorch.org/docs/stable/notes/cuda.html#cuda-streams for more d
           )",
           py::call_guard<py::gil_scoped_release>());
 
-  py::enum_<TorchCommlWinAccessType>(
-      m, "TorchCommlWinAccessType", "Window attribute.")
+  py::enum_<TorchCommWinAccessType>(
+      m, "TorchCommWinAccessType", "Window attribute.")
       .value(
           "WIN_ACCESS_TYPE_UNIFIED",
-          TorchCommlWinAccessType::WIN_ACCESS_TYPE_UNIFIED)
+          TorchCommWinAccessType::WIN_ACCESS_TYPE_UNIFIED)
       .value(
           "WIN_ACCESS_TYPE_SEPARATE",
-          TorchCommlWinAccessType::WIN_ACCESS_TYPE_SEPARATE);
+          TorchCommWinAccessType::WIN_ACCESS_TYPE_SEPARATE);
 
   py::class_<TorchCommWindowAttr, std::shared_ptr<TorchCommWindowAttr>>(
       m, "TorchCommWindowAttr", "Window attributes.")

--- a/comms/torchcomms/TorchCommWindow.hpp
+++ b/comms/torchcomms/TorchCommWindow.hpp
@@ -11,14 +11,14 @@ namespace comms {
 // Forward declaration
 class TorchWork;
 
-using TorchCommlWinAccessType = enum {
+using TorchCommWinAccessType = enum {
   WIN_ACCESS_TYPE_UNIFIED = 0,
   WIN_ACCESS_TYPE_SEPARATE = 1,
 };
 
 class TorchCommWindowAttr {
  public:
-  TorchCommlWinAccessType accessType;
+  TorchCommWinAccessType accessType;
 };
 
 class TorchCommWindow {

--- a/comms/torchcomms/_comms.pyi
+++ b/comms/torchcomms/_comms.pyi
@@ -123,13 +123,13 @@ class TorchWork:
     def is_completed(self) -> bool: ...
     def wait(self) -> None: ...
 
-class TorchCommlWinAccessType(Enum):
+class TorchCommWinAccessType(Enum):
     WIN_ACCESS_TYPE_UNIFIED = auto()
     WIN_ACCESS_TYPE_SEPARATE = auto()
 
 class TorchCommWindowAttr:
     def __init__(self) -> None: ...
-    access_type: TorchCommlWinAccessType
+    access_type: TorchCommWinAccessType
 
 class TorchCommWindow:
     def get_size(self) -> int: ...

--- a/comms/torchcomms/nccl/TorchCommNCCL.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCL.cpp
@@ -37,7 +37,7 @@ TorchCommNCCL::~TorchCommNCCL() {
     TC_LOG(ERROR) << "TorchCommNCCL was not finalized before destruction";
   }
 
-  // We need to dteach the memory hook in case finalize is not called,
+  // We need to detach the memory hook in case finalize is not called,
   // so that we don't encounter a memory corruption.
   detachMemoryHook();
 }

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -65,7 +65,7 @@ TorchCommNCCLX::~TorchCommNCCLX() {
                         << " was not finalized before destruction";
   }
 
-  // We need to dteach the memory hook in case finalize is not called,
+  // We need to detach the memory hook in case finalize is not called,
   // so that we don't encounter a memory corruption.
   detachMemoryHook();
 }
@@ -840,7 +840,7 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::all_gather_v(
   nccl_api_->groupStart();
 
   for (int i = 0; i < comm_size_; ++i) {
-    // assign inpu/output tensors to support vector all_gather (all_gather_v)
+    // assign input/output tensors to support vector all_gather (all_gather_v)
     // where unevenly sized inputs are gathered among participating ranks
     auto& output = tensor_list[i];
     auto& input = (i == rank_) ? tensor : output;
@@ -1380,7 +1380,7 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::alltoallv_dynamic_dispatch(
       output_tensor_list);
 
   // Convert vector of tensors to a CPU tensor holding pointers, which will be
-  // hold by torchComm.
+  // held by torchComm.
   at::Tensor output_tensor_ptrs = at::zeros(
       {static_cast<int64_t>(output_tensor_list.size())},
       at::TensorOptions().dtype(at::kLong).device(at::kCPU));
@@ -1885,7 +1885,7 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::gather(
   return work;
 }
 
-// Window & One-sidede Operations
+// Window & One-sided Operations
 std::shared_ptr<TorchCommWindow> TorchCommNCCLX::new_window() {
   auto win =
       std::make_shared<TorchCommWindowNCCLX>(nccl_comm_, shared_from_this());

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
@@ -221,7 +221,7 @@ class TorchCommNCCLX : public TorchCommBackend,
       bool async_op,
       const GatherOptions& options = {}) override;
 
-  // Window & One-sidede Operations
+  // Window & One-sided Operations
   std::shared_ptr<TorchCommWindow> new_window() override;
 
   // Communicator Management

--- a/comms/torchcomms/ncclx/TorchCommWindowNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommWindowNCCLX.cpp
@@ -250,10 +250,10 @@ std::shared_ptr<TorchCommWindowAttr> TorchCommWindowNCCLX::get_attr(
   auto attr = std::make_shared<TorchCommWindowAttr>();
   switch (nccl_attr->accessType) {
     case ncclWinAccessUnified:
-      attr->accessType = TorchCommlWinAccessType::WIN_ACCESS_TYPE_UNIFIED;
+      attr->accessType = TorchCommWinAccessType::WIN_ACCESS_TYPE_UNIFIED;
       break;
     case ncclWinAccessSeparate:
-      attr->accessType = TorchCommlWinAccessType::WIN_ACCESS_TYPE_SEPARATE;
+      attr->accessType = TorchCommWinAccessType::WIN_ACCESS_TYPE_SEPARATE;
       break;
     default:
       throw std::runtime_error("Unsupported NCCL window access type");

--- a/comms/torchcomms/objcol.py
+++ b/comms/torchcomms/objcol.py
@@ -81,7 +81,7 @@ def all_gather_object(
         comm: The comm to work on.
         object_list (list[object]): Output list. It should be correctly sized as the
             size of the comm for this collective and will contain the output.
-        obj (object): Pickable Python object to be broadcast from current process.
+        obj (object): Picklable Python object to be broadcast from current process.
         timeout: (timedelta, optional): Timeout for collective operations. If
             ``None``, will use the default timeout for the backend.
         weights_only (bool, optional): If ``True``, only safe objects such as
@@ -482,7 +482,7 @@ def broadcast_object_list(
 
     Similar to :func:`broadcast`, but Python objects can be passed in.
     Note that all objects in ``object_list`` must be picklable in order to be
-    broadcasted.
+    broadcast.
 
     Args:
         comm: The comm to work on.

--- a/comms/torchcomms/rccl/TorchCommRCCL.cpp
+++ b/comms/torchcomms/rccl/TorchCommRCCL.cpp
@@ -41,7 +41,7 @@ TorchCommRCCL::~TorchCommRCCL() {
     TC_LOG(ERROR) << "TorchCommRCCL was not finalized before destruction";
   }
 
-  // We need to dteach the memory hook in case finalize is not called,
+  // We need to detach the memory hook in case finalize is not called,
   // so that we don't encounter a memory corruption.
   detachMemoryHook();
 }

--- a/comms/torchcomms/rcclx/TorchCommRCCLX.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLX.cpp
@@ -41,7 +41,7 @@ TorchCommRCCLX::~TorchCommRCCLX() {
     TC_LOG(ERROR) << "TorchCommRCCLX was not finalized before destruction";
   }
 
-  // We need to dteach the memory hook in case finalize is not called,
+  // We need to detach the memory hook in case finalize is not called,
   // so that we don't encounter a memory corruption.
   detachMemoryHook();
 }

--- a/comms/torchcomms/tests/integration/py/WindowRmaTest.py
+++ b/comms/torchcomms/tests/integration/py/WindowRmaTest.py
@@ -8,7 +8,7 @@ import unittest
 
 import torch
 import torchcomms
-from torchcomms import TorchCommlWinAccessType
+from torchcomms import TorchCommWinAccessType
 from torchcomms.tests.integration.py.TorchCommTestHelpers import (
     get_dtype_name,
     TorchCommTestWrapper,
@@ -136,13 +136,13 @@ class WindowRmaTest(unittest.TestCase):
             next_rank = (self.rank + 1) % self.num_ranks
             win_attr = win.get_attr(next_rank)
             assert (
-                win_attr.access_type == TorchCommlWinAccessType.WIN_ACCESS_TYPE_UNIFIED
+                win_attr.access_type == TorchCommWinAccessType.WIN_ACCESS_TYPE_UNIFIED
             )
         else:
             next_rank = (self.rank + 8) % self.num_ranks
             win_attr = win.get_attr(next_rank)
             assert (
-                win_attr.access_type == TorchCommlWinAccessType.WIN_ACCESS_TYPE_SEPARATE
+                win_attr.access_type == TorchCommWinAccessType.WIN_ACCESS_TYPE_SEPARATE
             )
 
         # Cleanup
@@ -176,7 +176,7 @@ class WindowRmaTest(unittest.TestCase):
         # Test remote access (only for unified memory)
         remote_rank = (self.rank + 1) % self.num_ranks
         win_attr = win.get_attr(remote_rank)
-        if win_attr.access_type == TorchCommlWinAccessType.WIN_ACCESS_TYPE_UNIFIED:
+        if win_attr.access_type == TorchCommWinAccessType.WIN_ACCESS_TYPE_UNIFIED:
             remote_tensor = win.map_remote_tensor(remote_rank)
             self.assertEqual(remote_tensor.dtype, dtype)
             self.assertEqual(remote_tensor.shape, win_buf.shape)

--- a/comms/torchcomms/transport/RdmaTransport.h
+++ b/comms/torchcomms/transport/RdmaTransport.h
@@ -185,7 +185,7 @@ struct RdmaRemoteBuffer {
  *   4. Use APIs for memory registration and data transfer
  *
  * folly::EventBase is used to drive the underlying RDMA operations. User
- * should have a dedicated EventBase for for transport operations and can
+ * should have a dedicated EventBase for transport operations and can
  * be shared across all transport instances. When requests are pending, this
  * will likely keep EventBase thread pretty busy to minimize latency.
  *
@@ -196,7 +196,7 @@ struct RdmaRemoteBuffer {
  * Future APIs that can be supported as per use-case. Given this framework
  * adding new APIs should be relatively straightforward.
  * - Send - RDMA Send (needs matching Recv on other end)
- * - Recv - RDMA Receive (needs mactching Send on other end)
+ * - Recv - RDMA Receive (needs matching Send on other end)
  * - Read - RDMA Read from a remote memory
  * - waitForRead - Wait for a remote read operation
  * - <Atomic APIs>


### PR DESCRIPTION
Summary:
Fix various typos and spelling issues in torchcomms:
- "dteach" -> "detach" in destructor comments (TorchCommNCCL.cpp,
  TorchCommNCCLX.cpp, TorchCommRCCL.cpp, TorchCommRCCLX.cpp)
- "One-sidede" -> "One-sided" in window operation comments
  (TorchCommBackend.hpp, TorchCommDummy.hpp, TorchCommNCCLX.cpp,
  TorchCommNCCLX.hpp)
- "inpu/output" -> "input/output" in TorchCommNCCLX.cpp
- "coudl" -> "could" in TorchCommMCCLCCA.cpp
- "for for" -> "for" in RdmaTransport.h
- "mactching" -> "matching" in RdmaTransport.h
- "it it's" -> "it's" in AllToAllvSingleTest.py
- "TorchCommlWinAccessType" -> "TorchCommWinAccessType" to remove extra
  'l' between 'Comm' and 'Win'
- "Pickable" -> "Picklable" in objcol.py docstrings
- "broadcasted" -> "broadcast" in objcol.py docstrings
- "hold by" -> "held by" in alltoallv_dynamic_dispatch

Reviewed By: tanquer

Differential Revision: D91021933
