### PR TITLE
Add test for NVL cache staleness with expandable segments

### DIFF
--- a/comms/ctran/tests/CtranDistSendRecvUT.cc
+++ b/comms/ctran/tests/CtranDistSendRecvUT.cc
@@ -85,6 +85,7 @@ class CtranTestFixture : public NcclxBaseTest, public CtranBaseTest {
    * @param memType Type of memory allocation to use
    * @param oneToOne If true, only test send/recv between rank 0 and the last
    * rank. If false, rank 0 sends to all other ranks.
+   * @param numSegments Number of segments for kCuMemAllocDisjoint (default: 2)
    */
   void runTest(
       size_t offset,
@@ -92,7 +93,8 @@ class CtranTestFixture : public NcclxBaseTest, public CtranBaseTest {
       int numMaxQp,
       int nIter,
       MemAllocType memType,
-      bool oneToOne = false) {
+      bool oneToOne = false,
+      size_t numSegments = 2) {
     const commDataType_t dt = commInt;
 
     // Setup NCCL_CTRAN_IB_MAX_QPS before comm creation so that internal QP
@@ -128,7 +130,7 @@ class CtranTestFixture : public NcclxBaseTest, public CtranBaseTest {
     const int oneRecvRank = numRanks - 1;
     const bool isReceiver = (oneToOne && globalRank == oneRecvRank) ||
         (!oneToOne && globalRank != sendRank);
-    void* base = prepareBuf(bufSize, memType, segments);
+    void* base = prepareBuf(bufSize, memType, segments, numSegments);
     cudaStream_t stream = 0;
     CUDACHECK_TEST(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
 
@@ -263,7 +265,7 @@ class CtranTestFixture : public NcclxBaseTest, public CtranBaseTest {
       EXPECT_EQ(coll["algoName"].asString(), expAlgoName);
     }
 
-    releaseBuf(base, bufSize, memType);
+    releaseBuf(base, bufSize, memType, numSegments);
     CUDACHECK_TEST(cudaStreamDestroy(stream));
   }
 };
@@ -488,6 +490,55 @@ INSTANTIATE_TEST_SUITE_P(
           std::to_string(std::get<1>(info.param)) + "int_" +
           testMemAllocTypeToStr(std::get<2>(info.param));
     });
+
+// Test case for NVL zero-copy path with 3+ segments to expose
+// CTRAN_IPC_INLINE_SEGMENTS limitation. This test demonstrates the bug where
+// Ctran NVL zero-copy path fails when memory is backed by 3+ physical memory
+// allocations (expandable segments). The current implementation is limited to 2
+// segments due to fixed-size CtranIpcDesc.segments array.
+//
+// Expected behavior with current code: FAIL with error:
+// "CTRAN-IPC: tried to export CtranIpcMem backed by too many physical memory
+// allocations."
+//
+// After fix: Test should PASS
+TEST_F(CtranTestFixture, DISABLED_sendRecvCopyEngineMultiSegment) {
+  // Use kCuMemAllocDisjoint with 3 segments to trigger the bug
+  const MemAllocType memType = kCuMemAllocDisjoint;
+  constexpr size_t numSegments = 3;
+  const size_t offset = 0;
+  // Use 6MB buffer = 3 x 2MB segments to ensure 3 physical allocations
+  const ssize_t count = 6 * 1024 * 1024 / sizeof(int); // 6MB in int elements
+  const int numMaxQp = 1;
+
+  EnvRAII env1(NCCL_CTRAN_NVL_SENDRECV_COPY_ENGINE_ENABLE, true);
+  NcclCommRAII comm(globalRank, numRanks, localRank);
+  ASSERT_NE(nullptr, static_cast<ncclComm_t>(comm));
+
+  if (ncclIsCuMemSupported() == false) {
+    GTEST_SKIP() << "CuMem not supported, skip test";
+  }
+
+  if (!comm->dmaBufSupport || !NCCL_CTRAN_IB_DMABUF_ENABLE) {
+    GTEST_SKIP() << "dmabuf is not supported, skip multi-segment disjoint test";
+  }
+
+  regCache->init();
+
+  // This test currently exposes a bug - the runTest will fail with:
+  // "CTRAN ERROR CTRAN-IPC: tried to export CtranIpcMem backed by too many
+  // physical memory allocations."
+  runTest(
+      offset,
+      count,
+      numMaxQp,
+      1 /* nIter */,
+      memType,
+      false /* oneToOne */,
+      numSegments);
+
+  COMMCHECK_TEST(regCache->destroy());
+}
 
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/comms/ctran/tests/CtranNcclTestUtils.h
+++ b/comms/ctran/tests/CtranNcclTestUtils.h
@@ -60,13 +60,22 @@ class CtranNcclTestHelpers : public CtranTestHelpers {
   // - kMemCudaMalloc: Uses cudaMalloc
   // - kMemNcclMemAlloc: Uses ncclMemAlloc
   // - kCuMemAllocDisjoint: Uses commMemAllocDisjoint directly
+  // For kCuMemAllocDisjoint, numSegments specifies how many disjoint physical
+  // segments to allocate (default: 2).
   static void* prepareBuf(
       size_t bufSize,
       MemAllocType memType,
-      std::vector<TestMemSegment>& segments);
+      std::vector<TestMemSegment>& segments,
+      size_t numSegments = 2);
 
   // Release buffer allocated by prepareBuf.
-  static void releaseBuf(void* buf, size_t bufSize, MemAllocType memType);
+  // For kCuMemAllocDisjoint, numSegments must match the value used in
+  // prepareBuf.
+  static void releaseBuf(
+      void* buf,
+      size_t bufSize,
+      MemAllocType memType,
+      size_t numSegments = 2);
 };
 
 } // namespace ctran

