### PR TITLE
Move ncclx/ctran one-sided API to ncclx:: namespace

### DIFF
--- a/comms/ncclx/v2_27/meta/colltrace/tests/CollTraceDistTest.cc
+++ b/comms/ncclx/v2_27/meta/colltrace/tests/CollTraceDistTest.cc
@@ -1194,15 +1194,16 @@ TEST_F(CollTraceTest, winPutWait) {
   int prevPeer = (this->globalRank + this->numRanks - 1) % this->numRanks;
 
   for (auto iter = 0; iter < kNumIters; iter++) {
-    NCCLCHECK_TEST(ncclPutSignal(
-        localbuf + kNumElements * statex->rank(),
-        kNumElements,
-        ncclInt32,
-        nextPeer,
-        kNumElements * statex->rank(),
-        win,
-        put_stream));
-    NCCLCHECK_TEST(ncclWaitSignal(prevPeer, win, wait_stream));
+    NCCLCHECK_TEST(
+        ncclx::ncclPutSignal(
+            localbuf + kNumElements * statex->rank(),
+            kNumElements,
+            ncclInt32,
+            nextPeer,
+            kNumElements * statex->rank(),
+            win,
+            put_stream));
+    NCCLCHECK_TEST(ncclx::ncclWaitSignal(prevPeer, win, wait_stream));
     if (iter == 0) {
       CUDACHECK_TEST(cudaEventRecord(start_event, put_stream));
     }

--- a/comms/ncclx/v2_27/meta/colltrace/tests/CollTraceWatchdogTest.cc
+++ b/comms/ncclx/v2_27/meta/colltrace/tests/CollTraceWatchdogTest.cc
@@ -230,8 +230,9 @@ TEST_F(CollTraceWatchdogTest, TestAsyncErrorFromGPE) {
   auto dstRank = (rank + 1) % worldSize;
 
   NCCLCHECK_FATAL(
-      ncclPutSignal(sendBuff, 32, ncclFloat, dstRank, 0, win, stream.raw()));
-  NCCLCHECK_FATAL(ncclWaitSignal(srcRank, win, stream.raw()));
+      ncclx::ncclPutSignal(
+          sendBuff, 32, ncclFloat, dstRank, 0, win, stream.raw()));
+  NCCLCHECK_FATAL(ncclx::ncclWaitSignal(srcRank, win, stream.raw()));
   waitStreamWithTimeout(stream.raw(), std::chrono::seconds{80});
 }
 

--- a/comms/ncclx/v2_27/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
+++ b/comms/ncclx/v2_27/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
@@ -612,15 +612,16 @@ TEST_F(CollTraceTest, winPutWait) {
   int prevPeer = (this->globalRank + this->numRanks - 1) % this->numRanks;
 
   for (auto iter = 0; iter < kNumIters; iter++) {
-    NCCLCHECK_TEST(ncclPutSignal(
-        localbuf + kNumElements * statex->rank(),
-        kNumElements,
-        ncclInt32,
-        nextPeer,
-        kNumElements * statex->rank(),
-        win,
-        put_stream));
-    NCCLCHECK_TEST(ncclWaitSignal(prevPeer, win, wait_stream));
+    NCCLCHECK_TEST(
+        ncclx::ncclPutSignal(
+            localbuf + kNumElements * statex->rank(),
+            kNumElements,
+            ncclInt32,
+            nextPeer,
+            kNumElements * statex->rank(),
+            win,
+            put_stream));
+    NCCLCHECK_TEST(ncclx::ncclWaitSignal(prevPeer, win, wait_stream));
   }
 
   int errs = 0;

--- a/comms/ncclx/v2_27/meta/rma/rma.cc
+++ b/comms/ncclx/v2_27/meta/rma/rma.cc
@@ -28,16 +28,8 @@ getValidatedNcclWin(ncclWindow_t win, ncclWin** outWin, const char* funcName) {
 
 } // namespace
 
-NCCL_API(
-    ncclResult_t,
-    ncclPutSignal,
-    const void* origin_buff,
-    size_t count,
-    ncclDataType_t datatype,
-    int peer,
-    size_t target_disp,
-    ncclWindow_t win,
-    cudaStream_t stream);
+namespace ncclx {
+
 ncclResult_t ncclPutSignal(
     const void* origin_buff,
     size_t count,
@@ -59,16 +51,6 @@ ncclResult_t ncclPutSignal(
       true));
 }
 
-NCCL_API(
-    ncclResult_t,
-    ncclPut,
-    const void* origin_buff,
-    size_t count,
-    ncclDataType_t datatype,
-    int peer,
-    size_t target_disp,
-    ncclWindow_t win,
-    cudaStream_t stream);
 ncclResult_t ncclPut(
     const void* origin_buff,
     size_t count,
@@ -90,16 +72,6 @@ ncclResult_t ncclPut(
       false));
 }
 
-NCCL_API(
-    ncclResult_t,
-    ncclGet,
-    void* target_buff,
-    size_t target_disp,
-    size_t count,
-    ncclDataType_t datatype,
-    int peer,
-    ncclWindow_t win,
-    cudaStream_t stream);
 ncclResult_t ncclGet(
     void* target_buff,
     size_t target_disp,
@@ -122,26 +94,12 @@ ncclResult_t ncclGet(
       stream));
 }
 
-NCCL_API(
-    ncclResult_t,
-    ncclWaitSignal,
-    int peer,
-    ncclWindow_t win,
-    cudaStream_t stream);
 ncclResult_t ncclWaitSignal(int peer, ncclWindow_t win, cudaStream_t stream) {
   ncclWin* ncclWinPtr = nullptr;
   NCCLCHECK(getValidatedNcclWin(win, &ncclWinPtr, "ncclWaitSignal"));
   return metaCommToNccl(ctranWaitSignal(peer, ncclWinPtr->ctranWindow, stream));
 }
 
