### PR TITLE
Add LL128 packet structure (#924)

### DIFF
--- a/comms/pipes/ll128/Ll128Packet.cuh
+++ b/comms/pipes/ll128/Ll128Packet.cuh
@@ -1,0 +1,280 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include "comms/common/AtomicUtils.cuh"
+#include "comms/common/DeviceConstants.cuh"
+
+using comms::device::kWarpSize;
+
+namespace comms::pipes {
+
+// =============================================================================
+// LL128 Protocol Constants
+// =============================================================================
+
+/// Total size of one LL128 packet (one cache line).
+static constexpr size_t kLl128PacketSize = 128;
+
+/// Usable payload bytes per packet (128B - 8B flag).
+static constexpr size_t kLl128PayloadSize = 120;
+
+/// Byte offset of the 8-byte flag within a packet.
+static constexpr size_t kLl128FlagOffset = 120;
+
+/// Number of threads that cooperate to read/write one packet.
+static constexpr int kLl128ThreadsPerPacket = 8;
+
+/// Lane index of the flag-owning thread within each 8-thread group.
+static constexpr int kLl128FlagLane = kLl128ThreadsPerPacket - 1;
+
+/// Number of packets processed simultaneously by one warp (32 / 8).
+static constexpr int kLl128PacketsPerWarp = kWarpSize / kLl128ThreadsPerPacket;
+
+/// Payload bytes processed by one warp per iteration (4 * 120).
+static constexpr size_t kLl128PayloadPerWarp =
+    kLl128PacketsPerWarp * kLl128PayloadSize;
+
+/// LL128 flag protocol states.
+/// Positive flag_value values indicate "data ready for step N".
+enum class Ll128FlagState : int64_t {
+  READY_TO_WRITE = -1,
+};
+
+/// Convenience constant — avoids verbose static_cast in comparisons.
+static constexpr int64_t kLl128ReadyToWrite =
+    static_cast<int64_t>(Ll128FlagState::READY_TO_WRITE);
+
+/// Byte value used with cudaMemset to initialize LL128 packet flags to
+/// kLl128ReadyToWrite (-1). All-ones = -1 in two's complement int64_t.
+static constexpr int kLl128MemsetInitByte = 0xFF;
+
+// =============================================================================
+// Ll128Packet — 128-byte aligned packet with inline flag
+// =============================================================================
+
+/**
+ * Ll128Packet - A 128-byte cache-line-aligned packet for the LL128 protocol.
+ *
+ * Layout:
+ *   data[0..6] — 7 × 16B = 112B pure payload
+ *   data[7]    — 8B payload + 8B flag (int64_t)
+ *   Total: 128B = 120B payload + 8B flag
+ *
+ * The 8-byte flag (last 8 bytes of data[7]) serves as inline control:
+ *   Sender → Receiver: flag = flag_value (positive) means "data ready"
+ *   Receiver → Sender: flag = kLl128ReadyToWrite (-1) means "safe to overwrite"
+ *
+ * NVLink writes of 128 bytes to a 128-byte-aligned address are atomic at the
+ * cache-line level: the receiver sees either the complete old or complete new
+ * cache line. The flag being part of the same transaction is the atomicity
+ * indicator.
+ */
+struct alignas(128) Ll128Packet {
+  uint4 data[8]; // 8 × 16B = 128B
+
+  /// Volatile-load the flag value.
+  __device__ __forceinline__ int64_t load_flag() const;
+
+  /// Volatile-store the flag value.
+  __device__ __forceinline__ void store_flag(int64_t flag);
+
+  /// ACK: signal that this packet's buffer is safe to overwrite.
+  __device__ __forceinline__ void ack();
+};
+
+static_assert(sizeof(Ll128Packet) == 128, "Ll128Packet must be exactly 128B");
+static_assert(
+    alignof(Ll128Packet) == 128,
+    "Ll128Packet must be 128-byte aligned");
+
+// =============================================================================
+// Device-side Helpers
+// =============================================================================
+
+/**
+ * Return a pointer to the 16B slot for the given lane within a packet.
+ *
+ * Each 8-thread group writes one slot:
+ *   lane 0 → data[0], lane 1 → data[1], ..., lane 7 → data[7]
+ *
+ * The returned pointer is suitable for load128_volatile_global /
+ * store128_volatile_global (which operate on uint64_t pairs).
+ *
+ * @param pkt Reference to the packet
+ * @param lane_in_group Lane index within the 8-thread group [0, 7]
+ * @return Pointer to two consecutive uint64_t values (16B)
+ */
+__device__ __forceinline__ volatile uint64_t* ll128_slot_ptr(
+    Ll128Packet& pkt,
+    int lane_in_group) {
+  return reinterpret_cast<volatile uint64_t*>(&pkt.data[lane_in_group]);
+}
+
+__device__ __forceinline__ const volatile uint64_t* ll128_slot_ptr(
+    const Ll128Packet& pkt,
+    int lane_in_group) {
+  return reinterpret_cast<const volatile uint64_t*>(&pkt.data[lane_in_group]);
+}
+
+/**
+ * Return a pointer to the 8-byte flag field within a packet.
+ *
+ * The flag occupies the last 8 bytes of data[7] (bytes 120-127).
+ * data[7] is a uint4 = {x, y, z, w}. As two uint64_t values, the flag
+ * is the second uint64_t (bytes 8-15 of data[7] = bytes 120-127 of packet).
+ *
+ * @param pkt Reference to the packet
+ * @return Pointer to the flag as volatile int64_t
+ */
+__device__ __forceinline__ volatile int64_t* ll128_flag_ptr(Ll128Packet& pkt) {
+  // data[7] starts at byte 112. As uint64_t*, [0] = bytes 112-119 (payload),
+  // [1] = bytes 120-127 (flag).
+  auto* base = reinterpret_cast<volatile int64_t*>(&pkt.data[kLl128FlagLane]);
+  return base + 1;
+}
+
+__device__ __forceinline__ const volatile int64_t* ll128_flag_ptr(
+    const Ll128Packet& pkt) {
+  auto* base =
+      reinterpret_cast<const volatile int64_t*>(&pkt.data[kLl128FlagLane]);
+  return base + 1;
+}
+
+/**
+ * Volatile-load the 8-byte flag from a packet (polling-efficient).
+ *
+ * Uses an 8-byte volatile load rather than a 16-byte load, halving
+ * polling bandwidth compared to loading the full data[7] slot.
+ *
+ * @param pkt The packet to read from
+ * @return The current flag value
+ */
+__device__ __forceinline__ int64_t ll128_load_flag(const Ll128Packet& pkt) {
+#ifdef __CUDA_ARCH__
+  return static_cast<int64_t>(comms::device::ld_volatile_global(
+      reinterpret_cast<const volatile uint64_t*>(ll128_flag_ptr(pkt))));
+#else
+  (void)pkt;
+  return 0;
+#endif
+}
+
+/**
+ * Volatile-store the 8-byte flag in a packet.
+ *
+ * @param pkt The packet to write to
+ * @param flag The flag value to store
+ */
+__device__ __forceinline__ void ll128_store_flag(
+    Ll128Packet& pkt,
+    int64_t flag) {
+#ifdef __CUDA_ARCH__
+  comms::device::st_volatile_global(
+      reinterpret_cast<volatile uint64_t*>(ll128_flag_ptr(pkt)),
+      static_cast<uint64_t>(flag));
+#else
+  (void)pkt;
+  (void)flag;
+#endif
+}
+
+// =============================================================================
+// Ll128Packet method implementations
+// =============================================================================
+
+__device__ __forceinline__ int64_t Ll128Packet::load_flag() const {
+  return ll128_load_flag(*this);
+}
+
+__device__ __forceinline__ void Ll128Packet::store_flag(int64_t flag) {
+  ll128_store_flag(*this, flag);
+}
+
+__device__ __forceinline__ void Ll128Packet::ack() {
+  store_flag(static_cast<int64_t>(Ll128FlagState::READY_TO_WRITE));
+}
+
+// =============================================================================
+// Host/Device Utility Functions
+// =============================================================================
+
+/**
+ * Compute the number of valid payload bytes for a given packet index.
+ *
+ * @param packet_idx Zero-based packet index
+ * @param total_bytes Total message size in bytes
+ * @return Valid payload bytes for this packet [0, kLl128PayloadSize]
+ */
+__host__ __device__ __forceinline__ size_t
+ll128_packet_payload_size(size_t packet_idx, size_t total_bytes) {
+  size_t offset = packet_idx * kLl128PayloadSize;
+  if (offset >= total_bytes) {
+    return 0;
+  }
+  size_t remaining = total_bytes - offset;
+  return remaining < kLl128PayloadSize ? remaining : kLl128PayloadSize;
+}
+
+/**
+ * Compute the total number of LL128 packets needed for a message.
+ *
+ * @param nbytes Message size in bytes
+ * @return Number of packets (0 if nbytes == 0)
+ */
+__host__ __device__ __forceinline__ size_t ll128_num_packets(size_t nbytes) {
+  if (nbytes == 0) {
+    return 0;
+  }
+  return (nbytes + kLl128PayloadSize - 1) / kLl128PayloadSize;
+}
+
+/**
+ * Compute the LL128 buffer size needed for a given max message size.
+ *
+ * @param max_message_size Maximum message size in bytes
+ * @return Buffer size in bytes (multiple of 128)
+ */
+__host__ __device__ __forceinline__ size_t
+ll128_buffer_size(size_t max_message_size) {
+  return ll128_num_packets(max_message_size) * kLl128PacketSize;
+}
+
+/**
+ * Compute the max payload bytes that fit in an LL128 buffer of a given size.
+ *
+ * Result is rounded down to a 16-byte multiple (LL128 alignment requirement).
+ *
+ * @param buffer_size_bytes Size of the LL128 buffer in bytes
+ * @return Maximum payload capacity in bytes (16-byte aligned)
+ */
+__host__ __device__ __forceinline__ size_t
+ll128_buffer_payload_capacity(size_t buffer_size_bytes) {
+  size_t num_packets = buffer_size_bytes / kLl128PacketSize;
+  size_t raw_capacity = num_packets * kLl128PayloadSize;
+  return (raw_capacity / 16) * 16;
+}
+
+/**
+ * Check whether the given pointer and byte count are eligible for LL128.
+ *
+ * LL128 requires:
+ *   - nbytes is a multiple of 16
+ *   - ptr is 16-byte aligned (or nullptr when nbytes == 0)
+ *
+ * @param ptr    Pointer to user data buffer (src or dst)
+ * @param nbytes Message size in bytes
+ * @return true if the arguments satisfy LL128 requirements
+ */
+__host__ __device__ __forceinline__ bool can_use_ll128(
+    const void* ptr,
+    size_t nbytes) {
+  if (nbytes == 0) {
+    return true;
+  }
+  return (nbytes % 16 == 0) && (reinterpret_cast<uintptr_t>(ptr) % 16 == 0);
+}
+
+} // namespace comms::pipes

--- a/comms/pipes/ll128/tests/Ll128PacketTest.cc
+++ b/comms/pipes/ll128/tests/Ll128PacketTest.cc
@@ -1,0 +1,182 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+#include <cstdint>
+
+#include "comms/pipes/ll128/Ll128Packet.cuh"
+#include "comms/pipes/ll128/tests/Ll128PacketTest.cuh"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/CudaRAII.h"
+
+using meta::comms::DeviceBuffer;
+
+namespace comms::pipes {
+
+class Ll128PacketTestFixture : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    CUDACHECK_TEST(cudaSetDevice(0));
+  }
+
+  void TearDown() override {
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+  }
+};
+
+TEST_F(Ll128PacketTestFixture, Alignment) {
+  DeviceBuffer errorCountBuffer(sizeof(uint32_t));
+  auto* errorCount_d = static_cast<uint32_t*>(errorCountBuffer.get());
+  CUDACHECK_TEST(cudaMemset(errorCount_d, 0, sizeof(uint32_t)));
+
+  test::test_ll128_packet_alignment(errorCount_d);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  uint32_t errorCount_h = 0;
+  CUDACHECK_TEST(cudaMemcpy(
+      &errorCount_h, errorCount_d, sizeof(uint32_t), cudaMemcpyDeviceToHost));
+  EXPECT_EQ(errorCount_h, 0) << "Packet alignment/size checks failed";
+}
+
+TEST_F(Ll128PacketTestFixture, FlagReadWrite) {
+  DeviceBuffer packetBuffer(sizeof(Ll128Packet));
+  CUDACHECK_TEST(cudaMemset(packetBuffer.get(), 0, sizeof(Ll128Packet)));
+
+  DeviceBuffer errorCountBuffer(sizeof(uint32_t));
+  auto* errorCount_d = static_cast<uint32_t*>(errorCountBuffer.get());
+  CUDACHECK_TEST(cudaMemset(errorCount_d, 0, sizeof(uint32_t)));
+
+  test::test_ll128_flag_read_write(packetBuffer.get(), errorCount_d);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  uint32_t errorCount_h = 0;
+  CUDACHECK_TEST(cudaMemcpy(
+      &errorCount_h, errorCount_d, sizeof(uint32_t), cudaMemcpyDeviceToHost));
+  EXPECT_EQ(errorCount_h, 0) << "Flag read/write round-trip failed";
+}
+
+TEST_F(Ll128PacketTestFixture, PayloadSize) {
+  DeviceBuffer errorCountBuffer(sizeof(uint32_t));
+  auto* errorCount_d = static_cast<uint32_t*>(errorCountBuffer.get());
+  CUDACHECK_TEST(cudaMemset(errorCount_d, 0, sizeof(uint32_t)));
+
+  test::test_ll128_packet_payload_size(errorCount_d);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  uint32_t errorCount_h = 0;
+  CUDACHECK_TEST(cudaMemcpy(
+      &errorCount_h, errorCount_d, sizeof(uint32_t), cudaMemcpyDeviceToHost));
+  EXPECT_EQ(errorCount_h, 0) << "Payload size calculation failed";
+}
+
+TEST_F(Ll128PacketTestFixture, NumPackets) {
+  DeviceBuffer errorCountBuffer(sizeof(uint32_t));
+  auto* errorCount_d = static_cast<uint32_t*>(errorCountBuffer.get());
+  CUDACHECK_TEST(cudaMemset(errorCount_d, 0, sizeof(uint32_t)));
+
+  test::test_ll128_num_packets(errorCount_d);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  uint32_t errorCount_h = 0;
+  CUDACHECK_TEST(cudaMemcpy(
+      &errorCount_h, errorCount_d, sizeof(uint32_t), cudaMemcpyDeviceToHost));
+  EXPECT_EQ(errorCount_h, 0) << "Num packets calculation failed";
+}
+
+TEST_F(Ll128PacketTestFixture, SlotPtr) {
+  DeviceBuffer errorCountBuffer(sizeof(uint32_t));
+  auto* errorCount_d = static_cast<uint32_t*>(errorCountBuffer.get());
+  CUDACHECK_TEST(cudaMemset(errorCount_d, 0, sizeof(uint32_t)));
+
+  test::test_ll128_slot_ptr(errorCount_d);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  uint32_t errorCount_h = 0;
+  CUDACHECK_TEST(cudaMemcpy(
+      &errorCount_h, errorCount_d, sizeof(uint32_t), cudaMemcpyDeviceToHost));
+  EXPECT_EQ(errorCount_h, 0) << "Slot pointer addresses incorrect";
+}
+
+TEST_F(Ll128PacketTestFixture, FlagInitViaCudaMemset) {
+  // Allocate a packet on device, memset to 0xFF, verify flag == -1
+  DeviceBuffer packetBuffer(sizeof(Ll128Packet));
+  DeviceBuffer errorCountBuffer(sizeof(uint32_t));
+  auto* errorCount_d = static_cast<uint32_t*>(errorCountBuffer.get());
+  CUDACHECK_TEST(cudaMemset(errorCount_d, 0, sizeof(uint32_t)));
+
+  // 0xFF fills all bytes, int64_t all-ones = -1 in two's complement
+  CUDACHECK_TEST(cudaMemset(
+      packetBuffer.get(), kLl128MemsetInitByte, sizeof(Ll128Packet)));
+
+  test::test_ll128_flag_init(packetBuffer.get(), errorCount_d);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  uint32_t errorCount_h = 0;
+  CUDACHECK_TEST(cudaMemcpy(
+      &errorCount_h, errorCount_d, sizeof(uint32_t), cudaMemcpyDeviceToHost));
+  EXPECT_EQ(errorCount_h, 0)
+      << "cudaMemset 0xFF should produce flag == kLl128ReadyToWrite (-1)";
+}
+
+TEST_F(Ll128PacketTestFixture, HostPayloadSizeCalculation) {
+  // Verify the host-side versions of the helper functions
+  EXPECT_EQ(ll128_packet_payload_size(0, 0), 0u);
+  EXPECT_EQ(ll128_packet_payload_size(0, 1), 1u);
+  EXPECT_EQ(ll128_packet_payload_size(0, 120), 120u);
+  EXPECT_EQ(ll128_packet_payload_size(0, 121), 120u);
+  EXPECT_EQ(ll128_packet_payload_size(1, 121), 1u);
+
+  EXPECT_EQ(ll128_num_packets(0), 0u);
+  EXPECT_EQ(ll128_num_packets(1), 1u);
+  EXPECT_EQ(ll128_num_packets(120), 1u);
+  EXPECT_EQ(ll128_num_packets(121), 2u);
+  EXPECT_EQ(ll128_num_packets(65536), 547u);
+
+  EXPECT_EQ(ll128_buffer_size(0), 0u);
+  EXPECT_EQ(ll128_buffer_size(120), 128u);
+  EXPECT_EQ(ll128_buffer_size(121), 256u);
+  EXPECT_EQ(ll128_buffer_size(65536), 547u * 128u);
+}
+
+TEST_F(Ll128PacketTestFixture, HostCanUseLl128) {
+  // nbytes == 0 is always eligible regardless of pointer
+  EXPECT_TRUE(can_use_ll128(nullptr, 0));
+  EXPECT_TRUE(can_use_ll128(reinterpret_cast<const void*>(uintptr_t(1)), 0));
+
+  // Aligned pointer (0x100) + multiple of 16
+  auto* aligned = reinterpret_cast<const void*>(uintptr_t(0x100));
+  EXPECT_TRUE(can_use_ll128(aligned, 16));
+  EXPECT_TRUE(can_use_ll128(aligned, 32));
+  EXPECT_TRUE(can_use_ll128(aligned, 1024));
+
+  // Aligned pointer + NOT multiple of 16
+  EXPECT_FALSE(can_use_ll128(aligned, 1));
+  EXPECT_FALSE(can_use_ll128(aligned, 15));
+  EXPECT_FALSE(can_use_ll128(aligned, 17));
+
+  // Misaligned pointer (0x101) + multiple of 16
+  auto* misaligned = reinterpret_cast<const void*>(uintptr_t(0x101));
+  EXPECT_FALSE(can_use_ll128(misaligned, 16));
+  EXPECT_FALSE(can_use_ll128(misaligned, 32));
+
+  // Misaligned + not multiple of 16
+  EXPECT_FALSE(can_use_ll128(misaligned, 17));
+}
+
+TEST_F(Ll128PacketTestFixture, CanUseLl128) {
+  DeviceBuffer alignedBuffer(256); // cudaMalloc guarantees >= 256B alignment
+  DeviceBuffer errorCountBuffer(sizeof(uint32_t));
+  auto* errorCount_d = static_cast<uint32_t*>(errorCountBuffer.get());
+  CUDACHECK_TEST(cudaMemset(errorCount_d, 0, sizeof(uint32_t)));
+
+  test::test_can_use_ll128(
+      static_cast<const char*>(alignedBuffer.get()), errorCount_d);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  uint32_t errorCount_h = 0;
+  CUDACHECK_TEST(cudaMemcpy(
+      &errorCount_h, errorCount_d, sizeof(uint32_t), cudaMemcpyDeviceToHost));
+  EXPECT_EQ(errorCount_h, 0) << "can_use_ll128 device-side checks failed";
+}
+
+} // namespace comms::pipes

