### PR TITLE
Add lightweight AlgoStats for algorithm counting in baseline

### DIFF
--- a/comms/ncclx/v2_28/meta/colltrace/AlgoStats.cc
+++ b/comms/ncclx/v2_28/meta/colltrace/AlgoStats.cc
@@ -1,0 +1,21 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "meta/colltrace/AlgoStats.h"
+
+#include "comm.h"
+
+namespace ncclx::colltrace {
+
+__attribute__((visibility("default"))) void dumpAlgoStat(
+    ncclComm_t comm,
+    std::unordered_map<std::string, std::unordered_map<std::string, int64_t>>&
+        map) {
+  map.clear();
+  if (comm == nullptr || comm->algoStats == nullptr) {
+    return;
+  }
+  auto dump = comm->algoStats->dump();
+  map.swap(dump.counts);
+}
+
+} // namespace ncclx::colltrace

--- a/comms/ncclx/v2_28/meta/colltrace/AlgoStats.h
+++ b/comms/ncclx/v2_28/meta/colltrace/AlgoStats.h
@@ -1,0 +1,17 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#pragma once
+
+// Re-export AlgoStats from common location
+#include "comms/utils/colltrace/AlgoStats.h"
+
+#include "nccl.h"
+
+namespace ncclx::colltrace {
+
+// Re-export types from common namespace for backwards compatibility
+using meta::comms::colltrace::AlgoStats;
+
+// Note: AlgoStatDump and dumpAlgoStat are declared in nccl.h
+// (see NCCL_HAS_DUMP_ALGO_STAT)
+
+} // namespace ncclx::colltrace

