### PR TITLE
Dynamically Connected RDMA write test

### DIFF
--- a/comms/ctran/ibverbx/tests/IbverbxDcMultiRankTest.cc
+++ b/comms/ctran/ibverbx/tests/IbverbxDcMultiRankTest.cc
@@ -1,0 +1,403 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <optional>
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <folly/init/Init.h>
+#include <folly/logging/Init.h>
+#include <gtest/gtest.h>
+
+#include "comms/ctran/ibverbx/Ibverbx.h"
+#include "comms/ctran/ibverbx/IbverbxSymbols.h"
+#include "comms/ctran/ibverbx/tests/dc_utils.h"
+#include "comms/testinfra/mpi/MpiTestUtils.h"
+#include "comms/utils/checks.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+
+using ibverbx::createAddressHandle;
+using ibverbx::createDCI;
+using ibverbx::createDCT;
+using ibverbx::createSRQ;
+using ibverbx::DC_KEY;
+using ibverbx::DcBusinessCard;
+using ibverbx::kGidIndex;
+using ibverbx::kPortNum;
+using ibverbx::pollCqForCompletions;
+using ibverbx::transitionDCIToRts;
+using ibverbx::transitionDCTToRtr;
+
+FOLLY_INIT_LOGGING_CONFIG(
+    ".=WARNING"
+    ";default:async=true,sync_level=WARNING");
+
+class DcMultiRankTestFixture : public meta::comms::MpiBaseTestFixture {
+ protected:
+  void SetUp() override {
+    MpiBaseTestFixture::SetUp();
+    ncclCvarInit();
+    ASSERT_TRUE(ibverbx::ibvInit());
+
+    CUDA_CHECK(cudaSetDevice(localRank));
+    CUDA_CHECK(cudaGetDevice(&myDevId_));
+
+    // Get device and allocate PD
+    auto devices =
+        ibverbx::IbvDevice::ibvGetDeviceList(NCCL_IB_HCA, NCCL_IB_HCA_PREFIX);
+    ASSERT_TRUE(devices);
+    devices_.emplace(std::move(*devices));
+    auto& device = devices_->at(myDevId_);
+
+    auto pd = device.allocPd();
+    ASSERT_TRUE(pd);
+    pd_.emplace(std::move(*pd));
+
+    // Create CQ and SRQ
+    auto cq = device.createCq(kCqe, nullptr, nullptr, 0);
+    ASSERT_TRUE(cq);
+    cq_.emplace(std::move(*cq));
+
+    auto srqResult = createSRQ(*pd_, kSrqMaxWr);
+    ASSERT_TRUE(srqResult) << "Failed to create SRQ: "
+                           << srqResult.error().errStr;
+    srq_.emplace(std::move(*srqResult));
+
+    // Create DCI and DCT
+    auto dciResult = createDCI(*pd_, *cq_);
+    auto dctResult = createDCT(*pd_, *cq_, *srq_);
+
+    // Check if QP creation succeeded across all ranks
+    int localSuccess = (dciResult.hasValue() && dctResult.hasValue()) ? 1 : 0;
+    int globalSuccess = 0;
+    MPI_CHECK(MPI_Allreduce(
+        &localSuccess, &globalSuccess, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD));
+
+    if (globalSuccess == 0) {
+      GTEST_SKIP() << "DC QP creation failed on one or more ranks";
+    }
+
+    dci_.emplace(std::move(*dciResult));
+    dct_.emplace(std::move(*dctResult));
+
+    // Get extended QP interfaces for DC send operations
+    exQp_ = ibverbx::ibvSymbols.ibv_internal_qp_to_qp_ex(dci_->qp());
+    dvQp_ = ibverbx::ibvSymbols.mlx5dv_internal_qp_ex_from_ibv_qp_ex(exQp_);
+    ASSERT_NE(exQp_, nullptr);
+    ASSERT_NE(dvQp_, nullptr);
+
+    // Transition QPs to operational states
+    auto dciTransitionResult =
+        transitionDCIToRts(*dci_, kPortNum, ibverbx::IBV_MTU_4096);
+    ASSERT_TRUE(dciTransitionResult) << "Failed to transition DCI to RTS: "
+                                     << dciTransitionResult.error().errStr;
+    auto dctTransitionResult =
+        transitionDCTToRtr(*dct_, kPortNum, ibverbx::IBV_MTU_4096);
+    ASSERT_TRUE(dctTransitionResult) << "Failed to transition DCT to RTR: "
+                                     << dctTransitionResult.error().errStr;
+
+    // Query GID
+    auto gid = device.queryGid(kPortNum, kGidIndex);
+    ASSERT_TRUE(gid);
+    gid_ = *gid;
+  }
+
+  ibverbx::IbvDevice& device() {
+    return devices_->at(myDevId_);
+  }
+
+  static constexpr int kCqe = 2048;
+  static constexpr int kSrqMaxWr = 2048;
+
+  int myDevId_{-1};
+  std::optional<std::vector<ibverbx::IbvDevice>> devices_;
+  std::optional<ibverbx::IbvPd> pd_;
+  std::optional<ibverbx::IbvCq> cq_;
+  std::optional<ibverbx::IbvSrq> srq_;
+  std::optional<ibverbx::IbvQp> dci_;
+  std::optional<ibverbx::IbvQp> dct_;
+  ibverbx::ibv_qp_ex* exQp_{nullptr};
+  struct mlx5dv_qp_ex* dvQp_{nullptr};
+  ibverbx::ibv_gid gid_{};
+};
+
+// Ring communication test: each rank sends to (rank+1) % numRanks
+TEST_F(DcMultiRankTestFixture, RingRdmaWrite) {
+  // Allocate and initialize device buffer
+  size_t devBufSize = 1024 * 1024; // 1MB
+  void* devBuf{nullptr};
+  CUDA_CHECK(cudaMalloc(&devBuf, devBufSize));
+  size_t numElements = devBufSize / sizeof(int64_t);
+  std::vector<int64_t> hostBuf(numElements);
+
+  // Initialize with zeros (will be overwritten by sender)
+  std::fill(hostBuf.begin(), hostBuf.end(), 0);
+  CUDA_CHECK(cudaMemcpy(devBuf, hostBuf.data(), devBufSize, cudaMemcpyDefault));
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  // Register memory
+  auto access = static_cast<ibverbx::ibv_access_flags>(
+      ibverbx::IBV_ACCESS_LOCAL_WRITE | ibverbx::IBV_ACCESS_REMOTE_WRITE |
+      ibverbx::IBV_ACCESS_REMOTE_READ);
+  auto mr = pd_->regMr(devBuf, devBufSize, access);
+  ASSERT_TRUE(mr);
+
+  // Create and exchange business cards
+  DcBusinessCard localCard = {
+      .mtu = 5, // IBV_MTU_4096 = 5
+      .dctNum = dct_->qp()->qp_num,
+      .port = kPortNum,
+      .subnetPrefix = gid_.global.subnet_prefix,
+      .interfaceId = gid_.global.interface_id,
+      .rank = globalRank,
+      .remoteAddr = reinterpret_cast<uint64_t>(devBuf),
+      .rkey = mr->mr()->rkey,
+  };
+
+  std::vector<DcBusinessCard> cards(numRanks);
+  MPI_CHECK(MPI_Allgather(
+      &localCard,
+      sizeof(DcBusinessCard),
+      MPI_BYTE,
+      cards.data(),
+      sizeof(DcBusinessCard),
+      MPI_BYTE,
+      MPI_COMM_WORLD));
+
+  for (int i = 0; i < numRanks; i++) {
+    const auto& card = cards.at(i);
+    XLOG(INFO) << "rank " << globalRank << ": got card " << card;
+  }
+
+  // Send to next rank, receive from previous rank
+  int sendToRank = (globalRank + 1) % numRanks;
+  int recvFromRank = (globalRank + numRanks - 1) % numRanks;
+  const auto& targetCard = cards.at(sendToRank);
+
+  XLOGF(
+      INFO,
+      "rank {}: sending to rank {}, receiving from rank {}",
+      globalRank,
+      sendToRank,
+      recvFromRank);
+
+  // Synchronize before posting work
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  // Prepare data to send: fill with sender's rank as pattern
+  std::fill(hostBuf.begin(), hostBuf.end(), static_cast<int64_t>(globalRank));
+  void* sendBuf{nullptr};
+  CUDA_CHECK(cudaMalloc(&sendBuf, devBufSize));
+  CUDA_CHECK(
+      cudaMemcpy(sendBuf, hostBuf.data(), devBufSize, cudaMemcpyDefault));
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  auto sendMr = pd_->regMr(sendBuf, devBufSize, access);
+  ASSERT_TRUE(sendMr);
+
+  // Create address handle for target DCT
+  auto ahResult = createAddressHandle(*pd_, targetCard);
+  ASSERT_TRUE(ahResult) << "Failed to create Address Handle: "
+                        << ahResult.error().errStr;
+  auto ah = std::move(*ahResult);
+
+  // Post RDMA write to next rank
+  ibverbx::ibv_sge sendSge{};
+  sendSge.addr = reinterpret_cast<uint64_t>(sendBuf);
+  sendSge.length = static_cast<uint32_t>(devBufSize);
+  sendSge.lkey = sendMr->mr()->lkey;
+
+  ibverbx::ibvSymbols.ibv_internal_wr_start(exQp_);
+  exQp_->wr_id = static_cast<uint64_t>(sendToRank);
+  exQp_->wr_flags = ibverbx::IBV_SEND_SIGNALED;
+  ibverbx::ibvSymbols.ibv_internal_wr_rdma_write(
+      exQp_, targetCard.rkey, targetCard.remoteAddr);
+  ibverbx::ibvSymbols.ibv_internal_wr_set_sge_list(exQp_, 1, &sendSge);
+  ibverbx::ibvSymbols.mlx5dv_internal_wr_set_dc_addr(
+      dvQp_, ah.ah(), targetCard.dctNum, DC_KEY);
+  int ret = ibverbx::ibvSymbols.ibv_internal_wr_complete(exQp_);
+  ASSERT_EQ(ret, 0) << "Failed to post DC RDMA write";
+
+  XLOGF(INFO, "Rank {}: Posted RDMA write to rank {}", globalRank, sendToRank);
+
+  // Wait for send completion only (plain RDMA write has no receiver completion)
+  auto pollResult = pollCqForCompletions(globalRank, *cq_, 1);
+  ASSERT_TRUE(pollResult) << "CQ poll failed: " << pollResult.error().errStr;
+
+  // Synchronize to ensure all writes have landed before verification
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  // Verify received data - should be filled with recvFromRank's value
+  std::vector<int64_t> recvBuf(numElements);
+  CUDA_CHECK(cudaMemcpy(recvBuf.data(), devBuf, devBufSize, cudaMemcpyDefault));
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  std::vector<int64_t> expectedBuf(
+      numElements, static_cast<int64_t>(recvFromRank));
+  ASSERT_EQ(recvBuf, expectedBuf)
+      << "Data mismatch: expected data from rank " << recvFromRank;
+
+  XLOGF(
+      INFO,
+      "Rank {}: Ring RDMA write test passed - verified data from rank {}",
+      globalRank,
+      recvFromRank);
+
+  // Cleanup - RAII handles ibverbx objects
+  CUDA_CHECK(cudaFree(sendBuf));
+  CUDA_CHECK(cudaFree(devBuf));
+}
+
+// All-to-all communication test: each rank sends to all other ranks
+TEST_F(DcMultiRankTestFixture, AllToAllRdmaWrite) {
+  // Allocate receive buffer - one slot per sender
+  size_t slotSize = 1024; // 1KB per sender
+  size_t totalRecvSize = slotSize * numRanks;
+  void* recvBuf{nullptr};
+  CUDA_CHECK(cudaMalloc(&recvBuf, totalRecvSize));
+
+  // Initialize receive buffer to zeros
+  CUDA_CHECK(cudaMemset(recvBuf, 0, totalRecvSize));
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  // Allocate send buffer
+  void* sendBuf{nullptr};
+  CUDA_CHECK(cudaMalloc(&sendBuf, slotSize));
+
+  // Fill send buffer with sender's rank
+  size_t numElements = slotSize / sizeof(int64_t);
+  std::vector<int64_t> hostSendBuf(numElements);
+  std::fill(
+      hostSendBuf.begin(), hostSendBuf.end(), static_cast<int64_t>(globalRank));
+  CUDA_CHECK(
+      cudaMemcpy(sendBuf, hostSendBuf.data(), slotSize, cudaMemcpyDefault));
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  // Register memory
+  auto access = static_cast<ibverbx::ibv_access_flags>(
+      ibverbx::IBV_ACCESS_LOCAL_WRITE | ibverbx::IBV_ACCESS_REMOTE_WRITE |
+      ibverbx::IBV_ACCESS_REMOTE_READ);
+  auto recvMr = pd_->regMr(recvBuf, totalRecvSize, access);
+  ASSERT_TRUE(recvMr);
+  auto sendMr = pd_->regMr(sendBuf, slotSize, access);
+  ASSERT_TRUE(sendMr);
+
+  // Create and exchange business cards
+  DcBusinessCard localCard = {
+      .mtu = 5, // IBV_MTU_4096 = 5
+      .dctNum = dct_->qp()->qp_num,
+      .port = kPortNum,
+      .subnetPrefix = gid_.global.subnet_prefix,
+      .interfaceId = gid_.global.interface_id,
+      .rank = globalRank,
+      .remoteAddr = reinterpret_cast<uint64_t>(recvBuf),
+      .rkey = recvMr->mr()->rkey,
+  };
+
+  std::vector<DcBusinessCard> cards(numRanks);
+  MPI_CHECK(MPI_Allgather(
+      &localCard,
+      sizeof(DcBusinessCard),
+      MPI_BYTE,
+      cards.data(),
+      sizeof(DcBusinessCard),
+      MPI_BYTE,
+      MPI_COMM_WORLD));
+
+  // Create address handles for all remote DCTs
+  std::vector<ibverbx::IbvAh> addressHandles;
+  addressHandles.reserve(numRanks);
+  for (int i = 0; i < numRanks; ++i) {
+    if (i != globalRank) {
+      auto ahResult = createAddressHandle(*pd_, cards.at(i));
+      ASSERT_TRUE(ahResult) << "Failed to create AH for rank " << i;
+      addressHandles.emplace_back(std::move(*ahResult));
+    } else {
+      // Placeholder for self - create a dummy AH that won't be used
+      addressHandles.emplace_back();
+    }
+  }
+
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  for (int i = 0; i < numRanks; i++) {
+    if (i == globalRank) {
+      continue;
+    }
+
+    int recvFromRank = i;
+    int sendToRank = i;
+    XLOG(INFO) << "rank " << globalRank << ": sending to rank " << sendToRank
+               << ", receiving from rank " << recvFromRank;
+
+    const auto& card = cards.at(i);
+    XLOG(INFO) << "rank " << globalRank << ": got card " << card;
+
+    // Each sender writes to their designated slot in the receiver's buffer
+    uint64_t targetAddr = card.remoteAddr + (globalRank * slotSize);
+
+    // Post RDMA write to target rank's designated slot
+    ibverbx::ibv_sge sendSge{};
+    sendSge.addr = reinterpret_cast<uint64_t>(sendBuf);
+    sendSge.length = static_cast<uint32_t>(slotSize);
+    sendSge.lkey = sendMr->mr()->lkey;
+
+    ibverbx::ibvSymbols.ibv_internal_wr_start(exQp_);
+    exQp_->wr_id = static_cast<uint64_t>(sendToRank);
+    exQp_->wr_flags = ibverbx::IBV_SEND_SIGNALED;
+    ibverbx::ibvSymbols.ibv_internal_wr_rdma_write(
+        exQp_, card.rkey, targetAddr);
+    ibverbx::ibvSymbols.ibv_internal_wr_set_sge_list(exQp_, 1, &sendSge);
+    ibverbx::ibvSymbols.mlx5dv_internal_wr_set_dc_addr(
+        dvQp_, addressHandles[i].ah(), card.dctNum, DC_KEY);
+    int ret = ibverbx::ibvSymbols.ibv_internal_wr_complete(exQp_);
+    ASSERT_EQ(ret, 0) << "Failed to post DC RDMA write to rank "
+                      << recvFromRank;
+  }
+
+  XLOGF(INFO, "Rank {}: Posted RDMA write to all other ranks", globalRank);
+
+  // Wait for send completions only (plain RDMA write has no receiver
+  // completion)
+  int expectedCompletions = numRanks - 1;
+  auto pollResult = pollCqForCompletions(globalRank, *cq_, expectedCompletions);
+  ASSERT_TRUE(pollResult) << "CQ poll failed: " << pollResult.error().errStr;
+
+  // Synchronize to ensure all writes have landed before verification
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  // Verify received data from each sender
+  std::vector<int64_t> recvHostBuf(totalRecvSize / sizeof(int64_t));
+  CUDA_CHECK(cudaMemcpy(
+      recvHostBuf.data(), recvBuf, totalRecvSize, cudaMemcpyDefault));
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  // Construct expected buffer and compare as a whole
+  std::vector<int64_t> expectedBuf(totalRecvSize / sizeof(int64_t));
+  for (int recvFromRank = 0; recvFromRank < numRanks; recvFromRank++) {
+    int64_t expectedValue =
+        (recvFromRank == globalRank) ? 0 : static_cast<int64_t>(recvFromRank);
+    std::fill(
+        expectedBuf.begin() + recvFromRank * numElements,
+        expectedBuf.begin() + (recvFromRank + 1) * numElements,
+        expectedValue);
+  }
+  ASSERT_EQ(recvHostBuf, expectedBuf)
+      << "Data mismatch in all-to-all verification at rank " << globalRank;
+
+  XLOGF(
+      INFO,
+      "Rank {}: All-to-all RDMA write test passed - verified data from all {} peers",
+      globalRank,
+      numRanks - 1);
+
+  // Cleanup - RAII handles ibverbx objects
+  CUDA_CHECK(cudaFree(sendBuf));
+  CUDA_CHECK(cudaFree(recvBuf));
+}
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new meta::comms::MPIEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ctran/ibverbx/tests/dc_utils.cc
+++ b/comms/ctran/ibverbx/tests/dc_utils.cc
@@ -1,0 +1,256 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/ctran/ibverbx/tests/dc_utils.h"
+
+#include <chrono>
+
+#include <fmt/format.h>
+#include <folly/logging/xlog.h>
+
+namespace ibverbx {
+
+std::ostream& operator<<(std::ostream& out, DcBusinessCard const& card) {
+  out << fmt::format(
+      "<rank {} qp-num {}, port {}, gid {:x}/{:x} remoteAddr {:x}, rkey {:x}>",
+      card.rank,
+      card.dctNum,
+      card.port,
+      card.subnetPrefix,
+      card.interfaceId,
+      card.remoteAddr,
+      card.rkey);
+  return out;
+}
+
+folly::Expected<IbvSrq, Error> createSRQ(IbvPd& pd, int maxWr, int maxSge) {
+  ibv_srq_init_attr srqAttr{};
+  srqAttr.attr.max_wr = maxWr;
+  srqAttr.attr.max_sge = maxSge;
+  return pd.createSrq(&srqAttr);
+}
+
+folly::Expected<IbvQp, Error> createDCI(IbvPd& pd, IbvCq& cq) {
+  mlx5dv_qp_init_attr dvInitAttr{};
+  ibv_qp_init_attr_ex initAttr{};
+
+  initAttr.qp_type = IBV_QPT_DRIVER;
+  initAttr.send_cq = cq.cq();
+  initAttr.recv_cq = cq.cq();
+  initAttr.comp_mask = IBV_QP_INIT_ATTR_PD;
+
+  initAttr.cap.max_send_wr = 1024;
+  initAttr.cap.max_send_sge = 1;
+  initAttr.comp_mask |= IBV_QP_INIT_ATTR_SEND_OPS_FLAGS;
+  initAttr.send_ops_flags = IBV_QP_EX_WITH_RDMA_WRITE;
+
+  dvInitAttr.comp_mask = MLX5DV_QP_INIT_ATTR_MASK_DC;
+  dvInitAttr.dc_init_attr.dc_type = MLX5DV_DCTYPE_DCI;
+
+  return pd.createDcQp(&initAttr, &dvInitAttr);
+}
+
+folly::Expected<IbvQp, Error>
+createDCT(IbvPd& pd, IbvCq& cq, IbvSrq& srq, uint64_t dcKey) {
+  mlx5dv_qp_init_attr dvInitAttr{};
+  ibv_qp_init_attr_ex initAttr{};
+
+  initAttr.qp_type = IBV_QPT_DRIVER;
+  initAttr.send_cq = cq.cq();
+  initAttr.recv_cq = cq.cq();
+  initAttr.srq = srq.srq();
+  initAttr.comp_mask = IBV_QP_INIT_ATTR_PD;
+
+  dvInitAttr.comp_mask = MLX5DV_QP_INIT_ATTR_MASK_DC;
+  dvInitAttr.dc_init_attr.dc_type = MLX5DV_DCTYPE_DCT;
+  dvInitAttr.dc_init_attr.dct_access_key = dcKey;
+
+  return pd.createDcQp(&initAttr, &dvInitAttr);
+}
+
+folly::Expected<folly::Unit, Error>
+transitionDCIToRts(IbvQp& qp, uint8_t port, ibv_mtu mtu) {
+  ibv_qp_attr qpAttr{};
+
+  // RESET -> INIT
+  qpAttr.qp_state = IBV_QPS_INIT;
+  qpAttr.pkey_index = 0;
+  qpAttr.port_num = port;
+  auto initResult =
+      qp.modifyQp(&qpAttr, IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT);
+  if (initResult.hasError()) {
+    return folly::makeUnexpected(Error(
+        initResult.error().errNum,
+        fmt::format(
+            "Failed to transition DCI to INIT: {}",
+            initResult.error().errStr)));
+  }
+
+  // INIT -> RTR
+  qpAttr = {};
+  qpAttr.qp_state = IBV_QPS_RTR;
+  qpAttr.path_mtu = mtu;
+  qpAttr.ah_attr.is_global = 1;
+  qpAttr.ah_attr.grh.sgid_index = kGidIndex;
+  qpAttr.ah_attr.port_num = port;
+  auto rtrResult =
+      qp.modifyQp(&qpAttr, IBV_QP_STATE | IBV_QP_PATH_MTU | IBV_QP_AV);
+  if (rtrResult.hasError()) {
+    return folly::makeUnexpected(Error(
+        rtrResult.error().errNum,
+        fmt::format(
+            "Failed to transition DCI to RTR: {}", rtrResult.error().errStr)));
+  }
+
+  // RTR -> RTS
+  qpAttr = {};
+  qpAttr.qp_state = IBV_QPS_RTS;
+  qpAttr.timeout = 14;
+  qpAttr.retry_cnt = 7;
+  qpAttr.rnr_retry = 7;
+  qpAttr.sq_psn = 0;
+  qpAttr.max_rd_atomic = 1;
+  auto rtsResult = qp.modifyQp(
+      &qpAttr,
+      IBV_QP_STATE | IBV_QP_TIMEOUT | IBV_QP_RETRY_CNT | IBV_QP_RNR_RETRY |
+          IBV_QP_SQ_PSN | IBV_QP_MAX_QP_RD_ATOMIC);
+  if (rtsResult.hasError()) {
+    return folly::makeUnexpected(Error(
+        rtsResult.error().errNum,
+        fmt::format(
+            "Failed to transition DCI to RTS: {}", rtsResult.error().errStr)));
+  }
+
+  return folly::unit;
+}
+
+folly::Expected<folly::Unit, Error>
+transitionDCTToRtr(IbvQp& qp, uint8_t port, ibv_mtu mtu) {
+  ibv_qp_attr qpAttr{};
+
+  // RESET -> INIT (DCT needs access flags for remote operations)
+  qpAttr.qp_state = IBV_QPS_INIT;
+  qpAttr.pkey_index = 0;
+  qpAttr.port_num = port;
+  qpAttr.qp_access_flags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ |
+      IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_ATOMIC;
+  auto initResult = qp.modifyQp(
+      &qpAttr,
+      IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_ACCESS_FLAGS);
+  if (initResult.hasError()) {
+    return folly::makeUnexpected(Error(
+        initResult.error().errNum,
+        fmt::format(
+            "Failed to transition DCT to INIT: {}",
+            initResult.error().errStr)));
+  }
+
+  // INIT -> RTR
+  qpAttr = {};
+  qpAttr.qp_state = IBV_QPS_RTR;
+  qpAttr.path_mtu = mtu;
+  qpAttr.min_rnr_timer = 12;
+  // DCT requires these GRH attributes for RTR transition
+  qpAttr.ah_attr.is_global = 1;
+  qpAttr.ah_attr.grh.traffic_class = 0;
+  qpAttr.ah_attr.grh.flow_label = 0;
+  qpAttr.ah_attr.grh.sgid_index = kGidIndex;
+  qpAttr.ah_attr.grh.hop_limit = 255;
+  qpAttr.ah_attr.port_num = port;
+  auto rtrResult = qp.modifyQp(
+      &qpAttr,
+      IBV_QP_STATE | IBV_QP_PATH_MTU | IBV_QP_MIN_RNR_TIMER | IBV_QP_AV);
+  if (rtrResult.hasError()) {
+    return folly::makeUnexpected(Error(
+        rtrResult.error().errNum,
+        fmt::format(
+            "Failed to transition DCT to RTR: {}", rtrResult.error().errStr)));
+  }
+
+  return folly::unit;
+}
+
+folly::Expected<IbvAh, Error> createAddressHandle(
+    IbvPd& pd,
+    const DcBusinessCard& remoteCard,
+    uint8_t sgidIndex) {
+  ibv_ah_attr ahAttr{};
+  ahAttr.is_global = 1;
+  ahAttr.grh.dgid.global.subnet_prefix = remoteCard.subnetPrefix;
+  ahAttr.grh.dgid.global.interface_id = remoteCard.interfaceId;
+  ahAttr.grh.flow_label = 0;
+  ahAttr.grh.sgid_index = sgidIndex;
+  ahAttr.grh.hop_limit = 255;
+  ahAttr.grh.traffic_class = 0;
+  ahAttr.sl = 0;
+  ahAttr.src_path_bits = 0;
+  ahAttr.port_num = remoteCard.port;
+
+  return pd.createAh(&ahAttr);
+}
+
+folly::Expected<folly::Unit, Error> pollCqForCompletions(
+    int rank,
+    IbvCq& cq,
+    int expectedCompletions,
+    int timeoutMs) {
+  int completedCount = 0;
+  auto startTime = std::chrono::steady_clock::now();
+
+  while (completedCount < expectedCompletions) {
+    auto maybeWcsVector = cq.pollCq(expectedCompletions);
+    if (maybeWcsVector.hasError()) {
+      return folly::makeUnexpected(Error(
+          maybeWcsVector.error().errNum,
+          fmt::format(
+              "rank {}: CQ poll failed: {}",
+              rank,
+              maybeWcsVector.error().errStr)));
+    }
+
+    auto numWc = maybeWcsVector->size();
+    for (size_t i = 0; i < numWc; ++i) {
+      const auto& wc = maybeWcsVector->at(i);
+      if (wc.status != IBV_WC_SUCCESS) {
+        return folly::makeUnexpected(Error(
+            static_cast<int>(wc.status),
+            fmt::format(
+                "rank {} got WC status {}, opcode={}, wr_id={}, vendor_err={}",
+                rank,
+                wc.status,
+                wc.opcode,
+                wc.wr_id,
+                wc.vendor_err)));
+      }
+      completedCount++;
+      XLOGF(
+          DBG1,
+          "Rank {} got WC {}/{}: wr_id={}, opcode={}",
+          rank,
+          completedCount,
+          expectedCompletions,
+          wc.wr_id,
+          wc.opcode);
+    }
+
+    if (completedCount < expectedCompletions && numWc == 0) {
+      auto elapsed = std::chrono::steady_clock::now() - startTime;
+      auto elapsedMs =
+          std::chrono::duration_cast<std::chrono::milliseconds>(elapsed)
+              .count();
+      if (elapsedMs >= timeoutMs) {
+        return folly::makeUnexpected(Error(
+            ETIMEDOUT,
+            fmt::format(
+                "rank {}: CQ poll timed out after {}ms, got {}/{} completions",
+                rank,
+                timeoutMs,
+                completedCount,
+                expectedCompletions)));
+      }
+    }
+  }
+
+  return folly::unit;
+}
+
+} // namespace ibverbx

