### PR TITLE
AllReduce ctring AutoTune

### DIFF
--- a/comms/ctran/algos/AllReduce/AllReduceRingAutoTune.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceRingAutoTune.cc
@@ -1,0 +1,220 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/ctran/algos/AllReduce/AllReduceRingAutoTune.h"
+
+#include <algorithm>
+#include <bit>
+#include <cstddef>
+#include <iterator>
+
+#include <fmt/format.h>
+
+#include "comms/ctran/algos/CtranAlgoConsts.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/logger/LogUtils.h"
+
+namespace ctran::allreduce::ring {
+
+namespace {
+
+inline size_t getArchMaxBDP(GpuArch arch) {
+  switch (arch) {
+    case GpuArch::Hopper:
+      return kHopperMaxBDP;
+    default:
+      return kDefaultMaxBDP;
+  }
+}
+
+// Round n to the nearest power of 2. Ties (exact midpoint) round up.
+// Returns 1 for n <= 1.
+size_t roundToNearestPow2(size_t n) {
+  if (n <= 1) {
+    return 1;
+  }
+  if (std::has_single_bit(n)) {
+    return n; // already pow2
+  }
+  // floor pow2: clear all but the highest set bit
+  int bits = std::countl_zero(n);
+  size_t lo = size_t{1} << (sizeof(size_t) * 8 - 1 - bits);
+  size_t hi = lo << 1;
+  return (n - lo < hi - n) ? lo : hi;
+}
+
+PipelineParams
+getAutoTunedPipeline(size_t messageBytes, int nRanks, GpuArch arch) {
+  size_t maxBDP = getArchMaxBDP(arch);
+  if (NCCL_CTRAN_ALLREDUCE_RING_AUTO_TUNE_MAX_BDP > 0) {
+    maxBDP = static_cast<size_t>(NCCL_CTRAN_ALLREDUCE_RING_AUTO_TUNE_MAX_BDP);
+  }
+
+  static constexpr size_t kMinChunkSize = 1;
+  static constexpr size_t kMaxChunkSize = 16ULL * 1024 * 1024;
+
+  // clang-format off
+  static constexpr size_t kMax = ~size_t{0};
+  struct PipelineTier { size_t upTo; size_t depth; };
+  static constexpr PipelineTier kDefaultTiers[] = {
+    { 32ULL * 1024,          1},
+    {  1ULL * 1024 * 1024,   2},
+    { 16ULL * 1024 * 1024,   4},
+    { 32ULL * 1024 * 1024,   2},
+    {kMax,                   1},
+  };
+  static constexpr PipelineTier kHopperTiers[] = {
+    { 32ULL * 1024,          1},
+    {  1ULL * 1024 * 1024,   2},
+    {  4ULL * 1024 * 1024,   4},
+    {  8ULL * 1024 * 1024,   2},
+    {kMax,                   1},
+  };
+  // clang-format on
+
+  const auto* tiers = kDefaultTiers;
+  auto nTiers = std::size(kDefaultTiers);
+  if (arch == GpuArch::Hopper) {
+    tiers = kHopperTiers;
+    nTiers = std::size(kHopperTiers);
+  }
+
+  const size_t perRankMessageBytes = roundToNearestPow2(messageBytes) / nRanks;
+  size_t pipelineDepth = 1;
+  for (size_t i = 0; i < nTiers; ++i) {
+    if (perRankMessageBytes < tiers[i].upTo) {
+      pipelineDepth = tiers[i].depth;
+      break;
+    }
+  }
+
+  // within partition
+  size_t partitionMessageBytes = roundToNearestPow2(messageBytes);
+  // partitionMessageBytes being LEQ maxBDP Is a safety guard
+  while (partitionMessageBytes > maxBDP) {
+    partitionMessageBytes /= 2;
+  }
+  size_t numChunks = pipelineDepth * static_cast<size_t>(nRanks);
+  size_t chunkSize = partitionMessageBytes / numChunks;
+  chunkSize = std::clamp(chunkSize, kMinChunkSize, kMaxChunkSize);
+  numChunks =
+      std::max((partitionMessageBytes + chunkSize - 1) / chunkSize, 1UL);
+
+  return {chunkSize, numChunks};
+}
+
+BlockParams getAutoTunedBlockParams(
+    size_t chunkSize,
+    int maxOccupancyBlocks,
+    int defaultThreads,
+    GpuArch arch) {
+  // Lookup table: {exclusive chunkSize upper bound, numBlocks, blockSize}.
+  // blockSize == 0 means use defaultThreads (Default arch pass-through).
+  struct Tier {
+    size_t upTo;
+    int numBlocks;
+    int blockSize;
+  };
+
+  // clang-format off
+  static constexpr size_t kMax = ~size_t{0};
+  static constexpr Tier kDefaultTiers[] = {
+    { 8ULL * 1024,   1, 0},
+    {32ULL * 1024,   2, 0},
+    {64ULL * 1024,   4, 0},
+    {kMax,           8, 0},
+  };
+  static constexpr Tier kHopperTiers[] = {
+    { 16ULL * 1024,  1, 384},
+    {128ULL * 1024,  1, 512},
+    {512ULL * 1024,  2, 512},
+    {kMax,           4, 512},
+  };
+  // clang-format on
+
+  const auto* tiers = kDefaultTiers;
+  auto nTiers = std::size(kDefaultTiers);
+  if (arch == GpuArch::Hopper) {
+    tiers = kHopperTiers;
+    nTiers = std::size(kHopperTiers);
+  }
+
+  for (size_t i = 0; i < nTiers; ++i) {
+    if (chunkSize < tiers[i].upTo) {
+      int blockSize = tiers[i].blockSize ? tiers[i].blockSize : defaultThreads;
+      return {
+          std::min(tiers[i].numBlocks, maxOccupancyBlocks),
+          std::min(blockSize, defaultThreads)};
+    }
+  }
+  // Unreachable: kMax sentinel guarantees a match
+  return {};
+}
+
+} // namespace
+
+AutoTuneParams getAutoTunedParams(
+    size_t messageBytes,
+    int nRanks,
+    int maxOccupancyBlocks,
+    int defaultThreads,
+    GpuArch arch) {
+  auto p = getAutoTunedPipeline(messageBytes, nRanks, arch);
+  if (NCCL_CTRAN_ALLREDUCE_RING_TMPBUF_NUM_CHUNKS > 0) {
+    p.numChunks = NCCL_CTRAN_ALLREDUCE_RING_TMPBUF_NUM_CHUNKS;
+  }
+  if (NCCL_CTRAN_ALLREDUCE_RING_TMPBUF_CHUNK_SIZE > 0) {
+    p.chunkSize = NCCL_CTRAN_ALLREDUCE_RING_TMPBUF_CHUNK_SIZE;
+  }
+
+  auto bp = getAutoTunedBlockParams(
+      p.chunkSize, maxOccupancyBlocks, defaultThreads, arch);
+  if (NCCL_CTRAN_ALLREDUCE_RING_MAX_NUM_THREAD_BLOCKS > 0) {
+    bp.numBlocks = NCCL_CTRAN_ALLREDUCE_RING_MAX_NUM_THREAD_BLOCKS;
+  }
+  if (NCCL_CTRAN_ALLREDUCE_RING_THREAD_BLOCK_SIZE > 0) {
+    bp.blockSize = NCCL_CTRAN_ALLREDUCE_RING_THREAD_BLOCK_SIZE;
+  }
+
+  return {p, bp};
+}
+
+void logAutoTuneDecisions(
+    int nRanks,
+    int maxOccupancyBlocks,
+    int defaultThreads,
+    GpuArch arch) {
+  static_assert(
+      sizeof(size_t) >= 8, "logAutoTuneDecisions assumes 64-bit size_t");
+  static constexpr int kPow2MaxExponent = 25; // 32GB
+  static constexpr size_t kKB = 1024ULL;
+  for (int i = 0; i <= kPow2MaxExponent; i++) {
+    const size_t sz = (1ULL << i) * kKB;
+    const auto at = getAutoTunedParams(
+        sz, nRanks, maxOccupancyBlocks, defaultThreads, arch);
+    CLOGF(
+        DBG,
+        "AutoTune ranks {}, msg {}B: blocks {}, chunks {} x {}B",
+        nRanks,
+        sz,
+        at.block.numBlocks,
+        at.pipeline.numChunks,
+        at.pipeline.chunkSize);
+
+    if (i != kPow2MaxExponent) {
+      const size_t szNext = (1ULL << (i + 1)) * kKB;
+      const size_t mid = (sz + szNext) / 2;
+      const auto mat = getAutoTunedParams(
+          mid, nRanks, maxOccupancyBlocks, defaultThreads, arch);
+      CLOGF(
+          DBG,
+          "AutoTune ranks {}, msg {}B: blocks {}, chunks {} x {}B",
+          nRanks,
+          szNext,
+          mat.block.numBlocks,
+          mat.pipeline.numChunks,
+          mat.pipeline.chunkSize);
+    }
+  }
+}
+
+} // namespace ctran::allreduce::ring

