### PR TITLE
Improve RdmaMemory safety and documentation

### DIFF
--- a/comms/torchcomms/transport/RdmaTransport.cpp
+++ b/comms/torchcomms/transport/RdmaTransport.cpp
@@ -44,8 +44,13 @@ RdmaMemory::RdmaMemory(RdmaMemory&& other) noexcept
       cudaDev_(other.cudaDev_),
       regHdl_(other.regHdl_),
       remoteKey_(std::move(other.remoteKey_)) {
+  // Properly invalidate the moved-from object to prevent double-free
+  // and ensure the object is in a valid but unspecified state
+  other.buf_ = nullptr;
+  other.len_ = 0;
+  other.cudaDev_ = -1;
   other.regHdl_ = nullptr;
-  other.remoteKey_.clear();
+  // Note: remoteKey_ is already moved, leaving other.remoteKey_ empty
 }
 
 RdmaMemory::~RdmaMemory() noexcept {


### PR DESCRIPTION
Summary:
Multiple safety improvements for RdmaMemory class:
- Fix move constructor to properly invalidate moved-from objects by
  clearing buf_, len_, and cudaDev_ in addition to regHdl_. This
  prevents potential double-free or use-after-move bugs.
- Add overflow-safe bounds checking in View constructor to prevent
  integer overflow attacks.
- Add bounds validation in createView/createMutableView when creating
  views from arbitrary pointers, throwing std::out_of_range if the
  pointer is not within the registered memory region.
- Add comprehensive documentation for View and MutableView classes
  warning about lifetime safety requirements.
- Add isParentValid() helper method for debugging purposes.

Differential Revision: D91410705
