### PR TITLE
Remove launch_bounds of SendRecv p2p kernel: 5%-10% faster across message sizes

### DIFF
--- a/comms/ctran/algos/SendRecv/SendRecvP2p.cu
+++ b/comms/ctran/algos/SendRecv/SendRecvP2p.cu
@@ -34,7 +34,7 @@ __device__ __forceinline__ void recvImpl(
   }
 }
 
-__global__ void __launch_bounds__(1024, 1) ncclKernelSendRecvP2p(
+__global__ void ncclKernelSendRecvP2p(
     int* flag,
     CtranAlgoDeviceState* devState, // TODO: this is not needed for now, but
                                     // maybe needed for fault-tolerance


### PR DESCRIPTION
Summary:
Launch Bounds is a compiler hint used to optimize SM occupancy by restricting register numbers: details see [CUDA programming guide](https://docs.nvidia.com/cuda/cuda-programming-guide/05-appendices/cpp-language-extensions.html#launch-bounds). 

We set it to `maxThreadsPerBlock` in launch bounds to 1024 before but we actually only use 512 threads when launch SendRecv kernels - this can lead to worse performance because registers per thread is reduced to ensure more threads can fit in a SM. By removing launch bounds (or set `maxThreadsPerBlock=512`), latency reduced by 5%-10% across message sizes because there are more registers per thread to use.


See perf data in [sheet](https://docs.google.com/spreadsheets/d/1vYMIuoq4mz8qXSJkCTblyML7nRcw9-JntpKsJpzVC_8/edit?fbclid=IwY2xjawORxKNleHRuA2FlbQIxMQBicmlkETFhZFRvQTRtUVBuV3FqTDNnc3J0YwZhcHBfaWQBMAABHqBM71rhFC_k-HNVwyl-etiCK_H3_8rHhCwlOdXUTnazn3ZY_VdNsYQJ-NGw_aem_rS1ByeU2jq3_uaXEJ7wi8g&gid=148852661#gid=148852661).

Differential Revision: D90606584


