### PR TITLE
Relocate FB_CUCHECKTHROW macro from ctran/utils to comms/utils

### DIFF
--- a/comms/ctran/utils/CudaWrap.h
+++ b/comms/ctran/utils/CudaWrap.h
@@ -91,20 +91,6 @@ namespace ctran::utils {
     }                                                                    \
   } while (false)
 
-#define FB_CUCHECKTHROW(cmd)                                                   \
-  do {                                                                         \
-    CUresult err = cmd;                                                        \
-    if (err != CUDA_SUCCESS) {                                                 \
-      const char* errStr;                                                      \
-      (void)cuGetErrorString(err, &errStr);                                    \
-      CLOGF(ERR, "Cuda failure {} '{}'", static_cast<int>(err), errStr);       \
-      ErrorStackTraceUtil::logErrorMessage(                                    \
-          "Cuda Error: " + std::string(errStr));                               \
-      throw std::runtime_error(                                                \
-          fmt::format("Cuda failure {} '{}'", static_cast<int>(err), errStr)); \
-    }                                                                          \
-  } while (false)
-
 #define FB_CUCHECKRES(res)                                     \
   do {                                                         \
     if (res != CUDA_SUCCESS) {                                 \
@@ -163,20 +149,6 @@ namespace ctran::utils {
           "Cuda Error: " + std::string(errStr));                         \
       return commUnhandledCudaError;                                     \
     }                                                                    \
-  } while (false)
-
-#define FB_CUCHECKTHROW(cmd)                                                   \
-  do {                                                                         \
-    CUresult err = ::ctran::utils::pfn_##cmd;                                  \
-    if (err != CUDA_SUCCESS) {                                                 \
-      const char* errStr;                                                      \
-      (void)::ctran::utils::pfn_cuGetErrorString(err, &errStr);                \
-      CLOGF(ERR, "Cuda failure {} '{}'", static_cast<int>(err), errStr);       \
-      ErrorStackTraceUtil::logErrorMessage(                                    \
-          "Cuda Error: " + std::string(errStr));                               \
-      throw std::runtime_error(                                                \
-          fmt::format("Cuda failure {} '{}'", static_cast<int>(err), errStr)); \
-    }                                                                          \
   } while (false)
 
 #define FB_CUCHECK_RETURN(cmd, ret)                                      \

--- a/comms/ctran/utils/tests/CudaWrapUT.cc
+++ b/comms/ctran/utils/tests/CudaWrapUT.cc
@@ -23,27 +23,6 @@ class CudaWrapTest : public ::testing::Test {
   void TearDown() override {}
 };
 
-TEST_F(CudaWrapTest, FB_CUCHECKTHROW) {
-  auto dummyFn = []() {
-    // This should fail because we're passing an invalid device pointer
-    CUdeviceptr invalidPtr = 0;
-    size_t size = 0;
-    FB_CUCHECKTHROW(cuMemGetAddressRange(&invalidPtr, &size, (CUdeviceptr)0x1));
-    return commSuccess;
-  };
-
-  bool caughtException = false;
-  try {
-    dummyFn();
-  } catch (const std::runtime_error& e) {
-    auto errMsg = std::string(e.what());
-    EXPECT_THAT(errMsg, ::testing::HasSubstr("Cuda failure"));
-    caughtException = true;
-  }
-
-  ASSERT_TRUE(caughtException) << "Expected std::runtime_error";
-}
-
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   folly::Init init(&argc, &argv);

