### PR TITLE
Add ncclMetaDebugLog to fix logger passing file/func separately

### DIFF
--- a/comms/ncclx/v2_28/src/include/debug.h
+++ b/comms/ncclx/v2_28/src/include/debug.h
@@ -22,18 +22,20 @@ extern FILE *ncclDebugFile;
 
 void ncclDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *filefunc, int line, const char *fmt, ...) __attribute__ ((format (printf, 5, 6)));
 
-void ncclMetaDebugLogWithScuba(ncclDebugLogLevel level, unsigned long flags, const char *filefunc, int line, const char *fmt, ...) __attribute__ ((format (printf, 5, 6)));
+void ncclMetaDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *file, const char *func, int line, const char *fmt, ...) __attribute__ ((format (printf, 6, 7)));
+
+void ncclMetaDebugLogWithScuba(ncclDebugLogLevel level, unsigned long flags, const char *file, const char *func, int line, const char *fmt, ...) __attribute__ ((format (printf, 6, 7)));
 
 // Let code temporarily downgrade WARN into INFO
 extern thread_local int ncclDebugNoWarn;
 extern char ncclLastError[];
 
-#define VERSION(...) ncclDebugLog(NCCL_LOG_VERSION, NCCL_ALL, __func__, __LINE__, __VA_ARGS__)
-#define WARN(...) ncclDebugLog(NCCL_LOG_WARN, NCCL_ALL, __func__, __LINE__, __VA_ARGS__)
-#define ERR(...) ncclDebugLog(NCCL_LOG_ERROR, NCCL_ALL, __func__, __LINE__, __VA_ARGS__)
+#define VERSION(...) ncclMetaDebugLog(NCCL_LOG_VERSION, NCCL_ALL, __FILE__, __func__, __LINE__, __VA_ARGS__)
+#define WARN(...) ncclMetaDebugLog(NCCL_LOG_WARN, NCCL_ALL, __FILE__, __func__, __LINE__, __VA_ARGS__)
+#define ERR(...) ncclMetaDebugLog(NCCL_LOG_ERROR, NCCL_ALL, __FILE__, __func__, __LINE__, __VA_ARGS__)
 
-#define WARN_WITH_SCUBA(...) ncclMetaDebugLogWithScuba(NCCL_LOG_WARN, NCCL_ALL, __func__, __LINE__, __VA_ARGS__)
-#define ERR_WITH_SCUBA(...) ncclMetaDebugLogWithScuba(NCCL_LOG_ERROR, NCCL_ALL, __func__, __LINE__, __VA_ARGS__)
+#define WARN_WITH_SCUBA(...) ncclMetaDebugLogWithScuba(NCCL_LOG_WARN, NCCL_ALL, __FILE__, __func__, __LINE__, __VA_ARGS__)
+#define ERR_WITH_SCUBA(...) ncclMetaDebugLogWithScuba(NCCL_LOG_ERROR, NCCL_ALL, __FILE__, __func__, __LINE__, __VA_ARGS__)
 
 
 #define NOWARN(EXPR, FLAGS) \
@@ -48,14 +50,14 @@ extern char ncclLastError[];
     do{ \
         int level = __atomic_load_n(&ncclDebugLevel, __ATOMIC_ACQUIRE); \
         if((level >= NCCL_LOG_INFO && ((unsigned long)(FLAGS) & ncclDebugMask)) || (level < 0)) \
-            ncclDebugLog(NCCL_LOG_INFO, (unsigned long)(FLAGS), __func__, __LINE__, __VA_ARGS__); \
+            ncclMetaDebugLog(NCCL_LOG_INFO, (unsigned long)(FLAGS), __FILE__, __func__, __LINE__, __VA_ARGS__); \
     } while(0)
 
 #define TRACE_CALL(...) \
     do { \
         int level = __atomic_load_n(&ncclDebugLevel, __ATOMIC_ACQUIRE); \
         if((level >= NCCL_LOG_TRACE && (NCCL_CALL & ncclDebugMask)) || (level < 0)) { \
-            ncclDebugLog(NCCL_LOG_TRACE, NCCL_CALL, __func__, __LINE__, __VA_ARGS__); \
+            ncclMetaDebugLog(NCCL_LOG_TRACE, NCCL_CALL, __FILE__, __func__, __LINE__, __VA_ARGS__); \
         } \
     } while (0)
 
@@ -64,7 +66,7 @@ extern char ncclLastError[];
     do { \
         int level = __atomic_load_n(&ncclDebugLevel, __ATOMIC_ACQUIRE); \
         if ((level >= NCCL_LOG_TRACE && ((unsigned long)(FLAGS) & ncclDebugMask)) || (level < 0)) { \
-            ncclDebugLog(NCCL_LOG_TRACE, (unsigned long)(FLAGS), __func__, __LINE__, __VA_ARGS__); \
+            ncclMetaDebugLog(NCCL_LOG_TRACE, (unsigned long)(FLAGS), __FILE__, __func__, __LINE__, __VA_ARGS__); \
         } \
     } while (0)
 #else


### PR DESCRIPTION
Summary:
In ncclx v2.28, the upstream ncclDebugLog replaced Meta's ncclMetaDebugLog, causing two bugs: (1) nonErrorMessage was being updated with INFO logs and (2) WARN/ERROR logs were not going to stderr. The root cause is that v2.28 macros pass __func__ as the combined filefunc parameter to ncclDebugLog, which then passes it to LogStreamProcessor as the file argument with "" as func. This breaks folly's log level/category resolution. The fix adds ncclMetaDebugLog with separate file and func parameters (matching v2.27's approach) and updates all macros to call it with __FILE__, __func__, __LINE__. ncclDebugLog is left unchanged to preserve OFI NCCL plugin compatibility. Also updates ncclMetaDebugLogWithScuba to use separate file/func params and call ncclMetaDebugLog.# NCCLx v2.28 Debug Logging Changes and Bug Fixes

## Overview

In **NCCLx v2.28**, the upstream `ncclDebugLog` replaced Meta's `ncclMetaDebugLog`, introducing two key bugs:

1. **INFO logs were updating `nonErrorMessage`**.
2. **WARN/ERROR logs were not being sent to `stderr`**.

## Root Cause

- In v2.28, macros pass `__func__` as the combined `filefunc` parameter to `ncclDebugLog`.
- `ncclDebugLog` then forwards this to `LogStreamProcessor` as the `file` argument, with `""` as `func`.
- This breaks **folly's log level/category resolution**.

## Solution

- **Reintroduce `ncclMetaDebugLog`** with separate `file` and `func` parameters (restoring v2.27's approach).
- **Update all macros** to call `ncclMetaDebugLog` with `__FILE__`, `__func__`, and `__LINE__`.
- **Leave `ncclDebugLog` unchanged** to maintain compatibility with the OFI NCCL plugin.
- **Update `ncclMetaDebugLogWithScuba`** to use separate `file`/`func` parameters and call `ncclMetaDebugLog`.

---

**Summary Table**

| Change                                      | Reason/Impact                                 |
|----------------------------------------------|-----------------------------------------------|
| Re-add `ncclMetaDebugLog` (separate params)  | Fixes log level/category resolution           |
| Update macros to use `__FILE__`, `__func__`, `__LINE__` | Ensures correct log context                   |
| Leave `ncclDebugLog` as-is                   | Preserves OFI NCCL plugin compatibility       |
| Update `ncclMetaDebugLogWithScuba`           | Consistent parameter usage and logging        |

Differential Revision: D92917493


