### PR TITLE
Add Triton API for GPU-initiated communication via NCCLX GIN

### DIFF
--- a/comms/torchcomms/ncclx/TorchCommNCCLXPy.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXPy.cpp
@@ -7,6 +7,7 @@
 #include <torch/csrc/utils/pybind.h>
 
 #include "comms/torchcomms/ncclx/TorchCommNCCLX.hpp"
+#include "comms/torchcomms/ncclx/TorchCommWindowNCCLX.hpp"
 
 namespace py = pybind11;
 using namespace torch::comms;
@@ -242,4 +243,169 @@ Returns:
           py::arg("recv_indices"),
           py::arg("request"),
           py::call_guard<py::gil_scoped_release>());
+
+#ifdef TORCHCOMMS_HAS_NCCL_DEVICE_API
+  // ==========================================================================
+  // Device API Bindings (requires NCCLX 2.28+)
+  // ==========================================================================
+  //
+  // These bindings expose the device window API for use with Triton kernels.
+  // The get_device_window() method returns a pointer (as int64) that can be
+  // passed to Triton extern functions (torchcomms_put, torchcomms_signal, etc.)
+
+  py::class_<
+      TorchCommWindowNCCLXGin,
+      TorchCommWindow,
+      std::shared_ptr<TorchCommWindowNCCLXGin>>(m, "TorchCommWindowNCCLXGin")
+      .def(
+          "tensor_register",
+          &TorchCommWindowNCCLXGin::tensor_register,
+          R"(
+Register a tensor with this window.
+
+The tensor must be allocated from the RDMA-compatible memory pool
+obtained via torchcomms.get_mem_allocator(backend).
+
+Args:
+    tensor: A torch.Tensor allocated from the RDMA memory pool.
+
+Example:
+    >>> pool = torch.cuda.MemPool(allocator)
+    >>> with torch.cuda.use_mem_pool(pool):
+    ...     buf = torch.zeros(1024, device='cuda')
+    >>> window.tensor_register(buf)
+)",
+          py::arg("tensor"),
+          py::call_guard<py::gil_scoped_release>())
+      .def(
+          "tensor_deregister",
+          &TorchCommWindowNCCLXGin::tensor_deregister,
+          R"(
+Deregister the tensor from this window.
+
+Must be called before the window is destroyed if tensor_register was called.
+)",
+          py::call_guard<py::gil_scoped_release>())
+      .def(
+          "get_device_window",
+          [](TorchCommWindowNCCLXGin& self,
+             int signal_count,
+             int counter_count,
+             int barrier_count) {
+            auto* ptr = self.get_device_window(
+                signal_count, counter_count, barrier_count);
+            // Return as int64 for safe passage through Python to Triton
+            return reinterpret_cast<int64_t>(ptr);
+          },
+          R"(
+Get a device-side window handle for GPU-initiated operations.
+
+Returns a pointer (as int64) that can be passed to Triton kernels via
+the torchcomms_* extern functions (torchcomms_put, torchcomms_signal, etc.).
+
+The window is lazily created on first call and cached. The returned pointer
+is valid until this host window is destroyed.
+
+Args:
+    signal_count: Number of signal slots to allocate (-1 for default).
+    counter_count: Number of counter slots to allocate (-1 for default).
+    barrier_count: Number of barrier slots to allocate (default 1).
+
+Returns:
+    int: Device window pointer as int64, suitable for passing to Triton kernels.
+
+Example:
+    >>> window = comm.new_window()
+    >>> window.tensor_register(buffer)
+    >>> dev_win_ptr = ncclx_window.get_device_window(signal_count=8)
+    >>> # Pass dev_win_ptr to Triton kernel
+)",
+          py::arg("signal_count") = -1,
+          py::arg("counter_count") = -1,
+          py::arg("barrier_count") = 1,
+          py::call_guard<py::gil_scoped_release>())
+      .def(
+          "get_nccl_window",
+          [](TorchCommWindowNCCLXGin& self) {
+            // Return as int64 for safe passage through Python
+            return reinterpret_cast<int64_t>(self.get_nccl_window());
+          },
+          R"(
+Get the host-side NCCL window handle.
+
+Returns the ncclWindow_t as an int64, useful for advanced use cases
+where the raw NCCL window handle is needed.
+
+Returns:
+    int: NCCL window handle as int64.
+)",
+          py::call_guard<py::gil_scoped_release>());
+
+  // Helper function to cast a base TorchCommWindow to TorchCommWindowNCCLXGin
+  // This function has two overloads:
+  // 1. If already a TorchCommWindowNCCLXGin, return as-is
+  // 2. If a base TorchCommWindow, downcast to TorchCommWindowNCCLXGin
+  m.def(
+      "cast_to_ncclx_window",
+      [](std::shared_ptr<TorchCommWindowNCCLXGin> ncclx_window) {
+        // Already the right type, just return it
+        return ncclx_window;
+      },
+      R"(
+Cast a TorchCommWindow to TorchCommWindowNCCLXGin for device API access.
+
+If the window is already a TorchCommWindowNCCLXGin, returns it as-is.
+If the window is a base TorchCommWindow, attempts to downcast it.
+
+Args:
+    base_window: A TorchCommWindow or TorchCommWindowNCCLXGin from comm.new_window().
+
+Returns:
+    TorchCommWindowNCCLXGin: The window with device API methods available.
+
+Raises:
+    RuntimeError: If the window is not backed by NCCLX.
+)",
+      py::arg("base_window"),
+      py::call_guard<py::gil_scoped_release>());
+
+  // Second overload for base TorchCommWindow type
+  m.def(
+      "cast_to_ncclx_window",
+      [](std::shared_ptr<TorchCommWindow> base_window) {
+        auto ncclx_window =
+            std::dynamic_pointer_cast<TorchCommWindowNCCLXGin>(base_window);
+        if (!ncclx_window) {
+          throw std::runtime_error(
+              "Window is not a TorchCommWindowNCCLXGin. "
+              "Device API requires NCCLX backend.");
+        }
+        return ncclx_window;
+      },
+      R"(
+Cast a base TorchCommWindow to TorchCommWindowNCCLXGin for device API access.
+
+This is needed because comm.new_window() returns the base TorchCommWindow type,
+but device API methods (get_device_window, get_nccl_window) are only available
+on TorchCommWindowNCCLXGin.
+
+Args:
+    base_window: A TorchCommWindow obtained from comm.new_window().
+
+Returns:
+    TorchCommWindowNCCLXGin: The same window with device API methods available.
+
+Raises:
+    RuntimeError: If the window is not backed by NCCLX.
+
+Example:
+    >>> from torchcomms._comms_ncclx import cast_to_ncclx_window
+    >>> window = comm.new_window()
+    >>> window.tensor_register(buffer)
+    >>> ncclx_window = cast_to_ncclx_window(window)
+    >>> dev_win_ptr = ncclx_window.get_device_window(signal_count=8)
+)",
+      py::arg("base_window"),
+      py::call_guard<py::gil_scoped_release>());
+#endif
 }

