### PR TITLE
Implement PAT AVG for ReduceScatter

### DIFF
--- a/comms/ncclx/v2_28/meta/collectives/PatAvgHelper.h
+++ b/comms/ncclx/v2_28/meta/collectives/PatAvgHelper.h
@@ -1,0 +1,76 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include "comm.h"
+#include "device.h"
+#include "meta/algoconf/InfoExt.h"
+
+namespace ncclx {
+
+// PatAvg is restricted to types with enough exponent range to avoid
+// overflow during intermediate sum accumulation. fp16 and fp8 types are
+// excluded.
+inline bool isPatAvgSupportedType(ncclDataType_t dt) {
+  switch (dt) {
+    case ncclFloat16:
+    case ncclFloat8e4m3:
+    case ncclFloat8e5m2:
+      return false;
+    default:
+      return true;
+  }
+}
+
+// Compute nMaxChannels and nWarps for PAT algorithm with SIMPLE protocol.
+// This mirrors the computation in topoGetAlgoInfo() but can be called early
+// to enable per-communicator PAT AVG control via ncclInfoExt.
+inline void computePatAvgChannelsAndWarps(
+    struct ncclComm* comm,
+    size_t nBytes,
+    int* outNMaxChannels,
+    int* outNWarps) {
+  int nc = comm->nChannels;
+  int nt = comm->maxThreads[NCCL_ALGO_PAT][NCCL_PROTO_SIMPLE];
+  int threadThreshold =
+      comm->threadThresholds[NCCL_ALGO_PAT][NCCL_PROTO_SIMPLE];
+
+  // Reduce channels based on data size (same logic as topoGetAlgoInfo)
+  while (nBytes < static_cast<size_t>(nc * nt * threadThreshold) && nc >= 2) {
+    nc--;
+  }
+
+  // PAT always uses max threads
+  nt = NCCL_MAX_NTHREADS;
+
+  *outNMaxChannels = nc;
+  *outNWarps = nt / WARP_SIZE;
+}
+
+// Set up ncclInfoExt for PAT AVG override.
+// Call at ncclReduceScatter entry when comm->usePatAvg_ && op == ncclAvg.
+// Returns a fully constructed ncclInfoExt so that algoInfoMayOverride() will
+// apply the override and skip algorithm selection.
+inline algoconf::ncclInfoExt setupPatAvgInfoExt(
+    struct ncclComm* comm,
+    size_t nBytes,
+    ncclDataType_t datatype) {
+  int nMaxChannels = 0, nWarps = 0;
+  computePatAvgChannelsAndWarps(comm, nBytes, &nMaxChannels, &nWarps);
+
+  bool isSigned =
+      (datatype == ncclInt8 || datatype == ncclInt32 || datatype == ncclInt64);
+  ncclDevRedOpFull opDev{};
+  opDev.op = ncclDevPatSumPostDiv;
+  // Encode (divisor << 1 | isSigned): signed int types map to unsigned kernels
+  // via equivalent_primary(), so the device-side divide() needs isSigned to
+  // reinterpret the accumulated sum as signed before dividing.
+  opDev.scalarArg = (static_cast<uint64_t>(comm->nRanks) << 1) |
+      static_cast<uint64_t>(isSigned);
+  opDev.scalarArgIsPtr = false;
+
+  return algoconf::ncclInfoExt(
+      NCCL_ALGO_PAT, NCCL_PROTO_SIMPLE, nMaxChannels, nWarps, opDev);
+}
+
+} // namespace ncclx

