### PR TITLE
Add trafficClass to MultipeerIbgdaTransportConfig

### DIFF
--- a/comms/pipes/MultipeerIbgdaTransport.cc
+++ b/comms/pipes/MultipeerIbgdaTransport.cc
@@ -250,6 +250,9 @@ void MultipeerIbgdaTransport::openIbDevice() {
 
   err = doca_verbs_ah_attr_set_hop_limit(ahAttr_, kHopLimit);
   checkDocaError(err, "Failed to set hop limit");
+
+  err = doca_verbs_ah_attr_set_traffic_class(ahAttr_, config_.trafficClass);
+  checkDocaError(err, "Failed to set traffic class");
 }
 
 void MultipeerIbgdaTransport::allocateResources() {

--- a/comms/pipes/MultipeerIbgdaTransport.h
+++ b/comms/pipes/MultipeerIbgdaTransport.h
@@ -91,6 +91,11 @@ struct MultipeerIbgdaTransportConfig {
   // See InfiniBand specification Volume 1, section 12.7.38.
   // Default is 7 (similar to NCCL_IB_RETRY_CNT).
   uint8_t retryCount{7};
+
+  // InfiniBand traffic class field (similar to NCCL_IB_TC).
+  // See InfiniBand specification Volume 1 or vendor documentation.
+  // Default is 224.
+  uint8_t trafficClass{224};
 };
 
 /**


### PR DESCRIPTION
Summary:
Add a `trafficClass` field to `MultipeerIbgdaTransportConfig`, similar
to NCCL_IB_TC.

`trafficClass` (default 0) sets the InfiniBand traffic class on the
Address Handle attributes used for RDMA operations. Applied in
`openIbDevice()` via `doca_verbs_ah_attr_set_tc`.

Differential Revision: D93996829


