### PR TITLE
Refactor AllToAllvSingle integration tests with graph fixture

### DIFF
--- a/comms/torchcomms/tests/integration/cpp/AllToAllvSingleTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/AllToAllvSingleTest.cpp
@@ -2,333 +2,272 @@
 
 #include "AllToAllvSingleTest.hpp"
 
-#include <ATen/cuda/CUDAGraph.h>
-#include <c10/cuda/CUDAGuard.h>
 #include <gtest/gtest.h>
+#include <memory>
 #include <vector>
 #include "TorchCommTestHelpers.h"
 
-std::unique_ptr<TorchCommTestWrapper> AllToAllvSingleTest::createWrapper() {
-  return std::make_unique<TorchCommTestWrapper>();
-}
-
-void AllToAllvSingleTest::SetUp() {
-  wrapper_ = createWrapper();
-  torchcomm_ = wrapper_->getTorchComm();
-  rank_ = torchcomm_->getRank();
-  num_ranks_ = torchcomm_->getSize();
-  device_type_ = wrapper_->getDevice().type();
-}
-
-void AllToAllvSingleTest::TearDown() {
-  // Explicitly reset the TorchComm object to ensure proper cleanup
-  torchcomm_.reset();
-  wrapper_.reset();
-}
-
 // Test function for synchronous all_to_all_v_single with work object
-void AllToAllvSingleTest::testSyncAllToAllvSingle(
-    const std::vector<uint64_t>& input_split_sizes,
-    const std::vector<uint64_t>& output_split_sizes,
+template <typename Fixture>
+void AllToAllvSingleTest<Fixture>::testSync(
+    AllToAllvSizePattern pattern,
+    int count,
     at::ScalarType dtype) {
   SCOPED_TRACE(
-      ::testing::Message() << "Testing sync all_to_all_v_single with dtype="
-                           << getDtypeName(dtype));
+      ::testing::Message() << "count=" << count
+                           << " dtype=" << getDtypeName(dtype));
 
-  // Create input and output tensors
+  auto split_sizes = computeSplitSizes(pattern, count);
+  std::vector<uint64_t> input_split_sizes = split_sizes.first;
+  std::vector<uint64_t> output_split_sizes = split_sizes.second;
   at::Tensor input = createInputTensor(input_split_sizes, dtype);
   at::Tensor output = createOutputTensor(output_split_sizes, dtype);
 
-  // Call all_to_all_v_single
-  auto work = torchcomm_->all_to_all_v_single(
-      output, input, output_split_sizes, input_split_sizes, false);
-  work->wait();
+  auto original_output = output.clone();
 
-  // Verify the results
-  verifyResults(output, output_split_sizes);
+  auto execute = [&]() {
+    auto work = torchcomm_->all_to_all_v_single(
+        output, input, output_split_sizes, input_split_sizes, false);
+    work->wait();
+  };
+  auto reset = [&]() { output.copy_(original_output); };
+  auto verify = [&]() { verifyResults(output, output_split_sizes); };
+  run(execute, reset, verify);
 }
 
 // Test function for synchronous all_to_all_v_single without work object
-void AllToAllvSingleTest::testSyncAllToAllvSingleNoWork(
-    const std::vector<uint64_t>& input_split_sizes,
-    const std::vector<uint64_t>& output_split_sizes,
+template <typename Fixture>
+void AllToAllvSingleTest<Fixture>::testSyncNoWork(
+    AllToAllvSizePattern pattern,
+    int count,
     at::ScalarType dtype) {
   SCOPED_TRACE(
-      ::testing::Message()
-      << "Testing sync all_to_all_v_single without work object with dtype="
-      << getDtypeName(dtype));
+      ::testing::Message() << "count=" << count
+                           << " dtype=" << getDtypeName(dtype));
 
-  // Create input and output tensors
+  auto split_sizes = computeSplitSizes(pattern, count);
+  std::vector<uint64_t> input_split_sizes = split_sizes.first;
+  std::vector<uint64_t> output_split_sizes = split_sizes.second;
   at::Tensor input = createInputTensor(input_split_sizes, dtype);
   at::Tensor output = createOutputTensor(output_split_sizes, dtype);
 
-  // Call all_to_all_v_single without keeping the work object
-  torchcomm_->all_to_all_v_single(
-      output, input, output_split_sizes, input_split_sizes, false);
+  auto original_output = output.clone();
 
-  // Verify the results
-  verifyResults(output, output_split_sizes);
+  auto execute = [&]() {
+    torchcomm_->all_to_all_v_single(
+        output, input, output_split_sizes, input_split_sizes, false);
+  };
+  auto reset = [&]() { output.copy_(original_output); };
+  auto verify = [&]() { verifyResults(output, output_split_sizes); };
+  run(execute, reset, verify);
 }
 
 // Test function for asynchronous all_to_all_v_single with wait
