### PR TITLE
Fix segfault in copy engine SendRecv by properly constructing union member

### DIFF
--- a/comms/ctran/gpe/CtranGpe.cc
+++ b/comms/ctran/gpe/CtranGpe.cc
@@ -122,6 +122,7 @@ OpElem::OpElem(
       break;
     case SEND:
       this->send.kElem = nullptr;
+      new (&this->send.remoteAccessKey) CtranMapperRemoteAccessKey();
       break;
     case RECV:
       this->recv.kElem = nullptr;
@@ -175,6 +176,7 @@ OpElem::~OpElem() {
       if (this->send.kElem && !NCCL_CTRAN_NVL_SENDRECV_COPY_ENGINE_ENABLE) {
         this->send.kElem->free();
       }
+      this->send.remoteAccessKey.~CtranMapperRemoteAccessKey();
       break;
     case RECV:
       // when copy engine is enabled, kElem is freed by the kernels


### PR DESCRIPTION
Summary:
Fix segmentation fault in `CtranSendRecvCopyEngineTestParamFixture` tests caused by uninitialized `std::string` in union.

The `OpElem` struct uses a union containing operation-specific data. The `send` struct within this union contains `CtranMapperRemoteAccessKey`, which has `IpcRemHandle nvlKey` with a `std::string peerId` member.

When `OpElem` is constructed with type `SEND`, the union memory is uninitialized - C++ unions don't automatically construct non-trivial members. Later, when `exchangeSendRecvHandles` assigns to `op->send.remoteAccessKey`, it calls `std::string::operator=` on uninitialized memory, causing a segfault.

The fix adds placement new in the constructor to properly initialize `CtranMapperRemoteAccessKey`, and explicit destructor call in the destructor to clean it up - following the same pattern already used for other union members like `std::vector` and `std::unordered_map`.

Reviewed By: minsii

Differential Revision: D91985882


