### PR TITLE
Fix CUDA device context leak in watchdog thread

### DIFF
--- a/comms/torchcomms/device/cuda/CudaApi.cpp
+++ b/comms/torchcomms/device/cuda/CudaApi.cpp
@@ -13,6 +13,10 @@ cudaError_t DefaultCudaApi::setDevice(int device) {
   return cudaSetDevice(device);
 }
 
+cudaError_t DefaultCudaApi::getDevice(int* device) {
+  return cudaGetDevice(device);
+}
+
 cudaError_t DefaultCudaApi::getDeviceProperties(
     cudaDeviceProp* prop,
     int device) {

--- a/comms/torchcomms/device/cuda/CudaApi.hpp
+++ b/comms/torchcomms/device/cuda/CudaApi.hpp
@@ -40,6 +40,7 @@ class CudaApi {
 
   // Device management
   [[nodiscard]] virtual cudaError_t setDevice(int device) = 0;
+  [[nodiscard]] virtual cudaError_t getDevice(int* device) = 0;
   [[nodiscard]] virtual cudaError_t getDeviceProperties(
       cudaDeviceProp* prop,
       int device) = 0;
@@ -136,6 +137,7 @@ class DefaultCudaApi : public CudaApi {
 
   // Device management
   [[nodiscard]] cudaError_t setDevice(int device) override;
+  [[nodiscard]] cudaError_t getDevice(int* device) override;
   [[nodiscard]] cudaError_t getDeviceProperties(
       cudaDeviceProp* prop,
       int device) override;

--- a/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTest.cpp
@@ -227,8 +227,10 @@ TEST_F(TorchCommNCCLXTest, InitializationFailsWithInvalidDeviceId) {
 
     // Mock CUDA API to be called with device ID 0, since the boostrap
     // logic will assign a device ID in this case based on the rank.
+    // setDevice is called 3 times: once in the bootstrap constructor,
+    // once in init() post-bootstrap, and once in the watchdog thread.
     EXPECT_CALL(*cuda_mock_, setDevice(0))
-        .Times(2)
+        .Times(3)
         .WillRepeatedly(Return(cudaSuccess));
     EXPECT_CALL(*nccl_mock_, commInitRankConfig(_, 2, _, 0, _))
         .WillOnce(DoAll(

--- a/comms/torchcomms/ncclx/tests/unit/cpp/mocks/CudaMock.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/mocks/CudaMock.cpp
@@ -13,6 +13,8 @@ namespace torch::comms::test {
 void CudaMock::setupDefaultBehaviors() {
   // Device management - return success by default
   ON_CALL(*this, setDevice(_)).WillByDefault(Return(cudaSuccess));
+  ON_CALL(*this, getDevice(_))
+      .WillByDefault(DoAll(SetArgPointee<0>(0), Return(cudaSuccess)));
 
   ON_CALL(*this, getDeviceCount(_))
       .WillByDefault(DoAll(SetArgPointee<0>(1), Return(cudaSuccess)));

--- a/comms/torchcomms/ncclx/tests/unit/cpp/mocks/CudaMock.hpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/mocks/CudaMock.hpp
@@ -19,6 +19,7 @@ class CudaMock : public CudaApi {
 
   // Device management
   MOCK_METHOD(cudaError_t, setDevice, (int device), (override));
+  MOCK_METHOD(cudaError_t, getDevice, (int* device), (override));
   MOCK_METHOD(
       cudaError_t,
       getDeviceProperties,


### PR DESCRIPTION
Summary:
The TorchCommNCCLX watchdog thread was creating a spurious CUDA
primary context on GPU 0 because new threads default to device 0
and the thread made CUDA runtime calls (cudaEventQuery,
cudaThreadExchangeStreamCaptureMode) without first calling
cudaSetDevice.  On H100, each primary context costs ~534 MiB.
With 8 ranks per node, ranks 1-7 each leaked a context on GPU 0,
wasting ~3.7 GiB and causing OOM on rank 0.

Fix by calling cudaSetDevice(device_.index()) at the top of the
watchdog thread before any CUDA runtime call.

Also add a defensive cudaGetDevice check in split() to verify the
CUDA device is correct before ncclCommSplit, matching the
OptionalCUDAGuard pattern used by ProcessGroupNCCL.

Add CudaApi::getDevice() to the CUDA API interface to support the
device check.

Reviewed By: tanquer

Differential Revision: D94001528


