### PR TITLE
remove caffe2 from hipify

### DIFF
--- a/comms/torchcomms/rcclx/tests/unit/cpp/mocks/CachingAllocatorHookMock.hpp
+++ b/comms/torchcomms/rcclx/tests/unit/cpp/mocks/CachingAllocatorHookMock.hpp
@@ -11,11 +11,7 @@ namespace torch::comms::test {
 
 class CachingAllocatorHookMock : public CachingAllocatorHookImpl {
  public:
-  MOCK_METHOD(
-      void,
-      regDeregMem,
-      (const c10::hip::HIPCachingAllocator::TraceEntry& entry),
-      (override));
+  MOCK_METHOD(void, regDeregMem, (const TraceEntry& entry), (override));
   MOCK_METHOD(void, registerComm, (TorchCommRCCLX * comm), (override));
   MOCK_METHOD(void, deregisterComm, (TorchCommRCCLX * comm), (override));
   MOCK_METHOD(void, clear, (), (override));


### PR DESCRIPTION
Summary:
X-link: https://github.com/meta-pytorch/MSLK/pull/131

Reland of https://github.com/pytorch/pytorch/issues/172796.  Which replaced https://github.com/pytorch/pytorch/issues/151845 due to infra issue with pytorchbot PAT and ROCm fork where PR branch was originally hosted.  Which was a reland of https://github.com/pytorch/pytorch/issues/137157.

- "MasqueradingAsCUDA" files and classes thinly wrap their corresponding CUDA classes.
- Do not rename "CUDA" classes to "HIP".

cc sunway513 jithunnair-amd pruthvistony ROCmSupport jataylo hongxiayang naromero77amd pragupta jerrymannil xinyazhang voznesenskym penguinwu EikanWang jgong5 Guobing-Chen XiaobingSuper zhuhaozhe blzheng wenzhe-nrv jiayisunx ipiszy kadeng muchulee8 amjames chauhang aakhundov coconutruben

X-link: https://github.com/pytorch/pytorch/pull/174087

Reviewed By: malfet

Differential Revision: D92063294

Pulled By: atalman


