### PR TITLE
Match baseline NCCL ncclDebugLog signature for plugin ABI compatibility

### DIFF
--- a/comms/ncclx/v2_28/src/debug.cc
+++ b/comms/ncclx/v2_28/src/debug.cc
@@ -313,7 +313,7 @@ static void ncclDebugInit() {
   __atomic_store_n(&ncclDebugLevel, tempNcclDebugLevel, __ATOMIC_RELEASE);
 }
 
-void ncclMetaDebugLogWithScuba(ncclDebugLogLevel level, unsigned long flags, const char *file, const char *func, int line, const char *fmt, ...) {
+void ncclMetaDebugLogWithScuba(ncclDebugLogLevel level, unsigned long flags, const char *filefunc, int line, const char *fmt, ...) {
   char buffer[256];
   va_list vargs;
   va_start(vargs, fmt);
@@ -321,14 +321,14 @@ void ncclMetaDebugLogWithScuba(ncclDebugLogLevel level, unsigned long flags, con
   va_end(vargs);
   ::meta::comms::logger::appendErrorToStack(std::string{buffer});
   ErrorStackTraceUtil::logErrorMessage(std::string{buffer});
-  ncclDebugLog(level, flags, file, func, line, "%s", buffer);
+  ncclDebugLog(level, flags, filefunc, line, "%s", buffer);
 }
 
 /* Common logging function used by the INFO, WARN and TRACE macros
  * Also exported to the dynamically loadable Net transport modules so
  * they can share the debugging mechanisms and output files
  */
-void ncclDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *file, const char *func, int line, const char *fmt, ...) {
+void ncclDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *filefunc, int line, const char *fmt, ...) {
   int gotLevel = __atomic_load_n(&ncclDebugLevel, __ATOMIC_ACQUIRE);
 
   if (ncclDebugNoWarn != 0 && (level == NCCL_LOG_WARN || level == NCCL_LOG_ERROR)) { level = NCCL_LOG_INFO; flags = ncclDebugNoWarn; }
@@ -386,9 +386,9 @@ void ncclDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *file
   folly::LogStreamProcessor(
     XLOG_GET_CATEGORY(),
     logLevel,
-    file,
+    filefunc,
     line,
-    func,
+    "",
     folly::LogStreamProcessor::AppendType::APPEND)
         .stream()
     << logStr;

--- a/comms/ncclx/v2_28/src/include/debug.h
+++ b/comms/ncclx/v2_28/src/include/debug.h
@@ -20,20 +20,20 @@ extern int ncclDebugLevel;
 extern uint64_t ncclDebugMask;
 extern FILE *ncclDebugFile;
 
-void ncclDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *file, const char *func, int line, const char *fmt, ...) __attribute__ ((format (printf, 6, 7)));
+void ncclDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *filefunc, int line, const char *fmt, ...) __attribute__ ((format (printf, 5, 6)));
 
-void ncclMetaDebugLogWithScuba(ncclDebugLogLevel level, unsigned long flags, const char *file, const char *func, int line, const char *fmt, ...) __attribute__ ((format (printf, 6, 7)));
+void ncclMetaDebugLogWithScuba(ncclDebugLogLevel level, unsigned long flags, const char *filefunc, int line, const char *fmt, ...) __attribute__ ((format (printf, 5, 6)));
 
 // Let code temporarily downgrade WARN into INFO
 extern thread_local int ncclDebugNoWarn;
 extern char ncclLastError[];
 
-#define VERSION(...) ncclDebugLog(NCCL_LOG_VERSION, NCCL_ALL, __FILE__, __func__, __LINE__, __VA_ARGS__)
-#define WARN(...) ncclDebugLog(NCCL_LOG_WARN, NCCL_ALL, __FILE__, __func__, __LINE__, __VA_ARGS__)
-#define ERR(...) ncclDebugLog(NCCL_LOG_ERROR, NCCL_ALL, __FILE__, __func__, __LINE__, __VA_ARGS__)
+#define VERSION(...) ncclDebugLog(NCCL_LOG_VERSION, NCCL_ALL, __func__, __LINE__, __VA_ARGS__)
+#define WARN(...) ncclDebugLog(NCCL_LOG_WARN, NCCL_ALL, __func__, __LINE__, __VA_ARGS__)
+#define ERR(...) ncclDebugLog(NCCL_LOG_ERROR, NCCL_ALL, __func__, __LINE__, __VA_ARGS__)
 
