### PR TITLE
ci: limit make parallelism

### DIFF
--- a/build_ncclx.sh
+++ b/build_ncclx.sh
@@ -81,7 +81,7 @@ function build_automake_library() {
   pushd "$library_name"
   ./configure --prefix="$CMAKE_PREFIX_PATH" --disable-pie
 
-  make -j
+  make -j$(nproc)
   make install
   popd
 }
@@ -122,7 +122,7 @@ function build_openssl() {
   pushd "$library_name"
   ./config no-shared --prefix="$CMAKE_PREFIX_PATH" --openssldir="$CMAKE_PREFIX_PATH" --libdir=lib
 
-  make -j
+  make -j$(nproc)
   make install
   popd
 }
@@ -379,7 +379,7 @@ function build_nccl {
 }
 
 function build_and_install_nccl {
-make VERBOSE=1 -j \
+make VERBOSE=1 -j$(nproc) \
     src.install \
     BUILDDIR="$BUILDDIR" \
     NVCC_GENCODE="$NVCC_GENCODE" \

--- a/build_rcclx.sh
+++ b/build_rcclx.sh
@@ -81,7 +81,7 @@ function build_automake_library() {
   pushd "$library_name"
   ./configure --prefix="$CMAKE_PREFIX_PATH" --disable-pie
 
-  make -j
+  make -j$(nproc)
   make install
   popd
 }
@@ -122,7 +122,7 @@ function build_openssl() {
   pushd "$library_name"
   ./config no-shared --prefix="$CMAKE_PREFIX_PATH" --openssldir="$CMAKE_PREFIX_PATH" --libdir=lib
 
-  make -j
+  make -j$(nproc)
   make install
   popd
 }

--- a/comms/ncclx/v2_27/maint/oss_build.sh
+++ b/comms/ncclx/v2_27/maint/oss_build.sh
@@ -335,7 +335,7 @@ fi
 
 # Note: debug with: make SHELL="/bin/bash -x"
 # build libnccl
-make -j \
+make -j$(nproc) \
   src.build \
   NVCC_GENCODE="$NVCC_GENCODE" \
   CUDA_HOME="$CUDA_HOME" \

--- a/comms/ncclx/v2_28/maint/oss_build.sh
+++ b/comms/ncclx/v2_28/maint/oss_build.sh
@@ -335,7 +335,7 @@ fi
 
 # Note: debug with: make SHELL="/bin/bash -x"
 # build libnccl
-make -j \
+make -j$(nproc) \
   src.build \
   NVCC_GENCODE="$NVCC_GENCODE" \
   CUDA_HOME="$CUDA_HOME" \


### PR DESCRIPTION
This limits the parallelism for make builds to the number of cores on the system to avoid OOMing. Our standard runner is g5.12xlarge which is 48 cores, 192 GB mem and 4 GPUs.

https://instances.vantage.sh/aws/ec2/g5.12xlarge?currency=USD

Test plan:

CIl

This should fix https://github.com/meta-pytorch/torchcomms/actions/runs/22117865559/job/63930526099?pr=710