### PR TITLE
LSA signal + NVLink data path with acquire/release PTX

### DIFF
--- a/comms/torchcomms/device/TorchCommDeviceWindow.hpp
+++ b/comms/torchcomms/device/TorchCommDeviceWindow.hpp
@@ -185,6 +185,8 @@ class TorchCommDeviceWindow {
       uint64_t value = 1);
 
   __device__ int wait_signal(int signal_id, CmpOp cmp, uint64_t value);
+  __device__ int
+  wait_signal_from(int peer, int signal_id, CmpOp cmp, uint64_t value);
   __device__ uint64_t read_signal(int signal_id) const;
   __device__ void reset_signal(int signal_id);
 

--- a/comms/torchcomms/device/ncclx/NCCLDeviceBackend.cpp
+++ b/comms/torchcomms/device/ncclx/NCCLDeviceBackend.cpp
@@ -83,7 +83,7 @@ NCCLDeviceBackend::Ptr NCCLDeviceBackend::create_device_window(
       .lsaLLA2ASlotCount = 0,
       .ginForceEnable = true,
       .ginContextCount = 1,
-      .ginSignalCount = config.signal_count,
+      .ginSignalCount = 0,
       .ginCounterCount = config.counter_count,
   };
 

--- a/comms/torchcomms/device/ncclx/TorchCommDeviceNCCLX.cuh
+++ b/comms/torchcomms/device/ncclx/TorchCommDeviceNCCLX.cuh
@@ -1,7 +1,12 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
-// TorchComms Device API - NCCL Backend Implementation Header
+// TorchComms Device API - Unified NCCL Backend Implementation (GIN + LSA)
 //
-// Device-side implementations for TorchComms using NCCL's GIN APIs.
+// Device-side implementations for TorchComms using NCCL's GIN (RDMA) and
+// LSA (NVLink) APIs. Each operation dispatches to the optimal transport
+// based on peer reachability:
+//   - LSA-reachable peers (same node): NVLink direct load/store
+//   - Remote peers: GIN RDMA
+//
 // Header-only library - implementations are inline for template instantiation.
 //
 // IMPORTANT: This header contains CUDA device code and must ONLY be included
@@ -28,6 +33,7 @@
 #include <nccl_device.h> // @manual=//comms/ncclx:nccl
 #include <nccl_device/impl/comm__types.h> // @manual=//comms/ncclx:nccl_device_api
 
