### PR TITLE
Change createVirtualQp in IbvPd to use same CQ for both send and recv

### DIFF
--- a/comms/ctran/ibverbx/Coordinator.cc
+++ b/comms/ctran/ibverbx/Coordinator.cc
@@ -72,11 +72,13 @@ void Coordinator::registerVirtualQpWithVirtualCqMappings(
         physicalQpNum, deviceId, virtualQpNum);
   }
 
-  // Register the notify QP to virtual QP mapping
-  int notifyPhysicalQpNum = virtualQp->getNotifyQpRef().qp()->qp_num;
-  int notifyDeviceId = virtualQp->getNotifyQpRef().getDeviceId();
-  registerPhysicalQpAndDeviceIdToVirtualQp(
-      notifyPhysicalQpNum, notifyDeviceId, virtualQpNum);
+  // Register the notify QP to virtual QP mapping (if present)
+  if (virtualQp->hasNotifyQp()) {
+    int notifyPhysicalQpNum = virtualQp->getNotifyQpRef().qp()->qp_num;
+    int notifyDeviceId = virtualQp->getNotifyQpRef().getDeviceId();
+    registerPhysicalQpAndDeviceIdToVirtualQp(
+        notifyPhysicalQpNum, notifyDeviceId, virtualQpNum);
+  }
 }
 
 // Access APIs for testing and internal use

--- a/comms/ctran/ibverbx/IbvPd.h
+++ b/comms/ctran/ibverbx/IbvPd.h
@@ -48,12 +48,11 @@ class IbvPd {
 
   // The send_cq and recv_cq fields in initAttr are ignored.
   // Instead, initAttr.send_cq and initAttr.recv_cq will be set to the physical
-  // CQs contained within sendCq and recvCq, respectively.
+  // CQ contained within virtualCq.
   folly::Expected<IbvVirtualQp, Error> createVirtualQp(
       int totalQps,
       ibv_qp_init_attr* initAttr,
-      IbvVirtualCq* sendCq,
-      IbvVirtualCq* recvCq,
+      IbvVirtualCq* virtualCq,
       int maxMsgCntPerQp = kIbMaxMsgCntPerQp,
       int maxMsgSize = kIbMaxMsgSizeByte,
       LoadBalancingScheme loadBalancingScheme =

--- a/comms/ctran/ibverbx/benchmarks/IbverbxVirtualQpBench.cc
+++ b/comms/ctran/ibverbx/benchmarks/IbverbxVirtualQpBench.cc
@@ -104,7 +104,6 @@ IbvEndPoint::IbvEndPoint(int nicDevId, LoadBalancingScheme loadBalancingScheme)
             kTotalQps,
             &initAttr,
             &cq,
-            &cq,
             kMaxMsgCntPerQp,
             kMaxMsgSize,
             loadBalancingScheme);

--- a/comms/ctran/ibverbx/benchmarks/IbverbxVirtualQpCrossHostBench.cc
+++ b/comms/ctran/ibverbx/benchmarks/IbverbxVirtualQpCrossHostBench.cc
@@ -219,7 +219,6 @@ IbvEndPoint::IbvEndPoint(int nicDevId, LoadBalancingScheme loadBalancingScheme)
             kTotalQps,
             &initAttr,
             &cq,
-            &cq,
             kMaxMsgCntPerQp,
             kMaxMsgSize,
             loadBalancingScheme);

--- a/comms/ctran/ibverbx/tests/IbverbxDistributedVirtualQpGb200Test.cc
+++ b/comms/ctran/ibverbx/tests/IbverbxDistributedVirtualQpGb200Test.cc
@@ -383,12 +383,11 @@ class IbverbxVirtualQpTestFixture : public MpiBaseTestFixture {
     // Create IbvVirtualQp from vector of QPs
     auto virtualQp = IbvVirtualQp(
         std::move(qps),
-        std::move(*maybeNotifyQp),
-        &virtualCq,
         &virtualCq,
         maxMsgPerQp,
         maxMsgBytes,
-        loadBalancingScheme);
+        loadBalancingScheme,
+        std::move(*maybeNotifyQp));
 
     // init device buffer
     void* devBuf{nullptr};

--- a/comms/ctran/ibverbx/tests/IbverbxDistributedVirtualQpTest.cc
+++ b/comms/ctran/ibverbx/tests/IbverbxDistributedVirtualQpTest.cc
@@ -227,7 +227,6 @@ class IbverbxVirtualQpTestFixture : public MpiBaseTestFixture {
         totalQps,
         &initAttr,
         &virtualCq,
-        &virtualCq,
         maxMsgPerQp,
         maxMsgBytes,
         loadBalancingScheme);
