### PR TITLE
torchcomms: add method to get ranks (#834)

### DIFF
--- a/comms/torchcomms/TorchComm.cpp
+++ b/comms/torchcomms/TorchComm.cpp
@@ -8,7 +8,22 @@ namespace torch::comms {
 TorchComm::TorchComm(
     const std::string& backend_name,
     std::shared_ptr<TorchCommBackend> impl)
-    : backend_(backend_name), impl_(std::move(impl)) {}
+    : backend_(backend_name), impl_(std::move(impl)) {
+  // Initialize ranks_ for root communicator: [0, 1, 2, ..., size-1]
+  int size = impl_->getSize();
+  ranks_.reserve(size);
+  for (int i = 0; i < size; ++i) {
+    ranks_.push_back(i);
+  }
+}
+
+TorchComm::TorchComm(
+    const std::string& backend_name,
+    std::shared_ptr<TorchCommBackend> impl,
+    std::vector<int> ranks)
+    : backend_(backend_name),
+      impl_(std::move(impl)),
+      ranks_(std::move(ranks)) {}
 
 std::shared_ptr<TorchComm> new_comm(
     const std::string& backend_name,
@@ -32,6 +47,10 @@ int TorchComm::getRank() const {
 
 int TorchComm::getSize() const {
   return impl_->getSize();
+}
+
+std::vector<int> TorchComm::getRanks() const {
+  return ranks_;
 }
 
 std::string_view TorchComm::getCommName() const {
@@ -593,8 +612,14 @@ std::shared_ptr<TorchComm> TorchComm::split(
   if (new_impl == nullptr) {
     return nullptr;
   }
-  auto comm =
-      std::shared_ptr<TorchComm>(new TorchComm(backend_, std::move(new_impl)));
+  // Map the local ranks to global ranks from this communicator
+  std::vector<int> global_ranks;
+  global_ranks.reserve(ranks.size());
+  for (int local_rank : ranks) {
+    global_ranks.push_back(ranks_[local_rank]);
+  }
+  auto comm = std::shared_ptr<TorchComm>(
+      new TorchComm(backend_, std::move(new_impl), std::move(global_ranks)));
   postHook(
       PostHookArgs{
           .name = OpName::split,

--- a/comms/torchcomms/TorchComm.hpp
+++ b/comms/torchcomms/TorchComm.hpp
@@ -37,6 +37,7 @@ class TorchComm : public std::enable_shared_from_this<TorchComm> {
   void finalize();
   int getRank() const;
   int getSize() const;
+  std::vector<int> getRanks() const;
   std::string_view getCommName() const;
 
   // Point-to-Point Operations
@@ -233,10 +234,16 @@ class TorchComm : public std::enable_shared_from_this<TorchComm> {
       const CommOptions& options);
 
  private:
-  // constructor for split communicators
+  // constructor for root communicators
   explicit TorchComm(
       const std::string& backend,
       std::shared_ptr<TorchCommBackend> impl);
+
+  // constructor for split communicators
+  TorchComm(
+      const std::string& backend,
+      std::shared_ptr<TorchCommBackend> impl,
+      std::vector<int> ranks);
 
   void preHook(PreHookArgs&& args);
   void postHook(PostHookArgs&& args);
@@ -255,6 +262,10 @@ class TorchComm : public std::enable_shared_from_this<TorchComm> {
   std::unordered_map<int64_t, PostHook> postHooks_;
   // Counter for generating unique operation IDs
   std::atomic<size_t> nextOpId_{0};
+  // Global ranks of the members of this communicator.
+  // For root communicators: [0, 1, 2, ..., size-1]
+  // For split communicators: global ranks from the parent communicator
+  std::vector<int> ranks_;
 };
 
 // Constructor that creates the appropriate backend implementation

--- a/comms/torchcomms/hooks/fr/FlightRecorder.cpp
+++ b/comms/torchcomms/hooks/fr/FlightRecorder.cpp
@@ -819,10 +819,13 @@ void FlightRecorderHook::registerWithComm(std::shared_ptr<TorchComm> comm) {
   std::string pg_desc(comm->getBackend());
 
   auto pgName = std::make_tuple(comm_name, pg_desc);
+  // Get ranks from the communicator - for split comms this will be the
+  // global ranks from the parent
+  auto comm_ranks = comm->getRanks();
   std::vector<uint64_t> pg_ranks;
-  pg_ranks.reserve(comm->getSize());
-  for (auto i = 0; i < comm->getSize(); i++) {
-    pg_ranks.push_back(i);
+  pg_ranks.reserve(comm_ranks.size());
+  for (int rank : comm_ranks) {
+    pg_ranks.push_back(static_cast<uint64_t>(rank));
   }
   recorder_->record_pg_ranks(pgName, pg_ranks);
 

--- a/comms/torchcomms/tests/integration/cpp/SplitTest.hpp
+++ b/comms/torchcomms/tests/integration/cpp/SplitTest.hpp
@@ -36,6 +36,9 @@ class SplitTest : public ::testing::Test {
   void testRankNotInGroup();
   void testMultiLevel();
   void testMultipleSplitsSameRanks();
+  void testGetRanksRoot();
+  void testGetRanksAfterSplit();
+  void testGetRanksMultiLevelSplit();
 
   // Helper function declarations
   std::vector<std::vector<int>> createContigGroups(

--- a/comms/torchcomms/tests/integration/cpp/SplitTestMain.cpp
+++ b/comms/torchcomms/tests/integration/cpp/SplitTestMain.cpp
@@ -80,6 +80,27 @@ TEST_F(SplitTest, MultipleSplitsSameRanks) {
   testMultipleSplitsSameRanks();
 }
 
+TEST_F(SplitTest, GetRanksRoot) {
+  SCOPED_TRACE(
+      ::testing::Message()
+      << "Testing getRanks() returns sequential ranks for root communicator");
+  testGetRanksRoot();
+}
+
+TEST_F(SplitTest, GetRanksAfterSplit) {
+  SCOPED_TRACE(
+      ::testing::Message()
+      << "Testing getRanks() returns correct global ranks after split");
+  testGetRanksAfterSplit();
+}
+
+TEST_F(SplitTest, GetRanksMultiLevelSplit) {
+  SCOPED_TRACE(
+      ::testing::Message()
+      << "Testing getRanks() returns correct global ranks through multi-level splits");
+  testGetRanksMultiLevelSplit();
+}
+
 // This main function is provided by gtest
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Summary:

This diff introduces a new method, `getRanks()`, to the communicator class. This method returns a vector of global ranks within the communicator, which is useful for flight recorder to track operations.

**Key Changes:**

*   Added `getRanks()` method to `TorchComm` class, which also initializes the `ranks_` vector if not already set.
*   Updated `FlightRecorder.cpp` to use the new `getRanks()` method to retrieve ranks from the communicator.
*   Added test cases to `SplitTest.hpp` to verify the correctness of the `getRanks()` method in various scenarios, including root, split, and multi-level splits.

Reviewed By: d4l3k

Differential Revision: D94240481


