### PR TITLE
Pass graphUsageMode parameter to ncclCudaGraphNone()

### DIFF
--- a/comms/ncclx/v2_29/meta/colltrace/CollTraceEvent.cc
+++ b/comms/ncclx/v2_29/meta/colltrace/CollTraceEvent.cc
@@ -14,7 +14,8 @@ namespace {
 ncclResult_t waitGraphCaptureComplete(cudaStream_t stream) {
   struct ncclCudaGraph graph;
   do {
-    auto res = ncclCudaGetCapturingGraph(&graph, stream);
+    // FIXME[max7255]: should pass the graphmode variable here
+    auto res = ncclCudaGetCapturingGraph(&graph, stream, 0);
     if (res != ncclSuccess) {
       WARN_FIRST_N(
           1, "Internal error: ncclCudaGetCapturingGraph failed by %d", res);

--- a/comms/ncclx/v2_29/meta/transport/transportConnect.cc
+++ b/comms/ncclx/v2_29/meta/transport/transportConnect.cc
@@ -307,7 +307,7 @@ ncclResult_t devCommSetupChannels(ncclComm_t comm) {
 
   NCCLCHECKGOTO(
       ncclStrongStreamAcquire(
-          ncclCudaGraphNone(),
+          ncclCudaGraphNone(comm->config.graphUsageMode),
           &comm->sharedRes->deviceStream,
           /*concurrent=*/false,
           &deviceStream),
@@ -347,7 +347,7 @@ ncclResult_t devCommSetupChannels(ncclComm_t comm) {
 
 exit:
   NCCLCHECK(ncclStrongStreamRelease(
-      ncclCudaGraphNone(),
+      ncclCudaGraphNone(comm->config.graphUsageMode),
       &comm->sharedRes->deviceStream,
       /*concurrent=*/false));
   NCCLCHECK(ncclStrongStreamSynchronize(&comm->sharedRes->deviceStream));

--- a/comms/ncclx/v2_29/meta/transport/transportExt.cc
+++ b/comms/ncclx/v2_29/meta/transport/transportExt.cc
@@ -272,7 +272,7 @@ ncclResult_t ncclTransportP2pSetupExt(
   if (!comm->channelMetadataOnHost) {
     NCCLCHECKGOTO(
         ncclStrongStreamAcquire(
-            ncclCudaGraphNone(),
+            ncclCudaGraphNone(comm->config.graphUsageMode),
             &comm->sharedRes->hostStream,
             /*concurrent=*/false,
             &hostStream),
@@ -280,7 +280,7 @@ ncclResult_t ncclTransportP2pSetupExt(
         fail);
     NCCLCHECKGOTO(
         ncclStrongStreamAcquire(
-            ncclCudaGraphNone(),
+            ncclCudaGraphNone(comm->config.graphUsageMode),
             &comm->sharedRes->deviceStream,
             /*concurrent=*/false,
             &deviceStream),
@@ -612,11 +612,11 @@ exit:
     NCCLCHECK(ncclStreamWaitStream(
         deviceStream, hostStream, comm->sharedRes->scratchEvent));
     NCCLCHECK(ncclStrongStreamRelease(
-        ncclCudaGraphNone(),
+        ncclCudaGraphNone(comm->config.graphUsageMode),
         &comm->sharedRes->hostStream,
         /*concurrent=*/false));
     NCCLCHECK(ncclStrongStreamRelease(
-        ncclCudaGraphNone(),
+        ncclCudaGraphNone(comm->config.graphUsageMode),
         &comm->sharedRes->deviceStream,
         /*concurrent=*/false));
   }


### PR DESCRIPTION
Summary:
Function ncclCudaGraphNone() in 2.29 now requires additional parameter.

Luckily in all places except meta/colltrace/CollTraceEvent.cc we have suitable variable to pass. For CollTrace we pick 0 as default choice option with FIXME tag.

Reviewed By: zhiyongww

Differential Revision: D94455596