-void AllToAllvSingleTest::testAsyncAllToAllvSingle(
-    const std::vector<uint64_t>& input_split_sizes,
-    const std::vector<uint64_t>& output_split_sizes,
+template <typename Fixture>
+void AllToAllvSingleTest<Fixture>::testAsync(
+    AllToAllvSizePattern pattern,
+    int count,
     at::ScalarType dtype) {
   SCOPED_TRACE(
-      ::testing::Message() << "Testing async all_to_all_v_single with dtype="
-                           << getDtypeName(dtype));
+      ::testing::Message() << "count=" << count
+                           << " dtype=" << getDtypeName(dtype));
 
-  // Create input and output tensors
+  auto split_sizes = computeSplitSizes(pattern, count);
+  std::vector<uint64_t> input_split_sizes = split_sizes.first;
+  std::vector<uint64_t> output_split_sizes = split_sizes.second;
   at::Tensor input = createInputTensor(input_split_sizes, dtype);
   at::Tensor output = createOutputTensor(output_split_sizes, dtype);
 
-  // Call all_to_all_v_single
-  auto work = torchcomm_->all_to_all_v_single(
-      output, input, output_split_sizes, input_split_sizes, true);
+  auto original_output = output.clone();
 
-  // Wait for the all_to_all_v_single to complete
-  work->wait();
-
-  // Verify the results
-  verifyResults(output, output_split_sizes);
+  auto execute = [&]() {
+    auto work = torchcomm_->all_to_all_v_single(
+        output, input, output_split_sizes, input_split_sizes, true);
+    work->wait();
+  };
+  auto reset = [&]() { output.copy_(original_output); };
+  auto verify = [&]() { verifyResults(output, output_split_sizes); };
+  run(execute, reset, verify);
 }
 
 // Test function for asynchronous all_to_all_v_single with early reset
-void AllToAllvSingleTest::testAsyncAllToAllvSingleEarlyReset(
-    const std::vector<uint64_t>& input_split_sizes,
-    const std::vector<uint64_t>& output_split_sizes,
+template <typename Fixture>
+void AllToAllvSingleTest<Fixture>::testAsyncEarlyReset(
+    AllToAllvSizePattern pattern,
+    int count,
     at::ScalarType dtype) {
   SCOPED_TRACE(
-      ::testing::Message()
-      << "Testing async all_to_all_v_single with early reset with dtype="
-      << getDtypeName(dtype));
+      ::testing::Message() << "count=" << count
+                           << " dtype=" << getDtypeName(dtype));
 
-  // Create input and output tensors
+  auto split_sizes = computeSplitSizes(pattern, count);
+  std::vector<uint64_t> input_split_sizes = split_sizes.first;
+  std::vector<uint64_t> output_split_sizes = split_sizes.second;
   at::Tensor input = createInputTensor(input_split_sizes, dtype);
   at::Tensor output = createOutputTensor(output_split_sizes, dtype);
 
-  // Call all_to_all_v_single
-  auto work = torchcomm_->all_to_all_v_single(
-      output, input, output_split_sizes, input_split_sizes, true);
+  auto original_output = output.clone();
 
-  // Wait for the work to complete before resetting
-  work->wait();
-
-  // Reset the work object
-  work.reset();
-
-  // Verify the results
-  verifyResults(output, output_split_sizes);
+  auto execute = [&]() {
+    auto work = torchcomm_->all_to_all_v_single(
+        output, input, output_split_sizes, input_split_sizes, true);
+    work->wait();
+    work.reset();
+  };
+  auto reset = [&]() { output.copy_(original_output); };
+  auto verify = [&]() { verifyResults(output, output_split_sizes); };
+  run(execute, reset, verify);
 }
 
 // Test function for asynchronous all_to_all_v_single with input deleted after
 // enqueue
