### PR TITLE
Fix NvmlFabricInfo query to check status field (#936)

### DIFF
--- a/comms/pipes/NvmlFabricInfo.h
+++ b/comms/pipes/NvmlFabricInfo.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <cstdio>
 #include <cstring>
 
 #include <dlfcn.h>
@@ -130,10 +131,25 @@ inline NvmlFabricInfo NvmlFabricInfo::query(const char* busId) {
   NvmlGpuFabricInfoV fabricInfo{};
   fabricInfo.version = kNvmlGpuFabricInfoV2;
   if (nvmlApi.getGpuFabricInfoV(nvmlDev, &fabricInfo) == NVML_SUCCESS &&
-      fabricInfo.state == NVML_GPU_FABRIC_STATE_COMPLETED) {
-    std::memcpy(info.clusterUuid, fabricInfo.clusterUuid, kUuidLen);
-    info.cliqueId = fabricInfo.cliqueId;
-    info.available = true;
+      fabricInfo.state == NVML_GPU_FABRIC_STATE_COMPLETED &&
+      fabricInfo.status == NVML_SUCCESS) {
+    // Only report as available if the UUID is non-zero. On non-MNNVL
+    // hardware (e.g. H100), NVML can return success + completed with an
+    // all-zero UUID, meaning the GPU is not in any NVLink fabric domain.
+    unsigned char zeros[kUuidLen]{};
+    if (std::memcmp(fabricInfo.clusterUuid, zeros, kUuidLen) != 0) {
+      std::memcpy(info.clusterUuid, fabricInfo.clusterUuid, kUuidLen);
+      info.cliqueId = fabricInfo.cliqueId;
+      info.available = true;
+    } else {
+      std::fprintf(
+          stderr,
+          "NvmlFabricInfo: NVML returned success with completed state "
+          "but all-zero clusterUuid for %s (cliqueId=%u); treating as "
+          "no fabric\n",
+          busId,
+          fabricInfo.cliqueId);
+    }
   }
 
   return info;


### PR DESCRIPTION
Summary:

Fix for failing ncclx test (see T256706609)

The query() function only checked `state == COMPLETED` but not the
`status` field. On H100 CI machines, NVML can report state=COMPLETED
with a non-success status and all-zero UUID. This caused
NvmlFabricInfoTest.QueryResultConsistency to fail because `available`
was set to true with an invalid (all-zero) UUID.

Per NVML docs, the status field must be checked when state returns
complete: "Error status, if any. Must be checked only if state returns
'complete'."

Add `fabricInfo.status == NVML_SUCCESS` check to the condition in
NvmlFabricInfo::query() so that we only set available=true when the
NVML call succeeded, the fabric state is complete, AND the status
indicates no error.

Reviewed By: Regina8023

Differential Revision: D95264113
