### PR TITLE
Add validation for unsupported cuMem handle types in tryLoad

### DIFF
--- a/comms/ctran/utils/Alloc.h
+++ b/comms/ctran/utils/Alloc.h
@@ -4,6 +4,9 @@
 
 #include <cuda.h>
 #include <folly/ScopeGuard.h>
+#include <folly/String.h>
+#include <string>
+#include <vector>
 
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/utils/CudaWrap.h"
@@ -13,6 +16,28 @@
 #include "comms/utils/logger/alloc.h"
 
 namespace ctran::utils {
+
+inline std::string cuMemHandleTypeStr(CUmemAllocationHandleType handleType) {
+#if defined(__HIP_PLATFORM_AMD__)
+  // cuMemHandleTypeStr should not be called for AMD
+  return "UNKNOWN";
+#else
+  if (handleType == CU_MEM_HANDLE_TYPE_NONE) {
+    return "NONE";
+  }
+  std::vector<std::string> types;
+  if (handleType & CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR) {
+    types.push_back("POSIX_FD");
+  }
+  if (handleType & CU_MEM_HANDLE_TYPE_FABRIC) {
+    types.push_back("FABRIC");
+  }
+  if (types.empty()) {
+    return "UNKNOWN";
+  }
+  return folly::join("|", types);
+#endif
+}
 
 CUmemAllocationHandleType getCuMemAllocHandleType();
 

--- a/comms/ctran/utils/CtranIpc.cc
+++ b/comms/ctran/utils/CtranIpc.cc
@@ -247,6 +247,16 @@ inline commResult_t ctran::utils::CtranIpcMem::tryLoadCuMem(
     const void* ptr,
     std::size_t len,
     bool& supported) {
+  // Handle type decision in ctran:
+  // - getCuMemAllocHandleType(): Queries system-supported handle types. Used
+  // when
+  //   allocating ctran internal buffers (ALLOC mode). Always includes POSIX.
+  // - getCuMemExportHandleType(): Determines the export handle type based on
+  // CVAR
+  //   enable flag (NCCL_CTRAN_NVL_FABRIC_ENABLE) and the allocation's handle
+  //   type. Used in LOAD mode to validate that user-provided memory can be
+  //   exported.
+
   // temp linear loop through physical allocations, could be faster to get from
   // pytorch level
   size_t cur_offset = 0;
@@ -266,23 +276,44 @@ inline commResult_t ctran::utils::CtranIpcMem::tryLoadCuMem(
     CUmemAllocationProp prop;
     FB_CUCHECK(
         cuMemGetAllocationPropertiesFromHandle(&prop, allocHandles_.back()));
-    // cuMemHandleType_ is set to requestedHandleTypes during registration in
-    // load Mode.
+
+    // Set cuMemHandleType_ from first segment's allocation properties
     if (cuMemHandleType_ == CU_MEM_HANDLE_TYPE_NONE) {
       cuMemHandleType_ = ctran::utils::getCuMemHandleTypeFromProp(prop);
     }
-    if (prop.allocFlags.gpuDirectRDMACapable != 1 ||
-        ctran::utils::getCuMemHandleTypeFromProp(prop) != cuMemHandleType_) {
+
+    // Validate allocation is supported for IPC export. Reject if:
+    // 1. NONE handle type (no shareable handle)
+    // 2. ctran-incompatible type (e.g., FABRIC-only when FABRIC disabled)
+    // 3. no gpuDirectRDMACapable
+    // 4. mixed handle types across segments
+    CUmemAllocationHandleType segmentHandleType =
+        ctran::utils::getCuMemHandleTypeFromProp(prop);
+    CUmemAllocationHandleType supportedExportType =
+        getCuMemExportHandleType(cuMemHandleType_);
+    bool isUnsupportedType = (cuMemHandleType_ == CU_MEM_HANDLE_TYPE_NONE) ||
+        ((cuMemHandleType_ & supportedExportType) == 0) ||
+        (prop.allocFlags.gpuDirectRDMACapable != 1) ||
+        (segmentHandleType != cuMemHandleType_);
+
+    if (isUnsupportedType) {
       CLOGF(
           ERR,
-          "CTRAN-IPC: [pbase {:x} range {}] associated with [ptr {} len {}] does not have required property: "
-          "gpuDirectRDMACapable = {}, requestedHandleTypes = {}",
+          "CTRAN-IPC: [pbase {:x} range {}] associated with [ptr {} len {}] "
+          "has unsupported allocation properties for IPC export: "
+          "handleType = {} ({}), supportedExportType = {} ({}), gpuDirectRDMACapable = {}, "
+          "segmentHandleType = {} ({})",
           cur_pbase,
           cur_range,
           (void*)ptr,
           len,
+          cuMemHandleTypeStr(cuMemHandleType_),
+          static_cast<int>(cuMemHandleType_),
+          cuMemHandleTypeStr(supportedExportType),
+          static_cast<int>(supportedExportType),
           prop.allocFlags.gpuDirectRDMACapable,
-          ctran::utils::getCuMemHandleTypeFromProp(prop));
+          cuMemHandleTypeStr(segmentHandleType),
+          static_cast<int>(segmentHandleType));
       return commInvalidUsage;
     }
 

--- a/comms/ctran/utils/tests/IpcUT.cc
+++ b/comms/ctran/utils/tests/IpcUT.cc
@@ -1,0 +1,115 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include "comms/ctran/tests/CtranTestUtils.h"
+#include "comms/ctran/utils/Alloc.h"
+#include "comms/ctran/utils/CtranIpc.h"
+#include "comms/ctran/utils/CudaWrap.h"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/commSpecs.h"
+
+using namespace ctran::utils;
+
+class IpcUT : public ::testing::Test {
+ public:
+  void SetUp() override {
+    ncclCvarInit();
+    COMMCHECK_TEST(commCudaLibraryInit());
+    CUDACHECK_TEST(cudaSetDevice(0));
+  }
+
+  void TearDown() override {}
+
+ protected:
+  const char* dummyDesc_ = "IpcUT";
+};
+
+// Test Case 1: tryLoad should reject memory allocated with
+// CU_MEM_HANDLE_TYPE_NONE Currently this test is expected to FAIL because
+// tryLoad does not validate this
+TEST_F(IpcUT, TryLoadCuMemRejectsNoneHandleType) {
+  if (!ctran::utils::getCuMemSysSupported()) {
+    GTEST_SKIP() << "CuMem not supported, skipping test";
+  }
+
+  constexpr size_t size = 2 * 1024 * 1024; // 2MB (minimum granularity)
+  std::vector<size_t> segmentSizes = {size};
+  std::vector<TestMemSegment> segments;
+  void* ptr = nullptr;
+
+  auto result = ctran::commMemAllocDisjoint(
+      &ptr, segmentSizes, segments, true, CU_MEM_HANDLE_TYPE_NONE);
+  if (result != commSuccess || ptr == nullptr) {
+    GTEST_SKIP() << "Failed to allocate cuMem with NONE handle type";
+  }
+
+  // Create CtranIpcMem in LOAD mode
+  auto ipcMem = std::make_unique<CtranIpcMem>(0, dummyDesc_);
+
+  // tryLoad should fail for memory with no shareable handle type
+  bool supported = false;
+  (void)ipcMem->tryLoad(ptr, size, supported, false);
+
+  // Expected: tryLoad should return error or set supported=false
+  // because memory with NONE handle type cannot be exported
+  EXPECT_FALSE(supported)
+      << "tryLoad should reject memory with CU_MEM_HANDLE_TYPE_NONE";
+
+  ctran::commMemFreeDisjoint(ptr, segmentSizes);
+}
+
+// Test Case 2: tryLoad should reject FABRIC-only memory when FABRIC is disabled
+// Currently this test is expected to FAIL because tryLoad does not validate
+// this
+TEST_F(IpcUT, TryLoadCuMemRejectsFabricOnlyWhenFabricDisabled) {
+#if CUDART_VERSION < 12040
+  GTEST_SKIP() << "CUDA < 12.04, FABRIC handle type not available";
+#else
+  if (!ctran::utils::getCuMemSysSupported()) {
+    GTEST_SKIP() << "CuMem not supported, skipping test";
+  }
+
+  // Skip if system doesn't support FABRIC - allocation would silently downgrade
+  // to NONE (see D90902516 for details on CUDA's silent downgrade behavior)
+  {
+    EnvRAII fabricDisabled(NCCL_CTRAN_NVL_FABRIC_ENABLE, true);
+    CUmemAllocationHandleType systemSupported =
+        ctran::utils::getCuMemAllocHandleType();
+    if ((systemSupported & CU_MEM_HANDLE_TYPE_FABRIC) == 0) {
+      GTEST_SKIP()
+          << "System does not support FABRIC handle type, skipping test";
+    }
+  }
+
+  // Disable FABRIC support in ctran
+  EnvRAII fabricDisabled(NCCL_CTRAN_NVL_FABRIC_ENABLE, false);
+
+  constexpr size_t size = 2 * 1024 * 1024; // 2MB
+  std::vector<size_t> segmentSizes = {size};
+  std::vector<TestMemSegment> segments;
+  void* ptr = nullptr;
+
+  // Allocate with FABRIC-only handle type
+  auto result = ctran::commMemAllocDisjoint(
+      &ptr, segmentSizes, segments, true, CU_MEM_HANDLE_TYPE_FABRIC);
+  if (result != commSuccess || ptr == nullptr) {
+    GTEST_SKIP() << "Failed to allocate cuMem with FABRIC-only handle type";
+  }
+
+  // Create CtranIpcMem in LOAD mode
+  auto ipcMem = std::make_unique<CtranIpcMem>(0, dummyDesc_);
+
+  // tryLoad should fail because ctran would try to export as POSIX
+  // but the allocation only supports FABRIC
+  bool supported = false;
+  (void)ipcMem->tryLoad(ptr, size, supported, false);
+
+  // Expected: tryLoad should return error or set supported=false
+  // because FABRIC-only memory cannot be exported as POSIX
+  EXPECT_FALSE(supported)
+      << "tryLoad should reject FABRIC-only memory when FABRIC export is disabled";
+
+  ctran::commMemFreeDisjoint(ptr, segmentSizes);
+#endif
+}


### PR DESCRIPTION
Summary:
Improve validation in `tryLoadCuMem` to reject memory allocations that cannot be exported via IPC.

Previously, `tryLoad` would accept memory with unsupported handle types (e.g., `CU_MEM_HANDLE_TYPE_NONE` or FABRIC-only when FABRIC is disabled), leading to failures later during IPC export.

Changes:
- Add `cuMemHandleTypeStr()` helper function in `Alloc.h` to convert handle types to human-readable strings for debugging
- Enhance validation in `tryLoadCuMem` to check:
  1. Handle type is not NONE (no shareable handle)
  2. Handle type is compatible with ctran's export configuration
  3. Memory is gpuDirectRDMACapable
  4. Handle types are consistent across segments
- Improve error logging with detailed handle type information
- Add unit tests for validating rejection of unsupported memory types

Differential Revision: D91154192


