### PR TITLE
MultiPeerDeviceTransport: Add DeviceSignal for inbox-style signaling

### DIFF
--- a/comms/pipes/SignalState.cuh
+++ b/comms/pipes/SignalState.cuh
@@ -64,8 +64,41 @@ __device__ inline const char* cmpOpToString(CmpOp op) {
  * MEMORY SEMANTICS:
  * =================
  * - All reads use acquire ordering (visible after peer's release)
+ *   Uses ld_acquire_sys_global for system-scope acquire load
  * - All writes use release ordering (visible to peer after their acquire)
+ *   Uses st_release_sys_global for system-scope release store
  * - Uses .sys scope for cross-GPU NVLink coherence
+ *
+ * USAGE PATTERN:
+ * ==============
+ *   // Producer (on GPU A)            // Consumer (on GPU B)
+ *   // Write data first               // Wait for signal
+ *   memcpy_vectorized(dst, src, n);   wait_until(CMP_GE, 1);
+ *   signal(SIGNAL_ADD, 1);            // Data is now visible
+ *   // Release fence ensures          // Acquire fence ensures
+ *   // data is visible before signal  // data is visible after wait
+ *
+ * SIGNAL OVERFLOW AND LIFETIME:
+ * =============================
+ * The 64-bit counter is unlikely to overflow in practice:
+ * - At 1 billion signals/second, overflow takes ~584 years
+ * - Typical workloads signal at most millions of times
+ *
+ * RECOMMENDED USAGE PATTERNS:
+ * 1. Monotonically increasing values: Use cumulative signal values
+ *    (wait for 1, then 2, then 3, ...) without resetting. Works well
+ *    for streaming patterns with bounded iteration counts.
+ *
+ * 2. Slot rotation: Use different signal slots for different phases
+ *    to avoid accumulation within a single slot.
+ *
+ * 3. Phase-based reset: Reset signals between communication phases
+ *    using host-side reinitialization (cudaMemset the inbox to 0).
+ *    Synchronize all ranks (e.g., MPI_Barrier) before reset.
+ *
+ * DEBUG OVERFLOW DETECTION:
+ * In debug builds (PIPES_DEBUG defined), SIGNAL_ADD operations check
+ * for overflow and call __trap() with an error message if detected.
  *
  */
 struct alignas(128) SignalState {
@@ -100,6 +133,26 @@ struct alignas(128) SignalState {
    * @param value The value to set or add
    */
   __device__ __forceinline__ void signal(SignalOp op, uint64_t value) {
+#if defined(__CUDA_ARCH__) && defined(PIPES_DEBUG)
+    // Debug-only overflow detection for SIGNAL_ADD
+    if (op == SignalOp::SIGNAL_ADD) {
+      uint64_t current = load();
+      if (current > UINT64_MAX - value) {
+        printf(
+            "SignalState overflow detected: current=%llu, adding=%llu at "
+            "block=(%u,%u,%u) thread=(%u,%u,%u)\n",
+            (unsigned long long)current,
+            (unsigned long long)value,
+            blockIdx.x,
+            blockIdx.y,
+            blockIdx.z,
+            threadIdx.x,
+            threadIdx.y,
+            threadIdx.z);
+        __trap();
+      }
+    }
+#endif
     switch (op) {
       case SignalOp::SIGNAL_SET:
         store(value);

--- a/comms/pipes/Transport.cuh
+++ b/comms/pipes/Transport.cuh
@@ -4,11 +4,26 @@
 
 #include <cstdint>
 #include <new>
+#include <type_traits>
 
 #include "comms/pipes/P2pNvlTransportDevice.cuh"
 #include "comms/pipes/P2pSelfTransportDevice.cuh"
 
 namespace comms::pipes {
+// Transport union members must be safe for cudaMemcpy to device.
+// Requirements:
+// - Standard layout: predictable byte representation, no hidden members
+// - Trivially destructible: source destructor after memcpy is a no-op
+// See MultiPeerNvlTransport::initializeTransportsArray().
+static_assert(
+    std::is_standard_layout_v<P2pSelfTransportDevice> &&
+        std::is_trivially_destructible_v<P2pSelfTransportDevice>,
+    "P2pSelfTransportDevice must be standard layout with trivial destructor");
+static_assert(
+    std::is_standard_layout_v<P2pNvlTransportDevice> &&
+        std::is_trivially_destructible_v<P2pNvlTransportDevice>,
+    "P2pNvlTransportDevice must be standard layout with trivial destructor");
+
 // Transport union members must be safe for cudaMemcpy to device.
 // Requirements:
 // - Standard layout: predictable byte representation, no hidden members

--- a/comms/pipes/benchmarks/MultiPeerBenchmark.cc
+++ b/comms/pipes/benchmarks/MultiPeerBenchmark.cc
@@ -15,6 +15,7 @@
 #include "comms/common/DeviceConstants.cuh"
 #include "comms/pipes/MultiPeerNvlTransport.h"
 #include "comms/pipes/benchmarks/MultiPeerBenchmark.cuh"
+#include "comms/pipes/window/WindowMemory.h"
 #include "comms/testinfra/mpi/MpiBootstrap.h"
 #include "comms/testinfra/mpi/MpiTestUtils.h"
 #include "comms/utils/CudaRAII.h"
@@ -304,16 +305,134 @@ class MultiPeerBenchmarkFixture : public MpiBaseTestFixture {
 };
 
 // =============================================================================
-// Benchmark Test Cases
+// Test: Signal-All Latency (N-way signaling)
 // =============================================================================
-//
-// Individual benchmark tests (BarrierLatency, SignalAllLatency, etc.) are
-// added in subsequent diffs alongside their respective primitive
-// implementations:
-// - D92190695: DeviceSignal -> SignalAllLatency, SignalPingPongLatency
-// - D92190696: DeviceBarrier -> BarrierLatency
-//
+
+TEST_F(MultiPeerBenchmarkFixture, SignalAllLatency) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "Requires >= 2 ranks, got " << numRanks;
+  }
+
+  // Use reduced config set for expensive operations
+  auto configs = getStandardConfigs(/*reduced=*/true);
+  std::vector<MultiPeerBenchResult> results;
+
+  int maxSlots = getMaxSlots(configs);
+  MultiPeerNvlTransportConfig transportConfig{
+      .dataBufferSize = 1,
+      .chunkSize = 1,
+      .pipelineDepth = 1,
+  };
+  WindowMemoryConfig wmConfig{
+      .signalCount = static_cast<std::size_t>(maxSlots),
+  };
+
+  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  MultiPeerNvlTransport transport(
+      globalRank, numRanks, bootstrap, transportConfig);
+  WindowMemory wm(globalRank, numRanks, bootstrap, wmConfig);
+  transport.exchange();
+  wm.exchange();
+  auto device = transport.getMultiPeerDeviceTransport(wm);
+
+  for (const auto& config : configs) {
+    void* kernelFunc = config.useBlockGroups
+        ? (void*)multiPeerSignalAllKernel<SyncScope::BLOCK>
+        : (void*)multiPeerSignalAllKernel<SyncScope::WARP>;
+
+    int nSteps = getStepsPerIter();
+    dim3 grid(config.numBlocks);
+    dim3 block(kDefaultThreads);
+    void* args[] = {&device, &nSteps};
+
+    auto timing = runBenchmark(
+        [&]() -> cudaError_t {
+          return cudaLaunchKernel(kernelFunc, grid, block, args, 0, stream_);
+        },
+        nSteps,
+        /*useMpiBarrier=*/true);
+
+    ASSERT_TRUE(timing.success)
+        << "Benchmark failed for config: " << config.name;
+
+    results.push_back({
+        .configName = config.name,
+        .nRanks = numRanks,
+        .groupScope = config.scopeString(),
+        .latencyUs = timing.avgLatencyUs,
+    });
+  }
+
+  printResultsTable(
+      "Signal-All Benchmark",
+      "Latency = Average time per signalAll/waitAll cycle",
+      results);
+}
+
 // =============================================================================
+// Test: Signal Ping-Pong Latency (2-way signaling)
+// =============================================================================
+
+TEST_F(MultiPeerBenchmarkFixture, SignalPingPongLatency) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Requires exactly 2 ranks, got " << numRanks;
+  }
+
+  int peerRank = (globalRank == 0) ? 1 : 0;
+  auto configs = getStandardConfigs();
+  std::vector<MultiPeerBenchResult> results;
+
+  int maxSlots = getMaxSlots(configs);
+  MultiPeerNvlTransportConfig transportConfig{
+      .dataBufferSize = 1,
+      .chunkSize = 1,
+      .pipelineDepth = 1,
+  };
+  WindowMemoryConfig wmConfig{
+      .signalCount = static_cast<std::size_t>(maxSlots),
+  };
+
+  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  MultiPeerNvlTransport transport(
+      globalRank, numRanks, bootstrap, transportConfig);
+  WindowMemory wm(globalRank, numRanks, bootstrap, wmConfig);
+  transport.exchange();
+  wm.exchange();
+  auto device = transport.getMultiPeerDeviceTransport(wm);
+
+  for (const auto& config : configs) {
+    void* kernelFunc = config.useBlockGroups
+        ? (void*)multiPeerSignalPingPongKernel<SyncScope::BLOCK>
+        : (void*)multiPeerSignalPingPongKernel<SyncScope::WARP>;
+
+    int nSteps = getStepsPerIter();
+    dim3 grid(config.numBlocks);
+    dim3 block(kDefaultThreads);
+    void* args[] = {&device, &peerRank, &nSteps};
+
+    auto timing = runBenchmark(
+        [&]() -> cudaError_t {
+          return cudaLaunchKernel(kernelFunc, grid, block, args, 0, stream_);
+        },
+        nSteps,
+        /*useMpiBarrier=*/true);
+
+    ASSERT_TRUE(timing.success)
+        << "Benchmark failed for config: " << config.name;
+
+    results.push_back({
+        .configName = config.name,
+        .nRanks = 2,
+        .groupScope = config.scopeString(),
+        .latencyUs = timing.avgLatencyUs,
+    });
+  }
+
+  printResultsTable(
+      "Signal Ping-Pong Benchmark (Half-Duplex)",
+      "Latency = Average time per signal/wait pair",
+      results);
+}
 
 } // namespace
 } // namespace comms::pipes::benchmark

--- a/comms/pipes/benchmarks/MultiPeerBenchmark.cu
+++ b/comms/pipes/benchmarks/MultiPeerBenchmark.cu
@@ -42,4 +42,87 @@ template __device__ auto makeGroup<SyncScope::BLOCK>();
 template __device__ int computeSlotIndex<SyncScope::WARP>();
 template __device__ int computeSlotIndex<SyncScope::BLOCK>();
 
+// =============================================================================
+// Signal Ping-Pong Benchmark Kernel Implementation
+// =============================================================================
+
+template <SyncScope S>
+__global__ void multiPeerSignalPingPongKernel(
+    MultiPeerDeviceTransport transport,
+    int targetRank,
+    int nSteps) {
+  auto group = makeGroup<S>();
+  int slotId = computeSlotIndex<S>();
+  int myRank = transport.rank();
+
+  // Ping-pong pattern:
+  // - Even steps: Rank 0 signals, Rank 1 waits
+  // - Odd steps: Rank 1 signals, Rank 0 waits
+  //
+  // Uses SIGNAL_ADD: each signal adds 1, wait for cumulative value.
+  // After N signals from peer, peer's cumulative value = N.
+
+  for (int step = 0; step < nSteps; ++step) {
+    bool myTurnToSignal = ((step % 2) == myRank);
+
+    if (myTurnToSignal) {
+      transport.signal_peer(group, targetRank, slotId, SignalOp::SIGNAL_ADD, 1);
+    } else {
+      // Wait for (step/2 + 1) signals from peer
+      uint64_t expectedValue = (step / 2) + 1;
+      transport.wait_signal(group, slotId, CmpOp::CMP_GE, expectedValue);
+    }
+  }
+}
+
+// =============================================================================
+// Signal-All Benchmark Kernel Implementation
+// =============================================================================
+
+template <SyncScope S>
+__global__ void multiPeerSignalAllKernel(
+    MultiPeerDeviceTransport transport,
+    int nSteps) {
+  auto group = makeGroup<S>();
+  int slotId = computeSlotIndex<S>();
+
+  // In the per-signal model, all (nRanks-1) peers write to the same slot.
+  // After step+1 iterations, accumulated value = (nRanks-1) * (step+1).
+  int nPeers = transport.n_ranks() - 1;
+
+  for (int step = 0; step < nSteps; ++step) {
+    // Signal all peers
+    transport.signal_all(group, slotId, SignalOp::SIGNAL_ADD, 1);
+
+    // Wait for accumulated signals from all peers
+    transport.wait_signal(
+        group,
+        slotId,
+        CmpOp::CMP_GE,
+        static_cast<uint64_t>(nPeers * (step + 1)));
+  }
+}
+
+// =============================================================================
+// Explicit Template Instantiations for Signal Kernels
+// =============================================================================
+
+// Signal ping-pong kernels
+template __global__ void multiPeerSignalPingPongKernel<SyncScope::WARP>(
+    MultiPeerDeviceTransport,
+    int,
+    int);
+template __global__ void multiPeerSignalPingPongKernel<SyncScope::BLOCK>(
+    MultiPeerDeviceTransport,
+    int,
+    int);
+
+// Signal-all kernels
+template __global__ void multiPeerSignalAllKernel<SyncScope::WARP>(
+    MultiPeerDeviceTransport,
+    int);
+template __global__ void multiPeerSignalAllKernel<SyncScope::BLOCK>(
+    MultiPeerDeviceTransport,
+    int);
+
 } // namespace comms::pipes::benchmark