--- a/comms/torchcomms/ncclx/_comms_ncclx.pyi
+++ b/comms/torchcomms/ncclx/_comms_ncclx.pyi
@@ -1,9 +1,24 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # pyre-strict
 
-from typing import List
+from typing import Any, List, Union
 
 import torch
+
+class TorchCommWindowNCCLXGin:
+    def tensor_register(self, tensor: torch.Tensor) -> None: ...
+    def tensor_deregister(self) -> None: ...
+    def get_device_window(
+        self,
+        signal_count: int = -1,
+        counter_count: int = -1,
+        barrier_count: int = 1,
+    ) -> int: ...
+    def get_nccl_window(self) -> int: ...
+
+def cast_to_ncclx_window(
+    base_window: Union[TorchCommWindowNCCLXGin, Any],
+) -> TorchCommWindowNCCLXGin: ...
 
 class TorchWork:
     def is_completed(self) -> bool: ...

--- a/comms/torchcomms/triton/ir_include/nccl.h
+++ b/comms/torchcomms/triton/ir_include/nccl.h
@@ -1,0 +1,40 @@
+/*************************************************************************
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Minimal NCCL type definitions for IR/bitcode compilation.
+ * This header provides forward declarations and type aliases needed
+ * by the NCCLX device headers when compiled with clang for LLVM bitcode.
+ ************************************************************************/
+
+#ifndef NCCL_IR_H_
+#define NCCL_IR_H_
+
+#include <cuda_runtime.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Error type */
+typedef enum {
+  ncclSuccess = 0,
+  ncclUnhandledCudaError = 1,
+  ncclSystemError = 2,
+  ncclInternalError = 3,
+  ncclInvalidArgument = 4,
+  ncclInvalidUsage = 5,
+  ncclRemoteError = 6
+} ncclResult_t;
+
+/* Opaque handle to communicator */
+typedef struct ncclComm* ncclComm_t;
+
+/* Window type - pointer to ncclWindow_vidmem struct defined in core__types.h */
+struct ncclWindow_vidmem;
+typedef struct ncclWindow_vidmem* ncclWindow_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NCCL_IR_H_ */

