### PR TITLE
Add forceFree parameter to freeSegment for globalDeregister

### DIFF
--- a/comms/ctran/mapper/CtranMapper.cc
+++ b/comms/ctran/mapper/CtranMapper.cc
@@ -644,8 +644,8 @@ commResult_t CtranMapper::deregMem(void* segHdl, const bool skipRemRelease) {
   //   also deregisters all associated registrations.
   // - Ownership of registrations are transferred to the last communicator to
   //   release remote registration.
-  // - If the segment no longer exists in cache, likely double dereg.
-  //   ncclInvaidUsage is returned.
+  // - If the segment no longer exists in cache (e.g. already freed by
+  //   globalDeregister), this is a no-op.
   bool freed = false, ncclManaged = false;
   std::vector<std::unique_ptr<ctran::regcache::RegElem>> regElemsFreed;
   FB_COMMCHECK(

--- a/comms/ctran/regcache/RegCache.cc
+++ b/comms/ctran/regcache/RegCache.cc
@@ -393,7 +393,7 @@ ctran::RegCache::globalDeregister(const void* buf, size_t len, int deviceId) {
     bool freed = false;
     bool ncclManaged = false;
     std::vector<std::unique_ptr<ctran::regcache::RegElem>> regElemsFreed;
-    FB_COMMCHECK(freeSegment(segHdl, freed, ncclManaged, regElemsFreed));
+    FB_COMMCHECK(freeSegment(segHdl, freed, ncclManaged, regElemsFreed, true));
 
     if (freed) {
       totalSegmentsFreed++;
@@ -986,7 +986,8 @@ commResult_t ctran::RegCache::freeSegment(
     void* segHdl,
     bool& freed,
     bool& ncclManaged,
-    std::vector<std::unique_ptr<ctran::regcache::RegElem>>& regElems) {
+    std::vector<std::unique_ptr<ctran::regcache::RegElem>>& regElems,
+    bool forceFree) {
   ctran::regcache::Segment* segment = nullptr;
   {
     // Global lock:
@@ -1005,16 +1006,18 @@ commResult_t ctran::RegCache::freeSegment(
     segment = reinterpret_cast<ctran::regcache::Segment*>(
         segmentsAvl->lookup(segHdl));
 
-    // Invalid segment handle, likely double free
+    // Segment already freed (e.g. by globalDeregister with forceFree).
+    // This is not an error — just a no-op.
     if (!segment) {
-      CLOGF(ERR, "Invalid segment handle {}", (void*)segHdl);
-      return commInvalidUsage;
+      return commSuccess;
     }
 
     ncclManaged = segment->ncclManaged;
 
-    // Ask for free. False if still in use, then no-op and return
-    if (!segment->askFree()) {
+    // Ask for free. False if still in use, then no-op and return.
+    // When forceFree is true (e.g. globalDeregister), skip the refCount check
+    // because the underlying physical memory is about to be freed.
+    if (!forceFree && !segment->askFree()) {
       return commSuccess;
     }
 

--- a/comms/ctran/regcache/RegCache.h
+++ b/comms/ctran/regcache/RegCache.h
@@ -362,10 +362,15 @@ class RegCache {
   commResult_t deregDynamic(regcache::RegElem* regHdl);
 
   // Thread-safe functions to free a cached segment from the global cache and
-  // deregister any associated registration. If the segment is still in use by
-  // any communicator, this call is a no-op.
+  // deregister any associated registration. If the segment is already freed
+  // (e.g. by a prior globalDeregister), this is a no-op. If the segment is
+  // still in use by any communicator (refCount > 0), this call is a no-op
+  // unless forceFree is true.
   // input:
   //   - segHdl: the handle of the cached segment
+  //   - forceFree: if true, skip the refCount check and always free the
+  //                segment. Used by globalDeregister when the underlying
+  //                physical memory is about to be freed.
   // output:
   //   - freed: whether or not the segment is freed from the global cache
   //   - ncclManaged: whether or not the segment is managed by NCCL
@@ -376,7 +381,8 @@ class RegCache {
       void* segHdl,
       bool& freed,
       bool& ncclManaged,
-      std::vector<std::unique_ptr<regcache::RegElem>>& regElems);
+      std::vector<std::unique_ptr<regcache::RegElem>>& regElems,
+      bool forceFree = false);
 
   regcache::Segment* getSegment(void* segHdl);
 

--- a/comms/ctran/regcache/docs/design.md
+++ b/comms/ctran/regcache/docs/design.md
@@ -188,15 +188,21 @@ The segment uses reference counting (`SegmentStateMnger`): each
 `cacheSegment` call increments the refcount, and `freeSegment`
 decrements it. The segment is only actually freed when the refcount
 reaches zero. If the segment handle is not found (already freed),
-`freeSegment` returns `commInvalidUsage`.
+`freeSegment` is a no-op and returns success.
+
+An optional `forceFree` parameter (default `false`) bypasses the
+refcount check and always frees the segment. `globalDeregister` uses
+`forceFree=true` because the underlying physical memory is about to be
+freed, so the segment must be removed from cache regardless of how many
+communicators have cached it.
 
 ```
-freeSegment(segHdl) -> freed, regElems
+freeSegment(segHdl, forceFree=false) -> freed, regElems
 
   1. Acquire both segmentsAvl_ and regElemsMaps_ locks
   2. Lookup Segment from AVL handle
-     - Not found -> return commInvalidUsage (error)
-  3. askFree() -> decrement refCount
+     - Not found -> return (freed=false, commSuccess)
+  3. If !forceFree: askFree() -> decrement refCount
      - refCount > 0 -> return (freed=false, commSuccess)
   4. Collect all RegElems via segToRegElemsMap
   5. Transfer ownership from regHdlToElemMap to output vector

--- a/comms/ctran/regcache/tests/RegCacheUT.cc
+++ b/comms/ctran/regcache/tests/RegCacheUT.cc
@@ -1039,6 +1039,57 @@ TEST_F(RegCacheTest, IpcRemRegElemRefCountInitial) {
   EXPECT_EQ(ipcRegCache->getNumRemReg("test_peer_refcount"), 0);
 }
 
+// Test that forceFree bypasses refcount and always frees the segment
+TEST_F(RegCacheTest, FreeSegmentForceFreeBypassesRefCount) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  // Cache the segment twice to get refcount=2
+  std::vector<ctran::regcache::Segment*> segments1;
+  std::vector<void*> segHdls1;
+  EXPECT_EQ(
+      regCache->cacheSegment(
+          buf, bufSize, cudaDev, false, 0, segments1, segHdls1),
+      commSuccess);
+  EXPECT_EQ(segments1.size(), 1);
+
+  std::vector<ctran::regcache::Segment*> segments2;
+  std::vector<void*> segHdls2;
+  EXPECT_EQ(
+      regCache->cacheSegment(
+          buf, bufSize, cudaDev, false, 0, segments2, segHdls2),
+      commSuccess);
+  EXPECT_EQ(segments1[0], segments2[0]); // same segment, refcount=2
+
+  // Without forceFree, first free should NOT actually free (refcount > 0)
+  bool freed = false;
+  bool ncclManaged = false;
+  std::vector<std::unique_ptr<ctran::regcache::RegElem>> regElems;
+  EXPECT_EQ(
+      regCache->freeSegment(segHdls1[0], freed, ncclManaged, regElems, false),
+      commSuccess);
+  EXPECT_FALSE(freed);
+
+  // Re-cache to restore refcount to 2
+  std::vector<ctran::regcache::Segment*> segments3;
+  std::vector<void*> segHdls3;
+  EXPECT_EQ(
+      regCache->cacheSegment(
+          buf, bufSize, cudaDev, false, 0, segments3, segHdls3),
+      commSuccess);
+
+  // With forceFree=true, should free even though refcount > 1
+  freed = false;
+  regElems.clear();
+  EXPECT_EQ(
+      regCache->freeSegment(segHdls3[0], freed, ncclManaged, regElems, true),
+      commSuccess);
+  EXPECT_TRUE(freed);
+
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();


### PR DESCRIPTION
Summary:
When `globalDeregister` is called, the underlying physical memory is about to
be freed. The segment must be removed from the AVL cache regardless of how
many communicators have cached it. Without this fix, a segment cached by
multiple communicators (refcount > 1) would only have its refcount decremented,
leaving a dangling entry in the AVL tree pointing to freed CUDA memory.

Add a `bool forceFree = false` parameter to `freeSegment()`. When true, the
refcount check (`askFree()`) is bypassed and the segment is always removed
from the cache and deregistered from backends. `globalDeregister` passes
`forceFree=true`; all other callers use the default `false`.

Also updates `regcache/docs/design.md` to document the new parameter.

Differential Revision: D94978820


