### PR TITLE
Fix UTs to skip if number of nodes is less than 2

### DIFF
--- a/comms/ctran/ibverbx/tests/IbverbxDistributedTest.cc
+++ b/comms/ctran/ibverbx/tests/IbverbxDistributedTest.cc
@@ -212,6 +212,9 @@ class IbverbxSingleQpTestFixture : public MpiBaseTestFixture {
  protected:
   void SetUp() override {
     MpiBaseTestFixture::SetUp();
+    if (numRanks < 2) {
+      GTEST_SKIP() << "Need at least 2 ranks";
+    }
     ncclCvarInit();
     ASSERT_TRUE(ibvInit());
   }

--- a/comms/ctran/ibverbx/tests/IbverbxDistributedVirtualQpGb200Test.cc
+++ b/comms/ctran/ibverbx/tests/IbverbxDistributedVirtualQpGb200Test.cc
@@ -260,6 +260,9 @@ class IbverbxVirtualQpTestFixture : public MpiBaseTestFixture {
  protected:
   void SetUp() override {
     MpiBaseTestFixture::SetUp();
+    if (numRanks < 2) {
+      GTEST_SKIP() << "Need at least 2 ranks";
+    }
     ncclCvarInit();
     ASSERT_TRUE(ibvInit());
   }

--- a/comms/ctran/ibverbx/tests/IbverbxDistributedVirtualQpTest.cc
+++ b/comms/ctran/ibverbx/tests/IbverbxDistributedVirtualQpTest.cc
@@ -172,6 +172,9 @@ class IbverbxVirtualQpTestFixture : public MpiBaseTestFixture {
  protected:
   void SetUp() override {
     MpiBaseTestFixture::SetUp();
+    if (numRanks < 2) {
+      GTEST_SKIP() << "Need at least 2 ranks";
+    }
     ncclCvarInit();
     ASSERT_TRUE(ibvInit());
   }


### PR DESCRIPTION
Summary:
Noticing some test failures - https://www.internalfb.com/intern/test/844425196451890 causing the test to get disabled.

Failure log:
```
[ RUN      ] VirtualQpRdmaReadTestSmallBuffer/IbverbxVirtualQpRdmaReadTestFixture.RdmaReadVirtualQpWithParam/1024_devBufSize_INT8_dataType_1_numQp_64_maxMsgPerQp_128_maxMsgBytes_SPRAY_scheme
unknown file: Failure
C++ exception with description "vector::_M_range_check: __n (which is 1) >= this->size() (which is 1)" thrown in the test body.

```
https://www.internalfb.com/sandcastle/workflow/4282923245643066407

Reviewed By: mingrany

Differential Revision: D93884194


