### PR TITLE
Add binomial tree broadcast algorithm

### DIFF
--- a/comms/pipes/benchmarks/BenchmarkKernel.cu
+++ b/comms/pipes/benchmarks/BenchmarkKernel.cu
@@ -153,4 +153,31 @@ __global__ void p2pRecvMultiple(
   p2p.recv_multiple(group, dstBuff, chunkSizes);
 }
 
+__global__ void allToAllvKernel(
+    void* recvbuff_d,
+    const void* sendbuff_d,
+    int my_rank_id,
+    DeviceSpan<Transport> transports_per_rank,
+    DeviceSpan<ChunkInfo> send_chunk_infos,
+    DeviceSpan<ChunkInfo> recv_chunk_infos,
+    Timeout timeout) {
+  all_to_allv(
+      recvbuff_d,
+      sendbuff_d,
+      my_rank_id,
+      transports_per_rank,
+      send_chunk_infos,
+      recv_chunk_infos,
+      timeout);
+}
+
+__global__ void broadcastFlatKernel(
+    void* buff_d,
+    int myRank,
+    int rootRank,
+    DeviceSpan<Transport> transports,
+    std::size_t nbytes) {
+  comms::pipes::collectives::broadcast_flat(
+      buff_d, myRank, rootRank, transports, nbytes);
+}
 } // namespace comms::pipes::benchmark

--- a/comms/pipes/benchmarks/BenchmarkKernel.cu
+++ b/comms/pipes/benchmarks/BenchmarkKernel.cu
@@ -180,4 +180,15 @@ __global__ void broadcastFlatKernel(
   comms::pipes::collectives::broadcast_flat(
       buff_d, myRank, rootRank, transports, nbytes);
 }
+
+__global__ void broadcastBinomialTreeKernel(
+    void* buff_d,
+    int myRank,
+    int rootRank,
+    DeviceSpan<Transport> transports,
+    std::size_t nbytes) {
+  comms::pipes::collectives::broadcast_binomial_tree(
+      buff_d, myRank, rootRank, transports, nbytes);
+}
+
 } // namespace comms::pipes::benchmark

--- a/comms/pipes/benchmarks/BenchmarkKernel.cuh
+++ b/comms/pipes/benchmarks/BenchmarkKernel.cuh
@@ -6,6 +6,10 @@
 
 #include "comms/pipes/P2pNvlTransportDevice.cuh"
 #include "comms/pipes/ThreadGroup.cuh"
+#include "comms/pipes/TimeoutUtils.h"
+
+#include "comms/pipes/collectives/AllToAllv.cuh"
+#include "comms/pipes/collectives/BroadcastFlat.cuh"
 
 namespace comms::pipes::benchmark {
 
@@ -99,4 +103,40 @@ __global__ void p2pRecvMultiple(
     DeviceSpan<std::size_t> chunkSizes,
     SyncScope groupScope = SyncScope::WARP);
 
+/**
+ * AllToAllv benchmark kernel.
+ * All ranks participate in all-to-all communication with variable chunk sizes.
+ */
+__global__ void allToAllvKernel(
+    void* recvbuff_d,
+    const void* sendbuff_d,
+    int my_rank_id,
+    DeviceSpan<Transport> transports_per_rank,
+    DeviceSpan<ChunkInfo> send_chunk_infos,
+    DeviceSpan<ChunkInfo> recv_chunk_infos,
+    Timeout timeout);
+
+/**
+ * Broadcast benchmark kernel using flat-tree algorithm.
+ *
+ * The root rank broadcasts data to all non-root ranks in a single step.
+ * Each non-root rank receives the complete data directly from root.
+ *
+ * @param buff_d     Device buffer for both send (root) and receive (non-root).
+ *                   Must have at least nbytes allocated.
+ * @param myRank     This rank's ID in the communicator (0 to numRanks-1).
+ * @param rootRank   The rank that originates the broadcast data.
+ * @param transports Array of Transport handles for peer communication.
+ *                   Index i corresponds to peer rank i.
+ * @param nbytes     Number of bytes to broadcast from root to all peers.
+ *
+ * Thread/block configuration: Recommended minimum 8 blocks x 256 threads
+ * for good overlap of computation and communication.
+ */
+__global__ void broadcastFlatKernel(
+    void* buff_d,
+    int myRank,
+    int rootRank,
+    DeviceSpan<Transport> transports,
+    std::size_t nbytes);
 } // namespace comms::pipes::benchmark

--- a/comms/pipes/benchmarks/BenchmarkKernel.cuh
+++ b/comms/pipes/benchmarks/BenchmarkKernel.cuh
@@ -9,6 +9,7 @@
 #include "comms/pipes/TimeoutUtils.h"
 
 #include "comms/pipes/collectives/AllToAllv.cuh"
