### PR TITLE
torchcomms: use nodiscard for cuda API

### DIFF
--- a/comms/torchcomms/device/cuda/CudaApi.hpp
+++ b/comms/torchcomms/device/cuda/CudaApi.hpp
@@ -39,60 +39,62 @@ class CudaApi {
   virtual ~CudaApi() = default;
 
   // Device management
-  virtual cudaError_t setDevice(int device) = 0;
-  virtual cudaError_t getDeviceProperties(cudaDeviceProp* prop, int device) = 0;
-  virtual cudaError_t memGetInfo(size_t* free, size_t* total) = 0;
-  virtual cudaError_t getDeviceCount(int* count) = 0;
+  [[nodiscard]] virtual cudaError_t setDevice(int device) = 0;
+  [[nodiscard]] virtual cudaError_t getDeviceProperties(
+      cudaDeviceProp* prop,
+      int device) = 0;
+  [[nodiscard]] virtual cudaError_t memGetInfo(size_t* free, size_t* total) = 0;
+  [[nodiscard]] virtual cudaError_t getDeviceCount(int* count) = 0;
 
   // Stream management
-  virtual cudaError_t getStreamPriorityRange(
+  [[nodiscard]] virtual cudaError_t getStreamPriorityRange(
       int* leastPriority,
       int* greatestPriority) = 0;
-  virtual cudaError_t streamCreateWithPriority(
+  [[nodiscard]] virtual cudaError_t streamCreateWithPriority(
       cudaStream_t* pStream,
       unsigned int flags,
       int priority) = 0;
-  virtual cudaError_t streamDestroy(cudaStream_t stream) = 0;
-  virtual cudaError_t streamWaitEvent(
+  [[nodiscard]] virtual cudaError_t streamDestroy(cudaStream_t stream) = 0;
+  [[nodiscard]] virtual cudaError_t streamWaitEvent(
       cudaStream_t stream,
       cudaEvent_t event,
       unsigned int flags) = 0;
   virtual cudaStream_t getCurrentCUDAStream(int device_index) = 0;
-  virtual cudaError_t streamSynchronize(cudaStream_t stream) = 0;
-  virtual cudaError_t streamIsCapturing(
+  [[nodiscard]] virtual cudaError_t streamSynchronize(cudaStream_t stream) = 0;
+  [[nodiscard]] virtual cudaError_t streamIsCapturing(
       cudaStream_t stream,
       cudaStreamCaptureStatus* pCaptureStatus) = 0;
-  virtual cudaError_t streamGetCaptureInfo(
+  [[nodiscard]] virtual cudaError_t streamGetCaptureInfo(
       cudaStream_t stream,
       cudaStreamCaptureStatus* pCaptureStatus,
       unsigned long long* pId) = 0;
 
   // CUDA Graph and User Object management
-  virtual cudaError_t userObjectCreate(
+  [[nodiscard]] virtual cudaError_t userObjectCreate(
       cudaUserObject_t* object_out,
       void* ptr,
       cudaHostFn_t destroy,
       unsigned int initialRefcount,
       unsigned int flags) = 0;
-  virtual cudaError_t graphRetainUserObject(
+  [[nodiscard]] virtual cudaError_t graphRetainUserObject(
       cudaGraph_t graph,
       cudaUserObject_t object,
       unsigned int count,
       unsigned int flags) = 0;
-  virtual cudaError_t streamGetCaptureInfo_v2(
+  [[nodiscard]] virtual cudaError_t streamGetCaptureInfo_v2(
       cudaStream_t stream,
       cudaStreamCaptureStatus* captureStatus_out,
       unsigned long long* id_out,
       cudaGraph_t* graph_out,
       const cudaGraphNode_t** dependencies_out,
       size_t* numDependencies_out) = 0;
-  virtual cudaError_t threadExchangeStreamCaptureMode(
+  [[nodiscard]] virtual cudaError_t threadExchangeStreamCaptureMode(
       enum cudaStreamCaptureMode* mode) = 0;
 
   // Memory management
-  virtual cudaError_t malloc(void** devPtr, size_t size) = 0;
-  virtual cudaError_t free(void* devPtr) = 0;
-  virtual cudaError_t
+  [[nodiscard]] virtual cudaError_t malloc(void** devPtr, size_t size) = 0;
+  [[nodiscard]] virtual cudaError_t free(void* devPtr) = 0;
+  [[nodiscard]] virtual cudaError_t
   memcpy(void* dst, const void* src, size_t count, cudaMemcpyKind kind) = 0;
   virtual cudaError_t memcpyAsync(
       void* dst,
@@ -102,13 +104,15 @@ class CudaApi {
       cudaStream_t stream) = 0;
 
   // Event management
-  virtual cudaError_t eventCreate(cudaEvent_t* event) = 0;
-  virtual cudaError_t eventCreateWithFlags(
+  [[nodiscard]] virtual cudaError_t eventCreate(cudaEvent_t* event) = 0;
+  [[nodiscard]] virtual cudaError_t eventCreateWithFlags(
       cudaEvent_t* event,
       unsigned int flags) = 0;
-  virtual cudaError_t eventDestroy(cudaEvent_t event) = 0;
-  virtual cudaError_t eventRecord(cudaEvent_t event, cudaStream_t stream) = 0;
-  virtual cudaError_t eventQuery(cudaEvent_t event) = 0;
+  [[nodiscard]] virtual cudaError_t eventDestroy(cudaEvent_t event) = 0;
+  [[nodiscard]] virtual cudaError_t eventRecord(
+      cudaEvent_t event,
+      cudaStream_t stream) = 0;
+  [[nodiscard]] virtual cudaError_t eventQuery(cudaEvent_t event) = 0;
 
   // Error handling
   virtual const char* getErrorString(cudaError_t error) = 0;
@@ -122,59 +126,62 @@ class DefaultCudaApi : public CudaApi {
   ~DefaultCudaApi() override = default;
 
   // Device management
-  cudaError_t setDevice(int device) override;
-  cudaError_t getDeviceProperties(cudaDeviceProp* prop, int device) override;
-  cudaError_t memGetInfo(size_t* free, size_t* total) override;
-  cudaError_t getDeviceCount(int* count) override;
+  [[nodiscard]] cudaError_t setDevice(int device) override;
+  [[nodiscard]] cudaError_t getDeviceProperties(
+      cudaDeviceProp* prop,
+      int device) override;
+  [[nodiscard]] cudaError_t memGetInfo(size_t* free, size_t* total) override;
+  [[nodiscard]] cudaError_t getDeviceCount(int* count) override;
 
   // Stream management
-  cudaError_t getStreamPriorityRange(int* leastPriority, int* greatestPriority)
-      override;
-  cudaError_t streamCreateWithPriority(
+  [[nodiscard]] cudaError_t getStreamPriorityRange(
+      int* leastPriority,
+      int* greatestPriority) override;
+  [[nodiscard]] cudaError_t streamCreateWithPriority(
       cudaStream_t* pStream,
       unsigned int flags,
       int priority) override;
-  cudaError_t streamDestroy(cudaStream_t stream) override;
-  cudaError_t streamWaitEvent(
+  [[nodiscard]] cudaError_t streamDestroy(cudaStream_t stream) override;
+  [[nodiscard]] cudaError_t streamWaitEvent(
       cudaStream_t stream,
       cudaEvent_t event,
       unsigned int flags) override;
   cudaStream_t getCurrentCUDAStream(int device_index) override;
-  cudaError_t streamSynchronize(cudaStream_t stream) override;
-  cudaError_t streamIsCapturing(
+  [[nodiscard]] cudaError_t streamSynchronize(cudaStream_t stream) override;
+  [[nodiscard]] cudaError_t streamIsCapturing(
       cudaStream_t stream,
       cudaStreamCaptureStatus* pCaptureStatus) override;
-  cudaError_t streamGetCaptureInfo(
+  [[nodiscard]] cudaError_t streamGetCaptureInfo(
       cudaStream_t stream,
       cudaStreamCaptureStatus* pCaptureStatus,
       unsigned long long* pId) override;
 
   // CUDA Graph and User Object management
-  cudaError_t userObjectCreate(
+  [[nodiscard]] cudaError_t userObjectCreate(
       cudaUserObject_t* object_out,
       void* ptr,
       cudaHostFn_t destroy,
       unsigned int initialRefcount,
       unsigned int flags) override;
-  cudaError_t graphRetainUserObject(
+  [[nodiscard]] cudaError_t graphRetainUserObject(
       cudaGraph_t graph,
       cudaUserObject_t object,
       unsigned int count,
       unsigned int flags) override;
-  cudaError_t streamGetCaptureInfo_v2(
+  [[nodiscard]] cudaError_t streamGetCaptureInfo_v2(
       cudaStream_t stream,
       cudaStreamCaptureStatus* captureStatus_out,
       unsigned long long* id_out,
       cudaGraph_t* graph_out,
       const cudaGraphNode_t** dependencies_out,
       size_t* numDependencies_out) override;
-  cudaError_t threadExchangeStreamCaptureMode(
+  [[nodiscard]] cudaError_t threadExchangeStreamCaptureMode(
       enum cudaStreamCaptureMode* mode) override;
 
   // Memory management
-  cudaError_t malloc(void** devPtr, size_t size) override;
-  cudaError_t free(void* devPtr) override;
-  cudaError_t memcpy(
+  [[nodiscard]] cudaError_t malloc(void** devPtr, size_t size) override;
+  [[nodiscard]] cudaError_t free(void* devPtr) override;
+  [[nodiscard]] cudaError_t memcpy(
       void* dst,
       const void* src,
       size_t count,
@@ -187,12 +194,14 @@ class DefaultCudaApi : public CudaApi {
       cudaStream_t stream) override;
 
   // Event management
-  cudaError_t eventCreate(cudaEvent_t* event) override;
-  cudaError_t eventCreateWithFlags(cudaEvent_t* event, unsigned int flags)
+  [[nodiscard]] cudaError_t eventCreate(cudaEvent_t* event) override;
+  [[nodiscard]] cudaError_t eventCreateWithFlags(
+      cudaEvent_t* event,
+      unsigned int flags) override;
+  [[nodiscard]] cudaError_t eventDestroy(cudaEvent_t event) override;
+  [[nodiscard]] cudaError_t eventRecord(cudaEvent_t event, cudaStream_t stream)
       override;
-  cudaError_t eventDestroy(cudaEvent_t event) override;
-  cudaError_t eventRecord(cudaEvent_t event, cudaStream_t stream) override;
-  cudaError_t eventQuery(cudaEvent_t event) override;
+  [[nodiscard]] cudaError_t eventQuery(cudaEvent_t event) override;
 
   // Error handling
   const char* getErrorString(cudaError_t error) override;

--- a/comms/torchcomms/nccl/TorchCommNCCL.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCL.cpp
@@ -133,7 +133,10 @@ void TorchCommNCCL::init(
   // Check for high priority stream hint
   if (high_priority_stream_) {
     int leastPriority, greatestPriority;
-    cuda_api_->getStreamPriorityRange(&leastPriority, &greatestPriority);
+    CUDA_CHECK(
+        cuda_api_,
+        cuda_api_->getStreamPriorityRange(&leastPriority, &greatestPriority),
+        "Failed to get stream");
     stream_priority = greatestPriority;
   }
 

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -162,7 +162,10 @@ void TorchCommNCCLX::init(
   // Check for high priority stream hint
   if (high_priority_stream_) {
     int leastPriority, greatestPriority;
-    cuda_api_->getStreamPriorityRange(&leastPriority, &greatestPriority);
+    CUDA_CHECK(
+        cuda_api_,
+        cuda_api_->getStreamPriorityRange(&leastPriority, &greatestPriority),
+        "Failed to get stream");
     stream_priority = greatestPriority;
   }
 

--- a/comms/torchcomms/ncclx/TorchCommWindowNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommWindowNCCLX.cpp
@@ -33,8 +33,11 @@ TorchCommWindowNCCLX<Backend>::~TorchCommWindowNCCLX() noexcept {
   // Cleanup registered local buffers
   for (auto& buf : registered_local_buffers_) {
     if (buf.backend_window != nullptr && local_comm_ != nullptr) {
-      nccl_api_->commWindowDeregister(
-          local_comm_, static_cast<NcclxWindow>(buf.backend_window));
+      NCCLX_CHECK_IGNORE(
+          nccl_api_,
+          nccl_api_->commWindowDeregister(
+              local_comm_, static_cast<NcclxWindow>(buf.backend_window)),
+          "NCCLX local buffer deregister failed in destructor");
     }
   }
   registered_local_buffers_.clear();

--- a/comms/torchcomms/rccl/HipApi.hpp
+++ b/comms/torchcomms/rccl/HipApi.hpp
@@ -39,32 +39,34 @@ class HipApi {
   virtual ~HipApi() = default;
 
   // Device management
-  virtual hipError_t setDevice(int device) = 0;
-  virtual hipError_t getDeviceProperties(hipDeviceProp_t* prop, int device) = 0;
-  virtual hipError_t memGetInfo(size_t* free, size_t* total) = 0;
-  virtual hipError_t getDeviceCount(int* count) = 0;
+  [[nodiscard]] virtual hipError_t setDevice(int device) = 0;
+  [[nodiscard]] virtual hipError_t getDeviceProperties(
+      hipDeviceProp_t* prop,
+      int device) = 0;
+  [[nodiscard]] virtual hipError_t memGetInfo(size_t* free, size_t* total) = 0;
+  [[nodiscard]] virtual hipError_t getDeviceCount(int* count) = 0;
 
   // Stream management
-  virtual hipError_t getStreamPriorityRange(
+  [[nodiscard]] virtual hipError_t getStreamPriorityRange(
       int* leastPriority,
       int* greatestPriority) = 0;
-  virtual hipError_t streamCreateWithPriority(
+  [[nodiscard]] virtual hipError_t streamCreateWithPriority(
       hipStream_t* pStream,
       unsigned int flags,
       int priority) = 0;
-  virtual hipError_t streamDestroy(hipStream_t stream) = 0;
-  virtual hipError_t
+  [[nodiscard]] virtual hipError_t streamDestroy(hipStream_t stream) = 0;
+  [[nodiscard]] virtual hipError_t
   streamWaitEvent(hipStream_t stream, hipEvent_t event, unsigned int flags) = 0;
   virtual hipStream_t getCurrentHIPStreamMasqueradingAsCUDA(
       int device_index) = 0;
-  virtual hipError_t streamSynchronize(hipStream_t stream) = 0;
-  virtual hipError_t threadExchangeStreamCaptureMode(
+  [[nodiscard]] virtual hipError_t streamSynchronize(hipStream_t stream) = 0;
+  [[nodiscard]] virtual hipError_t threadExchangeStreamCaptureMode(
       enum hipStreamCaptureMode* mode) = 0;
 
   // Memory management
-  virtual hipError_t malloc(void** devPtr, size_t size) = 0;
-  virtual hipError_t free(void* devPtr) = 0;
-  virtual hipError_t memcpyAsync(
+  [[nodiscard]] virtual hipError_t malloc(void** devPtr, size_t size) = 0;
+  [[nodiscard]] virtual hipError_t free(void* devPtr) = 0;
+  [[nodiscard]] virtual hipError_t memcpyAsync(
       void* dst,
       const void* src,
       size_t count,
@@ -72,10 +74,12 @@ class HipApi {
       hipStream_t stream) = 0;
 
   // Event management
-  virtual hipError_t eventCreate(hipEvent_t* event) = 0;
-  virtual hipError_t eventDestroy(hipEvent_t event) = 0;
-  virtual hipError_t eventRecord(hipEvent_t event, hipStream_t stream) = 0;
-  virtual hipError_t eventQuery(hipEvent_t event) = 0;
+  [[nodiscard]] virtual hipError_t eventCreate(hipEvent_t* event) = 0;
+  [[nodiscard]] virtual hipError_t eventDestroy(hipEvent_t event) = 0;
+  [[nodiscard]] virtual hipError_t eventRecord(
+      hipEvent_t event,
+      hipStream_t stream) = 0;
+  [[nodiscard]] virtual hipError_t eventQuery(hipEvent_t event) = 0;
 
   // Error handling
   virtual const char* getErrorString(hipError_t error) = 0;
@@ -89,33 +93,35 @@ class DefaultHipApi : public HipApi {
   ~DefaultHipApi() override = default;
 
   // Device management
-  hipError_t setDevice(int device) override;
-  hipError_t getDeviceProperties(hipDeviceProp_t* prop, int device) override;
-  hipError_t memGetInfo(size_t* free, size_t* total) override;
-  hipError_t getDeviceCount(int* count) override;
+  [[nodiscard]] hipError_t setDevice(int device) override;
+  [[nodiscard]] hipError_t getDeviceProperties(
+      hipDeviceProp_t* prop,
+      int device) override;
+  [[nodiscard]] hipError_t memGetInfo(size_t* free, size_t* total) override;
+  [[nodiscard]] hipError_t getDeviceCount(int* count) override;
 
   // Stream management
-  virtual hipError_t getStreamPriorityRange(
+  [[nodiscard]] hipError_t getStreamPriorityRange(
       int* leastPriority,
       int* greatestPriority) override;
-  virtual hipError_t streamCreateWithPriority(
+  [[nodiscard]] hipError_t streamCreateWithPriority(
       hipStream_t* pStream,
       unsigned int flags,
       int priority) override;
-  hipError_t streamDestroy(hipStream_t stream) override;
-  hipError_t streamWaitEvent(
+  [[nodiscard]] hipError_t streamDestroy(hipStream_t stream) override;
+  [[nodiscard]] hipError_t streamWaitEvent(
       hipStream_t stream,
       hipEvent_t event,
       unsigned int flags) override;
   hipStream_t getCurrentHIPStreamMasqueradingAsCUDA(int device_index) override;
-  hipError_t streamSynchronize(hipStream_t stream) override;
-  hipError_t threadExchangeStreamCaptureMode(
+  [[nodiscard]] hipError_t streamSynchronize(hipStream_t stream) override;
+  [[nodiscard]] hipError_t threadExchangeStreamCaptureMode(
       enum hipStreamCaptureMode* mode) override;
 
   // Memory management
-  hipError_t malloc(void** devPtr, size_t size) override;
-  hipError_t free(void* devPtr) override;
-  hipError_t memcpyAsync(
+  [[nodiscard]] hipError_t malloc(void** devPtr, size_t size) override;
+  [[nodiscard]] hipError_t free(void* devPtr) override;
+  [[nodiscard]] hipError_t memcpyAsync(
       void* dst,
       const void* src,
       size_t count,
@@ -123,10 +129,11 @@ class DefaultHipApi : public HipApi {
       hipStream_t stream) override;
 
   // Event management
-  hipError_t eventCreate(hipEvent_t* event) override;
-  hipError_t eventDestroy(hipEvent_t event) override;
-  hipError_t eventRecord(hipEvent_t event, hipStream_t stream) override;
-  hipError_t eventQuery(hipEvent_t event) override;
+  [[nodiscard]] hipError_t eventCreate(hipEvent_t* event) override;
+  [[nodiscard]] hipError_t eventDestroy(hipEvent_t event) override;
+  [[nodiscard]] hipError_t eventRecord(hipEvent_t event, hipStream_t stream)
+      override;
+  [[nodiscard]] hipError_t eventQuery(hipEvent_t event) override;
 
   // Error handling
   const char* getErrorString(hipError_t error) override;

--- a/comms/torchcomms/rcclx/HipApi.hpp
+++ b/comms/torchcomms/rcclx/HipApi.hpp
@@ -39,32 +39,34 @@ class HipApi {
   virtual ~HipApi() = default;
 
   // Device management
-  virtual hipError_t setDevice(int device) = 0;
-  virtual hipError_t getDeviceProperties(hipDeviceProp_t* prop, int device) = 0;
-  virtual hipError_t memGetInfo(size_t* free, size_t* total) = 0;
-  virtual hipError_t getDeviceCount(int* count) = 0;
+  [[nodiscard]] virtual hipError_t setDevice(int device) = 0;
+  [[nodiscard]] virtual hipError_t getDeviceProperties(
+      hipDeviceProp_t* prop,
+      int device) = 0;
+  [[nodiscard]] virtual hipError_t memGetInfo(size_t* free, size_t* total) = 0;
+  [[nodiscard]] virtual hipError_t getDeviceCount(int* count) = 0;
 
   // Stream management
-  virtual hipError_t getStreamPriorityRange(
+  [[nodiscard]] virtual hipError_t getStreamPriorityRange(
       int* leastPriority,
       int* greatestPriority) = 0;
-  virtual hipError_t streamCreateWithPriority(
+  [[nodiscard]] virtual hipError_t streamCreateWithPriority(
       hipStream_t* pStream,
       unsigned int flags,
       int priority) = 0;
-  virtual hipError_t streamDestroy(hipStream_t stream) = 0;
-  virtual hipError_t
+  [[nodiscard]] virtual hipError_t streamDestroy(hipStream_t stream) = 0;
+  [[nodiscard]] virtual hipError_t
   streamWaitEvent(hipStream_t stream, hipEvent_t event, unsigned int flags) = 0;
   virtual hipStream_t getCurrentHIPStreamMasqueradingAsCUDA(
       int device_index) = 0;
-  virtual hipError_t streamSynchronize(hipStream_t stream) = 0;
-  virtual hipError_t threadExchangeStreamCaptureMode(
+  [[nodiscard]] virtual hipError_t streamSynchronize(hipStream_t stream) = 0;
+  [[nodiscard]] virtual hipError_t threadExchangeStreamCaptureMode(
       enum hipStreamCaptureMode* mode) = 0;
 
   // Memory management
-  virtual hipError_t malloc(void** devPtr, size_t size) = 0;
-  virtual hipError_t free(void* devPtr) = 0;
-  virtual hipError_t memcpyAsync(
+  [[nodiscard]] virtual hipError_t malloc(void** devPtr, size_t size) = 0;
+  [[nodiscard]] virtual hipError_t free(void* devPtr) = 0;
+  [[nodiscard]] virtual hipError_t memcpyAsync(
       void* dst,
       const void* src,
       size_t count,
@@ -72,10 +74,12 @@ class HipApi {
       hipStream_t stream) = 0;
 
   // Event management
-  virtual hipError_t eventCreate(hipEvent_t* event) = 0;
-  virtual hipError_t eventDestroy(hipEvent_t event) = 0;
-  virtual hipError_t eventRecord(hipEvent_t event, hipStream_t stream) = 0;
-  virtual hipError_t eventQuery(hipEvent_t event) = 0;
+  [[nodiscard]] virtual hipError_t eventCreate(hipEvent_t* event) = 0;
+  [[nodiscard]] virtual hipError_t eventDestroy(hipEvent_t event) = 0;
+  [[nodiscard]] virtual hipError_t eventRecord(
+      hipEvent_t event,
+      hipStream_t stream) = 0;
+  [[nodiscard]] virtual hipError_t eventQuery(hipEvent_t event) = 0;
 
   // Error handling
   virtual const char* getErrorString(hipError_t error) = 0;
@@ -89,33 +93,35 @@ class DefaultHipApi : public HipApi {
   ~DefaultHipApi() override = default;
 
   // Device management
-  hipError_t setDevice(int device) override;
-  hipError_t getDeviceProperties(hipDeviceProp_t* prop, int device) override;
-  hipError_t memGetInfo(size_t* free, size_t* total) override;
-  hipError_t getDeviceCount(int* count) override;
+  [[nodiscard]] hipError_t setDevice(int device) override;
+  [[nodiscard]] hipError_t getDeviceProperties(
+      hipDeviceProp_t* prop,
+      int device) override;
+  [[nodiscard]] hipError_t memGetInfo(size_t* free, size_t* total) override;
+  [[nodiscard]] hipError_t getDeviceCount(int* count) override;
 
   // Stream management
-  virtual hipError_t getStreamPriorityRange(
+  [[nodiscard]] hipError_t getStreamPriorityRange(
       int* leastPriority,
       int* greatestPriority) override;
-  virtual hipError_t streamCreateWithPriority(
+  [[nodiscard]] hipError_t streamCreateWithPriority(
       hipStream_t* pStream,
       unsigned int flags,
       int priority) override;
-  hipError_t streamDestroy(hipStream_t stream) override;
-  hipError_t streamWaitEvent(
+  [[nodiscard]] hipError_t streamDestroy(hipStream_t stream) override;
+  [[nodiscard]] hipError_t streamWaitEvent(
       hipStream_t stream,
       hipEvent_t event,
       unsigned int flags) override;
   hipStream_t getCurrentHIPStreamMasqueradingAsCUDA(int device_index) override;
-  hipError_t streamSynchronize(hipStream_t stream) override;
-  hipError_t threadExchangeStreamCaptureMode(
+  [[nodiscard]] hipError_t streamSynchronize(hipStream_t stream) override;
+  [[nodiscard]] hipError_t threadExchangeStreamCaptureMode(
       enum hipStreamCaptureMode* mode) override;
 
   // Memory management
-  hipError_t malloc(void** devPtr, size_t size) override;
-  hipError_t free(void* devPtr) override;
-  hipError_t memcpyAsync(
+  [[nodiscard]] hipError_t malloc(void** devPtr, size_t size) override;
+  [[nodiscard]] hipError_t free(void* devPtr) override;
+  [[nodiscard]] hipError_t memcpyAsync(
       void* dst,
       const void* src,
       size_t count,
@@ -123,10 +129,11 @@ class DefaultHipApi : public HipApi {
       hipStream_t stream) override;
 
   // Event management
-  hipError_t eventCreate(hipEvent_t* event) override;
-  hipError_t eventDestroy(hipEvent_t event) override;
-  hipError_t eventRecord(hipEvent_t event, hipStream_t stream) override;
-  hipError_t eventQuery(hipEvent_t event) override;
+  [[nodiscard]] hipError_t eventCreate(hipEvent_t* event) override;
+  [[nodiscard]] hipError_t eventDestroy(hipEvent_t event) override;
+  [[nodiscard]] hipError_t eventRecord(hipEvent_t event, hipStream_t stream)
+      override;
+  [[nodiscard]] hipError_t eventQuery(hipEvent_t event) override;
 
   // Error handling
   const char* getErrorString(hipError_t error) override;


### PR DESCRIPTION
Summary: This uses `[[nodiscard]]` for all Cuda API methods to avoid errors accidentally being missed.

Reviewed By: kapilsh

Differential Revision: D92103968