--- a/comms/ncclx/v2_28/meta/collectives/docs/ReduceScatterPat.md
+++ b/comms/ncclx/v2_28/meta/collectives/docs/ReduceScatterPat.md
@@ -1,0 +1,189 @@
+# PAT ReduceScatter Algorithm
+
+## Overview
+
+PAT (Pairwise Algorithm Tree) ReduceScatter implements a recursive halving algorithm that efficiently reduces and scatters data across ranks. For N ranks, each portion completes in log2(N) steps.
+
+## Key Data Structures
+
+### ncclPatStep (collectives.h)
+
+```cpp
+struct ncclPatStep {
+  int recvDim, sendDim;      // Dimension for recv/send (-1 = none/local)
+  int recvOffset, sendOffset; // Offset within peer buffer
+  int stepOffset;            // Step offset for pipelining
+  int postRecv, postSend;    // Post flags for completion
+  int nelem, last, flags;    // Element count, completion, status
+  bool isFinalWrite;         // True if final write for a chunk (apply division for AVG)
+  size_t inpIx, outIx;       // Input/output buffer indices
+};
+```
+
+### PatRSAlgorithm Class Members
+
+```cpp
+offset, end    // Current chunk range being processed
+count          // Total elements per rank in input buffer
+chunkCount     // Elements per chunk iteration
+nelem          // Actual elements this iteration
+rank, nranks   // This rank's ID and total rank count
+nrPow2         // Next power of 2 >= nranks
+aggFactor      // Aggregation factor (batches multiple steps)
+aggDelta       // Step delta = nrPow2 / aggFactor
+as             // Current aggregated step index
+a              // Sub-step within aggregated step
+phase          // Current algorithm phase (0-4)
+scale          // Scaling factor for phases 2-3
+```
+
+## recvDim and sendDim Encoding
+
+```
+recvDim = -1  ->  No receive (use local data only as source)
+recvDim >= 0  ->  Receive from peer along hypercube dimension N
+
+sendDim = -1  ->  Write to LOCAL output buffer (userOutput + outIx)
+sendDim >= 0  ->  Send to peer along hypercube dimension N
+```
+
+The dimension corresponds to hypercube edges. For 8 ranks:
+- Dim 0: pairs (0,1), (2,3), (4,5), (6,7) - rank XOR 1
+- Dim 1: pairs (0,2), (1,3), (4,6), (5,7) - rank XOR 2
+- Dim 2: pairs (0,4), (1,5), (2,6), (3,7) - rank XOR 4
+
+## The 5 Phases
+
+The algorithm uses 5 phases organized into two groups:
+
+### Primary Reduction (Phases 0-1)
+Handles the main recursive halving, processing odd-indexed `as` values.
+
+| Phase | Description | recvDim | sendDim |
+|-------|-------------|---------|---------|
+| **0** | Initial scatter: D2D copy from input, send to dim 0 peer | -1 (none) | 0 |
+| **1** | Recursive halving: receive from dimension, reduce, forward to next dimension | `firstBitSet(s)` | `firstBitSet(s')` or -1 |
+
+### Secondary Reduction (Phases 2-3)
+Activated when `aggFactor > 1`. Forms a butterfly pattern at increasing scales to complete the reduction.
+
+| Phase | Description | recvDim | sendDim |
+|-------|-------------|---------|---------|
+| **2** | Receive from dim 0 peer, reduce, forward to higher dimension | 0 | `firstBitSet(s)` or -1 |
+| **3** | Receive from higher dimension, reduce, forward or write locally | `firstBitSet(s)` | `firstBitSet(s')` or -1 |
+
+Phases 2-3 loop with `scale` doubling each iteration until `scale >= aggFactor`.
+
+### Finalization (Phase 4)
+
+| Phase | Description | recvDim | sendDim |
+|-------|-------------|---------|---------|
+| **4** | Final receive from dim 0, reduce, write to output buffer | 0 | -1 (local) |
+
+## 8-Rank ReduceScatter Example
+
+### Setup
+
+```
+Ranks: 0, 1, 2, 3, 4, 5, 6, 7
+nrPow2 = 8
+Dimensions: 0, 1, 2 (log2(8) = 3 dimensions)
+
+Input: Each rank has input[0..7] (8 portions)
+Output: Rank r gets reduced sum of all ranks' input[r]
+```
+
+### 3-Step Recursive Halving for portion[0] -> R0
+
+```
+STEP 1: Dim 0 exchange (pairs: 0<->1, 2<->3, 4<->5, 6<->7)
+================================================================================
+
+    R0          R1          R2          R3          R4          R5          R6          R7
+   [0_0]       [0_1]       [0_2]       [0_3]       [0_4]       [0_5]       [0_6]       [0_7]
+     |           |           |           |           |           |           |           |
+     +-----+-----+           +-----+-----+           +-----+-----+           +-----+-----+
+           |                       |                       |                       |
+           v                       v                       v                       v
+       [S0_{0,1}]             [S0_{2,3}]             [S0_{4,5}]             [S0_{6,7}]
+        at R0                  at R2                  at R4                  at R6
+
+
+STEP 2: Dim 1 exchange (pairs: 0<->2, 1<->3, 4<->6, 5<->7)
+================================================================================
+
+        R0                      R2                      R4                      R6
+    [S0_{0,1}]             [S0_{2,3}]             [S0_{4,5}]             [S0_{6,7}]
+         |                       |                       |                       |
+         +-----------+-----------+                       +-----------+-----------+
+                     |                                               |
+                     v                                               v
+              [S0_{0,1,2,3}]                                  [S0_{4,5,6,7}]
+                 at R0                                           at R4
+
+
+STEP 3: Dim 2 exchange (pairs: 0<->4, 1<->5, 2<->6, 3<->7)
+================================================================================
+
+                R0                                              R4
+           [S0_{0,1,2,3}]                                 [S0_{4,5,6,7}]
+                 |                                               |
+                 +-----------------------+-----------------------+
+                                         |
+                                         v
+                                  [S0_{all 8 ranks}]
+                                      at R0
+                                         |
+                                    /8 (AVG)
+                                         |
+                                         v
+                                   R0.OUTPUT = AVG
+```
+
+### All 8 Portions in Parallel (same 3 steps)
+
+```
+STEP 1 (Dim 0): Each dim0 pair reduces
+--------------------------------------------------------------------------------
+    portion[0]: R0,R1 -> R0          portion[1]: R0,R1 -> R1
+    portion[2]: R2,R3 -> R2          portion[3]: R2,R3 -> R3
+    portion[4]: R4,R5 -> R4          portion[5]: R4,R5 -> R5
+    portion[6]: R6,R7 -> R6          portion[7]: R6,R7 -> R7
+
+STEP 2 (Dim 1): Each dim1 pair reduces
+--------------------------------------------------------------------------------
+    portion[0]: R0,R2 -> R0          portion[1]: R1,R3 -> R1
+    portion[2]: R0,R2 -> R2          portion[3]: R1,R3 -> R3
+    portion[4]: R4,R6 -> R4          portion[5]: R5,R7 -> R5
+    portion[6]: R4,R6 -> R6          portion[7]: R5,R7 -> R7
+
+STEP 3 (Dim 2): Each dim2 pair reduces, FINAL destination reached
+--------------------------------------------------------------------------------
+    portion[0]: R0,R4 -> R0          portion[1]: R1,R5 -> R1
+    portion[2]: R2,R6 -> R2          portion[3]: R3,R7 -> R3
+    portion[4]: R0,R4 -> R4          portion[5]: R1,R5 -> R5
+    portion[6]: R2,R6 -> R6          portion[7]: R3,R7 -> R7
+
+    All portions complete in 3 steps! Apply /8 for AVG.
+```
+
+
+## Buffer Operations in Device Code (prims_simple.h)
+
+```cpp
+// Sources setup:
+if (recv) {
+    srcs[0] = peer->buff + recvOffset;     // Received data from peer, stored in tmp buffer
+}
+if (send && sendDim >= 0) {
+    dsts[0] = peer->buff + sendOffset;     // Send tmp buffer
+    srcs[1] = userInput + inpIx;           // Local contribution
+}
+if (sendDim < 0) {  // Local write (phase 4 or intermediate)
+    dsts[0] = userOutput + outIx;          // Output buffer
+    srcs[1] = userInput + inpIx;           // Local contribution
+}
+
+// Reduce: srcs[0] (received) + srcs[1] (local) -> dsts[0]
+reduceCopy(..., nSrcs, srcs, 1, dsts, ...);
+```