+#include "comms/common/AtomicUtils.cuh"
 #include "comms/torchcomms/device/ncclx/TorchCommDeviceNCCLXTypes.hpp"
 
 namespace torchcomms::device {
@@ -39,6 +45,178 @@ namespace torchcomms::device {
 constexpr int kDefaultGinContextIndex = 0;
 constexpr int kDefaultSignalBits = 64;
 constexpr int kDefaultCounterBits = 56;
+
+// =============================================================================
+// Internal Helpers
+// =============================================================================
+
+namespace detail {
+
+// Compare two uint64_t values using the given comparison operator.
+__device__ inline bool cmp_op(CmpOp cmp, uint64_t lhs, uint64_t rhs) {
+  switch (cmp) {
+    case CmpOp::EQ:
+      return lhs == rhs;
+    case CmpOp::NE:
+      return lhs != rhs;
+    case CmpOp::LT:
+      return lhs < rhs;
+    case CmpOp::LE:
+      return lhs <= rhs;
+    case CmpOp::GT:
+      return lhs > rhs;
+    case CmpOp::GE:
+      return lhs >= rhs;
+  }
+  return false;
+}
+
+// Vectorized memcpy for NVLink stores (single-thread scope for now).
+//
+// Uses 128-bit (uint4) loads/stores with loop unrolling for better memory
+// pipeline utilization, inspired by comms::pipes::memcpy_vectorized.
+//
+// No volatile or ordering semantics — put() provides no ordering guarantees.
+// Callers must use signal(), fence(), or flush() for store visibility.
+__device__ inline void memcpy_nvl(void* dst, const void* src, size_t bytes) {
+  constexpr int kUnroll = 4;
+  constexpr size_t kVecSize = sizeof(uint4);
+
+  if (reinterpret_cast<uintptr_t>(dst) % kVecSize == 0 &&
+      reinterpret_cast<uintptr_t>(src) % kVecSize == 0) {
+    auto* __restrict__ d = static_cast<uint4*>(dst);
+    auto* __restrict__ s = static_cast<const uint4*>(src);
+    size_t nvecs = bytes / kVecSize;
+    size_t nvecs_aligned = (nvecs / kUnroll) * kUnroll;
+
+    for (size_t i = 0; i < nvecs_aligned; i += kUnroll) {
+      uint4 v[kUnroll];
+#pragma unroll
+      for (int j = 0; j < kUnroll; j++) {
+        v[j] = s[i + j];
+      }
+#pragma unroll
+      for (int j = 0; j < kUnroll; j++) {
+        d[i + j] = v[j];
+      }
+    }
+    for (size_t i = nvecs_aligned; i < nvecs; i++) {
+      d[i] = s[i];
+    }
+
+    size_t tail = bytes % kVecSize;
+    if (tail > 0) {
+      auto* db = reinterpret_cast<char*>(d + nvecs);
+      auto* sb = reinterpret_cast<const char*>(s + nvecs);
+      for (size_t i = 0; i < tail; i++) {
+        db[i] = sb[i];
+      }
+    }
+    return;
+  }
+
+  // Fallback: unaligned path using 8-byte copies
+  auto* __restrict__ d = static_cast<uint64_t*>(dst);
+  auto* __restrict__ s = static_cast<const uint64_t*>(src);
+  size_t chunks = bytes / sizeof(uint64_t);
+  for (size_t i = 0; i < chunks; i++) {
+    d[i] = s[i];
+  }
+  size_t tail = bytes % sizeof(uint64_t);
+  if (tail > 0) {
+    auto* db = reinterpret_cast<char*>(d + chunks);
+    auto* sb = reinterpret_cast<const char*>(s + chunks);
+    for (size_t i = 0; i < tail; i++) {
+      db[i] = sb[i];
+    }
+  }
+}
+
+// Flat index into the signal buffer: slots[signal_id * num_ranks + rank].
+__device__ __forceinline__ size_t
+signal_slot_index(int signal_id, int num_ranks, int rank) {
+  return static_cast<size_t>(signal_id) * num_ranks + rank;
+}
+
+// Returns pointer to the first per-peer signal slot for |signal_id|.
+__device__ inline uint64_t* signal_slot_base(
+    const ncclDevComm& dev_comm,
+    uint32_t signal_buffer_handle,
+    int signal_id,
+    int num_ranks) {
+  void* local_buf =
+      ncclGetResourceBufferLocalPointer(dev_comm, signal_buffer_handle);
+  return reinterpret_cast<uint64_t*>(local_buf) +
+      signal_slot_index(signal_id, num_ranks, 0);
+}
+
+} // namespace detail
+
+// =============================================================================
+// TorchCommDeviceWindow<NCCLDeviceBackend> Signal Operations
+// =============================================================================
+//
+// Signals use per-peer resource buffer slots instead of GIN hardware signals.
+// Layout: slots[signal_id * num_ranks + sender_world_rank] = uint64_t
+// Each sender writes only to its own slot, avoiding cross-transport atomicity
+// hazards between NVLink volatile stores and RDMA atomics.
+//
+// NOTE: signal() is defined before put() because put() calls signal() inline,
+// and C++ requires explicit specializations to precede their first use.
+
+template <>
+__device__ inline int TorchCommDeviceWindow<NCCLDeviceBackend>::signal(
+    int peer,
+    int signal_id,
+    SignalOp op,
+    uint64_t value) {
+  const ncclDevComm& dev_comm = comm_;
+
+  if (ncclTeamRankIsMember(
+          ncclTeamLsa(dev_comm), ncclTeamWorld(dev_comm), peer)) {
+    // ---- LSA (NVLink) path ----
+    // Write to peer's resource buffer via NVLink-mapped pointer.
+    int lsa_peer = ncclTeamRankToTeam(
+        ncclTeamLsa(dev_comm), ncclTeamWorld(dev_comm), peer);
+    void* peer_buf = ncclGetResourceBufferLsaPointer(
+        dev_comm, signal_buffer_handle_, lsa_peer);
+    uint64_t* slot = reinterpret_cast<uint64_t*>(peer_buf) +
+        detail::signal_slot_index(signal_id, num_ranks_, rank_);
+
+    if (op == SignalOp::ADD) {
+      // atom.release.sys.add.u64 — single NVLink atomic with release
+      // semantics, ensuring all prior stores (data writes from put())
+      // are visible before the counter increment.
+      comms::device::atomic_fetch_add_release_sys_global(slot, value);
+    } else {
+      // st.release.sys — release store ensures all prior writes are
+      // visible before the signal value lands on the peer.
+      comms::device::st_release_sys_global(slot, value);
+    }
+  } else {
+    // ---- GIN (RDMA) path ----
+    // SET is not supported on RDMA (no atomic store opcode).
+    if (op != SignalOp::ADD) {
+      return -1;
+    }
+
+    ncclGin gin(dev_comm, kDefaultGinContextIndex);
+
+    size_t offset = ncclGetResourceBufferOffset(signal_buffer_handle_) +
+        detail::signal_slot_index(signal_id, num_ranks_, rank_) *
+            sizeof(uint64_t);
+    gin.atomicAdd(
+        ncclTeamWorld(dev_comm),
+        peer,
+        dev_comm.resourceWindow,
+        offset,
+        value,
+        ncclCoopThread{});
+    gin.flush(ncclCoopThread{});
+  }
+
+  return 0;
+}
 
 // =============================================================================
 // TorchCommDeviceWindow<NCCLDeviceBackend> RMA Operations
@@ -53,98 +231,61 @@ __device__ inline int TorchCommDeviceWindow<NCCLDeviceBackend>::put(
     size_t bytes,
     int signal_id,
     int counter_id) {
-  // Get backend comm directly - no nested struct!
   const ncclDevComm& dev_comm = comm_;
 
-  // Create GIN context
-  ncclGin gin(dev_comm, kDefaultGinContextIndex);
-
-  // Get window handles
   ncclWindow_t dst_win = window_;
   ncclWindow_t src_win = static_cast<ncclWindow_t>(src_buf.backend_window);
 
-  // Determine signal and counter actions
-  if (signal_id >= 0 && counter_id >= 0) {
-    // Both signal and counter
-    gin.put(
-        ncclTeamWorld(dev_comm),
-        dst_rank,
-        dst_win,
-        dst_offset,
-        src_win,
-        src_offset,
-        bytes,
-        ncclGin_SignalInc{static_cast<ncclGinSignal_t>(signal_id)},
-        ncclGin_CounterInc{static_cast<ncclGinCounter_t>(counter_id)},
-        ncclCoopThread{});
-  } else if (signal_id >= 0) {
-    // Signal only
-    gin.put(
-        ncclTeamWorld(dev_comm),
-        dst_rank,
-        dst_win,
-        dst_offset,
-        src_win,
-        src_offset,
-        bytes,
-        ncclGin_SignalInc{static_cast<ncclGinSignal_t>(signal_id)},
-        ncclGin_None{},
-        ncclCoopThread{});
-  } else if (counter_id >= 0) {
-    // Counter only
-    gin.put(
-        ncclTeamWorld(dev_comm),
-        dst_rank,
-        dst_win,
-        dst_offset,
-        src_win,
-        src_offset,
-        bytes,
-        ncclGin_None{},
-        ncclGin_CounterInc{static_cast<ncclGinCounter_t>(counter_id)},
-        ncclCoopThread{});
+  if (ncclTeamRankIsMember(
+          ncclTeamLsa(dev_comm), ncclTeamWorld(dev_comm), dst_rank)) {
+    // ---- LSA (NVLink) path ----
+    // Direct memcpy through NVLink-mapped pointers.
+    void* src = ncclGetLocalPointer(src_win, src_offset);
+    void* dst = ncclGetPeerPointer(dst_win, dst_offset, dst_rank);
+
+    detail::memcpy_nvl(dst, src, bytes);
+    // No explicit fence needed here — the signal() call below uses
+    // st.release.sys / atom.release.sys which orders all prior stores
+    // (including the memcpy data writes) before the signal write.
+
+    if (signal_id >= 0) {
+      signal(dst_rank, signal_id, SignalOp::ADD, 1);
+    }
+    // counter_id silently ignored for LSA — counters are GIN hardware only
   } else {
-    // Neither signal nor counter
-    gin.put(
-        ncclTeamWorld(dev_comm),
-        dst_rank,
-        dst_win,
-        dst_offset,
-        src_win,
-        src_offset,
-        bytes,
-        ncclGin_None{},
-        ncclGin_None{},
-        ncclCoopThread{});
+    // ---- GIN (RDMA) path ----
+    ncclGin gin(dev_comm, kDefaultGinContextIndex);
+
+    if (counter_id >= 0) {
+      gin.put(
+          ncclTeamWorld(dev_comm),
+          dst_rank,
+          dst_win,
+          dst_offset,
+          src_win,
+          src_offset,
+          bytes,
+          ncclGin_None{},
+          ncclGin_CounterInc{static_cast<ncclGinCounter_t>(counter_id)},
+          ncclCoopThread{});
+    } else {
+      gin.put(
+          ncclTeamWorld(dev_comm),
+          dst_rank,
+          dst_win,
+          dst_offset,
+          src_win,
+          src_offset,
+          bytes,
+          ncclGin_None{},
+          ncclGin_None{},
+          ncclCoopThread{});
+    }
+
+    if (signal_id >= 0) {
+      signal(dst_rank, signal_id, SignalOp::ADD, 1);
+    }
   }
-
-  return 0;
-}
-
-// =============================================================================
-// TorchCommDeviceWindow<NCCLDeviceBackend> Signal Operations
-// =============================================================================
-
-template <>
-__device__ inline int TorchCommDeviceWindow<NCCLDeviceBackend>::signal(
-    int peer,
-    int signal_id,
-    SignalOp op,
-    uint64_t value) {
-  // Only ADD operation is supported by NCCL GIN
-  // SET can be added later if NCCL adds support
-  if (op != SignalOp::ADD) {
-    return -1; // Unsupported signal operation
-  }
-
-  const ncclDevComm& dev_comm = comm_;
-  ncclGin gin(dev_comm, kDefaultGinContextIndex);
-
-  gin.signal(
-      ncclTeamWorld(dev_comm),
-      peer,
-      ncclGin_SignalAdd{static_cast<ncclGinSignal_t>(signal_id), value},
-      ncclCoopThread{});
 
   return 0;
 }
@@ -154,56 +295,85 @@ __device__ inline int TorchCommDeviceWindow<NCCLDeviceBackend>::wait_signal(
     int signal_id,
     CmpOp cmp,
     uint64_t value) {
-  // Only GE comparison is supported by NCCL GIN
-  // Other comparison operators can be added later if needed
-  if (cmp != CmpOp::GE) {
-    return -1; // Unsupported comparison operator
-  }
-
   const ncclDevComm& dev_comm = comm_;
-  ncclGin gin(dev_comm, kDefaultGinContextIndex);
+  uint64_t* base = detail::signal_slot_base(
+      dev_comm, signal_buffer_handle_, signal_id, num_ranks_);
 
-  gin.waitSignal(
-      ncclCoopThread{},
-      static_cast<ncclGinSignal_t>(signal_id),
-      value,
-      kDefaultSignalBits);
+  // Spin-poll with acquire loads
+  // that once we see a signal value, all prior stores from the signaler
+  // (i.e. the data written by put()) are visible to us.
+  for (;;) {
+    uint64_t sum = 0;
+    for (int i = 0; i < num_ranks_; i++) {
+      sum += comms::device::ld_acquire_sys_global(base + i);
+    }
+    if (detail::cmp_op(cmp, sum, value)) {
+      return 0;
+    }
+  }
+}
 
-  return 0;
+template <>
+__device__ inline int
+TorchCommDeviceWindow<NCCLDeviceBackend>::wait_signal_from(
+    int peer,
+    int signal_id,
+    CmpOp cmp,
+    uint64_t value) {
+  const ncclDevComm& dev_comm = comm_;
+  uint64_t* slot = detail::signal_slot_base(
+                       dev_comm, signal_buffer_handle_, signal_id, num_ranks_) +
+      peer;
+
+  for (;;) {
+    uint64_t val = comms::device::ld_acquire_sys_global(slot);
+    if (detail::cmp_op(cmp, val, value)) {
+      return 0;
+    }
+  }
 }
 
 template <>
 __device__ inline uint64_t
 TorchCommDeviceWindow<NCCLDeviceBackend>::read_signal(int signal_id) const {
   const ncclDevComm& dev_comm = comm_;
-  ncclGin gin(dev_comm, kDefaultGinContextIndex);
+  uint64_t* base = detail::signal_slot_base(
+      dev_comm, signal_buffer_handle_, signal_id, num_ranks_);
 
-  return gin.readSignal(
-      static_cast<ncclGinSignal_t>(signal_id), kDefaultSignalBits);
+  uint64_t sum = 0;
+  for (int i = 0; i < num_ranks_; i++) {
+    sum += comms::device::ld_acquire_sys_global(base + i);
+  }
+  return sum;
 }
 
 template <>
 __device__ inline void TorchCommDeviceWindow<NCCLDeviceBackend>::reset_signal(
     int signal_id) {
   const ncclDevComm& dev_comm = comm_;
-  ncclGin gin(dev_comm, kDefaultGinContextIndex);
+  uint64_t* base = detail::signal_slot_base(
+      dev_comm, signal_buffer_handle_, signal_id, num_ranks_);
 
-  gin.resetSignal(static_cast<ncclGinSignal_t>(signal_id));
+  for (int i = 0; i < num_ranks_; i++) {
+    comms::device::st_release_sys_global(base + i, 0ULL);
+  }
 }
 
 // =============================================================================
 // TorchCommDeviceWindow<NCCLDeviceBackend> Counter Operations
 // =============================================================================
+// Counters remain on GIN hardware — they track local DMA completion
+// (NIC increments after source buffer read). Only meaningful for RDMA path.
 
 template <>
 __device__ inline int TorchCommDeviceWindow<NCCLDeviceBackend>::wait_local(
     int op_id,
     CmpOp cmp,
     uint64_t value) {
-  // Only GE comparison is supported by NCCL GIN
-  // Other comparison operators can be added later if needed
   if (cmp != CmpOp::GE) {
-    return -1; // Unsupported comparison operator
+    // GIN hardware counters only support GE comparison.
+    __trap();
+    return -1; // Unreachable
   }
 
   const ncclDevComm& dev_comm = comm_;
@@ -243,35 +413,33 @@ __device__ inline void TorchCommDeviceWindow<NCCLDeviceBackend>::reset_counter(
 
 template <>
 __device__ inline int TorchCommDeviceWindow<NCCLDeviceBackend>::fence() {
-  // No-op for NCCL GIN backend.
-  // NCCL GIN guarantees ordering: put and signal operations to the same peer
-  // are delivered in order. No explicit fence is needed.
-  // TODO: Implement proper fence when adding LSA (NVLink/PCIe direct) support.
+  // fence.acq_rel.sys ensures all prior stores (NVLink data writes, signal
+  // updates) are globally visible before subsequent operations. Strictly
+  // stronger than release — use when you need a full barrier rather than
+  // a paired release/acquire on a specific location.
+  comms::device::fence_acq_rel_sys();
   return 0;
 }
 
 template <>
 __device__ inline int TorchCommDeviceWindow<NCCLDeviceBackend>::flush() {
+  // Ensure NVLink stores are globally visible, then flush any pending
+  // GIN WQEs (RDMA work queue entries).
+  comms::device::fence_acq_rel_sys();
+
   const ncclDevComm& dev_comm = comm_;
   ncclGin gin(dev_comm, kDefaultGinContextIndex);
-
   gin.flush(ncclCoopThread{});
+
   return 0;
 }
 
 template <>
 __device__ inline int TorchCommDeviceWindow<NCCLDeviceBackend>::barrier(
     int barrier_id) {
-  // NOT IMPLEMENTED - trap to prevent accidental usage.
-  //
-  // Full world-scope barrier requires host-side setup:
-  //   - ncclTeamTagRail constructor only syncs ranks within the same NIC rail
-  //   - Full constructor needs ncclGinBarrierHandle allocated at host via
-  //     ncclGinBarrierCreateRequirement(comm, ncclTeamWorld, ...) BEFORE
-  //     ncclDevCommCreate()
-  //
-  // Future: Allocate world-scope barrier handle at host, store in
-  // TorchCommDeviceCommState, use full ncclGinBarrierSession constructor.
+  // NOT IMPLEMENTED — barrier requires LSA barrier handle allocation
+  // at host side (ncclLsaBarrierCreateRequirement). Will be added in a
+  // future phase.
   (void)barrier_id;
   __trap();
   return -1; // Unreachable

--- a/comms/torchcomms/device/ncclx/tests/unit/cpp/NCCLDeviceBackendTest.cpp
+++ b/comms/torchcomms/device/ncclx/tests/unit/cpp/NCCLDeviceBackendTest.cpp
@@ -222,7 +222,7 @@ TEST_F(NCCLDeviceBackendTest, CreateDeviceWindowConfigIsPassedCorrectly) {
       1024);
 
   ASSERT_NE(device_window, nullptr);
-  EXPECT_EQ(captured_reqs.ginSignalCount, config.signal_count);
+  EXPECT_EQ(captured_reqs.ginSignalCount, 0);
   EXPECT_EQ(captured_reqs.ginCounterCount, config.counter_count);
   EXPECT_EQ(captured_reqs.barrierCount, config.barrier_count);
   EXPECT_TRUE(captured_reqs.ginForceEnable);

--- a/comms/torchcomms/tests/integration/cpp/DeviceApiTest.hpp
+++ b/comms/torchcomms/tests/integration/cpp/DeviceApiTest.hpp
@@ -53,6 +53,13 @@ class DeviceApiTest : public ::testing::Test {
   // fetch-and-add
   void testGinAtomicAdd();
 
+  // Per-peer signal test - validates resource buffer signal model
+  // Each rank signals the next in a ring, receiver aggregates per-peer slots
+  void testPerPeerSignal();
+
+  // Wait signal from specific peer test - validates point-to-point sync
+  void testWaitSignalFrom();
+
   // Member variables
   std::unique_ptr<TorchCommTestWrapper> wrapper_;
   std::shared_ptr<torch::comms::TorchComm> torchcomm_;

--- a/comms/torchcomms/tests/integration/cpp/DeviceApiTestKernels.cuh
+++ b/comms/torchcomms/tests/integration/cpp/DeviceApiTestKernels.cuh
@@ -72,7 +72,8 @@ void launchDeviceReadSignalKernel(
     cudaStream_t stream);
 
 // Launch GIN atomicAdd test kernel - performs remote atomic fetch-and-add
-// on a uint64_t in the destination window, then signals the destination rank.
+// on a uint64_t in the destination window, then signals the destination rank
+// using resource buffer signals.
 // Note: DeviceWindowNCCL* is a DEVICE pointer (allocated via cudaMalloc)
 void launchDeviceGinAtomicAddKernel(
     DeviceWindowNCCL* win,
@@ -80,6 +81,26 @@ void launchDeviceGinAtomicAddKernel(
     uint64_t add_value,
     int dst_rank,
     int signal_id,
+    cudaStream_t stream);
+
+// Launch standalone signal kernel - signals a peer without data transfer.
+// Tests per-peer resource buffer signal model in isolation.
+void launchDeviceSignalKernel(
+    DeviceWindowNCCL* win,
+    int peer,
+    int signal_id,
+    SignalOp op,
+    uint64_t value,
+    cudaStream_t stream);
+
+// Launch wait signal from specific peer kernel - waits for signal from a
+// single peer (not aggregated). Tests point-to-point synchronization.
+void launchDeviceWaitSignalFromKernel(
+    DeviceWindowNCCL* win,
+    int peer,
+    int signal_id,
+    CmpOp cmp,
+    uint64_t value,
     cudaStream_t stream);
 
 } // namespace torchcomms::device::test


### PR DESCRIPTION
Summary:
## Summary

Implements phases 2 and 3 of the LSA implementation plan: per-peer signal slot model and NVLink direct load/store data path for the NCCL device backend.

### Why

The device API previously only supported GIN (RDMA) for all operations. Same-node NVLink-connected peers can now use direct load/store for data transfer (`put`) and signaling, avoiding RDMA overhead for intra-node communication. Each operation dispatches at runtime based on peer reachability via `ncclTeamRankIsMember(ncclTeamLsa)`.

### Signal Model

Signals use per-peer resource buffer slots (`slots[signal_id * num_ranks + sender_world_rank]`) instead of GIN hardware signals. This avoids cross-transport atomicity hazards — NVLink atomics and RDMA atomics to the same address are not serialized by hardware. Each sender writes only to its own slot, and the receiver sums all slots for aggregate wait.

### Key Changes

- **`TorchCommDeviceNCCLX.cuh`**: Full LSA+GIN dispatch for `put`, `signal`, `wait_signal`, `wait_signal_from`, `read_signal`, `reset_signal`, `fence`, `flush`. Uses PTX acquire/release instructions (`ld.acquire.sys.global`, `st.release.sys.global`, `atom.release.sys.add`) from `comms/common/AtomicUtils.cuh` instead of volatile loads/stores + `__threadfence_system()` — strictly more efficient per-operation ordering vs full memory barriers.
- **`TorchCommDeviceWindow.hpp`**: Added `wait_signal_from()` declaration for point-to-point signal wait.
- **`DeviceApiTestKernels.cu`**: Updated existing kernel to use resource buffer signals; added `deviceSignalKernel`, `deviceWaitSignalFromKernel`, `deviceReadSignalKernel`.
- **`DeviceApiTest.cpp`**: Added `testPerPeerSignal` (ring signal + aggregate wait) and `testWaitSignalFrom` (ring signal + per-peer wait) integration tests.
- **BUCK**: Added `//comms/common:atomic_utils` dependency.

Differential Revision: D92890793
