### PR TITLE
device-api design for torchcomms | header file

### DIFF
--- a/comms/torchcomms/device/TorchCommDeviceComm.hpp
+++ b/comms/torchcomms/device/TorchCommDeviceComm.hpp
@@ -1,0 +1,190 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// TorchComm Device API - C++ Header
+//
+// Device-side API for TorchComm that can be used from CUDA kernels or Triton.
+//
+// Design:
+//   - Window is the first-class citizen; device comm is internal
+//   - Each device window has isolated signal/counter/barrier namespace
+//   - 1:1 mapping between host window and device window
+//
+// Backend Types (from DeviceBackendTraits.hpp):
+//   - NCCLGinBackend: NCCL GIN for GPU-initiated networking
+//   - Future: NVSHMEMBackend, etc.
+//
+// Type Aliases (defined in backend-specific headers):
+//   - DeviceWindowNCCL = TorchCommDeviceWindow<NCCLGinBackend>
+//   - RegisteredBufferNCCL = RegisteredBuffer
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <cstdint>
+
+namespace torchcomms::device {
+
+// =============================================================================
+// Forward Declarations
+// =============================================================================
+
+template <typename Backend>
+class TorchCommDeviceWindow;
+struct RegisteredBuffer;
+
+// =============================================================================
+// Enums
+// =============================================================================
+
+enum class SignalOp : int {
+  SET = 0, // signal = value
+  ADD = 1, // signal += value
+};
+
+enum class CmpOp : int {
+  EQ = 0, // ==
+  NE = 1, // !=
+  LT = 2, // <
+  LE = 3, // <=
+  GT = 4, // >
+  GE = 5, // >= (most common for wait operations)
+};
+
+// =============================================================================
+// RegisteredBuffer - Handle for Local Registered Source Buffers
+// =============================================================================
+//
+// Represents a registered local memory region for RMA put operations.
+// Created on host via hostWindow.register_local_buffer().
+//
+// IMPORTANT: Must be used with the SAME DeviceWindow that created it.
+
+struct RegisteredBuffer {
+  void* base_ptr;
+  size_t size;
+  void* backend_window; // Backend-specific window handle (e.g., ncclWindow_t)
+
+  __device__ void* ptr() const {
+    return base_ptr;
+  }
+  __device__ size_t buffer_size() const {
+    return size;
+  }
+};
+
+// =============================================================================
+// TorchCommDeviceWindow - Device-side Window Handle
+// =============================================================================
+//
+// Primary device-side handle for communication and synchronization.
+// Created from host window via hostWindow.get_device_window().
+//
+// Passed by value to CUDA kernels (CUDA copies automatically):
+//   DeviceWindowNCCL win = hostWindow.get_device_window();
+//   myKernel<<<grid, block>>>(win, ...);
+//
+// Template parameter Backend provides backend traits (Comm, Window types).
+//
+// Contains:
+//   - Window metadata (rank, num_ranks, base, size)
+//   - RMA operations (put)
+//   - Synchronization primitives (signal, counter, barrier, fence, flush)
+//
+// Signal vs Counter:
+//   - Signal: Written to REMOTE peer's memory (data arrival notification)
+//   - Counter: Written to LOCAL memory (source buffer consumed notification)
+
+template <typename Backend>
+class TorchCommDeviceWindow {
+ public:
+  // =========================================================================
+  // Metadata
+  // =========================================================================
+
+  __device__ int rank() const {
+    return rank_;
+  }
+  __device__ int num_ranks() const {
+    return num_ranks_;
+  }
+
+  // =========================================================================
+  // Window Properties
+  // =========================================================================
+
+  __device__ void* base() const {
+    return base_;
+  }
+  __device__ size_t size() const {
+    return size_;
+  }
+
+  // =========================================================================
+  // Backend Access
+  // =========================================================================
+
+  __device__ const typename Backend::Comm& comm() const {
+    return comm_;
+  }
+  __device__ typename Backend::Window window() const {
+    return window_;
+  }
+
+  // =========================================================================
+  // RMA Operations - Put
+  // =========================================================================
+
+  __device__ int put(
+      size_t dst_offset,
+      const RegisteredBuffer& src_buf,
+      size_t src_offset,
+      int dst_rank,
+      size_t bytes,
+      int signal_id = -1,
+      int counter_id = -1);
+
+  // =========================================================================
+  // Signaling Operations (Remote Notification)
+  // =========================================================================
+
+  __device__ int signal(
+      int peer,
+      int signal_id,
+      SignalOp op = SignalOp::ADD,
+      uint64_t value = 1);
+
+  __device__ int wait_signal(int signal_id, CmpOp cmp, uint64_t value);
+  __device__ uint64_t read_signal(int signal_id) const;
+  __device__ void reset_signal(int signal_id);
+
+  // =========================================================================
+  // Counter Operations (Local Completion)
+  // =========================================================================
+
+  __device__ int wait_local(int op_id, CmpOp cmp, uint64_t value);
+  __device__ uint64_t read_counter(int counter_id) const;
+  __device__ void reset_counter(int counter_id);
+
+  // =========================================================================
+  // Synchronization & Completion
+  // =========================================================================
+
+  __device__ int fence();
+  __device__ int flush();
+  __device__ int barrier(int barrier_id);
+
+  // =========================================================================
+  // Data Members
+  // =========================================================================
+
+  typename Backend::Comm comm_; // e.g., ncclDevComm
+  typename Backend::Window window_; // e.g., ncclWindow_t
+  void* base_; // Local window base pointer
+  size_t size_; // Window size in bytes
+  int rank_;
+  int num_ranks_;
+};
+
+// Type alias (also defined in backend-specific headers for convenience)
+// Note: Requires DeviceBackendTraits.hpp to be included first
+
+} // namespace torchcomms::device


### PR DESCRIPTION
Summary:
This diff introduces the device-side API header for TorchComms, enabling GPU-initiated communication directly from CUDA kernels.

### Design Philosophy

- **Window-centric design**: `TorchCommDeviceWindow` is the first-class citizen; the internal `TorchCommDeviceComm_` is hidden from users
- **1:1 mapping**: Each host window maps to exactly one device window with isolated signal/counter/barrier namespaces
- **Non-collective source buffer registration**: Uses `ncclCommSplit` to create a 1-rank local communicator, enabling `register_local_buffer()` without collective synchronization

### Key Components

#### Enums
| Enum | Values | Purpose |
|------|--------|---------|
| `BackendType` | `NCCL_GIN`, `NVSHMEM` | Backend selection |
| `SignalOp` | `SET`, `ADD` | Signal update operation (direct assign vs atomic add) |
| `CmpOp` | `EQ`, `NE`, `LT`, `LE`, `GT`, `GE` | Comparison for wait conditions |

#### RegisteredBuffer
- Handle for locally registered source buffers
- Created via `hostWindow.register_local_buffer()` (non-collective)
- Must be used with the same `DeviceWindow` that created it (ginState compatibility)

#### TorchCommDeviceWindow
| Category | APIs |
|----------|------|
| RMA | `put()` with optional signal/counter IDs |
| Signals | `signal()`, `wait_signal()`, `read_signal()`, `reset_signal()` |
| Counters | `wait_counter()`, `read_counter()`, `reset_counter()` |
| Sync | `fence()`, `flush()`, `barrier()` |

### Signal vs Counter Semantics

| Type | Location | Purpose |
|------|----------|---------|
| **Signal** | REMOTE peer's memory | Remote completion notification (data arrived) |
| **Counter** | LOCAL memory | Source buffer consumption tracking (safe to reuse) |

### Non-Collective Registration (NCCL GIN)

Differential Revision: D91172575


