### PR TITLE
Global pointer-based registration for CUDACachingAllocator (#417)

### DIFF
--- a/comms/torchcomms/ncclx/NcclxApi.cpp
+++ b/comms/torchcomms/ncclx/NcclxApi.cpp
@@ -102,6 +102,16 @@ ncclResult_t DefaultNcclxApi::commDeregister(ncclComm_t comm, void* handle) {
   return ncclCommDeregister(comm, handle);
 }
 
+ncclResult_t DefaultNcclxApi::globalRegisterWithPtr(void* buffer, size_t size) {
+  return ncclGlobalRegisterWithPtr(buffer, size);
+}
+
+ncclResult_t DefaultNcclxApi::globalDeregisterWithPtr(
+    void* buffer,
+    size_t size) {
+  return ncclGlobalDeregisterWithPtr(buffer, size);
+}
+
 ncclResult_t DefaultNcclxApi::send(
     const void* sendbuff,
     size_t count,

--- a/comms/torchcomms/ncclx/NcclxApi.hpp
+++ b/comms/torchcomms/ncclx/NcclxApi.hpp
@@ -108,6 +108,12 @@ class NcclxApi {
       ncclComm_t comm,
       void* handle) = 0;
 
+  // Pointer-based memory registration (global - does not require comm)
+  // cudaDev is auto-detected from the buffer pointer.
+  virtual ncclResult_t globalRegisterWithPtr(void* buffer, size_t size) = 0;
+
+  virtual ncclResult_t globalDeregisterWithPtr(void* buffer, size_t size) = 0;
+
   // Point-to-point operations
   [[nodiscard]] virtual ncclResult_t send(
       const void* sendbuff,
@@ -435,6 +441,10 @@ class DefaultNcclxApi : public NcclxApi {
 
   [[nodiscard]] ncclResult_t commDeregister(ncclComm_t comm, void* handle)
       override;
+
+  ncclResult_t globalRegisterWithPtr(void* buffer, size_t size) override;
+
+  ncclResult_t globalDeregisterWithPtr(void* buffer, size_t size) override;
 
   // Point-to-point operations
   [[nodiscard]] ncclResult_t send(

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -131,10 +131,6 @@ TorchCommNCCLX::~TorchCommNCCLX() {
       nccl_comm_ = nullptr;
     }
   }
-
-  // We need to detach the memory hook in case finalize is not called,
-  // so that we don't encounter a memory corruption.
-  detachMemoryHook();
 }
 
 void TorchCommNCCLX::init(
@@ -271,7 +267,8 @@ void TorchCommNCCLX::init(
   // Start timeout watchdog thread
   timeout_thread_ = std::thread(&TorchCommNCCLX::timeoutWatchdog, this);
 
-  // Register comm with CachingAllocator
+  // Attach memory hook to register pre-existing allocations and capture future
+  // ones
   attachMemoryHook();
 
   // Mark initialization as complete only after all steps succeed
@@ -390,8 +387,6 @@ void TorchCommNCCLX::finalize() {
   // Note: If abortNcclComm() was called, nccl_comm_ is already nullptr and this
   // is skipped. We must not call commDestroy after commAbort per NCCL docs.
   if (nccl_comm_) {
-    detachMemoryHook();
-    // Deregister comm from the CachingAllocator
     NCCLX_CHECK(
         nccl_api_,
         nccl_comm_,
@@ -408,7 +403,6 @@ void TorchCommNCCLX::abortNcclComm() {
   //   subsequent alloc/free callbacks do not reference a destroyed comm.
   TC_LOG(INFO, this) << "Calling abort hooks before commAbort.";
   runAbortHooks();
-  detachMemoryHook();
   if (nccl_comm_) {
     NCCLX_CHECK(
         nccl_api_,
@@ -2292,51 +2286,29 @@ std::shared_ptr<TorchCommBackend> TorchCommNCCLX::split(
   return new_torchcomm;
 }
 
-void TorchCommNCCLX::register_address(
-    const TorchCommNCCLX::AddressWithLen& addr) {
-  // We got a register after we got rid of the comm. Is this a fatal error?
-  if (nccl_comm_ == nullptr) {
-    return;
-  }
-
-  if (memoryRegistrationHandles_.contains(addr.addr)) {
-    throw std::runtime_error("Memory already registered with NCCLX");
-  }
-  void* handle = nullptr;
-  NCCLX_CHECK(
-      nccl_api_,
-      nccl_comm_,
-      nccl_api_->commRegister(nccl_comm_, addr.addr, addr.len, &handle),
-      "Failed to register memory with NCCLX");
-  // ncclCommRegister may return a NULL handle when registration is a no-op.
-  // Skip storing it so that deregister_address() does not later call
-  // ncclCommDeregister with a NULL handle.
-  if (handle != nullptr) {
-    memoryRegistrationHandles_.emplace(addr.addr, RegistrationHandle(handle));
+void TorchCommNCCLX::global_register_address(
+    const TorchCommNCCLX::AddressWithLen& addr,
+    NcclxApi* nccl_api) {
+  ncclResult_t result = nccl_api->globalRegisterWithPtr(addr.addr, addr.len);
+  if (result != ncclSuccess) {
+    LOG(WARNING) << "[TC] Failed to globally register memory with NCCL (addr="
+                 << addr.addr << ", len=" << addr.len
+                 << "). This is expected when ctran is not enabled. Error: "
+                 << nccl_api->getErrorString(result);
   }
 }
 
-void TorchCommNCCLX::deregister_address(const TorchCommNCCLX::Address& addr) {
-  // We got a deregister after we got rid of the comm. Is this a fatal error?
-  if (nccl_comm_ == nullptr) {
-    return;
+void TorchCommNCCLX::global_deregister_address(
+    const TorchCommNCCLX::AddressWithLen& addr,
+    NcclxApi* nccl_api) {
+  ncclResult_t result = nccl_api->globalDeregisterWithPtr(addr.addr, addr.len);
+
+  if (result != ncclSuccess) {
+    LOG(WARNING) << "[TC] Failed to globally deregister memory with NCCL (addr="
+                 << addr.addr << ", len=" << addr.len
+                 << "). This is expected when ctran is not enabled. Error: "
+                 << nccl_api->getErrorString(result);
   }
-
-  auto it = memoryRegistrationHandles_.find(addr.addr);
-  if (it == memoryRegistrationHandles_.end()) {
-    // it's possible that the memory was registered for a different comm,
-    // however failed registration for this comm.
-    return;
-  }
-
-  void* handle = it->second.regHandle;
-  NCCLX_CHECK(
-      nccl_api_,
-      nccl_comm_,
-      nccl_api_->commDeregister(nccl_comm_, handle),
-      "Failed to deregister memory with NCCLX");
-
-  memoryRegistrationHandles_.erase(it);
 }
 
 std::unordered_map<std::string, std::string> TorchCommNCCLX::comm_dump() {

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
@@ -319,6 +319,13 @@ class TorchCommNCCLX : public TorchCommBackend,
     TIMEOUT,
   };
 
+  std::atomic<CommState> comm_state_{
+      CommState::NORMAL}; // State of the communicator
+
+  cudaEvent_t
+      dependency_event_{}; // Pre-allocated event for stream dependencies
+
+ public:
   struct Address {
     void* addr;
   };
@@ -328,14 +335,17 @@ class TorchCommNCCLX : public TorchCommBackend,
     size_t len;
   };
 
-  std::atomic<CommState> comm_state_{
-      CommState::NORMAL}; // State of the communicator
+  // Global pointer-based registration that doesn't require a comm instance.
+  // Used by CachingAllocatorHook for pre-comm memory registration.
+  // The caller provides the NcclxApi to use for the registration.
+  static void global_register_address(
+      const AddressWithLen& addr,
+      NcclxApi* nccl_api);
+  static void global_deregister_address(
+      const AddressWithLen& addr,
+      NcclxApi* nccl_api);
 
-  cudaEvent_t
-      dependency_event_{}; // Pre-allocated event for stream dependencies
-
-  void register_address(const AddressWithLen& addr);
-  void deregister_address(const Address& addr);
+ protected:
   ncclDataType_t getNcclDataType(const at::Tensor& tensor);
   ncclDataType_t getNcclDataType(const at::ScalarType scalar_type);
 
@@ -462,8 +472,8 @@ class TorchCommNCCLX : public TorchCommBackend,
   bool getGraphCaptureMode();
   void ensureTensorContiguous(const at::Tensor& tensor);
 
+  // Initialize the CachingAllocatorHook singleton
   void attachMemoryHook();
-  void detachMemoryHook();
 
 #if defined(ENABLE_PIPES)
   torchcomms::device::PipesDeviceBackend::TransportHandleDevPtr

--- a/comms/torchcomms/ncclx/TorchCommNCCLXCCA.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXCCA.cpp
@@ -1,24 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include "comms/torchcomms/ncclx/TorchCommNCCLXCCA.hpp"
-#include <c10/cuda/driver_api.h>
-
-// Helper function to get allocation granularity for a device
-namespace {
-size_t getAllocationGranularity(int device) {
-  auto driver_api = c10::cuda::DriverAPI::get();
-  CUmemAllocationProp prop = {};
-  prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
-  prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
-  prop.location.id = device;
-
-  size_t granularity;
-  C10_CUDA_DRIVER_CHECK(driver_api->cuMemGetAllocationGranularity_(
-      &granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM));
-
-  return granularity;
-}
-} // namespace
 
 namespace torch::comms {
 
@@ -45,218 +27,53 @@ DefaultCachingAllocatorHookImpl::DefaultCachingAllocatorHookImpl() {
 }
 
 void CachingAllocatorHookImpl::registerMemPreHook() {
-  // We assume no mem pool and no comm has been created yet, we just loop up the
-  // snapshot of the default pool for all devices.
+  // Register all memory that has already been allocated by querying the
+  // CUDACachingAllocator snapshot directly. This captures any allocations
+  // that occurred before the trace hook was attached.
+  //
+  // We iterate through all segments in the snapshot. The
+  // global_register_address API auto-detects the correct cudaDev from the
+  // buffer pointer, so we don't need to filter by device here. Each segment
+  // will be registered with its correct device automatically.
   auto snapshot = c10::cuda::CUDACachingAllocator::snapshot();
   for (const auto& segmentInfo : snapshot.segments) {
     // NOLINTNEXTLINE(performance-no-int-to-ptr)
     void* addr = reinterpret_cast<void*>(segmentInfo.address);
     size_t len = segmentInfo.total_size;
-
-    if (registeredMemMap_.contains(addr)) {
-      throw std::runtime_error("Memory already registered with NCCLX");
-    } else {
-      registeredMemMap_.emplace(addr, MemInfo{len, segmentInfo.device});
-    }
+    TorchCommNCCLX::global_register_address(
+        TorchCommNCCLX::AddressWithLen(addr, len), nccl_api_.get());
   }
+
   mem_pre_hook_registered_ = true;
 }
 
 void CachingAllocatorHookImpl::regDeregMem(
     const c10::cuda::CUDACachingAllocator::TraceEntry& te) {
-  std::lock_guard<std::mutex> lock(mutex_);
-
   if (te.action_ ==
-      c10::cuda::CUDACachingAllocator::TraceEntry::Action::SEGMENT_ALLOC) {
-    // Memory got allocated, register it with NCCL
+          c10::cuda::CUDACachingAllocator::TraceEntry::Action::SEGMENT_ALLOC ||
+      te.action_ ==
+          c10::cuda::CUDACachingAllocator::TraceEntry::Action::SEGMENT_MAP) {
     // NOLINTNEXTLINE(performance-no-int-to-ptr)
     void* addr = reinterpret_cast<void*>(static_cast<uintptr_t>(te.addr_));
     size_t len = te.size_;
 
-    if (registeredMemMap_.contains(addr)) {
-      LOG(ERROR) << "[CCA] SEGMENT_ALLOC: Memory already registered at 0x"
-                 << std::hex << addr << std::dec << " size=" << len
-                 << " existing_size=" << registeredMemMap_.at(addr).len;
-      throw std::runtime_error("Memory already registered with NCCLX");
-    } else {
-      registeredMemMap_.emplace(addr, MemInfo{len, te.device_});
-    }
-
-    // Register the memory through ncclCommRegister and add to commRegHandles_
-    for (auto& comm : registeredComms_) {
-      if (te.device_ == comm->getDevice().index()) {
-        comm->register_address(TorchCommNCCLX::AddressWithLen(addr, len));
-      }
-    }
+    TorchCommNCCLX::global_register_address(
+        TorchCommNCCLX::AddressWithLen{addr, len}, nccl_api_.get());
   } else if (
       te.action_ ==
-      c10::cuda::CUDACachingAllocator::TraceEntry::Action::SEGMENT_MAP) {
-    // Memory got mapped, register it with NCCL
-
-    // PyTorch expandable segments can send MAP events covering one or more
-    // chunks. We need to register each chunk separately.
-    // Chunk size is determined by the allocation granularity for the device.
-    size_t total_size = te.size_;
-    size_t chunk_size = getAllocationGranularity(te.device_);
-
-    for (size_t offset = 0; offset < total_size;) {
-      // Determine the chunk size at this offset
-      size_t remaining = total_size - offset;
-
-      if (remaining < chunk_size) {
-        LOG(ERROR) << "[CCA] SEGMENT_MAP: Invalid remaining size=" << remaining
-                   << " at offset=" << offset << " total_size=" << total_size
-                   << " chunk_size=" << chunk_size;
-        throw std::runtime_error(
-            "SEGMENT_MAP: Remaining size must be a multiple of allocation granularity");
-      }
-
-      void* chunk_addr =
-          reinterpret_cast<void*>(  // NOLINT(performance-no-int-to-ptr)
-              static_cast<uintptr_t>(te.addr_) + offset);
-
-      if (registeredMemMap_.contains(chunk_addr)) {
-        LOG(ERROR) << "[CCA] SEGMENT_MAP: Memory already registered at 0x"
-                   << std::hex << chunk_addr << std::dec
-                   << " size=" << chunk_size
-                   << " existing_size=" << registeredMemMap_.at(chunk_addr).len;
-        throw std::runtime_error("Memory already registered with NCCLX");
-      }
-
-      registeredMemMap_.emplace(chunk_addr, MemInfo{chunk_size, te.device_});
-
-      // Register the memory through ncclCommRegister
-      for (auto& comm : registeredComms_) {
-        if (te.device_ == comm->getDevice().index()) {
-          comm->register_address(
-              TorchCommNCCLX::AddressWithLen(chunk_addr, chunk_size));
-        }
-      }
-
-      // Move to the next chunk
-      offset += chunk_size;
-    }
-  } else if (
+          c10::cuda::CUDACachingAllocator::TraceEntry::Action::SEGMENT_FREE ||
       te.action_ ==
-      c10::cuda::CUDACachingAllocator::TraceEntry::Action::SEGMENT_FREE) {
-    // Memory got freed, deregister it with NCCL
+          c10::cuda::CUDACachingAllocator::TraceEntry::Action::SEGMENT_UNMAP) {
     // NOLINTNEXTLINE(performance-no-int-to-ptr)
     void* addr = reinterpret_cast<void*>(static_cast<uintptr_t>(te.addr_));
+    size_t len = te.size_;
 
-    if (!registeredMemMap_.contains(addr)) {
-      LOG(ERROR) << "[CCA] SEGMENT_FREE: Memory not registered at 0x"
-                 << std::hex << addr << std::dec << " size=" << te.size_;
-      throw std::runtime_error("Memory not registered with NCCLX");
-    } else {
-      registeredMemMap_.erase(addr);
-    }
-
-    for (auto& comm : registeredComms_) {
-      if (te.device_ == comm->getDevice().index()) {
-        comm->deregister_address(TorchCommNCCLX::Address(addr));
-      }
-    }
-  } else if (
-      te.action_ ==
-      c10::cuda::CUDACachingAllocator::TraceEntry::Action::SEGMENT_UNMAP) {
-    // Memory got unmapped, deregister it with NCCL
-
-    // PyTorch expandable segments have chunks sized according to the
-    // allocation granularity. UNMAP events can cover multiple chunks.
-    // We iterate through registered chunks within the unmapped range and
-    // deregister each one.
-    size_t total_size = te.size_;
-
-    for (size_t offset = 0; offset < total_size;) {
-      void* chunk_addr =
-          reinterpret_cast<void*>(  // NOLINT(performance-no-int-to-ptr)
-              static_cast<uintptr_t>(te.addr_) + offset);
-
-      // Check if this chunk address is in our registered map
-      auto it = registeredMemMap_.find(chunk_addr);
-      if (it != registeredMemMap_.end() && it->second.device == te.device_) {
-        // Found a registered chunk, deregister it
-        size_t registered_size = it->second.len;
-
-        for (auto& comm : registeredComms_) {
-          if (te.device_ == comm->getDevice().index()) {
-            comm->deregister_address(TorchCommNCCLX::Address(chunk_addr));
-          }
-        }
-
-        registeredMemMap_.erase(it);
-
-        // Move to the next potential chunk by the size we just deregistered
-        offset += registered_size;
-      } else {
-        // No registered chunk found at this address - this indicates a
-        // serious inconsistency between MAP and UNMAP events
-        LOG(ERROR) << "[CCA] SEGMENT_UNMAP: No registered chunk at 0x"
-                   << std::hex << chunk_addr << std::dec << " offset=" << offset
-                   << " total_size=" << total_size;
-        throw std::runtime_error(
-            "SEGMENT_UNMAP: Expected registered chunk not found");
-      }
-    }
+    TorchCommNCCLX::global_deregister_address(
+        TorchCommNCCLX::AddressWithLen{addr, len}, nccl_api_.get());
   }
 }
 
-void CachingAllocatorHookImpl::registerComm(TorchCommNCCLX* comm) {
-  std::lock_guard<std::mutex> lock(mutex_);
-
-  // Check if the communicator is already registered
-  if (registeredComms_.contains(comm)) {
-    throw std::runtime_error("Communicator already registered");
-  }
-
-  // Register all memory that has already been allocated
-  for (const auto& [addr, mem_info] : registeredMemMap_) {
-    if (mem_info.device == comm->getDevice().index()) {
-      comm->register_address(
-          TorchCommNCCLX::AddressWithLen(addr, mem_info.len));
-    }
-  }
-
-  registeredComms_.insert(comm);
-}
-
-void CachingAllocatorHookImpl::deregisterComm(TorchCommNCCLX* comm) {
-  std::lock_guard<std::mutex> lock(mutex_);
-
-  if (!registeredComms_.contains(comm)) {
-    // Should this be fatal?
-    return;
-  }
-
-  // De-register all memory that has already been allocated
-  for (const auto& [addr, mem_info] : registeredMemMap_) {
-    if (mem_info.device == comm->getDevice().index()) {
-      comm->deregister_address(TorchCommNCCLX::Address(addr));
-    }
-  }
-
-  registeredComms_.erase(comm);
-}
-
-void CachingAllocatorHookImpl::clear() {
-  std::lock_guard<std::mutex> lock(mutex_);
-  for (auto& comm : registeredComms_) {
-    for (const auto& [addr, mem_info] : registeredMemMap_) {
-      if (mem_info.device == comm->getDevice().index()) {
-        comm->deregister_address(TorchCommNCCLX::Address(addr));
-      }
-    }
-  }
-  registeredMemMap_.clear();
-  registeredComms_.clear();
-}
-
-bool CachingAllocatorHookImpl::isCommRegistered(TorchCommNCCLX* comm) {
-  std::lock_guard<std::mutex> lock(mutex_);
-  return registeredComms_.contains(comm);
-}
-
-bool CachingAllocatorHookImpl::isMemRegisteredCalled() {
+bool CachingAllocatorHookImpl::isMemPreHookRegistered() {
   return mem_pre_hook_registered_;
 }
 

--- a/comms/torchcomms/ncclx/TorchCommNCCLXCCA.hpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXCCA.hpp
@@ -6,6 +6,7 @@
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <memory>
 #include <mutex>
+#include "comms/torchcomms/ncclx/NcclxApi.hpp"
 #include "comms/torchcomms/ncclx/TorchCommNCCLX.hpp"
 
 namespace torch::comms {
@@ -15,35 +16,28 @@ class CachingAllocatorHookImpl {
   virtual ~CachingAllocatorHookImpl() = default;
   virtual void regDeregMem(
       const c10::cuda::CUDACachingAllocator::TraceEntry& te);
-  virtual void registerComm(TorchCommNCCLX* comm);
-  virtual void deregisterComm(TorchCommNCCLX* comm);
   virtual void registerMemPreHook();
-  virtual void clear();
-
-  virtual bool isCommRegistered(TorchCommNCCLX* comm);
 
   // For testing purposes.
-  bool isMemRegisteredCalled();
+  virtual bool isMemPreHookRegistered();
 
- private:
-  std::mutex mutex_;
+  // Set the NcclxApi to use for registration. For testing.
+  void setNcclApi(std::shared_ptr<NcclxApi> api) {
+    nccl_api_ = std::move(api);
+  }
 
-  struct MemInfo {
-    size_t len;
-    int32_t device;
+  NcclxApi* getNcclApi() const {
+    return nccl_api_.get();
+  }
 
-    MemInfo(size_t l, int32_t d) : len(l), device(d) {}
-  };
-
-  // Map of registered memory addresses to their sizes and device
-  std::unordered_map<void*, MemInfo> registeredMemMap_;
-  // Set of registered communicators. TorchComms, manages it's membership inside
-  // this set.
-  std::set<TorchCommNCCLX*> registeredComms_;
-
+ protected:
   // Flag to indicate if the memory pre hook is registered. (For testing
   // purposes)
   bool mem_pre_hook_registered_ = false;
+
+  // NcclxApi used for global registration operations.
+  // Initialized to DefaultNcclxApi by default.
+  std::shared_ptr<NcclxApi> nccl_api_ = std::make_shared<DefaultNcclxApi>();
 };
 
 class DefaultCachingAllocatorHookImpl : public CachingAllocatorHookImpl {

--- a/comms/torchcomms/ncclx/TorchCommNCCLXUtils.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXUtils.cpp
@@ -470,13 +470,10 @@ void TorchCommNCCLX::returnEvent(cudaEvent_t event) {
 }
 
 void TorchCommNCCLX::attachMemoryHook() {
-  TC_LOG(INFO, this) << "Attaching memory hook comm=" << this;
-  CachingAllocatorHook::getInstance().registerComm(this);
-}
-
-void TorchCommNCCLX::detachMemoryHook() {
-  TC_LOG(INFO, this) << "Detaching memory hook comm=" << this;
-  CachingAllocatorHook::getInstance().deregisterComm(this);
+  // Initialize the CachingAllocatorHook singleton.
+  // This attaches the CCA trace hook and registers any pre-existing
+  // allocations.
+  CachingAllocatorHook::getInstance();
 }
 
 } // namespace torch::comms

--- a/comms/torchcomms/ncclx/tests/unit/cpp/GraphEventTrackerTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/GraphEventTrackerTest.cpp
@@ -83,8 +83,6 @@ class GraphEventTrackerTest : public TorchCommNCCLXTest {
 };
 
 TEST_F(GraphEventTrackerTest, GraphTimeoutCausesProcessDeath) {
-  setupCCAExpectations(0, 0, 1);
-
   EXPECT_DEATH(
       {
         cuda_mock_->setupDefaultBehaviors();
@@ -116,8 +114,6 @@ TEST_F(GraphEventTrackerTest, GraphTimeoutCausesProcessDeath) {
 TEST_F(
     GraphEventTrackerTest,
     GraphTimeoutAfterSuccessfulReplayCausesProcessDeath) {
-  setupCCAExpectations(0, 0, 1);
-
   // After a first replay completes, a second that hangs is still detected
   // as a timeout.  The sequence:
   //   1. end_event NOT REACHED  (first poll — replay in progress)
@@ -158,8 +154,6 @@ TEST_F(
 }
 
 TEST_F(GraphEventTrackerTest, GraphCaptureWorkObjectsDestroyedAfterCapture) {
-  setupCCAExpectations(1, 2, 1);
-
   auto comm = createMockedTorchComm();
   cuda_mock_->setupDefaultBehaviors();
   nccl_mock_->setupDefaultBehaviors();
@@ -186,8 +180,6 @@ TEST_F(GraphEventTrackerTest, GraphCaptureWorkObjectsDestroyedAfterCapture) {
 }
 
 TEST_F(GraphEventTrackerTest, GraphDestroyCleanupDestroysMonitorEvents) {
-  setupCCAExpectations(1, 2, 1);
-
   auto comm = createMockedTorchComm();
   cuda_mock_->setupDefaultBehaviors();
   nccl_mock_->setupDefaultBehaviors();
@@ -230,8 +222,6 @@ TEST_F(GraphEventTrackerTest, GraphDestroyCleanupDestroysMonitorEvents) {
 }
 
 TEST_F(GraphEventTrackerTest, CheckAllReturnsOKWhenNoEntries) {
-  setupCCAExpectations(1, 2, 1);
-
   auto comm = createMockedTorchComm();
   cuda_mock_->setupDefaultBehaviors();
   nccl_mock_->setupDefaultBehaviors();
@@ -257,8 +247,6 @@ TEST_F(GraphEventTrackerTest, CheckAllReturnsOKWhenNoEntries) {
 }
 
 TEST_F(GraphEventTrackerTest, CheckAllReturnsErrorOnCudaFailure) {
-  setupCCAExpectations(0, 0, 1);
-
   EXPECT_DEATH(
       {
         cuda_mock_->setupDefaultBehaviors();
@@ -286,8 +274,6 @@ TEST_F(GraphEventTrackerTest, CheckAllReturnsErrorOnCudaFailure) {
 }
 
 TEST_F(GraphEventTrackerTest, ReplayCounterResetsTimer) {
-  setupCCAExpectations(1, 2, 1);
-
   cuda_mock_->setupDefaultBehaviors();
   nccl_mock_->setupDefaultBehaviors();
 
@@ -351,8 +337,6 @@ TEST_F(GraphEventTrackerTest, ReplayCounterResetsTimer) {
 // destroyAll should destroy exactly the entry-owned events. We track which
 // events are destroyed to verify precise cleanup.
 TEST_F(GraphEventTrackerTest, DestroyAllCleansUpGraphEntryEvents) {
-  setupCCAExpectations(1, 2, 1);
-
   auto comm = createMockedTorchComm();
   cuda_mock_->setupDefaultBehaviors();
   nccl_mock_->setupDefaultBehaviors();
@@ -403,8 +387,6 @@ TEST_F(GraphEventTrackerTest, DestroyAllCleansUpGraphEntryEvents) {
 // Verify that the cleanup callback only sets the released flag when a graph
 // contains multiple captured collectives, without destroying events directly.
 TEST_F(GraphEventTrackerTest, MultipleCollectivesInSameGraphCleanedUp) {
-  setupCCAExpectations(1, 2, 1);
-
   auto comm = createMockedTorchComm();
   cuda_mock_->setupDefaultBehaviors();
   nccl_mock_->setupDefaultBehaviors();
@@ -468,8 +450,6 @@ TEST_F(GraphEventTrackerTest, MultipleCollectivesInSameGraphCleanedUp) {
 // Verify that when userObjectCreate fails during graph capture init,
 // the pool entry is harmless (no leak) and the error propagates.
 TEST_F(GraphEventTrackerTest, UserObjectCreateFailureCleanup) {
-  setupCCAExpectations(1, 2, 1);
-
   auto comm = createMockedTorchComm();
   cuda_mock_->setupDefaultBehaviors();
   nccl_mock_->setupDefaultBehaviors();
@@ -503,8 +483,6 @@ TEST_F(GraphEventTrackerTest, UserObjectCreateFailureCleanup) {
 // Verify that when graphRetainUserObject fails, the RAII guard releases the
 // user_object (via userObjectRelease) and the error propagates.
 TEST_F(GraphEventTrackerTest, GraphRetainUserObjectFailureCleanup) {
-  setupCCAExpectations(1, 2, 1);
-
   auto comm = createMockedTorchComm();
   cuda_mock_->setupDefaultBehaviors();
   nccl_mock_->setupDefaultBehaviors();
@@ -537,8 +515,6 @@ TEST_F(GraphEventTrackerTest, GraphRetainUserObjectFailureCleanup) {
 }
 
 TEST_F(GraphEventTrackerTest, CheckAllCleansUpReleasedGraphs) {
-  setupCCAExpectations(1, 2, 1);
-
   auto comm = createMockedTorchComm();
   cuda_mock_->setupDefaultBehaviors();
   nccl_mock_->setupDefaultBehaviors();
@@ -589,8 +565,6 @@ TEST_F(GraphEventTrackerTest, CheckAllCleansUpReleasedGraphs) {
 }
 
 TEST_F(GraphEventTrackerTest, MultipleGraphsOnlyReleasedOneCleanedUp) {
-  setupCCAExpectations(1, 2, 1);
-
   auto comm = createMockedTorchComm();
   cuda_mock_->setupDefaultBehaviors();
   nccl_mock_->setupDefaultBehaviors();
@@ -692,8 +666,6 @@ TEST_F(GraphEventTrackerTest, MultipleGraphsOnlyReleasedOneCleanedUp) {
 }
 
 TEST_F(GraphEventTrackerTest, DestroyAllIgnoresReleasedFlag) {
-  setupCCAExpectations(1, 2, 1);
-
   auto comm = createMockedTorchComm();
   cuda_mock_->setupDefaultBehaviors();
   nccl_mock_->setupDefaultBehaviors();
@@ -755,8 +727,6 @@ TEST_F(GraphEventTrackerTest, DestroyAllIgnoresReleasedFlag) {
 }
 
 TEST_F(GraphEventTrackerTest, EventResetByReplayDefeatsTimeout) {
-  setupCCAExpectations(0, 0, 1);
-
   EXPECT_DEATH(
       {
         cuda_mock_->setupDefaultBehaviors();
@@ -807,8 +777,6 @@ TEST_F(GraphEventTrackerTest, EventResetByReplayDefeatsTimeout) {
 // Test that alltoallv_dynamic_dispatch works correctly during graph capture
 // mode. The work object stores output tensors and CPU pointer tensor.
 TEST_F(GraphEventTrackerTest, GraphCaptureDispatchSavesOutputTensors) {
-  setupCCAExpectations(1, 2, 1);
-
   auto comm = createMockedTorchComm();
   cuda_mock_->setupDefaultBehaviors();
   nccl_mock_->setupDefaultBehaviors();
@@ -871,8 +839,6 @@ TEST_F(GraphEventTrackerTest, GraphCaptureDispatchSavesOutputTensors) {
 // Test that alltoallv_dynamic_combine works correctly during graph capture
 // mode. The work object stores the output tensor.
 TEST_F(GraphEventTrackerTest, GraphCaptureCombineSavesOutputTensor) {
-  setupCCAExpectations(1, 2, 1);
-
   auto comm = createMockedTorchComm();
   cuda_mock_->setupDefaultBehaviors();
   nccl_mock_->setupDefaultBehaviors();
@@ -926,7 +892,6 @@ TEST_F(GraphEventTrackerTest, GraphCaptureCombineSavesOutputTensor) {
 
 TEST_F(GraphEventTrackerTest, TimeoutMonitoringDisabled_NoStartEndEvents) {
   resetGraphTimeoutMonitoringCacheForTest();
-  setupCCAExpectations(1, 2, 1);
 
   auto comm = createMockedTorchComm();
   cuda_mock_->setupDefaultBehaviors();
@@ -974,7 +939,6 @@ TEST_F(
     GraphEventTrackerTest,
     TimeoutMonitoringDisabled_CpuTensorsStillTransferred) {
   resetGraphTimeoutMonitoringCacheForTest();
-  setupCCAExpectations(1, 2, 1);
 
   auto comm = createMockedTorchComm();
   cuda_mock_->setupDefaultBehaviors();
@@ -1044,7 +1008,6 @@ TEST_F(
     GraphEventTrackerTest,
     TimeoutMonitoringDisabled_CheckGraphEventsNoEventQueries) {
   resetGraphTimeoutMonitoringCacheForTest();
-  setupCCAExpectations(1, 2, 1);
 
   auto comm = createMockedTorchComm();
   cuda_mock_->setupDefaultBehaviors();

--- a/comms/torchcomms/ncclx/tests/unit/cpp/HintParsingTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/HintParsingTest.cpp
@@ -25,7 +25,6 @@ class HintParsingTest : public TorchCommNCCLXTest {
 };
 
 TEST_F(HintParsingTest, DefaultConfigValues) {
-  setupCCAExpectations(1, 2, 1);
   auto comm = createMockedTorchComm();
   cuda_mock_->setupDefaultBehaviors();
   nccl_mock_->setupDefaultBehaviors();
@@ -43,7 +42,6 @@ TEST_F(HintParsingTest, DefaultConfigValues) {
 }
 
 TEST_F(HintParsingTest, MaxEventPoolSizeHint) {
-  setupCCAExpectations(1, 2, 1);
   auto comm = createMockedTorchComm();
   cuda_mock_->setupDefaultBehaviors();
   nccl_mock_->setupDefaultBehaviors();
@@ -58,7 +56,6 @@ TEST_F(HintParsingTest, MaxEventPoolSizeHint) {
 }
 
 TEST_F(HintParsingTest, GarbageCollectIntervalMsHint) {
-  setupCCAExpectations(1, 2, 1);
   auto comm = createMockedTorchComm();
   cuda_mock_->setupDefaultBehaviors();
   nccl_mock_->setupDefaultBehaviors();
@@ -73,7 +70,6 @@ TEST_F(HintParsingTest, GarbageCollectIntervalMsHint) {
 }
 
 TEST_F(HintParsingTest, EnableCudaGraphSupportHint) {
-  setupCCAExpectations(1, 2, 1);
   auto comm = createMockedTorchComm();
   cuda_mock_->setupDefaultBehaviors();
   nccl_mock_->setupDefaultBehaviors();
@@ -88,7 +84,6 @@ TEST_F(HintParsingTest, EnableCudaGraphSupportHint) {
 }
 
 TEST_F(HintParsingTest, GraphTimeoutCheckIntervalMsHint) {
-  setupCCAExpectations(1, 2, 1);
   auto comm = createMockedTorchComm();
   cuda_mock_->setupDefaultBehaviors();
   nccl_mock_->setupDefaultBehaviors();
@@ -103,7 +98,6 @@ TEST_F(HintParsingTest, GraphTimeoutCheckIntervalMsHint) {
 }
 
 TEST_F(HintParsingTest, AllHintsCombined) {
-  setupCCAExpectations(1, 2, 1);
   auto comm = createMockedTorchComm();
   cuda_mock_->setupDefaultBehaviors();
   nccl_mock_->setupDefaultBehaviors();
@@ -131,7 +125,6 @@ TEST_F(HintParsingTest, AllHintsCombined) {
 }
 
 TEST_F(HintParsingTest, UnknownHintsIgnored) {
-  setupCCAExpectations(1, 2, 1);
   auto comm = createMockedTorchComm();
   cuda_mock_->setupDefaultBehaviors();
   nccl_mock_->setupDefaultBehaviors();

--- a/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXCommDumpTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXCommDumpTest.cpp
@@ -55,8 +55,6 @@ TEST_F(TorchCommNCCLXCommDumpTest, CommDumpSuccess) {
           SetArgPointee<0>(reinterpret_cast<ncclComm_t>(0x3000)),
           Return(ncclSuccess)));
 
-  setupCCAExpectations(1, 2, 1);
-
   torchcomm->init(*device_, "test_comm", default_options_);
 
   setupNormalDestruction(*torchcomm);
@@ -92,8 +90,6 @@ TEST_F(TorchCommNCCLXCommDumpTest, CommDumpFailure) {
       .WillOnce(DoAll(
           SetArgPointee<0>(reinterpret_cast<ncclComm_t>(0x3000)),
           Return(ncclSuccess)));
-
-  setupCCAExpectations(1, 1, 1);
 
   // After NCCLXException from commDump, the comm will be aborted
   EXPECT_CALL(*nccl_mock_, commAbort(_)).WillOnce(Return(ncclSuccess));

--- a/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTest.cpp
@@ -24,8 +24,6 @@ namespace torch::comms::test {
 // ============================================================================
 
 TEST_F(TorchCommNCCLXTest, TestOptionsEnvironmentVariables) {
-  setupCCAExpectations(0, 0, 1);
-
   setOptionsEnvironmentVariables(false, 1); // false abort, 1 second
 
   CommOptions options1;
@@ -108,12 +106,6 @@ TEST_F(TorchCommNCCLXTest, InitializationRank0GetUniqueId) {
   // store
   setupRankAndSize(0, 2); // rank 0, size 2
 
-  // Setup CCA expectations
-  // Register - 1 (init)
-  // Deregister - 2 (finalize, destructor)
-  // Clear - 1 (destructor)
-  setupCCAExpectations(1, 2, 1);
-
   cuda_mock_->setupDefaultBehaviors();
 
   auto comm = createMockedTorchComm();
@@ -153,12 +145,6 @@ TEST_F(TorchCommNCCLXTest, InitializationNonRank0ReadUniqueId) {
   // get it from store
   setupRankAndSize(1, 2); // rank 1, size 2
 
-  // Setup CCA expectations
-  // Register - 1 (init)
-  // Deregister - 2 (finalize, destructor)
-  // Clear - 1 (destructor)
-  setupCCAExpectations(1, 2, 1);
-
   auto bootstrap = new TorchCommNCCLXBootstrap(
       store_, *device_, nccl_mock_, cuda_mock_, std::chrono::seconds(60));
   auto store_key = bootstrap->getNCCLXStoreKeyPrefix() +
@@ -195,9 +181,6 @@ TEST_F(TorchCommNCCLXTest, InitializationNonRank0ReadUniqueId) {
 TEST_F(TorchCommNCCLXTest, InitializationFailsWithInvalidDeviceId) {
   // Test: TorchComm creation should fail when device ID is invalid
   setupRankAndSize(0, 2); // rank 0, size 2
-
-  // Setup CCA expectations - first init (device -1) should succeed
-  setupCCAExpectations(1, 2, 0);
 
   cuda_mock_->setupDefaultBehaviors();
 
@@ -248,9 +231,6 @@ TEST_F(TorchCommNCCLXTest, InitializationFailsWithInvalidDeviceId) {
   ::testing::Mock::VerifyAndClear(nccl_mock_.get());
   ::testing::Mock::VerifyAndClear(mock_hook_);
 
-  // Setup CCA expectations - no init should succeed, so only destructor calls
-  setupCCAExpectations(0, 1, 1);
-
   // Test with device ID larger than available devices
   {
     at::Device invalid_device(at::DeviceType::CUDA, 127);
@@ -279,12 +259,6 @@ TEST_F(TorchCommNCCLXTest, InitializationFailsWithInvalidDeviceId) {
 // ============================================================================
 
 TEST_F(TorchCommNCCLXTest, FinalizeNoJobsScheduled) {
-  // Setup CCA expectations
-  // Register - 1 (init)
-  // Deregister - 2 (finalize, destructor)
-  // Clear - 1 (destructor)
-  setupCCAExpectations(1, 2, 1);
-
   // Test: if no jobs are scheduled, finalize() returns immediately
   auto comm = createMockedTorchComm();
 
@@ -300,12 +274,6 @@ TEST_F(TorchCommNCCLXTest, FinalizeNoJobsScheduled) {
 }
 
 TEST_F(TorchCommNCCLXTest, FinalizeWorkNotFinishedWaitsForCompletion) {
-  // Setup CCA expectations
-  // Register - 1 (init)
-  // Deregister - 2 (finalize, destructor)
-  // Clear - 1 (destructor)
-  setupCCAExpectations(1, 2, 1);
-
   // Test: if work is scheduled but not finished, finalize waits until work
   // completes
   auto comm = createMockedTorchComm();
@@ -363,12 +331,6 @@ TEST_F(TorchCommNCCLXTest, FinalizeWorkNotFinishedWaitsForCompletion) {
 }
 
 TEST_F(TorchCommNCCLXTest, FinalizeWorkErrorThrowsNCCLXException) {
-  // Setup CCA expectations
-  // Register - 1 (init)
-  // Deregister - 2 (finalize, destructor)
-  // Clear - 1 (destructor)
-  setupCCAExpectations(1, 2, 1);
-
   // Test: if work errors because cudaEventQuery returns error, finalize throws
   // NCCLXException
   auto comm = createMockedTorchComm();
@@ -402,12 +364,6 @@ TEST_F(TorchCommNCCLXTest, FinalizeWorkErrorThrowsNCCLXException) {
 }
 
 TEST_F(TorchCommNCCLXTest, FinalizeWorkTimeoutThrowsRuntimeError) {
-  // Setup CCA expectations
-  // Register - 1 (init)
-  // Deregister - 2 (finalize, destructor)
-  // Clear - 1 (destructor)
-  setupCCAExpectations(1, 2, 1);
-
   // Test: if work times out, finalize throws std::runtime_error
   auto comm = createMockedTorchComm();
 
@@ -445,12 +401,6 @@ TEST_F(TorchCommNCCLXTest, FinalizeWorkTimeoutThrowsRuntimeError) {
 // ============================================================================
 // TODO: add more tests for other collectives
 TEST_F(TorchCommNCCLXTest, WorkErrorCausesAbortDuringCollective) {
-  // Setup CCA expectations
-  // Register - 1 (init)
-  // Deregister - 3 (abort, finalize, destructor)
-  // Clear - 1 (destructor)
-  setupCCAExpectations(1, 3, 1);
-
   // Test: if work errors, calling TorchCommNCCLX method calls commAbort and
   // throws NCCLXException
   auto comm = createMockedTorchComm();
@@ -490,12 +440,6 @@ TEST_F(TorchCommNCCLXTest, WorkErrorCausesAbortDuringCollective) {
 }
 
 TEST_F(TorchCommNCCLXTest, WorkDefaultTimeoutCausesAbortDuringCollective) {
-  // Setup CCA expectations
-  // Register - 1 (init)
-  // Deregister - 3 (abort, finalize, destructor)
-  // Clear - 1 (destructor)
-  setupCCAExpectations(1, 3, 1);
-
   // Test: if work errors, calling TorchCommNCCLX method calls commAbort and
   // throws NCCLXException
   auto comm = createMockedTorchComm();
@@ -528,12 +472,6 @@ TEST_F(TorchCommNCCLXTest, WorkDefaultTimeoutCausesAbortDuringCollective) {
 }
 
 TEST_F(TorchCommNCCLXTest, WorkOperationTimeoutCausesAbortDuringCollective) {
-  // Setup CCA expectations
-  // Register - 1 (init)
-  // Deregister - 3 (abort, finalize, destructor)
-  // Clear - 1 (destructor)
-  setupCCAExpectations(1, 3, 1);
-
   // Test: if work errors, calling TorchCommNCCLX method calls commAbort and
   // throws NCCLXException
   auto comm = createMockedTorchComm();
@@ -571,11 +509,9 @@ TEST_F(TorchCommNCCLXTest, WorkOperationTimeoutCausesAbortDuringCollective) {
 }
 
 TEST_F(TorchCommNCCLXTest, AbortProcessOnTimeoutCausesProcessDeath) {
-  // Setup CCA expectations
   // constructor, init, destructor are in the EXPECT_DEATH macro, which don't
   // count towards the expectations.  We only count the clear call in the
   // teardown.
-  setupCCAExpectations(0, 0, 1);
 
   // Test: when abort_process_on_timeout_or_error is true, timeout should cause
   // process death
@@ -620,273 +556,7 @@ TEST_F(TorchCommNCCLXTest, AbortProcessOnTimeoutCausesProcessDeath) {
       ".*"); // Match any death message
 }
 
-TEST_F(
-    TorchCommNCCLXTest,
-    CachingAllocatorHookRegistersAndUnregistersOnCreateAndDestroy) {
-  // Setup CCA expectations
-  // Register - 1 (init)
-  // Deregister - 1 (destructor)
-  // Clear - 1 (destructor)
-  setupCCAExpectations(1, 1, 1);
-
-  cuda_mock_->setupDefaultBehaviors();
-  nccl_mock_->setupDefaultBehaviors();
-
-  auto comm = createMockedTorchComm();
-  EXPECT_FALSE(mock_hook_->isCommRegistered(comm.get()));
-  // fake registration of the comm.
-  mock_hook_->registerComm(comm.get());
-  // Destroy the comm
-  comm.reset();
-  EXPECT_FALSE(mock_hook_->isCommRegistered(comm.get()));
-}
-
-TEST_F(
-    TorchCommNCCLXTest,
-    CachingAllocatorHookRegistersAndUnregistersOnCreateAndFinalize) {
-  // Setup CCA expectations
-  // Register - 1 (init)
-  // Deregister - 2 (finalize, destructor)
-  // Clear - 1 (destructor)
-  setupCCAExpectations(1, 2, 1);
-
-  cuda_mock_->setupDefaultBehaviors();
-  nccl_mock_->setupDefaultBehaviors();
-
-  auto comm = createMockedTorchComm();
-  EXPECT_FALSE(mock_hook_->isCommRegistered(comm.get()));
-  comm->init(*device_, "test_name", default_options_);
-  // Check that the comm is registered
-  EXPECT_TRUE(mock_hook_->isCommRegistered(comm.get()));
-  // Finalize the comm
-  comm->finalize();
-  EXPECT_FALSE(mock_hook_->isCommRegistered(comm.get()));
-}
-
-TEST_F(
-    TorchCommNCCLXTest,
-    CachingAllocatorHookUnregistersOnTimeoutDuringFinalize) {
-  // Setup CCA expectations
-  // Register - 1 (init)
-  // Deregister - 2 (finalize, destructor)
-  // Clear - 1 (destructor)
-  setupCCAExpectations(1, 2, 1);
-
-  cuda_mock_->setupDefaultBehaviors();
-  nccl_mock_->setupDefaultBehaviors();
-
-  auto comm = createMockedTorchComm();
-
-  comm->init(*device_, "test_name", default_options_);
-  EXPECT_TRUE(mock_hook_->isCommRegistered(comm.get()));
-
-  setupEventsForWork(*comm, 1);
-  comm->barrier(true);
-
-  auto& work_event = work_events_[0];
-  setupWorkToTimeout(work_event);
-  comm->waitTillTimeout();
-
-  // Finalize should cause a timeout
-  EXPECT_THROW(comm->finalize(), std::runtime_error);
-  EXPECT_FALSE(mock_hook_->isCommRegistered(comm.get()));
-}
-
-TEST_F(
-    TorchCommNCCLXTest,
-    CachingAllocatorHookUnregistersOnErrorDuringFinalize) {
-  // Setup CCA expectations
-  // Register - 1 (init)
-  // Deregister - 2 (finalize, destructor)
-  // Clear - 1 (destructor)
-  setupCCAExpectations(1, 2, 1);
-
-  cuda_mock_->setupDefaultBehaviors();
-  nccl_mock_->setupDefaultBehaviors();
-
-  auto comm = createMockedTorchComm();
-
-  comm->init(*device_, "test_name", default_options_);
-
-  setupEventsForWork(*comm, 1);
-  comm->barrier(true);
-
-  auto& work_event = work_events_[0];
-  setupWorkToError(work_event);
-  comm->waitTillError();
-
-  // Finalize should cause an error
-  EXPECT_THROW(comm->finalize(), NCCLXException);
-  EXPECT_FALSE(mock_hook_->isCommRegistered(comm.get()));
-}
-
-TEST_F(
-    TorchCommNCCLXTest,
-    CachingAllocatorHookUnregistersOnErrorOrTimeoutDuringCollective) {
-  // Setup CCA expectations
-  // Register - 1 (init)
-  // Deregister - 3 (abort, finalize, destructor)
-  // Clear - 1 (destructor)
-  setupCCAExpectations(1, 3, 1);
-
-  cuda_mock_->setupDefaultBehaviors();
-  nccl_mock_->setupDefaultBehaviors();
-
-  auto comm = createMockedTorchComm();
-
-  comm->init(*device_, "test_name", default_options_);
-
-  setupEventsForWork(*comm, 1);
-
-  comm->barrier(true);
-
-  auto& work_event = work_events_[0];
-  setupWorkToTimeout(work_event);
-
-  comm->waitTillTimeout();
-  EXPECT_THROW(comm->barrier(true), std::runtime_error);
-  EXPECT_FALSE(mock_hook_->isCommRegistered(comm.get()));
-  EXPECT_THROW(comm->finalize(), std::runtime_error);
-}
-
-TEST_F(
-    TorchCommNCCLXTest,
-    CachingAllocatorHookMemoryRegistrationWithMultipleComms) {
-  CachingAllocatorHook::setInstance(
-      std::make_unique<CachingAllocatorHookImpl>());
-  auto& allocator = CachingAllocatorHook::getInstance();
-
-  cuda_mock_->setupDefaultBehaviors();
-  nccl_mock_->setupDefaultBehaviors();
-
-  // Create and initialize two communicators
-  auto comm1 = createMockedTorchComm();
-  auto comm2 = createMockedTorchComm();
-
-  comm1->init(*device_, "test_name", default_options_);
-  comm2->init(*device_, "test_name", default_options_);
-
-  // Create memory registration trace entry
-  auto alloc_entry = createAllocation(0x1000);
-
-  // Set up expectations for register_address on both comms
-  EXPECT_CALL(
-      *nccl_mock_, commRegister(_, reinterpret_cast<void*>(0x1000), 1024, _))
-      .Times(2)
-      .WillRepeatedly(DoAll(
-          SetArgPointee<3>(reinterpret_cast<void*>(0x2000)),
-          Return(ncclSuccess)));
-
-  // Simulate memory allocation
-  allocator.regDeregMem(alloc_entry);
-
-  // Create a third communicator after memory registration
-  auto comm3 = createMockedTorchComm();
-
-  // Set up expectations for register_address on the new comm for previously
-  // registered memory
-  EXPECT_CALL(
-      *nccl_mock_, commRegister(_, reinterpret_cast<void*>(0x1000), 1024, _))
-      .WillOnce(DoAll(
-          SetArgPointee<3>(reinterpret_cast<void*>(0x2000)),
-          Return(ncclSuccess)));
-
-  // Initialize the third comm - this should register all previously registered
-  // addresses
-  comm3->init(*device_, "test_name", default_options_);
-  EXPECT_TRUE(allocator.isCommRegistered(comm3.get()));
-
-  // Create memory deregistration trace entry
-  c10::cuda::CUDACachingAllocator::TraceEntry dealloc_entry =
-      createDeallocation(0x1000);
-  EXPECT_CALL(*nccl_mock_, commDeregister(_, reinterpret_cast<void*>(0x2000)))
-      .Times(1)
-      .WillRepeatedly(Return(ncclSuccess));
-
-  comm1->finalize();
-
-  // Set up expectations for deregister_address on all three comms
-  EXPECT_CALL(*nccl_mock_, commDeregister(_, reinterpret_cast<void*>(0x2000)))
-      .Times(2)
-      .WillRepeatedly(Return(ncclSuccess));
-
-  // Simulate memory deallocation
-  allocator.regDeregMem(dealloc_entry);
-
-  // Clean up
-  setupNormalDestruction(*comm2);
-  comm2->finalize();
-  setupNormalDestruction(*comm3);
-  comm3->finalize();
-}
-
-TEST_F(
-    TorchCommNCCLXTest,
-    CachingAllocatorHookMemoryRegistrationErrorHandling) {
-  // Test: Verify error handling during memory registration and deregistration
-  CachingAllocatorHook::setInstance(
-      std::make_unique<CachingAllocatorHookImpl>());
-  auto& allocator = CachingAllocatorHook::getInstance();
-
-  cuda_mock_->setupDefaultBehaviors();
-  nccl_mock_->setupDefaultBehaviors();
-
-  // Create and initialize a communicator
-  auto comm = createMockedTorchComm();
-  comm->init(*device_, "test_name", default_options_);
-
-  // Create memory registration trace entry
-  c10::cuda::CUDACachingAllocator::TraceEntry alloc_entry =
-      createAllocation(0x1000);
-  // Set up expectations for register_address to fail
-  EXPECT_CALL(
-      *nccl_mock_, commRegister(_, reinterpret_cast<void*>(0x1000), 1024, _))
-      .WillOnce(Return(ncclInvalidArgument));
-
-  EXPECT_CALL(*nccl_mock_, getErrorString(ncclInvalidArgument))
-      .WillRepeatedly(Return("Invalid argument"));
-
-  EXPECT_CALL(*nccl_mock_, getLastError(_))
-      .WillRepeatedly(Return("Invalid argument details"));
-
-  // Simulate memory allocation - should throw NCCLXException due to
-  // registration failure
-  EXPECT_THROW(allocator.regDeregMem(alloc_entry), NCCLXException);
-
-  // Try again with successful registration
-  EXPECT_CALL(
-      *nccl_mock_, commRegister(_, reinterpret_cast<void*>(0x2000), 1024, _))
-      .WillOnce(DoAll(
-          SetArgPointee<3>(reinterpret_cast<void*>(0x2000)),
-          Return(ncclSuccess)));
-
-  // Simulate successful memory allocation
-  auto alloc_entry2 = createAllocation(0x2000);
-  allocator.regDeregMem(alloc_entry2);
-
-  // Create memory deregistration trace entry
-  auto dealloc_entry = createDeallocation(0x2000);
-
-  // Set up expectations for deregister_address to fail
-  EXPECT_CALL(*nccl_mock_, commDeregister(_, reinterpret_cast<void*>(0x2000)))
-      .WillOnce(Return(ncclInvalidArgument));
-
-  // Simulate memory deallocation - should throw NCCLXException due to
-  // deregistration failure
-  EXPECT_THROW(allocator.regDeregMem(dealloc_entry), NCCLXException);
-
-  // Clean up
-  setupNormalDestruction(*comm);
-  comm->finalize();
-}
-
 TEST_F(TorchCommNCCLXTest, Getters) {
-  // Setup CCA expectations
-  // Register - 1 (init)
-  // Deregister - 2 (finalize, destructor)
-  // Clear - 1 (destructor)
-  setupCCAExpectations(1, 2, 1);
-
   auto comm = createMockedTorchComm();
 
   cuda_mock_->setupDefaultBehaviors();
@@ -909,7 +579,6 @@ TEST_F(TorchCommNCCLXTest, HighPriorityStreamCreation) {
   {
     setupRankAndSize(0, 2); // rank 0, size 2
     // we don't call teardown in this test, so no clear
-    setupCCAExpectations(1, 2, 0);
 
     auto comm = createMockedTorchComm();
 
@@ -940,7 +609,6 @@ TEST_F(TorchCommNCCLXTest, HighPriorityStreamCreation) {
   // High priority for stream creation.
   {
     setupRankAndSize(0, 2); // rank 0, size 2
-    setupCCAExpectations(1, 2, 1);
 
     auto options = CommOptions();
     options.hints[std::string(kHintHighPriorityStream)] = "true";
@@ -972,9 +640,6 @@ TEST_F(TorchCommNCCLXTest, HighPriorityStreamCreation) {
 // INITIALIZATION STATE TESTS
 // ============================================================================
 TEST_F(TorchCommNCCLXTest, InitialStateIsUninitialized) {
-  // Setup CCA expectations - no init/finalize calls
-  setupCCAExpectations(0, 1, 1);
-
   auto comm = createMockedTorchComm();
 
   // Access the initialization state through a test-specific method
@@ -995,12 +660,6 @@ TEST_F(TorchCommNCCLXTest, InitialStateIsUninitialized) {
 }
 
 TEST_F(TorchCommNCCLXTest, InitializationStateTransitionsCorrectly) {
-  // Setup CCA expectations
-  // Register - 1 (init)
-  // Deregister - 2 (finalize, destructor)
-  // Clear - 1 (destructor)
-  setupCCAExpectations(1, 2, 1);
-
   auto comm = createMockedTorchComm();
 
   cuda_mock_->setupDefaultBehaviors();
@@ -1015,12 +674,6 @@ TEST_F(TorchCommNCCLXTest, InitializationStateTransitionsCorrectly) {
 }
 
 TEST_F(TorchCommNCCLXTest, DoubleInitializationThrowsException) {
-  // Setup CCA expectations
-  // Register - 1 (first init)
-  // Deregister - 2 (finalize, destructor)
-  // Clear - 1 (destructor)
-  setupCCAExpectations(1, 2, 1);
-
   auto comm = createMockedTorchComm();
 
   cuda_mock_->setupDefaultBehaviors();
@@ -1048,12 +701,6 @@ TEST_F(TorchCommNCCLXTest, DoubleInitializationThrowsException) {
 }
 
 TEST_F(TorchCommNCCLXTest, DoubleFinalizeThrowsException) {
-  // Setup CCA expectations
-  // Register - 1 (init)
-  // Deregister - 2 (finalize, destructor)
-  // Clear - 1 (destructor)
-  setupCCAExpectations(1, 2, 1);
-
   auto comm = createMockedTorchComm();
 
   cuda_mock_->setupDefaultBehaviors();
@@ -1081,12 +728,6 @@ TEST_F(TorchCommNCCLXTest, DoubleFinalizeThrowsException) {
 }
 
 TEST_F(TorchCommNCCLXTest, InitializeAfterFinalizeThrowsException) {
-  // Setup CCA expectations
-  // Register - 1 (first init)
-  // Deregister - 2 (finalize, destructor)
-  // Clear - 1 (destructor)
-  setupCCAExpectations(1, 2, 1);
-
   auto comm = createMockedTorchComm();
 
   cuda_mock_->setupDefaultBehaviors();
@@ -1112,9 +753,6 @@ TEST_F(TorchCommNCCLXTest, InitializeAfterFinalizeThrowsException) {
 }
 
 TEST_F(TorchCommNCCLXTest, FinalizeWithoutInitializeThrowsException) {
-  // Setup CCA expectations - no init/finalize calls
-  setupCCAExpectations(0, 1, 1);
-
   auto comm = createMockedTorchComm();
 
   // Attempting to finalize without initialization should throw
@@ -1134,9 +772,6 @@ TEST_F(TorchCommNCCLXTest, FinalizeWithoutInitializeThrowsException) {
 TEST_F(
     TorchCommNCCLXTest,
     CollectiveOperationsWithoutInitializationThrowException) {
-  // Setup CCA expectations - no init calls
-  setupCCAExpectations(0, 1, 1);
-
   auto comm = createMockedTorchComm();
 
   // Initialize and then finalize the communicator
@@ -1210,9 +845,6 @@ TEST_F(
 }
 
 TEST_F(TorchCommNCCLXTest, CollectiveOperationsAfterFinalizeThrowException) {
-  // Setup CCA expectations - init and finalize calls
-  setupCCAExpectations(1, 2, 1);
-
   auto comm = createMockedTorchComm();
 
   // Initialize and then finalize the communicator
@@ -1303,9 +935,6 @@ class TorchCommNCCLXPreHookTest : public TorchCommNCCLXTest {
 };
 
 TEST_F(TorchCommNCCLXPreHookTest, MemAllocatedBeforeCommRegistered) {
-  // Setup CCA expectations - init and finalize calls
-  setupCCAExpectations(1, 2, 1);
-
   auto comm = createMockedTorchComm();
 
   // Initialize and then finalize the communicator
@@ -1313,13 +942,165 @@ TEST_F(TorchCommNCCLXPreHookTest, MemAllocatedBeforeCommRegistered) {
   nccl_mock_->setupDefaultBehaviors();
 
   comm->init(*device_, "test_name", default_options_);
-  EXPECT_TRUE(mock_hook_->isMemRegisteredCalled());
+  EXPECT_TRUE(mock_hook_->isMemPreHookRegistered());
   comm->finalize();
+}
+
+// ============================================================================
+// GLOBAL REGISTRATION TESTS
+// ============================================================================
+
+TEST_F(TorchCommNCCLXTest, GlobalRegisterAddressSuccess) {
+  // Test: Verify global_register_address succeeds when NCCL returns success
+
+  void* test_addr = reinterpret_cast<void*>(0x1000);
+  size_t test_len = 1024;
+
+  // Set up expectation for global registration to succeed
+  EXPECT_CALL(*nccl_mock_, globalRegisterWithPtr(test_addr, test_len))
+      .WillOnce(Return(ncclSuccess));
+
+  // Execute: call global_register_address with the mock API
+  EXPECT_NO_THROW(
+      TorchCommNCCLX::global_register_address(
+          TorchCommNCCLX::AddressWithLen{test_addr, test_len},
+          nccl_mock_.get()));
+}
+
+TEST_F(TorchCommNCCLXTest, GlobalDeregisterAddressSuccess) {
+  // Test: Verify global_deregister_address succeeds when NCCL returns success
+
+  void* test_addr = reinterpret_cast<void*>(0x2000);
+  size_t test_len = 2048;
+
+  // Set up expectation for global deregistration to succeed
+  EXPECT_CALL(*nccl_mock_, globalDeregisterWithPtr(test_addr, test_len))
+      .WillOnce(Return(ncclSuccess));
+
+  // Execute: call global_deregister_address with the mock API
+  EXPECT_NO_THROW(
+      TorchCommNCCLX::global_deregister_address(
+          TorchCommNCCLX::AddressWithLen{test_addr, test_len},
+          nccl_mock_.get()));
+}
+
+TEST_F(TorchCommNCCLXTest, GlobalRegisterAddressFailure) {
+  // Test: Verify global_register_address logs warning (does not throw) on NCCL
+  // failure. Registration is best-effort — when ctran is not enabled, it's
+  // expected to fail silently.
+
+  void* test_addr = reinterpret_cast<void*>(0x3000);
+  size_t test_len = 4096;
+
+  // Set up expectation for global registration to fail
+  EXPECT_CALL(*nccl_mock_, globalRegisterWithPtr(test_addr, test_len))
+      .WillOnce(Return(ncclInvalidArgument));
+
+  EXPECT_CALL(*nccl_mock_, getErrorString(ncclInvalidArgument))
+      .WillOnce(Return("invalid argument"));
+
+  // Execute: call global_register_address — should not throw
+  EXPECT_NO_THROW(
+      TorchCommNCCLX::global_register_address(
+          TorchCommNCCLX::AddressWithLen{test_addr, test_len},
+          nccl_mock_.get()));
+}
+
+TEST_F(TorchCommNCCLXTest, GlobalDeregisterAddressFailure) {
+  // Test: Verify global_deregister_address logs warning (does not throw) on
+  // NCCL failure. Deregistration is best-effort — when ctran is not enabled,
+  // it's expected to fail silently.
+
+  void* test_addr = reinterpret_cast<void*>(0x4000);
+  size_t test_len = 8192;
+
+  // Set up expectation for global deregistration to fail
+  EXPECT_CALL(*nccl_mock_, globalDeregisterWithPtr(test_addr, test_len))
+      .WillOnce(Return(ncclInvalidArgument));
+
+  EXPECT_CALL(*nccl_mock_, getErrorString(ncclInvalidArgument))
+      .WillOnce(Return("invalid argument"));
+
+  // Execute: call global_deregister_address — should not throw
+  EXPECT_NO_THROW(
+      TorchCommNCCLX::global_deregister_address(
+          TorchCommNCCLX::AddressWithLen{test_addr, test_len},
+          nccl_mock_.get()));
+}
+
+TEST_F(
+    TorchCommNCCLXTest,
+    CachingAllocatorHookCallsGlobalRegisterOnSegmentAlloc) {
+  // Test: Verify that CCA hook calls global_register_address on SEGMENT_ALLOC
+  // The mock_hook_ already has nccl_mock_ set via SetUp()
+  auto hook = std::make_unique<CachingAllocatorHookImpl>();
+  hook->setNcclApi(nccl_mock_);
+  CachingAllocatorHook::setInstance(std::move(hook));
+  auto& allocator = CachingAllocatorHook::getInstance();
+
+  // Create memory allocation trace entry
+  auto alloc_entry = createAllocation(0x5000);
+
+  // Set up expectation for global registration to be called
+  EXPECT_CALL(
+      *nccl_mock_, globalRegisterWithPtr(reinterpret_cast<void*>(0x5000), 1024))
+      .WillOnce(Return(ncclSuccess));
+
+  // Execute: simulate memory allocation event
+  allocator.regDeregMem(alloc_entry);
+}
+
+TEST_F(
+    TorchCommNCCLXTest,
+    CachingAllocatorHookCallsGlobalDeregisterOnSegmentFree) {
+  // Test: Verify that CCA hook calls global_deregister_address on SEGMENT_FREE
+  auto hook = std::make_unique<CachingAllocatorHookImpl>();
+  hook->setNcclApi(nccl_mock_);
+  CachingAllocatorHook::setInstance(std::move(hook));
+  auto& allocator = CachingAllocatorHook::getInstance();
+
+  // Create memory deallocation trace entry
+  auto dealloc_entry = createDeallocation(0x6000);
+
+  // Set up expectation for global deregistration to be called
+  EXPECT_CALL(
+      *nccl_mock_,
+      globalDeregisterWithPtr(reinterpret_cast<void*>(0x6000), 1024))
+      .WillOnce(Return(ncclSuccess));
+
+  // Execute: simulate memory deallocation event
+  allocator.regDeregMem(dealloc_entry);
+}
+
+TEST_F(
+    TorchCommNCCLXTest,
+    CachingAllocatorHookGlobalRegistrationErrorHandling) {
+  // Test: Verify error handling during global memory registration.
+  // Registration is best-effort — when ctran is not enabled, it's expected to
+  // fail silently with a warning log rather than throwing.
+  auto hook = std::make_unique<CachingAllocatorHookImpl>();
+  hook->setNcclApi(nccl_mock_);
+  CachingAllocatorHook::setInstance(std::move(hook));
+  auto& allocator = CachingAllocatorHook::getInstance();
+
+  // Create memory allocation trace entry
+  auto alloc_entry = createAllocation(0x7000);
+
+  // Set up expectation for global registration to fail
+  EXPECT_CALL(
+      *nccl_mock_, globalRegisterWithPtr(reinterpret_cast<void*>(0x7000), 1024))
+      .WillOnce(Return(ncclInvalidArgument));
+
+  EXPECT_CALL(*nccl_mock_, getErrorString(ncclInvalidArgument))
+      .WillOnce(Return("invalid argument"));
+
+  // Execute: simulate memory allocation — should not throw, registration
+  // failure is handled gracefully with a warning log
+  EXPECT_NO_THROW(allocator.regDeregMem(alloc_entry));
 }
 
 TEST_F(TorchCommNCCLXTest, AlltoallvDynamicDispatchCombine) {
   setupRankAndSize(0, 2);
-  setupCCAExpectations(1, 2, 1);
 
   auto comm = createMockedTorchComm();
 
@@ -1379,7 +1160,6 @@ TEST_F(TorchCommNCCLXTest, AlltoallvDynamicDispatchCombine) {
 
 TEST_F(TorchCommNCCLXTest, AlltoallvDedupExecCombine) {
   setupRankAndSize(0, 4);
-  setupCCAExpectations(1, 2, 1);
 
   auto comm = createMockedTorchComm();
 
@@ -1512,7 +1292,6 @@ TEST_F(TorchCommNCCLXTest, NCCLXExceptionFromFailedSendIncludesLastError) {
   // Test that when send() fails, the thrown NCCLXException includes
   // the NCCL last error string
   setupRankAndSize(0, 2);
-  setupCCAExpectations(1, 2, 1);
 
   auto comm = createMockedTorchComm();
 
@@ -1558,7 +1337,6 @@ TEST_F(TorchCommNCCLXTest, NCCLXExceptionFromFailedAllReduceIncludesLastError) {
   // Test that when all_reduce() fails, the thrown NCCLXException includes
   // the NCCL last error string
   setupRankAndSize(0, 2);
-  setupCCAExpectations(1, 2, 1);
 
   auto comm = createMockedTorchComm();
 

--- a/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTestBase.hpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTestBase.hpp
@@ -115,11 +115,6 @@ class TorchCommNCCLXTest : public ::testing::Test {
   // Helper method to create a TorchCommNCCLX with mocked APIs
   std::shared_ptr<TestTorchCommNCCLX> createMockedTorchComm();
 
-  void setupCCAExpectations(
-      int times_register,
-      int times_deregister,
-      int times_clear);
-
   void setupNormalDestruction(TestTorchCommNCCLX& torchcomm, int times = 1);
 
   // Helper method to create a tensor for testing

--- a/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommWindowNCCLXPipesTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommWindowNCCLXPipesTest.cpp
@@ -45,7 +45,6 @@ TEST_F(
   // Production value: Clear error when the API is called out of order.
 
   setupRankAndSize(0, 2);
-  setupCCAExpectations(1, 2, 1);
   auto comm = createMockedTorchComm();
 
   cuda_mock_->setupDefaultBehaviors();
@@ -89,7 +88,6 @@ TEST_F(TorchCommWindowNCCLXPipesTest, GetDeviceWindowThrowsIfWinNull) {
   // Production value: Prevents silent failures when the API is misused.
 
   setupRankAndSize(0, 2);
-  setupCCAExpectations(1, 2, 1);
   auto comm = createMockedTorchComm();
 
   cuda_mock_->setupDefaultBehaviors();
@@ -131,7 +129,6 @@ TEST_F(TorchCommWindowNCCLXPipesTest, RegisterLocalBufferSuccess) {
   // Also verifies deregister_local_buffer() calls winLocalDeregisterBuffer.
 
   setupRankAndSize(0, 2);
-  setupCCAExpectations(1, 2, 1);
   auto comm = createMockedTorchComm();
 
   cuda_mock_->setupDefaultBehaviors();

--- a/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommWindowNCCLXTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommWindowNCCLXTest.cpp
@@ -8,7 +8,6 @@ class TorchCommWindowNCCLXTest : public TorchCommNCCLXTest {};
 
 TEST_F(TorchCommWindowNCCLXTest, windowPutExceedWindowSize) {
   setupRankAndSize(0, 2);
-  setupCCAExpectations(1, 2, 1);
   auto comm = createMockedTorchComm();
 
   cuda_mock_->setupDefaultBehaviors();
@@ -50,7 +49,6 @@ TEST_F(TorchCommWindowNCCLXTest, windowPutExceedWindowSize) {
 
 TEST_F(TorchCommWindowNCCLXTest, windowRegisterWithInvalidTensor) {
   setupRankAndSize(0, 2);
-  setupCCAExpectations(1, 2, 1);
   auto comm = createMockedTorchComm();
 
   cuda_mock_->setupDefaultBehaviors();
@@ -91,9 +89,6 @@ TEST_F(TorchCommWindowNCCLXTest, windowRegisterWithInvalidTensor) {
 TEST_F(
     TorchCommNCCLXTest,
     WindowOperationsWithoutInitializationThrowException) {
-  // Setup CCA expectations - no init calls
-  setupCCAExpectations(0, 1, 1);
-
   auto comm = createMockedTorchComm();
 
   // Initialize and then finalize the communicator
@@ -123,9 +118,6 @@ TEST_F(
 }
 
 TEST_F(TorchCommWindowNCCLXTest, WindowOperationsAfterFinalizeThrowException) {
-  // Setup CCA expectations - init and finalize calls
-  setupCCAExpectations(1, 2, 1);
-
   auto comm = createMockedTorchComm();
 
   // Initialize and then finalize the communicator
@@ -171,7 +163,6 @@ TEST_F(
   // Verifies: In graph capture mode, tensor_register() does NOT store
   // buf_tensor_ so the tensor can be released to save memory.
   setupRankAndSize(0, 2);
-  setupCCAExpectations(1, 2, 1);
   auto comm = createMockedTorchComm();
 
   cuda_mock_->setupDefaultBehaviors();
@@ -201,7 +192,6 @@ TEST_F(TorchCommWindowNCCLXTest, TensorRegisterStoresBufTensorInNormalMode) {
   // Verifies: In normal (non-graph-capture) mode, tensor_register() stores
   // buf_tensor_ as usual.
   setupRankAndSize(0, 2);
-  setupCCAExpectations(1, 2, 1);
   auto comm = createMockedTorchComm();
 
   cuda_mock_->setupDefaultBehaviors();
@@ -246,7 +236,6 @@ TEST_F(TorchCommWindowNCCLXTest, GetDeviceWindowWithoutTensorRegisterThrows) {
   // Without tensor_register(), get_device_window() would fail.
 
   setupRankAndSize(0, 2);
-  setupCCAExpectations(1, 2, 1);
   auto comm = createMockedTorchComm();
 
   cuda_mock_->setupDefaultBehaviors();
@@ -295,7 +284,6 @@ TEST_F(TorchCommWindowNCCLXTest, GetDeviceWindowReturnsConsistentValue) {
   //   3. The device window struct is in GPU memory (cudaMalloc)
 
   setupRankAndSize(0, 8);
-  setupCCAExpectations(1, 2, 1);
   auto comm = createMockedTorchComm();
 
   cuda_mock_->setupDefaultBehaviors();
@@ -338,7 +326,6 @@ TEST_F(TorchCommWindowNCCLXTest, GetDeviceWindowDefaultParameters) {
   // signal/counter per peer.
 
   setupRankAndSize(0, 8); // rank 0 of 8 (use rank 0 for proper mock setup)
-  setupCCAExpectations(1, 2, 1);
   auto comm = createMockedTorchComm();
 
   cuda_mock_->setupDefaultBehaviors();

--- a/comms/torchcomms/ncclx/tests/unit/cpp/mocks/CachingAllocatorHookMock.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/mocks/CachingAllocatorHookMock.cpp
@@ -3,22 +3,11 @@
 #include "CachingAllocatorHookMock.hpp"
 
 using ::testing::_;
-using ::testing::DoAll;
 using ::testing::Return;
 
 namespace torch::comms::test {
 
 void CachingAllocatorHookMock::setupDefaultBehaviors() {
-  // Set up default behavior for registerComm
-  ON_CALL(*this, registerComm(_)).WillByDefault([this](TorchCommNCCLX* comm) {
-    registered_comms_.insert(comm);
-  });
-
-  // Set up default behavior for deregisterComm
-  ON_CALL(*this, deregisterComm(_)).WillByDefault([this](TorchCommNCCLX* comm) {
-    registered_comms_.erase(comm);
-  });
-
   // Set up default behavior for regDeregMem (no-op by default)
   ON_CALL(*this, regDeregMem(_)).WillByDefault(Return());
 
@@ -30,19 +19,11 @@ void CachingAllocatorHookMock::setupDefaultBehaviors() {
   // Call registerMemPreHook to simulate what DefaultCachingAllocatorHookImpl
   // constructor does
   registerMemPreHook();
-
-  // Set up default behavior for clear
-  ON_CALL(*this, clear()).WillByDefault([this]() {
-    registered_comms_.clear();
-  });
 }
 
 void CachingAllocatorHookMock::reset() {
   // Clear all expectations and call counts
   ::testing::Mock::VerifyAndClearExpectations(this);
-
-  // Clear the registered communicators set
-  registered_comms_.clear();
 
   // Reset the mem pre hook flag
   mem_pre_hook_registered_ = false;
@@ -51,11 +32,7 @@ void CachingAllocatorHookMock::reset() {
   setupDefaultBehaviors();
 }
 
-bool CachingAllocatorHookMock::isCommRegistered(TorchCommNCCLX* comm) {
-  return registered_comms_.find(comm) != registered_comms_.end();
-}
-
-bool CachingAllocatorHookMock::isMemRegisteredCalled() {
+bool CachingAllocatorHookMock::isMemPreHookRegistered() {
   return mem_pre_hook_registered_;
 }
 

--- a/comms/torchcomms/ncclx/tests/unit/cpp/mocks/CachingAllocatorHookMock.hpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/mocks/CachingAllocatorHookMock.hpp
@@ -23,10 +23,7 @@ class CachingAllocatorHookMock : public CachingAllocatorHookImpl {
       regDeregMem,
       (const c10::cuda::CUDACachingAllocator::TraceEntry& te),
       (override));
-  MOCK_METHOD(void, registerComm, (TorchCommNCCLX * comm), (override));
-  MOCK_METHOD(void, deregisterComm, (TorchCommNCCLX * comm), (override));
   MOCK_METHOD(void, registerMemPreHook, (), (override));
-  MOCK_METHOD(void, clear, (), (override));
 
   /**
    * Set up default behaviors for common operations.
@@ -40,21 +37,10 @@ class CachingAllocatorHookMock : public CachingAllocatorHookImpl {
   void reset();
 
   /**
-   * Check if a communicator is registered with this hook.
-   * @param comm Pointer to the communicator to check
-   * @return true if the communicator is registered, false otherwise
-   */
-  bool isCommRegistered(TorchCommNCCLX* comm) override;
-
-  /**
    * Check if registerMemPreHook was called.
    * @return true if registerMemPreHook was called, false otherwise
    */
-  bool isMemRegisteredCalled();
-
- private:
-  std::set<TorchCommNCCLX*> registered_comms_;
-  bool mem_pre_hook_registered_ = false;
+  bool isMemPreHookRegistered() override;
 };
 
 } // namespace torch::comms::test

--- a/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.hpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.hpp
@@ -78,6 +78,19 @@ class NcclxMock : public NcclxApi {
       (ncclComm_t comm, void* handle),
       (override));
 
+  // Pointer-based memory registration (global - does not require comm)
+  MOCK_METHOD(
+      ncclResult_t,
+      globalRegisterWithPtr,
+      (void* buffer, size_t size),
+      (override));
+
+  MOCK_METHOD(
+      ncclResult_t,
+      globalDeregisterWithPtr,
+      (void* buffer, size_t size),
+      (override));
+
   // Point-to-point operations
   MOCK_METHOD(
       ncclResult_t,

--- a/comms/torchcomms/tests/integration/py/ExpandableSegmentsTest.py
+++ b/comms/torchcomms/tests/integration/py/ExpandableSegmentsTest.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+# pyre-unsafe
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+Check that large allocations that span multiple physical caching allocator segment
+chunks are correctly registered. This is the behavior when expandable segments is set.
+"""
+
+import os
+import unittest
+
+os.environ.setdefault("NCCL_DEBUG", "INFO")
+os.environ.setdefault("NCCL_DEBUG_SUBSYS", "ALLOC")
+os.environ.setdefault("NCCL_COMM_STATE_DEBUG_TOPO", "nolocal")
+os.environ.setdefault("NCCL_ALLREDUCE_ALGO", "ctran")
+
+import torch
+from torchcomms import ReduceOp
+from torchcomms.tests.integration.py.TorchCommTestHelpers import (
+    get_rank_and_size,
+    TorchCommTestWrapper,
+)
+
+
+class ExpandableSegmentsTest(unittest.TestCase):
+    """Test class for expandable segments multi-segment registration.
+
+    NCCL_CTRAN_REGISTER (async/eager) is configured via Buck target configurations.
+    """
+
+    def get_wrapper(self):
+        return TorchCommTestWrapper()
+
+    def get_device(self) -> torch.device:
+        """Get device for this rank without creating a comm."""
+        rank, _ = get_rank_and_size()
+        if device_str := os.environ.get("TEST_DEVICE"):
+            return torch.device(device_str)
+
+        if torch.accelerator.is_available():
+            device_count = torch.accelerator.device_count()
+            if device_count > 0:
+                device_id = rank % device_count
+                accelerator = torch.accelerator.current_accelerator()
+                assert accelerator is not None
+                device_type = accelerator.type
+                return torch.device(f"{device_type}:{device_id}")
+        return torch.device("cpu")
+
+    def setUp(self):
+        self.wrapper = self.get_wrapper()
+        self.torchcomm = self.wrapper.get_torchcomm()
+        self.rank = self.torchcomm.get_rank()
+        self.num_ranks = self.torchcomm.get_size()
+        self.device = self.torchcomm.get_device()
+
+    def tearDown(self):
+        self.torchcomm = None
+        self.wrapper = None
+
+    def test_large_allocation(self):
+        """
+        Test that large allocations spanning multiple physical memory allocations work correctly.
+
+        With expandable segments enabled, PyTorch allocates memory in 20MB segment chunks.
+        A 110MB allocation should span 6 physical 20 MB segment chunks. This test verifies that:
+        1. The CCA hook receives the SEGMENT_MAP event for the full range
+        2. ctran's pinRange() discovers all underlying physical segments and caches them
+        3. At collective time, the elements of the segment cache backing the input tensor are
+           correctly registered with NCCL
+        """
+        count = 110 * 1024 * 1024
+        dtype = torch.uint8
+
+        # Create input tensor - this triggers SEGMENT_MAP for a ~110MB allocation
+        input_tensor = torch.ones(count, dtype=dtype, device=self.device) * float(
+            self.rank + 1
+        )
+
+        # Perform all_reduce - this exercises the full ctran registration path
+        work = self.torchcomm.all_reduce(input_tensor, ReduceOp.SUM, False)
+        work.wait()
+
+        # Check collective result
+        expected = self.num_ranks * (self.num_ranks + 1) // 2
+        expected_tensor = torch.full_like(input_tensor.cpu(), float(expected))
+        torch.testing.assert_close(input_tensor.cpu(), expected_tensor)
+
+    def test_collective_after_empty_cache(self):
+        """Test that allocations and collectives work correctly after empty_cache.
+
+        This test verifies that the CCA hook correctly handles the case where
+        PyTorch fires SEGMENT_MAP for a new allocation before firing SEGMENT_UNMAP
+        for old memory at the same address (which can happen when addresses are
+        reused after empty_cache).
+        """
+        count = 110 * 1024 * 1024
+        dtype = torch.uint8
+
+        # First allocation and collective
+        input_tensor = torch.ones(count, dtype=dtype, device=self.device) * float(
+            self.rank + 1
+        )
+        work = self.torchcomm.all_reduce(input_tensor, ReduceOp.SUM, False)
+        work.wait()
+
+        expected = self.num_ranks * (self.num_ranks + 1) // 2
+        expected_tensor = torch.full_like(input_tensor.cpu(), float(expected))
+        torch.testing.assert_close(input_tensor.cpu(), expected_tensor)
+
+        # Delete tensor and call empty_cache to trigger SEGMENT_UNMAP
+        del input_tensor
+        torch.cuda.empty_cache()
+
+        # Second allocation - may reuse same address, triggering SEGMENT_MAP
+        # before the SEGMENT_UNMAP from above is processed
+        input_tensor2 = torch.ones(count, dtype=dtype, device=self.device) * float(
+            self.rank + 1
+        )
+        work2 = self.torchcomm.all_reduce(input_tensor2, ReduceOp.SUM, False)
+        work2.wait()
+
+        print(
+            f"rank {self.rank} input_tensor2: {input_tensor2}, expected: {expected_tensor}"
+        )
+        torch.testing.assert_close(input_tensor2.cpu(), expected_tensor)
+
+    def test_memory_allocated_before_comm_creation(self):
+        """Test that memory allocated BEFORE the CCA hook is attached gets registered.
+
+        This test verifies the registerMemPreHook path in TorchCommNCCLXCCA.cpp:
+        1. When the CCA trace hook is first attached, registerMemPreHook() is called
+        2. It queries CUDACachingAllocator::snapshot() to find all existing allocations
+        3. Each segment is registered globally via global_register_address()
+        4. The device is auto-detected from the buffer pointer by ctran
+
+        The test flow is:
+        1. Clean up the existing comm from setUp()
+        2. Allocate memory BEFORE creating a new comm
+        3. Create a new comm (the CCA hook attaches and registers pre-existing memory)
+        4. Use the pre-allocated memory in a collective to verify registration worked
+
+        Note: In the typical single-device-per-process setup, the snapshot only
+        contains segments for that process's device, so no device filtering is needed.
+        """
+        # Clean up the existing comm to start fresh
+        self.torchcomm.finalize()
+        self.torchcomm = None
+        self.wrapper = None
+
+        # Allocate memory BEFORE creating the comm
+        # This allocation will be in CUDACachingAllocator's snapshot when
+        # registerMemPreHook runs (triggered by CCA hook attachment)
+        device = self.get_device()
+        count = 110 * 1024 * 1024  # Large allocation spanning multiple segments
+        dtype = torch.uint8
+
+        rank, num_ranks = get_rank_and_size()
+
+        # Pre-allocate memory - this is the key: memory exists BEFORE the CCA hook
+        pre_allocated_tensor = torch.ones(count, dtype=dtype, device=device) * float(
+            rank + 1
+        )
+
+        # Now create a new comm - this attaches the CCA hook which triggers
+        # registerMemPreHook() to:
+        # 1. Get snapshot from CUDACachingAllocator
+        # 2. Find our pre-allocated tensor's segments
+        # 3. Register them globally via global_register_address()
+        self.wrapper = TorchCommTestWrapper()
+        self.torchcomm = self.wrapper.get_torchcomm()
+
+        # Use the pre-allocated tensor in a collective
+        # If registerMemPreHook worked correctly, the memory is already registered
+        # and the collective should succeed using ctran
+        work = self.torchcomm.all_reduce(pre_allocated_tensor, ReduceOp.SUM, False)
+        work.wait()
+
+        # Verify collective result
+        expected = num_ranks * (num_ranks + 1) // 2
+        expected_tensor = torch.full_like(pre_allocated_tensor.cpu(), float(expected))
+        torch.testing.assert_close(pre_allocated_tensor.cpu(), expected_tensor)
+
+        print(
+            f"rank {rank}: pre-allocated memory correctly registered and used in collective"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:

# Summary

Switch from handle-based per-comm registration (`ncclCommRegister`/`ncclCommDeregister`) to pointer-based global registration (`ncclGlobalRegisterWithPtr`/`ncclGlobalDeregisterWithPtr`).

The global API routes directly to RegCache, bypassing the mapper layer. This enables registration to be handled entirely within ctran, allowing use to greatly simplify the torchcomms layer to only
1. provide the initial registration calls from snapshot upon hook singleton creation
2. provide the callback to register/deregister upon CCA alloc, free, map, and unmap events
Torchcomms no longer has to track any memory registrations itself.

## Key Changes

### CUDACachingAllocator Hook Simplification
- **`registerMemPreHook()`**: Now queries CUDACachingAllocator::snapshot() and globally registers all existing segments. Device is auto-detected from buffer pointer by ctran.
- **`regDeregMem()`**: Unified handling of SEGMENT_ALLOC/MAP (register) and SEGMENT_FREE/UNMAP (deregister) via global APIs. Removed complex chunk iteration logic.
- **Deprecated functions**: `registerComm`, `deregisterComm`, `clear`, `isCommRegistered` are removed. Per-comm registration is no longer needed.

### TorchCommNCCLX Changes
- Converted `register_address`/`deregister_address` to static `global_register_address`/`global_deregister_address`
- These call directly into `ncclGlobalRegisterWithPtr`/`ncclGlobalDeregisterWithPtr`

### Removed State
- `registeredComms_` set (no longer tracking per-comm)
- `registeredMemMap_` map (registration cache is now in ctran's RegCache)
- `MemInfo` struct and associated mutex

## Context

When PyTorch's CUDA caching allocator uses expandable segments, physical memory is allocated in 20MB chunks using `cuMemCreate`. A 100MB allocation spans 5 physical segments. Previously torchcomms iterated through physical segments and called per-segment registration. Now torchcomms calls global registration once for the full allocation, and ctran's `pinRange()` discovers and caches all underlying physical segments automatically.

## Performance
Single segment global registration is about the same perf as comm registration (.2us) difference. For multi-segment registration, global is faster because we call registration once per buffer rather than once per segment. Details in D94120051.

Reviewed By: cenzhaometa, siyengar

Differential Revision: D91240027


