### PR TITLE
Capture async flag of collectives in PyTorch execution trace

### DIFF
--- a/comms/torchcomms/TorchCommTracing.cpp
+++ b/comms/torchcomms/TorchCommTracing.cpp
@@ -87,7 +87,8 @@ void TorchCommTracing::recordEventWithInputOutput(
       output_split_sizes, // outSplitSizes
       -1, // TODO: fix global rank start
       -1, // TODO: fix global rank stride
-      comm_size_); // worldSize
+      comm_size_, // worldSize
+      true); // isAsyncOp
 }
 
 std::shared_ptr<torch::ParamCommsDebugInfo> TorchCommTracingGuard::getDebugInfo(
@@ -127,7 +128,8 @@ std::shared_ptr<torch::ParamCommsDebugInfo> TorchCommTracingGuard::getDebugInfo(
       output_split_sizes,
       -1, // TODO: fix global rank start
       -1, // TODO: fix global rank stride
-      comm_size);
+      comm_size,
+      true); // isAsynchronizedOp
 }
 
 void TorchCommTracingGuard::initializeTracingCommon(


### PR DESCRIPTION
Summary:
PyTorch NCCL collectives have an async flag, which defines if the collective is a synchronized op or asynchronized op. This flag is not captured in PyTorch execution trace. 

PyTorch chakra replay tool need to know if the collective is async or not to replay it properly. It assumed the collective is async. In Megatron GPT models, there are large amount of collectives are synchronized op. If we assume they are async, it leads to large number of collectives are on fly, which easily leads to OOM.

X-link: https://github.com/pytorch/pytorch/pull/169416

Differential Revision: D88899905

Pulled By: ashramac


