### PR TITLE
replace the existing remReleaseMem with Cb functions in async-socket

### DIFF
--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -904,11 +904,11 @@ class CtranMapper {
       FB_COMMCHECK(this->ctranTcpDm->progress());
     }
 
-    // Check if any posted CB_CTRL requests are completed and cleanup
+    // Check if any posted IPC release requests are completed and cleanup
     for (auto it = this->postedCbCtrlReqs_.begin();
          it != this->postedCbCtrlReqs_.end();) {
       auto& req = *it;
-      if (req->checkComplete()) {
+      if (req->completed.load()) {
         it = this->postedCbCtrlReqs_.erase(it);
       } else {
         it++;
@@ -1919,14 +1919,6 @@ class CtranMapper {
 
   commResult_t remReleaseMem(ctran::regcache::RegElem* regElem);
 
-  // Callback function to handle incoming NVL_RELEASE_MEM ctrl msg
-  // Input arguments:
-  //   - rank: the rank sent the ctrl msg
-  //   - msgPtr: the pointer to the received ctrl msg
-  //   - ctx: the context of the ctrl msg; it is the CtranMapper object passed
-  //          in at cb registration
-  static commResult_t releaseMemCb(int rank, void* msgPtr, void* ctx);
-
   bool atDestruction{false};
 
   std::unique_ptr<class CtranIb> ctranIb{nullptr};
@@ -1941,49 +1933,20 @@ class CtranMapper {
   std::vector<bool> enableBackends_{
       std::vector<bool>(CtranMapperBackend::NUM_BACKENDS, false)};
 
-  // Lightweight request object to track mapper internal callback ctrl msgs
-  class CbCtrlRequest {
-   public:
-    CbCtrlRequest(int peer, CtranMapperBackend backend)
-        : peer(peer), backend(backend) {
-      if (backend == CtranMapperBackend::IB) {
-        ibReq = CtranIbRequest();
-      } else if (backend == CtranMapperBackend::SOCKET) {
-        sockReq = CtranSocketRequest();
-      } else if (backend == CtranMapperBackend::TCPDM) {
-        tcpDmReq = ctran::CtranTcpDmRequest();
-      } else {
-        CLOGF(ERR, "CTRAN-MAPPER: Unsupported backend {}", backend);
-        FB_COMMCHECKTHROW_EX_NOCOMM(commInternalError);
-      }
-    };
-    ~CbCtrlRequest() {};
-    bool checkComplete() {
-      if (backend == CtranMapperBackend::IB) {
-        return ibReq.isComplete();
-      } else if (backend == CtranMapperBackend::SOCKET) {
-        return sockReq.isComplete();
-      } else if (backend == CtranMapperBackend::TCPDM) {
-        return tcpDmReq.isComplete();
-      }
-      return false;
-    }
-
-    int peer{-1};
-    union {
-      CtranIbRequest ibReq;
-      CtranSocketRequest sockReq;
-      ctran::CtranTcpDmRequest tcpDmReq;
-    };
-    CtranMapperBackend backend;
-    ControlMsg msg;
-  };
-
-  // List of outstanding internal callback ctrl message requests to be processed
-  // when polling progress. The internal msg buffer is used to hold the content
-  // and may be queued at VC layer. Thus, we need temporarily hold the request
+  // List of outstanding internal IPC release requests to be processed
+  // when polling progress. We need to temporarily hold the request
   // instance and erase after completion.
-  std::deque<std::unique_ptr<CbCtrlRequest>> postedCbCtrlReqs_;
+  std::deque<std::unique_ptr<ctran::regcache::IpcReqCb>> postedCbCtrlReqs_;
+
+  // Peer IPC server addresses for async socket communication, indexed by rank.
+  // Populated via bootstrap allGather during mapper initialization.
+  std::vector<sockaddr_storage> peerIpcServerAddrs_;
+
+  // AllGather IPC server addresses from all ranks via bootstrap.
+  commResult_t allGatherIpcServerAddrs();
+
+  // Get peer's IPC server address by rank.
+  folly::SocketAddress getPeerIpcServerAddr(int rank) const;
 
   // Record remote ranks that each ipcRegElem has exported to.
   // - For each remote rank, the local rank will send RELEASE_MEM ctrlmsg to


### PR DESCRIPTION
Summary:
This diff replaces the control message mechanism for NVL memory release with an AsyncSocket-based approach:                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                           
  1. AsyncSocket-based IPC Release: Changed remReleaseMem() to use notifyRemoteIpcRelease() via AsyncSocket instead of isendCtrlMsg() over CtranIB/CtranSocket backends.                                                                 
  2. Server Address Exchange: Added bootstrap allGather to exchange IPC server addresses (peerIpcServerAddrs_) across all ranks during mapper initialization, enabling direct AsyncSocket communication between any pair of ranks.                                                                                         
  3. Request Tracking: Replaced CbCtrlRequest class with IpcReqCb for tracking pending release requests.        
  4. Removed Callback Registration: Removed releaseMemCb callback and its registration for NVL_RELEASE_MEM control message type. The IpcRegCache now handles incoming release requests directly via its AsyncSocket server.

The workflow of `exportMem` and `releaseMem` is as follows. Now `exportMem` and `releaseMem` could arrive at destination out of order. The reason of using AsyncSocket for `releaseMem` is that `IpcRegCache` will eventually be a singleton, and AsyncSocket can ensure all `releaseMem` arrives at peers reliably.

{F1985212617}

Reviewed By: dsjohns2

Differential Revision: D92077053


