### PR TITLE
Convert CtranIbSingleton to folly::Singleton

### DIFF
--- a/comms/ctran/backends/ib/ibutils.cc
+++ b/comms/ctran/backends/ib/ibutils.cc
@@ -59,8 +59,9 @@ commResult_t IbUtils::pollForAsyncEvent(
     ret = verbsPtr->ibv_poll_async_fd(
         &fdSet, 1, NCCL_CTRAN_IB_ASYNC_EVENT_POLL_INTERVAL_MS);
     if (NCCL_IB_ASYNC_EVENT_LOOP == NCCL_IB_ASYNC_EVENT_LOOP::ctran) {
-      stopRequested =
-          CtranIbSingleton::getInstance().stopIbAsyncEventHandlerFlag;
+      auto singleton = CtranIbSingleton::getInstance();
+      CHECK_VALID_IB_SINGLETON(singleton);
+      stopRequested = singleton->stopIbAsyncEventHandlerFlag;
     }
     linkDown = linkDownTimeout();
   } while (ret == 0 && !stopRequested && !linkDown);

--- a/comms/ctran/backends/ib/tests/CtranIbDistUT.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbDistUT.cc
@@ -65,8 +65,9 @@ class CtranIbTest : public ctran::CtranDistTestFixture {
   }
 
   size_t getIbRegCount() {
-    CtranIbSingleton& s = CtranIbSingleton::getInstance();
-    return s.getActiveRegCount();
+    auto s = CtranIbSingleton::getInstance();
+    CHECK_VALID_IB_SINGLETON(s);
+    return s->getActiveRegCount();
   }
 
   constexpr static int kSockSyncLen = 16;

--- a/comms/ctran/regcache/RegCache.cc
+++ b/comms/ctran/regcache/RegCache.cc
@@ -191,10 +191,10 @@ void ctran::RegCache::init() {
 commResult_t ctran::RegCache::destroy() {
   {
     // Warn if user missed any buffer registration.
-    // Skip deregistration to avoid unexpected error at destruction time for
-    // now. We need revisit after sets RegCache's dependency to
-    // CtranIbSingleton, otherwise ib singleton may be released before
-    // deregisteration here.
+    // TODO: With folly::Singleton, destruction order may not be guaranteed
+    // between RegCache and CtranIbSingleton. We need to ensure CtranIbSingleton
+    // is destroyed after RegCache to avoid use-after-free during
+    // deregistration.
     auto [segmentsAvl, regElemsMaps] =
         folly::acquireLocked(segmentsAvl_, regElemsMaps_);
     auto& regHdlToElemMap = regElemsMaps->regHdlToElemMap;

--- a/comms/ctran/tests/CtranDistUT.cc
+++ b/comms/ctran/tests/CtranDistUT.cc
@@ -37,8 +37,9 @@ class CtranTest : public NcclxBaseTest, public CtranBaseTest {
 
   void verifyPostCommResourceLeak() {
     // Check that all local/remote handles have been deregistered by CommAbort
-    CtranIbSingleton& s = CtranIbSingleton::getInstance();
-    EXPECT_EQ(s.getActiveRegCount(), 0);
+    auto s = CtranIbSingleton::getInstance();
+    CHECK_VALID_IB_SINGLETON(s);
+    EXPECT_EQ(s->getActiveRegCount(), 0);
     EXPECT_EQ(ctran::utils::getActiveIpcMemCount(), 0);
     EXPECT_EQ(ctran::utils::getActiveIpcRemMemCount(), 0);
   }
@@ -518,11 +519,12 @@ TEST_F(CtranTest, CommAbortScopeNone) {
   res = ncclCommAbort(comm);
   ASSERT_EQ(res, ncclSuccess);
 
-  CtranIbSingleton& s = CtranIbSingleton::getInstance();
+  auto s = CtranIbSingleton::getInstance();
+  CHECK_VALID_IB_SINGLETON(s);
 
   testing::internal::CaptureStdout();
   testing::internal::CaptureStderr();
-  ASSERT_EQ(s.destroy(), ncclSuccess);
+  ASSERT_EQ(s->destroy(), ncclSuccess);
 
   // Except no warning nor error message is printed
   std::string output = testing::internal::GetCapturedStdout();


### PR DESCRIPTION
Summary: Convert CtranIbSingleton to folly::Singleton to enable proper destruction ordering with other folly::Singleton instances (like RegCache).

Differential Revision: D93039664


