### PR TITLE
move CmsgIbExportMem to ctran::regcache::IbDesc, which is used for globalExportMem in regcache module

### DIFF
--- a/comms/ctran/CtranExRequest.cc
+++ b/comms/ctran/CtranExRequest.cc
@@ -102,8 +102,8 @@ void CtranExRequestImpl::atComplete(CtranExRequest* req) {
       // copy received buffer info to user specified pointers
       if (recvCtrl.msg.type == ControlMsgType::IB_EXPORT_MEM) {
         *(recvCtrl.rBuf) =
-            reinterpret_cast<void*>(recvCtrl.msg.ibExp.remoteAddr);
-        *(recvCtrl.rKey) = recvCtrl.msg.ibExp.rkeys[0];
+            reinterpret_cast<void*>(recvCtrl.msg.ibDesc.remoteAddr);
+        *(recvCtrl.rKey) = recvCtrl.msg.ibDesc.rkeys[0];
       }
       break;
     default:

--- a/comms/ctran/backends/CtranCtrl.cc
+++ b/comms/ctran/backends/CtranCtrl.cc
@@ -4,8 +4,6 @@
 #include "comms/ctran/utils/Checks.h"
 #include "comms/utils/logger/LogUtils.h"
 
-const std::string CmsgIbExportMem::name = "IB_EXPORT_MEM";
-
 commResult_t CtranCtrlManager::regCb(int type, ContrlMsgCbFn fn, void* ctx) {
   if (this->hasCb(type)) {
     CLOGF(

--- a/comms/ctran/backends/CtranCtrl.h
+++ b/comms/ctran/backends/CtranCtrl.h
@@ -15,8 +15,6 @@
 #include "comms/ctran/regcache/IpcRegCacheBase.h"
 #include "comms/ctran/utils/CtranIpc.h"
 
-constexpr int CTRAN_MAX_IB_DEVICES_PER_RANK{2};
-
 /**
  * Define all control message types used in CTran backends.
  *
@@ -76,24 +74,6 @@ struct CtranIbConfig {
   int64_t trafficClass{NCCL_IB_TC};
 };
 
-struct CmsgIbExportMem {
-  uint64_t remoteAddr{0};
-  std::array<uint32_t, CTRAN_MAX_IB_DEVICES_PER_RANK> rkeys{};
-  int nKeys{0};
-
-  static const std::string name;
-
-  CmsgIbExportMem() {};
-  std::string toString() const {
-    std::stringstream ss;
-    ss << "[" << name << "] remoteAddr: 0x" << std::hex << remoteAddr;
-    for (int i = 0; i < nKeys; i++) {
-      ss << ", rkeys[" << i << "]: " << std::dec << rkeys[i];
-    }
-    return ss.str();
-  }
-};
-
 /**
  * Packet structure of control message transferred by underlying backend.
  */
@@ -102,7 +82,7 @@ struct ControlMsg {
   union {
     struct ctran::regcache::IpcDesc ipcDesc;
     struct ctran::regcache::IpcRelease ipcRls;
-    struct CmsgIbExportMem ibExp;
+    struct ctran::regcache::IBDesc ibDesc;
   };
 
   AuxData_t<DefaultAuxType> aux; // Used to store the remote aux data
@@ -124,7 +104,7 @@ struct ControlMsg {
         ipcRls = ctran::regcache::IpcRelease{};
         break;
       case ControlMsgType::IB_EXPORT_MEM:
-        ibExp = CmsgIbExportMem{};
+        ibDesc = ctran::regcache::IBDesc{};
         break;
       default:
         break;
@@ -141,7 +121,7 @@ struct ControlMsg {
         ss << ipcRls.toString();
         break;
       case ControlMsgType::IB_EXPORT_MEM:
-        ss << ibExp.toString();
+        ss << ibDesc.toString();
         break;
       case ControlMsgType::SYNC:
         ss << "SYNC";

--- a/comms/ctran/backends/ib/CtranIb.h
+++ b/comms/ctran/backends/ib/CtranIb.h
@@ -734,9 +734,9 @@ class CtranIb {
   static inline commResult_t
   exportMemImpl(const void* buf, void* ibRegElem, ControlMsg& msg) {
     msg.setType(ControlMsgType::IB_EXPORT_MEM);
-    msg.ibExp.remoteAddr = reinterpret_cast<uint64_t>(buf);
-    msg.ibExp.nKeys = NCCL_CTRAN_IB_DEVICES_PER_RANK;
-    ctran::ib::getRemoteKeysImpl(ibRegElem, msg.ibExp.rkeys);
+    msg.ibDesc.remoteAddr = reinterpret_cast<uint64_t>(buf);
+    msg.ibDesc.nKeys = NCCL_CTRAN_IB_DEVICES_PER_RANK;
+    ctran::ib::getRemoteKeysImpl(ibRegElem, msg.ibDesc.rkeys);
 
     return commSuccess;
   }
@@ -745,11 +745,11 @@ class CtranIb {
       void** buf,
       CtranIbRemoteAccessKey* key,
       const ControlMsg& msg) {
-    (*buf) = reinterpret_cast<void*>(msg.ibExp.remoteAddr);
+    (*buf) = reinterpret_cast<void*>(msg.ibDesc.remoteAddr);
     for (int device = 0; device < NCCL_CTRAN_IB_DEVICES_PER_RANK; device++) {
-      key->rkeys[device] = msg.ibExp.rkeys[device];
+      key->rkeys[device] = msg.ibDesc.rkeys[device];
     }
-    key->nKeys = msg.ibExp.nKeys;
+    key->nKeys = msg.ibDesc.nKeys;
     return commSuccess;
   }
 

--- a/comms/ctran/backends/ib/tests/CtranIbCtrlMsgDistUT.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbCtrlMsgDistUT.cc
@@ -77,10 +77,10 @@ TEST_F(CtranIbCtrlMsgTest, CtrlMsg) {
       reqs.resize(3, CtranIbRequest());
       smsgs.resize(3, ControlMsg(ControlMsgType::IB_EXPORT_MEM));
       // send two msgs to rank 1
-      smsgs[0].ibExp.remoteAddr = 99;
-      smsgs[0].ibExp.rkeys[0] = recvRank0;
-      smsgs[0].ibExp.rkeys[1] = recvRank0;
-      smsgs[0].ibExp.nKeys = 2;
+      smsgs[0].ibDesc.remoteAddr = 99;
+      smsgs[0].ibDesc.rkeys[0] = recvRank0;
+      smsgs[0].ibDesc.rkeys[1] = recvRank0;
+      smsgs[0].ibDesc.nKeys = 2;
       COMMCHECK_TEST(ctranIb->isendCtrlMsg(
           smsgs[0].type, &smsgs[0], sizeof(smsgs[0]), recvRank0, reqs[0]));
 
@@ -89,19 +89,19 @@ TEST_F(CtranIbCtrlMsgTest, CtrlMsg) {
       // arrived in order
       sleep(2);
 
-      smsgs[1].ibExp.remoteAddr = 100;
-      smsgs[1].ibExp.rkeys[0] = recvRank0;
-      smsgs[1].ibExp.rkeys[1] = recvRank0;
-      smsgs[1].ibExp.nKeys = 2;
+      smsgs[1].ibDesc.remoteAddr = 100;
+      smsgs[1].ibDesc.rkeys[0] = recvRank0;
+      smsgs[1].ibDesc.rkeys[1] = recvRank0;
+      smsgs[1].ibDesc.nKeys = 2;
 
       COMMCHECK_TEST(ctranIb->isendCtrlMsg(
           smsgs[1].type, &smsgs[1], sizeof(smsgs[1]), recvRank0, reqs[1]));
 
       // send one msg to rank 2
-      smsgs[2].ibExp.remoteAddr = 101;
-      smsgs[2].ibExp.rkeys[0] = recvRank1;
-      smsgs[2].ibExp.rkeys[1] = recvRank1;
-      smsgs[2].ibExp.nKeys = 2;
+      smsgs[2].ibDesc.remoteAddr = 101;
+      smsgs[2].ibDesc.rkeys[0] = recvRank1;
+      smsgs[2].ibDesc.rkeys[1] = recvRank1;
+      smsgs[2].ibDesc.nKeys = 2;
       COMMCHECK_TEST(ctranIb->isendCtrlMsg(
           smsgs[2].type, &smsgs[2], sizeof(smsgs[2]), recvRank1, reqs[2]));
     } else if (this->globalRank == recvRank0) {
@@ -126,19 +126,19 @@ TEST_F(CtranIbCtrlMsgTest, CtrlMsg) {
     }
 
     if (this->globalRank == recvRank0) {
-      EXPECT_EQ(rmsg0.ibExp.rkeys[0], recvRank0);
-      EXPECT_EQ(rmsg0.ibExp.rkeys[1], recvRank0);
-      EXPECT_EQ(rmsg0.ibExp.nKeys, 2);
-      EXPECT_EQ(rmsg0.ibExp.remoteAddr, 99);
-      EXPECT_EQ(rmsg1.ibExp.rkeys[0], recvRank0);
-      EXPECT_EQ(rmsg1.ibExp.rkeys[1], recvRank0);
-      EXPECT_EQ(rmsg1.ibExp.nKeys, 2);
-      EXPECT_EQ(rmsg1.ibExp.remoteAddr, 100);
+      EXPECT_EQ(rmsg0.ibDesc.rkeys[0], recvRank0);
+      EXPECT_EQ(rmsg0.ibDesc.rkeys[1], recvRank0);
+      EXPECT_EQ(rmsg0.ibDesc.nKeys, 2);
+      EXPECT_EQ(rmsg0.ibDesc.remoteAddr, 99);
+      EXPECT_EQ(rmsg1.ibDesc.rkeys[0], recvRank0);
+      EXPECT_EQ(rmsg1.ibDesc.rkeys[1], recvRank0);
+      EXPECT_EQ(rmsg1.ibDesc.nKeys, 2);
+      EXPECT_EQ(rmsg1.ibDesc.remoteAddr, 100);
     } else if (this->globalRank == recvRank1) {
-      EXPECT_EQ(rmsg0.ibExp.rkeys[0], recvRank1);
-      EXPECT_EQ(rmsg0.ibExp.rkeys[1], recvRank1);
-      EXPECT_EQ(rmsg0.ibExp.nKeys, 2);
-      EXPECT_EQ(rmsg0.ibExp.remoteAddr, 101);
+      EXPECT_EQ(rmsg0.ibDesc.rkeys[0], recvRank1);
+      EXPECT_EQ(rmsg0.ibDesc.rkeys[1], recvRank1);
+      EXPECT_EQ(rmsg0.ibDesc.nKeys, 2);
+      EXPECT_EQ(rmsg0.ibDesc.remoteAddr, 101);
     }
   } catch (const std::bad_alloc& _) {
     GTEST_SKIP() << "IB backend not enabled. Skip test";

--- a/comms/ctran/backends/ib/tests/CtranIbDistUT.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbDistUT.cc
@@ -176,10 +176,10 @@ class CtranIbTest : public ctran::CtranDistTestFixture {
     // Sender puts the data to rank 1 using remote addr and rkey received in
     // previous irecvCtrlMsg
     if (this->globalRank == sendRank) {
-      void* remoteBuf = reinterpret_cast<void*>(msg.ibExp.remoteAddr);
+      void* remoteBuf = reinterpret_cast<void*>(msg.ibDesc.remoteAddr);
       CtranIbRemoteAccessKey key{};
-      for (int i = 0; i < msg.ibExp.nKeys; i++) {
-        key.rkeys[i] = msg.ibExp.rkeys[i];
+      for (int i = 0; i < msg.ibDesc.nKeys; i++) {
+        key.rkeys[i] = msg.ibDesc.rkeys[i];
       }
 
       for (int i = 0; i < numPuts; i++) {
@@ -357,10 +357,10 @@ class CtranIbTest : public ctran::CtranDistTestFixture {
     // Receiver gets the data to rank 1 using remote addr and rkey received in
     // previous irecvCtrlMsg
     if (this->globalRank == dstRank) {
-      void* remoteBuf = reinterpret_cast<void*>(msg.ibExp.remoteAddr);
+      void* remoteBuf = reinterpret_cast<void*>(msg.ibDesc.remoteAddr);
       CtranIbRemoteAccessKey key{};
-      for (int i = 0; i < msg.ibExp.nKeys; i++) {
-        key.rkeys[i] = msg.ibExp.rkeys[i];
+      for (int i = 0; i < msg.ibDesc.nKeys; i++) {
+        key.rkeys[i] = msg.ibDesc.rkeys[i];
       }
 
       for (int i = 0; i < numGets; i++) {
@@ -564,10 +564,10 @@ class CtranIbTest : public ctran::CtranDistTestFixture {
     // puts
     std::vector<std::unique_ptr<CtranIbRequest>> requests;
     if (this->globalRank == sendRank) {
-      void* remoteBuf = reinterpret_cast<void*>(msg.ibExp.remoteAddr);
+      void* remoteBuf = reinterpret_cast<void*>(msg.ibDesc.remoteAddr);
       CtranIbRemoteAccessKey key{};
-      for (int i = 0; i < msg.ibExp.nKeys; i++) {
-        key.rkeys[i] = msg.ibExp.rkeys[i];
+      for (int i = 0; i < msg.ibDesc.nKeys; i++) {
+        key.rkeys[i] = msg.ibDesc.rkeys[i];
       }
 
       CtranIbRequest fallbackPutReq;
@@ -802,10 +802,10 @@ class CtranIbTest : public ctran::CtranDistTestFixture {
       // Atomic FAdd testing
       int finalSum = numOps * (numRanks - 1);
       if (this->globalRank != dstRank) {
-        void* remoteBuf = reinterpret_cast<void*>(msg.ibExp.remoteAddr);
+        void* remoteBuf = reinterpret_cast<void*>(msg.ibDesc.remoteAddr);
         CtranIbRemoteAccessKey key{};
-        for (int i = 0; i < msg.ibExp.nKeys; i++) {
-          key.rkeys[i] = msg.ibExp.rkeys[i];
+        for (int i = 0; i < msg.ibDesc.nKeys; i++) {
+          key.rkeys[i] = msg.ibDesc.rkeys[i];
         }
         for (int i = 0; i < numOps; i++) {
           atomicReq = CtranIbRequest();
@@ -851,10 +851,10 @@ class CtranIbTest : public ctran::CtranDistTestFixture {
       }
     } else {
       // Atomic Set testing
-      void* remoteBuf = reinterpret_cast<void*>(msg.ibExp.remoteAddr);
+      void* remoteBuf = reinterpret_cast<void*>(msg.ibDesc.remoteAddr);
       CtranIbRemoteAccessKey key{};
-      for (int i = 0; i < msg.ibExp.nKeys; i++) {
-        key.rkeys[i] = msg.ibExp.rkeys[i];
+      for (int i = 0; i < msg.ibDesc.nKeys; i++) {
+        key.rkeys[i] = msg.ibDesc.rkeys[i];
       }
       for (int i = 0; i < numOps; i++) {
         // In every iteration, all senders atomic-set the same address in the
@@ -1011,9 +1011,9 @@ TEST_F(CtranIbTest, InitializeWithoutComm) {
 
   CtranIbEpochRAII epochRAII(ctranIb.get());
 
-  smsg.ibExp.remoteAddr = 99;
-  smsg.ibExp.rkeys[0] = 1;
-  smsg.ibExp.nKeys = 1;
+  smsg.ibDesc.remoteAddr = 99;
+  smsg.ibDesc.rkeys[0] = 1;
+  smsg.ibDesc.nKeys = 1;
   SocketServerAddr remoteAddr;
   if (this->globalRank == 0) {
     remoteAddr.port = qpServerAddrs[1].port;
@@ -1035,8 +1035,8 @@ TEST_F(CtranIbTest, InitializeWithoutComm) {
   waitIbReq(req, ctranIb);
 
   if (this->globalRank == 1) {
-    EXPECT_EQ(rmsg.ibExp.rkeys[0], smsg.ibExp.rkeys[0]);
-    EXPECT_EQ(rmsg.ibExp.remoteAddr, smsg.ibExp.remoteAddr);
+    EXPECT_EQ(rmsg.ibDesc.rkeys[0], smsg.ibDesc.rkeys[0]);
+    EXPECT_EQ(rmsg.ibDesc.remoteAddr, smsg.ibDesc.remoteAddr);
   }
 }
 
@@ -1131,9 +1131,9 @@ TEST_F(CtranIbTest, ExportMem) {
 
     COMMCHECK_TEST(CtranIb::exportMem(buf, handle, msg));
     EXPECT_EQ(msg.type, ControlMsgType::IB_EXPORT_MEM);
-    EXPECT_EQ(msg.ibExp.remoteAddr, reinterpret_cast<uint64_t>(buf));
+    EXPECT_EQ(msg.ibDesc.remoteAddr, reinterpret_cast<uint64_t>(buf));
     auto mrs = reinterpret_cast<std::vector<ibverbx::ibv_mr*>*>(handle);
-    EXPECT_EQ(msg.ibExp.rkeys[0], (*mrs).at(0)->rkey);
+    EXPECT_EQ(msg.ibDesc.rkeys[0], (*mrs).at(0)->rkey);
 
     auto ibRemoteAccesskeys = CtranIb::getRemoteAccessKey(handle);
     EXPECT_EQ(ibRemoteAccesskeys.nKeys, NCCL_CTRAN_IB_DEVICES_PER_RANK);
@@ -1193,13 +1193,13 @@ TEST_F(CtranIbTest, MatchAnyCtrlMsg) {
       auto& rmsg = rmsgs[i];
       auto& req = reqs[i];
       smsg.setType(ControlMsgType::IB_EXPORT_MEM);
-      smsg.ibExp.remoteAddr = 99;
-      smsg.ibExp.rkeys[0] = i + 1;
-      smsg.ibExp.nKeys = 1;
+      smsg.ibDesc.remoteAddr = 99;
+      smsg.ibDesc.rkeys[0] = i + 1;
+      smsg.ibDesc.nKeys = 1;
       rmsg.setType(ControlMsgType::UNSPECIFIED);
-      rmsg.ibExp.remoteAddr = 0;
-      rmsg.ibExp.rkeys[0] = 0;
-      rmsg.ibExp.nKeys = 1;
+      rmsg.ibDesc.remoteAddr = 0;
+      rmsg.ibDesc.rkeys[0] = 0;
+      rmsg.ibDesc.nKeys = 1;
 
       if (this->globalRank == 0) {
         COMMCHECK_TEST(
@@ -1218,9 +1218,9 @@ TEST_F(CtranIbTest, MatchAnyCtrlMsg) {
       if (this->globalRank == 1) {
         auto& rmsg = rmsgs[i];
         EXPECT_EQ(rmsg.type, ControlMsgType::IB_EXPORT_MEM);
-        EXPECT_EQ(rmsg.ibExp.rkeys[0], i + 1);
-        EXPECT_EQ(rmsg.ibExp.remoteAddr, 99);
-        EXPECT_EQ(rmsg.ibExp.nKeys, 1);
+        EXPECT_EQ(rmsg.ibDesc.rkeys[0], i + 1);
+        EXPECT_EQ(rmsg.ibDesc.remoteAddr, 99);
+        EXPECT_EQ(rmsg.ibDesc.nKeys, 1);
       }
     }
   } catch (const std::bad_alloc&) {
@@ -1239,8 +1239,8 @@ commResult_t testCtrlMsgCb(int peer, void* msgPtr, void* ctx) {
 
   auto msg = reinterpret_cast<ControlMsg*>(msgPtr);
   EXPECT_EQ(msg->type, ControlMsgType::IB_EXPORT_MEM);
-  EXPECT_EQ(msg->ibExp.rkeys[0], testRkey);
-  EXPECT_EQ(msg->ibExp.remoteAddr, testRemoteAddr);
+  EXPECT_EQ(msg->ibDesc.rkeys[0], testRkey);
+  EXPECT_EQ(msg->ibDesc.remoteAddr, testRemoteAddr);
   return commSuccess;
 }
 } // namespace
@@ -1261,9 +1261,9 @@ TEST_F(CtranIbTest, CbCtrlMsg) {
 
     CtranIbEpochRAII epochRAII(ctranIb.get());
 
-    smsg.ibExp.remoteAddr = testRemoteAddr;
-    smsg.ibExp.rkeys[0] = testRkey;
-    smsg.ibExp.nKeys = 1;
+    smsg.ibDesc.remoteAddr = testRemoteAddr;
+    smsg.ibDesc.rkeys[0] = testRkey;
+    smsg.ibDesc.nKeys = 1;
     if (this->globalRank == 0) {
       COMMCHECK_TEST(
           ctranIb->isendCtrlMsg(smsg.type, &smsg, sizeof(smsg), 1, req));
@@ -1663,10 +1663,10 @@ TEST_F(CtranIbTest, MultiPutTrafficProfiler) {
           }
 
           void* remoteBuf =
-              reinterpret_cast<void*>(recvMsgs[i].ibExp.remoteAddr);
+              reinterpret_cast<void*>(recvMsgs[i].ibDesc.remoteAddr);
           CtranIbRemoteAccessKey remoteKey{};
-          for (int j = 0; j < recvMsgs[i].ibExp.nKeys; j++) {
-            remoteKey.rkeys[j] = recvMsgs[i].ibExp.rkeys[j];
+          for (int j = 0; j < recvMsgs[i].ibDesc.nKeys; j++) {
+            remoteKey.rkeys[j] = recvMsgs[i].ibDesc.rkeys[j];
           }
 
           putReqs[i] = CtranIbRequest();
@@ -1819,7 +1819,7 @@ TEST_F(CtranIbTest, InvalidMemoryWaitNotify) {
 
     // Use invalid rkey (corrupted)
     CtranIbRemoteAccessKey invalidKey{};
-    for (int i = 0; i < msg.ibExp.nKeys; i++) {
+    for (int i = 0; i < msg.ibDesc.nKeys; i++) {
       invalidKey.rkeys[i] = 0xbadbeef; // Invalid rkey
     }
 
@@ -2209,9 +2209,9 @@ TEST_F(CtranIbTest, CtrlMsgAndPreConnect) {
 
     CtranIbEpochRAII epochRAII(ctranIb.get());
 
-    smsg.ibExp.remoteAddr = 99;
-    smsg.ibExp.rkeys[0] = 1;
-    smsg.ibExp.nKeys = 1;
+    smsg.ibDesc.remoteAddr = 99;
+    smsg.ibDesc.rkeys[0] = 1;
+    smsg.ibDesc.nKeys = 1;
     if (this->globalRank == sendRank) {
       COMMCHECK_TEST(
           ctranIb->isendCtrlMsg(smsg.type, &smsg, sizeof(smsg), recvRank, req));
@@ -2225,9 +2225,9 @@ TEST_F(CtranIbTest, CtrlMsgAndPreConnect) {
     waitIbReq(req, ctranIb);
 
     if (this->globalRank == recvRank) {
-      EXPECT_EQ(rmsg.ibExp.remoteAddr, smsg.ibExp.remoteAddr);
-      EXPECT_EQ(rmsg.ibExp.nKeys, smsg.ibExp.nKeys);
-      EXPECT_EQ(rmsg.ibExp.rkeys[0], smsg.ibExp.rkeys[0]);
+      EXPECT_EQ(rmsg.ibDesc.remoteAddr, smsg.ibDesc.remoteAddr);
+      EXPECT_EQ(rmsg.ibDesc.nKeys, smsg.ibDesc.nKeys);
+      EXPECT_EQ(rmsg.ibDesc.rkeys[0], smsg.ibDesc.rkeys[0]);
     }
 
     // pre-connect the peer
@@ -2318,10 +2318,10 @@ TEST_P(CtranIbTestParam, InvalidIputFastNotify) {
   waitIbReq(ctrlReq, ctranIb);
 
   if (this->globalRank == sendRank) {
-    void* remoteBuf = reinterpret_cast<void*>(msg.ibExp.remoteAddr);
+    void* remoteBuf = reinterpret_cast<void*>(msg.ibDesc.remoteAddr);
     CtranIbRemoteAccessKey key{};
-    for (int i = 0; i < msg.ibExp.nKeys; i++) {
-      key.rkeys[i] = msg.ibExp.rkeys[i];
+    for (int i = 0; i < msg.ibDesc.nKeys; i++) {
+      key.rkeys[i] = msg.ibDesc.rkeys[i];
     }
 
     // Failure case 1: the bufsize is larger than maxWqeSize
@@ -2485,10 +2485,10 @@ TEST_P(CtranIbTestParam, GpuMemPutNoSignalMixedFastRegular) {
 
   const int numFastPuts = NCCL_CTRAN_IB_QP_MAX_MSGS, numPuts = 1000;
   if (this->globalRank == sendRank) {
-    void* remoteBuf = reinterpret_cast<void*>(msg.ibExp.remoteAddr);
+    void* remoteBuf = reinterpret_cast<void*>(msg.ibDesc.remoteAddr);
     CtranIbRemoteAccessKey key{};
-    for (int i = 0; i < msg.ibExp.nKeys; i++) {
-      key.rkeys[i] = msg.ibExp.rkeys[i];
+    for (int i = 0; i < msg.ibDesc.nKeys; i++) {
+      key.rkeys[i] = msg.ibDesc.rkeys[i];
     }
 
     for (int i = 0; i < numFastPuts; i++) {
@@ -2586,10 +2586,10 @@ TEST_P(CtranIbTestParam, GpuMemPutNotifyLastMixedFastRegular) {
 
   const int numFastPuts = NCCL_CTRAN_IB_QP_MAX_MSGS, numPuts = 1000;
   if (this->globalRank == sendRank) {
-    void* remoteBuf = reinterpret_cast<void*>(msg.ibExp.remoteAddr);
+    void* remoteBuf = reinterpret_cast<void*>(msg.ibDesc.remoteAddr);
     CtranIbRemoteAccessKey key{};
-    for (int i = 0; i < msg.ibExp.nKeys; i++) {
-      key.rkeys[i] = msg.ibExp.rkeys[i];
+    for (int i = 0; i < msg.ibDesc.nKeys; i++) {
+      key.rkeys[i] = msg.ibDesc.rkeys[i];
     }
 
     for (int i = 0; i < numFastPuts; i++) {

--- a/comms/ctran/backends/socket/tests/CtranSocketDistUT.cc
+++ b/comms/ctran/backends/socket/tests/CtranSocketDistUT.cc
@@ -103,9 +103,9 @@ TEST_F(CtranSocketTest, InitializeWithoutComm) {
   ControlMsg rmsg(ControlMsgType::IB_EXPORT_MEM);
   CtranSocketRequest req;
 
-  smsg.ibExp.remoteAddr = 99;
-  smsg.ibExp.rkeys[0] = 1;
-  smsg.ibExp.nKeys = 1;
+  smsg.ibDesc.remoteAddr = 99;
+  smsg.ibDesc.rkeys[0] = 1;
+  smsg.ibDesc.nKeys = 1;
   SocketServerAddr remoteAddr;
   if (globalRank == 0) {
     remoteAddr.port = serverAddrs[1].port;
@@ -122,8 +122,8 @@ TEST_F(CtranSocketTest, InitializeWithoutComm) {
   waitSocketReq(req, ctranSock);
 
   if (globalRank == 1) {
-    EXPECT_EQ(rmsg.ibExp.rkeys[0], smsg.ibExp.rkeys[0]);
-    EXPECT_EQ(rmsg.ibExp.remoteAddr, smsg.ibExp.remoteAddr);
+    EXPECT_EQ(rmsg.ibDesc.rkeys[0], smsg.ibDesc.rkeys[0]);
+    EXPECT_EQ(rmsg.ibDesc.remoteAddr, smsg.ibDesc.remoteAddr);
   }
 }
 
@@ -137,8 +137,8 @@ commResult_t testCtrlMsgCb(int peer, void* msgPtr, void* ctx) {
   EXPECT_EQ(peer, 0);
   auto msg = reinterpret_cast<ControlMsg*>(msgPtr);
   EXPECT_EQ(msg->type, ControlMsgType::IB_EXPORT_MEM);
-  EXPECT_EQ(msg->ibExp.rkeys[0], testRkey);
-  EXPECT_EQ(msg->ibExp.remoteAddr, testRemoteAddr);
+  EXPECT_EQ(msg->ibDesc.rkeys[0], testRkey);
+  EXPECT_EQ(msg->ibDesc.remoteAddr, testRemoteAddr);
   return commSuccess;
 }
 } // namespace
@@ -157,9 +157,9 @@ TEST_F(CtranSocketTest, CbCtrlMsg) {
   CtranSocketRequest req;
   ControlMsg smsg(ControlMsgType::IB_EXPORT_MEM);
 
-  smsg.ibExp.remoteAddr = testRemoteAddr;
-  smsg.ibExp.rkeys[0] = testRkey;
-  smsg.ibExp.nKeys = 1;
+  smsg.ibDesc.remoteAddr = testRemoteAddr;
+  smsg.ibDesc.rkeys[0] = testRkey;
+  smsg.ibDesc.nKeys = 1;
   if (this->globalRank == 0) {
     COMMCHECK_TEST(ctranSock->isendCtrlMsg(smsg, 1, req));
 
@@ -199,9 +199,9 @@ TEST_F(CtranSocketTest, CtrlMsg) {
     reqs.resize(3, CtranSocketRequest());
     smsgs.resize(3, ControlMsg(ControlMsgType::IB_EXPORT_MEM));
     // send two msgs to rank 1
-    smsgs[0].ibExp.remoteAddr = 99;
-    smsgs[0].ibExp.rkeys[0] = recvRank0;
-    smsgs[0].ibExp.nKeys = 1;
+    smsgs[0].ibDesc.remoteAddr = 99;
+    smsgs[0].ibDesc.rkeys[0] = recvRank0;
+    smsgs[0].ibDesc.nKeys = 1;
     COMMCHECK_TEST(ctranSock->isendCtrlMsg(smsgs[0], recvRank0, reqs[0]));
 
     // let recvRank0 connected via ListenThread first; thus the next
@@ -209,16 +209,16 @@ TEST_F(CtranSocketTest, CtrlMsg) {
     // in order
     sleep(2);
 
-    smsgs[1].ibExp.remoteAddr = 100;
-    smsgs[1].ibExp.rkeys[0] = recvRank0;
-    smsgs[1].ibExp.nKeys = 1;
+    smsgs[1].ibDesc.remoteAddr = 100;
+    smsgs[1].ibDesc.rkeys[0] = recvRank0;
+    smsgs[1].ibDesc.nKeys = 1;
 
     COMMCHECK_TEST(ctranSock->isendCtrlMsg(smsgs[1], recvRank0, reqs[1]));
 
     // send one msg to rank 2
-    smsgs[2].ibExp.remoteAddr = 101;
-    smsgs[2].ibExp.rkeys[0] = recvRank1;
-    smsgs[2].ibExp.nKeys = 1;
+    smsgs[2].ibDesc.remoteAddr = 101;
+    smsgs[2].ibDesc.rkeys[0] = recvRank1;
+    smsgs[2].ibDesc.nKeys = 1;
     COMMCHECK_TEST(ctranSock->isendCtrlMsg(smsgs[2], recvRank1, reqs[2]));
   } else if (globalRank == recvRank0) {
     reqs.resize(2, CtranSocketRequest());
@@ -238,13 +238,13 @@ TEST_F(CtranSocketTest, CtrlMsg) {
   }
 
   if (globalRank == recvRank0) {
-    EXPECT_EQ(rmsg0.ibExp.rkeys[0], recvRank0);
-    EXPECT_EQ(rmsg0.ibExp.remoteAddr, 99);
-    EXPECT_EQ(rmsg1.ibExp.rkeys[0], recvRank0);
-    EXPECT_EQ(rmsg1.ibExp.remoteAddr, 100);
+    EXPECT_EQ(rmsg0.ibDesc.rkeys[0], recvRank0);
+    EXPECT_EQ(rmsg0.ibDesc.remoteAddr, 99);
+    EXPECT_EQ(rmsg1.ibDesc.rkeys[0], recvRank0);
+    EXPECT_EQ(rmsg1.ibDesc.remoteAddr, 100);
   } else if (globalRank == recvRank1) {
-    EXPECT_EQ(rmsg0.ibExp.rkeys[0], recvRank1);
-    EXPECT_EQ(rmsg0.ibExp.remoteAddr, 101);
+    EXPECT_EQ(rmsg0.ibDesc.rkeys[0], recvRank1);
+    EXPECT_EQ(rmsg0.ibDesc.remoteAddr, 101);
   }
 }
 
@@ -265,17 +265,17 @@ TEST_F(CtranSocketTest, AllGather) {
     auto& rreq = rreqs[i];
     auto& rmsg = rmsgs[i];
     rmsg.setType(ControlMsgType::IB_EXPORT_MEM);
-    rmsg.ibExp.remoteAddr = 0;
-    rmsg.ibExp.rkeys[0] = 0;
-    rmsg.ibExp.nKeys = 1;
+    rmsg.ibDesc.remoteAddr = 0;
+    rmsg.ibDesc.rkeys[0] = 0;
+    rmsg.ibDesc.nKeys = 1;
     COMMCHECK_TEST(ctranSock->irecvCtrlMsg(rmsg, i, rreq));
     // post send request
     auto& sreq = sreqs[i];
     auto& smsg = smsgs[i];
     smsg.setType(ControlMsgType::IB_EXPORT_MEM);
-    smsg.ibExp.remoteAddr = 99;
-    smsg.ibExp.rkeys[0] = globalRank;
-    smsg.ibExp.nKeys = 1;
+    smsg.ibDesc.remoteAddr = 99;
+    smsg.ibDesc.rkeys[0] = globalRank;
+    smsg.ibDesc.nKeys = 1;
     COMMCHECK_TEST(ctranSock->isendCtrlMsg(smsg, i, sreq));
   }
   for (int i = 0; i < numRanks; i++) {
@@ -292,8 +292,8 @@ TEST_F(CtranSocketTest, AllGather) {
       continue;
     }
     auto& rmsg = rmsgs[i];
-    EXPECT_EQ(rmsg.ibExp.rkeys[0], i);
-    EXPECT_EQ(rmsg.ibExp.remoteAddr, 99);
+    EXPECT_EQ(rmsg.ibDesc.rkeys[0], i);
+    EXPECT_EQ(rmsg.ibDesc.remoteAddr, 99);
   }
 }
 TEST_F(CtranSocketTest, MatchAnyCtrlMsg) {
@@ -312,13 +312,13 @@ TEST_F(CtranSocketTest, MatchAnyCtrlMsg) {
     auto& rmsg = rmsgs[i];
     auto& req = reqs[i];
     smsg.setType(ControlMsgType::IB_EXPORT_MEM);
-    smsg.ibExp.remoteAddr = 99;
-    smsg.ibExp.rkeys[0] = i + 1;
-    smsg.ibExp.nKeys = 1;
+    smsg.ibDesc.remoteAddr = 99;
+    smsg.ibDesc.rkeys[0] = i + 1;
+    smsg.ibDesc.nKeys = 1;
     rmsg.setType(ControlMsgType::UNSPECIFIED);
-    rmsg.ibExp.remoteAddr = 0;
-    rmsg.ibExp.rkeys[0] = 0;
-    rmsg.ibExp.nKeys = 1;
+    rmsg.ibDesc.remoteAddr = 0;
+    rmsg.ibDesc.rkeys[0] = 0;
+    rmsg.ibDesc.nKeys = 1;
 
     if (globalRank == 0) {
       COMMCHECK_TEST(ctranSock->isendCtrlMsg(smsg, 1, req));
@@ -335,8 +335,8 @@ TEST_F(CtranSocketTest, MatchAnyCtrlMsg) {
     if (globalRank == 1) {
       auto& rmsg = rmsgs[i];
       EXPECT_EQ(rmsg.type, ControlMsgType::IB_EXPORT_MEM);
-      EXPECT_EQ(rmsg.ibExp.rkeys[0], i + 1);
-      EXPECT_EQ(rmsg.ibExp.remoteAddr, 99);
+      EXPECT_EQ(rmsg.ibDesc.rkeys[0], i + 1);
+      EXPECT_EQ(rmsg.ibDesc.remoteAddr, 99);
     }
   }
 }
@@ -363,9 +363,9 @@ TEST_F(CtranSocketTest, CtrlMsgAndPreConnect) {
     COMMCHECK_TEST(ctranSock->preConnect(peerRanks));
   }
 
-  smsg.ibExp.remoteAddr = 99;
-  smsg.ibExp.rkeys[0] = 1;
-  smsg.ibExp.nKeys = 1;
+  smsg.ibDesc.remoteAddr = 99;
+  smsg.ibDesc.rkeys[0] = 1;
+  smsg.ibDesc.nKeys = 1;
   if (globalRank == sendRank) {
     COMMCHECK_TEST(ctranSock->isendCtrlMsg(smsg, recvRank, req));
   } else if (globalRank == recvRank) {
@@ -377,8 +377,8 @@ TEST_F(CtranSocketTest, CtrlMsgAndPreConnect) {
   waitSocketReq(req, ctranSock);
 
   if (globalRank == recvRank) {
-    EXPECT_EQ(rmsg.ibExp.rkeys[0], smsg.ibExp.rkeys[0]);
-    EXPECT_EQ(rmsg.ibExp.remoteAddr, smsg.ibExp.remoteAddr);
+    EXPECT_EQ(rmsg.ibDesc.rkeys[0], smsg.ibDesc.rkeys[0]);
+    EXPECT_EQ(rmsg.ibDesc.remoteAddr, smsg.ibDesc.remoteAddr);
   }
 }
 

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -1359,7 +1359,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       req.sendCtrl.msg = sendCtrlMsg;
       auto& msg = req.sendCtrl.msg;
       req.peer = peer;
-      msg.ibExp.remoteAddr = reinterpret_cast<uint64_t>(bufs[peer]);
+      msg.ibDesc.remoteAddr = reinterpret_cast<uint64_t>(bufs[peer]);
       msg.aux = reqs[idx - 1].aux;
       CLOGF_TRACE(
           COLL,

--- a/comms/ctran/regcache/IpcRegCacheBase.h
+++ b/comms/ctran/regcache/IpcRegCacheBase.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <fmt/core.h>
+#include <array>
 #include <cstring>
 #include <string>
 
@@ -9,8 +10,27 @@
 #include "comms/ctran/utils/CtranIpc.h"
 #include "comms/utils/commSpecs.h"
 
+// FIXME(alvinyc): move this IB constant to CtranIbBase.h once CtranIb doesn't
+// depend on CtranCtrl and CtranCtrl is removed
+constexpr int CTRAN_MAX_IB_DEVICES_PER_RANK{2};
+
 namespace ctran {
 namespace regcache {
+
+struct IBDesc {
+  uint64_t remoteAddr{0};
+  std::array<uint32_t, CTRAN_MAX_IB_DEVICES_PER_RANK> rkeys{};
+  int nKeys{0};
+
+  std::string toString() const {
+    std::string s =
+        fmt::format("[IB_EXPORT_MEM] remoteAddr: 0x{:x}", remoteAddr);
+    for (int i = 0; i < nKeys; i++) {
+      s += fmt::format(", rkeys[{}]: {}", i, rkeys[i]);
+    }
+    return s;
+  }
+};
 
 struct IpcDesc {
   ctran::utils::CtranIpcDesc desc;


### PR DESCRIPTION
Summary:
What: Moves CmsgIbExportMem into the ctran::regcache namespace as IbDesc, consolidating IB memory descriptor types alongside other regcache IPC descriptors.

  Changes:

  - regcache/IpcRegCacheBase.h — Added CTRAN_MAX_IB_DEVICES_PER_RANK constant and new ctran::regcache::IbDesc struct (replacement for CmsgIbExportMem). Uses fmt::format instead of std::stringstream for toString(), and removes the static name member.
  - backends/CtranCtrl.h — Removed the CTRAN_MAX_IB_DEVICES_PER_RANK constant and the CmsgIbExportMem struct definition. Updated the ControlMsg union member from ibExp (type CmsgIbExportMem) to ibDesc (type ctran::regcache::IbDesc).
  - backends/CtranCtrl.cc — Removed the CmsgIbExportMem::name static string definition.
  - backends/ib/CtranIb.h, CtranExRequest.cc, mapper/CtranMapper.h — Updated all references from msg.ibExp to msg.ibDesc.
  - Test files (CtranIbDistUT.cc, CtranIbCtrlMsgDistUT.cc, CtranSocketDistUT.cc) — Mechanical rename of all ibExp → ibDesc field accesses.

Reviewed By: mingrany

Differential Revision: D93164495
