### PR TITLE
Refactor AllToAll integration tests with graph fixture

### DIFF
--- a/comms/torchcomms/tests/integration/cpp/AllToAllTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/AllToAllTest.cpp
@@ -2,308 +2,205 @@
 
 #include "AllToAllTest.hpp"
 
-#include <ATen/cuda/CUDAGraph.h>
-#include <c10/cuda/CUDAGuard.h>
 #include <gtest/gtest.h>
+#include <memory>
 #include <vector>
 #include "TorchCommTestHelpers.h"
 
-std::unique_ptr<TorchCommTestWrapper> AllToAllTest::createWrapper() {
-  return std::make_unique<TorchCommTestWrapper>();
-}
-
-void AllToAllTest::SetUp() {
-  wrapper_ = createWrapper();
-  torchcomm_ = wrapper_->getTorchComm();
-  rank_ = torchcomm_->getRank();
-  num_ranks_ = torchcomm_->getSize();
-  device_type_ = wrapper_->getDevice().type();
-}
-
-void AllToAllTest::TearDown() {
-  // Explicitly reset the TorchComm object to ensure proper cleanup
-  torchcomm_.reset();
-  wrapper_.reset();
-}
-
 // Test function for synchronous all_to_all with work object
-void AllToAllTest::testSyncAllToAll(int count, at::ScalarType dtype) {
+template <typename Fixture>
+void AllToAllTest<Fixture>::testSync(int count, at::ScalarType dtype) {
   SCOPED_TRACE(
-      ::testing::Message() << "Testing sync all_to_all with count=" << count
-                           << " and dtype=" << getDtypeName(dtype));
+      ::testing::Message() << "count=" << count
+                           << " dtype=" << getDtypeName(dtype));
 
-  auto input_tensors = createInputTensors(count, dtype);
-  auto output_tensors = createOutputTensors(count, dtype);
-  auto expected_output = createExpectedOutput();
+  std::vector<at::Tensor> input_tensors = createInputTensors(count, dtype);
+  std::vector<at::Tensor> output_tensors = createOutputTensors(count, dtype);
 
-  // Test synchronous all_to_all
-  auto work = torchcomm_->all_to_all(output_tensors, input_tensors, false);
-  work->wait();
+  std::vector<at::Tensor> original_output_tensors;
+  original_output_tensors.reserve(output_tensors.size());
+  for (const auto& t : output_tensors) {
+    original_output_tensors.push_back(t.clone());
+  }
 
-  verifyResults(output_tensors, expected_output);
+  auto execute = [&]() {
+    auto work = torchcomm_->all_to_all(output_tensors, input_tensors, false);
+    work->wait();
+  };
+  auto reset = [&]() {
+    for (size_t i = 0; i < output_tensors.size(); ++i) {
+      output_tensors[i].copy_(original_output_tensors[i]);
+    }
+  };
+  auto verify = [&]() { verifyResults(output_tensors); };
+  run(execute, reset, verify);
 }
 
 // Test function for synchronous all_to_all without work object
-void AllToAllTest::testSyncAllToAllNoWork(int count, at::ScalarType dtype) {
+template <typename Fixture>
+void AllToAllTest<Fixture>::testSyncNoWork(int count, at::ScalarType dtype) {
   SCOPED_TRACE(
-      ::testing::Message()
-      << "Testing sync all_to_all without work object with count=" << count
-      << " and dtype=" << getDtypeName(dtype));
+      ::testing::Message() << "count=" << count
+                           << " dtype=" << getDtypeName(dtype));
 
-  auto input_tensors = createInputTensors(count, dtype);
-  auto output_tensors = createOutputTensors(count, dtype);
-  auto expected_output = createExpectedOutput();
+  std::vector<at::Tensor> input_tensors = createInputTensors(count, dtype);
+  std::vector<at::Tensor> output_tensors = createOutputTensors(count, dtype);
 
-  // Test synchronous all_to_all without keeping the work object
-  torchcomm_->all_to_all(output_tensors, input_tensors, false);
+  std::vector<at::Tensor> original_output_tensors;
+  original_output_tensors.reserve(output_tensors.size());
+  for (const auto& t : output_tensors) {
+    original_output_tensors.push_back(t.clone());
+  }
 
-  verifyResults(output_tensors, expected_output);
+  auto execute = [&]() {
+    torchcomm_->all_to_all(output_tensors, input_tensors, false);
+  };
+  auto reset = [&]() {
+    for (size_t i = 0; i < output_tensors.size(); ++i) {
+      output_tensors[i].copy_(original_output_tensors[i]);
+    }
+  };
+  auto verify = [&]() { verifyResults(output_tensors); };
+  run(execute, reset, verify);
 }
 
 // Test function for asynchronous all_to_all with wait
