### PR TITLE
Revert D91542525, D91543940 and D91021939 that worked on adding CUDA assert calls to torchcomms tests.  Instead, switch to using cpp_unittest to run the tests on CPU as designed.

### DIFF
--- a/comms/torchcomms/nccl/TorchCommNCCL.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCL.cpp
@@ -58,9 +58,6 @@ void TorchCommNCCL::init(
     at::Device device,
     const std::string& name,
     const CommOptions& options) {
-  TORCH_INTERNAL_ASSERT(
-      device.is_cuda(), "TorchCommNCCL requires a CUDA device");
-
   // Initialize private members
   device_ = device;
   name_ = name;
@@ -202,10 +199,6 @@ void TorchCommNCCL::init(
 }
 
 void TorchCommNCCL::finalize() {
-  TORCH_INTERNAL_ASSERT(
-      init_state_ != InitializationState::INITIALIZED || nccl_comm_ != nullptr,
-      "nccl_comm_ is null but state indicates we are initialized");
-
   if (init_state_ == InitializationState::UNINITIALIZED) {
     throw std::runtime_error("TorchCommNCCL not initialized");
   } else if (init_state_ == InitializationState::FINALIZED) {
@@ -1665,10 +1658,6 @@ std::shared_ptr<TorchCommBackend> TorchCommNCCL::split(
     const CommOptions& options) {
   // Validate the ranks list
   checkAndAbortIfTimedOutOrError();
-
-  TORCH_INTERNAL_ASSERT(
-      comm_size_ > 0,
-      "comm_size_ should be positive; was split called on an uninitialized comm?");
 
   std::unordered_set<int> rank_seen;
   for (int rank : ranks) {

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -87,9 +87,6 @@ void TorchCommNCCLX::init(
     at::Device device,
     const std::string& name,
     const CommOptions& options) {
-  TORCH_INTERNAL_ASSERT(
-      device.is_cuda(), "TorchCommNCCLX requires a CUDA device");
-
   // Initialize private members
   device_ = device;
   name_ = name;
@@ -101,6 +98,7 @@ void TorchCommNCCLX::init(
   } else if (init_state_ == InitializationState::FINALIZED) {
     throw std::runtime_error("TorchCommNCCLX already finalized");
   }
+  init_state_ = InitializationState::INITIALIZED;
 
   // Initialize default NCCL API implementation if not already set
   if (!nccl_api_) {
@@ -239,9 +237,6 @@ void TorchCommNCCLX::init(
 
   // Register comm with CachingAllocator
   attachMemoryHook();
-
-  // Mark initialization as complete only after all steps succeed
-  init_state_ = InitializationState::INITIALIZED;
 }
 
 void TorchCommNCCLX::finalize() {
@@ -2019,10 +2014,6 @@ std::shared_ptr<TorchCommBackend> TorchCommNCCLX::split(
     const std::string& split_name,
     const CommOptions& options) {
   checkAndAbortIfTimedOutOrError();
-
-  TORCH_INTERNAL_ASSERT(
-      comm_size_ > 0,
-      "comm_size_ should be positive; was split called on an uninitialized comm?");
 
   // Validate that all ranks are valid
   for (int rank : ranks) {

--- a/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTest.cpp
@@ -267,8 +267,7 @@ TEST_F(TorchCommNCCLXTest, InitializationFailsWithInvalidDeviceId) {
         comm->init(invalid_device, "test_name", default_options_),
         std::runtime_error);
 
-    // After a failed init, finalize should throw since we're not initialized
-    EXPECT_THROW(comm->finalize(), std::runtime_error);
+    comm->finalize();
   }
 }
 

--- a/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTestBase.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTestBase.cpp
@@ -22,9 +22,8 @@ void TorchCommNCCLXTest::SetUp() {
   // Create hash store for communication
   store_ = c10::make_intrusive<c10d::HashStore>();
 
-  // Set up device. Use CUDA device since TorchCommNCCLX requires it.
-  // The actual CUDA calls are mocked, so no real GPU is needed.
-  device_ = at::Device(at::DeviceType::CUDA, 0);
+  // Set up device. make it the cpu device because we're mocking cuda.
+  device_ = at::Device(at::DeviceType::CPU, 0);
 
   // Set timeout to 2 seconds for tests
   default_options_ = CommOptions();

--- a/comms/torchcomms/ncclx/tests/unit/cpp/TorchWorkNCCLXQueueTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/TorchWorkNCCLXQueueTest.cpp
@@ -65,9 +65,8 @@ class TorchWorkNCCLXQueueCommTest : public ::testing::Test {
     // Create hash store for communication
     auto store_ = c10::make_intrusive<c10d::HashStore>();
 
-    // Set up device. Use CUDA device since TorchCommNCCLX requires it.
-    // The actual CUDA calls are mocked, so no real GPU is needed.
-    device_ = at::Device(at::DeviceType::CUDA, 0);
+    // Set up device. make it the cpu device because we're mocking cuda.
+    device_ = at::Device(at::DeviceType::CPU, 0);
 
     // Set timeout to 2 seconds for tests
     default_options_ = CommOptions();


### PR DESCRIPTION
Summary:
Revert D91542525, D91543940 and D91021939 that worked on adding CUDA assert calls to torchcomms tests.  Instead, switch to using cpp_unittest to run the tests on CPU as designed.

Also updated CachingAllocatorMock to also mock registerMemPreHook method

Reviewed By: saifhhasan

Differential Revision: D91615589


