### PR TITLE
Add P2pIbgdaTransportDevice for GPU-initiated RDMA

### DIFF
--- a/comms/pipes/DocaVerbsUtils.cuh
+++ b/comms/pipes/DocaVerbsUtils.cuh
@@ -1,0 +1,103 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+
+#include <device/doca_gpunetio_dev_verbs_onesided.cuh>
+
+namespace comms::pipes {
+
+/**
+ * DocaVerbsUtils - Utility functions for DOCA GPU Verbs operations
+ *
+ * Provides higher-level abstractions over low-level DOCA GPUNetIO APIs,
+ * encapsulating WQE management and common patterns.
+ */
+
+/**
+ * doca_fence - Wait for all pending RDMA operations to complete at the NIC
+ *
+ * Issues a NOP WQE and waits for it to complete. Since WQEs are processed
+ * in order by the NIC, when the NOP completes, all prior WQEs have been
+ * processed.
+ *
+ * Use this to ensure ordering between RDMA operations when packet reordering
+ * on the network could cause issues (e.g., before reset_signal to ensure
+ * prior put_signal operations have been sent).
+ *
+ * Note: This only ensures local NIC completion, not remote arrival.
+ * For remote completion guarantees, use signal-based synchronization.
+ *
+ * @param qp GPU QP handle
+ */
+template <
+    enum doca_gpu_dev_verbs_resource_sharing_mode resource_sharing_mode =
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+    enum doca_gpu_dev_verbs_nic_handler nic_handler =
+        DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>
+__device__ __forceinline__ void doca_fence(doca_gpu_dev_verbs_qp* qp) {
+  // Issue a NOP WQE with CQ update
+  uint64_t wqe_idx =
+      doca_gpu_dev_verbs_reserve_wq_slots<resource_sharing_mode>(qp, 1);
+
+  struct doca_gpu_dev_verbs_wqe* wqe_ptr =
+      doca_gpu_dev_verbs_get_wqe_ptr(qp, wqe_idx);
+
+  doca_gpu_dev_verbs_wqe_prepare_nop(
+      qp,
+      wqe_ptr,
+      static_cast<uint16_t>(wqe_idx),
+      DOCA_GPUNETIO_IB_MLX5_WQE_CTRL_CQ_UPDATE);
+
+  doca_gpu_dev_verbs_mark_wqes_ready<resource_sharing_mode>(
+      qp, wqe_idx, wqe_idx);
+
+  doca_gpu_dev_verbs_submit<
+      resource_sharing_mode,
+      DOCA_GPUNETIO_VERBS_SYNC_SCOPE_GPU,
+      nic_handler>(qp, wqe_idx + 1);
+
+  // Wait for the NOP to complete
+  doca_gpu_dev_verbs_wait<resource_sharing_mode, nic_handler>(qp, wqe_idx);
+}
+
+/**
+ * doca_put_fenced - RDMA Write with pre-fence for ordering
+ *
+ * Issues a fence to ensure all prior operations complete, then performs
+ * an RDMA write and waits for local completion.
+ *
+ * @param qp GPU QP handle
+ * @param raddr Remote address descriptor
+ * @param laddr Local address descriptor
+ * @param size Number of bytes to transfer
+ */
+template <
+    enum doca_gpu_dev_verbs_resource_sharing_mode resource_sharing_mode =
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+    enum doca_gpu_dev_verbs_nic_handler nic_handler =
+        DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO,
+    enum doca_gpu_dev_verbs_exec_scope exec_scope =
+        DOCA_GPUNETIO_VERBS_EXEC_SCOPE_THREAD>
+__device__ __forceinline__ void doca_put_fenced(
+    doca_gpu_dev_verbs_qp* qp,
+    doca_gpu_dev_verbs_addr raddr,
+    doca_gpu_dev_verbs_addr laddr,
+    size_t size) {
+  // Fence before: ensure all prior operations are processed
+  doca_fence<resource_sharing_mode, nic_handler>(qp);
+
+  // Issue the put
+  doca_gpu_dev_verbs_ticket_t ticket;
+  doca_gpu_dev_verbs_put<resource_sharing_mode, nic_handler, exec_scope>(
+      qp, raddr, laddr, size, &ticket);
+
+  // Wait for local completion
+  doca_gpu_dev_verbs_wait<resource_sharing_mode, nic_handler>(qp, ticket);
+
+  // Fence after: ensure this operation is processed before subsequent ones
+  doca_fence<resource_sharing_mode, nic_handler>(qp);
+}
+
+} // namespace comms::pipes

--- a/comms/pipes/IbgdaBuffer.h
+++ b/comms/pipes/IbgdaBuffer.h
@@ -1,0 +1,256 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include <endian.h>
+
+// Allow compilation in both host (C++) and device (CUDA) contexts
+#ifdef __CUDACC__
+#define IBGDA_HOST_DEVICE __host__ __device__
+#else
+#define IBGDA_HOST_DEVICE
+#endif
+
+namespace comms::pipes {
+
+// =============================================================================
+// Strong Types for RDMA Memory Keys
+// =============================================================================
+//
+// DOCA GPUNetIO expects memory registration keys (lkey/rkey) in network byte
+// order (big-endian) for RDMA WQE construction. These strong types prevent
+// accidental mixing of host and network byte order keys.
+//
+// Use case:
+//   - ibv_reg_mr() returns keys in host byte order
+//   - DOCA device APIs expect keys in network byte order
+//   - These types ensure correct conversion at compile time
+
+/**
+ * HostLKey - Local key in host byte order
+ *
+ * Represents an lkey as returned by ibv_reg_mr() or similar APIs.
+ * Must be converted to NetworkLKey before use in RDMA operations.
+ */
+struct HostLKey {
+  uint32_t value{0};
+
+  HostLKey() = default;
+  IBGDA_HOST_DEVICE explicit HostLKey(uint32_t v) : value(v) {}
+
+  IBGDA_HOST_DEVICE bool operator==(const HostLKey& other) const {
+    return value == other.value;
+  }
+  IBGDA_HOST_DEVICE bool operator!=(const HostLKey& other) const {
+    return value != other.value;
+  }
+};
+
+/**
+ * NetworkLKey - Local key in network byte order (big-endian)
+ *
+ * Represents an lkey ready for use in RDMA WQE construction.
+ * This is the format expected by DOCA GPUNetIO device APIs.
+ *
+ * Supports implicit conversion from HostLKey (performs byte order conversion).
+ */
+struct NetworkLKey {
+  uint32_t value{0};
+
+  NetworkLKey() = default;
+  IBGDA_HOST_DEVICE explicit NetworkLKey(uint32_t v) : value(v) {}
+
+  // Implicit conversion from HostLKey (performs htobe32)
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  /* implicit */ NetworkLKey(HostLKey hostKey)
+      : value(htobe32(hostKey.value)) {}
+
+  IBGDA_HOST_DEVICE bool operator==(const NetworkLKey& other) const {
+    return value == other.value;
+  }
+  IBGDA_HOST_DEVICE bool operator!=(const NetworkLKey& other) const {
+    return value != other.value;
+  }
+};
+
+/**
+ * HostRKey - Remote key in host byte order
+ *
+ * Represents an rkey as received from a remote peer (after network transport).
+ * Must be converted to NetworkRKey before use in RDMA operations.
+ */
+struct HostRKey {
+  uint32_t value{0};
+
+  HostRKey() = default;
+  IBGDA_HOST_DEVICE explicit HostRKey(uint32_t v) : value(v) {}
+
+  IBGDA_HOST_DEVICE bool operator==(const HostRKey& other) const {
+    return value == other.value;
+  }
+  IBGDA_HOST_DEVICE bool operator!=(const HostRKey& other) const {
+    return value != other.value;
+  }
+};
+
+/**
+ * NetworkRKey - Remote key in network byte order (big-endian)
+ *
+ * Represents an rkey ready for use in RDMA WQE construction.
+ * This is the format expected by DOCA GPUNetIO device APIs.
+ *
+ * Supports implicit conversion from HostRKey (performs byte order conversion).
+ */
+struct NetworkRKey {
+  uint32_t value{0};
+
+  NetworkRKey() = default;
+  IBGDA_HOST_DEVICE explicit NetworkRKey(uint32_t v) : value(v) {}
+
+  // Implicit conversion from HostRKey (performs htobe32)
+  // Note: This constructor is intentionally NOT explicit - implicit conversion
+  // is the desired behavior. It is also intentionally host-only (no
+  // IBGDA_HOST_DEVICE) because htobe32() is not available on GPU. The
+  // conversion happens on the host before passing to device code.
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  /* implicit */ NetworkRKey(HostRKey hostKey)
+      : value(htobe32(hostKey.value)) {}
+
+  IBGDA_HOST_DEVICE bool operator==(const NetworkRKey& other) const {
+    return value == other.value;
+  }
+  IBGDA_HOST_DEVICE bool operator!=(const NetworkRKey& other) const {
+    return value != other.value;
+  }
+};
+
+// =============================================================================
+// Buffer Descriptors
+// =============================================================================
+
+/**
+ * IbgdaLocalBuffer - Local buffer descriptor for RDMA operations
+ *
+ * Represents a buffer in the local GPU's memory that can be used
+ * as a source for RDMA writes or destination for RDMA reads.
+ * Uses lkey (local key) in network byte order for memory registration.
+ *
+ * This struct is usable from both host and device code.
+ */
+struct IbgdaLocalBuffer {
+  void* ptr{nullptr};
+  NetworkLKey lkey{};
+
+  IbgdaLocalBuffer() = default;
+
+  IBGDA_HOST_DEVICE IbgdaLocalBuffer(void* p, NetworkLKey key)
+      : ptr(p), lkey(key) {}
+
+  /**
+   * Create a sub-buffer at the given byte offset
+   */
+  IBGDA_HOST_DEVICE IbgdaLocalBuffer subBuffer(std::size_t offset) const {
+    return IbgdaLocalBuffer(static_cast<char*>(ptr) + offset, lkey);
+  }
+};
+
+/**
+ * IbgdaRemoteBuffer - Remote buffer descriptor for RDMA operations
+ *
+ * Represents a buffer in a remote GPU's memory that can be accessed
+ * via RDMA operations. Uses rkey (remote key) in network byte order
+ * for memory registration.
+ *
+ * This struct is usable from both host and device code.
+ */
+struct IbgdaRemoteBuffer {
+  void* ptr{nullptr};
+  NetworkRKey rkey{};
+
+  IbgdaRemoteBuffer() = default;
+
+  IBGDA_HOST_DEVICE IbgdaRemoteBuffer(void* p, NetworkRKey key)
+      : ptr(p), rkey(key) {}
+
+  /**
+   * Create a sub-buffer at the given byte offset
+   */
+  IBGDA_HOST_DEVICE IbgdaRemoteBuffer subBuffer(std::size_t offset) const {
+    return IbgdaRemoteBuffer(static_cast<char*>(ptr) + offset, rkey);
+  }
+};
+
+// =============================================================================
+// Signal Operation Types
+// =============================================================================
+
+/**
+ * IbgdaSignalOp - Signal operation types for IBGDA transport
+ *
+ * Defines the atomic operation to perform on the remote signal buffer.
+ * Note: SET is not yet supported by DOCA GPUNetIO, but included for
+ * API consistency and future compatibility with torchcomms.
+ */
+enum class IbgdaSignalOp {
+  ADD, // Atomic fetch-add (supported)
+  SET, // Atomic set (not yet supported by DOCA)
+};
+
+/**
+ * IbgdaCmpOp - Comparison operations for wait_signal
+ *
+ * Defines the comparison operation used when waiting for a signal value.
+ * API consistent with torchcomms::device::CmpOp.
+ */
+enum class IbgdaCmpOp {
+  EQ, // ==
+  NE, // !=
+  LT, // <
+  LE, // <=
+  GT, // >
+  GE, // >= (most common for wait operations)
+};
+
+// =============================================================================
+// Buffer Exchange Info
+// =============================================================================
+
+/**
+ * IbgdaBufferExchInfo - Buffer info for exchange between hosts
+ *
+ * Represents a buffer's address and remote key in host byte order,
+ * suitable for serialization and exchange between peers. The rkey
+ * is stored in host byte order and will be converted to network
+ * byte order when creating an IbgdaRemoteBuffer for RDMA operations.
+ *
+ * Use case:
+ *   - Exchange buffer registration info between peers via bootstrap
+ *   - Convert to IbgdaRemoteBuffer after receiving from peer
+ */
+struct IbgdaBufferExchInfo {
+  uint64_t addr{0};
+  HostRKey rkey{};
+
+  IbgdaBufferExchInfo() = default;
+  IbgdaBufferExchInfo(uint64_t a, HostRKey r) : addr(a), rkey(r) {}
+
+  /**
+   * Convert to IbgdaRemoteBuffer for RDMA operations.
+   * The HostRKey is implicitly converted to NetworkRKey.
+   */
+  IbgdaRemoteBuffer toRemoteBuffer() const {
+    return IbgdaRemoteBuffer(reinterpret_cast<void*>(addr), rkey);
+  }
+
+  /**
+   * Create a sub-buffer at the given byte offset.
+   */
+  IbgdaBufferExchInfo subBuffer(std::size_t offset) const {
+    return IbgdaBufferExchInfo(addr + offset, rkey);
+  }
+};
+
+} // namespace comms::pipes

