### PR TITLE
Fix finalize assertion for aborted communicators

### DIFF
--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -245,9 +245,13 @@ void TorchCommNCCLX::init(
 }
 
 void TorchCommNCCLX::finalize() {
+  // If initialized and in normal state, nccl_comm_ must be valid.
+  // However, if comm was aborted (ERROR or TIMEOUT state), nccl_comm_ will be
+  // null.
   TORCH_INTERNAL_ASSERT(
-      init_state_ != InitializationState::INITIALIZED || nccl_comm_ != nullptr,
-      "nccl_comm_ is null but state indicates we are initialized");
+      init_state_ != InitializationState::INITIALIZED ||
+          comm_state_ != CommState::NORMAL || nccl_comm_ != nullptr,
+      "nccl_comm_ is null but state indicates we are initialized and not aborted");
 
   if (init_state_ == InitializationState::UNINITIALIZED) {
     throw std::runtime_error("TorchCommNCCLX not initialized");


### PR DESCRIPTION
Summary:
The assertion in finalize() was too strict - it didn't account for the
case where the comm was aborted due to an error or timeout. After an
abort, nccl_comm_ is set to nullptr but init_state_ remains INITIALIZED.

Updated the assertion to only check that nccl_comm_ is non-null when
init_state_ is INITIALIZED AND comm_state_ is NORMAL. If the comm was
aborted (ERROR or TIMEOUT state), nccl_comm_ will be null, which is
expected.

This fixes tests like WorkErrorCausesAbortDuringCollective that call
finalize() after the comm has been aborted.

Differential Revision: D91556119


