### PR TITLE
Add RAII-based in-use protection for RegElem

### DIFF
--- a/comms/ctran/mapper/CtranMapper.cc
+++ b/comms/ctran/mapper/CtranMapper.cc
@@ -762,6 +762,25 @@ commResult_t CtranMapper::searchRegHandle(
   return commSuccess;
 }
 
+commResult_t CtranMapper::searchRegHandleGuarded(
+    const void* buf,
+    std::size_t len,
+    ctran::regcache::RegElemGuard* guard,
+    bool* dynamicRegist,
+    bool allowDynamic) {
+  // First, use the regular searchRegHandle to get the raw pointer
+  void* regHdl = nullptr;
+  FB_COMMCHECK(searchRegHandle(buf, len, &regHdl, dynamicRegist, allowDynamic));
+
+  // Wrap the registration handle in a guard to track in-use.
+  // The guard increments inUseCount on construction and decrements on
+  // destruction, ensuring the registration cannot be invalidated while in use.
+  *guard = ctran::regcache::RegElemGuard(
+      static_cast<ctran::regcache::RegElem*>(regHdl));
+
+  return commSuccess;
+}
+
 commResult_t CtranMapper::icopy(
     void* dbuf,
     const void* sbuf,

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -108,6 +108,31 @@ class CtranMapper {
       bool* dynamicRegist,
       bool allowDynamic = true);
 
+  /* Get the handle of the given buffer with RAII-based in-use protection.
+   * This is the preferred method for collectives to acquire registration
+   * handles, as it automatically manages the in-use reference count.
+   * The guard ensures that the registration cannot be invalidated (via
+   * deregMem) while the collective is using it.
+   *
+   * Input arguments:
+   *   - buf: the local buffer to be searched in the cache
+   *   - len: number of bytes of 'buf' to be searched
+   *   - allowDynamic: whether or not allow to dynamic register if the
+   *                   segment is not cached
+   * Output arguments:
+   *   - guard: a RegElemGuard that holds the registration handle and
+   *            automatically manages the in-use count. Use guard.get()
+   *            to access the underlying registration handle.
+   *   - dynamicRegist: whether or not this buffer is dynamically cached and
+   *                    registered
+   */
+  commResult_t searchRegHandleGuarded(
+      const void* buf,
+      std::size_t len,
+      ctran::regcache::RegElemGuard* guard,
+      bool* dynamicRegist,
+      bool allowDynamic = true);
+
   DevMemType segmentType(void* segHdl);
 
   /* Deregister a dynamic registration.


### PR DESCRIPTION
Summary:
Add RegElemGuard RAII class to prevent deregistration while collectives are using memory registrations.

When a collective operation uses a registration handle, it must be protected from concurrent deregistration. Without protection, deregistration could invalidate the registration while RDMA operations are still in progress.

Key changes:
- Add inUseCount to RegElemStateMnger to track active users
- Add acquireInUse/releaseInUse/isInUse methods to RegElem
- Add RegElemGuard RAII class with move semantics that automatically manages inUseCount
- Add searchRegHandleGuarded() to CtranMapper that returns a guard instead of raw pointer
- Update all collective algorithms in ctran/algos/ to use the guarded API

Differential Revision: D91924415


