### PR TITLE
Fix init_state_ set before init completes

### DIFF
--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -98,7 +98,6 @@ void TorchCommNCCLX::init(
   } else if (init_state_ == InitializationState::FINALIZED) {
     throw std::runtime_error("TorchCommNCCLX already finalized");
   }
-  init_state_ = InitializationState::INITIALIZED;
 
   // Initialize default NCCL API implementation if not already set
   if (!nccl_api_) {
@@ -240,6 +239,9 @@ void TorchCommNCCLX::init(
 
   // Register comm with CachingAllocator
   attachMemoryHook();
+
+  // Mark initialization as complete only after all steps succeed
+  init_state_ = InitializationState::INITIALIZED;
 }
 
 void TorchCommNCCLX::finalize() {

--- a/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTest.cpp
@@ -267,7 +267,8 @@ TEST_F(TorchCommNCCLXTest, InitializationFailsWithInvalidDeviceId) {
         comm->init(invalid_device, "test_name", default_options_),
         std::runtime_error);
 
-    comm->finalize();
+    // After a failed init, finalize should throw since we're not initialized
+    EXPECT_THROW(comm->finalize(), std::runtime_error);
   }
 }
 


### PR DESCRIPTION
Summary:
D91615589 reverted D91542525 which fixed init_state_ being set to
INITIALIZED before init() actually completed. However, D91615589 did
not revert D91556119 which added an assertion in finalize() that
depends on init_state_ only being INITIALIZED after successful init.

This caused InitializationFailsWithInvalidDeviceId to fail: init()
sets init_state_ = INITIALIZED early, bootstrap throws on invalid
device, leaving nccl_comm_ null. finalize() then hits the assertion
because state says initialized+normal but nccl_comm_ is null.

Fix by moving init_state_ = INITIALIZED to the end of init() so it
is only set after all initialization steps succeed.

Differential Revision: D93773991


