### PR TITLE
Add casting function using stochastic rounding

### DIFF
--- a/comms/ncclx/v2_27/meta/collectives/kernels/stochastic_cast.cuh
+++ b/comms/ncclx/v2_27/meta/collectives/kernels/stochastic_cast.cuh
@@ -1,0 +1,135 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include "device.h"
+#include "op128.h"
+
+#include "comms/utils/kernels/rng/philox_rng.cuh"
+#include "comms/utils/kernels/stochastic_rounding/stochastic_rounding.cuh"
+
+// ==============================================================================
+// Apply_StochasticCast Templates
+// All take seed and offset EXPLICITLY (no state class)
+// ==============================================================================
+
+template <typename SrcType, typename DstType, int EltPerPack>
+struct Apply_StochasticCast;
+
+// ============================================================================
+// FP32 -> BF16 Specializations (Primary Use Case)
+// ============================================================================
+
+// Specialization for float -> __nv_bfloat16, 1 element
+template <>
+struct Apply_StochasticCast<float, __nv_bfloat16, 1> {
+  __device__ __forceinline__ static BytePack<2> // sizeof(bf16) = 2 bytes
+  cast(
+      BytePack<4> a,
+      uint64_t seed,
+      uint64_t offset) { // sizeof(float) = 4 bytes
+    float val = fromPack<float>(a);
+    uint32_t r0, r1, r2, r3;
+    philox_randint4x(seed, offset, r0, r1, r2, r3);
+    __nv_bfloat16 result = stochastic_round_bf16_software(val, r0);
+    return toPack(result);
+  }
+};
+
+// Specialization for float -> __nv_bfloat16, 2 elements (optimal vectorized
+// path)
+template <>
+struct Apply_StochasticCast<float, __nv_bfloat16, 2> {
+  __device__ __forceinline__ static BytePack<4> // 2 * sizeof(bf16) = 4 bytes
+  cast(
+      BytePack<8> a,
+      uint64_t seed,
+      uint64_t offset) { // 2 * sizeof(float) = 8 bytes
+    float2 vals = fromPack<float2>(a);
+    uint32_t r0, r1, r2, r3;
+    philox_randint4x(seed, offset, r0, r1, r2, r3);
+
+#if __CUDA_ARCH__ >= 1000
+    // Blackwell: use native hardware instruction
+    // Combine random bits: use XOR for entropy mixing
+    uint32_t rand_bits = r0 ^ (r1 << 16);
+    __nv_bfloat162 result = stochastic_round_bf16x2_blackwell(vals, rand_bits);
+#else
+    // Pre-Blackwell: software fallback
+    __nv_bfloat162 result = stochastic_round_bf16x2_software(vals, r0, r1);
+#endif
+    return toPack(result);
+  }
+};
+
+// Specialization for float -> __nv_bfloat16, 4 elements
+template <>
+struct Apply_StochasticCast<float, __nv_bfloat16, 4> {
+  __device__ __forceinline__ static BytePack<8> // 4 * sizeof(bf16) = 8 bytes
+  cast(
+      BytePack<16> a,
+      uint64_t seed,
+      uint64_t offset) { // 4 * sizeof(float) = 16 bytes
+    float4 vals = fromPack<float4>(a);
+    uint32_t r0, r1, r2, r3;
+    philox_randint4x(seed, offset, r0, r1, r2, r3);
+
+    __nv_bfloat162 lo, hi;
+#if __CUDA_ARCH__ >= 1000
+    // Blackwell: use native hardware instruction for each pair
+    uint32_t rand_lo = r0 ^ (r1 << 16);
+    uint32_t rand_hi = r2 ^ (r3 << 16);
+    lo =
+        stochastic_round_bf16x2_blackwell(make_float2(vals.x, vals.y), rand_lo);
+    hi =
+        stochastic_round_bf16x2_blackwell(make_float2(vals.z, vals.w), rand_hi);
+#else
+    // Pre-Blackwell: software fallback
+    lo = stochastic_round_bf16x2_software(make_float2(vals.x, vals.y), r0, r1);
+    hi = stochastic_round_bf16x2_software(make_float2(vals.z, vals.w), r2, r3);
+#endif
+    // Pack into BytePack<8>
+    BytePack<8> result;
+    result.half[0] = toPack(lo);
+    result.half[1] = toPack(hi);
+    return result;
+  }
+};
+
+// ============================================================================
+// Recursive/General Case
+// ============================================================================
+
+// General recursive case: split pack in half
+template <typename SrcType, typename DstType, int EltPerPack>
+struct Apply_StochasticCast {
+  __device__ __forceinline__ static BytePack<EltPerPack * sizeof(DstType)> cast(
+      BytePack<EltPerPack * sizeof(SrcType)> a,
+      uint64_t seed,
+      uint64_t offset) {
+    BytePack<EltPerPack * sizeof(DstType)> result;
+    result.half[0] =
+        Apply_StochasticCast<SrcType, DstType, EltPerPack / 2>::cast(
+            a.half[0], seed, offset);
+    result.half[1] =
+        Apply_StochasticCast<SrcType, DstType, EltPerPack / 2>::cast(
+            a.half[1], seed, offset + EltPerPack / 2);
+    return result;
+  }
+};
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+// Apply stochastic cast from SrcType to DstType with explicit seed and offset
+// Usage: applyStochasticCast<SrcType, DstType>(pack, seed, offset)
+template <typename SrcType, typename DstType, typename Pack>
+__device__ __forceinline__
+    BytePack<BytePackOf<Pack>::Size * sizeof(DstType) / sizeof(SrcType)>
+    applyStochasticCast(Pack a, uint64_t seed, uint64_t offset) {
+  return Apply_StochasticCast<
+      SrcType,
+      DstType,
+      BytePackOf<Pack>::Size / sizeof(SrcType)>::cast(toPack(a), seed, offset);
+}

