### PR TITLE
Set NCCL_CTRAN_IPC_REGCACHE_ENABLE_ASYNC_SOCKET in tests using IPC

### DIFF
--- a/comms/ctran/tests/CtranBroadcastTest.cc
+++ b/comms/ctran/tests/CtranBroadcastTest.cc
@@ -27,6 +27,7 @@ class CtranBroadcastTest : public CtranIntraProcessFixture,
   static constexpr size_t kBufferNElem = kBufferSize / kTypeSize;
 
   void SetUp() override {
+    setenv("NCCL_CTRAN_IPC_REGCACHE_ENABLE_ASYNC_SOCKET", "1", 1);
     CtranIntraProcessFixture::SetUp();
   }
 


### PR DESCRIPTION
Summary: D94369864 changed the default value of `NCCL_CTRAN_IPC_REGCACHE_ENABLE_ASYNC_SOCKET` from `true` to `false`, which broke several tests that depend on IPC functionality. This diff explicitly sets the env var in the tests that need it, matching the pattern already used in `DistRegCacheUT.cc` from the original diff.

Differential Revision: D94676671


