### PR TITLE
Add allGatherNvlDomain and barrierNvlDomain to bootstrap adapters

### DIFF
--- a/comms/ncclx/v2_28/meta/ctran-integration/BaselineBootstrap.cc
+++ b/comms/ncclx/v2_28/meta/ctran-integration/BaselineBootstrap.cc
@@ -48,6 +48,35 @@ folly::SemiFuture<int> BaselineBootstrap::barrierIntraNode(
   return folly::makeSemiFuture<int>(static_cast<int>(res));
 }
 
+folly::SemiFuture<int> BaselineBootstrap::allGatherNvlDomain(
+    void* buf,
+    int len,
+    int nvlLocalRank,
+    int nvlNranks,
+    std::vector<int> nvlRankToCommRank) {
+  auto res = bootstrapIntraNodeAllGather(
+      comm_->bootstrap,
+      nvlRankToCommRank.data(),
+      nvlLocalRank,
+      nvlNranks,
+      buf,
+      len);
+  return folly::makeSemiFuture<int>(static_cast<int>(res));
+}
+
+folly::SemiFuture<int> BaselineBootstrap::barrierNvlDomain(
+    int nvlLocalRank,
+    int nvlNranks,
+    std::vector<int> nvlRankToCommRank) {
+  auto res = bootstrapIntraNodeBarrier(
+      comm_->bootstrap,
+      nvlRankToCommRank.data(),
+      nvlLocalRank,
+      nvlNranks,
+      nvlRankToCommRank.at(0) /* tag */);
+  return folly::makeSemiFuture<int>(static_cast<int>(res));
+}
+
 folly::SemiFuture<int>
 BaselineBootstrap::send(void* buf, int len, int peer, int tag) {
   auto res = bootstrapSend(comm_->bootstrap, peer, tag, buf, len);

--- a/comms/ncclx/v2_28/meta/ctran-integration/BaselineBootstrap.h
+++ b/comms/ncclx/v2_28/meta/ctran-integration/BaselineBootstrap.h
@@ -29,6 +29,18 @@ class BaselineBootstrap : public ::ctran::bootstrap::IBootstrap {
       int localNranks,
       std::vector<int> localRankToCommRank) override;
 
+  virtual folly::SemiFuture<int> allGatherNvlDomain(
+      void* buf,
+      int len,
+      int nvlLocalRank,
+      int nvlNranks,
+      std::vector<int> nvlRankToCommRank) override;
+
+  virtual folly::SemiFuture<int> barrierNvlDomain(
+      int nvlLocalRank,
+      int nvlNranks,
+      std::vector<int> nvlRankToCommRank) override;
+
   virtual folly::SemiFuture<int> send(void* buf, int len, int peer, int tag)
       override;
 

--- a/comms/ncclx/v2_29/meta/ctran-integration/BaselineBootstrap.cc
+++ b/comms/ncclx/v2_29/meta/ctran-integration/BaselineBootstrap.cc
@@ -48,6 +48,35 @@ folly::SemiFuture<int> BaselineBootstrap::barrierIntraNode(
   return folly::makeSemiFuture<int>(static_cast<int>(res));
 }
 
+folly::SemiFuture<int> BaselineBootstrap::allGatherNvlDomain(
+    void* buf,
+    int len,
+    int nvlLocalRank,
+    int nvlNranks,
+    std::vector<int> nvlRankToCommRank) {
+  auto res = bootstrapIntraNodeAllGather(
+      comm_->bootstrap,
+      nvlRankToCommRank.data(),
+      nvlLocalRank,
+      nvlNranks,
+      buf,
+      len);
+  return folly::makeSemiFuture<int>(static_cast<int>(res));
+}
+
+folly::SemiFuture<int> BaselineBootstrap::barrierNvlDomain(
+    int nvlLocalRank,
+    int nvlNranks,
+    std::vector<int> nvlRankToCommRank) {
+  auto res = bootstrapIntraNodeBarrier(
+      comm_->bootstrap,
+      nvlRankToCommRank.data(),
+      nvlLocalRank,
+      nvlNranks,
+      nvlRankToCommRank.at(0) /* tag */);
+  return folly::makeSemiFuture<int>(static_cast<int>(res));
+}
+
 folly::SemiFuture<int>
 BaselineBootstrap::send(void* buf, int len, int peer, int tag) {
   auto res = bootstrapSend(comm_->bootstrap, peer, tag, buf, len);

--- a/comms/ncclx/v2_29/meta/ctran-integration/BaselineBootstrap.h
+++ b/comms/ncclx/v2_29/meta/ctran-integration/BaselineBootstrap.h
@@ -29,6 +29,18 @@ class BaselineBootstrap : public ::ctran::bootstrap::IBootstrap {
       int localNranks,
       std::vector<int> localRankToCommRank) override;
 
+  virtual folly::SemiFuture<int> allGatherNvlDomain(
+      void* buf,
+      int len,
+      int nvlLocalRank,
+      int nvlNranks,
+      std::vector<int> nvlRankToCommRank) override;
+
+  virtual folly::SemiFuture<int> barrierNvlDomain(
+      int nvlLocalRank,
+      int nvlNranks,
+      std::vector<int> nvlRankToCommRank) override;
+
   virtual folly::SemiFuture<int> send(void* buf, int len, int peer, int tag)
       override;
 


### PR DESCRIPTION
Summary:
When NCCL_CTRAN_USE_PIPES is enabled, the Pipes MultiPeerTransport uses
TopologyDiscovery to detect NVLink peers. For NVL domains (which may span
multiple hosts on MNNVL systems like GB200), the NvlBootstrapAdapter
delegates allGather() to the underlying bootstrap's allGatherNvlDomain().

Both BaselineBootstrap (used by NCCL communicators) and CtranAdapter (used
by TCP Store-based bootstrap) were missing these NVL domain methods, causing
initialization to fail with:
  "Failed to initialize Pipes MultiPeerTransport: allGatherNvlDomain not implemented"

This fix adds allGatherNvlDomain() and barrierNvlDomain() implementations to:

1. **BaselineBootstrap** (NCCL-based): Delegates to bootstrapIntraNodeAllGather
   and bootstrapIntraNodeBarrier NCCL functions.

2. **CtranAdapter** (TCP Store-based): Delegates to semi_allGather(subRanks)
   and semi_barrier(subRanks) on the underlying mccl bootstrap.

Both implementations use the existing subset-aware bootstrap functions that
already support arbitrary rank subsets via the ranks array parameter.

Reviewed By: siyengar

Differential Revision: D95226377


