### PR TITLE
Fix doubled $(OBJDIR) path in ctran genctran.py causing re-cc CUDA remote compilation failures

### DIFF
--- a/comms/ctran/algos/genctran.py
+++ b/comms/ctran/algos/genctran.py
@@ -296,10 +296,9 @@ def genalgos(gensrc):
     gen_reduce_scatter_files(gensrc, srcs, rules)
     gen_alltoall_files(gensrc, srcs, rules)
 
-    rules.write("CTRAN_GEN_SRCS = ")
-    for src in srcs:
-        rules.write("$(OBJDIR)/gensrc/" + src + " ")
-    rules.write("\n")
+    rules.write(
+        "CTRAN_LIB_OBJS = $(patsubst %,$(OBJDIR)/genobj/%.o," + " ".join(srcs) + ")\n"
+    )
     rules.close()
 
 

--- a/comms/ncclx/v2_27/src/device/Makefile
+++ b/comms/ncclx/v2_27/src/device/Makefile
@@ -122,9 +122,8 @@ SRCS += ${BASE_DIR}/comms/ctran/algos/DevShmState.cu
 SRCS += all_reduce_sparse_block.cu
 
 -include $(OBJDIR)/gensrc/ctran_rules.mk
-SRCS += $(CTRAN_GEN_SRCS)
 
-LIB_OBJS = $(patsubst %, $(OBJDIR)/%.o, $(SRCS)) $(LIB_OBJS_GEN) $(LIB_OBJS_SYM_GEN)
+LIB_OBJS = $(patsubst %, $(OBJDIR)/%.o, $(SRCS)) $(LIB_OBJS_GEN) $(LIB_OBJS_SYM_GEN) $(CTRAN_LIB_OBJS)
 
 $(OBJDIR)/%.o: % $(OBJDIR)/%.d
 	$(call COMPILE,$@,$<)

--- a/comms/ncclx/v2_28/src/device/Makefile
+++ b/comms/ncclx/v2_28/src/device/Makefile
@@ -127,9 +127,8 @@ SRCS += ${BASE_DIR}/comms/ctran/algos/DevShmState.cu
 SRCS += all_reduce_sparse_block.cu
 
 -include $(OBJDIR)/gensrc/ctran_rules.mk
-SRCS += $(CTRAN_GEN_SRCS)
 
-LIB_OBJS = $(patsubst %, $(OBJDIR)/%.o, $(SRCS)) $(LIB_OBJS_GEN) $(LIB_OBJS_SYM_GEN)
+LIB_OBJS = $(patsubst %, $(OBJDIR)/%.o, $(SRCS)) $(LIB_OBJS_GEN) $(LIB_OBJS_SYM_GEN) $(CTRAN_LIB_OBJS)
 
 $(OBJDIR)/%.o: % $(OBJDIR)/%.d
 	$(call COMPILE,$@,$<)


### PR DESCRIPTION
Summary:
genctran.py emitted `CTRAN_GEN_SRCS = $(OBJDIR)/gensrc/file.cu` which was then
added to `SRCS` and processed by `$(patsubst %, $(OBJDIR)/%.o, $(SRCS))` in the
device Makefile. This prepended a second `$(OBJDIR)/`, producing paths like
`build/obj/device/build/obj/device/gensrc/file.cu.o`. These malformed paths caused
re-cc CUDA tool server's output file matching to fail, forcing all ctran kernel
compilations to fall back to local execution and making the build too slow.

Fix follows the pattern already used by generate.py: emit `CTRAN_LIB_OBJS` with
the `$(patsubst %,$(OBJDIR)/genobj/%.o,...)` expansion, and add it directly to
`LIB_OBJS` instead of going through `SRCS`.

Differential Revision: D93762687


