### PR TITLE
Add scaleupDomain and localHostname to CudaError across full stack

### DIFF
--- a/comms/analyzer/if/CommsTracingService.thrift
+++ b/comms/analyzer/if/CommsTracingService.thrift
@@ -201,6 +201,8 @@ struct CudaError {
   1: i64 timestampMs;
   2: string errorString;
   3: i32 errorCode;
+  4: string scaleupDomain;
+  5: string localHostname;
 }
 
 // NOTE: Keep in sync with commDump.cc

--- a/comms/ncclx/v2_28/meta/analyzer/NCCLXCommsTracingServiceHandler.cc
+++ b/comms/ncclx/v2_28/meta/analyzer/NCCLXCommsTracingServiceHandler.cc
@@ -102,6 +102,8 @@ NCCLXCommsTracingServiceHandler::co_getComms(
       thriftErr.timestampMs() = cudaErr.timestampMs.count();
       thriftErr.errorString() = cudaErr.errorString;
       thriftErr.errorCode() = cudaErr.errorCode;
+      thriftErr.scaleupDomain() = cudaErr.scaleupDomain;
+      thriftErr.localHostname() = cudaErr.localHostname;
       response.cudaErrors().ensure().push_back(std::move(thriftErr));
     }
     ProcessGlobalErrorsUtil::clearCudaErrors();

--- a/comms/ncclx/v2_28/src/include/checks.h
+++ b/comms/ncclx/v2_28/src/include/checks.h
@@ -26,14 +26,16 @@ constexpr const char* ncclCodeToString(ncclResult_t code) {
 }
 
 // Report a CUDA error to colltrace for analyzer consumption
-#define COMMDUMP_REPORT_CUDA_ERROR(err)                     \
-  do {                                                       \
-    if (NCCL_PROCESS_GLOBAL_ERRORS_MAX_STACK_TRACES > 0) {                           \
-      ProcessGlobalErrorsUtil::CudaError cudaErr;            \
-      cudaErr.errorString = cudaGetErrorString(err);         \
-      cudaErr.errorCode = static_cast<int>(err);             \
-      ProcessGlobalErrorsUtil::addCudaError(std::move(cudaErr)); \
-    }                                                        \
+#define COMMDUMP_REPORT_CUDA_ERROR(err)                                    \
+  do {                                                                      \
+    if (NCCL_PROCESS_GLOBAL_ERRORS_MAX_STACK_TRACES > 0) {                  \
+      ProcessGlobalErrorsUtil::CudaError cudaErr;                           \
+      cudaErr.errorString = cudaGetErrorString(err);                        \
+      cudaErr.errorCode = static_cast<int>(err);                            \
+      cudaErr.scaleupDomain = ProcessGlobalErrorsUtil::getScaleupDomain();  \
+      cudaErr.localHostname = ProcessGlobalErrorsUtil::getHostname();       \
+      ProcessGlobalErrorsUtil::addCudaError(std::move(cudaErr));            \
+    }                                                                       \
   } while (false)
 
 // Check CUDA RT calls

--- a/comms/utils/logger/ProcessGlobalErrorsUtil.h
+++ b/comms/utils/logger/ProcessGlobalErrorsUtil.h
@@ -48,6 +48,8 @@ class ProcessGlobalErrorsUtil {
     std::chrono::milliseconds timestampMs{};
     std::string errorString; // from cudaGetErrorString(err)
     int errorCode{0}; // the raw cudaError_t value
+    std::string scaleupDomain;
+    std::string localHostname;
   };
 
   struct State {


### PR DESCRIPTION
Summary:
Add `scaleupDomain` and `localHostname` fields to `CudaError`, mirroring
the existing fields on `IbCompletionError`. This enables the CUDA error
analyzer verdict to report which scaleup domain and host is affected.

Changes across the full stack:
- Thrift IDL: add fields 4 (scaleupDomain) and 5 (localHostname) to CudaError
- ProcessGlobalErrorsUtil.h: add matching fields to the C++ CudaError struct
- checks.h: COMMDUMP_REPORT_CUDA_ERROR macro now populates scaleupDomain
  and localHostname using ProcessGlobalErrorsUtil helpers
- NCCLXCommsTracingServiceHandler.cc: serialize the new fields to thrift
- CudaErrorAnalyzer.h/cc: track earliestErrorScaleupDomain and
  earliestErrorLocalHostname, add buildResultString() method, include
  hostname and scaleupDomain in verdict messages for both NVLink and
  generic CUDA errors
- CudaErrorAnalyzerTest.cpp: update tests to verify new fields
- AnalyzerThriftIntegrationTest.cpp: add NVLink scaleupDomain assertions
  and new NvlinkErrorMultiRankTracksEarliestScaleupDomain test

Differential Revision: D94568232


