### PR TITLE
Enable testhelper to take extra hints for extensive testing.

### DIFF
--- a/comms/torchcomms/tests/integration/py/TorchCommTestHelpers.py
+++ b/comms/torchcomms/tests/integration/py/TorchCommTestHelpers.py
@@ -224,7 +224,7 @@ class TorchCommTestWrapper:
             hints.update({"fastInitMode": fast_init_mode})
         return hints
 
-    def __init__(self, store=None):
+    def __init__(self, store=None, hints=None):
         maybe_set_rank_envs()
 
         # Get backend from TEST_BACKEND environment variable, throw if not set
@@ -234,7 +234,12 @@ class TorchCommTestWrapper:
 
         rank, size = get_rank_and_size()
         device = self.get_device(os.environ["TEST_BACKEND"], rank)
-        hints = self.get_hints_from_env()
+        env_hints = self.get_hints_from_env()
+        if hints is None:
+            hints = env_hints
+        else:
+            hints = hints.copy()
+            hints.update(env_hints)
         # Create and initialize TorchComm instance
         TorchCommTestWrapper.NEXT_COMM_ID += 1
         self.torchcomm = new_comm(


### PR DESCRIPTION
Summary:
Motivation:

The TorchCommMCCL creates a sets of custom hints and would like to use the helper function `TorchCommWrapper` to pass different hints directly for testing.

Reviewed By: tanquer

Differential Revision: D89900867