--- a/comms/ncclx/v2_27/meta/collectives/tests/StochasticCastTest.cu
+++ b/comms/ncclx/v2_27/meta/collectives/tests/StochasticCastTest.cu
@@ -1,0 +1,265 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+#include <cmath>
+#include <cstdint>
+
+// NCCL Device headers
+#include "device.h" // @manual Without device.h, op128.h would cause a compile error
+#include "op128.h" // @manual
+
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "meta/collectives/kernels/stochastic_cast.cuh" // @manual
+
+// Kernel: test Apply_StochasticCast<float, __nv_bfloat16, 1>
+__global__ void stochasticCast1Kernel(
+    float input,
+    uint64_t seed,
+    uint64_t offset,
+    __nv_bfloat16* output) {
+  BytePack<4> pack = toPack(input);
+  BytePack<2> result =
+      Apply_StochasticCast<float, __nv_bfloat16, 1>::cast(pack, seed, offset);
+  *output = fromPack<__nv_bfloat16>(result);
+}
+
+// Kernel: test Apply_StochasticCast<float, __nv_bfloat16, 2>
+__global__ void stochasticCast2Kernel(
+    float x,
+    float y,
+    uint64_t seed,
+    uint64_t offset,
+    __nv_bfloat16* output) {
+  float2 vals = make_float2(x, y);
+  BytePack<8> pack = toPack(vals);
+  BytePack<4> result =
+      Apply_StochasticCast<float, __nv_bfloat16, 2>::cast(pack, seed, offset);
+  __nv_bfloat162 bf16_pair = fromPack<__nv_bfloat162>(result);
+  output[0] = __low2bfloat16(bf16_pair);
+  output[1] = __high2bfloat16(bf16_pair);
+}
+
+// Kernel: test Apply_StochasticCast<float, __nv_bfloat16, 4>
+__global__ void stochasticCast4Kernel(
+    float x,
+    float y,
+    float z,
+    float w,
+    uint64_t seed,
+    uint64_t offset,
+    __nv_bfloat16* output) {
+  float4 vals = make_float4(x, y, z, w);
+  BytePack<16> pack = toPack(vals);
+  BytePack<8> result =
+      Apply_StochasticCast<float, __nv_bfloat16, 4>::cast(pack, seed, offset);
+
+  __nv_bfloat162 lo = fromPack<__nv_bfloat162>(result.half[0]);
+  __nv_bfloat162 hi = fromPack<__nv_bfloat162>(result.half[1]);
+  output[0] = __low2bfloat16(lo);
+  output[1] = __high2bfloat16(lo);
+  output[2] = __low2bfloat16(hi);
+  output[3] = __high2bfloat16(hi);
+}
+
+// Kernel: test applyStochasticCast public API (1 element)
+__global__ void applyStochasticCastApiKernel(
+    float input,
+    uint64_t seed,
+    uint64_t offset,
+    __nv_bfloat16* output) {
+  BytePack<4> pack = toPack(input);
+  auto result = applyStochasticCast<float, __nv_bfloat16>(pack, seed, offset);
+  *output = fromPack<__nv_bfloat16>(result);
+}
+
+// Kernel: repeat applyStochasticCast with different offsets to test
+// unbiasedness
+__global__ void applyStochasticCastRepeatKernel(
+    float input,
+    int n,
+    uint64_t seed,
+    __nv_bfloat16* outputs) {
+  auto idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= n)
+    return;
+  BytePack<4> pack = toPack(input);
+  auto result =
+      applyStochasticCast<float, __nv_bfloat16>(pack, seed, (uint64_t)idx);
+  outputs[idx] = fromPack<__nv_bfloat16>(result);
+}
+
+class StochasticCastTest : public ::testing::Test {
+ protected:
+  void SetUp() override {}
+  void TearDown() override {}
+
+  // Helper: check if running on Blackwell (SM >= 100) GPU
+  static bool isBlackwell() {
+    int device;
+    cudaGetDevice(&device);
+    cudaDeviceProp prop;
+    cudaGetDeviceProperties(&prop, device);
+    return prop.major >= 10;
+  }
+
+  // Helper: convert bf16 back to float on host
+  static float bf16ToFloat(__nv_bfloat16 val) {
+    return __bfloat162float(val);
+  }
+
+  // Helper: get the two nearest bf16 values bracketing a float
+  static void getBracketingBf16(float val, float& lower, float& upper) {
+    __nv_bfloat16 rounded_down = __float2bfloat16_rd(val);
+    float rd = __bfloat162float(rounded_down);
+    ASSERT_TRUE(rd <= val) << "Rounding down should not increase value";
+
+    if (rd == val) {
+      lower = upper = val;
+      return;
+    }
+
+    __nv_bfloat16 rounded_up = __float2bfloat16_ru(val);
+    float ru = __bfloat162float(rounded_up);
+    ASSERT_TRUE(ru >= val) << "Rounding up should not decrease value";
+
+    lower = rd;
+    upper = ru;
+  }
+};
+
+// =============================================================================
+// Tests: Apply_StochasticCast specializations
+// =============================================================================
+
+TEST_F(StochasticCastTest, StochasticCast1Element) {
+  __nv_bfloat16* d_out;
+  CUDACHECK_TEST(cudaMalloc(&d_out, sizeof(__nv_bfloat16)));
+
+  float input = 3.0f;
+  stochasticCast1Kernel<<<1, 1>>>(input, 42, 0, d_out);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  __nv_bfloat16 h_out;
+  CUDACHECK_TEST(
+      cudaMemcpy(&h_out, d_out, sizeof(__nv_bfloat16), cudaMemcpyDeviceToHost));
+  EXPECT_EQ(bf16ToFloat(h_out), 3.0f);
+
+  cudaFree(d_out);
+}
+
+TEST_F(StochasticCastTest, StochasticCast2Elements) {
+  __nv_bfloat16* d_out;
+  CUDACHECK_TEST(cudaMalloc(&d_out, 2 * sizeof(__nv_bfloat16)));
+
+  stochasticCast2Kernel<<<1, 1>>>(1.0f, 2.0f, 42, 0, d_out);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  __nv_bfloat16 h_out[2];
+  CUDACHECK_TEST(cudaMemcpy(
+      h_out, d_out, 2 * sizeof(__nv_bfloat16), cudaMemcpyDeviceToHost));
+  EXPECT_EQ(bf16ToFloat(h_out[0]), 1.0f);
+  EXPECT_EQ(bf16ToFloat(h_out[1]), 2.0f);
+
+  cudaFree(d_out);
+}
+
+TEST_F(StochasticCastTest, StochasticCast4Elements) {
+  __nv_bfloat16* d_out;
+  CUDACHECK_TEST(cudaMalloc(&d_out, 4 * sizeof(__nv_bfloat16)));
+
+  stochasticCast4Kernel<<<1, 1>>>(1.0f, 2.0f, 3.0f, 4.0f, 42, 0, d_out);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  __nv_bfloat16 h_out[4];
+  CUDACHECK_TEST(cudaMemcpy(
+      h_out, d_out, 4 * sizeof(__nv_bfloat16), cudaMemcpyDeviceToHost));
+  EXPECT_EQ(bf16ToFloat(h_out[0]), 1.0f);
+  EXPECT_EQ(bf16ToFloat(h_out[1]), 2.0f);
+  EXPECT_EQ(bf16ToFloat(h_out[2]), 3.0f);
+  EXPECT_EQ(bf16ToFloat(h_out[3]), 4.0f);
+
+  cudaFree(d_out);
+}
+
+// Test the public applyStochasticCast API
+TEST_F(StochasticCastTest, ApplyStochasticCastApi) {
+  __nv_bfloat16* d_out;
+  CUDACHECK_TEST(cudaMalloc(&d_out, sizeof(__nv_bfloat16)));
+
+  applyStochasticCastApiKernel<<<1, 1>>>(5.0f, 42, 0, d_out);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  __nv_bfloat16 h_out;
+  CUDACHECK_TEST(
+      cudaMemcpy(&h_out, d_out, sizeof(__nv_bfloat16), cudaMemcpyDeviceToHost));
+  EXPECT_EQ(bf16ToFloat(h_out), 5.0f);
+
+  cudaFree(d_out);
+}
+
+// =============================================================================
+// Tests: Statistical properties of Apply_StochasticCast
+// =============================================================================
+
+TEST_F(StochasticCastTest, ApplyStochasticCastUnbiased) {
+  constexpr int N = 8192;
+  __nv_bfloat16* d_out;
+  CUDACHECK_TEST(cudaMalloc(&d_out, N * sizeof(__nv_bfloat16)));
+
+  float testValue = 1.004f;
+
+  applyStochasticCastRepeatKernel<<<(N + 255) / 256, 256>>>(
+      testValue, N, 42, d_out);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<__nv_bfloat16> h_out(N);
+  CUDACHECK_TEST(cudaMemcpy(
+      h_out.data(), d_out, N * sizeof(__nv_bfloat16), cudaMemcpyDeviceToHost));
+
+  double sum = 0.0;
+  for (int i = 0; i < N; i++) {
+    sum += bf16ToFloat(h_out[i]);
+  }
+  double avg = sum / N;
+
+  float lower, upper;
+  getBracketingBf16(testValue, lower, upper);
+  double gap = upper - lower;
+
+  EXPECT_NEAR(avg, (double)testValue, gap * 0.15)
+      << "applyStochasticCast should be unbiased. "
+      << "Expected: " << testValue << " Got avg: " << avg;
+
+  cudaFree(d_out);
+}
+
+// =============================================================================
+// Tests: Determinism
+// =============================================================================
+
+TEST_F(StochasticCastTest, DeterministicWithSameSeedOffset) {
+  __nv_bfloat16* d_out;
+  CUDACHECK_TEST(cudaMalloc(&d_out, sizeof(__nv_bfloat16)));
+
+  float input = 1.337f;
+  uint64_t seed = 42, offset = 17;
+
+  stochasticCast1Kernel<<<1, 1>>>(input, seed, offset, d_out);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  __nv_bfloat16 result1;
+  CUDACHECK_TEST(cudaMemcpy(
+      &result1, d_out, sizeof(__nv_bfloat16), cudaMemcpyDeviceToHost));
+
+  stochasticCast1Kernel<<<1, 1>>>(input, seed, offset, d_out);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  __nv_bfloat16 result2;
+  CUDACHECK_TEST(cudaMemcpy(
+      &result2, d_out, sizeof(__nv_bfloat16), cudaMemcpyDeviceToHost));
+
+  EXPECT_EQ(bf16ToFloat(result1), bf16ToFloat(result2))
+      << "Same seed+offset should produce same result";
+
+  cudaFree(d_out);
+}

