### PR TITLE
Add distwrap module for distributed communication wrappers

### DIFF
--- a/comms/torchcomms/distwrap/README.md
+++ b/comms/torchcomms/distwrap/README.md
@@ -1,0 +1,284 @@
+# distwrap - Distributed Communication Wrapper
+
+`distwrap` provides a `torch.distributed`-compatible API that can optionally
+route communication operations through torchcomms instead of native
+torch.distributed backends.
+
+## Overview
+
+The module creates wrapper functions for the torch.distributed API (with minor
+extensions) that internally dispatch to either torch.distributed or torchcomms
+based on configuration. It maintains a registry that maps ProcessGroups to
+their associated torchcomms instances.
+
+## Architecture
+
+```
++-------------------------------------------------------------------------+
+|                           User Code                                     |
+|         from torchcomms import distwrap as dist                         |
+|         dist.all_reduce(tensor)                                         |
++--------------------------------+----------------------------------------+
+                                 |
+                                 v
++-------------------------------------------------------------------------+
+|                      distwrap.collectives                               |
+|                                                                         |
+|   def all_reduce(tensor, ...):                                          |
+|       if torchcomms_is_enabled():                                       |
+|           tc = get_torchcomms_instance(pg, tensor)  <-- Registry lookup |
+|           return tc.all_reduce(...)                                     |
+|       else:                                                             |
+|           return dist.all_reduce(...)                                   |
++--------------------------------+----------------------------------------+
+                                 |
+              +------------------+------------------+
+              |                                     |
+              v                                     v
++-------------------------+           +-------------------------+
+|     torchcomms          |           |   torch.distributed     |
+|   (use_torchcomms=True) |           |  (use_torchcomms=False) |
++-------------------------+           +-------------------------+
+```
+
+## Module Structure
+
+- `__init__.py` - Public API exports and attribute forwarding to torch.distributed
+- `new_comm.py` - Process group management (init, new_group, split_group, destroy)
+- `collectives.py` - Standard collective operations (all_reduce, broadcast, etc.)
+- `collectives_extension.py` - torchcomms-only extensions (window ops, alltoallv variants)
+- `pginfo.py` - ProcessGroup registry for metadata and torchcomms instances
+- `utils.py` - Backend parsing, instance lookup, and helper functions
+
+## ProcessGroup Registry
+
+The core mechanism is a registry (`pginfo.py`) that maps `ProcessGroup` objects
+to metadata and torchcomms instances:
+
+```python
+@dataclass
+class _PG_INFO:
+    global_ranks: list[int]    # Global ranks in this group
+    group_desc: str            # Group description/name
+    data: dict[str, Any]       # Arbitrary data (stores torchcomms instances)
+
+# Registry: ProcessGroup -> _PG_INFO
+_PG_INFO_REGISTRY: dict[ProcessGroup, _PG_INFO] = {}
+```
+
+When torchcomms is enabled, the `data` dictionary stores:
+- `"torchcomms"`: Dict mapping device type (e.g., "cuda", "cpu") to TorchComm instance
+- `"device_backends"`: Dict mapping device type to backend name (e.g., "cuda" -> "nccl")
+
+## Usage
+
+### Basic Usage (torch.distributed passthrough)
+
+```python
+from torchcomms import distwrap as dist
+
+# Initialize without torchcomms - all calls pass through to torch.distributed
+dist.init_process_group(backend="nccl")
+
+# These call torch.distributed directly
+dist.all_reduce(tensor)
+dist.broadcast(tensor, src=0)
+```
+
+### With torchcomms Backend
+
+```python
+from torchcomms import distwrap as dist
+
+# Initialize with torchcomms enabled
+dist.init_process_group(backend="nccl", use_torchcomms=True)
+
+# These now route through torchcomms
+dist.all_reduce(tensor)  # Uses torchcomms.all_reduce internally
+dist.broadcast(tensor, src=0)
+
+# Direct torch.distributed calls are blocked when torchcomms is enabled
+# import torch.distributed as torch_dist
+# torch_dist.all_reduce(tensor)  # Raises NotImplementedError
+```
+
+### Creating Subgroups
+
+```python
+# With torchcomms, use split_group instead of new_group
+subgroup = dist.split_group(
+    split_ranks=[[0, 1], [2, 3]],
+    group_desc="my_subgroup"
+)
+
+# Operations on subgroups use the split torchcomms instance
+dist.all_reduce(tensor, group=subgroup)
+```
+
+### torchcomms-only Extensions
+
+```python
+# Window operations (for RMA/one-sided communication)
+window = dist.new_window(group=pg)
+
+# Specialized alltoallv variants for MoE workloads
+persist_req = dist.alltoallv_dedup_init(...)
+dist.alltoallv_dedup_exec(..., persist_req)
+```
+
+## Initialization Flow
+
+When `init_process_group(use_torchcomms=True)` is called:
+
+1. **Parse backend string**: Converts backend spec (e.g., "nccl", "cpu:gloo,cuda:nccl")
+   to device->backend mapping
+
+2. **Initialize torch.distributed**: Calls `dist.init_process_group()` with the
+   appropriate backend (ncclx/rcclx are renamed to nccl/rccl for compatibility)
+
+3. **Register world group**: Creates a `_PG_INFO` entry for `dist.group.WORLD`
+
+4. **Create torchcomms instances**: For each device type, creates a `TorchComm`
+   instance and stores it in the registry
+
+5. **Block direct dist calls**: Patches torch.distributed collectives to raise
+   `NotImplementedError` if called directly
+
+## Collective Dispatch Logic
+
+Each collective wrapper follows this pattern:
+
+```python
+def all_reduce(tensor, op=ReduceOp.SUM, group=None, async_op=False):
+    pg = get_group(group)  # Default to WORLD if None
+
+    if torchcomms_is_enabled():
+        # Look up torchcomms instance based on tensor's device type
+        tc = get_torchcomms_instance(pg, tensor=tensor)
+        work = tc.all_reduce(tensor, op, async_op)
+        return work if async_op else None
+    else:
+        # Pass through to torch.distributed
+        return dist.all_reduce(tensor, op, pg, async_op)
+```
+
+## Supported Operations
+
+### Standard Collectives
+- `all_reduce`, `broadcast`, `reduce`
+- `all_gather`, `all_gather_into_tensor`
+- `reduce_scatter`, `reduce_scatter_tensor`
+- `all_to_all`, `all_to_all_single`
+- `scatter`, `gather`
+- `barrier`
+
+### Point-to-Point
+- `send`, `recv`
+- `isend`, `irecv`
+- `batch_isend_irecv`
+
+### Object Collectives
+- `all_gather_object`, `gather_object`
+- `scatter_object_list`, `broadcast_object_list`
+
+### Extensions (torchcomms-only)
+- `new_window` - Create RMA window
+- `alltoallv_dedup_init/exec` - Deduplicated alltoallv for MoE
+- `alltoallv_dynamic_dispatch/combine` - Dynamic alltoallv for MoE
+
+## Limitations When torchcomms is Enabled
+
+The following operations that work with torch.distributed will raise exceptions
+when `use_torchcomms=True`:
+
+### new_group() is not supported
+
+Use `split_group()` instead. torchcomms requires splitting from an existing
+communicator rather than creating arbitrary new groups.
+
+```python
+# This raises AssertionError when torchcomms is enabled:
+subgroup = dist.new_group(ranks=[0, 1])
+
+# Use split_group instead:
+subgroup = dist.split_group(split_ranks=[[0, 1], [2, 3]])
+```
+
+### Wildcard recv/irecv (src=None) is not supported
+
+torchcomms requires an explicit source rank for receive operations.
+
+```python
+# These raise ValueError when torchcomms is enabled:
+dist.recv(tensor, src=None)   # Wildcard recv
+dist.irecv(tensor, src=None)  # Wildcard irecv
+
+# Specify explicit source rank instead:
+dist.recv(tensor, src=0)
+dist.irecv(tensor, src=0)
+```
+
+### Direct torch.distributed calls are blocked
+
+When torchcomms is enabled, direct calls to torch.distributed collective
+functions are patched to raise `NotImplementedError`. This prevents accidental
+bypassing of the distwrap layer.
+
+```python
+import torch.distributed as torch_dist
+
+# These raise NotImplementedError when torchcomms is enabled:
+torch_dist.all_reduce(tensor)
+torch_dist.broadcast(tensor, src=0)
+torch_dist.send(tensor, dst=1)
+# ... and all other collective operations
+
+# Use distwrap instead:
+from torchcomms import distwrap as dist
+dist.all_reduce(tensor)
+```
+
+### Object collectives use an arbitrary torchcomms instance
+
+For object-based collectives (`all_gather_object`, `gather_object`,
+`scatter_object_list`, `broadcast_object_list`), there is no tensor to infer
+the device type from. In this case, distwrap picks the first available
+torchcomms instance arbitrarily. If you have multiple backends configured
+(e.g., both CPU and GPU), the chosen backend may not be what you expect.
+
+### split_group and new_window operate on all backends by default
+
+For `split_group`, there is no way to infer which backend to use. By default,
+it creates a new torchcomms instance for each backend that was configured
+during `init_process_group` (e.g., both NCCL and Gloo if both were initialized).
+
+To limit which backends are used, pass the `backend` parameter explicitly:
+
+```python
+# Split only on NCCL backend
+subgroup = dist.split_group(
+    split_ranks=[[0, 1], [2, 3]],
+    backend="nccl"
+)
+```
+
+### new_window uses an arbitrary torchcomms instance by default
+
+Similar to object collectives, `new_window` picks the first available
+torchcomms instance from the group when `backend` is not specified. Use the
+`backend` parameter to explicitly choose which backend to use:
+
+```python
+# Create window on specific backend
+window = dist.new_window(group=pg, backend="ncclx")
+```
+
+## Forwarded Attributes
+
+The module forwards these attributes directly from torch.distributed:
+
+- `get_rank`, `get_world_size`
+- `is_initialized`, `is_available`
+- `get_process_group_ranks`
+- `ProcessGroup`, `ProcessGroupNCCL`, `GroupMember`
+- `ReduceOp`, `P2POp`, `group`, `Store`, `HashStore`, `Work`

--- a/comms/torchcomms/distwrap/__init__.py
+++ b/comms/torchcomms/distwrap/__init__.py
@@ -1,0 +1,181 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# pyre-strict
+
+from typing import Any, Callable
+
+import torch
+import torch.distributed as dist
+
+# pyre-fixme[21]: Could not find name in module (ProcessGroup backends not in stubs)
+from torch.distributed import (  # noqa: F401
+    get_process_group_ranks,
+    get_rank,
+    get_world_size,
+    group,
+    GroupMember,
+    HashStore,
+    is_available,
+    is_initialized,
+    ProcessGroup,
+    ProcessGroupGloo,
+    ProcessGroupNCCL,
+    ReduceOp,
+    Store,
+    Work,
+)
+from torchcomms.distwrap.collectives import (
+    all_gather,
+    all_gather_into_tensor,
+    all_gather_object,
+    all_reduce,
+    all_to_all,
+    all_to_all_single,
+    barrier,
+    batch_isend_irecv,
+    broadcast,
+    broadcast_object_list,
+    gather,
+    gather_object,
+    irecv,
+    isend,
+    recv,
+    reduce,
+    reduce_scatter,
+    reduce_scatter_tensor,
+    scatter,
+    scatter_object_list,
+    send,
+)
+from torchcomms.distwrap.collectives_extension import (
+    alltoallv_dedup_exec,
+    alltoallv_dedup_init,
+    alltoallv_dynamic_combine,
+    alltoallv_dynamic_dispatch,
+    new_window,
+)
+from torchcomms.distwrap.new_comm import (
+    destroy_process_group,
+    init_process_group,
+    new_group,
+    split_group,
+)
+
+
+# =============================================================================
+# P2POp wrapper
+# =============================================================================
+
+
+class P2POp:
+    """
+    A wrapper for torch.distributed.P2POp that accepts distwrap's isend/irecv.
+
+    This class allows users to use distwrap's isend/irecv functions when creating
+    P2POp instances, which are then mapped to torch.distributed.isend/irecv
+    internally for compatibility with batch_isend_irecv.
+    """
+
+    def __init__(
+        self,
+        op: Callable[..., Any],
+        tensor: torch.Tensor,
+        peer: int | None = None,
+        group: dist.ProcessGroup | None = None,
+        tag: int = 0,
+        group_peer: int | None = None,
+    ) -> None:
+        # Map distwrap's isend/irecv to torch.distributed versions
+        if op is isend:
+            mapped_op = dist.distributed_c10d.isend
+        elif op is irecv:
+            mapped_op = dist.distributed_c10d.irecv
+        else:
+            # Assume it's already a torch.distributed function
+            mapped_op = op
+
+        # Create the underlying torch.distributed.P2POp
+        self._p2p_op = dist.P2POp(
+            op=mapped_op,
+            tensor=tensor,
+            peer=peer,
+            group=group,
+            tag=tag,
+            group_peer=group_peer,
+        )
+
+    @property
+    def op(self) -> Callable[..., Any]:
+        return self._p2p_op.op
+
+    @property
+    def tensor(self) -> torch.Tensor:
+        return self._p2p_op.tensor
+
+    @property
+    def group(self) -> dist.ProcessGroup:
+        return self._p2p_op.group
+
+    @property
+    def peer(self) -> int:
+        return self._p2p_op.peer
+
+    @property
+    def tag(self) -> int:
+        return self._p2p_op.tag
+
+    @property
+    def group_peer(self) -> int:
+        return self._p2p_op.group_peer
+
+    def __repr__(self) -> str:
+        return repr(self._p2p_op)
+
+
+__all__ = [
+    "init_process_group",
+    "destroy_process_group",
+    "new_group",
+    "split_group",
+    "all_reduce",
+    "broadcast",
+    "reduce",
+    "all_gather",
+    "all_gather_into_tensor",
+    "reduce_scatter",
+    "reduce_scatter_tensor",
+    "all_to_all",
+    "all_to_all_single",
+    "scatter",
+    "gather",
+    "barrier",
+    "send",
+    "recv",
+    "isend",
+    "irecv",
+    "batch_isend_irecv",
+    "all_gather_object",
+    "gather_object",
+    "scatter_object_list",
+    "broadcast_object_list",
+    "new_window",
+    "alltoallv_dedup_init",
+    "alltoallv_dedup_exec",
+    "alltoallv_dynamic_dispatch",
+    "alltoallv_dynamic_combine",
+    # Re-exported from torch.distributed
+    "ReduceOp",
+    "P2POp",
+    "get_rank",
+    "get_world_size",
+    "is_initialized",
+    "is_available",
+    "get_process_group_ranks",
+    "ProcessGroup",
+    "ProcessGroupGloo",
+    "ProcessGroupNCCL",
+    "GroupMember",
+    "group",
+    "Store",
+    "HashStore",
+    "Work",
+]

