### PR TITLE
use ibverbx to setup host-level multipeerIbgda transport

### DIFF
--- a/comms/pipes/MultipeerIbgdaTransport.h
+++ b/comms/pipes/MultipeerIbgdaTransport.h
@@ -9,9 +9,9 @@
 #include <unordered_map>
 #include <vector>
 
-#include <doca_gpunetio_host.h>
-#include <infiniband/verbs.h>
+#include "comms/ctran/ibverbx/Ibverbx.h"
 
+#include <doca_gpunetio_host.h>
 #include "comms/ctran/interfaces/IBootstrap.h"
 #include "comms/pipes/IbgdaBuffer.h"
 
@@ -329,11 +329,11 @@ class MultipeerIbgdaTransport {
   // DOCA GPU context
   doca_gpu* docaGpu_{nullptr};
 
-  // IB verbs resources
-  ibv_context* ibvContext_{nullptr};
-  ibv_pd* ibvPd_{nullptr};
+  // IB verbs resources (ibverbx RAII wrappers)
+  std::optional<ibverbx::IbvDevice> ibvDevice_;
+  std::optional<ibverbx::IbvPd> ibvPd_;
   doca_verbs_ah_attr* ahAttr_{nullptr};
-  ibv_gid localGid_{};
+  ibverbx::ibv_gid localGid_{};
 
   // High-level QPs (one per peer)
   std::vector<doca_gpu_verbs_qp_hl*> qpHlList_;
@@ -343,10 +343,10 @@ class MultipeerIbgdaTransport {
   std::size_t signalBufferSize_{0};
 
   // Memory regions for signal buffer
-  ibv_mr* signalMr_{nullptr};
+  std::optional<ibverbx::IbvMr> signalMr_;
 
-  // User-registered buffers (maps ptr -> ibv_mr*)
-  std::unordered_map<void*, ibv_mr*> registeredBuffers_;
+  // User-registered buffers (maps ptr -> IbvMr)
+  std::unordered_map<void*, ibverbx::IbvMr> registeredBuffers_;
 
   // GPU PCIe bus ID and NIC device name
   std::string gpuPciBusId_;


### PR DESCRIPTION
Summary:
Replace raw ibverbs API calls (ibv_get_device_list, ibv_open_device, ibv_alloc_pd, ibv_reg_mr, etc.) in MultipeerIbgdaTransport with ibverbx RAII wrappers (IbvDevice, IbvPd, IbvMr)

Gaining automatic resource cleanup, eliminating manual ibv_dereg_mr/ibv_dealloc_pd/ibv_close_device calls in the destructor and
deregisterBuffer(). 

DOCA-specific QP lifecycle code is unchanged; reinterpret_cast
the ibverbx:: and :: type namespaces at the DOCA API boundary.

Reviewed By: siyengar, cenzhaometa

Differential Revision: D92661884


