### PR TITLE
Remove process abort from abortNcclComm, add eager timeout test

### DIFF
--- a/comms/torchcomms/nccl/TorchCommNCCL.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCL.cpp
@@ -342,10 +342,12 @@ void TorchCommNCCL::finalize() {
 }
 
 void TorchCommNCCL::abortNcclComm() {
-  // Call abort hooks before aborting to allow users to capture debug info
-  TC_LOG(INFO, this) << "Calling abort hooks before aborting.";
+  // Both runAbortHooks and detachMemoryHook must run before commAbort:
+  // - Abort hooks may need to inspect the live NCCL comm for debug info.
+  // - detachMemoryHook deregisters this comm from CachingAllocator so that
+  //   subsequent alloc/free callbacks do not reference a destroyed comm.
+  TC_LOG(INFO, this) << "Calling abort hooks before commAbort.";
   runAbortHooks();
-
   detachMemoryHook();
   if (nccl_comm_) {
     NCCL_CHECK(
@@ -354,10 +356,6 @@ void TorchCommNCCL::abortNcclComm() {
         nccl_api_->commAbort(nccl_comm_),
         "NCCL Abort failed");
     nccl_comm_ = nullptr;
-  }
-  if (options_.abort_process_on_timeout_or_error) {
-    TC_LOG(ERROR, this) << "Aborting process due to timeout";
-    abort();
   }
 }
 

--- a/comms/torchcomms/tests/integration/cpp/CollectiveTimeoutTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/CollectiveTimeoutTest.cpp
@@ -2,6 +2,7 @@
 
 #include "CollectiveTimeoutTest.hpp"
 
+#include <cstdlib>
 #include <functional>
 #include <vector>
 
@@ -287,6 +288,15 @@ void CollectiveTimeoutTest::testTimeout(
     const ExecMode mode) {
   if (mode != ExecMode::kEager && isRunningOnCPU()) {
     GTEST_SKIP() << "CUDA Graph timeout tests not supported on CPU";
+  }
+  // Graph mode timeout detection requires GraphEventTracker (ncclx only).
+  // TODO: Port GraphEventTracker to nccl to enable graph timeout tests.
+  if (mode != ExecMode::kEager) {
+    const char* backend = std::getenv("TEST_BACKEND");
+    if (!backend || std::string(backend) != "ncclx") {
+      GTEST_SKIP()
+          << "Graph mode timeout requires GraphEventTracker (ncclx only)";
+    }
   }
 
   // Expected exit behavior per rank:

--- a/comms/torchcomms/tests/integration/cpp/CollectiveTimeoutTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/CollectiveTimeoutTest.cpp
@@ -1,0 +1,327 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "CollectiveTimeoutTest.hpp"
+
+#include <functional>
+#include <vector>
+
+#include <ATen/cuda/CUDAContext.h>
+
+#include "TorchCommTestHelpers.h"
+#include "comms/torchcomms/TorchComm.hpp"
+#include "comms/torchcomms/TorchCommBatch.hpp"
+#include "comms/torchcomms/TorchCommOptions.hpp"
+#include "comms/torchcomms/TorchWork.hpp"
+
+using torch::comms::test::RankExpectation;
+using torch::comms::test::TimeoutTestHelper;
+using ExecMode = TimeoutTestHelper::ExecMode;
+
+std::string CollectiveTimeoutTest::collectiveTypeName(
+    const CollectiveType type) {
+  switch (type) {
+    case CollectiveType::kSendRecv:
+      return "SendRecv";
+    case CollectiveType::kBatchSendRecv:
+      return "BatchSendRecv";
+    case CollectiveType::kBroadcast:
+      return "Broadcast";
+    case CollectiveType::kAllReduce:
+      return "AllReduce";
+    case CollectiveType::kReduce:
+      return "Reduce";
+    case CollectiveType::kAllGather:
+      return "AllGather";
+    case CollectiveType::kAllGatherSingle:
+      return "AllGatherSingle";
+    case CollectiveType::kAllGatherV:
+      return "AllGatherV";
+    case CollectiveType::kReduceScatter:
+      return "ReduceScatter";
+    case CollectiveType::kReduceScatterSingle:
+      return "ReduceScatterSingle";
+    case CollectiveType::kReduceScatterV:
+      return "ReduceScatterV";
+    case CollectiveType::kAllToAllSingle:
+      return "AllToAllSingle";
+    case CollectiveType::kAllToAll:
+      return "AllToAll";
+    case CollectiveType::kBarrier:
+      return "Barrier";
+    case CollectiveType::kScatter:
+      return "Scatter";
+    case CollectiveType::kGather:
+      return "Gather";
+  }
+  return "Unknown";
+}
+
+namespace {
+at::Tensor makeTestTensor(
+    const std::vector<int64_t>& sizes,
+    const c10::DeviceType device_type,
+    const int rank) {
+  const auto device_index = rank % at::cuda::device_count();
+  return at::ones(
+      sizes,
+      at::TensorOptions().dtype(at::kFloat).device(device_type, device_index));
+}
+} // namespace
+
+void CollectiveTimeoutTest::childSetUp() {
+  wrapper_ = std::make_unique<TorchCommTestWrapper>();
+  torchcomm_ = wrapper_->getTorchComm();
+  rank_ = torchcomm_->getRank();
+  num_ranks_ = torchcomm_->getSize();
+  if (isRunningOnCPU()) {
+    device_type_ = c10::DeviceType::CPU;
+  } else {
+    device_type_ = c10::DeviceType::CUDA;
+  }
+}
+
+void CollectiveTimeoutTest::childTearDown() {
+  if (torchcomm_) {
+    try {
+      torchcomm_->finalize();
+    } catch (...) {
+    }
+    torchcomm_.reset();
+  }
+}
+
+void CollectiveTimeoutTest::execute(
+    const CollectiveType type,
+    const bool asyncOp,
+    const std::chrono::milliseconds timeout) {
+  constexpr int kCount = 1024;
+  auto tensor = makeTestTensor({kCount}, device_type_, rank_);
+  std::vector<c10::intrusive_ptr<torch::comms::TorchWork>> works;
+
+  switch (type) {
+    case CollectiveType::kSendRecv: {
+      torch::comms::SendOptions send_opts;
+      send_opts.timeout = timeout;
+      torch::comms::RecvOptions recv_opts;
+      recv_opts.timeout = timeout;
+      const int dst = (rank_ + 1) % num_ranks_;
+      const int src = (rank_ + num_ranks_ - 1) % num_ranks_;
+      auto recv_tensor = makeTestTensor({kCount}, device_type_, rank_);
+      // Alternate send/recv order by rank parity to avoid GPU-level deadlock.
+      // Standalone ncclSend/ncclRecv are serialized on internal_stream_;
+      // if all ranks send first, recv kernels deadlock waiting for a match.
+      if (rank_ % 2 == 0) {
+        works.push_back(torchcomm_->send(tensor, dst, asyncOp, send_opts));
+        works.push_back(torchcomm_->recv(recv_tensor, src, asyncOp, recv_opts));
+      } else {
+        works.push_back(torchcomm_->recv(recv_tensor, src, asyncOp, recv_opts));
+        works.push_back(torchcomm_->send(tensor, dst, asyncOp, send_opts));
+      }
+      break;
+    }
+    case CollectiveType::kBatchSendRecv: {
+      // Batch API groups send+recv in ncclGroupStart/End, no deadlock risk.
+      torch::comms::BatchP2POptions batch_opts;
+      batch_opts.timeout = timeout;
+      const int dst = (rank_ + 1) % num_ranks_;
+      const int src = (rank_ + num_ranks_ - 1) % num_ranks_;
+      auto recv_tensor = makeTestTensor({kCount}, device_type_, rank_);
+      auto batch = torchcomm_->batch_op_create();
+      batch.send(tensor, dst);
+      batch.recv(recv_tensor, src);
+      works.push_back(batch.issue(asyncOp, batch_opts));
+      break;
+    }
+    case CollectiveType::kBroadcast: {
+      torch::comms::BroadcastOptions opts;
+      opts.timeout = timeout;
+      works.push_back(torchcomm_->broadcast(tensor, 0, asyncOp, opts));
+      break;
+    }
+    case CollectiveType::kAllReduce: {
+      torch::comms::AllReduceOptions opts;
+      opts.timeout = timeout;
+      works.push_back(torchcomm_->all_reduce(
+          tensor, torch::comms::ReduceOp::SUM, asyncOp, opts));
+      break;
+    }
+    case CollectiveType::kReduce: {
+      torch::comms::ReduceOptions opts;
+      opts.timeout = timeout;
+      works.push_back(torchcomm_->reduce(
+          tensor, 1, torch::comms::ReduceOp::SUM, asyncOp, opts));
+      break;
+    }
+    case CollectiveType::kAllGather: {
+      torch::comms::AllGatherOptions opts;
+      opts.timeout = timeout;
+      std::vector<at::Tensor> outputs;
+      outputs.reserve(num_ranks_);
+      for (int i = 0; i < num_ranks_; ++i) {
+        outputs.push_back(makeTestTensor({kCount}, device_type_, rank_));
+      }
+      works.push_back(torchcomm_->all_gather(outputs, tensor, asyncOp, opts));
+      break;
+    }
+    case CollectiveType::kAllGatherSingle: {
+      torch::comms::AllGatherSingleOptions opts;
+      opts.timeout = timeout;
+      auto output = makeTestTensor({kCount * num_ranks_}, device_type_, rank_);
+      works.push_back(
+          torchcomm_->all_gather_single(output, tensor, asyncOp, opts));
+      break;
+    }
+    case CollectiveType::kAllGatherV: {
+      torch::comms::AllGatherOptions opts;
+      opts.timeout = timeout;
+      std::vector<at::Tensor> outputs;
+      outputs.reserve(num_ranks_);
+      for (int i = 0; i < num_ranks_; ++i) {
+        outputs.push_back(makeTestTensor({kCount}, device_type_, rank_));
+      }
+      works.push_back(torchcomm_->all_gather_v(outputs, tensor, asyncOp, opts));
+      break;
+    }
+    case CollectiveType::kReduceScatter: {
+      torch::comms::ReduceScatterOptions opts;
+      opts.timeout = timeout;
+      auto output = makeTestTensor({kCount}, device_type_, rank_);
+      std::vector<at::Tensor> inputs;
+      inputs.reserve(num_ranks_);
+      for (int i = 0; i < num_ranks_; ++i) {
+        inputs.push_back(makeTestTensor({kCount}, device_type_, rank_));
+      }
+      works.push_back(torchcomm_->reduce_scatter(
+          output, inputs, torch::comms::ReduceOp::SUM, asyncOp, opts));
+      break;
+    }
+    case CollectiveType::kReduceScatterSingle: {
+      torch::comms::ReduceScatterSingleOptions opts;
+      opts.timeout = timeout;
+      auto input = makeTestTensor({kCount * num_ranks_}, device_type_, rank_);
+      auto output = makeTestTensor({kCount}, device_type_, rank_);
+      works.push_back(torchcomm_->reduce_scatter_single(
+          output, input, torch::comms::ReduceOp::SUM, asyncOp, opts));
+      break;
+    }
+    case CollectiveType::kReduceScatterV: {
+      torch::comms::ReduceScatterOptions opts;
+      opts.timeout = timeout;
+      auto output = makeTestTensor({kCount}, device_type_, rank_);
+      std::vector<at::Tensor> inputs;
+      inputs.reserve(num_ranks_);
+      for (int i = 0; i < num_ranks_; ++i) {
+        inputs.push_back(makeTestTensor({kCount}, device_type_, rank_));
+      }
+      works.push_back(torchcomm_->reduce_scatter_v(
+          output, inputs, torch::comms::ReduceOp::SUM, asyncOp, opts));
+      break;
+    }
+    case CollectiveType::kAllToAllSingle: {
+      torch::comms::AllToAllSingleOptions opts;
+      opts.timeout = timeout;
+      auto output = makeTestTensor({kCount * num_ranks_}, device_type_, rank_);
+      auto input = makeTestTensor({kCount * num_ranks_}, device_type_, rank_);
+      works.push_back(
+          torchcomm_->all_to_all_single(output, input, asyncOp, opts));
+      break;
+    }
+    case CollectiveType::kAllToAll: {
+      torch::comms::AllToAllOptions opts;
+      opts.timeout = timeout;
+      std::vector<at::Tensor> outputs;
+      std::vector<at::Tensor> inputs;
+      outputs.reserve(num_ranks_);
+      inputs.reserve(num_ranks_);
+      for (int i = 0; i < num_ranks_; ++i) {
+        outputs.push_back(makeTestTensor({kCount}, device_type_, rank_));
+        inputs.push_back(makeTestTensor({kCount}, device_type_, rank_));
+      }
+      works.push_back(torchcomm_->all_to_all(outputs, inputs, asyncOp, opts));
+      break;
+    }
+    case CollectiveType::kBarrier: {
+      torch::comms::BarrierOptions opts;
+      opts.timeout = timeout;
+      works.push_back(torchcomm_->barrier(asyncOp, opts));
+      break;
+    }
+    case CollectiveType::kScatter: {
+      torch::comms::ScatterOptions opts;
+      opts.timeout = timeout;
+      auto output = makeTestTensor({kCount}, device_type_, rank_);
+      std::vector<at::Tensor> inputs;
+      if (rank_ == 0) {
+        inputs.reserve(num_ranks_);
+        for (int i = 0; i < num_ranks_; ++i) {
+          inputs.push_back(makeTestTensor({kCount}, device_type_, rank_));
+        }
+      }
+      works.push_back(torchcomm_->scatter(output, inputs, 0, asyncOp, opts));
+      break;
+    }
+    case CollectiveType::kGather: {
+      torch::comms::GatherOptions opts;
+      opts.timeout = timeout;
+      std::vector<at::Tensor> outputs;
+      if (rank_ == 1) {
+        outputs.reserve(num_ranks_);
+        for (int i = 0; i < num_ranks_; ++i) {
+          outputs.push_back(makeTestTensor({kCount}, device_type_, rank_));
+        }
+      }
+      works.push_back(torchcomm_->gather(outputs, tensor, 1, asyncOp, opts));
+      break;
+    }
+  }
+
+  if (asyncOp) {
+    for (auto& work : works) {
+      work->wait();
+    }
+  }
+}
+
+void CollectiveTimeoutTest::testTimeout(
+    const CollectiveType type,
+    const ExecMode mode) {
+  if (mode != ExecMode::kEager && isRunningOnCPU()) {
+    GTEST_SKIP() << "CUDA Graph timeout tests not supported on CPU";
+  }
+
+  // Expected exit behavior per rank:
+  // - Rank 0 exits cleanly or gets aborted
+  // - Rank 1+ must be aborted with timeout log
+  const std::vector<RankExpectation> expectations = {
+      {.exitCode = 0, .signal = SIGABRT},
+      {.signal = SIGABRT,
+       .logMustContain = {"Aborting process due to timeout"}},
+  };
+
+  helper_.launch(
+      collectiveTypeName(type),
+      num_ranks_,
+      [&](int /*rank*/) {
+        childSetUp();
+
+        std::vector<std::function<void()>> ops;
+        ops.reserve(kNumWarmup + 1);
+        for (int i = 0; i < kNumWarmup; i++) {
+          ops.emplace_back([&] { execute(type); });
+        }
+        if (rank_ != 0) {
+          ops.emplace_back([&] { execute(type, true, kTimeout); });
+        }
+        helper_.exec(mode, ops);
+
+        // rank 0 skips the last op so other ranks can timeout
+        if (rank_ == 0) {
+          std::this_thread::sleep_for(
+              kRank0Sleep); // NOLINT(facebook-hte-BadCall-sleep_for)
+          _exit(0);
+        } else {
+          childTearDown();
+        }
+      },
+      expectations);
+}

--- a/comms/torchcomms/tests/integration/cpp/CollectiveTimeoutTest.hpp
+++ b/comms/torchcomms/tests/integration/cpp/CollectiveTimeoutTest.hpp
@@ -1,0 +1,64 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "comms/torchcomms/TorchComm.hpp"
+#include "comms/torchcomms/tests/integration/cpp/TimeoutTestHelpers.hpp"
+#include "comms/torchcomms/tests/integration/cpp/TorchCommTestHelpers.h"
+
+class CollectiveTimeoutTest
+    : public ::testing::TestWithParam<std::tuple<int, int>> {
+ public:
+  enum class CollectiveType {
+    kSendRecv,
+    kBatchSendRecv,
+    kBroadcast,
+    kAllReduce,
+    kReduce,
+    kAllGather,
+    kAllGatherSingle,
+    kAllGatherV,
+    kReduceScatter,
+    kReduceScatterSingle,
+    kReduceScatterV,
+    kAllToAllSingle,
+    kAllToAll,
+    kBarrier,
+    kScatter,
+    kGather,
+  };
+
+  static std::string collectiveTypeName(CollectiveType type);
+
+ protected:
+  static constexpr int kNumWarmup = 2;
+  static constexpr std::chrono::milliseconds kTimeout{std::chrono::seconds(2)};
+  static constexpr std::chrono::seconds kRank0Sleep{5};
+
+  void testTimeout(
+      CollectiveType type,
+      torch::comms::test::TimeoutTestHelper::ExecMode mode);
+
+ private:
+  void childSetUp();
+  void childTearDown();
+
+  void execute(
+      CollectiveType type,
+      bool asyncOp = true,
+      std::chrono::milliseconds timeout = torch::comms::kNoTimeout);
+
+  torch::comms::test::TimeoutTestHelper helper_;
+  std::unique_ptr<TorchCommTestWrapper> wrapper_;
+  std::shared_ptr<torch::comms::TorchComm> torchcomm_;
+  int rank_{0};
+  int num_ranks_{2};
+  c10::DeviceType device_type_{c10::DeviceType::CUDA};
+};

--- a/comms/torchcomms/tests/integration/cpp/CollectiveTimeoutTestMain.cpp
+++ b/comms/torchcomms/tests/integration/cpp/CollectiveTimeoutTestMain.cpp
@@ -1,0 +1,59 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// Timeout test for all 16 collective operations.
+// - Timeout logic: TimeoutTestHelper::launch() forks child processes.
+//   Rank 0 only runs warmup ops then sleeps, so rank 1's final op
+//   (issued with a short timeout) has no matching peer and times out.
+// - Call path: TEST_P → testTimeout → helper_.launch(childBody) where
+//   childBody builds an ops vector and calls helper_.exec(mode, ops).
+//   exec() handles eager vs graph mode dispatch transparently.
+
+#include <gtest/gtest.h>
+#include "CollectiveTimeoutTest.hpp"
+
+using ExecMode = torch::comms::test::TimeoutTestHelper::ExecMode;
+using CollectiveType = CollectiveTimeoutTest::CollectiveType;
+
+TEST_P(CollectiveTimeoutTest, Timeout) {
+  const auto [type_int, mode_int] = GetParam();
+  testTimeout(
+      static_cast<CollectiveType>(type_int), static_cast<ExecMode>(mode_int));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AllCollectives,
+    CollectiveTimeoutTest,
+    ::testing::Combine(
+        ::testing::Values(
+            static_cast<int>(CollectiveType::kSendRecv),
+            static_cast<int>(CollectiveType::kBatchSendRecv),
+            static_cast<int>(CollectiveType::kBroadcast),
+            static_cast<int>(CollectiveType::kAllReduce),
+            static_cast<int>(CollectiveType::kReduce),
+            static_cast<int>(CollectiveType::kAllGather),
+            static_cast<int>(CollectiveType::kAllGatherSingle),
+            static_cast<int>(CollectiveType::kAllGatherV),
+            static_cast<int>(CollectiveType::kReduceScatter),
+            static_cast<int>(CollectiveType::kReduceScatterSingle),
+            static_cast<int>(CollectiveType::kReduceScatterV),
+            static_cast<int>(CollectiveType::kAllToAllSingle),
+            static_cast<int>(CollectiveType::kAllToAll),
+            static_cast<int>(CollectiveType::kBarrier),
+            static_cast<int>(CollectiveType::kScatter),
+            static_cast<int>(CollectiveType::kGather)),
+        ::testing::Values(
+            static_cast<int>(ExecMode::kEager),
+            static_cast<int>(ExecMode::kMultiGraphSequential),
+            static_cast<int>(ExecMode::kMultiGraphConcurrent))),
+    [](const ::testing::TestParamInfo<std::tuple<int, int>>& info) {
+      return CollectiveTimeoutTest::collectiveTypeName(
+                 static_cast<CollectiveType>(std::get<0>(info.param))) +
+          "_" +
+          torch::comms::test::TimeoutTestHelper::execModeName(
+                 static_cast<ExecMode>(std::get<1>(info.param)));
+    });
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/torchcomms/tests/integration/cpp/CollectiveTimeoutTestMain.cpp
+++ b/comms/torchcomms/tests/integration/cpp/CollectiveTimeoutTestMain.cpp
@@ -8,6 +8,8 @@
 //   childBody builds an ops vector and calls helper_.exec(mode, ops).
 //   exec() handles eager vs graph mode dispatch transparently.
 
+// TODO: Port GraphEventTracker from ncclx to nccl for graph mode timeout.
+
 #include <gtest/gtest.h>
 #include "CollectiveTimeoutTest.hpp"
 

--- a/comms/torchcomms/tests/integration/cpp/TimeoutTestHelpers.cpp
+++ b/comms/torchcomms/tests/integration/cpp/TimeoutTestHelpers.cpp
@@ -1,0 +1,370 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "TimeoutTestHelpers.hpp"
+
+#include <sys/wait.h>
+#include <unistd.h>
+#include <cerrno>
+#include <iostream>
+#include <memory>
+
+#include <fmt/format.h>
+#include <folly/String.h>
+
+#include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/CUDAGraph.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAStream.h>
+#include <gtest/gtest.h>
+
+namespace {
+
+// RAII wrapper for a forked child process with captured stderr pipe
+struct ChildProcess {
+  pid_t pid = -1;
+  int readFd = -1; // read end of stderr pipe (parent keeps)
+  int writeFd = -1; // write end of stderr pipe (closed in parent after fork)
+  bool waited = false;
+
+  ChildProcess() = default;
+
+  ChildProcess(const ChildProcess&) = delete;
+  ChildProcess& operator=(const ChildProcess&) = delete;
+
+  ChildProcess(ChildProcess&& other) noexcept
+      : pid(other.pid),
+        readFd(other.readFd),
+        writeFd(other.writeFd),
+        waited(other.waited) {
+    other.pid = -1;
+    other.readFd = -1;
+    other.writeFd = -1;
+    other.waited = true;
+  }
+
+  ~ChildProcess() {
+    cleanup();
+  }
+
+  // Create pipe pair. Returns false on failure.
+  bool setupPipe() {
+    int fds[2];
+    if (pipe(fds) == -1) {
+      return false;
+    }
+    readFd = fds[0];
+    writeFd = fds[1];
+    return true;
+  }
+
+  // Called in forked child: redirect stderr to write end, close read end
+  void pipeStderr() {
+    if (close(readFd) == -1) {
+      perror("close(pipe read end)");
+      _exit(1);
+    }
+    readFd = -1;
+    if (dup2(writeFd, STDERR_FILENO) == -1) {
+      perror("dup2(pipe -> stderr)");
+      _exit(1);
+    }
+    if (close(writeFd) == -1) {
+      perror("close(pipe write end)");
+      _exit(1);
+    }
+    writeFd = -1;
+  }
+
+  // Called in parent after fork: close write end, record pid
+  void onForked(const pid_t p) {
+    pid = p;
+    if (writeFd != -1) {
+      if (close(writeFd) == -1) {
+        perror("close(pipe write end in parent)");
+      }
+      writeFd = -1;
+    }
+  }
+
+  // Set environment variables for child process (called after fork in child)
+  static void
+  setEnv(const int rank, const int numChildren, const std::string& storePath) {
+    if (unsetenv("OMPI_COMM_WORLD_RANK") == -1 ||
+        unsetenv("OMPI_COMM_WORLD_SIZE") == -1 ||
+        setenv("TORCHCOMM_RANK", std::to_string(rank).c_str(), 1) == -1 ||
+        setenv("TORCHCOMM_SIZE", std::to_string(numChildren).c_str(), 1) ==
+            -1 ||
+        setenv("TORCHCOMM_STORE_PATH", storePath.c_str(), 1) == -1 ||
+        setenv("MASTER_ADDR", "127.0.0.1", 1) == -1 ||
+        setenv("MASTER_PORT", "29500", 1) == -1) {
+      perror("setenv/unsetenv");
+      _exit(1);
+    }
+  }
+
+  // Wait for the child to exit within timeout. Returns true if child exited.
+  bool waitForExit(int* status, const int timeoutSecs) {
+    for (int elapsed = 0; elapsed < timeoutSecs * 10; elapsed++) {
+      const pid_t result = waitpid(pid, status, WNOHANG);
+      if (result == pid) {
+        waited = true;
+        return true;
+      }
+      if (result == -1) {
+        waited = true;
+        return false;
+      }
+      usleep(100000); // NOLINT(facebook-hte-BadCall-usleep)
+    }
+    // Timed out — kill the child
+    if (kill(pid, SIGKILL) == -1 && errno != ESRCH) {
+      perror("kill(SIGKILL)");
+    }
+    waitpid(pid, status, 0);
+    waited = true;
+    return false;
+  }
+
+  // Read all captured stderr from the pipe and close it
+  std::string readStderr() {
+    std::string result;
+    if (readFd == -1) {
+      return result;
+    }
+    char buf[4096];
+    ssize_t n;
+    while ((n = read(readFd, buf, sizeof(buf))) > 0) {
+      result.append(buf, n);
+    }
+    close(readFd);
+    readFd = -1;
+    return result;
+  }
+
+ private:
+  void cleanup() {
+    if (!waited && pid > 0) {
+      kill(pid, SIGKILL);
+      int status;
+      waitpid(pid, &status, 0);
+    }
+    if (readFd != -1) {
+      close(readFd);
+      readFd = -1;
+    }
+    if (writeFd != -1) {
+      close(writeFd);
+      writeFd = -1;
+    }
+    pid = -1;
+    waited = true;
+  }
+};
+
+// Verify child exit status matches expectation
+void checkExitStatus(
+    const int rank,
+    const int status,
+    const torch::comms::test::RankExpectation& expect) {
+  bool matchesExitCode = true;
+  bool matchesSignal = true;
+  std::vector<std::string> expected;
+  if (expect.exitCode.has_value()) {
+    const auto cleanExit = WIFEXITED(status);
+    const auto exitCode = cleanExit ? WEXITSTATUS(status) : -1;
+    const auto expExitCode = expect.exitCode.value_or(-1);
+    matchesExitCode = cleanExit && exitCode == expExitCode;
+    if (!matchesExitCode) {
+      expected.push_back(
+          fmt::format(
+              "expected exitCode={} but got {}", expExitCode, exitCode));
+    }
+  }
+  if (expect.signal.has_value()) {
+    const auto signaled = WIFSIGNALED(status);
+    const auto termSignal = signaled ? WTERMSIG(status) : -1;
+    const auto expSignal = expect.signal.value_or(-1);
+    matchesSignal = signaled && termSignal == expSignal;
+    if (!matchesSignal) {
+      expected.push_back(
+          fmt::format("expected signal={} but got {}", expSignal, termSignal));
+    }
+  }
+
+  if (expect.exitCode.has_value() && expect.signal.has_value()) {
+    EXPECT_TRUE(matchesExitCode || matchesSignal)
+        << "Rank " << rank
+        << " exit status mismatch: " << folly::join(" OR ", expected);
+  } else if (expect.exitCode.has_value()) {
+    EXPECT_TRUE(matchesExitCode)
+        << "Rank " << rank
+        << " exit status mismatch: " << folly::join(" OR ", expected);
+  } else if (expect.signal.has_value()) {
+    EXPECT_TRUE(matchesSignal)
+        << "Rank " << rank
+        << " exit status mismatch: " << folly::join(" OR ", expected);
+  }
+}
+
+// Verify captured stderr matches log expectations
+void checkLogExpectations(
+    const int rank,
+    const std::string& capturedStderr,
+    const torch::comms::test::RankExpectation& expect) {
+  for (const auto& pattern : expect.logMustContain) {
+    EXPECT_NE(capturedStderr.find(pattern), std::string::npos)
+        << "Rank " << rank << " stderr missing expected pattern: '" << pattern
+        << "'\nstderr was:\n"
+        << capturedStderr;
+  }
+  for (const auto& pattern : expect.logMustNotContain) {
+    EXPECT_EQ(capturedStderr.find(pattern), std::string::npos)
+        << "Rank " << rank << " stderr contains unexpected pattern: '"
+        << pattern << "'\nstderr was:\n"
+        << capturedStderr;
+  }
+}
+
+} // namespace
+
+namespace torch::comms::test {
+
+std::string TimeoutTestHelper::execModeName(const ExecMode mode) {
+  switch (mode) {
+    case ExecMode::kEager:
+      return "Eager";
+    case ExecMode::kMultiGraphSequential:
+      return "MultiGraphSeq";
+    case ExecMode::kMultiGraphConcurrent:
+      return "MultiGraphConc";
+  }
+  return "Unknown";
+}
+
+void TimeoutTestHelper::exec(
+    const ExecMode mode,
+    const std::vector<std::function<void()>>& ops) {
+  switch (mode) {
+    case ExecMode::kEager:
+      for (const auto& op : ops) {
+        op();
+      }
+      at::cuda::getCurrentCUDAStream().synchronize();
+      break;
+    case ExecMode::kMultiGraphSequential: {
+      const auto stream = at::cuda::getStreamFromPool();
+      at::cuda::CUDAStreamGuard guard(stream);
+      const int numOps = static_cast<int>(ops.size());
+      // Capture each op as a separate graph
+      std::vector<std::unique_ptr<at::cuda::CUDAGraph>> graphs;
+      graphs.reserve(numOps);
+      for (const auto& op : ops) {
+        auto& graph =
+            graphs.emplace_back(std::make_unique<at::cuda::CUDAGraph>());
+        graph->capture_begin();
+        op();
+        graph->capture_end();
+      }
+      // Replay all graphs sequentially on the same stream
+      for (int i = 0; i < numOps; i++) {
+        graphs[i]->replay();
+      }
+      stream.synchronize();
+      break;
+    }
+    case ExecMode::kMultiGraphConcurrent: {
+      const int numOps = static_cast<int>(ops.size());
+      // Capture each op on its own stream
+      std::vector<at::cuda::CUDAStream> streams;
+      streams.reserve(numOps);
+      std::vector<std::unique_ptr<at::cuda::CUDAGraph>> graphs;
+      graphs.reserve(numOps);
+      for (const auto& op : ops) {
+        streams.push_back(at::cuda::getStreamFromPool());
+        auto& graph =
+            graphs.emplace_back(std::make_unique<at::cuda::CUDAGraph>());
+        at::cuda::CUDAStreamGuard streamGuard(streams.back());
+        graph->capture_begin();
+        op();
+        graph->capture_end();
+      }
+      // Replay all graphs on their respective streams
+      for (int i = 0; i < numOps; i++) {
+        at::cuda::CUDAStreamGuard streamGuard(streams[i]);
+        graphs[i]->replay();
+      }
+      for (int i = 0; i < numOps; i++) {
+        streams[i].synchronize();
+      }
+      break;
+    }
+  }
+}
+
+void TimeoutTestHelper::launch(
+    const std::string& testName,
+    const int numChildren,
+    const std::function<void(int rank)>& childBody,
+    const std::vector<RankExpectation>& expectations,
+    const int childWaitTimeoutSecs) {
+  const std::string storePath = "/tmp/torchcomm_timeout_test_" +
+      std::to_string(getpid()) + "_" + testName;
+  unlink(storePath.c_str());
+
+  std::vector<ChildProcess> children;
+  children.reserve(numChildren);
+
+  // Fork child processes with redirected stderr for log capture
+  for (int rank = 0; rank < numChildren; rank++) {
+    ChildProcess child;
+    if (!child.setupPipe()) {
+      FAIL() << "pipe() failed for rank " << rank;
+    }
+
+    const pid_t pid = fork();
+    if (pid == -1) {
+      FAIL() << "fork() failed for rank " << rank;
+      // child destructor cleans up pipe fds
+    } else if (pid == 0) {
+      child.pipeStderr();
+      ChildProcess::setEnv(rank, numChildren, storePath);
+      try {
+        childBody(rank);
+      } catch (const std::exception& ex) {
+        std::cerr << "Child rank " << rank << " exception: " << ex.what()
+                  << "\n";
+        _exit(1);
+      } catch (...) {
+        std::cerr << "Child rank " << rank << " unknown exception\n";
+        _exit(1);
+      }
+      _exit(0);
+    } else {
+      child.onForked(pid);
+      children.emplace_back(std::move(child));
+    }
+  }
+
+  // Wait for children and verify exit expectations
+  for (int rank = 0; rank < numChildren; rank++) {
+    int status = 0;
+    const bool exited =
+        children[rank].waitForExit(&status, childWaitTimeoutSecs);
+
+    EXPECT_TRUE(exited) << "Rank " << rank
+                        << " child did not exit within timeout";
+    if (!exited) {
+      continue;
+    }
+
+    const auto capturedStderr = children[rank].readStderr();
+    const auto& expect = expectations[rank];
+    checkExitStatus(rank, status, expect);
+    checkLogExpectations(rank, capturedStderr, expect);
+  }
+
+  EXPECT_NE(unlink(storePath.c_str()), -1)
+      << "unlink(" << storePath << ") failed";
+}
+
+} // namespace torch::comms::test

--- a/comms/torchcomms/tests/integration/cpp/TimeoutTestHelpers.hpp
+++ b/comms/torchcomms/tests/integration/cpp/TimeoutTestHelpers.hpp
@@ -1,0 +1,48 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <sys/types.h>
+#include <functional>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace torch::comms::test {
+
+struct RankExpectation {
+  // Exit expectations — set both for "either is OK"
+  std::optional<int> exitCode;
+  std::optional<int> signal;
+
+  // Log expectations (matched against captured stderr)
+  std::vector<std::string> logMustContain;
+  std::vector<std::string> logMustNotContain;
+};
+
+// Utility class providing execution mode dispatch and child process
+// orchestration for timeout tests. Does not inherit from gtest — used via
+// composition.
+class TimeoutTestHelper {
+ public:
+  enum class ExecMode {
+    kEager,
+    kMultiGraphSequential,
+    kMultiGraphConcurrent,
+  };
+
+  static std::string execModeName(ExecMode mode);
+
+  void exec(const ExecMode mode, const std::vector<std::function<void()>>& ops);
+
+  // Fork child processes with redirected stderr, run childBody in each,
+  // then verify exit status and log expectations.
+  void launch(
+      const std::string& testName,
+      const int numChildren,
+      const std::function<void(int rank)>& childBody,
+      const std::vector<RankExpectation>& expectations,
+      const int childWaitTimeoutSecs = 60);
+};
+
+} // namespace torch::comms::test

--- a/comms/torchcomms/tests/integration/cpp/WindowRmaTimeoutTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/WindowRmaTimeoutTest.cpp
@@ -1,0 +1,173 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "WindowRmaTimeoutTest.hpp"
+
+#include <functional>
+
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDACachingAllocator.h>
+
+#include "TorchCommTestHelpers.h"
+#include "comms/torchcomms/TorchComm.hpp"
+#include "comms/torchcomms/TorchCommOptions.hpp"
+
+using torch::comms::test::RankExpectation;
+using torch::comms::test::TimeoutTestHelper;
+using ExecMode = TimeoutTestHelper::ExecMode;
+
+std::string WindowRmaTimeoutTest::rmaTypeName(const RmaType type) {
+  switch (type) {
+    case RmaType::kWaitSignal:
+      return "WaitSignal";
+    case RmaType::kPutWaitSignal:
+      return "PutWaitSignal";
+  }
+  return "Unknown";
+}
+
+namespace {
+at::Tensor makeTestTensor(
+    const std::vector<int64_t>& sizes,
+    const c10::DeviceType device_type,
+    const int rank) {
+  const auto device_index = rank % at::cuda::device_count();
+  return at::ones(
+      sizes,
+      at::TensorOptions().dtype(at::kFloat).device(device_type, device_index));
+}
+} // namespace
+
+void WindowRmaTimeoutTest::childSetUp() {
+  wrapper_ = std::make_unique<TorchCommTestWrapper>();
+  torchcomm_ = wrapper_->getTorchComm();
+  rank_ = torchcomm_->getRank();
+  num_ranks_ = torchcomm_->getSize();
+  if (isRunningOnCPU()) {
+    device_type_ = c10::DeviceType::CPU;
+  } else {
+    device_type_ = c10::DeviceType::CUDA;
+  }
+
+  // Initialize window with memory pool allocation
+  const auto cuda_allocator =
+      torch::comms::get_mem_allocator(torchcomm_->getBackend());
+  mem_pool_ = std::make_unique<at::cuda::MemPool>(
+      std::static_pointer_cast<c10::cuda::CUDACachingAllocator::CUDAAllocator>(
+          cuda_allocator));
+  const auto device_index = rank_ % at::cuda::device_count();
+  c10::cuda::CUDACachingAllocator::beginAllocateToPool(
+      device_index, mem_pool_->id(), [](cudaStream_t) { return true; });
+  constexpr int kCount = 1024;
+  window_tensor_ = at::ones(
+      {kCount * num_ranks_},
+      at::TensorOptions().dtype(at::kFloat).device(device_type_, device_index));
+  c10::cuda::CUDACachingAllocator::endAllocateToPool(
+      device_index, mem_pool_->id());
+
+  torchcomm_->barrier(false);
+  window_ = torchcomm_->new_window();
+  window_->tensor_register(window_tensor_);
+  torchcomm_->barrier(false);
+}
+
+void WindowRmaTimeoutTest::childTearDown() {
+  // Tear down window before communicator
+  if (window_) {
+    try {
+      window_->tensor_deregister();
+    } catch (...) {
+    }
+    window_.reset();
+  }
+  window_tensor_ = at::Tensor();
+  mem_pool_.reset();
+
+  if (torchcomm_) {
+    try {
+      torchcomm_->finalize();
+    } catch (...) {
+    }
+    torchcomm_.reset();
+  }
+}
+
+void WindowRmaTimeoutTest::execute(
+    const RmaType type,
+    const bool asyncOp,
+    const std::chrono::milliseconds timeout) {
+  constexpr int kCount = 1024;
+  const int dst = (rank_ + 1) % num_ranks_;
+  const int src = (rank_ + num_ranks_ - 1) % num_ranks_;
+
+  c10::intrusive_ptr<torch::comms::TorchWork> work;
+  torch::comms::WaitSignalOptions opts;
+  opts.timeout = timeout;
+
+  switch (type) {
+    case RmaType::kWaitSignal: {
+      window_->signal(dst, false);
+      work = window_->wait_signal(src, asyncOp, opts);
+      break;
+    }
+    case RmaType::kPutWaitSignal: {
+      auto input = makeTestTensor({kCount}, device_type_, rank_);
+      window_->put(input, dst, rank_ * kCount, false);
+      window_->signal(dst, false);
+      work = window_->wait_signal(src, asyncOp, opts);
+      break;
+    }
+  }
+  if (asyncOp) {
+    work->wait();
+  }
+}
+
+void WindowRmaTimeoutTest::testTimeout(
+    const RmaType type,
+    const ExecMode mode) {
+  // RMA window ops require ncclx backend with ctran enabled
+  const auto skipReason = shouldSkipRmaTest();
+  if (!skipReason.empty()) {
+    GTEST_SKIP() << skipReason;
+  }
+
+  if (mode != ExecMode::kEager && isRunningOnCPU()) {
+    GTEST_SKIP() << "CUDA Graph timeout tests not supported on CPU";
+  }
+
+  // Expected exit behavior per rank:
+  // - Rank 0 exits cleanly or gets aborted
+  // - Rank 1+ must be aborted with timeout log
+  const std::vector<RankExpectation> expectations = {
+      {.exitCode = 0, .signal = SIGABRT},
+      {.signal = SIGABRT,
+       .logMustContain = {"Aborting process due to timeout"}},
+  };
+
+  helper_.launch(
+      rmaTypeName(type),
+      num_ranks_,
+      [&](int /*rank*/) {
+        childSetUp();
+
+        std::vector<std::function<void()>> ops;
+        ops.reserve(kNumWarmup + 1);
+        for (int i = 0; i < kNumWarmup; i++) {
+          ops.emplace_back([&] { execute(type); });
+        }
+        if (rank_ != 0) {
+          ops.emplace_back([&] { execute(type, true, kTimeout); });
+        }
+        helper_.exec(mode, ops);
+
+        // rank 0 skips the last op so other ranks can timeout
+        if (rank_ == 0) {
+          std::this_thread::sleep_for(
+              kRank0Sleep); // NOLINT(facebook-hte-BadCall-sleep_for)
+          _exit(0);
+        } else {
+          childTearDown();
+        }
+      },
+      expectations);
+}

--- a/comms/torchcomms/tests/integration/cpp/WindowRmaTimeoutTest.hpp
+++ b/comms/torchcomms/tests/integration/cpp/WindowRmaTimeoutTest.hpp
@@ -1,0 +1,56 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <tuple>
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/MemPool.h>
+#include <gtest/gtest.h>
+
+#include "comms/torchcomms/TorchComm.hpp"
+#include "comms/torchcomms/TorchCommWindow.hpp"
+#include "comms/torchcomms/tests/integration/cpp/TimeoutTestHelpers.hpp"
+#include "comms/torchcomms/tests/integration/cpp/TorchCommTestHelpers.h"
+
+class WindowRmaTimeoutTest
+    : public ::testing::TestWithParam<std::tuple<int, int>> {
+ public:
+  enum class RmaType {
+    kWaitSignal,
+    kPutWaitSignal,
+  };
+
+  static std::string rmaTypeName(RmaType type);
+
+ protected:
+  static constexpr int kNumWarmup = 2;
+  static constexpr std::chrono::milliseconds kTimeout{std::chrono::seconds(2)};
+  static constexpr std::chrono::seconds kRank0Sleep{5};
+
+  void testTimeout(
+      RmaType type,
+      torch::comms::test::TimeoutTestHelper::ExecMode mode);
+
+ private:
+  void childSetUp();
+  void childTearDown();
+
+  void execute(
+      RmaType type,
+      bool asyncOp = true,
+      std::chrono::milliseconds timeout = torch::comms::kNoTimeout);
+
+  torch::comms::test::TimeoutTestHelper helper_;
+  std::unique_ptr<TorchCommTestWrapper> wrapper_;
+  std::shared_ptr<torch::comms::TorchComm> torchcomm_;
+  int rank_{0};
+  int num_ranks_{2};
+  c10::DeviceType device_type_{c10::DeviceType::CUDA};
+
+  std::shared_ptr<torch::comms::TorchCommWindow> window_;
+  std::unique_ptr<at::cuda::MemPool> mem_pool_;
+  at::Tensor window_tensor_;
+};

--- a/comms/torchcomms/tests/integration/py/TimeoutTest.py
+++ b/comms/torchcomms/tests/integration/py/TimeoutTest.py
@@ -2,6 +2,8 @@
 # pyre-unsafe
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
+# TORCHCOMM_TEST_SINGLE_PARENT = True  # For GitHub CI: run with nproc_per_node=1
+
 import os
 import time
 import unittest
@@ -160,6 +162,65 @@ def _run_graph_timeout_after_success_scenario() -> None:
     comm.finalize()
 
 
+def _run_eager_short_timeout_success_scenario() -> None:
+    """Eager all_reduce with short timeout completes successfully."""
+
+    backend = os.environ.get("TEST_BACKEND", "")
+    rank, _ = get_rank_and_size()
+    device_count = torch.cuda.device_count()
+    device = torch.device("cuda", rank % device_count)
+    torch.cuda.set_device(device)
+
+    comm = torchcomms.new_comm(
+        backend,
+        device,
+        name="eager_short_timeout_success_subprocess_comm",
+        abort_process_on_timeout_or_error=True,
+        timeout=timedelta(seconds=2),
+    )
+    try:
+        inp = torch.ones(10, 10, device=device)
+        comm.all_reduce(inp, torchcomms.ReduceOp.SUM, async_op=False)
+        torch.cuda.synchronize()
+        expected = torch.ones(10, 10, device=device) * comm.get_size()
+        torch.testing.assert_close(inp, expected)
+    finally:
+        comm.finalize()
+
+
+def _run_graph_short_timeout_success_scenario() -> None:
+    """Graph replay without artificial delay completes without timeout."""
+
+    class _Context(CudaGraphTestBase, unittest.TestCase):
+        def runTest(self):
+            pass
+
+    ctx = _Context("runTest")
+    ctx.setUp()
+    try:
+        for async_op in [False, True]:
+
+            def capture(b: GraphTestBuilder, _async: bool = async_op) -> None:
+                _wait(
+                    b.comms[0].all_reduce(
+                        b.inputs[0], torchcomms.ReduceOp.SUM, async_op=_async
+                    )
+                )
+
+            def make_inputs(b: GraphTestBuilder) -> list[torch.Tensor]:
+                return [torch.ones(10, 10, device=ctx.device)]
+
+            def make_expected(b: GraphTestBuilder) -> list[torch.Tensor]:
+                return [b.inputs[0] * b.comms[0].get_size()]
+
+            GraphTestBuilder(ctx).add_capture(capture).run_serial(
+                inputs=make_inputs,
+                expected=make_expected,
+            )
+    finally:
+        ctx.tearDown()
+
+
 # Early exit for subprocess mode: when re-invoked with a sentinel env var,
 # run the scenario and exit before the test runner discovers any test classes.
 if os.environ.get("_TORCHCOMM_RUN_EAGER_TIMEOUT"):
@@ -178,27 +239,39 @@ if os.environ.get("_TORCHCOMM_RUN_GRAPH_TIMEOUT_AFTER_SUCCESS"):
     _run_graph_timeout_after_success_scenario()
     os._exit(1)
 
+if os.environ.get("_TORCHCOMM_RUN_EAGER_SHORT_TIMEOUT_SUCCESS"):
+    _run_eager_short_timeout_success_scenario()
+    os._exit(0)
 
-class TestTimeout(CudaGraphTestBase, FatalStateTestMixin):
-    """Tests timeout detection, abort behavior, and false timeout prevention."""
+if os.environ.get("_TORCHCOMM_RUN_GRAPH_SHORT_TIMEOUT_SUCCESS"):
+    _run_graph_short_timeout_success_scenario()
+    os._exit(0)
+
+
+class TestTimeout(FatalStateTestMixin, unittest.TestCase):
+    """Tests timeout detection, abort behavior, and short timeout success verification."""
 
     def _run_abort_timeout_test(self, sentinel_var: str, expected_stderr: str) -> None:
         """Common logic for all subprocess abort-timeout tests.
 
-        Syncs parent ranks via barrier, spawns subprocess with sentinel,
-        and asserts abort (non-rank-0) or failure (rank-0).
+        Spawns world_size subprocesses with sentinel, and asserts abort
+        (non-rank-0) or failure (rank-0).
         """
-        with self.create_comms(1):
-            pass
+        results = self.run_subprocesses(sentinel_var)
+        for rank, result in enumerate(results):
+            if rank != 0:
+                self.assert_subprocess_aborted(result, expected_stderr)
+            else:
+                self.assert_subprocess_failed(result)
 
-        env = self.make_subprocess_env(sentinel_var)
-        result = self.run_subprocess(env)
+    def _run_short_timeout_success_test(self, sentinel_var: str) -> None:
+        """Common logic for short-timeout-success tests.
 
-        rank, _ = get_rank_and_size()
-        if rank != 0:
-            self.assert_subprocess_aborted(result, expected_stderr)
-        else:
-            self.assert_subprocess_failed(result)
+        Spawns world_size subprocesses and asserts all succeeded.
+        """
+        results = self.run_subprocesses(sentinel_var)
+        for result in results:
+            self.assert_subprocess_succeeded(result)
 
     # pyre-ignore[56]
     @skip_unless_ncclx
@@ -238,54 +311,19 @@ class TestTimeout(CudaGraphTestBase, FatalStateTestMixin):
 
     # pyre-ignore[56]
     @skip_unless_ncclx
-    def test_eager_no_false_timeout(self) -> None:
-        """Normal eager collective with short timeout completes without false timeout."""
-        comm = torchcomms.new_comm(
-            self.backend,
-            self.device,
-            name="test_eager_no_false_timeout_comm",
-            abort_process_on_timeout_or_error=True,
-            timeout=timedelta(seconds=2),
+    def test_eager_short_timeout_success(self) -> None:
+        """Normal eager collective with short timeout completes successfully."""
+        self._run_short_timeout_success_test(
+            "_TORCHCOMM_RUN_EAGER_SHORT_TIMEOUT_SUCCESS"
         )
-        try:
-            inp = torch.ones(10, 10, device=self.device)
-            comm.all_reduce(inp, torchcomms.ReduceOp.SUM, async_op=False)
-            torch.cuda.synchronize()
-            expected = torch.ones(10, 10, device=self.device) * comm.get_size()
-            torch.testing.assert_close(inp, expected)
-        finally:
-            comm.finalize()
 
     # pyre-ignore[56]
     @skip_unless_ncclx
-    def test_graph_no_false_timeout(self) -> None:
+    def test_graph_short_timeout_success(self) -> None:
         """Graph replay without artificial delay should complete without timeout."""
-        for async_op in [False, True]:
-            with self.subTest(async_op=async_op):
-
-                def make_inputs(b: GraphTestBuilder) -> list[torch.Tensor]:
-                    return [torch.ones(10, 10, device=self.device)]
-
-                def make_expected(b: GraphTestBuilder) -> list[torch.Tensor]:
-                    return [b.inputs[0] * b.comms[0].get_size()]
-
-                def assert_graph(b: GraphTestBuilder) -> None:
-                    info = b.graph_infos[0]
-                    ar_kernels = info.kernels_with_name("AllReduce")
-                    self.assertEqual(len(ar_kernels), 1)
-
-                def capture(b: GraphTestBuilder, _async: bool = async_op) -> None:
-                    _wait(
-                        b.comms[0].all_reduce(
-                            b.inputs[0], torchcomms.ReduceOp.SUM, async_op=_async
-                        )
-                    )
-
-                GraphTestBuilder(self).add_capture(capture).run_serial(
-                    inputs=make_inputs,
-                    expected=make_expected,
-                    graph_assertions=assert_graph,
-                )
+        self._run_short_timeout_success_test(
+            "_TORCHCOMM_RUN_GRAPH_SHORT_TIMEOUT_SUCCESS"
+        )
 
 
 if __name__ == "__main__":

--- a/comms/torchcomms/tests/integration/py/TimeoutTest.py
+++ b/comms/torchcomms/tests/integration/py/TimeoutTest.py
@@ -42,12 +42,11 @@ def _run_eager_timeout_scenario() -> None:
         device,
         name="eager_timeout_subprocess_comm",
         abort_process_on_timeout_or_error=True,
-        timeout=timedelta(milliseconds=1),
     )
 
     if rank == 0:
         time.sleep(10)
-    comm.barrier(async_op=False)
+    comm.barrier(async_op=False, timeout=timedelta(milliseconds=1))
     torch.cuda.synchronize()
 
     # Should not reach here — process should have been aborted
@@ -68,7 +67,6 @@ def _run_eager_timeout_after_success_scenario() -> None:
         device,
         name="eager_timeout_after_success_subprocess_comm",
         abort_process_on_timeout_or_error=True,
-        timeout=timedelta(milliseconds=1),
     )
 
     # First barrier: all ranks participate, should succeed.
@@ -78,7 +76,7 @@ def _run_eager_timeout_after_success_scenario() -> None:
     # Second barrier: rank 0 delays, causing timeout on other ranks.
     if rank == 0:
         time.sleep(10)
-    comm.barrier(async_op=False)
+    comm.barrier(async_op=False, timeout=timedelta(milliseconds=1))
     torch.cuda.synchronize()
 
     # Should not reach here — process should have been aborted


### PR DESCRIPTION
Summary:
Extend the abort-removal + timeout-test pattern from ncclx to nccl backend:
- Remove the `abort()` call from `TorchCommNCCL::abortNcclComm()` so that `checkAndAbortIfTimedOutOrError()` can throw instead of terminating the process. This matches the ncclx change in D94266656.
- Add "nccl" to CollectiveTimeoutTest backends so all 16 collective timeout tests run against nccl in eager mode.
- TODO: Graph mode timeout tests are skipped for non-ncclx backends because GraphEventTracker (which detects timeout during CUDA graph replay) is ncclx-only. Added TODO to port GraphEventTracker to nccl.

Differential Revision: D94298461


