### PR TITLE
Disable NCCL_PXN_C2C if topo bound with 2.27

### DIFF
--- a/comms/ncclx/v2_28/src/misc/param.cc
+++ b/comms/ncclx/v2_28/src/misc/param.cc
@@ -103,6 +103,11 @@ void initEnv() {
   std::call_once(once, [] {
     meta::comms::initFolly();
     ncclCvarInit();
+    // To keep v2.28 has the same numeric behavior as v2.27
+    // TODO: remove this after numeric breakages rollout
+    if (!NCCL_TOPO_BOND_V228) {
+      NCCL_PXN_C2C = 0;
+    }
     initEnvFunc();
     initNcclLogger();
     initLegacyColltraceForCtran();


### PR DESCRIPTION
Summary:
`NCCL_PXN_C2C` by default is 0 on 2.27 but 1 on 2.28.
If `NCCL_TOPO_BOND_V228` is set by false (by default is true), we want to keep the same topology calculation as 2.27.

Differential Revision: D95295030


