### PR TITLE
Remove ncclMemAllocDisjoint wrapper, call commMemAllocDisjoint directly

### DIFF
--- a/comms/ctran/tests/CtranNcclTestUtils.cc
+++ b/comms/ctran/tests/CtranNcclTestUtils.cc
@@ -29,22 +29,6 @@ ncclResult_t ncclMemFreeWithRefCheck(void* ptr) {
   return ncclSuccess;
 }
 
-ncclResult_t ncclMemAllocDisjoint(
-    void** ptr,
-    std::vector<size_t>& disjointSegmentSizes,
-    std::vector<TestMemSegment>& segments,
-    bool setRdmaSupport) {
-  return metaCommToNccl(
-      ctran::commMemAllocDisjoint(
-          ptr, disjointSegmentSizes, segments, setRdmaSupport));
-}
-
-ncclResult_t ncclMemFreeDisjoint(
-    void* ptr,
-    std::vector<size_t>& disjointSegmentSizes) {
-  return metaCommToNccl(ctran::commMemFreeDisjoint(ptr, disjointSegmentSizes));
-}
-
 #endif // !defined(USE_ROCM)
 
 // ============================================================================
@@ -72,10 +56,9 @@ void* CtranNcclTestHelpers::prepareBuf(
     std::vector<size_t> disjointSegmentSizes(2);
     disjointSegmentSizes[0] = bufSize / 2;
     disjointSegmentSizes[1] = bufSize / 2;
-    NCCLCHECK_TEST(ncclMemAllocDisjoint(&buf, disjointSegmentSizes, segments));
+    COMMCHECK_TEST(commMemAllocDisjoint(&buf, disjointSegmentSizes, segments));
 #else
-    XLOG(FATAL)
-        << "kCuMemAllocDisjoint via ncclMemAllocDisjoint is not supported on AMD/HIP";
+    XLOG(FATAL) << "kCuMemAllocDisjoint is not supported on AMD/HIP";
 #endif
   }
   return buf;
@@ -99,10 +82,9 @@ void CtranNcclTestHelpers::releaseBuf(
     std::vector<size_t> disjointSegmentSizes(2);
     disjointSegmentSizes[0] = bufSize / 2;
     disjointSegmentSizes[1] = bufSize / 2;
-    NCCLCHECK_TEST(ncclMemFreeDisjoint(buf, disjointSegmentSizes));
+    COMMCHECK_TEST(commMemFreeDisjoint(buf, disjointSegmentSizes));
 #else
-    XLOG(FATAL)
-        << "kCuMemAllocDisjoint via ncclMemFreeDisjoint is not supported on AMD/HIP";
+    XLOG(FATAL) << "kCuMemAllocDisjoint is not supported on AMD/HIP";
 #endif
   }
 }

