### PR TITLE
Add configurable timeout and retryCount to MultipeerIbgdaTransportConfig

### DIFF
--- a/comms/pipes/MultipeerIbgdaTransport.cc
+++ b/comms/pipes/MultipeerIbgdaTransport.cc
@@ -436,9 +436,9 @@ void MultipeerIbgdaTransport::connectQp(
   checkDocaError(err, "Failed to set next state RTS");
   err = doca_verbs_qp_attr_set_sq_psn(qpAttr, 0);
   checkDocaError(err, "Failed to set SQ PSN");
-  err = doca_verbs_qp_attr_set_ack_timeout(qpAttr, 14);
+  err = doca_verbs_qp_attr_set_ack_timeout(qpAttr, config_.timeout);
   checkDocaError(err, "Failed to set ACK timeout");
-  err = doca_verbs_qp_attr_set_retry_cnt(qpAttr, 7);
+  err = doca_verbs_qp_attr_set_retry_cnt(qpAttr, config_.retryCount);
   checkDocaError(err, "Failed to set retry count");
   err = doca_verbs_qp_attr_set_rnr_retry(qpAttr, 1);
   checkDocaError(err, "Failed to set RNR retry");

--- a/comms/pipes/MultipeerIbgdaTransport.h
+++ b/comms/pipes/MultipeerIbgdaTransport.h
@@ -62,6 +62,20 @@ struct MultipeerIbgdaTransportConfig {
   // Queue pair depth (number of outstanding WQEs per peer).
   // Higher values allow more pipelining but use more memory.
   uint32_t qpDepth{128};
+
+  // InfiniBand Verbs Timeout for QP ACK timeout.
+  // Timeout is computed as 4.096 µs * 2^timeout.
+  // Increasing this value can help on very large networks (e.g., if
+  // ibv_poll_cq returns error 12). See InfiniBand specification Volume 1,
+  // section 12.7.34 (Local Ack Timeout).
+  // Valid values: 1-31. A value of 0 or >= 32 results in infinite timeout.
+  // Default is 20 (similar to NCCL_IB_TIMEOUT).
+  uint8_t timeout{20};
+
+  // InfiniBand retry count for QP transport errors.
+  // See InfiniBand specification Volume 1, section 12.7.38.
+  // Default is 7 (similar to NCCL_IB_RETRY_CNT).
+  uint8_t retryCount{7};
 };
 
 /**


### PR DESCRIPTION
Summary:
Add `timeout` and `retryCount` fields to `MultipeerIbgdaTransportConfig`
to make the InfiniBand QP ACK timeout and retry count configurable,
similar to NCCL_IB_TIMEOUT and NCCL_IB_RETRY_CNT.

Previously, these were hardcoded to 14 and 7 respectively in
`connectQp()`. The new defaults are:
- `timeout`: 20 (matching NCCL's default since v2.23). Accepts values
  1-31, where the actual timeout is 4.096 µs × 2^timeout. A value of
  0 or >= 32 results in an infinite timeout. Increasing the timeout can
  help on very large networks (e.g., when ibv_poll_cq returns error 12).
- `retryCount`: 7 (matching NCCL's default). See InfiniBand
  specification Volume 1, section 12.7.38.

Differential Revision: D93996826