--- a/comms/ncclx/v2_28/meta/collectives/docs/ReduceScatterPatAvg.md
+++ b/comms/ncclx/v2_28/meta/collectives/docs/ReduceScatterPatAvg.md
@@ -1,0 +1,54 @@
+# PAT AVG Design
+
+For PAT algorithm details (phases, data flow, buffer addressing), see [ReduceScatterPat.md](ReduceScatterPat.md).
+
+## Why a Separate Device Op Instead of Extending FuncSumPostDiv?
+
+FuncSumPostDiv uses `__umulhi` integer reciprocal multiplication for its `divide()` function, which has no floating-point equivalent — supporting floats would require a complete rewrite, not an extension. Additionally, extending FuncSumPostDiv to float types would generate ~200 additional kernel instantiations across all collectives, algorithms, and protocols. FuncPatSumPostDiv is restricted to ReduceScatter+PAT only (~18 kernels), keeping binary size minimal.
+
+## SumPostDiv vs. PreMulSum
+
+- **SumPostDiv (FuncPatSumPostDiv)**: Sum all contributions first, divide by N once on final write. Single rounding step gives better precision. Requires sufficient exponent range to avoid overflow during intermediate accumulation.
+- **PreMulSum**: Multiply each contribution by 1/N before summing. Lower overflow risk since values are pre-scaled. Introduces rounding error at every rank's contribution.
+
+Current PAT AVG implementation:
+- FuncPatSumPostDiv: supports bf16, f32, f64, and integer types (signed and unsigned)
+- TODO: FuncPatPreMulSum for fp16 and fp8 types that lack exponent range for safe intermediate accumulation
+- Unsupported types (fp16, fp8) currently fall back to standard non-PAT algorithm selection
+
+## Two-Phase Reduction
+
+Apply_Reduce dispatches to FuncSum for pure addition. Apply_PostOp applies division by nRanks. The reduction accumulates an exact sum across all ranks, and the single final division preserves maximum precision.
+
+## Host-Side Dispatch
+
+When `comm->usePatAvg_` is true and op is ncclAvg, `setupPatAvgInfoExt()` configures ncclInfoExt to force PAT algorithm with ncclDevPatSumPostDiv. The scalarArg encodes the divisor (nRanks) and a signed-type flag using the same `(divisor << 1 | isSigned)` encoding as FuncSumPostDiv.
+
+## Kernel-Side Division at Final Write Step
+
+The `isFinalWrite` flag in `ncclPatStep` controls when postOp (division) is applied. Only Phase 4 sets `isFinalWrite=true`, ensuring division happens exactly once per output element after all contributions have been accumulated.
+
+| Write Type | Phase | sendDim | isFinalWrite | PostOp Applied |
+|------------|-------|---------|--------------|----------------|
+| Send to peer | 0-3 | >= 0 | false | No |
+| Intermediate local write | 1 | -1 | false | No (partial sum) |
+| Final chunk write | 4 | -1 | true | Yes (divide by nRanks) |
+
+## Enabling PAT AVG
+
+### Per-Communicator Control (Recommended)
+
+Set `comm->usePatAvg_ = true` during communicator creation:
+
+```cpp
+// At comm creation time (init.cc)
+comm->usePatAvg_ = ncclx::commUsePatAvg();  // From CVAR or hint
+```
+
+Or via global hint before comm creation:
+
+```cpp
+ncclx::setGlobalHint("ncclx.comm.algo_reducescatter", "pat:avg");
+ncclComm_t comm = createNcclComm(...);  // usePatAvg_ = true
+ncclx::resetGlobalHint("ncclx.comm.algo_reducescatter");
+```

