### PR TITLE
Log CQ completion errors to scuba

### DIFF
--- a/comms/ncclx/v2_27/src/transport/net_ib.cc
+++ b/comms/ncclx/v2_27/src/transport/net_ib.cc
@@ -2453,7 +2453,7 @@ ncclResult_t ncclIbTest(void* request, int* done, int* sizes) {
 
             char line[SOCKET_NAME_MAXLEN+1];
             char *hcaName = r->devBases[i]->pd->context->device->name;
-            WARN("NET/IB: Got completion from peer %s with status=%d opcode=%d len=%u vendor err %u (%s)%s%s%s%s hca %s",
+            WARN_WITH_SCUBA("NET/IB: Got completion from peer %s with status=%d opcode=%d len=%u vendor err %u (%s)%s%s%s%s hca %s",
                 ncclSocketToString(&addr, line), wc->status, wc->opcode, wc->byte_len, wc->vendor_err, reqTypeStr[r->type],
                 localGidStr ?  " localGid ":"", localGidString, remoteGidStr ? " remoteGids":"", remoteGidString, hcaName);
             return ncclRemoteError;

--- a/comms/ncclx/v2_28/src/transport/net_ib.cc
+++ b/comms/ncclx/v2_28/src/transport/net_ib.cc
@@ -2540,7 +2540,7 @@ ncclResult_t ncclIbTest(void* request, int* done, int* sizes) {
               // For Send use the request size as WC byte_len is not reliable
               reqSize = req->send.size;
             }
-            WARN("NET/IB: Got completion from peer %s with status=%s(%d) opcode=%s(%d) reqSize=%d vendor_err=%u req_type=%s%s%s%s%s hca %s",
+            WARN_WITH_SCUBA("NET/IB: Got completion from peer %s with status=%s(%d) opcode=%s(%d) reqSize=%d vendor_err=%u req_type=%s%s%s%s%s hca %s",
                 ncclSocketToString(&addr, line), ibvWcStatusStr(wc->status), wc->status,
                 ibvWcOpcodeStr(wc->opcode), wc->opcode, reqSize, wc->vendor_err, reqTypeStr[r->type],
                 localGidStr ?  " localGid ":"", localGidString, remoteGidStr ? " remoteGids":"", remoteGidString, hcaName);


### PR DESCRIPTION
Summary:
In current RDMA design, only userspace code (collective library in this case) gets all error notifications from NIC. Most critical events (such as port flaps) are delivered to kernel via async events as well. However, there is some class of events which may also indicate network-related issues, but are reported only via CQ interface.

In addition, userspace code provides all the context required for troubleshooting and localizing such issues - and it is concentrated inside the single log line. CQ error is a critical terminal event which triggers job crash or expensive recovery process, so remote logging should not impose visible overhead here.

Considering the importance of logged data, let's also send it into scuba in order to be able to use it for advanced observability features.

Reviewed By: zhiyongww

Differential Revision: D91788424


