### PR TITLE
MultiPeerDeviceTransport Scaffolding + Host Integration

### DIFF
--- a/comms/pipes/MultiPeerDeviceTransport.cuh
+++ b/comms/pipes/MultiPeerDeviceTransport.cuh
@@ -1,0 +1,374 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cassert>
+#include <cstdint>
+#include "comms/pipes/DeviceSpan.cuh"
+#include "comms/pipes/P2pNvlTransportDevice.cuh"
+#include "comms/pipes/P2pSelfTransportDevice.cuh"
+#include "comms/pipes/ThreadGroup.cuh"
+#include "comms/pipes/Transport.cuh"
+
+namespace comms::pipes {
+
+/**
+ * MULTI_PEER_CHECK_RANK - Bounds checking macro for rank validation
+ *
+ * Validates that target_rank is in range [0, nRanks). This macro is used
+ * throughout MultiPeerDeviceTransport to catch invalid ranks early.
+ *
+ * BEHAVIOR:
+ * - Device code (__CUDA_ARCH__): Prints debug info including file:line,
+ *   block/thread indices, then calls __trap() to abort the kernel.
+ *   This is useful for debugging but cannot be caught by host-side testing.
+ *
+ * - Host code: Uses assert() which can be tested with EXPECT_DEBUG_DEATH
+ *   in debug builds, but is a no-op in release builds.
+ *
+ * USAGE:
+ *   MULTI_PEER_CHECK_PEER_INDEX(targetRank, num_peers());
+ *
+ * TESTED BY:
+ * - Valid peer ranges are tested by all functional tests that use peer indices
+ * - Invalid peer handling is documented here; device-side __trap() cannot be
+ *   unit tested but will produce clear error messages during development
+ *
+ * TODO(D91689639): Replace with PIPES_DEVICE_CHECK_MSG once D91689639 lands
+ */
+#ifdef __CUDA_ARCH__
+#define MULTI_PEER_CHECK_RANK(target_rank, nRanks)                        \
+  do {                                                                    \
+    if (!((target_rank) >= 0 && (target_rank) < (nRanks))) {              \
+      printf(                                                             \
+          "MultiPeerDeviceTransport: target_rank %d out of range [0, %d)" \
+          " at %s:%d block=(%u,%u,%u) thread=(%u,%u,%u)\n",               \
+          (int)(target_rank),                                             \
+          (int)(nRanks),                                                  \
+          __FILE__,                                                       \
+          __LINE__,                                                       \
+          blockIdx.x,                                                     \
+          blockIdx.y,                                                     \
+          blockIdx.z,                                                     \
+          threadIdx.x,                                                    \
+          threadIdx.y,                                                    \
+          threadIdx.z);                                                   \
+      __trap();                                                           \
+    }                                                                     \
+  } while (0)
+#else
+#define MULTI_PEER_CHECK_RANK(target_rank, nRanks) \
+  assert((target_rank) >= 0 && (target_rank) < (nRanks))
+#endif
+
+/**
+ * MULTI_PEER_CHECK_NOT_SELF - Validates target_rank != myRank
+ *
+ * Operations that target a specific peer (send, recv, put, put_signal,
+ * signal_peer, barrier_peer, get_peer_transport) do not support self.
+ * Passing target_rank == myRank traps with a diagnostic message.
+ *
+ * For local (self) operations, use get_self_transport() instead.
+ *
+ * USAGE:
+ *   MULTI_PEER_CHECK_NOT_SELF(target_rank, myRank_);
+ */
+#ifdef __CUDA_ARCH__
+#define MULTI_PEER_CHECK_NOT_SELF(target_rank, myRank)               \
+  do {                                                               \
+    if ((target_rank) == (myRank)) {                                 \
+      printf(                                                        \
+          "MultiPeerDeviceTransport: self-rank %d not supported at " \
+          "%s:%d block=(%u,%u,%u) thread=(%u,%u,%u)\n",              \
+          (int)(target_rank),                                        \
+          __FILE__,                                                  \
+          __LINE__,                                                  \
+          blockIdx.x,                                                \
+          blockIdx.y,                                                \
+          blockIdx.z,                                                \
+          threadIdx.x,                                               \
+          threadIdx.y,                                               \
+          threadIdx.z);                                              \
+      __trap();                                                      \
+    }                                                                \
+  } while (0)
+#else
+#define MULTI_PEER_CHECK_NOT_SELF(target_rank, myRank) \
+  assert((target_rank) != (myRank))
+#endif
+
+/**
+ * MultiPeerDeviceTransport - Unified device-side multi-peer NVLink transport
+ *
+ * Provides a single device object with:
+ * - Rank-based send/recv/put operations
+ *
+ * RANK-BASED API:
+ * All public APIs that target a specific peer accept a target_rank in the
+ * range [0, n_ranks()). Passing target_rank == rank() (self) to peer-
+ * targeting operations will __trap() with a diagnostic message.
+ *
+ * For local (self) operations, use get_self_transport() to access the
+ * self transport directly.
+ *
+ * Utility methods peer_index_to_rank() and rank_to_peer_index() are
+ * provided for converting between peer index and global rank when needed.
+ *
+ * DESIGN:
+ * - Aligned with TorchComm Device API style (D91172575)
+ * - Signal/Barrier use inbox model (one inbox per rank)
+ *
+ * API COEXISTENCE:
+ * This multi-peer API coexists with the existing P2pNvlTransportDevice API:
+ * - P2pNvlTransportDevice: P2P (one-to-one), per-peer signal buffers
+ * - MultiPeerDeviceTransport: Unified API with inbox model, multi-peer coord
+ *
+ * MEMORY ORDERING SEMANTICS
+ * =========================
+ *
+ * Signal Operations (signal_peer, signal_all):
+ * - Release semantics: All prior writes visible before signal
+ * - Uses st_release_sys_global (system-scope release store)
+ *
+ * Wait Operations (wait_signal):
+ * - Acquire semantics: Subsequent reads see peer's writes
+ * - Uses ld_acquire_sys_global (system-scope acquire load)
+ *
+ * Data Transfer (put, send, recv):
+ * - No implicit ordering; pair with signal for visibility guarantee
+ *
+ * Example pattern (rank 0 sends to rank 1):
+ *
+ * // Rank 0 (Sender): target_rank = 1
+ * send(1, group, src, nbytes);
+ * signal_peer(1, group, 0);
+ *
+ * // Rank 1 (Receiver): target_rank = 0
+ * wait_signal(group, 0, CMP_GE, 1);  // data now visible
+ * recv(0, group, dst, nbytes);
+ *
+ * ARCHITECTURE
+ * ============
+ *
+ *   ┌─────────────────────────────────────────────────────────────────┐
+ *   │  Host Control Path                                              │
+ *   ├─────────────────────────────────────────────────────────────────┤
+ *   │  MultiPeerNvlTransport (host RAII object)                       │
+ *   │  ├── GpuMemHandler[] (data, state, signal, barrier buffers)     │
+ *   │  ├── P2pNvlTransportDevice[] (per-peer NVLink handles)          │
+ *   │  └── IBootstrap (collective handle exchange)                    │
+ *   ├─────────────────────────────────────────────────────────────────┤
+ *   │  GPU Data Path (returned by getMultiPeerDeviceTransport())      │
+ *   ├─────────────────────────────────────────────────────────────────┤
+ *   │  MultiPeerDeviceTransport                                       │
+ *   │  ├── DeviceSpan<Transport> transports_ (indexed by global rank) │
+ *   │  │   ├── Transport[0]: SELF or P2P_NVL                          │
+ *   │  │   ├── Transport[1]: P2P_NVL                                  │
+ *   │  │   └── ...                                                    │
+ *   └─────────────────────────────────────────────────────────────────┘
+ *
+ * USAGE:
+ *   // Host setup
+ *   MultiPeerNvlTransport hostTransport(myRank, nRanks, bootstrap, config);
+ *   hostTransport.exchange();
+ *   auto transport = hostTransport.getMultiPeerDeviceTransport();
+ *
+ *   // Kernel (pass by const reference to avoid copy)
+ *   __global__ void myKernel(const MultiPeerDeviceTransport& transport, ...) {
+ *     auto group = make_warp_group();
+ *
+ *     // Data transfer (target_rank in [0, n_ranks()), must not be self)
+ *     transport.send(target_rank, group, src, nbytes);
+ *
+ *     // Signaling (rank-based)
+ *     transport.signal_peer(target_rank, group, 0, SIGNAL_ADD, 1);
+ *     transport.wait_signal(group, 0, CMP_GE, 1);
+ *
+ *     // Barrier
+ *     transport.barrier(group, 0);
+ *   }
+ */
+class MultiPeerDeviceTransport {
+ public:
+  __host__ __device__ MultiPeerDeviceTransport() = default;
+
+  MultiPeerDeviceTransport(const MultiPeerDeviceTransport&) = delete;
+  MultiPeerDeviceTransport& operator=(const MultiPeerDeviceTransport&) = delete;
+
+  // Move is allowed
+  MultiPeerDeviceTransport(MultiPeerDeviceTransport&&) = default;
+  MultiPeerDeviceTransport& operator=(MultiPeerDeviceTransport&&) = delete;
+
+  __host__ __device__ ~MultiPeerDeviceTransport() = default;
+
+  /**
+   * Construct a MultiPeerDeviceTransport
+   *
+   * @param myRank This rank's ID (must be in range [0, nRanks))
+   * @param nRanks Total number of ranks
+   * @param transports Span of Transport objects for each peer (size = nRanks)
+   */
+  __host__ __device__ MultiPeerDeviceTransport(
+      int myRank,
+      int nRanks,
+      DeviceSpan<Transport> transports)
+      : myRank_(myRank), nRanks_(nRanks), transports_(transports) {
+    // Validate constraints
+    assert(nRanks > 0);
+    assert(myRank >= 0 && myRank < nRanks);
+  }
+
+  // ===========================================================================
+  // Metadata
+  // ===========================================================================
+
+  __device__ __forceinline__ int rank() const {
+    return myRank_;
+  }
+
+  __device__ __forceinline__ int n_ranks() const {
+    return nRanks_;
+  }
+
+  // ===========================================================================
+  // Peer Iteration Helpers
+  // ===========================================================================
+
+  /**
+   * num_peers - Get number of peer connections (excludes self)
+   *
+   * @return Number of peers (nRanks - 1)
+   */
+  __host__ __device__ __forceinline__ int num_peers() const {
+    return nRanks_ - 1;
+  }
+
+  /**
+   * peer_index_to_rank - Convert peer index back to global rank
+   *
+   * When iterating over peers by index (0 to num_peers()-1), this converts
+   * the index back to the corresponding global rank, skipping self.
+   *
+   * Example for myRank=2, nRanks=4:
+   *   peer_index_to_rank(0) -> 0
+   *   peer_index_to_rank(1) -> 1
+   *   peer_index_to_rank(2) -> 3  (skips self at rank 2)
+   *
+   * @param index Index into peer list (0 to num_peers()-1)
+   * @return Global rank of the peer at this index
+   */
+  __host__ __device__ __forceinline__ int peer_index_to_rank(int index) const {
+    // If index < myRank, rank = index; else rank = index + 1 (skip self)
+    return (index < myRank_) ? index : (index + 1);
+  }
+
+  // ===========================================================================
+  // Send/Recv Operations
+  // ===========================================================================
+
+  /**
+   * send - Send data to a specific peer over NVLink
+   *
+   * For local copies (self transport), use:
+   *   get_self_transport()->self.put(group, dst, src, nbytes)
+   *
+   * Uses NVLink pipelined staged transfer.
+   *
+   * @param target_rank Global rank in [0, n_ranks()), must not be self
+   * @param group ThreadGroup for cooperative processing
+   * @param srcbuff Source buffer (local GPU memory)
+   * @param nbytes Number of bytes to send
+   * @param call_index Index for multiple concurrent calls (default: 0)
+   */
+  __device__ __forceinline__ void send(
+      int target_rank,
+      ThreadGroup& group,
+      void* srcbuff,
+      std::size_t nbytes,
+      uint32_t call_index = 0) {
+    MULTI_PEER_CHECK_RANK(target_rank, nRanks_);
+    MULTI_PEER_CHECK_NOT_SELF(target_rank, myRank_);
+    transports_[target_rank].p2p_nvl.send(group, srcbuff, nbytes, call_index);
+  }
+
+  /**
+   * recv - Receive data from a specific peer over NVLink
+   *
+   * For local copies (self transport), use:
+   *   get_self_transport()->self.put(group, dst, src, nbytes)
+   *
+   * @param target_rank Global rank in [0, n_ranks()), must not be self
+   * @param group ThreadGroup for cooperative processing
+   * @param dstbuff Destination buffer (local GPU memory)
+   * @param nbytes Number of bytes to receive
+   * @param call_index Index for multiple concurrent calls (default: 0)
+   */
+  __device__ __forceinline__ void recv(
+      int target_rank,
+      ThreadGroup& group,
+      void* dstbuff,
+      std::size_t nbytes,
+      uint32_t call_index = 0) {
+    MULTI_PEER_CHECK_RANK(target_rank, nRanks_);
+    MULTI_PEER_CHECK_NOT_SELF(target_rank, myRank_);
+    transports_[target_rank].p2p_nvl.recv(group, dstbuff, nbytes, call_index);
+  }
+
+  // ===========================================================================
+  // Advanced Access
+  // ===========================================================================
+
+  /**
+   * get_peer_transport - Get Transport pointer for specific peer
+   *
+   * @param target_rank Global rank in [0, n_ranks()), must not be self
+   * @return Pointer to Transport object for the peer
+   */
+  __device__ __forceinline__ Transport* get_peer_transport(int target_rank) {
+    MULTI_PEER_CHECK_RANK(target_rank, nRanks_);
+    MULTI_PEER_CHECK_NOT_SELF(target_rank, myRank_);
+    return &transports_[target_rank];
+  }
+
+  /**
+   * get_peer_transport - Const version for read-only access
+   *
+   * @param target_rank Global rank in [0, n_ranks()), must not be self
+   * @return Const pointer to Transport object for the peer
+   */
+  __device__ __forceinline__ const Transport* get_peer_transport(
+      int target_rank) const {
+    MULTI_PEER_CHECK_RANK(target_rank, nRanks_);
+    MULTI_PEER_CHECK_NOT_SELF(target_rank, myRank_);
+    return &transports_[target_rank];
+  }
+
+  /**
+   * get_self_transport - Get Transport pointer for this rank
+   *
+   * @return Pointer to this rank's own Transport object
+   */
+  __device__ __forceinline__ Transport* get_self_transport() {
+    return &transports_[myRank_];
+  }
+
+  /**
+   * get_self_transport - Const version for read-only access
+   *
+   * @return Const pointer to this rank's own Transport object
+   */
+  __device__ __forceinline__ const Transport* get_self_transport() const {
+    return &transports_[myRank_];
+  }
+
+ private:
+  // ===========================================================================
+  // Member Variables
+  // ===========================================================================
+
+  const int myRank_{-1};
+  const int nRanks_{0};
+  const DeviceSpan<Transport> transports_;
+};
+
+} // namespace comms::pipes

