### PR TITLE
move alltoallv to collectives

### DIFF
--- a/comms/pipes/benchmarks/BenchmarkKernel.cu
+++ b/comms/pipes/benchmarks/BenchmarkKernel.cu
@@ -118,20 +118,4 @@ __global__ void p2pSignalBenchKernel(
   }
 }
 
-__global__ void allToAllvKernel(
-    void* recvbuff_d,
-    const void* sendbuff_d,
-    int my_rank_id,
-    DeviceSpan<Transport> transports_per_rank,
-    DeviceSpan<ChunkInfo> send_chunk_infos,
-    DeviceSpan<ChunkInfo> recv_chunk_infos) {
-  allToAllv(
-      recvbuff_d,
-      sendbuff_d,
-      my_rank_id,
-      transports_per_rank,
-      send_chunk_infos,
-      recv_chunk_infos);
-}
-
 } // namespace comms::pipes::benchmark

--- a/comms/pipes/benchmarks/BenchmarkKernel.cuh
+++ b/comms/pipes/benchmarks/BenchmarkKernel.cuh
@@ -4,7 +4,6 @@
 
 #include <cuda_runtime.h>
 
-#include "comms/pipes/AllToAllv.cuh"
 #include "comms/pipes/P2pNvlTransportDevice.cuh"
 #include "comms/pipes/ThreadGroup.cuh"
 
@@ -71,17 +70,5 @@ __global__ void p2pSignalBenchKernel(
     P2pNvlTransportDevice p2p,
     int nSteps,
     SyncScope groupScope = SyncScope::WARP);
-
-/**
- * AllToAllv benchmark kernel.
- * All ranks participate in all-to-all communication with variable chunk sizes.
- */
-__global__ void allToAllvKernel(
-    void* recvbuff_d,
-    const void* sendbuff_d,
-    int my_rank_id,
-    DeviceSpan<Transport> transports_per_rank,
-    DeviceSpan<ChunkInfo> send_chunk_infos,
-    DeviceSpan<ChunkInfo> recv_chunk_infos);
 
 } // namespace comms::pipes::benchmark

