### PR TITLE
Fix flaky BarrierTest by handling duplicate entry points

### DIFF
--- a/comms/torchcomms/__init__.py
+++ b/comms/torchcomms/__init__.py
@@ -69,5 +69,7 @@ def _load_backend(backend: str) -> None:
         raise ModuleNotFoundError(
             f"failed to find backend {backend}, is it registered via entry_points.txt?"
         )
-    (wheel,) = found
+    # Use the first matching entry point - there should only be one, but
+    # duplicates can occur if multiple packages register the same backend
+    wheel = next(iter(found))
     wheel.load()


### PR DESCRIPTION
Summary:
The `_load_backend` function was crashing with `ValueError: too many values
to unpack (expected 1)` when `entry_points()` returned multiple results for
the same backend name. This can happen when multiple packages in a test
binary register the same torchcomms backend entry point.

Changed from tuple unpacking `(wheel,) = found` to `wheel = next(iter(found))`
to gracefully handle this case by using the first matching entry point.

Fixes T253323758

Differential Revision: D91865034


