### PR TITLE
Support timeout in graph mode

### DIFF
--- a/comms/torchcomms/device/cuda/CudaApi.cpp
+++ b/comms/torchcomms/device/cuda/CudaApi.cpp
@@ -89,6 +89,19 @@ cudaError_t DefaultCudaApi::graphRetainUserObject(
   return cudaGraphRetainUserObject(graph, object, count, flags);
 }
 
+cudaError_t DefaultCudaApi::userObjectRelease(
+    cudaUserObject_t object,
+    unsigned int count) {
+  return cudaUserObjectRelease(object, count);
+}
+
+cudaError_t DefaultCudaApi::launchHostFunc(
+    cudaStream_t stream,
+    cudaHostFn_t fn,
+    void* userData) {
+  return cudaLaunchHostFunc(stream, fn, userData);
+}
+
 cudaError_t DefaultCudaApi::streamGetCaptureInfo_v2(
     cudaStream_t stream,
     cudaStreamCaptureStatus* captureStatus_out,
@@ -164,6 +177,13 @@ cudaError_t DefaultCudaApi::eventRecord(
     cudaEvent_t event,
     cudaStream_t stream) {
   return cudaEventRecord(event, stream);
+}
+
+cudaError_t DefaultCudaApi::eventRecordWithFlags(
+    cudaEvent_t event,
+    cudaStream_t stream,
+    unsigned int flags) {
+  return cudaEventRecordWithFlags(event, stream, flags);
 }
 
 cudaError_t DefaultCudaApi::eventQuery(cudaEvent_t event) {

--- a/comms/torchcomms/device/cuda/CudaApi.hpp
+++ b/comms/torchcomms/device/cuda/CudaApi.hpp
@@ -81,6 +81,11 @@ class CudaApi {
       cudaUserObject_t object,
       unsigned int count,
       unsigned int flags) = 0;
+  [[nodiscard]] virtual cudaError_t userObjectRelease(
+      cudaUserObject_t object,
+      unsigned int count) = 0;
+  [[nodiscard]] virtual cudaError_t
+  launchHostFunc(cudaStream_t stream, cudaHostFn_t fn, void* userData) = 0;
   [[nodiscard]] virtual cudaError_t streamGetCaptureInfo_v2(
       cudaStream_t stream,
       cudaStreamCaptureStatus* captureStatus_out,
@@ -112,6 +117,10 @@ class CudaApi {
   [[nodiscard]] virtual cudaError_t eventRecord(
       cudaEvent_t event,
       cudaStream_t stream) = 0;
+  [[nodiscard]] virtual cudaError_t eventRecordWithFlags(
+      cudaEvent_t event,
+      cudaStream_t stream,
+      unsigned int flags) = 0;
   [[nodiscard]] virtual cudaError_t eventQuery(cudaEvent_t event) = 0;
 
   // Error handling
@@ -168,6 +177,11 @@ class DefaultCudaApi : public CudaApi {
       cudaUserObject_t object,
       unsigned int count,
       unsigned int flags) override;
+  [[nodiscard]] cudaError_t userObjectRelease(
+      cudaUserObject_t object,
+      unsigned int count) override;
+  [[nodiscard]] cudaError_t
+  launchHostFunc(cudaStream_t stream, cudaHostFn_t fn, void* userData) override;
   [[nodiscard]] cudaError_t streamGetCaptureInfo_v2(
       cudaStream_t stream,
       cudaStreamCaptureStatus* captureStatus_out,
@@ -201,6 +215,10 @@ class DefaultCudaApi : public CudaApi {
   [[nodiscard]] cudaError_t eventDestroy(cudaEvent_t event) override;
   [[nodiscard]] cudaError_t eventRecord(cudaEvent_t event, cudaStream_t stream)
       override;
+  [[nodiscard]] cudaError_t eventRecordWithFlags(
+      cudaEvent_t event,
+      cudaStream_t stream,
+      unsigned int flags) override;
   [[nodiscard]] cudaError_t eventQuery(cudaEvent_t event) override;
 
   // Error handling

--- a/comms/torchcomms/ncclx/GraphEventTracker.cpp
+++ b/comms/torchcomms/ncclx/GraphEventTracker.cpp
@@ -1,0 +1,253 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/torchcomms/ncclx/GraphEventTracker.hpp"
+
+#include <list>
+#include <stdexcept>
+
+#include <folly/ScopeGuard.h>
+
+#include "comms/torchcomms/TorchCommLogging.hpp"
+#include "comms/torchcomms/ncclx/TorchCommNCCLX.hpp"
+#include "comms/torchcomms/ncclx/TorchWorkNCCLX.hpp"
+
+namespace {
+
+torch::comms::SharedCallbackState* allocateCallbackState() {
+  static std::mutex mutex;
+  static std::list<torch::comms::SharedCallbackState> pool;
+  std::lock_guard<std::mutex> lock(mutex);
+  pool.emplace_back();
+  return &pool.back();
+}
+
+} // namespace
+
+namespace torch::comms {
+
+GraphEventTracker::GraphEventTracker(TorchCommNCCLX* comm) : comm_(comm) {}
+
+void GraphEventTracker::initOnGraphStart(cudaStream_t stream) {
+  // No op if not in graph capture mode
+  if (!comm_->getGraphCaptureMode()) {
+    return;
+  }
+
+  CudaApi* api = comm_->getCudaApi();
+
+  // Get CUDA stream capture info
+  cudaStreamCaptureStatus capture_status;
+  unsigned long long graph_id;
+  cudaGraph_t graph;
+  CUDA_CHECK(
+      api,
+      api->streamGetCaptureInfo_v2(
+          stream, &capture_status, &graph_id, &graph, nullptr, nullptr),
+      "Failed to get CUDA stream capture info");
+  if (capture_status != cudaStreamCaptureStatusActive) {
+    return;
+  }
+
+  std::lock_guard<std::mutex> lock(mutex_);
+  // reuse at subsequent enqueueWork->addEntry()
+  current_graph_id_ = graph_id;
+  maybeInitGraphState(stream, graph_id, graph);
+}
+
+void GraphEventTracker::maybeInitGraphState(
+    cudaStream_t stream,
+    unsigned long long graph_id,
+    cudaGraph_t graph) {
+  // One-time initialization per graph
+  auto [it, inserted] = graphs_.try_emplace(graph_id);
+  // No op if already initialized
+  if (!inserted) {
+    return;
+  }
+  auto& state = it->second;
+  CudaApi* api = comm_->getCudaApi();
+
+  SharedCallbackState* shared = allocateCallbackState();
+  state.shared_ = shared;
+
+  // Set up replay counter — host node fires on each replay
+  CUDA_CHECK(
+      api,
+      api->launchHostFunc(stream, replayCallback, &shared->replay_counter),
+      "Failed to launch replay counter host func");
+
+  // Set up deferred cleanup via a CUDA user object — when the graph is
+  // destroyed, the callback sets the released flag; the watchdog's next
+  // checkAll() will destroy the owned events.
+  cudaUserObject_t user_object;
+  CUDA_CHECK(
+      api,
+      api->userObjectCreate(
+          &user_object,
+          &shared->released,
+          cleanupCallback,
+          1,
+          cudaUserObjectNoDestructorSync),
+      "Failed to create user object");
+
+  auto user_obj_guard = folly::makeGuard(
+      [api, user_object] { (void)api->userObjectRelease(user_object, 1); });
+
+  CUDA_CHECK(
+      api,
+      api->graphRetainUserObject(
+          graph, user_object, 1, cudaGraphUserObjectMove),
+      "Failed to retain user object");
+
+  // graphRetainUserObject succeeded — graph now owns user_object
+  user_obj_guard.dismiss();
+}
+
+void GraphEventTracker::addEntry(TorchWorkNCCLX* work) {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  // Transfer start/end event ownership from the work object
+  auto [it, inserted] = graphs_.try_emplace(current_graph_id_);
+  it->second.entries.emplace_back(
+      work->start_event_, work->end_event_, work->timeout_ms_);
+  work->start_event_ = nullptr;
+  work->end_event_ = nullptr;
+}
+
+// Queries a CUDA event and returns CheckResult::ERROR on unexpected CUDA
+// errors. After the macro, `ret` is either cudaSuccess or cudaErrorNotReady.
+#define EVENT_QUERY_CHECK(call, ret, event_desc)                              \
+  do {                                                                        \
+    ret = (call);                                                             \
+    if (ret != cudaSuccess && ret != cudaErrorNotReady) {                     \
+      TC_LOG(ERROR, comm_) << "Graph monitor: CUDA error during "             \
+                           << (event_desc) << " for graph " << graph_id       \
+                           << " collective " << i << ": "                     \
+                           << api->getErrorString(ret) << " (" << ret << ")"; \
+      return CheckResult::ERROR;                                              \
+    }                                                                         \
+  } while (0)
+
+// Timeout detection for graph-captured collectives.
+//
+// During a single replay, the GPU executes nodes in order:
+//   host_node (counter++) → start_event record → NCCL collective → end_event
+//   record
+//
+// The watchdog may poll at any point. Possible observations:
+//
+//   (1) Between replays (previous end=success, counter unchanged):
+//       end=success → reset timer. Correct: collective is done.
+//
+//   (2) New replay started, GPU past host_node but before event records:
+//       counter changed → replay detection resets timer.
+//       end still=success from previous replay → reset timer (redundant,
+//       harmless).
+//
+//   (3) GPU past event records, collective in progress:
+//       start=success, end=notReady → start/continue timer. Correct.
+//
+//   (4) GPU past host_node but before this collective's start_event:
+//       both notReady → reset timer. Correct: collective hasn't started.
+//
+// Without the replay counter, case (2) could be missed if the watchdog
+// never observes end=success between consecutive replays, causing the
+// timer to span N replays and false-trigger a timeout.
+GraphEventTracker::CheckResult GraphEventTracker::checkAll() {
+  CudaApi* api = comm_->getCudaApi();
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  // Cleanup released graphs
+  cleanupReleasedGraphs();
+
+  // Traverse remaining active graphs
+  for (auto& [graph_id, graph_state] : graphs_) {
+    uint64_t current_replay =
+        graph_state.shared_->replay_counter.load(std::memory_order_acquire);
+
+    for (size_t i = 0; i < graph_state.entries.size(); ++i) {
+      auto& entry = graph_state.entries[i];
+
+      // Detect new replay — reset timer to avoid false timeout spanning
+      // multiple replays
+      if (current_replay != entry.last_seen_replay) {
+        entry.start_completed_time.reset();
+        entry.last_seen_replay = current_replay;
+      }
+
+      cudaError_t start_status, end_status;
+      EVENT_QUERY_CHECK(
+          api->eventQuery(entry.start_event),
+          start_status,
+          "start event query");
+      EVENT_QUERY_CHECK(
+          api->eventQuery(entry.end_event), end_status, "end event query");
+
+      if (end_status == cudaSuccess) {
+        // Collective completed or no replay in progress
+        entry.start_completed_time.reset();
+      } else if (start_status == cudaSuccess) {
+        // Collective in progress — start or continue timing
+        if (!entry.start_completed_time.has_value()) {
+          entry.start_completed_time = std::chrono::steady_clock::now();
+        }
+        auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() -
+            entry.start_completed_time.value());
+        if (entry.timeout.count() >= 0 && elapsed > entry.timeout) {
+          TC_LOG(ERROR, comm_)
+              << "Graph monitor: collective TIMED OUT for graph " << graph_id
+              << " collective " << i << " on rank " << comm_->getRank()
+              << " - elapsed " << elapsed.count() << "ms > timeout "
+              << entry.timeout.count() << "ms";
+          return CheckResult::TIMEOUT;
+        }
+      } else {
+        // Both notReady — replay started but haven't reached this collective
+        entry.start_completed_time.reset();
+      }
+    }
+  }
+  return CheckResult::OK;
+}
+
+#undef EVENT_QUERY_CHECK
+
+void GraphEventTracker::cleanupReleasedGraphs() {
+  CudaApi* api = comm_->getCudaApi();
+  for (auto it = graphs_.begin(); it != graphs_.end();) {
+    if (it->second.shared_->released.load(std::memory_order_relaxed)) {
+      for (auto& entry : it->second.entries) {
+        entry.destroyEvents(api);
+      }
+      it = graphs_.erase(it);
+    } else {
+      ++it;
+    }
+  }
+}
+
+void GraphEventTracker::destroyAll() {
+  CudaApi* api = comm_->getCudaApi();
+  std::lock_guard<std::mutex> lock(mutex_);
+  for (auto& [graph_id, graph_state] : graphs_) {
+    for (auto& entry : graph_state.entries) {
+      entry.destroyEvents(api);
+    }
+  }
+  graphs_.clear();
+}
+
+// Static callback — fires on each graph replay to increment counter
+void CUDART_CB GraphEventTracker::replayCallback(void* userData) {
+  auto* counter = static_cast<std::atomic<uint64_t>*>(userData);
+  counter->fetch_add(1, std::memory_order_release);
+}
+
+// Static callback — fires when graph is destroyed to set released flag
+void CUDART_CB GraphEventTracker::cleanupCallback(void* userData) {
+  static_cast<std::atomic<bool>*>(userData)->store(
+      true, std::memory_order_relaxed);
+}
+
+} // namespace torch::comms

--- a/comms/torchcomms/ncclx/GraphEventTracker.hpp
+++ b/comms/torchcomms/ncclx/GraphEventTracker.hpp
@@ -1,0 +1,126 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <mutex>
+#include <optional>
+#include <unordered_map>
+#include <vector>
+
+#include <cuda_runtime.h> // @manual=third-party//cuda:cuda-lazy
+
+#include "comms/torchcomms/device/cuda/CudaApi.hpp"
+
+namespace torch::comms {
+
+// Forward declarations
+class TorchCommNCCLX;
+class TorchWorkNCCLX;
+
+// Tracks a single graph-captured collective for timeout detection.
+struct GraphWork {
+  cudaEvent_t start_event; // OWNED — ad-hoc created, destroyed on cleanup
+  cudaEvent_t end_event; // OWNED — ad-hoc created, destroyed on cleanup
+  std::chrono::milliseconds timeout;
+  std::optional<std::chrono::steady_clock::time_point> start_completed_time;
+  uint64_t last_seen_replay{0};
+
+  GraphWork(cudaEvent_t start, cudaEvent_t end, std::chrono::milliseconds t)
+      : start_event(start), end_event(end), timeout(t) {}
+
+  void destroyEvents(CudaApi* api) {
+    (void)api->eventDestroy(start_event);
+    (void)api->eventDestroy(end_event);
+  }
+};
+
+// Shared state between CUDA callbacks and the tracker. Allocated from a static
+// pool so that callbacks only perform atomic stores, avoiding mutex acquisition
+// or CUDA API calls inside the callback (which violates CUDA docs). Resource is
+// automatically released when prcoess exits, so graph destruction and comm
+// finalization can occur in any order.
+struct SharedCallbackState {
+  std::atomic<uint64_t> replay_counter{0};
+  std::atomic<bool> released{false};
+};
+
+// Monitors graph-captured collectives for timeout/error after graph launch.
+//
+// CUDA graph capture turns each collective into a recorded node; the normal
+// eager-mode watchdog cannot monitor them.  GraphEventTracker solves this by
+// taking ownership of each collective's start/end CUDA events and polling
+// them from the watchdog thread.
+//
+// Replay detection: a host-node callback increments a per-graph atomic
+// counter on every replay so the watchdog can distinguish "not yet replayed"
+// from "stuck during a replay."
+//
+// Cleanup: a CUDA user-object callback sets a released flag when the graph
+// is destroyed.  The watchdog's next checkAll() call sees the flag and
+// destroys the owned events (deferred cleanup model — callbacks never call
+// CUDA APIs directly).
+//
+// Timeout-detection state machine (per collective, per replay):
+//
+//   start_event  end_event   → state
+//   ─────────────────────────────────────────────────
+//   COMPLETED    COMPLETED   → OK (reset timer)
+//   NOT REACHED  NOT REACHED → no replay in progress (reset timer)
+//   COMPLETED    NOT REACHED → IN PROGRESS (start / continue timer)
+//   NOT REACHED  COMPLETED   → impossible (would indicate a bug)
+//
+// The timer is also reset whenever a new replay is detected, preventing
+// false timeouts that would span multiple replays.
+class GraphEventTracker {
+ public:
+  enum class CheckResult { OK, TIMEOUT, ERROR };
+
+  explicit GraphEventTracker(TorchCommNCCLX* comm);
+  ~GraphEventTracker() = default;
+
+  // Non-copyable, non-movable (contains mutex)
+  GraphEventTracker(const GraphEventTracker&) = delete;
+  GraphEventTracker& operator=(const GraphEventTracker&) = delete;
+  GraphEventTracker(GraphEventTracker&&) = delete;
+  GraphEventTracker& operator=(GraphEventTracker&&) = delete;
+
+  // One-time initialization per graph during capture. Checks graph capture
+  // mode internally; no-op if not capturing. Must be called before the
+  // first collective's start_event is recorded on the stream.
+  void initOnGraphStart(cudaStream_t stream);
+  // Add a new entry for a captured collective. Takes ownership of the work's
+  // start/end events. Must be called after initOnGraphStart().
+  void addEntry(TorchWorkNCCLX* work);
+  // Check all entries for timeout or error. Called from the watchdog thread.
+  CheckResult checkAll();
+  // Destroy all owned events and replay counters. Called from finalize().
+  void destroyAll();
+
+ private:
+  // Static callback for CUDA user object cleanup — sets released flag
+  static void CUDART_CB cleanupCallback(void* userData);
+  // Static callback for replay detection (fires on each graph replay)
+  static void CUDART_CB replayCallback(void* userData);
+  // One-time per-graph setup: replay counter + cleanup user object.
+  // Must be called with mutex_ held.
+  void maybeInitGraphState(
+      cudaStream_t stream,
+      unsigned long long graph_id,
+      cudaGraph_t graph);
+  void cleanupReleasedGraphs();
+
+  struct GraphState {
+    std::vector<GraphWork> entries;
+    SharedCallbackState* shared_{nullptr};
+  };
+
+  TorchCommNCCLX* comm_; // raw pointer — parent owns this tracker
+  std::mutex mutex_;
+  // cached at initOnGraphStart() to be reused in addEntry() for each collective
+  unsigned long long current_graph_id_{0};
+  std::unordered_map<unsigned long long, GraphState> graphs_;
+};
+
+} // namespace torch::comms

--- a/comms/torchcomms/ncclx/TorchCommWindowNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommWindowNCCLX.cpp
@@ -189,6 +189,7 @@ c10::intrusive_ptr<TorchWork> TorchCommWindowNCCLX<Backend>::put(
 
   checkDeviceAndThrow(tensor);
   auto stream = torch_comm_->getOperationStream(asyncOp);
+  torch_comm_->graph_event_tracker_.initOnGraphStart(stream);
   auto work = torch_comm_->createWork(stream, options.timeout, {tensor});
   work->recordStart("put");
   CHECK_EQ(
@@ -234,6 +235,7 @@ c10::intrusive_ptr<TorchWork> TorchCommWindowNCCLX<Backend>::signal(
     const SignalOptions& options) {
   checkWindowAndThrow();
   auto stream = torch_comm_->getOperationStream(asyncOp);
+  torch_comm_->graph_event_tracker_.initOnGraphStart(stream);
   auto work = torch_comm_->createWork(stream, options.timeout);
   work->recordStart("signal");
   CHECK_EQ(nccl_api_->winSignal(peerRank, win_, stream), ncclSuccess);
@@ -250,6 +252,7 @@ c10::intrusive_ptr<TorchWork> TorchCommWindowNCCLX<Backend>::wait_signal(
   checkWindowAndThrow();
   auto stream = torch_comm_->getOperationStream(asyncOp);
 
+  torch_comm_->graph_event_tracker_.initOnGraphStart(stream);
   auto work = torch_comm_->createWork(stream, options.timeout);
   work->recordStart("wait_signal");
   CHECK_EQ(nccl_api_->winWaitSignal(peerRank, win_, stream), ncclSuccess);

--- a/comms/torchcomms/ncclx/docs/graph_timeout_design.md
+++ b/comms/torchcomms/ncclx/docs/graph_timeout_design.md
@@ -1,0 +1,164 @@
+# Graph Timeout Detection Design
+
+## Overview
+
+TorchCommNCCLX supports timeout detection for collectives during CUDA graph replay.
+Unlike eager mode where the watchdog queries per-work events from a FIFO queue,
+graph-captured collectives persist across replays and require a separate tracking
+mechanism. The `GraphEventTracker` class provides this functionality.
+
+## Architecture
+
+```text
+┌─────────────────────────────────────────────────────────────────┐
+│                      TorchCommNCCLX                             │
+│                                                                 │
+│  ┌──────────────────────┐    ┌──────────────────────────────┐  │
+│  │    Event Pool         │    │    Timeout Watchdog Thread    │  │
+│  │  (eager mode only)    │    │                              │  │
+│  │  getEvent()/          │    │  checkWorkQueue()            │  │
+│  │  returnEvent()        │    │    → eager work FIFO GC      │  │
+│  └──────────┬───────────┘    │                              │  │
+│             │                │  checkGraphEvents()           │  │
+│             │                │    → graph_event_tracker_     │  │
+│             │                │      .checkAll()              │  │
+│             │                └──────────────────────────────┘  │
+│             │                                                   │
+│  ┌──────────▼───────────────────────────────────────────────┐  │
+│  │                   TorchWorkNCCLX                          │  │
+│  │                                                           │  │
+│  │  start_event_  — start detection (pool / ad-hoc)          │  │
+│  │  end_event_    — completion detection (pool / ad-hoc)     │  │
+│  │  sync_event_   — stream join, graph only (nullptr eager)  │  │
+│  │                                                           │  │
+│  │  initEvents() / releaseEvents() — lifecycle management    │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  ┌─────────────────────────┐  ┌─────────────────────────────┐  │
+│  │  TorchWorkNCCLXQueue    │  │  GraphEventTracker           │  │
+│  │  (eager mode)           │  │  (graph mode)                │  │
+│  │                         │  │                               │  │
+│  │  Per-stream FIFO of     │  │  Per-graph GraphState:        │  │
+│  │  intrusive_ptr<Work>    │  │    vector<GraphWork>          │  │
+│  │                         │  │    atomic replay_counter      │  │
+│  │                         │  │                               │  │
+│  │  GC: pop when done      │  │  Cleanup via cudaUserObject   │  │
+│  │  Work dtor returns      │  │  Replay detect via host node  │  │
+│  │  events to pool         │  │                               │  │
+│  └─────────────────────────┘  └─────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Event Design
+
+### Why Three Events in Graph Mode
+
+CUDA graph capture records `cudaEventRecord` calls as graph nodes. Regular-recorded
+events become opaque during replay and cannot be queried from the host. To enable
+host-side timeout detection, we use `cudaEventRecordExternal` for start/end events,
+which creates EVENT_RECORD nodes that remain host-queryable during replay.
+
+However, externally-recorded events are NOT recognized by `cudaStreamWaitEvent` as
+valid stream join points (`cudaErrorStreamCaptureUnjoined`). So we need a third event
+(`sync_event_`) recorded with regular `cudaEventRecord` purely for `work.wait()`.
+
+| Event | Recording API | Purpose | Eager | Graph |
+|-------|--------------|---------|-------|-------|
+| `start_event_` | Eager: `cudaEventRecord` / Graph: `cudaEventRecordExternal` | Detect collective start | Pool | Ad-hoc, transferred to GraphWork |
+| `end_event_` | Eager: `cudaEventRecord` / Graph: `cudaEventRecordExternal` | Detect collective end, timeout detection | Pool | Ad-hoc, transferred to GraphWork |
+| `sync_event_` | `cudaEventRecord` (regular) | Stream join for `work.wait()` | N/A (nullptr) | Ad-hoc, destroyed in Work dtor |
+
+### Event Lifecycle
+
+**Eager mode:** Pool events, one-shot lifecycle.
+```text
+Pool.get() → Work ctor → record → watchdog query → GC → Work dtor → Pool.return()
+```
+
+**Graph mode:** Ad-hoc events, persistent across replays.
+```text
+Capture:  cudaEventCreate → Work ctor → record (External) → enqueueWork
+          → transfer start/end to GraphWork → Work dtor (destroys sync_event_ only)
+
+Replay:   GPU replays EVENT_RECORD_EXT nodes → watchdog queries → timeout check
+
+Cleanup:  Graph destruction → cudaUserObject callback sets released flag
+          → watchdog checkAll() → cleanupReleasedGraphs() → destroyEvents()
+```
+
+## GraphEventTracker Timeout Logic
+
+### State Machine
+
+During a single graph replay, the GPU executes nodes in this order:
+```text
+host_node (counter++) → start_event record → NCCL collective → end_event record
+```
+
+The watchdog polls `checkAll()` periodically, which queries each entry's events
+and determines the current state:
+
+```text
+                                  replay_counter changed
+                                 ┌────────────────────────┐
+                                 │                        │
+                                 ▼                        │
+                       ┌──────────────────┐               │
+            ┌─────────►│    COMPLETED     │───────────────┘
+            │          │  (between replays │
+            │          │   or coll done)   │
+            │          └────────┬─────────┘
+            │                   │ end = notReady
+            │                   │ start = notReady
+            │                   ▼
+            │          ┌──────────────────┐
+            │          │   NOT REACHED    │
+            │          │  (replay started │
+            │          │   but GPU before │
+            │          │   this coll)     │
+            │          └────────┬─────────┘
+            │                   │ start = success
+            │                   ▼
+  end =     │          ┌──────────────────┐
+  success   │          │   IN PROGRESS    │  elapsed > timeout
+            └──────────│  (start done,    │──────► abort()
+                       │   waiting end)   │
+                       └──────────────────┘
+```
+
+State detection (no enum — derived from event queries each poll):
+- **COMPLETED**: `end_event` query returns `cudaSuccess` → reset timer
+- **NOT REACHED**: both `start_event` and `end_event` return `cudaErrorNotReady` → reset timer
+- **IN PROGRESS**: `start_event` returns `cudaSuccess`, `end_event` returns `cudaErrorNotReady` → start/continue timer; if elapsed > timeout, return TIMEOUT
+
+### Replay Boundary Detection
+
+A CUDA host node (`launchHostFunc`) fires before any collective's start event in
+each replay, incrementing an `atomic<uint64_t>` replay counter. If the counter
+changes between polls, all timers reset — preventing false timeouts that span
+multiple replays.
+
+## Resource Cleanup
+
+Event cleanup uses a **deferred model** to avoid CUDA API calls and lock
+acquisition inside CUDA callbacks (which run on a shared internal thread per CUDA docs).
+
+Three paths ensure events are always destroyed:
+
+1. **Graph destruction → deferred cleanup**: The CUDA `cudaUserObject`
+   destructor (`cleanupCallback`) does a single atomic store:
+   `released.store(true)`. No lock, no CUDA calls. On the next watchdog poll,
+   `cleanupReleasedGraphs()` (called at the top of `checkAll()`) finds entries
+   with `released == true`, destroys their events, and erases the `GraphState`.
+
+2. **Comm finalization** (`destroyAll()`): Called from `TorchCommNCCLX::finalize()`.
+   Destroys all remaining events across all graphs unconditionally (regardless
+   of `released` flag). Handles cases where the comm is finalized before graphs
+   are destroyed.
+
+3. **Watchdog periodic cleanup**: `cleanupReleasedGraphs()` runs on every
+   `checkAll()` invocation, ensuring released graphs are cleaned up promptly
+   even without explicit finalization.
+
+All map/vector mutations happen under `mutex_`. The `cleanupCallback` is
+fully lock-free — it only writes to an atomic in the static pool.

--- a/comms/torchcomms/ncclx/tests/unit/cpp/GraphEventTrackerTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/GraphEventTrackerTest.cpp
@@ -1,0 +1,783 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTestBase.hpp"
+
+#include <algorithm>
+#include <vector>
+
+namespace torch::comms::test {
+
+class GraphEventTrackerTest : public TorchCommNCCLXTest {
+ protected:
+  struct GraphEvents {
+    cudaEvent_t start = reinterpret_cast<cudaEvent_t>(0xA001);
+    cudaEvent_t end = reinterpret_cast<cudaEvent_t>(0xA002);
+    cudaEvent_t sync = reinterpret_cast<cudaEvent_t>(0xA003);
+  };
+
+  CommOptions createAbortModeOptions(
+      std::chrono::milliseconds timeout = std::chrono::milliseconds(2000)) {
+    CommOptions options;
+    options.abort_process_on_timeout_or_error = true;
+    options.timeout = timeout;
+    options.store = store_;
+    return options;
+  }
+
+  void setupGraphCaptureMocks(
+      unsigned long long graph_id = 42,
+      cudaGraph_t graph = reinterpret_cast<cudaGraph_t>(0xB000)) {
+    ON_CALL(*cuda_mock_, streamIsCapturing(_, _))
+        .WillByDefault(DoAll(
+            SetArgPointee<1>(cudaStreamCaptureStatusActive),
+            Return(cudaSuccess)));
+    ON_CALL(*cuda_mock_, streamGetCaptureInfo_v2(_, _, _, _, _, _))
+        .WillByDefault(DoAll(
+            SetArgPointee<1>(cudaStreamCaptureStatusActive),
+            SetArgPointee<2>(graph_id),
+            SetArgPointee<3>(graph),
+            Return(cudaSuccess)));
+    ON_CALL(*cuda_mock_, launchHostFunc(_, _, _))
+        .WillByDefault(Return(cudaSuccess));
+    ON_CALL(*cuda_mock_, userObjectCreate(_, _, _, _, _))
+        .WillByDefault(DoAll(
+            SetArgPointee<0>(reinterpret_cast<cudaUserObject_t>(0x3000)),
+            Return(cudaSuccess)));
+    ON_CALL(*cuda_mock_, graphRetainUserObject(_, _, _, _))
+        .WillByDefault(Return(cudaSuccess));
+  }
+
+  GraphEvents setupGraphCaptureEvents() {
+    GraphEvents events;
+    EXPECT_CALL(*cuda_mock_, eventCreateWithFlags(_, _))
+        .WillOnce(DoAll(SetArgPointee<0>(events.start), Return(cudaSuccess)))
+        .WillOnce(DoAll(SetArgPointee<0>(events.end), Return(cudaSuccess)))
+        .WillOnce(DoAll(SetArgPointee<0>(events.sync), Return(cudaSuccess)))
+        .WillRepeatedly(DoAll(
+            SetArgPointee<0>(reinterpret_cast<cudaEvent_t>(0xA100)),
+            Return(cudaSuccess)));
+    return events;
+  }
+
+  void setupEventRecordMocks() {
+    ON_CALL(*cuda_mock_, eventRecord(_, _)).WillByDefault(Return(cudaSuccess));
+    ON_CALL(*cuda_mock_, eventRecordWithFlags(_, _, _))
+        .WillByDefault(Return(cudaSuccess));
+  }
+
+  void switchToReplayMode() {
+    ON_CALL(*cuda_mock_, streamIsCapturing(_, _))
+        .WillByDefault(DoAll(
+            SetArgPointee<1>(cudaStreamCaptureStatusNone),
+            Return(cudaSuccess)));
+  }
+
+  void setupFinalizeExpectations(TestTorchCommNCCLX& comm) {
+    EXPECT_CALL(*cuda_mock_, eventDestroy(_))
+        .WillRepeatedly(Return(cudaSuccess));
+    EXPECT_CALL(*cuda_mock_, free(_)).WillOnce(Return(cudaSuccess));
+    EXPECT_CALL(*cuda_mock_, streamDestroy(_)).WillOnce(Return(cudaSuccess));
+    EXPECT_CALL(*nccl_mock_, commDestroy(_)).WillOnce(Return(ncclSuccess));
+    comm.finalize();
+  }
+};
+
+TEST_F(GraphEventTrackerTest, GraphTimeoutCausesProcessDeath) {
+  setupCCAExpectations(0, 0, 1);
+
+  EXPECT_DEATH(
+      {
+        cuda_mock_->setupDefaultBehaviors();
+        nccl_mock_->setupDefaultBehaviors();
+
+        auto options = createAbortModeOptions(std::chrono::milliseconds(100));
+        auto comm = createMockedTorchComm();
+        comm->init(*device_, "test_graph_timeout", options);
+
+        setupGraphCaptureMocks();
+        auto events = setupGraphCaptureEvents();
+        setupEventRecordMocks();
+
+        auto tensor = createTestTensor({10, 10});
+        auto work = comm->send(tensor, 1, true);
+
+        switchToReplayMode();
+
+        ON_CALL(*cuda_mock_, eventQuery(events.start))
+            .WillByDefault(Return(cudaSuccess));
+        ON_CALL(*cuda_mock_, eventQuery(events.end))
+            .WillByDefault(Return(cudaErrorNotReady));
+
+        std::this_thread::sleep_for(std::chrono::seconds(5));
+      },
+      "Graph monitor: collective TIMED OUT for graph");
+}
+
+TEST_F(
+    GraphEventTrackerTest,
+    GraphTimeoutAfterSuccessfulReplayCausesProcessDeath) {
+  setupCCAExpectations(0, 0, 1);
+
+  // After a first replay completes, a second that hangs is still detected
+  // as a timeout.  The sequence:
+  //   1. end_event NOT REACHED  (first poll — replay in progress)
+  //   2. end_event COMPLETED    (first replay finishes — timer resets)
+  //   3. end_event NOT REACHED  (second replay hangs)
+  //   ... timer counts from step 3 and eventually fires.
+  // start_event is always COMPLETED because the hang is *after* the
+  // collective starts.
+  EXPECT_DEATH(
+      {
+        cuda_mock_->setupDefaultBehaviors();
+        nccl_mock_->setupDefaultBehaviors();
+
+        auto options = createAbortModeOptions(std::chrono::milliseconds(100));
+        auto comm = createMockedTorchComm();
+        comm->init(*device_, "test_graph_timeout_after_success", options);
+
+        setupGraphCaptureMocks();
+        auto events = setupGraphCaptureEvents();
+        setupEventRecordMocks();
+
+        auto tensor = createTestTensor({10, 10});
+        auto work = comm->send(tensor, 1, true);
+
+        switchToReplayMode();
+
+        EXPECT_CALL(*cuda_mock_, eventQuery(events.end))
+            .WillOnce(Return(cudaErrorNotReady))
+            .WillOnce(Return(cudaSuccess))
+            .WillRepeatedly(Return(cudaErrorNotReady));
+
+        EXPECT_CALL(*cuda_mock_, eventQuery(events.start))
+            .WillRepeatedly(Return(cudaSuccess));
+
+        std::this_thread::sleep_for(std::chrono::seconds(5));
+      },
+      "Graph monitor: collective TIMED OUT for graph");
+}
+
+TEST_F(GraphEventTrackerTest, GraphCaptureRejectsNoAbortMode) {
+  setupCCAExpectations(1, 2, 1);
+
+  auto comm = createMockedTorchComm();
+  cuda_mock_->setupDefaultBehaviors();
+  nccl_mock_->setupDefaultBehaviors();
+  comm->init(*device_, "test_graph_no_abort", default_options_);
+
+  setupGraphCaptureMocks();
+
+  auto tensor = createTestTensor({10, 10});
+
+  EXPECT_THROW(
+      {
+        try {
+          auto work = comm->send(tensor, 1, true);
+        } catch (const std::runtime_error& e) {
+          std::string error_msg = e.what();
+          EXPECT_TRUE(
+              error_msg.find("abort_process_on_timeout_or_error=true") !=
+              std::string::npos);
+          throw;
+        }
+      },
+      std::runtime_error);
+
+  switchToReplayMode();
+  setupFinalizeExpectations(*comm);
+}
+
+TEST_F(GraphEventTrackerTest, GraphCaptureWorkObjectsDestroyedAfterCapture) {
+  setupCCAExpectations(1, 2, 1);
+
+  auto comm = createMockedTorchComm();
+  cuda_mock_->setupDefaultBehaviors();
+  nccl_mock_->setupDefaultBehaviors();
+
+  auto options = createAbortModeOptions();
+  comm->init(*device_, "test_graph_work_destroyed", options);
+
+  setupGraphCaptureMocks();
+  auto events = setupGraphCaptureEvents();
+
+  auto tensor = createTestTensor({10, 10});
+
+  EXPECT_CALL(*cuda_mock_, eventDestroy(events.sync))
+      .WillOnce(Return(cudaSuccess));
+
+  {
+    auto work = comm->send(tensor, 1, true);
+  }
+
+  ::testing::Mock::VerifyAndClearExpectations(cuda_mock_.get());
+
+  switchToReplayMode();
+  setupFinalizeExpectations(*comm);
+}
+
+TEST_F(GraphEventTrackerTest, GraphDestroyCleanupDestroysMonitorEvents) {
+  setupCCAExpectations(1, 2, 1);
+
+  auto comm = createMockedTorchComm();
+  cuda_mock_->setupDefaultBehaviors();
+  nccl_mock_->setupDefaultBehaviors();
+
+  auto options = createAbortModeOptions();
+  comm->init(*device_, "test_graph_destroy_cleanup", options);
+
+  setupGraphCaptureMocks();
+  setupGraphCaptureEvents();
+
+  void* captured_cleanup_data = nullptr;
+  cudaHostFn_t captured_cleanup_fn = nullptr;
+  // Override userObjectCreate to capture the cleanup callback
+  EXPECT_CALL(*cuda_mock_, userObjectCreate(_, _, _, _, _))
+      .WillOnce(DoAll(
+          SetArgPointee<0>(reinterpret_cast<cudaUserObject_t>(0x3000)),
+          SaveArg<1>(&captured_cleanup_data),
+          SaveArg<2>(&captured_cleanup_fn),
+          Return(cudaSuccess)));
+
+  auto tensor = createTestTensor({10, 10});
+
+  {
+    auto work = comm->send(tensor, 1, true);
+  }
+
+  ASSERT_NE(captured_cleanup_fn, nullptr);
+  ASSERT_NE(captured_cleanup_data, nullptr);
+
+  ::testing::Mock::VerifyAndClearExpectations(cuda_mock_.get());
+
+  // Invoke cleanup callback — should only set released flag, NO eventDestroy
+  EXPECT_CALL(*cuda_mock_, eventDestroy(_)).Times(0);
+  captured_cleanup_fn(captured_cleanup_data);
+  ::testing::Mock::VerifyAndClearExpectations(cuda_mock_.get());
+
+  // Events destroyed during finalize (which calls destroyAll)
+  switchToReplayMode();
+  setupFinalizeExpectations(*comm);
+}
+
+TEST_F(GraphEventTrackerTest, CheckAllReturnsOKWhenNoEntries) {
+  setupCCAExpectations(1, 2, 1);
+
+  auto comm = createMockedTorchComm();
+  cuda_mock_->setupDefaultBehaviors();
+  nccl_mock_->setupDefaultBehaviors();
+
+  auto options = createAbortModeOptions();
+  comm->init(*device_, "test_empty_graph_check", options);
+
+  auto tensor = createTestTensor({10, 10});
+
+  setupEventsForWork(*comm, 1);
+  auto work = comm->send(tensor, 1, true);
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+  WorkEvent& we = work_events_[0];
+  ON_CALL(*cuda_mock_, eventQuery(we.start_event))
+      .WillByDefault(Return(cudaSuccess));
+  ON_CALL(*cuda_mock_, eventQuery(we.end_event))
+      .WillByDefault(Return(cudaSuccess));
+
+  setupFinalizeExpectations(*comm);
+}
+
+TEST_F(GraphEventTrackerTest, CheckAllReturnsErrorOnCudaFailure) {
+  setupCCAExpectations(0, 0, 1);
+
+  EXPECT_DEATH(
+      {
+        cuda_mock_->setupDefaultBehaviors();
+        nccl_mock_->setupDefaultBehaviors();
+
+        auto options = createAbortModeOptions();
+        auto comm = createMockedTorchComm();
+        comm->init(*device_, "test_graph_cuda_error", options);
+
+        setupGraphCaptureMocks();
+        auto events = setupGraphCaptureEvents();
+        setupEventRecordMocks();
+
+        auto tensor = createTestTensor({10, 10});
+        auto work = comm->send(tensor, 1, true);
+
+        switchToReplayMode();
+
+        ON_CALL(*cuda_mock_, eventQuery(events.start))
+            .WillByDefault(Return(cudaErrorInvalidValue));
+
+        std::this_thread::sleep_for(std::chrono::seconds(5));
+      },
+      ".*");
+}
+
+TEST_F(GraphEventTrackerTest, ReplayCounterResetsTimer) {
+  setupCCAExpectations(1, 2, 1);
+
+  cuda_mock_->setupDefaultBehaviors();
+  nccl_mock_->setupDefaultBehaviors();
+
+  auto options = createAbortModeOptions(std::chrono::milliseconds(200));
+  auto comm = createMockedTorchComm();
+  comm->init(*device_, "test_replay_counter_reset", options);
+
+  setupGraphCaptureMocks();
+  auto events = setupGraphCaptureEvents();
+  setupEventRecordMocks();
+
+  cudaHostFn_t captured_replay_fn = nullptr;
+  void* captured_replay_data = nullptr;
+  // Override launchHostFunc to capture the replay callback
+  ON_CALL(*cuda_mock_, launchHostFunc(_, _, _))
+      .WillByDefault(DoAll(
+          SaveArg<1>(&captured_replay_fn),
+          SaveArg<2>(&captured_replay_data),
+          Return(cudaSuccess)));
+
+  auto tensor = createTestTensor({10, 10});
+  auto work = comm->send(tensor, 1, true);
+
+  switchToReplayMode();
+
+  ON_CALL(*cuda_mock_, eventQuery(events.start))
+      .WillByDefault(Return(cudaSuccess));
+  ON_CALL(*cuda_mock_, eventQuery(events.end))
+      .WillByDefault(Return(cudaErrorNotReady));
+
+  ASSERT_NE(captured_replay_fn, nullptr);
+  ASSERT_NE(captured_replay_data, nullptr);
+
+  std::atomic<bool> stop_replays{false};
+  std::thread replay_thread([&]() {
+    while (!stop_replays.load()) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      if (!stop_replays.load()) {
+        captured_replay_fn(captured_replay_data);
+      }
+    }
+  });
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(800));
+
+  stop_replays.store(true);
+  replay_thread.join();
+
+  ON_CALL(*cuda_mock_, eventQuery(events.end))
+      .WillByDefault(Return(cudaSuccess));
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(300));
+
+  ::testing::Mock::VerifyAndClearExpectations(cuda_mock_.get());
+  setupFinalizeExpectations(*comm);
+}
+
+// destroyAll should destroy exactly the entry-owned events. We track which
+// events are destroyed to verify precise cleanup.
+TEST_F(GraphEventTrackerTest, DestroyAllCleansUpGraphEntryEvents) {
+  setupCCAExpectations(1, 2, 1);
+
+  auto comm = createMockedTorchComm();
+  cuda_mock_->setupDefaultBehaviors();
+  nccl_mock_->setupDefaultBehaviors();
+
+  auto options = createAbortModeOptions();
+  comm->init(*device_, "test_destroy_all_cleanup", options);
+
+  setupGraphCaptureMocks();
+  auto events = setupGraphCaptureEvents();
+
+  auto tensor = createTestTensor({10, 10});
+
+  EXPECT_CALL(*cuda_mock_, eventDestroy(events.sync))
+      .WillOnce(Return(cudaSuccess));
+
+  {
+    auto work = comm->send(tensor, 1, true);
+  }
+
+  ::testing::Mock::VerifyAndClearExpectations(cuda_mock_.get());
+
+  switchToReplayMode();
+
+  std::vector<cudaEvent_t> destroyed_events;
+  EXPECT_CALL(*cuda_mock_, eventDestroy(_))
+      .WillRepeatedly(DoAll(
+          Invoke([&destroyed_events](cudaEvent_t event) {
+            destroyed_events.push_back(event);
+          }),
+          Return(cudaSuccess)));
+  EXPECT_CALL(*cuda_mock_, free(_)).WillOnce(Return(cudaSuccess));
+  EXPECT_CALL(*cuda_mock_, streamDestroy(_)).WillOnce(Return(cudaSuccess));
+  EXPECT_CALL(*nccl_mock_, commDestroy(_)).WillOnce(Return(ncclSuccess));
+
+  comm->finalize();
+
+  EXPECT_TRUE(
+      std::find(
+          destroyed_events.begin(), destroyed_events.end(), events.start) !=
+      destroyed_events.end())
+      << "start event was not destroyed by destroyAll";
+  EXPECT_TRUE(
+      std::find(destroyed_events.begin(), destroyed_events.end(), events.end) !=
+      destroyed_events.end())
+      << "end event was not destroyed by destroyAll";
+}
+
+// Verify that the cleanup callback only sets the released flag when a graph
+// contains multiple captured collectives, without destroying events directly.
+TEST_F(GraphEventTrackerTest, MultipleCollectivesInSameGraphCleanedUp) {
+  setupCCAExpectations(1, 2, 1);
+
+  auto comm = createMockedTorchComm();
+  cuda_mock_->setupDefaultBehaviors();
+  nccl_mock_->setupDefaultBehaviors();
+
+  auto options = createAbortModeOptions();
+  comm->init(*device_, "test_multi_collective_cleanup", options);
+
+  setupGraphCaptureMocks();
+
+  // Two collectives: each creates 3 events (start, end, sync)
+  cudaEvent_t start1 = reinterpret_cast<cudaEvent_t>(0xA001);
+  cudaEvent_t end1 = reinterpret_cast<cudaEvent_t>(0xA002);
+  cudaEvent_t sync1 = reinterpret_cast<cudaEvent_t>(0xA003);
+  cudaEvent_t start2 = reinterpret_cast<cudaEvent_t>(0xA004);
+  cudaEvent_t end2 = reinterpret_cast<cudaEvent_t>(0xA005);
+  cudaEvent_t sync2 = reinterpret_cast<cudaEvent_t>(0xA006);
+
+  EXPECT_CALL(*cuda_mock_, eventCreateWithFlags(_, _))
+      .WillOnce(DoAll(SetArgPointee<0>(start1), Return(cudaSuccess)))
+      .WillOnce(DoAll(SetArgPointee<0>(end1), Return(cudaSuccess)))
+      .WillOnce(DoAll(SetArgPointee<0>(sync1), Return(cudaSuccess)))
+      .WillOnce(DoAll(SetArgPointee<0>(start2), Return(cudaSuccess)))
+      .WillOnce(DoAll(SetArgPointee<0>(end2), Return(cudaSuccess)))
+      .WillOnce(DoAll(SetArgPointee<0>(sync2), Return(cudaSuccess)))
+      .WillRepeatedly(DoAll(
+          SetArgPointee<0>(reinterpret_cast<cudaEvent_t>(0xA100)),
+          Return(cudaSuccess)));
+
+  void* captured_cleanup_data = nullptr;
+  cudaHostFn_t captured_cleanup_fn = nullptr;
+  // Capture the cleanup callback
+  EXPECT_CALL(*cuda_mock_, userObjectCreate(_, _, _, _, _))
+      .WillOnce(DoAll(
+          SetArgPointee<0>(reinterpret_cast<cudaUserObject_t>(0x3000)),
+          SaveArg<1>(&captured_cleanup_data),
+          SaveArg<2>(&captured_cleanup_fn),
+          Return(cudaSuccess)));
+
+  auto tensor = createTestTensor({10, 10});
+
+  {
+    auto work1 = comm->send(tensor, 1, true);
+    auto work2 = comm->send(tensor, 1, true);
+  }
+
+  ASSERT_NE(captured_cleanup_fn, nullptr);
+  ASSERT_NE(captured_cleanup_data, nullptr);
+
+  ::testing::Mock::VerifyAndClearExpectations(cuda_mock_.get());
+
+  // Invoke cleanup callback — should only set released flag, NO eventDestroy
+  EXPECT_CALL(*cuda_mock_, eventDestroy(_)).Times(0);
+  captured_cleanup_fn(captured_cleanup_data);
+  ::testing::Mock::VerifyAndClearExpectations(cuda_mock_.get());
+
+  // Events destroyed during finalize
+  switchToReplayMode();
+  setupFinalizeExpectations(*comm);
+}
+
+// Verify that when userObjectCreate fails during graph capture init,
+// the pool entry is harmless (no leak) and the error propagates.
+TEST_F(GraphEventTrackerTest, UserObjectCreateFailureCleanup) {
+  setupCCAExpectations(1, 2, 1);
+
+  auto comm = createMockedTorchComm();
+  cuda_mock_->setupDefaultBehaviors();
+  nccl_mock_->setupDefaultBehaviors();
+
+  auto options = createAbortModeOptions();
+  comm->init(*device_, "test_user_object_create_failure", options);
+
+  setupGraphCaptureMocks();
+
+  // Override userObjectCreate to fail
+  ON_CALL(*cuda_mock_, userObjectCreate(_, _, _, _, _))
+      .WillByDefault(Return(cudaErrorMemoryAllocation));
+
+  auto tensor = createTestTensor({10, 10});
+
+  // send() should throw because userObjectCreate fails during graph init
+  EXPECT_THROW(comm->send(tensor, 1, true), std::runtime_error);
+
+  switchToReplayMode();
+
+  // The work was never fully created, so cleanup needs to handle the
+  // partially-initialized state gracefully.
+  EXPECT_CALL(*cuda_mock_, eventDestroy(_)).WillRepeatedly(Return(cudaSuccess));
+  EXPECT_CALL(*cuda_mock_, free(_)).WillOnce(Return(cudaSuccess));
+  EXPECT_CALL(*cuda_mock_, streamDestroy(_)).WillOnce(Return(cudaSuccess));
+  EXPECT_CALL(*nccl_mock_, commDestroy(_)).WillOnce(Return(ncclSuccess));
+
+  comm->finalize();
+}
+
+// Verify that when graphRetainUserObject fails, the RAII guard releases the
+// user_object (via userObjectRelease) and the error propagates.
+TEST_F(GraphEventTrackerTest, GraphRetainUserObjectFailureCleanup) {
+  setupCCAExpectations(1, 2, 1);
+
+  auto comm = createMockedTorchComm();
+  cuda_mock_->setupDefaultBehaviors();
+  nccl_mock_->setupDefaultBehaviors();
+
+  auto options = createAbortModeOptions();
+  comm->init(*device_, "test_graph_retain_failure", options);
+
+  setupGraphCaptureMocks();
+
+  // Override graphRetainUserObject to fail
+  ON_CALL(*cuda_mock_, graphRetainUserObject(_, _, _, _))
+      .WillByDefault(Return(cudaErrorInvalidValue));
+
+  // userObjectRelease should be called by the RAII guard
+  EXPECT_CALL(*cuda_mock_, userObjectRelease(_, _))
+      .WillOnce(Return(cudaSuccess));
+
+  auto tensor = createTestTensor({10, 10});
+
+  EXPECT_THROW(comm->send(tensor, 1, true), std::runtime_error);
+
+  switchToReplayMode();
+
+  EXPECT_CALL(*cuda_mock_, eventDestroy(_)).WillRepeatedly(Return(cudaSuccess));
+  EXPECT_CALL(*cuda_mock_, free(_)).WillOnce(Return(cudaSuccess));
+  EXPECT_CALL(*cuda_mock_, streamDestroy(_)).WillOnce(Return(cudaSuccess));
+  EXPECT_CALL(*nccl_mock_, commDestroy(_)).WillOnce(Return(ncclSuccess));
+
+  comm->finalize();
+}
+
+TEST_F(GraphEventTrackerTest, CheckAllCleansUpReleasedGraphs) {
+  setupCCAExpectations(1, 2, 1);
+
+  auto comm = createMockedTorchComm();
+  cuda_mock_->setupDefaultBehaviors();
+  nccl_mock_->setupDefaultBehaviors();
+
+  auto options = createAbortModeOptions();
+  comm->init(*device_, "test_checkall_cleanup", options);
+
+  setupGraphCaptureMocks();
+  auto events = setupGraphCaptureEvents();
+
+  void* captured_cleanup_data = nullptr;
+  cudaHostFn_t captured_cleanup_fn = nullptr;
+  EXPECT_CALL(*cuda_mock_, userObjectCreate(_, _, _, _, _))
+      .WillOnce(DoAll(
+          SetArgPointee<0>(reinterpret_cast<cudaUserObject_t>(0x3000)),
+          SaveArg<1>(&captured_cleanup_data),
+          SaveArg<2>(&captured_cleanup_fn),
+          Return(cudaSuccess)));
+
+  auto tensor = createTestTensor({10, 10});
+
+  {
+    auto work = comm->send(tensor, 1, true);
+  }
+
+  ASSERT_NE(captured_cleanup_fn, nullptr);
+  ASSERT_NE(captured_cleanup_data, nullptr);
+
+  ::testing::Mock::VerifyAndClearExpectations(cuda_mock_.get());
+
+  switchToReplayMode();
+
+  // Invoke cleanup callback — sets released flag
+  captured_cleanup_fn(captured_cleanup_data);
+
+  // checkGraphEvents calls checkAll which calls cleanupReleasedGraphs
+  EXPECT_CALL(*cuda_mock_, eventDestroy(events.start))
+      .WillOnce(Return(cudaSuccess));
+  EXPECT_CALL(*cuda_mock_, eventDestroy(events.end))
+      .WillOnce(Return(cudaSuccess));
+
+  comm->checkGraphEvents();
+
+  ::testing::Mock::VerifyAndClearExpectations(cuda_mock_.get());
+
+  // finalize should have nothing to clean up (already cleaned by checkAll)
+  setupFinalizeExpectations(*comm);
+}
+
+TEST_F(GraphEventTrackerTest, MultipleGraphsOnlyReleasedOneCleanedUp) {
+  setupCCAExpectations(1, 2, 1);
+
+  auto comm = createMockedTorchComm();
+  cuda_mock_->setupDefaultBehaviors();
+  nccl_mock_->setupDefaultBehaviors();
+
+  auto options = createAbortModeOptions();
+  comm->init(*device_, "test_multi_graph_partial_cleanup", options);
+
+  cudaEvent_t start1 = reinterpret_cast<cudaEvent_t>(0xC001);
+  cudaEvent_t end1 = reinterpret_cast<cudaEvent_t>(0xC002);
+  cudaEvent_t sync1 = reinterpret_cast<cudaEvent_t>(0xC003);
+  cudaEvent_t start2 = reinterpret_cast<cudaEvent_t>(0xC004);
+  cudaEvent_t end2 = reinterpret_cast<cudaEvent_t>(0xC005);
+  cudaEvent_t sync2 = reinterpret_cast<cudaEvent_t>(0xC006);
+
+  void* cleanup_data_1 = nullptr;
+  cudaHostFn_t cleanup_fn_1 = nullptr;
+
+  setupGraphCaptureMocks(/*graph_id=*/100);
+
+  EXPECT_CALL(*cuda_mock_, eventCreateWithFlags(_, _))
+      .WillOnce(DoAll(SetArgPointee<0>(start1), Return(cudaSuccess)))
+      .WillOnce(DoAll(SetArgPointee<0>(end1), Return(cudaSuccess)))
+      .WillOnce(DoAll(SetArgPointee<0>(sync1), Return(cudaSuccess)))
+      .WillRepeatedly(DoAll(
+          SetArgPointee<0>(reinterpret_cast<cudaEvent_t>(0xA100)),
+          Return(cudaSuccess)));
+
+  EXPECT_CALL(*cuda_mock_, userObjectCreate(_, _, _, _, _))
+      .WillOnce(DoAll(
+          SetArgPointee<0>(reinterpret_cast<cudaUserObject_t>(0x3000)),
+          SaveArg<1>(&cleanup_data_1),
+          SaveArg<2>(&cleanup_fn_1),
+          Return(cudaSuccess)));
+
+  auto tensor = createTestTensor({10, 10});
+
+  {
+    auto work1 = comm->send(tensor, 1, true);
+  }
+
+  ASSERT_NE(cleanup_fn_1, nullptr);
+  ASSERT_NE(cleanup_data_1, nullptr);
+
+  ::testing::Mock::VerifyAndClearExpectations(cuda_mock_.get());
+  cuda_mock_->setupDefaultBehaviors();
+
+  void* cleanup_data_2 = nullptr;
+  cudaHostFn_t cleanup_fn_2 = nullptr;
+
+  setupGraphCaptureMocks(
+      /*graph_id=*/200, reinterpret_cast<cudaGraph_t>(0xB001));
+
+  EXPECT_CALL(*cuda_mock_, eventCreateWithFlags(_, _))
+      .WillOnce(DoAll(SetArgPointee<0>(start2), Return(cudaSuccess)))
+      .WillOnce(DoAll(SetArgPointee<0>(end2), Return(cudaSuccess)))
+      .WillOnce(DoAll(SetArgPointee<0>(sync2), Return(cudaSuccess)))
+      .WillRepeatedly(DoAll(
+          SetArgPointee<0>(reinterpret_cast<cudaEvent_t>(0xA100)),
+          Return(cudaSuccess)));
+
+  EXPECT_CALL(*cuda_mock_, userObjectCreate(_, _, _, _, _))
+      .WillOnce(DoAll(
+          SetArgPointee<0>(reinterpret_cast<cudaUserObject_t>(0x3001)),
+          SaveArg<1>(&cleanup_data_2),
+          SaveArg<2>(&cleanup_fn_2),
+          Return(cudaSuccess)));
+
+  {
+    auto work2 = comm->send(tensor, 1, true);
+  }
+
+  ASSERT_NE(cleanup_fn_2, nullptr);
+  ASSERT_NE(cleanup_data_2, nullptr);
+
+  ::testing::Mock::VerifyAndClearExpectations(cuda_mock_.get());
+
+  switchToReplayMode();
+
+  // Release only graph 1
+  cleanup_fn_1(cleanup_data_1);
+
+  // checkAll should destroy graph 1's events but not graph 2's
+  EXPECT_CALL(*cuda_mock_, eventDestroy(start1)).WillOnce(Return(cudaSuccess));
+  EXPECT_CALL(*cuda_mock_, eventDestroy(end1)).WillOnce(Return(cudaSuccess));
+  EXPECT_CALL(*cuda_mock_, eventDestroy(start2)).Times(0);
+  EXPECT_CALL(*cuda_mock_, eventDestroy(end2)).Times(0);
+
+  ON_CALL(*cuda_mock_, eventQuery(start2))
+      .WillByDefault(Return(cudaErrorNotReady));
+  ON_CALL(*cuda_mock_, eventQuery(end2))
+      .WillByDefault(Return(cudaErrorNotReady));
+
+  comm->checkGraphEvents();
+
+  ::testing::Mock::VerifyAndClearExpectations(cuda_mock_.get());
+
+  // finalize should destroy graph 2's events
+  setupFinalizeExpectations(*comm);
+}
+
+TEST_F(GraphEventTrackerTest, DestroyAllIgnoresReleasedFlag) {
+  setupCCAExpectations(1, 2, 1);
+
+  auto comm = createMockedTorchComm();
+  cuda_mock_->setupDefaultBehaviors();
+  nccl_mock_->setupDefaultBehaviors();
+
+  auto options = createAbortModeOptions();
+  comm->init(*device_, "test_destroy_all_ignores_flag", options);
+
+  setupGraphCaptureMocks();
+  auto events = setupGraphCaptureEvents();
+
+  void* captured_cleanup_data = nullptr;
+  cudaHostFn_t captured_cleanup_fn = nullptr;
+  EXPECT_CALL(*cuda_mock_, userObjectCreate(_, _, _, _, _))
+      .WillOnce(DoAll(
+          SetArgPointee<0>(reinterpret_cast<cudaUserObject_t>(0x3000)),
+          SaveArg<1>(&captured_cleanup_data),
+          SaveArg<2>(&captured_cleanup_fn),
+          Return(cudaSuccess)));
+
+  auto tensor = createTestTensor({10, 10});
+
+  {
+    auto work = comm->send(tensor, 1, true);
+  }
+
+  ASSERT_NE(captured_cleanup_fn, nullptr);
+  ASSERT_NE(captured_cleanup_data, nullptr);
+
+  ::testing::Mock::VerifyAndClearExpectations(cuda_mock_.get());
+
+  // Set released flag — but destroyAll should still clean up
+  captured_cleanup_fn(captured_cleanup_data);
+
+  switchToReplayMode();
+
+  // destroyAll (via finalize) should destroy events regardless of released flag
+  std::vector<cudaEvent_t> destroyed_events;
+  EXPECT_CALL(*cuda_mock_, eventDestroy(_))
+      .WillRepeatedly(DoAll(
+          Invoke([&destroyed_events](cudaEvent_t event) {
+            destroyed_events.push_back(event);
+          }),
+          Return(cudaSuccess)));
+  EXPECT_CALL(*cuda_mock_, free(_)).WillOnce(Return(cudaSuccess));
+  EXPECT_CALL(*cuda_mock_, streamDestroy(_)).WillOnce(Return(cudaSuccess));
+  EXPECT_CALL(*nccl_mock_, commDestroy(_)).WillOnce(Return(ncclSuccess));
+
+  comm->finalize();
+
+  EXPECT_TRUE(
+      std::find(
+          destroyed_events.begin(), destroyed_events.end(), events.start) !=
+      destroyed_events.end())
+      << "start event was not destroyed by destroyAll";
+  EXPECT_TRUE(
+      std::find(destroyed_events.begin(), destroyed_events.end(), events.end) !=
+      destroyed_events.end())
+      << "end event was not destroyed by destroyAll";
+}
+
+} // namespace torch::comms::test

--- a/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTestBase.hpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTestBase.hpp
@@ -83,6 +83,10 @@ class TorchCommNCCLXTest : public ::testing::Test {
     cudaEvent_t getAsyncDependencyEvent() const {
       return dependency_event_;
     }
+
+    void checkGraphEvents() {
+      TorchCommNCCLX::checkGraphEvents();
+    }
   };
 
   void setupEventsForWork(TestTorchCommNCCLX& torchcomm, size_t numWork);

--- a/comms/torchcomms/ncclx/tests/unit/cpp/mocks/CudaMock.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/mocks/CudaMock.cpp
@@ -66,6 +66,10 @@ void CudaMock::setupDefaultBehaviors() {
   ON_CALL(*this, graphRetainUserObject(_, _, _, _))
       .WillByDefault(Return(cudaSuccess));
 
+  ON_CALL(*this, userObjectRelease(_, _)).WillByDefault(Return(cudaSuccess));
+
+  ON_CALL(*this, launchHostFunc(_, _, _)).WillByDefault(Return(cudaSuccess));
+
   ON_CALL(*this, streamGetCaptureInfo_v2(_, _, _, _, _, _))
       .WillByDefault(DoAll(
           SetArgPointee<1>(cudaStreamCaptureStatusNone),
@@ -102,6 +106,9 @@ void CudaMock::setupDefaultBehaviors() {
   ON_CALL(*this, eventDestroy(_)).WillByDefault(Return(cudaSuccess));
 
   ON_CALL(*this, eventRecord(_, _)).WillByDefault(Return(cudaSuccess));
+
+  ON_CALL(*this, eventRecordWithFlags(_, _, _))
+      .WillByDefault(Return(cudaSuccess));
 
   ON_CALL(*this, eventQuery(_)).WillByDefault(Return(cudaSuccess));
 

--- a/comms/torchcomms/ncclx/tests/unit/cpp/mocks/CudaMock.hpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/mocks/CudaMock.hpp
@@ -91,6 +91,16 @@ class CudaMock : public CudaApi {
       (override));
   MOCK_METHOD(
       cudaError_t,
+      userObjectRelease,
+      (cudaUserObject_t object, unsigned int count),
+      (override));
+  MOCK_METHOD(
+      cudaError_t,
+      launchHostFunc,
+      (cudaStream_t stream, cudaHostFn_t fn, void* userData),
+      (override));
+  MOCK_METHOD(
+      cudaError_t,
       streamGetCaptureInfo_v2,
       (cudaStream_t stream,
        cudaStreamCaptureStatus* captureStatus_out,
@@ -135,6 +145,11 @@ class CudaMock : public CudaApi {
       cudaError_t,
       eventRecord,
       (cudaEvent_t event, cudaStream_t stream),
+      (override));
+  MOCK_METHOD(
+      cudaError_t,
+      eventRecordWithFlags,
+      (cudaEvent_t event, cudaStream_t stream, unsigned int flags),
       (override));
   MOCK_METHOD(cudaError_t, eventQuery, (cudaEvent_t event), (override));
 

--- a/comms/torchcomms/tests/helpers/py/fatal_state_test_helpers.py
+++ b/comms/torchcomms/tests/helpers/py/fatal_state_test_helpers.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# pyre-unsafe
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import os
+import signal
+import subprocess
+import sys
+
+
+class FatalStateTestMixin:
+    """Mixin for tests that verify process-fatal scenarios via subprocess.
+
+    Provides helpers to re-invoke the current test binary with a sentinel
+    env var, using FileStore-based bootstrap to avoid TCPStore port races.
+    """
+
+    def make_subprocess_env(self, sentinel_var: str) -> dict:
+        """Build env for subprocess with FileStore bootstrap.
+
+        Sets sentinel_var="1", configures TORCHCOMM_STORE_PATH for FileStore,
+        and offsets MASTER_PORT to avoid collision with parent process.
+        """
+        env = os.environ.copy()
+        env[sentinel_var] = "1"
+        # Deterministic path: all parent ranks share MASTER_PORT, so their
+        # subprocesses will agree on the same FileStore file.
+        parent_port = os.environ.get("MASTER_PORT", "29500")
+        store_path = f"/tmp/torchcomm_test_store_{sentinel_var}_{parent_port}"
+        # Remove stale store file from previous runs. All parent ranks
+        # attempt this; ENOENT on later ranks is harmless.
+        try:
+            os.remove(store_path)
+        except FileNotFoundError:
+            pass
+        # TORCHCOMM_STORE_PATH makes StoreManager create a FileStore instead
+        # of a TCPStore. MASTER_ADDR/MASTER_PORT must still be set because
+        # the NCCLX bootstrap's createStore() guards on their presence before
+        # calling StoreManager — but they won't be used for actual store
+        # creation when TORCHCOMM_STORE_PATH is set.
+        env["TORCHCOMM_STORE_PATH"] = store_path
+        env["MASTER_ADDR"] = "127.0.0.1"
+        env["MASTER_PORT"] = str(int(parent_port) + 1000)
+        return env
+
+    def run_subprocess(
+        self, env: dict, timeout: int = 120
+    ) -> subprocess.CompletedProcess:
+        """Re-invoke current test binary with modified env.
+
+        Calls subprocess.run([sys.executable, sys.argv[0]], ...).
+        Fails the test on TimeoutExpired.
+        """
+        try:
+            return subprocess.run(
+                [sys.executable, sys.argv[0]],
+                env=env,
+                timeout=timeout,
+                capture_output=True,
+            )
+        except subprocess.TimeoutExpired as e:
+            raise AssertionError(
+                f"Subprocess timed out after {timeout}s.\n"
+                f"stdout: {(e.stdout or b'').decode(errors='replace')}\n"
+                f"stderr: {(e.stderr or b'').decode(errors='replace')}"
+            )
+
+    def assert_subprocess_aborted(
+        self,
+        result: subprocess.CompletedProcess,
+        expected_stderr: str | None = None,
+    ) -> None:
+        """Assert subprocess was killed by SIGABRT, optionally check stderr."""
+        # pyre-ignore[16]: unittest.TestCase.assertEqual
+        self.assertEqual(
+            result.returncode,
+            -signal.SIGABRT,
+            f"Expected SIGABRT (-{signal.SIGABRT}), "
+            f"got {result.returncode}.\n"
+            f"stderr: {result.stderr.decode(errors='replace')}",
+        )
+        if expected_stderr:
+            # pyre-ignore[16]: unittest.TestCase.assertIn
+            self.assertIn(
+                expected_stderr,
+                result.stderr.decode(errors="replace"),
+                "Expected message not found in subprocess stderr.",
+            )
+
+    def assert_subprocess_failed(self, result: subprocess.CompletedProcess) -> None:
+        """Assert subprocess exited with non-zero (for asymmetric rank scenarios)."""
+        # pyre-ignore[16]: unittest.TestCase.assertNotEqual
+        self.assertNotEqual(
+            result.returncode,
+            0,
+            "Expected subprocess to fail (peers are dead).\n"
+            f"stderr: {result.stderr.decode(errors='replace')}",
+        )

--- a/comms/torchcomms/tests/integration/py/TimeoutTest.py
+++ b/comms/torchcomms/tests/integration/py/TimeoutTest.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+# pyre-unsafe
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import os
+import time
+import unittest
+from datetime import timedelta
+
+import torch
+import torchcomms
+from torchcomms.tests.helpers.py.cuda_graph_test_helpers import (
+    _wait,
+    CudaGraphTestBase,
+    GraphTestBuilder,
+    skip_unless_ncclx,
+)
+from torchcomms.tests.helpers.py.fatal_state_test_helpers import FatalStateTestMixin
+from torchcomms.tests.integration.py.TorchCommTestHelpers import get_rank_and_size
+
+
+# ---------------------------------------------------------------------------
+# Scenario functions — executed in subprocesses via sentinel env vars.
+# Each scenario sets up a comm, triggers a timeout, and expects the process
+# to be aborted by the watchdog. If it returns, os._exit(1) signals failure.
+# ---------------------------------------------------------------------------
+
+
+def _run_eager_timeout_scenario() -> None:
+    """Eager barrier timeout: rank 0 sleeps, others time out and abort."""
+
+    backend = os.environ.get("TEST_BACKEND", "")
+    rank, _ = get_rank_and_size()
+    device_count = torch.cuda.device_count()
+    device = torch.device("cuda", rank % device_count)
+    torch.cuda.set_device(device)
+
+    comm = torchcomms.new_comm(
+        backend,
+        device,
+        name="eager_timeout_subprocess_comm",
+        abort_process_on_timeout_or_error=True,
+        timeout=timedelta(milliseconds=1),
+    )
+
+    if rank == 0:
+        time.sleep(10)
+    comm.barrier(async_op=False)
+    torch.cuda.synchronize()
+
+    # Should not reach here — process should have been aborted
+    comm.finalize()
+
+
+def _run_eager_timeout_after_success_scenario() -> None:
+    """First eager barrier succeeds, second times out and aborts."""
+
+    backend = os.environ.get("TEST_BACKEND", "")
+    rank, _ = get_rank_and_size()
+    device_count = torch.cuda.device_count()
+    device = torch.device("cuda", rank % device_count)
+    torch.cuda.set_device(device)
+
+    comm = torchcomms.new_comm(
+        backend,
+        device,
+        name="eager_timeout_after_success_subprocess_comm",
+        abort_process_on_timeout_or_error=True,
+        timeout=timedelta(milliseconds=1),
+    )
+
+    # First barrier: all ranks participate, should succeed.
+    comm.barrier(async_op=False)
+    torch.cuda.synchronize()
+
+    # Second barrier: rank 0 delays, causing timeout on other ranks.
+    if rank == 0:
+        time.sleep(10)
+    comm.barrier(async_op=False)
+    torch.cuda.synchronize()
+
+    # Should not reach here — process should have been aborted
+    comm.finalize()
+
+
+def _run_graph_timeout_scenario() -> None:
+    """Graph replay timeout: rank 0 sleeps, others time out and abort."""
+
+    backend = os.environ.get("TEST_BACKEND", "")
+    rank, _ = get_rank_and_size()
+    device_count = torch.cuda.device_count()
+    device = torch.device("cuda", rank % device_count)
+    torch.cuda.set_device(device)
+
+    comm = torchcomms.new_comm(
+        backend,
+        device,
+        name="graph_timeout_subprocess_comm",
+        abort_process_on_timeout_or_error=True,
+    )
+
+    graph = torch.cuda.CUDAGraph(keep_graph=True)
+    with torch.cuda.graph(graph):
+        _wait(
+            comm.barrier(
+                async_op=False,
+                timeout=timedelta(milliseconds=1),
+            )
+        )
+    graph.instantiate()
+
+    if rank == 0:
+        time.sleep(10.0)
+    graph.replay()
+    torch.cuda.synchronize()
+
+    # If we reach here, timeout detection failed
+    graph.reset()
+    comm.finalize()
+
+
+def _run_graph_timeout_after_success_scenario() -> None:
+    """First graph replay succeeds, second times out and aborts."""
+
+    backend = os.environ.get("TEST_BACKEND", "")
+    rank, _ = get_rank_and_size()
+    device_count = torch.cuda.device_count()
+    device = torch.device("cuda", rank % device_count)
+    torch.cuda.set_device(device)
+
+    comm = torchcomms.new_comm(
+        backend,
+        device,
+        name="graph_timeout_after_success_subprocess_comm",
+        abort_process_on_timeout_or_error=True,
+    )
+
+    graph = torch.cuda.CUDAGraph(keep_graph=True)
+    with torch.cuda.graph(graph):
+        _wait(
+            comm.barrier(
+                async_op=False,
+                timeout=timedelta(milliseconds=1),
+            )
+        )
+    graph.instantiate()
+
+    # First replay: all ranks participate, should succeed.
+    graph.replay()
+    torch.cuda.synchronize()
+
+    # Second replay: rank 0 delays, causing timeout on other ranks.
+    if rank == 0:
+        time.sleep(10.0)
+    graph.replay()
+    torch.cuda.synchronize()
+
+    # If we reach here, timeout detection failed
+    graph.reset()
+    comm.finalize()
+
+
+# Early exit for subprocess mode: when re-invoked with a sentinel env var,
+# run the scenario and exit before the test runner discovers any test classes.
+if os.environ.get("_TORCHCOMM_RUN_EAGER_TIMEOUT"):
+    _run_eager_timeout_scenario()
+    os._exit(1)
+
+if os.environ.get("_TORCHCOMM_RUN_EAGER_TIMEOUT_AFTER_SUCCESS"):
+    _run_eager_timeout_after_success_scenario()
+    os._exit(1)
+
+if os.environ.get("_TORCHCOMM_RUN_GRAPH_TIMEOUT"):
+    _run_graph_timeout_scenario()
+    os._exit(1)
+
+if os.environ.get("_TORCHCOMM_RUN_GRAPH_TIMEOUT_AFTER_SUCCESS"):
+    _run_graph_timeout_after_success_scenario()
+    os._exit(1)
+
+
+class TestTimeout(CudaGraphTestBase, FatalStateTestMixin):
+    """Tests timeout detection, abort behavior, and false timeout prevention."""
+
+    def _run_abort_timeout_test(self, sentinel_var: str, expected_stderr: str) -> None:
+        """Common logic for all subprocess abort-timeout tests.
+
+        Syncs parent ranks via barrier, spawns subprocess with sentinel,
+        and asserts abort (non-rank-0) or failure (rank-0).
+        """
+        with self.create_comms(1):
+            pass
+
+        env = self.make_subprocess_env(sentinel_var)
+        result = self.run_subprocess(env)
+
+        rank, _ = get_rank_and_size()
+        if rank != 0:
+            self.assert_subprocess_aborted(result, expected_stderr)
+        else:
+            self.assert_subprocess_failed(result)
+
+    # pyre-ignore[56]
+    @skip_unless_ncclx
+    def test_eager_timeout(self) -> None:
+        """Eager collective timeout should abort the process."""
+        self._run_abort_timeout_test(
+            "_TORCHCOMM_RUN_EAGER_TIMEOUT",
+            "Aborting process due to timeout",
+        )
+
+    # pyre-ignore[56]
+    @skip_unless_ncclx
+    def test_graph_timeout(self) -> None:
+        """Graph replay timeout should abort the process."""
+        self._run_abort_timeout_test(
+            "_TORCHCOMM_RUN_GRAPH_TIMEOUT",
+            "Graph monitor: collective TIMED OUT for graph",
+        )
+
+    # pyre-ignore[56]
+    @skip_unless_ncclx
+    def test_eager_timeout_after_successful_op(self) -> None:
+        """First eager op succeeds, second times out and aborts."""
+        self._run_abort_timeout_test(
+            "_TORCHCOMM_RUN_EAGER_TIMEOUT_AFTER_SUCCESS",
+            "Aborting process due to timeout",
+        )
+
+    # pyre-ignore[56]
+    @skip_unless_ncclx
+    def test_graph_timeout_after_successful_replay(self) -> None:
+        """First graph replay succeeds, second times out and aborts."""
+        self._run_abort_timeout_test(
+            "_TORCHCOMM_RUN_GRAPH_TIMEOUT_AFTER_SUCCESS",
+            "Graph monitor: collective TIMED OUT for graph",
+        )
+
+    # pyre-ignore[56]
+    @skip_unless_ncclx
+    def test_eager_no_false_timeout(self) -> None:
+        """Normal eager collective with short timeout completes without false timeout."""
+        comm = torchcomms.new_comm(
+            self.backend,
+            self.device,
+            name="test_eager_no_false_timeout_comm",
+            abort_process_on_timeout_or_error=True,
+            timeout=timedelta(seconds=2),
+        )
+        try:
+            inp = torch.ones(10, 10, device=self.device)
+            comm.all_reduce(inp, torchcomms.ReduceOp.SUM, async_op=False)
+            torch.cuda.synchronize()
+            expected = torch.ones(10, 10, device=self.device) * comm.get_size()
+            torch.testing.assert_close(inp, expected)
+        finally:
+            comm.finalize()
+
+    # pyre-ignore[56]
+    @skip_unless_ncclx
+    def test_graph_no_false_timeout(self) -> None:
+        """Graph replay without artificial delay should complete without timeout."""
+        for async_op in [False, True]:
+            with self.subTest(async_op=async_op):
+
+                def make_inputs(b: GraphTestBuilder) -> list[torch.Tensor]:
+                    return [torch.ones(10, 10, device=self.device)]
+
+                def make_expected(b: GraphTestBuilder) -> list[torch.Tensor]:
+                    return [b.inputs[0] * b.comms[0].get_size()]
+
+                def assert_graph(b: GraphTestBuilder) -> None:
+                    info = b.graph_infos[0]
+                    ar_kernels = info.kernels_with_name("AllReduce")
+                    self.assertEqual(len(ar_kernels), 1)
+
+                def capture(b: GraphTestBuilder, _async: bool = async_op) -> None:
+                    _wait(
+                        b.comms[0].all_reduce(
+                            b.inputs[0], torchcomms.ReduceOp.SUM, async_op=_async
+                        )
+                    )
+
+                GraphTestBuilder(self).add_capture(capture).run_serial(
+                    inputs=make_inputs,
+                    expected=make_expected,
+                    graph_assertions=assert_graph,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
Add timeout detection for NCCL collectives during CUDA graph replay. The existing watchdog thread already monitors eager-mode collectives via a per-stream FIFO queue; this diff extends it to graph-captured collectives with a new `GraphEventTracker`.

## Key architecture

```
  TorchCommNCCLX
  ├── Event Pool (eager mode) — getEvent() / returnEvent()                                                                                                
  ├── Timeout Watchdog Thread                           
  │   ├── checkWorkQueue()     → eager work FIFO GC
  │   └── checkGraphEvents()   → graph_event_tracker_.checkAll()
  ├── TorchWorkNCCLX — start_event_, end_event_, sync_event_
  ├── TorchWorkNCCLXQueue (eager) — per-stream FIFO, GC on done
  └── GraphEventTracker (graph) — per-graph GraphState {vector<GraphWork>, atomic replay_counter}
```

## Graph mode event state machine
```
                                                      elapsed > timeout                                                                                   
                                                     ┌─────────────────► abort()
                                                     │                                                                                                    
                end=notReady        start=success     │ 
                start=notReady                        │
   COMPLETED ──────────────► NOT REACHED ──────────► IN PROGRESS
       ▲                                                  │
       │            end=success                           │
       └──────────────────────────────────────────────────┘
       ▲
       │  replay_counter changed
       └──────────────────────────────────────────────────┘
```
## Key design decisions
- **Event usage**: Use `cudaEventRecordExternal` for start/end events so they remain host-queryable during graph replay (regular `cudaEventRecord` events become opaque graph nodes). A third `sync_event_` with regular record is needed for `cudaStreamWaitEvent` join points, since External records aren't recognized as valid join points.
- **Per-graph replay counter** via CUDA host node (`launchHostFunc`) detects replay boundaries and prevents false timeouts spanning multiple replays.
- **State machine based detection and timeout check by watchdog**: `end=success` → done, `start=success + end=notReady` → in-progress (timer checked here), `both notReady` → not reached.
- **Resource cleanup**: graph destruction → 
  cudaUserObject callback sets released flag → watchdog checkAll() → cleanupReleasedGraphs() → destroyEvents(). Deferred cleanup avoids unsafe destroyEvents in graph callback. Release flag allows any order between graph destruction and comm finalize.
- **enqueueWork**: graph path transfers event ownership to `GraphEventTracker`, eager path pushes to `TorchWorkNCCLXQueue`.

## Design doc
[graph_timeout_design.md](https://www.internalfb.com/code/fbsource/[D93704653-V6]/fbcode/comms/torchcomms/ncclx/docs/graph_timeout_design.md)

## Co-author
Dylan Maloy <dmaloy@meta.com>

Files:
- `GraphEventTracker.hpp/.cpp` — new standalone class for graph timeout tracking
- `TorchWorkNCCLX.hpp/.cpp` — 3-event design with `initEvents()`/`releaseEvents()`, centralized event lifecycle
- `TorchCommNCCLXUtils.cpp` — watchdog integration (`checkGraphEvents()`), `enqueueWork()` branching
- `CudaApi.hpp/.cpp` — add `launchHostFunc` interface
- `GraphEventTrackerTest.cpp` — 11 unit tests with CudaMock (no GPU required)
- `TimeoutTest.py` — 6 integration tests (eager + graph, subprocess-isolated)
- `fatal_state_test_helpers.py` — reusable `FatalStateTestMixin` for subprocess test pattern

Reviewed By: pavanbalaji

Differential Revision: D93704653


