### PR TITLE
fix local rank issue

### DIFF
--- a/comms/pipes/benchmarks/AllToAllvBenchmark.cc
+++ b/comms/pipes/benchmarks/AllToAllvBenchmark.cc
@@ -115,7 +115,9 @@ class AllToAllvBenchmarkFixture : public MpiBaseTestFixture {
  protected:
   void SetUp() override {
     MpiBaseTestFixture::SetUp();
-    CUDA_CHECK_VOID(cudaSetDevice(globalRank));
+    // Use localRank for cudaSetDevice since each node has its own set of GPUs
+    // globalRank would fail on multi-node setups where rank > num_gpus_per_node
+    CUDA_CHECK_VOID(cudaSetDevice(localRank));
 
     // Initialize NCCL with default channel settings
     NCCL_CHECK_VOID(

--- a/comms/pipes/benchmarks/P2pNvlBenchmark.cc
+++ b/comms/pipes/benchmarks/P2pNvlBenchmark.cc
@@ -115,7 +115,9 @@ class P2pNvlBenchmarkFixture : public MpiBaseTestFixture {
  protected:
   void SetUp() override {
     MpiBaseTestFixture::SetUp();
-    cudaSetDevice(globalRank);
+    // Use localRank for cudaSetDevice since each node has its own set of GPUs
+    // globalRank would fail on multi-node setups where rank > num_gpus_per_node
+    CUDA_CHECK_VOID(cudaSetDevice(localRank));
 
     // Initialize NCCL
     NCCL_CHECK_VOID(


### PR DESCRIPTION
Summary: use the localrank instead of the global rank to set the device for the benchmarks

Reviewed By: Regina8023, cenzhaometa

Differential Revision: D91099168