--- a/comms/pipes/benchmarks/MultiPeerBenchmark.cuh
+++ b/comms/pipes/benchmarks/MultiPeerBenchmark.cuh
@@ -10,4 +10,39 @@ namespace comms::pipes::benchmark {
 
 // Use SyncScope from ThreadGroup.cuh for thread group type selection
 
+// =============================================================================
+// Signal Ping-Pong Benchmark Kernel
+// =============================================================================
+
+/**
+ * Signal ping-pong benchmark kernel (2 ranks only).
+ *
+ * Rank 0 and Rank 1 alternate signaling each other.
+ * Uses SIGNAL_ADD with cumulative wait values for reusability.
+ *
+ * Half-duplex measurement: one signal in flight at a time.
+ *
+ * Note: For 2-rank case, there's exactly one peer at index 0.
+ */
+template <SyncScope S>
+__global__ void multiPeerSignalPingPongKernel(
+    MultiPeerDeviceTransport transport,
+    int targetRank,
+    int nSteps);
+
+// =============================================================================
+// Signal-All Benchmark Kernel
+// =============================================================================
+
+/**
+ * Signal-all benchmark kernel.
+ *
+ * Each rank signals all peers, then waits for all arrivals.
+ * Uses SIGNAL_ADD with cumulative wait values.
+ */
+template <SyncScope S>
+__global__ void multiPeerSignalAllKernel(
+    MultiPeerDeviceTransport transport,
+    int nSteps);
+
 } // namespace comms::pipes::benchmark

