### PR TITLE
revert to c++17 since ctran does not support it

### DIFF
--- a/comms/ncclx/v2_28/makefiles/common.mk
+++ b/comms/ncclx/v2_28/makefiles/common.mk
@@ -68,7 +68,7 @@ else
 endif
 $(info NVCC_GENCODE is ${NVCC_GENCODE})
 
-CXXSTD ?= -std=c++20
+CXXSTD ?= -std=c++17
 
 CXXFLAGS   := -DCUDA_MAJOR=$(CUDA_MAJOR) -DCUDA_MINOR=$(CUDA_MINOR) -fPIC -fvisibility=hidden \
               -Wall -Wno-unused-function -Wno-sign-compare -std=c++2a -Wvla \


### PR DESCRIPTION
Summary:
D93374315 update to c++20, however
ctran kernel codebase indirectly include fmt & folly which is not compatible with cuda compilation process with c++20.

Differential Revision: D93991155


