### PR TITLE
refactor TopologyDiscovery for testability

### DIFF
--- a/comms/pipes/MultiPeerTransport.cc
+++ b/comms/pipes/MultiPeerTransport.cc
@@ -40,8 +40,8 @@ MultiPeerTransport::MultiPeerTransport(
       nRanks_(nRanks),
       deviceId_(deviceId),
       bootstrap_(std::move(bootstrap)) {
-  auto topo =
-      TopologyDiscovery::discover(myRank_, nRanks_, deviceId_, bootstrap_);
+  TopologyDiscovery topoDiscovery;
+  auto topo = topoDiscovery.discover(myRank_, nRanks_, deviceId_, *bootstrap_);
   nvlPeerRanks_ = std::move(topo.nvlPeerRanks);
   globalToNvlLocal_ = std::move(topo.globalToNvlLocal);
 

--- a/comms/pipes/TopologyDiscovery.h
+++ b/comms/pipes/TopologyDiscovery.h
@@ -2,7 +2,8 @@
 
 #pragma once
 
-#include <memory>
+#include <cstdint>
+#include <functional>
 #include <unordered_map>
 #include <vector>
 
@@ -11,6 +12,13 @@
 #include "comms/pipes/Transport.cuh"
 
 namespace comms::pipes {
+
+/**
+ * Callable that checks whether deviceA can access deviceB via P2P.
+ * Used for Tier 2 (same-host) NVLink detection.
+ * Return true if P2P access is possible.
+ */
+using PeerAccessFn = std::function<bool(int deviceA, int deviceB)>;
 
 /**
  * Result of topology discovery — identifies NVLink peers and provides
@@ -42,6 +50,26 @@ struct TopologyResult {
 };
 
 /**
+ * Per-rank topology info used by classify().
+ *
+ * This struct captures the per-rank inputs needed for topology classification
+ * without requiring CUDA or NVML. It enables unit testing of the
+ * classification logic with synthetic data.
+ */
+struct RankTopologyInfo {
+  char hostname[64]{};
+  int cudaDevice{0};
+  NvmlFabricInfo fabricInfo;
+};
+
+/**
+ * Callable that gathers local topology info for a given CUDA device.
+ * Returns a RankTopologyInfo populated with hostname, cudaDevice, and
+ * NvmlFabricInfo. Injectable for testing without real CUDA/NVML/gethostname.
+ */
+using LocalInfoFn = std::function<RankTopologyInfo(int deviceId)>;
+
+/**
  * Discovers multi-GPU topology via bootstrap allGather.
  *
  * Two-tier NVLink detection (following NCCL's MNNVL pattern):
@@ -56,17 +84,74 @@ struct TopologyResult {
  *   Fallback → IBGDA.
  *
  * Usage:
- *   auto topo = TopologyDiscovery::discover(myRank, nRanks, deviceId,
- * bootstrap);
- *   // topo.nvlPeerRanks, topo.globalToNvlLocal, etc.
+ *   TopologyDiscovery topo;  // default: real CUDA + NVML + gethostname
+ *   auto result = topo.discover(myRank, nRanks, deviceId, bootstrap);
+ *
+ * For testing:
+ *   TopologyDiscovery topo(myPeerAccessFn, myLocalInfoFn);
+ *   auto result = topo.discover(myRank, nRanks, deviceId, bootstrap);
  */
 class TopologyDiscovery {
  public:
-  static TopologyResult discover(
+  /**
+   * Default constructor: uses real CUDA + NVML + gethostname for local
+   * info gathering and cudaDeviceCanAccessPeer for Tier 2 detection.
+   */
+  TopologyDiscovery();
+
+  /**
+   * Constructor with custom peer access function.
+   * Uses real CUDA + NVML + gethostname for local info gathering.
+   *
+   * @param peerAccessFn  Custom peer access function for Tier 2 detection.
+   *                      Pass an empty std::function to skip Tier 2.
+   */
+  explicit TopologyDiscovery(PeerAccessFn peerAccessFn);
+
+  /**
+   * Constructor with custom peer access and local info functions.
+   * Fully injectable for testing without real hardware.
+   *
+   * @param peerAccessFn  Custom peer access function for Tier 2 detection.
+   *                      Pass an empty std::function to skip Tier 2.
+   * @param localInfoFn   Custom function to gather per-rank topology info.
+   */
+  TopologyDiscovery(PeerAccessFn peerAccessFn, LocalInfoFn localInfoFn);
+
+  /**
+   * Discover topology using local info gathering and bootstrap allGather.
+   *
+   * @param myRank      This rank's global index.
+   * @param nRanks      Total number of ranks.
+   * @param deviceId    CUDA device index.
+   * @param bootstrap   Bootstrap interface for allGather.
+   */
+  TopologyResult discover(
       int myRank,
       int nRanks,
       int deviceId,
-      std::shared_ptr<ctran::bootstrap::IBootstrap> bootstrap);
+      ctran::bootstrap::IBootstrap& bootstrap);
+
+  /**
+   * Classify pre-populated rank topology info into NVL peers.
+   *
+   * This is the core classification logic extracted from discover() for
+   * testability. It classifies peers using Tier 1 (MNNVL fabric match)
+   * and Tier 2 (same-host + peer access).
+   *
+   * Tier 2 requires a non-empty peerAccessFn (set via constructor).
+   * If not set, Tier 2 is skipped.
+   *
+   * @param myRank       This rank's global index.
+   * @param nRanks       Total number of ranks.
+   * @param allInfo      Pre-populated per-rank topology info (size == nRanks).
+   */
+  TopologyResult
+  classify(int myRank, int nRanks, std::vector<RankTopologyInfo>& allInfo);
+
+ private:
+  PeerAccessFn peerAccessFn_;
+  LocalInfoFn localInfoFn_;
 };
 
 } // namespace comms::pipes

--- a/comms/pipes/tests/MockBootstrap.h
+++ b/comms/pipes/tests/MockBootstrap.h
@@ -1,0 +1,66 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <vector>
+
+#include <gmock/gmock.h>
+
+#include "comms/ctran/interfaces/IBootstrap.h"
+
+namespace comms::pipes::testing {
+
+/// GMock-based mock of IBootstrap for unit testing.
+class MockBootstrap : public ctran::bootstrap::IBootstrap {
+ public:
+  MOCK_METHOD(
+      folly::SemiFuture<int>,
+      allGather,
+      (void* buf, int len, int rank, int nRanks),
+      (override));
+  MOCK_METHOD(
+      folly::SemiFuture<int>,
+      allGatherIntraNode,
+      (void* buf,
+       int len,
+       int localRank,
+       int localNRanks,
+       std::vector<int> localRankToCommRank),
+      (override));
+  MOCK_METHOD(
+      folly::SemiFuture<int>,
+      barrier,
+      (int rank, int nRanks),
+      (override));
+  MOCK_METHOD(
+      folly::SemiFuture<int>,
+      barrierIntraNode,
+      (int localRank, int localNRanks, std::vector<int> localRankToCommRank),
+      (override));
+  MOCK_METHOD(
+      folly::SemiFuture<int>,
+      allGatherNvlDomain,
+      (void* buf,
+       int len,
+       int nvlLocalRank,
+       int nvlNRanks,
+       std::vector<int> nvlRankToCommRank),
+      (override));
+  MOCK_METHOD(
+      folly::SemiFuture<int>,
+      barrierNvlDomain,
+      (int nvlLocalRank, int nvlNRanks, std::vector<int> nvlRankToCommRank),
+      (override));
+  MOCK_METHOD(
+      folly::SemiFuture<int>,
+      send,
+      (void* buf, int len, int peer, int tag),
+      (override));
+  MOCK_METHOD(
+      folly::SemiFuture<int>,
+      recv,
+      (void* buf, int len, int peer, int tag),
+      (override));
+};
+
+} // namespace comms::pipes::testing

--- a/comms/pipes/tests/TopologyClassifyTest.cc
+++ b/comms/pipes/tests/TopologyClassifyTest.cc
@@ -1,0 +1,208 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// Unit tests for TopologyDiscovery::classify() — the pure-logic core of
+// topology discovery. These tests use synthetic RankTopologyInfo data and
+// PeerAccessFn lambdas, requiring no CUDA, NVML, MPI, or specific hardware.
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "comms/pipes/NvmlFabricInfo.h"
+#include "comms/pipes/TopologyDiscovery.h"
+#include "comms/pipes/tests/TopologyTestUtils.h"
+
+namespace comms::pipes::tests {
+
+namespace {
+
+/// PeerAccessFn that always returns true (all same-host GPUs can peer).
+bool always_can_access(int /*deviceA*/, int /*deviceB*/) {
+  return true;
+}
+
+/// PeerAccessFn that always returns false (no peer access).
+bool never_can_access(int /*deviceA*/, int /*deviceB*/) {
+  return false;
+}
+
+} // namespace
+
+// =============================================================================
+// Basic classify() behavior (no MNNVL, same host)
+// =============================================================================
+
+// Two ranks on the same host with peer access → both are NVL peers.
+TEST(TopologyClassifyTest, SameHostPeerAccess) {
+  std::vector<RankTopologyInfo> allInfo = {
+      make_rank_info("host0", 0),
+      make_rank_info("host0", 1),
+  };
+
+  TopologyDiscovery topo(always_can_access);
+  auto result = topo.classify(/*myRank=*/0, /*nRanks=*/2, allInfo);
+
+  EXPECT_EQ(result.nvlPeerRanks.size(), 1u);
+  EXPECT_EQ(result.nvlPeerRanks[0], 1);
+  EXPECT_EQ(result.globalToNvlLocal.size(), 2u);
+  EXPECT_EQ(result.globalToNvlLocal.at(0), 0);
+  EXPECT_EQ(result.globalToNvlLocal.at(1), 1);
+  EXPECT_FALSE(result.fabricAvailable);
+}
+
+// Two ranks on the same host without peer access → no NVL peers.
+TEST(TopologyClassifyTest, SameHostNoPeerAccess) {
+  std::vector<RankTopologyInfo> allInfo = {
+      make_rank_info("host0", 0),
+      make_rank_info("host0", 1),
+  };
+
+  TopologyDiscovery topo(never_can_access);
+  auto result = topo.classify(/*myRank=*/0, /*nRanks=*/2, allInfo);
+
+  EXPECT_TRUE(result.nvlPeerRanks.empty());
+  EXPECT_EQ(result.globalToNvlLocal.size(), 1u); // Only self
+}
+
+// Two ranks on different hosts without MNNVL → no NVL peers.
+TEST(TopologyClassifyTest, DifferentHostsNoMnnvl) {
+  std::vector<RankTopologyInfo> allInfo = {
+      make_rank_info("host0", 0),
+      make_rank_info("host1", 0),
+  };
+
+  TopologyDiscovery topo(always_can_access);
+  auto result = topo.classify(/*myRank=*/0, /*nRanks=*/2, allInfo);
+
+  EXPECT_TRUE(result.nvlPeerRanks.empty());
+}
+
+// No peerAccessFn provided → Tier 2 is skipped entirely.
+TEST(TopologyClassifyTest, NoPeerAccessFnSkipsTier2) {
+  std::vector<RankTopologyInfo> allInfo = {
+      make_rank_info("host0", 0),
+      make_rank_info("host0", 1),
+  };
+
+  TopologyDiscovery topo(PeerAccessFn{});
+  auto result = topo.classify(/*myRank=*/0, /*nRanks=*/2, allInfo);
+
+  EXPECT_TRUE(result.nvlPeerRanks.empty());
+}
+
+// =============================================================================
+// Multi-host / large-scale scenarios
+// =============================================================================
+
+// 8 ranks on 2 hosts (4 GPUs per host), no MNNVL. Ranks on the same host
+// should be NVL peers via Tier 2.
+TEST(TopologyClassifyTest, TwoHostsFourGpusEachNoMnnvl) {
+  std::vector<RankTopologyInfo> allInfo;
+  for (int r = 0; r < 8; ++r) {
+    std::string host = (r < 4) ? "host0" : "host1";
+    allInfo.push_back(make_rank_info(host.c_str(), r % 4));
+  }
+
+  TopologyDiscovery topo(always_can_access);
+
+  // From rank 0's perspective: ranks 1,2,3 are NVL peers (same host).
+  auto result = topo.classify(/*myRank=*/0, /*nRanks=*/8, allInfo);
+
+  ASSERT_EQ(result.nvlPeerRanks.size(), 3u);
+  EXPECT_EQ(result.nvlPeerRanks[0], 1);
+  EXPECT_EQ(result.nvlPeerRanks[1], 2);
+  EXPECT_EQ(result.nvlPeerRanks[2], 3);
+
+  // From rank 5's perspective: ranks 4,6,7 are NVL peers.
+  TopologyDiscovery topo5(always_can_access);
+  auto result5 = topo5.classify(/*myRank=*/5, /*nRanks=*/8, allInfo);
+
+  ASSERT_EQ(result5.nvlPeerRanks.size(), 3u);
+  EXPECT_EQ(result5.nvlPeerRanks[0], 4);
+  EXPECT_EQ(result5.nvlPeerRanks[1], 6);
+  EXPECT_EQ(result5.nvlPeerRanks[2], 7);
+}
+
+// =============================================================================
+// NVL local rank consistency
+// =============================================================================
+
+// Verify NVL local indices are dense [0, N) and consistent regardless of
+// which rank calls classify().
+TEST(TopologyClassifyTest, NvlLocalRanksConsistentAcrossRanks) {
+  std::vector<RankTopologyInfo> baseInfo = {
+      make_rank_info("host0", 0),
+      make_rank_info("host0", 1),
+      make_rank_info("host0", 2),
+      make_rank_info("host0", 3),
+  };
+
+  // All 4 ranks should agree on the global→NVL-local mapping.
+  std::unordered_map<int, int> referenceMapping;
+
+  for (int myRank = 0; myRank < 4; ++myRank) {
+    // classify modifies allInfo[myRank], so make a fresh copy each time.
+    auto allInfo = baseInfo;
+    TopologyDiscovery topo(always_can_access);
+    auto result = topo.classify(myRank, /*nRanks=*/4, allInfo);
+
+    EXPECT_EQ(result.globalToNvlLocal.size(), 4u);
+
+    if (myRank == 0) {
+      referenceMapping = result.globalToNvlLocal;
+    } else {
+      EXPECT_EQ(result.globalToNvlLocal, referenceMapping)
+          << "Rank " << myRank
+          << " has different NVL local mapping than rank 0";
+    }
+  }
+}
+
+// Verify NVL local indices form a dense [0, N) range.
+TEST(TopologyClassifyTest, NvlLocalIndicesDense) {
+  std::vector<RankTopologyInfo> allInfo = {
+      make_rank_info("host0", 0),
+      make_rank_info("host0", 1),
+      make_rank_info("host0", 2),
+  };
+
+  TopologyDiscovery topo(always_can_access);
+  auto result = topo.classify(/*myRank=*/0, /*nRanks=*/3, allInfo);
+
+  int nvlNRanks = static_cast<int>(result.globalToNvlLocal.size());
+  ASSERT_EQ(nvlNRanks, 3);
+
+  std::vector<bool> seen(nvlNRanks, false);
+  for (const auto& [gRank, nvlLocal] : result.globalToNvlLocal) {
+    ASSERT_GE(nvlLocal, 0);
+    ASSERT_LT(nvlLocal, nvlNRanks);
+    EXPECT_FALSE(seen[nvlLocal]) << "Duplicate NVL local index " << nvlLocal;
+    seen[nvlLocal] = true;
+  }
+
+  for (int i = 0; i < nvlNRanks; ++i) {
+    EXPECT_TRUE(seen[i]) << "Missing NVL local index " << i;
+  }
+}
+
+// =============================================================================
+// Edge cases
+// =============================================================================
+
+// Single rank → no peers, self is in NVL local mapping.
+TEST(TopologyClassifyTest, SingleRank) {
+  std::vector<RankTopologyInfo> allInfo = {
+      make_rank_info("host0", 0),
+  };
+
+  TopologyDiscovery topo;
+  auto result = topo.classify(/*myRank=*/0, /*nRanks=*/1, allInfo);
+
+  EXPECT_TRUE(result.nvlPeerRanks.empty());
+  EXPECT_EQ(result.globalToNvlLocal.size(), 1u);
+  EXPECT_EQ(result.globalToNvlLocal.at(0), 0);
+}
+
+} // namespace comms::pipes::tests

--- a/comms/pipes/tests/TopologyDiscoveryE2eTest.cc
+++ b/comms/pipes/tests/TopologyDiscoveryE2eTest.cc
@@ -1,0 +1,220 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// End-to-end distributed tests for TopologyDiscovery using real CUDA, NVML,
+// gethostname, and MPI-based bootstrap. Requires GPU hardware and MPI.
+
+#include <unistd.h>
+#include <cstring>
+#include <vector>
+
+#include <cuda_runtime.h>
+#include <folly/init/Init.h>
+#include <folly/logging/xlog.h>
+#include <gtest/gtest.h>
+#include <mpi.h>
+
+#include "comms/pipes/NvmlFabricInfo.h"
+#include "comms/pipes/TopologyDiscovery.h"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/testinfra/mpi/MpiBootstrap.h"
+#include "comms/testinfra/mpi/MpiTestUtils.h"
+
+using meta::comms::MpiBaseTestFixture;
+using meta::comms::MpiBootstrap;
+using meta::comms::MPIEnvironmentBase;
+
+namespace comms::pipes::tests {
+
+class TopologyDiscoveryE2eFixture : public MpiBaseTestFixture {
+ protected:
+  void SetUp() override {
+    MpiBaseTestFixture::SetUp();
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+    detect_platform();
+  }
+
+  /**
+   * Independently detect the platform by querying NvmlFabricInfo and
+   * gathering hostnames from all ranks. This gives us ground truth to
+   * verify that TopologyDiscovery made the correct decisions.
+   */
+  void detect_platform() {
+    struct RankLocation {
+      char hostname[64]{};
+      NvmlFabricInfo fabricInfo;
+    };
+
+    RankLocation myLoc{};
+    gethostname(myLoc.hostname, sizeof(myLoc.hostname));
+
+    char busId[NvmlFabricInfo::kBusIdLen];
+    CUDACHECK_TEST(
+        cudaDeviceGetPCIBusId(busId, NvmlFabricInfo::kBusIdLen, localRank));
+    myLoc.fabricInfo = NvmlFabricInfo::query(busId);
+
+    std::vector<RankLocation> allLocs(numRanks);
+    MPI_Allgather(
+        &myLoc,
+        sizeof(RankLocation),
+        MPI_BYTE,
+        allLocs.data(),
+        sizeof(RankLocation),
+        MPI_BYTE,
+        MPI_COMM_WORLD);
+
+    // Count same-hostname ranks (= local node size).
+    localSize_ = 0;
+    for (int r = 0; r < numRanks; ++r) {
+      if (std::strcmp(myLoc.hostname, allLocs[r].hostname) == 0) {
+        ++localSize_;
+      }
+    }
+
+    // Check if ALL ranks share the same MNNVL fabric.
+    isMnnvl_ = myLoc.fabricInfo.available;
+    if (isMnnvl_) {
+      for (int r = 0; r < numRanks; ++r) {
+        if (!allLocs[r].fabricInfo.available ||
+            std::memcmp(
+                myLoc.fabricInfo.clusterUuid,
+                allLocs[r].fabricInfo.clusterUuid,
+                NvmlFabricInfo::kUuidLen) != 0 ||
+            myLoc.fabricInfo.cliqueId != allLocs[r].fabricInfo.cliqueId) {
+          isMnnvl_ = false;
+          break;
+        }
+      }
+    }
+
+    XLOGF(
+        INFO,
+        "Rank {} platform detection: isMnnvl={}, localSize={}",
+        globalRank,
+        isMnnvl_,
+        localSize_);
+  }
+
+  TopologyResult run_discover() {
+    auto bootstrap = std::make_shared<MpiBootstrap>();
+    TopologyDiscovery topo;
+    return topo.discover(globalRank, numRanks, localRank, *bootstrap);
+  }
+
+  bool isMnnvl_{false};
+  int localSize_{0};
+};
+
+// NVL peers should be populated and self should NOT appear in nvlPeerRanks.
+TEST_F(TopologyDiscoveryE2eFixture, BasicTopologyClassification) {
+  auto result = run_discover();
+
+  // Self should not be in the peer list.
+  for (int peer : result.nvlPeerRanks) {
+    EXPECT_NE(peer, globalRank) << "Self should not appear in nvlPeerRanks";
+  }
+
+  // Self should be in the global-to-NVL-local mapping.
+  EXPECT_NE(
+      result.globalToNvlLocal.find(globalRank), result.globalToNvlLocal.end())
+      << "Self should be in globalToNvlLocal";
+
+  // NVL domain size = peers + self.
+  int nvlNRanks = static_cast<int>(result.nvlPeerRanks.size()) + 1;
+  EXPECT_EQ(static_cast<int>(result.globalToNvlLocal.size()), nvlNRanks);
+
+  XLOGF(
+      INFO,
+      "Rank {}: {} NVL peers, fabricAvailable={}",
+      globalRank,
+      result.nvlPeerRanks.size(),
+      result.fabricAvailable);
+
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
+// Verify NVL local rank indices are consistent across all ranks that share
+// the same NVL domain.
+TEST_F(TopologyDiscoveryE2eFixture, NvlLocalRankConsistency) {
+  auto result = run_discover();
+
+  // Broadcast each rank's globalToNvlLocal mapping via allGather and verify
+  // consistency: if rank A thinks rank B has NVL-local index X, then rank B
+  // should agree on its own index.
+  int myNvlLocal = result.globalToNvlLocal.at(globalRank);
+
+  std::vector<int> allNvlLocals(numRanks);
+  MPI_Allgather(
+      &myNvlLocal, 1, MPI_INT, allNvlLocals.data(), 1, MPI_INT, MPI_COMM_WORLD);
+
+  // For each peer in our NVL domain, verify their self-reported NVL-local
+  // index matches what we assigned.
+  for (const auto& [gRank, expectedLocal] : result.globalToNvlLocal) {
+    EXPECT_EQ(allNvlLocals[gRank], expectedLocal)
+        << "Rank " << globalRank << " thinks rank " << gRank
+        << " has NVL-local " << expectedLocal << ", but rank " << gRank
+        << " reports " << allNvlLocals[gRank];
+  }
+
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
+// Verify NVL local indices form a dense [0, N) range.
+TEST_F(TopologyDiscoveryE2eFixture, NvlLocalIndicesDense) {
+  auto result = run_discover();
+
+  int nvlNRanks = static_cast<int>(result.globalToNvlLocal.size());
+  ASSERT_GT(nvlNRanks, 0);
+
+  std::vector<bool> seen(nvlNRanks, false);
+  for (const auto& [gRank, nvlLocal] : result.globalToNvlLocal) {
+    ASSERT_GE(nvlLocal, 0) << "NVL local index out of range for rank " << gRank;
+    ASSERT_LT(nvlLocal, nvlNRanks)
+        << "NVL local index out of range for rank " << gRank;
+    EXPECT_FALSE(seen[nvlLocal]) << "Duplicate NVL local index " << nvlLocal;
+    seen[nvlLocal] = true;
+  }
+
+  for (int i = 0; i < nvlNRanks; ++i) {
+    EXPECT_TRUE(seen[i]) << "Missing NVL local index " << i;
+  }
+
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
+// Verify NVL peer count matches the platform: on MNNVL all ranks in the
+// same clique are NVL peers, on non-MNNVL only same-host ranks are NVL peers.
+TEST_F(TopologyDiscoveryE2eFixture, PlatformNvlPeerCount) {
+  auto result = run_discover();
+
+  int nvlPeerCount = static_cast<int>(result.nvlPeerRanks.size());
+
+  if (isMnnvl_) {
+    // All ranks share the same NVLink fabric → every peer is NVL.
+    EXPECT_EQ(nvlPeerCount, numRanks - 1) << "MNNVL: all peers should be NVL";
+  } else {
+    // Same-host peers only.
+    EXPECT_EQ(nvlPeerCount, localSize_ - 1)
+        << "Non-MNNVL: NVL peers should be same-host only";
+  }
+
+  XLOGF(
+      INFO,
+      "Rank {} (localRank {}): isMnnvl={}, {} NVL peers (expected {})",
+      globalRank,
+      localRank,
+      isMnnvl_,
+      nvlPeerCount,
+      isMnnvl_ ? numRanks - 1 : localSize_ - 1);
+
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
+} // namespace comms::pipes::tests
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  auto mpi_env = std::make_unique<MPIEnvironmentBase>();
+  ::testing::AddGlobalTestEnvironment(mpi_env.get());
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/pipes/tests/TopologyDiscoveryTest.cc
+++ b/comms/pipes/tests/TopologyDiscoveryTest.cc
@@ -1,158 +1,133 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
+// Unit tests for TopologyDiscovery::discover(). Fully mocked — no GPU, CUDA,
+// NVML, or specific hardware required. Uses a mock LocalInfoFn to inject
+// synthetic RankTopologyInfo and a mock bootstrap for allGather.
+
 #include <cstring>
 #include <vector>
 
-#include <unistd.h>
-
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 
 #include "comms/pipes/NvmlFabricInfo.h"
 #include "comms/pipes/TopologyDiscovery.h"
-#include "comms/pipes/Transport.cuh"
-#include "comms/testinfra/TestXPlatUtils.h"
-#include "comms/testinfra/mpi/MpiBootstrap.h"
-#include "comms/testinfra/mpi/MpiTestUtils.h"
-#include "comms/utils/CudaRAII.h"
-
-using namespace meta::comms;
+#include "comms/pipes/tests/MockBootstrap.h"
+#include "comms/pipes/tests/TopologyTestUtils.h"
 
 namespace comms::pipes::tests {
 
-class TopologyDiscoveryFixture : public MpiBaseTestFixture {
- protected:
-  void SetUp() override {
-    MpiBaseTestFixture::SetUp();
-    CUDACHECK_TEST(cudaSetDevice(localRank));
-    detectPlatform();
-  }
+using ::testing::_;
 
-  void detectPlatform() {
-    struct RankLocation {
-      char hostname[64];
-      NvmlFabricInfo fabricInfo;
-    };
+namespace {
 
-    RankLocation myLoc{};
-    gethostname(myLoc.hostname, sizeof(myLoc.hostname));
-
-    char busId[NvmlFabricInfo::kBusIdLen];
-    CUDACHECK_TEST(
-        cudaDeviceGetPCIBusId(busId, NvmlFabricInfo::kBusIdLen, localRank));
-    myLoc.fabricInfo = NvmlFabricInfo::query(busId);
-
-    std::vector<RankLocation> allLocs(numRanks);
-    MPI_Allgather(
-        &myLoc,
-        sizeof(RankLocation),
-        MPI_BYTE,
-        allLocs.data(),
-        sizeof(RankLocation),
-        MPI_BYTE,
-        MPI_COMM_WORLD);
-
-    localSize_ = 0;
-    for (int r = 0; r < numRanks; ++r) {
-      if (std::strcmp(myLoc.hostname, allLocs[r].hostname) == 0) {
-        ++localSize_;
-      }
-    }
-
-    isMnnvl_ = myLoc.fabricInfo.available;
-    if (isMnnvl_) {
-      for (int r = 0; r < numRanks; ++r) {
-        if (!allLocs[r].fabricInfo.available ||
-            std::memcmp(
-                myLoc.fabricInfo.clusterUuid,
-                allLocs[r].fabricInfo.clusterUuid,
-                NvmlFabricInfo::kUuidLen) != 0 ||
-            myLoc.fabricInfo.cliqueId != allLocs[r].fabricInfo.cliqueId) {
-          isMnnvl_ = false;
-          break;
-        }
-      }
-    }
-  }
-
-  bool isMnnvl_{false};
-  int localSize_{0};
-};
-
-// Verify basic topology classification: NVL peers populated, self not in
-// nvlPeerRanks, globalToNvlLocal contains self.
-TEST_F(TopologyDiscoveryFixture, BasicTopologyClassification) {
-  auto bootstrap = std::make_shared<MpiBootstrap>();
-  auto topo =
-      TopologyDiscovery::discover(globalRank, numRanks, localRank, bootstrap);
-
-  // Self should be in the NVL local mapping but NOT in nvlPeerRanks.
-  EXPECT_NE(
-      topo.globalToNvlLocal.find(globalRank), topo.globalToNvlLocal.end());
-  for (int r : topo.nvlPeerRanks) {
-    EXPECT_NE(r, globalRank) << "Self should not appear in nvlPeerRanks";
-  }
-
-  // On same-node with >=2 GPUs, at least one peer should be NVL.
-  if (numRanks >= 2 && localSize_ >= 2) {
-    EXPECT_FALSE(topo.nvlPeerRanks.empty())
-        << "Expected NVL peers on same node";
-  }
-
-  XLOGF(
-      INFO,
-      "Rank {}: {} NVL peers, isMnnvl={}",
-      globalRank,
-      topo.nvlPeerRanks.size(),
-      isMnnvl_);
-
-  MPI_Barrier(MPI_COMM_WORLD);
+/// Create a simple mock LocalInfoFn that always returns the given info.
+LocalInfoFn make_simple_local_info_fn(const RankTopologyInfo& info) {
+  return [info](int /*deviceId*/) -> RankTopologyInfo { return info; };
 }
 
-// Verify NVL local rank indices are consistent across all ranks.
-TEST_F(TopologyDiscoveryFixture, NvlLocalRankConsistency) {
-  auto bootstrap = std::make_shared<MpiBootstrap>();
-  auto topo =
-      TopologyDiscovery::discover(globalRank, numRanks, localRank, bootstrap);
-
-  int nvlNRanks = static_cast<int>(topo.nvlPeerRanks.size()) + 1;
-  int nvlLocalRank = topo.globalToNvlLocal.at(globalRank);
-
-  // nvlLocalRank must be in [0, nvlNRanks)
-  EXPECT_GE(nvlLocalRank, 0);
-  EXPECT_LT(nvlLocalRank, nvlNRanks);
-
-  // globalToNvlLocal must contain self
-  auto it = topo.globalToNvlLocal.find(globalRank);
-  ASSERT_NE(it, topo.globalToNvlLocal.end());
-  EXPECT_EQ(it->second, nvlLocalRank);
-
-  // All NVL peers should be in the mapping
-  for (int r : topo.nvlPeerRanks) {
-    EXPECT_NE(topo.globalToNvlLocal.find(r), topo.globalToNvlLocal.end())
-        << "NVL peer " << r << " missing from globalToNvlLocal";
-  }
-
-  // Mapping size = nvlPeerRanks + self
-  EXPECT_EQ(
-      static_cast<int>(topo.globalToNvlLocal.size()),
-      static_cast<int>(topo.nvlPeerRanks.size()) + 1);
-
-  MPI_Barrier(MPI_COMM_WORLD);
+/// Configure mock bootstrap so allGather fills in pre-built data for all
+/// ranks except the caller's own slot (which discover() fills in itself).
+void expect_prefilled_all_gather(
+    testing::MockBootstrap& mock,
+    const std::vector<RankTopologyInfo>& allInfo) {
+  EXPECT_CALL(mock, allGather(_, _, _, _))
+      .WillRepeatedly(
+          [allInfo](void* buf, int len, int rank, int nRanks)
+              -> folly::SemiFuture<int> {
+            auto* charBuf = static_cast<char*>(buf);
+            for (int r = 0; r < nRanks; ++r) {
+              if (r != rank) {
+                std::memcpy(
+                    charBuf + r * len,
+                    reinterpret_cast<const char*>(&allInfo[r]),
+                    len);
+              }
+            }
+            return folly::makeSemiFuture(0);
+          });
 }
 
-// Verify NVL local indices form a dense [0, N) range.
-TEST_F(TopologyDiscoveryFixture, NvlLocalIndicesDense) {
-  auto bootstrap = std::make_shared<MpiBootstrap>();
-  auto topo =
-      TopologyDiscovery::discover(globalRank, numRanks, localRank, bootstrap);
+} // namespace
 
-  int nvlNRanks = static_cast<int>(topo.globalToNvlLocal.size());
+// =============================================================================
+// Basic discover() with mocked local info
+// =============================================================================
+
+// Verify discover() gathers local info via LocalInfoFn and classifies
+// fake same-host peers.
+TEST(TopologyDiscoveryTest, DiscoverWithFakeSameHostPeers) {
+  constexpr const char* kHostname = "test-host-001";
+
+  // 3 ranks: all on the same host.
+  constexpr int nRanks = 3;
+  std::vector<RankTopologyInfo> allInfo(nRanks);
+  allInfo[0] = make_rank_info(kHostname, 0);
+  allInfo[1] = make_rank_info(kHostname, 1);
+  allInfo[2] = make_rank_info(kHostname, 2);
+
+  testing::MockBootstrap bootstrap;
+  expect_prefilled_all_gather(bootstrap, allInfo);
+
+  PeerAccessFn alwaysAccess = [](int, int) { return true; };
+  TopologyDiscovery topo(alwaysAccess, make_simple_local_info_fn(allInfo[0]));
+  auto result = topo.discover(/*myRank=*/0, nRanks, /*deviceId=*/0, bootstrap);
+
+  EXPECT_EQ(static_cast<int>(result.nvlPeerRanks.size()), 2);
+  EXPECT_EQ(result.globalToNvlLocal.size(), 3u);
+  EXPECT_NE(result.globalToNvlLocal.find(0), result.globalToNvlLocal.end());
+
+  // Self should not appear in nvlPeerRanks.
+  for (int peer : result.nvlPeerRanks) {
+    EXPECT_NE(peer, 0);
+  }
+}
+
+// Verify discover() classifies a remote peer (different hostname) as non-NVL.
+TEST(TopologyDiscoveryTest, DiscoverWithRemotePeer) {
+  constexpr const char* kHostname = "test-host-001";
+
+  constexpr int nRanks = 2;
+  std::vector<RankTopologyInfo> allInfo(nRanks);
+  allInfo[0] = make_rank_info(kHostname, 0);
+  allInfo[1] = make_rank_info("remote-host-xyz", 0);
+
+  testing::MockBootstrap bootstrap;
+  expect_prefilled_all_gather(bootstrap, allInfo);
+
+  PeerAccessFn alwaysAccess = [](int, int) { return true; };
+  TopologyDiscovery topo(alwaysAccess, make_simple_local_info_fn(allInfo[0]));
+  auto result = topo.discover(/*myRank=*/0, nRanks, /*deviceId=*/0, bootstrap);
+
+  // Different host, no fabric → remote peer is not NVL.
+  EXPECT_TRUE(result.nvlPeerRanks.empty());
+  EXPECT_EQ(result.globalToNvlLocal.size(), 1u);
+}
+
+// Verify NVL local indices are dense and consistent.
+TEST(TopologyDiscoveryTest, NvlLocalIndicesDense) {
+  constexpr const char* kHostname = "test-host-001";
+
+  constexpr int nRanks = 4;
+  std::vector<RankTopologyInfo> allInfo(nRanks);
+  for (int r = 0; r < nRanks; ++r) {
+    allInfo[r] = make_rank_info(kHostname, r);
+  }
+
+  testing::MockBootstrap bootstrap;
+  expect_prefilled_all_gather(bootstrap, allInfo);
+
+  PeerAccessFn alwaysAccess = [](int, int) { return true; };
+  TopologyDiscovery topo(alwaysAccess, make_simple_local_info_fn(allInfo[0]));
+  auto result = topo.discover(/*myRank=*/0, nRanks, /*deviceId=*/0, bootstrap);
+
+  int nvlNRanks = static_cast<int>(result.globalToNvlLocal.size());
+  EXPECT_EQ(nvlNRanks, nRanks);
+
   std::vector<bool> seen(nvlNRanks, false);
-
-  for (const auto& [gRank, nvlLocal] : topo.globalToNvlLocal) {
+  for (const auto& [gRank, nvlLocal] : result.globalToNvlLocal) {
     ASSERT_GE(nvlLocal, 0);
     ASSERT_LT(nvlLocal, nvlNRanks);
     EXPECT_FALSE(seen[nvlLocal]) << "Duplicate NVL local index " << nvlLocal;
@@ -162,32 +137,33 @@ TEST_F(TopologyDiscoveryFixture, NvlLocalIndicesDense) {
   for (int i = 0; i < nvlNRanks; ++i) {
     EXPECT_TRUE(seen[i]) << "Missing NVL local index " << i;
   }
-
-  MPI_Barrier(MPI_COMM_WORLD);
 }
 
-// Verify NVL peer count matches platform expectations.
-TEST_F(TopologyDiscoveryFixture, PlatformNvlPeerCount) {
-  auto bootstrap = std::make_shared<MpiBootstrap>();
-  auto topo =
-      TopologyDiscovery::discover(globalRank, numRanks, localRank, bootstrap);
+// Single rank: no peers, but self should be in the NVL local mapping.
+TEST(TopologyDiscoveryTest, DiscoverSingleRank) {
+  constexpr const char* kHostname = "test-host-001";
 
-  if (isMnnvl_) {
-    EXPECT_EQ(static_cast<int>(topo.nvlPeerRanks.size()), numRanks - 1)
-        << "MNNVL: all peers should be NVL";
-  } else {
-    EXPECT_EQ(static_cast<int>(topo.nvlPeerRanks.size()), localSize_ - 1)
-        << "Non-MNNVL: NVL peers should be same-node only";
-  }
+  constexpr int nRanks = 1;
+  auto localInfo = make_rank_info(kHostname, 0);
 
-  MPI_Barrier(MPI_COMM_WORLD);
+  std::vector<RankTopologyInfo> allInfo(nRanks);
+  allInfo[0] = localInfo;
+
+  testing::MockBootstrap bootstrap;
+  expect_prefilled_all_gather(bootstrap, allInfo);
+
+  TopologyDiscovery topo(PeerAccessFn{}, make_simple_local_info_fn(localInfo));
+  auto result = topo.discover(/*myRank=*/0, nRanks, /*deviceId=*/0, bootstrap);
+
+  EXPECT_TRUE(result.nvlPeerRanks.empty());
+  EXPECT_EQ(result.globalToNvlLocal.size(), 1u);
+  EXPECT_EQ(result.globalToNvlLocal.at(0), 0);
 }
 
 } // namespace comms::pipes::tests
 
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
-  ::testing::AddGlobalTestEnvironment(new MPIEnvironmentBase);
   folly::Init init(&argc, &argv);
   return RUN_ALL_TESTS();
 }

--- a/comms/pipes/tests/TopologyTestUtils.h
+++ b/comms/pipes/tests/TopologyTestUtils.h
@@ -1,0 +1,32 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstring>
+
+#include "comms/pipes/NvmlFabricInfo.h"
+#include "comms/pipes/TopologyDiscovery.h"
+
+namespace comms::pipes::tests {
+
+/// Shared helper: build a RankTopologyInfo with the given hostname and CUDA
+/// device. Fabric info is left unavailable by default unless explicitly set.
+inline RankTopologyInfo make_rank_info(
+    const char* hostname,
+    int cudaDevice,
+    bool fabricAvailable = false,
+    const char* clusterUuid = nullptr,
+    unsigned int cliqueId = 0) {
+  RankTopologyInfo info{};
+  std::strncpy(info.hostname, hostname, sizeof(info.hostname) - 1);
+  info.cudaDevice = cudaDevice;
+  info.fabricInfo.available = fabricAvailable;
+  if (clusterUuid) {
+    std::memcpy(
+        info.fabricInfo.clusterUuid, clusterUuid, NvmlFabricInfo::kUuidLen);
+  }
+  info.fabricInfo.cliqueId = cliqueId;
+  return info;
+}
+
+} // namespace comms::pipes::tests


### PR DESCRIPTION
Summary:
Refactor TopologyDiscovery from a static-method class to an instance-based
design with injectable dependencies. This enables unit testing of topology
classification logic without requiring real CUDA, NVML, MPI, or GPUs.

Key changes:
- Extract RankTopologyInfo from anonymous-namespace RankInfo to public struct
- Add PeerAccessFn (injectable cudaDeviceCanAccessPeer replacement)
- Add LocalInfoFn (injectable hostname/NVML/device info gathering)
- Add three constructors: default (real hardware), PeerAccessFn-only, and
  fully injectable (PeerAccessFn + LocalInfoFn)
- Extract classify() as public method for direct unit testing of
  classification logic without bootstrap/allGather
- Change discover() to take IBootstrap& instead of shared_ptr
- Update MultiPeerTransport to use instance-based TopologyDiscovery
- Split tests: MockBootstrap for mocked unit tests, E2E tests for real
  hardware, TopologyClassifyTest for pure-logic classify() tests

Differential Revision: D94043675


