### PR TITLE
store peerIpcServerAddr in IpcRegCache

### DIFF
--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -1941,15 +1941,9 @@ class CtranMapper {
   // instance and erase after completion.
   std::deque<std::unique_ptr<ctran::regcache::IpcReqCb>> postedCbCtrlReqs_;
 
-  // Peer IPC server addresses for async socket communication, indexed by rank.
-  // Populated via bootstrap allGather during mapper initialization.
-  std::vector<sockaddr_storage> peerIpcServerAddrs_;
-
-  // AllGather IPC server addresses from all ranks via bootstrap.
+  // AllGather IPC server addresses from all ranks via bootstrap and update
+  // IpcRegCache with the gathered addresses.
   commResult_t allGatherIpcServerAddrs();
-
-  // Get peer's IPC server address by rank.
-  folly::SocketAddress getPeerIpcServerAddr(int rank) const;
 
   // Record remote ranks that each ipcRegElem has exported to.
   // - For each remote rank, the local rank will send RELEASE_MEM ctrlmsg to

--- a/comms/ctran/regcache/IpcRegCache.cc
+++ b/comms/ctran/regcache/IpcRegCache.cc
@@ -1,6 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include "comms/ctran/regcache/IpcRegCache.h"
+#include <fmt/core.h>
 #include <folly/Singleton.h>
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/utils/Debug.h"
@@ -220,6 +221,44 @@ size_t ctran::IpcRegCache::getNumRemReg(const std::string& peerId) const {
     return it->second.size();
   }
   return 0;
+}
+
+commResult_t ctran::IpcRegCache::setPeerIpcServerAddr(
+    const std::string& peerId,
+    const folly::SocketAddress& addr) {
+  auto lockedMap = peerIpcServerAddrs_.wlock();
+  auto it = lockedMap->find(peerId);
+  if (it != lockedMap->end()) {
+    if (it->second != addr) {
+      CLOGF(
+          ERR,
+          "CTRAN-REGCACHE: Peer IPC server address mismatch for peerId {}: "
+          "cached {} vs new {}",
+          peerId,
+          it->second.describe(),
+          addr.describe());
+      return commInternalError;
+    }
+    return commSuccess;
+  }
+  lockedMap->emplace(peerId, addr);
+  return commSuccess;
+}
+
+commResult_t ctran::IpcRegCache::getPeerIpcServerAddr(
+    const std::string& peerId,
+    folly::SocketAddress& addr) const {
+  auto lockedMap = peerIpcServerAddrs_.rlock();
+  auto it = lockedMap->find(peerId);
+  if (it == lockedMap->end()) {
+    CLOGF(
+        ERR,
+        "CTRAN-REGCACHE: Peer IPC server address not found for peerId {}",
+        peerId);
+    return commInvalidArgument;
+  }
+  addr = it->second;
+  return commSuccess;
 }
 
 commResult_t ctran::IpcRegCache::notifyRemoteIpcRelease(

--- a/comms/ctran/regcache/IpcRegCache.h
+++ b/comms/ctran/regcache/IpcRegCache.h
@@ -9,6 +9,7 @@
 #include <folly/Hash.h>
 #include <folly/SocketAddress.h>
 #include <folly/Synchronized.h>
+#include <folly/container/F14Map.h>
 #include <folly/io/async/ScopedEventBaseThread.h>
 
 #include "comms/ctran/bootstrap/AsyncSocket.h"
@@ -126,6 +127,18 @@ class IpcRegCache {
     return serverAddr_;
   }
 
+  // Set peer's IPC server address by peer ID (gPid).
+  commResult_t setPeerIpcServerAddr(
+      const std::string& peerId,
+      const folly::SocketAddress& addr);
+
+  // Get peer's IPC server address by peer ID (gPid).
+  // Output argument:
+  //   - addr: the socket address for the peer with the given gPid.
+  commResult_t getPeerIpcServerAddr(
+      const std::string& peerId,
+      folly::SocketAddress& addr) const;
+
   // Notify remote peers to release their imported NVL memory.
   // Output argument:
   //   - reqCb: IpcReqCb that the caller can track for completion.
@@ -190,6 +203,12 @@ class IpcRegCache {
   std::unique_ptr<folly::ScopedEventBaseThread> asyncSocketEvbThread_;
   std::unique_ptr<ctran::bootstrap::AsyncServerSocket> asyncServerSocket_;
   folly::SocketAddress serverAddr_;
+
+  // Peer IPC server addresses for async socket communication, keyed by gPid.
+  // Protected by Synchronized for concurrent access from multiple
+  // communicators.
+  folly::Synchronized<folly::F14FastMap<std::string, folly::SocketAddress>>
+      peerIpcServerAddrs_;
 
   // Monotonically increasing unique ID counter for IPC registrations
   static std::atomic<uint32_t> nextUniqueId_;


### PR DESCRIPTION
Summary: store peerIpcServerAddr in IpcRegCache instead of CtranMapper

Reviewed By: dsjohns2

Differential Revision: D92545629


