### PR TITLE
Fix remote signal buffer offset in MultipeerIbgdaTransport

### DIFF
--- a/comms/pipes/tests/MultipeerIbgdaDeviceTransportTestMain.cc
+++ b/comms/pipes/tests/MultipeerIbgdaDeviceTransportTestMain.cc
@@ -8,6 +8,7 @@
 
 #include <gtest/gtest.h>
 
+#include <cstdint>
 #include <vector>
 
 #include "comms/pipes/tests/MultipeerIbgdaDeviceTransportTest.cuh"
@@ -90,6 +91,120 @@ INSTANTIATE_TEST_SUITE_P(
         RankMappingTestCase{2, 4, {0, 1, 3}},
         // Rank 3: all peers have lower ranks [0, 1, 2]
         RankMappingTestCase{3, 4, {0, 1, 2}}));
+
+// =============================================================================
+// Signal Buffer Offset Test
+//
+// Verifies the invariant that for every pair of ranks (A, B):
+//   A's remoteSignalOffset for B == B's localSignalOffset for A
+//
+// This ensures that when rank A RDMA-writes to rank B's signal buffer,
+// it targets the slot that rank B actually reads for rank A. The bug
+// fixed in D93259521 was using the sender's peer index for the remote
+// offset instead of the receiver's peer index for the sender.
+//
+// The offset logic mirrors MultipeerIbgdaTransport::exchange():
+//   rankToPeerIndex(rank, myRank) = (rank < myRank) ? rank : (rank - 1)
+//   peerIndexToRank(idx, myRank)  = (idx < myRank) ? idx : (idx + 1)
+//   localSignalOffset(i)  = i * signalCount * sizeof(uint64_t)
+//   remoteSignalOffset(i) = myIndexOnPeer * signalCount * sizeof(uint64_t)
+//     where myIndexOnPeer = rankToPeerIndex(myRank, peerRank)
+// =============================================================================
+
+namespace {
+
+// Skip-self peer index: the index that `myRank` assigns to `rank`
+int rank_to_peer_index(int rank, int myRank) {
+  return (rank < myRank) ? rank : (rank - 1);
+}
+
+// Reverse: global rank at peer index `idx` from perspective of `myRank`
+int peer_index_to_rank(int idx, int myRank) {
+  return (idx < myRank) ? idx : (idx + 1);
+}
+
+} // namespace
+
+class SignalOffsetTest : public ::testing::TestWithParam<int> {};
+
+TEST_P(SignalOffsetTest, RemoteOffsetMatchesLocalSlot) {
+  const int nRanks = GetParam();
+  const int numPeers = nRanks - 1;
+  const std::size_t signalCount = 1;
+
+  // For every rank acting as sender...
+  for (int myRank = 0; myRank < nRanks; myRank++) {
+    // For every peer index i on this rank...
+    for (int i = 0; i < numPeers; i++) {
+      int peerRank = peer_index_to_rank(i, myRank);
+
+      // Sender's local offset for peer index i
+      std::size_t localOffset = i * signalCount * sizeof(uint64_t);
+
+      // Sender's remote offset: where to RDMA-write on the peer's buffer
+      int myIndexOnPeer = rank_to_peer_index(myRank, peerRank);
+      std::size_t remoteOffset = myIndexOnPeer * signalCount * sizeof(uint64_t);
+
+      // The peer's local offset for us must match our remote offset
+      int peersIndexForUs = rank_to_peer_index(myRank, peerRank);
+      std::size_t peersLocalOffset =
+          peersIndexForUs * signalCount * sizeof(uint64_t);
+
+      EXPECT_EQ(remoteOffset, peersLocalOffset)
+          << "Rank " << myRank << " -> Rank " << peerRank
+          << ": remoteOffset=" << remoteOffset
+          << " != peer's localOffset=" << peersLocalOffset
+          << " (myIndexOnPeer=" << myIndexOnPeer
+          << ", peersIndexForUs=" << peersIndexForUs << ")";
+
+      // Also verify the reverse direction: peer's remote offset for us
+      // must match our local offset
+      int peersPeerIndex = rank_to_peer_index(myRank, peerRank);
+      int peersMyIndexOnUs = rank_to_peer_index(peerRank, myRank);
+      std::size_t peersRemoteOffset =
+          peersMyIndexOnUs * signalCount * sizeof(uint64_t);
+
+      EXPECT_EQ(peersRemoteOffset, localOffset)
+          << "Rank " << peerRank << " -> Rank " << myRank
+          << ": remoteOffset=" << peersRemoteOffset
+          << " != our localOffset=" << localOffset
+          << " (peer's peerIndex=" << peersPeerIndex
+          << ", peersMyIndexOnUs=" << peersMyIndexOnUs << ")";
+    }
+  }
+}
+
+// Test with multiple signalCount values to verify scaling
+TEST_P(SignalOffsetTest, MultipleSignalSlots) {
+  const int nRanks = GetParam();
+  const int numPeers = nRanks - 1;
+
+  for (std::size_t signalCount : {1, 4, 16}) {
+    for (int myRank = 0; myRank < nRanks; myRank++) {
+      for (int i = 0; i < numPeers; i++) {
+        int peerRank = peer_index_to_rank(i, myRank);
+        int myIndexOnPeer = rank_to_peer_index(myRank, peerRank);
+
+        std::size_t remoteOffset =
+            myIndexOnPeer * signalCount * sizeof(uint64_t);
+        std::size_t peersLocalOffset = rank_to_peer_index(myRank, peerRank) *
+            signalCount * sizeof(uint64_t);
+
+        EXPECT_EQ(remoteOffset, peersLocalOffset)
+            << "signalCount=" << signalCount << " Rank " << myRank
+            << " -> Rank " << peerRank;
+      }
+    }
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    MultipeerIbgdaDeviceTransport,
+    SignalOffsetTest,
+    ::testing::Values(2, 3, 4, 8),
+    [](const ::testing::TestParamInfo<int>& info) {
+      return std::to_string(info.param) + "Ranks";
+    });
 
 } // namespace comms::pipes::tests
 