--- a/comms/ctran/algos/AllReduce/AllReduceRingAutoTune.h
+++ b/comms/ctran/algos/AllReduce/AllReduceRingAutoTune.h
@@ -1,0 +1,54 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cstddef>
+
+namespace ctran::allreduce::ring {
+
+enum class GpuArch {
+  Default, // GB200 / Blackwell (Phase 2 tuning)
+  Hopper, // H100 / SM 9.0
+};
+
+struct PipelineParams {
+  size_t chunkSize;
+  size_t numChunks;
+};
+
+struct BlockParams {
+  int numBlocks;
+  int blockSize;
+};
+
+struct AutoTuneParams {
+  PipelineParams pipeline;
+  BlockParams block;
+};
+
+// Combined auto-tune: pipeline chunking + block/thread selection.
+//
+// Pipeline stage: auto-tunes chunkSize and numChunks based on message size,
+// nRanks, and maxBDP. Values satisfy chunkSize * numChunks <= maxBDP.
+//
+// Block stage: auto-tunes numBlocks and blockSize based on chunkSize and arch.
+//
+// CVAR overrides (applied after auto-tune, highest priority):
+//   TMPBUF_CHUNK_SIZE, TMPBUF_NUM_CHUNKS override pipeline params.
+//   MAX_NUM_THREAD_BLOCKS, THREAD_BLOCK_SIZE override block params.
+//   Chunk size override feeds into block params computation.
+AutoTuneParams getAutoTunedParams(
+    size_t messageBytes,
+    int nRanks,
+    int maxOccupancyBlocks,
+    int defaultThreads,
+    GpuArch arch = GpuArch::Default);
+
+// Log of auto-tune decisions for pow2 message sizes from 1KB to 32GB.
+void logAutoTuneDecisions(
+    int nRanks,
+    int maxOccupancyBlocks,
+    int defaultThreads,
+    GpuArch arch = GpuArch::Default);
+
+} // namespace ctran::allreduce::ring