--- a/comms/pipes/benchmarks/P2pNvlSignalBenchmark.cc
+++ b/comms/pipes/benchmarks/P2pNvlSignalBenchmark.cc
@@ -193,7 +193,7 @@ TEST_F(P2pSignalBenchmarkFixture, SignalBenchmark) {
         .dataBufferSize = 1,
         .chunkSize = 1,
         .pipelineDepth = 1,
-        .signalCount = signalCount,
+        .p2pSignalCount = signalCount,
     };
 
     comms::pipes::MultiPeerNvlTransport transport(
@@ -219,7 +219,7 @@ TEST_F(P2pSignalBenchmarkFixture, SignalBenchmark) {
         .dataBufferSize = 1,
         .chunkSize = 1,
         .pipelineDepth = 1,
-        .signalCount = signalCount,
+        .p2pSignalCount = signalCount,
     };
 
     comms::pipes::MultiPeerNvlTransport transport(

--- a/comms/pipes/tests/MultiPeerDeviceTransportTest.cc
+++ b/comms/pipes/tests/MultiPeerDeviceTransportTest.cc
@@ -8,6 +8,7 @@
 #include "comms/pipes/MultiPeerDeviceTransport.cuh"
 #include "comms/pipes/Transport.cuh"
 #include "comms/pipes/tests/MultiPeerDeviceTransportTest.cuh"
+#include "comms/pipes/window/DeviceWindowSignal.cuh"
 #include "comms/testinfra/TestXPlatUtils.h"
 #include "comms/utils/CudaRAII.h"
 
@@ -25,6 +26,46 @@ class MultiPeerDeviceTransportTestFixture : public ::testing::Test {
     CUDACHECK_TEST(cudaDeviceSynchronize());
   }
 };
+
+// =============================================================================
+// DeviceWindowSignal Tests
+// =============================================================================
+
+TEST_F(MultiPeerDeviceTransportTestFixture, DeviceWindowSignalConstruction) {
+  const int myRank = 0;
+  const int nRanks = 4;
+  const int signalCount = 2;
+
+  DeviceBuffer resultsBuffer(3 * sizeof(int));
+  auto results_d = static_cast<int*>(resultsBuffer.get());
+
+  test::testDeviceWindowSignalConstruction(
+      myRank, nRanks, signalCount, results_d);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<int> results_h(3);
+  CUDACHECK_TEST(cudaMemcpy(
+      results_h.data(), results_d, 3 * sizeof(int), cudaMemcpyDeviceToHost));
+
+  EXPECT_EQ(results_h[0], myRank) << "rank() should return " << myRank;
+  EXPECT_EQ(results_h[1], nRanks) << "nRanks() should return " << nRanks;
+  EXPECT_EQ(results_h[2], signalCount)
+      << "signalCount() should return " << signalCount;
+}
+
+TEST_F(MultiPeerDeviceTransportTestFixture, SignalInboxBufferSize) {
+  // Test buffer size calculation
+  const int signalCount = 2;
+
+  std::size_t bufferSize = getSignalInboxBufferSize(signalCount);
+
+  // Expected: signalCount * sizeof(SignalState), aligned to 128 bytes
+  std::size_t expectedSlots = signalCount;
+  std::size_t expectedMinSize = expectedSlots * sizeof(SignalState);
+  // Should be aligned to 128 bytes
+  EXPECT_GE(bufferSize, expectedMinSize);
+  EXPECT_EQ(bufferSize % 128, 0) << "Buffer size should be 128-byte aligned";
+}
 
 // =============================================================================
 // MultiPeerDeviceTransport Tests
@@ -51,8 +92,58 @@ TEST_F(
 }
 
 // =============================================================================
+// DeviceWindowMemory Tests
+// =============================================================================
+
+// Verify DeviceWindowMemory bundles signal and barrier correctly.
+// Constructs DeviceWindowMemory from DeviceWindowSignal + DeviceBarrier,
+// then verifies signal() and barrier() return objects with matching metadata.
+TEST_F(MultiPeerDeviceTransportTestFixture, DeviceWindowMemoryAccessors) {
+  const int myRank = 1;
+  const int nRanks = 4;
+  const int signalCount = 2;
+
+  DeviceBuffer resultsBuffer(5 * sizeof(int));
+  auto results_d = static_cast<int*>(resultsBuffer.get());
+
+  test::testDeviceWindowMemoryAccessors(myRank, nRanks, signalCount, results_d);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<int> results_h(5);
+  CUDACHECK_TEST(cudaMemcpy(
+      results_h.data(), results_d, 5 * sizeof(int), cudaMemcpyDeviceToHost));
+
+  // Signal accessors should match input parameters
+  EXPECT_EQ(results_h[0], myRank) << "signal().rank()";
+  EXPECT_EQ(results_h[1], nRanks) << "signal().n_ranks()";
+  EXPECT_EQ(results_h[2], signalCount) << "signal().signal_count()";
+}
+
+// =============================================================================
 // Edge Cases
 // =============================================================================
+
+TEST_F(MultiPeerDeviceTransportTestFixture, SingleRankSignal) {
+  // Test with single rank (edge case)
+  const int myRank = 0;
+  const int nRanks = 1;
+  const int signalCount = 1;
+
+  DeviceBuffer resultsBuffer(3 * sizeof(int));
+  auto results_d = static_cast<int*>(resultsBuffer.get());
+
+  test::testDeviceWindowSignalConstruction(
+      myRank, nRanks, signalCount, results_d);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<int> results_h(3);
+  CUDACHECK_TEST(cudaMemcpy(
+      results_h.data(), results_d, 3 * sizeof(int), cudaMemcpyDeviceToHost));
+
+  EXPECT_EQ(results_h[0], myRank);
+  EXPECT_EQ(results_h[1], nRanks);
+  EXPECT_EQ(results_h[2], signalCount);
+}
 
 TEST_F(MultiPeerDeviceTransportTestFixture, MaxRanksTransport) {
   // Test with a high rank count to verify construction works
@@ -75,11 +166,11 @@ TEST_F(MultiPeerDeviceTransportTestFixture, MaxRanksTransport) {
 }
 
 // =============================================================================
-// Self-Transport Tests (via get_transport())
+// Self-Transport Tests (via get_self_transport())
 // =============================================================================
 
 TEST_F(MultiPeerDeviceTransportTestFixture, GetTransportReturnsCorrectType) {
-  // Test that get_transport() returns a valid Transport with SELF type
+  // Test that get_self_transport() returns a valid Transport with SELF type
   // when accessing myRank's transport
 
   // Allocate Transport on device with SELF type
@@ -219,6 +310,128 @@ TEST_F(MultiPeerDeviceTransportTestFixture, PeerIterationHelpersSinglePeer) {
 
   EXPECT_EQ(results_h[0], 1) << "numPeers() should return 1";
   EXPECT_EQ(results_h[1], 1) << "peerIndexToRank(0) should return 1";
+}
+
+// =============================================================================
+// Peer Index Conversion Roundtrip Tests
+// =============================================================================
+
+// Helper to run the roundtrip test kernel and verify results for a given
+// myRank/nRanks configuration. Tests:
+//   1. rank_to_peer_index() produces expected values
+//   2. peer_index_to_rank(rank_to_peer_index(rank)) == rank (roundtrip)
+//   3. rank_to_peer_index(peer_index_to_rank(i)) == i (roundtrip)
+//   4. get_self_transport()->type == SELF
+//   5. get_peer_transport(i)->type == P2P_NVL for all peers
+void verifyPeerIndexConversionRoundtrip(int myRank, int nRanks) {
+  const int numPeers = nRanks - 1;
+  // Results layout: numPeers + 3*numPeers (conversions/roundtrips) + 1 (self)
+  //                 + numPeers (peer types) = 4*numPeers + 2
+  const int numResults = 4 * numPeers + 2;
+
+  DeviceBuffer resultsBuffer(numResults * sizeof(int));
+  auto results_d = static_cast<int*>(resultsBuffer.get());
+  CUDACHECK_TEST(cudaMemset(results_d, 0xFF, numResults * sizeof(int)));
+
+  test::testPeerIndexConversionRoundtrip(myRank, nRanks, results_d);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<int> r(numResults);
+  CUDACHECK_TEST(cudaMemcpy(
+      r.data(), results_d, numResults * sizeof(int), cudaMemcpyDeviceToHost));
+
+  int idx = 0;
+
+  // [0] = numPeers
+  EXPECT_EQ(r[idx++], numPeers)
+      << "numPeers() for myRank=" << myRank << ", nRanks=" << nRanks;
+
+  // [1 .. numPeers] = rank_to_peer_index for each non-self rank
+  // Compute expected: for rank in [0, nRanks) excluding myRank,
+  //   peer_index = (rank < myRank) ? rank : (rank - 1)
+  for (int rank = 0; rank < nRanks; ++rank) {
+    if (rank == myRank) {
+      continue;
+    }
+    int expectedPeerIndex = (rank < myRank) ? rank : (rank - 1);
+    EXPECT_EQ(r[idx], expectedPeerIndex)
+        << "rank_to_peer_index(" << rank << ") for myRank=" << myRank
+        << ", nRanks=" << nRanks;
+    idx++;
+  }
+
+  // [numPeers+1 .. 2*numPeers] = roundtrip rank->peer_index->rank
+  for (int rank = 0; rank < nRanks; ++rank) {
+    if (rank == myRank) {
+      continue;
+    }
+    EXPECT_EQ(r[idx], rank)
+        << "Roundtrip peer_index_to_rank(rank_to_peer_index(" << rank
+        << ")) should equal " << rank << " for myRank=" << myRank
+        << ", nRanks=" << nRanks;
+    idx++;
+  }
+
+  // [2*numPeers+1 .. 3*numPeers] = roundtrip peer_index->rank->peer_index
+  for (int i = 0; i < numPeers; ++i) {
+    EXPECT_EQ(r[idx], i) << "Roundtrip rank_to_peer_index(peer_index_to_rank("
+                         << i << ")) should equal " << i
+                         << " for myRank=" << myRank << ", nRanks=" << nRanks;
+    idx++;
+  }
+
+  // [3*numPeers+1] = get_self_transport()->type (expect SELF=0)
+  EXPECT_EQ(r[idx++], 0)
+      << "get_self_transport()->type should be SELF for myRank=" << myRank;
+
+  // [3*numPeers+2 .. 4*numPeers+1] = get_peer_transport(i)->type
+  // (expect P2P_NVL=1)
+  for (int i = 0; i < numPeers; ++i) {
+    EXPECT_EQ(r[idx], 1) << "get_peer_transport(" << i
+                         << ")->type should be P2P_NVL for myRank=" << myRank;
+    idx++;
+  }
+}
+
+TEST_F(
+    MultiPeerDeviceTransportTestFixture,
+    PeerIndexConversionRoundtripRank0Of4) {
+  verifyPeerIndexConversionRoundtrip(/*myRank=*/0, /*nRanks=*/4);
+}
+
+TEST_F(
+    MultiPeerDeviceTransportTestFixture,
+    PeerIndexConversionRoundtripRank2Of4) {
+  // Middle rank: tests the skip-self logic in both directions
+  verifyPeerIndexConversionRoundtrip(/*myRank=*/2, /*nRanks=*/4);
+}
+
+TEST_F(
+    MultiPeerDeviceTransportTestFixture,
+    PeerIndexConversionRoundtripRank3Of4) {
+  // Last rank: peer indices map 1:1 to ranks [0, 1, 2]
+  verifyPeerIndexConversionRoundtrip(/*myRank=*/3, /*nRanks=*/4);
+}
+
+TEST_F(
+    MultiPeerDeviceTransportTestFixture,
+    PeerIndexConversionRoundtripRank0Of2) {
+  // Minimal 2-rank case: single peer
+  verifyPeerIndexConversionRoundtrip(/*myRank=*/0, /*nRanks=*/2);
+}
+
+TEST_F(
+    MultiPeerDeviceTransportTestFixture,
+    PeerIndexConversionRoundtripRank1Of2) {
+  // Minimal 2-rank case from the other side
+  verifyPeerIndexConversionRoundtrip(/*myRank=*/1, /*nRanks=*/2);
+}
+
+TEST_F(
+    MultiPeerDeviceTransportTestFixture,
+    PeerIndexConversionRoundtripRank4Of8) {
+  // 8-rank case with middle rank: exercises larger peer counts
+  verifyPeerIndexConversionRoundtrip(/*myRank=*/4, /*nRanks=*/8);
 }
 
 // =============================================================================

--- a/comms/pipes/tests/MultiPeerDeviceTransportTest.cu
+++ b/comms/pipes/tests/MultiPeerDeviceTransportTest.cu
@@ -3,11 +3,66 @@
 #include "comms/pipes/tests/MultiPeerDeviceTransportTest.cuh"
 
 #include "comms/pipes/MultiPeerDeviceTransport.cuh"
+#include "comms/pipes/ThreadGroup.cuh"
 #include "comms/pipes/Transport.cuh"
+#include "comms/pipes/window/DeviceWindowMemory.cuh"
+#include "comms/pipes/window/DeviceWindowSignal.cuh"
 #include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/CudaRAII.h"
 
 namespace comms::pipes::test {
 
+// Helper: allocate zeroed device memory and wrap in DeviceSpan
+template <typename T>
+DeviceSpan<T> makeZeroedSpan(
+    meta::comms::DeviceBuffer& buf,
+    std::size_t count) {
+  CUDACHECK_TEST(cudaMemset(buf.get(), 0, count * sizeof(T)));
+  return DeviceSpan<T>(static_cast<T*>(buf.get()), count);
+}
+
+// =============================================================================
+// DeviceWindowSignal Construction Test
+// =============================================================================
+
+__global__ void deviceSignalConstructionKernel(
+    int myRank,
+    int nRanks,
+    int signalCount,
+    DeviceSpan<SignalState> localInbox,
+    DeviceSpan<DeviceSpan<SignalState>> peerSignals,
+    int* results) {
+  DeviceWindowSignal signal(
+      myRank, nRanks, signalCount, localInbox, peerSignals);
+
+  // Verify accessors return correct values
+  results[0] = signal.rank();
+  results[1] = signal.n_ranks();
+  results[2] = signal.signal_count();
+}
+
+void testDeviceWindowSignalConstruction(
+    int myRank,
+    int nRanks,
+    int signalCount,
+    int* results) {
+  int nPeers = nRanks - 1;
+  meta::comms::DeviceBuffer localInboxBuf(signalCount * sizeof(SignalState));
+  meta::comms::DeviceBuffer peerSignalsBuf(
+      nPeers * sizeof(DeviceSpan<SignalState>));
+
+  auto localInbox = makeZeroedSpan<SignalState>(localInboxBuf, signalCount);
+  auto peerSignals =
+      makeZeroedSpan<DeviceSpan<SignalState>>(peerSignalsBuf, nPeers);
+
+  deviceSignalConstructionKernel<<<1, 1>>>(
+      myRank, nRanks, signalCount, localInbox, peerSignals, results);
+
+  CUDACHECK_TEST(cudaGetLastError());
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+}
+
+// =============================================================================
 // =============================================================================
 // MultiPeerDeviceTransport Construction Test
 // =============================================================================
@@ -15,11 +70,16 @@ namespace comms::pipes::test {
 __global__ void multiPeerDeviceTransportConstructionKernel(
     int myRank,
     int nRanks,
-    Transport* transports,
+    DeviceSpan<Transport> transports,
+    DeviceSpan<SignalState> signalInbox,
+    DeviceSpan<DeviceSpan<SignalState>> peerSignals,
     int* results) {
+  // Construct component objects
+  DeviceWindowSignal signal(myRank, nRanks, 1, signalInbox, peerSignals);
+  DeviceWindowMemory wm(signal);
+
   // Construct MultiPeerDeviceTransport
-  DeviceSpan<Transport> transportsSpan(transports, nRanks);
-  MultiPeerDeviceTransport transport(myRank, nRanks, transportsSpan);
+  MultiPeerDeviceTransport transport(myRank, nRanks, transports, wm);
 
   // Verify accessors return correct values
   results[0] = transport.rank();
@@ -30,20 +90,21 @@ void testMultiPeerDeviceTransportConstruction(
     int myRank,
     int nRanks,
     int* results) {
-  // Allocate minimal buffers for construction test
-  Transport* transports = nullptr;
+  int nPeers = nRanks - 1;
+  meta::comms::DeviceBuffer transportsBuf(nRanks * sizeof(Transport));
+  meta::comms::DeviceBuffer signalInboxBuf(sizeof(SignalState));
+  meta::comms::DeviceBuffer peerSignalsBuf(
+      nPeers * sizeof(DeviceSpan<SignalState>));
 
-  CUDACHECK_TEST(cudaMalloc(&transports, nRanks * sizeof(Transport)));
-
-  CUDACHECK_TEST(cudaMemset(transports, 0, nRanks * sizeof(Transport)));
+  auto transports = makeZeroedSpan<Transport>(transportsBuf, nRanks);
+  auto signalInbox = makeZeroedSpan<SignalState>(signalInboxBuf, 1);
+  auto peerSignals =
+      makeZeroedSpan<DeviceSpan<SignalState>>(peerSignalsBuf, nPeers);
 
   multiPeerDeviceTransportConstructionKernel<<<1, 1>>>(
-      myRank, nRanks, transports, results);
+      myRank, nRanks, transports, signalInbox, peerSignals, results);
   CUDACHECK_TEST(cudaGetLastError());
-
   CUDACHECK_TEST(cudaDeviceSynchronize());
-
-  CUDACHECK_TEST(cudaFree(transports));
 }
 
 // =============================================================================
@@ -69,11 +130,16 @@ void testGetTransportType(void* transport_d, int* results) {
 __global__ void peerIterationHelpersKernel(
     int myRank,
     int nRanks,
-    Transport* transports,
+    DeviceSpan<Transport> transports,
+    DeviceSpan<SignalState> signalInbox,
+    DeviceSpan<DeviceSpan<SignalState>> peerSignals,
     int* results) {
+  // Construct component objects
+  DeviceWindowSignal signal(myRank, nRanks, 1, signalInbox, peerSignals);
+  DeviceWindowMemory wm(signal);
+
   // Construct MultiPeerDeviceTransport
-  DeviceSpan<Transport> transportsSpan(transports, nRanks);
-  MultiPeerDeviceTransport transport(myRank, nRanks, transportsSpan);
+  MultiPeerDeviceTransport transport(myRank, nRanks, transports, wm);
 
   // Test num_peers()
   results[0] = transport.num_peers();
@@ -86,19 +152,163 @@ __global__ void peerIterationHelpersKernel(
 }
 
 void testPeerIterationHelpers(int myRank, int nRanks, int* results) {
-  // Allocate minimal buffers for construction test
-  Transport* transports = nullptr;
+  int nPeers = nRanks - 1;
+  meta::comms::DeviceBuffer transportsBuf(nRanks * sizeof(Transport));
+  meta::comms::DeviceBuffer signalInboxBuf(sizeof(SignalState));
+  meta::comms::DeviceBuffer peerSignalsBuf(
+      nPeers * sizeof(DeviceSpan<SignalState>));
 
-  CUDACHECK_TEST(cudaMalloc(&transports, nRanks * sizeof(Transport)));
+  auto transports = makeZeroedSpan<Transport>(transportsBuf, nRanks);
+  auto signalInbox = makeZeroedSpan<SignalState>(signalInboxBuf, 1);
+  auto peerSignals =
+      makeZeroedSpan<DeviceSpan<SignalState>>(peerSignalsBuf, nPeers);
 
-  CUDACHECK_TEST(cudaMemset(transports, 0, nRanks * sizeof(Transport)));
-
-  peerIterationHelpersKernel<<<1, 1>>>(myRank, nRanks, transports, results);
+  peerIterationHelpersKernel<<<1, 1>>>(
+      myRank, nRanks, transports, signalInbox, peerSignals, results);
   CUDACHECK_TEST(cudaGetLastError());
-
   CUDACHECK_TEST(cudaDeviceSynchronize());
+}
 
-  CUDACHECK_TEST(cudaFree(transports));
+// =============================================================================
+// Peer Index Conversion Roundtrip Test
+// =============================================================================
+
+__global__ void peerIndexConversionRoundtripKernel(
+    int myRank,
+    int nRanks,
+    DeviceSpan<Transport> transports,
+    DeviceSpan<SignalState> signalInbox,
+    DeviceSpan<DeviceSpan<SignalState>> peerSignals,
+    int* results) {
+  // Construct component objects
+  DeviceWindowSignal signal(myRank, nRanks, 1, signalInbox, peerSignals);
+  DeviceWindowMemory wm(signal);
+
+  // Construct MultiPeerDeviceTransport
+  MultiPeerDeviceTransport transport(myRank, nRanks, transports, wm);
+
+  int numPeers = transport.num_peers();
+  int idx = 0;
+
+  // results layout:
+  //   [0]                     = numPeers
+  //   [1 .. numPeers]         = rank_to_peer_index for each non-self rank
+  //   [numPeers+1 .. 2*numPeers] = roundtrip:
+  //   peer_index_to_rank(rank_to_peer_index(rank)) [2*numPeers+1 .. 3*numPeers]
+  //   = roundtrip: rank_to_peer_index(peer_index_to_rank(i)) [3*numPeers+1] =
+  //   get_self_transport()->type [3*numPeers+2 .. 4*numPeers+1] =
+  //   get_peer_transport(i)->type
+
+  results[idx++] = numPeers;
+
+  // Test rank_to_peer_index() for each non-self rank
+  for (int rank = 0; rank < nRanks; ++rank) {
+    if (rank == myRank) {
+      continue;
+    }
+    results[idx++] = transport.rank_to_peer_index(rank);
+  }
+
+  // Roundtrip: rank -> peer_index -> rank (should be identity for non-self)
+  for (int rank = 0; rank < nRanks; ++rank) {
+    if (rank == myRank) {
+      continue;
+    }
+    int peerIdx = transport.rank_to_peer_index(rank);
+    results[idx++] = transport.peer_index_to_rank(peerIdx);
+  }
+
+  // Roundtrip: peer_index -> rank -> peer_index (should be identity)
+  for (int i = 0; i < numPeers; ++i) {
+    int rank = transport.peer_index_to_rank(i);
+    results[idx++] = transport.rank_to_peer_index(rank);
+  }
+
+  // Test get_self_transport() type
+  results[idx++] = static_cast<int>(transport.get_self_transport()->type);
+
+  // Test get_peer_transport() types
+  for (int rank = 0; rank < nRanks; ++rank) {
+    if (rank == myRank)
+      continue;
+    results[idx++] = static_cast<int>(transport.get_peer_transport(rank)->type);
+  }
+}
+
+void testPeerIndexConversionRoundtrip(int myRank, int nRanks, int* results) {
+  int nPeers = nRanks - 1;
+  meta::comms::DeviceBuffer transportsBuf(nRanks * sizeof(Transport));
+  meta::comms::DeviceBuffer signalInboxBuf(sizeof(SignalState));
+  meta::comms::DeviceBuffer peerSignalsBuf(
+      nPeers * sizeof(DeviceSpan<SignalState>));
+
+  // Set up transports: self = SELF type, peers = P2P_NVL type.
+  auto* transportsPtr = static_cast<Transport*>(transportsBuf.get());
+  CUDACHECK_TEST(
+      cudaMemset(transportsBuf.get(), 0, nRanks * sizeof(Transport)));
+  for (int i = 0; i < nRanks; ++i) {
+    TransportType type =
+        (i == myRank) ? TransportType::SELF : TransportType::P2P_NVL;
+    CUDACHECK_TEST(cudaMemcpy(
+        &transportsPtr[i].type,
+        &type,
+        sizeof(TransportType),
+        cudaMemcpyHostToDevice));
+  }
+
+  DeviceSpan<Transport> transports(transportsPtr, nRanks);
+  auto signalInbox = makeZeroedSpan<SignalState>(signalInboxBuf, 1);
+  auto peerSignals =
+      makeZeroedSpan<DeviceSpan<SignalState>>(peerSignalsBuf, nPeers);
+
+  peerIndexConversionRoundtripKernel<<<1, 1>>>(
+      myRank, nRanks, transports, signalInbox, peerSignals, results);
+  CUDACHECK_TEST(cudaGetLastError());
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+}
+
+// =============================================================================
+// DeviceWindowMemory Accessors Test
+// =============================================================================
+
+__global__ void deviceWindowMemoryAccessorsKernel(
+    int myRank,
+    int nRanks,
+    int signalCount,
+    DeviceSpan<SignalState> signalInbox,
+    DeviceSpan<DeviceSpan<SignalState>> peerSignals,
+    int* results) {
+  // Construct primitives
+  DeviceWindowSignal signal(
+      myRank, nRanks, signalCount, signalInbox, peerSignals);
+
+  // Construct DeviceWindowMemory
+  DeviceWindowMemory wm(signal);
+
+  // Verify signal() accessor returns correct metadata
+  results[0] = wm.signal().rank();
+  results[1] = wm.signal().n_ranks();
+  results[2] = wm.signal().signal_count();
+}
+
+void testDeviceWindowMemoryAccessors(
+    int myRank,
+    int nRanks,
+    int signalCount,
+    int* results) {
+  int nPeers = nRanks - 1;
+  meta::comms::DeviceBuffer signalInboxBuf(signalCount * sizeof(SignalState));
+  meta::comms::DeviceBuffer peerSignalsBuf(
+      nPeers * sizeof(DeviceSpan<SignalState>));
+
+  auto signalInbox = makeZeroedSpan<SignalState>(signalInboxBuf, signalCount);
+  auto peerSignals =
+      makeZeroedSpan<DeviceSpan<SignalState>>(peerSignalsBuf, nPeers);
+
+  deviceWindowMemoryAccessorsKernel<<<1, 1>>>(
+      myRank, nRanks, signalCount, signalInbox, peerSignals, results);
+  CUDACHECK_TEST(cudaGetLastError());
+  CUDACHECK_TEST(cudaDeviceSynchronize());
 }
 
 } // namespace comms::pipes::test

--- a/comms/pipes/tests/MultiPeerDeviceTransportTest.cuh
+++ b/comms/pipes/tests/MultiPeerDeviceTransportTest.cuh
@@ -7,6 +7,21 @@
 namespace comms::pipes::test {
 
 /**
+ * Test kernel: Verify DeviceWindowSignal construction and basic accessors
+ *
+ * @param myRank Rank ID for the signal object
+ * @param nRanks Total number of ranks
+ * @param signalCount Number of signal slots per peer
+ * @param results Output array for test results [0]=rank, [1]=nRanks,
+ * [2]=signalCount
+ */
+void testDeviceWindowSignalConstruction(
+    int myRank,
+    int nRanks,
+    int signalCount,
+    int* results);
+
+/**
  * Test kernel: Verify MultiPeerDeviceTransport construction and basic accessors
  *
  * @param myRank Rank ID for the transport object
@@ -36,5 +51,35 @@ void testGetTransportType(void* transport_d, int* results);
  *   [1..numPeers]=peerIndexToRank for each index
  */
 void testPeerIterationHelpers(int myRank, int nRanks, int* results);
+
+/**
+ * Test kernel: Verify peer index conversion roundtrip and transport accessors
+ *
+ * Tests rank_to_peer_index(), roundtrip identity properties, and
+ * get_self_transport()/get_peer_transport() type correctness.
+ *
+ * @param myRank Rank ID for the transport object
+ * @param nRanks Total number of ranks
+ * @param results Output array for test results (size = 4*numPeers + 2)
+ */
+void testPeerIndexConversionRoundtrip(int myRank, int nRanks, int* results);
+
+/**
+ * Test kernel: Verify DeviceWindowMemory accessors return correct metadata
+ *
+ * Constructs DeviceWindowMemory from DeviceWindowSignal + DeviceBarrier, then
+ * verifies signal() and barrier() return objects with matching metadata.
+ *
+ * @param myRank Rank ID
+ * @param nRanks Total number of ranks
+ * @param signalCount Number of signal slots
+ * @param results Output array: [0]=signal.rank, [1]=signal.nRanks,
+ *   [2]=signal.signalCount, [3]=barrier.rank, [4]=barrier.nRanks
+ */
+void testDeviceWindowMemoryAccessors(
+    int myRank,
+    int nRanks,
+    int signalCount,
+    int* results);
 
 } // namespace comms::pipes::test

--- a/comms/pipes/tests/MultiPeerNvlTransportIntegrationTest.cc
+++ b/comms/pipes/tests/MultiPeerNvlTransportIntegrationTest.cc
@@ -13,6 +13,7 @@
 #include "comms/pipes/MultiPeerNvlTransport.h"
 #include "comms/pipes/tests/MultiPeerNvlTransportIntegrationTest.cuh"
 #include "comms/pipes/tests/Utils.cuh"
+#include "comms/pipes/window/WindowMemory.h"
 #include "comms/testinfra/TestXPlatUtils.h"
 #include "comms/testinfra/mpi/MpiBootstrap.h"
 #include "comms/testinfra/mpi/MpiTestUtils.h"
@@ -34,6 +35,10 @@ namespace {
 constexpr std::size_t kDefaultDataBufferSize = 1024 * 1024; // 1MB
 constexpr std::size_t kDefaultChunkSize = 1024;
 constexpr std::size_t kDefaultPipelineDepth = 4;
+
+// Signal and barrier slot counts
+constexpr int kDefaultSignalCount = 2;
+constexpr int kMultiSlotSignalCount = 4;
 
 // Transfer sizes for data tests
 constexpr std::size_t kSmallTransferSize = 1024 * 1024; // 1MB
@@ -62,16 +67,28 @@ class MultiPeerNvlTransportIntegrationTestFixture : public MpiBaseTestFixture {
     MpiBaseTestFixture::TearDown();
   }
 
+  // Bundle that keeps transport and window memory alive together.
+  // WindowMemory must outlive any device objects extracted from it.
+  struct TransportBundle {
+    std::unique_ptr<MultiPeerNvlTransport> transport;
+    std::unique_ptr<WindowMemory> windowMemory;
+    MultiPeerDeviceTransport device;
+  };
+
   // Helper to create a configured transport and get the
   // MultiPeerDeviceTransport
-  std::pair<std::unique_ptr<MultiPeerNvlTransport>, MultiPeerDeviceTransport>
-  createTransport(const MultiPeerNvlTransportConfig& config) {
+  TransportBundle createTransport(
+      const MultiPeerNvlTransportConfig& config,
+      const WindowMemoryConfig& wmConfig = {}) {
     auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
     auto transport = std::make_unique<MultiPeerNvlTransport>(
         globalRank, numRanks, bootstrap, config);
+    auto wm = std::make_unique<WindowMemory>(
+        globalRank, numRanks, bootstrap, wmConfig);
     transport->exchange();
-    auto device = transport->getMultiPeerDeviceTransport();
-    return {std::move(transport), std::move(device)};
+    wm->exchange();
+    auto device = transport->getMultiPeerDeviceTransport(*wm);
+    return {std::move(transport), std::move(wm), device};
   }
 };
 
@@ -88,7 +105,7 @@ TEST_F(
       .pipelineDepth = kDefaultPipelineDepth,
   };
 
-  auto [transport, device] = createTransport(config);
+  auto [transport, wm, device] = createTransport(config);
 
   // Allocate result buffer on device
   DeviceBuffer resultsBuffer(3 * sizeof(int));
@@ -134,12 +151,14 @@ TEST_F(
 
   auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
+  WindowMemory wm(globalRank, numRanks, bootstrap, WindowMemoryConfig{});
   transport.exchange();
+  wm.exchange();
 
   // Call getMultiPeerDeviceTransport() multiple times
-  auto device1 = transport.getMultiPeerDeviceTransport();
-  auto device2 = transport.getMultiPeerDeviceTransport();
-  auto device3 = transport.getMultiPeerDeviceTransport();
+  auto device1 = transport.getMultiPeerDeviceTransport(wm);
+  auto device2 = transport.getMultiPeerDeviceTransport(wm);
+  auto device3 = transport.getMultiPeerDeviceTransport(wm);
 
   // Allocate result buffers
   DeviceBuffer results1Buffer(3 * sizeof(int));
@@ -176,6 +195,118 @@ TEST_F(
 }
 
 // =============================================================================
+// Multi-GPU Signal/Wait Test
+// =============================================================================
+
+TEST_F(MultiPeerNvlTransportIntegrationTestFixture, SignalWait) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Requires exactly 2 ranks, got " << numRanks;
+  }
+
+  MultiPeerNvlTransportConfig config{
+      .dataBufferSize = kDefaultDataBufferSize,
+      .chunkSize = kDefaultChunkSize,
+      .pipelineDepth = kDefaultPipelineDepth,
+  };
+
+  auto [transport, wm, device] = createTransport(config);
+
+  int peerRank = (globalRank == 0) ? 1 : 0;
+
+  DeviceBuffer resultBuffer(sizeof(int));
+  auto result_d = static_cast<int*>(resultBuffer.get());
+  CUDACHECK_TEST(cudaMemset(result_d, 0, sizeof(int)));
+
+  // Rank 0 signals, Rank 1 waits
+  bool isSignaler = (globalRank == 0);
+
+  // Synchronize before starting
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  test::testSignalWait(device, peerRank, 0, isSignaler, result_d);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  int result_h = 0;
+  CUDACHECK_TEST(
+      cudaMemcpy(&result_h, result_d, sizeof(int), cudaMemcpyDeviceToHost));
+
+  EXPECT_EQ(result_h, 1) << "Signal/Wait operation failed";
+
+  XLOGF(
+      INFO,
+      "Rank {}: Signal/Wait test completed (isSignaler={})",
+      globalRank,
+      isSignaler);
+}
+
+// =============================================================================
+// Bidirectional Signal/Wait Test
+// =============================================================================
+
+TEST_F(MultiPeerNvlTransportIntegrationTestFixture, BidirectionalSignalWait) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Requires exactly 2 ranks, got " << numRanks;
+  }
+
+  const size_t dataBufferSize = 1024 * 1024;
+  MultiPeerNvlTransportConfig config{
+      .dataBufferSize = dataBufferSize,
+      .chunkSize = 1024,
+      .pipelineDepth = 4,
+  };
+  WindowMemoryConfig wmConfig{
+      .signalCount = kDefaultSignalCount, // Need 2 slots for bidirectional
+  };
+
+  auto [transport, wm, device] = createTransport(config, wmConfig);
+
+  int peerRank = (globalRank == 0) ? 1 : 0;
+
+  // Use different signal slots for each phase to avoid state accumulation
+  constexpr int kPhase1SignalSlot = 0;
+  constexpr int kPhase2SignalSlot = 1;
+
+  DeviceBuffer result1Buffer(sizeof(int));
+  DeviceBuffer result2Buffer(sizeof(int));
+  auto result1_d = static_cast<int*>(result1Buffer.get());
+  auto result2_d = static_cast<int*>(result2Buffer.get());
+  CUDACHECK_TEST(cudaMemset(result1_d, 0, sizeof(int)));
+  CUDACHECK_TEST(cudaMemset(result2_d, 0, sizeof(int)));
+
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  // Phase 1: Rank 0 signals slot 0, Rank 1 waits on slot 0
+  test::testSignalWait(
+      device, peerRank, kPhase1SignalSlot, globalRank == 0, result1_d);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  // Phase 2: Rank 1 signals slot 1, Rank 0 waits on slot 1
+  // Using different slot to avoid signal value accumulation
+  test::testSignalWait(
+      device, peerRank, kPhase2SignalSlot, globalRank == 1, result2_d);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  int result1_h = 0, result2_h = 0;
+  CUDACHECK_TEST(
+      cudaMemcpy(&result1_h, result1_d, sizeof(int), cudaMemcpyDeviceToHost));
+  CUDACHECK_TEST(
+      cudaMemcpy(&result2_h, result2_d, sizeof(int), cudaMemcpyDeviceToHost));
+
+  EXPECT_EQ(result1_h, 1) << "Phase 1 Signal/Wait failed";
+  EXPECT_EQ(result2_h, 1) << "Phase 2 Signal/Wait failed";
+
+  XLOGF(INFO, "Rank {}: Bidirectional Signal/Wait test completed", globalRank);
+}
+
+// =============================================================================
+
+// =============================================================================
 // Multi-GPU Send/Recv Test
 // =============================================================================
 
@@ -192,7 +323,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, SendRecv) {
       .pipelineDepth = 4,
   };
 
-  auto [transport, device] = createTransport(config);
+  auto [transport, wm, device] = createTransport(config);
 
   int peerRank = (globalRank == 0) ? 1 : 0;
   const size_t numInts = nbytes / sizeof(int);
@@ -257,7 +388,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, BidirectionalSendRecv) {
       .pipelineDepth = 4,
   };
 
-  auto [transport, device] = createTransport(config);
+  auto [transport, wm, device] = createTransport(config);
 
   int peerRank = (globalRank == 0) ? 1 : 0;
   const size_t numInts = nbytes / sizeof(int);
@@ -326,7 +457,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, SendRecvStress) {
       .pipelineDepth = kDefaultPipelineDepth,
   };
 
-  auto [transport, device] = createTransport(config);
+  auto [transport, wm, device] = createTransport(config);
 
   int peerRank = (globalRank == 0) ? 1 : 0;
   const size_t numInts = kSmallTransferSize / sizeof(int);
@@ -395,6 +526,364 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, SendRecvStress) {
 }
 
 // =============================================================================
