### PR TITLE
Refactor ChunkState API to use snake_case and require ThreadGroup

### DIFF
--- a/comms/pipes/P2pNvlTransportDevice.cuh
+++ b/comms/pipes/P2pNvlTransportDevice.cuh
@@ -187,7 +187,7 @@ struct P2pNvlTransportOptions {
  *        └───────┬───────┘
  *                │
  *                │ send() waits for READY_TO_SEND, copies data,
- *                │ signals readyToRecv(stepId)
+ *                │ signals ready_to_recv(stepId)
  *                ▼
  *        ┌───────────────┐
  *    ┌─▶ │ READY_TO_RECV │
@@ -195,7 +195,7 @@ struct P2pNvlTransportOptions {
  *    │   └───────┬───────┘
  *    │           │
  *    │           │ recv() waits for READY_TO_RECV, copies data,
- *    │           │ signals readyToSend()
+ *    │           │ signals ready_to_send()
  *    │           ▼
  *    │   ┌───────────────┐
  *    │   │ READY_TO_SEND │
@@ -203,7 +203,7 @@ struct P2pNvlTransportOptions {
  *    │   └───────┬───────┘
  *    │           │
  *    │           │ send() waits for READY_TO_SEND, copies data,
- *    │           │ signals readyToRecv(stepId)
+ *    │           │ signals ready_to_recv(stepId)
  *    │           │
  *    └───────────┘
  *
@@ -359,7 +359,7 @@ class P2pNvlTransportDevice {
 
         ChunkState& chunkState = sendStates[stateOffset + chunkIdx];
 
-        chunkState.waitReadyToSend(group);
+        chunkState.wait_ready_to_send(group);
 
         memcpy_vectorized(
             sendBuffer + dataBufferOffset + chunkOffset,
@@ -367,7 +367,7 @@ class P2pNvlTransportDevice {
             chunkBytes,
             group);
 
-        chunkState.readyToRecv(group, stepId, call_index);
+        chunkState.ready_to_recv(group, stepId, call_index);
       });
     }
 #endif
@@ -460,7 +460,7 @@ class P2pNvlTransportDevice {
 
         ChunkState& chunkState = recvStates[stateOffset + chunkIdx];
 
-        chunkState.waitReadyToRecv(group, stepId, call_index);
+        chunkState.wait_ready_to_recv(group, stepId, call_index);
 
         memcpy_vectorized(
             dst + stepOffset + chunkOffset,
@@ -468,7 +468,7 @@ class P2pNvlTransportDevice {
             chunkBytes,
             group);
 
-        chunkState.readyToSend(group);
+        chunkState.ready_to_send(group);
       });
     }
 #endif
@@ -481,7 +481,7 @@ class P2pNvlTransportDevice {
    * Thread-group 0 writes metadata (nbytes, offset, has_more) to the
    * receiver's first ChunkState before the data transfer begins.
    * The metadata is communicated through ChunkState fields and becomes
-   * visible to the receiver when readyToRecv is signaled (via release-store).
+   * visible to the receiver when ready_to_recv is signaled (via release-store).
    *
    * INPUTS:
    * @param group ThreadGroup for cooperative processing (all threads
@@ -506,19 +506,19 @@ class P2pNvlTransportDevice {
     ChunkState* const sendStates = remoteState_.stateBuffer.data();
 
     // same as send(), wait for previous recv_one() to complete
-    sendStates[kMetadataChunkIndex].waitReadyToSend(group);
+    sendStates[kMetadataChunkIndex].wait_ready_to_send(group);
 
     // Thread-group 0 writes metadata to receiver's chunk kMetadataChunkIndex
     // This happens before send() starts, so receiver can read it
     if (group.group_id == 0) {
-      sendStates[kMetadataChunkIndex].writeMetaData(
+      sendStates[kMetadataChunkIndex].write_metadata(
           group, nbytes, offset_in_output, has_more);
     }
 
     // empty data transfer, just do the signaling
     if (nbytes == 0) {
       if (group.group_id == 0) {
-        sendStates[kMetadataChunkIndex].readyToRecv(
+        sendStates[kMetadataChunkIndex].ready_to_recv(
             group, kMetadataChunkIndex, call_index);
       }
       return;
@@ -568,16 +568,16 @@ class P2pNvlTransportDevice {
 #ifdef __CUDA_ARCH__
     ChunkState* const recvStates = localState_.stateBuffer.data();
 
-    // ALL thread-groups wait for chunk kMetadataChunkIndex's readyToRecv to get
-    // metadata Step kMetadataChunkIndex is used for the metadata exchange
-    recvStates[kMetadataChunkIndex].waitReadyToRecv(
+    // ALL thread-groups wait for chunk kMetadataChunkIndex's ready_to_recv to
+    // get metadata Step kMetadataChunkIndex is used for the metadata exchange
+    recvStates[kMetadataChunkIndex].wait_ready_to_recv(
         group, kMetadataChunkIndex, call_index);
 
     // ALL threads read metadata from chunk kMetadataChunkIndex
     // (all threads need nbytes_val to call recv())
     std::size_t nbytes_val, offset_val;
     bool has_more_val;
-    recvStates[kMetadataChunkIndex].readMetaData(
+    recvStates[kMetadataChunkIndex].read_metadata(
         group, nbytes_val, offset_val, has_more_val);
 
     // Calculate destination pointer using offset
@@ -595,14 +595,14 @@ class P2pNvlTransportDevice {
     // empty data transfer, just do the signaling
     if (nbytes_val == 0) {
       if (group.group_id == 0) {
-        recvStates[kMetadataChunkIndex].readyToSend(group);
+        recvStates[kMetadataChunkIndex].ready_to_send(group);
       }
       return;
     }
 
     // Now call regular recv() to receive the data
     // recv() will handle all the pipelining and synchronization
-    // and will signal readyToSend() for ChunkState[kMetadataChunkIndex] after
+    // and will signal ready_to_send() for ChunkState[kMetadataChunkIndex] after
     // completion
     recv(group, dst, nbytes_val, call_index);
 #endif

--- a/comms/pipes/benchmarks/P2pSyncBench.cc
+++ b/comms/pipes/benchmarks/P2pSyncBench.cc
@@ -27,8 +27,8 @@ namespace comms::pipes::benchmark {
  * Benchmark P2P synchronization using ChunkState
  *
  * Sender (GPU 0) and Receiver (GPU 1) alternate signaling:
- *   - Sender: waitReadyToSend() -> readyToRecv(step)
- *   - Receiver: waitReadyToRecv(step) -> readyToSend()
+ *   - Sender: wait_ready_to_send() -> ready_to_recv(step)
+ *   - Receiver: wait_ready_to_recv(step) -> ready_to_send()
  *
  * The ChunkState array is allocated on Receiver's GPU and accessed by Sender
  * via P2P peer access.

--- a/comms/pipes/benchmarks/P2pSyncBench.cu
+++ b/comms/pipes/benchmarks/P2pSyncBench.cu
@@ -16,12 +16,14 @@ __global__ void p2pSyncKernel(
   ChunkState* myChunkState = &chunkStates[groupIdx];
 
   for (int step = 1; step <= nSteps; step++) {
+    // call_index=0 since this benchmark doesn't use multi-call pattern
+    constexpr uint32_t call_index = 0;
     if (isSender) {
-      myChunkState->waitReadyToSend(group);
-      myChunkState->readyToRecv(group, step);
+      myChunkState->wait_ready_to_send(group);
+      myChunkState->ready_to_recv(group, step, call_index);
     } else {
-      myChunkState->waitReadyToRecv(group, step);
-      myChunkState->readyToSend(group);
+      myChunkState->wait_ready_to_recv(group, step, call_index);
+      myChunkState->ready_to_send(group);
     }
   }
 }

--- a/comms/pipes/benchmarks/P2pSyncBench.cuh
+++ b/comms/pipes/benchmarks/P2pSyncBench.cuh
@@ -11,8 +11,8 @@ namespace comms::pipes::benchmark {
  * p2pSyncKernel - Benchmark kernel for P2P synchronization using ChunkState
  *
  * Sender and receiver alternate signaling through ChunkState:
- *   - Sender: waitReadyToSend() -> readyToRecv(step)
- *   - Receiver: waitReadyToRecv(step) -> readyToSend()
+ *   - Sender: wait_ready_to_send() -> ready_to_recv(step)
+ *   - Receiver: wait_ready_to_recv(step) -> ready_to_send()
  *
  * @param chunkStates Array of ChunkState objects (one per block/group)
  * @param isSender True for sender kernel, false for receiver


### PR DESCRIPTION
Summary:
Simplify the ChunkState API by:
1. Renaming methods from camelCase to snake_case for consistency with the rest
   of the pipes codebase (e.g., waitReadyToSend -> wait_ready_to_send)
2. Requiring ThreadGroup parameter for all public methods, removing the
   single-threaded overloads

The ThreadGroup abstraction ensures proper synchronization:
- For signals (ready_to_recv, ready_to_send): sync before leader writes
- For waits (wait_ready_to_send, wait_ready_to_recv): all threads poll for
  better latency

This is a breaking change to the ChunkState API but the only callers are within
the pipes library (P2pNvlTransportDevice, P2pSyncBench).

Differential Revision: D91412047


