### PR TITLE
Use rank to uniquely identify global process in addition to pid/host

### DIFF
--- a/comms/ctran/commstate/CommStateX.cc
+++ b/comms/ctran/commstate/CommStateX.cc
@@ -483,7 +483,7 @@ int CommStateX::gRank(int rank) const {
 std::string CommStateX::gPid(int rank) const {
   CHECK_TOPO_AND_SET_RANK(rank, rank_, rankStates_);
   return rankStates_.at(rank).host + ":" +
-      std::to_string(rankStates_.at(rank).pid);
+      std::to_string(rankStates_.at(rank).pid) + ":" + std::to_string(rank);
 }
 
 std::string CommStateX::dc(int rank) const {


### PR DESCRIPTION
Summary:
In UTs, we end up having pid to be set to -1 and hostname to "". Usually we use
a single communicator. This break the UTs with error as gPid() returns the same
value ":-1" for all ranks causing the assertion about change in IPC Server
address mismatch
```
CTRAN-REGCACHE: Peer IPC server address mismatch for peerId -1 ...
```

Differential Revision: D92879823