--- a/comms/pipes/MultiPeerNvlTransport.cc
+++ b/comms/pipes/MultiPeerNvlTransport.cc
@@ -4,6 +4,9 @@
 
 #include <vector>
 
+#include "comms/pipes/MultiPeerDeviceTransport.cuh"
+#include "comms/utils/checks.h"
+
 namespace comms::pipes {
 
 MultiPeerNvlTransport::MultiPeerNvlTransport(
@@ -14,7 +17,22 @@ MultiPeerNvlTransport::MultiPeerNvlTransport(
     : myRank_(myRank),
       nRanks_(nRanks),
       bootstrap_(std::move(bootstrap)),
-      config_(multiPeerNvlTransportConfig) {
+      config_(multiPeerNvlTransportConfig),
+      memSharingMode_(GpuMemHandler::detectBestMode()) {
+  // ===========================================================================
+  // Buffer Allocation
+  // ===========================================================================
+  //
+  // Memory allocation uses RAII pattern via std::unique_ptr<GpuMemHandler>.
+  // If any allocation or initialization fails and throws an exception:
+  // - Previously allocated GpuMemHandler objects are automatically cleaned up
+  //   when the exception propagates and unique_ptr destructors run
+  // - No manual cleanup is needed in the constructor
+  // - The destructor only needs to handle successfully constructed objects
+  //
+  // Allocation order: signal -> data -> state
+  // Each handler's destructor will free its GPU memory if constructed.
+
   // Calculate per-peer buffer sizes with pipelining
   perPeerDataBufferSize_ = config_.pipelineDepth * config_.dataBufferSize;
 
@@ -33,52 +51,40 @@ MultiPeerNvlTransport::MultiPeerNvlTransport(
   const std::size_t totalSignalBufferSize =
       perPeerSignalBufferSize_ * (nRanks_ - 1);
 
-  // Detect memory sharing mode once and use for both handlers
-  // This avoids redundant mode detection (fabric check is cached but this is
-  // cleaner)
-  const auto memSharingMode = GpuMemHandler::detectBestMode();
-
   signalBufferHandler_ = std::make_unique<GpuMemHandler>(
-      bootstrap_, myRank_, nRanks_, totalSignalBufferSize, memSharingMode);
+      bootstrap_, myRank_, nRanks_, totalSignalBufferSize, memSharingMode_);
 
   dataBufferHandler_ = std::make_unique<GpuMemHandler>(
-      bootstrap_, myRank_, nRanks_, totalDataBufferSize, memSharingMode);
+      bootstrap_, myRank_, nRanks_, totalDataBufferSize, memSharingMode_);
 
   stateBufferHandler_ = std::make_unique<GpuMemHandler>(
-      bootstrap_, myRank_, nRanks_, totalChunkStateBufferSize, memSharingMode);
+      bootstrap_, myRank_, nRanks_, totalChunkStateBufferSize, memSharingMode_);
 
   // Initialize state buffer to READY_TO_SEND for all pipeline slots
   auto statePtr =
       static_cast<ChunkState*>(stateBufferHandler_->getLocalDeviceMemPtr());
   const std::size_t totalNumChunksAllPeers = numChunksPerPeer * (nRanks_ - 1);
   std::vector<ChunkState> initStates(totalNumChunksAllPeers);
-  auto cudaErr = cudaMemcpy(
+  CUDA_CHECK(cudaMemcpy(
       statePtr,
       initStates.data(),
       totalChunkStateBufferSize,
-      cudaMemcpyDefault);
-  if (cudaErr != cudaSuccess) {
-    throw std::runtime_error(
-        "cudaMemcpy failed in state buffer initialization");
-  }
+      cudaMemcpyDefault));
 
   // Initialize signal state buffer to 0 for all ranks
   auto signalPtr =
       static_cast<SignalState*>(signalBufferHandler_->getLocalDeviceMemPtr());
   std::vector<SignalState> signalInitStates(
       config_.signalCount * (nRanks_ - 1));
-  cudaErr = cudaMemcpy(
+  CUDA_CHECK(cudaMemcpy(
       signalPtr,
       signalInitStates.data(),
       totalSignalBufferSize,
-      cudaMemcpyDefault);
-  if (cudaErr != cudaSuccess) {
-    throw std::runtime_error(
-        "cudaMemcpy failed in signal state buffer initialization");
-  }
-};
+      cudaMemcpyDefault));
+}
 
 void MultiPeerNvlTransport::exchange() {
+  // Exchange P2P transport buffer pointers
   dataBufferHandler_->exchangeMemPtrs();
   stateBufferHandler_->exchangeMemPtrs();
   signalBufferHandler_->exchangeMemPtrs();
@@ -174,6 +180,47 @@ P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
 
   return P2pNvlTransportDevice(
       myRank_, peerRank, options, localState, remoteState);
+}
+
+DeviceSpan<Transport> MultiPeerNvlTransport::getDeviceTransports() {
+  // Lazy initialization of device-accessible arrays
+  if (!multiPeerInitialized_) {
+    initializeTransportsArray();
+    multiPeerInitialized_ = true;
+  }
+
+  return DeviceSpan<Transport>(
+      static_cast<Transport*>(transportsDevice_->get()), nRanks_);
+}
+
+MultiPeerDeviceTransport MultiPeerNvlTransport::getMultiPeerDeviceTransport() {
+  return MultiPeerDeviceTransport(myRank_, nRanks_, getDeviceTransports());
+}
+
+void MultiPeerNvlTransport::initializeTransportsArray() {
+  // Allocate device memory for Transport objects using DeviceBuffer
+  transportsDevice_ =
+      std::make_unique<meta::comms::DeviceBuffer>(nRanks_ * sizeof(Transport));
+
+  // Build host-side Transport array, then batch copy to device
+  // Note: We use move semantics since Transport is non-copyable
+  std::vector<Transport> hostTransports;
+  hostTransports.reserve(nRanks_);
+  for (int rank = 0; rank < nRanks_; ++rank) {
+    if (rank == myRank_) {
+      hostTransports.emplace_back(P2pSelfTransportDevice());
+    } else {
+      hostTransports.emplace_back(getP2pTransportDevice(rank));
+    }
+  }
+
+  // Single batched memcpy for all Transport objects
+  // This works because Transport is designed for byte-copy (see Transport.cuh)
+  CUDA_CHECK(cudaMemcpy(
+      transportsDevice_->get(),
+      hostTransports.data(),
+      nRanks_ * sizeof(Transport),
+      cudaMemcpyDefault));
 }
 
 } // namespace comms::pipes

