### PR TITLE
allow users to pass in deviceId to set the cudaDev for CPU memory register

### DIFF
--- a/comms/ctran/regcache/RegCache.h
+++ b/comms/ctran/regcache/RegCache.h
@@ -275,12 +275,16 @@ class RegCache {
   // This allows registration without requiring a communicator.
   // Backends are initialized from NCCL_CTRAN_BACKENDS cvar in init().
   // If forceReg is true, registration happens even in async/lazy mode.
-  commResult_t
-  globalRegister(const void* buf, size_t len, bool forceReg = false);
+  // deviceId is optional: if not assigned, infer it from getCudaDevFromPtr()
+  commResult_t globalRegister(
+      const void* buf,
+      size_t len,
+      bool forceReg = false,
+      int deviceId = -1);
 
   // Global deregistration using pointer lookup.
   // Frees cached segments and their associated registrations.
-  commResult_t globalDeregister(const void* buf, size_t len);
+  commResult_t globalDeregister(const void* buf, size_t len, int deviceId = -1);
 
   // Thread-safe functions to cache a buffer range into the global cache.
   // This function uses pinRange to discover all physical segments underlying


### PR DESCRIPTION
Summary:
## Diff Summary
Add optional input argument `deviceId` in `globalRegister` and `globalDeregister` in `RegCache`. If `deviceId` is unset, we use auto-detect cudaDev from the buffer pointer; otherwise, we assign `deviceId` to `cudaDev`.

Reviewed By: dsjohns2

Differential Revision: D93637327


