### PR TITLE
Add asymmetric chunk size P2P benchmark infrastructure

### DIFF
--- a/comms/pipes/CopyUtils.cuh
+++ b/comms/pipes/CopyUtils.cuh
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <cuda_runtime.h>
+#include <array>
 #include <cstddef>
 
 #include "comms/pipes/ThreadGroup.cuh"
@@ -106,103 +107,165 @@ __device__ __forceinline__ void memcpy_vectorized(
 }
 
 /**
- * memcpy_vectorized_dual_dest_aligned - Dual-destination vectorized memory copy
+ * memcpy_vectorized_multi_dest_aligned - Multi-destination vectorized memory
+ * copy
  *
- * Reads each element from src once, then stores to both dst1 and dst2.
- * Eliminates the extra HBM read that occurs when doing two sequential copies
- * (src->dst1 then dst1->dst2). Same striding pattern as
- * memcpy_vectorized_aligned.
+ * Reads each element from src once, then stores to all N destination buffers.
+ * Eliminates the (N-1) extra HBM reads that occur when doing N sequential
+ * copies. Same striding pattern as memcpy_vectorized_aligned.
  *
+ * REQUIREMENTS:
+ * =============
+ * - All destination pointers and the source pointer must be aligned to
+ *   sizeof(VecType)
+ * - Destination buffers must not alias each other or the source buffer
+ * - N must be >= 1 (enforced by static_assert)
+ *
+ * PERFORMANCE NOTES:
+ * ==================
+ * - For N=1, prefer memcpy_vectorized_aligned which has full __restrict__
+ *   qualifier coverage
+ * - __restrict__ is applied to src_p only; the load-store separation pattern
+ *   (all loads complete before any stores) provides the key optimization
+ *   regardless
+ *
+ * @tparam N Number of destination buffers (must be >= 1)
  * @tparam VecType Vector type for loads/stores (typically uint4 = 16 bytes)
  * @tparam kUnroll Unroll factor (default 8)
- * @param dst1_p First destination buffer pointer
- * @param dst2_p Second destination buffer pointer
+ * @param dst_ps Array of N destination buffer pointers
  * @param src_p Source buffer pointer
  * @param nelems Number of elements of VecType to copy
  * @param group ThreadGroup for cooperative copy (all threads participate)
+ *
+ * N BOUNDS:
+ * =========
+ * - N is limited to 8 maximum to avoid excessive register pressure (each
+ *   destination requires kUnroll additional store instructions per iteration)
  */
