### PR TITLE
Remove redundant abort_process_on_timeout_or_error check in graph capture

### DIFF
--- a/comms/torchcomms/ncclx/TorchCommNCCLXUtils.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXUtils.cpp
@@ -379,14 +379,6 @@ void TorchCommNCCLX::enqueueWork(
     c10::intrusive_ptr<TorchWorkNCCLX> work,
     cudaStream_t stream) {
   if (getGraphCaptureMode()) {
-    // Graph replay timeouts are unrecoverable — there is no way to halt a
-    // replaying graph. The only safe response is abort().
-    if (!options_.abort_process_on_timeout_or_error) {
-      throw std::runtime_error(
-          "CUDA graph capture requires abort_process_on_timeout_or_error=true. "
-          "Graph replay timeouts are unrecoverable and must abort the process.");
-    }
-
     // Transfer start/end event ownership to the tracker.
     // Work object is NOT stored — it will be destroyed when the caller's
     // intrusive_ptr goes out of scope, destroying ad-hoc sync_event_.

--- a/comms/torchcomms/ncclx/tests/unit/cpp/GraphEventTrackerTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/GraphEventTrackerTest.cpp
@@ -157,36 +157,6 @@ TEST_F(
       "Graph monitor: collective TIMED OUT for graph");
 }
 
-TEST_F(GraphEventTrackerTest, GraphCaptureRejectsNoAbortMode) {
-  setupCCAExpectations(1, 2, 1);
-
-  auto comm = createMockedTorchComm();
-  cuda_mock_->setupDefaultBehaviors();
-  nccl_mock_->setupDefaultBehaviors();
-  comm->init(*device_, "test_graph_no_abort", default_options_);
-
-  setupGraphCaptureMocks();
-
-  auto tensor = createTestTensor({10, 10});
-
-  EXPECT_THROW(
-      {
-        try {
-          auto work = comm->send(tensor, 1, true);
-        } catch (const std::runtime_error& e) {
-          std::string error_msg = e.what();
-          EXPECT_TRUE(
-              error_msg.find("abort_process_on_timeout_or_error=true") !=
-              std::string::npos);
-          throw;
-        }
-      },
-      std::runtime_error);
-
-  switchToReplayMode();
-  setupFinalizeExpectations(*comm);
-}
-
 TEST_F(GraphEventTrackerTest, GraphCaptureWorkObjectsDestroyedAfterCapture) {
   setupCCAExpectations(1, 2, 1);
 


### PR DESCRIPTION
Summary:
Remove the check in enqueueWork() that required abort_process_on_timeout_or_error=true during CUDA graph capture, along with its unit test GraphCaptureRejectsNoAbortMode.

- Upcoming diffs will make abort mode the only supported mode, so this guard is no longer needed.

Differential Revision: D94266658


