### PR TITLE
implement sm-free AllToAllvP

### DIFF
--- a/comms/ctran/Ctran.h
+++ b/comms/ctran/Ctran.h
@@ -412,6 +412,28 @@ commResult_t AllToAllPExec(
 
 commResult_t AllToAllPDestroy(CtranPersistentRequest* request);
 
+/* Persistent alltoallv. */
+bool allToAllvPSupport(CtranComm* comm);
+
+commResult_t allToAllvPInit(
+    void* recvbuff,
+    const size_t maxRecvCount,
+    commDataType_t datatype,
+    CtranComm* comm,
+    cudaStream_t stream,
+    CtranPersistentRequest*& request);
+
+commResult_t allToAllvPExec(
+    const void* sendbuff,
+    const size_t sendcounts[],
+    const size_t sdispls[],
+    const size_t recvcounts[],
+    const size_t rdispls[],
+    commDataType_t datatype,
+    CtranPersistentRequest* request);
+
+commResult_t allToAllvPDestroy(CtranPersistentRequest* request);
+
 // Global pointer-based memory registration (does not require a comm).
 // If forceReg is true, registration happens even in async/lazy mode.
 commResult_t

--- a/comms/ctran/algos/AllToAllvP/AllToAllvP.cc
+++ b/comms/ctran/algos/AllToAllvP/AllToAllvP.cc
@@ -1,0 +1,156 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/ctran/algos/AllToAllvP/AllToAllvPImpl.h"
+#include "comms/ctran/algos/AllToAllvP/Types.h"
+
+#include "comms/ctran/algos/CtranAlgo.h"
+#include "comms/ctran/mapper/CtranMapper.h"
+#include "comms/utils/logger/LogUtils.h"
+
+using ctran::alltoallvp::AlgoImpl;
+
+#define CHECK_VALID_PREQ(pReq)                                     \
+  do {                                                             \
+    if (pReq->type != CtranPersistentRequest::Type::ALLTOALLV_P) { \
+      FB_ERRORRETURN(                                              \
+          commInvalidArgument,                                     \
+          "Unexpected PersistentRequest type {} called into {}",   \
+          pReq->type,                                              \
+          __func__);                                               \
+    }                                                              \
+  } while (0)
+
+namespace ctran {
+
+bool allToAllvPSupport(CtranComm* comm) {
+  bool ctranSupport = false;
+  const auto statex = comm->statex_.get();
+  if (ctranInitialized(comm)) {
+    ctranSupport = true;
+    for (auto rank = 0; rank < statex->nRanks(); rank++) {
+      if (comm->ctran_->mapper->getBackend(rank) == CtranMapperBackend::UNSET) {
+        ctranSupport = false;
+        break;
+      }
+    }
+  } else {
+    return false;
+  }
+  return ctranSupport;
+}
+
+commResult_t allToAllvPInit(
+    void* recvbuff,
+    const size_t maxRecvCount,
+    commDataType_t datatype,
+    CtranComm* comm,
+    cudaStream_t stream,
+    CtranPersistentRequest*& request) {
+  const auto statex = comm->statex_.get();
+  SetCudaDevRAII setCudaDev(statex->cudaDev());
+  AlgoImpl* algo = new AlgoImpl(comm, stream);
+  if (!algo) {
+    return commSystemError;
+  }
+
+  auto guard = folly::makeGuard([algo] {
+    if (algo) {
+      delete algo;
+    }
+  });
+
+  // Search recvbuff handle
+  auto mapper = comm->ctran_->mapper.get();
+  size_t maxRecvSize = maxRecvCount * commTypeSize(datatype);
+
+  void* recvHdl{nullptr};
+  bool localRegRecv = false;
+  FB_COMMCHECK(
+      mapper->searchRegHandle(recvbuff, maxRecvSize, &recvHdl, &localRegRecv));
+  if (localRegRecv) {
+    FB_COMMCHECK(mapper->deregDynamic(recvHdl));
+    CLOGF(
+        ERR,
+        "recvbuff is not registered. Pointer: {} length: {}",
+        (void*)recvbuff,
+        maxRecvSize);
+    return commInternalError;
+  }
+
+  // Set up persistent arguments
+  algo->pArgs.recvHdl = recvHdl;
+  algo->pArgs.recvbuff = recvbuff;
+  algo->pArgs.maxRecvCount = maxRecvCount;
+  algo->pArgs.datatype = datatype;
+  algo->pArgs.initialized.store(false);
+
+  // Schedule exchangeMemHdl on GPE thread
+  FB_COMMCHECK(algo->init());
+
+  // Create persistent request
+  request = new CtranPersistentRequest(
+      CtranPersistentRequest::Type::ALLTOALLV_P, comm, stream);
+  if (!request) {
+    return commSystemError;
+  }
+  request->algo = algo;
+
+  guard.dismiss();
+  return commSuccess;
+}
+
+commResult_t allToAllvPExec(
+    const void* sendbuff,
+    const size_t sendcounts[],
+    const size_t sdispls[],
+    const size_t recvcounts[],
+    const size_t rdispls[],
+    commDataType_t datatype,
+    CtranPersistentRequest* request) {
+  CHECK_VALID_PREQ(request);
+
+  auto algo = reinterpret_cast<AlgoImpl*>(request->algo);
+  const auto nRanks = request->comm_->statex_->nRanks();
+  size_t totalRecvCount = 0;
+  for (int i = 0; i < nRanks; i++) {
+    totalRecvCount += recvcounts[i];
+  }
+  if (totalRecvCount * commTypeSize(datatype) >
+      algo->pArgs.maxRecvCount * commTypeSize(algo->pArgs.datatype)) {
+    FB_ERRORRETURN(
+        commInvalidArgument,
+        "AllToAllvP invalid recvcounts {} * sizeof datatype {} exceeds maxRecvCount {} * sizeof datatype {}.",
+        totalRecvCount,
+        datatype,
+        algo->pArgs.maxRecvCount,
+        algo->pArgs.datatype);
+  }
+
+  switch (NCCL_ALLTOALLV_P_ALGO) {
+    case NCCL_ALLTOALLV_P_ALGO::ctran:
+      return algo->exec(
+          sendbuff, sendcounts, sdispls, recvcounts, rdispls, datatype);
+    default:
+      return ErrorStackTraceUtil::log(commInternalError);
+  }
+}
+
+commResult_t allToAllvPDestroy(CtranPersistentRequest* request) {
+  CHECK_VALID_PREQ(request);
+
+  // No need to dereg handles now since user should call explicit
+  // commDeregister before buffer is freed
+  auto algo = reinterpret_cast<AlgoImpl*>(request->algo);
+  delete algo;
+  request->algo = nullptr;
+
+  CLOGF_SUBSYS(
+      INFO,
+      INIT,
+      "allToAllvPDestroy: rank {} destroyed request {}",
+      request->comm_->statex_->rank(),
+      (void*)request);
+
+  return commSuccess;
+}
+} // namespace ctran

--- a/comms/ctran/algos/AllToAllvP/AllToAllvPImpl.cc
+++ b/comms/ctran/algos/AllToAllvP/AllToAllvPImpl.cc
@@ -1,0 +1,358 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <folly/ScopeGuard.h>
+#include <iostream>
+
+#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/algos/CtranAlgo.h"
+#include "comms/ctran/mapper/CtranMapper.h"
+#include "comms/ctran/utils/CtranPerf.h"
+#include "comms/ctran/utils/ExtUtils.h"
+#include "comms/utils/checks.h"
+
+#include "comms/ctran/algos/AllToAllvP/AllToAllvPImpl.h"
+#include "comms/ctran/algos/AllToAllvP/CommUtils.h"
+#include "comms/ctran/algos/AllToAllvP/Types.h"
+
+using ctran::alltoallvp::AlgoImpl;
+using ctran::alltoallvp::PersistArgs;
+
+namespace {
+const auto myAlgo = NCCL_ALLTOALLV_P_ALGO::ctran;
+const std::string algoInitName = "CtranAllToAllvPInit";
+const std::string algoExecName = "CtranAllToAllvPExec";
+
+// exchangeMemHdlInit: Called during init() phase
+// Uses allGatherCtrl to share the base recvbuff address with all peers
+// (rdispls is not available at init time)
+commResult_t exchangeMemHdlInit(
+    const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
+  struct OpElem* op = opGroup.front().get();
+  CtranComm* comm = op->comm_;
+  auto mapper = comm->ctran_->mapper.get();
+
+  const auto statex = comm->statex_.get();
+  const auto nRanks = statex->nRanks();
+
+  CtranAlgoLogger logger(algoInitName, op->opCount, comm);
+
+  auto* pArgs = reinterpret_cast<PersistArgs*>(op->alltoallvP.pArgs);
+  pArgs->remoteAccessKeys.resize(nRanks, CtranMapperRemoteAccessKey());
+  pArgs->remoteRecvBuffs.resize(nRanks, nullptr);
+
+  // Use allGatherCtrl to share the base recvbuff with all peers
+  FB_COMMCHECK(mapper->allGatherCtrl(
+      pArgs->recvbuff,
+      pArgs->recvHdl,
+      pArgs->remoteRecvBuffs,
+      pArgs->remoteAccessKeys));
+
+  // Ensure all ranks have finished remote importing before return
+  FB_COMMCHECK(mapper->barrier());
+
+  if (NCCL_CTRAN_ENABLE_TRACE_LOG) {
+    for (int i = 0; i < nRanks; i++) {
+      CLOGF_TRACE(
+          INIT,
+          "    remoteRecvBuffs[{}]: {}, remoteAccessKey: {}",
+          i,
+          (void*)pArgs->remoteRecvBuffs[i],
+          pArgs->remoteAccessKeys[i].toString());
+    }
+  }
+
+  // Mark the remote registration as initialized, so that consequent execution
+  // can schedule CE based NVL copy
+  pArgs->initialized.store(true);
+  return commSuccess;
+}
+
+// exchangeMemHdlExec: Called during exec() phase via gpeFn
+// Uses allToAllCtrl to share per-peer recvbuff offsets based on rdispls
+commResult_t exchangeMemHdlExec(
+    const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
+  struct OpElem* op = opGroup.front().get();
+  CtranComm* comm = op->comm_;
+  auto mapper = comm->ctran_->mapper.get();
+
+  const auto statex = comm->statex_.get();
+  const auto nRanks = statex->nRanks();
+
+  CtranAlgoLogger logger(algoExecName, op->opCount, comm);
+
+  auto* pArgs = reinterpret_cast<PersistArgs*>(op->alltoallvP.pArgs);
+
+  // Get rdispls and datatype from op
+  auto& rDispls = op->alltoallvP.rdispls;
+  auto datatype = op->alltoallvP.datatype;
+  auto recvbuff = pArgs->recvbuff;
+  auto recvHdl = pArgs->recvHdl;
+
+  // Initialize per-peer recvBuffs and recvHdls based on rdispls offsets
+  pArgs->recvBuffs.resize(nRanks);
+  pArgs->recvHdls.resize(nRanks);
+  for (int i = 0; i < nRanks; i++) {
+    auto recvOffset = rDispls[i] * commTypeSize(datatype);
+    pArgs->recvBuffs[i] =
+        static_cast<void*>(static_cast<char*>(recvbuff) + recvOffset);
+    pArgs->recvHdls[i] = recvHdl;
+  }
+
+  pArgs->remoteAccessKeys.resize(nRanks, CtranMapperRemoteAccessKey());
+  pArgs->remoteRecvBuffs.resize(nRanks, nullptr);
+
+  // Use allToAllCtrl to exchange per-peer receive buffer offsets
+  FB_COMMCHECK(mapper->allToAllCtrl(
+      pArgs->recvBuffs,
+      pArgs->recvHdls,
+      pArgs->remoteRecvBuffs,
+      pArgs->remoteAccessKeys));
+
+  // Ensure all ranks have finished remote importing before return
+  FB_COMMCHECK(mapper->barrier());
+
+  if (NCCL_CTRAN_ENABLE_TRACE_LOG) {
+    for (int i = 0; i < nRanks; i++) {
+      CLOGF_TRACE(
+          COLL,
+          "    remoteRecvBuffs[{}]: {}, remoteAccessKey: {}",
+          i,
+          (void*)pArgs->remoteRecvBuffs[i],
+          pArgs->remoteAccessKeys[i].toString());
+    }
+  }
+
+  // Signal to the main thread that address exchange is complete
+  pArgs->exchanged.store(true);
+  return commSuccess;
+}
+
+// gpeFn: Called during exec() phase
+// 1. Calls exchangeMemHdlExec to exchange per-peer addresses using allToAllCtrl
+// 2. Issues PUT operations for IB domain peers (inter-node)
+// NVL domain peers (intra-node) are handled by nvlCeBcast() on the main thread
+template <typename PerfConfig = DefaultPerfCollConfig>
+commResult_t gpeFn(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
+  struct OpElem* op = opGroup.front().get();
+
+  CtranComm* comm = op->comm_;
+  const auto statex = comm->statex_.get();
+  const auto nRanks = statex->nRanks();
+  const auto myRank = statex->rank();
+
+  // Step 1: Exchange per-peer receive buffer addresses using allToAllCtrl
+  FB_COMMCHECK(exchangeMemHdlExec(opGroup));
+
+  // persistent variables (pre-allocated in exchangeMemHdl during init)
+  auto* pArgs = reinterpret_cast<PersistArgs*>(op->alltoallvP.pArgs);
+  auto& remoteRecvBuffs = pArgs->remoteRecvBuffs;
+  auto& remoteAccessKeys = pArgs->remoteAccessKeys;
+
+  // non-persistent variables
+  auto sendbuff = op->alltoallvP.sendbuff;
+  auto& sendCounts = op->alltoallvP.sendcounts;
+  auto& sDispls = op->alltoallvP.sdispls;
+  auto datatype = op->alltoallvP.datatype;
+
+  // Step 2: Issue PUT operations for IB domain peers only
+  // IB peers are peers NOT on the same node (inter-node communication)
+  // NVL peers (same node) are handled by nvlCeBcast() on the main thread
+  std::vector<int> ibSendPeers;
+  for (int i = 0; i < nRanks; i++) {
+    int peer = (myRank + i) % nRanks;
+    if (!statex->isSameNode(myRank, peer) && sendCounts[peer] > 0) {
+      ibSendPeers.push_back(peer);
+    }
+  }
+
+  // Return if there are no IB peers to send to
+  if (ibSendPeers.empty()) {
+    return commSuccess;
+  }
+
+  auto mapper = comm->ctran_->mapper.get();
+
+  // Prepare send buffers for IB peers
+  std::vector<const void*> sendBuffs(nRanks);
+  size_t maxSendBufCount = 0;
+  for (const auto& peer : ibSendPeers) {
+    sendBuffs[peer] = static_cast<const char*>(sendbuff) +
+        sDispls[peer] * commTypeSize(datatype);
+    maxSendBufCount =
+        std::max(maxSendBufCount, sDispls[peer] + sendCounts[peer]);
+  }
+
+  // Get send handle for the sendbuff
+  void* sendHdl = nullptr;
+  bool localReg = false;
+  FB_COMMCHECK(mapper->searchRegHandle(
+      sendbuff, maxSendBufCount * commTypeSize(datatype), &sendHdl, &localReg));
+  auto guard = folly::makeGuard([sendHdl, localReg, mapper]() {
+    if (localReg) {
+      FB_COMMCHECKIGNORE(mapper->deregDynamic(sendHdl));
+    }
+  });
+
+  // Initialize notify batch for IB PUTs
+  std::vector<CtranMapperNotify> notifyVec(ibSendPeers.size());
+  FB_COMMCHECK(mapper->initNotifyBatchIB(ibSendPeers, notifyVec));
+
+  // Issue PUT operations to all IB peers
+  std::vector<CtranMapperRequest> ibPutReqs(ibSendPeers.size());
+  int idx = 0;
+  for (const auto& peer : ibSendPeers) {
+    auto sendSize = sendCounts[peer] * commTypeSize(datatype);
+    FB_COMMCHECK(mapper->iput<PerfConfig>(
+        sendBuffs[peer],
+        remoteRecvBuffs[peer],
+        sendSize,
+        peer,
+        CtranMapperConfig{
+            .memHdl_ = sendHdl,
+            .remoteAccessKey_ = remoteAccessKeys[peer],
+            .notify_ = true},
+        &ibPutReqs[idx++]));
+  }
+
+  // Wait for all PUT operations to complete
+  FB_COMMCHECK(mapper->waitAllRequests<PerfConfig>(ibPutReqs));
+  // Wait for all receives (i.e., remote IB puts from other ranks) to complete
+  FB_COMMCHECK(mapper->waitAllNotifies<PerfConfig>(notifyVec));
+
+  return commSuccess;
+}
+
+} // namespace
+
+namespace ctran::alltoallvp {
+
+extern __global__ void ncclKernelAllToAllvPInit(
+    int* flag,
+    CtranAlgoDeviceState* devState);
+
+commResult_t AlgoImpl::init() {
+  auto opCount = comm_->ctran_->getOpCount();
+
+  // set up GPE KernelConfig
+  KernelConfig config = KernelConfig(
+      KernelConfig::KernelType::ALLTOALLVP, stream_, algoName(myAlgo), opCount);
+  config.numBlocks = 1;
+  config.numThreads = 1;
+  config.args.devState_d = comm_->ctran_->algo->getDevState();
+
+  // set up GPE op
+  auto op = std::make_unique<OpElem>(
+      OpElem::opType::ALLTOALLVP, stream_, comm_, opCount);
+  // persistent variables
+  op->alltoallvP.pArgs = &pArgs;
+  // non-persistent variables
+  // None in init()
+  std::vector<std::unique_ptr<struct OpElem>> opGroup;
+  opGroup.push_back(std::move(op));
+
+  CLOGF_TRACE(
+      COLL,
+      "AllToAllvPInit: rank {} submit GPE op pArgs {}",
+      comm_->statex_->rank(),
+      opGroup.front().get()->alltoallvP.pArgs);
+
+  FB_COMMCHECK(comm_->ctran_->gpe->submit(
+      std::move(opGroup),
+      exchangeMemHdlInit,
+      config,
+      reinterpret_cast<void*>(ncclKernelAllToAllvPInit)));
+
+  return commSuccess;
+}
+
+extern __global__ void ncclKernelAllToAllvP(
+    int* flag,
+    CtranAlgoDeviceState* devState);
+
+commResult_t AlgoImpl::exec(
+    const void* sendbuff,
+    const size_t sendcounts[],
+    const size_t sdispls[],
+    const size_t recvcounts[],
+    const size_t rdispls[],
+    const commDataType_t datatype) {
+  const auto statex = comm_->statex_.get();
+  // const auto nNodes = statex->nNodes();
+  const auto nRanks = statex->nRanks();
+  const auto nLocalRanks = statex->nLocalRanks();
+  const auto myRank = statex->rank();
+
+  // Copy data to self for out-of-place alltoallv
+  auto recvbuff = pArgs.recvbuff;
+  FB_COMMCHECK(copyToSelf(
+      comm_,
+      sendbuff,
+      recvbuff,
+      sendcounts[myRank],
+      sdispls[myRank],
+      rdispls[myRank],
+      datatype,
+      stream_));
+
+  // Wait till async init is done, so that we can schedule copy operations with
+  // the remote address
+  if (nRanks > 1) {
+    FB_COMMCHECK(waitInit());
+  }
+
+  // Set up GPE for allToAllCtrl exchange
+  auto ctran = comm_->ctran_.get();
+  auto opCount = ctran->getOpCount();
+  auto config = KernelConfig(
+      KernelConfig::KernelType::ALLTOALLVP,
+      stream_,
+      AlgoImpl::algoName(myAlgo),
+      opCount);
+  config.numBlocks = 1;
+  config.numThreads = 1;
+  config.algoArgs = reinterpret_cast<void*>(&pArgs);
+  config.args.devState_d = ctran->algo->getDevState();
+
+  // Set up GPE op with rdispls for per-peer address exchange
+  auto op = std::make_unique<OpElem>(
+      OpElem::opType::ALLTOALLVP, stream_, comm_, opCount);
+  op->alltoallvP.pArgs = &pArgs;
+  op->alltoallvP.sendbuff = sendbuff;
+  op->alltoallvP.datatype = datatype;
+
+  op->alltoallvP.sendcounts.assign(sendcounts, sendcounts + nRanks);
+  op->alltoallvP.sdispls.assign(sdispls, sdispls + nRanks);
+  op->alltoallvP.recvcounts.assign(recvcounts, recvcounts + nRanks);
+  op->alltoallvP.rdispls.assign(rdispls, rdispls + nRanks);
+
+  std::vector<std::unique_ptr<struct OpElem>> opGroup;
+  opGroup.push_back(std::move(op));
+
+  // Reset the address exchange flag before submitting GPE
+  // exchangeMemHdlExec() will set this to true after address exchange completes
+  pArgs.exchanged.store(false);
+
+  // Submit GPE to:
+  // 1. Exchange per-peer receive buffer addresses using allToAllCtrl
+  // 2. Issue PUT operations for IB domain peers (inter-node)
+  FB_COMMCHECK(ctran->gpe->submit(
+      std::move(opGroup),
+      gpeFn<>,
+      config,
+      reinterpret_cast<void*>(ncclKernelAllToAllvP)));
+
+  if (nLocalRanks > 1) {
+    // Wait for GPE thread to complete the address exchange
+    // before using remoteRecvBuffs for NVL CE copy
+    if (nRanks > 1) {
+      FB_COMMCHECK(waitExchange());
+    }
+
+    // Copy data to other local ranks using NVL Copy Engine
+    // Now uses the exchanged per-peer remote addresses from allToAllCtrl
+    FB_COMMCHECK(nvlCeBcast(
+        comm_, sendbuff, sendcounts, sdispls, datatype, pArgs, stream_));
+  }
+  return commSuccess;
+}
+} // namespace ctran::alltoallvp

--- a/comms/ctran/algos/AllToAllvP/AllToAllvPImpl.cu
+++ b/comms/ctran/algos/AllToAllvP/AllToAllvPImpl.cu
@@ -1,0 +1,42 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#include "comms/ctran/algos/CtranAlgoDev.h"
+#include "comms/ctran/algos/DevCommon.cuh"
+#include "comms/ctran/algos/barrier.cuh"
+#include "comms/ctran/gpe/CtranGpeDev.h"
+
+namespace ctran::alltoallvp {
+
+// Stub kernel to hold stream while GPE thread does exchangeMemHdl during
+// AllToAllvPInit.
+__global__ void ncclKernelAllToAllvPInit(
+    int* flag,
+    CtranAlgoDeviceState* devState) {
+  if (flag) {
+    ctran::device::devLoadAbortFlags(flag, devState);
+    ctran::device::KernelStartGpe(flag);
+
+    ctran::device::KernelWaitGpeTerminate(flag);
+  }
+}
+
+__global__ void ncclKernelAllToAllvP(
+    int* flag,
+    CtranAlgoDeviceState* devState) {
+  if (flag) {
+    ctran::device::devLoadAbortFlags(flag, devState);
+    ctran::device::KernelStartGpe(flag);
+  }
+
+  devStateLoadToShm(devState);
+
+  const auto localRank = statex->localRank();
+  const auto nLocalRanks = statex->nLocalRanks();
+
+  // ensure nvl intra-node comm finishes
+  barrier(localRank, nLocalRanks);
+  if (flag) {
+    ctran::device::KernelWaitGpeTerminate(flag);
+  }
+}
+
+} // namespace ctran::alltoallvp

--- a/comms/ctran/algos/AllToAllvP/AllToAllvPImpl.h
+++ b/comms/ctran/algos/AllToAllvP/AllToAllvPImpl.h
@@ -1,0 +1,64 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include "comms/ctran/algos/AllToAllvP/Types.h"
+
+#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/gpe/CtranGpe.h"
+#include "comms/ctran/hints/Hints.h"
+#include "comms/ctran/mapper/CtranMapper.h"
+#include "comms/ctran/mapper/CtranMapperTypes.h"
+#include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/ExtUtils.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+
+namespace ctran::alltoallvp {
+
+class AlgoImpl {
+ public:
+  PersistArgs pArgs;
+
+  AlgoImpl(CtranComm* comm, cudaStream_t stream)
+      : comm_(comm), stream_(stream) {};
+  ~AlgoImpl() {};
+
+  commResult_t init();
+  commResult_t exec(
+      const void* sendbuff,
+      const size_t sendcounts[],
+      const size_t sdispls[],
+      const size_t recvcounts[],
+      const size_t rdispls[],
+      const commDataType_t datatype);
+
+  static inline const std::string algoName(enum NCCL_ALLTOALLV_P_ALGO algo) {
+    switch (algo) {
+      case NCCL_ALLTOALLV_P_ALGO::ctran:
+        return "CtranAllToAllvP";
+      default:
+        return "Unknown";
+    }
+  }
+
+ private:
+  // Wait till either the async initialization is done or hit async error.
+  // It is called before execution scheduling any CE copy to the stream.
+  inline commResult_t waitInit() {
+    while (!pArgs.initialized.load()) {
+      FB_COMMCHECK(comm_->getAsyncResult());
+    }
+    return commSuccess;
+  }
+
+  inline commResult_t waitExchange() {
+    while (!pArgs.exchanged.load()) {
+      FB_COMMCHECK(comm_->getAsyncResult());
+    }
+    return commSuccess;
+  }
+
+  CtranComm* comm_{nullptr};
+  cudaStream_t stream_{nullptr};
+};
+} // namespace ctran::alltoallvp

--- a/comms/ctran/algos/AllToAllvP/CommUtils.h
+++ b/comms/ctran/algos/AllToAllvP/CommUtils.h
@@ -1,0 +1,134 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <iostream>
+#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/algos/CtranAlgo.h"
+#include "comms/ctran/mapper/CtranMapper.h"
+#include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/ExtUtils.h"
+#include "comms/utils/logger/LogUtils.h"
+
+namespace ctran::alltoallvp {
+inline void* getPtr(void* base, size_t offset) {
+  return (void*)((uintptr_t)base + offset);
+}
+
+inline commResult_t nvlBarrier(CtranComm* comm, cudaStream_t stream) {
+  const auto statex = comm->statex_.get();
+  const auto localRank = statex->localRank();
+  const auto nLocalRanks = statex->nLocalRanks();
+
+  // FIXME: needs to add cudaGraph capture support
+
+  // Barrier to make sure all local ranks is ready to start intranode comm
+  std::array<void*, 3> kernelArgs;
+  kernelArgs.at(0) = (void*)&localRank;
+  kernelArgs.at(1) = (void*)&nLocalRanks;
+  auto devState_d = comm->ctran_->algo->getDevState();
+  kernelArgs.at(2) = (void*)&devState_d;
+  dim3 grid = {1, 1, 1};
+  dim3 blocks = {1, 1, 1};
+  FB_CUDACHECK(cudaFuncSetAttribute(
+      reinterpret_cast<void*>(ncclKernelNvlBarrier),
+      cudaFuncAttributeMaxDynamicSharedMemorySize,
+      sizeof(CtranAlgoDeviceState)));
+  FB_CUDACHECK(cudaLaunchKernel(
+      reinterpret_cast<void*>(ncclKernelNvlBarrier),
+      grid,
+      blocks,
+      kernelArgs.data(),
+      sizeof(CtranAlgoDeviceState),
+      stream));
+  return commSuccess;
+}
+
+inline commResult_t nvlCeBcast(
+    CtranComm* comm,
+    const void* sendBuff,
+    const size_t sendCounts[],
+    const size_t sDispls[],
+    const commDataType_t datatype,
+    PersistArgs& pArgs,
+    cudaStream_t stream,
+    bool barrier = true) {
+  const auto statex = comm->statex_.get();
+  const auto rank = statex->rank();
+  const auto localRank = statex->localRank();
+  const auto nLocalRanks = statex->nLocalRanks();
+
+  // Barrier to make sure all local ranks has arrived before CE bcast, to
+  // avoid unwanted incast traffic congestion
+  if (barrier) {
+    nvlBarrier(comm, stream);
+  }
+
+  auto mapper = comm->ctran_->mapper.get();
+
+  // Copy data to other local ranks
+  for (auto r = 1; r < nLocalRanks; r++) {
+    const auto localPeer = (localRank + r) % nLocalRanks;
+    const auto peer = statex->localRankToRank(localPeer);
+
+    auto sendSize = sendCounts[peer] * commTypeSize(datatype);
+    auto sendOffset = sDispls[peer] * commTypeSize(datatype);
+
+    if ((sendSize > 0) &&
+        (pArgs.remoteAccessKeys[peer].backend == CtranMapperBackend::NVL)) {
+      auto sendPtr = getPtr(const_cast<void*>(sendBuff), sendOffset);
+      auto recvPtr = getPtr(pArgs.remoteRecvBuffs[peer], 0);
+
+      CLOGF_TRACE(
+          COLL,
+          "Rank {} CE copy to peer {}, sendPtr {} (sendBuff {} + sendOffset {}) -> remoteRecvBuff {}, sendSize {}",
+          rank,
+          peer,
+          sendPtr,
+          sendBuff,
+          sendOffset,
+          recvPtr,
+          sendSize);
+
+      FB_COMMCHECK(mapper->icopy(recvPtr, sendPtr, sendSize, stream));
+    }
+  }
+  return commSuccess;
+}
+
+// Copy data to self for out-of-place AllToAllv. No-op if it is an in-place
+// AllToAllv.
+inline commResult_t copyToSelf(
+    CtranComm* comm,
+    const void* sendBuff,
+    void* recvBuff,
+    const size_t sendCount,
+    const size_t sendOffset,
+    const size_t recvOffset,
+    const commDataType_t datatype,
+    cudaStream_t stream) {
+  const auto statex = comm->statex_.get();
+  const auto rank = statex->rank();
+
+  // Copy data to self for out-of-place AllToAllv
+  auto sendSize = sendCount * commTypeSize(datatype);
+  auto sendPtr =
+      getPtr(const_cast<void*>(sendBuff), sendOffset * commTypeSize(datatype));
+  auto recvPtr = getPtr(recvBuff, recvOffset * commTypeSize(datatype));
+
+  if (recvPtr != sendPtr) {
+    CLOGF_TRACE(
+        COLL,
+        "Rank {} CE copy to self, sendPtr {} (sendBuff {} + sendOffset {}) -> recvPtr {} (recvBuff {} + recvOffset {}), sendSize {}",
+        rank,
+        sendPtr,
+        sendBuff,
+        sendOffset,
+        recvPtr,
+        recvBuff,
+        recvOffset,
+        sendSize);
+    FB_COMMCHECK(
+        comm->ctran_->mapper->icopy(recvPtr, sendPtr, sendSize, stream));
+  }
+  return commSuccess;
+}
+} // namespace ctran::alltoallvp

--- a/comms/ctran/algos/AllToAllvP/Types.h
+++ b/comms/ctran/algos/AllToAllvP/Types.h
@@ -1,0 +1,39 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+#include "comms/ctran/algos/common/GpeKernelSync.h"
+#include "comms/utils/commSpecs.h"
+
+using ctran::algos::GpeKernelSync;
+
+struct CtranMapperRemoteAccessKey;
+namespace ctran::alltoallvp {
+
+struct PersistArgs {
+  void* recvbuff;
+  void* recvHdl;
+  size_t maxRecvCount;
+  commDataType_t datatype;
+  std::vector<void*> remoteRecvBuffs;
+  std::vector<struct CtranMapperRemoteAccessKey> remoteAccessKeys;
+
+  // Per-peer receive buffers and handles for allToAllCtrl exchange
+  std::vector<void*> recvBuffs;
+  std::vector<void*> recvHdls;
+
+  // Initialization offloads the remote handle exchange to GPE thread to avoid
+  // potential deadlock on mapper epoch lock, if init is called again on the
+  // main thread while there is an outstanding exec. Init returns without
+  // waiting for the completion of async init. Any subsequent execution call
+  // should wait for its completion via the initialized_ flag, before the main
+  // thread can schedule copy engine copies
+  std::atomic<bool> initialized{false};
+
+  // Flag to signal that gpeFn() has completed the address exchange.
+  // The main thread waits on this before calling nvlCeBcast() to ensure
+  // remoteRecvBuffs contains valid exchanged addresses.
+  std::atomic<bool> exchanged{false};
+};
+
+class AlgoImpl;
+} // namespace ctran::alltoallvp

--- a/comms/ctran/algos/CtranAlgo.h
+++ b/comms/ctran/algos/CtranAlgo.h
@@ -254,6 +254,7 @@ class CtranPersistentRequest {
     ALLGATHER_P,
     ALLTOALL_DEDUP,
     ALLTOALL_P,
+    ALLTOALLV_P,
     ALLTOALLV_DEDUP,
   };
 

--- a/comms/ctran/colltrace/CollTraceWrapper.cc
+++ b/comms/ctran/colltrace/CollTraceWrapper.cc
@@ -251,6 +251,14 @@ CollectiveMetadata getCollectiveMetadata(
           .opCount = opCount,
       };
     }
