### PR TITLE
Fix rma_test: migrate to NcclxBaseTest for TCPStore support

### DIFF
--- a/comms/ncclx/v2_28/meta/rma/tests/RMATest.cc
+++ b/comms/ncclx/v2_28/meta/rma/tests/RMATest.cc
@@ -11,21 +11,24 @@
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
 
-class RMATest : public ::testing::Test {
+class RMATest : public NcclxBaseTest {
  public:
   RMATest() = default;
-  ncclComm_t comm{nullptr};
 
  protected:
   void SetUp() override {
     setenv("NCCL_CTRAN_ENABLE", "1", 0); // enable ctran
     setenv("NCCL_CTRAN_IB_EPOCH_LOCK_ENFORCE_CHECK", "true", 0);
 
-    std::tie(this->localRank, this->globalRank, this->numRanks) = getMpiInfo();
+    NcclxBaseTest::SetUp();
 
-    CUDACHECK_TEST(cudaSetDevice(this->localRank));
-    this->comm =
-        createNcclComm(this->globalRank, this->numRanks, this->localRank);
+    this->comm = createNcclComm(
+        this->globalRank,
+        this->numRanks,
+        this->localRank,
+        false,
+        nullptr,
+        server.get());
     ASSERT_NE(this->comm, nullptr);
   }
   void TearDown() override {
@@ -33,6 +36,7 @@ class RMATest : public ::testing::Test {
     NCCLCHECK_TEST(ncclCommDestroy(this->comm));
     // Check that all allocated memory segments have been freed
     EXPECT_TRUE(segments.empty()) << "Not all memory segments were freed";
+    NcclxBaseTest::TearDown();
   }
 
   void barrier(ncclComm_t ncclComm, cudaStream_t stream) {
@@ -92,9 +96,6 @@ class RMATest : public ::testing::Test {
     }
   }
 
-  int localRank{0};
-  int globalRank{0};
-  int numRanks{0};
   std::vector<TestMemSegment> segments;
 };
 
@@ -548,7 +549,12 @@ TEST_P(NvlEnabledTestParam, ncclWinGetAttributes) {
 
   // create a test comm using the provided backends
   ncclComm_t comm = createNcclComm(
-      this->globalRank, this->numRanks, this->localRank, false, nullptr);
+      this->globalRank,
+      this->numRanks,
+      this->localRank,
+      false,
+      nullptr,
+      server.get());
   ASSERT_NE(comm, nullptr);
 
   auto statex = comm->ctranComm_->statex_.get();


### PR DESCRIPTION
Summary:
RMATest extended ::testing::Test directly and called getMpiInfo() which crashes
in RE/TCPStore environments where MPI isn't initialized. Migrated to NcclxBaseTest
base class which handles both MPI and TCPStore via getTcpStoreOrMpiInfo(), and
pass server.get() to createNcclComm() for TCPStore-based unique ID broadcast.

Reviewed By: saifhhasan

Differential Revision: D95122239


