### PR TITLE
Use std::once_flag instead of folly::once_flag to unblock ci break

### DIFF
--- a/comms/torchcomms/nccl/TorchCommNCCLCCA.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCLCCA.cpp
@@ -13,8 +13,8 @@ void cachingAllocatorHookFn(
 }
 
 CachingAllocatorHookImpl& CachingAllocatorHook::getInstance() {
-  // Use folly::call_once for thread-safe singleton initialization
-  folly::call_once(init_flag_, createInstance);
+  // Use std::call_once for thread-safe singleton initialization
+  std::call_once(init_flag_, createInstance);
   return *instance_;
 }
 

--- a/comms/torchcomms/nccl/TorchCommNCCLCCA.hpp
+++ b/comms/torchcomms/nccl/TorchCommNCCLCCA.hpp
@@ -4,7 +4,6 @@
 
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDACachingAllocator.h>
-#include <folly/synchronization/CallOnce.h>
 #include <memory>
 #include <mutex>
 #include "comms/torchcomms/nccl/TorchCommNCCL.hpp"
@@ -75,7 +74,7 @@ class CachingAllocatorHook {
   }
 
   inline static std::unique_ptr<CachingAllocatorHookImpl> instance_ = nullptr;
-  inline static folly::once_flag init_flag_;
+  inline static std::once_flag init_flag_;
 };
 
 // Global function to be registered as a hook

--- a/comms/torchcomms/ncclx/TorchCommNCCLXCCA.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXCCA.cpp
@@ -31,8 +31,8 @@ void cachingAllocatorHookFn(
 }
 
 CachingAllocatorHookImpl& CachingAllocatorHook::getInstance() {
-  // Use folly::call_once for thread-safe singleton initialization
-  folly::call_once(init_flag_, createInstance);
+  // Use std::call_once for thread-safe singleton initialization
+  std::call_once(init_flag_, createInstance);
   return *instance_;
 }
 

--- a/comms/torchcomms/ncclx/TorchCommNCCLXCCA.hpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXCCA.hpp
@@ -4,7 +4,6 @@
 
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDACachingAllocator.h>
-#include <folly/synchronization/CallOnce.h>
 #include <memory>
 #include <mutex>
 #include "comms/torchcomms/ncclx/TorchCommNCCLX.hpp"
@@ -82,7 +81,7 @@ class CachingAllocatorHook {
   }
 
   inline static std::unique_ptr<CachingAllocatorHookImpl> instance_ = nullptr;
-  inline static folly::once_flag init_flag_;
+  inline static std::once_flag init_flag_;
 };
 
 // Global function to be registered as a hook

--- a/comms/torchcomms/rccl/TorchCommRCCLCCA.cpp
+++ b/comms/torchcomms/rccl/TorchCommRCCLCCA.cpp
@@ -14,8 +14,8 @@ void cachingAllocatorHookFn(
 }
 
 CachingAllocatorHookImpl& CachingAllocatorHook::getInstance() {
-  // Use folly::call_once for thread-safe singleton initialization
-  folly::call_once(init_flag_, createInstance);
+  // Use std::call_once for thread-safe singleton initialization
+  std::call_once(init_flag_, createInstance);
   return *instance_;
 }
 

--- a/comms/torchcomms/rccl/TorchCommRCCLCCA.hpp
+++ b/comms/torchcomms/rccl/TorchCommRCCLCCA.hpp
@@ -4,7 +4,6 @@
 
 #include <ATen/hip/HIPContext.h> // @manual
 #include <ATen/hip/impl/HIPCachingAllocatorMasqueradingAsCUDA.h> // @manual
-#include <folly/synchronization/CallOnce.h>
 #include <memory>
 #include <mutex>
 #include "comms/torchcomms/rccl/TorchCommRCCL.hpp"
@@ -74,7 +73,7 @@ class CachingAllocatorHook {
   }
 
   inline static std::unique_ptr<CachingAllocatorHookImpl> instance_ = nullptr;
-  inline static folly::once_flag init_flag_;
+  inline static std::once_flag init_flag_;
 };
 
 // Global function to be registered as a hook

--- a/comms/torchcomms/rcclx/TorchCommRCCLXCCA.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLXCCA.cpp
@@ -14,8 +14,8 @@ void cachingAllocatorHookFn(
 }
 
 CachingAllocatorHookImpl& CachingAllocatorHook::getInstance() {
-  // Use folly::call_once for thread-safe singleton initialization
-  folly::call_once(init_flag_, createInstance);
+  // Use std::call_once for thread-safe singleton initialization
+  std::call_once(init_flag_, createInstance);
   return *instance_;
 }
 

--- a/comms/torchcomms/rcclx/TorchCommRCCLXCCA.hpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLXCCA.hpp
@@ -4,7 +4,6 @@
 
 #include <ATen/hip/HIPContext.h> // @manual
 #include <ATen/hip/impl/HIPCachingAllocatorMasqueradingAsCUDA.h> // @manual
-#include <folly/synchronization/CallOnce.h>
 #include <memory>
 #include <mutex>
 #include "comms/torchcomms/rcclx/TorchCommRCCLX.hpp"
@@ -74,7 +73,7 @@ class CachingAllocatorHook {
   }
 
   inline static std::unique_ptr<CachingAllocatorHookImpl> instance_ = nullptr;
-  inline static folly::once_flag init_flag_;
+  inline static std::once_flag init_flag_;
 };
 
 // Global function to be registered as a hook


### PR DESCRIPTION
Differential Revision: D91347897