### PR DESCRIPTION
Summary:
Fix the remote signal buffer offset calculation in
`MultipeerIbgdaTransport::buildDeviceTransport()`.

## Background

Each rank in the multipeer transport allocates a single contiguous
signal buffer on the GPU, partitioned into `nRanks - 1` peer slots
using skip-self indexing:

```
  rankToPeerIndex(rank) = (rank < myRank) ? rank : (rank - 1)
  peerIndexToRank(idx)  = (idx  < myRank) ? idx  : (idx  + 1)
```

During connection setup each rank exchanges the base address and rkey
of its signal buffer via allgather. When building the per-peer
`P2pIbgdaTransportDevice` objects, the code must compute two offsets:

* **Local offset** — where in *my* buffer the peer will RDMA-write to.
  This is indexed by my local peer index `i`.
* **Remote offset** — where in the *peer's* buffer I should RDMA-write.
  This must be indexed by the peer's local peer index *for me*.

## The bug

The old code used the same peer index `i` for both offsets:

```cpp
  // BEFORE (bug)
  std::size_t signalOffset = i * signalCount * sizeof(uint64_t);
  // ...used for BOTH local and remote
```

This is only correct when `i == myIndexOnPeer`, which only holds for
adjacent ranks. For non-adjacent ranks the remote offset points to the
wrong peer's slot, causing signal clobbering.

Concrete example with 4 ranks — Rank 0 connecting to Rank 2:

```
  Rank 0's peer table          Rank 2's peer table
  (skip-self, myRank=0)        (skip-self, myRank=2)
  ┌───────┬───────┬───────┐    ┌───────┬───────┬───────┐
  │ idx 0 │ idx 1 │ idx 2 │    │ idx 0 │ idx 1 │ idx 2 │
  │  R1   │  R2   │  R3   │    │  R0   │  R1   │  R3   │
  └───────┴───────┴───────┘    └───────┴───────┴───────┘

  Rank 0's local index for R2 is i=1.
  Bug: remote offset used i=1 → wrote to R2's slot 1, which is R1's slot!
  Fix: myIndexOnPeer = rankToPeerIndex(myRank=0) on R2 = 0
       → remote offset uses 0 → correctly targets R0's slot on R2.
```

In a 4-rank system, 6 of 12 directed pairs had incorrect remote
offsets. Only adjacent-rank pairs (where `i == myIndexOnPeer`) were
unaffected:

```
  ┌────────┬──────┬───────────────┬───────────────────────────────┐
  │ Pair   │ i    │ myIndexOnPeer │ Effect (before fix)           │
  ├────────┼──────┼───────────────┼───────────────────────────────┤
  │ R0→R2  │  1   │  0            │ Wrote to R1's slot on R2      │
  │ R0→R3  │  2   │  0            │ Wrote to R1's slot on R3      │
  │ R1→R3  │  2   │  1            │ Wrote to R2's slot on R3      │
  │ R2→R0  │  0   │  1            │ Wrote to R1's slot on R0      │
  │ R3→R0  │  0   │  2            │ Wrote to R1's slot on R0      │
  │ R3→R1  │  1   │  2            │ Wrote to R2's slot on R1      │
  └────────┴──────┴───────────────┴───────────────────────────────┘
```

## The fix

Split the single `signalOffset` into two independent variables:

* `localSignalOffset  = i * signalCount * sizeof(uint64_t)` (unchanged)
* `remoteSignalOffset = myIndexOnPeer * signalCount * sizeof(uint64_t)`

where `myIndexOnPeer = (myRank_ < peerRank) ? myRank_ : (myRank_ - 1)`
is the skip-self peer index that the remote rank assigns to us. This is
equivalent to evaluating `rankToPeerIndex(myRank_)` from the remote
rank's perspective.

RDMA signal write path after the fix (Rank 0 → Rank 2):

```
  Rank 0 (sender)                        Rank 2 (receiver)
  ┌──────────────────┐                   ┌──────────────────────┐
  │ buildParams[1]   │                   │ signalBuffer_        │
  │                  │                   │ ┌──────┬──────┬────┐ │
  │ localSignalBuf   │                   │ │ R0   │ R1   │ R3 │ │
  │  (my buf, i=1)   │                   │ │ s0   │ s1   │ s2 │ │
  │                  │                   │ └──┬───┴──────┴────┘ │
  │ remoteSignalBuf ─┼── RDMA write ─────┼────┘                 │
  │  (peer's buf,    │                   │  myIndexOnPeer = 0   │
  │   idx=0) ← FIX   │                   │                      │
  └──────────────────┘                   └──────────────────────┘
```

Reviewed By: dmwu

Differential Revision: D93259521


