### PR TITLE
Workaround for graph capture failure with implicit launch order

### DIFF
--- a/comms/rcclx/develop/src/enqueue.cc
+++ b/comms/rcclx/develop/src/enqueue.cc
@@ -1999,7 +1999,11 @@ ncclResult_t ncclLaunchFinish(struct ncclComm* comm) {
     }
 
     if (capturing || planner->numStreams != 1 || ncclParamLaunchOrderImplicit()) {
-      CUDACHECK(cudaEventRecord(finishedEvent, launchStream));
+      if (!capturing){
+        // Only create the event if we're not capturing. The event recording on launchStream 
+        // creates an unjoinedfork when deviceStream waits on it during capture
+        CUDACHECK(cudaEventRecord(finishedEvent, launchStream));
+      }
       // deviceStream waits on userStream[0]
       NCCLCHECK(ncclStrongStreamAcquiredWorkStream(planner->capturingGraph, &comm->sharedRes->deviceStream, /*concurrent=*/false, &deviceStream));
 


### PR DESCRIPTION
Summary:
The recent nov.13 drop (D90291225) from upstream changed graph capture behavior. Especially, the fork-join edges is not handled correctly between the user stream and the nccl internal stream (used for kernel launch ordering control).

This diff provides a workaround to come back to previous behavior before the drop.
But need to follow up with AMD for more long-term solutions.

Differential Revision: D91408041


