### PR TITLE
Refactor Broadcast integration tests with graph fixture

### DIFF
--- a/comms/torchcomms/tests/integration/cpp/BroadcastTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/BroadcastTest.cpp
@@ -2,266 +2,125 @@
 
 #include "BroadcastTest.hpp"
 
-#include <ATen/cuda/CUDAGraph.h>
-#include <c10/cuda/CUDAGuard.h>
 #include <gtest/gtest.h>
-#include "comms/torchcomms/TorchWork.hpp"
-#include "comms/torchcomms/tests/integration/cpp/TorchCommTestHelpers.h"
-
-std::unique_ptr<TorchCommTestWrapper> BroadcastTest::createWrapper() {
-  return std::make_unique<TorchCommTestWrapper>();
-}
-
-void BroadcastTest::SetUp() {
-  wrapper_ = createWrapper();
-  torchcomm_ = wrapper_->getTorchComm();
-  rank_ = torchcomm_->getRank();
-  num_ranks_ = torchcomm_->getSize();
-  device_type_ = wrapper_->getDevice().type();
-}
-
-void BroadcastTest::TearDown() {
-  // Explicitly reset the TorchComm object to ensure proper cleanup
-  torchcomm_.reset();
-  wrapper_.reset();
-}
+#include <memory>
+#include "TorchCommTestHelpers.h"
 
 // Test function for synchronous broadcast with work object
-void BroadcastTest::testSyncBroadcast(int count, at::ScalarType dtype) {
+template <typename Fixture>
+void BroadcastTest<Fixture>::testSync(int count, at::ScalarType dtype) {
   SCOPED_TRACE(
-      ::testing::Message() << "Testing sync broadcast with count=" << count
-                           << " and dtype=" << getDtypeName(dtype));
+      ::testing::Message() << "count=" << count
+                           << " dtype=" << getDtypeName(dtype));
 
   const int root_rank = 0;
   const int root_value = 99;
 
-  // Create tensor with different values based on rank
-  at::Tensor tensor =
-      createBroadcastTensor(root_rank, root_value, count, dtype);
+  at::Tensor tensor = createTensor(root_rank, root_value, count, dtype);
+  auto originalTensor = tensor.clone();
 
-  // Call broadcast
-  auto work = torchcomm_->broadcast(tensor, root_rank, false);
-  work->wait();
-
-  // Verify the results
-  verifyBroadcastResults(tensor, root_value);
+  auto execute = [&]() {
+    auto work = torchcomm_->broadcast(tensor, root_rank, false);
+    work->wait();
+  };
+  auto reset = [&]() { tensor.copy_(originalTensor); };
+  auto verify = [&]() { verifyResults(tensor, root_value); };
+  run(execute, reset, verify);
 }
 
 // Test function for synchronous broadcast without work object
-void BroadcastTest::testSyncBroadcastNoWork(int count, at::ScalarType dtype) {
+template <typename Fixture>
+void BroadcastTest<Fixture>::testSyncNoWork(int count, at::ScalarType dtype) {
   SCOPED_TRACE(
-      ::testing::Message()
-      << "Testing sync broadcast without work object with count=" << count
-      << " and dtype=" << getDtypeName(dtype));
+      ::testing::Message() << "count=" << count
+                           << " dtype=" << getDtypeName(dtype));
 
   const int root_rank = 0;
   const int root_value = 99;
 
-  // Create tensor with different values based on rank
-  at::Tensor tensor =
-      createBroadcastTensor(root_rank, root_value, count, dtype);
+  at::Tensor tensor = createTensor(root_rank, root_value, count, dtype);
+  auto originalTensor = tensor.clone();
 
-  // Call broadcast without keeping the work object
-  torchcomm_->broadcast(tensor, root_rank, false);
-
-  // Verify the results
-  verifyBroadcastResults(tensor, root_value);
+  auto execute = [&]() { torchcomm_->broadcast(tensor, root_rank, false); };
+  auto reset = [&]() { tensor.copy_(originalTensor); };
+  auto verify = [&]() { verifyResults(tensor, root_value); };
+  run(execute, reset, verify);
 }
 
 // Test function for asynchronous broadcast with wait