-NCCL_API(
-    ncclResult_t,
-    ncclSignal,
-    size_t signalDisp, // TODO: to be deprecated
-    uint64_t signalVal, // TODO: to be deprecated
-    int peer,
-    ncclWindow_t win,
-    cudaStream_t stream);
 ncclResult_t ncclSignal(
     size_t signalDisp,
     uint64_t signalVal,
@@ -152,3 +110,5 @@ ncclResult_t ncclSignal(
   NCCLCHECK(getValidatedNcclWin(win, &ncclWinPtr, "ncclSignal"));
   return metaCommToNccl(ctranSignal(peer, ncclWinPtr->ctranWindow, stream));
 }
+
+} // namespace ncclx

--- a/comms/ncclx/v2_27/meta/rma/tests/RMATest.cc
+++ b/comms/ncclx/v2_27/meta/rma/tests/RMATest.cc
@@ -135,15 +135,16 @@ TEST_P(MultiWindowTestParam, multiWindow) {
     int prevPeer = (this->globalRank + this->numRanks - 1) % this->numRanks;
 
     for (auto iter = 0; iter < kNumIters; iter++) {
-      NCCLCHECK_TEST(ncclPutSignal(
-          localbuf + numElements * statex->rank(),
-          numElements,
-          ncclInt32,
-          nextPeer,
-          numElements * statex->rank(),
-          win,
-          put_stream));
-      NCCLCHECK_TEST(ncclWaitSignal(prevPeer, win, wait_stream));
+      NCCLCHECK_TEST(
+          ncclx::ncclPutSignal(
+              localbuf + numElements * statex->rank(),
+              numElements,
+              ncclInt32,
+              nextPeer,
+              numElements * statex->rank(),
+              win,
+              put_stream));
+      NCCLCHECK_TEST(ncclx::ncclWaitSignal(prevPeer, win, wait_stream));
     }
     // Barrier to ensure all peers have finished put
     this->barrier(comm, main_stream);
@@ -241,15 +242,16 @@ TEST_P(RMATestParam, winPutWait) {
   int prevPeer = (this->globalRank + this->numRanks - 1) % this->numRanks;
 
   for (auto iter = 0; iter < kNumIters; iter++) {
-    NCCLCHECK_TEST(ncclPutSignal(
-        localBuf,
-        kNumElements,
-        ncclInt32,
-        nextPeer,
-        kNumElements * statex->rank(),
-        win,
-        put_stream));
-    NCCLCHECK_TEST(ncclWaitSignal(prevPeer, win, wait_stream));
+    NCCLCHECK_TEST(
+        ncclx::ncclPutSignal(
+            localBuf,
+            kNumElements,
+            ncclInt32,
+            nextPeer,
+            kNumElements * statex->rank(),
+            win,
+            put_stream));
+    NCCLCHECK_TEST(ncclx::ncclWaitSignal(prevPeer, win, wait_stream));
     if (iter == 0) {
       // Skip first iteration to avoid any warmup overhead
       CUDACHECK_TEST(cudaEventRecord(start_event, put_stream));
@@ -364,14 +366,15 @@ TEST_P(RMATestParam, winPutOnly) {
 
   for (auto iter = 0; iter < kNumIters; iter++) {
     // Put data to next peer at offset of kNumElements * rank
-    NCCLCHECK_TEST(ncclPut(
-        localBuf,
-        kNumElements,
-        ncclInt32,
-        nextPeer,
-        kNumElements * rank,
-        win,
-        put_stream));
+    NCCLCHECK_TEST(
+        ncclx::ncclPut(
+            localBuf,
+            kNumElements,
+            ncclInt32,
+            nextPeer,
+            kNumElements * rank,
+            win,
+            put_stream));
   }
 
   // A couple of all-reduce after RMA tests
@@ -463,14 +466,15 @@ TEST_P(RMATestParam, winGet) {
 
   for (auto iter = 0; iter < kNumIters; iter++) {
     // Put data to next peer at offset of kNumElements * rank
-    NCCLCHECK_TEST(ncclGet(
-        localBuf,
-        kNumElements * rank,
-        kNumElements,
-        ncclInt32,
-        nextPeer,
-        win,
-        get_stream));
+    NCCLCHECK_TEST(
+        ncclx::ncclGet(
+            localBuf,
+            kNumElements * rank,
+            kNumElements,
+            ncclInt32,
+            nextPeer,
+            win,
+            get_stream));
   }
 
   // A couple of all-reduce after RMA tests

--- a/comms/ncclx/v2_27/src/nccl.h.in
+++ b/comms/ncclx/v2_27/src/nccl.h.in
@@ -738,70 +738,6 @@ ncclResult_t  ncclWinFree(ncclComm_t comm, ncclWindow_t win);
 __attribute__((deprecated("Use ncclCommWindowDeregister instead")))
 ncclResult_t pncclWinFree(ncclComm_t comm, ncclWindow_t win);
 
-/*
- * One-side put operation from a local buffer to a remote peer's pre-allocated
- * and registered buffer within a NCCL window.
- */
-ncclResult_t ncclPutSignal(
-    const void* originBuff,
-    size_t count,
-    ncclDataType_t datatype,
-    int peer,
-    size_t targetDisp,
-    ncclWindow_t win,
-    cudaStream_t stream);
-ncclResult_t pncclPutSignal(
-    const void* originBuff,
-    size_t count,
-    ncclDataType_t datatype,
-    int peer,
-    size_t targetDisp,
-    ncclWindow_t win,
-    cudaStream_t stream);
-
-/*
- * One-side put operation from a local buffer to a remote peer's pre-allocated
- * and registered buffer within a NCCL window. Without signaling.
- */
- ncclResult_t ncclPut(
-    const void* originBuff,
-    size_t count,
-    ncclDataType_t datatype,
-    int peer,
-    size_t targetDisp,
-    ncclWindow_t win,
-    cudaStream_t stream);
-
-/*
- * One-side get operation from a remote peer's pre-allocated and registered buffer
- * to a local buffer within a NCCL window. Without signaling.
- */
- ncclResult_t ncclGet(
-    void* targetBuff,
-    size_t targetDisp,
-    size_t count,
-    ncclDataType_t datatype,
-    int peer,
-    ncclWindow_t win,
-    cudaStream_t stream);
-
-/*
- * Wait for a signal from remote peer to complete the put operation.
- */
-ncclResult_t ncclWaitSignal(int peer, ncclWindow_t win, cudaStream_t stream);
-ncclResult_t pncclWaitSignal(int peer, ncclWindow_t win, cudaStream_t stream);
-
-/*
- * Wait for a signal given the local signal displacement, the signal value, and the comparison op.
- */
-ncclResult_t ncclSignal(
-    size_t signalDisp,
-    uint64_t signalVal,
-    int peer,
-    ncclWindow_t win,
-    cudaStream_t stream
-);
-
 /* Return the unique hash of the communicator.
  * For all ranks in a given communicator, this hash will be the same.
  */
@@ -832,6 +768,68 @@ ncclResult_t ncclCommDumpAll(std::unordered_map<std::string, std::unordered_map<
 ncclResult_t ncclCommsTracingServicePort(int& port);
 
 namespace ncclx {
+
+/*
+ * Window-based RMA API (NCCLX extension)
+ *
+ * These functions use the window-based model with ncclWindow_t handles.
+ * They are placed in the ncclx namespace to avoid conflicts with the
+ * comm-based baseline API above.
+ */
+
+/*
+ * One-side put operation from a local buffer to a remote peer's pre-allocated
+ * and registered buffer within a NCCL window.
+ */
+ncclResult_t ncclPutSignal(
+    const void* originBuff,
+    size_t count,
+    ncclDataType_t datatype,
+    int peer,
+    size_t targetDisp,
+    ncclWindow_t win,
+    cudaStream_t stream);
+
+/*
+ * One-side put operation from a local buffer to a remote peer's pre-allocated
+ * and registered buffer within a NCCL window. Without signaling.
+ */
+ncclResult_t ncclPut(
+    const void* originBuff,
+    size_t count,
+    ncclDataType_t datatype,
+    int peer,
+    size_t targetDisp,
+    ncclWindow_t win,
+    cudaStream_t stream);
+
+/*
+ * One-side get operation from a remote peer's pre-allocated and registered buffer
+ * to a local buffer within a NCCL window. Without signaling.
+ */
+ncclResult_t ncclGet(
+    void* targetBuff,
+    size_t targetDisp,
+    size_t count,
+    ncclDataType_t datatype,
+    int peer,
+    ncclWindow_t win,
+    cudaStream_t stream);
+
+/*
+ * Wait for a signal from remote peer to complete the put operation.
+ */
+ncclResult_t ncclWaitSignal(int peer, ncclWindow_t win, cudaStream_t stream);
+
+/*
+ * Signal a remote peer given the local signal displacement and value.
+ */
+ncclResult_t ncclSignal(
+    size_t signalDisp,
+    uint64_t signalVal,
+    int peer,
+    ncclWindow_t win,
+    cudaStream_t stream);
 
 /*
  * All-To-Allv Dynamic

--- a/comms/ncclx/v2_28/meta/colltrace/tests/CollTraceDistTest.cc
+++ b/comms/ncclx/v2_28/meta/colltrace/tests/CollTraceDistTest.cc
@@ -1194,15 +1194,16 @@ TEST_F(CollTraceTest, winPutWait) {
   int prevPeer = (this->globalRank + this->numRanks - 1) % this->numRanks;
 
   for (auto iter = 0; iter < kNumIters; iter++) {
-    NCCLCHECK_TEST(ncclPutSignal(
-        localbuf + kNumElements * statex->rank(),
-        kNumElements,
-        ncclInt32,
-        nextPeer,
-        kNumElements * statex->rank(),
-        win,
-        put_stream));
-    NCCLCHECK_TEST(ncclWaitSignal(prevPeer, win, wait_stream));
+    NCCLCHECK_TEST(
+        ncclx::ncclPutSignal(
+            localbuf + kNumElements * statex->rank(),
+            kNumElements,
+            ncclInt32,
+            nextPeer,
+            kNumElements * statex->rank(),
+            win,
+            put_stream));
+    NCCLCHECK_TEST(ncclx::ncclWaitSignal(prevPeer, win, wait_stream));
     if (iter == 0) {
       CUDACHECK_TEST(cudaEventRecord(start_event, put_stream));
     }

--- a/comms/ncclx/v2_28/meta/colltrace/tests/CollTraceWatchdogTest.cc
+++ b/comms/ncclx/v2_28/meta/colltrace/tests/CollTraceWatchdogTest.cc
@@ -230,8 +230,9 @@ TEST_F(CollTraceWatchdogTest, TestAsyncErrorFromGPE) {
   auto dstRank = (rank + 1) % worldSize;
 
   NCCLCHECK_FATAL(
-      ncclPutSignal(sendBuff, 32, ncclFloat, dstRank, 0, win, stream.raw()));
-  NCCLCHECK_FATAL(ncclWaitSignal(srcRank, win, stream.raw()));
+      ncclx::ncclPutSignal(
+          sendBuff, 32, ncclFloat, dstRank, 0, win, stream.raw()));
+  NCCLCHECK_FATAL(ncclx::ncclWaitSignal(srcRank, win, stream.raw()));
   waitStreamWithTimeout(stream.raw(), std::chrono::seconds{80});
 }
 

--- a/comms/ncclx/v2_28/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
+++ b/comms/ncclx/v2_28/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
@@ -612,15 +612,16 @@ TEST_F(CollTraceTest, winPutWait) {
   int prevPeer = (this->globalRank + this->numRanks - 1) % this->numRanks;
 
   for (auto iter = 0; iter < kNumIters; iter++) {
-    NCCLCHECK_TEST(ncclPutSignal(
-        localbuf + kNumElements * statex->rank(),
-        kNumElements,
-        ncclInt32,
-        nextPeer,
-        kNumElements * statex->rank(),
-        win,
-        put_stream));
-    NCCLCHECK_TEST(ncclWaitSignal(prevPeer, win, wait_stream));
+    NCCLCHECK_TEST(
+        ncclx::ncclPutSignal(
+            localbuf + kNumElements * statex->rank(),
+            kNumElements,
+            ncclInt32,
+            nextPeer,
+            kNumElements * statex->rank(),
+            win,
+            put_stream));
+    NCCLCHECK_TEST(ncclx::ncclWaitSignal(prevPeer, win, wait_stream));
   }
 
   int errs = 0;

--- a/comms/ncclx/v2_28/meta/rma/rma.cc
+++ b/comms/ncclx/v2_28/meta/rma/rma.cc
@@ -28,16 +28,8 @@ getValidatedNcclWin(ncclWindow_t win, ncclWin** outWin, const char* funcName) {
 
 } // namespace
 
-NCCL_API(
-    ncclResult_t,
-    ncclPutSignal,
-    const void* origin_buff,
-    size_t count,
-    ncclDataType_t datatype,
-    int peer,
-    size_t target_disp,
-    ncclWindow_t win,
-    cudaStream_t stream);
+namespace ncclx {
+
 ncclResult_t ncclPutSignal(
     const void* origin_buff,
     size_t count,
@@ -59,16 +51,6 @@ ncclResult_t ncclPutSignal(
       true));
 }
 
-NCCL_API(
-    ncclResult_t,
-    ncclPut,
-    const void* origin_buff,
-    size_t count,
-    ncclDataType_t datatype,
-    int peer,
-    size_t target_disp,
-    ncclWindow_t win,
-    cudaStream_t stream);
 ncclResult_t ncclPut(
     const void* origin_buff,
     size_t count,
@@ -90,16 +72,6 @@ ncclResult_t ncclPut(
       false));
 }
 
-NCCL_API(
-    ncclResult_t,
-    ncclGet,
-    void* target_buff,
-    size_t target_disp,
-    size_t count,
-    ncclDataType_t datatype,
-    int peer,
-    ncclWindow_t win,
-    cudaStream_t stream);
 ncclResult_t ncclGet(
     void* target_buff,
     size_t target_disp,
@@ -122,26 +94,12 @@ ncclResult_t ncclGet(
       stream));
 }
 
-NCCL_API(
-    ncclResult_t,
-    ncclWaitSignal,
-    int peer,
-    ncclWindow_t win,
-    cudaStream_t stream);
 ncclResult_t ncclWaitSignal(int peer, ncclWindow_t win, cudaStream_t stream) {
   ncclWin* ncclWinPtr = nullptr;
   NCCLCHECK(getValidatedNcclWin(win, &ncclWinPtr, "ncclWaitSignal"));
   return metaCommToNccl(ctranWaitSignal(peer, ncclWinPtr->ctranWindow, stream));
 }
 
-NCCL_API(
-    ncclResult_t,
-    ncclSignal,
-    size_t signalDisp,
-    uint64_t signalVal,
-    int peer,
-    ncclWindow_t win,
-    cudaStream_t stream);
 ncclResult_t ncclSignal(
     size_t signalDisp,
     uint64_t signalVal,
@@ -152,3 +110,5 @@ ncclResult_t ncclSignal(
   NCCLCHECK(getValidatedNcclWin(win, &ncclWinPtr, "ncclSignal"));
   return metaCommToNccl(ctranSignal(peer, ncclWinPtr->ctranWindow, stream));
 }
+
+} // namespace ncclx

--- a/comms/ncclx/v2_28/meta/rma/tests/RMATest.cc
+++ b/comms/ncclx/v2_28/meta/rma/tests/RMATest.cc
@@ -139,15 +139,16 @@ TEST_P(MultiWindowTestParam, multiWindow) {
     int prevPeer = (this->globalRank + this->numRanks - 1) % this->numRanks;
 
     for (auto iter = 0; iter < kNumIters; iter++) {
-      NCCLCHECK_TEST(ncclPutSignal(
-          localbuf + numElements * statex->rank(),
-          numElements,
-          ncclInt32,
-          nextPeer,
-          numElements * statex->rank(),
-          win,
-          put_stream));
-      NCCLCHECK_TEST(ncclWaitSignal(prevPeer, win, wait_stream));
+      NCCLCHECK_TEST(
+          ncclx::ncclPutSignal(
+              localbuf + numElements * statex->rank(),
+              numElements,
+              ncclInt32,
+              nextPeer,
+              numElements * statex->rank(),
+              win,
+              put_stream));
+      NCCLCHECK_TEST(ncclx::ncclWaitSignal(prevPeer, win, wait_stream));
     }
     // Barrier to ensure all peers have finished put
     this->barrier(comm, main_stream);
@@ -245,15 +246,16 @@ TEST_P(RMATestParam, winPutWait) {
   int prevPeer = (this->globalRank + this->numRanks - 1) % this->numRanks;
 
   for (auto iter = 0; iter < kNumIters; iter++) {
-    NCCLCHECK_TEST(ncclPutSignal(
-        localBuf,
-        kNumElements,
-        ncclInt32,
-        nextPeer,
-        kNumElements * statex->rank(),
-        win,
-        put_stream));
-    NCCLCHECK_TEST(ncclWaitSignal(prevPeer, win, wait_stream));
+    NCCLCHECK_TEST(
+        ncclx::ncclPutSignal(
+            localBuf,
+            kNumElements,
+            ncclInt32,
+            nextPeer,
+            kNumElements * statex->rank(),
+            win,
+            put_stream));
+    NCCLCHECK_TEST(ncclx::ncclWaitSignal(prevPeer, win, wait_stream));
     if (iter == 0) {
       // Skip first iteration to avoid any warmup overhead
       CUDACHECK_TEST(cudaEventRecord(start_event, put_stream));
@@ -368,14 +370,15 @@ TEST_P(RMATestParam, winPutOnly) {
 
   for (auto iter = 0; iter < kNumIters; iter++) {
     // Put data to next peer at offset of kNumElements * rank
-    NCCLCHECK_TEST(ncclPut(
-        localBuf,
-        kNumElements,
-        ncclInt32,
-        nextPeer,
-        kNumElements * rank,
-        win,
-        put_stream));
+    NCCLCHECK_TEST(
+        ncclx::ncclPut(
+            localBuf,
+            kNumElements,
+            ncclInt32,
+            nextPeer,
+            kNumElements * rank,
+            win,
+            put_stream));
   }
 
   // A couple of all-reduce after RMA tests
@@ -465,14 +468,15 @@ TEST_P(RMATestParam, winGet) {
 
   for (auto iter = 0; iter < kNumIters; iter++) {
     // Put data to next peer at offset of kNumElements * rank
-    NCCLCHECK_TEST(ncclGet(
-        localBuf,
-        kNumElements * rank,
-        kNumElements,
-        ncclInt32,
-        nextPeer,
-        win,
-        get_stream));
+    NCCLCHECK_TEST(
+        ncclx::ncclGet(
+            localBuf,
+            kNumElements * rank,
+            kNumElements,
+            ncclInt32,
+            nextPeer,
+            win,
+            get_stream));
   }
 
   // A couple of all-reduce after RMA tests

--- a/comms/ncclx/v2_28/src/nccl.h.in
+++ b/comms/ncclx/v2_28/src/nccl.h.in
@@ -815,71 +815,6 @@ ncclResult_t  ncclWinFree(ncclComm_t comm, ncclWindow_t win);
 __attribute__((deprecated("Use ncclCommWindowDeregister instead")))
 ncclResult_t pncclWinFree(ncclComm_t comm, ncclWindow_t win);
 
-/*
- * One-side put operation from a local buffer to a remote peer's pre-allocated
- * and registered buffer within a NCCL window.
- */
-ncclResult_t ncclPutSignal(
-    const void* originBuff,
-    size_t count,
-    ncclDataType_t datatype,
-    int peer,
-    size_t targetDisp,
-    ncclWindow_t win,
-    cudaStream_t stream);
-ncclResult_t pncclPutSignal(
-    const void* originBuff,
-    size_t count,
-    ncclDataType_t datatype,
-    int peer,
-    size_t targetDisp,
-    ncclWindow_t win,
-    cudaStream_t stream);
-
-/*
- * One-side put operation from a local buffer to a remote peer's pre-allocated
- * and registered buffer within a NCCL window. Without signaling.
- */
- ncclResult_t ncclPut(
-    const void* originBuff,
-    size_t count,
-    ncclDataType_t datatype,
-    int peer,
-    size_t targetDisp,
-    ncclWindow_t win,
-    cudaStream_t stream);
-
-/*
- * One-side get operation from a remote peer's pre-allocated and registered buffer
- * to a local buffer within a NCCL window. Without signaling.
- */
- ncclResult_t ncclGet(
-    void* targetBuff,
-    size_t targetDisp,
-    size_t count,
-    ncclDataType_t datatype,
-    int peer,
-    ncclWindow_t win,
-    cudaStream_t stream);
-
-/*
- * Wait for a signal from remote peer to complete the put operation.
- */
-ncclResult_t ncclWaitSignal(int peer, ncclWindow_t win, cudaStream_t stream);
-ncclResult_t pncclWaitSignal(int peer, ncclWindow_t win, cudaStream_t stream);
-
-/*
- * Wait for a signal given the local signal displacement, the signal value, and the comparison op.
- */
-
-ncclResult_t ncclSignal(
-    size_t signalDisp,
-    uint64_t signalVal,
-    int peer,
-    ncclWindow_t win,
-    cudaStream_t stream
-);
-
 /* Return the unique hash of the communicator.
  * For all ranks in a given communicator, this hash will be the same.
  */
@@ -928,6 +863,69 @@ void dumpAlgoStat(ncclComm_t comm, std::unordered_map<std::string, std::unordere
 } // namespace ncclx::colltrace
 
 namespace ncclx {
+
+/*
+ * Window-based RMA API (NCCLX extension)
+ *
+ * These functions use the window-based model with ncclWindow_t handles.
+ * They are placed in the ncclx namespace to avoid conflicts with the
+ * comm-based baseline API above.
+ */
+
+/*
+ * One-side put operation from a local buffer to a remote peer's pre-allocated
+ * and registered buffer within a NCCL window.
+ */
+ncclResult_t ncclPutSignal(
+    const void* originBuff,
+    size_t count,
+    ncclDataType_t datatype,
+    int peer,
+    size_t targetDisp,
+    ncclWindow_t win,
+    cudaStream_t stream);
+
+/*
+ * One-side put operation from a local buffer to a remote peer's pre-allocated
+ * and registered buffer within a NCCL window. Without signaling.
+ */
+ncclResult_t ncclPut(
+    const void* originBuff,
+    size_t count,
+    ncclDataType_t datatype,
+    int peer,
+    size_t targetDisp,
+    ncclWindow_t win,
+    cudaStream_t stream);
+
+/*
+ * One-side get operation from a remote peer's pre-allocated and registered buffer
+ * to a local buffer within a NCCL window. Without signaling.
+ */
+ncclResult_t ncclGet(
+    void* targetBuff,
+    size_t targetDisp,
+    size_t count,
+    ncclDataType_t datatype,
+    int peer,
+    ncclWindow_t win,
+    cudaStream_t stream);
+
+/*
+ * Wait for a signal from remote peer to complete the put operation.
+ */
+ncclResult_t ncclWaitSignal(int peer, ncclWindow_t win, cudaStream_t stream);
+
+/*
+ * Signal a remote peer given the local signal displacement and value.
+ */
+ncclResult_t ncclSignal(
+    size_t signalDisp,
+    uint64_t signalVal,
+    int peer,
+    ncclWindow_t win,
+    cudaStream_t stream
+);
 
 /*
  * All-To-Allv Dynamic

--- a/comms/ncclx/v2_29/meta/colltrace/tests/CollTraceDistTest.cc
+++ b/comms/ncclx/v2_29/meta/colltrace/tests/CollTraceDistTest.cc
@@ -1194,15 +1194,16 @@ TEST_F(CollTraceTest, winPutWait) {
   int prevPeer = (this->globalRank + this->numRanks - 1) % this->numRanks;
 
   for (auto iter = 0; iter < kNumIters; iter++) {
-    NCCLCHECK_TEST(ncclPutSignal(
-        localbuf + kNumElements * statex->rank(),
-        kNumElements,
-        ncclInt32,
-        nextPeer,
-        kNumElements * statex->rank(),
-        win,
-        put_stream));
-    NCCLCHECK_TEST(ncclWaitSignal(prevPeer, win, wait_stream));
+    NCCLCHECK_TEST(
+        ncclx::ncclPutSignal(
+            localbuf + kNumElements * statex->rank(),
+            kNumElements,
+            ncclInt32,
+            nextPeer,
+            kNumElements * statex->rank(),
+            win,
+            put_stream));
+    NCCLCHECK_TEST(ncclx::ncclWaitSignal(prevPeer, win, wait_stream));
     if (iter == 0) {
       CUDACHECK_TEST(cudaEventRecord(start_event, put_stream));
     }

--- a/comms/ncclx/v2_29/meta/colltrace/tests/CollTraceWatchdogTest.cc
+++ b/comms/ncclx/v2_29/meta/colltrace/tests/CollTraceWatchdogTest.cc
@@ -230,8 +230,9 @@ TEST_F(CollTraceWatchdogTest, TestAsyncErrorFromGPE) {
   auto dstRank = (rank + 1) % worldSize;
 
   NCCLCHECK_FATAL(
-      ncclPutSignal(sendBuff, 32, ncclFloat, dstRank, 0, win, stream.raw()));
-  NCCLCHECK_FATAL(ncclWaitSignal(srcRank, win, stream.raw()));
+      ncclx::ncclPutSignal(
+          sendBuff, 32, ncclFloat, dstRank, 0, win, stream.raw()));
+  NCCLCHECK_FATAL(ncclx::ncclWaitSignal(srcRank, win, stream.raw()));
   waitStreamWithTimeout(stream.raw(), std::chrono::seconds{80});
 }
 

--- a/comms/ncclx/v2_29/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
+++ b/comms/ncclx/v2_29/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
@@ -612,15 +612,16 @@ TEST_F(CollTraceTest, winPutWait) {
   int prevPeer = (this->globalRank + this->numRanks - 1) % this->numRanks;
 
   for (auto iter = 0; iter < kNumIters; iter++) {
-    NCCLCHECK_TEST(ncclPutSignal(
-        localbuf + kNumElements * statex->rank(),
-        kNumElements,
-        ncclInt32,
-        nextPeer,
-        kNumElements * statex->rank(),
-        win,
-        put_stream));
-    NCCLCHECK_TEST(ncclWaitSignal(prevPeer, win, wait_stream));
+    NCCLCHECK_TEST(
+        ncclx::ncclPutSignal(
+            localbuf + kNumElements * statex->rank(),
+            kNumElements,
+            ncclInt32,
+            nextPeer,
+            kNumElements * statex->rank(),
+            win,
+            put_stream));
+    NCCLCHECK_TEST(ncclx::ncclWaitSignal(prevPeer, win, wait_stream));
   }
 
   int errs = 0;

--- a/comms/ncclx/v2_29/meta/rma/rma.cc
+++ b/comms/ncclx/v2_29/meta/rma/rma.cc
@@ -28,16 +28,8 @@ getValidatedNcclWin(ncclWindow_t win, ncclWin** outWin, const char* funcName) {
 
 } // namespace
 
-NCCL_API(
-    ncclResult_t,
-    ncclPutSignal,
-    const void* origin_buff,
-    size_t count,
-    ncclDataType_t datatype,
-    int peer,
-    size_t target_disp,
-    ncclWindow_t win,
-    cudaStream_t stream);
+namespace ncclx {
+
 ncclResult_t ncclPutSignal(
     const void* origin_buff,
     size_t count,
@@ -59,16 +51,6 @@ ncclResult_t ncclPutSignal(
       true));
 }
 
-NCCL_API(
-    ncclResult_t,
-    ncclPut,
-    const void* origin_buff,
-    size_t count,
-    ncclDataType_t datatype,
-    int peer,
-    size_t target_disp,
-    ncclWindow_t win,
-    cudaStream_t stream);
 ncclResult_t ncclPut(
     const void* origin_buff,
     size_t count,
@@ -90,16 +72,6 @@ ncclResult_t ncclPut(
       false));
 }
 
-NCCL_API(
-    ncclResult_t,
-    ncclGet,
-    void* target_buff,
-    size_t target_disp,
-    size_t count,
-    ncclDataType_t datatype,
-    int peer,
-    ncclWindow_t win,
-    cudaStream_t stream);
 ncclResult_t ncclGet(
     void* target_buff,
     size_t target_disp,
@@ -122,26 +94,12 @@ ncclResult_t ncclGet(
       stream));
 }
 
-NCCL_API(
-    ncclResult_t,
-    ncclWaitSignal,
-    int peer,
-    ncclWindow_t win,
-    cudaStream_t stream);
 ncclResult_t ncclWaitSignal(int peer, ncclWindow_t win, cudaStream_t stream) {
   ncclWin* ncclWinPtr = nullptr;
   NCCLCHECK(getValidatedNcclWin(win, &ncclWinPtr, "ncclWaitSignal"));
   return metaCommToNccl(ctranWaitSignal(peer, ncclWinPtr->ctranWindow, stream));
 }
 
-NCCL_API(
-    ncclResult_t,
-    ncclSignal,
-    size_t signalDisp,
-    uint64_t signalVal,
-    int peer,
-    ncclWindow_t win,
-    cudaStream_t stream);
 ncclResult_t ncclSignal(
     size_t signalDisp,
     uint64_t signalVal,
@@ -152,3 +110,5 @@ ncclResult_t ncclSignal(
   NCCLCHECK(getValidatedNcclWin(win, &ncclWinPtr, "ncclSignal"));
   return metaCommToNccl(ctranSignal(peer, ncclWinPtr->ctranWindow, stream));
 }
+
+} // namespace ncclx

--- a/comms/ncclx/v2_29/meta/rma/tests/RMATest.cc
+++ b/comms/ncclx/v2_29/meta/rma/tests/RMATest.cc
@@ -139,15 +139,16 @@ TEST_P(MultiWindowTestParam, multiWindow) {
     int prevPeer = (this->globalRank + this->numRanks - 1) % this->numRanks;
 
     for (auto iter = 0; iter < kNumIters; iter++) {
-      NCCLCHECK_TEST(ncclPutSignal(
-          localbuf + numElements * statex->rank(),
-          numElements,
-          ncclInt32,
-          nextPeer,
-          numElements * statex->rank(),
-          win,
-          put_stream));
-      NCCLCHECK_TEST(ncclWaitSignal(prevPeer, win, wait_stream));
+      NCCLCHECK_TEST(
+          ncclx::ncclPutSignal(
+              localbuf + numElements * statex->rank(),
+              numElements,
+              ncclInt32,
+              nextPeer,
+              numElements * statex->rank(),
+              win,
+              put_stream));
+      NCCLCHECK_TEST(ncclx::ncclWaitSignal(prevPeer, win, wait_stream));
     }
     // Barrier to ensure all peers have finished put
     this->barrier(comm, main_stream);
@@ -245,15 +246,16 @@ TEST_P(RMATestParam, winPutWait) {
   int prevPeer = (this->globalRank + this->numRanks - 1) % this->numRanks;
 
   for (auto iter = 0; iter < kNumIters; iter++) {
-    NCCLCHECK_TEST(ncclPutSignal(
-        localBuf,
-        kNumElements,
-        ncclInt32,
-        nextPeer,
-        kNumElements * statex->rank(),
-        win,
-        put_stream));
-    NCCLCHECK_TEST(ncclWaitSignal(prevPeer, win, wait_stream));
+    NCCLCHECK_TEST(
+        ncclx::ncclPutSignal(
+            localBuf,
+            kNumElements,
+            ncclInt32,
+            nextPeer,
+            kNumElements * statex->rank(),
+            win,
+            put_stream));
+    NCCLCHECK_TEST(ncclx::ncclWaitSignal(prevPeer, win, wait_stream));
     if (iter == 0) {
       // Skip first iteration to avoid any warmup overhead
       CUDACHECK_TEST(cudaEventRecord(start_event, put_stream));
@@ -368,14 +370,15 @@ TEST_P(RMATestParam, winPutOnly) {
 
   for (auto iter = 0; iter < kNumIters; iter++) {
     // Put data to next peer at offset of kNumElements * rank
-    NCCLCHECK_TEST(ncclPut(
-        localBuf,
-        kNumElements,
-        ncclInt32,
-        nextPeer,
-        kNumElements * rank,
-        win,
-        put_stream));
+    NCCLCHECK_TEST(
+        ncclx::ncclPut(
+            localBuf,
+            kNumElements,
+            ncclInt32,
+            nextPeer,
+            kNumElements * rank,
+            win,
+            put_stream));
   }
 
   // A couple of all-reduce after RMA tests
@@ -465,14 +468,15 @@ TEST_P(RMATestParam, winGet) {
 
   for (auto iter = 0; iter < kNumIters; iter++) {
     // Put data to next peer at offset of kNumElements * rank
-    NCCLCHECK_TEST(ncclGet(
-        localBuf,
-        kNumElements * rank,
-        kNumElements,
-        ncclInt32,
-        nextPeer,
-        win,
-        get_stream));
+    NCCLCHECK_TEST(
+        ncclx::ncclGet(
+            localBuf,
+            kNumElements * rank,
+            kNumElements,
+            ncclInt32,
+            nextPeer,
+            win,
+            get_stream));
   }
 
   // A couple of all-reduce after RMA tests

--- a/comms/ncclx/v2_29/src/nccl.h.in
+++ b/comms/ncclx/v2_29/src/nccl.h.in
@@ -969,71 +969,6 @@ ncclResult_t  ncclWinFree(ncclComm_t comm, ncclWindow_t win);
 __attribute__((deprecated("Use ncclCommWindowDeregister instead")))
 ncclResult_t pncclWinFree(ncclComm_t comm, ncclWindow_t win);
 
-/*
- * One-side put operation from a local buffer to a remote peer's pre-allocated
- * and registered buffer within a NCCL window.
- */
-ncclResult_t ncclPutSignal(
-    const void* originBuff,
-    size_t count,
-    ncclDataType_t datatype,
-    int peer,
-    size_t targetDisp,
-    ncclWindow_t win,
-    cudaStream_t stream);
-ncclResult_t pncclPutSignal(
-    const void* originBuff,
-    size_t count,
-    ncclDataType_t datatype,
-    int peer,
-    size_t targetDisp,
-    ncclWindow_t win,
-    cudaStream_t stream);
-
-/*
- * One-side put operation from a local buffer to a remote peer's pre-allocated
- * and registered buffer within a NCCL window. Without signaling.
- */
- ncclResult_t ncclPut(
-    const void* originBuff,
-    size_t count,
-    ncclDataType_t datatype,
-    int peer,
-    size_t targetDisp,
-    ncclWindow_t win,
-    cudaStream_t stream);
-
-/*
- * One-side get operation from a remote peer's pre-allocated and registered buffer
- * to a local buffer within a NCCL window. Without signaling.
- */
- ncclResult_t ncclGet(
-    void* targetBuff,
-    size_t targetDisp,
-    size_t count,
-    ncclDataType_t datatype,
-    int peer,
-    ncclWindow_t win,
-    cudaStream_t stream);
-
-/*
- * Wait for a signal from remote peer to complete the put operation.
- */
-ncclResult_t ncclWaitSignal(int peer, ncclWindow_t win, cudaStream_t stream);
-ncclResult_t pncclWaitSignal(int peer, ncclWindow_t win, cudaStream_t stream);
-
-/*
- * Wait for a signal given the local signal displacement, the signal value, and the comparison op.
- */
-
-ncclResult_t ncclSignal(
-    size_t signalDisp,
-    uint64_t signalVal,
-    int peer,
-    ncclWindow_t win,
-    cudaStream_t stream
-);
-
 /* Return the unique hash of the communicator.
  * For all ranks in a given communicator, this hash will be the same.
  */
@@ -1043,6 +978,8 @@ ncclResult_t  pncclCommGetUniqueHash(ncclComm_t comm, uint64_t* uniqueHash);
 #ifdef __cplusplus
 } // end extern "C"
 #endif
+
+
 
 #ifdef __cplusplus
 #define NCCL_COMM_DUMP
@@ -1063,14 +1000,7 @@ ncclResult_t ncclCommDumpAll(std::unordered_map<std::string, std::unordered_map<
 #define NCCL_HAS_COMMS_TRACING_SERVICE_PORT
 ncclResult_t ncclCommsTracingServicePort(int& port);
 
-// NCCL_HAS_DUMP_ALGO_STAT controls whether dumpAlgoStat() is available.
-// By default, it is defined. To disable it (e.g., for adapters which may have
-// different ncclComm layout), compile with -DNCCL_HAS_DUMP_ALGO_STAT=0.
-#if !defined(NCCL_HAS_DUMP_ALGO_STAT)
 #define NCCL_HAS_DUMP_ALGO_STAT
-#elif NCCL_HAS_DUMP_ALGO_STAT == 0
-#undef NCCL_HAS_DUMP_ALGO_STAT
-#endif
 namespace ncclx::colltrace {
 
 // Dump collective algorithm statistics for a communicator.
@@ -1082,6 +1012,68 @@ void dumpAlgoStat(ncclComm_t comm, std::unordered_map<std::string, std::unordere
 } // namespace ncclx::colltrace
 
 namespace ncclx {
+
+/*
+ * Window-based RMA API (NCCLX extension)
+ *
+ * These functions use the window-based model with ncclWindow_t handles.
+ * They are placed in the ncclx namespace to avoid conflicts with the
+ * comm-based baseline API above.
+ */
+
+/*
+ * One-side put operation from a local buffer to a remote peer's pre-allocated
+ * and registered buffer within a NCCL window.
+ */
+ncclResult_t ncclPutSignal(
+    const void* originBuff,
+    size_t count,
+    ncclDataType_t datatype,
+    int peer,
+    size_t targetDisp,
+    ncclWindow_t win,
+    cudaStream_t stream);
+
+/*
+ * One-side put operation from a local buffer to a remote peer's pre-allocated
+ * and registered buffer within a NCCL window. Without signaling.
+ */
+ncclResult_t ncclPut(
+    const void* originBuff,
+    size_t count,
+    ncclDataType_t datatype,
+    int peer,
+    size_t targetDisp,
+    ncclWindow_t win,
+    cudaStream_t stream);
+
+/*
+ * One-side get operation from a remote peer's pre-allocated and registered buffer
+ * to a local buffer within a NCCL window. Without signaling.
+ */
+ncclResult_t ncclGet(
+    void* targetBuff,
+    size_t targetDisp,
+    size_t count,
+    ncclDataType_t datatype,
+    int peer,
+    ncclWindow_t win,
+    cudaStream_t stream);
+
+/*
+ * Wait for a signal from remote peer to complete the put operation.
+ */
+ncclResult_t ncclWaitSignal(int peer, ncclWindow_t win, cudaStream_t stream);
+
+/*
+ * Signal a remote peer given the local signal displacement and value.
+ */
+ncclResult_t ncclSignal(
+    size_t signalDisp,
+    uint64_t signalVal,
+    int peer,
+    ncclWindow_t win,
+    cudaStream_t stream);
 
 /*
  * All-To-Allv Dynamic

--- a/comms/torchcomms/ncclx/NcclxApi.cpp
+++ b/comms/torchcomms/ncclx/NcclxApi.cpp
@@ -403,7 +403,7 @@ ncclResult_t DefaultNcclxApi::winPut(
     NcclxWindow win,
     cudaStream_t stream) {
   std::lock_guard<std::mutex> lock(api_mutex_);
-  return ncclPut(
+  return ncclx::ncclPut(
       originBuff, count, datatype, peer, targetOffsetNelems, win, stream);
 };
 
@@ -419,13 +419,13 @@ ncclResult_t DefaultNcclxApi::winSharedQuery(
 ncclResult_t
 DefaultNcclxApi::winSignal(int peer, NcclxWindow win, cudaStream_t stream) {
   std::lock_guard<std::mutex> lock(api_mutex_);
-  return ncclSignal(peer, 0, peer, win, stream);
+  return ncclx::ncclSignal(peer, 0, peer, win, stream);
 }
 
 ncclResult_t
 DefaultNcclxApi::winWaitSignal(int peer, NcclxWindow win, cudaStream_t stream) {
   std::lock_guard<std::mutex> lock(api_mutex_);
-  return ncclWaitSignal(peer, win, stream);
+  return ncclx::ncclWaitSignal(peer, win, stream);
 }
 
 ncclResult_t DefaultNcclxApi::winGetAttributes(


### PR DESCRIPTION
Summary:
Pytorch already uses one-sided API from baseline 2.29 , so we need to provide both API variants to users at once.

Currently ctran-backed signal API completely matches baseline signal API function names.
In order to avoid symbol conflict,  move ctran-based one-sided API into ncclx:: namespace and migrate all callsites.

This requires changes in common ctran code and ncclx 2.27 and 2.28 as well.

Reviewed By: zhiyongww, tanquer

Differential Revision: D94455583


