### PR TITLE
add version Id to IpcRegElem, IpcRelease, and IpcDesc to distinguish RegElems with same pointer allocated in different times

### DIFF
--- a/comms/ctran/mapper/CtranMapper.cc
+++ b/comms/ctran/mapper/CtranMapper.cc
@@ -473,14 +473,13 @@ commResult_t CtranMapper::remReleaseMem(ctran::regcache::RegElem* regElem) {
 commResult_t CtranMapper::releaseMemCb(int rank, void* msgPtr, void* ctx) {
   auto mapper = reinterpret_cast<CtranMapper*>(ctx);
   auto msg = reinterpret_cast<ControlMsg*>(msgPtr);
-  auto& deregMsg = msg->ipcRls;
   CLOGF_TRACE(
       COLL,
       "CTRAN-MAPPER: Handle received CB ctrlmsg from rank {}: {}",
       rank,
       msg->toString());
   FB_COMMCHECK(mapper->ipcRegCache_->releaseRemReg(
-      mapper->comm->statex_->gPid(rank), deregMsg.base));
+      mapper->comm->statex_->gPid(rank), msg->ipcRls.base, msg->ipcRls.uid));
   return commSuccess;
 }
 
@@ -648,7 +647,7 @@ commResult_t CtranMapper::deregRemReg(struct CtranMapperRemoteAccessKey* rkey) {
           ctranNvl != nullptr,
           "Unexpected rkey with NVL backend but ctranNvl is not initialized");
       FB_COMMCHECK(ipcRegCache_->releaseRemReg(
-          rkey->nvlKey.peerId, rkey->nvlKey.basePtr));
+          rkey->nvlKey.peerId, rkey->nvlKey.basePtr, rkey->nvlKey.uid));
       break;
     }
     default:

--- a/comms/ctran/mapper/tests/CtranMapperUT.cc
+++ b/comms/ctran/mapper/tests/CtranMapperUT.cc
@@ -1181,7 +1181,7 @@ TEST_F(CtranMapperTest, RemoteAccessKeyToString) {
   rkey2.backend = CtranMapperBackend::NVL;
   EXPECT_EQ(
       rkey2.toString(),
-      "backend=NVL, nvlKey=[peerId: host1:1234, basePtr: 0x4567890]");
+      "backend=NVL, nvlKey=[peerId: host1:1234, basePtr: 0x4567890, uid: 0]");
 
   CtranMapperRemoteAccessKey rkey3 = rkey1;
   rkey3.backend = CtranMapperBackend::UNSET;


### PR DESCRIPTION
Summary:
### Add unique ID (uid) to IPC memory registrations                                                                                                                                                                                                                                                                         

Introduces a monotonically increasing unique ID to uniquely identify each IPC memory registration. This prevents incorrect cache lookups when the same virtual address is reused for a new memory allocation after a previous deregistration. For example, if rank A sends `exportMem1`, `releaseMem1`, `exportMem2` to rank B, and rank B receives `exportMem1`, `exportMem2`, and `releaseMem1`, we need unique IDs to differentiate these two `exportMem`

The cache key is now a composite of (base pointer, uid) instead of just base pointer, ensuring correct memory handle resolution across registration/deregistration cycles.

Reviewed By: dsjohns2

Differential Revision: D91979605


