### PR TITLE
Introduce device-side assertion macros that remain active in release builds

### DIFF
--- a/comms/pipes/DeviceCheck.cuh
+++ b/comms/pipes/DeviceCheck.cuh
@@ -1,0 +1,83 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdio>
+
+namespace comms::pipes {
+
+/**
+ * PIPES_DEVICE_CHECK: Device-side assertion that remains active in @mode/opt.
+ *
+ * Unlike standard assert(), this macro is NOT disabled by NDEBUG and will
+ * trigger a kernel trap in both debug and optimized builds.
+ *
+ * Behavior:
+ * - On device: Prints diagnostic message and calls __trap() to abort the kernel
+ * - On host: Evaluates to no-op (host-side checks should use standard assert)
+ *
+ * Usage:
+ *   PIPES_DEVICE_CHECK(transport.type == TransportType::P2P_NVL);
+ *   PIPES_DEVICE_CHECK(idx < size);
+ *
+ * Note: __trap() puts the CUDA device into an unrecoverable error state. After
+ * a trap, cudaDeviceReset() is required to recover the device context.
+ */
+#ifdef __CUDA_ARCH__
+#define PIPES_DEVICE_CHECK(expr)                                    \
+  do {                                                              \
+    if (!(expr)) {                                                  \
+      printf(                                                       \
+          "PIPES_DEVICE_CHECK: %s in %s at %s:%d block=(%u,%u,%u) " \
+          "thread=(%u,%u,%u)\n",                                    \
+          #expr,                                                    \
+          __func__,                                                 \
+          __FILE__,                                                 \
+          __LINE__,                                                 \
+          blockIdx.x,                                               \
+          blockIdx.y,                                               \
+          blockIdx.z,                                               \
+          threadIdx.x,                                              \
+          threadIdx.y,                                              \
+          threadIdx.z);                                             \
+      __trap();                                                     \
+    }                                                               \
+  } while (0)
+#else
+#define PIPES_DEVICE_CHECK(expr) ((void)0)
+#endif
+
+/**
+ * PIPES_DEVICE_CHECK_MSG: Device-side assertion with custom message.
+ *
+ * Same as PIPES_DEVICE_CHECK but allows a custom message for added context.
+ *
+ * Usage:
+ *   PIPES_DEVICE_CHECK_MSG(idx < size, "Index out of bounds");
+ */
+#ifdef __CUDA_ARCH__
+#define PIPES_DEVICE_CHECK_MSG(expr, msg)                                \
+  do {                                                                   \
+    if (!(expr)) {                                                       \
+      printf(                                                            \
+          "PIPES_DEVICE_CHECK: %s (%s) in %s at %s:%d block=(%u,%u,%u) " \
+          "thread=(%u,%u,%u)\n",                                         \
+          #expr,                                                         \
+          msg,                                                           \
+          __func__,                                                      \
+          __FILE__,                                                      \
+          __LINE__,                                                      \
+          blockIdx.x,                                                    \
+          blockIdx.y,                                                    \
+          blockIdx.z,                                                    \
+          threadIdx.x,                                                   \
+          threadIdx.y,                                                   \
+          threadIdx.z);                                                  \
+      __trap();                                                          \
+    }                                                                    \
+  } while (0)
+#else
+#define PIPES_DEVICE_CHECK_MSG(expr, msg) ((void)0)
+#endif
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/AllToAllv.cuh
+++ b/comms/pipes/collectives/AllToAllv.cuh
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <cstdio>
 
+#include "comms/pipes/DeviceCheck.cuh"
 #include "comms/pipes/DeviceSpan.cuh"
 #include "comms/pipes/Timeout.cuh"
 #include "comms/pipes/Transport.cuh"
@@ -114,8 +115,8 @@ __device__ __forceinline__ void all_to_allv(
 #ifdef __CUDA_ARCH__
   auto group = make_warp_group();
   const auto nranks = transports_per_rank.size();
-  assert(nranks == send_chunk_infos.size());
-  assert(nranks == recv_chunk_infos.size());
+  PIPES_DEVICE_CHECK(nranks == send_chunk_infos.size());
+  PIPES_DEVICE_CHECK(nranks == recv_chunk_infos.size());
 
   // Single rank case - just do self-copy
   if (nranks == 1) {
@@ -125,7 +126,7 @@ __device__ __forceinline__ void all_to_allv(
     char* dst = static_cast<char*>(recvbuff_d) + recv_info.offset;
 
     auto& transport = transports_per_rank[my_rank_id];
-    assert(transport.type == TransportType::SELF);
+    PIPES_DEVICE_CHECK(transport.type == TransportType::SELF);
     transport.self.put(group, dst, src, send_info.nbytes);
     return;
   }
@@ -142,11 +143,11 @@ __device__ __forceinline__ void all_to_allv(
   if (peer_rank_id == my_rank_id) {
     // Self partition - both send and recv groups participate in copying
     auto& transport = transports_per_rank[my_rank_id];
-    assert(transport.type == TransportType::SELF);
+    PIPES_DEVICE_CHECK(transport.type == TransportType::SELF);
 
     const auto& send_info = send_chunk_infos[my_rank_id];
     const auto& recv_info = recv_chunk_infos[my_rank_id];
-    assert(send_info.nbytes == recv_info.nbytes);
+    PIPES_DEVICE_CHECK(send_info.nbytes == recv_info.nbytes);
 
     const char* src = static_cast<const char*>(sendbuff_d) + send_info.offset;
     char* dst = static_cast<char*>(recvbuff_d) + recv_info.offset;
@@ -178,7 +179,7 @@ __device__ __forceinline__ void all_to_allv(
   // reloads. Local variable is provably independent. See DeviceSpan.cuh:228.
   auto transports = transports_per_rank.data();
   auto& transport = transports[peer_rank_id];
-  assert(transport.type == TransportType::P2P_NVL);
+  PIPES_DEVICE_CHECK(transport.type == TransportType::P2P_NVL);
 
 #ifdef DEBUG_ALLTOALLV
   if (group_per_peer.is_global_leader()) {

--- a/comms/pipes/tests/DeviceCheckMsgTrapTest.cc
+++ b/comms/pipes/tests/DeviceCheckMsgTrapTest.cc
@@ -1,0 +1,73 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include "comms/pipes/tests/DeviceCheckTest.cuh"
+#include "comms/testinfra/TestXPlatUtils.h"
+
+namespace comms::pipes {
+
+// =============================================================================
+// Trap Test - PIPES_DEVICE_CHECK_MSG
+// =============================================================================
+//
+// This test is in a separate binary because:
+// 1. __trap() puts the CUDA device into an unrecoverable error state
+// 2. cudaDeviceReset() is required to recover, but it invalidates all contexts
+// 3. This would break any subsequent tests in the same process
+
+class DeviceCheckMsgTrapTestFixture : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Ensure we have a valid CUDA device
+    int deviceCount = 0;
+    cudaError_t deviceErr = cudaGetDeviceCount(&deviceCount);
+    if (deviceErr != cudaSuccess || deviceCount == 0) {
+      GTEST_SKIP() << "No CUDA devices available";
+    }
+    CUDACHECK_TEST(cudaSetDevice(0));
+  }
+
+  void TearDown() override {
+    // Clear any CUDA errors from trap tests
+    cudaGetLastError(); // NOLINT(facebook-cuda-safe-api-call-check)
+  }
+};
+
+// Test: Verify that PIPES_DEVICE_CHECK_MSG with a false expression triggers a
+// device-side trap. This validates that the macro with custom message correctly
+// aborts kernel execution when the invariant is violated.
+//
+// Note: __trap() causes an illegal instruction that stops kernel execution.
+// After the trap fires, cudaDeviceSynchronize() returns an error.
+TEST_F(DeviceCheckMsgTrapTestFixture, DeviceCheckMsgWithFalseExpressionTraps) {
+  const int numBlocks = 1;
+  const int blockSize = 32;
+
+  // Launch the kernel - this should trigger the device trap
+  test::testDeviceCheckMsgFailing(numBlocks, blockSize);
+
+  // Synchronize and check for error
+  cudaError_t syncError = cudaDeviceSynchronize();
+
+  // The trap should have fired, causing a CUDA error
+  EXPECT_TRUE(
+      syncError == cudaErrorIllegalInstruction ||
+      syncError == cudaErrorAssert || syncError == cudaErrorLaunchFailure)
+      << "Expected CUDA error when PIPES_DEVICE_CHECK_MSG expression is false, "
+         "but got: "
+      << cudaGetErrorString(syncError);
+
+  // Reset the device to clear the sticky error state
+  cudaDeviceReset(); // NOLINT(facebook-cuda-safe-api-call-check)
+  cudaSetDevice(0); // NOLINT(facebook-cuda-safe-api-call-check)
+  cudaGetLastError(); // NOLINT(facebook-cuda-safe-api-call-check)
+}
+
+} // namespace comms::pipes
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/pipes/tests/DeviceCheckTest.cc
+++ b/comms/pipes/tests/DeviceCheckTest.cc
@@ -1,0 +1,119 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include "comms/pipes/tests/DeviceCheckTest.cuh"
+#include "comms/testinfra/TestXPlatUtils.h"
+
+namespace comms::pipes {
+
+class DeviceCheckTestFixture : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    int deviceCount = 0; // Ensure valid CUDA device
+    cudaError_t deviceErr = cudaGetDeviceCount(&deviceCount);
+    if (deviceErr != cudaSuccess || deviceCount == 0) {
+      GTEST_SKIP() << "No CUDA devices available";
+    }
+    CUDACHECK_TEST(cudaSetDevice(0));
+  }
+
+  void TearDown() override {
+    // Clear any lingering CUDA errors
+    cudaGetLastError(); // NOLINT(facebook-cuda-safe-api-call-check)
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+  }
+};
+
+// ==================================================================
+// Passing Case Tests (kernel should complete without error)
+// ==================================================================
+
+// Test: PIPES_DEVICE_CHECK with true expression completes successfully.
+// Verifies that the macro doesn't trigger a trap when the condition is true.
+TEST_F(DeviceCheckTestFixture, DeviceCheckPassingDoesNotTrap) {
+  const int numBlocks = 1;
+  const int blockSize = 32;
+
+  // Launch the kernel - should complete without error
+  test::testDeviceCheckPassing(numBlocks, blockSize);
+
+  // Verify kernel completed successfully
+  cudaError_t syncError = cudaDeviceSynchronize();
+  EXPECT_EQ(syncError, cudaSuccess)
+      << "PIPES_DEVICE_CHECK with true expression should not cause error, got: "
+      << cudaGetErrorString(syncError);
+}
+
+// Test: PIPES_DEVICE_CHECK_MSG with true expression completes successfully.
+// Verifies that macro with custom message doesn't trap when condition is true.
+TEST_F(DeviceCheckTestFixture, DeviceCheckMsgPassingDoesNotTrap) {
+  const int numBlocks = 1;
+  const int blockSize = 32;
+
+  // Launch the kernel - should complete without error
+  test::testDeviceCheckMsgPassing(numBlocks, blockSize);
+
+  // Verify kernel completed successfully
+  cudaError_t syncError = cudaDeviceSynchronize();
+  EXPECT_EQ(syncError, cudaSuccess)
+      << "PIPES_DEVICE_CHECK_MSG with true expression should not cause error, "
+         "got: "
+      << cudaGetErrorString(syncError);
+}
+
+// Test: Multiple PIPES_DEVICE_CHECK calls in a kernel all pass.
+// Verifies that multiple checks can coexist in the same kernel and all
+// evaluate correctly.
+TEST_F(DeviceCheckTestFixture, MultipleDeviceChecksPassingAllSucceed) {
+  const int numBlocks = 1;
+  const int blockSize = 32;
+  const uint32_t value = 5;
+  const uint32_t threshold = 10;
+
+  // Launch the kernel with value < threshold - all checks should pass
+  test::testMultipleDeviceChecksPassing(value, threshold, numBlocks, blockSize);
+
+  // Verify kernel completed successfully
+  cudaError_t syncError = cudaDeviceSynchronize();
+  EXPECT_EQ(syncError, cudaSuccess)
+      << "Multiple passing PIPES_DEVICE_CHECK calls should not cause error, "
+         "got: "
+      << cudaGetErrorString(syncError);
+}
+
+// Test: PIPES_DEVICE_CHECK works correctly with larger block configurations.
+// Verifies that the macro works across different thread configurations.
+TEST_F(DeviceCheckTestFixture, DeviceCheckPassingMultipleBlocks) {
+  const int numBlocks = 4;
+  const int blockSize = 128;
+
+  // Launch with multiple blocks - should complete without error
+  test::testDeviceCheckPassing(numBlocks, blockSize);
+
+  // Verify kernel completed successfully
+  cudaError_t syncError = cudaDeviceSynchronize();
+  EXPECT_EQ(syncError, cudaSuccess)
+      << "PIPES_DEVICE_CHECK should work with multiple blocks, got: "
+      << cudaGetErrorString(syncError);
+}
+
+// Test: PIPES_DEVICE_CHECK_MSG works correctly with larger block
+// configurations. Verifies that the macro with message works across different
+// thread configurations.
+TEST_F(DeviceCheckTestFixture, DeviceCheckMsgPassingMultipleBlocks) {
+  const int numBlocks = 4;
+  const int blockSize = 128;
+
+  // Launch with multiple blocks - should complete without error
+  test::testDeviceCheckMsgPassing(numBlocks, blockSize);
+
+  // Verify kernel completed successfully
+  cudaError_t syncError = cudaDeviceSynchronize();
+  EXPECT_EQ(syncError, cudaSuccess)
+      << "PIPES_DEVICE_CHECK_MSG should work with multiple blocks, got: "
+      << cudaGetErrorString(syncError);
+}
+
+} // namespace comms::pipes

--- a/comms/pipes/tests/DeviceCheckTest.cu
+++ b/comms/pipes/tests/DeviceCheckTest.cu
@@ -1,0 +1,96 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <cstdint>
+
+#include "comms/pipes/DeviceCheck.cuh"
+
+namespace comms::pipes::test {
+
+// =============================================================================
+// Passing case kernels - PIPES_DEVICE_CHECK with true expressions
+// =============================================================================
+
+// Kernel that uses PIPES_DEVICE_CHECK with an expression that evaluates to
+// true. Should complete without triggering a trap.
+__global__ void testDeviceCheckPassingKernel() {
+  // Simple true expression - should not trap
+  PIPES_DEVICE_CHECK(1 == 1);
+
+  // Thread-based check - always true since threadIdx is always >= 0
+  PIPES_DEVICE_CHECK(threadIdx.x >= 0);
+}
+
+void testDeviceCheckPassing(int numBlocks, int blockSize) {
+  testDeviceCheckPassingKernel<<<numBlocks, blockSize>>>();
+}
+
+// Kernel that uses PIPES_DEVICE_CHECK_MSG with an expression that evaluates to
+// true. Should complete without triggering a trap.
+__global__ void testDeviceCheckMsgPassingKernel() {
+  // Simple true expression with custom message - should not trap
+  PIPES_DEVICE_CHECK_MSG(1 == 1, "This should never print");
+
+  // Block-based check - always true since blockIdx is always >= 0
+  PIPES_DEVICE_CHECK_MSG(blockIdx.x >= 0, "Block index is never negative");
+}
+
+void testDeviceCheckMsgPassing(int numBlocks, int blockSize) {
+  testDeviceCheckMsgPassingKernel<<<numBlocks, blockSize>>>();
+}
+
+// Kernel with multiple PIPES_DEVICE_CHECK calls, all passing.
+// Tests that multiple checks in sequence work correctly.
+__global__ void testMultipleDeviceChecksPassingKernel(
+    uint32_t value,
+    uint32_t threshold) {
+  // Multiple checks that should all pass when value <= threshold
+  PIPES_DEVICE_CHECK(value <= threshold);
+  PIPES_DEVICE_CHECK(value >= 0); // Always true for unsigned
+  PIPES_DEVICE_CHECK_MSG(threshold > 0, "Threshold must be positive");
+}
+
+void testMultipleDeviceChecksPassing(
+    uint32_t value,
+    uint32_t threshold,
+    int numBlocks,
+    int blockSize) {
+  testMultipleDeviceChecksPassingKernel<<<numBlocks, blockSize>>>(
+      value, threshold);
+}
+
+// =============================================================================
+// Trap kernels - PIPES_DEVICE_CHECK with false expressions
+// =============================================================================
+
+// Kernel that uses PIPES_DEVICE_CHECK with a false expression.
+// Should trigger __trap() and cause a CUDA error.
+__global__ void testDeviceCheckFailingKernel() {
+  // False expression - should trigger trap
+  PIPES_DEVICE_CHECK(1 == 0);
+}
+
+void testDeviceCheckFailing(int numBlocks, int blockSize) {
+  // NOLINT because we intentionally don't check launch errors - the kernel
+  // is expected to trap
+  testDeviceCheckFailingKernel<<<
+      numBlocks,
+      blockSize>>>(); // NOLINT(facebook-cuda-safe-kernel-call-check)
+}
+
+// Kernel that uses PIPES_DEVICE_CHECK_MSG with a false expression.
+// Should trigger __trap() and cause a CUDA error.
+__global__ void testDeviceCheckMsgFailingKernel() {
+  // False expression with custom message - should trigger trap
+  PIPES_DEVICE_CHECK_MSG(1 == 0, "This intentionally fails for testing");
+}
+
+void testDeviceCheckMsgFailing(int numBlocks, int blockSize) {
+  // NOLINT because we intentionally don't check launch errors - the kernel
+  // is expected to trap
+  testDeviceCheckMsgFailingKernel<<<
+      numBlocks,
+      blockSize>>>(); // NOLINT(facebook-cuda-safe-kernel-call-check)
+}
+
+} // namespace comms::pipes::test

--- a/comms/pipes/tests/DeviceCheckTest.cuh
+++ b/comms/pipes/tests/DeviceCheckTest.cuh
@@ -1,0 +1,40 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <cstdint>
+
+namespace comms::pipes::test {
+
+// =============================================================================
+// Passing case tests - expression evaluates to true, kernel completes normally
+// =============================================================================
+
+// Tests PIPES_DEVICE_CHECK with a true expression - should complete without
+// trap
+void testDeviceCheckPassing(int numBlocks, int blockSize);
+
+// Tests PIPES_DEVICE_CHECK_MSG with a true expression - should complete without
+// trap
+void testDeviceCheckMsgPassing(int numBlocks, int blockSize);
+
+// Tests multiple PIPES_DEVICE_CHECK calls in same kernel - all passing
+void testMultipleDeviceChecksPassing(
+    uint32_t value,
+    uint32_t threshold,
+    int numBlocks,
+    int blockSize);
+
+// =============================================================================
+// Trap tests - expression evaluates to false, triggers __trap()
+// =============================================================================
+
+// Tests PIPES_DEVICE_CHECK with a false expression - should trigger trap
+void testDeviceCheckFailing(int numBlocks, int blockSize);
+
+// Tests PIPES_DEVICE_CHECK_MSG with a false expression - should trigger trap
+void testDeviceCheckMsgFailing(int numBlocks, int blockSize);
+
+} // namespace comms::pipes::test

--- a/comms/pipes/tests/DeviceCheckTrapTest.cc
+++ b/comms/pipes/tests/DeviceCheckTrapTest.cc
@@ -1,0 +1,73 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include "comms/pipes/tests/DeviceCheckTest.cuh"
+#include "comms/testinfra/TestXPlatUtils.h"
+
+namespace comms::pipes {
+
+// =============================================================================
+// Trap Test - PIPES_DEVICE_CHECK
+// =============================================================================
+//
+// This test is in a separate binary because:
+// 1. __trap() puts the CUDA device into an unrecoverable error state
+// 2. cudaDeviceReset() is required to recover, but it invalidates all contexts
+// 3. This would break any subsequent tests in the same process
+
+class DeviceCheckTrapTestFixture : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Ensure we have a valid CUDA device
+    int deviceCount = 0;
+    cudaError_t deviceErr = cudaGetDeviceCount(&deviceCount);
+    if (deviceErr != cudaSuccess || deviceCount == 0) {
+      GTEST_SKIP() << "No CUDA devices available";
+    }
+    CUDACHECK_TEST(cudaSetDevice(0));
+  }
+
+  void TearDown() override {
+    // Clear any CUDA errors from trap tests
+    cudaGetLastError(); // NOLINT(facebook-cuda-safe-api-call-check)
+  }
+};
+
+// Test: Verify that PIPES_DEVICE_CHECK with a false expression triggers a
+// device-side trap. This validates that the macro correctly aborts kernel
+// execution when the invariant is violated.
+//
+// Note: __trap() causes an illegal instruction that stops kernel execution.
+// After the trap fires, cudaDeviceSynchronize() returns an error.
+TEST_F(DeviceCheckTrapTestFixture, DeviceCheckWithFalseExpressionTraps) {
+  const int numBlocks = 1;
+  const int blockSize = 32;
+
+  // Launch the kernel - this should trigger the device trap
+  test::testDeviceCheckFailing(numBlocks, blockSize);
+
+  // Synchronize and check for error
+  cudaError_t syncError = cudaDeviceSynchronize();
+
+  // The trap should have fired, causing a CUDA error
+  EXPECT_TRUE(
+      syncError == cudaErrorIllegalInstruction ||
+      syncError == cudaErrorAssert || syncError == cudaErrorLaunchFailure)
+      << "Expected CUDA error when PIPES_DEVICE_CHECK expression is false, "
+         "but got: "
+      << cudaGetErrorString(syncError);
+
+  // Reset the device to clear the sticky error state
+  cudaDeviceReset(); // NOLINT(facebook-cuda-safe-api-call-check)
+  cudaSetDevice(0); // NOLINT(facebook-cuda-safe-api-call-check)
+  cudaGetLastError(); // NOLINT(facebook-cuda-safe-api-call-check)
+}
+
+} // namespace comms::pipes
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Summary:
**TL;DR:** Adds `PIPES_DEVICE_CHECK` and `PIPES_DEVICE_CHECK_MSG` macros for device-side assertions that remain active in `mode/opt` builds, enabling detection of invariant violations within GPU kernels.

## Context & Motivation

IIUC, standard C++ `assert()` statements are disabled when `NDEBUG` is defined, which occurs in optimized/release builds (`mode/opt`). This creates a dangerous gap in GPU kernel code: invariant violations that would be caught during development go undetected in production, potentially causing silent data corruption or undefined behavior.

Differential Revision: D91689639


