### PR TITLE
Enable GIN device headers to compile with Clang for LLVM bitcode generation

### DIFF
--- a/comms/ncclx/v2_28/src/include/nccl_device/barrier.h
+++ b/comms/ncclx/v2_28/src/include/nccl_device/barrier.h
@@ -10,7 +10,7 @@
 #include "impl/lsa_barrier__types.h"
 #include "impl/gin_barrier__types.h"
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename Coop>
 struct ncclBarrierSession_internal;
 

--- a/comms/ncclx/v2_28/src/include/nccl_device/coop.h
+++ b/comms/ncclx/v2_28/src/include/nccl_device/coop.h
@@ -15,7 +15,7 @@
 //   int Coop::num_threads(); // same as size()
 //   void Coop::sync();
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<int nThreadsPow2>
 struct ncclCoopTile { // An aligned pow2 set of threads within the warp.
   static_assert(nccl::utility::isPow2(nThreadsPow2) && nThreadsPow2 <= 32, "Condition required");
@@ -35,12 +35,12 @@ struct ncclCoopTile { // An aligned pow2 set of threads within the warp.
 };
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 typedef ncclCoopTile<1> ncclCoopThread;
 typedef ncclCoopTile<32> ncclCoopWarp;
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 struct ncclCoopLanes { // Some lanes of this warp.
   uint32_t lmask;
 
@@ -61,7 +61,7 @@ struct ncclCoopLanes { // Some lanes of this warp.
 };
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 // A set of consecutive warps that the user has also supplied with a unique
 // id from [0..15]. It is an error for two different warp spans with the same
 // id to be in a collective concurrently.
@@ -89,7 +89,7 @@ struct ncclCoopWarpSpan {
 };
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 struct ncclCoopCta {
   NCCL_DEVICE_INLINE int thread_rank() const { return threadIdx.x; }
   NCCL_DEVICE_INLINE int size() const { return blockDim.x; }
@@ -98,7 +98,7 @@ struct ncclCoopCta {
 };
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<int nThreadsPow2>
 NCCL_DEVICE_INLINE uint32_t ncclCoopGetLaneMask(ncclCoopTile<nThreadsPow2> coop) {
   return coop.laneMask();
@@ -114,7 +114,7 @@ NCCL_DEVICE_INLINE uint32_t ncclCoopGetLaneMask(ncclCoopCta coop) {
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 // ncclCoopIsThread:
 // At compile time do we know the given coop is a single thread only.
 template<int nThreads>
@@ -126,7 +126,7 @@ NCCL_DEVICE_INLINE constexpr bool ncclCoopIsThread(ncclCoopWarpSpan) { return fa
 NCCL_DEVICE_INLINE constexpr bool ncclCoopIsThread(ncclCoopCta) { return false; }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<int nThreads>
 NCCL_DEVICE_INLINE constexpr bool ncclCoopWithinWarp(ncclCoopTile<nThreads>) { return true; }
 NCCL_DEVICE_INLINE constexpr bool ncclCoopWithinWarp(ncclCoopLanes) { return true; }
@@ -134,14 +134,14 @@ NCCL_DEVICE_INLINE constexpr bool ncclCoopWithinWarp(ncclCoopWarpSpan) { return 
 NCCL_DEVICE_INLINE constexpr bool ncclCoopWithinWarp(ncclCoopCta) { return false; }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 // Pick threads of our warp that are safe to use collectively.
 NCCL_DEVICE_INLINE ncclCoopLanes ncclCoopCoalesced() {
   return ncclCoopLanes{__activemask()};
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 // Pick threads of our warp that are safe to use collectively given that this
 // is a collective on the provided cooperative group.
 template<typename Coop>
@@ -157,7 +157,7 @@ NCCL_DEVICE_INLINE ncclCoopTile<nThreads> ncclCoopCoalesced(ncclCoopTile<nThread
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<int nThreads, typename T>
 NCCL_DEVICE_INLINE T ncclCoopBcast(ncclCoopTile<nThreads>, T value, int root, bool entrySync=true) {
   constexpr int n = (sizeof(T)+4-1)/4;

--- a/comms/ncclx/v2_28/src/include/nccl_device/core.h
+++ b/comms/ncclx/v2_28/src/include/nccl_device/core.h
@@ -141,14 +141,14 @@ NCCL_EXTERN_C __host__ ncclTeam_t ncclTeamRail(ncclComm_t);
 // Get offset of resource buffer within `comm.resourceWindow`.
 NCCL_EXTERN_C NCCL_HOST_DEVICE_INLINE size_t ncclGetResourceBufferOffset(ncclDevResourceHandle_t);
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 NCCL_DEVICE_INLINE ncclSymPtr<char> ncclGetResourceBuffer(ncclDevComm const&, ncclDevResourceHandle);
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
 // Window API:
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 NCCL_DEVICE_INLINE void* ncclGetLocalPointer(ncclWindow_t w, size_t offset);
 NCCL_DEVICE_INLINE void* ncclGetLsaPointer(ncclWindow_t w, size_t offset, int peer);
 NCCL_DEVICE_INLINE void* ncclGetPeerPointer(ncclWindow_t w, size_t offset, int peer);
@@ -157,7 +157,7 @@ NCCL_DEVICE_INLINE void* ncclGetMultimemPointer(ncclWindow_t w, size_t offset, n
 NCCL_DEVICE_INLINE void* ncclGetLsaMultimemPointer(ncclWindow_t w, size_t offset, ncclDevComm const&);
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 // Convenience for combining ncclGet***Pointer() with resource handle.
 NCCL_DEVICE_INLINE void* ncclGetResourceBufferLocalPointer(ncclDevComm const&, ncclDevResourceHandle);
 NCCL_DEVICE_INLINE void* ncclGetResourceBufferLsaPointer(ncclDevComm const&, ncclDevResourceHandle, int peer);

--- a/comms/ncclx/v2_28/src/include/nccl_device/gin.h
+++ b/comms/ncclx/v2_28/src/include/nccl_device/gin.h
@@ -9,7 +9,7 @@
 #include "core.h"
 #include "gin/gin_device_common.h"
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 struct ncclGinCtx; // Definition in nccl_device/gin/gin_device_host_common.h
 template<unsigned> struct ncclGinCtx_M; // ...
 
@@ -40,7 +40,7 @@ using ncclGin = ncclGin_BackendMask<NCCL_GIN_BACKEND_MASK_ALL>;
 
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<unsigned backendMask>
 struct ncclGin_BackendMask {
   ncclDevComm const& comm;

--- a/comms/ncclx/v2_28/src/include/nccl_device/gin/gin_device_common.h
+++ b/comms/ncclx/v2_28/src/include/nccl_device/gin/gin_device_common.h
@@ -45,7 +45,7 @@ struct ncclGinDescriptorSmem {
   alignas(16) char space[64];
 };
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template <ncclNetDeviceType backend>
 struct ncclGinApi_Put {
   template <typename Coop>
@@ -96,7 +96,7 @@ struct ncclGinApi_Flush {
 };
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template <template <ncclNetDeviceType> typename ApiFn, unsigned beMask, typename... Arg>
 NCCL_DEVICE_INLINE static decltype(auto) ncclGinCall(ncclGinCtx_M<beMask> ctx, Arg&&... arg) {
   bool singleton = (beMask & (beMask - 1)) == 0;  // Only one bit set

--- a/comms/ncclx/v2_28/src/include/nccl_device/gin_barrier.h
+++ b/comms/ncclx/v2_28/src/include/nccl_device/gin_barrier.h
@@ -13,7 +13,7 @@ struct ncclGinBarrierHandle;
 
 NCCL_EXTERN_C __host__ ncclResult_t ncclGinBarrierCreateRequirement(ncclComm_t, ncclTeam_t, int nBarriers, ncclGinBarrierHandle_t* outHandle, ncclDevResourceRequirements_t* outReq);
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 enum class ncclGinFenceLevel {
   Relaxed
 };

--- a/comms/ncclx/v2_28/src/include/nccl_device/impl/barrier__funcs.h
+++ b/comms/ncclx/v2_28/src/include/nccl_device/impl/barrier__funcs.h
@@ -11,7 +11,7 @@
 #include "gin_barrier__funcs.h"
 #include "../utility.h"
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename Coop>
 NCCL_DEVICE_INLINE ncclBarrierSession<Coop>::ncclBarrierSession(
     Coop coop, ncclTeam innerTeam, ncclTeam outerTeam, ncclGin gin,
@@ -26,7 +26,7 @@ NCCL_DEVICE_INLINE ncclBarrierSession<Coop>::ncclBarrierSession(
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename Coop>
 NCCL_DEVICE_INLINE ncclBarrierSession<Coop>::ncclBarrierSession(
     Coop coop, ncclTeamTagWorld, ncclGin gin, uint32_t index, bool multimem
@@ -39,7 +39,7 @@ NCCL_DEVICE_INLINE ncclBarrierSession<Coop>::ncclBarrierSession(
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename Coop>
 NCCL_DEVICE_INLINE ncclBarrierSession<Coop>::ncclBarrierSession(
     Coop coop, ncclTeamTagLsa, ncclDevComm const& comm, uint32_t index, bool multimem
@@ -52,7 +52,7 @@ NCCL_DEVICE_INLINE ncclBarrierSession<Coop>::ncclBarrierSession(
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename Coop>
 NCCL_DEVICE_INLINE ncclBarrierSession<Coop>::ncclBarrierSession(
     Coop coop, ncclTeamTagRail, ncclGin gin, uint32_t index
@@ -65,21 +65,21 @@ NCCL_DEVICE_INLINE ncclBarrierSession<Coop>::ncclBarrierSession(
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename Coop>
 NCCL_DEVICE_INLINE ncclLsaBarrierSession<Coop>& ncclBarrierSession<Coop>::lsaBarrier() {
   return this->innerLsaBar.thing;
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename Coop>
 NCCL_DEVICE_INLINE ncclGinBarrierSession<Coop>& ncclBarrierSession<Coop>::ginBarrier() {
   return this->outerGinBar.thing;
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename Coop>
 NCCL_DEVICE_INLINE void ncclBarrierSession<Coop>::sync(Coop, cuda::memory_order ord, ncclGinFenceLevel fence) {
   if (this->innerLsaBar.present) {

--- a/comms/ncclx/v2_28/src/include/nccl_device/impl/barrier__types.h
+++ b/comms/ncclx/v2_28/src/include/nccl_device/impl/barrier__types.h
@@ -9,7 +9,7 @@
 #include "../barrier.h"
 #include "../utility.h"
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename Coop>
 struct ncclBarrierSession_internal {
   Coop coop;

--- a/comms/ncclx/v2_28/src/include/nccl_device/impl/core__funcs.h
+++ b/comms/ncclx/v2_28/src/include/nccl_device/impl/core__funcs.h
@@ -100,7 +100,7 @@ NCCL_HOST_DEVICE_INLINE int ncclTeamRankInDifference(ncclTeam_t parent, ncclTeam
   }
 }
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 NCCL_DEVICE_INLINE void* ncclGetLocalPointer(ncclWindow_t w, size_t offset) {
   char* base = nccl::utility::loadConst(&w->lsaFlatBase);
   uint32_t stride4G = nccl::utility::loadConst(&w->stride4G);
@@ -109,7 +109,7 @@ NCCL_DEVICE_INLINE void* ncclGetLocalPointer(ncclWindow_t w, size_t offset) {
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 NCCL_DEVICE_INLINE void* ncclGetLsaPointer(ncclWindow_t w, size_t offset, int peer) {
   char* base = nccl::utility::loadConst(&w->lsaFlatBase);
   uint32_t stride4G = nccl::utility::loadConst(&w->stride4G);
@@ -118,7 +118,7 @@ NCCL_DEVICE_INLINE void* ncclGetLsaPointer(ncclWindow_t w, size_t offset, int pe
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 NCCL_DEVICE_INLINE void* ncclGetPeerPointer(ncclWindow_t w, size_t offset, int peer) {
   char* base = nccl::utility::loadConst(&w->lsaFlatBase);
   uint32_t stride4G = nccl::utility::loadConst(&w->stride4G);
@@ -129,7 +129,7 @@ NCCL_DEVICE_INLINE void* ncclGetPeerPointer(ncclWindow_t w, size_t offset, int p
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 NCCL_DEVICE_INLINE void* ncclGetPeerPointer(ncclWindow_t w, size_t offset, ncclTeam tm, int peer) {
   char* base = nccl::utility::loadConst(&w->lsaFlatBase);
   uint32_t stride4G = nccl::utility::loadConst(&w->stride4G);
@@ -139,7 +139,7 @@ NCCL_DEVICE_INLINE void* ncclGetPeerPointer(ncclWindow_t w, size_t offset, ncclT
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 NCCL_DEVICE_INLINE void* ncclGetMultimemPointer(ncclWindow_t w, size_t offset, ncclMultimemHandle mm) {
   void* ptr = mm.mcBasePtr;
   ptr = reinterpret_cast<char(*)[4096]>(ptr) + nccl::utility::loadConst(&w->mcOffset4K);
@@ -147,13 +147,13 @@ NCCL_DEVICE_INLINE void* ncclGetMultimemPointer(ncclWindow_t w, size_t offset, n
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 NCCL_DEVICE_INLINE void* ncclGetLsaMultimemPointer(ncclWindow_t w, size_t offset, ncclDevComm const& comm) {
   return ncclGetMultimemPointer(w, offset, comm.lsaMultimem);
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename Coop>
 NCCL_DEVICE_INLINE ncclWindow_t ncclFindWindow(Coop coop, ncclDevComm const& comm, void const *ptr) {
   using nccl::utility::loadConst;
@@ -189,7 +189,7 @@ NCCL_HOST_DEVICE_INLINE size_t ncclGetResourceBufferOffset(ncclDevResourceHandle
   return ((size_t)h)*128;
 }
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 NCCL_DEVICE_INLINE void* ncclGetResourceBufferLocalPointer(ncclDevComm const& comm, ncclDevResourceHandle h) {
   void* lsaFlatBase = comm.resourceWindow_inlined.lsaFlatBase;
   uint32_t stride4G = comm.resourceWindow_inlined.stride4G;
@@ -198,7 +198,7 @@ NCCL_DEVICE_INLINE void* ncclGetResourceBufferLocalPointer(ncclDevComm const& co
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 NCCL_DEVICE_INLINE void* ncclGetResourceBufferLsaPointer(ncclDevComm const& comm, ncclDevResourceHandle h, int peer) {
   int r = peer;
   void* lsaFlatBase = comm.resourceWindow_inlined.lsaFlatBase;
@@ -208,7 +208,7 @@ NCCL_DEVICE_INLINE void* ncclGetResourceBufferLsaPointer(ncclDevComm const& comm
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 NCCL_DEVICE_INLINE void* ncclGetResourceBufferPeerPointer(ncclDevComm const& comm, ncclDevResourceHandle h, ncclTeam team, int peer) {
   int r = comm.lsaRank + (peer - team.rank)*team.stride;
   void* lsaFlatBase = comm.resourceWindow_inlined.lsaFlatBase;
@@ -218,7 +218,7 @@ NCCL_DEVICE_INLINE void* ncclGetResourceBufferPeerPointer(ncclDevComm const& com
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 NCCL_DEVICE_INLINE void* ncclGetResourceBufferMultimemPointer(ncclDevComm const& comm, ncclDevResourceHandle h, ncclMultimemHandle mm) {
   void* ptr = mm.mcBasePtr;
   ptr = reinterpret_cast<char(*)[4096]>(ptr) + comm.resourceWindow_inlined.mcOffset4K;
@@ -227,13 +227,13 @@ NCCL_DEVICE_INLINE void* ncclGetResourceBufferMultimemPointer(ncclDevComm const&
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 NCCL_DEVICE_INLINE void* ncclGetResourceBufferLsaMultimemPointer(ncclDevComm const& comm, ncclDevResourceHandle h) {
   return ncclGetResourceBufferMultimemPointer(comm, h, comm.lsaMultimem);
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 NCCL_DEVICE_INLINE ncclSymPtr<char> ncclGetResourceBuffer(ncclDevComm const& comm, ncclDevResourceHandle h) {
   return ncclSymPtr<char>(comm.resourceWindow, size_t(h)*128);
 }

--- a/comms/ncclx/v2_28/src/include/nccl_device/impl/gin__funcs.h
+++ b/comms/ncclx/v2_28/src/include/nccl_device/impl/gin__funcs.h
@@ -8,11 +8,11 @@
 #define _NCCL_DEVICE_GIN_SESSION__FUNCS_H_
 #include "gin__types.h"
 #include "ptr__types.h"
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 #include "nccl_device/gin/gin_device_api.h"
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<unsigned beMask>
 NCCL_DEVICE_INLINE ncclGin_BackendMask<beMask>::ncclGin_BackendMask(ncclDevComm const& comm, int contextIndex):
   comm(comm) {
@@ -30,7 +30,7 @@ NCCL_DEVICE_INLINE ncclGin_BackendMask<beMask>::ncclGin_BackendMask(ncclDevComm 
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<unsigned beMask>
 NCCL_DEVICE_INLINE ncclGinCtx_M<beMask> ncclGin_BackendMask<beMask>::_makeCtx() const {
   ncclGinCtx_M<beMask> ans;
@@ -45,7 +45,7 @@ NCCL_DEVICE_INLINE ncclGinCtx_M<beMask> ncclGin_BackendMask<beMask>::_makeCtx() 
 ////////////////////////////////////////////////////////////////////////////////
 // ncclGin descriptor helpers:
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename Descriptor>
 NCCL_DEVICE_INLINE constexpr bool ncclGin_isDescriptor(Descriptor) { return false; }
 template<typename Descriptor>
@@ -58,7 +58,7 @@ NCCL_DEVICE_INLINE constexpr ncclGinDescriptorSmem* ncclGin_getDescriptor(ncclGi
 ////////////////////////////////////////////////////////////////////////////////
 // ncclGin signal helpers:
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename RemoteAction>
 NCCL_DEVICE_INLINE constexpr bool ncclGin_isSignal(RemoteAction) { return false; }
 template<typename RemoteAction>
@@ -69,7 +69,7 @@ template<typename RemoteAction>
 NCCL_DEVICE_INLINE constexpr uint64_t ncclGin_getSignalOpArg(RemoteAction) { return 0; }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 NCCL_DEVICE_INLINE constexpr bool ncclGin_isSignal(ncclGin_SignalInc) { return true; }
 NCCL_DEVICE_INLINE constexpr ncclGinSignal_t ncclGin_getSignalId(
     ncclGin const& net, ncclGin_SignalInc arg
@@ -82,7 +82,7 @@ NCCL_DEVICE_INLINE constexpr ncclGinSignalOp_t ncclGin_getSignalOp(ncclGin_Signa
 NCCL_DEVICE_INLINE constexpr uint64_t ncclGin_getSignalOpArg(ncclGin_SignalInc) { return 1; }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 NCCL_DEVICE_INLINE constexpr bool ncclGin_isSignal(ncclGin_SignalAdd) { return true; }
 NCCL_DEVICE_INLINE constexpr ncclGinSignal_t ncclGin_getSignalId(
     ncclGin const& net, ncclGin_SignalAdd arg
@@ -98,21 +98,21 @@ NCCL_DEVICE_INLINE constexpr uint64_t ncclGin_getSignalOpArg(ncclGin_SignalAdd a
 ////////////////////////////////////////////////////////////////////////////////
 // ncclGin counter helpers:
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename LocalAction>
 NCCL_DEVICE_INLINE constexpr bool ncclGin_isCounter(LocalAction) { return false; }
 template<typename LocalAction>
 NCCL_DEVICE_INLINE constexpr ncclGinSignal_t ncclGin_getCounterId(ncclGin const&, LocalAction) { return -1u; }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 NCCL_DEVICE_INLINE constexpr bool ncclGin_isCounter(ncclGin_CounterInc) { return true; }
 NCCL_DEVICE_INLINE constexpr ncclGinSignal_t ncclGin_getCounterId(ncclGin const& net, ncclGin_CounterInc arg) { return net.comm.ginCounterBase + arg.counter; }
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<unsigned beMask>
 template<
   typename RemoteAction, // one of ncclGin_{None|SignalInc}
@@ -155,7 +155,7 @@ NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::put(
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<unsigned beMask>
 template<
   typename T,
@@ -180,7 +180,7 @@ NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::put(
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<unsigned beMask>
 template<
   typename T,
@@ -219,7 +219,7 @@ NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::putValue(
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<unsigned beMask>
 template<
   typename T,
@@ -242,7 +242,7 @@ NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::putValue(
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<unsigned beMask>
 template<typename RemoteAction, typename Coop, typename DescriptorSmem>
 NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::signal(
@@ -269,7 +269,7 @@ NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::signal(
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<unsigned beMask>
 template<typename Coop>
 NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::flush(Coop coop, cuda::memory_order ord) const {
@@ -279,7 +279,7 @@ NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::flush(Coop coop, cuda::memo
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<unsigned beMask>
 template<typename Coop>
 NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::waitCounter(
@@ -297,7 +297,7 @@ NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::waitCounter(
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<unsigned beMask>
 NCCL_DEVICE_INLINE uint64_t ncclGin_BackendMask<beMask>::readCounter(ncclGinCounter_t counter, int bits, cuda::memory_order ord) const {
   uint64_t* ptr = ncclGinCall<ncclGinApi_GetCounterPtr>(this->_makeCtx(), this->comm.ginCounterBase + counter);
@@ -306,21 +306,21 @@ NCCL_DEVICE_INLINE uint64_t ncclGin_BackendMask<beMask>::readCounter(ncclGinCoun
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<unsigned beMask>
 NCCL_DEVICE_INLINE uint64_t* ncclGin_BackendMask<beMask>::getSignalShadowPtr(ncclGinSignal_t signal) const {
   return &this->_signalShadows[signal];
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<unsigned beMask>
 NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::increaseSignalShadow(ncclGinSignal_t signal, uint64_t delta) const {
   asm volatile("red.relaxed.cta.add.u64 [%0],%1;" :: "l"(this->_signalShadows + signal), "l"(delta) : "memory");
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<unsigned beMask>
 NCCL_DEVICE_INLINE uint64_t ncclGin_BackendMask<beMask>::readSignal(ncclGinSignal_t signal, int bits, cuda::memory_order ord) const {
   uint64_t* ptr = ncclGinCall<ncclGinApi_GetSignalPtr>(this->_makeCtx(), this->comm.ginSignalBase + signal);
@@ -329,7 +329,7 @@ NCCL_DEVICE_INLINE uint64_t ncclGin_BackendMask<beMask>::readSignal(ncclGinSigna
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<unsigned beMask>
 template<typename Coop>
 NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::waitSignal(Coop coop, ncclGinSignal_t signal, uint64_t least, int bits, cuda::memory_order ord) const {
@@ -345,7 +345,7 @@ NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::waitSignal(Coop coop, ncclG
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<unsigned beMask>
 template<typename Coop>
 NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::waitSignalMeetShadow(Coop coop, ncclGinSignal_t signal, int bits, cuda::memory_order ord) const {
@@ -362,7 +362,7 @@ NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::waitSignalMeetShadow(Coop c
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<unsigned beMask>
 template<typename Coop, typename Uint>
 NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::waitSignalFollowShadow(Coop coop, ncclGinSignal_t signal, Uint leastDelta, Uint* before, Uint* delta, int bits, cuda::memory_order ord) const {
@@ -389,14 +389,14 @@ NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::waitSignalFollowShadow(Coop
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<unsigned beMask>
 NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::resetCounter(ncclGinCounter_t counter) const {
   ncclGinCall<ncclGinApi_ResetCounter>(this->_makeCtx(), this->comm.ginCounterBase + counter);
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<unsigned beMask>
 NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::resetSignal(ncclGinSignal_t signal) const {
   ncclGinCall<ncclGinApi_ResetSignal>(this->_makeCtx(), this->comm.ginSignalBase + signal);

--- a/comms/ncclx/v2_28/src/include/nccl_device/impl/gin_barrier__funcs.h
+++ b/comms/ncclx/v2_28/src/include/nccl_device/impl/gin_barrier__funcs.h
@@ -8,7 +8,7 @@
 #define _NCCL_DEVICE_GIN_BARRIER__FUNCS_H_
 #include "gin_barrier__types.h"
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename Coop>
 NCCL_DEVICE_INLINE ncclGinBarrierSession<Coop>::ncclGinBarrierSession(
     Coop coop, ncclGin net, ncclTeam team, ncclGinBarrierHandle handle, uint32_t barrierIndex
@@ -20,7 +20,7 @@ NCCL_DEVICE_INLINE ncclGinBarrierSession<Coop>::ncclGinBarrierSession(
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename Coop>
 NCCL_DEVICE_INLINE ncclGinBarrierSession<Coop>::ncclGinBarrierSession(
     Coop coop, ncclGin net, ncclTeamTagRail, uint32_t barrierIndex
@@ -29,7 +29,7 @@ NCCL_DEVICE_INLINE ncclGinBarrierSession<Coop>::ncclGinBarrierSession(
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename Coop>
 NCCL_DEVICE_INLINE ncclGinBarrierSession<Coop>::~ncclGinBarrierSession() {
   if (this->coop.thread_rank() == 0) {
@@ -40,7 +40,7 @@ NCCL_DEVICE_INLINE ncclGinBarrierSession<Coop>::~ncclGinBarrierSession() {
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename Coop>
 NCCL_DEVICE_INLINE void ncclGinBarrierSession<Coop>::sync(Coop, cuda::memory_order ord, ncclGinFenceLevel fence) {
   this->coop.sync();

--- a/comms/ncclx/v2_28/src/include/nccl_device/impl/gin_barrier__types.h
+++ b/comms/ncclx/v2_28/src/include/nccl_device/impl/gin_barrier__types.h
@@ -15,7 +15,7 @@ struct ncclGinBarrierHandle {
   ncclDevResourceHandle_t bufHandle;
 };
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename Coop>
 struct ncclGinBarrierSession_internal {
   Coop coop;

--- a/comms/ncclx/v2_28/src/include/nccl_device/impl/ll_a2a__funcs.h
+++ b/comms/ncclx/v2_28/src/include/nccl_device/impl/ll_a2a__funcs.h
@@ -10,7 +10,7 @@
 #include "comm__types.h"
 #include "../utility.h"
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename Coop>
 NCCL_DEVICE_INLINE ncclLLA2ASession<Coop>::ncclLLA2ASession(
     Coop coop, ncclDevComm const& comm, ncclTeam team,
@@ -28,7 +28,7 @@ NCCL_DEVICE_INLINE ncclLLA2ASession<Coop>::ncclLLA2ASession(
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename Coop>
 NCCL_DEVICE_INLINE ncclLLA2ASession<Coop>::~ncclLLA2ASession() {
   uint4* line = (uint4*)ncclGetResourceBufferLocalPointer(this->comm, this->handle.bufHandle);
@@ -38,7 +38,7 @@ NCCL_DEVICE_INLINE ncclLLA2ASession<Coop>::~ncclLLA2ASession() {
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename Coop>
 template<typename T>
 NCCL_DEVICE_INLINE void ncclLLA2ASession<Coop>::send(int peer, int elt, T data) {
@@ -57,7 +57,7 @@ NCCL_DEVICE_INLINE void ncclLLA2ASession<Coop>::send(int peer, int elt, T data) 
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename Coop>
 template<typename T>
 NCCL_DEVICE_INLINE void ncclLLA2ASession<Coop>::bcast(int elt, T data) {
@@ -115,7 +115,7 @@ NCCL_DEVICE_INLINE void ncclLLA2ASession<Coop>::bcast(int elt, T data) {
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename Coop>
 template<typename T>
 NCCL_DEVICE_INLINE T ncclLLA2ASession<Coop>::recv(int elt) {
@@ -125,7 +125,7 @@ NCCL_DEVICE_INLINE T ncclLLA2ASession<Coop>::recv(int elt) {
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename Coop>
 template<int MinEltCount, int MaxEltCount, typename T>
 NCCL_DEVICE_INLINE void ncclLLA2ASession<Coop>::recvUnrolled(int eltStart, int eltCount, int eltStride, T(&elts)[MaxEltCount]) {
@@ -176,7 +176,7 @@ NCCL_DEVICE_INLINE void ncclLLA2ASession<Coop>::recvUnrolled(int eltStart, int e
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename Coop>
 template<int Unroll, typename Elt, typename EltToAcc, typename Reduce>
 NCCL_DEVICE_INLINE auto ncclLLA2ASession<Coop>::recvReduce(
@@ -208,7 +208,7 @@ NCCL_DEVICE_INLINE auto ncclLLA2ASession<Coop>::recvReduce(
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename Coop>
 NCCL_DEVICE_INLINE void ncclLLA2ASession<Coop>::endEpoch(Coop) {
   if (__builtin_expect(this->epoch >= -2u, false)) {

--- a/comms/ncclx/v2_28/src/include/nccl_device/impl/ll_a2a__types.h
+++ b/comms/ncclx/v2_28/src/include/nccl_device/impl/ll_a2a__types.h
@@ -14,7 +14,7 @@ struct ncclLLA2AHandle {
   uint32_t nSlots;
 };
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename Coop>
 struct ncclLLA2ASession_internal {
   Coop coop;

--- a/comms/ncclx/v2_28/src/include/nccl_device/impl/lsa_barrier__funcs.h
+++ b/comms/ncclx/v2_28/src/include/nccl_device/impl/lsa_barrier__funcs.h
@@ -9,7 +9,7 @@
 #include "lsa_barrier__types.h"
 #include "comm__types.h"
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename Coop>
 NCCL_DEVICE_INLINE ncclLsaBarrierSession<Coop>::ncclLsaBarrierSession(
     Coop coop, ncclDevComm const& comm, ncclTeam team,
@@ -30,7 +30,7 @@ NCCL_DEVICE_INLINE ncclLsaBarrierSession<Coop>::ncclLsaBarrierSession(
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename Coop>
 NCCL_DEVICE_INLINE ncclLsaBarrierSession<Coop>::ncclLsaBarrierSession(
     Coop coop, ncclDevComm const& comm, ncclTeamTagLsa, uint32_t index, bool multimem
@@ -40,7 +40,7 @@ NCCL_DEVICE_INLINE ncclLsaBarrierSession<Coop>::ncclLsaBarrierSession(
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename Coop>
 NCCL_DEVICE_INLINE ncclLsaBarrierSession<Coop>::~ncclLsaBarrierSession() {
   uint32_t* state = (uint32_t*)ncclGetResourceBufferLocalPointer(this->comm, this->handle.bufHandle);
@@ -57,7 +57,7 @@ NCCL_DEVICE_INLINE ncclLsaBarrierSession<Coop>::~ncclLsaBarrierSession() {
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename Coop>
 NCCL_DEVICE_INLINE void ncclLsaBarrierSession<Coop>::arrive(Coop, cuda::memory_order order) {
   this->coop.sync();
@@ -83,7 +83,7 @@ NCCL_DEVICE_INLINE void ncclLsaBarrierSession<Coop>::arrive(Coop, cuda::memory_o
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename Coop>
 NCCL_DEVICE_INLINE void ncclLsaBarrierSession<Coop>::wait(Coop, cuda::memory_order order) {
   if (this->multimem) {
@@ -115,7 +115,7 @@ NCCL_DEVICE_INLINE void ncclLsaBarrierSession<Coop>::wait(Coop, cuda::memory_ord
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename Coop>
 NCCL_DEVICE_INLINE void ncclLsaBarrierSession<Coop>::sync(Coop coop, cuda::memory_order order) {
   this->arrive(coop, order);

--- a/comms/ncclx/v2_28/src/include/nccl_device/impl/lsa_barrier__types.h
+++ b/comms/ncclx/v2_28/src/include/nccl_device/impl/lsa_barrier__types.h
@@ -14,7 +14,7 @@ struct ncclLsaBarrierHandle {
   int nBarriers;
 };
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename Coop>
 struct ncclLsaBarrierSession_internal {
   Coop coop;

--- a/comms/ncclx/v2_28/src/include/nccl_device/impl/ptr__funcs.h
+++ b/comms/ncclx/v2_28/src/include/nccl_device/impl/ptr__funcs.h
@@ -89,42 +89,42 @@ NCCL_HOST_DEVICE_INLINE ncclSymPtr<T>& ncclSymPtr<T>::operator-=(unsigned long l
   return *this;
 }
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename T>
 NCCL_DEVICE_INLINE T* ncclSymPtr<T>::localPtr() const {
   return (T*)ncclGetLocalPointer(window, offset);
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename T>
 NCCL_DEVICE_INLINE T* ncclSymPtr<T>::lsaPtr(int peer) const {
   return (T*)ncclGetLsaPointer(window, offset, peer);
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename T>
 NCCL_DEVICE_INLINE T* ncclSymPtr<T>::peerPtr(int peer) const {
   return (T*)ncclGetPeerPointer(window, offset, peer);
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename T>
 NCCL_DEVICE_INLINE T* ncclSymPtr<T>::peerPtr(ncclTeam team, int peer) const {
   return (T*)ncclGetPeerPointer(window, offset, team, peer);
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename T>
 NCCL_DEVICE_INLINE T* ncclSymPtr<T>::multimemPtr(ncclMultimemHandle mmHandle) const {
   return (T*)ncclGetMultimemPointer(window, offset, mmHandle);
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename T>
 NCCL_DEVICE_INLINE T* ncclSymPtr<T>::lsaMultimemPtr(ncclDevComm const& comm) const {
   return (T*)ncclGetLsaMultimemPointer(window, offset, comm);

--- a/comms/ncclx/v2_28/src/include/nccl_device/ll_a2a.h
+++ b/comms/ncclx/v2_28/src/include/nccl_device/ll_a2a.h
@@ -14,7 +14,7 @@ NCCL_EXTERN_C __host__ int ncclLLA2ACalcSlots(int maxElts, int maxEltSize);
 
 NCCL_EXTERN_C __host__ ncclResult_t ncclLLA2ACreateRequirement(int nBlocks, int nSlots, ncclLLA2AHandle_t* outHandle, ncclDevResourceRequirements_t* outReq);
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename Coop>
 struct ncclLLA2ASession_internal;
 

--- a/comms/ncclx/v2_28/src/include/nccl_device/lsa_barrier.h
+++ b/comms/ncclx/v2_28/src/include/nccl_device/lsa_barrier.h
@@ -12,7 +12,7 @@ struct ncclLsaBarrierHandle;
 
 NCCL_EXTERN_C __host__ ncclResult_t ncclLsaBarrierCreateRequirement(ncclTeam_t, int nBarriers, ncclLsaBarrierHandle_t* outHandle, ncclDevResourceRequirements_t* outReq);
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename Coop>
 struct ncclLsaBarrierSession_internal;
 

--- a/comms/ncclx/v2_28/src/include/nccl_device/ptr.h
+++ b/comms/ncclx/v2_28/src/include/nccl_device/ptr.h
@@ -35,7 +35,7 @@ struct ncclSymPtr {
   NCCL_HOST_DEVICE_INLINE ncclSymPtr<T>& operator-=(long long d);
   NCCL_HOST_DEVICE_INLINE ncclSymPtr<T>& operator-=(unsigned long long d);
 
-  #if __CUDACC__
+  #if NCCL_CHECK_CUDACC
   NCCL_DEVICE_INLINE T* localPtr() const;
   NCCL_DEVICE_INLINE T* lsaPtr(int peer) const;
   NCCL_DEVICE_INLINE T* peerPtr(int peer) const;

--- a/comms/ncclx/v2_28/src/include/nccl_device/utility.h
+++ b/comms/ncclx/v2_28/src/include/nccl_device/utility.h
@@ -7,9 +7,25 @@
 #ifndef _NCCL_DEVICE_UTILITY_H_
 #define _NCCL_DEVICE_UTILITY_H_
 
-#if __CUDACC__
-  #define NCCL_DEVICE_INLINE __device__ __forceinline__
-  #define NCCL_HOST_DEVICE_INLINE __host__ __device__ __forceinline__
+// compiler specific check for __CUDACC__
+// Clang defines __CUDACC__ but as empty, so #if __CUDACC__ fails.
+// Use #ifdef which works for both clang and nvcc.
+#ifndef NCCL_CHECK_CUDACC
+    #ifdef __CUDACC__
+        #define NCCL_CHECK_CUDACC 1
+    #else
+        #define NCCL_CHECK_CUDACC 0
+    #endif
+#endif
+
+#if NCCL_CHECK_CUDACC
+  #if defined(NCCL_HOSTLIB_ONLY) || defined(__clang_llvm_bitcode_lib__)
+    #define NCCL_DEVICE_INLINE __device__ __attribute__((always_inline))
+    #define NCCL_HOST_DEVICE_INLINE __host__ __device__ __attribute__((always_inline))
+  #else
+    #define NCCL_DEVICE_INLINE __device__ __forceinline__
+    #define NCCL_HOST_DEVICE_INLINE __host__ __device__ __forceinline__
+  #endif
 #else
   #ifndef __host__
     #define __host__
@@ -24,10 +40,16 @@
 #define NCCL_EXTERN_C
 #endif
 
+#ifdef __clang_llvm_bitcode_lib__
+#define NCCL_IR_EXTERN_C extern "C"
+#else
+#define NCCL_IR_EXTERN_C
+#endif
+
 #include <stdint.h>
 #include <stdbool.h>
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 #include <cuda/atomic>
 #endif
 
@@ -45,7 +67,7 @@ struct ValueAsType { static constexpr T value = value_; };
 
 // Returns the value zero but the compiler cannot prove that it is zero so it
 // is useful to inhibit compiler optimizations.
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename=void>
 NCCL_DEVICE_INLINE int opaqueZero() {
   __device__ static int zero = 0;
@@ -203,7 +225,7 @@ NCCL_HOST_DEVICE_INLINE uint32_t imodFast64(uint64_t x, uint64_t y, uint64_t yrc
   return r;
 }
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 // Precomputed integer reciprocoals for denominator values 1..64 inclusive.
 // Pass these to idivFast64() for fast division on the GPU.
 NCCL_DEVICE_INLINE uint64_t idivRcp64_upto64(int x) {
@@ -230,13 +252,13 @@ NCCL_DEVICE_INLINE uint64_t idivRcp64_upto64(int x) {
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 NCCL_DEVICE_INLINE uint32_t idivRcp32_upto64(int x) {
   return idivRcp64_upto64(x)>>32;
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 NCCL_DEVICE_INLINE cuda::memory_order acquireOrderOf(cuda::memory_order ord) {
   return ord == cuda::memory_order_release ? cuda::memory_order_relaxed :
          ord == cuda::memory_order_acq_rel ? cuda::memory_order_acquire :
@@ -249,7 +271,7 @@ NCCL_DEVICE_INLINE cuda::memory_order releaseOrderOf(cuda::memory_order ord) {
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename T>
 NCCL_DEVICE_INLINE T atomicLoad(T* ptr, cuda::memory_order ord, cuda::thread_scope scope) {
   switch (scope) {
@@ -266,7 +288,7 @@ NCCL_DEVICE_INLINE T atomicLoad(T* ptr, cuda::memory_order ord, cuda::thread_sco
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 template<typename T>
 NCCL_DEVICE_INLINE void atomicStore(T* ptr, T val, cuda::memory_order ord, cuda::thread_scope scope) {
   switch (scope) {
@@ -287,7 +309,7 @@ NCCL_DEVICE_INLINE void atomicStore(T* ptr, T val, cuda::memory_order ord, cuda:
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 NCCL_DEVICE_INLINE int lane() {
   int ret;
   asm("mov.u32 %0, %%laneid;" : "=r"(ret));
@@ -300,7 +322,7 @@ NCCL_DEVICE_INLINE unsigned int lanemask_lt() {
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_CHECK_CUDACC
 // Load anything, but cache like its constant memory.
 template<typename T>
 NCCL_DEVICE_INLINE T loadConst(T const *p) {


### PR DESCRIPTION
Summary:
Enable NCCLX GIN device headers to compile with Clang for LLVM bitcode generation. This is needed to link NCCLX GIN templates with Triton-compiled kernels at runtime via cuLink APIs.

Key Changes:

utility.h: Added NCCL_CHECK_CUDACC macro that correctly detects CUDA compiler mode for both nvcc and Clang. Clang defines the CUDACC macro as empty, so "#if" checks fail but "#ifdef" checks work. Also added:

NCCL_IR_EXTERN_C macro for extern "C" linkage when compiling to LLVM bitcode
Use attribute((always_inline)) instead of forceinline when compiling with Clang (Clang doesn't support forceinline)
All other headers: Replaced the nvcc-style CUDACC checks with NCCL_CHECK_CUDACC throughout:

barrier.h, coop.h, core.h, gin.h, gin_barrier.h, ll_a2a.h, lsa_barrier.h, ptr.h
gin/gin_device_common.h
All impl/ headers (funcs and types files)
Why:

Triton compiles kernels to LLVM IR using Clang. To call NCCLX GIN operations from Triton kernels, we need to compile the NCCLX device headers to LLVM bitcode and link them at runtime. The existing headers used preprocessor checks that fail under Clang because Clang defines the CUDACC macro as empty rather than 1.

Differential Revision: D92456185