-#define WARN_WITH_SCUBA(...) ncclMetaDebugLogWithScuba(NCCL_LOG_WARN, NCCL_ALL, __FILE__, __func__, __LINE__, __VA_ARGS__)
-#define ERR_WITH_SCUBA(...) ncclMetaDebugLogWithScuba(NCCL_LOG_ERROR, NCCL_ALL, __FILE__, __func__, __LINE__, __VA_ARGS__)
+#define WARN_WITH_SCUBA(...) ncclMetaDebugLogWithScuba(NCCL_LOG_WARN, NCCL_ALL, __func__, __LINE__, __VA_ARGS__)
+#define ERR_WITH_SCUBA(...) ncclMetaDebugLogWithScuba(NCCL_LOG_ERROR, NCCL_ALL, __func__, __LINE__, __VA_ARGS__)
 
 
 #define NOWARN(EXPR, FLAGS) \
@@ -48,14 +48,14 @@ extern char ncclLastError[];
     do{ \
         int level = __atomic_load_n(&ncclDebugLevel, __ATOMIC_ACQUIRE); \
         if((level >= NCCL_LOG_INFO && ((unsigned long)(FLAGS) & ncclDebugMask)) || (level < 0)) \
-            ncclDebugLog(NCCL_LOG_INFO, (unsigned long)(FLAGS), __FILE__, __func__, __LINE__, __VA_ARGS__); \
+            ncclDebugLog(NCCL_LOG_INFO, (unsigned long)(FLAGS), __func__, __LINE__, __VA_ARGS__); \
     } while(0)
 
 #define TRACE_CALL(...) \
     do { \
         int level = __atomic_load_n(&ncclDebugLevel, __ATOMIC_ACQUIRE); \
         if((level >= NCCL_LOG_TRACE && (NCCL_CALL & ncclDebugMask)) || (level < 0)) { \
-            ncclDebugLog(NCCL_LOG_TRACE, NCCL_CALL, __FILE__, __func__, __LINE__, __VA_ARGS__); \
+            ncclDebugLog(NCCL_LOG_TRACE, NCCL_CALL, __func__, __LINE__, __VA_ARGS__); \
         } \
     } while (0)
 
@@ -64,7 +64,7 @@ extern char ncclLastError[];
     do { \
         int level = __atomic_load_n(&ncclDebugLevel, __ATOMIC_ACQUIRE); \
         if ((level >= NCCL_LOG_TRACE && ((unsigned long)(FLAGS) & ncclDebugMask)) || (level < 0)) { \
-            ncclDebugLog(NCCL_LOG_TRACE, (unsigned long)(FLAGS), __FILE__, __func__, __LINE__, __VA_ARGS__); \
+            ncclDebugLog(NCCL_LOG_TRACE, (unsigned long)(FLAGS), __func__, __LINE__, __VA_ARGS__); \
         } \
     } while (0)
 #else

--- a/comms/ncclx/v2_28/src/include/nccl_common.h
+++ b/comms/ncclx/v2_28/src/include/nccl_common.h
@@ -44,7 +44,7 @@ typedef enum {
   NCCL_ALL = ~0
 } ncclDebugLogSubSys;
 
-typedef void (*ncclDebugLogger_t)(ncclDebugLogLevel level, unsigned long flags, const char *file, const char *func, int line, const char *fmt, ...);
+typedef void (*ncclDebugLogger_t)(ncclDebugLogLevel level, unsigned long flags, const char *filefunc, int line, const char *fmt, ...);
 
 // NCCL core profiler callback for network defined events instrumentation
 enum {


### PR DESCRIPTION
Summary:
The OFI network plugin is compiled against baseline NCCL headers which expect a 5-parameter ncclDebugLog signature (with combined filefunc). NCCLx had a 6-parameter version (separate file and func params), causing ABI incompatibility and segfaults when loading the plugin.

This change aligns NCCLx's debug logging interface with baseline NCCL to enable using pre-compiled OFI plugins without recompilation.

Reviewed By: zhiyongww, saifhhasan

Differential Revision: D91632308


