### PR TITLE
Allow users to disable NCCL_HAS_DUMP_ALGO_STAT at compile time

### DIFF
--- a/comms/ncclx/v2_28/src/nccl.h.in
+++ b/comms/ncclx/v2_28/src/nccl.h.in
@@ -909,7 +909,14 @@ ncclResult_t ncclCommDumpAll(std::unordered_map<std::string, std::unordered_map<
 #define NCCL_HAS_COMMS_TRACING_SERVICE_PORT
 ncclResult_t ncclCommsTracingServicePort(int& port);
 
+// NCCL_HAS_DUMP_ALGO_STAT controls whether dumpAlgoStat() is available.
+// By default, it is defined. To disable it (e.g., for adapters which may have
+// different ncclComm layout), compile with -DNCCL_HAS_DUMP_ALGO_STAT=0.
+#if !defined(NCCL_HAS_DUMP_ALGO_STAT)
 #define NCCL_HAS_DUMP_ALGO_STAT
+#elif NCCL_HAS_DUMP_ALGO_STAT == 0
+#undef NCCL_HAS_DUMP_ALGO_STAT
+#endif
 namespace ncclx::colltrace {
 
 // Dump collective algorithm statistics for a communicator.


### PR DESCRIPTION
Summary:
Make `NCCL_HAS_DUMP_ALGO_STAT` conditional in nccl.h.in: if pre-defined as 0 (`via -DNCCL_HAS_DUMP_ALGO_STAT=0`), undefine it so callers skip the call entirely. 

We preserve two behaviors with `NCCL_HAS_DUMP_ALGO_STAT` in order to not break any existing code
1. default to be "turned on"
2. controlled via defined vs undefined (instead of values 0 and 1).

Reviewed By: Scusemua

Differential Revision: D94004991