+// Tests with Custom signalCount Configuration
+// =============================================================================
+
+TEST_F(MultiPeerNvlTransportIntegrationTestFixture, MultipleSignalSlots) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Requires exactly 2 ranks, got " << numRanks;
+  }
+
+  const size_t dataBufferSize = 1024 * 1024;
+  const int numSignalSlots = 4;
+  MultiPeerNvlTransportConfig config{
+      .dataBufferSize = dataBufferSize,
+      .chunkSize = 1024,
+      .pipelineDepth = 4,
+  };
+  WindowMemoryConfig wmConfig{
+      .signalCount = numSignalSlots,
+  };
+
+  auto [transport, wm, device] = createTransport(config, wmConfig);
+
+  int peerRank = (globalRank == 0) ? 1 : 0;
+
+  // Test signaling on each slot
+  for (int slotIdx = 0; slotIdx < numSignalSlots; ++slotIdx) {
+    DeviceBuffer resultBuffer(sizeof(int));
+    auto result_d = static_cast<int*>(resultBuffer.get());
+    CUDACHECK_TEST(cudaMemset(result_d, 0, sizeof(int)));
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    // Alternate which rank signals vs waits for each slot
+    bool isSignaler = ((globalRank + slotIdx) % 2 == 0);
+    test::testSignalWait(device, peerRank, slotIdx, isSignaler, result_d);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    int result_h = 0;
+    CUDACHECK_TEST(
+        cudaMemcpy(&result_h, result_d, sizeof(int), cudaMemcpyDeviceToHost));
+
+    EXPECT_EQ(result_h, 1) << "Signal slot " << slotIdx << " failed on rank "
+                           << globalRank;
+  }
+
+  XLOGF(
+      INFO,
+      "Rank {}: Multiple signal slots test completed ({} slots)",
+      globalRank,
+      numSignalSlots);
+}
+
+TEST_F(MultiPeerNvlTransportIntegrationTestFixture, ConcurrentSignalSlots) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Requires exactly 2 ranks, got " << numRanks;
+  }
+
+  const size_t dataBufferSize = 1024 * 1024;
+  const int numSignalSlots = 4;
+  MultiPeerNvlTransportConfig config{
+      .dataBufferSize = dataBufferSize,
+      .chunkSize = 1024,
+      .pipelineDepth = 4,
+  };
+  WindowMemoryConfig wmConfig{
+      .signalCount = numSignalSlots,
+  };
+
+  auto [transport, wm, device] = createTransport(config, wmConfig);
+
+  int peerRank = (globalRank == 0) ? 1 : 0;
+
+  // Test using all signal slots in sequence within a single phase
+  // Rank 0 signals all slots, Rank 1 waits on all slots
+  std::vector<DeviceBuffer> resultBuffers;
+  std::vector<int*> results_d;
+  for (int i = 0; i < numSignalSlots; ++i) {
+    resultBuffers.emplace_back(sizeof(int));
+    results_d.push_back(static_cast<int*>(resultBuffers.back().get()));
+    CUDACHECK_TEST(cudaMemset(results_d.back(), 0, sizeof(int)));
+  }
+
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  // Signal/wait on all slots
+  for (int slotIdx = 0; slotIdx < numSignalSlots; ++slotIdx) {
+    bool isSignaler = (globalRank == 0);
+    test::testSignalWait(
+        device, peerRank, slotIdx, isSignaler, results_d[slotIdx]);
+  }
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  // Verify all slots succeeded
+  for (int slotIdx = 0; slotIdx < numSignalSlots; ++slotIdx) {
+    int result_h = 0;
+    CUDACHECK_TEST(cudaMemcpy(
+        &result_h, results_d[slotIdx], sizeof(int), cudaMemcpyDeviceToHost));
+    EXPECT_EQ(result_h, 1) << "Concurrent signal slot " << slotIdx
+                           << " failed on rank " << globalRank;
+  }
+
+  XLOGF(
+      INFO,
+      "Rank {}: Concurrent signal slots test completed ({} slots)",
+      globalRank,
+      numSignalSlots);
+}
+
+// =============================================================================
+// Concurrent Signal Multi-Block Test (T3)
+// =============================================================================
+
+TEST_F(
+    MultiPeerNvlTransportIntegrationTestFixture,
+    ConcurrentSignalMultiBlock) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Requires exactly 2 ranks, got " << numRanks;
+  }
+
+  constexpr int kNumBlocks = 4;
+  MultiPeerNvlTransportConfig config{
+      .dataBufferSize = kDefaultDataBufferSize,
+      .chunkSize = kDefaultChunkSize,
+      .pipelineDepth = kDefaultPipelineDepth,
+  };
+  WindowMemoryConfig wmConfig{
+      .signalCount = kMultiSlotSignalCount,
+  };
+
+  auto [transport, wm, device] = createTransport(config, wmConfig);
+
+  int peerRank = (globalRank == 0) ? 1 : 0;
+
+  DeviceBuffer resultsBuffer(kNumBlocks * sizeof(int));
+  auto results_d = static_cast<int*>(resultsBuffer.get());
+  CUDACHECK_TEST(cudaMemset(results_d, 0, kNumBlocks * sizeof(int)));
+
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  // Rank 0 signals on all slots, Rank 1 waits
+  bool isSignaler = (globalRank == 0);
+  test::testConcurrentSignalMultiBlock(
+      device,
+      peerRank,
+      kMultiSlotSignalCount,
+      isSignaler,
+      results_d,
+      kNumBlocks);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  // Verify all blocks completed successfully
+  std::vector<int> results_h(kNumBlocks);
+  CUDACHECK_TEST(cudaMemcpy(
+      results_h.data(),
+      results_d,
+      kNumBlocks * sizeof(int),
+      cudaMemcpyDeviceToHost));
+
+  EXPECT_EQ(results_h, std::vector<int>(kNumBlocks, 1));
+
+  XLOGF(
+      INFO,
+      "Rank {}: Concurrent signal multi-block test completed ({} blocks)",
+      globalRank,
+      kNumBlocks);
+}
+
+// =============================================================================
+// Signal Reset Between Phases Test
+// =============================================================================
+
+TEST_F(MultiPeerNvlTransportIntegrationTestFixture, SignalResetBetweenPhases) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Requires exactly 2 ranks, got " << numRanks;
+  }
+
+  MultiPeerNvlTransportConfig config{
+      .dataBufferSize = kDefaultDataBufferSize,
+      .chunkSize = kDefaultChunkSize,
+      .pipelineDepth = kDefaultPipelineDepth,
+  };
+  WindowMemoryConfig wmConfig{
+      .signalCount = kMultiSlotSignalCount,
+  };
+
+  auto [transport, wm, device] = createTransport(config, wmConfig);
+
+  int peerRank = (globalRank == 0) ? 1 : 0;
+  constexpr int kSignalSlot = 0;
+  constexpr int kNumPhases = 3;
+
+  // Test that signal reuse with reset works correctly across multiple phases
+  // Without reset, signal values would accumulate and waits might pass early
+  for (int phase = 0; phase < kNumPhases; ++phase) {
+    DeviceBuffer resultBuffer(sizeof(int));
+    auto result_d = static_cast<int*>(resultBuffer.get());
+    CUDACHECK_TEST(cudaMemset(result_d, 0, sizeof(int)));
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    // Alternate which rank signals each phase
+    bool isSignaler = ((globalRank + phase) % 2 == 0);
+    test::testSignalWait(device, peerRank, kSignalSlot, isSignaler, result_d);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    int result_h = 0;
+    CUDACHECK_TEST(
+        cudaMemcpy(&result_h, result_d, sizeof(int), cudaMemcpyDeviceToHost));
+
+    EXPECT_EQ(result_h, 1) << "Signal phase " << phase << " failed on rank "
+                           << globalRank;
+
+    // Reset signal between phases to test proper reset functionality
+    // This is done implicitly by using different expected values in
+    // testSignalWait For explicit reset testing, we would call resetSignalFrom
+  }
+
+  XLOGF(
+      INFO,
+      "Rank {}: Signal reset between phases test completed ({} phases)",
+      globalRank,
+      kNumPhases);
+}
+
+// =============================================================================
+// Extended Concurrent Signal Stress Test
+// =============================================================================
+
+TEST_F(
+    MultiPeerNvlTransportIntegrationTestFixture,
+    ConcurrentSignalStressExtended) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Requires exactly 2 ranks, got " << numRanks;
+  }
+
+  // Extended stress test with more blocks and warps
+  constexpr int kNumBlocks = 8;
+  constexpr int kNumSignalSlots = 8;
+  constexpr int kNumIterations = 5;
+
+  MultiPeerNvlTransportConfig config{
+      .dataBufferSize = kDefaultDataBufferSize,
+      .chunkSize = kDefaultChunkSize,
+      .pipelineDepth = kDefaultPipelineDepth,
+  };
+  WindowMemoryConfig wmConfig{
+      .signalCount = kNumSignalSlots,
+  };
+
+  auto [transport, wm, device] = createTransport(config, wmConfig);
+
+  int peerRank = (globalRank == 0) ? 1 : 0;
+
+  for (int iter = 0; iter < kNumIterations; ++iter) {
+    DeviceBuffer resultsBuffer(kNumBlocks * sizeof(int));
+    auto results_d = static_cast<int*>(resultsBuffer.get());
+    CUDACHECK_TEST(cudaMemset(results_d, 0, kNumBlocks * sizeof(int)));
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    // Alternate sender/receiver each iteration
+    bool isSignaler = ((globalRank + iter) % 2 == 0);
+    test::testConcurrentSignalMultiBlock(
+        device, peerRank, kNumSignalSlots, isSignaler, results_d, kNumBlocks);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    // Verify all blocks completed successfully
+    std::vector<int> results_h(kNumBlocks);
+    CUDACHECK_TEST(cudaMemcpy(
+        results_h.data(),
+        results_d,
+        kNumBlocks * sizeof(int),
+        cudaMemcpyDeviceToHost));
+
+    std::vector<int> expected(kNumBlocks, 1);
+    EXPECT_EQ(results_h, expected)
+        << "Iteration " << iter << " failed on rank " << globalRank;
+  }
+
+  XLOGF(
+      INFO,
+      "Rank {}: Concurrent signal stress extended test completed ({} iterations, {} blocks)",
+      globalRank,
+      kNumIterations,
+      kNumBlocks);
+}
+
+// =============================================================================
+// Concurrent Signal Multi-Warp Stress Test (Issue 3)
+// =============================================================================
+
+TEST_F(
+    MultiPeerNvlTransportIntegrationTestFixture,
+    ConcurrentSignalWaitMultiWarp) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Requires exactly 2 ranks, got " << numRanks;
+  }
+
+  // Test with multiple warps within a single block
+  constexpr int kWarpsPerBlock = 4;
+  constexpr int kNumSignalSlots = 8; // More slots than warps to test modulo
+
+  MultiPeerNvlTransportConfig config{
+      .dataBufferSize = kDefaultDataBufferSize,
+      .chunkSize = kDefaultChunkSize,
+      .pipelineDepth = kDefaultPipelineDepth,
+  };
+  WindowMemoryConfig wmConfig{
+      .signalCount = kNumSignalSlots,
+  };
+
+  auto [transport, wm, device] = createTransport(config, wmConfig);
+
+  int peerRank = (globalRank == 0) ? 1 : 0;
+
+  DeviceBuffer resultsBuffer(kWarpsPerBlock * sizeof(int));
+  auto results_d = static_cast<int*>(resultsBuffer.get());
+  CUDACHECK_TEST(cudaMemset(results_d, 0, kWarpsPerBlock * sizeof(int)));
+
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  // Rank 0 signals, Rank 1 waits - each warp uses different slot
+  bool isSignaler = (globalRank == 0);
+  test::testConcurrentSignalWaitMultiWarp(
+      device, peerRank, kNumSignalSlots, isSignaler, results_d, kWarpsPerBlock);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  // Verify all warps completed successfully
+  std::vector<int> results_h(kWarpsPerBlock);
+  CUDACHECK_TEST(cudaMemcpy(
+      results_h.data(),
+      results_d,
+      kWarpsPerBlock * sizeof(int),
+      cudaMemcpyDeviceToHost));
+
+  std::vector<int> expected(kWarpsPerBlock, 1);
+  EXPECT_EQ(results_h, expected)
+      << "Not all warps completed successfully on rank " << globalRank;
+
+  XLOGF(
+      INFO,
+      "Rank {}: Concurrent signal multi-warp test completed ({} warps)",
+      globalRank,
+      kWarpsPerBlock);
+}
+
+// =============================================================================
 // Transport Accessor Verification Test
 // =============================================================================
 
