### PR TITLE
Fix CI config for 2_28 PACKAGE files

### DIFF
--- a/comms/ncclx/v2_28/meta/algoconf/tests/AlgoConfigTest.cc
+++ b/comms/ncclx/v2_28/meta/algoconf/tests/AlgoConfigTest.cc
@@ -117,7 +117,6 @@ TEST_F(AlgoConfigUT, AllReduceAlgoHintOverride) {
   std::unordered_map<enum NCCL_ALLREDUCE_ALGO, const char*> overrideAlgos = {
       {NCCL_ALLREDUCE_ALGO::ctran, "ctran"},
       {NCCL_ALLREDUCE_ALGO::ctdirect, "ctdirect"},
-      {NCCL_ALLREDUCE_ALGO::ctarg, "ctarg"},
       {NCCL_ALLREDUCE_ALGO::ctring, "ctring"},
   };
 

--- a/comms/ncclx/v2_28/meta/tests/CommRegisterTest.cc
+++ b/comms/ncclx/v2_28/meta/tests/CommRegisterTest.cc
@@ -7,7 +7,6 @@
 
 #include <nccl.h>
 #include "comms/ctran/Ctran.h"
-#include "comms/ctran/mapper/CtranMapperRegMem.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -62,10 +61,6 @@ TEST_P(CommRegisterTestParam, RegularUsage) {
       ASSERT_EQ(res, ncclSuccess);
     }
   }
-
-  // Cleanup cached segments in global cache before we test memory leak
-  auto regCache = CtranMapperRegCache::getInstance();
-  EXPECT_EQ(regCache->destroy(), commSuccess);
 
   testFreeBuf(buf, nbytes, memType);
 }

--- a/comms/ncclx/v2_28/meta/tests/LogTest.cc
+++ b/comms/ncclx/v2_28/meta/tests/LogTest.cc
@@ -23,7 +23,7 @@ class LogTest : public ::testing::Test {
 
   void initLogging() {
     ncclDebugLevel = -1;
-    ncclDebugLogFileStr = "";
+    ncclDebugFile = nullptr;
     initNcclLogger();
   }
 };

--- a/comms/ncclx/v2_28/meta/wrapper/tests/CtranExDistCommFailureUT.cc
+++ b/comms/ncclx/v2_28/meta/wrapper/tests/CtranExDistCommFailureUT.cc
@@ -121,8 +121,8 @@ INSTANTIATE_TEST_SUITE_P(
     CtranExCommFailureTest,
     CtranExCommFailureParamFixture,
     ::testing::Values(TestWaitType::TEST, TestWaitType::WAIT),
-    [&](const testing::TestParamInfo<CtranExCommFailureParamFixture::ParamType>&
-            info) {
+    [&](const ::testing::TestParamInfo<
+        CtranExCommFailureParamFixture::ParamType>& info) {
       const std::string waitType =
           info.param == TestWaitType::TEST ? "Test" : "Wait";
       return waitType;


### PR DESCRIPTION
Summary:
Fix the CI configuration for ncclx v2_28 PACKAGE files and fix pre-existing build failures in test code revealed by enabling CI.

## Problem
The original configuration in D83581470 had a logic issue:
```starlark
ci.package(
    ci.remove(ci.linux(ci.opt())),  # Removes the inherited opt CI
    ci.replace({ci.linux(ci.dev()): ci.linux(ci.opt(...))}),  # But there's no dev label to replace!
)
```

Since the parent `comms/ncclx/PACKAGE` uses `fbcode_ci.use_opt_instead_of_dev()` which already converts dev→opt, and adds an explicit `ci.linux(ci.opt())`, the child's configuration:
1. Removed the only active CI label (`ci.linux(ci.opt())`)
2. Tried to replace a non-existent dev label

This effectively **disabled CI** for v2_27 and v2_28 tests.

Instead of removing opt and replacing dev, we now replace opt with opt+buckconfig:
```starlark
ci.package(
    ci.replace({ci.linux(ci.opt()): ci.linux(
        ci.opt(ci.buckconfig("hpc_comms.use_ncclx", "2.28")),
    )}),
)
```

## Build Failures Fixed
Enabling CI revealed several pre-existing build failures in v2_28 test code:

1. **AlgoConfigTest.cc**: Removed invalid `ctarg` enum value from NCCL_ALLREDUCE_ALGO test (not in v2_28)
2. **LogTest.cc**: Changed `ncclDebugLogFileStr` to `ncclDebugFile` (API changed from string to FILE*)
3. **CommRegisterTest.cc**: Removed `CtranMapperRegCache` include and usage (API removed in v2_28)
4. **HelloWorld.cu**: Added missing `TestUtils.h` include for `setupNccl`/`cleanupNccl`/macros
5. **CtranExDistCommFailureUT.cc**: Fixed `testing::` namespace ambiguity (qualified as `::testing::`)
6. **CtranExDistCommUT.cc**: Removed `CtranMapperRegCache` usage and fixed `testing::` namespace
---
> Generated by [Claude Code](https://www.internalfb.com/wiki/Confucius/Analect/Dev/Assistant/Claude_Code/), powered by [Confucius](https://www.internalfb.com/wiki/Confucius/)
> [Session](https://www.internalfb.com/confucius?entry_name=Claude%20Code&mode=Focused&namespace[0]=dev&namespace[1]=assistant&session_id=f6bda30a-0c49-11f1-a44a-1b27373c5cce&tab=Chat), [Trace](https://www.internalfb.com/confucius?entry_name=Claude%20Code&mode=Focused&namespace[0]=dev&namespace[1]=assistant&session_id=f6bda30a-0c49-11f1-a44a-1b27373c5cce&tab=Trace)

Differential Revision: D90535386