@@ -365,8 +364,7 @@ TEST_F(IbverbxVirtualQpTestFixture, IbvVirtualQpModifyVirtualQp) {
   ASSERT_TRUE(pd);
 
   uint32_t totalQps = 16;
-  auto virtualQp =
-      pd->createVirtualQp(totalQps, &initAttr, &virtualCq, &virtualCq);
+  auto virtualQp = pd->createVirtualQp(totalQps, &initAttr, &virtualCq);
   ASSERT_TRUE(virtualQp);
 
   // create local business card and exchange
@@ -456,8 +454,8 @@ TEST_F(IbverbxVirtualQpTestFixture, IbvVirtualQpMultipleRdmaWrites) {
   // make qp group
   int totalQps = 16;
   auto initAttr = makeIbvQpInitAttr(virtualCq.getPhysicalCqsRef().at(0).cq());
-  auto virtualQp = pd->createVirtualQp(
-      totalQps, &initAttr, &virtualCq, &virtualCq, 128, 1024);
+  auto virtualQp =
+      pd->createVirtualQp(totalQps, &initAttr, &virtualCq, 128, 1024);
   ASSERT_TRUE(virtualQp);
 
   // init device buffer for receiver

--- a/comms/ctran/ibverbx/tests/IbverbxTest.cc
+++ b/comms/ctran/ibverbx/tests/IbverbxTest.cc
@@ -607,8 +607,7 @@ TEST_F(IbverbxTestFixture, IbvVirtualQp) {
   ASSERT_TRUE(pd);
 
   int totalQps = 16;
-  auto virtualQp =
-      pd->createVirtualQp(totalQps, &initAttr, &virtualCq, &virtualCq);
+  auto virtualQp = pd->createVirtualQp(totalQps, &initAttr, &virtualCq);
   ASSERT_TRUE(virtualQp);
   ASSERT_EQ(virtualQp->getQpsRef().size(), totalQps);
   ASSERT_EQ(virtualQp->getTotalQps(), totalQps);
@@ -664,8 +663,7 @@ TEST_F(IbverbxTestFixture, IbvVirtualQpMultiThreadUniqueQpNum) {
       ASSERT_TRUE(pd);
 
       int totalQps = 4;
-      auto virtualQp =
-          pd->createVirtualQp(totalQps, &initAttr, &virtualCq, &virtualCq);
+      auto virtualQp = pd->createVirtualQp(totalQps, &initAttr, &virtualCq);
       ASSERT_TRUE(virtualQp);
 
       localQpNums.push_back(virtualQp->getVirtualQpNum());
@@ -713,8 +711,8 @@ TEST_F(IbverbxTestFixture, IbvVirtualQpFindAvailableSendQp) {
 
   // Test setting 1: default maxMsgCntPerQp (100)
   {
-    auto virtualQp = pd->createVirtualQp(
-        totalQps, &initAttr, &virtualCq, &virtualCq, maxMsgCntPerQp);
+    auto virtualQp =
+        pd->createVirtualQp(totalQps, &initAttr, &virtualCq, maxMsgCntPerQp);
     ASSERT_TRUE(virtualQp);
     ASSERT_EQ(virtualQp->getQpsRef().size(), totalQps);
     ASSERT_EQ(virtualQp->getTotalQps(), totalQps);
@@ -803,8 +801,7 @@ TEST_F(IbverbxTestFixture, IbvVirtualQpFindAvailableSendQp) {
 
   // Test setting 2: No limit on maxMsgCntPerQp and maxMsgSize
   {
-    auto virtualQp =
-        pd->createVirtualQp(totalQps, &initAttr, &virtualCq, &virtualCq, -1);
+    auto virtualQp = pd->createVirtualQp(totalQps, &initAttr, &virtualCq, -1);
     ASSERT_TRUE(virtualQp);
     ASSERT_EQ(virtualQp->getQpsRef().size(), totalQps);
     ASSERT_EQ(virtualQp->getTotalQps(), totalQps);
@@ -853,12 +850,7 @@ TEST_F(IbverbxTestFixture, IbvVirtualQpUpdatePhysicalSendWrFromVirtualSendWr) {
   int maxMsgCntPerQp = 100;
   int maxMsgSizeByte = 100;
   auto virtualQp = pd->createVirtualQp(
-      totalQps,
-      &initAttr,
-      &virtualCq,
-      &virtualCq,
-      maxMsgCntPerQp,
-      maxMsgSizeByte);
+      totalQps, &initAttr, &virtualCq, maxMsgCntPerQp, maxMsgSizeByte);
   ASSERT_TRUE(virtualQp);
   ASSERT_EQ(virtualQp->getQpsRef().size(), totalQps);
   ASSERT_EQ(virtualQp->getTotalQps(), totalQps);
@@ -1037,8 +1029,7 @@ TEST_F(IbverbxTestFixture, IbvVirtualQpBusinessCard) {
   ASSERT_TRUE(pd);
 
   int totalQps = 16;
-  auto virtualQp =
-      pd->createVirtualQp(totalQps, &initAttr, &virtualCq, &virtualCq);
+  auto virtualQp = pd->createVirtualQp(totalQps, &initAttr, &virtualCq);
   ASSERT_TRUE(virtualQp);
   ASSERT_EQ(virtualQp->getQpsRef().size(), totalQps);
   ASSERT_EQ(virtualQp->getTotalQps(), totalQps);
@@ -1130,8 +1121,7 @@ TEST_F(IbverbxTestFixture, IbvVirtualQpBusinessCardSerializeAndDeserialize) {
   ASSERT_TRUE(pd);
 
   int totalQps = 16;
-  auto virtualQp =
-      pd->createVirtualQp(totalQps, &initAttr, &virtualCq, &virtualCq);
+  auto virtualQp = pd->createVirtualQp(totalQps, &initAttr, &virtualCq);
   ASSERT_TRUE(virtualQp);
   ASSERT_EQ(virtualQp->getQpsRef().size(), totalQps);
   ASSERT_EQ(virtualQp->getTotalQps(), totalQps);
@@ -1190,8 +1180,7 @@ TEST_F(IbverbxTestFixture, Coordinator) {
   ASSERT_TRUE(pd);
 
   int totalQps = 16;
-  auto maybeVirtualQp =
-      pd->createVirtualQp(totalQps, &initAttr, &virtualCq, &virtualCq);
+  auto maybeVirtualQp = pd->createVirtualQp(totalQps, &initAttr, &virtualCq);
   ASSERT_TRUE(maybeVirtualQp);
   auto virtualQp = std::move(*maybeVirtualQp);
   ASSERT_EQ(virtualQp.getQpsRef().size(), totalQps);
@@ -1296,13 +1285,13 @@ TEST_F(IbverbxTestFixture, CoordinatorRegisterUnregisterUpdateApis) {
 
       int totalQps = 4;
       auto maybeVirtualQp1 =
-          pd->createVirtualQp(totalQps, &initAttr, &virtualCq1, &virtualCq1);
+          pd->createVirtualQp(totalQps, &initAttr, &virtualCq1);
       ASSERT_TRUE(maybeVirtualQp1);
       auto virtualQp1 = std::move(*maybeVirtualQp1);
       virtualQpNum1 = virtualQp1.getVirtualQpNum();
 
       auto maybeVirtualQp2 =
-          pd->createVirtualQp(totalQps, &initAttr, &virtualCq2, &virtualCq2);
+          pd->createVirtualQp(totalQps, &initAttr, &virtualCq2);
       ASSERT_TRUE(maybeVirtualQp2);
       auto virtualQp2 = std::move(*maybeVirtualQp2);
       virtualQpNum2 = virtualQp2.getVirtualQpNum();
@@ -1354,8 +1343,7 @@ TEST_F(IbverbxTestFixture, CoordinatorRegisterUnregisterUpdateApis) {
     ASSERT_TRUE(pd);
 
     int totalQps = 4;
-    auto maybeVirtualQp =
-        pd->createVirtualQp(totalQps, &initAttr, &virtualCq, &virtualCq);
+    auto maybeVirtualQp = pd->createVirtualQp(totalQps, &initAttr, &virtualCq);
     ASSERT_TRUE(maybeVirtualQp);
     auto virtualQp = std::move(*maybeVirtualQp);
 
@@ -1397,8 +1385,7 @@ TEST_F(IbverbxTestFixture, CoordinatorRegisterUnregisterUpdateApis) {
     ASSERT_TRUE(pd);
 
     int totalQps = 4;
-    auto maybeVirtualQp =
-        pd->createVirtualQp(totalQps, &initAttr, &virtualCq1, &virtualCq1);
+    auto maybeVirtualQp = pd->createVirtualQp(totalQps, &initAttr, &virtualCq1);
     ASSERT_TRUE(maybeVirtualQp);
     auto virtualQp1 = std::move(*maybeVirtualQp);
 


### PR DESCRIPTION
Summary:
## Overview
This diff unifies the `createVirtualQp` factory and `IbvVirtualQp` constructor to use a single `IbvVirtualCq*` instead of separate `sendCq`/`recvCq` pointers. It also makes `notifyQp` an `std::optional<IbvQp>`, created only for SPRAY mode (not DQPLB). All callers across tests and benchmarks are updated to match.

## Key Design Decisions

1. **Single CQ**: `send_cq` and `recv_cq` in `ibv_qp_init_attr` are always set to the same physical CQ from the `IbvVirtualCq`. There is no use case for separate send/recv CQs in the VirtualQp abstraction.

2. **Optional notifyQp**: The notify QP is only used in SPRAY load-balancing mode. In DQPLB mode, sequence numbers embedded in IMM data replace the separate notification mechanism. Making `notifyQp_` an `std::optional<IbvQp>` reflects this — DQPLB VirtualQps no longer create an unnecessary notify QP.

3. **Backward-compatible accessors**: `getNotifyQpRef()` returns `.value()` (throws `std::bad_optional_access` if absent). `hasNotifyQp()` is added for callers that need to check before access.

Differential Revision: D92729017


