### PR TITLE
Add GpuMemHandler with fabric handle support and cudaIpc fallback

### DIFF
--- a/comms/pipes/GpuMemHandler.cc
+++ b/comms/pipes/GpuMemHandler.cc
@@ -1,0 +1,548 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/GpuMemHandler.h"
+
+#include <glog/logging.h>
+#include <mutex>
+#include <stdexcept>
+
+namespace comms::pipes {
+
+namespace {
+
+void checkCudaError(cudaError_t err, const char* msg) {
+  if (err != cudaSuccess) {
+    throw std::runtime_error(std::string(msg) + ": " + cudaGetErrorString(err));
+  }
+}
+
+void checkCuError(CUresult err, const char* msg) {
+  if (err != CUDA_SUCCESS) {
+    const char* errStr = nullptr;
+    cuGetErrorString(err, &errStr);
+    throw std::runtime_error(
+        std::string(msg) + ": " + (errStr ? errStr : "unknown error"));
+  }
+}
+
+// Minimum allocation size for trial allocation (matches ctran)
+constexpr size_t kTrialAllocSize = 2097152UL; // 2MB
+
+// Helper function that performs the actual fabric handle support check.
+// This is called once and the result is cached by isFabricHandleSupported().
+bool checkFabricHandleSupportedImpl() {
+#if CUDART_VERSION < 12030
+  return false;
+#else
+  int cudaDev = 0;
+  CUdevice cuDev;
+
+  // 1. Check basic CUDA setup
+  cudaError_t cudaErr = cudaGetDevice(&cudaDev);
+  if (cudaErr != cudaSuccess) {
+    return false;
+  }
+
+  CUresult cuErr = cuDeviceGet(&cuDev, cudaDev);
+  if (cuErr != CUDA_SUCCESS) {
+    return false;
+  }
+
+  // 2. Check device attribute for fabric handle support
+  int fabricSupported = 0;
+  cuErr = cuDeviceGetAttribute(
+      &fabricSupported,
+      CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED,
+      cuDev);
+
+  if (cuErr != CUDA_SUCCESS || !fabricSupported) {
+    return false;
+  }
+
+  // 3. Trial allocation to verify fabric handles actually work
+  //    (attribute may be true but allocation/export could still fail)
+  CUmemAllocationProp prop = {};
+  prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+  prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  prop.location.id = cuDev;
+  prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_FABRIC;
+
+  size_t granularity = 0;
+  cuErr = cuMemGetAllocationGranularity(
+      &granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM);
+  if (cuErr != CUDA_SUCCESS) {
+    return false;
+  }
+
+  size_t allocSize =
+      ((kTrialAllocSize + granularity - 1) / granularity) * granularity;
+
+  CUmemGenericAllocationHandle handle;
+  cuErr = cuMemCreate(&handle, allocSize, &prop, 0);
+  if (cuErr != CUDA_SUCCESS) {
+    return false;
+  }
+
+  CUdeviceptr ptr;
+  cuErr = cuMemAddressReserve(&ptr, allocSize, granularity, 0, 0);
+  if (cuErr != CUDA_SUCCESS) {
+    cuMemRelease(handle);
+    return false;
+  }
+
+  cuErr = cuMemMap(ptr, allocSize, 0, handle, 0);
+  if (cuErr != CUDA_SUCCESS) {
+    cuMemAddressFree(ptr, allocSize);
+    cuMemRelease(handle);
+    return false;
+  }
+
+  CUmemAccessDesc accessDesc = {};
+  accessDesc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  accessDesc.location.id = cuDev;
+  accessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+  cuErr = cuMemSetAccess(ptr, allocSize, &accessDesc, 1);
+  if (cuErr != CUDA_SUCCESS) {
+    cuMemUnmap(ptr, allocSize);
+    cuMemAddressFree(ptr, allocSize);
+    cuMemRelease(handle);
+    return false;
+  }
+
+  // 4. Trial export to fabric handle
+  CUmemFabricHandle fabricHandle;
+  cuErr = cuMemExportToShareableHandle(
+      &fabricHandle, handle, CU_MEM_HANDLE_TYPE_FABRIC, 0);
+  if (cuErr != CUDA_SUCCESS) {
+    cuMemUnmap(ptr, allocSize);
+    cuMemAddressFree(ptr, allocSize);
+    cuMemRelease(handle);
+    return false;
+  }
+
+  // 5. Trial import from fabric handle
+  CUmemGenericAllocationHandle importedHandle;
+  cuErr = cuMemImportFromShareableHandle(
+      &importedHandle, &fabricHandle, CU_MEM_HANDLE_TYPE_FABRIC);
+  if (cuErr != CUDA_SUCCESS) {
+    cuMemUnmap(ptr, allocSize);
+    cuMemAddressFree(ptr, allocSize);
+    cuMemRelease(handle);
+    return false;
+  }
+
+  // Import increases ref count, release it
+  cuMemRelease(importedHandle);
+
+  // Cleanup trial allocation
+  cuMemUnmap(ptr, allocSize);
+  cuMemAddressFree(ptr, allocSize);
+  cuMemRelease(handle);
+
+  return true;
+#endif
+}
+
+} // namespace
+
+bool GpuMemHandler::isFabricHandleSupported() {
+  static std::once_flag onceFlag;
+  static bool cachedResult = false;
+
+  std::call_once(
+      onceFlag, []() { cachedResult = checkFabricHandleSupportedImpl(); });
+
+  return cachedResult;
+}
+
+MemSharingMode GpuMemHandler::detectBestMode() {
+  if (isFabricHandleSupported()) {
+    return MemSharingMode::kFabric;
+  }
+  return MemSharingMode::kCudaIpc;
+}
+
+GpuMemHandler::GpuMemHandler(
+    std::shared_ptr<ctran::bootstrap::IBootstrap> bootstrap,
+    int32_t selfRank,
+    int32_t nRanks,
+    size_t size)
+    : GpuMemHandler(
+          std::move(bootstrap),
+          selfRank,
+          nRanks,
+          size,
+          detectBestMode()) {}
+
+GpuMemHandler::GpuMemHandler(
+    std::shared_ptr<ctran::bootstrap::IBootstrap> bootstrap,
+    int32_t selfRank,
+    int32_t nRanks,
+    size_t size,
+    MemSharingMode mode)
+    : bootstrap_(std::move(bootstrap)),
+      selfRank_(selfRank),
+      nRanks_(nRanks),
+      mode_(mode),
+      fabricPeerPtrs_(nRanks, 0),
+      fabricPeerAllocHandles_(nRanks, 0),
+      fabricPeerAllocatedSizes_(nRanks, 0),
+      cudaIpcPeerPtrs_(nRanks, nullptr) {
+  if (mode_ == MemSharingMode::kFabric && !isFabricHandleSupported()) {
+    throw std::runtime_error(
+        "Fabric handle mode requested but not supported on this system. "
+        "Requires Hopper (H100) or newer GPU with CUDA 12.3+.");
+  }
+
+  init(size);
+}
+
+GpuMemHandler::~GpuMemHandler() {
+  if (mode_ == MemSharingMode::kFabric) {
+    cleanupFabric();
+  } else {
+    cleanupCudaIpc();
+  }
+}
+
+void GpuMemHandler::init(size_t size) {
+  if (mode_ == MemSharingMode::kFabric) {
+    allocateFabricMemory(size);
+  } else {
+    allocateCudaIpcMemory(size);
+  }
+}
+
+void* GpuMemHandler::getLocalDeviceMemPtr() const {
+  if (mode_ == MemSharingMode::kFabric) {
+    // NOLINTNEXTLINE(performance-no-int-to-ptr): CUdeviceptr is an integer type
+    return reinterpret_cast<void*>(fabricLocalPtr_);
+  } else {
+    return cudaIpcLocalPtr_;
+  }
+}
+
+void* GpuMemHandler::getPeerDeviceMemPtr(int32_t rank) const {
+  if (rank < 0 || rank >= nRanks_) {
+    throw std::runtime_error(
+        "GpuMemHandler::getPeerDeviceMemPtr: rank out of bounds");
+  }
+
+  if (!exchanged_ && rank != selfRank_) {
+    throw std::runtime_error(
+        "GpuMemHandler: Must call exchangeMemPtrs() before accessing peer memory");
+  }
+
+  if (mode_ == MemSharingMode::kFabric) {
+    // NOLINTNEXTLINE(performance-no-int-to-ptr): CUdeviceptr is an integer type
+    return reinterpret_cast<void*>(fabricPeerPtrs_[rank]);
+  } else {
+    return cudaIpcPeerPtrs_[rank];
+  }
+}
+
+void GpuMemHandler::exchangeMemPtrs() {
+  if (exchanged_) {
+    return;
+  }
+
+  // Single rank case: nothing to exchange, just mark as exchanged
+  if (nRanks_ == 1) {
+    exchanged_ = true;
+    return;
+  }
+
+  if (mode_ == MemSharingMode::kFabric) {
+    exchangeFabricHandles();
+  } else {
+    exchangeCudaIpcHandles();
+  }
+
+  exchanged_ = true;
+}
+
+// ============================================================================
+// Fabric Mode Implementation
+// ============================================================================
+
+void GpuMemHandler::allocateFabricMemory(size_t size) {
+#if CUDART_VERSION < 12030
+  throw std::runtime_error("Fabric handles require CUDA 12.3+");
+#else
+  int cudaDev = 0;
+  CUdevice cuDev;
+
+  checkCudaError(cudaGetDevice(&cudaDev), "cudaGetDevice failed");
+  checkCuError(cuDeviceGet(&cuDev, cudaDev), "cuDeviceGet failed");
+
+  // Set up allocation properties with fabric handle support
+  CUmemAllocationProp prop = {};
+  prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+  prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  prop.location.id = cuDev;
+  prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_FABRIC;
+
+  // Check for GPUDirect RDMA support
+  int rdmaSupported = 0;
+  cuDeviceGetAttribute(
+      &rdmaSupported, CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_SUPPORTED, cuDev);
+  if (rdmaSupported) {
+    prop.allocFlags.gpuDirectRDMACapable = 1;
+  }
+
+  // Get allocation granularity
+  size_t granularity = 0;
+  checkCuError(
+      cuMemGetAllocationGranularity(
+          &granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM),
+      "cuMemGetAllocationGranularity failed");
+
+  // Round up size to granularity
+  allocatedSize_ = ((size + granularity - 1) / granularity) * granularity;
+
+  // Create the physical memory allocation
+  checkCuError(
+      cuMemCreate(&fabricLocalAllocHandle_, allocatedSize_, &prop, 0),
+      "cuMemCreate failed");
+
+  // Reserve virtual address space
+  checkCuError(
+      cuMemAddressReserve(&fabricLocalPtr_, allocatedSize_, granularity, 0, 0),
+      "cuMemAddressReserve failed");
+
+  // Map the physical memory to virtual address
+  checkCuError(
+      cuMemMap(fabricLocalPtr_, allocatedSize_, 0, fabricLocalAllocHandle_, 0),
+      "cuMemMap failed");
+
+  // Set access permissions
+  CUmemAccessDesc accessDesc = {};
+  accessDesc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  accessDesc.location.id = cuDev;
+  accessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+  checkCuError(
+      cuMemSetAccess(fabricLocalPtr_, allocatedSize_, &accessDesc, 1),
+      "cuMemSetAccess failed");
+
+  // Export to fabric handle for sharing with peers
+  checkCuError(
+      cuMemExportToShareableHandle(
+          &fabricLocalHandle_,
+          fabricLocalAllocHandle_,
+          CU_MEM_HANDLE_TYPE_FABRIC,
+          0),
+      "cuMemExportToShareableHandle failed");
+
+  // Store local pointer in peer array for uniform access
+  fabricPeerPtrs_[selfRank_] = fabricLocalPtr_;
+  fabricPeerAllocHandles_[selfRank_] = fabricLocalAllocHandle_;
+#endif
+}
+
+void GpuMemHandler::exchangeFabricHandles() {
+#if CUDART_VERSION < 12030
+  throw std::runtime_error("Fabric handles require CUDA 12.3+");
+#else
+  // Prepare data for allGather: fabric handle + allocated size
+  struct ExchangeData {
+    FabricHandle handle;
+    size_t allocatedSize;
+  };
+
+  std::vector<ExchangeData> allData(nRanks_);
+  allData[selfRank_].handle = fabricLocalHandle_;
+  allData[selfRank_].allocatedSize = allocatedSize_;
+
+  // Exchange fabric handles with all ranks
+  auto result =
+      bootstrap_
+          ->allGather(allData.data(), sizeof(ExchangeData), selfRank_, nRanks_)
+          .get();
+  if (result != 0) {
+    throw std::runtime_error(
+        "GpuMemHandler::exchangeFabricHandles allGather failed");
+  }
+
+  // Import peer memory from received fabric handles
+  for (int32_t rank = 0; rank < nRanks_; ++rank) {
+    if (rank == selfRank_) {
+      continue;
+    }
+    fabricPeerAllocatedSizes_[rank] = allData[rank].allocatedSize;
+    importFabricPeerMemory(
+        rank, allData[rank].handle, allData[rank].allocatedSize);
+  }
+#endif
+}
+
+void GpuMemHandler::importFabricPeerMemory(
+    int32_t rank,
+    const FabricHandle& handle,
+    size_t peerAllocatedSize) {
+#if CUDART_VERSION < 12030
+  throw std::runtime_error("Fabric handles require CUDA 12.3+");
+#else
+  int cudaDev = 0;
+  CUdevice cuDev;
+
+  checkCudaError(cudaGetDevice(&cudaDev), "cudaGetDevice failed");
+  checkCuError(cuDeviceGet(&cuDev, cudaDev), "cuDeviceGet failed");
+
+  // Import the fabric handle to get allocation handle
+  checkCuError(
+      cuMemImportFromShareableHandle(
+          &fabricPeerAllocHandles_[rank],
+          const_cast<void*>(static_cast<const void*>(&handle)),
+          CU_MEM_HANDLE_TYPE_FABRIC),
+      "cuMemImportFromShareableHandle failed");
+
+  // Get allocation properties for granularity
+  CUmemAllocationProp prop = {};
+  checkCuError(
+      cuMemGetAllocationPropertiesFromHandle(
+          &prop, fabricPeerAllocHandles_[rank]),
+      "cuMemGetAllocationPropertiesFromHandle failed");
+
+  size_t granularity = 0;
+  checkCuError(
+      cuMemGetAllocationGranularity(
+          &granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM),
+      "cuMemGetAllocationGranularity failed");
+
+  // Reserve virtual address space for peer memory
+  checkCuError(
+      cuMemAddressReserve(
+          &fabricPeerPtrs_[rank], peerAllocatedSize, granularity, 0, 0),
+      "cuMemAddressReserve for peer failed");
+
+  // Map peer's physical memory to our virtual address
+  checkCuError(
+      cuMemMap(
+          fabricPeerPtrs_[rank],
+          peerAllocatedSize,
+          0,
+          fabricPeerAllocHandles_[rank],
+          0),
+      "cuMemMap for peer failed");
+
+  // Set access permissions for peer memory
+  CUmemAccessDesc accessDesc = {};
+  accessDesc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  accessDesc.location.id = cuDev;
+  accessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+  checkCuError(
+      cuMemSetAccess(fabricPeerPtrs_[rank], peerAllocatedSize, &accessDesc, 1),
+      "cuMemSetAccess for peer failed");
+#endif
+}
+
+void GpuMemHandler::cleanupFabric() {
+#if CUDART_VERSION >= 12030
+  // Check if CUDA context is still valid
+  CUcontext ctx = nullptr;
+  if (cuCtxGetCurrent(&ctx) != CUDA_SUCCESS || ctx == nullptr) {
+    return;
+  }
+
+  // Release peer mappings
+  for (int32_t rank = 0; rank < nRanks_; ++rank) {
+    if (rank == selfRank_) {
+      continue;
+    }
+    if (fabricPeerPtrs_[rank] != 0) {
+      cuMemUnmap(fabricPeerPtrs_[rank], fabricPeerAllocatedSizes_[rank]);
+      cuMemAddressFree(fabricPeerPtrs_[rank], fabricPeerAllocatedSizes_[rank]);
+      fabricPeerPtrs_[rank] = 0;
+    }
+    if (fabricPeerAllocHandles_[rank] != 0) {
+      cuMemRelease(fabricPeerAllocHandles_[rank]);
+      fabricPeerAllocHandles_[rank] = 0;
+    }
+  }
+
+  // Release local allocation
+  if (fabricLocalPtr_ != 0) {
+    cuMemUnmap(fabricLocalPtr_, allocatedSize_);
+    cuMemAddressFree(fabricLocalPtr_, allocatedSize_);
+    fabricLocalPtr_ = 0;
+  }
+  if (fabricLocalAllocHandle_ != 0) {
+    cuMemRelease(fabricLocalAllocHandle_);
+    fabricLocalAllocHandle_ = 0;
+  }
+#endif
+}
+
+// ============================================================================
+// CudaIpc Mode Implementation
+// ============================================================================
+
+void GpuMemHandler::allocateCudaIpcMemory(size_t size) {
+  checkCudaError(cudaMalloc(&cudaIpcLocalPtr_, size), "cudaMalloc failed");
+  allocatedSize_ = size;
+
+  // Get IPC handle for local memory
+  checkCudaError(
+      cudaIpcGetMemHandle(&cudaIpcLocalHandle_, cudaIpcLocalPtr_),
+      "cudaIpcGetMemHandle failed");
+
+  // Store local pointer in peer array
+  cudaIpcPeerPtrs_[selfRank_] = cudaIpcLocalPtr_;
+}
+
+void GpuMemHandler::exchangeCudaIpcHandles() {
+  // Exchange IPC handles with all ranks
+  std::vector<cudaIpcMemHandle_t> allHandles(nRanks_);
+  allHandles[selfRank_] = cudaIpcLocalHandle_;
+
+  auto result =
+      bootstrap_
+          ->allGather(
+              allHandles.data(), sizeof(cudaIpcMemHandle_t), selfRank_, nRanks_)
+          .get();
+  if (result != 0) {
+    throw std::runtime_error(
+        "GpuMemHandler::exchangeCudaIpcHandles allGather failed");
+  }
+
+  // Open peer memory handles
+  for (int32_t rank = 0; rank < nRanks_; ++rank) {
+    if (rank == selfRank_) {
+      continue;
+    }
+    checkCudaError(
+        cudaIpcOpenMemHandle(
+            &cudaIpcPeerPtrs_[rank],
+            allHandles[rank],
+            cudaIpcMemLazyEnablePeerAccess),
+        "cudaIpcOpenMemHandle failed");
+  }
+}
+
+void GpuMemHandler::cleanupCudaIpc() {
+  // Close peer handles
+  for (int32_t rank = 0; rank < nRanks_; ++rank) {
+    if (rank == selfRank_) {
+      continue;
+    }
+    if (cudaIpcPeerPtrs_[rank] != nullptr) {
+      cudaError_t err = cudaIpcCloseMemHandle(cudaIpcPeerPtrs_[rank]);
+      if (err != cudaSuccess) {
+        LOG(ERROR) << "cudaIpcCloseMemHandle failed for rank " << rank << ": "
+                   << cudaGetErrorString(err);
+      }
+      cudaIpcPeerPtrs_[rank] = nullptr;
+    }
+  }
+
+  // Free local allocation
+  if (cudaIpcLocalPtr_ != nullptr) {
+    cudaError_t err = cudaFree(cudaIpcLocalPtr_);
+    if (err != cudaSuccess) {
+      LOG(ERROR) << "cudaFree failed: " << cudaGetErrorString(err);
+    }
+    cudaIpcLocalPtr_ = nullptr;
+  }
+}
+
+} // namespace comms::pipes

