### PR TITLE
Update benchmarks to use BenchmarkBootstrap

### DIFF
--- a/comms/pipes/benchmarks/P2pNvlSignalBenchmark.cc
+++ b/comms/pipes/benchmarks/P2pNvlSignalBenchmark.cc
@@ -9,7 +9,7 @@
 #include "comms/pipes/benchmarks/BenchmarkKernel.cuh"
 #include "comms/pipes/benchmarks/BenchmarkMacros.h"
 #include "comms/pipes/benchmarks/P2pNvlBenchmarkUtils.h"
-#include "comms/testinfra/mpi/MpiBootstrap.h"
+#include "comms/testinfra/BenchmarkTestFixture.h"
 #include "comms/testinfra/mpi/MpiTestUtils.h"
 #include "comms/utils/CudaRAII.h"
 
@@ -20,29 +20,29 @@
 
 using meta::comms::CudaEvent;
 using meta::comms::DeviceBuffer;
-using meta::comms::MpiBaseTestFixture;
-using meta::comms::MPIEnvironmentBase;
 
 namespace comms::pipes::benchmark {
 
-class P2pSignalBenchmarkFixture : public MpiBaseTestFixture {
+class P2pSignalBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
  protected:
   void SetUp() override {
-    MpiBaseTestFixture::SetUp();
+    // Initialize bootstrap and rank variables from base class
+    BenchmarkTestFixture::SetUp();
+
     // Use localRank for cudaSetDevice since each node has its own set of GPUs
     // globalRank would fail on multi-node setups where rank > num_gpus_per_node
     CUDA_CHECK_VOID(cudaSetDevice(localRank));
 
     // Initialize NCCL
     NCCL_CHECK_VOID(
-        ncclCommInitRank(&ncclComm_, numRanks, getNCCLId(), globalRank));
+        ncclCommInitRank(&ncclComm_, worldSize, getNCCLId(), globalRank));
     CUDA_CHECK_VOID(cudaStreamCreate(&stream_));
   }
 
   void TearDown() override {
     NCCL_CHECK_VOID(ncclCommDestroy(ncclComm_));
     CUDA_CHECK_VOID(cudaStreamDestroy(stream_));
-    MpiBaseTestFixture::TearDown();
+    BenchmarkTestFixture::TearDown();
   }
 
   ncclUniqueId getNCCLId() {
@@ -54,7 +54,20 @@ class P2pSignalBenchmarkFixture : public MpiBaseTestFixture {
         std::abort();
       }
     }
-    MPI_CHECK(MPI_Bcast(&id, sizeof(id), MPI_BYTE, 0, MPI_COMM_WORLD));
+
+    // Broadcast NCCL ID using bootstrap allGather
+    std::vector<ncclUniqueId> allIds(worldSize);
+    allIds[globalRank] = id;
+    auto result =
+        bootstrap
+            ->allGather(
+                allIds.data(), sizeof(ncclUniqueId), globalRank, worldSize)
+            .get();
+    if (result != 0) {
+      XLOG(ERR) << "Bootstrap allGather for NCCL ID failed";
+      std::abort();
+    }
+    id = allIds[0]; // Take rank 0's ID
     return id;
   }
 
@@ -78,7 +91,7 @@ class P2pSignalBenchmarkFixture : public MpiBaseTestFixture {
 
     // Synchronize both ranks before starting to ensure both GPUs launch
     // together
-    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    bootstrap->barrierAll();
 
     // Benchmark
     CUDA_CHECK(cudaEventRecord(start.get(), stream_));
@@ -93,7 +106,7 @@ class P2pSignalBenchmarkFixture : public MpiBaseTestFixture {
     // Calculate per-signal latency in microseconds
     float avgLatencyUs = (totalTime_ms / nSteps) * 1000.0f;
 
-    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    bootstrap->barrierAll();
 
     return avgLatencyUs;
   }
@@ -104,8 +117,8 @@ class P2pSignalBenchmarkFixture : public MpiBaseTestFixture {
 
 TEST_F(P2pSignalBenchmarkFixture, SignalBenchmark) {
   // Only test with 2 ranks
-  if (numRanks != 2) {
-    XLOGF(DBG1, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+  if (worldSize != 2) {
+    XLOGF(DBG1, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
     return;
   }
 
@@ -183,9 +196,8 @@ TEST_F(P2pSignalBenchmarkFixture, SignalBenchmark) {
         .signalCount = signalCount,
     };
 
-    auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
     comms::pipes::MultiPeerNvlTransport transport(
-        globalRank, numRanks, bootstrap, p2pConfig);
+        globalRank, worldSize, bootstrap, p2pConfig);
     transport.exchange();
 
     auto p2p = transport.getP2pTransportDevice(peerRank);
@@ -210,9 +222,8 @@ TEST_F(P2pSignalBenchmarkFixture, SignalBenchmark) {
         .signalCount = signalCount,
     };
 
-    auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
     comms::pipes::MultiPeerNvlTransport transport(
-        globalRank, numRanks, bootstrap, p2pConfig);
+        globalRank, worldSize, bootstrap, p2pConfig);
     transport.exchange();
 
     auto p2p = transport.getP2pTransportDevice(peerRank);
@@ -253,7 +264,13 @@ TEST_F(P2pSignalBenchmarkFixture, SignalBenchmark) {
 
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
-  ::testing::AddGlobalTestEnvironment(new MPIEnvironmentBase);
   folly::Init init(&argc, &argv);
+
+  // Set up distributed environment
+  if (!meta::comms::isTcpEnvironment()) {
+    ::testing::AddGlobalTestEnvironment(
+        new meta::comms::BenchmarkEnvironment());
+  }
+
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Summary:
Migrate all pipe benchmarks to use the Benckmark test fixtures.
This enables them to run in both MPI and TCP environments.

Reviewed By: siyengar

Differential Revision: D91697706


