### PR TITLE
DeviceWindowSignal: Replace accumulated inbox with per-peer inbox model

### DIFF
--- a/comms/pipes/MultiPeerDeviceTransport.cuh
+++ b/comms/pipes/MultiPeerDeviceTransport.cuh
@@ -398,6 +398,41 @@ class MultiPeerDeviceTransport {
     barrier_.barrier_peer(peer_index, group, barrier_id, timeout);
   }
 
+  /**
+   * wait_signal_from - Wait for signal from a specific peer
+   *
+   * @param group ThreadGroup for cooperative processing
+   * @param source_rank Global rank of the source peer in [0, n_ranks()),
+   *        must not be self
+   * @param signal_id Signal slot to use
+   * @param cmp Comparison operation (CMP_EQ, CMP_GE, etc.)
+   * @param value Value to compare against
+   * @param timeout_ns Optional timeout in nanoseconds (default: infinite)
+   */
+  __device__ __forceinline__ void wait_signal_from(
+      ThreadGroup& group,
+      int source_rank,
+      int signal_id,
+      CmpOp cmp,
+      uint64_t value,
+      uint64_t timeout_ns = UINT64_MAX) {
+    signal_.wait_signal_from(
+        group, source_rank, signal_id, cmp, value, timeout_ns);
+  }
+
+  /**
+   * read_signal_from - Read signal value from a specific peer (non-blocking)
+   *
+   * @param source_rank Global rank of the source peer in [0, n_ranks()),
+   *        must not be self
+   * @param signal_id Signal slot to use
+   * @return Current signal value from the specified peer
+   */
+  __device__ __forceinline__ uint64_t
+  read_signal_from(int source_rank, int signal_id) {
+    return signal_.read_signal_from(source_rank, signal_id);
+  }
+
   // ===========================================================================
   // Send/Recv Operations
   // ===========================================================================