--- a/comms/pipes/GpuMemHandler.h
+++ b/comms/pipes/GpuMemHandler.h
@@ -1,0 +1,220 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <vector>
+
+#include "comms/ctran/interfaces/IBootstrap.h"
+
+namespace comms::pipes {
+
+#if CUDART_VERSION >= 12030
+using FabricHandle = CUmemFabricHandle;
+#else
+struct FabricHandle {
+  unsigned char data[64]; // CU_IPC_HANDLE_SIZE
+};
+#endif
+
+/**
+ * Memory sharing mode - determines which IPC mechanism to use.
+ */
+enum class MemSharingMode {
+  // Use CUDA fabric handles (CU_MEM_HANDLE_TYPE_FABRIC)
+  // Requires: Hopper+ GPU, CUDA 12.3+
+  // Supports: Multi-node NVLink (GB200 NVL72)
+  kFabric,
+
+  // Use cudaIpcMemHandle_t
+  // Works on: All CUDA GPUs
+  // Limitation: Intra-node only
+  kCudaIpc,
+};
+
+/**
+ * Union to hold either fabric handle or cudaIpc handle for exchange.
+ */
+union IpcHandle {
+  FabricHandle fabric;
+  cudaIpcMemHandle_t cudaIpc;
+};
+
+/**
+ * GpuMemHandler - Manages GPU memory sharing across processes.
+ *
+ * This class provides GPU memory sharing with automatic fallback:
+ * 1. CUDA Fabric handles (preferred) - for H100+, CUDA 12.3+, enables GB200
+ * MNNVL
+ * 2. cudaIpcMemHandle_t (fallback) - for older GPUs/CUDA, intra-node only
+ *
+ * The mode is automatically detected at construction time based on hardware
+ * and CUDA version capabilities.
+ *
+ * DESIGN NOTE: This class allocates memory internally rather than accepting
+ * an external buffer. This is intentional because fabric handles require
+ * memory to be allocated with specific flags (CU_MEM_HANDLE_TYPE_FABRIC) at
+ * allocation time - you cannot create a fabric handle from an arbitrary
+ * cudaMalloc'd buffer. By owning the allocation, GpuMemHandler ensures the
+ * memory is properly allocated for the chosen sharing mode.
+ *
+ * This class is NOT thread-safe. Only one thread per process should use it.
+ *
+ * USAGE:
+ *   GpuMemHandler handler(bootstrap, selfRank, nRanks, size);
+ *   handler.exchangeMemPtrs();
+ *   void* localPtr = handler.getLocalDeviceMemPtr();  // get allocated buffer
+ *   void* peerPtr = handler.getPeerDeviceMemPtr(peerRank);
+ */
+class GpuMemHandler {
+ public:
+  /**
+   * Constructor - Allocates shareable GPU memory.
+   *
+   * Automatically selects the best available sharing mode:
+   * - Fabric handles on Hopper+ with CUDA 12.3+
+   * - cudaIpcMemHandle on older systems
+   *
+   * @param bootstrap Bootstrap interface for collective operations
+   * @param selfRank This rank's ID (0 to nRanks-1)
+   * @param nRanks Total number of ranks
+   * @param size Size of memory to allocate
+   *
+   * @throws std::runtime_error if memory allocation fails
+   */
+  GpuMemHandler(
+      std::shared_ptr<ctran::bootstrap::IBootstrap> bootstrap,
+      int32_t selfRank,
+      int32_t nRanks,
+      size_t size);
+
+  /**
+   * Constructor with explicit mode selection.
+   *
+   * @param bootstrap Bootstrap interface for collective operations
+   * @param selfRank This rank's ID (0 to nRanks-1)
+   * @param nRanks Total number of ranks
+   * @param size Size of memory to allocate
+   * @param mode Explicitly select fabric or cudaIpc mode
+   *
+   * @throws std::runtime_error if requested mode is not supported or allocation
+   * fails
+   */
+  GpuMemHandler(
+      std::shared_ptr<ctran::bootstrap::IBootstrap> bootstrap,
+      int32_t selfRank,
+      int32_t nRanks,
+      size_t size,
+      MemSharingMode mode);
+
+  ~GpuMemHandler();
+
+  // Non-copyable, non-movable
+  GpuMemHandler(const GpuMemHandler&) = delete;
+  GpuMemHandler& operator=(const GpuMemHandler&) = delete;
+  GpuMemHandler(GpuMemHandler&&) = delete;
+  GpuMemHandler& operator=(GpuMemHandler&&) = delete;
+
+  /**
+   * Exchange memory handles across all ranks.
+   *
+   * COLLECTIVE OPERATION: All ranks must call this.
+   *
+   * After this call, getPeerDeviceMemPtr() can be used to access
+   * any peer's memory.
+   *
+   * @throws std::runtime_error if exchange fails
+   */
+  void exchangeMemPtrs();
+
+  /**
+   * Get pointer to local memory (this rank's allocation).
+   *
+   * Can be called before or after exchangeMemPtrs().
+   */
+  void* getLocalDeviceMemPtr() const;
+
+  /**
+   * Get pointer to peer's memory.
+   *
+   * PRECONDITION: exchangeMemPtrs() must have been called.
+   *
+   * @param rank Peer rank to access (can be selfRank for local ptr)
+   * @return Pointer usable in local CUDA kernels to access peer's memory
+   *
+   * @throws std::runtime_error if exchange hasn't happened yet
+   */
+  void* getPeerDeviceMemPtr(int32_t rank) const;
+
+  /**
+   * Get the actual allocated size (may be larger than requested due to
+   * alignment).
+   */
+  size_t getAllocatedSize() const {
+    return allocatedSize_;
+  }
+
+  /**
+   * Get the memory sharing mode being used.
+   */
+  MemSharingMode getMode() const {
+    return mode_;
+  }
+
+  /**
+   * Check if the current GPU supports fabric handles.
+   *
+   * @return true if Hopper+ GPU with CUDA 12.3+ and fabric support enabled
+   */
+  static bool isFabricHandleSupported();
+
+  /**
+   * Get the best available sharing mode for the current system.
+   */
+  static MemSharingMode detectBestMode();
+
+ private:
+  void init(size_t size);
+
+  // Fabric mode methods
+  void allocateFabricMemory(size_t size);
+  void exchangeFabricHandles();
+  void importFabricPeerMemory(
+      int32_t rank,
+      const FabricHandle& handle,
+      size_t peerAllocatedSize);
+  void cleanupFabric();
+
+  // CudaIpc mode methods
+  void allocateCudaIpcMemory(size_t size);
+  void exchangeCudaIpcHandles();
+  void cleanupCudaIpc();
+
+  std::shared_ptr<ctran::bootstrap::IBootstrap> bootstrap_;
+  const int32_t selfRank_{-1};
+  const int32_t nRanks_{-1};
+  const MemSharingMode mode_{MemSharingMode::kCudaIpc};
+
+  // Common state
+  size_t allocatedSize_{0};
+  bool exchanged_{false};
+
+  // ---- Fabric mode state ----
+  CUdeviceptr fabricLocalPtr_{0};
+  CUmemGenericAllocationHandle fabricLocalAllocHandle_{0};
+  FabricHandle fabricLocalHandle_{};
+  std::vector<CUdeviceptr> fabricPeerPtrs_;
+  std::vector<CUmemGenericAllocationHandle> fabricPeerAllocHandles_;
+  std::vector<size_t> fabricPeerAllocatedSizes_;
+
+  // ---- CudaIpc mode state ----
+  void* cudaIpcLocalPtr_{nullptr};
+  cudaIpcMemHandle_t cudaIpcLocalHandle_{};
+  std::vector<void*> cudaIpcPeerPtrs_;
+};
+
+// Backwards compatibility alias
+using FabricMemHandler = GpuMemHandler;
+
+} // namespace comms::pipes

