### PR TITLE
Add memory allocation logging to McclComm

### DIFF
--- a/comms/ctran/mapper/CtranMapper.cc
+++ b/comms/ctran/mapper/CtranMapper.cc
@@ -553,6 +553,14 @@ DevMemType CtranMapper::segmentType(void* segHdl) {
   return segment->getType();
 }
 
+const void* CtranMapper::segmentBuf(void* segHdl) {
+  auto regCache = ctran::RegCache::getInstance();
+  ctran::CHECK_VALID_REGCACHE(regCache);
+
+  ctran::regcache::Segment* segment = regCache->getSegment(segHdl);
+  return segment ? segment->range.buf : nullptr;
+}
+
 commResult_t CtranMapper::deregMem(void* segHdl, const bool skipRemRelease) {
   auto regCache = ctran::RegCache::getInstance();
   ctran::CHECK_VALID_REGCACHE(regCache);

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -110,6 +110,8 @@ class CtranMapper {
 
   DevMemType segmentType(void* segHdl);
 
+  const void* segmentBuf(void* segHdl);
+
   /* Deregister a dynamic registration.
    * Input arguments:
    *   - regHdl: a handle of the dynamic registration

--- a/comms/ctran/mapper/tests/CtranMapperUT.cc
+++ b/comms/ctran/mapper/tests/CtranMapperUT.cc
@@ -234,6 +234,39 @@ TEST_F(CtranMapperTest, regHostMemLazy) {
   EXPECT_EQ(snapshot.totalNumDynamicReg, 0);
 }
 
+TEST_F(CtranMapperTest, segmentBufReturnsOriginalAddr) {
+  EnvRAII env(NCCL_CTRAN_REGISTER, NCCL_CTRAN_REGISTER::lazy);
+
+  mapper = std::make_unique<CtranMapper>(dummyComm_);
+  EXPECT_THAT(mapper, testing::NotNull());
+
+  auto res = mapper->regMem(buf, bufSize, &hdl, false);
+  EXPECT_EQ(res, commSuccess);
+  EXPECT_THAT(hdl, testing::NotNull());
+
+  EXPECT_EQ(mapper->segmentBuf(hdl), buf);
+
+  EXPECT_EQ(mapper->deregMem(hdl), commSuccess);
+}
+
+TEST_F(CtranMapperTest, segmentBufReturnsOriginalAddrHostMem) {
+  EnvRAII env(NCCL_CTRAN_REGISTER, NCCL_CTRAN_REGISTER::lazy);
+
+  mapper = std::make_unique<CtranMapper>(dummyComm_);
+  EXPECT_THAT(mapper, testing::NotNull());
+
+  void* bufH = malloc(bufSize);
+  void* segHdl = nullptr;
+  auto res = mapper->regMem(bufH, bufSize, &segHdl, false);
+  EXPECT_EQ(res, commSuccess);
+  EXPECT_THAT(segHdl, testing::NotNull());
+
+  EXPECT_EQ(mapper->segmentBuf(segHdl), bufH);
+
+  EXPECT_EQ(mapper->deregMem(segHdl), commSuccess);
+  free(bufH);
+}
+
 TEST_F(CtranMapperTest, deregMem) {
   mapper = std::make_unique<CtranMapper>(dummyComm_);
   EXPECT_THAT(mapper, testing::NotNull());


### PR DESCRIPTION
Summary:
McclComm did not emit any logMemoryEvent calls at its level — all GPU
memory logging happened indirectly through ctran allocation functions.
This made it impossible to attribute memory lifecycle events
(init, window allocate/free, register/deregister) to specific MCCL
communicators on the nccld dashboard.

Add logMemoryEvent calls at key McclComm allocation points:
- ctranInit begin/end markers in init()
- winAllocate after successful ctranWinAllocate
- ~McclWindow destructor before ctranWinFree
- commRegister/commDeregister with isRegMemEvent flag

Also add //comms/utils/logger:alloc dep to mccl_comm BUCK target.

Reviewed By: arttianezhu

Differential Revision: D93151088


