### PR TITLE
Fix tensor lifetime bug in CUDA graph mode for alltoallv_dynamic

### DIFF
--- a/comms/torchcomms/ncclx/GraphEventTracker.hpp
+++ b/comms/torchcomms/ncclx/GraphEventTracker.hpp
@@ -11,6 +11,8 @@
 
 #include <cuda_runtime.h> // @manual=third-party//cuda:cuda-lazy
 
+#include <ATen/ATen.h>
+
 #include "comms/torchcomms/device/cuda/CudaApi.hpp"
 
 namespace torch::comms {
@@ -114,6 +116,11 @@ class GraphEventTracker {
   struct GraphState {
     std::vector<GraphWork> entries;
     SharedCallbackState* shared_{nullptr};
+    // CPU tensors that must be kept alive for the graph's lifetime.
+    // This includes CPU pointer tensors used by alltoallv_dynamic_dispatch
+    // operations. These tensors are moved from work objects during graph
+    // capture and remain valid until the graph is destroyed.
+    std::vector<at::Tensor> cpu_tensors;
   };
 
   TorchCommNCCLX* comm_; // raw pointer — parent owns this tracker


### PR DESCRIPTION
Summary:
Fix a use-after-free bug where output tensors and CPU pointer tensors used by
`alltoallv_dynamic_dispatch` and `alltoallv_dynamic_combine` could be destroyed
prematurely during CUDA graph capture, causing garbage pointer values (e.g.,
`0x4`) during graph replay.

The fix has two parts:

1. **Save tensors to work object**: Added `setRetainedTensors()` API to
   `TorchWorkNCCLX` to store tensors that must outlive the async operation.
   - `dispatch`: Saves output tensors and CPU pointer tensor
   - `combine`: Saves output tensor

2. **Transfer tensors to GraphEventTracker**: In graph capture mode, tensors
   are transferred from the work object to `GraphState::retained_tensors`,
   keeping them alive for the graph's lifetime (not just the work's lifetime).

Without this fix, CUDA graph replay would fail with CTRAN buffer registration
errors like:
```
CTRAN-IB: buffer registration failed: buf=0x4, len=65536
```

Differential Revision: D94301857


