### PR TITLE
Fix ibv_port_attr ABI mismatch with rdma-core

### DIFF
--- a/comms/ctran/ibverbx/Ibvcore.h
+++ b/comms/ctran/ibverbx/Ibvcore.h
@@ -214,7 +214,9 @@ struct ibv_port_attr {
   uint8_t active_speed;
   uint8_t phys_state;
   uint8_t link_layer;
-  uint8_t reserved;
+  uint8_t flags;
+  uint16_t port_cap_flags2;
+  uint32_t active_speed_ex;
 };
 
 enum ibv_event_type {


### PR DESCRIPTION
Summary:
The ibverbx ibv_port_attr struct in Ibvcore.h was missing two fields (port_cap_flags2 and active_speed_ex) that rdma-core added to ::ibv_port_attr. This made ibverbx::ibv_port_attr 48 bytes while

rdma-core's version is 56 bytes. When IbvDevice::queryPort() allocates the undersized struct on the stack and passes it through reinterpret_cast to rdma-core's ibv_query_port, the rdma-core

implementation writes 56 bytes (via memset or the driver's query_port callback) into the 48-byte buffer, causing an 8-byte stack buffer overflow.

(https://man7.org/linux/man-pages/man3/ibv_query_port.3.html)

Reviewed By: mingrany, dmwu

Differential Revision: D93143104