--- a/comms/pipes/P2pIbgdaTransportDevice.cuh
+++ b/comms/pipes/P2pIbgdaTransportDevice.cuh
@@ -1,0 +1,486 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include <device/doca_gpunetio_dev_verbs_onesided.cuh>
+
+#include "comms/pipes/DocaVerbsUtils.cuh"
+#include "comms/pipes/IbgdaBuffer.h"
+
+namespace comms::pipes {
+
+// IbgdaSignalOp and IbgdaCmpOp are defined in IbgdaBuffer.h
+
+/**
+ * IbgdaWork - Wrapper for DOCA GPU verbs operation handle
+ *
+ * Wraps the raw doca_gpu_dev_verbs_ticket_t to provide type safety
+ * and a cleaner interface for tracking RDMA operation completion.
+ *
+ * The work handle represents a pending RDMA operation and can be used
+ * with wait_local() to synchronize on local completion.
+ */
+struct IbgdaWork {
+  doca_gpu_dev_verbs_ticket_t value{0};
+
+  IbgdaWork() = default;
+
+  __device__ explicit IbgdaWork(doca_gpu_dev_verbs_ticket_t ticket)
+      : value(ticket) {}
+};
+
+/**
+ * P2pIbgdaTransportDevice - Device-side per-peer RDMA transport handle
+ *
+ * Provides GPU-initiated RDMA operations using DOCA GPUNetIO high-level APIs.
+ * Each instance represents a connection to a single peer and contains:
+ * - GPU QP handle for issuing RDMA operations
+ * - Local and remote signal buffer arrays for synchronization
+ *
+ * SIGNAL ID-BASED API:
+ * ====================
+ * All signal operations use a signal_id (integer index) to identify which
+ * signal slot to operate on. This design is consistent with torchcomms
+ * device API and allows multiple independent signal channels per peer.
+ *
+ * Signal buffer layout:
+ * - localSignalBuf_: Base pointer to array of uint64_t signals
+ * - remoteSignalBuf_: Base pointer to peer's signal array
+ * - Each signal_id indexes into these arrays: buf[signal_id]
+ *
+ * EXECUTION SCOPE:
+ * ================
+ * Operations default to thread-level scope where each thread posts its own
+ * RDMA operation.
+ * TODO: For large transfers, consider using warp-level scope where
+ * all threads in a warp collaborate on a single operation.
+ */
+class P2pIbgdaTransportDevice {
+ public:
+  P2pIbgdaTransportDevice() = default;
+
+  /**
+   * Constructor
+   *
+   * @param qp GPU QP handle for RDMA operations
+   * @param localSignalBuf Base pointer to local signal buffer array
+   * @param remoteSignalBuf Base pointer to remote signal buffer array
+   * @param numSignals Number of signal slots in the buffer arrays
+   */
+  __host__ __device__ P2pIbgdaTransportDevice(
+      doca_gpu_dev_verbs_qp* qp,
+      const IbgdaLocalBuffer& localSignalBuf,
+      const IbgdaRemoteBuffer& remoteSignalBuf,
+      int numSignals = 1)
+      : qp_(qp),
+        localSignalBuf_(localSignalBuf),
+        remoteSignalBuf_(remoteSignalBuf),
+        numSignals_(numSignals) {
+    // Sanity check: numSignals must be positive
+    if (numSignals <= 0) {
+#ifdef __CUDA_ARCH__
+      printf(
+          "P2pIbgdaTransportDevice: invalid numSignals (%d), must be > 0\n",
+          numSignals);
+      __trap();
+#endif
+    }
+  }
+
+  /**
+   * put_signal - RDMA Write with atomic signal (adaptive routing safe)
+   *
+   * Performs an RDMA Write from local buffer to remote buffer, waits for
+   * local completion, then sends an atomic fetch-add to the remote signal
+   * buffer at signal_id. This two-phase approach ensures correct ordering
+   * on networks with adaptive routing, where data and signal packets may
+   * take different paths and arrive out of order.
+   *
+   * MEMORY ORDERING:
+   * The wait_local() between put and signal ensures the data write has
+   * been delivered to the remote NIC before the signal is sent, providing
+   * correct "release" semantics even with adaptive routing.
+   *
+   * PERFORMANCE NOTE:
+   * This is slower than put_signal_non_adaptive() due to the synchronization
+   * point. Use put_signal_non_adaptive() for networks with deterministic
+   * routing or when the NIC guarantees ordering between compound operations.
+   *
+   * @param localBuf Source buffer in local GPU memory
+   * @param remoteBuf Destination buffer in remote GPU memory
+   * @param nbytes Number of bytes to transfer
+   * @param signalId Index into the signal buffer array
+   * @param signalVal Value to atomically add to remote signal buffer
+   *
+   * @return IbgdaWork for tracking signal completion via wait_local()
+   */
+  __device__ IbgdaWork put_signal(
+      const IbgdaLocalBuffer& localBuf,
+      const IbgdaRemoteBuffer& remoteBuf,
+      std::size_t nbytes,
+      int signalId,
+      uint64_t signalVal) {
+    checkSignalId(signalId, "put_signal");
+    IbgdaWork putWork = put(localBuf, remoteBuf, nbytes);
+    wait_local(putWork);
+    return signal(signalId, signalVal);
+  }
+
+  /**
+   * put_signal_non_adaptive - RDMA Write with atomic signal as single operation
+   *
+   * Performs an RDMA Write from local buffer to remote buffer, followed by
+   * an atomic fetch-add on the remote signal buffer at signal_id as a single
+   * fused operation. Returns immediately with a ticket for completion tracking.
+   *
+   * WARNING - ADAPTIVE ROUTING:
+   * On networks with adaptive routing, the data and signal may take different
+   * paths and the signal could arrive before the data, causing the receiver
+   * to read stale data. Use put_signal() for networks with adaptive routing.
+   *
+   * MEMORY ORDERING:
+   * Relies on the NIC's internal ordering guarantees for compound operations.
+   * The atomic signal is issued after the data write at the sender NIC, but
+   * arrival order at the receiver depends on network path consistency.
+   *
+   * @param localBuf Source buffer in local GPU memory
+   * @param remoteBuf Destination buffer in remote GPU memory
+   * @param nbytes Number of bytes to transfer
+   * @param signalId Index into the signal buffer array
+   * @param signalVal Value to atomically add to remote signal buffer
+   *
+   * @return IbgdaWork for tracking local completion via wait_local()
+   */
+  __device__ IbgdaWork put_signal_non_adaptive(
+      const IbgdaLocalBuffer& localBuf,
+      const IbgdaRemoteBuffer& remoteBuf,
+      std::size_t nbytes,
+      int signalId,
+      uint64_t signalVal) {
+    checkSignalId(signalId, "put_signal_non_adaptive");
+    doca_gpu_dev_verbs_ticket_t ticket;
+
+    doca_gpu_dev_verbs_addr localAddr = {
+        .addr = reinterpret_cast<uint64_t>(localBuf.ptr),
+        .key = localBuf.lkey.value};
+    doca_gpu_dev_verbs_addr remoteAddr = {
+        .addr = reinterpret_cast<uint64_t>(remoteBuf.ptr),
+        .key = remoteBuf.rkey.value};
+    doca_gpu_dev_verbs_addr localSignalAddr = {
+        .addr = reinterpret_cast<uint64_t>(getLocalSignalPtr(signalId)),
+        .key = localSignalBuf_.lkey.value};
+    doca_gpu_dev_verbs_addr remoteSignalAddr = {
+        .addr = reinterpret_cast<uint64_t>(getRemoteSignalPtr(signalId)),
+        .key = remoteSignalBuf_.rkey.value};
+
+    doca_gpu_dev_verbs_put_signal<
+        DOCA_GPUNETIO_VERBS_SIGNAL_OP_ADD,
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+        DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO,
+        DOCA_GPUNETIO_VERBS_EXEC_SCOPE_THREAD>(
+        qp_,
+        remoteAddr,
+        localAddr,
+        nbytes,
+        remoteSignalAddr,
+        localSignalAddr,
+        signalVal,
+        &ticket);
+
+    return IbgdaWork(ticket);
+  }
+
+  /**
+   * put - RDMA Write without signal (non-blocking)
+   *
+   * Performs an RDMA Write from local buffer to remote buffer.
+   * Returns immediately with a work handle for optional completion tracking.
+   *
+   * @param localBuf Source buffer in local GPU memory
+   * @param remoteBuf Destination buffer in remote GPU memory
+   * @param nbytes Number of bytes to transfer
+   *
+   * @return IbgdaWork for tracking local completion via wait_local()
+   */
+
+  __device__ IbgdaWork
+  put(const IbgdaLocalBuffer& localBuf,
+      const IbgdaRemoteBuffer& remoteBuf,
+      std::size_t nbytes) {
+    doca_gpu_dev_verbs_ticket_t ticket;
+
+    doca_gpu_dev_verbs_addr localAddr = {
+        .addr = reinterpret_cast<uint64_t>(localBuf.ptr),
+        .key = localBuf.lkey.value};
+    doca_gpu_dev_verbs_addr remoteAddr = {
+        .addr = reinterpret_cast<uint64_t>(remoteBuf.ptr),
+        .key = remoteBuf.rkey.value};
+
+    doca_gpu_dev_verbs_put<
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+        DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO,
+        DOCA_GPUNETIO_VERBS_EXEC_SCOPE_THREAD>(
+        qp_, remoteAddr, localAddr, nbytes, &ticket);
+
+    return IbgdaWork(ticket);
+  }
+
+  /**
+   * signal - Send atomic signal only (non-blocking)
+   *
+   * Performs an atomic operation on the remote signal buffer at the
+   * specified signal_id. Useful for pure synchronization.
+   *
+   * @param signalId Index into the signal buffer array
+   * @param signalVal Value to use for the atomic operation
+   * @param op Signal operation type (ADD or SET). Defaults to ADD.
+   *           Note: SET is not yet supported by DOCA GPUNetIO.
+   *
+   * @return IbgdaWork for tracking local completion via wait_local()
+   */
+  __device__ IbgdaWork signal(
+      int signalId,
+      uint64_t signalVal,
+      IbgdaSignalOp op = IbgdaSignalOp::ADD) {
+    checkSignalId(signalId, "signal");
+    // Only ADD is supported by DOCA GPUNetIO currently.
+    // Trap if caller passes SET (or any future unsupported operation).
+    if (op != IbgdaSignalOp::ADD) {
+      printf(
+          "P2pIbgdaTransportDevice::signal: unsupported IbgdaSignalOp (%d), only ADD is supported\n",
+          static_cast<int>(op));
+      __trap();
+    }
+
+    doca_gpu_dev_verbs_ticket_t ticket;
+
+    doca_gpu_dev_verbs_addr localSignalAddr = {
+        .addr = reinterpret_cast<uint64_t>(getLocalSignalPtr(signalId)),
+        .key = localSignalBuf_.lkey.value};
+    doca_gpu_dev_verbs_addr remoteSignalAddr = {
+        .addr = reinterpret_cast<uint64_t>(getRemoteSignalPtr(signalId)),
+        .key = remoteSignalBuf_.rkey.value};
+
+    doca_gpu_dev_verbs_signal<
+        DOCA_GPUNETIO_VERBS_SIGNAL_OP_ADD,
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+        DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(
+        qp_, remoteSignalAddr, localSignalAddr, signalVal, &ticket);
+
+    return IbgdaWork(ticket);
+  }
+
+  /**
+   * wait_local - Wait for local completion of an RDMA operation
+   *
+   * Blocks until the RDMA operation identified by the work handle has completed
+   * locally. This means the data has been handed off to the remote NIC, but
+   * does NOT guarantee arrival at the remote HBM.
+   *
+   * For remote completion guarantee, use wait_signal() on the receiver side.
+   *
+   * @param work Work handle returned from put_signal(), put(), or signal()
+   */
+  __device__ void wait_local(const IbgdaWork& work) {
+    doca_gpu_dev_verbs_wait<
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+        DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(qp_, work.value);
+  }
+
+  /**
+   * wait_signal - Wait for remote signal arrival
+   *
+   * Spin-waits on the local signal buffer at signal_id until the comparison
+   * condition is satisfied. This provides "acquire" semantics - once the
+   * signal is seen, all prior remote writes are visible.
+   *
+   * @param signalId Index into the signal buffer array
+   * @param cmp Comparison operation to use
+   * @param value Value to compare against
+   */
+  __device__ void wait_signal(int signalId, IbgdaCmpOp cmp, uint64_t value) {
+    checkSignalId(signalId, "wait_signal");
+    volatile uint64_t* sig =
+        reinterpret_cast<volatile uint64_t*>(getLocalSignalPtr(signalId));
+
+    switch (cmp) {
+      case IbgdaCmpOp::EQ:
+        while (*sig != value) {
+        }
+        break;
+      case IbgdaCmpOp::NE:
+        while (*sig == value) {
+        }
+        break;
+      case IbgdaCmpOp::LT:
+        while (*sig >= value) {
+        }
+        break;
+      case IbgdaCmpOp::LE:
+        while (*sig > value) {
+        }
+        break;
+      case IbgdaCmpOp::GT:
+        while (*sig <= value) {
+        }
+        break;
+      case IbgdaCmpOp::GE:
+        while (*sig < value) {
+        }
+        break;
+    }
+    __threadfence_system();
+  }
+
+  /**
+   * read_signal - Read current signal value
+   *
+   * Non-blocking read of the local signal buffer value at signal_id.
+   *
+   * @param signalId Index into the signal buffer array
+   * @return Current signal value
+   */
+  __device__ uint64_t read_signal(int signalId) const {
+    checkSignalId(signalId, "read_signal");
+    volatile uint64_t* sig =
+        reinterpret_cast<volatile uint64_t*>(getLocalSignalPtr(signalId));
+    return *sig;
+  }
+
+  /**
+   * reset_signal - Reset remote peer's signal buffer to zero
+   *
+   * Performs an RDMA write to reset the remote signal at signal_id to zero.
+   * This is a sender-side operation - only the sender should reset the signal
+   * after the receiver has consumed the data.
+   *
+   * ORDERING GUARANTEES:
+   * This function inserts fences before and after the reset to ensure correct
+   * ordering with other RDMA operations:
+   * - Pre-fence: Ensures all prior operations (e.g., put_signal) are processed
+   *   by the NIC before the reset is issued
+   * - Post-fence: Ensures the reset completes before any subsequent operations
+   *
+   * This prevents packet reordering issues where a reset could overtake prior
+   * operations on the network and arrive at the remote peer first.
+   *
+   * Typical flow:
+   * 1. Sender: put_signal() - write data and signal receiver
+   * 2. Receiver: wait_signal() - wait for signal and read data
+   * 3. Sender: reset_signal() - reset for next iteration (fenced)
+   *
+   * @param signalId Index into the signal buffer array
+   */
+  __device__ void reset_signal(int signalId) {
+    checkSignalId(signalId, "reset_signal");
+
+    // Fence before reset: ensure all prior operations are processed by NIC
+    fence();
+
+    // Prepare local signal value to write (0)
+    volatile uint64_t* localSig =
+        reinterpret_cast<volatile uint64_t*>(getLocalSignalPtr(signalId));
+    *localSig = 0;
+    __threadfence_system();
+
+    // Issue the reset RDMA write
+    doca_gpu_dev_verbs_ticket_t ticket;
+
+    doca_gpu_dev_verbs_addr localSignalAddr = {
+        .addr = reinterpret_cast<uint64_t>(getLocalSignalPtr(signalId)),
+        .key = localSignalBuf_.lkey.value};
+    doca_gpu_dev_verbs_addr remoteSignalAddr = {
+        .addr = reinterpret_cast<uint64_t>(getRemoteSignalPtr(signalId)),
+        .key = remoteSignalBuf_.rkey.value};
+
+    doca_gpu_dev_verbs_put<
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+        DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO,
+        DOCA_GPUNETIO_VERBS_EXEC_SCOPE_THREAD>(
+        qp_, remoteSignalAddr, localSignalAddr, sizeof(uint64_t), &ticket);
+
+    // Wait for reset to complete locally
+    doca_gpu_dev_verbs_wait<
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+        DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(qp_, ticket);
+
+    // Fence after reset: ensure reset is processed before subsequent operations
+    fence();
+  }
+
+  /**
+   * fence - Wait for all pending RDMA operations to complete at the NIC
+   *
+   * Issues a NOP WQE and waits for it to complete. Since WQEs are processed
+   * in order by the NIC, when the NOP completes, all prior WQEs have been
+   * processed. This is useful before reset_signal to ensure prior operations
+   * have been sent to the remote peer before the reset.
+   *
+   * Note: This only ensures local NIC completion, not remote arrival.
+   * For remote completion guarantees, use signal-based synchronization.
+   */
+  __device__ void fence() {
+    doca_fence<
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+        DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(qp_);
+  }
+
+  // Getters for buffer info (useful for advanced operations)
+  __host__ __device__ const IbgdaLocalBuffer& getLocalSignalBuffer() const {
+    return localSignalBuf_;
+  }
+
+  __host__ __device__ const IbgdaRemoteBuffer& getRemoteSignalBuffer() const {
+    return remoteSignalBuf_;
+  }
+
+  __host__ __device__ doca_gpu_dev_verbs_qp* getQp() const {
+    return qp_;
+  }
+
+  __host__ __device__ int getNumSignals() const {
+    return numSignals_;
+  }
+
+ private:
+  /**
+   * Check signalId bounds and trap if out of range.
+   * Only active in device code for better debuggability.
+   */
+  __device__ void checkSignalId(int signalId, const char* funcName) const {
+    if (signalId < 0 || signalId >= numSignals_) {
+      printf(
+          "P2pIbgdaTransportDevice::%s: signalId (%d) out of range [0, %d)\n",
+          funcName,
+          signalId,
+          numSignals_);
+      __trap();
+    }
+  }
+
+  /**
+   * Get pointer to local signal at index
+   */
+  __host__ __device__ __forceinline__ void* getLocalSignalPtr(
+      int signalId) const {
+    return static_cast<uint64_t*>(localSignalBuf_.ptr) + signalId;
+  }
+
+  /**
+   * Get pointer to remote signal at index
+   */
+  __host__ __device__ __forceinline__ void* getRemoteSignalPtr(
+      int signalId) const {
+    return static_cast<uint64_t*>(remoteSignalBuf_.ptr) + signalId;
+  }
+
+  doca_gpu_dev_verbs_qp* qp_{nullptr};
+  IbgdaLocalBuffer localSignalBuf_;
+  IbgdaRemoteBuffer remoteSignalBuf_;
+  int numSignals_{1};
+};
+
+} // namespace comms::pipes

