### PR TITLE
timepoint use duration 1us

### DIFF
--- a/comms/ctran/algos/perftrace/TimestampPoint.cc
+++ b/comms/ctran/algos/perftrace/TimestampPoint.cc
@@ -10,7 +10,7 @@ namespace ctran::perftrace {
 
 namespace {
 // Convert tp to dur in us to be visible in trace
-const int kPointToDurUs = 5;
+const int kPointToDurUs = 1;
 } // namespace
 
 std::string TimestampPoint::toJsonEntry(


### PR DESCRIPTION
Summary: This is to minimize events dropped due to overlaps. Not sure why it was 5 before (perhaps it was easier for viewing there?)

Differential Revision: D93538017