@@ -406,7 +895,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, TransportAccessorTypes) {
       .pipelineDepth = kDefaultPipelineDepth,
   };
 
-  auto [transport, device] = createTransport(config);
+  auto [transport, wm, device] = createTransport(config);
 
   // Allocate result buffer: [numPeers, selfType, peer0Type, peer1Type, ...]
   DeviceBuffer resultsBuffer((1 + numRanks) * sizeof(int));
@@ -436,11 +925,250 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, TransportAccessorTypes) {
   XLOGF(INFO, "Rank {}: Transport accessor types test completed", globalRank);
 }
 
+// =============================================================================
+// signal_all() Test
+// =============================================================================
+
+TEST_F(MultiPeerNvlTransportIntegrationTestFixture, SignalAll) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "Requires at least 2 ranks, got " << numRanks;
+  }
+
+  MultiPeerNvlTransportConfig config{
+      .dataBufferSize = kDefaultDataBufferSize,
+      .chunkSize = kDefaultChunkSize,
+      .pipelineDepth = kDefaultPipelineDepth,
+  };
+
+  auto [transport, wm, device] = createTransport(config);
+
+  constexpr int kSignalerRank = 0;
+  constexpr int kSignalIdx = 0;
+
+  DeviceBuffer resultBuffer(sizeof(int));
+  auto result_d = static_cast<int*>(resultBuffer.get());
+  CUDACHECK_TEST(cudaMemset(result_d, 0, sizeof(int)));
+
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  // Rank 0 signals all peers, all other ranks wait for signal from rank 0
+  test::testSignalAll(device, kSignalerRank, kSignalIdx, result_d);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  int result_h = 0;
+  CUDACHECK_TEST(
+      cudaMemcpy(&result_h, result_d, sizeof(int), cudaMemcpyDeviceToHost));
+
+  EXPECT_EQ(result_h, 1) << "signal_all() operation failed on rank "
+                         << globalRank;
+
+  XLOGF(
+      INFO,
+      "Rank {}: signal_all() test completed (signalerRank={})",
+      globalRank,
+      kSignalerRank);
+}
+
+// =============================================================================
+// wait_signal_from_all() Test
+// =============================================================================
+
+TEST_F(MultiPeerNvlTransportIntegrationTestFixture, WaitSignalFromAll) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "Requires at least 2 ranks, got " << numRanks;
+  }
+
+  MultiPeerNvlTransportConfig config{
+      .dataBufferSize = kDefaultDataBufferSize,
+      .chunkSize = kDefaultChunkSize,
+      .pipelineDepth = kDefaultPipelineDepth,
+  };
+
+  auto [transport, wm, device] = createTransport(config);
+
+  constexpr int kTargetRank = 0;
+  constexpr int kSignalIdx = 0;
+
+  DeviceBuffer resultBuffer(sizeof(int));
+  auto result_d = static_cast<int*>(resultBuffer.get());
+  CUDACHECK_TEST(cudaMemset(result_d, 0, sizeof(int)));
+
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  // All peers signal rank 0, rank 0 waits for signals from all peers
+  test::testWaitSignalFromAll(device, kTargetRank, kSignalIdx, result_d);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  int result_h = 0;
+  CUDACHECK_TEST(
+      cudaMemcpy(&result_h, result_d, sizeof(int), cudaMemcpyDeviceToHost));
+
+  EXPECT_EQ(result_h, 1) << "wait_signal_from_all() operation failed on rank "
+                         << globalRank;
+
+  XLOGF(
+      INFO,
+      "Rank {}: wait_signal_from_all() test completed (targetRank={})",
+      globalRank,
+      kTargetRank);
+}
+
+// =============================================================================
+// CmpOp::CMP_EQ Test
+// =============================================================================
+
+TEST_F(MultiPeerNvlTransportIntegrationTestFixture, WaitWithCmpEq) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Requires exactly 2 ranks, got " << numRanks;
+  }
+
+  MultiPeerNvlTransportConfig config{
+      .dataBufferSize = kDefaultDataBufferSize,
+      .chunkSize = kDefaultChunkSize,
+      .pipelineDepth = kDefaultPipelineDepth,
+  };
+
+  auto [transport, wm, device] = createTransport(config);
+
+  int peerRank = (globalRank == 0) ? 1 : 0;
+  constexpr int kSignalIdx = 0;
+  constexpr uint64_t kExpectedValue = 42;
+
+  DeviceBuffer resultBuffer(sizeof(int));
+  auto result_d = static_cast<int*>(resultBuffer.get());
+  CUDACHECK_TEST(cudaMemset(result_d, 0, sizeof(int)));
+
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  // Rank 0 signals with exact value using SIGNAL_SET, Rank 1 waits with CMP_EQ
+  bool isSignaler = (globalRank == 0);
+  test::testWaitWithCmpEq(
+      device, peerRank, kSignalIdx, kExpectedValue, isSignaler, result_d);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  int result_h = 0;
+  CUDACHECK_TEST(
+      cudaMemcpy(&result_h, result_d, sizeof(int), cudaMemcpyDeviceToHost));
+
+  EXPECT_EQ(result_h, 1) << "CMP_EQ wait operation failed on rank "
+                         << globalRank;
+
+  XLOGF(
+      INFO,
+      "Rank {}: WaitWithCmpEq test completed (expectedValue={})",
+      globalRank,
+      kExpectedValue);
+}
+
+// =============================================================================
+// Monotonic Wait Values Test
+// =============================================================================
+
+TEST_F(MultiPeerNvlTransportIntegrationTestFixture, MonotonicWaitValues) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Requires exactly 2 ranks, got " << numRanks;
+  }
+
+  MultiPeerNvlTransportConfig config{
+      .dataBufferSize = kDefaultDataBufferSize,
+      .chunkSize = kDefaultChunkSize,
+      .pipelineDepth = kDefaultPipelineDepth,
+  };
+
+  auto [transport, wm, device] = createTransport(config);
+
+  int peerRank = (globalRank == 0) ? 1 : 0;
+  constexpr int kSignalIdx = 0;
+  constexpr int kNumIterations = 5;
+
+  DeviceBuffer resultBuffer(sizeof(int));
+  auto result_d = static_cast<int*>(resultBuffer.get());
+  CUDACHECK_TEST(cudaMemset(result_d, 0, sizeof(int)));
+
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  // Test monotonically increasing wait values pattern:
+  // signal(1), wait_for(1), signal(1), wait_for(2), etc.
+  bool isSignaler = (globalRank == 0);
+  test::testMonotonicWaitValues(
+      device, peerRank, kSignalIdx, kNumIterations, isSignaler, result_d);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  int result_h = 0;
+  CUDACHECK_TEST(
+      cudaMemcpy(&result_h, result_d, sizeof(int), cudaMemcpyDeviceToHost));
+
+  EXPECT_EQ(result_h, 1) << "Monotonic wait values test failed on rank "
+                         << globalRank;
+
+  XLOGF(
+      INFO,
+      "Rank {}: MonotonicWaitValues test completed ({} iterations)",
+      globalRank,
+      kNumIterations);
+}
+
+// =============================================================================
+// SIGNAL_SET Integration Test
+// =============================================================================
+
+TEST_F(MultiPeerNvlTransportIntegrationTestFixture, SignalWithSet) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Requires exactly 2 ranks, got " << numRanks;
+  }
+
+  MultiPeerNvlTransportConfig config{
+      .dataBufferSize = kDefaultDataBufferSize,
+      .chunkSize = kDefaultChunkSize,
+      .pipelineDepth = kDefaultPipelineDepth,
+  };
+
+  auto [transport, wm, device] = createTransport(config);
+
+  int peerRank = (globalRank == 0) ? 1 : 0;
+  constexpr int kSignalIdx = 0;
+  constexpr uint64_t kSetValue = 100;
+
+  DeviceBuffer resultBuffer(sizeof(int));
+  auto result_d = static_cast<int*>(resultBuffer.get());
+  CUDACHECK_TEST(cudaMemset(result_d, 0, sizeof(int)));
+
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  // Rank 0 signals using SIGNAL_SET, Rank 1 waits for the set value
+  bool isSignaler = (globalRank == 0);
+  test::testSignalWithSet(
+      device, peerRank, kSignalIdx, kSetValue, isSignaler, result_d);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  int result_h = 0;
+  CUDACHECK_TEST(
+      cudaMemcpy(&result_h, result_d, sizeof(int), cudaMemcpyDeviceToHost));
+
+  EXPECT_EQ(result_h, 1) << "SIGNAL_SET operation failed on rank "
+                         << globalRank;
+
+  XLOGF(
+      INFO,
+      "Rank {}: SignalWithSet test completed (setValue={})",
+      globalRank,
+      kSetValue);
+}
+
 } // namespace comms::pipes::tests
 
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
-  auto mpi_env = std::make_unique<MPIEnvironmentBase>();
   ::testing::AddGlobalTestEnvironment(new MPIEnvironmentBase);
   folly::Init init(&argc, &argv);
   return RUN_ALL_TESTS();

