### PR TITLE
Add backup/restore, copy-stable, and only-stable options to rcclx snapshot scripts

### DIFF
--- a/comms/rcclx/snapshots/scripts/backup_manifold_artifacts.py
+++ b/comms/rcclx/snapshots/scripts/backup_manifold_artifacts.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+# pyre-strict
+"""
+Script to backup rcclx prebuilt artifacts within Manifold.
+
+This script copies stable and last-stable artifacts from their current
+locations in Manifold to an archives backup path with a timestamp prefix.
+
+The backup structure in Manifold:
+  rcclx_prebuilt_artifacts/tree/archives/
+  └── backup_20260127_012000/
+      ├── stable/
+      │   ├── 6.2/librcclx-dev.a
+      │   ├── 6.4/librcclx-dev.a
+      │   └── 7.0/librcclx-dev.a
+      └── last_stable/
+          ├── 6.2/librcclx-dev.a
+          ├── 6.4/librcclx-dev.a
+          └── 7.0/librcclx-dev.a
+
+Usage:
+    buck2 run fbcode//comms/rcclx/snapshots/scripts:backup_manifold_artifacts
+
+    # Or with specific ROCm versions:
+    buck2 run fbcode//comms/rcclx/snapshots/scripts:backup_manifold_artifacts -- \\
+        --rocm-versions 6.2,6.4,7.0
+"""
+
+import argparse
+import io
+import logging
+import sys
+from datetime import datetime, timedelta
+from typing import List
+
+from ai_infra.privacy_security.security.file_vault.meta.manifold_client.python import (
+    BarnFSManifoldClient,
+)
+from libfb.py.asyncio.await_utils import await_sync
+
+logging.basicConfig(level=logging.INFO)
+logger: logging.Logger = logging.getLogger(__name__)
+
+MANIFOLD_BUCKET: str = "rcclx_prebuilt_artifacts"
+MANIFOLD_PATH_PREFIX: str = "tree/"
+MANIFOLD_TIMEOUT_SEC: int = 600  # 10 minutes
+MANIFOLD_NUM_RETRIES: int = 10
+
+# Default ROCm versions to backup
+DEFAULT_ROCM_VERSIONS: List[str] = ["6.2", "6.4", "7.0"]
+
+# Stages to backup
+STAGES: List[str] = ["stable", "last_stable"]
+
+# Library filename
+LIBRARY_NAME: str = "librcclx-dev.a"
+
+
+def get_manifold_path(stage: str, rocm_version: str, filename: str = "") -> str:
+    """
+    Construct a Manifold path for artifacts.
+
+    Args:
+        stage: One of 'stable', 'last_stable'
+        rocm_version: ROCm version (e.g., '6.2')
+        filename: Optional filename to append
+
+    Returns:
+        Full Manifold path (without bucket prefix)
+    """
+    if filename:
+        return f"{MANIFOLD_PATH_PREFIX}{stage}/{rocm_version}/{filename}"
+    return f"{MANIFOLD_PATH_PREFIX}{stage}/{rocm_version}"
+
+
+def get_backup_path(
+    backup_name: str, stage: str, rocm_version: str, filename: str = ""
+) -> str:
+    """
+    Construct a Manifold backup path for artifacts.
+
+    Args:
+        backup_name: Name of the backup directory (e.g., 'backup_20260127_012000')
+        stage: One of 'stable', 'last_stable'
+        rocm_version: ROCm version (e.g., '6.2')
+        filename: Optional filename to append
+
+    Returns:
+        Full Manifold backup path (without bucket prefix)
+    """
+    if filename:
+        return f"{MANIFOLD_PATH_PREFIX}archives/{backup_name}/{stage}/{rocm_version}/{filename}"
+    return f"{MANIFOLD_PATH_PREFIX}archives/{backup_name}/{stage}/{rocm_version}"
+
+
+def check_manifold_path_exists(manifold_path: str) -> bool:
+    """
+    Check if a path exists in Manifold.
+
+    Args:
+        manifold_path: Manifold path (without bucket prefix)
+
+    Returns:
+        True if path exists, False otherwise
+    """
+
+    async def async_exists() -> bool:
+        client = BarnFSManifoldClient.get_client(
+            bucket=MANIFOLD_BUCKET, apiKey=f"{MANIFOLD_BUCKET}-key"
+        )
+        with client:
+            return await client.exists(path=manifold_path)
+
+    return await_sync(async_exists())
+
+
+def create_manifold_directory(dir_path: str) -> bool:
+    """
+    Create a directory in Manifold (tree namespace).
+
+    Args:
+        dir_path: Directory path to create (without bucket prefix)
+
+    Returns:
+        True if successful or already exists
+    """
+
+    async def async_mkdir() -> bool:
+        client = BarnFSManifoldClient.get_client(
+            bucket=MANIFOLD_BUCKET, apiKey=f"{MANIFOLD_BUCKET}-key"
+        )
+        with client:
+            await client.mkdir(path=dir_path)
+            return True
+
+    return await_sync(async_mkdir())
+
+
+def copy_manifold_file(src_path: str, dst_path: str) -> bool:
+    """
+    Copy a file within Manifold by downloading and re-uploading.
+
+    Args:
+        src_path: Source Manifold path (without bucket prefix)
+        dst_path: Destination Manifold path (without bucket prefix)
+
+    Returns:
+        True if successful, False if source doesn't exist
+    """
+
+    async def async_copy() -> bool:
+        client = BarnFSManifoldClient.get_client(
+            bucket=MANIFOLD_BUCKET, apiKey=f"{MANIFOLD_BUCKET}-key"
+        )
+        with client:
+            # Check if source exists
+            if not await client.exists(path=src_path):
+                return False
+
+            # Download from source
+            buffer = io.BytesIO()
+            await client.get(
+                path=src_path,
+                output=buffer,
+                timeout=timedelta(seconds=MANIFOLD_TIMEOUT_SEC),
+                numRetries=MANIFOLD_NUM_RETRIES,
+            )
+
+            # Upload to destination
+            buffer.seek(0)
+            await client.put(
+                path=dst_path,
+                input=buffer,
+                timeout=timedelta(seconds=MANIFOLD_TIMEOUT_SEC),
+                numRetries=MANIFOLD_NUM_RETRIES,
+            )
+
+            return True
+
+    return await_sync(async_copy())
+
+
+def generate_backup_name() -> str:
+    """
+    Generate a backup directory name with timestamp.
+
+    Returns:
+        Backup name in format 'backup_YYYYMMDD_HHMMSS'
+    """
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    return f"backup_{timestamp}"
+
+
+def backup_artifacts(
+    rocm_versions: List[str],
+) -> str:
+    """
+    Backup all artifacts within Manifold to an archives backup path.
+
+    Args:
+        rocm_versions: List of ROCm versions to backup
+
+    Returns:
+        The backup path name that was created
+    """
+    backup_name = generate_backup_name()
+    backup_base_path = f"{MANIFOLD_PATH_PREFIX}archives/{backup_name}"
+
+    logger.info("=" * 60)
+    logger.info("Backing up Manifold artifacts")
+    logger.info("=" * 60)
+    logger.info(f"Backup name: {backup_name}")
+    logger.info(f"Backup path: {MANIFOLD_BUCKET}/{backup_base_path}/")
+    logger.info(f"ROCm versions: {', '.join(rocm_versions)}")
+    logger.info(f"Stages: {', '.join(STAGES)}")
+    logger.info("")
+
+    # Create the directory structure in Manifold before copying files
+    logger.info("Creating backup directory structure in Manifold...")
+    try:
+        # Create the backup root directory
+        create_manifold_directory(backup_base_path)
+        logger.info(f"  -> Created: {backup_base_path}")
+
+        # Create stage and version directories
+        for stage in STAGES:
+            stage_path = f"{backup_base_path}/{stage}"
+            create_manifold_directory(stage_path)
+            logger.info(f"  -> Created: {stage_path}")
+
+            for rocm_version in rocm_versions:
+                version_path = f"{stage_path}/{rocm_version}"
+                create_manifold_directory(version_path)
+                logger.info(f"  -> Created: {version_path}")
+    except Exception as e:
+        logger.error(f"Error creating directory structure: {e}")
+        raise
+
+    logger.info("")
+
+    total_copied = 0
+    total_missing = 0
+
+    for stage in STAGES:
+        for rocm_version in rocm_versions:
+            src_path = get_manifold_path(stage, rocm_version, LIBRARY_NAME)
+            dst_path = get_backup_path(backup_name, stage, rocm_version, LIBRARY_NAME)
+
+            logger.info(f"Backing up {stage}/{rocm_version}/{LIBRARY_NAME}...")
+
+            try:
+                if copy_manifold_file(src_path, dst_path):
+                    logger.info(f"  -> Copied to {dst_path}")
+                    total_copied += 1
+                else:
+                    logger.warning(f"  -> Source not found: {src_path}")
+                    total_missing += 1
+            except Exception as e:
+                logger.error(f"  -> Error copying: {e}")
+                total_missing += 1
+
+    logger.info("")
+    logger.info("=" * 60)
+    logger.info("Backup Summary")
+    logger.info("=" * 60)
+    logger.info(f"Total copied: {total_copied}")
+    logger.info(f"Total missing/failed: {total_missing}")
+    logger.info("")
+    logger.info(f"Backup location: {MANIFOLD_BUCKET}/{backup_base_path}/")
+    logger.info("")
+
+    if total_copied > 0:
+        logger.info("Backup structure:")
+        for stage in STAGES:
+            for rocm_version in rocm_versions:
+                backup_path = get_backup_path(
+                    backup_name, stage, rocm_version, LIBRARY_NAME
+                )
+                if check_manifold_path_exists(backup_path):
+                    logger.info(f"  {backup_name}/{stage}/{rocm_version}/{LIBRARY_NAME}")
+
+    logger.info("")
+    logger.info("=" * 60)
+    logger.info(f"BACKUP PATH: {backup_name}")
+    logger.info("=" * 60)
+    logger.info("")
+    logger.info("Use this path with restore_manifold_artifacts to restore:")
+    logger.info(
+        f"  buck2 run fbcode//comms/rcclx/snapshots/scripts:restore_manifold_artifacts -- \\"
+    )
+    logger.info(f"      --backup-name {backup_name}")
+    logger.info("")
+
+    return backup_name
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Backup rcclx prebuilt artifacts within Manifold"
+    )
+    parser.add_argument(
+        "--rocm-versions",
+        type=str,
+        default=",".join(DEFAULT_ROCM_VERSIONS),
+        help=f"Comma-separated list of ROCm versions to backup (default: {','.join(DEFAULT_ROCM_VERSIONS)})",
+    )
+
+    args = parser.parse_args()
+
+    # Parse ROCm versions
+    rocm_versions = [v.strip() for v in args.rocm_versions.split(",") if v.strip()]
+
+    if not rocm_versions:
+        logger.error("No ROCm versions specified")
+        return 1
+
+    try:
+        backup_name = backup_artifacts(rocm_versions=rocm_versions)
+        print(f"\n{backup_name}")
+        return 0
+    except Exception as e:
+        logger.error(f"Error: {e}", exc_info=True)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/comms/rcclx/snapshots/scripts/create_snapshot.py
+++ b/comms/rcclx/snapshots/scripts/create_snapshot.py
@@ -4,10 +4,11 @@
 Script to create snapshots of rcclx static libraries and headers.
 
 This script handles:
