### PR TITLE
Add MCCL_SCUBA_ENABLED CVAR for MCCL Scuba logging

### DIFF
--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2786,6 +2786,14 @@ cvars:
      Usage: If the NCCL_CTRAN_BACKENS is set with certain values,
      this config will allow MCCL to override backends.
 
+ - name        : MCCL_SCUBA_ENABLED
+   type        : bool
+   default     : false
+   description : |-
+     Enable MCCL Scuba structured logging. When enabled, MCCL will log
+     events to dedicated MCCL Scuba tables for observability and debugging.
+     This is separate from NCCLX logging to minimize risk.
+
  - name        : NCCL_GIN_GDAKI_NIC_HANDLER
    type        : int
    default     : 0


### PR DESCRIPTION
Summary: Add a new CVAR to enable MCCL-specific Scuba structured logging. This is a prerequisite for implementing MCCL tables (like mccl_operation_trace & others).

Differential Revision: D91364554


