### PR TITLE
Add timeout watchdog thread for mccl

### DIFF
--- a/comms/torchcomms/tests/integration/py/TorchCommTestHelpers.py
+++ b/comms/torchcomms/tests/integration/py/TorchCommTestHelpers.py
@@ -224,7 +224,7 @@ class TorchCommTestWrapper:
             hints.update({"fastInitMode": fast_init_mode})
         return hints
 
-    def __init__(self, store=None, hints=None):
+    def __init__(self, store=None, hints=None, abort_process_on_timeout_or_error=None):
         maybe_set_rank_envs()
 
         # Get backend from TEST_BACKEND environment variable, throw if not set
@@ -248,6 +248,7 @@ class TorchCommTestWrapper:
             store=store,
             name=f"comms_test_{TorchCommTestWrapper.NEXT_COMM_ID}",
             hints=hints,
+            abort_process_on_timeout_or_error=abort_process_on_timeout_or_error,
         )
 
         print(


### PR DESCRIPTION
Summary:
This diff adds a timeout detection mechanism to TorchWorkMCCL to detect hung collective operations.

**Changes:**
- Enable `TorchWorkMCCL` to track the elapsed time and return TIMEOUT status if it is over `timeout_`
- In workqueue, once identified TorchWorkMCCL in timeout, make the comm to be in TIMEOUT state.
- create a hint `torchcomm::mccl::watchdog_timeout_ms` to allow passing in a universal value for setting watchdog timeout. 

**Tests:**
- Create a test case with setting watchdog timeout to 1s through hints



This enables the watchdog thread (configured via `torchcomm::mccl::watchdog_timeout_ms` hint) to detect and report stuck collectives, improving debuggability of distributed training hangs.

Reviewed By: saifhhasan

Differential Revision: D92799185


