### PR TITLE
Add dynamicSharedMemBytes to GPE KernelConfig

### DIFF
--- a/comms/ctran/gpe/CtranGpe.h
+++ b/comms/ctran/gpe/CtranGpe.h
@@ -325,6 +325,9 @@ struct KernelConfig {
   const uint64_t opCount;
   bool isDevice{true};
 
+  // Dynamic shared memory size override. 0 = use sizeof(CtranAlgoDeviceState).
+  size_t dynamicSharedMemBytes{0};
+
   // Experimental: allows one-sided communications, waitSignal and
   // multiWaitSignal, to run in parallel with other kernels when
   // launched on a single GPE thread.

--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -312,11 +312,14 @@ commResult_t CtranGpe::Impl::submit(
 
     // Set the maximum dynamic shared memory size since CtranAlgoDeviceState
     // (~67KB) exceeds the default limit (48KB)
+    size_t sharedMemBytes = kernelConfig.dynamicSharedMemBytes > 0
+        ? kernelConfig.dynamicSharedMemBytes
+        : sizeof(CtranAlgoDeviceState);
     FB_CUDACHECKGOTO(
         cudaFuncSetAttribute(
             ncclKernel,
             cudaFuncAttributeMaxDynamicSharedMemorySize,
-            sizeof(CtranAlgoDeviceState)),
+            sharedMemBytes),
         res,
         fail);
     FB_CUDACHECKGOTO(
@@ -325,7 +328,7 @@ commResult_t CtranGpe::Impl::submit(
             grid,
             blocks,
             kernelArgs.data(),
-            sizeof(CtranAlgoDeviceState),
+            sharedMemBytes,
             kernelConfig.stream),
         res,
         fail);


### PR DESCRIPTION
Summary:
Add a `dynamicSharedMemBytes` field to GPE KernelConfig so kernels can
request custom shared memory sizes beyond the default sizeof(CtranAlgoDeviceState).
When set to 0 (default), the existing behavior is preserved. This is needed
for kernels like the TMA scatter-signal kernel that require larger shared
memory allocations.

Differential Revision: D94578739


