### PR TITLE
Make key unique by split for TorchCommGloo

### DIFF
--- a/comms/torchcomms/gloo/TorchCommGloo.cpp
+++ b/comms/torchcomms/gloo/TorchCommGloo.cpp
@@ -1646,7 +1646,9 @@ std::shared_ptr<TorchCommBackend> TorchCommGloo::split(
   new_torchcomm->comm_size_ = new_size;
 
   auto new_name = fmt::format("{}_{}", name, color);
-  auto new_store = c10::make_intrusive<c10d::PrefixStore>(new_name, store_);
+  auto split_id = splitCounter_++;
+  auto store_prefix = fmt::format("{}/{}_{}", split_id, name, color);
+  auto new_store = c10::make_intrusive<c10d::PrefixStore>(store_prefix, store_);
 
   CommOptions new_options = options;
   new_options.store = new_store;

--- a/comms/torchcomms/gloo/TorchCommGloo.hpp
+++ b/comms/torchcomms/gloo/TorchCommGloo.hpp
@@ -203,6 +203,7 @@ class TorchCommGloo : public TorchCommBackend,
   std::shared_ptr<gloo::Context> context_;
 
   uint32_t collectiveCounter_{0};
+  uint32_t splitCounter_{0};
 };
 
 } // namespace torch::comms

--- a/comms/torchcomms/tests/integration/cpp/SplitTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/SplitTest.cpp
@@ -430,3 +430,51 @@ void SplitTest::testMultiLevel() {
   second_level_comm->finalize();
   first_level_comm->finalize();
 }
+
+void SplitTest::testMultipleSplitsSameRanks() {
+  // Test splitting multiple times with the same ranks and same name
+  // This verifies that the splitCounter_ properly creates unique store prefixes
+  // preventing key collisions when the same name and ranks are used
+  std::vector<int> all_ranks;
+  all_ranks.reserve(num_ranks_);
+  for (int i = 0; i < num_ranks_; i++) {
+    all_ranks.push_back(i);
+  }
+
+  // Perform multiple splits with the same ranks AND same name
+  const std::string split_name = "same_name_split";
+  std::shared_ptr<torch::comms::TorchComm> split_comm_1 =
+      torchcomm_->split(all_ranks, split_name);
+  std::shared_ptr<torch::comms::TorchComm> split_comm_2 =
+      torchcomm_->split(all_ranks, split_name);
+  std::shared_ptr<torch::comms::TorchComm> split_comm_3 =
+      torchcomm_->split(all_ranks, split_name);
+
+  // All communicators should be valid since all ranks are included
+  ASSERT_TRUE(split_comm_1 != nullptr)
+      << "Expected first split communicator but got nullptr for rank " << rank_;
+  ASSERT_TRUE(split_comm_2 != nullptr)
+      << "Expected second split communicator but got nullptr for rank "
+      << rank_;
+  ASSERT_TRUE(split_comm_3 != nullptr)
+      << "Expected third split communicator but got nullptr for rank " << rank_;
+
+  // Verify each communicator has the correct rank and size
+  EXPECT_EQ(split_comm_1->getRank(), rank_);
+  EXPECT_EQ(split_comm_1->getSize(), num_ranks_);
+  EXPECT_EQ(split_comm_2->getRank(), rank_);
+  EXPECT_EQ(split_comm_2->getSize(), num_ranks_);
+  EXPECT_EQ(split_comm_3->getRank(), rank_);
+  EXPECT_EQ(split_comm_3->getSize(), num_ranks_);
+
+  // Test communication on each split communicator independently
+  // to verify they are separate and don't interfere with each other
+  testCommunication(split_comm_1);
+  testCommunication(split_comm_2);
+  testCommunication(split_comm_3);
+
+  // Finalize communicators
+  split_comm_1->finalize();
+  split_comm_2->finalize();
+  split_comm_3->finalize();
+}

--- a/comms/torchcomms/tests/integration/cpp/SplitTest.hpp
+++ b/comms/torchcomms/tests/integration/cpp/SplitTest.hpp
@@ -35,6 +35,7 @@ class SplitTest : public ::testing::Test {
   void testDuplicateRanks();
   void testRankNotInGroup();
   void testMultiLevel();
+  void testMultipleSplitsSameRanks();
 
   // Helper function declarations
   std::vector<std::vector<int>> createContigGroups(

--- a/comms/torchcomms/tests/integration/cpp/SplitTestMain.cpp
+++ b/comms/torchcomms/tests/integration/cpp/SplitTestMain.cpp
@@ -73,6 +73,13 @@ TEST_F(SplitTest, MultiLevelSplit) {
   testMultiLevel();
 }
 
+TEST_F(SplitTest, MultipleSplitsSameRanks) {
+  SCOPED_TRACE(
+      ::testing::Message()
+      << "Testing multiple splits with the same ranks to verify unique store prefixes");
+  testMultipleSplitsSameRanks();
+}
+
 // This main function is provided by gtest
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Summary: split_group on N-D mesh with GLOO will fail on key collision on the store. This should fix it.

Differential Revision: D92429662


