### PR TITLE
Move CtranComm implementations from header to .cc

### DIFF
--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -49,17 +49,7 @@ class CtranComm {
   explicit CtranComm(
       std::shared_ptr<Abort> abort =
           ctran::utils::createAbort(/*enabled=*/false),
-      ctranConfig commConfig = ctranConfig{})
-      : config_(commConfig), abort_(abort) {
-    asyncErr_ =
-        std::make_shared<AsyncError>(NCCL_CTRAN_ABORT_ON_ERROR, "CtranComm");
-    if (!abort_) {
-      throw ctran::utils::Exception(
-          "abort must not be empty", commInternalError);
-    }
-    // Default points to internal opCount
-    opCount_ = &ctranOpCount_;
-  }
+      ctranConfig commConfig = ctranConfig{});
 
   // The MemCache allocator is destroyed in a different time than all
   // other Ctran resources. To accommodate this, we split the CtranComm
@@ -67,26 +57,9 @@ class CtranComm {
   // resources except for MemCache. The second part is moved to the
   // destructor, where it is safe to destroy MemCache and reset its
   // reference.
-  void destroy() {
-    // All smart pointers are automatically de-initialized, but we want to
-    // ensure they do so in a specific order. Therefore, we manually handle
-    // their de-initialization here.
-    ctran_.reset();
-    bootstrap_.reset();
-    collTrace_.reset();
-    colltraceNew_.reset();
-    statex_.reset();
-    // NOTE: memCache needs to be destroyed after transportProxy_ to release
-    // all buffers
-    memCache_.reset();
+  void destroy();
 
-    this->logMetaData_.commDesc.clear();
-    this->logMetaData_.commDesc.shrink_to_fit();
-  }
-
-  ~CtranComm() {
-    this->destroy();
-  }
+  ~CtranComm();
 
   // Finalize any outstanding communication associated with the CtranComm
   // instance. Any resource release would be handled in later call to
@@ -184,8 +157,8 @@ class CtranComm {
   // refactoring we will remove ncclx fields from ncclx and will initialize
   // them on CtranComm. Until then only factory method should be used to
   // initialize CtranComm.
-  CtranComm(CtranComm&&) = default;
-  CtranComm& operator=(CtranComm&&) = default;
+  CtranComm(CtranComm&&);
+  CtranComm& operator=(CtranComm&&);
   CtranComm(const CtranComm&) = delete;
   CtranComm& operator=(const CtranComm&) = delete;
 


### PR DESCRIPTION
Summary:
Move CtranComm constructor, destructor, destroy(), and move
operators from inline definitions in CtranComm.h to Ctran.cc.

This is a pure refactoring with no functional change. It prepares
for adding members with forward-declared types (e.g., unique_ptr
of incomplete types) which require the destructor to be in a
translation unit that includes the full type definition.

Reviewed By: siyengar

Differential Revision: D94539611