--- a/comms/ncclx/v2_28/meta/device/FuncPatSumPostDiv.cuh
+++ b/comms/ncclx/v2_28/meta/device/FuncPatSumPostDiv.cuh
@@ -1,0 +1,97 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <type_traits>
+
+////////////////////////////////////////////////////////////////////////////////
+// FuncPatSumPostDiv - Native AVG support for PAT algorithm
+// Unlike FuncSumPostDiv which only supports unsigned integers,
+// FuncPatSumPostDiv supports float, double, bfloat16, and integer types
+// (both signed and unsigned). Reduction is pure sum, division is applied as
+// postOp on final write. The opArg encodes (divisor << 1) | isSigned.
+
+template <typename T>
+struct RedOpArg<FuncPatSumPostDiv<T>> {
+  static constexpr bool ArgUsed = true;
+  __device__ __forceinline__ static uint64_t loadArg(void* ptr) {
+    return *(uint64_t*)ptr;
+  }
+};
+
+// General FuncPatSumPostDiv definition for all types.
+// opArg encoding: (divisor << 1) | isSigned, matching FuncSumPostDiv
+// convention.
+template <typename T>
+struct FuncPatSumPostDiv {
+  using EltType = T;
+  uint32_t divisor;
+  uint32_t isSigned;
+
+  __device__ __forceinline__ FuncPatSumPostDiv(uint64_t opArg = 0) {
+    isSigned = opArg & 1;
+    divisor = opArg >> 1;
+  }
+
+  // Division helper - uses signed division when the original dtype is signed
+  __device__ __forceinline__ T divide(T x) const {
+    if constexpr (std::is_integral_v<T>) {
+      if (isSigned) {
+        // Use at least 32-bit signed type to avoid overflow for small T (e.g.,
+        // uint8_t with nRanks > 127)
+        using WideSignedT = typename std::conditional<
+            sizeof(T) < 4,
+            int32_t,
+            typename std::make_signed<T>::type>::type;
+        return T(WideSignedT(x) / WideSignedT(divisor));
+      }
+    }
+    return x / T(divisor);
+  }
+};
+
+#if defined(__CUDA_BF16_TYPES_EXIST__)
+// Specialization for bfloat16.
+// opArg encoding: (divisor << 1) | isSigned, same as generic template.
+// divide() uses float-precision arithmetic, so sign handling is not needed.
+template <>
+struct FuncPatSumPostDiv<__nv_bfloat16> {
+  using EltType = __nv_bfloat16;
+  uint32_t divisor;
+  uint32_t isSigned;
+
+  __device__ __forceinline__ FuncPatSumPostDiv(uint64_t opArg = 0) {
+    isSigned = opArg & 1;
+    divisor = opArg >> 1;
+  }
+
+  __device__ __forceinline__ __nv_bfloat16 divide(__nv_bfloat16 x) const {
+    return __float2bfloat16(__bfloat162float(x) / static_cast<float>(divisor));
+  }
+};
+#endif
+
+// Apply_Reduce for FuncPatSumPostDiv - dispatches to FuncSum (reduction is pure
+// sum)
+template <typename T, int EltPerPack>
+struct Apply_Reduce<FuncPatSumPostDiv<T>, EltPerPack>
+    : Apply_Reduce<FuncSum<T>, EltPerPack> {
+  __device__ __forceinline__ static BytePack<EltPerPack * sizeof(T)> reduce(
+      FuncPatSumPostDiv<T> fn,
+      BytePack<EltPerPack * sizeof(T)> a,
+      BytePack<EltPerPack * sizeof(T)> b) {
+    // FuncPatSumPostDiv reduce dispatches to FuncSum - division only at postOp
+    return Apply_Reduce<FuncSum<T>, EltPerPack>::reduce(FuncSum<T>(), a, b);
+  }
+};
+
+// Apply_PostOp for FuncPatSumPostDiv - applies division
+template <typename T>
+struct Apply_PostOp<FuncPatSumPostDiv<T>, /*EltPerPack=*/1> {
+  static constexpr bool IsIdentity = false;
+  __device__ __forceinline__ static BytePack<sizeof(T)> postOp(
+      FuncPatSumPostDiv<T> fn,
+      BytePack<sizeof(T)> a) {
+    return toPack<T>(fn.divide(fromPack<T>(a)));
+  }
+};

