### PR TITLE
Add host wrapper for AllToAllv collective

### DIFF
--- a/comms/pipes/collectives/AllToAllv.cu
+++ b/comms/pipes/collectives/AllToAllv.cu
@@ -1,0 +1,71 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/collectives/AllToAllv.h"
+
+#include "comms/common/CudaWrap.h"
+#include "comms/pipes/TimeoutUtils.h"
+#include "comms/pipes/tests/Checks.h"
+
+namespace comms::pipes {
+
+/**
+ * AllToAllv kernel.
+ * Wrapper kernel that calls the device all_to_allv function.
+ */
+__global__ void allToAllvKernel(
+    void* recvbuff_d,
+    const void* sendbuff_d,
+    int my_rank_id,
+    DeviceSpan<Transport> transports_per_rank,
+    DeviceSpan<ChunkInfo> send_chunk_infos,
+    DeviceSpan<ChunkInfo> recv_chunk_infos,
+    Timeout timeout) {
+  timeout.start();
+  all_to_allv(
+      recvbuff_d,
+      sendbuff_d,
+      my_rank_id,
+      transports_per_rank,
+      send_chunk_infos,
+      recv_chunk_infos,
+      timeout);
+}
+
+void all_to_allv(
+    void* recvbuff_d,
+    const void* sendbuff_d,
+    int my_rank_id,
+    DeviceSpan<Transport> transports_per_rank,
+    DeviceSpan<ChunkInfo> send_chunk_infos,
+    DeviceSpan<ChunkInfo> recv_chunk_infos,
+    std::chrono::milliseconds timeout,
+    cudaStream_t stream,
+    int num_blocks,
+    int num_threads,
+    std::optional<dim3> cluster_dim) {
+  // Get current device for timeout creation
+  int device = 0;
+  PIPES_CUDA_CHECK(cudaGetDevice(&device));
+  Timeout timeout_config =
+      makeTimeout(static_cast<uint32_t>(timeout.count()), device);
+
+  void* args[] = {
+      &recvbuff_d,
+      &sendbuff_d,
+      &my_rank_id,
+      &transports_per_rank,
+      &send_chunk_infos,
+      &recv_chunk_infos,
+      &timeout_config};
+
+  comms::common::launchKernel(
+      (void*)allToAllvKernel,
+      dim3(num_blocks),
+      dim3(num_threads),
+      args,
+      stream,
+      cluster_dim);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/AllToAllv.cuh
+++ b/comms/pipes/collectives/AllToAllv.cuh
@@ -112,9 +112,6 @@ __device__ __forceinline__ void all_to_allv(
     // all arguments below will eventually come from communicator
 ) {
 #ifdef __CUDA_ARCH__
-  // Start the timeout timer - must be called once before any wait operations
-  timeout.start();
-
   auto group = make_warp_group();
   const auto nranks = transports_per_rank.size();
   assert(nranks == send_chunk_infos.size());

--- a/comms/pipes/collectives/AllToAllv.h
+++ b/comms/pipes/collectives/AllToAllv.h
@@ -1,0 +1,51 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <chrono>
+#include <optional>
+
+#include "comms/pipes/collectives/AllToAllv.cuh"
+
+namespace comms::pipes {
+
+/**
+ * Host wrapper for AllToAllv collective communication.
+ *
+ * Performs variable-sized all-to-all data exchange among multiple ranks.
+ * Each rank sends a potentially different amount of data to every other rank,
+ * and receives a potentially different amount of data from every other rank.
+ *
+ * This is a host function that launches the AllToAllv kernel. All device
+ * pointers and DeviceSpans must already be allocated and populated on the GPU.
+ *
+ * @param recvbuff_d Device pointer to receive buffer
+ * @param sendbuff_d Device pointer to send buffer (const)
+ * @param my_rank_id Current rank ID
+ * @param transports_per_rank DeviceSpan of Transport objects (self for my_rank,
+ *                            P2P for others)
+ * @param send_chunk_infos DeviceSpan of ChunkInfo for send operations
+ * @param recv_chunk_infos DeviceSpan of ChunkInfo for receive operations
+ * @param timeout Timeout duration (0ms = no timeout, default)
+ * @param stream CUDA stream for kernel execution
+ * @param num_blocks Number of thread blocks to launch (default: 4)
+ * @param num_threads Number of threads per block (default: 256)
+ * @param cluster_dim Cluster dimensions for spread cluster launch.
+ *                    Default: dim3{4, 1, 1} for better load balancing.
+ *                    Set to std::nullopt to use standard kernel launch.
+ */
+void all_to_allv(
+    void* recvbuff_d,
+    const void* sendbuff_d,
+    int my_rank_id,
+    DeviceSpan<Transport> transports_per_rank,
+    DeviceSpan<ChunkInfo> send_chunk_infos,
+    DeviceSpan<ChunkInfo> recv_chunk_infos,
+    std::chrono::milliseconds timeout = std::chrono::milliseconds{0},
+    cudaStream_t stream = nullptr,
+    int num_blocks = 4,
+    int num_threads = 256,
+    std::optional<dim3> cluster_dim = dim3{4, 1, 1});
+
+} // namespace comms::pipes

--- a/comms/pipes/tests/AllToAllvTest.cu
+++ b/comms/pipes/tests/AllToAllvTest.cu
@@ -14,7 +14,9 @@ __global__ void testAllToAllvKernel(
     int nranks,
     DeviceSpan<Transport> transports,
     DeviceSpan<ChunkInfo> send_chunk_infos,
-    DeviceSpan<ChunkInfo> recv_chunk_infos) {
+    DeviceSpan<ChunkInfo> recv_chunk_infos,
+    Timeout timeout) {
+  timeout.start();
   // Call all_to_allv - it will perform actual data transfers
   all_to_allv(
       recvbuff_d,
@@ -22,7 +24,8 @@ __global__ void testAllToAllvKernel(
       my_rank_id,
       transports,
       send_chunk_infos,
-      recv_chunk_infos);
+      recv_chunk_infos,
+      timeout);
 }
 
 void testAllToAllv(
@@ -35,6 +38,7 @@ void testAllToAllv(
     DeviceSpan<ChunkInfo> recv_chunk_infos,
     int numBlocks,
     int blockSize) {
+  Timeout timeout; // Default no timeout
   testAllToAllvKernel<<<numBlocks, blockSize>>>(
       recvbuff_d,
       sendbuff_d,
@@ -42,7 +46,8 @@ void testAllToAllv(
       nranks,
       transports,
       send_chunk_infos,
-      recv_chunk_infos);
+      recv_chunk_infos,
+      timeout);
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 


### PR DESCRIPTION
Summary:
Add a host-side wrapper function `launch_all_to_allv()` for the AllToAllv
collective, similar to the dispatch host wrapper. This eliminates the need
for a separate kernel wrapper in the benchmark.

Key changes:
- Add AllToAllv.h with host wrapper declaration
- Add AllToAllv.cu with kernel and host wrapper implementation
- Support optional cluster launch with spread scheduling for better
  load balancing across GPCs
- Update AllToAllvBenchmark to use the new host wrapper instead of
  directly launching the kernel
- Fix AllToAllvTest.cu to pass Timeout parameter to device function

The host wrapper is named `launch_all_to_allv()` to distinguish it from
the device function `all_to_allv()`.

Differential Revision: D91440692
