### PR TITLE
Fix IPC remote registration leak in mapper destructor

### DIFF
--- a/comms/ctran/mapper/CtranMapper.cc
+++ b/comms/ctran/mapper/CtranMapper.cc
@@ -411,6 +411,18 @@ CtranMapper::~CtranMapper() {
 
   this->reportProfiling(true);
 
+  // Release all remote IPC registrations tracked by this mapper.
+  // This sends kRelease to remote peers so they can decrement their refCounts
+  // and eventually unmap CUDA IPC memory. Must happen BEFORE
+  // deregisterExportClient so the mapper is still in the client list during
+  // cleanup.
+  {
+    auto entries = exportRegCache_.rlock()->dump();
+    for (auto& [regElem, _] : entries) {
+      remReleaseMem(regElem);
+    }
+  }
+
   // Deregister from IpcRegCache so globalDeregister won't call this mapper
   // after it's destroyed.
   auto ipcRegCache = ctran::IpcRegCache::getInstance();


### PR DESCRIPTION
Summary:
When a communicator is destroyed before memory is freed, the mapper
destructor did not call `remReleaseMem` for entries in `exportRegCache_`.
This meant remote peers were never notified to release their imported
CUDA IPC memory, causing IPC remote registration leaks.

Fix: iterate `exportRegCache_.dump()` and call `remReleaseMem` for each
tracked export before calling `deregisterExportClient`. This ensures
remote peers decrement their refCounts and eventually unmap the IPC
memory.

Reviewed By: elvinlife

Differential Revision: D94978821