-void AllToAllvSingleTest::testAllToAllvSingleInputDeleted(
-    const std::vector<uint64_t>& input_split_sizes,
-    const std::vector<uint64_t>& output_split_sizes,
+template <typename Fixture>
+void AllToAllvSingleTest<Fixture>::testInputDeleted(
+    AllToAllvSizePattern pattern,
+    int count,
     at::ScalarType dtype) {
   SCOPED_TRACE(
-      ::testing::Message()
-      << "Testing async all_to_all_v_single with input deleted after enqueue with dtype="
-      << getDtypeName(dtype));
+      ::testing::Message() << "count=" << count
+                           << " dtype=" << getDtypeName(dtype));
 
-  // Create output tensor that persists throughout the test
+  auto split_sizes = computeSplitSizes(pattern, count);
+  std::vector<uint64_t> input_split_sizes = split_sizes.first;
+  std::vector<uint64_t> output_split_sizes = split_sizes.second;
+  auto input =
+      std::make_shared<at::Tensor>(createInputTensor(input_split_sizes, dtype));
   at::Tensor output = createOutputTensor(output_split_sizes, dtype);
 
-  {
-    // Create input tensor in a limited scope
-    at::Tensor input = createInputTensor(input_split_sizes, dtype);
+  auto original_output = output.clone();
 
-    // Call all_to_all_v_single
+  auto execute = [&]() {
     torchcomm_->all_to_all_v_single(
-        output, input, output_split_sizes, input_split_sizes, false);
-
-    // Input tensor goes out of scope here and gets deleted
-  }
-
-  // Verify the results
-  verifyResults(output, output_split_sizes);
-}
-
-// CUDA Graph test function for all_to_all_v_single
-void AllToAllvSingleTest::testGraphAllToAllvSingle(
-    const std::vector<uint64_t>& input_split_sizes,
-    const std::vector<uint64_t>& output_split_sizes,
-    at::ScalarType dtype) {
-  // Skip CUDA Graph tests when running on CPU
-  if (isRunningOnCPU()) {
-    std::cout
-        << "Skipping CUDA Graph all_to_all_v_single test: not supported on CPU"
-        << std::endl;
-    return;
-  }
-
-  SCOPED_TRACE(
-      ::testing::Message()
-      << "Testing CUDA Graph all_to_all_v_single with dtype="
-      << getDtypeName(dtype));
-
-  // Create a non-default CUDA stream (required for CUDA graph capture)
-  at::cuda::CUDAStream stream = at::cuda::getStreamFromPool();
-
-  // Set the stream as current for graph capture
-  at::cuda::CUDAStreamGuard guard(stream);
-
-  // Create input and output tensors AFTER setting non-default stream but BEFORE
-  // graph capture
-  at::Tensor input = createInputTensor(input_split_sizes, dtype);
-  at::Tensor output = createOutputTensor(output_split_sizes, dtype);
-  at::Tensor original_output = output.clone();
-
-  // Create PyTorch CUDA graph
-  at::cuda::CUDAGraph graph;
-
-  // Capture the all_to_all_v_single operation in the graph
-  graph.capture_begin();
-
-  // Call all_to_all_v_single without keeping the work object
-  torchcomm_->all_to_all_v_single(
-      output, input, output_split_sizes, input_split_sizes, false);
-
-  graph.capture_end();
-
-  // Replay the captured graph multiple times
-  for (int i = 0; i < num_replays; ++i) {
-    // Reset output buffer before each replay
-    output.copy_(original_output);
-
-    graph.replay();
-
-    // Verify the results after each replay
-    verifyResults(output, output_split_sizes);
-  }
-}
-
-// CUDA Graph test function for all_to_all_v_single with input deleted after
-// graph creation
-void AllToAllvSingleTest::testGraphAllToAllvSingleInputDeleted(
-    const std::vector<uint64_t>& input_split_sizes,
-    const std::vector<uint64_t>& output_split_sizes,
-    at::ScalarType dtype) {
-  // Skip CUDA Graph tests when running on CPU
-  if (isRunningOnCPU()) {
-    std::cout << "Skipping CUDA Graph all_to_all_v_single (input deleted) "
-                 "test: not supported on CPU"
-              << std::endl;
-    return;
-  }
-
-  SCOPED_TRACE(
-      ::testing::Message()
-      << "Testing CUDA Graph all_to_all_v_single with input deleted after graph creation with dtype="
-      << getDtypeName(dtype));
-
-  // Create a non-default CUDA stream (required for CUDA graph capture)
-  at::cuda::CUDAStream stream = at::cuda::getStreamFromPool();
-
-  // Set the stream as current for graph capture
-  at::cuda::CUDAStreamGuard guard(stream);
-
-  // Create output tensor that persists throughout the test
-  at::Tensor output = createOutputTensor(output_split_sizes, dtype);
-  at::Tensor original_output = output.clone();
-
-  // Create PyTorch CUDA graph
-  at::cuda::CUDAGraph graph;
-
-  {
-    // Create input tensor in a limited scope
-    at::Tensor input = createInputTensor(input_split_sizes, dtype);
-
-    // Capture the all_to_all_v_single operation in the graph
-    graph.capture_begin();
-
-    // Call all_to_all_v_single without keeping the work object
-    torchcomm_->all_to_all_v_single(
-        output, input, output_split_sizes, input_split_sizes, false);
-
-    graph.capture_end();
-
-    // Input tensor goes out of scope here and gets deleted
-  }
-
-  // Replay the captured graph multiple times even though input is deleted
-  for (int i = 0; i < num_replays; ++i) {
-    // Reset output buffer before each replay
-    output.copy_(original_output);
-
-    graph.replay();
-
-    // Verify the results after each replay
-    verifyResults(output, output_split_sizes);
-  }
+        output, *input, output_split_sizes, input_split_sizes, false);
+  };
+  auto reset = [&]() { output.copy_(original_output); };
+  auto verify = [&]() { verifyResults(output, output_split_sizes); };
+  auto cleanup = [&]() { input.reset(); };
+  run(execute, reset, verify, cleanup);
 }
 
 // Test function for synchronous all_to_all_v_single with work object
