### PR TITLE
Fix UT by using switch statement for CommFunc conversion

### DIFF
--- a/comms/ncclx/v2_27/meta/wrapper/DataTypeConv.h
+++ b/comms/ncclx/v2_27/meta/wrapper/DataTypeConv.h
@@ -29,12 +29,26 @@ inline CommPattern ncclToCommPattern(ncclPattern_t ncclPattern) {
 }
 
 constexpr CommFunc ncclToCommFunc(ncclFunc_t ncclFunc) {
-  // NCCLX2.28 adds more functions to ncclFunc_t enum, we need special handling
-  // when ncclFunc is ncclNumFuncs
-  if (ncclFunc == ncclNumFuncs) {
-    return CommFunc::NumFuncs;
+  switch (ncclFunc) {
+    case ::ncclFuncBroadcast:
+      return CommFunc::Broadcast;
+    case ::ncclFuncReduce:
+      return CommFunc::Reduce;
+    case ::ncclFuncAllGather:
+      return CommFunc::AllGather;
+    case ::ncclFuncReduceScatter:
+      return CommFunc::ReduceScatter;
+    case ::ncclFuncAllReduce:
+      return CommFunc::AllReduce;
+    case ::ncclFuncSendRecv:
+      return CommFunc::SendRecv;
+    case ::ncclFuncSend:
+      return CommFunc::Send;
+    case ::ncclFuncRecv:
+      return CommFunc::Recv;
+    default:
+      return CommFunc::NumFuncs;
   }
-  return static_cast<CommFunc>(ncclFunc);
 }
 
 inline commDataType_t ncclToCommDataType(ncclDataType_t ncclDataType) {
@@ -130,50 +144,6 @@ static_assert(
 static_assert(
     static_cast<int>(CommPattern::Recv) == static_cast<int>(::ncclPatternRecv),
     "CommPattern::Recv must match ncclPatternRecv");
-
-/******************************************************************************
- * Begin of static check to ensure CommFunc enum matches ncclFunc_T enum      *
- *****************************************************************************/
-static_assert(
-    static_cast<int>(CommFunc::Broadcast) ==
-        static_cast<int>(::ncclFuncBroadcast),
-    "CommFunc::Broadcast must match ncclFuncBroadcast");
-
-static_assert(
-    static_cast<int>(CommFunc::Reduce) == static_cast<int>(::ncclFuncReduce),
-    "CommFunc::Reduce must match ncclFuncReduce");
-
-static_assert(
-    static_cast<int>(CommFunc::AllGather) ==
-        static_cast<int>(::ncclFuncAllGather),
-    "CommFunc::AllGather must match ncclFuncAllGather");
-
-static_assert(
-    static_cast<int>(CommFunc::ReduceScatter) ==
-        static_cast<int>(::ncclFuncReduceScatter),
-    "CommFunc::ReduceScatter must match ncclFuncReduceScatter");
-
-static_assert(
-    static_cast<int>(CommFunc::AllReduce) ==
-        static_cast<int>(::ncclFuncAllReduce),
-    "CommFunc::AllReduce must match ncclFuncAllReduce");
-
-static_assert(
-    static_cast<int>(CommFunc::SendRecv) ==
-        static_cast<int>(::ncclFuncSendRecv),
-    "CommFunc::SendRecv must match ncclFuncSendRecv");
-
-static_assert(
-    static_cast<int>(CommFunc::Send) == static_cast<int>(::ncclFuncSend),
-    "CommFunc::Send must match ncclFuncSend");
-
-static_assert(
-    static_cast<int>(CommFunc::Recv) == static_cast<int>(::ncclFuncRecv),
-    "CommFunc::Recv must match ncclFuncRecv");
-
-static_assert(
-    CommFunc::NumFuncs == ncclToCommFunc(::ncclNumFuncs),
-    "CommFunc::commNumFuncs must match ncclNumFuncs");
 
 /******************************************************************************
  * Begin of static check to ensure commDataType_t enum matches ncclDataType_t *

--- a/comms/ncclx/v2_27/meta/wrapper/tests/TypeConvertionUT.cc
+++ b/comms/ncclx/v2_27/meta/wrapper/tests/TypeConvertionUT.cc
@@ -75,10 +75,7 @@ TEST(DataTypeConvTest, NcclToCommFunc) {
   EXPECT_EQ(ncclToCommFunc(ncclFuncSendRecv), CommFunc::SendRecv);
   EXPECT_EQ(ncclToCommFunc(ncclFuncSend), CommFunc::Send);
   EXPECT_EQ(ncclToCommFunc(ncclFuncRecv), CommFunc::Recv);
-
-  // Test NumFuncs
-  EXPECT_EQ(
-      static_cast<int>(CommFunc::NumFuncs), static_cast<int>(ncclNumFuncs));
+  EXPECT_EQ(ncclToCommFunc(ncclNumFuncs), CommFunc::NumFuncs);
 }
 
 // Test ncclToCommDataType conversion

--- a/comms/ncclx/v2_28/meta/wrapper/DataTypeConv.h
+++ b/comms/ncclx/v2_28/meta/wrapper/DataTypeConv.h
@@ -4,6 +4,7 @@
 
 #include "info.h"
 #include "nccl_common.h"
+#include "proxy.h"
 
 #include "comms/utils/commSpecs.h"
 
@@ -29,12 +30,26 @@ inline CommPattern ncclToCommPattern(ncclPattern_t ncclPattern) {
 }
 
 constexpr CommFunc ncclToCommFunc(ncclFunc_t ncclFunc) {
-  // NCCLX2.28 adds more functions to ncclFunc_t enum, we need special handling
-  // when ncclFunc is ncclNumFuncs
-  if (ncclFunc == ncclNumFuncs) {
-    return CommFunc::NumFuncs;
+  switch (ncclFunc) {
+    case ::ncclFuncBroadcast:
+      return CommFunc::Broadcast;
+    case ::ncclFuncReduce:
+      return CommFunc::Reduce;
+    case ::ncclFuncAllGather:
+      return CommFunc::AllGather;
+    case ::ncclFuncReduceScatter:
+      return CommFunc::ReduceScatter;
+    case ::ncclFuncAllReduce:
+      return CommFunc::AllReduce;
+    case ::ncclFuncSendRecv:
+      return CommFunc::SendRecv;
+    case ::ncclFuncSend:
+      return CommFunc::Send;
+    case ::ncclFuncRecv:
+      return CommFunc::Recv;
+    default:
+      return CommFunc::NumFuncs;
   }
-  return static_cast<CommFunc>(ncclFunc);
 }
 
 inline commDataType_t ncclToCommDataType(ncclDataType_t ncclDataType) {
@@ -130,50 +145,6 @@ static_assert(
 static_assert(
     static_cast<int>(CommPattern::Recv) == static_cast<int>(::ncclPatternRecv),
     "CommPattern::Recv must match ncclPatternRecv");
-
-/******************************************************************************
- * Begin of static check to ensure CommFunc enum matches ncclFunc_T enum      *
- *****************************************************************************/
-static_assert(
-    static_cast<int>(CommFunc::Broadcast) ==
-        static_cast<int>(::ncclFuncBroadcast),
-    "CommFunc::Broadcast must match ncclFuncBroadcast");
-
-static_assert(
-    static_cast<int>(CommFunc::Reduce) == static_cast<int>(::ncclFuncReduce),
-    "CommFunc::Reduce must match ncclFuncReduce");
-
-static_assert(
-    static_cast<int>(CommFunc::AllGather) ==
-        static_cast<int>(::ncclFuncAllGather),
-    "CommFunc::AllGather must match ncclFuncAllGather");
-
-static_assert(
-    static_cast<int>(CommFunc::ReduceScatter) ==
-        static_cast<int>(::ncclFuncReduceScatter),
-    "CommFunc::ReduceScatter must match ncclFuncReduceScatter");
-
-static_assert(
-    static_cast<int>(CommFunc::AllReduce) ==
-        static_cast<int>(::ncclFuncAllReduce),
-    "CommFunc::AllReduce must match ncclFuncAllReduce");
-
-static_assert(
-    static_cast<int>(CommFunc::SendRecv) ==
-        static_cast<int>(::ncclFuncSendRecv),
-    "CommFunc::SendRecv must match ncclFuncSendRecv");
-
-static_assert(
-    static_cast<int>(CommFunc::Send) == static_cast<int>(::ncclFuncSend),
-    "CommFunc::Send must match ncclFuncSend");
-
-static_assert(
-    static_cast<int>(CommFunc::Recv) == static_cast<int>(::ncclFuncRecv),
-    "CommFunc::Recv must match ncclFuncRecv");
-
-static_assert(
-    CommFunc::NumFuncs == ncclToCommFunc(::ncclNumFuncs),
-    "CommFunc::commNumFuncs must match ncclNumFuncs");
 
 /******************************************************************************
  * Begin of static check to ensure commDataType_t enum matches ncclDataType_t *

--- a/comms/ncclx/v2_28/meta/wrapper/tests/TypeConvertionUT.cc
+++ b/comms/ncclx/v2_28/meta/wrapper/tests/TypeConvertionUT.cc
@@ -75,10 +75,7 @@ TEST(DataTypeConvTest, NcclToCommFunc) {
   EXPECT_EQ(ncclToCommFunc(ncclFuncSendRecv), CommFunc::SendRecv);
   EXPECT_EQ(ncclToCommFunc(ncclFuncSend), CommFunc::Send);
   EXPECT_EQ(ncclToCommFunc(ncclFuncRecv), CommFunc::Recv);
-
-  // Test NumFuncs
-  EXPECT_EQ(
-      static_cast<int>(CommFunc::NumFuncs), static_cast<int>(ncclNumFuncs));
+  EXPECT_EQ(ncclToCommFunc(ncclNumFuncs), CommFunc::NumFuncs);
 }
 
 // Test ncclToCommDataType conversion


### PR DESCRIPTION
Summary:
This fixes the unit tests by changing `ncclToCommFunc()` from using static_cast to an explicit switch statement. The static_cast approach relied on enum value ordering matching between `CommFunc` and `ncclFunc_t`, which doesn't work across versions.

Changes:
- Replaced static_cast with explicit switch statement in `ncclToCommFunc()` for both v2_27 and v2_28
- Removed static_assert checks that assumed enum ordering matched
- Added CI labels to force tests to run in opt mode since they intentionally test undefined behavior
- Simplified NumFuncs test case to verify the function behavior directly

Reviewed By: zhiyongww

Differential Revision: D92337250