--- a/comms/pipes/ll128/tests/Ll128PacketTest.cu
+++ b/comms/pipes/ll128/tests/Ll128PacketTest.cu
@@ -1,0 +1,288 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <cstdint>
+
+#include "comms/pipes/ll128/Ll128Packet.cuh"
+#include "comms/pipes/tests/Checks.h"
+
+namespace comms::pipes::test {
+
+using namespace comms::pipes;
+
+// =============================================================================
+// Alignment and Size Tests
+// =============================================================================
+
+__global__ void test_ll128_packet_alignment_kernel(uint32_t* errorCount) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    // Verify struct size
+    if (sizeof(Ll128Packet) != 128) {
+      atomicAdd(errorCount, 1);
+    }
+
+    // Verify alignment
+    if (alignof(Ll128Packet) != 128) {
+      atomicAdd(errorCount, 1);
+    }
+
+    // Verify an on-stack packet is aligned (note: __shared__ guarantees this)
+    __shared__ Ll128Packet pkt;
+    uintptr_t addr = reinterpret_cast<uintptr_t>(&pkt);
+    if (addr % 128 != 0) {
+      atomicAdd(errorCount, 1);
+    }
+  }
+}
+
+void test_ll128_packet_alignment(uint32_t* errorCount_d) {
+  test_ll128_packet_alignment_kernel<<<1, 1>>>(errorCount_d);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+// =============================================================================
+// Flag Read/Write Tests
+// =============================================================================
+
+__global__ void test_ll128_flag_read_write_kernel(
+    Ll128Packet* pkt,
+    uint32_t* errorCount) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    // Write flag = kLl128ReadyToWrite (-1)
+    ll128_store_flag(*pkt, kLl128ReadyToWrite);
+    int64_t flag = ll128_load_flag(*pkt);
+    if (flag != kLl128ReadyToWrite) {
+      printf(
+          "Flag read/write mismatch: expected %lld, got %lld\n",
+          (long long)kLl128ReadyToWrite,
+          (long long)flag);
+      atomicAdd(errorCount, 1);
+    }
+
+    // Write flag = 1 (step ID)
+    ll128_store_flag(*pkt, 1);
+    flag = ll128_load_flag(*pkt);
+    if (flag != 1) {
+      printf(
+          "Flag read/write mismatch: expected 1, got %lld\n", (long long)flag);
+      atomicAdd(errorCount, 1);
+    }
+
+    // Write flag = 42
+    ll128_store_flag(*pkt, 42);
+    flag = ll128_load_flag(*pkt);
+    if (flag != 42) {
+      printf(
+          "Flag read/write mismatch: expected 42, got %lld\n", (long long)flag);
+      atomicAdd(errorCount, 1);
+    }
+  }
+}
+
+void test_ll128_flag_read_write(void* packet_d, uint32_t* errorCount_d) {
+  test_ll128_flag_read_write_kernel<<<1, 1>>>(
+      static_cast<Ll128Packet*>(packet_d), errorCount_d);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+// =============================================================================
+// Payload Size Calculation Tests
+// =============================================================================
+
+__global__ void test_ll128_packet_payload_size_kernel(uint32_t* errorCount) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    // 0 bytes total → packet 0 has 0 payload
+    if (ll128_packet_payload_size(0, 0) != 0) {
+      atomicAdd(errorCount, 1);
+    }
+
+    // 1 byte total → packet 0 has 1 payload byte
+    if (ll128_packet_payload_size(0, 1) != 1) {
+      atomicAdd(errorCount, 1);
+    }
+
+    // 119 bytes total → packet 0 has 119 payload bytes
+    if (ll128_packet_payload_size(0, 119) != 119) {
+      atomicAdd(errorCount, 1);
+    }
+
+    // Exactly 120 bytes → packet 0 has 120 payload bytes
+    if (ll128_packet_payload_size(0, 120) != 120) {
+      atomicAdd(errorCount, 1);
+    }
+
+    // 121 bytes → packet 0 has 120, packet 1 has 1
+    if (ll128_packet_payload_size(0, 121) != 120) {
+      atomicAdd(errorCount, 1);
+    }
+    if (ll128_packet_payload_size(1, 121) != 1) {
+      atomicAdd(errorCount, 1);
+    }
+
+    // 240 bytes → 2 full packets
+    if (ll128_packet_payload_size(0, 240) != 120) {
+      atomicAdd(errorCount, 1);
+    }
+    if (ll128_packet_payload_size(1, 240) != 120) {
+      atomicAdd(errorCount, 1);
+    }
+
+    // 241 bytes → 2 full + 1 partial
+    if (ll128_packet_payload_size(2, 241) != 1) {
+      atomicAdd(errorCount, 1);
+    }
+
+    // Out-of-range packet → 0
+    if (ll128_packet_payload_size(1, 120) != 0) {
+      atomicAdd(errorCount, 1);
+    }
+    if (ll128_packet_payload_size(10, 120) != 0) {
+      atomicAdd(errorCount, 1);
+    }
+  }
+}
+
+void test_ll128_packet_payload_size(uint32_t* errorCount_d) {
+  test_ll128_packet_payload_size_kernel<<<1, 1>>>(errorCount_d);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+// =============================================================================
+// Num Packets Tests
+// =============================================================================
+
+__global__ void test_ll128_num_packets_kernel(uint32_t* errorCount) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    if (ll128_num_packets(0) != 0) {
+      atomicAdd(errorCount, 1);
+    }
+    if (ll128_num_packets(1) != 1) {
+      atomicAdd(errorCount, 1);
+    }
+    if (ll128_num_packets(119) != 1) {
+      atomicAdd(errorCount, 1);
+    }
+    if (ll128_num_packets(120) != 1) {
+      atomicAdd(errorCount, 1);
+    }
+    if (ll128_num_packets(121) != 2) {
+      atomicAdd(errorCount, 1);
+    }
+    if (ll128_num_packets(240) != 2) {
+      atomicAdd(errorCount, 1);
+    }
+    if (ll128_num_packets(241) != 3) {
+      atomicAdd(errorCount, 1);
+    }
+    // 64KB
+    if (ll128_num_packets(65536) != 547) {
+      atomicAdd(errorCount, 1);
+    }
+  }
+}
+
+void test_ll128_num_packets(uint32_t* errorCount_d) {
+  test_ll128_num_packets_kernel<<<1, 1>>>(errorCount_d);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+// =============================================================================
+// Slot Pointer Tests
+// =============================================================================
+
+__global__ void test_ll128_slot_ptr_kernel(uint32_t* errorCount) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    __shared__ Ll128Packet pkt;
+
+    auto* pkt_base = reinterpret_cast<volatile uint64_t*>(&pkt);
+
+    // Each lane's slot pointer should point to data[lane] = pkt_base + lane*2
+    for (int lane = 0; lane < 8; ++lane) {
+      volatile uint64_t* slot = ll128_slot_ptr(pkt, lane);
+      volatile uint64_t* expected = pkt_base + lane * 2;
+      if (slot != expected) {
+        printf(
+            "Slot ptr mismatch for lane %d: expected %p, got %p\n",
+            lane,
+            (void*)expected,
+            (void*)slot);
+        atomicAdd(errorCount, 1);
+      }
+    }
+  }
+}
+
+void test_ll128_slot_ptr(uint32_t* errorCount_d) {
+  test_ll128_slot_ptr_kernel<<<1, 1>>>(errorCount_d);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+// =============================================================================
+// Flag Initialization Test (cudaMemset 0xFF → kLl128ReadyToWrite)
+// =============================================================================
+
+__global__ void test_ll128_flag_init_kernel(
+    Ll128Packet* pkt,
+    uint32_t* errorCount) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    int64_t flag = ll128_load_flag(*pkt);
+    if (flag != kLl128ReadyToWrite) {
+      printf(
+          "Flag init mismatch: expected %lld (-1), got %lld\n",
+          (long long)kLl128ReadyToWrite,
+          (long long)flag);
+      atomicAdd(errorCount, 1);
+    }
+  }
+}
+
+void test_ll128_flag_init(void* packet_d, uint32_t* errorCount_d) {
+  test_ll128_flag_init_kernel<<<1, 1>>>(
+      static_cast<Ll128Packet*>(packet_d), errorCount_d);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+// =============================================================================
+// can_use_ll128 Tests
+// =============================================================================
+
+__global__ void test_can_use_ll128_kernel(
+    const char* aligned_ptr,
+    uint32_t* errorCount) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    // nbytes == 0 always eligible
+    if (!can_use_ll128(nullptr, 0))
+      atomicAdd(errorCount, 1);
+    if (!can_use_ll128(aligned_ptr + 1, 0))
+      atomicAdd(errorCount, 1);
+
+    // Aligned + multiple of 16
+    if (!can_use_ll128(aligned_ptr, 16))
+      atomicAdd(errorCount, 1);
+    if (!can_use_ll128(aligned_ptr, 32))
+      atomicAdd(errorCount, 1);
+
+    // Aligned + NOT multiple of 16
+    if (can_use_ll128(aligned_ptr, 1))
+      atomicAdd(errorCount, 1);
+    if (can_use_ll128(aligned_ptr, 15))
+      atomicAdd(errorCount, 1);
+    if (can_use_ll128(aligned_ptr, 17))
+      atomicAdd(errorCount, 1);
+
+    // Misaligned (ptr+1) + multiple of 16
+    if (can_use_ll128(aligned_ptr + 1, 16))
+      atomicAdd(errorCount, 1);
+
+    // Misaligned + not multiple of 16
+    if (can_use_ll128(aligned_ptr + 1, 17))
+      atomicAdd(errorCount, 1);
+  }
+}
+
+void test_can_use_ll128(const char* aligned_ptr_d, uint32_t* errorCount_d) {
+  test_can_use_ll128_kernel<<<1, 1>>>(aligned_ptr_d, errorCount_d);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+} // namespace comms::pipes::test