-1. Moving last-stable to archives with timestamp (metadata and headers in repo, artifacts in Manifold)
-2. Moving stable to last-stable (metadata and headers in repo, artifacts in Manifold)
-3. Copying newly built library to stable (metadata and headers in repo, artifacts in Manifold)
-4. Creating metadata file with commit hashes
+1. Creating a backup of all current artifacts in Manifold (checkpoint for recovery)
+2. Moving last-stable to archives with timestamp (metadata and headers in repo, artifacts in Manifold)
+3. Moving stable to last-stable (metadata and headers in repo, artifacts in Manifold)
+4. Copying newly built library to stable (metadata and headers in repo, artifacts in Manifold)
+5. Creating metadata file with commit hashes
 
 Artifacts (.a files) are stored in Manifold at:
   rcclx_prebuilt_artifacts/tree/stable/{rocm_version}/librcclx-dev.a
@@ -32,7 +33,7 @@ import subprocess
 import sys
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from ai_infra.privacy_security.security.file_vault.meta.manifold_client.python import (
     BarnFSManifoldClient,
@@ -46,6 +47,196 @@ MANIFOLD_BUCKET: str = "rcclx_prebuilt_artifacts"
 MANIFOLD_PATH_PREFIX: str = "tree/"
 MANIFOLD_TIMEOUT_SEC: int = 600  # 10 minutes
 MANIFOLD_NUM_RETRIES: int = 10
+
+# Default ROCm versions for backup
+DEFAULT_ROCM_VERSIONS: List[str] = ["6.2", "6.4", "7.0"]
+
+# Stages to backup
+BACKUP_STAGES: List[str] = ["stable", "last_stable"]
+
+# Library filename
+LIBRARY_NAME: str = "librcclx-dev.a"
+
+
+def get_backup_path(
+    backup_name: str, stage: str, rocm_version: str, filename: str = ""
+) -> str:
+    """
+    Construct a Manifold backup path for artifacts.
+
+    Args:
+        backup_name: Name of the backup directory (e.g., 'backup_20260127_012000')
+        stage: One of 'stable', 'last_stable'
+        rocm_version: ROCm version (e.g., '6.2')
+        filename: Optional filename to append
+
+    Returns:
+        Full Manifold backup path (without bucket prefix)
+    """
+    if filename:
+        return f"{MANIFOLD_PATH_PREFIX}archives/{backup_name}/{stage}/{rocm_version}/{filename}"
+    return f"{MANIFOLD_PATH_PREFIX}archives/{backup_name}/{stage}/{rocm_version}"
+
+
+def generate_backup_name() -> str:
+    """
+    Generate a backup directory name with timestamp.
+
+    Returns:
+        Backup name in format 'backup_YYYYMMDD_HHMMSS'
+    """
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    return f"backup_{timestamp}"
+
+
+def create_manifold_directory_for_backup(dir_path: str) -> bool:
+    """
+    Create a directory in Manifold (tree namespace) for backup.
+
+    Args:
+        dir_path: Directory path to create (without bucket prefix)
+
+    Returns:
+        True if successful or already exists
+    """
+
+    async def async_mkdir() -> bool:
+        client = BarnFSManifoldClient.get_client(
+            bucket=MANIFOLD_BUCKET, apiKey=f"{MANIFOLD_BUCKET}-key"
+        )
+        with client:
+            await client.mkdir(path=dir_path)
+            return True
+
+    return await_sync(async_mkdir())
+
+
+def copy_manifold_file_for_backup(src_path: str, dst_path: str) -> bool:
+    """
+    Copy a file within Manifold for backup purposes.
+
+    Args:
+        src_path: Source Manifold path (without bucket prefix)
+        dst_path: Destination Manifold path (without bucket prefix)
+
+    Returns:
+        True if successful, False if source doesn't exist
+    """
+
+    async def async_copy() -> bool:
+        client = BarnFSManifoldClient.get_client(
+            bucket=MANIFOLD_BUCKET, apiKey=f"{MANIFOLD_BUCKET}-key"
+        )
+        with client:
+            # Check if source exists
+            if not await client.exists(path=src_path):
+                return False
+
+            # Download from source
+            buffer = io.BytesIO()
+            await client.get(
+                path=src_path,
+                output=buffer,
+                timeout=timedelta(seconds=MANIFOLD_TIMEOUT_SEC),
+                numRetries=MANIFOLD_NUM_RETRIES,
+            )
+
+            # Upload to destination
+            buffer.seek(0)
+            await client.put(
+                path=dst_path,
+                input=buffer,
+                timeout=timedelta(seconds=MANIFOLD_TIMEOUT_SEC),
+                numRetries=MANIFOLD_NUM_RETRIES,
+            )
+
+            return True
+
+    return await_sync(async_copy())
+
+
+def backup_all_artifacts(rocm_versions: List[str]) -> str:
+    """
+    Create a backup of all stable and last-stable artifacts in Manifold.
+
+    This creates a checkpoint that can be used to restore artifacts if
+    something goes wrong during snapshot creation.
+
+    Args:
+        rocm_versions: List of ROCm versions to backup
+
+    Returns:
+        The backup path name that was created
+    """
+    backup_name = generate_backup_name()
+    backup_base_path = f"{MANIFOLD_PATH_PREFIX}archives/{backup_name}"
+
+    logger.info("=" * 60)
+    logger.info("Creating backup checkpoint before snapshot creation")
+    logger.info("=" * 60)
+    logger.info(f"Backup name: {backup_name}")
+    logger.info(f"Backup path: {MANIFOLD_BUCKET}/{backup_base_path}/")
+    logger.info(f"Stages to backup: {', '.join(BACKUP_STAGES)}")
+    logger.info(f"ROCm versions: {', '.join(rocm_versions)}")
+    logger.info("")
+
+    # Create the directory structure in Manifold before copying files
+    logger.info("Creating backup directory structure in Manifold...")
+    try:
+        # Create the backup root directory
+        create_manifold_directory_for_backup(backup_base_path)
+        logger.info(f"  -> Created: {backup_base_path}")
+
+        # Create stage and version directories
+        for stage in BACKUP_STAGES:
+            stage_path = f"{backup_base_path}/{stage}"
+            create_manifold_directory_for_backup(stage_path)
+            logger.info(f"  -> Created: {stage_path}")
+
+            for rocm_version in rocm_versions:
+                version_path = f"{stage_path}/{rocm_version}"
+                create_manifold_directory_for_backup(version_path)
+                logger.info(f"  -> Created: {version_path}")
+    except Exception as e:
+        logger.error(f"Error creating backup directory structure: {e}")
+        raise
+
+    logger.info("")
+
+    total_copied = 0
+    total_missing = 0
+
+    for stage in BACKUP_STAGES:
+        for rocm_version in rocm_versions:
+            src_path = get_manifold_path(stage, rocm_version, LIBRARY_NAME)
+            dst_path = get_backup_path(backup_name, stage, rocm_version, LIBRARY_NAME)
+
+            logger.info(f"Backing up {stage}/{rocm_version}/{LIBRARY_NAME}...")
+
+            try:
+                if copy_manifold_file_for_backup(src_path, dst_path):
+                    logger.info(f"  -> Copied to {dst_path}")
+                    total_copied += 1
+                else:
+                    logger.warning(f"  -> Source not found (skipping): {src_path}")
+                    total_missing += 1
+            except Exception as e:
+                logger.error(f"  -> Error copying: {e}")
+                total_missing += 1
+
+    logger.info("")
+    logger.info(f"Backup complete: {total_copied} copied, {total_missing} missing/skipped")
+    logger.info(f"Backup checkpoint: {backup_name}")
+    logger.info("")
+    logger.info("To restore from this backup if needed, run:")
+    logger.info(
+        f"  buck2 run fbcode//comms/rcclx/snapshots/scripts:restore_manifold_artifacts -- \\"
+    )
+    logger.info(f"      --backup-name {backup_name}")
+    logger.info("=" * 60)
+    logger.info("")
+
+    return backup_name
 
 
 def get_git_commit_hash(repo_path: str) -> Optional[str]:
@@ -372,6 +563,8 @@ def create_snapshot(
     snapshots_root: Path,
     rcclx_repo_path: Path,
     header_path: Path,
+    skip_backup: bool = False,
+    only_stable: bool = False,
 ) -> None:
     """
     Create a snapshot of the rcclx library and header.
@@ -385,8 +578,13 @@ def create_snapshot(
         snapshots_root: Root path of the snapshots directory
         rcclx_repo_path: Path to the rcclx repository for getting commit info
         header_path: Path to the rccl.h header file to snapshot
+        skip_backup: If True, skip the backup step (not recommended)
+        only_stable: If True, only update stable without rotating to last-stable
     """
-    logger.info(f"Creating snapshot for ROCm {rocm_version}")
+    if only_stable:
+        logger.info(f"Creating snapshot for ROCm {rocm_version} (only-stable mode)")
+    else:
+        logger.info(f"Creating snapshot for ROCm {rocm_version}")
 
     # Validate inputs
     if not library_path.exists():
@@ -398,84 +596,69 @@ def create_snapshot(
     if not snapshots_root.exists():
         raise FileNotFoundError(f"Snapshots directory not found: {snapshots_root}")
 
+    # Step 0: Create a backup of all artifacts before making any changes
+    if not skip_backup:
+        backup_name = backup_all_artifacts(DEFAULT_ROCM_VERSIONS)
+        logger.info(f"Backup checkpoint created: {backup_name}")
+    else:
+        logger.warning("Skipping backup step (--skip-backup flag was set)")
+
     # Define directories for metadata (in repo)
     stable_dir = snapshots_root / "stable" / rocm_version
     last_stable_dir = snapshots_root / "last-stable" / rocm_version
-    archives_dir = snapshots_root / "archives" / rocm_version
 
     # Create directories if they don't exist
     stable_dir.mkdir(parents=True, exist_ok=True)
-    last_stable_dir.mkdir(parents=True, exist_ok=True)
-    archives_dir.mkdir(parents=True, exist_ok=True)
+    if not only_stable:
+        last_stable_dir.mkdir(parents=True, exist_ok=True)
 
     library_name = library_path.name
     header_name = header_path.name
 
-    # Step 1: Move last-stable to archives with timestamp-prefixed filenames
-    # Check if last-stable metadata exists in repo
-    if not is_directory_empty(last_stable_dir):
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        logger.info(
-            f"Archiving last-stable to archives/{rocm_version}/{timestamp}_metadata.txt"
-        )
+    # Step 1: Move stable to last-stable (unless only_stable mode)
+    if not only_stable:
+        # The backup already preserves the old last-stable, so we can safely overwrite
+        if not is_directory_empty(stable_dir):
+            logger.info(f"Moving stable to last-stable/{rocm_version}/")
 
-        # Archive metadata in repo with timestamp prefix
-        for item in last_stable_dir.iterdir():
-            if item.is_file():
-                archive_filename = f"{timestamp}_{item.name}"
-                archive_path = archives_dir / archive_filename
-                shutil.move(str(item), str(archive_path))
-                logger.info(f"Archived metadata: {archive_path}")
+            # Move metadata in repo (overwrites existing last-stable)
+            move_directory_contents(stable_dir, last_stable_dir)
 
-        # Archive artifact in Manifold (if exists) with timestamp prefix
-        last_stable_manifold_path = get_manifold_path(
-            "last_stable", rocm_version, library_name
-        )
-        if check_manifold_path_exists(last_stable_manifold_path):
-            archive_library_name = f"{timestamp}_{library_name}"
-            archive_manifold_path = get_manifold_path(
-                "archives", rocm_version, archive_library_name
-            )
-            copy_manifold_file(last_stable_manifold_path, archive_manifold_path)
-            delete_manifold_file(last_stable_manifold_path)
-            logger.info(f"Archived artifact in Manifold: {archive_manifold_path}")
+            # Move artifact in Manifold (if exists)
+            stable_manifold_path = get_manifold_path("stable", rocm_version, library_name)
+            if check_manifold_path_exists(stable_manifold_path):
+                last_stable_manifold_path = get_manifold_path(
+                    "last_stable", rocm_version, library_name
+                )
+                copy_manifold_file(stable_manifold_path, last_stable_manifold_path)
+                delete_manifold_file(stable_manifold_path)
+                logger.info(
+                    f"Moved artifact in Manifold to last_stable/{rocm_version}/{library_name}"
+                )
+    else:
+        logger.info("Skipping stable-to-last-stable rotation (--only-stable mode)")
+        # Clear existing stable metadata files before creating new ones
+        if not is_directory_empty(stable_dir):
+            for item in stable_dir.iterdir():
+                if item.is_file():
+                    item.unlink()
 
-    # Step 2: Move stable to last-stable
-    # Check if stable metadata exists in repo
-    if not is_directory_empty(stable_dir):
-        logger.info(f"Moving stable to last-stable/{rocm_version}/")
-
-        # Move metadata in repo
-        move_directory_contents(stable_dir, last_stable_dir)
-
-        # Move artifact in Manifold (if exists)
-        stable_manifold_path = get_manifold_path("stable", rocm_version, library_name)
-        if check_manifold_path_exists(stable_manifold_path):
-            last_stable_manifold_path = get_manifold_path(
-                "last_stable", rocm_version, library_name
-            )
-            copy_manifold_file(stable_manifold_path, last_stable_manifold_path)
-            delete_manifold_file(stable_manifold_path)
-            logger.info(
-                f"Moved artifact in Manifold to last_stable/{rocm_version}/{library_name}"
-            )
-
-    # Step 3: Calculate checksums for the library before uploading
+    # Step 2: Calculate checksums for the library before uploading
     logger.info(f"Calculating checksums for {library_path}")
     checksums = calculate_file_checksums(library_path)
     logger.info(f"SHA1: {checksums['sha1']}")
     logger.info(f"SHA256: {checksums['sha256']}")
 
-    # Step 4: Upload newly built library to Manifold stable
+    # Step 3: Upload newly built library to Manifold stable
     stable_manifold_path = get_manifold_path("stable", rocm_version, library_name)
     upload_file_to_manifold(library_path, stable_manifold_path)
 
-    # Step 5: Copy header file to repo stable
+    # Step 4: Copy header file to repo stable
     stable_header_path = stable_dir / header_name
     shutil.copy2(header_path, stable_header_path)
     logger.info(f"Copied {header_name} to {stable_header_path}")
 
-    # Step 6: Create metadata file in repo stable with checksums
+    # Step 5: Create metadata file in repo stable with checksums
     deps_info = get_dependency_info(str(rcclx_repo_path))
     metadata_path = stable_dir / "metadata.txt"
     create_metadata_file(metadata_path, rocm_version, deps_info, checksums)
@@ -486,6 +669,138 @@ def create_snapshot(
     )
     logger.info(f"Header stored in repo at: {stable_header_path}")
     logger.info(f"Metadata stored in repo at: {metadata_path}")
+    if only_stable:
+        logger.info("Last-stable was not modified (--only-stable mode)")
+
+
+def copy_stable_to_last_stable(
+    rocm_version: str,
+    snapshots_root: Path,
+    skip_backup: bool = False,
+) -> None:
+    """
+    Copy current stable snapshot to last-stable.
+
+    This function rotates snapshots without creating a new stable:
+    1. Creates a backup checkpoint (unless skipped)
+    2. Copies current stable to last-stable (overwrites existing last-stable)
+    3. Stable remains unchanged
+
+    Args:
+        rocm_version: ROCm version (e.g., "6.2", "6.4", "7.0")
+        snapshots_root: Root path of the snapshots directory
+        skip_backup: If True, skip the backup step (not recommended)
+    """
+    logger.info(f"Copying stable to last-stable for ROCm {rocm_version}")
+
+    if not snapshots_root.exists():
+        raise FileNotFoundError(f"Snapshots directory not found: {snapshots_root}")
+
+    # Step 0: Create a backup of all artifacts before making any changes
+    if not skip_backup:
+        backup_name = backup_all_artifacts(DEFAULT_ROCM_VERSIONS)
+        logger.info(f"Backup checkpoint created: {backup_name}")
+    else:
+        logger.warning("Skipping backup step (--skip-backup flag was set)")
+
+    # Define directories for metadata (in repo)
+    stable_dir = snapshots_root / "stable" / rocm_version
+    last_stable_dir = snapshots_root / "last-stable" / rocm_version
+
+    # Validate that stable exists
+    if is_directory_empty(stable_dir):
+        raise ValueError(
+            f"Stable directory is empty for ROCm {rocm_version}. "
+            "Cannot copy stable to last-stable."
+        )
+
+    # Check if stable artifact exists in Manifold
+    stable_manifold_path = get_manifold_path("stable", rocm_version, LIBRARY_NAME)
+    if not check_manifold_path_exists(stable_manifold_path):
+        raise ValueError(
+            f"Stable artifact not found in Manifold for ROCm {rocm_version}. "
+            "Cannot copy stable to last-stable."
+        )
+
+    # Create last-stable directory if it doesn't exist
+    last_stable_dir.mkdir(parents=True, exist_ok=True)
+
+    # Step 1: Copy stable to last-stable (overwrites existing last-stable)
+    # The backup already preserves the old last-stable, so we can safely overwrite
+    logger.info(f"Copying stable to last-stable/{rocm_version}/")
+
+    # Clear existing last-stable files and copy from stable
+    for item in last_stable_dir.iterdir():
+        if item.is_file():
+            item.unlink()
+
+    # Copy metadata in repo
+    for item in stable_dir.iterdir():
+        if item.is_file():
+            dst_item = last_stable_dir / item.name
+            shutil.copy2(str(item), str(dst_item))
+            logger.info(f"Copied {item.name} to {dst_item}")
+
+    # Copy artifact in Manifold (overwrites existing)
+    last_stable_manifold_path = get_manifold_path(
+        "last_stable", rocm_version, LIBRARY_NAME
+    )
+    copy_manifold_file(stable_manifold_path, last_stable_manifold_path)
+    logger.info(
+        f"Copied artifact in Manifold to last_stable/{rocm_version}/{LIBRARY_NAME}"
+    )
+
+    logger.info(
+        f"Successfully copied stable to last-stable for ROCm {rocm_version}"
+    )
+    logger.info(f"Stable remains at: {stable_dir}")
+    logger.info(f"Last-stable updated at: {last_stable_dir}")
+
+
+def copy_stable_all_versions(
+    snapshots_root: Path,
+    rocm_versions: List[str],
+    skip_backup: bool = False,
+) -> None:
+    """
+    Copy stable to last-stable for all specified ROCm versions.
+
+    Args:
+        snapshots_root: Root path of the snapshots directory
+        rocm_versions: List of ROCm versions to process
+        skip_backup: If True, skip the backup step (not recommended)
+    """
+    logger.info("=" * 60)
+    logger.info("Copying stable to last-stable for all ROCm versions")
+    logger.info("=" * 60)
+    logger.info(f"ROCm versions: {', '.join(rocm_versions)}")
+    logger.info("")
+
+    # Step 0: Create a single backup for all versions before making any changes
+    if not skip_backup:
+        backup_name = backup_all_artifacts(DEFAULT_ROCM_VERSIONS)
+        logger.info(f"Backup checkpoint created: {backup_name}")
+    else:
+        logger.warning("Skipping backup step (--skip-backup flag was set)")
+
+    # Process each ROCm version (skip backup since we already did it once)
+    for rocm_version in rocm_versions:
+        logger.info("")
+        logger.info(f"Processing ROCm {rocm_version}...")
+        try:
+            copy_stable_to_last_stable(
+                rocm_version=rocm_version,
+                snapshots_root=snapshots_root,
+                skip_backup=True,  # Already backed up above
+            )
+        except Exception as e:
+            logger.error(f"Error processing ROCm {rocm_version}: {e}")
+            raise
+
+    logger.info("")
+    logger.info("=" * 60)
+    logger.info("Successfully copied stable to last-stable for all ROCm versions")
+    logger.info("=" * 60)
 
 
 def main() -> int:
@@ -495,14 +810,14 @@ def main() -> int:
     parser.add_argument(
         "--library",
         type=Path,
-        required=True,
-        help="Path to the built library file (e.g., librcclx-dev.a)",
+        help="Path to the built library file (e.g., librcclx-dev.a). "
+        "Required unless --copy-stable is used.",
     )
     parser.add_argument(
         "--rocm-version",
         type=str,
-        required=True,
-        help="ROCm version (e.g., 6.2, 6.4, 7.0)",
+        help="ROCm version (e.g., 6.2, 6.4, 7.0). "
+        "Required unless --copy-stable is used.",
     )
     parser.add_argument(
         "--snapshots-root",
@@ -513,26 +828,80 @@ def main() -> int:
     parser.add_argument(
         "--rcclx-repo",
         type=Path,
-        required=True,
-        help="Path to the rcclx repository root",
+        help="Path to the rcclx repository root. "
+        "Required unless --copy-stable is used.",
     )
     parser.add_argument(
         "--header",
         type=Path,
-        required=True,
-        help="Path to the rccl.h header file to snapshot",
+        help="Path to the rccl.h header file to snapshot. "
+        "Required unless --copy-stable is used.",
+    )
+    parser.add_argument(
+        "--skip-backup",
+        action="store_true",
+        help="Skip the backup step before creating snapshot (not recommended)",
+    )
+    parser.add_argument(
+        "--only-stable",
+        action="store_true",
+        help="Only update stable snapshot without rotating to last-stable. "
+        "Last-stable will remain unchanged.",
+    )
+    parser.add_argument(
+        "--copy-stable",
+        action="store_true",
+        help="Copy current stable to last-stable for all ROCm versions. "
+        "Does not create a new stable snapshot.",
+    )
+    parser.add_argument(
+        "--rocm-versions",
+        type=str,
+        default=",".join(DEFAULT_ROCM_VERSIONS),
+        help=f"Comma-separated list of ROCm versions for --copy-stable mode "
+        f"(default: {','.join(DEFAULT_ROCM_VERSIONS)})",
     )
 
     args = parser.parse_args()
 
     try:
-        create_snapshot(
-            library_path=args.library,
-            rocm_version=args.rocm_version,
-            snapshots_root=args.snapshots_root,
-            rcclx_repo_path=args.rcclx_repo,
-            header_path=args.header,
-        )
+        if args.copy_stable:
+            # Copy stable mode - rotate stable to last-stable for all versions
+            if args.only_stable:
+                parser.error("--copy-stable and --only-stable are mutually exclusive")
+
+            rocm_versions = [
+                v.strip() for v in args.rocm_versions.split(",") if v.strip()
+            ]
+            if not rocm_versions:
+                logger.error("No ROCm versions specified")
+                return 1
+
+            copy_stable_all_versions(
+                snapshots_root=args.snapshots_root,
+                rocm_versions=rocm_versions,
+                skip_backup=args.skip_backup,
+            )
+        else:
+            # Normal snapshot creation mode - validate required args
+            if not args.library:
+                parser.error("--library is required unless --copy-stable is used")
+            if not args.rocm_version:
+                parser.error("--rocm-version is required unless --copy-stable is used")
+            if not args.rcclx_repo:
+                parser.error("--rcclx-repo is required unless --copy-stable is used")
+            if not args.header:
+                parser.error("--header is required unless --copy-stable is used")
+
+            create_snapshot(
+                library_path=args.library,
+                rocm_version=args.rocm_version,
+                snapshots_root=args.snapshots_root,
+                rcclx_repo_path=args.rcclx_repo,
+                header_path=args.header,
+                skip_backup=args.skip_backup,
+                only_stable=args.only_stable,
+            )
         return 0
     except Exception as e:
         logger.error(f"Error: {e}", exc_info=True)

--- a/comms/rcclx/snapshots/scripts/create_snapshot_wrapper.sh
+++ b/comms/rcclx/snapshots/scripts/create_snapshot_wrapper.sh
@@ -12,6 +12,37 @@ fi
 
 # Parse command line arguments
 ROCM_VERSION=""
+ROCM_VERSIONS=""
+COPY_STABLE=false
+ONLY_STABLE=false
+SKIP_BACKUP=false
+
+show_usage() {
+    echo "Usage: $0 [OPTIONS]"
+    echo ""
+    echo "Options for creating a new snapshot (default mode):"
+    echo "  --rocm-version <version>   ROCm version (6.2, 6.4, or 7.0) - REQUIRED"
+    echo "  --only-stable              Update only stable, leave last-stable unchanged"
+    echo "  --skip-backup              Skip backup before making changes (not recommended)"
+    echo ""
+    echo "Options for copying stable to last-stable (--copy-stable mode):"
+    echo "  --copy-stable              Copy current stable to last-stable for all versions"
+    echo "  --rocm-versions <list>     Comma-separated ROCm versions (default: 6.2,6.4,7.0)"
+    echo "  --skip-backup              Skip backup before making changes (not recommended)"
+    echo ""
+    echo "Examples:"
+    echo "  # Create a new snapshot for ROCm 6.4"
+    echo "  $0 --rocm-version 6.4"
+    echo ""
+    echo "  # Create a new snapshot, only updating stable (not rotating to last-stable)"
+    echo "  $0 --rocm-version 6.4 --only-stable"
+    echo ""
+    echo "  # Copy stable to last-stable for all ROCm versions"
+    echo "  $0 --copy-stable"
+    echo ""
+    echo "  # Copy stable to last-stable for specific ROCm versions"
+    echo "  $0 --copy-stable --rocm-versions 6.4,7.0"
+}
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -19,126 +50,256 @@ while [[ $# -gt 0 ]]; do
             ROCM_VERSION="$2"
             shift 2
             ;;
+        --rocm-versions)
+            ROCM_VERSIONS="$2"
+            shift 2
+            ;;
+        --copy-stable)
+            COPY_STABLE=true
+            shift
+            ;;
+        --only-stable)
+            ONLY_STABLE=true
+            shift
+            ;;
+        --skip-backup)
+            SKIP_BACKUP=true
+            shift
+            ;;
+        --help|-h)
+            show_usage
+            exit 0
+            ;;
         *)
             echo "Unknown option: $1"