--- a/comms/ctran/algos/AllReduce/tests/AllReduceRingAutoTuneTest.cc
+++ b/comms/ctran/algos/AllReduce/tests/AllReduceRingAutoTuneTest.cc
@@ -1,0 +1,1061 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+
+#include "comms/ctran/algos/AllReduce/AllReduceRingAutoTune.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+
+using ctran::allreduce::ring::getAutoTunedParams;
+using ctran::allreduce::ring::GpuArch;
+
+constexpr size_t KB = 1024ULL;
+constexpr size_t MB = 1024ULL * 1024;
+constexpr size_t GB = 1024ULL * 1024 * 1024;
+
+// RAII guard for the maxBDP CVAR override. Restores to default on destruction.
+class MaxBDPOverride {
+ public:
+  explicit MaxBDPOverride(size_t maxBDP) {
+    NCCL_CTRAN_ALLREDUCE_RING_AUTO_TUNE_MAX_BDP = static_cast<int>(maxBDP);
+  }
+  ~MaxBDPOverride() {
+    NCCL_CTRAN_ALLREDUCE_RING_AUTO_TUNE_MAX_BDP =
+        NCCL_CTRAN_ALLREDUCE_RING_AUTO_TUNE_MAX_BDP_DEFAULTCVARVALUE;
+  }
+};
+
+// RAII guard for TMPBUF_CHUNK_SIZE CVAR.
+class ChunkSizeOverride {
+ public:
+  explicit ChunkSizeOverride(int v) {
+    NCCL_CTRAN_ALLREDUCE_RING_TMPBUF_CHUNK_SIZE = v;
+  }
+  ~ChunkSizeOverride() {
+    NCCL_CTRAN_ALLREDUCE_RING_TMPBUF_CHUNK_SIZE =
+        NCCL_CTRAN_ALLREDUCE_RING_TMPBUF_CHUNK_SIZE_DEFAULTCVARVALUE;
+  }
+};
+
+// RAII guard for TMPBUF_NUM_CHUNKS CVAR.
+class NumChunksOverride {
+ public:
+  explicit NumChunksOverride(int v) {
+    NCCL_CTRAN_ALLREDUCE_RING_TMPBUF_NUM_CHUNKS = v;
+  }
+  ~NumChunksOverride() {
+    NCCL_CTRAN_ALLREDUCE_RING_TMPBUF_NUM_CHUNKS =
+        NCCL_CTRAN_ALLREDUCE_RING_TMPBUF_NUM_CHUNKS_DEFAULTCVARVALUE;
+  }
+};
+
+// RAII guard for MAX_NUM_THREAD_BLOCKS CVAR.
+class NumBlocksOverride {
+ public:
+  explicit NumBlocksOverride(int v) {
+    NCCL_CTRAN_ALLREDUCE_RING_MAX_NUM_THREAD_BLOCKS = v;
+  }
+  ~NumBlocksOverride() {
+    NCCL_CTRAN_ALLREDUCE_RING_MAX_NUM_THREAD_BLOCKS =
+        NCCL_CTRAN_ALLREDUCE_RING_MAX_NUM_THREAD_BLOCKS_DEFAULTCVARVALUE;
+  }
+};
+
+// RAII guard for THREAD_BLOCK_SIZE CVAR.
+class BlockSizeOverride {
+ public:
+  explicit BlockSizeOverride(int v) {
+    NCCL_CTRAN_ALLREDUCE_RING_THREAD_BLOCK_SIZE = v;
+  }
+  ~BlockSizeOverride() {
+    NCCL_CTRAN_ALLREDUCE_RING_THREAD_BLOCK_SIZE =
+        NCCL_CTRAN_ALLREDUCE_RING_THREAD_BLOCK_SIZE_DEFAULTCVARVALUE;
+  }
+};
+
+// ============================================================================
+// getAutoTunedParams golden tables: different arch / BDP & nranks.
+// ============================================================================
+
+struct AutoTuneExpected {
+  size_t msgBytes;
+  int blocks;
+  int threads;
+  size_t chunkSize;
+  size_t numChunks;
+};
+
+// ============================================================================
+// getAutoTunedParams golden tables: Default arch, 8 ranks, pow2 sizes 1K-64G
+// ============================================================================
+
+template <size_t N>
+void verifyAutoTune(
+    const AutoTuneExpected (&cases)[N],
+    int nRanks,
+    int maxOcc,
+    int defThreads,
+    GpuArch arch = GpuArch::Default) {
+  for (const auto& c : cases) {
+    auto at = getAutoTunedParams(c.msgBytes, nRanks, maxOcc, defThreads, arch);
+    EXPECT_EQ(at.block.numBlocks, c.blocks)
+        << "blocks mismatch at msg=" << c.msgBytes;
+    EXPECT_EQ(at.block.blockSize, c.threads)
+        << "threads mismatch at msg=" << c.msgBytes;
+    EXPECT_EQ(at.pipeline.chunkSize, c.chunkSize)
+        << "chunkSize mismatch at msg=" << c.msgBytes;
+    EXPECT_EQ(at.pipeline.numChunks, c.numChunks)
+        << "numChunks mismatch at msg=" << c.msgBytes;
+  }
+}
+
+TEST(AutoTuneCombinedDefault, MaxBDP16M_8Ranks) {
+  MaxBDPOverride o(16 * MB);
+  const int nRanks = 8;
+  const int maxOcc = 64;
+  const int defThreads = 512;
+
+  // clang-format off
+  const AutoTuneExpected cases[] = {
+      {      1 * KB, 1, 512,         128, 8},
+      {      2 * KB, 1, 512,         256, 8},
+      {      4 * KB, 1, 512,         512, 8},
+      {      8 * KB, 1, 512,      1 * KB, 8},
+      {     16 * KB, 1, 512,      2 * KB, 8},
+      {     32 * KB, 1, 512,      4 * KB, 8},
+      {     64 * KB, 2, 512,      8 * KB, 8},
+      {    128 * KB, 2, 512,     16 * KB, 8},
+      {    256 * KB, 2, 512,     16 * KB, 16},
+      {    512 * KB, 4, 512,     32 * KB, 16},
+      {      1 * MB, 8, 512,     64 * KB, 16},
+      {      2 * MB, 8, 512,    128 * KB, 16},
+      {      4 * MB, 8, 512,    256 * KB, 16},
+      {      8 * MB, 8, 512,    256 * KB, 32},
+      {     16 * MB, 8, 512,    512 * KB, 32},
+      {     32 * MB, 8, 512,    512 * KB, 32},
+      {     64 * MB, 8, 512,    512 * KB, 32},
+      {    128 * MB, 8, 512,      1 * MB, 16},
+      {    256 * MB, 8, 512,      2 * MB, 8},
+      {    512 * MB, 8, 512,      2 * MB, 8},
+      {      1 * GB, 8, 512,      2 * MB, 8},
+      {      2 * GB, 8, 512,      2 * MB, 8},
+      {      4 * GB, 8, 512,      2 * MB, 8},
+      {      8 * GB, 8, 512,      2 * MB, 8},
+      {     16 * GB, 8, 512,      2 * MB, 8},
+      {     32 * GB, 8, 512,      2 * MB, 8},
+      {     64 * GB, 8, 512,      2 * MB, 8},
+  };
+  // clang-format on
+
+  verifyAutoTune(cases, nRanks, maxOcc, defThreads);
+}
+
+TEST(AutoTuneCombinedDefault, MaxBDP32M_8Ranks) {
+  MaxBDPOverride o(32 * MB);
+  const int nRanks = 8;
+  const int maxOcc = 64;
+  const int defThreads = 512;
+
+  // clang-format off
+  const AutoTuneExpected cases[] = {
+      {      1 * KB, 1, 512,         128, 8},
+      {      2 * KB, 1, 512,         256, 8},
+      {      4 * KB, 1, 512,         512, 8},
+      {      8 * KB, 1, 512,      1 * KB, 8},
+      {     16 * KB, 1, 512,      2 * KB, 8},
+      {     32 * KB, 1, 512,      4 * KB, 8},
+      {     64 * KB, 2, 512,      8 * KB, 8},
+      {    128 * KB, 2, 512,     16 * KB, 8},
+      {    256 * KB, 2, 512,     16 * KB, 16},
+      {    512 * KB, 4, 512,     32 * KB, 16},
+      {      1 * MB, 8, 512,     64 * KB, 16},
+      {      2 * MB, 8, 512,    128 * KB, 16},
+      {      4 * MB, 8, 512,    256 * KB, 16},
+      {      8 * MB, 8, 512,    256 * KB, 32},
+      {     16 * MB, 8, 512,    512 * KB, 32},
+      {     32 * MB, 8, 512,      1 * MB, 32},
+      {     64 * MB, 8, 512,      1 * MB, 32},
+      {    128 * MB, 8, 512,      2 * MB, 16},
+      {    256 * MB, 8, 512,      4 * MB, 8},
+      {    512 * MB, 8, 512,      4 * MB, 8},
+      {      1 * GB, 8, 512,      4 * MB, 8},
+      {      2 * GB, 8, 512,      4 * MB, 8},
+      {      4 * GB, 8, 512,      4 * MB, 8},
+      {      8 * GB, 8, 512,      4 * MB, 8},
+      {     16 * GB, 8, 512,      4 * MB, 8},
+      {     32 * GB, 8, 512,      4 * MB, 8},
+      {     64 * GB, 8, 512,      4 * MB, 8},
+  };
+  // clang-format on
+
+  verifyAutoTune(cases, nRanks, maxOcc, defThreads);
+}
+
+TEST(AutoTuneCombinedDefault, MaxBDP64M_8Ranks) {
+  MaxBDPOverride o(64 * MB);
+  const int nRanks = 8;
+  const int maxOcc = 64;
+  const int defThreads = 512;
+
+  // clang-format off
+  const AutoTuneExpected cases[] = {
+      {      1 * KB, 1, 512,         128, 8},
+      {      2 * KB, 1, 512,         256, 8},
+      {      4 * KB, 1, 512,         512, 8},
+      {      8 * KB, 1, 512,      1 * KB, 8},
+      {     16 * KB, 1, 512,      2 * KB, 8},
+      {     32 * KB, 1, 512,      4 * KB, 8},
+      {     64 * KB, 2, 512,      8 * KB, 8},
+      {    128 * KB, 2, 512,     16 * KB, 8},
+      {    256 * KB, 2, 512,     16 * KB, 16},
+      {    512 * KB, 4, 512,     32 * KB, 16},
+      {      1 * MB, 8, 512,     64 * KB, 16},
+      {      2 * MB, 8, 512,    128 * KB, 16},
+      {      4 * MB, 8, 512,    256 * KB, 16},
+      {      8 * MB, 8, 512,    256 * KB, 32},
+      {     16 * MB, 8, 512,    512 * KB, 32},
+      {     32 * MB, 8, 512,      1 * MB, 32},
+      {     64 * MB, 8, 512,      2 * MB, 32},
+      {    128 * MB, 8, 512,      4 * MB, 16},
+      {    256 * MB, 8, 512,      8 * MB, 8},
+      {    512 * MB, 8, 512,      8 * MB, 8},
+      {      1 * GB, 8, 512,      8 * MB, 8},
+      {      2 * GB, 8, 512,      8 * MB, 8},
+      {      4 * GB, 8, 512,      8 * MB, 8},
+      {      8 * GB, 8, 512,      8 * MB, 8},
+      {     16 * GB, 8, 512,      8 * MB, 8},
+      {     32 * GB, 8, 512,      8 * MB, 8},
+      {     64 * GB, 8, 512,      8 * MB, 8},
+  };
+  // clang-format on
+
+  verifyAutoTune(cases, nRanks, maxOcc, defThreads);
+}
+
+TEST(AutoTuneCombinedDefault, MaxBDP128M_8Ranks) {
+  MaxBDPOverride o(128 * MB);
+  const int nRanks = 8;
+  const int maxOcc = 64;
+  const int defThreads = 512;
+
+  // clang-format off
+  const AutoTuneExpected cases[] = {
+      {      1 * KB, 1, 512,         128, 8},
+      {      2 * KB, 1, 512,         256, 8},
+      {      4 * KB, 1, 512,         512, 8},
+      {      8 * KB, 1, 512,      1 * KB, 8},
+      {     16 * KB, 1, 512,      2 * KB, 8},
+      {     32 * KB, 1, 512,      4 * KB, 8},
+      {     64 * KB, 2, 512,      8 * KB, 8},
+      {    128 * KB, 2, 512,     16 * KB, 8},
+      {    256 * KB, 2, 512,     16 * KB, 16},
+      {    512 * KB, 4, 512,     32 * KB, 16},
+      {      1 * MB, 8, 512,     64 * KB, 16},
+      {      2 * MB, 8, 512,    128 * KB, 16},
+      {      4 * MB, 8, 512,    256 * KB, 16},
+      {      8 * MB, 8, 512,    256 * KB, 32},
+      {     16 * MB, 8, 512,    512 * KB, 32},
+      {     32 * MB, 8, 512,      1 * MB, 32},
+      {     64 * MB, 8, 512,      2 * MB, 32},
+      {    128 * MB, 8, 512,      8 * MB, 16},
+      {    256 * MB, 8, 512,     16 * MB, 8},
+      {    512 * MB, 8, 512,     16 * MB, 8},
+      {      1 * GB, 8, 512,     16 * MB, 8},
+      {      2 * GB, 8, 512,     16 * MB, 8},
+      {      4 * GB, 8, 512,     16 * MB, 8},
+      {      8 * GB, 8, 512,     16 * MB, 8},
+      {     16 * GB, 8, 512,     16 * MB, 8},
+      {     32 * GB, 8, 512,     16 * MB, 8},
+      {     64 * GB, 8, 512,     16 * MB, 8},
+  };
+  // clang-format on
+
+  verifyAutoTune(cases, nRanks, maxOcc, defThreads);
+}
+
+// ============================================================================
+// getAutoTunedParams golden tables: Hopper (H100) arch, 8 ranks, pow2 1K-64G
+// ============================================================================
+
+TEST(AutoTuneCombinedHopper, MaxBDP16M_8Ranks) {
+  MaxBDPOverride o(16 * MB);
+  const int nRanks = 8;
+  const int maxOcc = 64;
+  const int defThreads = 512;
+  const auto arch = GpuArch::Hopper;
+
+  // clang-format off
+  const AutoTuneExpected cases[] = {
+      {      1 * KB, 1, 384,         128, 8},
+      {      2 * KB, 1, 384,         256, 8},
+      {      4 * KB, 1, 384,         512, 8},
+      {      8 * KB, 1, 384,      1 * KB, 8},
+      {     16 * KB, 1, 384,      2 * KB, 8},
+      {     32 * KB, 1, 384,      4 * KB, 8},
+      {     64 * KB, 1, 384,      8 * KB, 8},
+      {    128 * KB, 1, 512,     16 * KB, 8},
+      {    256 * KB, 1, 512,     16 * KB, 16},
+      {    512 * KB, 1, 512,     32 * KB, 16},
+      {      1 * MB, 1, 512,     64 * KB, 16},
+      {      2 * MB, 2, 512,    128 * KB, 16},
+      {      4 * MB, 2, 512,    256 * KB, 16},
+      {      8 * MB, 2, 512,    256 * KB, 32},
+      {     16 * MB, 4, 512,    512 * KB, 32},
+      {     32 * MB, 4, 512,      1 * MB, 16},
+      {     64 * MB, 4, 512,      2 * MB, 8},
+      {    128 * MB, 4, 512,      2 * MB, 8},
+      {    256 * MB, 4, 512,      2 * MB, 8},
+      {    512 * MB, 4, 512,      2 * MB, 8},
+      {      1 * GB, 4, 512,      2 * MB, 8},
+      {      2 * GB, 4, 512,      2 * MB, 8},
+      {      4 * GB, 4, 512,      2 * MB, 8},
+      {      8 * GB, 4, 512,      2 * MB, 8},
+      {     16 * GB, 4, 512,      2 * MB, 8},
+      {     32 * GB, 4, 512,      2 * MB, 8},
+      {     64 * GB, 4, 512,      2 * MB, 8},
+  };
+  // clang-format on
+
+  verifyAutoTune(cases, nRanks, maxOcc, defThreads, arch);
+}
+
+TEST(AutoTuneCombinedHopper, MaxBDP32M_8Ranks) {
+  MaxBDPOverride o(32 * MB);
+  const int nRanks = 8;
+  const int maxOcc = 64;
+  const int defThreads = 512;
+  const auto arch = GpuArch::Hopper;
+
+  // clang-format off
+  const AutoTuneExpected cases[] = {
+      {      1 * KB, 1, 384,         128, 8},
+      {      2 * KB, 1, 384,         256, 8},
+      {      4 * KB, 1, 384,         512, 8},
+      {      8 * KB, 1, 384,      1 * KB, 8},
+      {     16 * KB, 1, 384,      2 * KB, 8},
+      {     32 * KB, 1, 384,      4 * KB, 8},
+      {     64 * KB, 1, 384,      8 * KB, 8},
+      {    128 * KB, 1, 512,     16 * KB, 8},
+      {    256 * KB, 1, 512,     16 * KB, 16},
+      {    512 * KB, 1, 512,     32 * KB, 16},
+      {      1 * MB, 1, 512,     64 * KB, 16},
+      {      2 * MB, 2, 512,    128 * KB, 16},
+      {      4 * MB, 2, 512,    256 * KB, 16},
+      {      8 * MB, 2, 512,    256 * KB, 32},
+      {     16 * MB, 4, 512,    512 * KB, 32},
+      {     32 * MB, 4, 512,      2 * MB, 16},
+      {     64 * MB, 4, 512,      4 * MB, 8},
+      {    128 * MB, 4, 512,      4 * MB, 8},
+      {    256 * MB, 4, 512,      4 * MB, 8},
+      {    512 * MB, 4, 512,      4 * MB, 8},
+      {      1 * GB, 4, 512,      4 * MB, 8},
+      {      2 * GB, 4, 512,      4 * MB, 8},
+      {      4 * GB, 4, 512,      4 * MB, 8},
+      {      8 * GB, 4, 512,      4 * MB, 8},
+      {     16 * GB, 4, 512,      4 * MB, 8},
+      {     32 * GB, 4, 512,      4 * MB, 8},
+      {     64 * GB, 4, 512,      4 * MB, 8},
+  };
+  // clang-format on
+
+  verifyAutoTune(cases, nRanks, maxOcc, defThreads, arch);
+}
+
+TEST(AutoTuneCombinedHopper, MaxBDP64M_8Ranks) {
+  MaxBDPOverride o(64 * MB);
+  const int nRanks = 8;
+  const int maxOcc = 64;
+  const int defThreads = 512;
+  const auto arch = GpuArch::Hopper;
+
+  // clang-format off
+  const AutoTuneExpected cases[] = {
+      {      1 * KB, 1, 384,         128, 8},
+      {      2 * KB, 1, 384,         256, 8},
+      {      4 * KB, 1, 384,         512, 8},
+      {      8 * KB, 1, 384,      1 * KB, 8},
+      {     16 * KB, 1, 384,      2 * KB, 8},
+      {     32 * KB, 1, 384,      4 * KB, 8},
+      {     64 * KB, 1, 384,      8 * KB, 8},
+      {    128 * KB, 1, 512,     16 * KB, 8},
+      {    256 * KB, 1, 512,     16 * KB, 16},
+      {    512 * KB, 1, 512,     32 * KB, 16},
+      {      1 * MB, 1, 512,     64 * KB, 16},
+      {      2 * MB, 2, 512,    128 * KB, 16},
+      {      4 * MB, 2, 512,    256 * KB, 16},
+      {      8 * MB, 2, 512,    256 * KB, 32},
+      {     16 * MB, 4, 512,    512 * KB, 32},
+      {     32 * MB, 4, 512,      2 * MB, 16},
+      {     64 * MB, 4, 512,      8 * MB, 8},
+      {    128 * MB, 4, 512,      8 * MB, 8},
+      {    256 * MB, 4, 512,      8 * MB, 8},
+      {    512 * MB, 4, 512,      8 * MB, 8},
+      {      1 * GB, 4, 512,      8 * MB, 8},
+      {      2 * GB, 4, 512,      8 * MB, 8},
+      {      4 * GB, 4, 512,      8 * MB, 8},
+      {      8 * GB, 4, 512,      8 * MB, 8},
+      {     16 * GB, 4, 512,      8 * MB, 8},
+      {     32 * GB, 4, 512,      8 * MB, 8},
+      {     64 * GB, 4, 512,      8 * MB, 8},
+  };
+  // clang-format on
+
+  verifyAutoTune(cases, nRanks, maxOcc, defThreads, arch);
+}
+
+TEST(AutoTuneCombinedHopper, MaxBDP128M_8Ranks) {
+  MaxBDPOverride o(128 * MB);
+  const int nRanks = 8;
+  const int maxOcc = 64;
+  const int defThreads = 512;
+  const auto arch = GpuArch::Hopper;
+
+  // clang-format off
+  const AutoTuneExpected cases[] = {
+      {      1 * KB, 1, 384,         128, 8},
+      {      2 * KB, 1, 384,         256, 8},
+      {      4 * KB, 1, 384,         512, 8},
+      {      8 * KB, 1, 384,      1 * KB, 8},
+      {     16 * KB, 1, 384,      2 * KB, 8},
+      {     32 * KB, 1, 384,      4 * KB, 8},
+      {     64 * KB, 1, 384,      8 * KB, 8},
+      {    128 * KB, 1, 512,     16 * KB, 8},
+      {    256 * KB, 1, 512,     16 * KB, 16},
+      {    512 * KB, 1, 512,     32 * KB, 16},
+      {      1 * MB, 1, 512,     64 * KB, 16},
+      {      2 * MB, 2, 512,    128 * KB, 16},
+      {      4 * MB, 2, 512,    256 * KB, 16},
+      {      8 * MB, 2, 512,    256 * KB, 32},
+      {     16 * MB, 4, 512,    512 * KB, 32},
+      {     32 * MB, 4, 512,      2 * MB, 16},
+      {     64 * MB, 4, 512,      8 * MB, 8},
+      {    128 * MB, 4, 512,     16 * MB, 8},
+      {    256 * MB, 4, 512,     16 * MB, 8},
+      {    512 * MB, 4, 512,     16 * MB, 8},
+      {      1 * GB, 4, 512,     16 * MB, 8},
+      {      2 * GB, 4, 512,     16 * MB, 8},
+      {      4 * GB, 4, 512,     16 * MB, 8},
+      {      8 * GB, 4, 512,     16 * MB, 8},
+      {     16 * GB, 4, 512,     16 * MB, 8},
+      {     32 * GB, 4, 512,     16 * MB, 8},
+      {     64 * GB, 4, 512,     16 * MB, 8},
+  };
+  // clang-format on
+
+  verifyAutoTune(cases, nRanks, maxOcc, defThreads, arch);
+}
+
+// ============================================================================
+// Rank-sweep tables: Default arch, arch-default BDP, ranks {8,16,32,64}
+// ============================================================================
+
+TEST(AutoTuneDefaultRankSweep, DefaultBDP_8Ranks) {
+  const int nRanks = 8;
+  const int maxOcc = 64;
+  const int defThreads = 512;
+
+  // clang-format off
+  const AutoTuneExpected cases[] = {
+      {      1 * KB, 1, 512,         128, 8},
+      {      2 * KB, 1, 512,         256, 8},
+      {      4 * KB, 1, 512,         512, 8},
+      {      8 * KB, 1, 512,      1 * KB, 8},
+      {     16 * KB, 1, 512,      2 * KB, 8},
+      {     32 * KB, 1, 512,      4 * KB, 8},
+      {     64 * KB, 2, 512,      8 * KB, 8},
+      {    128 * KB, 2, 512,     16 * KB, 8},
+      {    256 * KB, 2, 512,     16 * KB, 16},
+      {    512 * KB, 4, 512,     32 * KB, 16},
+      {      1 * MB, 8, 512,     64 * KB, 16},
+      {      2 * MB, 8, 512,    128 * KB, 16},
+      {      4 * MB, 8, 512,    256 * KB, 16},
+      {      8 * MB, 8, 512,    256 * KB, 32},
+      {     16 * MB, 8, 512,    512 * KB, 32},
+      {     32 * MB, 8, 512,      1 * MB, 32},
+      {     64 * MB, 8, 512,      2 * MB, 32},
+      {    128 * MB, 8, 512,      8 * MB, 16},
+      {    256 * MB, 8, 512,     16 * MB, 8},
+      {    512 * MB, 8, 512,     16 * MB, 8},
+      {      1 * GB, 8, 512,     16 * MB, 8},
+      {      2 * GB, 8, 512,     16 * MB, 8},
+      {      4 * GB, 8, 512,     16 * MB, 8},
+      {      8 * GB, 8, 512,     16 * MB, 8},
+      {     16 * GB, 8, 512,     16 * MB, 8},
+      {     32 * GB, 8, 512,     16 * MB, 8},
+      {     64 * GB, 8, 512,     16 * MB, 8},
+  };
+  // clang-format on
+
+  verifyAutoTune(cases, nRanks, maxOcc, defThreads);
+}
+
+TEST(AutoTuneDefaultRankSweep, DefaultBDP_16Ranks) {
+  const int nRanks = 16;
+  const int maxOcc = 64;
+  const int defThreads = 512;
+
+  // clang-format off
+  const AutoTuneExpected cases[] = {
+      {      1 * KB, 1, 512,          64, 16},
+      {      2 * KB, 1, 512,         128, 16},
+      {      4 * KB, 1, 512,         256, 16},
+      {      8 * KB, 1, 512,         512, 16},
+      {     16 * KB, 1, 512,      1 * KB, 16},
+      {     32 * KB, 1, 512,      2 * KB, 16},
+      {     64 * KB, 1, 512,      4 * KB, 16},
+      {    128 * KB, 2, 512,      8 * KB, 16},
+      {    256 * KB, 2, 512,     16 * KB, 16},
+      {    512 * KB, 2, 512,     16 * KB, 32},
+      {      1 * MB, 4, 512,     32 * KB, 32},
+      {      2 * MB, 8, 512,     64 * KB, 32},
+      {      4 * MB, 8, 512,    128 * KB, 32},
+      {      8 * MB, 8, 512,    256 * KB, 32},
+      {     16 * MB, 8, 512,    256 * KB, 64},
+      {     32 * MB, 8, 512,    512 * KB, 64},
+      {     64 * MB, 8, 512,      1 * MB, 64},
+      {    128 * MB, 8, 512,      2 * MB, 64},
+      {    256 * MB, 8, 512,      4 * MB, 32},
+      {    512 * MB, 8, 512,      8 * MB, 16},
+      {      1 * GB, 8, 512,      8 * MB, 16},
+      {      2 * GB, 8, 512,      8 * MB, 16},
+      {      4 * GB, 8, 512,      8 * MB, 16},
+      {      8 * GB, 8, 512,      8 * MB, 16},
+      {     16 * GB, 8, 512,      8 * MB, 16},
+      {     32 * GB, 8, 512,      8 * MB, 16},
+      {     64 * GB, 8, 512,      8 * MB, 16},
+  };
+  // clang-format on
+
+  verifyAutoTune(cases, nRanks, maxOcc, defThreads);
+}
+
+TEST(AutoTuneDefaultRankSweep, DefaultBDP_32Ranks) {
+  const int nRanks = 32;
+  const int maxOcc = 64;
+  const int defThreads = 512;
+
+  // clang-format off
+  const AutoTuneExpected cases[] = {
+      {      1 * KB, 1, 512,          32, 32},
+      {      2 * KB, 1, 512,          64, 32},
+      {      4 * KB, 1, 512,         128, 32},
+      {      8 * KB, 1, 512,         256, 32},
+      {     16 * KB, 1, 512,         512, 32},
+      {     32 * KB, 1, 512,      1 * KB, 32},
+      {     64 * KB, 1, 512,      2 * KB, 32},
+      {    128 * KB, 1, 512,      4 * KB, 32},
+      {    256 * KB, 2, 512,      8 * KB, 32},
+      {    512 * KB, 2, 512,     16 * KB, 32},
+      {      1 * MB, 2, 512,     16 * KB, 64},
+      {      2 * MB, 4, 512,     32 * KB, 64},
+      {      4 * MB, 8, 512,     64 * KB, 64},
+      {      8 * MB, 8, 512,    128 * KB, 64},
+      {     16 * MB, 8, 512,    256 * KB, 64},
+      {     32 * MB, 8, 512,    256 * KB, 128},
+      {     64 * MB, 8, 512,    512 * KB, 128},
+      {    128 * MB, 8, 512,      1 * MB, 128},
+      {    256 * MB, 8, 512,      1 * MB, 128},
+      {    512 * MB, 8, 512,      2 * MB, 64},
+      {      1 * GB, 8, 512,      4 * MB, 32},
+      {      2 * GB, 8, 512,      4 * MB, 32},
+      {      4 * GB, 8, 512,      4 * MB, 32},
+      {      8 * GB, 8, 512,      4 * MB, 32},
+      {     16 * GB, 8, 512,      4 * MB, 32},
+      {     32 * GB, 8, 512,      4 * MB, 32},
+      {     64 * GB, 8, 512,      4 * MB, 32},
+  };
+  // clang-format on
+
+  verifyAutoTune(cases, nRanks, maxOcc, defThreads);
+}
+
+TEST(AutoTuneDefaultRankSweep, DefaultBDP_64Ranks) {
+  const int nRanks = 64;
+  const int maxOcc = 64;
+  const int defThreads = 512;
+
+  // clang-format off
+  const AutoTuneExpected cases[] = {
+      {      1 * KB, 1, 512,          16, 64},
+      {      2 * KB, 1, 512,          32, 64},
+      {      4 * KB, 1, 512,          64, 64},
+      {      8 * KB, 1, 512,         128, 64},
+      {     16 * KB, 1, 512,         256, 64},
+      {     32 * KB, 1, 512,         512, 64},
+      {     64 * KB, 1, 512,      1 * KB, 64},
+      {    128 * KB, 1, 512,      2 * KB, 64},
+      {    256 * KB, 1, 512,      4 * KB, 64},
+      {    512 * KB, 2, 512,      8 * KB, 64},
+      {      1 * MB, 2, 512,     16 * KB, 64},
+      {      2 * MB, 2, 512,     16 * KB, 128},
+      {      4 * MB, 4, 512,     32 * KB, 128},
+      {      8 * MB, 8, 512,     64 * KB, 128},
+      {     16 * MB, 8, 512,    128 * KB, 128},
+      {     32 * MB, 8, 512,    256 * KB, 128},
+      {     64 * MB, 8, 512,    256 * KB, 256},
+      {    128 * MB, 8, 512,    512 * KB, 256},
+      {    256 * MB, 8, 512,    512 * KB, 256},
+      {    512 * MB, 8, 512,    512 * KB, 256},
+      {      1 * GB, 8, 512,      1 * MB, 128},
+      {      2 * GB, 8, 512,      2 * MB, 64},
+      {      4 * GB, 8, 512,      2 * MB, 64},
+      {      8 * GB, 8, 512,      2 * MB, 64},
+      {     16 * GB, 8, 512,      2 * MB, 64},
+      {     32 * GB, 8, 512,      2 * MB, 64},
+      {     64 * GB, 8, 512,      2 * MB, 64},
+  };
+  // clang-format on
+
+  verifyAutoTune(cases, nRanks, maxOcc, defThreads);
+}
+
+// ============================================================================
+// Rank-sweep tables: Hopper arch, arch-default BDP, ranks {8,16,32,64}
+// ============================================================================
+
+TEST(AutoTuneHopperRankSweep, DefaultBDP_8Ranks) {
+  const int nRanks = 8;
+  const int maxOcc = 64;
+  const int defThreads = 512;
+  const auto arch = GpuArch::Hopper;
+
+  // clang-format off
+  const AutoTuneExpected cases[] = {
+      {      1 * KB, 1, 384,         128, 8},
+      {      2 * KB, 1, 384,         256, 8},
+      {      4 * KB, 1, 384,         512, 8},
+      {      8 * KB, 1, 384,      1 * KB, 8},
+      {     16 * KB, 1, 384,      2 * KB, 8},
+      {     32 * KB, 1, 384,      4 * KB, 8},
+      {     64 * KB, 1, 384,      8 * KB, 8},
+      {    128 * KB, 1, 512,     16 * KB, 8},
+      {    256 * KB, 1, 512,     16 * KB, 16},
+      {    512 * KB, 1, 512,     32 * KB, 16},
+      {      1 * MB, 1, 512,     64 * KB, 16},
+      {      2 * MB, 2, 512,    128 * KB, 16},
+      {      4 * MB, 2, 512,    256 * KB, 16},
+      {      8 * MB, 2, 512,    256 * KB, 32},
+      {     16 * MB, 4, 512,    512 * KB, 32},
+      {     32 * MB, 4, 512,      2 * MB, 16},
+      {     64 * MB, 4, 512,      4 * MB, 8},
+      {    128 * MB, 4, 512,      4 * MB, 8},
+      {    256 * MB, 4, 512,      4 * MB, 8},
+      {    512 * MB, 4, 512,      4 * MB, 8},
+      {      1 * GB, 4, 512,      4 * MB, 8},
+      {      2 * GB, 4, 512,      4 * MB, 8},
+      {      4 * GB, 4, 512,      4 * MB, 8},
+      {      8 * GB, 4, 512,      4 * MB, 8},
+      {     16 * GB, 4, 512,      4 * MB, 8},
+      {     32 * GB, 4, 512,      4 * MB, 8},
+      {     64 * GB, 4, 512,      4 * MB, 8},
+  };
+  // clang-format on
+
+  verifyAutoTune(cases, nRanks, maxOcc, defThreads, arch);
+}
+
+TEST(AutoTuneHopperRankSweep, DefaultBDP_16Ranks) {
+  const int nRanks = 16;
+  const int maxOcc = 64;
+  const int defThreads = 512;
+  const auto arch = GpuArch::Hopper;
+
+  // clang-format off
+  const AutoTuneExpected cases[] = {
+      {      1 * KB, 1, 384,          64, 16},
+      {      2 * KB, 1, 384,         128, 16},
+      {      4 * KB, 1, 384,         256, 16},
+      {      8 * KB, 1, 384,         512, 16},
+      {     16 * KB, 1, 384,      1 * KB, 16},
+      {     32 * KB, 1, 384,      2 * KB, 16},
+      {     64 * KB, 1, 384,      4 * KB, 16},
+      {    128 * KB, 1, 384,      8 * KB, 16},
+      {    256 * KB, 1, 512,     16 * KB, 16},
+      {    512 * KB, 1, 512,     16 * KB, 32},
+      {      1 * MB, 1, 512,     32 * KB, 32},
+      {      2 * MB, 1, 512,     64 * KB, 32},
+      {      4 * MB, 2, 512,    128 * KB, 32},
+      {      8 * MB, 2, 512,    256 * KB, 32},
+      {     16 * MB, 2, 512,    256 * KB, 64},
+      {     32 * MB, 4, 512,    512 * KB, 64},
+      {     64 * MB, 4, 512,      1 * MB, 32},
+      {    128 * MB, 4, 512,      2 * MB, 16},
+      {    256 * MB, 4, 512,      2 * MB, 16},
+      {    512 * MB, 4, 512,      2 * MB, 16},
+      {      1 * GB, 4, 512,      2 * MB, 16},
+      {      2 * GB, 4, 512,      2 * MB, 16},
+      {      4 * GB, 4, 512,      2 * MB, 16},
+      {      8 * GB, 4, 512,      2 * MB, 16},
+      {     16 * GB, 4, 512,      2 * MB, 16},
+      {     32 * GB, 4, 512,      2 * MB, 16},
+      {     64 * GB, 4, 512,      2 * MB, 16},
+  };
+  // clang-format on
+
+  verifyAutoTune(cases, nRanks, maxOcc, defThreads, arch);
+}
+
+TEST(AutoTuneHopperRankSweep, DefaultBDP_32Ranks) {
+  const int nRanks = 32;
+  const int maxOcc = 64;
+  const int defThreads = 512;
+  const auto arch = GpuArch::Hopper;
+
+  // clang-format off
+  const AutoTuneExpected cases[] = {
+      {      1 * KB, 1, 384,          32, 32},
+      {      2 * KB, 1, 384,          64, 32},
+      {      4 * KB, 1, 384,         128, 32},
+      {      8 * KB, 1, 384,         256, 32},
+      {     16 * KB, 1, 384,         512, 32},
+      {     32 * KB, 1, 384,      1 * KB, 32},
+      {     64 * KB, 1, 384,      2 * KB, 32},
+      {    128 * KB, 1, 384,      4 * KB, 32},
+      {    256 * KB, 1, 384,      8 * KB, 32},
+      {    512 * KB, 1, 512,     16 * KB, 32},
+      {      1 * MB, 1, 512,     16 * KB, 64},
+      {      2 * MB, 1, 512,     32 * KB, 64},
+      {      4 * MB, 1, 512,     64 * KB, 64},
+      {      8 * MB, 2, 512,    128 * KB, 64},
+      {     16 * MB, 2, 512,    256 * KB, 64},
+      {     32 * MB, 2, 512,    256 * KB, 128},
+      {     64 * MB, 2, 512,    256 * KB, 128},
+      {    128 * MB, 4, 512,    512 * KB, 64},
+      {    256 * MB, 4, 512,      1 * MB, 32},
+      {    512 * MB, 4, 512,      1 * MB, 32},
+      {      1 * GB, 4, 512,      1 * MB, 32},
+      {      2 * GB, 4, 512,      1 * MB, 32},
+      {      4 * GB, 4, 512,      1 * MB, 32},
+      {      8 * GB, 4, 512,      1 * MB, 32},
+      {     16 * GB, 4, 512,      1 * MB, 32},
+      {     32 * GB, 4, 512,      1 * MB, 32},
+      {     64 * GB, 4, 512,      1 * MB, 32},
+  };
+  // clang-format on
+
+  verifyAutoTune(cases, nRanks, maxOcc, defThreads, arch);
+}
+
+TEST(AutoTuneHopperRankSweep, DefaultBDP_64Ranks) {
+  const int nRanks = 64;
+  const int maxOcc = 64;
+  const int defThreads = 512;
+  const auto arch = GpuArch::Hopper;
+
+  // clang-format off
+  const AutoTuneExpected cases[] = {
+      {      1 * KB, 1, 384,          16, 64},
+      {      2 * KB, 1, 384,          32, 64},
+      {      4 * KB, 1, 384,          64, 64},
+      {      8 * KB, 1, 384,         128, 64},
+      {     16 * KB, 1, 384,         256, 64},
+      {     32 * KB, 1, 384,         512, 64},
+      {     64 * KB, 1, 384,      1 * KB, 64},
+      {    128 * KB, 1, 384,      2 * KB, 64},
+      {    256 * KB, 1, 384,      4 * KB, 64},
+      {    512 * KB, 1, 384,      8 * KB, 64},
+      {      1 * MB, 1, 512,     16 * KB, 64},
+      {      2 * MB, 1, 512,     16 * KB, 128},
+      {      4 * MB, 1, 512,     32 * KB, 128},
+      {      8 * MB, 1, 512,     64 * KB, 128},
+      {     16 * MB, 2, 512,    128 * KB, 128},
+      {     32 * MB, 2, 512,    256 * KB, 128},
+      {     64 * MB, 2, 512,    128 * KB, 256},
+      {    128 * MB, 2, 512,    128 * KB, 256},
+      {    256 * MB, 2, 512,    256 * KB, 128},
+      {    512 * MB, 4, 512,    512 * KB, 64},
+      {      1 * GB, 4, 512,    512 * KB, 64},
+      {      2 * GB, 4, 512,    512 * KB, 64},
+      {      4 * GB, 4, 512,    512 * KB, 64},
+      {      8 * GB, 4, 512,    512 * KB, 64},
+      {     16 * GB, 4, 512,    512 * KB, 64},
+      {     32 * GB, 4, 512,    512 * KB, 64},
+      {     64 * GB, 4, 512,    512 * KB, 64},
+  };
+  // clang-format on
+
+  verifyAutoTune(cases, nRanks, maxOcc, defThreads, arch);
+}
+
+// ============================================================================
+// CVAR override tests for getAutoTunedParams
+// ============================================================================
+
+class AutoTuneCVAROverrideTest : public ::testing::Test {
+ protected:
+  static constexpr int kMaxOcc = 64;
+  static constexpr int kDefThreads = 512;
+  static constexpr int kNRanks = 8;
+  // Use a message size large enough that auto-tune produces non-trivial values.
+  static constexpr size_t kMsg = 64 * MB;
+};
+
+// Chunk size CVAR alone overrides chunkSize, numChunks stays auto-tuned.
+TEST_F(AutoTuneCVAROverrideTest, ChunkSizeOnly) {
+  MaxBDPOverride bdp(128 * MB);
+  ChunkSizeOverride cs(1 * MB);
+
+  auto at = getAutoTunedParams(kMsg, kNRanks, kMaxOcc, kDefThreads);
+  EXPECT_EQ(at.pipeline.chunkSize, 1 * MB);
+  // numChunks is still auto-tuned (not overridden)
+  EXPECT_GT(at.pipeline.numChunks, 0u);
+}
+
+// Num chunks CVAR alone overrides numChunks, chunkSize stays auto-tuned.
+TEST_F(AutoTuneCVAROverrideTest, NumChunksOnly) {
+  MaxBDPOverride bdp(128 * MB);
+  NumChunksOverride nc(4);
+
+  auto at = getAutoTunedParams(kMsg, kNRanks, kMaxOcc, kDefThreads);
+  EXPECT_EQ(at.pipeline.numChunks, 4u);
+  // chunkSize is still auto-tuned
+  EXPECT_GT(at.pipeline.chunkSize, 0u);
+}
+
+// Both chunk CVARs set together.
+TEST_F(AutoTuneCVAROverrideTest, ChunkSizeAndNumChunks) {
+  MaxBDPOverride bdp(128 * MB);
+  ChunkSizeOverride cs(2 * MB);
+  NumChunksOverride nc(8);
+
+  auto at = getAutoTunedParams(kMsg, kNRanks, kMaxOcc, kDefThreads);
+  EXPECT_EQ(at.pipeline.chunkSize, 2 * MB);
+  EXPECT_EQ(at.pipeline.numChunks, 8u);
+}
+
+// Block CVARs override auto-tuned block params.
+TEST_F(AutoTuneCVAROverrideTest, BlockOverrides) {
+  MaxBDPOverride bdp(128 * MB);
+  NumBlocksOverride nb(3);
+  BlockSizeOverride bs(384);
+
+  auto at = getAutoTunedParams(kMsg, kNRanks, kMaxOcc, kDefThreads);
+  EXPECT_EQ(at.block.numBlocks, 3);
+  EXPECT_EQ(at.block.blockSize, 384);
+}
+
+// Chunk size override feeds into block params computation (Default arch).
+// Default thresholds: <8K->1, 8K-32K->2, 32K-64K->4, >=64K->8
+TEST_F(AutoTuneCVAROverrideTest, ChunkSizeAffectsBlockParams) {
+  MaxBDPOverride bdp(128 * MB);
+
+  struct Case {
+    int chunkSize;
+    int expectedBlocks;
+  };
+  // clang-format off
+  const Case cases[] = {
+      {  4 * KB, 1},
+      {  8 * KB, 2},
+      { 32 * KB, 4},
+      { 64 * KB, 8},
+      {  1 * MB, 8},
+  };
+  // clang-format on
+
+  for (const auto& c : cases) {
+    ChunkSizeOverride cs(c.chunkSize);
+    auto at = getAutoTunedParams(kMsg, kNRanks, kMaxOcc, kDefThreads);
+    EXPECT_EQ(at.block.numBlocks, c.expectedBlocks)
+        << "chunkSize=" << c.chunkSize;
+  }
+}
+
+// Chunk size override feeds into block params on Hopper arch.
+// Hopper thresholds: <16K->{1,384}, 16K-128K->{1,512}, 128K-512K->{2,512},
+// >=512K->{4,512}
+TEST_F(AutoTuneCVAROverrideTest, ChunkSizeAffectsBlockParamsHopper) {
+  MaxBDPOverride bdp(128 * MB);
+  const auto arch = GpuArch::Hopper;
+
+  struct Case {
+    int chunkSize;
+    int expectedBlocks;
+    int expectedBlockSize;
+  };
+  // clang-format off
+  const Case cases[] = {
+      {   8 * KB, 1, 384},
+      {  16 * KB, 1, 512},
+      { 128 * KB, 2, 512},
+      { 512 * KB, 4, 512},
+  };
+  // clang-format on
+
+  for (const auto& c : cases) {
+    ChunkSizeOverride cs(c.chunkSize);
+    auto at = getAutoTunedParams(kMsg, kNRanks, kMaxOcc, kDefThreads, arch);
+    EXPECT_EQ(at.block.numBlocks, c.expectedBlocks)
+        << "chunkSize=" << c.chunkSize;
+    EXPECT_EQ(at.block.blockSize, c.expectedBlockSize)
+        << "chunkSize=" << c.chunkSize;
+  }
+}
+
+// Block CVARs take priority over the block params derived from chunk override.
+TEST_F(AutoTuneCVAROverrideTest, BlockOverrideTakesPriorityOverChunkDerived) {
+  MaxBDPOverride bdp(128 * MB);
+  ChunkSizeOverride cs(1 * MB); // would auto-tune to 8 blocks on Default
+  NumBlocksOverride nb(2); // explicit override wins
+
+  auto at = getAutoTunedParams(kMsg, kNRanks, kMaxOcc, kDefThreads);
+  EXPECT_EQ(at.pipeline.chunkSize, 1 * MB);
+  EXPECT_EQ(at.block.numBlocks, 2);
+}
+
+// All four CVARs set simultaneously.
+TEST_F(AutoTuneCVAROverrideTest, AllFourOverrides) {
+  MaxBDPOverride bdp(128 * MB);
+  ChunkSizeOverride cs(512 * KB);
+  NumChunksOverride nc(16);
+  NumBlocksOverride nb(4);
+  BlockSizeOverride bs(256);
+
+  auto at = getAutoTunedParams(kMsg, kNRanks, kMaxOcc, kDefThreads);
+  EXPECT_EQ(at.pipeline.chunkSize, 512 * KB);
+  EXPECT_EQ(at.pipeline.numChunks, 16u);
+  EXPECT_EQ(at.block.numBlocks, 4);
+  EXPECT_EQ(at.block.blockSize, 256);
+}
+
+// Pipeline BDP invariant: chunkSize * numChunks <= maxBDP for all configs.
+TEST_F(AutoTuneCVAROverrideTest, BDPInvariant) {
+  const size_t maxBDPs[] = {
+      256 * KB,
+      512 * KB,
+      1 * MB,
+      2 * MB,
+      4 * MB,
+      8 * MB,
+      16 * MB,
+      32 * MB,
+      64 * MB,
+      128 * MB};
+
+  size_t msg = 1 * KB;
+  while (msg <= 64 * GB) {
+    for (auto maxBDP : maxBDPs) {
+      MaxBDPOverride o(maxBDP);
+      auto at = getAutoTunedParams(msg, kNRanks, kMaxOcc, kDefThreads);
+      EXPECT_LE(at.pipeline.chunkSize * at.pipeline.numChunks, maxBDP)
+          << "BDP violated: msg=" << msg << " maxBDP=" << maxBDP
+          << " chunkSize=" << at.pipeline.chunkSize
+          << " numChunks=" << at.pipeline.numChunks;
+    }
+    msg *= 2;
+  }
+}
+
+// Spot-check that small maxBDP values correctly reduce pipeline chunks.
+TEST_F(AutoTuneCVAROverrideTest, SmallMaxBDP_ChunksReduced) {
+  {
+    MaxBDPOverride o(256 * KB);
+    auto at = getAutoTunedParams(1 * MB, kNRanks, kMaxOcc, kDefThreads);
+    EXPECT_EQ(at.pipeline.chunkSize, 16 * KB);
+    EXPECT_EQ(at.pipeline.numChunks, 16u);
+  }
+  {
+    MaxBDPOverride o(512 * KB);
+    auto at = getAutoTunedParams(1 * MB, kNRanks, kMaxOcc, kDefThreads);
+    EXPECT_EQ(at.pipeline.chunkSize, 32 * KB);
+    EXPECT_EQ(at.pipeline.numChunks, 16u);
+  }
+}
+
+// maxOccupancyBlocks clamps block count; blockSize clamped by defaultThreads.
+// Hopper tiers have explicit blockSize values (384, 512) that can exceed
+// defaultThreads, exercising the std::min(blockSize, defaultThreads) path.
+TEST_F(AutoTuneCVAROverrideTest, MaxOccupancyClampWithBlockSize) {
+  MaxBDPOverride bdp(128 * MB);
+  const auto arch = GpuArch::Hopper;
+
+  // Hopper tier: chunkSize < 16K -> {1 block, 384 threads}
+  // With defaultThreads=256, blockSize should clamp to 256.
+  // With maxOccupancyBlocks=1, numBlocks stays 1 (no clamp needed).
+  {
+    ChunkSizeOverride cs(8 * KB);
+    // Verify unclamped tier values are larger (clamping is meaningful)
+    auto unclamped = getAutoTunedParams(
+        kMsg, kNRanks, /*maxOccupancyBlocks=*/kMaxOcc, kDefThreads, arch);
+    ASSERT_GE(unclamped.block.blockSize, 256);
+
+    auto at = getAutoTunedParams(
+        kMsg, kNRanks, /*maxOccupancyBlocks=*/1, /*defaultThreads=*/256, arch);
+    EXPECT_EQ(at.block.numBlocks, 1);
+    EXPECT_EQ(at.block.blockSize, 256); // clamped from 384
+  }
+
+  // Hopper tier: chunkSize >= 512K -> {4 blocks, 512 threads}
+  // With defaultThreads=256, blockSize should clamp to 256.
+  // With maxOccupancyBlocks=2, numBlocks should clamp to 2.
+  {
+    ChunkSizeOverride cs(1 * MB);
+    // Verify unclamped tier values are larger (clamping is meaningful)
+    auto unclamped = getAutoTunedParams(
+        kMsg, kNRanks, /*maxOccupancyBlocks=*/kMaxOcc, kDefThreads, arch);
+    ASSERT_GE(unclamped.block.numBlocks, 2);
+    ASSERT_GE(unclamped.block.blockSize, 256);
+
+    auto at = getAutoTunedParams(
+        kMsg, kNRanks, /*maxOccupancyBlocks=*/2, /*defaultThreads=*/256, arch);
+    EXPECT_EQ(at.block.numBlocks, 2); // clamped from 4
+    EXPECT_EQ(at.block.blockSize, 256); // clamped from 512
+  }
+}
+
+// Non-pow2 message sizes: verifies that auto-tune decisions for non-pow2
+// inputs match the nearest pow2 (roundToNearestPow2 snaps internally).
+// Probes 7 points per boundary: pow2(n), pow2(n)+1, mid-1, mid, mid+1,
+// pow2(n+1)-1, pow2(n+1).
+TEST_F(AutoTuneCVAROverrideTest, NonPow2MessageSizes) {
+  MaxBDPOverride bdp(128 * MB);
+
+  // clang-format off
+  const size_t pow2Sizes[] = {
+      8 * KB,   // block tier boundary
+      64 * KB,  // block tier boundary
+      256 * KB, // pipeline chunking region
+      1 * MB,   // pipeline depth transition
+      16 * MB,  // large message region
+      32 * MB,  // pipeline depth change
+  };
+  // clang-format on
+
+  for (auto p2 : pow2Sizes) {
+    const size_t p2next = p2 * 2;
+    const size_t mid = (p2 + p2next) / 2;
+
+    struct Probe {
+      size_t msg;
+      size_t expectedPow2;
+    };
+    // clang-format off
+    const Probe probes[] = {
+        {p2,         p2},      // exact pow2(n)
+        {p2 + 1,     p2},      // just above, rounds down
+        {mid - 1,    p2},      // just below midpoint, rounds down
+        {mid,        p2next},  // exact midpoint, ties round up
+        {mid + 1,    p2next},  // just above midpoint, rounds up
+        {p2next - 1, p2next},  // just below pow2(n+1), rounds up
+        {p2next,     p2next},  // exact pow2(n+1)
+    };
+    // clang-format on
+
+    for (const auto& pr : probes) {
+      auto actual = getAutoTunedParams(pr.msg, kNRanks, kMaxOcc, kDefThreads);
+      auto expected =
+          getAutoTunedParams(pr.expectedPow2, kNRanks, kMaxOcc, kDefThreads);
+      EXPECT_EQ(actual.pipeline.chunkSize, expected.pipeline.chunkSize)
+          << "chunkSize: msg=" << pr.msg
+          << " expected pow2=" << pr.expectedPow2;
+      EXPECT_EQ(actual.pipeline.numChunks, expected.pipeline.numChunks)
+          << "numChunks: msg=" << pr.msg
+          << " expected pow2=" << pr.expectedPow2;
+      EXPECT_EQ(actual.block.numBlocks, expected.block.numBlocks)
+          << "numBlocks: msg=" << pr.msg
+          << " expected pow2=" << pr.expectedPow2;
+      EXPECT_EQ(actual.block.blockSize, expected.block.blockSize)
+          << "blockSize: msg=" << pr.msg
+          << " expected pow2=" << pr.expectedPow2;
+    }
+  }
+}