--- a/comms/pipes/tests/MultiPeerNvlTransportIntegrationTest.cuh
+++ b/comms/pipes/tests/MultiPeerNvlTransportIntegrationTest.cuh
@@ -20,6 +20,25 @@ void testMultiPeerDeviceTransportAccessors(
     int* results);
 
 /**
+ * Test kernel: Signal from one rank to another and wait for it
+ *
+ * Uses inbox-model signaling: rank signals to peer's inbox, peer waits on own
+ * inbox.
+ *
+ * @param transport The MultiPeerDeviceTransport to use
+ * @param targetRank The target rank to signal/wait from
+ * @param signalIdx The signal slot index to use
+ * @param isSignaler If true, this rank signals; if false, this rank waits
+ * @param result Output: 1 if successful, 0 if failed
+ */
+void testSignalWait(
+    MultiPeerDeviceTransport& transport,
+    int targetRank,
+    int signalIdx,
+    bool isSignaler,
+    int* result);
+
+/**
  * Test kernel: Send data from this rank to a single peer
  *
  * @param transport The MultiPeerDeviceTransport to use
@@ -78,6 +97,26 @@ void testMultiPeerSendRecvAllPeers(
     int blockSize);
 
 /**
+ * Test kernel: Concurrent signal/barrier using multiple blocks
+ *
+ * Each block uses different signal/barrier slots concurrently
+ * to verify no races or deadlocks.
+ *
+ * @param transport The MultiPeerDeviceTransport to use
+ * @param targetRank The target rank to signal/wait from
+ * @param numSlots Number of slots to test concurrently
+ * @param isSignaler If true, this rank signals; if false, waits
+ * @param results Output array: results[blockIdx] = 1 if successful
+ */
+void testConcurrentSignalMultiBlock(
+    MultiPeerDeviceTransport& transport,
+    int targetRank,
+    int numSlots,
+    bool isSignaler,
+    int* results,
+    int numBlocks);
+
+/**
  * Test kernel: Verify transport type accessors
  *
  * Checks that get_peer_transport() and get_self_transport() return correct
@@ -89,5 +128,123 @@ void testMultiPeerSendRecvAllPeers(
 void testTransportTypes(
     const MultiPeerDeviceTransport& transport,
     int* results);
+
+/**
+ * Test kernel: Concurrent signal/wait from multiple warps within a block
+ *
+ * Each warp uses a different signal slot to verify thread-safety of
+ * signal operations when multiple warps operate concurrently.
+ *
+ * @param transport The MultiPeerDeviceTransport to use
+ * @param targetRank The target rank to signal/wait from
+ * @param numSlots Number of signal slots (should be >= warps per block)
+ * @param isSignaler If true, this rank signals; if false, waits
+ * @param results Output array: results[warpIdx] = 1 if successful
+ * @param warpsPerBlock Number of warps per block
+ */
+void testConcurrentSignalWaitMultiWarp(
+    MultiPeerDeviceTransport& transport,
+    int targetRank,
+    int numSlots,
+    bool isSignaler,
+    int* results,
+    int warpsPerBlock);
+
+/**
+ * Test kernel: signal_all() signals all peers at once
+ *
+ * Tests that signal_all() correctly signals all peers (excluding self).
+ * One rank signals, all other ranks wait for the signal.
+ *
+ * @param transport The MultiPeerDeviceTransport to use
+ * @param signalerRank The rank that will call signal_all()
+ * @param signalIdx The signal slot index to use
+ * @param result Output: 1 if successful
+ */
+void testSignalAll(
+    MultiPeerDeviceTransport& transport,
+    int signalerRank,
+    int signalIdx,
+    int* result);
+
+/**
+ * Test kernel: wait_signal_from_all() barrier-like synchronization
+ *
+ * Tests that wait_signal_from_all() correctly waits for signals from
+ * all peers. All peers signal one rank, that rank waits for all.
+ *
+ * @param transport The MultiPeerDeviceTransport to use
+ * @param targetRank The rank that will call wait_signal_from_all()
+ * @param signalIdx The signal slot index to use
+ * @param result Output: 1 if successful
+ */
+void testWaitSignalFromAll(
+    MultiPeerDeviceTransport& transport,
+    int targetRank,
+    int signalIdx,
+    int* result);
+
+/**
+ * Test kernel: Wait with CMP_EQ comparison operation
+ *
+ * Tests exact equality comparison (vs CMP_GE which is more commonly used).
+ * Signals with exact value, waits with CMP_EQ.
+ *
+ * @param transport The MultiPeerDeviceTransport to use
+ * @param targetRank The target rank to signal/wait from
+ * @param signalIdx The signal slot index to use
+ * @param expectedValue The value to signal and wait for
+ * @param isSignaler If true, this rank signals; if false, waits
+ * @param result Output: 1 if successful
+ */
+void testWaitWithCmpEq(
+    MultiPeerDeviceTransport& transport,
+    int targetRank,
+    int signalIdx,
+    uint64_t expectedValue,
+    bool isSignaler,
+    int* result);
+
+/**
+ * Test kernel: Monotonically increasing wait values pattern
+ *
+ * Tests the recommended pattern of using monotonically increasing wait
+ * values (signal 1, wait for 1, signal 1, wait for 2, etc.) across
+ * multiple iterations.
+ *
+ * @param transport The MultiPeerDeviceTransport to use
+ * @param targetRank The target rank to signal/wait from
+ * @param signalIdx The signal slot index to use
+ * @param numIterations Number of iterations to perform
+ * @param isSignaler If true, this rank signals; if false, waits
+ * @param result Output: 1 if all iterations successful
+ */
+void testMonotonicWaitValues(
+    MultiPeerDeviceTransport& transport,
+    int targetRank,
+    int signalIdx,
+    int numIterations,
+    bool isSignaler,
+    int* result);
+
+/**
+ * Test kernel: SIGNAL_SET operation in multi-GPU context
+ *
+ * Tests that SIGNAL_SET correctly overwrites values in multi-GPU signaling.
+ *
+ * @param transport The MultiPeerDeviceTransport to use
+ * @param targetRank The target rank to signal/wait from
+ * @param signalIdx The signal slot index to use
+ * @param setValue The value to SET
+ * @param isSignaler If true, this rank signals; if false, waits
+ * @param result Output: 1 if successful
+ */
+void testSignalWithSet(
+    MultiPeerDeviceTransport& transport,
+    int targetRank,
+    int signalIdx,
+    uint64_t setValue,
+    bool isSignaler,
+    int* result);
 
 } // namespace comms::pipes::test

--- a/comms/pipes/tests/WindowMemoryTest.cc
+++ b/comms/pipes/tests/WindowMemoryTest.cc
@@ -1,0 +1,130 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include <folly/init/Init.h>
+#include <folly/logging/xlog.h>
+
+#include "comms/pipes/window/WindowMemory.h"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/testinfra/mpi/MpiBootstrap.h"
+#include "comms/testinfra/mpi/MpiTestUtils.h"
+
+using comms::pipes::MemSharingMode;
+using comms::pipes::WindowMemory;
+using comms::pipes::WindowMemoryConfig;
+using meta::comms::MpiBaseTestFixture;
+using meta::comms::MpiBootstrap;
+using meta::comms::MPIEnvironmentBase;
+
+namespace comms::pipes::tests {
+
+class WindowMemoryTestFixture : public MpiBaseTestFixture {
+ protected:
+  void SetUp() override {
+    MpiBaseTestFixture::SetUp();
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+  }
+
+  void TearDown() override {
+    MpiBaseTestFixture::TearDown();
+  }
+};
+
+/**
+ * Test construction with valid parameters.
+ */
+TEST_F(WindowMemoryTestFixture, Construction) {
+  auto bootstrap = std::make_shared<MpiBootstrap>();
+  WindowMemoryConfig config{.signalCount = 4};
+  WindowMemory signals(globalRank, numRanks, bootstrap, config);
+
+  EXPECT_EQ(signals.rank(), globalRank);
+  EXPECT_EQ(signals.nRanks(), numRanks);
+  EXPECT_EQ(signals.signalCount(), 4);
+  EXPECT_FALSE(signals.isExchanged());
+}
+
+/**
+ * Test exchange and state verification.
+ */
+TEST_F(WindowMemoryTestFixture, ExchangeAndStateVerification) {
+  auto bootstrap = std::make_shared<MpiBootstrap>();
+  WindowMemoryConfig config{.signalCount = 2};
+  WindowMemory signals(globalRank, numRanks, bootstrap, config);
+
+  signals.exchange();
+
+  EXPECT_TRUE(signals.isExchanged());
+  // Note: getDeviceWindowSignal() is tested via MultiPeerNvlTransport
+  // integration tests since it requires CUDA compilation
+}
+
+/**
+ * Test various signal counts.
+ */
+TEST_F(WindowMemoryTestFixture, VariousSignalCounts) {
+  auto bootstrap = std::make_shared<MpiBootstrap>();
+
+  for (std::size_t signalCount : {1, 2, 4, 8, 16}) {
+    WindowMemoryConfig config{.signalCount = signalCount};
+    WindowMemory signals(globalRank, numRanks, bootstrap, config);
+
+    signals.exchange();
+
+    EXPECT_EQ(signals.signalCount(), signalCount);
+    EXPECT_TRUE(signals.isExchanged());
+  }
+}
+
+/**
+ * Test explicit memory sharing modes.
+ */
+TEST_F(WindowMemoryTestFixture, ExplicitCudaIpcMode) {
+  auto bootstrap = std::make_shared<MpiBootstrap>();
+  WindowMemoryConfig config{.signalCount = 2};
+
+  // Explicitly request cudaIpc mode
+  WindowMemory signals(
+      globalRank, numRanks, bootstrap, config, MemSharingMode::kCudaIpc);
+
+  EXPECT_EQ(signals.getMemSharingMode(), MemSharingMode::kCudaIpc);
+
+  signals.exchange();
+
+  EXPECT_TRUE(signals.isExchanged());
+}
+
+/**
+ * Test single rank scenario.
+ */
+TEST_F(WindowMemoryTestFixture, SingleRankExchange) {
+  // This test creates WindowMemory with nRanks=1, which requires a single-rank
+  // MPI environment to avoid bootstrap/rank mismatch issues
+  if (numRanks > 1) {
+    GTEST_SKIP() << "Single rank test requires single MPI rank";
+  }
+
+  auto bootstrap = std::make_shared<MpiBootstrap>();
+  WindowMemoryConfig config{.signalCount = 2};
+
+  WindowMemory signals(0 /* myRank */, 1 /* nRanks */, bootstrap, config);
+
+  signals.exchange();
+
+  EXPECT_TRUE(signals.isExchanged());
+}
+
+// Note: getDeviceWindowSignal() error path (calling before exchange()) and
+// success path are tested via MultiPeerNvlTransport integration tests since
+// DeviceWindowSignal requires CUDA compilation (.cuh file with __device__
+// methods).
+
+} // namespace comms::pipes::tests
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new MPIEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/pipes/window/DeviceWindowMemory.cuh
+++ b/comms/pipes/window/DeviceWindowMemory.cuh
@@ -1,0 +1,39 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include "comms/pipes/window/DeviceWindowSignal.cuh"
+
+namespace comms::pipes {
+
+/**
+ * DeviceWindowMemory - Device-side bundle of synchronization primitives
+ *
+ * Bundles DeviceWindowSignal (and later on, DeviceBarrier) into a single
+ * device-side object for convenient passing to CUDA kernels.
+ *
+ * Returned by WindowMemory::getDeviceWindowMemory() after exchange().
+ *
+ * This is a lightweight handle (contains only DeviceWindowSignal and eventually
+ * DeviceBarrier as well) that can be passed by value to CUDA kernels.
+ */
+class DeviceWindowMemory {
+ public:
+  __host__ __device__ DeviceWindowMemory() = default;
+
+  __host__ __device__ explicit DeviceWindowMemory(DeviceWindowSignal signal)
+      : signal_(signal) {}
+
+  __host__ __device__ __forceinline__ DeviceWindowSignal& signal() {
+    return signal_;
+  }
+
+  __host__ __device__ __forceinline__ const DeviceWindowSignal& signal() const {
+    return signal_;
+  }
+
+ private:
+  DeviceWindowSignal signal_;
+};
+
+} // namespace comms::pipes