--- a/comms/utils/CudaChecks.h
+++ b/comms/utils/CudaChecks.h
@@ -1,0 +1,113 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <stdexcept>
+
+#include <fmt/format.h>
+
+#include "comms/utils/logger/LogUtils.h"
+
+#if CUDART_VERSION >= 11030
+#include <cudaTypedefs.h>
+#endif
+
+namespace comms::utils::cuda {
+
+/**
+ * Dynamically loads a CUDA driver function using the CUDA runtime API.
+ * This avoids the need to link against libcuda.so at build time.
+ *
+ * Returns nullptr if the function cannot be loaded (e.g., driver not
+ * available).
+ */
+template <typename FuncPtr>
+inline FuncPtr loadDriverFunction(const char* funcName) {
+  FuncPtr func = nullptr;
+#if CUDART_VERSION >= 12000
+  cudaDriverEntryPointQueryResult driverStatus =
+      cudaDriverEntryPointSymbolNotFound;
+  cudaGetDriverEntryPoint(
+      funcName,
+      reinterpret_cast<void**>(&func),
+      cudaEnableDefault,
+      &driverStatus);
+#elif CUDART_VERSION >= 11030
+  cudaGetDriverEntryPoint(
+      funcName, reinterpret_cast<void**>(&func), cudaEnableDefault);
+#endif
+  return func;
+}
+
+/**
+ * Gets the error string for a CUresult error code.
+ * Uses dynamic loading to avoid link-time dependency on libcuda.so.
+ *
+ * Returns "Unknown error" if the driver function cannot be loaded.
+ */
+inline const char* getCuErrorString(CUresult err) {
+#if CUDART_VERSION >= 11030
+  static auto pfn_cuGetErrorString =
+      loadDriverFunction<PFN_cuGetErrorString_v6000>("cuGetErrorString");
+  if (pfn_cuGetErrorString != nullptr) {
+    const char* errStr = nullptr;
+    pfn_cuGetErrorString(err, &errStr);
+    if (errStr != nullptr) {
+      return errStr;
+    }
+  }
+#endif
+  return "Unknown error";
+}
+
+/**
+ * Wrapper for cuMemGetAddressRange that uses dynamic loading.
+ * This avoids the need to link against libcuda.so at build time.
+ *
+ * Returns CUDA_ERROR_NOT_INITIALIZED if the driver function cannot be loaded.
+ */
+inline CUresult cuMemGetAddressRangeDynamic(
+    CUdeviceptr* pbase,
+    size_t* psize,
+    CUdeviceptr dptr) {
+#if CUDART_VERSION >= 11030
+  static auto pfn_cuMemGetAddressRange =
+      loadDriverFunction<PFN_cuMemGetAddressRange_v3020>(
+          "cuMemGetAddressRange");
+  if (pfn_cuMemGetAddressRange != nullptr) {
+    return pfn_cuMemGetAddressRange(pbase, psize, dptr);
+  }
+#endif
+  return CUDA_ERROR_NOT_INITIALIZED;
+}
+
+} // namespace comms::utils::cuda
+
+/**
+ * Checks a CUDA driver API command (CUresult) and throws std::runtime_error on
+ * failure.
+ *
+ * This macro is for CUDA driver API calls that return CUresult.
+ * For CUDA runtime API calls (cudaError_t), use FB_CUDACHECKTHROW instead.
+ *
+ * Note: This implementation uses dynamic loading via cudaGetDriverEntryPoint
+ * to avoid requiring libcuda.so to be present at link time. This makes it
+ * suitable for use in environments where only the CUDA runtime is available
+ * (e.g., some CI build environments).
+ *
+ * Usage:
+ *   FB_CUCHECKTHROW(comms::utils::cuda::cuMemGetAddressRangeDynamic(&pbase,
+ * &size, devPtr));
+ */
+#define FB_CUCHECKTHROW(cmd)                                                   \
+  do {                                                                         \
+    CUresult err = cmd;                                                        \
+    if (err != CUDA_SUCCESS) {                                                 \
+      const char* errStr = ::comms::utils::cuda::getCuErrorString(err);        \
+      CLOGF(ERR, "Cuda failure {} '{}'", static_cast<int>(err), errStr);       \
+      throw std::runtime_error(                                                \
+          fmt::format("Cuda failure {} '{}'", static_cast<int>(err), errStr)); \
+    }                                                                          \
+  } while (false)

--- a/comms/utils/MemUtils.cc
+++ b/comms/utils/MemUtils.cc
@@ -2,6 +2,7 @@
 #include "comms/utils/MemUtils.h"
 #include "comms/ctran/utils/CudaWrap.h"
 #include "comms/ctran/utils/DevMemType.h"
+#include "comms/utils/CudaChecks.h"
 #include "comms/utils/checks.h"
 
 namespace comms::utils::cumem {
@@ -32,7 +33,9 @@ bool isBackedByMultipleCuMemAllocations(
   CUdeviceptr curPbase = 0;
   CUdeviceptr ptr_ = reinterpret_cast<CUdeviceptr>(const_cast<void*>(ptr));
 
-  FB_CUCHECKTHROW(cuMemGetAddressRange(&curPbase, &curRange, ptr_));
+  FB_CUCHECKTHROW(
+      ::comms::utils::cuda::cuMemGetAddressRangeDynamic(
+          &curPbase, &curRange, ptr_));
   const size_t remaining_in_first_alloc = (size_t)ctran::utils::subDevicePtr(
       ctran::utils::addDevicePtr(curPbase, curRange), (void*)ptr_);
   if (len <= remaining_in_first_alloc) {

--- a/comms/utils/tests/CudaChecksUT.cc
+++ b/comms/utils/tests/CudaChecksUT.cc
@@ -1,0 +1,31 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <string>
+
+#include <cuda.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "comms/utils/CudaChecks.h"
+
+class CommsUtilsCudaChecksTest : public ::testing::Test {};
+
+TEST_F(CommsUtilsCudaChecksTest, FB_CUCHECKTHROW) {
+  auto dummyFn = []() {
+    CUdeviceptr invalidPtr = 0;
+    size_t size = 0;
+    FB_CUCHECKTHROW(cuMemGetAddressRange(&invalidPtr, &size, (CUdeviceptr)0x1));
+    return true;
+  };
+
+  bool caughtException = false;
+  try {
+    dummyFn();
+  } catch (const std::runtime_error& e) {
+    auto errMsg = std::string(e.what());
+    EXPECT_THAT(errMsg, ::testing::HasSubstr("Cuda failure"));
+    caughtException = true;
+  }
+
+  ASSERT_TRUE(caughtException) << "Expected std::runtime_error";
+}


### PR DESCRIPTION
Summary:
As part of the ongoing migration from `std::runtime_error` to `ctran::utils::Exception` within ctran, this relocates the `FB_CUCHECKTHROW` macro (for CUDA driver API calls) to `comms/utils/checks.h`, enabling external consumers to use it without depending on ctran internals.

The new macro uses CUDA driver API directly rather than ctran's PFN wrappers, making it usable outside of ctran. The corresponding unit test has also been relocated to `comms/utils/tests/ChecksUT.cc`.

Differential Revision: D91232132


