### PR TITLE
Add CoopScope support to device API for cooperative put/signal/flush/barrier

### DIFF
--- a/comms/common/AtomicUtils.cuh
+++ b/comms/common/AtomicUtils.cuh
@@ -382,6 +382,15 @@ __device__ __forceinline__ void st_release_sys_global(
  *   // After seeing flag, data is guaranteed visible due to fence+relaxed store
  */
 
+// Compiler-only barrier: prevents the compiler from reordering instructions
+// across this point. Emits no hardware instruction — zero runtime cost.
+// Use when you need ordering within a single thread's instruction stream
+// (e.g., between two put() calls) where the only adversary is compiler
+// reordering. GPU hardware does not reorder stores within a single thread.
+__device__ __forceinline__ void compiler_barrier() {
+  asm volatile("" ::: "memory");
+}
+
 __device__ __forceinline__ void threadfence() {
 #if defined(__CUDA_ARCH__) || defined(__HIP_ARCH__)
   __threadfence();

--- a/comms/pipes/ThreadGroup.cuh
+++ b/comms/pipes/ThreadGroup.cuh
@@ -20,11 +20,12 @@ namespace comms::pipes {
  * 2. Selecting which factory function to use when creating ThreadGroups
  *
  * Available scopes:
- * - WARP: 32 threads per group (finest granularity, uses __syncwarp)
+ * - THREAD:    Single thread per group (no-op sync, finest granularity)
+ * - WARP:      32 threads per group (uses __syncwarp)
  * - MULTIWARP: 128 threads per group (4 warps, uses named barriers)
- * - BLOCK: All threads in a block form one group (uses __syncthreads)
- * - CLUSTER: All threads in a cluster form one group (uses cluster
- * barriers)
+ * - BLOCK:     All threads in a block form one group (uses __syncthreads)
+ * - CLUSTER:   All threads in a cluster form one group (uses cluster
+ *              barriers)
  *
  * Usage example:
  *   __global__ void myKernel(SyncScope scope) {
@@ -32,7 +33,7 @@ namespace comms::pipes {
  *     // ...
  *   }
  */
-enum class SyncScope { WARP, MULTIWARP, BLOCK, CLUSTER };
+enum class SyncScope { THREAD, WARP, MULTIWARP, BLOCK, CLUSTER };
 
 /**
  * ThreadGroup - Abstraction for cooperative thread group operations
@@ -88,6 +89,15 @@ struct ThreadGroup {
   __device__ inline void sync() {
 #ifdef __CUDA_ARCH__
     switch (scope) {
+      case SyncScope::THREAD:
+        // Single-thread group: emit a compiler barrier to prevent reordering
+        // across this sync point. No hardware instruction needed since there
+        // is only one thread, but the compiler must not hoist or sink memory
+        // operations across sync() — matching the invariant that sync()
+        // establishes a happens-before boundary within a thread's instruction
+        // stream.
+        asm volatile("" ::: "memory");
+        break;
       case SyncScope::WARP:
         __syncwarp();
         break;
@@ -514,6 +524,36 @@ __device__ inline PartitionResult ThreadGroup::partition_interleaved(
   return PartitionResult{};
 }
 
+/**
+ * make_thread_solo - Create a single-thread ThreadGroup for this thread
+ *
+ * Each thread forms its own group of size 1. sync() is a no-op.
+ * Use when an operation must execute on a single thread at a time,
+ * or when composing with scope-dispatch code that needs a THREAD scope group.
+ *
+ * Unlike warp/block groups, thread_id_in_group is always 0 (this thread is
+ * always the leader). group_id and total_groups are based on the global
+ * thread index and count respectively.
+ */
+__device__ inline ThreadGroup make_thread_solo() {
+#ifdef __CUDA_ARCH__
+  uint32_t tid = threadIdx.x + threadIdx.y * blockDim.x +
+      threadIdx.z * blockDim.x * blockDim.y;
+  uint32_t threads_per_block = blockDim.x * blockDim.y * blockDim.z;
+  uint32_t global_tid = blockIdx.x * threads_per_block + tid;
+  uint32_t total_threads = gridDim.x * threads_per_block;
+
+  return ThreadGroup{
+      .thread_id_in_group = 0,
+      .group_size = 1,
+      .group_id = global_tid,
+      .total_groups = total_threads,
+      .scope = SyncScope::THREAD};
+#else
+  return ThreadGroup{};
+#endif
+}
+
 __device__ inline ThreadGroup make_warp_group() {
 #ifdef __CUDA_ARCH__
   uint32_t warps_per_block = blockDim.x / comms::device::kWarpSize;
@@ -687,9 +727,11 @@ __device__ inline ThreadGroup make_multiwarp_group() {
  *
  * Convenience function that dispatches to the appropriate factory function
  * based on the scope parameter:
- *   - SyncScope::WARP → make_warp_group()
+ *   - SyncScope::THREAD    → make_thread_solo() (no-op sync, size 1)
+ *   - SyncScope::WARP      → make_warp_group()
  *   - SyncScope::MULTIWARP → make_multiwarp_group()
- *   - SyncScope::BLOCK → make_block_group()
+ *   - SyncScope::BLOCK     → make_block_group()
+ *   - SyncScope::CLUSTER   → make_cluster_group()
  *
  * @param scope The desired thread grouping strategy
  * @return ThreadGroup configured for the specified scope
@@ -705,6 +747,8 @@ __device__ inline ThreadGroup make_multiwarp_group() {
 __device__ inline ThreadGroup make_thread_group(SyncScope scope) {
 #ifdef __CUDA_ARCH__
   switch (scope) {
+    case SyncScope::THREAD:
+      return make_thread_solo();
     case SyncScope::WARP:
       return make_warp_group();
     case SyncScope::MULTIWARP:

--- a/comms/pipes/tests/ThreadGroupTest.cuh
+++ b/comms/pipes/tests/ThreadGroupTest.cuh
@@ -23,6 +23,25 @@ void testContiguousLocality(
     int blockSize,
     SyncScope scope);
 
+// Tests make_thread_solo() - where each thread forms its own group of size 1
+// Verifies:
+// - group_size == 1 for every thread
+// - thread_id_in_group == 0 for every thread (always the leader)
+// - is_leader() == true for every thread
+// - group_id == global_thread_index (unique per thread)
+// - total_groups == total thread count (numBlocks * blockSize)
+// - scope == SyncScope::THREAD
+// - sync() completes without deadlock (compiler barrier only, no hardware sync)
+void testThreadSoloGroup(
+    uint32_t* groupIds_d,
+    uint32_t* groupSizes_d,
+    uint32_t* threadIdsInGroup_d,
+    uint32_t* isLeader_d,
+    uint32_t* syncResults_d,
+    uint32_t* errorCount_d,
+    int numBlocks,
+    int blockSize);
+
 // Tests make_block_group() - where all threads in a block form one group
 // Verifies:
 // - group_id == blockIdx.x

--- a/comms/torchcomms/device/ncclx/TorchCommDeviceNCCLX.cuh
+++ b/comms/torchcomms/device/ncclx/TorchCommDeviceNCCLX.cuh
@@ -34,6 +34,7 @@
 #include <nccl_device/impl/comm__types.h> // @manual=//comms/ncclx:nccl_device_api
 
 #include "comms/common/AtomicUtils.cuh"
+#include "comms/pipes/CopyUtils.cuh"
 #include "comms/torchcomms/device/ncclx/TorchCommDeviceNCCLXTypes.hpp"
 
 namespace torchcomms::device {
@@ -71,65 +72,46 @@ __device__ inline bool cmp_op(CmpOp cmp, uint64_t lhs, uint64_t rhs) {
   return false;
 }
 
-// Vectorized memcpy for NVLink stores (single-thread scope for now).
-//
-// Uses 128-bit (uint4) loads/stores with loop unrolling for better memory
-// pipeline utilization, inspired by comms::pipes::memcpy_vectorized.
-//
-// No volatile or ordering semantics — put() provides no ordering guarantees.
-// Callers must use signal(), fence(), or flush() for store visibility.
-__device__ inline void memcpy_nvl(void* dst, const void* src, size_t bytes) {
-  constexpr int kUnroll = 4;
-  constexpr size_t kVecSize = sizeof(uint4);
-
-  if (reinterpret_cast<uintptr_t>(dst) % kVecSize == 0 &&
-      reinterpret_cast<uintptr_t>(src) % kVecSize == 0) {
-    auto* __restrict__ d = static_cast<uint4*>(dst);
-    auto* __restrict__ s = static_cast<const uint4*>(src);
-    size_t nvecs = bytes / kVecSize;
-    size_t nvecs_aligned = (nvecs / kUnroll) * kUnroll;
-
-    for (size_t i = 0; i < nvecs_aligned; i += kUnroll) {
-      uint4 v[kUnroll];
-#pragma unroll
-      for (int j = 0; j < kUnroll; j++) {
-        v[j] = s[i + j];
-      }
-#pragma unroll
-      for (int j = 0; j < kUnroll; j++) {
-        d[i + j] = v[j];
-      }
-    }
-    for (size_t i = nvecs_aligned; i < nvecs; i++) {
-      d[i] = s[i];
-    }
-
-    size_t tail = bytes % kVecSize;
-    if (tail > 0) {
-      auto* db = reinterpret_cast<char*>(d + nvecs);
-      auto* sb = reinterpret_cast<const char*>(s + nvecs);
-      for (size_t i = 0; i < tail; i++) {
-        db[i] = sb[i];
-      }
-    }
-    return;
+// Build a pipes::ThreadGroup for the given CoopScope.
+// Delegates to the pipes factory functions for each scope.
+__device__ inline comms::pipes::ThreadGroup make_thread_group(CoopScope scope) {
+  switch (scope) {
+    case CoopScope::WARP:
+      return comms::pipes::make_warp_group();
+    case CoopScope::BLOCK:
+      return comms::pipes::make_block_group();
+    case CoopScope::THREAD:
+      return comms::pipes::make_thread_solo();
   }
+  // Unreachable — all CoopScope values are handled above.
+  __builtin_unreachable();
+}
 
-  // Fallback: unaligned path using 8-byte copies
-  auto* __restrict__ d = static_cast<uint64_t*>(dst);
-  auto* __restrict__ s = static_cast<const uint64_t*>(src);
-  size_t chunks = bytes / sizeof(uint64_t);
-  for (size_t i = 0; i < chunks; i++) {
-    d[i] = s[i];
+// NVLink memcpy using pipes::memcpy_vectorized with the given cooperative
+// scope. No volatile or ordering semantics — put() provides no ordering
+// guarantees. Callers must use signal(), fence(), or flush() for store
+// visibility.
+__device__ inline void
+memcpy_nvl(void* dst, const void* src, size_t bytes, CoopScope scope) {
+  auto group = make_thread_group(scope);
+  comms::pipes::memcpy_vectorized(
+      static_cast<char*>(dst), static_cast<const char*>(src), bytes, group);
+}
+
+// Dispatch a callable with the appropriate NCCL coop type based on CoopScope.
+// GIN methods are templated on coop type, so we need a dispatch function.
+template <typename Func>
+__device__ inline auto nccl_coop_dispatch(CoopScope scope, Func&& func) {
+  switch (scope) {
+    case CoopScope::WARP:
+      return func(ncclCoopWarp{});
+    case CoopScope::BLOCK:
+      return func(ncclCoopCta{});
+    case CoopScope::THREAD:
+      return func(ncclCoopThread{});
   }
-  size_t tail = bytes % sizeof(uint64_t);
-  if (tail > 0) {
-    auto* db = reinterpret_cast<char*>(d + chunks);
-    auto* sb = reinterpret_cast<const char*>(s + chunks);
-    for (size_t i = 0; i < tail; i++) {
-      db[i] = sb[i];
-    }
-  }
+  // Unreachable — all CoopScope values are handled above.
+  __builtin_unreachable();
 }
 
 // Flat index into the signal buffer: slots[signal_id * num_ranks + rank].
@@ -169,29 +151,35 @@ __device__ inline int TorchCommDeviceWindow<NCCLDeviceBackend>::signal(
     int peer,
     int signal_id,
     SignalOp op,
-    uint64_t value) {
+    uint64_t value,
+    CoopScope scope) {
   const ncclDevComm& dev_comm = comm_;
 
   if (ncclTeamRankIsMember(
           ncclTeamLsa(dev_comm), ncclTeamWorld(dev_comm), peer)) {
     // ---- LSA (NVLink) path ----
-    // Write to peer's resource buffer via NVLink-mapped pointer.
-    int lsa_peer = ncclTeamRankToTeam(
-        ncclTeamLsa(dev_comm), ncclTeamWorld(dev_comm), peer);
-    void* peer_buf = ncclGetResourceBufferLsaPointer(
-        dev_comm, signal_buffer_handle_, lsa_peer);
-    uint64_t* slot = reinterpret_cast<uint64_t*>(peer_buf) +
-        detail::signal_slot_index(signal_id, num_ranks_, rank_);
+    // Signal is a single atomic/store — only thread 0 needs to execute it.
+    // For warp/block scope, all threads reach this point but only thread 0
+    // performs the actual write (same pattern as GIN internally).
+    auto group = detail::make_thread_group(scope);
+    if (group.is_leader()) {
+      int lsa_peer = ncclTeamRankToTeam(
+          ncclTeamLsa(dev_comm), ncclTeamWorld(dev_comm), peer);
+      void* peer_buf = ncclGetResourceBufferLsaPointer(
+          dev_comm, signal_buffer_handle_, lsa_peer);
+      uint64_t* slot = reinterpret_cast<uint64_t*>(peer_buf) +
+          detail::signal_slot_index(signal_id, num_ranks_, rank_);
 
-    if (op == SignalOp::ADD) {
-      // atom.release.sys.add.u64 — single NVLink atomic with release
-      // semantics, ensuring all prior stores (data writes from put())
-      // are visible before the counter increment.
-      comms::device::atomic_fetch_add_release_sys_global(slot, value);
-    } else {
-      // st.release.sys — release store ensures all prior writes are
-      // visible before the signal value lands on the peer.
-      comms::device::st_release_sys_global(slot, value);
+      if (op == SignalOp::ADD) {
+        // atom.release.sys.add.u64 — single NVLink atomic with release
+        // semantics, ensuring all prior stores (data writes from put())
+        // are visible before the counter increment.
+        comms::device::atomic_fetch_add_release_sys_global(slot, value);
+      } else {
+        // st.release.sys — release store ensures all prior writes are
+        // visible before the signal value lands on the peer.
+        comms::device::st_release_sys_global(slot, value);
+      }
     }
   } else {
     // ---- GIN (RDMA) path ----
@@ -205,14 +193,18 @@ __device__ inline int TorchCommDeviceWindow<NCCLDeviceBackend>::signal(
     size_t offset = ncclGetResourceBufferOffset(signal_buffer_handle_) +
         detail::signal_slot_index(signal_id, num_ranks_, rank_) *
             sizeof(uint64_t);
-    gin.atomicAdd(
-        ncclTeamWorld(dev_comm),
-        peer,
-        dev_comm.resourceWindow,
-        offset,
-        value,
-        ncclCoopThread{});
-    gin.flush(ncclCoopThread{});
+    // atomicAdd posts a WQE and rings the doorbell inline — no flush needed.
+    // QP ordering guarantees prior puts on this QP complete before this atomic.
+    // User calls flush() explicitly if they need local completion.
+    detail::nccl_coop_dispatch(scope, [&](auto coop) {
+      gin.atomicAdd(
+          ncclTeamWorld(dev_comm),
+          peer,
+          dev_comm.resourceWindow,
+          offset,
+          value,
+          coop);
+    });
   }
 
   return 0;
@@ -230,7 +222,8 @@ __device__ inline int TorchCommDeviceWindow<NCCLDeviceBackend>::put(
     int dst_rank,
     size_t bytes,
     int signal_id,
-    int counter_id) {
+    int counter_id,
+    CoopScope scope) {
   const ncclDevComm& dev_comm = comm_;
 
   ncclWindow_t dst_win = window_;
@@ -239,51 +232,53 @@ __device__ inline int TorchCommDeviceWindow<NCCLDeviceBackend>::put(
   if (ncclTeamRankIsMember(
           ncclTeamLsa(dev_comm), ncclTeamWorld(dev_comm), dst_rank)) {
     // ---- LSA (NVLink) path ----
-    // Direct memcpy through NVLink-mapped pointers.
+    // Cooperative memcpy through NVLink-mapped pointers.
     void* src = ncclGetLocalPointer(src_win, src_offset);
     void* dst = ncclGetPeerPointer(dst_win, dst_offset, dst_rank);
 
-    detail::memcpy_nvl(dst, src, bytes);
+    detail::memcpy_nvl(dst, src, bytes, scope);
     // No explicit fence needed here — the signal() call below uses
     // st.release.sys / atom.release.sys which orders all prior stores
     // (including the memcpy data writes) before the signal write.
 
     if (signal_id >= 0) {
-      signal(dst_rank, signal_id, SignalOp::ADD, 1);
+      signal(dst_rank, signal_id, SignalOp::ADD, 1, scope);
     }
     // counter_id silently ignored for LSA — counters are GIN hardware only
   } else {
     // ---- GIN (RDMA) path ----
     ncclGin gin(dev_comm, kDefaultGinContextIndex);
 
-    if (counter_id >= 0) {
-      gin.put(
-          ncclTeamWorld(dev_comm),
-          dst_rank,
-          dst_win,
-          dst_offset,
-          src_win,
-          src_offset,
-          bytes,
-          ncclGin_None{},
-          ncclGin_CounterInc{static_cast<ncclGinCounter_t>(counter_id)},
-          ncclCoopThread{});
-    } else {
-      gin.put(
-          ncclTeamWorld(dev_comm),
-          dst_rank,
-          dst_win,
-          dst_offset,
-          src_win,
-          src_offset,
-          bytes,
-          ncclGin_None{},
-          ncclGin_None{},
-          ncclCoopThread{});
-    }
+    detail::nccl_coop_dispatch(scope, [&](auto coop) {
+      if (counter_id >= 0) {
+        gin.put(
+            ncclTeamWorld(dev_comm),
+            dst_rank,
+            dst_win,
+            dst_offset,
+            src_win,
+            src_offset,
+            bytes,
+            ncclGin_None{},
+            ncclGin_CounterInc{static_cast<ncclGinCounter_t>(counter_id)},
+            coop);
+      } else {
+        gin.put(
+            ncclTeamWorld(dev_comm),
+            dst_rank,
+            dst_win,
+            dst_offset,
+            src_win,
+            src_offset,
+            bytes,
+            ncclGin_None{},
+            ncclGin_None{},
+            coop);
+      }
+    });
 
     if (signal_id >= 0) {
-      signal(dst_rank, signal_id, SignalOp::ADD, 1);
+      signal(dst_rank, signal_id, SignalOp::ADD, 1, scope);
     }
   }
 
@@ -413,42 +408,55 @@ __device__ inline void TorchCommDeviceWindow<NCCLDeviceBackend>::reset_counter(
 
 template <>
 __device__ inline int TorchCommDeviceWindow<NCCLDeviceBackend>::fence() {
-  // fence.acq_rel.sys ensures all prior stores (NVLink data writes, signal
-  // updates) are globally visible before subsequent operations. Strictly
-  // stronger than release — use when you need a full barrier rather than
-  // a paired release/acquire on a specific location.
-  comms::device::fence_acq_rel_sys();
+  // Compiler barrier: prevents the compiler from reordering put() calls
+  // across this point. No hardware fence needed — GPU hardware does not
+  // reorder stores within a single thread's instruction stream. Cross-GPU
+  // visibility is handled by signal()'s release semantics (atom.release.sys).
+  comms::device::compiler_barrier();
   return 0;
 }
 
 template <>
-__device__ inline int TorchCommDeviceWindow<NCCLDeviceBackend>::flush() {
-  // Ensure NVLink stores are globally visible, then flush any pending
-  // GIN WQEs (RDMA work queue entries).
-  comms::device::fence_acq_rel_sys();
+__device__ inline int TorchCommDeviceWindow<NCCLDeviceBackend>::flush(
+    CoopScope scope) {
+  // flush() = local completion: all threads in the cooperative group have
+  // finished issuing their operations and the source buffers are safe to reuse.
+  //
+  // NVLink path: stores are inline (no async DMA). group.sync() is sufficient
+  // — once all threads have passed the sync, every store they issued has
+  // already executed. Cross-GPU visibility is NOT flush's responsibility;
+  // signal()'s atom.release.sys / st.release.sys handles that.
+  //
+  // RDMA (GIN) path: puts are async WQEs posted to the NIC. gin.flush() spins
+  // until the NIC signals local completion (source buffer safe to reuse).
+  // gin.flush() internally handles any necessary group synchronization.
+  auto group = detail::make_thread_group(scope);
+  group.sync();
 
   const ncclDevComm& dev_comm = comm_;
   ncclGin gin(dev_comm, kDefaultGinContextIndex);
-  gin.flush(ncclCoopThread{});
+  detail::nccl_coop_dispatch(scope, [&](auto coop) { gin.flush(coop); });
 
   return 0;
 }
 
 template <>
 __device__ inline int TorchCommDeviceWindow<NCCLDeviceBackend>::barrier(
-    int barrier_id) {
+    int barrier_id,
+    CoopScope scope) {
   const ncclDevComm& dev_comm = comm_;
   ncclGin gin(dev_comm, kDefaultGinContextIndex);
 
   // World barrier: syncs LSA team (NVLink) first, then Rail team (RDMA)
-  ncclBarrierSession barrier(
-      ncclCoopThread{},
-      ncclTeamTagWorld{},
-      gin,
-      static_cast<uint32_t>(barrier_id),
-      false /* multimem */);
-  barrier.sync(
-      ncclCoopThread{}, cuda::memory_order_acq_rel, ncclGinFenceLevel::Relaxed);
+  detail::nccl_coop_dispatch(scope, [&](auto coop) {
+    ncclBarrierSession barrier(
+        coop,
+        ncclTeamTagWorld{},
+        gin,
+        static_cast<uint32_t>(barrier_id),
+        false /* multimem */);
+    barrier.sync(coop, cuda::memory_order_acq_rel, ncclGinFenceLevel::Relaxed);
+  });
 
   return 0;
 }

--- a/comms/torchcomms/tests/integration/cpp/DeviceApiTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/DeviceApiTest.cpp
@@ -848,3 +848,207 @@ void DeviceApiTest::testDeviceBarrier() {
 TEST_F(DeviceApiTest, DeviceBarrier) {
   testDeviceBarrier();
 }
+
+// =============================================================================
+// Scope-Aware Put Tests
+// =============================================================================
+// Validates that put() with CoopScope::WARP and CoopScope::BLOCK produces
+// correct results. Uses the same ring pattern as testDevicePut but with
+// cooperative kernels launched with the appropriate thread count.
+
+void DeviceApiTest::testDevicePutScoped(
+    int count,
+    at::ScalarType dtype,
+    torchcomms::device::CoopScope scope,
+    int num_threads) {
+  std::string scope_name =
+      (scope == torchcomms::device::CoopScope::WARP) ? "WARP" : "BLOCK";
+  SCOPED_TRACE(
+      ::testing::Message() << "Testing Scoped Put (" << scope_name
+                           << ", threads=" << num_threads << ") with count="
+                           << count << " and dtype=" << getDtypeName(dtype));
+
+  auto put_stream = at::cuda::getStreamFromPool(false, device_index_);
+  auto wait_stream = at::cuda::getStreamFromPool(false, device_index_);
+
+  auto mem_pool = std::make_unique<at::cuda::MemPool>(
+      std::static_pointer_cast<c10::cuda::CUDACachingAllocator::CUDAAllocator>(
+          allocator_));
+  c10::cuda::CUDACachingAllocator::beginAllocateToPool(
+      mem_pool->device(), mem_pool->id(), [](cudaStream_t) { return true; });
+
+  auto options =
+      at::TensorOptions().dtype(dtype).device(at::kCUDA, device_index_);
+  at::Tensor win_tensor = at::zeros({count * num_ranks_}, options);
+  at::Tensor src_tensor = at::zeros({count}, options);
+  src_tensor.fill_(static_cast<float>(rank_ + 1));
+
+  c10::cuda::CUDACachingAllocator::endAllocateToPool(
+      mem_pool->device(), mem_pool->id());
+
+  torchcomm_->barrier(false);
+  auto base_win = torchcomm_->new_window();
+  base_win->tensor_register(win_tensor);
+  torchcomm_->barrier(false);
+
+  auto* win =
+      dynamic_cast<torch::comms::TorchCommWindowNCCLXGin*>(base_win.get());
+  ASSERT_NE(win, nullptr) << "Window should be TorchCommWindowNCCLXGin";
+
+  int signal_count = num_ranks_;
+  auto* dev_win = win->get_device_window(signal_count, -1, 1);
+  EXPECT_NE(dev_win, nullptr) << "Device window pointer should not be null";
+
+  auto src_buf = win->register_local_buffer(src_tensor);
+  ASSERT_NE(src_buf.base_ptr, nullptr);
+  ASSERT_NE(src_buf.backend_window, nullptr);
+
+  int dst_rank = (rank_ + 1) % num_ranks_;
+  int src_rank = (rank_ - 1 + num_ranks_) % num_ranks_;
+  constexpr int kSignalId = 0;
+
+  size_t elem_size = win_tensor.element_size();
+  size_t bytes = count * elem_size;
+  size_t src_offset = 0;
+  size_t dst_offset = rank_ * bytes;
+
+  // Launch scoped put kernel
+  {
+    c10::cuda::CUDAStreamGuard guard(put_stream);
+    torchcomms::device::test::launchDevicePutScopedKernel(
+        dev_win,
+        src_buf,
+        src_offset,
+        dst_offset,
+        bytes,
+        dst_rank,
+        kSignalId,
+        scope,
+        num_threads,
+        put_stream.stream());
+  }
+
+  // Wait for signal (thread scope is fine for the wait side)
+  {
+    c10::cuda::CUDAStreamGuard guard(wait_stream);
+    torchcomms::device::test::launchDeviceWaitSignalKernel(
+        dev_win, kSignalId, 1, wait_stream.stream());
+  }
+
+  put_stream.synchronize();
+  wait_stream.synchronize();
+
+  // Verify data
+  at::Tensor result_slice = win_tensor.index(
+      {at::indexing::Slice(src_rank * count, (src_rank + 1) * count)});
+  at::Tensor result_cpu = result_slice.cpu();
+
+  auto cpu_options = at::TensorOptions().dtype(dtype).device(at::kCPU);
+  at::Tensor expected_cpu = at::zeros({count}, cpu_options);
+  expected_cpu.fill_(static_cast<float>(src_rank + 1));
+
+  bool equal = at::allclose(result_cpu, expected_cpu);
+  ASSERT_TRUE(equal) << "Scoped put (" << scope_name
+                     << ") data mismatch: expected value " << (src_rank + 1)
+                     << " from rank " << src_rank
+                     << ", got first element: " << result_cpu[0].item<float>();
+
+  // Reset signals
+  {
+    c10::cuda::CUDAStreamGuard guard(put_stream);
+    torchcomms::device::test::launchDeviceResetSignalKernel(
+        dev_win, kSignalId, put_stream.stream());
+  }
+  put_stream.synchronize();
+
+  win->deregister_local_buffer(src_buf);
+  base_win->tensor_deregister();
+  base_win.reset();
+  mem_pool.reset();
+
+  torchcomm_->barrier(false);
+}
+
+TEST_F(DeviceApiTest, DevicePutWarpScope) {
+  testDevicePutScoped(
+      1024, at::kFloat, torchcomms::device::CoopScope::WARP, 32);
+}
+
+TEST_F(DeviceApiTest, DevicePutBlockScope) {
+  testDevicePutScoped(
+      1024, at::kFloat, torchcomms::device::CoopScope::BLOCK, 256);
+}
+
+// =============================================================================
+// Scope-Aware Barrier Tests
+// =============================================================================
+
+void DeviceApiTest::testDeviceBarrierScoped(
+    torchcomms::device::CoopScope scope,
+    int num_threads) {
+  std::string scope_name =
+      (scope == torchcomms::device::CoopScope::WARP) ? "WARP" : "BLOCK";
+  SCOPED_TRACE(
+      ::testing::Message() << "Testing Scoped Barrier (" << scope_name
+                           << ", threads=" << num_threads << ")");
+
+  auto op_stream = at::cuda::getStreamFromPool(false, device_index_);
+
+  auto mem_pool = std::make_unique<at::cuda::MemPool>(
+      std::static_pointer_cast<c10::cuda::CUDACachingAllocator::CUDAAllocator>(
+          allocator_));
+  c10::cuda::CUDACachingAllocator::beginAllocateToPool(
+      mem_pool->device(), mem_pool->id(), [](cudaStream_t) { return true; });
+
+  auto options =
+      at::TensorOptions().dtype(at::kLong).device(at::kCUDA, device_index_);
+  at::Tensor win_tensor = at::zeros({1}, options);
+
+  c10::cuda::CUDACachingAllocator::endAllocateToPool(
+      mem_pool->device(), mem_pool->id());
+
+  torchcomm_->barrier(false);
+  auto base_win = torchcomm_->new_window();
+  base_win->tensor_register(win_tensor);
+  torchcomm_->barrier(false);
+
+  auto* win =
+      dynamic_cast<torch::comms::TorchCommWindowNCCLXGin*>(base_win.get());
+  ASSERT_NE(win, nullptr);
+
+  int barrier_count = 2;
+  auto* dev_win = win->get_device_window(-1, -1, barrier_count);
+  ASSERT_NE(dev_win, nullptr);
+
+  constexpr int kBarrierId = 0;
+
+  // First barrier
+  {
+    c10::cuda::CUDAStreamGuard guard(op_stream);
+    torchcomms::device::test::launchDeviceBarrierScopedKernel(
+        dev_win, kBarrierId, scope, num_threads, op_stream.stream());
+  }
+  op_stream.synchronize();
+
+  // Second barrier to verify reusability
+  {
+    c10::cuda::CUDAStreamGuard guard(op_stream);
+    torchcomms::device::test::launchDeviceBarrierScopedKernel(
+        dev_win, kBarrierId + 1, scope, num_threads, op_stream.stream());
+  }
+  op_stream.synchronize();
+
+  base_win->tensor_deregister();
+  base_win.reset();
+  mem_pool.reset();
+
+  torchcomm_->barrier(false);
+}
+
+TEST_F(DeviceApiTest, DeviceBarrierWarpScope) {
+  testDeviceBarrierScoped(torchcomms::device::CoopScope::WARP, 32);
+}
+
+TEST_F(DeviceApiTest, DeviceBarrierBlockScope) {
+  testDeviceBarrierScoped(torchcomms::device::CoopScope::BLOCK, 256);
+}

--- a/comms/torchcomms/tests/integration/cpp/DeviceApiTest.hpp
+++ b/comms/torchcomms/tests/integration/cpp/DeviceApiTest.hpp
@@ -63,6 +63,18 @@ class DeviceApiTest : public ::testing::Test {
   // Device barrier test - validates world barrier (LSA + GIN)
   void testDeviceBarrier();
 
+  // Scope-aware put test - validates cooperative put with warp/block scope
+  void testDevicePutScoped(
+      int count,
+      at::ScalarType dtype,
+      torchcomms::device::CoopScope scope,
+      int num_threads);
+
+  // Scope-aware barrier test - validates cooperative barrier
+  void testDeviceBarrierScoped(
+      torchcomms::device::CoopScope scope,
+      int num_threads);
+
   // Member variables
   std::unique_ptr<TorchCommTestWrapper> wrapper_;
   std::shared_ptr<torch::comms::TorchComm> torchcomm_;

--- a/comms/torchcomms/tests/integration/cpp/DeviceApiTestKernels.cuh
+++ b/comms/torchcomms/tests/integration/cpp/DeviceApiTestKernels.cuh
@@ -109,4 +109,28 @@ void launchDeviceBarrierKernel(
     int barrier_id,
     cudaStream_t stream);
 
+// Launch scope-aware put kernel - all threads in the cooperative group
+// call put() together. num_threads must match the scope:
+//   - WARP:  32
+//   - BLOCK: 256 (or any block size)
+void launchDevicePutScopedKernel(
+    DeviceWindowNCCL* win,
+    RegisteredBufferNCCL src_buf,
+    size_t src_offset,
+    size_t dst_offset,
+    size_t bytes,
+    int dst_rank,
+    int signal_id,
+    CoopScope scope,
+    int num_threads,
+    cudaStream_t stream);
+
+// Launch scope-aware barrier kernel
+void launchDeviceBarrierScopedKernel(
+    DeviceWindowNCCL* win,
+    int barrier_id,
+    CoopScope scope,
+    int num_threads,
+    cudaStream_t stream);
+
 } // namespace torchcomms::device::test


### PR DESCRIPTION
Summary:
Adds cooperative scope support (`THREAD`, `WARP`, `BLOCK`) to the TorchComms device API, enabling multiple threads to participate in RMA and synchronization operations for higher throughput. `THREAD` (default) preserves backward compatibility, while `WARP` and `BLOCK` enable cooperative execution through NCCL's GIN and pipes' vectorized memcpy.

###Key Changes

- **`CoopScope` enum** in `TorchCommDeviceWindow.hpp` with `THREAD`/`WARP`/`BLOCK` values
- **Unified API surface**: `put()`, `signal()`, `flush()`, `barrier()` each take an optional `CoopScope scope = CoopScope::THREAD` default parameter — no duplicate overloads
- **NCCLX implementation helpers**: `detail::nccl_coop_dispatch()` bridges runtime `CoopScope` enum to compile-time GIN coop types (`ncclCoopThread`/`ncclCoopWarp`/`ncclCoopCta`); `detail::make_thread_group()` + `detail::memcpy_nvl()` for cooperative NVLink memcpy via pipes
- **Signal cleanup**: Removed unnecessary `gin.flush()` from inside `signal()` — WQEs are submitted inline via doorbell, and QP ordering guarantees prior puts complete before the signal atomic. Users call `flush()` explicitly for local completion.
- **Integration tests**: Added `DevicePutWarpScope`, `DevicePutBlockScope`, `DeviceBarrierWarpScope`, `DeviceBarrierBlockScope` tests with scoped kernel launchers

Differential Revision: D93534775
