### PR TITLE
Title: Fix Sphinx project name for better search discoverability

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -123,7 +123,8 @@ source_suffix = [".rst", ".md"]
 master_doc = "index"
 
 # General information about the project.
-project = "meta-pytorch/torchcomms"
+project = "TorchComms"
+html_title = "TorchComms"
 copyright = "2025, torchcomms Contributors"
 author = "torchcomms Contributors"
 


### PR DESCRIPTION
Change project from "meta-pytorch/torchcomms" to "TorchComms" in conf.py.

Sphinx uses project to build HTML <title> tags: {page title} — {project}. With the current value, pages render as "API Reference — meta-pytorch/torchcomms" which looks awkward and hurts discoverability.
After this change, page titles become "API Reference — TorchComms", matching what users actually search for.