### PR TITLE
Add VerifyAlgoStatsHelper test utility

### DIFF
--- a/comms/ncclx/v2_28/meta/tests/VerifyAlgoStatsUtil.cc
+++ b/comms/ncclx/v2_28/meta/tests/VerifyAlgoStatsUtil.cc
@@ -1,0 +1,77 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "VerifyAlgoStatsUtil.h"
+
+#include <fmt/core.h>
+#include <gtest/gtest.h>
+#include <unordered_map>
+#include "meta/colltrace/AlgoStats.h"
+
+namespace ncclx::test {
+
+namespace {
+
+using AlgoStatsMap = std::unordered_map<std::string, int64_t>;
+
+// Retrieve per-algorithm stats for a collective.
+// Returns the algo name -> call count map; empty if collective not found.
+AlgoStatsMap getAlgoStats(ncclComm_t comm, const std::string& collective) {
+  std::unordered_map<std::string, std::unordered_map<std::string, int64_t>>
+      stats;
+  ncclx::colltrace::dumpAlgoStat(comm, stats);
+
+  auto it = stats.find(collective);
+  EXPECT_NE(it, stats.end())
+      << collective << " not found in AlgoStats. Stats may not be enabled.";
+  if (it == stats.end()) {
+    return {};
+  }
+  return std::move(it->second);
+}
+
+// Format algo stats map as "algo1(count1), algo2(count2), ...".
+std::string formatAlgoStats(const AlgoStatsMap& algoStats) {
+  std::string result;
+  for (const auto& [algoName, callCount] : algoStats) {
+    if (!result.empty()) {
+      result += ", ";
+    }
+    result += fmt::format("{}({})", algoName, callCount);
+  }
+  return result;
+}
+
+} // namespace
+
+void VerifyAlgoStatsHelper::enable() {
+  colltraceGuard_.emplace(NCCL_COLLTRACE, std::vector<std::string>{"algostat"});
+}
+
+void VerifyAlgoStatsHelper::dump(ncclComm_t comm, const std::string& collective)
+    const {
+  auto stats = getAlgoStats(comm, collective);
+  fmt::print(
+      stderr, "AlgoStats[{}]: [{}]\n", collective, formatAlgoStats(stats));
+}
+
+void VerifyAlgoStatsHelper::verify(
+    ncclComm_t comm,
+    const std::string& collective,
+    const std::string& expectedAlgoSubstr) const {
+  auto stats = getAlgoStats(comm, collective);
+
+  bool found = false;
+  for (const auto& [algoName, callCount] : stats) {
+    if (algoName.find(expectedAlgoSubstr) != std::string::npos &&
+        callCount > 0) {
+      found = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(found) << "Expected algorithm containing '" << expectedAlgoSubstr
+                     << "' not found in " << collective
+                     << ". Found algorithms: [" << formatAlgoStats(stats)
+                     << "]";
+}
+
+} // namespace ncclx::test

--- a/comms/ncclx/v2_28/meta/tests/VerifyAlgoStatsUtil.h
+++ b/comms/ncclx/v2_28/meta/tests/VerifyAlgoStatsUtil.h
@@ -1,0 +1,58 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+#include "comms/testinfra/TestUtils.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+#include "nccl.h" // @manual
+
+namespace ncclx::test {
+
+// Helper class for algorithm statistics verification in tests.
+//
+// Usage:
+//   class MyTest : public NcclxBaseTest {
+//    protected:
+//     VerifyAlgoStatsHelper algoStats_;
+//
+//     void SetUp() override {
+//       NcclxBaseTest::SetUp();
+//       algoStats_.enable();  // Must be called before comm creation
+//     }
+//   };
+//
+//   TEST_F(MyTest, Foo) {
+//     // ... run collective ...
+//     algoStats_.verify(comm, "ReduceScatter", "PAT");
+//   }
+class VerifyAlgoStatsHelper {
+ public:
+  VerifyAlgoStatsHelper() = default;
+
+  // Enable AlgoStats tracing. Must be called after Cvars are initialized
+  // (e.g., via initEnv()) and before NCCL comm creation.
+  void enable();
+
+  // Dump all algorithm statistics to stderr.
+  // @param comm The NCCL communicator to query stats from
+  // @param collective The collective name (e.g., "ReduceScatter", "AllReduce")
+  void dump(ncclComm_t comm, const std::string& collective) const;
+
+  // Verify that the expected algorithm was used via AlgoStats.
+  // @param comm The NCCL communicator to query stats from
+  // @param collective The collective name (e.g., "ReduceScatter", "AllReduce")
+  // @param expectedAlgoSubstr Substring to match in algorithm name (e.g.,
+  // "PAT", "Ring")
+  void verify(
+      ncclComm_t comm,
+      const std::string& collective,
+      const std::string& expectedAlgoSubstr) const;
+
+ private:
+  std::optional<EnvRAII<std::vector<std::string>>> colltraceGuard_;
+};
+
+} // namespace ncclx::test


### PR DESCRIPTION
Summary:
This adds a test utility helper class (VerifyAlgoStatsHelper) that enables
algorithm verification in NCCL tests via the AlgoStats infrastructure.

The utility:
- Sets NCCL_ALGOSTATS_ENABLE=1 to enable algorithm statistics collection
- Provides verify() method to check if a specific algorithm was used
- Supports substring matching for algorithm names (e.g., "PAT", "Ring")

This helper is standalone and can be used by any test that needs to verify
which algorithm was selected for a collective operation.

Differential Revision: D92487189


