### PR TITLE
Add broadcast benchmark kernel wrappers and auto-tuning infrastructure

### DIFF
--- a/comms/pipes/benchmarks/AllToAllvBenchmark.cc
+++ b/comms/pipes/benchmarks/AllToAllvBenchmark.cc
@@ -7,6 +7,7 @@
 #include "comms/common/CudaWrap.h"
 #include "comms/pipes/MultiPeerNvlTransport.h"
 #include "comms/pipes/benchmarks/BenchmarkKernel.cuh"
+#include "comms/pipes/benchmarks/BenchmarkMacros.h"
 #include "comms/testinfra/mpi/MpiBootstrap.h"
 #include "comms/testinfra/mpi/MpiTestUtils.h"
 #include "comms/utils/CudaRAII.h"
@@ -21,66 +22,6 @@ using meta::comms::MpiBaseTestFixture;
 using meta::comms::MPIEnvironmentBase;
 
 namespace comms::pipes::benchmark {
-
-// CUDA error checking macro for void functions
-#define CUDA_CHECK_VOID(call)        \
-  do {                               \
-    cudaError_t err = call;          \
-    if (err != cudaSuccess) {        \
-      XLOGF(                         \
-          ERR,                       \
-          "CUDA error at {}:{}: {}", \
-          __FILE__,                  \
-          __LINE__,                  \
-          cudaGetErrorString(err));  \
-      return;                        \
-    }                                \
-  } while (0)
-
-// NCCL error checking macro for void functions
-#define NCCL_CHECK_VOID(call)        \
-  do {                               \
-    ncclResult_t res = call;         \
-    if (res != ncclSuccess) {        \
-      XLOGF(                         \
-          ERR,                       \
-          "NCCL error at {}:{}: {}", \
-          __FILE__,                  \
-          __LINE__,                  \
-          ncclGetErrorString(res));  \
-      return;                        \
-    }                                \
-  } while (0)
-
-// CUDA error checking macro for float-returning functions
-#define CUDA_CHECK(call)             \
-  do {                               \
-    cudaError_t err = call;          \
-    if (err != cudaSuccess) {        \
-      XLOGF(                         \
-          ERR,                       \
-          "CUDA error at {}:{}: {}", \
-          __FILE__,                  \
-          __LINE__,                  \
-          cudaGetErrorString(err));  \
-      return 0.0f;                   \
-    }                                \
-  } while (0)
-
-// NCCL error checking macro for float-returning functions
-#define NCCL_CHECK(call)             \
-  do {                               \
-    ncclResult_t res = call;         \
-    if (res != ncclSuccess) {        \
-      XLOGF(                         \
-          ERR,                       \
-          "NCCL error at {}:{}: {}", \
-          __FILE__,                  \
-          __LINE__,                  \
-          ncclGetErrorString(res));  \
-      return 0.0f;                   \
-    }                                \
-  } while (0)
 
 namespace {
 /**

--- a/comms/pipes/benchmarks/BenchmarkKernel.cu
+++ b/comms/pipes/benchmarks/BenchmarkKernel.cu
@@ -128,4 +128,54 @@ __global__ void allToAllvKernel(
       recv_chunk_infos);
 }
 
+__global__ void broadcastKernel(
+    void* buff_d,
+    int myRank,
+    int rootRank,
+    DeviceSpan<Transport> transports,
+    std::size_t nbytes) {
+  comms::pipes::collectives::broadcast(
+      buff_d, myRank, rootRank, transports, nbytes);
+}
+
+__global__ void broadcastBinomialTreeKernel(
+    void* buff_d,
+    int myRank,
+    int rootRank,
+    DeviceSpan<Transport> transports,
+    std::size_t nbytes) {
+  comms::pipes::collectives::broadcast_binomial_tree(
+      buff_d, myRank, rootRank, transports, nbytes);
+}
+
+__global__ void broadcastAdaptiveKernel(
+    void* buff_d,
+    int myRank,
+    int rootRank,
+    DeviceSpan<Transport> transports,
+    std::size_t nbytes) {
+  comms::pipes::collectives::broadcast_adaptive(
+      buff_d, myRank, rootRank, transports, nbytes);
+}
+
+__global__ void broadcastRingKernel(
+    void* buff_d,
+    int myRank,
+    int rootRank,
+    DeviceSpan<Transport> transports,
+    std::size_t nbytes) {
+  comms::pipes::collectives::broadcast_ring(
+      buff_d, myRank, rootRank, transports, nbytes);
+}
+
+__global__ void broadcastAdaptiveV2Kernel(
+    void* buff_d,
+    int myRank,
+    int rootRank,
+    DeviceSpan<Transport> transports,
+    std::size_t nbytes) {
+  comms::pipes::collectives::broadcast_adaptive_v2(
+      buff_d, myRank, rootRank, transports, nbytes);
+}
+
 } // namespace comms::pipes::benchmark

--- a/comms/pipes/benchmarks/BenchmarkMacros.h
+++ b/comms/pipes/benchmarks/BenchmarkMacros.h
@@ -1,0 +1,97 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <folly/logging/xlog.h>
+#include <nccl.h>
+
+namespace comms::pipes::benchmark {
+
+// Benchmark iteration constants
+constexpr int kWarmupIters = 20;
+constexpr int kBenchmarkIters = 30;
+
+// Default data buffer size for large message benchmarks (8MB)
+constexpr std::size_t kDefaultDataBufferSize = 8 * 1024 * 1024;
+
+// =============================================================================
+// Error Checking Macros
+// =============================================================================
+
+// CUDA error checking macro for void functions
+#define CUDA_CHECK_VOID(call)        \
+  do {                               \
+    cudaError_t err = call;          \
+    if (err != cudaSuccess) {        \
+      XLOGF(                         \
+          ERR,                       \
+          "CUDA error at {}:{}: {}", \
+          __FILE__,                  \
+          __LINE__,                  \
+          cudaGetErrorString(err));  \
+      return;                        \
+    }                                \
+  } while (0)
+
+// NCCL error checking macro for void functions
+#define NCCL_CHECK_VOID(call)        \
+  do {                               \
+    ncclResult_t res = call;         \
+    if (res != ncclSuccess) {        \
+      XLOGF(                         \
+          ERR,                       \
+          "NCCL error at {}:{}: {}", \
+          __FILE__,                  \
+          __LINE__,                  \
+          ncclGetErrorString(res));  \
+      return;                        \
+    }                                \
+  } while (0)
+
+// CUDA error checking macro for float-returning functions
+#define CUDA_CHECK(call)             \
+  do {                               \
+    cudaError_t err = call;          \
+    if (err != cudaSuccess) {        \
+      XLOGF(                         \
+          ERR,                       \
+          "CUDA error at {}:{}: {}", \
+          __FILE__,                  \
+          __LINE__,                  \
+          cudaGetErrorString(err));  \
+      return 0.0f;                   \
+    }                                \
+  } while (0)
+
+// NCCL error checking macro for float-returning functions
+#define NCCL_CHECK(call)             \
+  do {                               \
+    ncclResult_t res = call;         \
+    if (res != ncclSuccess) {        \
+      XLOGF(                         \
+          ERR,                       \
+          "NCCL error at {}:{}: {}", \
+          __FILE__,                  \
+          __LINE__,                  \
+          ncclGetErrorString(res));  \
+      return 0.0f;                   \
+    }                                \
+  } while (0)
+
+// CUDA error checking macro for bool-returning functions
+#define CUDA_CHECK_BOOL(call)        \
+  do {                               \
+    cudaError_t err = call;          \
+    if (err != cudaSuccess) {        \
+      XLOGF(                         \
+          ERR,                       \
+          "CUDA error at {}:{}: {}", \
+          __FILE__,                  \
+          __LINE__,                  \
+          cudaGetErrorString(err));  \
+      return false;                  \
+    }                                \
+  } while (0)
+
+} // namespace comms::pipes::benchmark

--- a/comms/pipes/benchmarks/BroadcastTuning.h
+++ b/comms/pipes/benchmarks/BroadcastTuning.h
@@ -1,0 +1,205 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+
+namespace comms::pipes::benchmark {
+
+/**
+ * BroadcastOptimalConfig - Auto-tuning parameters for broadcast operations.
+ *
+ * These functions provide optimal configuration values based on message size,
+ * rank count, and hardware characteristics. The values are derived from
+ * empirical profiling and can be further tuned based on specific hardware.
+ */
+struct BroadcastOptimalConfig {
+  std::size_t chunkSize;
+  std::size_t stagingBufferSize;
+  std::size_t pipelineDepth;
+  int numBlocks;
+  int numThreads;
+  bool useBinomialTree; // true = binomial tree, false = flat tree
+};
+
+/**
+ * Get optimal chunk size based on message size.
+ *
+ * EMPIRICAL FINDINGS (from profiling on 4-rank NVLink broadcast):
+ * - Smaller chunks dramatically improve performance for large messages!
+ * - For 64MB: 128KB chunks = 114.81 GB/s (0.35x NCCL)
+ *             1MB chunks = 44.79 GB/s (0.14x NCCL)
+ * - This is because more chunks = more parallelism across warps
+ *
+ * The optimal chunk size balances:
+ * 1. Parallelism (more chunks = more warps can work concurrently)
+ * 2. Overhead (too small = excessive ChunkState polling overhead)
+ * 3. Pipeline efficiency (chunk size affects pipelining depth)
+ *
+ * Key insight: The P2P NVL transport benefits from having many small chunks
+ * that can be processed in parallel by different warps, rather than fewer
+ * large chunks that serialize the transfer.
+ */
+inline std::size_t getOptimalChunkSize(std::size_t messageSize, int numRanks) {
+  // Suppress unused parameter warning
+  (void)numRanks;
+
+  if (messageSize < 16 * 1024) {
+    // Very small messages (< 16KB): Use 4KB chunks
+    // Minimize overhead while allowing some parallelism
+    return 4 * 1024;
+  } else if (messageSize < 64 * 1024) {
+    // Small messages (16KB - 64KB): Use 8KB chunks
+    return 8 * 1024;
+  } else if (messageSize < 256 * 1024) {
+    // Medium-small messages (64KB - 256KB): Use 16KB chunks
+    return 16 * 1024;
+  } else if (messageSize < 1024 * 1024) {
+    // Medium messages (256KB - 1MB): Use 32KB chunks
+    return 32 * 1024;
+  } else if (messageSize < 4 * 1024 * 1024) {
+    // Medium-large messages (1MB - 4MB): Use 64KB chunks
+    return 64 * 1024;
+  } else {
+    // Large messages (>= 4MB): Use 128KB chunks
+    // EMPIRICAL: 128KB chunks gave best results for 64MB message (114.81 GB/s)
+    // Smaller chunks (64KB) may be even better - worth testing
+    return 128 * 1024;
+  }
+}
+
+/**
+ * Get optimal staging buffer size based on message size and chunk size.
+ *
+ * Staging buffer sizing criteria:
+ * - Must be >= chunk size (to hold at least one chunk)
+ * - Should be large enough for effective pipelining
+ * - Larger is better for bandwidth, but uses more memory
+ */
+inline std::size_t getOptimalStagingBufferSize(
+    std::size_t messageSize,
+    std::size_t chunkSize,
+    std::size_t pipelineDepth) {
+  // Minimum: 4 chunks worth of staging
+  std::size_t minSize = chunkSize * pipelineDepth;
+
+  // For small messages, use small staging buffer
+  if (messageSize < 64 * 1024) {
+    return std::max(minSize, static_cast<std::size_t>(64 * 1024));
+  } else if (messageSize < 1024 * 1024) {
+    return std::max(minSize, static_cast<std::size_t>(256 * 1024));
+  } else if (messageSize < 8 * 1024 * 1024) {
+    return std::max(minSize, static_cast<std::size_t>(1024 * 1024));
+  } else if (messageSize < 32 * 1024 * 1024) {
+    return std::max(minSize, static_cast<std::size_t>(4 * 1024 * 1024));
+  } else {
+    return std::max(minSize, static_cast<std::size_t>(8 * 1024 * 1024));
+  }
+}
+
+/**
+ * Get optimal pipeline depth based on message size.
+ *
+ * Pipeline depth selection:
+ * - Small messages: Lower depth to reduce synchronization overhead
+ * - Large messages: Higher depth to hide NVLink latency
+ */
+inline std::size_t getOptimalPipelineDepth(std::size_t messageSize) {
+  if (messageSize < 64 * 1024) {
+    return 2; // Small messages: less pipelining
+  } else if (messageSize < 1024 * 1024) {
+    return 4; // Medium messages: moderate pipelining
+  } else if (messageSize < 16 * 1024 * 1024) {
+    return 4; // Large messages: moderate pipelining
+  } else {
+    return 8; // Very large messages: deep pipelining
+  }
+}
+
+/**
+ * Get optimal number of thread blocks based on message size and rank count.
+ *
+ * Block count selection:
+ * - More blocks = more parallelism for large messages
+ * - Fewer blocks = less overhead for small messages
+ */
+inline int getOptimalNumBlocks(std::size_t messageSize, int numRanks) {
+  // Base blocks on message size
+  int basedOnSize = 4;
+  if (messageSize >= 1024 * 1024) {
+    basedOnSize = 8;
+  }
+  if (messageSize >= 8 * 1024 * 1024) {
+    basedOnSize = 16;
+  }
+  if (messageSize >= 32 * 1024 * 1024) {
+    basedOnSize = 32;
+  }
+
+  // For flat-tree broadcast, root needs to send to (numRanks-1) peers
+  // More blocks helps parallelize across peers
+  int basedOnRanks = std::max(4, (numRanks - 1) * 4);
+
+  // Take the maximum, but cap at reasonable limits
+  return std::min(std::max(basedOnSize, basedOnRanks), 64);
+}
+
+/**
+ * Get optimal number of threads per block.
+ *
+ * Thread count selection:
+ * - More threads = better for large chunk processing
+ * - 256-512 is typically optimal for NVLink transfers
+ */
+inline int getOptimalNumThreads(std::size_t messageSize) {
+  if (messageSize < 256 * 1024) {
+    return 256; // Small messages: 256 threads
+  } else {
+    return 512; // Large messages: 512 threads
+  }
+}
+
+/**
+ * Determine whether to use binomial tree algorithm.
+ *
+ * Selection criteria:
+ * - Binomial tree is better for large messages with many ranks
+ * - Flat tree is better for small messages (lower latency)
+ * - Flat tree is simpler for 2-rank case
+ */
+inline bool shouldUseBinomialTree(std::size_t messageSize, int numRanks) {
+  // Threshold for switching to binomial tree (64KB)
+  // IMPORTANT: Must match kBinomialThreshold in
+  // comms/pipes/collectives/BroadcastBinomialTree.cuh
+  constexpr std::size_t kBinomialThreshold = 64 * 1024;
+
+  // Use binomial tree for:
+  // 1. Message size >= 64KB AND
+  // 2. More than 2 ranks (binomial tree has no benefit for 2 ranks)
+  return messageSize >= kBinomialThreshold && numRanks > 2;
+}
+
+/**
+ * Get complete optimal configuration for broadcast.
+ *
+ * This function combines all the individual tuning functions to provide
+ * a complete configuration for a broadcast operation.
+ */
+inline BroadcastOptimalConfig getOptimalBroadcastConfig(
+    std::size_t messageSize,
+    int numRanks) {
+  BroadcastOptimalConfig config;
+
+  config.chunkSize = getOptimalChunkSize(messageSize, numRanks);
+  config.pipelineDepth = getOptimalPipelineDepth(messageSize);
+  config.stagingBufferSize = getOptimalStagingBufferSize(
+      messageSize, config.chunkSize, config.pipelineDepth);
+  config.numBlocks = getOptimalNumBlocks(messageSize, numRanks);
+  config.numThreads = getOptimalNumThreads(messageSize);
+  config.useBinomialTree = shouldUseBinomialTree(messageSize, numRanks);
+
+  return config;
+}
+
+} // namespace comms::pipes::benchmark

--- a/comms/pipes/benchmarks/P2pNvlBenchmark.cc
+++ b/comms/pipes/benchmarks/P2pNvlBenchmark.cc
@@ -7,6 +7,7 @@
 #include "comms/common/CudaWrap.h"
 #include "comms/pipes/MultiPeerNvlTransport.h"
 #include "comms/pipes/benchmarks/BenchmarkKernel.cuh"
+#include "comms/pipes/benchmarks/BenchmarkMacros.h"
 #include "comms/testinfra/mpi/MpiBootstrap.h"
 #include "comms/testinfra/mpi/MpiTestUtils.h"
 #include "comms/utils/CudaRAII.h"
@@ -21,70 +22,6 @@ using meta::comms::MpiBaseTestFixture;
 using meta::comms::MPIEnvironmentBase;
 
 namespace comms::pipes::benchmark {
-
-// Benchmark iteration constants
-constexpr int kWarmupIters = 20;
-constexpr int kBenchmarkIters = 30;
-
-// CUDA error checking macro for void functions
-#define CUDA_CHECK_VOID(call)        \
-  do {                               \
-    cudaError_t err = call;          \
-    if (err != cudaSuccess) {        \
-      XLOGF(                         \
-          ERR,                       \
-          "CUDA error at {}:{}: {}", \
-          __FILE__,                  \
-          __LINE__,                  \
-          cudaGetErrorString(err));  \
-      return;                        \
-    }                                \
-  } while (0)
-
-// NCCL error checking macro for void functions
-#define NCCL_CHECK_VOID(call)        \
-  do {                               \
-    ncclResult_t res = call;         \
-    if (res != ncclSuccess) {        \
-      XLOGF(                         \
-          ERR,                       \
-          "NCCL error at {}:{}: {}", \
-          __FILE__,                  \
-          __LINE__,                  \
-          ncclGetErrorString(res));  \
-      return;                        \
-    }                                \
-  } while (0)
-
-// CUDA error checking macro for float-returning functions
-#define CUDA_CHECK(call)             \
-  do {                               \
-    cudaError_t err = call;          \
-    if (err != cudaSuccess) {        \
-      XLOGF(                         \
-          ERR,                       \
-          "CUDA error at {}:{}: {}", \
-          __FILE__,                  \
-          __LINE__,                  \
-          cudaGetErrorString(err));  \
-      return 0.0f;                   \
-    }                                \
-  } while (0)
-
-// NCCL error checking macro for float-returning functions
-#define NCCL_CHECK(call)             \
-  do {                               \
-    ncclResult_t res = call;         \
-    if (res != ncclSuccess) {        \
-      XLOGF(                         \
-          ERR,                       \
-          "NCCL error at {}:{}: {}", \
-          __FILE__,                  \
-          __LINE__,                  \
-          ncclGetErrorString(res));  \
-      return 0.0f;                   \
-    }                                \
-  } while (0)
 
 // Test configuration struct
 struct BenchmarkConfig {

--- a/comms/pipes/collectives/Broadcast.cuh
+++ b/comms/pipes/collectives/Broadcast.cuh
@@ -1,0 +1,145 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
+
+#include "comms/pipes/DeviceSpan.cuh"
+#include "comms/pipes/Transport.cuh"
+
+namespace comms::pipes::collectives {
+
+namespace {
+/**
+ * Debug helper to print broadcast operation information.
+ */
+__device__ __forceinline__ void printBroadcastOperation(
+    int my_rank_id,
+    int root_rank_id,
+    int peer_rank_id,
+    bool is_send,
+    uint32_t total_groups,
+    std::size_t nbytes) {
+  printf(
+      "Rank=%d root=%d total-groups=%d: %s rank=%d nbytes=%lu\n",
+      my_rank_id,
+      root_rank_id,
+      total_groups,
+      is_send ? "send to" : "recv from",
+      peer_rank_id,
+      nbytes);
+}
+} // namespace
+
+/**
+ * Broadcast collective communication primitive.
+ *
+ * Broadcasts data from root rank to all other ranks using a flat-tree (star)
+ * algorithm where the root sends directly to each non-root rank in parallel.
+ *
+ * Algorithm:
+ * 1. Single rank case: No-op (root already has data)
+ * 2. Zero bytes case: No-op
+ * 3. Root rank: Partitions warps across (nranks-1) peers and sends to each
+ * 4. Non-root ranks: All warps collaborate on receiving data from root
+ *
+ * Parameters:
+ *   @param buff_d: Device buffer pointer
+ *                  - For root: contains source data to broadcast
+ *                  - For non-root: receives broadcast data
+ *   @param my_rank_id: Current rank ID
+ *   @param root_rank_id: Rank ID of the broadcast source
+ *   @param transports_per_rank: Array of transport objects, one per rank
+ *                               (self-transport for my_rank, P2P for others)
+ *   @param nbytes: Number of bytes to broadcast
+ *
+ * Requirements:
+ * - Must be called from device code with sufficient threads
+ * - All ranks must call with same root_rank_id and nbytes
+ * - Max 8 ranks supported
+ * - transports_per_rank[my_rank_id].type must be SELF
+ * - transports_per_rank[i].type must be P2P_NVL for i != my_rank_id
+ */
+__device__ __forceinline__ void broadcast(
+    void* buff_d,
+    int my_rank_id,
+    int root_rank_id,
+    DeviceSpan<Transport> transports_per_rank,
+    std::size_t nbytes) {
+#ifdef __CUDA_ARCH__
+  const auto nranks = transports_per_rank.size();
+
+  // Single rank case: no-op (root already has data)
+  if (nranks == 1) {
+    return;
+  }
+
+  // Zero-byte broadcast: no-op
+  if (nbytes == 0) {
+    return;
+  }
+
+  auto group = make_warp_group();
+
+  // Extract raw pointer to avoid aliasing issues.
+  // See "PERFORMANCE NOTE: Lambda Capture and Aliasing"
+  // in DeviceSpan.cuh for explanation.
+  auto transports = transports_per_rank.data();
+
+  bool is_root = (my_rank_id == root_rank_id);
+
+  if (is_root) {
+    // Root: partition warps across (nranks - 1) peers for parallel sends
+    auto [peer_idx, peer_group] = group.partition(nranks - 1);
+
+    // Map peer_idx [0, nranks-2] to actual peer rank, skipping root
+    // For root_rank_id = 2 and nranks = 4:
+    //   peer_idx 0 → rank 0
+    //   peer_idx 1 → rank 1
+    //   peer_idx 2 → rank 3 (skip root at index 2)
+    int peer_rank = static_cast<int>(
+        peer_idx < static_cast<uint32_t>(root_rank_id) ? peer_idx
+                                                       : peer_idx + 1);
+
+    auto& transport = transports[peer_rank];
+    assert(transport.type == TransportType::P2P_NVL);
+
+#ifdef DEBUG_BROADCAST
+    if (peer_group.is_global_leader()) {
+      printBroadcastOperation(
+          my_rank_id,
+          root_rank_id,
+          peer_rank,
+          true, // is_send
+          peer_group.total_groups,
+          nbytes);
+    }
+#endif
+
+    transport.p2p_nvl.send(peer_group, static_cast<char*>(buff_d), nbytes);
+  } else {
+    // Non-root: all warps collaborate on receiving from root
+    auto& transport = transports[root_rank_id];
+    assert(transport.type == TransportType::P2P_NVL);
+
+#ifdef DEBUG_BROADCAST
+    if (group.is_global_leader()) {
+      printBroadcastOperation(
+          my_rank_id,
+          root_rank_id,
+          root_rank_id,
+          false, // is_send
+          group.total_groups,
+          nbytes);
+    }
+#endif
+
+    transport.p2p_nvl.recv(group, static_cast<char*>(buff_d), nbytes);
+  }
+#endif
+}
+
+} // namespace comms::pipes::collectives

--- a/comms/pipes/collectives/BroadcastBinomialTree.cuh
+++ b/comms/pipes/collectives/BroadcastBinomialTree.cuh
@@ -1,0 +1,291 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <cassert>
+#include <cstdio>
+
+#include "comms/pipes/DeviceSpan.cuh"
+#include "comms/pipes/Transport.cuh"
+#include "comms/pipes/collectives/Broadcast.cuh"
+
+namespace comms::pipes::collectives {
+
+namespace {
+
+// Chunk size for pipelined binomial tree broadcast (128KB)
+// Optimized based on empirical profiling - smaller chunks enable
+// better warp parallelism across chunks within each round
+constexpr std::size_t kBinomialChunkSize = 128 * 1024;
+
+// Memory alignment for optimal NVLink transfers (256 bytes)
+constexpr std::size_t kNVLinkAlignment = 256;
+
+// Maximum number of chunks that can be processed concurrently by warps
+// This limits memory usage for synchronization flags
+constexpr std::size_t kMaxConcurrentChunks = 256;
+
+/**
+ * Debug helper to print binomial tree broadcast operation information.
+ */
+__device__ __forceinline__ void printBinomialTreeOperation(
+    int my_rank_id,
+    int root_rank_id,
+    int virtual_rank,
+    int round,
+    int peer_rank_id,
+    bool is_send,
+    std::size_t nbytes) {
+  printf(
+      "Rank=%d (virtual=%d) root=%d round=%d: %s rank=%d nbytes=%lu\n",
+      my_rank_id,
+      virtual_rank,
+      root_rank_id,
+      round,
+      is_send ? "send to" : "recv from",
+      peer_rank_id,
+      nbytes);
+}
+
+/**
+ * Align a size to the specified alignment boundary.
+ */
+__device__ __forceinline__ std::size_t alignUp(
+    std::size_t size,
+    std::size_t alignment) {
+  return ((size + alignment - 1) / alignment) * alignment;
+}
+
+} // namespace
+
+/**
+ * Binomial Tree Broadcast collective communication primitive.
+ *
+ * Broadcasts data from root rank to all other ranks using a binomial tree
+ * algorithm with O(log N) rounds. This is more bandwidth-efficient than
+ * the flat-tree (star) algorithm for large messages because:
+ *
+ *   1. Root bandwidth = 1×messageSize (sends to one peer per round)
+ *   2. Parallelism increases each round (2^round senders in round r)
+ *   3. Total bandwidth distributed across all nodes
+ *
+ * Optimization: Chunk-Based Pipelining
+ * =====================================
+ * For large messages, the data is broken into chunks and processed in a
+ * pipelined manner. This allows:
+ *   - Overlapping communication across rounds for different chunks
+ *   - Better utilization of available bandwidth
+ *   - Warps can be partitioned to work on different chunks concurrently
+ *
+ * The pipelining follows a "chunk-major" order:
+ *   for each chunk:
+ *     for each round:
+ *       process chunk in this round
+ *
+ * This ensures that once a rank receives a chunk, it can immediately forward
+ * it in the next round while the previous rank moves on to the next chunk.
+ *
+ * Algorithm:
+ * ==========
+ * For N ranks, the broadcast completes in ceil(log2(N)) rounds.
+ *
+ * In each round r (0-indexed):
+ *   - Ranks with virtual_rank < 2^r have the data
+ *   - Each such rank sends to virtual_rank + 2^r (if that rank exists)
+ *   - Receiving ranks wait for data before proceeding to next round
+ *
+ * Example for 4 ranks (root=0):
+ *   Round 0: Rank 0 → Rank 1 (virtual_rank 0 sends to 0+1=1)
+ *   Round 1: Rank 0 → Rank 2, Rank 1 → Rank 3
+ *
+ * Example for 8 ranks (root=0):
+ *   Round 0: Rank 0 → Rank 1
+ *   Round 1: Rank 0 → Rank 2, Rank 1 → Rank 3
+ *   Round 2: Ranks 0→4, 1→5, 2→6, 3→7
+ *
+ * Virtual Rank Mapping:
+ * =====================
+ * To support arbitrary root ranks, we use virtual ranks:
+ *   virtual_rank = (actual_rank - root_rank + nranks) % nranks
+ *   actual_rank = (virtual_rank + root_rank) % nranks
+ *
+ * This way, the root always has virtual_rank=0, and the algorithm
+ * proceeds identically regardless of which physical rank is the root.
+ *
+ * Parameters:
+ *   @param buff_d: Device buffer pointer
+ *                  - For root: contains source data to broadcast
+ *                  - For non-root: receives broadcast data
+ *   @param my_rank_id: Current rank ID
+ *   @param root_rank_id: Rank ID of the broadcast source
+ *   @param transports_per_rank: Array of transport objects, one per rank
+ *   @param nbytes: Number of bytes to broadcast
+ *
+ * Requirements:
+ * - Must be called from device code with sufficient threads
+ * - All ranks must call with same root_rank_id and nbytes
+ * - Max 8 ranks supported
+ * - transports_per_rank[my_rank_id].type must be SELF
+ * - transports_per_rank[i].type must be P2P_NVL for i != my_rank_id
+ */
+__device__ __forceinline__ void broadcast_binomial_tree(
+    void* buff_d,
+    int my_rank_id,
+    int root_rank_id,
+    DeviceSpan<Transport> transports_per_rank,
+    std::size_t nbytes) {
+#ifdef __CUDA_ARCH__
+  const int nranks = static_cast<int>(transports_per_rank.size());
+
+  // Single rank case: no-op (root already has data)
+  if (nranks == 1) {
+    return;
+  }
+
+  // Zero-byte broadcast: no-op
+  if (nbytes == 0) {
+    return;
+  }
+
+  auto group = make_warp_group();
+
+  // Extract raw pointer to avoid aliasing issues.
+  auto transports = transports_per_rank.data();
+
+  // Compute virtual rank relative to root (root has virtual_rank=0)
+  int virtual_rank = (my_rank_id - root_rank_id + nranks) % nranks;
+
+  // Calculate number of rounds = ceil(log2(nranks))
+  int num_rounds = 0;
+  for (int n = 1; n < nranks; n <<= 1) {
+    num_rounds++;
+  }
+
+  // Determine chunk size (aligned for optimal NVLink transfers)
+  const std::size_t chunk_size = alignUp(kBinomialChunkSize, kNVLinkAlignment);
+  const std::size_t num_chunks = (nbytes + chunk_size - 1) / chunk_size;
+
+  char* buff = static_cast<char*>(buff_d);
+
+  // Chunk-major pipelining: process chunks sequentially, allowing
+  // pipelining across rounds for different chunks.
+  //
+  // NOTE: We cannot partition warps across chunks like the flat-tree does
+  // across peers, because in the binomial tree algorithm, send/recv are
+  // paired operations that require ALL warps on both sender and receiver
+  // to participate. If we partition chunks across warps, we'd have a
+  // subset of warps trying to send while another subset tries to receive
+  // a different chunk, causing a deadlock.
+  //
+  // The pipelining benefit comes from the transport layer's internal
+  // pipelining, not from warp-level parallelism across chunks.
+  for (std::size_t chunk_idx = 0; chunk_idx < num_chunks; ++chunk_idx) {
+    const std::size_t chunk_offset = chunk_idx * chunk_size;
+    const std::size_t chunk_bytes = (chunk_offset + chunk_size <= nbytes)
+        ? chunk_size
+        : (nbytes - chunk_offset);
+
+    char* chunk_ptr = buff + chunk_offset;
+
+    // Process each round of the binomial tree for this chunk
+    for (int round = 0; round < num_rounds; ++round) {
+      int distance = 1 << round; // 2^round
+
+      if (virtual_rank < distance) {
+        // I have the data - check if I need to send to a peer
+        int send_to_virtual = virtual_rank + distance;
+
+        if (send_to_virtual < nranks) {
+          // Convert virtual rank back to actual rank
+          int send_to_actual = (send_to_virtual + root_rank_id) % nranks;
+
+          auto& transport = transports[send_to_actual];
+          assert(transport.type == TransportType::P2P_NVL);
+
+#ifdef DEBUG_BROADCAST
+          if (group.is_leader()) {
+            printBinomialTreeOperation(
+                my_rank_id,
+                root_rank_id,
+                virtual_rank,
+                round,
+                send_to_actual,
+                true, // is_send
+                chunk_bytes);
+          }
+#endif
+
+          transport.p2p_nvl.send(group, chunk_ptr, chunk_bytes);
+        }
+        // If no peer to send to in this round, just continue to next round
+      } else if (virtual_rank < 2 * distance) {
+        // I don't have data yet - receive from peer
+        int recv_from_virtual = virtual_rank - distance;
+        int recv_from_actual = (recv_from_virtual + root_rank_id) % nranks;
+
+        auto& transport = transports[recv_from_actual];
+        assert(transport.type == TransportType::P2P_NVL);
+
+#ifdef DEBUG_BROADCAST
+        if (group.is_leader()) {
+          printBinomialTreeOperation(
+              my_rank_id,
+              root_rank_id,
+              virtual_rank,
+              round,
+              recv_from_actual,
+              false, // is_send
+              chunk_bytes);
+        }
+#endif
+
+        transport.p2p_nvl.recv(group, chunk_ptr, chunk_bytes);
+      }
+      // Ranks >= 2*distance don't participate in this round
+
+      // Implicit synchronization: recv completes before proceeding,
+      // which acts as a barrier for that rank to have data before
+      // potentially sending in the next round.
+    }
+  }
+#endif
+}
+
+/**
+ * Wrapper that selects between flat-tree and binomial tree broadcast
+ * based on message size and rank count.
+ *
+ * Selection criteria:
+ * - For small messages (< 64KB): Use flat-tree (lower latency)
+ * - For large messages (>= 64KB) with many ranks: Use binomial tree
+ *   (better bandwidth utilization)
+ *
+ * The threshold can be tuned based on profiling results.
+ */
+__device__ __forceinline__ void broadcast_adaptive(
+    void* buff_d,
+    int my_rank_id,
+    int root_rank_id,
+    DeviceSpan<Transport> transports_per_rank,
+    std::size_t nbytes) {
+#ifdef __CUDA_ARCH__
+  // Threshold for switching to binomial tree (64KB)
+  constexpr std::size_t kBinomialThreshold = 64 * 1024;
+
+  const auto nranks = transports_per_rank.size();
+
+  // Use binomial tree for large messages with multiple ranks
+  // The benefit of binomial tree increases with message size and rank count
+  if (nbytes >= kBinomialThreshold && nranks > 2) {
+    broadcast_binomial_tree(
+        buff_d, my_rank_id, root_rank_id, transports_per_rank, nbytes);
+  } else {
+    // Fall back to flat-tree for small messages or small rank counts
+    // Import the flat-tree broadcast from Broadcast.cuh
+    broadcast(buff_d, my_rank_id, root_rank_id, transports_per_rank, nbytes);
+  }
+#endif
+}
+
+} // namespace comms::pipes::collectives

--- a/comms/pipes/collectives/BroadcastBinomialTree.cuh
+++ b/comms/pipes/collectives/BroadcastBinomialTree.cuh
@@ -271,6 +271,8 @@ __device__ __forceinline__ void broadcast_adaptive(
     std::size_t nbytes) {
 #ifdef __CUDA_ARCH__
   // Threshold for switching to binomial tree (64KB)
+  // IMPORTANT: Must match kBinomialThreshold in
+  // comms/pipes/benchmarks/BroadcastTuning.h
   constexpr std::size_t kBinomialThreshold = 64 * 1024;
 
   const auto nranks = transports_per_rank.size();

--- a/comms/pipes/collectives/BroadcastRing.cuh
+++ b/comms/pipes/collectives/BroadcastRing.cuh
@@ -1,0 +1,197 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <cassert>
+#include <cstdio>
+
+#include "comms/pipes/DeviceSpan.cuh"
+#include "comms/pipes/Transport.cuh"
+
+namespace comms::pipes::collectives {
+
+namespace {
+
+// Chunk size for pipelined ring broadcast (128KB)
+// Smaller chunks enable better inter-hop pipelining
+constexpr std::size_t kRingChunkSize = 128 * 1024;
+
+// Memory alignment for optimal NVLink transfers (256 bytes)
+constexpr std::size_t kRingNVLinkAlignment = 256;
+
+/**
+ * Debug helper to print ring broadcast operation information.
+ */
+__device__ __forceinline__ void printRingBroadcastOperation(
+    int my_rank_id,
+    int root_rank_id,
+    int step,
+    int chunk,
+    int peer_rank,
+    bool is_send,
+    std::size_t nbytes) {
+  printf(
+      "Rank=%d root=%d step=%d: %s chunk=%d %s rank=%d nbytes=%lu\n",
+      my_rank_id,
+      root_rank_id,
+      step,
+      is_send ? "SEND" : "RECV",
+      chunk,
+      is_send ? "to" : "from",
+      peer_rank,
+      nbytes);
+}
+
+/**
+ * Align a size to the specified alignment boundary.
+ */
+__device__ __forceinline__ std::size_t alignUpRing(
+    std::size_t size,
+    std::size_t alignment) {
+  return ((size + alignment - 1) / alignment) * alignment;
+}
+
+} // namespace
+
+/**
+ * Ring Broadcast collective communication primitive.
+ *
+ * Broadcasts data from root rank to all other ranks using a sequential ring
+ * algorithm. Data flows around the ring one hop at a time:
+ *   root -> rank1 -> rank2 -> ... -> rank(N-1)
+ *
+ * Algorithm Overview:
+ * ===================
+ * Each rank first receives the entire message from its predecessor (if not
+ * root), then sends the entire message to its successor (if not last rank).
+ *
+ * This is a simple sequential hop algorithm:
+ *   if not root: recv entire message from prev_rank
+ *   if not last_rank: send entire message to next_rank
+ *
+ * The pipelining benefit comes from the transport layer's internal
+ * pipelining within each send/recv operation. The transport automatically
+ * divides each transfer into steps and uses pipeline buffer slots to
+ * overlap data movement with synchronization.
+ *
+ * Virtual Rank Mapping:
+ * =====================
+ * To handle arbitrary root ranks, we use virtual ranks:
+ *   virtual_rank = (actual_rank - root_rank + nranks) % nranks
+ * This way, root always has virtual_rank=0.
+ *
+ * Why Sequential Hops (Not Chunk-Pipelined)?
+ * ==========================================
+ * The P2P NVLink transport's internal pipelining is designed for efficiency
+ * within a single large transfer, not for coordinating multiple independent
+ * transfers. Each send()/recv() call:
+ *   - Uses internal stepId 0, 1, 2, ... which resets for each call
+ *   - Maps stepId to pipeline buffer slots: slot = stepId % pipelineDepth
+ *
+ * If we tried to do chunk-level pipelining across hops:
+ *   - Different chunks would use the SAME buffer slots (both start at step 0)
+ *   - No actual overlap would occur between chunks on different hops
+ *   - We'd just add loop overhead without performance benefit
+ *
+ * The transport's internal pipelining already maximizes NVLink utilization
+ * for each hop, so sequential hops with large transfers is optimal.
+ *
+ * Performance Characteristics:
+ * ============================
+ * - Total latency = (N-1) × message_transfer_time
+ * - Each hop achieves near-peak NVLink bandwidth due to internal pipelining
+ * - For N ranks, this is O(N) slower than flat-tree O(1) for broadcast
+ * - Ring is designed for reduce-scatter/all-gather, not pure broadcast
+ *
+ * When to Use Ring Broadcast:
+ * ===========================
+ * Ring broadcast is NOT recommended for pure broadcast operations.
+ * Use flat-tree (Broadcast.cuh) or binomial tree (BroadcastBinomialTree.cuh)
+ * instead. Ring is included for completeness and testing purposes.
+ *
+ * Parameters:
+ *   @param buff_d: Device buffer pointer (same for source and destination)
+ *   @param my_rank_id: Current rank ID
+ *   @param root_rank_id: Rank ID of the broadcast source
+ *   @param transports_per_rank: Array of transport objects, one per rank
+ *   @param nbytes: Number of bytes to broadcast
+ */
+__device__ __forceinline__ void broadcast_ring(
+    void* buff_d,
+    int my_rank_id,
+    int root_rank_id,
+    DeviceSpan<Transport> transports_per_rank,
+    std::size_t nbytes) {
+#ifdef __CUDA_ARCH__
+  const int nranks = static_cast<int>(transports_per_rank.size());
+
+  // Single rank case: no-op (root already has data)
+  if (nranks == 1) {
+    return;
+  }
+
+  // Zero-byte broadcast: no-op
+  if (nbytes == 0) {
+    return;
+  }
+
+  auto group = make_warp_group();
+
+  // Extract raw pointer to avoid aliasing issues.
+  auto transports = transports_per_rank.data();
+
+  // Compute virtual rank relative to root (root has virtual_rank=0)
+  int virtual_rank = (my_rank_id - root_rank_id + nranks) % nranks;
+
+  // Ring neighbors (based on virtual rank ordering)
+  int next_virtual = (virtual_rank + 1) % nranks;
+  int prev_virtual = (virtual_rank - 1 + nranks) % nranks;
+  int next_rank = (next_virtual + root_rank_id) % nranks;
+  int prev_rank = (prev_virtual + root_rank_id) % nranks;
+
+  char* buff = static_cast<char*>(buff_d);
+
+  // Get transport handles for neighbors
+  auto& next_transport = transports[next_rank];
+  auto& prev_transport = transports[prev_rank];
+
+  // Validate transport types for neighbors we'll actually use
+  if (virtual_rank < nranks - 1) {
+    assert(next_transport.type == TransportType::P2P_NVL);
+  }
+  if (virtual_rank > 0) {
+    assert(prev_transport.type == TransportType::P2P_NVL);
+  }
+
+  // Sequential ring: first receive from predecessor, then send to successor.
+  //
+  // The transport's internal pipelining (pipelineDepth and chunking) handles
+  // efficiency within each transfer. We transfer the entire message in one
+  // send()/recv() call to maximize this internal pipelining benefit.
+
+  // Phase 1: Receive from predecessor (if not root)
+  if (virtual_rank > 0) {
+#ifdef DEBUG_BROADCAST
+    if (group.is_leader()) {
+      printRingBroadcastOperation(
+          my_rank_id, root_rank_id, 0, 0, prev_rank, false, nbytes);
+    }
+#endif
+    prev_transport.p2p_nvl.recv(group, buff, nbytes);
+  }
+
+  // Phase 2: Send to successor (if not last rank)
+  if (virtual_rank < nranks - 1) {
+#ifdef DEBUG_BROADCAST
+    if (group.is_leader()) {
+      printRingBroadcastOperation(
+          my_rank_id, root_rank_id, 1, 0, next_rank, true, nbytes);
+    }
+#endif
+    next_transport.p2p_nvl.send(group, buff, nbytes);
+  }
+#endif
+}
+
+} // namespace comms::pipes::collectives

--- a/comms/pipes/tests/BroadcastTest.cc
+++ b/comms/pipes/tests/BroadcastTest.cc
@@ -1,0 +1,734 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include <folly/init/Init.h>
+#include <folly/logging/xlog.h>
+
+#include "comms/pipes/MultiPeerNvlTransport.h"
+#include "comms/pipes/P2pSelfTransportDevice.cuh"
+#include "comms/pipes/collectives/Broadcast.cuh"
+#include "comms/pipes/tests/BroadcastTest.cuh"
+#include "comms/pipes/tests/Utils.cuh"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/testinfra/mpi/MpiBootstrap.h"
+#include "comms/testinfra/mpi/MpiTestUtils.h"
+#include "comms/utils/CudaRAII.h"
+
+using namespace meta::comms;
+
+namespace comms::pipes::collectives {
+
+namespace {
+// Helper function to print device buffer contents for debugging
+void printDeviceBuffer(
+    const char* label,
+    void* deviceBuffer,
+    int rank,
+    size_t numInts,
+    bool showAll = false) {
+  std::vector<int32_t> h_buffer(numInts);
+  CUDACHECK_TEST(cudaMemcpy(
+      h_buffer.data(),
+      deviceBuffer,
+      numInts * sizeof(int32_t),
+      cudaMemcpyDeviceToHost));
+
+  size_t numToShow = showAll ? numInts : std::min(size_t(8), numInts);
+  XLOGF(
+      DBG1,
+      "Rank {}: {} (showing {}/{} values):",
+      rank,
+      label,
+      numToShow,
+      numInts);
+
+  std::string line = "  Values: ";
+  for (size_t i = 0; i < numToShow; i++) {
+    line += std::to_string(h_buffer[i]) + " ";
+  }
+  if (!showAll && numInts > 8) {
+    line += "...";
+  }
+  XLOG(DBG1) << line;
+}
+} // namespace
+
+// Test fixture for Broadcast tests using MPI for multi-rank coordination
+class BroadcastTestFixture : public MpiBaseTestFixture {
+ protected:
+  void SetUp() override {
+    MpiBaseTestFixture::SetUp();
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+  }
+
+  void TearDown() override {
+    MpiBaseTestFixture::TearDown();
+  }
+};
+
+// Test parameters for parameterized Broadcast tests
+struct BroadcastTestParams {
+  int numBlocks;
+  int blockSize;
+  size_t numBytes;
+  int rootRank; // -1 means use numRanks/2 as root
+  std::string testName;
+};
+
+// Parameterized test fixture
+class BroadcastParamTest
+    : public BroadcastTestFixture,
+      public ::testing::WithParamInterface<BroadcastTestParams> {};
+
+/**
+ * Test broadcast with parameterized configurations.
+ *
+ * This test verifies that:
+ * 1. Root rank's data is correctly broadcast to all other ranks
+ * 2. All ranks have identical data after broadcast
+ * 3. Data integrity is preserved (no corruption)
+ *
+ * Data pattern: root_rank * 1000 + position
+ * This allows easy identification of data source and position for debugging.
+ */
+TEST_P(BroadcastParamTest, BroadcastDataTransfer) {
+  const auto& params = GetParam();
+  const size_t numBytes = params.numBytes;
+  const int numBlocks = params.numBlocks;
+  const int blockSize = params.blockSize;
+
+  // Resolve root rank: -1 means use middle rank
+  const int rootRank =
+      params.rootRank < 0 ? numRanks / 2 : params.rootRank % numRanks;
+
+  XLOGF(
+      DBG1,
+      "Rank {}: Running {} with numBlocks={}, blockSize={}, numBytes={}, root={}",
+      globalRank,
+      params.testName,
+      numBlocks,
+      blockSize,
+      numBytes,
+      rootRank);
+
+  // Configuration for P2pNvlTransport
+  // Use a fixed staging buffer size (64KB) - large transfers are handled via
+  // pipelining. This keeps memory usage reasonable with 8 ranks (7 peers each).
+  MultiPeerNvlTransportConfig config{
+      .dataBufferSize = 64 * 1024, // 64KB staging buffer per peer
+      .chunkSize = 512,
+      .pipelineDepth = 4,
+  };
+
+  // Create transport and exchange IPC handles across all ranks
+  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
+  transport.exchange();
+  XLOGF(DBG1, "Rank {} created transport and exchanged IPC", globalRank);
+
+  // Build transport array: self-transport for my rank, P2P for peers
+  P2pSelfTransportDevice selfTransport;
+  std::vector<Transport> h_transports;
+  h_transports.reserve(numRanks);
+
+  for (int rank = 0; rank < numRanks; rank++) {
+    if (rank == globalRank) {
+      h_transports.emplace_back(selfTransport);
+    } else {
+      h_transports.emplace_back(transport.getP2pTransportDevice(rank));
+    }
+  }
+
+  // Copy transports to device
+  DeviceBuffer d_transports(sizeof(Transport) * numRanks);
+  CUDACHECK_TEST(cudaMemcpy(
+      d_transports.get(),
+      h_transports.data(),
+      sizeof(Transport) * numRanks,
+      cudaMemcpyHostToDevice));
+
+  DeviceSpan<Transport> transports_span(
+      static_cast<Transport*>(d_transports.get()), numRanks);
+
+  // Allocate broadcast buffer
+  DeviceBuffer buffer(numBytes);
+
+  // Calculate number of int32_t elements
+  const size_t numInts = numBytes / sizeof(int32_t);
+
+  // Initialize buffer: root has data, non-roots have -1 (sentinel)
+  if (globalRank == rootRank) {
+    // Root: fill with pattern root_rank * 1000 + position
+    std::vector<int32_t> h_init(numInts);
+    for (size_t i = 0; i < numInts; i++) {
+      h_init[i] = rootRank * 1000 + static_cast<int32_t>(i);
+    }
+    CUDACHECK_TEST(cudaMemcpy(
+        buffer.get(), h_init.data(), numBytes, cudaMemcpyHostToDevice));
+  } else {
+    // Non-root: initialize with -1 to detect missing writes
+    ::comms::pipes::test::fillBuffer(
+        reinterpret_cast<int*>(buffer.get()), -1, numInts);
+  }
+
+  // Debug: print buffer before broadcast
+  printDeviceBuffer("Buffer BEFORE", buffer.get(), globalRank, numInts);
+
+  // Synchronize all ranks before broadcast
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  XLOGF(DBG1, "Rank {}: calling broadcast with root={}", globalRank, rootRank);
+
+  // Execute broadcast
+  test::testBroadcast(
+      buffer.get(),
+      globalRank,
+      rootRank,
+      transports_span,
+      numBytes,
+      numBlocks,
+      blockSize);
+
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  // Debug: print buffer after broadcast
+  printDeviceBuffer("Buffer AFTER", buffer.get(), globalRank, numInts);
+
+  // Verify all ranks have correct data
+  // Expected: value[i] = rootRank * 1000 + i
+
+  // Generate expected data
+  std::vector<int32_t> h_expected(numInts);
+  for (size_t i = 0; i < numInts; i++) {
+    h_expected[i] = rootRank * 1000 + static_cast<int32_t>(i);
+  }
+
+  // Copy result from device
+  std::vector<int32_t> h_result(numInts);
+  CUDACHECK_TEST(cudaMemcpy(
+      h_result.data(), buffer.get(), numBytes, cudaMemcpyDeviceToHost));
+
+  // Direct comparison - Google Test provides detailed diff on failure
+  XLOGF(DBG1, "Rank {}: verification completed", globalRank);
+  EXPECT_EQ(h_result, h_expected)
+      << "Rank " << globalRank << " verification failed";
+
+  // Ensure all ranks complete before cleanup
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
+// Broadcast algorithm types for explicit algorithm testing
+enum class BroadcastAlgorithm { FlatTree, BinomialTree, Ring };
+
+// Extended test parameters including algorithm selection
+struct BroadcastAlgorithmTestParams {
+  int numBlocks;
+  int blockSize;
+  size_t numBytes;
+  int rootRank;
+  BroadcastAlgorithm algorithm;
+  std::string testName;
+};
+
+// Parameterized test fixture for explicit algorithm selection tests
+class BroadcastAlgorithmParamTest
+    : public BroadcastTestFixture,
+      public ::testing::WithParamInterface<BroadcastAlgorithmTestParams> {};
+
+/**
+ * Test explicit algorithm selection with various configurations.
+ *
+ * This test verifies that each broadcast algorithm (flat-tree, binomial tree,
+ * ring) correctly broadcasts data from root to all other ranks, regardless of
+ * message size. This allows testing algorithms with message sizes outside their
+ * typical adaptive selection thresholds.
+ */
+TEST_P(BroadcastAlgorithmParamTest, AlgorithmDataTransfer) {
+  const auto& params = GetParam();
+  const size_t numBytes = params.numBytes;
+  const int numBlocks = params.numBlocks;
+  const int blockSize = params.blockSize;
+
+  // Resolve root rank: -1 means use middle rank
+  const int rootRank =
+      params.rootRank < 0 ? numRanks / 2 : params.rootRank % numRanks;
+
+  const char* algorithmName = params.algorithm == BroadcastAlgorithm::FlatTree
+      ? "FlatTree"
+      : (params.algorithm == BroadcastAlgorithm::BinomialTree ? "BinomialTree"
+                                                              : "Ring");
+
+  XLOGF(
+      DBG1,
+      "Rank {}: Running {} with algorithm={}, numBlocks={}, blockSize={}, numBytes={}, root={}",
+      globalRank,
+      params.testName,
+      algorithmName,
+      numBlocks,
+      blockSize,
+      numBytes,
+      rootRank);
+
+  // Configuration for P2pNvlTransport
+  // Use larger staging buffer for large messages
+  MultiPeerNvlTransportConfig config{
+      .dataBufferSize = 256 * 1024,
+      .chunkSize = 512,
+      .pipelineDepth = 4,
+  };
+
+  // Create transport and exchange IPC handles across all ranks
+  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
+  transport.exchange();
+  XLOGF(DBG1, "Rank {} created transport and exchanged IPC", globalRank);
+
+  // Build transport array: self-transport for my rank, P2P for peers
+  P2pSelfTransportDevice selfTransport;
+  std::vector<Transport> h_transports;
+  h_transports.reserve(numRanks);
+
+  for (int rank = 0; rank < numRanks; rank++) {
+    if (rank == globalRank) {
+      h_transports.emplace_back(selfTransport);
+    } else {
+      h_transports.emplace_back(transport.getP2pTransportDevice(rank));
+    }
+  }
+
+  // Copy transports to device
+  DeviceBuffer d_transports(sizeof(Transport) * numRanks);
+  CUDACHECK_TEST(cudaMemcpy(
+      d_transports.get(),
+      h_transports.data(),
+      sizeof(Transport) * numRanks,
+      cudaMemcpyHostToDevice));
+
+  DeviceSpan<Transport> transports_span(
+      static_cast<Transport*>(d_transports.get()), numRanks);
+
+  // Allocate broadcast buffer
+  DeviceBuffer buffer(numBytes);
+
+  // Calculate number of int32_t elements
+  const size_t numInts = numBytes / sizeof(int32_t);
+
+  // Initialize buffer: root has data, non-roots have -1 (sentinel)
+  if (globalRank == rootRank) {
+    // Root: fill with pattern root_rank * 1000 + position
+    std::vector<int32_t> h_init(numInts);
+    for (size_t i = 0; i < numInts; i++) {
+      h_init[i] = rootRank * 1000 + static_cast<int32_t>(i);
+    }
+    CUDACHECK_TEST(cudaMemcpy(
+        buffer.get(), h_init.data(), numBytes, cudaMemcpyHostToDevice));
+  } else {
+    // Non-root: initialize with -1 to detect missing writes
+    ::comms::pipes::test::fillBuffer(
+        reinterpret_cast<int*>(buffer.get()), -1, numInts);
+  }
+
+  // Debug: print buffer before broadcast
+  printDeviceBuffer("Buffer BEFORE", buffer.get(), globalRank, numInts);
+
+  // Synchronize all ranks before broadcast
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  XLOGF(
+      DBG1,
+      "Rank {}: calling {} broadcast with root={}",
+      globalRank,
+      algorithmName,
+      rootRank);
+
+  // Execute broadcast with the specified algorithm
+  switch (params.algorithm) {
+    case BroadcastAlgorithm::FlatTree:
+      test::testBroadcast(
+          buffer.get(),
+          globalRank,
+          rootRank,
+          transports_span,
+          numBytes,
+          numBlocks,
+          blockSize);
+      break;
+    case BroadcastAlgorithm::BinomialTree:
+      test::testBroadcastBinomialTree(
+          buffer.get(),
+          globalRank,
+          rootRank,
+          transports_span,
+          numBytes,
+          numBlocks,
+          blockSize);
+      break;
+    case BroadcastAlgorithm::Ring:
+      test::testBroadcastRing(
+          buffer.get(),
+          globalRank,
+          rootRank,
+          transports_span,
+          numBytes,
+          numBlocks,
+          blockSize);
+      break;
+  }
+
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  // Debug: print buffer after broadcast
+  printDeviceBuffer("Buffer AFTER", buffer.get(), globalRank, numInts);
+
+  // Verify all ranks have correct data
+  // Expected: value[i] = rootRank * 1000 + i
+
+  // Generate expected data
+  std::vector<int32_t> h_expected(numInts);
+  for (size_t i = 0; i < numInts; i++) {
+    h_expected[i] = rootRank * 1000 + static_cast<int32_t>(i);
+  }
+
+  // Copy result from device
+  std::vector<int32_t> h_result(numInts);
+  CUDACHECK_TEST(cudaMemcpy(
+      h_result.data(), buffer.get(), numBytes, cudaMemcpyDeviceToHost));
+
+  // Direct comparison - Google Test provides detailed diff on failure
+  XLOGF(DBG1, "Rank {}: verification completed", globalRank);
+  EXPECT_EQ(h_result, h_expected)
+      << "Rank " << globalRank << " verification failed using "
+      << algorithmName;
+
+  // Ensure all ranks complete before cleanup
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
+// Test configurations covering various scenarios:
+// - Different message sizes (small, medium, large)
+// - Different thread configurations
+// - Different root ranks
+INSTANTIATE_TEST_SUITE_P(
+    BroadcastConfigs,
+    BroadcastParamTest,
+    ::testing::Values(
+        // Small message (64 bytes = 16 int32_t), root=0
+        BroadcastTestParams{
+            .numBlocks = 4,
+            .blockSize = 256,
+            .numBytes = 64,
+            .rootRank = 0,
+            .testName = "small_64B_root0"},
+
+        // Medium message (4KB), root=0
+        BroadcastTestParams{
+            .numBlocks = 4,
+            .blockSize = 256,
+            .numBytes = 4096,
+            .rootRank = 0,
+            .testName = "medium_4KB_root0"},
+
+        // Large message (1MB), root=0
+        BroadcastTestParams{
+            .numBlocks = 8,
+            .blockSize = 512,
+            .numBytes = 1048576,
+            .rootRank = 0,
+            .testName = "large_1MB_root0"},
+
+        // Medium message with non-zero root (middle rank)
+        BroadcastTestParams{
+            .numBlocks = 4,
+            .blockSize = 256,
+            .numBytes = 4096,
+            .rootRank = -1, // Will use numRanks/2
+            .testName = "medium_4KB_middle_root"},
+
+        // Different thread configuration: more blocks, fewer threads
+        BroadcastTestParams{
+            .numBlocks = 16,
+            .blockSize = 128,
+            .numBytes = 4096,
+            .rootRank = 0,
+            .testName = "16b_128t_4KB"},
+
+        // Different thread configuration: single block
+        BroadcastTestParams{
+            .numBlocks = 1,
+            .blockSize = 256,
+            .numBytes = 1024,
+            .rootRank = 0,
+            .testName = "1b_256t_1KB"},
+
+        // Boundary test: last rank as root (root_rank = nranks - 1)
+        // This verifies the peer mapping correctly handles the case where
+        // peer_idx values 0 through nranks-2 all map to ranks < root_rank,
+        // ensuring no off-by-one errors in the mapping logic.
+        BroadcastTestParams{
+            .numBlocks = 4,
+            .blockSize = 256,
+            .numBytes = 4096,
+            .rootRank = 7, // Last rank in 8-rank configuration
+            .testName = "medium_4KB_last_root"}),
+    [](const ::testing::TestParamInfo<BroadcastTestParams>& info) {
+      return info.param.testName;
+    });
+
+// Binomial Tree algorithm tests (designed for messages >= 64KB)
+// Tests the O(log N) rounds algorithm with various message sizes and root ranks
+INSTANTIATE_TEST_SUITE_P(
+    BinomialTreeConfigs,
+    BroadcastAlgorithmParamTest,
+    ::testing::Values(
+        // Medium message at threshold (64KB), root=0
+        BroadcastAlgorithmTestParams{
+            .numBlocks = 8,
+            .blockSize = 512,
+            .numBytes = 64 * 1024,
+            .rootRank = 0,
+            .algorithm = BroadcastAlgorithm::BinomialTree,
+            .testName = "binomial_64KB_root0"},
+
+        // Large message (256KB), root=0
+        BroadcastAlgorithmTestParams{
+            .numBlocks = 8,
+            .blockSize = 512,
+            .numBytes = 256 * 1024,
+            .rootRank = 0,
+            .algorithm = BroadcastAlgorithm::BinomialTree,
+            .testName = "binomial_256KB_root0"},
+
+        // Large message (512KB), middle root
+        BroadcastAlgorithmTestParams{
+            .numBlocks = 8,
+            .blockSize = 512,
+            .numBytes = 512 * 1024,
+            .rootRank = -1,
+            .algorithm = BroadcastAlgorithm::BinomialTree,
+            .testName = "binomial_512KB_middle_root"},
+
+        // Near ring threshold (1MB - 1), root=0
+        BroadcastAlgorithmTestParams{
+            .numBlocks = 8,
+            .blockSize = 512,
+            .numBytes = 1024 * 1024 - 1024,
+            .rootRank = 0,
+            .algorithm = BroadcastAlgorithm::BinomialTree,
+            .testName = "binomial_1MB_minus_1KB_root0"},
+
+        // Boundary test: last rank as root
+        BroadcastAlgorithmTestParams{
+            .numBlocks = 8,
+            .blockSize = 512,
+            .numBytes = 128 * 1024,
+            .rootRank = 7,
+            .algorithm = BroadcastAlgorithm::BinomialTree,
+            .testName = "binomial_128KB_last_root"}),
+    [](const ::testing::TestParamInfo<BroadcastAlgorithmTestParams>& info) {
+      return info.param.testName;
+    });
+
+// Ring algorithm tests (designed for messages >= 1MB)
+// Tests the bandwidth-optimized ring algorithm with various message sizes
+INSTANTIATE_TEST_SUITE_P(
+    RingConfigs,
+    BroadcastAlgorithmParamTest,
+    ::testing::Values(
+        // At ring threshold (1MB), root=0
+        BroadcastAlgorithmTestParams{
+            .numBlocks = 8,
+            .blockSize = 512,
+            .numBytes = 1024 * 1024,
+            .rootRank = 0,
+            .algorithm = BroadcastAlgorithm::Ring,
+            .testName = "ring_1MB_root0"},
+
+        // Large message (2MB), root=0
+        BroadcastAlgorithmTestParams{
+            .numBlocks = 16,
+            .blockSize = 512,
+            .numBytes = 2 * 1024 * 1024,
+            .rootRank = 0,
+            .algorithm = BroadcastAlgorithm::Ring,
+            .testName = "ring_2MB_root0"},
+
+        // Large message (4MB), middle root
+        BroadcastAlgorithmTestParams{
+            .numBlocks = 16,
+            .blockSize = 512,
+            .numBytes = 4 * 1024 * 1024,
+            .rootRank = -1,
+            .algorithm = BroadcastAlgorithm::Ring,
+            .testName = "ring_4MB_middle_root"},
+
+        // Very large message (8MB), root=0
+        BroadcastAlgorithmTestParams{
+            .numBlocks = 16,
+            .blockSize = 512,
+            .numBytes = 8 * 1024 * 1024,
+            .rootRank = 0,
+            .algorithm = BroadcastAlgorithm::Ring,
+            .testName = "ring_8MB_root0"},
+
+        // Boundary test: last rank as root
+        BroadcastAlgorithmTestParams{
+            .numBlocks = 16,
+            .blockSize = 512,
+            .numBytes = 2 * 1024 * 1024,
+            .rootRank = 7,
+            .algorithm = BroadcastAlgorithm::Ring,
+            .testName = "ring_2MB_last_root"}),
+    [](const ::testing::TestParamInfo<BroadcastAlgorithmTestParams>& info) {
+      return info.param.testName;
+    });
+
+/**
+ * Test edge case: single-rank broadcast (no-op).
+ *
+ * When there's only one rank, broadcast should be a no-op.
+ * The data should remain unchanged.
+ *
+ * Note: This test only runs effectively when launched with ppn=1.
+ * When launched with ppn>1, it tests that single-rank edge case
+ * handling works even if we manually set nranks=1.
+ */
+TEST_F(BroadcastTestFixture, SingleRankNoOp) {
+  // Skip if actually running multi-rank - this test is for single rank only
+  if (numRanks > 1) {
+    GTEST_SKIP() << "Skipping single-rank test in multi-rank environment";
+  }
+
+  const size_t numBytes = 256;
+  const size_t numInts = numBytes / sizeof(int32_t);
+  const int rootRank = 0;
+
+  XLOGF(DBG1, "Rank {}: Running single-rank no-op test", globalRank);
+
+  // Create minimal transport setup
+  P2pSelfTransportDevice selfTransport;
+  std::vector<Transport> h_transports;
+  h_transports.emplace_back(selfTransport);
+
+  DeviceBuffer d_transports(sizeof(Transport));
+  CUDACHECK_TEST(cudaMemcpy(
+      d_transports.get(),
+      h_transports.data(),
+      sizeof(Transport),
+      cudaMemcpyHostToDevice));
+
+  DeviceSpan<Transport> transports_span(
+      static_cast<Transport*>(d_transports.get()), 1);
+
+  // Initialize buffer with known pattern
+  DeviceBuffer buffer(numBytes);
+  std::vector<int32_t> h_init(numInts);
+  for (size_t i = 0; i < numInts; i++) {
+    h_init[i] = 42 + static_cast<int32_t>(i); // Arbitrary pattern
+  }
+  CUDACHECK_TEST(cudaMemcpy(
+      buffer.get(), h_init.data(), numBytes, cudaMemcpyHostToDevice));
+
+  // Execute broadcast (should be no-op for single rank)
+  test::testBroadcast(
+      buffer.get(),
+      globalRank,
+      rootRank,
+      transports_span,
+      numBytes,
+      4, // numBlocks
+      256); // blockSize
+
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  // Verify data is unchanged
+  std::vector<int32_t> h_result(numInts);
+  CUDACHECK_TEST(cudaMemcpy(
+      h_result.data(), buffer.get(), numBytes, cudaMemcpyDeviceToHost));
+
+  EXPECT_EQ(h_result, h_init) << "Single-rank broadcast should not modify data";
+}
+
+/**
+ * Test edge case: zero-byte broadcast (no-op).
+ *
+ * Broadcasting zero bytes should be a no-op and not crash.
+ */
+TEST_F(BroadcastTestFixture, ZeroByteBroadcast) {
+  const int rootRank = 0;
+
+  XLOGF(DBG1, "Rank {}: Running zero-byte broadcast test", globalRank);
+
+  // Setup transport
+  MultiPeerNvlTransportConfig config{
+      .dataBufferSize = 2048,
+      .chunkSize = 512,
+      .pipelineDepth = 4,
+  };
+
+  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
+  transport.exchange();
+
+  P2pSelfTransportDevice selfTransport;
+  std::vector<Transport> h_transports;
+  h_transports.reserve(numRanks);
+
+  for (int rank = 0; rank < numRanks; rank++) {
+    if (rank == globalRank) {
+      h_transports.emplace_back(selfTransport);
+    } else {
+      h_transports.emplace_back(transport.getP2pTransportDevice(rank));
+    }
+  }
+
+  DeviceBuffer d_transports(sizeof(Transport) * numRanks);
+  CUDACHECK_TEST(cudaMemcpy(
+      d_transports.get(),
+      h_transports.data(),
+      sizeof(Transport) * numRanks,
+      cudaMemcpyHostToDevice));
+
+  DeviceSpan<Transport> transports_span(
+      static_cast<Transport*>(d_transports.get()), numRanks);
+
+  // Allocate a small buffer (won't be used since nbytes=0)
+  DeviceBuffer buffer(64);
+  ::comms::pipes::test::fillBuffer(
+      reinterpret_cast<int*>(buffer.get()), 99, 16);
+
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  // Execute zero-byte broadcast
+  test::testBroadcast(
+      buffer.get(),
+      globalRank,
+      rootRank,
+      transports_span,
+      0, // zero bytes
+      4,
+      256);
+
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  // Verify buffer is unchanged (should still have 99s)
+  std::vector<int32_t> h_result(16);
+  CUDACHECK_TEST(
+      cudaMemcpy(h_result.data(), buffer.get(), 64, cudaMemcpyDeviceToHost));
+
+  for (size_t i = 0; i < 16; i++) {
+    EXPECT_EQ(h_result[i], 99)
+        << "Zero-byte broadcast should not modify buffer at index " << i;
+  }
+
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
+} // namespace comms::pipes::collectives
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new MPIEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/pipes/tests/BroadcastTest.cu
+++ b/comms/pipes/tests/BroadcastTest.cu
@@ -1,0 +1,91 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/tests/BroadcastTest.cuh"
+
+#include "comms/pipes/collectives/Broadcast.cuh"
+#include "comms/pipes/collectives/BroadcastBinomialTree.cuh"
+#include "comms/pipes/collectives/BroadcastRing.cuh"
+#include "comms/pipes/tests/Checks.h"
+
+namespace comms::pipes::collectives::test {
+
+/**
+ * Device kernel that invokes the flat-tree broadcast collective.
+ * Minimal wrapper - all logic is in Broadcast.cuh.
+ */
+__global__ void testBroadcastKernel(
+    void* buff_d,
+    int my_rank_id,
+    int root_rank_id,
+    DeviceSpan<Transport> transports_per_rank,
+    std::size_t nbytes) {
+  broadcast(buff_d, my_rank_id, root_rank_id, transports_per_rank, nbytes);
+}
+
+/**
+ * Device kernel that invokes the binomial tree broadcast collective.
+ * Minimal wrapper - all logic is in BroadcastBinomialTree.cuh.
+ */
+__global__ void testBroadcastBinomialTreeKernel(
+    void* buff_d,
+    int my_rank_id,
+    int root_rank_id,
+    DeviceSpan<Transport> transports_per_rank,
+    std::size_t nbytes) {
+  broadcast_binomial_tree(
+      buff_d, my_rank_id, root_rank_id, transports_per_rank, nbytes);
+}
+
+/**
+ * Device kernel that invokes the ring broadcast collective.
+ * Minimal wrapper - all logic is in BroadcastRing.cuh.
+ */
+__global__ void testBroadcastRingKernel(
+    void* buff_d,
+    int my_rank_id,
+    int root_rank_id,
+    DeviceSpan<Transport> transports_per_rank,
+    std::size_t nbytes) {
+  broadcast_ring(buff_d, my_rank_id, root_rank_id, transports_per_rank, nbytes);
+}
+
+void testBroadcast(
+    void* buff_d,
+    int my_rank_id,
+    int root_rank_id,
+    DeviceSpan<Transport> transports_per_rank,
+    std::size_t nbytes,
+    int numBlocks,
+    int blockSize) {
+  testBroadcastKernel<<<numBlocks, blockSize>>>(
+      buff_d, my_rank_id, root_rank_id, transports_per_rank, nbytes);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void testBroadcastBinomialTree(
+    void* buff_d,
+    int my_rank_id,
+    int root_rank_id,
+    DeviceSpan<Transport> transports_per_rank,
+    std::size_t nbytes,
+    int numBlocks,
+    int blockSize) {
+  testBroadcastBinomialTreeKernel<<<numBlocks, blockSize>>>(
+      buff_d, my_rank_id, root_rank_id, transports_per_rank, nbytes);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void testBroadcastRing(
+    void* buff_d,
+    int my_rank_id,
+    int root_rank_id,
+    DeviceSpan<Transport> transports_per_rank,
+    std::size_t nbytes,
+    int numBlocks,
+    int blockSize) {
+  testBroadcastRingKernel<<<numBlocks, blockSize>>>(
+      buff_d, my_rank_id, root_rank_id, transports_per_rank, nbytes);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+} // namespace comms::pipes::collectives::test

--- a/comms/pipes/tests/BroadcastTest.cuh
+++ b/comms/pipes/tests/BroadcastTest.cuh
@@ -1,0 +1,73 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "comms/pipes/DeviceSpan.cuh"
+#include "comms/pipes/Transport.cuh"
+
+namespace comms::pipes::collectives::test {
+
+/**
+ * Host-callable wrapper to launch the broadcast test kernel (flat-tree).
+ *
+ * @param buff_d Device buffer (source for root, destination for non-root)
+ * @param my_rank_id Current rank ID
+ * @param root_rank_id Rank that broadcasts data
+ * @param transports_per_rank Array of transport objects
+ * @param nbytes Number of bytes to broadcast
+ * @param numBlocks Number of CUDA blocks to launch
+ * @param blockSize Number of threads per block
+ */
+void testBroadcast(
+    void* buff_d,
+    int my_rank_id,
+    int root_rank_id,
+    DeviceSpan<Transport> transports_per_rank,
+    std::size_t nbytes,
+    int numBlocks,
+    int blockSize);
+
+/**
+ * Host-callable wrapper to launch the binomial tree broadcast test kernel.
+ *
+ * @param buff_d Device buffer (source for root, destination for non-root)
+ * @param my_rank_id Current rank ID
+ * @param root_rank_id Rank that broadcasts data
+ * @param transports_per_rank Array of transport objects
+ * @param nbytes Number of bytes to broadcast
+ * @param numBlocks Number of CUDA blocks to launch
+ * @param blockSize Number of threads per block
+ */
+void testBroadcastBinomialTree(
+    void* buff_d,
+    int my_rank_id,
+    int root_rank_id,
+    DeviceSpan<Transport> transports_per_rank,
+    std::size_t nbytes,
+    int numBlocks,
+    int blockSize);
+
+/**
+ * Host-callable wrapper to launch the ring broadcast test kernel.
+ *
+ * @param buff_d Device buffer (source for root, destination for non-root)
+ * @param my_rank_id Current rank ID
+ * @param root_rank_id Rank that broadcasts data
+ * @param transports_per_rank Array of transport objects
+ * @param nbytes Number of bytes to broadcast
+ * @param numBlocks Number of CUDA blocks to launch
+ * @param blockSize Number of threads per block
+ */
+void testBroadcastRing(
+    void* buff_d,
+    int my_rank_id,
+    int root_rank_id,
+    DeviceSpan<Transport> transports_per_rank,
+    std::size_t nbytes,
+    int numBlocks,
+    int blockSize);
+
+} // namespace comms::pipes::collectives::test


### PR DESCRIPTION
Summary:
**TL;DR:** Adds CUDA kernel wrappers for broadcast algorithms and a tuning header with empirically-derived optimal configuration functions for chunk size, staging buffer, pipeline depth, and thread block dimensions.

---

# Detailed Overview

## Context & Motivation
Broadcast benchmarks require host-callable kernel wrappers and configuration tuning logic. The optimal parameters vary significantly with message size and rank count, requiring auto-tuning based on empirical profiling results.

## Specific Changes Enumerated 

**BenchmarkKernel.cu/cuh additions:**
- `broadcastKernel`: Flat-tree algorithm wrapper
- `broadcastBinomialTreeKernel`: Binomial tree algorithm wrapper
- `broadcastRingKernel`: Ring algorithm wrapper
- `broadcastAdaptiveKernel`: Adaptive algorithm selection wrapper
- `broadcastAdaptiveV2Kernel`: Alternative adaptive implementation
- `BroadcastTimingStats` struct for detailed profiling

**BroadcastTuning.h tuning logic:**
- `getOptimalChunkSize()`: 4KB-128KB based on message size (smaller is better for parallelism)
- `getOptimalStagingBufferSize()`: 64KB-8MB based on message and chunk size
- `getOptimalPipelineDepth()`: 2-8 based on message size
- `getOptimalNumBlocks()`: 4-64 based on message size and rank count
- `getOptimalNumThreads()`: 256-512 based on message size
- `shouldUseRing()`: Returns true for messages ≥8MB with >2 ranks
- `getOptimalBroadcastConfig()`: Complete configuration struct

Differential Revision: D91504826


