### PR TITLE
AllReduce ctring eliminate trailing 16B chunks

### DIFF
--- a/comms/ctran/algos/AllReduce/AllReduceRingCommon.cuh
+++ b/comms/ctran/algos/AllReduce/AllReduceRingCommon.cuh
@@ -186,7 +186,9 @@ DEVICE_ATTRIBUTE void updatePartitionCtx(AlgoContext& algoCtx) {
   size_t remainNumel = algoCtx.numElements - algoCtx.partitionOffset;
   if (remainNumel < totalTmpNumel) {
     algoCtx.partitionNumel = remainNumel;
-  } else if (remainNumel < totalTmpNumel + minPartitionNumel) {
+  } else if (
+      remainNumel > totalTmpNumel &&
+      remainNumel < totalTmpNumel + minPartitionNumel) {
     // ensure last partition can still be handled as multi-shard ring
     algoCtx.partitionNumel = remainNumel - minPartitionNumel;
   } else {


### PR DESCRIPTION
Summary:
There is a bug in the algorithm that creates trailing 16B chunks in certain situations. I observed this from the profiles.

E.g. if TotalTmpNumel == remainNumel, and both are already power of 2, the old logic would cut remainNumel into two chunks: 16, remainNumel - 16. The new logic avoids this issue

Differential Revision: D93698089


