### PR TITLE
Auto-tune BiDir AllGather threshold per GPU architecture

### DIFF
--- a/comms/ctran/algos/AllReduce/AllReduceRing.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceRing.cc
@@ -20,6 +20,7 @@
 #include "comms/ctran/algos/AllReduce/AllReduceRingAutoTune.h"
 #include "comms/ctran/algos/AllReduce/AllReduceRingCommon.cuh"
 #include "comms/ctran/algos/CtranAlgo.h"
+#include "comms/ctran/algos/CtranAlgoConsts.h"
 #include "comms/ctran/mapper/CtranMapper.h"
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -90,14 +91,34 @@ namespace ctran::allreduce::ring {
 // Check if bi-directional AllGather should be enabled based on CVAR and
 // message size.
 // Returns true if bidir AG should be used, false for simple kernel.
+//
+// CVAR values:
+//   0  = disabled
+//  -1  = enabled for all sizes
+//  -2  = auto-tune per GPU architecture (GB200: 128MB, H100: 4MB)
+//  >0  = enabled for messages up to that size in bytes
 inline bool shouldEnableBidirAg(size_t messageBytes) {
   int64_t maxSize = NCCL_CTRAN_ALLREDUCE_RING_BIDIR_AG_MAX_SIZE;
   if (maxSize == 0) {
     // Explicitly disabled
     return false;
   }
+  if (maxSize == -1) {
+    // Enable for all sizes
+    return true;
+  }
+  if (maxSize == -2) {
+    // Auto-tune: select threshold based on GPU architecture
+    int cudaDev = 0;
+    cudaGetDevice(&cudaDev);
+    int smMajor = 0;
+    cudaDeviceGetAttribute(
+        &smMajor, cudaDevAttrComputeCapabilityMajor, cudaDev);
+    maxSize = (smMajor < 10) ? static_cast<int64_t>(kHopperBidirAgMaxSize)
+                             : static_cast<int64_t>(kDefaultBidirAgMaxSize);
+  }
   if (maxSize < 0) {
-    // -1 means enable for all sizes
+    // Any other negative value: treat as enabled for all sizes
     return true;
   }
   // Enable only for messages up to maxSize

--- a/comms/ctran/algos/CtranAlgoConsts.h
+++ b/comms/ctran/algos/CtranAlgoConsts.h
@@ -11,6 +11,14 @@ constexpr size_t kDefaultMaxBDP =
     128ULL * 1024 * 1024; // 128MB (GB200/Blackwell)
 constexpr size_t kHopperMaxBDP = 32ULL * 1024 * 1024; // 32MB (H100)
 
+// Per-arch BiDir AllGather thresholds (used by auto-tune, CVAR value -2).
+// BiDir AG sends data in both directions during AllGather; beneficial for
+// messages up to approximately the BDP where ring latency dominates.
+constexpr size_t kDefaultBidirAgMaxSize =
+    128ULL * 1024 * 1024; // 128MB (GB200/Blackwell)
+constexpr size_t kHopperBidirAgMaxSize =
+    4ULL * 1024 * 1024; // 4MB (H100/Hopper)
+
 // Maximum BDP across all architectures — used for buffer pre-allocation
 // when the arch is not yet known.
 constexpr size_t kMaxBDP = kDefaultMaxBDP;

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2858,15 +2858,15 @@ cvars:
 
  - name        : NCCL_CTRAN_ALLREDUCE_RING_BIDIR_AG_MAX_SIZE
    type        : int64_t
-   default     : 4194304
+   default     : -2
    description : |-
      Maximum message size in bytes for bi-directional AllGather optimization
      in AllReduceRing. Bi-directional AG sends data in both directions
      simultaneously during the AllGather phase, reducing total steps.
      Set to 0 to disable bi-directional AG entirely.
      Set to -1 to enable for all message sizes.
-     Set to a positive value to enable only for messages up to that size
-     (default: 4194304 bytes / 4MB).
+     Set to -2 to auto-tune per GPU architecture (GB200: 128MB, H100: 4MB).
+     Set to a positive value to enable only for messages up to that size.
 
  - name        : NCCL_CTRAN_ENABLE_FAULT_TOLERANCE
    type        : bool


### PR DESCRIPTION
Summary:
Change the default of NCCL_CTRAN_ALLREDUCE_RING_BIDIR_AG_MAX_SIZE from a
hardcoded 128MB to -2 (auto-tune), which selects a per-GPU-architecture
threshold at runtime:
- GB200 (Blackwell, SM >= 10): 128MB
- H100 (Hopper, SM < 10): 4MB (conservative)

BiDir AllGather sends data in both directions during the AllGather phase
of AllReduceRing, reducing total steps. It benefits small-to-medium
messages where ring latency dominates, but hurts large messages where
the extra coordination overhead outweighs the reduced step count.

The optimal crossover depends on the platform's bandwidth-delay product
(BDP), which varies by GPU architecture:

**GB200 benchmarks** (aarch64, IB-only, ppn=1, 8/16/32/64 nodes):
- BiDir consistently outperforms NoBidir for messages up to 64-128MB
- 1M-64M: +10-28% busBW improvement
- 128M+: marginal or mixed results

**H100 benchmarks** (x86_64, IB-only, ppn=1, 8/16/32/64 nodes):
- BiDir wins at smaller sizes, crossover scales with node count:
  - 8N:  BiDir wins up to 4MB (+6.1%)
  - 16N: BiDir wins up to 8MB (+10.3%)
  - 32N: BiDir wins up to 16MB (+12.8%)
  - 64N: BiDir wins up to 32MB (+16.5%)
- Conservative threshold: 4MB (safe across all node counts)

**MCCL Auto-Tuned vs NCCL baseline (H100, sizes >= 512KB):**
| Nodes | Avg % Diff | Min % Diff | Max % Diff |
|-------|-----------|-----------|-----------|
| 8N    | +0.5%     | -0.3%     | +3.6%     |
| 16N   | -0.9%     | -5.2%     | +6.9%     |
| 32N   | +0.9%     | -4.8%     | +19.4%    |
| 64N   | +3.1%     | -0.5%     | +17.0%    |

CVAR semantics updated:
- 0: disabled
- -1: enabled for all sizes
- -2: auto-tune per GPU architecture (new default)
- >0: explicit threshold in bytes

Differential Revision: D94867201


