### PR TITLE
Use dynamic_cast with proper null checks for PREMUL_SUM supplement

### DIFF
--- a/comms/torchcomms/BackendWrapper.cpp
+++ b/comms/torchcomms/BackendWrapper.cpp
@@ -9,11 +9,18 @@ namespace {
 
 // Extract the scaling factor from NCCL's PREMUL_SUM operation supplement.
 // NCCLPreMulSumSupplement stores either a tensor or double scaling factor
-// that is applied before summation. The reinterpret_cast is safe because
-// PREMUL_SUM operations always have a NCCLPreMulSumSupplement attached.
+// that is applied before summation.
 PreMulSumFactorT getPreMulSumFactor(const c10d::ReduceOp& op) {
+  TORCH_CHECK(
+      op.supplement_ != nullptr,
+      "PREMUL_SUM operation requires a supplement, but none was provided");
+
   const auto* preMulSupplement =
-      reinterpret_cast<c10d::NCCLPreMulSumSupplement*>(op.supplement_.get());
+      dynamic_cast<const c10d::NCCLPreMulSumSupplement*>(op.supplement_.get());
+  TORCH_CHECK(
+      preMulSupplement != nullptr,
+      "PREMUL_SUM operation supplement must be of type NCCLPreMulSumSupplement");
+
   if (preMulSupplement->tensor_factor.defined()) {
     return preMulSupplement->tensor_factor;
   }


### PR DESCRIPTION
Summary:
Replace unsafe reinterpret_cast with dynamic_cast when extracting the
NCCLPreMulSumSupplement from ReduceOp. Add TORCH_CHECK assertions to
verify the supplement is not null and is of the expected type. This
provides better runtime diagnostics when PREMUL_SUM operations are
used incorrectly.

Differential Revision: D91410706
