### PR TITLE
move iboostrap to common

### DIFF
--- a/comms/common/IpcGpuBarrier.cu
+++ b/comms/common/IpcGpuBarrier.cu
@@ -37,7 +37,7 @@ __host__ IpcGpuBarrier::IpcGpuBarrier(
         int nRanks,
         int nBlocks,
         int selfRank,
-        std::shared_ptr<ctran::bootstrap::IBootstrap> commBootstrap) {
+        std::shared_ptr<IBootstrap> commBootstrap) {
   assert(nRanks == NRANKS);
   auto [selfMboxBuf, selfMbox] = DeviceMailbox::mallocAndInit(nRanks, nBlocks);
 

--- a/comms/common/IpcGpuBarrier.cuh
+++ b/comms/common/IpcGpuBarrier.cuh
@@ -5,7 +5,7 @@
 #include <cuda.h>
 #include <memory>
 #include "comms/common/IpcMemHandler.h"
-#include "comms/ctran/interfaces/IBootstrap.h" // @manual
+#include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/utils/CudaRAII.h"
 
 namespace meta::comms {
@@ -113,7 +113,7 @@ class IpcGpuBarrier {
           int nRanks,
           int nBlocks,
           int selfRank,
-          std::shared_ptr<ctran::bootstrap::IBootstrap> bootstrap);
+          std::shared_ptr<IBootstrap> bootstrap);
 
   // If the kernel has peer rank mem access before the barrier, set
   // hasPreviousMemAccess=true; If the kernel has peer rank mem access after the

--- a/comms/common/IpcMemHandler.cc
+++ b/comms/common/IpcMemHandler.cc
@@ -5,7 +5,7 @@
 namespace meta::comms {
 
 IpcMemHandler::IpcMemHandler(
-    std::shared_ptr<ctran::bootstrap::IBootstrap> commBootstrap,
+    std::shared_ptr<IBootstrap> commBootstrap,
     int32_t selfRank,
     int32_t nRanks)
     : commBootstrap_(std::move(commBootstrap)),

--- a/comms/common/IpcMemHandler.h
+++ b/comms/common/IpcMemHandler.h
@@ -5,7 +5,7 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 #include <glog/logging.h>
-#include "comms/ctran/interfaces/IBootstrap.h" // @manual
+#include "comms/common/bootstrap/IBootstrap.h"
 
 namespace meta::comms {
 
@@ -23,7 +23,7 @@ namespace meta::comms {
 class IpcMemHandler {
  public:
   IpcMemHandler(
-      std::shared_ptr<ctran::bootstrap::IBootstrap> commBootstrap,
+      std::shared_ptr<IBootstrap> commBootstrap,
       int32_t selfRank,
       int32_t nRanks);
   IpcMemHandler(const IpcMemHandler&) = delete;
@@ -41,7 +41,7 @@ class IpcMemHandler {
   void* getPeerDeviceMemPtr(int32_t rank);
 
  private:
-  std::shared_ptr<ctran::bootstrap::IBootstrap> commBootstrap_;
+  std::shared_ptr<IBootstrap> commBootstrap_;
   const int32_t selfRank_{-1};
   const int32_t nRanks_{-1};
   std::vector<void*> memPtrs_;

--- a/comms/common/algorithms/AlgoFactory.cu
+++ b/comms/common/algorithms/AlgoFactory.cu
@@ -8,7 +8,7 @@
 namespace meta::comms {
 
 AlgoFactory::AlgoFactory(
-    std::shared_ptr<ctran::bootstrap::IBootstrap> bootstrap,
+    std::shared_ptr<IBootstrap> bootstrap,
     int nRanks,
     int selfRank,
     int maxBlocks,
@@ -38,7 +38,7 @@ AlgoFactory::AlgoFactory(
 }
 
 AlgoFactoryDev::AlgoFactoryDev(
-    std::shared_ptr<ctran::bootstrap::IBootstrap> bootstrap,
+    std::shared_ptr<IBootstrap> bootstrap,
     int nRanks,
     int selfRank,
     int maxBlocks,

--- a/comms/common/algorithms/AlgoFactory.cuh
+++ b/comms/common/algorithms/AlgoFactory.cuh
@@ -7,7 +7,7 @@
 #include "comms/common/algorithms/all_reduce/AllReduceAlgoManager.h"
 #include "comms/common/algorithms/all_to_all/AllToAllAlgoManager.h"
 #include "comms/common/algorithms/reduce_scatter/ReduceScatterAlgoManager.h"
-#include "comms/ctran/interfaces/IBootstrap.h" // @manual
+#include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/utils/CudaRAII.h"
 #include "comms/utils/commSpecs.h"
 
@@ -37,7 +37,7 @@ class AlgoFactory {
     int ddaTreeMaxThresholdBytes{0};
   };
   AlgoFactory(
-      std::shared_ptr<ctran::bootstrap::IBootstrap> bootstrap,
+      std::shared_ptr<IBootstrap> bootstrap,
       int nRanks,
       int selfRank,
       int maxBlocks,
@@ -103,7 +103,7 @@ class AlgoFactoryDev {
   };
 
   AlgoFactoryDev(
-      std::shared_ptr<ctran::bootstrap::IBootstrap> bootstrap,
+      std::shared_ptr<IBootstrap> bootstrap,
       int nRanks,
       int selfRank,
       int maxBlocks,

--- a/comms/common/algorithms/all_gather/AllGatherAlgoManager.h
+++ b/comms/common/algorithms/all_gather/AllGatherAlgoManager.h
@@ -4,7 +4,7 @@
 
 #include "comms/common/IpcGpuBarrier.cuh"
 #include "comms/common/algorithms/all_gather/AlgoAllGather.cuh"
-#include "comms/ctran/interfaces/IBootstrap.h" // @manual
+#include "comms/common/bootstrap/IBootstrap.h" // @manual
 #include "comms/utils/CudaRAII.h"
 #include "comms/utils/commSpecs.h"
 

--- a/comms/common/algorithms/all_reduce/AllReduceAlgoManager.cu
+++ b/comms/common/algorithms/all_reduce/AllReduceAlgoManager.cu
@@ -5,7 +5,7 @@
 namespace meta::comms {
 
 AllReduceAlgoManager::AllReduceAlgoManager(
-    std::shared_ptr<ctran::bootstrap::IBootstrap> bootstrap,
+    std::shared_ptr<IBootstrap> bootstrap,
     int nRanks,
     int selfRank,
     int maxBlocks,

--- a/comms/common/algorithms/all_reduce/AllReduceAlgoManager.h
+++ b/comms/common/algorithms/all_reduce/AllReduceAlgoManager.h
@@ -4,7 +4,7 @@
 
 #include "comms/common/IpcGpuBarrier.cuh"
 #include "comms/common/algorithms/all_reduce/AlgoAllReduce.cuh"
-#include "comms/ctran/interfaces/IBootstrap.h" // @manual
+#include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/utils/CudaRAII.h"
 #include "comms/utils/commSpecs.h"
 
@@ -13,7 +13,7 @@ namespace meta::comms {
 class AllReduceAlgoManager {
  public:
   AllReduceAlgoManager(
-      std::shared_ptr<ctran::bootstrap::IBootstrap> bootstrap,
+      std::shared_ptr<IBootstrap> bootstrap,
       int nRanks,
       int selfRank,
       int maxBlocks,

--- a/comms/common/algorithms/all_to_all/AllToAllAlgoManager.h
+++ b/comms/common/algorithms/all_to_all/AllToAllAlgoManager.h
@@ -4,7 +4,7 @@
 
 #include "comms/common/IpcGpuBarrier.cuh"
 #include "comms/common/algorithms/all_to_all/AlgoAllToAll.cuh"
-#include "comms/ctran/interfaces/IBootstrap.h" // @manual
+#include "comms/common/bootstrap/IBootstrap.h" // @manual
 #include "comms/utils/CudaRAII.h"
 #include "comms/utils/commSpecs.h"
 

--- a/comms/common/algorithms/reduce_scatter/ReduceScatterAlgoManager.h
+++ b/comms/common/algorithms/reduce_scatter/ReduceScatterAlgoManager.h
@@ -4,7 +4,7 @@
 
 #include "comms/common/IpcGpuBarrier.cuh"
 #include "comms/common/algorithms/reduce_scatter/AlgoReduceScatter.cuh"
-#include "comms/ctran/interfaces/IBootstrap.h" // @manual
+#include "comms/common/bootstrap/IBootstrap.h" // @manual
 #include "comms/utils/CudaRAII.h"
 #include "comms/utils/commSpecs.h"
 

--- a/comms/common/bootstrap/IBootstrap.h
+++ b/comms/common/bootstrap/IBootstrap.h
@@ -7,7 +7,7 @@
 
 #include <folly/futures/Future.h>
 
-namespace ctran::bootstrap {
+namespace meta::comms {
 
 /*
  * Abstract class for all bootstrap operations. This is used
@@ -115,4 +115,4 @@ class IBootstrap {
   recv(void* buf, int len, int peer, int tag) = 0;
 };
 
-} // namespace ctran::bootstrap
+} // namespace meta::comms

--- a/comms/common/tests/TestBaselineBootstrap.h
+++ b/comms/common/tests/TestBaselineBootstrap.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "comms/ctran/interfaces/IBootstrap.h" // @manual
+#include "comms/common/bootstrap/IBootstrap.h"
 
 #if defined(USE_ROCM)
 #include "rccl.h" // @manual
@@ -13,7 +13,7 @@
 namespace meta::comms {
 
 // Only used in unit tests for the components in /comms/common
-class TestBaselineBootstrap : public ::ctran::bootstrap::IBootstrap {
+class TestBaselineBootstrap : public IBootstrap {
  public:
   explicit TestBaselineBootstrap(ncclComm_t comm) : comm_(comm) {}
   virtual folly::SemiFuture<int>

--- a/comms/ctran/Ctran.h
+++ b/comms/ctran/Ctran.h
@@ -9,12 +9,12 @@
 
 #include "comms/ctran/interfaces/ICtran.h"
 
+#include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/ctran/commstate/CommStateX.h"
 #include "comms/ctran/gpe/CtranGpe.h"
 #include "comms/ctran/hints/Hints.h"
-#include "comms/ctran/interfaces/IBootstrap.h"
 #include "comms/ctran/mapper/CtranMapper.h"
 #include "comms/ctran/memory/memCacheAllocator.h"
 #include "comms/ctran/profiler/Profiler.h"

--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -7,8 +7,8 @@
 #include <cstdint>
 
 #include <folly/Synchronized.h>
+#include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/ctran/commstate/CommStateX.h"
-#include "comms/ctran/interfaces/IBootstrap.h"
 #include "comms/ctran/interfaces/ICtran.h"
 #include "comms/ctran/utils/Abort.h"
 #include "comms/ctran/utils/AsyncError.h"
@@ -145,7 +145,7 @@ class CtranComm {
   // TODO: change shared_prt to unique_ptr after refactor all ctran code using
   // CtranComm
   std::shared_ptr<ICtran> ctran_;
-  std::unique_ptr<ctran::bootstrap::IBootstrap> bootstrap_;
+  std::unique_ptr<meta::comms::IBootstrap> bootstrap_;
   std::shared_ptr<CollTrace> collTrace_;
   std::shared_ptr<meta::comms::colltrace::ICollTrace> colltraceNew_;
   std::shared_ptr<ncclx::memory::memCacheAllocator> memCache_;

--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -18,9 +18,9 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     // Create a non-owning shared_ptr wrapper for bootstrap.
     // SAFETY: multiPeerTransport_ must be destroyed before bootstrap_ in
     // CtranComm::destroy() to avoid dangling reference.
-    auto bootstrapPtr = std::shared_ptr<ctran::bootstrap::IBootstrap>(
+    auto bootstrapPtr = std::shared_ptr<meta::comms::IBootstrap>(
         comm->bootstrap_.get(),
-        [](ctran::bootstrap::IBootstrap*) {}); // no-op deleter
+        [](meta::comms::IBootstrap*) {}); // no-op deleter
 
     comms::pipes::MultiPeerTransportConfig config{};
 

--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
@@ -23,7 +23,7 @@ namespace ctran {
     }                                                                 \
   } while (0)
 
-void CtranTcpDm::bootstrapPrepare(ctran::bootstrap::IBootstrap* bootstrap) {
+void CtranTcpDm::bootstrapPrepare(meta::comms::IBootstrap* bootstrap) {
   folly::SocketAddress ifAddrSockAddr;
   sockaddr_in6 sin6{};
   auto dev = netdev_->bootstrapIface();

--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.h
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.h
@@ -121,7 +121,7 @@ class CtranTcpDm {
 
   commResult_t connectPeer(int peerRank);
 
-  void bootstrapPrepare(ctran::bootstrap::IBootstrap* bootstrap);
+  void bootstrapPrepare(meta::comms::IBootstrap* bootstrap);
   void bootstrapAddRecvPeer(
       int peerRank,
       ::comms::tcp_devmem::CommunicatorInterface* comm);

--- a/comms/ctran/commstate/CommStateX.cc
+++ b/comms/ctran/commstate/CommStateX.cc
@@ -99,8 +99,7 @@ void CommStateX::initRankTopologyVnode(const int nLocalRanks) {
   }
 }
 
-void CommStateX::initRankStatesTopology(
-    ctran::bootstrap::IBootstrap* bootstrap) {
+void CommStateX::initRankStatesTopology(meta::comms::IBootstrap* bootstrap) {
   auto myTopo = ctran::commstate::loadTopology(rank_, NCCL_TOPO_FILE_PATH);
   if (!myTopo) {
     FB_CHECKTHROW_EX(

--- a/comms/ctran/commstate/CommStateX.h
+++ b/comms/ctran/commstate/CommStateX.h
@@ -9,8 +9,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/ctran/commstate/CommStateXDev.h"
-#include "comms/ctran/interfaces/IBootstrap.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
 namespace ncclx {
@@ -88,7 +88,7 @@ class CommStateX {
   void initRankTopologyNolocal();
   void initRankTopologyVnode(const int nLocalRanks);
   friend void initRankTopologyFrom(CommStateX* _CommStateX, void* _comm);
-  void initRankStatesTopology(ctran::bootstrap::IBootstrap* bootstrap);
+  void initRankStatesTopology(meta::comms::IBootstrap* bootstrap);
 
   /* Setters */
   void setRankTopologies(std::vector<RankTopology> rankTopologies);

--- a/comms/ctran/tests/CtranTestUtils.cc
+++ b/comms/ctran/tests/CtranTestUtils.cc
@@ -531,7 +531,7 @@ namespace {
 
 void initRankStatesTopologyWrapper(
     ncclx::CommStateX* statex,
-    ctran::bootstrap::IBootstrap* bootstrap,
+    meta::comms::IBootstrap* bootstrap,
     int nRanks) {
   // Fake topology with nLocalRanks=1
   if (NCCL_COMM_STATE_DEBUG_TOPO == NCCL_COMM_STATE_DEBUG_TOPO::nolocal) {

--- a/comms/ctran/tests/bootstrap/IntraProcessBootstrap.h
+++ b/comms/ctran/tests/bootstrap/IntraProcessBootstrap.h
@@ -2,11 +2,11 @@
 
 #pragma once
 
-#include "comms/ctran/interfaces/IBootstrap.h"
+#include "comms/common/bootstrap/IBootstrap.h"
 
 namespace ctran::testing {
 
-class IntraProcessBootstrap : public ctran::bootstrap::IBootstrap {
+class IntraProcessBootstrap : public meta::comms::IBootstrap {
  public:
   struct State {
     State() {

--- a/comms/ctran/tests/bootstrap/MockBootstrap.h
+++ b/comms/ctran/tests/bootstrap/MockBootstrap.h
@@ -5,12 +5,12 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include "comms/ctran/interfaces/IBootstrap.h"
+#include "comms/common/bootstrap/IBootstrap.h"
 
 namespace ctran::testing {
 
 // Mock IBootstrap for testing
-class MockBootstrap : public ctran::bootstrap::IBootstrap {
+class MockBootstrap : public meta::comms::IBootstrap {
  public:
   MOCK_METHOD(
       folly::SemiFuture<int>,

--- a/comms/ncclx/v2_27/meta/ctran-integration/BaselineBootstrap.h
+++ b/comms/ncclx/v2_27/meta/ctran-integration/BaselineBootstrap.h
@@ -2,13 +2,13 @@
 
 #pragma once
 
-#include "comms/ctran/interfaces/IBootstrap.h"
+#include "comms/common/bootstrap/IBootstrap.h"
 
 #include "nccl.h" // @manual
 
 namespace ncclx {
 
-class BaselineBootstrap : public ::ctran::bootstrap::IBootstrap {
+class BaselineBootstrap : public ::meta::comms::IBootstrap {
  public:
   explicit BaselineBootstrap(ncclComm_t comm) : comm_(comm) {}
 

--- a/comms/ncclx/v2_27/src/include/comm.h
+++ b/comms/ncclx/v2_27/src/include/comm.h
@@ -28,9 +28,9 @@
 
 // Forward declarations of ncclx classes to avoid circular dependencies
 class ICtran;
-namespace ctran::bootstrap {
+namespace meta::comms {
 class IBootstrap;
-} // namespace ctran::bootstrap
+} // namespace meta::comms
 class CollTrace;
 namespace ncclx {
 class CommStateX;
@@ -694,7 +694,7 @@ struct ncclComm {
   struct CommLogData logMetaData;
   std::shared_ptr<CollTrace> collTrace;
   std::shared_ptr<meta::comms::colltrace::ICollTrace> newCollTrace;
-  std::shared_ptr<ctran::bootstrap::IBootstrap> ctranBootstrap;
+  std::shared_ptr<meta::comms::IBootstrap> ctranBootstrap;
   std::shared_ptr<ncclx::memory::memCacheAllocator> memCache{nullptr};
   std::vector<std::string> connSetupBufKeys;
   std::shared_ptr<ncclx::transport::TransportProxy> transportProxy_;

--- a/comms/ncclx/v2_27/src/init.cc
+++ b/comms/ncclx/v2_27/src/init.cc
@@ -35,7 +35,7 @@
 #include "comms/ctran/Ctran.h"
 #include "meta/commstate/FactoryCommStateX.h"
 #include "comms/ctran/commstate/CommStateX.h"
-#include "comms/ctran/interfaces/IBootstrap.h"
+#include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/ctran/utils/Utils.h"
 #include "comms/ctran/utils/SkipDestroyUtil.h"
 #include "comms/utils/commSpecs.h"

--- a/comms/ncclx/v2_28/meta/ctran-integration/BaselineBootstrap.h
+++ b/comms/ncclx/v2_28/meta/ctran-integration/BaselineBootstrap.h
@@ -2,13 +2,13 @@
 
 #pragma once
 
-#include "comms/ctran/interfaces/IBootstrap.h"
+#include "comms/common/bootstrap/IBootstrap.h"
 
 #include "nccl.h" // @manual
 
 namespace ncclx {
 
-class BaselineBootstrap : public ::ctran::bootstrap::IBootstrap {
+class BaselineBootstrap : public ::meta::comms::IBootstrap {
  public:
   explicit BaselineBootstrap(ncclComm_t comm) : comm_(comm) {}
 

--- a/comms/ncclx/v2_28/src/include/comm.h
+++ b/comms/ncclx/v2_28/src/include/comm.h
@@ -34,9 +34,9 @@
 
 // Forward declarations of ncclx classes to avoid circular dependencies
 class ICtran;
-namespace ctran::bootstrap {
+namespace meta::comms {
 class IBootstrap;
-} // namespace ctran::bootstrap
+} // namespace meta::comms
 class CollTrace;
 namespace ncclx {
 class CommStateX;
@@ -731,7 +731,7 @@ struct ncclComm {
   std::shared_ptr<CollTrace> collTrace;
   std::shared_ptr<meta::comms::colltrace::ICollTrace> newCollTrace;
   std::unique_ptr<meta::comms::colltrace::AlgoStats> algoStats;
-  std::shared_ptr<ctran::bootstrap::IBootstrap> ctranBootstrap;
+  std::shared_ptr<meta::comms::IBootstrap> ctranBootstrap;
   std::shared_ptr<ncclx::memory::memCacheAllocator> memCache{nullptr};
   std::vector<std::string> connSetupBufKeys;
   std::shared_ptr<ncclx::transport::TransportProxy> transportProxy_;

--- a/comms/ncclx/v2_28/src/init.cc
+++ b/comms/ncclx/v2_28/src/init.cc
@@ -40,7 +40,7 @@
 #include "comms/ctran/Ctran.h"
 #include "meta/commstate/FactoryCommStateX.h"
 #include "comms/ctran/commstate/CommStateX.h"
-#include "comms/ctran/interfaces/IBootstrap.h"
+#include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/ctran/utils/Utils.h"
 #include "comms/ctran/utils/SkipDestroyUtil.h"
 #include "comms/utils/commSpecs.h"

--- a/comms/ncclx/v2_29/meta/ctran-integration/BaselineBootstrap.h
+++ b/comms/ncclx/v2_29/meta/ctran-integration/BaselineBootstrap.h
@@ -2,13 +2,13 @@
 
 #pragma once
 
-#include "comms/ctran/interfaces/IBootstrap.h"
+#include "comms/common/bootstrap/IBootstrap.h"
 
 #include "nccl.h" // @manual
 
 namespace ncclx {
 
-class BaselineBootstrap : public ::ctran::bootstrap::IBootstrap {
+class BaselineBootstrap : public ::meta::comms::IBootstrap {
  public:
   explicit BaselineBootstrap(ncclComm_t comm) : comm_(comm) {}
 

--- a/comms/ncclx/v2_29/src/include/comm.h
+++ b/comms/ncclx/v2_29/src/include/comm.h
@@ -38,9 +38,9 @@
 
 // Forward declarations of ncclx classes to avoid circular dependencies
 class ICtran;
-namespace ctran::bootstrap {
+namespace meta::comms {
 class IBootstrap;
-} // namespace ctran::bootstrap
+} // namespace meta::comms
 class CollTrace;
 namespace ncclx {
 class CommStateX;
@@ -829,7 +829,7 @@ struct ncclComm {
   std::shared_ptr<CollTrace> collTrace;
   std::shared_ptr<meta::comms::colltrace::ICollTrace> newCollTrace;
   std::unique_ptr<meta::comms::colltrace::AlgoStats> algoStats;
-  std::shared_ptr<ctran::bootstrap::IBootstrap> ctranBootstrap;
+  std::shared_ptr<meta::comms::IBootstrap> ctranBootstrap;
   std::shared_ptr<ncclx::memory::memCacheAllocator> memCache{nullptr};
   std::vector<std::string> connSetupBufKeys;
   std::shared_ptr<ncclx::transport::TransportProxy> transportProxy_;

--- a/comms/ncclx/v2_29/src/init.cc
+++ b/comms/ncclx/v2_29/src/init.cc
@@ -37,7 +37,7 @@
 #include "comms/ctran/Ctran.h"
 #include "meta/commstate/FactoryCommStateX.h"
 #include "comms/ctran/commstate/CommStateX.h"
-#include "comms/ctran/interfaces/IBootstrap.h"
+#include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/ctran/utils/Utils.h"
 #include "comms/ctran/utils/SkipDestroyUtil.h"
 #include "comms/utils/commSpecs.h"

--- a/comms/pipes/GpuMemHandler.cc
+++ b/comms/pipes/GpuMemHandler.cc
@@ -163,7 +163,7 @@ MemSharingMode GpuMemHandler::detectBestMode() {
 }
 
 GpuMemHandler::GpuMemHandler(
-    std::shared_ptr<ctran::bootstrap::IBootstrap> bootstrap,
+    std::shared_ptr<meta::comms::IBootstrap> bootstrap,
     int32_t selfRank,
     int32_t nRanks,
     size_t size)
@@ -175,7 +175,7 @@ GpuMemHandler::GpuMemHandler(
           detectBestMode()) {}
 
 GpuMemHandler::GpuMemHandler(
-    std::shared_ptr<ctran::bootstrap::IBootstrap> bootstrap,
+    std::shared_ptr<meta::comms::IBootstrap> bootstrap,
     int32_t selfRank,
     int32_t nRanks,
     size_t size,

--- a/comms/pipes/GpuMemHandler.h
+++ b/comms/pipes/GpuMemHandler.h
@@ -6,7 +6,7 @@
 #include <cuda_runtime.h>
 #include <vector>
 
-#include "comms/ctran/interfaces/IBootstrap.h"
+#include "comms/common/bootstrap/IBootstrap.h"
 
 namespace comms::pipes {
 
@@ -84,7 +84,7 @@ class GpuMemHandler {
    * @throws std::runtime_error if memory allocation fails
    */
   GpuMemHandler(
-      std::shared_ptr<ctran::bootstrap::IBootstrap> bootstrap,
+      std::shared_ptr<meta::comms::IBootstrap> bootstrap,
       int32_t selfRank,
       int32_t nRanks,
       size_t size);
@@ -102,7 +102,7 @@ class GpuMemHandler {
    * fails
    */
   GpuMemHandler(
-      std::shared_ptr<ctran::bootstrap::IBootstrap> bootstrap,
+      std::shared_ptr<meta::comms::IBootstrap> bootstrap,
       int32_t selfRank,
       int32_t nRanks,
       size_t size,
@@ -191,7 +191,7 @@ class GpuMemHandler {
   void exchangeCudaIpcHandles();
   void cleanupCudaIpc();
 
-  std::shared_ptr<ctran::bootstrap::IBootstrap> bootstrap_;
+  std::shared_ptr<meta::comms::IBootstrap> bootstrap_;
   const int32_t selfRank_{-1};
   const int32_t nRanks_{-1};
   const MemSharingMode mode_{MemSharingMode::kCudaIpc};

--- a/comms/pipes/MultiPeerNvlTransport.cc
+++ b/comms/pipes/MultiPeerNvlTransport.cc
@@ -15,7 +15,7 @@ namespace comms::pipes {
 MultiPeerNvlTransport::MultiPeerNvlTransport(
     int myRank,
     int nRanks,
-    std::shared_ptr<ctran::bootstrap::IBootstrap> bootstrap,
+    std::shared_ptr<meta::comms::IBootstrap> bootstrap,
     const MultiPeerNvlTransportConfig& multiPeerNvlTransportConfig)
     : myRank_(myRank),
       nRanks_(nRanks),

--- a/comms/pipes/MultiPeerNvlTransport.h
+++ b/comms/pipes/MultiPeerNvlTransport.h
@@ -4,6 +4,7 @@
 
 #include <memory>
 
+#include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/pipes/GpuMemHandler.h"
 #include "comms/pipes/P2pNvlTransportDevice.cuh"
 #include "comms/pipes/Transport.cuh"
@@ -110,7 +111,7 @@ class MultiPeerNvlTransport {
   MultiPeerNvlTransport(
       int myRank,
       int nRanks,
-      std::shared_ptr<ctran::bootstrap::IBootstrap> bootstrap,
+      std::shared_ptr<meta::comms::IBootstrap> bootstrap,
       const MultiPeerNvlTransportConfig& multiPeerNvlTransportConfig);
 
   /**
@@ -238,7 +239,7 @@ class MultiPeerNvlTransport {
 
   const int myRank_{-1};
   const int nRanks_{-1};
-  std::shared_ptr<ctran::bootstrap::IBootstrap> bootstrap_;
+  std::shared_ptr<meta::comms::IBootstrap> bootstrap_;
   const MultiPeerNvlTransportConfig config_;
 
   // GpuMemHandler-based memory for data, state, and signal buffers

--- a/comms/pipes/MultiPeerTransport.cc
+++ b/comms/pipes/MultiPeerTransport.cc
@@ -34,7 +34,7 @@ MultiPeerTransport::MultiPeerTransport(
     int myRank,
     int nRanks,
     int deviceId,
-    std::shared_ptr<ctran::bootstrap::IBootstrap> bootstrap,
+    std::shared_ptr<meta::comms::IBootstrap> bootstrap,
     const MultiPeerTransportConfig& config)
     : myRank_(myRank),
       nRanks_(nRanks),

--- a/comms/pipes/MultiPeerTransport.h
+++ b/comms/pipes/MultiPeerTransport.h
@@ -9,7 +9,7 @@
 
 #include <cuda_runtime.h>
 
-#include "comms/ctran/interfaces/IBootstrap.h"
+#include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/pipes/MultiPeerNvlTransport.h"
 #include "comms/pipes/MultipeerIbgdaTransport.h"
 #include "comms/pipes/P2pSelfTransportDevice.cuh"
@@ -58,7 +58,7 @@ class MultiPeerTransport {
       int myRank,
       int nRanks,
       int deviceId,
-      std::shared_ptr<ctran::bootstrap::IBootstrap> bootstrap,
+      std::shared_ptr<meta::comms::IBootstrap> bootstrap,
       const MultiPeerTransportConfig& config);
 
   ~MultiPeerTransport();
@@ -217,7 +217,7 @@ class MultiPeerTransport {
   const int myRank_;
   const int nRanks_;
   const int deviceId_;
-  std::shared_ptr<ctran::bootstrap::IBootstrap> bootstrap_;
+  std::shared_ptr<meta::comms::IBootstrap> bootstrap_;
 
   // --- Topology (populated in constructor) ---
   std::vector<int> nvlPeerRanks_;
@@ -230,7 +230,7 @@ class MultiPeerTransport {
   int nvlNRanks_{0};
 
   // --- Sub-transports ---
-  std::shared_ptr<ctran::bootstrap::IBootstrap> nvlBootstrapAdapter_;
+  std::shared_ptr<meta::comms::IBootstrap> nvlBootstrapAdapter_;
   std::unique_ptr<MultiPeerNvlTransport> nvlTransport_;
   std::unique_ptr<MultipeerIbgdaTransport> ibgdaTransport_;
 

--- a/comms/pipes/MultipeerIbgdaTransport.cc
+++ b/comms/pipes/MultipeerIbgdaTransport.cc
@@ -475,7 +475,7 @@ int MultipeerIbgdaTransport::peerIndexToRank(int peerIndex) const {
 MultipeerIbgdaTransport::MultipeerIbgdaTransport(
     int myRank,
     int nRanks,
-    std::shared_ptr<ctran::bootstrap::IBootstrap> bootstrap,
+    std::shared_ptr<meta::comms::IBootstrap> bootstrap,
     const MultipeerIbgdaTransportConfig& config)
     : myRank_(myRank),
       nRanks_(nRanks),

--- a/comms/pipes/MultipeerIbgdaTransport.h
+++ b/comms/pipes/MultipeerIbgdaTransport.h
@@ -13,7 +13,7 @@
 #include <infiniband/verbs.h>
 
 #include <doca_gpunetio_host.h>
-#include "comms/ctran/interfaces/IBootstrap.h"
+#include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/pipes/IbgdaBuffer.h"
 
 // Forward declarations for device types (defined in .cuh files)
@@ -250,7 +250,7 @@ class MultipeerIbgdaTransport {
   MultipeerIbgdaTransport(
       int myRank,
       int nRanks,
-      std::shared_ptr<ctran::bootstrap::IBootstrap> bootstrap,
+      std::shared_ptr<meta::comms::IBootstrap> bootstrap,
       const MultipeerIbgdaTransportConfig& config);
 
   /**
@@ -385,7 +385,7 @@ class MultipeerIbgdaTransport {
   const int nRanks_{0};
 
   // Bootstrap for collective operations
-  std::shared_ptr<ctran::bootstrap::IBootstrap> bootstrap_;
+  std::shared_ptr<meta::comms::IBootstrap> bootstrap_;
 
   // Configuration
   MultipeerIbgdaTransportConfig config_;

--- a/comms/pipes/TopologyDiscovery.cc
+++ b/comms/pipes/TopologyDiscovery.cc
@@ -207,7 +207,7 @@ TopologyResult TopologyDiscovery::discover(
     int myRank,
     int nRanks,
     int deviceId,
-    ctran::bootstrap::IBootstrap& bootstrap,
+    meta::comms::IBootstrap& bootstrap,
     const TopologyConfig& topoConfig) {
   std::vector<RankTopologyInfo> allInfo(nRanks);
 

--- a/comms/pipes/TopologyDiscovery.h
+++ b/comms/pipes/TopologyDiscovery.h
@@ -8,7 +8,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include "comms/ctran/interfaces/IBootstrap.h"
+#include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/pipes/NvmlFabricInfo.h"
 #include "comms/pipes/Transport.cuh"
 
@@ -202,7 +202,7 @@ class TopologyDiscovery {
       int myRank,
       int nRanks,
       int deviceId,
-      ctran::bootstrap::IBootstrap& bootstrap,
+      meta::comms::IBootstrap& bootstrap,
       const TopologyConfig& topoConfig = {});
 
   /**

--- a/comms/pipes/bootstrap/NvlBootstrapAdapter.h
+++ b/comms/pipes/bootstrap/NvlBootstrapAdapter.h
@@ -6,7 +6,7 @@
 #include <utility>
 #include <vector>
 
-#include "comms/ctran/interfaces/IBootstrap.h"
+#include "comms/common/bootstrap/IBootstrap.h"
 
 namespace comms::pipes {
 
@@ -27,7 +27,7 @@ namespace comms::pipes {
  * local rank indices [0, nvlNRanks) while the underlying bootstrap
  * coordinates using global communicator ranks.
  */
-class NvlBootstrapAdapter : public ctran::bootstrap::IBootstrap {
+class NvlBootstrapAdapter : public meta::comms::IBootstrap {
  public:
   /**
    * @param underlying          The global bootstrap instance.
@@ -36,7 +36,7 @@ class NvlBootstrapAdapter : public ctran::bootstrap::IBootstrap {
    *                            (including self).
    */
   NvlBootstrapAdapter(
-      std::shared_ptr<ctran::bootstrap::IBootstrap> underlying,
+      std::shared_ptr<meta::comms::IBootstrap> underlying,
       std::vector<int> localRankToCommRank)
       : underlying_(std::move(underlying)),
         localRankToCommRank_(std::move(localRankToCommRank)) {}
@@ -78,7 +78,7 @@ class NvlBootstrapAdapter : public ctran::bootstrap::IBootstrap {
   }
 
  private:
-  std::shared_ptr<ctran::bootstrap::IBootstrap> underlying_;
+  std::shared_ptr<meta::comms::IBootstrap> underlying_;
   std::vector<int> localRankToCommRank_;
 };
 

--- a/comms/pipes/tests/MockBootstrap.h
+++ b/comms/pipes/tests/MockBootstrap.h
@@ -6,12 +6,12 @@
 
 #include <gmock/gmock.h>
 
-#include "comms/ctran/interfaces/IBootstrap.h"
+#include "comms/common/bootstrap/IBootstrap.h"
 
 namespace comms::pipes::testing {
 
 /// GMock-based mock of IBootstrap for unit testing.
-class MockBootstrap : public ctran::bootstrap::IBootstrap {
+class MockBootstrap : public meta::comms::IBootstrap {
  public:
   MOCK_METHOD(
       folly::SemiFuture<int>,

--- a/comms/pipes/window/WindowMemory.cc
+++ b/comms/pipes/window/WindowMemory.cc
@@ -14,7 +14,7 @@ namespace comms::pipes {
 WindowMemory::WindowMemory(
     int myRank,
     int nRanks,
-    std::shared_ptr<ctran::bootstrap::IBootstrap> bootstrap,
+    std::shared_ptr<meta::comms::IBootstrap> bootstrap,
     const WindowMemoryConfig& config,
     MemSharingMode memSharingMode)
     : myRank_(myRank),

--- a/comms/pipes/window/WindowMemory.h
+++ b/comms/pipes/window/WindowMemory.h
@@ -76,7 +76,7 @@ class WindowMemory {
   WindowMemory(
       int myRank,
       int nRanks,
-      std::shared_ptr<ctran::bootstrap::IBootstrap> bootstrap,
+      std::shared_ptr<meta::comms::IBootstrap> bootstrap,
       const WindowMemoryConfig& config,
       MemSharingMode memSharingMode = GpuMemHandler::detectBestMode());
 
@@ -182,7 +182,7 @@ class WindowMemory {
 
   const int myRank_{-1};
   const int nRanks_{-1};
-  std::shared_ptr<ctran::bootstrap::IBootstrap> bootstrap_;
+  std::shared_ptr<meta::comms::IBootstrap> bootstrap_;
   const WindowMemoryConfig config_;
   const MemSharingMode memSharingMode_;
 

--- a/comms/rcclx/develop/CMakeLists.txt
+++ b/comms/rcclx/develop/CMakeLists.txt
@@ -1028,7 +1028,7 @@ set(CTRAN_FILES
   comms/ctran/ibverbx/Mlx5core.h
   comms/ctran/ibverbx/Mlx5dv.cc
   comms/ctran/ibverbx/Mlx5dv.h
-  comms/ctran/interfaces/IBootstrap.h
+  comms/common/bootstrap/IBootstrap.h
   comms/ctran/interfaces/ICtran.h
   comms/ctran/mapper/CtranMapper.cc
   comms/ctran/mapper/CtranMapper.h
@@ -1186,6 +1186,7 @@ set(COMMON_FILES
   comms/pipes/window/DeviceWindowSignal.cuh
   comms/pipes/window/WindowMemory.cc
   comms/pipes/window/WindowMemory.h
+  comms/common/bootstrap/IBootstrap.h
   comms/utils/checks.h
   comms/utils/colltrace/AlgoStats.cc
   comms/utils/colltrace/AlgoStats.h

--- a/comms/rcclx/develop/meta/ctran/BaselineBootstrap.h
+++ b/comms/rcclx/develop/meta/ctran/BaselineBootstrap.h
@@ -2,12 +2,12 @@
 
 #pragma once
 
-#include "comms/ctran/interfaces/IBootstrap.h" // @manual
+#include "comms/common/bootstrap/IBootstrap.h" // @manual
 #include "nccl.h"
 
 namespace rcclx {
 
-class BaselineBootstrap : public ::ctran::bootstrap::IBootstrap {
+class BaselineBootstrap : public ::meta::comms::IBootstrap {
  public:
   explicit BaselineBootstrap(ncclComm_t comm) : comm_(comm) {}
 

--- a/comms/rcclx/snapshots/last-stable/comms/rcclx/develop/meta/ctran/BaselineBootstrap.h
+++ b/comms/rcclx/snapshots/last-stable/comms/rcclx/develop/meta/ctran/BaselineBootstrap.h
@@ -2,12 +2,12 @@
 
 #pragma once
 
-#include "comms/ctran/interfaces/IBootstrap.h" // @manual
+#include "comms/common/bootstrap/IBootstrap.h" // @manual
 #include "nccl.h"
 
 namespace rcclx {
 
-class BaselineBootstrap : public ::ctran::bootstrap::IBootstrap {
+class BaselineBootstrap : public ::meta::comms::IBootstrap {
  public:
   explicit BaselineBootstrap(ncclComm_t comm) : comm_(comm) {}
 

--- a/comms/rcclx/snapshots/stable/comms/rcclx/develop/meta/ctran/BaselineBootstrap.h
+++ b/comms/rcclx/snapshots/stable/comms/rcclx/develop/meta/ctran/BaselineBootstrap.h
@@ -2,12 +2,12 @@
 
 #pragma once
 
-#include "comms/ctran/interfaces/IBootstrap.h" // @manual
+#include "comms/common/bootstrap/IBootstrap.h" // @manual
 #include "nccl.h"
 
 namespace rcclx {
 
-class BaselineBootstrap : public ::ctran::bootstrap::IBootstrap {
+class BaselineBootstrap : public ::meta::comms::IBootstrap {
  public:
   explicit BaselineBootstrap(ncclComm_t comm) : comm_(comm) {}
 


### PR DESCRIPTION
Summary:
Move the iboostrap to common so that pipes can depend on this too without having a
circular dep

Reviewed By: dboyda, saifhhasan

Differential Revision: D91200685