--- a/comms/ncclx/v2_28/meta/colltrace/CollTraceFunc.cc
+++ b/comms/ncclx/v2_28/meta/colltrace/CollTraceFunc.cc
@@ -885,6 +885,14 @@ using meta::comms::colltrace::ICollTraceHandle;
 std::shared_ptr<ICollTraceHandle> collTraceBaselineGetHandle(
     ncclKernelPlan* plan,
     cudaStream_t stream) {
+  // Record to standalone AlgoStats (independent of colltrace implementation)
+  if (plan->comm->algoStats) {
+    auto collOpt = parseCollInfoFromNcclKernelPlan(*plan, stream);
+    if (collOpt.has_value()) {
+      plan->comm->algoStats->record(collOpt->opName, collOpt->algoName);
+    }
+  }
+
   if (!NCCL_COLLTRACE.empty() && NCCL_COLLTRACE_USE_NEW_COLLTRACE) {
     return meta::comms::ncclx::getHandleFromNcclKernelPlan(*plan, stream);
   }

--- a/comms/ncclx/v2_28/meta/colltrace/tests/AlgoStatsTest.cpp
+++ b/comms/ncclx/v2_28/meta/colltrace/tests/AlgoStatsTest.cpp
@@ -1,0 +1,106 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+
+#include <thread>
+#include <vector>
+
+#include "meta/colltrace/AlgoStats.h"
+
+using namespace ncclx::colltrace;
+
+TEST(AlgoStatsTest, BasicRecordAndDump) {
+  AlgoStats stats(0x12345678, "TP_PG");
+
+  stats.record("ReduceScatter", "PAT");
+  stats.record("ReduceScatter", "PAT");
+  stats.record("ReduceScatter", "RING");
+  stats.record("AllReduce", "TREE");
+
+  auto dump = stats.dump();
+
+  EXPECT_EQ(dump.commHash, 0x12345678);
+  EXPECT_EQ(dump.commDesc, "TP_PG");
+  EXPECT_EQ(dump.counts["ReduceScatter"]["PAT"], 2);
+  EXPECT_EQ(dump.counts["ReduceScatter"]["RING"], 1);
+  EXPECT_EQ(dump.counts["AllReduce"]["TREE"], 1);
+}
+
+TEST(AlgoStatsTest, Reset) {
+  AlgoStats stats(0xABCD, "test_comm");
+
+  stats.record("AllGather", "RING");
+  stats.record("AllGather", "RING");
+
+  auto dumpBefore = stats.dump();
+  EXPECT_EQ(dumpBefore.counts["AllGather"]["RING"], 2);
+
+  stats.reset();
+
+  auto dumpAfter = stats.dump();
+  EXPECT_TRUE(dumpAfter.counts.empty());
+  // Comm info should be preserved after reset
+  EXPECT_EQ(dumpAfter.commHash, 0xABCD);
+  EXPECT_EQ(dumpAfter.commDesc, "test_comm");
+}
+
+TEST(AlgoStatsTest, ConcurrentRecording) {
+  AlgoStats stats(0x1234, "concurrent_test");
+
+  constexpr int kNumThreads = 4;
+  constexpr int kRecordsPerThread = 1000;
+
+  std::vector<std::thread> threads;
+  threads.reserve(kNumThreads);
+  for (int i = 0; i < kNumThreads; ++i) {
+    threads.emplace_back([&stats]() {
+      for (int j = 0; j < kRecordsPerThread; ++j) {
+        stats.record("AllReduce", "PAT");
+      }
+    });
+  }
+
+  for (auto& t : threads) {
+    t.join();
+  }
+
+  auto dump = stats.dump();
+  EXPECT_EQ(dump.counts["AllReduce"]["PAT"], kNumThreads * kRecordsPerThread);
+}
+
+TEST(AlgoStatsTest, MultipleCollectivesAndAlgorithms) {
+  AlgoStats stats(0x5678, "multi_test");
+
+  // Record various collectives with different algorithms
+  for (int i = 0; i < 30; ++i) {
+    stats.record("ReduceScatter", "PAT");
+  }
+  for (int i = 0; i < 5; ++i) {
+    stats.record("ReduceScatter", "RING");
+  }
+  for (int i = 0; i < 50; ++i) {
+    stats.record("AllReduce", "TREE");
+  }
+  for (int i = 0; i < 10; ++i) {
+    stats.record("AllGather", "RING");
+  }
+
+  auto dump = stats.dump();
+
+  EXPECT_EQ(dump.counts.size(), 3); // 3 collectives
+  EXPECT_EQ(dump.counts["ReduceScatter"].size(), 2); // 2 algorithms
+  EXPECT_EQ(dump.counts["ReduceScatter"]["PAT"], 30);
+  EXPECT_EQ(dump.counts["ReduceScatter"]["RING"], 5);
+  EXPECT_EQ(dump.counts["AllReduce"]["TREE"], 50);
+  EXPECT_EQ(dump.counts["AllGather"]["RING"], 10);
+}
+
+TEST(AlgoStatsTest, EmptyDump) {
+  AlgoStats stats(0x9999, "empty_test");
+
+  auto dump = stats.dump();
+
+  EXPECT_EQ(dump.commHash, 0x9999);
+  EXPECT_EQ(dump.commDesc, "empty_test");
+  EXPECT_TRUE(dump.counts.empty());
+}

--- a/comms/ncclx/v2_28/src/include/comm.h
+++ b/comms/ncclx/v2_28/src/include/comm.h
@@ -25,6 +25,7 @@
 #include <optional>
 
 #include "comms/ctran/CtranComm.h"
+#include "comms/utils/colltrace/AlgoStats.h"
 #include "comms/utils/colltrace/CollTraceInterface.h"
 #include "comms/ctran/memory/SlabAllocator.h"
 #include "comms/ctran/memory/memCacheAllocator.h"
@@ -726,6 +727,7 @@ struct ncclComm {
   struct CommLogData logMetaData;
   std::shared_ptr<CollTrace> collTrace;
   std::shared_ptr<meta::comms::colltrace::ICollTrace> newCollTrace;
+  std::unique_ptr<meta::comms::colltrace::AlgoStats> algoStats;
   std::shared_ptr<ctran::bootstrap::IBootstrap> ctranBootstrap;
   std::shared_ptr<ncclx::memory::memCacheAllocator> memCache{nullptr};
   std::vector<std::string> connSetupBufKeys;

--- a/comms/ncclx/v2_28/src/nccl.h.in
+++ b/comms/ncclx/v2_28/src/nccl.h.in
@@ -883,6 +883,17 @@ ncclResult_t ncclCommDumpAll(std::unordered_map<std::string, std::unordered_map<
 #define NCCL_HAS_COMMS_TRACING_SERVICE_PORT
 ncclResult_t ncclCommsTracingServicePort(int& port);
 
+#define NCCL_HAS_DUMP_ALGO_STAT
+namespace ncclx::colltrace {
+
+// Dump collective algorithm statistics for a communicator.
+// Output map format: collective name -> algorithm name -> call count.
+// Requires NCCL_COLLTRACE=algostat to be enabled.
+// Clears and populates the output map. Empty if algostat not enabled or comm is null.
+void dumpAlgoStat(ncclComm_t comm, std::unordered_map<std::string, std::unordered_map<std::string, int64_t>>& map);
+
+} // namespace ncclx::colltrace
+
 namespace ncclx {
 
 /*

--- a/comms/utils/colltrace/AlgoStats.cc
+++ b/comms/utils/colltrace/AlgoStats.cc
@@ -1,0 +1,30 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/utils/colltrace/AlgoStats.h"
+
+namespace meta::comms::colltrace {
+
+void AlgoStats::record(const std::string& opName, const std::string& algoName) {
+  algoCounters_.withWLock(
+      [&](auto& counters) { ++counters[AlgoKey{opName, algoName}]; });
+}
+
+AlgoStatDump AlgoStats::dump() const {
+  AlgoStatDump result;
+  result.commHash = commHash_;
+  result.commDesc = commDesc_;
+
+  algoCounters_.withRLock([&](const auto& counters) {
+    for (const auto& [key, count] : counters) {
+      result.counts[key.first][key.second] = count;
+    }
+  });
+
+  return result;
+}
+
+void AlgoStats::reset() {
+  algoCounters_.withWLock([](auto& counters) { counters.clear(); });
+}
+
+} // namespace meta::comms::colltrace

--- a/comms/utils/colltrace/AlgoStats.h
+++ b/comms/utils/colltrace/AlgoStats.h
@@ -1,0 +1,58 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include <folly/Synchronized.h>
+#include <folly/container/F14Map.h>
+#include <folly/hash/Hash.h>
+
+namespace meta::comms::colltrace {
+
+// Result of algorithm statistics dump, per communicator.
+struct AlgoStatDump {
+  uint64_t commHash{0};
+  std::string commDesc;
+  // Map: collective name -> algorithm name -> call count
+  std::unordered_map<std::string, std::unordered_map<std::string, int64_t>>
+      counts;
+};
+
+// Thread-safe algorithm statistics tracker.
+// Used in "stats" mode of colltrace to count collective calls by algorithm.
+// Each communicator has its own AlgoStats instance.
+class AlgoStats {
+ public:
+  AlgoStats() = default;
+  AlgoStats(uint64_t commHash, const std::string& commDesc)
+      : commHash_(commHash), commDesc_(commDesc) {}
+
+  // Record a collective execution with the given algorithm.
+  // Thread-safe: can be called concurrently from multiple threads.
+  void record(const std::string& opName, const std::string& algoName);
+
+  // Get aggregated counts with communicator info.
+  AlgoStatDump dump() const;
+
+  // Reset all counters to zero.
+  void reset();
+
+ private:
+  uint64_t commHash_{0};
+  std::string commDesc_;
+
+  // Key: (opName, algoName), Value: count
+  using AlgoKey = std::pair<std::string, std::string>;
+  struct AlgoKeyHash {
+    std::size_t operator()(const AlgoKey& key) const noexcept {
+      return folly::hash::hash_combine(key.first, key.second);
+    }
+  };
+
+  folly::Synchronized<folly::F14FastMap<AlgoKey, int64_t, AlgoKeyHash>>
+      algoCounters_;
+};
+
+} // namespace meta::comms::colltrace

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2154,6 +2154,8 @@ cvars:
      of the following features. Leave empty to disable all features.
      verbose - print every completed event as NCCL INFO log. Mostly for debug.
      trace - Just enable collective trace.
+     algostat - lightweight algorithm counting (no CUDA events/worker thread).
+                Use ncclx::colltrace::dumpAlgoStat(comm) to retrieve stats.
 
  - name        : NCCL_COLLTRACE_USE_NEW_COLLTRACE
    type        : bool


### PR DESCRIPTION
Summary:
Add a standalone AlgoStats class that tracks collective algorithm usage without
the overhead of full colltrace (no CUDA events, no worker thread). This enables
lightweight performance monitoring in production.

Key changes:
- Add AlgoStats class in comms/utils/colltrace/ with thread-safe counters
- Add "algostat" mode to NCCL_COLLTRACE that initializes only AlgoStats
- Record algorithm usage in collTraceBaselineGetHandle() when algoStats enabled
- Add public API ncclx::colltrace::dumpAlgoStat(comm, map) in nccl.h with
  NCCL_HAS_DUMP_ALGO_STAT macro for version detection
- Add AlgoStatsTest unit tests
- Refactor CollTraceInitConfigTest to use parameterized tests with EnvRAII
  for cleaner CVAR handling

The algostat mode is independent of verbose/trace modes - it can be used alone
for minimal overhead or combined with other modes.

Usage:
  #ifdef NCCL_HAS_DUMP_ALGO_STAT
  std::unordered_map<std::string, std::unordered_map<std::string, int64_t>> stats;
  ncclx::colltrace::dumpAlgoStat(comm, stats);
  // stats["AllReduce"]["Ring"] == count
  #endif

Differential Revision: D91817144


