### PR TITLE
CtranIpc tryLoad: set shouldSupportCudaMalloc = true on AMD

### DIFF
--- a/comms/ctran/utils/CtranIpc.cc
+++ b/comms/ctran/utils/CtranIpc.cc
@@ -221,6 +221,13 @@ commResult_t ctran::utils::CtranIpcMem::tryLoad(
   if (memType_ == DevMemType::kCumem) {
     FB_COMMCHECK(this->tryLoadCuMem(ptr, len, supported));
   } else if (memType_ == DevMemType::kCudaMalloc) {
+#if defined(__HIP_PLATFORM_AMD__)
+    // TODO(liuke): Follow up on AMD ROCm cuMem support and migrate to Ctran
+    // window-based collectives for safer IPC buffer management. Using
+    // cudaMalloc IPC for persistent buffers is risky without explicit control
+    // over remote release ordering before local cudaFree.
+    shouldSupportCudaMalloc = true;
+#endif
     if (!shouldSupportCudaMalloc) {
       supported = false;
       return commSuccess;


### PR DESCRIPTION
Summary:
In this diff:
- Fix the issue of CtranIpc.cc on AMD, since `cuMem` API is not yet supported on AMD
  - `shouldSupportCudaMalloc` should be true on AMD

-----------------------
Take AllGatherP as an example

Before this diff, 
- single-node perf: P2162362269 --> AGP pipeline @ 13836.803 GB/s (exceeding theoretical peak) --> why? --> icopy is skipped --> AGP is not performed at all

After this diff,
- single-node perf: P2162378472 --> AGP pipeline @ 60.670 GB/s --> icopy is performed

Differential Revision: D91988270