--- a/comms/ctran/algos/CtranAlgoConsts.h
+++ b/comms/ctran/algos/CtranAlgoConsts.h
@@ -1,0 +1,21 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cstddef>
+
+namespace ctran::allreduce::ring {
+
+// Maximum BDP (bandwidth-delay product) per GPU architecture.
+constexpr size_t kDefaultMaxBDP =
+    128ULL * 1024 * 1024; // 128MB (GB200/Blackwell)
+constexpr size_t kHopperMaxBDP = 32ULL * 1024 * 1024; // 32MB (H100)
+
+// Maximum BDP across all architectures — used for buffer pre-allocation
+// when the arch is not yet known.
+constexpr size_t kMaxBDP = kDefaultMaxBDP;
+
+static_assert(kMaxBDP >= kDefaultMaxBDP);
+static_assert(kMaxBDP >= kHopperMaxBDP);
+
+} // namespace ctran::allreduce::ring

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2746,7 +2746,7 @@ cvars:
 
  - name        : NCCL_CTRAN_ALLREDUCE_RING_TMPBUF_CHUNK_SIZE
    type        : uint64_t
-   default     : 8388608
+   default     : 0
    description : |-
      size in bytes of each chunk for temporary send and receive buffers used in
      NCCL CTRAN allreduce ring. The size of each temporary buffer is
