### PR TITLE
remove sync_event_

### DIFF
--- a/comms/torchcomms/device/cuda/CudaApi.cpp
+++ b/comms/torchcomms/device/cuda/CudaApi.cpp
@@ -138,6 +138,15 @@ cudaError_t DefaultCudaApi::threadExchangeStreamCaptureMode(
   return cudaThreadExchangeStreamCaptureMode(mode);
 }
 
+cudaError_t DefaultCudaApi::streamUpdateCaptureDependencies(
+    cudaStream_t stream,
+    cudaGraphNode_t* dependencies,
+    size_t numDependencies,
+    unsigned int flags) {
+  return cudaStreamUpdateCaptureDependencies(
+      stream, dependencies, numDependencies, flags);
+}
+
 cudaError_t DefaultCudaApi::malloc(void** devPtr, size_t size) {
   return cudaMalloc(devPtr, size);
 }

--- a/comms/torchcomms/device/cuda/CudaApi.hpp
+++ b/comms/torchcomms/device/cuda/CudaApi.hpp
@@ -96,6 +96,11 @@ class CudaApi {
       size_t* numDependencies_out) = 0;
   [[nodiscard]] virtual cudaError_t threadExchangeStreamCaptureMode(
       enum cudaStreamCaptureMode* mode) = 0;
+  [[nodiscard]] virtual cudaError_t streamUpdateCaptureDependencies(
+      cudaStream_t stream,
+      cudaGraphNode_t* dependencies,
+      size_t numDependencies,
+      unsigned int flags) = 0;
 
   // Memory management
   [[nodiscard]] virtual cudaError_t malloc(void** devPtr, size_t size) = 0;
@@ -193,6 +198,11 @@ class DefaultCudaApi : public CudaApi {
       size_t* numDependencies_out) override;
   [[nodiscard]] cudaError_t threadExchangeStreamCaptureMode(
       enum cudaStreamCaptureMode* mode) override;
+  [[nodiscard]] cudaError_t streamUpdateCaptureDependencies(
+      cudaStream_t stream,
+      cudaGraphNode_t* dependencies,
+      size_t numDependencies,
+      unsigned int flags) override;
 
   // Memory management
   [[nodiscard]] cudaError_t malloc(void** devPtr, size_t size) override;