-void AllToAllvSingleTest::testSyncAllToAllvSingleMultiDimTensor(
-    const std::vector<uint64_t>& input_split_sizes_,
-    const std::vector<uint64_t>& output_split_sizes_,
+template <typename Fixture>
+void AllToAllvSingleTest<Fixture>::testMultiDimTensor(
+    AllToAllvSizePattern pattern,
+    int count,
     at::ScalarType dtype) {
   SCOPED_TRACE(
-      ::testing::Message() << "Testing sync all_to_all_v_single with dtype="
-                           << getDtypeName(dtype));
+      ::testing::Message() << "count=" << count
+                           << " dtype=" << getDtypeName(dtype));
 
-  // Create input and output tensors using original sizes
-  at::Tensor input = createInputTensor(input_split_sizes_, dtype);
+  auto split_sizes = computeSplitSizes(pattern, count);
+  std::vector<uint64_t> input_split_sizes = split_sizes.first;
+  std::vector<uint64_t> output_split_sizes = split_sizes.second;
+
+  at::Tensor input = createInputTensor(input_split_sizes, dtype);
+  at::Tensor output = createOutputTensor(output_split_sizes, dtype);
+
+  // Reshape tensors to 2D
   input = input.reshape({input.numel() / 2, 2});
-  at::Tensor output = createOutputTensor(output_split_sizes_, dtype);
   output = output.reshape({output.numel() / 2, 2});
 
-  // Copy split sizes before modifying them
-  std::vector<uint64_t> input_split_sizes = input_split_sizes_;
-  std::vector<uint64_t> output_split_sizes = output_split_sizes_;
-
-  // Reduce each value in input_split_sizes and output_split_sizes by half
-  for (size_t i = 0; i < input_split_sizes.size(); ++i) {
-    if (input_split_sizes[i] % 2 != 0) {
-      std::cout << "Input size must be divisible by 2 for multi-dim tensor test"
-                << std::endl;
+  // Halve split sizes for the 2D tensor
+  auto halved_input_sizes = input_split_sizes;
+  auto halved_output_sizes = output_split_sizes;
+  for (auto& s : halved_input_sizes) {
+    if (s % 2 != 0) {
       return;
-    } else {
-      input_split_sizes[i] /= 2;
     }
+    s /= 2;
   }
-  for (size_t i = 0; i < output_split_sizes.size(); ++i) {
-    if (output_split_sizes[i] % 2 != 0) {
-      std::cout
-          << "Output size must be divisible by 2 for multi-dim tensor test"
-          << std::endl;
+  for (auto& s : halved_output_sizes) {
+    if (s % 2 != 0) {
       return;
-    } else {
-      output_split_sizes[i] /= 2;
     }
+    s /= 2;
   }
 
-  // Call all_to_all_v_single
-  auto work = torchcomm_->all_to_all_v_single(
-      output, input, output_split_sizes, input_split_sizes, false);
-  work->wait();
+  auto original_output = output.clone();
 
-  output = output.reshape({output.numel()});
+  auto execute = [&]() {
+    auto work = torchcomm_->all_to_all_v_single(
+        output, input, halved_output_sizes, halved_input_sizes, false);
+    work->wait();
+  };
+  auto reset = [&]() { output.copy_(original_output); };
+  auto verify = [&]() {
+    auto flat_output = output.reshape({output.numel()});
+    verifyResults(flat_output, output_split_sizes);
+  };
+  run(execute, reset, verify);
+}
 
-  // Verify the results with the original output_split_sizes
-  verifyResults(output, output_split_sizes_);
+template <typename Fixture>
+std::string AllToAllvSingleTest<Fixture>::getPatternName(
+    AllToAllvSizePattern pattern) {
+  switch (pattern) {
+    case AllToAllvSizePattern::Uniform:
+      return "Uniform";
+    case AllToAllvSizePattern::Variable:
+      return "Variable";
+    case AllToAllvSizePattern::ZeroSizes:
+      return "ZeroSizes";
+    case AllToAllvSizePattern::AllZero:
+      return "AllZero";
+    case AllToAllvSizePattern::Asymmetric:
+      return "Asymmetric";
+  }
+  return "Unknown";
+}
+
+template <typename Fixture>
+std::pair<std::vector<uint64_t>, std::vector<uint64_t>> AllToAllvSingleTest<
+    Fixture>::computeSplitSizes(AllToAllvSizePattern pattern, int count) {
+  std::vector<uint64_t> inputSizes, outputSizes;
+  switch (pattern) {
+    case AllToAllvSizePattern::Uniform:
+      inputSizes.assign(num_ranks_, count);
+      outputSizes.assign(num_ranks_, count);
+      break;
+    case AllToAllvSizePattern::Variable:
+      for (int i = 0; i < num_ranks_; i++) {
+        inputSizes.push_back(static_cast<uint64_t>((rank_ + 1) * count));
+        outputSizes.push_back(static_cast<uint64_t>((i + 1) * count));
+      }
+      break;
+    case AllToAllvSizePattern::ZeroSizes:
+      for (int i = 0; i < num_ranks_; i++) {
+        uint64_t sendSize = (rank_ + i) % 3 == 0 ? 0 : count;
+        uint64_t recvSize = (i + rank_) % 3 == 0 ? 0 : count;
+        inputSizes.push_back(sendSize);
+        outputSizes.push_back(recvSize);
+      }
+      break;
+    case AllToAllvSizePattern::AllZero:
+      inputSizes.assign(num_ranks_, 0);
+      outputSizes.assign(num_ranks_, 0);
+      break;
+    case AllToAllvSizePattern::Asymmetric:
+      for (int i = 0; i < num_ranks_; i++) {
+        inputSizes.push_back(rank_ % 2 == 0 ? count : 0);
+        outputSizes.push_back(i % 2 == 0 ? count : 0);
+      }
+      break;
+  }
+  return {inputSizes, outputSizes};
 }
 
 // Helper function to create input tensor
-at::Tensor AllToAllvSingleTest::createInputTensor(
+template <typename Fixture>
+at::Tensor AllToAllvSingleTest<Fixture>::createInputTensor(
     const std::vector<uint64_t>& input_split_sizes,
     at::ScalarType dtype) {
   uint64_t total_size = 0;
-  for (uint64_t size : input_split_sizes) {
-    total_size += size;
+  for (uint64_t s : input_split_sizes) {
+    total_size += s;
   }
-
   auto options = at::TensorOptions().dtype(dtype).device(device_type_);
   at::Tensor input = at::zeros({static_cast<int64_t>(total_size)}, options);
 
-  // Fill each section with rank-specific values
   uint64_t offset = 0;
   for (int i = 0; i < num_ranks_; i++) {
     if (input_split_sizes[i] > 0) {
@@ -344,44 +283,42 @@ at::Tensor AllToAllvSingleTest::createInputTensor(
     }
     offset += input_split_sizes[i];
   }
-  // at::cuda::getCurrentCUDAStream().synchronize();
   return input;
 }
 
 // Helper function to create output tensor
-at::Tensor AllToAllvSingleTest::createOutputTensor(
+template <typename Fixture>
+at::Tensor AllToAllvSingleTest<Fixture>::createOutputTensor(
     const std::vector<uint64_t>& output_split_sizes,
     at::ScalarType dtype) {
   uint64_t total_size = 0;
-  for (uint64_t size : output_split_sizes) {
-    total_size += size;
+  for (uint64_t s : output_split_sizes) {
+    total_size += s;
   }
-
   auto options = at::TensorOptions().dtype(dtype).device(device_type_);
   return at::zeros({static_cast<int64_t>(total_size)}, options);
 }
 
 // Helper function to verify results
-void AllToAllvSingleTest::verifyResults(
+template <typename Fixture>
+void AllToAllvSingleTest<Fixture>::verifyResults(
     const at::Tensor& output,
     const std::vector<uint64_t>& output_split_sizes) {
   uint64_t offset = 0;
   for (int i = 0; i < num_ranks_; i++) {
     if (output_split_sizes[i] > 0) {
-      // For each rank's section in the output tensor
       at::Tensor section =
           output.slice(0, offset, offset + output_split_sizes[i]);
-
-      // Expected value: what rank i would have sent to this rank
       int expected_value = i * 100 + rank_ + 1;
       if (output.dtype() == at::kChar) {
         expected_value = (i * 10 + rank_ + 1) % 128;
       }
-
-      // Use verifyTensorEquality to compare section with expected value
-      std::string description = "rank " + std::to_string(i) + " section";
-      verifyTensorEquality(section.cpu(), expected_value, description);
+      verifyTensorEquality(section.cpu(), expected_value);
     }
     offset += output_split_sizes[i];
   }
 }
+
+template class AllToAllvSingleTest<EagerTestFixture<AllToAllvSingleParams>>;
+template class AllToAllvSingleTest<GraphTestFixture<AllToAllvSingleParams, 1>>;
+template class AllToAllvSingleTest<GraphTestFixture<AllToAllvSingleParams, 2>>;

--- a/comms/torchcomms/tests/integration/cpp/AllToAllvSingleTestMain.cpp
+++ b/comms/torchcomms/tests/integration/cpp/AllToAllvSingleTestMain.cpp
@@ -3,213 +3,166 @@
 #include "AllToAllvSingleTest.hpp"
 
 #include <gtest/gtest.h>
+#include <string>
 #include <vector>
+#include "TorchCommTestHelpers.h"
 
-TEST_F(AllToAllvSingleTest, AllTests) {
-  // Define enum for size patterns
-  enum class SizePattern { Uniform, Variable, ZeroSizes };
+using Eager = AllToAllvSingleTest<EagerTestFixture<AllToAllvSingleParams>>;
+using SingleGraph =
+    AllToAllvSingleTest<GraphTestFixture<AllToAllvSingleParams, 1>>;
+using MultiGraph =
+    AllToAllvSingleTest<GraphTestFixture<AllToAllvSingleParams, 2>>;
 
-  // Helper function to convert enum to string
-  auto getPatternName = [](SizePattern pattern) -> std::string {
-    switch (pattern) {
-      case SizePattern::Uniform:
-        return "Uniform";
-      case SizePattern::Variable:
-        return "Variable";
-      case SizePattern::ZeroSizes:
-        return "ZeroSizes";
-      default:
-        return "Unknown";
-    }
-  };
-
-  // Define different counts to test
-  std::vector<uint64_t> counts = {4, 1024, 1024 * 1024};
-
-  // Define size patterns to test (excluding AllZero which is handled
-  // separately)
-  std::vector<SizePattern> size_patterns = {
-      SizePattern::Uniform, SizePattern::Variable, SizePattern::ZeroSizes};
-
-  // Define datatypes to test
-  std::vector<at::ScalarType> dtypes = {at::kFloat, at::kInt, at::kChar};
-
-  // Nested loops for all parameter combinations (counts x patterns x dtypes)
-  for (uint64_t count : counts) {
-    for (SizePattern pattern : size_patterns) {
-      for (at::ScalarType dtype : dtypes) {
-        // Create size vectors based on pattern and count
-        std::vector<uint64_t> input_sizes, output_sizes;
-
-        switch (pattern) {
-          case SizePattern::Uniform:
-            // Test with uniform sizes
-            input_sizes = std::vector<uint64_t>(num_ranks_, count);
-            output_sizes = std::vector<uint64_t>(num_ranks_, count);
-            break;
-          case SizePattern::Variable:
-            // Test with variable sizes - create a symmetric communication
-            // pattern Each rank i sends (i+1)*count elements to each other
-            // rank j So rank j should expect to receive (i+1)*count elements
-            // from rank i
-            for (int i = 0; i < num_ranks_; i++) {
-              // This rank sends (rank_+1)*count elements to rank i
-              input_sizes.push_back((rank_ + 1) * count);
-              // This rank receives (i+1)*count elements from rank i
-              output_sizes.push_back((i + 1) * count);
-            }
-            break;
-          case SizePattern::ZeroSizes:
-            // Test with some zero sizes - ensure symmetric pattern
-            for (int i = 0; i < num_ranks_; i++) {
-              // Create a pattern where some communications have zero size
-              // If this rank sends 0 to rank i, then rank i sends 0 to this
-              // rank
-              uint64_t size = (rank_ + i) % 3 == 0 ? 0 : count;
-              input_sizes.push_back(size);
-
-              // This rank receives from rank i what rank i sends to this rank
-              uint64_t recv_size = (i + rank_) % 3 == 0 ? 0 : count;
-              output_sizes.push_back(recv_size);
-            }
-            break;
-          default:
-            TORCH_INTERNAL_ASSERT(false, "Unexpected SizePattern enum value");
-        }
-
-        // Create a descriptive test name for better test output
-        std::string testName = getPatternName(pattern) + "_" +
-            std::to_string(count) + "_" + getDtypeName(dtype);
-
-        SCOPED_TRACE("Running tests with parameters: " + testName);
-
-        // Run all test functions with clear tracing, passing parameters
-        // directly
-        SCOPED_TRACE("Running testSyncAllToAllvSingle");
-        testSyncAllToAllvSingle(input_sizes, output_sizes, dtype);
-
-        SCOPED_TRACE("Running testSyncAllToAllvSingleNoWork");
-        testSyncAllToAllvSingleNoWork(input_sizes, output_sizes, dtype);
-
-        SCOPED_TRACE("Running testAsyncAllToAllvSingle");
-        testAsyncAllToAllvSingle(input_sizes, output_sizes, dtype);
-
-        SCOPED_TRACE("Running testAsyncAllToAllvSingleEarlyReset");
-        testAsyncAllToAllvSingleEarlyReset(input_sizes, output_sizes, dtype);
-
-        SCOPED_TRACE("Running testAllToAllvSingleInputDeleted");
-        testAllToAllvSingleInputDeleted(input_sizes, output_sizes, dtype);
-
-        // Run CUDA Graph tests
-        SCOPED_TRACE("Running testGraphAllToAllvSingle");
-        testGraphAllToAllvSingle(input_sizes, output_sizes, dtype);
-
-        SCOPED_TRACE("Running testGraphAllToAllvSingleInputDeleted");
-        testGraphAllToAllvSingleInputDeleted(input_sizes, output_sizes, dtype);
-
-        SCOPED_TRACE("Running testSyncAllToAllvSingleMultiDimTensor");
-        testSyncAllToAllvSingleMultiDimTensor(input_sizes, output_sizes, dtype);
-      }
-    }
-  }
-
-  // Handle AllZero separately, as it is independent of the count and datatype
-  for (at::ScalarType dtype : dtypes) {
-    // Test with all zero sizes
-    std::vector<uint64_t> input_sizes = std::vector<uint64_t>(num_ranks_, 0);
-    std::vector<uint64_t> output_sizes = std::vector<uint64_t>(num_ranks_, 0);
-
-    // Create a descriptive test name for better test output
-    std::string testName = "AllZero_" + getDtypeName(dtype);
-
-    SCOPED_TRACE("Running tests with parameters: " + testName);
-
-    // Run all test functions with clear tracing, passing parameters directly
-    SCOPED_TRACE("Running testSyncAllToAllvSingle");
-    testSyncAllToAllvSingle(input_sizes, output_sizes, dtype);
-
-    SCOPED_TRACE("Running testSyncAllToAllvSingleNoWork");
-    testSyncAllToAllvSingleNoWork(input_sizes, output_sizes, dtype);
-
-    SCOPED_TRACE("Running testAsyncAllToAllvSingle");
-    testAsyncAllToAllvSingle(input_sizes, output_sizes, dtype);
-
-    SCOPED_TRACE("Running testAsyncAllToAllvSingleEarlyReset");
-    testAsyncAllToAllvSingleEarlyReset(input_sizes, output_sizes, dtype);
-
-    SCOPED_TRACE("Running testAllToAllvSingleInputDeleted");
-    testAllToAllvSingleInputDeleted(input_sizes, output_sizes, dtype);
-
-    SCOPED_TRACE("Running testGraphAllToAllvSingle");
-    testGraphAllToAllvSingle(input_sizes, output_sizes, dtype);
-
-    SCOPED_TRACE("Running testGraphAllToAllvSingleInputDeleted");
-    testGraphAllToAllvSingleInputDeleted(input_sizes, output_sizes, dtype);
-
-    SCOPED_TRACE("Running testSyncAllToAllvSingleMultiDimTensor");
-    testSyncAllToAllvSingleMultiDimTensor(input_sizes, output_sizes, dtype);
-  }
-
-  // Test asymmetric communication: some ranks have all zero inputs but non-zero
-  // outputs
-  for (uint64_t count : counts) {
-    for (at::ScalarType dtype : dtypes) {
-      // Create an asymmetric pattern where even ranks send data but odd ranks
-      // don't However, odd ranks receive data from even ranks
-      std::vector<uint64_t> input_sizes, output_sizes;
-
-      for (int i = 0; i < num_ranks_; i++) {
-        if (rank_ % 2 == 0) {
-          // Even ranks send data to all ranks
-          input_sizes.push_back(count);
-        } else {
-          // Odd ranks don't send any data
-          input_sizes.push_back(0);
-        }
-
-        if (i % 2 == 0) {
-          // All ranks receive data from even ranks
-          output_sizes.push_back(count);
-        } else {
-          // All ranks don't receive from odd ranks (since they don't send)
-          output_sizes.push_back(0);
-        }
-      }
-
-      // Create a descriptive test name for better test output
-      std::string testName = "AsymmetricZeroInput_" + std::to_string(count) +
-          "_" + getDtypeName(dtype);
-
-      SCOPED_TRACE("Running tests with parameters: " + testName);
-
-      // Run all test functions with clear tracing, passing parameters directly
-      SCOPED_TRACE("Running testSyncAllToAllvSingle");
-      testSyncAllToAllvSingle(input_sizes, output_sizes, dtype);
-
-      SCOPED_TRACE("Running testSyncAllToAllvSingleNoWork");
-      testSyncAllToAllvSingleNoWork(input_sizes, output_sizes, dtype);
-
-      SCOPED_TRACE("Running testAsyncAllToAllvSingle");
-      testAsyncAllToAllvSingle(input_sizes, output_sizes, dtype);
-
-      SCOPED_TRACE("Running testAsyncAllToAllvSingleEarlyReset");
-      testAsyncAllToAllvSingleEarlyReset(input_sizes, output_sizes, dtype);
-
-      SCOPED_TRACE("Running testAllToAllvSingleInputDeleted");
-      testAllToAllvSingleInputDeleted(input_sizes, output_sizes, dtype);
-
-      // Run CUDA Graph tests
-      SCOPED_TRACE("Running testGraphAllToAllvSingle");
-      testGraphAllToAllvSingle(input_sizes, output_sizes, dtype);
-
-      SCOPED_TRACE("Running testGraphAllToAllvSingleInputDeleted");
-      testGraphAllToAllvSingleInputDeleted(input_sizes, output_sizes, dtype);
-
-      SCOPED_TRACE("Running testSyncAllToAllvSingleMultiDimTensor");
-      testSyncAllToAllvSingleMultiDimTensor(input_sizes, output_sizes, dtype);
-    }
-  }
+TEST_P(Eager, Sync) {
+  AllToAllvSizePattern pattern = std::get<0>(GetParam());
+  int count = std::get<1>(GetParam());
+  at::ScalarType dtype = std::get<2>(GetParam());
+  testSync(pattern, count, dtype);
 }
+
+TEST_P(Eager, SyncNoWork) {
+  AllToAllvSizePattern pattern = std::get<0>(GetParam());
+  int count = std::get<1>(GetParam());
+  at::ScalarType dtype = std::get<2>(GetParam());
+  testSyncNoWork(pattern, count, dtype);
+}
+
+TEST_P(Eager, Async) {
+  AllToAllvSizePattern pattern = std::get<0>(GetParam());
+  int count = std::get<1>(GetParam());
+  at::ScalarType dtype = std::get<2>(GetParam());
+  testAsync(pattern, count, dtype);
+}
+
+TEST_P(Eager, AsyncEarlyReset) {
+  AllToAllvSizePattern pattern = std::get<0>(GetParam());
+  int count = std::get<1>(GetParam());
+  at::ScalarType dtype = std::get<2>(GetParam());
+  testAsyncEarlyReset(pattern, count, dtype);
+}
+
+TEST_P(Eager, InputDeleted) {
+  AllToAllvSizePattern pattern = std::get<0>(GetParam());
+  int count = std::get<1>(GetParam());
+  at::ScalarType dtype = std::get<2>(GetParam());
+  testInputDeleted(pattern, count, dtype);
+}
+
+TEST_P(Eager, MultiDimTensor) {
+  AllToAllvSizePattern pattern = std::get<0>(GetParam());
+  int count = std::get<1>(GetParam());
+  at::ScalarType dtype = std::get<2>(GetParam());
+  testMultiDimTensor(pattern, count, dtype);
+}
+
+TEST_P(SingleGraph, Sync) {
+  AllToAllvSizePattern pattern = std::get<0>(GetParam());
+  int count = std::get<1>(GetParam());
+  at::ScalarType dtype = std::get<2>(GetParam());
+  testSync(pattern, count, dtype);
+}
+
+TEST_P(SingleGraph, SyncNoWork) {
+  AllToAllvSizePattern pattern = std::get<0>(GetParam());
+  int count = std::get<1>(GetParam());
+  at::ScalarType dtype = std::get<2>(GetParam());
+  testSyncNoWork(pattern, count, dtype);
+}
+
+TEST_P(SingleGraph, Async) {
+  AllToAllvSizePattern pattern = std::get<0>(GetParam());
+  int count = std::get<1>(GetParam());
+  at::ScalarType dtype = std::get<2>(GetParam());
+  testAsync(pattern, count, dtype);
+}
+
+TEST_P(SingleGraph, InputDeleted) {
+  AllToAllvSizePattern pattern = std::get<0>(GetParam());
+  int count = std::get<1>(GetParam());
+  at::ScalarType dtype = std::get<2>(GetParam());
+  testInputDeleted(pattern, count, dtype);
+}
+
+TEST_P(MultiGraph, Sync) {
+  AllToAllvSizePattern pattern = std::get<0>(GetParam());
+  int count = std::get<1>(GetParam());
+  at::ScalarType dtype = std::get<2>(GetParam());
+  testSync(pattern, count, dtype);
+}
+
+TEST_P(MultiGraph, SyncNoWork) {
+  AllToAllvSizePattern pattern = std::get<0>(GetParam());
+  int count = std::get<1>(GetParam());
+  at::ScalarType dtype = std::get<2>(GetParam());
+  testSyncNoWork(pattern, count, dtype);
+}
+
+TEST_P(MultiGraph, Async) {
+  AllToAllvSizePattern pattern = std::get<0>(GetParam());
+  int count = std::get<1>(GetParam());
+  at::ScalarType dtype = std::get<2>(GetParam());
+  testAsync(pattern, count, dtype);
+}
+
+TEST_P(MultiGraph, InputDeleted) {
+  AllToAllvSizePattern pattern = std::get<0>(GetParam());
+  int count = std::get<1>(GetParam());
+  at::ScalarType dtype = std::get<2>(GetParam());
+  testInputDeleted(pattern, count, dtype);
+}
+
+auto allToAllvSingleParamValues() {
+  static std::vector<AllToAllvSingleParams> params = []() {
+    std::vector<AllToAllvSingleParams> p;
+    std::vector<at::ScalarType> dtypes = {at::kFloat, at::kInt, at::kChar};
+
+    // Uniform pattern: full dtype coverage with two counts
+    for (int count : {4, 1024}) {
+      for (auto dtype : dtypes) {
+        p.emplace_back(AllToAllvSizePattern::Uniform, count, dtype);
+      }
+    }
+    // Other patterns: minimal config (count=4, Float only) for pattern coverage
+    p.emplace_back(AllToAllvSizePattern::Variable, 4, at::kFloat);
+    p.emplace_back(AllToAllvSizePattern::ZeroSizes, 4, at::kFloat);
+    p.emplace_back(AllToAllvSizePattern::AllZero, 0, at::kFloat);
+    p.emplace_back(AllToAllvSizePattern::Asymmetric, 4, at::kFloat);
+    return p;
+  }();
+  return ::testing::ValuesIn(params);
+}
+
+auto allToAllvSingleGraphParamValues() {
+  return ::testing::Values(
+      AllToAllvSingleParams{AllToAllvSizePattern::Uniform, 4, at::kFloat});
+}
+
+auto allToAllvSingleParamNamer(
+    const ::testing::TestParamInfo<AllToAllvSingleParams>& info) {
+  AllToAllvSizePattern pattern = std::get<0>(info.param);
+  int count = std::get<1>(info.param);
+  at::ScalarType dtype = std::get<2>(info.param);
+  return Eager::getPatternName(pattern) + "_Count_" + std::to_string(count) +
+      "_" + getDtypeName(dtype);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AllToAllvSingle,
+    Eager,
+    allToAllvSingleParamValues(),
+    allToAllvSingleParamNamer);
+
+INSTANTIATE_TEST_SUITE_P(
+    AllToAllvSingle,
+    SingleGraph,
+    allToAllvSingleGraphParamValues(),
+    allToAllvSingleParamNamer);
+
+INSTANTIATE_TEST_SUITE_P(
+    AllToAllvSingle,
+    MultiGraph,
+    allToAllvSingleGraphParamValues(),
+    allToAllvSingleParamNamer);
 
 // This main function is provided by gtest
 int main(int argc, char** argv) {


### PR DESCRIPTION
Summary:
- Migrate AllToAllvSingle from monolithic `TEST_F` to parameterized `TEST_P` with template-based `AllToAllvSingleTest<Fixture>` and stateless `AllToAllvSingleHelper` class
- AllToAllvSingle-specific: `computeSplitSizes()`, `createInputTensor()`, `createOutputTensor()`, and `verifyResults()` supporting 5 size patterns (Uniform, Variable, ZeroSizes, AllZero, Asymmetric)
- Eager param count reduced from 39 to 10 combos to avoid P2P-connection-related timeouts; adds testMultiDimTensor for multi-dimensional tensor support
- Graph tests use SingleGraph and MultiGraph fixtures (Float only, Uniform pattern)
- HCCL AllToAllvSingleTest updated to inherit from `AllToAllvSingleTest<EagerTestFixture<AllToAllvSingleParams>>` since MTIA has no CUDA graph support

Test counts (AllToAllvSingle):
  Eager:  10 params (5 patterns × varied) × 6 methods = 60
  Graph:   1 param × 4 methods × 2 fixtures = 8
  Total: 68

Reviewed By: mingrany

Differential Revision: D93253015


