### PR TITLE
Add Philox RNG

### DIFF
--- a/comms/utils/kernels/rng/philox_rng.cuh
+++ b/comms/utils/kernels/rng/philox_rng.cuh
@@ -1,0 +1,85 @@
+#ifndef NCCL_DEVICE_PHILOX_RNG_H_
+#define NCCL_DEVICE_PHILOX_RNG_H_
+
+#include <cstdint>
+
+// The code below was copied from: https://fburl.com/vcg6rcfk (lines 35-109)
+// (in github, access required)
+
+// ==============================================================================
+// Philox 4x32 Counter-Based RNG (7 rounds - minimum to pass BigCrush)
+// ==============================================================================
+// Based on Triton's implementation:
+// https://github.com/triton-lang/triton/blob/main/python/triton/language/random.py
+// Philox is a counter-based RNG that produces statistically high-quality
+// random numbers. 7 rounds is the minimum proven to pass BigCrush tests.
+
+// Philox constants for 32-bit version
+constexpr uint32_t PHILOX_KEY_A = 0x9E3779B9;
+constexpr uint32_t PHILOX_KEY_B = 0xBB67AE85;
+constexpr uint32_t PHILOX_ROUND_A = 0xD2511F53;
+constexpr uint32_t PHILOX_ROUND_B = 0xCD9E8D57;
+
+// Helper: unsigned 32-bit multiply high (upper 32 bits of 64-bit product)
+__device__ __forceinline__ uint32_t umulhi32(uint32_t a, uint32_t b) {
+  return __umulhi(a, b);
+}
+
+// Philox 4x32 implementation with n_rounds
+// Takes 4 counters (c0, c1, c2, c3) and 2 keys (k0, k1)
+// Returns 4 random uint32 values
+template <int N_ROUNDS = 7>
+__device__ __forceinline__ void philox4x32(
+    uint32_t& c0,
+    uint32_t& c1,
+    uint32_t& c2,
+    uint32_t& c3,
+    uint32_t k0,
+    uint32_t k1) {
+#pragma unroll
+  for (int round = 0; round < N_ROUNDS; round++) {
+    // Save old values
+    uint32_t _c0 = c0;
+    uint32_t _c2 = c2;
+
+    // Update random state using Philox round function
+    c0 = umulhi32(PHILOX_ROUND_B, _c2) ^ c1 ^ k0;
+    c2 = umulhi32(PHILOX_ROUND_A, _c0) ^ c3 ^ k1;
+    c1 = PHILOX_ROUND_B * _c2;
+    c3 = PHILOX_ROUND_A * _c0;
+
+    // Raise key (Weyl sequence)
+    k0 += PHILOX_KEY_A;
+    k1 += PHILOX_KEY_B;
+  }
+}
+
+// Generate 4 random uint32 values from seed and offset
+// This matches Triton's randint4x function
+__device__ __forceinline__ void philox_randint4x(
+    uint64_t seed,
+    uint64_t offset,
+    uint32_t& r0,
+    uint32_t& r1,
+    uint32_t& r2,
+    uint32_t& r3) {
+  // Split seed into key (k0, k1)
+  uint32_t k0 = static_cast<uint32_t>(seed);
+  uint32_t k1 = static_cast<uint32_t>(seed >> 32);
+
+  // Split offset into counters (c0, c1), c2 and c3 are 0
+  uint32_t c0 = static_cast<uint32_t>(offset);
+  uint32_t c1 = static_cast<uint32_t>(offset >> 32);
+  uint32_t c2 = 0;
+  uint32_t c3 = 0;
+
+  // Run Philox 7 rounds
+  philox4x32<7>(c0, c1, c2, c3, k0, k1);
+
+  r0 = c0;
+  r1 = c1;
+  r2 = c2;
+  r3 = c3;
+}
+
+#endif // NCCL_DEVICE_PHILOX_RNG_H_