--- a/comms/torchcomms/distwrap/collectives.py
+++ b/comms/torchcomms/distwrap/collectives.py
@@ -1,0 +1,643 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# pyre-strict
+
+from typing import Any
+
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup, ReduceOp
+from torchcomms import objcol, ReduceOp as TcReduceOp, TorchComm
+from torchcomms.distwrap.fallback import (
+    fallback_all_gather_gloo,
+    fallback_all_to_all_gloo,
+    fallback_all_to_all_single_gloo,
+)
+from torchcomms.distwrap.pginfo import pg_info_assert_registered, pg_info_get_data
+from torchcomms.distwrap.utils import (
+    get_backend_for_device,
+    get_group,
+    get_group_rank,
+    get_torchcomms_instance,
+    torchcomms_is_enabled,
+)
+
+
+# =============================================================================
+# Private Helper Functions
+# =============================================================================
+
+
+def _convert_reduce_op(op: ReduceOp) -> TcReduceOp:
+    """Convert torch.distributed.ReduceOp to torchcomms.ReduceOp."""
+    # Map from torch.distributed ReduceOp to torchcomms ReduceOp
+    op_map = {
+        ReduceOp.SUM: TcReduceOp.SUM,
+        ReduceOp.PRODUCT: TcReduceOp.PRODUCT,
+        ReduceOp.MIN: TcReduceOp.MIN,
+        ReduceOp.MAX: TcReduceOp.MAX,
+        ReduceOp.BAND: TcReduceOp.BAND,
+        ReduceOp.BOR: TcReduceOp.BOR,
+        ReduceOp.BXOR: TcReduceOp.BXOR,
+        ReduceOp.AVG: TcReduceOp.AVG,
+    }
+    if op in op_map:
+        return op_map[op]
+    raise ValueError(f"Unsupported ReduceOp: {op}")
+
+
+def _get_default_torchcomms_instance(pg: ProcessGroup) -> TorchComm:
+    """
+    Get a default torchcomms instance for the given process group.
+
+    This is used for operations that don't have a tensor to infer the device
+    from (e.g., object collectives, barrier).
+
+    Args:
+        pg: The process group.
+
+    Returns:
+        A torchcomms instance.
+
+    Raises:
+        AssertionError: If no torchcomms instances found for the process group.
+    """
+    torchcomms_instances = pg_info_get_data(pg, "torchcomms")
+    if not torchcomms_instances:
+        raise AssertionError(f"No torchcomms instances found for process group {pg}")
+    # Use the first available torchcomms instance
+    return next(iter(torchcomms_instances.values()))
+
+
+# =============================================================================
+# Public API Functions
+# =============================================================================
+
+
+def all_reduce(
+    tensor: torch.Tensor,
+    op: ReduceOp = ReduceOp.SUM,
+    group: ProcessGroup | None = None,
+    async_op: bool = False,
+) -> dist.Work | None:
+    pg = get_group(group)
+    pg_info_assert_registered(pg)
+
+    if torchcomms_is_enabled():
+        tc = get_torchcomms_instance(pg, tensor=tensor)
+        tc_op = _convert_reduce_op(op)
+        work = tc.all_reduce(tensor, tc_op, async_op)
+        return work if async_op else None
+    else:
+        return dist.all_reduce(tensor, op, pg, async_op)
+
+
+def broadcast(
+    tensor: torch.Tensor,
+    src: int | None = None,
+    group: ProcessGroup | None = None,
+    async_op: bool = False,
+    group_src: int | None = None,
+) -> dist.Work | None:
+    pg = get_group(group)
+    pg_info_assert_registered(pg)
+
+    if torchcomms_is_enabled():
+        # Resolve group_src for torchcomms
+        if group_src is None:
+            if src is None:
+                raise ValueError("Either src or group_src must be specified")
+            group_src = get_group_rank(pg, src)
+        elif src is not None:
+            raise ValueError("Cannot specify both src and group_src")
+
+        tc = get_torchcomms_instance(pg, tensor=tensor)
+        work = tc.broadcast(tensor, group_src, async_op)
+        return work if async_op else None
+    else:
+        return dist.broadcast(
+            tensor, src=src, group=pg, async_op=async_op, group_src=group_src
+        )
+
+
+def reduce(
+    tensor: torch.Tensor,
+    dst: int | None = None,
+    op: ReduceOp = ReduceOp.SUM,
+    group: ProcessGroup | None = None,
+    async_op: bool = False,
+    group_dst: int | None = None,
+) -> dist.Work | None:
+    pg = get_group(group)
+    pg_info_assert_registered(pg)
+
+    if torchcomms_is_enabled():
+        # Resolve group_dst for torchcomms
+        if group_dst is None:
+            if dst is None:
+                raise ValueError("Either dst or group_dst must be specified")
+            group_dst = get_group_rank(pg, dst)
+        elif dst is not None:
+            raise ValueError("Cannot specify both dst and group_dst")
+
+        tc = get_torchcomms_instance(pg, tensor=tensor)
+        tc_op = _convert_reduce_op(op)
+        work = tc.reduce(tensor, group_dst, tc_op, async_op)
+        return work if async_op else None
+    else:
+        return dist.reduce(
+            tensor, dst=dst, op=op, group=pg, async_op=async_op, group_dst=group_dst
+        )
+
+
+def all_gather(
+    tensor_list: list[torch.Tensor],
+    tensor: torch.Tensor,
+    group: ProcessGroup | None = None,
+    async_op: bool = False,
+) -> dist.Work | None:
+    pg = get_group(group)
+    pg_info_assert_registered(pg)
+
+    if torchcomms_is_enabled():
+        tc = get_torchcomms_instance(pg, tensor=tensor)
+        # Check if tensors have variable sizes (need all_gather_v)
+        sizes = [t.numel() for t in tensor_list]
+        if len(set(sizes)) > 1:
+            # Variable-size all_gather
+            work = tc.all_gather_v(tensor_list, tensor, async_op)
+        else:
+            work = tc.all_gather(tensor_list, tensor, async_op)
+        return work if async_op else None
+    else:
+        # Check if tensors have variable sizes - Gloo doesn't support this
+        sizes = [t.numel() for t in tensor_list]
+        if (
+            len(set(sizes)) > 1
+            and get_backend_for_device(pg, tensor.device.type) == "gloo"
+        ):
+            return fallback_all_gather_gloo(tensor_list, tensor, pg, async_op)
+        else:
+            return dist.all_gather(tensor_list, tensor, pg, async_op)
+
+
+def all_gather_into_tensor(
+    output_tensor: torch.Tensor,
+    input_tensor: torch.Tensor,
+    group: ProcessGroup | None = None,
+    async_op: bool = False,
+) -> dist.Work | None:
+    pg = get_group(group)
+    pg_info_assert_registered(pg)
+
+    if torchcomms_is_enabled():
+        tc = get_torchcomms_instance(pg, tensor=input_tensor)
+        work = tc.all_gather_single(output_tensor, input_tensor, async_op)
+        return work if async_op else None
+    else:
+        return dist.all_gather_into_tensor(output_tensor, input_tensor, pg, async_op)
+
+
+def reduce_scatter(
+    output: torch.Tensor,
+    input_list: list[torch.Tensor],
+    op: ReduceOp = ReduceOp.SUM,
+    group: ProcessGroup | None = None,
+    async_op: bool = False,
+) -> dist.Work | None:
+    pg = get_group(group)
+    pg_info_assert_registered(pg)
+
+    if torchcomms_is_enabled():
+        tc = get_torchcomms_instance(pg, tensor=output)
+        tc_op = _convert_reduce_op(op)
+        # Check if tensors have variable sizes (need reduce_scatter_v)
+        sizes = [t.numel() for t in input_list]
+        if len(set(sizes)) > 1:
+            # Variable-size reduce_scatter
+            work = tc.reduce_scatter_v(output, input_list, tc_op, async_op)
+        else:
+            work = tc.reduce_scatter(output, input_list, tc_op, async_op)
+        return work if async_op else None
+    else:
+        return dist.reduce_scatter(output, input_list, op, pg, async_op)
+
+
+def reduce_scatter_tensor(
+    output: torch.Tensor,
+    input: torch.Tensor,
+    op: ReduceOp = ReduceOp.SUM,
+    group: ProcessGroup | None = None,
+    async_op: bool = False,
+) -> dist.Work | None:
+    pg = get_group(group)
+    pg_info_assert_registered(pg)
+
+    if torchcomms_is_enabled():
+        tc = get_torchcomms_instance(pg, tensor=output)
+        tc_op = _convert_reduce_op(op)
+        work = tc.reduce_scatter_single(output, input, tc_op, async_op)
+        return work if async_op else None
+    else:
+        return dist.reduce_scatter_tensor(output, input, op, pg, async_op)
+
+
+def all_to_all(
+    output_tensor_list: list[torch.Tensor],
+    input_tensor_list: list[torch.Tensor],
+    group: ProcessGroup | None = None,
+    async_op: bool = False,
+) -> dist.Work | None:
+    pg = get_group(group)
+    pg_info_assert_registered(pg)
+
+    if torchcomms_is_enabled():
+        tc = get_torchcomms_instance(pg, tensor=input_tensor_list[0])
+        work = tc.all_to_all(output_tensor_list, input_tensor_list, async_op)
+        return work if async_op else None
+    else:
+        # Gloo doesn't support all_to_all
+        if get_backend_for_device(pg, input_tensor_list[0].device.type) == "gloo":
+            return fallback_all_to_all_gloo(
+                output_tensor_list, input_tensor_list, pg, async_op
+            )
+        else:
+            return dist.all_to_all(output_tensor_list, input_tensor_list, pg, async_op)
+
+
+def all_to_all_single(
+    output: torch.Tensor,
+    input: torch.Tensor,
+    output_split_sizes: list[int] | None = None,
+    input_split_sizes: list[int] | None = None,
+    group: ProcessGroup | None = None,
+    async_op: bool = False,
+) -> dist.Work | None:
+    pg = get_group(group)
+    pg_info_assert_registered(pg)
+
+    if torchcomms_is_enabled():
+        tc = get_torchcomms_instance(pg, tensor=input)
+        if output_split_sizes is None and input_split_sizes is None:
+            work = tc.all_to_all_single(output, input, async_op)
+        else:
+            work = tc.all_to_all_v_single(
+                output,
+                input,
+                output_split_sizes or [],
+                input_split_sizes or [],
+                async_op,
+            )
+        return work if async_op else None
+    else:
+        # Gloo doesn't support all_to_all_single
+        if get_backend_for_device(pg, input.device.type) == "gloo":
+            return fallback_all_to_all_single_gloo(
+                output, input, output_split_sizes, input_split_sizes, pg, async_op
+            )
+        else:
+            return dist.all_to_all_single(
+                output, input, output_split_sizes, input_split_sizes, pg, async_op
+            )
+
+
+def scatter(
+    tensor: torch.Tensor,
+    scatter_list: list[torch.Tensor] | None = None,
+    src: int | None = None,
+    group: ProcessGroup | None = None,
+    async_op: bool = False,
+    group_src: int | None = None,
+) -> dist.Work | None:
+    pg = get_group(group)
+    pg_info_assert_registered(pg)
+
+    if torchcomms_is_enabled():
+        # Resolve group_src for torchcomms
+        if group_src is None:
+            if src is None:
+                raise ValueError("Either src or group_src must be specified")
+            group_src = get_group_rank(pg, src)
+        elif src is not None:
+            raise ValueError("Cannot specify both src and group_src")
+
+        tc = get_torchcomms_instance(pg, tensor=tensor)
+        work = tc.scatter(tensor, scatter_list or [], group_src, async_op)
+        return work if async_op else None
+    else:
+        return dist.scatter(
+            tensor,
+            scatter_list,
+            src=src,
+            group=pg,
+            async_op=async_op,
+            group_src=group_src,
+        )
+
+
+def gather(
+    tensor: torch.Tensor,
+    gather_list: list[torch.Tensor] | None = None,
+    dst: int | None = None,
+    group: ProcessGroup | None = None,
+    async_op: bool = False,
+    group_dst: int | None = None,
+) -> dist.Work | None:
+    pg = get_group(group)
+    pg_info_assert_registered(pg)
+
+    if torchcomms_is_enabled():
+        # Resolve group_dst for torchcomms
+        if group_dst is None:
+            if dst is None:
+                raise ValueError("Either dst or group_dst must be specified")
+            group_dst = get_group_rank(pg, dst)
+        elif dst is not None:
+            raise ValueError("Cannot specify both dst and group_dst")
+
+        tc = get_torchcomms_instance(pg, tensor=tensor)
+        work = tc.gather(gather_list or [], tensor, group_dst, async_op)
+        return work if async_op else None
+    else:
+        return dist.gather(
+            tensor,
+            gather_list,
+            dst=dst,
+            group=pg,
+            async_op=async_op,
+            group_dst=group_dst,
+        )
+
+
+def barrier(
+    group: ProcessGroup | None = None,
+    async_op: bool = False,
+    device_ids: list[int] | None = None,
+) -> dist.Work | None:
+    pg = get_group(group)
+    pg_info_assert_registered(pg)
+
+    if torchcomms_is_enabled():
+        tc = _get_default_torchcomms_instance(pg)
+        work = tc.barrier(async_op)
+        # pyre-ignore[7]: TorchWork is compatible with Work
+        return work if async_op else None
+    else:
+        return dist.barrier(pg, async_op, device_ids)
+
+
+def send(
+    tensor: torch.Tensor,
+    dst: int | None = None,
+    group: ProcessGroup | None = None,
+    tag: int = 0,
+    group_dst: int | None = None,
+) -> None:
+    pg = get_group(group)
+    pg_info_assert_registered(pg)
+
+    if torchcomms_is_enabled():
+        # Resolve group_dst for torchcomms
+        if group_dst is None:
+            if dst is None:
+                raise ValueError("Either dst or group_dst must be specified")
+            group_dst = get_group_rank(pg, dst)
+        elif dst is not None:
+            raise ValueError("Cannot specify both dst and group_dst")
+
+        tc = get_torchcomms_instance(pg, tensor=tensor)
+        work = tc.send(tensor, group_dst, False)
+        work.wait()
+    else:
+        dist.send(tensor, dst=dst, group=pg, tag=tag, group_dst=group_dst)
+
+
+def recv(
+    tensor: torch.Tensor,
+    src: int | None = None,
+    group: ProcessGroup | None = None,
+    tag: int = 0,
+    group_src: int | None = None,
+) -> int:
+    pg = get_group(group)
+    pg_info_assert_registered(pg)
+
+    if torchcomms_is_enabled():
+        # Resolve group_src for torchcomms
+        if group_src is None:
+            if src is not None:
+                group_src = get_group_rank(pg, src)
+            else:
+                raise ValueError("torchcomms does not support wildcard recv (src=None)")
+        elif src is not None:
+            raise ValueError("Cannot specify both src and group_src")
+
+        tc = get_torchcomms_instance(pg, tensor=tensor)
+        work = tc.recv(tensor, group_src, False)
+        work.wait()
+        return src if src is not None else dist.get_process_group_ranks(pg)[group_src]
+    else:
+        return dist.recv(tensor, src=src, group=pg, tag=tag, group_src=group_src)
+
+
+def isend(
+    tensor: torch.Tensor,
+    dst: int | None = None,
+    group: ProcessGroup | None = None,
+    tag: int = 0,
+    group_dst: int | None = None,
+) -> dist.Work:
+    pg = get_group(group)
+    pg_info_assert_registered(pg)
+
+    if torchcomms_is_enabled():
+        # Resolve group_dst for torchcomms
+        if group_dst is None:
+            if dst is None:
+                raise ValueError("Either dst or group_dst must be specified")
+            group_dst = get_group_rank(pg, dst)
+        elif dst is not None:
+            raise ValueError("Cannot specify both dst and group_dst")
+
+        tc = get_torchcomms_instance(pg, tensor=tensor)
+        return tc.send(tensor, group_dst, True)
+    else:
+        work = dist.isend(tensor, dst=dst, group=pg, tag=tag, group_dst=group_dst)
+        if work is None:
+            raise AssertionError("dist.isend returned None")
+        return work
+
+
+def irecv(
+    tensor: torch.Tensor,
+    src: int | None = None,
+    group: ProcessGroup | None = None,
+    tag: int = 0,
+    group_src: int | None = None,
+) -> dist.Work:
+    pg = get_group(group)
+    pg_info_assert_registered(pg)
+
+    if torchcomms_is_enabled():
+        # Resolve group_src for torchcomms
+        if group_src is None:
+            if src is not None:
+                group_src = get_group_rank(pg, src)
+            else:
+                raise ValueError(
+                    "torchcomms does not support wildcard irecv (src=None)"
+                )
+        elif src is not None:
+            raise ValueError("Cannot specify both src and group_src")
+
+        tc = get_torchcomms_instance(pg, tensor=tensor)
+        return tc.recv(tensor, group_src, True)
+    else:
+        work = dist.irecv(tensor, src=src, group=pg, tag=tag, group_src=group_src)
+        if work is None:
+            raise AssertionError("dist.irecv returned None")
+        return work
+
+
+def batch_isend_irecv(p2p_op_list: list[Any]) -> list[dist.Work]:
+    if torchcomms_is_enabled():
+        works: list[dist.Work] = []
+        for p2p_op in p2p_op_list:
+            # Handle both distwrap P2POp and torch.distributed.P2POp
+            actual_op = getattr(p2p_op, "_p2p_op", p2p_op)
+            pg = get_group(actual_op.group)
+            pg_info_assert_registered(pg)
+            tc = get_torchcomms_instance(pg, tensor=actual_op.tensor)
+            op_name = actual_op.op.__name__
+
+            # Get group_peer, converting from global peer if needed
+            group_peer = actual_op.group_peer
+            if group_peer is None:
+                if actual_op.peer is not None:
+                    group_peer = get_group_rank(pg, actual_op.peer)
+                else:
+                    raise ValueError(
+                        "torchcomms does not support wildcard P2P operations "
+                        "(peer=None)"
+                    )
+
+            if "send" in op_name:
+                work = tc.send(actual_op.tensor, group_peer, True)
+            elif "recv" in op_name:
+                work = tc.recv(actual_op.tensor, group_peer, True)
+            else:
+                raise ValueError(f"Unknown P2P operation: {op_name}")
+            works.append(work)
+        return works
+    # Unwrap distwrap P2POp objects to torch.distributed.P2POp
+    unwrapped_ops = [getattr(op, "_p2p_op", op) for op in p2p_op_list]
+    works = dist.batch_isend_irecv(unwrapped_ops)
+    if works is None:
+        raise AssertionError("dist.batch_isend_irecv returned None")
+    return works
+
+
+def all_gather_object(
+    object_list: list[Any],
+    obj: Any,
+    group: ProcessGroup | None = None,
+) -> None:
+    pg = get_group(group)
+    pg_info_assert_registered(pg)
+
+    if torchcomms_is_enabled():
+        tc = _get_default_torchcomms_instance(pg)
+        objcol.all_gather_object(tc, object_list, obj)
+    else:
+        dist.all_gather_object(object_list, obj, pg)
+
+
+def gather_object(
+    obj: Any,
+    object_gather_list: list[Any] | None = None,
+    dst: int | None = None,
+    group: ProcessGroup | None = None,
+    group_dst: int | None = None,
+) -> None:
+    pg = get_group(group)
+    pg_info_assert_registered(pg)
+
+    if torchcomms_is_enabled():
+        # Resolve group_dst for torchcomms
+        if group_dst is None:
+            if dst is None:
+                raise ValueError("Either dst or group_dst must be specified")
+            group_dst = get_group_rank(pg, dst)
+        elif dst is not None:
+            raise ValueError("Cannot specify both dst and group_dst")
+
+        tc = _get_default_torchcomms_instance(pg)
+        objcol.gather_object(
+            tc, obj, root=group_dst, object_gather_list=object_gather_list
+        )
+    else:
+        dist.gather_object(
+            obj, object_gather_list, dst=dst, group=pg, group_dst=group_dst
+        )
+
+
+def scatter_object_list(
+    scatter_object_output_list: list[Any],
+    scatter_object_input_list: list[Any] | None = None,
+    src: int | None = None,
+    group: ProcessGroup | None = None,
+    group_src: int | None = None,
+) -> None:
+    pg = get_group(group)
+    pg_info_assert_registered(pg)
+
+    if torchcomms_is_enabled():
+        # Resolve group_src for torchcomms
+        if group_src is None:
+            if src is None:
+                raise ValueError("Either src or group_src must be specified")
+            group_src = get_group_rank(pg, src)
+        elif src is not None:
+            raise ValueError("Cannot specify both src and group_src")
+
+        tc = _get_default_torchcomms_instance(pg)
+        objcol.scatter_object_list(
+            tc,
+            root=group_src,
+            scatter_object_output_list=scatter_object_output_list,
+            scatter_object_input_list=scatter_object_input_list,
+        )
+    else:
+        dist.scatter_object_list(
+            scatter_object_output_list,
+            scatter_object_input_list,
+            src=src,
+            group=pg,
+            group_src=group_src,
+        )
+
+
+def broadcast_object_list(
+    object_list: list[Any],
+    src: int | None = None,
+    group: ProcessGroup | None = None,
+    device: torch.device | None = None,
+    group_src: int | None = None,
+) -> None:
+    pg = get_group(group)
+    pg_info_assert_registered(pg)
+
+    if torchcomms_is_enabled():
+        # Resolve group_src for torchcomms
+        if group_src is None:
+            if src is None:
+                raise ValueError("Either src or group_src must be specified")
+            group_src = get_group_rank(pg, src)
+        elif src is not None:
+            raise ValueError("Cannot specify both src and group_src")
+
+        tc = _get_default_torchcomms_instance(pg)
+        objcol.broadcast_object_list(tc, object_list, root=group_src)
+    else:
+        dist.broadcast_object_list(
+            object_list, src=src, group=pg, device=device, group_src=group_src
+        )

--- a/comms/torchcomms/distwrap/collectives_extension.py
+++ b/comms/torchcomms/distwrap/collectives_extension.py
@@ -1,0 +1,195 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# pyre-strict
+
+from typing import Any, List
+
+import torch
+from torch.distributed import ProcessGroup
+from torchcomms.distwrap.pginfo import pg_info_get_data
+from torchcomms.distwrap.utils import (
+    get_group,
+    get_torchcomms_instance,
+    parse_backend_string,
+    torchcomms_is_enabled,
+)
+
+
+# =============================================================================
+# Window Operations (torchcomms-only)
+# =============================================================================
+
+
+def new_window(
+    group: ProcessGroup | None = None,
+    backend: str | None = None,
+) -> Any:
+    if not torchcomms_is_enabled():
+        raise AssertionError("new_window requires torchcomms to be enabled")
+
+    pg = get_group(group)
+
+    if backend is not None:
+        # Determine device type from backend parameter
+        device_backends = parse_backend_string(backend)
+        # Use the first (and typically only) device type from the parsed backend
+        device_type = next(iter(device_backends.keys()))
+        tc = get_torchcomms_instance(pg, device_type=device_type)
+    else:
+        # Pick the first available torchcomms instance from the group
+        torchcomms_instances = pg_info_get_data(pg, "torchcomms")
+        if not torchcomms_instances:
+            raise AssertionError(
+                f"No torchcomms instances found for process group {pg}"
+            )
+        tc = next(iter(torchcomms_instances.values()))
+
+    return tc.new_window()
+
+
+# =============================================================================
+# AlltoAllv-Dedup Operations (torchcomms/ncclx-only)
+# =============================================================================
+
+
+def alltoallv_dedup_init(
+    num_tokens: int,
+    token_size: int,
+    topk_k: int,
+    experts_per_rank: int,
+    dtype: torch.dtype,
+    group: ProcessGroup | None = None,
+    async_op: bool = False,
+) -> Any:
+    if not torchcomms_is_enabled():
+        raise AssertionError("alltoallv_dedup_init requires torchcomms to be enabled")
+
+    pg = get_group(group)
+    tc = get_torchcomms_instance(pg, device_type="cuda")
+
+    # Verify backend is ncclx
+    backend_name = tc.get_backend()
+    if backend_name != "ncclx":
+        raise AssertionError(
+            f"alltoallv_dedup_init requires ncclx backend, got {backend_name}"
+        )
+
+    ncclx_backend = tc.unsafe_get_backend()
+    return ncclx_backend.alltoallv_dedup_init(
+        num_tokens, token_size, topk_k, experts_per_rank, dtype, async_op
+    )
+
+
+def alltoallv_dedup_exec(
+    output_tensor: torch.Tensor,
+    recv_block_ids: torch.Tensor,
+    input_tensor: torch.Tensor,
+    send_indices: torch.Tensor,
+    forward_indices: torch.Tensor,
+    recv_indices: torch.Tensor,
+    persist_req: Any,
+    group: ProcessGroup | None = None,
+) -> Any:
+    if not torchcomms_is_enabled():
+        raise AssertionError("alltoallv_dedup_exec requires torchcomms to be enabled")
+
+    pg = get_group(group)
+    tc = get_torchcomms_instance(pg, device_type="cuda")
+
+    # Verify backend is ncclx
+    backend_name = tc.get_backend()
+    if backend_name != "ncclx":
+        raise AssertionError(
+            f"alltoallv_dedup_exec requires ncclx backend, got {backend_name}"
+        )
+
+    ncclx_backend = tc.unsafe_get_backend()
+    return ncclx_backend.alltoallv_dedup_exec(
+        output_tensor,
+        recv_block_ids,
+        input_tensor,
+        send_indices,
+        forward_indices,
+        recv_indices,
+        persist_req,
+    )
+
+
+# =============================================================================
+# AlltoAllv-Dynamic Operations (torchcomms/ncclx-only)
+# =============================================================================
+
+
+def alltoallv_dynamic_dispatch(
+    output_tensors: List[torch.Tensor],
+    output_split_sizes: torch.Tensor,
+    input_tensor: torch.Tensor,
+    input_split_sizes: torch.Tensor,
+    input_split_indices: torch.Tensor,
+    input_split_indices_per_rank: torch.Tensor,
+    D: int,
+    group: ProcessGroup | None = None,
+    async_op: bool = False,
+) -> Any:
+    if not torchcomms_is_enabled():
+        raise AssertionError(
+            "alltoallv_dynamic_dispatch requires torchcomms to be enabled"
+        )
+
+    pg = get_group(group)
+    tc = get_torchcomms_instance(pg, device_type="cuda")
+
+    # Verify backend is ncclx
+    backend_name = tc.get_backend()
+    if backend_name != "ncclx":
+        raise AssertionError(
+            f"alltoallv_dynamic_dispatch requires ncclx backend, got {backend_name}"
+        )
+
+    ncclx_backend = tc.unsafe_get_backend()
+    return ncclx_backend.alltoallv_dynamic_dispatch(
+        output_tensors,
+        output_split_sizes,
+        input_tensor,
+        input_split_sizes,
+        input_split_indices,
+        input_split_indices_per_rank,
+        D,
+        async_op,
+    )
+
+
+def alltoallv_dynamic_combine(
+    output_tensor: torch.Tensor,
+    input_tensor: torch.Tensor,
+    input_split_sizes: torch.Tensor,
+    input_split_indices: torch.Tensor,
+    input_split_indices_per_rank: torch.Tensor,
+    D: int,
+    group: ProcessGroup | None = None,
+    async_op: bool = False,
+) -> None:
+    if not torchcomms_is_enabled():
+        raise AssertionError(
+            "alltoallv_dynamic_combine requires torchcomms to be enabled"
+        )
+
+    pg = get_group(group)
+    tc = get_torchcomms_instance(pg, device_type="cuda")
+
+    # Verify backend is ncclx
+    backend_name = tc.get_backend()
+    if backend_name != "ncclx":
+        raise AssertionError(
+            f"alltoallv_dynamic_combine requires ncclx backend, got {backend_name}"
+        )
+
+    ncclx_backend = tc.unsafe_get_backend()
+    ncclx_backend.alltoallv_dynamic_combine(
+        output_tensor,
+        input_tensor,
+        input_split_sizes,
+        input_split_indices,
+        input_split_indices_per_rank,
+        D,
+        async_op,
+    )

