### PR TITLE
Add gin.atomicAdd() API for remote atomic fetch-and-add

### DIFF
--- a/comms/ncclx/v2_28/src/include/nccl_device/gin.h
+++ b/comms/ncclx/v2_28/src/include/nccl_device/gin.h
@@ -131,6 +131,22 @@ struct ncclGin_BackendMask {
     cuda::thread_scope expected_scope = cuda::thread_scope_device
   ) const;
 
+  // Performs a remote atomic fetch-and-add on a uint64_t in the destination window.
+  // The value at dstWnd[dstOffset] on the peer is atomically incremented by `value`.
+  // This uses RDMA OPCODE_ATOMIC_FA under the hood (same mechanism as signal).
+  template<
+    typename Coop = ncclCoopThread,
+    typename DescriptorSmem = ncclGin_None
+  >
+  NCCL_DEVICE_INLINE void atomicAdd(
+    ncclTeam, int peer,
+    ncclWindow_t dstWnd, size_t dstOffset, uint64_t value,
+    Coop coop = ncclCoopThread{},
+    DescriptorSmem descriptor = ncclGin_None{},
+    cuda::thread_scope alreadyReleased = cuda::thread_scope_thread,
+    cuda::thread_scope expected_scope = cuda::thread_scope_device
+  ) const;
+
   template<typename RemoteAction,
            typename Coop = ncclCoopThread,
            typename DescriptorSmem = ncclGin_None>

--- a/comms/ncclx/v2_28/src/include/nccl_device/gin/gin_device_common.h
+++ b/comms/ncclx/v2_28/src/include/nccl_device/gin/gin_device_common.h
@@ -71,6 +71,15 @@ struct ncclGinApi_PutValue {
 };
 
 template <ncclNetDeviceType backend>
+struct ncclGinApi_AtomicAdd {
+  template <typename Coop>
+  NCCL_DEVICE_INLINE static void call(ncclGinCtx, Coop coop, int peer, ncclGinWindow_t dstWin,
+                                      size_t dstOff, uint64_t value, bool hasDescriptor,
+                                      ncclGinDescriptorSmem* descriptor,
+                                      cuda::thread_scope required, cuda::thread_scope given);
+};
+
+template <ncclNetDeviceType backend>
 struct ncclGinApi_GetSignalPtr {
   NCCL_DEVICE_INLINE static uint64_t* call(ncclGinCtx, int peer, ncclGinSignal_t signalId);
 };

--- a/comms/ncclx/v2_28/src/include/nccl_device/gin/proxy/gin_proxy.h
+++ b/comms/ncclx/v2_28/src/include/nccl_device/gin/proxy/gin_proxy.h
@@ -232,4 +232,17 @@ struct ncclGinApi_PutValue<NCCL_NET_DEVICE_GIN_PROXY> {
   }
 };
 
+template <>
+struct ncclGinApi_AtomicAdd<NCCL_NET_DEVICE_GIN_PROXY> {
+  template <typename Coop>
+  NCCL_DEVICE_INLINE static void call(ncclGinCtx ctx, Coop coop, int peer, ncclGinWindow_t dstWin,
+                                      size_t dstOff, uint64_t value, bool hasDescriptor,
+                                      ncclGinDescriptorSmem* descriptor,
+                                      cuda::thread_scope required, cuda::thread_scope given) {
+    // Not supported on proxy backend — proxy CPU-side signal path only targets
+    // the signal table, not arbitrary window addresses. Use GDAKI backend.
+    __trap();
+  }
+};
+
 #endif

