### PR TITLE
Fix init_state_ set before init completes

### DIFF
--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -101,7 +101,6 @@ void TorchCommNCCLX::init(
   } else if (init_state_ == InitializationState::FINALIZED) {
     throw std::runtime_error("TorchCommNCCLX already finalized");
   }
-  init_state_ = InitializationState::INITIALIZED;
 
   // Initialize default NCCL API implementation if not already set
   if (!nccl_api_) {
@@ -240,6 +239,9 @@ void TorchCommNCCLX::init(
 
   // Register comm with CachingAllocator
   attachMemoryHook();
+
+  // Mark initialization as complete only after all steps succeed
+  init_state_ = InitializationState::INITIALIZED;
 }
 
 void TorchCommNCCLX::finalize() {

--- a/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTest.cpp
@@ -267,7 +267,8 @@ TEST_F(TorchCommNCCLXTest, InitializationFailsWithInvalidDeviceId) {
         comm->init(invalid_device, "test_name", default_options_),
         std::runtime_error);
 
-    comm->finalize();
+    // After a failed init, finalize should throw since we're not initialized
+    EXPECT_THROW(comm->finalize(), std::runtime_error);
   }
 }
 


### PR DESCRIPTION
Summary:
The init_state_ was being set to INITIALIZED at the beginning of the
init() function, before any actual initialization occurred. This caused
problems when init() threw an exception (e.g., due to invalid device ID):
the state would be INITIALIZED even though initialization never completed.

When finalize() was later called, it would hit an assertion failure
because init_state_ == INITIALIZED but nccl_comm_ was nullptr.

The fix moves init_state_ = INITIALIZED to the end of the init() function,
after all initialization steps complete successfully. This ensures that
if any exception is thrown during initialization, the state remains
UNINITIALIZED, and finalize() will correctly throw "TorchCommNCCLX not
initialized" instead of hitting the assertion.

The test is also updated to expect finalize() to throw after a failed init.

Reviewed By: pavanbalaji

Differential Revision: D91542525