--- a/comms/torchcomms/distwrap/fallback.py
+++ b/comms/torchcomms/distwrap/fallback.py
@@ -1,0 +1,174 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# pyre-strict
+
+"""
+Fallback implementations for collectives that are not supported by certain backends.
+
+These functions provide software implementations of collectives using simpler
+primitives when the native backend implementation is not available.
+"""
+
+from datetime import timedelta
+from typing import Any
+
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
+
+
+def fallback_split_group_new_group(
+    parent_pg: ProcessGroup,
+    my_group_ranks: list[int],
+    timeout: timedelta | None,
+    pg_options: Any | None,
+    group_desc: str | None,
+) -> ProcessGroup:
+    my_rank = dist.get_rank(parent_pg)
+
+    # Only the smallest rank in each group provides the list
+    if my_rank == min(my_group_ranks):
+        my_contribution: list[int] | None = my_group_ranks
+    else:
+        my_contribution = None
+
+    # All-gather to get all unique split lists
+    gathered_lists: list[list[int] | None] = [None] * dist.get_world_size(parent_pg)
+    dist.all_gather_object(gathered_lists, my_contribution, group=parent_pg)
+
+    # Filter out Nones to get unique split lists
+    all_split_ranks = [r for r in gathered_lists if r is not None]
+
+    # Create process groups for each split
+    new_pg = None
+    for rank_list in all_split_ranks:
+        if my_rank in rank_list:
+            new_pg = dist.new_group(
+                ranks=rank_list,
+                timeout=timeout,
+                pg_options=pg_options,
+                group_desc=group_desc,
+            )
+        else:
+            # Other ranks still need to participate in the collective
+            dist.new_group(
+                ranks=rank_list,
+                timeout=timeout,
+                pg_options=pg_options,
+                group_desc=group_desc,
+            )
+
+    if new_pg is None:
+        raise AssertionError("Failed to create process group for this rank")
+
+    return new_pg
+
+
+def fallback_all_gather_gloo(
+    tensor_list: list[torch.Tensor],
+    tensor: torch.Tensor,
+    pg: ProcessGroup,
+    async_op: bool,
+) -> dist.Work | None:
+    """Implement all_gather using all_to_all for gloo backend."""
+    # For all_gather, each rank sends its tensor to all ranks
+    # Create input list where every element is the same tensor
+    input_tensor_list = [tensor] * len(tensor_list)
+    return fallback_all_to_all_gloo(tensor_list, input_tensor_list, pg, async_op)
+
+
+def fallback_all_to_all_gloo(
+    output_tensor_list: list[torch.Tensor],
+    input_tensor_list: list[torch.Tensor],
+    pg: ProcessGroup,
+    async_op: bool,
+) -> dist.Work | None:
+    """Implement all_to_all using batched send/recv for gloo backend."""
+    my_rank = dist.get_rank(pg)
+    world_size = dist.get_world_size(pg)
+
+    # Local copy: my own data stays local
+    output_tensor_list[my_rank].copy_(input_tensor_list[my_rank])
+
+    # Build list of P2P operations for all remote exchanges
+    p2p_ops = []
+    for i in range(world_size):
+        if i == my_rank:
+            continue
+        # Receive from rank i into output_tensor_list[i]
+        p2p_ops.append(dist.P2POp(dist.irecv, output_tensor_list[i], i, pg))
+        # Send to rank i from input_tensor_list[i]
+        p2p_ops.append(dist.P2POp(dist.isend, input_tensor_list[i], i, pg))
+
+    if p2p_ops:
+        reqs = dist.batch_isend_irecv(p2p_ops)
+        for req in reqs[:-1]:
+            req.wait()
+        if async_op:
+            return reqs[-1]
+        else:
+            reqs[-1].wait()
+
+    return None
+
+
+def fallback_all_to_all_single_gloo(
+    output: torch.Tensor,
+    input: torch.Tensor,
+    output_split_sizes: list[int] | None,
+    input_split_sizes: list[int] | None,
+    pg: ProcessGroup,
+    async_op: bool,
+) -> dist.Work | None:
+    """Implement all_to_all_single using batched send/recv for gloo backend."""
+    my_rank = dist.get_rank(pg)
+    world_size = dist.get_world_size(pg)
+
+    if input_split_sizes is None:
+        in_split = input.numel() // world_size
+        input_split_sizes = [in_split] * world_size
+    if output_split_sizes is None:
+        out_split = output.numel() // world_size
+        output_split_sizes = [out_split] * world_size
+
+    # Compute offsets for input and output tensors
+    input_offsets = [0]
+    for size in input_split_sizes[:-1]:
+        input_offsets.append(input_offsets[-1] + size)
+    output_offsets = [0]
+    for size in output_split_sizes[:-1]:
+        output_offsets.append(output_offsets[-1] + size)
+
+    # Local copy: my own data stays local
+    local_in_start = input_offsets[my_rank]
+    local_in_end = local_in_start + input_split_sizes[my_rank]
+    local_out_start = output_offsets[my_rank]
+    local_out_end = local_out_start + output_split_sizes[my_rank]
+    output[local_out_start:local_out_end].copy_(input[local_in_start:local_in_end])
+
+    # Build list of P2P operations for all remote exchanges
+    p2p_ops = []
+    for i in range(world_size):
+        if i == my_rank:
+            continue
+        # Receive from rank i into output slice for rank i
+        out_start = output_offsets[i]
+        out_end = out_start + output_split_sizes[i]
+        recv_tensor = output[out_start:out_end]
+        p2p_ops.append(dist.P2POp(dist.irecv, recv_tensor, i, pg))
+
+        # Send to rank i from input slice for rank i
+        in_start = input_offsets[i]
+        in_end = in_start + input_split_sizes[i]
+        send_tensor = input[in_start:in_end].contiguous()
+        p2p_ops.append(dist.P2POp(dist.isend, send_tensor, i, pg))
+
+    if p2p_ops:
+        reqs = dist.batch_isend_irecv(p2p_ops)
+        for req in reqs[:-1]:
+            req.wait()
+        if async_op:
+            return reqs[-1]
+        else:
+            reqs[-1].wait()
+
+    return None

--- a/comms/torchcomms/distwrap/new_comm.py
+++ b/comms/torchcomms/distwrap/new_comm.py
@@ -1,0 +1,322 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# pyre-strict
+
+import os
+from datetime import timedelta
+from typing import Any
+
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup, TCPStore
+from torchcomms._comms import new_comm, TorchComm
+from torchcomms.distwrap.fallback import fallback_split_group_new_group
+from torchcomms.distwrap.pginfo import (
+    pg_info_assert_registered,
+    pg_info_create,
+    pg_info_destroy,
+    pg_info_get_data,
+    pg_info_set_data,
+)
+from torchcomms.distwrap.utils import (
+    _BACKEND_RENAME_FOR_DIST,
+    _block_torch_distributed_collectives,
+    eager_init_is_enabled,
+    format_backend_string,
+    get_rank_and_world_size,
+    parse_backend_string,
+    set_eager_init_enabled,
+    set_torchcomms_enabled,
+    torchcomms_create_split_group,
+    torchcomms_is_enabled,
+)
+
+
+def init_process_group(
+    backend: str | dist.Backend | None = None,
+    init_method: str | None = None,
+    timeout: timedelta | None = None,
+    world_size: int = -1,
+    rank: int = -1,
+    store: dist.Store | None = None,
+    group_name: str = "",
+    pg_options: Any | None = None,
+    device_id: torch.device | int | None = None,
+    # Extension API
+    use_torchcomms: bool = False,
+) -> None:
+    """
+    Initialize the process group for distributed communication.
+
+    Note: If use_torchcomms is True, device_id is ignored and set to None
+    internally to disable eager mode in torch.distributed.
+    """
+    if backend is None:
+        raise ValueError("backend must be specified")
+
+    # Store the use_torchcomms setting globally
+    set_torchcomms_enabled(use_torchcomms)
+
+    # Get rank and world_size from parameters or environment variables
+    rank, world_size = get_rank_and_world_size(rank, world_size)
+
+    # If torchcomms is active, turn off eager mode for torch.distributed
+    # and create a shared store if one is not provided
+    tc_store: TCPStore | None = None
+    if use_torchcomms:
+        device_id = None
+        # Create a TCPStore to share between torch.distributed and torchcomms
+        # This avoids port conflicts since both will use the same store
+        if store is None:
+            master_addr = os.environ.get("MASTER_ADDR", "localhost")
+            master_port = int(os.environ.get("MASTER_PORT", "29500"))
+            tc_store = TCPStore(
+                host_name=master_addr,
+                port=master_port,
+                world_size=world_size,
+                is_master=(rank == 0),
+                wait_for_workers=True,
+            )
+            store = tc_store
+        else:
+            # Use provided store for torchcomms as well
+            tc_store = store  # type: ignore[assignment]
+
+    # Store the eager_init setting globally
+    set_eager_init_enabled(device_id is not None)
+
+    # Parse backend string and get dist-compatible backend string
+    device_backends = parse_backend_string(backend)
+
+    # torch.distributed does not understand ncclx/rcclx backends,
+    # so rename them to nccl/rccl respectively
+    dist_device_backends = {
+        device: _BACKEND_RENAME_FOR_DIST.get(be, be)
+        for device, be in device_backends.items()
+    }
+    dist_backend = format_backend_string(dist_device_backends)
+
+    # Call dist.init_process_group
+    dist.init_process_group(
+        backend=dist_backend,
+        init_method=init_method,
+        timeout=timeout,
+        world_size=world_size,
+        rank=rank,
+        store=store,
+        group_name=group_name,
+        pg_options=pg_options,
+        device_id=device_id,
+    )
+
+    # Register the world process group
+    world_ranks = list(range(world_size))
+    world_pg = dist.group.WORLD
+    if world_pg is None:
+        raise AssertionError("World process group is not initialized")
+    pg_info_create(world_pg, world_ranks, group_name)
+
+    # Store the device_backends mapping
+    pg_info_set_data(world_pg, "device_backends", device_backends)
+
+    # If use_torchcomms is set, create torchcomms communicators for each backend
+    if use_torchcomms:
+        # Block direct calls to torch.distributed collectives
+        _block_torch_distributed_collectives()
+
+        # Store the shared store reference for cleanup later
+        pg_info_set_data(world_pg, "tc_store", tc_store)
+
+        torchcomms_instances: dict[str, TorchComm] = {}
+        for device_type, backend_name in device_backends.items():
+            name = group_name or f"default_torchcomm_{backend_name}"
+
+            # Create torchcomms instance with the shared store
+            torchcomms_instance = new_comm(
+                backend=backend_name,
+                device=torch.device(device_type),
+                name=name,
+                store=tc_store,
+            )
+
+            torchcomms_instances[device_type] = torchcomms_instance
+
+        # Store torchcomms instances in pg_info data field
+        pg_info_set_data(world_pg, "torchcomms", torchcomms_instances)
+
+
+def new_group(
+    ranks: list[int] | None = None,
+    timeout: timedelta | None = None,
+    backend: str | None = None,
+    pg_options: Any | None = None,
+    use_local_synchronization: bool = False,
+    group_desc: str | None = None,
+    device_id: torch.device | None = None,
+) -> ProcessGroup:
+    if not dist.is_initialized():
+        raise AssertionError("new_group called before init_process_group")
+    pg_info_assert_registered(dist.group.WORLD)
+
+    if torchcomms_is_enabled():
+        raise AssertionError(
+            "new_group is not supported with torchcomms. Use split_group instead."
+        )
+
+    if backend is None:
+        raise ValueError("backend must be specified")
+
+    if ranks is None:
+        ranks = list(range(dist.get_world_size()))
+
+    # Get device_backends from backend parameter
+    device_backends = parse_backend_string(backend)
+
+    # torch.distributed does not understand ncclx/rcclx backends,
+    # so rename them to nccl/rccl respectively
+    dist_device_backends = {
+        device: _BACKEND_RENAME_FOR_DIST.get(be, be)
+        for device, be in device_backends.items()
+    }
+    dist_backend = format_backend_string(dist_device_backends)
+
+    # Create the process group
+    new_pg = dist.new_group(
+        ranks=ranks,
+        timeout=timeout,
+        backend=dist_backend,
+        pg_options=pg_options,
+        use_local_synchronization=use_local_synchronization,
+        group_desc=group_desc,
+        device_id=device_id,
+    )
+
+    # Register the new process group
+    pg_info_create(new_pg, ranks, group_desc)
+
+    # Store device_backends
+    pg_info_set_data(new_pg, "device_backends", device_backends)
+
+    return new_pg
+
+
+def destroy_process_group(group: ProcessGroup | None = None) -> None:
+    """Destroy the process group and clean up resources."""
+    if group is None:
+        group = dist.group.WORLD
+
+    if group is None:
+        raise AssertionError("Process group is not initialized")
+
+    # Finalize torchcomms instances if they exist
+    if torchcomms_is_enabled():
+        torchcomms_instances = pg_info_get_data(group, "torchcomms")
+        for _device_type, tc_instance in torchcomms_instances.items():
+            tc_instance.finalize()
+
+        # Clear the store reference - it will be garbage collected
+        # and its destructor will handle cleanup (shutdown server if master)
+        pg_info_set_data(group, "tc_store", None)
+
+    # Clean up pg_info registry
+    pg_info_destroy(group)
+
+    # Call dist.destroy_process_group
+    dist.destroy_process_group(group)
+
+
+def split_group(  # noqa: C901
+    group: ProcessGroup | None = None,
+    split_ranks: list[list[int]] | None = None,
+    timeout: timedelta | None = None,
+    pg_options: Any | None = None,
+    group_desc: str | None = None,
+    # Extension API
+    backend: str | None = None,
+) -> ProcessGroup:
+    if not dist.is_initialized():
+        raise AssertionError("split_group called before init_process_group")
+
+    # Default to WORLD if no group specified
+    if group is None:
+        parent_pg = dist.group.WORLD
+        if parent_pg is None:
+            raise AssertionError("World process group is not initialized")
+    else:
+        parent_pg = group
+    pg_info_assert_registered(parent_pg)
+
+    if split_ranks is None:
+        split_ranks = [list(range(dist.get_world_size(parent_pg)))]
+
+    # Find which group this rank belongs to
+    my_rank = dist.get_rank(parent_pg)
+    my_group_ranks = None
+    for rank_list in split_ranks:
+        if my_rank in rank_list:
+            my_group_ranks = rank_list
+            break
+
+    if my_group_ranks is None:
+        raise ValueError(f"Rank {my_rank} not found in any split_ranks group")
+
+    # Get device_backends from backend parameter or parent group
+    if backend is not None:
+        device_backends = parse_backend_string(backend)
+    else:
+        device_backends = pg_info_get_data(parent_pg, "device_backends")
+
+    if torchcomms_is_enabled():
+        # Create a pg with new_group
+        new_pg = dist.new_group(
+            ranks=my_group_ranks,
+            pg_options=pg_options,
+            group_desc=group_desc,
+        )
+
+        # Register the new process group
+        pg_info_create(new_pg, my_group_ranks, group_desc)
+
+        # Store device_backends
+        pg_info_set_data(new_pg, "device_backends", device_backends)
+
+        # Create torchcomms instances by splitting from the parent pg
+        torchcomms_create_split_group(
+            new_pg,
+            parent_pg,
+            split_ranks,
+            group_desc or "",
+            pg_options,
+            device_backends,
+        )
+    else:
+        # Check if split_group is supported
+        split_group_supported = True
+        for be in device_backends.values():
+            if be == "gloo":
+                split_group_supported = False
+                break
+        if not eager_init_is_enabled():
+            split_group_supported = False
+
+        if split_group_supported:
+            # Use dist.split_group
+            new_pg = dist.split_group(
+                parent_pg,
+                split_ranks=split_ranks,
+                timeout=timeout,
+                pg_options=pg_options,
+                group_desc=group_desc,
+            )
+        else:
+            # Slow path: implement split_group using new_group
+            new_pg = fallback_split_group_new_group(
+                parent_pg, my_group_ranks, timeout, pg_options, group_desc
+            )
+
+        # Register the new process group
+        pg_info_create(new_pg, my_group_ranks, group_desc)
+
+        # Store device_backends
+        pg_info_set_data(new_pg, "device_backends", device_backends)
+
+    return new_pg

--- a/comms/torchcomms/distwrap/pginfo.py
+++ b/comms/torchcomms/distwrap/pginfo.py
@@ -1,0 +1,82 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# pyre-strict
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from torch.distributed import ProcessGroup
+
+
+# =============================================================================
+# Public API Functions
+# =============================================================================
+
+
+def pg_info_create(
+    pg: ProcessGroup, global_ranks: list[int] | None, group_desc: str | None
+) -> None:
+    if pg in _PG_INFO_REGISTRY:
+        raise AssertionError(f"Process group {pg} already registered")
+    pg_info = _PG_INFO(
+        global_ranks=global_ranks.copy() if global_ranks is not None else [],
+        group_desc=group_desc or "",
+    )
+    _PG_INFO_REGISTRY[pg] = pg_info
+
+
+def pg_info_destroy(pg: ProcessGroup) -> None:
+    if pg not in _PG_INFO_REGISTRY:
+        return
+    _PG_INFO_REGISTRY.pop(pg)
+
+
+def pg_info_get(pg: ProcessGroup) -> "_PG_INFO | None":
+    return _PG_INFO_REGISTRY.get(pg, None)
+
+
+def pg_info_assert_registered(pg: ProcessGroup) -> None:
+    assert pg in _PG_INFO_REGISTRY, f"Process group {pg} not registered"
+
+
+def pg_info_get_global_ranks(pg: ProcessGroup) -> list[int]:
+    pg_info = _PG_INFO_REGISTRY.get(pg, None)
+    if pg_info is None:
+        raise AssertionError(f"Process group {pg} not registered")
+    return pg_info.global_ranks
+
+
+def pg_info_get_group_desc(pg: ProcessGroup) -> str:
+    pg_info = _PG_INFO_REGISTRY.get(pg, None)
+    if pg_info is None:
+        raise AssertionError(f"Process group {pg} not registered")
+    return pg_info.group_desc
+
+
+def pg_info_set_data(pg: ProcessGroup, key: str, data: Any) -> None:
+    pg_info = _PG_INFO_REGISTRY.get(pg, None)
+    if pg_info is None:
+        raise AssertionError(f"Process group {pg} not registered")
+    pg_info.data[key] = data
+
+
+def pg_info_get_data(pg: ProcessGroup, key: str) -> Any:
+    pg_info = _PG_INFO_REGISTRY.get(pg, None)
+    if pg_info is None:
+        raise AssertionError(f"Process group {pg} not registered")
+    assert key in pg_info.data, f"Key '{key}' not found in process group {pg}"
+    return pg_info.data[key]
+
+
+# =============================================================================
+# Private Data Structures
+# =============================================================================
+
+
+@dataclass
+class _PG_INFO:
+    global_ranks: list[int]
+    group_desc: str
+    data: dict[str, Any] = field(default_factory=dict)
+
+
+_PG_INFO_REGISTRY: dict[ProcessGroup, _PG_INFO] = {}

