### PR TITLE
separate p2p benchmarks to sendrecv and signal

### DIFF
--- a/comms/pipes/benchmarks/P2pNvlBenchmarkUtils.h
+++ b/comms/pipes/benchmarks/P2pNvlBenchmarkUtils.h
@@ -1,0 +1,59 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <iomanip>
+#include <sstream>
+#include <string>
+
+#include "comms/pipes/P2pNvlTransportDevice.cuh"
+
+namespace comms::pipes::benchmark {
+
+// Test configuration struct
+struct BenchmarkConfig {
+  std::size_t nBytes = 0;
+  std::size_t stagedBufferSize = 0;
+  int numBlocks = 0;
+  int numThreads = 0;
+  std::size_t pipelineDepth = 4;
+  std::size_t chunkSize = 512 * 1024; // 512KB default
+  SyncScope groupScope = SyncScope::WARP; // Thread group scope for parallelism
+  bool spreadClusterLaunch = false; // Use spread cluster kernel launch
+  std::string name;
+};
+
+// Result struct for collecting benchmark data
+struct BenchmarkResult {
+  std::string testName;
+  std::size_t messageSize{};
+  std::size_t stagingBufferSize{};
+  std::size_t pipelineDepth{};
+  std::size_t chunkSize{};
+  int numBlocks{};
+  int numThreads{};
+  float ncclBandwidth{};
+  float p2pBandwidth{};
+  float ncclTime{};
+  float p2pTime{};
+  float p2pSpeedup{}; // P2P vs NCCL
+};
+
+// Format bytes as human-readable size string (e.g., "8KB", "256MB", "1GB")
+inline std::string formatSize(std::size_t bytes) {
+  std::stringstream ss;
+  if (bytes >= 1024 * 1024 * 1024) {
+    ss << std::fixed << std::setprecision(0)
+       << (bytes / (1024.0 * 1024.0 * 1024.0)) << "GB";
+  } else if (bytes >= 1024 * 1024) {
+    ss << std::fixed << std::setprecision(0) << (bytes / (1024.0 * 1024.0))
+       << "MB";
+  } else if (bytes >= 1024) {
+    ss << std::fixed << std::setprecision(0) << (bytes / 1024.0) << "KB";
+  } else {
+    ss << bytes << "B";
+  }
+  return ss.str();
+}
+
+} // namespace comms::pipes::benchmark

--- a/comms/pipes/benchmarks/P2pNvlSendRecvBenchmark.cc
+++ b/comms/pipes/benchmarks/P2pNvlSendRecvBenchmark.cc
@@ -1,4 +1,4 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 #include <folly/init/Init.h>
 #include <folly/logging/xlog.h>
@@ -6,9 +6,9 @@
 
 #include "comms/common/CudaWrap.h"
 #include "comms/pipes/MultiPeerNvlTransport.h"
-#include "comms/pipes/TimeoutUtils.h"
 #include "comms/pipes/benchmarks/BenchmarkKernel.cuh"
 #include "comms/pipes/benchmarks/BenchmarkMacros.h"
+#include "comms/pipes/benchmarks/P2pNvlBenchmarkUtils.h"
 #include "comms/testinfra/mpi/MpiBootstrap.h"
 #include "comms/testinfra/mpi/MpiTestUtils.h"
 #include "comms/utils/CudaRAII.h"