-void AllToAllTest::testAsyncAllToAll(int count, at::ScalarType dtype) {
+template <typename Fixture>
+void AllToAllTest<Fixture>::testAsync(int count, at::ScalarType dtype) {
   SCOPED_TRACE(
-      ::testing::Message() << "Testing async all_to_all with count=" << count
-                           << " and dtype=" << getDtypeName(dtype));
+      ::testing::Message() << "count=" << count
+                           << " dtype=" << getDtypeName(dtype));
 
-  auto input_tensors = createInputTensors(count, dtype);
-  auto output_tensors = createOutputTensors(count, dtype);
-  auto expected_output = createExpectedOutput();
+  std::vector<at::Tensor> input_tensors = createInputTensors(count, dtype);
+  std::vector<at::Tensor> output_tensors = createOutputTensors(count, dtype);
 
-  // Test asynchronous all_to_all
-  auto work = torchcomm_->all_to_all(output_tensors, input_tensors, true);
+  std::vector<at::Tensor> original_output_tensors;
+  original_output_tensors.reserve(output_tensors.size());
+  for (const auto& t : output_tensors) {
+    original_output_tensors.push_back(t.clone());
+  }
 
-  // Wait for the all_to_all to complete
-  work->wait();
-
-  verifyResults(output_tensors, expected_output);
+  auto execute = [&]() {
+    auto work = torchcomm_->all_to_all(output_tensors, input_tensors, true);
+    work->wait();
+  };
+  auto reset = [&]() {
+    for (size_t i = 0; i < output_tensors.size(); ++i) {
+      output_tensors[i].copy_(original_output_tensors[i]);
+    }
+  };
+  auto verify = [&]() { verifyResults(output_tensors); };
+  run(execute, reset, verify);
 }
 
 // Test function for asynchronous all_to_all with early reset
-void AllToAllTest::testAsyncAllToAllEarlyReset(
+template <typename Fixture>
+void AllToAllTest<Fixture>::testAsyncEarlyReset(
     int count,
     at::ScalarType dtype) {
   SCOPED_TRACE(
-      ::testing::Message()
-      << "Testing async all_to_all with early reset with count=" << count
-      << " and dtype=" << getDtypeName(dtype));
+      ::testing::Message() << "count=" << count
+                           << " dtype=" << getDtypeName(dtype));
 
-  auto input_tensors = createInputTensors(count, dtype);
-  auto output_tensors = createOutputTensors(count, dtype);
-  auto expected_output = createExpectedOutput();
+  std::vector<at::Tensor> input_tensors = createInputTensors(count, dtype);
+  std::vector<at::Tensor> output_tensors = createOutputTensors(count, dtype);
 
-  // Test asynchronous all_to_all
-  auto work = torchcomm_->all_to_all(output_tensors, input_tensors, true);
+  std::vector<at::Tensor> original_output_tensors;
+  original_output_tensors.reserve(output_tensors.size());
+  for (const auto& t : output_tensors) {
+    original_output_tensors.push_back(t.clone());
+  }
 
-  // Wait for the work to complete before resetting
-  work->wait();
-
-  // Reset the work object
-  work.reset();
-
-  verifyResults(output_tensors, expected_output);
+  auto execute = [&]() {
+    auto work = torchcomm_->all_to_all(output_tensors, input_tensors, true);
+    work->wait();
+    work.reset();
+  };
+  auto reset = [&]() {
+    for (size_t i = 0; i < output_tensors.size(); ++i) {
+      output_tensors[i].copy_(original_output_tensors[i]);
+    }
+  };
+  auto verify = [&]() { verifyResults(output_tensors); };
+  run(execute, reset, verify);
 }
 
 // Test function for asynchronous all_to_all with input deleted after enqueue