--- a/comms/torchcomms/distwrap/tests/integration/AllGatherTest.py
+++ b/comms/torchcomms/distwrap/tests/integration/AllGatherTest.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+# pyre-unsafe
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""Integration tests for all_gather and all_gather_into_tensor collectives."""
+
+import unittest
+
+import torch
+from torchcomms import distwrap as dist
+from torchcomms.distwrap.tests.integration.test_helpers import (
+    get_backend,
+    get_device,
+    get_rank_and_size,
+    use_torchcomms,
+)
+
+
+class AllGatherTest(unittest.TestCase):
+    """Test class for all_gather operations using distwrap."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Initialize distwrap once for all tests."""
+        rank, _ = get_rank_and_size()
+        device = get_device(rank)
+        backend = get_backend()
+
+        dist.init_process_group(
+            backend=backend,
+            use_torchcomms=use_torchcomms(),
+        )
+
+        if device.type == "cuda":
+            torch.cuda.set_device(device)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """Clean up distwrap after all tests."""
+        dist.destroy_process_group()
+
+    def test_sync_all_gather(self) -> None:
+        """Test synchronous all_gather."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+        device = get_device(rank)
+
+        input_tensor = torch.ones(1024, dtype=torch.float, device=device) * (rank + 1)
+        output_list = [
+            torch.zeros(1024, dtype=torch.float, device=device)
+            for _ in range(num_ranks)
+        ]
+
+        dist.all_gather(output_list, input_tensor, async_op=False)
+
+        for i, output in enumerate(output_list):
+            expected = torch.full_like(output.cpu(), i + 1)
+            torch.testing.assert_close(output.cpu(), expected)
+
+    def test_async_all_gather(self) -> None:
+        """Test asynchronous all_gather."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+        device = get_device(rank)
+
+        input_tensor = torch.ones(1024, dtype=torch.float, device=device) * (rank + 1)
+        output_list = [
+            torch.zeros(1024, dtype=torch.float, device=device)
+            for _ in range(num_ranks)
+        ]
+
+        work = dist.all_gather(output_list, input_tensor, async_op=True)
+        if work is None:
+            raise AssertionError("work is None")
+        work.wait()
+
+        for i, output in enumerate(output_list):
+            expected = torch.full_like(output.cpu(), i + 1)
+            torch.testing.assert_close(output.cpu(), expected)
+
+    def test_sync_all_gather_into_tensor(self) -> None:
+        """Test synchronous all_gather_into_tensor."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+        device = get_device(rank)
+
+        input_tensor = torch.ones(1024, dtype=torch.float, device=device) * (rank + 1)
+        output_tensor = torch.zeros(1024 * num_ranks, dtype=torch.float, device=device)
+
+        dist.all_gather_into_tensor(output_tensor, input_tensor, async_op=False)
+
+        for i in range(num_ranks):
+            chunk = output_tensor[i * 1024 : (i + 1) * 1024].cpu()
+            expected = torch.full_like(chunk, i + 1)
+            torch.testing.assert_close(chunk, expected)
+
+    def test_async_all_gather_into_tensor(self) -> None:
+        """Test asynchronous all_gather_into_tensor."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+        device = get_device(rank)
+
+        input_tensor = torch.ones(1024, dtype=torch.float, device=device) * (rank + 1)
+        output_tensor = torch.zeros(1024 * num_ranks, dtype=torch.float, device=device)
+
+        work = dist.all_gather_into_tensor(output_tensor, input_tensor, async_op=True)
+        if work is None:
+            raise AssertionError("work is None")
+        work.wait()
+
+        for i in range(num_ranks):
+            chunk = output_tensor[i * 1024 : (i + 1) * 1024].cpu()
+            expected = torch.full_like(chunk, i + 1)
+            torch.testing.assert_close(chunk, expected)
+
+    def test_all_gather_variable_sizes(self) -> None:
+        """Test all_gather with variable-sized output tensors."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+        device = get_device(rank)
+
+        # Each rank contributes a tensor of size (rank + 1) * 256
+        input_size = (rank + 1) * 256
+        input_tensor = torch.ones(input_size, dtype=torch.float, device=device) * (
+            rank + 1
+        )
+
+        # Output list has variable-sized tensors matching each rank's contribution
+        output_list = [
+            torch.zeros((i + 1) * 256, dtype=torch.float, device=device)
+            for i in range(num_ranks)
+        ]
+
+        dist.all_gather(output_list, input_tensor, async_op=False)
+
+        for i, output in enumerate(output_list):
+            expected_size = (i + 1) * 256
+            self.assertEqual(output.numel(), expected_size)
+            expected = torch.full_like(output.cpu(), i + 1)
+            torch.testing.assert_close(output.cpu(), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/comms/torchcomms/distwrap/tests/integration/AllReduceTest.py
+++ b/comms/torchcomms/distwrap/tests/integration/AllReduceTest.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# pyre-unsafe
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import unittest
+
+import torch
+from torchcomms import distwrap as dist
+from torchcomms.distwrap.tests.integration.test_helpers import (
+    get_backend,
+    get_device,
+    get_rank_and_size,
+    use_torchcomms,
+)
+
+
+class AllReduceTest(unittest.TestCase):
+    """Test class for all_reduce operations using distwrap."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Initialize distwrap once for all tests."""
+        rank, _ = get_rank_and_size()
+        device = get_device(rank)
+        backend = get_backend()
+
+        dist.init_process_group(
+            backend=backend,
+            use_torchcomms=use_torchcomms(),
+        )
+
+        if device.type == "cuda":
+            torch.cuda.set_device(device)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """Clean up distwrap after all tests."""
+        dist.destroy_process_group()
+
+    def test_sync_all_reduce(self) -> None:
+        """Test synchronous all_reduce with SUM."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+        device = get_device(rank)
+
+        input_tensor = torch.ones(1024, dtype=torch.float, device=device) * (rank + 1)
+
+        dist.all_reduce(input_tensor, dist.ReduceOp.SUM, async_op=False)
+
+        expected = num_ranks * (num_ranks + 1) // 2
+        expected_tensor = torch.full_like(input_tensor.cpu(), expected)
+        torch.testing.assert_close(input_tensor.cpu(), expected_tensor)
+
+    def test_async_all_reduce(self) -> None:
+        """Test asynchronous all_reduce with SUM."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+        device = get_device(rank)
+
+        input_tensor = torch.ones(1024, dtype=torch.float, device=device) * (rank + 1)
+
+        work = dist.all_reduce(input_tensor, dist.ReduceOp.SUM, async_op=True)
+        if work is None:
+            raise AssertionError("work is None")
+        work.wait()
+
+        expected = num_ranks * (num_ranks + 1) // 2
+        expected_tensor = torch.full_like(input_tensor.cpu(), expected)
+        torch.testing.assert_close(input_tensor.cpu(), expected_tensor)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/comms/torchcomms/distwrap/tests/integration/AllToAllTest.py
+++ b/comms/torchcomms/distwrap/tests/integration/AllToAllTest.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+# pyre-unsafe
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""Integration tests for all_to_all and all_to_all_single collectives."""
+
+import unittest
+
+import torch
+from torchcomms import distwrap as dist
+from torchcomms.distwrap.tests.integration.test_helpers import (
+    get_backend,
+    get_device,
+    get_rank_and_size,
+    use_torchcomms,
+)
+
+
+class AllToAllTest(unittest.TestCase):
+    """Test class for all_to_all operations using distwrap."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Initialize distwrap once for all tests."""
+        rank, _ = get_rank_and_size()
+        device = get_device(rank)
+        backend = get_backend()
+
+        dist.init_process_group(
+            backend=backend,
+            use_torchcomms=use_torchcomms(),
+        )
+
+        if device.type == "cuda":
+            torch.cuda.set_device(device)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """Clean up distwrap after all tests."""
+        dist.destroy_process_group()
+
+    def test_sync_all_to_all(self) -> None:
+        """Test synchronous all_to_all."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+        device = get_device(rank)
+
+        # Each rank sends its rank value to all other ranks
+        input_list = [
+            torch.ones(1024, dtype=torch.float, device=device) * (rank + 1)
+            for _ in range(num_ranks)
+        ]
+        output_list = [
+            torch.zeros(1024, dtype=torch.float, device=device)
+            for _ in range(num_ranks)
+        ]
+
+        dist.all_to_all(output_list, input_list, async_op=False)
+
+        # After all_to_all, output_list[i] should contain data from rank i
+        for i, output in enumerate(output_list):
+            expected = torch.full_like(output.cpu(), i + 1)
+            torch.testing.assert_close(output.cpu(), expected)
+
+    def test_async_all_to_all(self) -> None:
+        """Test asynchronous all_to_all."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+        device = get_device(rank)
+
+        input_list = [
+            torch.ones(1024, dtype=torch.float, device=device) * (rank + 1)
+            for _ in range(num_ranks)
+        ]
+        output_list = [
+            torch.zeros(1024, dtype=torch.float, device=device)
+            for _ in range(num_ranks)
+        ]
+
+        work = dist.all_to_all(output_list, input_list, async_op=True)
+        if work is None:
+            raise AssertionError("work is None")
+        work.wait()
+
+        for i, output in enumerate(output_list):
+            expected = torch.full_like(output.cpu(), i + 1)
+            torch.testing.assert_close(output.cpu(), expected)
+
+    def test_sync_all_to_all_single(self) -> None:
+        """Test synchronous all_to_all_single."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+        device = get_device(rank)
+
+        # Create input tensor with rank-specific values for each destination
+        input_tensor = torch.zeros(1024 * num_ranks, dtype=torch.float, device=device)
+        for i in range(num_ranks):
+            input_tensor[i * 1024 : (i + 1) * 1024] = rank + 1
+
+        output_tensor = torch.zeros(1024 * num_ranks, dtype=torch.float, device=device)
+
+        dist.all_to_all_single(output_tensor, input_tensor, async_op=False)
+
+        # After all_to_all_single, chunk i should contain data from rank i
+        for i in range(num_ranks):
+            chunk = output_tensor[i * 1024 : (i + 1) * 1024].cpu()
+            expected = torch.full_like(chunk, i + 1)
+            torch.testing.assert_close(chunk, expected)
+
+    def test_async_all_to_all_single(self) -> None:
+        """Test asynchronous all_to_all_single."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+        device = get_device(rank)
+
+        input_tensor = torch.zeros(1024 * num_ranks, dtype=torch.float, device=device)
+        for i in range(num_ranks):
+            input_tensor[i * 1024 : (i + 1) * 1024] = rank + 1
+
+        output_tensor = torch.zeros(1024 * num_ranks, dtype=torch.float, device=device)
+
+        work = dist.all_to_all_single(output_tensor, input_tensor, async_op=True)
+        if work is None:
+            raise AssertionError("work is None")
+        work.wait()
+
+        for i in range(num_ranks):
+            chunk = output_tensor[i * 1024 : (i + 1) * 1024].cpu()
+            expected = torch.full_like(chunk, i + 1)
+            torch.testing.assert_close(chunk, expected)
+
+    def test_all_to_all_single_with_split_sizes(self) -> None:
+        """Test all_to_all_single with variable split sizes."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+        device = get_device(rank)
+
+        # Each rank sends (i + 1) * 128 elements to rank i
+        input_split_sizes = [(i + 1) * 128 for i in range(num_ranks)]
+        output_split_sizes = [(rank + 1) * 128 for _ in range(num_ranks)]
+
+        total_input = sum(input_split_sizes)
+        total_output = sum(output_split_sizes)
+
+        # Fill input tensor with rank value
+        input_tensor = torch.ones(total_input, dtype=torch.float, device=device) * (
+            rank + 1
+        )
+        output_tensor = torch.zeros(total_output, dtype=torch.float, device=device)
+
+        dist.all_to_all_single(
+            output_tensor,
+            input_tensor,
+            output_split_sizes=output_split_sizes,
+            input_split_sizes=input_split_sizes,
+            async_op=False,
+        )
+
+        # Verify output: each chunk should contain data from the corresponding rank
+        offset = 0
+        for i in range(num_ranks):
+            chunk_size = output_split_sizes[i]
+            chunk = output_tensor[offset : offset + chunk_size].cpu()
+            expected = torch.full_like(chunk, i + 1)
+            torch.testing.assert_close(chunk, expected)
+            offset += chunk_size
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/comms/torchcomms/distwrap/tests/integration/BarrierTest.py
+++ b/comms/torchcomms/distwrap/tests/integration/BarrierTest.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# pyre-unsafe
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""Integration tests for barrier collective."""
+
+import unittest
+
+import torch
+from torchcomms import distwrap as dist
+from torchcomms.distwrap.tests.integration.test_helpers import (
+    get_backend,
+    get_device,
+    get_rank_and_size,
+    use_torchcomms,
+)
+
+
+class BarrierTest(unittest.TestCase):
+    """Test class for barrier operations using distwrap."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Initialize distwrap once for all tests."""
+        rank, _ = get_rank_and_size()
+        device = get_device(rank)
+        backend = get_backend()
+
+        dist.init_process_group(
+            backend=backend,
+            use_torchcomms=use_torchcomms(),
+        )
+
+        if device.type == "cuda":
+            torch.cuda.set_device(device)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """Clean up distwrap after all tests."""
+        dist.destroy_process_group()
+
+    def test_sync_barrier(self) -> None:
+        """Test synchronous barrier."""
+        # Simply test that barrier completes without error
+        dist.barrier(async_op=False)
+
+        # If we get here, barrier succeeded
+        self.assertTrue(True)
+
+    def test_async_barrier(self) -> None:
+        """Test asynchronous barrier."""
+        work = dist.barrier(async_op=True)
+        if work is None:
+            raise AssertionError("work is None")
+        work.wait()
+
+        # If we get here, barrier succeeded
+        self.assertTrue(True)
+
+    def test_barrier_synchronization(self) -> None:
+        """Test that barrier actually synchronizes ranks."""
+        rank = dist.get_rank()
+        device = get_device(rank)
+
+        # Each rank sets a value before barrier
+        tensor = torch.ones(1, dtype=torch.float, device=device) * rank
+
+        # Barrier to synchronize
+        dist.barrier(async_op=False)
+
+        # After barrier, verify tensor still has correct value
+        expected = torch.full_like(tensor.cpu(), rank)
+        torch.testing.assert_close(tensor.cpu(), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/comms/torchcomms/distwrap/tests/integration/BroadcastTest.py
+++ b/comms/torchcomms/distwrap/tests/integration/BroadcastTest.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# pyre-unsafe
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""Integration tests for broadcast collective."""
+
+import unittest
+
+import torch
+from torchcomms import distwrap as dist
+from torchcomms.distwrap.tests.integration.test_helpers import (
+    get_backend,
+    get_device,
+    get_rank_and_size,
+    use_torchcomms,
+)
+
+
+class BroadcastTest(unittest.TestCase):
+    """Test class for broadcast operations using distwrap."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Initialize distwrap once for all tests."""
+        rank, _ = get_rank_and_size()
+        device = get_device(rank)
+        backend = get_backend()
+
+        dist.init_process_group(
+            backend=backend,
+            use_torchcomms=use_torchcomms(),
+        )
+
+        if device.type == "cuda":
+            torch.cuda.set_device(device)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """Clean up distwrap after all tests."""
+        dist.destroy_process_group()
+
+    def test_sync_broadcast(self) -> None:
+        """Test synchronous broadcast from rank 0."""
+        rank = dist.get_rank()
+        device = get_device(rank)
+
+        if rank == 0:
+            tensor = torch.ones(1024, dtype=torch.float, device=device) * 42
+        else:
+            tensor = torch.zeros(1024, dtype=torch.float, device=device)
+
+        dist.broadcast(tensor, src=0, async_op=False)
+
+        expected_tensor = torch.full_like(tensor.cpu(), 42)
+        torch.testing.assert_close(tensor.cpu(), expected_tensor)
+
+    def test_async_broadcast(self) -> None:
+        """Test asynchronous broadcast from rank 0."""
+        rank = dist.get_rank()
+        device = get_device(rank)
+
+        if rank == 0:
+            tensor = torch.ones(1024, dtype=torch.float, device=device) * 99
+        else:
+            tensor = torch.zeros(1024, dtype=torch.float, device=device)
+
+        work = dist.broadcast(tensor, src=0, async_op=True)
+        if work is None:
+            raise AssertionError("work is None")
+        work.wait()
+
+        expected_tensor = torch.full_like(tensor.cpu(), 99)
+        torch.testing.assert_close(tensor.cpu(), expected_tensor)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/comms/torchcomms/distwrap/tests/integration/InitProcessGroupBackendRequiredTest.py
+++ b/comms/torchcomms/distwrap/tests/integration/InitProcessGroupBackendRequiredTest.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+# pyre-unsafe
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""Test that init_process_group raises error when backend is None."""
+
+import unittest
+
+from torchcomms import distwrap as dist
+
+
+class Test(unittest.TestCase):
+    def test(self) -> None:
+        with self.assertRaises(ValueError) as context:
+            dist.init_process_group(backend=None)
+        self.assertIn("backend must be specified", str(context.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/comms/torchcomms/distwrap/tests/integration/InitProcessGroupDefaultTest.py
+++ b/comms/torchcomms/distwrap/tests/integration/InitProcessGroupDefaultTest.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# pyre-unsafe
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""Test init_process_group without use_torchcomms argument (defaults to False)."""
+
+import unittest
+
+import torch
+from torchcomms import distwrap as dist
+from torchcomms.distwrap.tests.integration.test_helpers import (
+    get_backend,
+    get_device,
+    get_rank_and_size,
+)
+
+
+class Test(unittest.TestCase):
+    def test(self) -> None:
+        rank, num_ranks = get_rank_and_size()
+        device = get_device(rank)
+
+        dist.init_process_group(backend=get_backend())
+
+        if device.type == "cuda":
+            torch.cuda.set_device(device)
+
+        try:
+            self.assertTrue(dist.is_initialized())
+            self.assertEqual(dist.get_rank(), rank)
+            self.assertEqual(dist.get_world_size(), num_ranks)
+
+            input_tensor = torch.ones(1024, dtype=torch.float, device=device) * (
+                rank + 1
+            )
+            dist.all_reduce(input_tensor, dist.ReduceOp.SUM, async_op=False)
+
+            expected = num_ranks * (num_ranks + 1) // 2
+            expected_tensor = torch.full_like(input_tensor.cpu(), expected)
+            torch.testing.assert_close(input_tensor.cpu(), expected_tensor)
+        finally:
+            dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/comms/torchcomms/distwrap/tests/integration/InitProcessGroupDeviceIdTest.py
+++ b/comms/torchcomms/distwrap/tests/integration/InitProcessGroupDeviceIdTest.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# pyre-unsafe
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""Test init_process_group with device_id for eager initialization."""
+
+import unittest
+
+import torch
+from torchcomms import distwrap as dist
+from torchcomms.distwrap.tests.integration.test_helpers import (
+    get_backend,
+    get_device,
+    get_rank_and_size,
+    use_torchcomms,
+)
+
+
+class Test(unittest.TestCase):
+    def test(self) -> None:
+        rank, num_ranks = get_rank_and_size()
+        device = get_device(rank)
+
+        if device.type != "cuda":
+            self.skipTest("device_id test requires CUDA")
+
+        dist.init_process_group(
+            backend=get_backend(),
+            device_id=device,
+            use_torchcomms=use_torchcomms(),
+        )
+
+        torch.cuda.set_device(device)
+
+        try:
+            self.assertTrue(dist.is_initialized())
+
+            input_tensor = torch.ones(1024, dtype=torch.float, device=device) * (
+                rank + 1
+            )
+            dist.all_reduce(input_tensor, dist.ReduceOp.SUM, async_op=False)
+
+            expected = num_ranks * (num_ranks + 1) // 2
+            expected_tensor = torch.full_like(input_tensor.cpu(), expected)
+            torch.testing.assert_close(input_tensor.cpu(), expected_tensor)
+        finally:
+            dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/comms/torchcomms/distwrap/tests/integration/InitProcessGroupExplicitRankTest.py
+++ b/comms/torchcomms/distwrap/tests/integration/InitProcessGroupExplicitRankTest.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# pyre-unsafe
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""Test init_process_group with explicit rank and world_size."""
+
+import unittest
+
+import torch
+from torchcomms import distwrap as dist
+from torchcomms.distwrap.tests.integration.test_helpers import (
+    get_backend,
+    get_device,
+    get_rank_and_size,
+    use_torchcomms,
+)
+
+
+class Test(unittest.TestCase):
+    def test(self) -> None:
+        rank, num_ranks = get_rank_and_size()
+        device = get_device(rank)
+
+        dist.init_process_group(
+            backend=get_backend(),
+            rank=rank,
+            world_size=num_ranks,
+            use_torchcomms=use_torchcomms(),
+        )
+
+        if device.type == "cuda":
+            torch.cuda.set_device(device)
+
+        try:
+            self.assertTrue(dist.is_initialized())
+            self.assertEqual(dist.get_rank(), rank)
+            self.assertEqual(dist.get_world_size(), num_ranks)
+
+            input_tensor = torch.ones(1024, dtype=torch.float, device=device) * (
+                rank + 1
+            )
+            dist.all_reduce(input_tensor, dist.ReduceOp.SUM, async_op=False)
+
+            expected = num_ranks * (num_ranks + 1) // 2
+            expected_tensor = torch.full_like(input_tensor.cpu(), expected)
+            torch.testing.assert_close(input_tensor.cpu(), expected_tensor)
+        finally:
+            dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/comms/torchcomms/distwrap/tests/integration/InitProcessGroupExplicitTorchcommsTest.py
+++ b/comms/torchcomms/distwrap/tests/integration/InitProcessGroupExplicitTorchcommsTest.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# pyre-unsafe
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""Test init_process_group with use_torchcomms explicitly set to True."""
+
+import unittest
+
+import torch
+from torchcomms import distwrap as dist
+from torchcomms.distwrap.tests.integration.test_helpers import (
+    get_backend,
+    get_device,
+    get_rank_and_size,
+)
+
+
+class Test(unittest.TestCase):
+    def test(self) -> None:
+        rank, num_ranks = get_rank_and_size()
+        device = get_device(rank)
+
+        dist.init_process_group(
+            backend=get_backend(),
+            use_torchcomms=True,
+        )
+
+        if device.type == "cuda":
+            torch.cuda.set_device(device)
+
+        try:
+            self.assertTrue(dist.is_initialized())
+
+            input_tensor = torch.ones(1024, dtype=torch.float, device=device) * (
+                rank + 1
+            )
+            dist.all_reduce(input_tensor, dist.ReduceOp.SUM, async_op=False)
+
+            expected = num_ranks * (num_ranks + 1) // 2
+            expected_tensor = torch.full_like(input_tensor.cpu(), expected)
+            torch.testing.assert_close(input_tensor.cpu(), expected_tensor)
+        finally:
+            dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/comms/torchcomms/distwrap/tests/integration/InitProcessGroupGroupNameTest.py
+++ b/comms/torchcomms/distwrap/tests/integration/InitProcessGroupGroupNameTest.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# pyre-unsafe
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""Test init_process_group with group_name."""
+
+import unittest
+
+import torch
+from torchcomms import distwrap as dist
+from torchcomms.distwrap.tests.integration.test_helpers import (
+    get_backend,
+    get_device,
+    get_rank_and_size,
+    use_torchcomms,
+)
+
+
+class Test(unittest.TestCase):
+    def test(self) -> None:
+        rank, num_ranks = get_rank_and_size()
+        device = get_device(rank)
+
+        dist.init_process_group(
+            backend=get_backend(),
+            group_name="test_group",
+            use_torchcomms=use_torchcomms(),
+        )
+
+        if device.type == "cuda":
+            torch.cuda.set_device(device)
+
+        try:
+            self.assertTrue(dist.is_initialized())
+
+            input_tensor = torch.ones(1024, dtype=torch.float, device=device) * (
+                rank + 1
+            )
+            dist.all_reduce(input_tensor, dist.ReduceOp.SUM, async_op=False)
+
+            expected = num_ranks * (num_ranks + 1) // 2
+            expected_tensor = torch.full_like(input_tensor.cpu(), expected)
+            torch.testing.assert_close(input_tensor.cpu(), expected_tensor)
+        finally:
+            dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/comms/torchcomms/distwrap/tests/integration/InitProcessGroupPgOptionsTest.py
+++ b/comms/torchcomms/distwrap/tests/integration/InitProcessGroupPgOptionsTest.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# pyre-unsafe
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""Test init_process_group with pg_options parameter."""
+
+import unittest
+
+import torch
+from torchcomms import distwrap as dist
+from torchcomms.distwrap.tests.integration.test_helpers import (
+    get_backend,
+    get_device,
+    get_pg_options,
+    get_rank_and_size,
+    use_torchcomms,
+)
+
+
+class Test(unittest.TestCase):
+    def test(self) -> None:
+        rank, num_ranks = get_rank_and_size()
+        device = get_device(rank)
+        backend = get_backend()
+
+        pg_options = get_pg_options(backend)
+        if pg_options is None:
+            self.skipTest(f"pg_options test not supported for backend {backend}")
+
+        dist.init_process_group(
+            backend=backend,
+            pg_options=pg_options,
+            use_torchcomms=use_torchcomms(),
+        )
+
+        if device.type == "cuda":
+            torch.cuda.set_device(device)
+
+        try:
+            self.assertTrue(dist.is_initialized())
+
+            input_tensor = torch.ones(1024, dtype=torch.float, device=device) * (
+                rank + 1
+            )
+            dist.all_reduce(input_tensor, dist.ReduceOp.SUM, async_op=False)
+
+            expected = num_ranks * (num_ranks + 1) // 2
+            expected_tensor = torch.full_like(input_tensor.cpu(), expected)
+            torch.testing.assert_close(input_tensor.cpu(), expected_tensor)
+        finally:
+            dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/comms/torchcomms/distwrap/tests/integration/InitProcessGroupRankAndWorldSizeFromEnvTest.py
+++ b/comms/torchcomms/distwrap/tests/integration/InitProcessGroupRankAndWorldSizeFromEnvTest.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# pyre-unsafe
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""Test init_process_group deriving both rank and world_size from environment."""
+
+import unittest
+
+import torch
+from torchcomms import distwrap as dist
+from torchcomms.distwrap.tests.integration.test_helpers import (
+    get_backend,
+    get_device,
+    get_rank_and_size,
+    use_torchcomms,
+)
+
+
+class Test(unittest.TestCase):
+    def test(self) -> None:
+        rank, num_ranks = get_rank_and_size()
+        device = get_device(rank)
+
+        dist.init_process_group(
+            backend=get_backend(),
+            use_torchcomms=use_torchcomms(),
+        )
+
+        if device.type == "cuda":
+            torch.cuda.set_device(device)
+
+        try:
+            self.assertTrue(dist.is_initialized())
+            self.assertEqual(dist.get_rank(), rank)
+            self.assertEqual(dist.get_world_size(), num_ranks)
+
+            input_tensor = torch.ones(1024, dtype=torch.float, device=device) * (
+                rank + 1
+            )
+            dist.all_reduce(input_tensor, dist.ReduceOp.SUM, async_op=False)
+
+            expected = num_ranks * (num_ranks + 1) // 2
+            expected_tensor = torch.full_like(input_tensor.cpu(), expected)
+            torch.testing.assert_close(input_tensor.cpu(), expected_tensor)
+        finally:
+            dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/comms/torchcomms/distwrap/tests/integration/InitProcessGroupRankFromEnvTest.py
+++ b/comms/torchcomms/distwrap/tests/integration/InitProcessGroupRankFromEnvTest.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# pyre-unsafe
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""Test init_process_group deriving rank from environment."""
+
+import unittest
+
+import torch
+from torchcomms import distwrap as dist
+from torchcomms.distwrap.tests.integration.test_helpers import (
+    get_backend,
+    get_device,
+    get_rank_and_size,
+    use_torchcomms,
+)
+
+
+class Test(unittest.TestCase):
+    def test(self) -> None:
+        rank, num_ranks = get_rank_and_size()
+        device = get_device(rank)
+
+        dist.init_process_group(
+            backend=get_backend(),
+            world_size=num_ranks,
+            use_torchcomms=use_torchcomms(),
+        )
+
+        if device.type == "cuda":
+            torch.cuda.set_device(device)
+
+        try:
+            self.assertTrue(dist.is_initialized())
+            self.assertEqual(dist.get_rank(), rank)
+
+            input_tensor = torch.ones(1024, dtype=torch.float, device=device) * (
+                rank + 1
+            )
+            dist.all_reduce(input_tensor, dist.ReduceOp.SUM, async_op=False)
+
+            expected = num_ranks * (num_ranks + 1) // 2
+            expected_tensor = torch.full_like(input_tensor.cpu(), expected)
+            torch.testing.assert_close(input_tensor.cpu(), expected_tensor)
+        finally:
+            dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/comms/torchcomms/distwrap/tests/integration/InitProcessGroupTimeoutTest.py
+++ b/comms/torchcomms/distwrap/tests/integration/InitProcessGroupTimeoutTest.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# pyre-unsafe
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""Test init_process_group with explicit timeout."""
+
+import unittest
+from datetime import timedelta
+
+import torch
+from torchcomms import distwrap as dist
+from torchcomms.distwrap.tests.integration.test_helpers import (
+    get_backend,
+    get_device,
+    get_rank_and_size,
+    use_torchcomms,
+)
+
+
+class Test(unittest.TestCase):
+    def test(self) -> None:
+        rank, num_ranks = get_rank_and_size()
+        device = get_device(rank)
+
+        dist.init_process_group(
+            backend=get_backend(),
+            timeout=timedelta(seconds=60),
+            use_torchcomms=use_torchcomms(),
+        )
+
+        if device.type == "cuda":
+            torch.cuda.set_device(device)
+
+        try:
+            self.assertTrue(dist.is_initialized())
+
+            input_tensor = torch.ones(1024, dtype=torch.float, device=device) * (
+                rank + 1
+            )
+            dist.all_reduce(input_tensor, dist.ReduceOp.SUM, async_op=False)
+
+            expected = num_ranks * (num_ranks + 1) // 2
+            expected_tensor = torch.full_like(input_tensor.cpu(), expected)
+            torch.testing.assert_close(input_tensor.cpu(), expected_tensor)
+        finally:
+            dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/comms/torchcomms/distwrap/tests/integration/InitProcessGroupWorldSizeFromEnvTest.py
+++ b/comms/torchcomms/distwrap/tests/integration/InitProcessGroupWorldSizeFromEnvTest.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# pyre-unsafe
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""Test init_process_group deriving world_size from environment."""
+
+import unittest
+
+import torch
+from torchcomms import distwrap as dist
+from torchcomms.distwrap.tests.integration.test_helpers import (
+    get_backend,
+    get_device,
+    get_rank_and_size,
+    use_torchcomms,
+)
+
+
+class Test(unittest.TestCase):
+    def test(self) -> None:
+        rank, num_ranks = get_rank_and_size()
+        device = get_device(rank)
+
+        dist.init_process_group(
+            backend=get_backend(),
+            rank=rank,
+            use_torchcomms=use_torchcomms(),
+        )
+
+        if device.type == "cuda":
+            torch.cuda.set_device(device)
+
+        try:
+            self.assertTrue(dist.is_initialized())
+            self.assertEqual(dist.get_world_size(), num_ranks)
+
+            input_tensor = torch.ones(1024, dtype=torch.float, device=device) * (
+                rank + 1
+            )
+            dist.all_reduce(input_tensor, dist.ReduceOp.SUM, async_op=False)
+
+            expected = num_ranks * (num_ranks + 1) // 2
+            expected_tensor = torch.full_like(input_tensor.cpu(), expected)
+            torch.testing.assert_close(input_tensor.cpu(), expected_tensor)
+        finally:
+            dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/comms/torchcomms/distwrap/tests/integration/NewGroupTest.py
+++ b/comms/torchcomms/distwrap/tests/integration/NewGroupTest.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+# pyre-unsafe
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""Integration tests for new_group.
+
+Tests various parameter combinations for new_group:
+- Explicit ranks and default ranks
+- Backend parameter (required)
+- Timeout parameter
+- Group description parameter
+- use_local_synchronization parameter
+- device_id parameter
+- Collectives on new groups
+"""
+
+import unittest
+
+import torch
+from torchcomms import distwrap as dist
+from torchcomms.distwrap.tests.integration.test_helpers import (
+    get_backend,
+    get_device,
+    get_pg_options,
+    get_rank_and_size,
+    use_torchcomms,
+)
+
+
+class NewGroupTest(unittest.TestCase):
+    """Test class for new_group operations using distwrap."""
+
+    def setUp(self) -> None:
+        """Initialize distwrap before each test."""
+        rank, size = get_rank_and_size()
+        device = get_device(rank)
+        backend = get_backend()
+
+        dist.init_process_group(
+            backend=backend,
+            use_torchcomms=use_torchcomms(),
+        )
+
+        if device.type == "cuda":
+            torch.cuda.set_device(device)
+
+    def tearDown(self) -> None:
+        """Clean up distwrap after each test."""
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+    def _verify_collective(self, pg: dist.ProcessGroup) -> None:
+        """Verify the process group works with a basic all_reduce."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size(pg)
+        device = get_device(rank)
+
+        input_tensor = torch.ones(1024, dtype=torch.float, device=device) * (rank + 1)
+        dist.all_reduce(input_tensor, dist.ReduceOp.SUM, group=pg, async_op=False)
+
+        expected = num_ranks * (num_ranks + 1) // 2
+        expected_tensor = torch.full_like(input_tensor.cpu(), expected)
+        torch.testing.assert_close(input_tensor.cpu(), expected_tensor)
+
+    def test_new_group_all_ranks(self) -> None:
+        """Test new_group with all ranks."""
+        num_ranks = dist.get_world_size()
+        all_ranks = list(range(num_ranks))
+        backend = get_backend()
+
+        if use_torchcomms():
+            # new_group is not supported with torchcomms
+            with self.assertRaises(AssertionError) as context:
+                dist.new_group(ranks=all_ranks, backend=backend)
+            self.assertIn(
+                "new_group is not supported with torchcomms",
+                str(context.exception),
+            )
+            return
+
+        new_pg = dist.new_group(ranks=all_ranks, backend=backend)
+
+        self.assertIsNotNone(new_pg)
+        self.assertEqual(
+            dist.get_world_size(new_pg),
+            num_ranks,
+        )
+
+        self._verify_collective(new_pg)
+
+        dist.destroy_process_group(new_pg)
+
+    def test_new_group_default_ranks(self) -> None:
+        """Test new_group with default ranks (None = all ranks)."""
+        num_ranks = dist.get_world_size()
+        backend = get_backend()
+
+        if use_torchcomms():
+            with self.assertRaises(AssertionError) as context:
+                dist.new_group(backend=backend)
+            self.assertIn(
+                "new_group is not supported with torchcomms",
+                str(context.exception),
+            )
+            return
+
+        new_pg = dist.new_group(backend=backend)
+
+        self.assertIsNotNone(new_pg)
+        self.assertEqual(
+            dist.get_world_size(new_pg),
+            num_ranks,
+        )
+
+        self._verify_collective(new_pg)
+
+        dist.destroy_process_group(new_pg)
+
+    def test_new_group_collective(self) -> None:
+        """Test that collectives work on new groups."""
+        num_ranks = dist.get_world_size()
+        backend = get_backend()
+
+        # Create a group with all ranks
+        all_ranks = list(range(num_ranks))
+
+        if use_torchcomms():
+            # new_group is not supported with torchcomms
+            with self.assertRaises(AssertionError) as context:
+                dist.new_group(ranks=all_ranks, backend=backend)
+            self.assertIn(
+                "new_group is not supported with torchcomms",
+                str(context.exception),
+            )
+            return
+
+        new_pg = dist.new_group(ranks=all_ranks, backend=backend)
+
+        self._verify_collective(new_pg)
+
+        dist.destroy_process_group(new_pg)
+
+    def test_new_group_with_timeout(self) -> None:
+        """Test new_group with explicit timeout parameter."""
+        from datetime import timedelta
+
+        num_ranks = dist.get_world_size()
+        all_ranks = list(range(num_ranks))
+        backend = get_backend()
+
+        if use_torchcomms():
+            with self.assertRaises(AssertionError):
+                dist.new_group(
+                    ranks=all_ranks,
+                    backend=backend,
+                    timeout=timedelta(seconds=60),
+                )
+            return
+
+        new_pg = dist.new_group(
+            ranks=all_ranks,
+            backend=backend,
+            timeout=timedelta(seconds=60),
+        )
+
+        self.assertIsNotNone(new_pg)
+        self.assertEqual(
+            dist.get_world_size(new_pg),
+            num_ranks,
+        )
+
+        self._verify_collective(new_pg)
+
+        dist.destroy_process_group(new_pg)
+
+    def test_new_group_with_group_desc(self) -> None:
+        """Test new_group with group_desc parameter."""
+        num_ranks = dist.get_world_size()
+        all_ranks = list(range(num_ranks))
+        backend = get_backend()
+
+        if use_torchcomms():
+            with self.assertRaises(AssertionError):
+                dist.new_group(
+                    ranks=all_ranks,
+                    backend=backend,
+                    group_desc="test_new_group",
+                )
+            return
+
+        new_pg = dist.new_group(
+            ranks=all_ranks,
+            backend=backend,
+            group_desc="test_new_group",
+        )
+
+        self.assertIsNotNone(new_pg)
+        self.assertEqual(
+            dist.get_world_size(new_pg),
+            num_ranks,
+        )
+
+        self._verify_collective(new_pg)
+
+        dist.destroy_process_group(new_pg)
+
+    def test_new_group_with_local_synchronization(self) -> None:
+        """Test new_group with use_local_synchronization parameter."""
+        num_ranks = dist.get_world_size()
+        all_ranks = list(range(num_ranks))
+        backend = get_backend()
+
+        if use_torchcomms():
+            with self.assertRaises(AssertionError):
+                dist.new_group(
+                    ranks=all_ranks,
+                    backend=backend,
+                    use_local_synchronization=True,
+                )
+            return
+
+        new_pg = dist.new_group(
+            ranks=all_ranks,
+            backend=backend,
+            use_local_synchronization=True,
+        )
+
+        self.assertIsNotNone(new_pg)
+        self.assertEqual(
+            dist.get_world_size(new_pg),
+            num_ranks,
+        )
+
+        self._verify_collective(new_pg)
+
+        dist.destroy_process_group(new_pg)
+
+    def test_new_group_with_device_id(self) -> None:
+        """Test new_group with device_id parameter."""
+        rank = dist.get_rank()
+        device = get_device(rank)
+
+        # Only test with CUDA if available
+        if device.type != "cuda":
+            self.skipTest("device_id test requires CUDA")
+
+        num_ranks = dist.get_world_size()
+        all_ranks = list(range(num_ranks))
+        backend = get_backend()
+
+        if use_torchcomms():
+            with self.assertRaises(AssertionError):
+                dist.new_group(
+                    ranks=all_ranks,
+                    backend=backend,
+                    device_id=device,
+                )
+            return
+
+        new_pg = dist.new_group(
+            ranks=all_ranks,
+            backend=backend,
+            device_id=device,
+        )
+
+        self.assertIsNotNone(new_pg)
+        self.assertEqual(
+            dist.get_world_size(new_pg),
+            num_ranks,
+        )
+
+        self._verify_collective(new_pg)
+
+        dist.destroy_process_group(new_pg)
+
+    def test_new_group_backend_required(self) -> None:
+        """Test that new_group raises error when backend is None."""
+        num_ranks = dist.get_world_size()
+        all_ranks = list(range(num_ranks))
+
+        if use_torchcomms():
+            # new_group is not supported with torchcomms
+            with self.assertRaises(AssertionError) as context:
+                dist.new_group(ranks=all_ranks, backend=None)
+            self.assertIn(
+                "new_group is not supported with torchcomms",
+                str(context.exception),
+            )
+            return
+
+        with self.assertRaises(ValueError) as context:
+            dist.new_group(ranks=all_ranks, backend=None)
+
+        self.assertIn("backend must be specified", str(context.exception))
+
+    def test_new_group_with_pg_options(self) -> None:
+        """Test new_group with pg_options parameter."""
+        backend = get_backend()
+        num_ranks = dist.get_world_size()
+        all_ranks = list(range(num_ranks))
+
+        pg_options = get_pg_options(backend)
+        if pg_options is None:
+            self.skipTest(f"pg_options test not supported for backend {backend}")
+
+        if use_torchcomms():
+            with self.assertRaises(AssertionError):
+                dist.new_group(
+                    ranks=all_ranks,
+                    backend=backend,
+                    pg_options=pg_options,
+                )
+            return
+
+        new_pg = dist.new_group(
+            ranks=all_ranks,
+            backend=backend,
+            pg_options=pg_options,
+        )
+
+        self.assertIsNotNone(new_pg)
+        self.assertEqual(
+            dist.get_world_size(new_pg),
+            num_ranks,
+        )
+
+        self._verify_collective(new_pg)
+
+        dist.destroy_process_group(new_pg)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/comms/torchcomms/distwrap/tests/integration/ObjectCollectivesTest.py
+++ b/comms/torchcomms/distwrap/tests/integration/ObjectCollectivesTest.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+# pyre-unsafe
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""Integration tests for object collectives."""
+
+import unittest
+
+import torch
+from torchcomms import distwrap as dist
+from torchcomms.distwrap.tests.integration.test_helpers import (
+    get_backend,
+    get_device,
+    get_rank_and_size,
+    use_torchcomms,
+)
+
+
+class ObjectCollectivesTest(unittest.TestCase):
+    """Test class for object collective operations using distwrap."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Initialize distwrap once for all tests."""
+        rank, _ = get_rank_and_size()
+        device = get_device(rank)
+        backend = get_backend()
+
+        dist.init_process_group(
+            backend=backend,
+            use_torchcomms=use_torchcomms(),
+        )
+
+        if device.type == "cuda":
+            torch.cuda.set_device(device)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """Clean up distwrap after all tests."""
+        dist.destroy_process_group()
+
+    def test_all_gather_object(self) -> None:
+        """Test all_gather_object gathers objects from all ranks."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+
+        # Each rank contributes its rank as an object
+        obj = {"rank": rank, "data": f"from_rank_{rank}"}
+        object_list = [None] * num_ranks
+
+        dist.all_gather_object(object_list, obj)
+
+        # Verify all objects were gathered
+        for i in range(num_ranks):
+            obj_i = object_list[i]
+            if obj_i is None:
+                raise AssertionError(f"object_list[{i}] is None")
+            self.assertEqual(obj_i["rank"], i)
+            self.assertEqual(obj_i["data"], f"from_rank_{i}")
+
+    def test_all_gather_object_with_list(self) -> None:
+        """Test all_gather_object with list objects."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+
+        # Each rank contributes a list
+        obj = [rank, rank * 2, rank * 3]
+        object_list = [None] * num_ranks
+
+        dist.all_gather_object(object_list, obj)
+
+        # Verify all lists were gathered
+        for i in range(num_ranks):
+            self.assertEqual(object_list[i], [i, i * 2, i * 3])
+
+    def test_gather_object(self) -> None:
+        """Test gather_object gathers objects to root rank."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+        root = 0
+
+        # Each rank contributes its data
+        obj = f"data_from_rank_{rank}"
+
+        if rank == root:
+            object_gather_list = [None] * num_ranks
+        else:
+            object_gather_list = None
+
+        dist.gather_object(obj, object_gather_list=object_gather_list, dst=root)
+
+        # Only root rank should have the gathered objects
+        if rank == root:
+            if object_gather_list is None:
+                raise AssertionError("object_gather_list is None")
+            for i in range(num_ranks):
+                self.assertEqual(object_gather_list[i], f"data_from_rank_{i}")
+
+    def test_gather_object_non_zero_root(self) -> None:
+        """Test gather_object with non-zero root rank."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+
+        if num_ranks < 2:
+            self.skipTest("Need at least 2 ranks for this test")
+
+        root = num_ranks - 1  # Last rank is root
+
+        obj = {"value": rank * 10}
+
+        if rank == root:
+            object_gather_list = [None] * num_ranks
+        else:
+            object_gather_list = None
+
+        dist.gather_object(obj, object_gather_list=object_gather_list, dst=root)
+
+        if rank == root:
+            if object_gather_list is None:
+                raise AssertionError("object_gather_list is None")
+            for i in range(num_ranks):
+                self.assertEqual(object_gather_list[i], {"value": i * 10})
+
+    def test_scatter_object_list(self) -> None:
+        """Test scatter_object_list scatters objects from root."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+        root = 0
+
+        # Root prepares objects to scatter
+        if rank == root:
+            scatter_input = [f"object_for_rank_{i}" for i in range(num_ranks)]
+        else:
+            scatter_input = None
+
+        scatter_output = [None]
+
+        dist.scatter_object_list(
+            scatter_output, scatter_object_input_list=scatter_input, src=root
+        )
+
+        # Each rank should receive its designated object
+        self.assertEqual(scatter_output[0], f"object_for_rank_{rank}")
+
+    def test_scatter_object_list_with_dicts(self) -> None:
+        """Test scatter_object_list with dictionary objects."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+        root = 0
+
+        if rank == root:
+            scatter_input = [{"id": i, "value": i * 100} for i in range(num_ranks)]
+        else:
+            scatter_input = None
+
+        scatter_output = [None]
+
+        dist.scatter_object_list(
+            scatter_output, scatter_object_input_list=scatter_input, src=root
+        )
+
+        self.assertEqual(scatter_output[0], {"id": rank, "value": rank * 100})
+
+    def test_broadcast_object_list(self) -> None:
+        """Test broadcast_object_list broadcasts objects from root."""
+        rank = dist.get_rank()
+        root = 0
+
+        if rank == root:
+            object_list = ["broadcast_string", 123, {"key": "value"}, [1, 2, 3]]
+        else:
+            object_list = [None, None, None, None]
+
+        dist.broadcast_object_list(object_list, src=root)
+
+        # All ranks should have the same objects
+        self.assertEqual(object_list[0], "broadcast_string")
+        self.assertEqual(object_list[1], 123)
+        self.assertEqual(object_list[2], {"key": "value"})
+        self.assertEqual(object_list[3], [1, 2, 3])
+
+    def test_broadcast_object_list_non_zero_root(self) -> None:
+        """Test broadcast_object_list with non-zero root."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+
+        if num_ranks < 2:
+            self.skipTest("Need at least 2 ranks for this test")
+
+        root = num_ranks - 1
+
+        if rank == root:
+            object_list = [{"source": "last_rank"}, 999]
+        else:
+            object_list = [None, None]
+
+        dist.broadcast_object_list(object_list, src=root)
+
+        self.assertEqual(object_list[0], {"source": "last_rank"})
+        self.assertEqual(object_list[1], 999)
+
+    def test_broadcast_object_list_complex_objects(self) -> None:
+        """Test broadcast_object_list with complex nested objects."""
+        rank = dist.get_rank()
+        root = 0
+
+        complex_obj = {
+            "nested": {"level1": {"level2": [1, 2, 3]}},
+            "tuple_as_list": [1, "two", 3.0],
+            "none_value": None,
+        }
+
+        if rank == root:
+            object_list = [complex_obj]
+        else:
+            object_list = [None]
+
+        dist.broadcast_object_list(object_list, src=root)
+
+        obj_0 = object_list[0]
+        if obj_0 is None:
+            raise AssertionError("obj_0 is None")
+        if not isinstance(obj_0, dict):
+            raise AssertionError(f"obj_0 is not a dict: {type(obj_0)}")
+        nested = obj_0["nested"]
+        if not isinstance(nested, dict):
+            raise AssertionError(f"nested is not a dict: {type(nested)}")
+        level1 = nested["level1"]
+        if not isinstance(level1, dict):
+            raise AssertionError(f"level1 is not a dict: {type(level1)}")
+        self.assertEqual(level1["level2"], [1, 2, 3])
+        self.assertEqual(obj_0["tuple_as_list"], [1, "two", 3.0])
+        self.assertIsNone(obj_0["none_value"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/comms/torchcomms/distwrap/tests/integration/ReduceScatterTest.py
+++ b/comms/torchcomms/distwrap/tests/integration/ReduceScatterTest.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+# pyre-unsafe
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""Integration tests for reduce_scatter and reduce_scatter_tensor collectives."""
+
+import unittest
+
+import torch
+from torchcomms import distwrap as dist
+from torchcomms.distwrap.tests.integration.test_helpers import (
+    get_backend,
+    get_device,
+    get_rank_and_size,
+    use_torchcomms,
+)
+
+
+class ReduceScatterTest(unittest.TestCase):
+    """Test class for reduce_scatter operations using distwrap."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Initialize distwrap once for all tests."""
+        rank, _ = get_rank_and_size()
+        device = get_device(rank)
+        backend = get_backend()
+
+        dist.init_process_group(
+            backend=backend,
+            use_torchcomms=use_torchcomms(),
+        )
+
+        if device.type == "cuda":
+            torch.cuda.set_device(device)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """Clean up distwrap after all tests."""
+        dist.destroy_process_group()
+
+    def test_sync_reduce_scatter(self) -> None:
+        """Test synchronous reduce_scatter with SUM."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+        device = get_device(rank)
+
+        input_list = [
+            torch.ones(1024, dtype=torch.float, device=device) * (rank + 1)
+            for _ in range(num_ranks)
+        ]
+        output_tensor = torch.zeros(1024, dtype=torch.float, device=device)
+
+        dist.reduce_scatter(
+            output_tensor, input_list, op=dist.ReduceOp.SUM, async_op=False
+        )
+
+        # Each rank gets the sum of all ranks' contribution for its chunk
+        expected = num_ranks * (num_ranks + 1) // 2
+        expected_tensor = torch.full_like(output_tensor.cpu(), expected)
+        torch.testing.assert_close(output_tensor.cpu(), expected_tensor)
+
+    def test_async_reduce_scatter(self) -> None:
+        """Test asynchronous reduce_scatter with SUM."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+        device = get_device(rank)
+
+        input_list = [
+            torch.ones(1024, dtype=torch.float, device=device) * (rank + 1)
+            for _ in range(num_ranks)
+        ]
+        output_tensor = torch.zeros(1024, dtype=torch.float, device=device)
+
+        work = dist.reduce_scatter(
+            output_tensor, input_list, op=dist.ReduceOp.SUM, async_op=True
+        )
+        if work is None:
+            raise AssertionError("work is None")
+        work.wait()
+
+        expected = num_ranks * (num_ranks + 1) // 2
+        expected_tensor = torch.full_like(output_tensor.cpu(), expected)
+        torch.testing.assert_close(output_tensor.cpu(), expected_tensor)
+
+    def test_sync_reduce_scatter_tensor(self) -> None:
+        """Test synchronous reduce_scatter_tensor with SUM."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+        device = get_device(rank)
+
+        input_tensor = torch.ones(
+            1024 * num_ranks, dtype=torch.float, device=device
+        ) * (rank + 1)
+        output_tensor = torch.zeros(1024, dtype=torch.float, device=device)
+
+        dist.reduce_scatter_tensor(
+            output_tensor, input_tensor, op=dist.ReduceOp.SUM, async_op=False
+        )
+
+        expected = num_ranks * (num_ranks + 1) // 2
+        expected_tensor = torch.full_like(output_tensor.cpu(), expected)
+        torch.testing.assert_close(output_tensor.cpu(), expected_tensor)
+
+    def test_async_reduce_scatter_tensor(self) -> None:
+        """Test asynchronous reduce_scatter_tensor with SUM."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+        device = get_device(rank)
+
+        input_tensor = torch.ones(
+            1024 * num_ranks, dtype=torch.float, device=device
+        ) * (rank + 1)
+        output_tensor = torch.zeros(1024, dtype=torch.float, device=device)
+
+        work = dist.reduce_scatter_tensor(
+            output_tensor, input_tensor, op=dist.ReduceOp.SUM, async_op=True
+        )
+        if work is None:
+            raise AssertionError("work is None")
+        work.wait()
+
+        expected = num_ranks * (num_ranks + 1) // 2
+        expected_tensor = torch.full_like(output_tensor.cpu(), expected)
+        torch.testing.assert_close(output_tensor.cpu(), expected_tensor)
+
+    def test_reduce_scatter_variable_sizes(self) -> None:
+        """Test reduce_scatter with variable-sized input tensors."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+        device = get_device(rank)
+
+        # Each input tensor has size (i + 1) * 256 for rank i's chunk
+        input_list = [
+            torch.ones((i + 1) * 256, dtype=torch.float, device=device) * (rank + 1)
+            for i in range(num_ranks)
+        ]
+
+        # Output tensor receives the chunk for this rank
+        output_size = (rank + 1) * 256
+        output_tensor = torch.zeros(output_size, dtype=torch.float, device=device)
+
+        dist.reduce_scatter(
+            output_tensor, input_list, op=dist.ReduceOp.SUM, async_op=False
+        )
+
+        # Each rank gets the sum of all ranks' contributions
+        expected = num_ranks * (num_ranks + 1) // 2
+        expected_tensor = torch.full_like(output_tensor.cpu(), expected)
+        torch.testing.assert_close(output_tensor.cpu(), expected_tensor)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/comms/torchcomms/distwrap/tests/integration/ReduceTest.py
+++ b/comms/torchcomms/distwrap/tests/integration/ReduceTest.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# pyre-unsafe
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""Integration tests for reduce collective."""
+
+import unittest
+
+import torch
+from torchcomms import distwrap as dist
+from torchcomms.distwrap.tests.integration.test_helpers import (
+    get_backend,
+    get_device,
+    get_rank_and_size,
+    use_torchcomms,
+)
+
+
+class ReduceTest(unittest.TestCase):
+    """Test class for reduce operations using distwrap."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Initialize distwrap once for all tests."""
+        rank, _ = get_rank_and_size()
+        device = get_device(rank)
+        backend = get_backend()
+
+        dist.init_process_group(
+            backend=backend,
+            use_torchcomms=use_torchcomms(),
+        )
+
+        if device.type == "cuda":
+            torch.cuda.set_device(device)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """Clean up distwrap after all tests."""
+        dist.destroy_process_group()
+
+    def test_sync_reduce(self) -> None:
+        """Test synchronous reduce to rank 0 with SUM."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+        device = get_device(rank)
+
+        input_tensor = torch.ones(1024, dtype=torch.float, device=device) * (rank + 1)
+
+        dist.reduce(input_tensor, dst=0, op=dist.ReduceOp.SUM, async_op=False)
+
+        if rank == 0:
+            expected = num_ranks * (num_ranks + 1) // 2
+            expected_tensor = torch.full_like(input_tensor.cpu(), expected)
+            torch.testing.assert_close(input_tensor.cpu(), expected_tensor)
+
+    def test_async_reduce(self) -> None:
+        """Test asynchronous reduce to rank 0 with SUM."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+        device = get_device(rank)
+
+        input_tensor = torch.ones(1024, dtype=torch.float, device=device) * (rank + 1)
+
+        work = dist.reduce(input_tensor, dst=0, op=dist.ReduceOp.SUM, async_op=True)
+        if work is None:
+            raise AssertionError("work is None")
+        work.wait()
+
+        if rank == 0:
+            expected = num_ranks * (num_ranks + 1) // 2
+            expected_tensor = torch.full_like(input_tensor.cpu(), expected)
+            torch.testing.assert_close(input_tensor.cpu(), expected_tensor)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/comms/torchcomms/distwrap/tests/integration/ScatterGatherTest.py
+++ b/comms/torchcomms/distwrap/tests/integration/ScatterGatherTest.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# pyre-unsafe
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""Integration tests for scatter and gather collectives."""
+
+import unittest
+
+import torch
+from torchcomms import distwrap as dist
+from torchcomms.distwrap.tests.integration.test_helpers import (
+    get_backend,
+    get_device,
+    get_rank_and_size,
+    use_torchcomms,
+)
+
+
+class ScatterGatherTest(unittest.TestCase):
+    """Test class for scatter and gather operations using distwrap."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Initialize distwrap once for all tests."""
+        rank, _ = get_rank_and_size()
+        device = get_device(rank)
+        backend = get_backend()
+
+        dist.init_process_group(
+            backend=backend,
+            use_torchcomms=use_torchcomms(),
+        )
+
+        if device.type == "cuda":
+            torch.cuda.set_device(device)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """Clean up distwrap after all tests."""
+        dist.destroy_process_group()
+
+    def test_sync_scatter(self) -> None:
+        """Test synchronous scatter from rank 0."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+        device = get_device(rank)
+
+        output_tensor = torch.zeros(1024, dtype=torch.float, device=device)
+
+        if rank == 0:
+            scatter_list = [
+                torch.ones(1024, dtype=torch.float, device=device) * (i + 1)
+                for i in range(num_ranks)
+            ]
+        else:
+            scatter_list = None
+
+        dist.scatter(output_tensor, scatter_list, src=0, async_op=False)
+
+        expected = torch.full_like(output_tensor.cpu(), rank + 1)
+        torch.testing.assert_close(output_tensor.cpu(), expected)
+
+    def test_async_scatter(self) -> None:
+        """Test asynchronous scatter from rank 0."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+        device = get_device(rank)
+
+        output_tensor = torch.zeros(1024, dtype=torch.float, device=device)
+
+        if rank == 0:
+            scatter_list = [
+                torch.ones(1024, dtype=torch.float, device=device) * (i + 1)
+                for i in range(num_ranks)
+            ]
+        else:
+            scatter_list = None
+
+        work = dist.scatter(output_tensor, scatter_list, src=0, async_op=True)
+        if work is None:
+            raise AssertionError("work is None")
+        work.wait()
+
+        expected = torch.full_like(output_tensor.cpu(), rank + 1)
+        torch.testing.assert_close(output_tensor.cpu(), expected)
+
+    def test_sync_gather(self) -> None:
+        """Test synchronous gather to rank 0."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+        device = get_device(rank)
+
+        input_tensor = torch.ones(1024, dtype=torch.float, device=device) * (rank + 1)
+
+        if rank == 0:
+            gather_list = [
+                torch.zeros(1024, dtype=torch.float, device=device)
+                for _ in range(num_ranks)
+            ]
+        else:
+            gather_list = None
+
+        dist.gather(input_tensor, gather_list, dst=0, async_op=False)
+
+        if rank == 0:
+            if gather_list is None:
+                raise AssertionError("gather_list is None")
+            for i, gathered in enumerate(gather_list):
+                expected = torch.full_like(gathered.cpu(), i + 1)
+                torch.testing.assert_close(gathered.cpu(), expected)
+
+    def test_async_gather(self) -> None:
+        """Test asynchronous gather to rank 0."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+        device = get_device(rank)
+
+        input_tensor = torch.ones(1024, dtype=torch.float, device=device) * (rank + 1)
+
+        if rank == 0:
+            gather_list = [
+                torch.zeros(1024, dtype=torch.float, device=device)
+                for _ in range(num_ranks)
+            ]
+        else:
+            gather_list = None
+
+        work = dist.gather(input_tensor, gather_list, dst=0, async_op=True)
+        if work is None:
+            raise AssertionError("work is None")
+        work.wait()
+
+        if rank == 0:
+            if gather_list is None:
+                raise AssertionError("gather_list is None")
+            for i, gathered in enumerate(gather_list):
+                expected = torch.full_like(gathered.cpu(), i + 1)
+                torch.testing.assert_close(gathered.cpu(), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/comms/torchcomms/distwrap/tests/integration/SendRecvTest.py
+++ b/comms/torchcomms/distwrap/tests/integration/SendRecvTest.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+# pyre-unsafe
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""Integration tests for send, recv, isend, and irecv point-to-point operations."""
+
+import unittest
+
+import torch
+from torchcomms import distwrap as dist
+from torchcomms.distwrap.tests.integration.test_helpers import (
+    get_backend,
+    get_device,
+    get_rank_and_size,
+    use_torchcomms,
+)
+
+
+class SendRecvTest(unittest.TestCase):
+    """Test class for send/recv operations using distwrap."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Initialize distwrap once for all tests."""
+        rank, _ = get_rank_and_size()
+        device = get_device(rank)
+        backend = get_backend()
+
+        dist.init_process_group(
+            backend=backend,
+            use_torchcomms=use_torchcomms(),
+        )
+
+        if device.type == "cuda":
+            torch.cuda.set_device(device)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """Clean up distwrap after all tests."""
+        dist.destroy_process_group()
+
+    def test_send_recv(self) -> None:
+        """Test synchronous send and recv between rank 0 and rank 1."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+        device = get_device(rank)
+
+        if num_ranks < 2:
+            self.skipTest("Need at least 2 ranks for send/recv test")
+
+        if rank == 0:
+            tensor = torch.ones(1024, dtype=torch.float, device=device) * 42
+            dist.send(tensor, dst=1)
+        elif rank == 1:
+            tensor = torch.zeros(1024, dtype=torch.float, device=device)
+            dist.recv(tensor, src=0)
+            expected = torch.full_like(tensor.cpu(), 42)
+            torch.testing.assert_close(tensor.cpu(), expected)
+
+    def test_isend_irecv(self) -> None:
+        """Test asynchronous isend and irecv between rank 0 and rank 1."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+        device = get_device(rank)
+
+        if num_ranks < 2:
+            self.skipTest("Need at least 2 ranks for isend/irecv test")
+
+        if rank == 0:
+            tensor = torch.ones(1024, dtype=torch.float, device=device) * 99
+            work = dist.isend(tensor, dst=1)
+            work.wait()
+        elif rank == 1:
+            tensor = torch.zeros(1024, dtype=torch.float, device=device)
+            work = dist.irecv(tensor, src=0)
+            work.wait()
+            expected = torch.full_like(tensor.cpu(), 99)
+            torch.testing.assert_close(tensor.cpu(), expected)
+
+    def test_bidirectional_send_recv(self) -> None:
+        """Test bidirectional send/recv between rank 0 and rank 1."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+        device = get_device(rank)
+
+        if num_ranks < 2:
+            self.skipTest("Need at least 2 ranks for bidirectional test")
+
+        if rank == 0:
+            send_tensor = torch.ones(1024, dtype=torch.float, device=device) * 10
+            recv_tensor = torch.zeros(1024, dtype=torch.float, device=device)
+
+            send_work = dist.isend(send_tensor, dst=1)
+            recv_work = dist.irecv(recv_tensor, src=1)
+
+            send_work.wait()
+            recv_work.wait()
+
+            expected = torch.full_like(recv_tensor.cpu(), 20)
+            torch.testing.assert_close(recv_tensor.cpu(), expected)
+
+        elif rank == 1:
+            send_tensor = torch.ones(1024, dtype=torch.float, device=device) * 20
+            recv_tensor = torch.zeros(1024, dtype=torch.float, device=device)
+
+            recv_work = dist.irecv(recv_tensor, src=0)
+            send_work = dist.isend(send_tensor, dst=0)
+
+            recv_work.wait()
+            send_work.wait()
+
+            expected = torch.full_like(recv_tensor.cpu(), 10)
+            torch.testing.assert_close(recv_tensor.cpu(), expected)
+
+    def test_batch_isend_irecv(self) -> None:
+        """Test batch_isend_irecv for batched point-to-point operations."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+        device = get_device(rank)
+
+        if num_ranks < 2:
+            self.skipTest("Need at least 2 ranks for batch_isend_irecv test")
+
+        if rank == 0:
+            send_tensor = torch.ones(1024, dtype=torch.float, device=device) * 77
+            recv_tensor = torch.zeros(1024, dtype=torch.float, device=device)
+
+            p2p_ops = [
+                dist.P2POp(dist.isend, send_tensor, peer=1),
+                dist.P2POp(dist.irecv, recv_tensor, peer=1),
+            ]
+
+            works = dist.batch_isend_irecv(p2p_ops)
+            for work in works:
+                work.wait()
+
+            expected = torch.full_like(recv_tensor.cpu(), 88)
+            torch.testing.assert_close(recv_tensor.cpu(), expected)
+
+        elif rank == 1:
+            send_tensor = torch.ones(1024, dtype=torch.float, device=device) * 88
+            recv_tensor = torch.zeros(1024, dtype=torch.float, device=device)
+
+            p2p_ops = [
+                dist.P2POp(dist.irecv, recv_tensor, peer=0),
+                dist.P2POp(dist.isend, send_tensor, peer=0),
+            ]
+
+            works = dist.batch_isend_irecv(p2p_ops)
+            for work in works:
+                work.wait()
+
+            expected = torch.full_like(recv_tensor.cpu(), 77)
+            torch.testing.assert_close(recv_tensor.cpu(), expected)
+
+    def test_batch_isend_irecv_multiple_ops(self) -> None:
+        """Test batch_isend_irecv with multiple send/recv operations."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+        device = get_device(rank)
+
+        if num_ranks < 2:
+            self.skipTest("Need at least 2 ranks for batch_isend_irecv test")
+
+        if rank == 0:
+            send_tensor1 = torch.ones(512, dtype=torch.float, device=device) * 11
+            send_tensor2 = torch.ones(512, dtype=torch.float, device=device) * 22
+            recv_tensor1 = torch.zeros(512, dtype=torch.float, device=device)
+            recv_tensor2 = torch.zeros(512, dtype=torch.float, device=device)
+
+            p2p_ops = [
+                dist.P2POp(dist.isend, send_tensor1, peer=1),
+                dist.P2POp(dist.isend, send_tensor2, peer=1),
+                dist.P2POp(dist.irecv, recv_tensor1, peer=1),
+                dist.P2POp(dist.irecv, recv_tensor2, peer=1),
+            ]
+
+            works = dist.batch_isend_irecv(p2p_ops)
+            for work in works:
+                work.wait()
+
+            expected1 = torch.full_like(recv_tensor1.cpu(), 33)
+            expected2 = torch.full_like(recv_tensor2.cpu(), 44)
+            torch.testing.assert_close(recv_tensor1.cpu(), expected1)
+            torch.testing.assert_close(recv_tensor2.cpu(), expected2)
+
+        elif rank == 1:
+            send_tensor1 = torch.ones(512, dtype=torch.float, device=device) * 33
+            send_tensor2 = torch.ones(512, dtype=torch.float, device=device) * 44
+            recv_tensor1 = torch.zeros(512, dtype=torch.float, device=device)
+            recv_tensor2 = torch.zeros(512, dtype=torch.float, device=device)
+
+            p2p_ops = [
+                dist.P2POp(dist.irecv, recv_tensor1, peer=0),
+                dist.P2POp(dist.irecv, recv_tensor2, peer=0),
+                dist.P2POp(dist.isend, send_tensor1, peer=0),
+                dist.P2POp(dist.isend, send_tensor2, peer=0),
+            ]
+
+            works = dist.batch_isend_irecv(p2p_ops)
+            for work in works:
+                work.wait()
+
+            expected1 = torch.full_like(recv_tensor1.cpu(), 11)
+            expected2 = torch.full_like(recv_tensor2.cpu(), 22)
+            torch.testing.assert_close(recv_tensor1.cpu(), expected1)
+            torch.testing.assert_close(recv_tensor2.cpu(), expected2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/comms/torchcomms/distwrap/tests/integration/SplitGroupTest.py
+++ b/comms/torchcomms/distwrap/tests/integration/SplitGroupTest.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+# pyre-unsafe
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""Integration tests for split_group.
+
+Tests various parameter combinations for split_group:
+- split_ranks with single group, individual groups
+- Collectives on split groups
+- Explicit backend parameter
+- Timeout parameter
+- Group description parameter
+- Explicit parent group parameter
+"""
+
+import unittest
+
+import torch
+from torchcomms import distwrap as dist
+from torchcomms.distwrap.tests.integration.test_helpers import (
+    get_backend,
+    get_device,
+    get_pg_options,
+    get_rank_and_size,
+    use_torchcomms,
+)
+
+
+class SplitGroupTest(unittest.TestCase):
+    """Test class for split_group operations using distwrap."""
+
+    def setUp(self) -> None:
+        """Initialize distwrap before each test."""
+        rank, size = get_rank_and_size()
+        device = get_device(rank)
+        backend = get_backend()
+
+        dist.init_process_group(
+            backend=backend,
+            use_torchcomms=use_torchcomms(),
+        )
+
+        if device.type == "cuda":
+            torch.cuda.set_device(device)
+
+    def tearDown(self) -> None:
+        """Clean up distwrap after each test."""
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+    def _verify_collective(self, pg: dist.ProcessGroup) -> None:
+        """Verify the process group works with a basic all_reduce."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size(pg)
+        device = get_device(rank)
+
+        input_tensor = torch.ones(1024, dtype=torch.float, device=device) * (rank + 1)
+        dist.all_reduce(input_tensor, dist.ReduceOp.SUM, group=pg, async_op=False)
+
+        expected = num_ranks * (num_ranks + 1) // 2
+        expected_tensor = torch.full_like(input_tensor.cpu(), expected)
+        torch.testing.assert_close(input_tensor.cpu(), expected_tensor)
+
+    def test_split_group_single_group(self) -> None:
+        """Test split_group with all ranks in one group."""
+        num_ranks = dist.get_world_size()
+        all_ranks = list(range(num_ranks))
+
+        new_pg = dist.split_group(split_ranks=[all_ranks])
+
+        self.assertIsNotNone(new_pg)
+        self.assertEqual(
+            dist.get_world_size(new_pg),
+            num_ranks,
+        )
+
+        self._verify_collective(new_pg)
+
+        dist.destroy_process_group(new_pg)
+
+    def test_split_group_individual_groups(self) -> None:
+        """Test split_group with each rank in its own group."""
+        num_ranks = dist.get_world_size()
+        split_ranks = [[i] for i in range(num_ranks)]
+
+        new_pg = dist.split_group(split_ranks=split_ranks)
+
+        self.assertIsNotNone(new_pg)
+        self.assertEqual(dist.get_world_size(new_pg), 1)
+
+        # Can't do allreduce with group size 1, just verify it was created
+        # self._verify_collective(new_pg)
+
+        dist.destroy_process_group(new_pg)
+
+    def test_split_group_collective(self) -> None:
+        """Test that collectives work on split groups."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+        device = get_device(rank)
+
+        # Create a single group with all ranks
+        all_ranks = list(range(num_ranks))
+        new_pg = dist.split_group(split_ranks=[all_ranks])
+
+        # Test all_reduce on the new group
+        input_tensor = torch.ones(1024, dtype=torch.float, device=device) * (rank + 1)
+        dist.all_reduce(input_tensor, dist.ReduceOp.SUM, group=new_pg, async_op=False)
+
+        expected = num_ranks * (num_ranks + 1) // 2
+        expected_tensor = torch.full_like(input_tensor.cpu(), expected)
+        torch.testing.assert_close(input_tensor.cpu(), expected_tensor)
+
+        dist.destroy_process_group(new_pg)
+
+    def test_split_group_with_backend(self) -> None:
+        """Test split_group with explicit backend parameter."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+        device = get_device(rank)
+
+        # Create a single group with all ranks and explicit backend
+        all_ranks = list(range(num_ranks))
+        backend = get_backend()
+        new_pg = dist.split_group(split_ranks=[all_ranks], backend=backend)
+
+        self.assertIsNotNone(new_pg)
+        self.assertEqual(
+            dist.get_world_size(new_pg),
+            num_ranks,
+        )
+
+        # Test all_reduce on the new group with explicit backend
+        input_tensor = torch.ones(1024, dtype=torch.float, device=device) * (rank + 1)
+        dist.all_reduce(input_tensor, dist.ReduceOp.SUM, group=new_pg, async_op=False)
+
+        expected = num_ranks * (num_ranks + 1) // 2
+        expected_tensor = torch.full_like(input_tensor.cpu(), expected)
+        torch.testing.assert_close(input_tensor.cpu(), expected_tensor)
+
+        dist.destroy_process_group(new_pg)
+
+    def test_split_group_with_timeout(self) -> None:
+        """Test split_group with explicit timeout parameter."""
+        from datetime import timedelta
+
+        num_ranks = dist.get_world_size()
+        all_ranks = list(range(num_ranks))
+
+        new_pg = dist.split_group(
+            split_ranks=[all_ranks],
+            timeout=timedelta(seconds=60),
+        )
+
+        self.assertIsNotNone(new_pg)
+        self.assertEqual(
+            dist.get_world_size(new_pg),
+            num_ranks,
+        )
+
+        self._verify_collective(new_pg)
+
+        dist.destroy_process_group(new_pg)
+
+    def test_split_group_with_group_desc(self) -> None:
+        """Test split_group with group_desc parameter."""
+        num_ranks = dist.get_world_size()
+        all_ranks = list(range(num_ranks))
+
+        new_pg = dist.split_group(
+            split_ranks=[all_ranks],
+            group_desc="test_split_group",
+        )
+
+        self.assertIsNotNone(new_pg)
+        self.assertEqual(
+            dist.get_world_size(new_pg),
+            num_ranks,
+        )
+
+        self._verify_collective(new_pg)
+
+        dist.destroy_process_group(new_pg)
+
+    def test_split_group_with_parent_group(self) -> None:
+        """Test split_group with explicit parent group parameter."""
+        num_ranks = dist.get_world_size()
+        all_ranks = list(range(num_ranks))
+
+        # First create a split group from WORLD
+        parent_pg = dist.split_group(split_ranks=[all_ranks])
+
+        # Then split from that parent group
+        new_pg = dist.split_group(
+            group=parent_pg,
+            split_ranks=[all_ranks],
+        )
+
+        self.assertIsNotNone(new_pg)
+        self.assertEqual(
+            dist.get_world_size(new_pg),
+            num_ranks,
+        )
+
+        self._verify_collective(new_pg)
+
+        # Destroy child group first, then parent
+        dist.destroy_process_group(new_pg)
+        dist.destroy_process_group(parent_pg)
+
+    def test_split_group_with_pg_options(self) -> None:
+        """Test split_group with pg_options parameter."""
+        num_ranks = dist.get_world_size()
+        all_ranks = list(range(num_ranks))
+
+        backend = get_backend()
+        pg_options = get_pg_options(backend)
+        if pg_options is None:
+            self.skipTest(f"pg_options test not supported for backend {backend}")
+
+        new_pg = dist.split_group(
+            split_ranks=[all_ranks],
+            pg_options=pg_options,
+        )
+
+        self.assertIsNotNone(new_pg)
+        self.assertEqual(
+            dist.get_world_size(new_pg),
+            num_ranks,
+        )
+
+        self._verify_collective(new_pg)
+
+        dist.destroy_process_group(new_pg)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/comms/torchcomms/distwrap/tests/integration/test_helpers.py
+++ b/comms/torchcomms/distwrap/tests/integration/test_helpers.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# pyre-unsafe
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import os
+from typing import Tuple
+
+import torch
+from torchcomms import distwrap as dist
+
+
+def get_dtype_name(dtype: torch.dtype) -> str:
+    """Helper function to get a string representation of the datatype."""
+    dtype_names = {
+        torch.half: "Half",
+        torch.float: "Float",
+        torch.bfloat16: "BFloat16",
+        torch.double: "Double",
+        torch.int: "Int",
+        torch.int8: "SignedChar",
+    }
+    return dtype_names.get(dtype, "Unknown")
+
+
+def get_op_name(op: dist.ReduceOp) -> str:
+    """Helper function to get a string representation of the reduction operation."""
+    op_names = {
+        dist.ReduceOp.SUM: "Sum",
+        dist.ReduceOp.PRODUCT: "Product",
+        dist.ReduceOp.MIN: "Min",
+        dist.ReduceOp.MAX: "Max",
+        dist.ReduceOp.BAND: "BAnd",
+        dist.ReduceOp.BOR: "BOr",
+        dist.ReduceOp.BXOR: "BXor",
+        dist.ReduceOp.AVG: "Avg",
+    }
+    return op_names.get(op, f"Unknown: {op}")
+
+
+def get_rank_and_size() -> Tuple[int, int]:
+    """
+    Get rank and world size from environment variables.
+    Returns (rank, size) tuple.
+    """
+    env_pairs = [
+        ("OMPI_COMM_WORLD_RANK", "OMPI_COMM_WORLD_SIZE"),
+        ("RANK", "WORLD_SIZE"),
+        ("SLURM_PROCID", "SLURM_NTASKS"),
+        ("PMI_RANK", "PMI_SIZE"),
+    ]
+
+    for rank_var, size_var in env_pairs:
+        rank = os.environ.get(rank_var)
+        size = os.environ.get(size_var)
+        if rank is not None and size is not None:
+            return int(rank), int(size)
+
+    raise RuntimeError(
+        "Could not determine rank or world size from environment variables."
+    )
+
+
+def get_device(rank: int) -> torch.device:
+    """Get the device to use for the test."""
+    if device_str := os.environ.get("TEST_DEVICE"):
+        return torch.device(device_str)
+
+    if torch.cuda.is_available():
+        device_count = torch.cuda.device_count()
+        if device_count > 0:
+            device_id = rank % device_count
+            return torch.device(f"cuda:{device_id}")
+
+    return torch.device("cpu")
+
+
+def get_backend() -> str:
+    """Get the backend from environment variable."""
+    backend = os.getenv("TEST_BACKEND")
+    if backend is None:
+        raise RuntimeError("TEST_BACKEND environment variable is not set")
+    return backend
+
+
+def use_torchcomms() -> bool:
+    """Check if torchcomms should be used from environment variable."""
+    value = os.getenv("USE_TORCHCOMMS")
+    if value is None:
+        raise RuntimeError("USE_TORCHCOMMS environment variable is not set")
+    return value == "1"
+
+
+def get_pg_options(backend: str) -> object | None:
+    """
+    Get the appropriate ProcessGroup options for the given backend.
+
+    Returns the backend-specific options object, or None if the backend
+    doesn't have a supported options class.
+    """
+    if backend in ["nccl", "ncclx"]:
+        # pyre-ignore[16]: ProcessGroupNCCL not in Pyre stubs
+        return dist.ProcessGroupNCCL.Options()
+    elif backend in ["gloo"]:
+        # pyre-ignore[16]: ProcessGroupGloo not in Pyre stubs
+        return dist.ProcessGroupGloo._Options()
+    else:
+        return None

--- a/comms/torchcomms/distwrap/tests/unit/test_distwrap.py
+++ b/comms/torchcomms/distwrap/tests/unit/test_distwrap.py
@@ -1,0 +1,175 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# pyre-strict
+
+import unittest
+
+import torch.distributed
+import torchcomms.distwrap
+
+
+class ForwardedAttributesTest(unittest.TestCase):
+    """Tests for attributes forwarded from torch.distributed."""
+
+    def test_get_rank_is_forwarded(self) -> None:
+        self.assertIs(torchcomms.distwrap.get_rank, torch.distributed.get_rank)
+
+    def test_get_world_size_is_forwarded(self) -> None:
+        self.assertIs(
+            torchcomms.distwrap.get_world_size, torch.distributed.get_world_size
+        )
+
+    def test_is_initialized_is_forwarded(self) -> None:
+        self.assertIs(
+            torchcomms.distwrap.is_initialized, torch.distributed.is_initialized
+        )
+
+    def test_is_available_is_forwarded(self) -> None:
+        self.assertIs(torchcomms.distwrap.is_available, torch.distributed.is_available)
+
+    def test_get_process_group_ranks_is_forwarded(self) -> None:
+        self.assertIs(
+            torchcomms.distwrap.get_process_group_ranks,
+            torch.distributed.get_process_group_ranks,
+        )
+
+    def test_ProcessGroup_is_forwarded(self) -> None:
+        self.assertIs(torchcomms.distwrap.ProcessGroup, torch.distributed.ProcessGroup)
+
+    def test_GroupMember_is_forwarded(self) -> None:
+        self.assertIs(torchcomms.distwrap.GroupMember, torch.distributed.GroupMember)
+
+    def test_ReduceOp_is_forwarded(self) -> None:
+        self.assertIs(torchcomms.distwrap.ReduceOp, torch.distributed.ReduceOp)
+
+    def test_P2POp_is_exported(self) -> None:
+        # P2POp is a custom wrapper class, not a direct forwarding from torch.distributed
+        self.assertTrue(callable(torchcomms.distwrap.P2POp))
+
+    def test_group_is_forwarded(self) -> None:
+        self.assertIs(torchcomms.distwrap.group, torch.distributed.group)
+
+    def test_Store_is_forwarded(self) -> None:
+        self.assertIs(torchcomms.distwrap.Store, torch.distributed.Store)
+
+    def test_HashStore_is_forwarded(self) -> None:
+        self.assertIs(torchcomms.distwrap.HashStore, torch.distributed.HashStore)
+
+    def test_Work_is_forwarded(self) -> None:
+        self.assertIs(torchcomms.distwrap.Work, torch.distributed.Work)
+
+    def test_unknown_attribute_raises_attribute_error(self) -> None:
+        with self.assertRaises(AttributeError) as context:
+            # pyre-ignore[16]: Intentionally accessing nonexistent attribute
+            _ = torchcomms.distwrap.nonexistent_attribute
+
+        self.assertIn("has no attribute", str(context.exception))
+        self.assertIn("nonexistent_attribute", str(context.exception))
+
+
+class ExportedFunctionsTest(unittest.TestCase):
+    """Tests that all expected functions are exported and callable."""
+
+    def test_destroy_process_group_is_exported(self) -> None:
+        self.assertTrue(callable(torchcomms.distwrap.destroy_process_group))
+
+    def test_init_process_group_is_exported(self) -> None:
+        self.assertTrue(callable(torchcomms.distwrap.init_process_group))
+
+    def test_new_group_is_exported(self) -> None:
+        self.assertTrue(callable(torchcomms.distwrap.new_group))
+
+    def test_split_group_is_exported(self) -> None:
+        self.assertTrue(callable(torchcomms.distwrap.split_group))
+
+    def test_all_reduce_is_exported(self) -> None:
+        self.assertTrue(callable(torchcomms.distwrap.all_reduce))
+
+    def test_broadcast_is_exported(self) -> None:
+        self.assertTrue(callable(torchcomms.distwrap.broadcast))
+
+    def test_reduce_is_exported(self) -> None:
+        self.assertTrue(callable(torchcomms.distwrap.reduce))
+
+    def test_all_gather_is_exported(self) -> None:
+        self.assertTrue(callable(torchcomms.distwrap.all_gather))
+
+    def test_all_gather_into_tensor_is_exported(self) -> None:
+        self.assertTrue(callable(torchcomms.distwrap.all_gather_into_tensor))
+
+    def test_reduce_scatter_is_exported(self) -> None:
+        self.assertTrue(callable(torchcomms.distwrap.reduce_scatter))
+
+    def test_reduce_scatter_tensor_is_exported(self) -> None:
+        self.assertTrue(callable(torchcomms.distwrap.reduce_scatter_tensor))
+
+    def test_all_to_all_is_exported(self) -> None:
+        self.assertTrue(callable(torchcomms.distwrap.all_to_all))
+
+    def test_all_to_all_single_is_exported(self) -> None:
+        self.assertTrue(callable(torchcomms.distwrap.all_to_all_single))
+
+    def test_scatter_is_exported(self) -> None:
+        self.assertTrue(callable(torchcomms.distwrap.scatter))
+
+    def test_gather_is_exported(self) -> None:
+        self.assertTrue(callable(torchcomms.distwrap.gather))
+
+    def test_barrier_is_exported(self) -> None:
+        self.assertTrue(callable(torchcomms.distwrap.barrier))
+
+    def test_send_is_exported(self) -> None:
+        self.assertTrue(callable(torchcomms.distwrap.send))
+
+    def test_recv_is_exported(self) -> None:
+        self.assertTrue(callable(torchcomms.distwrap.recv))
+
+    def test_isend_is_exported(self) -> None:
+        self.assertTrue(callable(torchcomms.distwrap.isend))
+
+    def test_irecv_is_exported(self) -> None:
+        self.assertTrue(callable(torchcomms.distwrap.irecv))
+
+    def test_batch_isend_irecv_is_exported(self) -> None:
+        self.assertTrue(callable(torchcomms.distwrap.batch_isend_irecv))
+
+    def test_all_gather_object_is_exported(self) -> None:
+        self.assertTrue(callable(torchcomms.distwrap.all_gather_object))
+
+    def test_gather_object_is_exported(self) -> None:
+        self.assertTrue(callable(torchcomms.distwrap.gather_object))
+
+    def test_scatter_object_list_is_exported(self) -> None:
+        self.assertTrue(callable(torchcomms.distwrap.scatter_object_list))
+
+    def test_broadcast_object_list_is_exported(self) -> None:
+        self.assertTrue(callable(torchcomms.distwrap.broadcast_object_list))
+
+    def test_new_window_is_exported(self) -> None:
+        self.assertTrue(callable(torchcomms.distwrap.new_window))
+
+    def test_alltoallv_dedup_init_is_exported(self) -> None:
+        self.assertTrue(callable(torchcomms.distwrap.alltoallv_dedup_init))
+
+    def test_alltoallv_dedup_exec_is_exported(self) -> None:
+        self.assertTrue(callable(torchcomms.distwrap.alltoallv_dedup_exec))
+
+    def test_alltoallv_dynamic_dispatch_is_exported(self) -> None:
+        self.assertTrue(callable(torchcomms.distwrap.alltoallv_dynamic_dispatch))
+
+    def test_alltoallv_dynamic_combine_is_exported(self) -> None:
+        self.assertTrue(callable(torchcomms.distwrap.alltoallv_dynamic_combine))
+
+
+class AllExportsTest(unittest.TestCase):
+    """Tests that __all__ matches actual exports."""
+
+    def test_all_exports_are_accessible(self) -> None:
+        for name in torchcomms.distwrap.__all__:
+            self.assertTrue(
+                hasattr(torchcomms.distwrap, name),
+                f"'{name}' in __all__ but not accessible",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/comms/torchcomms/distwrap/utils.py
+++ b/comms/torchcomms/distwrap/utils.py
@@ -1,0 +1,432 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# pyre-strict
+
+import os
+from typing import Any
+
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
+from torchcomms._comms import TorchComm
+from torchcomms.distwrap.pginfo import pg_info_get_data, pg_info_set_data
+
+
+# =============================================================================
+# Public API Functions
+# =============================================================================
+
+
+def set_torchcomms_enabled(enabled: bool) -> None:
+    """Set whether torchcomms is enabled."""
+    global _use_torchcomms
+    _use_torchcomms = enabled
+
+
+def torchcomms_is_enabled() -> bool:
+    """Check if torchcomms is enabled."""
+    return _use_torchcomms
+
+
+def set_eager_init_enabled(enabled: bool) -> None:
+    """Set whether eager init is enabled (device_id was passed to init_process_group)."""
+    global _eager_init_enabled
+    _eager_init_enabled = enabled
+
+
+def eager_init_is_enabled() -> bool:
+    """Check if eager init is enabled."""
+    return _eager_init_enabled
+
+
+def parse_backend_string(backend: str) -> dict[str, str]:
+    """
+    Parse a backend string into its components.
+
+    The backend string can be:
+    - Simple form: "nccl", "gloo", "ncclx", "rccl", "rcclx", "hccl"
+    - Merged form: "cpu:gloo,gpu:nccl"
+
+    Known backends and their default device types:
+    - nccl -> cuda
+    - ncclx -> cuda
+    - gloo -> cpu
+    - hccl -> mtia
+
+    Args:
+        backend: Backend string
+
+    Returns:
+        device_backends: Dict mapping device type ("cpu"/"gpu"/"mtia") to backend
+    """
+    device_backends = {}
+
+    # Check if it's a merged form like "cpu:gloo,gpu:nccl"
+    if ":" in backend:
+        # Parse the merged form
+        parts = backend.split(",")
+        for part in parts:
+            split_result = part.split(":")
+            if len(split_result) != 2:
+                raise ValueError(
+                    f"Invalid backend format: '{part}'. Each part in merged form "
+                    f"must have exactly one colon (e.g., 'cpu:gloo,gpu:nccl'), "
+                    f"got {len(split_result) - 1} colons."
+                )
+            device_type, be = split_result
+            device_type = device_type.strip()
+            be = be.strip()
+            device_backends[device_type] = be
+    else:
+        # Simple form: just the backend name
+        # Use known default device type, or raise error for unknown backends
+        if backend not in _BACKEND_DEFAULT_DEVICES:
+            raise ValueError(
+                f"Unknown backend: '{backend}'. Known backends are: "
+                f"{', '.join(sorted(_BACKEND_DEFAULT_DEVICES.keys()))}"
+            )
+        default_device = _BACKEND_DEFAULT_DEVICES[backend]
+        device_backends[default_device] = backend
+
+    return device_backends
+
+
+def format_backend_string(device_backends: dict[str, str]) -> str:
+    """
+    Convert a device_backends dictionary to a backend string.
+
+    This is the inverse of parse_backend_string.
+
+    Args:
+        device_backends: Dict mapping device type to backend name
+            (e.g., {"cpu": "gloo"} or {"cpu": "gloo", "cuda": "nccl"})
+
+    Returns:
+        Backend string (e.g., "cpu:gloo" or "cpu:gloo,cuda:nccl")
+    """
+    return ",".join(f"{device}:{be}" for device, be in device_backends.items())
+
+
+def get_rank_and_world_size(rank: int, world_size: int) -> tuple[int, int]:
+    """
+    Resolve rank and world_size from parameters or environment variables.
+
+    If rank or world_size is -1, attempt to derive from environment variables.
+    Checks multiple environment variable pairs in order:
+    - OMPI_COMM_WORLD_RANK / OMPI_COMM_WORLD_SIZE (MPI)
+    - RANK / WORLD_SIZE (torchrun)
+    - SLURM_PROCID / SLURM_NTASKS (SLURM)
+    - PMI_RANK / PMI_SIZE (PMI)
+
+    Args:
+        rank: Rank parameter (-1 means derive from environment)
+        world_size: World size parameter (-1 means derive from environment)
+
+    Returns:
+        Tuple of (rank, world_size)
+
+    Raises:
+        AssertionError: If rank or world_size cannot be determined
+    """
+    env_pairs = [
+        ("OMPI_COMM_WORLD_RANK", "OMPI_COMM_WORLD_SIZE"),
+        ("RANK", "WORLD_SIZE"),
+        ("SLURM_PROCID", "SLURM_NTASKS"),
+        ("PMI_RANK", "PMI_SIZE"),
+    ]
+
+    # If rank is not set, derive it from environment
+    if rank == -1:
+        for rank_var, _ in env_pairs:
+            if rank_var in os.environ:
+                rank = int(os.environ[rank_var])
+                break
+
+    # If world_size is not set, derive it from environment
+    if world_size == -1:
+        for _, size_var in env_pairs:
+            if size_var in os.environ:
+                world_size = int(os.environ[size_var])
+                break
+
+    # Ensure rank and world_size are set
+    if rank == -1:
+        raise AssertionError(
+            "rank must be specified either as a parameter or via environment "
+            "variables (RANK, OMPI_COMM_WORLD_RANK, SLURM_PROCID, or PMI_RANK)"
+        )
+    if world_size == -1:
+        raise AssertionError(
+            "world_size must be specified either as a parameter or via environment "
+            "variables (WORLD_SIZE, OMPI_COMM_WORLD_SIZE, SLURM_NTASKS, or PMI_SIZE)"
+        )
+
+    return rank, world_size
+
+
+def torchcomms_create_split_group(
+    pg: ProcessGroup,
+    parent_pg: ProcessGroup,
+    split_ranks: list[list[int]],
+    group_desc: str,
+    pg_options: dict[str, Any] | None,
+    device_backends: dict[str, str],
+) -> None:
+    """
+    Create torchcomms instances for a split process group.
+
+    Splits the torchcomms instances from the parent process group to create
+    new instances for the given process group.
+
+    Args:
+        pg: The new process group to create torchcomms instances for.
+        parent_pg: The parent process group to split from.
+        split_ranks: List of lists of ranks defining the split.
+        group_desc: Description for the new process group.
+        pg_options: Dictionary of options to pass to torchcomms.
+        device_backends: Dict mapping device type to backend name.
+    """
+    # Get the torchcomms instances from the parent process group
+    parent_torchcomms = pg_info_get_data(parent_pg, "torchcomms")
+    if not parent_torchcomms:
+        raise AssertionError(
+            f"No torchcomms instances found for parent process group {parent_pg}"
+        )
+
+    # Find which ranks this process belongs to
+    my_rank = dist.get_rank(parent_pg)
+    ranks = []
+    for rank_list in split_ranks:
+        if my_rank in rank_list:
+            ranks = rank_list
+            break
+
+    # Convert pg_options to hints for torchcomms
+    hints = _pg_options_to_hints(pg_options)
+
+    # Create torchcomms instances for the new process group using split
+    device_types_to_create = set(device_backends.keys())
+    new_torchcomms_instances: dict[str, TorchComm] = {}
+    for device_type, parent_tc in parent_torchcomms.items():
+        if device_type not in device_types_to_create:
+            continue
+        split_torchcomms = parent_tc.split(ranks, name=group_desc, hints=hints)
+
+        new_torchcomms_instances[device_type] = split_torchcomms
+
+    # Store the new torchcomms instances
+    pg_info_set_data(pg, "torchcomms", new_torchcomms_instances)
+
+
+# =============================================================================
+# Private Data and Helper Functions
+# =============================================================================
+
+
+# Global state for torchcomms usage
+_use_torchcomms: bool = False
+_eager_init_enabled: bool = False
+
+# Known backends and their default device types
+_BACKEND_DEFAULT_DEVICES: dict[str, str] = {
+    "nccl": "cuda",
+    "ncclx": "cuda",
+    "rccl": "cuda",
+    "rcclx": "cuda",
+    "gloo": "cpu",
+    "hccl": "mtia",
+}
+
+# Backend rename mapping for torch.distributed compatibility
+_BACKEND_RENAME_FOR_DIST: dict[str, str] = {
+    "ncclx": "nccl",
+    "rcclx": "rccl",
+}
+
+# List of torch.distributed collectives to block when torchcomms is enabled
+_BLOCKED_COLLECTIVES: list[str] = [
+    "send",
+    "recv",
+    "isend",
+    "irecv",
+    "broadcast",
+    "all_reduce",
+    "reduce",
+    "all_gather",
+    "all_gather_into_tensor",
+    "gather",
+    "scatter",
+    "reduce_scatter",
+    "reduce_scatter_tensor",
+    "all_to_all_single",
+    "all_to_all",
+    "barrier",
+    "batch_isend_irecv",
+    "all_gather_object",
+    "gather_object",
+    "scatter_object_list",
+    "broadcast_object_list",
+]
+
+
+def get_group(group: ProcessGroup | None) -> ProcessGroup:
+    """Get the process group, defaulting to WORLD if None."""
+    if group is None:
+        pg = dist.group.WORLD
+        if pg is None:
+            raise AssertionError("dist.group.WORLD is not initialized")
+        return pg
+    return group
+
+
+def get_torchcomms_instance(
+    group: ProcessGroup,
+    device_type: str | None = None,
+    tensor: torch.Tensor | None = None,
+) -> Any:
+    """
+    Get the torchcomms instance for the given group.
+
+    Args:
+        group: The process group.
+        device_type: The device type string (e.g., "cuda", "cpu"). If provided, uses this directly.
+        tensor: A tensor to infer device type from. Used if device_type is not provided.
+
+    Returns:
+        The torchcomms instance for the specified device type.
+
+    Raises:
+        ValueError: If neither device_type nor tensor is provided, or if device type not found.
+    """
+    if device_type is None and tensor is None:
+        raise ValueError("Either device_type or tensor must be provided")
+
+    if device_type is None:
+        if tensor is None:
+            raise AssertionError("tensor should not be None at this point")
+        device_type = tensor.device.type
+
+    torchcomms_instances = pg_info_get_data(group, "torchcomms")
+    if not torchcomms_instances:
+        raise AssertionError(f"No torchcomms instances found for process group {group}")
+
+    if device_type not in torchcomms_instances:
+        raise ValueError(
+            f"No torchcomms instance for device type '{device_type}'. "
+            f"Available: {', '.join(sorted(torchcomms_instances.keys()))}"
+        )
+
+    return torchcomms_instances[device_type]
+
+
+def get_group_rank(group: ProcessGroup, global_rank: int) -> int:
+    """
+    Convert a global rank to a group-local rank.
+
+    Args:
+        group: The process group.
+        global_rank: The global rank to convert.
+
+    Returns:
+        The group-local rank (index within the group).
+
+    Raises:
+        ValueError: If the global rank is not in the group.
+    """
+    from torchcomms.distwrap.pginfo import pg_info_get_global_ranks
+
+    global_ranks = pg_info_get_global_ranks(group)
+    try:
+        return global_ranks.index(global_rank)
+    except ValueError:
+        raise ValueError(
+            f"Global rank {global_rank} is not in process group. "
+            f"Group ranks: {global_ranks}"
+        )
+
+
+def get_backend_for_device(group: ProcessGroup, device_type: str) -> str:
+    """
+    Get the backend name for a given device type in a process group.
+
+    Args:
+        group: The process group.
+        device_type: The device type (e.g., "cpu", "cuda").
+
+    Returns:
+        The backend name for the device type.
+    """
+    device_backends = pg_info_get_data(group, "device_backends")
+    assert device_backends is not None, (
+        f"No device_backends found for process group {group}"
+    )
+    assert device_type in device_backends, (
+        f"Device type '{device_type}' not found in device_backends. "
+        f"Available: {', '.join(sorted(device_backends.keys()))}"
+    )
+    return device_backends[device_type]
+
+
+def _block_torch_distributed_collectives() -> None:
+    """
+    Block torch.distributed collective calls when torchcomms is enabled.
+
+    This patches torch.distributed collective functions to raise
+    NotImplementedError, ensuring users don't accidentally call dist.*
+    functions directly when they should be using the distwrap wrappers.
+    """
+    from unittest.mock import patch
+
+    for coll in _BLOCKED_COLLECTIVES:
+        patch(
+            f"torch.distributed.{coll}",
+            side_effect=NotImplementedError(
+                f"{coll}: torch.distributed APIs have been disabled. "
+                "Use torchcomms.distwrap collectives instead."
+            ),
+        ).__enter__()
+
+
+def _pg_options_to_hints(pg_options: Any | None) -> dict[str, str] | None:  # noqa: C901
+    """
+    Convert ProcessGroup options to hints dictionary for torchcomms.
+
+    Args:
+        pg_options: ProcessGroupNCCL.Options or similar options object
+
+    Returns:
+        Dictionary of string hints, or None if no options provided
+    """
+    if pg_options is None:
+        return None
+
+    hints = {}
+
+    # Check if it's a ProcessGroupNCCL.Options object
+    if hasattr(pg_options, "config"):
+        # Extract config attributes
+        config = pg_options.config
+        # pyre-ignore[16]: ProcessGroupNCCL may not be available
+        process_group_nccl = getattr(dist, "ProcessGroupNCCL", None)
+        if process_group_nccl is not None:
+            nccl_config_class = getattr(process_group_nccl, "NCCLConfig", None)
+            if nccl_config_class:
+                for attr in dir(config):
+                    if not attr.startswith("_"):
+                        try:
+                            value = getattr(config, attr)
+                            if not callable(value):
+                                hints[attr] = str(value)
+                        except Exception:
+                            pass
+
+    # Also extract direct attributes from pg_options
+    for attr in dir(pg_options):
+        if not attr.startswith("_") and attr != "config":
+            try:
+                value = getattr(pg_options, attr)
+                if not callable(value):
+                    hints[attr] = str(value)
+            except Exception:
+                pass
+
+    return hints if hints else None


### PR DESCRIPTION
Summary:
Add a new distwrap module that provides wrapper functions for distributed
communication operations, with optional torchcomms backend support. The module
includes:

- new_comm.py: Process group management
  - init_process_group: Initialize with optional torchcomms backend
  - new_group: Create new process groups
  - split_group: Split world process group into subgroups

- collectives.py: Full implementations of distributed collectives
  - all_reduce, broadcast, reduce, all_gather, all_gather_into_tensor
  - reduce_scatter, reduce_scatter_tensor, all_to_all, all_to_all_single
  - scatter, gather, barrier, send, recv, isend, irecv, batch_isend_irecv
  - Object-based collectives: all_gather_object, gather_object, etc.

- collectives_extension.py: Extended torchcomms-only operations
  - new_window, alltoallv_dedup_init/exec, alltoallv_dynamic_dispatch/combine

- pginfo.py: Process group info registry to track global ranks, group
  descriptions, and associated data (like torchcomms instances)

- utils.py: Utility functions for backend parsing, rank/world_size resolution,
  torchcomms instance management, and torch.distributed blocking

Differential Revision: D91544666


