### PR TITLE
torchcomms: nccl+ncclx nodiscard for results

### DIFF
--- a/comms/torchcomms/nccl/NcclApi.hpp
+++ b/comms/torchcomms/nccl/NcclApi.hpp
@@ -21,25 +21,25 @@ class NcclApi {
   virtual std::string getLastError(ncclComm_t comm) = 0;
 
   // Unique ID generation
-  virtual ncclResult_t getUniqueId(ncclUniqueId* uniqueId) = 0;
+  [[nodiscard]] virtual ncclResult_t getUniqueId(ncclUniqueId* uniqueId) = 0;
 
   // Communicator management
-  virtual ncclResult_t commInitRankConfig(
+  [[nodiscard]] virtual ncclResult_t commInitRankConfig(
       ncclComm_t* comm,
       int nranks,
       ncclUniqueId commId,
       int rank,
       ncclConfig_t* config) = 0;
 
-  virtual ncclResult_t commDestroy(ncclComm_t comm) = 0;
+  [[nodiscard]] virtual ncclResult_t commDestroy(ncclComm_t comm) = 0;
 
-  virtual ncclResult_t commAbort(ncclComm_t comm) = 0;
+  [[nodiscard]] virtual ncclResult_t commAbort(ncclComm_t comm) = 0;
 
-  virtual ncclResult_t commGetAsyncError(
+  [[nodiscard]] virtual ncclResult_t commGetAsyncError(
       ncclComm_t comm,
       ncclResult_t* asyncError) = 0;
 
-  virtual ncclResult_t commSplit(
+  [[nodiscard]] virtual ncclResult_t commSplit(
       ncclComm_t comm,
       int color,
       int key,
@@ -47,13 +47,15 @@ class NcclApi {
       ncclConfig_t* config) = 0;
 
   // Memory registration
-  virtual ncclResult_t
+  [[nodiscard]] virtual ncclResult_t
   commRegister(ncclComm_t comm, void* buffer, size_t size, void** handle) = 0;
 
-  virtual ncclResult_t commDeregister(ncclComm_t comm, void* handle) = 0;
+  [[nodiscard]] virtual ncclResult_t commDeregister(
+      ncclComm_t comm,
+      void* handle) = 0;
 
   // Point-to-point operations
-  virtual ncclResult_t send(
+  [[nodiscard]] virtual ncclResult_t send(
       const void* sendbuff,
       size_t count,
       ncclDataType_t datatype,
@@ -61,7 +63,7 @@ class NcclApi {
       ncclComm_t comm,
       cudaStream_t stream) = 0;
 
-  virtual ncclResult_t recv(
+  [[nodiscard]] virtual ncclResult_t recv(
       void* recvbuff,
       size_t count,
       ncclDataType_t datatype,
@@ -70,7 +72,7 @@ class NcclApi {
       cudaStream_t stream) = 0;
 
   // Collective operations
-  virtual ncclResult_t broadcast(
+  [[nodiscard]] virtual ncclResult_t broadcast(
       const void* sendbuff,
       void* recvbuff,
       size_t count,
@@ -79,7 +81,7 @@ class NcclApi {
       ncclComm_t comm,
       cudaStream_t stream) = 0;
 
-  virtual ncclResult_t bcast(
+  [[nodiscard]] virtual ncclResult_t bcast(
       void* buff,
       size_t count,
       ncclDataType_t datatype,
@@ -87,7 +89,7 @@ class NcclApi {
       ncclComm_t comm,
       cudaStream_t stream) = 0;
 
-  virtual ncclResult_t allReduce(
+  [[nodiscard]] virtual ncclResult_t allReduce(
       const void* sendbuff,
       void* recvbuff,
       size_t count,
@@ -96,7 +98,7 @@ class NcclApi {
       ncclComm_t comm,
       cudaStream_t stream) = 0;
 
-  virtual ncclResult_t reduce(
+  [[nodiscard]] virtual ncclResult_t reduce(
       const void* sendbuff,
       void* recvbuff,
       size_t count,
@@ -106,7 +108,7 @@ class NcclApi {
       ncclComm_t comm,
       cudaStream_t stream) = 0;
 
-  virtual ncclResult_t allGather(
+  [[nodiscard]] virtual ncclResult_t allGather(
       const void* sendbuff,
       void* recvbuff,
       size_t sendcount,
@@ -114,7 +116,7 @@ class NcclApi {
       ncclComm_t comm,
       cudaStream_t stream) = 0;
 
-  virtual ncclResult_t reduceScatter(
+  [[nodiscard]] virtual ncclResult_t reduceScatter(
       const void* sendbuff,
       void* recvbuff,
       size_t recvcount,
@@ -123,7 +125,7 @@ class NcclApi {
       ncclComm_t comm,
       cudaStream_t stream) = 0;
 
-  virtual ncclResult_t allToAll(
+  [[nodiscard]] virtual ncclResult_t allToAll(
       const void* sendbuff,
       void* recvbuff,
       size_t count,
@@ -132,22 +134,28 @@ class NcclApi {
       cudaStream_t stream) = 0;
 
   // Group operations
-  virtual ncclResult_t groupStart() = 0;
-  virtual ncclResult_t groupEnd() = 0;
+  [[nodiscard]] virtual ncclResult_t groupStart() = 0;
+  [[nodiscard]] virtual ncclResult_t groupEnd() = 0;
 
-  virtual ncclResult_t commUserRank(const ncclComm_t comm, int* userRank) = 0;
-  virtual ncclResult_t commCount(const ncclComm_t comm, int* count) = 0;
+  [[nodiscard]] virtual ncclResult_t commUserRank(
+      const ncclComm_t comm,
+      int* userRank) = 0;
+  [[nodiscard]] virtual ncclResult_t commCount(
+      const ncclComm_t comm,
+      int* count) = 0;
 
-  virtual ncclResult_t redOpCreatePreMulSum(
+  [[nodiscard]] virtual ncclResult_t redOpCreatePreMulSum(
       ncclRedOp_t* op,
       void* scalar,
       ncclDataType_t datatype,
       ncclScalarResidence_t residence,
       ncclComm_t comm) = 0;
-  virtual ncclResult_t redOpDestroy(ncclRedOp_t op, ncclComm_t comm) = 0;
+  [[nodiscard]] virtual ncclResult_t redOpDestroy(
+      ncclRedOp_t op,
+      ncclComm_t comm) = 0;
 
-  virtual ncclResult_t memAlloc(void** buff, size_t size) = 0;
-  virtual ncclResult_t memFree(void* buff) = 0;
+  [[nodiscard]] virtual ncclResult_t memAlloc(void** buff, size_t size) = 0;
+  [[nodiscard]] virtual ncclResult_t memFree(void* buff) = 0;
 };
 
 /**
@@ -162,40 +170,42 @@ class DefaultNcclApi : public NcclApi {
   std::string getLastError(ncclComm_t comm) override;
 
   // Unique ID generation
-  ncclResult_t getUniqueId(ncclUniqueId* uniqueId) override;
+  [[nodiscard]] ncclResult_t getUniqueId(ncclUniqueId* uniqueId) override;
 
   // Communicator management
-  ncclResult_t commInitRankConfig(
+  [[nodiscard]] ncclResult_t commInitRankConfig(
       ncclComm_t* comm,
       int nranks,
       ncclUniqueId commId,
       int rank,
       ncclConfig_t* config) override;
 
-  ncclResult_t commDestroy(ncclComm_t comm) override;
+  [[nodiscard]] ncclResult_t commDestroy(ncclComm_t comm) override;
 
-  ncclResult_t commAbort(ncclComm_t comm) override;
+  [[nodiscard]] ncclResult_t commAbort(ncclComm_t comm) override;
 
-  ncclResult_t commGetAsyncError(ncclComm_t comm, ncclResult_t* asyncError)
-      override;
+  [[nodiscard]] ncclResult_t commGetAsyncError(
+      ncclComm_t comm,
+      ncclResult_t* asyncError) override;
 
-  ncclResult_t commSplit(
+  [[nodiscard]] ncclResult_t commSplit(
       ncclComm_t comm,
       int color,
       int key,
       ncclComm_t* newcomm,
       ncclConfig_t* config) override;
 
-  ncclResult_t commRegister(
+  [[nodiscard]] ncclResult_t commRegister(
       ncclComm_t comm,
       void* buffer,
       size_t size,
       void** handle) override;
 
-  ncclResult_t commDeregister(ncclComm_t comm, void* handle) override;
+  [[nodiscard]] ncclResult_t commDeregister(ncclComm_t comm, void* handle)
+      override;
 
   // Point-to-point operations
-  ncclResult_t send(
+  [[nodiscard]] ncclResult_t send(
       const void* sendbuff,
       size_t count,
       ncclDataType_t datatype,
@@ -203,7 +213,7 @@ class DefaultNcclApi : public NcclApi {
       ncclComm_t comm,
       cudaStream_t stream) override;
 
-  ncclResult_t recv(
+  [[nodiscard]] ncclResult_t recv(
       void* recvbuff,
       size_t count,
       ncclDataType_t datatype,
@@ -212,7 +222,7 @@ class DefaultNcclApi : public NcclApi {
       cudaStream_t stream) override;
 
   // Collective operations
-  ncclResult_t broadcast(
+  [[nodiscard]] ncclResult_t broadcast(
       const void* sendbuff,
       void* recvbuff,
       size_t count,
@@ -221,7 +231,7 @@ class DefaultNcclApi : public NcclApi {
       ncclComm_t comm,
       cudaStream_t stream) override;
 
-  ncclResult_t bcast(
+  [[nodiscard]] ncclResult_t bcast(
       void* buff,
       size_t count,
       ncclDataType_t datatype,
@@ -229,7 +239,7 @@ class DefaultNcclApi : public NcclApi {
       ncclComm_t comm,
       cudaStream_t stream) override;
 
-  ncclResult_t allReduce(
+  [[nodiscard]] ncclResult_t allReduce(
       const void* sendbuff,
       void* recvbuff,
       size_t count,
@@ -238,7 +248,7 @@ class DefaultNcclApi : public NcclApi {
       ncclComm_t comm,
       cudaStream_t stream) override;
 
-  ncclResult_t reduce(
+  [[nodiscard]] ncclResult_t reduce(
       const void* sendbuff,
       void* recvbuff,
       size_t count,
@@ -248,7 +258,7 @@ class DefaultNcclApi : public NcclApi {
       ncclComm_t comm,
       cudaStream_t stream) override;
 
-  ncclResult_t allGather(
+  [[nodiscard]] ncclResult_t allGather(
       const void* sendbuff,
       void* recvbuff,
       size_t sendcount,
@@ -256,7 +266,7 @@ class DefaultNcclApi : public NcclApi {
       ncclComm_t comm,
       cudaStream_t stream) override;
 
-  ncclResult_t reduceScatter(
+  [[nodiscard]] ncclResult_t reduceScatter(
       const void* sendbuff,
       void* recvbuff,
       size_t recvcount,
@@ -265,7 +275,7 @@ class DefaultNcclApi : public NcclApi {
       ncclComm_t comm,
       cudaStream_t stream) override;
 
-  ncclResult_t allToAll(
+  [[nodiscard]] ncclResult_t allToAll(
       const void* sendbuff,
       void* recvbuff,
       size_t count,
@@ -274,22 +284,25 @@ class DefaultNcclApi : public NcclApi {
       cudaStream_t stream) override;
 
   // Group operations
-  ncclResult_t groupStart() override;
-  ncclResult_t groupEnd() override;
+  [[nodiscard]] ncclResult_t groupStart() override;
+  [[nodiscard]] ncclResult_t groupEnd() override;
 
-  ncclResult_t commUserRank(const ncclComm_t comm, int* userRank) override;
-  ncclResult_t commCount(const ncclComm_t comm, int* count) override;
+  [[nodiscard]] ncclResult_t commUserRank(const ncclComm_t comm, int* userRank)
+      override;
+  [[nodiscard]] ncclResult_t commCount(const ncclComm_t comm, int* count)
+      override;
 
-  ncclResult_t redOpCreatePreMulSum(
+  [[nodiscard]] ncclResult_t redOpCreatePreMulSum(
       ncclRedOp_t* op,
       void* scalar,
       ncclDataType_t datatype,
       ncclScalarResidence_t residence,
       ncclComm_t comm) override;
-  ncclResult_t redOpDestroy(ncclRedOp_t op, ncclComm_t comm) override;
+  [[nodiscard]] ncclResult_t redOpDestroy(ncclRedOp_t op, ncclComm_t comm)
+      override;
 
-  ncclResult_t memAlloc(void** buff, size_t size) override;
-  ncclResult_t memFree(void* buff) override;
+  [[nodiscard]] ncclResult_t memAlloc(void** buff, size_t size) override;
+  [[nodiscard]] ncclResult_t memFree(void* buff) override;
 };
 
 } // namespace torch::comms

--- a/comms/torchcomms/nccl/TorchCommNCCL.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCL.cpp
@@ -237,7 +237,11 @@ void TorchCommNCCL::finalize() {
   } else if (work_status == TorchWorkNCCL::WorkStatus::ERROR) {
     comm_state_ = CommState::ERROR;
     ncclResult_t asyncErr;
-    nccl_api_->commGetAsyncError(nccl_comm_, &asyncErr);
+    NCCL_CHECK(
+        nccl_api_,
+        nccl_comm_,
+        nccl_api_->commGetAsyncError(nccl_comm_, &asyncErr),
+        "failed to get async error");
     NCCLException ncclException(
         *nccl_api_, "NCCL Async Error", asyncErr, nccl_comm_);
     abortNcclComm();
@@ -288,7 +292,11 @@ void TorchCommNCCL::finalize() {
   if (nccl_comm_) {
     detachMemoryHook();
     // Deregister comm from the CachingAllocator
-    nccl_api_->commDestroy(nccl_comm_);
+    NCCL_CHECK(
+        nccl_api_,
+        nccl_comm_,
+        nccl_api_->commDestroy(nccl_comm_),
+        "NCCL Destroy failed");
     nccl_comm_ = nullptr;
   }
 }
@@ -296,7 +304,11 @@ void TorchCommNCCL::finalize() {
 void TorchCommNCCL::abortNcclComm() {
   detachMemoryHook();
   if (nccl_comm_) {
-    nccl_api_->commAbort(nccl_comm_);
+    NCCL_CHECK(
+        nccl_api_,
+        nccl_comm_,
+        nccl_api_->commAbort(nccl_comm_),
+        "NCCL Abort failed");
     nccl_comm_ = nullptr;
   }
   if (options_.abort_process_on_timeout_or_error) {

--- a/comms/torchcomms/nccl/TorchCommNCCL.hpp
+++ b/comms/torchcomms/nccl/TorchCommNCCL.hpp
@@ -295,7 +295,10 @@ class TorchCommNCCL : public TorchCommBackend,
       if (this != &other) {
         // Destroy current op if we own one
         if (comm_ && nccl_api_) {
-          nccl_api_->redOpDestroy(ncclRedOp_, comm_);
+          NCCL_CHECK_IGNORE(
+              nccl_api_,
+              nccl_api_->redOpDestroy(ncclRedOp_, comm_),
+              "failed to destroy NCCL reduction operation");
         }
         ncclRedOp_ = other.ncclRedOp_;
         comm_ = other.comm_;

--- a/comms/torchcomms/nccl/TorchCommNCCLUtils.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCLUtils.cpp
@@ -52,7 +52,11 @@ void createPreMulSum(
       is_tensor ? dataType == getNcclDataTypeInternal(tensor)
                 : dataType != ncclBfloat16,
       "PreMulSum factor type must match input data type");
-  nccl_api->redOpCreatePreMulSum(op, scalar, dataType, residence, comm);
+  NCCL_CHECK(
+      nccl_api,
+      comm,
+      nccl_api->redOpCreatePreMulSum(op, scalar, dataType, residence, comm),
+      "NCCL redOpCreatePreMulSum failed");
 }
 
 } // namespace
@@ -268,7 +272,11 @@ void TorchCommNCCL::checkAndAbortIfTimedOutOrError() {
     }
   } else if (comm_state_ == CommState::ERROR) {
     ncclResult_t asyncErr;
-    nccl_api_->commGetAsyncError(nccl_comm_, &asyncErr);
+    NCCL_CHECK(
+        nccl_api_,
+        nccl_comm_,
+        nccl_api_->commGetAsyncError(nccl_comm_, &asyncErr),
+        "failed to get async error");
     NCCLException ncclException(
         *nccl_api_, "NCCL Async Error", asyncErr, nccl_comm_);
     abortNcclComm();

--- a/comms/torchcomms/ncclx/NcclxApi.hpp
+++ b/comms/torchcomms/ncclx/NcclxApi.hpp
@@ -73,25 +73,25 @@ class NcclxApi {
   virtual std::string getLastError(ncclComm_t comm) = 0;
 
   // Unique ID generation
-  virtual ncclResult_t getUniqueId(ncclUniqueId* uniqueId) = 0;
+  [[nodiscard]] virtual ncclResult_t getUniqueId(ncclUniqueId* uniqueId) = 0;
 
   // Communicator management
-  virtual ncclResult_t commInitRankConfig(
+  [[nodiscard]] virtual ncclResult_t commInitRankConfig(
       ncclComm_t* comm,
       int nranks,
       ncclUniqueId commId,
       int rank,
       ncclConfig_t* config) = 0;
 
-  virtual ncclResult_t commDestroy(ncclComm_t comm) = 0;
+  [[nodiscard]] virtual ncclResult_t commDestroy(ncclComm_t comm) = 0;
 
-  virtual ncclResult_t commAbort(ncclComm_t comm) = 0;
+  [[nodiscard]] virtual ncclResult_t commAbort(ncclComm_t comm) = 0;
 
-  virtual ncclResult_t commGetAsyncError(
+  [[nodiscard]] virtual ncclResult_t commGetAsyncError(
       ncclComm_t comm,
       ncclResult_t* asyncError) = 0;
 
-  virtual ncclResult_t commSplit(
+  [[nodiscard]] virtual ncclResult_t commSplit(
       ncclComm_t comm,
       int color,
       int key,
@@ -99,13 +99,15 @@ class NcclxApi {
       ncclConfig_t* config) = 0;
 
   // Memory registration
-  virtual ncclResult_t
+  [[nodiscard]] virtual ncclResult_t
   commRegister(ncclComm_t comm, void* buffer, size_t size, void** handle) = 0;
 
-  virtual ncclResult_t commDeregister(ncclComm_t comm, void* handle) = 0;
+  [[nodiscard]] virtual ncclResult_t commDeregister(
+      ncclComm_t comm,
+      void* handle) = 0;
 
   // Point-to-point operations
-  virtual ncclResult_t send(
+  [[nodiscard]] virtual ncclResult_t send(
       const void* sendbuff,
       size_t count,
       ncclDataType_t datatype,
@@ -113,7 +115,7 @@ class NcclxApi {
       ncclComm_t comm,
       cudaStream_t stream) = 0;
 
-  virtual ncclResult_t recv(
+  [[nodiscard]] virtual ncclResult_t recv(
       void* recvbuff,
       size_t count,
       ncclDataType_t datatype,
@@ -122,7 +124,7 @@ class NcclxApi {
       cudaStream_t stream) = 0;
 
   // Collective operations
-  virtual ncclResult_t broadcast(
+  [[nodiscard]] virtual ncclResult_t broadcast(
       const void* sendbuff,
       void* recvbuff,
       size_t count,
@@ -131,7 +133,7 @@ class NcclxApi {
       ncclComm_t comm,
       cudaStream_t stream) = 0;
 
-  virtual ncclResult_t bcast(
+  [[nodiscard]] virtual ncclResult_t bcast(
       void* buff,
       size_t count,
       ncclDataType_t datatype,
@@ -139,7 +141,7 @@ class NcclxApi {
       ncclComm_t comm,
       cudaStream_t stream) = 0;
 
-  virtual ncclResult_t allReduce(
+  [[nodiscard]] virtual ncclResult_t allReduce(
       const void* sendbuff,
       void* recvbuff,
       size_t count,
@@ -148,7 +150,7 @@ class NcclxApi {
       ncclComm_t comm,
       cudaStream_t stream) = 0;
 
-  virtual ncclResult_t reduce(
+  [[nodiscard]] virtual ncclResult_t reduce(
       const void* sendbuff,
       void* recvbuff,
       size_t count,
@@ -158,7 +160,7 @@ class NcclxApi {
       ncclComm_t comm,
       cudaStream_t stream) = 0;
 
-  virtual ncclResult_t allGather(
+  [[nodiscard]] virtual ncclResult_t allGather(
       const void* sendbuff,
       void* recvbuff,
       size_t sendcount,
@@ -166,7 +168,7 @@ class NcclxApi {
       ncclComm_t comm,
       cudaStream_t stream) = 0;
 
-  virtual ncclResult_t reduceScatter(
+  [[nodiscard]] virtual ncclResult_t reduceScatter(
       const void* sendbuff,
       void* recvbuff,
       size_t recvcount,
@@ -175,7 +177,7 @@ class NcclxApi {
       ncclComm_t comm,
       cudaStream_t stream) = 0;
 
-  virtual ncclResult_t allToAll(
+  [[nodiscard]] virtual ncclResult_t allToAll(
       const void* sendbuff,
       void* recvbuff,
       size_t count,
@@ -183,7 +185,7 @@ class NcclxApi {
       ncclComm_t comm,
       cudaStream_t stream) = 0;
 
-  virtual ncclResult_t allToAllv(
+  [[nodiscard]] virtual ncclResult_t allToAllv(
       const void* sendbuff,
       const size_t sendcounts[],
       const size_t sdispls[],
@@ -194,7 +196,7 @@ class NcclxApi {
       ncclComm_t comm,
       cudaStream_t stream) = 0;
 
-  virtual ncclResult_t alltoallvDynamicDispatch(
+  [[nodiscard]] virtual ncclResult_t alltoallvDynamicDispatch(
       const void* sendbuff,
       const size_t* sendSplitLengths,
       size_t numSendSplitLengths,
@@ -208,7 +210,7 @@ class NcclxApi {
       ncclComm_t comm,
       cudaStream_t stream) = 0;
 
-  virtual ncclResult_t alltoallvDynamicCombine(
+  [[nodiscard]] virtual ncclResult_t alltoallvDynamicCombine(
       const void* sendbuff,
       const size_t* sendSplitLengths,
       size_t numSendSplitLengths,
@@ -221,7 +223,7 @@ class NcclxApi {
       ncclComm_t comm,
       cudaStream_t stream) = 0;
 
-  virtual ncclResult_t alltoallvDedupInit(
+  [[nodiscard]] virtual ncclResult_t alltoallvDedupInit(
       const size_t totalNumSendBlocks, // number of blocks (tokens) per batch
       const size_t blockCount, // number of elements per block (token)
       const size_t blockNumRecvBuckets, // number of receiving buckets for each
@@ -233,7 +235,7 @@ class NcclxApi {
       cudaStream_t stream,
       void** request) = 0;
 
-  virtual ncclResult_t alltoallvDedupExec(
+  [[nodiscard]] virtual ncclResult_t alltoallvDedupExec(
       const void* sendBuff,
       const int* sendIdx,
       const int* fwdIdx,
@@ -242,7 +244,7 @@ class NcclxApi {
       int recvBlockIds[],
       void* request) = 0;
 
-  virtual ncclResult_t alltoallvDedupCombine(
+  [[nodiscard]] virtual ncclResult_t alltoallvDedupCombine(
       const void* sendBuff,
       const int* sendIdx,
       const int* fwdIdx,
@@ -250,18 +252,18 @@ class NcclxApi {
       void* recvBuff,
       void* request) = 0;
 
-  virtual ncclResult_t pFree(void* request) = 0;
+  [[nodiscard]] virtual ncclResult_t pFree(void* request) = 0;
 
-  virtual ncclResult_t commWindowRegister(
+  [[nodiscard]] virtual ncclResult_t commWindowRegister(
       void* baseptr,
       const size_t size,
       ncclComm_t comm,
       NcclxWindow* winPtr,
       int winFlags = NCCL_WIN_DEFAULT) = 0;
-  virtual ncclResult_t commWindowDeregister(
+  [[nodiscard]] virtual ncclResult_t commWindowDeregister(
       ncclComm_t comm,
       NcclxWindow win) = 0;
-  virtual ncclResult_t winPut(
+  [[nodiscard]] virtual ncclResult_t winPut(
       const void* originBuff,
       size_t count,
       ncclDataType_t datatype,
@@ -269,17 +271,17 @@ class NcclxApi {
       size_t targetOffsetNelems,
       NcclxWindow win,
       cudaStream_t stream) = 0;
-  virtual ncclResult_t
+  [[nodiscard]] virtual ncclResult_t
   winSharedQuery(int rank, ncclComm_t comm, NcclxWindow win, void** addr) = 0;
-  virtual ncclResult_t
+  [[nodiscard]] virtual ncclResult_t
   winSignal(int peer, NcclxWindow win, cudaStream_t stream) = 0;
-  virtual ncclResult_t
+  [[nodiscard]] virtual ncclResult_t
   winWaitSignal(int peer, NcclxWindow win, cudaStream_t stream) = 0;
-  virtual ncclResult_t
+  [[nodiscard]] virtual ncclResult_t
   winGetAttributes(int peer, NcclxWindow win, NcclxWindowAttr* attrPtr) = 0;
 
-  virtual ncclResult_t memAlloc(void** buff, size_t size) = 0;
-  virtual ncclResult_t memFree(void* buff) = 0;
+  [[nodiscard]] virtual ncclResult_t memAlloc(void** buff, size_t size) = 0;
+  [[nodiscard]] virtual ncclResult_t memFree(void* buff) = 0;
 
 #ifdef TORCHCOMMS_HAS_NCCL_DEVICE_API
   // Device communicator operations (for device API / GIN support)
@@ -294,19 +296,25 @@ class NcclxApi {
 #endif
 
   // Group operations
-  virtual ncclResult_t groupStart() = 0;
-  virtual ncclResult_t groupEnd() = 0;
+  [[nodiscard]] virtual ncclResult_t groupStart() = 0;
+  [[nodiscard]] virtual ncclResult_t groupEnd() = 0;
 
-  virtual ncclResult_t commUserRank(const ncclComm_t comm, int* userRank) = 0;
-  virtual ncclResult_t commCount(const ncclComm_t comm, int* count) = 0;
+  [[nodiscard]] virtual ncclResult_t commUserRank(
+      const ncclComm_t comm,
+      int* userRank) = 0;
+  [[nodiscard]] virtual ncclResult_t commCount(
+      const ncclComm_t comm,
+      int* count) = 0;
 
-  virtual ncclResult_t redOpCreatePreMulSum(
+  [[nodiscard]] virtual ncclResult_t redOpCreatePreMulSum(
       ncclRedOp_t* op,
       void* scalar,
       ncclDataType_t datatype,
       ncclScalarResidence_t residence,
       ncclComm_t comm) = 0;
-  virtual ncclResult_t redOpDestroy(ncclRedOp_t op, ncclComm_t comm) = 0;
+  [[nodiscard]] virtual ncclResult_t redOpDestroy(
+      ncclRedOp_t op,
+      ncclComm_t comm) = 0;
 };
 
 /**
@@ -321,40 +329,42 @@ class DefaultNcclxApi : public NcclxApi {
   std::string getLastError(ncclComm_t comm) override;
 
   // Unique ID generation
-  ncclResult_t getUniqueId(ncclUniqueId* uniqueId) override;
+  [[nodiscard]] ncclResult_t getUniqueId(ncclUniqueId* uniqueId) override;
 
   // Communicator management
-  ncclResult_t commInitRankConfig(
+  [[nodiscard]] ncclResult_t commInitRankConfig(
       ncclComm_t* comm,
       int nranks,
       ncclUniqueId commId,
       int rank,
       ncclConfig_t* config) override;
 
-  ncclResult_t commDestroy(ncclComm_t comm) override;
+  [[nodiscard]] ncclResult_t commDestroy(ncclComm_t comm) override;
 
-  ncclResult_t commAbort(ncclComm_t comm) override;
+  [[nodiscard]] ncclResult_t commAbort(ncclComm_t comm) override;
 
-  ncclResult_t commGetAsyncError(ncclComm_t comm, ncclResult_t* asyncError)
-      override;
+  [[nodiscard]] ncclResult_t commGetAsyncError(
+      ncclComm_t comm,
+      ncclResult_t* asyncError) override;
 
-  ncclResult_t commSplit(
+  [[nodiscard]] ncclResult_t commSplit(
       ncclComm_t comm,
       int color,
       int key,
       ncclComm_t* newcomm,
       ncclConfig_t* config) override;
 
-  ncclResult_t commRegister(
+  [[nodiscard]] ncclResult_t commRegister(
       ncclComm_t comm,
       void* buffer,
       size_t size,
       void** handle) override;
 
-  ncclResult_t commDeregister(ncclComm_t comm, void* handle) override;
+  [[nodiscard]] ncclResult_t commDeregister(ncclComm_t comm, void* handle)
+      override;
 
   // Point-to-point operations
-  ncclResult_t send(
+  [[nodiscard]] ncclResult_t send(
       const void* sendbuff,
       size_t count,
       ncclDataType_t datatype,
@@ -362,7 +372,7 @@ class DefaultNcclxApi : public NcclxApi {
       ncclComm_t comm,
       cudaStream_t stream) override;
 
-  ncclResult_t recv(
+  [[nodiscard]] ncclResult_t recv(
       void* recvbuff,
       size_t count,
       ncclDataType_t datatype,
@@ -371,7 +381,7 @@ class DefaultNcclxApi : public NcclxApi {
       cudaStream_t stream) override;
 
   // Collective operations
-  ncclResult_t broadcast(
+  [[nodiscard]] ncclResult_t broadcast(
       const void* sendbuff,
       void* recvbuff,
       size_t count,
@@ -380,7 +390,7 @@ class DefaultNcclxApi : public NcclxApi {
       ncclComm_t comm,
       cudaStream_t stream) override;
 
-  ncclResult_t bcast(
+  [[nodiscard]] ncclResult_t bcast(
       void* buff,
       size_t count,
       ncclDataType_t datatype,
@@ -388,7 +398,7 @@ class DefaultNcclxApi : public NcclxApi {
       ncclComm_t comm,
       cudaStream_t stream) override;
 
-  ncclResult_t allReduce(
+  [[nodiscard]] ncclResult_t allReduce(
       const void* sendbuff,
       void* recvbuff,
       size_t count,
@@ -397,7 +407,7 @@ class DefaultNcclxApi : public NcclxApi {
       ncclComm_t comm,
       cudaStream_t stream) override;
 
-  ncclResult_t reduce(
+  [[nodiscard]] ncclResult_t reduce(
       const void* sendbuff,
       void* recvbuff,
       size_t count,
@@ -407,7 +417,7 @@ class DefaultNcclxApi : public NcclxApi {
       ncclComm_t comm,
       cudaStream_t stream) override;
 
-  ncclResult_t allGather(
+  [[nodiscard]] ncclResult_t allGather(
       const void* sendbuff,
       void* recvbuff,
       size_t sendcount,
@@ -415,7 +425,7 @@ class DefaultNcclxApi : public NcclxApi {
       ncclComm_t comm,
       cudaStream_t stream) override;
 
-  ncclResult_t reduceScatter(
+  [[nodiscard]] ncclResult_t reduceScatter(
       const void* sendbuff,
       void* recvbuff,
       size_t recvcount,
@@ -424,7 +434,7 @@ class DefaultNcclxApi : public NcclxApi {
       ncclComm_t comm,
       cudaStream_t stream) override;
 
-  ncclResult_t allToAll(
+  [[nodiscard]] ncclResult_t allToAll(
       const void* sendbuff,
       void* recvbuff,
       size_t count,
@@ -432,7 +442,7 @@ class DefaultNcclxApi : public NcclxApi {
       ncclComm_t comm,
       cudaStream_t stream) override;
 
-  ncclResult_t allToAllv(
+  [[nodiscard]] ncclResult_t allToAllv(
       const void* sendbuff,
       const size_t sendcounts[],
       const size_t senddispls[],
@@ -443,7 +453,7 @@ class DefaultNcclxApi : public NcclxApi {
       ncclComm_t comm,
       cudaStream_t stream) override;
 
-  ncclResult_t alltoallvDynamicDispatch(
+  [[nodiscard]] ncclResult_t alltoallvDynamicDispatch(
       const void* sendbuff,
       const size_t* sendSplitLengths,
       size_t numSendSplitLengths,
@@ -457,7 +467,7 @@ class DefaultNcclxApi : public NcclxApi {
       ncclComm_t comm,
       cudaStream_t stream) override;
 
-  ncclResult_t alltoallvDynamicCombine(
+  [[nodiscard]] ncclResult_t alltoallvDynamicCombine(
       const void* sendbuff,
       const size_t* sendSplitLengths,
       size_t numSendSplitLengths,
@@ -470,7 +480,7 @@ class DefaultNcclxApi : public NcclxApi {
       ncclComm_t comm,
       cudaStream_t stream) override;
 
-  ncclResult_t alltoallvDedupInit(
+  [[nodiscard]] ncclResult_t alltoallvDedupInit(
       const size_t totalNumSendBlocks,
       const size_t blockCount,
       const size_t blockNumRecvBuckets,
@@ -480,7 +490,7 @@ class DefaultNcclxApi : public NcclxApi {
       cudaStream_t stream,
       void** request) override;
 
-  ncclResult_t alltoallvDedupExec(
+  [[nodiscard]] ncclResult_t alltoallvDedupExec(
       const void* sendBuff,
       const int* sendIdx,
       const int* fwdIdx,
@@ -489,7 +499,7 @@ class DefaultNcclxApi : public NcclxApi {
       int recvBlockIds[],
       void* request) override;
 
-  ncclResult_t alltoallvDedupCombine(
+  [[nodiscard]] ncclResult_t alltoallvDedupCombine(
       const void* sendBuff,
       const int* sendIdx,
       const int* fwdIdx,
@@ -497,17 +507,19 @@ class DefaultNcclxApi : public NcclxApi {
       void* recvBuff,
       void* request) override;
 
-  ncclResult_t pFree(void* request) override;
+  [[nodiscard]] ncclResult_t pFree(void* request) override;
 
   // Window RMA operations
-  ncclResult_t commWindowRegister(
+  [[nodiscard]] ncclResult_t commWindowRegister(
       void* baseptr,
       const size_t size,
       ncclComm_t comm,
       NcclxWindow* winPtr,
       int winFlags = NCCL_WIN_DEFAULT) override;
-  ncclResult_t commWindowDeregister(ncclComm_t comm, NcclxWindow win) override;
-  ncclResult_t winPut(
+  [[nodiscard]] ncclResult_t commWindowDeregister(
+      ncclComm_t comm,
+      NcclxWindow win) override;
+  [[nodiscard]] ncclResult_t winPut(
       const void* originBuff,
       size_t count,
       ncclDataType_t datatype,
@@ -515,22 +527,22 @@ class DefaultNcclxApi : public NcclxApi {
       size_t targetOffsetNelems,
       NcclxWindow win,
       cudaStream_t stream) override;
-  ncclResult_t winSharedQuery(
+  [[nodiscard]] ncclResult_t winSharedQuery(
       int rank,
       ncclComm_t comm,
       NcclxWindow win,
       void** addr) override;
-  ncclResult_t winSignal(int peer, NcclxWindow win, cudaStream_t stream)
-      override;
-  ncclResult_t winWaitSignal(int peer, NcclxWindow win, cudaStream_t stream)
-      override;
-  ncclResult_t winGetAttributes(
+  [[nodiscard]] ncclResult_t
+  winSignal(int peer, NcclxWindow win, cudaStream_t stream) override;
+  [[nodiscard]] ncclResult_t
+  winWaitSignal(int peer, NcclxWindow win, cudaStream_t stream) override;
+  [[nodiscard]] ncclResult_t winGetAttributes(
       int peer,
       NcclxWindow win,
       NcclxWindowAttr* attrPtr) override;
 
-  ncclResult_t memAlloc(void** buff, size_t size) override;
-  ncclResult_t memFree(void* buff) override;
+  [[nodiscard]] ncclResult_t memAlloc(void** buff, size_t size) override;
+  [[nodiscard]] ncclResult_t memFree(void* buff) override;
 
 #ifdef TORCHCOMMS_HAS_NCCL_DEVICE_API
   // Device communicator operations (for device API / GIN support)
@@ -544,19 +556,22 @@ class DefaultNcclxApi : public NcclxApi {
 #endif
 
   // Group operations
-  ncclResult_t groupStart() override;
-  ncclResult_t groupEnd() override;
+  [[nodiscard]] ncclResult_t groupStart() override;
+  [[nodiscard]] ncclResult_t groupEnd() override;
 
-  ncclResult_t commUserRank(const ncclComm_t comm, int* userRank) override;
-  ncclResult_t commCount(const ncclComm_t comm, int* count) override;
+  [[nodiscard]] ncclResult_t commUserRank(const ncclComm_t comm, int* userRank)
+      override;
+  [[nodiscard]] ncclResult_t commCount(const ncclComm_t comm, int* count)
+      override;
 
-  ncclResult_t redOpCreatePreMulSum(
+  [[nodiscard]] ncclResult_t redOpCreatePreMulSum(
       ncclRedOp_t* op,
       void* scalar,
       ncclDataType_t datatype,
       ncclScalarResidence_t residence,
       ncclComm_t comm) override;
-  ncclResult_t redOpDestroy(ncclRedOp_t op, ncclComm_t comm) override;
+  [[nodiscard]] ncclResult_t redOpDestroy(ncclRedOp_t op, ncclComm_t comm)
+      override;
 };
 
 } // namespace torch::comms

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -291,7 +291,11 @@ void TorchCommNCCLX::finalize() {
     TC_LOG(INFO, this) << "Aborting NCCL comm due to error";
     comm_state_ = CommState::ERROR;
     ncclResult_t asyncErr;
-    nccl_api_->commGetAsyncError(nccl_comm_, &asyncErr);
+    NCCLX_CHECK(
+        nccl_api_,
+        nccl_comm_,
+        nccl_api_->commGetAsyncError(nccl_comm_, &asyncErr),
+        "failed to get async error");
     NCCLXException ncclException(
         *nccl_api_, "NCCLX Async Error", asyncErr, nccl_comm_);
     abortNcclComm();
@@ -344,7 +348,11 @@ void TorchCommNCCLX::finalize() {
   if (nccl_comm_) {
     detachMemoryHook();
     // Deregister comm from the CachingAllocator
-    nccl_api_->commDestroy(nccl_comm_);
+    NCCLX_CHECK(
+        nccl_api_,
+        nccl_comm_,
+        nccl_api_->commDestroy(nccl_comm_),
+        "NCCLX Destroy failed");
     nccl_comm_ = nullptr;
   }
 }
@@ -352,7 +360,11 @@ void TorchCommNCCLX::finalize() {
 void TorchCommNCCLX::abortNcclComm() {
   detachMemoryHook();
   if (nccl_comm_) {
-    nccl_api_->commAbort(nccl_comm_);
+    NCCLX_CHECK(
+        nccl_api_,
+        nccl_comm_,
+        nccl_api_->commAbort(nccl_comm_),
+        "NCCLX Abort failed");
     nccl_comm_ = nullptr;
   }
   if (options_.abort_process_on_timeout_or_error) {

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
@@ -336,7 +336,10 @@ class TorchCommNCCLX : public TorchCommBackend,
       if (this != &other) {
         // Destroy current op if we own one
         if (comm_ && nccl_api_) {
-          nccl_api_->redOpDestroy(ncclRedOp_, comm_);
+          NCCLX_CHECK_IGNORE(
+              nccl_api_,
+              nccl_api_->redOpDestroy(ncclRedOp_, comm_),
+              "failed to destroy NCCL reduction operation");
         }
         ncclRedOp_ = other.ncclRedOp_;
         comm_ = other.comm_;

--- a/comms/torchcomms/ncclx/TorchCommNCCLXUtils.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXUtils.cpp
@@ -66,7 +66,11 @@ void createPreMulSum(
       is_tensor ? dataType == getNcclDataTypeInternal(tensor)
                 : dataType != ncclBfloat16,
       "PreMulSum factor type must match input data type");
-  nccl_api->redOpCreatePreMulSum(op, scalar, dataType, residence, comm);
+  NCCLX_CHECK(
+      nccl_api,
+      comm,
+      nccl_api->redOpCreatePreMulSum(op, scalar, dataType, residence, comm),
+      "NCCLX redOpCreatePreMulSum failed");
 }
 
 } // namespace
@@ -253,7 +257,12 @@ void TorchCommNCCLX::checkAndAbortIfTimedOutOrError() {
     }
   } else if (comm_state_ == CommState::ERROR) {
     ncclResult_t asyncErr;
-    nccl_api_->commGetAsyncError(nccl_comm_, &asyncErr);
+
+    NCCLX_CHECK(
+        nccl_api_,
+        nccl_comm_,
+        nccl_api_->commGetAsyncError(nccl_comm_, &asyncErr),
+        "failed to get async error");
     NCCLXException ncclException(
         *nccl_api_, "NCCLX Async Error", asyncErr, nccl_comm_);
     abortNcclComm();

--- a/comms/torchcomms/rccl/RcclApi.hpp
+++ b/comms/torchcomms/rccl/RcclApi.hpp
@@ -22,25 +22,25 @@ class RcclApi {
   virtual std::string getLastError(ncclComm_t comm) = 0;
 
   // Unique ID generation
-  virtual ncclResult_t getUniqueId(ncclUniqueId* uniqueId) = 0;
+  [[nodiscard]] virtual ncclResult_t getUniqueId(ncclUniqueId* uniqueId) = 0;
 
   // Communicator management
-  virtual ncclResult_t commInitRankConfig(
+  [[nodiscard]] virtual ncclResult_t commInitRankConfig(
       ncclComm_t* comm,
       int nranks,
       ncclUniqueId commId,
       int rank,
       ncclConfig_t* config) = 0;
 
-  virtual ncclResult_t commDestroy(ncclComm_t comm) = 0;
+  [[nodiscard]] virtual ncclResult_t commDestroy(ncclComm_t comm) = 0;
 
-  virtual ncclResult_t commAbort(ncclComm_t comm) = 0;
+  [[nodiscard]] virtual ncclResult_t commAbort(ncclComm_t comm) = 0;
 
-  virtual ncclResult_t commGetAsyncError(
+  [[nodiscard]] virtual ncclResult_t commGetAsyncError(
       ncclComm_t comm,
       ncclResult_t* asyncError) = 0;
 
-  virtual ncclResult_t commSplit(
+  [[nodiscard]] virtual ncclResult_t commSplit(
       ncclComm_t comm,
       int color,
       int key,
@@ -48,13 +48,15 @@ class RcclApi {
       ncclConfig_t* config) = 0;
 
   // Memory registration
-  virtual ncclResult_t
+  [[nodiscard]] virtual ncclResult_t
   commRegister(ncclComm_t comm, void* buffer, size_t size, void** handle) = 0;
 
-  virtual ncclResult_t commDeregister(ncclComm_t comm, void* handle) = 0;
+  [[nodiscard]] virtual ncclResult_t commDeregister(
+      ncclComm_t comm,
+      void* handle) = 0;
 
   // Point-to-point operations
-  virtual ncclResult_t send(
+  [[nodiscard]] virtual ncclResult_t send(
       const void* sendbuff,
       size_t count,
       ncclDataType_t datatype,
@@ -62,7 +64,7 @@ class RcclApi {
       ncclComm_t comm,
       hipStream_t stream) = 0;
 
-  virtual ncclResult_t recv(
+  [[nodiscard]] virtual ncclResult_t recv(
       void* recvbuff,
       size_t count,
       ncclDataType_t datatype,
@@ -71,7 +73,7 @@ class RcclApi {
       hipStream_t stream) = 0;
 
   // Collective operations
-  virtual ncclResult_t broadcast(
+  [[nodiscard]] virtual ncclResult_t broadcast(
       const void* sendbuff,
       void* recvbuff,
       size_t count,
@@ -80,7 +82,7 @@ class RcclApi {
       ncclComm_t comm,
       hipStream_t stream) = 0;
 
-  virtual ncclResult_t bcast(
+  [[nodiscard]] virtual ncclResult_t bcast(
       void* buff,
       size_t count,
       ncclDataType_t datatype,
@@ -88,7 +90,7 @@ class RcclApi {
       ncclComm_t comm,
       hipStream_t stream) = 0;
 
-  virtual ncclResult_t allReduce(
+  [[nodiscard]] virtual ncclResult_t allReduce(
       const void* sendbuff,
       void* recvbuff,
       size_t count,
@@ -97,7 +99,7 @@ class RcclApi {
       ncclComm_t comm,
       hipStream_t stream) = 0;
 
-  virtual ncclResult_t reduce(
+  [[nodiscard]] virtual ncclResult_t reduce(
       const void* sendbuff,
       void* recvbuff,
       size_t count,
@@ -107,7 +109,7 @@ class RcclApi {
       ncclComm_t comm,
       hipStream_t stream) = 0;
 
-  virtual ncclResult_t allGather(
+  [[nodiscard]] virtual ncclResult_t allGather(
       const void* sendbuff,
       void* recvbuff,
       size_t sendcount,
@@ -115,7 +117,7 @@ class RcclApi {
       ncclComm_t comm,
       hipStream_t stream) = 0;
 
-  virtual ncclResult_t reduceScatter(
+  [[nodiscard]] virtual ncclResult_t reduceScatter(
       const void* sendbuff,
       void* recvbuff,
       size_t recvcount,
@@ -124,7 +126,7 @@ class RcclApi {
       ncclComm_t comm,
       hipStream_t stream) = 0;
 
-  virtual ncclResult_t allToAll(
+  [[nodiscard]] virtual ncclResult_t allToAll(
       const void* sendbuff,
       void* recvbuff,
       size_t count,
@@ -132,7 +134,7 @@ class RcclApi {
       ncclComm_t comm,
       hipStream_t stream) = 0;
 
-  virtual ncclResult_t allToAllv(
+  [[nodiscard]] virtual ncclResult_t allToAllv(
       const void* sendbuff,
       const size_t sendcounts[],
       const size_t sdispls[],
@@ -144,21 +146,27 @@ class RcclApi {
       hipStream_t stream) = 0;
 
   // Group operations
-  virtual ncclResult_t groupStart() = 0;
-  virtual ncclResult_t groupEnd() = 0;
+  [[nodiscard]] virtual ncclResult_t groupStart() = 0;
+  [[nodiscard]] virtual ncclResult_t groupEnd() = 0;
 
-  virtual ncclResult_t commUserRank(const ncclComm_t comm, int* userRank) = 0;
-  virtual ncclResult_t commCount(const ncclComm_t comm, int* count) = 0;
+  [[nodiscard]] virtual ncclResult_t commUserRank(
+      const ncclComm_t comm,
+      int* userRank) = 0;
+  [[nodiscard]] virtual ncclResult_t commCount(
+      const ncclComm_t comm,
+      int* count) = 0;
 
   // Custom reduction operations
-  virtual ncclResult_t redOpCreatePreMulSum(
+  [[nodiscard]] virtual ncclResult_t redOpCreatePreMulSum(
       ncclRedOp_t* op,
       void* scalar,
       ncclDataType_t datatype,
       ncclScalarResidence_t residence,
       ncclComm_t comm) = 0;
 
-  virtual ncclResult_t redOpDestroy(ncclRedOp_t op, ncclComm_t comm) = 0;
+  [[nodiscard]] virtual ncclResult_t redOpDestroy(
+      ncclRedOp_t op,
+      ncclComm_t comm) = 0;
 };
 
 /**
@@ -173,40 +181,42 @@ class DefaultRcclApi : public RcclApi {
   std::string getLastError(ncclComm_t comm) override;
 
   // Unique ID generation
-  ncclResult_t getUniqueId(ncclUniqueId* uniqueId) override;
+  [[nodiscard]] ncclResult_t getUniqueId(ncclUniqueId* uniqueId) override;
 
   // Communicator management
-  ncclResult_t commInitRankConfig(
+  [[nodiscard]] ncclResult_t commInitRankConfig(
       ncclComm_t* comm,
       int nranks,
       ncclUniqueId commId,
       int rank,
       ncclConfig_t* config) override;
 
-  ncclResult_t commDestroy(ncclComm_t comm) override;
+  [[nodiscard]] ncclResult_t commDestroy(ncclComm_t comm) override;
 
-  ncclResult_t commAbort(ncclComm_t comm) override;
+  [[nodiscard]] ncclResult_t commAbort(ncclComm_t comm) override;
 
-  ncclResult_t commGetAsyncError(ncclComm_t comm, ncclResult_t* asyncError)
-      override;
+  [[nodiscard]] ncclResult_t commGetAsyncError(
+      ncclComm_t comm,
+      ncclResult_t* asyncError) override;
 
-  ncclResult_t commSplit(
+  [[nodiscard]] ncclResult_t commSplit(
       ncclComm_t comm,
       int color,
       int key,
       ncclComm_t* newcomm,
       ncclConfig_t* config) override;
 
-  ncclResult_t commRegister(
+  [[nodiscard]] ncclResult_t commRegister(
       ncclComm_t comm,
       void* buffer,
       size_t size,
       void** handle) override;
 
-  ncclResult_t commDeregister(ncclComm_t comm, void* handle) override;
+  [[nodiscard]] ncclResult_t commDeregister(ncclComm_t comm, void* handle)
+      override;
 
   // Point-to-point operations
-  ncclResult_t send(
+  [[nodiscard]] ncclResult_t send(
       const void* sendbuff,
       size_t count,
       ncclDataType_t datatype,
@@ -214,7 +224,7 @@ class DefaultRcclApi : public RcclApi {
       ncclComm_t comm,
       hipStream_t stream) override;
 
-  ncclResult_t recv(
+  [[nodiscard]] ncclResult_t recv(
       void* recvbuff,
       size_t count,
       ncclDataType_t datatype,
@@ -223,7 +233,7 @@ class DefaultRcclApi : public RcclApi {
       hipStream_t stream) override;
 
   // Collective operations
-  ncclResult_t broadcast(
+  [[nodiscard]] ncclResult_t broadcast(
       const void* sendbuff,
       void* recvbuff,
       size_t count,
@@ -232,7 +242,7 @@ class DefaultRcclApi : public RcclApi {
       ncclComm_t comm,
       hipStream_t stream) override;
 
-  ncclResult_t bcast(
+  [[nodiscard]] ncclResult_t bcast(
       void* buff,
       size_t count,
       ncclDataType_t datatype,
@@ -240,7 +250,7 @@ class DefaultRcclApi : public RcclApi {
       ncclComm_t comm,
       hipStream_t stream) override;
 
-  ncclResult_t allReduce(
+  [[nodiscard]] ncclResult_t allReduce(
       const void* sendbuff,
       void* recvbuff,
       size_t count,
@@ -249,7 +259,7 @@ class DefaultRcclApi : public RcclApi {
       ncclComm_t comm,
       hipStream_t stream) override;
 
-  ncclResult_t reduce(
+  [[nodiscard]] ncclResult_t reduce(
       const void* sendbuff,
       void* recvbuff,
       size_t count,
@@ -259,7 +269,7 @@ class DefaultRcclApi : public RcclApi {
       ncclComm_t comm,
       hipStream_t stream) override;
 
-  ncclResult_t allGather(
+  [[nodiscard]] ncclResult_t allGather(
       const void* sendbuff,
       void* recvbuff,
       size_t sendcount,
@@ -267,7 +277,7 @@ class DefaultRcclApi : public RcclApi {
       ncclComm_t comm,
       hipStream_t stream) override;
 
-  ncclResult_t reduceScatter(
+  [[nodiscard]] ncclResult_t reduceScatter(
       const void* sendbuff,
       void* recvbuff,
       size_t recvcount,
@@ -276,7 +286,7 @@ class DefaultRcclApi : public RcclApi {
       ncclComm_t comm,
       hipStream_t stream) override;
 
-  ncclResult_t allToAll(
+  [[nodiscard]] ncclResult_t allToAll(
       const void* sendbuff,
       void* recvbuff,
       size_t count,
@@ -284,7 +294,7 @@ class DefaultRcclApi : public RcclApi {
       ncclComm_t comm,
       hipStream_t stream) override;
 
-  ncclResult_t allToAllv(
+  [[nodiscard]] ncclResult_t allToAllv(
       const void* sendbuff,
       const size_t sendcounts[],
       const size_t senddispls[],
@@ -296,21 +306,24 @@ class DefaultRcclApi : public RcclApi {
       hipStream_t stream) override;
 
   // Group operations
-  ncclResult_t groupStart() override;
-  ncclResult_t groupEnd() override;
+  [[nodiscard]] ncclResult_t groupStart() override;
+  [[nodiscard]] ncclResult_t groupEnd() override;
 
-  ncclResult_t commUserRank(const ncclComm_t comm, int* userRank) override;
-  ncclResult_t commCount(const ncclComm_t comm, int* count) override;
+  [[nodiscard]] ncclResult_t commUserRank(const ncclComm_t comm, int* userRank)
+      override;
+  [[nodiscard]] ncclResult_t commCount(const ncclComm_t comm, int* count)
+      override;
 
   // Custom reduction operations
-  ncclResult_t redOpCreatePreMulSum(
+  [[nodiscard]] ncclResult_t redOpCreatePreMulSum(
       ncclRedOp_t* op,
       void* scalar,
       ncclDataType_t datatype,
       ncclScalarResidence_t residence,
       ncclComm_t comm) override;
 
-  ncclResult_t redOpDestroy(ncclRedOp_t op, ncclComm_t comm) override;
+  [[nodiscard]] ncclResult_t redOpDestroy(ncclRedOp_t op, ncclComm_t comm)
+      override;
 };
 
 } // namespace torch::comms

--- a/comms/torchcomms/rccl/TorchCommRCCL.cpp
+++ b/comms/torchcomms/rccl/TorchCommRCCL.cpp
@@ -242,7 +242,11 @@ void TorchCommRCCL::finalize() {
     throw std::runtime_error("Work timed out during finalize");
   } else if (comm_state_ == CommState::ERROR) {
     ncclResult_t asyncErr;
-    rccl_api_->commGetAsyncError(nccl_comm_, &asyncErr);
+    RCCL_CHECK(
+        rccl_api_,
+        nccl_comm_,
+        rccl_api_->commGetAsyncError(nccl_comm_, &asyncErr),
+        "failed to get async error");
     RCCLException RCCLException(
         *rccl_api_, "NCCL Async Error", asyncErr, nccl_comm_);
     abortRcclComm();
@@ -296,7 +300,11 @@ void TorchCommRCCL::finalize() {
   if (nccl_comm_) {
     detachMemoryHook();
     // Deregister comm from the CachingAllocator
-    rccl_api_->commDestroy(nccl_comm_);
+    RCCL_CHECK(
+        rccl_api_,
+        nccl_comm_,
+        rccl_api_->commDestroy(nccl_comm_),
+        "RCCL Destroy failed");
     nccl_comm_ = nullptr;
   }
 }
@@ -304,7 +312,11 @@ void TorchCommRCCL::finalize() {
 void TorchCommRCCL::abortRcclComm() {
   detachMemoryHook();
   if (nccl_comm_) {
-    rccl_api_->commAbort(nccl_comm_);
+    RCCL_CHECK(
+        rccl_api_,
+        nccl_comm_,
+        rccl_api_->commAbort(nccl_comm_),
+        "RCCL Abort failed");
     nccl_comm_ = nullptr;
   }
 }

--- a/comms/torchcomms/rccl/TorchCommRCCL.hpp
+++ b/comms/torchcomms/rccl/TorchCommRCCL.hpp
@@ -276,7 +276,10 @@ class TorchCommRCCL : public TorchCommBackend,
       if (this != &other) {
         // Destroy current op if we own one
         if (comm_ && rccl_api_) {
-          rccl_api_->redOpDestroy(ncclRedOp_, comm_);
+          RCCL_CHECK_IGNORE(
+              rccl_api_,
+              rccl_api_->redOpDestroy(ncclRedOp_, comm_),
+              "failed to destroy NCCL reduction operation");
         }
         ncclRedOp_ = other.ncclRedOp_;
         comm_ = other.comm_;

--- a/comms/torchcomms/rccl/TorchCommRCCLUtils.cpp
+++ b/comms/torchcomms/rccl/TorchCommRCCLUtils.cpp
@@ -54,7 +54,11 @@ void createPreMulSum(
       is_tensor ? dataType == getNcclDataTypeInternal(tensor)
                 : dataType != ncclBfloat16,
       "PreMulSum factor type must match input data type");
-  rccl_api->redOpCreatePreMulSum(op, scalar, dataType, residence, comm);
+  RCCL_CHECK(
+      rccl_api,
+      comm,
+      rccl_api->redOpCreatePreMulSum(op, scalar, dataType, residence, comm),
+      "RCCL redOpCreatePreMulSum failed");
 }
 
 } // namespace
@@ -266,7 +270,11 @@ void TorchCommRCCL::checkAndAbortIfTimedOutOrError() {
     throw std::runtime_error("NCCL operation timed out");
   } else if (comm_state_ == CommState::ERROR) {
     ncclResult_t asyncErr;
-    rccl_api_->commGetAsyncError(nccl_comm_, &asyncErr);
+    RCCL_CHECK(
+        rccl_api_,
+        nccl_comm_,
+        rccl_api_->commGetAsyncError(nccl_comm_, &asyncErr),
+        "failed to get async error");
     RCCLException RCCLException(
         *rccl_api_, "NCCL Async Error", asyncErr, nccl_comm_);
     abortRcclComm();

--- a/comms/torchcomms/rcclx/RcclxApi.hpp
+++ b/comms/torchcomms/rcclx/RcclxApi.hpp
@@ -30,25 +30,25 @@ class RcclxApi {
   virtual std::string getLastError(ncclComm_t comm) = 0;
 
   // Unique ID generation
-  virtual ncclResult_t getUniqueId(ncclUniqueId* uniqueId) = 0;
+  [[nodiscard]] virtual ncclResult_t getUniqueId(ncclUniqueId* uniqueId) = 0;
 
   // Communicator management
-  virtual ncclResult_t commInitRankConfig(
+  [[nodiscard]] virtual ncclResult_t commInitRankConfig(
       ncclComm_t* comm,
       int nranks,
       ncclUniqueId commId,
       int rank,
       ncclConfig_t* config) = 0;
 
-  virtual ncclResult_t commDestroy(ncclComm_t comm) = 0;
+  [[nodiscard]] virtual ncclResult_t commDestroy(ncclComm_t comm) = 0;
 
-  virtual ncclResult_t commAbort(ncclComm_t comm) = 0;
+  [[nodiscard]] virtual ncclResult_t commAbort(ncclComm_t comm) = 0;
 
-  virtual ncclResult_t commGetAsyncError(
+  [[nodiscard]] virtual ncclResult_t commGetAsyncError(
       ncclComm_t comm,
       ncclResult_t* asyncError) = 0;
 
-  virtual ncclResult_t commSplit(
+  [[nodiscard]] virtual ncclResult_t commSplit(
       ncclComm_t comm,
       int color,
       int key,
@@ -56,13 +56,15 @@ class RcclxApi {
       ncclConfig_t* config) = 0;
 
   // Memory registration
-  virtual ncclResult_t
+  [[nodiscard]] virtual ncclResult_t
   commRegister(ncclComm_t comm, void* buffer, size_t size, void** handle) = 0;
 
-  virtual ncclResult_t commDeregister(ncclComm_t comm, void* handle) = 0;
+  [[nodiscard]] virtual ncclResult_t commDeregister(
+      ncclComm_t comm,
+      void* handle) = 0;
 
   // Point-to-point operations
-  virtual ncclResult_t send(
+  [[nodiscard]] virtual ncclResult_t send(
       const void* sendbuff,
       size_t count,
       ncclDataType_t datatype,
@@ -70,7 +72,7 @@ class RcclxApi {
       ncclComm_t comm,
       hipStream_t stream) = 0;
 
-  virtual ncclResult_t recv(
+  [[nodiscard]] virtual ncclResult_t recv(
       void* recvbuff,
       size_t count,
       ncclDataType_t datatype,
@@ -79,7 +81,7 @@ class RcclxApi {
       hipStream_t stream) = 0;
 
   // Collective operations
-  virtual ncclResult_t broadcast(
+  [[nodiscard]] virtual ncclResult_t broadcast(
       const void* sendbuff,
       void* recvbuff,
       size_t count,
@@ -88,7 +90,7 @@ class RcclxApi {
       ncclComm_t comm,
       hipStream_t stream) = 0;
 
-  virtual ncclResult_t bcast(
+  [[nodiscard]] virtual ncclResult_t bcast(
       void* buff,
       size_t count,
       ncclDataType_t datatype,
@@ -96,7 +98,7 @@ class RcclxApi {
       ncclComm_t comm,
       hipStream_t stream) = 0;
 
-  virtual ncclResult_t allReduce(
+  [[nodiscard]] virtual ncclResult_t allReduce(
       const void* sendbuff,
       void* recvbuff,
       size_t count,
@@ -105,7 +107,7 @@ class RcclxApi {
       ncclComm_t comm,
       hipStream_t stream) = 0;
 
-  virtual ncclResult_t reduce(
+  [[nodiscard]] virtual ncclResult_t reduce(
       const void* sendbuff,
       void* recvbuff,
       size_t count,
@@ -115,7 +117,7 @@ class RcclxApi {
       ncclComm_t comm,
       hipStream_t stream) = 0;
 
-  virtual ncclResult_t allGather(
+  [[nodiscard]] virtual ncclResult_t allGather(
       const void* sendbuff,
       void* recvbuff,
       size_t sendcount,
@@ -123,7 +125,7 @@ class RcclxApi {
       ncclComm_t comm,
       hipStream_t stream) = 0;
 
-  virtual ncclResult_t reduceScatter(
+  [[nodiscard]] virtual ncclResult_t reduceScatter(
       const void* sendbuff,
       void* recvbuff,
       size_t recvcount,
@@ -132,7 +134,7 @@ class RcclxApi {
       ncclComm_t comm,
       hipStream_t stream) = 0;
 
-  virtual ncclResult_t allToAll(
+  [[nodiscard]] virtual ncclResult_t allToAll(
       const void* sendbuff,
       void* recvbuff,
       size_t count,
@@ -140,7 +142,7 @@ class RcclxApi {
       ncclComm_t comm,
       hipStream_t stream) = 0;
 
-  virtual ncclResult_t allToAllv(
+  [[nodiscard]] virtual ncclResult_t allToAllv(
       const void* sendbuff,
       const size_t sendcounts[],
       const size_t sdispls[],
@@ -151,7 +153,7 @@ class RcclxApi {
       ncclComm_t comm,
       hipStream_t stream) = 0;
 
-  virtual ncclResult_t winAllocate(
+  [[nodiscard]] virtual ncclResult_t winAllocate(
       size_t size,
       ncclComm_t comm,
       void** baseptr,
@@ -159,9 +161,11 @@ class RcclxApi {
       bool cpuBuf,
       const size_t signal_size = 256) = 0;
 
-  virtual ncclResult_t winFree(ncclComm_t comm, RcclxWindow win) = 0;
+  [[nodiscard]] virtual ncclResult_t winFree(
+      ncclComm_t comm,
+      RcclxWindow win) = 0;
 
-  virtual ncclResult_t winPut(
+  [[nodiscard]] virtual ncclResult_t winPut(
       const void* originBuff,
       size_t count,
       ncclDataType_t datatype,
@@ -170,17 +174,17 @@ class RcclxApi {
       RcclxWindow win,
       hipStream_t stream) = 0;
 
-  virtual ncclResult_t
+  [[nodiscard]] virtual ncclResult_t
   winSharedQuery(int rank, ncclComm_t comm, RcclxWindow win, void** addr) = 0;
 
-  virtual ncclResult_t winSignal(
+  [[nodiscard]] virtual ncclResult_t winSignal(
       size_t signalDisp,
       uint64_t signalVal,
       int peer,
       RcclxWindow win,
       hipStream_t stream) = 0;
 
-  virtual ncclResult_t winWaitSignal(
+  [[nodiscard]] virtual ncclResult_t winWaitSignal(
       size_t signal_disp,
       uint64_t cmp_val,
       RcclxWindowCmpOp cmp_op,
@@ -188,21 +192,27 @@ class RcclxApi {
       hipStream_t stream) = 0;
 
   // Group operations
-  virtual ncclResult_t groupStart() = 0;
-  virtual ncclResult_t groupEnd() = 0;
+  [[nodiscard]] virtual ncclResult_t groupStart() = 0;
+  [[nodiscard]] virtual ncclResult_t groupEnd() = 0;
 
-  virtual ncclResult_t commUserRank(const ncclComm_t comm, int* userRank) = 0;
-  virtual ncclResult_t commCount(const ncclComm_t comm, int* count) = 0;
+  [[nodiscard]] virtual ncclResult_t commUserRank(
+      const ncclComm_t comm,
+      int* userRank) = 0;
+  [[nodiscard]] virtual ncclResult_t commCount(
+      const ncclComm_t comm,
+      int* count) = 0;
 
   // Custom reduction operations
-  virtual ncclResult_t redOpCreatePreMulSum(
+  [[nodiscard]] virtual ncclResult_t redOpCreatePreMulSum(
       ncclRedOp_t* op,
       void* scalar,
       ncclDataType_t datatype,
       ncclScalarResidence_t residence,
       ncclComm_t comm) = 0;
 
-  virtual ncclResult_t redOpDestroy(ncclRedOp_t op, ncclComm_t comm) = 0;
+  [[nodiscard]] virtual ncclResult_t redOpDestroy(
+      ncclRedOp_t op,
+      ncclComm_t comm) = 0;
 };
 
 /**
@@ -217,40 +227,42 @@ class DefaultRcclxApi : public RcclxApi {
   std::string getLastError(ncclComm_t comm) override;
 
   // Unique ID generation
-  ncclResult_t getUniqueId(ncclUniqueId* uniqueId) override;
+  [[nodiscard]] ncclResult_t getUniqueId(ncclUniqueId* uniqueId) override;
 
   // Communicator management
-  ncclResult_t commInitRankConfig(
+  [[nodiscard]] ncclResult_t commInitRankConfig(
       ncclComm_t* comm,
       int nranks,
       ncclUniqueId commId,
       int rank,
       ncclConfig_t* config) override;
 
-  ncclResult_t commDestroy(ncclComm_t comm) override;
+  [[nodiscard]] ncclResult_t commDestroy(ncclComm_t comm) override;
 
-  ncclResult_t commAbort(ncclComm_t comm) override;
+  [[nodiscard]] ncclResult_t commAbort(ncclComm_t comm) override;
 
-  ncclResult_t commGetAsyncError(ncclComm_t comm, ncclResult_t* asyncError)
-      override;
+  [[nodiscard]] ncclResult_t commGetAsyncError(
+      ncclComm_t comm,
+      ncclResult_t* asyncError) override;
 
-  ncclResult_t commSplit(
+  [[nodiscard]] ncclResult_t commSplit(
       ncclComm_t comm,
       int color,
       int key,
       ncclComm_t* newcomm,
       ncclConfig_t* config) override;
 
-  ncclResult_t commRegister(
+  [[nodiscard]] ncclResult_t commRegister(
       ncclComm_t comm,
       void* buffer,
       size_t size,
       void** handle) override;
 
-  ncclResult_t commDeregister(ncclComm_t comm, void* handle) override;
+  [[nodiscard]] ncclResult_t commDeregister(ncclComm_t comm, void* handle)
+      override;
 
   // Point-to-point operations
-  ncclResult_t send(
+  [[nodiscard]] ncclResult_t send(
       const void* sendbuff,
       size_t count,
       ncclDataType_t datatype,
@@ -258,7 +270,7 @@ class DefaultRcclxApi : public RcclxApi {
       ncclComm_t comm,
       hipStream_t stream) override;
 
-  ncclResult_t recv(
+  [[nodiscard]] ncclResult_t recv(
       void* recvbuff,
       size_t count,
       ncclDataType_t datatype,
@@ -267,7 +279,7 @@ class DefaultRcclxApi : public RcclxApi {
       hipStream_t stream) override;
 
   // Collective operations
-  ncclResult_t broadcast(
+  [[nodiscard]] ncclResult_t broadcast(
       const void* sendbuff,
       void* recvbuff,
       size_t count,
@@ -276,7 +288,7 @@ class DefaultRcclxApi : public RcclxApi {
       ncclComm_t comm,
       hipStream_t stream) override;
 
-  ncclResult_t bcast(
+  [[nodiscard]] ncclResult_t bcast(
       void* buff,
       size_t count,
       ncclDataType_t datatype,
@@ -284,7 +296,7 @@ class DefaultRcclxApi : public RcclxApi {
       ncclComm_t comm,
       hipStream_t stream) override;
 
-  ncclResult_t allReduce(
+  [[nodiscard]] ncclResult_t allReduce(
       const void* sendbuff,
       void* recvbuff,
       size_t count,
@@ -293,7 +305,7 @@ class DefaultRcclxApi : public RcclxApi {
       ncclComm_t comm,
       hipStream_t stream) override;
 
-  ncclResult_t reduce(
+  [[nodiscard]] ncclResult_t reduce(
       const void* sendbuff,
       void* recvbuff,
       size_t count,
@@ -303,7 +315,7 @@ class DefaultRcclxApi : public RcclxApi {
       ncclComm_t comm,
       hipStream_t stream) override;
 
-  ncclResult_t allGather(
+  [[nodiscard]] ncclResult_t allGather(
       const void* sendbuff,
       void* recvbuff,
       size_t sendcount,
@@ -311,7 +323,7 @@ class DefaultRcclxApi : public RcclxApi {
       ncclComm_t comm,
       hipStream_t stream) override;
 
-  ncclResult_t reduceScatter(
+  [[nodiscard]] ncclResult_t reduceScatter(
       const void* sendbuff,
       void* recvbuff,
       size_t recvcount,
@@ -320,7 +332,7 @@ class DefaultRcclxApi : public RcclxApi {
       ncclComm_t comm,
       hipStream_t stream) override;
 
-  ncclResult_t allToAll(
+  [[nodiscard]] ncclResult_t allToAll(
       const void* sendbuff,
       void* recvbuff,
       size_t count,
@@ -328,7 +340,7 @@ class DefaultRcclxApi : public RcclxApi {
       ncclComm_t comm,
       hipStream_t stream) override;
 
-  ncclResult_t allToAllv(
+  [[nodiscard]] ncclResult_t allToAllv(
       const void* sendbuff,
       const size_t sendcounts[],
       const size_t senddispls[],
@@ -340,15 +352,15 @@ class DefaultRcclxApi : public RcclxApi {
       hipStream_t stream) override;
 
   // Window RMA operations
-  ncclResult_t winAllocate(
+  [[nodiscard]] ncclResult_t winAllocate(
       size_t size,
       ncclComm_t comm,
       void** baseptr,
       RcclxWindow* winPtr,
       bool cpuBuf,
       const size_t signal_size = 256) override;
-  ncclResult_t winFree(ncclComm_t comm, RcclxWindow win) override;
-  ncclResult_t winPut(
+  [[nodiscard]] ncclResult_t winFree(ncclComm_t comm, RcclxWindow win) override;
+  [[nodiscard]] ncclResult_t winPut(
       const void* originBuff,
       size_t count,
       ncclDataType_t datatype,
@@ -356,18 +368,18 @@ class DefaultRcclxApi : public RcclxApi {
       size_t targetDisp,
       RcclxWindow win,
       hipStream_t stream) override;
-  ncclResult_t winSharedQuery(
+  [[nodiscard]] ncclResult_t winSharedQuery(
       int rank,
       ncclComm_t comm,
       RcclxWindow win,
       void** addr) override;
-  ncclResult_t winSignal(
+  [[nodiscard]] ncclResult_t winSignal(
       size_t signalDisp,
       uint64_t signalVal,
       int peer,
       RcclxWindow win,
       hipStream_t stream) override;
-  ncclResult_t winWaitSignal(
+  [[nodiscard]] ncclResult_t winWaitSignal(
       size_t signal_disp,
       uint64_t cmp_val,
       RcclxWindowCmpOp cmp_op,
@@ -375,21 +387,24 @@ class DefaultRcclxApi : public RcclxApi {
       hipStream_t stream) override;
 
   // Group operations
-  ncclResult_t groupStart() override;
-  ncclResult_t groupEnd() override;
+  [[nodiscard]] ncclResult_t groupStart() override;
+  [[nodiscard]] ncclResult_t groupEnd() override;
 
-  ncclResult_t commUserRank(const ncclComm_t comm, int* userRank) override;
-  ncclResult_t commCount(const ncclComm_t comm, int* count) override;
+  [[nodiscard]] ncclResult_t commUserRank(const ncclComm_t comm, int* userRank)
+      override;
+  [[nodiscard]] ncclResult_t commCount(const ncclComm_t comm, int* count)
+      override;
 
   // Custom reduction operations
-  ncclResult_t redOpCreatePreMulSum(
+  [[nodiscard]] ncclResult_t redOpCreatePreMulSum(
       ncclRedOp_t* op,
       void* scalar,
       ncclDataType_t datatype,
       ncclScalarResidence_t residence,
       ncclComm_t comm) override;
 
-  ncclResult_t redOpDestroy(ncclRedOp_t op, ncclComm_t comm) override;
+  [[nodiscard]] ncclResult_t redOpDestroy(ncclRedOp_t op, ncclComm_t comm)
+      override;
 };
 
 } // namespace torch::comms

--- a/comms/torchcomms/rcclx/TorchCommRCCLX.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLX.cpp
@@ -242,7 +242,11 @@ void TorchCommRCCLX::finalize() {
     throw std::runtime_error("Work timed out during finalize");
   } else if (comm_state_ == CommState::ERROR) {
     ncclResult_t asyncErr;
-    rcclx_api_->commGetAsyncError(nccl_comm_, &asyncErr);
+    RCCLX_CHECK(
+        rcclx_api_,
+        nccl_comm_,
+        rcclx_api_->commGetAsyncError(nccl_comm_, &asyncErr),
+        "failed to get async error");
     RCCLXException RCCLXException(
         *rcclx_api_, "RCCLX Async Error", asyncErr, nccl_comm_);
     abortRcclxComm();
@@ -296,7 +300,11 @@ void TorchCommRCCLX::finalize() {
   if (nccl_comm_) {
     detachMemoryHook();
     // Deregister comm from the CachingAllocator
-    rcclx_api_->commDestroy(nccl_comm_);
+    RCCLX_CHECK(
+        rcclx_api_,
+        nccl_comm_,
+        rcclx_api_->commDestroy(nccl_comm_),
+        "RCCLX Destroy failed");
     nccl_comm_ = nullptr;
   }
 }
@@ -304,7 +312,11 @@ void TorchCommRCCLX::finalize() {
 void TorchCommRCCLX::abortRcclxComm() {
   detachMemoryHook();
   if (nccl_comm_) {
-    rcclx_api_->commAbort(nccl_comm_);
+    RCCLX_CHECK(
+        rcclx_api_,
+        nccl_comm_,
+        rcclx_api_->commAbort(nccl_comm_),
+        "RCCLX Abort failed");
     nccl_comm_ = nullptr;
   }
 }

--- a/comms/torchcomms/rcclx/TorchCommRCCLX.hpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLX.hpp
@@ -288,7 +288,10 @@ class TorchCommRCCLX : public TorchCommBackend,
       if (this != &other) {
         // Destroy current op if we own one
         if (comm_ && rcclx_api_) {
-          rcclx_api_->redOpDestroy(ncclRedOp_, comm_);
+          RCCLX_CHECK_IGNORE(
+              rcclx_api_,
+              rcclx_api_->redOpDestroy(ncclRedOp_, comm_),
+              "failed to destroy NCCL reduction operation");
         }
         ncclRedOp_ = other.ncclRedOp_;
         comm_ = other.comm_;

--- a/comms/torchcomms/rcclx/TorchCommRCCLXUtils.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLXUtils.cpp
@@ -54,7 +54,11 @@ void createPreMulSum(
       is_tensor ? dataType == getNcclDataTypeInternal(tensor)
                 : dataType != ncclBfloat16,
       "PreMulSum factor type must match input data type");
-  rcclx_api->redOpCreatePreMulSum(op, scalar, dataType, residence, comm);
+  RCCLX_CHECK(
+      rcclx_api,
+      comm,
+      rcclx_api->redOpCreatePreMulSum(op, scalar, dataType, residence, comm),
+      "RCCLX redOpCreatePreMulSum failed");
 }
 
 } // namespace
@@ -266,7 +270,11 @@ void TorchCommRCCLX::checkAndAbortIfTimedOutOrError() {
     throw std::runtime_error("NCCL operation timed out");
   } else if (comm_state_ == CommState::ERROR) {
     ncclResult_t asyncErr;
-    rcclx_api_->commGetAsyncError(nccl_comm_, &asyncErr);
+    RCCLX_CHECK(
+        rcclx_api_,
+        nccl_comm_,
+        rcclx_api_->commGetAsyncError(nccl_comm_, &asyncErr),
+        "failed to get async error");
     RCCLXException RCCLXException(
         *rcclx_api_, "NCCL Async Error", asyncErr, nccl_comm_);
     abortRcclxComm();


### PR DESCRIPTION
Summary: This adds `[[nodiscard]]` to all the NcclApi methods so we don't forget to check error statuses.

Reviewed By: kapilsh

Differential Revision: D92103391