--- a/comms/ncclx/v2_27/meta/collectives/tests/StochasticRoundingBench.cu
+++ b/comms/ncclx/v2_27/meta/collectives/tests/StochasticRoundingBench.cu
@@ -1,0 +1,457 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+#include "device.h" // @manual needed for op128.h
+#include "op128.h" // @manual
+
+#include "meta/collectives/kernels/stochastic_cast.cuh" // @manual
+
+#define CUDACHECK(cmd)                                                    \
+  do {                                                                    \
+    cudaError_t e = cmd;                                                  \
+    ASSERT_EQ(e, cudaSuccess) << "CUDA error: " << cudaGetErrorString(e); \
+  } while (0)
+
+// =============================================================================
+// Benchmark Kernels
+// =============================================================================
+
+// Stochastic rounding benchmark: read FP32, write BF16 with stochastic rounding
+template <int Pack>
+__global__ void benchSRCast(
+    float* src,
+    __nv_bfloat16* dst,
+    int64_t nElts,
+    uint64_t seed,
+    uint64_t offset) {
+  auto tid = threadIdx.x + blockIdx.x * blockDim.x;
+  auto nThreads = blockDim.x * gridDim.x;
+
+  if constexpr (Pack == 1) {
+    for (int64_t i = tid; i < nElts; i += nThreads) {
+      BytePack<4> pack = toPack(src[i]);
+      BytePack<2> result = Apply_StochasticCast<float, __nv_bfloat16, 1>::cast(
+          pack, seed, offset + i);
+      dst[i] = fromPack<__nv_bfloat16>(result);
+    }
+  } else if constexpr (Pack == 2) {
+    for (int64_t i = tid * 2; i < nElts; i += nThreads * 2) {
+      if (i + 1 < nElts) {
+        float2 vals = make_float2(src[i], src[i + 1]);
+        BytePack<8> pack = toPack(vals);
+        BytePack<4> result =
+            Apply_StochasticCast<float, __nv_bfloat16, 2>::cast(
+                pack, seed, offset + i);
+        __nv_bfloat162 bf16_pair = fromPack<__nv_bfloat162>(result);
+        dst[i] = __low2bfloat16(bf16_pair);
+        dst[i + 1] = __high2bfloat16(bf16_pair);
+      }
+    }
+  } else if constexpr (Pack == 4) {
+    for (int64_t i = tid * 4; i < nElts; i += nThreads * 4) {
+      if (i + 3 < nElts) {
+        float4 vals = make_float4(src[i], src[i + 1], src[i + 2], src[i + 3]);
+        BytePack<16> pack = toPack(vals);
+        BytePack<8> result =
+            Apply_StochasticCast<float, __nv_bfloat16, 4>::cast(
+                pack, seed, offset + i);
+        __nv_bfloat162 lo = fromPack<__nv_bfloat162>(result.half[0]);
+        __nv_bfloat162 hi = fromPack<__nv_bfloat162>(result.half[1]);
+        dst[i] = __low2bfloat16(lo);
+        dst[i + 1] = __high2bfloat16(lo);
+        dst[i + 2] = __low2bfloat16(hi);
+        dst[i + 3] = __high2bfloat16(hi);
+      }
+    }
+  }
+}
+
+// Naive truncation baseline: read FP32, write BF16 with simple truncation
+__global__ void benchNaiveCast(float* src, __nv_bfloat16* dst, int64_t nElts) {
+  auto tid = threadIdx.x + blockIdx.x * blockDim.x;
+  auto nThreads = blockDim.x * gridDim.x;
+  for (int64_t i = tid; i < nElts; i += nThreads) {
+    dst[i] = __float2bfloat16(src[i]);
+  }
+}
+
+// FP32 identity copy (ceiling): Just copy FP32→FP32 to measure pure bandwidth
+__global__ void benchIdentityCopy(float* src, float* dst, int64_t nElts) {
+  auto tid = threadIdx.x + blockIdx.x * blockDim.x;
+  auto nThreads = blockDim.x * gridDim.x;
+  for (int64_t i = tid; i < nElts; i += nThreads) {
+    dst[i] = src[i];
+  }
+}
+
+// =============================================================================
+// Benchmark Fixture
+// =============================================================================
+
+class StochasticRoundingBench : public ::testing::Test {
+ protected:
+  static constexpr int64_t kMaxElts = 16 * 1024 * 1024; // 16M elements
+  static constexpr int kBlockSize = 256;
+  static constexpr int kWarmupIters = 10;
+  static constexpr int kBenchIters = 100;
+
+  float* d_srcFloat = nullptr;
+  __nv_bfloat16* d_dstBf16 = nullptr;
+  float* d_dstFloat = nullptr;
+  cudaEvent_t startEvent, stopEvent;
+
+  void SetUp() override {
+    CUDACHECK(cudaMalloc(&d_srcFloat, kMaxElts * sizeof(float)));
+    CUDACHECK(cudaMalloc(&d_dstBf16, kMaxElts * sizeof(__nv_bfloat16)));
+    CUDACHECK(cudaMalloc(&d_dstFloat, kMaxElts * sizeof(float)));
+    CUDACHECK(cudaEventCreate(&startEvent));
+    CUDACHECK(cudaEventCreate(&stopEvent));
+
+    // Initialize source data with simple pattern
+    std::vector<float> h_init(kMaxElts);
+    for (int64_t i = 0; i < kMaxElts; i++) {
+      h_init[i] = 1.0f + static_cast<float>(i % 1000) * 1e-4f;
+    }
+    CUDACHECK(cudaMemcpy(
+        d_srcFloat,
+        h_init.data(),
+        kMaxElts * sizeof(float),
+        cudaMemcpyHostToDevice));
+  }
+
+  void TearDown() override {
+    cudaEventDestroy(startEvent);
+    cudaEventDestroy(stopEvent);
+    cudaFree(d_srcFloat);
+    cudaFree(d_dstBf16);
+    cudaFree(d_dstFloat);
+  }
+
+  // Compute the maximum number of blocks for a given element count
+  int maxBlocks(int64_t nElts) {
+    return std::min((int)((nElts + kBlockSize - 1) / kBlockSize), 1024);
+  }
+
+  // Generate a sequence of block counts: 1, 2, 4, 8, ..., up to maxBlk
+  static std::vector<int> blockCountSweep(int maxBlk) {
+    std::vector<int> counts;
+    for (int b = 1; b <= maxBlk; b *= 2) {
+      counts.push_back(b);
+    }
+    // Always include the true max if it wasn't a power of 2
+    if (counts.empty() || counts.back() != maxBlk) {
+      counts.push_back(maxBlk);
+    }
+    return counts;
+  }
+
+  // Core benchmark runner with explicit block count
+  template <typename LaunchFn>
+  void runBenchCore(
+      int64_t nElts,
+      int nBlocks,
+      size_t totalBytesPerIter,
+      LaunchFn launchFn,
+      const char* label) {
+    // Warmup
+    for (int i = 0; i < kWarmupIters; i++) {
+      launchFn(nBlocks, kBlockSize, nElts);
+    }
+    CUDACHECK(cudaDeviceSynchronize());
+
+    // Timed iterations
+    CUDACHECK(cudaEventRecord(startEvent));
+    for (int i = 0; i < kBenchIters; i++) {
+      launchFn(nBlocks, kBlockSize, nElts);
+    }
+    CUDACHECK(cudaEventRecord(stopEvent));
+    CUDACHECK(cudaDeviceSynchronize());
+
+    float elapsedMs = 0.0f;
+    CUDACHECK(cudaEventElapsedTime(&elapsedMs, startEvent, stopEvent));
+    float avgMs = elapsedMs / kBenchIters;
+
+    double gbPerSec = (double)totalBytesPerIter / (avgMs * 1e6);
+    printf(
+        "  %-45s  nBlocks=%4d  nElts=%10ld  avg=%.3f ms  BW=%.2f GB/s\n",
+        label,
+        nBlocks,
+        (long)nElts,
+        avgMs,
+        gbPerSec);
+  }
+
+  // Generic benchmark runner (max blocks)
+  template <typename LaunchFn>
+  void runBench(
+      int64_t nElts,
+      size_t totalBytesPerIter,
+      LaunchFn launchFn,
+      const char* label) {
+    runBenchCore(nElts, maxBlocks(nElts), totalBytesPerIter, launchFn, label);
+  }
+};
+
+// =============================================================================
+// Benchmarks: FP32→BF16 Stochastic Rounding vs Naive Truncation
+// =============================================================================
+
+TEST_F(StochasticRoundingBench, FloatToBf16_Pack1_SizesSweep) {
+  printf(
+      "\n--- Stochastic Rounding: FP32→BF16 (pack=1) vs Naive Truncation ---\n");
+  int64_t sizes[] = {
+      1024, 8192, 65536, 524288, 4 * 1024 * 1024, 16 * 1024 * 1024};
+  uint64_t seed = 12345ULL;
+  uint64_t offset = 0;
+
+  for (int64_t n : sizes) {
+    size_t totalBytes = n * (sizeof(float) + sizeof(__nv_bfloat16));
+
+    // Stochastic rounding
+    runBench(
+        n,
+        totalBytes,
+        [&](int nBlocks, int blockSize, int64_t nElts) {
+          benchSRCast<1><<<nBlocks, blockSize>>>(
+              d_srcFloat, d_dstBf16, nElts, seed, offset);
+        },
+        "f32→bf16(SR,pack=1)");
+
+    // Naive truncation
+    runBench(
+        n,
+        totalBytes,
+        [&](int nBlocks, int blockSize, int64_t nElts) {
+          benchNaiveCast<<<nBlocks, blockSize>>>(d_srcFloat, d_dstBf16, nElts);
+        },
+        "f32→bf16(naive)");
+  }
+}
+
+TEST_F(StochasticRoundingBench, FloatToBf16_Pack2_SizesSweep) {
+  printf("\n--- Stochastic Rounding: FP32→BF16 (pack=2) ---\n");
+  int64_t sizes[] = {
+      1024, 8192, 65536, 524288, 4 * 1024 * 1024, 16 * 1024 * 1024};
+  uint64_t seed = 12345ULL;
+  uint64_t offset = 0;
+
+  for (int64_t n : sizes) {
+    size_t totalBytes = n * (sizeof(float) + sizeof(__nv_bfloat16));
+    runBench(
+        n,
+        totalBytes,
+        [&](int nBlocks, int blockSize, int64_t nElts) {
+          benchSRCast<2><<<nBlocks, blockSize>>>(
+              d_srcFloat, d_dstBf16, nElts, seed, offset);
+        },
+        "f32→bf16(SR,pack=2)");
+  }
+}
+
+TEST_F(StochasticRoundingBench, FloatToBf16_Pack4_SizesSweep) {
+  printf("\n--- Stochastic Rounding: FP32→BF16 (pack=4) ---\n");
+  int64_t sizes[] = {
+      1024, 8192, 65536, 524288, 4 * 1024 * 1024, 16 * 1024 * 1024};
+  uint64_t seed = 12345ULL;
+  uint64_t offset = 0;
+
+  for (int64_t n : sizes) {
+    size_t totalBytes = n * (sizeof(float) + sizeof(__nv_bfloat16));
+    runBench(
+        n,
+        totalBytes,
+        [&](int nBlocks, int blockSize, int64_t nElts) {
+          benchSRCast<4><<<nBlocks, blockSize>>>(
+              d_srcFloat, d_dstBf16, nElts, seed, offset);
+        },
+        "f32→bf16(SR,pack=4)");
+  }
+}
+
+// =============================================================================
+// Benchmarks: FP32→FP32 Identity Copy (Bandwidth Ceiling)
+// =============================================================================
+
+TEST_F(StochasticRoundingBench, IdentityCopy_FloatToFloat) {
+  printf("\n--- FP32→FP32 Identity Copy (bandwidth ceiling) ---\n");
+  int64_t sizes[] = {
+      1024, 8192, 65536, 524288, 4 * 1024 * 1024, 16 * 1024 * 1024};
+
+  for (int64_t n : sizes) {
+    size_t totalBytes = n * 2 * sizeof(float); // read + write
+    runBench(
+        n,
+        totalBytes,
+        [&](int nBlocks, int blockSize, int64_t nElts) {
+          benchIdentityCopy<<<nBlocks, blockSize>>>(
+              d_srcFloat, d_dstFloat, nElts);
+        },
+        "f32→f32(identity)");
+  }
+}
+
+// =============================================================================
+// Benchmarks: Block count sweep (1 to max)
+// =============================================================================
+
+TEST_F(StochasticRoundingBench, BlockSweep_StochasticRounding) {
+  constexpr int64_t N = 4 * 1024 * 1024;
+  printf(
+      "\n--- Stochastic Rounding block sweep: FP32→BF16 (%ldM elts) ---\n",
+      (long)(N / (1024 * 1024)));
+  uint64_t seed = 12345ULL;
+  uint64_t offset = 0;
+  size_t totalBytes = N * (sizeof(float) + sizeof(__nv_bfloat16));
+
+  for (int b : blockCountSweep(maxBlocks(N))) {
+    runBenchCore(
+        N,
+        b,
+        totalBytes,
+        [&](int nBlocks, int blockSize, int64_t nElts) {
+          benchSRCast<4><<<nBlocks, blockSize>>>(
+              d_srcFloat, d_dstBf16, nElts, seed, offset);
+        },
+        "f32→bf16(SR,pack=4)");
+  }
+}
+
+TEST_F(StochasticRoundingBench, BlockSweep_NaiveTruncation) {
+  constexpr int64_t N = 4 * 1024 * 1024;
+  printf(
+      "\n--- Naive Truncation block sweep: FP32→BF16 (%ldM elts) ---\n",
+      (long)(N / (1024 * 1024)));
+  size_t totalBytes = N * (sizeof(float) + sizeof(__nv_bfloat16));
+
+  for (int b : blockCountSweep(maxBlocks(N))) {
+    runBenchCore(
+        N,
+        b,
+        totalBytes,
+        [&](int nBlocks, int blockSize, int64_t nElts) {
+          benchNaiveCast<<<nBlocks, blockSize>>>(d_srcFloat, d_dstBf16, nElts);
+        },
+        "f32→bf16(naive)");
+  }
+}
+
+TEST_F(StochasticRoundingBench, BlockSweep_IdentityCopy) {
+  constexpr int64_t N = 4 * 1024 * 1024;
+  printf(
+      "\n--- Identity Copy block sweep: FP32→FP32 (%ldM elts) ---\n",
+      (long)(N / (1024 * 1024)));
+  size_t totalBytes = N * 2 * sizeof(float);
+
+  for (int b : blockCountSweep(maxBlocks(N))) {
+    runBenchCore(
+        N,
+        b,
+        totalBytes,
+        [&](int nBlocks, int blockSize, int64_t nElts) {
+          benchIdentityCopy<<<nBlocks, blockSize>>>(
+              d_srcFloat, d_dstFloat, nElts);
+        },
+        "f32→f32(identity)");
+  }
+}
+
+// clang-format off
+// We want to keep the format for the result below
+
+// GB200 results:
+/*
+--- Stochastic Rounding: FP32→BF16 (pack=1) vs Naive Truncation ---
+  f32→bf16(SR,pack=1)                          nBlocks=   4  nElts=      1024  avg=0.004 ms  BW=1.49 GB/s
+  f32→bf16(naive)                              nBlocks=   4  nElts=      1024  avg=0.004 ms  BW=1.49 GB/s
+  f32→bf16(SR,pack=1)                          nBlocks=  32  nElts=      8192  avg=0.004 ms  BW=11.95 GB/s
+  f32→bf16(naive)                              nBlocks=  32  nElts=      8192  avg=0.004 ms  BW=11.96 GB/s
+  f32→bf16(SR,pack=1)                          nBlocks= 256  nElts=     65536  avg=0.004 ms  BW=95.35 GB/s
+  f32→bf16(naive)                              nBlocks= 256  nElts=     65536  avg=0.004 ms  BW=95.47 GB/s
+  f32→bf16(SR,pack=1)                          nBlocks=1024  nElts=    524288  avg=0.005 ms  BW=573.94 GB/s
+  f32→bf16(naive)                              nBlocks=1024  nElts=    524288  avg=0.004 ms  BW=762.70 GB/s
+  f32→bf16(SR,pack=1)                          nBlocks=1024  nElts=   4194304  avg=0.014 ms  BW=1751.60 GB/s
+  f32→bf16(naive)                              nBlocks=1024  nElts=   4194304  avg=0.006 ms  BW=4069.72 GB/s
+  f32→bf16(SR,pack=1)                          nBlocks=1024  nElts=  16777216  avg=0.051 ms  BW=1963.34 GB/s
+  f32→bf16(naive)                              nBlocks=1024  nElts=  16777216  avg=0.027 ms  BW=3767.20 GB/s
+[       OK ] StochasticRoundingBench.FloatToBf16_Pack1_SizesSweep (236 ms)
+[ RUN      ] StochasticRoundingBench.FloatToBf16_Pack2_SizesSweep
+
+--- Stochastic Rounding: FP32→BF16 (pack=2) ---
+  f32→bf16(SR,pack=2)                          nBlocks=   4  nElts=      1024  avg=0.004 ms  BW=1.49 GB/s
+  f32→bf16(SR,pack=2)                          nBlocks=  32  nElts=      8192  avg=0.004 ms  BW=12.02 GB/s
+  f32→bf16(SR,pack=2)                          nBlocks= 256  nElts=     65536  avg=0.004 ms  BW=95.79 GB/s
+  f32→bf16(SR,pack=2)                          nBlocks=1024  nElts=    524288  avg=0.004 ms  BW=762.22 GB/s
+  f32→bf16(SR,pack=2)                          nBlocks=1024  nElts=   4194304  avg=0.009 ms  BW=2898.86 GB/s
+  f32→bf16(SR,pack=2)                          nBlocks=1024  nElts=  16777216  avg=0.029 ms  BW=3498.56 GB/s
+[       OK ] StochasticRoundingBench.FloatToBf16_Pack2_SizesSweep (29 ms)
+[ RUN      ] StochasticRoundingBench.FloatToBf16_Pack4_SizesSweep
+
+--- Stochastic Rounding: FP32→BF16 (pack=4) ---
+  f32→bf16(SR,pack=4)                          nBlocks=   4  nElts=      1024  avg=0.004 ms  BW=1.50 GB/s
+  f32→bf16(SR,pack=4)                          nBlocks=  32  nElts=      8192  avg=0.004 ms  BW=11.97 GB/s
+  f32→bf16(SR,pack=4)                          nBlocks= 256  nElts=     65536  avg=0.004 ms  BW=95.71 GB/s
+  f32→bf16(SR,pack=4)                          nBlocks=1024  nElts=    524288  avg=0.004 ms  BW=765.13 GB/s
+  f32→bf16(SR,pack=4)                          nBlocks=1024  nElts=   4194304  avg=0.007 ms  BW=3502.41 GB/s
+  f32→bf16(SR,pack=4)                          nBlocks=1024  nElts=  16777216  avg=0.019 ms  BW=5253.21 GB/s
+[       OK ] StochasticRoundingBench.FloatToBf16_Pack4_SizesSweep (29 ms)
+[ RUN      ] StochasticRoundingBench.IdentityCopy_FloatToFloat
+
+--- FP32→FP32 Identity Copy (bandwidth ceiling) ---
+  f32→f32(identity)                            nBlocks=   4  nElts=      1024  avg=0.004 ms  BW=1.99 GB/s
+  f32→f32(identity)                            nBlocks=  32  nElts=      8192  avg=0.004 ms  BW=15.92 GB/s
+  f32→f32(identity)                            nBlocks= 256  nElts=     65536  avg=0.004 ms  BW=127.39 GB/s
+  f32→f32(identity)                            nBlocks=1024  nElts=    524288  avg=0.004 ms  BW=1016.22 GB/s
+  f32→f32(identity)                            nBlocks=1024  nElts=   4194304  avg=0.008 ms  BW=4248.52 GB/s
+  f32→f32(identity)                            nBlocks=1024  nElts=  16777216  avg=0.041 ms  BW=3242.45 GB/s
+[       OK ] StochasticRoundingBench.IdentityCopy_FloatToFloat (30 ms)
+[ RUN      ] StochasticRoundingBench.BlockSweep_StochasticRounding
+
+--- Stochastic Rounding block sweep: FP32→BF16 (4M elts) ---
+  f32→bf16(SR,pack=4)                          nBlocks=   1  nElts=   4194304  avg=0.919 ms  BW=27.37 GB/s
+  f32→bf16(SR,pack=4)                          nBlocks=   2  nElts=   4194304  avg=0.465 ms  BW=54.17 GB/s
+  f32→bf16(SR,pack=4)                          nBlocks=   4  nElts=   4194304  avg=0.233 ms  BW=107.82 GB/s
+  f32→bf16(SR,pack=4)                          nBlocks=   8  nElts=   4194304  avg=0.119 ms  BW=211.85 GB/s
+  f32→bf16(SR,pack=4)                          nBlocks=  16  nElts=   4194304  avg=0.061 ms  BW=409.64 GB/s
+  f32→bf16(SR,pack=4)                          nBlocks=  32  nElts=   4194304  avg=0.033 ms  BW=767.30 GB/s
+  f32→bf16(SR,pack=4)                          nBlocks=  64  nElts=   4194304  avg=0.018 ms  BW=1364.48 GB/s
+  f32→bf16(SR,pack=4)                          nBlocks= 128  nElts=   4194304  avg=0.010 ms  BW=2448.80 GB/s
+  f32→bf16(SR,pack=4)                          nBlocks= 256  nElts=   4194304  avg=0.008 ms  BW=3066.13 GB/s
+  f32→bf16(SR,pack=4)                          nBlocks= 512  nElts=   4194304  avg=0.008 ms  BW=3065.41 GB/s
+  f32→bf16(SR,pack=4)                          nBlocks=1024  nElts=   4194304  avg=0.007 ms  BW=3483.64 GB/s
+[       OK ] StochasticRoundingBench.BlockSweep_StochasticRounding (231 ms)
+[ RUN      ] StochasticRoundingBench.BlockSweep_NaiveTruncation
+
+--- Naive Truncation block sweep: FP32→BF16 (4M elts) ---
+  f32→bf16(naive)                              nBlocks=   1  nElts=   4194304  avg=2.702 ms  BW=9.31 GB/s
+  f32→bf16(naive)                              nBlocks=   2  nElts=   4194304  avg=1.353 ms  BW=18.60 GB/s
+  f32→bf16(naive)                              nBlocks=   4  nElts=   4194304  avg=0.678 ms  BW=37.11 GB/s
+  f32→bf16(naive)                              nBlocks=   8  nElts=   4194304  avg=0.341 ms  BW=73.86 GB/s
+  f32→bf16(naive)                              nBlocks=  16  nElts=   4194304  avg=0.172 ms  BW=146.26 GB/s
+  f32→bf16(naive)                              nBlocks=  32  nElts=   4194304  avg=0.088 ms  BW=285.81 GB/s
+  f32→bf16(naive)                              nBlocks=  64  nElts=   4194304  avg=0.045 ms  BW=557.90 GB/s
+  f32→bf16(naive)                              nBlocks= 128  nElts=   4194304  avg=0.025 ms  BW=1022.79 GB/s
+  f32→bf16(naive)                              nBlocks= 256  nElts=   4194304  avg=0.014 ms  BW=1753.55 GB/s
+  f32→bf16(naive)                              nBlocks= 512  nElts=   4194304  avg=0.009 ms  BW=2788.77 GB/s
+  f32→bf16(naive)                              nBlocks=1024  nElts=   4194304  avg=0.006 ms  BW=4076.89 GB/s
+[       OK ] StochasticRoundingBench.BlockSweep_NaiveTruncation (619 ms)
+[ RUN      ] StochasticRoundingBench.BlockSweep_IdentityCopy
+
+--- Identity Copy block sweep: FP32→FP32 (4M elts) ---
+  f32→f32(identity)                            nBlocks=   1  nElts=   4194304  avg=2.699 ms  BW=12.43 GB/s
+  f32→f32(identity)                            nBlocks=   2  nElts=   4194304  avg=1.349 ms  BW=24.86 GB/s
+  f32→f32(identity)                            nBlocks=   4  nElts=   4194304  avg=0.676 ms  BW=49.64 GB/s
+  f32→f32(identity)                            nBlocks=   8  nElts=   4194304  avg=0.340 ms  BW=98.70 GB/s
+  f32→f32(identity)                            nBlocks=  16  nElts=   4194304  avg=0.172 ms  BW=195.10 GB/s
+  f32→f32(identity)                            nBlocks=  32  nElts=   4194304  avg=0.088 ms  BW=381.09 GB/s
+  f32→f32(identity)                            nBlocks=  64  nElts=   4194304  avg=0.045 ms  BW=743.78 GB/s
+  f32→f32(identity)                            nBlocks= 128  nElts=   4194304  avg=0.025 ms  BW=1364.27 GB/s
+  f32→f32(identity)                            nBlocks= 256  nElts=   4194304  avg=0.014 ms  BW=2334.99 GB/s
+  f32→f32(identity)                            nBlocks= 512  nElts=   4194304  avg=0.009 ms  BW=3627.29 GB/s
+  f32→f32(identity)                            nBlocks=1024  nElts=   4194304  avg=0.008 ms  BW=4237.70 GB/s
+*/


