### PR TITLE
Add IbHcaParser for NCCL_IB_HCA environment variable parsing

### DIFF
--- a/comms/pipes/MultipeerIbgdaTransport.h
+++ b/comms/pipes/MultipeerIbgdaTransport.h
@@ -45,11 +45,11 @@ struct MultipeerIbgdaTransportConfig {
   // If empty, uses topology-aware auto-discovery.
   std::map<int, std::vector<std::string>> gpuNicMap;
 
-  // IB HCA allowlist for NIC filtering during auto-discovery.
-  // If empty, all discovered NICs are considered.
+  // IB HCA filter string (NCCL_IB_HCA format) for NIC filtering during
+  // auto-discovery. If empty, all discovered NICs are considered.
   // Only used during auto-discovery (not when gpuNicMap has a mapping for the
   // GPU).
-  std::vector<std::string> ibHca;
+  std::string ibHca;
 
   // Per-peer data buffer size in bytes.
   // This determines the maximum transfer size per put_signal call.

--- a/comms/pipes/NicDiscovery.cc
+++ b/comms/pipes/NicDiscovery.cc
@@ -249,14 +249,11 @@ void NicDiscovery::initGpuTopology() {
             << " NUMA " << gpuNumaNode_;
 }
 
-NicDiscovery::NicDiscovery(
-    int cudaDevice,
-    const std::vector<std::string>& ibHca)
-    : cudaDevice_(cudaDevice) {
-  if (!ibHca.empty()) {
-    ibHcaFilter_ = std::unordered_set<std::string>(ibHca.begin(), ibHca.end());
-    LOG(INFO) << "NicDiscovery: IB HCA filter with " << ibHcaFilter_.size()
-              << " entries";
+NicDiscovery::NicDiscovery(int cudaDevice, const std::string& ibHcaEnv)
+    : cudaDevice_(cudaDevice), ibHcaParser_(ibHcaEnv) {
+  if (!ibHcaParser_.empty()) {
+    LOG(INFO) << "NicDiscovery: IB HCA filter with "
+              << ibHcaParser_.entries().size() << " entries";
   }
   discover();
 }
@@ -273,8 +270,10 @@ void NicDiscovery::discover() {
   candidates_.clear();
 
   for (const auto& devName : devices) {
-    // Skip NICs not in the allowlist (if filter is set)
-    if (!ibHcaFilter_.empty() && ibHcaFilter_.count(devName) == 0) {
+    // Skip NICs that don't pass the HCA filter
+    if (!ibHcaParser_.matches(devName)) {
+      LOG(INFO) << "NicDiscovery: skipping NIC " << devName
+                << " due to IB HCA filter";
       continue;
     }
 
@@ -300,7 +299,7 @@ void NicDiscovery::discover() {
 
   if (candidates_.empty()) {
     std::string errMsg = "No suitable IB device found with active port";
-    if (!ibHcaFilter_.empty()) {
+    if (!ibHcaParser_.empty()) {
       errMsg +=
           " (IB HCA filter excluded all devices; check ibHca config value)";
     }

--- a/comms/pipes/NicDiscovery.h
+++ b/comms/pipes/NicDiscovery.h
@@ -7,6 +7,8 @@
 #include <utility>
 #include <vector>
 
+#include "comms/pipes/rdma/IbHcaParser.h"
+
 namespace comms::pipes {
 
 /**
@@ -80,11 +82,10 @@ class NicDiscovery {
    * to retrieve the ranked NIC list.
    *
    * @param cudaDevice CUDA device index for GPU topology analysis
+   * @param ibHcaEnv NCCL_IB_HCA-style filter string (empty = no filtering)
    * @throws std::runtime_error if no suitable NIC found
    */
-  explicit NicDiscovery(
-      int cudaDevice,
-      const std::vector<std::string>& ibHca = {});
+  explicit NicDiscovery(int cudaDevice, const std::string& ibHcaEnv = {});
 
   /**
    * Get all discovered NIC candidates, sorted best-to-worst.
@@ -155,8 +156,8 @@ class NicDiscovery {
   std::unordered_set<std::string> gpuAncestors_;
   int gpuNumaNode_{-1};
 
-  // IB HCA allowlist filter (empty = no filtering)
-  std::unordered_set<std::string> ibHcaFilter_;
+  // IB HCA filter (empty = no filtering)
+  IbHcaParser ibHcaParser_;
 
   // Discovered candidates (populated during discovery)
   std::vector<NicCandidate> candidates_;

--- a/comms/pipes/rdma/IbHcaParser.cc
+++ b/comms/pipes/rdma/IbHcaParser.cc
@@ -1,0 +1,115 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/rdma/IbHcaParser.h"
+
+#include <algorithm>
+#include <stdexcept>
+
+namespace comms::pipes {
+
+void IbHcaParser::parse_prefix(const std::string& hcaStr, size_t& pos) {
+  // Check ^= before ^ before = to handle combined prefix correctly
+  if (hcaStr.compare(pos, 2, "^=") == 0) {
+    matchMode_ = HcaMatchMode::EXACT_EXCLUDE;
+    pos += 2;
+  } else if (hcaStr[pos] == '^') {
+    matchMode_ = HcaMatchMode::PREFIX_EXCLUDE;
+    pos += 1;
+  } else if (hcaStr[pos] == '=') {
+    matchMode_ = HcaMatchMode::EXACT_INCLUDE;
+    pos += 1;
+  } else {
+    matchMode_ = HcaMatchMode::PREFIX_INCLUDE;
+  }
+}
+
+HcaEntry IbHcaParser::parse_entry(const std::string& token) const {
+  HcaEntry entry;
+  auto colonPos = token.find(':');
+  if (colonPos != std::string::npos) {
+    entry.name = token.substr(0, colonPos);
+    entry.port = std::stoi(token.substr(colonPos + 1));
+  } else {
+    entry.name = token;
+    entry.port = -1;
+  }
+  return entry;
+}
+
+IbHcaParser::IbHcaParser(const std::string& hcaStr) {
+  if (hcaStr.empty()) {
+    return;
+  }
+
+  // Parse mode prefix
+  size_t pos = 0;
+  parse_prefix(hcaStr, pos);
+
+  // Split by ',' and parse each entry
+  std::string remaining = hcaStr.substr(pos);
+  size_t start = 0;
+  while (start < remaining.size()) {
+    auto commaPos = remaining.find(',', start);
+    std::string token;
+    if (commaPos != std::string::npos) {
+      token = remaining.substr(start, commaPos - start);
+      start = commaPos + 1;
+    } else {
+      token = remaining.substr(start);
+      start = remaining.size();
+    }
+
+    // Trim whitespace
+    auto trimStart = token.find_first_not_of(" \t");
+    auto trimEnd = token.find_last_not_of(" \t");
+    if (trimStart == std::string::npos) {
+      continue; // Skip empty tokens
+    }
+    token = token.substr(trimStart, trimEnd - trimStart + 1);
+
+    entries_.push_back(parse_entry(token));
+  }
+
+  if (entries_.size() > kMaxHcaDevices) {
+    throw std::runtime_error(
+        "Too many IB HCA entries (" + std::to_string(entries_.size()) +
+        "), maximum is " + std::to_string(kMaxHcaDevices));
+  }
+}
+
+bool IbHcaParser::matches(const std::string& devName, int port) const {
+  // Empty entries means no filter - match everything
+  if (entries_.empty()) {
+    return true;
+  }
+
+  bool matchFound = false;
+  for (const auto& entry : entries_) {
+    bool nameMatch = false;
+    if (matchMode_ == HcaMatchMode::PREFIX_INCLUDE ||
+        matchMode_ == HcaMatchMode::PREFIX_EXCLUDE) {
+      nameMatch = devName.compare(0, entry.name.size(), entry.name) == 0;
+    } else {
+      // EXACT modes
+      nameMatch = (devName == entry.name);
+    }
+
+    if (nameMatch) {
+      // If both entry port and query port are specified, they must match
+      if (entry.port >= 0 && port >= 0 && entry.port != port) {
+        continue;
+      }
+      matchFound = true;
+      break;
+    }
+  }
+
+  if (matchMode_ == HcaMatchMode::PREFIX_INCLUDE ||
+      matchMode_ == HcaMatchMode::EXACT_INCLUDE) {
+    return matchFound;
+  }
+  // EXCLUDE modes: return the inverse
+  return !matchFound;
+}
+
+} // namespace comms::pipes

--- a/comms/pipes/rdma/IbHcaParser.h
+++ b/comms/pipes/rdma/IbHcaParser.h
@@ -1,0 +1,118 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace comms::pipes {
+
+/**
+ * Match mode for IB HCA filtering.
+ *
+ * Determines how device names are matched against filter entries:
+ * - PREFIX_INCLUDE: Include devices whose name starts with an entry (default)
+ * - EXACT_INCLUDE: Include devices whose name exactly matches an entry (=)
+ * - PREFIX_EXCLUDE: Exclude devices whose name starts with an entry (^)
+ * - EXACT_EXCLUDE: Exclude devices whose name exactly matches an entry (^=)
+ */
+enum class HcaMatchMode {
+  PREFIX_INCLUDE,
+  EXACT_INCLUDE,
+  PREFIX_EXCLUDE,
+  EXACT_EXCLUDE,
+};
+
+/**
+ * A single HCA filter entry parsed from the NCCL_IB_HCA string.
+ *
+ * Each entry specifies a device name and an optional port number.
+ * For example, "mlx5_0:1" means device "mlx5_0", port 1.
+ */
+struct HcaEntry {
+  std::string name;
+  int port{-1}; // -1 means "any port"
+};
+
+/**
+ * IbHcaParser - Parses and applies NCCL_IB_HCA-style device filters.
+ *
+ * The NCCL_IB_HCA environment variable format is:
+ *   [^][=]<device_name>[:<port>][,<device_name>[:<port>],...]
+ *
+ * Prefix modifiers:
+ *   (none) - PREFIX_INCLUDE: include devices matching any entry prefix
+ *   =      - EXACT_INCLUDE: include devices matching any entry exactly
+ *   ^      - PREFIX_EXCLUDE: exclude devices matching any entry prefix
+ *   ^=     - EXACT_EXCLUDE: exclude devices matching any entry exactly
+ *
+ * Examples:
+ *   "mlx5_0,mlx5_1"      - Include devices starting with mlx5_0 or mlx5_1
+ *   "=mlx5_0,=mlx5_1"    - Include only exactly mlx5_0 or mlx5_1
+ *   "^mlx5_1"             - Exclude devices starting with mlx5_1
+ *   "^=mlx5_1"            - Exclude only exactly mlx5_1
+ *   "mlx5_0:1"            - Include mlx5_0 port 1 only
+ *
+ * Usage:
+ *   IbHcaParser parser("mlx5_0,mlx5_1");
+ *   if (parser.matches("mlx5_0")) { ... }
+ *
+ *   IbHcaParser empty;  // No filter, matches everything
+ *   assert(empty.matches("any_device"));
+ */
+class IbHcaParser {
+ public:
+  static constexpr int kMaxHcaDevices = 32;
+
+  /**
+   * Construct a parser from the raw NCCL_IB_HCA-style string.
+   *
+   * @param hcaStr The filter string to parse
+   * @throws std::runtime_error if more than kMaxHcaDevices entries
+   */
+  explicit IbHcaParser(const std::string& hcaStr);
+
+  /**
+   * Default constructor - empty filter that matches everything.
+   */
+  IbHcaParser() = default;
+
+  /**
+   * Check if a device name (and optional port) passes the filter.
+   *
+   * @param devName Device name to check (e.g., "mlx5_0")
+   * @param port Port number to check (-1 means ignore port matching)
+   * @return true if the device passes the filter
+   */
+  bool matches(const std::string& devName, int port = -1) const;
+
+  /**
+   * Get the match mode.
+   */
+  HcaMatchMode match_mode() const {
+    return matchMode_;
+  }
+
+  /**
+   * Get the parsed entries.
+   */
+  const std::vector<HcaEntry>& entries() const {
+    return entries_;
+  }
+
+  /**
+   * Check if the filter is empty (no entries, matches everything).
+   */
+  bool empty() const {
+    return entries_.empty();
+  }
+
+ private:
+  void parse_prefix(const std::string& hcaStr, size_t& pos);
+  HcaEntry parse_entry(const std::string& token) const;
+
+  HcaMatchMode matchMode_{HcaMatchMode::PREFIX_INCLUDE};
+  std::vector<HcaEntry> entries_;
+};
+
+} // namespace comms::pipes

--- a/comms/pipes/rdma/tests/IbHcaParserTest.cc
+++ b/comms/pipes/rdma/tests/IbHcaParserTest.cc
@@ -1,0 +1,330 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/rdma/IbHcaParser.h"
+
+#include <gtest/gtest.h>
+#include <stdexcept>
+
+namespace comms::pipes {
+namespace {
+
+// =============================================================================
+// Construction tests
+// =============================================================================
+
+TEST(IbHcaParserTest, DefaultConstruction) {
+  IbHcaParser parser;
+  EXPECT_TRUE(parser.empty());
+  EXPECT_EQ(parser.match_mode(), HcaMatchMode::PREFIX_INCLUDE);
+  EXPECT_TRUE(parser.entries().empty());
+}
+
+TEST(IbHcaParserTest, EmptyString) {
+  IbHcaParser parser("");
+  EXPECT_TRUE(parser.empty());
+  EXPECT_TRUE(parser.entries().empty());
+}
+
+TEST(IbHcaParserTest, SingleDevice) {
+  IbHcaParser parser("mlx5_0");
+  EXPECT_FALSE(parser.empty());
+  EXPECT_EQ(parser.entries().size(), 1);
+  EXPECT_EQ(parser.entries()[0].name, "mlx5_0");
+  EXPECT_EQ(parser.entries()[0].port, -1);
+}
+
+TEST(IbHcaParserTest, MultipleDevices) {
+  IbHcaParser parser("mlx5_0,mlx5_1,mlx5_2");
+  EXPECT_EQ(parser.entries().size(), 3);
+  EXPECT_EQ(parser.entries()[0].name, "mlx5_0");
+  EXPECT_EQ(parser.entries()[1].name, "mlx5_1");
+  EXPECT_EQ(parser.entries()[2].name, "mlx5_2");
+}
+
+TEST(IbHcaParserTest, DeviceWithPort) {
+  IbHcaParser parser("mlx5_0:1");
+  EXPECT_EQ(parser.entries().size(), 1);
+  EXPECT_EQ(parser.entries()[0].name, "mlx5_0");
+  EXPECT_EQ(parser.entries()[0].port, 1);
+}
+
+TEST(IbHcaParserTest, MultipleDevicesWithPorts) {
+  IbHcaParser parser("mlx5_0:1,mlx5_1:2");
+  EXPECT_EQ(parser.entries().size(), 2);
+  EXPECT_EQ(parser.entries()[0].name, "mlx5_0");
+  EXPECT_EQ(parser.entries()[0].port, 1);
+  EXPECT_EQ(parser.entries()[1].name, "mlx5_1");
+  EXPECT_EQ(parser.entries()[1].port, 2);
+}
+
+TEST(IbHcaParserTest, MixedPortAndNoPort) {
+  IbHcaParser parser("mlx5_0:1,mlx5_1");
+  EXPECT_EQ(parser.entries().size(), 2);
+  EXPECT_EQ(parser.entries()[0].port, 1);
+  EXPECT_EQ(parser.entries()[1].port, -1);
+}
+
+// =============================================================================
+// Prefix parsing tests
+// =============================================================================
+
+TEST(IbHcaParserTest, PrefixIncludeDefault) {
+  IbHcaParser parser("mlx5_0");
+  EXPECT_EQ(parser.match_mode(), HcaMatchMode::PREFIX_INCLUDE);
+}
+
+TEST(IbHcaParserTest, ExactIncludePrefix) {
+  IbHcaParser parser("=mlx5_0");
+  EXPECT_EQ(parser.match_mode(), HcaMatchMode::EXACT_INCLUDE);
+  EXPECT_EQ(parser.entries().size(), 1);
+  EXPECT_EQ(parser.entries()[0].name, "mlx5_0");
+}
+
+TEST(IbHcaParserTest, PrefixExcludePrefix) {
+  IbHcaParser parser("^mlx5_0");
+  EXPECT_EQ(parser.match_mode(), HcaMatchMode::PREFIX_EXCLUDE);
+  EXPECT_EQ(parser.entries().size(), 1);
+  EXPECT_EQ(parser.entries()[0].name, "mlx5_0");
+}
+
+TEST(IbHcaParserTest, ExactExcludePrefix) {
+  IbHcaParser parser("^=mlx5_0");
+  EXPECT_EQ(parser.match_mode(), HcaMatchMode::EXACT_EXCLUDE);
+  EXPECT_EQ(parser.entries().size(), 1);
+  EXPECT_EQ(parser.entries()[0].name, "mlx5_0");
+}
+
+// =============================================================================
+// PREFIX_INCLUDE matching tests
+// =============================================================================
+
+TEST(IbHcaParserTest, PrefixIncludeMatches) {
+  IbHcaParser parser("mlx5");
+  EXPECT_TRUE(parser.matches("mlx5_0"));
+  EXPECT_TRUE(parser.matches("mlx5_10"));
+  EXPECT_TRUE(parser.matches("mlx5"));
+  EXPECT_FALSE(parser.matches("mlx4_0"));
+  EXPECT_FALSE(parser.matches("ib0"));
+}
+
+TEST(IbHcaParserTest, PrefixIncludeMultipleEntries) {
+  IbHcaParser parser("mlx5_0,mlx5_1");
+  EXPECT_TRUE(parser.matches("mlx5_0"));
+  EXPECT_TRUE(parser.matches("mlx5_1"));
+  EXPECT_TRUE(parser.matches("mlx5_10")); // prefix match on mlx5_1
+  EXPECT_FALSE(parser.matches("mlx5_2"));
+}
+
+TEST(IbHcaParserTest, PrefixIncludeWithPort) {
+  IbHcaParser parser("mlx5_0:1");
+  EXPECT_TRUE(parser.matches("mlx5_0", 1));
+  EXPECT_FALSE(parser.matches("mlx5_0", 2)); // wrong port
+  EXPECT_TRUE(parser.matches("mlx5_0")); // no port query, matches
+  EXPECT_TRUE(parser.matches("mlx5_0", -1)); // default port, matches
+}
+
+// =============================================================================
+// EXACT_INCLUDE matching tests
+// =============================================================================
+
+TEST(IbHcaParserTest, ExactIncludeMatches) {
+  IbHcaParser parser("=mlx5_0");
+  EXPECT_TRUE(parser.matches("mlx5_0"));
+  EXPECT_FALSE(parser.matches("mlx5_00")); // not exact
+  EXPECT_FALSE(parser.matches("mlx5_0x")); // not exact
+  EXPECT_FALSE(parser.matches("mlx5")); // not exact
+}
+
+TEST(IbHcaParserTest, ExactIncludeMultiple) {
+  IbHcaParser parser("=mlx5_0,mlx5_1");
+  EXPECT_TRUE(parser.matches("mlx5_0"));
+  EXPECT_TRUE(parser.matches("mlx5_1"));
+  EXPECT_FALSE(parser.matches("mlx5_10")); // exact, no prefix
+  EXPECT_FALSE(parser.matches("mlx5_2"));
+}
+
+// =============================================================================
+// PREFIX_EXCLUDE matching tests
+// =============================================================================
+
+TEST(IbHcaParserTest, PrefixExcludeMatches) {
+  IbHcaParser parser("^mlx5_1");
+  EXPECT_TRUE(parser.matches("mlx5_0")); // not excluded
+  EXPECT_FALSE(parser.matches("mlx5_1")); // excluded
+  EXPECT_FALSE(parser.matches("mlx5_10")); // excluded (prefix match)
+  EXPECT_TRUE(parser.matches("mlx5_2")); // not excluded
+}
+
+TEST(IbHcaParserTest, PrefixExcludeMultiple) {
+  IbHcaParser parser("^mlx5_0,mlx5_1");
+  EXPECT_FALSE(parser.matches("mlx5_0")); // excluded
+  EXPECT_FALSE(parser.matches("mlx5_1")); // excluded
+  EXPECT_FALSE(parser.matches("mlx5_10")); // excluded (prefix on mlx5_1)
+  EXPECT_TRUE(parser.matches("mlx5_2")); // not excluded
+  EXPECT_TRUE(parser.matches("ib0")); // not excluded
+}
+
+// =============================================================================
+// EXACT_EXCLUDE matching tests
+// =============================================================================
+
+TEST(IbHcaParserTest, ExactExcludeMatches) {
+  IbHcaParser parser("^=mlx5_1");
+  EXPECT_TRUE(parser.matches("mlx5_0")); // not excluded
+  EXPECT_FALSE(parser.matches("mlx5_1")); // exactly excluded
+  EXPECT_TRUE(parser.matches("mlx5_10")); // not exactly mlx5_1
+  EXPECT_TRUE(parser.matches("mlx5_2")); // not excluded
+}
+
+TEST(IbHcaParserTest, ExactExcludeMultiple) {
+  IbHcaParser parser("^=mlx5_0,mlx5_1");
+  EXPECT_FALSE(parser.matches("mlx5_0")); // excluded
+  EXPECT_FALSE(parser.matches("mlx5_1")); // excluded
+  EXPECT_TRUE(parser.matches("mlx5_10")); // not exact match
+  EXPECT_TRUE(parser.matches("mlx5_2")); // not excluded
+}
+
+// =============================================================================
+// Edge cases
+// =============================================================================
+
+TEST(IbHcaParserTest, EmptyFilterMatchesAll) {
+  IbHcaParser parser;
+  EXPECT_TRUE(parser.matches("anything"));
+  EXPECT_TRUE(parser.matches("mlx5_0"));
+  EXPECT_TRUE(parser.matches("mlx5_0", 1));
+  EXPECT_TRUE(parser.matches(""));
+}
+
+TEST(IbHcaParserTest, WhitespaceHandling) {
+  IbHcaParser parser("mlx5_0 , mlx5_1 , mlx5_2");
+  EXPECT_EQ(parser.entries().size(), 3);
+  EXPECT_EQ(parser.entries()[0].name, "mlx5_0");
+  EXPECT_EQ(parser.entries()[1].name, "mlx5_1");
+  EXPECT_EQ(parser.entries()[2].name, "mlx5_2");
+}
+
+TEST(IbHcaParserTest, PortZero) {
+  IbHcaParser parser("mlx5_0:0");
+  EXPECT_EQ(parser.entries()[0].port, 0);
+  EXPECT_TRUE(parser.matches("mlx5_0", 0));
+  EXPECT_FALSE(parser.matches("mlx5_0", 1));
+}
+
+TEST(IbHcaParserTest, MaxDeviceLimitExceeded) {
+  // Build a string with kMaxHcaDevices + 1 entries
+  std::string hcaStr;
+  for (int i = 0; i <= IbHcaParser::kMaxHcaDevices; i++) {
+    if (i > 0) {
+      hcaStr += ",";
+    }
+    hcaStr += "mlx5_" + std::to_string(i);
+  }
+  EXPECT_THROW(IbHcaParser{hcaStr}, std::runtime_error);
+}
+
+TEST(IbHcaParserTest, MaxDeviceLimitExact) {
+  // Build a string with exactly kMaxHcaDevices entries (should succeed)
+  std::string hcaStr;
+  for (int i = 0; i < IbHcaParser::kMaxHcaDevices; i++) {
+    if (i > 0) {
+      hcaStr += ",";
+    }
+    hcaStr += "mlx5_" + std::to_string(i);
+  }
+  EXPECT_NO_THROW(IbHcaParser{hcaStr});
+}
+
+// =============================================================================
+// Accessor tests
+// =============================================================================
+
+TEST(IbHcaParserTest, MatchModeAccessor) {
+  EXPECT_EQ(IbHcaParser().match_mode(), HcaMatchMode::PREFIX_INCLUDE);
+  EXPECT_EQ(IbHcaParser("mlx5").match_mode(), HcaMatchMode::PREFIX_INCLUDE);
+  EXPECT_EQ(IbHcaParser("=mlx5").match_mode(), HcaMatchMode::EXACT_INCLUDE);
+  EXPECT_EQ(IbHcaParser("^mlx5").match_mode(), HcaMatchMode::PREFIX_EXCLUDE);
+  EXPECT_EQ(IbHcaParser("^=mlx5").match_mode(), HcaMatchMode::EXACT_EXCLUDE);
+}
+
+TEST(IbHcaParserTest, EntriesAccessor) {
+  IbHcaParser parser("mlx5_0:1,mlx5_1");
+  const auto& entries = parser.entries();
+  EXPECT_EQ(entries.size(), 2);
+  EXPECT_EQ(entries[0].name, "mlx5_0");
+  EXPECT_EQ(entries[0].port, 1);
+  EXPECT_EQ(entries[1].name, "mlx5_1");
+  EXPECT_EQ(entries[1].port, -1);
+}
+
+TEST(IbHcaParserTest, EmptyAccessor) {
+  EXPECT_TRUE(IbHcaParser().empty());
+  EXPECT_TRUE(IbHcaParser("").empty());
+  EXPECT_FALSE(IbHcaParser("mlx5_0").empty());
+}
+
+// =============================================================================
+// Malformed input tests
+// =============================================================================
+
+TEST(IbHcaParserTest, MalformedPortNonNumeric) {
+  // "mlx5_0:abc" — std::stoi throws std::invalid_argument
+  EXPECT_THROW(IbHcaParser{"mlx5_0:abc"}, std::invalid_argument);
+}
+
+TEST(IbHcaParserTest, MalformedPortEmpty) {
+  // "mlx5_0:" — empty string after colon, std::stoi throws
+  EXPECT_THROW(IbHcaParser{"mlx5_0:"}, std::invalid_argument);
+}
+
+TEST(IbHcaParserTest, MalformedPortOverflow) {
+  // Port number too large for int
+  EXPECT_THROW(IbHcaParser{"mlx5_0:99999999999999999999"}, std::out_of_range);
+}
+
+TEST(IbHcaParserTest, TrailingComma) {
+  // Trailing comma produces an empty token which is skipped
+  IbHcaParser parser("mlx5_0,");
+  EXPECT_EQ(parser.entries().size(), 1);
+  EXPECT_EQ(parser.entries()[0].name, "mlx5_0");
+}
+
+TEST(IbHcaParserTest, LeadingComma) {
+  // Leading comma produces an empty token which is skipped
+  IbHcaParser parser(",mlx5_0");
+  EXPECT_EQ(parser.entries().size(), 1);
+  EXPECT_EQ(parser.entries()[0].name, "mlx5_0");
+}
+
+TEST(IbHcaParserTest, ConsecutiveCommas) {
+  // Multiple commas produce empty tokens which are skipped
+  IbHcaParser parser("mlx5_0,,mlx5_1");
+  EXPECT_EQ(parser.entries().size(), 2);
+  EXPECT_EQ(parser.entries()[0].name, "mlx5_0");
+  EXPECT_EQ(parser.entries()[1].name, "mlx5_1");
+}
+
+TEST(IbHcaParserTest, OnlyCommas) {
+  // All tokens are empty, so no entries are added
+  IbHcaParser parser(",,,");
+  EXPECT_TRUE(parser.empty());
+}
+
+TEST(IbHcaParserTest, PrefixOnly) {
+  // Just "^" with no device names — no entries, matches everything
+  IbHcaParser parser("^");
+  EXPECT_TRUE(parser.empty());
+  EXPECT_EQ(parser.match_mode(), HcaMatchMode::PREFIX_EXCLUDE);
+  EXPECT_TRUE(parser.matches("mlx5_0"));
+}
+
+TEST(IbHcaParserTest, ExactPrefixOnly) {
+  // Just "^=" with no device names
+  IbHcaParser parser("^=");
+  EXPECT_TRUE(parser.empty());
+  EXPECT_EQ(parser.match_mode(), HcaMatchMode::EXACT_EXCLUDE);
+  EXPECT_TRUE(parser.matches("mlx5_0"));
+}
+
+} // namespace
+} // namespace comms::pipes


### PR DESCRIPTION
Summary:
Add a standalone IbHcaParser class in comms/pipes/rdma/ that parses the
NCCL_IB_HCA environment variable format for IB device filtering. The parser
supports all four match modes: PREFIX_INCLUDE (default), EXACT_INCLUDE (=),
PREFIX_EXCLUDE (^), and EXACT_EXCLUDE (^=), with optional per-device port
filtering.

Integrate the parser into NicDiscovery by replacing the raw
std::vector<std::string> ibHca parameter with a std::string that is parsed
internally. NicDiscovery now accepts the raw NCCL_IB_HCA string and
constructs the parser as an implementation detail. MultipeerIbgdaTransport
config's ibHca field is reverted to std::string accordingly.

This enables prefix/exact matching and exclude-mode filtering, which the
previous unordered_set-based approach could not support.

Differential Revision: D93960268


