### PR TITLE
Fix lookupSegmentsForBuffer for unmapped memory

### DIFF
--- a/comms/ctran/regcache/RegCache.h
+++ b/comms/ctran/regcache/RegCache.h
@@ -366,6 +366,12 @@ class RegCache {
   // If no regElem is associated, empty vector is returned
   std::vector<regcache::RegElem*> getRegElems(const void* segHdl) const;
 
+  // Get deduplicated regElems associated with multiple segHdls.
+  // Deduplication is needed because a single regElem can span multiple
+  // segments.
+  std::vector<regcache::RegElem*> getRegElems(
+      const std::vector<void*>& segHdls) const;
+
   // Thread-safe functions to get a list of all cached segments in the global
   // cache.
   std::vector<void*> getSegments() const;

--- a/comms/ctran/utils/CtranAvlTree.h
+++ b/comms/ctran/utils/CtranAvlTree.h
@@ -48,6 +48,10 @@ class CtranAvlTree {
   // Get all elements in the tree.
   std::vector<void*> getAllElems() const;
 
+  // Search for all elements whose address range overlaps with [addr, addr+len).
+  // Returns handles to all overlapping elements.
+  std::vector<void*> searchRange(const void* addr, std::size_t len) const;
+
   // Get total number of elements.
   size_t size() const;
 

--- a/comms/ctran/utils/tests/AvlTreeUT.cc
+++ b/comms/ctran/utils/tests/AvlTreeUT.cc
@@ -404,3 +404,157 @@ TEST_F(CtranUtilsAvlTreeTest, DoubleRemove) {
   ASSERT_EQ(res, commInvalidUsage);
   ASSERT_EQ(tree->size(), 0);
 }
+
+// Test searchRange with 5 contiguous 20MB segments.
+// Query [30MB, 70MB) should find segments 2, 3, 4
+// Segments layout:
+//   Segment 1: [0MB,  20MB)
+//   Segment 2: [20MB, 40MB)  <- overlaps [30MB, 70MB) at [30MB, 40MB)
+//   Segment 3: [40MB, 60MB)  <- fully inside [30MB, 70MB)
+//   Segment 4: [60MB, 80MB)  <- overlaps [30MB, 70MB) at [60MB, 70MB)
+//   Segment 5: [80MB, 100MB)
+TEST_F(CtranUtilsAvlTreeTest, SearchRangePartialRange) {
+  auto tree = std::make_unique<CtranAvlTree>();
+
+  constexpr size_t MB = 1024 * 1024;
+  constexpr size_t segmentSize = 20 * MB;
+  constexpr int numSegments = 5;
+
+  // Insert 5 contiguous 20MB segments
+  std::vector<void*> handles(numSegments);
+  for (int i = 0; i < numSegments; i++) {
+    uintptr_t addr = i * segmentSize;
+    void* val = reinterpret_cast<void*>(static_cast<uintptr_t>(i + 1));
+    handles[i] = tree->insert(reinterpret_cast<void*>(addr), segmentSize, val);
+    ASSERT_NE(handles[i], nullptr);
+  }
+  ASSERT_EQ(tree->size(), numSegments);
+
+  // Query range [30MB, 70MB)
+  uintptr_t rangeStart = 30 * MB;
+  uintptr_t rangeEnd = 70 * MB;
+  auto overlapping = tree->searchRange(
+      reinterpret_cast<void*>(rangeStart), rangeEnd - rangeStart);
+
+  // Should find exactly 3 segments
+  ASSERT_EQ(overlapping.size(), 3);
+
+  // Verify we found the correct handles
+  std::unordered_set<void*> expectedHandles = {
+      handles[1], handles[2], handles[3]};
+  std::unordered_set<void*> foundHandles(
+      overlapping.begin(), overlapping.end());
+  EXPECT_EQ(expectedHandles, foundHandles);
+
+  // Cleanup
+  for (auto hdl : handles) {
+    tree->remove(hdl);
+  }
+}
+
+// Test searchRange with 5 contiguous 20MB segments.
+// Query [20MB, 80MB) should find segments 2, 3, 4
+// This tests exact boundary alignment where:
+//   - rangeStart (20MB) equals segment 2's start
+//   - rangeEnd (80MB) equals segment 5's start (exclusive)
+// Segments layout:
+//   Segment 1: [0MB,  20MB)  <- ends at rangeStart, no overlap
+//   Segment 2: [20MB, 40MB)  <- starts at rangeStart, overlaps
+//   Segment 3: [40MB, 60MB)  <- fully inside
+//   Segment 4: [60MB, 80MB)  <- ends at rangeEnd, overlaps
+//   Segment 5: [80MB, 100MB) <- starts at rangeEnd, no overlap (half-open)
+TEST_F(CtranUtilsAvlTreeTest, SearchRangeExactBoundary) {
+  auto tree = std::make_unique<CtranAvlTree>();
+
+  constexpr size_t MB = 1024 * 1024;
+  constexpr size_t segmentSize = 20 * MB;
+  constexpr int numSegments = 5;
+
+  // Insert 5 contiguous 20MB segments
+  std::vector<void*> handles(numSegments);
+  for (int i = 0; i < numSegments; i++) {
+    uintptr_t addr = i * segmentSize;
+    void* val = reinterpret_cast<void*>(static_cast<uintptr_t>(i + 1));
+    handles[i] = tree->insert(reinterpret_cast<void*>(addr), segmentSize, val);
+    ASSERT_NE(handles[i], nullptr);
+  }
+  ASSERT_EQ(tree->size(), numSegments);
+
+  // Query range [20MB, 80MB) - exact segment boundaries
+  // Should find segments 2, 3, 4
+  uintptr_t rangeStart = 20 * MB;
+  uintptr_t rangeEnd = 80 * MB;
+  auto overlapping = tree->searchRange(
+      reinterpret_cast<void*>(rangeStart), rangeEnd - rangeStart);
+
+  // Should find exactly 3 segments
+  ASSERT_EQ(overlapping.size(), 3);
+
+  // Verify we found the correct handles
+  std::unordered_set<void*> expectedHandles = {
+      handles[1], handles[2], handles[3]};
+  std::unordered_set<void*> foundHandles(
+      overlapping.begin(), overlapping.end());
+  EXPECT_EQ(expectedHandles, foundHandles);
+
+  // Cleanup
+  for (auto hdl : handles) {
+    tree->remove(hdl);
+  }
+}
+
+// Test that searchRange correctly prunes the left subtree when the search range
+// starts after a node's start address. This leverages the fact that segments
+// don't overlap, so all nodes in the left subtree must end before nodeStart.
+//
+// Tree structure (ordered by address):
+//   Segment 1: [100, 150)   <- left child
+//   Segment 2: [200, 250)   <- root
+//   Segment 3: [300, 350)   <- right child
+//
+// Query [220, 280): starts after root's start (200), so left subtree should be
+// pruned. Only segments 2 and 3 should be checked/returned.
+TEST_F(CtranUtilsAvlTreeTest, SearchRangeLeftSubtreePruning) {
+  auto tree = std::make_unique<CtranAvlTree>();
+
+  // Insert segments in order that creates a balanced tree
+  // Insert middle first (becomes root), then left, then right
+  void* hdl2 = tree->insert(
+      reinterpret_cast<void*>(200), 50, reinterpret_cast<void*>(2));
+  void* hdl1 = tree->insert(
+      reinterpret_cast<void*>(100), 50, reinterpret_cast<void*>(1));
+  void* hdl3 = tree->insert(
+      reinterpret_cast<void*>(300), 50, reinterpret_cast<void*>(3));
+
+  ASSERT_EQ(tree->size(), 3);
+
+  // Query [220, 280) - starts at 220 which is > root's start (200)
+  // Since segments don't overlap, segment 1 [100, 150) cannot overlap with
+  // [220, 280) because it ends at 150 < 200 (root's start).
+  // The pruning condition rangeStart < nodeStart (220 < 200 = false) should
+  // skip the left subtree entirely.
+  auto overlapping =
+      tree->searchRange(reinterpret_cast<void*>(220), 60); // [220, 280)
+
+  // Should find segment 2 [200, 250) which overlaps at [220, 250)
+  // Should NOT find segment 1 [100, 150) - no overlap
+  // Should NOT find segment 3 [300, 350) - no overlap
+  ASSERT_EQ(overlapping.size(), 1);
+
+  void* foundVal = tree->lookup(overlapping[0]);
+  EXPECT_EQ(foundVal, reinterpret_cast<void*>(2));
+
+  // Query [350, 400) - beyond all segments
+  auto noOverlap =
+      tree->searchRange(reinterpret_cast<void*>(350), 50); // [350, 400)
+  EXPECT_EQ(noOverlap.size(), 0);
+
+  // Query [0, 50) - before all segments
+  auto beforeAll = tree->searchRange(reinterpret_cast<void*>(0), 50); // [0, 50)
+  EXPECT_EQ(beforeAll.size(), 0);
+
+  // Cleanup
+  tree->remove(hdl1);
+  tree->remove(hdl2);
+  tree->remove(hdl3);
+}


### PR DESCRIPTION
Summary:
Fix `lookupSegmentsForBuffer` to work correctly when the underlying CUDA memory has been unmapped.

## Problem
When PyTorch's CUDA Caching Allocator uses expandable segments, physical memory is allocated in 20MB chunks. When getting a SEGMENT_UNMAP event for the virtual address range, the memory is already unmapped by the time we receive the callback.

The previous implementation used `pinRange()` which calls `cuMemGetAllocationHandle()` to discover physical segments. This fails on unmapped memory, causing deregistration to silently skip segments.

## Solution
Replace `pinRange()`-based discovery with range-based overlap detection using stored segment metadata:

1. Add `findOverlapping(rangeStart, rangeEnd)` to CtranAvlTree - an O(log n + k) range query that leverages the tree's sorted structure with pruning
2. Use the segment's own stored address/length (`segment->range.buf/len`) instead of querying CUDA
3. Deduplicate regElems (needed because one regElem can span multiple segments)

Reviewed By: minsii

Differential Revision: D93189284