+    case KernelConfig::KernelType::ALLTOALLVP: {
+      // TODO: Add more info for alltoallvp
+      return CollectiveMetadata{
+          .opName = "AllToAllvP",
+          .algoName = kernelConfig.algoName,
+          .opCount = opCount,
+      };
+    }
     case KernelConfig::KernelType::BROADCAST: {
       auto broadcastArgs = kernelConfig.args.collective.broadcast;
       return CollectiveMetadata{

--- a/comms/ctran/gpe/CtranGpe.cc
+++ b/comms/ctran/gpe/CtranGpe.cc
@@ -105,6 +105,16 @@ OpElem::OpElem(
       new (&this->alltoallv.rdispls) std::vector<size_t>;
       this->alltoallv.rdispls.resize(comm_->statex_->nRanks());
       break;
+    case ALLTOALLVP:
+      new (&this->alltoallvP.sendcounts) std::vector<size_t>;
+      this->alltoallvP.sendcounts.resize(comm_->statex_->nRanks());
+      new (&this->alltoallvP.sdispls) std::vector<size_t>;
+      this->alltoallvP.sdispls.resize(comm_->statex_->nRanks());
+      new (&this->alltoallvP.recvcounts) std::vector<size_t>;
+      this->alltoallvP.recvcounts.resize(comm_->statex_->nRanks());
+      new (&this->alltoallvP.rdispls) std::vector<size_t>;
+      this->alltoallvP.rdispls.resize(comm_->statex_->nRanks());
+      break;
     case ALLTOALLV_DYNAMIC_SPLIT:
       this->send.kElem = nullptr;
       break;
@@ -156,6 +166,12 @@ OpElem::~OpElem() {
       this->alltoallv.sdispls.~vector();
       this->alltoallv.recvcounts.~vector();
       this->alltoallv.rdispls.~vector();
+      break;
+    case ALLTOALLVP:
+      this->alltoallvP.sendcounts.~vector();
+      this->alltoallvP.sdispls.~vector();
+      this->alltoallvP.recvcounts.~vector();
+      this->alltoallvP.rdispls.~vector();
       break;
     case ALLTOALL_DEDUP:
       for (auto& pair : this->alltoall_dedup.bcastElemMap) {

--- a/comms/ctran/gpe/CtranGpe.h
+++ b/comms/ctran/gpe/CtranGpe.h
@@ -52,6 +52,7 @@ struct OpElem {
     ALLTOALLV_DYNAMIC_SPLIT_NON_CONTIG_P,
     ALLTOALL_DEDUP,
     ALLTOALLV_DEDUP,
+    ALLTOALLVP,
     BROADCAST,
     REDUCESCATTER,
     PUTNOTIFY,
@@ -191,6 +192,19 @@ struct OpElem {
       void* perfTracer;
     } alltoallv_dedup_exec;
     struct {
+      // persistent
+      void* pArgs;
+      // non-persistent
+      size_t count;
+      const void* sendbuff;
+      std::vector<size_t> sendcounts;
+      std::vector<size_t> sdispls;
+      void* recvbuff;
+      std::vector<size_t> recvcounts;
+      std::vector<size_t> rdispls;
+      commDataType_t datatype;
+    } alltoallvP;
+    struct {
       const void* sendbuff;
       void* recvbuff;
       size_t count;
@@ -294,6 +308,7 @@ struct KernelConfig {
     SENDRECV_P2P,
     ALLTOALL,
     ALLTOALLV,
+    ALLTOALLVP,
     ALLTOALLV_DYNAMIC,
     ALLTOALLV_DYNAMIC_SPLIT,
     ALLTOALLV_DYNAMIC_SPLIT_NON_CONTIG,

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -428,6 +428,53 @@ class CtranMapper {
       std::vector<struct CtranMapperRemoteAccessKey>& remoteAccessKeys,
       CtranMapperBackend backend = CtranMapperBackend::UNSET);
 
+  /* Blocking alltoall control messages among ranks of the mapper associated
+   * communicator specified in ranks. It returns after sent and received all
+   * control messages.
+   * Unlike allGatherCtrl where each rank sends the same buffer to all peers,
+   * allToAllCtrl allows each rank to send a different buffer to each peer.
+   * Input argument:
+   *   - bufs: vector of local buffers, one for each rank. bufs[peer] is the
+   *           buffer to be shared with peer rank.
+   *   - hdls: vector of handles for the local buffers, one for each rank.
+   *           hdls[peer] is the handle for bufs[peer].
+   *   - ranks: the ranks to be used for the AllToAll exchange
+   *   - backend: the backend to be used for data transfer. If not specified,
+   *              use internal default based on peer rank and memory type.
+   * Output arguments:
+   *   - remoteBufs: the received remote buffers from all ranks.
+   * remoteBufs[peer] is the buffer address that peer sent to this rank.
+   *   - remoteAccessKeys: the received remote access keys from all ranks
+   */
+  commResult_t allToAllCtrl(
+      const std::vector<void*>& bufs,
+      const std::vector<void*>& hdls,
+      const std::vector<int>& ranks,
+      std::vector<void*>& remoteBufs,
+      std::vector<struct CtranMapperRemoteAccessKey>& remoteAccessKeys,
+      CtranMapperBackend backend = CtranMapperBackend::UNSET);
+
+  /* Blocking alltoall control messages among all ranks of the mapper
+   * associated communicator. This is a wrapper of allToAllCtrl on all ranks.
+   * Input argument:
+   *   - bufs: vector of local buffers, one for each rank. bufs[peer] is the
+   *           buffer to be shared with peer rank.
+   *   - hdls: vector of handles for the local buffers, one for each rank.
+   *           hdls[peer] is the handle for bufs[peer].
+   *   - backend: the backend to be used for data transfer. If not specified,
+   *              use internal default based on peer rank and memory type.
+   * Output arguments:
+   *   - remoteBufs: the received remote buffers from all ranks.
+   * remoteBufs[peer] is the buffer address that peer sent to this rank.
+   *   - remoteAccessKeys: the received remote access keys from all ranks
+   */
+  commResult_t allToAllCtrl(
+      const std::vector<void*>& bufs,
+      const std::vector<void*>& hdls,
+      std::vector<void*>& remoteBufs,
+      std::vector<struct CtranMapperRemoteAccessKey>& remoteAccessKeys,
+      CtranMapperBackend backend = CtranMapperBackend::UNSET);
+
   /* Convenient wrapper of isendCtrl/irecvCtrl to post a blocking barrier among
    * all local ranks of the mapper associated communicator.
    */
@@ -506,7 +553,7 @@ class CtranMapper {
       void* dbuf,
       std::size_t len,
       int peerRank,
-      CtranMapperConfig config,
+      const CtranMapperConfig& config,
       CtranMapperRequest* req) {
     return iputImpl<PerfConfig>(sbuf, dbuf, len, peerRank, config, req);
   }

--- a/comms/ncclx/v2_27/meta/colltrace/CollTraceFunc.cc
+++ b/comms/ncclx/v2_27/meta/colltrace/CollTraceFunc.cc
@@ -426,6 +426,10 @@ bool collTraceRecordCtranKernelInfo(
       // FIXME: need pass in arguments; a placeholder to pass build for now
       break;
     }
+    case KernelConfig::KernelType::ALLTOALLVP: {
+      coll.opName = "AllToAllvP";
+      break;
+    }
     case KernelConfig::KernelType::BROADCAST_UNPACK:
     case KernelConfig::KernelType::BROADCAST: {
       coll.opName = "Broadcast";
@@ -555,6 +559,10 @@ bool collTraceRecordCtranCollective(
     case OpElem::ALLTOALLV_DYNAMIC_SPLIT_NON_CONTIG_P:
       coll.opName = "AllToAllvDynamicSplitNonContigP";
       break;
+    case OpElem::ALLTOALLVP: {
+      coll.opName = "AllToAllvP";
+      break;
+    }
     case OpElem::BROADCAST:
       coll.opName = "Broadcast";
       coll.sendbuff = gpeOp.broadcast.sendbuff;

--- a/comms/ncclx/v2_28/meta/colltrace/CollTraceFunc.cc
+++ b/comms/ncclx/v2_28/meta/colltrace/CollTraceFunc.cc
@@ -426,6 +426,10 @@ bool collTraceRecordCtranKernelInfo(
       // FIXME: need pass in arguments; a placeholder to pass build for now
       break;
     }
+    case KernelConfig::KernelType::ALLTOALLVP: {
+      coll.opName = "AllToAllvP";
+      break;
+    }
     case KernelConfig::KernelType::BROADCAST_UNPACK:
     case KernelConfig::KernelType::BROADCAST: {
       coll.opName = "Broadcast";
@@ -555,6 +559,10 @@ bool collTraceRecordCtranCollective(
     case OpElem::ALLTOALLV_DYNAMIC_SPLIT_NON_CONTIG_P:
       coll.opName = "AllToAllvDynamicSplitNonContigP";
       break;
+    case OpElem::ALLTOALLVP: {
+      coll.opName = "AllToAllvP";
+      break;
+    }
     case OpElem::BROADCAST:
       coll.opName = "Broadcast";
       coll.sendbuff = gpeOp.broadcast.sendbuff;

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1994,6 +1994,15 @@ cvars:
      compCtran - Compression-based communication using IB Control message exchange
      bsCompCtran - Compression-based communication with NCCL socket bootstrapping
 
+ - name        : NCCL_ALLTOALLV_P_ALGO
+   type        : enum
+   default     : orig
+   choices     : orig, ctran
+   description : |-
+     The algorithm to use for AllToAllv communication
+     orig - Copy-based communication
+     ctran - Ctran-based communication
+
  - name        : NCCL_RMA_ALGO
    type        : enum
    default     : ctran


### PR DESCRIPTION
Summary:
In this diff, we implement SM-free AllToAllv-Persistent
{F1985891598}
----------------------------------------
In order to add a new `AllToAllvP`:
- update `Ctran.h` to add
  - `allToAllvPSupport()`
  - `allToAllvPInit()`
  - `allToAllvPExec()`
  - `allToAllvPDestroy()`
- update `algos/CtranAlgo.h` to add
  - `CtranPersistentRequest`: ALLTOALLV_P
- update `utils/cvars/nccl_cvars.yaml` to add `NCCL_ALLTOALLV_P_ALGO`
- update `gpe/CtranGpe.h`
  - `OpElem`
    - `opType`: ALLTOALLVP
    - `alltoallvP`
  - `KernelConfig`
    - `KernelType`: ALLTOALLVP
- update `colltrace/CollTraceWrapper.cc` to add
  - `case KernelConfig::KernelType::ALLTOALLVP:...`
- update `ncclx/v2_28/meta/colltrace/CollTaceFunc.cc` to add
  - `case KernelConfig::KernelType::ALLTOALLVP`
  - `case OpElem::ALLTOALLVP`
- update `ncclx/v2_27/meta/colltrace/CollTaceFunc.cc` to add
  - `case KernelConfig::KernelType::ALLTOALLVP`
  - `case OpElem::ALLTOALLVP`
- update `BUCK` to add `AllToAllvP` in `hetero_ctran_device_lib`
  - `srcs`
  - `headers`
------------------------------
As non-uniform AllToAllv, `allToAllvPExec` takes below four vectors as input
```
const size_t sendcounts[]
const size_t sdispls[]
const size_t recvcounts[]
const size_t rdispls[]
```
- add `allToAllCtrl()` to exchange the non-uniform Counts/Displs metadata in `allToAllvPExec()`

Differential Revision: D89499474