--- a/comms/pipes/MultiPeerNvlTransport.h
+++ b/comms/pipes/MultiPeerNvlTransport.h
@@ -2,10 +2,18 @@
 
 #pragma once
 
+#include <memory>
+
 #include "comms/pipes/GpuMemHandler.h"
 #include "comms/pipes/P2pNvlTransportDevice.cuh"
+#include "comms/pipes/Transport.cuh"
+#include "comms/utils/CudaRAII.h"
 
 namespace comms::pipes {
+
+// Forward declarations for multi-peer device transport types
+class MultiPeerDeviceTransport;
+struct Transport;
 
 /**
  * Configuration for multi-peer NVLink transport.
@@ -31,8 +39,8 @@ struct MultiPeerNvlTransportConfig {
   std::size_t pipelineDepth{0};
 
   // Number of signal slots per peer for signal/wait communication.
-  // Larger = more signal available for parallelism.
-  // Typical: 1-num of block for most workloads.
+  // Larger = more signals available for parallelism.
+  // Typical: 1-num of blocks for most workloads.
   std::size_t signalCount{1};
 };
 
@@ -70,6 +78,12 @@ struct MultiPeerNvlTransportConfig {
  */
 class MultiPeerNvlTransport {
  public:
+  // Non-copyable and non-movable (CUDA resources cannot be safely moved)
+  MultiPeerNvlTransport(const MultiPeerNvlTransport&) = delete;
+  MultiPeerNvlTransport& operator=(const MultiPeerNvlTransport&) = delete;
+  MultiPeerNvlTransport(MultiPeerNvlTransport&&) = delete;
+  MultiPeerNvlTransport& operator=(MultiPeerNvlTransport&&) = delete;
+
   /**
    * Constructor - Initialize multi-peer NVLink transport
    *
@@ -96,6 +110,13 @@ class MultiPeerNvlTransport {
       int nRanks,
       std::shared_ptr<ctran::bootstrap::IBootstrap> bootstrap,
       const MultiPeerNvlTransportConfig& multiPeerNvlTransportConfig);
+
+  /**
+   * Destructor - Clean up CUDA resources
+   *
+   * Frees device memory allocated for Transport array.
+   */
+  ~MultiPeerNvlTransport() = default;
 
   /**
    * exchange - Exchange memory handles across all ranks
@@ -142,6 +163,40 @@ class MultiPeerNvlTransport {
   P2pNvlTransportDevice getP2pTransportDevice(int peerRank);
 
   /**
+   * getMultiPeerDeviceTransport - Get unified device handle for all peers
+   *
+   * Returns a MultiPeerDeviceTransport that provides:
+   * - Peer-indexed send/recv operations
+   *
+   * PRECONDITION: exchange() must have been called by all ranks first.
+   *
+   * The returned device handle is designed for multi-peer collective operations
+   * where a single kernel needs to communicate with multiple peers.
+   *
+   * @return MultiPeerDeviceTransport handle for use in CUDA kernels
+   *
+   * @note Thread-safe after exchange() completes
+   * @note The returned handle is copyable and can be passed to multiple kernels
+   */
+  MultiPeerDeviceTransport getMultiPeerDeviceTransport();
+
+  /**
+   * getDeviceTransports - Get device-accessible array of Transport objects
+   *
+   * Returns a DeviceSpan of Transport objects indexed by global rank.
+   * Each element is either a P2pNvlTransportDevice (for peer ranks) or a
+   * P2pSelfTransportDevice (for myRank).
+   *
+   * PRECONDITION: exchange() must have been called by all ranks first.
+   *
+   * @return DeviceSpan<Transport> of size nRanks, indexed by global rank
+   *
+   * @note Thread-safe after exchange() completes
+   * @note The span points to device memory owned by this transport
+   */
+  DeviceSpan<Transport> getDeviceTransports();
+
+  /**
    * Check if fabric-based transport is supported (H100+, CUDA 12.3+).
    *
    * Note: Even if this returns false, the transport will still work using
@@ -163,6 +218,17 @@ class MultiPeerNvlTransport {
   }
 
  private:
+  // ==========================================================================
+  // Lazy initialization helpers for getMultiPeerDeviceTransport()
+  // ==========================================================================
+
+  // Initialize transports array on device (both P2P and SELF transports)
+  void initializeTransportsArray();
+
+  // ==========================================================================
+  // Member variables
+  // ==========================================================================
+
   const int myRank_{-1};
   const int nRanks_{-1};
   std::shared_ptr<ctran::bootstrap::IBootstrap> bootstrap_;
@@ -174,10 +240,21 @@ class MultiPeerNvlTransport {
   std::unique_ptr<GpuMemHandler> stateBufferHandler_;
   std::unique_ptr<GpuMemHandler> signalBufferHandler_;
 
+  // Device-accessible Transport array for multi-peer transport
+  // Allocated on device and populated in getMultiPeerDeviceTransport()
+  // Uses DeviceBuffer instead of GpuMemHandler since no exchange is needed
+  std::unique_ptr<meta::comms::DeviceBuffer> transportsDevice_;
+
   // Per-peer buffer sizes for offset calculation
   std::size_t perPeerDataBufferSize_{0};
   std::size_t perPeerChunkStateBufferSize_{0};
   std::size_t perPeerSignalBufferSize_{0};
+
+  // Flag to track if multi-peer device arrays have been initialized
+  bool multiPeerInitialized_{false};
+
+  // Cached memory sharing mode (detected once in constructor)
+  MemSharingMode memSharingMode_;
 };
 
 } // namespace comms::pipes

--- a/comms/pipes/Transport.cuh
+++ b/comms/pipes/Transport.cuh
@@ -9,6 +9,19 @@
 #include "comms/pipes/P2pSelfTransportDevice.cuh"
 
 namespace comms::pipes {
+// Transport union members must be safe for cudaMemcpy to device.
+// Requirements:
+// - Standard layout: predictable byte representation, no hidden members
+// - Trivially destructible: source destructor after memcpy is a no-op
+// See MultiPeerNvlTransport::initializeTransportsArray().
+static_assert(
+    std::is_standard_layout_v<P2pSelfTransportDevice> &&
+        std::is_trivially_destructible_v<P2pSelfTransportDevice>,
+    "P2pSelfTransportDevice must be standard layout with trivial destructor");
+static_assert(
+    std::is_standard_layout_v<P2pNvlTransportDevice> &&
+        std::is_trivially_destructible_v<P2pNvlTransportDevice>,
+    "P2pNvlTransportDevice must be standard layout with trivial destructor");
 
 /**
  * Transport type tag for discriminated union.

--- a/comms/pipes/benchmarks/MultiPeerBenchmark.cc
+++ b/comms/pipes/benchmarks/MultiPeerBenchmark.cc
@@ -1,0 +1,326 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+
+#include <folly/init/Init.h>
+#include <folly/logging/xlog.h>
+#include <gflags/gflags.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <iomanip>
+#include <sstream>
+#include <vector>
+
+#include "comms/common/DeviceConstants.cuh"
+#include "comms/pipes/MultiPeerNvlTransport.h"
+#include "comms/pipes/benchmarks/MultiPeerBenchmark.cuh"
+#include "comms/testinfra/mpi/MpiBootstrap.h"
+#include "comms/testinfra/mpi/MpiTestUtils.h"
+#include "comms/utils/CudaRAII.h"
+
+// Command-line configurable parameters
+DEFINE_int32(benchmark_iters, 50, "Number of benchmark iterations");
+DEFINE_int32(steps_per_iter, 100, "Number of steps per kernel launch");
+DEFINE_int32(warmup_iters, 10, "Number of warmup iterations");
+
+using meta::comms::CudaEvent;
+using meta::comms::MpiBaseTestFixture;
+using meta::comms::MPIEnvironmentBase;
+
+namespace comms::pipes::benchmark {
+namespace {
+
+constexpr int kDefaultThreads = 128; // Thread configuration
+
+// =============================================================================
+// Runtime Configuration Helpers
+// =============================================================================
+
+// Validate flag values are positive
+inline int getWarmupIters() {
+  CHECK_GT(FLAGS_warmup_iters, 0) << "warmup_iters must be positive";
+  return FLAGS_warmup_iters;
+}
+
+inline int getBenchmarkIters() {
+  CHECK_GT(FLAGS_benchmark_iters, 0) << "benchmark_iters must be positive";
+  return FLAGS_benchmark_iters;
+}
+
+inline int getStepsPerIter() {
+  CHECK_GT(FLAGS_steps_per_iter, 0) << "steps_per_iter must be positive";
+  return FLAGS_steps_per_iter;
+}
+
+// =============================================================================
+// Configuration and Results
+// =============================================================================
+
+struct MultiPeerBenchConfig {
+  int numBlocks{1};
+  bool useBlockGroups{false};
+  std::string name;
+
+  // Calculate number of thread groups (and required slots)
+  int numGroups() const {
+    return useBlockGroups
+        ? numBlocks
+        : numBlocks * (kDefaultThreads / comms::device::kWarpSize);
+  }
+
+  // Get scope string for display (returns const char* for efficiency)
+  const char* scopeString() const {
+    return useBlockGroups ? "block" : "warp";
+  }
+};
+
+struct MultiPeerBenchResult {
+  std::string configName;
+  int nRanks{};
+  std::string groupScope;
+  float latencyUs{};
+};
+
+// =============================================================================
+// Configuration Helpers
+// =============================================================================
+
+// Single source of truth for all configurations
+std::vector<MultiPeerBenchConfig> getStandardConfigs(bool reduced = false) {
+  // Full configuration list
+  static const std::vector<MultiPeerBenchConfig> kAllConfigs = {
+      {.numBlocks = 1, .useBlockGroups = false, .name = "1b_warp"},
+      {.numBlocks = 4, .useBlockGroups = false, .name = "4b_warp"},
+      {.numBlocks = 16, .useBlockGroups = false, .name = "16b_warp"},
+      {.numBlocks = 1, .useBlockGroups = true, .name = "1b_block"},
+      {.numBlocks = 4, .useBlockGroups = true, .name = "4b_block"},
+      {.numBlocks = 16, .useBlockGroups = true, .name = "16b_block"},
+  };
+
+  if (!reduced) {
+    return kAllConfigs;
+  }
+
+  // Reduced set for expensive operations (SignalAll) - filter from full list
+  std::vector<MultiPeerBenchConfig> filtered;
+  filtered.reserve(4);
+  for (const auto& c : kAllConfigs) {
+    if (c.numBlocks <= 4) {
+      filtered.push_back(c);
+    }
+  }
+  return filtered;
+}
+
+// Calculate max slots with validation for empty config list
+inline int getMaxSlots(const std::vector<MultiPeerBenchConfig>& configs) {
+  CHECK(!configs.empty()) << "Config list cannot be empty";
+  int maxSlots = 0;
+  for (const auto& c : configs) {
+    maxSlots = std::max(maxSlots, c.numGroups());
+  }
+  return maxSlots;
+}
+
+// =============================================================================
+// Benchmark Fixture
+// =============================================================================
+
+class MultiPeerBenchmarkFixture : public MpiBaseTestFixture {
+ protected:
+  void SetUp() override {
+    MpiBaseTestFixture::SetUp();
+    ASSERT_EQ(cudaSetDevice(localRank), cudaSuccess);
+    ASSERT_EQ(cudaStreamCreate(&stream_), cudaSuccess);
+  }
+
+  void TearDown() override {
+    ASSERT_EQ(cudaStreamDestroy(stream_), cudaSuccess);
+    MpiBaseTestFixture::TearDown();
+  }
+
+  // -------------------------------------------------------------------------
+  // Timing Result Structure
+  // -------------------------------------------------------------------------
+
+  struct TimingResult {
+    float avgLatencyUs{0.0f};
+    bool success{true};
+  };
+
+  // -------------------------------------------------------------------------
+  // Benchmark Execution Helper
+  // -------------------------------------------------------------------------
+
+  // Note: Lambda returns cudaError_t to avoid ASSERT inside lambda issues
+  template <typename LaunchFn>
+  TimingResult runBenchmark(
+      LaunchFn launchKernel,
+      int stepsPerIter,
+      bool useMpiBarrier = true) {
+    const int warmupIters = getWarmupIters();
+    const int benchIters = getBenchmarkIters();
+
+    TimingResult result;
+
+    // --- Warmup Phase ---
+    if (useMpiBarrier) {
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    }
+
+    for (int i = 0; i < warmupIters; ++i) {
+      cudaError_t err = launchKernel();
+      if (err != cudaSuccess) {
+        XLOGF(
+            ERR,
+            "Kernel launch failed during warmup: {}",
+            cudaGetErrorString(err));
+        result.success = false;
+        return result;
+      }
+      err = cudaStreamSynchronize(stream_);
+      if (err != cudaSuccess) {
+        XLOGF(
+            ERR,
+            "Stream sync failed during warmup: {}",
+            cudaGetErrorString(err));
+        result.success = false;
+        return result;
+      }
+    }
+
+    // Verify no CUDA errors accumulated after warmup
+    cudaError_t lastErr = cudaGetLastError();
+    if (lastErr != cudaSuccess) {
+      XLOGF(
+          ERR,
+          "CUDA error detected after warmup: {}",
+          cudaGetErrorString(lastErr));
+      result.success = false;
+      return result;
+    }
+
+    if (useMpiBarrier) {
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    }
+
+    // --- Batch Timing for Average ---
+    CudaEvent batchStart, batchStop;
+
+    cudaError_t err = cudaEventRecord(batchStart.get(), stream_);
+    if (err != cudaSuccess) {
+      result.success = false;
+      return result;
+    }
+
+    for (int i = 0; i < benchIters; ++i) {
+      err = launchKernel();
+      if (err != cudaSuccess) {
+        result.success = false;
+        return result;
+      }
+    }
+
+    err = cudaEventRecord(batchStop.get(), stream_);
+    if (err != cudaSuccess) {
+      result.success = false;
+      return result;
+    }
+
+    err = cudaStreamSynchronize(stream_);
+    if (err != cudaSuccess) {
+      result.success = false;
+      return result;
+    }
+
+    float totalTimeMs = 0.0f;
+    err = cudaEventElapsedTime(&totalTimeMs, batchStart.get(), batchStop.get());
+    if (err != cudaSuccess) {
+      result.success = false;
+      return result;
+    }
+
+    // Calculate average per-step latency
+    int totalSteps = benchIters * stepsPerIter;
+    result.avgLatencyUs = (totalTimeMs / totalSteps) * 1000.0f;
+
+    if (useMpiBarrier) {
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    }
+
+    return result;
+  }
+
+  // -------------------------------------------------------------------------
+  // Unified Table Printing
+  // -------------------------------------------------------------------------
+
+  void printResultsTable(
+      const std::string& title,
+      const std::string& latencyLabel,
+      const std::vector<MultiPeerBenchResult>& results,
+      bool showRanks = true) {
+    if (globalRank != 0) {
+      return;
+    }
+
+    std::stringstream ss;
+    ss << "\n";
+    ss << "========================================================================\n";
+    ss << "     " << title << "\n";
+    ss << "========================================================================\n";
+
+    // Header
+    ss << std::left << std::setw(12) << "Config";
+    if (showRanks) {
+      ss << std::right << std::setw(8) << "nRanks";
+    }
+    ss << std::right << std::setw(10) << "Scope" << std::right << std::setw(16)
+       << "Latency (us)\n";
+    ss << "------------------------------------------------------------------------\n";
+
+    // Rows
+    for (const auto& r : results) {
+      ss << std::left << std::setw(12) << r.configName;
+      if (showRanks) {
+        ss << std::right << std::setw(8) << r.nRanks;
+      }
+      ss << std::right << std::setw(10) << r.groupScope << std::right
+         << std::setw(16) << std::fixed << std::setprecision(3) << r.latencyUs
+         << "\n";
+    }
+
+    ss << "========================================================================\n";
+    ss << latencyLabel << "\n";
+    ss << "Each measurement: " << getBenchmarkIters() << " iterations x "
+       << getStepsPerIter() << " steps/iter\n";
+    ss << "========================================================================\n\n";
+
+    XLOG(INFO) << ss.str();
+  }
+
+  cudaStream_t stream_{};
+};
+
+// =============================================================================
+// Benchmark Test Cases
+// =============================================================================
+//
+// Individual benchmark tests (BarrierLatency, SignalAllLatency, etc.) are
+// added in subsequent diffs alongside their respective primitive
+// implementations:
+// - D92190695: DeviceSignal -> SignalAllLatency, SignalPingPongLatency
+// - D92190696: DeviceBarrier -> BarrierLatency
+//
+// =============================================================================
+
+} // namespace
+} // namespace comms::pipes::benchmark
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new MPIEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/pipes/benchmarks/MultiPeerBenchmark.cu
+++ b/comms/pipes/benchmarks/MultiPeerBenchmark.cu
@@ -1,0 +1,45 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/ThreadGroup.cuh"
+#include "comms/pipes/benchmarks/MultiPeerBenchmark.cuh"
+
+namespace comms::pipes::benchmark {
+
+// =============================================================================
+// Thread Group Helpers
+// =============================================================================
+
+template <SyncScope S>
+__device__ __forceinline__ auto makeGroup() {
+  return make_thread_group(S);
+}
+
+// Compute unique slot index for current thread group
+// Returns int to match barrier/signal slot API expectations
+template <SyncScope S>
+__device__ __forceinline__ int computeSlotIndex() {
+  if constexpr (S == SyncScope::BLOCK) {
+    // One slot per block
+    return static_cast<int>(blockIdx.x);
+  } else {
+    // One slot per warp - use comms::device::kWarpSize
+    auto warpsPerBlock = blockDim.x / comms::device::kWarpSize;
+    auto warpIdInBlock = threadIdx.x / comms::device::kWarpSize;
+    return static_cast<int>(blockIdx.x * warpsPerBlock + warpIdInBlock);
+  }
+}
+
+// =============================================================================
+// Explicit Template Instantiations for Helper Functions
+// =============================================================================
+
+// Note: These helpers are used by benchmark kernels added in later diffs.
+// The explicit instantiations ensure the templates are available for linking.
+
+template __device__ auto makeGroup<SyncScope::WARP>();
+template __device__ auto makeGroup<SyncScope::BLOCK>();
+
+template __device__ int computeSlotIndex<SyncScope::WARP>();
+template __device__ int computeSlotIndex<SyncScope::BLOCK>();
+
+} // namespace comms::pipes::benchmark

--- a/comms/pipes/benchmarks/MultiPeerBenchmark.cuh
+++ b/comms/pipes/benchmarks/MultiPeerBenchmark.cuh
@@ -1,0 +1,13 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include "comms/common/DeviceConstants.cuh"
+#include "comms/pipes/MultiPeerDeviceTransport.cuh"
+#include "comms/pipes/ThreadGroup.cuh"
+
+namespace comms::pipes::benchmark {
+
+// Use SyncScope from ThreadGroup.cuh for thread group type selection
+
+} // namespace comms::pipes::benchmark

--- a/comms/pipes/tests/MultiPeerDeviceTransportTest.cc
+++ b/comms/pipes/tests/MultiPeerDeviceTransportTest.cc
@@ -1,0 +1,256 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+#include <numeric>
+#include <vector>
+
+#include "comms/pipes/MultiPeerDeviceTransport.cuh"
+#include "comms/pipes/Transport.cuh"
+#include "comms/pipes/tests/MultiPeerDeviceTransportTest.cuh"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/CudaRAII.h"
+
+using meta::comms::DeviceBuffer;
+
+namespace comms::pipes {
+
+class MultiPeerDeviceTransportTestFixture : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    CUDACHECK_TEST(cudaSetDevice(0));
+  }
+
+  void TearDown() override {
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+  }
+};
+
+// =============================================================================
+// MultiPeerDeviceTransport Tests
+// =============================================================================
+
+TEST_F(
+    MultiPeerDeviceTransportTestFixture,
+    MultiPeerDeviceTransportConstruction) {
+  const int myRank = 2;
+  const int nRanks = 4;
+
+  DeviceBuffer resultsBuffer(2 * sizeof(int));
+  auto results_d = static_cast<int*>(resultsBuffer.get());
+
+  test::testMultiPeerDeviceTransportConstruction(myRank, nRanks, results_d);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<int> results_h(2);
+  CUDACHECK_TEST(cudaMemcpy(
+      results_h.data(), results_d, 2 * sizeof(int), cudaMemcpyDeviceToHost));
+
+  EXPECT_EQ(results_h[0], myRank) << "rank() should return " << myRank;
+  EXPECT_EQ(results_h[1], nRanks) << "nRanks() should return " << nRanks;
+}
+
+// =============================================================================
+// Edge Cases
+// =============================================================================
+
+TEST_F(MultiPeerDeviceTransportTestFixture, MaxRanksTransport) {
+  // Test with a high rank count to verify construction works
+  // (actual max depends on hardware: H100=8, GB200=72)
+  const int myRank = 7;
+  const int nRanks = 8;
+
+  DeviceBuffer resultsBuffer(2 * sizeof(int));
+  auto results_d = static_cast<int*>(resultsBuffer.get());
+
+  test::testMultiPeerDeviceTransportConstruction(myRank, nRanks, results_d);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<int> results_h(2);
+  CUDACHECK_TEST(cudaMemcpy(
+      results_h.data(), results_d, 2 * sizeof(int), cudaMemcpyDeviceToHost));
+
+  EXPECT_EQ(results_h[0], myRank) << "rank() should return " << myRank;
+  EXPECT_EQ(results_h[1], nRanks) << "nRanks() should return " << nRanks;
+}
+
+// =============================================================================
+// Self-Transport Tests (via get_transport())
+// =============================================================================
+
+TEST_F(MultiPeerDeviceTransportTestFixture, GetTransportReturnsCorrectType) {
+  // Test that get_transport() returns a valid Transport with SELF type
+  // when accessing myRank's transport
+
+  // Allocate Transport on device with SELF type
+  P2pSelfTransportDevice selfTransport;
+  Transport hostTransport(selfTransport);
+
+  // Copy Transport to device (need to use placement new due to deleted copy)
+  Transport* transport_d = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&transport_d, sizeof(Transport)));
+
+  // Use cudaMemcpy to copy the bytes (Transport has trivial layout for union)
+  CUDACHECK_TEST(cudaMemcpy(
+      transport_d, &hostTransport, sizeof(Transport), cudaMemcpyHostToDevice));
+
+  // Allocate results buffer
+  DeviceBuffer resultsBuffer(sizeof(int));
+  auto results_d = static_cast<int*>(resultsBuffer.get());
+  CUDACHECK_TEST(cudaMemset(results_d, 0, sizeof(int)));
+
+  // Test that transport type is SELF
+  test::testGetTransportType(transport_d, results_d);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  int result_h = 0;
+  CUDACHECK_TEST(
+      cudaMemcpy(&result_h, results_d, sizeof(int), cudaMemcpyDeviceToHost));
+
+  EXPECT_EQ(result_h, 1) << "Transport type should be SELF";
+
+  CUDACHECK_TEST(cudaFree(transport_d));
+}
+
+// Peer Iteration Helper Tests
+// =============================================================================
+
+TEST_F(MultiPeerDeviceTransportTestFixture, PeerIterationHelpersRank0) {
+  // Test peer iteration helpers with myRank=0, nRanks=4
+  // Expected: numPeers=3, peerIndexToRank=[1, 2, 3]
+  const int myRank = 0;
+  const int nRanks = 4;
+  const int numPeers = nRanks - 1;
+
+  DeviceBuffer resultsBuffer((1 + numPeers) * sizeof(int));
+  auto results_d = static_cast<int*>(resultsBuffer.get());
+
+  test::testPeerIterationHelpers(myRank, nRanks, results_d);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<int> results_h(1 + numPeers);
+  CUDACHECK_TEST(cudaMemcpy(
+      results_h.data(),
+      results_d,
+      (1 + numPeers) * sizeof(int),
+      cudaMemcpyDeviceToHost));
+
+  EXPECT_EQ(results_h[0], numPeers) << "numPeers() should return " << numPeers;
+  EXPECT_EQ(results_h[1], 1) << "peerIndexToRank(0) should return 1";
+  EXPECT_EQ(results_h[2], 2) << "peerIndexToRank(1) should return 2";
+  EXPECT_EQ(results_h[3], 3) << "peerIndexToRank(2) should return 3";
+}
+
+TEST_F(MultiPeerDeviceTransportTestFixture, PeerIterationHelpersRank2) {
+  // Test peer iteration helpers with myRank=2, nRanks=4
+  // Expected: numPeers=3, peerIndexToRank=[0, 1, 3] (skips self at 2)
+  const int myRank = 2;
+  const int nRanks = 4;
+  const int numPeers = nRanks - 1;
+
+  DeviceBuffer resultsBuffer((1 + numPeers) * sizeof(int));
+  auto results_d = static_cast<int*>(resultsBuffer.get());
+
+  test::testPeerIterationHelpers(myRank, nRanks, results_d);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<int> results_h(1 + numPeers);
+  CUDACHECK_TEST(cudaMemcpy(
+      results_h.data(),
+      results_d,
+      (1 + numPeers) * sizeof(int),
+      cudaMemcpyDeviceToHost));
+
+  EXPECT_EQ(results_h[0], numPeers) << "numPeers() should return " << numPeers;
+  EXPECT_EQ(results_h[1], 0) << "peerIndexToRank(0) should return 0";
+  EXPECT_EQ(results_h[2], 1) << "peerIndexToRank(1) should return 1";
+  EXPECT_EQ(results_h[3], 3)
+      << "peerIndexToRank(2) should return 3 (skip self)";
+}
+
+TEST_F(MultiPeerDeviceTransportTestFixture, PeerIterationHelpersRank7) {
+  // Test peer iteration helpers with myRank=7, nRanks=8 (max rank)
+  // Expected: numPeers=7, peerIndexToRank=[0, 1, 2, 3, 4, 5, 6]
+  const int myRank = 7;
+  const int nRanks = 8;
+  const int numPeers = nRanks - 1;
+
+  DeviceBuffer resultsBuffer((1 + numPeers) * sizeof(int));
+  auto results_d = static_cast<int*>(resultsBuffer.get());
+
+  test::testPeerIterationHelpers(myRank, nRanks, results_d);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<int> results_h(1 + numPeers);
+  CUDACHECK_TEST(cudaMemcpy(
+      results_h.data(),
+      results_d,
+      (1 + numPeers) * sizeof(int),
+      cudaMemcpyDeviceToHost));
+
+  EXPECT_EQ(results_h[0], numPeers) << "numPeers() should return " << numPeers;
+  // For myRank=7, all indices map directly (0->0, 1->1, ..., 6->6)
+  std::vector<int> expectedPeerRanks(numPeers);
+  std::iota(expectedPeerRanks.begin(), expectedPeerRanks.end(), 0);
+  std::vector<int> actualPeerRanks(results_h.begin() + 1, results_h.end());
+  EXPECT_EQ(actualPeerRanks, expectedPeerRanks)
+      << "peerIndexToRank mapping mismatch for myRank=7";
+}
+
+TEST_F(MultiPeerDeviceTransportTestFixture, PeerIterationHelpersSinglePeer) {
+  // Test with nRanks=2 (minimal multi-peer case)
+  // Expected: numPeers=1
+  const int myRank = 0;
+  const int nRanks = 2;
+  const int numPeers = nRanks - 1;
+
+  DeviceBuffer resultsBuffer((1 + numPeers) * sizeof(int));
+  auto results_d = static_cast<int*>(resultsBuffer.get());
+
+  test::testPeerIterationHelpers(myRank, nRanks, results_d);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<int> results_h(1 + numPeers);
+  CUDACHECK_TEST(cudaMemcpy(
+      results_h.data(),
+      results_d,
+      (1 + numPeers) * sizeof(int),
+      cudaMemcpyDeviceToHost));
+
+  EXPECT_EQ(results_h[0], 1) << "numPeers() should return 1";
+  EXPECT_EQ(results_h[1], 1) << "peerIndexToRank(0) should return 1";
+}
+
+// =============================================================================
+// Bounds Checking Documentation
+// =============================================================================
+//
+// MULTI_PEER_CHECK_RANK / MULTI_PEER_CHECK_NOT_SELF TESTING STRATEGY:
+//
+// These macros provide validation for rank-based operations. Testing this is
+// challenging because:
+//
+// 1. Device code (__CUDA_ARCH__): The macros call __trap() which aborts the
+//    kernel. This cannot be caught by standard gtest mechanisms. Testing
+//    invalid ranks on device would require:
+//    - Running the kernel with invalid input
+//    - Checking cudaGetLastError() for cudaErrorLaunchFailure
+//    - This is not done here because it would leave the CUDA context in a bad
+//      state and contaminate subsequent tests
+//
+// 2. Host code: The macros use assert() which is:
+//    - A no-op in release builds
+//    - Calls abort() in debug builds, testable with EXPECT_DEBUG_DEATH
+//
+// IMPLICIT TESTING:
+// All functional tests that pass valid target ranks indirectly test that
+// MULTI_PEER_CHECK_RANK allows valid inputs through. The tests above
+// (PeerIterationHelpers*) verify peer iteration for all valid ranks.
+//
+// For invalid rank detection during development, the macros print detailed
+// debug information (file:line, block/thread indices) before aborting,
+// making issues easy to diagnose.
+//
+// =============================================================================
+
+} // namespace comms::pipes

--- a/comms/pipes/tests/MultiPeerDeviceTransportTest.cu
+++ b/comms/pipes/tests/MultiPeerDeviceTransportTest.cu
@@ -1,0 +1,104 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/tests/MultiPeerDeviceTransportTest.cuh"
+
+#include "comms/pipes/MultiPeerDeviceTransport.cuh"
+#include "comms/pipes/Transport.cuh"
+#include "comms/testinfra/TestXPlatUtils.h"
+
+namespace comms::pipes::test {
+
+// =============================================================================
+// MultiPeerDeviceTransport Construction Test
+// =============================================================================
+
+__global__ void multiPeerDeviceTransportConstructionKernel(
+    int myRank,
+    int nRanks,
+    Transport* transports,
+    int* results) {
+  // Construct MultiPeerDeviceTransport
+  DeviceSpan<Transport> transportsSpan(transports, nRanks);
+  MultiPeerDeviceTransport transport(myRank, nRanks, transportsSpan);
+
+  // Verify accessors return correct values
+  results[0] = transport.rank();
+  results[1] = transport.n_ranks();
+}
+
+void testMultiPeerDeviceTransportConstruction(
+    int myRank,
+    int nRanks,
+    int* results) {
+  // Allocate minimal buffers for construction test
+  Transport* transports = nullptr;
+
+  CUDACHECK_TEST(cudaMalloc(&transports, nRanks * sizeof(Transport)));
+
+  CUDACHECK_TEST(cudaMemset(transports, 0, nRanks * sizeof(Transport)));
+
+  multiPeerDeviceTransportConstructionKernel<<<1, 1>>>(
+      myRank, nRanks, transports, results);
+  CUDACHECK_TEST(cudaGetLastError());
+
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  CUDACHECK_TEST(cudaFree(transports));
+}
+
+// =============================================================================
+// Get Transport Type Test
+// =============================================================================
+
+__global__ void getTransportTypeKernel(Transport* transport, int* results) {
+  // Check if transport type is SELF
+  results[0] = (transport->type == TransportType::SELF) ? 1 : 0;
+}
+
+void testGetTransportType(void* transport_d, int* results) {
+  getTransportTypeKernel<<<1, 1>>>(
+      static_cast<Transport*>(transport_d), results);
+  CUDACHECK_TEST(cudaGetLastError());
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+}
+
+// =============================================================================
+// Peer Iteration Helpers Test
+// =============================================================================
+
+__global__ void peerIterationHelpersKernel(
+    int myRank,
+    int nRanks,
+    Transport* transports,
+    int* results) {
+  // Construct MultiPeerDeviceTransport
+  DeviceSpan<Transport> transportsSpan(transports, nRanks);
+  MultiPeerDeviceTransport transport(myRank, nRanks, transportsSpan);
+
+  // Test num_peers()
+  results[0] = transport.num_peers();
+
+  // Test peer_index_to_rank() for each peer index
+  int numPeers = transport.num_peers();
+  for (int i = 0; i < numPeers; ++i) {
+    results[1 + i] = transport.peer_index_to_rank(i);
+  }
+}
+
+void testPeerIterationHelpers(int myRank, int nRanks, int* results) {
+  // Allocate minimal buffers for construction test
+  Transport* transports = nullptr;
+
+  CUDACHECK_TEST(cudaMalloc(&transports, nRanks * sizeof(Transport)));
+
+  CUDACHECK_TEST(cudaMemset(transports, 0, nRanks * sizeof(Transport)));
+
+  peerIterationHelpersKernel<<<1, 1>>>(myRank, nRanks, transports, results);
+  CUDACHECK_TEST(cudaGetLastError());
+
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  CUDACHECK_TEST(cudaFree(transports));
+}
+
+} // namespace comms::pipes::test

--- a/comms/pipes/tests/MultiPeerDeviceTransportTest.cuh
+++ b/comms/pipes/tests/MultiPeerDeviceTransportTest.cuh
@@ -1,0 +1,40 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+
+namespace comms::pipes::test {
+
+/**
+ * Test kernel: Verify MultiPeerDeviceTransport construction and basic accessors
+ *
+ * @param myRank Rank ID for the transport object
+ * @param nRanks Total number of ranks
+ * @param results Output array for test results [0]=rank, [1]=nRanks
+ */
+void testMultiPeerDeviceTransportConstruction(
+    int myRank,
+    int nRanks,
+    int* results);
+
+/**
+ * Test kernel: Verify transport returns correct transport type
+ *
+ * @param transport_d Device pointer to Transport object (self-transport)
+ * @param results Output: [0]=1 if SELF type, 0 otherwise
+ */
+void testGetTransportType(void* transport_d, int* results);
+
+/**
+ * Test kernel: Verify peer iteration helpers (numPeers, peerIndexToRank)
+ *
+ * @param myRank Rank ID for the transport object
+ * @param nRanks Total number of ranks
+ * @param results Output array for test results:
+ *   [0]=numPeers
+ *   [1..numPeers]=peerIndexToRank for each index
+ */
+void testPeerIterationHelpers(int myRank, int nRanks, int* results);
+
+} // namespace comms::pipes::test

--- a/comms/pipes/tests/MultiPeerNvlTransportIntegrationTest.cc
+++ b/comms/pipes/tests/MultiPeerNvlTransportIntegrationTest.cc
@@ -1,0 +1,447 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include <folly/init/Init.h>
+#include <folly/logging/xlog.h>
+
+#include <string>
+#include <vector>
+
+#include "comms/pipes/MultiPeerDeviceTransport.cuh"
+#include "comms/pipes/MultiPeerNvlTransport.h"
+#include "comms/pipes/tests/MultiPeerNvlTransportIntegrationTest.cuh"
+#include "comms/pipes/tests/Utils.cuh"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/testinfra/mpi/MpiBootstrap.h"
+#include "comms/testinfra/mpi/MpiTestUtils.h"
+#include "comms/utils/CudaRAII.h"
+
+using meta::comms::DeviceBuffer;
+using meta::comms::MpiBaseTestFixture;
+using meta::comms::MpiBootstrap;
+using meta::comms::MPIEnvironmentBase;
+
+namespace comms::pipes::tests {
+
+// =============================================================================
+// Test Configuration Constants
+// =============================================================================
+
+namespace {
+// Default configuration for transport setup
+constexpr std::size_t kDefaultDataBufferSize = 1024 * 1024; // 1MB
+constexpr std::size_t kDefaultChunkSize = 1024;
+constexpr std::size_t kDefaultPipelineDepth = 4;
+
+// Transfer sizes for data tests
+constexpr std::size_t kSmallTransferSize = 1024 * 1024; // 1MB
+
+// Stress test parameters
+constexpr int kStressIterations = 50;
+
+// Kernel launch parameters
+constexpr int kDefaultNumBlocks = 4;
+constexpr int kDefaultBlockSize = 128;
+} // namespace
+
+// =============================================================================
+// Test Fixture
+// =============================================================================
+
+class MultiPeerNvlTransportIntegrationTestFixture : public MpiBaseTestFixture {
+ protected:
+  void SetUp() override {
+    MpiBaseTestFixture::SetUp();
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+  }
+
+  void TearDown() override {
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    MpiBaseTestFixture::TearDown();
+  }
+
+  // Helper to create a configured transport and get the
+  // MultiPeerDeviceTransport
+  std::pair<std::unique_ptr<MultiPeerNvlTransport>, MultiPeerDeviceTransport>
+  createTransport(const MultiPeerNvlTransportConfig& config) {
+    auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+    auto transport = std::make_unique<MultiPeerNvlTransport>(
+        globalRank, numRanks, bootstrap, config);
+    transport->exchange();
+    auto device = transport->getMultiPeerDeviceTransport();
+    return {std::move(transport), std::move(device)};
+  }
+};
+
+// =============================================================================
+// getMultiPeerDeviceTransport() End-to-End Test
+// =============================================================================
+
+TEST_F(
+    MultiPeerNvlTransportIntegrationTestFixture,
+    GetMultiPeerDeviceTransport) {
+  MultiPeerNvlTransportConfig config{
+      .dataBufferSize = kDefaultDataBufferSize,
+      .chunkSize = kDefaultChunkSize,
+      .pipelineDepth = kDefaultPipelineDepth,
+  };
+
+  auto [transport, device] = createTransport(config);
+
+  // Allocate result buffer on device
+  DeviceBuffer resultsBuffer(3 * sizeof(int));
+  auto results_d = static_cast<int*>(resultsBuffer.get());
+
+  // Call test kernel to verify accessors
+  test::testMultiPeerDeviceTransportAccessors(device, results_d);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  // Copy results back to host
+  std::vector<int> results_h(3);
+  CUDACHECK_TEST(cudaMemcpy(
+      results_h.data(), results_d, 3 * sizeof(int), cudaMemcpyDeviceToHost));
+
+  EXPECT_EQ(results_h[0], globalRank) << "rank() should return " << globalRank;
+  EXPECT_EQ(results_h[1], numRanks) << "nRanks() should return " << numRanks;
+  EXPECT_EQ(results_h[2], numRanks - 1)
+      << "numPeers() should return " << (numRanks - 1);
+
+  XLOGF(
+      INFO,
+      "Rank {}: getMultiPeerDeviceTransport test completed (rank={}, nRanks={}, numPeers={})",
+      globalRank,
+      results_h[0],
+      results_h[1],
+      results_h[2]);
+}
+
+// =============================================================================
+// Repeated getMultiPeerDeviceTransport() Calls
+// =============================================================================
+
+TEST_F(
+    MultiPeerNvlTransportIntegrationTestFixture,
+    GetMultiPeerDeviceTransportRepeated) {
+  // Test that getMultiPeerDeviceTransport() can be called multiple times
+  // and returns consistent results (tests lazy initialization)
+  MultiPeerNvlTransportConfig config{
+      .dataBufferSize = kDefaultDataBufferSize,
+      .chunkSize = kDefaultChunkSize,
+      .pipelineDepth = kDefaultPipelineDepth,
+  };
+
+  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
+  transport.exchange();
+
+  // Call getMultiPeerDeviceTransport() multiple times
+  auto device1 = transport.getMultiPeerDeviceTransport();
+  auto device2 = transport.getMultiPeerDeviceTransport();
+  auto device3 = transport.getMultiPeerDeviceTransport();
+
+  // Allocate result buffers
+  DeviceBuffer results1Buffer(3 * sizeof(int));
+  DeviceBuffer results2Buffer(3 * sizeof(int));
+  DeviceBuffer results3Buffer(3 * sizeof(int));
+
+  auto results1_d = static_cast<int*>(results1Buffer.get());
+  auto results2_d = static_cast<int*>(results2Buffer.get());
+  auto results3_d = static_cast<int*>(results3Buffer.get());
+
+  test::testMultiPeerDeviceTransportAccessors(device1, results1_d);
+  test::testMultiPeerDeviceTransportAccessors(device2, results2_d);
+  test::testMultiPeerDeviceTransportAccessors(device3, results3_d);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<int> results1_h(3), results2_h(3), results3_h(3);
+  CUDACHECK_TEST(cudaMemcpy(
+      results1_h.data(), results1_d, 3 * sizeof(int), cudaMemcpyDeviceToHost));
+  CUDACHECK_TEST(cudaMemcpy(
+      results2_h.data(), results2_d, 3 * sizeof(int), cudaMemcpyDeviceToHost));
+  CUDACHECK_TEST(cudaMemcpy(
+      results3_h.data(), results3_d, 3 * sizeof(int), cudaMemcpyDeviceToHost));
+
+  // All calls should return the same values
+  EXPECT_EQ(results1_h, results2_h)
+      << "Repeated getMultiPeerDeviceTransport calls returned different values";
+  EXPECT_EQ(results1_h, results3_h)
+      << "Repeated getMultiPeerDeviceTransport calls returned different values";
+
+  XLOGF(
+      INFO,
+      "Rank {}: Repeated getMultiPeerDeviceTransport test completed",
+      globalRank);
+}
+
+// =============================================================================
+// Multi-GPU Send/Recv Test
+// =============================================================================
+
+TEST_F(MultiPeerNvlTransportIntegrationTestFixture, SendRecv) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Requires exactly 2 ranks, got " << numRanks;
+  }
+
+  const size_t dataBufferSize = 1024 * 1024;
+  const size_t nbytes = 4 * 1024 * 1024; // 4MB transfer
+  MultiPeerNvlTransportConfig config{
+      .dataBufferSize = dataBufferSize,
+      .chunkSize = 1024,
+      .pipelineDepth = 4,
+  };
+
+  auto [transport, device] = createTransport(config);
+
+  int peerRank = (globalRank == 0) ? 1 : 0;
+  const size_t numInts = nbytes / sizeof(int);
+
+  DeviceBuffer srcBuffer(nbytes);
+  DeviceBuffer dstBuffer(nbytes);
+
+  auto src_d = static_cast<int*>(srcBuffer.get());
+  auto dst_d = static_cast<int*>(dstBuffer.get());
+
+  const int testValue = 42 + globalRank;
+  const int expectedValue = 42 + peerRank;
+
+  if (globalRank == 0) {
+    // Rank 0: Fill source buffer and send
+    test::fillBuffer(src_d, testValue, numInts);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    test::testSinglePeerSend(device, peerRank, src_d, nbytes, 4, 128);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  } else {
+    // Rank 1: Clear destination buffer and receive
+    CUDACHECK_TEST(cudaMemset(dst_d, 0, nbytes));
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    test::testSinglePeerRecv(device, peerRank, dst_d, nbytes, 4, 128);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    // Verify received data
+    std::vector<int> hostBuffer(numInts);
+    CUDACHECK_TEST(
+        cudaMemcpy(hostBuffer.data(), dst_d, nbytes, cudaMemcpyDeviceToHost));
+
+    std::vector<int> expected(numInts, expectedValue);
+    EXPECT_EQ(hostBuffer, expected) << "Data mismatch in SendRecv transfer";
+  }
+
+  XLOGF(INFO, "Rank {}: Send/Recv test completed", globalRank);
+}
+
+// =============================================================================
+// Bidirectional Send/Recv Test
+// =============================================================================
+
+TEST_F(MultiPeerNvlTransportIntegrationTestFixture, BidirectionalSendRecv) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Requires exactly 2 ranks, got " << numRanks;
+  }
+
+  const size_t dataBufferSize = 1024 * 1024;
+  const size_t nbytes = 2 * 1024 * 1024; // 2MB transfer each direction
+  MultiPeerNvlTransportConfig config{
+      .dataBufferSize = dataBufferSize,
+      .chunkSize = 1024,
+      .pipelineDepth = 4,
+  };
+
+  auto [transport, device] = createTransport(config);
+
+  int peerRank = (globalRank == 0) ? 1 : 0;
+  const size_t numInts = nbytes / sizeof(int);
+
+  DeviceBuffer sendBuffer(nbytes);
+  DeviceBuffer recvBuffer(nbytes);
+
+  auto send_d = static_cast<int*>(sendBuffer.get());
+  auto recv_d = static_cast<int*>(recvBuffer.get());
+
+  const int sendValue = 100 + globalRank;
+  const int expectedRecvValue = 100 + peerRank;
+
+  // Fill send buffer and clear receive buffer
+  test::fillBuffer(send_d, sendValue, numInts);
+  CUDACHECK_TEST(cudaMemset(recv_d, 0, nbytes));
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  // Rank 0 sends then receives, Rank 1 receives then sends
+  if (globalRank == 0) {
+    test::testSinglePeerSend(device, peerRank, send_d, nbytes, 4, 128);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    test::testSinglePeerRecv(device, peerRank, recv_d, nbytes, 4, 128);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  } else {
+    test::testSinglePeerRecv(device, peerRank, recv_d, nbytes, 4, 128);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    test::testSinglePeerSend(device, peerRank, send_d, nbytes, 4, 128);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  }
+
+  // Verify received data
+  std::vector<int> hostBuffer(numInts);
+  CUDACHECK_TEST(
+      cudaMemcpy(hostBuffer.data(), recv_d, nbytes, cudaMemcpyDeviceToHost));
+
+  std::vector<int> expected(numInts, expectedRecvValue);
+  EXPECT_EQ(hostBuffer, expected)
+      << "Rank " << globalRank << ": Data mismatch in BidirectionalSendRecv";
+
+  XLOGF(INFO, "Rank {}: Bidirectional Send/Recv test completed", globalRank);
+}
+
+// =============================================================================
+// Stress Test with Many Iterations
+// =============================================================================
+
+TEST_F(MultiPeerNvlTransportIntegrationTestFixture, SendRecvStress) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Requires exactly 2 ranks, got " << numRanks;
+  }
+
+  constexpr std::size_t kStressDataBufferSize = 512 * 1024;
+  constexpr std::size_t kStressChunkSize = 512;
+  MultiPeerNvlTransportConfig config{
+      .dataBufferSize = kStressDataBufferSize,
+      .chunkSize = kStressChunkSize,
+      .pipelineDepth = kDefaultPipelineDepth,
+  };
+
+  auto [transport, device] = createTransport(config);
+
+  int peerRank = (globalRank == 0) ? 1 : 0;
+  const size_t numInts = kSmallTransferSize / sizeof(int);
+
+  DeviceBuffer srcBuffer(kSmallTransferSize);
+  DeviceBuffer dstBuffer(kSmallTransferSize);
+
+  auto src_d = static_cast<int*>(srcBuffer.get());
+  auto dst_d = static_cast<int*>(dstBuffer.get());
+
+  for (int iter = 0; iter < kStressIterations; ++iter) {
+    const int testValue = 1000 + iter;
+
+    if (globalRank == 0) {
+      test::fillBuffer(src_d, testValue, numInts);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+      test::testSinglePeerSend(
+          device,
+          peerRank,
+          src_d,
+          kSmallTransferSize,
+          kDefaultNumBlocks,
+          kDefaultBlockSize);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    } else {
+      CUDACHECK_TEST(cudaMemset(dst_d, 0, kSmallTransferSize));
+
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+      test::testSinglePeerRecv(
+          device,
+          peerRank,
+          dst_d,
+          kSmallTransferSize,
+          kDefaultNumBlocks,
+          kDefaultBlockSize);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+      // Verify a sample of received data
+      std::vector<int> hostBuffer(numInts);
+      CUDACHECK_TEST(cudaMemcpy(
+          hostBuffer.data(),
+          dst_d,
+          kSmallTransferSize,
+          cudaMemcpyDeviceToHost));
+
+      EXPECT_EQ(hostBuffer[0], testValue)
+          << "Iteration " << iter << ": first element mismatch";
+      EXPECT_EQ(hostBuffer[numInts - 1], testValue)
+          << "Iteration " << iter << ": last element mismatch";
+    }
+  }
+
+  XLOGF(
+      INFO,
+      "Rank {}: Stress test completed ({} iterations)",
+      globalRank,
+      kStressIterations);
+}
+
+// =============================================================================
+// Transport Accessor Verification Test
+// =============================================================================
+
+TEST_F(MultiPeerNvlTransportIntegrationTestFixture, TransportAccessorTypes) {
+  // Test that get_peer_transport/get_self_transport return correct types
+  MultiPeerNvlTransportConfig config{
+      .dataBufferSize = kDefaultDataBufferSize,
+      .chunkSize = kDefaultChunkSize,
+      .pipelineDepth = kDefaultPipelineDepth,
+  };
+
+  auto [transport, device] = createTransport(config);
+
+  // Allocate result buffer: [numPeers, selfType, peer0Type, peer1Type, ...]
+  DeviceBuffer resultsBuffer((1 + numRanks) * sizeof(int));
+  auto results_d = static_cast<int*>(resultsBuffer.get());
+  CUDACHECK_TEST(cudaMemset(results_d, 0, (1 + numRanks) * sizeof(int)));
+
+  test::testTransportTypes(device, results_d);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<int> results_h(1 + numRanks);
+  CUDACHECK_TEST(cudaMemcpy(
+      results_h.data(),
+      results_d,
+      (1 + numRanks) * sizeof(int),
+      cudaMemcpyDeviceToHost));
+
+  EXPECT_EQ(results_h[0], numRanks - 1)
+      << "numPeers should be " << (numRanks - 1);
+
+  // Verify self transport is SELF type (0) and others are P2P_NVL (1)
+  for (int peer = 0; peer < numRanks; ++peer) {
+    int expectedType = (peer == globalRank) ? 0 : 1; // SELF=0, P2P_NVL=1
+    EXPECT_EQ(results_h[1 + peer], expectedType)
+        << "Transport type mismatch for peer " << peer;
+  }
+
+  XLOGF(INFO, "Rank {}: Transport accessor types test completed", globalRank);
+}
+
+} // namespace comms::pipes::tests
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  auto mpi_env = std::make_unique<MPIEnvironmentBase>();
+  ::testing::AddGlobalTestEnvironment(new MPIEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/pipes/tests/MultiPeerNvlTransportIntegrationTest.cu
+++ b/comms/pipes/tests/MultiPeerNvlTransportIntegrationTest.cu
@@ -1,0 +1,151 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/tests/MultiPeerNvlTransportIntegrationTest.cuh"
+
+#include "comms/pipes/MultiPeerDeviceTransport.cuh"
+#include "comms/pipes/ThreadGroup.cuh"
+#include "comms/testinfra/TestXPlatUtils.h"
+
+namespace comms::pipes::test {
+
+// =============================================================================
+// MultiPeerDeviceTransport Accessors Test
+// =============================================================================
+
+__global__ void multiPeerDeviceTransportAccessorsKernel(
+    MultiPeerDeviceTransport& transport,
+    int* results) {
+  results[0] = transport.rank();
+  results[1] = transport.n_ranks();
+  results[2] = transport.num_peers();
+}
+
+void testMultiPeerDeviceTransportAccessors(
+    MultiPeerDeviceTransport& transport,
+    int* results) {
+  multiPeerDeviceTransportAccessorsKernel<<<1, 1>>>(transport, results);
+  CUDACHECK_TEST(cudaGetLastError());
+}
+
+// =============================================================================
+// Single-Peer Send/Recv Tests
+// =============================================================================
+
+__global__ void singlePeerSendKernel(
+    MultiPeerDeviceTransport& transport,
+    int peerRank,
+    void* srcBuff,
+    std::size_t nbytes) {
+  auto group = make_warp_group();
+  transport.send(peerRank, group, srcBuff, nbytes);
+}
+
+void testSinglePeerSend(
+    MultiPeerDeviceTransport& transport,
+    int peerRank,
+    void* srcBuff,
+    std::size_t nbytes,
+    int numBlocks,
+    int blockSize) {
+  singlePeerSendKernel<<<numBlocks, blockSize>>>(
+      transport, peerRank, srcBuff, nbytes);
+  CUDACHECK_TEST(cudaGetLastError());
+}
+
+__global__ void singlePeerRecvKernel(
+    MultiPeerDeviceTransport& transport,
+    int peerRank,
+    void* dstBuff,
+    std::size_t nbytes) {
+  auto group = make_warp_group();
+  transport.recv(peerRank, group, dstBuff, nbytes);
+}
+
+void testSinglePeerRecv(
+    MultiPeerDeviceTransport& transport,
+    int peerRank,
+    void* dstBuff,
+    std::size_t nbytes,
+    int numBlocks,
+    int blockSize) {
+  singlePeerRecvKernel<<<numBlocks, blockSize>>>(
+      transport, peerRank, dstBuff, nbytes);
+  CUDACHECK_TEST(cudaGetLastError());
+}
+
+// =============================================================================
+// Multi-Peer Send/Recv Test (Parallel via Partition)
+// =============================================================================
+
+__global__ void multiPeerSendRecvAllPeersKernel(
+    MultiPeerDeviceTransport& transport,
+    void** srcBuffs,
+    void** dstBuffs,
+    std::size_t nbytesPerPeer) {
+  auto group = make_warp_group();
+
+  int myRank = transport.rank();
+  int numPeers = transport.num_peers();
+
+  // Partition into send and recv groups (interleaved for SM balance)
+  auto [partition_id, send_recv_group] = group.partition_interleaved(2);
+
+  // Further partition across peers
+  auto [peer_idx, group_per_peer] =
+      send_recv_group.partition_interleaved(numPeers);
+
+  // Map peer_idx to actual rank (skip self)
+  int peer_rank = peer_idx < myRank ? peer_idx : peer_idx + 1;
+
+  if (partition_id == 0) {
+    transport.send(
+        peer_rank, group_per_peer, srcBuffs[peer_idx], nbytesPerPeer, peer_idx);
+  } else {
+    transport.recv(
+        peer_rank, group_per_peer, dstBuffs[peer_idx], nbytesPerPeer, peer_idx);
+  }
+}
+
+void testMultiPeerSendRecvAllPeers(
+    MultiPeerDeviceTransport& transport,
+    void** srcBuffs,
+    void** dstBuffs,
+    std::size_t nbytesPerPeer,
+    int numBlocks,
+    int blockSize) {
+  multiPeerSendRecvAllPeersKernel<<<numBlocks, blockSize>>>(
+      transport, srcBuffs, dstBuffs, nbytesPerPeer);
+  CUDACHECK_TEST(cudaGetLastError());
+}
+
+// =============================================================================
+// Transport Types Test
+// =============================================================================
+
+__global__ void transportTypesKernel(
+    const MultiPeerDeviceTransport& transport,
+    int* results) {
+  // Output numPeers in results[0]
+  results[0] = transport.num_peers();
+
+  // Self transport type
+  int myRank = transport.rank();
+  results[1 + myRank] = static_cast<int>(transport.get_self_transport()->type);
+
+  // Peer transport types
+  int nRanks = transport.n_ranks();
+  for (int r = 0; r < nRanks; ++r) {
+    if (r == myRank)
+      continue;
+    results[1 + r] = static_cast<int>(transport.get_peer_transport(r)->type);
+  }
+}
+
+void testTransportTypes(
+    const MultiPeerDeviceTransport& transport,
+    int* results) {
+  transportTypesKernel<<<1, 1>>>(transport, results);
+  CUDACHECK_TEST(cudaGetLastError());
+}
+
+} // namespace comms::pipes::test

--- a/comms/pipes/tests/MultiPeerNvlTransportIntegrationTest.cuh
+++ b/comms/pipes/tests/MultiPeerNvlTransportIntegrationTest.cuh
@@ -1,0 +1,93 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "comms/pipes/MultiPeerDeviceTransport.cuh"
+
+namespace comms::pipes::test {
+
+/**
+ * Test kernel: Verify MultiPeerDeviceTransport accessors on device
+ *
+ * @param transport The MultiPeerDeviceTransport to test
+ * @param results Output array: [0]=rank, [1]=nRanks, [2]=numPeers
+ */
+void testMultiPeerDeviceTransportAccessors(
+    MultiPeerDeviceTransport& transport,
+    int* results);
+
+/**
+ * Test kernel: Send data from this rank to a single peer
+ *
+ * @param transport The MultiPeerDeviceTransport to use
+ * @param targetRank The destination rank
+ * @param srcBuff Source buffer containing data to send
+ * @param nbytes Number of bytes to send
+ * @param numBlocks Number of thread blocks to launch
+ * @param blockSize Threads per block
+ */
+void testSinglePeerSend(
+    MultiPeerDeviceTransport& transport,
+    int targetRank,
+    void* srcBuff,
+    std::size_t nbytes,
+    int numBlocks,
+    int blockSize);
+
+/**
+ * Test kernel: Receive data from a single peer to this rank
+ *
+ * @param transport The MultiPeerDeviceTransport to use
+ * @param targetRank The source rank
+ * @param dstBuff Destination buffer for received data
+ * @param nbytes Number of bytes to receive
+ * @param numBlocks Number of thread blocks to launch
+ * @param blockSize Threads per block
+ */
+void testSinglePeerRecv(
+    MultiPeerDeviceTransport& transport,
+    int targetRank,
+    void* dstBuff,
+    std::size_t nbytes,
+    int numBlocks,
+    int blockSize);
+
+/**
+ * Test kernel: Parallel send/recv to all peers using partition
+ *
+ * Uses partition_interleaved to split warps between send and recv work,
+ * then further partitions across peers. This avoids deadlocks that can occur
+ * when send and recv are done sequentially.
+ *
+ * @param transport The MultiPeerDeviceTransport to use
+ * @param srcBuffs Array of source buffers, one per peer
+ * @param dstBuffs Array of destination buffers, one per peer
+ * @param nbytesPerPeer Number of bytes to transfer per peer
+ * @param numBlocks Number of thread blocks to launch
+ * @param blockSize Threads per block
+ */
+void testMultiPeerSendRecvAllPeers(
+    MultiPeerDeviceTransport& transport,
+    void** srcBuffs,
+    void** dstBuffs,
+    std::size_t nbytesPerPeer,
+    int numBlocks,
+    int blockSize);
+
+/**
+ * Test kernel: Verify transport type accessors
+ *
+ * Checks that get_peer_transport() and get_self_transport() return correct
+ * transport types for self vs peer.
+ *
+ * @param transport The MultiPeerDeviceTransport to use
+ * @param results Output array: [0]=numPeers, [1..nRanks]=transport types
+ */
+void testTransportTypes(
+    const MultiPeerDeviceTransport& transport,
+    int* results);
+
+} // namespace comms::pipes::test


### PR DESCRIPTION
Summary:
**TL;DR:** Introduces foundational device-side primitives and the unified `MultiPeerDeviceTransport` API for multi-peer NVLink communication in the Pipes library, aligned with the TorchComm Device API design.

 ---

# Detailed Overview

## Context & Motivation
The Pipes library provides GPU-side transport primitives for NVLink-based communication. Currently, device kernels must receive a `DeviceSpan<Transport>` and manually index into it for each peer, which leads to boilerplate code and tight coupling between kernels and transport implementation details.

This diff establishes the scaffolding for a unified `MultiPeerDeviceTransport` abstraction that will provide:
- **DeviceSignal**: Inbox-style signaling for remote completion notification; D92190695.
- **DeviceCounter**: Local completion notification (source buffer consumed); D92190692.
- **DeviceBarrier**: N-way multi-peer synchronization; D92190696.

## Technical Details
- Creates the `MultiPeerDeviceTransport` class as a composable device-side API
- Implements the host-side `MultiPeerNvlTransport` to manage buffer allocation, memory exchange, and device transport construction
- Provides peer-indexed access to underlying transports via `getTransport(rank)`
- Adds basic accessor methods: `rank()`, `nRanks()`, `numPeers()`
- Introduces a `dispatch()` helper to reduce duplication in transport-specific operations
- Includes comprehensive documentation for memory ordering semantics (acquire/release) and architecture diagrams

Differential Revision: D91796254
