### PR TITLE
Add timeout support to blocking wait methods

### DIFF
--- a/comms/pipes/Timeout.cuh
+++ b/comms/pipes/Timeout.cuh
@@ -1,0 +1,212 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+#include <cstdio>
+
+namespace comms::pipes {
+
+// Forward declaration - full definition in ThreadGroup.cuh
+struct ThreadGroup;
+
+/**
+ * Timeout - Stateful timeout for GPU kernel wait operations
+ *
+ * A timeout object that captures the start time once (via start()) and can
+ * then be checked multiple times throughout the kernel's lifetime. This avoids
+ * calling clock64() at the start of every wait loop.
+ *
+ * Usage:
+ *   // Host side - create timeout config using makeTimeout()
+ *   Timeout timeout = makeTimeout(1000, deviceId);  // 1 second timeout
+ *
+ *   // Kernel side - start the timeout once at kernel entry
+ *   timeout.start();
+ *
+ *   // Use in wait loops with ThreadGroup - only leader checks
+ *   while (!ready) {
+ *     timeout.check(group);  // Leader checks and traps if exceeded
+ *   }
+ *
+ * Default constructor creates a "no timeout" config (infinite wait) with
+ * zero overhead - check() is a no-op when timeout is disabled.
+ *
+ * Memory layout: Compact 16-byte struct (2x uint64_t) for efficient GPU usage.
+ */
+struct Timeout {
+  uint64_t timeout_cycles; // Timeout duration in cycles (0 = infinite wait)
+  uint64_t deadline_cycles; // Absolute deadline (set by start())
+
+  /**
+   * Default constructor - creates "no timeout" config (infinite wait)
+   */
+  __host__ __device__ Timeout() : timeout_cycles(0), deadline_cycles(0) {}
+
+  /**
+   * Constructor with pre-computed timeout in cycles
+   *
+   * Use makeTimeout() from TimeoutUtils.h instead of calling this directly.
+   * That helper queries the GPU clock rate and computes timeout_cycles for you.
+   *
+   * @param cycles Total timeout duration in GPU clock cycles
+   */
+  __host__ __device__ explicit Timeout(uint64_t cycles)
+      : timeout_cycles(cycles), deadline_cycles(0) {}
+
+  /**
+   * Check if timeout is enabled
+   */
+  __host__ __device__ bool isEnabled() const {
+    return timeout_cycles > 0;
+  }
+
+  /**
+   * Start the timeout timer
+   *
+   * Call this once at the beginning of the kernel (or at least before any
+   * wait operations that use this timeout). Captures the current GPU cycle
+   * count and computes the absolute deadline for efficient checking.
+   *
+   * IMPORTANT: All threads that will call check() must call start() first.
+   * Since Timeout is passed by value, each thread has its own copy and
+   * captures its own deadline. For ThreadGroup-based check(group), only
+   * the leader checks, so only the leader's deadline_cycles is used.
+   *
+   * Only captures the clock if timeout is enabled (timeout_cycles > 0).
+   * Traps if called more than once (programming error) - detected by
+   * deadline_cycles already being non-zero.
+   */
+  __device__ __forceinline__ void start() {
+#ifdef __CUDA_ARCH__
+    if (timeout_cycles > 0) {
+      if (deadline_cycles != 0) {
+        printf(
+            "CUDA TIMEOUT ERROR: Timeout::start() called twice "
+            "(deadline_cycles=%llu)\n",
+            static_cast<unsigned long long>(deadline_cycles));
+        __trap(); // Double-start is a programming error
+      }
+      deadline_cycles = clock64() + timeout_cycles;
+    }
+#endif
+  }
+
+  /**
+   * Check if timeout has expired (single-threaded version)
+   *
+   * Compares current clock against the precomputed deadline.
+   *
+   * IMPORTANT: The calling thread must have called start() first to compute
+   * its deadline_cycles.
+   *
+   * Use this version for single-threaded timeout checking. For multi-threaded
+   * use with ThreadGroup, prefer checkExpired(const ThreadGroup&) which only
+   * has the leader check for better efficiency.
+   *
+   * @return true if timeout has expired, false otherwise (or if disabled)
+   */
+  __device__ __forceinline__ bool checkExpired() const {
+#ifdef __CUDA_ARCH__
+    if (timeout_cycles > 0) {
+      return clock64() > deadline_cycles;
+    }
+#endif
+    return false;
+  }
+
+  /**
+   * Check if timeout has expired (ThreadGroup version)
+   *
+   * Only the group leader calls clock64() and checks the deadline.
+   * Returns the result to all threads via warp shuffle or shared memory
+   * depending on the ThreadGroup scope.
+   *
+   * This is more efficient than all threads checking: O(1) clock64() calls
+   * per group instead of O(N).
+   *
+   * @param group ThreadGroup for cooperative processing
+   * @return true if timeout has expired, false otherwise (or if disabled)
+   */
+  __device__ __forceinline__ bool checkExpired(const ThreadGroup& group) const;
+};
+
+} // namespace comms::pipes
+
+// Include ThreadGroup for the inline implementation of check(ThreadGroup&)
+// This is placed after the namespace to avoid circular dependencies
+#include "comms/pipes/ThreadGroup.cuh"
+
+namespace comms::pipes {
+
+__device__ __forceinline__ bool Timeout::checkExpired(
+    const ThreadGroup& group) const {
+#ifdef __CUDA_ARCH__
+  if (timeout_cycles > 0 && group.is_leader()) {
+    return clock64() > deadline_cycles;
+  }
+#else
+  (void)group;
+#endif
+  return false;
+}
+
+/**
+ * TIMEOUT_TRAP_IF_EXPIRED - Check timeout and trap with error message if
+ * expired
+ *
+ * This macro consolidates the common pattern of checking for timeout
+ * expiration, printing a context-specific error message, and calling __trap().
+ *
+ * Usage:
+ *   while (condition) {
+ *     TIMEOUT_TRAP_IF_EXPIRED(timeout, group,
+ *         "MyClass::my_method waiting for X (current=%d)", current_value);
+ *   }
+ *
+ * @param timeout The Timeout object
+ * @param group The ThreadGroup for cooperative checking
+ * @param fmt Printf-style format string (without newline)
+ * @param ... Format arguments
+ */
+#ifdef __CUDA_ARCH__
+#define TIMEOUT_TRAP_IF_EXPIRED(timeout, group, fmt, ...)     \
+  do {                                                        \
+    if ((timeout).checkExpired(group)) {                      \
+      printf("CUDA TIMEOUT ERROR: " fmt "\n", ##__VA_ARGS__); \
+      __trap();                                               \
+    }                                                         \
+  } while (0)
+#else
+#define TIMEOUT_TRAP_IF_EXPIRED(timeout, group, fmt, ...) \
+  do {                                                    \
+    (void)(timeout);                                      \
+    (void)(group);                                        \
+  } while (0)
+#endif
+
+/**
+ * TIMEOUT_TRAP_IF_EXPIRED_SINGLE - Single-threaded version (no ThreadGroup)
+ *
+ * Same as TIMEOUT_TRAP_IF_EXPIRED but for single-threaded timeout checking.
+ *
+ * @param timeout The Timeout object
+ * @param fmt Printf-style format string (without newline)
+ * @param ... Format arguments
+ */
+#ifdef __CUDA_ARCH__
+#define TIMEOUT_TRAP_IF_EXPIRED_SINGLE(timeout, fmt, ...)     \
+  do {                                                        \
+    if ((timeout).checkExpired()) {                           \
+      printf("CUDA TIMEOUT ERROR: " fmt "\n", ##__VA_ARGS__); \
+      __trap();                                               \
+    }                                                         \
+  } while (0)
+#else
+#define TIMEOUT_TRAP_IF_EXPIRED_SINGLE(timeout, fmt, ...) \
+  do {                                                    \
+    (void)(timeout);                                      \
+  } while (0)
+#endif
+
+} // namespace comms::pipes

--- a/comms/pipes/TimeoutUtils.h
+++ b/comms/pipes/TimeoutUtils.h
@@ -1,0 +1,59 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <cstdint>
+#include <stdexcept>
+#include "comms/pipes/Timeout.cuh"
+
+namespace comms::pipes {
+
+/**
+ * getGpuCyclesPerMs - Get the GPU clock rate in cycles per millisecond
+ *
+ * Query the GPU's shader clock rate for use with timeout-enabled wait methods.
+ *
+ * @param device CUDA device ID (default: 0)
+ * @return Clock cycles per millisecond
+ * @throws std::runtime_error if cudaDeviceGetAttribute fails
+ */
+inline uint64_t getGpuCyclesPerMs(int device = 0) {
+  int clock_rate_khz;
+  cudaError_t err =
+      cudaDeviceGetAttribute(&clock_rate_khz, cudaDevAttrClockRate, device);
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        "Failed to get GPU clock rate: " +
+        std::string(cudaGetErrorString(err)));
+  }
+  // cudaDevAttrClockRate returns kHz, which equals cycles per millisecond
+  return static_cast<uint64_t>(clock_rate_khz);
+}
+
+/**
+ * makeTimeout - Create a Timeout configuration for the specified device
+ *
+ * Convenience function that queries the GPU clock rate and creates a
+ * Timeout object ready to pass to kernels. Precomputes timeout_cycles
+ * on the host side for efficient GPU-side checking.
+ *
+ * @param timeout_ms Timeout in milliseconds (0 = infinite wait)
+ * @param device CUDA device ID (default: 0)
+ * @return Timeout configuration with precomputed timeout_cycles
+ * @throws std::runtime_error if cudaDeviceGetAttribute fails
+ *
+ * Example usage:
+ *   auto timeout = makeTimeout(1000, deviceId);  // 1 second timeout
+ *   myKernel<<<...>>>(timeout, ...);
+ */
+inline Timeout makeTimeout(uint32_t timeout_ms, int device = 0) {
+  if (timeout_ms == 0) {
+    return Timeout(); // No timeout
+  }
+  uint64_t cycles_per_ms = getGpuCyclesPerMs(device);
+  uint64_t timeout_cycles = static_cast<uint64_t>(timeout_ms) * cycles_per_ms;
+  return Timeout(timeout_cycles);
+}
+
+} // namespace comms::pipes

