### PR TITLE
Graceful cleanup when finalize() not called before destruction

### DIFF
--- a/comms/torchcomms/nccl/TorchCommNCCL.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCL.cpp
@@ -46,7 +46,44 @@ TorchCommNCCL::TorchCommNCCL(const ncclComm_t nccl_comm)
 
 TorchCommNCCL::~TorchCommNCCL() {
   if (init_state_ == InitializationState::INITIALIZED) {
-    TC_LOG(ERROR, this) << "TorchCommNCCL was not finalized before destruction";
+    TC_LOG(WARNING, this)
+        << "TorchCommNCCL " << name_
+        << " was not finalized before destruction. "
+        << "This may indicate a resource leak. Please call finalize() explicitly.";
+
+    // Signal shutdown to timeout watchdog thread to prevent it from accessing
+    // this object after destruction
+    shutdown_ = true;
+
+    // Wake up the timeout watchdog thread
+    {
+      std::lock_guard<std::mutex> lock(timeout_mutex_);
+      timeout_cv_.notify_all();
+    }
+
+    // Wait for timeout thread to finish. If we're being called from within
+    // the timeout thread itself (e.g., garbageCollect popped a work item whose
+    // destruction released the last shared_ptr to this comm), we must detach
+    // instead of join to avoid a deadlock.
+    if (timeout_thread_.joinable()) {
+      if (std::this_thread::get_id() != timeout_thread_.get_id()) {
+        timeout_thread_.join();
+      } else {
+        timeout_thread_.detach();
+      }
+    }
+
+    // Abort the NCCL communicator since we can't do a clean finalization
+    // Note: We don't call the full abortNcclComm() to avoid potential abort()
+    // calls from options_.abort_process_on_timeout_or_error
+    if (nccl_comm_) {
+      // Best effort to abort the communicator - ignore errors since we're
+      // in the destructor
+      if (nccl_api_) {
+        (void)nccl_api_->commAbort(nccl_comm_);
+      }
+      nccl_comm_ = nullptr;
+    }
   }
 
   // We need to detach the memory hook in case finalize is not called,

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -74,8 +74,44 @@ TorchCommNCCLX::TorchCommNCCLX(const ncclComm_t nccl_comm)
 
 TorchCommNCCLX::~TorchCommNCCLX() {
   if (init_state_ == InitializationState::INITIALIZED) {
-    TC_LOG(ERROR, this) << "TorchCommNCCLX " << name_
-                        << " was not finalized before destruction";
+    TC_LOG(WARNING, this)
+        << "TorchCommNCCLX " << name_
+        << " was not finalized before destruction. "
+        << "This may indicate a resource leak. Please call finalize() explicitly.";
+
+    // Signal shutdown to timeout watchdog thread to prevent it from accessing
+    // this object after destruction
+    shutdown_ = true;
+
+    // Wake up the timeout watchdog thread
+    {
+      std::lock_guard<std::mutex> lock(timeout_mutex_);
+      timeout_cv_.notify_all();
+    }
+
+    // Wait for timeout thread to finish. If we're being called from within
+    // the timeout thread itself (e.g., garbageCollect popped a work item whose
+    // destruction released the last shared_ptr to this comm), we must detach
+    // instead of join to avoid a deadlock.
+    if (timeout_thread_.joinable()) {
+      if (std::this_thread::get_id() != timeout_thread_.get_id()) {
+        timeout_thread_.join();
+      } else {
+        timeout_thread_.detach();
+      }
+    }
+
+    // Abort the NCCL communicator since we can't do a clean finalization
+    // Note: We don't call the full abortNcclComm() to avoid potential abort()
+    // calls from options_.abort_process_on_timeout_or_error
+    if (nccl_comm_) {
+      // Best effort to abort the communicator - ignore errors since we're
+      // in the destructor
+      if (nccl_api_) {
+        (void)nccl_api_->commAbort(nccl_comm_);
+      }
+      nccl_comm_ = nullptr;
+    }
   }
 
   // We need to detach the memory hook in case finalize is not called,

--- a/comms/torchcomms/ncclx/TorchCommNCCLXUtils.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXUtils.cpp
@@ -211,7 +211,16 @@ void TorchCommNCCLX::timeoutWatchdog() noexcept {
     // Thread-safety: checkWorkQueue() calls garbageCollect() which acquires
     // work_queues_mutex_ before accessing the work queue, ensuring safe
     // concurrent access with the main thread's enqueueWork() calls.
+    //
+    // NOTE: garbageCollect may pop a completed work item whose destruction
+    // releases the last shared_ptr to this comm, triggering our destructor.
+    // In that case, the destructor sets shutdown_=true and detaches this
+    // thread. We must check shutdown_ immediately after to avoid accessing
+    // potentially destroyed member state.
     checkWorkQueue();
+    if (shutdown_) {
+      break;
+    }
     if (comm_state_ != CommState::NORMAL &&
         options_.abort_process_on_timeout_or_error) {
       // Log the error and abort the process.  We cannot abort the NCCL

--- a/comms/torchcomms/rccl/TorchCommRCCL.cpp
+++ b/comms/torchcomms/rccl/TorchCommRCCL.cpp
@@ -50,7 +50,44 @@ TorchCommRCCL::TorchCommRCCL(
 
 TorchCommRCCL::~TorchCommRCCL() {
   if (init_state_ == InitializationState::INITIALIZED) {
-    TC_LOG(ERROR, this) << "TorchCommRCCL was not finalized before destruction";
+    TC_LOG(WARNING, this)
+        << "TorchCommRCCL " << name_
+        << " was not finalized before destruction. "
+        << "This may indicate a resource leak. Please call finalize() explicitly.";
+
+    // Signal shutdown to timeout watchdog thread to prevent it from accessing
+    // this object after destruction
+    shutdown_ = true;
+
+    // Wake up the timeout watchdog thread
+    {
+      std::lock_guard<std::mutex> lock(timeout_mutex_);
+      timeout_cv_.notify_all();
+    }
+
+    // Wait for timeout thread to finish. If we're being called from within
+    // the timeout thread itself (e.g., garbageCollect popped a work item whose
+    // destruction released the last shared_ptr to this comm), we must detach
+    // instead of join to avoid a deadlock.
+    if (timeout_thread_.joinable()) {
+      if (std::this_thread::get_id() != timeout_thread_.get_id()) {
+        timeout_thread_.join();
+      } else {
+        timeout_thread_.detach();
+      }
+    }
+
+    // Abort the RCCL communicator since we can't do a clean finalization
+    // Note: We don't call the full abortRcclComm() to avoid potential abort()
+    // calls from options_.abort_process_on_timeout_or_error
+    if (nccl_comm_) {
+      // Best effort to abort the communicator - ignore errors since we're
+      // in the destructor
+      if (rccl_api_) {
+        (void)rccl_api_->commAbort(nccl_comm_);
+      }
+      nccl_comm_ = nullptr;
+    }
   }
 
   // We need to detach the memory hook in case finalize is not called,

--- a/comms/torchcomms/rcclx/TorchCommRCCLXUtils.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLXUtils.cpp
@@ -226,9 +226,18 @@ void TorchCommRCCLX::timeoutWatchdog() noexcept {
     }
 
     // Check work objects for completion or timeout
+    //
+    // NOTE: garbageCollectWorkQueues may pop a completed work item whose
+    // destruction releases the last shared_ptr to this comm, triggering our
+    // destructor. In that case, the destructor sets shutdown_=true and
+    // detaches this thread. We must check shutdown_ immediately after to
+    // avoid accessing potentially destroyed member state.
 
     std::lock_guard<std::mutex> lock(work_queues_mutex_);
     garbageCollectWorkQueues();
+    if (shutdown_) {
+      break;
+    }
     if (comm_state_ != CommState::NORMAL &&
         options_.abort_process_on_timeout_or_error) {
       // Log the error and abort the process.  We cannot abort the NCCL

--- a/comms/torchcomms/tests/integration/py/FinalizeWarningTest.py
+++ b/comms/torchcomms/tests/integration/py/FinalizeWarningTest.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+# pyre-unsafe
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+Test that TorchComm backends log a warning but do not abort when finalize() is
+not called before destruction.
+"""
+
+import gc
+import os
+import time
+import unittest
+
+import torch
+from torchcomms import new_comm
+from torchcomms._comms import _get_store
+from torchcomms.tests.integration.py.TorchCommTestHelpers import (
+    get_rank_and_size,
+    maybe_set_rank_envs,
+)
+
+
+def create_store():
+    """Create a TCPStore object for coordination."""
+    maybe_set_rank_envs()
+    return _get_store("my_backend", "finalize_warning_test")
+
+
+class FinalizeWarningTest(unittest.TestCase):
+    """
+    Test class for verifying that TorchComm backends do not abort when finalize
+    is not called before destruction.
+
+    This test verifies that:
+    1. A TorchComm can be destroyed without calling finalize()
+    2. The destructor logs a warning instead of aborting
+    3. The process continues to run normally after the comm is destroyed
+    """
+
+    def test_destructor_without_finalize_does_not_abort(self):
+        """
+        Test that destroying a TorchComm without calling finalize() does not abort.
+
+        This test creates a TorchComm, uses it, and then lets it be garbage
+        collected without calling finalize(). The test passes if the process
+        does not abort and continues running normally.
+        """
+        maybe_set_rank_envs()
+
+        backend = os.getenv("TEST_BACKEND")
+        if backend is None:
+            raise RuntimeError("TEST_BACKEND environment variable is not set")
+
+        rank, size = get_rank_and_size()
+
+        # Determine device
+        if torch.accelerator.is_available():
+            device_count = torch.accelerator.device_count()
+            if device_count > 0:
+                device_id = rank % device_count
+                accelerator = torch.accelerator.current_accelerator()
+                assert accelerator is not None
+                device_type = accelerator.type
+                device = torch.device(f"{device_type}:{device_id}")
+            else:
+                device = torch.device("cpu")
+        else:
+            device = torch.device("cpu")
+
+        store = create_store()
+
+        # Create a TorchComm
+        comm = new_comm(
+            backend,
+            device,
+            store=store,
+            name="finalize_warning_test_comm",
+        )
+
+        # Use the comm to ensure it is properly initialized
+        _ = torch.ones(4, dtype=torch.float, device=device) * float(rank + 1)
+        work = comm.barrier(False)
+        work.wait()
+
+        print(f"Rank {rank}: Barrier completed, now deleting comm without finalize()")
+
+        # IMPORTANT: Delete the work object BEFORE the comm. TorchWorkNCCL
+        # holds a shared_ptr to TorchCommNCCL, so if `work` is alive when
+        # `del comm` is called, the comm won't actually be destroyed. We must
+        # also wait for the timeout watchdog thread (which runs every 1s) to
+        # garbage-collect the work item from its internal queue, breaking the
+        # circular reference: comm -> workq -> work_item -> comm.
+        del work
+        time.sleep(2)
+
+        # Delete the comm without calling finalize()
+        # This should log a warning but NOT abort
+        del comm
+
+        # Force garbage collection to ensure the destructor runs
+        gc.collect()
+
+        # If we reach here, the test passes - the destructor did not abort
+        print(f"Rank {rank}: Comm deleted successfully without abort")
+
+        # Perform another operation to verify the process is still healthy
+        # Create a new comm to verify the process can still function
+        store2 = _get_store("my_backend", "finalize_warning_test_2")
+        comm2 = new_comm(
+            backend,
+            device,
+            store=store2,
+            name="finalize_warning_test_comm_2",
+        )
+
+        # Use the new comm
+        work2 = comm2.barrier(False)
+        work2.wait()
+
+        print(f"Rank {rank}: Second comm created and used successfully")
+
+        # Clean up properly this time
+        comm2.finalize()
+        del work2
+        del comm2
+        gc.collect()
+
+        print(f"Rank {rank}: Test completed successfully")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
Previously, the TorchComm backends (NCCL, NCCLX, RCCL, RCCLX) would log an error and potentially crash when a communicator was destroyed without calling finalize(). This change makes the destructor handle this case gracefully by:

1. Logging a WARNING instead of ERROR to indicate the issue without aborting
2. Properly shutting down the timeout watchdog thread to prevent use-after-free


NOTE: this leaks the nccl communicator since shutting down/abort has been shown to cause errors.

This allows applications to terminate safely if they forget to call finalize(), while still warning about the potential resource leak.

Reviewed By: kapilsh, amirafzali

Differential Revision: D92755212


