### PR TITLE
Github CI - for RCCL but not on diff

### DIFF
--- a/.github/workflows/build_test_rccl.yaml
+++ b/.github/workflows/build_test_rccl.yaml
@@ -1,0 +1,85 @@
+name: Build RCCL
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+      id-token: write
+      contents: read
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: RCCL
+            runs-on: amd-mi350-runner
+            gpu-arch-type: "rocm"
+            gpu-arch-version: "7.0"
+            torch-spec: '--pre torch --index-url https://download.pytorch.org/whl/nightly/rocm7.0'
+            docker-image: pytorch/manylinux2_28-builder:rocm7.0
+            cmake-version: "latest"
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    with:
+      timeout: 180
+      runner: ${{ matrix.runs-on }}
+      gpu-arch-type: ${{ matrix.gpu-arch-type }}
+      gpu-arch-version: ${{ matrix.gpu-arch-version }}
+      script: |
+        set -ex
+        # use faster libmamba solver
+        conda config --set solver libmamba
+
+        # TODO: remove dependency on fbwhoami
+        echo "DEVICE_NAME=$(hostname)" > /etc/fbwhoami
+        cat /etc/fbwhoami
+
+        # For picking C++ 20 compiler from toolset-13
+        export PATH=/opt/rh/gcc-toolset-13/root/usr/bin:$PATH
+        export CXX=/opt/rh/gcc-toolset-13/root/usr/bin/c++
+        export CC=/opt/rh/gcc-toolset-13/root/usr/bin/cc
+
+        conda create -n venv python=3.12 -y
+        conda activate venv
+        python -m pip install --upgrade pip
+        conda install conda-forge::libopenssl-static conda-forge::rsync -y
+        conda install conda-forge::glog=0.4.0 conda-forge::gflags conda-forge::fmt -y
+
+        pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/rocm7.0
+
+        if [ "${{ matrix.cmake-version }}" = "latest" ]; then
+          conda install -y cmake
+        else # default to latest
+          conda install -y cmake==${{ matrix.cmake-version }}
+        fi
+
+        pip install -r requirements.txt
+
+        export ROCM_HOME=/opt/rocm
+        export RCCL_INCLUDE=$ROCM_HOME/include/rccl
+
+        ./build_rccl.sh
+        pip install numpy
+        USE_SYSTEM_LIBS=1 USE_NCCL=0 USE_NCCLX=0 USE_GLOO=0 USE_RCCL=1 USE_TRANSPORT=OFF pip install --no-build-isolation -v -e .
+
+        # Verify installation - TODO re-enable this section after D90936340 stack lands
+        #python -c "import torch; print(f'PyTorch version: {torch.__version__}')"
+        #python -c "import torch; print(f'HIP available: {torch.cuda.is_available()}')"
+        #python -c "import torchcomms; print('TorchComms imported successfully')"
+
+        # Test RCCL backend availability
+        #python -c "
+        #import torchcomms
+        #try:
+        #    comm = torchcomms.new_comm('rccl', torch.device('hip'), 'test_comm')
+        #    print('RCCL backend available')
+        #except Exception as e:
+        #    print(f'RCCL backend test failed: {e}')
+        #"
+
+        # Run integration tests
+        #echo "Running RCCL integration tests..."
+        #comms/torchcomms/scripts/run_tests_integration_rccl_py.sh


### PR DESCRIPTION
Summary:
Remove on-diff CI until we figure out permissions issue with EC2.


When run on a fork (triggered by PR run), this fails due to access issues with EC2
https://github.com/meta-pytorch/torchcomms/pull/427?fbclid=IwY2xjawPnZMdleHRuA2FlbQIxMQBicmlkETF5OEVVUnZQaE8yemxmRzdxc3J0YwZhcHBfaWQBMAABHhxFS6dkvj8_sGecjWN1737KOulIbNEi-OlDcw00jCQ59kaura5S4znmzXd7_aem_TbihlyGxEldv0BL842VoLA



But when run on main it passes fine:
https://github.com/meta-pytorch/torchcomms/actions/runs/21445832046/job/61761221572?fbclid=IwY2xjawPnZq5leHRuA2FlbQIxMQBicmlkETFtOVVUSFpLdUNrcDlNeEpEc3J0YwZhcHBfaWQBMAABHmGmYsX8cgU0KYuiTN520E4Mcv4Wi_ssXmYS8dHG_Q3ctMrhRJDnWolS9KqO_aem_NlU3wecBKpwjdCC_m9xdLA

Disabling PR runs until we figure out a long term solution to unblock diffs.

Differential Revision: D91802801