--- a/comms/torchcomms/tests/integration/cpp/DeviceApiTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/DeviceApiTest.cpp
@@ -482,3 +482,126 @@ TEST_F(DeviceApiTest, DeviceWindowWithCountersFloat) {
 TEST_F(DeviceApiTest, DevicePutFloat) {
   testDevicePut(1024, at::kFloat);
 }
+
+// =============================================================================
+// GIN atomicAdd Test
+// =============================================================================
+// This test validates the gin.atomicAdd() API at the NCCLx layer:
+//   1. Each rank creates a window with uint64_t slots
+//   2. In a ring pattern, rank i atomically adds (rank+1) to slot[rank] on
+//      the next rank's window
+//   3. Signal the next rank after atomicAdd completes
+//   4. Wait for signal from previous rank
+//   5. Verify the atomically-added value matches expected
+
+void DeviceApiTest::testGinAtomicAdd() {
+  SCOPED_TRACE(::testing::Message() << "Testing GIN atomicAdd");
+
+  auto op_stream = at::cuda::getStreamFromPool(false, device_index_);
+  auto wait_stream = at::cuda::getStreamFromPool(false, device_index_);
+
+  // Create MemPool for RDMA-compatible memory allocation
+  auto mem_pool = std::make_unique<at::cuda::MemPool>(
+      std::static_pointer_cast<c10::cuda::CUDACachingAllocator::CUDAAllocator>(
+          allocator_));
+  c10::cuda::CUDACachingAllocator::beginAllocateToPool(
+      mem_pool->device(), mem_pool->id(), [](cudaStream_t) { return true; });
+
+  // Window layout: num_ranks uint64_t slots, one per sender rank
+  // Each slot is 8 bytes (sizeof(uint64_t))
+  auto options =
+      at::TensorOptions().dtype(at::kLong).device(at::kCUDA, device_index_);
+  at::Tensor win_tensor = at::zeros({num_ranks_}, options);
+
+  c10::cuda::CUDACachingAllocator::endAllocateToPool(
+      mem_pool->device(), mem_pool->id());
+
+  // Create window and register tensor
+  torchcomm_->barrier(false);
+  auto base_win = torchcomm_->new_window();
+  base_win->tensor_register(win_tensor);
+  torchcomm_->barrier(false);
+
+  auto* win =
+      dynamic_cast<torch::comms::TorchCommWindowNCCLXGin*>(base_win.get());
+  ASSERT_NE(win, nullptr) << "Window should be TorchCommWindowNCCLXGin";
+
+  // Get device window with signals for synchronization
+  int signal_count = num_ranks_;
+  auto* dev_win = win->get_device_window(signal_count, -1, 1);
+  ASSERT_NE(dev_win, nullptr) << "Device window pointer should not be null";
+
+  // Ring pattern: rank i atomicAdds to rank (i+1) % num_ranks
+  int dst_rank = (rank_ + 1) % num_ranks_;
+  int src_rank = (rank_ - 1 + num_ranks_) % num_ranks_;
+
+  // Each rank writes to its own slot on the destination.
+  // dst_offset = rank_ * sizeof(uint64_t) bytes into the window.
+  size_t dst_offset = rank_ * sizeof(uint64_t);
+  uint64_t add_value = static_cast<uint64_t>(rank_ + 1);
+  constexpr int kSignalId = 0;
+
+  // Launch atomicAdd kernel
+  {
+    c10::cuda::CUDAStreamGuard guard(op_stream);
+    torchcomms::device::test::launchDeviceGinAtomicAddKernel(
+        dev_win,
+        dst_offset,
+        add_value,
+        dst_rank,
+        kSignalId,
+        op_stream.stream());
+  }
+
+  // Wait for signal from src_rank indicating its atomicAdd completed to us
+  {
+    c10::cuda::CUDAStreamGuard guard(wait_stream);
+    torchcomms::device::test::launchDeviceWaitSignalKernel(
+        dev_win, kSignalId, 1, wait_stream.stream());
+  }
+
+  op_stream.synchronize();
+  wait_stream.synchronize();
+
+  // Verify: slot[src_rank] should have value (src_rank + 1) from the sender
+  at::Tensor result_cpu = win_tensor.cpu();
+  int64_t got = result_cpu[src_rank].item<int64_t>();
+  int64_t expected = static_cast<int64_t>(src_rank + 1);
+  ASSERT_EQ(got, expected) << "atomicAdd mismatch at slot[" << src_rank
+                           << "]: expected " << expected << ", got " << got;
+
+  // Reset signal for cleanup
+  {
+    c10::cuda::CUDAStreamGuard guard(op_stream);
+    torchcomms::device::test::launchDeviceResetSignalKernel(
+        dev_win, kSignalId, op_stream.stream());
+  }
+  op_stream.synchronize();
+
+  // Verify signal was reset to 0
+  uint64_t* d_signal_out = nullptr;
+  cudaMalloc(&d_signal_out, sizeof(uint64_t));
+  {
+    c10::cuda::CUDAStreamGuard guard(op_stream);
+    torchcomms::device::test::launchDeviceReadSignalKernel(
+        dev_win, kSignalId, d_signal_out, op_stream.stream());
+  }
+  op_stream.synchronize();
+
+  uint64_t signal_value = 0;
+  cudaMemcpy(
+      &signal_value, d_signal_out, sizeof(uint64_t), cudaMemcpyDeviceToHost);
+  cudaFree(d_signal_out);
+  ASSERT_EQ(signal_value, 0) << "Signal should be reset to 0 after reset";
+
+  // Cleanup
+  base_win->tensor_deregister();
+  base_win.reset();
+  mem_pool.reset();
+
+  torchcomm_->barrier(false);
+}
+
+TEST_F(DeviceApiTest, GinAtomicAdd) {
+  testGinAtomicAdd();
+}

--- a/comms/torchcomms/tests/integration/cpp/DeviceApiTest.hpp
+++ b/comms/torchcomms/tests/integration/cpp/DeviceApiTest.hpp
@@ -49,6 +49,10 @@ class DeviceApiTest : public ::testing::Test {
   // Device-initiated RMA test - uses CUDA kernel to perform put
   void testDevicePut(int count, at::ScalarType dtype);
 
+  // GIN atomicAdd test - uses CUDA kernel to perform remote atomic
+  // fetch-and-add
+  void testGinAtomicAdd();
+
   // Member variables
   std::unique_ptr<TorchCommTestWrapper> wrapper_;
   std::shared_ptr<torch::comms::TorchComm> torchcomm_;

--- a/comms/torchcomms/tests/integration/cpp/DeviceApiTestKernels.cu
+++ b/comms/torchcomms/tests/integration/cpp/DeviceApiTestKernels.cu
@@ -85,6 +85,58 @@ __global__ void deviceResetSignalKernel(DeviceWindowNCCL* win, int signal_id) {
   }
 }
 
+__global__ void
+deviceReadSignalKernel(DeviceWindowNCCL* win, int signal_id, uint64_t* out) {
+  // Only thread 0 performs the operation
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    *out = win->read_signal(signal_id);
+  }
+}
+
+// =============================================================================
+// GIN atomicAdd Test Kernel
+// =============================================================================
+// This kernel directly uses the ncclGin::atomicAdd() API to perform a remote
+// atomic fetch-and-add on a uint64_t in the destination window.
+//
+// Pattern:
+//   1. Each rank atomically adds `add_value` to dstWnd[dstOffset] on dst_rank
+//   2. After atomicAdd, signals dst_rank using gin.signal() for synchronization
+//   3. The receiver waits for the signal and then reads the result (host-side)
+
+__global__ void deviceGinAtomicAddKernel(
+    DeviceWindowNCCL* win,
+    size_t dst_offset,
+    uint64_t add_value,
+    int dst_rank,
+    int signal_id) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    const ncclDevComm& dev_comm = win->comm_;
+    ncclGin gin(dev_comm, torchcomms::device::kDefaultGinContextIndex);
+
+    ncclWindow_t dst_win = win->window_;
+
+    // Perform remote atomic add on the destination window
+    gin.atomicAdd(
+        ncclTeamWorld(dev_comm),
+        dst_rank,
+        dst_win,
+        dst_offset,
+        add_value,
+        ncclCoopThread{});
+
+    // Signal the destination rank that atomicAdd is complete
+    gin.signal(
+        ncclTeamWorld(dev_comm),
+        dst_rank,
+        ncclGin_SignalInc{static_cast<ncclGinSignal_t>(signal_id)},
+        ncclCoopThread{});
+
+    // Flush to ensure all operations are posted
+    gin.flush(ncclCoopThread{});
+  }
+}
+
 // =============================================================================
 // Host-callable wrapper functions
 // =============================================================================
