### PR TITLE
Add Python bindings for TorchComm hooks and document registration with examples

### DIFF
--- a/comms/torchcomms/_comms.pyi
+++ b/comms/torchcomms/_comms.pyi
@@ -4,7 +4,7 @@
 
 from datetime import timedelta
 from enum import auto, Enum
-from typing import Any, Dict, List
+from typing import Any, Callable, Dict, List
 
 class RedOpType(Enum):
     SUM = auto()
@@ -30,6 +30,54 @@ class ReduceOp:
     def PREMUL_SUM(factor: Any) -> ReduceOp: ...
     @property
     def type(self) -> RedOpType: ...
+
+class OpName(Enum):
+    """Collective operation name for hooks."""
+
+    send = auto()
+    recv = auto()
+    broadcast = auto()
+    all_reduce = auto()
+    reduce = auto()
+    all_gather = auto()
+    all_gather_v = auto()
+    all_gather_single = auto()
+    reduce_scatter = auto()
+    reduce_scatter_v = auto()
+    reduce_scatter_single = auto()
+    all_to_all_single = auto()
+    all_to_all_v_single = auto()
+    all_to_all = auto()
+    barrier = auto()
+    scatter = auto()
+    gather = auto()
+    split = auto()
+    new_window = auto()
+
+class RemovableHandle:
+    """Handle for removing a registered hook."""
+
+    def remove(self) -> None: ...
+
+class PreHookArgs:
+    """Arguments passed to pre-hook callbacks."""
+
+    @property
+    def name(self) -> OpName: ...
+    @property
+    def async_op(self) -> bool: ...
+    @property
+    def root(self) -> int: ...
+    @property
+    def op_id(self) -> int: ...
+
+class PostHookArgs:
+    """Arguments passed to post-hook callbacks."""
+
+    @property
+    def name(self) -> OpName: ...
+    @property
+    def op_id(self) -> int: ...
 
 class CommOptions:
     abort_process_on_timeout_or_error: bool
@@ -356,6 +404,13 @@ class TorchComm:
     def new_window(self, tensor: Any | None = None) -> TorchCommWindow: ...
     @property
     def mem_allocator(self) -> Any: ...
