### PR TITLE
Avoid referencing ncclComm in ncclGinResetSignalsAndCounters()

### DIFF
--- a/comms/ncclx/v2_29/src/dev_runtime.cc
+++ b/comms/ncclx/v2_29/src/dev_runtime.cc
@@ -1650,7 +1650,7 @@ ncclResult_t ncclDevCommDestroy(
   NCCLCHECK(PtrCheck(devComm, __func__, "devComm"));
   struct ncclDevrState* devr = &comm->devrState;
   if (devr->ginEnabled) {
-    NCCLCHECK(ncclGinResetSignalsAndCounters(comm, devComm));
+    NCCLCHECK(ncclGinResetSignalsAndCounters(comm->cudaDev, devComm));
 
     ncclGinFreeSignalsCounters(comm,
       devComm->ginSignalBase, devComm->ginSignalCount,

--- a/comms/ncclx/v2_29/src/device/common.cu
+++ b/comms/ncclx/v2_29/src/device/common.cu
@@ -9,7 +9,8 @@
 #include "collectives.h"
 #include "common.h"
 #include "nccl_device.h"
-#include "comm.h"
+#include "checks.h"
+#include "sym_kernels.h"
 
 __shared__ ncclShmemData ncclShmem;
 #if __CUDA_ARCH__ < 700
@@ -45,7 +46,7 @@ __global__ void ncclDevKernelGinResetSignalsAndCounters(ncclDevComm devComm) {
   }
 }
 
-ncclResult_t ncclGinResetSignalsAndCounters(struct ncclComm* comm, ncclDevComm_t const* devComm) {
+ncclResult_t ncclGinResetSignalsAndCounters(int cudaDev, ncclDevComm_t const* devComm) {
   int deviceWork = std::max(devComm->ginSignalCount, devComm->ginCounterCount);
 
   if (deviceWork == 0) {
@@ -53,7 +54,7 @@ ncclResult_t ncclGinResetSignalsAndCounters(struct ncclComm* comm, ncclDevComm_t
   }
 
   // Ensure we run on the comm's device (important when called from async reclaim thread)
-  CUDACHECK(cudaSetDevice(comm->cudaDev));
+  CUDACHECK(cudaSetDevice(cudaDev));
 
   dim3 grid(1);
   dim3 block(ncclSymkMaxThreads);

--- a/comms/ncclx/v2_29/src/include/device.h
+++ b/comms/ncclx/v2_29/src/include/device.h
@@ -646,6 +646,6 @@ inline int ncclDevFuncId(int coll, int devRedOp, int type, int algo, int proto) 
 
 inline int ncclDevFuncId_P2p() { return ncclDevFuncRowToId[0]; }
 
-ncclResult_t ncclGinResetSignalsAndCounters(struct ncclComm* comm, ncclDevComm_t const* devComm);
+ncclResult_t ncclGinResetSignalsAndCounters(int cudaDev, ncclDevComm_t const* devComm);
 
 #endif


### PR DESCRIPTION
Summary:
NCCL 2.29.7 introduces too generic "comm.h" include in common.cu, which also brings in folly headers with some features not support by nvcc coming with certain cuda runtime versions, so it breaks the build.

Luckily, this change could be easily reworked by providing single cudaDev parameter instead of the whole struct ncclComm pointer.

Reviewed By: zhiyongww, tanquer

Differential Revision: D94925897