--- a/comms/ncclx/v2_28/meta/tests/ReduceScatterPatSelectTest.cc
+++ b/comms/ncclx/v2_28/meta/tests/ReduceScatterPatSelectTest.cc
@@ -1,0 +1,445 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <comm.h>
+#include <cuda_fp16.h>
+#include <fmt/core.h>
+#include <folly/init/Init.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <nccl.h>
+#include <stdlib.h>
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "VerifyAlgoStatsUtil.h"
+#include "comms/testinfra/TestUtils.h"
+#include "comms/testinfra/TestsDistUtils.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+#include "meta/wrapper/DataTypeStrUtils.h"
+
+/**
+ * Test suite for ReduceScatter PAT algorithm selection logic.
+ *
+ * Tests cover:
+ * 1. PAT algorithm selection with different PAT_AVG settings and ncclOps
+ * 2. User-defined PreMulSum operations are correctly blocked from PAT
+ * 3. Built-in ncclAvg correctly uses PAT when PAT_AVG is enabled
+ */
+
+class ReduceScatterPatSelectTest : public NcclxBaseTest {
+ public:
+  ReduceScatterPatSelectTest() = default;
+
+  void SetUp() override {
+    NcclxBaseTest::SetUp();
+    // [META:PAT] Enable PAT algorithm for all tests in this suite.
+    // This must be set BEFORE any communicator is created because
+    // ncclParamPatEnable() uses a static cache that is only populated once.
+    // Setting it here ensures the cache is populated with the correct value
+    // regardless of test execution order.
+    patEnableGuard_ =
+        std::make_unique<EnvRAII<int64_t>>(NCCL_PAT_ENABLE, (int64_t)1);
+    // Enable AlgoStats for algorithm validation (must be before comm creation)
+    algoStats_.enable();
+    CUDACHECK_TEST(cudaStreamCreate(&stream));
+  }
+
+  void TearDown() override {
+    CUDACHECK_TEST(cudaStreamDestroy(stream));
+    patEnableGuard_.reset();
+    NcclxBaseTest::TearDown();
+  }
+
+ protected:
+  // Common run() helper that encapsulates the typical ReduceScatter
+  // test flow: create comm -> set usePatAvg_ -> alloc buffers ->
+  // init send buffer -> run ncclReduceScatter -> sync -> check result
+  // -> verify algo -> free buffers.
+  //
+  // Template parameter T: C++ data type (float, __half, int32_t, etc.)
+  //
+  // sendValFn(numRanks, globalRank, chunkIdx) returns the value to
+  // fill into each chunk of the send buffer.
+  // expectedValFn(numRanks, globalRank) returns the expected result;
+  // pass nullptr to skip result checking.
+  template <typename T>
+  void run(
+      ncclDataType_t dtype,
+      ncclRedOp_t op,
+      bool usePatAvg,
+      const std::function<
+          T(int /*numRanks*/, int /*globalRank*/, int /*chunkIdx*/)>& sendValFn,
+      const std::function<T(int /*numRanks*/, int /*globalRank*/)>&
+          expectedValFn,
+      std::optional<std::string> expectedAlgo = std::nullopt,
+      std::optional<std::string> unexpectedAlgo = std::nullopt,
+      std::optional<double> tolerance = std::nullopt) {
+    NcclCommRAII commGuard{globalRank, numRanks, localRank};
+    ncclComm_t comm = commGuard.get();
+    comm->usePatAvg_ = usePatAvg;
+
+    const size_t count = 8000;
+    const size_t allocSize = count * numRanks * sizeof(T);
+
+    T* sendBuf = nullptr;
+    T* recvBuf = nullptr;
+    NCCLCHECK_TEST(ncclMemAlloc((void**)&sendBuf, allocSize));
+    NCCLCHECK_TEST(ncclMemAlloc((void**)&recvBuf, allocSize));
+
+    for (int r = 0; r < numRanks; r++) {
+      assignChunkValue(
+          sendBuf + r * count, count, sendValFn(numRanks, globalRank, r));
+    }
+
+    auto res =
+        ncclReduceScatter(sendBuf, recvBuf, count, dtype, op, comm, stream);
+    ASSERT_EQ(res, ncclSuccess);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    if (expectedValFn) {
+      T expected = expectedValFn(numRanks, globalRank);
+      T zero{0};
+      size_t errs = checkChunkValue(
+          recvBuf, count, expected, zero, globalRank, stream, tolerance);
+      EXPECT_EQ(errs, 0) << "Rank " << globalRank
+                         << " got wrong result (expected="
+                         << static_cast<double>(expected) << ")";
+    }
+
+    if (expectedAlgo.has_value()) {
+      algoStats_.verify(comm, "ReduceScatter", expectedAlgo.value());
+    }
+    if (unexpectedAlgo.has_value()) {
+      algoStats_.verifyNot(comm, "ReduceScatter", unexpectedAlgo.value());
+    }
+
+    NCCLCHECK_TEST(ncclMemFree(sendBuf));
+    NCCLCHECK_TEST(ncclMemFree(recvBuf));
+  }
+
+  cudaStream_t stream{nullptr};
+  ncclx::test::VerifyAlgoStatsHelper algoStats_;
+  std::unique_ptr<EnvRAII<int64_t>> patEnableGuard_;
+};
+
+/**
+ * Test: User-defined PreMulSum should NOT be converted to PatAvg
+ *
+ * Verifies that setting usePatAvg_ = true only affects ncclAvg operations,
+ * not user-defined PreMulSum ops. The ext is only set when op == ncclAvg,
+ * so user ops continue through normal algorithm selection.
+ */
+TEST_F(ReduceScatterPatSelectTest, UserPreMulSumNotConvertedToPatAvg) {
+  NcclCommRAII commGuard{globalRank, numRanks, localRank};
+  ncclComm_t comm = commGuard.get();
+  comm->usePatAvg_ = true;
+
+  // Create user-defined PreMulSum with scalar = 0.25
+  // This is different from ncclAvg which uses 1/nRanks (0.5 for 2 ranks)
+  ncclRedOp_t userOp;
+  float scalar = 0.25f;
+  NCCLCHECK_TEST(ncclRedOpCreatePreMulSum(
+      &userOp, &scalar, ncclFloat, ncclScalarHostImmediate, comm));
+
+  const size_t count = 8000;
+  const size_t allocSize = count * numRanks * sizeof(float);
+
+  float* sendBuf = nullptr;
+  float* recvBuf = nullptr;
+  NCCLCHECK_TEST(ncclMemAlloc((void**)&sendBuf, allocSize));
+  NCCLCHECK_TEST(ncclMemAlloc((void**)&recvBuf, allocSize));
+
+  // Initialize: each rank sends 1.0 in all chunks
+  for (int r = 0; r < numRanks; r++) {
+    assignChunkValue(sendBuf + r * count, count, 1.0f);
+  }
+
+  // Run ReduceScatter with user PreMulSum op
+  // Should succeed and use normal algorithm (not PAT AVG)
+  auto res = ncclReduceScatter(
+      sendBuf, recvBuf, count, ncclFloat, userOp, comm, stream);
+  ASSERT_EQ(res, ncclSuccess);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  // Expected result with scalar = 0.25:
+  // Each element: sum of contributions from all ranks * 0.25
+  // = numRanks * 1.0 * 0.25 = 0.5 (for 2 ranks)
+  float expectedVal = static_cast<float>(numRanks) * 0.25f;
+
+  size_t errs = checkChunkValue(
+      recvBuf, count, expectedVal, 0.0f, globalRank, stream, 1e-3);
+  EXPECT_EQ(errs, 0) << "Rank " << globalRank
+                     << " user PreMulSum got wrong result"
+                     << " (expected=" << expectedVal << ")";
+
+  NCCLCHECK_TEST(ncclRedOpDestroy(userOp, comm));
+  NCCLCHECK_TEST(ncclMemFree(sendBuf));
+  NCCLCHECK_TEST(ncclMemFree(recvBuf));
+}
+
+/**
+ * Test: Built-in ncclAvg with PAT_AVG should work correctly (regression test)
+ *
+ * Verifies that built-in ncclAvg uses PAT algorithm with PAT_AVG enabled
+ * and produces correct results (sum / nRanks).
+ */
+TEST_F(ReduceScatterPatSelectTest, BuiltInAvgWithPatAvgWorks) {
+  constexpr bool kUsePatAvg = true;
+  const std::string kExpectAlgo = "PAT";
+  run<float>(
+      ncclFloat,
+      ncclAvg,
+      kUsePatAvg,
+      [](int nRanks, int rank, int chunk) -> float {
+        return static_cast<float>(rank * nRanks + chunk);
+      },
+      [](int nRanks, int rank) -> float {
+        float sum = 0.0f;
+        for (int r = 0; r < nRanks; r++) {
+          sum += static_cast<float>(r * nRanks + rank);
+        }
+        return sum / static_cast<float>(nRanks);
+      },
+      kExpectAlgo,
+      std::nullopt,
+      1e-3);
+}
+
+/**
+ * Parameterized test for PAT algorithm selection with different settings.
+ *
+ * Tests PAT algorithm selection with:
+ * - Different PAT_AVG_ENABLE settings (true/false)
+ * - Different ncclRedOp_t operations (ncclSum, ncclAvg)
+ * - Validates the expected algorithm was used via AlgoStats
+ */
+class ReduceScatterPatAlgoSelectionTest
+    : public ReduceScatterPatSelectTest,
+      public ::testing::WithParamInterface<
+          std::tuple<bool, ncclRedOp_t, std::string>> {};
+
+TEST_P(ReduceScatterPatAlgoSelectionTest, AlgoSelection) {
+  auto [patAvgEnable, op, expectedAlgoSubstr] = GetParam();
+
+  // Enforce PAT algorithm selection via env vars for SUM (both NCCL_ALGO,
+  // NCCL_PROTO and NCCL_PAT_ENABLE must be set, NCCL_PAT_ENABLE=1 is set in
+  // base fixture SetUp()). AVG require usePatAvg_ = true
+  auto algoGuard = EnvRAII<std::string>(NCCL_ALGO, "reducescatter:pat");
+  auto protoGuard = EnvRAII<std::string>(NCCL_PROTO, "Simple");
+
+  run<float>(
+      ncclFloat,
+      op,
+      patAvgEnable,
+      [](int /*nRanks*/, int /*rank*/, int /*chunk*/) -> float { return 1.0f; },
+      nullptr, // no result check, only algo verification
+      expectedAlgoSubstr);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ReduceScatterPatAlgoSelectionTestInstance,
+    ReduceScatterPatAlgoSelectionTest,
+    ::testing::Values(
+        // PAT_AVG_ENABLE=true: ALL operations use PAT (including Avg)
+        std::make_tuple(true, ncclSum, "PAT"),
+        std::make_tuple(true, ncclAvg, "PAT"),
+        // PAT_AVG_ENABLE=false: Sum uses PAT, Avg would fail (not tested here)
+        std::make_tuple(false, ncclSum, "PAT")),
+    [](const testing::TestParamInfo<std::tuple<bool, ncclRedOp_t, std::string>>&
+           info) {
+      auto patAvgEnable = std::get<0>(info.param);
+      auto op = std::get<1>(info.param);
+      const auto& expectedAlgo = std::get<2>(info.param);
+      return fmt::format(
+          "PAT_AVG_{}_{}_{}",
+          patAvgEnable ? "on" : "off",
+          getRedOpStr(op),
+          expectedAlgo);
+    });
+
+/**
+ * Test: Grouped ReduceScatter with PAT AVG - expected to fail
+ *
+ * Tests that grouped collectives with ncclInfoExt override are correctly
+ * rejected with ncclInvalidUsage. Grouped collectives with per-comm
+ * algorithm override (PAT AVG) are not currently supported.
+ *
+ * This is a negative test - it validates that the proper error is returned.
+ */
+TEST_F(ReduceScatterPatSelectTest, GroupedReduceScatterPatAvg) {
+  NcclCommRAII commGuard{globalRank, numRanks, localRank};
+  ncclComm_t comm = commGuard.get();
+  // Enable PAT AVG via per-communicator control
+  comm->usePatAvg_ = true;
+
+  constexpr int kNumOpsInGroup = 3;
+  const size_t count = 8000;
+  const size_t allocSize = count * numRanks * sizeof(float);
+
+  std::vector<float*> sendBufs(kNumOpsInGroup, nullptr);
+  std::vector<float*> recvBufs(kNumOpsInGroup, nullptr);
+
+  for (int i = 0; i < kNumOpsInGroup; i++) {
+    NCCLCHECK_TEST(ncclMemAlloc((void**)&sendBufs[i], allocSize));
+    NCCLCHECK_TEST(ncclMemAlloc((void**)&recvBufs[i], allocSize));
+  }
+
+  // Initialize with different values per operation
+  for (int i = 0; i < kNumOpsInGroup; i++) {
+    for (int r = 0; r < numRanks; r++) {
+      float val = static_cast<float>(globalRank * numRanks + r + i * 100);
+      assignChunkValue(sendBufs[i] + r * count, count, val);
+    }
+  }
+
+  // Run grouped ReduceScatter - all with ncclAvg
+  // Individual enqueue calls succeed, but ncclGroupEnd will fail
+  NCCLCHECK_TEST(ncclGroupStart());
+  for (int i = 0; i < kNumOpsInGroup; i++) {
+    auto res = ncclReduceScatter(
+        sendBufs[i], recvBufs[i], count, ncclFloat, ncclAvg, comm, stream);
+    ASSERT_EQ(res, ncclSuccess);
+  }
+  // Grouped collectives with ncclInfoExt override are not supported
+  // ncclGroupEnd should return ncclInvalidUsage
+  auto groupEndRes = ncclGroupEnd();
+  EXPECT_EQ(groupEndRes, ncclInvalidUsage)
+      << "Grouped collectives with PAT AVG ext override should fail with "
+         "ncclInvalidUsage";
+
+  for (int i = 0; i < kNumOpsInGroup; i++) {
+    NCCLCHECK_TEST(ncclMemFree(sendBufs[i]));
+    NCCLCHECK_TEST(ncclMemFree(recvBufs[i]));
+  }
+}
+
+/**
+ * Test: Direct usePatAvg_ control enables PAT AVG for ReduceScatter
+ *
+ * Verifies that setting comm->usePatAvg_ = true directly enables PAT AVG
+ * for ReduceScatter with ncclAvg, bypassing the need for CVARs.
+ * This is the per-communicator control mechanism.
+ */
+TEST_F(ReduceScatterPatSelectTest, UsePatAvgDirectControl) {
+  // Verify default is disabled before run() creates a comm with it enabled
+  {
+    NcclCommRAII probe{globalRank, numRanks, localRank};
+    ASSERT_FALSE(probe.get()->usePatAvg_);
+  }
+  constexpr bool kUsePatAvg = true;
+  const std::string kExpectAlgo = "PAT";
+  run<float>(
+      ncclFloat,
+      ncclAvg,
+      kUsePatAvg,
+      [](int numRanks, int globalRank, int chunkIdx) -> float {
+        return static_cast<float>(globalRank * numRanks + chunkIdx);
+      },
+      [](int numRanks, int globalRank) -> float {
+        float sum = 0.0f;
+        for (int r = 0; r < numRanks; r++) {
+          sum += static_cast<float>(r * numRanks + globalRank);
+        }
+        return sum / static_cast<float>(numRanks);
+      },
+      kExpectAlgo,
+      std::nullopt,
+      1e-3);
+}
+
+/**
+ * Test: usePatAvg_ only affects ReduceScatter with ncclAvg
+ */
+TEST_F(ReduceScatterPatSelectTest, UsePatAvgOnlyAffectsReduceScatterAvg) {
+  constexpr bool kUsePatAvg = true;
+  run<float>(
+      ncclFloat,
+      ncclSum,
+      kUsePatAvg,
+      [](int /*nRanks*/, int /*rank*/, int /*chunk*/) -> float { return 1.0f; },
+      [](int nRanks, int /*rank*/) -> float {
+        return static_cast<float>(nRanks);
+      },
+      std::nullopt,
+      std::nullopt,
+      1e-3);
+}
+
+/**
+ * Test: Unsupported dtype (fp16) falls back from PAT to normal algorithm
+ *
+ * When usePatAvg_ is true but dtype is fp16, isPatAvgSupportedType() returns
+ * false, so the PAT AVG override is not applied and normal algorithm selection
+ * is used instead. Verifies:
+ * 1. The operation succeeds (no crash)
+ * 2. The result is correct (standard ncclAvg via PreMulSum path)
+ * 3. The algorithm used is NOT PAT
+ */
+TEST_F(ReduceScatterPatSelectTest, UnsupportedDtypeFallsBackFromPat) {
+  using Traits = DataTypeTraits<__half>;
+  constexpr bool kUsePatAvg = true;
+  const std::string kUnexpectAlgo = "PAT";
+  run<__half>(
+      ncclFloat16,
+      ncclAvg,
+      kUsePatAvg,
+      [](int nRanks, int rank, int chunk) -> __half {
+        using T = DataTypeTraits<__half>;
+        float val = static_cast<float>(rank * nRanks + chunk);
+        return T::toDevice(val);
+      },
+      [](int nRanks, int rank) -> __half {
+        using T = DataTypeTraits<__half>;
+        float sum = 0.0f;
+        for (int r = 0; r < nRanks; r++) {
+          sum += static_cast<float>(r * nRanks + rank);
+        }
+        return T::toDevice(sum / static_cast<float>(nRanks));
+      },
+      std::nullopt,
+      kUnexpectAlgo,
+      Traits::tolerance());
+}
+
+/**
+ * Test: Signed integer (ncclInt32) average with PAT AVG works correctly
+ *
+ * Verifies that FuncPatSumPostDiv correctly handles signed integer division
+ * via the isSigned flag. Each rank sends negative values, and the post-division
+ * must reinterpret the accumulated unsigned sum as signed before dividing.
+ *
+ * For N ranks: each rank r sends -(r+1) in every element.
+ * Expected average = sum(-(r+1) for r in 0..N-1) / N
+ *   e.g. 2 ranks: (-1 + -2) / 2 = -3/2 = -1 (truncation toward zero)
+ *   e.g. 8 ranks: (-1 + -2 + ... + -8) / 8 = -36/8 = -4 (exact)
+ */
+TEST_F(ReduceScatterPatSelectTest, SignedIntAvgWithPatSumPostDiv) {
+  constexpr bool kUsePatAvg = true;
+  const std::string kExpectAlgo = "PAT";
+  run<int32_t>(
+      ncclInt32,
+      ncclAvg,
+      kUsePatAvg,
+      [](int /*nRanks*/, int rank, int /*chunk*/) -> int32_t {
+        return -(static_cast<int32_t>(rank) + 1);
+      },
+      [](int nRanks, int /*rank*/) -> int32_t {
+        int32_t sum = 0;
+        for (int r = 0; r < nRanks; r++) {
+          sum += -(static_cast<int32_t>(r) + 1);
+        }
+        return sum / static_cast<int32_t>(nRanks);
+      },
+      kExpectAlgo);
+}
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ncclx/v2_28/meta/tests/VerifyAlgoStatsUtil.h
+++ b/comms/ncclx/v2_28/meta/tests/VerifyAlgoStatsUtil.h
@@ -51,6 +51,16 @@ class VerifyAlgoStatsHelper {
       const std::string& collective,
       const std::string& expectedAlgoSubstr) const;
 