-void BroadcastTest::testAsyncBroadcast(int count, at::ScalarType dtype) {
+template <typename Fixture>
+void BroadcastTest<Fixture>::testAsync(int count, at::ScalarType dtype) {
   SCOPED_TRACE(
-      ::testing::Message() << "Testing async broadcast with count=" << count
-                           << " and dtype=" << getDtypeName(dtype));
+      ::testing::Message() << "count=" << count
+                           << " dtype=" << getDtypeName(dtype));
 
   const int root_rank = 0;
-  const int root_value = 42;
+  const int root_value = 99;
 
-  // Create tensor with different values based on rank
-  at::Tensor tensor =
-      createBroadcastTensor(root_rank, root_value, count, dtype);
+  at::Tensor tensor = createTensor(root_rank, root_value, count, dtype);
+  auto originalTensor = tensor.clone();
 
-  // Call broadcast
-  auto work = torchcomm_->broadcast(tensor, root_rank, true);
-
-  // Wait for the broadcast to complete
-  work->wait();
-
-  // Verify the results
-  verifyBroadcastResults(tensor, root_value);
+  auto execute = [&]() {
+    auto work = torchcomm_->broadcast(tensor, root_rank, true);
+    work->wait();
+  };
+  auto reset = [&]() { tensor.copy_(originalTensor); };
+  auto verify = [&]() { verifyResults(tensor, root_value); };
+  run(execute, reset, verify);
 }
 
 // Test function for asynchronous broadcast with early reset
-void BroadcastTest::testAsyncBroadcastEarlyReset(
+template <typename Fixture>
+void BroadcastTest<Fixture>::testAsyncEarlyReset(
     int count,
     at::ScalarType dtype) {
   SCOPED_TRACE(
-      ::testing::Message()
-      << "Testing async broadcast with early reset with count=" << count
-      << " and dtype=" << getDtypeName(dtype));
+      ::testing::Message() << "count=" << count
+                           << " dtype=" << getDtypeName(dtype));
 
   const int root_rank = 0;
-  const int root_value = 42;
+  const int root_value = 99;
 
-  // Create tensor with different values based on rank
-  at::Tensor tensor =
-      createBroadcastTensor(root_rank, root_value, count, dtype);
+  at::Tensor tensor = createTensor(root_rank, root_value, count, dtype);
+  auto originalTensor = tensor.clone();
 
-  // Call broadcast
-  auto work = torchcomm_->broadcast(tensor, root_rank, true);
-
-  // Wait for the work to complete before resetting
-  work->wait();
-
-  // Reset the work object
-  work.reset();
-
-  // Verify the results
-  verifyBroadcastResults(tensor, root_value);
+  auto execute = [&]() {
+    auto work = torchcomm_->broadcast(tensor, root_rank, true);
+    work->wait();
+    work.reset();
+  };
+  auto reset = [&]() { tensor.copy_(originalTensor); };
+  auto verify = [&]() { verifyResults(tensor, root_value); };
+  run(execute, reset, verify);
 }
 
 // Test function for asynchronous broadcast with input deleted after enqueue
