### PR TITLE
Add VirtualQp/VirtualCq registration and common helpers

### DIFF
--- a/comms/ctran/ibverbx/IbvVirtualCq.h
+++ b/comms/ctran/ibverbx/IbvVirtualCq.h
@@ -399,14 +399,10 @@ IbvVirtualCq::pollCq_v2() {
         const RegisteredQpInfo* info =
             findRegisteredQpInfo(physicalWc.qp_num, deviceId);
 
-        if (info == nullptr) {
-          return folly::makeUnexpected(Error(
-              EINVAL,
-              fmt::format(
-                  "[Ibverbx]IbvVirtualCq::pollCq_v2, unregistered QP: qpNum={}, deviceId={}",
-                  physicalWc.qp_num,
-                  deviceId)));
-        }
+        CHECK(info != nullptr) << fmt::format(
+            "[Ibverbx]IbvVirtualCq::pollCq_v2, unregistered QP: qpNum={}, deviceId={}",
+            physicalWc.qp_num,
+            deviceId);
 
         if (isUsingMultiQpLoadBalancing(info->isMultiQp, physicalWc.opcode)) {
           // Multi-QP RDMA: route to VirtualQp for fragment reassembly


### PR DESCRIPTION
Summary:
Add v2 infrastructure to IbvVirtualQp. This includes new private members (isMultiQp_, sendTracker_, recvTracker_, pendingSendNotifyQue_, pendingRecvNotifyQue_), a public isMultiQp() accessor, VirtualCq registration helpers (registerWithVirtualCq/unregisterFromVirtualCq) that register all physical QPs directly with the VirtualCq registration table, and common inline helpers (isSendOpcode, updateWrState, buildVirtualWc) that will be used by later postSend_v2/postRecv_v2/processCompletion implementations.

During this intermediate phase, VirtualQps register with BOTH the Coordinator (old path for pollCq) AND the VirtualCq registration table (new path for pollCq_v2). Both paths work correctly and independently. The constructor, move constructor/assignment, and destructor are all updated to maintain dual registration.

Differential Revision: D92789192
