### PR TITLE
Add op_count to event scopes for parent-child correlation

### DIFF
--- a/comms/utils/commSpecs.h
+++ b/comms/utils/commSpecs.h
@@ -238,12 +238,13 @@ struct CommLogData {
   std::string commDesc{"undefined"};
   int rank{-1};
   int nRanks{-1};
+  int64_t uuid{-1}; // MCCL comm instance UUID (from InitOpts::uuid)
 
   bool operator==(const CommLogData& other) const {
     return (
         commId == other.commId && commHash == other.commHash &&
         commDesc == other.commDesc && rank == other.rank &&
-        nRanks == other.nRanks);
+        nRanks == other.nRanks && uuid == other.uuid);
   }
 
   std::size_t hash() const noexcept;


### PR DESCRIPTION
Summary:
Event scopes (MCCL_EVENT_SCOPE) logged by child operations during init() and allReduce() were missing the mcclop and op_count fields needed to correlate them with their parent operation in Scuba queries. This made it difficult to trace which child events (e.g., RANK_ASSIGNMENT, ALLREDUCE_ENQUEUE) belonged to which parent operation.

This change:
1. Adds mcclOpType and opCount fields to McclCommLogMetadata so parent operations can populate them before spawning child event scopes
2. Updates McclOperationTraceGuard to set op_count from its sequence number and log OPERATION_COMPLETE/OPERATION_ERROR events for lifecycle (sync) operations
3. Propagates operation context to McclWork for async collective operations
4. Ensures McclCommLogMetadataUtil populates comm identity fields from logMetaData_ (available early) before falling back to statex_ (available later)

With these changes, all child event scopes inherit mcclop + op_count from their parent, enabling Scuba queries like:
```sql
SELECT * FROM mccl_operation_trace WHERE mcclop = 'init' AND op_count = 42
```
to return both the parent INIT operation and all its child events.

Differential Revision: D93266785


