### PR TITLE
Move SendRecv kernel args to Types.h (P1-D1)

### DIFF
--- a/comms/ctran/algos/SendRecv/SendRecv.cu
+++ b/comms/ctran/algos/SendRecv/SendRecv.cu
@@ -18,7 +18,7 @@ __shared__ UnpackBlockState sendRecvUnpack;
 __global__ void __launch_bounds__(1024, 1) ncclKernelSend(
     int* flag,
     CtranAlgoDeviceState* devState,
-    CtranKernelSendArgs args) {
+    ctran::sendrecv::KernelSendArgs args) {
   const auto tId = threadIdx.x;
   const auto bId = blockIdx.x;
 
@@ -48,7 +48,7 @@ template <bool UNPACK>
 __global__ void __launch_bounds__(1024, 1) ncclKernelRecv(
     int* flag,
     CtranAlgoDeviceState* devState,
-    CtranKernelRecvArgs args) {
+    ctran::sendrecv::KernelRecvArgs args) {
   const auto tId = threadIdx.x;
   const auto bId = blockIdx.x;
 
@@ -83,7 +83,7 @@ template <bool UNPACK>
 __global__ void __launch_bounds__(1024, 1) ncclKernelSendRecv(
     int* flag,
     CtranAlgoDeviceState* devState,
-    CtranKernelSendRecvArgs args) {
+    ctran::sendrecv::KernelSendRecvArgs args) {
   const auto tId = threadIdx.x;
   const auto bId = blockIdx.x;
 
@@ -124,7 +124,7 @@ __global__ void __launch_bounds__(1024, 1) ncclKernelSendRecv(
 __global__ void __launch_bounds__(1024, 1) ncclKernelSendRecvNotifyOnly(
     int* flag,
     CtranAlgoDeviceState* devState,
-    CtranKernelSendRecvArgs args) {
+    ctran::sendrecv::KernelSendRecvArgs args) {
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
 
   if (flag && gtIdx == 0) {
@@ -152,7 +152,7 @@ __global__ void __launch_bounds__(1024, 1) ncclKernelSendRecvNotifyOnly(
 __global__ void __launch_bounds__(1024, 1) ncclKernelSendNotifyOnly(
     int* flag,
     CtranAlgoDeviceState* devState,
-    CtranKernelSendArgs args) {
+    ctran::sendrecv::KernelSendArgs args) {
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
 
   if (flag && gtIdx == 0) {
@@ -175,7 +175,7 @@ __global__ void __launch_bounds__(1024, 1) ncclKernelSendNotifyOnly(
 __global__ void __launch_bounds__(1, 1) ncclKernelRecvNotifyOnly(
     int* flag,
     CtranAlgoDeviceState* devState,
-    CtranKernelRecvArgs args) {
+    ctran::sendrecv::KernelRecvArgs args) {
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
 
   if (flag && gtIdx == 0) {
@@ -195,11 +195,15 @@ __global__ void __launch_bounds__(1, 1) ncclKernelRecvNotifyOnly(
   }
 }
 
-#define DECL_SENDRECV_KERN(UNPACK)                                          \
-  template __global__ void ncclKernelRecv<UNPACK>(                          \
-      int* flag, CtranAlgoDeviceState* devState, CtranKernelRecvArgs args); \
-  template __global__ void ncclKernelSendRecv<UNPACK>(                      \
-      int* flag, CtranAlgoDeviceState* devState, CtranKernelSendRecvArgs args)
+#define DECL_SENDRECV_KERN(UNPACK)                     \
+  template __global__ void ncclKernelRecv<UNPACK>(     \
+      int* flag,                                       \
+      CtranAlgoDeviceState* devState,                  \
+      ctran::sendrecv::KernelRecvArgs args);           \
+  template __global__ void ncclKernelSendRecv<UNPACK>( \
+      int* flag,                                       \
+      CtranAlgoDeviceState* devState,                  \
+      ctran::sendrecv::KernelSendRecvArgs args)
 
 DECL_SENDRECV_KERN(/*UNPACK=*/false);
 DECL_SENDRECV_KERN(/*UNPACK=*/true);

--- a/comms/ctran/gpe/CtranGpe.h
+++ b/comms/ctran/gpe/CtranGpe.h
@@ -463,34 +463,34 @@ __global__ void ncclKernelAllReduceARG(
 extern __global__ void ncclKernelSend(
     int* flag,
     CtranAlgoDeviceState* devState,
-    CtranKernelSendArgs args);
+    ctran::sendrecv::KernelSendArgs args);
 
 template <bool UNPACK>
 extern __global__ void ncclKernelRecv(
     int* flag,
     CtranAlgoDeviceState* devState,
-    CtranKernelRecvArgs args);
+    ctran::sendrecv::KernelRecvArgs args);
 
 template <bool UNPACK>
 extern __global__ void ncclKernelSendRecv(
     int* flag,
     CtranAlgoDeviceState* devState,
-    CtranKernelSendRecvArgs args);
+    ctran::sendrecv::KernelSendRecvArgs args);
 
 extern __global__ void ncclKernelSendNotifyOnly(
     int* flag,
     CtranAlgoDeviceState* devState,
-    CtranKernelSendArgs args);
+    ctran::sendrecv::KernelSendArgs args);
 
 extern __global__ void ncclKernelRecvNotifyOnly(
     int* flag,
     CtranAlgoDeviceState* devState,
-    CtranKernelRecvArgs args);
+    ctran::sendrecv::KernelRecvArgs args);
 
 extern __global__ void ncclKernelSendRecvNotifyOnly(
     int* flag,
     CtranAlgoDeviceState* devState,
-    CtranKernelSendRecvArgs args);
+    ctran::sendrecv::KernelSendRecvArgs args);
 
 extern __global__ void ncclKernelSendRecvStaged(
     int* flag,

--- a/comms/ctran/gpe/CtranGpeDev.h
+++ b/comms/ctran/gpe/CtranGpeDev.h
@@ -8,14 +8,9 @@
 
 #include "comms/ctran/algos/CtranAlgoArgDev.h"
 #include "comms/ctran/algos/CtranAlgoDev.h"
+#include "comms/ctran/algos/SendRecv/Types.h"
 #include "comms/ctran/utils/Abort.h"
 #include "comms/utils/commSpecs.h"
-
-#ifdef CTRAN_DISABLE_TCPDM
-#include "comms/ctran/backends/mock/CtranTcpDmBaseMock.h"
-#else
-#include "comms/tcp_devmem/unpack/batch_unpack_kernel.h"
-#endif
 
 // Used for ngroups value checking only. For H100, >128 is not possible.
 #define MAX_NGROUPS (128)
@@ -184,30 +179,6 @@ enum class AllReduceKernElemRole {
   kRemInterReduce
 };
 
-struct CtranKernelSendArgs {
-  // List of send p2p elements each will be transferred via NVL copy
-  KernelElem* putNotifyList;
-  // used for checksum
-  const void* sendbuff;
-  commDataType_t datatype;
-  size_t count;
-};
-
-struct CtranKernelRecvArgs {
-  KernelElem* waitNotifyList;
-  // used for checksum
-  const void* recvbuff;
-  commDataType_t datatype;
-  size_t count;
-  SQueues unpack; // TCP Device Memory
-};
-
-struct CtranKernelSendRecvArgs {
-  KernelElem* putNotifyList;
-  KernelElem* waitNotifyList;
-  SQueues unpack; // TCP Device Memory
-};
-
 struct CtranKernelAllToAllArgs {
   const void* sendbuff;
   void* recvbuff;
@@ -316,9 +287,9 @@ struct CtranKernelArgs {
   union {
     CtranKernelAllGatherArgs allgather;
     CtranKernelAllReduceArgs allreduce;
-    CtranKernelSendArgs send;
-    CtranKernelRecvArgs recv;
-    CtranKernelSendRecvArgs sendrecv;
+    ctran::sendrecv::KernelSendArgs send;
+    ctran::sendrecv::KernelRecvArgs recv;
+    ctran::sendrecv::KernelSendRecvArgs sendrecv;
     CtranKernelAllToAllArgs alltoall;
     CtranKernelAllToAllvArgs alltoallv;
     CtranKernelAllToAllvDynamicArgs alltoallv_dynamic;


### PR DESCRIPTION
Summary:
Move CtranKernelSendArgs, CtranKernelRecvArgs, and CtranKernelSendRecvArgs from
gpe/CtranGpeDev.h to algos/SendRecv/Types.h as ctran::sendrecv::KernelSendArgs,
KernelRecvArgs, and KernelSendRecvArgs respectively.

Part of KernelElem cleanup Phase 1.

Naming follows the convention:
- Remove "Ctran" prefix
- Keep "Kernel" prefix
- Keep "Send/Recv/SendRecv" suffix since they're distinct types

Differential Revision: D91983715


