### PR TITLE
Pass p2pNvlTransportDevice to kernels by pointer to allow stateful transport

### DIFF
--- a/comms/pipes/DeviceSpan.cuh
+++ b/comms/pipes/DeviceSpan.cuh
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cuda_runtime.h>
+
 #include <cassert>
 #include <cstdint>
 

--- a/comms/pipes/MultiPeerNvlTransport.cc
+++ b/comms/pipes/MultiPeerNvlTransport.cc
@@ -2,15 +2,30 @@
 
 #include "comms/pipes/MultiPeerNvlTransport.h"
 
+#include <cuda_runtime.h>
 #include <vector>
 
 #include "comms/pipes/MultiPeerDeviceTransport.cuh"
+#include "comms/pipes/P2pSelfTransportDevice.cuh"
+#include "comms/pipes/Transport.cuh"
 #include "comms/pipes/window/DeviceWindowMemory.cuh"
-#include "comms/pipes/window/DeviceWindowSignal.cuh"
 #include "comms/pipes/window/WindowMemory.h"
 #include "comms/utils/checks.h"
 
 namespace comms::pipes {
+
+namespace {
+// Helper macro for CUDA error checking
+#define CUDACHECK(cmd)                                                   \
+  do {                                                                   \
+    cudaError_t e = cmd;                                                 \
+    if (e != cudaSuccess) {                                              \
+      throw std::runtime_error(                                          \
+          std::string("CUDA error: ") + cudaGetErrorString(e) + " at " + \
+          __FILE__ + ":" + std::to_string(__LINE__));                    \
+    }                                                                    \
+  } while (0)
+} // namespace
 
 MultiPeerNvlTransport::MultiPeerNvlTransport(
     int myRank,
@@ -63,6 +78,12 @@ MultiPeerNvlTransport::MultiPeerNvlTransport(
   stateBufferHandler_ = std::make_unique<GpuMemHandler>(
       bootstrap_, myRank_, nRanks_, totalChunkStateBufferSize, memSharingMode_);
 
+  // Allocate device memory for Transport array (nRanks elements)
+  // This array is populated in exchange() after peer buffer pointers are
+  // available. Uses DeviceBuffer instead of raw cudaMalloc for RAII.
+  transportsDevice_ =
+      std::make_unique<meta::comms::DeviceBuffer>(nRanks_ * sizeof(Transport));
+
   // Initialize state buffer to READY_TO_SEND for all pipeline slots
   auto statePtr =
       static_cast<ChunkState*>(stateBufferHandler_->getLocalDeviceMemPtr());
@@ -91,9 +112,47 @@ void MultiPeerNvlTransport::exchange() {
   dataBufferHandler_->exchangeMemPtrs();
   stateBufferHandler_->exchangeMemPtrs();
   signalBufferHandler_->exchangeMemPtrs();
+
+  // Build Transport array with P2pNvlTransportDevice stored by value
+  auto* transports_d = static_cast<Transport*>(transportsDevice_->get());
+  for (int rank = 0; rank < nRanks_; ++rank) {
+    if (rank == myRank_) {
+      // Self transport for local copies
+      P2pSelfTransportDevice selfDevice{};
+      Transport hostTransport{selfDevice};
+      CUDACHECK(cudaMemcpy(
+          &transports_d[rank],
+          &hostTransport,
+          sizeof(Transport),
+          cudaMemcpyHostToDevice));
+    } else {
+      // P2P NVL transport - store by value in Transport
+      P2pNvlTransportDevice nvlDevice = buildP2pTransportDevice(rank);
+      Transport hostTransport{nvlDevice};
+      CUDACHECK(cudaMemcpy(
+          &transports_d[rank],
+          &hostTransport,
+          sizeof(Transport),
+          cudaMemcpyHostToDevice));
+    }
+  }
 }
 
-P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
+P2pNvlTransportDevice* MultiPeerNvlTransport::getP2pTransportDevice(
+    int peerRank) {
+  // Return pointer to the P2pNvlTransportDevice stored in the Transport union
+  if (peerRank == myRank_) {
+    throw std::runtime_error("Cannot get P2P transport for self rank");
+  }
+  auto* transports_d = static_cast<Transport*>(transportsDevice_->get());
+  return &transports_d[peerRank].p2p_nvl;
+}
+
+Transport* MultiPeerNvlTransport::getTransportsArray() {
+  return static_cast<Transport*>(transportsDevice_->get());
+}
+
+P2pNvlTransportDevice MultiPeerNvlTransport::buildP2pTransportDevice(
     int peerRank) {
   // Buffer Layout Example (4 ranks, buffer size X per peer):
   //
@@ -203,29 +262,41 @@ MultiPeerDeviceTransport MultiPeerNvlTransport::getMultiPeerDeviceTransport(
 }
 
 void MultiPeerNvlTransport::initializeTransportsArray() {
-  // Allocate device memory for Transport objects using DeviceBuffer
+  // NOTE: This function is for legacy lazy initialization via
+  // getDeviceTransports(). The main initialization path is in exchange() which
+  // populates transportsDevice_.
+  //
+  // If transportsDevice_ is already allocated (from constructor), this function
+  // just returns as the arrays were already set up in exchange().
+  if (transportsDevice_) {
+    return;
+  }
+
+  // Fallback: allocate and initialize if not already done
   transportsDevice_ =
       std::make_unique<meta::comms::DeviceBuffer>(nRanks_ * sizeof(Transport));
 
-  // Build host-side Transport array, then batch copy to device
-  // Note: We use move semantics since Transport is non-copyable
-  std::vector<Transport> hostTransports;
-  hostTransports.reserve(nRanks_);
+  // Build Transport array with P2pNvlTransportDevice stored by value
+  auto* transports_d = static_cast<Transport*>(transportsDevice_->get());
   for (int rank = 0; rank < nRanks_; ++rank) {
     if (rank == myRank_) {
-      hostTransports.emplace_back(P2pSelfTransportDevice());
+      P2pSelfTransportDevice selfDevice{};
+      Transport hostTransport{selfDevice};
+      CUDACHECK(cudaMemcpy(
+          &transports_d[rank],
+          &hostTransport,
+          sizeof(Transport),
+          cudaMemcpyHostToDevice));
     } else {
-      hostTransports.emplace_back(getP2pTransportDevice(rank));
+      P2pNvlTransportDevice nvlDevice = buildP2pTransportDevice(rank);
+      Transport hostTransport{nvlDevice};
+      CUDACHECK(cudaMemcpy(
+          &transports_d[rank],
+          &hostTransport,
+          sizeof(Transport),
+          cudaMemcpyHostToDevice));
     }
   }
-
-  // Single batched memcpy for all Transport objects
-  // This works because Transport is designed for byte-copy (see Transport.cuh)
-  CUDA_CHECK(cudaMemcpy(
-      transportsDevice_->get(),
-      hostTransports.data(),
-      nRanks_ * sizeof(Transport),
-      cudaMemcpyDefault));
 }
 
 } // namespace comms::pipes

--- a/comms/pipes/MultiPeerNvlTransport.h
+++ b/comms/pipes/MultiPeerNvlTransport.h
@@ -7,6 +7,7 @@
 #include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/pipes/GpuMemHandler.h"
 #include "comms/pipes/P2pNvlTransportDevice.cuh"
+#include "comms/pipes/P2pSelfTransportDevice.cuh"
 #include "comms/pipes/Transport.cuh"
 #include "comms/utils/CudaRAII.h"
 
@@ -93,12 +94,17 @@ class MultiPeerNvlTransport {
    * Allocates local GPU buffers for multi-peer communication:
    * - Data buffer: for staging data transfers (nRanks-1 peer regions)
    * - State buffer: for chunk-level synchronization states
+   * - P2pNvlTransportDevice array: preallocated on device memory for all peers
+   *   to allow stateful tranport and reduce kernel launch latency (avoids
+   *   per-launch H2D copy)
    *
    * Memory sharing mode is automatically detected:
    * - Fabric handles (H100+, CUDA 12.3+): Enables GB200 multi-node NVLink
    * - cudaIpcMemHandle (fallback): Works on all CUDA GPUs, intra-node only
    *
    * Does NOT exchange memory handles - call exchange() after construction.
+   * The preallocated P2pNvlTransportDevice array is populated in exchange()
+   * after peer buffer pointers are available.
    *
    * @param myRank This rank's ID in the communicator (0 to nRanks-1)
    * @param nRanks Total number of ranks in the communicator
@@ -130,7 +136,9 @@ class MultiPeerNvlTransport {
    * Performs collective handle exchange using the bootstrap interface:
    * 1. Each rank shares its local buffer's handle with all other ranks
    * 2. Each rank receives handles from all other ranks
-   * 3. Implicit barrier ensures all ranks complete before returning
+   * 3. Builds and copies P2pNvlTransportDevice for each peer to the
+   *    preallocated device array (allocated in constructor)
+   * 4. Implicit barrier ensures all ranks complete before returning
    *
    * The type of handle (fabric or cudaIpc) depends on the automatically
    * detected memory sharing mode.
@@ -145,8 +153,10 @@ class MultiPeerNvlTransport {
   /**
    * getP2pTransportDevice - Get device handle for P2P communication with a peer
    *
-   * Returns a device-side transport handle configured for communication with
-   * the specified peer rank. This handle can be passed to CUDA kernels.
+   * Returns a pointer to the device-side transport handle configured for
+   * communication with the specified peer rank. This handle can be passed to
+   * CUDA kernels. The P2pNvlTransportDevice is preallocated on device memory
+   * in the constructor to reduce kernel launch latency.
    *
    * PRECONDITION: exchange() must have been called by all ranks first.
    *
@@ -157,13 +167,63 @@ class MultiPeerNvlTransport {
    *
    * @param peerRank Target peer rank ID (must be in range [0, nRanks) and !=
    * myRank)
-   * @return P2pNvlTransportDevice handle for use in CUDA kernels
+   * @return Pointer to P2pNvlTransportDevice on device memory for use in CUDA
+   * kernels
    *
    * @note Thread-safe after exchange() completes
    * @note Can be called multiple times for the same or different peers
-   * @note The returned handle is copyable and can be passed to multiple kernels
+   * @note The returned pointer is valid until this MultiPeerNvlTransport is
+   * destroyed
    */
-  P2pNvlTransportDevice getP2pTransportDevice(int peerRank);
+  P2pNvlTransportDevice* getP2pTransportDevice(int peerRank);
+
+  /**
+   * getTransportsArray - Get preallocated Transport array on device memory
+   *
+   * Returns a pointer to the device-side Transport array containing all
+   * transport handles (P2pSelfTransportDevice for self, P2pNvlTransportDevice
+   * for all peers). This array can be passed directly to CUDA kernels for
+   * all-to-all communication patterns without per-launch H2D copies.
+   *
+   * PRECONDITION: exchange() must have been called by all ranks first.
+   *
+   * Array layout: [Transport for rank 0, Transport for rank 1, ..., Transport
+   * for rank nRanks-1]
+   * - transports_d_[myRank_] contains P2pSelfTransportDevice
+   * - transports_d_[peerRank] contains P2pNvlTransportDevice for peer
+   *
+   * @return Pointer to Transport array on device memory (size = nRanks)
+   *
+   * @note Thread-safe after exchange() completes
+   * @note The returned pointer is valid until this MultiPeerNvlTransport is
+   * destroyed
+   */
+  Transport* getTransportsArray();
+
+  /**
+   * getNRanks - Get total number of ranks
+   *
+   * @return Total number of ranks in the communicator
+   */
+  int getNRanks() const {
+    return nRanks_;
+  }
+
+  /**
+   * buildP2pTransportDevice - Build host-side P2pNvlTransportDevice
+   *
+   * Constructs a P2pNvlTransportDevice on the host for the specified peer.
+   *
+   * This method is used in tests to access const members and when building
+   * Transport objects on the host side.
+   *
+   * PRECONDITION: exchange() must have been called first (for external use).
+   *
+   * @param peerRank Target peer rank ID (must be in range [0, nRanks) and !=
+   * myRank)
+   * @return P2pNvlTransportDevice constructed on the host
+   */
+  P2pNvlTransportDevice buildP2pTransportDevice(int peerRank);
 
   /**
    * getMultiPeerDeviceTransport - Get unified device handle for all peers

--- a/comms/pipes/MultiPeerTransport.cc
+++ b/comms/pipes/MultiPeerTransport.cc
@@ -115,7 +115,7 @@ bool MultiPeerTransport::is_ibgda_peer(int peerRank) const {
   return typePerRank_[peerRank] == TransportType::P2P_IBGDA;
 }
 
-P2pNvlTransportDevice MultiPeerTransport::get_p2p_nvl_transport_device(
+P2pNvlTransportDevice* MultiPeerTransport::get_p2p_nvl_transport_device(
     int globalPeerRank) const {
   if (!nvlTransport_) {
     throw std::runtime_error(
@@ -180,7 +180,8 @@ void MultiPeerTransport::build_device_handle() {
 
       case TransportType::P2P_NVL: {
         int nvlLocal = globalToNvlLocal_.at(r);
-        auto nvlDev = nvlTransport_->getP2pTransportDevice(nvlLocal);
+        P2pNvlTransportDevice nvlDev =
+            nvlTransport_->buildP2pTransportDevice(nvlLocal);
         new (&transportsHost[r]) Transport(nvlDev);
         break;
       }

--- a/comms/pipes/MultiPeerTransport.h
+++ b/comms/pipes/MultiPeerTransport.h
@@ -131,9 +131,10 @@ class MultiPeerTransport {
 
   /**
    * @param globalPeerRank Global rank of the NVL peer.
-   * @return P2pNvlTransportDevice handle (by value) for the given peer.
+   * @return Pointer to P2pNvlTransportDevice on device memory for the given
+   * peer.
    */
-  P2pNvlTransportDevice get_p2p_nvl_transport_device(int globalPeerRank) const;
+  P2pNvlTransportDevice* get_p2p_nvl_transport_device(int globalPeerRank) const;
 
   /**
    * @param globalPeerRank Global rank of the IBGDA peer.

--- a/comms/pipes/benchmarks/BenchmarkKernel.cuh
+++ b/comms/pipes/benchmarks/BenchmarkKernel.cuh
@@ -27,7 +27,7 @@ struct TimingStats {
 
 // Send kernel - groupScope selects warp vs block level parallelism
 __global__ void p2pSend(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     void* srcBuff,
     std::size_t nBytes,
     SyncScope groupScope = SyncScope::WARP,
@@ -35,7 +35,7 @@ __global__ void p2pSend(
 
 // Recv kernel
 __global__ void p2pRecv(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     void* dstBuff,
     std::size_t nBytes,
     SyncScope groupScope = SyncScope::WARP,
@@ -43,14 +43,14 @@ __global__ void p2pRecv(
 
 // Timed versions that export GPU-side clock64() timing stats
 __global__ void p2pSendTimed(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     void* srcBuff,
     std::size_t nBytes,
     TimingStats* stats,
     SyncScope groupScope = SyncScope::WARP);
 
 __global__ void p2pRecvTimed(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     void* dstBuff,
     std::size_t nBytes,
     TimingStats* stats,
@@ -58,16 +58,16 @@ __global__ void p2pRecvTimed(
 
 // Bidirectional kernel - half groups send, half groups receive
 __global__ void p2pBidirectional(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     void* sendBuff,
     void* recvBuff,
     std::size_t nBytes,
     SyncScope groupScope = SyncScope::WARP,
     Timeout timeout = Timeout());
 
-// Signal benchmark kernel - ping-pong signaling between two peers
+// Signal benchmark kernel - ping-pong signaling pattern
 __global__ void p2pSignalBenchKernel(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     int nSteps,
     SyncScope groupScope = SyncScope::WARP);
 

--- a/comms/pipes/collectives/Dispatchv.cu
+++ b/comms/pipes/collectives/Dispatchv.cu
@@ -4,6 +4,7 @@
 #include "comms/pipes/collectives/Dispatchv.h"
 
 #include "comms/pipes/Checks.h"
+#include "comms/pipes/P2pNvlTransportDevice.cuh"
 #include "comms/pipes/ThreadGroup.cuh"
 
 namespace comms::pipes {

--- a/comms/pipes/collectives/benchmarks/AllToAllvBenchmark.cc
+++ b/comms/pipes/collectives/benchmarks/AllToAllvBenchmark.cc
@@ -241,26 +241,11 @@ class AllToAllvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     MultiPeerNvlTransport transport(globalRank, nranks, bootstrap, nvlConfig);
     transport.exchange();
 
-    // Create transport array: self for my rank, P2P for others
-    P2pSelfTransportDevice selfTransport;
-    std::vector<Transport> h_transports;
-    h_transports.reserve(nranks);
-
-    for (int rank = 0; rank < nranks; rank++) {
-      if (rank == globalRank) {
-        h_transports.emplace_back(selfTransport);
-      } else {
-        h_transports.emplace_back(transport.getP2pTransportDevice(rank));
-      }
-    }
-
-    // Copy transports to device
-    DeviceBuffer d_transports(sizeof(Transport) * nranks);
-    CUDA_CHECK(cudaMemcpy(
-        d_transports.get(),
-        h_transports.data(),
-        sizeof(Transport) * nranks,
-        cudaMemcpyHostToDevice));
+    // Get preallocated transport array from MultiPeerNvlTransport
+    // (includes P2pSelfTransportDevice for self and P2pNvlTransportDevice for
+    // peers)
+    DeviceSpan<Transport> transports_span(
+        transport.getTransportsArray(), nranks);
 
     // Create chunk info arrays (equal size for all peers)
     std::vector<ChunkInfo> h_send_chunks, h_recv_chunks;
@@ -283,8 +268,6 @@ class AllToAllvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
         cudaMemcpyHostToDevice));
 
     // Create device spans
-    DeviceSpan<Transport> transports_span(
-        static_cast<Transport*>(d_transports.get()), nranks);
     DeviceSpan<ChunkInfo> send_chunk_infos(
         static_cast<ChunkInfo*>(d_send_chunks.get()), nranks);
     DeviceSpan<ChunkInfo> recv_chunk_infos(

--- a/comms/pipes/collectives/benchmarks/DispatchBenchmark.cc
+++ b/comms/pipes/collectives/benchmarks/DispatchBenchmark.cc
@@ -15,10 +15,10 @@
 
 #include "comms/pipes/DeviceSpan.cuh"
 #include "comms/pipes/MultiPeerNvlTransport.h"
-#include "comms/pipes/P2pSelfTransportDevice.cuh"
 #include "comms/pipes/Transport.cuh"
 #include "comms/pipes/collectives/Dispatchv.h"
 #include "comms/testinfra/BenchmarkTestFixture.h"
+#include "comms/testinfra/mpi/MpiBootstrap.h"
 #include "comms/testinfra/mpi/MpiTestUtils.h"
 #include "comms/utils/CudaRAII.h"
 
@@ -194,32 +194,8 @@ class DispatchBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
         globalRank, nranks, bootstrap, transportConfig);
     transport.exchange();
 
-    // Create transport array on device
-    std::size_t transportsSize = nranks * sizeof(Transport);
-    std::vector<char> transportsHostBuffer(transportsSize);
-    for (int rank = 0; rank < nranks; rank++) {
-      Transport* slot = reinterpret_cast<Transport*>(
-          transportsHostBuffer.data() + rank * sizeof(Transport));
-      if (rank == globalRank) {
-        new (slot) Transport(P2pSelfTransportDevice());
-      } else {
-        new (slot) Transport(transport.getP2pTransportDevice(rank));
-      }
-    }
-
-    DeviceBuffer transportsDevice(transportsSize);
-    CUDA_CHECK(cudaMemcpy(
-        transportsDevice.get(),
-        transportsHostBuffer.data(),
-        transportsSize,
-        cudaMemcpyHostToDevice));
-
-    // Destroy host Transport objects
-    for (int rank = 0; rank < nranks; rank++) {
-      Transport* slot = reinterpret_cast<Transport*>(
-          transportsHostBuffer.data() + rank * sizeof(Transport));
-      slot->~Transport();
-    }
+    // Use preallocated transport array from MultiPeerNvlTransport
+    DeviceSpan<Transport> transports(transport.getTransportsArray(), nranks);
 
     // Benchmark timing
     CudaEvent start, stop;
@@ -235,8 +211,7 @@ class DispatchBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
           DeviceSpan<std::size_t>(
               static_cast<std::size_t*>(outputChunkSizesPerRankDevice.get()),
               nranks * totalChunks),
-          DeviceSpan<Transport>(
-              static_cast<Transport*>(transportsDevice.get()), nranks),
+          transports,
           globalRank,
           sendBuffer.get(),
           DeviceSpan<const std::size_t>(
@@ -265,8 +240,7 @@ class DispatchBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
           DeviceSpan<std::size_t>(
               static_cast<std::size_t*>(outputChunkSizesPerRankDevice.get()),
               nranks * totalChunks),
-          DeviceSpan<Transport>(
-              static_cast<Transport*>(transportsDevice.get()), nranks),
+          transports,
           globalRank,
           sendBuffer.get(),
           DeviceSpan<const std::size_t>(
@@ -400,32 +374,8 @@ class DispatchBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
         globalRank, nranks, bootstrap, transportConfig);
     transport.exchange();
 
-    // Create transport array on device
-    std::size_t transportsSize = nranks * sizeof(Transport);
-    std::vector<char> transportsHostBuffer(transportsSize);
-    for (int rank = 0; rank < nranks; rank++) {
-      Transport* slot = reinterpret_cast<Transport*>(
-          transportsHostBuffer.data() + rank * sizeof(Transport));
-      if (rank == globalRank) {
-        new (slot) Transport(P2pSelfTransportDevice());
-      } else {
-        new (slot) Transport(transport.getP2pTransportDevice(rank));
-      }
-    }
-
-    DeviceBuffer transportsDevice(transportsSize);
-    CUDA_CHECK(cudaMemcpy(
-        transportsDevice.get(),
-        transportsHostBuffer.data(),
-        transportsSize,
-        cudaMemcpyHostToDevice));
-
-    // Destroy host Transport objects
-    for (int rank = 0; rank < nranks; rank++) {
-      Transport* slot = reinterpret_cast<Transport*>(
-          transportsHostBuffer.data() + rank * sizeof(Transport));
-      slot->~Transport();
-    }
+    // Use preallocated transport array from MultiPeerNvlTransport
+    DeviceSpan<Transport> transports(transport.getTransportsArray(), nranks);
 
     // Benchmark timing
     CudaEvent start, stop;
@@ -441,8 +391,7 @@ class DispatchBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
           DeviceSpan<std::size_t>(
               static_cast<std::size_t*>(outputChunkSizesPerRankDevice.get()),
               nranks * nranks),
-          DeviceSpan<Transport>(
-              static_cast<Transport*>(transportsDevice.get()), nranks),
+          transports,
           globalRank,
           sendBuffer.get(),
           DeviceSpan<const std::size_t>(
@@ -470,8 +419,7 @@ class DispatchBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
           DeviceSpan<std::size_t>(
               static_cast<std::size_t*>(outputChunkSizesPerRankDevice.get()),
               nranks * nranks),
-          DeviceSpan<Transport>(
-              static_cast<Transport*>(transportsDevice.get()), nranks),
+          transports,
           globalRank,
           sendBuffer.get(),
           DeviceSpan<const std::size_t>(

--- a/comms/pipes/tests/DispatchTest.cc
+++ b/comms/pipes/tests/DispatchTest.cc
@@ -8,7 +8,9 @@
 #include <numeric>
 #include <vector>
 
+#include "comms/pipes/DeviceSpan.cuh"
 #include "comms/pipes/MultiPeerNvlTransport.h"
+#include "comms/pipes/Transport.cuh"
 #include "comms/pipes/tests/DispatchTestKernels.cuh"
 #include "comms/pipes/tests/Utils.cuh"
 #include "comms/testinfra/TestXPlatUtils.h"
@@ -42,7 +44,8 @@ struct DispatchTestConfig {
 
 // Helper struct to hold device buffers for dispatch
 struct DispatchDeviceBuffers {
-  std::unique_ptr<DeviceBuffer> transportsDevice;
+  Transport* transportsPtr{nullptr};
+  int transportsCount{0};
   std::unique_ptr<DeviceBuffer> sendBuffer;
   std::vector<std::unique_ptr<DeviceBuffer>> recvBuffers;
   std::unique_ptr<DeviceBuffer> recvBufferPtrsDevice;
@@ -53,6 +56,10 @@ struct DispatchDeviceBuffers {
   std::vector<void*> recvBufferPtrsHost;
   std::vector<uint8_t> sendData;
   size_t totalBufferSize;
+
+  DeviceSpan<Transport> getTransportsSpan() const {
+    return DeviceSpan<Transport>(transportsPtr, transportsCount);
+  }
 };
 
 // Helper to create uniform chunk sizes
@@ -104,35 +111,14 @@ class DispatchTestFixture : public MpiBaseTestFixture {
   }
 
   // Setup transport array on device
+  // Use preallocated Transport array from MultiPeerNvlTransport
+  // (includes P2pSelfTransportDevice for self and P2pNvlTransportDevice for
+  // peers)
   void setupTransports(
       MultiPeerNvlTransport& transport,
       DispatchDeviceBuffers& buffers) {
-    std::size_t transportsSize = numRanks * sizeof(Transport);
-    std::vector<char> transportsHostBuffer(transportsSize);
-
-    for (int rank = 0; rank < numRanks; rank++) {
-      Transport* slot = reinterpret_cast<Transport*>(
-          transportsHostBuffer.data() + rank * sizeof(Transport));
-      if (rank == globalRank) {
-        new (slot) Transport(P2pSelfTransportDevice());
-      } else {
-        new (slot) Transport(transport.getP2pTransportDevice(rank));
-      }
-    }
-
-    buffers.transportsDevice = std::make_unique<DeviceBuffer>(transportsSize);
-    CUDACHECK_TEST(cudaMemcpy(
-        buffers.transportsDevice->get(),
-        transportsHostBuffer.data(),
-        transportsSize,
-        cudaMemcpyHostToDevice));
-
-    // Destroy host Transport objects
-    for (int rank = 0; rank < numRanks; rank++) {
-      Transport* slot = reinterpret_cast<Transport*>(
-          transportsHostBuffer.data() + rank * sizeof(Transport));
-      slot->~Transport();
-    }
+    buffers.transportsPtr = transport.getTransportsArray();
+    buffers.transportsCount = numRanks;
   }
 
   // Setup send buffer with pattern data
@@ -253,8 +239,7 @@ class DispatchTestFixture : public MpiBaseTestFixture {
             static_cast<size_t*>(buffers.outputChunkSizesPerRankDevice->get()),
             numRanks * numChunks),
         // Inputs
-        DeviceSpan<Transport>(
-            static_cast<Transport*>(buffers.transportsDevice->get()), numRanks),
+        buffers.getTransportsSpan(),
         globalRank,
         buffers.sendBuffer->get(),
         DeviceSpan<const size_t>(

--- a/comms/pipes/tests/MultiPeerTransportMultiNodeTest.cc
+++ b/comms/pipes/tests/MultiPeerTransportMultiNodeTest.cc
@@ -224,13 +224,14 @@ TEST_F(MultiPeerTransportMultiNodeFixture, HostAccessorsMultiNode) {
   states->exchange();
 
   // NVL peer accessor — always has at least same-node peers.
+  // The returned pointers point to device memory inside the Transport array.
+  // We can only verify they're non-null here; device-side tests verify
+  // functionality.
   ASSERT_FALSE(states->nvl_peer_ranks().empty());
   for (int r : states->nvl_peer_ranks()) {
-    auto p2p = states->get_p2p_nvl_transport_device(r);
-    EXPECT_NE(p2p.getLocalState().dataBuffer, nullptr)
-        << "NVL local data buffer null for peer " << r;
-    EXPECT_NE(p2p.getRemoteState().dataBuffer, nullptr)
-        << "NVL remote data buffer null for peer " << r;
+    auto* p2p = states->get_p2p_nvl_transport_device(r);
+    EXPECT_NE(p2p, nullptr)
+        << "NVL transport device pointer null for peer " << r;
   }
 
   // IBGDA is universal — accessor works for ALL non-self peers.

--- a/comms/pipes/tests/MultiPeerTransportTest.cc
+++ b/comms/pipes/tests/MultiPeerTransportTest.cc
@@ -114,7 +114,8 @@ TEST_F(MultiPeerTransportTestFixture, ExchangeSucceeds) {
   MPI_Barrier(MPI_COMM_WORLD);
 }
 
-// Verify host-side NVL transport accessor returns valid objects after exchange.
+// Verify host-side NVL transport accessor returns valid device pointer after
+// exchange.
 TEST_F(MultiPeerTransportTestFixture, HostNvlAccessor) {
   if (numRanks < 2) {
     GTEST_SKIP() << "Requires >= 2 ranks, got " << numRanks;
@@ -124,13 +125,13 @@ TEST_F(MultiPeerTransportTestFixture, HostNvlAccessor) {
   states->exchange();
 
   int peerRank = (globalRank == 0) ? 1 : 0;
-  auto p2p = states->get_p2p_nvl_transport_device(peerRank);
+  auto* p2p = states->get_p2p_nvl_transport_device(peerRank);
 
-  // The returned device should have valid local/remote state pointers
-  EXPECT_NE(p2p.getLocalState().dataBuffer, nullptr)
-      << "Rank " << globalRank << ": NVL local data buffer is null";
-  EXPECT_NE(p2p.getRemoteState().dataBuffer, nullptr)
-      << "Rank " << globalRank << ": NVL remote data buffer is null";
+  // The returned pointer points to device memory inside the Transport array.
+  // We can only verify it's non-null here; actual functionality is tested
+  // by device-side tests (P2pNvlTransportTest, AllToAllvTest, etc.).
+  EXPECT_NE(p2p, nullptr) << "Rank " << globalRank
+                          << ": NVL transport device pointer is null";
 
   MPI_Barrier(MPI_COMM_WORLD);
 }

--- a/comms/pipes/tests/P2pNvlSendRecvMultipleTest.cu
+++ b/comms/pipes/tests/P2pNvlSendRecvMultipleTest.cu
@@ -10,26 +10,26 @@ namespace comms::pipes::test {
 // testSendMultipleKernel: Tests send_multiple (multiple chunks with varying
 // sizes)
 __global__ void testSendMultipleKernel(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     const void* src_d,
     DeviceSpan<const size_t> chunk_sizes,
     DeviceSpan<const size_t> chunk_indices) {
   auto group = make_warp_group();
-  p2p.send_multiple(group, src_d, chunk_sizes, chunk_indices);
+  p2p->send_multiple(group, src_d, chunk_sizes, chunk_indices);
 }
 
 // testRecvMultipleKernel: Tests recv_multiple (multiple chunks with varying
 // sizes)
 __global__ void testRecvMultipleKernel(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     void* dst_d,
     DeviceSpan<size_t> chunk_sizes) {
   auto group = make_warp_group();
-  p2p.recv_multiple(group, dst_d, chunk_sizes);
+  p2p->recv_multiple(group, dst_d, chunk_sizes);
 }
 
 void testSendMultiple(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     const void* src_d,
     const size_t* chunk_sizes_d,
     size_t chunk_sizes_count,
@@ -45,7 +45,7 @@ void testSendMultiple(
 }
 
 void testRecvMultiple(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     void* dst_d,
     size_t* chunk_sizes_d,
     size_t chunk_sizes_count,

--- a/comms/pipes/tests/P2pNvlSendRecvMultipleTest.cuh
+++ b/comms/pipes/tests/P2pNvlSendRecvMultipleTest.cuh
@@ -14,7 +14,7 @@ using comms::pipes::P2pNvlTransportDevice;
 
 // Test send_multiple: sends selected chunks from input buffer
 void testSendMultiple(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     const void* src_d,
     const size_t* chunk_sizes_d,
     size_t chunk_sizes_count,
@@ -25,7 +25,7 @@ void testSendMultiple(
 
 // Test recv_multiple: receives chunks into output buffer
 void testRecvMultiple(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     void* dst_d,
     size_t* chunk_sizes_d,
     size_t chunk_sizes_count,

--- a/comms/pipes/tests/P2pNvlSendRecvOneTest.cu
+++ b/comms/pipes/tests/P2pNvlSendRecvOneTest.cu
@@ -8,18 +8,18 @@ namespace comms::pipes::test {
 
 // testSendOneKernel: Tests send_one (single chunk with metadata)
 __global__ void testSendOneKernel(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     const void* src_d,
     size_t nbytes,
     size_t offset_in_output,
     bool has_more) {
   auto group = make_warp_group();
-  p2p.send_one(group, src_d, nbytes, 0, offset_in_output, has_more);
+  p2p->send_one(group, src_d, nbytes, 0, offset_in_output, has_more);
 }
 
 // testRecvOneKernel: Tests recv_one (single chunk with metadata)
 __global__ void testRecvOneKernel(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     void* dst_base_d,
     size_t* nbytes_d,
     size_t* offset_d,
@@ -31,7 +31,7 @@ __global__ void testRecvOneKernel(
   size_t offset = 0;
   bool has_more = false;
 
-  p2p.recv_one(group, dst_base_d, &nbytes, 0, &offset, &has_more);
+  p2p->recv_one(group, dst_base_d, &nbytes, 0, &offset, &has_more);
 
   // Write results to device memory for verification
   // Only one thread needs to write
@@ -43,7 +43,7 @@ __global__ void testRecvOneKernel(
 }
 
 void testSendOne(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     const void* src_d,
     size_t nbytes,
     size_t offset_in_output,
@@ -56,7 +56,7 @@ void testSendOne(
 }
 
 void testRecvOne(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     void* dst_base_d,
     size_t* nbytes_d,
     size_t* offset_d,
@@ -71,7 +71,7 @@ void testRecvOne(
 // testSendOneMultipleTimesKernel: Tests send_one called multiple times in one
 // kernel
 __global__ void testSendOneMultipleTimesKernel(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     const void* const* src_d_array,
     const size_t* nbytes_array,
     const size_t* offset_array,
@@ -80,7 +80,7 @@ __global__ void testSendOneMultipleTimesKernel(
   auto group = make_warp_group();
 
   for (size_t i = 0; i < num_calls; i++) {
-    p2p.send_one(
+    p2p->send_one(
         group,
         src_d_array[i],
         nbytes_array[i],
@@ -93,7 +93,7 @@ __global__ void testSendOneMultipleTimesKernel(
 // testRecvOneMultipleTimesKernel: Tests recv_one called multiple times in one
 // kernel
 __global__ void testRecvOneMultipleTimesKernel(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     void* dst_base_d,
     size_t* nbytes_array_d,
     size_t* offset_array_d,
@@ -106,7 +106,7 @@ __global__ void testRecvOneMultipleTimesKernel(
     size_t offset = 0;
     bool has_more = false;
 
-    p2p.recv_one(
+    p2p->recv_one(
         group,
         dst_base_d,
         &nbytes,
@@ -124,7 +124,7 @@ __global__ void testRecvOneMultipleTimesKernel(
 }
 
 void testSendOneMultipleTimes(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     const void* const* src_d_array,
     const size_t* nbytes_array,
     const size_t* offset_array,
@@ -138,7 +138,7 @@ void testSendOneMultipleTimes(
 }
 
 void testRecvOneMultipleTimes(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     void* dst_base_d,
     size_t* nbytes_array_d,
     size_t* offset_array_d,

--- a/comms/pipes/tests/P2pNvlSendRecvOneTest.cuh
+++ b/comms/pipes/tests/P2pNvlSendRecvOneTest.cuh
@@ -14,7 +14,7 @@ using comms::pipes::P2pNvlTransportDevice;
 
 // Test send_one: sends a single chunk with metadata
 void testSendOne(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     const void* src_d,
     size_t nbytes,
     size_t offset_in_output,
@@ -24,7 +24,7 @@ void testSendOne(
 
 // Test recv_one: receives a single chunk with metadata
 void testRecvOne(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     void* dst_base_d,
     size_t* nbytes_d,
     size_t* offset_d,
@@ -34,7 +34,7 @@ void testRecvOne(
 
 // Test send_one called multiple times in one kernel
 void testSendOneMultipleTimes(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     const void* const* src_d_array,
     const size_t* nbytes_array,
     const size_t* offset_array,
@@ -45,7 +45,7 @@ void testSendOneMultipleTimes(
 
 // Test recv_one called multiple times in one kernel
 void testRecvOneMultipleTimes(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     void* dst_base_d,
     size_t* nbytes_array_d,
     size_t* offset_array_d,

--- a/comms/pipes/tests/P2pNvlTransportTest.cc
+++ b/comms/pipes/tests/P2pNvlTransportTest.cc
@@ -75,7 +75,8 @@ TEST_F(P2pNvlTransportTestFixture, IpcMemAccess) {
   transport.exchange();
   XLOGF(INFO, "Rank {} created transport and exchanged IPC", globalRank);
 
-  auto p2p = transport.getP2pTransportDevice(peerRank);
+  // Get host-side copy to access buffer pointers from host
+  auto p2p = transport.buildP2pTransportDevice(peerRank);
 
   auto localAddr =
       static_cast<int*>(static_cast<void*>(p2p.getLocalState().dataBuffer));
@@ -152,7 +153,7 @@ void verifyReceivedData(
 // Helper to run a single send/recv iteration with verification
 void runSendRecvIteration(
     int globalRank,
-    P2pNvlTransportDevice& p2p,
+    P2pNvlTransportDevice* p2p,
     int* src_d,
     int* dst_d,
     size_t nbytes,
@@ -219,10 +220,24 @@ class TransportTestHelper {
                 config)) {
     CUDACHECK_TEST(cudaSetDevice(localRank));
     transport_->exchange();
+
+    // Build a host copy of P2pNvlTransportDevice for tests that need
+    // to access buffer pointers from the host side (e.g., for cudaMemset)
+    // Use unique_ptr because P2pNvlTransportDevice has const members and
+    // cannot be copy-assigned
+    p2pHost_ = std::make_unique<P2pNvlTransportDevice>(
+        transport_->buildP2pTransportDevice(peerRank_));
   }
 
-  P2pNvlTransportDevice getDevice() {
+  // Returns pointer to preallocated P2pNvlTransportDevice on device
+  // This pointer is managed by MultiPeerNvlTransport
+  P2pNvlTransportDevice* getDevicePtr() {
     return transport_->getP2pTransportDevice(peerRank_);
+  }
+
+  // Returns reference to host copy (for accessing state pointers from host)
+  P2pNvlTransportDevice& getHostDevice() {
+    return *p2pHost_;
   }
 
   int peerRank() const {
@@ -239,6 +254,7 @@ class TransportTestHelper {
   int peerRank_;
   std::shared_ptr<meta::comms::MpiBootstrap> bootstrap_;
   std::unique_ptr<MultiPeerNvlTransport> transport_;
+  std::unique_ptr<P2pNvlTransportDevice> p2pHost_;
 };
 
 // =============================================================================
@@ -253,7 +269,7 @@ void runBasicSendRecvTest(
     int nIter = 1,
     test::GroupType groupType = test::GroupType::WARP,
     bool useCudaGraph = false) {
-  auto p2p = helper.getDevice();
+  auto p2p = helper.getDevicePtr();
 
   DeviceBuffer srcBuffer(nbytes);
   DeviceBuffer dstBuffer(nbytes);
@@ -737,7 +753,7 @@ TEST_F(P2pNvlTransportTestFixture, BidirectionalSendRecv) {
   };
 
   TransportTestHelper helper(globalRank, numRanks, localRank, config);
-  auto p2p = helper.getDevice();
+  auto p2p = helper.getDevicePtr();
 
   const size_t numInts = nbytes / sizeof(int);
 
@@ -862,7 +878,7 @@ TEST_F(P2pNvlTransportTestFixture, SendRecvZeroBytes) {
   };
 
   TransportTestHelper helper(globalRank, numRanks, localRank, config);
-  auto p2p = helper.getDevice();
+  auto p2p = helper.getDevicePtr();
 
   // Allocate small buffers for the zero-byte transfer test
   const size_t bufferSize = 64;
@@ -935,7 +951,7 @@ TEST_F(P2pNvlTransportTestFixture, MultiSendInKernel) {
   };
 
   TransportTestHelper helper(globalRank, numRanks, localRank, config);
-  auto p2p = helper.getDevice();
+  auto p2p = helper.getDevicePtr();
 
   DeviceBuffer srcBuffer(totalBytes);
   DeviceBuffer dstBuffer(totalBytes);
@@ -1015,7 +1031,7 @@ TEST_F(P2pNvlTransportTestFixture, MultiRecvInKernel) {
   };
 
   TransportTestHelper helper(globalRank, numRanks, localRank, config);
-  auto p2p = helper.getDevice();
+  auto p2p = helper.getDevicePtr();
 
   DeviceBuffer srcBuffer(totalBytes);
   DeviceBuffer dstBuffer(totalBytes);
@@ -1091,7 +1107,7 @@ TEST_F(P2pNvlTransportTestFixture, SimultaneousSendRecvInKernel) {
   };
 
   TransportTestHelper helper(globalRank, numRanks, localRank, config);
-  auto p2p = helper.getDevice();
+  auto p2p = helper.getDevicePtr();
 
   const size_t numInts = nbytes / sizeof(int);
 
@@ -1193,7 +1209,7 @@ TEST_P(WeightedPartitionTestFixture, SendRecv) {
   };
 
   TransportTestHelper helper(globalRank, numRanks, localRank, config);
-  auto p2p = helper.getDevice();
+  auto p2p = helper.getDevicePtr();
 
   const size_t numInts = nbytes / sizeof(int);
 
@@ -2002,7 +2018,7 @@ TEST_P(AsymmetricGroupTestFixture, SendRecv) {
   };
 
   TransportTestHelper helper(globalRank, numRanks, localRank, config);
-  auto p2p = helper.getDevice();
+  auto p2p = helper.getDevicePtr();
 
   const size_t numInts = nbytes / sizeof(int);
 
@@ -2235,7 +2251,7 @@ INSTANTIATE_TEST_SUITE_P(
 // Helper to run a write() test with verification
 void runPutTest(
     int globalRank,
-    P2pNvlTransportDevice& p2p,
+    P2pNvlTransportDevice* p2p,
     char* localSrc,
     char* remoteDst,
     size_t nbytes,
@@ -2308,11 +2324,12 @@ TEST_F(P2pNvlTransportTestFixture, PutBasic) {
   };
 
   TransportTestHelper helper(globalRank, numRanks, localRank, config);
-  auto p2p = helper.getDevice();
+  auto p2p = helper.getDevicePtr();
+  auto& p2pHost = helper.getHostDevice();
 
   // Get remote destination (peer's local data buffer)
-  char* localSrc = p2p.getLocalState().dataBuffer;
-  char* remoteDst = p2p.getRemoteState().dataBuffer;
+  char* localSrc = p2pHost.getLocalState().dataBuffer;
+  char* remoteDst = p2pHost.getRemoteState().dataBuffer;
 
   runPutTest(globalRank, p2p, localSrc, remoteDst, nbytes, 4, 128, "PutBasic");
 
@@ -2355,10 +2372,11 @@ TEST_P(PutTransferSizeTestFixture, Put) {
   };
 
   TransportTestHelper helper(globalRank, numRanks, localRank, config);
-  auto p2p = helper.getDevice();
+  auto p2p = helper.getDevicePtr();
+  auto& p2pHost = helper.getHostDevice();
 
-  char* localSrc = p2p.getLocalState().dataBuffer;
-  char* remoteDst = p2p.getRemoteState().dataBuffer;
+  char* localSrc = p2pHost.getLocalState().dataBuffer;
+  char* remoteDst = p2pHost.getRemoteState().dataBuffer;
 
   runPutTest(
       globalRank, p2p, localSrc, remoteDst, params.nbytes, 4, 128, params.name);
@@ -2445,11 +2463,12 @@ TEST_P(PutUnalignedTestFixture, Put) {
   };
 
   TransportTestHelper helper(globalRank, numRanks, localRank, config);
-  auto p2p = helper.getDevice();
+  auto p2p = helper.getDevicePtr();
+  auto& p2pHost = helper.getHostDevice();
 
   // Get remote and local destination with offset applied
-  char* localSrc = p2p.getLocalState().dataBuffer;
-  char* remoteDst = p2p.getRemoteState().dataBuffer;
+  char* localSrc = p2pHost.getLocalState().dataBuffer;
+  char* remoteDst = p2pHost.getRemoteState().dataBuffer;
   if (globalRank == 0) {
     localSrc += params.srcOffset;
     remoteDst += params.dstOffset;

--- a/comms/pipes/tests/P2pNvlTransportTest.cu
+++ b/comms/pipes/tests/P2pNvlTransportTest.cu
@@ -18,26 +18,26 @@ __device__ inline ThreadGroup make_group(GroupType groupType) {
 }
 
 __global__ void testSendKernel(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     void* src_d,
     size_t nbytes,
     GroupType groupType) {
   auto group = make_group(groupType);
-  p2p.send(group, src_d, nbytes);
+  p2p->send(group, src_d, nbytes);
 }
 
 __global__ void testRecvKernel(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     void* dst_d,
     size_t nbytes,
     GroupType groupType) {
   auto group = make_group(groupType);
-  p2p.recv(group, dst_d, nbytes);
+  p2p->recv(group, dst_d, nbytes);
 }
 
 // Kernel that performs multiple sequential sends within a single kernel launch
 __global__ void testMultiSendKernel(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     void* src_d,
     size_t nbytes,
     int numSends,
@@ -45,13 +45,13 @@ __global__ void testMultiSendKernel(
   auto group = make_group(groupType);
   char* src = reinterpret_cast<char*>(src_d);
   for (int i = 0; i < numSends; i++) {
-    p2p.send(group, src + i * nbytes, nbytes);
+    p2p->send(group, src + i * nbytes, nbytes);
   }
 }
 
 // Kernel that performs multiple sequential recvs within a single kernel launch
 __global__ void testMultiRecvKernel(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     void* dst_d,
     size_t nbytes,
     int numRecvs,
@@ -59,41 +59,41 @@ __global__ void testMultiRecvKernel(
   auto group = make_group(groupType);
   char* dst = reinterpret_cast<char*>(dst_d);
   for (int i = 0; i < numRecvs; i++) {
-    p2p.recv(group, dst + i * nbytes, nbytes);
+    p2p->recv(group, dst + i * nbytes, nbytes);
   }
 }
 
 // Kernel that performs both send and recv within a single kernel launch
 // Used for pipelined bidirectional communication
 __global__ void testSendRecvKernel(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     void* send_d,
     void* recv_d,
     size_t nbytes,
     GroupType groupType) {
   auto group = make_group(groupType);
-  p2p.send(group, send_d, nbytes);
-  p2p.recv(group, recv_d, nbytes);
+  p2p->send(group, send_d, nbytes);
+  p2p->recv(group, recv_d, nbytes);
 }
 
 // Kernel that performs recv then send within a single kernel launch
 // Paired with testSendRecvKernel for bidirectional tests
 __global__ void testRecvSendKernel(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     void* recv_d,
     void* send_d,
     size_t nbytes,
     GroupType groupType) {
   auto group = make_group(groupType);
-  p2p.recv(group, recv_d, nbytes);
-  p2p.send(group, send_d, nbytes);
+  p2p->recv(group, recv_d, nbytes);
+  p2p->send(group, send_d, nbytes);
 }
 
 // Kernel that performs weighted partition send/recv
 // Groups are partitioned according to weights, partition 0 sends, partition 1
 // recvs
 __global__ void testWeightedSendRecvKernel(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     void* send_d,
     void* recv_d,
     size_t nbytes,
@@ -104,9 +104,9 @@ __global__ void testWeightedSendRecvKernel(
   uint32_t weights[] = {sendWeight, recvWeight};
   auto [partition_id, subgroup] = group.partition(make_device_span(weights, 2));
   if (partition_id == 0) {
-    p2p.send(subgroup, send_d, nbytes);
+    p2p->send(subgroup, send_d, nbytes);
   } else {
-    p2p.recv(subgroup, recv_d, nbytes);
+    p2p->recv(subgroup, recv_d, nbytes);
   }
 }
 
@@ -114,7 +114,7 @@ __global__ void testWeightedSendRecvKernel(
 // Groups are partitioned according to weights, partition 0 recvs, partition 1
 // sends
 __global__ void testWeightedRecvSendKernel(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     void* recv_d,
     void* send_d,
     size_t nbytes,
@@ -125,14 +125,14 @@ __global__ void testWeightedRecvSendKernel(
   uint32_t weights[] = {recvWeight, sendWeight};
   auto [partition_id, subgroup] = group.partition(make_device_span(weights, 2));
   if (partition_id == 0) {
-    p2p.recv(subgroup, recv_d, nbytes);
+    p2p->recv(subgroup, recv_d, nbytes);
   } else {
-    p2p.send(subgroup, send_d, nbytes);
+    p2p->send(subgroup, send_d, nbytes);
   }
 }
 
 void testSend(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     void* src_d,
     size_t nbytes,
     int numBlocks,
@@ -146,7 +146,7 @@ void testSend(
 }
 
 void testRecv(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     void* dst_d,
     size_t nbytes,
     int numBlocks,
@@ -160,7 +160,7 @@ void testRecv(
 }
 
 void testMultiSend(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     void* src_d,
     size_t nbytes,
     int numSends,
@@ -174,7 +174,7 @@ void testMultiSend(
 }
 
 void testMultiRecv(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     void* dst_d,
     size_t nbytes,
     int numRecvs,
@@ -188,7 +188,7 @@ void testMultiRecv(
 }
 
 void testSendRecv(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     void* send_d,
     void* recv_d,
     size_t nbytes,
@@ -202,7 +202,7 @@ void testSendRecv(
 }
 
 void testRecvSend(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     void* recv_d,
     void* send_d,
     size_t nbytes,
@@ -216,7 +216,7 @@ void testRecvSend(
 }
 
 void testWeightedSendRecv(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     void* send_d,
     void* recv_d,
     size_t nbytes,
@@ -231,7 +231,7 @@ void testWeightedSendRecv(
 }
 
 void testWeightedRecvSend(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     void* recv_d,
     void* send_d,
     size_t nbytes,
@@ -250,19 +250,19 @@ void testWeightedRecvSend(
 // =============================================================================
 
 __global__ void testPutWithSignalKernel(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     char* dst_d,
     const char* src_d,
     uint64_t signal_id,
     size_t nbytes,
     GroupType groupType) {
   auto group = make_group(groupType);
-  auto writtenBytes = p2p.put(group, dst_d, src_d, nbytes);
-  p2p.signal_threadgroup(group, signal_id, SignalOp::SIGNAL_ADD, writtenBytes);
+  auto writtenBytes = p2p->put(group, dst_d, src_d, nbytes);
+  p2p->signal_threadgroup(group, signal_id, SignalOp::SIGNAL_ADD, writtenBytes);
 }
 
 void testPutWithSignal(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     char* dst_d,
     const char* src_d,
     uint64_t signal_id,
@@ -280,17 +280,17 @@ void testPutWithSignal(
 // =============================================================================
 
 __global__ void testWaitKernel(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     CmpOp op,
     uint64_t signal_id,
     uint64_t expected,
     GroupType groupType) {
   auto group = make_group(groupType);
-  p2p.wait_signal_until_threadgroup(group, signal_id, op, expected);
+  p2p->wait_signal_until_threadgroup(group, signal_id, op, expected);
 }
 
 void testWait(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     CmpOp op,
     uint64_t signal_id,
     uint64_t expected,

--- a/comms/pipes/tests/P2pNvlTransportTest.cuh
+++ b/comms/pipes/tests/P2pNvlTransportTest.cuh
@@ -19,7 +19,7 @@ enum class GroupType {
 };
 
 void testSend(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     void* src_d,
     size_t nbytes,
     int numBlocks,
@@ -29,7 +29,7 @@ void testSend(
     cudaStream_t stream = nullptr);
 
 void testRecv(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     void* dst_d,
     size_t nbytes,
     int numBlocks,
@@ -40,7 +40,7 @@ void testRecv(
 
 // Multiple sequential sends within a single kernel
 void testMultiSend(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     void* src_d,
     size_t nbytes,
     int numSends,
@@ -51,7 +51,7 @@ void testMultiSend(
 
 // Multiple sequential recvs within a single kernel
 void testMultiRecv(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     void* dst_d,
     size_t nbytes,
     int numRecvs,
@@ -62,7 +62,7 @@ void testMultiRecv(
 
 // Send then recv within a single kernel (for pipelined bidirectional)
 void testSendRecv(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     void* send_d,
     void* recv_d,
     size_t nbytes,
@@ -73,7 +73,7 @@ void testSendRecv(
 
 // Recv then send within a single kernel (paired with testSendRecv)
 void testRecvSend(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     void* recv_d,
     void* send_d,
     size_t nbytes,
@@ -85,7 +85,7 @@ void testRecvSend(
 // Weighted partition send/recv - partitions groups according to weights
 // sendWeight:recvWeight controls the ratio of groups assigned to send vs recv
 void testWeightedSendRecv(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     void* send_d,
     void* recv_d,
     size_t nbytes,
@@ -98,7 +98,7 @@ void testWeightedSendRecv(
 // Weighted partition recv/send - partitions groups according to weights
 // recvWeight:sendWeight controls the ratio of groups assigned to recv vs send
 void testWeightedRecvSend(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     void* recv_d,
     void* send_d,
     size_t nbytes,
@@ -111,7 +111,7 @@ void testWeightedRecvSend(
 // Test put() - one-sided direct memory write to peer GPU and signal peer
 // Unlike send()/recv(), put() writes directly to dst_d without staging buffers
 void testPutWithSignal(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     char* dst_d, // Destination on peer GPU (must be NVLink-accessible)
     const char* src_d, // Source on local GPU
     uint64_t signal_id,
@@ -122,7 +122,7 @@ void testPutWithSignal(
 
 // Test wait() - one-sided wait for peer to write to dst_d and signal
 void testWait(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     CmpOp op,
     uint64_t signal_id,
     uint64_t expected,


### PR DESCRIPTION
Summary:
Previouly we pass `p2pNvlTransportDevice` to kernels by copy/value as `p2pNvlTransportDevice` was stateless and only stores const values. 

However, as we introduce dual-chunkState (see D?), dynamic chunk size features to p2pNvlTransport, we need it to be stateful to keep track of counters, etc.

This diff preallocates `p2pNvlTransportDevice` on device right after handle exchanged and pass the device pointer to kernels: this enabled stateful p2p transport - we won't lose any changes to transport class.

Note that his change has ~0 impact on perf: see Test Plan.

Differential Revision: D91717513