-void AllToAllTest::testAllToAllInputDeleted(int count, at::ScalarType dtype) {
+template <typename Fixture>
+void AllToAllTest<Fixture>::testInputDeleted(int count, at::ScalarType dtype) {
   SCOPED_TRACE(
-      ::testing::Message()
-      << "Testing async all_to_all with input deleted after enqueue with count="
-      << count << " and dtype=" << getDtypeName(dtype));
+      ::testing::Message() << "count=" << count
+                           << " dtype=" << getDtypeName(dtype));
 
-  // Create output tensors that persist throughout the test
-  auto output_tensors = createOutputTensors(count, dtype);
-  auto expected_output = createExpectedOutput();
+  auto input_tensors = std::make_shared<std::vector<at::Tensor>>(
+      createInputTensors(count, dtype));
+  std::vector<at::Tensor> output_tensors = createOutputTensors(count, dtype);
 
-  {
-    // Create input tensors in a limited scope
-    auto input_tensors = createInputTensors(count, dtype);
-
-    // Call all_to_all
-    torchcomm_->all_to_all(output_tensors, input_tensors, false);
-
-    // Input tensors go out of scope here and get deleted
-  }
-
-  // Verify the results
-  verifyResults(output_tensors, expected_output);
-}
-
-// CUDA Graph test function for all_to_all
-void AllToAllTest::testGraphAllToAll(int count, at::ScalarType dtype) {
-  // Skip CUDA Graph tests when running on CPU
-  if (isRunningOnCPU()) {
-    std::cout << "Skipping CUDA Graph all_to_all test: not supported on CPU"
-              << std::endl;
-    return;
-  }
-
-  SCOPED_TRACE(
-      ::testing::Message() << "Testing CUDA Graph all_to_all with count="
-                           << count << " and dtype=" << getDtypeName(dtype));
-
-  // Create a non-default CUDA stream (required for CUDA graph capture)
-  at::cuda::CUDAStream stream = at::cuda::getStreamFromPool();
-
-  // Set the stream as current for graph capture
-  at::cuda::CUDAStreamGuard guard(stream);
-
-  // Create input and output tensors AFTER setting non-default stream but BEFORE
-  // graph capture
-  auto input_tensors = createInputTensors(count, dtype);
-  auto output_tensors = createOutputTensors(count, dtype);
   std::vector<at::Tensor> original_output_tensors;
   original_output_tensors.reserve(output_tensors.size());
-  for (const auto& output_tensor : output_tensors) {
-    original_output_tensors.push_back(output_tensor.clone());
+  for (const auto& t : output_tensors) {
+    original_output_tensors.push_back(t.clone());
   }
-  auto expected_output = createExpectedOutput();
 
-  // Create PyTorch CUDA graph
-  at::cuda::CUDAGraph graph;
-
-  // Capture the all_to_all operation in the graph
-  graph.capture_begin();
-
-  // Call all_to_all without keeping the work object
-  torchcomm_->all_to_all(output_tensors, input_tensors, false);
-
-  graph.capture_end();
-
-  // Replay the captured graph multiple times
-  for (int i = 0; i < num_replays; ++i) {
-    // Reset output tensors before each replay
-    for (size_t j = 0; j < output_tensors.size(); ++j) {
-      output_tensors[j].copy_(original_output_tensors[j]);
+  auto execute = [&]() {
+    torchcomm_->all_to_all(output_tensors, *input_tensors, false);
+  };
+  auto reset = [&]() {
+    for (size_t i = 0; i < output_tensors.size(); ++i) {
+      output_tensors[i].copy_(original_output_tensors[i]);
     }
-
-    graph.replay();
-
-    // Verify the results after each replay
-    verifyResults(output_tensors, expected_output);
-  }
-}
-
-// CUDA Graph test function for all_to_all with input deleted after graph
-// creation
-void AllToAllTest::testGraphAllToAllInputDeleted(
-    int count,
-    at::ScalarType dtype) {
-  // Skip CUDA Graph tests when running on CPU
-  if (isRunningOnCPU()) {
-    std::cout << "Skipping CUDA Graph all_to_all (input deleted) test: not "
-                 "supported on CPU"
-              << std::endl;
-    return;
-  }
-
-  SCOPED_TRACE(
-      ::testing::Message()
-      << "Testing CUDA Graph all_to_all with input deleted after graph creation with count="
-      << count << " and dtype=" << getDtypeName(dtype));
-
-  // Create a non-default CUDA stream (required for CUDA graph capture)
-  at::cuda::CUDAStream stream = at::cuda::getStreamFromPool();
-
-  // Set the stream as current for graph capture
-  at::cuda::CUDAStreamGuard guard(stream);
-
-  // Create output tensors that persist throughout the test
-  auto output_tensors = createOutputTensors(count, dtype);
-  std::vector<at::Tensor> original_output_tensors;
-  original_output_tensors.reserve(output_tensors.size());
-  for (const auto& output_tensor : output_tensors) {
-    original_output_tensors.push_back(output_tensor.clone());
-  }
-  auto expected_output = createExpectedOutput();
-
-  // Create PyTorch CUDA graph
-  at::cuda::CUDAGraph graph;
-
-  {
-    // Create input tensors in a limited scope
-    auto input_tensors = createInputTensors(count, dtype);
-
-    // Capture the all_to_all operation in the graph
-    graph.capture_begin();
-
-    // Call all_to_all without keeping the work object
-    torchcomm_->all_to_all(output_tensors, input_tensors, false);
-
-    graph.capture_end();
-
-    // Input tensors go out of scope here and get deleted
-  }
-
-  // Replay the captured graph multiple times even though input tensors are
-  // deleted
-  for (int i = 0; i < num_replays; ++i) {
-    // Reset output tensors before each replay
-    for (size_t j = 0; j < output_tensors.size(); ++j) {
-      output_tensors[j].copy_(original_output_tensors[j]);
-    }
-
-    graph.replay();
-
-    // Verify the results after each replay
-    verifyResults(output_tensors, expected_output);
-  }
+  };
+  auto verify = [&]() { verifyResults(output_tensors); };
+  auto cleanup = [&]() { input_tensors.reset(); };
+  run(execute, reset, verify, cleanup);
 }
 
 // Helper function to create input tensors
-std::vector<at::Tensor> AllToAllTest::createInputTensors(
+template <typename Fixture>
+std::vector<at::Tensor> AllToAllTest<Fixture>::createInputTensors(
     int count,
     at::ScalarType dtype) {
-  std::vector<at::Tensor> input_tensors;
-  input_tensors.reserve(num_ranks_);
   auto options = at::TensorOptions().dtype(dtype).device(device_type_);
-
-  for (int r = 0; r < num_ranks_; r++) {
-    // Each tensor has rank-specific values
-    at::Tensor tensor;
+  std::vector<at::Tensor> tensors;
+  tensors.reserve(num_ranks_);
+  for (int r = 0; r < num_ranks_; ++r) {
     if (dtype == at::kFloat || dtype == at::kHalf || dtype == at::kBFloat16) {
-      tensor = at::ones({count}, options) * static_cast<float>(rank_ + 1);
+      tensors.push_back(
+          at::ones({count}, options) * static_cast<float>(rank_ + 1));
     } else if (dtype == at::kInt) {
-      tensor = at::ones({count}, options) * static_cast<int>(rank_ + 1);
+      tensors.push_back(
+          at::ones({count}, options) * static_cast<int>(rank_ + 1));
     } else if (dtype == at::kChar) {
-      tensor = at::ones({count}, options) * static_cast<signed char>(rank_ + 1);
+      tensors.push_back(
+          at::ones({count}, options) * static_cast<signed char>(rank_ + 1));
     }
-    input_tensors.push_back(tensor);
   }
-  return input_tensors;
+  return tensors;
 }
 
 // Helper function to create output tensors
-std::vector<at::Tensor> AllToAllTest::createOutputTensors(
+template <typename Fixture>
+std::vector<at::Tensor> AllToAllTest<Fixture>::createOutputTensors(
     int count,
     at::ScalarType dtype) {
-  std::vector<at::Tensor> output_tensors;
-  output_tensors.reserve(num_ranks_);
   auto options = at::TensorOptions().dtype(dtype).device(device_type_);
-
-  for (int r = 0; r < num_ranks_; r++) {
-    auto tensor = at::zeros({count}, options);
-    output_tensors.push_back(tensor);
+  std::vector<at::Tensor> tensors;
+  tensors.reserve(num_ranks_);
+  for (int r = 0; r < num_ranks_; ++r) {
+    tensors.push_back(at::zeros({count}, options));
   }
-  return output_tensors;
-}
-
-// Helper function to create expected output tensors
-std::vector<int> AllToAllTest::createExpectedOutput() {
-  std::vector<int> expected_output;
-  expected_output.reserve(num_ranks_);
-
-  for (int r = 0; r < num_ranks_; r++) {
-    expected_output.push_back(r + 1);
-  }
-  return expected_output;
+  return tensors;
 }
 
 // Helper function to verify results
-void AllToAllTest::verifyResults(
-    const std::vector<at::Tensor>& output_tensors,
-    const std::vector<int>& expected_output) {
-  for (int r = 0; r < num_ranks_; r++) {
-    verifyTensorEquality(output_tensors[r].cpu(), expected_output[r]);
+template <typename Fixture>
+void AllToAllTest<Fixture>::verifyResults(
+    const std::vector<at::Tensor>& output_tensors) {
+  for (int r = 0; r < num_ranks_; ++r) {
+    verifyTensorEquality(output_tensors[r].cpu(), r + 1);
   }
 }
+
+template class AllToAllTest<EagerTestFixture<AllToAllParams>>;
+template class AllToAllTest<GraphTestFixture<AllToAllParams, 1>>;
+template class AllToAllTest<GraphTestFixture<AllToAllParams, 2>>;

--- a/comms/torchcomms/tests/integration/cpp/AllToAllTest.hpp
+++ b/comms/torchcomms/tests/integration/cpp/AllToAllTest.hpp
@@ -1,52 +1,38 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
+
 #pragma once
 
-#include <ATen/cuda/CUDAContext.h>
-#include <ATen/cuda/CUDAGraph.h>
-#include <c10/cuda/CUDAGuard.h>
+#include <ATen/ATen.h>
+#include <c10/core/Device.h>
 #include <gtest/gtest.h>
+#include <memory>
+#include <tuple>
 #include <vector>
+#include "comms/torchcomms/tests/integration/cpp/GraphTestFixtures.hpp"
 #include "comms/torchcomms/tests/integration/cpp/TorchCommTestHelpers.h"
 
-class AllToAllTest : public ::testing::Test {
- public:
-  AllToAllTest() : AllToAllTest(c10::DeviceType::CUDA) {}
-  explicit AllToAllTest(c10::DeviceType device_type)
-      : rank_(0), num_ranks_(0), device_type_(device_type) {}
+using AllToAllParams = std::tuple<int, at::ScalarType>;
 
-  // Test function declarations
-  void testSyncAllToAll(int count, at::ScalarType dtype);
-  void testSyncAllToAllNoWork(int count, at::ScalarType dtype);
-  void testAsyncAllToAll(int count, at::ScalarType dtype);
-  void testAsyncAllToAllEarlyReset(int count, at::ScalarType dtype);
-  void testAllToAllInputDeleted(int count, at::ScalarType dtype);
-  void testGraphAllToAll(int count, at::ScalarType dtype);
-  void testGraphAllToAllInputDeleted(int count, at::ScalarType dtype);
-
+template <typename Fixture>
+class AllToAllTest : public Fixture {
  protected:
-  virtual std::unique_ptr<TorchCommTestWrapper> createWrapper();
+  using Fixture::device_type_;
+  using Fixture::num_ranks_;
+  using Fixture::rank_;
+  using Fixture::run;
+  using Fixture::torchcomm_;
 
-  virtual void SetUp() override;
+  void testSync(int count, at::ScalarType dtype);
+  void testSyncNoWork(int count, at::ScalarType dtype);
+  void testAsync(int count, at::ScalarType dtype);
+  void testAsyncEarlyReset(int count, at::ScalarType dtype);
+  void testInputDeleted(int count, at::ScalarType dtype);
 
-  virtual void TearDown() override;
-
-  std::unique_ptr<TorchCommTestWrapper> wrapper_;
-  std::shared_ptr<torch::comms::TorchComm> torchcomm_;
-  int rank_;
-  int num_ranks_;
-  c10::DeviceType device_type_;
-
-  static constexpr int num_replays = 4;
-
-  // Helper function declarations
   virtual std::vector<at::Tensor> createInputTensors(
       int count,
       at::ScalarType dtype);
   virtual std::vector<at::Tensor> createOutputTensors(
       int count,
       at::ScalarType dtype);
-  std::vector<int> createExpectedOutput();
-  void verifyResults(
-      const std::vector<at::Tensor>& output_tensors,
-      const std::vector<int>& expected_output);
+  void verifyResults(const std::vector<at::Tensor>& output_tensors);
 };

--- a/comms/torchcomms/tests/integration/cpp/AllToAllTestMain.cpp
+++ b/comms/torchcomms/tests/integration/cpp/AllToAllTestMain.cpp
@@ -3,47 +3,124 @@
 #include "AllToAllTest.hpp"
 
 #include <gtest/gtest.h>
-#include <vector>
-#include "comms/torchcomms/tests/integration/cpp/TorchCommTestHelpers.h"
+#include "TorchCommTestHelpers.h"
 
-TEST_F(AllToAllTest, AllTests) {
-  // Define the parameter combinations
-  std::vector<int> counts = {0, 4, 1024, 1024 * 1024};
-  std::vector<at::ScalarType> dtypes = {at::kFloat, at::kInt, at::kChar};
+using Eager = AllToAllTest<EagerTestFixture<AllToAllParams>>;
+using SingleGraph = AllToAllTest<GraphTestFixture<AllToAllParams, 1>>;
+using MultiGraph = AllToAllTest<GraphTestFixture<AllToAllParams, 2>>;
 
-  // Loop over all parameter combinations
-  for (int count : counts) {
-    for (at::ScalarType dtype : dtypes) {
-      // Create a descriptive test name for better test output
-      std::string testName =
-          "Count_" + std::to_string(count) + "_" + getDtypeName(dtype);
-
-      SCOPED_TRACE("Running tests with parameters: " + testName);
-
-      // Run all test functions with the current parameters
-      SCOPED_TRACE("Running testSyncAllToAll");
-      testSyncAllToAll(count, dtype);
-
-      SCOPED_TRACE("Running testSyncAllToAllNoWork");
-      testSyncAllToAllNoWork(count, dtype);
-
-      SCOPED_TRACE("Running testAsyncAllToAll");
-      testAsyncAllToAll(count, dtype);
-
-      SCOPED_TRACE("Running testAsyncAllToAllEarlyReset");
-      testAsyncAllToAllEarlyReset(count, dtype);
-
-      SCOPED_TRACE("Running testAllToAllInputDeleted");
-      testAllToAllInputDeleted(count, dtype);
-
-      SCOPED_TRACE("Running testGraphAllToAll");
-      testGraphAllToAll(count, dtype);
-
-      SCOPED_TRACE("Running testGraphAllToAllInputDeleted");
-      testGraphAllToAllInputDeleted(count, dtype);
-    }
-  }
+TEST_P(Eager, Sync) {
+  int count = std::get<0>(GetParam());
+  at::ScalarType dtype = std::get<1>(GetParam());
+  testSync(count, dtype);
 }
+
+TEST_P(Eager, SyncNoWork) {
+  int count = std::get<0>(GetParam());
+  at::ScalarType dtype = std::get<1>(GetParam());
+  testSyncNoWork(count, dtype);
+}
+
+TEST_P(Eager, Async) {
+  int count = std::get<0>(GetParam());
+  at::ScalarType dtype = std::get<1>(GetParam());
+  testAsync(count, dtype);
+}
+
+TEST_P(Eager, AsyncEarlyReset) {
+  int count = std::get<0>(GetParam());
+  at::ScalarType dtype = std::get<1>(GetParam());
+  testAsyncEarlyReset(count, dtype);
+}
+
+TEST_P(Eager, InputDeleted) {
+  int count = std::get<0>(GetParam());
+  at::ScalarType dtype = std::get<1>(GetParam());
+  testInputDeleted(count, dtype);
+}
+
+TEST_P(SingleGraph, Sync) {
+  int count = std::get<0>(GetParam());
+  at::ScalarType dtype = std::get<1>(GetParam());
+  testSync(count, dtype);
+}
+
+TEST_P(SingleGraph, SyncNoWork) {
+  int count = std::get<0>(GetParam());
+  at::ScalarType dtype = std::get<1>(GetParam());
+  testSyncNoWork(count, dtype);
+}
+
+TEST_P(SingleGraph, Async) {
+  int count = std::get<0>(GetParam());
+  at::ScalarType dtype = std::get<1>(GetParam());
+  testAsync(count, dtype);
+}
+
+TEST_P(SingleGraph, InputDeleted) {
+  int count = std::get<0>(GetParam());
+  at::ScalarType dtype = std::get<1>(GetParam());
+  testInputDeleted(count, dtype);
+}
+
+TEST_P(MultiGraph, Sync) {
+  int count = std::get<0>(GetParam());
+  at::ScalarType dtype = std::get<1>(GetParam());
+  testSync(count, dtype);
+}
+
+TEST_P(MultiGraph, SyncNoWork) {
+  int count = std::get<0>(GetParam());
+  at::ScalarType dtype = std::get<1>(GetParam());
+  testSyncNoWork(count, dtype);
+}
+
+TEST_P(MultiGraph, Async) {
+  int count = std::get<0>(GetParam());
+  at::ScalarType dtype = std::get<1>(GetParam());
+  testAsync(count, dtype);
+}
+
+TEST_P(MultiGraph, InputDeleted) {
+  int count = std::get<0>(GetParam());
+  at::ScalarType dtype = std::get<1>(GetParam());
+  testInputDeleted(count, dtype);
+}
+
+auto allToAllParamValues() {
+  return ::testing::Combine(
+      ::testing::Values(0, 4, 1024, 1024 * 1024),
+      ::testing::Values(at::kFloat, at::kInt, at::kChar));
+}
+
+auto allToAllGraphParamValues() {
+  return ::testing::Combine(
+      ::testing::Values(4), ::testing::Values(at::kFloat));
+}
+
+auto allToAllParamNamer(const ::testing::TestParamInfo<AllToAllParams>& info) {
+  int count = std::get<0>(info.param);
+  at::ScalarType dtype = std::get<1>(info.param);
+  return "Count_" + std::to_string(count) + "_" + getDtypeName(dtype);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AllToAll,
+    Eager,
+    allToAllParamValues(),
+    allToAllParamNamer);
+
+INSTANTIATE_TEST_SUITE_P(
+    AllToAll,
+    SingleGraph,
+    allToAllGraphParamValues(),
+    allToAllParamNamer);
+
+INSTANTIATE_TEST_SUITE_P(
+    AllToAll,
+    MultiGraph,
+    allToAllGraphParamValues(),
+    allToAllParamNamer);
 
 // This main function is provided by gtest
 int main(int argc, char** argv) {


### PR DESCRIPTION
Summary:
- Migrate AllToAll from `TEST_F` with manual parameter loops to `TEST_P` with template-based `AllToAllTest<Fixture>` and stateless `AllToAllHelper` class
- AllToAll-specific: `createInputTensors`/`createOutputTensors`/`verifyResults` taking explicit parameters; InputDeleted uses `shared_ptr<vector<Tensor>>` for input tensors with cleanup callback
- Graph params limited to count=4, Float only to avoid timeout from expensive P2P setup
- HCCL AllToAllTest updated to inherit from `AllToAllTest<EagerTestFixture<AllToAllParams>>` since MTIA has no CUDA graph support

Test counts (AllToAll):
  Eager:  12 params (4 counts × 3 dtypes) × 5 methods = 60
  Graph:   1 param (1 count × 1 dtype) × 4 methods × 2 fixtures = 8
  Total: 68

Reviewed By: pavanbalaji

Differential Revision: D93253014


