### PR TITLE
Add clang-tidy check to ban std::runtime_error in CTRAN

### DIFF
--- a/comms/ctran/.clang-tidy
+++ b/comms/ctran/.clang-tidy
@@ -1,0 +1,10 @@
+# CTRAN-specific clang-tidy configuration
+# Enables checks to ban non-approved exceptions in CTRAN code.
+# Only ctran::utils::Exception and std::bad_alloc are allowed.
+---
+InheritParentConfig: true
+Checks: 'facebook-ban-runtime-error-in-ctran,facebook-ban-non-ctran-exceptions,'
+
+WarningsAsErrors: 'facebook-ban-runtime-error-in-ctran,facebook-ban-non-ctran-exceptions,'
+
+CheckOptions: []

--- a/comms/ctran/backends/ib/tests/CtranIbBootstrapTest.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbBootstrapTest.cc
@@ -637,7 +637,7 @@ class CtranIbAbortCtrlMsgTest
 
   // Execute a test for control message operations (send or recv) with abort
   //
-  // CtranIb throws an std::runtime_error when a socket operation returns a
+  // CtranIb throws an runtime error when a socket operation returns a
   // non-zero error code and the abortCtrl_ is unset.
   void testAbortedCtrlMsg(
       std::unique_ptr<StrictMock<ctran::bootstrap::testing::MockISocket>>


### PR DESCRIPTION
Summary:
As part of T238821628, we are migrating from `std::runtime_error` to `ctran::utils::Exception` throughout CTRAN.

This diff adds a custom clang-tidy check cAST that will detect and ban new usages of `std::runtime_error` in the CTRAN library (`comms/ctran/*`). This provides compile-time enforcement of the migration policy. See T247828833 for more details.

## Phabricator Warnings

The warnings indicate that the clang-tidy binary used by Phabricator (`clang-tidy-platform010-clang-19`) doesn't recognize the checks `facebook-ban-non-ctran-exceptions` and `facebook-ban-runtime-error-in-ctran`.

IIUC, this is basically a timing/deployment problem. This diff adds new clang-tidy checks, but the clang-tidy binary that Phabricator uses hasn't been rebuilt yet to include these new checks. Until that binary is rebuilt and deployed, Phabricator will warn about unrecognized checks. So, once the diff is landed and the clang-tidy toolchain is rebuilt, Phabricator will recognize the checks.

## A Note on Existing Uses of Usages of `std::runtime_error`

All existing `std::runtime_error` references within `comms/ctran` are in `catch` clauses (receiving exceptions thrown by external libraries), not in constructor expressions or throw statements. Neither clang-tidy check will fire on them, so these files can continue to catch `std::runtime_error` from other libraries without triggering the ban.

Reviewed By: arttianezhu, minsii

Differential Revision: D88646705


