### PR TITLE
Fix ibv_qp_init_attr_ex ABI mismatch with rdma-core

### DIFF
--- a/comms/ctran/ibverbx/Ibvcore.h
+++ b/comms/ctran/ibverbx/Ibvcore.h
@@ -523,12 +523,20 @@ struct ibv_qp_init_attr {
 enum ibv_qp_init_attr_mask {
   IBV_QP_INIT_ATTR_PD = 1 << 0,
   IBV_QP_INIT_ATTR_XRCD = 1 << 1,
-  IBV_QP_INIT_ATTR_RESERVED = 1 << 2,
-  IBV_QP_INIT_ATTR_CREATE_FLAGS = 1 << 3,
-  IBV_QP_INIT_ATTR_MAX_TSO_HEADER = 1 << 4,
-  IBV_QP_INIT_ATTR_IND_TABLE = 1 << 5,
-  IBV_QP_INIT_ATTR_RX_HASH = 1 << 6,
-  IBV_QP_INIT_ATTR_SEND_OPS_FLAGS = 1 << 7,
+  IBV_QP_INIT_ATTR_CREATE_FLAGS = 1 << 2,
+  IBV_QP_INIT_ATTR_MAX_TSO_HEADER = 1 << 3,
+  IBV_QP_INIT_ATTR_IND_TABLE = 1 << 4,
+  IBV_QP_INIT_ATTR_RX_HASH = 1 << 5,
+  IBV_QP_INIT_ATTR_SEND_OPS_FLAGS = 1 << 6,
+};
+
+struct ibv_rx_hash_conf {
+  /* enum ibv_rx_hash_function_flags */
+  uint8_t rx_hash_function;
+  uint8_t rx_hash_key_len;
+  uint8_t* rx_hash_key;
+  /* enum ibv_rx_hash_fields */
+  uint64_t rx_hash_fields_mask;
 };
 
 struct ibv_qp_init_attr_ex {
@@ -546,6 +554,8 @@ struct ibv_qp_init_attr_ex {
   uint32_t create_flags;
   uint16_t max_tso_header;
   struct ibv_rwq_ind_table* rwq_ind_tbl;
+  struct ibv_rx_hash_conf rx_hash_conf;
+  uint32_t source_qpn;
   uint64_t send_ops_flags;
 };
 


### PR DESCRIPTION
Summary:
The ibverbx wrapper's ibv_qp_init_attr_mask enum had an extra
IBV_QP_INIT_ATTR_RESERVED entry at bit 2 that does not exist in the
current rdma-core ABI. This shifted all subsequent enum values up by
one bit, causing IBV_QP_INIT_ATTR_SEND_OPS_FLAGS to be 1<<7 instead
of the correct 1<<6. When createDCI set this bit in comp_mask,
rdma-core saw an unknown bit and the mlx5 driver rejected DC QP
creation with ENODEV (errno 19).

Additionally, ibv_qp_init_attr_ex was missing the rx_hash_conf and
source_qpn fields that exist in the rdma-core struct, making the
ibverbx struct 32 bytes smaller than rdma-core expects. This caused
send_ops_flags to be at the wrong offset when reinterpret_cast passed
the struct to rdma-core's mlx5dv_create_qp.

This diff fixes both issues:
1. Remove IBV_QP_INIT_ATTR_RESERVED and re-align enum values to match
   rdma-core (CREATE_FLAGS=1<<2, ..., SEND_OPS_FLAGS=1<<6)
2. Add the missing ibv_rx_hash_conf struct and rx_hash_conf/source_qpn
   fields to ibv_qp_init_attr_ex so the struct layout matches
   rdma-core byte-for-byte

Differential Revision: D92586628


