### PR TITLE
Update gPidTest to expect rank suffix in gPid() output

### DIFF
--- a/comms/ctran/commstate/tests/CommStateXTest.cc
+++ b/comms/ctran/commstate/tests/CommStateXTest.cc
@@ -512,13 +512,13 @@ TEST(CommStateXTest, gPidTest) {
 
     // Test gPid() for default (current) rank
     std::string expectedGPid = std::string(rankTopologies[rank].host) + ":" +
-        std::to_string(rankTopologies[rank].pid);
+        std::to_string(rankTopologies[rank].pid) + ":" + std::to_string(rank);
     EXPECT_EQ(commState->gPid(), expectedGPid);
 
     // Test gPid(rank) for all ranks
     for (int r = 0; r < nRanks; ++r) {
       std::string expected = std::string(rankTopologies[r].host) + ":" +
-          std::to_string(rankTopologies[r].pid);
+          std::to_string(rankTopologies[r].pid) + ":" + std::to_string(r);
       EXPECT_EQ(commState->gPid(r), expected);
     }
   }


### PR DESCRIPTION
Summary:
D92879823 changed gPid() to include rank in the return value
(format changed from "host:pid" to "host:pid:rank") to uniquely identify
global processes and fix UTs where pid and hostname may be identical.
This updates the test expectations to match the new behavior.

Reviewed By: dboyda, function47

Differential Revision: D93139545


