### PR TITLE
Using  IBV_SEND_FENCE for signal

### DIFF
--- a/comms/pipes/benchmarks/IbgdaBenchmark.h
+++ b/comms/pipes/benchmarks/IbgdaBenchmark.h
@@ -15,6 +15,26 @@ class P2pIbgdaTransportDevice;
 namespace comms::pipes::benchmark {
 
 /**
+ * Single-shot launchers for correctness verification.
+ * Each launches exactly one put_signal + wait_local, no warmup, no loop.
+ */
+void launchIbgdaPutSignalSingle(
+    P2pIbgdaTransportDevice* transport,
+    const IbgdaLocalBuffer& localBuf,
+    const IbgdaRemoteBuffer& remoteBuf,
+    std::size_t nbytes,
+    int signalId,
+    cudaStream_t stream);
+
+void launchIbgdaPutSignalNonAdaptiveSingle(
+    P2pIbgdaTransportDevice* transport,
+    const IbgdaLocalBuffer& localBuf,
+    const IbgdaRemoteBuffer& remoteBuf,
+    std::size_t nbytes,
+    int signalId,
+    cudaStream_t stream);
+
+/**
  * Launch batched kernel: Multiple put+wait_local iterations in a single kernel
  *
  * This avoids per-operation kernel launch overhead and uses GPU cycle counters

--- a/comms/pipes/tests/P2pIbgdaTransportDeviceTest.cu
+++ b/comms/pipes/tests/P2pIbgdaTransportDeviceTest.cu
@@ -2,6 +2,7 @@
 
 #include "comms/pipes/IbgdaBuffer.h"
 #include "comms/pipes/P2pIbgdaTransportDevice.cuh"
+#include "comms/pipes/tests/Checks.h"
 #include "comms/pipes/tests/P2pIbgdaTransportDeviceTest.cuh"
 
 namespace comms::pipes::tests {


### PR DESCRIPTION
Summary:
This diff introduces `put_signal_with_fence()` and the underlying `signal_with_fence()`, which achieve the same ordering guarantee by setting `IBV_SEND_FENCE` (`DOCA_GPUNETIO_IB_MLX5_WQE_CTRL_FENCE`) on the signal WQE. The fence flag instructs the NIC to complete all prior posted WQEs (the data write) before processing the atomic signal, providing adaptive-routing safety without any GPU-side CQ polling overhead — the fence is handled entirely in NIC hardware.

Summary of the three put_signal variants now available:
- `put_signal()`: put + wait_local + signal (GPU-side CQ poll, adaptive safe)
- `put_signal_with_fence()`: put + signal_with_fence (NIC-level fence, adaptive safe) — **new**
- `put_signal_non_adaptive()`: fused put_signal WQE (no fence, NOT adaptive safe)

Also extends the IBGDA benchmark suite with:
- `signal_with_fence()` as a standalone low-level primitive
- Single-shot kernel launchers for all three put_signal variants (correctness verification)
- Batched kernel launcher for `put_signal_with_fence` (performance measurement)
- A 3-way comparison benchmark (`PutSignalComparison`) with per-size data correctness checks before performance measurement

Reviewed By: siyengar

Differential Revision: D93763318


