### PR TITLE
Add benchmark to compare commRegister vs globalRegisterWithPtr

### DIFF
--- a/comms/ctran/regcache/tests/RegCacheBench.cc
+++ b/comms/ctran/regcache/tests/RegCacheBench.cc
@@ -173,6 +173,112 @@ int main(int argc, char* argv[]) {
   return RUN_ALL_TESTS();
 }
 
+// Benchmarks commRegister (mapper->regMem/deregMem) vs globalRegisterWithPtr
+// (regCache->globalRegister/globalDeregister) using the same allocation setup.
+// The third tuple element selects the registration path by name.
+class CommVsGlobalRegParam : public RegCacheBench,
+                             public ::testing::WithParamInterface<
+                                 std::tuple<int, size_t, std::string>> {};
+
+TEST_P(CommVsGlobalRegParam, RegDeregTime) {
+  auto& [numSegments, segmentSize, method] = GetParam();
+  bool useGlobal = (method == "global");
+
+  constexpr int numWarmup = 100;
+  constexpr int numIter = 1000;
+  std::vector<size_t> segSizes(numSegments, segmentSize);
+
+  // Allocate a single buffer — reused across iterations since each
+  // iteration registers then deregisters before the next.
+  void* buf = nullptr;
+  std::vector<TestMemSegment> segments;
+  NCCLCHECK_TEST(ncclMemAllocDisjoint(&buf, segSizes, segments));
+
+  auto& mapper = comm_->ctran_->mapper;
+  EXPECT_THAT(mapper, testing::NotNull());
+
+  // Compute total buffer size for global API (which discovers segments
+  // internally)
+  size_t totalBufSize = 0;
+  for (const auto& sz : segSizes) {
+    totalBufSize += sz;
+  }
+
+  auto runRegDeregIter = [&](int64_t& regNs, int64_t& deregNs) {
+    // --- Registration ---
+    std::vector<void*> segHandles;
+    auto t0 = std::chrono::steady_clock::now();
+    if (useGlobal) {
+      // Global API: single call with full buffer, discovers segments internally
+      COMMCHECK_TEST(ctran::globalRegisterWithPtr(buf, totalBufSize, false));
+    } else {
+      // Comm API: must call per-segment (designed for single-segment buffers)
+      for (auto& segment : segments) {
+        void* hdl = nullptr;
+        COMMCHECK_TEST(mapper->regMem(segment.ptr, segment.size, &hdl, false));
+        segHandles.push_back(hdl);
+      }
+    }
+    auto t1 = std::chrono::steady_clock::now();
+
+    // --- Deregistration ---
+    auto t2 = std::chrono::steady_clock::now();
+    if (useGlobal) {
+      // Global API: single call with full buffer
+      COMMCHECK_TEST(ctran::globalDeregisterWithPtr(buf, totalBufSize));
+    } else {
+      for (auto& segHdl : segHandles) {
+        COMMCHECK_TEST(mapper->deregMem(segHdl));
+      }
+    }
+    auto t3 = std::chrono::steady_clock::now();
+
+    regNs =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
+    deregNs =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(t3 - t2).count();
+  };
+
+  // Warmup — results discarded
+  for (int iter = 0; iter < numWarmup; iter++) {
+    int64_t regNs = 0, deregNs = 0;
+    runRegDeregIter(regNs, deregNs);
+  }
+
+  // Timed iterations
+  int64_t totalRegNs = 0, totalDeregNs = 0;
+  for (int iter = 0; iter < numIter; iter++) {
+    int64_t regNs = 0, deregNs = 0;
+    runRegDeregIter(regNs, deregNs);
+    totalRegNs += regNs;
+    totalDeregNs += deregNs;
+  }
+
+  auto avgRegNs = totalRegNs / numIter;
+  auto avgDeregNs = totalDeregNs / numIter;
+
+  NCCLCHECK_TEST(ncclMemFreeDisjoint(buf, segSizes));
+
+  std::cout << "[Registration comparison] method " << method << " numSegments "
+            << numSegments << ", segmentSize " << segmentSize
+            << ", avgRegTime(us) " << avgRegNs / 1000.0 << ", avgDeregTime(us) "
+            << avgDeregNs / 1000.0 << " (warmup=" << numWarmup
+            << ", measured=" << numIter << ")" << std::endl;
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CommVsGlobalReg,
+    CommVsGlobalRegParam,
+    ::testing::Combine(
+        testing::Values(1, 4, 8, 16),
+        testing::Values(20 * 1024 * 1024),
+        testing::Values("global", "comm")),
+    [&](const testing::TestParamInfo<CommVsGlobalRegParam::ParamType>& info) {
+      return std::to_string(std::get<0>(info.param)) + "numSeg_" +
+          std::to_string(std::get<1>(info.param)) + "SegSize_" +
+          std::get<2>(info.param);
+    });
+
 // Benchmark for regAll - registers all cached segments as contiguous regions
 TEST_F(RegCacheBench, RegAllTime) {
   constexpr int numIter = 10;


### PR DESCRIPTION
Summary:
Add a new parameterized benchmark (`CommVsGlobalRegParam.RegDeregTime`) to compare the performance of two registration paths:

1. **comm** (legacy): `mapper->regMem()` / `mapper->deregMem()` — requires a communicator
2. **global** (new): `ctran::globalRegisterWithPtr()` / `ctran::globalDeregisterWithPtr()` — does not require a communicator


Global registration is .2-.3 us slower because we lookup the cudaDev from the buffer information rather than getting it from the communicator. 
https://www.internalfb.com/code/fbsource/[20dc4df683326c5958c745ede55502b0deb2e48c]/fbcode/comms/ctran/regcache/RegCache.cc?lines=303
https://www.internalfb.com/code/fbsource/[20dc4df683326c5958c745ede55502b0deb2e48c]/fbcode/comms/ctran/utils/DevMemType.cc?lines=101-102

Global deregistration is a couple microseconds slower because we need to look up the underlying physical segments of the buffer while commDeregister expects the segment information itsef, but it is not on the critical path.
https://www.internalfb.com/code/fbsource/[20dc4df683326c5958c745ede55502b0deb2e48c]/fbcode/comms/ctran/regcache/RegCache.cc?lines=362
https://www.internalfb.com/code/fbsource/[20dc4df683326c5958c745ede55502b0deb2e48c]/fbcode/comms/ctran/regcache/RegCache.cc?lines=589

Differential Revision: D94120051


