### PR TITLE
Add dual-chunkstate mode to P2P transport for local busy-polling - up to 5% busbw gain in pipes SendRecv bench (#508)

### DIFF
--- a/comms/ctran/algos/CtranAlgo.cc
+++ b/comms/ctran/algos/CtranAlgo.cc
@@ -365,13 +365,13 @@ commResult_t CtranAlgo::initKernelResources() {
 
     comms::pipes::LocalState localState{
         .dataBuffer = static_cast<char*>(devState_.localStagingBufsMap[peer]),
-        .stateBuffer = DeviceSpan<ChunkState>(
+        .receiverStateBuffer = DeviceSpan<ChunkState>(
             static_cast<ChunkState*>(devState_.localChunkStatesMap[peer]),
             CTRAN_P2P_NVL_DEVMEM_MAX_CHUNKS)};
 
     comms::pipes::RemoteState remoteState{
         .dataBuffer = static_cast<char*>(devState_.remoteStagingBufsMap[peer]),
-        .stateBuffer = DeviceSpan<ChunkState>(
+        .receiverStateBuffer = DeviceSpan<ChunkState>(
             static_cast<ChunkState*>(devState_.remoteChunkStatesMap[peer]),
             CTRAN_P2P_NVL_DEVMEM_MAX_CHUNKS)};
 

--- a/comms/ctran/algos/SendRecv/SendRecvP2p.cu
+++ b/comms/ctran/algos/SendRecv/SendRecvP2p.cu
@@ -34,7 +34,7 @@ __device__ __forceinline__ void recvImpl(
   }
 }
 
-__global__ void ncclKernelSendRecvP2p(
+__global__ __launch_bounds__(512, 1) void ncclKernelSendRecvP2p(
     int* flag,
     CtranAlgoDeviceState* devState, // TODO: this is not needed for now, but
                                     // maybe needed for fault-tolerance

--- a/comms/pipes/ChunkState.cuh
+++ b/comms/pipes/ChunkState.cuh
@@ -23,23 +23,43 @@ struct ThreadGroup;
  *
  * STATES:
  * =======
- *   READY_TO_SEND (-1) : Buffer is empty, sender can write
+ *   READY_TO_SEND (-1) : Buffer is ready for sender to write
  *   READY_TO_RECV (N)  : Buffer has data from step N, receiver can read
+ *   UNREADY (-2)       : Buffer is in transition (local-only, group-visible)
  *
- * STATE MACHINE:
- * ==============
+ * STATE MACHINE (Single State Mode):
+ * ==================================
  *                      ready_to_recv(stepId)
  *    ┌───────────────┐ ─────────────────────▶ ┌───────────────┐
  *    │ READY_TO_SEND │                        │ READY_TO_RECV │
  *    │     (-1)      │ ◀───────────────────── │   (stepId)    │
  *    └───────────────┘      ready_to_send()   └───────────────┘
  *
- * SENDER WORKFLOW:
+ * STATE MACHINE (Dual State Mode - senderStateBuffer):
+ * ====================================================
+ *   init: READY_TO_SEND (-1)
+ *                        unready()
+ *    ┌───────────────┐ ─────────────────────▶ ┌───────────────┐
+ *    │ READY_TO_SEND │                        │   UNREADY     │
+ *    │     (-1)      │ ◀───────────────────── │    (-2)       │
+ *    └───────────────┘   ready_to_send()      └───────────────┘
+ *                        (from receiver)
+ *
+ * STATE MACHINE (Dual State Mode - receiverStateBuffer):
+ * ======================================================
+ *   init: UNREADY (-2)
+ *                      ready_to_recv(stepId)
+ *    ┌───────────────┐ ─────────────────────▶ ┌───────────────┐
+ *    │   UNREADY     │                        │ READY_TO_RECV │
+ *    │    (-2)       │ ◀───────────────────── │   (stepId)    │
+ *    └───────────────┘       unready()        └───────────────┘
+ *
+ * SENDER WORKFLOW (Single State):
  *   1. wait_ready_to_send()      - Block until state == READY_TO_SEND
  *   2. [copy data to buffer]
  *   3. ready_to_recv(stepId)    - Transition to READY_TO_RECV
  *
- * RECEIVER WORKFLOW:
+ * RECEIVER WORKFLOW (Single State):
  *   1. wait_ready_to_recv(stepId) - Block until state == stepId
  *   2. [copy data from buffer]
  *   3. ready_to_send()           - Transition to READY_TO_SEND
@@ -56,6 +76,7 @@ struct ThreadGroup;
  */
 struct alignas(128) ChunkState {
   static constexpr int32_t READY_TO_SEND = -1;
+  static constexpr int32_t UNREADY = -2;
 
   int32_t value_; // 4 bytes - sync state (stepId or READY_TO_SEND)
   char padding_[128 - sizeof(int32_t)]{};
@@ -121,6 +142,25 @@ struct alignas(128) ChunkState {
    * @param group ThreadGroup for cooperative processing
    */
   __device__ __forceinline__ void ready_to_send(ThreadGroup& group);
+
+  /**
+   * unready - Mark chunk state as UNREADY (local-only, group-visible)
+   *
+   * Sets the state to UNREADY (-2) using a plain write (not release-store).
+   * This is faster than release-store but only guarantees visibility within
+   * the same thread group after group.sync().
+   *
+   * USAGE: Called by sender after send and before signaling receiver,
+   * or by receiver after read and before signaling sender. This prevents
+   * the same side from re-executing before the other side has completed.
+   *
+   * REQUIRES: Caller must use for_each_item_strided to ensure the same
+   * chunk is always assigned to the same thread group. Without this,
+   * the UNREADY write may not be visible to other groups.
+   *
+   * @param group ThreadGroup for cooperative processing
+   */
+  __device__ __forceinline__ void unready(ThreadGroup& group);
 
  private:
   __device__ __forceinline__ int32_t load() const {
@@ -191,6 +231,13 @@ __device__ __forceinline__ void ChunkState::ready_to_send(ThreadGroup& group) {
   group.sync();
   if (group.is_leader()) {
     store(READY_TO_SEND);
+  }
+}
+
+__device__ __forceinline__ void ChunkState::unready(ThreadGroup& group) {
+  group.sync();
+  if (group.is_leader()) {
+    value_ = UNREADY;
   }
 }
 

--- a/comms/pipes/MultiPeerNvlTransport.cc
+++ b/comms/pipes/MultiPeerNvlTransport.cc
@@ -48,11 +48,21 @@ MultiPeerNvlTransport::MultiPeerNvlTransport(
   // When dataBufferSize=0, skip allocation — put() works without staging.
   if (config_.dataBufferSize > 0) {
     // Calculate state buffer size based on chunk size and pipeline depth
+    // Single state mode (useDualStateBuffer=false):
+    //   - 1 chunk state per chunk, stored on receiver side only
+    // Dual state mode (useDualStateBuffer=true):
+    //   - 2 chunk states per chunk:
+    //     - First half [0, numChunksPerPeer): my chunk state (local operations)
+    //     - Second half [numChunksPerPeer, 2*numChunksPerPeer): peer's chunk
+    //     state
+    //       (stored locally for local polling)
     const std::size_t numChunksPerStep =
         (config_.dataBufferSize + config_.chunkSize - 1) / config_.chunkSize;
     const std::size_t numChunksPerPeer =
         config_.pipelineDepth * numChunksPerStep;
-    perPeerChunkStateBufferSize_ = numChunksPerPeer * sizeof(ChunkState);
+    const std::size_t chunkStateMultiplier = config_.useDualStateBuffer ? 2 : 1;
+    perPeerChunkStateBufferSize_ =
+        chunkStateMultiplier * numChunksPerPeer * sizeof(ChunkState);
 
     // Allocate buffers for (nRanks - 1) peers using GpuMemHandler
     const std::size_t totalDataBufferSize =
@@ -71,9 +81,13 @@ MultiPeerNvlTransport::MultiPeerNvlTransport(
         memSharingMode_);
 
     // Initialize state buffer to READY_TO_SEND for all pipeline slots
+    // The number of states depends on useDualStateBuffer:
+    // - Single mode: 1x chunk states (only receiverStateBuffer)
+    // - Dual mode: 2x chunk states (receiverStateBuffer + senderStateBuffer)
     auto statePtr =
         static_cast<ChunkState*>(stateBufferHandler_->getLocalDeviceMemPtr());
-    const std::size_t totalNumChunksAllPeers = numChunksPerPeer * (nRanks_ - 1);
+    const std::size_t totalNumChunksAllPeers =
+        chunkStateMultiplier * numChunksPerPeer * (nRanks_ - 1);
     std::vector<ChunkState> initStates(totalNumChunksAllPeers);
     CUDA_CHECK(cudaMemcpy(
         statePtr,
@@ -147,7 +161,8 @@ P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
   P2pNvlTransportOptions options{
       .dataBufferSize = config_.dataBufferSize,
       .chunkSize = config_.chunkSize,
-      .pipelineDepth = config_.pipelineDepth};
+      .pipelineDepth = config_.pipelineDepth,
+      .useDualStateBuffer = config_.useDualStateBuffer};
 
   auto* localSignalPtr =
       static_cast<char*>(signalBufferHandler_->getLocalDeviceMemPtr());
@@ -167,12 +182,14 @@ P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
   if (!dataBufferHandler_ || !stateBufferHandler_) {
     LocalState localState{
         .dataBuffer = nullptr,
-        .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+        .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+        .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
         .signalBuffer = localSignalSpan,
     };
     RemoteState remoteState{
         .dataBuffer = nullptr,
-        .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+        .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+        .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
         .signalBuffer = remoteSignalSpan,
     };
     return P2pNvlTransportDevice(
@@ -189,31 +206,76 @@ P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
   auto* localStatePtr =
       static_cast<char*>(stateBufferHandler_->getLocalDeviceMemPtr());
 
+  auto* localChunkStateBase = reinterpret_cast<ChunkState*>(
+      localStatePtr + localChunkStateBufferOffset);
+
   auto* remoteDataPtr =
       static_cast<char*>(dataBufferHandler_->getPeerDeviceMemPtr(peerRank));
   auto* remoteChunkStatePtr =
       static_cast<char*>(stateBufferHandler_->getPeerDeviceMemPtr(peerRank));
 
-  LocalState localState{
-      .dataBuffer = localDataPtr + localDataBufferOffset,
-      .stateBuffer = DeviceSpan<ChunkState>(
-          reinterpret_cast<ChunkState*>(
-              localStatePtr + localChunkStateBufferOffset),
-          numChunksPerPeer),
-      .signalBuffer = localSignalSpan,
-  };
+  auto* remoteChunkStateBase = reinterpret_cast<ChunkState*>(
+      remoteChunkStatePtr + remoteChunkStateBufferOffset);
 
-  RemoteState remoteState{
-      .dataBuffer = remoteDataPtr + remoteDataBufferOffset,
-      .stateBuffer = DeviceSpan<ChunkState>(
-          reinterpret_cast<ChunkState*>(
-              remoteChunkStatePtr + remoteChunkStateBufferOffset),
-          numChunksPerPeer),
-      .signalBuffer = remoteSignalSpan,
-  };
+  // Create LocalState and RemoteState based on useDualStateBuffer mode
+  // Note: Using direct initialization since DeviceSpan has const members
+  // that prevent copy-assignment
+  if (config_.useDualStateBuffer) {
+    // Dual state mode: 2x chunk states per peer
+    //   Local buffer layout:
+    //     [0, numChunksPerPeer): receiver state buffer (state to poll if
+    //     I am a receiver)
+    //     [numChunksPerPeer, 2*numChunksPerPeer): sender state buffer
+    //     (state to poll if I am a sender)
+    //   Remote buffer layout (on peer's memory via NVLink):
+    //     [0, numChunksPerPeer): peer's receiver state buffer (I write to
+    //     signal data ready)
+    //     [numChunksPerPeer, 2*numChunksPerPeer): peer's sender state buffer
+    //     (I write READY_TO_SEND after reading)
+    LocalState localState{
+        .dataBuffer = localDataPtr + localDataBufferOffset,
+        .receiverStateBuffer =
+            DeviceSpan<ChunkState>(localChunkStateBase, numChunksPerPeer),
+        .senderStateBuffer = DeviceSpan<ChunkState>(
+            localChunkStateBase + numChunksPerPeer, numChunksPerPeer),
+        .signalBuffer = localSignalSpan,
+    };
 
-  return P2pNvlTransportDevice(
-      myRank_, peerRank, options, localState, remoteState);
+    RemoteState remoteState{
+        .dataBuffer = remoteDataPtr + remoteDataBufferOffset,
+        .receiverStateBuffer =
+            DeviceSpan<ChunkState>(remoteChunkStateBase, numChunksPerPeer),
+        .senderStateBuffer = DeviceSpan<ChunkState>(
+            remoteChunkStateBase + numChunksPerPeer, numChunksPerPeer),
+        .signalBuffer = remoteSignalSpan,
+    };
+
+    return P2pNvlTransportDevice(
+        myRank_, peerRank, options, localState, remoteState);
+  } else {
+    // Single state mode: 1x chunk state per peer (on receiver side only)
+    //   Local buffer: only receiverStateBuffer is used (receiver waits here)
+    //   Remote buffer: only receiverStateBuffer is used (points to peer's
+    //   receiverStateBuffer, sender writes to signal data ready)
+    LocalState localState{
+        .dataBuffer = localDataPtr + localDataBufferOffset,
+        .receiverStateBuffer =
+            DeviceSpan<ChunkState>(localChunkStateBase, numChunksPerPeer),
+        .senderStateBuffer = DeviceSpan<ChunkState>(), // Not used
+        .signalBuffer = localSignalSpan,
+    };
+
+    RemoteState remoteState{
+        .dataBuffer = remoteDataPtr + remoteDataBufferOffset,
+        .receiverStateBuffer =
+            DeviceSpan<ChunkState>(remoteChunkStateBase, numChunksPerPeer),
+        .senderStateBuffer = DeviceSpan<ChunkState>(), // Not used
+        .signalBuffer = remoteSignalSpan,
+    };
+
+    return P2pNvlTransportDevice(
+        myRank_, peerRank, options, localState, remoteState);
+  }
 }
 
 DeviceSpan<Transport> MultiPeerNvlTransport::getDeviceTransports() {

--- a/comms/pipes/MultiPeerNvlTransport.h
+++ b/comms/pipes/MultiPeerNvlTransport.h
@@ -44,6 +44,38 @@ struct MultiPeerNvlTransportConfig {
   // This is separate from WindowConfig.peerSignalCount (inbox model).
   // Typical: 1-num of blocks for most workloads.
   std::size_t p2pSignalCount{1};
+
+  // If true, use dual chunk state buffers (one on each side) for local polling
+  // on both sender and receiver. If false (default), use single chunk state
+  // buffer on receiver side only.
+  //
+  // Single State Mode (default):
+  //   - 1 ChunkState per chunk, stored on receiver side
+  //   - Sender polls over NVLink (slower), receiver polls locally (faster)
+  //   - Lower memory usage
+  //
+  // Dual State Mode:
+  //   - 2 ChunkStates per chunk: receiverState (for data-ready signal),
+  //     senderState (for ready-to-send signal)
+  //   - Both sender and receiver poll locally (faster on both sides)
+  //   - Higher memory usage, better performance for high-throughput workloads
+  //
+  // DUAL STATE MODE - STATE MACHINE:
+  //   Sender: poll local senderState for READY_TO_SEND → send data →
+  //           mark local senderState as UNREADY → signal receiver's
+  //           receiverState
+  //   Receiver: poll local receiverState for stepId → read data →
+  //           mark local receiverState as UNREADY → signal sender's senderState
+  //                                                  as READY_TO_SEND
+  //
+  // DUAL STATE MODE - STRIDED CHUNK ASSIGNMENT REQUIREMENT:
+  //   Dual state mode MUST use for_each_item_strided for chunk
+  //   distribution. The UNREADY state uses plain write + group.sync() for
+  //   efficiency (st.release.gpu is too slow). This write is only visible
+  //   within the same thread group. Strided ensures chunk K is ALWAYS
+  //   assigned to group (K % total_groups), making the unready write visible
+  //   after group.sync().
+  bool useDualStateBuffer{false};
 };
 
 /**

--- a/comms/pipes/P2pNvlTransportDevice.cuh
+++ b/comms/pipes/P2pNvlTransportDevice.cuh
@@ -1,10 +1,10 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
-
 #pragma once
 
 #include <cuda.h>
 #include <cuda_runtime.h>
 #include <cstddef>
+#include <cstring>
 #include "comms/pipes/BarrierState.cuh"
 #include "comms/pipes/ChunkState.cuh"
 #include "comms/pipes/CopyUtils.cuh"
@@ -23,10 +23,27 @@ namespace comms::pipes {
  * - Receiver reads from LocalState (own local buffers)
  *
  * This means LocalState buffers are the DESTINATION for incoming data.
+ *
+ * Chunk state buffers (usage depends on useDualStateBuffer option):
+ *
+ * SINGLE STATE MODE (useDualStateBuffer=false):
+ *   - Only receiverStateBuffer is used
+ *   - receiverStateBuffer: State to poll if I am a receiver
+ *     - Sender signals data ready via NVLink write
+ *     - Receiver waits locally, then signals ready-to-send locally
+ *   - senderStateBuffer: Not used (empty span)
+ *
+ * DUAL STATE MODE (useDualStateBuffer=true):
+ *   - Both buffers are used for fully local polling
+ *   - receiverStateBuffer: State to poll if I am a receiver (peer writes
+ *     via NVLink to signal data ready)
+ *   - senderStateBuffer: State to poll if I am a sender (peer writes
+ *     via NVLink to signal ready-to-send after reading)
  */
 struct LocalState {
   char* dataBuffer;
-  DeviceSpan<ChunkState> stateBuffer;
+  DeviceSpan<ChunkState> receiverStateBuffer;
+  DeviceSpan<ChunkState> senderStateBuffer;
   DeviceSpan<SignalState> signalBuffer;
   DeviceSpan<BarrierState> barrierBuffer;
 };
@@ -39,10 +56,26 @@ struct LocalState {
  * - This allows receiver to read from local memory (faster)
  *
  * These pointers are obtained via IPC and point to peer's LocalState buffers.
+ *
+ * Chunk state buffers (usage depends on useDualStateBuffer option):
+ *
+ * SINGLE STATE MODE (useDualStateBuffer=false):
+ *   - Only receiverStateBuffer is used (points to peer's receiverStateBuffer)
+ *   - receiverStateBuffer: State to signal if I am a sender (I write via
+ *     NVLink to signal data ready, or I wait via NVLink for ack)
+ *   - senderStateBuffer: Not used (empty span)
+ *
+ * DUAL STATE MODE (useDualStateBuffer=true):
+ *   - Both buffers are used for fully local polling
+ *   - receiverStateBuffer: State to signal if I am a sender (I write via
+ *     NVLink to signal data ready to peer's receiver)
+ *   - senderStateBuffer: State to signal if I am a receiver (I write via
+ *     NVLink to signal ready-to-send to peer's sender after reading)
  */
 struct RemoteState {
   char* dataBuffer;
-  DeviceSpan<ChunkState> stateBuffer;
+  DeviceSpan<ChunkState> receiverStateBuffer;
+  DeviceSpan<ChunkState> senderStateBuffer;
   DeviceSpan<SignalState> signalBuffer;
   DeviceSpan<BarrierState> barrierBuffer;
 };
@@ -55,13 +88,44 @@ struct RemoteState {
  * transfer)
  * - chunkSize: Size of each chunk for parallel processing
  * - pipelineDepth: Number of buffer slots for pipelining (typically 2-8)
+ * - useDualStateBuffer: If true, use dual chunk state buffers (one on each
+ *   side) for local polling on both sender and receiver. If false (default),
+ *   use single chunk state buffer on receiver side only.
  *
  * Total memory allocated = pipelineDepth × dataBufferSize
+ *
+ * STATE BUFFER MODES:
+ * ===================
+ * Single State (useDualStateBuffer=false, default):
+ *   - 1 ChunkState per chunk, stored on receiver side
+ *   - Sender polls over NVLink (slower), receiver polls locally (faster)
+ *   - Lower memory usage
+ *
+ * Dual State (useDualStateBuffer=true):
+ *   - 2 ChunkStates per chunk: one on receiver (receiverStateBuffer for data
+ *     ready signal), one on sender (senderStateBuffer for ready-to-send signal)
+ *   - Both sender and receiver poll locally (faster on both sides)
+ *   - Higher memory usage, better performance for high-throughput workloads
+ *   - REQUIRES for_each_item_strided for chunk distribution (see below)
+ *
+ * DUAL STATE MODE - STRIDED CHUNK ASSIGNMENT:
+ * ===========================================
+ * Dual state mode MUST use for_each_item_strided to ensure each chunk is
+ * always assigned to the same thread group within a kernel. This is required
+ * because:
+ *   - ChunkState.unready() uses a plain write with group-wise sync for
+ *     efficiency (st.release.gpu is too slow)
+ *   - This plain write from one group may not be visible to other groups
+ *     without expensive global memory barriers
+ *   - With strided assignment, chunk K is ALWAYS assigned to group
+ *     (K % total_groups), so the unready write is visible to the same group
+ *     after group.sync()
  */
 struct P2pNvlTransportOptions {
   std::size_t dataBufferSize;
   std::size_t chunkSize;
   std::size_t pipelineDepth;
+  bool useDualStateBuffer{false}; // Default to single state buffer mode
 };
 
 /**
@@ -175,38 +239,56 @@ struct P2pNvlTransportOptions {
  *   - Receiver warp can process a chunk as soon as sender warp signals it
  *   - Contiguous chunk assignment → good cache locality per warp
  *
- * STATE MACHINE (per chunk)
- * =========================
+ * STATE MACHINE (per chunk) - DUAL CHUNK STATE
+ * =============================================
  *
- * State lives in RECEIVER's local memory. Both GPUs access it:
- * - Sender accesses via NVLink (remote)
- * - Receiver accesses locally (fast)
+ * With dual chunk states, ALL waits are local (no NVLink polling):
+ * - Each GPU has two state buffers per peer:
+ *   1. receiverStateBuffer: State to poll if I am a receiver (peer writes
+ *      here to signal data ready)
+ *   2. senderStateBuffer: State to poll if I am a sender (peer writes here
+ *      to signal ready-to-send after reading)
  *
- *        ┌───────────────┐
- * init → │ READY_TO_SEND │
- *        │     (-1)      │
- *        └───────┬───────┘
- *                │
- *                │ send() waits for READY_TO_SEND, copies data,
- *                │ signals ready_to_recv(stepId)
- *                ▼
- *        ┌───────────────┐
- *    ┌─▶ │ READY_TO_RECV │
- *    │   │   (stepId)    │
- *    │   └───────┬───────┘
- *    │           │
- *    │           │ recv() waits for READY_TO_RECV, copies data,
- *    │           │ signals ready_to_send()
- *    │           ▼
- *    │   ┌───────────────┐
- *    │   │ READY_TO_SEND │
- *    │   │     (-1)      │
- *    │   └───────┬───────┘
- *    │           │
- *    │           │ send() waits for READY_TO_SEND, copies data,
- *    │           │ signals ready_to_recv(stepId)
- *    │           │
- *    └───────────┘
+ * SENDER (GPU A) FLOW:
+ * ====================
+ * 1. Wait LOCAL: localState_.senderStateBuffer for READY_TO_SEND
+ *    - Polls locally for receiver's ready-to-send signal
+ * 2. Copy data to remoteState_.dataBuffer (NVLink write)
+ * 3. Mark LOCAL senderState as UNREADY to prevent re-sending before
+ *    receiver reads (plain write + group sync)
+ * 4. Signal REMOTE: remoteState_.receiverStateBuffer = stepId
+ *    (This is peer's localState_.receiverStateBuffer)
+ *
+ * RECEIVER (GPU B) FLOW:
+ * ======================
+ * 1. Wait LOCAL: localState_.receiverStateBuffer for stepId
+ * 2. Copy data from localState_.dataBuffer (local read)
+ * 3. Mark LOCAL receiverState as UNREADY to prevent re-reading before
+ *    sender writes next (plain write + group sync)
+ * 4. Signal REMOTE: remoteState_.senderStateBuffer = READY_TO_SEND
+ *    (This is peer's localState_.senderStateBuffer - sender can send again)
+ *
+ * STATE TRANSITIONS (per pipeline slot):
+ * ======================================
+ *
+ * localState_.senderStateBuffer (sender waits here):
+ *   init: READY_TO_SEND (-1)
+ *   After sender sends: UNREADY (-2) (prevents re-send before receiver reads)
+ *   After receiver reads: READY_TO_SEND (-1) (sender can send again)
+ *
+ * localState_.receiverStateBuffer (receiver waits here):
+ *   init: UNREADY (-2) (no data)
+ *   After sender writes: stepId (data ready)
+ *   After receiver reads: UNREADY (-2) (prevents re-read before next write)
+ *
+ * WHY STRIDED CHUNK ASSIGNMENT:
+ * =============================
+ * The UNREADY state uses a plain write + group.sync() for efficiency
+ * (st.release.gpu is too slow). This plain write is only visible to
+ * the same thread group after group.sync(), not to other groups.
+ * By using for_each_item_strided, chunk K is ALWAYS assigned to
+ * group (K % total_groups), ensuring the unready write is visible
+ * to the same group in subsequent iterations.
  *
  * CHUNK DISTRIBUTION
  * ==================
@@ -243,8 +325,9 @@ struct P2pNvlTransportOptions {
  */
 class P2pNvlTransportDevice {
  public:
-  __host__ __device__ P2pNvlTransportDevice() = default;
-  __host__ __device__ P2pNvlTransportDevice(
+  __host__ P2pNvlTransportDevice() = default;
+
+  __host__ P2pNvlTransportDevice(
       int myRank,
       int peerRank,
       const P2pNvlTransportOptions& options,
@@ -324,13 +407,10 @@ class P2pNvlTransportDevice {
     }
     char* src = reinterpret_cast<char*>(srcbuff);
 
-    // REMOTE-WRITE PATTERN:
-    // Sender writes data directly to RECEIVER's local buffer via NVLink.
-    // Benefits: Receiver reads from local memory (faster read, no NVLink hop)
-    // Trade-off: Sender's copy goes over NVLink
     char* sendBuffer = remoteState_.dataBuffer;
-    // Extract raw pointer to avoid aliasing issues (see DeviceSpan.cuh).
-    ChunkState* const sendStates = remoteState_.stateBuffer.data();
+    // Remote signal buffer: peer's receiverStateBuffer (NVLink write)
+    ChunkState* const remoteReceiverStates =
+        remoteState_.receiverStateBuffer.data();
 
     const std::size_t totalSteps =
         (nbytes + options_.dataBufferSize - 1) / options_.dataBufferSize;
@@ -338,43 +418,202 @@ class P2pNvlTransportDevice {
     const std::size_t chunksPerStep =
         (options_.dataBufferSize + kChunkSize - 1) / kChunkSize;
 
-    for (std::size_t stepId = 0; stepId < totalSteps; ++stepId) {
-      // Calculate pipeline slot index for this step
-      const std::size_t pipelineIdx = stepId % options_.pipelineDepth;
-      const std::size_t dataBufferOffset =
-          pipelineIdx * options_.dataBufferSize;
-      const std::size_t stateOffset = pipelineIdx * chunksPerStep;
+    if (options_.useDualStateBuffer) {
+      // =====================================================================
+      // DUAL CHUNK STATE MODE
+      // =====================================================================
+      // Uses two ChunkState buffers per peer to enable local polling:
+      //   - receiverStateBuffer: State to poll if I am a receiver (sender
+      //     writes via NVLink to signal data ready)
+      //   - senderStateBuffer: State to poll if I am a sender (receiver
+      //     signals via NVLink when ready-to-send after reading)
+      //
+      // STATE MACHINE (per chunk, showing sync points):
+      //   ┌──────────────────────────────────────────────────────────────────┐
+      //   │ SENDER (this side)              RECEIVER (peer side)            │
+      //   ├──────────────────────────────────────────────────────────────────┤
+      //   │ 1. Wait LOCAL senderState       1. Wait LOCAL receiverState     │
+      //   │    for READY_TO_SEND               for currentStep value        │
+      //   │    (ld.acquire.sys.global)         (ld.acquire.sys.global)      │
+      //   │                                                                  │
+      //   │ 2. Copy data to peer buffer     2. Copy data from local buffer  │
+      //   │    via NVLink                      (no NVLink needed)           │
+      //   │                                                                  │
+      //   │    ─── group.sync() [inside unready()] ───                      │
+      //   │ 3. Mark LOCAL senderState       3. Mark LOCAL receiverState     │
+      //   │    as UNREADY (plain write)        as UNREADY (plain write)     │
+      //   │                                                                  │
+      //   │    ─── group.sync() [inside ready_to_recv/send()] ───           │
+      //   │ 4. Signal REMOTE peer via       4. Signal REMOTE sender via     │
+      //   │    NVLink st.release.sys to        NVLink st.release.sys        │
+      //   │    receiverState (stepId)          READY_TO_SEND to senderState │
+      //   └──────────────────────────────────────────────────────────────────┘
+      //
+      // KEY INSIGHT: Both sender and receiver poll LOCAL memory, avoiding
+      // expensive NVLink round-trips for busy-wait synchronization.
+      //
+      // FORMAL CORRECTNESS — WHY TWO group.sync() CALLS ARE REQUIRED:
+      // =============================================================
+      //
+      // The two syncs (one in unready(), one in ready_to_recv/send()) serve
+      // different purposes and both are necessary:
+      //
+      // Sync #1 (inside unready(), before plain write):
+      //   Ensures all threads have finished their memcpy before the leader
+      //   writes UNREADY. Without this, some threads may stuck at
+      //   wait_ready_to_send().
+      //
+      // Sync #2 (inside ready_to_recv/send(), before release store):
+      //   Ensures all threads in the group observe the UNREADY plain write
+      //   before the leader does st.release.sys.global to the REMOTE state.
+      //   This is critical because:
+      //
+      //   - unready() writes value_ = UNREADY via a plain store (not
+      //     st.release.sys), so it is only guaranteed visible to threads
+      //     that participate in a subsequent group.sync().
+      //
+      //   - Without sync #2, a non-leader thread could loop back to
+      //     wait_ready_to_send() and do ld.acquire.sys.global on the LOCAL
+      //     senderState. This acquire load has NO acquire-release pair with
+      //     the plain write — they are on the SAME address but the write is
+      //     plain, not a release store. Nor does it pair with the release
+      //     store in ready_to_recv(), which writes to a DIFFERENT address
+      //     (the REMOTE receiverState). So the acquire load could return
+      //     the stale READY_TO_SEND value, causing the thread to re-enter
+      //     memcpy before the peer has consumed the previous data.
+      //
+      //   - sync #2 (__syncthreads) acts as a memory fence that makes the
+      //     UNREADY plain write visible to all threads in the group,
+      //     preventing them from seeing stale READY_TO_SEND.
+      //
+      // STRIDED ASSIGNMENT: Uses for_each_item_strided to ensure
+      // each chunk is always assigned to the same thread group. This is
+      // required because unready() uses plain write + group.sync() (not
+      // st.release.sys), which is only visible within the same group.
+      // =====================================================================
+      ChunkState* const localSenderStates =
+          localState_.senderStateBuffer.data();
 
-      const std::size_t stepOffset = stepId * options_.dataBufferSize;
-      const std::size_t stepBytes =
-          (stepOffset + options_.dataBufferSize <= nbytes)
-          ? options_.dataBufferSize
-          : nbytes - stepOffset;
-      const std::size_t numChunksThisStep =
-          (stepBytes + kChunkSize - 1) / kChunkSize;
+      for (std::size_t stepId = 0; stepId < totalSteps; ++stepId) {
+        const std::size_t pipelineIdx = stepId % options_.pipelineDepth;
+        const std::size_t dataBufferOffset =
+            pipelineIdx * options_.dataBufferSize;
+        const std::size_t stateOffset = pipelineIdx * chunksPerStep;
 
-      group.for_each_item_contiguous(numChunksThisStep, [&](uint32_t chunkIdx) {
-        const std::size_t chunkOffset = chunkIdx * kChunkSize;
-        const std::size_t chunkBytes = (chunkOffset + kChunkSize <= stepBytes)
-            ? kChunkSize
-            : stepBytes - chunkOffset;
+        const std::size_t stepOffset = stepId * options_.dataBufferSize;
+        const std::size_t stepBytes =
+            (stepOffset + options_.dataBufferSize <= nbytes)
+            ? options_.dataBufferSize
+            : nbytes - stepOffset;
+        const std::size_t numChunksThisStep =
+            (stepBytes + kChunkSize - 1) / kChunkSize;
 
-        if (chunkBytes == 0) {
-          return;
-        }
+        group.for_each_item_strided(numChunksThisStep, [&](uint32_t chunkIdx) {
+          const std::size_t chunkOffset = chunkIdx * kChunkSize;
+          const std::size_t chunkBytes = (chunkOffset + kChunkSize <= stepBytes)
+              ? kChunkSize
+              : stepBytes - chunkOffset;
 
-        ChunkState& chunkState = sendStates[stateOffset + chunkIdx];
+          if (chunkBytes == 0) {
+            return;
+          }
 
-        chunkState.wait_ready_to_send(group, timeout);
+          const std::size_t chunkStateIdx = stateOffset + chunkIdx;
 
-        memcpy_vectorized(
-            sendBuffer + dataBufferOffset + chunkOffset,
-            src + stepOffset + chunkOffset,
-            chunkBytes,
-            group);
+          // Wait on LOCAL senderStateBuffer for ready-to-send signal
+          // (fast local poll - receiver signals when done reading)
+          ChunkState& localSenderState = localSenderStates[chunkStateIdx];
 
-        chunkState.ready_to_recv(group, stepId);
-      });
+          localSenderState.wait_ready_to_send(group, timeout);
+
+          // Copy data to peer's buffer via NVLink
+          memcpy_vectorized(
+              sendBuffer + dataBufferOffset + chunkOffset,
+              src + stepOffset + chunkOffset,
+              chunkBytes,
+              group);
+
+          // Sync #1 + plain write: barrier all threads, then leader
+          // writes UNREADY to local senderState (see correctness note above)
+          localSenderState.unready(group);
+
+          // Sync #2 + release store: barrier all threads (flushes the
+          // UNREADY plain write), then leader does st.release.sys.global
+          // to peer's receiverState via NVLink (see correctness note above)
+          ChunkState& remoteReceiverState = remoteReceiverStates[chunkStateIdx];
+          remoteReceiverState.ready_to_recv(group, stepId);
+        });
+      }
+    } else {
+      // =====================================================================
+      // SINGLE CHUNK STATE MODE (Original Design)
+      // =====================================================================
+      // Uses one ChunkState buffer per peer (simpler but more NVLink latency):
+      //   - receiverStateBuffer: Both wait and signal happen here via NVLink
+      //
+      // STATE MACHINE (per chunk):
+      //   ┌──────────────────────────────────────────────────────────────────┐
+      //   │ SENDER (this side)              RECEIVER (peer side)            │
+      //   ├──────────────────────────────────────────────────────────────────┤
+      //   │ 1. Wait REMOTE receiverState    1. Wait LOCAL receiverState     │
+      //   │    for READY_TO_SEND (-1)          for stepId value             │
+      //   │    (NVLink round-trip)             (fast local poll)            │
+      //   │                                                                  │
+      //   │ 2. Copy data to peer buffer     2. Copy data from local buffer  │
+      //   │    via NVLink                      (no NVLink needed)           │
+      //   │                                                                  │
+      //   │ 3. Signal peer via NVLink       3. Signal LOCAL receiverState   │
+      //   │    write with stepId               with READY_TO_SEND (-1)      │
+      //   └──────────────────────────────────────────────────────────────────┘
+      //
+      // TRADE-OFF: Simpler (no call_index tracking needed) but sender's
+      // busy-wait polls remote memory via NVLink, adding latency.
+      // =====================================================================
+
+      for (std::size_t stepId = 0; stepId < totalSteps; ++stepId) {
+        const std::size_t pipelineIdx = stepId % options_.pipelineDepth;
+        const std::size_t dataBufferOffset =
+            pipelineIdx * options_.dataBufferSize;
+        const std::size_t stateOffset = pipelineIdx * chunksPerStep;
+
+        const std::size_t stepOffset = stepId * options_.dataBufferSize;
+        const std::size_t stepBytes =
+            (stepOffset + options_.dataBufferSize <= nbytes)
+            ? options_.dataBufferSize
+            : nbytes - stepOffset;
+        const std::size_t numChunksThisStep =
+            (stepBytes + kChunkSize - 1) / kChunkSize;
+
+        group.for_each_item_contiguous(
+            numChunksThisStep, [&](uint32_t chunkIdx) {
+              const std::size_t chunkOffset = chunkIdx * kChunkSize;
+              const std::size_t chunkBytes =
+                  (chunkOffset + kChunkSize <= stepBytes)
+                  ? kChunkSize
+                  : stepBytes - chunkOffset;
+
+              if (chunkBytes == 0) {
+                return;
+              }
+
+              const std::size_t chunkStateIdx = stateOffset + chunkIdx;
+
+              // Wait on REMOTE receiverStateBuffer via NVLink (slower)
+              ChunkState& remoteReceiverState =
+                  remoteReceiverStates[chunkStateIdx];
+              remoteReceiverState.wait_ready_to_send(group, timeout);
+
+              // Copy data to peer's buffer via NVLink
+              memcpy_vectorized(
+                  sendBuffer + dataBufferOffset + chunkOffset,
+                  src + stepOffset + chunkOffset,
+                  chunkBytes,
+                  group);
+
+              // Signal peer's receiverStateBuffer via NVLink write
+              remoteReceiverState.ready_to_recv(group, stepId);
+            });
+      }
     }
 #endif
   }
@@ -434,12 +673,10 @@ class P2pNvlTransportDevice {
     }
     char* dst = reinterpret_cast<char*>(dstbuff);
 
-    // REMOTE-WRITE PATTERN:
-    // Receiver reads from LOCAL buffer (sender wrote here via NVLink).
-    // Benefits: Local memory read is faster than reading over NVLink
     char* recvBuffer = localState_.dataBuffer;
-    // Extract raw pointer to avoid aliasing issues (see DeviceSpan.cuh).
-    ChunkState* const recvStates = localState_.stateBuffer.data();
+    // Local wait buffer: my state (sender writes here via NVLink)
+    ChunkState* const localReceiverStates =
+        localState_.receiverStateBuffer.data();
 
     const std::size_t totalSteps =
         (nbytes + options_.dataBufferSize - 1) / options_.dataBufferSize;
@@ -447,43 +684,135 @@ class P2pNvlTransportDevice {
     const std::size_t chunksPerStep =
         (options_.dataBufferSize + kChunkSize - 1) / kChunkSize;
 
-    for (std::size_t stepId = 0; stepId < totalSteps; stepId++) {
-      // Calculate pipeline slot index for this step
-      const std::size_t pipelineIdx = stepId % options_.pipelineDepth;
-      const std::size_t dataBufferOffset =
-          pipelineIdx * options_.dataBufferSize;
-      const std::size_t stateOffset = pipelineIdx * chunksPerStep;
+    if (options_.useDualStateBuffer) {
+      // =====================================================================
+      // DUAL CHUNK STATE MODE (Receiver side)
+      // =====================================================================
+      // See send() for detailed state machine, correctness analysis, and
+      // explanation of why two group.sync() calls are required.
+      //
+      // Receiver steps per chunk:
+      // 1. Wait LOCAL receiverState for sender's signal (ld.acquire.sys)
+      // 2. Copy data from local buffer
+      //    ─── group.sync() [inside unready()] ───
+      // 3. Mark LOCAL receiverState as UNREADY (plain write)
+      //    ─── group.sync() [inside ready_to_send()] ───
+      // 4. Signal REMOTE senderState via NVLink (st.release.sys)
+      //
+      // STRIDED ASSIGNMENT: Uses for_each_item_strided to ensure
+      // each chunk is always assigned to the same thread group. This is
+      // required because unready() uses plain write + group.sync() (not
+      // st.release.sys), which is only visible within the same group.
+      // =====================================================================
+      ChunkState* const remoteSenderStates =
+          remoteState_.senderStateBuffer.data();
 
-      const std::size_t stepOffset = stepId * options_.dataBufferSize;
-      const std::size_t stepBytes =
-          (stepOffset + options_.dataBufferSize <= nbytes)
-          ? options_.dataBufferSize
-          : nbytes - stepOffset;
-      const std::size_t numChunksThisStep =
-          (stepBytes + kChunkSize - 1) / kChunkSize;
+      for (std::size_t stepId = 0; stepId < totalSteps; stepId++) {
+        const std::size_t pipelineIdx = stepId % options_.pipelineDepth;
+        const std::size_t dataBufferOffset =
+            pipelineIdx * options_.dataBufferSize;
+        const std::size_t stateOffset = pipelineIdx * chunksPerStep;
 
-      group.for_each_item_contiguous(numChunksThisStep, [&](uint32_t chunkIdx) {
-        const std::size_t chunkOffset = chunkIdx * kChunkSize;
-        const std::size_t chunkBytes = (chunkOffset + kChunkSize <= stepBytes)
-            ? kChunkSize
-            : stepBytes - chunkOffset;
+        const std::size_t stepOffset = stepId * options_.dataBufferSize;
+        const std::size_t stepBytes =
+            (stepOffset + options_.dataBufferSize <= nbytes)
+            ? options_.dataBufferSize
+            : nbytes - stepOffset;
+        const std::size_t numChunksThisStep =
+            (stepBytes + kChunkSize - 1) / kChunkSize;
 
-        if (chunkBytes == 0) {
-          return;
-        }
+        group.for_each_item_strided(numChunksThisStep, [&](uint32_t chunkIdx) {
+          const std::size_t chunkOffset = chunkIdx * kChunkSize;
+          const std::size_t chunkBytes = (chunkOffset + kChunkSize <= stepBytes)
+              ? kChunkSize
+              : stepBytes - chunkOffset;
 
-        ChunkState& chunkState = recvStates[stateOffset + chunkIdx];
+          if (chunkBytes == 0) {
+            return;
+          }
 
-        chunkState.wait_ready_to_recv(group, stepId, timeout);
+          const std::size_t chunkStateIdx = stateOffset + chunkIdx;
 
-        memcpy_vectorized(
-            dst + stepOffset + chunkOffset,
-            recvBuffer + dataBufferOffset + chunkOffset,
-            chunkBytes,
-            group);
+          // Wait on LOCAL receiverStateBuffer for sender's signal
+          // (fast local poll - sender signals when data is ready)
+          ChunkState& localReceiverState = localReceiverStates[chunkStateIdx];
+          localReceiverState.wait_ready_to_recv(group, stepId, timeout);
 
-        chunkState.ready_to_send(group);
-      });
+          // Copy data from local buffer
+          memcpy_vectorized(
+              dst + stepOffset + chunkOffset,
+              recvBuffer + dataBufferOffset + chunkOffset,
+              chunkBytes,
+              group);
+
+          // Sync #1 + plain write: barrier all threads, then leader
+          // writes UNREADY to local receiverState (see send() correctness
+          // note for why two syncs are required)
+          localReceiverState.unready(group);
+
+          // Sync #2 + release store: barrier all threads (flushes the
+          // UNREADY plain write), then leader does st.release.sys.global
+          // READY_TO_SEND to peer's senderState via NVLink
+          ChunkState& remoteSenderState = remoteSenderStates[chunkStateIdx];
+          remoteSenderState.ready_to_send(group);
+        });
+      }
+    } else {
+      // =====================================================================
+      // SINGLE CHUNK STATE MODE (Original Design)
+      // =====================================================================
+      // See send() for detailed state machine documentation.
+      //
+      // Receiver side:
+      // 1. Wait LOCAL receiverStateBuffer for sender's signal (stepId)
+      // 2. Copy data from local buffer (sender wrote via NVLink)
+      // 3. Signal LOCAL receiverStateBuffer with READY_TO_SEND (-1)
+      // =====================================================================
+
+      for (std::size_t stepId = 0; stepId < totalSteps; stepId++) {
+        const std::size_t pipelineIdx = stepId % options_.pipelineDepth;
+        const std::size_t dataBufferOffset =
+            pipelineIdx * options_.dataBufferSize;
+        const std::size_t stateOffset = pipelineIdx * chunksPerStep;
+
+        const std::size_t stepOffset = stepId * options_.dataBufferSize;
+        const std::size_t stepBytes =
+            (stepOffset + options_.dataBufferSize <= nbytes)
+            ? options_.dataBufferSize
+            : nbytes - stepOffset;
+        const std::size_t numChunksThisStep =
+            (stepBytes + kChunkSize - 1) / kChunkSize;
+
+        group.for_each_item_contiguous(
+            numChunksThisStep, [&](uint32_t chunkIdx) {
+              const std::size_t chunkOffset = chunkIdx * kChunkSize;
+              const std::size_t chunkBytes =
+                  (chunkOffset + kChunkSize <= stepBytes)
+                  ? kChunkSize
+                  : stepBytes - chunkOffset;
+
+              if (chunkBytes == 0) {
+                return;
+              }
+
+              const std::size_t chunkStateIdx = stateOffset + chunkIdx;
+
+              // Wait on LOCAL receiverStateBuffer for sender's signal (stepId)
+              ChunkState& localReceiverState =
+                  localReceiverStates[chunkStateIdx];
+              localReceiverState.wait_ready_to_recv(group, stepId, timeout);
+
+              // Copy data from local buffer
+              memcpy_vectorized(
+                  dst + stepOffset + chunkOffset,
+                  recvBuffer + dataBufferOffset + chunkOffset,
+                  chunkBytes,
+                  group);
+
+              // Signal LOCAL receiverStateBuffer with READY_TO_SEND
+              localReceiverState.ready_to_send(group);
+            });
+      }
     }
 #endif
   }

--- a/comms/pipes/benchmarks/BarrierBench.cu
+++ b/comms/pipes/benchmarks/BarrierBench.cu
@@ -42,13 +42,15 @@ void launchBarrierBenchKernel(
   // Create local and remote state with barrier buffers
   LocalState localState{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(nullptr, 0),
       .barrierBuffer = DeviceSpan<BarrierState>(localBarrier, numBarriers),
   };
   RemoteState remoteState{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(nullptr, 0),
       .barrierBuffer = DeviceSpan<BarrierState>(remoteBarrier, numBarriers),
   };

--- a/comms/pipes/benchmarks/BenchmarkKernel.cu
+++ b/comms/pipes/benchmarks/BenchmarkKernel.cu
@@ -79,7 +79,7 @@ __global__ void p2pRecvTimed(
   }
 }
 
-__global__ void p2pBidirectional(
+__global__ __launch_bounds__(512, 1) void p2pBidirectional(
     P2pNvlTransportDevice* p2p,
     void* sendBuff,
     void* recvBuff,

--- a/comms/pipes/benchmarks/P2pNvlBenchmarkUtils.h
+++ b/comms/pipes/benchmarks/P2pNvlBenchmarkUtils.h
@@ -20,6 +20,7 @@ struct BenchmarkConfig {
   std::size_t chunkSize = 512 * 1024; // 512KB default
   SyncScope groupScope = SyncScope::WARP; // Thread group scope for parallelism
   bool spreadClusterLaunch = false; // Use spread cluster kernel launch
+  bool useDualStateBuffer = false; // Use dual chunk state buffers
   std::string name;
 };
 

--- a/comms/pipes/benchmarks/P2pNvlSendRecvBenchmark.cc
+++ b/comms/pipes/benchmarks/P2pNvlSendRecvBenchmark.cc
@@ -130,8 +130,10 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
   }
 
   // Helper function to run P2P NVL benchmark - returns bandwidth
+  // p2pDevicePtr must point to a P2pNvlTransportDevice in device memory
+  // (e.g. obtained from getDeviceTransports()).
   float runP2pNvlBenchmark(
-      comms::pipes::P2pNvlTransportDevice& p2p,
+      comms::pipes::P2pNvlTransportDevice* p2pDevicePtr,
       const BenchmarkConfig& config,
       float& timeUs) {
     XLOGF(DBG1, "=== Running P2P NVL benchmark: {} ===", config.name);
@@ -161,7 +163,7 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     SyncScope groupScope = config.groupScope;
     void* devicePtr = (isSend ? sendBuff.get() : recvBuff.get());
     Timeout timeout; // Default timeout (disabled)
-    void* args[] = {&p2p, &devicePtr, &nBytes, &groupScope, &timeout};
+    void* args[] = {&p2pDevicePtr, &devicePtr, &nBytes, &groupScope, &timeout};
     void* kernelFunc = isSend ? (void*)comms::pipes::benchmark::p2pSend
                               : (void*)comms::pipes::benchmark::p2pRecv;
     cudaStream_t stream = isSend ? sendStream : recvStream;
@@ -284,9 +286,10 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
   }
 
   // Helper function to run P2P NVL bidirectional benchmark - returns algorithm
-  // BW
+  // BW. p2pDevicePtr must point to a P2pNvlTransportDevice in device memory
+  // (e.g. obtained from getDeviceTransports()).
   float runP2pNvlBidirectionalBenchmark(
-      comms::pipes::P2pNvlTransportDevice& p2p,
+      comms::pipes::P2pNvlTransportDevice* p2pDevicePtr,
       const BenchmarkConfig& config,
       float& timeUs) {
     XLOGF(
@@ -312,7 +315,8 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     void* recvPtr = recvBuff.get();
     SyncScope groupScope = config.groupScope;
     Timeout timeout; // Default timeout (disabled)
-    void* args[] = {&p2p, &sendPtr, &recvPtr, &nBytes, &groupScope, &timeout};
+    void* args[] = {
+        &p2pDevicePtr, &sendPtr, &recvPtr, &nBytes, &groupScope, &timeout};
     void* kernelFunc = (void*)comms::pipes::benchmark::p2pBidirectional;
 
     // Warmup - no reset needed, recv() signals -1 after each transfer
@@ -432,178 +436,90 @@ TEST_F(P2pSendRecvBenchmarkFixture, UnidirectionalBenchmark) {
 
   int peerRank = (globalRank == 0) ? 1 : 0;
 
-  // Test configurations
-  // IMPORTANT: Balance threads with staging buffer size
-  // - chunks = stagingBufferSize / chunkSize
-  // - warps = numBlocks * numThreads / 32
-  // - Aim for chunks >= warps for good utilization
-  // - Small messages need smaller chunks to enable parallelism
+  // NCCL-like test configurations
+  // NCCL uses 16 blocks for < 512M messages, 32 blocks for >= 512M messages
   std::vector<BenchmarkConfig> configs;
 
-  // === SMALL MESSAGES (8KB - 2MB) ===
-  // Key insight: Use smaller chunks to enable warp parallelism
+  constexpr int kNcclBlocksSmall = 16; // For messages < 512MB
+  constexpr int kNcclBlocksLarge = 32; // For messages >= 512MB
+  constexpr int kNcclThreads = 512;
+  constexpr std::size_t kNcclStagedBufferSize = 8 * 1024 * 1024; // 8MB
+  constexpr std::size_t kChunkSize = 512 * 1024; // 512KB
+  constexpr std::size_t kLargeMessageThreshold = 512 * 1024 * 1024; // 512MB
 
-  configs.push_back({
-      .nBytes = 8 * 1024,
-      .stagedBufferSize = 8 * 1024,
-      .numBlocks = 1,
-      .numThreads = 128,
-      .pipelineDepth = 2,
-      .chunkSize = 8 * 1024,
-      .name = "8KB",
-  });
+  // Helper function for adding NCCL-like config with auto-computed numBlocks
+  // Adds both single state and dual state variants
+  auto addNcclConfig = [&configs,
+                        kNcclBlocksLarge,
+                        kNcclStagedBufferSize,
+                        kLargeMessageThreshold](
+                           std::size_t sizeBytes,
+                           const std::string& sizeName,
+                           SyncScope scope,
+                           const std::string& scopeName) {
+    int numBlks = (sizeBytes >= kLargeMessageThreshold) ? kNcclBlocksLarge
+                                                        : kNcclBlocksSmall;
+    // Single state buffer variant
+    configs.push_back({
+        .nBytes = sizeBytes,
+        .stagedBufferSize = kNcclStagedBufferSize,
+        .numBlocks = numBlks,
+        .numThreads = kNcclThreads,
+        .pipelineDepth = 2,
+        .chunkSize = kChunkSize,
+        .groupScope = scope,
+        .spreadClusterLaunch = true,
+        .useDualStateBuffer = false,
+        .name = "NCCL_" + sizeName + "_" + scopeName + "_Single",
+    });
+    // Dual state buffer variant
+    configs.push_back({
+        .nBytes = sizeBytes,
+        .stagedBufferSize = kNcclStagedBufferSize,
+        .numBlocks = numBlks,
+        .numThreads = kNcclThreads,
+        .pipelineDepth = 2,
+        .chunkSize = kChunkSize,
+        .groupScope = scope,
+        .spreadClusterLaunch = true,
+        .useDualStateBuffer = true,
+        .name = "NCCL_" + sizeName + "_" + scopeName + "_Dual",
+    });
+  };
 
-  // 32KB: 4 warps, 4 chunks (8KB each) -> 1 chunk/warp
-  configs.push_back({
-      .nBytes = 32 * 1024,
-      .stagedBufferSize = 32 * 1024,
-      .numBlocks = 1,
-      .numThreads = 128,
-      .pipelineDepth = 2,
-      .chunkSize = 8 * 1024,
-      .name = "32KB",
-  });
+  // === BLOCK-BASED CONFIGURATIONS ===
+  addNcclConfig(4 * 1024, "4K", SyncScope::BLOCK, "Block");
+  addNcclConfig(8 * 1024, "8K", SyncScope::BLOCK, "Block");
+  addNcclConfig(16 * 1024, "16K", SyncScope::BLOCK, "Block");
+  addNcclConfig(64 * 1024, "64K", SyncScope::BLOCK, "Block");
+  addNcclConfig(128 * 1024, "128K", SyncScope::BLOCK, "Block");
+  addNcclConfig(256 * 1024, "256K", SyncScope::BLOCK, "Block");
+  addNcclConfig(1 * 1024 * 1024, "1M", SyncScope::BLOCK, "Block");
+  addNcclConfig(2 * 1024 * 1024, "2M", SyncScope::BLOCK, "Block");
+  addNcclConfig(8 * 1024 * 1024, "8M", SyncScope::BLOCK, "Block");
+  addNcclConfig(32 * 1024 * 1024, "32M", SyncScope::BLOCK, "Block");
+  addNcclConfig(64 * 1024 * 1024, "64M", SyncScope::BLOCK, "Block");
+  addNcclConfig(128 * 1024 * 1024, "128M", SyncScope::BLOCK, "Block");
+  addNcclConfig(256 * 1024 * 1024, "256M", SyncScope::BLOCK, "Block");
+  addNcclConfig(512 * 1024 * 1024, "512M", SyncScope::BLOCK, "Block");
+  addNcclConfig(1024 * 1024 * 1024, "1G", SyncScope::BLOCK, "Block");
 
-  // 64KB: 8 warps, 8 chunks -> 1 chunk/warp
-  configs.push_back({
-      .nBytes = 64 * 1024,
-      .stagedBufferSize = 64 * 1024,
-      .numBlocks = 2,
-      .numThreads = 128,
-      .pipelineDepth = 2,
-      .chunkSize = 8 * 1024,
-      .name = "64KB",
-  });
-
-  // 128KB: 16 warps, 16 chunks -> 1 chunk/warp
-  configs.push_back({
-      .nBytes = 128 * 1024,
-      .stagedBufferSize = 128 * 1024,
-      .numBlocks = 4,
-      .numThreads = 128,
-      .pipelineDepth = 2,
-      .chunkSize = 8 * 1024,
-      .name = "128KB",
-  });
-
-  // 256KB: 32 warps, 32 chunks -> 1 chunk/warp
-  configs.push_back({
-      .nBytes = 256 * 1024,
-      .stagedBufferSize = 256 * 1024,
-      .numBlocks = 8,
-      .numThreads = 128,
-      .pipelineDepth = 2,
-      .chunkSize = 8 * 1024,
-      .name = "256KB",
-  });
-
-  // 512KB: 64 warps, 32 chunks (16KB each)
-  configs.push_back({
-      .nBytes = 512 * 1024,
-      .stagedBufferSize = 512 * 1024,
-      .numBlocks = 16,
-      .numThreads = 128,
-      .pipelineDepth = 2,
-      .chunkSize = 16 * 1024,
-      .name = "512KB",
-  });
-
-  // 1MB: 128 warps, 32 chunks (32KB each)
-  configs.push_back({
-      .nBytes = 1024 * 1024,
-      .stagedBufferSize = 1024 * 1024,
-      .numBlocks = 32,
-      .numThreads = 128,
-      .pipelineDepth = 2,
-      .chunkSize = 32 * 1024,
-      .name = "1MB",
-  });
-
-  // 2MB: 256 warps, 128 chunks (16KB each) -> 1.24x speedup!
-  configs.push_back({
-      .nBytes = 2 * 1024 * 1024,
-      .stagedBufferSize = 2 * 1024 * 1024,
-      .numBlocks = 64,
-      .numThreads = 128,
-      .pipelineDepth = 2,
-      .chunkSize = 16 * 1024,
-      .name = "2MB",
-  });
-
-  // === MEDIUM/LARGE MESSAGES (64MB - 1GB) ===
-  // Key insight: Larger chunks work well, bandwidth is the limit
-
-  // 64MB: 512 warps, 256 chunks (128KB each)
-  configs.push_back({
-      .nBytes = 64 * 1024 * 1024,
-      .stagedBufferSize = 32 * 1024 * 1024,
-      .numBlocks = 128,
-      .numThreads = 128,
-      .pipelineDepth = 4,
-      .chunkSize = 128 * 1024,
-      .name = "64MB",
-  });
-
-  // 256MB: 1024 warps, 128 chunks (512KB each)
-  configs.push_back({
-      .nBytes = 256 * 1024 * 1024,
-      .stagedBufferSize = 64 * 1024 * 1024,
-      .numBlocks = 256,
-      .numThreads = 128,
-      .pipelineDepth = 4,
-      .chunkSize = 512 * 1024,
-      .name = "256MB",
-  });
-
-  // 1GB with 256MB staging
-  configs.push_back({
-      .nBytes = 1024 * 1024 * 1024,
-      .stagedBufferSize = 256 * 1024 * 1024,
-      .numBlocks = 256,
-      .numThreads = 128,
-      .pipelineDepth = 4,
-      .chunkSize = 512 * 1024,
-      .name = "1GB",
-  });
-
-  // === BLOCK-BASED GROUPS (fewer coordination points) ===
-  // With block groups: 256 blocks = 256 groups (vs 1024 warps)
-
-  // 64MB with block groups
-  configs.push_back({
-      .nBytes = 64 * 1024 * 1024,
-      .stagedBufferSize = 32 * 1024 * 1024,
-      .numBlocks = 128,
-      .numThreads = 128,
-      .pipelineDepth = 4,
-      .chunkSize = 128 * 1024,
-      .groupScope = SyncScope::BLOCK,
-      .name = "64MB_Block",
-  });
-
-  // 256MB with block groups
-  configs.push_back({
-      .nBytes = 256 * 1024 * 1024,
-      .stagedBufferSize = 64 * 1024 * 1024,
-      .numBlocks = 256,
-      .numThreads = 128,
-      .pipelineDepth = 4,
-      .chunkSize = 512 * 1024,
-      .groupScope = SyncScope::BLOCK,
-      .name = "256MB_Block",
-  });
-
-  // 1GB with block groups
-  configs.push_back({
-      .nBytes = 1024 * 1024 * 1024,
-      .stagedBufferSize = 256 * 1024 * 1024,
-      .numBlocks = 256,
-      .numThreads = 128,
-      .pipelineDepth = 4,
-      .chunkSize = 512 * 1024,
-      .groupScope = SyncScope::BLOCK,
-      .name = "1GB_Block",
-  });
+  // === CLUSTER-BASED CONFIGURATIONS ===
+  addNcclConfig(4 * 1024, "4K", SyncScope::CLUSTER, "Cluster");
+  addNcclConfig(8 * 1024, "8K", SyncScope::CLUSTER, "Cluster");
+  addNcclConfig(16 * 1024, "16K", SyncScope::CLUSTER, "Cluster");
+  addNcclConfig(64 * 1024, "64K", SyncScope::CLUSTER, "Cluster");
+  addNcclConfig(128 * 1024, "128K", SyncScope::CLUSTER, "Cluster");
+  addNcclConfig(256 * 1024, "256K", SyncScope::CLUSTER, "Cluster");
+  addNcclConfig(1 * 1024 * 1024, "1M", SyncScope::CLUSTER, "Cluster");
+  addNcclConfig(2 * 1024 * 1024, "2M", SyncScope::CLUSTER, "Cluster");
+  addNcclConfig(8 * 1024 * 1024, "8M", SyncScope::CLUSTER, "Cluster");
+  addNcclConfig(32 * 1024 * 1024, "32M", SyncScope::CLUSTER, "Cluster");
+  addNcclConfig(64 * 1024 * 1024, "64M", SyncScope::CLUSTER, "Cluster");
+  addNcclConfig(128 * 1024 * 1024, "128M", SyncScope::CLUSTER, "Cluster");
+  addNcclConfig(256 * 1024 * 1024, "256M", SyncScope::CLUSTER, "Cluster");
+  addNcclConfig(512 * 1024 * 1024, "512M", SyncScope::CLUSTER, "Cluster");
+  addNcclConfig(1024 * 1024 * 1024, "1G", SyncScope::CLUSTER, "Cluster");
 
   std::vector<BenchmarkResult> results;
 
@@ -613,13 +529,17 @@ TEST_F(P2pSendRecvBenchmarkFixture, UnidirectionalBenchmark) {
         .dataBufferSize = config.stagedBufferSize,
         .chunkSize = config.chunkSize,
         .pipelineDepth = config.pipelineDepth,
+        .useDualStateBuffer = config.useDualStateBuffer,
     };
 
     comms::pipes::MultiPeerNvlTransport transport(
         globalRank, worldSize, bootstrap, p2pConfig);
     transport.exchange();
 
-    auto p2p = transport.getP2pTransportDevice(peerRank);
+    // Get device pointer to the pre-allocated P2pNvlTransportDevice
+    // from the device-side Transport array (indexed by global rank).
+    auto deviceTransports = transport.getDeviceTransports();
+    auto* p2pDevicePtr = &deviceTransports.data()[peerRank].p2p_nvl;
 
     BenchmarkResult result;
     result.testName = config.name;
@@ -634,7 +554,8 @@ TEST_F(P2pSendRecvBenchmarkFixture, UnidirectionalBenchmark) {
     result.ncclBandwidth = runNcclBenchmark(config, result.ncclTime);
 
     // Run P2P NVL benchmark
-    result.p2pBandwidth = runP2pNvlBenchmark(p2p, config, result.p2pTime);
+    result.p2pBandwidth =
+        runP2pNvlBenchmark(p2pDevicePtr, config, result.p2pTime);
 
     // Calculate speedup
     result.p2pSpeedup = (result.ncclBandwidth > 0)
@@ -657,78 +578,8 @@ TEST_F(P2pSendRecvBenchmarkFixture, BidirectionalBenchmark) {
 
   int peerRank = (globalRank == 0) ? 1 : 0;
 
-  // Bidirectional test configurations
-  // Key insight: Same rules as unidirectional - small chunks for small messages
+  // Bidirectional test configurations using NCCL-like parameters
   std::vector<BenchmarkConfig> configs;
-
-  // 2MB: 256 warps, 128 chunks (16KB each) - matches optimal unidirectional
-  configs.push_back({
-      .nBytes = 2 * 1024 * 1024,
-      .stagedBufferSize = 2 * 1024 * 1024,
-      .numBlocks = 64,
-      .numThreads = 128,
-      .pipelineDepth = 2,
-      .chunkSize = 16 * 1024,
-      .name = "Bidir_2MB",
-  });
-
-  // 64MB: 512 warps, 256 chunks (128KB each)
-  configs.push_back({
-      .nBytes = 64 * 1024 * 1024,
-      .stagedBufferSize = 8 * 1024 * 1024,
-      .numBlocks = 32,
-      .numThreads = 512,
-      .pipelineDepth = 2,
-      .chunkSize = 512 * 1024,
-      .groupScope = SyncScope::BLOCK,
-      .name = "Bidir_64MB",
-  });
-
-  configs.push_back({
-      .nBytes = 128 * 1024 * 1024,
-      .stagedBufferSize = 8 * 1024 * 1024,
-      .numBlocks = 32,
-      .numThreads = 512,
-      .pipelineDepth = 2,
-      .chunkSize = 512 * 1024,
-      .groupScope = SyncScope::BLOCK,
-      .name = "Bidir_128MB",
-  });
-
-  // 256MB: 512 warps, 256 chunks (256KB each)
-  configs.push_back({
-      .nBytes = 256 * 1024 * 1024,
-      .stagedBufferSize = 8 * 1024 * 1024,
-      .numBlocks = 32,
-      .numThreads = 512,
-      .pipelineDepth = 2,
-      .chunkSize = 512 * 1024,
-      .groupScope = SyncScope::BLOCK,
-      .name = "Bidir_256MB",
-  });
-
-  configs.push_back({
-      .nBytes = 512 * 1024 * 1024,
-      .stagedBufferSize = 8 * 1024 * 1024,
-      .numBlocks = 32,
-      .numThreads = 512,
-      .pipelineDepth = 2,
-      .chunkSize = 512 * 1024,
-      .groupScope = SyncScope::BLOCK,
-      .name = "Bidir_512MB",
-  });
-
-  // 1GB with 256MB staging
-  configs.push_back({
-      .nBytes = 1024 * 1024 * 1024,
-      .stagedBufferSize = 8 * 1024 * 1024,
-      .numBlocks = 32,
-      .numThreads = 512,
-      .pipelineDepth = 2,
-      .chunkSize = 512 * 1024,
-      .groupScope = SyncScope::BLOCK,
-      .name = "Bidir_1GB",
-  });
 
   // === NCCL-LIKE CONFIGURATIONS ===
   // Helper function to add NCCL-like configs with consistent parameters
@@ -738,10 +589,12 @@ TEST_F(P2pSendRecvBenchmarkFixture, BidirectionalBenchmark) {
   constexpr int kNcclThreads = 512;
   constexpr std::size_t kNcclStagedBufferSize = 8 * 1024 * 1024; // 8MB
   constexpr std::size_t kChunkSize = 512 * 1024; // 512KB
+  const size_t kWarpChunkSize = 16 * 1024;
   constexpr std::size_t kLargeMessageThreshold = 512 * 1024 * 1024; // 512MB
 
   // Helper function for adding NCCL-like config with auto-computed numBlocks
   // Uses 16 blocks for < 512M, 32 blocks for >= 512M (like NCCL)
+  // Adds both single state and dual state variants
   auto addNcclConfig = [&configs,
                         kNcclBlocksLarge,
                         kNcclStagedBufferSize,
@@ -752,20 +605,56 @@ TEST_F(P2pSendRecvBenchmarkFixture, BidirectionalBenchmark) {
                            const std::string& scopeName) {
     int numBlks = (sizeBytes >= kLargeMessageThreshold) ? kNcclBlocksLarge
                                                         : kNcclBlocksSmall;
+    // Single state buffer variant
     configs.push_back({
         .nBytes = sizeBytes,
         .stagedBufferSize = kNcclStagedBufferSize,
         .numBlocks = numBlks,
         .numThreads = kNcclThreads,
         .pipelineDepth = 2,
-        .chunkSize = kChunkSize,
+        .chunkSize = scope == SyncScope::WARP ? kWarpChunkSize : kChunkSize,
         .groupScope = scope,
         .spreadClusterLaunch = true,
-        .name = "NCCL_" + sizeName + "_" + scopeName,
+        .useDualStateBuffer = false,
+        .name = "NCCL_" + sizeName + "_" + scopeName + "_Single",
+    });
+    // Dual state buffer variant
+    configs.push_back({
+        .nBytes = sizeBytes,
+        .stagedBufferSize = kNcclStagedBufferSize,
+        .numBlocks = numBlks,
+        .numThreads = kNcclThreads,
+        .pipelineDepth = 2,
+        .chunkSize = scope == SyncScope::WARP ? kWarpChunkSize : kChunkSize,
+        .groupScope = scope,
+        .spreadClusterLaunch = true,
+        .useDualStateBuffer = true,
+        .name = "NCCL_" + sizeName + "_" + scopeName + "_Dual",
     });
   };
 
+  // === WARP-BASED CONFIGURATIONS ===
+  addNcclConfig(4 * 1024, "4K", SyncScope::WARP, "Warp");
+  addNcclConfig(8 * 1024, "8K", SyncScope::WARP, "Warp");
+  addNcclConfig(16 * 1024, "16K", SyncScope::WARP, "Warp");
+  addNcclConfig(64 * 1024, "64K", SyncScope::WARP, "Warp");
+  addNcclConfig(128 * 1024, "128K", SyncScope::WARP, "Warp");
+  addNcclConfig(256 * 1024, "256K", SyncScope::WARP, "Warp");
+  addNcclConfig(1 * 1024 * 1024, "1M", SyncScope::WARP, "Warp");
+  addNcclConfig(2 * 1024 * 1024, "2M", SyncScope::WARP, "Warp");
+  addNcclConfig(8 * 1024 * 1024, "8M", SyncScope::WARP, "Warp");
+  addNcclConfig(32 * 1024 * 1024, "32M", SyncScope::WARP, "Warp");
+  addNcclConfig(64 * 1024 * 1024, "64M", SyncScope::WARP, "Warp");
+  addNcclConfig(128 * 1024 * 1024, "128M", SyncScope::WARP, "Warp");
+  addNcclConfig(256 * 1024 * 1024, "256M", SyncScope::WARP, "Warp");
+  addNcclConfig(512 * 1024 * 1024, "512M", SyncScope::WARP, "Warp");
+  addNcclConfig(1024 * 1024 * 1024, "1G", SyncScope::WARP, "Warp");
+
   // === BLOCK-BASED CONFIGURATIONS ===
+  addNcclConfig(4 * 1024, "4K", SyncScope::BLOCK, "Block");
+  addNcclConfig(8 * 1024, "8K", SyncScope::BLOCK, "Block");
+  addNcclConfig(16 * 1024, "16K", SyncScope::BLOCK, "Block");
+  addNcclConfig(64 * 1024, "64K", SyncScope::BLOCK, "Block");
   addNcclConfig(128 * 1024, "128K", SyncScope::BLOCK, "Block");
   addNcclConfig(256 * 1024, "256K", SyncScope::BLOCK, "Block");
   addNcclConfig(1 * 1024 * 1024, "1M", SyncScope::BLOCK, "Block");
@@ -779,6 +668,10 @@ TEST_F(P2pSendRecvBenchmarkFixture, BidirectionalBenchmark) {
   addNcclConfig(1024 * 1024 * 1024, "1G", SyncScope::BLOCK, "Block");
 
   // === CLUSTER-BASED CONFIGURATIONS ===
+  addNcclConfig(4 * 1024, "4K", SyncScope::CLUSTER, "Cluster");
+  addNcclConfig(8 * 1024, "8K", SyncScope::CLUSTER, "Cluster");
+  addNcclConfig(16 * 1024, "16K", SyncScope::CLUSTER, "Cluster");
+  addNcclConfig(64 * 1024, "64K", SyncScope::CLUSTER, "Cluster");
   addNcclConfig(128 * 1024, "128K", SyncScope::CLUSTER, "Cluster");
   addNcclConfig(256 * 1024, "256K", SyncScope::CLUSTER, "Cluster");
   addNcclConfig(1 * 1024 * 1024, "1M", SyncScope::CLUSTER, "Cluster");
@@ -799,13 +692,17 @@ TEST_F(P2pSendRecvBenchmarkFixture, BidirectionalBenchmark) {
         .dataBufferSize = config.stagedBufferSize,
         .chunkSize = config.chunkSize,
         .pipelineDepth = config.pipelineDepth,
+        .useDualStateBuffer = config.useDualStateBuffer,
     };
 
     comms::pipes::MultiPeerNvlTransport transport(
         globalRank, worldSize, bootstrap, p2pConfig);
     transport.exchange();
 
-    auto p2p = transport.getP2pTransportDevice(peerRank);
+    // Get device pointer to the pre-allocated P2pNvlTransportDevice
+    // from the device-side Transport array (indexed by global rank).
+    auto deviceTransports = transport.getDeviceTransports();
+    auto* p2pDevicePtr = &deviceTransports.data()[peerRank].p2p_nvl;
 
     BenchmarkResult result;
     result.testName = config.name;
@@ -822,7 +719,7 @@ TEST_F(P2pSendRecvBenchmarkFixture, BidirectionalBenchmark) {
 
     // Run P2P NVL bidirectional benchmark
     result.p2pBandwidth =
-        runP2pNvlBidirectionalBenchmark(p2p, config, result.p2pTime);
+        runP2pNvlBidirectionalBenchmark(p2pDevicePtr, config, result.p2pTime);
 
     // Calculate speedup
     result.p2pSpeedup = (result.ncclBandwidth > 0)

--- a/comms/pipes/benchmarks/P2pNvlSignalBenchmark.cc
+++ b/comms/pipes/benchmarks/P2pNvlSignalBenchmark.cc
@@ -74,7 +74,7 @@ class P2pSignalBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
   // Helper function to run P2P signal benchmark - returns latency
   // in microseconds
   float runSignalBenchmark(
-      comms::pipes::P2pNvlTransportDevice& p2p,
+      comms::pipes::P2pNvlTransportDevice* p2p,
       const BenchmarkConfig& config,
       int nSteps = 1000) {
     XLOGF(DBG1, "=== Running Signal benchmark: {} ===", config.name);

--- a/comms/pipes/tests/BarrierTest.cc
+++ b/comms/pipes/tests/BarrierTest.cc
@@ -296,34 +296,56 @@ TEST_F(BarrierTwoGpuFixture, DeviceBarrierSyncTwoGpu) {
   // Transport on GPU 0: writes to GPU 1's barrier, waits on GPU 0's barrier
   LocalState localState0{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(nullptr, 0),
       .barrierBuffer = DeviceSpan<BarrierState>(barrierBuffer0, numBarriers),
   };
   RemoteState remoteState0{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(nullptr, 0),
       .barrierBuffer = DeviceSpan<BarrierState>(barrierBuffer1, numBarriers),
   };
   P2pNvlTransportDevice transport0(
       kGpu0, kGpu1, options, localState0, remoteState0);
 
+  // Allocate device copy of transport0
+  P2pNvlTransportDevice* transport0_d;
+  CUDACHECK_TEST(cudaMalloc(&transport0_d, sizeof(P2pNvlTransportDevice)));
+  CUDACHECK_TEST(cudaMemcpy(
+      transport0_d,
+      &transport0,
+      sizeof(P2pNvlTransportDevice),
+      cudaMemcpyHostToDevice));
+
   // Transport on GPU 1: writes to GPU 0's barrier, waits on GPU 1's barrier
   LocalState localState1{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(nullptr, 0),
       .barrierBuffer = DeviceSpan<BarrierState>(barrierBuffer1, numBarriers),
   };
   RemoteState remoteState1{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(nullptr, 0),
       .barrierBuffer = DeviceSpan<BarrierState>(barrierBuffer0, numBarriers),
   };
   P2pNvlTransportDevice transport1(
       kGpu1, kGpu0, options, localState1, remoteState1);
+
+  // Allocate device copy of transport1
+  P2pNvlTransportDevice* transport1_d;
+  CUDACHECK_TEST(cudaMalloc(&transport1_d, sizeof(P2pNvlTransportDevice)));
+  CUDACHECK_TEST(cudaMemcpy(
+      transport1_d,
+      &transport1,
+      sizeof(P2pNvlTransportDevice),
+      cudaMemcpyHostToDevice));
 
   const int numBlocks = 1;
   const int blockSize = 32;
@@ -333,11 +355,11 @@ TEST_F(BarrierTwoGpuFixture, DeviceBarrierSyncTwoGpu) {
   // They should synchronize with each other
   CUDACHECK_TEST(cudaSetDevice(kGpu0));
   test::testDeviceBarrierSync(
-      transport0, barrierId, numBlocks, blockSize, test::GroupType::WARP);
+      transport0_d, barrierId, numBlocks, blockSize, test::GroupType::WARP);
 
   CUDACHECK_TEST(cudaSetDevice(kGpu1));
   test::testDeviceBarrierSync(
-      transport1, barrierId, numBlocks, blockSize, test::GroupType::WARP);
+      transport1_d, barrierId, numBlocks, blockSize, test::GroupType::WARP);
 
   // Wait for both to complete
   CUDACHECK_TEST(cudaSetDevice(kGpu0));
@@ -349,8 +371,10 @@ TEST_F(BarrierTwoGpuFixture, DeviceBarrierSyncTwoGpu) {
 
   CUDACHECK_TEST(cudaSetDevice(kGpu0));
   CUDACHECK_TEST(cudaFree(barrierBuffer0));
+  CUDACHECK_TEST(cudaFree(transport0_d));
   CUDACHECK_TEST(cudaSetDevice(kGpu1));
   CUDACHECK_TEST(cudaFree(barrierBuffer1));
+  CUDACHECK_TEST(cudaFree(transport1_d));
 }
 
 TEST_F(BarrierTwoGpuFixture, DeviceBarrierSyncTwoGpuMultipleIds) {
@@ -378,33 +402,56 @@ TEST_F(BarrierTwoGpuFixture, DeviceBarrierSyncTwoGpuMultipleIds) {
 
   LocalState localState0{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(nullptr, 0),
       .barrierBuffer = DeviceSpan<BarrierState>(barrierBuffer0, numBarriers),
   };
   RemoteState remoteState0{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(nullptr, 0),
       .barrierBuffer = DeviceSpan<BarrierState>(barrierBuffer1, numBarriers),
   };
   P2pNvlTransportDevice transport0(
       kGpu0, kGpu1, options, localState0, remoteState0);
 
+  // Allocate device copy of transport0
+  P2pNvlTransportDevice* transport0_d;
+  CUDACHECK_TEST(cudaMalloc(&transport0_d, sizeof(P2pNvlTransportDevice)));
+  CUDACHECK_TEST(cudaMemcpy(
+      transport0_d,
+      &transport0,
+      sizeof(P2pNvlTransportDevice),
+      cudaMemcpyHostToDevice));
+
   LocalState localState1{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(nullptr, 0),
       .barrierBuffer = DeviceSpan<BarrierState>(barrierBuffer1, numBarriers),
   };
   RemoteState remoteState1{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(nullptr, 0),
       .barrierBuffer = DeviceSpan<BarrierState>(barrierBuffer0, numBarriers),
   };
   P2pNvlTransportDevice transport1(
       kGpu1, kGpu0, options, localState1, remoteState1);
+
+  // Allocate device copy of transport1
+  CUDACHECK_TEST(cudaSetDevice(kGpu1));
+  P2pNvlTransportDevice* transport1_d;
+  CUDACHECK_TEST(cudaMalloc(&transport1_d, sizeof(P2pNvlTransportDevice)));
+  CUDACHECK_TEST(cudaMemcpy(
+      transport1_d,
+      &transport1,
+      sizeof(P2pNvlTransportDevice),
+      cudaMemcpyHostToDevice));
 
   const int numBlocks = 1;
   const int blockSize = 32;
@@ -424,11 +471,11 @@ TEST_F(BarrierTwoGpuFixture, DeviceBarrierSyncTwoGpuMultipleIds) {
     // Launch barrier sync on both GPUs
     CUDACHECK_TEST(cudaSetDevice(kGpu0));
     test::testDeviceBarrierSync(
-        transport0, barrierId, numBlocks, blockSize, test::GroupType::WARP);
+        transport0_d, barrierId, numBlocks, blockSize, test::GroupType::WARP);
 
     CUDACHECK_TEST(cudaSetDevice(kGpu1));
     test::testDeviceBarrierSync(
-        transport1, barrierId, numBlocks, blockSize, test::GroupType::WARP);
+        transport1_d, barrierId, numBlocks, blockSize, test::GroupType::WARP);
 
     CUDACHECK_TEST(cudaSetDevice(kGpu0));
     CUDACHECK_TEST(cudaDeviceSynchronize());
@@ -440,8 +487,10 @@ TEST_F(BarrierTwoGpuFixture, DeviceBarrierSyncTwoGpuMultipleIds) {
 
   CUDACHECK_TEST(cudaSetDevice(kGpu0));
   CUDACHECK_TEST(cudaFree(barrierBuffer0));
+  CUDACHECK_TEST(cudaFree(transport0_d));
   CUDACHECK_TEST(cudaSetDevice(kGpu1));
   CUDACHECK_TEST(cudaFree(barrierBuffer1));
+  CUDACHECK_TEST(cudaFree(transport1_d));
 }
 
 TEST_F(BarrierTwoGpuFixture, DeviceBarrierSyncTwoGpuMultipleSyncs) {
@@ -470,33 +519,56 @@ TEST_F(BarrierTwoGpuFixture, DeviceBarrierSyncTwoGpuMultipleSyncs) {
 
   LocalState localState0{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(nullptr, 0),
       .barrierBuffer = DeviceSpan<BarrierState>(barrierBuffer0, numBarriers),
   };
   RemoteState remoteState0{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(nullptr, 0),
       .barrierBuffer = DeviceSpan<BarrierState>(barrierBuffer1, numBarriers),
   };
   P2pNvlTransportDevice transport0(
       kGpu0, kGpu1, options, localState0, remoteState0);
 
+  // Allocate device copy of transport0
+  P2pNvlTransportDevice* transport0_d;
+  CUDACHECK_TEST(cudaMalloc(&transport0_d, sizeof(P2pNvlTransportDevice)));
+  CUDACHECK_TEST(cudaMemcpy(
+      transport0_d,
+      &transport0,
+      sizeof(P2pNvlTransportDevice),
+      cudaMemcpyHostToDevice));
+
   LocalState localState1{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(nullptr, 0),
       .barrierBuffer = DeviceSpan<BarrierState>(barrierBuffer1, numBarriers),
   };
   RemoteState remoteState1{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(nullptr, 0),
       .barrierBuffer = DeviceSpan<BarrierState>(barrierBuffer0, numBarriers),
   };
   P2pNvlTransportDevice transport1(
       kGpu1, kGpu0, options, localState1, remoteState1);
+
+  // Allocate device copy of transport1
+  CUDACHECK_TEST(cudaSetDevice(kGpu1));
+  P2pNvlTransportDevice* transport1_d;
+  CUDACHECK_TEST(cudaMalloc(&transport1_d, sizeof(P2pNvlTransportDevice)));
+  CUDACHECK_TEST(cudaMemcpy(
+      transport1_d,
+      &transport1,
+      sizeof(P2pNvlTransportDevice),
+      cudaMemcpyHostToDevice));
 
   const int numBlocks = 1;
   const int blockSize = 32;
@@ -505,7 +577,7 @@ TEST_F(BarrierTwoGpuFixture, DeviceBarrierSyncTwoGpuMultipleSyncs) {
   // Multiple syncs in the same kernel
   CUDACHECK_TEST(cudaSetDevice(kGpu0));
   test::testDeviceBarrierSyncMultiple(
-      transport0,
+      transport0_d,
       barrierId,
       numSyncs,
       numBlocks,
@@ -514,7 +586,7 @@ TEST_F(BarrierTwoGpuFixture, DeviceBarrierSyncTwoGpuMultipleSyncs) {
 
   CUDACHECK_TEST(cudaSetDevice(kGpu1));
   test::testDeviceBarrierSyncMultiple(
-      transport1,
+      transport1_d,
       barrierId,
       numSyncs,
       numBlocks,
@@ -530,8 +602,10 @@ TEST_F(BarrierTwoGpuFixture, DeviceBarrierSyncTwoGpuMultipleSyncs) {
 
   CUDACHECK_TEST(cudaSetDevice(kGpu0));
   CUDACHECK_TEST(cudaFree(barrierBuffer0));
+  CUDACHECK_TEST(cudaFree(transport0_d));
   CUDACHECK_TEST(cudaSetDevice(kGpu1));
   CUDACHECK_TEST(cudaFree(barrierBuffer1));
+  CUDACHECK_TEST(cudaFree(transport1_d));
 }
 
 TEST_F(BarrierTwoGpuFixture, DeviceBarrierSyncTwoGpuBlockGroups) {
@@ -559,33 +633,56 @@ TEST_F(BarrierTwoGpuFixture, DeviceBarrierSyncTwoGpuBlockGroups) {
 
   LocalState localState0{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(nullptr, 0),
       .barrierBuffer = DeviceSpan<BarrierState>(barrierBuffer0, numBarriers),
   };
   RemoteState remoteState0{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(nullptr, 0),
       .barrierBuffer = DeviceSpan<BarrierState>(barrierBuffer1, numBarriers),
   };
   P2pNvlTransportDevice transport0(
       kGpu0, kGpu1, options, localState0, remoteState0);
 
+  // Allocate device copy of transport0
+  P2pNvlTransportDevice* transport0_d;
+  CUDACHECK_TEST(cudaMalloc(&transport0_d, sizeof(P2pNvlTransportDevice)));
+  CUDACHECK_TEST(cudaMemcpy(
+      transport0_d,
+      &transport0,
+      sizeof(P2pNvlTransportDevice),
+      cudaMemcpyHostToDevice));
+
   LocalState localState1{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(nullptr, 0),
       .barrierBuffer = DeviceSpan<BarrierState>(barrierBuffer1, numBarriers),
   };
   RemoteState remoteState1{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(nullptr, 0),
       .barrierBuffer = DeviceSpan<BarrierState>(barrierBuffer0, numBarriers),
   };
   P2pNvlTransportDevice transport1(
       kGpu1, kGpu0, options, localState1, remoteState1);
+
+  // Allocate device copy of transport1
+  CUDACHECK_TEST(cudaSetDevice(kGpu1));
+  P2pNvlTransportDevice* transport1_d;
+  CUDACHECK_TEST(cudaMalloc(&transport1_d, sizeof(P2pNvlTransportDevice)));
+  CUDACHECK_TEST(cudaMemcpy(
+      transport1_d,
+      &transport1,
+      sizeof(P2pNvlTransportDevice),
+      cudaMemcpyHostToDevice));
 
   const int numBlocks = 1;
   const int blockSize = 256;
@@ -594,11 +691,11 @@ TEST_F(BarrierTwoGpuFixture, DeviceBarrierSyncTwoGpuBlockGroups) {
   // Test with block groups
   CUDACHECK_TEST(cudaSetDevice(kGpu0));
   test::testDeviceBarrierSync(
-      transport0, barrierId, numBlocks, blockSize, test::GroupType::BLOCK);
+      transport0_d, barrierId, numBlocks, blockSize, test::GroupType::BLOCK);
 
   CUDACHECK_TEST(cudaSetDevice(kGpu1));
   test::testDeviceBarrierSync(
-      transport1, barrierId, numBlocks, blockSize, test::GroupType::BLOCK);
+      transport1_d, barrierId, numBlocks, blockSize, test::GroupType::BLOCK);
 
   CUDACHECK_TEST(cudaSetDevice(kGpu0));
   CUDACHECK_TEST(cudaDeviceSynchronize());
@@ -609,8 +706,10 @@ TEST_F(BarrierTwoGpuFixture, DeviceBarrierSyncTwoGpuBlockGroups) {
 
   CUDACHECK_TEST(cudaSetDevice(kGpu0));
   CUDACHECK_TEST(cudaFree(barrierBuffer0));
+  CUDACHECK_TEST(cudaFree(transport0_d));
   CUDACHECK_TEST(cudaSetDevice(kGpu1));
   CUDACHECK_TEST(cudaFree(barrierBuffer1));
+  CUDACHECK_TEST(cudaFree(transport1_d));
 }
 
 TEST_F(BarrierTwoGpuFixture, DeviceBarrierDataTransferVerification) {
@@ -663,34 +762,57 @@ TEST_F(BarrierTwoGpuFixture, DeviceBarrierDataTransferVerification) {
   // GPU 0 will use put() to copy from dataBuffer0 to dataBuffer1 via P2P
   LocalState localState0{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(nullptr, 0),
       .barrierBuffer = DeviceSpan<BarrierState>(barrierBuffer0, numBarriers),
   };
   RemoteState remoteState0{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(nullptr, 0),
       .barrierBuffer = DeviceSpan<BarrierState>(barrierBuffer1, numBarriers),
   };
   P2pNvlTransportDevice transport0(
       kGpu0, kGpu1, options, localState0, remoteState0);
 
+  // Allocate device copy of transport0
+  P2pNvlTransportDevice* transport0_d;
+  CUDACHECK_TEST(cudaMalloc(&transport0_d, sizeof(P2pNvlTransportDevice)));
+  CUDACHECK_TEST(cudaMemcpy(
+      transport0_d,
+      &transport0,
+      sizeof(P2pNvlTransportDevice),
+      cudaMemcpyHostToDevice));
+
   // Transport on GPU 1: local=barrier1, remote=barrier0
   LocalState localState1{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(nullptr, 0),
       .barrierBuffer = DeviceSpan<BarrierState>(barrierBuffer1, numBarriers),
   };
   RemoteState remoteState1{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(nullptr, 0),
       .barrierBuffer = DeviceSpan<BarrierState>(barrierBuffer0, numBarriers),
   };
   P2pNvlTransportDevice transport1(
       kGpu1, kGpu0, options, localState1, remoteState1);
+
+  // Allocate device copy of transport1
+  CUDACHECK_TEST(cudaSetDevice(kGpu1));
+  P2pNvlTransportDevice* transport1_d;
+  CUDACHECK_TEST(cudaMalloc(&transport1_d, sizeof(P2pNvlTransportDevice)));
+  CUDACHECK_TEST(cudaMemcpy(
+      transport1_d,
+      &transport1,
+      sizeof(P2pNvlTransportDevice),
+      cudaMemcpyHostToDevice));
 
   const int numBlocks = 4; // 4 blocks = 4 warp groups (barrier ids 0-3)
   const int blockSize = 32; // 32 threads per block = 1 warp group per block
@@ -699,7 +821,7 @@ TEST_F(BarrierTwoGpuFixture, DeviceBarrierDataTransferVerification) {
   // then barrier sync
   CUDACHECK_TEST(cudaSetDevice(kGpu0));
   test::testBarrierWriteData(
-      transport0,
+      transport0_d,
       reinterpret_cast<char*>(dataBuffer1), // Remote buffer on GPU 1
       reinterpret_cast<const char*>(dataBuffer0), // Local source on GPU 0
       dataSize,
@@ -710,7 +832,7 @@ TEST_F(BarrierTwoGpuFixture, DeviceBarrierDataTransferVerification) {
   // GPU 1: Barrier sync, then verify the data
   CUDACHECK_TEST(cudaSetDevice(kGpu1));
   test::testBarrierVerifyData(
-      transport1,
+      transport1_d,
       dataBuffer1, // Local buffer on GPU 1
       dataSize,
       fillValue,
@@ -738,10 +860,12 @@ TEST_F(BarrierTwoGpuFixture, DeviceBarrierDataTransferVerification) {
   CUDACHECK_TEST(cudaSetDevice(kGpu0));
   CUDACHECK_TEST(cudaFree(barrierBuffer0));
   CUDACHECK_TEST(cudaFree(dataBuffer0));
+  CUDACHECK_TEST(cudaFree(transport0_d));
   CUDACHECK_TEST(cudaSetDevice(kGpu1));
   CUDACHECK_TEST(cudaFree(barrierBuffer1));
   CUDACHECK_TEST(cudaFree(dataBuffer1));
   CUDACHECK_TEST(cudaFree(errorCount_d));
+  CUDACHECK_TEST(cudaFree(transport1_d));
 }
 
 } // namespace comms::pipes

--- a/comms/pipes/tests/BarrierTest.cu
+++ b/comms/pipes/tests/BarrierTest.cu
@@ -109,26 +109,26 @@ void testReadBarrierExpectedCounter(
 // =============================================================================
 
 __global__ void testDeviceBarrierSyncKernel(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     uint64_t barrierId,
     GroupType groupType) {
   auto group = make_group(groupType);
-  p2p.barrier_sync_threadgroup(group, barrierId);
+  p2p->barrier_sync_threadgroup(group, barrierId);
 }
 
 __global__ void testDeviceBarrierSyncMultipleKernel(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     uint64_t barrierId,
     int numSyncs,
     GroupType groupType) {
   auto group = make_group(groupType);
   for (int i = 0; i < numSyncs; ++i) {
-    p2p.barrier_sync_threadgroup(group, barrierId);
+    p2p->barrier_sync_threadgroup(group, barrierId);
   }
 }
 
 void testDeviceBarrierSync(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     uint64_t barrierId,
     int numBlocks,
     int blockSize,
@@ -139,7 +139,7 @@ void testDeviceBarrierSync(
 }
 
 void testDeviceBarrierSyncMultiple(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     uint64_t barrierId,
     int numSyncs,
     int numBlocks,
@@ -156,7 +156,7 @@ void testDeviceBarrierSyncMultiple(
 // =============================================================================
 
 __global__ void testBarrierWriteDataKernel(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     char* remoteDataBuffer,
     const char* localSrcBuffer,
     size_t dataSize,
@@ -167,14 +167,14 @@ __global__ void testBarrierWriteDataKernel(
   uint64_t barrierId = group.group_id;
 
   // The put() API distributes work across all thread groups automatically
-  p2p.put(group, remoteDataBuffer, localSrcBuffer, dataSize);
+  p2p->put(group, remoteDataBuffer, localSrcBuffer, dataSize);
 
   // Each thread group uses its own barrier id
-  p2p.barrier_sync_threadgroup(group, barrierId);
+  p2p->barrier_sync_threadgroup(group, barrierId);
 }
 
 __global__ void testBarrierVerifyDataKernel(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     uint8_t* localDataBuffer,
     size_t dataSize,
     uint8_t expectedValue,
@@ -187,7 +187,7 @@ __global__ void testBarrierVerifyDataKernel(
 
   // Barrier sync - arrive on remote, wait on local
   // This ensures writer's data is visible before we read
-  p2p.barrier_sync_threadgroup(group, barrierId);
+  p2p->barrier_sync_threadgroup(group, barrierId);
 
   // Calculate the portion of data this thread group handles
   size_t bytesPerGroup = dataSize / group.total_groups;
@@ -204,7 +204,7 @@ __global__ void testBarrierVerifyDataKernel(
 }
 
 void testBarrierWriteData(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     char* remoteDataBuffer,
     const char* localSrcBuffer,
     size_t dataSize,
@@ -217,7 +217,7 @@ void testBarrierWriteData(
 }
 
 void testBarrierVerifyData(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     uint8_t* localDataBuffer,
     size_t dataSize,
     uint8_t expectedValue,

--- a/comms/pipes/tests/BarrierTest.cuh
+++ b/comms/pipes/tests/BarrierTest.cuh
@@ -56,7 +56,7 @@ void testReadBarrierExpectedCounter(
 
 // Barrier sync operation using P2pNvlTransportDevice
 void testDeviceBarrierSync(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     uint64_t barrierId,
     int numBlocks,
     int blockSize,
@@ -64,7 +64,7 @@ void testDeviceBarrierSync(
 
 // Multiple barrier syncs in sequence
 void testDeviceBarrierSyncMultiple(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     uint64_t barrierId,
     int numSyncs,
     int numBlocks,
@@ -79,7 +79,7 @@ void testDeviceBarrierSyncMultiple(
 
 // Write data to remote buffer using put() API, then barrier sync
 void testBarrierWriteData(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     char* remoteDataBuffer,
     const char* localSrcBuffer,
     size_t dataSize,
@@ -89,7 +89,7 @@ void testBarrierWriteData(
 
 // Barrier sync, then verify local data matches expected value
 void testBarrierVerifyData(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     uint8_t* localDataBuffer,
     size_t dataSize,
     uint8_t expectedValue,

--- a/comms/pipes/tests/P2pNvlTransportDeviceTest.cc
+++ b/comms/pipes/tests/P2pNvlTransportDeviceTest.cc
@@ -411,30 +411,53 @@ TEST_F(P2pNvlTransportDeviceTwoGpuFixture, DeviceSignalTwoGpu) {
   // Transport on GPU 0: signals to GPU 1's buffer, waits on GPU 0's buffer
   LocalState localState0{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(signalBuffer0, numSignals),
   };
   RemoteState remoteState0{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(signalBuffer1, numSignals),
   };
   P2pNvlTransportDevice transport0(
       kGpu0, kGpu1, options, localState0, remoteState0);
 
+  // Allocate device copy of transport0
+  P2pNvlTransportDevice* transport0_d;
+  CUDACHECK_TEST(cudaMalloc(&transport0_d, sizeof(P2pNvlTransportDevice)));
+  CUDACHECK_TEST(cudaMemcpy(
+      transport0_d,
+      &transport0,
+      sizeof(P2pNvlTransportDevice),
+      cudaMemcpyHostToDevice));
+
   // Transport on GPU 1: signals to GPU 0's buffer, waits on GPU 1's buffer
   LocalState localState1{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(signalBuffer1, numSignals),
   };
   RemoteState remoteState1{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(signalBuffer0, numSignals),
   };
   P2pNvlTransportDevice transport1(
       kGpu1, kGpu0, options, localState1, remoteState1);
+
+  // Allocate device copy of transport1
+  CUDACHECK_TEST(cudaSetDevice(kGpu1));
+  P2pNvlTransportDevice* transport1_d;
+  CUDACHECK_TEST(cudaMalloc(&transport1_d, sizeof(P2pNvlTransportDevice)));
+  CUDACHECK_TEST(cudaMemcpy(
+      transport1_d,
+      &transport1,
+      sizeof(P2pNvlTransportDevice),
+      cudaMemcpyHostToDevice));
 
   const int numBlocks = 1;
   const int blockSize = 32;
@@ -443,30 +466,32 @@ TEST_F(P2pNvlTransportDeviceTwoGpuFixture, DeviceSignalTwoGpu) {
   // GPU 0 signals to GPU 1's buffer
   CUDACHECK_TEST(cudaSetDevice(kGpu0));
   test::testDeviceSignal(
-      transport0, signalId, SignalOp::SIGNAL_SET, 42, numBlocks, blockSize);
+      transport0_d, signalId, SignalOp::SIGNAL_SET, 42, numBlocks, blockSize);
 
   // GPU 1 waits on its local buffer - should complete immediately
   CUDACHECK_TEST(cudaSetDevice(kGpu1));
   test::testDeviceWaitSignal(
-      transport1, signalId, CmpOp::CMP_EQ, 42, numBlocks, blockSize);
+      transport1_d, signalId, CmpOp::CMP_EQ, 42, numBlocks, blockSize);
   CUDACHECK_TEST(cudaDeviceSynchronize());
 
   // Now GPU 1 signals to GPU 0's buffer
   test::testDeviceSignal(
-      transport1, signalId, SignalOp::SIGNAL_SET, 100, numBlocks, blockSize);
+      transport1_d, signalId, SignalOp::SIGNAL_SET, 100, numBlocks, blockSize);
 
   // GPU 0 waits on its local buffer - should complete immediately
   CUDACHECK_TEST(cudaSetDevice(kGpu0));
   test::testDeviceWaitSignal(
-      transport0, signalId, CmpOp::CMP_EQ, 100, numBlocks, blockSize);
+      transport0_d, signalId, CmpOp::CMP_EQ, 100, numBlocks, blockSize);
   CUDACHECK_TEST(cudaDeviceSynchronize());
 
   SUCCEED();
 
   CUDACHECK_TEST(cudaSetDevice(kGpu0));
   CUDACHECK_TEST(cudaFree(signalBuffer0));
+  CUDACHECK_TEST(cudaFree(transport0_d));
   CUDACHECK_TEST(cudaSetDevice(kGpu1));
   CUDACHECK_TEST(cudaFree(signalBuffer1));
+  CUDACHECK_TEST(cudaFree(transport1_d));
 }
 
 TEST_F(P2pNvlTransportDeviceTwoGpuFixture, DeviceSignalTwoGpuMultipleIds) {
@@ -492,29 +517,52 @@ TEST_F(P2pNvlTransportDeviceTwoGpuFixture, DeviceSignalTwoGpuMultipleIds) {
 
   LocalState localState0{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(signalBuffer0, numSignals),
   };
   RemoteState remoteState0{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(signalBuffer1, numSignals),
   };
   P2pNvlTransportDevice transport0(
       kGpu0, kGpu1, options, localState0, remoteState0);
 
+  // Allocate device copy of transport0
+  P2pNvlTransportDevice* transport0_d;
+  CUDACHECK_TEST(cudaMalloc(&transport0_d, sizeof(P2pNvlTransportDevice)));
+  CUDACHECK_TEST(cudaMemcpy(
+      transport0_d,
+      &transport0,
+      sizeof(P2pNvlTransportDevice),
+      cudaMemcpyHostToDevice));
+
   LocalState localState1{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(signalBuffer1, numSignals),
   };
   RemoteState remoteState1{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(signalBuffer0, numSignals),
   };
   P2pNvlTransportDevice transport1(
       kGpu1, kGpu0, options, localState1, remoteState1);
+
+  // Allocate device copy of transport1
+  CUDACHECK_TEST(cudaSetDevice(kGpu1));
+  P2pNvlTransportDevice* transport1_d;
+  CUDACHECK_TEST(cudaMalloc(&transport1_d, sizeof(P2pNvlTransportDevice)));
+  CUDACHECK_TEST(cudaMemcpy(
+      transport1_d,
+      &transport1,
+      sizeof(P2pNvlTransportDevice),
+      cudaMemcpyHostToDevice));
 
   const int numBlocks = 1;
   const int blockSize = 32;
@@ -526,7 +574,7 @@ TEST_F(P2pNvlTransportDeviceTwoGpuFixture, DeviceSignalTwoGpuMultipleIds) {
     // GPU 0 signals to GPU 1 with signalId + 1 as value
     CUDACHECK_TEST(cudaSetDevice(kGpu0));
     test::testDeviceSignal(
-        transport0,
+        transport0_d,
         signalId,
         SignalOp::SIGNAL_SET,
         signalId + 1,
@@ -536,7 +584,7 @@ TEST_F(P2pNvlTransportDeviceTwoGpuFixture, DeviceSignalTwoGpuMultipleIds) {
     // GPU 1 waits for the expected value
     CUDACHECK_TEST(cudaSetDevice(kGpu1));
     test::testDeviceWaitSignal(
-        transport1,
+        transport1_d,
         signalId,
         CmpOp::CMP_EQ,
         signalId + 1,
@@ -549,8 +597,10 @@ TEST_F(P2pNvlTransportDeviceTwoGpuFixture, DeviceSignalTwoGpuMultipleIds) {
 
   CUDACHECK_TEST(cudaSetDevice(kGpu0));
   CUDACHECK_TEST(cudaFree(signalBuffer0));
+  CUDACHECK_TEST(cudaFree(transport0_d));
   CUDACHECK_TEST(cudaSetDevice(kGpu1));
   CUDACHECK_TEST(cudaFree(signalBuffer1));
+  CUDACHECK_TEST(cudaFree(transport1_d));
 }
 
 TEST_F(P2pNvlTransportDeviceTwoGpuFixture, DeviceSignalTwoGpuAdd) {
@@ -576,29 +626,52 @@ TEST_F(P2pNvlTransportDeviceTwoGpuFixture, DeviceSignalTwoGpuAdd) {
 
   LocalState localState0{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(signalBuffer0, numSignals),
   };
   RemoteState remoteState0{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(signalBuffer1, numSignals),
   };
   P2pNvlTransportDevice transport0(
       kGpu0, kGpu1, options, localState0, remoteState0);
 
+  // Allocate device copy of transport0
+  P2pNvlTransportDevice* transport0_d;
+  CUDACHECK_TEST(cudaMalloc(&transport0_d, sizeof(P2pNvlTransportDevice)));
+  CUDACHECK_TEST(cudaMemcpy(
+      transport0_d,
+      &transport0,
+      sizeof(P2pNvlTransportDevice),
+      cudaMemcpyHostToDevice));
+
   LocalState localState1{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(signalBuffer1, numSignals),
   };
   RemoteState remoteState1{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(signalBuffer0, numSignals),
   };
   P2pNvlTransportDevice transport1(
       kGpu1, kGpu0, options, localState1, remoteState1);
+
+  // Allocate device copy of transport1
+  CUDACHECK_TEST(cudaSetDevice(kGpu1));
+  P2pNvlTransportDevice* transport1_d;
+  CUDACHECK_TEST(cudaMalloc(&transport1_d, sizeof(P2pNvlTransportDevice)));
+  CUDACHECK_TEST(cudaMemcpy(
+      transport1_d,
+      &transport1,
+      sizeof(P2pNvlTransportDevice),
+      cudaMemcpyHostToDevice));
 
   const int numBlocks = 1;
   const int blockSize = 32;
@@ -607,24 +680,26 @@ TEST_F(P2pNvlTransportDeviceTwoGpuFixture, DeviceSignalTwoGpuAdd) {
   // GPU 0 adds 5 to GPU 1's signal
   CUDACHECK_TEST(cudaSetDevice(kGpu0));
   test::testDeviceSignal(
-      transport0, signalId, SignalOp::SIGNAL_ADD, 5, numBlocks, blockSize);
+      transport0_d, signalId, SignalOp::SIGNAL_ADD, 5, numBlocks, blockSize);
 
   // GPU 0 adds 10 more to GPU 1's signal
   test::testDeviceSignal(
-      transport0, signalId, SignalOp::SIGNAL_ADD, 10, numBlocks, blockSize);
+      transport0_d, signalId, SignalOp::SIGNAL_ADD, 10, numBlocks, blockSize);
 
   // GPU 1 waits for >= 15
   CUDACHECK_TEST(cudaSetDevice(kGpu1));
   test::testDeviceWaitSignal(
-      transport1, signalId, CmpOp::CMP_GE, 15, numBlocks, blockSize);
+      transport1_d, signalId, CmpOp::CMP_GE, 15, numBlocks, blockSize);
   CUDACHECK_TEST(cudaDeviceSynchronize());
 
   SUCCEED();
 
   CUDACHECK_TEST(cudaSetDevice(kGpu0));
   CUDACHECK_TEST(cudaFree(signalBuffer0));
+  CUDACHECK_TEST(cudaFree(transport0_d));
   CUDACHECK_TEST(cudaSetDevice(kGpu1));
   CUDACHECK_TEST(cudaFree(signalBuffer1));
+  CUDACHECK_TEST(cudaFree(transport1_d));
 }
 
 TEST_F(P2pNvlTransportDeviceTwoGpuFixture, DeviceSignalTwoGpuBlockGroups) {
@@ -650,29 +725,52 @@ TEST_F(P2pNvlTransportDeviceTwoGpuFixture, DeviceSignalTwoGpuBlockGroups) {
 
   LocalState localState0{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(signalBuffer0, numSignals),
   };
   RemoteState remoteState0{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(signalBuffer1, numSignals),
   };
   P2pNvlTransportDevice transport0(
       kGpu0, kGpu1, options, localState0, remoteState0);
 
+  // Allocate device copy of transport0
+  P2pNvlTransportDevice* transport0_d;
+  CUDACHECK_TEST(cudaMalloc(&transport0_d, sizeof(P2pNvlTransportDevice)));
+  CUDACHECK_TEST(cudaMemcpy(
+      transport0_d,
+      &transport0,
+      sizeof(P2pNvlTransportDevice),
+      cudaMemcpyHostToDevice));
+
   LocalState localState1{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(signalBuffer1, numSignals),
   };
   RemoteState remoteState1{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(signalBuffer0, numSignals),
   };
   P2pNvlTransportDevice transport1(
       kGpu1, kGpu0, options, localState1, remoteState1);
+
+  // Allocate device copy of transport1
+  CUDACHECK_TEST(cudaSetDevice(kGpu1));
+  P2pNvlTransportDevice* transport1_d;
+  CUDACHECK_TEST(cudaMalloc(&transport1_d, sizeof(P2pNvlTransportDevice)));
+  CUDACHECK_TEST(cudaMemcpy(
+      transport1_d,
+      &transport1,
+      sizeof(P2pNvlTransportDevice),
+      cudaMemcpyHostToDevice));
 
   const int numBlocks = 1;
   const int blockSize = 256;
@@ -681,7 +779,7 @@ TEST_F(P2pNvlTransportDeviceTwoGpuFixture, DeviceSignalTwoGpuBlockGroups) {
   // GPU 0 signals with block groups
   CUDACHECK_TEST(cudaSetDevice(kGpu0));
   test::testDeviceSignal(
-      transport0,
+      transport0_d,
       signalId,
       SignalOp::SIGNAL_SET,
       999,
@@ -692,7 +790,7 @@ TEST_F(P2pNvlTransportDeviceTwoGpuFixture, DeviceSignalTwoGpuBlockGroups) {
   // GPU 1 waits with block groups
   CUDACHECK_TEST(cudaSetDevice(kGpu1));
   test::testDeviceWaitSignal(
-      transport1,
+      transport1_d,
       signalId,
       CmpOp::CMP_EQ,
       999,
@@ -705,8 +803,10 @@ TEST_F(P2pNvlTransportDeviceTwoGpuFixture, DeviceSignalTwoGpuBlockGroups) {
 
   CUDACHECK_TEST(cudaSetDevice(kGpu0));
   CUDACHECK_TEST(cudaFree(signalBuffer0));
+  CUDACHECK_TEST(cudaFree(transport0_d));
   CUDACHECK_TEST(cudaSetDevice(kGpu1));
   CUDACHECK_TEST(cudaFree(signalBuffer1));
+  CUDACHECK_TEST(cudaFree(transport1_d));
 }
 
 TEST_F(P2pNvlTransportDeviceTwoGpuFixture, DeviceSignalTwoGpuPingPong) {
@@ -734,29 +834,52 @@ TEST_F(P2pNvlTransportDeviceTwoGpuFixture, DeviceSignalTwoGpuPingPong) {
 
   LocalState localState0{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(signalBuffer0, numSignals),
   };
   RemoteState remoteState0{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(signalBuffer1, numSignals),
   };
   P2pNvlTransportDevice transport0(
       kGpu0, kGpu1, options, localState0, remoteState0);
 
+  // Allocate device copy of transport0
+  P2pNvlTransportDevice* transport0_d;
+  CUDACHECK_TEST(cudaMalloc(&transport0_d, sizeof(P2pNvlTransportDevice)));
+  CUDACHECK_TEST(cudaMemcpy(
+      transport0_d,
+      &transport0,
+      sizeof(P2pNvlTransportDevice),
+      cudaMemcpyHostToDevice));
+
   LocalState localState1{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(signalBuffer1, numSignals),
   };
   RemoteState remoteState1{
       .dataBuffer = nullptr,
-      .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
       .signalBuffer = DeviceSpan<SignalState>(signalBuffer0, numSignals),
   };
   P2pNvlTransportDevice transport1(
       kGpu1, kGpu0, options, localState1, remoteState1);
+
+  // Allocate device copy of transport1
+  CUDACHECK_TEST(cudaSetDevice(kGpu1));
+  P2pNvlTransportDevice* transport1_d;
+  CUDACHECK_TEST(cudaMalloc(&transport1_d, sizeof(P2pNvlTransportDevice)));
+  CUDACHECK_TEST(cudaMemcpy(
+      transport1_d,
+      &transport1,
+      sizeof(P2pNvlTransportDevice),
+      cudaMemcpyHostToDevice));
 
   const int numBlocks = 1;
   const int blockSize = 32;
@@ -767,17 +890,22 @@ TEST_F(P2pNvlTransportDeviceTwoGpuFixture, DeviceSignalTwoGpuPingPong) {
     // GPU 0 signals step value to GPU 1
     CUDACHECK_TEST(cudaSetDevice(kGpu0));
     test::testDeviceSignal(
-        transport0, signalId, SignalOp::SIGNAL_SET, step, numBlocks, blockSize);
+        transport0_d,
+        signalId,
+        SignalOp::SIGNAL_SET,
+        step,
+        numBlocks,
+        blockSize);
 
     // GPU 1 waits for step value
     CUDACHECK_TEST(cudaSetDevice(kGpu1));
     test::testDeviceWaitSignal(
-        transport1, signalId, CmpOp::CMP_EQ, step, numBlocks, blockSize);
+        transport1_d, signalId, CmpOp::CMP_EQ, step, numBlocks, blockSize);
     CUDACHECK_TEST(cudaDeviceSynchronize());
 
     // GPU 1 signals step * 10 back to GPU 0
     test::testDeviceSignal(
-        transport1,
+        transport1_d,
         signalId,
         SignalOp::SIGNAL_SET,
         step * 10,
@@ -788,7 +916,7 @@ TEST_F(P2pNvlTransportDeviceTwoGpuFixture, DeviceSignalTwoGpuPingPong) {
     // GPU 0 waits for step * 10
     CUDACHECK_TEST(cudaSetDevice(kGpu0));
     test::testDeviceWaitSignal(
-        transport0, signalId, CmpOp::CMP_EQ, step * 10, numBlocks, blockSize);
+        transport0_d, signalId, CmpOp::CMP_EQ, step * 10, numBlocks, blockSize);
     CUDACHECK_TEST(cudaDeviceSynchronize());
   }
 
@@ -796,8 +924,10 @@ TEST_F(P2pNvlTransportDeviceTwoGpuFixture, DeviceSignalTwoGpuPingPong) {
 
   CUDACHECK_TEST(cudaSetDevice(kGpu0));
   CUDACHECK_TEST(cudaFree(signalBuffer0));
+  CUDACHECK_TEST(cudaFree(transport0_d));
   CUDACHECK_TEST(cudaSetDevice(kGpu1));
   CUDACHECK_TEST(cudaFree(signalBuffer1));
+  CUDACHECK_TEST(cudaFree(transport1_d));
 }
 
 } // namespace comms::pipes

--- a/comms/pipes/tests/P2pNvlTransportDeviceTest.cu
+++ b/comms/pipes/tests/P2pNvlTransportDeviceTest.cu
@@ -23,27 +23,27 @@ __device__ inline ThreadGroup make_group(GroupType groupType) {
 // =============================================================================
 
 __global__ void testDeviceSignalKernel(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     uint64_t signalId,
     SignalOp op,
     uint64_t value,
     GroupType groupType) {
   auto group = make_group(groupType);
-  p2p.signal_threadgroup(group, signalId, op, value);
+  p2p->signal_threadgroup(group, signalId, op, value);
 }
 
 __global__ void testDeviceWaitSignalKernel(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     uint64_t signalId,
     CmpOp op,
     uint64_t value,
     GroupType groupType) {
   auto group = make_group(groupType);
-  p2p.wait_signal_until_threadgroup(group, signalId, op, value);
+  p2p->wait_signal_until_threadgroup(group, signalId, op, value);
 }
 
 __global__ void testDeviceSignalThenWaitKernel(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     uint64_t signalId,
     SignalOp signalOp,
     uint64_t signalValue,
@@ -51,12 +51,12 @@ __global__ void testDeviceSignalThenWaitKernel(
     uint64_t waitValue,
     GroupType groupType) {
   auto group = make_group(groupType);
-  p2p.signal_threadgroup(group, signalId, signalOp, signalValue);
-  p2p.wait_signal_until_threadgroup(group, signalId, waitOp, waitValue);
+  p2p->signal_threadgroup(group, signalId, signalOp, signalValue);
+  p2p->wait_signal_until_threadgroup(group, signalId, waitOp, waitValue);
 }
 
 void testDeviceSignal(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     uint64_t signalId,
     SignalOp op,
     uint64_t value,
@@ -69,7 +69,7 @@ void testDeviceSignal(
 }
 
 void testDeviceWaitSignal(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     uint64_t signalId,
     CmpOp op,
     uint64_t value,
@@ -82,7 +82,7 @@ void testDeviceWaitSignal(
 }
 
 void testDeviceSignalThenWait(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     uint64_t signalId,
     SignalOp signalOp,
     uint64_t signalValue,

--- a/comms/pipes/tests/P2pNvlTransportDeviceTest.cuh
+++ b/comms/pipes/tests/P2pNvlTransportDeviceTest.cuh
@@ -25,7 +25,7 @@ enum class GroupType {
 
 // Signal operation on a single transport (signals to its remote state)
 void testDeviceSignal(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     uint64_t signalId,
     SignalOp op,
     uint64_t value,
@@ -35,7 +35,7 @@ void testDeviceSignal(
 
 // Wait operation on a single transport (waits on its local state)
 void testDeviceWaitSignal(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     uint64_t signalId,
     CmpOp op,
     uint64_t value,
@@ -45,7 +45,7 @@ void testDeviceWaitSignal(
 
 // Signal then wait within a single kernel
 void testDeviceSignalThenWait(
-    P2pNvlTransportDevice p2p,
+    P2pNvlTransportDevice* p2p,
     uint64_t signalId,
     SignalOp signalOp,
     uint64_t signalValue,

--- a/comms/pipes/tests/P2pNvlTransportTest.cc
+++ b/comms/pipes/tests/P2pNvlTransportTest.cc
@@ -22,22 +22,25 @@ using namespace meta::comms;
 
 namespace comms::pipes::tests {
 
-// Parameters for transfer size tests: (nbytes, dataBufferSize, chunkSize, name)
+// Parameters for transfer size tests: (nbytes, dataBufferSize, chunkSize, name,
+// useDualStateBuffer, useCudaGraph)
 struct TransferSizeParams {
   size_t nbytes;
   size_t dataBufferSize;
   size_t chunkSize;
+  bool useDualStateBuffer;
   bool useCudaGraph;
   std::string name;
 };
 
 // Parameters for group type tests: (groupType, numBlocks, blockSize,
-// blocksPerGroup, name)
+// blocksPerGroup, useDualStateBuffer, useCudaGraph, name)
 struct GroupTypeParams {
   test::GroupType groupType;
   int numBlocks;
   int blockSize;
   int blocksPerGroup;
+  bool useDualStateBuffer;
   bool useCudaGraph;
   std::string name;
 };
@@ -393,17 +396,19 @@ TEST_P(TransferSizeTestFixture, SendRecv) {
   const auto& params = GetParam();
   XLOGF(
       INFO,
-      "Running transfer size test: {} (nbytes={}, bufferSize={}, chunkSize={}, cudaGraph={})",
+      "Running transfer size test: {} (nbytes={}, bufferSize={}, chunkSize={}, dualState={}, cudaGraph={})",
       params.name,
       params.nbytes,
       params.dataBufferSize,
       params.chunkSize,
+      params.useDualStateBuffer,
       params.useCudaGraph);
 
   MultiPeerNvlTransportConfig config{
       .dataBufferSize = params.dataBufferSize,
       .chunkSize = params.chunkSize,
       .pipelineDepth = 4,
+      .useDualStateBuffer = params.useDualStateBuffer,
   };
 
   TransportTestHelper helper(globalRank, numRanks, localRank, config);
@@ -432,151 +437,174 @@ INSTANTIATE_TEST_SUITE_P(
     TransferSizeVariations,
     TransferSizeTestFixture,
     ::testing::Values(
+        // ===== SINGLE STATE BUFFER MODE (default) =====
         // Small transfer: nbytes < chunkSize
         TransferSizeParams{
             .nbytes = 512,
             .dataBufferSize = 4096,
             .chunkSize = 1024,
+            .useDualStateBuffer = false,
             .useCudaGraph = false,
-            .name = "SmallTransfer_LessThanChunk"},
+            .name = "SmallTransfer_LessThanChunk_SingleState"},
         TransferSizeParams{
             .nbytes = 512,
             .dataBufferSize = 4096,
             .chunkSize = 1024,
+            .useDualStateBuffer = false,
             .useCudaGraph = true,
-            .name = "SmallTransfer_LessThanChunk"},
+            .name = "SmallTransfer_LessThanChunk_SingleState"},
         // Single chunk: nbytes == chunkSize
         TransferSizeParams{
             .nbytes = 1024,
             .dataBufferSize = 4096,
             .chunkSize = 1024,
+            .useDualStateBuffer = false,
             .useCudaGraph = false,
-            .name = "SingleChunk_ExactMatch"},
+            .name = "SingleChunk_ExactMatch_SingleState"},
         TransferSizeParams{
             .nbytes = 1024,
             .dataBufferSize = 4096,
             .chunkSize = 1024,
+            .useDualStateBuffer = false,
             .useCudaGraph = true,
-            .name = "SingleChunk_ExactMatch"},
+            .name = "SingleChunk_ExactMatch_SingleState"},
         // Transfer not aligned to chunk size
         TransferSizeParams{
             .nbytes = 1000,
             .dataBufferSize = 4096,
             .chunkSize = 256,
+            .useDualStateBuffer = false,
             .useCudaGraph = false,
-            .name = "UnalignedToChunk"},
+            .name = "UnalignedToChunk_SingleState"},
         TransferSizeParams{
             .nbytes = 1000,
             .dataBufferSize = 4096,
             .chunkSize = 256,
+            .useDualStateBuffer = false,
             .useCudaGraph = true,
-            .name = "UnalignedToChunk"},
+            .name = "UnalignedToChunk_SingleState"},
         // Transfer not aligned to vector size (16 bytes)
         TransferSizeParams{
             .nbytes = 1000,
             .dataBufferSize = 4096,
             .chunkSize = 256,
+            .useDualStateBuffer = false,
             .useCudaGraph = false,
-            .name = "NonVectorAligned_1000bytes"},
+            .name = "NonVectorAligned_1000bytes_SingleState"},
         TransferSizeParams{
             .nbytes = 1000,
             .dataBufferSize = 4096,
             .chunkSize = 256,
+            .useDualStateBuffer = false,
             .useCudaGraph = true,
-            .name = "NonVectorAligned_1000bytes"},
+            .name = "NonVectorAligned_1000bytes_SingleState"},
         // Another non-vector-aligned size
         TransferSizeParams{
             .nbytes = 100,
             .dataBufferSize = 1024,
             .chunkSize = 64,
+            .useDualStateBuffer = false,
             .useCudaGraph = false,
-            .name = "NonVectorAligned_100bytes"},
+            .name = "NonVectorAligned_100bytes_SingleState"},
         TransferSizeParams{
             .nbytes = 100,
             .dataBufferSize = 1024,
             .chunkSize = 64,
+            .useDualStateBuffer = false,
             .useCudaGraph = true,
-            .name = "NonVectorAligned_100bytes"},
+            .name = "NonVectorAligned_100bytes_SingleState"},
         // Transfer exactly equals buffer size (single step)
         TransferSizeParams{
             .nbytes = 4096,
             .dataBufferSize = 4096,
             .chunkSize = 256,
+            .useDualStateBuffer = false,
             .useCudaGraph = false,
-            .name = "ExactBufferSize"},
+            .name = "ExactBufferSize_SingleState"},
         TransferSizeParams{
             .nbytes = 4096,
             .dataBufferSize = 4096,
             .chunkSize = 256,
+            .useDualStateBuffer = false,
             .useCudaGraph = true,
-            .name = "ExactBufferSize"},
+            .name = "ExactBufferSize_SingleState"},
         // Multiple steps: transfer > buffer size
         TransferSizeParams{
             .nbytes = 16 * 1024,
             .dataBufferSize = 4096,
             .chunkSize = 256,
+            .useDualStateBuffer = false,
             .useCudaGraph = false,
-            .name = "MultipleSteps_4x"},
+            .name = "MultipleSteps_4x_SingleState"},
         TransferSizeParams{
             .nbytes = 16 * 1024,
             .dataBufferSize = 4096,
             .chunkSize = 256,
+            .useDualStateBuffer = false,
             .useCudaGraph = true,
-            .name = "MultipleSteps_4x"},
+            .name = "MultipleSteps_4x_SingleState"},
         // Large transfer with multiple steps
         TransferSizeParams{
             .nbytes = 4 * 1024 * 1024,
             .dataBufferSize = 1024 * 1024,
             .chunkSize = 4096,
+            .useDualStateBuffer = false,
             .useCudaGraph = false,
-            .name = "LargeMultiStep_4MB"},
+            .name = "LargeMultiStep_4MB_SingleState"},
         TransferSizeParams{
             .nbytes = 4 * 1024 * 1024,
             .dataBufferSize = 1024 * 1024,
             .chunkSize = 4096,
+            .useDualStateBuffer = false,
             .useCudaGraph = true,
-            .name = "LargeMultiStep_4MB"},
+            .name = "LargeMultiStep_4MB_SingleState"},
         // Very large transfer (64MB with 8MB buffer = 8 steps)
         TransferSizeParams{
             .nbytes = 64 * 1024 * 1024,
             .dataBufferSize = 8 * 1024 * 1024,
             .chunkSize = 1024,
+            .useDualStateBuffer = false,
             .useCudaGraph = false,
-            .name = "VeryLargeMultiStep_64MB"},
+            .name = "VeryLargeMultiStep_64MB_SingleState"},
         TransferSizeParams{
             .nbytes = 64 * 1024 * 1024,
             .dataBufferSize = 8 * 1024 * 1024,
             .chunkSize = 1024,
+            .useDualStateBuffer = false,
             .useCudaGraph = true,
-            .name = "VeryLargeMultiStep_64MB"},
+            .name = "VeryLargeMultiStep_64MB_SingleState"},
         // Edge case: stepBytes exactly divisible by chunkSize (no partial
         // chunk) Tests that we don't process any 0-byte chunks
         TransferSizeParams{
             .nbytes = 4096,
             .dataBufferSize = 4096,
             .chunkSize = 1024,
+            .useDualStateBuffer = false,
             .useCudaGraph = false,
-            .name = "ExactChunkBoundary_4Chunks"},
+            .name = "ExactChunkBoundary_4Chunks_SingleState"},
         TransferSizeParams{
             .nbytes = 4096,
             .dataBufferSize = 4096,
             .chunkSize = 1024,
+            .useDualStateBuffer = false,
             .useCudaGraph = true,
-            .name = "ExactChunkBoundary_4Chunks"},
+            .name = "ExactChunkBoundary_4Chunks_SingleState"},
         // Edge case: last chunk has minimal bytes (1 byte remainder)
         // stepBytes=4097, chunkSize=1024 → 5 chunks, last chunk = 1 byte
         TransferSizeParams{
             .nbytes = 4097,
             .dataBufferSize = 8192,
             .chunkSize = 1024,
+            .useDualStateBuffer = false,
             .useCudaGraph = false,
-            .name = "MinimalLastChunk_1Byte"},
+            .name = "MinimalLastChunk_1Byte_SingleState"},
         TransferSizeParams{
             .nbytes = 4097,
             .dataBufferSize = 8192,
             .chunkSize = 1024,
+            .useDualStateBuffer = false,
             .useCudaGraph = true,
-            .name = "MinimalLastChunk_1Byte"},
+            .name = "MinimalLastChunk_1Byte_SingleState"},
         // Edge case: multiple steps where each step ends exactly on chunk
         // boundary 8KB transfer, 4KB buffer, 1KB chunks → 2 steps × 4 chunks
         // each
@@ -584,28 +612,124 @@ INSTANTIATE_TEST_SUITE_P(
             .nbytes = 8 * 1024,
             .dataBufferSize = 4 * 1024,
             .chunkSize = 1024,
+            .useDualStateBuffer = false,
             .useCudaGraph = false,
-            .name = "MultiStep_ExactChunkBoundaries"},
+            .name = "MultiStep_ExactChunkBoundaries_SingleState"},
         TransferSizeParams{
             .nbytes = 8 * 1024,
             .dataBufferSize = 4 * 1024,
             .chunkSize = 1024,
+            .useDualStateBuffer = false,
             .useCudaGraph = true,
-            .name = "MultiStep_ExactChunkBoundaries"},
+            .name = "MultiStep_ExactChunkBoundaries_SingleState"},
         // Edge case: chunkSize larger than stepBytes
         // Forces single chunk per step with partial fill
         TransferSizeParams{
             .nbytes = 2048,
             .dataBufferSize = 1024,
             .chunkSize = 2048,
+            .useDualStateBuffer = false,
             .useCudaGraph = false,
-            .name = "ChunkLargerThanStep"},
+            .name = "ChunkLargerThanStep_SingleState"},
         TransferSizeParams{
             .nbytes = 2048,
             .dataBufferSize = 1024,
             .chunkSize = 2048,
+            .useDualStateBuffer = false,
             .useCudaGraph = true,
-            .name = "ChunkLargerThanStep"}),
+            .name = "ChunkLargerThanStep_SingleState"},
+
+        // ===== DUAL STATE BUFFER MODE =====
+        // Small transfer: nbytes < chunkSize
+        TransferSizeParams{
+            .nbytes = 512,
+            .dataBufferSize = 4096,
+            .chunkSize = 1024,
+            .useDualStateBuffer = true,
+            .useCudaGraph = false,
+            .name = "SmallTransfer_LessThanChunk_DualState"},
+        TransferSizeParams{
+            .nbytes = 512,
+            .dataBufferSize = 4096,
+            .chunkSize = 1024,
+            .useDualStateBuffer = true,
+            .useCudaGraph = true,
+            .name = "SmallTransfer_LessThanChunk_DualState"},
+        // Single chunk: nbytes == chunkSize
+        TransferSizeParams{
+            .nbytes = 1024,
+            .dataBufferSize = 4096,
+            .chunkSize = 1024,
+            .useDualStateBuffer = true,
+            .useCudaGraph = false,
+            .name = "SingleChunk_ExactMatch_DualState"},
+        TransferSizeParams{
+            .nbytes = 1024,
+            .dataBufferSize = 4096,
+            .chunkSize = 1024,
+            .useDualStateBuffer = true,
+            .useCudaGraph = true,
+            .name = "SingleChunk_ExactMatch_DualState"},
+        // Transfer not aligned to chunk size
+        TransferSizeParams{
+            .nbytes = 1000,
+            .dataBufferSize = 4096,
+            .chunkSize = 256,
+            .useDualStateBuffer = true,
+            .useCudaGraph = false,
+            .name = "UnalignedToChunk_DualState"},
+        TransferSizeParams{
+            .nbytes = 1000,
+            .dataBufferSize = 4096,
+            .chunkSize = 256,
+            .useDualStateBuffer = true,
+            .useCudaGraph = true,
+            .name = "UnalignedToChunk_DualState"},
+        // Multiple steps: transfer > buffer size
+        TransferSizeParams{
+            .nbytes = 16 * 1024,
+            .dataBufferSize = 4096,
+            .chunkSize = 256,
+            .useDualStateBuffer = true,
+            .useCudaGraph = false,
+            .name = "MultipleSteps_4x_DualState"},
+        TransferSizeParams{
+            .nbytes = 16 * 1024,
+            .dataBufferSize = 4096,
+            .chunkSize = 256,
+            .useDualStateBuffer = true,
+            .useCudaGraph = true,
+            .name = "MultipleSteps_4x_DualState"},
+        // Large transfer with multiple steps
+        TransferSizeParams{
+            .nbytes = 4 * 1024 * 1024,
+            .dataBufferSize = 1024 * 1024,
+            .chunkSize = 4096,
+            .useDualStateBuffer = true,
+            .useCudaGraph = false,
+            .name = "LargeMultiStep_4MB_DualState"},
+        TransferSizeParams{
+            .nbytes = 4 * 1024 * 1024,
+            .dataBufferSize = 1024 * 1024,
+            .chunkSize = 4096,
+            .useDualStateBuffer = true,
+            .useCudaGraph = true,
+            .name = "LargeMultiStep_4MB_DualState"},
+        // Very large transfer (64MB with 8MB buffer = 8 steps)
+        TransferSizeParams{
+            .nbytes = 64 * 1024 * 1024,
+            .dataBufferSize = 8 * 1024 * 1024,
+            .chunkSize = 1024,
+            .useDualStateBuffer = true,
+            .useCudaGraph = false,
+            .name = "VeryLargeMultiStep_64MB_DualState"},
+        TransferSizeParams{
+            .nbytes = 64 * 1024 * 1024,
+            .dataBufferSize = 8 * 1024 * 1024,
+            .chunkSize = 1024,
+            .useDualStateBuffer = true,
+            .useCudaGraph = true,
+            .name = "VeryLargeMultiStep_64MB_DualState"}),
     transferSizeParamName);
 
 // =============================================================================
@@ -631,10 +755,11 @@ TEST_P(GroupTypeTestFixture, SendRecv) {
   const auto& params = GetParam();
   XLOGF(
       INFO,
-      "Running group type test: {} (numBlocks={}, blockSize={}, cudaGraph={})",
+      "Running group type test: {} (numBlocks={}, blockSize={}, dualState={}, cudaGraph={})",
       params.name,
       params.numBlocks,
       params.blockSize,
+      params.useDualStateBuffer,
       params.useCudaGraph);
 
   const size_t dataBufferSize = 1024 * 1024; // 1MB staging buffer
@@ -643,6 +768,7 @@ TEST_P(GroupTypeTestFixture, SendRecv) {
       .dataBufferSize = dataBufferSize,
       .chunkSize = 1024,
       .pipelineDepth = 4,
+      .useDualStateBuffer = params.useDualStateBuffer,
   };
 
   TransportTestHelper helper(globalRank, numRanks, localRank, config);
@@ -668,78 +794,117 @@ INSTANTIATE_TEST_SUITE_P(
     GroupTypeVariations,
     GroupTypeTestFixture,
     ::testing::Values(
+        // ===== SINGLE STATE BUFFER MODE (default) =====
         // Warp-based groups (32 threads per group)
         GroupTypeParams{
             .groupType = test::GroupType::WARP,
             .numBlocks = 4,
             .blockSize = 128,
             .blocksPerGroup = 1,
+            .useDualStateBuffer = false,
             .useCudaGraph = false,
-            .name = "Warp_4Blocks_128Threads"},
+            .name = "Warp_4Blocks_128Threads_SingleState"},
         GroupTypeParams{
             .groupType = test::GroupType::WARP,
             .numBlocks = 4,
             .blockSize = 128,
             .blocksPerGroup = 1,
+            .useDualStateBuffer = false,
             .useCudaGraph = true,
-            .name = "Warp_4Blocks_128Threads"},
+            .name = "Warp_4Blocks_128Threads_SingleState"},
         GroupTypeParams{
             .groupType = test::GroupType::WARP,
             .numBlocks = 8,
             .blockSize = 256,
             .blocksPerGroup = 1,
+            .useDualStateBuffer = false,
             .useCudaGraph = false,
-            .name = "Warp_8Blocks_256Threads"},
+            .name = "Warp_8Blocks_256Threads_SingleState"},
         GroupTypeParams{
             .groupType = test::GroupType::WARP,
             .numBlocks = 8,
             .blockSize = 256,
             .blocksPerGroup = 1,
+            .useDualStateBuffer = false,
             .useCudaGraph = true,
-            .name = "Warp_8Blocks_256Threads"},
+            .name = "Warp_8Blocks_256Threads_SingleState"},
         // Block-based groups (all threads in block form one group)
         GroupTypeParams{
             .groupType = test::GroupType::BLOCK,
             .numBlocks = 4,
             .blockSize = 128,
             .blocksPerGroup = 1,
+            .useDualStateBuffer = false,
             .useCudaGraph = false,
-            .name = "Block_4Groups_128Threads"},
+            .name = "Block_4Groups_128Threads_SingleState"},
         GroupTypeParams{
             .groupType = test::GroupType::BLOCK,
             .numBlocks = 4,
             .blockSize = 128,
             .blocksPerGroup = 1,
+            .useDualStateBuffer = false,
             .useCudaGraph = true,
-            .name = "Block_4Groups_128Threads"},
+            .name = "Block_4Groups_128Threads_SingleState"},
         GroupTypeParams{
             .groupType = test::GroupType::BLOCK,
             .numBlocks = 8,
             .blockSize = 256,
             .blocksPerGroup = 1,
+            .useDualStateBuffer = false,
             .useCudaGraph = false,
-            .name = "Block_8Groups_256Threads"},
+            .name = "Block_8Groups_256Threads_SingleState"},
         GroupTypeParams{
             .groupType = test::GroupType::BLOCK,
             .numBlocks = 8,
             .blockSize = 256,
             .blocksPerGroup = 1,
+            .useDualStateBuffer = false,
             .useCudaGraph = true,
-            .name = "Block_8Groups_256Threads"},
+            .name = "Block_8Groups_256Threads_SingleState"},
         GroupTypeParams{
             .groupType = test::GroupType::BLOCK,
             .numBlocks = 2,
             .blockSize = 512,
             .blocksPerGroup = 1,
+            .useDualStateBuffer = false,
             .useCudaGraph = false,
-            .name = "Block_2Groups_512Threads"},
+            .name = "Block_2Groups_512Threads_SingleState"},
         GroupTypeParams{
             .groupType = test::GroupType::BLOCK,
             .numBlocks = 2,
             .blockSize = 512,
             .blocksPerGroup = 1,
+            .useDualStateBuffer = false,
             .useCudaGraph = true,
-            .name = "Block_2Groups_512Threads"}),
+            .name = "Block_2Groups_512Threads_SingleState"},
+
+        // ===== DUAL STATE BUFFER MODE =====
+        // Warp-based groups (32 threads per group)
+        GroupTypeParams{
+            .groupType = test::GroupType::WARP,
+            .numBlocks = 4,
+            .blockSize = 128,
+            .blocksPerGroup = 1,
+            .useDualStateBuffer = true,
+            .useCudaGraph = false,
+            .name = "Warp_4Blocks_128Threads_DualState"},
+        GroupTypeParams{
+            .groupType = test::GroupType::WARP,
+            .numBlocks = 8,
+            .blockSize = 256,
+            .blocksPerGroup = 1,
+            .useDualStateBuffer = true,
+            .useCudaGraph = false,
+            .name = "Warp_8Blocks_256Threads_DualState"},
+        // Block-based groups (all threads in block form one group)
+        GroupTypeParams{
+            .groupType = test::GroupType::BLOCK,
+            .numBlocks = 4,
+            .blockSize = 128,
+            .blocksPerGroup = 1,
+            .useDualStateBuffer = true,
+            .useCudaGraph = false,
+            .name = "Block_4Groups_128Threads_DualState"}),
     groupTypeParamName);
 
 // =============================================================================
@@ -949,7 +1114,7 @@ TEST_F(P2pNvlTransportTestFixture, MultiSendInKernel) {
 
   const size_t dataBufferSize = 512 * 1024; // 512KB staging buffer
   const size_t nbytesPerSend = 256 * 1024; // 256KB per send
-  const int numSends = 4;
+  const int numSends = 16;
   const size_t totalBytes = nbytesPerSend * numSends;
 
   MultiPeerNvlTransportConfig config{
@@ -983,6 +1148,7 @@ TEST_F(P2pNvlTransportTestFixture, MultiSendInKernel) {
     test::testMultiSend(
         p2p, src_d, nbytesPerSend, numSends, numBlocks, blockSize);
     CUDACHECK_TEST(cudaDeviceSynchronize());
+    std::cout << "Rank 0: MultiSendInKernel test completed" << std::endl;
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
   } else {
     CUDACHECK_TEST(cudaMemset(dst_d, 0, totalBytes));
@@ -991,6 +1157,7 @@ TEST_F(P2pNvlTransportTestFixture, MultiSendInKernel) {
     test::testMultiRecv(
         p2p, dst_d, nbytesPerSend, numSends, numBlocks, blockSize);
     CUDACHECK_TEST(cudaDeviceSynchronize());
+    std::cout << "Rank 1: MultiRecvKernel test completed" << std::endl;
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 
     // Verify each segment

--- a/comms/pipes/tests/ThreadGroupTest.cc
+++ b/comms/pipes/tests/ThreadGroupTest.cc
@@ -224,7 +224,7 @@ class ThreadGroupStridedTest
 // 4. This mapping is deterministic regardless of total_items
 //
 // Why this matters:
-// - ROUND-ROBIN pattern ensures consistent chunk-to-group mapping
+// - STRIDED pattern ensures consistent chunk-to-group mapping
 // - Useful when groups maintain local state for specific chunks
 // - e.g., ChunkState tracking where each group "owns" certain chunks
 //
@@ -260,7 +260,7 @@ TEST_P(ThreadGroupStridedTest, ForEachItemStridedLocality) {
       &errorCount_h, errorCount_d, sizeof(uint32_t), cudaMemcpyDeviceToHost));
 
   EXPECT_EQ(errorCount_h, 0)
-      << "Round-robin pattern should assign item K to group (K % total_groups) ("
+      << "Strided pattern should assign item K to group (K % total_groups) ("
       << params.description << ")";
 
   std::vector<uint32_t> groupIds_h(numItems);
@@ -847,9 +847,9 @@ class ThreadGroupPartitionInterleavedTest
     : public ThreadGroupTestFixture,
       public ::testing::WithParamInterface<PartitionTestParams> {};
 
-// Test: partition_interleaved round-robin assignment
+// Test: partition_interleaved strided assignment
 // Verifies:
-// - partition_id = group_id % num_partitions (round-robin)
+// - partition_id = group_id % num_partitions (strided)
 // - subgroup.group_id = group_id / num_partitions (renumbered within partition)
 // - subgroup.total_groups = (total_groups + num_partitions - 1 - pid) /
 // num_partitions
@@ -949,7 +949,7 @@ TEST_P(ThreadGroupPartitionInterleavedTest, PartitionInterleaved) {
   }
 
   EXPECT_EQ(partitionIds_h, expectedPartitionIds)
-      << "Partition IDs should follow interleaved (round-robin) pattern";
+      << "Partition IDs should follow interleaved (strided) pattern";
   EXPECT_EQ(subgroupIds_h, expectedSubgroupIds)
       << "Subgroup IDs should be sequential within each partition";
   EXPECT_EQ(subgroupTotalGroups_h, expectedTotalGroups)

--- a/comms/pipes/tests/ThreadGroupTest.cuh
+++ b/comms/pipes/tests/ThreadGroupTest.cuh
@@ -110,7 +110,7 @@ void testWeightedPartition(
     int blockSize,
     SyncScope scope);
 
-// Tests partition_interleaved(num_partitions) - round-robin partition
+// Tests partition_interleaved(num_partitions) - interleaved partition
 // Verifies:
 // - Each group gets partition_id = group_id % num_partitions
 // - subgroup.group_id is renumbered as group_id / num_partitions


### PR DESCRIPTION
Summary:

This diff adds an experimental dual-chunkstate mode to P2pNvlTransportDevice that enables local busy-polling instead of remote NVLink polling, achieving up to 5% busbw gain.

## Motivation

In the original single-chunkstate design, the sender busy-waits on REMOTE memory via NVLink to check if the receiver has freed the buffer. This NVLink round-trip adds latency and may congest NVLink path, especially for larger message sizes.

## Solution: Dual-Chunkstate Mode

When `useDualStateBuffer = true`, we use two ChunkState buffers per peer:
- receiverState = state to poll if I am a receiver (sender signals when write complete)
- senderState = state to poll if I am a sender (receiver signals when read complete)

This allows BOTH sender and receiver to poll LOCAL memory, eliminating NVLink round-trip latency and reduce NVLink contention during busy-wait synchronization.

### State Machine Comparison

**Single State Mode** (original):
```
Sender                           Receiver
──────                           ────────
Wait REMOTE for READY_TO_SEND    Wait LOCAL for stepId
  (NVLink poll - slow)             (local poll - fast)
Copy data via NVLink             Copy from local buffer
Signal REMOTE with stepId        Signal LOCAL with READY_TO_SEND
```

**Dual State Mode** (new):
```
Sender                           Receiver
──────                           ────────
Wait LOCAL for READY_TO_SEND     Wait LOCAL for stepId
  (local poll - fast)              (local poll - fast)
Copy data via NVLink             Copy from local buffer
Mark LOCAL as UNREADY            Mark LOCAL as UNREADY
  (prevent re-send)                (prevent re-read)
Signal REMOTE with stepId        Signal REMOTE READY_TO_SEND
  (data ready)                     (sender can send again)
```

**State Buffers per Peer:**
- `senderStateBuffer`: State to poll if I am a sender (init: READY_TO_SEND)
- `receiverStateBuffer`: State to poll if I am a receiver (init: UNREADY)

**Strided Chunk Assignment Requirement:**
The UNREADY state uses plain write + `group.sync()` instead of `st.release.gpu` for efficiency. This write is only visible within the same thread group. Dual-chunkstate MUST use `for_each_item_strided` to ensure chunk `K` is ALWAYS assigned to group `(K % total_groups)`, making the unready write visible to the same group in subsequent iterations.


## Performance Results
see Test Plan

## Next
- Integrate to Ctran SendRecv, alltoallv, send_one/multiple, dispatch to measure perf gain

Reviewed By: siyengar

Differential Revision: D91619478


