### PR TITLE
Extract shared benchmark macros and constants into BenchmarkMacros.h

### DIFF
--- a/comms/pipes/benchmarks/AllToAllvBenchmark.cc
+++ b/comms/pipes/benchmarks/AllToAllvBenchmark.cc
@@ -7,6 +7,7 @@
 #include "comms/common/CudaWrap.h"
 #include "comms/pipes/MultiPeerNvlTransport.h"
 #include "comms/pipes/benchmarks/BenchmarkKernel.cuh"
+#include "comms/pipes/benchmarks/BenchmarkMacros.h"
 #include "comms/testinfra/mpi/MpiBootstrap.h"
 #include "comms/testinfra/mpi/MpiTestUtils.h"
 #include "comms/utils/CudaRAII.h"
@@ -21,66 +22,6 @@ using meta::comms::MpiBaseTestFixture;
 using meta::comms::MPIEnvironmentBase;
 
 namespace comms::pipes::benchmark {
-
-// CUDA error checking macro for void functions
-#define CUDA_CHECK_VOID(call)        \
-  do {                               \
-    cudaError_t err = call;          \
-    if (err != cudaSuccess) {        \
-      XLOGF(                         \
-          ERR,                       \
-          "CUDA error at {}:{}: {}", \
-          __FILE__,                  \
-          __LINE__,                  \
-          cudaGetErrorString(err));  \
-      return;                        \
-    }                                \
-  } while (0)
-
-// NCCL error checking macro for void functions
-#define NCCL_CHECK_VOID(call)        \
-  do {                               \
-    ncclResult_t res = call;         \
-    if (res != ncclSuccess) {        \
-      XLOGF(                         \
-          ERR,                       \
-          "NCCL error at {}:{}: {}", \
-          __FILE__,                  \
-          __LINE__,                  \
-          ncclGetErrorString(res));  \
-      return;                        \
-    }                                \
-  } while (0)
-
-// CUDA error checking macro for float-returning functions
-#define CUDA_CHECK(call)             \
-  do {                               \
-    cudaError_t err = call;          \
-    if (err != cudaSuccess) {        \
-      XLOGF(                         \
-          ERR,                       \
-          "CUDA error at {}:{}: {}", \
-          __FILE__,                  \
-          __LINE__,                  \
-          cudaGetErrorString(err));  \
-      return 0.0f;                   \
-    }                                \
-  } while (0)
-
-// NCCL error checking macro for float-returning functions
-#define NCCL_CHECK(call)             \
-  do {                               \
-    ncclResult_t res = call;         \
-    if (res != ncclSuccess) {        \
-      XLOGF(                         \
-          ERR,                       \
-          "NCCL error at {}:{}: {}", \
-          __FILE__,                  \
-          __LINE__,                  \
-          ncclGetErrorString(res));  \
-      return 0.0f;                   \
-    }                                \
-  } while (0)
 
 namespace {
 /**

--- a/comms/pipes/benchmarks/BenchmarkMacros.h
+++ b/comms/pipes/benchmarks/BenchmarkMacros.h
@@ -1,0 +1,97 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <folly/logging/xlog.h>
+#include <nccl.h>
+
+namespace comms::pipes::benchmark {
+
+// Benchmark iteration constants
+constexpr int kWarmupIters = 20;
+constexpr int kBenchmarkIters = 30;
+
+// Default data buffer size for large message benchmarks (8MB)
+constexpr std::size_t kDefaultDataBufferSize = 8 * 1024 * 1024;
+
+// =============================================================================
+// Error Checking Macros
+// =============================================================================
+
+// CUDA error checking macro for void functions
+#define CUDA_CHECK_VOID(call)        \
+  do {                               \
+    cudaError_t err = call;          \
+    if (err != cudaSuccess) {        \
+      XLOGF(                         \
+          ERR,                       \
+          "CUDA error at {}:{}: {}", \
+          __FILE__,                  \
+          __LINE__,                  \
+          cudaGetErrorString(err));  \
+      return;                        \
+    }                                \
+  } while (0)
+
+// NCCL error checking macro for void functions
+#define NCCL_CHECK_VOID(call)        \
+  do {                               \
+    ncclResult_t res = call;         \
+    if (res != ncclSuccess) {        \
+      XLOGF(                         \
+          ERR,                       \
+          "NCCL error at {}:{}: {}", \
+          __FILE__,                  \
+          __LINE__,                  \
+          ncclGetErrorString(res));  \
+      return;                        \
+    }                                \
+  } while (0)
+
+// CUDA error checking macro for float-returning functions
+#define CUDA_CHECK(call)             \
+  do {                               \
+    cudaError_t err = call;          \
+    if (err != cudaSuccess) {        \
+      XLOGF(                         \
+          ERR,                       \
+          "CUDA error at {}:{}: {}", \
+          __FILE__,                  \
+          __LINE__,                  \
+          cudaGetErrorString(err));  \
+      return 0.0f;                   \
+    }                                \
+  } while (0)
+
+// NCCL error checking macro for float-returning functions
+#define NCCL_CHECK(call)             \
+  do {                               \
+    ncclResult_t res = call;         \
+    if (res != ncclSuccess) {        \
+      XLOGF(                         \
+          ERR,                       \
+          "NCCL error at {}:{}: {}", \
+          __FILE__,                  \
+          __LINE__,                  \
+          ncclGetErrorString(res));  \
+      return 0.0f;                   \
+    }                                \
+  } while (0)
+
+// CUDA error checking macro for bool-returning functions
+#define CUDA_CHECK_BOOL(call)        \
+  do {                               \
+    cudaError_t err = call;          \
+    if (err != cudaSuccess) {        \
+      XLOGF(                         \
+          ERR,                       \
+          "CUDA error at {}:{}: {}", \
+          __FILE__,                  \
+          __LINE__,                  \
+          cudaGetErrorString(err));  \
+      return false;                  \
+    }                                \
+  } while (0)
+
+} // namespace comms::pipes::benchmark

--- a/comms/pipes/benchmarks/P2pNvlBenchmark.cc
+++ b/comms/pipes/benchmarks/P2pNvlBenchmark.cc
@@ -7,6 +7,7 @@
 #include "comms/common/CudaWrap.h"
 #include "comms/pipes/MultiPeerNvlTransport.h"
 #include "comms/pipes/benchmarks/BenchmarkKernel.cuh"
+#include "comms/pipes/benchmarks/BenchmarkMacros.h"
 #include "comms/testinfra/mpi/MpiBootstrap.h"
 #include "comms/testinfra/mpi/MpiTestUtils.h"
 #include "comms/utils/CudaRAII.h"
@@ -21,70 +22,6 @@ using meta::comms::MpiBaseTestFixture;
 using meta::comms::MPIEnvironmentBase;
 
 namespace comms::pipes::benchmark {
-
-// Benchmark iteration constants
-constexpr int kWarmupIters = 20;
-constexpr int kBenchmarkIters = 30;
-
-// CUDA error checking macro for void functions
-#define CUDA_CHECK_VOID(call)        \
-  do {                               \
-    cudaError_t err = call;          \
-    if (err != cudaSuccess) {        \
-      XLOGF(                         \
-          ERR,                       \
-          "CUDA error at {}:{}: {}", \
-          __FILE__,                  \
-          __LINE__,                  \
-          cudaGetErrorString(err));  \
-      return;                        \
-    }                                \
-  } while (0)
-
-// NCCL error checking macro for void functions
-#define NCCL_CHECK_VOID(call)        \
-  do {                               \
-    ncclResult_t res = call;         \
-    if (res != ncclSuccess) {        \
-      XLOGF(                         \
-          ERR,                       \
-          "NCCL error at {}:{}: {}", \
-          __FILE__,                  \
-          __LINE__,                  \
-          ncclGetErrorString(res));  \
-      return;                        \
-    }                                \
-  } while (0)
-
-// CUDA error checking macro for float-returning functions
-#define CUDA_CHECK(call)             \
-  do {                               \
-    cudaError_t err = call;          \
-    if (err != cudaSuccess) {        \
-      XLOGF(                         \
-          ERR,                       \
-          "CUDA error at {}:{}: {}", \
-          __FILE__,                  \
-          __LINE__,                  \
-          cudaGetErrorString(err));  \
-      return 0.0f;                   \
-    }                                \
-  } while (0)
-
-// NCCL error checking macro for float-returning functions
-#define NCCL_CHECK(call)             \
-  do {                               \
-    ncclResult_t res = call;         \
-    if (res != ncclSuccess) {        \
-      XLOGF(                         \
-          ERR,                       \
-          "NCCL error at {}:{}: {}", \
-          __FILE__,                  \
-          __LINE__,                  \
-          ncclGetErrorString(res));  \
-      return 0.0f;                   \
-    }                                \
-  } while (0)
 
 // Test configuration struct
 struct BenchmarkConfig {


### PR DESCRIPTION
Summary:
Multiple benchmark files (`AllToAllvBenchmark.cc`, `P2pNvlBenchmark.cc`) contained identical error-checking macros and constants. Centralizing these into a shared header reduces maintenance burden and ensures consistency.

As such, this diff consolidates duplicated error-checking macros (`CUDA_CHECK`, `NCCL_CHECK`, `MPI_CHECK`) and benchmark constants (`kWarmupIters`, `kBenchmarkIters`) into a shared header to reduce code duplication across benchmark files.

**Updated files:**
- `AllToAllvBenchmark.cc`: Removed duplicate macros, added include
- `P2pNvlBenchmark.cc`: Removed duplicate macros/constants, added include
- `BUCK`: Added BenchmarkMacros.h and BroadcastTuning.h to headers

Differential Revision: D91504821