--- a/comms/torchcomms/ncclx/GraphEventTracker.cpp
+++ b/comms/torchcomms/ncclx/GraphEventTracker.cpp
@@ -108,12 +108,14 @@ void GraphEventTracker::maybeInitGraphState(
 void GraphEventTracker::addEntry(TorchWorkNCCLX* work) {
   std::lock_guard<std::mutex> lock(mutex_);
 
-  // Transfer start/end event ownership from the work object, grouped by stream.
+  // Copy start/end event pointers to GraphWork for timeout monitoring.
+  // Ownership transfers to GraphEventTracker — it destroys the events
+  // when the graph is released. Null start_event_ to signal the transfer
+  // (releaseEvents checks this). Keep end_event_ for use in wait().
   auto [it, inserted] = graphs_.try_emplace(current_graph_id_);
   it->second.stream_entries[work->stream_].emplace_back(
       work->start_event_, work->end_event_, work->timeout_ms_);
   work->start_event_ = nullptr;
-  work->end_event_ = nullptr;
 
   // Transfer CPU tensors from the work object to the graph state.
   // These tensors (e.g., CPU pointer tensors used by alltoallv_dynamic_dispatch

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
@@ -311,6 +311,7 @@ class TorchCommNCCLX : public TorchCommBackend,
   void enqueueWork(
       c10::intrusive_ptr<TorchWorkNCCLX> work,
       cudaStream_t stream);
+
   cudaStream_t getInternalStream() const {
     return internal_stream_;
   }

--- a/comms/torchcomms/ncclx/TorchCommNCCLXUtils.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXUtils.cpp
@@ -400,7 +400,7 @@ void TorchCommNCCLX::enqueueWork(
   if (getGraphCaptureMode()) {
     // Transfer start/end event ownership to the tracker.
     // Work object is NOT stored — it will be destroyed when the caller's
-    // intrusive_ptr goes out of scope, destroying ad-hoc sync_event_.
+    // intrusive_ptr goes out of scope.
     graph_event_tracker_.addEntry(work.get());
   } else {
     // Add work to stream's queue after events have been recorded

--- a/comms/torchcomms/ncclx/TorchWorkNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchWorkNCCLX.cpp
@@ -11,11 +11,10 @@ namespace torch::comms {
 
 void TorchWorkNCCLX::initEvents() {
   if (graph_capture_mode_) {
-    // Ad-hoc create all three events — NOT from the event pool.
-    // start_event_ and end_event_ ownership will be transferred to
-    // GraphWork in enqueueWork(). sync_event_ is destroyed in dtor.
-    // TODO: sync_event_ is only needed for async_op=true; skip creation
-    // for synchronous operations where the work runs on the current stream.
+    // start_event_ and end_event_ are only created when timeout monitoring
+    // is enabled — lifetime ownership is transferred to GraphWork in
+    // enqueueWork(), although we will still hold a reference to end_event_ for
+    // usage in wait()
     CUDA_CHECK(
         comm_->getCudaApi(),
         comm_->getCudaApi()->eventCreateWithFlags(
@@ -26,11 +25,6 @@ void TorchWorkNCCLX::initEvents() {
         comm_->getCudaApi()->eventCreateWithFlags(
             &end_event_, cudaEventDisableTiming),
         "Failed to create end event for graph capture");
-    CUDA_CHECK(
-        comm_->getCudaApi(),
-        comm_->getCudaApi()->eventCreateWithFlags(
-            &sync_event_, cudaEventDisableTiming),
-        "Failed to create sync event for graph capture");
   } else {
     start_event_ = comm_->getEvent();
     end_event_ = comm_->getEvent();
@@ -39,18 +33,12 @@ void TorchWorkNCCLX::initEvents() {
 
 void TorchWorkNCCLX::releaseEvents() {
   if (graph_capture_mode_) {
-    // In graph mode: start_event_ and end_event_ were ad-hoc created and
-    // should have been transferred to the GraphWorkEntry (set to nullptr).
-    // If transfer didn't happen (error path), destroy them.
-    // sync_event_ is always ad-hoc and always destroyed here.
-    if (start_event_) {
+    // graph mode: start_event_ is nulled by addEntry() when events are
+    // transferred to GraphEventTracker. if non-null, transfer of ownership
+    // hasn't happened — destroy both events here.
+    if (start_event_ && end_event_) {
       (void)comm_->getCudaApi()->eventDestroy(start_event_);
-    }
-    if (end_event_) {
       (void)comm_->getCudaApi()->eventDestroy(end_event_);
-    }
-    if (sync_event_) {
-      (void)comm_->getCudaApi()->eventDestroy(sync_event_);
     }
   } else {
     // Non-graph mode: both start and end events are from the pool.
@@ -144,22 +132,16 @@ void TorchWorkNCCLX::recordStart(std::string_view coll_name) {
 void TorchWorkNCCLX::recordEnd() {
   // During graph capture, end_event_ is recorded with cudaEventRecordExternal
   // so it remains host-queryable during graph replay for watchdog timeout
-  // detection. sync_event_ is recorded with regular cudaEventRecord to serve
-  // as a valid join point for work.wait() (cudaStreamWaitEvent).
+  // detection.
   //
   // In eager mode, end_event_ is recorded with regular cudaEventRecord and
   // serves as both the completion detection event and the join point.
-  // sync_event_ is nullptr.
   if (graph_capture_mode_) {
     CUDA_CHECK(
         comm_->getCudaApi(),
         comm_->getCudaApi()->eventRecordWithFlags(
             end_event_, stream_, cudaEventRecordExternal),
         "Failed to record end event");
-    CUDA_CHECK(
-        comm_->getCudaApi(),
-        comm_->getCudaApi()->eventRecord(sync_event_, stream_),
-        "Failed to record sync event");
   } else {
     CUDA_CHECK(
         comm_->getCudaApi(),
@@ -245,17 +227,26 @@ void TorchWorkNCCLX::wait() {
       "wait",
       comm_->getRank());
 
-  // Get the current stream using the device from the comm object
   cudaStream_t current_stream =
       comm_->getCudaApi()->getCurrentCUDAStream(comm_->device_.index());
 
-  // Add a dependency from the work's stream to the current stream.
-  // In graph mode, use sync_event_ (the regular-recorded join point).
-  // In eager mode, use end_event_ (sync_event_ is nullptr).
-  cudaEvent_t wait_event = sync_event_ ? sync_event_ : end_event_;
+  if (graph_capture_mode_) {
+    // Clear stream_'s tracked fork so the fork/join checker
+    // at capture_end() doesn't see unjoined explicit EVENT_RECORD_EXT
+    // nodes. The streamWaitEvent below creates the actual graph edge.
+    CUDA_CHECK(
+        comm_->getCudaApi(),
+        comm_->getCudaApi()->streamUpdateCaptureDependencies(
+            stream_, nullptr, 0, cudaStreamSetCaptureDependencies),
+        "Failed to clear stream_'s capture dependencies");
+  }
+
   CUDA_CHECK(
       comm_->getCudaApi(),
-      comm_->getCudaApi()->streamWaitEvent(current_stream, wait_event, 0),
+      comm_->getCudaApi()->streamWaitEvent(
+          current_stream,
+          end_event_,
+          graph_capture_mode_ ? cudaEventWaitExternal : 0x00),
       "Failed to make stream wait for event");
 
   // Release tensor references. The CUDA caching allocator manages stream

--- a/comms/torchcomms/ncclx/TorchWorkNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchWorkNCCLX.hpp
@@ -114,17 +114,10 @@ class TorchWorkNCCLX : public TorchWork {
   // recorded after the NCCL operation completes. In eager mode, it is also
   // used as the join point for work.wait(). In graph mode, it is recorded
   // with cudaEventRecordExternal (host-queryable for watchdog timeout
-  // detection) and ownership is transferred to GraphWorkEntry.
+  // detection). addEntry() copies both event pointers to GraphEventTracker
+  // and nulls start_event_ to signal the transfer. end_event_ is retained
+  // for use in wait().
   cudaEvent_t end_event_{};
-  // Stream synchronization event for graph mode only. Recorded with regular
-  // cudaEventRecord to serve as a valid join point for work.wait()
-  // (cudaStreamWaitEvent). nullptr in eager mode.
-  //
-  // In graph mode, all three events (start, end, sync) are ad-hoc created
-  // (NOT from the event pool). start_event_ and end_event_ ownership is
-  // transferred to GraphWorkEntry in enqueueWork(), which sets them to
-  // nullptr. sync_event_ is destroyed in the work destructor.
-  cudaEvent_t sync_event_{};
   cudaStream_t stream_; // stream is not owned by this class
 
   // Whether this work was created during CUDA graph capture. Controls

--- a/comms/torchcomms/ncclx/docs/graph_timeout_design.md
+++ b/comms/torchcomms/ncclx/docs/graph_timeout_design.md
@@ -11,62 +11,70 @@ mechanism. The `GraphEventTracker` class provides this functionality.
 
 ```text
 ┌─────────────────────────────────────────────────────────────────┐
-│                      TorchCommNCCLX                             │
+│                        TorchCommNCCLX                           │
 │                                                                 │
-│  ┌──────────────────────┐    ┌──────────────────────────────┐  │
-│  │    Event Pool         │    │    Timeout Watchdog Thread    │  │
-│  │  (eager mode only)    │    │                              │  │
-│  │  getEvent()/          │    │  checkWorkQueue()            │  │
-│  │  returnEvent()        │    │    → eager work FIFO GC      │  │
-│  └──────────┬───────────┘    │                              │  │
-│             │                │  checkGraphEvents()           │  │
-│             │                │    → graph_event_tracker_     │  │
-│             │                │      .checkAll()              │  │
-│             │                └──────────────────────────────┘  │
-│             │                                                   │
-│  ┌──────────▼───────────────────────────────────────────────┐  │
-│  │                   TorchWorkNCCLX                          │  │
+│  ┌────────────────────────┐    ┌─────────────────────────────┐  │
+│  │ Event Pool             │    │ Timeout Watchdog Thread     │  │
+│  │ (eager mode)           │    │                             │  │
+│  │ getEvent()/            │    │ checkWorkQueue()            │  │
+│  │ returnEvent()          │    │   → eager work FIFO GC      │  │
+│  └───────────┬────────────┘    │                             │  │
+│              │                 │ checkGraphEvents()          │  │
+│              │                 │   → graph_event_tracker_    │  │
+│              │                 │     .checkAll()             │  │
+│              │                 └─────────────────────────────┘  │
+│              │                                                  │
+│  ┌───────────▼───────────────────────────────────────────────┐  │
+│  │ TorchWorkNCCLX                                            │  │
 │  │                                                           │  │
-│  │  start_event_  — start detection (pool / ad-hoc)          │  │
-│  │  end_event_    — completion detection (pool / ad-hoc)     │  │
-│  │  sync_event_   — stream join, graph only (nullptr eager)  │  │
+│  │ start_event_ — start detection (pool / ad-hoc)            │  │
+│  │ end_event_   — completion detection (pool / ad-hoc)       │  │
 │  │                                                           │  │
-│  │  initEvents() / releaseEvents() — lifecycle management    │  │
+│  │ initEvents() / releaseEvents() — lifecycle management     │  │
 │  └───────────────────────────────────────────────────────────┘  │
 │                                                                 │
-│  ┌─────────────────────────┐  ┌─────────────────────────────┐  │
-│  │  TorchWorkNCCLXQueue    │  │  GraphEventTracker           │  │
-│  │  (eager mode)           │  │  (graph mode)                │  │
-│  │                         │  │                               │  │
-│  │  Per-stream FIFO of     │  │  Per-graph GraphState:        │  │
-│  │  intrusive_ptr<Work>    │  │    vector<GraphWork>          │  │
-│  │                         │  │    atomic replay_counter      │  │
-│  │                         │  │                               │  │
-│  │  GC: pop when done      │  │  Cleanup via cudaUserObject   │  │
-│  │  Work dtor returns      │  │  Replay detect via host node  │  │
-│  │  events to pool         │  │                               │  │
-│  └─────────────────────────┘  └─────────────────────────────┘  │
+│  ┌─────────────────────────┐  ┌──────────────────────────────┐  │
+│  │ TorchWorkNCCLXQueue     │  │ GraphEventTracker            │  │
+│  │ (eager mode)            │  │ (graph mode)                 │  │
+│  │                         │  │                              │  │
+│  │ Per-stream FIFO of      │  │ Per-graph GraphState:        │  │
+│  │ intrusive_ptr<Work>     │  │   vector<GraphWork>          │  │
+│  │                         │  │   atomic replay_counter      │  │
+│  │                         │  │                              │  │
+│  │ GC: pop when done       │  │ Cleanup via cudaUserObject   │  │
+│  │ Work dtor returns       │  │ Replay detect via host node  │  │
+│  │ events to pool          │  │                              │  │
+│  └─────────────────────────┘  └──────────────────────────────┘  │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
 ## Event Design
 
-### Why Three Events in Graph Mode
+### Events in Graph Mode
 
 CUDA graph capture records `cudaEventRecord` calls as graph nodes. Regular-recorded
 events become opaque during replay and cannot be queried from the host. To enable
 host-side timeout detection, we use `cudaEventRecordExternal` for start/end events,
 which creates EVENT_RECORD nodes that remain host-queryable during replay.
 
-However, externally-recorded events are NOT recognized by `cudaStreamWaitEvent` as
-valid stream join points (`cudaErrorStreamCaptureUnjoined`). So we need a third event
-(`sync_event_`) recorded with regular `cudaEventRecord` purely for `work.wait()`.
+The `cudaEventRecordExternal` calls create explicit graph nodes on `internal_stream_`
+(s1). These explicit nodes cause CUDA's fork/join checker to consider s1 as "active"
+at `capture_end()`. To resolve this, `work.wait()` during graph capture performs a
+two-step join:
+
+1. `cudaStreamUpdateCaptureDependencies(s1, nullptr, 0, SET)` — clears s1's tracked
+   fork state so the fork/join checker no longer considers it active.
+2. `cudaStreamWaitEvent(s0, end_event_)` — creates a graph edge from s1's
+   EVENT_RECORD_EXT node to s0, ensuring proper execution ordering during replay.
+
+The next collective's `getOperationStream()` re-forks s1 from s0 as usual. All
+async ops must be waited during graph capture to avoid
+`cudaErrorStreamCaptureUnjoined` (error 904).
 
 | Event | Recording API | Purpose | Eager | Graph |
 |-------|--------------|---------|-------|-------|
 | `start_event_` | Eager: `cudaEventRecord` / Graph: `cudaEventRecordExternal` | Detect collective start | Pool | Ad-hoc, transferred to GraphWork |
 | `end_event_` | Eager: `cudaEventRecord` / Graph: `cudaEventRecordExternal` | Detect collective end, timeout detection | Pool | Ad-hoc, transferred to GraphWork |
-| `sync_event_` | `cudaEventRecord` (regular) | Stream join for `work.wait()` | N/A (nullptr) | Ad-hoc, destroyed in Work dtor |
 
 ### Event Lifecycle
 
@@ -77,14 +85,69 @@ Pool.get() → Work ctor → record → watchdog query → GC → Work dtor → 
 
 **Graph mode:** Ad-hoc events, persistent across replays.
 ```text
-Capture:  cudaEventCreate → Work ctor → record (External) → enqueueWork
-          → transfer start/end to GraphWork → Work dtor (destroys sync_event_ only)
+Capture:  cudaEventCreate (start/end) → Work ctor → record
+          → enqueueWork → copy event ptrs to GraphWork
+          → work.wait() → SET(s1, empty) + streamWaitEvent(s0, end_event_)
 
 Replay:   GPU replays EVENT_RECORD_EXT nodes → watchdog queries → timeout check
 
 Cleanup:  Graph destruction → cudaUserObject callback sets released flag
           → watchdog checkAll() → cleanupReleasedGraphs() → destroyEvents()
 ```
+
+## Stream Join Mechanism
+
+### Problem
+
+TorchCommNCCLX runs collectives on the internal stream `stream_` (s1), which is
+forked from the user stream (s0) via `getOperationStream()`. The
+`cudaEventRecordExternal` calls for `start_event_` and `end_event_` create explicit
+`EVENT_RECORD` graph nodes on s1. If s1 is not joined back to s0 before
+`cudaStreamEndCapture`, CUDA
+detects the unjoined fork and returns `cudaErrorStreamCaptureUnjoined` (error 904).
+
+We've previously avoided this by only using regular `cudaEventRecord` (which
+don't materialize to explicit graph nodes). A forked stream with only implicit
+nodes is transparent to the fork/join checker, thus we don't run into the error.
+
+### Solution
+
+When `work.wait()` is called during graph capture, it performs a two-step join:
+
+```text
+Per collective during graph capture:
+
+  getOperationStream()
+    eventRecord(dep_event, s0)       ← fork: s0 records, s1 waits
+    streamWaitEvent(s1, dep_event)
+
+  NCCL collective on s1
+  cudaEventRecordExternal(start_event_, s1)   ← explicit node on s1
+  cudaEventRecordExternal(end_event_, s1)     ← explicit node on s1
+
+  enqueueWork()
+    copy event ptrs to GraphEventTracker (for timeout monitoring)
+
+  ... user compute on s0 can overlap with collective ...
+
+  work.wait()
+    streamUpdateCaptureDependencies( ← clear s1's tracked fork
+        s1, {}, SET)
+    streamWaitEvent(s0, end_event_)  ← graph edge: s0 depends on s1
+```
+
+The `SET(empty)` clears s1's tracked tail nodes so the fork/join checker at
+`capture_end()` no longer considers s1 as having unjoined work. Clearing the
+tracked deps does NOT remove the EVENT_RECORD_EXT graph nodes — they remain in
+the graph. The `streamWaitEvent` creates the actual graph edge from the
+EVENT_RECORD_EXT node to s0, ensuring correct execution ordering during replay.
+
+This preserves async overlap: user compute on s0 between `enqueueWork()` and
+`work.wait()` is not blocked by the collective. The join happens at the natural
+synchronization point — the same place eager mode joins via `streamWaitEvent`.
+
+**Important**: All async ops must be waited during graph capture. Unwaited ops
+leave s1 unjoined, causing error 904 at `capture_end()`.
 
 ## GraphEventTracker Timeout Logic
 

--- a/comms/torchcomms/ncclx/tests/unit/cpp/GraphEventTrackerTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/GraphEventTrackerTest.cpp
@@ -12,7 +12,6 @@ class GraphEventTrackerTest : public TorchCommNCCLXTest {
   struct GraphEvents {
     cudaEvent_t start = reinterpret_cast<cudaEvent_t>(0xA001);
     cudaEvent_t end = reinterpret_cast<cudaEvent_t>(0xA002);
-    cudaEvent_t sync = reinterpret_cast<cudaEvent_t>(0xA003);
   };
 
   CommOptions createAbortModeOptions(
@@ -52,7 +51,6 @@ class GraphEventTrackerTest : public TorchCommNCCLXTest {
     EXPECT_CALL(*cuda_mock_, eventCreateWithFlags(_, _))
         .WillOnce(DoAll(SetArgPointee<0>(events.start), Return(cudaSuccess)))
         .WillOnce(DoAll(SetArgPointee<0>(events.end), Return(cudaSuccess)))
-        .WillOnce(DoAll(SetArgPointee<0>(events.sync), Return(cudaSuccess)))
         .WillRepeatedly(DoAll(
             SetArgPointee<0>(reinterpret_cast<cudaEvent_t>(0xA100)),
             Return(cudaSuccess)));
@@ -168,12 +166,9 @@ TEST_F(GraphEventTrackerTest, GraphCaptureWorkObjectsDestroyedAfterCapture) {
   comm->init(*device_, "test_graph_work_destroyed", options);
 
   setupGraphCaptureMocks();
-  auto events = setupGraphCaptureEvents();
+  setupGraphCaptureEvents();
 
   auto tensor = createTestTensor({10, 10});
-
-  EXPECT_CALL(*cuda_mock_, eventDestroy(events.sync))
-      .WillOnce(Return(cudaSuccess));
 
   {
     auto work = comm->send(tensor, 1, true);
@@ -365,9 +360,6 @@ TEST_F(GraphEventTrackerTest, DestroyAllCleansUpGraphEntryEvents) {
 
   auto tensor = createTestTensor({10, 10});
 
-  EXPECT_CALL(*cuda_mock_, eventDestroy(events.sync))
-      .WillOnce(Return(cudaSuccess));
-
   {
     auto work = comm->send(tensor, 1, true);
   }
@@ -414,21 +406,17 @@ TEST_F(GraphEventTrackerTest, MultipleCollectivesInSameGraphCleanedUp) {
 
   setupGraphCaptureMocks();
 
-  // Two collectives: each creates 3 events (start, end, sync)
+  // Two collectives: each creates 2 events (start, end)
   cudaEvent_t start1 = reinterpret_cast<cudaEvent_t>(0xA001);
   cudaEvent_t end1 = reinterpret_cast<cudaEvent_t>(0xA002);
-  cudaEvent_t sync1 = reinterpret_cast<cudaEvent_t>(0xA003);
-  cudaEvent_t start2 = reinterpret_cast<cudaEvent_t>(0xA004);
-  cudaEvent_t end2 = reinterpret_cast<cudaEvent_t>(0xA005);
-  cudaEvent_t sync2 = reinterpret_cast<cudaEvent_t>(0xA006);
+  cudaEvent_t start2 = reinterpret_cast<cudaEvent_t>(0xA003);
+  cudaEvent_t end2 = reinterpret_cast<cudaEvent_t>(0xA004);
 
   EXPECT_CALL(*cuda_mock_, eventCreateWithFlags(_, _))
       .WillOnce(DoAll(SetArgPointee<0>(start1), Return(cudaSuccess)))
       .WillOnce(DoAll(SetArgPointee<0>(end1), Return(cudaSuccess)))
-      .WillOnce(DoAll(SetArgPointee<0>(sync1), Return(cudaSuccess)))
       .WillOnce(DoAll(SetArgPointee<0>(start2), Return(cudaSuccess)))
       .WillOnce(DoAll(SetArgPointee<0>(end2), Return(cudaSuccess)))
-      .WillOnce(DoAll(SetArgPointee<0>(sync2), Return(cudaSuccess)))
       .WillRepeatedly(DoAll(
           SetArgPointee<0>(reinterpret_cast<cudaEvent_t>(0xA100)),
           Return(cudaSuccess)));
@@ -600,10 +588,8 @@ TEST_F(GraphEventTrackerTest, MultipleGraphsOnlyReleasedOneCleanedUp) {
 
   cudaEvent_t start1 = reinterpret_cast<cudaEvent_t>(0xC001);
   cudaEvent_t end1 = reinterpret_cast<cudaEvent_t>(0xC002);
-  cudaEvent_t sync1 = reinterpret_cast<cudaEvent_t>(0xC003);
   cudaEvent_t start2 = reinterpret_cast<cudaEvent_t>(0xC004);
   cudaEvent_t end2 = reinterpret_cast<cudaEvent_t>(0xC005);
-  cudaEvent_t sync2 = reinterpret_cast<cudaEvent_t>(0xC006);
 
   void* cleanup_data_1 = nullptr;
   cudaHostFn_t cleanup_fn_1 = nullptr;
@@ -613,7 +599,6 @@ TEST_F(GraphEventTrackerTest, MultipleGraphsOnlyReleasedOneCleanedUp) {
   EXPECT_CALL(*cuda_mock_, eventCreateWithFlags(_, _))
       .WillOnce(DoAll(SetArgPointee<0>(start1), Return(cudaSuccess)))
       .WillOnce(DoAll(SetArgPointee<0>(end1), Return(cudaSuccess)))
-      .WillOnce(DoAll(SetArgPointee<0>(sync1), Return(cudaSuccess)))
       .WillRepeatedly(DoAll(
           SetArgPointee<0>(reinterpret_cast<cudaEvent_t>(0xA100)),
           Return(cudaSuccess)));
@@ -646,7 +631,6 @@ TEST_F(GraphEventTrackerTest, MultipleGraphsOnlyReleasedOneCleanedUp) {
   EXPECT_CALL(*cuda_mock_, eventCreateWithFlags(_, _))
       .WillOnce(DoAll(SetArgPointee<0>(start2), Return(cudaSuccess)))
       .WillOnce(DoAll(SetArgPointee<0>(end2), Return(cudaSuccess)))
-      .WillOnce(DoAll(SetArgPointee<0>(sync2), Return(cudaSuccess)))
       .WillRepeatedly(DoAll(
           SetArgPointee<0>(reinterpret_cast<cudaEvent_t>(0xA100)),
           Return(cudaSuccess)));
@@ -771,7 +755,7 @@ TEST_F(GraphEventTrackerTest, GraphCaptureDispatchSavesOutputTensors) {
   comm->init(*device_, "test_graph_dispatch_tensors", options);
 
   setupGraphCaptureMocks();
-  auto events = setupGraphCaptureEvents();
+  setupGraphCaptureEvents();
 
   // Create test tensors
   auto input_tensor = createTestTensor({100});
@@ -792,10 +776,6 @@ TEST_F(GraphEventTrackerTest, GraphCaptureDispatchSavesOutputTensors) {
   EXPECT_CALL(
       *nccl_mock_, alltoallvDynamicDispatch(_, _, _, _, _, _, _, _, _, _, _, _))
       .WillOnce(Return(ncclSuccess));
-
-  // The sync event will be destroyed when work goes out of scope
-  EXPECT_CALL(*cuda_mock_, eventDestroy(events.sync))
-      .WillOnce(Return(cudaSuccess));
 
   {
     auto work = comm->alltoallv_dynamic_dispatch(
@@ -835,7 +815,7 @@ TEST_F(GraphEventTrackerTest, GraphCaptureCombineSavesOutputTensor) {
   comm->init(*device_, "test_graph_combine_tensors", options);
 
   setupGraphCaptureMocks();
-  auto events = setupGraphCaptureEvents();
+  setupGraphCaptureEvents();
 
   // Create test tensors
   auto input_tensor = createTestTensor({100});
@@ -850,10 +830,6 @@ TEST_F(GraphEventTrackerTest, GraphCaptureCombineSavesOutputTensor) {
   EXPECT_CALL(
       *nccl_mock_, alltoallvDynamicCombine(_, _, _, _, _, _, _, _, _, _, _))
       .WillOnce(Return(ncclSuccess));
-
-  // The sync event will be destroyed when work goes out of scope
-  EXPECT_CALL(*cuda_mock_, eventDestroy(events.sync))
-      .WillOnce(Return(cudaSuccess));
 
   {
     auto work = comm->alltoallv_dynamic_combine(
@@ -871,6 +847,61 @@ TEST_F(GraphEventTrackerTest, GraphCaptureCombineSavesOutputTensor) {
 
   // After work is destroyed, our local tensor variable should still be valid
   EXPECT_NE(output_tensor.data_ptr(), nullptr);
+
+  ::testing::Mock::VerifyAndClearExpectations(cuda_mock_.get());
+
+  switchToReplayMode();
+  setupFinalizeExpectations(*comm);
+}
+
+// Verify that work.wait() clears internal_stream_'s tracked fork via
+// streamUpdateCaptureDependencies(SET empty) and joins via streamWaitEvent
+// on end_event_ during graph capture.
+TEST_F(GraphEventTrackerTest, WaitJoinsInternalToUserStream) {
+  setupCCAExpectations(1, 2, 1);
+
+  auto comm = createMockedTorchComm();
+  cuda_mock_->setupDefaultBehaviors();
+  nccl_mock_->setupDefaultBehaviors();
+
+  // Use distinct stream addresses so we can verify which stream each call uses
+  cudaStream_t user_stream = reinterpret_cast<cudaStream_t>(0x100);
+  cudaStream_t internal_stream = reinterpret_cast<cudaStream_t>(0x200);
+
+  ON_CALL(*cuda_mock_, getCurrentCUDAStream(_))
+      .WillByDefault(Return(user_stream));
+  ON_CALL(*cuda_mock_, streamCreateWithPriority(_, _, _))
+      .WillByDefault(
+          DoAll(SetArgPointee<0>(internal_stream), Return(cudaSuccess)));
+
+  auto options = createAbortModeOptions();
+  comm->init(*device_, "test_wait_join", options);
+
+  setupGraphCaptureMocks();
+  auto events = setupGraphCaptureEvents();
+  setupEventRecordMocks();
+
+  // Expect work.wait() to: SET s1 deps to empty, then streamWaitEvent on
+  // end_event_.
+  EXPECT_CALL(
+      *cuda_mock_,
+      streamUpdateCaptureDependencies(
+          internal_stream, nullptr, 0, cudaStreamSetCaptureDependencies))
+      .Times(1)
+      .WillOnce(Return(cudaSuccess));
+  EXPECT_CALL(*cuda_mock_, streamWaitEvent(user_stream, events.end, 0))
+      .Times(1)
+      .WillOnce(Return(cudaSuccess));
+  // Allow other streamWaitEvent calls (e.g., getOperationStream fork)
+  EXPECT_CALL(*cuda_mock_, streamWaitEvent(::testing::Ne(user_stream), _, _))
+      .WillRepeatedly(Return(cudaSuccess));
+
+  auto tensor = createTestTensor({10, 10});
+
+  {
+    auto work = comm->send(tensor, 1, true);
+    work->wait();
+  }
 
   ::testing::Mock::VerifyAndClearExpectations(cuda_mock_.get());
 

--- a/comms/torchcomms/ncclx/tests/unit/cpp/mocks/CudaMock.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/mocks/CudaMock.cpp
@@ -82,6 +82,9 @@ void CudaMock::setupDefaultBehaviors() {
   ON_CALL(*this, threadExchangeStreamCaptureMode(_))
       .WillByDefault(Return(cudaSuccess));
 
+  ON_CALL(*this, streamUpdateCaptureDependencies(_, _, _, _))
+      .WillByDefault(Return(cudaSuccess));
+
   // Memory management - return success by default
   ON_CALL(*this, malloc(_, _))
       .WillByDefault(DoAll(

--- a/comms/torchcomms/ncclx/tests/unit/cpp/mocks/CudaMock.hpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/mocks/CudaMock.hpp
@@ -115,6 +115,14 @@ class CudaMock : public CudaApi {
       threadExchangeStreamCaptureMode,
       (enum cudaStreamCaptureMode * mode),
       (override));
+  MOCK_METHOD(
+      cudaError_t,
+      streamUpdateCaptureDependencies,
+      (cudaStream_t stream,
+       cudaGraphNode_t* dependencies,
+       size_t numDependencies,
+       unsigned int flags),
+      (override));
 
   // Memory management
   MOCK_METHOD(cudaError_t, malloc, (void** devPtr, size_t size), (override));


### PR DESCRIPTION
Summary:
sync_event_ was recorded with regular cudaEventRecord, not cudaEventRecordExternal.

regular event recordings do not create graph nodes, and as such, cudaStreamWaitEvent(internal_stream_, sync_event_) is recognized by the fork/join checker as a proper join.


the flow was:
```                                                                                                                                                                              
1. cudaEventRecordExternal(start_event_, internal_stream_) — explicit node                                                                                         
2. cudaEventRecordExternal(end_event_, internal_stream_) — explicit node                                                                                           
3. cudaEventRecord(sync_event_, internal_stream_) — regular/absorbed, becomes s1's tracked tail
4. cudaStreamWaitEvent(user_stream_, sync_event_) — proper join (regular event)
```

the fork/join checker treats regular and external events differently. a streamWaitEvent with a regular event resolves the fork, whereas a streamWaitEvent with an external event does not. sync_event_ was the regular event that made the join work. the external events (start/end) were "covered" by sync_event_ being recorded after them on s1's chain.

now that we removed sync_event_, we have no regular event on s1 to join on... instead, we use SET(empty) to explicitly resolve the fork (what sync_event_ + streamWaitEvent used to do implicitly), and streamWaitEvent(user_stream_, end_event_) just for the graph ordering edge.

Differential Revision: D94987985


