### PR TITLE
Revert DeviceSpan and P2pNvlTransportDevice members back to const

### DIFF
--- a/comms/pipes/DeviceSpan.cuh
+++ b/comms/pipes/DeviceSpan.cuh
@@ -132,7 +132,7 @@ class DeviceSpan {
   using element_type = T;
   using value_type = typename std::remove_cv<T>::type;
   using size_type = uint32_t;
-  using pointer = T*;
+  using pointer = T* const;
   using const_pointer = T const* const;
   using reference = T&;
   using const_reference = const T&;
@@ -221,7 +221,7 @@ class DeviceSpan {
 
  private:
   pointer data_;
-  size_type size_;
+  size_type const size_;
 };
 
 /**

--- a/comms/pipes/P2pNvlTransportDevice.cuh
+++ b/comms/pipes/P2pNvlTransportDevice.cuh
@@ -889,9 +889,9 @@ class P2pNvlTransportDevice {
   }
 
  private:
-  int myRank_;
-  int peerRank_;
-  P2pNvlTransportOptions options_;
+  const int myRank_{-1};
+  const int peerRank_{-1};
+  const P2pNvlTransportOptions options_;
   LocalState localState_;
   RemoteState remoteState_;
 };


### PR DESCRIPTION
Summary: Removed const by mistake in D88866184, now revert it back

Differential Revision: D91356198


