### PR TITLE
Add ibError logging logic

### DIFF
--- a/comms/analyzer/if/CommsTracingService.thrift
+++ b/comms/analyzer/if/CommsTracingService.thrift
@@ -180,6 +180,23 @@ struct ProcessGlobalErrors {
   2: list<ErrorAndStackTrace> errorAndStackTraces;
 }
 
+struct IbCompletionError {
+  1: i64 timestampMs;
+  2: string peer;
+  3: string statusStr;
+  4: i32 status;
+  5: string opcodeStr;
+  6: i32 opcode;
+  7: i32 reqSize;
+  8: i64 vendorErr;
+  9: string reqType;
+  10: string localGid;
+  11: string remoteGid;
+  12: string hcaName;
+  13: string scaleupDomain;
+  14: string localHostname;
+}
+
 // NOTE: Keep in sync with commDump.cc
 // The field names must exactly match the json keys.
 // The values themselves are serialized json.
@@ -266,6 +283,7 @@ struct GetCommsResponse {
   // For inference, this is 0
   5: i64 step;
   6: i64 stepStartTimeNs;
+  7: list<IbCompletionError> ibErrors;
 }
 
 // Implementors of this service expose tracing information about communications

--- a/comms/ncclx/v2_28/meta/analyzer/NCCLXCommsTracingServiceHandler.cc
+++ b/comms/ncclx/v2_28/meta/analyzer/NCCLXCommsTracingServiceHandler.cc
@@ -12,6 +12,7 @@
 #include <thrift/lib/cpp2/protocol/Serializer.h>
 
 #include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/logger/ProcessGlobalErrorsUtil.h"
 #include "comms/utils/trainer/TrainerContext.h"
 #include "meta/RankUtil.h"
 
@@ -69,6 +70,31 @@ NCCLXCommsTracingServiceHandler::co_getComms(
     auto s = folly::toJson(obj);
     apache::thrift::SimpleJSONSerializer::deserialize(s, ncclParsedEntry);
   }
+
+  {
+    auto globalState = ProcessGlobalErrorsUtil::getAllState();
+    for (const auto& ibErr : globalState.ibCompletionErrors) {
+      comms::IbCompletionError thriftErr;
+      thriftErr.timestampMs() = ibErr.timestampMs.count();
+      thriftErr.peer() = ibErr.peer;
+      thriftErr.statusStr() = ibErr.statusStr;
+      thriftErr.status() = ibErr.status;
+      thriftErr.opcodeStr() = ibErr.opcodeStr;
+      thriftErr.opcode() = ibErr.opcode;
+      thriftErr.reqSize() = ibErr.reqSize;
+      thriftErr.vendorErr() = static_cast<int64_t>(ibErr.vendorErr);
+      thriftErr.reqType() = ibErr.reqType;
+      thriftErr.localGid() = ibErr.localGid;
+      thriftErr.remoteGid() = ibErr.remoteGid;
+      thriftErr.hcaName() = ibErr.hcaName;
+      thriftErr.scaleupDomain() = ibErr.scaleupDomain;
+      thriftErr.localHostname() = ibErr.localHostname;
+      response.ibErrors()->push_back(std::move(thriftErr));
+    }
+    // Flush after reading so errors are only reported once
+    ProcessGlobalErrorsUtil::clearIbCompletionErrors();
+  }
+
   co_return std::make_unique<comms::GetCommsResponse>(std::move(response));
 }
 

--- a/comms/ncclx/v2_28/meta/logger/tests/ProcessGlobalErrorsUtilTest.cc
+++ b/comms/ncclx/v2_28/meta/logger/tests/ProcessGlobalErrorsUtilTest.cc
@@ -82,3 +82,116 @@ TEST_F(ProcessGlobalErrorsUtilTest, LogStackTraceOnErrorReturn) {
   auto state2 = ProcessGlobalErrorsUtil::getAllState();
   ASSERT_EQ(2, state2.errorAndStackTraces.size());
 }