+#include "comms/pipes/collectives/BroadcastBinomialTree.cuh"
 #include "comms/pipes/collectives/BroadcastFlat.cuh"
 
 namespace comms::pipes::benchmark {
@@ -134,6 +135,18 @@ __global__ void allToAllvKernel(
  * for good overlap of computation and communication.
  */
 __global__ void broadcastFlatKernel(
+    void* buff_d,
+    int myRank,
+    int rootRank,
+    DeviceSpan<Transport> transports,
+    std::size_t nbytes);
+
+/**
+ * Broadcast benchmark kernel using binomial tree algorithm.
+ * Root rank broadcasts data to all non-root ranks using O(log N) rounds.
+ * More bandwidth-efficient than flat-tree for large messages.
+ */
+__global__ void broadcastBinomialTreeKernel(
     void* buff_d,
     int myRank,
     int rootRank,

--- a/comms/pipes/benchmarks/BenchmarkMacros.h
+++ b/comms/pipes/benchmarks/BenchmarkMacros.h
@@ -15,6 +15,41 @@ constexpr int kBenchmarkIters = 30;
 // Default data buffer size for large message benchmarks (8MB)
 constexpr std::size_t kDefaultDataBufferSize = 8 * 1024 * 1024;
 
+// Default cluster size for clustered kernel launches
+constexpr int kDefaultClusterSize = 4;
+
+// =============================================================================
+// Auto-tune Message Size Thresholds
+// =============================================================================
+
+constexpr std::size_t kSmallMessageThreshold = 16 * 1024; // 16KB
+constexpr std::size_t kMediumMessageThreshold = 256 * 1024; // 256KB
+constexpr std::size_t kLargeMessageThreshold = 4 * 1024 * 1024; // 4MB
+
+// Auto-tune configuration values for small messages (< 16KB)
+constexpr std::size_t kSmallMsgChunkSize = 4 * 1024; // 4KB
+constexpr std::size_t kSmallMsgStagingBuffer = 64 * 1024; // 64KB
+constexpr int kSmallMsgNumBlocks = 4;
+constexpr int kSmallMsgNumThreads = 256;
+
+// Auto-tune configuration values for medium messages (16KB - 256KB)
+constexpr std::size_t kMediumMsgChunkSize = 16 * 1024; // 16KB
+constexpr std::size_t kMediumMsgStagingBuffer = 256 * 1024; // 256KB
+constexpr int kMediumMsgNumBlocks = 8;
+constexpr int kMediumMsgNumThreads = 256;
+
+// Auto-tune configuration values for large messages (256KB - 4MB)
+constexpr std::size_t kLargeMsgChunkSize = 64 * 1024; // 64KB
+constexpr std::size_t kLargeMsgStagingBuffer = 1 * 1024 * 1024; // 1MB
+constexpr int kLargeMsgNumBlocks = 16;
+constexpr int kLargeMsgNumThreads = 512;
+
+// Auto-tune configuration values for very large messages (>= 4MB)
+constexpr std::size_t kVeryLargeMsgChunkSize = 128 * 1024; // 128KB
+constexpr std::size_t kMaxStagingBufferSize = 64 * 1024 * 1024; // 64MB
+constexpr int kVeryLargeMsgNumBlocks = 32;
+constexpr int kVeryLargeMsgNumThreads = 512;
+
 // =============================================================================
 // Error Checking Macros
 // =============================================================================

--- a/comms/pipes/benchmarks/BroadcastBenchmark.cc
+++ b/comms/pipes/benchmarks/BroadcastBenchmark.cc
@@ -1,0 +1,1526 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <folly/init/Init.h>
+#include <folly/logging/xlog.h>
+#include <gflags/gflags.h>
+#include <nccl.h>
+
+#ifdef USE_NVTX
+#include <nvtx3/nvToolsExt.h>
+#endif
+
+#include "comms/common/CudaWrap.h"
+#include "comms/pipes/MultiPeerNvlTransport.h"
+#include "comms/pipes/benchmarks/BenchmarkKernel.cuh"
+#include "comms/pipes/benchmarks/BenchmarkMacros.h"
+#include "comms/testinfra/mpi/MpiBootstrap.h"
+#include "comms/testinfra/mpi/MpiTestUtils.h"
+#include "comms/utils/CudaRAII.h"
+
+#include <iomanip>
+#include <sstream>
+#include <vector>
+
+// Command-line flag for enabling data correctness verification
+DEFINE_bool(
+    verify_correctness,
+    false,
+    "Enable data correctness verification after broadcast operations");
+
+// Command-line flag for enabling NVTX profiling annotations
+DEFINE_bool(
+    profile,
+    false,
+    "Enable NVTX profiling annotations for nsys profiling");
+
+// Command-line flag for selecting which benchmarks to run
+// Valid values: "all", "optimal", "tuning", "algorithm"
+// Can also be comma-separated: "optimal,algorithm"
+DEFINE_string(
+    benchmark,
+    "all",
+    "Which benchmark(s) to run: all, optimal, tuning, algorithm (comma-separated)");
+
+namespace {
+// NVTX helper macros for profiling
+#ifdef USE_NVTX
+#define NVTX_RANGE_PUSH(name) \
+  do {                        \
+    if (FLAGS_profile) {      \
+      nvtxRangePushA(name);   \
+    }                         \
+  } while (0)
+
+#define NVTX_RANGE_POP() \
+  do {                   \
+    if (FLAGS_profile) { \
+      nvtxRangePop();    \
+    }                    \
+  } while (0)
+
+#define NVTX_MARK(name)  \
+  do {                   \
+    if (FLAGS_profile) { \
+      nvtxMarkA(name);   \
+    }                    \
+  } while (0)
+#else
+#define NVTX_RANGE_PUSH(name) ((void)0)
+#define NVTX_RANGE_POP() ((void)0)
+#define NVTX_MARK(name) ((void)0)
+#endif
+} // namespace
+
+using meta::comms::CudaEvent;
+using meta::comms::DeviceBuffer;
+using meta::comms::MpiBaseTestFixture;
+using meta::comms::MPIEnvironmentBase;
+
+namespace comms::pipes::benchmark {
+
+// ============================================================================
+// FILE ORGANIZATION
+// ============================================================================
+// This file is organized into the following sections:
+//
+//   1. CONFIGURATION STRUCTS
+//      - BroadcastBenchmarkConfig, GridConfig, BroadcastBenchmarkResult
+//
+//   2. TEST FIXTURE CLASS
+//      - BroadcastBenchmarkFixture with SetUp/TearDown
+//      - Data verification helpers
+//      - NCCL benchmark runner
+//      - Pipes transport setup helpers
+//      - Pipes benchmark runners (standard and clustered)
+//      - Result formatting utilities
+//
+//   3. TEST CASES
+//      - ClusteredLaunchComparison: Standard vs clustered kernel launch
+//      - RootRankSweep: Performance with different root ranks
+//      - ExtendedMessageSizes: 64B to 256MB message sweep
+//      - GridConfigSweep: Block/thread configuration optimization
+//
+//   4. MAIN FUNCTION
+//      - CLI argument parsing and test filtering
+// ============================================================================
+
+namespace {
+
+// ============================================================================
+// SECTION 1: CONFIGURATION STRUCTS
+// ============================================================================
+
+/**
+ * Test configuration for Broadcast benchmark.
+ */
+struct BroadcastBenchmarkConfig {
+  std::size_t messageSize;
+  std::size_t stagingBufferSize;
+  std::size_t pipelineDepth = 4;
+  std::size_t chunkSize = 32 * 1024; // 32KB default (profiling shows optimal)
+  int numBlocks;
+  int numThreads;
+  int rootRank; // Which rank is the broadcast source (use -1 for dynamic)
+  std::string name;
+};
+
+/**
+ * Grid configuration for GPU kernel launches.
+ * Used for sweeping block/thread configurations in benchmarks.
+ */
+struct GridConfig {
+  int numBlocks;
+  int numThreads;
+  std::string name; // Display name, e.g., "4x128", "32x512"
+};
+
+/**
+ * Result struct for collecting benchmark data.
+ */
+struct BroadcastBenchmarkResult {
+  std::string testName;
+  std::size_t messageSize{};
+  int rootRank{};
+  int nRanks{};
+  float ncclBandwidth{}; // GB/s
+  float pipesBandwidth{}; // GB/s
+  float ncclLatency{}; // microseconds
+  float pipesLatency{}; // microseconds
+  float speedup{}; // Pipes / NCCL
+  bool ncclVerified{}; // Data correctness verified for NCCL
+  bool pipesVerified{}; // Data correctness verified for Pipes
+};
+
+/**
+ * Broadcast algorithm types for parameterized testing.
+ * New algorithms should be added here as they are implemented.
+ */
+enum class BroadcastAlgorithm {
+  FlatTree,
+  // BinomialTree - added in D91729677
+  // Ring - added in D91697545
+  // Adaptive - added in D91729719
+};
+
+inline std::string algorithmName(BroadcastAlgorithm algo) {
+  switch (algo) {
+    case BroadcastAlgorithm::FlatTree:
+      return "Flat-Tree";
+  }
+  return "Unknown";
+}
+
+/**
+ * All broadcast algorithms for parameterized testing.
+ * Add new algorithms here as they are implemented.
+ */
+const std::vector<BroadcastAlgorithm> kAllAlgorithms = {
+    BroadcastAlgorithm::FlatTree,
+};
+
+// ============================================================================
+// SECTION 2: TEST FIXTURE CLASS
+// ============================================================================
+
+class BroadcastBenchmarkFixture : public MpiBaseTestFixture {
+ protected:
+  void SetUp() override {
+    MpiBaseTestFixture::SetUp();
+    // Use localRank for cudaSetDevice since each node has its own set of GPUs
+    CUDA_CHECK_VOID(cudaSetDevice(localRank));
+
+    // Initialize NCCL
+    NCCL_CHECK_VOID(
+        ncclCommInitRank(&ncclComm_, numRanks, getNCCLId(), globalRank));
+    CUDA_CHECK_VOID(cudaStreamCreate(&stream_));
+  }
+
+  void TearDown() override {
+    NCCL_CHECK_VOID(ncclCommDestroy(ncclComm_));
+    CUDA_CHECK_VOID(cudaStreamDestroy(stream_));
+    MpiBaseTestFixture::TearDown();
+  }
+
+  ncclUniqueId getNCCLId() {
+    ncclUniqueId id;
+    if (globalRank == 0) {
+      ncclResult_t res = ncclGetUniqueId(&id);
+      if (res != ncclSuccess) {
+        XLOGF(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
+        std::abort();
+      }
+    }
+    MPI_CHECK(MPI_Bcast(&id, sizeof(id), MPI_BYTE, 0, MPI_COMM_WORLD));
+    return id;
+  }
+
+  // --------------------------------------------------------------------------
+  // Data Generation and Verification Helpers
+  // --------------------------------------------------------------------------
+
+  /**
+   * Generate expected data pattern for a given root rank.
+   * The pattern is (byte_index + rootRank) % 256.
+   */
+  std::vector<char> generateExpectedData(std::size_t size, int rootRank) {
+    std::vector<char> data(size);
+    for (std::size_t i = 0; i < size; i++) {
+      data[i] = static_cast<char>((i + rootRank) % 256);
+    }
+    return data;
+  }
+
+  /**
+   * Verify that buffer contains the expected broadcast data.
+   * Returns true if verification passes, false otherwise.
+   */
+  bool verifyBroadcastData(
+      void* buffer_d,
+      std::size_t size,
+      int rootRank,
+      const std::string& testName,
+      const std::string& impl) {
+    std::vector<char> h_result(size);
+    CUDA_CHECK_BOOL(
+        cudaMemcpy(h_result.data(), buffer_d, size, cudaMemcpyDeviceToHost));
+
+    auto expected = generateExpectedData(size, rootRank);
+
+    std::size_t mismatchCount = 0;
+    std::size_t firstMismatch = 0;
+    char expectedVal = 0, actualVal = 0;
+
+    for (std::size_t i = 0; i < size; i++) {
+      if (h_result[i] != expected[i]) {
+        if (mismatchCount == 0) {
+          firstMismatch = i;
+          expectedVal = expected[i];
+          actualVal = h_result[i];
+        }
+        mismatchCount++;
+      }
+    }
+
+    if (mismatchCount > 0) {
+      XLOGF(
+          ERR,
+          "Rank {}: {} {} verification FAILED: {} mismatches out of {} bytes. "
+          "First mismatch at byte {}: expected {}, got {}",
+          globalRank,
+          impl,
+          testName,
+          mismatchCount,
+          size,
+          firstMismatch,
+          static_cast<int>(expectedVal),
+          static_cast<int>(actualVal));
+      return false;
+    }
+
+    XLOGF(
+        DBG1,
+        "Rank {}: {} {} verification PASSED ({} bytes)",
+        globalRank,
+        impl,
+        testName,
+        size);
+    return true;
+  }
+
+  // --------------------------------------------------------------------------
+  // NCCL Baseline Benchmark
+  // --------------------------------------------------------------------------
+
+  /**
+   * Run NCCL Broadcast benchmark.
+   * Returns bandwidth in GB/s and sets latency in microseconds.
+   */
+  float runNcclBroadcastBenchmark(
+      const BroadcastBenchmarkConfig& config,
+      int rootRank,
+      float& latencyUs,
+      bool& verified) {
+    XLOGF(
+        DBG1,
+        "Rank {}: Running NCCL Broadcast benchmark: {} (root={})",
+        globalRank,
+        config.name,
+        rootRank);
+
+    verified = false;
+    DeviceBuffer buffer(config.messageSize);
+
+    // Initialize buffer: root has data, others have zeros
+    if (globalRank == rootRank) {
+      auto h_data = generateExpectedData(config.messageSize, rootRank);
+      CUDA_CHECK(cudaMemcpy(
+          buffer.get(),
+          h_data.data(),
+          config.messageSize,
+          cudaMemcpyHostToDevice));
+    } else {
+      CUDA_CHECK(cudaMemset(buffer.get(), 0, config.messageSize));
+    }
+
+    CudaEvent start, stop;
+
+    // Warmup
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    NVTX_RANGE_PUSH("NCCL_Broadcast_Warmup");
+    for (int i = 0; i < kWarmupIters; i++) {
+      NCCL_CHECK(ncclBroadcast(
+          buffer.get(),
+          buffer.get(),
+          config.messageSize,
+          ncclChar,
+          rootRank,
+          ncclComm_,
+          stream_));
+      CUDA_CHECK(cudaStreamSynchronize(stream_));
+    }
+    NVTX_RANGE_POP();
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    // Benchmark
+    NVTX_RANGE_PUSH("NCCL_Broadcast_Benchmark");
+    CUDA_CHECK(cudaEventRecord(start.get(), stream_));
+    for (int i = 0; i < kBenchmarkIters; i++) {
+      NVTX_RANGE_PUSH("NCCL_Broadcast_Iter");
+      NCCL_CHECK(ncclBroadcast(
+          buffer.get(),
+          buffer.get(),
+          config.messageSize,
+          ncclChar,
+          rootRank,
+          ncclComm_,
+          stream_));
+      NVTX_RANGE_POP();
+    }
+    CUDA_CHECK(cudaEventRecord(stop.get(), stream_));
+    CUDA_CHECK(cudaStreamSynchronize(stream_));
+    NVTX_RANGE_POP();
+
+    float totalTime_ms = 0.0f;
+    CUDA_CHECK(cudaEventElapsedTime(&totalTime_ms, start.get(), stop.get()));
+    float avgTime_ms = totalTime_ms / kBenchmarkIters;
+    latencyUs = avgTime_ms * 1000.0f;
+
+    // Broadcast bandwidth: data transferred / time
+    // (root sends to all other ranks, so effective data = messageSize)
+    // Use double for intermediate calculations to avoid precision loss with
+    // small messages
+    float bandwidth_GBps = static_cast<float>(
+        (static_cast<double>(config.messageSize) / 1e9) /
+        (static_cast<double>(avgTime_ms) / 1000.0));
+
+    // Verify data correctness if enabled
+    if (FLAGS_verify_correctness) {
+      // Re-initialize and run one more broadcast for verification
+      if (globalRank == rootRank) {
+        auto h_data = generateExpectedData(config.messageSize, rootRank);
+        CUDA_CHECK(cudaMemcpy(
+            buffer.get(),
+            h_data.data(),
+            config.messageSize,
+            cudaMemcpyHostToDevice));
+      } else {
+        CUDA_CHECK(cudaMemset(buffer.get(), 0, config.messageSize));
+      }
+
+      NCCL_CHECK(ncclBroadcast(
+          buffer.get(),
+          buffer.get(),
+          config.messageSize,
+          ncclChar,
+          rootRank,
+          ncclComm_,
+          stream_));
+      CUDA_CHECK(cudaStreamSynchronize(stream_));
+
+      verified = verifyBroadcastData(
+          buffer.get(), config.messageSize, rootRank, config.name, "NCCL");
+    }
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    return bandwidth_GBps;
+  }
+
+  // --------------------------------------------------------------------------
+  // Pipes Transport Setup Helpers
+  // --------------------------------------------------------------------------
+
+  /**
+   * Initialize broadcast buffer: root rank gets expected data, others get
+   * zeros. Returns 0.0f on failure (for CUDA_CHECK compatibility).
+   */
+  float initializeBroadcastBuffer(
+      DeviceBuffer& buffer,
+      std::size_t messageSize,
+      int rootRank) {
+    if (globalRank == rootRank) {
+      auto h_data = generateExpectedData(messageSize, rootRank);
+      CUDA_CHECK(cudaMemcpy(
+          buffer.get(), h_data.data(), messageSize, cudaMemcpyHostToDevice));
+    } else {
+      CUDA_CHECK(cudaMemset(buffer.get(), 0, messageSize));
+    }
+    return 1.0f; // Success
+  }
+
+  /**
+   * Result struct for transport setup.
+   */
+  struct TransportSetupResult {
+    std::unique_ptr<MultiPeerNvlTransport> transport;
+    DeviceBuffer d_transports;
+    DeviceSpan<Transport> transports_span;
+  };
+
+  /**
+   * Setup P2P NVL transports for Pipes benchmark.
+   * Returns a struct containing the transport objects and device span.
+   */
+  TransportSetupResult setupPipesTransports(
+      const BroadcastBenchmarkConfig& config) {
+    MultiPeerNvlTransportConfig nvlConfig{
+        .dataBufferSize = config.stagingBufferSize,
+        .chunkSize = config.chunkSize,
+        .pipelineDepth = config.pipelineDepth,
+    };
+
+    auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+    auto transport = std::make_unique<MultiPeerNvlTransport>(
+        globalRank, numRanks, bootstrap, nvlConfig);
+    transport->exchange();
+
+    // Create transport array: self for my rank, P2P for others
+    P2pSelfTransportDevice selfTransport;
+    std::vector<Transport> h_transports;
+    h_transports.reserve(numRanks);
+
+    for (int rank = 0; rank < numRanks; rank++) {
+      if (rank == globalRank) {
+        h_transports.emplace_back(selfTransport);
+      } else {
+        h_transports.emplace_back(transport->getP2pTransportDevice(rank));
+      }
+    }
+
+    // Copy transports to device
+    DeviceBuffer d_transports(sizeof(Transport) * numRanks);
+    cudaMemcpy(
+        d_transports.get(),
+        h_transports.data(),
+        sizeof(Transport) * numRanks,
+        cudaMemcpyHostToDevice);
+
+    DeviceSpan<Transport> transports_span(
+        static_cast<Transport*>(d_transports.get()), numRanks);
+
+    return TransportSetupResult{
+        std::move(transport),
+        std::move(d_transports),
+        transports_span,
+    };
+  }
+
+  /**
+   * Calculate bandwidth and latency from timing data.
+   */
+  struct BenchmarkTiming {
+    float bandwidthGBps;
+    float latencyUs;
+  };
+
+  BenchmarkTiming calculateBenchmarkTiming(
+      float totalTimeMs,
+      std::size_t messageSize) {
+    float avgTimeMs = totalTimeMs / kBenchmarkIters;
+    float latencyUs = avgTimeMs * 1000.0f;
+
+    // Use double for intermediate calculations to avoid precision loss with
+    // small messages
+    float bandwidthGBps = static_cast<float>(
+        (static_cast<double>(messageSize) / 1e9) /
+        (static_cast<double>(avgTimeMs) / 1000.0));
+
+    return BenchmarkTiming{bandwidthGBps, latencyUs};
+  }
+
+  /**
+   * Generic Pipes broadcast benchmark runner.
+   *
+   * Runs the specified broadcast kernel through warmup, benchmark, and optional
+   * verification phases. This eliminates code duplication across algorithm-
+   * specific benchmark functions.
+   *
+   * @param kernelFunc Pointer to the broadcast kernel function
+   * @param algorithmName Name of the algorithm for logging/verification
+   * @param config Benchmark configuration
+   * @param rootRank Root rank for the broadcast
+   * @param latencyUs Output: average latency in microseconds
+   * @param verified Output: whether verification passed (if enabled)
+   * @return Bandwidth in GB/s
+   */
+  template <typename KernelFunc>
+  float runGenericPipesBroadcast(
+      KernelFunc kernelFunc,
+      const std::string& algorithmName,
+      const BroadcastBenchmarkConfig& config,
+      int rootRank,
+      float& latencyUs,
+      bool& verified) {
+    XLOGF(
+        DBG1,
+        "Rank {}: Running Pipes {} broadcast: {} (root={})",
+        globalRank,
+        algorithmName,
+        config.name,
+        rootRank);
+
+    verified = false;
+    DeviceBuffer buffer(config.messageSize);
+
+    // Initialize buffer using helper
+    if (initializeBroadcastBuffer(buffer, config.messageSize, rootRank) ==
+        0.0f) {
+      return 0.0f;
+    }
+
+    // Setup transports using helper
+    auto transportSetup = setupPipesTransports(config);
+
+    // Prepare kernel launch parameters
+    dim3 gridDim(config.numBlocks);
+    dim3 blockDim(config.numThreads);
+
+    void* buff_d = buffer.get();
+    std::size_t nbytes = config.messageSize;
+    void* args[] = {
+        &buff_d,
+        &globalRank,
+        &rootRank,
+        &transportSetup.transports_span,
+        &nbytes};
+
+    CudaEvent start, stop;
+
+    // Warmup
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    std::string warmupRange = "Pipes_" + algorithmName + "_Warmup";
+    NVTX_RANGE_PUSH(warmupRange.c_str());
+    for (int i = 0; i < kWarmupIters; i++) {
+      CUDA_CHECK(cudaLaunchKernel(
+          (void*)kernelFunc, gridDim, blockDim, args, 0, stream_));
+      CUDA_CHECK(cudaStreamSynchronize(stream_));
+    }
+    NVTX_RANGE_POP();
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    // Benchmark
+    std::string benchmarkRange = "Pipes_" + algorithmName + "_Benchmark";
+    NVTX_RANGE_PUSH(benchmarkRange.c_str());
+    CUDA_CHECK(cudaEventRecord(start.get(), stream_));
+    for (int i = 0; i < kBenchmarkIters; i++) {
+      std::string iterRange = "Pipes_" + algorithmName + "_Iter";
+      NVTX_RANGE_PUSH(iterRange.c_str());
+      CUDA_CHECK(cudaLaunchKernel(
+          (void*)kernelFunc, gridDim, blockDim, args, 0, stream_));
+      NVTX_RANGE_POP();
+    }
+    CUDA_CHECK(cudaEventRecord(stop.get(), stream_));
+    CUDA_CHECK(cudaStreamSynchronize(stream_));
+    NVTX_RANGE_POP();
+
+    float totalTime_ms = 0.0f;
+    CUDA_CHECK(cudaEventElapsedTime(&totalTime_ms, start.get(), stop.get()));
+
+    // Calculate timing using helper
+    auto timing = calculateBenchmarkTiming(totalTime_ms, config.messageSize);
+    latencyUs = timing.latencyUs;
+
+    // Verify data correctness if enabled
+    if (FLAGS_verify_correctness) {
+      // Re-initialize buffer for verification
+      if (initializeBroadcastBuffer(buffer, config.messageSize, rootRank) ==
+          0.0f) {
+        return 0.0f;
+      }
+
+      buff_d = buffer.get();
+      CUDA_CHECK(cudaLaunchKernel(
+          (void*)kernelFunc, gridDim, blockDim, args, 0, stream_));
+      CUDA_CHECK(cudaStreamSynchronize(stream_));
+
+      verified = verifyBroadcastData(
+          buffer.get(),
+          config.messageSize,
+          rootRank,
+          config.name,
+          algorithmName);
+    }
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    return timing.bandwidthGBps;
+  }
+
+  // --------------------------------------------------------------------------
+  // Pipes Benchmark Runners
+  // --------------------------------------------------------------------------
+
+  /**
+   * Run Pipes Broadcast benchmark with flat-tree algorithm.
+   * Returns bandwidth in GB/s and sets latency in microseconds.
+   */
+  float runPipesBroadcastFlatBenchmark(
+      const BroadcastBenchmarkConfig& config,
+      int rootRank,
+      float& latencyUs,
+      bool& verified) {
+    return runGenericPipesBroadcast(
+        broadcastFlatKernel,
+        "Flat-Tree",
+        config,
+        rootRank,
+        latencyUs,
+        verified);
+  }
+
+  /**
+   * Run Pipes Broadcast benchmark with clustered kernel launch.
+   * Uses cudaClusterSchedulingPolicySpread to spread clusters across GPCs.
+   * Returns bandwidth in GB/s and sets latency in microseconds.
+   */
+  float runPipesClusteredBroadcastBenchmark(
+      const BroadcastBenchmarkConfig& config,
+      int rootRank,
+      float& latencyUs,
+      bool& verified,
+      int clusterSize = kDefaultClusterSize) {
+    XLOGF(
+        DBG1,
+        "Rank {}: Running Pipes Clustered broadcast: {} (root={}, cluster={})",
+        globalRank,
+        config.name,
+        rootRank,
+        clusterSize);
+
+    verified = false;
+    DeviceBuffer buffer(config.messageSize);
+
+    // Initialize buffer using helper
+    if (initializeBroadcastBuffer(buffer, config.messageSize, rootRank) ==
+        0.0f) {
+      return 0.0f;
+    }
+
+    // Setup transports using helper
+    auto transportSetup = setupPipesTransports(config);
+
+    // Prepare kernel launch parameters
+    dim3 gridDim(config.numBlocks);
+    dim3 blockDim(config.numThreads);
+    dim3 clusterDim(clusterSize, 1, 1);
+
+    void* buff_d = buffer.get();
+    std::size_t nbytes = config.messageSize;
+    void* args[] = {
+        &buff_d,
+        &globalRank,
+        &rootRank,
+        &transportSetup.transports_span,
+        &nbytes};
+
+    CudaEvent start, stop;
+
+    // Warmup with clustered launch
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    NVTX_RANGE_PUSH("Pipes_Clustered_Warmup");
+    for (int i = 0; i < kWarmupIters; i++) {
+      CUDA_CHECK(
+          comms::common::launchKernel(
+              (void*)broadcastFlatKernel,
+              gridDim,
+              blockDim,
+              args,
+              stream_,
+              clusterDim));
+      CUDA_CHECK(cudaStreamSynchronize(stream_));
+    }
+    NVTX_RANGE_POP();
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    // Benchmark with clustered launch
+    NVTX_RANGE_PUSH("Pipes_Clustered_Benchmark");
+    CUDA_CHECK(cudaEventRecord(start.get(), stream_));
+    for (int i = 0; i < kBenchmarkIters; i++) {
+      NVTX_RANGE_PUSH("Pipes_Clustered_Iter");
+      CUDA_CHECK(
+          comms::common::launchKernel(
+              (void*)broadcastFlatKernel,
+              gridDim,
+              blockDim,
+              args,
+              stream_,
+              clusterDim));
+      NVTX_RANGE_POP();
+    }
+    CUDA_CHECK(cudaEventRecord(stop.get(), stream_));
+    CUDA_CHECK(cudaStreamSynchronize(stream_));
+    NVTX_RANGE_POP();
+
+    float totalTime_ms = 0.0f;
+    CUDA_CHECK(cudaEventElapsedTime(&totalTime_ms, start.get(), stop.get()));
+
+    // Calculate timing using helper
+    auto timing = calculateBenchmarkTiming(totalTime_ms, config.messageSize);
+    latencyUs = timing.latencyUs;
+
+    // Verify data correctness if enabled
+    if (FLAGS_verify_correctness) {
+      // Re-initialize buffer for verification
+      if (initializeBroadcastBuffer(buffer, config.messageSize, rootRank) ==
+          0.0f) {
+        return 0.0f;
+      }
+
+      buff_d = buffer.get();
+      CUDA_CHECK(
+          comms::common::launchKernel(
+              (void*)broadcastFlatKernel,
+              gridDim,
+              blockDim,
+              args,
+              stream_,
+              clusterDim));
+      CUDA_CHECK(cudaStreamSynchronize(stream_));
+
+      verified = verifyBroadcastData(
+          buffer.get(), config.messageSize, rootRank, config.name, "Clustered");
+    }
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    return timing.bandwidthGBps;
+  }
+
+  // --------------------------------------------------------------------------
+  // Unified Algorithm Runner
+  // --------------------------------------------------------------------------
+
+  /**
+   * Unified runner that dispatches to the appropriate algorithm.
+   * This allows parameterized testing across all algorithms.
+   * Add new algorithm cases here as they are implemented.
+   */
+  float runPipesBroadcast(
+      BroadcastAlgorithm algo,
+      const BroadcastBenchmarkConfig& config,
+      int rootRank,
+      float& latencyUs,
+      bool& verified) {
+    switch (algo) {
+      case BroadcastAlgorithm::FlatTree:
+        return runPipesBroadcastFlatBenchmark(
+            config, rootRank, latencyUs, verified);
+        // case BroadcastAlgorithm::BinomialTree - added in D91729677
+        // case BroadcastAlgorithm::Ring - added in D91697545
+        // case BroadcastAlgorithm::Adaptive - added in D91729719
+    }
+    return 0.0f;
+  }
+
+  // --------------------------------------------------------------------------
+  // Result Formatting and Output Utilities
+  // --------------------------------------------------------------------------
+
+  void printResultsTable(const std::vector<BroadcastBenchmarkResult>& results) {
+    if (globalRank != 0) {
+      return;
+    }
+
+    std::stringstream ss;
+    ss << "\n";
+    ss << "======================================================================================================================";
+    if (FLAGS_verify_correctness) {
+      ss << "================";
+    }
+    ss << "\n";
+    ss << "                         NCCL vs Pipes Broadcast Benchmark Results";
+    if (FLAGS_verify_correctness) {
+      ss << " (with verification)";
+    }
+    ss << "\n";
+    ss << "======================================================================================================================";
+    if (FLAGS_verify_correctness) {
+      ss << "================";
+    }
+    ss << "\n";
+    ss << std::left << std::setw(22) << "Test Name" << std::right
+       << std::setw(10) << "Size" << std::right << std::setw(8) << "Root"
+       << std::right << std::setw(8) << "Ranks" << std::right << std::setw(12)
+       << "NCCL BW" << std::right << std::setw(12) << "Pipes BW" << std::right
+       << std::setw(10) << "Speedup" << std::right << std::setw(12)
+       << "NCCL Lat" << std::right << std::setw(12) << "Pipes Lat" << std::right
+       << std::setw(12) << "Lat Reduc";
+    if (FLAGS_verify_correctness) {
+      ss << std::right << std::setw(8) << "NCCL OK" << std::right
+         << std::setw(8) << "Pipes OK";
+    }
+    ss << "\n";
+    ss << std::left << std::setw(22) << "" << std::right << std::setw(10) << ""
+       << std::right << std::setw(8) << "" << std::right << std::setw(8) << ""
+       << std::right << std::setw(12) << "(GB/s)" << std::right << std::setw(12)
+       << "(GB/s)" << std::right << std::setw(10) << "Pipes/NCCL" << std::right
+       << std::setw(12) << "(us)" << std::right << std::setw(12) << "(us)"
+       << std::right << std::setw(12) << "(us)";
+    if (FLAGS_verify_correctness) {
+      ss << std::right << std::setw(8) << "" << std::right << std::setw(8)
+         << "";
+    }
+    ss << "\n";
+    ss << "----------------------------------------------------------------------------------------------------------------------";
+    if (FLAGS_verify_correctness) {
+      ss << "----------------";
+    }
+    ss << "\n";
+
+    for (const auto& r : results) {
+      std::string msgSize = formatSize(r.messageSize);
+      float latencyReduction = r.ncclLatency - r.pipesLatency;
+
+      ss << std::left << std::setw(22) << r.testName << std::right
+         << std::setw(10) << msgSize << std::right << std::setw(8) << r.rootRank
+         << std::right << std::setw(8) << r.nRanks << std::right
+         << std::setw(12) << std::fixed << std::setprecision(2)
+         << r.ncclBandwidth << std::right << std::setw(12) << std::fixed
+         << std::setprecision(2) << r.pipesBandwidth << std::right
+         << std::setw(9) << std::fixed << std::setprecision(2) << r.speedup
+         << "x" << std::right << std::setw(12) << std::fixed
+         << std::setprecision(1) << r.ncclLatency << std::right << std::setw(12)
+         << std::fixed << std::setprecision(1) << r.pipesLatency << std::right
+         << std::setw(12) << std::fixed << std::setprecision(1)
+         << latencyReduction;
+      if (FLAGS_verify_correctness) {
+        ss << std::right << std::setw(8) << (r.ncclVerified ? "PASS" : "FAIL")
+           << std::right << std::setw(8) << (r.pipesVerified ? "PASS" : "FAIL");
+      }
+      ss << "\n";
+    }
+
+    ss << "======================================================================================================================";
+    if (FLAGS_verify_correctness) {
+      ss << "================";
+    }
+    ss << "\n";
+
+    XLOG(INFO) << ss.str();
+
+    // Print legend separately to avoid MPI buffer splitting issues
+    XLOG(INFO) << "BW (Bandwidth) = Message size / time, in GB/s";
+    XLOG(INFO) << "Lat (Latency) = Average transfer time per iteration, in us";
+    XLOG(INFO)
+        << "Lat Reduc = NCCL latency - Pipes latency (positive = Pipes faster)";
+    XLOG(INFO) << "Speedup = Pipes Bandwidth / NCCL Bandwidth";
+    if (FLAGS_verify_correctness) {
+      XLOG(INFO) << "NCCL OK / Pipes OK = Data correctness verification result";
+      XLOG(INFO)
+          << "======================================================================================================================================";
+    } else {
+      XLOG(INFO)
+          << "======================================================================================================================";
+    }
+  }
+
+  std::string formatSize(std::size_t bytes) {
+    std::stringstream ss;
+    if (bytes >= 1024 * 1024 * 1024) {
+      ss << std::fixed << std::setprecision(0)
+         << (bytes / (1024.0 * 1024.0 * 1024.0)) << "GB";
+    } else if (bytes >= 1024 * 1024) {
+      ss << std::fixed << std::setprecision(0) << (bytes / (1024.0 * 1024.0))
+         << "MB";
+    } else if (bytes >= 1024) {
+      ss << std::fixed << std::setprecision(0) << (bytes / 1024.0) << "KB";
+    } else {
+      ss << bytes << "B";
+    }
+    return ss.str();
+  }
+
+  ncclComm_t ncclComm_{};
+  cudaStream_t stream_{};
+};
+
+// ============================================================================
+// SECTION 3: TEST CASES
+// ============================================================================
+
+/**
+ * Clustered Launch Comparison Benchmark
+ *
+ * Compares standard kernel launch vs clustered kernel launch with
+ * cudaClusterSchedulingPolicySpread across various message sizes.
+ *
+ * Clustered launches group thread blocks into clusters that are scheduled
+ * together on the same GPC, which can reduce L2 cache thrashing and improve
+ * memory access patterns.
+ */
+TEST_F(BroadcastBenchmarkFixture, ClusteredLaunchComparison) {
+  if (globalRank == 0) {
+    XLOG(INFO) << "\n=== Clustered Launch vs Standard Launch Comparison ===\n";
+    XLOG(INFO) << "Comparing cudaLaunchKernel vs cudaLaunchKernelExC with "
+                  "cudaClusterSchedulingPolicySpread\n";
+  }
+
+  // Test configurations across message sizes
+  std::vector<BroadcastBenchmarkConfig> configs = {
+      // Small message
+      {
+          .messageSize = 64 * 1024,
+          .stagingBufferSize = 64 * 1024,
+          .pipelineDepth = 4,
+          .chunkSize = 16 * 1024,
+          .numBlocks = 8,
+          .numThreads = 256,
+          .rootRank = 0,
+          .name = "64KB",
+      },
+      // Medium message
+      {
+          .messageSize = 1 * 1024 * 1024,
+          .stagingBufferSize = 16 * 1024 * 1024,
+          .pipelineDepth = 4,
+          .chunkSize = 128 * 1024,
+          .numBlocks = 32,
+          .numThreads = 512,
+          .rootRank = 0,
+          .name = "1MB",
+      },
+      // Large message
+      {
+          .messageSize = 8 * 1024 * 1024,
+          .stagingBufferSize = 16 * 1024 * 1024,
+          .pipelineDepth = 4,
+          .chunkSize = 128 * 1024,
+          .numBlocks = 32,
+          .numThreads = 512,
+          .rootRank = 0,
+          .name = "8MB",
+      },
+      // Very large message
+      {
+          .messageSize = 64 * 1024 * 1024,
+          .stagingBufferSize = 64 * 1024 * 1024,
+          .pipelineDepth = 4,
+          .chunkSize = 128 * 1024,
+          .numBlocks = 32,
+          .numThreads = 512,
+          .rootRank = 0,
+          .name = "64MB",
+      },
+  };
+
+  // Print header
+  if (globalRank == 0) {
+    std::stringstream ss;
+    ss << "\n";
+    ss << "========================================================================"
+          "================================================\n";
+    ss << "     Standard vs Clustered Launch Comparison (Flat-Tree Broadcast)\n";
+    ss << "========================================================================"
+          "================================================\n";
+    ss << std::left << std::setw(12) << "MsgSize" << std::right << std::setw(12)
+       << "NCCL BW" << std::right << std::setw(14) << "Standard BW"
+       << std::right << std::setw(14) << "Clustered BW" << std::right
+       << std::setw(12) << "Speedup" << std::right << std::setw(14)
+       << "Std/NCCL" << std::right << std::setw(14) << "Clust/NCCL" << "\n";
+    ss << std::left << std::setw(12) << "" << std::right << std::setw(12)
+       << "(GB/s)" << std::right << std::setw(14) << "(GB/s)" << std::right
+       << std::setw(14) << "(GB/s)" << std::right << std::setw(12)
+       << "Clust/Std" << std::right << std::setw(14) << "" << std::right
+       << std::setw(14) << "" << "\n";
+    ss << "------------------------------------------------------------------------"
+          "------------------------------------------------\n";
+    XLOG(INFO) << ss.str();
+  }
+
+  for (const auto& config : configs) {
+    int rootRank = config.rootRank;
+
+    // NCCL baseline
+    float ncclLatencyUs = 0.0f;
+    bool ncclVerified = false;
+    float ncclBandwidth = runNcclBroadcastBenchmark(
+        config, rootRank, ncclLatencyUs, ncclVerified);
+
+    // Standard launch
+    float stdLatencyUs = 0.0f;
+    bool stdVerified = false;
+    float stdBandwidth = runPipesBroadcastFlatBenchmark(
+        config, rootRank, stdLatencyUs, stdVerified);
+
+    // Clustered launch (cluster size = kDefaultClusterSize)
+    float clusteredLatencyUs = 0.0f;
+    bool clusteredVerified = false;
+    float clusteredBandwidth = runPipesClusteredBroadcastBenchmark(
+        config,
+        rootRank,
+        clusteredLatencyUs,
+        clusteredVerified,
+        kDefaultClusterSize);
+
+    if (globalRank == 0) {
+      float clusterSpeedup =
+          (stdBandwidth > 0) ? clusteredBandwidth / stdBandwidth : 0;
+      float stdVsNccl = (ncclBandwidth > 0) ? stdBandwidth / ncclBandwidth : 0;
+      float clustVsNccl =
+          (ncclBandwidth > 0) ? clusteredBandwidth / ncclBandwidth : 0;
+
+      std::stringstream ss;
+      ss << std::left << std::setw(12) << config.name << std::right
+         << std::setw(12) << std::fixed << std::setprecision(2) << ncclBandwidth
+         << std::right << std::setw(14) << std::fixed << std::setprecision(2)
+         << stdBandwidth << std::right << std::setw(14) << std::fixed
+         << std::setprecision(2) << clusteredBandwidth << std::right
+         << std::setw(11) << std::fixed << std::setprecision(2)
+         << clusterSpeedup << "x" << std::right << std::setw(13) << std::fixed
+         << std::setprecision(2) << stdVsNccl << "x" << std::right
+         << std::setw(13) << std::fixed << std::setprecision(2) << clustVsNccl
+         << "x";
+      XLOG(INFO) << ss.str();
+    }
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  }
+
+  if (globalRank == 0) {
+    XLOG(INFO)
+        << "========================================================================"
+           "================================================";
+    XLOG(INFO)
+        << "Speedup > 1.0x indicates clustered launch is faster than standard";
+    XLOG(INFO)
+        << "========================================================================"
+           "================================================\n";
+  }
+}
+
+/**
+ * Root Rank Sweep Benchmark
+ *
+ * Tests broadcast performance with each rank as root to identify
+ * any topology-dependent performance variations.
+ */
+TEST_F(BroadcastBenchmarkFixture, RootRankSweep) {
+  if (globalRank == 0) {
+    XLOG(INFO) << "\n=== Root Rank Sweep Benchmark (All Algorithms) ===\n";
+    XLOG(INFO) << "Testing broadcast with each rank as root to identify "
+                  "topology-dependent performance variations.\n";
+  }
+
+  // Use a fixed medium message size for this sweep
+  BroadcastBenchmarkConfig baseConfig{
+      .messageSize = 4 * 1024 * 1024, // 4MB
+      .stagingBufferSize = 16 * 1024 * 1024,
+      .pipelineDepth = 4,
+      .chunkSize = 128 * 1024,
+      .numBlocks = 32,
+      .numThreads = 512,
+      .rootRank = 0, // Will be overridden
+      .name = "4MB",
+  };
+
+  // Print header
+  if (globalRank == 0) {
+    std::stringstream ss;
+    ss << "\n";
+    ss << "========================================================================"
+          "======================================\n";
+    ss << "                         Root Rank Sweep (4MB Message, All Algorithms)\n";
+    ss << "========================================================================"
+          "======================================\n";
+    ss << std::left << std::setw(8) << "Root" << std::left << std::setw(12)
+       << "Algorithm" << std::right << std::setw(12) << "NCCL BW" << std::right
+       << std::setw(12) << "Pipes BW" << std::right << std::setw(12)
+       << "Speedup" << std::right << std::setw(12) << "NCCL Lat" << std::right
+       << std::setw(12) << "Pipes Lat" << std::right << std::setw(14)
+       << "Lat Diff" << "\n";
+    ss << std::left << std::setw(8) << "Rank" << std::left << std::setw(12)
+       << "" << std::right << std::setw(12) << "(GB/s)" << std::right
+       << std::setw(12) << "(GB/s)" << std::right << std::setw(12)
+       << "Pipes/NCCL" << std::right << std::setw(12) << "(us)" << std::right
+       << std::setw(12) << "(us)" << std::right << std::setw(14) << "(us)"
+       << "\n";
+    ss << "------------------------------------------------------------------------"
+          "--------------------------------------\n";
+    XLOG(INFO) << ss.str();
+  }
+
+  // Sweep through all root ranks
+  for (int rootRank = 0; rootRank < numRanks; rootRank++) {
+    BroadcastBenchmarkConfig config = baseConfig;
+    config.rootRank = rootRank;
+    config.name = "Root" + std::to_string(rootRank);
+
+    // Run NCCL once per root rank (baseline)
+    float ncclLatencyUs = 0.0f;
+    bool ncclVerified = false;
+    float ncclBandwidth = runNcclBroadcastBenchmark(
+        config, rootRank, ncclLatencyUs, ncclVerified);
+
+    // Run each algorithm
+    for (auto algo : kAllAlgorithms) {
+      float pipesLatencyUs = 0.0f;
+      bool pipesVerified = false;
+      float pipesBandwidth = runPipesBroadcast(
+          algo, config, rootRank, pipesLatencyUs, pipesVerified);
+
+      if (globalRank == 0) {
+        float speedup =
+            (ncclBandwidth > 0) ? pipesBandwidth / ncclBandwidth : 0;
+        float latDiff = ncclLatencyUs - pipesLatencyUs;
+
+        std::stringstream ss;
+        ss << std::left << std::setw(8) << rootRank << std::left
+           << std::setw(12) << algorithmName(algo) << std::right
+           << std::setw(12) << std::fixed << std::setprecision(2)
+           << ncclBandwidth << std::right << std::setw(12) << std::fixed
+           << std::setprecision(2) << pipesBandwidth << std::right
+           << std::setw(11) << std::fixed << std::setprecision(2) << speedup
+           << "x" << std::right << std::setw(12) << std::fixed
+           << std::setprecision(1) << ncclLatencyUs << std::right
+           << std::setw(12) << std::fixed << std::setprecision(1)
+           << pipesLatencyUs << std::right << std::setw(14) << std::fixed
+           << std::setprecision(1) << latDiff;
+        XLOG(INFO) << ss.str();
+      }
+
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    }
+
+    // Print separator between root ranks (when multiple algorithms exist)
+    if (globalRank == 0 && rootRank < numRanks - 1 &&
+        kAllAlgorithms.size() > 1) {
+      XLOG(INFO)
+          << "------------------------------------------------------------------------"
+             "--------------------------------------";
+    }
+  }
+
+  if (globalRank == 0) {
+    XLOG(INFO)
+        << "========================================================================"
+           "======================================";
+    XLOG(INFO) << "Speedup > 1.0x indicates Pipes is faster than NCCL for that "
+                  "algorithm/root combination";
+    XLOG(INFO)
+        << "========================================================================"
+           "======================================\n";
+  }
+}
+
+/**
+ * Extended Message Sizes Benchmark
+ *
+ * Tests a comprehensive range of message sizes from very small (64B)
+ * to very large (256MB) to identify optimal message size ranges.
+ */
+TEST_F(BroadcastBenchmarkFixture, ExtendedMessageSizes) {
+  if (globalRank == 0) {
+    XLOG(INFO)
+        << "\n=== Extended Message Sizes Benchmark (All Algorithms) ===\n";
+    XLOG(INFO) << "Testing message sizes from 64B to 256MB.\n";
+  }
+
+  // Extended message size sweep
+  std::vector<std::size_t> messageSizes = {
+      64, // 64 bytes - latency bound
+      256, // 256 bytes
+      1 * 1024, // 1KB
+      4 * 1024, // 4KB
+      16 * 1024, // 16KB
+      64 * 1024, // 64KB
+      256 * 1024, // 256KB
+      512 * 1024, // 512KB
+      1 * 1024 * 1024, // 1MB
+      2 * 1024 * 1024, // 2MB
+      4 * 1024 * 1024, // 4MB
+      8 * 1024 * 1024, // 8MB
+      16 * 1024 * 1024, // 16MB
+      32 * 1024 * 1024, // 32MB
+      64 * 1024 * 1024, // 64MB
+      128 * 1024 * 1024, // 128MB
+      256 * 1024 * 1024, // 256MB
+  };
+
+  // Print header
+  if (globalRank == 0) {
+    std::stringstream ss;
+    ss << "\n";
+    ss << "========================================================================"
+          "============================================\n";
+    ss << "                  Extended Message Size Sweep (All Algorithms)\n";
+    ss << "========================================================================"
+          "============================================\n";
+    ss << std::left << std::setw(10) << "MsgSize" << std::left << std::setw(12)
+       << "Algorithm" << std::right << std::setw(12) << "NCCL BW" << std::right
+       << std::setw(12) << "Pipes BW" << std::right << std::setw(12)
+       << "Speedup" << std::right << std::setw(12) << "NCCL Lat" << std::right
+       << std::setw(12) << "Pipes Lat" << std::right << std::setw(12) << "Chunk"
+       << std::right << std::setw(10) << "Blocks" << "\n";
+    ss << std::left << std::setw(10) << "" << std::left << std::setw(12) << ""
+       << std::right << std::setw(12) << "(GB/s)" << std::right << std::setw(12)
+       << "(GB/s)" << std::right << std::setw(12) << "Pipes/NCCL" << std::right
+       << std::setw(12) << "(us)" << std::right << std::setw(12) << "(us)"
+       << std::right << std::setw(12) << "Size" << std::right << std::setw(10)
+       << "" << "\n";
+    ss << "------------------------------------------------------------------------"
+          "--------------------------------------------\n";
+    XLOG(INFO) << ss.str();
+  }
+
+  for (std::size_t msgSize : messageSizes) {
+    // Configure based on message size
+    BroadcastBenchmarkConfig config;
+    config.messageSize = msgSize;
+    config.rootRank = 0;
+
+    // Auto-tune configuration based on message size
+    if (msgSize < kSmallMessageThreshold) {
+      config.chunkSize = kSmallMsgChunkSize;
+      config.stagingBufferSize = kSmallMsgStagingBuffer;
+      config.numBlocks = kSmallMsgNumBlocks;
+      config.numThreads = kSmallMsgNumThreads;
+    } else if (msgSize < kMediumMessageThreshold) {
+      config.chunkSize = kMediumMsgChunkSize;
+      config.stagingBufferSize = kMediumMsgStagingBuffer;
+      config.numBlocks = kMediumMsgNumBlocks;
+      config.numThreads = kMediumMsgNumThreads;
+    } else if (msgSize < kLargeMessageThreshold) {
+      config.chunkSize = kLargeMsgChunkSize;
+      config.stagingBufferSize = kLargeMsgStagingBuffer;
+      config.numBlocks = kLargeMsgNumBlocks;
+      config.numThreads = kLargeMsgNumThreads;
+    } else {
+      config.chunkSize = kVeryLargeMsgChunkSize;
+      config.stagingBufferSize = std::min(msgSize, kMaxStagingBufferSize);
+      config.numBlocks = kVeryLargeMsgNumBlocks;
+      config.numThreads = kVeryLargeMsgNumThreads;
+    }
+    config.pipelineDepth = 4;
+    config.name = formatSize(msgSize);
+
+    // Run NCCL once per message size (baseline)
+    float ncclLatencyUs = 0.0f;
+    bool ncclVerified = false;
+    float ncclBandwidth = runNcclBroadcastBenchmark(
+        config, config.rootRank, ncclLatencyUs, ncclVerified);
+
+    // Run each algorithm
+    for (auto algo : kAllAlgorithms) {
+      float pipesLatencyUs = 0.0f;
+      bool pipesVerified = false;
+      float pipesBandwidth = runPipesBroadcast(
+          algo, config, config.rootRank, pipesLatencyUs, pipesVerified);
+
+      if (globalRank == 0) {
+        float speedup =
+            (ncclBandwidth > 0) ? pipesBandwidth / ncclBandwidth : 0;
+
+        std::stringstream ss;
+        ss << std::left << std::setw(10) << formatSize(msgSize) << std::left
+           << std::setw(12) << algorithmName(algo) << std::right
+           << std::setw(12) << std::fixed << std::setprecision(2)
+           << ncclBandwidth << std::right << std::setw(12) << std::fixed
+           << std::setprecision(2) << pipesBandwidth << std::right
+           << std::setw(11) << std::fixed << std::setprecision(2) << speedup
+           << "x" << std::right << std::setw(12) << std::fixed
+           << std::setprecision(1) << ncclLatencyUs << std::right
+           << std::setw(12) << std::fixed << std::setprecision(1)
+           << pipesLatencyUs << std::right << std::setw(12)
+           << formatSize(config.chunkSize) << std::right << std::setw(10)
+           << config.numBlocks;
+        XLOG(INFO) << ss.str();
+      }
+
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    }
+
+    // Print separator between message sizes (when multiple algorithms exist)
+    if (globalRank == 0 && msgSize != messageSizes.back() &&
+        kAllAlgorithms.size() > 1) {
+      XLOG(INFO)
+          << "------------------------------------------------------------------------"
+             "--------------------------------------------";
+    }
+  }
+
+  if (globalRank == 0) {
+    XLOG(INFO)
+        << "========================================================================"
+           "============================================";
+    XLOG(INFO)
+        << "Speedup > 1.0x indicates Pipes is faster than NCCL at that size";
+    XLOG(INFO)
+        << "========================================================================"
+           "============================================\n";
+  }
+}
+
+/**
+ * Grid Configuration Sweep Benchmark
+ *
+ * Tests various block count and thread count configurations to identify
+ * optimal launch parameters for different message sizes.
+ */
+TEST_F(BroadcastBenchmarkFixture, GridConfigSweep) {
+  if (globalRank == 0) {
+    XLOG(INFO) << "\n=== Grid Configuration Sweep ===\n";
+    XLOG(INFO) << "Testing various block/thread configurations for 16MB "
+                  "message.\n";
+  }
+
+  const std::size_t msgSize = 16 * 1024 * 1024; // 16MB
+
+  std::vector<GridConfig> gridConfigs = {
+      {4, 128, "4x128"},
+      {4, 256, "4x256"},
+      {4, 512, "4x512"},
+      {8, 128, "8x128"},
+      {8, 256, "8x256"},
+      {8, 512, "8x512"},
+      {16, 128, "16x128"},
+      {16, 256, "16x256"},
+      {16, 512, "16x512"},
+      {32, 128, "32x128"},
+      {32, 256, "32x256"},
+      {32, 512, "32x512"},
+      {64, 256, "64x256"},
+      {64, 512, "64x512"},
+  };
+
+  // Get NCCL baseline
+  BroadcastBenchmarkConfig ncclConfig{
+      .messageSize = msgSize,
+      .stagingBufferSize = 16 * 1024 * 1024,
+      .pipelineDepth = 4,
+      .chunkSize = 128 * 1024,
+      .numBlocks = 32,
+      .numThreads = 512,
+      .rootRank = 0,
+      .name = "baseline",
+  };
+
+  float ncclLatencyUs = 0.0f;
+  bool ncclVerified = false;
+  float ncclBandwidth =
+      runNcclBroadcastBenchmark(ncclConfig, 0, ncclLatencyUs, ncclVerified);
+
+  // Print header
+  if (globalRank == 0) {
+    std::stringstream ss;
+    ss << "Message Size: " << formatSize(msgSize) << "\n";
+    ss << "NCCL Baseline: " << std::fixed << std::setprecision(2)
+       << ncclBandwidth << " GB/s\n\n";
+    ss << std::left << std::setw(12) << "Config" << std::right << std::setw(10)
+       << "Blocks" << std::right << std::setw(10) << "Threads" << std::right
+       << std::setw(10) << "Total" << std::right << std::setw(14) << "Algorithm"
+       << std::right << std::setw(12) << "Bandwidth" << std::right
+       << std::setw(12) << "vs NCCL" << "\n";
+    ss << std::left << std::setw(12) << "(BxT)" << std::right << std::setw(10)
+       << "" << std::right << std::setw(10) << "" << std::right << std::setw(10)
+       << "Threads" << std::right << std::setw(14) << "" << std::right
+       << std::setw(12) << "(GB/s)" << std::right << std::setw(12) << ""
+       << "\n";
+    ss << "--------------------------------------------------------------------------------\n";
+    XLOG(INFO) << ss.str();
+  }
+
+  float bestBandwidth = 0.0f;
+  std::string bestConfig;
+  std::string bestAlgorithm;
+
+  for (const auto& grid : gridConfigs) {
+    BroadcastBenchmarkConfig config{
+        .messageSize = msgSize,
+        .stagingBufferSize = 16 * 1024 * 1024,
+        .pipelineDepth = 4,
+        .chunkSize = 128 * 1024,
+        .numBlocks = grid.numBlocks,
+        .numThreads = grid.numThreads,
+        .rootRank = 0,
+        .name = grid.name,
+    };
+
+    for (auto algo : kAllAlgorithms) {
+      float pipesLatencyUs = 0.0f;
+      bool pipesVerified = false;
+      float pipesBandwidth =
+          runPipesBroadcast(algo, config, 0, pipesLatencyUs, pipesVerified);
+
+      if (globalRank == 0) {
+        float speedup =
+            (ncclBandwidth > 0) ? pipesBandwidth / ncclBandwidth : 0;
+        int totalThreads = grid.numBlocks * grid.numThreads;
+
+        std::stringstream ss;
+        ss << std::left << std::setw(12) << grid.name << std::right
+           << std::setw(10) << grid.numBlocks << std::right << std::setw(10)
+           << grid.numThreads << std::right << std::setw(10) << totalThreads
+           << std::right << std::setw(14) << algorithmName(algo) << std::right
+           << std::setw(12) << std::fixed << std::setprecision(2)
+           << pipesBandwidth << std::right << std::setw(11) << std::fixed
+           << std::setprecision(2) << speedup << "x";
+        XLOG(INFO) << ss.str();
+
+        if (pipesBandwidth > bestBandwidth) {
+          bestBandwidth = pipesBandwidth;
+          bestConfig = grid.name;
+          bestAlgorithm = algorithmName(algo);
+        }
+      }
+
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    }
+
+    // Print separator between grid configs when there are multiple algorithms
+    if (kAllAlgorithms.size() > 1 && globalRank == 0) {
+      XLOG(INFO) << "  ---";
+    }
+  }
+
+  if (globalRank == 0) {
+    XLOG(INFO)
+        << "--------------------------------------------------------------------------------";
+    XLOG(INFO) << "Best config: " << bestConfig << " (" << bestAlgorithm
+               << ") at " << std::fixed << std::setprecision(2) << bestBandwidth
+               << " GB/s (" << std::fixed << std::setprecision(2)
+               << (bestBandwidth / ncclBandwidth) << "x of NCCL)";
+    XLOG(INFO)
+        << "================================================================================\n";
+  }
+}
+
+} // namespace
+
+} // namespace comms::pipes::benchmark
+
+// ============================================================================
+// SECTION 4: MAIN FUNCTION - CLI Parsing and Test Execution
+// ============================================================================
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new MPIEnvironmentBase);
+  folly::Init init(&argc, &argv);
+
+  // Build test filter based on --benchmark flag
+  // Valid values: "all", "optimal", "tuning", "algorithm", "clustered",
+  //               "rootsweep", "extended", "gridconfig"
+  // Can also be comma-separated: "optimal,algorithm"
+  if (FLAGS_benchmark != "all") {
+    std::string filter;
+    std::istringstream iss(FLAGS_benchmark);
+    std::string token;
+    bool first = true;
+
+    while (std::getline(iss, token, ',')) {
+      // Trim whitespace
+      token.erase(0, token.find_first_not_of(" \t"));
+      token.erase(token.find_last_not_of(" \t") + 1);
+
+      std::string testPattern;
+      if (token == "clustered") {
+        testPattern = "*ClusteredLaunchComparison*";
+      } else if (token == "rootsweep") {
+        testPattern = "*RootRankSweep*";
+      } else if (token == "extended") {
+        testPattern = "*ExtendedMessageSizes*";
+      } else if (token == "gridconfig") {
+        testPattern = "*GridConfigSweep*";
+      } else {
+        // Unknown benchmark name, print help and continue
+        std::cerr
+            << "Warning: Unknown benchmark '" << token << "'. "
+            << "Valid values: clustered, rootsweep, extended, gridconfig, clustered, "
+            << "rootsweep, extended, gridconfig, all\n";
+        continue;
+      }
+
+      if (!first) {
+        filter += ":";
+      }
+      filter += testPattern;
+      first = false;
+    }
+
+    if (!filter.empty()) {
+      ::testing::GTEST_FLAG(filter) = filter;
+    }
+  }
+
+  return RUN_ALL_TESTS();
+}

--- a/comms/pipes/collectives/BroadcastBinomialTree.cuh
+++ b/comms/pipes/collectives/BroadcastBinomialTree.cuh
@@ -1,0 +1,220 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <cstdio>
+
+#include "comms/pipes/DeviceCheck.cuh"
+#include "comms/pipes/DeviceSpan.cuh"
+#include "comms/pipes/Transport.cuh"
+#include "comms/pipes/collectives/BroadcastFlat.cuh"
+
+namespace comms::pipes::collectives {
+
+namespace {
+
+/**
+ * Debug helper to print binomial tree broadcast operation information.
+ */
+__device__ __forceinline__ void printBinomialTreeOperation(
+    int my_rank_id,
+    int root_rank_id,
+    int virtual_rank,
+    int round,
+    int peer_rank_id,
+    bool is_send,
+    std::size_t nbytes) {
+  printf(
+      "Rank=%d (virtual=%d) root=%d round=%d: %s rank=%d nbytes=%lu\n",
+      my_rank_id,
+      virtual_rank,
+      root_rank_id,
+      round,
+      is_send ? "send to" : "recv from",
+      peer_rank_id,
+      nbytes);
+}
+
+} // namespace
+
+/**
+ * Binomial Tree Broadcast collective communication primitive.
+ *
+ * Broadcasts data from root rank to all other ranks using a binomial tree
+ * algorithm with O(log N) rounds. This is more bandwidth-efficient than
+ * the flat-tree (star) algorithm for large messages because:
+ *
+ *   1. Root bandwidth = 1×messageSize (sends to one peer per round)
+ *   2. Parallelism increases each round (2^round senders in round r)
+ *   3. Total bandwidth distributed across all nodes
+ *
+ * ROUND-MAJOR PIPELINING
+ * ======================
+ * This implementation uses round-major ordering: in each round, the entire
+ * message is transferred (not chunk-by-chunk). The transport layer handles
+ * internal chunking and pipelining, which allows:
+ *   - Maximum utilization of the transport's pipeline depth
+ *   - Concurrent chunk transfers within each round
+ *   - Minimal synchronization overhead between chunks
+ *
+ * This is much faster than chunk-major ordering (which was used previously)
+ * because the transport's internal pipelining can work across the full message
+ * rather than being limited to small individual chunks.
+ *
+ * Performance Notes:
+ * ==================
+ * - Works well with clustered kernel launches
+ * (cudaClusterSchedulingPolicySpread)
+ * - Unlike flat-tree, partition_interleaved is NOT used here because each rank
+ *   performs at most one operation per round (send OR recv to ONE peer), so
+ *   there's no opportunity to partition across peers
+ * - All warps must participate in each send/recv operation to avoid deadlock
+ *   with the paired operation on the remote rank
+ *
+ * Algorithm:
+ * ==========
+ * For N ranks, the broadcast completes in ceil(log2(N)) rounds.
+ *
+ * In each round r (0-indexed):
+ *   - Ranks with virtual_rank < 2^r have the data
+ *   - Each such rank sends to virtual_rank + 2^r (if that rank exists)
+ *   - Receiving ranks wait for data before proceeding to next round
+ *
+ * Example for 4 ranks (root=0):
+ *   Round 0: Rank 0 → Rank 1 (virtual_rank 0 sends to 0+1=1)
+ *   Round 1: Rank 0 → Rank 2, Rank 1 → Rank 3
+ *
+ * Example for 8 ranks (root=0):
+ *   Round 0: Rank 0 → Rank 1
+ *   Round 1: Rank 0 → Rank 2, Rank 1 → Rank 3
+ *   Round 2: Ranks 0→4, 1→5, 2→6, 3→7
+ *
+ * Virtual Rank Mapping:
+ * =====================
+ * To support arbitrary root ranks, we use virtual ranks:
+ *   virtual_rank = (actual_rank - root_rank + nranks) % nranks
+ *   actual_rank = (virtual_rank + root_rank) % nranks
+ *
+ * This way, the root always has virtual_rank=0, and the algorithm
+ * proceeds identically regardless of which physical rank is the root.
+ *
+ * Parameters:
+ *   @param buff_d: Device buffer pointer
+ *                  - For root: contains source data to broadcast
+ *                  - For non-root: receives broadcast data
+ *   @param my_rank_id: Current rank ID
+ *   @param root_rank_id: Rank ID of the broadcast source
+ *   @param transports_per_rank: Array of transport objects, one per rank
+ *   @param nbytes: Number of bytes to broadcast
+ *
+ * Requirements:
+ * - Must be called from device code with sufficient threads
+ * - All ranks must call with same root_rank_id and nbytes
+ * - Max 8 ranks supported
+ * - transports_per_rank[my_rank_id].type must be SELF
+ * - transports_per_rank[i].type must be P2P_NVL for i != my_rank_id
+ */
+__device__ __forceinline__ void broadcast_binomial_tree(
+    void* buff_d,
+    int my_rank_id,
+    int root_rank_id,
+    DeviceSpan<Transport> transports_per_rank,
+    std::size_t nbytes) {
+#ifdef __CUDA_ARCH__
+  const int nranks = static_cast<int>(transports_per_rank.size());
+
+  // Single rank case: no-op (root already has data)
+  if (nranks == 1) {
+    return;
+  }
+
+  // Zero-byte broadcast: no-op
+  if (nbytes == 0) {
+    return;
+  }
+
+  auto group = make_warp_group();
+
+  // Extract raw pointer to avoid aliasing issues.
+  auto transports = transports_per_rank.data();
+
+  // Compute virtual rank relative to root (root has virtual_rank=0)
+  int virtual_rank = (my_rank_id - root_rank_id + nranks) % nranks;
+
+  // Calculate number of rounds = ceil(log2(nranks))
+  int num_rounds = 0;
+  for (int n = 1; n < nranks; n <<= 1) {
+    num_rounds++;
+  }
+
+  char* buff = static_cast<char*>(buff_d);
+
+  // ROUND-MAJOR ordering: Transfer entire message each round.
+  // This allows the transport layer to use its full pipeline depth
+  // for maximum bandwidth utilization.
+  for (int round = 0; round < num_rounds; ++round) {
+    int distance = 1 << round; // 2^round
+
+    if (virtual_rank < distance) {
+      // I have the data - check if I need to send to a peer
+      int send_to_virtual = virtual_rank + distance;
+
+      if (send_to_virtual < nranks) {
+        // Convert virtual rank back to actual rank
+        int send_to_actual = (send_to_virtual + root_rank_id) % nranks;
+
+        auto& transport = transports[send_to_actual];
+        PIPES_DEVICE_CHECK(transport.type == TransportType::P2P_NVL);
+
+#ifdef DEBUG_BROADCAST
+        if (group.is_leader()) {
+          printBinomialTreeOperation(
+              my_rank_id,
+              root_rank_id,
+              virtual_rank,
+              round,
+              send_to_actual,
+              true, // is_send
+              nbytes);
+        }
+#endif
+
+        // Send entire message - transport handles internal chunking/pipelining
+        transport.p2p_nvl.send(group, buff, nbytes);
+      }
+      // If no peer to send to in this round, just continue to next round
+    } else if (virtual_rank < 2 * distance) {
+      // I don't have data yet - receive from peer
+      int recv_from_virtual = virtual_rank - distance;
+      int recv_from_actual = (recv_from_virtual + root_rank_id) % nranks;
+
+      auto& transport = transports[recv_from_actual];
+      PIPES_DEVICE_CHECK(transport.type == TransportType::P2P_NVL);
+
+#ifdef DEBUG_BROADCAST
+      if (group.is_leader()) {
+        printBinomialTreeOperation(
+            my_rank_id,
+            root_rank_id,
+            virtual_rank,
+            round,
+            recv_from_actual,
+            false, // is_send
+            nbytes);
+      }
+#endif
+
+      // Receive entire message - transport handles internal chunking/pipelining
+      transport.p2p_nvl.recv(group, buff, nbytes);
+    }
+    // Ranks >= 2*distance don't participate in this round
+
+    // Implicit synchronization: recv completes before proceeding,
+    // which acts as a barrier for that rank to have data before
+    // potentially sending in the next round.
+  }
+#endif
+}
+
+} // namespace comms::pipes::collectives

--- a/comms/pipes/collectives/BroadcastFlat.cuh
+++ b/comms/pipes/collectives/BroadcastFlat.cuh
@@ -1,0 +1,149 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <cstdint>
+#include <cstdio>
+
+#include "comms/pipes/DeviceCheck.cuh"
+#include "comms/pipes/DeviceSpan.cuh"
+#include "comms/pipes/Transport.cuh"
+
+namespace comms::pipes::collectives {
+
+namespace {
+/**
+ * Debug helper to print broadcast operation information.
+ */
+__device__ __forceinline__ void printBroadcastOperation(
+    int my_rank_id,
+    int root_rank_id,
+    int peer_rank_id,
+    bool is_send,
+    uint32_t total_groups,
+    std::size_t nbytes) {
+  printf(
+      "Rank=%d root=%d total-groups=%d: %s rank=%d nbytes=%lu\n",
+      my_rank_id,
+      root_rank_id,
+      total_groups,
+      is_send ? "send to" : "recv from",
+      peer_rank_id,
+      nbytes);
+}
+} // namespace
+
+/**
+ * Broadcast collective communication primitive.
+ *
+ * Broadcasts data from root rank to all other ranks using a flat-tree (star)
+ * algorithm where the root sends directly to each non-root rank in parallel.
+ *
+ * Algorithm:
+ * 1. Single rank case: No-op (root already has data)
+ * 2. Zero bytes case: No-op
+ * 3. Root rank: Partitions warps across (nranks-1) peers using contiguous
+ *    partitioning for better cache locality
+ * 4. Non-root ranks: All warps collaborate on receiving data from root
+ *
+ * Parameters:
+ *   @param buff_d: Device buffer pointer
+ *                  - For root: contains source data to broadcast
+ *                  - For non-root: receives broadcast data
+ *   @param my_rank_id: Current rank ID
+ *   @param root_rank_id: Rank ID of the broadcast source
+ *   @param transports_per_rank: Array of transport objects, one per rank
+ *                               (self-transport for my_rank, P2P for others)
+ *   @param nbytes: Number of bytes to broadcast
+ *
+ * Requirements:
+ * - Must be called from device code with sufficient threads
+ * - All ranks must call with same root_rank_id and nbytes
+ * - Max 8 ranks supported
+ * - transports_per_rank[my_rank_id].type must be SELF
+ * - transports_per_rank[i].type must be P2P_NVL for i != my_rank_id
+ */
+__device__ __forceinline__ void broadcast_flat(
+    void* buff_d,
+    int my_rank_id,
+    int root_rank_id,
+    DeviceSpan<Transport> transports_per_rank,
+    std::size_t nbytes) {
+#ifdef __CUDA_ARCH__
+  const auto nranks = transports_per_rank.size();
+
+  // Single rank case: no-op (root already has data)
+  if (nranks == 1) {
+    return;
+  }
+
+  // Zero-byte broadcast: no-op
+  if (nbytes == 0) {
+    return;
+  }
+
+  auto group = make_warp_group();
+
+  // Extract raw pointer to avoid aliasing issues.
+  // See "PERFORMANCE NOTE: Lambda Capture and Aliasing"
+  // in DeviceSpan.cuh for explanation.
+  auto transports = transports_per_rank.data();
+
+  bool is_root = (my_rank_id == root_rank_id);
+
+  if (is_root) {
+    // Root: partition warps across (nranks - 1) peers for parallel sends
+    // Use contiguous partitioning: adjacent blocks handle the same peer.
+    // Profiling shows this provides better cache locality and 39% better
+    // performance than interleaved partitioning for 1MB messages.
+    auto [peer_idx, peer_group] = group.partition(nranks - 1);
+
+    // Map peer_idx [0, nranks-2] to actual peer rank, skipping root
+    // For root_rank_id = 2 and nranks = 4:
+    //   peer_idx 0 → rank 0
+    //   peer_idx 1 → rank 1
+    //   peer_idx 2 → rank 3 (skip root at index 2)
+    int peer_rank = static_cast<int>(
+        peer_idx < static_cast<uint32_t>(root_rank_id) ? peer_idx
+                                                       : peer_idx + 1);
+
+    auto& transport = transports[peer_rank];
+    PIPES_DEVICE_CHECK(transport.type == TransportType::P2P_NVL);
+
+#ifdef DEBUG_BROADCAST
+    if (peer_group.is_global_leader()) {
+      printBroadcastOperation(
+          my_rank_id,
+          root_rank_id,
+          peer_rank,
+          true, // is_send
+          peer_group.total_groups,
+          nbytes);
+    }
+#endif
+
+    transport.p2p_nvl.send(peer_group, static_cast<char*>(buff_d), nbytes);
+  } else {
+    // Non-root: all warps collaborate on receiving from root
+    auto& transport = transports[root_rank_id];
+    PIPES_DEVICE_CHECK(transport.type == TransportType::P2P_NVL);
+
+#ifdef DEBUG_BROADCAST
+    if (group.is_global_leader()) {
+      printBroadcastOperation(
+          my_rank_id,
+          root_rank_id,
+          root_rank_id,
+          false, // is_send
+          group.total_groups,
+          nbytes);
+    }
+#endif
+
+    transport.p2p_nvl.recv(group, static_cast<char*>(buff_d), nbytes);
+  }
+#endif
+}
+
+} // namespace comms::pipes::collectives

--- a/comms/pipes/collectives/benchmarks/CollectiveBenchmark.cuh
+++ b/comms/pipes/collectives/benchmarks/CollectiveBenchmark.cuh
@@ -4,7 +4,7 @@
 
 #include <cuda_runtime.h>
 
-#include "comms/pipes/Timeout.cuh"
+#include "comms/pipes/Timeout.h"
 #include "comms/pipes/collectives/AllGather.cuh"
 #include "comms/pipes/collectives/AllToAllv.cuh"
 

--- a/comms/pipes/tests/BroadcastTest.cc
+++ b/comms/pipes/tests/BroadcastTest.cc
@@ -1,0 +1,486 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include <folly/init/Init.h>
+#include <folly/logging/xlog.h>
+
+#include "comms/pipes/MultiPeerNvlTransport.h"
+#include "comms/pipes/P2pSelfTransportDevice.cuh"
+#include "comms/pipes/collectives/BroadcastFlat.cuh"
+#include "comms/pipes/tests/BroadcastTest.cuh"
+#include "comms/pipes/tests/Utils.cuh"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/testinfra/mpi/MpiBootstrap.h"
+#include "comms/testinfra/mpi/MpiTestUtils.h"
+#include "comms/utils/CudaRAII.h"
+
+using namespace meta::comms;
+
+namespace comms::pipes::collectives {
+
+namespace {
+// Helper function to print device buffer contents for debugging
+void printDeviceBuffer(
+    const char* label,
+    void* deviceBuffer,
+    int rank,
+    size_t numInts,
+    bool showAll = false) {
+  std::vector<int32_t> h_buffer(numInts);
+  CUDACHECK_TEST(cudaMemcpy(
+      h_buffer.data(),
+      deviceBuffer,
+      numInts * sizeof(int32_t),
+      cudaMemcpyDeviceToHost));
+
+  size_t numToShow = showAll ? numInts : std::min(size_t(8), numInts);
+  XLOGF(
+      DBG1,
+      "Rank {}: {} (showing {}/{} values):",
+      rank,
+      label,
+      numToShow,
+      numInts);
+
+  std::string line = "  Values: ";
+  for (size_t i = 0; i < numToShow; i++) {
+    line += std::to_string(h_buffer[i]) + " ";
+  }
+  if (!showAll && numInts > 8) {
+    line += "...";
+  }
+  XLOG(DBG1) << line;
+}
+} // namespace
+
+// Test fixture for Broadcast tests using MPI for multi-rank coordination
+class BroadcastTestFixture : public MpiBaseTestFixture {
+ protected:
+  void SetUp() override {
+    MpiBaseTestFixture::SetUp();
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+  }
+
+  void TearDown() override {
+    MpiBaseTestFixture::TearDown();
+  }
+};
+
+/**
+ * Test single-rank broadcast edge case.
+ *
+ * When there's only one rank, broadcast should be a no-op since the root
+ * already has the data and there are no peers to send to. This tests that
+ * the implementation correctly handles nranks == 1.
+ */
+TEST_F(BroadcastTestFixture, SingleRankBroadcastIsNoop) {
+  // This test simulates single-rank behavior by creating a transport array
+  // with only one entry (self-transport) and verifying data is preserved.
+  const size_t numBytes = 4096;
+  const int numBlocks = 4;
+  const int blockSize = 256;
+  const int myRank = 0;
+  const int rootRank = 0;
+
+  XLOGF(
+      DBG1,
+      "Rank {}: Running single-rank broadcast test with numBytes={}",
+      globalRank,
+      numBytes);
+
+  // Synchronize all ranks before test
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  // Build transport array with only self-transport (single rank scenario)
+  P2pSelfTransportDevice selfTransport;
+  std::vector<Transport> h_transports;
+  h_transports.emplace_back(selfTransport);
+
+  // Copy transport to device
+  DeviceBuffer d_transports(sizeof(Transport));
+  CUDACHECK_TEST(cudaMemcpy(
+      d_transports.get(),
+      h_transports.data(),
+      sizeof(Transport),
+      cudaMemcpyHostToDevice));
+
+  DeviceSpan<Transport> transports_span(
+      static_cast<Transport*>(d_transports.get()), 1);
+
+  // Allocate and initialize buffer with known data
+  DeviceBuffer buffer(numBytes);
+  const size_t numInts = numBytes / sizeof(int32_t);
+
+  std::vector<int32_t> h_init(numInts);
+  for (size_t i = 0; i < numInts; i++) {
+    h_init[i] = rootRank * 1000 + static_cast<int32_t>(i);
+  }
+  CUDACHECK_TEST(cudaMemcpy(
+      buffer.get(), h_init.data(), numBytes, cudaMemcpyHostToDevice));
+
+  // Execute broadcast (should be no-op for single rank)
+  test::testBroadcastFlat(
+      buffer.get(),
+      myRank,
+      rootRank,
+      transports_span,
+      numBytes,
+      numBlocks,
+      blockSize);
+
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  // Verify data is unchanged (single-rank broadcast is no-op)
+  std::vector<int32_t> h_result(numInts);
+  CUDACHECK_TEST(cudaMemcpy(
+      h_result.data(), buffer.get(), numBytes, cudaMemcpyDeviceToHost));
+
+  EXPECT_EQ(h_result, h_init)
+      << "Single-rank broadcast should preserve data unchanged";
+
+  // Ensure all ranks complete before next test
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
+// Broadcast algorithm types for parameterized algorithm testing
+enum class BroadcastAlgorithm { FlatTree, BinomialTree, Ring };
+
+// Test parameters for parameterized Broadcast tests
+struct BroadcastTestParams {
+  int numBlocks;
+  int blockSize;
+  size_t numBytes;
+  int rootRank; // -1 means use numRanks/2 as root
+  BroadcastAlgorithm algorithm;
+  std::string testName;
+};
+
+// Parameterized test fixture for broadcast tests
+class BroadcastParamTest
+    : public BroadcastTestFixture,
+      public ::testing::WithParamInterface<BroadcastTestParams> {};
+
+/**
+ * Test broadcast with parameterized algorithm and configurations.
+ *
+ * This test verifies that each broadcast algorithm (flat-tree,
+ * later binomial tree and ring) correctly broadcasts data from
+ * root to all other ranks.
+ *
+ * Data pattern: root_rank * 1000 + position
+ * This allows easy identification of data source and position for debugging.
+ */
+TEST_P(BroadcastParamTest, DataTransfer) {
+  const auto& params = GetParam();
+  const size_t numBytes = params.numBytes;
+  const int numBlocks = params.numBlocks;
+  const int blockSize = params.blockSize;
+
+  // Resolve root rank: -1 means use middle rank
+  const int rootRank =
+      params.rootRank < 0 ? numRanks / 2 : params.rootRank % numRanks;
+
+  const char* algorithmName = params.algorithm == BroadcastAlgorithm::FlatTree
+      ? "FlatTree"
+      : (params.algorithm == BroadcastAlgorithm::BinomialTree ? "BinomialTree"
+                                                              : "Ring");
+
+  XLOGF(
+      DBG1,
+      "Rank {}: Running {} with algorithm={}, numBlocks={}, blockSize={}, numBytes={}, root={}",
+      globalRank,
+      params.testName,
+      algorithmName,
+      numBlocks,
+      blockSize,
+      numBytes,
+      rootRank);
+
+  // Configuration for P2pNvlTransport
+  // Use larger staging buffer for large messages
+  MultiPeerNvlTransportConfig config{
+      .dataBufferSize = 256 * 1024,
+      .chunkSize = 512,
+      .pipelineDepth = 4,
+  };
+
+  // Create transport and exchange IPC handles across all ranks
+  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
+  transport.exchange();
+  XLOGF(DBG1, "Rank {} created transport and exchanged IPC", globalRank);
+
+  // Build transport array: self-transport for my rank, P2P for peers
+  P2pSelfTransportDevice selfTransport;
+  std::vector<Transport> h_transports;
+  h_transports.reserve(numRanks);
+
+  for (int rank = 0; rank < numRanks; rank++) {
+    if (rank == globalRank) {
+      h_transports.emplace_back(selfTransport);
+    } else {
+      h_transports.emplace_back(transport.getP2pTransportDevice(rank));
+    }
+  }
+
+  // Copy transports to device
+  DeviceBuffer d_transports(sizeof(Transport) * numRanks);
+  CUDACHECK_TEST(cudaMemcpy(
+      d_transports.get(),
+      h_transports.data(),
+      sizeof(Transport) * numRanks,
+      cudaMemcpyHostToDevice));
+
+  DeviceSpan<Transport> transports_span(
+      static_cast<Transport*>(d_transports.get()), numRanks);
+
+  // Handle zero-byte edge case: verify broadcast is a no-op
+  if (numBytes == 0) {
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // Execute zero-byte broadcast (should be no-op)
+    switch (params.algorithm) {
+      case BroadcastAlgorithm::FlatTree:
+        test::testBroadcastFlat(
+            nullptr,
+            globalRank,
+            rootRank,
+            transports_span,
+            0,
+            numBlocks,
+            blockSize);
+        break;
+      default:
+        GTEST_SKIP() << "Broadcast algorithm " << algorithmName
+                     << " not implemented yet";
+        return;
+    }
+
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    XLOGF(DBG1, "Rank {}: zero-byte broadcast completed (no-op)", globalRank);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    return;
+  }
+
+  // Allocate broadcast buffer
+  DeviceBuffer buffer(numBytes);
+
+  // Calculate number of int32_t elements
+  const size_t numInts = numBytes / sizeof(int32_t);
+
+  // Initialize buffer: root has data, non-roots have -1 (sentinel)
+  if (globalRank == rootRank) {
+    // Root: fill with pattern root_rank * 1000 + position
+    std::vector<int32_t> h_init(numInts);
+    for (size_t i = 0; i < numInts; i++) {
+      h_init[i] = rootRank * 1000 + static_cast<int32_t>(i);
+    }
+    CUDACHECK_TEST(cudaMemcpy(
+        buffer.get(), h_init.data(), numBytes, cudaMemcpyHostToDevice));
+  } else {
+    // Non-root: initialize with -1 to detect missing writes
+    ::comms::pipes::test::fillBuffer(
+        reinterpret_cast<int*>(buffer.get()), -1, numInts);
+  }
+
+  // Debug: print buffer before broadcast
+  printDeviceBuffer("Buffer BEFORE", buffer.get(), globalRank, numInts);
+
+  // Synchronize all ranks before broadcast
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  XLOGF(
+      DBG1,
+      "Rank {}: calling {} broadcast with root={}",
+      globalRank,
+      algorithmName,
+      rootRank);
+
+  // Execute broadcast with the specified algorithm
+  switch (params.algorithm) {
+    case BroadcastAlgorithm::FlatTree:
+      test::testBroadcastFlat(
+          buffer.get(),
+          globalRank,
+          rootRank,
+          transports_span,
+          numBytes,
+          numBlocks,
+          blockSize);
+      break;
+      // TODO: add support for binomial tree and ring.
+    default:
+      GTEST_SKIP() << "Broadcast algorithm " << algorithmName
+                   << " not implemented yet";
+      return;
+  }
+
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  // Debug: print buffer after broadcast
+  printDeviceBuffer("Buffer AFTER", buffer.get(), globalRank, numInts);
+
+  // Verify all ranks have correct data
+  // Expected: value[i] = rootRank * 1000 + i
+
+  // Generate expected data
+  std::vector<int32_t> h_expected(numInts);
+  for (size_t i = 0; i < numInts; i++) {
+    h_expected[i] = rootRank * 1000 + static_cast<int32_t>(i);
+  }
+
+  // Copy result from device
+  std::vector<int32_t> h_result(numInts);
+  CUDACHECK_TEST(cudaMemcpy(
+      h_result.data(), buffer.get(), numBytes, cudaMemcpyDeviceToHost));
+
+  XLOGF(DBG1, "Rank {}: verification completed", globalRank);
+  EXPECT_EQ(h_result, h_expected)
+      << "Rank " << globalRank << " verification failed using "
+      << algorithmName;
+
+  // Ensure all ranks complete before cleanup
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
+// Flat Tree algorithm tests
+// Tests the FlatTree algorithm with various message sizes, root ranks,
+// thread configurations, and edge cases (zero bytes, non-aligned sizes)
+INSTANTIATE_TEST_SUITE_P(
+    FlatTreeConfigs,
+    BroadcastParamTest,
+    ::testing::Values(
+        // Edge case: zero-byte broadcast (should be no-op)
+        BroadcastTestParams{
+            .numBlocks = 4,
+            .blockSize = 256,
+            .numBytes = 0,
+            .rootRank = 0,
+            .algorithm = BroadcastAlgorithm::FlatTree,
+            .testName = "zero_bytes"},
+
+        // Small message (64 bytes = 16 int32_t), root=0
+        BroadcastTestParams{
+            .numBlocks = 4,
+            .blockSize = 256,
+            .numBytes = 64,
+            .rootRank = 0,
+            .algorithm = BroadcastAlgorithm::FlatTree,
+            .testName = "small_64B_root0"},
+
+        // Non-power-of-2 message size (1000 bytes = 250 int32_t)
+        // Tests handling of non-aligned buffer sizes
+        BroadcastTestParams{
+            .numBlocks = 4,
+            .blockSize = 256,
+            .numBytes = 1000,
+            .rootRank = 0,
+            .algorithm = BroadcastAlgorithm::FlatTree,
+            .testName = "non_aligned_1000B"},
+
+        // Medium message (4KB), root=0
+        BroadcastTestParams{
+            .numBlocks = 4,
+            .blockSize = 256,
+            .numBytes = 4096,
+            .rootRank = 0,
+            .algorithm = BroadcastAlgorithm::FlatTree,
+            .testName = "medium_4KB_root0"},
+
+        // Medium message at threshold (64KB), root=0
+        BroadcastTestParams{
+            .numBlocks = 8,
+            .blockSize = 512,
+            .numBytes = 64 * 1024,
+            .rootRank = 0,
+            .algorithm = BroadcastAlgorithm::FlatTree,
+            .testName = "medium_64KB_root0"},
+
+        // Large message (256KB), root=0
+        BroadcastTestParams{
+            .numBlocks = 8,
+            .blockSize = 512,
+            .numBytes = 256 * 1024,
+            .rootRank = 0,
+            .algorithm = BroadcastAlgorithm::FlatTree,
+            .testName = "large_256KB_root0"},
+
+        // Large message (512KB), middle root
+        BroadcastTestParams{
+            .numBlocks = 8,
+            .blockSize = 512,
+            .numBytes = 512 * 1024,
+            .rootRank = -1,
+            .algorithm = BroadcastAlgorithm::FlatTree,
+            .testName = "large_512KB_middle_root"},
+
+        // Large message (1MB), root=0
+        BroadcastTestParams{
+            .numBlocks = 8,
+            .blockSize = 512,
+            .numBytes = 1048576,
+            .rootRank = 0,
+            .algorithm = BroadcastAlgorithm::FlatTree,
+            .testName = "large_1MB_root0"},
+
+        // Near ring threshold (1MB - 1KB), root=0
+        BroadcastTestParams{
+            .numBlocks = 8,
+            .blockSize = 512,
+            .numBytes = 1024 * 1024 - 1024,
+            .rootRank = 0,
+            .algorithm = BroadcastAlgorithm::FlatTree,
+            .testName = "large_1MB_minus_1KB_root0"},
+
+        // Different thread configuration: more blocks, fewer threads
+        BroadcastTestParams{
+            .numBlocks = 16,
+            .blockSize = 128,
+            .numBytes = 4096,
+            .rootRank = 0,
+            .algorithm = BroadcastAlgorithm::FlatTree,
+            .testName = "16b_128t_4KB"},
+
+        // Different thread configuration: single block
+        BroadcastTestParams{
+            .numBlocks = 1,
+            .blockSize = 256,
+            .numBytes = 1024,
+            .rootRank = 0,
+            .algorithm = BroadcastAlgorithm::FlatTree,
+            .testName = "1b_256t_1KB"},
+
+        // Boundary test: last rank as root (root_rank = nranks - 1)
+        // This verifies the peer mapping correctly handles the case where
+        // peer_idx values 0 through nranks-2 all map to ranks < root_rank,
+        // ensuring no off-by-one errors in the mapping logic.
+        BroadcastTestParams{
+            .numBlocks = 4,
+            .blockSize = 256,
+            .numBytes = 4096,
+            .rootRank = 7, // Last rank in 8-rank configuration
+            .algorithm = BroadcastAlgorithm::FlatTree,
+            .testName = "medium_4KB_last_root"},
+
+        // Boundary test: last rank as root with larger message
+        BroadcastTestParams{
+            .numBlocks = 8,
+            .blockSize = 512,
+            .numBytes = 128 * 1024,
+            .rootRank = 7,
+            .algorithm = BroadcastAlgorithm::FlatTree,
+            .testName = "large_128KB_last_root"}),
+    [](const ::testing::TestParamInfo<BroadcastTestParams>& info) {
+      return info.param.testName;
+    });
+
+} // namespace comms::pipes::collectives
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new MPIEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/pipes/tests/BroadcastTest.cu
+++ b/comms/pipes/tests/BroadcastTest.cu
@@ -1,0 +1,47 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/tests/BroadcastTest.cuh"
+
+#include "comms/common/CudaWrap.h"
+#include "comms/pipes/collectives/BroadcastFlat.cuh"
+#include "comms/pipes/tests/Checks.h"
+
+namespace comms::pipes::collectives::test {
+
+/**
+ * Device kernel that invokes the flat-tree broadcast collective.
+ * Minimal wrapper - all logic is in Broadcast.cuh.
+ */
+__global__ void testBroadcastFlatKernel(
+    void* buff_d,
+    int my_rank_id,
+    int root_rank_id,
+    DeviceSpan<Transport> transports_per_rank,
+    std::size_t nbytes) {
+  broadcast_flat(buff_d, my_rank_id, root_rank_id, transports_per_rank, nbytes);
+}
+
+void testBroadcastFlat(
+    void* buff_d,
+    int my_rank_id,
+    int root_rank_id,
+    DeviceSpan<Transport> transports_per_rank,
+    std::size_t nbytes,
+    int numBlocks,
+    int blockSize,
+    std::optional<dim3> clusterDim,
+    cudaStream_t stream) {
+  void* args[] = {
+      &buff_d, &my_rank_id, &root_rank_id, &transports_per_rank, &nbytes};
+  PIPES_CUDA_CHECK(
+      comms::common::launchKernel(
+          (void*)testBroadcastFlatKernel,
+          dim3(numBlocks, 1, 1),
+          dim3(blockSize, 1, 1),
+          args,
+          stream,
+          clusterDim));
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+} // namespace comms::pipes::collectives::test

--- a/comms/pipes/tests/BroadcastTest.cu
+++ b/comms/pipes/tests/BroadcastTest.cu
@@ -3,6 +3,7 @@
 #include "comms/pipes/tests/BroadcastTest.cuh"
 
 #include "comms/common/CudaWrap.h"
+#include "comms/pipes/collectives/BroadcastBinomialTree.cuh"
 #include "comms/pipes/collectives/BroadcastFlat.cuh"
 #include "comms/pipes/tests/Checks.h"
 
@@ -21,6 +22,20 @@ __global__ void testBroadcastFlatKernel(
   broadcast_flat(buff_d, my_rank_id, root_rank_id, transports_per_rank, nbytes);
 }
 
+/**
+ * Device kernel that invokes the binomial tree broadcast collective.
+ * Minimal wrapper - all logic is in BroadcastBinomialTree.cuh.
+ */
+__global__ void testBroadcastBinomialTreeKernel(
+    void* buff_d,
+    int my_rank_id,
+    int root_rank_id,
+    DeviceSpan<Transport> transports_per_rank,
+    std::size_t nbytes) {
+  broadcast_binomial_tree(
+      buff_d, my_rank_id, root_rank_id, transports_per_rank, nbytes);
+}
+
 void testBroadcastFlat(
     void* buff_d,
     int my_rank_id,
@@ -36,6 +51,29 @@ void testBroadcastFlat(
   PIPES_CUDA_CHECK(
       comms::common::launchKernel(
           (void*)testBroadcastFlatKernel,
+          dim3(numBlocks, 1, 1),
+          dim3(blockSize, 1, 1),
+          args,
+          stream,
+          clusterDim));
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void testBroadcastBinomialTree(
+    void* buff_d,
+    int my_rank_id,
+    int root_rank_id,
+    DeviceSpan<Transport> transports_per_rank,
+    std::size_t nbytes,
+    int numBlocks,
+    int blockSize,
+    std::optional<dim3> clusterDim,
+    cudaStream_t stream) {
+  void* args[] = {
+      &buff_d, &my_rank_id, &root_rank_id, &transports_per_rank, &nbytes};
+  PIPES_CUDA_CHECK(
+      comms::common::launchKernel(
+          (void*)testBroadcastBinomialTreeKernel,
           dim3(numBlocks, 1, 1),
           dim3(blockSize, 1, 1),
           args,

--- a/comms/pipes/tests/BroadcastTest.cuh
+++ b/comms/pipes/tests/BroadcastTest.cuh
@@ -40,4 +40,31 @@ void testBroadcastFlat(
     std::optional<dim3> clusterDim = std::nullopt,
     cudaStream_t stream = nullptr);
 
+/**
+ * Host-callable wrapper to launch the binomial tree broadcast test kernel.
+ *
+ * @param buff_d Device buffer (source for root, destination for non-root)
+ * @param my_rank_id Current rank ID
+ * @param root_rank_id Rank that broadcasts data
+ * @param transports_per_rank Array of transport objects
+ * @param nbytes Number of bytes to broadcast
+ * @param numBlocks Number of CUDA blocks to launch
+ * @param blockSize Number of threads per block
+ * @param clusterDim Optional cluster dimension for spread cluster launch.
+ *                   When provided, uses cudaLaunchKernelExC with
+ *                   cudaClusterSchedulingPolicySpread for better SM
+ * distribution.
+ * @param stream CUDA stream for kernel execution (default: 0)
+ */
+void testBroadcastBinomialTree(
+    void* buff_d,
+    int my_rank_id,
+    int root_rank_id,
+    DeviceSpan<Transport> transports_per_rank,
+    std::size_t nbytes,
+    int numBlocks,
+    int blockSize,
+    std::optional<dim3> clusterDim = std::nullopt,
+    cudaStream_t stream = nullptr);
+
 } // namespace comms::pipes::collectives::test

--- a/comms/pipes/tests/BroadcastTest.cuh
+++ b/comms/pipes/tests/BroadcastTest.cuh
@@ -1,0 +1,43 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+
+#include <cuda_runtime.h>
+
+#include "comms/pipes/DeviceSpan.cuh"
+#include "comms/pipes/Transport.cuh"
+
+namespace comms::pipes::collectives::test {
+
+/**
+ * Host-callable wrapper to launch the broadcast test kernel (flat-tree).
+ *
+ * @param buff_d Device buffer (source for root, destination for non-root)
+ * @param my_rank_id Current rank ID
+ * @param root_rank_id Rank that broadcasts data
+ * @param transports_per_rank Array of transport objects
+ * @param nbytes Number of bytes to broadcast
+ * @param numBlocks Number of CUDA blocks to launch
+ * @param blockSize Number of threads per block
+ * @param clusterDim Optional cluster dimension for spread cluster launch.
+ *                   When provided, uses cudaLaunchKernelExC with
+ *                   cudaClusterSchedulingPolicySpread for better SM
+ * distribution.
+ * @param stream CUDA stream for kernel execution (default: 0)
+ */
+void testBroadcastFlat(
+    void* buff_d,
+    int my_rank_id,
+    int root_rank_id,
+    DeviceSpan<Transport> transports_per_rank,
+    std::size_t nbytes,
+    int numBlocks,
+    int blockSize,
+    std::optional<dim3> clusterDim = std::nullopt,
+    cudaStream_t stream = nullptr);
+
+} // namespace comms::pipes::collectives::test


### PR DESCRIPTION
Summary:
Adds the binomial tree broadcast algorithm for the Pipes API.
This algorithm uses O(log N) rounds for better bandwidth efficiency on large messages:
- Round 0: Root sends to rank 1
- Round 1: Ranks 0,1 send to ranks 2,3
- Round 2: Ranks 0-3 send to ranks 4-7

Includes chunk-based pipelining for large messages and parameterized tests
covering message sizes from 64KB to 1MB.

---

Also introduces two additional benchmarks:
- optimal: Tests pre-tuned optimal configurations for key message sizes
- tuning: Parameter sweeps for staging buffer sizes

Differential Revision: D91729677


