### PR TITLE
Fix duplicate commDesc comparison in ctranConfig equality operator

### DIFF
--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -26,7 +26,6 @@ struct ctranConfig {
   bool operator==(const ctranConfig& other) const {
     return (
         blocking == other.blocking && commDesc == other.commDesc &&
-        commDesc == other.commDesc &&
         ncclAllGatherAlgo == other.ncclAllGatherAlgo &&
         backends == other.backends);
   }


### PR DESCRIPTION
Summary:
Duplicate check of
```
commDesc == other.commDesc
```

Reviewed By: minsii

Differential Revision: D91696569


