### PR TITLE
Use TMA-based scatter signal kernel for NVLink peers (SM90+)

### DIFF
--- a/comms/ctran/gpe/CtranGpe.h
+++ b/comms/ctran/gpe/CtranGpe.h
@@ -325,6 +325,9 @@ struct KernelConfig {
   const uint64_t opCount;
   bool isDevice{true};
 
+  // Dynamic shared memory size override. 0 = use sizeof(CtranAlgoDeviceState).
+  size_t dynamicSharedMemBytes{0};
+
   // Experimental: allows one-sided communications, waitSignal and
   // multiWaitSignal, to run in parallel with other kernels when
   // launched on a single GPE thread.

--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -312,11 +312,14 @@ commResult_t CtranGpe::Impl::submit(
 
     // Set the maximum dynamic shared memory size since CtranAlgoDeviceState
     // (~67KB) exceeds the default limit (48KB)
+    size_t sharedMemBytes = kernelConfig.dynamicSharedMemBytes > 0
+        ? kernelConfig.dynamicSharedMemBytes
+        : sizeof(CtranAlgoDeviceState);
     FB_CUDACHECKGOTO(
         cudaFuncSetAttribute(
             ncclKernel,
             cudaFuncAttributeMaxDynamicSharedMemorySize,
-            sizeof(CtranAlgoDeviceState)),
+            sharedMemBytes),
         res,
         fail);
     FB_CUDACHECKGOTO(
@@ -325,7 +328,7 @@ commResult_t CtranGpe::Impl::submit(
             grid,
             blocks,
             kernelArgs.data(),
-            sizeof(CtranAlgoDeviceState),
+            sharedMemBytes,
             kernelConfig.stream),
         res,
         fail);


### PR DESCRIPTION
Summary:
Switch ATF and FTA scatter-signal operations to use a new TMA (Tensor Memory Accelerator) kernel for NVLink peers on SM90+ (Hopper and later). The new kernel offloads data movement to TMA DMA hardware through a 4-stage shared-memory pipeline (16KB per stage), achieving near-zero SM utilization compared to the previous SM-driven kernel that used 8 blocks of 256 threads doing int4 load/store. The TMA kernel launches 1 block per NVLink peer with 1 warp (32 threads), where only thread 0 programs the DMA pipeline.

Key changes:
- Add `scatterSignalKernelTma` and `tmaPipelineCopy` in kernels.cu with architecture guards (stub on AMD/pre-SM90)
- Add TMA pipeline constants in common.h (stage count, chunk size, barrier sizes, shared memory layout)
- Switch ATF/FTA in algos.cc to use the TMA kernel, counting NVL peers for grid sizing
- Add `dynamicSharedMemBytes` field to GPE KernelConfig so kernels can request custom shared memory sizes beyond the default sizeof(CtranAlgoDeviceState)
- The TMA kernel's shared memory layout places CtranAlgoDeviceState at the start (for GPE protocol) followed by TMA staging buffers and barriers (~132KB total)
- Split benchmark configs into tier2 and tier4 variants with updated dp_size/ep_size parameters

Differential Revision: D93133989