+    def register_pre_hook(
+        self, callback: Callable[[PreHookArgs], None]
+    ) -> RemovableHandle: ...
+    def register_post_hook(
+        self, callback: Callable[[PostHookArgs], None]
+    ) -> RemovableHandle: ...
+    def register_abort_hook(self, callback: Callable[[], None]) -> RemovableHandle: ...
 
 def new_comm(
     backend: str,

--- a/comms/torchcomms/tests/unit/py/test_hooks.py
+++ b/comms/torchcomms/tests/unit/py/test_hooks.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+# pyre-unsafe
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import unittest
+
+import torch
+import torchcomms
+from torchcomms._comms import OpName, PostHookArgs, PreHookArgs, RemovableHandle
+
+
+class TestHooks(unittest.TestCase):
+    def _create_comm(self, name: str) -> torchcomms.TorchComm:
+        """Create a communicator using the dummy backend."""
+        return torchcomms.new_comm("dummy", torch.device("cpu"), name=name)
+
+    def test_register_pre_hook(self) -> None:
+        """Test that pre-hooks are called before collective operations."""
+        comm = self._create_comm("test_pre_hook")
+
+        pre_hook_calls: list[OpName] = []
+
+        def my_pre_hook(args: PreHookArgs) -> None:
+            pre_hook_calls.append(args.name)
+
+        handle = comm.register_pre_hook(my_pre_hook)
+        self.assertIsInstance(handle, RemovableHandle)
+
+        # Run a collective operation
+        tensor = torch.ones(10)
+        comm.all_reduce(tensor, torchcomms.ReduceOp.SUM, async_op=False)
+
+        # Verify hook was called
+        self.assertEqual(len(pre_hook_calls), 1)
+        self.assertEqual(pre_hook_calls[0], OpName.all_reduce)
+
+        comm.finalize()
+
+    def test_register_post_hook(self) -> None:
+        """Test that post-hooks are called after collective operations."""
+        comm = self._create_comm("test_post_hook")
+
+        post_hook_calls: list[OpName] = []
+
+        def my_post_hook(args: PostHookArgs) -> None:
+            post_hook_calls.append(args.name)
+
+        handle = comm.register_post_hook(my_post_hook)
+        self.assertIsInstance(handle, RemovableHandle)
+
+        # Run a collective operation
+        tensor = torch.ones(10)
+        comm.all_reduce(tensor, torchcomms.ReduceOp.SUM, async_op=False)
+
+        # Verify hook was called
+        self.assertEqual(len(post_hook_calls), 1)
+        self.assertEqual(post_hook_calls[0], OpName.all_reduce)
+
+        comm.finalize()
+
+    def test_hook_op_id_correlation(self) -> None:
+        """Test that pre-hook and post-hook op_ids match for the same operation."""
+        comm = self._create_comm("test_op_id")
+
+        pre_op_ids: list[int] = []
+        post_op_ids: list[int] = []
+
+        def my_pre_hook(args: PreHookArgs) -> None:
+            pre_op_ids.append(args.op_id)
+
+        def my_post_hook(args: PostHookArgs) -> None:
+            post_op_ids.append(args.op_id)
+
+        comm.register_pre_hook(my_pre_hook)
+        comm.register_post_hook(my_post_hook)
+
+        # Run multiple operations
+        tensor = torch.ones(10)
+        comm.all_reduce(tensor, torchcomms.ReduceOp.SUM, async_op=False)
+        comm.barrier(async_op=False)
+
+        # Verify op_ids match and increase
+        self.assertEqual(len(pre_op_ids), 2)
+        self.assertEqual(len(post_op_ids), 2)
+        self.assertEqual(pre_op_ids[0], post_op_ids[0])
+        self.assertEqual(pre_op_ids[1], post_op_ids[1])
+        self.assertLess(pre_op_ids[0], pre_op_ids[1])
+
+        comm.finalize()
+
+    def test_hook_removal(self) -> None:
+        """Test that hooks are not called after removal."""
+        comm = self._create_comm("test_removal")
+
+        call_count = 0
+
+        def my_pre_hook(args: PreHookArgs) -> None:
+            nonlocal call_count
+            call_count += 1
+
+        handle = comm.register_pre_hook(my_pre_hook)
+
+        # First operation - hook should be called
+        tensor = torch.ones(10)
+        comm.all_reduce(tensor, torchcomms.ReduceOp.SUM, async_op=False)
+        self.assertEqual(call_count, 1)
+
+        # Remove the hook
+        handle.remove()
+
+        # Second operation - hook should NOT be called
+        comm.all_reduce(tensor, torchcomms.ReduceOp.SUM, async_op=False)
+        self.assertEqual(call_count, 1)
+
+        comm.finalize()
+
+    def test_multiple_hooks(self) -> None:
+        """Test that multiple hooks are all called."""
+        comm = self._create_comm("test_multi")
+
+        hook1_calls = 0
+        hook2_calls = 0
+
+        def hook1(args: PreHookArgs) -> None:
+            nonlocal hook1_calls
+            hook1_calls += 1
+
+        def hook2(args: PreHookArgs) -> None:
+            nonlocal hook2_calls
+            hook2_calls += 1
+
+        comm.register_pre_hook(hook1)
+        comm.register_pre_hook(hook2)
+
+        # Run operation
+        tensor = torch.ones(10)
+        comm.all_reduce(tensor, torchcomms.ReduceOp.SUM, async_op=False)
+
+        # Both hooks should be called
+        self.assertEqual(hook1_calls, 1)
+        self.assertEqual(hook2_calls, 1)
+
+        comm.finalize()
+
+    def test_pre_hook_args_properties(self) -> None:
+        """Test that PreHookArgs has expected properties."""
+        comm = self._create_comm("test_args")
+
+        captured_args: list[PreHookArgs] = []
+
+        def my_pre_hook(args: PreHookArgs) -> None:
+            captured_args.append(args)
+
+        comm.register_pre_hook(my_pre_hook)
+
+        tensor = torch.ones(10)
+        comm.broadcast(tensor, root=0, async_op=False)
+
+        self.assertEqual(len(captured_args), 1)
+        args = captured_args[0]
+        self.assertEqual(args.name, OpName.broadcast)
+        self.assertEqual(args.root, 0)
+        self.assertIsInstance(args.op_id, int)
+        self.assertFalse(args.async_op)
+
+        comm.finalize()
+
+    def test_register_abort_hook(self) -> None:
+        """Test that abort hooks can be registered."""
+        comm = self._create_comm("test_abort")
+
+        abort_called = False
+
+        def my_abort_hook() -> None:
+            nonlocal abort_called
+            abort_called = True
+
+        handle = comm.register_abort_hook(my_abort_hook)
+        self.assertIsInstance(handle, RemovableHandle)
+
+        # We don't trigger abort in this test as it would terminate the process
+        # Just verify registration works
+        handle.remove()
+
+        comm.finalize()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/source/hooks.rst
+++ b/docs/source/hooks.rst
@@ -1,0 +1,145 @@
+Hooks
+=====
+
+torchcomms provides a hooks mechanism that allows you to intercept and monitor
+collective operations. Hooks are useful for debugging, profiling, and
+implementing custom monitoring solutions.
+
+Hook Types
+----------
+
+torchcomms supports three types of hooks:
+
+**Pre-hooks**
+    Called before each collective operation starts. Receives operation metadata
+    including operation name, tensors, and a unique operation ID.
+
+**Post-hooks**
+    Called after each collective operation completes. Receives the operation
+    name, work object, and the same operation ID for correlation.
+
+**Abort-hooks**
+    Called before the process aborts due to a collective timeout or failure.
+    Useful for capturing debug information before termination.
+
+Custom Hooks
+------------
+
+You can register custom hook callbacks directly on a communicator using the
+``register_pre_hook``, ``register_post_hook``, and ``register_abort_hook``
+methods. This allows you to implement custom monitoring, logging, or debugging
+logic.
+
+Registering Hooks
+^^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+
+    import torch
+    import torchcomms
+    from torchcomms._comms import OpName, PreHookArgs, PostHookArgs
+
+    # Create a communicator
+    device = torch.device("cuda:0")
+    comm = torchcomms.new_comm("ncclx", device)
+
+    # Define hook callbacks
+    def my_pre_hook(args: PreHookArgs) -> None:
+        print(f"Starting operation: {args.name} (op_id={args.op_id})")
+
+    def my_post_hook(args: PostHookArgs) -> None:
+        print(f"Completed operation: {args.name} (op_id={args.op_id})")
+
+    def my_abort_hook() -> None:
+        print("Process is about to abort, saving debug info...")
+
+    # Register hooks - each returns a RemovableHandle
+    pre_handle = comm.register_pre_hook(my_pre_hook)
+    post_handle = comm.register_post_hook(my_post_hook)
+    abort_handle = comm.register_abort_hook(my_abort_hook)
+
+    # Run collective operations - hooks will be called
+    tensor = torch.ones(10, device=device)
+    comm.all_reduce(tensor, torchcomms.ReduceOp.SUM, async_op=False)
+
+    # Unregister hooks when done
+    pre_handle.remove()
+    post_handle.remove()
+    abort_handle.remove()
+
+    comm.finalize()
+
+Thread Safety Note
+^^^^^^^^^^^^^^^^^^
+
+Hooks are not thread-safe and must not be modified (registered or removed)
+while a collective operation is in progress. Register hooks before starting
+collective operations and remove them after all operations have completed.
+
+FlightRecorderHook
+------------------
+
+The ``FlightRecorderHook`` is a built-in hook implementation that tracks all
+collective operations for debugging purposes. It records operation metadata,
+timing information, and completion status in a ring buffer.
+
+The output format matches the OSS FlightRecorder format from PyTorch's
+distributed module, so traces can be analyzed using the same ``fr_trace``
+analysis tools.
+
+Basic Usage
+^^^^^^^^^^^
+
+.. code-block:: python
+
+    import torch
+    import torchcomms
+    from torchcomms.hooks import FlightRecorderHook
+
+    # Create a communicator
+    device = torch.device("cuda:0")
+    comm = torchcomms.new_comm("ncclx", device)
+
+    # Create and register a flight recorder hook
+    recorder = FlightRecorderHook(max_entries=1024)
+    recorder.register_with_comm(comm)
+
+    # Run some collective operations
+    tensor = torch.ones(10, device=device)
+    comm.all_reduce(tensor, torchcomms.ReduceOp.SUM, async_op=False)
+    comm.barrier(async_op=False)
+
+    # Dump the recorded trace as JSON
+    json_trace = recorder.dump_json()
+    print(json_trace)
+
+    # Optionally dump to a file
+    recorder.dump_file(rank=comm.get_rank())
+
+    # Unregister when done
+    recorder.unregister()
+
+    # Finalize the communicator
+    comm.finalize()
+
+Environment Variables
+^^^^^^^^^^^^^^^^^^^^^
+
+The FlightRecorderHook uses the following environment variable:
+
+``TORCHCOMM_FR_DUMP_TEMP_FILE``
+    Controls the output location for ``dump_file()``. Files are written as
+    ``<prefix><rank>`` where the prefix is the value of this variable.
+
+API Reference
+-------------
+
+Hooks Module
+^^^^^^^^^^^^
+
+.. automodule:: torchcomms.hooks
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :special-members: __init__
+    :member-order: bysource

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -33,6 +33,13 @@ Browse the documentation and Examples
         Complete API documentation for all torchcomms classes,
         functions, and backends.
 
+    .. grid-item-card:: 🔗 Hooks
+        :link: hooks
+        :link-type: doc
+
+        Learn how to use hooks to monitor and debug collective
+        operations with FlightRecorderHook.
+
     .. grid-item-card:: 💻 Code Examples
         :link: https://github.com/meta-pytorch/torchcomms/tree/main/comms/torchcomms/examples
 
@@ -107,3 +114,4 @@ Create and manage process groups with ease:
 
    getting_started
    api
+   hooks


### PR DESCRIPTION
Summary:
Enable Python users to register pre/post/abort hooks for torchcomms operations, improving observability for debugging and profiling. Provide Sphinx docs with usage examples and FlightRecorder guidance to make hook adoption straightforward.

---
AI generated Summary & Test Plan from DEV71697077

Differential Revision: D93769004