--- a/comms/utils/kernels/rng/tests/PhiloxRngBench.cu
+++ b/comms/utils/kernels/rng/tests/PhiloxRngBench.cu
@@ -1,0 +1,427 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+#include "comms/utils/kernels/rng/philox_rng.cuh"
+
+#define CUDACHECK(cmd)                                                    \
+  do {                                                                    \
+    cudaError_t e = cmd;                                                  \
+    ASSERT_EQ(e, cudaSuccess) << "CUDA error: " << cudaGetErrorString(e); \
+  } while (0)
+
+// =============================================================================
+// Benchmark Kernels
+// =============================================================================
+
+// Benchmark kernel: Generate random numbers using Philox RNG
+// Each thread generates 4 random uint32 values and writes them to output
+template <int Unroll>
+__global__ void benchPhiloxKernel(
+    uint64_t seed,
+    uint64_t baseOffset,
+    uint32_t* output,
+    int64_t nElts) {
+  auto thread = threadIdx.x + blockIdx.x * blockDim.x;
+  auto nThreads = blockDim.x * gridDim.x;
+
+  // Process 4 elements at a time (Philox generates 4 random numbers per call)
+  for (int64_t i = thread * 4; i < nElts; i += nThreads * 4 * Unroll) {
+#pragma unroll
+    for (int u = 0; u < Unroll; u++) {
+      int64_t idx = i + u * nThreads * 4;
+      if (idx + 3 < nElts) {
+        uint32_t r0, r1, r2, r3;
+        philox_randint4x(seed, baseOffset + idx, r0, r1, r2, r3);
+        output[idx + 0] = r0;
+        output[idx + 1] = r1;
+        output[idx + 2] = r2;
+        output[idx + 3] = r3;
+      }
+    }
+  }
+}
+
+// =============================================================================
+// Benchmark Fixture
+// =============================================================================
+
+class PhiloxRngBench : public ::testing::Test {
+ protected:
+  static constexpr int64_t kMaxElts =
+      1024L * 8L * 8L * 8L * 8L * 8L * 8L * 8L; // 2G elements
+  static constexpr int kBlockSize = 256;
+  static constexpr int kWarmupIters = 10;
+  static constexpr int kBenchIters = 100;
+
+  uint32_t* d_output = nullptr;
+  cudaEvent_t startEvent, stopEvent;
+
+  void SetUp() override {
+    CUDACHECK(cudaMalloc(&d_output, kMaxElts * sizeof(uint32_t)));
+    CUDACHECK(cudaEventCreate(&startEvent));
+    CUDACHECK(cudaEventCreate(&stopEvent));
+  }
+
+  void TearDown() override {
+    CUDACHECK(cudaEventDestroy(startEvent));
+    CUDACHECK(cudaEventDestroy(stopEvent));
+    CUDACHECK(cudaFree(d_output));
+  }
+
+  // Compute the maximum number of blocks for a given element count
+  int maxBlocks(int64_t nElts) {
+    return std::min((int)((nElts + kBlockSize - 1) / kBlockSize), 1024);
+  }
+
+  // Generate a sequence of block counts: 1, 2, 4, 8, ..., up to maxBlk
+  static std::vector<int> blockCountSweep(int maxBlk) {
+    std::vector<int> counts;
+    for (int b = 1; b <= maxBlk; b *= 2) {
+      counts.push_back(b);
+    }
+    // Always include the true max if it wasn't a power of 2
+    if (counts.empty() || counts.back() != maxBlk) {
+      counts.push_back(maxBlk);
+    }
+    return counts;
+  }
+
+  // Core benchmark runner with explicit block count
+  template <typename LaunchFn>
+  void runBenchCore(
+      int64_t nElts,
+      int nBlocks,
+      LaunchFn launchFn,
+      const char* label) {
+    // Warmup
+    for (int i = 0; i < kWarmupIters; i++) {
+      launchFn(nBlocks, kBlockSize, nElts);
+    }
+    CUDACHECK(cudaDeviceSynchronize());
+
+    // Timed iterations
+    CUDACHECK(cudaEventRecord(startEvent));
+    for (int i = 0; i < kBenchIters; i++) {
+      launchFn(nBlocks, kBlockSize, nElts);
+    }
+    CUDACHECK(cudaEventRecord(stopEvent));
+    CUDACHECK(cudaDeviceSynchronize());
+
+    float elapsedMs = 0.0f;
+    CUDACHECK(cudaEventElapsedTime(&elapsedMs, startEvent, stopEvent));
+    float avgMs = elapsedMs / kBenchIters;
+
+    // Calculate throughput: GB/s of random bytes produced
+    size_t totalBytes = nElts * sizeof(uint32_t);
+    double gbPerSec = (double)totalBytes / (avgMs * 1e6);
+    printf(
+        "  %-45s  nBlocks=%4d  nElts=%10ld  avg=%.3f ms  BW=%.2f GB/s\n",
+        label,
+        nBlocks,
+        (long)nElts,
+        avgMs,
+        gbPerSec);
+  }
+
+  // Generic benchmark runner (max blocks)
+  template <typename LaunchFn>
+  void runBench(int64_t nElts, LaunchFn launchFn, const char* label) {
+    runBenchCore(nElts, maxBlocks(nElts), launchFn, label);
+  }
+};
+
+// =============================================================================
+// Benchmarks: Throughput / Block count sweep
+// =============================================================================
+
+TEST_F(PhiloxRngBench, Throughput) {
+  printf("\n--- Philox RNG: Throughput (varying sizes) ---\n");
+  // 1K to 2G in powers of 8
+  int64_t sizes[] = {
+      1024L, // 1K
+      1024L * 8L, // 8K
+      1024L * 8L * 8L, // 64K
+      1024L * 8L * 8L * 8L, // 512K
+      1024L * 8L * 8L * 8L * 8L, // 4M
+      1024L * 8L * 8L * 8L * 8L * 8L, // 32M
+      1024L * 8L * 8L * 8L * 8L * 8L * 8L, // 256M
+      1024L * 8L * 8L * 8L * 8L * 8L * 8L * 8L, // 2G
+  };
+  uint64_t seed = 12345ULL;
+  uint64_t baseOffset = 0;
+
+  for (int64_t n : sizes) {
+    runBench(
+        n,
+        [&](int nBlocks, int blockSize, int64_t nElts) {
+          benchPhiloxKernel<4>
+              <<<nBlocks, blockSize>>>(seed, baseOffset, d_output, nElts);
+          CUDACHECK(cudaGetLastError());
+        },
+        "Philox RNG (comms, 7 rounds)");
+    printf("\n");
+  }
+}
+
+// =============================================================================
+// Benchmarks: Combined Block count sweep x Unroll factor
+// =============================================================================
+
+TEST_F(PhiloxRngBench, BlockSweepUnrollComparison) {
+  constexpr int64_t N = 4 * 1024 * 1024; // 4M elements
+  printf(
+      "\n--- Philox RNG: Block sweep x Unroll comparison (4M elements) ---\n");
+  uint64_t seed = 12345ULL;
+  uint64_t baseOffset = 0;
+
+  // Helper to run a specific unroll factor with a given block count
+  auto runUnrollWithBlocks = [&](auto unrollTag, int nBlocks) {
+    constexpr int U = decltype(unrollTag)::value;
+    char label[128];
+    snprintf(
+        label,
+        sizeof(label),
+        "comms (7 rounds): Unroll=%d, Blocks=%d",
+        U,
+        nBlocks);
+    runBenchCore(
+        N,
+        nBlocks,
+        [&](int /*ignored*/, int blockSize, int64_t nElts) {
+          benchPhiloxKernel<U>
+              <<<nBlocks, blockSize>>>(seed, baseOffset, d_output, nElts);
+          CUDACHECK(cudaGetLastError());
+        },
+        label);
+  };
+
+  // Sweep blocks for each unroll factor
+  for (int b : blockCountSweep(maxBlocks(N))) {
+    runUnrollWithBlocks(std::integral_constant<int, 1>{}, b);
+    runUnrollWithBlocks(std::integral_constant<int, 2>{}, b);
+    runUnrollWithBlocks(std::integral_constant<int, 4>{}, b);
+    runUnrollWithBlocks(std::integral_constant<int, 8>{}, b);
+    runUnrollWithBlocks(std::integral_constant<int, 16>{}, b);
+    runUnrollWithBlocks(std::integral_constant<int, 32>{}, b);
+    runUnrollWithBlocks(std::integral_constant<int, 64>{}, b);
+
+    // Line break between block sizes
+    printf("\n");
+  }
+}
+
+// clang-format off
+// We want to keep the format for the result below
+
+/*
+-----------------------------------------------------------------------------------------------
+H100 Results
+-----------------------------------------------------------------------------------------------
+
+--- Philox RNG: Throughput (varying sizes) ---
+  Philox RNG                                     nBlocks=   4  nElts=      1024  avg=0.003 ms  BW=1.54 GB/s
+  Philox RNG                                     nBlocks=  32  nElts=      8192  avg=0.003 ms  BW=12.41 GB/s
+  Philox RNG                                     nBlocks= 256  nElts=     65536  avg=0.003 ms  BW=104.50 GB/s
+  Philox RNG                                     nBlocks=1024  nElts=    524288  avg=0.003 ms  BW=608.62 GB/s
+  Philox RNG                                     nBlocks=1024  nElts=   4194304  avg=0.008 ms  BW=2200.39 GB/s
+  Philox RNG                                     nBlocks=1024  nElts=  33554432  avg=0.054 ms  BW=2493.97 GB/s
+  Philox RNG                                     nBlocks=1024  nElts= 268435456  avg=0.432 ms  BW=2483.83 GB/s
+  Philox RNG                                     nBlocks=1024  nElts=2147483648  avg=3.468 ms  BW=2476.81 GB/s
+
+--- Philox RNG: Block sweep x Unroll comparison (4M elements) ---
+  Philox RNG: Unroll=1, Blocks=1                 nBlocks=   1  nElts=   4194304  avg=0.487 ms  BW=34.43 GB/s
+  Philox RNG: Unroll=2, Blocks=1                 nBlocks=   1  nElts=   4194304  avg=0.493 ms  BW=34.02 GB/s
+  Philox RNG: Unroll=4, Blocks=1                 nBlocks=   1  nElts=   4194304  avg=0.476 ms  BW=35.22 GB/s
+  Philox RNG: Unroll=8, Blocks=1                 nBlocks=   1  nElts=   4194304  avg=0.492 ms  BW=34.08 GB/s
+  Philox RNG: Unroll=16, Blocks=1                nBlocks=   1  nElts=   4194304  avg=0.463 ms  BW=36.23 GB/s
+  Philox RNG: Unroll=32, Blocks=1                nBlocks=   1  nElts=   4194304  avg=0.476 ms  BW=35.23 GB/s
+  Philox RNG: Unroll=64, Blocks=1                nBlocks=   1  nElts=   4194304  avg=0.476 ms  BW=35.24 GB/s
+
+  Philox RNG: Unroll=1, Blocks=2                 nBlocks=   2  nElts=   4194304  avg=0.245 ms  BW=68.59 GB/s
+  Philox RNG: Unroll=2, Blocks=2                 nBlocks=   2  nElts=   4194304  avg=0.248 ms  BW=67.74 GB/s
+  Philox RNG: Unroll=4, Blocks=2                 nBlocks=   2  nElts=   4194304  avg=0.239 ms  BW=70.12 GB/s
+  Philox RNG: Unroll=8, Blocks=2                 nBlocks=   2  nElts=   4194304  avg=0.248 ms  BW=67.55 GB/s
+  Philox RNG: Unroll=16, Blocks=2                nBlocks=   2  nElts=   4194304  avg=0.233 ms  BW=72.12 GB/s
+  Philox RNG: Unroll=32, Blocks=2                nBlocks=   2  nElts=   4194304  avg=0.239 ms  BW=70.16 GB/s
+  Philox RNG: Unroll=64, Blocks=2                nBlocks=   2  nElts=   4194304  avg=0.239 ms  BW=70.07 GB/s
+
+  Philox RNG: Unroll=1, Blocks=4                 nBlocks=   4  nElts=   4194304  avg=0.124 ms  BW=135.13 GB/s
+  Philox RNG: Unroll=2, Blocks=4                 nBlocks=   4  nElts=   4194304  avg=0.125 ms  BW=133.96 GB/s
+  Philox RNG: Unroll=4, Blocks=4                 nBlocks=   4  nElts=   4194304  avg=0.121 ms  BW=138.82 GB/s
+  Philox RNG: Unroll=8, Blocks=4                 nBlocks=   4  nElts=   4194304  avg=0.125 ms  BW=133.77 GB/s
+  Philox RNG: Unroll=16, Blocks=4                nBlocks=   4  nElts=   4194304  avg=0.118 ms  BW=142.78 GB/s
+  Philox RNG: Unroll=32, Blocks=4                nBlocks=   4  nElts=   4194304  avg=0.121 ms  BW=139.00 GB/s
+  Philox RNG: Unroll=64, Blocks=4                nBlocks=   4  nElts=   4194304  avg=0.121 ms  BW=138.96 GB/s
+
+  Philox RNG: Unroll=1, Blocks=8                 nBlocks=   8  nElts=   4194304  avg=0.063 ms  BW=267.25 GB/s
+  Philox RNG: Unroll=2, Blocks=8                 nBlocks=   8  nElts=   4194304  avg=0.064 ms  BW=263.57 GB/s
+  Philox RNG: Unroll=4, Blocks=8                 nBlocks=   8  nElts=   4194304  avg=0.062 ms  BW=272.59 GB/s
+  Philox RNG: Unroll=8, Blocks=8                 nBlocks=   8  nElts=   4194304  avg=0.064 ms  BW=262.09 GB/s
+  Philox RNG: Unroll=16, Blocks=8                nBlocks=   8  nElts=   4194304  avg=0.060 ms  BW=280.00 GB/s
+  Philox RNG: Unroll=32, Blocks=8                nBlocks=   8  nElts=   4194304  avg=0.061 ms  BW=273.18 GB/s
+  Philox RNG: Unroll=64, Blocks=8                nBlocks=   8  nElts=   4194304  avg=0.061 ms  BW=273.16 GB/s
+
+  Philox RNG: Unroll=1, Blocks=16                nBlocks=  16  nElts=   4194304  avg=0.033 ms  BW=504.11 GB/s
+  Philox RNG: Unroll=2, Blocks=16                nBlocks=  16  nElts=   4194304  avg=0.033 ms  BW=509.80 GB/s
+  Philox RNG: Unroll=4, Blocks=16                nBlocks=  16  nElts=   4194304  avg=0.032 ms  BW=527.17 GB/s
+  Philox RNG: Unroll=8, Blocks=16                nBlocks=  16  nElts=   4194304  avg=0.033 ms  BW=507.47 GB/s
+  Philox RNG: Unroll=16, Blocks=16               nBlocks=  16  nElts=   4194304  avg=0.031 ms  BW=539.65 GB/s
+  Philox RNG: Unroll=32, Blocks=16               nBlocks=  16  nElts=   4194304  avg=0.032 ms  BW=528.86 GB/s
+  Philox RNG: Unroll=64, Blocks=16               nBlocks=  16  nElts=   4194304  avg=0.032 ms  BW=528.57 GB/s
+
+  Philox RNG: Unroll=1, Blocks=32                nBlocks=  32  nElts=   4194304  avg=0.018 ms  BW=946.40 GB/s
+  Philox RNG: Unroll=2, Blocks=32                nBlocks=  32  nElts=   4194304  avg=0.018 ms  BW=951.07 GB/s
+  Philox RNG: Unroll=4, Blocks=32                nBlocks=  32  nElts=   4194304  avg=0.017 ms  BW=991.02 GB/s
+  Philox RNG: Unroll=8, Blocks=32                nBlocks=  32  nElts=   4194304  avg=0.018 ms  BW=953.15 GB/s
+  Philox RNG: Unroll=16, Blocks=32               nBlocks=  32  nElts=   4194304  avg=0.017 ms  BW=1006.20 GB/s
+  Philox RNG: Unroll=32, Blocks=32               nBlocks=  32  nElts=   4194304  avg=0.017 ms  BW=993.67 GB/s
+  Philox RNG: Unroll=64, Blocks=32               nBlocks=  32  nElts=   4194304  avg=0.017 ms  BW=991.81 GB/s
+
+  Philox RNG: Unroll=1, Blocks=64                nBlocks=  64  nElts=   4194304  avg=0.010 ms  BW=1688.26 GB/s
+  Philox RNG: Unroll=2, Blocks=64                nBlocks=  64  nElts=   4194304  avg=0.010 ms  BW=1701.63 GB/s
+  Philox RNG: Unroll=4, Blocks=64                nBlocks=  64  nElts=   4194304  avg=0.010 ms  BW=1762.19 GB/s
+  Philox RNG: Unroll=8, Blocks=64                nBlocks=  64  nElts=   4194304  avg=0.010 ms  BW=1698.81 GB/s
+  Philox RNG: Unroll=16, Blocks=64               nBlocks=  64  nElts=   4194304  avg=0.009 ms  BW=1771.18 GB/s
+  Philox RNG: Unroll=32, Blocks=64               nBlocks=  64  nElts=   4194304  avg=0.009 ms  BW=1771.06 GB/s
+  Philox RNG: Unroll=64, Blocks=64               nBlocks=  64  nElts=   4194304  avg=0.010 ms  BW=1764.09 GB/s
+
+  Philox RNG: Unroll=1, Blocks=128               nBlocks= 128  nElts=   4194304  avg=0.006 ms  BW=2647.52 GB/s
+  Philox RNG: Unroll=2, Blocks=128               nBlocks= 128  nElts=   4194304  avg=0.006 ms  BW=2753.18 GB/s
+  Philox RNG: Unroll=4, Blocks=128               nBlocks= 128  nElts=   4194304  avg=0.006 ms  BW=2720.89 GB/s
+  Philox RNG: Unroll=8, Blocks=128               nBlocks= 128  nElts=   4194304  avg=0.006 ms  BW=2659.47 GB/s
+  Philox RNG: Unroll=16, Blocks=128              nBlocks= 128  nElts=   4194304  avg=0.006 ms  BW=2652.88 GB/s
+  Philox RNG: Unroll=32, Blocks=128              nBlocks= 128  nElts=   4194304  avg=0.006 ms  BW=2742.38 GB/s
+  Philox RNG: Unroll=64, Blocks=128              nBlocks= 128  nElts=   4194304  avg=0.008 ms  BW=2071.06 GB/s
+
+  Philox RNG: Unroll=1, Blocks=256               nBlocks= 256  nElts=   4194304  avg=0.007 ms  BW=2412.29 GB/s
+  Philox RNG: Unroll=2, Blocks=256               nBlocks= 256  nElts=   4194304  avg=0.006 ms  BW=2615.16 GB/s
+  Philox RNG: Unroll=4, Blocks=256               nBlocks= 256  nElts=   4194304  avg=0.007 ms  BW=2531.45 GB/s
+  Philox RNG: Unroll=8, Blocks=256               nBlocks= 256  nElts=   4194304  avg=0.007 ms  BW=2564.76 GB/s
+  Philox RNG: Unroll=16, Blocks=256              nBlocks= 256  nElts=   4194304  avg=0.007 ms  BW=2316.99 GB/s
+  Philox RNG: Unroll=32, Blocks=256              nBlocks= 256  nElts=   4194304  avg=0.007 ms  BW=2381.61 GB/s
+  Philox RNG: Unroll=64, Blocks=256              nBlocks= 256  nElts=   4194304  avg=0.009 ms  BW=1825.90 GB/s
+
+  Philox RNG: Unroll=1, Blocks=512               nBlocks= 512  nElts=   4194304  avg=0.008 ms  BW=2204.47 GB/s
+  Philox RNG: Unroll=2, Blocks=512               nBlocks= 512  nElts=   4194304  avg=0.007 ms  BW=2373.63 GB/s
+  Philox RNG: Unroll=4, Blocks=512               nBlocks= 512  nElts=   4194304  avg=0.007 ms  BW=2261.03 GB/s
+  Philox RNG: Unroll=8, Blocks=512               nBlocks= 512  nElts=   4194304  avg=0.007 ms  BW=2316.68 GB/s
+  Philox RNG: Unroll=16, Blocks=512              nBlocks= 512  nElts=   4194304  avg=0.007 ms  BW=2239.49 GB/s
+  Philox RNG: Unroll=32, Blocks=512              nBlocks= 512  nElts=   4194304  avg=0.009 ms  BW=1924.28 GB/s
+  Philox RNG: Unroll=64, Blocks=512              nBlocks= 512  nElts=   4194304  avg=0.012 ms  BW=1371.01 GB/s
+
+  Philox RNG: Unroll=1, Blocks=1024              nBlocks=1024  nElts=   4194304  avg=0.008 ms  BW=2197.07 GB/s
+  Philox RNG: Unroll=2, Blocks=1024              nBlocks=1024  nElts=   4194304  avg=0.008 ms  BW=2167.73 GB/s
+  Philox RNG: Unroll=4, Blocks=1024              nBlocks=1024  nElts=   4194304  avg=0.008 ms  BW=2209.48 GB/s
+  Philox RNG: Unroll=8, Blocks=1024              nBlocks=1024  nElts=   4194304  avg=0.007 ms  BW=2314.23 GB/s
+  Philox RNG: Unroll=16, Blocks=1024             nBlocks=1024  nElts=   4194304  avg=0.009 ms  BW=1924.06 GB/s
+  Philox RNG: Unroll=32, Blocks=1024             nBlocks=1024  nElts=   4194304  avg=0.009 ms  BW=1940.80 GB/s
+  Philox RNG: Unroll=64, Blocks=1024             nBlocks=1024  nElts=   4194304  avg=0.016 ms  BW=1072.58 GB/s
+
+-----------------------------------------------------------------------------------------------
+GB200 Results
+-----------------------------------------------------------------------------------------------
+
+--- Philox RNG: Throughput (varying sizes) ---
+  Philox RNG                                     nBlocks=   4  nElts=      1024  avg=0.003 ms  BW=1.25 GB/s
+  Philox RNG                                     nBlocks=  32  nElts=      8192  avg=0.004 ms  BW=8.08 GB/s
+  Philox RNG                                     nBlocks= 256  nElts=     65536  avg=0.004 ms  BW=64.95 GB/s
+  Philox RNG                                     nBlocks=1024  nElts=    524288  avg=0.004 ms  BW=507.48 GB/s
+  Philox RNG                                     nBlocks=1024  nElts=   4194304  avg=0.006 ms  BW=2674.94 GB/s
+  Philox RNG                                     nBlocks=1024  nElts=  33554432  avg=0.029 ms  BW=4673.58 GB/s
+  Philox RNG                                     nBlocks=1024  nElts= 268435456  avg=0.198 ms  BW=5415.49 GB/s
+  Philox RNG                                     nBlocks=1024  nElts=2147483648  avg=1.555 ms  BW=5525.12 GB/s
+
+--- Philox RNG: Block sweep x Unroll comparison (4M elements) ---
+  Philox RNG: Unroll=1, Blocks=1                 nBlocks=   1  nElts=   4194304  avg=0.467 ms  BW=35.94 GB/s
+  Philox RNG: Unroll=2, Blocks=1                 nBlocks=   1  nElts=   4194304  avg=0.524 ms  BW=31.99 GB/s
+  Philox RNG: Unroll=4, Blocks=1                 nBlocks=   1  nElts=   4194304  avg=0.562 ms  BW=29.83 GB/s
+  Philox RNG: Unroll=8, Blocks=1                 nBlocks=   1  nElts=   4194304  avg=0.566 ms  BW=29.64 GB/s
+  Philox RNG: Unroll=16, Blocks=1                nBlocks=   1  nElts=   4194304  avg=0.480 ms  BW=34.93 GB/s
+  Philox RNG: Unroll=32, Blocks=1                nBlocks=   1  nElts=   4194304  avg=0.456 ms  BW=36.75 GB/s
+  Philox RNG: Unroll=64, Blocks=1                nBlocks=   1  nElts=   4194304  avg=0.469 ms  BW=35.74 GB/s
+
+  Philox RNG: Unroll=1, Blocks=2                 nBlocks=   2  nElts=   4194304  avg=0.227 ms  BW=73.77 GB/s
+  Philox RNG: Unroll=2, Blocks=2                 nBlocks=   2  nElts=   4194304  avg=0.262 ms  BW=64.09 GB/s
+  Philox RNG: Unroll=4, Blocks=2                 nBlocks=   2  nElts=   4194304  avg=0.283 ms  BW=59.32 GB/s
+  Philox RNG: Unroll=8, Blocks=2                 nBlocks=   2  nElts=   4194304  avg=0.285 ms  BW=58.92 GB/s
+  Philox RNG: Unroll=16, Blocks=2                nBlocks=   2  nElts=   4194304  avg=0.243 ms  BW=68.95 GB/s
+  Philox RNG: Unroll=32, Blocks=2                nBlocks=   2  nElts=   4194304  avg=0.230 ms  BW=72.83 GB/s
+  Philox RNG: Unroll=64, Blocks=2                nBlocks=   2  nElts=   4194304  avg=0.237 ms  BW=70.65 GB/s
+
+  Philox RNG: Unroll=1, Blocks=4                 nBlocks=   4  nElts=   4194304  avg=0.115 ms  BW=145.35 GB/s
+  Philox RNG: Unroll=2, Blocks=4                 nBlocks=   4  nElts=   4194304  avg=0.133 ms  BW=125.83 GB/s
+  Philox RNG: Unroll=4, Blocks=4                 nBlocks=   4  nElts=   4194304  avg=0.143 ms  BW=117.01 GB/s
+  Philox RNG: Unroll=8, Blocks=4                 nBlocks=   4  nElts=   4194304  avg=0.144 ms  BW=116.22 GB/s
+  Philox RNG: Unroll=16, Blocks=4                nBlocks=   4  nElts=   4194304  avg=0.126 ms  BW=133.62 GB/s
+  Philox RNG: Unroll=32, Blocks=4                nBlocks=   4  nElts=   4194304  avg=0.118 ms  BW=142.32 GB/s
+  Philox RNG: Unroll=64, Blocks=4                nBlocks=   4  nElts=   4194304  avg=0.121 ms  BW=138.89 GB/s
+
+  Philox RNG: Unroll=1, Blocks=8                 nBlocks=   8  nElts=   4194304  avg=0.059 ms  BW=282.19 GB/s
+  Philox RNG: Unroll=2, Blocks=8                 nBlocks=   8  nElts=   4194304  avg=0.069 ms  BW=244.34 GB/s
+  Philox RNG: Unroll=4, Blocks=8                 nBlocks=   8  nElts=   4194304  avg=0.074 ms  BW=227.62 GB/s
+  Philox RNG: Unroll=8, Blocks=8                 nBlocks=   8  nElts=   4194304  avg=0.074 ms  BW=227.31 GB/s
+  Philox RNG: Unroll=16, Blocks=8                nBlocks=   8  nElts=   4194304  avg=0.066 ms  BW=255.93 GB/s
+  Philox RNG: Unroll=32, Blocks=8                nBlocks=   8  nElts=   4194304  avg=0.061 ms  BW=275.03 GB/s
+  Philox RNG: Unroll=64, Blocks=8                nBlocks=   8  nElts=   4194304  avg=0.061 ms  BW=272.84 GB/s
+
+  Philox RNG: Unroll=1, Blocks=16                nBlocks=  16  nElts=   4194304  avg=0.032 ms  BW=528.47 GB/s
+  Philox RNG: Unroll=2, Blocks=16                nBlocks=  16  nElts=   4194304  avg=0.037 ms  BW=454.87 GB/s
+  Philox RNG: Unroll=4, Blocks=16                nBlocks=  16  nElts=   4194304  avg=0.039 ms  BW=430.74 GB/s
+  Philox RNG: Unroll=8, Blocks=16                nBlocks=  16  nElts=   4194304  avg=0.039 ms  BW=430.95 GB/s
+  Philox RNG: Unroll=16, Blocks=16               nBlocks=  16  nElts=   4194304  avg=0.035 ms  BW=481.66 GB/s
+  Philox RNG: Unroll=32, Blocks=16               nBlocks=  16  nElts=   4194304  avg=0.033 ms  BW=511.43 GB/s
+  Philox RNG: Unroll=64, Blocks=16               nBlocks=  16  nElts=   4194304  avg=0.033 ms  BW=511.72 GB/s
+
+  Philox RNG: Unroll=1, Blocks=32                nBlocks=  32  nElts=   4194304  avg=0.018 ms  BW=909.59 GB/s
+  Philox RNG: Unroll=2, Blocks=32                nBlocks=  32  nElts=   4194304  avg=0.021 ms  BW=818.34 GB/s
+  Philox RNG: Unroll=4, Blocks=32                nBlocks=  32  nElts=   4194304  avg=0.021 ms  BW=817.71 GB/s
+  Philox RNG: Unroll=8, Blocks=32                nBlocks=  32  nElts=   4194304  avg=0.021 ms  BW=817.28 GB/s
+  Philox RNG: Unroll=16, Blocks=32               nBlocks=  32  nElts=   4194304  avg=0.018 ms  BW=908.90 GB/s
+  Philox RNG: Unroll=32, Blocks=32               nBlocks=  32  nElts=   4194304  avg=0.018 ms  BW=909.45 GB/s
+  Philox RNG: Unroll=64, Blocks=32               nBlocks=  32  nElts=   4194304  avg=0.018 ms  BW=908.39 GB/s
+
+  Philox RNG: Unroll=1, Blocks=64                nBlocks=  64  nElts=   4194304  avg=0.010 ms  BW=1631.47 GB/s
+  Philox RNG: Unroll=2, Blocks=64                nBlocks=  64  nElts=   4194304  avg=0.012 ms  BW=1363.56 GB/s
+  Philox RNG: Unroll=4, Blocks=64                nBlocks=  64  nElts=   4194304  avg=0.012 ms  BW=1358.93 GB/s
+  Philox RNG: Unroll=8, Blocks=64                nBlocks=  64  nElts=   4194304  avg=0.012 ms  BW=1359.46 GB/s
+  Philox RNG: Unroll=16, Blocks=64               nBlocks=  64  nElts=   4194304  avg=0.012 ms  BW=1365.12 GB/s
+  Philox RNG: Unroll=32, Blocks=64               nBlocks=  64  nElts=   4194304  avg=0.010 ms  BW=1632.84 GB/s
+  Philox RNG: Unroll=64, Blocks=64               nBlocks=  64  nElts=   4194304  avg=0.010 ms  BW=1628.12 GB/s
+
+  Philox RNG: Unroll=1, Blocks=128               nBlocks= 128  nElts=   4194304  avg=0.008 ms  BW=2042.26 GB/s
+  Philox RNG: Unroll=2, Blocks=128               nBlocks= 128  nElts=   4194304  avg=0.008 ms  BW=2044.01 GB/s
+  Philox RNG: Unroll=4, Blocks=128               nBlocks= 128  nElts=   4194304  avg=0.008 ms  BW=2039.95 GB/s
+  Philox RNG: Unroll=8, Blocks=128               nBlocks= 128  nElts=   4194304  avg=0.008 ms  BW=2038.84 GB/s
+  Philox RNG: Unroll=16, Blocks=128              nBlocks= 128  nElts=   4194304  avg=0.008 ms  BW=2043.93 GB/s
+  Philox RNG: Unroll=32, Blocks=128              nBlocks= 128  nElts=   4194304  avg=0.008 ms  BW=2101.44 GB/s
+  Philox RNG: Unroll=64, Blocks=128              nBlocks= 128  nElts=   4194304  avg=0.010 ms  BW=1636.25 GB/s
+
+  Philox RNG: Unroll=1, Blocks=256               nBlocks= 256  nElts=   4194304  avg=0.006 ms  BW=2713.00 GB/s
+  Philox RNG: Unroll=2, Blocks=256               nBlocks= 256  nElts=   4194304  avg=0.007 ms  BW=2328.10 GB/s
+  Philox RNG: Unroll=4, Blocks=256               nBlocks= 256  nElts=   4194304  avg=0.008 ms  BW=2043.37 GB/s
+  Philox RNG: Unroll=8, Blocks=256               nBlocks= 256  nElts=   4194304  avg=0.008 ms  BW=2041.22 GB/s
+  Philox RNG: Unroll=16, Blocks=256              nBlocks= 256  nElts=   4194304  avg=0.008 ms  BW=2192.57 GB/s
+  Philox RNG: Unroll=32, Blocks=256              nBlocks= 256  nElts=   4194304  avg=0.008 ms  BW=2036.54 GB/s
+  Philox RNG: Unroll=64, Blocks=256              nBlocks= 256  nElts=   4194304  avg=0.010 ms  BW=1633.80 GB/s
+
+  Philox RNG: Unroll=1, Blocks=512               nBlocks= 512  nElts=   4194304  avg=0.006 ms  BW=2719.20 GB/s
+  Philox RNG: Unroll=2, Blocks=512               nBlocks= 512  nElts=   4194304  avg=0.007 ms  BW=2341.51 GB/s
+  Philox RNG: Unroll=4, Blocks=512               nBlocks= 512  nElts=   4194304  avg=0.008 ms  BW=2041.62 GB/s
+  Philox RNG: Unroll=8, Blocks=512               nBlocks= 512  nElts=   4194304  avg=0.008 ms  BW=2063.64 GB/s
+  Philox RNG: Unroll=16, Blocks=512              nBlocks= 512  nElts=   4194304  avg=0.008 ms  BW=2041.54 GB/s
+  Philox RNG: Unroll=32, Blocks=512              nBlocks= 512  nElts=   4194304  avg=0.008 ms  BW=2039.24 GB/s
+  Philox RNG: Unroll=64, Blocks=512              nBlocks= 512  nElts=   4194304  avg=0.012 ms  BW=1364.48 GB/s
+
+  Philox RNG: Unroll=1, Blocks=1024              nBlocks=1024  nElts=   4194304  avg=0.006 ms  BW=2713.14 GB/s
+  Philox RNG: Unroll=2, Blocks=1024              nBlocks=1024  nElts=   4194304  avg=0.006 ms  BW=2713.71 GB/s
+  Philox RNG: Unroll=4, Blocks=1024              nBlocks=1024  nElts=   4194304  avg=0.006 ms  BW=2683.02 GB/s
+  Philox RNG: Unroll=8, Blocks=1024              nBlocks=1024  nElts=   4194304  avg=0.008 ms  BW=2047.04 GB/s
+  Philox RNG: Unroll=16, Blocks=1024             nBlocks=1024  nElts=   4194304  avg=0.008 ms  BW=2043.53 GB/s
+  Philox RNG: Unroll=32, Blocks=1024             nBlocks=1024  nElts=   4194304  avg=0.010 ms  BW=1632.63 GB/s
+  Philox RNG: Unroll=64, Blocks=1024             nBlocks=1024  nElts=   4194304  avg=0.015 ms  BW=1117.41 GB/s
+  */