--- a/comms/ctran/ibverbx/tests/dc_utils.h
+++ b/comms/ctran/ibverbx/tests/dc_utils.h
@@ -1,0 +1,73 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cstdint>
+#include <ostream>
+#include <string>
+
+#include "comms/ctran/ibverbx/IbvAh.h"
+#include "comms/ctran/ibverbx/IbvCq.h"
+#include "comms/ctran/ibverbx/IbvPd.h"
+#include "comms/ctran/ibverbx/IbvQp.h"
+#include "comms/ctran/ibverbx/IbvSrq.h"
+#include "comms/ctran/ibverbx/Ibvcore.h"
+
+namespace ibverbx {
+
+// DC Authentication Key
+constexpr uint64_t DC_KEY = 0x1234;
+
+// mlx5 is the only supported NIC for DC
+inline const std::string kNicPrefix("mlx5_");
+
+constexpr uint8_t kPortNum = 1;
+
+#if defined(USE_FE_NIC)
+constexpr int kGidIndex = 1;
+#else
+constexpr int kGidIndex = 3;
+#endif
+
+struct DcBusinessCard {
+  int mtu{5}; // IBV_MTU_4096 = 5, use int to avoid enum forward decl issues
+  uint32_t dctNum{0}; // DCT number for receiving
+  uint8_t port{0};
+  uint64_t subnetPrefix{0};
+  uint64_t interfaceId{0};
+  int32_t rank{-1};
+  // Memory registration info for RDMA_WRITE
+  uint64_t remoteAddr{0};
+  uint32_t rkey{0};
+};
+
+std::ostream& operator<<(std::ostream& out, DcBusinessCard const& card);
+
+// helper functions using ibverbx types
+
+folly::Expected<IbvSrq, Error>
+createSRQ(IbvPd& pd, int maxWr = 256, int maxSge = 1);
+
+folly::Expected<IbvQp, Error> createDCI(IbvPd& pd, IbvCq& cq);
+
+folly::Expected<IbvQp, Error>
+createDCT(IbvPd& pd, IbvCq& cq, IbvSrq& srq, uint64_t dcKey = DC_KEY);
+
+folly::Expected<folly::Unit, Error>
+transitionDCIToRts(IbvQp& qp, uint8_t port, ibv_mtu mtu);
+
+folly::Expected<folly::Unit, Error>
+transitionDCTToRtr(IbvQp& qp, uint8_t port, ibv_mtu mtu);
+
+folly::Expected<IbvAh, Error> createAddressHandle(
+    IbvPd& pd,
+    const DcBusinessCard& remoteCard,
+    uint8_t sgidIndex = kGidIndex);
+
+folly::Expected<folly::Unit, Error> pollCqForCompletions(
+    int rank,
+    IbvCq& cq,
+    int expectedCompletions,
+    int timeoutMs = 30000);
+
+} // namespace ibverbx


### PR DESCRIPTION
Summary:
Dynamic Connection (DC) is a transport protocol used within RDMA implementations, improving scalability over the widely used Reliably Connected (RC) transport. DC reduces the total number of QPs required system-wide, by having QPs of reliable type dynamically connect and disconnect from any remote node. (see https://docs.nvidia.com/networking/display/rdmacore50/dynamically+connected+(dc)+qps) Currently, we are using RC within RDMA implementations for ctran.

In this diff, we experiment with DC using RDMA write tests. This is an initial experiment with the goal of eventually implementing and benchmarking DC as a potential alternative to RC.

We have two types of RDMA write tests implemented here: one that does a ring pattern (each rank receives from rank (n-1)%numRanks, sends to rank (n+1)%numRanks), and one that does an all-to-all pattern (receives from every rank and sends to every rank)

Reviewed By: GirasoleY

Differential Revision: D91064760


