### PR TITLE
Fix IpcRegCache teardown SIGSEGV by avoiding unnecessary RemoteAcceptor

### DIFF
--- a/comms/ctran/bootstrap/AsyncSocket.cc
+++ b/comms/ctran/bootstrap/AsyncSocket.cc
@@ -134,7 +134,7 @@ folly::SemiFuture<folly::SocketAddress> AsyncServerSocket::start(
     server_ = folly::AsyncServerSocket::newSocket(&evb_);
     server_->setReusePortEnabled(true);
     server_->bind(bindAddr_);
-    server_->addAcceptCallback(this, &evb_);
+    server_->addAcceptCallback(this, nullptr);
     server_->listen(1024 /* backlog */);
     server_->startAccepting();
     auto addr = server_->getAddress();


### PR DESCRIPTION
Summary:
**TL;DR:** Pass `nullptr` instead of `&evb_` to `addAcceptCallback` in ctran's `AsyncServerSocket::start()` to avoid creating a `RemoteAcceptor` that causes a use-after-free during teardown.

---

HangAndShrink integration tests intermittently SIGSEGV during process exit teardown when run together. All worker processes report [PASSED], but ranks crash with SIGSEGV (exit code 11) in `folly::AsyncServerSocket::RemoteAcceptor::stop()` during `IpcRegCache` singleton destruction.

The root cause is a use-after-free race in the ctran `AsyncServerSocket`. When `addAcceptCallback(this, &evb_)` is called with a non-null EventBase, folly always creates a `RemoteAcceptor`, even when the provided EventBase is the same as the server's primary one. During teardown, `RemoteAcceptor::stop()` defers cleanup via `runInEventBaseThread`, which queues a lambda calling `acceptStopped()` on the callback object. The main thread proceeds to destroy the callback (the ctran `AsyncServerSocket`) before the deferred lambda executes, resulting in a call to a destroyed object.

The fix passes `nullptr` instead of `&evb_` to `addAcceptCallback`. When the EventBase argument is null, folly skips `RemoteAcceptor` creation and invokes callbacks directly on the server's primary EventBase, which is already `&evb_`. This makes `acceptStopped()` synchronous during destruction, eliminating the race. This matches folly's own guidance and introduces no behavioral change since the ctran `AsyncServerSocket` already assumes all operations run on `evb_`.

Differential Revision: D93492800


