### PR TITLE
Fix integration tests

### DIFF
--- a/comms/torchcomms/tests/integration/py/DPTPCommTest.py
+++ b/comms/torchcomms/tests/integration/py/DPTPCommTest.py
@@ -107,7 +107,7 @@ class DPTPCommTest(unittest.TestCase):
             name="comms_test_global",
             timeout=datetime.timedelta(seconds=360),
         )
-        world_size = torch.cuda.device_count()
+        world_size = comm.get_size()
         dp_degree = 2
         tp_degree = world_size // dp_degree
         mesh = torch.arange(world_size, dtype=torch.int, device="cpu").view(

--- a/comms/torchcomms/tests/integration/py/DeviceMeshTest.py
+++ b/comms/torchcomms/tests/integration/py/DeviceMeshTest.py
@@ -68,18 +68,17 @@ class DeviceMeshTest(unittest.TestCase):
     def test_2_d_parallel(self) -> None:
         backend = os.environ["TEST_BACKEND"]
         device = torch.device(os.environ.get("TEST_DEVICE", "cuda"))
-        world_size = torch.cuda.device_count()
-        dp_degree = 2
-        tp_degree = world_size // dp_degree
-        mesh = torch.arange(world_size, dtype=torch.int, device="cpu").view(
-            dp_degree, tp_degree
-        )
-
         comm = torchcomms.new_comm(
             backend,
             device,
             name="comms_test_2_d_parallel",
             timeout=datetime.timedelta(seconds=60),
+        )
+        world_size = comm.get_size()
+        dp_degree = 2
+        tp_degree = world_size // dp_degree
+        mesh = torch.arange(world_size, dtype=torch.int, device="cpu").view(
+            dp_degree, tp_degree
         )
 
         # Get current rank to determine which groups this rank belongs to
@@ -216,19 +215,19 @@ class DeviceMeshTest(unittest.TestCase):
     def test_n_d_parallel(self) -> None:
         backend = os.environ["TEST_BACKEND"]
         device = torch.device(os.environ.get("TEST_DEVICE", "cuda"))
-        world_size = torch.cuda.device_count()
-        pp_degree = 2
-        ep_degree = 2
-        cp_degree = world_size // (pp_degree * ep_degree)
-        mesh = torch.arange(world_size, dtype=torch.int, device="cpu").view(
-            pp_degree, cp_degree, ep_degree
-        )
-
         comm = torchcomms.new_comm(
             backend,
             device,
             name="comms_test_n_d_parallel",
             timeout=datetime.timedelta(seconds=60),
+        )
+
+        world_size = comm.get_size()
+        pp_degree = 2
+        ep_degree = 2
+        cp_degree = world_size // (pp_degree * ep_degree)
+        mesh = torch.arange(world_size, dtype=torch.int, device="cpu").view(
+            pp_degree, cp_degree, ep_degree
         )
 
         # Get current rank to determine which groups this rank belongs to

--- a/comms/torchcomms/tests/integration/py/MemPoolTest.py
+++ b/comms/torchcomms/tests/integration/py/MemPoolTest.py
@@ -16,9 +16,6 @@ class MemPoolTorchCommTest(unittest.TestCase):
         self.device_ = torch.device("cuda")
         self.backend_ = os.environ["TEST_BACKEND"]
 
-        # Get allocator using global function - can be obtained once and reused
-        self.allocator_ = torchcomms.get_mem_allocator(self.backend_)
-
         self.num_comms_ = 16
         self.tensor_size_ = 1024 * 1024
         self.comms_ = []
@@ -28,6 +25,10 @@ class MemPoolTorchCommTest(unittest.TestCase):
                     self.backend_, self.device_, name=f"test_mem_pool_{x}"
                 )
             )
+        # Get allocator using global function - can be obtained once and reused
+        # This should be called after torchcomms.new_comm(), since the mempool
+        # related symbols is lazy loaded at runtime during torchcomms.new_comm()
+        self.allocator_ = torchcomms.get_mem_allocator(self.backend_)
 
     def tearDown(self) -> None:
         for comm in self.comms_:


### PR DESCRIPTION
Summary:
Fix integration tests by addressing two issues:           

1. Use `comm.get_size()` instead of `torch.cuda.device_count()` to determine world_size in DPTPCommTest and DeviceMeshTest. This ensures the world size reflects the actual communicator group size rather than the local GPU count, which may differ in multi-node or partial-GPU configurations.
2. In MemPoolTest, move the torchcomms.get_mem_allocator() call to after torchcomms.new_comm(), since mempool-related symbols are lazy-loaded at runtime during comm initialization.

Differential Revision: D92738739


