### PR TITLE
Fix for Hipify V2 changes

### DIFF
--- a/comms/torchcomms/rccl/HipApi.cpp
+++ b/comms/torchcomms/rccl/HipApi.cpp
@@ -49,8 +49,7 @@ hipError_t DefaultHipApi::streamWaitEvent(
   return hipStreamWaitEvent(stream, event, flags);
 }
 
-hipStream_t DefaultHipApi::getCurrentHIPStreamMasqueradingAsCUDA(
-    int device_index) {
+hipStream_t DefaultHipApi::getCurrentCUDAStream(int device_index) {
 #ifdef HIPIFY_V2
   return at::cuda::getCurrentCUDAStream(device_index).stream();
 #else

--- a/comms/torchcomms/rccl/HipApi.hpp
+++ b/comms/torchcomms/rccl/HipApi.hpp
@@ -57,8 +57,9 @@ class HipApi {
   [[nodiscard]] virtual hipError_t streamDestroy(hipStream_t stream) = 0;
   [[nodiscard]] virtual hipError_t
   streamWaitEvent(hipStream_t stream, hipEvent_t event, unsigned int flags) = 0;
-  virtual hipStream_t getCurrentHIPStreamMasqueradingAsCUDA(
-      int device_index) = 0;
+  // Note: Named getCurrentCUDAStream because hipify transforms
+  // getCurrentHIPStreamMasqueradingAsCUDA to getCurrentCUDAStream
+  virtual hipStream_t getCurrentCUDAStream(int device_index) = 0;
   [[nodiscard]] virtual hipError_t streamSynchronize(hipStream_t stream) = 0;
   [[nodiscard]] virtual hipError_t threadExchangeStreamCaptureMode(
       enum hipStreamCaptureMode* mode) = 0;
@@ -113,7 +114,7 @@ class DefaultHipApi : public HipApi {
       hipStream_t stream,
       hipEvent_t event,
       unsigned int flags) override;
-  hipStream_t getCurrentHIPStreamMasqueradingAsCUDA(int device_index) override;
+  hipStream_t getCurrentCUDAStream(int device_index) override;
   [[nodiscard]] hipError_t streamSynchronize(hipStream_t stream) override;
   [[nodiscard]] hipError_t threadExchangeStreamCaptureMode(
       enum hipStreamCaptureMode* mode) override;

--- a/comms/torchcomms/rccl/TorchCommRCCLBootstrap.cpp
+++ b/comms/torchcomms/rccl/TorchCommRCCLBootstrap.cpp
@@ -170,8 +170,7 @@ void TorchCommRCCLBootstrap::cleanupTCPStore(ncclComm_t nccl_comm) {
     // object.
     store_.reset();
 
-    auto stream =
-        hip_api_->getCurrentHIPStreamMasqueradingAsCUDA(device_.index());
+    auto stream = hip_api_->getCurrentCUDAStream(device_.index());
     ncclResult_t result = rccl_api_->allReduce(
         barrier_buffer_,
         barrier_buffer_,

--- a/comms/torchcomms/rccl/TorchCommRCCLCCA.hpp
+++ b/comms/torchcomms/rccl/TorchCommRCCLCCA.hpp
@@ -10,9 +10,9 @@ using c10::cuda::CUDACachingAllocator::snapshot;
 using c10::cuda::CUDACachingAllocator::TraceEntry;
 #else
 #include <ATen/hip/impl/HIPCachingAllocatorMasqueradingAsCUDA.h> // @manual
-using c10::hip::HIPCachingAllocator::attachAllocatorTraceTracker;
-using c10::hip::HIPCachingAllocator::snapshot;
-using c10::hip::HIPCachingAllocator::TraceEntry;
+using c10::cuda::CUDACachingAllocator::attachAllocatorTraceTracker;
+using c10::cuda::CUDACachingAllocator::snapshot;
+using c10::cuda::CUDACachingAllocator::TraceEntry;
 #endif
 #include <memory>
 #include <mutex>

--- a/comms/torchcomms/rccl/TorchCommRCCLUtils.cpp
+++ b/comms/torchcomms/rccl/TorchCommRCCLUtils.cpp
@@ -331,7 +331,7 @@ hipStream_t TorchCommRCCL::getOperationStream(bool async_op) {
   if (async_op) {
     // Get current PyTorch CUDA stream for this device
     hipStream_t current_stream =
-        hip_api_->getCurrentHIPStreamMasqueradingAsCUDA(device_.index());
+        hip_api_->getCurrentCUDAStream(device_.index());
 
     // Record event on current stream and wait for it on internal stream
     HIP_CHECK(
@@ -347,7 +347,7 @@ hipStream_t TorchCommRCCL::getOperationStream(bool async_op) {
     return internal_stream_;
   } else {
     // Use the current PyTorch CUDA stream for synchronous operations
-    return hip_api_->getCurrentHIPStreamMasqueradingAsCUDA(device_.index());
+    return hip_api_->getCurrentCUDAStream(device_.index());
   }
 }
 

--- a/comms/torchcomms/rccl/TorchWorkRCCL.cpp
+++ b/comms/torchcomms/rccl/TorchWorkRCCL.cpp
@@ -160,8 +160,7 @@ void TorchWorkRCCL::wait() {
 
   // Get the current stream using the device from the comm object
   hipStream_t current_stream =
-      comm_->getHipApi()->getCurrentHIPStreamMasqueradingAsCUDA(
-          comm_->device_.index());
+      comm_->getHipApi()->getCurrentCUDAStream(comm_->device_.index());
 
   // Add a dependency from the work's stream to the current stream
   // This makes the current stream wait for the end_event_ recorded on the

--- a/comms/torchcomms/rccl/tests/unit/cpp/mocks/CachingAllocatorHookMock.hpp
+++ b/comms/torchcomms/rccl/tests/unit/cpp/mocks/CachingAllocatorHookMock.hpp
@@ -11,11 +11,7 @@ namespace torch::comms::test {
 
 class CachingAllocatorHookMock : public CachingAllocatorHookImpl {
  public:
-  MOCK_METHOD(
-      void,
-      regDeregMem,
-      (const c10::hip::HIPCachingAllocator::TraceEntry& entry),
-      (override));
+  MOCK_METHOD(void, regDeregMem, (const TraceEntry& entry), (override));
   MOCK_METHOD(void, registerComm, (TorchCommRCCL * comm), (override));
   MOCK_METHOD(void, deregisterComm, (TorchCommRCCL * comm), (override));
   MOCK_METHOD(void, clear, (), (override));

--- a/comms/torchcomms/rccl/tests/unit/cpp/mocks/HipMock.hpp
+++ b/comms/torchcomms/rccl/tests/unit/cpp/mocks/HipMock.hpp
@@ -36,7 +36,7 @@ class HipMock : public HipApi {
       (override));
   MOCK_METHOD(
       hipStream_t,
-      getCurrentHIPStreamMasqueradingAsCUDA,
+      getCurrentCUDAStream,
       (int device_index),
       (override));
   MOCK_METHOD(hipError_t, streamSynchronize, (hipStream_t stream), (override));

--- a/comms/torchcomms/rcclx/TorchCommRCCLXCCA.hpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLXCCA.hpp
@@ -10,9 +10,9 @@ using c10::cuda::CUDACachingAllocator::snapshot;
 using c10::cuda::CUDACachingAllocator::TraceEntry;
 #else
 #include <ATen/hip/impl/HIPCachingAllocatorMasqueradingAsCUDA.h> // @manual
-using c10::hip::HIPCachingAllocator::attachAllocatorTraceTracker;
-using c10::hip::HIPCachingAllocator::snapshot;
-using c10::hip::HIPCachingAllocator::TraceEntry;
+using c10::cuda::CUDACachingAllocator::attachAllocatorTraceTracker;
+using c10::cuda::CUDACachingAllocator::snapshot;
+using c10::cuda::CUDACachingAllocator::TraceEntry;
 #endif
 #include <memory>
 #include <mutex>


### PR DESCRIPTION
Summary:
Similar to RCCLX, D92454446

Original context: D91603922
Pytorch decided to change to Hipify V2 and hence some APIs like getCurrentHIPStreamMasqueradingAsCUDA aren't supported anymore in hipification process. So we are moving them to the respective correct APIs.

Differential Revision: D93810681


