### PR TITLE
Add device API infrastructure with explicit window path control

### DIFF
--- a/comms/ncclx/v2_28/src/nccl.h.in
+++ b/comms/ncclx/v2_28/src/nccl.h.in
@@ -91,6 +91,9 @@ typedef enum { ncclSuccess                 =  0,
 /* Window Registration flags */
 #define NCCL_WIN_DEFAULT 0x00
 #define NCCL_WIN_COLL_SYMMETRIC 0x01
+// TODO: Revisit NCCL_WIN_DEVICE_API - this is a temporary fix to bypass CTRAN
+// and force the original NCCL path for device API (GIN support).
+#define NCCL_WIN_DEVICE_API 0x02
 
 #define NCCL_WIN_REQUIRED_ALIGNMENT 4096
 

--- a/comms/torchcomms/device/DeviceBackendTraits.hpp
+++ b/comms/torchcomms/device/DeviceBackendTraits.hpp
@@ -1,0 +1,42 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// TorchComm Device Backend Traits
+//
+// Defines backend trait types for compile-time polymorphism in device API.
+// Each backend defines its communicator and window types.
+//
+// Current Backends:
+//   - NCCLGinBackend: NCCL GIN for GPU-initiated networking
+//
+// Future Backends:
+//   - NVSHMEMBackend: NVSHMEM for symmetric memory operations
+
+#pragma once
+
+#include <nccl.h> // @manual=//comms/ncclx:nccl
+#include <nccl_device/impl/comm__types.h> // @manual=//comms/ncclx:nccl_device_api
+
+namespace torchcomms::device {
+
+// =============================================================================
+// NCCLGinBackend - Backend traits for NCCL GIN
+// =============================================================================
+//
+// Defines types for NCCL's GPU-Initiated Networking backend:
+//   - Comm: ncclDevComm - Device communicator passed by value to kernels
+//   - Window: ncclWindow_t - Window handle for RMA operations
+
+struct NCCLGinBackend {
+  using Comm = ncclDevComm;
+  using Window = ncclWindow_t;
+};
+
+// =============================================================================
+// Future Backends (placeholder)
+// =============================================================================
+
+// struct NVSHMEMBackend {
+//   using Comm = nvshmem_team_t;
+//   using Window = void*;  // NVSHMEM uses symmetric heap, no explicit window
+// };
+
+} // namespace torchcomms::device

--- a/comms/torchcomms/ncclx/NcclxApi.cpp
+++ b/comms/torchcomms/ncclx/NcclxApi.cpp
@@ -352,8 +352,9 @@ ncclResult_t DefaultNcclxApi::commWindowRegister(
     void* baseptr,
     const size_t size,
     ncclComm_t comm,
-    NcclxWindow* winPtr) {
-  return ncclCommWindowRegister(comm, baseptr, size, winPtr, NCCL_WIN_DEFAULT);
+    NcclxWindow* winPtr,
+    int winFlags) {
+  return ncclCommWindowRegister(comm, baseptr, size, winPtr, winFlags);
 }
 
 ncclResult_t DefaultNcclxApi::commWindowDeregister(

--- a/comms/torchcomms/ncclx/NcclxApi.hpp
+++ b/comms/torchcomms/ncclx/NcclxApi.hpp
@@ -250,7 +250,8 @@ class NcclxApi {
       void* baseptr,
       const size_t size,
       ncclComm_t comm,
-      NcclxWindow* winPtr) = 0;
+      NcclxWindow* winPtr,
+      int winFlags = NCCL_WIN_DEFAULT) = 0;
   virtual ncclResult_t commWindowDeregister(
       ncclComm_t comm,
       NcclxWindow win) = 0;
@@ -485,7 +486,8 @@ class DefaultNcclxApi : public NcclxApi {
       void* baseptr,
       const size_t size,
       ncclComm_t comm,
-      NcclxWindow* winPtr) override;
+      NcclxWindow* winPtr,
+      int winFlags = NCCL_WIN_DEFAULT) override;
   ncclResult_t commWindowDeregister(ncclComm_t comm, NcclxWindow win) override;
   ncclResult_t winPut(
       const void* originBuff,

--- a/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.cpp
@@ -80,7 +80,7 @@ void NcclxMock::setupDefaultBehaviors() {
       .WillByDefault(Return(ncclSuccess));
   ON_CALL(*this, pFree(_)).WillByDefault(Return(ncclSuccess));
 
-  ON_CALL(*this, commWindowRegister(_, _, _, _))
+  ON_CALL(*this, commWindowRegister(_, _, _, _, _))
       .WillByDefault(DoAll(
           SetArgPointee<3>(reinterpret_cast<NcclxWindow>(0x5000)),
           Return(ncclSuccess)));

--- a/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.hpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.hpp
@@ -262,7 +262,11 @@ class NcclxMock : public NcclxApi {
   MOCK_METHOD(
       ncclResult_t,
       commWindowRegister,
-      (void* baseptr, size_t size, ncclComm_t comm, NcclxWindow* win),
+      (void* baseptr,
+       const size_t size,
+       ncclComm_t comm,
+       NcclxWindow* win,
+       int winFlags),
       (override));
 
   MOCK_METHOD(


### PR DESCRIPTION
Summary:
This diff adds the host-side infrastructure for TorchComms device API, enabling GPU-initiated networking (GIN) from CUDA kernels.

## Key Design Decisions

### 1. Dual Window Architecture
`tensor_register()` now creates **BOTH**:
- A **CTRAN window** for host API (`put`/`signal`/`wait_signal`)
- An **NCCL orig window** for device API with GIN support

This allows host and device APIs to coexist.

### 2. Explicit Window Path Control
Added `NCCL_WIN_FORCE_ORIG_PATH` flag to NCCLX that bypasses the global `NCCL_RMA_ALGO` environment variable. This allows device API windows to always use the NCCL orig path (which has GIN support) regardless of the default RMA algorithm setting.

### 3. Non-Collective Local Buffer Registration
Uses `ncclCommSplit` to create a 1-rank local communicator that shares `ginState` with the parent. This enables `register_local_buffer()` to be truly **non-collective** since all bootstrap barriers become no-ops when `nranks=1`.

### 4. Single Synchronization Point
All collective operations (`initLocalComm()`, `initNcclOrigWindow()`) now happen in `tensor_register()`, which is already a well-defined synchronization point. This prevents potential deadlocks from lazy initialization.

## Changes

### NCCLX Core (v2_27 and v2_28)
- Added `NCCL_WIN_FORCE_ORIG_PATH` (0x02) window flag to `nccl.h.in`
- Modified `ncclCommWindowRegister()` to check for this flag and bypass CTRAN path when set

### TorchComms NcclxApi
- Added `winFlags` parameter to `commWindowRegister()` with default `NCCL_WIN_DEFAULT`

### TorchCommWindowNCCLX
- **`tensor_register()`**: Now initializes local communicator and NCCL orig window alongside CTRAN window
- **`register_local_buffer()`**: Registers source buffers for device-side put operations (non-collective)
- **`deregister_local_buffer()`**: Deregisters local buffers (non-collective)
- **`get_device_window()`**: Placeholder for device window allocation (to be implemented in Diff 2B)
- Added cleanup logic in destructor for new resources

### BUCK
- Added `device-api-headers` library target for `TorchCommDeviceComm.hpp`
- Added dependency on `device-api-headers` to ncclx libraries

Differential Revision: D91499629