--- a/comms/pipes/tests/GpuMemHandlerTest.cc
+++ b/comms/pipes/tests/GpuMemHandlerTest.cc
@@ -1,0 +1,259 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+
+#include <folly/init/Init.h>
+#include <folly/logging/xlog.h>
+
+#include "comms/pipes/GpuMemHandler.h"
+#include "comms/pipes/tests/Utils.cuh"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/testinfra/mpi/MpiBootstrap.h"
+#include "comms/testinfra/mpi/MpiTestUtils.h"
+#include "comms/utils/CudaRAII.h"
+
+using comms::pipes::GpuMemHandler;
+using comms::pipes::MemSharingMode;
+using meta::comms::DeviceBuffer;
+using meta::comms::MpiBaseTestFixture;
+using meta::comms::MpiBootstrap;
+using meta::comms::MPIEnvironmentBase;
+
+namespace comms::pipes::tests {
+
+class GpuMemHandlerTestFixture : public MpiBaseTestFixture {
+ protected:
+  void SetUp() override {
+    MpiBaseTestFixture::SetUp();
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+  }
+
+  void TearDown() override {
+    MpiBaseTestFixture::TearDown();
+  }
+};
+
+/**
+ * Test basic IPC memory access via GpuMemHandler.
+ *
+ * Each rank allocates memory, exchanges handles, then:
+ * - Writes its rank value to local buffer
+ * - Reads from peer's buffer and verifies peer's rank value
+ */
+TEST_F(GpuMemHandlerTestFixture, RemoteWriteLocalRead) {
+  // Only test with 2 ranks
+  if (numRanks != 2) {
+    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    return;
+  }
+
+  int peerRank = (globalRank == 0) ? 1 : 0;
+
+  const size_t numElements = 256;
+  const size_t bufferSize = sizeof(int) * numElements;
+
+  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  GpuMemHandler handler(bootstrap, globalRank, numRanks, bufferSize);
+
+  XLOGF(
+      INFO,
+      "Rank {} created handler in {} mode",
+      globalRank,
+      handler.getMode() == MemSharingMode::kFabric ? "fabric" : "cudaIpc");
+
+  handler.exchangeMemPtrs();
+  XLOGF(INFO, "Rank {} exchanged memory handles", globalRank);
+
+  auto localAddr = static_cast<int*>(handler.getLocalDeviceMemPtr());
+  auto remoteAddr = static_cast<int*>(handler.getPeerDeviceMemPtr(peerRank));
+
+  XLOGF(
+      INFO,
+      "Rank {}: localAddr: {}, remoteAddr: {}",
+      globalRank,
+      static_cast<void*>(localAddr),
+      static_cast<void*>(remoteAddr));
+
+  // Each rank writes its rank value to local buffer
+  // rank0 writes all 0s, rank1 writes all 1s
+  int writeValue = globalRank;
+  test::fillBuffer(localAddr, writeValue, numElements);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  XLOGF(INFO, "Rank {} filled local buffer with {}", globalRank, writeValue);
+
+  // Barrier to ensure both ranks have written their data
+  MPI_Barrier(MPI_COMM_WORLD);
+  XLOGF(INFO, "Rank {} passed barrier", globalRank);
+
+  // Each rank reads from peer's buffer and verifies
+  // rank0 should read all 1s from rank1
+  // rank1 should read all 0s from rank0
+  int expectedValue = peerRank;
+
+  // Allocate error counter on device using DeviceBuffer
+  DeviceBuffer errorCountBuffer(sizeof(int));
+  auto d_errorCount = static_cast<int*>(errorCountBuffer.get());
+  CUDACHECK_TEST(cudaMemset(d_errorCount, 0, sizeof(int)));
+
+  test::verifyBuffer(remoteAddr, expectedValue, numElements, d_errorCount);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  // Copy error count back to host
+  int h_errorCount = 0;
+  CUDACHECK_TEST(cudaMemcpy(
+      &h_errorCount, d_errorCount, sizeof(int), cudaMemcpyDeviceToHost));
+
+  XLOGF(
+      INFO,
+      "Rank {} verified peer buffer, errors: {}",
+      globalRank,
+      h_errorCount);
+
+  // Assert no errors
+  ASSERT_EQ(h_errorCount, 0)
+      << "Rank " << globalRank << " found " << h_errorCount
+      << " errors when reading from peer rank " << peerRank;
+}
+
+/**
+ * Test that self rank returns local pointer.
+ */
+TEST_F(GpuMemHandlerTestFixture, SelfRankReturnsLocalPtr) {
+  // Only test with 2 ranks
+  if (numRanks != 2) {
+    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    return;
+  }
+
+  const size_t bufferSize = 1024;
+
+  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  GpuMemHandler handler(bootstrap, globalRank, numRanks, bufferSize);
+  handler.exchangeMemPtrs();
+
+  // getPeerDeviceMemPtr(selfRank) should return the local pointer
+  void* localPtr = handler.getLocalDeviceMemPtr();
+  void* selfPtr = handler.getPeerDeviceMemPtr(globalRank);
+
+  EXPECT_EQ(localPtr, selfPtr)
+      << "getPeerDeviceMemPtr(selfRank) should return local pointer";
+}
+
+/**
+ * Test explicit cudaIpc mode.
+ */
+TEST_F(GpuMemHandlerTestFixture, ExplicitCudaIpcMode) {
+  // Only test with 2 ranks
+  if (numRanks != 2) {
+    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    return;
+  }
+
+  int peerRank = (globalRank == 0) ? 1 : 0;
+
+  const size_t numElements = 128;
+  const size_t bufferSize = sizeof(int) * numElements;
+
+  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  // Explicitly request cudaIpc mode
+  GpuMemHandler handler(
+      bootstrap, globalRank, numRanks, bufferSize, MemSharingMode::kCudaIpc);
+
+  EXPECT_EQ(handler.getMode(), MemSharingMode::kCudaIpc);
+  XLOGF(INFO, "Rank {} created handler with explicit cudaIpc mode", globalRank);
+
+  handler.exchangeMemPtrs();
+
+  auto localAddr = static_cast<int*>(handler.getLocalDeviceMemPtr());
+  auto remoteAddr = static_cast<int*>(handler.getPeerDeviceMemPtr(peerRank));
+
+  // Write and verify
+  int writeValue = globalRank + 100;
+  test::fillBuffer(localAddr, writeValue, numElements);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  int expectedValue = peerRank + 100;
+
+  DeviceBuffer errorCountBuffer(sizeof(int));
+  auto d_errorCount = static_cast<int*>(errorCountBuffer.get());
+  CUDACHECK_TEST(cudaMemset(d_errorCount, 0, sizeof(int)));
+
+  test::verifyBuffer(remoteAddr, expectedValue, numElements, d_errorCount);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  int h_errorCount = 0;
+  CUDACHECK_TEST(cudaMemcpy(
+      &h_errorCount, d_errorCount, sizeof(int), cudaMemcpyDeviceToHost));
+
+  ASSERT_EQ(h_errorCount, 0) << "Rank " << globalRank << " found "
+                             << h_errorCount << " errors in cudaIpc mode test";
+}
+
+/**
+ * Test single rank exchange (nRanks=1).
+ *
+ * Each MPI rank independently tests the single-rank scenario where
+ * we only exchange with ourselves. This verifies that GpuMemHandler
+ * works correctly when there are no peers.
+ */
+TEST_F(GpuMemHandlerTestFixture, SingleRankExchange) {
+  const size_t numElements = 256;
+  const size_t bufferSize = sizeof(int) * numElements;
+
+  // Create a single-rank handler (nRanks=1, selfRank=0)
+  // Each MPI rank tests this independently
+  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  GpuMemHandler handler(
+      bootstrap, 0 /* selfRank */, 1 /* nRanks */, bufferSize);
+
+  XLOGF(
+      INFO,
+      "MPI Rank {} testing single-rank exchange in {} mode",
+      globalRank,
+      handler.getMode() == MemSharingMode::kFabric ? "fabric" : "cudaIpc");
+
+  handler.exchangeMemPtrs();
+  XLOGF(INFO, "MPI Rank {} completed single-rank exchange", globalRank);
+
+  // Get local pointer
+  auto localAddr = static_cast<int*>(handler.getLocalDeviceMemPtr());
+  ASSERT_NE(localAddr, nullptr) << "Local pointer should not be null";
+
+  // getPeerDeviceMemPtr(0) should return the same as local pointer
+  auto selfPtr = static_cast<int*>(handler.getPeerDeviceMemPtr(0));
+  EXPECT_EQ(localAddr, selfPtr)
+      << "getPeerDeviceMemPtr(0) should return local pointer in single-rank "
+         "mode";
+
+  // Write to local buffer and verify we can read it back
+  int writeValue = 42;
+  test::fillBuffer(localAddr, writeValue, numElements);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  // Verify the data through the "peer" pointer (which is the same as local)
+  DeviceBuffer errorCountBuffer(sizeof(int));
+  auto d_errorCount = static_cast<int*>(errorCountBuffer.get());
+  CUDACHECK_TEST(cudaMemset(d_errorCount, 0, sizeof(int)));
+
+  test::verifyBuffer(selfPtr, writeValue, numElements, d_errorCount);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  int h_errorCount = 0;
+  CUDACHECK_TEST(cudaMemcpy(
+      &h_errorCount, d_errorCount, sizeof(int), cudaMemcpyDeviceToHost));
+
+  ASSERT_EQ(h_errorCount, 0) << "Single-rank exchange verification failed";
+
+  XLOGF(INFO, "MPI Rank {} single-rank exchange test passed", globalRank);
+}
+
+} // namespace comms::pipes::tests
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new MPIEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/pipes/tests/P2pNvlSendRecvMultipleTest.cc
+++ b/comms/pipes/tests/P2pNvlSendRecvMultipleTest.cc
@@ -13,6 +13,7 @@
 #include "comms/pipes/tests/P2pNvlSendRecvMultipleTest.cuh"
 
 #include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/testinfra/mpi/MpiBootstrap.h"
 #include "comms/testinfra/mpi/MpiTestUtils.h"
 #include "comms/utils/CudaRAII.h"
 

