### PR TITLE
Add CommsScubaSample base class for code reuse

### DIFF
--- a/comms/utils/logger/CommsScubaSample.cpp
+++ b/comms/utils/logger/CommsScubaSample.cpp
@@ -1,0 +1,76 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/utils/logger/CommsScubaSample.h"
+
+#include <sstream>
+
+#include <folly/debugging/symbolizer/Symbolizer.h>
+#include <folly/json/json.h>
+
+namespace comms {
+
+CommsScubaSample::CommsScubaSample(std::string type)
+    : sample_(folly::dynamic::object()) {
+  sample_["int"] = folly::dynamic::object;
+  sample_["normal"] = folly::dynamic::object;
+  sample_["normvector"] = folly::dynamic::object;
+  sample_["tags"] = folly::dynamic::object;
+  sample_["double"] = folly::dynamic::object;
+  sample_["normal"]["type"] = std::move(type);
+}
+
+void CommsScubaSample::addNormal(const std::string& key, std::string value) {
+  sample_["normal"][key] = std::move(value);
+}
+
+void CommsScubaSample::addInt(const std::string& key, int64_t value) {
+  sample_["int"][key] = value;
+}
+
+void CommsScubaSample::addDouble(const std::string& key, double value) {
+  sample_["double"][key] = value;
+}
+
+void CommsScubaSample::addNormVector(
+    const std::string& key,
+    std::vector<std::string> value) {
+  sample_["normvector"][key] =
+      folly::dynamic::array(value.begin(), value.end());
+}
+
+void CommsScubaSample::addTagSet(
+    const std::string& key,
+    const std::set<std::string>& value) {
+  sample_["tags"][key] = folly::dynamic::array(value.begin(), value.end());
+}
+
+std::string CommsScubaSample::toJson() const {
+  return folly::toJson(sample_);
+}
+
+void CommsScubaSample::setError(const std::string& error) noexcept {
+  try {
+    if (shouldCaptureStackTrace()) {
+      std::stringstream ss;
+      ss << folly::symbolizer::getStackTraceStr();
+      std::vector<std::string> stackTraceMangled;
+      // @lint-ignore CLANGTIDY
+      folly::split('\n', ss.str(), stackTraceMangled);
+      for (auto& line : stackTraceMangled) {
+        auto demangledLine = folly::demangle(line.c_str()).toStdString();
+        line.swap(demangledLine);
+      }
+      this->stackTrace = stackTraceMangled;
+      addNormVector("stack_trace", std::move(stackTraceMangled));
+    }
+
+    this->hasException = true;
+    this->exceptionMessage = error;
+
+    addInt("exception_set", 1);
+    addNormal("exception_message", error);
+  } catch (...) {
+  }
+}
+
+} // namespace comms

--- a/comms/utils/logger/CommsScubaSample.h
+++ b/comms/utils/logger/CommsScubaSample.h
@@ -1,0 +1,59 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <set>
+#include <string>
+#include <vector>
+
+#include <folly/json/dynamic.h>
+
+namespace comms {
+
+// Base class for Scuba samples in comms libraries (NCCL, MCCL, etc.)
+// Provides common field setters and JSON serialization.
+// See rfe/scubadata/ScubaDataSample.h for the underlying Scuba format.
+class CommsScubaSample {
+ public:
+  // Only allow moves not copies (public interface)
+  CommsScubaSample(CommsScubaSample&&) = default;
+  CommsScubaSample& operator=(CommsScubaSample&&) = default;
+  virtual ~CommsScubaSample() = default;
+
+  // Core field setters
+  void addNormal(const std::string& key, std::string value);
+  void addInt(const std::string& key, int64_t value);
+  void addDouble(const std::string& key, double value);
+  void addNormVector(const std::string& key, std::vector<std::string> value);
+  void addTagSet(const std::string& key, const std::set<std::string>& value);
+
+  std::string toJson() const;
+
+  // Error handling - captures stack trace and sets exception fields
+  // Subclasses may override to customize behavior
+  virtual void setError(const std::string& error) noexcept;
+
+  // Extra attributes for subsequent retrieval. We do so to avoid retrieval
+  // from dynamic object which may pose undesired exceptions e.g. type
+  // conversion if not set properly
+  bool hasException{false};
+  std::string exceptionMessage;
+  std::vector<std::string> stackTrace;
+
+ protected:
+  explicit CommsScubaSample(std::string type);
+
+  // Allow subclasses to copy
+  CommsScubaSample(const CommsScubaSample&) = default;
+  CommsScubaSample& operator=(const CommsScubaSample&) = default;
+
+ private:
+  // Override this to control stack trace capture behavior
+  virtual bool shouldCaptureStackTrace() const {
+    return true;
+  }
+
+  folly::dynamic sample_;
+};
+
+} // namespace comms

