### PR TITLE
Fix IpcRegCache AsyncSocket teardown

### DIFF
--- a/comms/ctran/regcache/IpcRegCache.cc
+++ b/comms/ctran/regcache/IpcRegCache.cc
@@ -390,11 +390,15 @@ void ctran::IpcRegCache::stopAsyncSocket() {
   if (asyncServerSocket_) {
     auto fut = asyncServerSocket_->stop();
     std::move(fut).get();
-    asyncServerSocket_.reset();
     CLOGF_SUBSYS(INFO, INIT, "CTRAN-REGCACHE: AsyncSocket server stopped");
   }
 
+  // Destroy the EVB thread BEFORE asyncServerSocket_ to drain pending
+  // callbacks (e.g. RemoteAcceptor cleanup) while the AcceptCallback is
+  // still alive, avoiding a use-after-free SIGSEGV.
   if (asyncSocketEvbThread_) {
     asyncSocketEvbThread_.reset();
   }
+
+  asyncServerSocket_.reset();
 }


### PR DESCRIPTION
Summary:
As title, the teardown order is having a race condition between current thread
and the AsyncThread.

Prior to this diff:
```
buck2 test fbcode//mode/opt fbcode//comms/mccl/integration_tests:all_reduce_test -- --stress-runs 20
```
https://www.internalfb.com/intern/testinfra/testrun/10977524242424316

Trace: https://www.internalfb.com/phabricator/paste/view/P2184733642

Reviewed By: elvinlife

Differential Revision: D93173556


