### PR TITLE
implement the notification of remote NVL import mem release via async-socket in CtranIpcRegCache

### DIFF
--- a/comms/ctran/regcache/IpcRegCacheBase.h
+++ b/comms/ctran/regcache/IpcRegCacheBase.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <fmt/core.h>
+#include <cstring>
 #include <string>
 
 #include <folly/Synchronized.h>
@@ -80,6 +81,68 @@ struct IpcRemHandle {
   std::string toString() const {
     return fmt::format("peerId: {}, basePtr: {}", peerId, basePtr);
   }
+};
+
+// Type of IPC request
+enum class IpcReqType : uint8_t {
+  kDesc = 0, // Memory descriptor for export
+  kRelease = 1, // Release notification
+};
+
+// Maximum length for peer ID string (including null terminator)
+// Format: "hostname:pid" - hostname can be up to 255 chars (DNS limit)
+constexpr size_t kMaxPeerIdLen = 272;
+
+// Unified IPC request structure sent over the network.
+// Used for both memory export (IpcDesc) and release (IpcRelease) requests.
+// The peer checks IpcReqType to determine which callback to invoke.
+struct IpcReq {
+  IpcReqType type{IpcReqType::kRelease};
+  char peerId[kMaxPeerIdLen]{};
+  union {
+    IpcDesc desc;
+    IpcRelease release;
+  };
+
+  IpcReq() : release() {}
+
+  explicit IpcReq(IpcReqType t, const std::string& id) : type(t) {
+    // Copy peerId with bounds checking
+    std::strncpy(peerId, id.c_str(), kMaxPeerIdLen - 1);
+    peerId[kMaxPeerIdLen - 1] = '\0';
+
+    if (t == IpcReqType::kDesc) {
+      new (&desc) IpcDesc();
+    } else {
+      new (&release) IpcRelease();
+    }
+  }
+
+  ~IpcReq() {}
+
+  std::string getPeerId() const {
+    return std::string(peerId);
+  }
+
+  std::string toString() const {
+    if (type == IpcReqType::kDesc) {
+      return fmt::format(
+          "[IpcReq] type: DESC, peerId: {}, {}", peerId, desc.toString());
+    } else {
+      return fmt::format(
+          "[IpcReq] type: RELEASE, peerId: {}, {}", peerId, release.toString());
+    }
+  }
+};
+
+// Callback tracking structure for async IPC requests.
+// Used on the sender side to track whether the request send has completed.
+struct IpcReqCb {
+  IpcReq req;
+  std::atomic<bool> completed{false};
+
+  IpcReqCb() = default;
+  explicit IpcReqCb(IpcReqType t, const std::string& id) : req(t, id) {}
 };
 
 } // namespace regcache


### PR DESCRIPTION
Summary:
### Summary                                                                                                                                                                                              
                                                                                                                                                                                                                     
This diff adds a socket-based asynchronous notification mechanism to IpcRegCache that enables a rank to push memory export and release events to remote peers. When a rank exports memory, it can call `notifyRemoteIpcExport()` to notify peers, which automatically triggers importMem() on the receiving side. Similarly, `notifyRemoteIpcRelease()` notifies peers to release previously imported memory. This push-based approach eliminates the need for peers to poll or use separate control message channels (like IB) for IPC memory coordination. The IpcReqCb structure allows callers to track async request completion via an atomic flag.
                                                                                                                                                                                                                     
  ---                                                                                                                                                                                                                
  New APIs                                                                                                                                                                                                           
  ┌──────────────────────────┬─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐                                     
  │           API            │                                                                     Purpose                                                                     │                                     
  ├──────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤                                     
  │ getServerAddr()          │ Returns the socket address where this rank listens for IPC notifications from peers                                                             │                                     
  ├──────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤                                     
  │ notifyRemoteIpcExport()  │ Sends an async notification to a remote peer to import exported memory. The peer automatically calls importMem() upon receiving                 │                                     
  ├──────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤                                     
  │ notifyRemoteIpcRelease() │ Sends an async notification to a remote peer to release previously imported memory. The peer automatically calls releaseRemReg() upon receiving │                                     
  └──────────────────────────┴─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘                                     
  ---                                                                                                                                                                                                                
  New Data Structures                                                                                                                                                                                                
  ┌────────────┬─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐                                                                                       
  │ Structure  │                                                   Purpose                                                   │                                                                                       
  ├────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────┤                                                                                       
  │ IpcReqType │ Enum distinguishing between export (kDesc) and release (kRelease) request types                             │                                                                                       
  ├────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────┤                                                                                       
  │ IpcReq     │ Unified request structure containing peer ID and either an IpcDesc (for export) or IpcRelease (for release) │                                                                                       
  ├────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────┤                                                                                       
  │ IpcReqCb   │ Callback tracking structure with atomic completed flag for caller to poll async request completion          │                                                                                       
  └────────────┴─────────────────────────────────────────────────────────────────────────────────────────────────────────────┘                                                                                       
  ---                                                                                                                                                                                                                
  New Test                                                                                                                                                                                                           
  ┌────────────────────┬───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐                                                     
  │        Test        │                                                                Purpose                                                                │                                                     
  ├────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤                                                     
  │ ExportReleaseMemCb │ Validates that rank 0 can export memory to multiple peers via socket notifications, and peers automatically import/release the memory │                                                     
  └────────────────────┴───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

Reviewed By: dsjohns2

Differential Revision: D90810098