--- a/comms/torchcomms/triton/torchcomms_device.cu
+++ b/comms/torchcomms/triton/torchcomms_device.cu
@@ -1,0 +1,224 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// TorchComms Triton Device API - nvcc-compiled implementations
+//
+// This file provides extern "C" wrappers around TorchCommDeviceWindow methods.
+// Compiled with nvcc to support NCCLX GIN templates.
+// Linked at compile time into Triton kernels via extern_libs bitcode.
+//
+// Design:
+// - All functions take void* handles (TorchCommsWindowHandle,
+// TorchCommsBufferHandle)
+// - Internally cast to TorchCommDeviceWindow<NCCLGinBackend>* and
+// RegisteredBuffer*
+// - 1:1 mapping with TorchCommDeviceWindow methods
+//
+// IMPORTANT: Side-effecting functions (put, signal, wait, flush, reset) use a
+// threadIdx.x == 0 guard because Triton's extern_elementwise emits a call per
+// thread in the block.  With the default num_warps=4 that is 128 threads, so
+// without the guard these operations would execute 128 times per kernel launch.
+// Pure query functions (rank, num_ranks, base, size) are idempotent and don't
+// need the guard.
+
+#include <cuda_runtime.h>
+
+#include "comms/torchcomms/device/ncclx/TorchCommDeviceNCCLX.cuh"
+
+using namespace torchcomms::device;
+
+using DeviceWindow = TorchCommDeviceWindow<NCCLGinBackend>;
+
+extern "C" {
+
+// =============================================================================
+// RMA Operations
+// =============================================================================
+
+// torchcomms_put takes expanded RegisteredBuffer fields as arguments instead
+// of a pointer to a GPU-allocated struct. This avoids GPU memory allocation
+// conflicts with NCCLX's cuMemMap-based memory management.
+//
+// The RegisteredBuffer is constructed on the stack from the passed arguments.
+__device__ int torchcomms_put(
+    void* win_ptr,
+    unsigned long long dst_offset,
+    void* src_base_ptr,
+    unsigned long long src_size,
+    void* src_nccl_win,
+    unsigned long long src_offset,
+    int dst_rank,
+    unsigned long long bytes,
+    int signal_id,
+    int counter_id) {
+  // HACK: Triton's extern_elementwise vectorizes calls when arguments have
+  // block shape. This guard ensures only thread 0 executes the actual put.
+  // All other threads return early with success.
+  if (threadIdx.x != 0) {
+    return 0;
+  }
+
+  auto* win = reinterpret_cast<DeviceWindow*>(win_ptr);
+
+  // Construct RegisteredBuffer on the stack from passed arguments
+  RegisteredBuffer src_buf;
+  src_buf.base_ptr = src_base_ptr;
+  src_buf.size = static_cast<size_t>(src_size);
+  src_buf.backend_window = src_nccl_win;
+
+  return win->put(
+      static_cast<size_t>(dst_offset),
+      src_buf,
+      static_cast<size_t>(src_offset),
+      dst_rank,
+      static_cast<size_t>(bytes),
+      signal_id,
+      counter_id);
+}
+
+// =============================================================================
+// Signal Operations (Remote Notification)
+// =============================================================================
+
+__device__ int torchcomms_signal(
+    void* win_ptr,
+    int peer,
+    int signal_id,
+    unsigned long long value) {
+  // HACK: Guard against Triton vectorization - only thread 0 executes
+  if (threadIdx.x != 0) {
+    return 0;
+  }
+  auto* win = reinterpret_cast<DeviceWindow*>(win_ptr);
+  return win->signal(peer, signal_id, SignalOp::ADD, value);
+}
+
+__device__ int torchcomms_wait_signal(
+    void* win_ptr,
+    int signal_id,
+    unsigned long long expected_value) {
+  // HACK: Guard against Triton vectorization - only thread 0 executes
+  if (threadIdx.x != 0) {
+    return 0;
+  }
+  auto* win = reinterpret_cast<DeviceWindow*>(win_ptr);
+  return win->wait_signal(signal_id, CmpOp::GE, expected_value);
+}
+
+__device__ unsigned long long torchcomms_read_signal(
+    void* win_ptr,
+    int signal_id) {
+  // HACK: Guard against Triton vectorization - only thread 0 executes
+  if (threadIdx.x != 0) {
+    return 0;
+  }
+  auto* win = reinterpret_cast<DeviceWindow*>(win_ptr);
+  return win->read_signal(signal_id);
+}
+
+__device__ void torchcomms_reset_signal(void* win_ptr, int signal_id) {
+  // HACK: Guard against Triton vectorization - only thread 0 executes
+  if (threadIdx.x != 0) {
+    return;
+  }
+  auto* win = reinterpret_cast<DeviceWindow*>(win_ptr);
+  win->reset_signal(signal_id);
+}
+
+// =============================================================================
+// Counter Operations (Local Completion)
+// =============================================================================
+
+__device__ int torchcomms_wait_local(
+    void* win_ptr,
+    int counter_id,
+    unsigned long long expected_value) {
+  // HACK: Guard against Triton vectorization - only thread 0 executes
+  if (threadIdx.x != 0) {
+    return 0;
+  }
+  auto* win = reinterpret_cast<DeviceWindow*>(win_ptr);
+  return win->wait_local(counter_id, CmpOp::GE, expected_value);
+}
+
+__device__ unsigned long long torchcomms_read_counter(
+    void* win_ptr,
+    int counter_id) {
+  // HACK: Guard against Triton vectorization - only thread 0 executes
+  if (threadIdx.x != 0) {
+    return 0;
+  }
+  auto* win = reinterpret_cast<DeviceWindow*>(win_ptr);
+  return win->read_counter(counter_id);
+}
+
+__device__ void torchcomms_reset_counter(void* win_ptr, int counter_id) {
+  // HACK: Guard against Triton vectorization - only thread 0 executes
+  if (threadIdx.x != 0) {
+    return;
+  }
+  auto* win = reinterpret_cast<DeviceWindow*>(win_ptr);
+  win->reset_counter(counter_id);
+}
+
+// =============================================================================
+// Synchronization & Completion
+// =============================================================================
+
+__device__ int torchcomms_fence(void* win_ptr) {
+  // HACK: Guard against Triton vectorization - only thread 0 executes
+  if (threadIdx.x != 0) {
+    return 0;
+  }
+  auto* win = reinterpret_cast<DeviceWindow*>(win_ptr);
+  return win->fence();
+}
+
+__device__ int torchcomms_flush(void* win_ptr) {
+  // HACK: Guard against Triton vectorization - only thread 0 executes
+  if (threadIdx.x != 0) {
+    return 0;
+  }
+  auto* win = reinterpret_cast<DeviceWindow*>(win_ptr);
+  return win->flush();
+}
+
+// =============================================================================
+// Window Properties
+// =============================================================================
+
+__device__ int torchcomms_rank(void* win_ptr) {
+  // HACK: Guard against Triton vectorization - only thread 0 executes
+  if (threadIdx.x != 0) {
+    return 0;
+  }
+  auto* win = reinterpret_cast<DeviceWindow*>(win_ptr);
+  return win->rank();
+}
+
+__device__ int torchcomms_num_ranks(void* win_ptr) {
+  // HACK: Guard against Triton vectorization - only thread 0 executes
+  if (threadIdx.x != 0) {
+    return 0;
+  }
+  auto* win = reinterpret_cast<DeviceWindow*>(win_ptr);
+  return win->num_ranks();
+}
+
+__device__ void* torchcomms_base(void* win_ptr) {
+  // HACK: Guard against Triton vectorization - only thread 0 executes
+  if (threadIdx.x != 0) {
+    return nullptr;
+  }
+  auto* win = reinterpret_cast<DeviceWindow*>(win_ptr);
+  return win->base();
+}
+
+__device__ unsigned long long torchcomms_size(void* win_ptr) {
+  // HACK: Guard against Triton vectorization - only thread 0 executes
+  if (threadIdx.x != 0) {
+    return 0;
+  }
+  auto* win = reinterpret_cast<DeviceWindow*>(win_ptr);
+  return static_cast<unsigned long long>(win->size());
+}
+
+} // extern "C"