--- a/comms/pipes/tests/IbgdaBufferTest.cc
+++ b/comms/pipes/tests/IbgdaBufferTest.cc
@@ -1,0 +1,80 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include <endian.h>
+
+#include "comms/pipes/IbgdaBuffer.h"
+
+namespace comms::pipes::tests {
+
+// =============================================================================
+// Key Conversion Tests
+// =============================================================================
+
+TEST(IbgdaBufferTest, KeyImplicitConversion) {
+  // Test implicit conversion from HostLKey to NetworkLKey
+  HostLKey hostLKey(0x12345678);
+  NetworkLKey networkLKey = hostLKey; // Implicit conversion
+  EXPECT_EQ(networkLKey.value, htobe32(0x12345678));
+  EXPECT_EQ(be32toh(networkLKey.value), hostLKey.value);
+
+  // Test implicit conversion from HostRKey to NetworkRKey
+  HostRKey hostRKey(0xABCDEF01);
+  NetworkRKey networkRKey = hostRKey; // Implicit conversion
+  EXPECT_EQ(networkRKey.value, htobe32(0xABCDEF01));
+  EXPECT_EQ(be32toh(networkRKey.value), hostRKey.value);
+}
+
+TEST(IbgdaBufferTest, KeyImplicitConversionInBufferConstructor) {
+  // Test that implicit conversion works when constructing buffer descriptors
+  char data[64];
+  HostLKey hostLKey(0x1234);
+  HostRKey hostRKey(0x5678);
+
+  // IbgdaLocalBuffer should accept HostLKey via implicit conversion
+  IbgdaLocalBuffer localBuf(data, hostLKey);
+  EXPECT_EQ(localBuf.ptr, data);
+  EXPECT_EQ(localBuf.lkey.value, htobe32(0x1234));
+
+  // IbgdaRemoteBuffer should accept HostRKey via implicit conversion
+  IbgdaRemoteBuffer remoteBuf(data, hostRKey);
+  EXPECT_EQ(remoteBuf.ptr, data);
+  EXPECT_EQ(remoteBuf.rkey.value, htobe32(0x5678));
+}
+
+// =============================================================================
+// Buffer Tests
+// =============================================================================
+
+TEST(IbgdaBufferTest, LocalBufferOperations) {
+  char data[64];
+  NetworkLKey lkey(0x1234);
+
+  // Construction
+  IbgdaLocalBuffer buf(data, lkey);
+  EXPECT_EQ(buf.ptr, data);
+  EXPECT_EQ(buf.lkey, lkey);
+
+  // SubBuffer with offset
+  auto sub = buf.subBuffer(16);
+  EXPECT_EQ(sub.ptr, data + 16);
+  EXPECT_EQ(sub.lkey, lkey);
+}
+
+TEST(IbgdaBufferTest, RemoteBufferOperations) {
+  char data[64];
+  NetworkRKey rkey(0x5678);
+
+  // Construction
+  IbgdaRemoteBuffer buf(data, rkey);
+  EXPECT_EQ(buf.ptr, data);
+  EXPECT_EQ(buf.rkey, rkey);
+
+  // SubBuffer with offset
+  auto sub = buf.subBuffer(32);
+  EXPECT_EQ(sub.ptr, data + 32);
+  EXPECT_EQ(sub.rkey, rkey);
+}
+
+} // namespace comms::pipes::tests

--- a/comms/pipes/tests/P2pIbgdaTransportDeviceTest.cu
+++ b/comms/pipes/tests/P2pIbgdaTransportDeviceTest.cu
@@ -1,0 +1,405 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/IbgdaBuffer.h"
+#include "comms/pipes/P2pIbgdaTransportDevice.cuh"
+#include "comms/pipes/tests/P2pIbgdaTransportDeviceTest.cuh"
+
+namespace comms::pipes::tests {
+
+// =============================================================================
+// Device-side test kernels
+// =============================================================================
+
+__global__ void testP2pTransportConstruction(
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    bool* success) {
+  // Create transport on device with the given buffers (no real QP)
+  P2pIbgdaTransportDevice transport(nullptr, localBuf, remoteBuf);
+
+  *success = true;
+
+  // Verify buffer accessors work
+  auto localSig = transport.getLocalSignalBuffer();
+  auto remoteSig = transport.getRemoteSignalBuffer();
+
+  if (localSig.ptr != localBuf.ptr || localSig.lkey != localBuf.lkey) {
+    *success = false;
+  }
+  if (remoteSig.ptr != remoteBuf.ptr || remoteSig.rkey != remoteBuf.rkey) {
+    *success = false;
+  }
+
+  // QP should be null in this test (no real DOCA setup)
+  if (transport.getQp() != nullptr) {
+    *success = false;
+  }
+}
+
+__global__ void testP2pTransportDefaultConstruction(bool* success) {
+  // Default construction should initialize all members
+  P2pIbgdaTransportDevice transport;
+
+  *success = true;
+
+  // QP should be null
+  if (transport.getQp() != nullptr) {
+    *success = false;
+  }
+
+  // Local signal buffer should have null ptr
+  auto localSig = transport.getLocalSignalBuffer();
+  if (localSig.ptr != nullptr) {
+    *success = false;
+  }
+
+  // Remote signal buffer should have null ptr
+  auto remoteSig = transport.getRemoteSignalBuffer();
+  if (remoteSig.ptr != nullptr) {
+    *success = false;
+  }
+
+  // Default numSignals should be 1
+  if (transport.getNumSignals() != 1) {
+    *success = false;
+  }
+}
+
+__global__ void testP2pTransportNumSignals(
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    int numSignals,
+    bool* success) {
+  P2pIbgdaTransportDevice transport(nullptr, localBuf, remoteBuf, numSignals);
+
+  *success = (transport.getNumSignals() == numSignals);
+}
+
+__global__ void testP2pTransportSignalPointerArithmetic(
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    int numSignals,
+    bool* success) {
+  P2pIbgdaTransportDevice transport(nullptr, localBuf, remoteBuf, numSignals);
+
+  *success = true;
+
+  // The transport stores base pointers and calculates signal[i] as base + i
+  // We can verify this by checking the buffer accessors still point to base
+  auto localSig = transport.getLocalSignalBuffer();
+  auto remoteSig = transport.getRemoteSignalBuffer();
+
+  // Base pointers should match what we passed in
+  if (localSig.ptr != localBuf.ptr) {
+    *success = false;
+  }
+  if (remoteSig.ptr != remoteBuf.ptr) {
+    *success = false;
+  }
+
+  // Keys should be preserved
+  if (localSig.lkey != localBuf.lkey) {
+    *success = false;
+  }
+  if (remoteSig.rkey != remoteBuf.rkey) {
+    *success = false;
+  }
+}
+
+__global__ void testP2pTransportReadSignal(
+    uint64_t* d_signalBuf,
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    int numSignals,
+    bool* success) {
+  // The localBuf should point to d_signalBuf which is pre-initialized with
+  // known values: d_signalBuf[i] = (i + 1) * 100
+  P2pIbgdaTransportDevice transport(nullptr, localBuf, remoteBuf, numSignals);
+
+  *success = true;
+
+  // Test read_signal for each slot
+  for (int i = 0; i < numSignals; ++i) {
+    uint64_t expected = static_cast<uint64_t>(i + 1) * 100;
+    uint64_t actual = transport.read_signal(i);
+    if (actual != expected) {
+      *success = false;
+    }
+  }
+}
+
+__global__ void testIbgdaWork(bool* success) {
+  *success = true;
+
+  // Test default construction
+  IbgdaWork defaultWork;
+  if (defaultWork.value != 0) {
+    *success = false;
+  }
+
+  // Test explicit construction with a value
+  doca_gpu_dev_verbs_ticket_t testTicket = 12345;
+  IbgdaWork workWithValue(testTicket);
+  if (workWithValue.value != testTicket) {
+    *success = false;
+  }
+
+  // Test copy
+  IbgdaWork copiedWork = workWithValue;
+  if (copiedWork.value != testTicket) {
+    *success = false;
+  }
+}
+
+// =============================================================================
+// wait_signal test kernels
+// =============================================================================
+
+__global__ void testWaitSignalEQ(
+    uint64_t* d_signalBuf,
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    uint64_t targetValue,
+    bool* success) {
+  P2pIbgdaTransportDevice transport(nullptr, localBuf, remoteBuf, 1);
+
+  // Signal buffer is pre-set to targetValue by host
+  // wait_signal with EQ should return immediately
+  transport.wait_signal(0, IbgdaCmpOp::EQ, targetValue);
+
+  // If we get here, the wait completed successfully
+  *success = true;
+}
+
+__global__ void testWaitSignalNE(
+    uint64_t* d_signalBuf,
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    uint64_t signalValue,
+    uint64_t targetValue,
+    bool* success) {
+  P2pIbgdaTransportDevice transport(nullptr, localBuf, remoteBuf, 1);
+
+  // Signal buffer is pre-set to signalValue (which != targetValue)
+  // wait_signal with NE should return immediately
+  transport.wait_signal(0, IbgdaCmpOp::NE, targetValue);
+
+  // If we get here, the wait completed successfully
+  *success = true;
+}
+
+__global__ void testWaitSignalGE(
+    uint64_t* d_signalBuf,
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    uint64_t signalValue,
+    uint64_t targetValue,
+    bool* success) {
+  P2pIbgdaTransportDevice transport(nullptr, localBuf, remoteBuf, 1);
+
+  // Signal buffer is pre-set to signalValue (which >= targetValue)
+  // wait_signal with GE should return immediately
+  transport.wait_signal(0, IbgdaCmpOp::GE, targetValue);
+
+  // If we get here, the wait completed successfully
+  *success = true;
+}
+
+__global__ void testWaitSignalGT(
+    uint64_t* d_signalBuf,
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    uint64_t signalValue,
+    uint64_t targetValue,
+    bool* success) {
+  P2pIbgdaTransportDevice transport(nullptr, localBuf, remoteBuf, 1);
+
+  // Signal buffer is pre-set to signalValue (which > targetValue)
+  // wait_signal with GT should return immediately
+  transport.wait_signal(0, IbgdaCmpOp::GT, targetValue);
+
+  // If we get here, the wait completed successfully
+  *success = true;
+}
+
+__global__ void testWaitSignalLE(
+    uint64_t* d_signalBuf,
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    uint64_t signalValue,
+    uint64_t targetValue,
+    bool* success) {
+  P2pIbgdaTransportDevice transport(nullptr, localBuf, remoteBuf, 1);
+
+  // Signal buffer is pre-set to signalValue (which <= targetValue)
+  // wait_signal with LE should return immediately
+  transport.wait_signal(0, IbgdaCmpOp::LE, targetValue);
+
+  // If we get here, the wait completed successfully
+  *success = true;
+}
+
+__global__ void testWaitSignalLT(
+    uint64_t* d_signalBuf,
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    uint64_t signalValue,
+    uint64_t targetValue,
+    bool* success) {
+  P2pIbgdaTransportDevice transport(nullptr, localBuf, remoteBuf, 1);
+
+  // Signal buffer is pre-set to signalValue (which < targetValue)
+  // wait_signal with LT should return immediately
+  transport.wait_signal(0, IbgdaCmpOp::LT, targetValue);
+
+  // If we get here, the wait completed successfully
+  *success = true;
+}
+
+__global__ void testWaitSignalMultipleSlots(
+    uint64_t* d_signalBuf,
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    int numSignals,
+    bool* success) {
+  P2pIbgdaTransportDevice transport(nullptr, localBuf, remoteBuf, numSignals);
+
+  *success = true;
+
+  // Signal buffer is pre-set: slot[i] = (i + 1) * 100
+  // Test wait_signal on each slot with matching EQ condition
+  for (int i = 0; i < numSignals; ++i) {
+    uint64_t expectedValue = static_cast<uint64_t>(i + 1) * 100;
+    transport.wait_signal(i, IbgdaCmpOp::EQ, expectedValue);
+
+    // Verify read_signal returns the same value
+    uint64_t readValue = transport.read_signal(i);
+    if (readValue != expectedValue) {
+      *success = false;
+    }
+  }
+}
+
+// =============================================================================
+// Wrapper functions to launch the kernels (called from .cc test file)
+// =============================================================================
+
+void runTestP2pTransportConstruction(
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    bool* d_success) {
+  testP2pTransportConstruction<<<1, 1>>>(localBuf, remoteBuf, d_success);
+}
+
+void runTestP2pTransportDefaultConstruction(bool* d_success) {
+  testP2pTransportDefaultConstruction<<<1, 1>>>(d_success);
+}
+
+void runTestP2pTransportNumSignals(
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    int numSignals,
+    bool* d_success) {
+  testP2pTransportNumSignals<<<1, 1>>>(
+      localBuf, remoteBuf, numSignals, d_success);
+}
+
+void runTestP2pTransportSignalPointerArithmetic(
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    int numSignals,
+    bool* d_success) {
+  testP2pTransportSignalPointerArithmetic<<<1, 1>>>(
+      localBuf, remoteBuf, numSignals, d_success);
+}
+
+void runTestP2pTransportReadSignal(
+    uint64_t* d_signalBuf,
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    int numSignals,
+    bool* d_success) {
+  testP2pTransportReadSignal<<<1, 1>>>(
+      d_signalBuf, localBuf, remoteBuf, numSignals, d_success);
+}
+
+void runTestIbgdaWork(bool* d_success) {
+  testIbgdaWork<<<1, 1>>>(d_success);
+}
+
+void runTestWaitSignalEQ(
+    uint64_t* d_signalBuf,
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    uint64_t targetValue,
+    bool* d_success) {
+  testWaitSignalEQ<<<1, 1>>>(
+      d_signalBuf, localBuf, remoteBuf, targetValue, d_success);
+}
+
+void runTestWaitSignalNE(
+    uint64_t* d_signalBuf,
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    uint64_t signalValue,
+    uint64_t targetValue,
+    bool* d_success) {
+  testWaitSignalNE<<<1, 1>>>(
+      d_signalBuf, localBuf, remoteBuf, signalValue, targetValue, d_success);
+}
+
+void runTestWaitSignalGE(
+    uint64_t* d_signalBuf,
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    uint64_t signalValue,
+    uint64_t targetValue,
+    bool* d_success) {
+  testWaitSignalGE<<<1, 1>>>(
+      d_signalBuf, localBuf, remoteBuf, signalValue, targetValue, d_success);
+}
+
+void runTestWaitSignalGT(
+    uint64_t* d_signalBuf,
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    uint64_t signalValue,
+    uint64_t targetValue,
+    bool* d_success) {
+  testWaitSignalGT<<<1, 1>>>(
+      d_signalBuf, localBuf, remoteBuf, signalValue, targetValue, d_success);
+}
+
+void runTestWaitSignalLE(
+    uint64_t* d_signalBuf,
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    uint64_t signalValue,
+    uint64_t targetValue,
+    bool* d_success) {
+  testWaitSignalLE<<<1, 1>>>(
+      d_signalBuf, localBuf, remoteBuf, signalValue, targetValue, d_success);
+}
+
+void runTestWaitSignalLT(
+    uint64_t* d_signalBuf,
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    uint64_t signalValue,
+    uint64_t targetValue,
+    bool* d_success) {
+  testWaitSignalLT<<<1, 1>>>(
+      d_signalBuf, localBuf, remoteBuf, signalValue, targetValue, d_success);
+}
+
+void runTestWaitSignalMultipleSlots(
+    uint64_t* d_signalBuf,
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    int numSignals,
+    bool* d_success) {
+  testWaitSignalMultipleSlots<<<1, 1>>>(
+      d_signalBuf, localBuf, remoteBuf, numSignals, d_success);
+}
+
+} // namespace comms::pipes::tests

