### PR TITLE
Fix multinode RE TCPStore connectivity by using container IP

### DIFF
--- a/comms/ctran/tests/CtranDistTestUtils.cc
+++ b/comms/ctran/tests/CtranDistTestUtils.cc
@@ -43,9 +43,8 @@ std::unique_ptr<c10d::TCPStore> createTcpStore(bool isServer) {
   const std::string masterAddr(masterAddrStr);
   c10d::TCPStoreOptions opts{
       .port = static_cast<uint16_t>(std::stoi(masterPortStr)),
-      .waitWorkers = false,
-      .useLibUV = true,
       .isServer = isServer,
+      .waitWorkers = false,
   };
 
   XLOG(INFO) << "TCPStore "


### PR DESCRIPTION
Summary:
The multihost_re_launcher was using the hostname from `get_hostname(0)` as MASTER_ADDR for TCPStore-based bootstrap. This hostname doesn't resolve to a routable address within RE containers, causing TCPStore connections to time out — even the server's own internal client couldn't connect to itself.

The `twac ls -a -F ip,ports` command already returns the container's routable IP as the first field, but it was being discarded. This change captures that IP and uses it as MASTER_ADDR instead of the hostname, fixing cross-node TCPStore connectivity in multinode RE tests.

Also fixes out-of-order C++20 designated initializers in `createTcpStore()` to match the `TCPStoreOptions` struct field order and removes redundant `.useLibUV = true` (already the default).

Reviewed By: MittalMakwana

Differential Revision: D93835157


