### PR TITLE
Fix iterative build script

### DIFF
--- a/build_ncclx.sh
+++ b/build_ncclx.sh
@@ -22,7 +22,7 @@ function do_cmake_build() {
     -DCMAKE_POLICY_VERSION_MINIMUM=3.22 \
     $extra_flags \
     -S "${source_dir}"
-  ninja
+  ninja -j$(nproc)
   ninja install
 }
 
@@ -178,10 +178,10 @@ function build_third_party {
         zstd
         conda-forge::zlib
         conda-forge::libopenssl-static
-        conda-forge::folly
         fmt
       )
       conda install "${DEPS[@]}" --yes
+      build_fb_oss_library "https://github.com/facebook/folly.git" "$third_party_tag" folly
     fi
   fi
 

--- a/comms/torchcomms/ncclx/CMakeLists.txt
+++ b/comms/torchcomms/ncclx/CMakeLists.txt
@@ -102,7 +102,10 @@ target_link_libraries(torchcomms_comms_ncclx PRIVATE
 if(USE_SYSTEM_LIBS)
     target_link_libraries(torchcomms_comms_ncclx PRIVATE
         ${NCCLX_SHARED_LIB}
+        ${FOLLY_LDFLAGS}
         "-lfmt"
+        "-lboost_program_options"
+        "-lboost_filesystem"
     )
 else()
     target_link_libraries(torchcomms_comms_ncclx PRIVATE


### PR DESCRIPTION
Summary:
1. fix folly version conflict of iterative build script
2. enable folly for torchcomms ncclx backend

Differential Revision: D93948069