--- a/comms/utils/kernels/rng/tests/PhiloxRngTest.cu
+++ b/comms/utils/kernels/rng/tests/PhiloxRngTest.cu
@@ -1,0 +1,419 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+#include <cmath>
+#include <cstdint>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+// The device header under test
+#include "comms/utils/kernels/rng/philox_rng.cuh"
+
+#define CUDACHECK(cmd)                                                    \
+  do {                                                                    \
+    cudaError_t e = cmd;                                                  \
+    ASSERT_EQ(e, cudaSuccess) << "CUDA error: " << cudaGetErrorString(e); \
+  } while (0)
+
+// =============================================================================
+// Test Kernels
+// =============================================================================
+
+// Kernel: run philox_randint4x for a single (seed, offset) and store results
+__global__ void
+philoxSingleKernel(uint64_t seed, uint64_t offset, uint32_t* out) {
+  uint32_t r0, r1, r2, r3;
+  philox_randint4x(seed, offset, r0, r1, r2, r3);
+  out[0] = r0;
+  out[1] = r1;
+  out[2] = r2;
+  out[3] = r3;
+}
+
+// Kernel: run philox_randint4x for N different offsets
+__global__ void
+philoxBatchKernel(uint64_t seed, uint64_t baseOffset, int n, uint32_t* out) {
+  auto idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= n) {
+    return;
+  }
+  uint32_t r0, r1, r2, r3;
+  philox_randint4x(seed, baseOffset + idx, r0, r1, r2, r3);
+  out[idx * 4 + 0] = r0;
+  out[idx * 4 + 1] = r1;
+  out[idx * 4 + 2] = r2;
+  out[idx * 4 + 3] = r3;
+}
+
+// Kernel: test philox4x32 directly with specified round count
+template <int N_ROUNDS>
+__global__ void philoxRoundsKernel(
+    uint32_t c0_in,
+    uint32_t c1_in,
+    uint32_t c2_in,
+    uint32_t c3_in,
+    uint32_t k0,
+    uint32_t k1,
+    uint32_t* out) {
+  uint32_t c0 = c0_in, c1 = c1_in, c2 = c2_in, c3 = c3_in;
+  philox4x32<N_ROUNDS>(c0, c1, c2, c3, k0, k1);
+  out[0] = c0;
+  out[1] = c1;
+  out[2] = c2;
+  out[3] = c3;
+}
+
+// =============================================================================
+// Test Fixture
+// =============================================================================
+
+class PhiloxRngTest : public ::testing::Test {
+ protected:
+  uint32_t* d_out = nullptr;
+  static constexpr int kMaxOutputSize = 4096 * 4; // 4096 offsets * 4 values
+
+  void SetUp() override {
+    CUDACHECK(cudaMalloc(&d_out, kMaxOutputSize * sizeof(uint32_t)));
+    CUDACHECK(cudaMemset(d_out, 0, kMaxOutputSize * sizeof(uint32_t)));
+  }
+
+  void TearDown() override {
+    if (d_out) {
+      CUDACHECK(cudaFree(d_out));
+    }
+  }
+
+  std::vector<uint32_t> readOutput(int count) {
+    std::vector<uint32_t> h_out(count);
+    EXPECT_EQ(
+        cudaMemcpy(
+            h_out.data(),
+            d_out,
+            count * sizeof(uint32_t),
+            cudaMemcpyDeviceToHost),
+        cudaSuccess);
+    return h_out;
+  }
+};
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+// Test determinism: same (seed, offset) produces same output
+TEST_F(PhiloxRngTest, Deterministic) {
+  uint64_t seed = 12345ULL;
+  uint64_t offset = 67890ULL;
+
+  philoxSingleKernel<<<1, 1>>>(seed, offset, d_out);
+  CUDACHECK(cudaGetLastError());
+  CUDACHECK(cudaDeviceSynchronize());
+  auto result1 = readOutput(4);
+
+  CUDACHECK(cudaMemset(d_out, 0, 4 * sizeof(uint32_t)));
+  philoxSingleKernel<<<1, 1>>>(seed, offset, d_out);
+  CUDACHECK(cudaGetLastError());
+  CUDACHECK(cudaDeviceSynchronize());
+  auto result2 = readOutput(4);
+
+  EXPECT_EQ(result1[0], result2[0]);
+  EXPECT_EQ(result1[1], result2[1]);
+  EXPECT_EQ(result1[2], result2[2]);
+  EXPECT_EQ(result1[3], result2[3]);
+}
+
+// Test that different offsets produce different outputs
+TEST_F(PhiloxRngTest, DifferentOffsetsProduceDifferentValues) {
+  uint64_t seed = 42ULL;
+
+  philoxSingleKernel<<<1, 1>>>(seed, 0, d_out);
+  CUDACHECK(cudaGetLastError());
+  CUDACHECK(cudaDeviceSynchronize());
+  auto result0 = readOutput(4);
+
+  philoxSingleKernel<<<1, 1>>>(seed, 1, d_out);
+  CUDACHECK(cudaGetLastError());
+  CUDACHECK(cudaDeviceSynchronize());
+  auto result1 = readOutput(4);
+
+  // At least one of the 4 outputs should differ
+  bool anyDifferent = false;
+  for (int i = 0; i < 4; i++) {
+    if (result0[i] != result1[i]) {
+      anyDifferent = true;
+    }
+  }
+  EXPECT_TRUE(anyDifferent)
+      << "Different offsets should produce different values";
+}
+
+// Test that different seeds produce different outputs
+TEST_F(PhiloxRngTest, DifferentSeedsProduceDifferentValues) {
+  uint64_t offset = 0;
+
+  philoxSingleKernel<<<1, 1>>>(0, offset, d_out);
+  CUDACHECK(cudaGetLastError());
+  CUDACHECK(cudaDeviceSynchronize());
+  auto result0 = readOutput(4);
+
+  philoxSingleKernel<<<1, 1>>>(1, offset, d_out);
+  CUDACHECK(cudaGetLastError());
+  CUDACHECK(cudaDeviceSynchronize());
+  auto result1 = readOutput(4);
+
+  bool anyDifferent = false;
+  for (int i = 0; i < 4; i++) {
+    if (result0[i] != result1[i]) {
+      anyDifferent = true;
+    }
+  }
+  EXPECT_TRUE(anyDifferent)
+      << "Different seeds should produce different values";
+}
+
+// Test uniformity: output values should be roughly uniformly distributed
+// Use a chi-squared test approach with buckets
+TEST_F(PhiloxRngTest, UniformDistribution) {
+  constexpr int N = 4096;
+  uint64_t seed = 0xDEADBEEFULL;
+
+  philoxBatchKernel<<<(N + 255) / 256, 256>>>(seed, 0, N, d_out);
+  CUDACHECK(cudaGetLastError());
+  CUDACHECK(cudaDeviceSynchronize());
+  auto results = readOutput(N * 4);
+
+  // Split uint32 range into 16 buckets and check distribution
+  constexpr int nBuckets = 16;
+  int buckets[nBuckets] = {};
+  int totalValues = N * 4;
+
+  for (int i = 0; i < totalValues; i++) {
+    int bucket = results[i] / (UINT32_MAX / nBuckets + 1);
+    if (bucket >= nBuckets) {
+      bucket = nBuckets - 1;
+    }
+    buckets[bucket]++;
+  }
+
+  double expected = (double)totalValues / nBuckets;
+  double chiSquared = 0.0;
+  for (int b = 0; b < nBuckets; b++) {
+    double diff = buckets[b] - expected;
+    chiSquared += (diff * diff) / expected;
+  }
+
+  // Chi-squared critical value for 15 df at p=0.001 is ~30.58
+  // Use a generous threshold since we have finite samples
+  EXPECT_LT(chiSquared, 50.0)
+      << "Distribution does not look uniform, chi-squared = " << chiSquared;
+}
+
+// Test that all 4 output channels are independent (low correlation)
+TEST_F(PhiloxRngTest, OutputChannelIndependence) {
+  constexpr int N = 1024;
+  uint64_t seed = 0xCAFEBABEULL;
+
+  philoxBatchKernel<<<(N + 255) / 256, 256>>>(seed, 0, N, d_out);
+  CUDACHECK(cudaGetLastError());
+  CUDACHECK(cudaDeviceSynchronize());
+  auto results = readOutput(N * 4);
+
+  // Check that channels r0 and r1 are not correlated
+  // Compute Pearson correlation coefficient
+  auto computeCorrelation = [&](int ch_a, int ch_b) -> double {
+    double sumA = 0, sumB = 0, sumAB = 0, sumA2 = 0, sumB2 = 0;
+    for (int i = 0; i < N; i++) {
+      double a = (double)results[i * 4 + ch_a];
+      double b = (double)results[i * 4 + ch_b];
+      sumA += a;
+      sumB += b;
+      sumAB += a * b;
+      sumA2 += a * a;
+      sumB2 += b * b;
+    }
+    double meanA = sumA / N, meanB = sumB / N;
+    double covAB = sumAB / N - meanA * meanB;
+    double stdA = std::sqrt(sumA2 / N - meanA * meanA);
+    double stdB = std::sqrt(sumB2 / N - meanB * meanB);
+    if (stdA < 1e-10 || stdB < 1e-10) {
+      return 0.0;
+    }
+    return covAB / (stdA * stdB);
+  };
+
+  // Test all pairs of output channels
+  for (int a = 0; a < 4; a++) {
+    for (int b = a + 1; b < 4; b++) {
+      double corr = computeCorrelation(a, b);
+      EXPECT_LT(std::abs(corr), 0.1) << "Channels " << a << " and " << b
+                                     << " appear correlated (r=" << corr << ")";
+    }
+  }
+}
+
+// Test with zero seed and offset
+TEST_F(PhiloxRngTest, ZeroInputs) {
+  philoxSingleKernel<<<1, 1>>>(0, 0, d_out);
+  CUDACHECK(cudaGetLastError());
+  CUDACHECK(cudaDeviceSynchronize());
+  auto result = readOutput(4);
+
+  // Should produce non-zero output even with zero inputs
+  bool anyNonZero = false;
+  for (int i = 0; i < 4; i++) {
+    if (result[i] != 0) {
+      anyNonZero = true;
+    }
+  }
+  EXPECT_TRUE(anyNonZero)
+      << "Philox with zero inputs should produce non-zero output";
+}
+
+// Test with maximum seed and offset values
+TEST_F(PhiloxRngTest, MaxInputs) {
+  philoxSingleKernel<<<1, 1>>>(UINT64_MAX, UINT64_MAX, d_out);
+  CUDACHECK(cudaGetLastError());
+  CUDACHECK(cudaDeviceSynchronize());
+  auto result = readOutput(4);
+
+  // Should not crash and should produce valid output
+  // No specific value check, just verify it runs
+  EXPECT_TRUE(true);
+}
+
+// Test that 64-bit seed uses both halves
+TEST_F(PhiloxRngTest, SeedBothHalves) {
+  uint64_t offset = 42;
+
+  // Seeds that differ only in upper 32 bits
+  uint64_t seedA = 0x00000001ULL;
+  uint64_t seedB = 0x0000000100000001ULL;
+
+  philoxSingleKernel<<<1, 1>>>(seedA, offset, d_out);
+  CUDACHECK(cudaGetLastError());
+  CUDACHECK(cudaDeviceSynchronize());
+  auto resultA = readOutput(4);
+
+  philoxSingleKernel<<<1, 1>>>(seedB, offset, d_out);
+  CUDACHECK(cudaGetLastError());
+  CUDACHECK(cudaDeviceSynchronize());
+  auto resultB = readOutput(4);
+
+  bool anyDifferent = false;
+  for (int i = 0; i < 4; i++) {
+    if (resultA[i] != resultB[i]) {
+      anyDifferent = true;
+    }
+  }
+  EXPECT_TRUE(anyDifferent) << "Seed upper bits should affect output";
+}
+
+// Test that 64-bit offset uses both halves
+TEST_F(PhiloxRngTest, OffsetBothHalves) {
+  uint64_t seed = 42;
+
+  uint64_t offsetA = 0x00000001ULL;
+  uint64_t offsetB = 0x0000000100000001ULL;
+
+  philoxSingleKernel<<<1, 1>>>(seed, offsetA, d_out);
+  CUDACHECK(cudaGetLastError());
+  CUDACHECK(cudaDeviceSynchronize());
+  auto resultA = readOutput(4);
+
+  philoxSingleKernel<<<1, 1>>>(seed, offsetB, d_out);
+  CUDACHECK(cudaGetLastError());
+  CUDACHECK(cudaDeviceSynchronize());
+  auto resultB = readOutput(4);
+
+  bool anyDifferent = false;
+  for (int i = 0; i < 4; i++) {
+    if (resultA[i] != resultB[i]) {
+      anyDifferent = true;
+    }
+  }
+  EXPECT_TRUE(anyDifferent) << "Offset upper bits should affect output";
+}
+
+// Test uniqueness: consecutive offsets produce unique 4-tuples
+TEST_F(PhiloxRngTest, ConsecutiveOffsetsUnique) {
+  constexpr int N = 256;
+  uint64_t seed = 999;
+
+  philoxBatchKernel<<<(N + 255) / 256, 256>>>(seed, 0, N, d_out);
+  CUDACHECK(cudaGetLastError());
+  CUDACHECK(cudaDeviceSynchronize());
+  auto results = readOutput(N * 4);
+
+  // Check each 4-tuple is unique by creating string keys
+  std::unordered_set<std::string> seen;
+  for (int i = 0; i < N; i++) {
+    std::string key = std::to_string(results[i * 4]) + "," +
+        std::to_string(results[i * 4 + 1]) + "," +
+        std::to_string(results[i * 4 + 2]) + "," +
+        std::to_string(results[i * 4 + 3]);
+    EXPECT_EQ(seen.count(key), 0u) << "Duplicate 4-tuple found at offset " << i;
+    seen.insert(key);
+  }
+}
+
+// Test that different round counts produce different (and presumably
+// weaker/stronger) outputs
+TEST_F(PhiloxRngTest, DifferentRoundCounts) {
+  uint32_t c0 = 1, c1 = 2, c2 = 0, c3 = 0;
+  uint32_t k0 = 0xDEAD, k1 = 0xBEEF;
+
+  philoxRoundsKernel<1><<<1, 1>>>(c0, c1, c2, c3, k0, k1, d_out);
+  CUDACHECK(cudaGetLastError());
+  CUDACHECK(cudaDeviceSynchronize());
+  auto result1 = readOutput(4);
+
+  philoxRoundsKernel<7><<<1, 1>>>(c0, c1, c2, c3, k0, k1, d_out);
+  CUDACHECK(cudaGetLastError());
+  CUDACHECK(cudaDeviceSynchronize());
+  auto result7 = readOutput(4);
+
+  philoxRoundsKernel<10><<<1, 1>>>(c0, c1, c2, c3, k0, k1, d_out);
+  CUDACHECK(cudaGetLastError());
+  CUDACHECK(cudaDeviceSynchronize());
+  auto result10 = readOutput(4);
+
+  // Different round counts should produce different results
+  bool diff_1_7 = false, diff_7_10 = false;
+  for (int i = 0; i < 4; i++) {
+    if (result1[i] != result7[i]) {
+      diff_1_7 = true;
+    }
+    if (result7[i] != result10[i]) {
+      diff_7_10 = true;
+    }
+  }
+  EXPECT_TRUE(diff_1_7) << "1 round vs 7 rounds should differ";
+  EXPECT_TRUE(diff_7_10) << "7 rounds vs 10 rounds should differ";
+}
+
+// Test multi-threaded consistency: each thread gets its own unique output
+TEST_F(PhiloxRngTest, MultiThreadedConsistency) {
+  constexpr int N = 512;
+  uint64_t seed = 0x1234;
+
+  // Launch with many threads
+  philoxBatchKernel<<<2, 256>>>(seed, 0, N, d_out);
+  CUDACHECK(cudaGetLastError());
+  CUDACHECK(cudaDeviceSynchronize());
+  auto resultsMulti = readOutput(N * 4);
+
+  // Verify against single-threaded execution
+  CUDACHECK(cudaMemset(d_out, 0, N * 4 * sizeof(uint32_t)));
+  philoxBatchKernel<<<N, 1>>>(seed, 0, N, d_out);
+  CUDACHECK(cudaGetLastError());
+  CUDACHECK(cudaDeviceSynchronize());
+  auto resultsSingle = readOutput(N * 4);
+
+  for (int i = 0; i < N * 4; i++) {
+    EXPECT_EQ(resultsMulti[i], resultsSingle[i])
+        << "Mismatch at index " << i
+        << " between multi-thread and single-thread execution";
+  }
+}


### PR DESCRIPTION
Summary:
Add Philox 4x32 counter-based RNG implementation for stochastic rounding in quantized collectives. The implementation is copied from [Jianyu's commit](https://github.com/fairinternal/gb200_moe_sol/commit/50546403adb2e0ef13013dee644ac6d61025dcc6#diff-18537af02b8d0c93856db69d228a907d1f118ae4d857f23b57eb8841c738d2a6)

Key components:
- philox4x32<N_ROUNDS>(): Core template function implementing the Philox round function with configurable round count
- philox_randint4x(): Convenience function that generates 4 random uint32 values from a 64-bit seed and offset

Also adds comprehensive unit tests covering: determinism, different seeds/offsets producing different values, uniform distribution (chi-squared test), output channel independence, 64-bit seed/offset utilization, uniqueness of consecutive outputs, different round counts, and multi-threaded consistency.

Differential Revision: D92755791


