### PR TITLE
Add conda feedstock for libpipes.so

### DIFF
--- a/comms/pipes/Checks.h
+++ b/comms/pipes/Checks.h
@@ -1,0 +1,23 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+#define PIPES_CUDA_CHECK(EXPR)                      \
+  do {                                              \
+    const cudaError_t err = EXPR;                   \
+    if (err == cudaSuccess) {                       \
+      break;                                        \
+    }                                               \
+    std::string error_message;                      \
+    error_message.append(__FILE__);                 \
+    error_message.append(":");                      \
+    error_message.append(std::to_string(__LINE__)); \
+    error_message.append(" CUDA error: ");          \
+    error_message.append(cudaGetErrorString(err));  \
+    throw std::runtime_error(error_message);        \
+  } while (0)
+
+#define PIPES_KERNEL_LAUNCH_CHECK() PIPES_CUDA_CHECK(cudaGetLastError())

--- a/comms/pipes/Transport.cuh
+++ b/comms/pipes/Transport.cuh
@@ -31,7 +31,11 @@ class P2pIbgdaTransportDevice;
  * Transport type tag for discriminated union.
  * Used to identify which transport type is active in the Transport union.
  */
-enum class TransportType : uint8_t { SELF, P2P_NVL, P2P_IBGDA };
+enum class TransportType : uint8_t {
+  SELF,
+  P2P_NVL,
+  P2P_IBGDA,
+};
 
 /**
  * Polymorphic transport wrapper using tagged union.
@@ -75,7 +79,6 @@ struct Transport {
   /** Constructor for P2pIbgdaTransportDevice (non-owning pointer) */
   __host__ __device__ explicit Transport(P2pIbgdaTransportDevice* p)
       : type(TransportType::P2P_IBGDA), p2p_ibgda(p) {}
-
   /**
    * Delete copy constructor and copy assignment.
    * Transport objects contain device pointers and IPC handles that should not

--- a/comms/pipes/collectives/AllToAllv.cu
+++ b/comms/pipes/collectives/AllToAllv.cu
@@ -3,8 +3,8 @@
 #include "comms/pipes/collectives/AllToAllv.h"
 
 #include "comms/common/CudaWrap.h"
+#include "comms/pipes/Checks.h"
 #include "comms/pipes/TimeoutUtils.h"
-#include "comms/pipes/tests/Checks.h"
 
 namespace comms::pipes {
 

--- a/comms/pipes/collectives/Dispatchv.cu
+++ b/comms/pipes/collectives/Dispatchv.cu
@@ -3,8 +3,8 @@
 #include "comms/pipes/collectives/Dispatchv.cuh"
 #include "comms/pipes/collectives/Dispatchv.h"
 
+#include "comms/pipes/Checks.h"
 #include "comms/pipes/ThreadGroup.cuh"
-#include "comms/pipes/tests/Checks.h"
 
 namespace comms::pipes {
 

--- a/comms/pipes/tests/Checks.h
+++ b/comms/pipes/tests/Checks.h
@@ -1,23 +1,8 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
+// This header now lives at comms/pipes/Checks.h.
+// This forwarding header is kept for backward compatibility with existing
+// tests.
 #pragma once
 
-#include <stdexcept>
-#include <string>
-
-#define PIPES_CUDA_CHECK(EXPR)                      \
-  do {                                              \
-    const cudaError_t err = EXPR;                   \
-    if (err == cudaSuccess) {                       \
-      break;                                        \
-    }                                               \
-    std::string error_message;                      \
-    error_message.append(__FILE__);                 \
-    error_message.append(":");                      \
-    error_message.append(std::to_string(__LINE__)); \
-    error_message.append(" CUDA error: ");          \
-    error_message.append(cudaGetErrorString(err));  \
-    throw std::runtime_error(error_message);        \
-  } while (0)
-
-#define PIPES_KERNEL_LAUNCH_CHECK() PIPES_CUDA_CHECK(cudaGetLastError())
+#include "comms/pipes/Checks.h"


### PR DESCRIPTION
Summary:
Add a conda feedstock that builds libpipes.so from source. With DOCA
now available as a conda package (parent diff D94712101), the
standalone build always compiles IBGDA sources and links
doca_gpunetio — there is no USE_IBGDA toggle.

## Pipes conda feedstock

- CMakeLists.txt (180 lines): C++20/CUDA, sm_90a (required for IBGDA
  instructions), symbol visibility hidden with --exclude-libs,ALL to
  avoid conflicts with folly/gflags/glog copies in libnccl.so.
  Compiles 9 .cc + 3 .cu files. Always links
  doca_gpunetio/ibverbs/mlx5 (IBGDA unconditionally enabled).
- build_pipes.sh (181 lines): Builds gflags+glog from source into
  /tmp/third-party-install, optionally builds folly from fbcode
  source, then runs cmake+ninja. Pattern follows build_mccl.sh.
  Dead env vars (LIB_SUFFIX, NVCC_GENCODE, TORCH_CUDA_ARCH_LIST)
  removed — pipes uses CMAKE_CUDA_ARCHITECTURES hardcoded in
  CMakeLists.txt, not these shell variables.
- pipes_iter.sh (153 lines): Iterative dev build for local and
  Sandcastle. Supports H100 (sm_90a) and GB200 (sm_100a).
- Conda recipe with doca, rdma-core, folly, glog, gflags, fmt,
  libboost as deps. Folly/gflags statically linked (host-only).
- BUCK targets and standalone test config (pipes.toml).

## Checks.h relocation

Production code (AllToAllv.cu, Dispatchv.cu) was including from
tests/Checks.h. Moved PIPES_CUDA_CHECK macros to comms/pipes/Checks.h,
updated BUCK deps, left forwarding header in tests/ for compat.

## Transport.cuh formatting

Expanded TransportType enum from single-line to multi-line format.

Reviewed By: tanquer

Differential Revision: D94712118