--- a/comms/pipes/window/DeviceWindowSignal.cuh
+++ b/comms/pipes/window/DeviceWindowSignal.cuh
@@ -1,0 +1,345 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cassert>
+#include <cstdint>
+#include "comms/pipes/DeviceSpan.cuh"
+#include "comms/pipes/SignalState.cuh"
+#include "comms/pipes/ThreadGroup.cuh"
+
+namespace comms::pipes {
+
+// Debug-only bounds check helpers for device code
+// TODO(D91689639): Replace with PIPES_DEVICE_CHECK_MSG once D91689639 lands
+#ifdef __CUDA_ARCH__
+#define DEVICE_WINDOW_SIGNAL_CHECK_RANK(target_rank, nRanks)            \
+  do {                                                                  \
+    if (!((target_rank) >= 0 && (target_rank) < (nRanks))) {            \
+      printf(                                                           \
+          "DeviceWindowSignal: target_rank %d out of range [0, %d) at " \
+          "%s:%d block=(%u,%u,%u) thread=(%u,%u,%u)\n",                 \
+          (int)(target_rank),                                           \
+          (int)(nRanks),                                                \
+          __FILE__,                                                     \
+          __LINE__,                                                     \
+          blockIdx.x,                                                   \
+          blockIdx.y,                                                   \
+          blockIdx.z,                                                   \
+          threadIdx.x,                                                  \
+          threadIdx.y,                                                  \
+          threadIdx.z);                                                 \
+      __trap();                                                         \
+    }                                                                   \
+  } while (0)
+
+#define DEVICE_WINDOW_SIGNAL_CHECK_NOT_SELF(target_rank, myRank) \
+  do {                                                           \
+    if ((target_rank) == (myRank)) {                             \
+      printf(                                                    \
+          "DeviceWindowSignal: cannot signal self (rank %d) at " \
+          "%s:%d block=(%u,%u,%u) thread=(%u,%u,%u)\n",          \
+          (int)(target_rank),                                    \
+          __FILE__,                                              \
+          __LINE__,                                              \
+          blockIdx.x,                                            \
+          blockIdx.y,                                            \
+          blockIdx.z,                                            \
+          threadIdx.x,                                           \
+          threadIdx.y,                                           \
+          threadIdx.z);                                          \
+      __trap();                                                  \
+    }                                                            \
+  } while (0)
+
+#define DEVICE_WINDOW_SIGNAL_CHECK_SIGNAL_ID(signal_id, signalCount)  \
+  do {                                                                \
+    if (!((signal_id) >= 0 && (signal_id) < (signalCount))) {         \
+      printf(                                                         \
+          "DeviceWindowSignal: signal_id %d out of range [0, %d) at " \
+          "%s:%d block=(%u,%u,%u) thread=(%u,%u,%u)\n",               \
+          (int)(signal_id),                                           \
+          (int)(signalCount),                                         \
+          __FILE__,                                                   \
+          __LINE__,                                                   \
+          blockIdx.x,                                                 \
+          blockIdx.y,                                                 \
+          blockIdx.z,                                                 \
+          threadIdx.x,                                                \
+          threadIdx.y,                                                \
+          threadIdx.z);                                               \
+      __trap();                                                       \
+    }                                                                 \
+  } while (0)
+#else
+#define DEVICE_WINDOW_SIGNAL_CHECK_RANK(target_rank, nRanks) \
+  assert((target_rank) >= 0 && (target_rank) < (nRanks))
+#define DEVICE_WINDOW_SIGNAL_CHECK_NOT_SELF(target_rank, myRank) \
+  assert((target_rank) != (myRank))
+#define DEVICE_WINDOW_SIGNAL_CHECK_SIGNAL_ID(signal_id, signalCount) \
+  assert((signal_id) >= 0 && (signal_id) < (signalCount))
+#endif
+
+/**
+ * DeviceWindowSignal - Device-side signal object with per-signal inbox
+ * semantics
+ *
+ * Implements NCCL-style "per-signal inbox" model for multi-peer signaling:
+ * - Each rank has a single inbox buffer (local memory)
+ * - All peers write to the SAME slot for a given signal_id
+ * - Values accumulate: slot[signal_id] += value from each peer
+ * - Inbox size = signalCount (one slot per signal)
+ *
+ * RANK-BASED API:
+ * All peer-facing APIs use global rank in [0, nRanks), not peer index.
+ * Internally, peerSignals_ has nPeers entries (excludes self). The
+ * rank_to_peer_index() helper converts rank to the internal peer index.
+ *
+ * SIGNAL VS COUNTER (NCCL semantics):
+ * - Signal: Written to REMOTE peer's memory (remote completion notification)
+ * - Counter: Written to LOCAL memory (source buffer consumed, safe to reuse)
+ *
+ * This class implements the Signal semantics. We will later introduce
+ * DeviceCounter for local completion tracking.
+ *
+ * SLOT MAPPING (NCCL-style):
+ * All peers write to the same slot: slot = signal_id
+ * Values accumulate from all peers who signal with the same signal_id.
+ *
+ * WAIT SEMANTICS:
+ * wait_signal() waits for the accumulated value in the inbox slot to reach
+ * the expected threshold. With N peers each signaling value=1:
+ *   wait_signal(group, signal_id, CMP_GE, N)  // Wait for all N peers
+ *
+ * v1: Unicast writes (parallel writes to each peer)
+ * v2 (future): Multi-mem multicast optimization
+ *
+ * RESET OPERATIONS:
+ * DeviceWindowSignal intentionally has NO reset operations. Signals are written
+ * by REMOTE peers to this rank's inbox via NVLink. A local reset while a
+ * remote peer is signaling creates a race condition. Use monotonically
+ * increasing values (wait for N, then 2N, ...) instead of resetting.
+ *
+ * SIGNAL LIFETIME AND REUSE:
+ * ==========================
+ * Signal values accumulate across operations. For long-running workloads:
+ *
+ * Option 1: Use monotonically increasing wait values
+ *   signal.signal_peer(group, target_rank, slot, SIGNAL_ADD, 1);
+ *   signal.wait_signal(group, slot, CMP_GE, N);  // Wait for N total signals
+ *
+ * Option 2: Rotate between signal slots
+ *   int slot = iteration % signalCount;  // Use different slots per phase
+ *
+ * Option 3: Reset between phases (requires host synchronization)
+ *   // After MPI_Barrier, before new phase:
+ *   cudaMemset(signalInboxPtr, 0, signalInboxSize);
+ *
+ * BOUNDS CHECKING:
+ * ================
+ * In device builds (__CUDA_ARCH__ defined), invalid target_rank or signal_id
+ * values trigger __trap() with a descriptive error message showing the invalid
+ * value, valid range, file/line, and block/thread indices.
+ *
+ * USAGE:
+ *   // Sender (rank 0) signals receiver (rank 1) that data is ready
+ *   signal.signal_peer(group, 1, 0, SignalOp::SIGNAL_ADD, 1);
+ *
+ *   // Receiver (rank 1) waits for accumulated signals
+ *   signal.wait_signal(group, 0, CmpOp::CMP_GE, 1);
+ *
+ *   // Wait for signals from all N-1 peers (barrier-like)
+ *   signal.wait_signal(group, 0, CmpOp::CMP_GE, nRanks - 1);
+ */
+class DeviceWindowSignal {
+ public:
+  __host__ __device__ DeviceWindowSignal() = default;
+
+  /**
+   * Construct a DeviceWindowSignal with inbox semantics
+   *
+   * @param myRank This rank's ID
+   * @param nRanks Total number of ranks
+   * @param signalCount Number of signal slots per peer
+   * @param localInbox This rank's inbox (local memory, size = signalCount)
+   * @param peerSignals Peers' inboxes (for remote writes)
+   */
+  __host__ __device__ DeviceWindowSignal(
+      int myRank,
+      int nRanks,
+      int signalCount,
+      DeviceSpan<SignalState> localInbox,
+      DeviceSpan<DeviceSpan<SignalState>> peerSignals)
+      : myRank_(myRank),
+        nRanks_(nRanks),
+        signalCount_(signalCount),
+        localInbox_(localInbox),
+        peerSignals_(peerSignals) {}
+
+  // ===========================================================================
+  // Signal Operations (writing to target's inbox)
+  // ===========================================================================
+
+  /**
+   * signal_peer - Signal a specific peer by writing to their inbox.
+   *
+   * Writes to the target's inbox at the signal_id slot.
+   * Uses release semantics for memory ordering.
+   *
+   * @param group ThreadGroup for cooperative processing
+   * @param target_rank Global rank in [0, nRanks), must not be self
+   * @param signal_id Index within this rank's slot range (0 to signalCount-1)
+   * @param op SIGNAL_SET or SIGNAL_ADD
+   * @param value Value to set or add (default: 1)
+   */
+  __device__ __forceinline__ void signal_peer(
+      ThreadGroup& group,
+      int target_rank,
+      int signal_id,
+      SignalOp op = SignalOp::SIGNAL_ADD,
+      uint64_t value = 1) {
+    DEVICE_WINDOW_SIGNAL_CHECK_RANK(target_rank, nRanks_);
+    DEVICE_WINDOW_SIGNAL_CHECK_NOT_SELF(target_rank, myRank_);
+    DEVICE_WINDOW_SIGNAL_CHECK_SIGNAL_ID(signal_id, signalCount_);
+    int peer = rank_to_peer_index(target_rank);
+    peerSignals_[peer][signal_id].signal(group, op, value);
+  }
+
+  /**
+   * signal_all - Signal all peers (parallel unicast writes)
+   *
+   * Writes to all peers' inboxes via NVLink.
+   * Uses thread-level parallelism: each thread signals different peers.
+   * v1: Parallel unicast writes to each peer
+   * v2 (future): Multi-mem multicast for efficiency
+   *
+   * MEMORY ORDERING: Syncs before signaling to ensure all threads' prior
+   * writes are visible. The single-thread signal() uses release semantics
+   * which only guarantees THIS thread's writes are visible. A preceding
+   * group.sync() ensures ALL threads' writes are complete before any signal
+   * is sent.
+   *
+   * @param group ThreadGroup for cooperative processing
+   * @param signal_id Index within this rank's slot range
+   * @param op SIGNAL_SET or SIGNAL_ADD
+   * @param value Value to set or add (default: 1)
+   */
+  __device__ __forceinline__ void signal_all(
+      ThreadGroup& group,
+      int signal_id,
+      SignalOp op = SignalOp::SIGNAL_ADD,
+      uint64_t value = 1) {
+    DEVICE_WINDOW_SIGNAL_CHECK_SIGNAL_ID(signal_id, signalCount_);
+
+    // Sync BEFORE: ensures all threads' prior writes are complete
+    group.sync();
+
+    // Thread-level parallelism: each thread signals different peers
+    // peerSignals_ has nPeers entries (excludes self)
+    int nPeers = static_cast<int>(peerSignals_.size());
+    for (int peer = static_cast<int>(group.thread_id_in_group); peer < nPeers;
+         peer += static_cast<int>(group.group_size)) {
+      peerSignals_[peer][signal_id].signal(op, value);
+    }
+
+    // Sync AFTER: ensures all signals complete before returning
+    group.sync();
+  }
+
+  // ===========================================================================
+  // Wait Operations (reading from local inbox)
+  // ===========================================================================
+
+  /**
+   * wait_signal - Wait for accumulated signal value
+   *
+   * Polls local inbox at the signal_id slot until the condition is met.
+   * Uses acquire semantics for memory ordering.
+   *
+   * In the per-signal inbox model, all peers write to the same slot, so
+   * the accumulated value represents the sum of all received signals.
+   *
+   * @param group ThreadGroup for cooperative processing
+   * @param signal_id Index of the signal slot (0 to signalCount-1)
+   * @param cmp Comparison operation (CMP_EQ, CMP_GE, etc.)
+   * @param value Value to compare against (e.g., nRanks-1 for all peers)
+   * @param timeout_ns Optional timeout in nanoseconds (default: infinite)
+   */
+  __device__ __forceinline__ void wait_signal(
+      ThreadGroup& group,
+      int signal_id,
+      CmpOp cmp,
+      uint64_t value,
+      [[maybe_unused]] uint64_t timeout_ns = UINT64_MAX) {
+    DEVICE_WINDOW_SIGNAL_CHECK_SIGNAL_ID(signal_id, signalCount_);
+    localInbox_[signal_id].wait_until(group, cmp, value);
+  }
+
+  // ===========================================================================
+  // Non-blocking Read Operations
+  // ===========================================================================
+
+  /**
+   * read_signal - Read current signal value from a slot (non-blocking)
+   *
+   * @param signal_id Index of the signal slot
+   * @return Current accumulated signal value
+   */
+  __device__ __forceinline__ uint64_t read_signal(int signal_id) {
+    DEVICE_WINDOW_SIGNAL_CHECK_SIGNAL_ID(signal_id, signalCount_);
+    return localInbox_[signal_id].load();
+  }
+
+  // ===========================================================================
+  // Accessors
+  // ===========================================================================
+
+  __device__ __forceinline__ int rank() const {
+    return myRank_;
+  }
+
+  __device__ __forceinline__ int n_ranks() const {
+    return nRanks_;
+  }
+
+  __device__ __forceinline__ int num_peers() const {
+    return static_cast<int>(peerSignals_.size());
+  }
+
+  __device__ __forceinline__ int signal_count() const {
+    return signalCount_;
+  }
+
+ private:
+  /**
+   * rank_to_peer_index - Convert global rank to internal peer index
+   *
+   * Peer index excludes self: ranks below myRank_ map directly,
+   * ranks above myRank_ are shifted down by one.
+   *
+   * @param rank Global rank (must NOT be myRank_)
+   * @return Peer index for indexing into peerSignals_
+   */
+  __device__ __forceinline__ int rank_to_peer_index(int rank) const {
+    return (rank < myRank_) ? rank : (rank - 1);
+  }
+
+  int myRank_{-1};
+  int nRanks_{0};
+  int signalCount_{0};
+  DeviceSpan<SignalState> localInbox_;
+  DeviceSpan<DeviceSpan<SignalState>> peerSignals_;
+};
+
+/**
+ * getSignalInboxBufferSize - Calculate buffer size for signal inbox
+ *
+ * @param signalCount Number of signal slots
+ * @return Size in bytes, aligned to 128-byte boundary
+ */
+__host__ __device__ __forceinline__ std::size_t getSignalInboxBufferSize(
+    int signalCount) {
+  return getSignalBufferSize(signalCount);
+}
+
+} // namespace comms::pipes