@@ -24,37 +24,7 @@ using meta::comms::MPIEnvironmentBase;
 
 namespace comms::pipes::benchmark {
 
-// Test configuration struct
-struct BenchmarkConfig {
-  std::size_t nBytes = 0;
-  std::size_t stagedBufferSize = 0;
-  int numBlocks = 0;
-  int numThreads = 0;
-  std::size_t pipelineDepth = 4;
-  std::size_t chunkSize = 512 * 1024; // 512KB default
-  SyncScope groupScope = SyncScope::WARP; // Thread group scope for parallelism
-  bool spreadClusterLaunch = false; // Use spread cluster kernel launch
-  uint32_t timeout_ms = 0; // Timeout in milliseconds (0 = no timeout)
-  std::string name;
-};
-
-// Result struct for collecting benchmark data
-struct BenchmarkResult {
-  std::string testName;
-  std::size_t messageSize{};
-  std::size_t stagingBufferSize{};
-  std::size_t pipelineDepth{};
-  std::size_t chunkSize{};
-  int numBlocks{};
-  int numThreads{};
-  float ncclBandwidth{};
-  float p2pBandwidth{};
-  float ncclTime{};
-  float p2pTime{};
-  float p2pSpeedup{}; // P2P vs NCCL
-};
-
-class P2pNvlBenchmarkFixture : public MpiBaseTestFixture {
+class P2pSendRecvBenchmarkFixture : public MpiBaseTestFixture {
  protected:
   void SetUp() override {
     MpiBaseTestFixture::SetUp();
@@ -166,44 +136,41 @@ class P2pNvlBenchmarkFixture : public MpiBaseTestFixture {
     dim3 gridDim(config.numBlocks);
     dim3 blockDim(config.numThreads);
 
+    cudaStream_t sendStream, recvStream;
+    CUDA_CHECK(cudaStreamCreate(&sendStream));
+    CUDA_CHECK(cudaStreamCreate(&recvStream));
+
     CudaEvent start, stop;
 
     std::size_t nBytes = config.nBytes;
     bool isSend = (globalRank == 0);
     SyncScope groupScope = config.groupScope;
     void* devicePtr = (isSend ? sendBuff.get() : recvBuff.get());
-    Timeout timeout = comms::pipes::makeTimeout(config.timeout_ms, localRank);
+    Timeout timeout; // Default timeout (disabled)
     void* args[] = {&p2p, &devicePtr, &nBytes, &groupScope, &timeout};
     void* kernelFunc = isSend ? (void*)comms::pipes::benchmark::p2pSend
                               : (void*)comms::pipes::benchmark::p2pRecv;
-
-    // Use pointer to cluster dimension for clustered launch
-    dim3 defaultClusterDim(comms::common::kDefaultClusterSize, 1, 1);
-    std::optional<dim3> clusterDimOpt = config.spreadClusterLaunch
-        ? std::optional{defaultClusterDim}
-        : std::nullopt;
+    cudaStream_t stream = isSend ? sendStream : recvStream;
 
     // Warmup
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
     for (int i = 0; i < kWarmupIters; i++) {
       MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
       CUDA_CHECK(
-          comms::common::launchKernel(
-              kernelFunc, gridDim, blockDim, args, nullptr, clusterDimOpt));
-      CUDA_CHECK(cudaDeviceSynchronize());
+          cudaLaunchKernel(kernelFunc, gridDim, blockDim, args, 0, stream));
+      CUDA_CHECK(cudaStreamSynchronize(stream));
     }
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 
     // Benchmark - measure time across all iterations
     // No barrier between iterations - ChunkState provides synchronization
-    CUDA_CHECK(cudaEventRecord(start.get()));
+    CUDA_CHECK(cudaEventRecord(start.get(), stream));
     for (int i = 0; i < kBenchmarkIters; i++) {
       CUDA_CHECK(
-          comms::common::launchKernel(
-              kernelFunc, gridDim, blockDim, args, nullptr, clusterDimOpt));
+          cudaLaunchKernel(kernelFunc, gridDim, blockDim, args, 0, stream));
     }
-    CUDA_CHECK(cudaEventRecord(stop.get()));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaEventRecord(stop.get(), stream));
+    CUDA_CHECK(cudaStreamSynchronize(stream));
 
     float totalTime_ms = 0.0f;
     CUDA_CHECK(cudaEventElapsedTime(&totalTime_ms, start.get(), stop.get()));
@@ -212,86 +179,12 @@ class P2pNvlBenchmarkFixture : public MpiBaseTestFixture {
     // Unidirectional bandwidth: data transferred in one direction / time
     float bandwidth_GBps = (config.nBytes / 1e9f) / (avgTime_ms / 1000.0f);
 
+    CUDA_CHECK(cudaStreamDestroy(sendStream));
+    CUDA_CHECK(cudaStreamDestroy(recvStream));
+
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 
     return bandwidth_GBps;
-  }
-
-  void printResultsTable(const std::vector<BenchmarkResult>& results) {
-    if (globalRank != 0) {
-      return; // Only rank 0 prints the table
-    }
-
-    std::stringstream ss;
-    ss << "\n";
-    ss << "==============================================================================================================================\n";
-    ss << "                              NCCL vs P2P NVLink Benchmark Results\n";
-    ss << "==============================================================================================================================\n";
-    ss << std::left << std::setw(18) << "Test Name" << std::right
-       << std::setw(10) << "Msg Size" << std::right << std::setw(12)
-       << "Staging" << std::right << std::setw(5) << "PD" << std::right
-       << std::setw(8) << "Chunk" << std::right << std::setw(7) << "Blocks"
-       << std::right << std::setw(8) << "Threads" << std::right << std::setw(11)
-       << "NCCL BW" << std::right << std::setw(11) << "P2P BW" << std::right
-       << std::setw(9) << "Speedup" << std::right << std::setw(11) << "NCCL Lat"
-       << std::right << std::setw(11) << "P2P Lat" << std::right
-       << std::setw(11) << "Lat Reduc\n";
-    ss << std::left << std::setw(18) << "" << std::right << std::setw(10) << ""
-       << std::right << std::setw(12) << "" << std::right << std::setw(5) << ""
-       << std::right << std::setw(8) << "" << std::right << std::setw(7) << ""
-       << std::right << std::setw(8) << "" << std::right << std::setw(11)
-       << "(GB/s)" << std::right << std::setw(11) << "(GB/s)" << std::right
-       << std::setw(9) << "P2P/NCCL" << std::right << std::setw(11) << "(us)"
-       << std::right << std::setw(11) << "(us)" << std::right << std::setw(11)
-       << "(us)\n";
-    ss << "------------------------------------------------------------------------------------------------------------------------------\n";
-
-    for (const auto& r : results) {
-      std::string msgSize = formatSize(r.messageSize);
-      std::string stagingSize = formatSize(r.stagingBufferSize);
-      std::string chunkSizeStr = formatSize(r.chunkSize);
-      float latencyReduction = r.ncclTime - r.p2pTime;
-
-      ss << std::left << std::setw(18) << r.testName << std::right
-         << std::setw(10) << msgSize << std::right << std::setw(12)
-         << stagingSize << std::right << std::setw(5) << r.pipelineDepth
-         << std::right << std::setw(8) << chunkSizeStr << std::right
-         << std::setw(7) << r.numBlocks << std::right << std::setw(8)
-         << r.numThreads << std::right << std::setw(11) << std::fixed
-         << std::setprecision(2) << r.ncclBandwidth << std::right
-         << std::setw(11) << std::fixed << std::setprecision(2)
-         << r.p2pBandwidth << std::right << std::setw(8) << std::fixed
-         << std::setprecision(2) << r.p2pSpeedup << "x" << std::right
-         << std::setw(11) << std::fixed << std::setprecision(1) << r.ncclTime
-         << std::right << std::setw(11) << std::fixed << std::setprecision(1)
-         << r.p2pTime << std::right << std::setw(11) << std::fixed
-         << std::setprecision(1) << latencyReduction << "\n";
-    }
-    ss << "==============================================================================================================================\n";
-    ss << "PD = Pipeline Depth, Chunk = Chunk Size, Blocks/Threads = P2P kernel launch config\n";
-    ss << "BW (Bandwidth) = Data transferred / time, in GB/s\n";
-    ss << "Lat (Latency) = Average transfer time per iteration, in microseconds\n";
-    ss << "Lat Reduc = NCCL latency - P2P latency (positive = P2P faster)\n";
-    ss << "Speedup = P2P Bandwidth / NCCL Bandwidth\n";
-    ss << "==============================================================================================================================\n\n";
-
-    XLOG(INFO) << ss.str();
-  }
-
-  std::string formatSize(std::size_t bytes) {
-    std::stringstream ss;
-    if (bytes >= 1024 * 1024 * 1024) {
-      ss << std::fixed << std::setprecision(0)
-         << (bytes / (1024.0 * 1024.0 * 1024.0)) << "GB";
-    } else if (bytes >= 1024 * 1024) {
-      ss << std::fixed << std::setprecision(0) << (bytes / (1024.0 * 1024.0))
-         << "MB";
-    } else if (bytes >= 1024) {
-      ss << std::fixed << std::setprecision(0) << (bytes / 1024.0) << "KB";
-    } else {
-      ss << bytes << "B";
-    }
-    return ss.str();
   }
 
   // Helper function to run NCCL bidirectional benchmark - returns algorithm BW
@@ -404,7 +297,7 @@ class P2pNvlBenchmarkFixture : public MpiBaseTestFixture {
     void* sendPtr = sendBuff.get();
     void* recvPtr = recvBuff.get();
     SyncScope groupScope = config.groupScope;
-    Timeout timeout = comms::pipes::makeTimeout(config.timeout_ms, localRank);
+    Timeout timeout; // Default timeout (disabled)
     void* args[] = {&p2p, &sendPtr, &recvPtr, &nBytes, &groupScope, &timeout};
     void* kernelFunc = (void*)comms::pipes::benchmark::p2pBidirectional;
 
@@ -449,51 +342,74 @@ class P2pNvlBenchmarkFixture : public MpiBaseTestFixture {
     return bandwidth_GBps;
   }
 
-  // Helper function to run P2P signal benchmark - returns latency
-  // in microseconds
-  float runSignalBenchmark(
-      comms::pipes::P2pNvlTransportDevice& p2p,
-      const BenchmarkConfig& config,
-      int nSteps = 1000) {
-    XLOGF(DBG1, "=== Running Signal benchmark: {} ===", config.name);
+  void printResultsTable(
+      const std::vector<BenchmarkResult>& results,
+      const std::string& title) {
+    if (globalRank != 0) {
+      return; // Only rank 0 prints the table
+    }
 
-    dim3 gridDim(config.numBlocks);
-    dim3 blockDim(config.numThreads);
+    std::stringstream ss;
+    ss << "\n";
+    ss << "==============================================================================================================================\n";
+    ss << "                              " << title << "\n";
+    ss << "==============================================================================================================================\n";
+    ss << std::left << std::setw(18) << "Test Name" << std::right
+       << std::setw(10) << "Msg Size" << std::right << std::setw(12)
+       << "Staging" << std::right << std::setw(5) << "PD" << std::right
+       << std::setw(8) << "Chunk" << std::right << std::setw(7) << "Blocks"
+       << std::right << std::setw(8) << "Threads" << std::right << std::setw(11)
+       << "NCCL BW" << std::right << std::setw(11) << "P2P BW" << std::right
+       << std::setw(9) << "Speedup" << std::right << std::setw(11) << "NCCL Lat"
+       << std::right << std::setw(11) << "P2P Lat" << std::right
+       << std::setw(11) << "Lat Reduc\n";
+    ss << std::left << std::setw(18) << "" << std::right << std::setw(10) << ""
+       << std::right << std::setw(12) << "" << std::right << std::setw(5) << ""
+       << std::right << std::setw(8) << "" << std::right << std::setw(7) << ""
+       << std::right << std::setw(8) << "" << std::right << std::setw(11)
+       << "(GB/s)" << std::right << std::setw(11) << "(GB/s)" << std::right
+       << std::setw(9) << "P2P/NCCL" << std::right << std::setw(11) << "(us)"
+       << std::right << std::setw(11) << "(us)" << std::right << std::setw(11)
+       << "(us)\n";
+    ss << "------------------------------------------------------------------------------------------------------------------------------\n";
 
-    CudaEvent start, stop;
+    for (const auto& r : results) {
+      std::string msgSize = formatSize(r.messageSize);
+      std::string stagingSize = formatSize(r.stagingBufferSize);
+      std::string chunkSizeStr = formatSize(r.chunkSize);
+      float latencyReduction = r.ncclTime - r.p2pTime;
 
-    int nStepsArg = nSteps;
-    SyncScope groupScope = config.groupScope;
-    void* args[] = {&p2p, &nStepsArg, &groupScope};
-    void* kernelFunc = (void*)comms::pipes::benchmark::p2pSignalBenchKernel;
+      ss << std::left << std::setw(18) << r.testName << std::right
+         << std::setw(10) << msgSize << std::right << std::setw(12)
+         << stagingSize << std::right << std::setw(5) << r.pipelineDepth
+         << std::right << std::setw(8) << chunkSizeStr << std::right
+         << std::setw(7) << r.numBlocks << std::right << std::setw(8)
+         << r.numThreads << std::right << std::setw(11) << std::fixed
+         << std::setprecision(2) << r.ncclBandwidth << std::right
+         << std::setw(11) << std::fixed << std::setprecision(2)
+         << r.p2pBandwidth << std::right << std::setw(8) << std::fixed
+         << std::setprecision(2) << r.p2pSpeedup << "x" << std::right
+         << std::setw(11) << std::fixed << std::setprecision(1) << r.ncclTime
+         << std::right << std::setw(11) << std::fixed << std::setprecision(1)
+         << r.p2pTime << std::right << std::setw(11) << std::fixed
+         << std::setprecision(1) << latencyReduction << "\n";
+    }
+    ss << "==============================================================================================================================\n";
+    ss << "PD = Pipeline Depth, Chunk = Chunk Size, Blocks/Threads = P2P kernel launch config\n";
+    ss << "BW (Bandwidth) = Data transferred / time, in GB/s\n";
+    ss << "Lat (Latency) = Average transfer time per iteration, in microseconds\n";
+    ss << "Lat Reduc = NCCL latency - P2P latency (positive = P2P faster)\n";
+    ss << "Speedup = P2P Bandwidth / NCCL Bandwidth\n";
+    ss << "==============================================================================================================================\n\n";
 
-    // Synchronize both ranks before starting to ensure both GPUs launch
-    // together
-    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
-
-    // Benchmark
-    CUDA_CHECK(cudaEventRecord(start.get(), stream_));
-    CUDA_CHECK(
-        cudaLaunchKernel(kernelFunc, gridDim, blockDim, args, 0, stream_));
-    CUDA_CHECK(cudaEventRecord(stop.get(), stream_));
-    CUDA_CHECK(cudaStreamSynchronize(stream_));
-
-    float totalTime_ms = 0.0f;
-    CUDA_CHECK(cudaEventElapsedTime(&totalTime_ms, start.get(), stop.get()));
-
-    // Calculate per-signal latency in microseconds
-    float avgLatencyUs = (totalTime_ms / nSteps) * 1000.0f;
-
-    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
-
-    return avgLatencyUs;
+    XLOG(INFO) << ss.str();
   }
 
   ncclComm_t ncclComm_{};
   cudaStream_t stream_{};
 };
 
-TEST_F(P2pNvlBenchmarkFixture, CompareNcclVsP2pNvl) {
+TEST_F(P2pSendRecvBenchmarkFixture, UnidirectionalBenchmark) {
   // Only test with 2 ranks
   if (numRanks != 2) {
     XLOGF(DBG1, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
@@ -636,20 +552,6 @@ TEST_F(P2pNvlBenchmarkFixture, CompareNcclVsP2pNvl) {
       .name = "1GB",
   });
 
-  // 1GB with timeout (NCCL-like config with 30 second timeout)
-  configs.push_back({
-      .nBytes = 1024 * 1024 * 1024,
-      .stagedBufferSize = 8 * 1024 * 1024,
-      .numBlocks = 32,
-      .numThreads = 512,
-      .pipelineDepth = 2,
-      .chunkSize = 512 * 1024,
-      .groupScope = SyncScope::BLOCK,
-      .spreadClusterLaunch = true,
-      .timeout_ms = 30000, // 30 second timeout
-      .name = "1GB_Timeout",
-  });
-
   // === BLOCK-BASED GROUPS (fewer coordination points) ===
   // With block groups: 256 blocks = 256 groups (vs 1024 warps)
 
@@ -729,10 +631,10 @@ TEST_F(P2pNvlBenchmarkFixture, CompareNcclVsP2pNvl) {
     results.push_back(result);
   }
 
-  printResultsTable(results);
+  printResultsTable(results, "NCCL vs P2P NVLink Benchmark Results");
 }
 
-TEST_F(P2pNvlBenchmarkFixture, BidirectionalBenchmark) {
+TEST_F(P2pSendRecvBenchmarkFixture, BidirectionalBenchmark) {
   // Only test with 2 ranks
   if (numRanks != 2) {
     XLOGF(DBG1, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
@@ -814,20 +716,6 @@ TEST_F(P2pNvlBenchmarkFixture, BidirectionalBenchmark) {
       .name = "Bidir_1GB",
   });
 
-  // 1GB with timeout (NCCL-like config with 30 second timeout)
-  configs.push_back({
-      .nBytes = 1024 * 1024 * 1024,
-      .stagedBufferSize = 8 * 1024 * 1024,
-      .numBlocks = 32,
-      .numThreads = 512,
-      .pipelineDepth = 2,
-      .chunkSize = 512 * 1024,
-      .groupScope = SyncScope::BLOCK,
-      .spreadClusterLaunch = true,
-      .timeout_ms = 30000, // 30 second timeout
-      .name = "Bidir_1GB_Timeout",
-  });
-
   // === NCCL-LIKE CONFIGURATIONS ===
   // Helper function to add NCCL-like configs with consistent parameters
   // NCCL uses 16 blocks for < 512M messages, 32 blocks for >= 512M messages
@@ -841,11 +729,8 @@ TEST_F(P2pNvlBenchmarkFixture, BidirectionalBenchmark) {
   // Helper function for adding NCCL-like config with auto-computed numBlocks
   // Uses 16 blocks for < 512M, 32 blocks for >= 512M (like NCCL)
   auto addNcclConfig = [&configs,
-                        kNcclBlocksSmall,
                         kNcclBlocksLarge,
-                        kNcclThreads,
                         kNcclStagedBufferSize,
-                        kChunkSize,
                         kLargeMessageThreshold](
                            std::size_t sizeBytes,
                            const std::string& sizeName,
@@ -985,153 +870,6 @@ TEST_F(P2pNvlBenchmarkFixture, BidirectionalBenchmark) {
     ss << "Bidirectional: Both ranks send AND receive simultaneously\n";
     ss << "BW = Algorithm bandwidth (2 x message size / time)\n";
     ss << "==============================================================================================================================\n\n";
-
-    XLOG(INFO) << ss.str();
-  }
-}
-
-TEST_F(P2pNvlBenchmarkFixture, SignalBenchmark) {
-  // Only test with 2 ranks
-  if (numRanks != 2) {
-    XLOGF(DBG1, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
-    return;
-  }
-
-  int peerRank = (globalRank == 0) ? 1 : 0;
-
-  // Signal benchmark configurations using BenchmarkConfig
-  std::vector<BenchmarkConfig> configs = {
-      {.numBlocks = 1,
-       .numThreads = 32,
-       .groupScope = SyncScope::WARP,
-       .name = "1b_32t_warp"},
-      {.numBlocks = 1,
-       .numThreads = 128,
-       .groupScope = SyncScope::WARP,
-       .name = "1b_warp"},
-      {.numBlocks = 2,
-       .numThreads = 128,
-       .groupScope = SyncScope::WARP,
-       .name = "2b_warp"},
-      {.numBlocks = 4,
-       .numThreads = 128,
-       .groupScope = SyncScope::WARP,
-       .name = "4b_warp"},
-      {.numBlocks = 8,
-       .numThreads = 128,
-       .groupScope = SyncScope::WARP,
-       .name = "8b_warp"},
-      {.numBlocks = 16,
-       .numThreads = 128,
-       .groupScope = SyncScope::WARP,
-       .name = "16b_warp"},
-      {.numBlocks = 32,
-       .numThreads = 128,
-       .groupScope = SyncScope::WARP,
-       .name = "32b_warp"},
-      {.numBlocks = 1,
-       .numThreads = 128,
-       .groupScope = SyncScope::BLOCK,
-       .name = "1b_block"},
-      {.numBlocks = 2,
-       .numThreads = 128,
-       .groupScope = SyncScope::BLOCK,
-       .name = "2b_block"},
-      {.numBlocks = 4,
-       .numThreads = 128,
-       .groupScope = SyncScope::BLOCK,
-       .name = "4b_block"},
-      {.numBlocks = 8,
-       .numThreads = 128,
-       .groupScope = SyncScope::BLOCK,
-       .name = "8b_block"},
-      {.numBlocks = 16,
-       .numThreads = 128,
-       .groupScope = SyncScope::BLOCK,
-       .name = "16b_block"},
-      {.numBlocks = 32,
-       .numThreads = 128,
-       .groupScope = SyncScope::BLOCK,
-       .name = "32b_block"},
-  };
-
-  const int nSteps = 1000; // Number of signal iterations per kernel launch
-
-  // GPU warmup phase - run one iteration to avoid cold start overhead
-  {
-    const auto& warmupConfig = configs[0];
-    std::size_t signalCount = warmupConfig.groupScope == SyncScope::BLOCK
-        ? warmupConfig.numBlocks
-        : warmupConfig.numBlocks * (warmupConfig.numThreads / 32);
-
-    comms::pipes::MultiPeerNvlTransportConfig p2pConfig{
-        .dataBufferSize = 1,
-        .chunkSize = 1,
-        .pipelineDepth = 1,
-        .signalCount = signalCount,
-    };
-
-    auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
-    comms::pipes::MultiPeerNvlTransport transport(
-        globalRank, numRanks, bootstrap, p2pConfig);
-    transport.exchange();
-
-    auto p2p = transport.getP2pTransportDevice(peerRank);
-    runSignalBenchmark(p2p, warmupConfig, nSteps); // Discard result
-  }
-
-  std::vector<BenchmarkResult> results;
-
-  for (const auto& config : configs) {
-    // Calculate signalCount for this config
-    // For warp groups: numBlocks * (numThreads / 32)
-    // For block groups: numBlocks
-    std::size_t signalCount = config.groupScope == SyncScope::BLOCK
-        ? config.numBlocks
-        : config.numBlocks * (config.numThreads / 32);
-
-    // Create fresh P2P transport for each config to reset signal buffers
-    comms::pipes::MultiPeerNvlTransportConfig p2pConfig{
-        .dataBufferSize = 1,
-        .chunkSize = 1,
-        .pipelineDepth = 1,
-        .signalCount = signalCount,
-    };
-
-    auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
-    comms::pipes::MultiPeerNvlTransport transport(
-        globalRank, numRanks, bootstrap, p2pConfig);
-    transport.exchange();
-
-    auto p2p = transport.getP2pTransportDevice(peerRank);
-
-    BenchmarkResult result;
-    result.testName = config.name;
-    result.p2pTime = runSignalBenchmark(p2p, config, nSteps);
-    results.push_back(result);
-  }
-
-  // Print results
-  if (globalRank == 0) {
-    std::stringstream ss;
-    ss << "\n";
-    ss << "================================================================\n";
-    ss << "              P2P NVLink Signal Benchmark Results\n";
-    ss << "================================================================\n";
-    ss << std::left << std::setw(20) << "Config" << std::right << std::setw(15)
-       << "Latency (us)\n";
-    ss << "----------------------------------------------------------------\n";
-
-    for (const auto& r : results) {
-      ss << std::left << std::setw(20) << r.testName << std::right
-         << std::setw(15) << std::fixed << std::setprecision(3) << r.p2pTime
-         << "\n";
-    }
-    ss << "================================================================\n";
-    ss << "Latency = Average time per signal/wait pair\n";
-    ss << "Each measurement: 1 kernel launches x " << nSteps
-       << " signal+wait/launch\n";
-    ss << "================================================================\n\n";
 
     XLOG(INFO) << ss.str();
   }

--- a/comms/pipes/benchmarks/P2pNvlSignalBenchmark.cc
+++ b/comms/pipes/benchmarks/P2pNvlSignalBenchmark.cc
@@ -1,0 +1,258 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <folly/init/Init.h>
+#include <folly/logging/xlog.h>
+#include <nccl.h>
+
+#include "comms/common/CudaWrap.h"
+#include "comms/pipes/MultiPeerNvlTransport.h"
+#include "comms/pipes/benchmarks/BenchmarkKernel.cuh"
+#include "comms/pipes/benchmarks/BenchmarkMacros.h"
+#include "comms/pipes/benchmarks/P2pNvlBenchmarkUtils.h"
+#include "comms/testinfra/mpi/MpiBootstrap.h"
+#include "comms/testinfra/mpi/MpiTestUtils.h"
+#include "comms/utils/CudaRAII.h"
+
+#include <iomanip>
+#include <sstream>
+#include <vector>
+
+using meta::comms::CudaEvent;
+using meta::comms::DeviceBuffer;
+using meta::comms::MpiBaseTestFixture;
+using meta::comms::MPIEnvironmentBase;
+
+namespace comms::pipes::benchmark {
+
+class P2pSignalBenchmarkFixture : public MpiBaseTestFixture {
+ protected:
+  void SetUp() override {
+    MpiBaseTestFixture::SetUp();
+    // Use localRank for cudaSetDevice since each node has its own set of GPUs
+    // globalRank would fail on multi-node setups where rank > num_gpus_per_node
+    CUDA_CHECK_VOID(cudaSetDevice(localRank));
+
+    // Initialize NCCL
+    NCCL_CHECK_VOID(
+        ncclCommInitRank(&ncclComm_, numRanks, getNCCLId(), globalRank));
+    CUDA_CHECK_VOID(cudaStreamCreate(&stream_));
+  }
+
+  void TearDown() override {
+    NCCL_CHECK_VOID(ncclCommDestroy(ncclComm_));
+    CUDA_CHECK_VOID(cudaStreamDestroy(stream_));
+    MpiBaseTestFixture::TearDown();
+  }
+
+  ncclUniqueId getNCCLId() {
+    ncclUniqueId id;
+    if (globalRank == 0) {
+      ncclResult_t res = ncclGetUniqueId(&id);
+      if (res != ncclSuccess) {
+        XLOGF(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
+        std::abort();
+      }
+    }
+    MPI_CHECK(MPI_Bcast(&id, sizeof(id), MPI_BYTE, 0, MPI_COMM_WORLD));
+    return id;
+  }
+
+  // Helper function to run P2P signal benchmark - returns latency
+  // in microseconds
+  float runSignalBenchmark(
+      comms::pipes::P2pNvlTransportDevice& p2p,
+      const BenchmarkConfig& config,
+      int nSteps = 1000) {
+    XLOGF(DBG1, "=== Running Signal benchmark: {} ===", config.name);
+
+    dim3 gridDim(config.numBlocks);
+    dim3 blockDim(config.numThreads);
+
+    CudaEvent start, stop;
+
+    int nStepsArg = nSteps;
+    SyncScope groupScope = config.groupScope;
+    void* args[] = {&p2p, &nStepsArg, &groupScope};
+    void* kernelFunc = (void*)comms::pipes::benchmark::p2pSignalBenchKernel;
+
+    // Synchronize both ranks before starting to ensure both GPUs launch
+    // together
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    // Benchmark
+    CUDA_CHECK(cudaEventRecord(start.get(), stream_));
+    CUDA_CHECK(
+        cudaLaunchKernel(kernelFunc, gridDim, blockDim, args, 0, stream_));
+    CUDA_CHECK(cudaEventRecord(stop.get(), stream_));
+    CUDA_CHECK(cudaStreamSynchronize(stream_));
+
+    float totalTime_ms = 0.0f;
+    CUDA_CHECK(cudaEventElapsedTime(&totalTime_ms, start.get(), stop.get()));
+
+    // Calculate per-signal latency in microseconds
+    float avgLatencyUs = (totalTime_ms / nSteps) * 1000.0f;
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    return avgLatencyUs;
+  }
+
+  ncclComm_t ncclComm_{};
+  cudaStream_t stream_{};
+};
+
+TEST_F(P2pSignalBenchmarkFixture, SignalBenchmark) {
+  // Only test with 2 ranks
+  if (numRanks != 2) {
+    XLOGF(DBG1, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    return;
+  }
+
+  int peerRank = (globalRank == 0) ? 1 : 0;
+
+  // Signal benchmark configurations using BenchmarkConfig
+  std::vector<BenchmarkConfig> configs = {
+      {.numBlocks = 1,
+       .numThreads = 32,
+       .groupScope = SyncScope::WARP,
+       .name = "1b_32t_warp"},
+      {.numBlocks = 1,
+       .numThreads = 128,
+       .groupScope = SyncScope::WARP,
+       .name = "1b_warp"},
+      {.numBlocks = 2,
+       .numThreads = 128,
+       .groupScope = SyncScope::WARP,
+       .name = "2b_warp"},
+      {.numBlocks = 4,
+       .numThreads = 128,
+       .groupScope = SyncScope::WARP,
+       .name = "4b_warp"},
+      {.numBlocks = 8,
+       .numThreads = 128,
+       .groupScope = SyncScope::WARP,
+       .name = "8b_warp"},
+      {.numBlocks = 16,
+       .numThreads = 128,
+       .groupScope = SyncScope::WARP,
+       .name = "16b_warp"},
+      {.numBlocks = 32,
+       .numThreads = 128,
+       .groupScope = SyncScope::WARP,
+       .name = "32b_warp"},
+      {.numBlocks = 1,
+       .numThreads = 128,
+       .groupScope = SyncScope::BLOCK,
+       .name = "1b_block"},
+      {.numBlocks = 2,
+       .numThreads = 128,
+       .groupScope = SyncScope::BLOCK,
+       .name = "2b_block"},
+      {.numBlocks = 4,
+       .numThreads = 128,
+       .groupScope = SyncScope::BLOCK,
+       .name = "4b_block"},
+      {.numBlocks = 8,
+       .numThreads = 128,
+       .groupScope = SyncScope::BLOCK,
+       .name = "8b_block"},
+      {.numBlocks = 16,
+       .numThreads = 128,
+       .groupScope = SyncScope::BLOCK,
+       .name = "16b_block"},
+      {.numBlocks = 32,
+       .numThreads = 128,
+       .groupScope = SyncScope::BLOCK,
+       .name = "32b_block"},
+  };
+
+  const int nSteps = 1000; // Number of signal iterations per kernel launch
+
+  // GPU warmup phase - run one iteration to avoid cold start overhead
+  {
+    const auto& warmupConfig = configs[0];
+    std::size_t signalCount = warmupConfig.groupScope == SyncScope::BLOCK
+        ? warmupConfig.numBlocks
+        : warmupConfig.numBlocks * (warmupConfig.numThreads / 32);
+
+    comms::pipes::MultiPeerNvlTransportConfig p2pConfig{
+        .dataBufferSize = 1,
+        .chunkSize = 1,
+        .pipelineDepth = 1,
+        .signalCount = signalCount,
+    };
+
+    auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+    comms::pipes::MultiPeerNvlTransport transport(
+        globalRank, numRanks, bootstrap, p2pConfig);
+    transport.exchange();
+
+    auto p2p = transport.getP2pTransportDevice(peerRank);
+    runSignalBenchmark(p2p, warmupConfig, nSteps); // Discard result
+  }
+
+  std::vector<BenchmarkResult> results;
+
+  for (const auto& config : configs) {
+    // Calculate signalCount for this config
+    // For warp groups: numBlocks * (numThreads / 32)
+    // For block groups: numBlocks
+    std::size_t signalCount = config.groupScope == SyncScope::BLOCK
+        ? config.numBlocks
+        : config.numBlocks * (config.numThreads / 32);
+
+    // Create fresh P2P transport for each config to reset signal buffers
+    comms::pipes::MultiPeerNvlTransportConfig p2pConfig{
+        .dataBufferSize = 1,
+        .chunkSize = 1,
+        .pipelineDepth = 1,
+        .signalCount = signalCount,
+    };
+
+    auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+    comms::pipes::MultiPeerNvlTransport transport(
+        globalRank, numRanks, bootstrap, p2pConfig);
+    transport.exchange();
+
+    auto p2p = transport.getP2pTransportDevice(peerRank);
+
+    BenchmarkResult result;
+    result.testName = config.name;
+    result.p2pTime = runSignalBenchmark(p2p, config, nSteps);
+    results.push_back(result);
+  }
+
+  // Print results
+  if (globalRank == 0) {
+    std::stringstream ss;
+    ss << "\n";
+    ss << "================================================================\n";
+    ss << "              P2P NVLink Signal Benchmark Results\n";
+    ss << "================================================================\n";
+    ss << std::left << std::setw(20) << "Config" << std::right << std::setw(15)
+       << "Latency (us)\n";
+    ss << "----------------------------------------------------------------\n";
+
+    for (const auto& r : results) {
+      ss << std::left << std::setw(20) << r.testName << std::right
+         << std::setw(15) << std::fixed << std::setprecision(3) << r.p2pTime
+         << "\n";
+    }
+    ss << "================================================================\n";
+    ss << "Latency = Average time per signal/wait pair\n";
+    ss << "Each measurement: 1 kernel launches x " << nSteps
+       << " signal+wait/launch\n";
+    ss << "================================================================\n\n";
+
+    XLOG(INFO) << ss.str();
+  }
+}
+
+} // namespace comms::pipes::benchmark
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new MPIEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Summary:
p2p_nvl_benchmark gets too big now, separate to 2 benchmarks:
- p2p_nvl_send_recv_benchmark
- p2p_nvl_signal_benchmark

no functionality change

Differential Revision: D91643723


