### PR TITLE
Add OS auto-detection to os.h to fix test build failures

### DIFF
--- a/comms/ncclx/v2_29/src/graph/paths.cc
+++ b/comms/ncclx/v2_29/src/graph/paths.cc
@@ -7,6 +7,7 @@
 
 #include "core.h"
 #include "graph.h"
+#include "os.h"
 #include "topo.h"
 #include "comm.h"
 #include "net.h"

--- a/comms/ncclx/v2_29/src/include/cpuset.h
+++ b/comms/ncclx/v2_29/src/include/cpuset.h
@@ -9,6 +9,7 @@
 #define NCCL_CPUSET_H_
 
 #include "nccl.h"
+#include "os.h"
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>

--- a/comms/ncclx/v2_29/src/include/os.h
+++ b/comms/ncclx/v2_29/src/include/os.h
@@ -15,6 +15,14 @@
 #include <ctime>
 #include <mutex>
 
+#if !defined(NCCL_OS_LINUX) && !defined(NCCL_OS_WINDOWS)
+#if defined(_WIN32) || defined(_WIN64)
+#define NCCL_OS_WINDOWS
+#else
+#define NCCL_OS_LINUX
+#endif
+#endif
+
 #ifdef NCCL_OS_WINDOWS
 #include <windows.h>
 #include <winsock2.h>


### PR DESCRIPTION
Summary:
Tests that include comm.h (transitively via TestUtils.h) fail to compile
because os.h conditionally defines ncclSocketDescriptor and ncclAffinity
types based on NCCL_OS_LINUX/NCCL_OS_WINDOWS macros. While the NCCLX
library build passes -DNCCL_OS_LINUX in its compiler flags, test targets
using nccl_cpp_unittest/nccl_cpp_distributed_unittest_suite do not
inherit these flags when including the headers.

This adds auto-detection of the OS at the top of os.h: if neither
NCCL_OS_LINUX nor NCCL_OS_WINDOWS is explicitly defined, it defaults
to Linux (or Windows based on _WIN32/_WIN64). This ensures the types
are always defined regardless of how the header is included.

Fixes ~36 v2_29 test targets that were failing with:
- unknown type name 'ncclSocketDescriptor' (os.h, socket.h)
- unknown type name 'ncclAffinity' (os.h, graph.h, comm.h)

*Crafted with care by Navi*

Differential Revision: D95334192


