### PR TITLE
Fix FlightRecorderHook docstring RST formatting

### DIFF
--- a/comms/torchcomms/hooks/fr/FlightRecorderPy.cpp
+++ b/comms/torchcomms/hooks/fr/FlightRecorderPy.cpp
@@ -31,7 +31,9 @@ Example:
     >>> json_trace = recorder.dump_json()
 
 For testing, use isolated=True to create a separate FlightRecorder instance
-that is not shared with other hooks:
+that is not shared with other hooks.
+
+Example:
     >>> recorder = fr.FlightRecorderHook(max_entries=100, isolated=True)
       )")
       .def(

--- a/comms/torchcomms/objcol.py
+++ b/comms/torchcomms/objcol.py
@@ -107,7 +107,7 @@ def all_gather_object(
 
     .. warning::
         Object collectives have a number of serious performance and scalability
-        limitations.  See :ref:`object_collectives` for details.
+        limitations.
 
     .. warning::
         :func:`all_gather_object` uses ``pickle`` module implicitly, which is
@@ -212,7 +212,7 @@ def gather_object(
 
     .. warning::
         Object collectives have a number of serious performance and scalability
-        limitations.  See :ref:`object_collectives` for details.
+        limitations.
 
     .. warning::
         :func:`gather_object` uses ``pickle`` module implicitly, which is
@@ -326,7 +326,7 @@ def send_object_list(
 
     .. warning::
         Object collectives have a number of serious performance and scalability
-        limitations.  See :ref:`object_collectives` for details.
+        limitations.
 
     .. warning::
         :func:`send_object_list` uses ``pickle`` module implicitly, which
@@ -415,7 +415,7 @@ def recv_object_list(
 
     .. warning::
         Object collectives have a number of serious performance and scalability
-        limitations.  See :ref:`object_collectives` for details.
+        limitations.
 
     .. warning::
         :func:`recv_object_list` uses ``pickle`` module implicitly, which
@@ -513,7 +513,7 @@ def broadcast_object_list(
 
     .. warning::
         Object collectives have a number of serious performance and scalability
-        limitations.  See :ref:`object_collectives` for details.
+        limitations.
 
     .. warning::
         :func:`broadcast_object_list` uses ``pickle`` module implicitly, which
@@ -624,7 +624,7 @@ def scatter_object_list(
 
     .. warning::
         Object collectives have a number of serious performance and scalability
-        limitations.  See :ref:`object_collectives` for details.
+        limitations.
 
     .. warning::
         :func:`scatter_object_list` uses ``pickle`` module implicitly, which

--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -56,7 +56,7 @@ pip install --pre torch torchcomms --index-url https://download.pytorch.org/whl/
 
 ### Building from Source
 
-#### Prerequisites
+#### Build Prerequisites
 
 - CMake 3.22 or higher
 - Ninja 1.10 or higher


### PR DESCRIPTION
Summary:
D94889999 exposed a pre-existing RST formatting issue in the
FlightRecorderHook pybind11 docstring. Moving the class to a
standalone pybind11 extension allowed Sphinx to introspect its
docstring for the first time, revealing an "Unexpected indentation"
error that breaks the GitHub docs CI build.

The fix replaces a plain-text colon (which RST doesn't recognize as
introducing a code block) with a proper Napoleon `Example:` section
header.

Differential Revision: D95226172