--- a/comms/ctran/tests/CtranNcclTestUtils.h
+++ b/comms/ctran/tests/CtranNcclTestUtils.h
@@ -33,27 +33,13 @@ namespace ctran {
 #endif // !defined(USE_ROCM)
 
 // ============================================================================
-// NCCL-Specific Memory Allocation Helpers
+// NCCL-Specific Memory Helpers
 // ============================================================================
 
 #if !defined(USE_ROCM)
 // Helper for freeing NCCL memory with reference count verification.
 // This ensures all internal handles have been properly released.
 ncclResult_t ncclMemFreeWithRefCheck(void* ptr);
-
-// Wrapper for ncclMemAllocDisjoint that calls commMemAllocDisjoint
-// and converts the result to ncclResult_t.
-ncclResult_t ncclMemAllocDisjoint(
-    void** ptr,
-    std::vector<size_t>& disjointSegmentSizes,
-    std::vector<TestMemSegment>& segments,
-    bool setRdmaSupport = true);
-
-// Wrapper for ncclMemFreeDisjoint that calls commMemFreeDisjoint
-// and converts the result to ncclResult_t.
-ncclResult_t ncclMemFreeDisjoint(
-    void* ptr,
-    std::vector<size_t>& disjointSegmentSizes);
 #endif // !defined(USE_ROCM)
 
 // ============================================================================
@@ -70,17 +56,16 @@ class CtranNcclTestHelpers : public CtranTestHelpers {
   CtranNcclTestHelpers() = default;
 
   // Prepare buffer with specified memory type.
-  // Extends base class to support NCCL memory allocation types:
-  // - kMemCudaMalloc: Uses cudaMalloc (handled by base class)
+  // Supports NCCL memory allocation types:
+  // - kMemCudaMalloc: Uses cudaMalloc
   // - kMemNcclMemAlloc: Uses ncclMemAlloc
-  // - kCuMemAllocDisjoint: Uses ncclMemAllocDisjoint
+  // - kCuMemAllocDisjoint: Uses commMemAllocDisjoint directly
   static void* prepareBuf(
       size_t bufSize,
       MemAllocType memType,
       std::vector<TestMemSegment>& segments);
 
   // Release buffer allocated by prepareBuf.
-  // Extends base class to support NCCL memory types.
   static void releaseBuf(void* buf, size_t bufSize, MemAllocType memType);
 };
 


### PR DESCRIPTION
Summary:
**TL;DR:** Address tech debt from D88759911 by removing the `ncclMemAllocDisjoint()`/`ncclMemFreeDisjoint()` wrapper functions and calling `commMemAllocDisjoint()`/`commMemFreeDisjoint()` directly from `CtranNcclTestHelpers`.

---

# Detailed Overview

## Context & Motivation

D88759911 introduced a refactoring that separated NCCL-specific test utilities from `CtranTestUtils` into `CtranNcclTestUtils`. During the code review, the following concern was raised:

> *"The current dependency is circular and looks sick to me. I.e., ctran->ncclHelper->ctran (i.e., commMemAlloc\*). It also adds problem that, **whenever I am extending commMemAllocDisjoint, it has to change all the upper layers**."*

The reviewer proposed simplifying the architecture so that `CtranNcclTestHelpers` calls `commMemAllocDisjoint()` directly when `memType` requires it, rather than going through a wrapper layer.

## The Issue

D88759911 introduced wrapper functions that created an unnecessary call chain:
```
CtranNcclTestHelpers::prepareBuf() --> ncclMemAllocDisjoint() -- wrapper added by D88759911 --> commMemAllocDisjoint()

---

[Code Structure]
CtranUtUtils.cc
    ↓ includes
CtranNcclTestUtils.h
    ↓ includes  
CtranTestUtils.h

[Call Flow]
CtranBaseTest::prepareBuf() (CtranUtUtils.cc)
    ↓ calls
CtranNcclTestHelpers::prepareBuf() (CtranNcclTestUtils.cc)
    ↓ calls (for kCuMemAllocDisjoint)
ncclMemAllocDisjoint() (CtranNcclTestUtils.cc)
    ↓ calls
commMemAllocDisjoint() (CtranTestUtils.cc)
```

These wrappers (`ncclMemAllocDisjoint`/`ncclMemFreeDisjoint`) only performed `commResult_t` -> `ncclResult_t` conversion via `metaCommToNccl()`, which is unnecessary since `CtranNcclTestHelpers` can use the `COMMCHECK_TEST` macro to call `commMemAllocDisjoint()` directly.

## The Fix

This diff removes the unnecessary wrapper layer:

| Before (D88759911) | After (This Diff) |
|-------------------|-------------------|
| `NCCLCHECK_TEST(ncclMemAllocDisjoint(...))` | `COMMCHECK_TEST(commMemAllocDisjoint(...))` |
| `NCCLCHECK_TEST(ncclMemFreeDisjoint(...))` | `COMMCHECK_TEST(commMemFreeDisjoint(...))` |

The simplified call chain is now:

```
All Tests → commMemAlloc() (CtranTestUtils.cc)
    ├── kMemCudaMalloc      --> cudaMalloc()
    ├── kCuMemAllocDisjoint --> commMemAllocDisjoint() (direct, no wrapper)
    └── kMemNcclMemAlloc    --> ncclMemAlloc() (CtranNcclTestUtils.cc)
```

## Changes Summary

1. **Removed** `ncclMemAllocDisjoint()` and `ncclMemFreeDisjoint()` wrapper functions from `CtranNcclTestUtils.cc`
2. **Updated** `CtranNcclTestHelpers::prepareBuf()` to call `commMemAllocDisjoint()` directly via `COMMCHECK_TEST`
3. **Updated** `CtranNcclTestHelpers::releaseBuf()` to call `commMemFreeDisjoint()` directly via `COMMCHECK_TEST`
4. **Removed** wrapper function declarations from `CtranNcclTestUtils.h`

## Benefit

This makes it easier to extend `commMemAllocDisjoint()` without updating intermediate wrapper layers, directly addressing the reviewer's concern from D88759911.

Differential Revision: D91334237