-            echo "Usage: $0 --rocm-version <6.2|6.4|7.0>"
+            show_usage
             exit 1
             ;;
     esac
 done
 
-if [[ -z "$ROCM_VERSION" ]]; then
-    echo "Error: --rocm-version is required"
-    echo "Usage: $0 --rocm-version <6.2|6.4|7.0>"
-    exit 1
-fi
-
-# Display warning and ask for confirmation
-echo ""
-echo "╔════════════════════════════════════════════════════════════════════════════╗"
-echo "║                              ⚠️  WARNING  ⚠️                                ║"
-echo "╠════════════════════════════════════════════════════════════════════════════╣"
-echo "║                                                                            ║"
-echo "║  THIS SCRIPT WILL UPDATE THE MANIFOLD STABLE ARTIFACT REFERENCE!          ║"
-echo "║                                                                            ║"
-echo "║  The following operations will be performed:                               ║"
-echo "║  1. Archive current last-stable to archives (Manifold + repo metadata)    ║"
-echo "║  2. Move current stable to last-stable (Manifold + repo metadata)         ║"
-echo "║  3. Upload NEW artifact to stable in Manifold                             ║"
-echo "║                                                                            ║"
-echo "║  This will affect the stable artifact for ROCm ${ROCM_VERSION}                            ║"
-echo "║                                                                            ║"
-echo "╚════════════════════════════════════════════════════════════════════════════╝"
-echo ""
-read -r -p "Do you want to proceed? (yes/no): " CONFIRM
-
-# Convert to lowercase for comparison
-CONFIRM=$(echo "$CONFIRM" | tr '[:upper:]' '[:lower:]')
-
-if [[ "$CONFIRM" != "yes" ]]; then
-    echo "Operation cancelled by user."
-    exit 0
-fi
-
-echo ""
-echo "Proceeding with snapshot creation..."
-echo ""
-
-# Determine ROCm constraint
-case $ROCM_VERSION in
-    6.2)
-        ROCM_CONSTRAINT="ovr_config//third-party/rocm/constraints:6.2.1"
-        ;;
-    6.4)
-        ROCM_CONSTRAINT="ovr_config//third-party/rocm/constraints:6.4.2"
-        ;;
-    7.0)
-        ROCM_CONSTRAINT="ovr_config//third-party/rocm/constraints:7.0"
-        ;;
-    *)
-        echo "Error: Unsupported ROCm version: $ROCM_VERSION"
-        echo "Supported versions: 6.2, 6.4, 7.0"
+# Validate arguments based on mode
+if [[ "$COPY_STABLE" == "true" ]]; then
+    # Copy stable mode
+    if [[ "$ONLY_STABLE" == "true" ]]; then
+        echo "Error: --copy-stable and --only-stable are mutually exclusive"
         exit 1