--- a/comms/pipes/tests/P2pIbgdaTransportDeviceTest.cuh
+++ b/comms/pipes/tests/P2pIbgdaTransportDeviceTest.cuh
@@ -1,0 +1,125 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+
+#include "comms/pipes/IbgdaBuffer.h"
+
+namespace comms::pipes::tests {
+
+// Wrapper function to launch test kernel (defined in .cu, called from .cc)
+// This function creates a P2pIbgdaTransportDevice on the device with the given
+// buffers and verifies its accessors work correctly.
+void runTestP2pTransportConstruction(
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    bool* d_success);
+
+// Test default construction - all members should be initialized to null/zero
+void runTestP2pTransportDefaultConstruction(bool* d_success);
+
+// Test getNumSignals accessor with various values
+void runTestP2pTransportNumSignals(
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    int numSignals,
+    bool* d_success);
+
+// Test signal pointer arithmetic - verify correct offsets for multi-signal
+// setup This tests the internal getLocalSignalPtr/getRemoteSignalPtr logic by
+// checking buffer accessors return pointers at expected offsets.
+void runTestP2pTransportSignalPointerArithmetic(
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    int numSignals,
+    bool* d_success);
+
+// Test read_signal returns the value at the correct signal slot.
+// This writes known values to the signal buffer and verifies read_signal
+// returns the correct value for each slot.
+void runTestP2pTransportReadSignal(
+    uint64_t* d_signalBuf,
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    int numSignals,
+    bool* d_success);
+
+// Test IbgdaWork struct construction and value access
+void runTestIbgdaWork(bool* d_success);
+
+// =============================================================================
+// wait_signal tests - Test each comparison operation
+// These tests pre-set the signal buffer to a value that satisfies the condition
+// so wait_signal returns immediately without blocking.
+// =============================================================================
+
+// Test wait_signal with EQ (equal) comparison
+// Pre-sets signal to targetValue, waits for EQ targetValue
+void runTestWaitSignalEQ(
+    uint64_t* d_signalBuf,
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    uint64_t targetValue,
+    bool* d_success);
+
+// Test wait_signal with NE (not equal) comparison
+// Pre-sets signal to a value != targetValue, waits for NE targetValue
+void runTestWaitSignalNE(
+    uint64_t* d_signalBuf,
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    uint64_t signalValue,
+    uint64_t targetValue,
+    bool* d_success);
+
+// Test wait_signal with GE (greater or equal) comparison
+// Pre-sets signal to a value >= targetValue, waits for GE targetValue
+void runTestWaitSignalGE(
+    uint64_t* d_signalBuf,
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    uint64_t signalValue,
+    uint64_t targetValue,
+    bool* d_success);
+
+// Test wait_signal with GT (greater than) comparison
+// Pre-sets signal to a value > targetValue, waits for GT targetValue
+void runTestWaitSignalGT(
+    uint64_t* d_signalBuf,
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    uint64_t signalValue,
+    uint64_t targetValue,
+    bool* d_success);
+
+// Test wait_signal with LE (less or equal) comparison
+// Pre-sets signal to a value <= targetValue, waits for LE targetValue
+void runTestWaitSignalLE(
+    uint64_t* d_signalBuf,
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    uint64_t signalValue,
+    uint64_t targetValue,
+    bool* d_success);
+
+// Test wait_signal with LT (less than) comparison
+// Pre-sets signal to a value < targetValue, waits for LT targetValue
+void runTestWaitSignalLT(
+    uint64_t* d_signalBuf,
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    uint64_t signalValue,
+    uint64_t targetValue,
+    bool* d_success);
+
+// Test wait_signal with multiple signal slots
+// Verifies that wait_signal operates on the correct slot
+void runTestWaitSignalMultipleSlots(
+    uint64_t* d_signalBuf,
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    int numSignals,
+    bool* d_success);
+
+} // namespace comms::pipes::tests