--- a/comms/pipes/tests/MultiPeerDeviceTransportTest.cc
+++ b/comms/pipes/tests/MultiPeerDeviceTransportTest.cc
@@ -55,13 +55,14 @@ TEST_F(MultiPeerDeviceTransportTestFixture, DeviceWindowSignalConstruction) {
 }
 
 TEST_F(MultiPeerDeviceTransportTestFixture, SignalInboxBufferSize) {
-  // Test buffer size calculation
+  // Test buffer size calculation with per-peer inbox model
   const int signalCount = 2;
+  const int nPeers = 3; // e.g., 4 ranks -> 3 peers
 
-  std::size_t bufferSize = getSignalInboxBufferSize(signalCount);
+  std::size_t bufferSize = getSignalInboxBufferSize(signalCount, nPeers);
 
-  // Expected: signalCount * sizeof(SignalState), aligned to 128 bytes
-  std::size_t expectedSlots = signalCount;
+  // Expected: nPeers * signalCount * sizeof(SignalState), aligned to 128 bytes
+  std::size_t expectedSlots = nPeers * signalCount;
   std::size_t expectedMinSize = expectedSlots * sizeof(SignalState);
   // Should be aligned to 128 bytes
   EXPECT_GE(bufferSize, expectedMinSize);

--- a/comms/pipes/tests/MultiPeerDeviceTransportTest.cu
+++ b/comms/pipes/tests/MultiPeerDeviceTransportTest.cu
@@ -48,11 +48,14 @@ void testDeviceWindowSignalConstruction(
     int signalCount,
     int* results) {
   int nPeers = nRanks - 1;
-  meta::comms::DeviceBuffer localInboxBuf(signalCount * sizeof(SignalState));
+  // Per-peer inbox model: localInbox has nPeers * signalCount entries
+  std::size_t localInboxSlots = static_cast<std::size_t>(nPeers) * signalCount;
+  meta::comms::DeviceBuffer localInboxBuf(
+      localInboxSlots * sizeof(SignalState));
   meta::comms::DeviceBuffer peerSignalsBuf(
       nPeers * sizeof(DeviceSpan<SignalState>));
 
-  auto localInbox = makeZeroedSpan<SignalState>(localInboxBuf, signalCount);
+  auto localInbox = makeZeroedSpan<SignalState>(localInboxBuf, localInboxSlots);
   auto peerSignals =
       makeZeroedSpan<DeviceSpan<SignalState>>(peerSignalsBuf, nPeers);
 

--- a/comms/pipes/tests/MultiPeerNvlTransportIntegrationTest.cuh
+++ b/comms/pipes/tests/MultiPeerNvlTransportIntegrationTest.cuh
@@ -334,4 +334,79 @@ void testPutOperation(
     bool isWriter,
     int* result);
 
+/**
+ * Test kernel: wait_signal_from() basic per-peer signal/wait
+ *
+ * Rank 0 signals rank 1, rank 1 uses wait_signal_from(0, ...) to wait
+ * for the specific peer's signal. Verifies read_signal_from() as well.
+ *
+ * @param transport The MultiPeerDeviceTransport to use
+ * @param peerRank The peer rank to signal/wait from
+ * @param signalIdx The signal slot index to use
+ * @param isSignaler If true, this rank signals; if false, waits
+ * @param result Output: 1 if successful
+ */
+void testWaitSignalFromPeer(
+    MultiPeerDeviceTransport& transport,
+    int peerRank,
+    int signalIdx,
+    bool isSignaler,
+    int* result);
+
+/**
+ * Test kernel: wait_signal_from() per-peer isolation
+ *
+ * All peers signal one target rank with different values using SIGNAL_SET.
+ * Target calls wait_signal_from() for each peer individually, verifying
+ * each peer's sub-slot has the correct independent value.
+ *
+ * @param transport The MultiPeerDeviceTransport to use
+ * @param targetRank The rank that all peers signal and that verifies isolation
+ * @param signalIdx The signal slot index to use
+ * @param result Output: 1 if successful
+ */
+void testWaitSignalFromMultiPeerIsolation(
+    MultiPeerDeviceTransport& transport,
+    int targetRank,
+    int signalIdx,
+    int* result);
+
+/**
+ * Test kernel: Both wait_signal() and wait_signal_from() work together
+ *
+ * All peers signal rank 0 with SIGNAL_ADD, 1. Rank 0 verifies:
+ * - wait_signal(signal_id, CMP_GE, nRanks-1) succeeds (accumulated sum)
+ * - wait_signal_from(peer, signal_id, CMP_GE, 1) succeeds for each peer
+ *
+ * @param transport The MultiPeerDeviceTransport to use
+ * @param targetRank The rank that waits for all signals
+ * @param signalIdx The signal slot index to use
+ * @param result Output: 1 if successful
+ */
+void testWaitSignalAndWaitSignalFromBothWork(
+    MultiPeerDeviceTransport& transport,
+    int targetRank,
+    int signalIdx,
+    int* result);
+
+/**
+ * Test kernel: Signal/Wait using BLOCK scope (exercises fallback path)
+ *
+ * Same as testSignalWait but uses make_block_group() instead of
+ * make_warp_group() to exercise the non-WARP fallback code path in
+ * DeviceWindowSignal::wait_signal().
+ *
+ * @param transport The MultiPeerDeviceTransport to use
+ * @param targetRank The target rank to signal/wait from
+ * @param signalIdx The signal slot index to use
+ * @param isSignaler If true, this rank signals; if false, this rank waits
+ * @param result Output: 1 if successful, 0 if failed
+ */
+void testSignalWaitBlockScope(
+    MultiPeerDeviceTransport& transport,
+    int targetRank,
+    int signalIdx,
+    bool isSignaler,
+    int* result);
+
 } // namespace comms::pipes::test


### PR DESCRIPTION
Summary:
**TL;DR:** Replaces `DeviceWindowSignal`'s accumulated inbox model (all peers write to the same slot) with a per-peer inbox model (each peer has its own row of signal slots), adding `wait_signal_from()` and `read_signal_from()` APIs for per-peer signal semantics while preserving backward-compatible accumulated `wait_signal()` via sum-based polling.

Keeping this diff separate from D92190695 so we can independently evaluate the two different inbox models.

 ---

# Detailed Overview

## Context & Motivation

The Pipes `DeviceWindowSignal` previously used an accumulated inbox model where all peers wrote to the **same** slot for a given `signal_id`, and `wait_signal()` polled the accumulated value. This made it impossible to wait for a signal from a *specific* peer. The TorchComms host API (`TorchCommWindow::wait_signal(peerRank, ...)`) supports per-peer signal semantics, as does NCCL's core Primitives layer (per-connection head/tail counters). To enable Pipes as the NVLink backend for TorchComms device-level `wait_signal_from`, we need per-peer signal support.

## Technical Details

**Per-peer inbox model:** The accumulated inbox is replaced with a per-peer inbox where each peer has its own row of signal slots, laid out as `[nPeers][signalCount]`. Each `SignalState` is 128-byte aligned. Total memory per rank = `nPeers * signalCount * sizeof(SignalState)` (e.g., 3.5 KB for 8 GPUs / 4 signals — negligible).

**Signal write path (`signal_peer()`):** Unchanged code. `WindowMemory::exchange()` now sets up `peerSignals_` spans to point to the sender's per-peer row in the target's inbox (`peerBase + myPeerIndexOnPeer * signalCount`), so each `signal_peer()` write lands in the correct per-peer sub-slot with a single NVLink write — no dual-write overhead.

**New per-peer wait/read APIs:**
- `wait_signal_from(group, source_rank, signal_id, cmp, value)` — polls a specific peer's sub-slot in the local inbox. O(1) per poll iteration.
- `read_signal_from(source_rank, signal_id)` — non-blocking read of a specific peer's signal value.

**Backward-compatible accumulated semantics:**
- `wait_signal(group, signal_id, cmp, value)` — now sums across all per-peer sub-slots and polls until the sum meets the condition. A private `compare()` helper handles all `CmpOp` variants. O(nPeers) local L2 reads per iteration — negligible vs. signal arrival time (10s-100s μs for data transfers).
- `read_signal(signal_id)` — similarly sums across per-peer sub-slots, consistent with `wait_signal()`.

**Host-side changes (`WindowMemory.cc`):**
- Constructor allocates `nPeers * signalCount` inbox entries instead of `signalCount`.
- `exchange()` computes `myPeerIndexOnPeer` for each peer and builds spans pointing to per-peer rows.
- `getDeviceWindowSignal()` passes the full `nPeers * signalCount` local inbox span.

**`getSignalInboxBufferSize()` signature change:** Now takes `(signalCount, nPeers)` instead of just `(signalCount)` to compute the per-peer inbox size.

**Why not hybrid (accumulated + per-peer)?** A hybrid model with a separate accumulated region and dual-write in `signal_peer()` adds real complexity (extra region, dual-write, extra spans) for a `wait_signal()` performance benefit that is not perceivable in practice. The polling reads local GPU memory (L2 cache), not NVLink. The simpler per-peer-only model is the right choice.

**Existing tests pass unchanged** — the sum-based `wait_signal()` produces identical results to the old accumulated model for all existing signal/wait patterns.

Differential Revision: D93017011