--- a/comms/pipes/window/WindowMemory.cc
+++ b/comms/pipes/window/WindowMemory.cc
@@ -1,0 +1,103 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/window/WindowMemory.h"
+
+#include <vector>
+
+#include "comms/pipes/window/DeviceWindowMemory.cuh"
+#include "comms/pipes/window/DeviceWindowSignal.cuh"
+#include "comms/utils/checks.h"
+
+namespace comms::pipes {
+
+WindowMemory::WindowMemory(
+    int myRank,
+    int nRanks,
+    std::shared_ptr<ctran::bootstrap::IBootstrap> bootstrap,
+    const WindowMemoryConfig& config,
+    MemSharingMode memSharingMode)
+    : myRank_(myRank),
+      nRanks_(nRanks),
+      bootstrap_(std::move(bootstrap)),
+      config_(config),
+      memSharingMode_(memSharingMode) {
+  // Calculate inbox size: signalCount * sizeof(SignalState)
+  // Note: sizeof(SignalState) == 128 due to alignas(128) on the struct
+  inboxSize_ = getSignalInboxBufferSize(static_cast<int>(config_.signalCount));
+
+  // Allocate inbox buffer using GpuMemHandler (needs exchange with peers)
+  inboxHandler_ = std::make_unique<GpuMemHandler>(
+      bootstrap_, myRank_, nRanks_, inboxSize_, memSharingMode_);
+
+  // Initialize inbox to zero
+  std::vector<SignalState> initStates(config_.signalCount);
+  CUDA_CHECK(cudaMemcpy(
+      inboxHandler_->getLocalDeviceMemPtr(),
+      initStates.data(),
+      inboxSize_,
+      cudaMemcpyDefault));
+
+  // Allocate peer signal spans array (populate later in exchange())
+  // Each entry is a DeviceSpan<SignalState> pointing to a peer's inbox
+  // Size = nPeers (not nRanks) - excludes self
+  int nPeers = nRanks_ - 1;
+  std::size_t spanArraySize = nPeers * sizeof(DeviceSpan<SignalState>);
+  peerInboxPtrsDevice_ =
+      std::make_unique<meta::comms::DeviceBuffer>(spanArraySize);
+}
+
+void WindowMemory::exchange() {
+  // Exchange inbox handles so peers can write to our inbox
+  inboxHandler_->exchangeMemPtrs();
+
+  // Build peer signal spans on host (peer-indexed, excludes self)
+  // Each span wraps a peer's inbox pointer + signalCount
+  int nPeers = nRanks_ - 1;
+  auto signalCount = static_cast<uint32_t>(config_.signalCount);
+  std::vector<DeviceSpan<SignalState>> peerSpans;
+  peerSpans.reserve(nPeers);
+  for (int peerIdx = 0; peerIdx < nPeers; ++peerIdx) {
+    int rank = peerToRank(peerIdx);
+    auto* ptr =
+        static_cast<SignalState*>(inboxHandler_->getPeerDeviceMemPtr(rank));
+    peerSpans.emplace_back(ptr, signalCount);
+  }
+
+  // Copy peer spans to device (buffer already allocated in constructor)
+  CUDA_CHECK(cudaMemcpy(
+      peerInboxPtrsDevice_->get(),
+      peerSpans.data(),
+      nPeers * sizeof(DeviceSpan<SignalState>),
+      cudaMemcpyDefault));
+
+  exchanged_ = true;
+}
+
+DeviceWindowSignal WindowMemory::getDeviceWindowSignal() const {
+  if (!exchanged_) {
+    throw std::runtime_error(
+        "WindowMemory::getDeviceWindowSignal() called before exchange()");
+  }
+
+  // Build DeviceWindowSignal object
+  SignalState* localInbox =
+      static_cast<SignalState*>(inboxHandler_->getLocalDeviceMemPtr());
+  auto* peerSpans =
+      static_cast<DeviceSpan<SignalState>*>(peerInboxPtrsDevice_->get());
+
+  // peerSpans has nPeers entries (not nRanks)
+  int nPeers = nRanks_ - 1;
+  return DeviceWindowSignal(
+      myRank_,
+      nRanks_,
+      static_cast<int>(config_.signalCount),
+      DeviceSpan<SignalState>(
+          localInbox, static_cast<uint32_t>(config_.signalCount)),
+      DeviceSpan<DeviceSpan<SignalState>>(peerSpans, nPeers));
+}
+
+DeviceWindowMemory WindowMemory::getDeviceWindowMemory() const {
+  return DeviceWindowMemory(getDeviceWindowSignal());
+}
+
+} // namespace comms::pipes

--- a/comms/pipes/window/WindowMemory.h
+++ b/comms/pipes/window/WindowMemory.h
@@ -1,0 +1,180 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <memory>
+
+#include "comms/pipes/GpuMemHandler.h"
+#include "comms/utils/CudaRAII.h"
+
+namespace comms::pipes {
+
+// Forward declarations - users must include the corresponding .cuh to use the
+// returned objects
+class DeviceWindowSignal;
+
+class DeviceWindowMemory;
+
+/**
+ * Configuration for window memory allocation.
+ */
+struct WindowMemoryConfig {
+  // Number of signal slots (inbox size)
+  // Typical: 1 for simple signaling, more for multi-phase patterns
+  std::size_t signalCount{1};
+};
+
+/**
+ * WindowMemory - Host-side RAII manager for synchronization primitive buffers
+ * (signals, eventually counters and barriers)
+ *
+ * Manages GPU memory allocation and handle exchange for DeviceWindowSignal.
+ *
+ * MEMORY MODEL (Inbox):
+ * Each rank has a local "inbox" buffer. All peers can write to this rank's
+ * inbox to signal it. This provides a many-to-one signaling pattern.
+ *
+ * MEMORY ALIGNMENT:
+ * Signal slots are 128-byte aligned to avoid false sharing between slots.
+ *
+ * COMMUNICATOR SEMANTICS:
+ * - Constructor allocates local GPU memory
+ * - exchange() is COLLECTIVE (all ranks must call)
+ * - getDeviceWindowSignal() returns device object after exchange()
+ *
+ * USAGE:
+ *   WindowMemoryConfig config{.signalCount = 4};
+ *   WindowMemory windowMemory(myRank, nRanks, bootstrap, config);
+ *   windowMemory.exchange();  // Collective - all ranks must call
+ *   auto deviceSignal = windowMemory.getDeviceWindowSignal();
+ *   auto deviceWM = windowMemory.getDeviceWindowMemory();
+ *   myKernel<<<...>>>(deviceWM, ...);
+ */
+class WindowMemory {
+ public:
+  WindowMemory(const WindowMemory&) = delete;
+  WindowMemory& operator=(const WindowMemory&) = delete;
+  WindowMemory(WindowMemory&&) = delete;
+  WindowMemory& operator=(WindowMemory&&) = delete;
+
+  /**
+   * Constructor - Allocate signal slot buffers
+   *
+   * @param myRank This rank's ID (0 to nRanks-1)
+   * @param nRanks Total number of ranks
+   * @param bootstrap Bootstrap interface for collective handle exchange
+   * @param config Window memory configuration
+   * @param memSharingMode Optional: Memory sharing mode (auto-detected if not
+   * specified)
+   */
+  WindowMemory(
+      int myRank,
+      int nRanks,
+      std::shared_ptr<ctran::bootstrap::IBootstrap> bootstrap,
+      const WindowMemoryConfig& config,
+      MemSharingMode memSharingMode = GpuMemHandler::detectBestMode());
+
+  ~WindowMemory() = default;
+
+  /**
+   * exchange - Exchange memory handles across all ranks
+   *
+   * COLLECTIVE OPERATION: All ranks must call before getDeviceWindowSignal().
+   */
+  void exchange();
+
+  /**
+   * isExchanged - Check if exchange() has been called
+   */
+  bool isExchanged() const {
+    return exchanged_;
+  }
+
+  /**
+   * getDeviceWindowSignal - Get device-side signal object
+   *
+   * PRECONDITION: exchange() must have completed on all ranks.
+   *
+   * Returns by value since DeviceWindowSignal is a lightweight handle (~40
+   * bytes) containing only pointers and integers - no heap allocations or RAII.
+   *
+   * @return DeviceWindowSignal for use in CUDA kernels
+   * @throws std::runtime_error if called before exchange()
+   */
+  DeviceWindowSignal getDeviceWindowSignal() const;
+
+  /**
+   * getDeviceWindowMemory - Get unified device-side window memory object
+   *
+   * Returns a DeviceWindowMemory that bundles DeviceWindowSignal.
+   *
+   * PRECONDITION: exchange() must have completed on all ranks.
+   *
+   * @return DeviceWindowMemory for use in CUDA kernels
+   * @throws std::runtime_error if called before exchange()
+   */
+  DeviceWindowMemory getDeviceWindowMemory() const;
+
+  /**
+   * Get the memory sharing mode being used.
+   */
+  MemSharingMode getMemSharingMode() const {
+    return inboxHandler_->getMode();
+  }
+
+  /**
+   * Get signal count.
+   */
+  std::size_t signalCount() const {
+    return config_.signalCount;
+  }
+
+  /**
+   * Get rank.
+   */
+  int rank() const {
+    return myRank_;
+  }
+
+  /**
+   * Get total number of ranks.
+   */
+  int nRanks() const {
+    return nRanks_;
+  }
+
+ private:
+  /**
+   * peerToRank - Convert peer index to global rank
+   *
+   * @param peer Peer index (0 to nRanks-2)
+   * @return Global rank of the peer
+   */
+  int peerToRank(int peer) const {
+    return peer < myRank_ ? peer : peer + 1;
+  }
+
+  const int myRank_{-1};
+  const int nRanks_{-1};
+  std::shared_ptr<ctran::bootstrap::IBootstrap> bootstrap_;
+  const WindowMemoryConfig config_;
+  const MemSharingMode memSharingMode_;
+
+  // Signal inbox buffer (local memory, peers write here)
+  // Uses GpuMemHandler because this IS shared with peers via exchange
+  std::unique_ptr<GpuMemHandler> inboxHandler_;
+
+  // Peer signal spans array (device-accessible, LOCAL-only)
+  // Array of DeviceSpan<SignalState>, each pointing to a peer's inbox
+  // Uses DeviceBuffer because this is NOT shared with peers
+  // Size = nPeers (not nRanks) - excludes self
+  std::unique_ptr<meta::comms::DeviceBuffer> peerInboxPtrsDevice_;
+
+  // Inbox size in bytes
+  std::size_t inboxSize_{0};
+
+  // Flag to track if exchange has been called
+  bool exchanged_{false};
+};
+
+} // namespace comms::pipes


### PR DESCRIPTION
Summary:
**TL;DR:** Adds `DeviceSignal` primitive to `MultiPeerDeviceTransport` for inbox-style remote completion signaling, enabling peers to notify each other via NVLink writes to dedicated inbox slots.

 ---

# Detailed Overview

## Context & Motivation
For efficient GPU-to-GPU communication, ranks need a mechanism to signal completion to remote peers. The inbox signaling model allows each rank to have a single inbox buffer where all peers can write signals, with dedicated slots per peer to distinguish signal sources.

## Technical Details
- Implements `DeviceSignal` class with inbox semantics ("one inbox, everyone can write")
- Each rank's inbox is organized as: `actual_slot = peer * signalCount + signal_id`
- Provides the following signal operations:
  - `signalPeer()`: Signal a specific peer (writes to peer's inbox)
  - `signalAll()`: Signal all peers in parallel
  - `waitSignalFrom()`: Wait for signal from a specific peer
  - `waitSignalFromAll()`: Wait for signals from all peers
  - `readSignalFrom()`: Non-blocking read of signal value
- Adds bounds checking macros with detailed debug output for device code
- **No reset operations**: Signals are written by remote peers, making local reset unsafe (use monotonically increasing values instead)
- Integrates `DeviceSignal` into `MultiPeerNvlTransport` with buffer allocation and memory exchange
- Adds comprehensive unit and integration tests for signaling operations

## Benchmarking

**Added test cases: **
- `TEST_F(MultiPeerBenchmarkFixture, SignalAllLatency)` - Measures N-way signaling latency
- `TEST_F(MultiPeerBenchmarkFixture, SignalPingPongLatency)` - Measures 2-way ping-pong latency

**Added test targets:**
- `multi_peer_benchmark` - 2-rank target for ping-pong test
- `multi_peer_benchmark_8rank` - 8-rank target for signal-all scaling test

Differential Revision: D92190695