--- a/comms/pipes/tests/P2pIbgdaTransportDeviceTestMain.cc
+++ b/comms/pipes/tests/P2pIbgdaTransportDeviceTestMain.cc
@@ -1,0 +1,444 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// Tests for P2pIbgdaTransportDevice
+// Note: P2pIbgdaTransportDevice.cuh includes DOCA GPUNetIO headers with
+// __device__ annotations that cannot be compiled by a regular C++ compiler.
+// Device-side tests are implemented in P2pIbgdaTransportDeviceTest.cu and
+// launched via kernel wrapper functions.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <functional>
+#include <vector>
+
+#include "comms/pipes/IbgdaBuffer.h"
+#include "comms/pipes/tests/P2pIbgdaTransportDeviceTest.cuh"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/CudaRAII.h"
+
+using namespace meta::comms;
+
+namespace comms::pipes::tests {
+
+// =============================================================================
+// Test Fixture
+// =============================================================================
+
+class P2pIbgdaTransportDeviceTestFixture : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    CUDACHECK_TEST(cudaSetDevice(0));
+  }
+
+  // Helper to run a device-side test and check result
+  void runAndVerify(const std::function<void(bool*)>& runKernel) {
+    DeviceBuffer successBuf(sizeof(bool));
+    auto* d_success = static_cast<bool*>(successBuf.get());
+
+    bool initSuccess = false;
+    CUDACHECK_TEST(cudaMemcpy(
+        d_success, &initSuccess, sizeof(bool), cudaMemcpyHostToDevice));
+
+    runKernel(d_success);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    bool success = false;
+    CUDACHECK_TEST(
+        cudaMemcpy(&success, d_success, sizeof(bool), cudaMemcpyDeviceToHost));
+
+    EXPECT_TRUE(success);
+  }
+};
+
+// =============================================================================
+// P2pIbgdaTransportDevice Device-side Tests
+// These tests verify that the transport can be constructed and accessed on GPU.
+// The actual P2pIbgdaTransportDevice type cannot be used here because its
+// header includes DOCA GPUNetIO headers with __device__ annotations.
+// =============================================================================
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, DeviceConstruction) {
+  // Test that transport can be copied to device and accessed there
+
+  // Create mock buffers for signal data
+  char localSignalData[64];
+  char remoteSignalData[64];
+  IbgdaLocalBuffer localBuf(localSignalData, NetworkLKey(0xAAAA));
+  IbgdaRemoteBuffer remoteBuf(remoteSignalData, NetworkRKey(0xBBBB));
+
+  runAndVerify([&](bool* d_success) {
+    runTestP2pTransportConstruction(localBuf, remoteBuf, d_success);
+  });
+}
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, DefaultConstruction) {
+  // Test that default-constructed transport has null values
+  runAndVerify([](bool* d_success) {
+    runTestP2pTransportDefaultConstruction(d_success);
+  });
+}
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, NumSignalsDefault) {
+  // Test default numSignals (should be 1)
+  char localSignalData[64];
+  char remoteSignalData[64];
+  IbgdaLocalBuffer localBuf(localSignalData, NetworkLKey(0x1111));
+  IbgdaRemoteBuffer remoteBuf(remoteSignalData, NetworkRKey(0x2222));
+
+  // When numSignals is not specified, default is 1
+  DeviceBuffer successBuf(sizeof(bool));
+  auto* d_success = static_cast<bool*>(successBuf.get());
+
+  bool initSuccess = false;
+  CUDACHECK_TEST(cudaMemcpy(
+      d_success, &initSuccess, sizeof(bool), cudaMemcpyHostToDevice));
+
+  // numSignals = 1 (default)
+  runTestP2pTransportNumSignals(localBuf, remoteBuf, 1, d_success);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  bool success = false;
+  CUDACHECK_TEST(
+      cudaMemcpy(&success, d_success, sizeof(bool), cudaMemcpyDeviceToHost));
+  EXPECT_TRUE(success) << "Default numSignals should be 1";
+}
+
+// Parameterized test for different numSignals values
+class NumSignalsTestFixture : public P2pIbgdaTransportDeviceTestFixture,
+                              public ::testing::WithParamInterface<int> {};
+
+TEST_P(NumSignalsTestFixture, NumSignalsAccessor) {
+  int numSignals = GetParam();
+
+  char localSignalData[512]; // Enough for multiple signals
+  char remoteSignalData[512];
+  IbgdaLocalBuffer localBuf(localSignalData, NetworkLKey(0x1111));
+  IbgdaRemoteBuffer remoteBuf(remoteSignalData, NetworkRKey(0x2222));
+
+  runAndVerify([&](bool* d_success) {
+    runTestP2pTransportNumSignals(localBuf, remoteBuf, numSignals, d_success);
+  });
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    NumSignalsVariations,
+    NumSignalsTestFixture,
+    ::testing::Values(1, 2, 4, 8, 16, 32));
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, SignalPointerArithmetic) {
+  // Test that signal pointer arithmetic works correctly for multi-signal setup
+  const int numSignals = 4;
+  char localSignalData[numSignals * sizeof(uint64_t)];
+  char remoteSignalData[numSignals * sizeof(uint64_t)];
+  IbgdaLocalBuffer localBuf(localSignalData, NetworkLKey(0x3333));
+  IbgdaRemoteBuffer remoteBuf(remoteSignalData, NetworkRKey(0x4444));
+
+  runAndVerify([&](bool* d_success) {
+    runTestP2pTransportSignalPointerArithmetic(
+        localBuf, remoteBuf, numSignals, d_success);
+  });
+}
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, ReadSignal) {
+  // Test that read_signal returns correct values for each signal slot
+  const int numSignals = 4;
+
+  // Allocate device memory for signal buffer
+  DeviceBuffer signalBuf(numSignals * sizeof(uint64_t));
+  auto* d_signalBuf = static_cast<uint64_t*>(signalBuf.get());
+
+  // Initialize signal buffer with known values: slot[i] = (i+1) * 100
+  std::vector<uint64_t> h_signals(numSignals);
+  for (int i = 0; i < numSignals; ++i) {
+    h_signals[i] = static_cast<uint64_t>(i + 1) * 100;
+  }
+  CUDACHECK_TEST(cudaMemcpy(
+      d_signalBuf,
+      h_signals.data(),
+      numSignals * sizeof(uint64_t),
+      cudaMemcpyHostToDevice));
+
+  // Create buffers pointing to device memory
+  IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKey(0x5555));
+  IbgdaRemoteBuffer remoteBuf(d_signalBuf, NetworkRKey(0x6666));
+
+  runAndVerify([&](bool* d_success) {
+    runTestP2pTransportReadSignal(
+        d_signalBuf, localBuf, remoteBuf, numSignals, d_success);
+  });
+}
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, IbgdaWorkConstruction) {
+  // Test IbgdaWork struct construction and value access
+  runAndVerify([](bool* d_success) { runTestIbgdaWork(d_success); });
+}
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, BufferSubBufferWithTransport) {
+  // Test that sub-buffers work correctly with transport construction
+  const size_t offset = 32;
+  char localSignalData[128];
+  char remoteSignalData[128];
+
+  // Create base buffers
+  IbgdaLocalBuffer baseLBuf(localSignalData, NetworkLKey(0x7777));
+  IbgdaRemoteBuffer baseRBuf(remoteSignalData, NetworkRKey(0x8888));
+
+  // Create sub-buffers at offset
+  IbgdaLocalBuffer subLBuf = baseLBuf.subBuffer(offset);
+  IbgdaRemoteBuffer subRBuf = baseRBuf.subBuffer(offset);
+
+  // Verify sub-buffer pointers
+  EXPECT_EQ(subLBuf.ptr, localSignalData + offset);
+  EXPECT_EQ(subRBuf.ptr, remoteSignalData + offset);
+
+  // Verify keys are preserved
+  EXPECT_EQ(subLBuf.lkey, baseLBuf.lkey);
+  EXPECT_EQ(subRBuf.rkey, baseRBuf.rkey);
+
+  // Test transport construction with sub-buffers
+  runAndVerify([&](bool* d_success) {
+    runTestP2pTransportConstruction(subLBuf, subRBuf, d_success);
+  });
+}
+
+// =============================================================================
+// wait_signal Tests
+// These tests verify the spin-wait logic for each comparison operation.
+// Signal buffers are pre-set to values that satisfy the condition so
+// wait_signal returns immediately without blocking.
+// =============================================================================
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalEQ) {
+  // Test wait_signal with EQ comparison
+  const uint64_t targetValue = 42;
+
+  // Allocate device memory for signal buffer
+  DeviceBuffer signalBuf(sizeof(uint64_t));
+  auto* d_signalBuf = static_cast<uint64_t*>(signalBuf.get());
+
+  // Pre-set signal to targetValue so EQ condition is satisfied
+  CUDACHECK_TEST(cudaMemcpy(
+      d_signalBuf, &targetValue, sizeof(uint64_t), cudaMemcpyHostToDevice));
+
+  IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKey(0x1111));
+  IbgdaRemoteBuffer remoteBuf(d_signalBuf, NetworkRKey(0x2222));
+
+  runAndVerify([&](bool* d_success) {
+    runTestWaitSignalEQ(
+        d_signalBuf, localBuf, remoteBuf, targetValue, d_success);
+  });
+}
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalNE) {
+  // Test wait_signal with NE comparison
+  const uint64_t signalValue = 100;
+  const uint64_t targetValue = 42; // Different from signalValue
+
+  DeviceBuffer signalBuf(sizeof(uint64_t));
+  auto* d_signalBuf = static_cast<uint64_t*>(signalBuf.get());
+
+  // Pre-set signal to signalValue (which != targetValue) so NE is satisfied
+  CUDACHECK_TEST(cudaMemcpy(
+      d_signalBuf, &signalValue, sizeof(uint64_t), cudaMemcpyHostToDevice));
+
+  IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKey(0x1111));
+  IbgdaRemoteBuffer remoteBuf(d_signalBuf, NetworkRKey(0x2222));
+
+  runAndVerify([&](bool* d_success) {
+    runTestWaitSignalNE(
+        d_signalBuf, localBuf, remoteBuf, signalValue, targetValue, d_success);
+  });
+}
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalGE_Equal) {
+  // Test wait_signal with GE comparison when signal == target
+  const uint64_t signalValue = 50;
+  const uint64_t targetValue = 50; // Equal
+
+  DeviceBuffer signalBuf(sizeof(uint64_t));
+  auto* d_signalBuf = static_cast<uint64_t*>(signalBuf.get());
+
+  CUDACHECK_TEST(cudaMemcpy(
+      d_signalBuf, &signalValue, sizeof(uint64_t), cudaMemcpyHostToDevice));
+
+  IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKey(0x1111));
+  IbgdaRemoteBuffer remoteBuf(d_signalBuf, NetworkRKey(0x2222));
+
+  runAndVerify([&](bool* d_success) {
+    runTestWaitSignalGE(
+        d_signalBuf, localBuf, remoteBuf, signalValue, targetValue, d_success);
+  });
+}
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalGE_Greater) {
+  // Test wait_signal with GE comparison when signal > target
+  const uint64_t signalValue = 100;
+  const uint64_t targetValue = 50; // Less than signal
+
+  DeviceBuffer signalBuf(sizeof(uint64_t));
+  auto* d_signalBuf = static_cast<uint64_t*>(signalBuf.get());
+
+  CUDACHECK_TEST(cudaMemcpy(
+      d_signalBuf, &signalValue, sizeof(uint64_t), cudaMemcpyHostToDevice));
+
+  IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKey(0x1111));
+  IbgdaRemoteBuffer remoteBuf(d_signalBuf, NetworkRKey(0x2222));
+
+  runAndVerify([&](bool* d_success) {
+    runTestWaitSignalGE(
+        d_signalBuf, localBuf, remoteBuf, signalValue, targetValue, d_success);
+  });
+}
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalGT) {
+  // Test wait_signal with GT comparison
+  const uint64_t signalValue = 100;
+  const uint64_t targetValue = 50; // Less than signal
+
+  DeviceBuffer signalBuf(sizeof(uint64_t));
+  auto* d_signalBuf = static_cast<uint64_t*>(signalBuf.get());
+
+  CUDACHECK_TEST(cudaMemcpy(
+      d_signalBuf, &signalValue, sizeof(uint64_t), cudaMemcpyHostToDevice));
+
+  IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKey(0x1111));
+  IbgdaRemoteBuffer remoteBuf(d_signalBuf, NetworkRKey(0x2222));
+
+  runAndVerify([&](bool* d_success) {
+    runTestWaitSignalGT(
+        d_signalBuf, localBuf, remoteBuf, signalValue, targetValue, d_success);
+  });
+}
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalLE_Equal) {
+  // Test wait_signal with LE comparison when signal == target
+  const uint64_t signalValue = 50;
+  const uint64_t targetValue = 50; // Equal
+
+  DeviceBuffer signalBuf(sizeof(uint64_t));
+  auto* d_signalBuf = static_cast<uint64_t*>(signalBuf.get());
+
+  CUDACHECK_TEST(cudaMemcpy(
+      d_signalBuf, &signalValue, sizeof(uint64_t), cudaMemcpyHostToDevice));
+
+  IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKey(0x1111));
+  IbgdaRemoteBuffer remoteBuf(d_signalBuf, NetworkRKey(0x2222));
+
+  runAndVerify([&](bool* d_success) {
+    runTestWaitSignalLE(
+        d_signalBuf, localBuf, remoteBuf, signalValue, targetValue, d_success);
+  });
+}
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalLE_Less) {
+  // Test wait_signal with LE comparison when signal < target
+  const uint64_t signalValue = 25;
+  const uint64_t targetValue = 50; // Greater than signal
+
+  DeviceBuffer signalBuf(sizeof(uint64_t));
+  auto* d_signalBuf = static_cast<uint64_t*>(signalBuf.get());
+
+  CUDACHECK_TEST(cudaMemcpy(
+      d_signalBuf, &signalValue, sizeof(uint64_t), cudaMemcpyHostToDevice));
+
+  IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKey(0x1111));
+  IbgdaRemoteBuffer remoteBuf(d_signalBuf, NetworkRKey(0x2222));
+
+  runAndVerify([&](bool* d_success) {
+    runTestWaitSignalLE(
+        d_signalBuf, localBuf, remoteBuf, signalValue, targetValue, d_success);
+  });
+}
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalLT) {
+  // Test wait_signal with LT comparison
+  const uint64_t signalValue = 25;
+  const uint64_t targetValue = 50; // Greater than signal
+
+  DeviceBuffer signalBuf(sizeof(uint64_t));
+  auto* d_signalBuf = static_cast<uint64_t*>(signalBuf.get());
+
+  CUDACHECK_TEST(cudaMemcpy(
+      d_signalBuf, &signalValue, sizeof(uint64_t), cudaMemcpyHostToDevice));
+
+  IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKey(0x1111));
+  IbgdaRemoteBuffer remoteBuf(d_signalBuf, NetworkRKey(0x2222));
+
+  runAndVerify([&](bool* d_success) {
+    runTestWaitSignalLT(
+        d_signalBuf, localBuf, remoteBuf, signalValue, targetValue, d_success);
+  });
+}
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalMultipleSlots) {
+  // Test wait_signal operates on correct slot in multi-signal setup
+  const int numSignals = 4;
+
+  DeviceBuffer signalBuf(numSignals * sizeof(uint64_t));
+  auto* d_signalBuf = static_cast<uint64_t*>(signalBuf.get());
+
+  // Initialize signal buffer with known values: slot[i] = (i+1) * 100
+  std::vector<uint64_t> h_signals(numSignals);
+  for (int i = 0; i < numSignals; ++i) {
+    h_signals[i] = static_cast<uint64_t>(i + 1) * 100;
+  }
+  CUDACHECK_TEST(cudaMemcpy(
+      d_signalBuf,
+      h_signals.data(),
+      numSignals * sizeof(uint64_t),
+      cudaMemcpyHostToDevice));
+
+  IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKey(0x3333));
+  IbgdaRemoteBuffer remoteBuf(d_signalBuf, NetworkRKey(0x4444));
+
+  runAndVerify([&](bool* d_success) {
+    runTestWaitSignalMultipleSlots(
+        d_signalBuf, localBuf, remoteBuf, numSignals, d_success);
+  });
+}
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalZeroValue) {
+  // Test wait_signal with zero value (edge case)
+  const uint64_t targetValue = 0;
+
+  DeviceBuffer signalBuf(sizeof(uint64_t));
+  auto* d_signalBuf = static_cast<uint64_t*>(signalBuf.get());
+
+  // Pre-set signal to 0
+  CUDACHECK_TEST(cudaMemset(d_signalBuf, 0, sizeof(uint64_t)));
+
+  IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKey(0x1111));
+  IbgdaRemoteBuffer remoteBuf(d_signalBuf, NetworkRKey(0x2222));
+
+  runAndVerify([&](bool* d_success) {
+    runTestWaitSignalEQ(
+        d_signalBuf, localBuf, remoteBuf, targetValue, d_success);
+  });
+}
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalMaxValue) {
+  // Test wait_signal with max uint64 value (edge case)
+  const uint64_t targetValue = UINT64_MAX;
+
+  DeviceBuffer signalBuf(sizeof(uint64_t));
+  auto* d_signalBuf = static_cast<uint64_t*>(signalBuf.get());
+
+  CUDACHECK_TEST(cudaMemcpy(
+      d_signalBuf, &targetValue, sizeof(uint64_t), cudaMemcpyHostToDevice));
+
+  IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKey(0x1111));
+  IbgdaRemoteBuffer remoteBuf(d_signalBuf, NetworkRKey(0x2222));
+
+  runAndVerify([&](bool* d_success) {
+    runTestWaitSignalEQ(
+        d_signalBuf, localBuf, remoteBuf, targetValue, d_success);
+  });
+}
+
+} // namespace comms::pipes::tests
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/pipes/tests/P2pIbgdaTransportDistributedTest.cc
+++ b/comms/pipes/tests/P2pIbgdaTransportDistributedTest.cc
@@ -1,0 +1,910 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/tests/P2pIbgdaTransportDistributedTest.h"
+
+#include <climits>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <fmt/format.h>
+#include <folly/init/Init.h>
+#include <folly/logging/xlog.h>
+#include <gtest/gtest.h>
+#include <mpi.h>
+
+#include <cuda_runtime.h>
+#include <infiniband/verbs.h>
+
+#include <host/doca_error.h>
+#include <host/doca_gpunetio.h>
+#include <host/doca_gpunetio_high_level.h>
+#include <host/doca_verbs.h>
+
+#include "comms/pipes/IbgdaBuffer.h"
+#include "comms/testinfra/mpi/MpiBootstrap.h"
+#include "comms/testinfra/mpi/MpiTestUtils.h"
+
+namespace comms::pipes::tests {
+
+// =============================================================================
+// Error Checking Macros
+// =============================================================================
+
+#define CUDACHECK_TEST(cmd)          \
+  do {                               \
+    cudaError_t err = (cmd);         \
+    if (err != cudaSuccess) {        \
+      FAIL() << fmt::format(         \
+          "CUDA error: {} at {}:{}", \
+          cudaGetErrorString(err),   \
+          __FILE__,                  \
+          __LINE__);                 \
+    }                                \
+  } while (0)
+
+#define DOCA_CHECK_TEST(cmd)         \
+  do {                               \
+    doca_error_t err = (cmd);        \
+    if (err != DOCA_SUCCESS) {       \
+      FAIL() << fmt::format(         \
+          "DOCA error: {} at {}:{}", \
+          static_cast<int>(err),     \
+          __FILE__,                  \
+          __LINE__);                 \
+    }                                \
+  } while (0)
+
+#define DOCA_CHECK_RETURN(cmd, msg)                                   \
+  do {                                                                \
+    doca_error_t _status = (cmd);                                     \
+    if (_status != DOCA_SUCCESS) {                                    \
+      XLOGF(WARNING, "{}: error {}", msg, static_cast<int>(_status)); \
+      return false;                                                   \
+    }                                                                 \
+  } while (0)
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+constexpr int kDefaultNumSignals = 4;
+constexpr size_t kDefaultDataSize = 4096;
+constexpr uint16_t kDefaultQueueSize = 2048;
+constexpr uint8_t kDefaultHopLimit = 255;
+constexpr uint8_t kDefaultPortNum = 1;
+constexpr int kDefaultGidIndex = 3;
+
+// =============================================================================
+// IB/DOCA Utility Functions (inlined from DocaVerbsUtils.h)
+// =============================================================================
+
+inline std::string readSysfs(const std::string& path) {
+  FILE* f = fopen(path.c_str(), "r");
+  if (!f) {
+    return "";
+  }
+  char buf[256] = {};
+  size_t n = fread(buf, 1, sizeof(buf) - 1, f);
+  fclose(f);
+  while (n > 0 && (buf[n - 1] == '\n' || buf[n - 1] == '\r')) {
+    buf[--n] = '\0';
+  }
+  return std::string(buf);
+}
+
+inline int getNumaNode(const std::string& pciAddr) {
+  std::string addr = pciAddr;
+  if (addr.length() < 12) {
+    addr = "0000:" + addr;
+  }
+  for (char& c : addr) {
+    c = static_cast<char>(tolower(static_cast<unsigned char>(c)));
+  }
+  std::string path = "/sys/bus/pci/devices/" + addr + "/numa_node";
+  std::string content = readSysfs(path);
+  if (content.empty()) {
+    return -1;
+  }
+  return std::stoi(content);
+}
+
+inline std::string getIbDevicePciAddr(const std::string& ibDevName) {
+  std::string symlinkPath = "/sys/class/infiniband/" + ibDevName + "/device";
+  char resolvedPath[PATH_MAX] = {};
+  if (realpath(symlinkPath.c_str(), resolvedPath) == nullptr) {
+    return "";
+  }
+  std::string path(resolvedPath);
+  size_t lastSlash = path.rfind('/');
+  if (lastSlash == std::string::npos) {
+    return "";
+  }
+  return path.substr(lastSlash + 1);
+}
+
+inline int parsePciBus(const std::string& pciAddr) {
+  size_t colonPos = pciAddr.find(':');
+  if (colonPos == std::string::npos) {
+    return -1;
+  }
+  std::string busStr;
+  size_t secondColon = pciAddr.find(':', colonPos + 1);
+  if (secondColon != std::string::npos) {
+    busStr = pciAddr.substr(colonPos + 1, secondColon - colonPos - 1);
+  } else {
+    busStr = pciAddr.substr(0, colonPos);
+  }
+  try {
+    return std::stoi(busStr, nullptr, 16);
+  } catch (...) {
+    return -1;
+  }
+}
+
+inline std::string findClosestNic(const std::string& gpuPciAddr) {
+  int numDevs = 0;
+  struct ibv_device** devList = ibv_get_device_list(&numDevs);
+  if (!devList || numDevs == 0) {
+    return "";
+  }
+
+  int gpuNuma = getNumaNode(gpuPciAddr);
+  int gpuBus = parsePciBus(gpuPciAddr);
+
+  std::string bestNic;
+  int bestScore = INT_MIN;
+
+  for (int i = 0; i < numDevs; i++) {
+    const char* devName = ibv_get_device_name(devList[i]);
+    if (strncmp(devName, "mlx5", 4) != 0) {
+      continue;
+    }
+    std::string nicPciAddr = getIbDevicePciAddr(devName);
+    if (nicPciAddr.empty()) {
+      continue;
+    }
+    int nicNuma = getNumaNode(nicPciAddr);
+    int nicBus = parsePciBus(nicPciAddr);
+
+    int score = 0;
+    if (gpuNuma >= 0 && nicNuma >= 0 && gpuNuma == nicNuma) {
+      score += 1000;
+    }
+    if (gpuBus >= 0 && nicBus >= 0) {
+      score += 255 - std::abs(gpuBus - nicBus);
+    }
+    if (score > bestScore) {
+      bestScore = score;
+      bestNic = devName;
+    }
+  }
+
+  ibv_free_device_list(devList);
+  return bestNic;
+}
+
+inline std::string findFirstMlx5Device() {
+  int numDevs = 0;
+  struct ibv_device** devList = ibv_get_device_list(&numDevs);
+  if (!devList || numDevs == 0) {
+    return "";
+  }
+  std::string name;
+  for (int i = 0; i < numDevs; i++) {
+    const char* devName = ibv_get_device_name(devList[i]);
+    if (strncmp(devName, "mlx5", 4) == 0) {
+      name = devName;
+      break;
+    }
+  }
+  ibv_free_device_list(devList);
+  return name;
+}
+
+inline struct ibv_context* openIbDevice(const std::string& name) {
+  int numDevs = 0;
+  struct ibv_device** devList = ibv_get_device_list(&numDevs);
+  if (!devList || numDevs == 0) {
+    return nullptr;
+  }
+  struct ibv_context* ctx = nullptr;
+  for (int i = 0; i < numDevs; i++) {
+    if (name == ibv_get_device_name(devList[i])) {
+      ctx = ibv_open_device(devList[i]);
+      break;
+    }
+  }
+  ibv_free_device_list(devList);
+  return ctx;
+}
+
+// =============================================================================
+// QP Connection Helper (inlined from DocaVerbsUtils.h)
+// =============================================================================
+
+class QpConnector {
+ public:
+  static bool connect(
+      struct ibv_context* ctx,
+      doca_verbs_qp* qp,
+      uint32_t remoteQpNum,
+      const union ibv_gid& remoteGid) {
+    // Create and configure AH attributes
+    doca_verbs_ah_attr* ahAttr = nullptr;
+    if (doca_verbs_ah_attr_create(ctx, &ahAttr) != DOCA_SUCCESS || !ahAttr) {
+      return false;
+    }
+
+    doca_verbs_gid docaGid{};
+    memcpy(docaGid.raw, remoteGid.raw, 16);
+
+    if (doca_verbs_ah_attr_set_addr_type(ahAttr, DOCA_VERBS_ADDR_TYPE_IPv6) !=
+            DOCA_SUCCESS ||
+        doca_verbs_ah_attr_set_gid(ahAttr, docaGid) != DOCA_SUCCESS ||
+        doca_verbs_ah_attr_set_sgid_index(ahAttr, kDefaultGidIndex) !=
+            DOCA_SUCCESS ||
+        doca_verbs_ah_attr_set_hop_limit(ahAttr, kDefaultHopLimit) !=
+            DOCA_SUCCESS) {
+      doca_verbs_ah_attr_destroy(ahAttr);
+      return false;
+    }
+
+    // Create and configure QP attributes
+    doca_verbs_qp_attr* qpAttr = nullptr;
+    if (doca_verbs_qp_attr_create(&qpAttr) != DOCA_SUCCESS || !qpAttr) {
+      doca_verbs_ah_attr_destroy(ahAttr);
+      return false;
+    }
+
+    if (doca_verbs_qp_attr_set_port_num(qpAttr, kDefaultPortNum) !=
+            DOCA_SUCCESS ||
+        doca_verbs_qp_attr_set_rq_psn(qpAttr, 0) != DOCA_SUCCESS ||
+        doca_verbs_qp_attr_set_sq_psn(qpAttr, 0) != DOCA_SUCCESS ||
+        doca_verbs_qp_attr_set_ack_timeout(qpAttr, 20) != DOCA_SUCCESS ||
+        doca_verbs_qp_attr_set_retry_cnt(qpAttr, 7) != DOCA_SUCCESS ||
+        doca_verbs_qp_attr_set_rnr_retry(qpAttr, 7) != DOCA_SUCCESS ||
+        doca_verbs_qp_attr_set_min_rnr_timer(qpAttr, 12) != DOCA_SUCCESS ||
+        doca_verbs_qp_attr_set_dest_qp_num(qpAttr, remoteQpNum) !=
+            DOCA_SUCCESS ||
+        doca_verbs_qp_attr_set_ah_attr(qpAttr, ahAttr) != DOCA_SUCCESS) {
+      doca_verbs_qp_attr_destroy(qpAttr);
+      doca_verbs_ah_attr_destroy(ahAttr);
+      return false;
+    }
+
+    // RST -> INIT
+    if (doca_verbs_qp_attr_set_next_state(qpAttr, DOCA_VERBS_QP_STATE_INIT) !=
+            DOCA_SUCCESS ||
+        doca_verbs_qp_attr_set_allow_remote_write(qpAttr, 1) != DOCA_SUCCESS ||
+        doca_verbs_qp_attr_set_allow_remote_read(qpAttr, 1) != DOCA_SUCCESS ||
+        doca_verbs_qp_attr_set_allow_remote_atomic(
+            qpAttr, DOCA_VERBS_QP_ATOMIC_MODE_IB_SPEC) != DOCA_SUCCESS) {
+      doca_verbs_qp_attr_destroy(qpAttr);
+      doca_verbs_ah_attr_destroy(ahAttr);
+      return false;
+    }
+
+    doca_error_t err = doca_verbs_qp_modify(
+        qp,
+        qpAttr,
+        DOCA_VERBS_QP_ATTR_NEXT_STATE | DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_WRITE |
+            DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_READ |
+            DOCA_VERBS_QP_ATTR_PKEY_INDEX | DOCA_VERBS_QP_ATTR_PORT_NUM);
+    if (err != DOCA_SUCCESS) {
+      XLOGF(WARNING, "Failed to modify QP to INIT: {}", static_cast<int>(err));
+      doca_verbs_qp_attr_destroy(qpAttr);
+      doca_verbs_ah_attr_destroy(ahAttr);
+      return false;
+    }
+
+    // INIT -> RTR
+    doca_verbs_qp_attr_set_next_state(qpAttr, DOCA_VERBS_QP_STATE_RTR);
+    err = doca_verbs_qp_modify(
+        qp,
+        qpAttr,
+        DOCA_VERBS_QP_ATTR_NEXT_STATE | DOCA_VERBS_QP_ATTR_RQ_PSN |
+            DOCA_VERBS_QP_ATTR_DEST_QP_NUM | DOCA_VERBS_QP_ATTR_PATH_MTU |
+            DOCA_VERBS_QP_ATTR_AH_ATTR | DOCA_VERBS_QP_ATTR_MIN_RNR_TIMER);
+    if (err != DOCA_SUCCESS) {
+      XLOGF(WARNING, "Failed to modify QP to RTR: {}", static_cast<int>(err));
+      doca_verbs_qp_attr_destroy(qpAttr);
+      doca_verbs_ah_attr_destroy(ahAttr);
+      return false;
+    }
+
+    // RTR -> RTS
+    doca_verbs_qp_attr_set_next_state(qpAttr, DOCA_VERBS_QP_STATE_RTS);
+    err = doca_verbs_qp_modify(
+        qp,
+        qpAttr,
+        DOCA_VERBS_QP_ATTR_NEXT_STATE | DOCA_VERBS_QP_ATTR_SQ_PSN |
+            DOCA_VERBS_QP_ATTR_ACK_TIMEOUT | DOCA_VERBS_QP_ATTR_RETRY_CNT |
+            DOCA_VERBS_QP_ATTR_RNR_RETRY);
+    if (err != DOCA_SUCCESS) {
+      XLOGF(WARNING, "Failed to modify QP to RTS: {}", static_cast<int>(err));
+      doca_verbs_qp_attr_destroy(qpAttr);
+      doca_verbs_ah_attr_destroy(ahAttr);
+      return false;
+    }
+
+    doca_verbs_qp_attr_destroy(qpAttr);
+    doca_verbs_ah_attr_destroy(ahAttr);
+    return true;
+  }
+};
+
+// =============================================================================
+// QP Exchange Info
+// =============================================================================
+
+struct QpExchangeInfo {
+  uint32_t qpNum;
+  uint8_t port;
+  uint64_t subnetPrefix;
+  uint64_t interfaceId;
+  int32_t rank;
+  uint64_t dataAddr;
+  uint64_t signalAddr;
+  uint32_t dataRkey;
+  uint32_t signalRkey;
+};
+
+// =============================================================================
+// Test Fixture
+// =============================================================================
+
+class P2pIbgdaTransportDistributedTest
+    : public meta::comms::MpiBaseTestFixture {
+ protected:
+  void SetUp() override {
+    meta::comms::MpiBaseTestFixture::SetUp();
+    cudaGetLastError(); // Clear previous errors
+
+    int deviceCount = 0;
+    if (cudaGetDeviceCount(&deviceCount) != cudaSuccess || deviceCount == 0) {
+      GTEST_SKIP() << "No CUDA devices available";
+      return;
+    }
+    if (localRank >= deviceCount) {
+      GTEST_SKIP() << "Not enough CUDA devices";
+      return;
+    }
+
+    XLOGF(INFO, "Rank {}: Setting CUDA device to {}", globalRank, localRank);
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+    CUDACHECK_TEST(cudaFree(0)); // Initialize CUDA context
+
+    // Initialize all resources
+    if (!initializeResources(kDefaultDataSize)) {
+      GTEST_SKIP() << "Failed to initialize DOCA/IB resources";
+      return;
+    }
+
+    if (!exchangeAndConnect()) {
+      cleanup();
+      GTEST_SKIP() << "Failed to exchange QP info and connect";
+      return;
+    }
+
+    // Create device transport
+    deviceTransport_ = allocateDeviceTransport(
+        qpGpuDev_, localSignalBuf_, remoteSignalBuf_, kDefaultNumSignals);
+    if (!deviceTransport_) {
+      cleanup();
+      GTEST_SKIP() << "Failed to allocate device transport";
+      return;
+    }
+
+    XLOGF(INFO, "Rank {}: Setup complete", globalRank);
+  }
+
+  void TearDown() override {
+    cleanup();
+    meta::comms::MpiBaseTestFixture::TearDown();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Resource Initialization
+  // ---------------------------------------------------------------------------
+
+  bool initializeResources(size_t dataBufferSize) {
+    dataBufferSize_ = dataBufferSize;
+
+    // Detect GPU PCI address
+    std::string gpuAddr = detectGpuAddr();
+    if (gpuAddr.empty()) {
+      XLOG(WARNING) << "Failed to detect GPU PCI address";
+      return false;
+    }
+
+    // Find closest NIC based on PCIe topology
+    std::string nicName = findClosestNic(gpuAddr);
+    if (nicName.empty()) {
+      nicName = findFirstMlx5Device();
+    }
+    if (nicName.empty()) {
+      XLOG(WARNING) << "No suitable NIC found";
+      return false;
+    }
+    XLOGF(INFO, "Rank {}: Using NIC={} GPU={}", globalRank, nicName, gpuAddr);
+
+    // Create DOCA GPU device
+    DOCA_CHECK_RETURN(
+        doca_gpu_create(gpuAddr.c_str(), &gpuDev_),
+        "Failed to create DOCA GPU");
+
+    // Open IB device and allocate PD
+    verbsCtx_ = openIbDevice(nicName);
+    if (!verbsCtx_) {
+      XLOG(WARNING) << "Failed to open IB device";
+      return false;
+    }
+    verbsPd_ = ibv_alloc_pd(verbsCtx_);
+    if (!verbsPd_) {
+      XLOG(WARNING) << "Failed to allocate PD";
+      return false;
+    }
+
+    // Query GID
+    if (ibv_query_gid(
+            verbsCtx_, kDefaultPortNum, kDefaultGidIndex, &localGid_) != 0) {
+      XLOG(WARNING) << "Failed to query GID";
+      return false;
+    }
+
+    // Create high-level QP
+    doca_gpu_verbs_qp_init_attr_hl qpInit{};
+    qpInit.gpu_dev = gpuDev_;
+    qpInit.ibpd = verbsPd_;
+    qpInit.sq_nwqe = kDefaultQueueSize;
+    qpInit.nic_handler = DOCA_GPUNETIO_VERBS_NIC_HANDLER_GPU_SM_DB;
+    qpInit.mreg_type = DOCA_GPUNETIO_VERBS_MEM_REG_TYPE_CUDA_DMABUF;
+
+    DOCA_CHECK_RETURN(
+        doca_gpu_verbs_create_qp_hl(&qpInit, &qpHl_), "Failed to create QP");
+    localQpNum_ = doca_verbs_qp_get_qpn(qpHl_->qp);
+    XLOGF(INFO, "Rank {}: Created QP with qpn={}", globalRank, localQpNum_);
+
+    // Allocate and register buffers
+    return allocateBuffers();
+  }
+
+  bool exchangeAndConnect() {
+    // Prepare local info
+    QpExchangeInfo localInfo{};
+    localInfo.qpNum = localQpNum_;
+    localInfo.port = kDefaultPortNum;
+    localInfo.subnetPrefix = localGid_.global.subnet_prefix;
+    localInfo.interfaceId = localGid_.global.interface_id;
+    localInfo.rank = globalRank;
+    localInfo.dataAddr = reinterpret_cast<uint64_t>(dataBuffer_);
+    localInfo.signalAddr = reinterpret_cast<uint64_t>(signalBuffer_);
+    localInfo.dataRkey = dataMr_->rkey;
+    localInfo.signalRkey = signalMr_->rkey;
+
+    // Exchange via MPI
+    std::vector<QpExchangeInfo> allCards(numRanks);
+    MPI_CHECK(MPI_Allgather(
+        &localInfo,
+        sizeof(QpExchangeInfo),
+        MPI_BYTE,
+        allCards.data(),
+        sizeof(QpExchangeInfo),
+        MPI_BYTE,
+        MPI_COMM_WORLD));
+
+    // Get peer info (rank 0 connects to rank 1, rank 1 connects to rank 0)
+    int peerRank = (globalRank == 0) ? 1 : 0;
+    const auto& remote = allCards[peerRank];
+    remoteQpNum_ = remote.qpNum;
+    remoteGid_.global.subnet_prefix = remote.subnetPrefix;
+    remoteGid_.global.interface_id = remote.interfaceId;
+    remoteDataAddr_ = remote.dataAddr;
+    remoteSignalAddr_ = remote.signalAddr;
+    remoteDataRkey_ = remote.dataRkey;
+    remoteSignalRkey_ = remote.signalRkey;
+
+    XLOGF(
+        INFO,
+        "Rank {}: Remote QPN={} dataAddr={:#x}",
+        globalRank,
+        remoteQpNum_,
+        remoteDataAddr_);
+
+    // Connect QP
+    if (!QpConnector::connect(verbsCtx_, qpHl_->qp, remoteQpNum_, remoteGid_)) {
+      XLOG(WARNING) << "Failed to connect QP";
+      return false;
+    }
+
+    // Export to GPU
+    DOCA_CHECK_RETURN(
+        doca_gpu_verbs_qp_flat_list_create_hl(&qpHl_, 1, &qpGpuDev_),
+        "Failed to export QP to GPU");
+
+    XLOGF(
+        INFO,
+        "Rank {}: QP connected to remote QPN={}",
+        globalRank,
+        remoteQpNum_);
+
+    // Build buffer descriptors with strong types - implicit conversion handles
+    // byte order swap
+    localDataBuf_ = IbgdaLocalBuffer(dataBuffer_, HostLKey(dataMr_->lkey));
+    localSignalBuf_ =
+        IbgdaLocalBuffer(signalBuffer_, HostLKey(signalMr_->lkey));
+
+    remoteDataBuf_ = IbgdaRemoteBuffer(
+        reinterpret_cast<void*>(remoteDataAddr_), HostRKey(remoteDataRkey_));
+    remoteSignalBuf_ = IbgdaRemoteBuffer(
+        reinterpret_cast<void*>(remoteSignalAddr_),
+        HostRKey(remoteSignalRkey_));
+
+    return true;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helper Methods
+  // ---------------------------------------------------------------------------
+
+  void syncRanks() {
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  }
+
+  void resetSignalBuffers() {
+    CUDACHECK_TEST(
+        cudaMemset(signalBuffer_, 0, kDefaultNumSignals * sizeof(uint64_t)));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    syncRanks();
+  }
+
+ private:
+  std::string detectGpuAddr() {
+    char pciBusId[32] = {};
+    if (cudaDeviceGetPCIBusId(pciBusId, sizeof(pciBusId), localRank) !=
+        cudaSuccess) {
+      return "";
+    }
+    return std::string(pciBusId);
+  }
+
+  bool allocateBuffers() {
+    cudaError_t err;
+
+    err = cudaMalloc(&dataBuffer_, dataBufferSize_);
+    if (err != cudaSuccess) {
+      XLOGF(
+          WARNING,
+          "Failed to allocate data buffer: {}",
+          cudaGetErrorString(err));
+      return false;
+    }
+
+    // Allocate signal buffer for multiple signals
+    size_t signalBufferSize = kDefaultNumSignals * sizeof(uint64_t);
+    err = cudaMalloc(&signalBuffer_, signalBufferSize);
+    if (err != cudaSuccess) {
+      XLOGF(
+          WARNING,
+          "Failed to allocate signal buffer: {}",
+          cudaGetErrorString(err));
+      return false;
+    }
+
+    err = cudaMemset(signalBuffer_, 0, signalBufferSize);
+    if (err != cudaSuccess) {
+      XLOGF(
+          WARNING,
+          "Failed to memset signal buffer: {}",
+          cudaGetErrorString(err));
+      return false;
+    }
+
+    int flags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE |
+        IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_ATOMIC;
+
+    dataMr_ = ibv_reg_mr(verbsPd_, dataBuffer_, dataBufferSize_, flags);
+    signalMr_ = ibv_reg_mr(verbsPd_, signalBuffer_, signalBufferSize, flags);
+
+    if (!dataMr_ || !signalMr_) {
+      XLOG(WARNING) << "Failed to register buffers with RDMA";
+      return false;
+    }
+
+    XLOGF(
+        INFO,
+        "Rank {}: Allocated buffers - data={} signal={}",
+        globalRank,
+        dataBuffer_,
+        signalBuffer_);
+    return true;
+  }
+
+  void cleanup() {
+    if (deviceTransport_) {
+      freeDeviceTransport(deviceTransport_);
+      deviceTransport_ = nullptr;
+    }
+    if (qpGpuDev_) {
+      doca_gpu_verbs_qp_flat_list_destroy_hl(qpGpuDev_);
+      qpGpuDev_ = nullptr;
+    }
+    if (qpHl_) {
+      doca_gpu_verbs_destroy_qp_hl(qpHl_);
+      qpHl_ = nullptr;
+    }
+    if (dataMr_) {
+      ibv_dereg_mr(dataMr_);
+      dataMr_ = nullptr;
+    }
+    if (signalMr_) {
+      ibv_dereg_mr(signalMr_);
+      signalMr_ = nullptr;
+    }
+    if (dataBuffer_) {
+      cudaFree(dataBuffer_);
+      dataBuffer_ = nullptr;
+    }
+    if (signalBuffer_) {
+      cudaFree(signalBuffer_);
+      signalBuffer_ = nullptr;
+    }
+    if (verbsPd_) {
+      ibv_dealloc_pd(verbsPd_);
+      verbsPd_ = nullptr;
+    }
+    if (verbsCtx_) {
+      ibv_close_device(verbsCtx_);
+      verbsCtx_ = nullptr;
+    }
+    if (gpuDev_) {
+      doca_gpu_destroy(gpuDev_);
+      gpuDev_ = nullptr;
+    }
+  }
+
+ protected:
+  // DOCA/GPU resources
+  doca_gpu* gpuDev_{nullptr};
+  struct ibv_context* verbsCtx_{nullptr};
+  struct ibv_pd* verbsPd_{nullptr};
+
+  // QP resources
+  doca_gpu_verbs_qp_hl* qpHl_{nullptr};
+  doca_gpu_dev_verbs_qp* qpGpuDev_{nullptr};
+  uint32_t localQpNum_{0};
+  union ibv_gid localGid_{};
+
+  // Remote QP info
+  uint32_t remoteQpNum_{0};
+  union ibv_gid remoteGid_{};
+  uint64_t remoteDataAddr_{0};
+  uint64_t remoteSignalAddr_{0};
+  uint32_t remoteDataRkey_{0};
+  uint32_t remoteSignalRkey_{0};
+
+  // Buffers
+  void* dataBuffer_{nullptr};
+  void* signalBuffer_{nullptr};
+  size_t dataBufferSize_{0};
+  struct ibv_mr* dataMr_{nullptr};
+  struct ibv_mr* signalMr_{nullptr};
+
+  // Buffer descriptors for device use
+  IbgdaLocalBuffer localDataBuf_;
+  IbgdaLocalBuffer localSignalBuf_;
+  IbgdaRemoteBuffer remoteDataBuf_;
+  IbgdaRemoteBuffer remoteSignalBuf_;
+
+  // Device transport
+  P2pIbgdaTransportDevice* deviceTransport_{nullptr};
+};
+
+// =============================================================================
+// Test Cases
+// =============================================================================
+
+TEST_F(P2pIbgdaTransportDistributedTest, PutSignalBasic) {
+  // Rank 0 sends data to Rank 1 with signal
+  // Rank 1 waits for signal, then verifies data
+
+  constexpr int kSignalId = 0;
+  constexpr uint64_t kSignalVal = 1;
+  constexpr uint8_t kDataPattern = 0xAB;
+  const size_t nbytes = dataBufferSize_;
+
+  resetSignalBuffers();
+
+  if (globalRank == 0) {
+    // Sender: fill local data and send to peer
+    runFillDataKernel(dataBuffer_, nbytes, kDataPattern);
+    XLOGF(INFO, "Rank 0: Sending {} bytes with signal", nbytes);
+
+    runPutSignalKernel(
+        deviceTransport_,
+        localDataBuf_,
+        remoteDataBuf_,
+        nbytes,
+        kSignalId,
+        kSignalVal);
+
+    XLOG(INFO) << "Rank 0: put_signal complete";
+  } else {
+    // Receiver: wait for signal, then verify data
+    bool* d_success = nullptr;
+    CUDACHECK_TEST(cudaMalloc(&d_success, sizeof(bool)));
+    CUDACHECK_TEST(cudaMemset(d_success, 0, sizeof(bool)));
+
+    XLOG(INFO) << "Rank 1: Waiting for signal...";
+    runWaitSignalKernel(deviceTransport_, kSignalId, kSignalVal, d_success);
+    XLOG(INFO) << "Rank 1: Signal received";
+
+    // Verify data
+    runVerifyDataKernel(dataBuffer_, nbytes, kDataPattern, d_success);
+
+    bool success = false;
+    CUDACHECK_TEST(
+        cudaMemcpy(&success, d_success, sizeof(bool), cudaMemcpyDeviceToHost));
+    CUDACHECK_TEST(cudaFree(d_success));
+    EXPECT_TRUE(success) << "Rank 1: Data verification failed";
+  }
+
+  syncRanks();
+}
+
+TEST_F(P2pIbgdaTransportDistributedTest, PutSignalNonAdaptiveBasic) {
+  // Test put_signal_non_adaptive - same as PutSignalBasic but uses
+  // the fused put_signal operation instead of the split put + signal
+
+  constexpr int kSignalId = 0;
+  constexpr uint64_t kSignalVal = 1;
+  constexpr uint8_t kDataPattern = 0xCD;
+  const size_t nbytes = dataBufferSize_;
+
+  resetSignalBuffers();
+
+  if (globalRank == 0) {
+    // Sender: fill local data and send to peer using non-adaptive version
+    runFillDataKernel(dataBuffer_, nbytes, kDataPattern);
+    XLOGF(
+        INFO, "Rank 0: Sending {} bytes with put_signal_non_adaptive", nbytes);
+
+    runPutSignalNonAdaptiveKernel(
+        deviceTransport_,
+        localDataBuf_,
+        remoteDataBuf_,
+        nbytes,
+        kSignalId,
+        kSignalVal);
+
+    XLOG(INFO) << "Rank 0: put_signal_non_adaptive complete";
+  } else {
+    // Receiver: wait for signal, then verify data
+    bool* d_success = nullptr;
+    CUDACHECK_TEST(cudaMalloc(&d_success, sizeof(bool)));
+    CUDACHECK_TEST(cudaMemset(d_success, 0, sizeof(bool)));
+
+    XLOG(INFO) << "Rank 1: Waiting for signal...";
+    runWaitSignalKernel(deviceTransport_, kSignalId, kSignalVal, d_success);
+    XLOG(INFO) << "Rank 1: Signal received";
+
+    // Verify data
+    runVerifyDataKernel(dataBuffer_, nbytes, kDataPattern, d_success);
+
+    bool success = false;
+    CUDACHECK_TEST(
+        cudaMemcpy(&success, d_success, sizeof(bool), cudaMemcpyDeviceToHost));
+    CUDACHECK_TEST(cudaFree(d_success));
+    EXPECT_TRUE(success) << "Rank 1: Data verification failed (non-adaptive)";
+  }
+
+  syncRanks();
+}
+
+TEST_F(P2pIbgdaTransportDistributedTest, SignalOnly) {
+  // Test signal-only operation without data transfer
+  // Rank 0 sends signal to Rank 1
+  // Rank 1 waits for signal
+
+  constexpr int kSignalId = 1;
+  constexpr uint64_t kSignalVal = 42;
+
+  resetSignalBuffers();
+
+  if (globalRank == 0) {
+    XLOG(INFO) << "Rank 0: Sending signal only";
+    runSignalOnlyKernel(deviceTransport_, kSignalId, kSignalVal);
+    XLOG(INFO) << "Rank 0: signal complete";
+  } else {
+    bool* d_success = nullptr;
+    CUDACHECK_TEST(cudaMalloc(&d_success, sizeof(bool)));
+    CUDACHECK_TEST(cudaMemset(d_success, 0, sizeof(bool)));
+
+    XLOG(INFO) << "Rank 1: Waiting for signal...";
+    runWaitSignalKernel(deviceTransport_, kSignalId, kSignalVal, d_success);
+
+    bool success = false;
+    CUDACHECK_TEST(
+        cudaMemcpy(&success, d_success, sizeof(bool), cudaMemcpyDeviceToHost));
+    CUDACHECK_TEST(cudaFree(d_success));
+    EXPECT_TRUE(success) << "Rank 1: wait_signal failed";
+    XLOG(INFO) << "Rank 1: Signal received";
+  }
+
+  syncRanks();
+}
+
+// =============================================================================
+// Parameterized Tests for Different Transfer Sizes
+// =============================================================================
+
+class P2pIbgdaTransportSizeTest : public P2pIbgdaTransportDistributedTest,
+                                  public ::testing::WithParamInterface<size_t> {
+};
+
+TEST_P(P2pIbgdaTransportSizeTest, PutSignalVaryingSize) {
+  const size_t nbytes = GetParam();
+
+  // Skip if requested size exceeds allocated buffer
+  if (nbytes > dataBufferSize_) {
+    GTEST_SKIP() << "Requested size " << nbytes << " exceeds buffer size "
+                 << dataBufferSize_;
+    return;
+  }
+
+  constexpr int kSignalId = 2;
+  constexpr uint64_t kSignalVal = 1;
+  constexpr uint8_t kDataPattern = 0xCD;
+
+  resetSignalBuffers();
+
+  if (globalRank == 0) {
+    runFillDataKernel(dataBuffer_, nbytes, kDataPattern);
+    XLOGF(INFO, "Rank 0: Sending {} bytes", nbytes);
+
+    runPutSignalKernel(
+        deviceTransport_,
+        localDataBuf_,
+        remoteDataBuf_,
+        nbytes,
+        kSignalId,
+        kSignalVal);
+  } else {
+    bool* d_success = nullptr;
+    CUDACHECK_TEST(cudaMalloc(&d_success, sizeof(bool)));
+    CUDACHECK_TEST(cudaMemset(d_success, 0, sizeof(bool)));
+
+    runWaitSignalKernel(deviceTransport_, kSignalId, kSignalVal, d_success);
+    runVerifyDataKernel(dataBuffer_, nbytes, kDataPattern, d_success);
+
+    bool success = false;
+    CUDACHECK_TEST(
+        cudaMemcpy(&success, d_success, sizeof(bool), cudaMemcpyDeviceToHost));
+    CUDACHECK_TEST(cudaFree(d_success));
+    EXPECT_TRUE(success) << "Rank 1: Data verification failed for size "
+                         << nbytes;
+  }
+
+  syncRanks();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    TransferSizes,
+    P2pIbgdaTransportSizeTest,
+    ::testing::Values(256, 1024, 4096),
+    [](const ::testing::TestParamInfo<size_t>& info) {
+      return fmt::format("{}B", info.param);
+    });
+
+} // namespace comms::pipes::tests
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  auto mpi_env = std::make_unique<meta::comms::MPIEnvironmentBase>();
+  ::testing::AddGlobalTestEnvironment(mpi_env.get());
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/pipes/tests/P2pIbgdaTransportDistributedTest.cu
+++ b/comms/pipes/tests/P2pIbgdaTransportDistributedTest.cu
@@ -1,0 +1,199 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/tests/P2pIbgdaTransportDistributedTest.cuh"
+
+#include <cuda_runtime.h>
+
+namespace comms::pipes::tests {
+
+// =============================================================================
+// CUDA Check Macro for test code
+// =============================================================================
+
+#define PIPES_CUDA_CHECK_KERNEL(EXPR) \
+  do {                                \
+    const cudaError_t err = EXPR;     \
+    if (err != cudaSuccess) {         \
+      return;                         \
+    }                                 \
+  } while (0)
+
+// =============================================================================
+// Device Transport Allocation Helpers
+// =============================================================================
+
+P2pIbgdaTransportDevice* allocateDeviceTransport(
+    doca_gpu_dev_verbs_qp* qp,
+    const IbgdaLocalBuffer& localSignalBuf,
+    const IbgdaRemoteBuffer& remoteSignalBuf,
+    int numSignals) {
+  P2pIbgdaTransportDevice* d_transport = nullptr;
+  cudaError_t err = cudaMalloc(&d_transport, sizeof(P2pIbgdaTransportDevice));
+  if (err != cudaSuccess) {
+    return nullptr;
+  }
+
+  // Create host-side transport and copy to device
+  P2pIbgdaTransportDevice hostTransport(
+      qp, localSignalBuf, remoteSignalBuf, numSignals);
+  err = cudaMemcpy(
+      d_transport,
+      &hostTransport,
+      sizeof(P2pIbgdaTransportDevice),
+      cudaMemcpyHostToDevice);
+  if (err != cudaSuccess) {
+    cudaFree(d_transport);
+    return nullptr;
+  }
+
+  return d_transport;
+}
+
+void freeDeviceTransport(P2pIbgdaTransportDevice* d_transport) {
+  if (d_transport) {
+    cudaFree(d_transport);
+  }
+}
+
+// =============================================================================
+// CUDA Kernel Implementations
+// =============================================================================
+
+__global__ void putSignalKernel(
+    P2pIbgdaTransportDevice* transport,
+    IbgdaLocalBuffer localDataBuf,
+    IbgdaRemoteBuffer remoteDataBuf,
+    std::size_t nbytes,
+    int signalId,
+    uint64_t signalVal) {
+  // Single-threaded kernel
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    IbgdaWork work = transport->put_signal(
+        localDataBuf, remoteDataBuf, nbytes, signalId, signalVal);
+    transport->wait_local(work);
+  }
+}
+
+__global__ void putSignalNonAdaptiveKernel(
+    P2pIbgdaTransportDevice* transport,
+    IbgdaLocalBuffer localDataBuf,
+    IbgdaRemoteBuffer remoteDataBuf,
+    std::size_t nbytes,
+    int signalId,
+    uint64_t signalVal) {
+  // Single-threaded kernel
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    IbgdaWork work = transport->put_signal_non_adaptive(
+        localDataBuf, remoteDataBuf, nbytes, signalId, signalVal);
+    transport->wait_local(work);
+  }
+}
+
+__global__ void waitSignalKernel(
+    P2pIbgdaTransportDevice* transport,
+    int signalId,
+    uint64_t expectedSignal,
+    bool* success) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    transport->wait_signal(signalId, IbgdaCmpOp::GE, expectedSignal);
+    *success = true;
+  }
+}
+
+__global__ void signalOnlyKernel(
+    P2pIbgdaTransportDevice* transport,
+    int signalId,
+    uint64_t signalVal) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    IbgdaWork work = transport->signal(signalId, signalVal);
+    transport->wait_local(work);
+  }
+}
+
+__global__ void verifyDataKernel(
+    void* data,
+    std::size_t nbytes,
+    uint8_t expectedPattern,
+    bool* success) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    uint8_t* bytes = static_cast<uint8_t*>(data);
+    *success = true;
+    for (std::size_t i = 0; i < nbytes; i++) {
+      if (bytes[i] != expectedPattern) {
+        *success = false;
+        return;
+      }
+    }
+  }
+}
+
+__global__ void
+fillDataKernel(void* data, std::size_t nbytes, uint8_t pattern) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    uint8_t* bytes = static_cast<uint8_t*>(data);
+    for (std::size_t i = 0; i < nbytes; i++) {
+      bytes[i] = pattern;
+    }
+  }
+}
+
+// =============================================================================
+// Kernel Wrapper Implementations
+// =============================================================================
+
+void runPutSignalKernel(
+    P2pIbgdaTransportDevice* d_transport,
+    const IbgdaLocalBuffer& localDataBuf,
+    const IbgdaRemoteBuffer& remoteDataBuf,
+    std::size_t nbytes,
+    int signalId,
+    uint64_t signalVal) {
+  putSignalKernel<<<1, 1>>>(
+      d_transport, localDataBuf, remoteDataBuf, nbytes, signalId, signalVal);
+  PIPES_CUDA_CHECK_KERNEL(cudaDeviceSynchronize());
+}
+
+void runPutSignalNonAdaptiveKernel(
+    P2pIbgdaTransportDevice* d_transport,
+    const IbgdaLocalBuffer& localDataBuf,
+    const IbgdaRemoteBuffer& remoteDataBuf,
+    std::size_t nbytes,
+    int signalId,
+    uint64_t signalVal) {
+  putSignalNonAdaptiveKernel<<<1, 1>>>(
+      d_transport, localDataBuf, remoteDataBuf, nbytes, signalId, signalVal);
+  PIPES_CUDA_CHECK_KERNEL(cudaDeviceSynchronize());
+}
+
+void runWaitSignalKernel(
+    P2pIbgdaTransportDevice* d_transport,
+    int signalId,
+    uint64_t expectedSignal,
+    bool* d_success) {
+  waitSignalKernel<<<1, 1>>>(d_transport, signalId, expectedSignal, d_success);
+  PIPES_CUDA_CHECK_KERNEL(cudaDeviceSynchronize());
+}
+
+void runSignalOnlyKernel(
+    P2pIbgdaTransportDevice* d_transport,
+    int signalId,
+    uint64_t signalVal) {
+  signalOnlyKernel<<<1, 1>>>(d_transport, signalId, signalVal);
+  PIPES_CUDA_CHECK_KERNEL(cudaDeviceSynchronize());
+}
+
+void runVerifyDataKernel(
+    void* d_data,
+    std::size_t nbytes,
+    uint8_t expectedPattern,
+    bool* d_success) {
+  verifyDataKernel<<<1, 1>>>(d_data, nbytes, expectedPattern, d_success);
+  PIPES_CUDA_CHECK_KERNEL(cudaDeviceSynchronize());
+}
+
+void runFillDataKernel(void* d_data, std::size_t nbytes, uint8_t pattern) {
+  fillDataKernel<<<1, 1>>>(d_data, nbytes, pattern);
+  PIPES_CUDA_CHECK_KERNEL(cudaDeviceSynchronize());
+}
+
+} // namespace comms::pipes::tests

