### PR TITLE
Implement getFuture() in BackendWrapper and add DDP test

### DIFF
--- a/comms/torchcomms/BackendWrapper.hpp
+++ b/comms/torchcomms/BackendWrapper.hpp
@@ -1,6 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 #pragma once
 
+#include <ATen/core/ivalue.h> // @manual=//caffe2:ATen-core
 #include <torch/csrc/distributed/c10d/Backend.hpp> // @manual=//caffe2:torch-cpp-cpu
 #include <torch/csrc/distributed/c10d/Store.hpp> // @manual=//caffe2:torch-cpp-cpu
 #include <torch/csrc/distributed/c10d/Work.hpp> // @manual=//caffe2:torch-cpp-cpu
@@ -13,7 +14,9 @@ namespace torch::comms {
 
 class WorkWrapper : public c10d::Work {
  public:
-  explicit WorkWrapper(c10::intrusive_ptr<TorchWork> work);
+  explicit WorkWrapper(
+      c10::intrusive_ptr<TorchWork> work,
+      std::vector<at::Tensor> outputTensors = {});
   ~WorkWrapper() override = default;
 
   bool isCompleted() override;
@@ -22,10 +25,13 @@ class WorkWrapper : public c10d::Work {
   void synchronize() override;
   bool wait(std::chrono::milliseconds timeout) override;
   std::vector<at::Tensor> result() override;
+  c10::intrusive_ptr<c10::ivalue::Future> getFuture() override;
 
  private:
   friend class BackendWrapper;
   c10::intrusive_ptr<TorchWork> work_;
+  c10::intrusive_ptr<c10::ivalue::Future> future_;
+  std::vector<at::Tensor> outputTensors_;
 };
 
 using c10d::kUnsetTimeout;

--- a/comms/torchcomms/TorchWork.hpp
+++ b/comms/torchcomms/TorchWork.hpp
@@ -67,6 +67,7 @@ class TorchWork : public c10::intrusive_ptr_target {
   }
 
   friend class TorchComm;
+  friend class WorkWrapper;
 
   void setCallback(std::function<void()> callback) {
     callback_ = std::move(callback);

--- a/comms/torchcomms/tests/integration/py/DDPCommTest.py
+++ b/comms/torchcomms/tests/integration/py/DDPCommTest.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+# pyre-unsafe
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import os
+import unittest
+
+import torch
+import torch.nn as nn
+import torchcomms
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torchcomms.device_mesh import init_device_mesh
+
+
+class DDPCommTest(unittest.TestCase):
+    def test_training(self) -> None:
+        backend = os.environ["TEST_BACKEND"]
+        device = torch.device(os.environ.get("TEST_DEVICE", "cuda"))
+
+        comm = torchcomms.new_comm(backend, device, name="comms_test_ddp")
+
+        try:
+            device_mesh = init_device_mesh(
+                mesh_dim_comms=(comm,),
+                mesh_dim_names=("main",),
+            )
+        except TypeError as e:
+            # TODO: remove this once PT 2.10 is released
+            if "_rank" in str(e):
+                comm.finalize()
+                return
+            raise
+
+        pg = device_mesh.get_group("main")
+
+        torch.manual_seed(42)
+        dim0 = 4
+        nlayer = 2
+        model = nn.Sequential(
+            *[nn.Linear(dim0, dim0, bias=False, device=device) for _ in range(nlayer)]
+        )
+
+        model = DDP(model, process_group=pg)
+
+        optim = torch.optim.Adam(model.parameters(), lr=0.05)
+        # Create input on CPU for reproducibility across ranks, then move
+        inp = torch.randn((4, dim0)).to(device)
+
+        prev_loss = None
+        for i in range(10):
+            loss = model(inp).sum()
+            loss.backward()
+            optim.step()
+            optim.zero_grad()
+
+            loss_val = loss.item()
+            if prev_loss is not None and i < 5:
+                # Verify loss is changing (training is progressing)
+                assert loss_val != prev_loss, (
+                    f"loss did not change at step {i}: {loss_val}"
+                )
+            prev_loss = loss_val
+
+        if device.type == "cuda":
+            torch.cuda.synchronize()
+        comm.finalize()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
Implement the missing `getFuture()` override in `WorkWrapper` to support DDP and other PyTorch distributed features that rely on `c10d::Work::getFuture()`. The future completion behavior differs by device type:

- CUDA: The future is resolved immediately in the constructor under a device guard, so the CUDA event is recorded on the correct stream. Consumers synchronize via CUDA events in the Future.
- CPU (synchronous): The future is resolved immediately since the work is already complete when the constructor runs (e.g., Gloo).
- CPU (async): A callback is registered via `TorchWork::setCallback` so the future completes when `setStatus` transitions to a terminal state.

All collective methods in `BackendWrapper` now pass output tensors to `WorkWrapper`, enabling `result()` and `getFuture()` to return the correct tensors. A fallback in `wait()` and `synchronize()` ensures the future is marked completed even if the callback path wasn't used.

Also adds `DDPCommTest`, an integration test that verifies DDP training works end-to-end with torchcomms using `init_device_mesh`.

Fixes https://github.com/meta-pytorch/torchcomms/issues/688

Differential Revision: D93149654


