### PR TITLE
Remove system->inter change in 2.28

### DIFF
--- a/comms/ncclx/v2_28/src/graph/paths.cc
+++ b/comms/ncclx/v2_28/src/graph/paths.cc
@@ -852,11 +852,7 @@ ncclResult_t ncclTopoTrimSystem(struct ncclTopoSystem* system, struct ncclComm* 
     NCCLCHECKGOTO(ncclTopoRemoveNode(system, GPU, g), ret, fail);
   }
 
-  if (!NCCL_TOPO_BOND_V228) {
-    system->inter = system->nodes[NET].count;
-  } else {
     system->inter = system->nodes[GPU].count == comm->nRanks ? 0 : 1;
-  }
 exit:
   free(domains);
   if (ids) free(ids);


### PR DESCRIPTION
Summary:
Remove system->inter change as it was causing a numerics issue. 
See https://docs.google.com/document/d/1uA5YK9p7JcUmfiLqJ8CSu1MoIWNKscyKuiLTJODLfAY/edit?usp=sharing for details.

Reviewed By: tanquer

Differential Revision: D94933841