--- a/comms/pipes/tests/P2pIbgdaTransportDistributedTest.cuh
+++ b/comms/pipes/tests/P2pIbgdaTransportDistributedTest.cuh
@@ -1,0 +1,72 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "comms/pipes/IbgdaBuffer.h"
+#include "comms/pipes/P2pIbgdaTransportDevice.cuh"
+
+namespace comms::pipes::tests {
+
+// =============================================================================
+// CUDA Kernels for Distributed P2pIbgdaTransport Tests
+// =============================================================================
+
+/**
+ * Kernel to execute put_signal operation.
+ * Single-threaded kernel for simplicity.
+ */
+__global__ void putSignalKernel(
+    P2pIbgdaTransportDevice* transport,
+    IbgdaLocalBuffer localDataBuf,
+    IbgdaRemoteBuffer remoteDataBuf,
+    std::size_t nbytes,
+    int signalId,
+    uint64_t signalVal);
+
+/**
+ * Kernel to execute put_signal_non_adaptive operation.
+ * Single-threaded kernel for simplicity.
+ */
+__global__ void putSignalNonAdaptiveKernel(
+    P2pIbgdaTransportDevice* transport,
+    IbgdaLocalBuffer localDataBuf,
+    IbgdaRemoteBuffer remoteDataBuf,
+    std::size_t nbytes,
+    int signalId,
+    uint64_t signalVal);
+
+/**
+ * Kernel to wait for signal and set success flag.
+ */
+__global__ void waitSignalKernel(
+    P2pIbgdaTransportDevice* transport,
+    int signalId,
+    uint64_t expectedSignal,
+    bool* success);
+
+/**
+ * Kernel to send signal only (no data transfer).
+ */
+__global__ void signalOnlyKernel(
+    P2pIbgdaTransportDevice* transport,
+    int signalId,
+    uint64_t signalVal);
+
+/**
+ * Kernel to verify data buffer contents match expected pattern.
+ */
+__global__ void verifyDataKernel(
+    void* data,
+    std::size_t nbytes,
+    uint8_t expectedPattern,
+    bool* success);
+
+/**
+ * Kernel to fill data buffer with a pattern.
+ */
+__global__ void fillDataKernel(void* data, std::size_t nbytes, uint8_t pattern);
+
+} // namespace comms::pipes::tests