### PR DESCRIPTION
Summary:
Add `Apply_StochasticCast` template infrastructure for stochastic-rounding casts between precisions, with FP32→BF16 as the primary use case. This bridges the lower-level stochastic rounding primitives (added in 2/N) with NCCL's BytePack-based data movement, enabling quantized collectives to perform precision conversion inline during communication.

Key components:
- `stochastic_cast.cuh`: Template struct `Apply_StochasticCast<SrcType, DstType, EltPerPack>` with explicit specializations for FP32→BF16 at 1, 2, and 4 element pack sizes. The 2- and 4-element paths use hardware-accelerated stochastic rounding on Blackwell GPUs (SM ≥ 100) via native PTX `cvt.rs.satfinite.bf16x2.f32`, with a software fallback for pre-Blackwell. A general recursive case handles larger packs by splitting in half. Public API `applyStochasticCast<SrcType, DstType>(pack, seed, offset)` provides a clean entry point.
- `StochasticCastTest.cu`: Unit tests covering 1/2/4-element casts, public API correctness, statistical unbiasedness over 8192 trials, and determinism with identical seed/offset.
- `def_build.bzl`: Add header globs for `meta/collectives/*.h` and `meta/collectives/kernels/*.cuh`, and add deps on `philox_rng` and `stochastic_rounding` libraries.
- `BUCK`: Add `stochastic_cast_test` target.

Differential Revision: D94261255