--- a/comms/pipes/ll128/tests/Ll128PacketTest.cuh
+++ b/comms/pipes/ll128/tests/Ll128PacketTest.cuh
@@ -1,0 +1,30 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+
+namespace comms::pipes::test {
+
+/// Test that Ll128Packet is 128-byte aligned and sized.
+void test_ll128_packet_alignment(uint32_t* errorCount_d);
+
+/// Test flag read/write round-trip via volatile helpers.
+void test_ll128_flag_read_write(void* packet_d, uint32_t* errorCount_d);
+
+/// Test ll128_packet_payload_size for various inputs.
+void test_ll128_packet_payload_size(uint32_t* errorCount_d);
+
+/// Test ll128_num_packets for various message sizes.
+void test_ll128_num_packets(uint32_t* errorCount_d);
+
+/// Test ll128_slot_ptr returns correct addresses for each lane.
+void test_ll128_slot_ptr(uint32_t* errorCount_d);
+
+/// Test flag initialization to kLl128ReadyToWrite via cudaMemset 0xFF.
+void test_ll128_flag_init(void* packet_d, uint32_t* errorCount_d);
+
+/// Test can_use_ll128 on device side.
+void test_can_use_ll128(const char* aligned_ptr_d, uint32_t* errorCount_d);
+
+} // namespace comms::pipes::test


### PR DESCRIPTION
Summary:

Add the foundational LL128 packet data structure with:
- **`Ll128Packet` struct:** 128-byte cache-line-aligned packet
- **Constants:** `kLl128PacketSize`, `kLl128PayloadSize`, `kLl128FlagOffset`
- **Device helpers:** `ll128_load_flag`, `ll128_store_flag`, `ll128_slot_ptr`
- **Host/device helpers:** `ll128_packet_payload_size`, `ll128_num_packets`, `ll128_buffer_size`
- **`can_use_ll128` utility:** Host/device pre-check for LL128 eligibility (16-byte alignment + nbytes multiple of 16), enabling callers to implement graceful fallback logic instead of hitting fatal `__trap()` assertions
- Unit tests for packet alignment, flag read/write, payload size calculation, and `can_use_ll128` (both host and device)

Reviewed By: dmwu, siyengar

Differential Revision: D94943423


