### PR TITLE
Extract ScubaFileUtils and add data_sink target

### DIFF
--- a/comms/rcclx/develop/CMakeLists.txt
+++ b/comms/rcclx/develop/CMakeLists.txt
@@ -1228,6 +1228,8 @@ set(COMMON_FILES
   comms/utils/logger/NcclWriterWrapper.h
   comms/utils/logger/ProcessGlobalErrorsUtil.cc
   comms/utils/logger/ProcessGlobalErrorsUtil.h
+  comms/utils/logger/ScubaFileUtils.cc
+  comms/utils/logger/ScubaFileUtils.h
   comms/utils/logger/ScubaLogger.cc
   comms/utils/logger/ScubaLogger.h
   comms/utils/MemUtils.cc

--- a/comms/utils/logger/ScubaFileUtils.cc
+++ b/comms/utils/logger/ScubaFileUtils.cc
@@ -1,0 +1,63 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/utils/logger/ScubaFileUtils.h"
+
+#include <chrono>
+#include <filesystem>
+
+#include <fmt/format.h>
+#include <folly/logging/xlog.h>
+
+#include "comms/utils/RankUtils.h"
+#include "comms/utils/StrUtils.h"
+
+namespace comms::logger {
+
+std::string getScubaFileName(
+    const std::string& logFilePrefix,
+    const std::string& tableName) {
+  auto globalRank = RankUtils::getGlobalRank().value_or(-1);
+  return fmt::format(
+      "{}/dedicated_log_structured_json.perfpipe_{}.Rank_{}.{}.scribe",
+      logFilePrefix,
+      tableName,
+      globalRank,
+      getUniqueFileSuffix());
+}
+
+std::optional<folly::File> createScubaFile(
+    const std::string& fileName,
+    bool appendMode) {
+  try {
+    // Extract the directory path and create the directory if it doesn't exist
+    std::filesystem::path filePath{fileName};
+    std::filesystem::path dirPath{filePath.parent_path()};
+    std::filesystem::create_directories(dirPath);
+    int flags = O_CREAT | O_WRONLY | (appendMode ? O_APPEND : 0);
+    return folly::File(fileName, flags, 0644);
+  } catch (const std::exception& e) {
+    XLOG(WARNING) << "Failed to create scuba file " << fileName << ": "
+                  << e.what();
+  }
+  return std::nullopt;
+}
+
+int64_t getTimestamp() {
+  return std::chrono::duration_cast<std::chrono::seconds>(
+             std::chrono::system_clock::now().time_since_epoch())
+      .count();
+}
+
+int64_t getTimestampMs() {
+  return std::chrono::duration_cast<std::chrono::milliseconds>(
+             std::chrono::system_clock::now().time_since_epoch())
+      .count();
+}
+
+int64_t getTimestampUs() {
+  return std::chrono::duration_cast<std::chrono::microseconds>(
+             std::chrono::system_clock::now().time_since_epoch())
+      .count();
+}
+
+} // namespace comms::logger

--- a/comms/utils/logger/ScubaFileUtils.h
+++ b/comms/utils/logger/ScubaFileUtils.h
@@ -1,0 +1,43 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+#include <folly/File.h>
+
+namespace comms::logger {
+
+// Generate Scuba log file name following Logarithm's expected format.
+// Format:
+// {logFilePrefix}/dedicated_log_structured_json.perfpipe_{tableName}.Rank_{rank}.{uniqueSuffix}.scribe
+// See:
+// https://www.internalfb.com/code/configerator/[master]/source/datainfra/logarithm/transport/logarithm_conda_custom_transport.cinc
+std::string getScubaFileName(
+    const std::string& logFilePrefix,
+    const std::string& tableName);
+
+// Create the Scuba log file, creating directories if needed.
+// Returns nullopt if file creation fails.
+// If appendMode is true, the file is opened with O_APPEND flag (used by MCCL).
+// If appendMode is false, the file is opened without O_APPEND (original NCCLX
+// behavior).
+std::optional<folly::File> createScubaFile(
+    const std::string& fileName,
+    bool appendMode = false);
+
+// Get current timestamp in seconds since epoch.
+// Used for Scuba "time" field which requires seconds precision.
+int64_t getTimestamp();
+
+// Get current timestamp in milliseconds since epoch.
+// Useful for trace context generation and correlation.
+int64_t getTimestampMs();
+
+// Get current timestamp in microseconds since epoch.
+// Useful for high-precision timing in operation traces.
+int64_t getTimestampUs();
+
+} // namespace comms::logger


### PR DESCRIPTION
Summary:
Refactor common Scuba file utilities into a shared library that can be used by both
NCCLX DataTable and MCCL McclDataTable:

- Add ScubaFileUtils.h/.cpp with getScubaFileName(), createScubaFile(), and getTimestamp()
- Add scuba_file_utils BUCK target with shared dependencies
- Add data_sink BUCK target for DataSink.h header-only library
- Update DataTable.cc to use the new ScubaFileUtils functions
- Update data_table BUCK target to depend on scuba_file_utils

This enables code reuse and eliminates duplicate implementations of file-related
utilities between the NCCLX and MCCL logging systems.

Differential Revision: D92017771


