### PR TITLE
Parameterize ncclx build folly

### DIFF
--- a/build_ncclx.sh
+++ b/build_ncclx.sh
@@ -178,9 +178,11 @@ function build_third_party {
         zstd
         conda-forge::zlib
         conda-forge::libopenssl-static
-        conda-forge::folly
         fmt
       )
+      if [[ -n "${NCCL_FEEDSTOCK_BUILD}" ]]; then
+          DEPS+=(conda-forge::folly)
+      fi
       conda install "${DEPS[@]}" --yes
     fi
   fi


### PR DESCRIPTION
Summary: We need to us oss build for folly in docker, parametrizing the folly build so that for feedstock builds it pulls from the env but for docker it builds it

Differential Revision: D91340646


