### PR TITLE
make IpcRegCache a singleton, and also send the releaseMem ctrl-msg  at mapper destruction

### DIFF
--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -858,8 +858,6 @@ class CtranMapper {
 
   CtranSocket* ctranSockPtr();
 
-  ctran::IpcRegCache* ipcRegCachePtr();
-
   // number of iput requests made for each backend
   std::vector<int> iPutCount;
   std::vector<int> iGetCount;
@@ -1087,7 +1085,8 @@ class CtranMapper {
     if (backend == CtranMapperBackend::NVL) {
       msg.setType(ControlMsgType::NVL_EXPORT_MEM);
       FB_COMMCHECK(
-          ipcRegCache_->exportMem(buf, regElem->ipcRegElem, msg.ipcDesc));
+          ctran::IpcRegCache::getInstance()->exportMem(
+              buf, regElem->ipcRegElem, msg.ipcDesc));
 
       // Record the exported remote rank to notify at deregistration
       exportRegCache_.wlock()->record(regElem, rank);
@@ -1136,8 +1135,13 @@ class CtranMapper {
         }
         remKey->backend = CtranMapperBackend::NVL;
         const std::string peerId = comm->statex_->gPid(rank);
-        FB_COMMCHECK(ipcRegCache_->importMem(
-            peerId, msg.ipcDesc, buf, &(remKey->nvlKey)));
+        FB_COMMCHECK(
+            ctran::IpcRegCache::getInstance()->importMem(
+                peerId,
+                msg.ipcDesc,
+                buf,
+                &(remKey->nvlKey),
+                &this->logMetaData_));
         break;
       }
       default:
@@ -1926,7 +1930,6 @@ class CtranMapper {
   std::unique_ptr<class CtranSocket> ctranSock{nullptr};
   std::unique_ptr<class ctran::CtranTcpDm> ctranTcpDm{nullptr};
   std::unique_ptr<class CtranCtrlManager> ctrlMgr{nullptr};
-  std::unique_ptr<class ctran::IpcRegCache> ipcRegCache_{nullptr};
 
   // holds enabled backends when the mapper is created.
   // A unified struct for holding all available backends.

--- a/comms/ctran/mapper/tests/CtranDistMapperUT.cc
+++ b/comms/ctran/mapper/tests/CtranDistMapperUT.cc
@@ -841,7 +841,7 @@ TEST_P(CtranDistMapperBufExportParam, BufExportCtrl) {
 
   COMMCHECK_TEST(mapper->deregMem(segHandle, skipRemRelease));
   if (!skipRemRelease) {
-    auto ipcRegCache = mapper->ipcRegCachePtr();
+    auto ipcRegCache = ctran::IpcRegCache::getInstance();
     if (remoteAccessKeys.backend == CtranMapperBackend::NVL) {
       while (ipcRegCache->getNumRemReg(remoteAccessKeys.nvlKey.peerId) > 0) {
         std::this_thread::yield();

--- a/comms/ctran/regcache/tests/DistRegCacheUT.cc
+++ b/comms/ctran/regcache/tests/DistRegCacheUT.cc
@@ -189,7 +189,7 @@ TEST_P(DistRegCacheTestSuite, ExportImportMem) {
 
   auto& mapper = comm_->ctran_->mapper;
   ASSERT_NE(mapper, nullptr);
-  auto* ipcRegCache = mapper->ipcRegCachePtr();
+  auto ipcRegCache = ctran::IpcRegCache::getInstance();
   ASSERT_NE(ipcRegCache, nullptr);
 
   std::unique_ptr<CtranIb> ctranIb;
@@ -264,7 +264,11 @@ TEST_P(DistRegCacheTestSuite, ExportImportMem) {
     CtranMapperRemoteAccessKey remKey{};
     remKey.backend = CtranMapperBackend::NVL;
     COMMCHECK_TEST(ipcRegCache->importMem(
-        peerId, msg.ipcDesc, &mappedData, &remKey.nvlKey));
+        peerId,
+        msg.ipcDesc,
+        &mappedData,
+        &remKey.nvlKey,
+        &comm_->logMetaData_));
     EXPECT_NE(mappedData, nullptr);
     EXPECT_EQ(remKey.nvlKey.basePtr, msg.ipcDesc.desc.base);
 
@@ -292,7 +296,8 @@ TEST_F(DistRegCacheTest, ExportReleaseMemCb) {
   const size_t dataCount = 100;
   size_t dataRange = dataCount * sizeof(int);
 
-  auto* ipcRegCache = mapper->ipcRegCachePtr();
+  // Get ipcRegCache singleton
+  auto ipcRegCache = ctran::IpcRegCache::getInstance();
   folly::SocketAddress localServerAddr = ipcRegCache->getServerAddr();
   std::vector<folly::SocketAddress> peerServerAddrs;
   allGatherSocketAddress(localServerAddr, peerServerAddrs);
@@ -366,8 +371,8 @@ TEST_F(DistRegCacheTest, ExportMultiMem) {
   ASSERT_NE(mapper, nullptr);
   const size_t dataCount = 100;
   size_t dataRange = dataCount * sizeof(int);
-  // Get ipcRegCache from mapper
-  auto* ipcRegCache = mapper->ipcRegCachePtr();
+  // Get ipcRegCache singleton
+  auto ipcRegCache = ctran::IpcRegCache::getInstance();
   folly::SocketAddress localServerAddr = ipcRegCache->getServerAddr();
   std::vector<folly::SocketAddress> peerServerAddrs;
   allGatherSocketAddress(localServerAddr, peerServerAddrs);


### PR DESCRIPTION
Summary:
### Convert IpcRegCache to singleton and add server address exchange                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                           
**Key Changes:**                                                                                                                                                                                                                                                                                                             
```                                                                                                                                                                                                                                                                                                                       
  1. IpcRegCache Singleton Pattern                                                                                                                                                                                                                                                                                         
    - Converted IpcRegCache from per-mapper instance to singleton shared by all communicators                                                                                                                                                                                                                              
    - Added getInstance() static method using folly::Singleton                                                                                                                                                                                                                                                             
    - Made init() idempotent with CUDA device validation - throws exception if different CUDA devices attempt to use the same singleton                                                                                                                                                                                    
  2. Remove Per-Communicator State                                                                                                                                                                                                                                                                                         
    - Removed logMetaData_ member variable from IpcRegCache                                                                                                                                                                                                                                                                
    - Made logMetaData an optional parameter (default nullptr) for importMem()                                                                                                                                                                                                                                             
    - Each communicator now passes its own logMetaData when needed                                                                                                                                                                                                                                                         
  3. Server Address Exchange                                                                                                                                                                                                                                                                                               
    - Added allGatherIpcServerAddrs() in CtranMapper to exchange AsyncSocket server addresses via bootstrap                                                                                                                                                                                                                
    - Added peerIpcServerAddrs_ storage and getPeerIpcServerAddr() accessor in CtranMapper                                                                                                                                                                                                                                 
    - Fixed remReleaseMem() to use the gathered peer addresses for async socket communication                                                                                                                                                                                                                              
  4. Remote Memory Release Fix                                                                                                                                                                                                                                                                                             
    - Removed the atDestruction check in remReleaseMem()                                                                                                                                                                                                                                                                   
    - Now always sends release messages even during destruction since IpcRegCache is a singleton that outlives individual mappers                                                                                                                                                                                          
  5. Test Updates                                                                                                                                                                                                                                                                                                          
    - Updated all tests to use IpcRegCache::getInstance() instead of ipcRegCachePtr()                                                                                                                                                                                                                                      
    - Updated importMem() calls to use new parameter order with optional logMetaData
```
**Benefits**
```                                                                                                                                                                                                                                                                     
  - Reduces memory usage by sharing IpcRegCache across communicators                                                                                                                                                                                                                                                       
  - Properly exchanges server addresses needed for async socket communication                                                                                                                                                                                                                                              
  - Ensures consistent CUDA device usage across all communicators                                                                                                                                                                                                                                                          
  - Fixes potential memory leaks by always releasing remote memory
```

Reviewed By: dsjohns2

Differential Revision: D92090165


