### PR TITLE
Add memcpy_vectorized_dual_dest for fused dual-destination copy

### DIFF
--- a/comms/pipes/tests/CopyUtilsTest.cc
+++ b/comms/pipes/tests/CopyUtilsTest.cc
@@ -117,4 +117,109 @@ INSTANTIATE_TEST_SUITE_P(
         // Edge case: single warp
         CopyChunkVectorizedParams{1, 32, 2048, 0, 0}));
 
+// --- Dual-destination tests for memcpy_vectorized_dual_dest ---
+
+struct CopyChunkVectorizedDualDestParams {
+  int numBlocks;
+  int numThreads;
+  std::size_t nBytes;
+  std::size_t dst1Offset;
+  std::size_t dst2Offset;
+  std::size_t srcOffset;
+};
+
+class CopyUtilsTestDualDestParameterized
+    : public CopyUtilsTestFixture,
+      public ::testing::WithParamInterface<CopyChunkVectorizedDualDestParams> {
+};
+
+// Test memcpy_vectorized_dual_dest() which reads source data once and writes
+// to two destinations simultaneously. Verifies both destinations match the
+// source byte-for-byte across various sizes, alignments, and thread configs.
+TEST_P(CopyUtilsTestDualDestParameterized, CopyChunkVectorizedDualDest) {
+  const auto& params = GetParam();
+  const std::size_t maxOffset =
+      std::max({params.dst1Offset, params.dst2Offset, params.srcOffset});
+  const std::size_t bufferSize = params.nBytes + maxOffset;
+
+  DeviceBuffer srcBuffer(bufferSize);
+  DeviceBuffer dst1Buffer(bufferSize);
+  DeviceBuffer dst2Buffer(bufferSize);
+  DeviceBuffer errorCountBuffer(sizeof(uint32_t));
+
+  auto src_d = static_cast<char*>(srcBuffer.get());
+  auto dst1_d = static_cast<char*>(dst1Buffer.get());
+  auto dst2_d = static_cast<char*>(dst2Buffer.get());
+  auto errorCount_d = static_cast<uint32_t*>(errorCountBuffer.get());
+
+  std::vector<char> src_h(bufferSize);
+  for (std::size_t i = 0; i < bufferSize; i++) {
+    src_h[i] = static_cast<char>(i % 256);
+  }
+
+  CUDACHECK_TEST(
+      cudaMemcpy(src_d, src_h.data(), bufferSize, cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(cudaMemset(dst1_d, 0, bufferSize));
+  CUDACHECK_TEST(cudaMemset(dst2_d, 0, bufferSize));
+  CUDACHECK_TEST(cudaMemset(errorCount_d, 0, sizeof(uint32_t)));
+
+  testCopyChunkVectorizedDualDest(
+      dst1_d + params.dst1Offset,
+      dst2_d + params.dst2Offset,
+      src_d + params.srcOffset,
+      params.nBytes,
+      errorCount_d,
+      params.numBlocks,
+      params.numThreads);
+
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  uint32_t errorCount_h = 0;
+  CUDACHECK_TEST(cudaMemcpy(
+      &errorCount_h, errorCount_d, sizeof(uint32_t), cudaMemcpyDeviceToHost));
+
+  EXPECT_EQ(errorCount_h, 0)
+      << "Dual-dest copy failed with " << errorCount_h << " mismatches"
+      << " (numBlocks=" << params.numBlocks
+      << ", numThreads=" << params.numThreads << ", nBytes=" << params.nBytes
+      << ", dst1Offset=" << params.dst1Offset
+      << ", dst2Offset=" << params.dst2Offset
+      << ", srcOffset=" << params.srcOffset << ")";
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CopyUtilsDualDestTests,
+    CopyUtilsTestDualDestParameterized,
+    ::testing::Values(
+        // Basic aligned case: 4KB, no offsets
+        CopyChunkVectorizedDualDestParams{1, 256, 4096, 0, 0, 0},
+        // Unaligned size (not multiple of 64 bytes)
+        CopyChunkVectorizedDualDestParams{1, 256, 4097, 0, 0, 0},
+        // Small size (less than warp size * vector size)
+        CopyChunkVectorizedDualDestParams{1, 32, 128, 0, 0, 0},
+        // Large size with multiple blocks
+        CopyChunkVectorizedDualDestParams{4, 256, 65536, 0, 0, 0},
+        // dst1 offset only (16-byte aligned)
+        CopyChunkVectorizedDualDestParams{1, 256, 4096, 64, 0, 0},
+        // dst2 offset only (16-byte aligned)
+        CopyChunkVectorizedDualDestParams{1, 256, 4096, 0, 64, 0},
+        // src offset only (16-byte aligned)
+        CopyChunkVectorizedDualDestParams{1, 256, 4096, 0, 0, 128},
+        // All three offsets non-zero (16-byte aligned)
+        CopyChunkVectorizedDualDestParams{1, 256, 4096, 32, 48, 64},
+        // Different thread count
+        CopyChunkVectorizedDualDestParams{2, 128, 8192, 0, 0, 0},
+        // Single warp
+        CopyChunkVectorizedDualDestParams{1, 32, 2048, 0, 0, 0},
+        // dst1 unaligned (forces byte-level fallback path)
+        CopyChunkVectorizedDualDestParams{1, 256, 4096, 3, 0, 0},
+        // dst2 unaligned (forces byte-level fallback path)
+        CopyChunkVectorizedDualDestParams{1, 256, 4096, 0, 7, 0},
+        // src unaligned (forces byte-level fallback path)
+        CopyChunkVectorizedDualDestParams{1, 256, 4096, 0, 0, 5},
+        // Tiny copy (< 16 bytes, smaller than single uint4)
+        CopyChunkVectorizedDualDestParams{1, 256, 15, 0, 0, 0},
+        // Zero-byte copy (no-op boundary condition)
+        CopyChunkVectorizedDualDestParams{1, 256, 0, 0, 0, 0}));
+
 } // namespace comms::pipes::test

--- a/comms/pipes/tests/CopyUtilsTest.cu
+++ b/comms/pipes/tests/CopyUtilsTest.cu
@@ -23,7 +23,7 @@ __global__ void testCopyChunkVectorizedKernel(
 
   __syncthreads();
 
-  if (warp.is_leader() && warp.group_id == 0) {
+  if (warp.is_global_leader()) {
     for (std::size_t i = 0; i < chunk_bytes; i++) {
       if (dst_d[i] != src_d[i]) {
         atomicAdd(errorCount_d, 1);
@@ -41,6 +41,43 @@ void testCopyChunkVectorized(
     int blockSize) {
   testCopyChunkVectorizedKernel<<<numBlocks, blockSize>>>(
       dst_d, src_d, chunk_bytes, errorCount_d);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+__global__ void testCopyChunkVectorizedDualDestKernel(
+    char* dst1_d,
+    char* dst2_d,
+    const char* src_d,
+    std::size_t chunk_bytes,
+    uint32_t* errorCount_d) {
+  auto warp = make_warp_group();
+
+  memcpy_vectorized_dual_dest(dst1_d, dst2_d, src_d, chunk_bytes, warp);
+
+  __syncthreads();
+
+  if (warp.is_global_leader()) {
+    for (std::size_t i = 0; i < chunk_bytes; i++) {
+      if (dst1_d[i] != src_d[i]) {
+        atomicAdd(errorCount_d, 1);
+      }
+      if (dst2_d[i] != src_d[i]) {
+        atomicAdd(errorCount_d, 1);
+      }
+    }
+  }
+}
+
+void testCopyChunkVectorizedDualDest(
+    char* dst1_d,
+    char* dst2_d,
+    const char* src_d,
+    std::size_t chunk_bytes,
+    uint32_t* errorCount_d,
+    int numBlocks,
+    int blockSize) {
+  testCopyChunkVectorizedDualDestKernel<<<numBlocks, blockSize>>>(
+      dst1_d, dst2_d, src_d, chunk_bytes, errorCount_d);
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 

--- a/comms/pipes/tests/CopyUtilsTest.cuh
+++ b/comms/pipes/tests/CopyUtilsTest.cuh
@@ -17,4 +17,13 @@ void testCopyChunkVectorized(
     int numBlocks,
     int blockSize);
 
+void testCopyChunkVectorizedDualDest(
+    char* dst1_d,
+    char* dst2_d,
+    const char* src_d,
+    std::size_t chunk_bytes,
+    uint32_t* errorCount_d,
+    int numBlocks,
+    int blockSize);
+
 } // namespace comms::pipes::test


### PR DESCRIPTION
Summary:
**TL;DR:** Adds a dual-destination variant of `memcpy_vectorized` that reads source data once and writes to two destinations simultaneously, eliminating the redundant HBM read that occurs when performing two sequential copies.

---

# Detailed Overview

## Context & Motivation
In pipelined broadcast collectives (e.g., ring broadcast), intermediate ranks must forward received data to two locations: the local output buffer and the next peer's staging buffer. The naive approach is two sequential `memcpy_vectorized` calls (src→dst1, then src→dst2), which reads the source from HBM twice. Since HBM bandwidth is the primary bottleneck on GPU, this extra read is wasteful and directly impacts collective latency.

## Technical Details
This diff introduces two new CUDA device functions in `CopyUtils.cuh`:

- **`memcpy_vectorized_dual_dest_aligned<VecType, kUnroll>`**: The core vectorized kernel that reads each element from `src` once into registers, then stores to both `dst1` and `dst2`. Uses the same coalesced striding pattern as the existing `memcpy_vectorized_aligned` (each thread handles `kUnroll` elements strided by `group_size` for coalesced memory access). The unrolled loop is split into three phases: load from src, store to dst1, store to dst2—keeping the read-then-write separation that allows the compiler to optimize memory operations.

- **`memcpy_vectorized_dual_dest<kUnroll>`**: A byte-level wrapper that checks 16-byte (`uint4`) alignment of all three pointers (dst1, dst2, src). When aligned, it dispatches to the vectorized `uint4` path; any remaining bytes (or the entire copy if unaligned) fall back to byte-granularity copying.

Both functions mirror the existing single-destination API pattern (`memcpy_vectorized` / `memcpy_vectorized_aligned`) and use `__restrict__` qualifiers to enable store-forwarding optimizations.

---

## Usability/Applicability Overview

| Collective | `memcpy_vectorized_dual_dest` |
|---|---|---|
| **Ring Broadcast** | Designed for this |
| **Ring Allgather** | Direct reuse |
| **Ring Reduce** | Not applicable (1 output, not 2) |
| **Ring Allreduce** | Allgather phase only |
| **Ring Reduce-Scatter** | Not applicable |
| **Tree Broadcast** | Partial (2 of N children) |
| **Tree Reduce** | Not applicable |
| **All-to-All** | Not applicable |

**`memcpy_vectorized_dual_dest` is reusable for collectives where intermediate ranks forward data *unchanged* to two destinations (local output + successor staging).** This is broadcast and allgather only. Reduction collectives don't have the "forward unchanged" pattern.

Differential Revision: D93523410


