### PR TITLE
Refactor Gather integration tests with graph fixture

### DIFF
--- a/comms/torchcomms/tests/integration/cpp/GatherTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/GatherTest.cpp
@@ -2,276 +2,200 @@
 
 #include "GatherTest.hpp"
 
-#include <ATen/cuda/CUDAGraph.h>
-#include <c10/cuda/CUDAGuard.h>
 #include <gtest/gtest.h>
-#include <vector>
-#include "comms/torchcomms/tests/integration/cpp/TorchCommTestHelpers.h"
-
-std::unique_ptr<TorchCommTestWrapper> GatherTest::createWrapper() {
-  return std::make_unique<TorchCommTestWrapper>();
-}
-
-void GatherTest::synchronizeStream() {
-  if (!isRunningOnCPU()) {
-    at::cuda::getCurrentCUDAStream(0).synchronize();
-  }
-}
-
-void GatherTest::SetUp() {
-  wrapper_ = createWrapper();
-  torchcomm_ = wrapper_->getTorchComm();
-  rank_ = torchcomm_->getRank();
-  num_ranks_ = torchcomm_->getSize();
-  device_type_ = wrapper_->getDevice().type();
-}
-
-void GatherTest::TearDown() {
-  // Explicitly reset the TorchComm object to ensure proper cleanup
-  torchcomm_.reset();
-  wrapper_.reset();
-}
+#include <memory>
+#include "TorchCommTestHelpers.h"
 
 // Test function for synchronous gather with work object
-void GatherTest::testSyncGather(int count, at::ScalarType dtype) {
+template <typename Fixture>
+void GatherTest<Fixture>::testSync(int count, at::ScalarType dtype) {
   SCOPED_TRACE(
-      ::testing::Message() << "Testing sync gather with count=" << count
-                           << " and dtype=" << getDtypeName(dtype));
+      ::testing::Message() << "count=" << count
+                           << " dtype=" << getDtypeName(dtype));
 
-  // Create input tensor with rank-specific values
-  at::Tensor input = createInputTensor(count, dtype);
-
-  // Root rank will receive data from all ranks
   const int root_rank = 0;
+  at::Tensor input = createInputTensor(count, dtype);
   std::vector<at::Tensor> outputs =
       createOutputTensors(root_rank, count, dtype);
 
-  // Call gather
-  auto work = torchcomm_->gather(outputs, input, root_rank, false);
-  work->wait();
+  std::vector<at::Tensor> original_outputs;
+  original_outputs.reserve(outputs.size());
+  for (const auto& output : outputs) {
+    original_outputs.push_back(output.clone());
+  }
 
-  // Verify the results on root rank
-  verifyGatherResults(outputs, root_rank);
+  auto execute = [&]() {
+    auto work = torchcomm_->gather(outputs, input, root_rank, false);
+    work->wait();
+  };
+  auto reset = [&]() {
+    for (size_t i = 0; i < outputs.size(); i++) {
+      outputs[i].copy_(original_outputs[i]);
+    }
+  };
+  auto verify = [&]() {
+    if (rank_ == root_rank) {
+      verifyResults(outputs);
+    } else {
+      synchronizeStream();
+    }
+  };
+  run(execute, reset, verify);
 }
 
 // Test function for synchronous gather without work object
