### PR TITLE
ci: remove unnecessary deps torchaudio+torchvision

### DIFF
--- a/.github/scripts/setup_env.sh
+++ b/.github/scripts/setup_env.sh
@@ -71,7 +71,7 @@ if [ -n "$CUDA_VERSION" ]; then
     if [ -n "$TORCH_VERSION" ]; then
       pip install --pre torch=="${TORCH_VERSION}" --index-url "$INDEX_URL"
     else
-      pip install --pre torch torchvision torchaudio --index-url "$INDEX_URL"
+      pip install --pre torch --index-url "$INDEX_URL"
     fi
   else
     # Stable with CUDA - use PyTorch wheel index
@@ -79,7 +79,7 @@ if [ -n "$CUDA_VERSION" ]; then
     if [ -n "$TORCH_VERSION" ]; then
       pip install torch=="${TORCH_VERSION}" --index-url "$INDEX_URL"
     else
-      pip install torch torchvision torchaudio --index-url "$INDEX_URL"
+      pip install torch --index-url "$INDEX_URL"
     fi
   fi
 else

--- a/.github/scripts/xpu_test.sh
+++ b/.github/scripts/xpu_test.sh
@@ -21,7 +21,7 @@ export USE_NCCLX=OFF
 export USE_TRANSPORT=OFF
 export USE_SYSTEM_LIBS=1
 
-python3 -m pip install torch torchvision torchaudio pytorch-triton-xpu --index-url https://download.pytorch.org/whl/nightly/xpu --force-reinstall --no-cache-dir 
+python3 -m pip install torch pytorch-triton-xpu --index-url https://download.pytorch.org/whl/nightly/xpu --force-reinstall --no-cache-dir
 cd torchcomms && pip install . --no-build-isolation && cd ..
 
 python3 -c "import torch; import torchcomms; print(f'Torch version: {torch.__version__}')"

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -38,7 +38,7 @@ jobs:
         run: python -m pip install --upgrade pip
       - name: Install pytorch
         shell: bash -l {0}
-        run: pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu128
+        run: pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu128
       - name: Install Dependencies
         shell: bash -l {0}
         run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -46,7 +46,7 @@ jobs:
         run: python -m pip install --upgrade pip
       - name: Install pytorch
         shell: bash -l {0}
-        run: pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu128
+        run: pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu128
       - name: Install Dependencies
         shell: bash -l {0}
         run: |


### PR DESCRIPTION
We're getting downstream issues from torchvision nightlies not being stable. We don't actually use these dependencies so lets just remove them.

https://github.com/meta-pytorch/torchcomms/actions/runs/21959756498/job/63433728308?pr=659

Test plan:

CI