@@ -126,6 +178,25 @@ void launchDeviceResetSignalKernel(
     int signal_id,
     cudaStream_t stream) {
   deviceResetSignalKernel<<<1, 1, 0, stream>>>(win, signal_id);
+}
+
+void launchDeviceReadSignalKernel(
+    DeviceWindowNCCL* win,
+    int signal_id,
+    uint64_t* out,
+    cudaStream_t stream) {
+  deviceReadSignalKernel<<<1, 1, 0, stream>>>(win, signal_id, out);
+}
+
+void launchDeviceGinAtomicAddKernel(
+    DeviceWindowNCCL* win,
+    size_t dst_offset,
+    uint64_t add_value,
+    int dst_rank,
+    int signal_id,
+    cudaStream_t stream) {
+  deviceGinAtomicAddKernel<<<1, 1, 0, stream>>>(
+      win, dst_offset, add_value, dst_rank, signal_id);
 }
 
 } // namespace torchcomms::device::test

--- a/comms/torchcomms/tests/integration/cpp/DeviceApiTestKernels.cuh
+++ b/comms/torchcomms/tests/integration/cpp/DeviceApiTestKernels.cuh
@@ -63,4 +63,23 @@ void launchDeviceResetSignalKernel(
     int signal_id,
     cudaStream_t stream);
 
+// Launch read signal kernel - reads aggregated signal value into output buffer.
+// out must be a device pointer to a single uint64_t.
+void launchDeviceReadSignalKernel(
+    DeviceWindowNCCL* win,
+    int signal_id,
+    uint64_t* out,
+    cudaStream_t stream);
+
+// Launch GIN atomicAdd test kernel - performs remote atomic fetch-and-add
+// on a uint64_t in the destination window, then signals the destination rank.
+// Note: DeviceWindowNCCL* is a DEVICE pointer (allocated via cudaMalloc)
+void launchDeviceGinAtomicAddKernel(
+    DeviceWindowNCCL* win,
+    size_t dst_offset,
+    uint64_t add_value,
+    int dst_rank,
+    int signal_id,
+    cudaStream_t stream);
+
 } // namespace torchcomms::device::test


### PR DESCRIPTION
Summary:
## Summary

Adds `gin.atomicAdd()` as a new NCCLx GIN device API for performing RDMA atomic fetch-and-add on arbitrary window addresses. This is needed by the torchcomms device layer to implement per-peer signal slots on resource buffers, where cross-rank signaling uses RDMA atomics on user-managed memory rather than the GIN hardware signal table.

The implementation reuses the existing `doca_gpu_dev_verbs_signal()` function (which builds `OPCODE_ATOMIC_FA` WQEs) but targets window addresses instead of the signal table. The PROXY backend traps since it doesn't support arbitrary-address atomics.

An integration test (`DeviceApiTest.GinAtomicAdd`) validates the new API using a ring-based pattern where each rank atomically adds to a slot on the next rank's window.

Differential Revision: D92856247