--- a/comms/pipes/benchmarks/BenchmarkKernel.cu
+++ b/comms/pipes/benchmarks/BenchmarkKernel.cu
@@ -13,18 +13,22 @@ __global__ void p2pSend(
     P2pNvlTransportDevice p2p,
     void* srcBuff,
     std::size_t nBytes,
-    SyncScope groupScope) {
+    SyncScope groupScope,
+    Timeout timeout) {
+  timeout.start();
   auto group = make_thread_group(groupScope);
-  p2p.send(group, srcBuff, nBytes);
+  p2p.send(group, srcBuff, nBytes, 0, timeout);
 }
 
 __global__ void p2pRecv(
     P2pNvlTransportDevice p2p,
     void* dstBuff,
     std::size_t nBytes,
-    SyncScope groupScope) {
+    SyncScope groupScope,
+    Timeout timeout) {
+  timeout.start();
   auto group = make_thread_group(groupScope);
-  p2p.recv(group, dstBuff, nBytes);
+  p2p.recv(group, dstBuff, nBytes, 0, timeout);
 }
 
 __global__ void p2pSendTimed(
@@ -80,15 +84,17 @@ __global__ void p2pBidirectional(
     void* sendBuff,
     void* recvBuff,
     std::size_t nBytes,
-    SyncScope groupScope) {
+    SyncScope groupScope,
+    Timeout timeout) {
+  timeout.start();
   auto group = make_thread_group(groupScope);
 
   // Partition groups into 2: half for send, half for recv
   auto [partition_id, subgroup] = group.partition_interleaved(2);
   if (partition_id == 0) {
-    p2p.send(subgroup, sendBuff, nBytes);
+    p2p.send(subgroup, sendBuff, nBytes, 0, timeout);
   } else {
-    p2p.recv(subgroup, recvBuff, nBytes);
+    p2p.recv(subgroup, recvBuff, nBytes, 0, timeout);
   }
 }
 

--- a/comms/pipes/benchmarks/BenchmarkKernel.cuh
+++ b/comms/pipes/benchmarks/BenchmarkKernel.cuh
@@ -31,14 +31,16 @@ __global__ void p2pSend(
     P2pNvlTransportDevice p2p,
     void* srcBuff,
     std::size_t nBytes,
-    SyncScope groupScope = SyncScope::WARP);
+    SyncScope groupScope = SyncScope::WARP,
+    Timeout timeout = Timeout());
 
 // Recv kernel
 __global__ void p2pRecv(
     P2pNvlTransportDevice p2p,
     void* dstBuff,
     std::size_t nBytes,
-    SyncScope groupScope = SyncScope::WARP);
+    SyncScope groupScope = SyncScope::WARP,
+    Timeout timeout = Timeout());
 
 // Timed versions that export GPU-side clock64() timing stats
 __global__ void p2pSendTimed(
@@ -61,7 +63,8 @@ __global__ void p2pBidirectional(
     void* sendBuff,
     void* recvBuff,
     std::size_t nBytes,
-    SyncScope groupScope = SyncScope::WARP);
+    SyncScope groupScope = SyncScope::WARP,
+    Timeout timeout = Timeout());
 
 // Signal benchmark kernel - ping-pong signaling between two peers
 __global__ void p2pSignalBenchKernel(

--- a/comms/pipes/tests/TimeoutTrapTest.cc
+++ b/comms/pipes/tests/TimeoutTrapTest.cc
@@ -1,0 +1,122 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/tests/TimeoutTrapTest.cuh"
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+namespace comms::pipes::test {
+
+class TimeoutTrapTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    int deviceCount;
+    cudaError_t err = cudaGetDeviceCount(&deviceCount);
+    if (err != cudaSuccess || deviceCount == 0) {
+      GTEST_SKIP() << "No CUDA devices available";
+    }
+    err = cudaSetDevice(0);
+    ASSERT_EQ(err, cudaSuccess) << "Failed to set CUDA device";
+  }
+
+  void TearDown() override {
+    // Reset device to clear any trap state.
+    // These calls are intentionally unchecked - device may be in corrupted
+    // state.
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaDeviceReset();
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaSetDevice(0);
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaGetLastError(); // Clear any pending errors
+  }
+
+  bool isExpectedTrapError(cudaError_t err) {
+    // Different CUDA versions/drivers report traps differently
+    return err == cudaErrorIllegalInstruction || err == cudaErrorAssert ||
+        err == cudaErrorLaunchFailure;
+  }
+};
+
+// Test that ChunkState::wait_ready_to_recv times out and traps
+TEST_F(TimeoutTrapTest, ChunkStateWaitReadyToRecvTimeout) {
+  // Use a short timeout (10ms) - should trigger quickly
+  launchChunkStateTimeoutKernel(0, 10);
+
+  cudaError_t err = cudaGetLastError();
+  EXPECT_TRUE(isExpectedTrapError(err))
+      << "Expected trap error, got: " << cudaGetErrorString(err);
+}
+
+// Test that SignalState::wait_until times out and traps
+TEST_F(TimeoutTrapTest, SignalStateWaitUntilTimeout) {
+  // Use a short timeout (10ms) - should trigger quickly
+  launchSignalStateTimeoutKernel(0, 10);
+
+  cudaError_t err = cudaGetLastError();
+  EXPECT_TRUE(isExpectedTrapError(err))
+      << "Expected trap error, got: " << cudaGetErrorString(err);
+}
+
+// Test that a kernel calling start() and check() completes successfully
+// when the timeout has not expired (positive test case)
+TEST_F(TimeoutTrapTest, NoTimeoutWhenKernelCompletes) {
+  // Use a long timeout (1000ms) - kernel calls start() then check() once
+  // and completes immediately without trapping
+  launchNoTimeoutKernel(0, 1000);
+
+  cudaError_t err = cudaGetLastError();
+  EXPECT_EQ(err, cudaSuccess)
+      << "Expected success, got: " << cudaGetErrorString(err);
+}
+
+// Test that ChunkState with ThreadGroup-based timeout checking works
+TEST_F(TimeoutTrapTest, ChunkStateThreadGroupTimeout) {
+  // Use a short timeout (10ms) - should trigger quickly
+  // This tests the leader-only check(ThreadGroup&) path
+  launchChunkStateThreadGroupTimeoutKernel(0, 10);
+
+  cudaError_t err = cudaGetLastError();
+  EXPECT_TRUE(isExpectedTrapError(err))
+      << "Expected trap error, got: " << cudaGetErrorString(err);
+}
+
+// Test that SignalState with ThreadGroup-based timeout checking works
+TEST_F(TimeoutTrapTest, SignalStateThreadGroupTimeout) {
+  // Use a short timeout (10ms) - should trigger quickly
+  // This tests the leader-only check(ThreadGroup&) path
+  launchSignalStateThreadGroupTimeoutKernel(0, 10);
+
+  cudaError_t err = cudaGetLastError();
+  EXPECT_TRUE(isExpectedTrapError(err))
+      << "Expected trap error, got: " << cudaGetErrorString(err);
+}
+
+// Test that calling start() twice traps (programming error detection)
+TEST_F(TimeoutTrapTest, DoubleStartTraps) {
+  // Calling start() twice is a programming error and should trap
+  launchDoubleStartKernel(0, 1000);
+
+  cudaError_t err = cudaGetLastError();
+  EXPECT_TRUE(isExpectedTrapError(err))
+      << "Expected trap error from double-start, got: "
+      << cudaGetErrorString(err);
+}
+
+// Test that when a kernel traps, subsequent kernels on the same stream don't
+// run
+TEST_F(TimeoutTrapTest, TrapPreventsSubsequentKernelsOnStream) {
+  // Launch two kernels on the same stream - first will trap, second should not
+  // run
+  bool secondKernelDidNotRun = launchMultipleKernelsOnStreamTest(0, 10);
+
+  cudaError_t err = cudaGetLastError();
+  EXPECT_TRUE(isExpectedTrapError(err))
+      << "Expected trap error from first kernel, got: "
+      << cudaGetErrorString(err);
+
+  // Verify the second kernel did not execute
+  EXPECT_TRUE(secondKernelDidNotRun)
+      << "Second kernel should NOT have run after first kernel trapped";
+}
+
+} // namespace comms::pipes::test

