### PR TITLE
Fix out-of-bounds memcpy in P2pNvlTransportDevice::put()

### DIFF
--- a/comms/pipes/P2pNvlTransportDevice.cuh
+++ b/comms/pipes/P2pNvlTransportDevice.cuh
@@ -847,10 +847,10 @@ class P2pNvlTransportDevice {
 
     // Distribute chunks across all groups using for_each_item_contiguous
     // Each group processes its assigned contiguous range of chunks
-    std::size_t chunkBytes = 0;
+    std::size_t totalBytesWritten = 0;
     group.for_each_item_contiguous(numChunks, [&](uint32_t chunkIdx) {
       const std::size_t chunkOffset = chunkIdx * alignedChunkSize;
-      chunkBytes += (chunkOffset + alignedChunkSize <= nbytes)
+      const std::size_t chunkBytes = (chunkOffset + alignedChunkSize <= nbytes)
           ? alignedChunkSize
           : nbytes - chunkOffset;
 
@@ -860,9 +860,10 @@ class P2pNvlTransportDevice {
             src_d + chunkOffset, // src_base
             chunkBytes, // chunk_bytes
             group);
+        totalBytesWritten += chunkBytes;
       }
     });
-    return chunkBytes;
+    return totalBytesWritten;
 #endif
     return 0;
   }


### PR DESCRIPTION
Summary:
## Bug Description

`P2pNvlTransportDevice::put()` has a critical data corruption bug where
`chunkBytes` is accumulated across loop iterations instead of being
computed fresh per iteration. This causes `memcpy_vectorized` to copy
an ever-growing number of bytes while the source/destination offsets
advance per-chunk, resulting in out-of-bounds reads and writes.

## Root Cause

The variable `chunkBytes` is declared outside the lambda and uses `+=`
(line 853), causing it to accumulate across iterations of
`for_each_item_contiguous`. On iteration K, `chunkBytes` contains the
sum of all chunk sizes from iterations 0 through K. However,
`chunkOffset` correctly advances to chunk K's starting position. This
means `memcpy_vectorized` copies (K+1) chunks of data starting from
chunk K's offset -- reading and writing well past allocation boundaries.

```
Bug visualization (3 chunks assigned to 1 group, alignedChunkSize=64):

Iteration 0: chunkOffset=0,   chunkBytes=64    -> copies [0..63]     ✓ correct
Iteration 1: chunkOffset=64,  chunkBytes=128   -> copies [64..191]   ✗ OOB!
Iteration 2: chunkOffset=128, chunkBytes=192   -> copies [128..319]  ✗ OOB!

Memory layout:
  src: [chunk0][chunk1][chunk2][  out of bounds  ]
        0      64     128    192                320
                                 ^^^^^^^^^^^^^^^^^
                              Iteration 2 reads past buffer end

  dst: [chunk0][chunk1][chunk2][  out of bounds  ]
        0      64     128    192                320
                                 ^^^^^^^^^^^^^^^^^
                              Iteration 2 writes past buffer end
```

## Why it hasn't crashed yet

The chunk-sizing math typically produces `numChunks <= total_groups`,
so `for_each_item_contiguous` assigns at most 1 chunk per group. With
a single iteration, the accumulation has no effect. However, this
depends on a numerical coincidence:

```
targetChunkSize = nbytes / total_groups
alignedChunkSize = ceil(targetChunkSize, 16)  // >= targetChunkSize
numChunks = ceil(nbytes / alignedChunkSize)   // typically <= total_groups
```

The bug CAN trigger when:
- Partitioned subgroups have smaller total_groups
- Transfer sizes don't divide evenly and produce numChunks > total_groups
- Any future change to chunk sizing formula

## Fix

Change `chunkBytes` from a mutable outer-scope variable with `+=` to a
`const` variable declared inside the lambda (fresh per iteration). This
matches the correct pattern used in three other places in the codebase:

```
Before (buggy):                    After (fixed):
  std::size_t chunkBytes = 0;        std::size_t totalBytesWritten = 0;
  ... [&](...) {                     ... [&](...) {
    chunkBytes += ...                  const std::size_t chunkBytes = ...
    memcpy(... chunkBytes ...);        memcpy(... chunkBytes ...);
  }                                    totalBytesWritten += chunkBytes;
  return chunkBytes;                 }
                                     return totalBytesWritten;
```

Reference implementations (all correct):
- `P2pSelfTransportDevice::put()` at line 112
- `P2pNvlTransportDevice::send()` at line 354
- `P2pNvlTransportDevice::recv()` at line 451

## Impact

- **Data corruption**: Chunks after the first copy data from wrong
  offsets, corrupting peer GPU memory via NVLink silently
- **Out-of-bounds reads/writes**: Later iterations read/write past
  source and destination buffer boundaries
- **Incorrect return value**: Returns accumulated total instead of
  actual bytes written by this group

Oncall: ncclx

Differential Revision: D94437171