--- a/comms/utils/logger/NcclScubaSample.h
+++ b/comms/utils/logger/NcclScubaSample.h
@@ -7,16 +7,15 @@
 #include <string>
 #include <vector>
 
-#include <folly/json/dynamic.h>
-
 #include "comms/utils/commSpecs.h"
+#include "comms/utils/logger/CommsScubaSample.h"
 
 // See rfe/scubadata/ScubaDataSample.h
 // We can't use it here to avoid all nccl headers including this type.
 // Keys are scuba column names
 // Each sample must explicitly define its own type so that different types of
 // events within the system can be observed in different way.
-class NcclScubaSample {
+class NcclScubaSample : public comms::CommsScubaSample {
  public:
   enum ScubaLogType {
     REGULAR,
@@ -28,22 +27,14 @@ class NcclScubaSample {
   // Only allow moves not copies
   NcclScubaSample(NcclScubaSample&& other) = default;
   NcclScubaSample& operator=(NcclScubaSample&& other) = default;
-  ~NcclScubaSample() = default;
+  ~NcclScubaSample() override = default;
 
   ScubaLogType getLogType();
 
-  void addNormal(const std::string& key, std::string value);
-  void addInt(const std::string& key, int64_t value);
-  void addDouble(const std::string& key, double value);
-  void addNormVector(const std::string& key, std::vector<std::string> value);
   void addTagSet(const std::string& key, const std::set<std::string>& value);
-  std::string toJson() const;
 
   // Helper to set exception info and collect stack traces
   void setExceptionInfo(const std::exception& ex);
-
-  // Helper to include a custom error and collect stack trace
-  void setError(const std::string& error);
 
   // Set custom data attribute
   void setData(std::string data);
@@ -52,22 +43,17 @@ class NcclScubaSample {
   void setCommunicatorMetadata(const CommLogData* commMetadata);
   void setExecResult(std::string result);
 
-  // Extra attributes for subsequent retrieval. We do so to avoid retrieval
-  // from dynamic object which may pose undesired exceptions e.g. type
-  // conversion if not set properly
-  bool hasException{false};
-  std::string exceptionMessage;
-  std::vector<std::string> stackTrace;
-
   // explicit copy function to avoid implicit copy constructor
   NcclScubaSample makeCopy() const {
     return NcclScubaSample(*this);
   }
+
+ protected:
+  bool shouldCaptureStackTrace() const override;
 
  private:
   NcclScubaSample(const NcclScubaSample& other) = default;
   NcclScubaSample& operator=(const NcclScubaSample& other) = default;
 
   ScubaLogType logType_;
-  folly::dynamic sample_;
 };


### PR DESCRIPTION
Summary:
Extract common Scuba sample functionality into a shared base class to eliminate code duplication between NcclScubaSample and McclScubaSample.

Both classes had nearly identical implementations of addNormal(), addInt(), addDouble(), addNormVector(), toJson(), and setError() with stack trace capture. This refactoring consolidates ~100 lines of duplicated code into CommsScubaSample, improving maintainability and providing a foundation for future comms library sample classes.

The base class provides a virtual shouldCaptureStackTrace() method that subclasses can override to customize error handling behavior (e.g., NcclScubaSample checks the NCCL_SCUBA_STACK_TRACE_ON_ERROR_ENABLED CVAR).

Differential Revision: D91526131