--- a/comms/pipes/collectives/AllToAllv.cuh
+++ b/comms/pipes/collectives/AllToAllv.cuh
@@ -13,7 +13,7 @@ namespace comms::pipes {
 
 namespace {
 /**
- * Debug helper to print allToAllv communication information.
+ * Debug helper to print all_to_allv communication information.
  * Automatically detects self-copy vs peer communication based on my_rank ==
  * peer_rank.
  */
@@ -55,7 +55,7 @@ __device__ __forceinline__ void printPerPeerOperation(
 } // namespace
 
 /**
- * Chunk metadata for allToAllv operation.
+ * Chunk metadata for all_to_allv operation.
  * Describes a contiguous chunk of data to send or receive for a specific peer.
  */
 struct ChunkInfo {
@@ -100,7 +100,7 @@ struct ChunkInfo {
  *   my_rank_id
  * - Max 8 ranks supported (stack-allocated weights)
  */
-__device__ __forceinline__ void allToAllv(
+__device__ __forceinline__ void all_to_allv(
     void* recvbuff_d,
     const void* sendbuff_d,
     int my_rank_id,

--- a/comms/pipes/collectives/benchmarks/AllToAllvBenchmark.cc
+++ b/comms/pipes/collectives/benchmarks/AllToAllvBenchmark.cc
@@ -6,8 +6,8 @@
 
 #include "comms/common/CudaWrap.h"
 #include "comms/pipes/MultiPeerNvlTransport.h"
-#include "comms/pipes/benchmarks/BenchmarkKernel.cuh"
 #include "comms/pipes/benchmarks/BenchmarkMacros.h"
+#include "comms/pipes/collectives/benchmarks/CollectiveBenchmark.cuh"
 #include "comms/testinfra/mpi/MpiBootstrap.h"
 #include "comms/testinfra/mpi/MpiTestUtils.h"
 #include "comms/utils/CudaRAII.h"
@@ -309,7 +309,7 @@ class AllToAllvBenchmarkFixture : public MpiBaseTestFixture {
     for (int i = 0; i < nIterWarmup; i++) {
       CUDA_CHECK(
           comms::common::launchKernel(
-              (void*)allToAllvKernel,
+              (void*)all_to_allv_kernel,
               gridDim,
               blockDim,
               args,
@@ -324,7 +324,7 @@ class AllToAllvBenchmarkFixture : public MpiBaseTestFixture {
     for (int i = 0; i < nIter; i++) {
       CUDA_CHECK(
           comms::common::launchKernel(
-              (void*)allToAllvKernel,
+              (void*)all_to_allv_kernel,
               gridDim,
               blockDim,
               args,

--- a/comms/pipes/collectives/benchmarks/CollectiveBenchmark.cu
+++ b/comms/pipes/collectives/benchmarks/CollectiveBenchmark.cu
@@ -1,0 +1,23 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/collectives/benchmarks/CollectiveBenchmark.cuh"
+
+namespace comms::pipes::benchmark {
+
+__global__ void all_to_allv_kernel(
+    void* recvbuff_d,
+    const void* sendbuff_d,
+    int my_rank_id,
+    DeviceSpan<Transport> transports_per_rank,
+    DeviceSpan<ChunkInfo> send_chunk_infos,
+    DeviceSpan<ChunkInfo> recv_chunk_infos) {
+  all_to_allv(
+      recvbuff_d,
+      sendbuff_d,
+      my_rank_id,
+      transports_per_rank,
+      send_chunk_infos,
+      recv_chunk_infos);
+}
+
+} // namespace comms::pipes::benchmark

--- a/comms/pipes/collectives/benchmarks/CollectiveBenchmark.cuh
+++ b/comms/pipes/collectives/benchmarks/CollectiveBenchmark.cuh
@@ -1,0 +1,23 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda_runtime.h>
+
+#include "comms/pipes/collectives/AllToAllv.cuh"
+
+namespace comms::pipes::benchmark {
+
+/**
+ * AllToAllv benchmark kernel.
+ * All ranks participate in all-to-all communication with variable chunk sizes.
+ */
+__global__ void all_to_allv_kernel(
+    void* recvbuff_d,
+    const void* sendbuff_d,
+    int my_rank_id,
+    DeviceSpan<Transport> transports_per_rank,
+    DeviceSpan<ChunkInfo> send_chunk_infos,
+    DeviceSpan<ChunkInfo> recv_chunk_infos);
+
+} // namespace comms::pipes::benchmark

--- a/comms/pipes/collectives/dispatch.cu
+++ b/comms/pipes/collectives/dispatch.cu
@@ -65,12 +65,12 @@ __device__ __forceinline__ void handleSelfCopy(
       chunk_offset += input_chunk_sizes_d[j];
     }
 
-    selfTransport.self.write(
+    selfTransport.self.put(
         group, dst_base + chunk_offset, src_base + chunk_offset, chunk_size);
   }
 
   // Write output chunk sizes for self (copy all chunk sizes)
-  selfTransport.self.write(
+  selfTransport.self.put(
       group,
       reinterpret_cast<char*>(self_output_sizes),
       reinterpret_cast<const char*>(input_chunk_sizes_d),
@@ -318,6 +318,7 @@ void dispatch(
           input_chunk_indices_d,
           input_chunk_indices_count_per_rank,
           output_chunk_sizes_per_rank);
+      PIPES_KERNEL_LAUNCH_CHECK();
       break;
     case ShardingMode::HORIZONTAL:
       dispatchKernelHorizontal<<<num_blocks, num_threads, 0, stream>>>(
@@ -329,9 +330,9 @@ void dispatch(
           input_chunk_indices_d,
           input_chunk_indices_count_per_rank,
           output_chunk_sizes_per_rank);
+      PIPES_KERNEL_LAUNCH_CHECK();
       break;
   }
-  PIPES_KERNEL_LAUNCH_CHECK();
 }
 
 } // namespace comms::pipes::collectives

--- a/comms/pipes/tests/AllToAllvTest.cc
+++ b/comms/pipes/tests/AllToAllvTest.cc
@@ -5,9 +5,9 @@
 #include <folly/init/Init.h>
 #include <folly/logging/xlog.h>
 
-#include "comms/pipes/AllToAllv.cuh"
 #include "comms/pipes/MultiPeerNvlTransport.h"
 #include "comms/pipes/P2pSelfTransportDevice.cuh"
+#include "comms/pipes/collectives/AllToAllv.cuh"
 #include "comms/pipes/tests/AllToAllvTest.cuh"
 #include "comms/pipes/tests/Utils.cuh"
 #include "comms/testinfra/TestXPlatUtils.h"
@@ -83,7 +83,7 @@ class AllToAllvEqualSizeTest
     : public AllToAllvTestFixture,
       public ::testing::WithParamInterface<AllToAllvTestParams> {};
 
-// Test allToAllv with actual data transfer and verification
+// Test all_to_allv with actual data transfer and verification
 TEST_P(AllToAllvEqualSizeTest, AllToAllvEqualSize) {
   const auto& params = GetParam();
   const size_t numIntsPerRank = params.numIntsPerRank;
@@ -202,7 +202,7 @@ TEST_P(AllToAllvEqualSizeTest, AllToAllvEqualSize) {
   // Barrier to ensure all ranks are ready
   MPI_Barrier(MPI_COMM_WORLD);
 
-  // Debug: Print send and recv buffers before allToAllv
+  // Debug: Print send and recv buffers before all_to_allv
   printDeviceBuffer(
       "Send buffer BEFORE",
       sendBuffer.get(),
@@ -216,9 +216,9 @@ TEST_P(AllToAllvEqualSizeTest, AllToAllvEqualSize) {
       numRanks,
       numIntsPerRank);
 
-  XLOGF(DBG1, "Rank {}: calling allToAllv", globalRank);
+  XLOGF(DBG1, "Rank {}: calling all_to_allv", globalRank);
 
-  // Call allToAllv with actual data transfer
+  // Call all_to_allv with actual data transfer
   test::testAllToAllv(
       recvBuffer.get(),
       sendBuffer.get(),
@@ -232,7 +232,7 @@ TEST_P(AllToAllvEqualSizeTest, AllToAllvEqualSize) {
 
   CUDACHECK_TEST(cudaDeviceSynchronize());
 
-  // Debug: Print recv buffer after allToAllv
+  // Debug: Print recv buffer after all_to_allv
   printDeviceBuffer(
       "Recv buffer AFTER",
       recvBuffer.get(),
@@ -328,7 +328,7 @@ class AllToAllvUnequalSizeTest
     : public AllToAllvTestFixture,
       public ::testing::WithParamInterface<AllToAllvUnequalSizeParams> {};
 
-// Test allToAllv with variable chunk sizes per peer
+// Test all_to_allv with variable chunk sizes per peer
 // Sizes are symmetric: rank i→j size == rank j→i size
 TEST_P(AllToAllvUnequalSizeTest, AllToAllvUnequalSize) {
   const auto& params = GetParam();
@@ -476,9 +476,9 @@ TEST_P(AllToAllvUnequalSizeTest, AllToAllvUnequalSize) {
   // Barrier to ensure all ranks are ready
   MPI_Barrier(MPI_COMM_WORLD);
 
-  XLOGF(DBG1, "Rank {}: calling allToAllv with variable sizes", globalRank);
+  XLOGF(DBG1, "Rank {}: calling all_to_allv with variable sizes", globalRank);
 
-  // Call allToAllv with variable sizes
+  // Call all_to_allv with variable sizes
   test::testAllToAllv(
       recvBuffer.get(),
       sendBuffer.get(),

--- a/comms/pipes/tests/AllToAllvTest.cu
+++ b/comms/pipes/tests/AllToAllvTest.cu
@@ -6,7 +6,7 @@
 
 namespace comms::pipes::test {
 
-// Kernel that calls allToAllv
+// Kernel that calls all_to_allv
 __global__ void testAllToAllvKernel(
     void* recvbuff_d,
     const void* sendbuff_d,
@@ -15,8 +15,8 @@ __global__ void testAllToAllvKernel(
     DeviceSpan<Transport> transports,
     DeviceSpan<ChunkInfo> send_chunk_infos,
     DeviceSpan<ChunkInfo> recv_chunk_infos) {
-  // Call allToAllv - it will perform actual data transfers
-  allToAllv(
+  // Call all_to_allv - it will perform actual data transfers
+  all_to_allv(
       recvbuff_d,
       sendbuff_d,
       my_rank_id,

--- a/comms/pipes/tests/AllToAllvTest.cuh
+++ b/comms/pipes/tests/AllToAllvTest.cuh
@@ -5,11 +5,11 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 
-#include "comms/pipes/AllToAllv.cuh"
+#include "comms/pipes/collectives/AllToAllv.cuh"
 
 namespace comms::pipes::test {
 
-// Test allToAllv with transports
+// Test all_to_allv with transports
 void testAllToAllv(
     void* recvbuff_d,
     const void* sendbuff_d,

--- a/comms/pipes/tests/DispatchTest.cc
+++ b/comms/pipes/tests/DispatchTest.cc
@@ -12,6 +12,7 @@
 #include "comms/pipes/tests/DispatchTestKernels.cuh"
 #include "comms/pipes/tests/Utils.cuh"
 #include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/testinfra/mpi/MpiBootstrap.h"
 #include "comms/testinfra/mpi/MpiTestUtils.h"
 #include "comms/utils/CudaRAII.h"
 


### PR DESCRIPTION
Summary:
1. move the alltoallv collective to the collectives dir
2. change the naming to be consistent with the other functions now with _ functions
3. move benchmarks also to collectives

Differential Revision: D91439414
