### PR TITLE
Add op_id tracking to TorchComm hook system

### DIFF
--- a/comms/torchcomms/RemovableHandle.hpp
+++ b/comms/torchcomms/RemovableHandle.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <memory>
 #include <mutex>
 
 namespace torch::comms {
@@ -23,9 +24,17 @@ class RemovableHandle {
     });
   }
 
+  // Factory function to create a unique_ptr to RemovableHandle
+  // This allows the handle to be moved via the unique_ptr
+  static std::unique_ptr<RemovableHandle> create(
+      std::function<void()>&& callback) {
+    return std::unique_ptr<RemovableHandle>(
+        new RemovableHandle(std::move(callback)));
+  }
+
  private:
-  std::once_flag once_;
   std::function<void()> callback_;
+  std::once_flag once_;
 };
 
 } // namespace torch::comms

--- a/comms/torchcomms/TorchComm.cpp
+++ b/comms/torchcomms/TorchComm.cpp
@@ -54,13 +54,14 @@ c10::intrusive_ptr<TorchWork> TorchComm::send(
     bool async_op,
     const SendOptions& options) {
   validateRank(dst, "dst");
-
+  auto op_id = nextOpId_++;
   preHook(
       PreHookArgs{
           .name = OpName::send,
           .async_op = async_op,
           .input_tensor = &tensor,
           .root = dst,
+          .op_id = op_id,
       });
 
   auto work = impl_->send(tensor, dst, async_op, options);
@@ -69,6 +70,7 @@ c10::intrusive_ptr<TorchWork> TorchComm::send(
       PostHookArgs{
           .name = OpName::send,
           .work = c10::weak_intrusive_ptr<TorchWork>(work),
+          .op_id = op_id,
       });
 
   return work;
@@ -80,13 +82,14 @@ c10::intrusive_ptr<TorchWork> TorchComm::recv(
     bool async_op,
     const RecvOptions& options) {
   validateRank(src, "src");
-
+  auto op_id = nextOpId_++;
   preHook(
       PreHookArgs{
           .name = OpName::recv,
           .async_op = async_op,
           .output_tensor = &tensor,
           .root = src,
+          .op_id = op_id,
       });
 
   auto work = impl_->recv(tensor, src, async_op, options);
@@ -95,6 +98,7 @@ c10::intrusive_ptr<TorchWork> TorchComm::recv(
       PostHookArgs{
           .name = OpName::recv,
           .work = c10::weak_intrusive_ptr<TorchWork>(work),
+          .op_id = op_id,
       });
 
   return work;
@@ -107,13 +111,14 @@ c10::intrusive_ptr<TorchWork> TorchComm::broadcast(
     bool async_op,
     const BroadcastOptions& options) {
   validateRank(root, "root");
-
+  auto op_id = nextOpId_++;
   preHook(
       PreHookArgs{
           .name = OpName::broadcast,
           .async_op = async_op,
           .input_tensor = &tensor,
           .root = root,
+          .op_id = op_id,
       });
 
   auto work = impl_->broadcast(tensor, root, async_op, options);
@@ -122,6 +127,7 @@ c10::intrusive_ptr<TorchWork> TorchComm::broadcast(
       PostHookArgs{
           .name = OpName::broadcast,
           .work = c10::weak_intrusive_ptr<TorchWork>(work),
+          .op_id = op_id,
       });
 
   return work;
@@ -132,11 +138,13 @@ c10::intrusive_ptr<TorchWork> TorchComm::all_reduce(
     const ReduceOp& op,
     bool async_op,
     const AllReduceOptions& options) {
+  auto op_id = nextOpId_++;
   preHook(
       PreHookArgs{
           .name = OpName::all_reduce,
           .async_op = async_op,
           .input_tensor = &tensor,
+          .op_id = op_id,
       });
 
   auto work = impl_->all_reduce(tensor, op, async_op, options);
@@ -145,6 +153,7 @@ c10::intrusive_ptr<TorchWork> TorchComm::all_reduce(
       PostHookArgs{
           .name = OpName::all_reduce,
           .work = c10::weak_intrusive_ptr<TorchWork>(work),
+          .op_id = op_id,
       });
 
   return work;
@@ -157,13 +166,14 @@ c10::intrusive_ptr<TorchWork> TorchComm::reduce(
     bool async_op,
     const ReduceOptions& options) {
   validateRank(root, "root");
-
+  auto op_id = nextOpId_++;
   preHook(
       PreHookArgs{
           .name = OpName::reduce,
           .async_op = async_op,
           .input_tensor = &tensor,
           .root = root,
+          .op_id = op_id,
       });
 
   auto work = impl_->reduce(tensor, root, op, async_op, options);
@@ -172,6 +182,7 @@ c10::intrusive_ptr<TorchWork> TorchComm::reduce(
       PostHookArgs{
           .name = OpName::reduce,
           .work = c10::weak_intrusive_ptr<TorchWork>(work),
+          .op_id = op_id,
       });
 
   return work;
@@ -182,11 +193,13 @@ c10::intrusive_ptr<TorchWork> TorchComm::all_gather(
     const at::Tensor& tensor,
     bool async_op,
     const AllGatherOptions& options) {
+  auto op_id = nextOpId_++;
   preHook(
       PreHookArgs{
           .name = OpName::all_gather,
           .async_op = async_op,
           .input_tensor = &tensor,
+          .op_id = op_id,
       });
 
   auto work = impl_->all_gather(tensor_list, tensor, async_op, options);
@@ -195,6 +208,7 @@ c10::intrusive_ptr<TorchWork> TorchComm::all_gather(
       PostHookArgs{
           .name = OpName::all_gather,
           .work = c10::weak_intrusive_ptr<TorchWork>(work),
+          .op_id = op_id,
       });
 
   return work;
@@ -205,11 +219,13 @@ c10::intrusive_ptr<TorchWork> TorchComm::all_gather_v(
     const at::Tensor& tensor,
     bool async_op,
     const AllGatherOptions& options) {
+  auto op_id = nextOpId_++;
   preHook(
       PreHookArgs{
           .name = OpName::all_gather_v,
           .async_op = async_op,
           .input_tensor = &tensor,
+          .op_id = op_id,
       });
 
   auto work = impl_->all_gather_v(tensor_list, tensor, async_op, options);
@@ -218,6 +234,7 @@ c10::intrusive_ptr<TorchWork> TorchComm::all_gather_v(
       PostHookArgs{
           .name = OpName::all_gather_v,
           .work = c10::weak_intrusive_ptr<TorchWork>(work),
+          .op_id = op_id,
       });
 
   return work;
@@ -228,12 +245,14 @@ c10::intrusive_ptr<TorchWork> TorchComm::all_gather_single(
     const at::Tensor& input,
     bool async_op,
     const AllGatherSingleOptions& options) {
+  auto op_id = nextOpId_++;
   preHook(
       PreHookArgs{
           .name = OpName::all_gather_single,
           .async_op = async_op,
           .input_tensor = &input,
           .output_tensor = &output,
+          .op_id = op_id,
       });
 
   auto work = impl_->all_gather_single(output, input, async_op, options);
@@ -242,6 +261,7 @@ c10::intrusive_ptr<TorchWork> TorchComm::all_gather_single(
       PostHookArgs{
           .name = OpName::all_gather_single,
           .work = c10::weak_intrusive_ptr<TorchWork>(work),
+          .op_id = op_id,
       });
 
   return work;
@@ -253,11 +273,13 @@ c10::intrusive_ptr<TorchWork> TorchComm::reduce_scatter(
     const ReduceOp& op,
     bool async_op,
     const ReduceScatterOptions& options) {
+  auto op_id = nextOpId_++;
   preHook(
       PreHookArgs{
           .name = OpName::reduce_scatter,
           .async_op = async_op,
           .output_tensor = &output,
+          .op_id = op_id,
       });
 
   auto work = impl_->reduce_scatter(output, input_list, op, async_op, options);
@@ -266,6 +288,7 @@ c10::intrusive_ptr<TorchWork> TorchComm::reduce_scatter(
       PostHookArgs{
           .name = OpName::reduce_scatter,
           .work = c10::weak_intrusive_ptr<TorchWork>(work),
+          .op_id = op_id,
       });
 
   return work;
@@ -277,11 +300,13 @@ c10::intrusive_ptr<TorchWork> TorchComm::reduce_scatter_v(
     const ReduceOp& op,
     bool async_op,
     const ReduceScatterOptions& options) {
+  auto op_id = nextOpId_++;
   preHook(
       PreHookArgs{
           .name = OpName::reduce_scatter_v,
           .async_op = async_op,
           .output_tensor = &output,
+          .op_id = op_id,
       });
 
   auto work =
@@ -291,6 +316,7 @@ c10::intrusive_ptr<TorchWork> TorchComm::reduce_scatter_v(
       PostHookArgs{
           .name = OpName::reduce_scatter_v,
           .work = c10::weak_intrusive_ptr<TorchWork>(work),
+          .op_id = op_id,
       });
 
   return work;
@@ -302,12 +328,14 @@ c10::intrusive_ptr<TorchWork> TorchComm::reduce_scatter_single(
     const ReduceOp& op,
     bool async_op,
     const ReduceScatterSingleOptions& options) {
+  auto op_id = nextOpId_++;
   preHook(
       PreHookArgs{
           .name = OpName::reduce_scatter_single,
           .async_op = async_op,
           .input_tensor = &input,
           .output_tensor = &output,
+          .op_id = op_id,
       });
 
   auto work =
@@ -317,6 +345,7 @@ c10::intrusive_ptr<TorchWork> TorchComm::reduce_scatter_single(
       PostHookArgs{
           .name = OpName::reduce_scatter_single,
           .work = c10::weak_intrusive_ptr<TorchWork>(work),
+          .op_id = op_id,
       });
 
   return work;
@@ -327,12 +356,14 @@ c10::intrusive_ptr<TorchWork> TorchComm::all_to_all_single(
     const at::Tensor& input,
     bool async_op,
     const AllToAllSingleOptions& options) {
+  auto op_id = nextOpId_++;
   preHook(
       PreHookArgs{
           .name = OpName::all_to_all_single,
           .async_op = async_op,
           .input_tensor = &input,
           .output_tensor = &output,
+          .op_id = op_id,
       });
 
   auto work = impl_->all_to_all_single(output, input, async_op, options);
@@ -341,6 +372,7 @@ c10::intrusive_ptr<TorchWork> TorchComm::all_to_all_single(
       PostHookArgs{
           .name = OpName::all_to_all_single,
           .work = c10::weak_intrusive_ptr<TorchWork>(work),
+          .op_id = op_id,
       });
 
   return work;
@@ -353,6 +385,7 @@ c10::intrusive_ptr<TorchWork> TorchComm::all_to_all_v_single(
     const std::vector<uint64_t>& input_split_sizes,
     bool async_op,
     const AllToAllvSingleOptions& options) {
+  auto op_id = nextOpId_++;
   preHook(
       PreHookArgs{
           .name = OpName::all_to_all_v_single,
@@ -361,6 +394,7 @@ c10::intrusive_ptr<TorchWork> TorchComm::all_to_all_v_single(
           .output_tensor = &output,
           .output_split_sizes = &output_split_sizes,
           .input_split_sizes = &input_split_sizes,
+          .op_id = op_id,
       });
 
   auto work = impl_->all_to_all_v_single(
@@ -370,6 +404,7 @@ c10::intrusive_ptr<TorchWork> TorchComm::all_to_all_v_single(
       PostHookArgs{
           .name = OpName::all_to_all_v_single,
           .work = c10::weak_intrusive_ptr<TorchWork>(work),
+          .op_id = op_id,
       });
 
   return work;
@@ -380,10 +415,12 @@ c10::intrusive_ptr<TorchWork> TorchComm::all_to_all(
     const std::vector<at::Tensor>& input_tensor_list,
     bool async_op,
     const AllToAllOptions& options) {
+  auto op_id = nextOpId_++;
   preHook(
       PreHookArgs{
           .name = OpName::all_to_all,
           .async_op = async_op,
+          .op_id = op_id,
       });
 
   auto work = impl_->all_to_all(
@@ -393,6 +430,7 @@ c10::intrusive_ptr<TorchWork> TorchComm::all_to_all(
       PostHookArgs{
           .name = OpName::all_to_all,
           .work = c10::weak_intrusive_ptr<TorchWork>(work),
+          .op_id = op_id,
       });
 
   return work;
@@ -401,10 +439,12 @@ c10::intrusive_ptr<TorchWork> TorchComm::all_to_all(
 c10::intrusive_ptr<TorchWork> TorchComm::barrier(
     bool async_op,
     const BarrierOptions& options) {
+  auto op_id = nextOpId_++;
   preHook(
       PreHookArgs{
           .name = OpName::barrier,
           .async_op = async_op,
+          .op_id = op_id,
       });
 
   auto work = impl_->barrier(async_op, options);
@@ -413,6 +453,7 @@ c10::intrusive_ptr<TorchWork> TorchComm::barrier(
       PostHookArgs{
           .name = OpName::barrier,
           .work = c10::weak_intrusive_ptr<TorchWork>(work),
+          .op_id = op_id,
       });
 
   return work;
@@ -426,13 +467,14 @@ c10::intrusive_ptr<TorchWork> TorchComm::scatter(
     bool async_op,
     const ScatterOptions& options) {
   validateRank(root, "root");
-
+  auto op_id = nextOpId_++;
   preHook(
       PreHookArgs{
           .name = OpName::scatter,
           .async_op = async_op,
           .output_tensor = &output_tensor,
           .root = root,
+          .op_id = op_id,
       });
 
   auto work =
@@ -442,6 +484,7 @@ c10::intrusive_ptr<TorchWork> TorchComm::scatter(
       PostHookArgs{
           .name = OpName::scatter,
           .work = c10::weak_intrusive_ptr<TorchWork>(work),
+          .op_id = op_id,
       });
 
   return work;
@@ -454,13 +497,14 @@ c10::intrusive_ptr<TorchWork> TorchComm::gather(
     bool async_op,
     const GatherOptions& options) {
   validateRank(root, "root");
-
+  auto op_id = nextOpId_++;
   preHook(
       PreHookArgs{
           .name = OpName::gather,
           .async_op = async_op,
           .input_tensor = &input_tensor,
           .root = root,
+          .op_id = op_id,
       });
 
   auto work =
@@ -470,6 +514,7 @@ c10::intrusive_ptr<TorchWork> TorchComm::gather(
       PostHookArgs{
           .name = OpName::gather,
           .work = c10::weak_intrusive_ptr<TorchWork>(work),
+          .op_id = op_id,
       });
 
   return work;
@@ -477,15 +522,18 @@ c10::intrusive_ptr<TorchWork> TorchComm::gather(
 
 std::shared_ptr<TorchCommWindow> TorchComm::new_window(
     const std::optional<at::Tensor>& tensor) {
+  auto op_id = nextOpId_++;
   preHook(
       PreHookArgs{
           .name = OpName::new_window,
+          .op_id = op_id,
       });
   auto window = impl_->new_window(tensor);
   postHook(
       PostHookArgs{
           .name = OpName::new_window,
           .new_window = std::weak_ptr<TorchCommWindow>(window),
+          .op_id = op_id,
       });
   return window;
 }
@@ -495,11 +543,13 @@ std::shared_ptr<TorchComm> TorchComm::split(
     const std::vector<int>& ranks,
     const std::string& name,
     const CommOptions& options) {
+  auto op_id = nextOpId_++;
   preHook(
       PreHookArgs{
           .name = OpName::split,
           .ranks = &ranks,
           .split_name = &name,
+          .op_id = op_id,
       });
   auto new_impl = impl_->split(ranks, name, options);
   if (new_impl == nullptr) {
@@ -511,6 +561,7 @@ std::shared_ptr<TorchComm> TorchComm::split(
       PostHookArgs{
           .name = OpName::split,
           .new_comm = std::weak_ptr<TorchComm>(comm),
+          .op_id = op_id,
       });
   return comm;
 }
@@ -559,20 +610,22 @@ std::shared_ptr<c10::Allocator> get_mem_allocator(const std::string& backend) {
   return TorchCommFactory::get().get_allocator(backend);
 }
 
-RemovableHandle TorchComm::registerPreHook(TorchComm::PreHook preHook) {
+std::unique_ptr<RemovableHandle> TorchComm::registerPreHook(
+    TorchComm::PreHook preHook) {
   auto hookId = nextHookId_++;
   preHooks_.emplace(hookId, std::move(preHook));
-  return RemovableHandle([self = weak_from_this(), hookId]() {
+  return RemovableHandle::create([self = weak_from_this(), hookId]() {
     if (auto selfPtr = self.lock()) {
       selfPtr->preHooks_.erase(hookId);
     }
   });
 }
 
-RemovableHandle TorchComm::registerPostHook(TorchComm::PostHook postHook) {
+std::unique_ptr<RemovableHandle> TorchComm::registerPostHook(
+    TorchComm::PostHook postHook) {
   auto hookId = nextHookId_++;
   postHooks_.emplace(hookId, std::move(postHook));
-  return RemovableHandle([self = weak_from_this(), hookId]() {
+  return RemovableHandle::create([self = weak_from_this(), hookId]() {
     if (auto selfPtr = self.lock()) {
       selfPtr->postHooks_.erase(hookId);
     }

--- a/comms/torchcomms/TorchComm.hpp
+++ b/comms/torchcomms/TorchComm.hpp
@@ -244,6 +244,8 @@ class TorchComm : public std::enable_shared_from_this<TorchComm> {
     // For split
     const std::vector<int>* ranks{nullptr};
     const std::string* split_name{nullptr};
+    // Unique operation ID to correlate pre-hook and post-hook calls
+    size_t op_id{0};
   };
   using PreHook = std::function<void(PreHookArgs)>;
   struct PostHookArgs {
@@ -251,13 +253,15 @@ class TorchComm : public std::enable_shared_from_this<TorchComm> {
     std::optional<c10::weak_intrusive_ptr<TorchWork>> work{};
     std::weak_ptr<TorchComm> new_comm{};
     std::weak_ptr<TorchCommWindow> new_window{};
+    // Unique operation ID to correlate pre-hook and post-hook calls
+    size_t op_id{0};
   };
   using PostHook = std::function<void(PostHookArgs)>;
 
   // These are not thread safe and must not be modified while a collective is
   // in progress.
-  RemovableHandle registerPreHook(PreHook preHook);
-  RemovableHandle registerPostHook(PostHook postHook);
+  std::unique_ptr<RemovableHandle> registerPreHook(PreHook preHook);
+  std::unique_ptr<RemovableHandle> registerPostHook(PostHook postHook);
 
   // Disable copy and move semantics
   TorchComm(const TorchComm&) = delete;
@@ -298,6 +302,8 @@ class TorchComm : public std::enable_shared_from_this<TorchComm> {
   int64_t nextHookId_ = 0;
   std::unordered_map<int64_t, PreHook> preHooks_;
   std::unordered_map<int64_t, PostHook> postHooks_;
+  // Counter for generating unique operation IDs
+  std::atomic<size_t> nextOpId_{0};
 };
 
 // Constructor that creates the appropriate backend implementation

--- a/comms/torchcomms/TorchWork.hpp
+++ b/comms/torchcomms/TorchWork.hpp
@@ -71,6 +71,12 @@ class TorchWork : public c10::intrusive_ptr_target {
 
   void setCallback(std::function<void()> callback) {
     callback_ = std::move(callback);
+    auto currentStatus = status();
+    if (currentStatus == WorkStatus::COMPLETED ||
+        currentStatus == WorkStatus::ERROR ||
+        currentStatus == WorkStatus::TIMEDOUT) {
+      runCallback();
+    }
   }
 
   void runCallback() {

--- a/comms/torchcomms/tests/unit/cpp/TorchCommHooksTest.cpp
+++ b/comms/torchcomms/tests/unit/cpp/TorchCommHooksTest.cpp
@@ -1,0 +1,203 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <comms/torchcomms/TorchComm.hpp>
+#include <comms/torchcomms/TorchCommFactory.hpp>
+#include <gtest/gtest.h>
+#include <cstdlib>
+#include <vector>
+
+namespace torch::comms {
+
+namespace {
+constexpr const char* kBackendName = "dummy_test";
+constexpr const char* kBackendEnvKey = "TORCHCOMMS_BACKEND_LIB_PATH_DUMMY_TEST";
+} // namespace
+
+class TorchCommHooksTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const char* lib_path = std::getenv("DUMMY_TEST_BACKEND_LIB_PATH");
+    ASSERT_NE(lib_path, nullptr) << "DUMMY_TEST_BACKEND_LIB_PATH not set";
+    setenv(kBackendEnvKey, lib_path, 1);
+  }
+
+  void TearDown() override {
+    unsetenv(kBackendEnvKey);
+  }
+};
+
+TEST_F(TorchCommHooksTest, PreAndPostHookCalledAfterRegistration) {
+  at::Device device(at::kCPU);
+  auto torchcomm = new_comm(kBackendName, device, "test_comm", {});
+  ASSERT_NE(torchcomm, nullptr);
+
+  std::vector<OpName> preHookCalls;
+  std::vector<OpName> postHookCalls;
+
+  auto preHandle =
+      torchcomm->registerPreHook([&preHookCalls](TorchComm::PreHookArgs args) {
+        preHookCalls.push_back(args.name);
+      });
+
+  auto postHandle = torchcomm->registerPostHook(
+      [&postHookCalls](TorchComm::PostHookArgs args) {
+        postHookCalls.push_back(args.name);
+      });
+
+  auto tensor = at::ones({2, 2}, at::kFloat);
+  torchcomm->all_reduce(tensor, ReduceOp::SUM, true);
+
+  ASSERT_EQ(preHookCalls.size(), 1);
+  EXPECT_EQ(preHookCalls[0], OpName::all_reduce);
+
+  ASSERT_EQ(postHookCalls.size(), 1);
+  EXPECT_EQ(postHookCalls[0], OpName::all_reduce);
+}
+
+TEST_F(TorchCommHooksTest, PreAndPostHookOpIdIncreases) {
+  at::Device device(at::kCPU);
+  auto torchcomm = new_comm(kBackendName, device, "test_comm", {});
+  ASSERT_NE(torchcomm, nullptr);
+
+  std::vector<size_t> preOpIds;
+  std::vector<size_t> postOpIds;
+
+  auto preHandle =
+      torchcomm->registerPreHook([&preOpIds](TorchComm::PreHookArgs args) {
+        preOpIds.push_back(args.op_id);
+      });
+
+  auto postHandle =
+      torchcomm->registerPostHook([&postOpIds](TorchComm::PostHookArgs args) {
+        postOpIds.push_back(args.op_id);
+      });
+
+  auto tensor = at::ones({2, 2}, at::kFloat);
+
+  torchcomm->all_reduce(tensor, ReduceOp::SUM, true);
+  torchcomm->barrier(true);
+  torchcomm->broadcast(tensor, 0, true);
+
+  ASSERT_EQ(preOpIds.size(), 3);
+  ASSERT_EQ(postOpIds.size(), 3);
+
+  EXPECT_LT(preOpIds[0], preOpIds[1]);
+  EXPECT_LT(preOpIds[1], preOpIds[2]);
+
+  EXPECT_LT(postOpIds[0], postOpIds[1]);
+  EXPECT_LT(postOpIds[1], postOpIds[2]);
+
+  EXPECT_EQ(preOpIds[0], postOpIds[0]);
+  EXPECT_EQ(preOpIds[1], postOpIds[1]);
+  EXPECT_EQ(preOpIds[2], postOpIds[2]);
+}
+
+TEST_F(TorchCommHooksTest, PreAndPostHookNotCalledAfterRemoval) {
+  at::Device device(at::kCPU);
+  auto torchcomm = new_comm(kBackendName, device, "test_comm", {});
+  ASSERT_NE(torchcomm, nullptr);
+
+  int preHookCallCount = 0;
+  int postHookCallCount = 0;
+
+  auto preHandle = torchcomm->registerPreHook(
+      [&preHookCallCount](TorchComm::PreHookArgs) { preHookCallCount++; });
+
+  auto postHandle = torchcomm->registerPostHook(
+      [&postHookCallCount](TorchComm::PostHookArgs) { postHookCallCount++; });
+
+  auto tensor = at::ones({2, 2}, at::kFloat);
+  auto work = torchcomm->all_reduce(tensor, ReduceOp::SUM, true);
+
+  EXPECT_EQ(preHookCallCount, 1);
+  EXPECT_EQ(postHookCallCount, 1);
+
+  preHandle->remove();
+  postHandle->remove();
+
+  torchcomm->all_reduce(tensor, ReduceOp::SUM, true);
+
+  EXPECT_EQ(preHookCallCount, 1);
+  EXPECT_EQ(postHookCallCount, 1);
+}
+
+TEST_F(TorchCommHooksTest, MultiplePreAndPostHooksRegistered) {
+  at::Device device(at::kCPU);
+  auto torchcomm = new_comm(kBackendName, device, "test_comm", {});
+  ASSERT_NE(torchcomm, nullptr);
+
+  int preHook1CallCount = 0;
+  int preHook2CallCount = 0;
+  int postHook1CallCount = 0;
+  int postHook2CallCount = 0;
+
+  auto preHandle1 = torchcomm->registerPreHook(
+      [&preHook1CallCount](TorchComm::PreHookArgs) { preHook1CallCount++; });
+
+  auto preHandle2 = torchcomm->registerPreHook(
+      [&preHook2CallCount](TorchComm::PreHookArgs) { preHook2CallCount++; });
+
+  auto postHandle1 = torchcomm->registerPostHook(
+      [&postHook1CallCount](TorchComm::PostHookArgs) { postHook1CallCount++; });
+
+  auto postHandle2 = torchcomm->registerPostHook(
+      [&postHook2CallCount](TorchComm::PostHookArgs) { postHook2CallCount++; });
+
+  auto tensor = at::ones({2, 2}, at::kFloat);
+  torchcomm->all_reduce(tensor, ReduceOp::SUM, true);
+
+  EXPECT_EQ(preHook1CallCount, 1);
+  EXPECT_EQ(preHook2CallCount, 1);
+  EXPECT_EQ(postHook1CallCount, 1);
+  EXPECT_EQ(postHook2CallCount, 1);
+}
+
+TEST_F(
+    TorchCommHooksTest,
+    PreAndPostHookOpIdIncreasesAcrossDifferentOperations) {
+  at::Device device(at::kCPU);
+  auto torchcomm = new_comm(kBackendName, device, "test_comm", {});
+  ASSERT_NE(torchcomm, nullptr);
+
+  std::vector<std::pair<OpName, size_t>> preHookCalls;
+  std::vector<std::pair<OpName, size_t>> postHookCalls;
+
+  auto preHandle =
+      torchcomm->registerPreHook([&preHookCalls](TorchComm::PreHookArgs args) {
+        preHookCalls.push_back({args.name, args.op_id});
+      });
+
+  auto postHandle = torchcomm->registerPostHook(
+      [&postHookCalls](TorchComm::PostHookArgs args) {
+        postHookCalls.push_back({args.name, args.op_id});
+      });
+
+  auto tensor = at::ones({2, 2}, at::kFloat);
+
+  torchcomm->all_reduce(tensor, ReduceOp::SUM, true);
+  torchcomm->barrier(true);
+  torchcomm->broadcast(tensor, 0, true);
+
+  ASSERT_EQ(preHookCalls.size(), 3);
+  ASSERT_EQ(postHookCalls.size(), 3);
+
+  EXPECT_EQ(preHookCalls[0].first, OpName::all_reduce);
+  EXPECT_EQ(preHookCalls[1].first, OpName::barrier);
+  EXPECT_EQ(preHookCalls[2].first, OpName::broadcast);
+
+  EXPECT_EQ(postHookCalls[0].first, OpName::all_reduce);
+  EXPECT_EQ(postHookCalls[1].first, OpName::barrier);
+  EXPECT_EQ(postHookCalls[2].first, OpName::broadcast);
+
+  EXPECT_LT(preHookCalls[0].second, preHookCalls[1].second);
+  EXPECT_LT(preHookCalls[1].second, preHookCalls[2].second);
+
+  EXPECT_LT(postHookCalls[0].second, postHookCalls[1].second);
+  EXPECT_LT(postHookCalls[1].second, postHookCalls[2].second);
+
+  EXPECT_EQ(preHookCalls[0].second, postHookCalls[0].second);
+  EXPECT_EQ(preHookCalls[1].second, postHookCalls[1].second);
+  EXPECT_EQ(preHookCalls[2].second, postHookCalls[2].second);
+}
+
+} // namespace torch::comms


### PR DESCRIPTION
Summary:
**Op Id Tracking and Enhancements to TorchWork and RemovableHandle**
=====================================================

### Op Id Tracking

*   Introduced a unique operation ID (`op_id`) to correlate pre-hook and post-hook calls. This ID is now included in the `PreHookArgs` and `PostHookArgs` structs.
*   Updated collectives to include the `op_id` in the pre-hook and post-hook calls.

### Changes to RemovableHandle

*   Added a factory function `create` to create a unique_ptr to `RemovableHandle`, enabling the handle to be moved via the unique_ptr.

### Changes to TorchWork

*  Run the callback on `TorchWork` if it is created with Completed status

Reviewed By: d4l3k

Differential Revision: D93011745


