### PR TITLE
Fix dispatch.cu to use P2pSelfTransportDevice::put API

### DIFF
--- a/comms/pipes/P2pSelfTransportDevice.cuh
+++ b/comms/pipes/P2pSelfTransportDevice.cuh
@@ -31,7 +31,7 @@ namespace comms::pipes {
  *
  * Example:
  *   SelfTransportDevice transport;
- *   transport.write(group, dst_d, src_d, nbytes);
+ *   transport.put(group, dst_d, src_d, nbytes);
  */
 class P2pSelfTransportDevice {
  public:
@@ -79,7 +79,7 @@ class P2pSelfTransportDevice {
    * @param group ThreadGroup for cooperative processing
    * @param dst_d Destination pointer (device memory)
    * @param src_d Source pointer (device memory)
-   * @param nbytes Number of bytes to write
+   * @param nbytes Number of bytes to copy
    */
   __device__ __forceinline__ void
   put(ThreadGroup& group, char* dst_d, const char* src_d, std::size_t nbytes) {

--- a/comms/pipes/benchmarks/DispatchBenchmark.cc
+++ b/comms/pipes/benchmarks/DispatchBenchmark.cc
@@ -18,6 +18,7 @@
 #include "comms/pipes/P2pSelfTransportDevice.cuh"
 #include "comms/pipes/Transport.cuh"
 #include "comms/pipes/collectives/dispatch.h"
+#include "comms/testinfra/mpi/MpiBootstrap.h"
 #include "comms/testinfra/mpi/MpiTestUtils.h"
 #include "comms/utils/CudaRAII.h"
 

--- a/comms/pipes/collectives/dispatch.cu
+++ b/comms/pipes/collectives/dispatch.cu
@@ -65,12 +65,12 @@ __device__ __forceinline__ void handleSelfCopy(
       chunk_offset += input_chunk_sizes_d[j];
     }
 
-    selfTransport.self.write(
+    selfTransport.self.put(
         group, dst_base + chunk_offset, src_base + chunk_offset, chunk_size);
   }
 
   // Write output chunk sizes for self (copy all chunk sizes)
-  selfTransport.self.write(
+  selfTransport.self.put(
       group,
       reinterpret_cast<char*>(self_output_sizes),
       reinterpret_cast<const char*>(input_chunk_sizes_d),

--- a/comms/pipes/tests/DispatchTest.cc
+++ b/comms/pipes/tests/DispatchTest.cc
@@ -12,6 +12,7 @@
 #include "comms/pipes/tests/DispatchTestKernels.cuh"
 #include "comms/pipes/tests/Utils.cuh"
 #include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/testinfra/mpi/MpiBootstrap.h"
 #include "comms/testinfra/mpi/MpiTestUtils.h"
 #include "comms/utils/CudaRAII.h"
 


### PR DESCRIPTION
Summary:
dispatch.cu was calling selfTransport.self.write() but P2pSelfTransportDevice
only has a put() method. Updated the calls to use put() and fixed the docstring
example to be consistent.

Differential Revision: D91498719


