### PR TITLE
add searchIbRegElem API in regCache to get the IB regHdl for later usage

### DIFF
--- a/comms/ctran/regcache/RegCache.cc
+++ b/comms/ctran/regcache/RegCache.cc
@@ -577,6 +577,14 @@ bool ctran::RegCache::isRegistered(const void* ptr, const size_t len) {
   return regHdl != nullptr;
 }
 
+void* ctran::RegCache::searchIbRegElem(const void* ptr, const size_t len) {
+  auto* regElem = searchRegElem(ptr, len);
+  if (regElem == nullptr || regElem->ibRegElem == nullptr) {
+    return nullptr;
+  }
+  return regElem->ibRegElem;
+}
+
 std::vector<void*> ctran::RegCache::getSegments() const {
   return segmentsAvl_.rlock()->getAllElems();
 }

--- a/comms/ctran/regcache/RegCache.h
+++ b/comms/ctran/regcache/RegCache.h
@@ -423,6 +423,10 @@ class RegCache {
   // Thread-safe function to check if a given <ptr, len> range is registered.
   bool isRegistered(const void* ptr, const size_t len);
 
+  // Thread-safe function to search for a RegElem containing [ptr, ptr+len)
+  // and return its ibRegElem. Returns nullptr if not found.
+  void* searchIbRegElem(const void* ptr, size_t len);
+
   // Thread-safe function to wait on all async registration requests to finish.
   // Used by test only.
   void waitAsyncRegComplete();

--- a/comms/ctran/regcache/tests/GlobalRegistrationUT.cc
+++ b/comms/ctran/regcache/tests/GlobalRegistrationUT.cc
@@ -251,6 +251,8 @@ TEST_F(GlobalRegistrationTest, CpuTensorRegistration) {
   ASSERT_NE(regCache, nullptr);
   EXPECT_TRUE(regCache->isRegistered(cpuBuf, cpuBufSize))
       << "CPU buffer should be found by searchRegElem after registration";
+  auto* ibRegHdl = regCache->searchIbRegElem(cpuBuf, cpuBufSize);
+  EXPECT_NE(ibRegHdl, nullptr);
 
   // Deregistration of CPU memory should also succeed gracefully
   result = ctran::globalDeregisterWithPtr(cpuBuf, cpuBufSize);


### PR DESCRIPTION
Summary: add `searchIbRegElem` public API to get IB regHdl from regCache.

Reviewed By: dsjohns2

Differential Revision: D94563783


