### PR TITLE
Revising the sidecar/agent thrift APIs to accomodate external use-case

### DIFF
--- a/comms/ncclx/v2_27/src/Makefile
+++ b/comms/ncclx/v2_27/src/Makefile
@@ -112,39 +112,39 @@ ifeq ($(ENABLE_TCPDM),1)
 CXXFLAGS    += -DTCP_DEVMEM_AGENT
 THRIFT      ?= thrift1
 DEVMEM_DIR  := $(BASE_DIR)/comms/tcp_devmem
-THRIFT_FILE := $(DEVMEM_DIR)/devmgr/devmgr.thrift
-THRIFT_H    := $(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_client.h
+THRIFT_FILE := $(DEVMEM_DIR)/devmgr/if/devmgr.thrift
+THRIFT_H    := $(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_client.h
 
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/DevMgr.cpp
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/DevMgrAsyncClient.cpp
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/DevMgr_processmap_binary.cpp
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/DevMgr_processmap_compact.cpp
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_constants.cpp
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_data.cpp
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_metadata.cpp
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_types.cpp
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_types_binary.cpp
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_types_compact.cpp
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_types_serialization.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/DevMgr.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/DevMgrAsyncClient.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/DevMgr_processmap_binary.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/DevMgr_processmap_compact.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_constants.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_data.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_metadata.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_types.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_types_binary.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_types_compact.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_types_serialization.cpp
 
 $(THRIFT_H): $(THRIFT_FILE)
 	@printf "Generating  %-35s > %s\n" $(THRIFT_FILE) $(DEVMEM_DIR)/devmgr
-	$(THRIFT) --gen mstch_cpp2:include_prefix=$(DEVMEM_DIR)/devmgr -o $(DEVMEM_DIR)/devmgr $(THRIFT_FILE)
+	$(THRIFT) --gen mstch_cpp2:include_prefix=$(DEVMEM_DIR)/devmgr/if -o $(DEVMEM_DIR)/devmgr/if $(THRIFT_FILE)
 
 $(DEVMEM_DIR)/devmgr/devmgr_client.cc: $(THRIFT_H)
 $(DEVMEM_DIR)/transport.cc: $(THRIFT_H)
 
-$(DEVMEM_DIR)/devmgr/gen-cpp2/DevMgr.cpp: $(THRIFT_H)
-$(DEVMEM_DIR)/devmgr/gen-cpp2/DevMgrAsyncClient.cpp: $(THRIFT_H)
-$(DEVMEM_DIR)/devmgr/gen-cpp2/DevMgr_processmap_binary.cpp: $(THRIFT_H)
-$(DEVMEM_DIR)/devmgr/gen-cpp2/DevMgr_processmap_compact.cpp: $(THRIFT_H)
-$(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_constants.cpp: $(THRIFT_H)
-$(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_data.cpp: $(THRIFT_H)
-$(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_metadata.cpp: $(THRIFT_H)
-$(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_types.cpp: $(THRIFT_H)
-$(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_types_binary.cpp: $(THRIFT_H)
-$(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_types_compact.cpp: $(THRIFT_H)
-$(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_types_serialization.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/DevMgr.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/DevMgrAsyncClient.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/DevMgr_processmap_binary.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/DevMgr_processmap_compact.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_constants.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_data.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_metadata.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_types.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_types_binary.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_types_compact.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_types_serialization.cpp: $(THRIFT_H)
 
 ## Include TCP Devmem transport files and dependencies
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/ctran/backends/tcpdevmem/*.cc)

--- a/comms/ncclx/v2_28/src/Makefile
+++ b/comms/ncclx/v2_28/src/Makefile
@@ -119,39 +119,39 @@ ifeq ($(ENABLE_TCPDM),1)
 CXXFLAGS    += -DTCP_DEVMEM_AGENT
 THRIFT      ?= thrift1
 DEVMEM_DIR  := $(BASE_DIR)/comms/tcp_devmem
-THRIFT_FILE := $(DEVMEM_DIR)/devmgr/devmgr.thrift
-THRIFT_H    := $(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_client.h
+THRIFT_FILE := $(DEVMEM_DIR)/devmgr/if/devmgr.thrift
+THRIFT_H    := $(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_client.h
 
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/DevMgr.cpp
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/DevMgrAsyncClient.cpp
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/DevMgr_processmap_binary.cpp
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/DevMgr_processmap_compact.cpp
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_constants.cpp
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_data.cpp
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_metadata.cpp
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_types.cpp
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_types_binary.cpp
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_types_compact.cpp
-LIBSRCFILES += $(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_types_serialization.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/DevMgr.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/DevMgrAsyncClient.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/DevMgr_processmap_binary.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/DevMgr_processmap_compact.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_constants.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_data.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_metadata.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_types.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_types_binary.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_types_compact.cpp
+LIBSRCFILES += $(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_types_serialization.cpp
 
 $(THRIFT_H): $(THRIFT_FILE)
 	@printf "Generating  %-35s > %s\n" $(THRIFT_FILE) $(DEVMEM_DIR)/devmgr
-	$(THRIFT) --gen mstch_cpp2:include_prefix=$(DEVMEM_DIR)/devmgr -o $(DEVMEM_DIR)/devmgr $(THRIFT_FILE)
+	$(THRIFT) --gen mstch_cpp2:include_prefix=$(DEVMEM_DIR)/devmgr/if -o $(DEVMEM_DIR)/devmgr/if $(THRIFT_FILE)
 
 $(DEVMEM_DIR)/devmgr/devmgr_client.cc: $(THRIFT_H)
 $(DEVMEM_DIR)/transport.cc: $(THRIFT_H)
 
-$(DEVMEM_DIR)/devmgr/gen-cpp2/DevMgr.cpp: $(THRIFT_H)
-$(DEVMEM_DIR)/devmgr/gen-cpp2/DevMgrAsyncClient.cpp: $(THRIFT_H)
-$(DEVMEM_DIR)/devmgr/gen-cpp2/DevMgr_processmap_binary.cpp: $(THRIFT_H)
-$(DEVMEM_DIR)/devmgr/gen-cpp2/DevMgr_processmap_compact.cpp: $(THRIFT_H)
-$(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_constants.cpp: $(THRIFT_H)
-$(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_data.cpp: $(THRIFT_H)
-$(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_metadata.cpp: $(THRIFT_H)
-$(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_types.cpp: $(THRIFT_H)
-$(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_types_binary.cpp: $(THRIFT_H)
-$(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_types_compact.cpp: $(THRIFT_H)
-$(DEVMEM_DIR)/devmgr/gen-cpp2/devmgr_types_serialization.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/DevMgr.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/DevMgrAsyncClient.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/DevMgr_processmap_binary.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/DevMgr_processmap_compact.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_constants.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_data.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_metadata.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_types.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_types_binary.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_types_compact.cpp: $(THRIFT_H)
+$(DEVMEM_DIR)/devmgr/if/gen-cpp2/devmgr_types_serialization.cpp: $(THRIFT_H)
 
 ## Include TCP Devmem transport files and dependencies
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/ctran/backends/tcpdevmem/*.cc)


### PR DESCRIPTION
Summary:
This diff directly addresses all the review comments in D91604911.

Changes include:
1. Standardizing the thrift API definition.
2. Removing "devmem" from common APIs
3. moving the thrift definition to devmgr/if
4. removing the hardcoded agent TCP address. The agent accepts the address:port pair as a cmd argument (`-a`). The client can use TCP_DEVMEM_AGENT_TCP_ADDR CVAR to connect to the tcp agent. The default address-port pair is kept at 127.0.0.1 for compatibility. The tw job spec should be able to provide the -a flag accordingly.

Reviewed By: spikeh

Differential Revision: D93186355