-void GatherTest::testSyncGatherNoWork(int count, at::ScalarType dtype) {
+template <typename Fixture>
+void GatherTest<Fixture>::testSyncNoWork(int count, at::ScalarType dtype) {
   SCOPED_TRACE(
-      ::testing::Message()
-      << "Testing sync gather without work object with count=" << count
-      << " and dtype=" << getDtypeName(dtype));
+      ::testing::Message() << "count=" << count
+                           << " dtype=" << getDtypeName(dtype));
 
-  // Create input tensor with rank-specific values
-  at::Tensor input = createInputTensor(count, dtype);
-
-  // Root rank will receive data from all ranks
   const int root_rank = 0;
+  at::Tensor input = createInputTensor(count, dtype);
   std::vector<at::Tensor> outputs =
       createOutputTensors(root_rank, count, dtype);
 
-  // Call gather without keeping the work object
-  torchcomm_->gather(outputs, input, root_rank, false);
+  std::vector<at::Tensor> original_outputs;
+  original_outputs.reserve(outputs.size());
+  for (const auto& output : outputs) {
+    original_outputs.push_back(output.clone());
+  }
 
-  // Verify the results on root rank
-  verifyGatherResults(outputs, root_rank);
+  auto execute = [&]() {
+    torchcomm_->gather(outputs, input, root_rank, false);
+  };
+  auto reset = [&]() {
+    for (size_t i = 0; i < outputs.size(); i++) {
+      outputs[i].copy_(original_outputs[i]);
+    }
+  };
+  auto verify = [&]() {
+    if (rank_ == root_rank) {
+      verifyResults(outputs);
+    } else {
+      synchronizeStream();
+    }
+  };
+  run(execute, reset, verify);
 }
 
 // Test function for asynchronous gather with wait
-void GatherTest::testAsyncGather(int count, at::ScalarType dtype) {
+template <typename Fixture>
+void GatherTest<Fixture>::testAsync(int count, at::ScalarType dtype) {
   SCOPED_TRACE(
-      ::testing::Message() << "Testing async gather with count=" << count
-                           << " and dtype=" << getDtypeName(dtype));
+      ::testing::Message() << "count=" << count
+                           << " dtype=" << getDtypeName(dtype));
 
-  // Create input tensor with rank-specific values
-  at::Tensor input = createInputTensor(count, dtype);
-
-  // Root rank will receive data from all ranks
   const int root_rank = 0;
+  at::Tensor input = createInputTensor(count, dtype);
   std::vector<at::Tensor> outputs =
       createOutputTensors(root_rank, count, dtype);
 
-  // Call gather
-  auto work = torchcomm_->gather(outputs, input, root_rank, true);
+  std::vector<at::Tensor> original_outputs;
+  original_outputs.reserve(outputs.size());
+  for (const auto& output : outputs) {
+    original_outputs.push_back(output.clone());
+  }
 
-  // Wait for the gather to complete
-  work->wait();
-
-  // Verify the results on root rank
-  verifyGatherResults(outputs, root_rank);
+  auto execute = [&]() {
+    auto work = torchcomm_->gather(outputs, input, root_rank, true);
+    work->wait();
+  };
+  auto reset = [&]() {
+    for (size_t i = 0; i < outputs.size(); i++) {
+      outputs[i].copy_(original_outputs[i]);
+    }
+  };
+  auto verify = [&]() {
+    if (rank_ == root_rank) {
+      verifyResults(outputs);
+    } else {
+      synchronizeStream();
+    }
+  };
+  run(execute, reset, verify);
 }
 
 // Test function for asynchronous gather with early reset