--- a/comms/pipes/tests/P2pIbgdaTransportDistributedTest.h
+++ b/comms/pipes/tests/P2pIbgdaTransportDistributedTest.h
@@ -1,0 +1,136 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "comms/pipes/IbgdaBuffer.h"
+
+// Forward declarations for DOCA types (opaque in host code)
+struct doca_gpu_dev_verbs_qp;
+
+namespace comms::pipes {
+// Forward declaration - full definition in .cuh file
+class P2pIbgdaTransportDevice;
+} // namespace comms::pipes
+
+namespace comms::pipes::tests {
+
+/**
+ * Allocate and initialize a P2pIbgdaTransportDevice on the GPU.
+ *
+ * This helper function allows .cc files to create device transport objects
+ * without needing to include CUDA headers. The device transport is allocated
+ * in GPU memory and initialized with the provided parameters.
+ *
+ * @param qp GPU QP handle for RDMA operations
+ * @param localSignalBuf Local signal buffer descriptor
+ * @param remoteSignalBuf Remote signal buffer descriptor
+ * @param numSignals Number of signal slots
+ * @return Pointer to device-allocated transport, or nullptr on failure
+ */
+P2pIbgdaTransportDevice* allocateDeviceTransport(
+    doca_gpu_dev_verbs_qp* qp,
+    const IbgdaLocalBuffer& localSignalBuf,
+    const IbgdaRemoteBuffer& remoteSignalBuf,
+    int numSignals);
+
+/**
+ * Free a device-allocated P2pIbgdaTransportDevice.
+ *
+ * @param d_transport Device pointer to free (null-safe)
+ */
+void freeDeviceTransport(P2pIbgdaTransportDevice* d_transport);
+
+// =============================================================================
+// Kernel Wrapper Declarations
+// =============================================================================
+
+/**
+ * Test put_signal: Sender writes data and signals receiver.
+ *
+ * @param d_transport Device transport handle
+ * @param localDataBuf Source data buffer
+ * @param remoteDataBuf Destination data buffer on peer
+ * @param nbytes Number of bytes to transfer
+ * @param signalId Signal slot to use
+ * @param signalVal Value to add to signal
+ */
+void runPutSignalKernel(
+    P2pIbgdaTransportDevice* d_transport,
+    const IbgdaLocalBuffer& localDataBuf,
+    const IbgdaRemoteBuffer& remoteDataBuf,
+    std::size_t nbytes,
+    int signalId,
+    uint64_t signalVal);
+
+/**
+ * Test put_signal_non_adaptive: Sender writes data and signals receiver.
+ * Uses fused put_signal operation - faster but unsafe with adaptive routing.
+ *
+ * @param d_transport Device transport handle
+ * @param localDataBuf Source data buffer
+ * @param remoteDataBuf Destination data buffer on peer
+ * @param nbytes Number of bytes to transfer
+ * @param signalId Signal slot to use
+ * @param signalVal Value to add to signal
+ */
+void runPutSignalNonAdaptiveKernel(
+    P2pIbgdaTransportDevice* d_transport,
+    const IbgdaLocalBuffer& localDataBuf,
+    const IbgdaRemoteBuffer& remoteDataBuf,
+    std::size_t nbytes,
+    int signalId,
+    uint64_t signalVal);
+
+/**
+ * Test wait_signal: Receiver waits for signal, then verifies data.
+ *
+ * @param d_transport Device transport handle
+ * @param signalId Signal slot to wait on
+ * @param expectedSignal Expected signal value (GE comparison)
+ * @param d_success Device pointer to success flag
+ */
+void runWaitSignalKernel(
+    P2pIbgdaTransportDevice* d_transport,
+    int signalId,
+    uint64_t expectedSignal,
+    bool* d_success);
+
+/**
+ * Test signal-only operation.
+ *
+ * @param d_transport Device transport handle
+ * @param signalId Signal slot to use
+ * @param signalVal Value to add to signal
+ */
+void runSignalOnlyKernel(
+    P2pIbgdaTransportDevice* d_transport,
+    int signalId,
+    uint64_t signalVal);
+
+/**
+ * Verify data matches expected pattern after transfer.
+ *
+ * @param d_data Device data buffer to verify
+ * @param nbytes Number of bytes to check
+ * @param expectedPattern Expected byte pattern
+ * @param d_success Device pointer to success flag
+ */
+void runVerifyDataKernel(
+    void* d_data,
+    std::size_t nbytes,
+    uint8_t expectedPattern,
+    bool* d_success);
+
+/**
+ * Fill data buffer with a pattern.
+ *
+ * @param d_data Device data buffer to fill
+ * @param nbytes Number of bytes to fill
+ * @param pattern Byte pattern to write
+ */
+void runFillDataKernel(void* d_data, std::size_t nbytes, uint8_t pattern);
+
+} // namespace comms::pipes::tests


### PR DESCRIPTION
Summary:
1) Add foundational buffer types for IBGDA
2) Add device-side per-peer RDMA transport class that provides GPU-initiated RDMA operations using DOCA GPUNetIO high-level APIs:
- put_signal(): RDMA Write with atomic signal for data transfer + notification
- put(): RDMA Write without signal
- signal(): Atomic signal only (no data transfer)
- wait_local(): Wait for local completion (data sent to NIC)
- wait_signal(): Spin-wait for remote signal arrival

Includes component-level unit tests.

Differential Revision: D92107374


