### PR TITLE
Use switch statement for RedOps type conversion

### DIFF
--- a/comms/ncclx/v2_27/meta/wrapper/DataTypeConv.h
+++ b/comms/ncclx/v2_27/meta/wrapper/DataTypeConv.h
@@ -56,7 +56,20 @@ inline commDataType_t ncclToCommDataType(ncclDataType_t ncclDataType) {
 }
 
 inline commRedOp_t ncclToCommRedOp(ncclRedOp_t ncclRedOp) {
-  return static_cast<commRedOp_t>(ncclRedOp);
+  switch (ncclRedOp) {
+    case ::ncclSum:
+      return commSum;
+    case ::ncclProd:
+      return commProd;
+    case ::ncclMax:
+      return commMax;
+    case ::ncclMin:
+      return commMin;
+    case ::ncclAvg:
+      return commAvg;
+    default:
+      return commNumOps;
+  }
 }
 
 inline CommAlgo ncclToCommAlgo(int ncclAlgo) {
@@ -191,29 +204,6 @@ static_assert(
 static_assert(
     static_cast<int>(commNumTypes) == static_cast<int>(::ncclNumTypes),
     "commNumTypes must match ncclNumTypes");
-
-/******************************************************************************
- * Begin of static check to ensure commRedOp_t enum matches ncclRedOp_t       *
- *****************************************************************************/
-static_assert(
-    static_cast<int>(commSum) == static_cast<int>(::ncclSum),
-    "commSum must match ncclSum");
-
-static_assert(
-    static_cast<int>(commProd) == static_cast<int>(::ncclProd),
-    "commProd must match ncclProd");
-
-static_assert(
-    static_cast<int>(commMax) == static_cast<int>(::ncclMax),
-    "commMax must match ncclMax");
-
-static_assert(
-    static_cast<int>(commMin) == static_cast<int>(::ncclMin),
-    "commMin must match ncclMin");
-
-static_assert(
-    static_cast<int>(commNumOps) == static_cast<int>(::ncclNumOps),
-    "commNumOps must match ncclNumOps");
 
 /******************************************************************************
  * Begin of static check to ensure CommAlgo enum matches NCCL algorithm       *

--- a/comms/ncclx/v2_27/meta/wrapper/tests/TypeConvertionUT.cc
+++ b/comms/ncclx/v2_27/meta/wrapper/tests/TypeConvertionUT.cc
@@ -107,9 +107,8 @@ TEST(DataTypeConvTest, NcclToCommRedOp) {
   EXPECT_EQ(ncclToCommRedOp(ncclProd), commProd);
   EXPECT_EQ(ncclToCommRedOp(ncclMax), commMax);
   EXPECT_EQ(ncclToCommRedOp(ncclMin), commMin);
-
-  // Test NumOps
-  EXPECT_EQ(static_cast<int>(commNumOps), static_cast<int>(ncclNumOps));
+  EXPECT_EQ(ncclToCommRedOp(ncclAvg), commAvg);
+  EXPECT_EQ(ncclToCommRedOp(ncclNumOps), commNumOps);
 }
 
 TEST(DataTypeConvTest, NcclToCommCmpOp) {

--- a/comms/ncclx/v2_28/meta/wrapper/DataTypeConv.h
+++ b/comms/ncclx/v2_28/meta/wrapper/DataTypeConv.h
@@ -57,7 +57,20 @@ inline commDataType_t ncclToCommDataType(ncclDataType_t ncclDataType) {
 }
 
 inline commRedOp_t ncclToCommRedOp(ncclRedOp_t ncclRedOp) {
-  return static_cast<commRedOp_t>(ncclRedOp);
+  switch (ncclRedOp) {
+    case ::ncclSum:
+      return commSum;
+    case ::ncclProd:
+      return commProd;
+    case ::ncclMax:
+      return commMax;
+    case ::ncclMin:
+      return commMin;
+    case ::ncclAvg:
+      return commAvg;
+    default:
+      return commNumOps;
+  }
 }
 
 inline CommAlgo ncclToCommAlgo(int ncclAlgo) {
@@ -192,29 +205,6 @@ static_assert(
 static_assert(
     static_cast<int>(commNumTypes) == static_cast<int>(::ncclNumTypes),
     "commNumTypes must match ncclNumTypes");
-
-/******************************************************************************
- * Begin of static check to ensure commRedOp_t enum matches ncclRedOp_t       *
- *****************************************************************************/
-static_assert(
-    static_cast<int>(commSum) == static_cast<int>(::ncclSum),
-    "commSum must match ncclSum");
-
-static_assert(
-    static_cast<int>(commProd) == static_cast<int>(::ncclProd),
-    "commProd must match ncclProd");
-
-static_assert(
-    static_cast<int>(commMax) == static_cast<int>(::ncclMax),
-    "commMax must match ncclMax");
-
-static_assert(
-    static_cast<int>(commMin) == static_cast<int>(::ncclMin),
-    "commMin must match ncclMin");
-
-static_assert(
-    static_cast<int>(commNumOps) == static_cast<int>(::ncclNumOps),
-    "commNumOps must match ncclNumOps");
 
 /******************************************************************************
  * Begin of static check to ensure CommAlgo enum matches NCCL algorithm       *

--- a/comms/ncclx/v2_28/meta/wrapper/tests/TypeConvertionUT.cc
+++ b/comms/ncclx/v2_28/meta/wrapper/tests/TypeConvertionUT.cc
@@ -107,9 +107,8 @@ TEST(DataTypeConvTest, NcclToCommRedOp) {
   EXPECT_EQ(ncclToCommRedOp(ncclProd), commProd);
   EXPECT_EQ(ncclToCommRedOp(ncclMax), commMax);
   EXPECT_EQ(ncclToCommRedOp(ncclMin), commMin);
-
-  // Test NumOps
-  EXPECT_EQ(static_cast<int>(commNumOps), static_cast<int>(ncclNumOps));
+  EXPECT_EQ(ncclToCommRedOp(ncclAvg), commAvg);
+  EXPECT_EQ(ncclToCommRedOp(ncclNumOps), commNumOps);
 }
 
 TEST(DataTypeConvTest, NcclToCommCmpOp) {


### PR DESCRIPTION
Summary:
This diff changes `ncclToCommRedOp()` from using `static_cast` to an explicit switch statement for type-safe conversion between `ncclRedOp_t` and `commRedOp_t` enums.

The static_cast approach relied on enum value ordering matching between the two types, which doesn't work when the enum does not match across versions.

Changes:
- Replaced static_cast with explicit switch statement mapping each reduction op
- Added handling for `ncclAvg` → `commAvg` conversion
- Default case returns `commNumOps` for unknown/invalid values
- Removed static_assert checks that assumed enum ordering matched
- Updated unit tests to verify the conversion function directly

Reviewed By: zhiyongww

Differential Revision: D92337253


