### PR TITLE
Disable CI for benchmark targets and fix build errors

### DIFF
--- a/comms/pipes/collectives/AllToAllv.cuh
+++ b/comms/pipes/collectives/AllToAllv.cuh
@@ -7,7 +7,7 @@
 #include <cstdio>
 
 #include "comms/pipes/DeviceSpan.cuh"
-#include "comms/pipes/TimeoutUtils.cuh"
+#include "comms/pipes/Timeout.cuh"
 #include "comms/pipes/Transport.cuh"
 
 namespace comms::pipes {

--- a/comms/pipes/collectives/benchmarks/CollectiveBenchmark.cuh
+++ b/comms/pipes/collectives/benchmarks/CollectiveBenchmark.cuh
@@ -4,7 +4,7 @@
 
 #include <cuda_runtime.h>
 
-#include "comms/pipes/TimeoutUtils.cuh"
+#include "comms/pipes/Timeout.cuh"
 #include "comms/pipes/collectives/AllToAllv.cuh"
 
 namespace comms::pipes::benchmark {


### PR DESCRIPTION
Summary:
Benchmark targets in pipes/benchmarks and pipes/collectives/benchmarks
were running in Sandcastle CI despite being intended for manual performance
testing only. This change:

1. Adds PACKAGE files to both benchmark directories to exclude them from
   all CI builds (both diff and continuous)
2. Fixes a missing dependency on //comms/pipes/benchmarks:benchmark_kernels
   in the alltoallv_benchmark target
3. Fixes incorrect include path from TimeoutUtils.cuh to Timeout.cuh in
   CollectiveBenchmark.cuh and AllToAllv.cuh
4. Adds missing //comms/pipes:timeout_utils dependency to
   collective_benchmark_kernels

Reviewed By: saifhhasan

Differential Revision: D91956471


