### PR TITLE
Fix BUCK dependency and build issues

### DIFF
--- a/comms/torchcomms/device/DeviceBackendTraits.hpp
+++ b/comms/torchcomms/device/DeviceBackendTraits.hpp
@@ -17,7 +17,7 @@
 #include <memory>
 
 #include <nccl.h> // @manual=//comms/ncclx:nccl
-#include <nccl_device/impl/comm__types.h> // @manual=//comms/ncclx:nccl_device_api
+#include <nccl_device/impl/comm__types.h> // @manual=//comms/ncclx:nccl
 
 // Forward declarations
 namespace torch::comms {

--- a/comms/torchcomms/device/ncclx/TorchCommDeviceNCCLX.cuh
+++ b/comms/torchcomms/device/ncclx/TorchCommDeviceNCCLX.cuh
@@ -31,7 +31,7 @@
 #include <cuda_runtime.h>
 
 #include <nccl_device.h> // @manual=//comms/ncclx:nccl
-#include <nccl_device/impl/comm__types.h> // @manual=//comms/ncclx:nccl_device_api
+#include <nccl_device/impl/comm__types.h> // @manual=//comms/ncclx:nccl
 
 #include "comms/common/AtomicUtils.cuh"
 #include "comms/pipes/CopyUtils.cuh"


### PR DESCRIPTION
Summary:
Fix BUCK lint warnings: remove unused deps, reorder deps, add
lint-ignore for valid link_whole usage. Fix incorrect manual
target references in device headers.

Differential Revision: D94061926


