### PR TITLE
Stable snapshot on-diff CI

### DIFF
--- a/comms/rcclx/develop/meta/tests/param_comms_rcclx/rcclx_comms_test.py
+++ b/comms/rcclx/develop/meta/tests/param_comms_rcclx/rcclx_comms_test.py
@@ -1,0 +1,32 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+import sys
+import unittest
+
+from param_bench.train.comms.pt.fb.launcher import main as test_launcher
+
+
+class RcclxCommsTest(unittest.TestCase):
+    def test_rcclx_all_reduce(self) -> None:
+        args = [
+            "launcher.py",
+            "--launcher",
+            "local",
+            "--nnode",
+            "1",
+            "--ppn",
+            "2",
+            "--z",
+            "1",
+            "--b",
+            "8",
+            "--e",
+            "64",
+            "--collective",
+            "all_reduce",
+            "--nw-stack",
+            "pytorch-torchcomms",
+            "--backend",
+            "rcclx",
+        ]
+        sys.argv = args
+        test_launcher()


### PR DESCRIPTION
Summary:
Adds a simple param comms test against rcclx_stable and enable for on-diff CI.

This is for task - T253701369

Reviewed By: ganesank-git

Differential Revision: D93168276