--- a/comms/torchcomms/triton/torchcomms_device.h
+++ b/comms/torchcomms/triton/torchcomms_device.h
@@ -1,0 +1,131 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// TorchComms Triton Device API - C-style declarations for LLVM bitcode
+//
+// This header declares C-style wrapper functions for TorchComms Device API.
+// Compiled to LLVM bitcode with clang for linking with Triton kernels.
+//
+// All functions use opaque void* handles to avoid C++ type dependencies.
+// The actual implementations (in torchcomms_device.cu) cast these to the
+// appropriate TorchComms types.
+//
+// Usage:
+//   1. Compile this header with clang to produce bitcode (.bc)
+//   2. Pass the .bc file to Triton via extern_libs parameter
+//   3. Use @core.extern to declare these functions in Triton kernels
+//   4. Triton statically links the bitcode into generated kernel PTX at JIT
+//   time
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Opaque handle types
+// These are void* to avoid any NCCLX header dependencies.
+// The actual types are resolved in the nvcc-compiled implementation.
+typedef void* TorchCommsWindowHandle;
+typedef void* TorchCommsBufferHandle;
+
+// =============================================================================
+// RMA Operations
+// =============================================================================
+
+// Put data from local registered buffer to remote window.
+// The source buffer is specified by its components (base_ptr, size, nccl_win)
+// rather than a pointer to a RegisteredBuffer struct. This avoids GPU memory
+// allocation conflicts with NCCLX's cuMemMap-based memory management.
+// Returns: 0 on success, negative on error
+__device__ int torchcomms_put(
+    TorchCommsWindowHandle win,
+    unsigned long long dst_offset,
+    void* src_base_ptr,
+    unsigned long long src_size,
+    void* src_nccl_win,
+    unsigned long long src_offset,
+    int dst_rank,
+    unsigned long long bytes,
+    int signal_id,
+    int counter_id);
+
+// =============================================================================
+// Signal Operations (Remote Notification)
+// =============================================================================
+
+// Send signal to remote peer (atomic add)
+// Returns: 0 on success, negative on error
+__device__ int torchcomms_signal(
+    TorchCommsWindowHandle win,
+    int peer,
+    int signal_id,
+    unsigned long long value);
+
+// Wait for signal to reach expected value (>=)
+// Returns: 0 on success, negative on error
+__device__ int torchcomms_wait_signal(
+    TorchCommsWindowHandle win,
+    int signal_id,
+    unsigned long long expected_value);
+
+// Read current signal value
+__device__ unsigned long long torchcomms_read_signal(
+    TorchCommsWindowHandle win,
+    int signal_id);
+
+// Reset signal to zero
+__device__ void torchcomms_reset_signal(
+    TorchCommsWindowHandle win,
+    int signal_id);
+
+// =============================================================================
+// Counter Operations (Local Completion)
+// =============================================================================
+
+// Wait for local counter to reach expected value (>=)
+// Returns: 0 on success, negative on error
+__device__ int torchcomms_wait_local(
+    TorchCommsWindowHandle win,
+    int counter_id,
+    unsigned long long expected_value);
+
+// Read current counter value
+__device__ unsigned long long torchcomms_read_counter(
+    TorchCommsWindowHandle win,
+    int counter_id);
+
+// Reset counter to zero
+__device__ void torchcomms_reset_counter(
+    TorchCommsWindowHandle win,
+    int counter_id);
+
+// =============================================================================
+// Synchronization & Completion
+// =============================================================================
+
+// Memory fence (ordering guarantee)
+// Returns: 0 on success
+__device__ int torchcomms_fence(TorchCommsWindowHandle win);
+
+// Flush all pending operations
+// Returns: 0 on success
+__device__ int torchcomms_flush(TorchCommsWindowHandle win);
+
+// =============================================================================
+// Window Properties
+// =============================================================================
+
+// Get rank of this process
+__device__ int torchcomms_rank(TorchCommsWindowHandle win);
+
+// Get total number of ranks
+__device__ int torchcomms_num_ranks(TorchCommsWindowHandle win);
+
+// Get window base pointer
+__device__ void* torchcomms_base(TorchCommsWindowHandle win);
+
+// Get window size in bytes
+__device__ unsigned long long torchcomms_size(TorchCommsWindowHandle win);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Summary:
Enables calling TorchComms device APIs from Triton kernels using NCCLX GIN (GPU-Initiated Networking). This allows Triton-authored collective/RMA operations without leaving the GPU, enabling tighter integration with computation kernels.

Key Components
Python API (triton/fb/__init__.py): Triton-callable wrappers using core.extern and extern_elementwise for put, signal, wait_signal, flush, etc. Includes requires_torchcomms decorator that injects extern_libs and link_libs at JIT time.

C Device Functions (triton/torchcomms_device.cu): extern "C" wrappers around TorchCommDeviceWindow<NCCLGinBackend> methods. Includes threadIdx.x == 0 guards to handle Triton's extern_elementwise vectorization (which calls device functions once per thread).

LLVM Bitcode Generation (triton/BUCK): Genrule to compile device functions to LLVM bitcode with Clang for Triton's extern_libs linking.

Python Bindings (ncclx/TorchCommNCCLXPy.cpp): Exposes TorchCommWindowNCCLXGin class with get_device_window() and get_nccl_window() methods to obtain device handles for Triton.

E2E Test (triton/fb/tests/test_e2e.py): Validates ring-based put with signal synchronization across ranks.

Differential Revision: D92457411