-        ;;
-esac
-
-echo "Creating snapshot for ROCm $ROCM_VERSION..."
-echo "Building rcclx-dev library..."
-echo "Note: First-time builds will take 20-30 minutes as we build from source without cache"
-
-# Build the rcclx-dev library
-# Use --no-remote-cache to disable remote cache queries/writes
-# Use --local-only to force local execution, preventing use of remote execution
-# which could otherwise provide prebuilt artifacts. This ensures we always do a
-# fresh local build when creating snapshots.
-buck2 build @fbcode//mode/opt-amd-gpu -m rcclx_dev -m "$ROCM_CONSTRAINT" --no-remote-cache --local-only fbcode//comms/rcclx:rcclx-dev
-
-# Get the library path from buck2 (relative to fbsource root)
-LIBRARY_PATH_RELATIVE=$(buck2 build @fbcode//mode/opt-amd-gpu -m rcclx_dev -m "$ROCM_CONSTRAINT" fbcode//comms/rcclx:rcclx-dev --show-output | grep -oP 'fbcode//comms/rcclx:rcclx-dev\s+\K.*')
-
-# Convert to absolute path (buck-out is at fbsource level, we're in fbcode)
-LIBRARY_PATH="../$LIBRARY_PATH_RELATIVE"
-
-if [[ ! -f "$LIBRARY_PATH" ]]; then
-    echo "Error: Could not find built library at $LIBRARY_PATH"
-    echo "Tried relative path: $LIBRARY_PATH_RELATIVE"
-    exit 1
+    fi
+    if [[ -n "$ROCM_VERSION" ]]; then
+        echo "Warning: --rocm-version is ignored in --copy-stable mode. Use --rocm-versions instead."
+    fi
+else
+    # Normal snapshot creation mode
+    if [[ -z "$ROCM_VERSION" ]]; then
+        echo "Error: --rocm-version is required for snapshot creation"
+        show_usage
+        exit 1
+    fi
 fi
 
-echo "Library built at: $LIBRARY_PATH"
-
-# Define header path
-HEADER_PATH="$(pwd)/comms/rcclx/develop/src/rccl.h"
-
-if [[ ! -f "$HEADER_PATH" ]]; then
-    echo "Error: Could not find rccl.h header at $HEADER_PATH"
-    exit 1
+# Build extra args for create_snapshot
+EXTRA_ARGS=""
+if [[ "$SKIP_BACKUP" == "true" ]]; then
+    EXTRA_ARGS="$EXTRA_ARGS --skip-backup"
 fi
 
-echo "Header found at: $HEADER_PATH"
-echo "Running snapshot script..."
+if [[ "$COPY_STABLE" == "true" ]]; then
+    # =====================================================================
+    # COPY STABLE MODE
+    # =====================================================================
+    echo ""
+    echo "╔════════════════════════════════════════════════════════════════════════════╗"
+    echo "║                         COPY STABLE TO LAST-STABLE                         ║"
+    echo "╠════════════════════════════════════════════════════════════════════════════╣"
+    echo "║                                                                            ║"
+    echo "║  This will copy current stable snapshots to last-stable.                   ║"
+    echo "║                                                                            ║"
+    echo "║  Operations:                                                               ║"
+    echo "║  1. Create a backup of all stable and last-stable artifacts                ║"
+    echo "║  2. Copy stable to last-stable for each ROCm version                       ║"
+    echo "║                                                                            ║"
+    if [[ -n "$ROCM_VERSIONS" ]]; then
+        echo "║  ROCm versions: $ROCM_VERSIONS"
+    else
+        echo "║  ROCm versions: 6.2,6.4,7.0 (default)                                      ║"
+    fi
+    echo "║                                                                            ║"
+    echo "╚════════════════════════════════════════════════════════════════════════════╝"
+    echo ""
+    read -r -p "Do you want to proceed? (yes/no): " CONFIRM
 
-# Run the snapshot creation script using buck2 run to get proper Python dependencies
-buck2 run fbcode//comms/rcclx/snapshots/scripts:create_snapshot -- \
-    --library "$LIBRARY_PATH" \
-    --rocm-version "$ROCM_VERSION" \
-    --snapshots-root "$(pwd)/comms/rcclx/snapshots" \
-    --rcclx-repo "$(pwd)/comms/rcclx" \
-    --header "$HEADER_PATH"
+    CONFIRM=$(echo "$CONFIRM" | tr '[:upper:]' '[:lower:]')
 
-echo "Snapshot created successfully for ROCm $ROCM_VERSION"
-echo ""
-echo "Generating stable_checksums.bzl from metadata files..."
+    if [[ "$CONFIRM" != "yes" ]]; then
+        echo "Operation cancelled by user."
+        exit 0
+    fi
 
-# Generate the checksums.bzl file from metadata
-buck2 run fbcode//comms/rcclx/snapshots/scripts:generate_checksums_bzl -- \
-    --snapshots-root "$(pwd)/comms/rcclx/snapshots" \
-    --output "$(pwd)/comms/rcclx/stable_checksums.bzl"
+    echo ""
+    echo "Proceeding with copy-stable operation..."
+    echo ""
 
-echo ""
-echo "✓ Snapshot creation completed successfully!"
-echo "  - Artifact uploaded to Manifold: rcclx_prebuilt_artifacts/tree/stable/$ROCM_VERSION/librcclx-dev.a"
-echo "  - Metadata saved to: comms/rcclx/snapshots/stable/$ROCM_VERSION/metadata.txt"
-echo "  - Checksums updated in: comms/rcclx/stable_checksums.bzl"
-echo ""
-echo "The BUCK file will automatically use the checksum from stable_checksums.bzl"
+    # Build the command
+    CMD="buck2 run fbcode//comms/rcclx/snapshots/scripts:create_snapshot -- \
+        --snapshots-root $(pwd)/comms/rcclx/snapshots \
+        --copy-stable"
+
+    if [[ -n "$ROCM_VERSIONS" ]]; then
+        CMD="$CMD --rocm-versions $ROCM_VERSIONS"
+    fi
+
+    if [[ -n "$EXTRA_ARGS" ]]; then
+        CMD="$CMD $EXTRA_ARGS"
+    fi
+
+    eval $CMD
+
+    echo ""
+    echo "Generating stable_checksums.bzl from metadata files..."
+
+    buck2 run fbcode//comms/rcclx/snapshots/scripts:generate_checksums_bzl -- \
+        --snapshots-root "$(pwd)/comms/rcclx/snapshots" \
+        --output "$(pwd)/comms/rcclx/stable_checksums.bzl"
+
+    echo ""
+    echo "✓ Copy-stable operation completed successfully!"
+    echo "  - Stable snapshots copied to last-stable"
+    echo "  - Checksums updated in: comms/rcclx/stable_checksums.bzl"
+
+else
+    # =====================================================================
+    # NORMAL SNAPSHOT CREATION MODE
+    # =====================================================================
+
+    # Display warning and ask for confirmation
+    echo ""
+    echo "╔════════════════════════════════════════════════════════════════════════════╗"
+    echo "║                              ⚠️  WARNING  ⚠️                                ║"
+    echo "╠════════════════════════════════════════════════════════════════════════════╣"
+    echo "║                                                                            ║"
+    echo "║  THIS SCRIPT WILL UPDATE THE MANIFOLD STABLE ARTIFACT REFERENCE!          ║"
+    echo "║                                                                            ║"
+    if [[ "$ONLY_STABLE" == "true" ]]; then
+        echo "║  Mode: ONLY-STABLE (last-stable will NOT be modified)                     ║"
+        echo "║                                                                            ║"
+        echo "║  The following operations will be performed:                               ║"
+        echo "║  1. Create a backup of all stable and last-stable artifacts                ║"
+        echo "║  2. Upload NEW artifact to stable in Manifold                              ║"
+        echo "║  3. Update stable metadata in repo                                         ║"
+        echo "║                                                                            ║"
+        echo "║  Last-stable will remain UNCHANGED.                                        ║"
+    else
+        echo "║  Mode: NORMAL (stable will rotate to last-stable)                          ║"
+        echo "║                                                                            ║"
+        echo "║  The following operations will be performed:                               ║"
+        echo "║  1. Create a backup of all stable and last-stable artifacts                ║"
+        echo "║  2. Move current stable to last-stable (Manifold + repo metadata)          ║"
+        echo "║  3. Upload NEW artifact to stable in Manifold                              ║"
+    fi
+    echo "║                                                                            ║"
+    echo "║  This will affect the stable artifact for ROCm ${ROCM_VERSION}                            ║"
+    echo "║                                                                            ║"
+    echo "╚════════════════════════════════════════════════════════════════════════════╝"
+    echo ""
+    read -r -p "Do you want to proceed? (yes/no): " CONFIRM
+
+    # Convert to lowercase for comparison
+    CONFIRM=$(echo "$CONFIRM" | tr '[:upper:]' '[:lower:]')
+
+    if [[ "$CONFIRM" != "yes" ]]; then
+        echo "Operation cancelled by user."
+        exit 0
+    fi
+
+    echo ""
+    echo "Proceeding with snapshot creation..."
+    echo ""
+
+    # Determine ROCm constraint
+    case $ROCM_VERSION in
+        6.2)
+            ROCM_CONSTRAINT="ovr_config//third-party/rocm/constraints:6.2.1"
+            ;;
+        6.4)
+            ROCM_CONSTRAINT="ovr_config//third-party/rocm/constraints:6.4.2"
+            ;;
+        7.0)
+            ROCM_CONSTRAINT="ovr_config//third-party/rocm/constraints:7.0"
+            ;;
+        *)
+            echo "Error: Unsupported ROCm version: $ROCM_VERSION"
+            echo "Supported versions: 6.2, 6.4, 7.0"
+            exit 1
+            ;;
+    esac
+
+    echo "Creating snapshot for ROCm $ROCM_VERSION..."
+    echo "Building rcclx-dev library..."
+    echo "Note: First-time builds will take 20-30 minutes as we build from source without cache"
+
+    # Build the rcclx-dev library
+    # Use --no-remote-cache to disable remote cache queries/writes
+    # Use --local-only to force local execution, preventing use of remote execution
+    # which could otherwise provide prebuilt artifacts. This ensures we always do a
+    # fresh local build when creating snapshots.
+    buck2 build @fbcode//mode/opt-amd-gpu -m rcclx_dev -m "$ROCM_CONSTRAINT" --no-remote-cache --local-only fbcode//comms/rcclx:rcclx-dev
+
+    # Get the library path from buck2 (relative to fbsource root)
+    LIBRARY_PATH_RELATIVE=$(buck2 build @fbcode//mode/opt-amd-gpu -m rcclx_dev -m "$ROCM_CONSTRAINT" fbcode//comms/rcclx:rcclx-dev --show-output | grep -oP 'fbcode//comms/rcclx:rcclx-dev\s+\K.*')
+
+    # Convert to absolute path (buck-out is at fbsource level, we're in fbcode)
+    LIBRARY_PATH="../$LIBRARY_PATH_RELATIVE"
+
+    if [[ ! -f "$LIBRARY_PATH" ]]; then
+        echo "Error: Could not find built library at $LIBRARY_PATH"
+        echo "Tried relative path: $LIBRARY_PATH_RELATIVE"
+        exit 1
+    fi
+
+    echo "Library built at: $LIBRARY_PATH"
+
+    # Define header path
+    HEADER_PATH="$(pwd)/comms/rcclx/develop/src/rccl.h"
+
+    if [[ ! -f "$HEADER_PATH" ]]; then
+        echo "Error: Could not find rccl.h header at $HEADER_PATH"
+        exit 1
+    fi
+
+    echo "Header found at: $HEADER_PATH"
+    echo "Running snapshot script..."
+
+    # Build extra args for only-stable mode
+    if [[ "$ONLY_STABLE" == "true" ]]; then
+        EXTRA_ARGS="$EXTRA_ARGS --only-stable"
+    fi
+
+    # Run the snapshot creation script using buck2 run to get proper Python dependencies
+    buck2 run fbcode//comms/rcclx/snapshots/scripts:create_snapshot -- \
+        --library "$LIBRARY_PATH" \
+        --rocm-version "$ROCM_VERSION" \
+        --snapshots-root "$(pwd)/comms/rcclx/snapshots" \
+        --rcclx-repo "$(pwd)/comms/rcclx" \
+        --header "$HEADER_PATH" \
+        $EXTRA_ARGS
+
+    echo "Snapshot created successfully for ROCm $ROCM_VERSION"
+    echo ""
+    echo "Generating stable_checksums.bzl from metadata files..."
+
+    # Generate the checksums.bzl file from metadata
+    buck2 run fbcode//comms/rcclx/snapshots/scripts:generate_checksums_bzl -- \
+        --snapshots-root "$(pwd)/comms/rcclx/snapshots" \
+        --output "$(pwd)/comms/rcclx/stable_checksums.bzl"
+
+    echo ""
+    echo "✓ Snapshot creation completed successfully!"
+    echo "  - Artifact uploaded to Manifold: rcclx_prebuilt_artifacts/tree/stable/$ROCM_VERSION/librcclx-dev.a"
+    echo "  - Metadata saved to: comms/rcclx/snapshots/stable/$ROCM_VERSION/metadata.txt"
+    echo "  - Checksums updated in: comms/rcclx/stable_checksums.bzl"
+    if [[ "$ONLY_STABLE" == "true" ]]; then
+        echo "  - Last-stable was NOT modified (--only-stable mode)"
+    fi
+    echo ""
+    echo "The BUCK file will automatically use the checksum from stable_checksums.bzl"
+fi

--- a/comms/rcclx/snapshots/scripts/restore_manifold_artifacts.py
+++ b/comms/rcclx/snapshots/scripts/restore_manifold_artifacts.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+# pyre-strict
+"""
+Script to restore rcclx prebuilt artifacts from a Manifold backup.
+
+This script restores stable and/or last-stable artifacts from a named
+backup location in Manifold archives back to their original locations.
+
+Backup structure in Manifold:
+  rcclx_prebuilt_artifacts/tree/archives/
+  └── backup_20260127_012000/
+      ├── stable/
+      │   ├── 6.2/librcclx-dev.a
+      │   ├── 6.4/librcclx-dev.a
+      │   └── 7.0/librcclx-dev.a
+      └── last_stable/
+          ├── 6.2/librcclx-dev.a
+          ├── 6.4/librcclx-dev.a
+          └── 7.0/librcclx-dev.a
+
+Usage:
+    # Restore both stable and last_stable from a backup
+    buck2 run fbcode//comms/rcclx/snapshots/scripts:restore_manifold_artifacts -- \\
+        --backup-name backup_20260127_012000
+
+    # Dry run to see what would be restored
+    buck2 run fbcode//comms/rcclx/snapshots/scripts:restore_manifold_artifacts -- \\
+        --backup-name backup_20260127_012000 \\
+        --dry-run
+
+    # Restore only stable artifacts
+    buck2 run fbcode//comms/rcclx/snapshots/scripts:restore_manifold_artifacts -- \\
+        --backup-name backup_20260127_012000 \\
+        --stages stable
+
+    # Restore only last_stable artifacts
+    buck2 run fbcode//comms/rcclx/snapshots/scripts:restore_manifold_artifacts -- \\
+        --backup-name backup_20260127_012000 \\
+        --stages last_stable
+
+    # Restore specific ROCm versions
+    buck2 run fbcode//comms/rcclx/snapshots/scripts:restore_manifold_artifacts -- \\
+        --backup-name backup_20260127_012000 \\
+        --rocm-versions 6.2,6.4
+"""
+
+import argparse
+import io
+import logging
+import sys
+from datetime import timedelta
+from typing import List
+
+from ai_infra.privacy_security.security.file_vault.meta.manifold_client.python import (
+    BarnFSManifoldClient,
+)
+from libfb.py.asyncio.await_utils import await_sync
+
+logging.basicConfig(level=logging.INFO)
+logger: logging.Logger = logging.getLogger(__name__)
+
+MANIFOLD_BUCKET: str = "rcclx_prebuilt_artifacts"
+MANIFOLD_PATH_PREFIX: str = "tree/"
+MANIFOLD_TIMEOUT_SEC: int = 600  # 10 minutes
+MANIFOLD_NUM_RETRIES: int = 10
+
+# Default ROCm versions
+DEFAULT_ROCM_VERSIONS: List[str] = ["6.2", "6.4", "7.0"]
+
+# Default stages to restore
+DEFAULT_STAGES: List[str] = ["stable", "last_stable"]
+
+# Library filename
+LIBRARY_NAME: str = "librcclx-dev.a"
+
+
+def get_manifold_path(stage: str, rocm_version: str, filename: str = "") -> str:
+    """
+    Construct a Manifold path for artifacts.
+
+    Args:
+        stage: One of 'stable', 'last_stable'
+        rocm_version: ROCm version (e.g., '6.2')
+        filename: Optional filename to append
+
+    Returns:
+        Full Manifold path (without bucket prefix)
+    """
+    if filename:
+        return f"{MANIFOLD_PATH_PREFIX}{stage}/{rocm_version}/{filename}"
+    return f"{MANIFOLD_PATH_PREFIX}{stage}/{rocm_version}"
+
+
+def get_backup_path(
+    backup_name: str, stage: str, rocm_version: str, filename: str = ""
+) -> str:
+    """
+    Construct a Manifold backup path for artifacts.
+
+    Args:
+        backup_name: Name of the backup directory (e.g., 'backup_20260127_012000')
+        stage: One of 'stable', 'last_stable'
+        rocm_version: ROCm version (e.g., '6.2')
+        filename: Optional filename to append
+
+    Returns:
+        Full Manifold backup path (without bucket prefix)
+    """
+    if filename:
+        return f"{MANIFOLD_PATH_PREFIX}archives/{backup_name}/{stage}/{rocm_version}/{filename}"
+    return f"{MANIFOLD_PATH_PREFIX}archives/{backup_name}/{stage}/{rocm_version}"
+
+
+def check_manifold_path_exists(manifold_path: str) -> bool:
+    """
+    Check if a path exists in Manifold.
+
+    Args:
+        manifold_path: Manifold path (without bucket prefix)
+
+    Returns:
+        True if path exists, False otherwise
+    """
+
+    async def async_exists() -> bool:
+        client = BarnFSManifoldClient.get_client(
+            bucket=MANIFOLD_BUCKET, apiKey=f"{MANIFOLD_BUCKET}-key"
+        )
+        with client:
+            return await client.exists(path=manifold_path)
+
+    return await_sync(async_exists())
+
+
+def copy_manifold_file(src_path: str, dst_path: str, overwrite: bool = True) -> bool:
+    """
+    Copy a file within Manifold by downloading and re-uploading.
+
+    Args:
+        src_path: Source Manifold path (without bucket prefix)
+        dst_path: Destination Manifold path (without bucket prefix)
+        overwrite: If True, delete existing destination file before copy
+
+    Returns:
+        True if successful, False if source doesn't exist
+    """
+
+    async def async_copy() -> bool:
+        client = BarnFSManifoldClient.get_client(
+            bucket=MANIFOLD_BUCKET, apiKey=f"{MANIFOLD_BUCKET}-key"
+        )
+        with client:
+            # Check if source exists
+            if not await client.exists(path=src_path):
+                return False
+
+            # Delete destination if it exists and overwrite is enabled
+            if overwrite and await client.exists(path=dst_path):
+                logger.info(f"  Deleting existing file at {dst_path}")
+                await client.rm(path=dst_path)
+
+            # Download from source
+            buffer = io.BytesIO()
+            await client.get(
+                path=src_path,
+                output=buffer,
+                timeout=timedelta(seconds=MANIFOLD_TIMEOUT_SEC),
+                numRetries=MANIFOLD_NUM_RETRIES,
+            )
+
+            # Upload to destination
+            buffer.seek(0)
+            await client.put(
+                path=dst_path,
+                input=buffer,
+                timeout=timedelta(seconds=MANIFOLD_TIMEOUT_SEC),
+                numRetries=MANIFOLD_NUM_RETRIES,
+            )
+
+            return True
+
+    return await_sync(async_copy())
+
+
+def restore_artifacts(
+    backup_name: str,
+    rocm_versions: List[str],
+    stages: List[str],
+    dry_run: bool = False,
+) -> None:
+    """
+    Restore artifacts from a backup location in Manifold.
+
+    Args:
+        backup_name: Name of the backup directory (e.g., 'backup_20260127_012000')
+        rocm_versions: List of ROCm versions to restore
+        stages: List of stages to restore ('stable', 'last_stable')
+        dry_run: If True, only log what would be done
+    """
+    backup_base_path = f"{MANIFOLD_PATH_PREFIX}archives/{backup_name}"
+
+    logger.info("=" * 60)
+    logger.info("Restoring artifacts from Manifold backup")
+    logger.info("=" * 60)
+    logger.info(f"Backup name: {backup_name}")
+    logger.info(f"Backup path: {MANIFOLD_BUCKET}/{backup_base_path}/")
+    logger.info(f"ROCm versions: {', '.join(rocm_versions)}")
+    logger.info(f"Stages: {', '.join(stages)}")
+    logger.info(f"Dry run: {dry_run}")
+    logger.info("")
+
+    total_restored = 0
+    total_missing = 0
+    total_failed = 0
+
+    for stage in stages:
+        for rocm_version in rocm_versions:
+            src_path = get_backup_path(backup_name, stage, rocm_version, LIBRARY_NAME)
+            dst_path = get_manifold_path(stage, rocm_version, LIBRARY_NAME)
+
+            logger.info(f"Restoring {stage}/{rocm_version}/{LIBRARY_NAME}...")
+
+            if dry_run:
+                if check_manifold_path_exists(src_path):
+                    logger.info(f"  [DRY RUN] Would copy from {src_path} to {dst_path}")
+                    total_restored += 1
+                else:
+                    logger.warning(f"  [DRY RUN] Backup not found: {src_path}")
+                    total_missing += 1
+            else:
+                try:
+                    if copy_manifold_file(src_path, dst_path):
+                        logger.info(f"  -> Restored to {dst_path}")
+                        total_restored += 1
+                    else:
+                        logger.warning(f"  -> Backup not found: {src_path}")
+                        total_missing += 1
+                except Exception as e:
+                    logger.error(f"  -> Error restoring: {e}")
+                    total_failed += 1
+
+    logger.info("")
+    logger.info("=" * 60)
+    logger.info("Restore Summary")
+    logger.info("=" * 60)
+    logger.info(f"Total restored: {total_restored}")
+    logger.info(f"Total missing (not in backup): {total_missing}")
+    logger.info(f"Total failed: {total_failed}")
+
+    if dry_run:
+        logger.info("")
+        logger.info("This was a dry run. No changes were made to Manifold.")
+        logger.info("Run without --dry-run to apply changes.")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Restore rcclx prebuilt artifacts from Manifold backup"
+    )
+    parser.add_argument(
+        "--backup-name",
+        type=str,
+        required=True,
+        help="Name of the backup directory (e.g., 'backup_20260127_012000')",
+    )
+    parser.add_argument(
+        "--rocm-versions",
+        type=str,
+        default=",".join(DEFAULT_ROCM_VERSIONS),
+        help=f"Comma-separated list of ROCm versions (default: {','.join(DEFAULT_ROCM_VERSIONS)})",
+    )
+    parser.add_argument(
+        "--stages",
+        type=str,
+        default=",".join(DEFAULT_STAGES),
+        help=f"Comma-separated list of stages to restore (default: {','.join(DEFAULT_STAGES)})",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Only log what would be done, without making changes to Manifold",
+    )
+
+    args = parser.parse_args()
+
+    # Parse ROCm versions
+    rocm_versions = [v.strip() for v in args.rocm_versions.split(",") if v.strip()]
+
+    if not rocm_versions:
+        logger.error("No ROCm versions specified")
+        return 1
+
+    # Parse stages
+    stages = [s.strip() for s in args.stages.split(",") if s.strip()]
+
+    if not stages:
+        logger.error("No stages specified")
+        return 1
+
+    # Validate stages
+    valid_stages = {"stable", "last_stable"}
+    for stage in stages:
+        if stage not in valid_stages:
+            logger.error(f"Invalid stage: {stage}. Valid stages: {valid_stages}")
+            return 1
+
+    try:
+        restore_artifacts(
+            backup_name=args.backup_name,
+            rocm_versions=rocm_versions,
+            stages=stages,
+            dry_run=args.dry_run,
+        )
+        return 0
+    except Exception as e:
+        logger.error(f"Error: {e}", exc_info=True)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Summary:
This diff adds comprehensive backup/restore capabilities and new snapshot management options to the rcclx snapshot infrastructure.