-void BroadcastTest::testBroadcastInputDeleted(int count, at::ScalarType dtype) {
+template <typename Fixture>
+void BroadcastTest<Fixture>::testInputDeleted(int count, at::ScalarType dtype) {
   SCOPED_TRACE(
-      ::testing::Message()
-      << "Testing async broadcast with input deleted after enqueue with count="
-      << count << " and dtype=" << getDtypeName(dtype));
-
-  const int root_rank = 0;
-  const int root_value = 42;
-
-  // Create work object to hold the async operation
-  c10::intrusive_ptr<torch::comms::TorchWork> work;
-
-  {
-    // Create tensor in a limited scope
-    at::Tensor tensor =
-        createBroadcastTensor(root_rank, root_value, count, dtype);
-
-    // Call broadcast
-    work = torchcomm_->broadcast(tensor, root_rank, false);
-
-    // Tensor goes out of scope here and gets deleted
-  }
-
-  // Wait for the broadcast to complete even though tensor is deleted
-  work->wait();
-
-  // Note: Cannot verify results since tensor is deleted
-  // This test validates that the operation completes without crashing
-}
-
-// CUDA Graph test function for broadcast
-void BroadcastTest::testGraphBroadcast(int count, at::ScalarType dtype) {
-  // Skip CUDA Graph tests when running on CPU
-  if (isRunningOnCPU()) {
-    GTEST_SKIP() << "CUDA Graph tests are not supported on CPU";
-  }
-
-  SCOPED_TRACE(
-      ::testing::Message() << "Testing CUDA Graph broadcast with count="
-                           << count << " and dtype=" << getDtypeName(dtype));
-
-  // Create a non-default CUDA stream (required for CUDA graph capture)
-  at::cuda::CUDAStream stream = at::cuda::getStreamFromPool();
-
-  // Set the stream as current for graph capture
-  at::cuda::CUDAStreamGuard guard(stream);
+      ::testing::Message() << "count=" << count
+                           << " dtype=" << getDtypeName(dtype));
 
   const int root_rank = 0;
   const int root_value = 99;
 
-  // Create tensor with different values based on rank AFTER setting non-default
-  // stream but BEFORE graph capture
-  at::Tensor tensor =
-      createBroadcastTensor(root_rank, root_value, count, dtype);
-  at::Tensor original_values = tensor.clone();
+  auto tensor = std::make_shared<at::Tensor>(
+      createTensor(root_rank, root_value, count, dtype));
 
-  // Create PyTorch CUDA graph
-  at::cuda::CUDAGraph graph;
-
-  // Capture the broadcast operation in the graph
-  graph.capture_begin();
-
-  // Call broadcast without keeping the work object
-  torchcomm_->broadcast(tensor, root_rank, false);
-
-  graph.capture_end();
-
-  // Replay the captured graph multiple times
-  for (int i = 0; i < num_replays; ++i) {
-    // Reset tensor to original values before each replay
-    tensor.copy_(original_values);
-
-    graph.replay();
-
-    // Verify the results after each replay
-    verifyBroadcastResults(tensor, root_value);
-  }
-}
-
-// CUDA Graph test function for broadcast with input deleted after graph
-// creation
-void BroadcastTest::testGraphBroadcastInputDeleted(
-    int count,
-    at::ScalarType dtype) {
-  // Skip CUDA Graph tests when running on CPU
-  if (isRunningOnCPU()) {
-    GTEST_SKIP() << "CUDA Graph tests are not supported on CPU";
-  }
-
-  SCOPED_TRACE(
-      ::testing::Message()
-      << "Testing CUDA Graph broadcast with input deleted after graph creation with count="
-      << count << " and dtype=" << getDtypeName(dtype));
-
-  // Create a non-default CUDA stream (required for CUDA graph capture)
-  at::cuda::CUDAStream stream = at::cuda::getStreamFromPool();
-
-  // Set the stream as current for graph capture
-  at::cuda::CUDAStreamGuard guard(stream);
-
-  const int root_rank = 0;
-  const int root_value = 99;
-
-  // Create PyTorch CUDA graph
-  at::cuda::CUDAGraph graph;
-
-  {
-    // Create tensor in a limited scope
-    at::Tensor tensor =
-        createBroadcastTensor(root_rank, root_value, count, dtype);
-
-    // Capture the broadcast operation in the graph
-    graph.capture_begin();
-
-    // Call broadcast without keeping the work object
-    torchcomm_->broadcast(tensor, root_rank, false);
-
-    graph.capture_end();
-
-    // Tensor goes out of scope here and gets deleted
-  }
-
-  // Replay the captured graph multiple times even though tensor is deleted
-  for (int i = 0; i < num_replays; ++i) {
-    graph.replay();
-
-    // Note: Cannot verify results since tensor is deleted
-    // This test validates that the graph replay completes without crashing
-  }
+  auto execute = [&]() { torchcomm_->broadcast(*tensor, root_rank, false); };
+  auto cleanup = [&]() { tensor.reset(); };
+  run(execute, {}, {}, cleanup);
 }
 
 // Helper function to create tensor for broadcast
