### PR TITLE
NCCL_CTRAN_ALLREDUCE_RING_MAX_NUM_THREAD_BLOCKS default to 8

### DIFF
--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2755,7 +2755,7 @@ cvars:
 
  - name        : NCCL_CTRAN_ALLREDUCE_RING_MAX_NUM_THREAD_BLOCKS
    type        : int
-   default     : 2
+   default     : 8
    description : |-
      Maximum number of thread blocks used for the AllReduce kernel.
      We might use fewer thread blocks, if we can achieve max occupancy


### PR DESCRIPTION
Summary: This targets GB200 and be more futureproof. H100 is overriden to use 4 blocks in chef: https://www.internalfb.com/diff/D92581251.

Reviewed By: saifhhasan

Differential Revision: D92582012