# New Scripts
backup_manifold_artifacts.py - Creates timestamped backups of all stable and last-stable artifacts within Manifold at archives/backup_<timestamp>/. Prints the backup name for use with restore.

restore_manifold_artifacts.py - Restores stable and/or last-stable artifacts from a named Manifold backup. Supports --stages to restore only stable or last_stable, and --dry-run for preview.

# New Options for create_snapshot.py
Option	Description
--copy-stable	Copy current stable to last-stable for all ROCm versions without building new snapshots
--only-stable	Update only stable snapshot, leaving last-stable unchanged
--skip-backup	Skip the automatic backup step (not recommended)
--rocm-versions	Specify ROCm versions for --copy-stable mode
Simplified Architecture
Removed old archive rotation scheme - The per-version archiving (moving last-stable to archives/<version>/<timestamp>_*) has been removed in favor of the new unified backup mechanism
Automatic backup before changes - Every snapshot operation now creates a full backup checkpoint first, providing a consistent recovery point
Backup-based recovery - Use restore_manifold_artifacts.py to restore from any backup checkpoint
Updated create_snapshot_wrapper.sh
The shell wrapper script now supports all new options:

**Normal mode (rotates stable to last-stable)**
./create_snapshot_wrapper.sh --rocm-version 6.4

**Only update stable (last-stable unchanged)**
./create_snapshot_wrapper.sh --rocm-version 6.4 --only-stable

**Copy stable to last-stable (no build)**
./create_snapshot_wrapper.sh --copy-stable

**Copy for specific versions**
./create_snapshot_wrapper.sh --copy-stable --rocm-versions 6.4,7.0

# Updated BUCK and README
Added build targets for new scripts in BUCK file
Comprehensive README documentation with usage examples, options table, and disaster recovery workflows

Reviewed By: dmwu

Differential Revision: D91547031


