### PR TITLE
Move AllReduce kernel args to Types.h (P1-D5)

### DIFF
--- a/comms/ctran/algos/AllReduce/AllReduceARG.cuh
+++ b/comms/ctran/algos/AllReduce/AllReduceARG.cuh
@@ -3,6 +3,7 @@
 
 #pragma once
 #include "comms/ctran/algos/AllReduce/AllReduceARGCommonDev.h"
+#include "comms/ctran/algos/AllReduce/Types.h"
 #include "comms/ctran/algos/CtranAlgoDev.h"
 #include "comms/ctran/algos/DevAlgoImpl.cuh"
 #include "comms/ctran/algos/DevCommon.cuh"
@@ -12,7 +13,7 @@
 
 template <typename T>
 __device__ void prepareBcastArg(
-    CtranKernelAllReduceArgs& args,
+    ctran::allreduce::KernelArgs& args,
     ctran::allreduce::arg::AllReduceARGContext& context,
     CtranAlgoDevBcastArg& bcastArg) {
   const auto localRank = statex->localRank();
@@ -43,7 +44,7 @@ __device__ void prepareBcastArg(
 template <typename T, typename RedT, commRedOp_t RedOp>
 __device__ __forceinline__ void reduceInLocal(
     CtranAlgoDeviceState* devState,
-    CtranKernelAllReduceArgs& args,
+    ctran::allreduce::KernelArgs& args,
     ctran::allreduce::arg::AllReduceARGContext& context) {
   bool revoked = false;
   const auto nRanks = statex->nRanks();
@@ -71,7 +72,7 @@ __device__ __forceinline__ void reduceInLocal(
 template <typename T>
 __device__ __forceinline__ void intraNodeAllGather(
     CtranAlgoDeviceState* devState,
-    CtranKernelAllReduceArgs& args,
+    ctran::allreduce::KernelArgs& args,
     ctran::allreduce::arg::AllReduceARGContext& context) {
   bool allGatherRevoke;
   KernelElem* elem = args.kernelElems[ctran::allreduce::arg::kIntraAllGather];
@@ -91,7 +92,7 @@ __device__ __forceinline__ void intraNodeAllGather(
 template <typename T>
 __device__ __forceinline__ void alltoall(
     CtranAlgoDeviceState* devState,
-    CtranKernelAllReduceArgs& args,
+    ctran::allreduce::KernelArgs& args,
     ctran::allreduce::arg::AllReduceARGContext& context) {
   KernelElem* alltoall =
       args.kernelElems[ctran::allreduce::arg::kIntraAllToAll];
@@ -142,7 +143,7 @@ template <typename T, typename RedT, commRedOp_t RedOp>
 __global__ void ncclKernelAllReduceARG(
     int* flag,
     CtranAlgoDeviceState* devState,
-    CtranKernelAllReduceArgs args) {
+    ctran::allreduce::KernelArgs args) {
   const auto tId = threadIdx.x;
   const auto bId = blockIdx.x;
   if (flag && tId == 0) {
@@ -221,12 +222,12 @@ __global__ void ncclKernelAllReduceARG(
   template __global__ void ncclKernelAllReduceARG<T, T, RedOp>( \
       int* flag,                                                \
       CtranAlgoDeviceState* devState,                           \
-      CtranKernelAllReduceArgs args);
+      ctran::allreduce::KernelArgs args);
 
 #define DECL_CTRAN_ALLREDUCEARG_KERN_REDT(T, RedT, RedOp)          \
   template __global__ void ncclKernelAllReduceARG<T, RedT, RedOp>( \
       int* flag,                                                   \
       CtranAlgoDeviceState* devState,                              \
-      CtranKernelAllReduceArgs args);
+      ctran::allreduce::KernelArgs args);
 
 #endif // !defined(USE_ROCM)

--- a/comms/ctran/algos/AllReduce/Types.h
+++ b/comms/ctran/algos/AllReduce/Types.h
@@ -1,0 +1,40 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include "comms/ctran/algos/CtranAlgoDev.h"
+#include "comms/utils/commSpecs.h"
+
+// Forward declaration
+struct KernelElem;
+
+#define ALLREDUCE_MAX_KERNEL_ELEMS (8)
+
+namespace ctran::allreduce {
+
+enum class KernElemRole {
+  kIntraReduceScatter,
+  kInterReduceScatter,
+  kIntraAllGather,
+  kRemIntraReduce,
+  kRemIntraBcast,
+  kRemInterReduce
+};
+
+struct KernelArgs {
+  const void* sendbuff;
+  void* recvbuff;
+  commDataType_t datatype;
+  commRedOp_t redOp;
+  size_t count;
+  size_t nSteps;
+  void* tmpbuff;
+  size_t tmpbuffSize;
+  // IPC imported ptr to each of the local peers' tmpRecvBuff
+  void* intraNodeRemoteTmpRecvBuffs[CTRAN_MAX_NVL_PEERS];
+  // IPC imported ptr to each of the local peers' RecvBuff
+  void* intraNodeRemoteRecvBuffs[CTRAN_MAX_NVL_PEERS];
+  KernelElem* kernelElems[ALLREDUCE_MAX_KERNEL_ELEMS];
+};
+
+} // namespace ctran::allreduce

--- a/comms/ctran/gpe/CtranGpe.h
+++ b/comms/ctran/gpe/CtranGpe.h
@@ -13,6 +13,7 @@
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/CtranExImpl.h"
 #include "comms/ctran/algos/AllGather/Types.h"
+#include "comms/ctran/algos/AllReduce/Types.h"
 #include "comms/ctran/algos/AllToAll/Types.h"
 #include "comms/ctran/algos/Broadcast/Types.h"
 #include "comms/ctran/algos/CtranAlgoDev.h"
@@ -455,13 +456,13 @@ template <typename T, commRedOp_t RedOp>
 __global__ void ncclKernelAllReduceCtranDirect(
     int* flag,
     CtranAlgoDeviceState* devState,
-    CtranKernelAllReduceArgs args);
+    ctran::allreduce::KernelArgs args);
 
 template <typename T, typename RedT, commRedOp_t RedOp>
 __global__ void ncclKernelAllReduceARG(
     int* flag,
     CtranAlgoDeviceState* devState,
-    CtranKernelAllReduceArgs args);
+    ctran::allreduce::KernelArgs args);
 
 extern __global__ void ncclKernelSend(
     int* flag,

--- a/comms/ctran/gpe/CtranGpeDev.h
+++ b/comms/ctran/gpe/CtranGpeDev.h
@@ -7,6 +7,7 @@
 #include <stdint.h>
 
 #include "comms/ctran/algos/AllGather/Types.h"
+#include "comms/ctran/algos/AllReduce/Types.h"
 #include "comms/ctran/algos/Broadcast/Types.h"
 #include "comms/ctran/algos/CtranAlgoArgDev.h"
 #include "comms/ctran/algos/CtranAlgoDev.h"
@@ -149,31 +150,6 @@ struct fmt::formatter<KernelElem::ElemStatus> : fmt::formatter<int> {
   }
 };
 
-#define ALLREDUCE_MAX_KERNEL_ELEMS (8)
-struct CtranKernelAllReduceArgs {
-  const void* sendbuff;
-  void* recvbuff;
-  commDataType_t datatype;
-  commRedOp_t redOp;
-  size_t count;
-  size_t nSteps;
-  void* tmpbuff;
-  size_t tmpbuffSize;
-  // IPC imported ptr to each of the local peers' tmpRecvBuff
-  void* intraNodeRemoteTmpRecvBuffs[CTRAN_MAX_NVL_PEERS];
-  // IPC imported ptr to each of the local peers' RecvBuff
-  void* intraNodeRemoteRecvBuffs[CTRAN_MAX_NVL_PEERS];
-  KernelElem* kernelElems[ALLREDUCE_MAX_KERNEL_ELEMS];
-};
-enum class AllReduceKernElemRole {
-  kIntraReduceScatter,
-  kInterReduceScatter,
-  kIntraAllGather,
-  kRemIntraReduce,
-  kRemIntraBcast,
-  kRemInterReduce
-};
-
 struct CtranKernelAllToAllArgs {
   const void* sendbuff;
   void* recvbuff;
@@ -259,7 +235,7 @@ struct CtranKernelArgs {
   CtranAlgoDeviceState* devState_d{nullptr};
   union {
     ctran::allgather::KernelArgs allgather;
-    CtranKernelAllReduceArgs allreduce;
+    ctran::allreduce::KernelArgs allreduce;
     ctran::sendrecv::KernelSendArgs send;
     ctran::sendrecv::KernelRecvArgs recv;
     ctran::sendrecv::KernelSendRecvArgs sendrecv;


### PR DESCRIPTION
Summary:
Move CtranKernelAllReduceArgs and CtranKernElemRole from gpe/CtranGpeDev.h to
algos/AllReduce/Types.h as ctran::allreduce::KernelArgs and KernElemRole.
Part of KernelElem cleanup Phase 1.

Naming follows the convention:
- Remove "Ctran" prefix
- Keep "Kernel"/"KernElem" prefix
- Omit algorithm name since namespace provides context

Differential Revision: D91983714
