### PR TITLE
Simplify device assertion in init()

### DIFF
--- a/comms/torchcomms/nccl/TorchCommNCCL.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCL.cpp
@@ -60,8 +60,7 @@ void TorchCommNCCL::init(
     const std::string& name,
     const CommOptions& options) {
   TORCH_INTERNAL_ASSERT(
-      device.is_cuda() || device.index() == -1,
-      "TorchCommNCCL requires a CUDA device or unspecified device index");
+      device.is_cuda(), "TorchCommNCCL requires a CUDA device");
 
   // Initialize private members
   device_ = device;

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -89,8 +89,7 @@ void TorchCommNCCLX::init(
     const std::string& name,
     const CommOptions& options) {
   TORCH_INTERNAL_ASSERT(
-      device.is_cuda() || device.index() == -1,
-      "TorchCommNCCLX requires a CUDA device or unspecified device index");
+      device.is_cuda(), "TorchCommNCCLX requires a CUDA device");
 
   // Initialize private members
   device_ = device;


### PR DESCRIPTION
Summary:
Remove the check for unspecified device index (device.index() == -1) from
the TORCH_INTERNAL_ASSERT in init(). The assertion now simply requires
device.is_cuda() to be true.

Differential Revision: D91401414


