### PR TITLE
Fix reduce_scatter_v root rank not contributing input data

### DIFF
--- a/comms/torchcomms/gloo/TorchCommGloo.cpp
+++ b/comms/torchcomms/gloo/TorchCommGloo.cpp
@@ -1077,7 +1077,8 @@ c10::intrusive_ptr<TorchWork> TorchCommGloo::reduce_scatter_v(
           preReduce(inputTensor, opCPU);
 
           if (i == rank) {
-            // This rank is the root - receive the reduced result
+            // This rank is the root - copy input to output then reduce
+            outputCPU.copy_(inputTensor);
             GENERATE_ALL_TYPES(scalarType, setOutput, opts, outputCPU);
           } else {
             // Non-root ranks just contribute their input

--- a/comms/torchcomms/tests/integration/cpp/ReduceScatterVTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/ReduceScatterVTest.cpp
@@ -16,6 +16,7 @@ void ReduceScatterVTest::SetUp() {
   torchcomm_ = wrapper_->getTorchComm();
   rank_ = torchcomm_->getRank();
   num_ranks_ = torchcomm_->getSize();
+  device_type_ = wrapper_->getDevice().type();
 }
 
 void ReduceScatterVTest::TearDown() {

--- a/comms/torchcomms/tests/integration/cpp/ReduceScatterVTestMain.cpp
+++ b/comms/torchcomms/tests/integration/cpp/ReduceScatterVTestMain.cpp
@@ -7,10 +7,6 @@
 #include "TorchCommTestHelpers.h"
 
 TEST_P(ReduceScatterVTest, SyncReduceScatterV) {
-  auto backend = std::string(getenv("TEST_BACKEND"));
-  if (backend != "ncclx") {
-    GTEST_SKIP() << "skip reduce_scatter_v test for non-NCCLX backends";
-  }
   int count = std::get<0>(GetParam());
   at::ScalarType dtype = std::get<1>(GetParam());
   torch::comms::ReduceOp op = std::get<2>(GetParam());

--- a/comms/torchcomms/tests/integration/py/ReduceScatterVTest.py
+++ b/comms/torchcomms/tests/integration/py/ReduceScatterVTest.py
@@ -3,7 +3,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import itertools
-import os
 import unittest
 
 import torch
@@ -116,10 +115,6 @@ class ReduceScatterVTest(unittest.TestCase):
                 f"Tensors not equal for {description}",
             )
 
-    @unittest.skipIf(
-        os.getenv("TEST_BACKEND") != "ncclx",
-        "Skipping reduce_scatter_v test for non-NCCLX backend",
-    )
     def test_sync_reduce_scatter_v(self):
         """Test synchronous reduce_scatter_v with work object."""
         for count, dtype, op in itertools.product(self.counts, self.dtypes, self.ops):


### PR DESCRIPTION
Summary:
In the gloo backend's reduce_scatter_v implementation, the root rank was
setting outputCPU as the reduce buffer without first copying its input
data into it. This caused the root rank to contribute zeros instead of
its actual input value, resulting in incorrect reduction results.

The fix copies the input tensor to the output buffer before calling
gloo::reduce, ensuring the root rank's data is included in the reduction.

Reviewed By: cenzhaometa

Differential Revision: D91706158


