### PR TITLE
Fix SendRecv p2p kernel hang by adding devLoadAbortFlags call in SendRecvP2p kernel

### DIFF
--- a/comms/ctran/algos/SendRecv/SendRecvP2p.cu
+++ b/comms/ctran/algos/SendRecv/SendRecvP2p.cu
@@ -42,6 +42,7 @@ __global__ void ncclKernelSendRecvP2p(
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
 
   if (flag && gtIdx == 0) {
+    ctran::device::devLoadAbortFlags(flag, devState);
     ctran::device::KernelStartGpe(flag);
   }
 


### PR DESCRIPTION
Summary:
Add `devLoadAbortFlags` call to properly initialize abort flags before `KernelStartGpe`.
This is needed because `KernelTestHostAbort` may return true (due to uninitialized
shmDevState.enableCancellableWaits) and prevent the kernel from signaling GPE to
start the gpe func, causing a hang in IB-only (no-local) scenarios.

Reviewed By: minsii

Differential Revision: D92235206


