### PR TITLE
fix work leak via. weak-reference cycle

### DIFF
--- a/comms/torchcomms/tests/unit/cpp/TorchWorkTest.cpp
+++ b/comms/torchcomms/tests/unit/cpp/TorchWorkTest.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+
+#include <c10/util/intrusive_ptr.h>
+#include "comms/torchcomms/TorchWork.hpp"
+
+namespace torch::comms::test {
+
+class TestWork : public TorchWork {
+ public:
+  explicit TestWork(bool* destroyed) : destroyed_(destroyed) {}
+  ~TestWork() override {
+    if (destroyed_) {
+      *destroyed_ = true;
+    }
+  }
+
+  void wait() override {}
+
+  // expose for testing
+  using TorchWork::setCallback;
+
+ private:
+  bool* destroyed_;
+};
+
+// validate that a work object with a callback capturing a weak_intrusive_ptr
+// back to itself is properly destroyed when the last strong reference is
+// dropped. this is the cycle that release_resources() is designed to break...
+TEST(TorchWorkTest, WorkDestroyedAfterCallbackWithWeakRef) {
+  bool destroyed = false;
+  {
+    c10::intrusive_ptr<TestWork> work =
+        c10::make_intrusive<TestWork>(&destroyed);
+    // postHook pattern: callback captures a weak ref to work.
+    c10::weak_intrusive_ptr<TestWork> weak_work(work);
+    // capture creates the prevent-destruction cycle...
+    work->setCallback(
+        [weak_work = std::move(weak_work)]() { (void)weak_work; });
+    EXPECT_FALSE(destroyed);
+  }
+  EXPECT_TRUE(destroyed);
+}
+
+TEST(TorchWorkTest, WorkDestroyedWithoutCallback) {
+  bool destroyed = false;
+  {
+    c10::intrusive_ptr<TestWork> work =
+        c10::make_intrusive<TestWork>(&destroyed);
+    EXPECT_FALSE(destroyed);
+  }
+  EXPECT_TRUE(destroyed);
+}
+
+} // namespace torch::comms::test


### PR DESCRIPTION
Summary:
`TorchComm::postHook()` sets a callback on each work object via `setCallback()`. The callback lambda captures `PostHookArgs` which contains a `weak_intrusive_ptr<TorchWork>` pointing back to the same work object. This creates a weak self-reference: when the strong refcount reaches 0, `c10::intrusive_ptr` calls `release_resources()` and decrements the weak refcount, but the weak_intrusive_ptr inside the callback (stored on the work object itself) still holds a weak reference. The weak refcount never reaches 0, so `delete` is never called and the destructor never fires.

Override `release_resources()` in `TorchWork` to clear `callback_`, breaking the cycle so the weak refcount can reach 0 and the object can be deleted.

Differential Revision: D92987110


