### PR TITLE
Enable IPC regcache async socket for IPC tests

### DIFF
--- a/comms/ctran/tests/CtranUtUtils.cc
+++ b/comms/ctran/tests/CtranUtUtils.cc
@@ -34,6 +34,9 @@ void CtranDistBaseTest::SetUp() {
   setenv("NCCL_CTRAN_ENABLE", "1", 0);
   setenv("NCCL_COLLTRACE", "trace", 0);
   setenv("NCCL_CTRAN_IB_EPOCH_LOCK_ENFORCE_CHECK", "true", 0);
+  // Enable async socket for IPC regcache. This is needed when NVL backend
+  // exports IPC handles to peers.
+  setenv("NCCL_CTRAN_IPC_REGCACHE_ENABLE_ASYNC_SOCKET", "1", 0);
 
   // Create single tcpStore and commWorld shared by all tests running in
   // this test suite.


### PR DESCRIPTION
Summary:
After D94369864 changed the default value of `NCCL_CTRAN_IPC_REGCACHE_ENABLE_ASYNC_SOCKET` from `true` to `false`, tests using ctran/IPC functionality with NVL backend started timing out or failing.

This adds the environment variable explicitly to:
1. **DeviceApiTest** configurations in BUCK - which use IPC for device-side window communication
2. **PersistentAPITestBase.setUp()** in `test_c10d_ncclx_persistent.py` - which uses ctpipeline (IPC-based allgather_p)
3. **CtranDistBaseTest::SetUp()** in `CtranUtUtils.cc` - conditionally enabled only when NVL backend is available

Reviewed By: MogicianWu

Differential Revision: D94781889