-void GatherTest::testAsyncGatherEarlyReset(int count, at::ScalarType dtype) {
+template <typename Fixture>
+void GatherTest<Fixture>::testAsyncEarlyReset(int count, at::ScalarType dtype) {
   SCOPED_TRACE(
-      ::testing::Message()
-      << "Testing async gather with early reset with count=" << count
-      << " and dtype=" << getDtypeName(dtype));
+      ::testing::Message() << "count=" << count
+                           << " dtype=" << getDtypeName(dtype));
 
-  // Create input tensor with rank-specific values
-  at::Tensor input = createInputTensor(count, dtype);
-
-  // Root rank will receive data from all ranks
   const int root_rank = 0;
+  at::Tensor input = createInputTensor(count, dtype);
   std::vector<at::Tensor> outputs =
       createOutputTensors(root_rank, count, dtype);
 
-  // Call gather
-  auto work = torchcomm_->gather(outputs, input, root_rank, true);
+  std::vector<at::Tensor> original_outputs;
+  original_outputs.reserve(outputs.size());
+  for (const auto& output : outputs) {
+    original_outputs.push_back(output.clone());
+  }
 
-  // Wait for the work to complete before resetting
-  work->wait();
-
-  // Reset the work object
-  work.reset();
-
-  // Verify the results on root rank
-  verifyGatherResults(outputs, root_rank);
+  auto execute = [&]() {
+    auto work = torchcomm_->gather(outputs, input, root_rank, true);
+    work->wait();
+    work.reset();
+  };
+  auto reset = [&]() {
+    for (size_t i = 0; i < outputs.size(); i++) {
+      outputs[i].copy_(original_outputs[i]);
+    }
+  };
+  auto verify = [&]() {
+    if (rank_ == root_rank) {
+      verifyResults(outputs);
+    } else {
+      synchronizeStream();
+    }
+  };
+  run(execute, reset, verify);
 }
 
 // Test function for asynchronous gather with input deleted after enqueue