--- a/comms/ctran/tests/CtranTestUtils.cc
+++ b/comms/ctran/tests/CtranTestUtils.cc
@@ -71,7 +71,8 @@ commResult_t commMemAllocDisjoint(
     std::vector<size_t>& disjointSegmentSizes,
     std::vector<TestMemSegment>& segments,
     bool setRdmaSupport,
-    std::optional<CUmemAllocationHandleType> handleType) {
+    std::optional<CUmemAllocationHandleType> handleType,
+    size_t reservedVASize) {
   commResult_t ret = commSuccess;
 
   size_t numSegments = disjointSegmentSizes.size();
@@ -119,12 +120,23 @@ commResult_t commMemAllocDisjoint(
   FB_CUCHECK(cuMemGetAllocationGranularity(
       &memGran, &memprop, CU_MEM_ALLOC_GRANULARITY_MINIMUM));
 
-  vaSize = 0;
+  // Calculate mapped size (sum of aligned segment sizes)
+  size_t mappedSize = 0;
   std::vector<size_t> alignedSizes(numSegments);
   for (int i = 0; i < numSegments; i++) {
     alignedSizes[i] = disjointSegmentSizes[i];
     ALIGN_SIZE(alignedSizes[i], memGran);
-    vaSize += alignedSizes[i];
+    mappedSize += alignedSizes[i];
+  }
+
+  // Use reservedVASize if specified, otherwise use mappedSize
+  vaSize = (reservedVASize > 0) ? reservedVASize : mappedSize;
+  ALIGN_SIZE(vaSize, memGran);
+
+  if (vaSize < mappedSize) {
+    LOG(ERROR) << "reservedVASize " << reservedVASize
+               << " is smaller than mapped size " << mappedSize;
+    return ErrorStackTraceUtil::log(commInvalidArgument);
   }
 
   for (int i = 0; i < numSegments; i++) {
@@ -149,18 +161,19 @@ commResult_t commMemAllocDisjoint(
 
     curPtr = ctran::utils::addDevicePtr(curPtr, alignedSizes[i]);
   }
-  // Now allow RW access to the newly mapped memory.
+  // Now allow RW access to the mapped memory only (not the entire reserved VA).
   accessDesc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
   accessDesc.location.id = currentDev;
   accessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
-  FB_CUCHECK(cuMemSetAccess((CUdeviceptr)*ptr, vaSize, &accessDesc, 1));
+  FB_CUCHECK(cuMemSetAccess((CUdeviceptr)*ptr, mappedSize, &accessDesc, 1));
 
   return ret;
 }
 
 commResult_t commMemFreeDisjoint(
     void* ptr,
-    std::vector<size_t>& disjointSegmentSizes) {
+    std::vector<size_t>& disjointSegmentSizes,
+    size_t reservedVASize) {
   commResult_t ret = commSuccess;
   int saveDevice;
   CUmemGenericAllocationHandle handle;
@@ -192,14 +205,18 @@ commResult_t commMemFreeDisjoint(
   FB_CUCHECK(cuMemGetAllocationGranularity(
       &memGran, &memprop, CU_MEM_ALLOC_GRANULARITY_MINIMUM));
 
-  size_t vaSize = 0;
+  size_t mappedSize = 0;
   size_t numSegments = disjointSegmentSizes.size();
   std::vector<size_t> alignedSizes(numSegments);
   for (int i = 0; i < numSegments; i++) {
     alignedSizes[i] = disjointSegmentSizes[i];
     ALIGN_SIZE(alignedSizes[i], memGran);
-    vaSize += alignedSizes[i];
+    mappedSize += alignedSizes[i];
   }
+
+  // Use reservedVASize if specified, otherwise use mappedSize
+  size_t vaSize = (reservedVASize > 0) ? reservedVASize : mappedSize;
+  ALIGN_SIZE(vaSize, memGran);
 
   CUdeviceptr curPtr = (CUdeviceptr)ptr;
   for (int i = 0; i < alignedSizes.size(); i++) {
@@ -217,6 +234,130 @@ commResult_t commMemFreeDisjoint(
   FB_CUCHECK(cuMemAddressFree((CUdeviceptr)ptr, vaSize));
   cudaSetDevice(saveDevice);
   return ret;
+}
+
+commResult_t commMemAllocExpandable(
+    ExpandableTestBuffer* buf,
+    size_t reservedSize,
+    size_t initialMappedSize,
+    bool setRdmaSupport) {
+  buf->reservedSize = reservedSize;
+
+  // Create initial segment sizes vector
+  std::vector<size_t> initialSegments = {initialMappedSize};
+
+  // Call commMemAllocDisjoint with larger reservedVASize
+  FB_COMMCHECK(commMemAllocDisjoint(
+      &buf->base,
+      initialSegments,
+      buf->segments,
+      setRdmaSupport,
+      CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR,
+      reservedSize));
+
+  buf->mappedSize = buf->segments[0].size;
+  buf->segmentSize = buf->mappedSize;
+
+  CUDACHECK_TEST(cudaGetDevice(&buf->cudaDev));
+  CUdevice currentDev;
+  FB_CUCHECK(cuDeviceGet(&currentDev, buf->cudaDev));
+
+  buf->memprop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+  buf->memprop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  buf->memprop.location.id = currentDev;
+  buf->memprop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+  if (setRdmaSupport &&
+      ctran::utils::gpuDirectRdmaWithCudaVmmSupported(
+          currentDev, buf->cudaDev)) {
+    buf->memprop.allocFlags.gpuDirectRDMACapable = 1;
+  }
+
+  buf->accessDesc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  buf->accessDesc.location.id = currentDev;
+  buf->accessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+
+  // Store initial handle via cuMemRetainAllocationHandle
+  CUmemGenericAllocationHandle initialHandle;
+  FB_CUCHECK(cuMemRetainAllocationHandle(&initialHandle, buf->base));
+  buf->handles.push_back(initialHandle);
+
+  return commSuccess;
+}
+
+commResult_t commMemExpandBuffer(
+    ExpandableTestBuffer* buf,
+    size_t newMappedSize) {
+  if (newMappedSize <= buf->mappedSize) {
+    LOG(ERROR) << "newMappedSize " << newMappedSize
+               << " must be greater than current mappedSize "
+               << buf->mappedSize;
+    return commInvalidArgument;
+  }
+  if (newMappedSize > buf->reservedSize) {
+    LOG(ERROR) << "newMappedSize " << newMappedSize << " exceeds reservedSize "
+               << buf->reservedSize;
+    return commInvalidArgument;
+  }
+
+  // Calculate number of new segments needed
+  size_t additionalSize = newMappedSize - buf->mappedSize;
+  size_t numNewSegments =
+      (additionalSize + buf->segmentSize - 1) / buf->segmentSize;
+
+  CUdeviceptr curPtr =
+      ctran::utils::addDevicePtr((CUdeviceptr)buf->base, buf->mappedSize);
+
+  for (size_t i = 0; i < numNewSegments; i++) {
+    CUmemGenericAllocationHandle handle;
+    FB_CUCHECK(cuMemCreate(&handle, buf->segmentSize, &buf->memprop, 0));
+    FB_CUCHECK(cuMemMap(curPtr, buf->segmentSize, 0, handle, 0));
+
+    buf->handles.push_back(handle);
+    buf->segments.emplace_back(
+        reinterpret_cast<void*>(curPtr), buf->segmentSize);
+
+    LOG(INFO) << "commMemExpandBuffer maps new segment ptr "
+              << reinterpret_cast<void*>(curPtr) << " size "
+              << buf->segmentSize;
+
+    curPtr = ctran::utils::addDevicePtr(curPtr, buf->segmentSize);
+  }
+
+  // Set access for new region
+  size_t newRegionSize = numNewSegments * buf->segmentSize;
+  FB_CUCHECK(cuMemSetAccess(
+      ctran::utils::addDevicePtr((CUdeviceptr)buf->base, buf->mappedSize),
+      newRegionSize,
+      &buf->accessDesc,
+      1));
+
+  buf->mappedSize += newRegionSize;
+
+  return commSuccess;
+}
+
+commResult_t commMemFreeExpandable(ExpandableTestBuffer* buf) {
+  if (buf->base == nullptr) {
+    return commSuccess;
+  }
+
+  // Unmap and release all segments
+  CUdeviceptr curPtr = (CUdeviceptr)buf->base;
+  for (size_t i = 0; i < buf->segments.size(); i++) {
+    FB_CUCHECK(cuMemUnmap(curPtr, buf->segments[i].size));
+    curPtr = ctran::utils::addDevicePtr(curPtr, buf->segments[i].size);
+  }
+
+  // Release all handles
+  for (auto& handle : buf->handles) {
+    FB_CUCHECK(cuMemRelease(handle));
+  }
+
+  // Free the reserved VA
+  FB_CUCHECK(cuMemAddressFree((CUdeviceptr)buf->base, buf->reservedSize));
+
+  *buf = ExpandableTestBuffer{};
+  return commSuccess;
 }
 
 // Wrapper for memory allocation in tests with different memory types

--- a/comms/ctran/tests/CtranTestUtils.h
+++ b/comms/ctran/tests/CtranTestUtils.h
@@ -164,16 +164,51 @@ inline consteval commDataType_t getCommDataType() {
   }
 }
 
+// Allocate disjoint memory segments mapped to a single VA range.
+// - reservedVASize: optional, if specified reserves larger VA than mapped
+//                   segments (enables later expansion). If 0 or unspecified,
+//                   reserves exactly sum of segment sizes.
 commResult_t commMemAllocDisjoint(
     void** ptr,
     std::vector<size_t>& disjointSegmentSizes,
     std::vector<TestMemSegment>& segments,
     bool setRdmaSupport = true,
     std::optional<CUmemAllocationHandleType> handleType =
-        CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR);
+        CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR,
+    size_t reservedVASize = 0);
+
 commResult_t commMemFreeDisjoint(
     void* ptr,
-    std::vector<size_t>& disjointSegmentSizes);
+    std::vector<size_t>& disjointSegmentSizes,
+    size_t reservedVASize = 0);
+
+// State for expandable buffer that can grow in-place (simulates PyTorch CCA)
+struct ExpandableTestBuffer {
+  void* base{nullptr};
+  size_t reservedSize{0};
+  size_t mappedSize{0};
+  size_t segmentSize{0};
+  std::vector<CUmemGenericAllocationHandle> handles;
+  std::vector<TestMemSegment> segments;
+  CUmemAllocationProp memprop{};
+  CUmemAccessDesc accessDesc{};
+  int cudaDev{-1};
+};
+
+// Allocate expandable buffer with reserved VA larger than initially mapped
+commResult_t commMemAllocExpandable(
+    ExpandableTestBuffer* buf,
+    size_t reservedSize,
+    size_t initialMappedSize,
+    bool setRdmaSupport = true);
+
+// Expand buffer by mapping more segments into reserved VA (NO unmap/dereg)
+commResult_t commMemExpandBuffer(
+    ExpandableTestBuffer* buf,
+    size_t newMappedSize);
+
+// Free all resources
+commResult_t commMemFreeExpandable(ExpandableTestBuffer* buf);
 
 void* commMemAlloc(
     size_t bufSize,

--- a/comms/ctran/tests/CtranTestUtils.h
+++ b/comms/ctran/tests/CtranTestUtils.h
@@ -178,8 +178,13 @@ commResult_t commMemFreeDisjoint(
 void* commMemAlloc(
     size_t bufSize,
     MemAllocType memType,
-    std::vector<TestMemSegment>& segments);
-void commMemFree(void* buf, size_t bufSize, MemAllocType memType);
+    std::vector<TestMemSegment>& segments,
+    size_t numSegments = 2);
+void commMemFree(
+    void* buf,
+    size_t bufSize,
+    MemAllocType memType,
+    size_t numSegments = 2);
 
 // Bootstrap initialization type
 enum class InitEnvType { MPI, TCP_STORE, STANDALONE };

--- a/comms/ctran/tests/CtranUtUtils.cc
+++ b/comms/ctran/tests/CtranUtUtils.cc
@@ -87,17 +87,19 @@ void CtranDistBaseTest::TearDown() {
 void* CtranBaseTest::prepareBuf(
     size_t bufSize,
     MemAllocType memType,
-    std::vector<TestMemSegment>& segments) {
+    std::vector<TestMemSegment>& segments,
+    size_t numSegments) {
   // Delegate to CtranNcclTestHelpers for all memory types
-  return ncclHelpers.prepareBuf(bufSize, memType, segments);
+  return ncclHelpers.prepareBuf(bufSize, memType, segments, numSegments);
 }
 
 void CtranBaseTest::releaseBuf(
     void* buf,
     size_t bufSize,
-    MemAllocType memType) {
+    MemAllocType memType,
+    size_t numSegments) {
   // Delegate to CtranNcclTestHelpers for all memory types
-  ncclHelpers.releaseBuf(buf, bufSize, memType);
+  ncclHelpers.releaseBuf(buf, bufSize, memType, numSegments);
 }
 
 void CtranBaseTest::allocDevArg(const size_t nbytes, void*& ptr) {

--- a/comms/ctran/tests/CtranUtUtils.h
+++ b/comms/ctran/tests/CtranUtUtils.h
@@ -197,9 +197,14 @@ class CtranBaseTest {
   void* prepareBuf(
       size_t bufSize,
       MemAllocType memType,
-      std::vector<TestMemSegment>& segments);
+      std::vector<TestMemSegment>& segments,
+      size_t numSegments = 2);
 
-  void releaseBuf(void* buf, size_t bufSize, MemAllocType memType);
+  void releaseBuf(
+      void* buf,
+      size_t bufSize,
+      MemAllocType memType,
+      size_t numSegments = 2);
 
   inline size_t pageAligned(size_t nBytes) {
     return ((nBytes + pageSize_ - 1) / pageSize_) * pageSize_;

--- a/comms/ctran/utils/Alloc.h
+++ b/comms/ctran/utils/Alloc.h
@@ -4,6 +4,9 @@
 
 #include <cuda.h>
 #include <folly/ScopeGuard.h>
+#include <folly/String.h>
+#include <string>
+#include <vector>
 
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/utils/CudaWrap.h"
@@ -13,6 +16,28 @@
 #include "comms/utils/logger/alloc.h"
 
 namespace ctran::utils {
+
+inline std::string cuMemHandleTypeStr(CUmemAllocationHandleType handleType) {
+#if defined(__HIP_PLATFORM_AMD__)
+  // cuMemHandleTypeStr should not be called for AMD
+  return "UNKNOWN";
+#else
+  if (handleType == CU_MEM_HANDLE_TYPE_NONE) {
+    return "NONE";
+  }
+  std::vector<std::string> types;
+  if (handleType & CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR) {
+    types.push_back("POSIX_FD");
+  }
+  if (handleType & CU_MEM_HANDLE_TYPE_FABRIC) {
+    types.push_back("FABRIC");
+  }
+  if (types.empty()) {
+    return "UNKNOWN";
+  }
+  return folly::join("|", types);
+#endif
+}
 
 CUmemAllocationHandleType getCuMemAllocHandleType();
 

--- a/comms/ctran/utils/CtranIpc.cc
+++ b/comms/ctran/utils/CtranIpc.cc
@@ -247,6 +247,16 @@ inline commResult_t ctran::utils::CtranIpcMem::tryLoadCuMem(
     const void* ptr,
     std::size_t len,
     bool& supported) {
+  // Handle type decision in ctran:
+  // - getCuMemAllocHandleType(): Queries system-supported handle types. Used
+  // when
+  //   allocating ctran internal buffers (ALLOC mode). Always includes POSIX.
+  // - getCuMemExportHandleType(): Determines the export handle type based on
+  // CVAR
+  //   enable flag (NCCL_CTRAN_NVL_FABRIC_ENABLE) and the allocation's handle
+  //   type. Used in LOAD mode to validate that user-provided memory can be
+  //   exported.
+
   // temp linear loop through physical allocations, could be faster to get from
   // pytorch level
   size_t cur_offset = 0;
@@ -266,23 +276,44 @@ inline commResult_t ctran::utils::CtranIpcMem::tryLoadCuMem(
     CUmemAllocationProp prop;
     FB_CUCHECK(
         cuMemGetAllocationPropertiesFromHandle(&prop, allocHandles_.back()));
-    // cuMemHandleType_ is set to requestedHandleTypes during registration in
-    // load Mode.
+
+    // Set cuMemHandleType_ from first segment's allocation properties
     if (cuMemHandleType_ == CU_MEM_HANDLE_TYPE_NONE) {
       cuMemHandleType_ = ctran::utils::getCuMemHandleTypeFromProp(prop);
     }
-    if (prop.allocFlags.gpuDirectRDMACapable != 1 ||
-        ctran::utils::getCuMemHandleTypeFromProp(prop) != cuMemHandleType_) {
+
+    // Validate allocation is supported for IPC export. Reject if:
+    // 1. NONE handle type (no shareable handle)
+    // 2. ctran-incompatible type (e.g., FABRIC-only when FABRIC disabled)
+    // 3. no gpuDirectRDMACapable
+    // 4. mixed handle types across segments
+    CUmemAllocationHandleType segmentHandleType =
+        ctran::utils::getCuMemHandleTypeFromProp(prop);
+    CUmemAllocationHandleType supportedExportType =
+        getCuMemExportHandleType(cuMemHandleType_);
+    bool isUnsupportedType = (cuMemHandleType_ == CU_MEM_HANDLE_TYPE_NONE) ||
+        ((cuMemHandleType_ & supportedExportType) == 0) ||
+        (prop.allocFlags.gpuDirectRDMACapable != 1) ||
+        (segmentHandleType != cuMemHandleType_);
+
+    if (isUnsupportedType) {
       CLOGF(
           ERR,
-          "CTRAN-IPC: [pbase {:x} range {}] associated with [ptr {} len {}] does not have required property: "
-          "gpuDirectRDMACapable = {}, requestedHandleTypes = {}",
+          "CTRAN-IPC: [pbase {:x} range {}] associated with [ptr {} len {}] "
+          "has unsupported allocation properties for IPC export: "
+          "handleType = {} ({}), supportedExportType = {} ({}), gpuDirectRDMACapable = {}, "
+          "segmentHandleType = {} ({})",
           cur_pbase,
           cur_range,
           (void*)ptr,
           len,
+          cuMemHandleTypeStr(cuMemHandleType_),
+          static_cast<int>(cuMemHandleType_),
+          cuMemHandleTypeStr(supportedExportType),
+          static_cast<int>(supportedExportType),
           prop.allocFlags.gpuDirectRDMACapable,
-          ctran::utils::getCuMemHandleTypeFromProp(prop));
+          cuMemHandleTypeStr(segmentHandleType),
+          static_cast<int>(segmentHandleType));
       return commInvalidUsage;
     }
 

--- a/comms/ctran/utils/CtranIpc.cc
+++ b/comms/ctran/utils/CtranIpc.cc
@@ -87,10 +87,13 @@ static inline CUmemAllocationHandleType getCuMemExportHandleType(
 }
 
 commResult_t ctran::utils::CtranIpcMem::ipcExport(CtranIpcDesc& ipcDesc) {
+  // FIXME: we need either fallback to IB or support numSegments > 2 case via
+  // variable length control msg
   if (allocHandles_.size() > CTRAN_IPC_INLINE_SEGMENTS) {
     CLOGF(
         ERR,
-        "CTRAN-IPC: tried to export CtranIpcMem backed by too many physical memory allocations.");
+        "CTRAN-IPC: tried to export CtranIpcMem backed by too many physical memory allocations. [{}]",
+        this->toString());
     return commInternalError;
   }
 

--- a/comms/ctran/utils/tests/IpcUT.cc
+++ b/comms/ctran/utils/tests/IpcUT.cc
@@ -1,0 +1,115 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include "comms/ctran/tests/CtranTestUtils.h"
+#include "comms/ctran/utils/Alloc.h"
+#include "comms/ctran/utils/CtranIpc.h"
+#include "comms/ctran/utils/CudaWrap.h"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/commSpecs.h"
+
+using namespace ctran::utils;
+
+class IpcUT : public ::testing::Test {
+ public:
+  void SetUp() override {
+    ncclCvarInit();
+    COMMCHECK_TEST(commCudaLibraryInit());
+    CUDACHECK_TEST(cudaSetDevice(0));
+  }
+
+  void TearDown() override {}
+
+ protected:
+  const char* dummyDesc_ = "IpcUT";
+};
+
+// Test Case 1: tryLoad should reject memory allocated with
+// CU_MEM_HANDLE_TYPE_NONE Currently this test is expected to FAIL because
+// tryLoad does not validate this
+TEST_F(IpcUT, TryLoadCuMemRejectsNoneHandleType) {
+  if (!ctran::utils::getCuMemSysSupported()) {
+    GTEST_SKIP() << "CuMem not supported, skipping test";
+  }
+
+  constexpr size_t size = 2 * 1024 * 1024; // 2MB (minimum granularity)
+  std::vector<size_t> segmentSizes = {size};
+  std::vector<TestMemSegment> segments;
+  void* ptr = nullptr;
+
+  auto result = ctran::commMemAllocDisjoint(
+      &ptr, segmentSizes, segments, true, CU_MEM_HANDLE_TYPE_NONE);
+  if (result != commSuccess || ptr == nullptr) {
+    GTEST_SKIP() << "Failed to allocate cuMem with NONE handle type";
+  }
+
+  // Create CtranIpcMem in LOAD mode
+  auto ipcMem = std::make_unique<CtranIpcMem>(0, dummyDesc_);
+
+  // tryLoad should fail for memory with no shareable handle type
+  bool supported = false;
+  (void)ipcMem->tryLoad(ptr, size, supported, false);
+
+  // Expected: tryLoad should return error or set supported=false
+  // because memory with NONE handle type cannot be exported
+  EXPECT_FALSE(supported)
+      << "tryLoad should reject memory with CU_MEM_HANDLE_TYPE_NONE";
+
+  ctran::commMemFreeDisjoint(ptr, segmentSizes);
+}
+
+// Test Case 2: tryLoad should reject FABRIC-only memory when FABRIC is disabled
+// Currently this test is expected to FAIL because tryLoad does not validate
+// this
+TEST_F(IpcUT, TryLoadCuMemRejectsFabricOnlyWhenFabricDisabled) {
+#if CUDART_VERSION < 12040
+  GTEST_SKIP() << "CUDA < 12.04, FABRIC handle type not available";
+#else
+  if (!ctran::utils::getCuMemSysSupported()) {
+    GTEST_SKIP() << "CuMem not supported, skipping test";
+  }
+
+  // Skip if system doesn't support FABRIC - allocation would silently downgrade
+  // to NONE (see D90902516 for details on CUDA's silent downgrade behavior)
+  {
+    EnvRAII fabricDisabled(NCCL_CTRAN_NVL_FABRIC_ENABLE, true);
+    CUmemAllocationHandleType systemSupported =
+        ctran::utils::getCuMemAllocHandleType();
+    if ((systemSupported & CU_MEM_HANDLE_TYPE_FABRIC) == 0) {
+      GTEST_SKIP()
+          << "System does not support FABRIC handle type, skipping test";
+    }
+  }
+
+  // Disable FABRIC support in ctran
+  EnvRAII fabricDisabled(NCCL_CTRAN_NVL_FABRIC_ENABLE, false);
+
+  constexpr size_t size = 2 * 1024 * 1024; // 2MB
+  std::vector<size_t> segmentSizes = {size};
+  std::vector<TestMemSegment> segments;
+  void* ptr = nullptr;
+
+  // Allocate with FABRIC-only handle type
+  auto result = ctran::commMemAllocDisjoint(
+      &ptr, segmentSizes, segments, true, CU_MEM_HANDLE_TYPE_FABRIC);
+  if (result != commSuccess || ptr == nullptr) {
+    GTEST_SKIP() << "Failed to allocate cuMem with FABRIC-only handle type";
+  }
+
+  // Create CtranIpcMem in LOAD mode
+  auto ipcMem = std::make_unique<CtranIpcMem>(0, dummyDesc_);
+
+  // tryLoad should fail because ctran would try to export as POSIX
+  // but the allocation only supports FABRIC
+  bool supported = false;
+  (void)ipcMem->tryLoad(ptr, size, supported, false);
+
+  // Expected: tryLoad should return error or set supported=false
+  // because FABRIC-only memory cannot be exported as POSIX
+  EXPECT_FALSE(supported)
+      << "tryLoad should reject FABRIC-only memory when FABRIC export is disabled";
+
+  ctran::commMemFreeDisjoint(ptr, segmentSizes);
+#endif
+}


### PR DESCRIPTION
Summary:
Add NvlCacheExpandableSegmentStaleness test that reproduces the NVL IPC cache staleness bug with PyTorch-like expandable segments. The test simulates the bug scenario where:

- A buffer is allocated with reserved VA larger than initially mapped
- The receiver caches the initial (smaller) mapping
- The sender expands the buffer in-place (NO deregistration)
- The receiver's cache returns stale mapping

Differential Revision: D91344591


