### PR TITLE
Pin CI dependency versions to fix lint workflow

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -22,8 +22,8 @@ jobs:
       - name: Setup conda env
         uses: conda-incubator/setup-miniconda@v2
         with:
-          auto-update-conda: true
           miniconda-version: "latest"
+          conda-version: "25.11.1"
           activate-environment: test
           python-version: '3.10'
           auto-activate: false
@@ -45,7 +45,7 @@ jobs:
           set -eux
           conda install -y git
           conda install -y -c conda-forge glog==0.4.0 gflags fmt
-          pip install cmake
+          pip install cmake==3.31.6
           pip install -r docs/requirements.txt
           export USE_NCCL=0
           export USE_NCCLX=0

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -30,8 +30,8 @@ jobs:
       - name: Setup conda env
         uses: conda-incubator/setup-miniconda@v2
         with:
-          auto-update-conda: true
           miniconda-version: "latest"
+          conda-version: "25.11.1"
           activate-environment: test
           python-version: '3.14'
           auto-activate: false
@@ -54,7 +54,7 @@ jobs:
 
           conda install -y git
           conda install -y -c conda-forge glog==0.4.0 gflags fmt
-          pip install cmake
+          pip install cmake==3.31.6
           export USE_NCCL=0
           export USE_NCCLX=0
           export USE_GLOO=0
@@ -66,7 +66,7 @@ jobs:
         run: |
           set -eux
 
-          pip install uv
+          pip install uv==0.10.4
           lintrunner init
       - name: Lint
         shell: bash -l {0}


### PR DESCRIPTION
## Summary

- Pin `uv==0.10.4` in lint.yaml — `uv` 0.10.5 (released overnight Feb 23-24) introduced a regression that strips execute permissions from the `clang-format` binary bundled in the `clang-format` pip package, causing all lint CI runs to fail with `PermissionError: [Errno 13]`
- Pin `conda-version: "25.11.1"` in lint.yaml and docs.yaml
- Pin `cmake==3.31.6` in lint.yaml and docs.yaml

## Test plan

- [ ] Lint CI job passes on this PR