+
+TEST_F(ProcessGlobalErrorsUtilTest, AddIbCompletionError) {
+  auto state1 = ProcessGlobalErrorsUtil::getAllState();
+  ASSERT_TRUE(state1.ibCompletionErrors.empty());
+
+  // Ensure we keep only the last N errors
+  for (int i = 0; i < NCCL_PROCESS_GLOBAL_ERRORS_MAX_STACK_TRACES * 2; ++i) {
+    ProcessGlobalErrorsUtil::IbCompletionError ibErr;
+    ibErr.peer = "peer_addr";
+    ibErr.statusStr = "IBV_WC_REM_ACCESS_ERR";
+    ibErr.status = 5;
+    ibErr.opcodeStr = "IBV_WC_RDMA_WRITE";
+    ibErr.opcode = 0;
+    ibErr.reqSize = 1024;
+    ibErr.vendorErr = 42;
+    ibErr.reqType = "send";
+    ibErr.localGid = "fe80::1";
+    ibErr.remoteGid = "fe80::2";
+    ibErr.hcaName = "mlx5_0";
+    ProcessGlobalErrorsUtil::addIbCompletionError(std::move(ibErr));
+  }
+
+  auto state2 = ProcessGlobalErrorsUtil::getAllState();
+  ASSERT_EQ(
+      NCCL_PROCESS_GLOBAL_ERRORS_MAX_STACK_TRACES,
+      state2.ibCompletionErrors.size());
+  for (const auto& ibErr : state2.ibCompletionErrors) {
+    ASSERT_GT(ibErr.timestampMs.count(), 0);
+    ASSERT_EQ("peer_addr", ibErr.peer);
+    ASSERT_EQ("IBV_WC_REM_ACCESS_ERR", ibErr.statusStr);
+    ASSERT_EQ(5, ibErr.status);
+    ASSERT_EQ("IBV_WC_RDMA_WRITE", ibErr.opcodeStr);
+    ASSERT_EQ(0, ibErr.opcode);
+    ASSERT_EQ(1024, ibErr.reqSize);
+    ASSERT_EQ(42u, ibErr.vendorErr);
+    ASSERT_EQ("send", ibErr.reqType);
+    ASSERT_EQ("fe80::1", ibErr.localGid);
+    ASSERT_EQ("fe80::2", ibErr.remoteGid);
+    ASSERT_EQ("mlx5_0", ibErr.hcaName);
+  }
+}
+
+TEST_F(ProcessGlobalErrorsUtilTest, AddIbCompletionErrorNoGids) {
+  ProcessGlobalErrorsUtil::IbCompletionError ibErr;
+  ibErr.peer = "peer_addr";
+  ibErr.statusStr = "IBV_WC_RETRY_EXC_ERR";
+  ibErr.status = 12;
+  ibErr.opcodeStr = "IBV_WC_SEND";
+  ibErr.opcode = 1;
+  ibErr.reqSize = 512;
+  ibErr.vendorErr = 0;
+  ibErr.reqType = "recv";
+  ibErr.hcaName = "mlx5_1";
+  // localGid and remoteGid intentionally left empty
+  ProcessGlobalErrorsUtil::addIbCompletionError(std::move(ibErr));
+
+  auto state = ProcessGlobalErrorsUtil::getAllState();
+  ASSERT_EQ(1, state.ibCompletionErrors.size());
+  const auto& stored = state.ibCompletionErrors.front();
+  ASSERT_GT(stored.timestampMs.count(), 0);
+  ASSERT_EQ("peer_addr", stored.peer);
+  ASSERT_EQ("", stored.localGid);
+  ASSERT_EQ("", stored.remoteGid);
+  ASSERT_EQ("mlx5_1", stored.hcaName);
+}
+
+TEST_F(ProcessGlobalErrorsUtilTest, ClearIbCompletionErrors) {
+  // Add some errors
+  for (int i = 0; i < 3; ++i) {
+    ProcessGlobalErrorsUtil::IbCompletionError ibErr;
+    ibErr.peer = "peer_addr";
+    ibErr.statusStr = "IBV_WC_REM_ACCESS_ERR";
+    ibErr.status = 5;
+    ibErr.opcodeStr = "IBV_WC_RDMA_WRITE";
+    ibErr.opcode = 0;
+    ibErr.reqSize = 1024;
+    ibErr.vendorErr = 0;
+    ibErr.reqType = "send";
+    ibErr.hcaName = "mlx5_0";
+    ProcessGlobalErrorsUtil::addIbCompletionError(std::move(ibErr));
+  }
+
+  auto state1 = ProcessGlobalErrorsUtil::getAllState();
+  ASSERT_EQ(3, state1.ibCompletionErrors.size());
+
+  // Clear and verify empty
+  ProcessGlobalErrorsUtil::clearIbCompletionErrors();
+  auto state2 = ProcessGlobalErrorsUtil::getAllState();
+  ASSERT_TRUE(state2.ibCompletionErrors.empty());
+
+  // Verify other error types are unaffected
+  ProcessGlobalErrorsUtil::setNic("beth0", 8000, "bad");
+  ProcessGlobalErrorsUtil::addErrorAndStackTrace("error", {"s1"});
+
+  ProcessGlobalErrorsUtil::IbCompletionError ibErr;
+  ibErr.peer = "peer_addr";
+  ibErr.statusStr = "IBV_WC_REM_ACCESS_ERR";
+  ibErr.status = 5;
+  ibErr.opcodeStr = "IBV_WC_RDMA_WRITE";
+  ibErr.opcode = 0;
+  ibErr.reqSize = 1024;
+  ibErr.vendorErr = 0;
+  ibErr.reqType = "send";
+  ibErr.hcaName = "mlx5_0";
+  ProcessGlobalErrorsUtil::addIbCompletionError(std::move(ibErr));
+
+  ProcessGlobalErrorsUtil::clearIbCompletionErrors();
+
+  auto state3 = ProcessGlobalErrorsUtil::getAllState();
+  ASSERT_TRUE(state3.ibCompletionErrors.empty());
+  ASSERT_FALSE(state3.badNics.empty());
+  ASSERT_FALSE(state3.errorAndStackTraces.empty());
+}

