### PR TITLE
remove dependency on ruamel.yaml from extractcvars.py

### DIFF
--- a/comms/utils/cvars/extractcvars.py
+++ b/comms/utils/cvars/extractcvars.py
@@ -9,7 +9,7 @@ import pathlib
 import subprocess
 from io import StringIO
 
-import ruamel.yaml as yaml
+import yaml
 
 # Maps from environment variables to CVAR names.
 # These are used to populate the C++ CVAR mappings.
@@ -771,7 +771,7 @@ def main():
 
     print(f"Parsing NCCL env variables from {config_file}")
     with open(config_file, "r") as f:
-        data = yaml.YAML().load(f.read())
+        data = yaml.safe_load(f)
     if data["cvars"] is None:
         data["cvars"] = []
 


### PR DESCRIPTION
Summary:
As title, removes the dependency on the `ruamel.yaml` Python module for the `extractcvars.py` library.

This is ultimately to enable D88748045, as the dependency on `ruamel.yaml` was proving to be problematic: the NCCLX GitHub OSS build was breaking due to the `ruamel.yaml` not being present, and adding the `ruamel.yaml` module to the build environment was unexpectedly not straight-forward.

Differential Revision: D91694592


