### PR TITLE
Fix missing CommsScubaSample symbol in conda build

### DIFF
--- a/comms/utils/CMakeLists.txt
+++ b/comms/utils/CMakeLists.txt
@@ -4,6 +4,7 @@ find_package(CUDA REQUIRED)
 
 file(GLOB_RECURSE UTILS_SOURCES
     "*.cc"
+    "*.cpp"
 )
 list(FILTER UTILS_SOURCES EXCLUDE REGEX ".*/tests/.*")
 


### PR DESCRIPTION
Summary:
The conda build was failing with `undefined symbol: _ZTIN5comms16CommsScubaSampleE` (typeinfo for `comms::CommsScubaSample`).

Root cause: The `comms/utils/CMakeLists.txt` only collected `*.cc` files, but `CommsScubaSample.cpp` uses the `.cpp` extension, causing it to be excluded from the build.

Fix: Updated the glob pattern to include both `*.cc` and `*.cpp` files, ensuring all source files in the logger directory are compiled.

Reviewed By: dboyda, mlunar-meta

Differential Revision: D91828594