+  // Verify that the given algorithm was NOT used via AlgoStats.
+  // @param comm The NCCL communicator to query stats from
+  // @param collective The collective name (e.g., "ReduceScatter", "AllReduce")
+  // @param unexpectedAlgoSubstr Substring that must NOT appear in any algorithm
+  // name with nonzero call count
+  void verifyNot(
+      ncclComm_t comm,
+      const std::string& collective,
+      const std::string& unexpectedAlgoSubstr) const;
+
  private:
   std::optional<EnvRAII<std::vector<std::string>>> colltraceGuard_;
 };

--- a/comms/ncclx/v2_28/src/device/prims_simple.h
+++ b/comms/ncclx/v2_28/src/device/prims_simple.h
@@ -1017,8 +1017,13 @@ private:
 
     int workSize = ncclShmem.aborted ? 0 : nelem;
 
+    // [META:PAT_AVG] Apply postOp (division for AVG) on final write to local output
+    // isFinalWrite is set only in Phase 4, which is the final write for each chunk
+    // For non-PatSumPostDiv ops, Apply_PostOp is identity so this is safe
+    const int applyPostOp = ps->isFinalWrite ? 1 : 0;
+
     reduceCopy<Unroll, RedOp, T, 0, 1, 2, 0, 1, 1, /*PreOpSrcs*/0>
