### PR TITLE
Fix inline function linkage error from header refactoring

### DIFF
--- a/comms/ctran/ibverbx/Coordinator.cc
+++ b/comms/ctran/ibverbx/Coordinator.cc
@@ -187,4 +187,21 @@ void Coordinator::unregisterVirtualCq(
   }
 }
 
+void Coordinator::submitRequestToVirtualCq(VirtualCqRequest&& request) {
+  if (request.type == RequestType::SEND) {
+    auto virtualCq = getVirtualSendCq(request.virtualQpNum);
+    virtualCq->processRequest(std::move(request));
+  } else {
+    auto virtualCq = getVirtualRecvCq(request.virtualQpNum);
+    virtualCq->processRequest(std::move(request));
+  }
+}
+
+folly::Expected<VirtualQpResponse, Error> Coordinator::submitRequestToVirtualQp(
+    VirtualQpRequest&& request) {
+  auto virtualQp = getVirtualQpByPhysicalQpNumAndDeviceId(
+      request.physicalQpNum, request.deviceId);
+  return virtualQp->processRequest(std::move(request));
+}
+
 } // namespace ibverbx

--- a/comms/ctran/ibverbx/Coordinator.h
+++ b/comms/ctran/ibverbx/Coordinator.h
@@ -55,8 +55,8 @@ class Coordinator {
   Coordinator(Coordinator&&) = default;
   Coordinator& operator=(Coordinator&&) = default;
 
-  inline void submitRequestToVirtualCq(VirtualCqRequest&& request);
-  inline folly::Expected<VirtualQpResponse, Error> submitRequestToVirtualQp(
+  void submitRequestToVirtualCq(VirtualCqRequest&& request);
+  folly::Expected<VirtualQpResponse, Error> submitRequestToVirtualQp(
       VirtualQpRequest&& request);
 
   // Register APIs for mapping management

--- a/comms/ctran/ibverbx/IbvVirtualCq.h
+++ b/comms/ctran/ibverbx/IbvVirtualCq.h
@@ -137,16 +137,6 @@ class IbvVirtualCq {
       int32_t deviceId) const;
 };
 
-inline void Coordinator::submitRequestToVirtualCq(VirtualCqRequest&& request) {
-  if (request.type == RequestType::SEND) {
-    auto virtualCq = getVirtualSendCq(request.virtualQpNum);
-    virtualCq->processRequest(std::move(request));
-  } else {
-    auto virtualCq = getVirtualRecvCq(request.virtualQpNum);
-    virtualCq->processRequest(std::move(request));
-  }
-}
-
 // IbvVirtualCq inline functions
 inline folly::Expected<std::vector<ibv_wc>, Error> IbvVirtualCq::pollCq(
     int numEntries) {

--- a/comms/ctran/ibverbx/IbvVirtualQp.h
+++ b/comms/ctran/ibverbx/IbvVirtualQp.h
@@ -200,13 +200,6 @@ class IbvVirtualQp {
   inline folly::Expected<folly::Unit, Error> postRecvNotifyImm(int qpIdx = -1);
 };
 
-inline folly::Expected<VirtualQpResponse, Error>
-Coordinator::submitRequestToVirtualQp(VirtualQpRequest&& request) {
-  auto virtualQp = getVirtualQpByPhysicalQpNumAndDeviceId(
-      request.physicalQpNum, request.deviceId);
-  return virtualQp->processRequest(std::move(request));
-}
-
 // IbvVirtualQp inline functions
 inline folly::Expected<folly::Unit, Error>
 IbvVirtualQp::mapPendingSendQueToPhysicalQp(int qpIdx) {


### PR DESCRIPTION
Summary:
Fixes a build failure for a benchmark target in D92781246. This build failure waas introduced by D92788153, which refactored headers to remove `IbvVirtualCq.h` from `IbvVirtualQp.h`.

The issue was that `submitRequestToVirtualCq` and `submitRequestToVirtualQp` were declared as `inline` in `Coordinator.h` but defined in separate header files (`IbvVirtualCq.h` and `IbvVirtualQp.h`). After the header refactoring, when `IbvVirtualQp.h` included `Coordinator.h`, it could see the inline declarations but not the definitions, causing an "undefined inline function" compiler error.

The fix moves these function definitions from the header files to `Coordinator.cc`, making them regular (non-inline) functions. This resolves the linkage issue while maintaining the same functionality.

Differential Revision: D92995240


