### PR TITLE
Split NicDiscovery into GpuNicDiscovery + CpuNicDiscovery

### DIFF
--- a/comms/pipes/MultipeerIbgdaTransport.cc
+++ b/comms/pipes/MultipeerIbgdaTransport.cc
@@ -107,7 +107,7 @@ void MultipeerIbgdaTransport::initDocaGpu() {
         std::string(cudaGetErrorString(cudaErr)));
   }
 
-  gpuPciBusId_ = NicDiscovery::getCudaPciBusId(config_.cudaDevice);
+  gpuPciBusId_ = GpuNicDiscovery::getCudaPciBusId(config_.cudaDevice);
 
   LOG(INFO) << "MultipeerIbgdaTransport: GPU " << config_.cudaDevice << " PCIe "
             << gpuPciBusId_;
@@ -139,7 +139,7 @@ void MultipeerIbgdaTransport::openIbDevice() {
 
   // Priority 2: Auto-discovery if no config override
   if (nicDeviceName_.empty()) {
-    NicDiscovery discovery(config_.cudaDevice, config_.ibHca);
+    auto discovery = GpuNicDiscovery(config_.cudaDevice, config_.ibHca);
     const auto& candidates = discovery.getCandidates();
     nicDeviceName_ = candidates[0].name;
     LOG(INFO) << "MultipeerIbgdaTransport: using NIC " << nicDeviceName_

--- a/comms/pipes/rdma/NicDiscovery.cc
+++ b/comms/pipes/rdma/NicDiscovery.cc
@@ -4,6 +4,7 @@
 
 #include <cuda_runtime.h>
 #include <spdlog/spdlog.h>
+#include <sys/syscall.h>
 #include <unistd.h>
 
 #include <dirent.h>
@@ -106,7 +107,20 @@ std::vector<std::string> buildAncestorChain(const std::string& normalizedPcie) {
 
 } // namespace
 
-// Static methods
+// Free functions
+
+int getCurrentNumaNode() {
+  unsigned cpu = 0;
+  unsigned node = 0;
+  if (syscall(SYS_getcpu, &cpu, &node, nullptr) == 0) {
+    return static_cast<int>(node);
+  }
+  return -1;
+}
+
+// =============================================================================
+// NicDiscovery (base class)
+// =============================================================================
 
 std::string NicDiscovery::normalizePcieAddress(const std::string& pciBusId) {
   std::string result = pciBusId;
@@ -114,17 +128,6 @@ std::string NicDiscovery::normalizePcieAddress(const std::string& pciBusId) {
     c = std::tolower(static_cast<unsigned char>(c));
   }
   return result;
-}
-
-std::string NicDiscovery::getCudaPciBusId(int cudaDevice) {
-  char busId[32];
-  cudaError_t err = cudaDeviceGetPCIBusId(busId, sizeof(busId), cudaDevice);
-  if (err != cudaSuccess) {
-    throw std::runtime_error(
-        "Failed to get CUDA device PCIe bus ID: " +
-        std::string(cudaGetErrorString(err)));
-  }
-  return std::string(busId);
 }
 
 int NicDiscovery::getNumaNodeForPcie(const std::string& pciBusId) {
@@ -169,103 +172,16 @@ std::string NicDiscovery::getPcieForIbDev(const char* devName) {
   return path;
 }
 
-std::pair<PathType, int> NicDiscovery::computePathType(
-    const std::string& nicPcie,
-    int nicNuma) const {
-  // If different NUMA nodes, it's PATH_SYS
-  if (gpuNumaNode_ >= 0 && nicNuma >= 0 && gpuNumaNode_ != nicNuma) {
-    return {PathType::SYS, -1};
-  }
-
-  // Normalize NIC address and build its chain
-  std::string nicNormalized = normalizePcieAddress(nicPcie);
-  std::vector<std::string> nicChain = buildAncestorChain(nicNormalized);
-
-  // Find common ancestor
-  int nicHops = 0;
-  for (const auto& ancestor : nicChain) {
-    if (gpuAncestors_.count(ancestor)) {
-      // Found common ancestor
-      // Count hops from GPU to this ancestor
-      int gpuHops = 0;
-      for (const auto& g : gpuAncestorChain_) {
-        if (g == ancestor) {
-          break;
-        }
-        gpuHops++;
-      }
-
-      int totalHops = gpuHops + nicHops;
-
-      // Heuristic based on PCI topology depth:
-      // - 2 hops (GPU->switch->NIC) = PIX (same switch)
-      // - 3-4 hops = PXB (multiple switches, same NUMA)
-      // - More = PHB (through host bridge)
-      if (totalHops <= 2) {
-        return {PathType::PIX, totalHops};
-      }
-      if (totalHops <= 4) {
-        return {PathType::PXB, totalHops};
-      }
-      return {PathType::PHB, totalHops};
-    }
-    nicHops++;
-  }
-
-  // No common ancestor found in PCI tree
-  if (gpuNumaNode_ >= 0 && gpuNumaNode_ == nicNuma) {
-    // Same NUMA node but different PCI domains
-    int nhops =
-        static_cast<int>(gpuAncestorChain_.size() + nicChain.size()) + 2;
-    return {PathType::NODE, nhops};
-  }
-  return {PathType::SYS, -1};
-}
-
-void NicDiscovery::initGpuTopology() {
-  // Skip if already initialized
-  if (!gpuPciBusId_.empty()) {
-    return;
-  }
-
-  // Get GPU PCIe bus ID
-  gpuPciBusId_ = getCudaPciBusId(cudaDevice_);
-  gpuPcieNormalized_ = normalizePcieAddress(gpuPciBusId_);
-
-  // Build GPU ancestor chain for topology comparison (O(1) lookups later)
-  gpuAncestorChain_ = buildAncestorChain(gpuPcieNormalized_);
-  gpuAncestors_ = std::unordered_set<std::string>(
-      gpuAncestorChain_.begin(), gpuAncestorChain_.end());
-
-  // Get GPU NUMA node using pre-normalized address
-  std::string numaPath =
-      "/sys/bus/pci/devices/" + gpuPcieNormalized_ + "/numa_node";
-  std::ifstream numaFile(numaPath);
-  if (numaFile.is_open()) {
-    numaFile >> gpuNumaNode_;
-  }
-
-  spdlog::info(
-      "NicDiscovery: GPU {} PCIe {} NUMA {}",
-      cudaDevice_,
-      gpuPciBusId_,
-      gpuNumaNode_);
-}
-
-NicDiscovery::NicDiscovery(int cudaDevice, const std::string& ibHcaEnv)
-    : cudaDevice_(cudaDevice), ibHcaParser_(ibHcaEnv) {
+NicDiscovery::NicDiscovery(const std::string& ibHcaEnv)
+    : ibHcaParser_(ibHcaEnv) {
   if (!ibHcaParser_.empty()) {
     spdlog::info(
         "NicDiscovery: IB HCA filter with {} entries",
         ibHcaParser_.entries().size());
   }
-  discover();
 }
 
 void NicDiscovery::discover() {
-  // Initialize GPU topology for auto-discovery
-  initGpuTopology();
-
   auto devices = listIbDevices();
   if (devices.empty()) {
     throw std::runtime_error("No IB devices found");
@@ -340,13 +256,146 @@ void NicDiscovery::discover() {
 
   const NicCandidate& best = candidates_[0];
   spdlog::info(
-      "NicDiscovery: best candidate NIC {} for GPU {} (path={}, bandwidth={} Gb/s) (numa={}, nhops={})",
+      "NicDiscovery: best candidate NIC {} for {} (path={}, bandwidth={} Gb/s) (numa={}, nhops={})",
       best.name,
-      gpuPciBusId_,
+      anchorDescription(),
       pathTypeToString(best.pathType),
       best.bandwidthGbps,
       best.numaNode,
       best.nhops);
+}
+
+// =============================================================================
+// GpuNicDiscovery
+// =============================================================================
+
+std::string GpuNicDiscovery::getCudaPciBusId(int cudaDevice) {
+  char busId[32];
+  cudaError_t err = cudaDeviceGetPCIBusId(busId, sizeof(busId), cudaDevice);
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        "Failed to get CUDA device PCIe bus ID: " +
+        std::string(cudaGetErrorString(err)));
+  }
+  return std::string(busId);
+}
+
+GpuNicDiscovery::GpuNicDiscovery(int cudaDevice, const std::string& ibHcaEnv)
+    : NicDiscovery(ibHcaEnv), cudaDevice_(cudaDevice) {
+  initGpuTopology();
+  discover();
+}
+
+void GpuNicDiscovery::initGpuTopology() {
+  anchorPciBusId_ = getCudaPciBusId(cudaDevice_);
+  std::string normalized = normalizePcieAddress(anchorPciBusId_);
+
+  // Build ancestor chain for topology comparison (O(1) lookups later)
+  anchorAncestorChain_ = buildAncestorChain(normalized);
+  anchorAncestors_ = std::unordered_set<std::string>(
+      anchorAncestorChain_.begin(), anchorAncestorChain_.end());
+
+  // Get NUMA node using pre-normalized address
+  std::string numaPath = "/sys/bus/pci/devices/" + normalized + "/numa_node";
+  std::ifstream numaFile(numaPath);
+  if (numaFile.is_open()) {
+    numaFile >> anchorNumaNode_;
+  }
+
+  spdlog::info(
+      "NicDiscovery: GPU {} PCIe {} NUMA {}",
+      cudaDevice_,
+      anchorPciBusId_,
+      anchorNumaNode_);
+}
+
+std::pair<PathType, int> GpuNicDiscovery::computePathType(
+    const std::string& nicPcie,
+    int nicNuma) const {
+  // If different NUMA nodes, it's PATH_SYS
+  if (anchorNumaNode_ >= 0 && nicNuma >= 0 && anchorNumaNode_ != nicNuma) {
+    return {PathType::SYS, -1};
+  }
+
+  // Normalize NIC address and build its chain
+  std::string nicNormalized = normalizePcieAddress(nicPcie);
+  std::vector<std::string> nicChain = buildAncestorChain(nicNormalized);
+
+  // Find common ancestor
+  int nicHops = 0;
+  for (const auto& ancestor : nicChain) {
+    if (anchorAncestors_.count(ancestor)) {
+      // Found common ancestor
+      // Count hops from GPU to this ancestor
+      int gpuHops = 0;
+      for (const auto& g : anchorAncestorChain_) {
+        if (g == ancestor) {
+          break;
+        }
+        gpuHops++;
+      }
+
+      int totalHops = gpuHops + nicHops;
+
+      // Heuristic based on PCI topology depth:
+      // - 2 hops (GPU->switch->NIC) = PIX (same switch)
+      // - 3-4 hops = PXB (multiple switches, same NUMA)
+      // - More = PHB (through host bridge)
+      if (totalHops <= 2) {
+        return {PathType::PIX, totalHops};
+      }
+      if (totalHops <= 4) {
+        return {PathType::PXB, totalHops};
+      }
+      return {PathType::PHB, totalHops};
+    }
+    nicHops++;
+  }
+
+  // No common ancestor found in PCI tree
+  if (anchorNumaNode_ >= 0 && anchorNumaNode_ == nicNuma) {
+    // Same NUMA node but different PCI domains
+    int nhops =
+        static_cast<int>(anchorAncestorChain_.size() + nicChain.size()) + 2;
+    return {PathType::NODE, nhops};
+  }
+  return {PathType::SYS, -1};
+}
+
+std::string GpuNicDiscovery::anchorDescription() const {
+  return "GPU " + anchorPciBusId_;
+}
+
+// =============================================================================
+// CpuNicDiscovery
+// =============================================================================
+
+CpuNicDiscovery::CpuNicDiscovery(int numaNode, const std::string& ibHcaEnv)
+    : NicDiscovery(ibHcaEnv) {
+  std::string numaPath =
+      "/sys/devices/system/node/node" + std::to_string(numaNode);
+  if (access(numaPath.c_str(), F_OK) != 0) {
+    throw std::invalid_argument(
+        "Invalid NUMA node " + std::to_string(numaNode) + ": " + numaPath +
+        " does not exist");
+  }
+  anchorNumaNode_ = numaNode;
+  spdlog::info(
+      "NicDiscovery: CPU-anchored discovery, NUMA node {}", anchorNumaNode_);
+  discover();
+}
+
+std::pair<PathType, int> CpuNicDiscovery::computePathType(
+    const std::string& /* nicPcie */,
+    int nicNuma) const {
+  if (anchorNumaNode_ >= 0 && nicNuma >= 0 && anchorNumaNode_ == nicNuma) {
+    return {PathType::NODE, -1};
+  }
+  return {PathType::SYS, -1};
+}
+
+std::string CpuNicDiscovery::anchorDescription() const {
+  return "CPU NUMA " + std::to_string(anchorNumaNode_);
 }
 
 } // namespace comms::pipes

--- a/comms/pipes/rdma/NicDiscovery.h
+++ b/comms/pipes/rdma/NicDiscovery.h
@@ -47,6 +47,13 @@ inline const char* pathTypeToString(PathType pt) {
 }
 
 /**
+ * Get the NUMA node of the calling thread via getcpu(2) syscall.
+ *
+ * @return NUMA node number, or -1 on failure
+ */
+int getCurrentNumaNode();
+
+/**
  * NIC candidate information for topology-aware selection.
  */
 struct NicCandidate {
@@ -59,33 +66,23 @@ struct NicCandidate {
 };
 
 /**
- * NicDiscovery - Topology-aware RDMA NIC selection for GPUs.
+ * NicDiscovery - Base class for topology-aware RDMA NIC selection.
  *
- * Discovers and selects the best RDMA NIC for a given GPU based on
- * PCIe topology analysis (prefers closest NIC to GPU).
+ * Discovers and selects the best RDMA NIC based on PCIe/NUMA topology
+ * analysis. Subclasses define the topology ranking strategy:
  *
- * Usage:
- *   NicDiscovery discovery(0);  // Discovery happens in constructor
- *   const auto& candidates = discovery.getCandidates();
- *   std::string nicName = candidates[0].name;  // Best NIC first
+ *   // GPU-anchored: fine-grained PCIe topology ranking
+ *   GpuNicDiscovery discovery(0);
+ *
+ *   // CPU-anchored: NUMA affinity ranking
+ *   CpuNicDiscovery discovery(getCurrentNumaNode());
  *
  * This class only discovers and ranks NICs - it does not manage
  * any ibv_context*. The caller should open the selected device.
  */
 class NicDiscovery {
  public:
-  /**
-   * Constructor - performs NIC discovery for the given CUDA device.
-   *
-   * Discovery runs immediately, selecting the best NIC based on
-   * PCIe topology. After construction, call getCandidates()
-   * to retrieve the ranked NIC list.
-   *
-   * @param cudaDevice CUDA device index for GPU topology analysis
-   * @param ibHcaEnv NCCL_IB_HCA-style filter string (empty = no filtering)
-   * @throws std::runtime_error if no suitable NIC found
-   */
-  explicit NicDiscovery(int cudaDevice, const std::string& ibHcaEnv = {});
+  virtual ~NicDiscovery() = default;
 
   /**
    * Get all discovered NIC candidates, sorted best-to-worst.
@@ -95,17 +92,12 @@ class NicDiscovery {
   }
 
   /**
-   * Get the GPU's PCIe bus ID string.
+   * Get the anchor's NUMA node.
+   * For GPU-anchored: the GPU's NUMA node.
+   * For CPU-anchored: the NUMA node passed to the constructor.
    */
-  const std::string& getGpuPciBusId() const {
-    return gpuPciBusId_;
-  }
-
-  /**
-   * Get the GPU's NUMA node.
-   */
-  int getGpuNumaNode() const {
-    return gpuNumaNode_;
+  int getAnchorNumaNode() const {
+    return anchorNumaNode_;
   }
 
   // Static utility functions
@@ -115,11 +107,6 @@ class NicDiscovery {
    * CUDA returns uppercase (e.g., "0000:1B:00.0") but sysfs uses lowercase.
    */
   static std::string normalizePcieAddress(const std::string& pciBusId);
-
-  /**
-   * Get PCIe bus ID string from CUDA device.
-   */
-  static std::string getCudaPciBusId(int cudaDevice);
 
   /**
    * Get NUMA node for a PCIe device.
@@ -145,16 +132,12 @@ class NicDiscovery {
    */
   static std::string getPcieForIbDev(const char* devName);
 
- private:
-  // CUDA device index
-  int cudaDevice_;
+ protected:
+  // Protected constructor — only subclasses construct.
+  explicit NicDiscovery(const std::string& ibHcaEnv);
 
-  // GPU topology info (lazily initialized by initGpuTopology())
-  std::string gpuPciBusId_;
-  std::string gpuPcieNormalized_;
-  std::vector<std::string> gpuAncestorChain_;
-  std::unordered_set<std::string> gpuAncestors_;
-  int gpuNumaNode_{-1};
+  // Anchor NUMA node (GPU's NUMA for GPU-anchored, pass-in for CPU)
+  int anchorNumaNode_{-1};
 
   // IB HCA filter (empty = no filtering)
   IbHcaParser ibHcaParser_;
@@ -162,12 +145,102 @@ class NicDiscovery {
   // Discovered candidates (populated during discovery)
   std::vector<NicCandidate> candidates_;
 
-  // Private helpers
+  /**
+   * Discover and rank NICs. Called by subclass constructors after
+   * subclass-specific initialization is complete.
+   */
   void discover();
+
+  /**
+   * Compute the path type between the anchor device and a NIC.
+   * Subclasses override to implement their ranking strategy.
+   *
+   * @param nicPcie NIC's PCIe bus ID
+   * @param nicNuma NIC's NUMA node
+   * @return (PathType, hop count) pair
+   */
+  virtual std::pair<PathType, int> computePathType(
+      const std::string& nicPcie,
+      int nicNuma) const = 0;
+
+  /**
+   * Return a description of the anchor for log messages.
+   * E.g., "GPU 0000:1B:00.0" or "CPU NUMA 0".
+   */
+  virtual std::string anchorDescription() const = 0;
+};
+
+/**
+ * GpuNicDiscovery - GPU-anchored NIC selection using PCIe topology.
+ *
+ * Ranks NICs by PCIe ancestor walk from the CUDA GPU device,
+ * producing fine-grained path types (PIX/PXB/PHB/NODE/SYS).
+ */
+class GpuNicDiscovery : public NicDiscovery {
+ public:
+  /**
+   * Create a GPU-anchored NIC discovery.
+   *
+   * @param cudaDevice CUDA device index
+   * @param ibHcaEnv NCCL_IB_HCA-style filter string (empty = no filtering)
+   * @throws std::runtime_error if no suitable NIC found
+   */
+  explicit GpuNicDiscovery(int cudaDevice, const std::string& ibHcaEnv = {});
+
+  /**
+   * Get the anchor GPU's PCIe bus ID string.
+   */
+  const std::string& getAnchorPciBusId() const {
+    return anchorPciBusId_;
+  }
+
+  /**
+   * Get PCIe bus ID string from CUDA device.
+   */
+  static std::string getCudaPciBusId(int cudaDevice);
+
+ private:
   void initGpuTopology();
+
   std::pair<PathType, int> computePathType(
       const std::string& nicPcie,
-      int nicNuma) const;
+      int nicNuma) const override;
+
+  std::string anchorDescription() const override;
+
+  int cudaDevice_;
+  std::string anchorPciBusId_;
+  std::vector<std::string> anchorAncestorChain_;
+  std::unordered_set<std::string> anchorAncestors_;
+};
+
+/**
+ * CpuNicDiscovery - CPU-anchored NIC selection using NUMA affinity.
+ *
+ * Ranks NICs by NUMA affinity to the given node (NODE for same-NUMA,
+ * SYS for cross-NUMA). No CUDA dependency.
+ */
+class CpuNicDiscovery : public NicDiscovery {
+ public:
+  /**
+   * Create a CPU-anchored NIC discovery.
+   *
+   * The NUMA node is validated against sysfs; throws
+   * std::invalid_argument if the node does not exist.
+   *
+   * @param numaNode NUMA node to anchor on
+   * @param ibHcaEnv NCCL_IB_HCA-style filter string (empty = no filtering)
+   * @throws std::runtime_error if no suitable NIC found
+   * @throws std::invalid_argument if numaNode is invalid
+   */
+  explicit CpuNicDiscovery(int numaNode, const std::string& ibHcaEnv = {});
+
+ private:
+  std::pair<PathType, int> computePathType(
+      const std::string& nicPcie,
+      int nicNuma) const override;
+
+  std::string anchorDescription() const override;
 };
 
 } // namespace comms::pipes

--- a/comms/pipes/rdma/tests/NicDiscoveryTest.cc
+++ b/comms/pipes/rdma/tests/NicDiscoveryTest.cc
@@ -1,6 +1,7 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 #include <gtest/gtest.h>
+#include <spdlog/spdlog.h>
 
 #include "comms/pipes/rdma/NicDiscovery.h"
 
@@ -47,6 +48,45 @@ TEST(NicDiscoveryTest, NicCandidateDefaultConstruction) {
   EXPECT_EQ(candidate.bandwidthGbps, 0);
   EXPECT_EQ(candidate.numaNode, -1);
   EXPECT_EQ(candidate.nhops, -1);
+}
+
+// =============================================================================
+// CPU-Anchored Discovery Tests
+// =============================================================================
+
+TEST(NicDiscoveryTest, CpuAnchoredDiscovery) {
+  int numaNode = getCurrentNumaNode();
+  ASSERT_GE(numaNode, 0) << "Failed to get NUMA node for test";
+
+  try {
+    CpuNicDiscovery discovery(numaNode);
+    EXPECT_EQ(discovery.getAnchorNumaNode(), numaNode);
+
+    const auto& candidates = discovery.getCandidates();
+    EXPECT_FALSE(candidates.empty());
+    spdlog::info(
+        "CpuAnchoredDiscovery: anchor NUMA={}, discovered {} NICs:",
+        discovery.getAnchorNumaNode(),
+        candidates.size());
+    for (size_t i = 0; i < candidates.size(); i++) {
+      spdlog::info(
+          "  [{}] {} path={} bandwidth={} Gb/s numa={} nhops={}",
+          i,
+          candidates[i].name,
+          pathTypeToString(candidates[i].pathType),
+          candidates[i].bandwidthGbps,
+          candidates[i].numaNode,
+          candidates[i].nhops);
+    }
+  } catch (const std::runtime_error& e) {
+    spdlog::info(
+        "CpuAnchoredDiscovery: no IB devices in test env: {}", e.what());
+  }
+}
+
+TEST(NicDiscoveryTest, CpuAnchoredInvalidNumaNode) {
+  // NUMA node 9999 should not exist on any real system.
+  EXPECT_THROW(CpuNicDiscovery(9999), std::invalid_argument);
 }
 
 } // namespace comms::pipes::tests


### PR DESCRIPTION
Summary:
NicDiscovery was a single class with for_gpu()/for_cpu() factory methods
that set different internal modes. GPU-only state (PCIe ancestor chain,
CUDA bus ID) was carried as dead weight for CPU instances, and the GPU
path will get more complex (direct NIC mode, C2C path discovery).

Split into a base class + two concrete subclasses:

  NicDiscovery (base)
  ├── GpuNicDiscovery  — PCIe topology ranking, CUDA dependency
  └── CpuNicDiscovery  — NUMA affinity ranking, no CUDA

  // GPU-anchored: fine-grained PCIe topology ranking
  GpuNicDiscovery discovery(cudaDevice);

  // CPU-anchored: NUMA affinity ranking
  CpuNicDiscovery discovery(getCurrentNumaNode());

NicDiscovery base class owns shared logic: candidate list, IB HCA
filtering, sysfs enumeration, sorting, and static utilities
(normalizePcieAddress, getNumaNodeForPcie, etc.). computePathType()
is a pure virtual that each subclass overrides.

GpuNicDiscovery owns GPU-specific state (cudaDevice_, anchorPciBusId_,
PCIe ancestor chain) and does the full PCIe ancestor walk for
fine-grained path types (PIX/PXB/PHB/NODE/SYS).

CpuNicDiscovery validates the NUMA node via sysfs and ranks NICs by
NUMA affinity (NODE for same-socket, SYS for cross-socket). No CUDA
dependency.

Callers updated:
- MultipeerIbgdaTransport.cc: NicDiscovery::for_gpu() → GpuNicDiscovery()
- NicDiscoveryTest.cc: NicDiscovery::for_cpu() → CpuNicDiscovery()

Reviewed By: siyengar

Differential Revision: D94973720


