### PR TITLE
Backward-compatible TCP socket support for Devmem Agent

### DIFF
--- a/comms/ncclx/v2_27/src/Makefile
+++ b/comms/ncclx/v2_27/src/Makefile
@@ -112,39 +112,39 @@ ifeq ($(ENABLE_TCPDM),1)
 CXXFLAGS    += -DTCP_DEVMEM_AGENT
 THRIFT      ?= thrift1
 DEVMEM_DIR  := $(BASE_DIR)/comms/tcp_devmem
-THRIFT_FILE := $(DEVMEM_DIR)/devmgr/devmgr.thrift
-THRIFT_H    := $(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_client.h
+THRIFT_FILE := $(DEVMEM_DIR)/devmgr/if/devmgr.thrift
+THRIFT_H    := $(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_client.h
 
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/DevMgr.cpp
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/DevMgrAsyncClient.cpp
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/DevMgr_processmap_binary.cpp
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/DevMgr_processmap_compact.cpp
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_constants.cpp
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_data.cpp
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_metadata.cpp
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_types.cpp
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_types_binary.cpp
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_types_compact.cpp
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_types_serialization.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/DevMgr.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/DevMgrAsyncClient.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/DevMgr_processmap_binary.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/DevMgr_processmap_compact.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_constants.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_data.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_metadata.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_types.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_types_binary.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_types_compact.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_types_serialization.cpp
 
 $(THRIFT_H): $(THRIFT_FILE)
 	@printf "Generating  %-35s > %s\n" $(THRIFT_FILE) $(DEVMEM_DIR)/devmgr
-	$(THRIFT) --gen mstch_cpp2:include_prefix=$(DEVMEM_DIR)/devmgr -o $(DEVMEM_DIR)/devmgr $(THRIFT_FILE)
+	$(THRIFT) --gen mstch_cpp2:include_prefix=$(DEVMEM_DIR)/devmgr/if -o $(DEVMEM_DIR)/devmgr/if $(THRIFT_FILE)
 
 $(DEVMEM_DIR)/devmgr/devmgr_client.cc: $(THRIFT_H)
 $(DEVMEM_DIR)/transport.cc: $(THRIFT_H)
 
-$(DEVMEM_DIR)/devmgr/gen-cpp2/DevMgr.cpp: $(THRIFT_H)
-$(DEVMEM_DIR)/devmgr/gen-cpp2/DevMgrAsyncClient.cpp: $(THRIFT_H)
-$(DEVMEM_DIR)/devmgr/gen-cpp2/DevMgr_processmap_binary.cpp: $(THRIFT_H)
-$(DEVMEM_DIR)/devmgr/gen-cpp2/DevMgr_processmap_compact.cpp: $(THRIFT_H)
-$(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_constants.cpp: $(THRIFT_H)
-$(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_data.cpp: $(THRIFT_H)
-$(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_metadata.cpp: $(THRIFT_H)
-$(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_types.cpp: $(THRIFT_H)
-$(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_types_binary.cpp: $(THRIFT_H)
-$(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_types_compact.cpp: $(THRIFT_H)
-$(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_types_serialization.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/DevMgr.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/DevMgrAsyncClient.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/DevMgr_processmap_binary.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/DevMgr_processmap_compact.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_constants.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_data.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_metadata.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_types.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_types_binary.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_types_compact.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_types_serialization.cpp: $(THRIFT_H)
 
 ## Include TCP Devmem transport files and dependencies
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/ctran/backends/tcpdevmem/*.cc)
@@ -156,6 +156,7 @@ LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/tcp_devmem/request_pool.cc)
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/tcp_devmem/transport.cc)
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/tcp_devmem/worker.cc)
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/tcp_devmem/devmgr/devmgr.cc)
+LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/tcp_devmem/devmgr/bufmgr.cc)
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/tcp_devmem/devmgr/devmgr_client.cc)
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/tcp_devmem/common/*.cc)
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/tcp_devmem/unpack/external_unpack.cc)

--- a/comms/ncclx/v2_28/src/Makefile
+++ b/comms/ncclx/v2_28/src/Makefile
@@ -119,39 +119,39 @@ ifeq ($(ENABLE_TCPDM),1)
 CXXFLAGS    += -DTCP_DEVMEM_AGENT
 THRIFT      ?= thrift1
 DEVMEM_DIR  := $(BASE_DIR)/comms/tcp_devmem
-THRIFT_FILE := $(DEVMEM_DIR)/devmgr/devmgr.thrift
-THRIFT_H    := $(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_client.h
+THRIFT_FILE := $(DEVMEM_DIR)/devmgr/if/devmgr.thrift
+THRIFT_H    := $(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_client.h
 
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/DevMgr.cpp
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/DevMgrAsyncClient.cpp
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/DevMgr_processmap_binary.cpp
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/DevMgr_processmap_compact.cpp
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_constants.cpp
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_data.cpp
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_metadata.cpp
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_types.cpp
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_types_binary.cpp
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_types_compact.cpp
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_types_serialization.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/DevMgr.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/DevMgrAsyncClient.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/DevMgr_processmap_binary.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/DevMgr_processmap_compact.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_constants.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_data.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_metadata.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_types.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_types_binary.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_types_compact.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_types_serialization.cpp
 
 $(THRIFT_H): $(THRIFT_FILE)
 	@printf "Generating  %-35s > %s\n" $(THRIFT_FILE) $(DEVMEM_DIR)/devmgr
-	$(THRIFT) --gen mstch_cpp2:include_prefix=$(DEVMEM_DIR)/devmgr -o $(DEVMEM_DIR)/devmgr $(THRIFT_FILE)
+	$(THRIFT) --gen mstch_cpp2:include_prefix=$(DEVMEM_DIR)/devmgr/if -o $(DEVMEM_DIR)/devmgr/if $(THRIFT_FILE)
 
 $(DEVMEM_DIR)/devmgr/devmgr_client.cc: $(THRIFT_H)
 $(DEVMEM_DIR)/transport.cc: $(THRIFT_H)
 
-$(DEVMEM_DIR)/devmgr/gen-cpp2/DevMgr.cpp: $(THRIFT_H)
-$(DEVMEM_DIR)/devmgr/gen-cpp2/DevMgrAsyncClient.cpp: $(THRIFT_H)
-$(DEVMEM_DIR)/devmgr/gen-cpp2/DevMgr_processmap_binary.cpp: $(THRIFT_H)
-$(DEVMEM_DIR)/devmgr/gen-cpp2/DevMgr_processmap_compact.cpp: $(THRIFT_H)
-$(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_constants.cpp: $(THRIFT_H)
-$(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_data.cpp: $(THRIFT_H)
-$(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_metadata.cpp: $(THRIFT_H)
-$(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_types.cpp: $(THRIFT_H)
-$(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_types_binary.cpp: $(THRIFT_H)
-$(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_types_compact.cpp: $(THRIFT_H)
-$(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_types_serialization.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/DevMgr.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/DevMgrAsyncClient.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/DevMgr_processmap_binary.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/DevMgr_processmap_compact.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_constants.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_data.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_metadata.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_types.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_types_binary.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_types_compact.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_types_serialization.cpp: $(THRIFT_H)
 
 ## Include TCP Devmem transport files and dependencies
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/ctran/backends/tcpdevmem/*.cc)
@@ -163,6 +163,7 @@ LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/tcp_devmem/request_pool.cc)
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/tcp_devmem/transport.cc)
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/tcp_devmem/worker.cc)
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/tcp_devmem/devmgr/devmgr.cc)
+LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/tcp_devmem/devmgr/bufmgr.cc)
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/tcp_devmem/devmgr/devmgr_client.cc)
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/tcp_devmem/common/*.cc)
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/tcp_devmem/unpack/external_unpack.cc)


### PR DESCRIPTION
Summary:
The diff introduces a secondary communication channel between the plugin and the devmem agent:
1. The agent listens to both UDS and TCP addresses
2. Some small changes to thrift protocol (`fillRxQueue()`) to support IpcMemHandle passing in TCP mode.
3. Additional CVAR `TCP_DEVMEM_FORCE_TCP_AGENT_SOCKET` will force the plugin to use TCP instead of UDS (enabled on llama-train only)
4. Added support in transpor_bench via new flag `--agent-scoket uds/tcp`)

Reviewed By: spikeh

Differential Revision: D91604911


