### PR TITLE
Enable MCCL_SCUBA_ENABLED by default

### DIFF
--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2816,7 +2816,7 @@ cvars:
 
  - name        : MCCL_SCUBA_ENABLED
    type        : bool
-   default     : false
+   default     : true
    description : |-
      Enable MCCL Scuba structured logging. When enabled, MCCL will log
      events to dedicated MCCL Scuba tables for observability and debugging.


### PR DESCRIPTION
Summary:
Now that MCCL_SCUBA_LOG_LEVEL filtering is in place (D93776465), Scuba logging can be safely enabled by default without overwhelming storage or query noise. The filtering mechanism allows operators to tune verbosity through MCCL_SCUBA_LOG_LEVEL while still benefiting from observability data being captured automatically.

This completes the MCCL Scuba logging rollout by making structured logging opt-out rather than opt-in, improving out-of-the-box observability for debugging and performance analysis.

Differential Revision: D93907153


