### PR TITLE
Making activites in ProfilerGuard, and PG name in sanityCheckProfilerMeta a parameter

### DIFF
--- a/comms/torchcomms/ncclx/tests/integration/cpp/ProfilerTestMain.cpp
+++ b/comms/torchcomms/ncclx/tests/integration/cpp/ProfilerTestMain.cpp
@@ -63,7 +63,7 @@ TEST_F(ProfilerNcclxTest, AllTests) {
   if (rank_ == 0) {
     Json::Value json_value = readTraceFile(trace_file);
     std::map<std::string, std::vector<Json::Value>> events;
-    sanityCheckProfilerMeta(json_value, events);
+    sanityCheckProfilerMeta(json_value, events, "comms_test_name");
 
     // Call the validation function
     validation_func_(events);

--- a/comms/torchcomms/tests/integration/cpp/ProfilerTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/ProfilerTest.cpp
@@ -33,7 +33,8 @@ Json::Value ProfilerTest::readTraceFile(
 
 void ProfilerTest::sanityCheckProfilerMeta(
     const Json::Value& json_value,
-    std::map<std::string, std::vector<Json::Value>>& events) {
+    std::map<std::string, std::vector<Json::Value>>& events,
+    const std::string& pgName) {
   ASSERT_GT(json_value["traceEvents"].size(), 1u);
 
   for (const auto& event : json_value["traceEvents"]) {
@@ -51,7 +52,7 @@ void ProfilerTest::sanityCheckProfilerMeta(
     }
     events[coll_name].push_back(args);
 
-    ASSERT_EQ(args["Process Group Name"], "comms_test_name");
+    ASSERT_EQ(args["Process Group Name"], pgName);
     ASSERT_NE(args["Process Group Ranks"], "");
 
     ASSERT_GE(args["In msg nelems"], 0);

--- a/comms/torchcomms/tests/integration/cpp/ProfilerTest.hpp
+++ b/comms/torchcomms/tests/integration/cpp/ProfilerTest.hpp
@@ -17,7 +17,10 @@ constexpr at::ScalarType kProfilerTestTensorDtype = at::kFloat;
 // RAII guard for profiler setup/teardown
 class ProfilerGuard {
  public:
-  ProfilerGuard() {
+  ProfilerGuard(
+      const std::set<torch::autograd::profiler::ActivityType>& activities = {
+          torch::autograd::profiler::ActivityType::CPU,
+          torch::autograd::profiler::ActivityType::CUDA}) {
     torch::autograd::profiler::ProfilerConfig cfg{
         torch::autograd::profiler::ProfilerState::KINETO,
         true,
@@ -25,9 +28,7 @@ class ProfilerGuard {
         false,
         false,
         false};
-    std::set<torch::autograd::profiler::ActivityType> activities{
-        torch::autograd::profiler::ActivityType::CPU,
-        torch::autograd::profiler::ActivityType::CUDA};
+
     torch::autograd::profiler::prepareProfiler(cfg, activities);
     torch::autograd::profiler::enableProfiler(cfg, activities);
   }
@@ -78,7 +79,8 @@ class ProfilerTest : public ::testing::Test {
 
   static void sanityCheckProfilerMeta(
       const Json::Value& json_value,
-      std::map<std::string, std::vector<Json::Value>>& events);
+      std::map<std::string, std::vector<Json::Value>>& events,
+      const std::string& pgName);
 
   c10::intrusive_ptr<torch::comms::TorchWork> runAllCollectiveOperations();
 


### PR DESCRIPTION
Summary:
Make ProfilerGuard activities and sanityCheckProfilerMeta pgName configurable parameters

This diff refactors two aspects of the ProfilerTest to improve flexibility:

1. **ProfilerGuard activities**: Made the activity types (CPU, CUDA, etc.) a constructor parameter instead of hardcoding them. This allows different tests to profile different  activity types as needed, while maintaining the default behavior (CPU + CUDA) for existing call sites.

2. **sanityCheckProfilerMeta pgName**: Added a pgName parameter to allow tests to specify the expected process group name for validation.

Differential Revision: D91678532