@@ -2754,7 +2754,7 @@ cvars:
 
  - name        : NCCL_CTRAN_ALLREDUCE_RING_TMPBUF_NUM_CHUNKS
    type        : uint32_t
-   default     : 4
+   default     : 0
    description : |-
      number of chunks allocated for temporary send and receive buffers used in
      NCCL CTRAN allreduce ring. The size of each temporary buffer is
@@ -2769,7 +2769,7 @@ cvars:
 
  - name        : NCCL_CTRAN_ALLREDUCE_RING_MAX_NUM_THREAD_BLOCKS
    type        : int
-   default     : 8
+   default     : 0
    description : |-
      Maximum number of thread blocks used for the AllReduce kernel.
      We might use fewer thread blocks, if we can achieve max occupancy
@@ -2777,10 +2777,19 @@ cvars:
 
  - name        : NCCL_CTRAN_ALLREDUCE_RING_THREAD_BLOCK_SIZE
    type        : int
-   default     : 512
+   default     : 0
    description : |-
      Number of threads in each thread block used for the AllReduce
-     kernel. Default -1 to use the recommended size by CUDA runtime.
+     kernel.
+
+ - name        : NCCL_CTRAN_ALLREDUCE_RING_AUTO_TUNE_MAX_BDP
+   type        : int
+   default     : 0
+   description : |-
+     Enable auto-tuning of AllReduceRing parameters based on message size.
+     When enabled, overrides MAX_NUM_THREAD_BLOCKS and pipeline parameters
+     with per-message-size optimal values. Set to 0 to use static CVAR
+     values instead.
 
  - name        : NCCL_CTRAN_ENABLE_FAULT_TOLERANCE
    type        : bool


