### PR TITLE
Add packaging to torchcomms wheel requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 torch
 pyyaml
+packaging


### PR DESCRIPTION
Summary:
Adds the packaging library as a declared dependency for the torchcomms wheel to ensure version parsing code has its required module at install time. This prevents build/install issues caused by the missing packaging dependency referenced in setup.py.

```
tristanr@devvm5553 ~/torchcomms (main)> MASTER_ADDR=localhost MASTER_PORT=0 RANK=0 WORLD_SIZE=1 python -c "import torch; import torch.distributed as dist; import torchcomms; comm = torchcomms.new_comm('ncclx', torch.device('cuda'), store=None, name='1234')
; t = torch.zeros(10, device=comm.get_device()); comm.all_reduce(t, torchcomms.ReduceOp.SUM, async_op=False)"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    import torch; import torch.distributed as dist; import torchcomms; comm = torchcomms.new_comm('ncclx', torch.device('cuda'), store=None, name='1234'); t = torch.zeros(10, device=comm.get_device()); comm.all_reduce(t, torchcomms.ReduceOp.SUM, async_op=False)
                                                    ^^^^^^^^^^^^^^^^^
  File "/home/tristanr/.conda/envs/torchcomms-nightly-3.13/lib/python3.13/site-packages/torchcomms/__init__.py", line 12, in <module>
    from torchcomms.functional import is_torch_compile_supported_and_enabled
  File "/home/tristanr/.conda/envs/torchcomms-nightly-3.13/lib/python3.13/site-packages/torchcomms/functional/__init__.py", line 5, in <module>
    from packaging import version
ModuleNotFoundError: No module named 'packaging'
```

Session: DEV58746194

Differential Revision: D92747877