-template <typename VecType, int kUnroll = 8>
-__device__ __forceinline__ void memcpy_vectorized_dual_dest_aligned(
-    VecType* dst1_p,
-    VecType* dst2_p,
-    const VecType* src_p,
+template <std::size_t N, typename VecType, int kUnroll = 8>
+__device__ __forceinline__ void memcpy_vectorized_multi_dest_aligned(
+    const std::array<VecType*, N>& dst_ps,
+    const VecType* __restrict__ src_p,
     std::size_t nelems,
     const ThreadGroup& group) {
+  static_assert(
+      N > 0 && N <= 8, "N must be between 1 and 8 (register pressure)");
 #ifdef __CUDA_ARCH__
+  // std::array<T,N> is layout-compatible with T[N]; cast to raw pointer for
+  // CUDA device code (std::array member functions are not __device__-qualified)
+  VecType* const* dst = reinterpret_cast<VecType* const*>(&dst_ps);
+
   const std::size_t kLoopStride = group.group_size * kUnroll;
   const std::size_t numVecsAligned = (nelems / kLoopStride) * kLoopStride;
-  VecType* __restrict__ dst1 = dst1_p;
-  VecType* __restrict__ dst2 = dst2_p;
-  const VecType* __restrict__ src = src_p;
 
+  // Main loop: coalesced strided access pattern
   for (std::size_t i = group.thread_id_in_group; i < numVecsAligned;
        i += kLoopStride) {
+    // Phase 1: Load kUnroll elements from src into registers
     VecType v[kUnroll];
 #pragma unroll
     for (int j = 0; j < kUnroll; ++j) {
-      v[j] = src[i + j * group.group_size];
+      v[j] = src_p[i + j * group.group_size];
     }
+    // Phase 2: Store to each of N destinations
 #pragma unroll
-    for (int j = 0; j < kUnroll; ++j) {
-      dst1[i + j * group.group_size] = v[j];
-    }
+    for (std::size_t d = 0; d < N; ++d) {
 #pragma unroll
-    for (int j = 0; j < kUnroll; ++j) {
-      dst2[i + j * group.group_size] = v[j];
+      for (int j = 0; j < kUnroll; ++j) {
+        dst[d][i + j * group.group_size] = v[j];
+      }
     }
   }
 
+  // Remainder: elements not fitting in full kLoopStride groups
   for (std::size_t i = numVecsAligned + group.thread_id_in_group; i < nelems;
        i += group.group_size) {
-    VecType v = src[i];
-    dst1[i] = v;
-    dst2[i] = v;
+    VecType v = src_p[i];
+#pragma unroll
+    for (std::size_t d = 0; d < N; ++d) {
+      dst[d][i] = v;
+    }
   }
 #endif // __CUDA_ARCH__
 }
 
 /**
- * memcpy_vectorized_dual_dest - Byte-level dual-destination vectorized copy
+ * memcpy_vectorized_multi_dest - Byte-level multi-destination vectorized copy
  *
- * Copies len bytes from src to both dst1 and dst2 with a single source read.
- * Checks alignment of all three pointers to select vectorized (uint4) or
+ * Copies len bytes from src to all N destination buffers with a single source
+ * read. Checks alignment of all (N+1) pointers to select vectorized (uint4) or
  * byte-level path.
  *
+ * @tparam N Number of destination buffers (must be >= 1)
  * @tparam kUnroll Unroll factor (default 8)
- * @param dst1 First destination buffer
- * @param dst2 Second destination buffer
+ * @param dsts Array of N destination buffer pointers
  * @param src Source buffer
  * @param len Number of bytes to copy
  * @param group ThreadGroup for cooperative copy
  */
-template <int kUnroll = 8>
-__device__ __forceinline__ void memcpy_vectorized_dual_dest(
-    char* dst1,
-    char* dst2,
+template <std::size_t N, int kUnroll = 8>
+__device__ __forceinline__ void memcpy_vectorized_multi_dest(
+    const std::array<char*, N>& dsts,
     const char* src,
     std::size_t len,
     const ThreadGroup& group) {
+  static_assert(
+      N > 0 && N <= 8, "N must be between 1 and 8 (register pressure)");
 #ifdef __CUDA_ARCH__
   constexpr std::size_t kAlignment = sizeof(uint4);
-  if ((uintptr_t)dst1 % kAlignment == 0 && (uintptr_t)dst2 % kAlignment == 0 &&
-      (uintptr_t)src % kAlignment == 0) {
+
+  // std::array<T,N> is layout-compatible with T[N]; cast to raw pointer for
+  // CUDA device code (std::array member functions are not __device__-qualified)
+  char* const* dsts_raw = reinterpret_cast<char* const*>(&dsts);
+
+  // Check alignment of all N destinations + source
+  // Use bitwise AND to avoid branch divergence in the unrolled loop
+  bool all_aligned = ((uintptr_t)src % kAlignment == 0);
+#pragma unroll
+  for (std::size_t d = 0; d < N; ++d) {
+    all_aligned = all_aligned & ((uintptr_t)dsts_raw[d] % kAlignment == 0);
+  }
+
+  // Local copies for pointer adjustment after aligned section
+  char* local_dsts[N];
+#pragma unroll
+  for (std::size_t d = 0; d < N; ++d) {
+    local_dsts[d] = dsts_raw[d];
+  }
+  const char* local_src = src;
+
+  if (all_aligned) {
     const std::size_t nelems = len / kAlignment;
-    uint4* __restrict__ dst1_p = reinterpret_cast<uint4*>(dst1);
-    uint4* __restrict__ dst2_p = reinterpret_cast<uint4*>(dst2);
-    const uint4* __restrict__ src_p = reinterpret_cast<const uint4*>(src);
-    memcpy_vectorized_dual_dest_aligned<uint4, kUnroll>(
-        dst1_p, dst2_p, src_p, nelems, group);
+    uint4* uint4_dsts[N];
+#pragma unroll
+    for (std::size_t d = 0; d < N; ++d) {
+      uint4_dsts[d] = reinterpret_cast<uint4*>(local_dsts[d]);
+    }
+    const uint4* __restrict__ src_p = reinterpret_cast<const uint4*>(local_src);
+
+    memcpy_vectorized_multi_dest_aligned<N, uint4, kUnroll>(
+        reinterpret_cast<const std::array<uint4*, N>&>(uint4_dsts),
+        src_p,
+        nelems,
+        group);
+
     len -= nelems * kAlignment;
     if (len == 0) {
       return;
     }
-    dst1 = reinterpret_cast<char*>(dst1_p + nelems);
-    dst2 = reinterpret_cast<char*>(dst2_p + nelems);
-    src = reinterpret_cast<const char*>(src_p + nelems);
+    // Adjust pointers for remainder bytes
+#pragma unroll
+    for (std::size_t d = 0; d < N; ++d) {
+      local_dsts[d] = reinterpret_cast<char*>(uint4_dsts[d] + nelems);
+    }
+    local_src = reinterpret_cast<const char*>(src_p + nelems);
   }
 
-  memcpy_vectorized_dual_dest_aligned<char, kUnroll>(
-      dst1, dst2, src, len, group);
+  memcpy_vectorized_multi_dest_aligned<N, char, kUnroll>(
+      reinterpret_cast<const std::array<char*, N>&>(local_dsts),
+      local_src,
+      len,
+      group);
 #endif // __CUDA_ARCH__
 }
 

--- a/comms/pipes/P2pNvlTransportDevice.cuh
+++ b/comms/pipes/P2pNvlTransportDevice.cuh
@@ -850,17 +850,17 @@ class P2pNvlTransportDevice {
     std::size_t totalBytesWritten = 0;
     group.for_each_item_contiguous(numChunks, [&](uint32_t chunkIdx) {
       const std::size_t chunkOffset = chunkIdx * alignedChunkSize;
-      const std::size_t chunkBytes = (chunkOffset + alignedChunkSize <= nbytes)
-          ? alignedChunkSize
-          : nbytes - chunkOffset;
+      const std::size_t currentChunkBytes =
+          (chunkOffset + alignedChunkSize <= nbytes) ? alignedChunkSize
+                                                     : nbytes - chunkOffset;
 
-      if (chunkBytes > 0) {
+      if (currentChunkBytes > 0) {
         memcpy_vectorized(
             dst_d + chunkOffset, // dst_base
             src_d + chunkOffset, // src_base
-            chunkBytes, // chunk_bytes
+            currentChunkBytes, // chunk_bytes
             group);
-        totalBytesWritten += chunkBytes;
+        totalBytesWritten += currentChunkBytes;
       }
     });
     return totalBytesWritten;
@@ -959,6 +959,356 @@ class P2pNvlTransportDevice {
     group.sync();
   }
 
+  // ===========================================================================
+  // Transport Configuration Accessors
+  // ===========================================================================
+
+  /**
+   * chunk_size - Get the configured chunk size for this transport.
+   */
+  __host__ __device__ __forceinline__ std::size_t chunk_size() const {
+    return options_.chunkSize;
+  }
+
+  /**
+   * data_buffer_size - Get the configured data buffer size for this transport.
+   */
+  __host__ __device__ __forceinline__ std::size_t data_buffer_size() const {
+    return options_.dataBufferSize;
+  }
+
+  /**
+   * pipeline_depth - Get the configured pipeline depth for this transport.
+   */
+  __host__ __device__ __forceinline__ std::size_t pipeline_depth() const {
+    return options_.pipelineDepth;
+  }
+
+  __device__ __forceinline__ char* local_data_buffer() const {
+    return localState_.dataBuffer;
+  }
+
+  __device__ __forceinline__ ChunkState* local_state_buffer() const {
+    return localState_.stateBuffer.data();
+  }
+
+  __device__ __forceinline__ char* remote_data_buffer() const {
+    return remoteState_.dataBuffer;
+  }
+
+  __device__ __forceinline__ ChunkState* remote_state_buffer() const {
+    return remoteState_.stateBuffer.data();
+  }
+
+  // ===========================================================================
+  // Streaming Primitives API
+  // ===========================================================================
+  // The streaming API provides reusable primitives for pipelined collectives.
+  // RecvStream yields chunks as they become ready; SendStream provides slots
+  // for sending. These can be composed to build intermediate rank logic for
+  // broadcast, reduce, all-to-all, etc.
+  // ===========================================================================
+
+  /**
+   * StagingChunkView - Read-only view of a ready chunk in the staging buffer
+   *
+   * Yielded by RecvStream::for_each_ready_chunk(). The caller can read from
+   * `data` and use `offset`/`size` to determine where to copy.
+   *
+   * MEMORY SEMANTICS:
+   * - `data` points to local staging buffer (receiver's memory)
+   * - Data is visible with acquire semantics (predecessor's writes are visible)
+   * - Valid only within the callback scope; auto-released after callback
+   *   returns
+   *
+   * LIFETIME:
+   * - The staging buffer slot is released when the callback returns
+   * - Do NOT store `data` pointer beyond the callback scope
+   */
+  struct StagingChunkView {
+    const char* data; // Pointer into staging buffer (read-only)
+    std::size_t offset; // Offset within the full message (always chunk-aligned)
+    std::size_t size; // Chunk size in bytes (may be < chunkSize for last chunk)
+  };
+
+  /**
+   * SendSlotView - Writable view of a staging slot for sending
+   *
+   * Obtained from SendStream::slot_for() or yielded by
+   * SendStream::for_each_slot(). The caller writes data to `data`, then calls
+   * commit_slot() to signal the receiver.
+   *
+   * MEMORY SEMANTICS:
+   * - `data` points to REMOTE staging buffer (receiver's memory via NVLink)
+   * - Writes go over NVLink to receiver's local memory
+   * - commit_slot() provides release semantics (writes visible to receiver)
+   *
+   * INTERNAL STATE:
+   * - stepId_ and stateIndex_ are used by commit_slot() to signal the correct
+   *   ChunkState
+   * - These are opaque to the caller
+   */
+  struct SendSlotView {
+    char* data; // Writable pointer into remote staging buffer
+    std::size_t offset; // Offset within the full message
+    std::size_t size; // Chunk size in bytes
+
+    // Internal state for commit_slot() - do not access directly
+    std::size_t stepId_; // Step ID for ready_to_recv signaling
+    std::size_t stateIndex_; // Index into stateBuffer for commit_slot
+
+    __device__ __forceinline__ SendSlotView(
+        char* data,
+        std::size_t offset,
+        std::size_t size,
+        std::size_t stepId,
+        std::size_t stateIndex)
+        : data(data),
+          offset(offset),
+          size(size),
+          stepId_(stepId),
+          stateIndex_(stateIndex) {}
+  };
+
+  // Forward declarations for streaming primitives
+  class RecvStream;
+  class SendStream;
+
+  /**
+   * RecvStream - Streaming receive iterator for pipelined transfers
+   *
+   * Iterates over all chunks assigned to this warp group, yielding each chunk
+   * as it becomes ready. The caller processes each chunk via a callback, then
+   * the staging slot is automatically released.
+   *
+   * MEMORY ORDERING:
+   * - Acquire semantics before yielding chunk (predecessor's writes are
+   *   visible)
+   * - Release semantics after callback returns (slot freed for predecessor
+   *   reuse)
+   *
+   * BUFFER ASYMMETRY:
+   * - RecvStream reads from LOCAL staging buffer (receiver's memory)
+   * - Predecessor wrote to this buffer via NVLink (remote write pattern)
+   * - This allows fast local reads without NVLink latency
+   *
+   * CALLBACK CONTRACT:
+   * - Callback MUST NOT exit early without completing its work
+   * - Callback MUST call commit_slot() on any SendStream slots acquired
+   * - If callback fails, the pipeline will hang (no automatic cleanup)
+   *
+   * SIGNAL ORDERING:
+   * - RecvStream releases predecessor's slot AFTER callback returns
+   * - This matches NCCL's postPeer ordering (signal successor, then free
+   *   predecessor)
+   * - Safe for unidirectional ring topologies
+   */
+  class RecvStream {
+   public:
+    /**
+     * for_each_ready_chunk - Iterate over all ready chunks
+     *
+     * For each chunk assigned to this warp group:
+     * 1. Blocks until predecessor signals chunk ready (acquire semantics)
+     * 2. Yields StagingChunkView to callback
+     * 3. After callback returns, releases staging slot (release semantics)
+     *
+     * @param group ThreadGroup for cooperative processing
+     * @param func Callback invoked for each ready chunk: void(StagingChunkView)
+     */
+    template <typename Func>
+    __device__ __forceinline__ void for_each_ready_chunk(
+        ThreadGroup& group,
+        Func&& func);
+
+   private:
+    friend class P2pNvlTransportDevice;
+
+    char* dataBuffer_; // Local staging buffer (receiver reads from here)
+    ChunkState* stateBuffer_; // Array of per-chunk synchronization flags
+    std::size_t nbytes_; // Total bytes to receive
+    std::size_t dataBufferSize_; // Size of one pipeline slot
+    std::size_t chunkSize_; // Size of each chunk
+    std::size_t pipelineDepth_; // Number of slots
+    std::size_t chunksPerStep_; // dataBufferSize / chunkSize (chunks per slot)
+    std::size_t totalSteps_; // nbytes / dataBufferSize (total iterations)
+    uint32_t callIndex_;
+    Timeout timeout_;
+
+    __device__ __forceinline__ RecvStream(
+        char* dataBuffer,
+        ChunkState* stateBuffer,
+        std::size_t nbytes,
+        std::size_t dataBufferSize,
+        std::size_t chunkSize,
+        std::size_t pipelineDepth,
+        uint32_t callIndex,
+        const Timeout& timeout)
+        : dataBuffer_(dataBuffer),
+          stateBuffer_(stateBuffer),
+          nbytes_(nbytes),
+          dataBufferSize_(dataBufferSize),
+          chunkSize_(chunkSize),
+          pipelineDepth_(pipelineDepth),
+          chunksPerStep_((dataBufferSize + chunkSize - 1) / chunkSize),
+          totalSteps_((nbytes + dataBufferSize - 1) / dataBufferSize),
+          callIndex_(callIndex),
+          timeout_(timeout) {}
+  };
+
+  /**
+   * SendStream - Streaming send iterator for pipelined transfers
+   *
+   * Provides two APIs for different use cases:
+   *
+   * 1. CALLBACK API (for_each_slot): For root rank that drives its own
+   *    iteration. Iterates over all staging slots, waits for each to be free,
+   *    yields to callback, then AUTO-SIGNALS receiver after callback returns.
+   *
+   * 2. POSITIONAL API (slot_for + commit_slot): For intermediate ranks called
+   *    inside RecvStream's callback. Maps a received chunk's offset to the
+   *    corresponding send staging slot. REQUIRES MANUAL commit_slot() call.
+   *
+   * MEMORY ORDERING:
+   * - slot_for() waits with acquire semantics (successor freed the slot)
+   * - commit_slot() signals with release semantics (writes visible to
+   *   successor)
+   *
+   * BUFFER ASYMMETRY:
+   * - SendStream writes to REMOTE staging buffer (receiver's memory via
+   *   NVLink)
+   * - This is the "remote write" pattern: receiver reads from local memory
+   *   (fast)
+   */
+  class SendStream {
+   public:
+    // --- Callback API (for root rank — drives its own iteration) ---
+    // AUTO-COMMITS after callback returns
+
+    /**
+     * for_each_slot - Iterate over all staging slots
+     *
+     * For each slot assigned to this warp group:
+     * 1. Waits for slot to be free (successor consumed previous data)
+     * 2. Yields SendSlotView to callback (caller writes data)
+     * 3. After callback returns, AUTO-SIGNALS receiver (data ready)
+     *
+     * NOTE: Do NOT call commit_slot() inside this callback - it auto-commits.
+     *
+     * @param group ThreadGroup for cooperative processing
+     * @param func Callback invoked for each slot: void(SendSlotView)
+     */
+    template <typename Func>
+    __device__ __forceinline__ void for_each_slot(
+        ThreadGroup& group,
+        Func&& func);
+
+    // --- Positional API (for intermediate rank — called inside RecvStream)
+    // --- REQUIRES MANUAL commit_slot() call
+
+    /**
+     * slot_for - Get send slot corresponding to a received chunk
+     *
+     * Reverse-maps recv_chunk.offset to the corresponding send staging slot.
+     * Waits for the slot to be free before returning.
+     *
+     * IMPORTANT: Assumes recv and send transports have matching configs.
+     *
+     * @param group ThreadGroup for cooperative processing
+     * @param recv_chunk The received chunk (from RecvStream)
+     * @return SendSlotView pointing to the corresponding send staging buffer
+     */
+    __device__ __forceinline__ SendSlotView
+    slot_for(ThreadGroup& group, const StagingChunkView& recv_chunk);
+
+    /**
+     * commit_slot - Signal receiver that data is ready
+     *
+     * MUST be called after writing data to slot.data when using slot_for().
+     * Do NOT call when using for_each_slot() (it auto-commits).
+     *
+     * @param group ThreadGroup for cooperative processing
+     * @param slot The slot returned by slot_for()
+     */
+    __device__ __forceinline__ void commit_slot(
+        ThreadGroup& group,
+        const SendSlotView& slot);
+
+   private:
+    friend class P2pNvlTransportDevice;
+
+    char* dataBuffer_; // Remote staging buffer (receiver's memory via NVLink)
+    ChunkState* stateBuffer_; // Array of per-chunk synchronization flags
+    std::size_t nbytes_; // Total bytes to receive
+    std::size_t dataBufferSize_; // Size of one pipeline slot
+    std::size_t chunkSize_; // Size of each chunk
+    std::size_t pipelineDepth_; // Number of slots
+    std::size_t chunksPerStep_; // dataBufferSize / chunkSize (chunks per slot)
+    std::size_t totalSteps_; // nbytes / dataBufferSize (total iterations)
+    uint32_t callIndex_;
+    Timeout timeout_;
+
+    __device__ __forceinline__ SendStream(
+        char* dataBuffer,
+        ChunkState* stateBuffer,
+        std::size_t nbytes,
+        std::size_t dataBufferSize,
+        std::size_t chunkSize,
+        std::size_t pipelineDepth,
+        uint32_t callIndex,
+        const Timeout& timeout)
+        : dataBuffer_(dataBuffer),
+          stateBuffer_(stateBuffer),
+          nbytes_(nbytes),
+          dataBufferSize_(dataBufferSize),
+          chunkSize_(chunkSize),
+          pipelineDepth_(pipelineDepth),
+          chunksPerStep_((dataBufferSize + chunkSize - 1) / chunkSize),
+          totalSteps_((nbytes + dataBufferSize - 1) / dataBufferSize),
+          callIndex_(callIndex),
+          timeout_(timeout) {}
+  };
+
+  /**
+   * recv_stream - Create a RecvStream for streaming receive
+   *
+   * Creates a RecvStream that yields chunks as they become ready from the
+   * predecessor. Use for intermediate ranks that need to process chunks
+   * as they arrive.
+   *
+   * NOTE: The caller is responsible for calling timeout.start() before
+   * creating the stream if timeout enforcement is desired.
+   *
+   * @param nbytes Total number of bytes to receive
+   * @param call_index Call index for disambiguating multiple calls (default 0)
+   * @param timeout Timeout configuration (default none)
+   * @return RecvStream for iterating over ready chunks
+   */
+  __device__ __forceinline__ RecvStream recv_stream(
+      std::size_t nbytes,
+      uint32_t call_index = 0,
+      const Timeout& timeout = Timeout()) const;
+
+  /**
+   * send_stream - Create a SendStream for streaming send
+   *
+   * Creates a SendStream for sending chunks to the successor. Use for root
+   * rank (with for_each_slot) or intermediate ranks (with slot_for +
+   * commit_slot).
+   *
+   * NOTE: The caller is responsible for calling timeout.start() before
+   * creating the stream if timeout enforcement is desired.
+   *
+   * @param nbytes Total number of bytes to send
+   * @param call_index Call index for disambiguating multiple calls (default 0)
+   * @param timeout Timeout configuration (default none)
+   * @return SendStream for iterating over or accessing send slots
+   */
+  __device__ __forceinline__ SendStream send_stream(
+      std::size_t nbytes,
+      uint32_t call_index = 0,
+      const Timeout& timeout = Timeout()) const;
+
  private:
   const int myRank_{-1};
   const int peerRank_{-1};
@@ -966,5 +1316,242 @@ class P2pNvlTransportDevice {
   LocalState localState_;
   RemoteState remoteState_;
 };
+
+// =============================================================================
+// Streaming Primitives Implementation
+// =============================================================================
+
+template <typename Func>
+__device__ __forceinline__ void
+P2pNvlTransportDevice::RecvStream::for_each_ready_chunk(
+    ThreadGroup& group,
+    Func&& func) {
+#ifdef __CUDA_ARCH__
+  // Cross-step deferred signaling optimization:
+  // With pipelineDepth >= 2, we defer SIGNAL-2 (ready_to_send, which frees
+  // the predecessor's staging slot) from step N until after WAIT-1 of step
+  // N+1. This removes SIGNAL-2 from the critical path between steps:
+  //   Before: func(N) -> SIGNAL-2(N) -> WAIT-1(N+1) -> func(N+1)
+  //   After:  func(N) -> WAIT-1(N+1) -> SIGNAL-2(N) -> func(N+1)
+  // Safe because the predecessor reuses slot N%pd at step N+pd, and we
+  // release it at step N+1 — leaving pd-1 steps of slack.
+  // Falls back to immediate release when pipelineDepth == 1.
+  const bool deferRelease = (pipelineDepth_ >= 2);
+
+  for (std::size_t stepId = 0; stepId < totalSteps_; ++stepId) {
+    const std::size_t pipelineIdx = stepId % pipelineDepth_;
+    const std::size_t stepOffset = stepId * dataBufferSize_;
+    const std::size_t stepBytes = (stepOffset + dataBufferSize_ <= nbytes_)
+        ? dataBufferSize_ // Full step
+        : nbytes_ - stepOffset; // Partial (last step)
+    const std::size_t numChunks = (stepBytes + chunkSize_ - 1) / chunkSize_;
+    const std::size_t stateOffset = pipelineIdx * chunksPerStep_;
+    const std::size_t stagingOffset = pipelineIdx * dataBufferSize_;
+
+    // Compute previous step info for deferred release
+    std::size_t prevStateOffset = 0;
+    std::size_t prevNumChunks = 0;
+    if (deferRelease && stepId > 0) {
+      const std::size_t prevPipelineIdx = (stepId - 1) % pipelineDepth_;
+      prevStateOffset = prevPipelineIdx * chunksPerStep_;
+      const std::size_t prevStepOffset = (stepId - 1) * dataBufferSize_;
+      const std::size_t prevStepBytes =
+          (prevStepOffset + dataBufferSize_ <= nbytes_)
+          ? dataBufferSize_
+          : nbytes_ - prevStepOffset;
+      prevNumChunks = (prevStepBytes + chunkSize_ - 1) / chunkSize_;
+    }
+
+    // Iterate over max(numChunks, prevNumChunks) to ensure all previous
+    // step's chunks get released even if the current step has fewer chunks
+    // (can happen for the last step when nbytes is not a multiple of
+    // dataBufferSize)
+    const std::size_t iterChunks = (deferRelease && stepId > 0)
+        ? (numChunks > prevNumChunks ? numChunks : prevNumChunks)
+        : numChunks;
+
+    // Each warp gets assigned a contiguous range of chunks
+    group.for_each_item_contiguous(iterChunks, [&](uint32_t chunkIdx) {
+      const bool hasCurrentChunk = (chunkIdx < numChunks);
+      const std::size_t chunkOffset = chunkIdx * chunkSize_;
+      const std::size_t chunkBytes = hasCurrentChunk
+          ? ((chunkOffset + chunkSize_ <= stepBytes) ? chunkSize_
+                                                     : stepBytes - chunkOffset)
+          : 0;
+
+      // WAIT-1: Wait for predecessor's data (acquire semantics)
+      if (hasCurrentChunk && chunkBytes > 0) {
+        ChunkState& state = stateBuffer_[stateOffset + chunkIdx];
+        state.wait_ready_to_recv(group, stepId, callIndex_, timeout_);
+      }
+
+      // Deferred SIGNAL-2: release previous step's staging slot AFTER
+      // waiting for current step's data, overlapping with the wait
+      if (deferRelease && stepId > 0 && chunkIdx < prevNumChunks) {
+        stateBuffer_[prevStateOffset + chunkIdx].ready_to_send(group);
+      }
+
+      // Yield chunk to callback
+      if (hasCurrentChunk && chunkBytes > 0) {
+        StagingChunkView view{
+            dataBuffer_ + stagingOffset + chunkOffset, // Data pointer
+            stepOffset + chunkOffset, // Offset (in full message)
+            chunkBytes}; // Chunk size
+        func(view);
+      }
+
+      // Immediate release when deferred signaling is disabled (pd == 1)
+      if (!deferRelease && hasCurrentChunk && chunkBytes > 0) {
+        stateBuffer_[stateOffset + chunkIdx].ready_to_send(group);
+      }
+    });
+  }
+
+  // Release the last step's staging slots (deferred from the final iteration)
+  if (deferRelease && totalSteps_ > 0) {
+    const std::size_t lastStepId = totalSteps_ - 1;
+    const std::size_t lastPipelineIdx = lastStepId % pipelineDepth_;
+    const std::size_t lastStepOffset = lastStepId * dataBufferSize_;
+    const std::size_t lastStepBytes =
+        (lastStepOffset + dataBufferSize_ <= nbytes_)
+        ? dataBufferSize_
+        : nbytes_ - lastStepOffset;
+    const std::size_t lastNumChunks =
+        (lastStepBytes + chunkSize_ - 1) / chunkSize_;
+    const std::size_t lastStateOffset = lastPipelineIdx * chunksPerStep_;
+
+    group.for_each_item_contiguous(lastNumChunks, [&](uint32_t chunkIdx) {
+      stateBuffer_[lastStateOffset + chunkIdx].ready_to_send(group);
+    });
+  }
+#endif
+}
+
+template <typename Func>
+__device__ __forceinline__ void
+P2pNvlTransportDevice::SendStream::for_each_slot(
+    ThreadGroup& group,
+    Func&& func) {
+#ifdef __CUDA_ARCH__
+  for (std::size_t stepId = 0; stepId < totalSteps_; ++stepId) {
+    const std::size_t pipelineIdx = stepId % pipelineDepth_;
+    const std::size_t stepOffset = stepId * dataBufferSize_;
+    const std::size_t stepBytes = (stepOffset + dataBufferSize_ <= nbytes_)
+        ? dataBufferSize_ // Full step
+        : nbytes_ - stepOffset; // Partial (last step)
+    const std::size_t numChunks = (stepBytes + chunkSize_ - 1) / chunkSize_;
+    const std::size_t stateOffset = pipelineIdx * chunksPerStep_;
+    const std::size_t stagingOffset = pipelineIdx * dataBufferSize_;
+
+    group.for_each_item_contiguous(numChunks, [&](uint32_t chunkIdx) {
+      const std::size_t chunkOffset = chunkIdx * chunkSize_;
+      const std::size_t chunkBytes = (chunkOffset + chunkSize_ <= stepBytes)
+          ? chunkSize_
+          : stepBytes - chunkOffset;
+
+      if (chunkBytes == 0) {
+        return;
+      }
+
+      ChunkState& state = stateBuffer_[stateOffset + chunkIdx];
+
+      // Wait for slot to be free (acquire semantics)
+      state.wait_ready_to_send(group, timeout_);
+
+      // Yield slot to callback
+      SendSlotView slot{
+          dataBuffer_ + stagingOffset + chunkOffset,
+          stepOffset + chunkOffset,
+          chunkBytes,
+          stepId,
+          stateOffset + chunkIdx};
+      func(slot);
+
+      // AUTO-SIGNAL receiver (release semantics)
+      state.ready_to_recv(group, stepId, callIndex_);
+    });
+  }
+#endif
+}
+
+__device__ __forceinline__ P2pNvlTransportDevice::SendSlotView
+P2pNvlTransportDevice::SendStream::slot_for(
+    ThreadGroup& group,
+    const StagingChunkView& recv_chunk) {
+#ifdef __CUDA_ARCH__
+  // Reverse-map offset → step and pipeline slot
+  const std::size_t stepId = recv_chunk.offset / dataBufferSize_;
+  const std::size_t pipelineIdx = stepId % pipelineDepth_;
+  const std::size_t offsetInStep = recv_chunk.offset - stepId * dataBufferSize_;
+  const std::size_t chunkIdx = offsetInStep / chunkSize_;
+  const std::size_t stateOffset = pipelineIdx * chunksPerStep_;
+  const std::size_t stagingOffset = pipelineIdx * dataBufferSize_;
+  const std::size_t stateIndex = stateOffset + chunkIdx;
+
+  ChunkState& state = stateBuffer_[stateIndex];
+
+  // Wait for slot to be free (acquire semantics)
+  state.wait_ready_to_send(group, timeout_);
+
+  return SendSlotView{
+      dataBuffer_ + stagingOffset + offsetInStep,
+      recv_chunk.offset,
+      recv_chunk.size,
+      stepId,
+      stateIndex};
+#else
+  return SendSlotView{nullptr, 0, 0, 0, 0};
+#endif
+}
+
+__device__ __forceinline__ void P2pNvlTransportDevice::SendStream::commit_slot(
+    ThreadGroup& group,
+    const SendSlotView& slot) {
+#ifdef __CUDA_ARCH__
+  ChunkState& state = stateBuffer_[slot.stateIndex_];
+  // Signal receiver: data ready (release semantics)
+  state.ready_to_recv(group, slot.stepId_, callIndex_);
+#endif
+}
+
+__device__ __forceinline__ P2pNvlTransportDevice::RecvStream
+P2pNvlTransportDevice::recv_stream(
+    std::size_t nbytes,
+    uint32_t call_index,
+    const Timeout& timeout) const {
+#ifdef __CUDA_ARCH__
+  return RecvStream{
+      localState_.dataBuffer,
+      localState_.stateBuffer.data(),
+      nbytes,
+      options_.dataBufferSize,
+      options_.chunkSize,
+      options_.pipelineDepth,
+      call_index,
+      timeout};
+#else
+  return RecvStream{nullptr, nullptr, 0, 0, 0, 0, 0, Timeout{}};
+#endif
+}
+
+__device__ __forceinline__ P2pNvlTransportDevice::SendStream
+P2pNvlTransportDevice::send_stream(
+    std::size_t nbytes,
+    uint32_t call_index,
+    const Timeout& timeout) const {
+#ifdef __CUDA_ARCH__
+  return SendStream{
+      remoteState_.dataBuffer,
+      remoteState_.stateBuffer.data(),
+      nbytes,
+      options_.dataBufferSize,
+      options_.chunkSize,
+      options_.pipelineDepth,
+      call_index,
+      timeout};
+#else
+  return SendStream{nullptr, nullptr, 0, 0, 0, 0, 0, Timeout{}};
+#endif
+}
 
 } // namespace comms::pipes

--- a/comms/pipes/benchmarks/BenchmarkKernel.cu
+++ b/comms/pipes/benchmarks/BenchmarkKernel.cu
@@ -98,6 +98,322 @@ __global__ void p2pBidirectional(
   }
 }
 
+/**
+ * asymmetric_recv_impl - Batched recv that coalesces fine-grained ChunkStates
+ *
+ * Replicates the structure of P2pNvlTransportDevice::recv() but processes
+ * chunks in "macro chunks" of size recvChunkSize. For each macro chunk:
+ *   1. Wait for all constituent fine-grained ChunkStates (spin loops)
+ *   2. Single large memcpy_vectorized for the full macro chunk
+ *   3. Release all constituent ChunkStates
+ *
+ * @param p2p Transport device (configured at fine chunk granularity)
+ * @param group ThreadGroup for cooperative processing
+ * @param dstBuff Destination buffer
+ * @param nBytes Total bytes to receive
+ * @param recvChunkSize Coarse recv chunk size (must be multiple of
+ *        p2p.chunk_size())
+ * @param timeout Timeout configuration
+ */
+__device__ __forceinline__ void asymmetric_recv_impl(
+    P2pNvlTransportDevice& p2p,
+    ThreadGroup& group,
+    void* dstBuff,
+    std::size_t nBytes,
+    std::size_t recvChunkSize,
+    const Timeout& timeout) {
+#ifdef __CUDA_ARCH__
+  char* dst = reinterpret_cast<char*>(dstBuff);
+  char* recvBuffer = p2p.local_data_buffer();
+  ChunkState* recvStates = p2p.local_state_buffer();
+
+  const std::size_t transportChunkSize = p2p.chunk_size();
+  const std::size_t dataBufferSize = p2p.data_buffer_size();
+  const std::size_t pipelineDepth = p2p.pipeline_depth();
+
+  // Validate: recvChunkSize must be an exact multiple of transport chunk size
+  if (recvChunkSize % transportChunkSize != 0) {
+    printf(
+        "asymmetric_recv: recvChunkSize (%llu) must be a multiple of "
+        "transportChunkSize (%llu)\n",
+        (unsigned long long)recvChunkSize,
+        (unsigned long long)transportChunkSize);
+    __trap();
+  }
+
+  // Validate: dataBufferSize must be an exact multiple of recvChunkSize
+  // to ensure macro-chunk indexing doesn't overshoot the state buffer
+  if (dataBufferSize % recvChunkSize != 0) {
+    printf(
+        "asymmetric_recv: dataBufferSize (%llu) must be a multiple of "
+        "recvChunkSize (%llu)\n",
+        (unsigned long long)dataBufferSize,
+        (unsigned long long)recvChunkSize);
+    __trap();
+  }
+
+  const std::size_t chunksPerStep =
+      (dataBufferSize + transportChunkSize - 1) / transportChunkSize;
+  const std::size_t totalSteps = (nBytes + dataBufferSize - 1) / dataBufferSize;
+  const std::size_t batchFactor = recvChunkSize / transportChunkSize;
+
+  for (std::size_t stepId = 0; stepId < totalSteps; ++stepId) {
+    const std::size_t pipelineIdx = stepId % pipelineDepth;
+    const std::size_t dataBufferOffset = pipelineIdx * dataBufferSize;
+    const std::size_t stateOffset = pipelineIdx * chunksPerStep;
+    const std::size_t stepOffset = stepId * dataBufferSize;
+    const std::size_t stepBytes = (stepOffset + dataBufferSize <= nBytes)
+        ? dataBufferSize
+        : nBytes - stepOffset;
+    const std::size_t numMacroChunks =
+        (stepBytes + recvChunkSize - 1) / recvChunkSize;
+
+    group.for_each_item_contiguous(numMacroChunks, [&](uint32_t macroIdx) {
+      const std::size_t macroOffset = macroIdx * recvChunkSize;
+      const std::size_t macroBytes = (macroOffset + recvChunkSize <= stepBytes)
+          ? recvChunkSize
+          : stepBytes - macroOffset;
+      if (macroBytes == 0) {
+        return;
+      }
+
+      const std::size_t firstChunk = macroIdx * batchFactor;
+      const std::size_t numFineChunks =
+          (macroBytes + transportChunkSize - 1) / transportChunkSize;
+
+      // Phase 1: Wait for all fine-grained chunks (spin loops, no sync
+      // overhead)
+      for (std::size_t i = 0; i < numFineChunks; ++i) {
+        recvStates[stateOffset + firstChunk + i].wait_ready_to_recv(
+            group, stepId, 0, timeout);
+      }
+
+      // Phase 2: Single large memcpy for the entire macro chunk
+      memcpy_vectorized(
+          dst + stepOffset + macroOffset,
+          recvBuffer + dataBufferOffset + macroOffset,
+          macroBytes,
+          group);
+
+      // Phase 3: Batched release of all fine-grained chunks.
+      // A single group.sync() fences the Phase 2 memcpy, then the leader
+      // performs N release-stores. This replaces N ready_to_send() calls
+      // (each with its own group.sync()) with 1 sync + N stores,
+      // eliminating (N-1) redundant barriers.
+      group.sync();
+      if (group.is_leader()) {
+        for (std::size_t i = 0; i < numFineChunks; ++i) {
+          recvStates[stateOffset + firstChunk + i].release_to_send();
+        }
+      }
+    });
+  }
+#endif
+}
+
+__global__ void p2pAsymmetricRecv(
+    P2pNvlTransportDevice p2p,
+    void* dstBuff,
+    std::size_t nBytes,
+    std::size_t recvChunkSize,
+    SyncScope groupScope,
+    Timeout timeout) {
+  timeout.start();
+  auto group = make_thread_group(groupScope);
+  asymmetric_recv_impl(p2p, group, dstBuff, nBytes, recvChunkSize, timeout);
+}
+
+__global__ void p2pAsymmetricBidirectional(
+    P2pNvlTransportDevice p2p,
+    void* sendBuff,
+    void* recvBuff,
+    std::size_t nBytes,
+    std::size_t recvChunkSize,
+    SyncScope groupScope,
+    Timeout timeout) {
+  timeout.start();
+  auto group = make_thread_group(groupScope);
+
+  // Partition groups into 2: half for send, half for recv
+  auto [partition_id, subgroup] = group.partition_interleaved(2);
+  if (partition_id == 0) {
+    p2p.send(subgroup, sendBuff, nBytes, 0, timeout);
+  } else {
+    asymmetric_recv_impl(
+        p2p, subgroup, recvBuff, nBytes, recvChunkSize, timeout);
+  }
+}
+
+/**
+ * asymmetric_send_impl - Batched send that coalesces fine-grained ChunkStates
+ *
+ * Replicates the structure of P2pNvlTransportDevice::send() but processes
+ * chunks in "macro chunks" of size sendChunkSize. For each macro chunk:
+ *   1. Wait for all constituent fine-grained ChunkStates (spin loops)
+ *   2. Single large memcpy_vectorized for the full macro chunk (over NVLink)
+ *   3. Release all constituent ChunkStates via batched release_to_recv
+ *
+ * @param p2p Transport device (configured at fine chunk granularity)
+ * @param group ThreadGroup for cooperative processing
+ * @param srcBuff Source buffer
+ * @param nBytes Total bytes to send
+ * @param sendChunkSize Coarse send chunk size (must be multiple of
+ *        p2p.chunk_size())
+ * @param timeout Timeout configuration
+ */
+__device__ __forceinline__ void asymmetric_send_impl(
+    P2pNvlTransportDevice& p2p,
+    ThreadGroup& group,
+    void* srcBuff,
+    std::size_t nBytes,
+    std::size_t sendChunkSize,
+    const Timeout& timeout) {
+#ifdef __CUDA_ARCH__
+  char* src = reinterpret_cast<char*>(srcBuff);
+  char* sendBuffer = p2p.remote_data_buffer();
+  ChunkState* sendStates = p2p.remote_state_buffer();
+
+  const std::size_t transportChunkSize = p2p.chunk_size();
+  const std::size_t dataBufferSize = p2p.data_buffer_size();
+  const std::size_t pipelineDepth = p2p.pipeline_depth();
+
+  // Validate: sendChunkSize must be an exact multiple of transport chunk size
+  if (sendChunkSize % transportChunkSize != 0) {
+    printf(
+        "asymmetric_send: sendChunkSize (%llu) must be a multiple of "
+        "transportChunkSize (%llu)\n",
+        (unsigned long long)sendChunkSize,
+        (unsigned long long)transportChunkSize);
+    __trap();
+  }
+
+  // Validate: dataBufferSize must be an exact multiple of sendChunkSize
+  // to ensure macro-chunk indexing doesn't overshoot the state buffer
+  if (dataBufferSize % sendChunkSize != 0) {
+    printf(
+        "asymmetric_send: dataBufferSize (%llu) must be a multiple of "
+        "sendChunkSize (%llu)\n",
+        (unsigned long long)dataBufferSize,
+        (unsigned long long)sendChunkSize);
+    __trap();
+  }
+
+  const std::size_t chunksPerStep =
+      (dataBufferSize + transportChunkSize - 1) / transportChunkSize;
+  const std::size_t totalSteps = (nBytes + dataBufferSize - 1) / dataBufferSize;
+  const std::size_t batchFactor = sendChunkSize / transportChunkSize;
+
+  for (std::size_t stepId = 0; stepId < totalSteps; ++stepId) {
+    const std::size_t pipelineIdx = stepId % pipelineDepth;
+    const std::size_t dataBufferOffset = pipelineIdx * dataBufferSize;
+    const std::size_t stateOffset = pipelineIdx * chunksPerStep;
+    const std::size_t stepOffset = stepId * dataBufferSize;
+    const std::size_t stepBytes = (stepOffset + dataBufferSize <= nBytes)
+        ? dataBufferSize
+        : nBytes - stepOffset;
+    const std::size_t numMacroChunks =
+        (stepBytes + sendChunkSize - 1) / sendChunkSize;
+
+    group.for_each_item_contiguous(numMacroChunks, [&](uint32_t macroIdx) {
+      const std::size_t macroOffset = macroIdx * sendChunkSize;
+      const std::size_t macroBytes = (macroOffset + sendChunkSize <= stepBytes)
+          ? sendChunkSize
+          : stepBytes - macroOffset;
+      if (macroBytes == 0) {
+        return;
+      }
+
+      const std::size_t firstChunk = macroIdx * batchFactor;
+      const std::size_t numFineChunks =
+          (macroBytes + transportChunkSize - 1) / transportChunkSize;
+
+      // Phase 1: Wait for all fine-grained chunks to be ready for send
+      // (spin loops, no sync overhead). Poll sequentially since receiver
+      // releases them in order.
+      for (std::size_t i = 0; i < numFineChunks; ++i) {
+        sendStates[stateOffset + firstChunk + i].wait_ready_to_send(
+            group, timeout);
+      }
+
+      // Phase 2: Single large memcpy for the entire macro chunk (over NVLink)
+      memcpy_vectorized(
+          sendBuffer + dataBufferOffset + macroOffset,
+          src + stepOffset + macroOffset,
+          macroBytes,
+          group);
+
+      // Phase 3: Batched release of all fine-grained chunks.
+      // A single group.sync() fences the Phase 2 memcpy, then the leader
+      // performs N release-stores. This replaces N ready_to_recv() calls
+      // (each with its own group.sync()) with 1 sync + N stores,
+      // eliminating (N-1) redundant barriers.
+      group.sync();
+      if (group.is_leader()) {
+        for (std::size_t i = 0; i < numFineChunks; ++i) {
+          sendStates[stateOffset + firstChunk + i].release_to_recv(stepId, 0);
+        }
+      }
+    });
+  }
+#endif
+}
+
+__global__ void p2pAsymmetricSend(
+    P2pNvlTransportDevice p2p,
+    void* srcBuff,
+    std::size_t nBytes,
+    std::size_t sendChunkSize,
+    SyncScope groupScope,
+    Timeout timeout) {
+  timeout.start();
+  auto group = make_thread_group(groupScope);
+  asymmetric_send_impl(p2p, group, srcBuff, nBytes, sendChunkSize, timeout);
+}
+
+__global__ void p2pAsymmetricSendBidirectional(
+    P2pNvlTransportDevice p2p,
+    void* sendBuff,
+    void* recvBuff,
+    std::size_t nBytes,
+    std::size_t sendChunkSize,
+    SyncScope groupScope,
+    Timeout timeout) {
+  timeout.start();
+  auto group = make_thread_group(groupScope);
+
+  // Partition groups into 2: half for send, half for recv
+  auto [partition_id, subgroup] = group.partition_interleaved(2);
+  if (partition_id == 0) {
+    asymmetric_send_impl(
+        p2p, subgroup, sendBuff, nBytes, sendChunkSize, timeout);
+  } else {
+    p2p.recv(subgroup, recvBuff, nBytes, 0, timeout);
+  }
+}
+
+__global__ void p2pAsymmetricBothBidirectional(
+    P2pNvlTransportDevice p2p,
+    void* sendBuff,
+    void* recvBuff,
+    std::size_t nBytes,
+    std::size_t sendChunkSize,
+    std::size_t recvChunkSize,
+    SyncScope groupScope,
+    Timeout timeout) {
+  timeout.start();
+  auto group = make_thread_group(groupScope);
+
+  // Partition groups into 2: half for send, half for recv
+  auto [partition_id, subgroup] = group.partition_interleaved(2);
+  if (partition_id == 0) {
+    asymmetric_send_impl(
+        p2p, subgroup, sendBuff, nBytes, sendChunkSize, timeout);
+  } else {
+    asymmetric_recv_impl(
+        p2p, subgroup, recvBuff, nBytes, recvChunkSize, timeout);
+  }
+}
+
 __global__ void p2pSignalBenchKernel(
     P2pNvlTransportDevice p2p,
     int nSteps,

--- a/comms/pipes/benchmarks/BenchmarkKernel.cuh
+++ b/comms/pipes/benchmarks/BenchmarkKernel.cuh
@@ -99,4 +99,20 @@ __global__ void p2pRecvMultiple(
     DeviceSpan<std::size_t> chunkSizes,
     SyncScope groupScope = SyncScope::WARP);
 
+// Stream send kernel - uses SendStream::for_each_slot API
+__global__ void p2pStreamSend(
+    P2pNvlTransportDevice p2p,
+    void* srcBuff,
+    std::size_t nBytes,
+    SyncScope groupScope = SyncScope::WARP,
+    Timeout timeout = Timeout());
+
+// Stream recv kernel - uses RecvStream::for_each_ready_chunk API
+__global__ void p2pStreamRecv(
+    P2pNvlTransportDevice p2p,
+    void* dstBuff,
+    std::size_t nBytes,
+    SyncScope groupScope = SyncScope::WARP,
+    Timeout timeout = Timeout());
+
 } // namespace comms::pipes::benchmark

--- a/comms/pipes/benchmarks/BenchmarkKernel.cuh
+++ b/comms/pipes/benchmarks/BenchmarkKernel.cuh
@@ -65,6 +65,62 @@ __global__ void p2pBidirectional(
     SyncScope groupScope = SyncScope::WARP,
     Timeout timeout = Timeout());
 
+// Asymmetric recv - batches fine-grained ChunkStates into coarser recv chunks.
+// recvChunkSize must be an exact multiple of the transport's chunkSize.
+__global__ void p2pAsymmetricRecv(
+    P2pNvlTransportDevice p2p,
+    void* dstBuff,
+    std::size_t nBytes,
+    std::size_t recvChunkSize,
+    SyncScope groupScope = SyncScope::WARP,
+    Timeout timeout = Timeout());
+
+// Asymmetric bidirectional - normal send (transport chunkSize) + batched recv
+// (recvChunkSize). recvChunkSize must be an exact multiple of transport
+// chunkSize.
+__global__ void p2pAsymmetricBidirectional(
+    P2pNvlTransportDevice p2p,
+    void* sendBuff,
+    void* recvBuff,
+    std::size_t nBytes,
+    std::size_t recvChunkSize,
+    SyncScope groupScope = SyncScope::WARP,
+    Timeout timeout = Timeout());
+
+// Asymmetric send - batches fine-grained ChunkStates into coarser send chunks.
+// sendChunkSize must be an exact multiple of the transport's chunkSize.
+__global__ void p2pAsymmetricSend(
+    P2pNvlTransportDevice p2p,
+    void* srcBuff,
+    std::size_t nBytes,
+    std::size_t sendChunkSize,
+    SyncScope groupScope = SyncScope::WARP,
+    Timeout timeout = Timeout());
+
+// Asymmetric send bidirectional - batched send (sendChunkSize) + normal recv
+// (transport chunkSize). sendChunkSize must be an exact multiple of transport
+// chunkSize.
+__global__ void p2pAsymmetricSendBidirectional(
+    P2pNvlTransportDevice p2p,
+    void* sendBuff,
+    void* recvBuff,
+    std::size_t nBytes,
+    std::size_t sendChunkSize,
+    SyncScope groupScope = SyncScope::WARP,
+    Timeout timeout = Timeout());
+
+// Asymmetric both bidirectional - batched send (sendChunkSize) + batched recv
+// (recvChunkSize). Both must be exact multiples of transport chunkSize.
+__global__ void p2pAsymmetricBothBidirectional(
+    P2pNvlTransportDevice p2p,
+    void* sendBuff,
+    void* recvBuff,
+    std::size_t nBytes,
+    std::size_t sendChunkSize,
+    std::size_t recvChunkSize,
+    SyncScope groupScope = SyncScope::WARP,
+    Timeout timeout = Timeout());
+
 // Signal benchmark kernel - ping-pong signaling between two peers
 __global__ void p2pSignalBenchKernel(
     P2pNvlTransportDevice p2p,

--- a/comms/pipes/benchmarks/CopyKernelBench.cc
+++ b/comms/pipes/benchmarks/CopyKernelBench.cc
@@ -17,6 +17,59 @@ using meta::comms::DeviceBuffer;
 namespace comms::pipes::benchmark {
 
 //------------------------------------------------------------------------------
+// Shared Benchmark Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Compute benchmark metrics and populate folly counters.
+ * Shared by all copy kernel benchmark functions.
+ */
+static void populateBenchCounters(
+    folly::UserCounters& counters,
+    float totalTimeMs,
+    uint32_t iters,
+    int nRunsPerIter,
+    size_t nBytes,
+    int nBlocks,
+    int nThreads,
+    SyncScope groupScope,
+    int clusterSize,
+    int hbmMultiplier = 2) {
+  float avgTimeUs = (totalTimeMs / iters / nRunsPerIter) * 1000.0f;
+  float busBwGBps = (nBytes / 1e9f) / (avgTimeUs / 1e6f);
+  float hbmTrafficGBps = busBwGBps * hbmMultiplier;
+
+  size_t nGroups;
+  switch (groupScope) {
+    case SyncScope::BLOCK:
+      nGroups = nBlocks;
+      break;
+    case SyncScope::MULTIWARP:
+      nGroups = nBlocks * (nThreads / 128);
+      break;
+    case SyncScope::CLUSTER:
+      nGroups = nBlocks / clusterSize;
+      break;
+    case SyncScope::WARP:
+    default:
+      nGroups = nBlocks * (nThreads / 32);
+      break;
+  }
+  size_t chunkSize = nBytes / nGroups / 1024;
+
+  counters["deviceTimeUs"] =
+      folly::UserMetric(avgTimeUs, folly::UserMetric::Type::METRIC);
+  counters["busBwGBps"] =
+      folly::UserMetric(busBwGBps, folly::UserMetric::Type::METRIC);
+  counters["hbmTrafficGBps"] =
+      folly::UserMetric(hbmTrafficGBps, folly::UserMetric::Type::METRIC);
+  counters["nGroups"] =
+      folly::UserMetric(nGroups, folly::UserMetric::Type::METRIC);
+  counters["chunkSizeKB"] =
+      folly::UserMetric(chunkSize, folly::UserMetric::Type::METRIC);
+}
+
+//------------------------------------------------------------------------------
 // Benchmark Functions
 //------------------------------------------------------------------------------
 
@@ -78,35 +131,16 @@ static void p2pCopyKernel(
     totalTimeMs += bench.measureTime();
   }
 
-  float avgTimeUs = (totalTimeMs / iters / nRunsPerIter) * 1000.0f;
-  float busBwGBps = (nBytes / 1e9f) / (avgTimeUs / 1e6f);
-
-  size_t nGroups;
-  switch (groupScope) {
-    case SyncScope::BLOCK:
-      nGroups = nBlocks;
-      break;
-    case SyncScope::MULTIWARP:
-      nGroups = nBlocks * (nThreads / 128); // 4 warps per multiwarp
-      break;
-    case SyncScope::CLUSTER:
-      nGroups = nBlocks / clusterSize; // blocks per cluster
-      break;
-    case SyncScope::WARP:
-    default:
-      nGroups = nBlocks * (nThreads / 32);
-      break;
-  }
-  size_t chunkSize = nBytes / nGroups / 1024;
-
-  counters["deviceTimeUs"] =
-      folly::UserMetric(avgTimeUs, folly::UserMetric::Type::METRIC);
-  counters["busBwGBps"] =
-      folly::UserMetric(busBwGBps, folly::UserMetric::Type::METRIC);
-  counters["nGroups"] =
-      folly::UserMetric(nGroups, folly::UserMetric::Type::METRIC);
-  counters["chunkSizeKB"] =
-      folly::UserMetric(chunkSize, folly::UserMetric::Type::METRIC);
+  populateBenchCounters(
+      counters,
+      totalTimeMs,
+      iters,
+      nRunsPerIter,
+      nBytes,
+      nBlocks,
+      nThreads,
+      groupScope,
+      clusterSize);
 }
 
 /**
@@ -162,35 +196,16 @@ static void d2dCopyKernel(
     totalTimeMs += bench.measureTime();
   }
 
-  float avgTimeUs = (totalTimeMs / iters / nRunsPerIter) * 1000.0f;
-  float busBwGBps = (nBytes / 1e9f) / (avgTimeUs / 1e6f);
-
-  size_t nGroups;
-  switch (groupScope) {
-    case SyncScope::BLOCK:
-      nGroups = nBlocks;
-      break;
-    case SyncScope::MULTIWARP:
-      nGroups = nBlocks * (nThreads / 128); // 4 warps per multiwarp
-      break;
-    case SyncScope::CLUSTER:
-      nGroups = nBlocks / clusterSize; // blocks per cluster
-      break;
-    case SyncScope::WARP:
-    default:
-      nGroups = nBlocks * (nThreads / 32);
-      break;
-  }
-  size_t chunkSize = nBytes / nGroups / 1024;
-
-  counters["deviceTimeUs"] =
-      folly::UserMetric(avgTimeUs, folly::UserMetric::Type::METRIC);
-  counters["busBwGBps"] =
-      folly::UserMetric(busBwGBps, folly::UserMetric::Type::METRIC);
-  counters["nGroups"] =
-      folly::UserMetric(nGroups, folly::UserMetric::Type::METRIC);
-  counters["chunkSizeKB"] =
-      folly::UserMetric(chunkSize, folly::UserMetric::Type::METRIC);
+  populateBenchCounters(
+      counters,
+      totalTimeMs,
+      iters,
+      nRunsPerIter,
+      nBytes,
+      nBlocks,
+      nThreads,
+      groupScope,
+      clusterSize);
 }
 
 //------------------------------------------------------------------------------
@@ -286,6 +301,374 @@ REGISTER_COPY_BENCH_ALL_SIZES_CLUSTER(d2dCopyKernelCluster, cluster);
 
 // P2P (cross device) benchmarks - cluster groups (2 blocks per cluster)
 REGISTER_COPY_BENCH_ALL_SIZES_CLUSTER(p2pCopyKernelCluster, cluster);
+
+//------------------------------------------------------------------------------
+// Dual-Dest Benchmark Functions
+// Compare sequential 2x memcpy vs 1x dual-dest memcpy
+//------------------------------------------------------------------------------
+
+/**
+ * Shared implementation for dual-dest benchmarks. Allocates src, dst1, dst2
+ * on device 0 and launches the given kernel for timing.
+ *
+ * @param kernel Kernel function pointer (sequentialCopyKernel or
+ *               dualDestCopyKernel)
+ */
+static void d2dDualDestBenchImpl(
+    uint32_t iters,
+    size_t nBytes,
+    int nBlocks,
+    SyncScope groupScope,
+    folly::UserCounters& counters,
+    int clusterSize,
+    void* kernel,
+    int hbmMultiplier) {
+  const int nRunsPerIter = 50;
+
+  CHECK_EQ(cudaSetDevice(0), cudaSuccess);
+  CudaBenchBase bench;
+
+  DeviceBuffer srcBuffer(nBytes);
+  DeviceBuffer dst1Buffer(nBytes);
+  DeviceBuffer dst2Buffer(nBytes);
+
+  char* srcPtr = static_cast<char*>(srcBuffer.get());
+  char* dst1Ptr = static_cast<char*>(dst1Buffer.get());
+  char* dst2Ptr = static_cast<char*>(dst2Buffer.get());
+
+  float totalTimeMs = 0.0f;
+  const int nThreads = 256;
+  for (uint32_t i = 0; i < iters; ++i) {
+    bench.startTiming();
+
+    void* kernArgs[6] = {
+        (void*)&dst1Ptr,
+        (void*)&dst2Ptr,
+        (void*)&srcPtr,
+        (void*)&nBytes,
+        (void*)&nRunsPerIter,
+        (void*)&groupScope};
+    dim3 grid{static_cast<unsigned int>(nBlocks), 1, 1};
+    dim3 blocks{nThreads, 1, 1};
+
+    std::optional<dim3> clusterDimOpt =
+        (groupScope == SyncScope::CLUSTER && clusterSize > 1)
+        ? std::optional{dim3(clusterSize, 1, 1)}
+        : std::nullopt;
+    CHECK_EQ(
+        comms::common::launchKernel(
+            kernel, grid, blocks, kernArgs, bench.stream, clusterDimOpt),
+        cudaSuccess);
+
+    bench.stopTiming();
+    totalTimeMs += bench.measureTime();
+  }
+
+  populateBenchCounters(
+      counters,
+      totalTimeMs,
+      iters,
+      nRunsPerIter,
+      nBytes,
+      nBlocks,
+      nThreads,
+      groupScope,
+      clusterSize,
+      hbmMultiplier);
+}
+
+/**
+ * Benchmark sequential copy: two separate memcpy_vectorized calls
+ * (src->dst1 then src->dst2). HBM traffic: 2 reads + 2 writes = 4x nBytes.
+ */
+static void d2dSequentialCopy(
+    uint32_t iters,
+    size_t nBytes,
+    int nBlocks,
+    SyncScope groupScope,
+    folly::UserCounters& counters,
+    int clusterSize = 1) {
+  d2dDualDestBenchImpl(
+      iters,
+      nBytes,
+      nBlocks,
+      groupScope,
+      counters,
+      clusterSize,
+      (void*)sequentialCopyKernel,
+      /*hbmMultiplier=*/4);
+}
+
+/**
+ * Benchmark dual-dest copy: single memcpy_vectorized_multi_dest<2> call
+ * (src->dst1+dst2). HBM traffic: 1 read + 2 writes = 3x nBytes.
+ */
+static void d2dDualDestCopy(
+    uint32_t iters,
+    size_t nBytes,
+    int nBlocks,
+    SyncScope groupScope,
+    folly::UserCounters& counters,
+    int clusterSize = 1) {
+  d2dDualDestBenchImpl(
+      iters,
+      nBytes,
+      nBlocks,
+      groupScope,
+      counters,
+      clusterSize,
+      (void*)dualDestCopyKernel,
+      /*hbmMultiplier=*/3);
+}
+
+//------------------------------------------------------------------------------
+// Dual-Dest Cluster Benchmark Wrapper Functions
+//------------------------------------------------------------------------------
+
+static void d2dSequentialCopyCluster(
+    uint32_t iters,
+    size_t nBytes,
+    int nBlocks,
+    folly::UserCounters& counters) {
+  d2dSequentialCopy(
+      iters,
+      nBytes,
+      nBlocks,
+      SyncScope::CLUSTER,
+      counters,
+      comms::common::kDefaultClusterSize);
+}
+
+static void d2dDualDestCopyCluster(
+    uint32_t iters,
+    size_t nBytes,
+    int nBlocks,
+    folly::UserCounters& counters) {
+  d2dDualDestCopy(
+      iters,
+      nBytes,
+      nBlocks,
+      SyncScope::CLUSTER,
+      counters,
+      comms::common::kDefaultClusterSize);
+}
+
+//------------------------------------------------------------------------------
+// Dual-Dest Benchmark Registration
+//------------------------------------------------------------------------------
+
+// D2D sequential copy benchmarks - warp groups
+REGISTER_COPY_BENCH_ALL_SIZES(d2dSequentialCopy, SyncScope::WARP, warp);
+
+// D2D dual-dest copy benchmarks - warp groups
+REGISTER_COPY_BENCH_ALL_SIZES(d2dDualDestCopy, SyncScope::WARP, warp);
+
+// D2D sequential copy benchmarks - multiwarp groups
+REGISTER_COPY_BENCH_ALL_SIZES(
+    d2dSequentialCopy,
+    SyncScope::MULTIWARP,
+    multiwarp);
+
+// D2D dual-dest copy benchmarks - multiwarp groups
+REGISTER_COPY_BENCH_ALL_SIZES(d2dDualDestCopy, SyncScope::MULTIWARP, multiwarp);
+
+// D2D sequential copy benchmarks - block groups
+REGISTER_COPY_BENCH_ALL_SIZES(d2dSequentialCopy, SyncScope::BLOCK, block);
+
+// D2D dual-dest copy benchmarks - block groups
+REGISTER_COPY_BENCH_ALL_SIZES(d2dDualDestCopy, SyncScope::BLOCK, block);
+
+// D2D sequential copy benchmarks - cluster groups
+REGISTER_COPY_BENCH_ALL_SIZES_CLUSTER(d2dSequentialCopyCluster, cluster);
+
+// D2D dual-dest copy benchmarks - cluster groups
+REGISTER_COPY_BENCH_ALL_SIZES_CLUSTER(d2dDualDestCopyCluster, cluster);
+
+//------------------------------------------------------------------------------
+// Tri-Dest Benchmark Functions
+// Compare sequential 3x memcpy vs 1x tri-dest memcpy
+//------------------------------------------------------------------------------
+
+/**
+ * Shared implementation for tri-dest benchmarks. Allocates src, dst1, dst2,
+ * dst3 on device 0 and launches the given kernel for timing.
+ *
+ * @param kernel Kernel function pointer (sequentialTriCopyKernel or
+ *               triDestCopyKernel)
+ */
+static void d2dTriDestBenchImpl(
+    uint32_t iters,
+    size_t nBytes,
+    int nBlocks,
+    SyncScope groupScope,
+    folly::UserCounters& counters,
+    int clusterSize,
+    void* kernel,
+    int hbmMultiplier) {
+  const int nRunsPerIter = 50;
+
+  CHECK_EQ(cudaSetDevice(0), cudaSuccess);
+  CudaBenchBase bench;
+
+  DeviceBuffer srcBuffer(nBytes);
+  DeviceBuffer dst1Buffer(nBytes);
+  DeviceBuffer dst2Buffer(nBytes);
+  DeviceBuffer dst3Buffer(nBytes);
+
+  char* srcPtr = static_cast<char*>(srcBuffer.get());
+  char* dst1Ptr = static_cast<char*>(dst1Buffer.get());
+  char* dst2Ptr = static_cast<char*>(dst2Buffer.get());
+  char* dst3Ptr = static_cast<char*>(dst3Buffer.get());
+
+  float totalTimeMs = 0.0f;
+  const int nThreads = 256;
+  for (uint32_t i = 0; i < iters; ++i) {
+    bench.startTiming();
+
+    void* kernArgs[7] = {
+        (void*)&dst1Ptr,
+        (void*)&dst2Ptr,
+        (void*)&dst3Ptr,
+        (void*)&srcPtr,
+        (void*)&nBytes,
+        (void*)&nRunsPerIter,
+        (void*)&groupScope};
+    dim3 grid{static_cast<unsigned int>(nBlocks), 1, 1};
+    dim3 blocks{nThreads, 1, 1};
+
+    std::optional<dim3> clusterDimOpt =
+        (groupScope == SyncScope::CLUSTER && clusterSize > 1)
+        ? std::optional{dim3(clusterSize, 1, 1)}
+        : std::nullopt;
+    CHECK_EQ(
+        comms::common::launchKernel(
+            kernel, grid, blocks, kernArgs, bench.stream, clusterDimOpt),
+        cudaSuccess);
+
+    bench.stopTiming();
+    totalTimeMs += bench.measureTime();
+  }
+
+  populateBenchCounters(
+      counters,
+      totalTimeMs,
+      iters,
+      nRunsPerIter,
+      nBytes,
+      nBlocks,
+      nThreads,
+      groupScope,
+      clusterSize,
+      hbmMultiplier);
+}
+
+/**
+ * Benchmark sequential tri-copy: three separate memcpy_vectorized calls
+ * (src->dst1 then src->dst2 then src->dst3). HBM traffic: 3 reads + 3 writes =
+ * 6x nBytes.
+ */
+static void d2dSequentialTriCopy(
+    uint32_t iters,
+    size_t nBytes,
+    int nBlocks,
+    SyncScope groupScope,
+    folly::UserCounters& counters,
+    int clusterSize = 1) {
+  d2dTriDestBenchImpl(
+      iters,
+      nBytes,
+      nBlocks,
+      groupScope,
+      counters,
+      clusterSize,
+      (void*)sequentialTriCopyKernel,
+      /*hbmMultiplier=*/6);
+}
+
+/**
+ * Benchmark tri-dest copy: single memcpy_vectorized_multi_dest<3> call
+ * (src->dst1+dst2+dst3). HBM traffic: 1 read + 3 writes = 4x nBytes.
+ */
+static void d2dTriDestCopy(
+    uint32_t iters,
+    size_t nBytes,
+    int nBlocks,
+    SyncScope groupScope,
+    folly::UserCounters& counters,
+    int clusterSize = 1) {
+  d2dTriDestBenchImpl(
+      iters,
+      nBytes,
+      nBlocks,
+      groupScope,
+      counters,
+      clusterSize,
+      (void*)triDestCopyKernel,
+      /*hbmMultiplier=*/4);
+}
+
+//------------------------------------------------------------------------------
+// Tri-Dest Cluster Benchmark Wrapper Functions
+//------------------------------------------------------------------------------
+
+static void d2dSequentialTriCopyCluster(
+    uint32_t iters,
+    size_t nBytes,
+    int nBlocks,
+    folly::UserCounters& counters) {
+  d2dSequentialTriCopy(
+      iters,
+      nBytes,
+      nBlocks,
+      SyncScope::CLUSTER,
+      counters,
+      comms::common::kDefaultClusterSize);
+}
+
+static void d2dTriDestCopyCluster(
+    uint32_t iters,
+    size_t nBytes,
+    int nBlocks,
+    folly::UserCounters& counters) {
+  d2dTriDestCopy(
+      iters,
+      nBytes,
+      nBlocks,
+      SyncScope::CLUSTER,
+      counters,
+      comms::common::kDefaultClusterSize);
+}
+
+//------------------------------------------------------------------------------
+// Tri-Dest Benchmark Registration
+//------------------------------------------------------------------------------
+
+// D2D sequential tri-copy benchmarks - warp groups
+REGISTER_COPY_BENCH_ALL_SIZES(d2dSequentialTriCopy, SyncScope::WARP, warp);
+
+// D2D tri-dest copy benchmarks - warp groups
+REGISTER_COPY_BENCH_ALL_SIZES(d2dTriDestCopy, SyncScope::WARP, warp);
+
+// D2D sequential tri-copy benchmarks - multiwarp groups
+REGISTER_COPY_BENCH_ALL_SIZES(
+    d2dSequentialTriCopy,
+    SyncScope::MULTIWARP,
+    multiwarp);
+
+// D2D tri-dest copy benchmarks - multiwarp groups
+REGISTER_COPY_BENCH_ALL_SIZES(d2dTriDestCopy, SyncScope::MULTIWARP, multiwarp);
+
+// D2D sequential tri-copy benchmarks - block groups
+REGISTER_COPY_BENCH_ALL_SIZES(d2dSequentialTriCopy, SyncScope::BLOCK, block);
+
+// D2D tri-dest copy benchmarks - block groups
+REGISTER_COPY_BENCH_ALL_SIZES(d2dTriDestCopy, SyncScope::BLOCK, block);
+
+// D2D sequential tri-copy benchmarks - cluster groups
+REGISTER_COPY_BENCH_ALL_SIZES_CLUSTER(d2dSequentialTriCopyCluster, cluster);
+
+// D2D tri-dest copy benchmarks - cluster groups
+REGISTER_COPY_BENCH_ALL_SIZES_CLUSTER(d2dTriDestCopyCluster, cluster);
 
 } // namespace comms::pipes::benchmark
 

--- a/comms/pipes/benchmarks/CopyKernelBench.cu
+++ b/comms/pipes/benchmarks/CopyKernelBench.cu
@@ -4,6 +4,25 @@
 
 namespace comms::pipes::benchmark {
 
+struct ChunkPartition {
+  std::size_t start_offset;
+  std::size_t chunk_bytes;
+};
+
+__device__ __forceinline__ ChunkPartition
+compute_chunk_partition(std::size_t nBytes, const ThreadGroup& group) {
+  const std::size_t bytes_per_group =
+      (nBytes + group.total_groups - 1) / group.total_groups;
+  const std::size_t start_offset =
+      static_cast<std::size_t>(group.group_id) * bytes_per_group;
+  const std::size_t end_offset = (start_offset + bytes_per_group < nBytes)
+      ? start_offset + bytes_per_group
+      : nBytes;
+  const std::size_t chunk_bytes =
+      (start_offset < nBytes) ? end_offset - start_offset : 0;
+  return {start_offset, chunk_bytes};
+}
+
 __global__ void copyKernel(
     char* dst,
     const char* src,
@@ -11,21 +30,108 @@ __global__ void copyKernel(
     int nRuns,
     SyncScope groupScope) {
   auto group = make_thread_group(groupScope);
-
-  const std::size_t bytes_per_group =
-      (nBytes + group.total_groups - 1) / group.total_groups;
-  const std::size_t start_offset =
-      static_cast<std::size_t>(group.group_id) * bytes_per_group;
-
-  const std::size_t end_offset = (start_offset + bytes_per_group < nBytes)
-      ? start_offset + bytes_per_group
-      : nBytes;
-  const std::size_t chunk_bytes =
-      (start_offset < nBytes) ? end_offset - start_offset : 0;
+  ChunkPartition chunk = compute_chunk_partition(nBytes, group);
 
   for (int run = 0; run < nRuns; ++run) {
     memcpy_vectorized(
-        dst + start_offset, src + start_offset, chunk_bytes, group);
+        dst + chunk.start_offset,
+        src + chunk.start_offset,
+        chunk.chunk_bytes,
+        group);
+  }
+}
+
+__global__ void sequentialCopyKernel(
+    char* dst1,
+    char* dst2,
+    const char* src,
+    std::size_t nBytes,
+    int nRuns,
+    SyncScope groupScope) {
+  auto group = make_thread_group(groupScope);
+  ChunkPartition chunk = compute_chunk_partition(nBytes, group);
+
+  for (int run = 0; run < nRuns; ++run) {
+    memcpy_vectorized(
+        dst1 + chunk.start_offset,
+        src + chunk.start_offset,
+        chunk.chunk_bytes,
+        group);
+    memcpy_vectorized(
+        dst2 + chunk.start_offset,
+        src + chunk.start_offset,
+        chunk.chunk_bytes,
+        group);
+  }
+}
+
+__global__ void dualDestCopyKernel(
+    char* dst1,
+    char* dst2,
+    const char* src,
+    std::size_t nBytes,
+    int nRuns,
+    SyncScope groupScope) {
+  auto group = make_thread_group(groupScope);
+  ChunkPartition chunk = compute_chunk_partition(nBytes, group);
+
+  for (int run = 0; run < nRuns; ++run) {
+    std::array<char*, 2> dsts = {
+        {dst1 + chunk.start_offset, dst2 + chunk.start_offset}};
+    memcpy_vectorized_multi_dest<2>(
+        dsts, src + chunk.start_offset, chunk.chunk_bytes, group);
+  }
+}
+
+__global__ void sequentialTriCopyKernel(
+    char* dst1,
+    char* dst2,
+    char* dst3,
+    const char* src,
+    std::size_t nBytes,
+    int nRuns,
+    SyncScope groupScope) {
+  auto group = make_thread_group(groupScope);
+  ChunkPartition chunk = compute_chunk_partition(nBytes, group);
+
+  for (int run = 0; run < nRuns; ++run) {
+    memcpy_vectorized(
+        dst1 + chunk.start_offset,
+        src + chunk.start_offset,
+        chunk.chunk_bytes,
+        group);
+    memcpy_vectorized(
+        dst2 + chunk.start_offset,
+        src + chunk.start_offset,
+        chunk.chunk_bytes,
+        group);
+    memcpy_vectorized(
+        dst3 + chunk.start_offset,
+        src + chunk.start_offset,
+        chunk.chunk_bytes,
+        group);
+  }
+}
+
+__global__ void triDestCopyKernel(
+    char* dst1,
+    char* dst2,
+    char* dst3,
+    const char* src,
+    std::size_t nBytes,
+    int nRuns,
+    SyncScope groupScope) {
+  auto group = make_thread_group(groupScope);
+  ChunkPartition chunk = compute_chunk_partition(nBytes, group);
+
+  std::array<char*, 3> dsts = {
+      {dst1 + chunk.start_offset,
+       dst2 + chunk.start_offset,
+       dst3 + chunk.start_offset}};
+
+  for (int run = 0; run < nRuns; ++run) {
+    memcpy_vectorized_multi_dest<3>(
+        dsts, src + chunk.start_offset, chunk.chunk_bytes, group);
   }
 }
 

--- a/comms/pipes/benchmarks/CopyKernelBench.cuh
+++ b/comms/pipes/benchmarks/CopyKernelBench.cuh
@@ -19,4 +19,38 @@ __global__ void copyKernel(
     int nRuns,
     SyncScope groupScope);
 
+__global__ void sequentialCopyKernel(
+    char* dst1,
+    char* dst2,
+    const char* src,
+    std::size_t nBytes,
+    int nRuns,
+    SyncScope groupScope);
+
+__global__ void dualDestCopyKernel(
+    char* dst1,
+    char* dst2,
+    const char* src,
+    std::size_t nBytes,
+    int nRuns,
+    SyncScope groupScope);
+
+__global__ void sequentialTriCopyKernel(
+    char* dst1,
+    char* dst2,
+    char* dst3,
+    const char* src,
+    std::size_t nBytes,
+    int nRuns,
+    SyncScope groupScope);
+
+__global__ void triDestCopyKernel(
+    char* dst1,
+    char* dst2,
+    char* dst3,
+    const char* src,
+    std::size_t nBytes,
+    int nRuns,
+    SyncScope groupScope);
+
 } // namespace comms::pipes::benchmark

--- a/comms/pipes/benchmarks/P2pNvlAsymmetricChunkBenchmark.cc
+++ b/comms/pipes/benchmarks/P2pNvlAsymmetricChunkBenchmark.cc
@@ -1,0 +1,915 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <folly/init/Init.h>
+#include <folly/logging/xlog.h>
+#include <nccl.h>
+
+#include "comms/common/CudaWrap.h"
+#include "comms/pipes/MultiPeerNvlTransport.h"
+#include "comms/pipes/benchmarks/BenchmarkKernel.cuh"
+#include "comms/pipes/benchmarks/BenchmarkMacros.h"
+#include "comms/pipes/benchmarks/P2pNvlBenchmarkUtils.h"
+#include "comms/testinfra/BenchmarkTestFixture.h"
+#include "comms/testinfra/mpi/MpiTestUtils.h"
+#include "comms/utils/CudaRAII.h"
+
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <vector>
+
+using meta::comms::CudaEvent;
+using meta::comms::DeviceBuffer;
+
+namespace comms::pipes::benchmark {
+
+class P2pAsymmetricChunkBenchmarkFixture
+    : public meta::comms::BenchmarkTestFixture {
+ protected:
+  void SetUp() override {
+    BenchmarkTestFixture::SetUp();
+    CUDA_CHECK_VOID(cudaSetDevice(localRank));
+
+    // Initialize NCCL
+    NCCL_CHECK_VOID(
+        ncclCommInitRank(&ncclComm_, worldSize, getNCCLId(), globalRank));
+    CUDA_CHECK_VOID(cudaStreamCreate(&stream_));
+  }
+
+  void TearDown() override {
+    NCCL_CHECK_VOID(ncclCommDestroy(ncclComm_));
+    CUDA_CHECK_VOID(cudaStreamDestroy(stream_));
+    BenchmarkTestFixture::TearDown();
+  }
+
+  ncclUniqueId getNCCLId() {
+    ncclUniqueId id;
+    if (globalRank == 0) {
+      ncclResult_t res = ncclGetUniqueId(&id);
+      if (res != ncclSuccess) {
+        XLOGF(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
+        std::abort();
+      }
+    }
+
+    std::vector<ncclUniqueId> allIds(worldSize);
+    allIds[globalRank] = id;
+    auto result =
+        bootstrap
+            ->allGather(
+                allIds.data(), sizeof(ncclUniqueId), globalRank, worldSize)
+            .get();
+    if (result != 0) {
+      XLOG(ERR) << "Bootstrap allGather for NCCL ID failed";
+      std::abort();
+    }
+    id = allIds[0];
+    return id;
+  }
+
+  // NCCL unidirectional benchmark
+  float runNcclBenchmark(const BenchmarkConfig& config, float& timeUs) {
+    XLOGF(DBG1, "=== Running NCCL benchmark: {} ===", config.name);
+
+    DeviceBuffer sendBuff(config.nBytes);
+    DeviceBuffer recvBuff(config.nBytes);
+
+    if (globalRank == 0) {
+      CUDA_CHECK(cudaMemset(sendBuff.get(), 1, config.nBytes));
+    }
+    if (globalRank == 1) {
+      CUDA_CHECK(cudaMemset(recvBuff.get(), 0, config.nBytes));
+    }
+
+    CudaEvent start, stop;
+
+    // Warmup
+    bootstrap->barrierAll();
+    for (int i = 0; i < kWarmupIters; i++) {
+      if (globalRank == 0) {
+        NCCL_CHECK(ncclSend(
+            sendBuff.get(), config.nBytes, ncclChar, 1, ncclComm_, stream_));
+      } else if (globalRank == 1) {
+        NCCL_CHECK(ncclRecv(
+            recvBuff.get(), config.nBytes, ncclChar, 0, ncclComm_, stream_));
+      }
+      CUDA_CHECK(cudaStreamSynchronize(stream_));
+    }
+    bootstrap->barrierAll();
+
+    // Benchmark
+    CUDA_CHECK(cudaEventRecord(start.get(), stream_));
+    for (int i = 0; i < kBenchmarkIters; i++) {
+      if (globalRank == 0) {
+        NCCL_CHECK(ncclSend(
+            sendBuff.get(), config.nBytes, ncclChar, 1, ncclComm_, stream_));
+      } else if (globalRank == 1) {
+        NCCL_CHECK(ncclRecv(
+            recvBuff.get(), config.nBytes, ncclChar, 0, ncclComm_, stream_));
+      }
+    }
+    CUDA_CHECK(cudaEventRecord(stop.get(), stream_));
+    CUDA_CHECK(cudaStreamSynchronize(stream_));
+
+    float totalTime_ms = 0.0f;
+    CUDA_CHECK(cudaEventElapsedTime(&totalTime_ms, start.get(), stop.get()));
+    float avgTime_ms = totalTime_ms / kBenchmarkIters;
+    timeUs = avgTime_ms * 1000.0f;
+    float bandwidth_GBps = (config.nBytes / 1e9f) / (avgTime_ms / 1000.0f);
+
+    bootstrap->barrierAll();
+    return bandwidth_GBps;
+  }
+
+  // NCCL bidirectional benchmark
+  float runNcclBidirectionalBenchmark(
+      const BenchmarkConfig& config,
+      float& timeUs) {
+    XLOGF(
+        DBG1,
+        "Rank {}: Starting NCCL bidirectional benchmark: {}",
+        globalRank,
+        config.name);
+
+    DeviceBuffer sendBuff(config.nBytes);
+    DeviceBuffer recvBuff(config.nBytes);
+
+    CUDA_CHECK(cudaMemset(sendBuff.get(), globalRank, config.nBytes));
+    CUDA_CHECK(cudaMemset(recvBuff.get(), 0, config.nBytes));
+
+    int peerRank = (globalRank == 0) ? 1 : 0;
+    CudaEvent start, stop;
+
+    // Warmup
+    bootstrap->barrierAll();
+    for (int i = 0; i < kWarmupIters; i++) {
+      NCCL_CHECK(ncclGroupStart());
+      NCCL_CHECK(ncclSend(
+          sendBuff.get(),
+          config.nBytes,
+          ncclChar,
+          peerRank,
+          ncclComm_,
+          stream_));
+      NCCL_CHECK(ncclRecv(
+          recvBuff.get(),
+          config.nBytes,
+          ncclChar,
+          peerRank,
+          ncclComm_,
+          stream_));
+      NCCL_CHECK(ncclGroupEnd());
+      CUDA_CHECK(cudaStreamSynchronize(stream_));
+    }
+
+    // Benchmark
+    CUDA_CHECK(cudaEventRecord(start.get(), stream_));
+    for (int i = 0; i < kBenchmarkIters; i++) {
+      NCCL_CHECK(ncclGroupStart());
+      NCCL_CHECK(ncclSend(
+          sendBuff.get(),
+          config.nBytes,
+          ncclChar,
+          peerRank,
+          ncclComm_,
+          stream_));
+      NCCL_CHECK(ncclRecv(
+          recvBuff.get(),
+          config.nBytes,
+          ncclChar,
+          peerRank,
+          ncclComm_,
+          stream_));
+      NCCL_CHECK(ncclGroupEnd());
+    }
+    CUDA_CHECK(cudaEventRecord(stop.get(), stream_));
+    CUDA_CHECK(cudaStreamSynchronize(stream_));
+
+    float totalTime_ms = 0.0f;
+    CUDA_CHECK(cudaEventElapsedTime(&totalTime_ms, start.get(), stop.get()));
+    float avgTime_ms = totalTime_ms / kBenchmarkIters;
+    timeUs = avgTime_ms * 1000.0f;
+    float bandwidth_GBps =
+        (2.0f * config.nBytes / 1e9f) / (avgTime_ms / 1000.0f);
+
+    bootstrap->barrierAll();
+    return bandwidth_GBps;
+  }
+
+  /**
+   * Unidirectional P2P benchmark helper.
+   *
+   * Runs warmup iterations (with inner barrier) followed by timed benchmark
+   * iterations. The caller is responsible for allocating buffers and the
+   * stream, and for constructing the correct kernelFunc and args array.
+   *
+   * @param config Benchmark configuration (used for grid/block dims, nBytes).
+   * @param kernelFunc Pointer to the __global__ kernel to launch.
+   * @param args Kernel argument array (pointers to caller-owned locals).
+   * @param stream CUDA stream to launch on.
+   * @param timeUs Output: average iteration time in microseconds.
+   * @return Unidirectional bandwidth in GB/s.
+   */
+  float runUnidirectionalP2pBenchmark(
+      const BenchmarkConfig& config,
+      void* kernelFunc,
+      void** args,
+      cudaStream_t stream,
+      float& timeUs) {
+    XLOGF(DBG1, "=== Running P2P benchmark: {} ===", config.name);
+
+    dim3 gridDim(config.numBlocks);
+    dim3 blockDim(config.numThreads);
+
+    CudaEvent start, stop;
+
+    // Warmup
+    bootstrap->barrierAll();
+    for (int i = 0; i < kWarmupIters; i++) {
+      bootstrap->barrierAll();
+      CUDA_CHECK(
+          cudaLaunchKernel(kernelFunc, gridDim, blockDim, args, 0, stream));
+      CUDA_CHECK(cudaStreamSynchronize(stream));
+    }
+    bootstrap->barrierAll();
+
+    // Benchmark
+    CUDA_CHECK(cudaEventRecord(start.get(), stream));
+    for (int i = 0; i < kBenchmarkIters; i++) {
+      CUDA_CHECK(
+          cudaLaunchKernel(kernelFunc, gridDim, blockDim, args, 0, stream));
+    }
+    CUDA_CHECK(cudaEventRecord(stop.get(), stream));
+    CUDA_CHECK(cudaStreamSynchronize(stream));
+
+    float totalTime_ms = 0.0f;
+    CUDA_CHECK(cudaEventElapsedTime(&totalTime_ms, start.get(), stop.get()));
+    float avgTime_ms = totalTime_ms / kBenchmarkIters;
+    timeUs = avgTime_ms * 1000.0f;
+    float bandwidth_GBps = (config.nBytes / 1e9f) / (avgTime_ms / 1000.0f);
+
+    bootstrap->barrierAll();
+    return bandwidth_GBps;
+  }
+
+  /**
+   * Bidirectional P2P benchmark helper.
+   *
+   * Runs warmup iterations followed by timed benchmark iterations using
+   * comms::common::launchKernel for optional cluster launch support.
+   * The caller is responsible for allocating buffers and constructing the
+   * correct kernelFunc and args array.
+   *
+   * @param config Benchmark configuration (used for grid/block dims, nBytes,
+   *               spreadClusterLaunch).
+   * @param kernelFunc Pointer to the __global__ kernel to launch.
+   * @param args Kernel argument array (pointers to caller-owned locals).
+   * @param timeUs Output: average iteration time in microseconds.
+   * @return Bidirectional bandwidth in GB/s (2x data volume).
+   */
+  float runBidirectionalP2pBenchmark(
+      const BenchmarkConfig& config,
+      void* kernelFunc,
+      void** args,
+      float& timeUs) {
+    XLOGF(
+        DBG1,
+        "Rank {}: Starting P2P bidirectional benchmark: {}",
+        globalRank,
+        config.name);
+
+    dim3 gridDim(config.numBlocks);
+    dim3 blockDim(config.numThreads);
+
+    CudaEvent start, stop;
+
+    dim3 defaultClusterDim(comms::common::kDefaultClusterSize, 1, 1);
+    std::optional<dim3> clusterDimOpt = config.spreadClusterLaunch
+        ? std::optional{defaultClusterDim}
+        : std::nullopt;
+
+    // Warmup
+    bootstrap->barrierAll();
+    for (int i = 0; i < kWarmupIters; i++) {
+      CUDA_CHECK(
+          comms::common::launchKernel(
+              kernelFunc, gridDim, blockDim, args, nullptr, clusterDimOpt));
+      CUDA_CHECK(cudaDeviceSynchronize());
+    }
+    bootstrap->barrierAll();
+
+    // Benchmark
+    CUDA_CHECK(cudaEventRecord(start.get()));
+    for (int i = 0; i < kBenchmarkIters; i++) {
+      CUDA_CHECK(
+          comms::common::launchKernel(
+              kernelFunc, gridDim, blockDim, args, nullptr, clusterDimOpt));
+    }
+    CUDA_CHECK(cudaEventRecord(stop.get()));
+    CUDA_CHECK(cudaDeviceSynchronize());
+
+    float totalTime_ms = 0.0f;
+    CUDA_CHECK(cudaEventElapsedTime(&totalTime_ms, start.get(), stop.get()));
+    float avgTime_ms = totalTime_ms / kBenchmarkIters;
+    timeUs = avgTime_ms * 1000.0f;
+    float bandwidth_GBps =
+        (2.0f * config.nBytes / 1e9f) / (avgTime_ms / 1000.0f);
+
+    bootstrap->barrierAll();
+    return bandwidth_GBps;
+  }
+
+  // Correctness check for asymmetric configs
+  void runP2pCorrectnessCheck(
+      comms::pipes::P2pNvlTransportDevice& p2p,
+      const BenchmarkConfig& config) {
+    XLOGF(DBG1, "=== Running correctness check: {} ===", config.name);
+
+    DeviceBuffer sendBuff(config.nBytes);
+    DeviceBuffer recvBuff(config.nBytes);
+
+    // Sender fills with known pattern, receiver zeros
+    if (globalRank == 0) {
+      CUDA_CHECK_VOID(cudaMemset(sendBuff.get(), 0xAB, config.nBytes));
+    } else {
+      CUDA_CHECK_VOID(cudaMemset(recvBuff.get(), 0, config.nBytes));
+    }
+
+    dim3 gridDim(config.numBlocks);
+    dim3 blockDim(config.numThreads);
+
+    cudaStream_t sendStream, recvStream;
+    CUDA_CHECK_VOID(cudaStreamCreate(&sendStream));
+    CUDA_CHECK_VOID(cudaStreamCreate(&recvStream));
+
+    std::size_t nBytes = config.nBytes;
+    SyncScope groupScope = config.groupScope;
+    Timeout timeout;
+    bool isSend = (globalRank == 0);
+
+    void* devicePtr = isSend ? sendBuff.get() : recvBuff.get();
+
+    // Determine which kernel to use based on config
+    void* kernelFunc = nullptr;
+    void* symSendArgs[] = {&p2p, &devicePtr, &nBytes, &groupScope, &timeout};
+    std::size_t sendChunkSize = config.sendChunkSize.value_or(0);
+    void* asymSendArgs[] = {
+        &p2p, &devicePtr, &nBytes, &sendChunkSize, &groupScope, &timeout};
+    std::size_t recvChunkSize = config.recvChunkSize.value_or(0);
+    void* asymRecvArgs[] = {
+        &p2p, &devicePtr, &nBytes, &recvChunkSize, &groupScope, &timeout};
+
+    void** args = nullptr;
+    if (isSend) {
+      if (config.sendChunkSize.has_value()) {
+        kernelFunc = (void*)comms::pipes::benchmark::p2pAsymmetricSend;
+        args = asymSendArgs;
+      } else {
+        kernelFunc = (void*)comms::pipes::benchmark::p2pSend;
+        args = symSendArgs;
+      }
+    } else {
+      if (config.recvChunkSize.has_value()) {
+        kernelFunc = (void*)comms::pipes::benchmark::p2pAsymmetricRecv;
+        args = asymRecvArgs;
+      } else {
+        kernelFunc = (void*)comms::pipes::benchmark::p2pRecv;
+        args = symSendArgs; // same layout: (p2p, buf, nBytes, scope, timeout)
+      }
+    }
+    cudaStream_t stream = isSend ? sendStream : recvStream;
+
+    // Run one transfer
+    bootstrap->barrierAll();
+    CUDA_CHECK_VOID(
+        cudaLaunchKernel(kernelFunc, gridDim, blockDim, args, 0, stream));
+    CUDA_CHECK_VOID(cudaStreamSynchronize(stream));
+    bootstrap->barrierAll();
+
+    // Receiver verifies data
+    if (globalRank == 1) {
+      std::size_t checkSize = std::min(config.nBytes, (std::size_t)4096);
+      std::vector<char> hostBuf(checkSize);
+      CUDA_CHECK_VOID(cudaMemcpy(
+          hostBuf.data(), recvBuff.get(), checkSize, cudaMemcpyDeviceToHost));
+      for (size_t i = 0; i < checkSize; ++i) {
+        EXPECT_EQ(static_cast<unsigned char>(hostBuf[i]), 0xAB)
+            << "Data mismatch at byte " << i;
+      }
+      XLOG(INFO) << "Correctness check passed for " << config.name << " ("
+                 << checkSize << " bytes verified)";
+    }
+
+    CUDA_CHECK_VOID(cudaStreamDestroy(sendStream));
+    CUDA_CHECK_VOID(cudaStreamDestroy(recvStream));
+    bootstrap->barrierAll();
+  }
+
+  void printResultsTable(
+      const std::vector<BenchmarkResult>& results,
+      const std::string& title) {
+    if (globalRank != 0) {
+      return;
+    }
+
+    std::stringstream ss;
+    ss << "\n";
+    ss << "==========================================================================================================================================================\n";
+    ss << "                              " << title << "\n";
+    ss << "==========================================================================================================================================================\n";
+    ss << std::left << std::setw(28) << "Test Name" << std::right
+       << std::setw(10) << "Msg Size" << std::right << std::setw(12)
+       << "Staging" << std::right << std::setw(5) << "PD" << std::right
+       << std::setw(10) << "Snd Chunk" << std::right << std::setw(10)
+       << "Rcv Chunk" << std::right << std::setw(7) << "Blocks" << std::right
+       << std::setw(8) << "Threads" << std::right << std::setw(11) << "NCCL BW"
+       << std::right << std::setw(11) << "P2P BW" << std::right << std::setw(9)
+       << "Speedup" << std::right << std::setw(11) << "NCCL Lat" << std::right
+       << std::setw(11) << "P2P Lat" << std::right << std::setw(11)
+       << "Lat Reduc\n";
+    ss << std::left << std::setw(28) << "" << std::right << std::setw(10) << ""
+       << std::right << std::setw(12) << "" << std::right << std::setw(5) << ""
+       << std::right << std::setw(10) << "" << std::right << std::setw(10) << ""
+       << std::right << std::setw(7) << "" << std::right << std::setw(8) << ""
+       << std::right << std::setw(11) << "(GB/s)" << std::right << std::setw(11)
+       << "(GB/s)" << std::right << std::setw(9) << "P2P/NCCL" << std::right
+       << std::setw(11) << "(us)" << std::right << std::setw(11) << "(us)"
+       << std::right << std::setw(11) << "(us)\n";
+    ss << "----------------------------------------------------------------------------------------------------------------------------------------------------------\n";
+
+    for (const auto& r : results) {
+      std::string msgSize = formatSize(r.messageSize);
+      std::string stagingSize = formatSize(r.stagingBufferSize);
+      std::string sendChunkStr = r.sendChunkSize.has_value()
+          ? formatSize(r.sendChunkSize.value())
+          : formatSize(r.chunkSize);
+      std::string recvChunkStr = r.recvChunkSize.has_value()
+          ? formatSize(r.recvChunkSize.value())
+          : formatSize(r.chunkSize);
+      float latencyReduction = r.ncclTime - r.p2pTime;
+
+      ss << std::left << std::setw(28) << r.testName << std::right
+         << std::setw(10) << msgSize << std::right << std::setw(12)
+         << stagingSize << std::right << std::setw(5) << r.pipelineDepth
+         << std::right << std::setw(10) << sendChunkStr << std::right
+         << std::setw(10) << recvChunkStr << std::right << std::setw(7)
+         << r.numBlocks << std::right << std::setw(8) << r.numThreads
+         << std::right << std::setw(11) << std::fixed << std::setprecision(2)
+         << r.ncclBandwidth << std::right << std::setw(11) << std::fixed
+         << std::setprecision(2) << r.p2pBandwidth << std::right << std::setw(8)
+         << std::fixed << std::setprecision(2) << r.p2pSpeedup << "x"
+         << std::right << std::setw(11) << std::fixed << std::setprecision(1)
+         << r.ncclTime << std::right << std::setw(11) << std::fixed
+         << std::setprecision(1) << r.p2pTime << std::right << std::setw(11)
+         << std::fixed << std::setprecision(1) << latencyReduction << "\n";
+    }
+    ss << "==========================================================================================================================================================\n";
+    ss << "PD = Pipeline Depth, Snd Chunk = Send Chunk Size, Rcv Chunk = Recv Chunk Size\n";
+    ss << "BW (Bandwidth) = Data transferred / time, in GB/s\n";
+    ss << "Lat (Latency) = Average transfer time per iteration, in microseconds\n";
+    ss << "Lat Reduc = NCCL latency - P2P latency (positive = P2P faster)\n";
+    ss << "Speedup = P2P Bandwidth / NCCL Bandwidth\n";
+    ss << "==========================================================================================================================================================\n\n";
+
+    std::cout << ss.str();
+  }
+
+  ncclComm_t ncclComm_{};
+  cudaStream_t stream_{};
+};
+
+// =============================================================================
+// Unidirectional Asymmetric Chunk Benchmark
+// =============================================================================
+TEST_F(P2pAsymmetricChunkBenchmarkFixture, UnidirectionalAsymmetricChunk) {
+  if (worldSize != 2) {
+    GTEST_SKIP() << "Test requires exactly 2 ranks, got " << worldSize;
+  }
+
+  int peerRank = (globalRank == 0) ? 1 : 0;
+
+  // Message sizes to test
+  const std::vector<std::pair<std::size_t, std::string>> messageSizes = {
+      {64 * 1024 * 1024, "64MB"},
+      {128 * 1024 * 1024, "128MB"},
+      {256 * 1024 * 1024, "256MB"},
+      {512 * 1024 * 1024, "512MB"},
+      {1024 * 1024 * 1024, "1GB"},
+  };
+
+  constexpr std::size_t kStagedBufferSize = 16 * 1024 * 1024; // 16MB
+  constexpr std::size_t kPipelineDepth = 2;
+  constexpr int kNumBlocks = 32;
+  constexpr int kNumThreads = 512;
+  constexpr std::size_t kSmallChunk = 32 * 1024; // 32KB
+  constexpr std::size_t kLargeChunk = 512 * 1024; // 512KB
+
+  std::vector<BenchmarkResult> results;
+
+  for (const auto& [msgBytes, sizeName] : messageSizes) {
+    // Config 1: Symmetric 32KB
+    BenchmarkConfig sym32k{
+        .nBytes = msgBytes,
+        .stagedBufferSize = kStagedBufferSize,
+        .numBlocks = kNumBlocks,
+        .numThreads = kNumThreads,
+        .pipelineDepth = kPipelineDepth,
+        .chunkSize = kSmallChunk,
+        .groupScope = SyncScope::BLOCK,
+        .name = "Sym_32K_" + sizeName,
+    };
+
+    // Config 2: Symmetric 512KB
+    // NOTE: Despite fewer chunks per step (32 vs 512), Sym_512K consistently
+    // outperforms Sym_32K. Fewer NVLink round-trips per step outweigh the
+    // reduced parallelism.
+    BenchmarkConfig sym512k{
+        .nBytes = msgBytes,
+        .stagedBufferSize = kStagedBufferSize,
+        .numBlocks = kNumBlocks,
+        .numThreads = kNumThreads,
+        .pipelineDepth = kPipelineDepth,
+        .chunkSize = kLargeChunk,
+        .groupScope = SyncScope::BLOCK,
+        .name = "Sym_512K_" + sizeName,
+    };
+
+    // Config 3: Asymmetric 32K send / 512K recv
+    BenchmarkConfig asymRecv{
+        .nBytes = msgBytes,
+        .stagedBufferSize = kStagedBufferSize,
+        .numBlocks = kNumBlocks,
+        .numThreads = kNumThreads,
+        .pipelineDepth = kPipelineDepth,
+        .chunkSize = kSmallChunk, // transport configured at 32KB
+        .groupScope = SyncScope::BLOCK,
+        .recvChunkSize = kLargeChunk, // recv batches to 512KB
+        .name = "Asym_Recv_32K_512K_" + sizeName,
+    };
+
+    // Config 4: Asymmetric 512K send / 32K recv
+    BenchmarkConfig asymSend{
+        .nBytes = msgBytes,
+        .stagedBufferSize = kStagedBufferSize,
+        .numBlocks = kNumBlocks,
+        .numThreads = kNumThreads,
+        .pipelineDepth = kPipelineDepth,
+        .chunkSize = kSmallChunk, // transport configured at 32KB
+        .groupScope = SyncScope::BLOCK,
+        .sendChunkSize = kLargeChunk, // send batches to 512KB
+        .name = "Asym_Send_512K_32K_" + sizeName,
+    };
+
+    // Config 5: Asymmetric both 512K send / 512K recv
+    BenchmarkConfig asymBoth{
+        .nBytes = msgBytes,
+        .stagedBufferSize = kStagedBufferSize,
+        .numBlocks = kNumBlocks,
+        .numThreads = kNumThreads,
+        .pipelineDepth = kPipelineDepth,
+        .chunkSize = kSmallChunk, // transport configured at 32KB
+        .groupScope = SyncScope::BLOCK,
+        .sendChunkSize = kLargeChunk, // send batches to 512KB
+        .recvChunkSize = kLargeChunk, // recv batches to 512KB
+        .name = "Asym_Both_512K_" + sizeName,
+    };
+
+    // Run each config: create transport, run NCCL ref, then P2P
+    for (auto& config : {sym32k, sym512k, asymRecv, asymSend, asymBoth}) {
+      comms::pipes::MultiPeerNvlTransportConfig p2pConfig{
+          .dataBufferSize = config.stagedBufferSize,
+          .chunkSize = config.chunkSize,
+          .pipelineDepth = config.pipelineDepth,
+      };
+
+      comms::pipes::MultiPeerNvlTransport transport(
+          globalRank, worldSize, bootstrap, p2pConfig);
+      transport.exchange();
+      auto p2p = transport.getP2pTransportDevice(peerRank);
+
+      BenchmarkResult result;
+      result.testName = config.name;
+      result.messageSize = config.nBytes;
+      result.stagingBufferSize = config.stagedBufferSize;
+      result.pipelineDepth = config.pipelineDepth;
+      result.chunkSize = config.chunkSize;
+      result.sendChunkSize = config.sendChunkSize;
+      result.recvChunkSize = config.recvChunkSize;
+      result.numBlocks = config.numBlocks;
+      result.numThreads = config.numThreads;
+
+      // NCCL reference
+      result.ncclBandwidth = runNcclBenchmark(config, result.ncclTime);
+
+      // Set up buffers and stream
+      DeviceBuffer sendBuff(config.nBytes);
+      DeviceBuffer recvBuff(config.nBytes);
+
+      if (globalRank == 0) {
+        CUDA_CHECK_VOID(cudaMemset(sendBuff.get(), 1, config.nBytes));
+      }
+      if (globalRank == 1) {
+        CUDA_CHECK_VOID(cudaMemset(recvBuff.get(), 0, config.nBytes));
+      }
+
+      cudaStream_t stream;
+      CUDA_CHECK_VOID(cudaStreamCreate(&stream));
+
+      std::size_t nBytes = config.nBytes;
+      SyncScope groupScope = config.groupScope;
+      Timeout timeout;
+      bool isSend = (globalRank == 0);
+      void* devicePtr = isSend ? sendBuff.get() : recvBuff.get();
+
+      // Pre-build all possible arg layouts (only the selected one is used)
+      std::size_t sendChunkSize = config.sendChunkSize.value_or(0);
+      std::size_t recvChunkSize = config.recvChunkSize.value_or(0);
+      void* symArgs[] = {&p2p, &devicePtr, &nBytes, &groupScope, &timeout};
+      void* asymSendArgs[] = {
+          &p2p, &devicePtr, &nBytes, &sendChunkSize, &groupScope, &timeout};
+      void* asymRecvArgs[] = {
+          &p2p, &devicePtr, &nBytes, &recvChunkSize, &groupScope, &timeout};
+
+      // P2P benchmark — dispatch based on asymmetric config
+      bool hasSendAsym = config.sendChunkSize.has_value();
+      bool hasRecvAsym = config.recvChunkSize.has_value();
+
+      if (hasSendAsym || hasRecvAsym) {
+        // Correctness check before benchmarking
+        runP2pCorrectnessCheck(p2p, config);
+      }
+
+      void* kernelFunc = nullptr;
+      void** args = nullptr;
+      if (hasSendAsym && hasRecvAsym) {
+        kernelFunc = isSend ? (void*)comms::pipes::benchmark::p2pAsymmetricSend
+                            : (void*)comms::pipes::benchmark::p2pAsymmetricRecv;
+        args = isSend ? asymSendArgs : asymRecvArgs;
+      } else if (hasSendAsym) {
+        kernelFunc = isSend ? (void*)comms::pipes::benchmark::p2pAsymmetricSend
+                            : (void*)comms::pipes::benchmark::p2pRecv;
+        args = isSend ? asymSendArgs : symArgs;
+      } else if (hasRecvAsym) {
+        kernelFunc = isSend ? (void*)comms::pipes::benchmark::p2pSend
+                            : (void*)comms::pipes::benchmark::p2pAsymmetricRecv;
+        args = isSend ? symArgs : asymRecvArgs;
+      } else {
+        kernelFunc = isSend ? (void*)comms::pipes::benchmark::p2pSend
+                            : (void*)comms::pipes::benchmark::p2pRecv;
+        args = symArgs;
+      }
+
+      result.p2pBandwidth = runUnidirectionalP2pBenchmark(
+          config, kernelFunc, args, stream, result.p2pTime);
+
+      CUDA_CHECK_VOID(cudaStreamDestroy(stream));
+
+      result.p2pSpeedup = (result.ncclBandwidth > 0)
+          ? result.p2pBandwidth / result.ncclBandwidth
+          : 0;
+
+      results.push_back(result);
+    }
+  }
+
+  printResultsTable(
+      results, "Asymmetric Chunk Size UNIDIRECTIONAL Benchmark Results");
+}
+
+// =============================================================================
+// Bidirectional Asymmetric Chunk Benchmark
+// =============================================================================
+TEST_F(P2pAsymmetricChunkBenchmarkFixture, BidirectionalAsymmetricChunk) {
+  if (worldSize != 2) {
+    GTEST_SKIP() << "Test requires exactly 2 ranks, got " << worldSize;
+  }
+
+  int peerRank = (globalRank == 0) ? 1 : 0;
+
+  const std::vector<std::pair<std::size_t, std::string>> messageSizes = {
+      {64 * 1024 * 1024, "64MB"},
+      {128 * 1024 * 1024, "128MB"},
+      {256 * 1024 * 1024, "256MB"},
+      {512 * 1024 * 1024, "512MB"},
+      {1024 * 1024 * 1024, "1GB"},
+  };
+
+  constexpr std::size_t kStagedBufferSize = 16 * 1024 * 1024; // 16MB
+  constexpr std::size_t kPipelineDepth = 2;
+  constexpr int kNumBlocks = 32;
+  constexpr int kNumThreads = 512;
+  constexpr std::size_t kSmallChunk = 32 * 1024; // 32KB
+  constexpr std::size_t kLargeChunk = 512 * 1024; // 512KB
+  constexpr std::size_t kLargeMessageThreshold = 256 * 1024 * 1024; // 256MB
+
+  std::vector<BenchmarkResult> results;
+
+  for (const auto& [msgBytes, sizeName] : messageSizes) {
+    // Config 1: Symmetric 32KB bidirectional
+    BenchmarkConfig sym32k{
+        .nBytes = msgBytes,
+        .stagedBufferSize = kStagedBufferSize,
+        .numBlocks = kNumBlocks,
+        .numThreads = kNumThreads,
+        .pipelineDepth = kPipelineDepth,
+        .chunkSize = kSmallChunk,
+        .groupScope = SyncScope::BLOCK,
+        .name = "Sym_32K_" + sizeName,
+    };
+
+    // Config 2: Symmetric 512KB bidirectional
+    // NOTE: Despite fewer chunks per step (32 vs 512), Sym_512K consistently
+    // outperforms Sym_32K. Fewer NVLink round-trips per step outweigh the
+    // reduced parallelism.
+    BenchmarkConfig sym512k{
+        .nBytes = msgBytes,
+        .stagedBufferSize = kStagedBufferSize,
+        .numBlocks = kNumBlocks,
+        .numThreads = kNumThreads,
+        .pipelineDepth = kPipelineDepth,
+        .chunkSize = kLargeChunk,
+        .groupScope = SyncScope::BLOCK,
+        .name = "Sym_512K_" + sizeName,
+    };
+
+    // Config 3: Asymmetric recv bidirectional (BLOCK scope)
+    BenchmarkConfig asymRecv{
+        .nBytes = msgBytes,
+        .stagedBufferSize = kStagedBufferSize,
+        .numBlocks = kNumBlocks,
+        .numThreads = kNumThreads,
+        .pipelineDepth = kPipelineDepth,
+        .chunkSize = kSmallChunk,
+        .groupScope = SyncScope::BLOCK,
+        .recvChunkSize = kLargeChunk,
+        .name = "Asym_Recv_32K_512K_" + sizeName,
+    };
+
+    // Config 4: Asymmetric send bidirectional (BLOCK scope)
+    BenchmarkConfig asymSend{
+        .nBytes = msgBytes,
+        .stagedBufferSize = kStagedBufferSize,
+        .numBlocks = kNumBlocks,
+        .numThreads = kNumThreads,
+        .pipelineDepth = kPipelineDepth,
+        .chunkSize = kSmallChunk,
+        .groupScope = SyncScope::BLOCK,
+        .sendChunkSize = kLargeChunk,
+        .name = "Asym_Send_512K_32K_" + sizeName,
+    };
+
+    // Config 5: Asymmetric both bidirectional (BLOCK scope)
+    BenchmarkConfig asymBoth{
+        .nBytes = msgBytes,
+        .stagedBufferSize = kStagedBufferSize,
+        .numBlocks = kNumBlocks,
+        .numThreads = kNumThreads,
+        .pipelineDepth = kPipelineDepth,
+        .chunkSize = kSmallChunk,
+        .groupScope = SyncScope::BLOCK,
+        .sendChunkSize = kLargeChunk,
+        .recvChunkSize = kLargeChunk,
+        .name = "Asym_Both_512K_" + sizeName,
+    };
+
+    std::vector<BenchmarkConfig> configs = {
+        sym32k, sym512k, asymRecv, asymSend, asymBoth};
+
+    // Config 6: Asymmetric with cluster scope for 256MB+ messages
+    if (msgBytes >= kLargeMessageThreshold) {
+      BenchmarkConfig asymCluster{
+          .nBytes = msgBytes,
+          .stagedBufferSize = kStagedBufferSize,
+          .numBlocks = kNumBlocks,
+          .numThreads = kNumThreads,
+          .pipelineDepth = kPipelineDepth,
+          .chunkSize = kSmallChunk,
+          .groupScope = SyncScope::CLUSTER,
+          .spreadClusterLaunch = true,
+          .recvChunkSize = kLargeChunk,
+          .name = "Asym_Cluster_" + sizeName,
+      };
+      configs.push_back(asymCluster);
+    }
+
+    for (auto& config : configs) {
+      comms::pipes::MultiPeerNvlTransportConfig p2pConfig{
+          .dataBufferSize = config.stagedBufferSize,
+          .chunkSize = config.chunkSize,
+          .pipelineDepth = config.pipelineDepth,
+      };
+
+      comms::pipes::MultiPeerNvlTransport transport(
+          globalRank, worldSize, bootstrap, p2pConfig);
+      transport.exchange();
+      auto p2p = transport.getP2pTransportDevice(peerRank);
+
+      BenchmarkResult result;
+      result.testName = config.name;
+      result.messageSize = config.nBytes;
+      result.stagingBufferSize = config.stagedBufferSize;
+      result.pipelineDepth = config.pipelineDepth;
+      result.chunkSize = config.chunkSize;
+      result.sendChunkSize = config.sendChunkSize;
+      result.recvChunkSize = config.recvChunkSize;
+      result.numBlocks = config.numBlocks;
+      result.numThreads = config.numThreads;
+
+      // NCCL reference
+      result.ncclBandwidth =
+          runNcclBidirectionalBenchmark(config, result.ncclTime);
+
+      // Set up buffers
+      DeviceBuffer sendBuff(config.nBytes);
+      DeviceBuffer recvBuff(config.nBytes);
+
+      CUDA_CHECK_VOID(cudaMemset(sendBuff.get(), globalRank, config.nBytes));
+      CUDA_CHECK_VOID(cudaMemset(recvBuff.get(), 0, config.nBytes));
+
+      std::size_t nBytes = config.nBytes;
+      void* sendPtr = sendBuff.get();
+      void* recvPtr = recvBuff.get();
+      SyncScope groupScope = config.groupScope;
+      Timeout timeout;
+
+      // Pre-build all possible arg layouts (only the selected one is used)
+      std::size_t sendChunkSize = config.sendChunkSize.value_or(0);
+      std::size_t recvChunkSize = config.recvChunkSize.value_or(0);
+      void* symArgs[] = {
+          &p2p, &sendPtr, &recvPtr, &nBytes, &groupScope, &timeout};
+      void* asymRecvArgs[] = {
+          &p2p,
+          &sendPtr,
+          &recvPtr,
+          &nBytes,
+          &recvChunkSize,
+          &groupScope,
+          &timeout};
+      void* asymSendArgs[] = {
+          &p2p,
+          &sendPtr,
+          &recvPtr,
+          &nBytes,
+          &sendChunkSize,
+          &groupScope,
+          &timeout};
+      void* asymBothArgs[] = {
+          &p2p,
+          &sendPtr,
+          &recvPtr,
+          &nBytes,
+          &sendChunkSize,
+          &recvChunkSize,
+          &groupScope,
+          &timeout};
+
+      // P2P benchmark — dispatch based on asymmetric config
+      bool hasSendAsym = config.sendChunkSize.has_value();
+      bool hasRecvAsym = config.recvChunkSize.has_value();
+
+      void* kernelFunc = nullptr;
+      void** args = nullptr;
+      if (hasSendAsym && hasRecvAsym) {
+        kernelFunc =
+            (void*)comms::pipes::benchmark::p2pAsymmetricBothBidirectional;
+        args = asymBothArgs;
+      } else if (hasSendAsym) {
+        kernelFunc =
+            (void*)comms::pipes::benchmark::p2pAsymmetricSendBidirectional;
+        args = asymSendArgs;
+      } else if (hasRecvAsym) {
+        kernelFunc = (void*)comms::pipes::benchmark::p2pAsymmetricBidirectional;
+        args = asymRecvArgs;
+      } else {
+        kernelFunc = (void*)comms::pipes::benchmark::p2pBidirectional;
+        args = symArgs;
+      }
+
+      result.p2pBandwidth = runBidirectionalP2pBenchmark(
+          config, kernelFunc, args, result.p2pTime);
+
+      result.p2pSpeedup = (result.ncclBandwidth > 0)
+          ? result.p2pBandwidth / result.ncclBandwidth
+          : 0;
+
+      results.push_back(result);
+    }
+  }
+
+  printResultsTable(
+      results, "Asymmetric Chunk Size BIDIRECTIONAL Benchmark Results");
+}
+
+} // namespace comms::pipes::benchmark
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv);
+
+  if (!meta::comms::isTcpEnvironment()) {
+    ::testing::AddGlobalTestEnvironment(
+        new meta::comms::BenchmarkEnvironment());
+  }
+
+  return RUN_ALL_TESTS();
+}

--- a/comms/pipes/benchmarks/P2pNvlBenchmarkUtils.h
+++ b/comms/pipes/benchmarks/P2pNvlBenchmarkUtils.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <iomanip>
+#include <optional>
 #include <sstream>
 #include <string>
 
@@ -20,6 +21,10 @@ struct BenchmarkConfig {
   std::size_t chunkSize = 512 * 1024; // 512KB default
   SyncScope groupScope = SyncScope::WARP; // Thread group scope for parallelism
   bool spreadClusterLaunch = false; // Use spread cluster kernel launch
+  std::optional<std::size_t> sendChunkSize =
+      std::nullopt; // Asymmetric send chunk size (nullopt = symmetric)
+  std::optional<std::size_t> recvChunkSize =
+      std::nullopt; // Asymmetric recv chunk size (nullopt = symmetric)
   std::string name;
 };
 
@@ -30,6 +35,8 @@ struct BenchmarkResult {
   std::size_t stagingBufferSize{};
   std::size_t pipelineDepth{};
   std::size_t chunkSize{};
+  std::optional<std::size_t> sendChunkSize{};
+  std::optional<std::size_t> recvChunkSize{};
   int numBlocks{};
   int numThreads{};
   float ncclBandwidth{};

--- a/comms/pipes/benchmarks/P2pNvlStreamBenchmark.cc
+++ b/comms/pipes/benchmarks/P2pNvlStreamBenchmark.cc
@@ -1,0 +1,388 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <folly/init/Init.h>
+#include <folly/logging/xlog.h>
+#include <nccl.h>
+
+#include "comms/common/CudaWrap.h"
+#include "comms/pipes/MultiPeerNvlTransport.h"
+#include "comms/pipes/benchmarks/BenchmarkKernel.cuh"
+#include "comms/pipes/benchmarks/BenchmarkMacros.h"
+#include "comms/pipes/benchmarks/P2pNvlBenchmarkUtils.h"
+#include "comms/testinfra/BenchmarkTestFixture.h"
+#include "comms/testinfra/mpi/MpiTestUtils.h"
+#include "comms/utils/CudaRAII.h"
+
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <vector>
+
+using meta::comms::CudaEvent;
+using meta::comms::DeviceBuffer;
+
+namespace comms::pipes::benchmark {
+namespace {
+
+class P2pStreamBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
+ protected:
+  void SetUp() override {
+    BenchmarkTestFixture::SetUp();
+    CUDA_CHECK_VOID(cudaSetDevice(localRank));
+
+    // Initialize NCCL
+    NCCL_CHECK_VOID(
+        ncclCommInitRank(&ncclComm_, worldSize, getNCCLId(), globalRank));
+    CUDA_CHECK_VOID(cudaStreamCreate(&stream_));
+  }
+
+  void TearDown() override {
+    NCCL_CHECK_VOID(ncclCommDestroy(ncclComm_));
+    CUDA_CHECK_VOID(cudaStreamDestroy(stream_));
+    BenchmarkTestFixture::TearDown();
+  }
+
+  ncclUniqueId getNCCLId() {
+    ncclUniqueId id;
+    if (globalRank == 0) {
+      ncclResult_t res = ncclGetUniqueId(&id);
+      if (res != ncclSuccess) {
+        XLOGF(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
+        std::abort();
+      }
+    }
+
+    // Broadcast NCCL ID using bootstrap allGather
+    std::vector<ncclUniqueId> allIds(worldSize);
+    allIds[globalRank] = id;
+    auto result =
+        bootstrap
+            ->allGather(
+                allIds.data(), sizeof(ncclUniqueId), globalRank, worldSize)
+            .get();
+    if (result != 0) {
+      XLOG(ERR) << "Bootstrap allGather for NCCL ID failed";
+      std::abort();
+    }
+    id = allIds[0];
+    return id;
+  }
+
+  float runNcclBenchmark(const BenchmarkConfig& config, float& timeUs) {
+    XLOGF(DBG1, "=== Running NCCL benchmark: {} ===", config.name);
+
+    DeviceBuffer sendBuff(config.nBytes);
+    DeviceBuffer recvBuff(config.nBytes);
+
+    if (globalRank == 0) {
+      CUDA_CHECK(cudaMemset(sendBuff.get(), 1, config.nBytes));
+    }
+    if (globalRank == 1) {
+      CUDA_CHECK(cudaMemset(recvBuff.get(), 0, config.nBytes));
+    }
+
+    CudaEvent start, stop;
+
+    // Warmup
+    bootstrap->barrierAll();
+    for (int i = 0; i < kWarmupIters; i++) {
+      if (globalRank == 0) {
+        NCCL_CHECK(ncclSend(
+            sendBuff.get(), config.nBytes, ncclChar, 1, ncclComm_, stream_));
+      } else if (globalRank == 1) {
+        NCCL_CHECK(ncclRecv(
+            recvBuff.get(), config.nBytes, ncclChar, 0, ncclComm_, stream_));
+      }
+      CUDA_CHECK(cudaStreamSynchronize(stream_));
+    }
+    bootstrap->barrierAll();
+
+    // Benchmark
+    CUDA_CHECK(cudaEventRecord(start.get(), stream_));
+    for (int i = 0; i < kBenchmarkIters; i++) {
+      if (globalRank == 0) {
+        NCCL_CHECK(ncclSend(
+            sendBuff.get(), config.nBytes, ncclChar, 1, ncclComm_, stream_));
+      } else if (globalRank == 1) {
+        NCCL_CHECK(ncclRecv(
+            recvBuff.get(), config.nBytes, ncclChar, 0, ncclComm_, stream_));
+      }
+    }
+    CUDA_CHECK(cudaEventRecord(stop.get(), stream_));
+    CUDA_CHECK(cudaStreamSynchronize(stream_));
+
+    float totalTime_ms = 0.0f;
+    CUDA_CHECK(cudaEventElapsedTime(&totalTime_ms, start.get(), stop.get()));
+    float avgTime_ms = totalTime_ms / kBenchmarkIters;
+    timeUs = avgTime_ms * 1000.0f;
+    float bandwidth_GBps = (config.nBytes / 1e9f) / (avgTime_ms / 1000.0f);
+
+    bootstrap->barrierAll();
+
+    return bandwidth_GBps;
+  }
+
+  float runStreamBenchmark(
+      comms::pipes::P2pNvlTransportDevice& p2p,
+      const BenchmarkConfig& config,
+      float& timeUs) {
+    XLOGF(DBG1, "=== Running Stream P2P benchmark: {} ===", config.name);
+
+    DeviceBuffer sendBuff(config.nBytes);
+    DeviceBuffer recvBuff(config.nBytes);
+
+    if (globalRank == 0) {
+      CUDA_CHECK(cudaMemset(sendBuff.get(), 1, config.nBytes));
+    }
+    if (globalRank == 1) {
+      CUDA_CHECK(cudaMemset(recvBuff.get(), 0, config.nBytes));
+    }
+
+    dim3 gridDim(config.numBlocks);
+    dim3 blockDim(config.numThreads);
+
+    cudaStream_t sendStream, recvStream;
+    CUDA_CHECK(cudaStreamCreate(&sendStream));
+    CUDA_CHECK(cudaStreamCreate(&recvStream));
+
+    CudaEvent start, stop;
+
+    std::size_t nBytes = config.nBytes;
+    bool isSend = (globalRank == 0);
+    SyncScope groupScope = config.groupScope;
+    void* devicePtr = (isSend ? sendBuff.get() : recvBuff.get());
+    Timeout timeout;
+    void* args[] = {&p2p, &devicePtr, &nBytes, &groupScope, &timeout};
+    void* kernelFunc = isSend ? (void*)comms::pipes::benchmark::p2pStreamSend
+                              : (void*)comms::pipes::benchmark::p2pStreamRecv;
+    cudaStream_t stream = isSend ? sendStream : recvStream;
+
+    // Warmup
+    bootstrap->barrierAll();
+    for (int i = 0; i < kWarmupIters; i++) {
+      bootstrap->barrierAll();
+      CUDA_CHECK(
+          cudaLaunchKernel(kernelFunc, gridDim, blockDim, args, 0, stream));
+      CUDA_CHECK(cudaStreamSynchronize(stream));
+    }
+    bootstrap->barrierAll();
+
+    // Benchmark
+    CUDA_CHECK(cudaEventRecord(start.get(), stream));
+    for (int i = 0; i < kBenchmarkIters; i++) {
+      CUDA_CHECK(
+          cudaLaunchKernel(kernelFunc, gridDim, blockDim, args, 0, stream));
+    }
+    CUDA_CHECK(cudaEventRecord(stop.get(), stream));
+    CUDA_CHECK(cudaStreamSynchronize(stream));
+
+    float totalTime_ms = 0.0f;
+    CUDA_CHECK(cudaEventElapsedTime(&totalTime_ms, start.get(), stop.get()));
+    float avgTime_ms = totalTime_ms / kBenchmarkIters;
+    timeUs = avgTime_ms * 1000.0f;
+    float bandwidth_GBps = (config.nBytes / 1e9f) / (avgTime_ms / 1000.0f);
+
+    CUDA_CHECK(cudaStreamDestroy(sendStream));
+    CUDA_CHECK(cudaStreamDestroy(recvStream));
+
+    bootstrap->barrierAll();
+
+    return bandwidth_GBps;
+  }
+
+  void printResultsTable(
+      const std::vector<BenchmarkResult>& results,
+      const std::string& title) {
+    if (globalRank != 0) {
+      return;
+    }
+
+    std::stringstream ss;
+    ss << "\n";
+    ss << "====================================================================================================================================\n";
+    ss << "                              " << title << "\n";
+    ss << "====================================================================================================================================\n";
+    ss << std::left << std::setw(18) << "Test Name" << std::right
+       << std::setw(10) << "Msg Size" << std::right << std::setw(12)
+       << "Staging" << std::right << std::setw(5) << "PD" << std::right
+       << std::setw(8) << "Chunk" << std::right << std::setw(7) << "Blocks"
+       << std::right << std::setw(8) << "Threads" << std::right << std::setw(11)
+       << "NCCL BW" << std::right << std::setw(11) << "P2P BW" << std::right
+       << std::setw(9) << "Speedup" << std::right << std::setw(11) << "NCCL Lat"
+       << std::right << std::setw(11) << "P2P Lat" << std::right
+       << std::setw(11) << "Lat Reduc\n";
+    ss << std::left << std::setw(18) << "" << std::right << std::setw(10) << ""
+       << std::right << std::setw(12) << "" << std::right << std::setw(5) << ""
+       << std::right << std::setw(8) << "" << std::right << std::setw(7) << ""
+       << std::right << std::setw(8) << "" << std::right << std::setw(11)
+       << "(GB/s)" << std::right << std::setw(11) << "(GB/s)" << std::right
+       << std::setw(9) << "P2P/NCCL" << std::right << std::setw(11) << "(us)"
+       << std::right << std::setw(11) << "(us)" << std::right << std::setw(11)
+       << "(us)\n";
+    ss << "------------------------------------------------------------------------------------------------------------------------------------\n";
+
+    for (const auto& r : results) {
+      std::string msgSize = formatSize(r.messageSize);
+      std::string stagingSize = formatSize(r.stagingBufferSize);
+      std::string chunkSizeStr = formatSize(r.chunkSize);
+      float latencyReduction = r.ncclTime - r.p2pTime;
+
+      ss << std::left << std::setw(18) << r.testName << std::right
+         << std::setw(10) << msgSize << std::right << std::setw(12)
+         << stagingSize << std::right << std::setw(5) << r.pipelineDepth
+         << std::right << std::setw(8) << chunkSizeStr << std::right
+         << std::setw(7) << r.numBlocks << std::right << std::setw(8)
+         << r.numThreads << std::right << std::setw(11) << std::fixed
+         << std::setprecision(2) << r.ncclBandwidth << std::right
+         << std::setw(11) << std::fixed << std::setprecision(2)
+         << r.p2pBandwidth << std::right << std::setw(8) << std::fixed
+         << std::setprecision(2) << r.p2pSpeedup << "x" << std::right
+         << std::setw(11) << std::fixed << std::setprecision(1) << r.ncclTime
+         << std::right << std::setw(11) << std::fixed << std::setprecision(1)
+         << r.p2pTime << std::right << std::setw(11) << std::fixed
+         << std::setprecision(1) << latencyReduction << "\n";
+    }
+    ss << "====================================================================================================================================\n";
+    ss << "PD = Pipeline Depth, Chunk = Chunk Size, Blocks/Threads = P2P kernel launch config\n";
+    ss << "BW (Bandwidth) = Data transferred / time, in GB/s\n";
+    ss << "Lat (Latency) = Average transfer time per iteration, in microseconds\n";
+    ss << "Lat Reduc = NCCL latency - P2P latency (positive = P2P faster)\n";
+    ss << "Speedup = P2P Bandwidth / NCCL Bandwidth\n";
+    ss << "====================================================================================================================================\n\n";
+
+    std::cout << ss.str();
+  }
+
+  ncclComm_t ncclComm_{};
+  cudaStream_t stream_{};
+};
+
+} // namespace
+
+TEST_F(P2pStreamBenchmarkFixture, UnidirectionalStreamBenchmark) {
+  if (worldSize != 2) {
+    XLOGF(DBG1, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
+    return;
+  }
+
+  int peerRank = (globalRank == 0) ? 1 : 0;
+
+  std::vector<BenchmarkConfig> configs;
+
+  // 8KB: 1 block, 128 threads, PD=2, chunk=8KB
+  configs.push_back({
+      .nBytes = 8 * 1024,
+      .stagedBufferSize = 8 * 1024,
+      .numBlocks = 1,
+      .numThreads = 128,
+      .pipelineDepth = 2,
+      .chunkSize = 8 * 1024,
+      .name = "Stream_8KB",
+  });
+
+  // 64KB: 2 blocks, 128 threads, PD=2, chunk=8KB
+  configs.push_back({
+      .nBytes = 64 * 1024,
+      .stagedBufferSize = 64 * 1024,
+      .numBlocks = 2,
+      .numThreads = 128,
+      .pipelineDepth = 2,
+      .chunkSize = 8 * 1024,
+      .name = "Stream_64KB",
+  });
+
+  // 1MB: 32 blocks, 128 threads, PD=2, chunk=32KB
+  configs.push_back({
+      .nBytes = 1024 * 1024,
+      .stagedBufferSize = 1024 * 1024,
+      .numBlocks = 32,
+      .numThreads = 128,
+      .pipelineDepth = 2,
+      .chunkSize = 32 * 1024,
+      .name = "Stream_1MB",
+  });
+
+  // 64MB: 128 blocks, 128 threads, PD=4, chunk=128KB
+  configs.push_back({
+      .nBytes = 64 * 1024 * 1024,
+      .stagedBufferSize = 32 * 1024 * 1024,
+      .numBlocks = 128,
+      .numThreads = 128,
+      .pipelineDepth = 4,
+      .chunkSize = 128 * 1024,
+      .name = "Stream_64MB",
+  });
+
+  // 256MB: 256 blocks, 128 threads, PD=4, chunk=512KB
+  configs.push_back({
+      .nBytes = 256 * 1024 * 1024,
+      .stagedBufferSize = 64 * 1024 * 1024,
+      .numBlocks = 256,
+      .numThreads = 128,
+      .pipelineDepth = 4,
+      .chunkSize = 512 * 1024,
+      .name = "Stream_256MB",
+  });
+
+  // 1GB: 256 blocks, 128 threads, PD=4, chunk=512KB
+  configs.push_back({
+      .nBytes = 1024 * 1024 * 1024,
+      .stagedBufferSize = 256 * 1024 * 1024,
+      .numBlocks = 256,
+      .numThreads = 128,
+      .pipelineDepth = 4,
+      .chunkSize = 512 * 1024,
+      .name = "Stream_1GB",
+  });
+
+  std::vector<BenchmarkResult> results;
+
+  for (const auto& config : configs) {
+    comms::pipes::MultiPeerNvlTransportConfig p2pConfig{
+        .dataBufferSize = config.stagedBufferSize,
+        .chunkSize = config.chunkSize,
+        .pipelineDepth = config.pipelineDepth,
+    };
+
+    comms::pipes::MultiPeerNvlTransport transport(
+        globalRank, worldSize, bootstrap, p2pConfig);
+    transport.exchange();
+
+    auto p2p = transport.getP2pTransportDevice(peerRank);
+
+    BenchmarkResult result;
+    result.testName = config.name;
+    result.messageSize = config.nBytes;
+    result.stagingBufferSize = config.stagedBufferSize;
+    result.pipelineDepth = config.pipelineDepth;
+    result.chunkSize = config.chunkSize;
+    result.numBlocks = config.numBlocks;
+    result.numThreads = config.numThreads;
+
+    result.ncclBandwidth = runNcclBenchmark(config, result.ncclTime);
+    result.p2pBandwidth = runStreamBenchmark(p2p, config, result.p2pTime);
+
+    result.p2pSpeedup = (result.ncclBandwidth > 0)
+        ? result.p2pBandwidth / result.ncclBandwidth
+        : 0;
+
+    results.push_back(result);
+  }
+
+  printResultsTable(
+      results, "NCCL vs P2P NVLink STREAMING UNIDIRECTIONAL Benchmark Results");
+}
+
+} // namespace comms::pipes::benchmark
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv);
+
+  if (!meta::comms::isTcpEnvironment()) {
+    ::testing::AddGlobalTestEnvironment(
+        new meta::comms::BenchmarkEnvironment());
+  }
+
+  return RUN_ALL_TESTS();
+}

--- a/comms/pipes/tests/CopyUtilsTest.cc
+++ b/comms/pipes/tests/CopyUtilsTest.cc
@@ -117,4 +117,109 @@ INSTANTIATE_TEST_SUITE_P(
         // Edge case: single warp
         CopyChunkVectorizedParams{1, 32, 2048, 0, 0}));
 
+// --- Dual-destination tests for memcpy_vectorized_dual_dest ---
+
+struct CopyChunkVectorizedDualDestParams {
+  int numBlocks;
+  int numThreads;
+  std::size_t nBytes;
+  std::size_t dst1Offset;
+  std::size_t dst2Offset;
+  std::size_t srcOffset;
+};
+
+class CopyUtilsTestDualDestParameterized
+    : public CopyUtilsTestFixture,
+      public ::testing::WithParamInterface<CopyChunkVectorizedDualDestParams> {
+};
+
+// Test memcpy_vectorized_dual_dest() which reads source data once and writes
+// to two destinations simultaneously. Verifies both destinations match the
+// source byte-for-byte across various sizes, alignments, and thread configs.
+TEST_P(CopyUtilsTestDualDestParameterized, CopyChunkVectorizedDualDest) {
+  const auto& params = GetParam();
+  const std::size_t maxOffset =
+      std::max({params.dst1Offset, params.dst2Offset, params.srcOffset});
+  const std::size_t bufferSize = params.nBytes + maxOffset;
+
+  DeviceBuffer srcBuffer(bufferSize);
+  DeviceBuffer dst1Buffer(bufferSize);
+  DeviceBuffer dst2Buffer(bufferSize);
+  DeviceBuffer errorCountBuffer(sizeof(uint32_t));
+
+  auto src_d = static_cast<char*>(srcBuffer.get());
+  auto dst1_d = static_cast<char*>(dst1Buffer.get());
+  auto dst2_d = static_cast<char*>(dst2Buffer.get());
+  auto errorCount_d = static_cast<uint32_t*>(errorCountBuffer.get());
+
+  std::vector<char> src_h(bufferSize);
+  for (std::size_t i = 0; i < bufferSize; i++) {
+    src_h[i] = static_cast<char>(i % 256);
+  }
+
+  CUDACHECK_TEST(
+      cudaMemcpy(src_d, src_h.data(), bufferSize, cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(cudaMemset(dst1_d, 0, bufferSize));
+  CUDACHECK_TEST(cudaMemset(dst2_d, 0, bufferSize));
+  CUDACHECK_TEST(cudaMemset(errorCount_d, 0, sizeof(uint32_t)));
+
+  testCopyChunkVectorizedDualDest(
+      dst1_d + params.dst1Offset,
+      dst2_d + params.dst2Offset,
+      src_d + params.srcOffset,
+      params.nBytes,
+      errorCount_d,
+      params.numBlocks,
+      params.numThreads);
+
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  uint32_t errorCount_h = 0;
+  CUDACHECK_TEST(cudaMemcpy(
+      &errorCount_h, errorCount_d, sizeof(uint32_t), cudaMemcpyDeviceToHost));
+
+  EXPECT_EQ(errorCount_h, 0)
+      << "Dual-dest copy failed with " << errorCount_h << " mismatches"
+      << " (numBlocks=" << params.numBlocks
+      << ", numThreads=" << params.numThreads << ", nBytes=" << params.nBytes
+      << ", dst1Offset=" << params.dst1Offset
+      << ", dst2Offset=" << params.dst2Offset
+      << ", srcOffset=" << params.srcOffset << ")";
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CopyUtilsDualDestTests,
+    CopyUtilsTestDualDestParameterized,
+    ::testing::Values(
+        // Basic aligned case: 4KB, no offsets
+        CopyChunkVectorizedDualDestParams{1, 256, 4096, 0, 0, 0},
+        // Unaligned size (not multiple of 64 bytes)
+        CopyChunkVectorizedDualDestParams{1, 256, 4097, 0, 0, 0},
+        // Small size (less than warp size * vector size)
+        CopyChunkVectorizedDualDestParams{1, 32, 128, 0, 0, 0},
+        // Large size with multiple blocks
+        CopyChunkVectorizedDualDestParams{4, 256, 65536, 0, 0, 0},
+        // dst1 offset only (16-byte aligned)
+        CopyChunkVectorizedDualDestParams{1, 256, 4096, 64, 0, 0},
+        // dst2 offset only (16-byte aligned)
+        CopyChunkVectorizedDualDestParams{1, 256, 4096, 0, 64, 0},
+        // src offset only (16-byte aligned)
+        CopyChunkVectorizedDualDestParams{1, 256, 4096, 0, 0, 128},
+        // All three offsets non-zero (16-byte aligned)
+        CopyChunkVectorizedDualDestParams{1, 256, 4096, 32, 48, 64},
+        // Different thread count
+        CopyChunkVectorizedDualDestParams{2, 128, 8192, 0, 0, 0},
+        // Single warp
+        CopyChunkVectorizedDualDestParams{1, 32, 2048, 0, 0, 0},
+        // dst1 unaligned (forces byte-level fallback path)
+        CopyChunkVectorizedDualDestParams{1, 256, 4096, 3, 0, 0},
+        // dst2 unaligned (forces byte-level fallback path)
+        CopyChunkVectorizedDualDestParams{1, 256, 4096, 0, 7, 0},
+        // src unaligned (forces byte-level fallback path)
+        CopyChunkVectorizedDualDestParams{1, 256, 4096, 0, 0, 5},
+        // Tiny copy (< 16 bytes, smaller than single uint4)
+        CopyChunkVectorizedDualDestParams{1, 256, 15, 0, 0, 0},
+        // Zero-byte copy (no-op boundary condition)
+        CopyChunkVectorizedDualDestParams{1, 256, 0, 0, 0, 0}));
+
 } // namespace comms::pipes::test

--- a/comms/pipes/tests/CopyUtilsTest.cu
+++ b/comms/pipes/tests/CopyUtilsTest.cu
@@ -23,7 +23,7 @@ __global__ void testCopyChunkVectorizedKernel(
 
   __syncthreads();
 
-  if (warp.is_leader() && warp.group_id == 0) {
+  if (warp.is_global_leader()) {
     for (std::size_t i = 0; i < chunk_bytes; i++) {
       if (dst_d[i] != src_d[i]) {
         atomicAdd(errorCount_d, 1);
@@ -41,6 +41,43 @@ void testCopyChunkVectorized(
     int blockSize) {
   testCopyChunkVectorizedKernel<<<numBlocks, blockSize>>>(
       dst_d, src_d, chunk_bytes, errorCount_d);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+__global__ void testCopyChunkVectorizedDualDestKernel(
+    char* dst1_d,
+    char* dst2_d,
+    const char* src_d,
+    std::size_t chunk_bytes,
+    uint32_t* errorCount_d) {
+  auto warp = make_warp_group();
+
+  memcpy_vectorized_dual_dest(dst1_d, dst2_d, src_d, chunk_bytes, warp);
+
+  __syncthreads();
+
+  if (warp.is_global_leader()) {
+    for (std::size_t i = 0; i < chunk_bytes; i++) {
+      if (dst1_d[i] != src_d[i]) {
+        atomicAdd(errorCount_d, 1);
+      }
+      if (dst2_d[i] != src_d[i]) {
+        atomicAdd(errorCount_d, 1);
+      }
+    }
+  }
+}
+
+void testCopyChunkVectorizedDualDest(
+    char* dst1_d,
+    char* dst2_d,
+    const char* src_d,
+    std::size_t chunk_bytes,
+    uint32_t* errorCount_d,
+    int numBlocks,
+    int blockSize) {
+  testCopyChunkVectorizedDualDestKernel<<<numBlocks, blockSize>>>(
+      dst1_d, dst2_d, src_d, chunk_bytes, errorCount_d);
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 

--- a/comms/pipes/tests/CopyUtilsTest.cu
+++ b/comms/pipes/tests/CopyUtilsTest.cu
@@ -52,7 +52,8 @@ __global__ void testCopyChunkVectorizedDualDestKernel(
     uint32_t* errorCount_d) {
   auto warp = make_warp_group();
 
-  memcpy_vectorized_dual_dest(dst1_d, dst2_d, src_d, chunk_bytes, warp);
+  std::array<char*, 2> dsts = {{dst1_d, dst2_d}};
+  memcpy_vectorized_multi_dest<2>(dsts, src_d, chunk_bytes, warp);
 
   __syncthreads();
 
@@ -78,6 +79,82 @@ void testCopyChunkVectorizedDualDest(
     int blockSize) {
   testCopyChunkVectorizedDualDestKernel<<<numBlocks, blockSize>>>(
       dst1_d, dst2_d, src_d, chunk_bytes, errorCount_d);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+__global__ void testCopyChunkVectorizedMultiDest1Kernel(
+    char* dst_d,
+    const char* src_d,
+    std::size_t chunk_bytes,
+    uint32_t* errorCount_d) {
+  auto warp = make_warp_group();
+
+  std::array<char*, 1> dsts = {{dst_d}};
+  memcpy_vectorized_multi_dest<1>(dsts, src_d, chunk_bytes, warp);
+
+  __syncthreads();
+
+  if (warp.is_global_leader()) {
+    for (std::size_t i = 0; i < chunk_bytes; i++) {
+      if (dst_d[i] != src_d[i]) {
+        atomicAdd(errorCount_d, 1);
+      }
+    }
+  }
+}
+
+void testCopyChunkVectorizedMultiDest1(
+    char* dst_d,
+    const char* src_d,
+    std::size_t chunk_bytes,
+    uint32_t* errorCount_d,
+    int numBlocks,
+    int blockSize) {
+  testCopyChunkVectorizedMultiDest1Kernel<<<numBlocks, blockSize>>>(
+      dst_d, src_d, chunk_bytes, errorCount_d);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+__global__ void testCopyChunkVectorizedMultiDest3Kernel(
+    char* dst1_d,
+    char* dst2_d,
+    char* dst3_d,
+    const char* src_d,
+    std::size_t chunk_bytes,
+    uint32_t* errorCount_d) {
+  auto warp = make_warp_group();
+
+  std::array<char*, 3> dsts = {{dst1_d, dst2_d, dst3_d}};
+  memcpy_vectorized_multi_dest<3>(dsts, src_d, chunk_bytes, warp);
+
+  __syncthreads();
+
+  if (warp.is_global_leader()) {
+    for (std::size_t i = 0; i < chunk_bytes; i++) {
+      if (dst1_d[i] != src_d[i]) {
+        atomicAdd(errorCount_d, 1);
+      }
+      if (dst2_d[i] != src_d[i]) {
+        atomicAdd(errorCount_d, 1);
+      }
+      if (dst3_d[i] != src_d[i]) {
+        atomicAdd(errorCount_d, 1);
+      }
+    }
+  }
+}
+
+void testCopyChunkVectorizedMultiDest3(
+    char* dst1_d,
+    char* dst2_d,
+    char* dst3_d,
+    const char* src_d,
+    std::size_t chunk_bytes,
+    uint32_t* errorCount_d,
+    int numBlocks,
+    int blockSize) {
+  testCopyChunkVectorizedMultiDest3Kernel<<<numBlocks, blockSize>>>(
+      dst1_d, dst2_d, dst3_d, src_d, chunk_bytes, errorCount_d);
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 

--- a/comms/pipes/tests/CopyUtilsTest.cuh
+++ b/comms/pipes/tests/CopyUtilsTest.cuh
@@ -26,4 +26,22 @@ void testCopyChunkVectorizedDualDest(
     int numBlocks,
     int blockSize);
 
+void testCopyChunkVectorizedMultiDest1(
+    char* dst_d,
+    const char* src_d,
+    std::size_t chunk_bytes,
+    uint32_t* errorCount_d,
+    int numBlocks,
+    int blockSize);
+
+void testCopyChunkVectorizedMultiDest3(
+    char* dst1_d,
+    char* dst2_d,
+    char* dst3_d,
+    const char* src_d,
+    std::size_t chunk_bytes,
+    uint32_t* errorCount_d,
+    int numBlocks,
+    int blockSize);
+
 } // namespace comms::pipes::test

--- a/comms/pipes/tests/CopyUtilsTest.cuh
+++ b/comms/pipes/tests/CopyUtilsTest.cuh
@@ -17,4 +17,13 @@ void testCopyChunkVectorized(
     int numBlocks,
     int blockSize);
 
+void testCopyChunkVectorizedDualDest(
+    char* dst1_d,
+    char* dst2_d,
+    const char* src_d,
+    std::size_t chunk_bytes,
+    uint32_t* errorCount_d,
+    int numBlocks,
+    int blockSize);
+
 } // namespace comms::pipes::test

--- a/comms/pipes/tests/P2pNvlTransportDeviceTest.cu
+++ b/comms/pipes/tests/P2pNvlTransportDeviceTest.cu
@@ -154,4 +154,136 @@ void testReadSignal(SignalState* signal_d, uint64_t* result_d) {
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 
+// =============================================================================
+// RecvStream/SendStream test kernels
+// =============================================================================
+
+__global__ void testRecvSendStreamSenderKernel(
+    P2pNvlTransportDevice transport,
+    char* srcBuffer,
+    std::size_t nbytes) {
+  auto group = make_warp_group();
+  auto send = transport.send_stream(nbytes);
+
+  send.for_each_slot(group, [&](auto slot) {
+    // Copy from source buffer to staging
+    memcpy_vectorized(slot.data, srcBuffer + slot.offset, slot.size, group);
+  });
+}
+
+__global__ void testRecvSendStreamReceiverKernel(
+    P2pNvlTransportDevice transport,
+    char* dstBuffer,
+    std::size_t nbytes) {
+  auto group = make_warp_group();
+  auto recv = transport.recv_stream(nbytes);
+
+  recv.for_each_ready_chunk(group, [&](auto chunk) {
+    // Copy from staging to destination buffer
+    memcpy_vectorized(dstBuffer + chunk.offset, chunk.data, chunk.size, group);
+  });
+}
+
+void testRecvSendStreamLoopback(
+    P2pNvlTransportDevice transport0,
+    P2pNvlTransportDevice transport1,
+    char* srcBuffer0,
+    char* dstBuffer1,
+    std::size_t nbytes,
+    int numBlocks,
+    int blockSize) {
+  // Launch sender and receiver kernels concurrently
+  cudaStream_t stream0, stream1;
+  PIPES_CUDA_CHECK(cudaStreamCreate(&stream0));
+  PIPES_CUDA_CHECK(cudaStreamCreate(&stream1));
+
+  // Sender on GPU 0
+  PIPES_CUDA_CHECK(cudaSetDevice(0));
+  testRecvSendStreamSenderKernel<<<numBlocks, blockSize, 0, stream0>>>(
+      transport0, srcBuffer0, nbytes);
+  PIPES_KERNEL_LAUNCH_CHECK();
+
+  // Receiver on GPU 1
+  PIPES_CUDA_CHECK(cudaSetDevice(1));
+  testRecvSendStreamReceiverKernel<<<numBlocks, blockSize, 0, stream1>>>(
+      transport1, dstBuffer1, nbytes);
+  PIPES_KERNEL_LAUNCH_CHECK();
+
+  // Wait for both to complete
+  PIPES_CUDA_CHECK(cudaSetDevice(0));
+  PIPES_CUDA_CHECK(cudaStreamSynchronize(stream0));
+  PIPES_CUDA_CHECK(cudaSetDevice(1));
+  PIPES_CUDA_CHECK(cudaStreamSynchronize(stream1));
+
+  PIPES_CUDA_CHECK(cudaStreamDestroy(stream0));
+  PIPES_CUDA_CHECK(cudaStreamDestroy(stream1));
+}
+
+// Intermediate rank kernel: receives from predecessor, forwards to successor
+// using the positional API (slot_for + commit_slot).
+__global__ void testRecvSendStreamIntermediateKernel(
+    P2pNvlTransportDevice transport_recv,
+    P2pNvlTransportDevice transport_send,
+    std::size_t nbytes) {
+  auto group = make_warp_group();
+  auto recv = transport_recv.recv_stream(nbytes);
+  auto send = transport_send.send_stream(nbytes);
+
+  recv.for_each_ready_chunk(group, [&](auto chunk) {
+    auto slot = send.slot_for(group, chunk);
+    memcpy_vectorized(slot.data, chunk.data, chunk.size, group);
+    send.commit_slot(group, slot);
+  });
+}
+
+void testRecvSendStreamForwarding(
+    P2pNvlTransportDevice transport_send_0to1,
+    P2pNvlTransportDevice transport_recv_1from0,
+    P2pNvlTransportDevice transport_send_1to0,
+    P2pNvlTransportDevice transport_recv_0from1,
+    char* srcBuffer0,
+    char* dstBuffer0,
+    std::size_t nbytes,
+    int numBlocks,
+    int blockSize) {
+  // Launch 3 kernels concurrently:
+  // GPU0 sender → GPU1 intermediate → GPU0 receiver
+  cudaStream_t streamSender, streamIntermediate, streamReceiver;
+  PIPES_CUDA_CHECK(cudaStreamCreate(&streamSender));
+  PIPES_CUDA_CHECK(cudaStreamCreate(&streamIntermediate));
+  PIPES_CUDA_CHECK(cudaStreamCreate(&streamReceiver));
+
+  // Sender on GPU 0
+  PIPES_CUDA_CHECK(cudaSetDevice(0));
+  testRecvSendStreamSenderKernel<<<numBlocks, blockSize, 0, streamSender>>>(
+      transport_send_0to1, srcBuffer0, nbytes);
+  PIPES_KERNEL_LAUNCH_CHECK();
+
+  // Intermediate on GPU 1
+  PIPES_CUDA_CHECK(cudaSetDevice(1));
+  testRecvSendStreamIntermediateKernel<<<
+      numBlocks,
+      blockSize,
+      0,
+      streamIntermediate>>>(transport_recv_1from0, transport_send_1to0, nbytes);
+  PIPES_KERNEL_LAUNCH_CHECK();
+
+  // Receiver on GPU 0
+  PIPES_CUDA_CHECK(cudaSetDevice(0));
+  testRecvSendStreamReceiverKernel<<<numBlocks, blockSize, 0, streamReceiver>>>(
+      transport_recv_0from1, dstBuffer0, nbytes);
+  PIPES_KERNEL_LAUNCH_CHECK();
+
+  // Wait for all to complete
+  PIPES_CUDA_CHECK(cudaStreamSynchronize(streamSender));
+  PIPES_CUDA_CHECK(cudaSetDevice(1));
+  PIPES_CUDA_CHECK(cudaStreamSynchronize(streamIntermediate));
+  PIPES_CUDA_CHECK(cudaSetDevice(0));
+  PIPES_CUDA_CHECK(cudaStreamSynchronize(streamReceiver));
+
+  PIPES_CUDA_CHECK(cudaStreamDestroy(streamSender));
+  PIPES_CUDA_CHECK(cudaStreamDestroy(streamIntermediate));
+  PIPES_CUDA_CHECK(cudaStreamDestroy(streamReceiver));
+}
+
 } // namespace comms::pipes::test

--- a/comms/pipes/tests/P2pNvlTransportDeviceTest.cuh
+++ b/comms/pipes/tests/P2pNvlTransportDeviceTest.cuh
@@ -81,4 +81,63 @@ void testRawWaitSignal(
 // Read the signal value (for verification)
 void testReadSignal(SignalState* signal_d, uint64_t* result_d);
 
+// =============================================================================
+// RecvStream/SendStream test helpers
+// These test the streaming primitives for pipelined collectives
+// =============================================================================
+
+/**
+ * Test RecvStream/SendStream loopback transfer.
+ *
+ * Uses two transports in a loopback configuration where transport0 sends
+ * to transport1. The sender uses SendStream::for_each_slot() and the
+ * receiver uses RecvStream::for_each_ready_chunk().
+ *
+ * @param transport0 Sender transport (writes to transport1's staging)
+ * @param transport1 Receiver transport (reads from its own staging)
+ * @param srcBuffer0 Source buffer on GPU 0
+ * @param dstBuffer1 Destination buffer on GPU 1
+ * @param nbytes Number of bytes to transfer
+ * @param numBlocks Number of blocks to launch
+ * @param blockSize Threads per block
+ */
+void testRecvSendStreamLoopback(
+    P2pNvlTransportDevice transport0,
+    P2pNvlTransportDevice transport1,
+    char* srcBuffer0,
+    char* dstBuffer1,
+    std::size_t nbytes,
+    int numBlocks,
+    int blockSize);
+
+/**
+ * Test RecvStream/SendStream forwarding through an intermediate rank.
+ *
+ * Uses a ring topology: GPU0 (sender) → GPU1 (intermediate) → GPU0 (receiver).
+ * The intermediate rank uses the positional API (slot_for + commit_slot) to
+ * forward each received chunk to the next hop.
+ *
+ * @param transport_send_0to1 Sender transport on GPU0 (writes to GPU1 staging)
+ * @param transport_recv_1from0 Receiver transport on GPU1 (reads from GPU1
+ * staging)
+ * @param transport_send_1to0 Sender transport on GPU1 (writes to GPU0 staging)
+ * @param transport_recv_0from1 Receiver transport on GPU0 (reads from GPU0
+ * staging)
+ * @param srcBuffer0 Source buffer on GPU 0
+ * @param dstBuffer0 Destination buffer on GPU 0
+ * @param nbytes Number of bytes to transfer
+ * @param numBlocks Number of blocks to launch
+ * @param blockSize Threads per block
+ */
+void testRecvSendStreamForwarding(
+    P2pNvlTransportDevice transport_send_0to1,
+    P2pNvlTransportDevice transport_recv_1from0,
+    P2pNvlTransportDevice transport_send_1to0,
+    P2pNvlTransportDevice transport_recv_0from1,
+    char* srcBuffer0,
+    char* dstBuffer0,
+    std::size_t nbytes,
+    int numBlocks,
+    int blockSize);
+
 } // namespace comms::pipes::test


### PR DESCRIPTION
Summary:
Adds infrastructure for benchmarking asymmetric send/recv chunk sizes in the Pipes P2P transport layer. This is exploratory research to understand performance characteristics when send and receive chunk sizes differ.

**Key additions:**
- `asymmetric_recv_impl` and `asymmetric_send_impl` device functions that batch fine-grained ChunkStates into coarser chunks
- Multiple asymmetric kernel variants: `p2pAsymmetricRecv`, `p2pAsymmetricBidirectional`, `p2pAsymmetricSend`, etc.
- `P2pNvlAsymmetricChunkBenchmark.cc` - comprehensive benchmark comparing NCCL vs Pipes P2P with asymmetric configurations
- `ChunkState::release_to_send()` and `release_to_recv()` methods for batched release patterns (eliminates redundant barriers)
- Extended `BenchmarkConfig` and `BenchmarkResult` structs with optional `sendChunkSize` and `recvChunkSize` fields

This infrastructure is independent of any specific collective and can be reused for future transport-level research.

Differential Revision: D94225031