--- a/comms/pipes/tests/TimeoutTrapTest.cu
+++ b/comms/pipes/tests/TimeoutTrapTest.cu
@@ -1,0 +1,287 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/tests/TimeoutTrapTest.cuh"
+
+#include <cuda_runtime.h>
+#include <cstdio>
+#include <stdexcept>
+#include "comms/pipes/ChunkState.cuh"
+#include "comms/pipes/SignalState.cuh"
+#include "comms/pipes/ThreadGroup.cuh"
+#include "comms/pipes/TimeoutUtils.h"
+
+namespace comms::pipes::test {
+
+// CUDA error checking macro for test setup code
+// Throws on failure so tests fail clearly
+#define CUDA_CHECK(call)                                                   \
+  do {                                                                     \
+    cudaError_t err = call;                                                \
+    if (err != cudaSuccess) {                                              \
+      throw std::runtime_error(                                            \
+          std::string("CUDA error: ") + cudaGetErrorString(err) + " at " + \
+          __FILE__ + ":" + std::to_string(__LINE__));                      \
+    }                                                                      \
+  } while (0)
+
+// Kernel that waits on ChunkState that will never become ready
+// This should trigger a timeout and call __trap()
+__global__ void chunkStateTimeoutKernel(ChunkState* state, Timeout timeout) {
+  // Start the timeout timer - captures clock64() once at kernel entry
+  timeout.start();
+  auto group = make_thread_group(SyncScope::WARP);
+
+  // State is initialized to READY_TO_SEND (-1), so waiting for stepId=0
+  // will spin forever unless timeout triggers
+  state->wait_ready_to_recv(group, 0, 0, timeout);
+}
+
+// Kernel that waits on SignalState that will never be signaled
+// This should trigger a timeout and call __trap()
+// Uses the single-threaded API which creates a ThreadGroup internally
+__global__ void signalStateTimeoutKernel(SignalState* state, Timeout timeout) {
+  // Start the timeout timer - captures clock64() once at kernel entry
+  timeout.start();
+
+  // State is initialized to 0, so waiting for value 1 will spin forever
+  // unless timeout triggers
+  // Uses simple API - ThreadGroup is created internally for timeout checking
+  state->wait_until(CmpOp::CMP_EQ, 1, timeout);
+}
+
+// Kernel that starts timeout, checks once, and completes successfully
+// This is a positive test case that exercises the full timeout path
+// without actually timing out
+__global__ void noTimeoutKernel(Timeout timeout) {
+  // Start the timeout timer
+  timeout.start();
+
+  // Check timeout once - should not be expired since we're well within timeout
+  if (timeout.checkExpired()) {
+    printf("CUDA TIMEOUT ERROR: Unexpected timeout in noTimeoutKernel\n");
+    __trap();
+  }
+}
+
+void launchChunkStateTimeoutKernel(int device, uint32_t timeout_ms) {
+  CUDA_CHECK(cudaSetDevice(device));
+
+  // Allocate ChunkState on device
+  ChunkState* d_state;
+  CUDA_CHECK(cudaMalloc(&d_state, sizeof(ChunkState)));
+
+  // Initialize to READY_TO_SEND (default constructor state)
+  ChunkState h_state;
+  CUDA_CHECK(cudaMemcpy(
+      d_state, &h_state, sizeof(ChunkState), cudaMemcpyHostToDevice));
+
+  // Create timeout configuration
+  Timeout timeout = makeTimeout(timeout_ms, device);
+
+  // Launch kernel with a full warp - should trap due to timeout
+  // Intentionally unchecked - we expect the kernel to trap
+  // NOLINTNEXTLINE(facebook-cuda-safe-kernel-call-check)
+  chunkStateTimeoutKernel<<<1, 32>>>(d_state, timeout);
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaDeviceSynchronize();
+
+  // Don't free - device will be reset by test
+}
+
+void launchSignalStateTimeoutKernel(int device, uint32_t timeout_ms) {
+  CUDA_CHECK(cudaSetDevice(device));
+
+  // Allocate SignalState on device
+  SignalState* d_state;
+  CUDA_CHECK(cudaMalloc(&d_state, sizeof(SignalState)));
+
+  // Initialize to 0 (default constructor state)
+  SignalState h_state;
+  CUDA_CHECK(cudaMemcpy(
+      d_state, &h_state, sizeof(SignalState), cudaMemcpyHostToDevice));
+
+  // Create timeout configuration
+  Timeout timeout = makeTimeout(timeout_ms, device);
+
+  // Launch kernel with a full warp - should trap due to timeout
+  // Intentionally unchecked - we expect the kernel to trap
+  // NOLINTNEXTLINE(facebook-cuda-safe-kernel-call-check)
+  signalStateTimeoutKernel<<<1, 32>>>(d_state, timeout);
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaDeviceSynchronize();
+
+  // Don't free - device will be reset by test
+}
+
+void launchNoTimeoutKernel(int device, uint32_t timeout_ms) {
+  CUDA_CHECK(cudaSetDevice(device));
+
+  // Create timeout configuration
+  Timeout timeout = makeTimeout(timeout_ms, device);
+
+  // Launch kernel - should complete normally
+  noTimeoutKernel<<<1, 1>>>(timeout);
+  CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+// Kernel that uses ThreadGroup-based timeout checking for ChunkState
+// This tests the new check(ThreadGroup&) method with leader-only checking
+__global__ void chunkStateThreadGroupTimeoutKernel(
+    ChunkState* state,
+    Timeout timeout) {
+  timeout.start();
+  auto group = make_thread_group(SyncScope::WARP);
+
+  // State is initialized to READY_TO_SEND (-1), so waiting for stepId=0
+  // will spin forever unless timeout triggers
+  // Uses ThreadGroup-based wait which calls timeout.check(group)
+  state->wait_ready_to_recv(group, 0, 0, timeout);
+}
+
+// Kernel that uses ThreadGroup-based timeout checking for SignalState
+__global__ void signalStateThreadGroupTimeoutKernel(
+    SignalState* state,
+    Timeout timeout) {
+  timeout.start();
+  auto group = make_thread_group(SyncScope::WARP);
+
+  // State is initialized to 0, so waiting for value 1 will spin forever
+  // Uses ThreadGroup-based wait which calls timeout.check(group)
+  state->wait_until(group, CmpOp::CMP_EQ, 1, timeout);
+}
+
+// Kernel that calls start() twice - should trap on the second call
+__global__ void doubleStartKernel(Timeout timeout) {
+  timeout.start(); // First start - OK
+  timeout.start(); // Second start - should trap!
+}
+
+// Simple kernel that sets a flag to indicate it ran
+__global__ void setFlagKernel(int* flag) {
+  *flag = 1;
+}
+
+// Kernel that will timeout and trap, used to test stream behavior
+__global__ void timeoutTrapKernel(Timeout timeout) {
+  timeout.start();
+  // Spin until timeout expires, then trap
+  while (true) {
+    if (timeout.checkExpired()) {
+      printf("CUDA TIMEOUT ERROR: timeoutTrapKernel timed out\n");
+      __trap();
+    }
+  }
+}
+
+void launchChunkStateThreadGroupTimeoutKernel(int device, uint32_t timeout_ms) {
+  CUDA_CHECK(cudaSetDevice(device));
+
+  // Allocate ChunkState on device
+  ChunkState* d_state;
+  CUDA_CHECK(cudaMalloc(&d_state, sizeof(ChunkState)));
+
+  // Initialize to READY_TO_SEND (default constructor state)
+  ChunkState h_state;
+  CUDA_CHECK(cudaMemcpy(
+      d_state, &h_state, sizeof(ChunkState), cudaMemcpyHostToDevice));
+
+  // Create timeout configuration
+  Timeout timeout = makeTimeout(timeout_ms, device);
+
+  // Launch kernel with a full warp - should trap due to timeout
+  // Leader-only checking means only thread 0 calls clock64()
+  // Intentionally unchecked - we expect the kernel to trap
+  // NOLINTNEXTLINE(facebook-cuda-safe-kernel-call-check)
+  chunkStateThreadGroupTimeoutKernel<<<1, 32>>>(d_state, timeout);
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaDeviceSynchronize();
+
+  // Don't free - device will be reset by test
+}
+
+void launchSignalStateThreadGroupTimeoutKernel(
+    int device,
+    uint32_t timeout_ms) {
+  CUDA_CHECK(cudaSetDevice(device));
+
+  // Allocate SignalState on device
+  SignalState* d_state;
+  CUDA_CHECK(cudaMalloc(&d_state, sizeof(SignalState)));
+
+  // Initialize to 0 (default constructor state)
+  SignalState h_state;
+  CUDA_CHECK(cudaMemcpy(
+      d_state, &h_state, sizeof(SignalState), cudaMemcpyHostToDevice));
+
+  // Create timeout configuration
+  Timeout timeout = makeTimeout(timeout_ms, device);
+
+  // Launch kernel with a full warp - should trap due to timeout
+  // Leader-only checking means only thread 0 calls clock64()
+  // Intentionally unchecked - we expect the kernel to trap
+  // NOLINTNEXTLINE(facebook-cuda-safe-kernel-call-check)
+  signalStateThreadGroupTimeoutKernel<<<1, 32>>>(d_state, timeout);
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaDeviceSynchronize();
+
+  // Don't free - device will be reset by test
+}
+
+void launchDoubleStartKernel(int device, uint32_t timeout_ms) {
+  CUDA_CHECK(cudaSetDevice(device));
+
+  // Create timeout configuration
+  Timeout timeout = makeTimeout(timeout_ms, device);
+
+  // Launch kernel - should trap on second start() call
+  // Intentionally unchecked - we expect the kernel to trap
+  // NOLINTNEXTLINE(facebook-cuda-safe-kernel-call-check)
+  doubleStartKernel<<<1, 1>>>(timeout);
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaDeviceSynchronize();
+}
+
+bool launchMultipleKernelsOnStreamTest(int device, uint32_t timeout_ms) {
+  CUDA_CHECK(cudaSetDevice(device));
+
+  // Create a stream for ordered execution
+  cudaStream_t stream;
+  CUDA_CHECK(cudaStreamCreate(&stream));
+
+  // Allocate a flag on device to track if second kernel ran
+  int* d_flag;
+  CUDA_CHECK(cudaMalloc(&d_flag, sizeof(int)));
+  int zero = 0;
+  CUDA_CHECK(cudaMemcpy(d_flag, &zero, sizeof(int), cudaMemcpyHostToDevice));
+
+  // Create timeout configuration
+  Timeout timeout = makeTimeout(timeout_ms, device);
+
+  // Launch first kernel that will trap due to timeout
+  // Intentionally unchecked - we expect the kernel to trap
+  // NOLINTNEXTLINE(facebook-cuda-safe-kernel-call-check)
+  timeoutTrapKernel<<<1, 1, 0, stream>>>(timeout);
+
+  // Launch second kernel on the same stream - should NOT run if first traps
+  // Intentionally unchecked - previous kernel will trap
+  // NOLINTNEXTLINE(facebook-cuda-safe-kernel-call-check)
+  setFlagKernel<<<1, 1, 0, stream>>>(d_flag);
+
+  // Synchronize - this will return an error due to the trap
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaDeviceSynchronize();
+
+  // Copy flag back to check if second kernel ran
+  // Note: After a trap, the context is corrupted, so this may fail
+  // but we try anyway to verify the second kernel didn't run
+  int h_flag = -1; // Use -1 as sentinel
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaError_t copyErr =
+      cudaMemcpy(&h_flag, d_flag, sizeof(int), cudaMemcpyDeviceToHost);
+
+  // If copy failed or flag is still 0, second kernel did not run
+  // Return true if second kernel did NOT run (expected behavior)
+  return (copyErr != cudaSuccess || h_flag == 0);
+}
+
+} // namespace comms::pipes::test

--- a/comms/pipes/tests/TimeoutTrapTest.cuh
+++ b/comms/pipes/tests/TimeoutTrapTest.cuh
@@ -1,0 +1,31 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+
+namespace comms::pipes::test {
+
+// Test kernel that spins forever, should trigger timeout
+void launchChunkStateTimeoutKernel(int device, uint32_t timeout_ms);
+
+// Test kernel that spins forever on SignalState, should trigger timeout
+void launchSignalStateTimeoutKernel(int device, uint32_t timeout_ms);
+
+// Test kernel that completes before timeout (should NOT trap)
+void launchNoTimeoutKernel(int device, uint32_t timeout_ms);
+
+// Test kernel that uses ThreadGroup-based timeout checking for ChunkState
+void launchChunkStateThreadGroupTimeoutKernel(int device, uint32_t timeout_ms);
+
+// Test kernel that uses ThreadGroup-based timeout checking for SignalState
+void launchSignalStateThreadGroupTimeoutKernel(int device, uint32_t timeout_ms);
+
+// Test kernel that calls start() twice (should trap on double-start)
+void launchDoubleStartKernel(int device, uint32_t timeout_ms);
+
+// Test that when a kernel traps, subsequent kernels on the same stream don't
+// run Returns true if second kernel did NOT run (expected behavior)
+bool launchMultipleKernelsOnStreamTest(int device, uint32_t timeout_ms);
+
+} // namespace comms::pipes::test


### PR DESCRIPTION
Summary:
Add optional timeout support to ChunkState and SignalState wait methods
that can block indefinitely on P2P NVLink I/O operations. When a timeout
occurs, the kernel aborts via __trap().

Key changes:
- Add TimeoutUtils.cuh with Timeout struct for efficient GPU-side timeout
  checking using clock64() and precomputed deadline cycles
- Add TimeoutUtils.h with makeTimeout() host helper that queries GPU clock
  rate and converts milliseconds to cycles
- Add optional Timeout parameter to ChunkState::wait_ready_to_send(),
  wait_ready_to_recv() and SignalState::wait_until()
- Propagate Timeout parameters through P2pNvlTransportDevice methods:
  send(), recv(), send_one(), recv_one(), send_multiple(), recv_multiple()
- Add TimeoutTrapTest with tests verifying timeout behavior

Design decisions:
- Timeout unit is milliseconds (intuitive for debugging)
- Default timeout_ms=0 means infinite wait (backward compatible)
- start() must be called once at kernel entry to capture reference time
- check() is called in polling loops with leader-only optimization for
  ThreadGroup-based waits

Differential Revision: D91412046