### PR DESCRIPTION
Summary:
TODO: to reviewers: I still need to remove small message size coverage (perrank < 64KB) but otherwise is ready for reviewing.


**tl;dr**  adds AutoTune module and integrates with allreduce ctring algorithm + CtranAlgo tmpbuf allocations.

--------------

**Logic**

**Pipeline auto-tuning** (`getAutoTunedPipeline`):
-  The message size is rounded to the nearest power-of-2 and clamped to a per-architecture maximum bandwidth-delay product (BDP) (overridable via `NCCL_CTRAN_ALLREDUCE_RING_AUTO_TUNE_MAX_BDP`)
  - 128MB for GB200/Blackwell
  - 32MB for H100/Hopper

A pipeline depth multiplier is chosen based on per-rank message size:
- depth 2 for small (<1MB) and large (>=4MB) messages
- depth 4 for medium (1-4MB) messages where pushing smaller chunks faster helps latency, throughput.

`numChunks = pipelineDepth * nRanks`
`chunkSize = partitionMessageBytes / numChunks` clamped to [256KB,  16MB].

A BDP-enforcement loop reduces chunkSize first and then numChunks to guarantee `chunkSize * numChunks <= maxBDP`.

**Block auto-tuning** (`getAutoTunedBlockParams`):
- A tiered lookup table maps chunkSize ranges to (numBlocks, blockSize) pairs with separate tiers per GPU architecture. 
  - Default arch (GB200/Blackwell) scales from 1 block at <8KB chunks up to 8 blocks at >=64KB, using the CUDA occupancy-reported block size.
