### PR TITLE
Temporary disable globalDeregister and deregAll in RegCache

### DIFF
--- a/comms/ctran/regcache/RegCache.cc
+++ b/comms/ctran/regcache/RegCache.cc
@@ -352,6 +352,9 @@ commResult_t ctran::RegCache::globalRegister(
 
 commResult_t
 ctran::RegCache::globalDeregister(const void* buf, size_t len, int deviceId) {
+  CLOGF(ERR, "globalDeregister is disabled while remReleaseMem is moved.");
+  return commInternalError;
+
   if (buf == nullptr || len == 0) {
     return commSuccess;
   }
@@ -391,8 +394,7 @@ ctran::RegCache::globalDeregister(const void* buf, size_t len, int deviceId) {
     auto ipcRegElem =
         reinterpret_cast<ctran::regcache::IpcRegElem*>(regElem->ipcRegElem);
     if (ipcRegElem != nullptr) {
-      FB_COMMCHECK(
-          ipcRegCache->remReleaseMem(localPeerId, ipcRegElem, postedReqs));
+      // FIXME: call mapper function to release remote memory
     }
   }
 
@@ -1355,6 +1357,9 @@ commResult_t ctran::RegCache::regAll() {
 // Global API: Deregister all non-dynamic registration elements.
 // This removes all registrations but keeps cached segments intact.
 commResult_t ctran::RegCache::deregAll() {
+  CLOGF(ERR, "deregAll is disabled while remReleaseMem is moved.");
+  return commInternalError;
+
   auto regCache = ctran::RegCache::getInstance();
   if (!regCache) {
     CLOGF(ERR, "deregAll: RegCache instance not available");
@@ -1417,8 +1422,7 @@ commResult_t ctran::RegCache::deregAll() {
     auto ipcRegElem =
         reinterpret_cast<ctran::regcache::IpcRegElem*>(regElem->ipcRegElem);
     if (ipcRegElem != nullptr) {
-      FB_COMMCHECK(
-          ipcRegCache->remReleaseMem(localPeerId, ipcRegElem, postedReqs));
+      // FIXME: call mapper function to release remote memory
     }
   }
 

--- a/comms/ctran/regcache/tests/GlobalRegistrationUT.cc
+++ b/comms/ctran/regcache/tests/GlobalRegistrationUT.cc
@@ -73,7 +73,7 @@ class GlobalRegistrationTest : public ::testing::Test {
  * 2. CtranIbSingleton is lazily initialized when needed
  * 3. Registration and deregistration succeed
  */
-TEST_F(GlobalRegistrationTest, RegisterWithoutCommOrMapper) {
+TEST_F(GlobalRegistrationTest, DISABLED_RegisterWithoutCommOrMapper) {
   // Verify NO CtranComm or CtranMapper exists - we're testing global API only
   // There is no comm to check, this test runs standalone
 
@@ -93,7 +93,7 @@ TEST_F(GlobalRegistrationTest, RegisterWithoutCommOrMapper) {
  * This simulates the CCA pattern where multiple memory allocations
  * are registered before a comm is created.
  */
-TEST_F(GlobalRegistrationTest, MultipleRegistrationsBeforeComm) {
+TEST_F(GlobalRegistrationTest, DISABLED_MultipleRegistrationsBeforeComm) {
   constexpr int numBuffers = 4;
   std::vector<void*> buffers(numBuffers, nullptr);
 
@@ -137,7 +137,7 @@ TEST_F(GlobalRegistrationTest, MultipleRegistrationsBeforeComm) {
  * 3. Verifies that pinRange discovers all physical segments
  * 4. Deregisters and frees the memory
  */
-TEST_F(GlobalRegistrationTest, MultiSegmentDisjointRegistration) {
+TEST_F(GlobalRegistrationTest, DISABLED_MultiSegmentDisjointRegistration) {
   // Allocate disjoint memory with 2 segments
   constexpr size_t totalSize = 2 * 1024 * 1024; // 2MB total
   std::vector<size_t> segmentSizes = {totalSize / 2, totalSize / 2};
@@ -189,7 +189,7 @@ TEST_F(GlobalRegistrationTest, MultiSegmentDisjointRegistration) {
  * physical segments, similar to large PyTorch allocations that span
  * multiple 20MB chunks in expandable segments mode.
  */
-TEST_F(GlobalRegistrationTest, MultiSegmentManyChunks) {
+TEST_F(GlobalRegistrationTest, DISABLED_MultiSegmentManyChunks) {
   // Allocate disjoint memory with 5 segments (simulating 5 x 20MB chunks)
   constexpr int numSegments = 5;
   constexpr size_t segmentSize = 512 * 1024; // 512KB per segment for test
@@ -232,7 +232,7 @@ TEST_F(GlobalRegistrationTest, MultiSegmentManyChunks) {
  * proceeds through the normal path, and the IB backend handles it gracefully
  * via exception catching in doRegister, matching CtranMapper behavior.
  */
-TEST_F(GlobalRegistrationTest, CpuTensorRegistration) {
+TEST_F(GlobalRegistrationTest, DISABLED_CpuTensorRegistration) {
   constexpr size_t cpuBufSize = 1024 * 1024; // 1MB
   void* cpuBuf = malloc(cpuBufSize);
   ASSERT_NE(cpuBuf, nullptr) << "CPU memory allocation should succeed";

--- a/comms/ctran/regcache/tests/RegCacheBench.cc
+++ b/comms/ctran/regcache/tests/RegCacheBench.cc
@@ -272,7 +272,7 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Combine(
         testing::Values(1, 4, 8, 16),
         testing::Values(20 * 1024 * 1024),
-        testing::Values("global", "comm")),
+        testing::Values("comm")),
     [&](const testing::TestParamInfo<CommVsGlobalRegParam::ParamType>& info) {
       return std::to_string(std::get<0>(info.param)) + "numSeg_" +
           std::to_string(std::get<1>(info.param)) + "SegSize_" +
@@ -280,7 +280,7 @@ INSTANTIATE_TEST_SUITE_P(
     });
 
 // Benchmark for regAll - registers all cached segments as contiguous regions
-TEST_F(RegCacheBench, RegAllTime) {
+TEST_F(RegCacheBench, DISABLED_RegAllTime) {
   constexpr int numIter = 10;
   constexpr int numSegments = 8;
   constexpr size_t segmentSize = 20 * 1024 * 1024; // 20MB per segment

--- a/comms/ctran/regcache/tests/RegCacheUT.cc
+++ b/comms/ctran/regcache/tests/RegCacheUT.cc
@@ -631,7 +631,7 @@ TEST_F(RegCacheTest, HoldsCtranIbSingletonReference) {
 // Test multiple deregAll/regAll cycles to verify no resource leaks or
 // corruption. This simulates a workload that periodically re-registers
 // memory (e.g., for BAR1 memory management).
-TEST_F(RegCacheTest, MultipleDeregAllRegAllCycles) {
+TEST_F(RegCacheTest, DISABLED_MultipleDeregAllRegAllCycles) {
   constexpr size_t segmentSize = 2 * 1024 * 1024; // 2MB
   constexpr int numSegments = 2;
   constexpr int numCycles = 5;
@@ -693,14 +693,14 @@ TEST_F(RegCacheTest, RegAllWithNoSegmentsReturnsSuccess) {
 }
 
 // Test deregAll with no registrations returns success (edge case)
-TEST_F(RegCacheTest, DeregAllWithNoRegistrationsReturnsSuccess) {
+TEST_F(RegCacheTest, DISABLED_DeregAllWithNoRegistrationsReturnsSuccess) {
   // deregAll should succeed (no-op)
   EXPECT_EQ(ctran::RegCache::deregAll(), commSuccess);
 }
 
 // Test getContiguousRegions logic: single segment forms one region
 // This indirectly tests getContiguousRegions through regAll
-TEST_F(RegCacheTest, GetContiguousRegionsSingleSegment) {
+TEST_F(RegCacheTest, DISABLED_GetContiguousRegionsSingleSegment) {
   size_t bufSize = 8192;
   void* buf = nullptr;
   CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
@@ -735,7 +735,7 @@ TEST_F(RegCacheTest, GetContiguousRegionsSingleSegment) {
 // Test getContiguousRegions logic: multiple contiguous segments form one region
 // This tests that adjacent segments (where end addr == next start addr) are
 // grouped together
-TEST_F(RegCacheTest, GetContiguousRegionsMultipleContiguousSegments) {
+TEST_F(RegCacheTest, DISABLED_GetContiguousRegionsMultipleContiguousSegments) {
   constexpr size_t segmentSize = 2 * 1024 * 1024; // 2MB per segment
   constexpr int numSegments = 4;
   std::vector<size_t> segSizes(numSegments, segmentSize);
@@ -782,7 +782,7 @@ TEST_F(RegCacheTest, GetContiguousRegionsMultipleContiguousSegments) {
 // Test regAll handles multiple non-contiguous memory regions correctly.
 // This ensures that regAll creates separate registrations for each
 // contiguous region, not one giant registration spanning gaps.
-TEST_F(RegCacheTest, RegAllHandlesNonContiguousRegions) {
+TEST_F(RegCacheTest, DISABLED_RegAllHandlesNonContiguousRegions) {
   // Allocate three disjoint buffers. Cache only buf1 and buf3, using buf2
   // as a spacer to guarantee buf1 and buf3 are non-contiguous in memory.
   constexpr size_t segmentSize = 2 * 1024 * 1024; // 2MB


### PR DESCRIPTION
Summary: remReleaseMem is moving, which causes globalDeregister and deregAll to not compile. Disable these codepaths with an early error return until remReleaseMem lands in its new location. These calls are not used yet, so this temporary disable is ok.

Differential Revision: D94529614