-      (tid, nthreads, ncclShmem.redOpArgs[0],  nullptr, /*postOp=*/false,
+      (tid, nthreads, ncclShmem.redOpArgs[0],  nullptr, /*postOp=*/applyPostOp,
        nSrcs, srcs, 1, ncclShmem.groups[group].dsts, workSize);
 
     // Store conn step here inside the two barriers to make sure next reload will see the update.

--- a/comms/ncclx/v2_28/src/device/reduce_kernel.h
+++ b/comms/ncclx/v2_28/src/device/reduce_kernel.h
@@ -57,6 +57,7 @@ struct FuncMinMax {
 
 template<typename T> struct FuncPreMulSum;
 template<typename T> struct FuncSumPostDiv;
+template<typename T> struct FuncPatSumPostDiv;  // [META:PAT_AVG] Defined in meta/device/FuncPatSumPostDiv.cuh
 
 ////////////////////////////////////////////////////////////////////////////////
 // Trait class for handling the reduction argument.
@@ -819,6 +820,12 @@ struct Apply_PostOp<FuncSumPostDiv<T>, /*EltPerPack=*/1> {
     return toPack<T>(fn.divide(fromPack<T>(a)));
   }
 };
+
+////////////////////////////////////////////////////////////////////////////////
+// [META:PAT_AVG] FuncPatSumPostDiv - Native AVG support for PAT algorithm
+// Type definition and trait specializations (RedOpArg, Apply_Reduce,
+// Apply_PostOp) are in the included file.
+#include "meta/device/FuncPatSumPostDiv.cuh"
 
 ////////////////////////////////////////////////////////////////////////////////
 // Apply_LoadMultimem

--- a/comms/ncclx/v2_28/src/include/collectives.h
+++ b/comms/ncclx/v2_28/src/include/collectives.h
@@ -401,6 +401,7 @@ static constexpr int PatUsed = 0x1,
 
 struct ncclPatStep {
   int recvDim, sendDim, recvOffset, sendOffset, stepOffset, postRecv, postSend, nelem, last, flags;
+  bool isFinalWrite;  // [META:PAT_AVG] True if final write for a chunk (apply division for AVG)
   size_t inpIx, outIx;
 };
 
@@ -539,6 +540,7 @@ public:
     ps->nelem = nelem;
     ps->outIx = offset;
     ps->stepOffset = stepOffset;
+    ps->isFinalWrite = false;  // [META:PAT_AVG] for label last step
     int skip = 0;
     if (a >= lastA) {
       skip = 1;
@@ -638,6 +640,7 @@ public:
     } else if (phase == 4) {
       ps->recvDim = 0;
       ps->sendDim = -1;
+      ps->isFinalWrite = true;  // [META:PAT_AVG] last step, apply division for PAT AVG in patReduce
       ps->inpIx = rank * count + offset;
       ps->recvOffset = ((aggFactor-1)%postFreq) * nelem;
       ps->sendOffset = -1;

--- a/comms/ncclx/v2_28/src/include/comm.h
+++ b/comms/ncclx/v2_28/src/include/comm.h
@@ -740,6 +740,10 @@ struct ncclComm {
   bool useCtran_{false}; // Ctran per-communicator control; set at init entry functions
   std::unique_ptr<CtranComm> ctranComm_;
 
+  // [META:PAT_AVG] per-communicator control; set at init entry functions
+  // When enabled, forces PAT algorithm with ncclDevPatSumPostDiv for ReduceScatter with ncclAvg
+  bool usePatAvg_{false};
+
   uint64_t endMagic;
 };
 

--- a/comms/ncclx/v2_28/src/include/device.h
+++ b/comms/ncclx/v2_28/src/include/device.h
@@ -58,6 +58,7 @@ extern const char* ncclProtoStr[NCCL_NUM_PROTOCOLS];
 enum ncclDevRedOp_t {
   ncclDevSum, ncclDevProd, ncclDevMinMax,
   ncclDevPreMulSum, ncclDevSumPostDiv,
+  ncclDevPatSumPostDiv,  // [META:PAT_AVG] Native AVG for PAT ReduceScatter
   ncclNumDevRedOps
 };
 struct ncclDevRedOpFull {


### PR DESCRIPTION
Summary:
This implements PAT (Pairwise Algorithm Tree) AVG support for ReduceScatter,
enabling ncclAvg operations to use the PAT algorithm through a per-comm flag.

Key changes:

**Device Code (FuncPatAvg)**:
- New ncclDevPatAvg reduction operator that performs sum during reduction
  and division by nRanks on final write to output buffer
- Apply_Reduce<FuncPatAvg> dispatches to FuncSum for pure addition
- Apply_PostOp<FuncPatAvg> applies division by the divisor (nRanks)
- Device kernel generation updated to produce PatAvg kernels for ReduceScatter+PAT

**Algorithm Selection (ncclInfoExt)**:
- PatAvgHelper.h provides setupPatAvgInfoExt() to configure PAT/SIMPLE/PatAvg
  with nRanks as divisor for ReduceScatter ncclAvg operations
- collectives.cc calls setupPatAvgInfoExt() when comm->usePatAvg_ && op == ncclAvg that internally computes nChannels/nWarps same as original logic (copy out to avoid inclusive change in baseline)
- Leverage ncclInfoExt to override algo/proto/nChannels/nWarps
- Added usePatAvg_ flag to ncclComm for per-communicator control

**Tests**:
- ReduceScatterPatSelectTest validates PAT algorithm selection with different
  PAT_AVG settings and ncclOps
- Tests verify: PAT+Sum, PAT+Avg, user PreMulSum not converted, grouped rejection

Differential Revision: D92587062