-at::Tensor BroadcastTest::createBroadcastTensor(
+template <typename Fixture>
+at::Tensor BroadcastTest<Fixture>::createTensor(
     int root_rank,
     int value,
     int count,
     at::ScalarType dtype) {
   auto options = at::TensorOptions().dtype(dtype).device(device_type_);
   at::Tensor tensor;
-
-  // Initialize tensor based on dtype
   if (dtype == at::kFloat || dtype == at::kHalf || dtype == at::kBFloat16) {
     tensor = rank_ == root_rank
         ? at::ones({count}, options) * static_cast<float>(value)
@@ -275,15 +134,18 @@ at::Tensor BroadcastTest::createBroadcastTensor(
         ? at::ones({count}, options) * static_cast<signed char>(value)
         : at::zeros({count}, options);
   }
-
   return tensor;
 }
 
 // Helper function to verify results
-void BroadcastTest::verifyBroadcastResults(
+template <typename Fixture>
+void BroadcastTest<Fixture>::verifyResults(
     const at::Tensor& tensor,
     int value) {
-  // Use verifyTensorEquality to compare tensor with expected tensor
   std::string description = "broadcast with value " + std::to_string(value);
   verifyTensorEquality(tensor.cpu(), value, description);
 }
+
+template class BroadcastTest<EagerTestFixture<BroadcastParams>>;
+template class BroadcastTest<GraphTestFixture<BroadcastParams, 1>>;
+template class BroadcastTest<GraphTestFixture<BroadcastParams, 2>>;

--- a/comms/torchcomms/tests/integration/cpp/BroadcastTest.hpp
+++ b/comms/torchcomms/tests/integration/cpp/BroadcastTest.hpp
@@ -1,48 +1,33 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
+
 #pragma once
 
-#include <ATen/cuda/CUDAContext.h>
-#include <ATen/cuda/CUDAGraph.h>
-#include <c10/cuda/CUDAGuard.h>
+#include <ATen/ATen.h>
+#include <c10/core/Device.h>
 #include <gtest/gtest.h>
+#include <memory>
+#include <tuple>
+#include "comms/torchcomms/tests/integration/cpp/GraphTestFixtures.hpp"
 #include "comms/torchcomms/tests/integration/cpp/TorchCommTestHelpers.h"
 
-class BroadcastTest
-    : public ::testing::TestWithParam<std::tuple<int, at::ScalarType>> {
- public:
-  BroadcastTest() : BroadcastTest(c10::DeviceType::CUDA) {}
-  explicit BroadcastTest(c10::DeviceType device_type)
-      : rank_(0), num_ranks_(0), device_type_(device_type) {}
+using BroadcastParams = std::tuple<int, at::ScalarType>;
 
-  // Test function declarations with parameters
-  void testSyncBroadcast(int count, at::ScalarType dtype);
-  void testSyncBroadcastNoWork(int count, at::ScalarType dtype);
-  void testAsyncBroadcast(int count, at::ScalarType dtype);
-  void testAsyncBroadcastEarlyReset(int count, at::ScalarType dtype);
-  void testBroadcastInputDeleted(int count, at::ScalarType dtype);
-  void testGraphBroadcast(int count, at::ScalarType dtype);
-  void testGraphBroadcastInputDeleted(int count, at::ScalarType dtype);
-
+template <typename Fixture>
+class BroadcastTest : public Fixture {
  protected:
-  virtual std::unique_ptr<TorchCommTestWrapper> createWrapper();
+  using Fixture::device_type_;
+  using Fixture::num_ranks_;
+  using Fixture::rank_;
+  using Fixture::run;
+  using Fixture::torchcomm_;
 
-  virtual void SetUp() override;
+  void testSync(int count, at::ScalarType dtype);
+  void testSyncNoWork(int count, at::ScalarType dtype);
+  void testAsync(int count, at::ScalarType dtype);
+  void testAsyncEarlyReset(int count, at::ScalarType dtype);
+  void testInputDeleted(int count, at::ScalarType dtype);
 
-  virtual void TearDown() override;
-
-  std::unique_ptr<TorchCommTestWrapper> wrapper_;
-  std::shared_ptr<torch::comms::TorchComm> torchcomm_;
-  int rank_;
-  int num_ranks_;
-  c10::DeviceType device_type_;
-
-  static constexpr int num_replays = 4;
-
-  // Helper function declarations with parameters
-  at::Tensor createBroadcastTensor(
-      int root_rank,
-      int value,
-      int count,
-      at::ScalarType dtype);
-  void verifyBroadcastResults(const at::Tensor& tensor, int value);
+  at::Tensor
+  createTensor(int rootRank, int value, int count, at::ScalarType dtype);
+  void verifyResults(const at::Tensor& tensor, int value);
 };

--- a/comms/torchcomms/tests/integration/cpp/BroadcastTestMain.cpp
+++ b/comms/torchcomms/tests/integration/cpp/BroadcastTestMain.cpp
@@ -5,59 +5,123 @@
 #include <gtest/gtest.h>
 #include "TorchCommTestHelpers.h"
 
-TEST_P(BroadcastTest, SyncBroadcast) {
+using Eager = BroadcastTest<EagerTestFixture<BroadcastParams>>;
+using SingleGraph = BroadcastTest<GraphTestFixture<BroadcastParams, 1>>;
+using MultiGraph = BroadcastTest<GraphTestFixture<BroadcastParams, 2>>;
+
+TEST_P(Eager, Sync) {
   int count = std::get<0>(GetParam());
   at::ScalarType dtype = std::get<1>(GetParam());
-  testSyncBroadcast(count, dtype);
+  testSync(count, dtype);
 }
 
-TEST_P(BroadcastTest, SyncBroadcastNoWork) {
+TEST_P(Eager, SyncNoWork) {
   int count = std::get<0>(GetParam());
   at::ScalarType dtype = std::get<1>(GetParam());
-  testSyncBroadcastNoWork(count, dtype);
+  testSyncNoWork(count, dtype);
 }
 
-TEST_P(BroadcastTest, AsyncBroadcast) {
+TEST_P(Eager, Async) {
   int count = std::get<0>(GetParam());
   at::ScalarType dtype = std::get<1>(GetParam());
-  testAsyncBroadcast(count, dtype);
+  testAsync(count, dtype);
 }
 
-TEST_P(BroadcastTest, AsyncBroadcastEarlyReset) {
+TEST_P(Eager, AsyncEarlyReset) {
   int count = std::get<0>(GetParam());
   at::ScalarType dtype = std::get<1>(GetParam());
-  testAsyncBroadcastEarlyReset(count, dtype);
+  testAsyncEarlyReset(count, dtype);
 }
 
-TEST_P(BroadcastTest, BroadcastInputDeleted) {
+TEST_P(Eager, InputDeleted) {
   int count = std::get<0>(GetParam());
   at::ScalarType dtype = std::get<1>(GetParam());
-  testBroadcastInputDeleted(count, dtype);
+  testInputDeleted(count, dtype);
 }
 
-TEST_P(BroadcastTest, GraphBroadcast) {
+TEST_P(SingleGraph, Sync) {
   int count = std::get<0>(GetParam());
   at::ScalarType dtype = std::get<1>(GetParam());
-  testGraphBroadcast(count, dtype);
+  testSync(count, dtype);
 }
 
-TEST_P(BroadcastTest, GraphBroadcastInputDeleted) {
+TEST_P(SingleGraph, SyncNoWork) {
   int count = std::get<0>(GetParam());
   at::ScalarType dtype = std::get<1>(GetParam());
-  testGraphBroadcastInputDeleted(count, dtype);
+  testSyncNoWork(count, dtype);
+}
+
+TEST_P(SingleGraph, Async) {
+  int count = std::get<0>(GetParam());
+  at::ScalarType dtype = std::get<1>(GetParam());
+  testAsync(count, dtype);
+}
+
+TEST_P(SingleGraph, InputDeleted) {
+  int count = std::get<0>(GetParam());
+  at::ScalarType dtype = std::get<1>(GetParam());
+  testInputDeleted(count, dtype);
+}
+
+TEST_P(MultiGraph, Sync) {
+  int count = std::get<0>(GetParam());
+  at::ScalarType dtype = std::get<1>(GetParam());
+  testSync(count, dtype);
+}
+
+TEST_P(MultiGraph, SyncNoWork) {
+  int count = std::get<0>(GetParam());
+  at::ScalarType dtype = std::get<1>(GetParam());
+  testSyncNoWork(count, dtype);
+}
+
+TEST_P(MultiGraph, Async) {
+  int count = std::get<0>(GetParam());
+  at::ScalarType dtype = std::get<1>(GetParam());
+  testAsync(count, dtype);
+}
+
+TEST_P(MultiGraph, InputDeleted) {
+  int count = std::get<0>(GetParam());
+  at::ScalarType dtype = std::get<1>(GetParam());
+  testInputDeleted(count, dtype);
+}
+
+auto broadcastParamValues() {
+  return ::testing::Combine(
+      ::testing::Values(0, 4, 1024, 1024 * 1024),
+      ::testing::Values(at::kFloat, at::kInt, at::kChar));
+}
+
+auto broadcastGraphParamValues() {
+  return ::testing::Combine(
+      ::testing::Values(0, 1000, 1024 * 1024), ::testing::Values(at::kFloat));
+}
+
+auto broadcastParamNamer(
+    const ::testing::TestParamInfo<BroadcastParams>& info) {
+  int count = std::get<0>(info.param);
+  at::ScalarType dtype = std::get<1>(info.param);
+  return "Count_" + std::to_string(count) + "_" + getDtypeName(dtype);
 }
 
 INSTANTIATE_TEST_SUITE_P(
-    BroadcastTestParams,
-    BroadcastTest,
-    ::testing::Combine(
-        ::testing::Values(0, 4, 1024, 1024 * 1024),
-        ::testing::Values(at::kFloat, at::kInt, at::kChar)),
-    [](const ::testing::TestParamInfo<std::tuple<int, at::ScalarType>>& info) {
-      int count = std::get<0>(info.param);
-      at::ScalarType dtype = std::get<1>(info.param);
-      return "Count_" + std::to_string(count) + "_" + getDtypeName(dtype);
-    });
+    Broadcast,
+    Eager,
+    broadcastParamValues(),
+    broadcastParamNamer);
+
+INSTANTIATE_TEST_SUITE_P(
+    Broadcast,
+    SingleGraph,
+    broadcastGraphParamValues(),
+    broadcastParamNamer);
+
+INSTANTIATE_TEST_SUITE_P(
+    Broadcast,
+    MultiGraph,
+    broadcastGraphParamValues(),
+    broadcastParamNamer);
 
 // This main function is provided by gtest
 int main(int argc, char** argv) {


### PR DESCRIPTION
Summary:
- Migrate Broadcast to template-based `BroadcastTest<Fixture>` with stateless `BroadcastHelper` class
- Broadcast-specific: in-place collective with no ReduceOp parameter; root rank initialized with broadcast value, non-root ranks with zeros
- Graph tests use reduced parameters (Float only, counts={0,1000,1M})
- HCCL BroadcastTest updated to inherit from `BroadcastTest<EagerTestFixture<BroadcastParams>>` since MTIA has no CUDA graph support

Test counts (Broadcast):
  Eager:  12 params (4 counts × 3 dtypes) × 5 methods = 60
  Graph:   3 params (3 counts × 1 dtype) × 4 methods × 2 fixtures = 24
  Total: 84

Reviewed By: pavanbalaji

Differential Revision: D93253007


