### PR TITLE
disable aarch64 github ci since it has some infra issues

### DIFF
--- a/.github/workflows/build_wheels_linux_aarch64.yml
+++ b/.github/workflows/build_wheels_linux_aarch64.yml
@@ -1,41 +1,41 @@
-name: Build Linux Aarch64 Wheels
+# name: Build Linux Aarch64 Wheels
 
-on:
-  pull_request:
-  push:
-    branches:
-      - main
-      - nightly
-  workflow_dispatch:
+# on:
+#   pull_request:
+#   push:
+#     branches:
+#       - main
+#       - nightly
+#   workflow_dispatch:
 
-jobs:
-  generate-matrix:
-    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
-    with:
-      package-type: wheel
-      os: linux-aarch64
-      test-infra-repository: pytorch/test-infra
-      test-infra-ref: main
-      with-cuda: enable
-      with-rocm: disable
-      with-cpu: disable
-  build:
-    needs: generate-matrix
-    name: ${{ matrix.repository }}
-    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
-    with:
-      repository: meta-pytorch/torchcomms
-      ref: ""
-      pre-script: ""
-      post-script: ""
-      build-platform: "python-build-package"
-      build-command: "scripts/_build_wheel.sh"
-      smoke-test-script: "scripts/smoke_test.py"
-      package-name: torchcomms
-      test-infra-repository: pytorch/test-infra
-      test-infra-ref: main
-      build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
-      trigger-event: ${{ github.event_name }}
-      architecture: aarch64
-      #setup-miniconda: false
-      runner: linux.arm64.r7g.12xlarge.memory
+# jobs:
+#   generate-matrix:
+#     uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+#     with:
+#       package-type: wheel
+#       os: linux-aarch64
+#       test-infra-repository: pytorch/test-infra
+#       test-infra-ref: main
+#       with-cuda: enable
+#       with-rocm: disable
+#       with-cpu: disable
+#   build:
+#     needs: generate-matrix
+#     name: ${{ matrix.repository }}
+#     uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
+#     with:
+#       repository: meta-pytorch/torchcomms
+#       ref: ""
+#       pre-script: ""
+#       post-script: ""
+#       build-platform: "python-build-package"
+#       build-command: "scripts/_build_wheel.sh"
+#       smoke-test-script: "scripts/smoke_test.py"
+#       package-name: torchcomms
+#       test-infra-repository: pytorch/test-infra
+#       test-infra-ref: main
+#       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+#       trigger-event: ${{ github.event_name }}
+#       architecture: aarch64
+#       #setup-miniconda: false
+#       runner: linux.arm64.r7g.12xlarge.memory


### PR DESCRIPTION
Summary: All aarch64 CIs are broken because of environment setup issues. Let's disable it temporarily.

Differential Revision: D91506754


