### PR TITLE
Fix for build_rccl.sh

### DIFF
--- a/build_rccl.sh
+++ b/build_rccl.sh
@@ -75,5 +75,5 @@ else
   export RCCL_HOME=$ROCM_HOME/lib
 fi
 
-popd || exit 1
+popd || true
 pip install numpy


### PR DESCRIPTION
Summary: If librccl.so is found on system and builds using system libs, it tries to popd but fails with exit 1 since it did not go into directory.

Differential Revision: D92971319


