### PR TITLE
Refactor AllReduce integration tests with graph fixture

### DIFF
--- a/comms/torchcomms/tests/integration/cpp/AllReducePreMulSumTestMain.cpp
+++ b/comms/torchcomms/tests/integration/cpp/AllReducePreMulSumTestMain.cpp
@@ -5,112 +5,191 @@
 #include <gtest/gtest.h>
 #include "TorchCommTestHelpers.h"
 
-TEST_P(AllReduceTest, SyncAllReduce) {
+using Eager = AllReduceTest<EagerTestFixture<PreMulSumParams>>;
+using SingleGraph = AllReduceTest<GraphTestFixture<PreMulSumParams, 1>>;
+using MultiGraph = AllReduceTest<GraphTestFixture<PreMulSumParams, 2>>;
+
+#define MAKE_PREMUL_OP(opType, dtype)                  \
+  ((opType) == PreMulSumOpType::kTensor                \
+       ? torch::comms::ReduceOp::make_nccl_premul_sum( \
+             createPreMulFactorTensor((dtype)))        \
+       : torch::comms::ReduceOp::make_nccl_premul_sum(2.0))
+
+TEST_P(Eager, Sync) {
   int count = std::get<0>(GetParam());
   at::ScalarType dtype = std::get<1>(GetParam());
-  torch::comms::ReduceOp op = std::get<2>(GetParam());
-  testSyncAllReduce(count, dtype, op);
-
-  testSyncAllReduce(
-      count,
-      at::kBFloat16,
-      torch::comms::ReduceOp::make_nccl_premul_sum(
-          createPreMulFactorTensor(at::kBFloat16)));
+  PreMulSumOpType opType = std::get<2>(GetParam());
+  testSync(count, dtype, MAKE_PREMUL_OP(opType, dtype));
 }
 
-TEST_P(AllReduceTest, SyncAllReduceNoWork) {
+TEST_P(Eager, SyncNoWork) {
   int count = std::get<0>(GetParam());
   at::ScalarType dtype = std::get<1>(GetParam());
-  torch::comms::ReduceOp op = std::get<2>(GetParam());
-  testSyncAllReduceNoWork(count, dtype, op);
-
-  testSyncAllReduceNoWork(
-      count,
-      at::kBFloat16,
-      torch::comms::ReduceOp::make_nccl_premul_sum(
-          createPreMulFactorTensor(at::kBFloat16)));
+  PreMulSumOpType opType = std::get<2>(GetParam());
+  testSyncNoWork(count, dtype, MAKE_PREMUL_OP(opType, dtype));
 }
 
-TEST_P(AllReduceTest, AsyncAllReduce) {
+TEST_P(Eager, Async) {
   int count = std::get<0>(GetParam());
   at::ScalarType dtype = std::get<1>(GetParam());
-  torch::comms::ReduceOp op = std::get<2>(GetParam());
-  testAsyncAllReduce(count, dtype, op);
-
-  testAsyncAllReduce(
-      count,
-      at::kBFloat16,
-      torch::comms::ReduceOp::make_nccl_premul_sum(
-          createPreMulFactorTensor(at::kBFloat16)));
+  PreMulSumOpType opType = std::get<2>(GetParam());
+  testAsync(count, dtype, MAKE_PREMUL_OP(opType, dtype));
 }
 
-TEST_P(AllReduceTest, AsyncAllReduceEarlyReset) {
+TEST_P(Eager, AsyncEarlyReset) {
   int count = std::get<0>(GetParam());
   at::ScalarType dtype = std::get<1>(GetParam());
-  torch::comms::ReduceOp op = std::get<2>(GetParam());
-  testAsyncAllReduceEarlyReset(count, dtype, op);
-
-  testAsyncAllReduceEarlyReset(
-      count,
-      at::kBFloat16,
-      torch::comms::ReduceOp::make_nccl_premul_sum(
-          createPreMulFactorTensor(at::kBFloat16)));
+  PreMulSumOpType opType = std::get<2>(GetParam());
+  testAsyncEarlyReset(count, dtype, MAKE_PREMUL_OP(opType, dtype));
 }
 
-TEST_P(AllReduceTest, AllReduceInputDeleted) {
+TEST_P(Eager, InputDeleted) {
   int count = std::get<0>(GetParam());
   at::ScalarType dtype = std::get<1>(GetParam());
-  torch::comms::ReduceOp op = std::get<2>(GetParam());
-  testAllReduceInputDeleted(count, dtype, op);
-
-  testAllReduceInputDeleted(
-      count,
-      at::kBFloat16,
-      torch::comms::ReduceOp::make_nccl_premul_sum(
-          createPreMulFactorTensor(at::kBFloat16)));
+  PreMulSumOpType opType = std::get<2>(GetParam());
+  testInputDeleted(count, dtype, MAKE_PREMUL_OP(opType, dtype));
 }
 
-TEST_P(AllReduceTest, GraphAllReduce) {
+TEST_P(SingleGraph, Sync) {
   int count = std::get<0>(GetParam());
   at::ScalarType dtype = std::get<1>(GetParam());
-  torch::comms::ReduceOp op = std::get<2>(GetParam());
-  testGraphAllReduce(count, dtype, op);
-
-  testGraphAllReduce(
-      count,
-      at::kBFloat16,
-      torch::comms::ReduceOp::make_nccl_premul_sum(
-          createPreMulFactorTensor(at::kBFloat16)));
+  PreMulSumOpType opType = std::get<2>(GetParam());
+  testSync(count, dtype, MAKE_PREMUL_OP(opType, dtype));
 }
 
-TEST_P(AllReduceTest, GraphAllReduceInputDeleted) {
+TEST_P(SingleGraph, SyncNoWork) {
   int count = std::get<0>(GetParam());
   at::ScalarType dtype = std::get<1>(GetParam());
-  torch::comms::ReduceOp op = std::get<2>(GetParam());
-  testGraphAllReduceInputDeleted(count, dtype, op);
+  PreMulSumOpType opType = std::get<2>(GetParam());
+  testSyncNoWork(count, dtype, MAKE_PREMUL_OP(opType, dtype));
+}
 
-  testGraphAllReduceInputDeleted(
-      count,
-      at::kBFloat16,
-      torch::comms::ReduceOp::make_nccl_premul_sum(
-          createPreMulFactorTensor(at::kBFloat16)));
+TEST_P(SingleGraph, Async) {
+  int count = std::get<0>(GetParam());
+  at::ScalarType dtype = std::get<1>(GetParam());
+  PreMulSumOpType opType = std::get<2>(GetParam());
+  testAsync(count, dtype, MAKE_PREMUL_OP(opType, dtype));
+}
+
+TEST_P(SingleGraph, InputDeleted) {
+  int count = std::get<0>(GetParam());
+  at::ScalarType dtype = std::get<1>(GetParam());
+  PreMulSumOpType opType = std::get<2>(GetParam());
+  testInputDeleted(count, dtype, MAKE_PREMUL_OP(opType, dtype));
+}
+
+TEST_P(MultiGraph, Sync) {
+  int count = std::get<0>(GetParam());
+  at::ScalarType dtype = std::get<1>(GetParam());
+  PreMulSumOpType opType = std::get<2>(GetParam());
+  testSync(count, dtype, MAKE_PREMUL_OP(opType, dtype));
+}
+
+TEST_P(MultiGraph, SyncNoWork) {
+  int count = std::get<0>(GetParam());
+  at::ScalarType dtype = std::get<1>(GetParam());
+  PreMulSumOpType opType = std::get<2>(GetParam());
+  testSyncNoWork(count, dtype, MAKE_PREMUL_OP(opType, dtype));
+}
+
+TEST_P(MultiGraph, Async) {
+  int count = std::get<0>(GetParam());
+  at::ScalarType dtype = std::get<1>(GetParam());
+  PreMulSumOpType opType = std::get<2>(GetParam());
+  testAsync(count, dtype, MAKE_PREMUL_OP(opType, dtype));
+}
+
+TEST_P(MultiGraph, InputDeleted) {
+  int count = std::get<0>(GetParam());
+  at::ScalarType dtype = std::get<1>(GetParam());
+  PreMulSumOpType opType = std::get<2>(GetParam());
+  testInputDeleted(count, dtype, MAKE_PREMUL_OP(opType, dtype));
+}
+
+#undef MAKE_PREMUL_OP
+
+auto allReducePreMulSumScalarParams() {
+  return ::testing::Combine(
+      ::testing::Values(0, 4, 1024, 1024 * 1024),
+      ::testing::Values(at::kHalf, at::kFloat, at::kDouble),
+      ::testing::Values(PreMulSumOpType::kScalar));
+}
+
+auto allReducePreMulSumBf16TensorParams() {
+  return ::testing::Combine(
+      ::testing::Values(0, 4, 1024, 1024 * 1024),
+      ::testing::Values(at::kBFloat16),
+      ::testing::Values(PreMulSumOpType::kTensor));
+}
+
+auto allReducePreMulSumGraphScalarParams() {
+  return ::testing::Combine(
+      ::testing::Values(0, 1024, 1024 * 1024),
+      ::testing::Values(at::kFloat),
+      ::testing::Values(PreMulSumOpType::kScalar));
+}
+
+auto allReducePreMulSumGraphBf16TensorParams() {
+  return ::testing::Combine(
+      ::testing::Values(0, 1024, 1024 * 1024),
+      ::testing::Values(at::kBFloat16),
+      ::testing::Values(PreMulSumOpType::kTensor));
+}
+
+std::string getPreMulSumOpTypeName(PreMulSumOpType opType) {
+  switch (opType) {
+    case PreMulSumOpType::kScalar:
+      return "ScalarPreMulSum";
+    case PreMulSumOpType::kTensor:
+      return "TensorPreMulSum";
+  }
+  return "Unknown";
+}
+
+auto allReducePreMulSumParamNamer(
+    const ::testing::TestParamInfo<PreMulSumParams>& info) {
+  int count = std::get<0>(info.param);
+  at::ScalarType dtype = std::get<1>(info.param);
+  PreMulSumOpType opType = std::get<2>(info.param);
+  return "Count_" + std::to_string(count) + "_" + getDtypeName(dtype) + "_" +
+      getPreMulSumOpTypeName(opType);
 }
 
 INSTANTIATE_TEST_SUITE_P(
-    AllReducePreMulSumDeviceTestParams,
-    AllReduceTest,
-    ::testing::Combine(
-        ::testing::Values(0, 4, 1024, 1024 * 1024),
-        ::testing::Values(at::kHalf, at::kFloat, at::kDouble),
-        ::testing::Values(torch::comms::ReduceOp::make_nccl_premul_sum(2.0))),
-    [](const ::testing::TestParamInfo<
-        std::tuple<int, at::ScalarType, torch::comms::ReduceOp>>& info) {
-      int count = std::get<0>(info.param);
-      at::ScalarType dtype = std::get<1>(info.param);
-      torch::comms::ReduceOp op = std::get<2>(info.param);
-      return "Count_" + std::to_string(count) + "_" + getDtypeName(dtype) +
-          "_" + getOpName(op);
-    });
+    AllReducePreMulSum,
+    Eager,
+    allReducePreMulSumScalarParams(),
+    allReducePreMulSumParamNamer);
+
+INSTANTIATE_TEST_SUITE_P(
+    AllReducePreMulSumBf16Tensor,
+    Eager,
+    allReducePreMulSumBf16TensorParams(),
+    allReducePreMulSumParamNamer);
+
+INSTANTIATE_TEST_SUITE_P(
+    AllReducePreMulSum,
+    SingleGraph,
+    allReducePreMulSumGraphScalarParams(),
+    allReducePreMulSumParamNamer);
+
+INSTANTIATE_TEST_SUITE_P(
+    AllReducePreMulSumBf16Tensor,
+    SingleGraph,
+    allReducePreMulSumGraphBf16TensorParams(),
+    allReducePreMulSumParamNamer);
+
+INSTANTIATE_TEST_SUITE_P(
+    AllReducePreMulSum,
+    MultiGraph,
+    allReducePreMulSumGraphScalarParams(),
+    allReducePreMulSumParamNamer);
+
+INSTANTIATE_TEST_SUITE_P(
+    AllReducePreMulSumBf16Tensor,
+    MultiGraph,
+    allReducePreMulSumGraphBf16TensorParams(),
+    allReducePreMulSumParamNamer);
 
 // This main function is provided by gtest
 int main(int argc, char** argv) {

--- a/comms/torchcomms/tests/integration/cpp/AllReduceTestMain.cpp
+++ b/comms/torchcomms/tests/integration/cpp/AllReduceTestMain.cpp
@@ -5,73 +5,144 @@
 #include <gtest/gtest.h>
 #include "TorchCommTestHelpers.h"
 
-TEST_P(AllReduceTest, SyncAllReduce) {
+using Eager = AllReduceTest<EagerTestFixture<AllReduceParams>>;
+using SingleGraph = AllReduceTest<GraphTestFixture<AllReduceParams, 1>>;
+using MultiGraph = AllReduceTest<GraphTestFixture<AllReduceParams, 2>>;
+
+TEST_P(Eager, Sync) {
   int count = std::get<0>(GetParam());
   at::ScalarType dtype = std::get<1>(GetParam());
   torch::comms::ReduceOp op = std::get<2>(GetParam());
-  testSyncAllReduce(count, dtype, op);
+  testSync(count, dtype, op);
 }
 
-TEST_P(AllReduceTest, SyncAllReduceNoWork) {
+TEST_P(Eager, SyncNoWork) {
   int count = std::get<0>(GetParam());
   at::ScalarType dtype = std::get<1>(GetParam());
   torch::comms::ReduceOp op = std::get<2>(GetParam());
-  testSyncAllReduceNoWork(count, dtype, op);
+  testSyncNoWork(count, dtype, op);
 }
 
-TEST_P(AllReduceTest, AsyncAllReduce) {
+TEST_P(Eager, Async) {
   int count = std::get<0>(GetParam());
   at::ScalarType dtype = std::get<1>(GetParam());
   torch::comms::ReduceOp op = std::get<2>(GetParam());
-  testAsyncAllReduce(count, dtype, op);
+  testAsync(count, dtype, op);
 }
 
-TEST_P(AllReduceTest, AsyncAllReduceEarlyReset) {
+TEST_P(Eager, AsyncEarlyReset) {
   int count = std::get<0>(GetParam());
   at::ScalarType dtype = std::get<1>(GetParam());
   torch::comms::ReduceOp op = std::get<2>(GetParam());
-  testAsyncAllReduceEarlyReset(count, dtype, op);
+  testAsyncEarlyReset(count, dtype, op);
 }
 
-TEST_P(AllReduceTest, AllReduceInputDeleted) {
+TEST_P(Eager, InputDeleted) {
   int count = std::get<0>(GetParam());
   at::ScalarType dtype = std::get<1>(GetParam());
   torch::comms::ReduceOp op = std::get<2>(GetParam());
-  testAllReduceInputDeleted(count, dtype, op);
+  testInputDeleted(count, dtype, op);
 }
 
-TEST_P(AllReduceTest, GraphAllReduce) {
+TEST_P(SingleGraph, Sync) {
   int count = std::get<0>(GetParam());
   at::ScalarType dtype = std::get<1>(GetParam());
   torch::comms::ReduceOp op = std::get<2>(GetParam());
-  testGraphAllReduce(count, dtype, op);
+  testSync(count, dtype, op);
 }
 
-TEST_P(AllReduceTest, GraphAllReduceInputDeleted) {
+TEST_P(SingleGraph, SyncNoWork) {
   int count = std::get<0>(GetParam());
   at::ScalarType dtype = std::get<1>(GetParam());
   torch::comms::ReduceOp op = std::get<2>(GetParam());
-  testGraphAllReduceInputDeleted(count, dtype, op);
+  testSyncNoWork(count, dtype, op);
+}
+
+TEST_P(SingleGraph, Async) {
+  int count = std::get<0>(GetParam());
+  at::ScalarType dtype = std::get<1>(GetParam());
+  torch::comms::ReduceOp op = std::get<2>(GetParam());
+  testAsync(count, dtype, op);
+}
+
+TEST_P(SingleGraph, InputDeleted) {
+  int count = std::get<0>(GetParam());
+  at::ScalarType dtype = std::get<1>(GetParam());
+  torch::comms::ReduceOp op = std::get<2>(GetParam());
+  testInputDeleted(count, dtype, op);
+}
+
+TEST_P(MultiGraph, Sync) {
+  int count = std::get<0>(GetParam());
+  at::ScalarType dtype = std::get<1>(GetParam());
+  torch::comms::ReduceOp op = std::get<2>(GetParam());
+  testSync(count, dtype, op);
+}
+
+TEST_P(MultiGraph, SyncNoWork) {
+  int count = std::get<0>(GetParam());
+  at::ScalarType dtype = std::get<1>(GetParam());
+  torch::comms::ReduceOp op = std::get<2>(GetParam());
+  testSyncNoWork(count, dtype, op);
+}
+
+TEST_P(MultiGraph, Async) {
+  int count = std::get<0>(GetParam());
+  at::ScalarType dtype = std::get<1>(GetParam());
+  torch::comms::ReduceOp op = std::get<2>(GetParam());
+  testAsync(count, dtype, op);
+}
+
+TEST_P(MultiGraph, InputDeleted) {
+  int count = std::get<0>(GetParam());
+  at::ScalarType dtype = std::get<1>(GetParam());
+  torch::comms::ReduceOp op = std::get<2>(GetParam());
+  testInputDeleted(count, dtype, op);
+}
+
+auto allReduceParamValues() {
+  return ::testing::Combine(
+      ::testing::Values(0, 4, 1024, 1024 * 1024),
+      ::testing::Values(at::kFloat, at::kInt, at::kChar),
+      ::testing::Values(
+          torch::comms::ReduceOp::SUM,
+          torch::comms::ReduceOp::MAX,
+          torch::comms::ReduceOp::AVG));
+}
+
+auto allReduceGraphParamValues() {
+  return ::testing::Combine(
+      ::testing::Values(0, 1000, 1024 * 1024),
+      ::testing::Values(at::kFloat),
+      ::testing::Values(torch::comms::ReduceOp::SUM));
+}
+
+auto allReduceParamNamer(
+    const ::testing::TestParamInfo<AllReduceParams>& info) {
+  int count = std::get<0>(info.param);
+  at::ScalarType dtype = std::get<1>(info.param);
+  torch::comms::ReduceOp op = std::get<2>(info.param);
+  return "Count_" + std::to_string(count) + "_" + getDtypeName(dtype) + "_" +
+      getOpName(op);
 }
 
 INSTANTIATE_TEST_SUITE_P(
-    AllReduceTestParams,
-    AllReduceTest,
-    ::testing::Combine(
-        ::testing::Values(0, 4, 1024, 1024 * 1024),
-        ::testing::Values(at::kFloat, at::kInt, at::kChar),
-        ::testing::Values(
-            torch::comms::ReduceOp::SUM,
-            torch::comms::ReduceOp::MAX,
-            torch::comms::ReduceOp::AVG)),
-    [](const ::testing::TestParamInfo<
-        std::tuple<int, at::ScalarType, torch::comms::ReduceOp>>& info) {
-      int count = std::get<0>(info.param);
-      at::ScalarType dtype = std::get<1>(info.param);
-      torch::comms::ReduceOp op = std::get<2>(info.param);
-      return "Count_" + std::to_string(count) + "_" + getDtypeName(dtype) +
-          "_" + getOpName(op);
-    });
+    AllReduce,
+    Eager,
+    allReduceParamValues(),
+    allReduceParamNamer);
+
+INSTANTIATE_TEST_SUITE_P(
+    AllReduce,
+    SingleGraph,
+    allReduceGraphParamValues(),
+    allReduceParamNamer);
+
+INSTANTIATE_TEST_SUITE_P(
+    AllReduce,
+    MultiGraph,
+    allReduceGraphParamValues(),
+    allReduceParamNamer);
 
 // This main function is provided by gtest
 int main(int argc, char** argv) {

--- a/comms/torchcomms/tests/integration/cpp/GraphTestFixtures.hpp
+++ b/comms/torchcomms/tests/integration/cpp/GraphTestFixtures.hpp
@@ -1,0 +1,142 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/CUDAGraph.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <gtest/gtest.h>
+#include "comms/torchcomms/tests/integration/cpp/TorchCommTestHelpers.h"
+
+template <typename Params>
+class TorchCommsTestBase : public ::testing::TestWithParam<Params> {
+ public:
+  TorchCommsTestBase()
+      : TorchCommsTestBase(
+            isRunningOnCPU() ? c10::DeviceType::CPU : c10::DeviceType::CUDA) {}
+  explicit TorchCommsTestBase(c10::DeviceType deviceType)
+      : rank_(0), num_ranks_(0), device_type_(deviceType) {}
+
+ protected:
+  virtual std::unique_ptr<TorchCommTestWrapper> createWrapper() {
+    return std::make_unique<TorchCommTestWrapper>();
+  }
+
+  void SetUp() override {
+    wrapper_ = createWrapper();
+    torchcomm_ = wrapper_->getTorchComm();
+    rank_ = torchcomm_->getRank();
+    num_ranks_ = torchcomm_->getSize();
+  }
+
+  void TearDown() override {
+    torchcomm_.reset();
+    wrapper_.reset();
+  }
+
+  // Unified test execution entry point. Fixture controls how the op runs
+  // (eager vs graph capture/replay).
+  //
+  // Usage patterns:
+  //   Standard test:    run(execute, reset, verify)
+  //   InputDeleted:     run(execute, {}, {}, cleanup)
+  //
+  // Parameters:
+  //   execute      - the collective op to run (captured into graph in graph
+  //                  mode)
+  //   reset        - restores input tensors to pre-op state (called before each
+  //                  graph replay; ignored in eager mode)
+  //   verify       - checks correctness (called after execute/replay)
+  //   afterCapture - one-shot callback after graph capture completes, before
+  //                  replay begins (graph mode only; e.g. destroy tensors for
+  //                  InputDeleted tests)
+  virtual void run(
+      const std::function<void()>& execute,
+      const std::function<void()>& reset = {},
+      const std::function<void()>& verify = {},
+      const std::function<void()>& afterCapture = {}) = 0;
+
+  std::unique_ptr<TorchCommTestWrapper> wrapper_;
+  std::shared_ptr<torch::comms::TorchComm> torchcomm_;
+  int rank_;
+  int num_ranks_;
+  c10::DeviceType device_type_;
+};
+
+// Eager mode: execute once, verify once. No CUDA graph involvement.
+template <typename Params>
+class EagerTestFixture : public TorchCommsTestBase<Params> {
+ protected:
+  void run(
+      const std::function<void()>& execute,
+      const std::function<void()>& /* reset */ = {},
+      const std::function<void()>& verify = {},
+      const std::function<void()>& /* afterCapture */ = {}) override {
+    execute();
+    if (verify) {
+      verify();
+    }
+  }
+};
+
+// Graph fixture: sets up non-default stream, captures op into NumGraphs
+// separate graphs, replays each. Skips on CPU.
+// NumGraphs=1 for single-graph tests, NumGraphs=2 for multi-graph tests.
+template <typename Params, int NumGraphs = 1>
+class GraphTestFixture : public TorchCommsTestBase<Params> {
+ protected:
+  void SetUp() override {
+    if (isRunningOnCPU()) {
+      GTEST_SKIP() << "CUDA Graph tests are not supported on CPU";
+    }
+    TorchCommsTestBase<Params>::SetUp();
+    stream_ = at::cuda::getStreamFromPool();
+    guard_.emplace(*stream_);
+  }
+
+  void TearDown() override {
+    guard_.reset();
+    stream_.reset();
+    TorchCommsTestBase<Params>::TearDown();
+  }
+
+  void run(
+      const std::function<void()>& execute,
+      const std::function<void()>& reset = {},
+      const std::function<void()>& verify = {},
+      const std::function<void()>& afterCapture = {}) override {
+    std::vector<std::unique_ptr<at::cuda::CUDAGraph>> graphs;
+    for (int g = 0; g < NumGraphs; ++g) {
+      graphs.push_back(std::make_unique<at::cuda::CUDAGraph>());
+      graphs.back()->capture_begin();
+      execute();
+      graphs.back()->capture_end();
+    }
+
+    if (afterCapture) {
+      afterCapture();
+    }
+
+    for (int i = 0; i < kNumReplays; ++i) {
+      for (int g = 0; g < NumGraphs; ++g) {
+        if (reset) {
+          reset();
+        }
+        graphs[g]->replay();
+        if (verify) {
+          verify();
+        }
+      }
+    }
+  }
+
+ private:
+  static constexpr int kNumReplays = 4;
+  std::optional<at::cuda::CUDAStream> stream_;
+  std::optional<at::cuda::CUDAStreamGuard> guard_;
+};


### PR DESCRIPTION
Summary:
Introduce GraphTestFixtures.hpp with a unified test fixture framework for torchcomms C++ integration tests:

- Three fixture types (EagerTestFixture, GraphTestFixture<Params, NumGraphs>) share a common base (TorchCommsTestBase) with a single `run(execute, reset, verify, afterCapture)` API
- Each collective defines test logic once and it automatically runs in Eager, SingleGraph (NumGraphs=1), and MultiGraph (NumGraphs=2) modes via gtest parameterization
- AllReduce and AllReducePreMulSum are migrated as Phase 1 prototype with PreMulSum tests using a PreMulSumOpType enum (kScalar/kTensor) to cleanly parameterize scalar vs tensor premul_sum without runtime op override
- Graph test parameters are reduced (Float+SUM only, fewer counts) to keep total test time reasonable
- HCCL AllReduceTest is updated to inherit from `AllReduceTest<EagerTestFixture<AllReduceParams>>` since MTIA has no CUDA graph support and only needs eager mode

Test counts (AllReduce):
  Eager:  36 params (4 counts × 3 dtypes × 3 ops) × 5 methods = 180
  Graph:   3 params (3 counts × 1 dtype × 1 op) × 4 methods × 2 fixtures = 24
  Total: 204

Differential Revision: D93253012


