### PR TITLE
Guard detachMemoryHook in destructor to prevent SIGABRT

### DIFF
--- a/comms/torchcomms/nccl/TorchCommNCCL.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCL.cpp
@@ -84,11 +84,12 @@ TorchCommNCCL::~TorchCommNCCL() {
       }
       nccl_comm_ = nullptr;
     }
-  }
 
-  // We need to detach the memory hook in case finalize is not called,
-  // so that we don't encounter a memory corruption.
-  detachMemoryHook();
+    // Detach the memory hook since finalize was not called.
+    // Only needed when init completed (INITIALIZED), because
+    // attachMemoryHook is only called at the end of a successful init.
+    detachMemoryHook();
+  }
 }
 
 void TorchCommNCCL::init(

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -112,11 +112,12 @@ TorchCommNCCLX::~TorchCommNCCLX() {
       }
       nccl_comm_ = nullptr;
     }
-  }
 
-  // We need to detach the memory hook in case finalize is not called,
-  // so that we don't encounter a memory corruption.
-  detachMemoryHook();
+    // Detach the memory hook since finalize was not called.
+    // Only needed when init completed (INITIALIZED), because
+    // attachMemoryHook is only called at the end of a successful init.
+    detachMemoryHook();
+  }
 }
 
 void TorchCommNCCLX::init(

--- a/comms/torchcomms/rccl/TorchCommRCCL.cpp
+++ b/comms/torchcomms/rccl/TorchCommRCCL.cpp
@@ -88,11 +88,12 @@ TorchCommRCCL::~TorchCommRCCL() {
       }
       nccl_comm_ = nullptr;
     }
-  }
 
-  // We need to detach the memory hook in case finalize is not called,
-  // so that we don't encounter a memory corruption.
-  detachMemoryHook();
+    // Detach the memory hook since finalize was not called.
+    // Only needed when init completed (INITIALIZED), because
+    // attachMemoryHook is only called at the end of a successful init.
+    detachMemoryHook();
+  }
 }
 
 void TorchCommRCCL::init(

--- a/comms/torchcomms/rcclx/TorchCommRCCLX.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLX.cpp
@@ -87,11 +87,12 @@ TorchCommRCCLX::~TorchCommRCCLX() {
       }
       nccl_comm_ = nullptr;
     }
-  }
 
-  // We need to detach the memory hook in case finalize is not called,
-  // so that we don't encounter a memory corruption.
-  detachMemoryHook();
+    // Detach the memory hook since finalize was not called.
+    // Only needed when init completed (INITIALIZED), because
+    // attachMemoryHook is only called at the end of a successful init.
+    detachMemoryHook();
+  }
 }
 
 void TorchCommRCCLX::init(


### PR DESCRIPTION
## Summary

- Move `detachMemoryHook()` inside the `if (init_state_ == INITIALIZED)` guard in the destructor across all four backends (nccl, ncclx, rccl, rcclx)
- Prevents `std::terminate` / SIGABRT when a partially-initialized comm is destroyed during stack unwinding

## Problem

When `init()` fails partway through (e.g., CUDA GPUs become transiently unavailable), the partially-initialized comm is destroyed during stack unwinding. The unconditional `detachMemoryHook()` in the destructor triggers lazy `CachingAllocatorHook` singleton creation, which calls `device_count_ensure_non_zero()` and throws again. Throwing during stack unwinding calls `std::terminate()`, producing a SIGABRT instead of a clean exception.

Observed in CI:
- https://github.com/meta-pytorch/torchcomms/actions/runs/22201371373/job/64219743572
- https://github.com/meta-pytorch/torchcomms/actions/runs/22201372219/job/64219777157

## Why this is safe

`attachMemoryHook()` is the last fallible operation in `init()`, called at line 277 (ncclx), immediately before `init_state_ = INITIALIZED` at line 280. If `init_state_ != INITIALIZED`, then `attachMemoryHook()` either was never called or threw — in both cases the comm was never registered with the singleton, so there is nothing to detach. `deregisterComm()` is also idempotent (silently returns if comm not found), so double-detach after `finalize()` remains safe.

## Test plan

- [x] Existing CI tests pass (nccl, ncclx, rccl, rcclx backends)
- [x] Verify the SIGABRT no longer occurs when CUDA GPUs are transiently unavailable during init