--- a/comms/pipes/tests/P2pNvlSendRecvOneTest.cc
+++ b/comms/pipes/tests/P2pNvlSendRecvOneTest.cc
@@ -14,6 +14,7 @@
 #include "comms/pipes/tests/P2pNvlSendRecvOneTest.cuh"
 
 #include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/testinfra/mpi/MpiBootstrap.h"
 #include "comms/testinfra/mpi/MpiTestUtils.h"
 #include "comms/utils/CudaRAII.h"
 


### PR DESCRIPTION
Summary:
Add GpuMemHandler class that provides GPU memory sharing with automatic fallback:
- Fabric handles (preferred): For H100+, CUDA 12.3+, enables GB200 multi-node NVLink
- cudaIpcMemHandle (fallback): For older GPUs/CUDA, intra-node only

The mode is automatically detected at construction time based on hardware and
CUDA driver capabilities. This enables MultiPeerNvlTransport to work on both
new GB200 systems (with fabric handles for MNNVL) and existing systems (with
cudaIpc fallback).

Key changes:
- Add FabricMemHandler.h/.cc with GpuMemHandler class
- Update MultiPeerNvlTransport to use GpuMemHandler instead of IpcMemHandler
- Add isFabricSupported() and getMemSharingMode() APIs
- Remove dependency on cuda_raii (GpuMemHandler manages its own memory)

Differential Revision: D91100082