-void GatherTest::testGatherInputDeleted(int count, at::ScalarType dtype) {
+template <typename Fixture>
+void GatherTest<Fixture>::testInputDeleted(int count, at::ScalarType dtype) {
   SCOPED_TRACE(
-      ::testing::Message()
-      << "Testing async gather with input deleted after enqueue with count="
-      << count << " and dtype=" << getDtypeName(dtype));
+      ::testing::Message() << "count=" << count
+                           << " dtype=" << getDtypeName(dtype));
 
-  // Root rank will receive data from all ranks
   const int root_rank = 0;
+  auto input = std::make_shared<at::Tensor>(createInputTensor(count, dtype));
   std::vector<at::Tensor> outputs =
       createOutputTensors(root_rank, count, dtype);
 
-  {
-    // Create input tensor in a limited scope
-    at::Tensor input = createInputTensor(count, dtype);
-
-    // Call gather
-    torchcomm_->gather(outputs, input, root_rank, false);
-
-    // Input tensor goes out of scope here and gets deleted
-  }
-
-  // Verify the results on root rank
-  verifyGatherResults(outputs, root_rank);
-}
-
-// CUDA Graph test function for gather
-void GatherTest::testGraphGather(int count, at::ScalarType dtype) {
-  // Skip CUDA Graph tests when running on CPU
-  if (isRunningOnCPU()) {
-    GTEST_SKIP() << "CUDA Graph tests are not supported on CPU";
-  }
-
-  SCOPED_TRACE(
-      ::testing::Message() << "Testing CUDA Graph gather with count=" << count
-                           << " and dtype=" << getDtypeName(dtype));
-
-  // Create a non-default CUDA stream (required for CUDA graph capture)
-  at::cuda::CUDAStream stream = at::cuda::getStreamFromPool();
-
-  // Set the stream as current for graph capture
-  at::cuda::CUDAStreamGuard guard(stream);
-
-  // Create input tensor with rank-specific values AFTER setting non-default
-  // stream but BEFORE graph capture
-  at::Tensor input = createInputTensor(count, dtype);
-
-  // Root rank will receive data from all ranks
-  const int root_rank = 0;
-  std::vector<at::Tensor> outputs =
-      createOutputTensors(root_rank, count, dtype);
   std::vector<at::Tensor> original_outputs;
   original_outputs.reserve(outputs.size());
   for (const auto& output : outputs) {
     original_outputs.push_back(output.clone());
   }
 
-  // Create PyTorch CUDA graph
-  at::cuda::CUDAGraph graph;
-
-  // Capture the gather operation in the graph
-  graph.capture_begin();
-
-  // Call gather without keeping the work object
-  torchcomm_->gather(outputs, input, root_rank, false);
-
-  graph.capture_end();
-
-  // Replay the captured graph multiple times
-  for (int i = 0; i < num_replays; ++i) {
-    // Reset output tensors before each replay
-    for (size_t j = 0; j < outputs.size(); ++j) {
-      outputs[j].copy_(original_outputs[j]);
+  auto execute = [&]() {
+    torchcomm_->gather(outputs, *input, root_rank, false);
+  };
+  auto reset = [&]() {
+    for (size_t i = 0; i < outputs.size(); i++) {
+      outputs[i].copy_(original_outputs[i]);
     }
-
-    graph.replay();
-
-    // Verify the results after each replay
-    verifyGatherResults(outputs, root_rank);
-  }
-}
-
-// CUDA Graph test function for gather with input deleted after graph creation
-void GatherTest::testGraphGatherInputDeleted(int count, at::ScalarType dtype) {
-  // Skip CUDA Graph tests when running on CPU
-  if (isRunningOnCPU()) {
-    GTEST_SKIP() << "CUDA Graph tests are not supported on CPU";
-  }
-
-  SCOPED_TRACE(
-      ::testing::Message()
-      << "Testing CUDA Graph gather with input deleted after graph creation with count="
-      << count << " and dtype=" << getDtypeName(dtype));
-
-  // Create a non-default CUDA stream (required for CUDA graph capture)
-  at::cuda::CUDAStream stream = at::cuda::getStreamFromPool();
-
-  // Set the stream as current for graph capture
-  at::cuda::CUDAStreamGuard guard(stream);
-
-  // Root rank will receive data from all ranks
-  const int root_rank = 0;
-  std::vector<at::Tensor> outputs =
-      createOutputTensors(root_rank, count, dtype);
-  std::vector<at::Tensor> original_outputs;
-  original_outputs.reserve(outputs.size());
-  for (const auto& output : outputs) {
-    original_outputs.push_back(output.clone());
-  }
-
-  // Create PyTorch CUDA graph
-  at::cuda::CUDAGraph graph;
-
-  {
-    // Create input tensor in a limited scope
-    at::Tensor input = createInputTensor(count, dtype);
-
-    // Capture the gather operation in the graph
-    graph.capture_begin();
-
-    // Call gather without keeping the work object
-    torchcomm_->gather(outputs, input, root_rank, false);
-
-    graph.capture_end();
-
-    // Input tensor goes out of scope here and gets deleted
-  }
-
-  // Replay the captured graph multiple times even though input is deleted
-  for (int i = 0; i < num_replays; ++i) {
-    // Reset output tensors before each replay
-    for (size_t j = 0; j < outputs.size(); ++j) {
-      outputs[j].copy_(original_outputs[j]);
+  };
+  auto verify = [&]() {
+    if (rank_ == root_rank) {
+      verifyResults(outputs);
+    } else {
+      synchronizeStream();
     }
-
-    graph.replay();
-
-    // Verify the results after each replay
-    verifyGatherResults(outputs, root_rank);
-  }
+  };
+  auto cleanup = [&]() { input.reset(); };
+  run(execute, reset, verify, cleanup);
 }
 
 // Helper function to create input tensor
-at::Tensor GatherTest::createInputTensor(int count, at::ScalarType dtype) {
+template <typename Fixture>
+at::Tensor GatherTest<Fixture>::createInputTensor(
+    int count,
+    at::ScalarType dtype) {
   auto options = at::TensorOptions().dtype(dtype).device(device_type_);
   at::Tensor input;
   if (dtype == at::kFloat || dtype == at::kHalf || dtype == at::kBFloat16) {
@@ -285,37 +209,39 @@ at::Tensor GatherTest::createInputTensor(int count, at::ScalarType dtype) {
 }
 
 // Helper function to create output tensors
-std::vector<at::Tensor> GatherTest::createOutputTensors(
+template <typename Fixture>
+std::vector<at::Tensor> GatherTest<Fixture>::createOutputTensors(
     int root_rank,
     int count,
     at::ScalarType dtype) {
   auto options = at::TensorOptions().dtype(dtype).device(device_type_);
   std::vector<at::Tensor> outputs;
-
-  // Only root rank needs to allocate output tensors
   if (rank_ == root_rank) {
     outputs.reserve(num_ranks_);
     for (int i = 0; i < num_ranks_; i++) {
       outputs.push_back(at::zeros({count}, options));
     }
   }
-
   return outputs;
 }
 
 // Helper function to verify results
-void GatherTest::verifyGatherResults(
-    const std::vector<at::Tensor>& outputs,
-    int root_rank) {
-  // Only verify on root rank
-  if (rank_ != root_rank) {
-    synchronizeStream();
-    return;
-  }
-
+template <typename Fixture>
+void GatherTest<Fixture>::verifyResults(
+    const std::vector<at::Tensor>& outputs) {
   for (int i = 0; i < num_ranks_; i++) {
-    // Use verifyTensorEquality to compare output with expected tensor
     std::string description = "gather rank " + std::to_string(i) + " tensor";
     verifyTensorEquality(outputs[i].cpu(), i + 1, description);
   }
 }
+
+template <typename Fixture>
+void GatherTest<Fixture>::synchronizeStream() {
+  if (device_type_ == c10::DeviceType::CUDA) {
+    at::cuda::getCurrentCUDAStream(0).synchronize();
+  }
+}
+
+template class GatherTest<EagerTestFixture<GatherParams>>;
+template class GatherTest<GraphTestFixture<GatherParams, 1>>;
+template class GatherTest<GraphTestFixture<GatherParams, 2>>;

--- a/comms/torchcomms/tests/integration/cpp/GatherTest.hpp
+++ b/comms/torchcomms/tests/integration/cpp/GatherTest.hpp
@@ -1,51 +1,36 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
+
 #pragma once
 
-#include <ATen/cuda/CUDAContext.h>
-#include <ATen/cuda/CUDAGraph.h>
-#include <c10/cuda/CUDAGuard.h>
+#include <ATen/ATen.h>
+#include <c10/core/Device.h>
 #include <gtest/gtest.h>
+#include <memory>
+#include <tuple>
 #include <vector>
+#include "comms/torchcomms/tests/integration/cpp/GraphTestFixtures.hpp"
 #include "comms/torchcomms/tests/integration/cpp/TorchCommTestHelpers.h"
 
-class GatherTest
-    : public ::testing::TestWithParam<std::tuple<int, at::ScalarType>> {
- public:
-  GatherTest() : GatherTest(c10::DeviceType::CUDA) {}
-  explicit GatherTest(c10::DeviceType device_type)
-      : rank_(0), num_ranks_(0), device_type_(device_type) {}
+using GatherParams = std::tuple<int, at::ScalarType>;
 
-  // Test function declarations with parameters
-  void testSyncGather(int count, at::ScalarType dtype);
-  void testSyncGatherNoWork(int count, at::ScalarType dtype);
-  void testAsyncGather(int count, at::ScalarType dtype);
-  void testAsyncGatherEarlyReset(int count, at::ScalarType dtype);
-  void testGatherInputDeleted(int count, at::ScalarType dtype);
-  void testGraphGather(int count, at::ScalarType dtype);
-  void testGraphGatherInputDeleted(int count, at::ScalarType dtype);
-
+template <typename Fixture>
+class GatherTest : public Fixture {
  protected:
-  virtual std::unique_ptr<TorchCommTestWrapper> createWrapper();
+  using Fixture::device_type_;
+  using Fixture::num_ranks_;
+  using Fixture::rank_;
+  using Fixture::run;
+  using Fixture::torchcomm_;
 
-  virtual void synchronizeStream();
+  void testSync(int count, at::ScalarType dtype);
+  void testSyncNoWork(int count, at::ScalarType dtype);
+  void testAsync(int count, at::ScalarType dtype);
+  void testAsyncEarlyReset(int count, at::ScalarType dtype);
+  void testInputDeleted(int count, at::ScalarType dtype);
 
-  virtual void SetUp() override;
-
-  virtual void TearDown() override;
-
-  std::unique_ptr<TorchCommTestWrapper> wrapper_;
-  std::shared_ptr<torch::comms::TorchComm> torchcomm_;
-  int rank_;
-  int num_ranks_;
-  c10::DeviceType device_type_;
-
-  static constexpr int num_replays = 4;
-
-  // Helper function declarations with parameters
   virtual at::Tensor createInputTensor(int count, at::ScalarType dtype);
   virtual std::vector<at::Tensor>
   createOutputTensors(int root_rank, int count, at::ScalarType dtype);
-  void verifyGatherResults(
-      const std::vector<at::Tensor>& outputs,
-      int root_rank);
+  void verifyResults(const std::vector<at::Tensor>& outputs);
+  virtual void synchronizeStream();
 };

--- a/comms/torchcomms/tests/integration/cpp/GatherTestMain.cpp
+++ b/comms/torchcomms/tests/integration/cpp/GatherTestMain.cpp
@@ -3,60 +3,120 @@
 #include "GatherTest.hpp"
 
 #include <gtest/gtest.h>
+#include "TorchCommTestHelpers.h"
 
-TEST_P(GatherTest, SyncGather) {
+using Eager = GatherTest<EagerTestFixture<GatherParams>>;
+using SingleGraph = GatherTest<GraphTestFixture<GatherParams, 1>>;
+using MultiGraph = GatherTest<GraphTestFixture<GatherParams, 2>>;
+
+TEST_P(Eager, Sync) {
   int count = std::get<0>(GetParam());
   at::ScalarType dtype = std::get<1>(GetParam());
-  testSyncGather(count, dtype);
+  testSync(count, dtype);
 }
 
-TEST_P(GatherTest, SyncGatherNoWork) {
+TEST_P(Eager, SyncNoWork) {
   int count = std::get<0>(GetParam());
   at::ScalarType dtype = std::get<1>(GetParam());
-  testSyncGatherNoWork(count, dtype);
+  testSyncNoWork(count, dtype);
 }
 
-TEST_P(GatherTest, AsyncGather) {
+TEST_P(Eager, Async) {
   int count = std::get<0>(GetParam());
   at::ScalarType dtype = std::get<1>(GetParam());
-  testAsyncGather(count, dtype);
+  testAsync(count, dtype);
 }
 
-TEST_P(GatherTest, AsyncGatherEarlyReset) {
+TEST_P(Eager, AsyncEarlyReset) {
   int count = std::get<0>(GetParam());
   at::ScalarType dtype = std::get<1>(GetParam());
-  testAsyncGatherEarlyReset(count, dtype);
+  testAsyncEarlyReset(count, dtype);
 }
 
-TEST_P(GatherTest, GatherInputDeleted) {
+TEST_P(Eager, InputDeleted) {
   int count = std::get<0>(GetParam());
   at::ScalarType dtype = std::get<1>(GetParam());
-  testGatherInputDeleted(count, dtype);
+  testInputDeleted(count, dtype);
 }
 
-TEST_P(GatherTest, GraphGather) {
+TEST_P(SingleGraph, Sync) {
   int count = std::get<0>(GetParam());
   at::ScalarType dtype = std::get<1>(GetParam());
-  testGraphGather(count, dtype);
+  testSync(count, dtype);
 }
 
-TEST_P(GatherTest, GraphGatherInputDeleted) {
+TEST_P(SingleGraph, SyncNoWork) {
   int count = std::get<0>(GetParam());
   at::ScalarType dtype = std::get<1>(GetParam());
-  testGraphGatherInputDeleted(count, dtype);
+  testSyncNoWork(count, dtype);
 }
+
+TEST_P(SingleGraph, Async) {
+  int count = std::get<0>(GetParam());
+  at::ScalarType dtype = std::get<1>(GetParam());
+  testAsync(count, dtype);
+}
+
+TEST_P(SingleGraph, InputDeleted) {
+  int count = std::get<0>(GetParam());
+  at::ScalarType dtype = std::get<1>(GetParam());
+  testInputDeleted(count, dtype);
+}
+
+TEST_P(MultiGraph, Sync) {
+  int count = std::get<0>(GetParam());
+  at::ScalarType dtype = std::get<1>(GetParam());
+  testSync(count, dtype);
+}
+
+TEST_P(MultiGraph, SyncNoWork) {
+  int count = std::get<0>(GetParam());
+  at::ScalarType dtype = std::get<1>(GetParam());
+  testSyncNoWork(count, dtype);
+}
+
+TEST_P(MultiGraph, Async) {
+  int count = std::get<0>(GetParam());
+  at::ScalarType dtype = std::get<1>(GetParam());
+  testAsync(count, dtype);
+}
+
+TEST_P(MultiGraph, InputDeleted) {
+  int count = std::get<0>(GetParam());
+  at::ScalarType dtype = std::get<1>(GetParam());
+  testInputDeleted(count, dtype);
+}
+
+auto gatherParamValues() {
+  return ::testing::Combine(
+      ::testing::Values(0, 4, 1024, 1024 * 1024),
+      ::testing::Values(at::kFloat, at::kInt, at::kChar));
+}
+
+auto gatherGraphParamValues() {
+  return ::testing::Combine(
+      ::testing::Values(0, 1000, 1024 * 1024), ::testing::Values(at::kFloat));
+}
+
+auto gatherParamNamer(const ::testing::TestParamInfo<GatherParams>& info) {
+  int count = std::get<0>(info.param);
+  at::ScalarType dtype = std::get<1>(info.param);
+  return "Count_" + std::to_string(count) + "_" + getDtypeName(dtype);
+}
+
+INSTANTIATE_TEST_SUITE_P(Gather, Eager, gatherParamValues(), gatherParamNamer);
 
 INSTANTIATE_TEST_SUITE_P(
-    GatherTestParams,
-    GatherTest,
-    ::testing::Combine(
-        ::testing::Values(0, 4, 1024, 1024 * 1024),
-        ::testing::Values(at::kFloat, at::kInt, at::kChar)),
-    [](const ::testing::TestParamInfo<std::tuple<int, at::ScalarType>>& info) {
-      int count = std::get<0>(info.param);
-      at::ScalarType dtype = std::get<1>(info.param);
-      return "Count_" + std::to_string(count) + "_" + getDtypeName(dtype);
-    });
+    Gather,
+    SingleGraph,
+    gatherGraphParamValues(),
+    gatherParamNamer);
+
+INSTANTIATE_TEST_SUITE_P(
+    Gather,
+    MultiGraph,
+    gatherGraphParamValues(),
+    gatherParamNamer);
 
 // This main function is provided by gtest
 int main(int argc, char** argv) {


### PR DESCRIPTION
Summary:
- Migrate Gather to template-based `GatherTest<Fixture>` with stateless `GatherHelper` class
- Gather-specific: root-rank-aware output allocation (only root allocates outputs, non-root gets empty vector) with `synchronizeStream` for non-root verification
- Graph tests use reduced parameters (Float only, counts={0,1000,1M})
- HCCL GatherTest updated to inherit from `GatherTest<EagerTestFixture<GatherParams>>` since MTIA has no CUDA graph support

Test counts (Gather):
  Eager:  12 params (4 counts × 3 dtypes) × 5 methods = 60
  Graph:   3 params (3 counts × 1 dtype) × 4 methods × 2 fixtures = 24
  Total: 84

Reviewed By: pavanbalaji

Differential Revision: D93253018