- Hopper uses fewer blocks (max 4) with explicit block sizes (384 for tiny chunks, 512 otherwise). numBlocks is clamped by `cudaOccupancyMaxPotentialBlockSize`.

**Buffer pre-allocation** (`CtranAlgo.cc`): 
- Ring tmp buffers are now sized to the maximum BDP the auto-tuner could produce (from CVAR or constant), rather than
   the old fixed `chunk_size * num_chunks` product, ensuring the buffer is always large enough for any runtime decision.

**Note: non-pow2 message** bytes would be round to the nearest pow2 message bytes to perform chunk tuning, so that eventually the produced chunks would be mostly 16B aligned (fast path), except for the last chunk.
--------------

Existing CVARs (`TMPBUF_CHUNK_SIZE`, `TMPBUF_NUM_CHUNKS`, `MAX_NUM_THREAD_BLOCKS`, `THREAD_BLOCK_SIZE`) now default to 0,

**New Cvar Override order:**

Highest:
  - NCCL_CTRAN_ALLREDUCE_RING_TMPBUF_NUM_CHUNKS > 0
  - NCCL_CTRAN_ALLREDUCE_RING_TMPBUF_CHUNK_SIZE > 0
  - NCCL_CTRAN_ALLREDUCE_RING_MAX_NUM_THREAD_BLOCKS > 0
0
  - NCCL_CTRAN_ALLREDUCE_RING_THREAD_BLOCK_SIZE > 0

Next:
  - NCCL_CTRAN_ALLREDUCE_RING_AUTO_TUNE_MAX_BDP

Default:
  - use autotune


------------
**Notes:**

I chose not to split this diff into smaller, because the autotune logic is very much dependent on the buffer size, decided by BDP, and have overrides from the cvars for experiments. The override logic must align between
- AllReduce ctring AutoTune
- CtranAlgo tmpbuf allocation.

`CtranAlgoConsts.h` is created to avoid adding per algorithm dependency into the main CtranAlgo.(h|cc)

Unfortunately, it's also difficult to justify the gains if we play with only one of the parameters at a time. Going forward, once we have this baseline, the further optimizations will be more fine grained.

Differential Revision: D93342742