--- a/comms/utils/logger/ProcessGlobalErrorsUtil.cc
+++ b/comms/utils/logger/ProcessGlobalErrorsUtil.cc
@@ -6,12 +6,29 @@
 #include <folly/Synchronized.h>
 
 #include "comms/utils/cvars/nccl_cvars.h" // @manual=fbcode//comms/utils/cvars:ncclx-cvars
+#include "comms/utils/logger/BackendTopologyUtil.h"
 #include "comms/utils/logger/ScubaLogger.h"
 
 namespace {
 std::chrono::milliseconds nowTs() {
   return std::chrono::duration_cast<std::chrono::milliseconds>(
       std::chrono::system_clock::now().time_since_epoch());
+}
+
+std::string readHostname() {
+  auto topology = BackendTopologyUtil::getBackendTopology("/etc/fbwhoami");
+  if (topology.has_value()) {
+    return topology->host;
+  }
+  return "";
+}
+
+std::string readScaleupDomain() {
+  auto topology = BackendTopologyUtil::getBackendTopology("/etc/fbwhoami");
+  if (topology.has_value()) {
+    return topology->scaleUp.domain;
+  }
+  return "";
 }
 
 struct AllStateTag {};
@@ -76,10 +93,67 @@ void ProcessGlobalErrorsUtil::addErrorAndStackTrace(
 }
 
 /* static */
+void ProcessGlobalErrorsUtil::addIbCompletionError(IbCompletionError error) {
+  if (NCCL_PROCESS_GLOBAL_ERRORS_MAX_STACK_TRACES == 0) {
+    return;
+  }
+  auto statePtr = kAllState.try_get();
+  if (!statePtr) {
+    return;
+  }
+  statePtr->withWLock([&](auto& state) {
+    // If we are at capacity, remove the earliest one
+    if (state.ibCompletionErrors.size() ==
+        NCCL_PROCESS_GLOBAL_ERRORS_MAX_STACK_TRACES) {
+      state.ibCompletionErrors.pop_front();
+    }
+    error.timestampMs = nowTs();
+    state.ibCompletionErrors.push_back(std::move(error));
+  });
+}
+
+/* static */
+void ProcessGlobalErrorsUtil::clearIbCompletionErrors() {
+  auto statePtr = kAllState.try_get();
+  if (!statePtr) {
+    return;
+  }
+  statePtr->withWLock([](auto& state) { state.ibCompletionErrors.clear(); });
+}
+
+/* static */
 ProcessGlobalErrorsUtil::State ProcessGlobalErrorsUtil::getAllState() {
   auto statePtr = kAllState.try_get();
   if (!statePtr) {
     return ProcessGlobalErrorsUtil::State{};
   }
   return statePtr->copy();
+}
+
+/* static */
+std::string ProcessGlobalErrorsUtil::getHostname() {
+  auto statePtr = kAllState.try_get();
+  if (!statePtr) {
+    return "";
+  }
+  return statePtr->withWLock([](auto& state) -> std::string {
+    if (state.hostname.empty()) {
+      state.hostname = readHostname();
+    }
+    return state.hostname;
+  });
+}
+
+/* static */
+std::string ProcessGlobalErrorsUtil::getScaleupDomain() {
+  auto statePtr = kAllState.try_get();
+  if (!statePtr) {
+    return "";
+  }
+  return statePtr->withWLock([](auto& state) -> std::string {
+    if (state.scaleupDomain.empty()) {
+      state.scaleupDomain = readScaleupDomain();
+    }
+    return state.scaleupDomain;
+  });
 }


### PR DESCRIPTION
Summary:
This diff adds structured IB completion error reporting from the transport layer (net_ib.cc) to the NCCLX comms analyzer thrift service (GetCommsResponse). Errors are stored in the process-global ProcessGlobalErrorsUtil singleton and read directly by the handler. Each error is reported only once: the handler flushes the IB error state after populating the response.

IB errors are per-rank, not per-communicator, so ibErrors is a top-level field on GetCommsResponse. The handler reads from ProcessGlobalErrorsUtil::getAllState() directly, bypassing the per-comm commDump.cc serialization path.

Differential Revision: D92873340


