### PR TITLE
Fix topo_test: preserve error state in ncclTopoGetSystem on success

### DIFF
--- a/comms/ncclx/v2_28/meta/tests/topoTest.cc
+++ b/comms/ncclx/v2_28/meta/tests/topoTest.cc
@@ -29,10 +29,13 @@ class topoTest : public ::testing::Test {
 
 TEST_F(topoTest, defaultTopoXmlNotFound) {
   folly::test::TemporaryFile dumpXmlFile;
+  // Capture error state before calling ncclTopoGetSystem.
+  auto lastErrBefore = std::string(ncclGetLastError(mockComm));
   auto res = ncclTopoGetSystem(mockComm, nullptr, dumpXmlFile.path().c_str());
   EXPECT_EQ(res, ncclSuccess);
   auto lastErr = std::string(ncclGetLastError(mockComm));
-  EXPECT_TRUE(lastErr.empty());
+  // ncclTopoGetSystem should not modify the error state when returning success.
+  EXPECT_EQ(lastErr, lastErrBefore);
   // print the dump xml file
   std::ifstream dumpXml(dumpXmlFile.path().c_str());
   std::string dumpXmlStr(

--- a/comms/ncclx/v2_28/src/debug.cc
+++ b/comms/ncclx/v2_28/src/debug.cc
@@ -495,6 +495,14 @@ void ncclResetDebugInit() {
   ncclResetDebugInitInternal();
 }
 
+size_t ncclGetErrorStackSize() {
+  return ::meta::comms::logger::getErrorStackSize();
+}
+
+void ncclTruncateErrorStack(size_t size) {
+  ::meta::comms::logger::truncateErrorStack(size);
+}
+
 NCCL_PARAM(SetThreadName, "SET_THREAD_NAME", 0);
 
 void ncclSetThreadName(pthread_t thread, const char *fmt, ...) {

--- a/comms/ncclx/v2_28/src/graph/topo.cc
+++ b/comms/ncclx/v2_28/src/graph/topo.cc
@@ -1415,6 +1415,10 @@ static std::mutex netMutex;
 
 ncclResult_t ncclTopoGetSystem(struct ncclComm* comm, struct ncclTopoSystem** system, const char* dumpXmlFile) {
   ncclResult_t ret = ncclSuccess;
+  // Save error stack size so we can restore it if this function succeeds,
+  // preventing transient topology detection warnings from polluting the
+  // error state visible to callers.
+  size_t savedErrorStackSize = ncclGetErrorStackSize();
   struct ncclXml* xml;
   char* mem = NULL;
   int* localRanks = NULL;
@@ -1541,6 +1545,9 @@ ncclResult_t ncclTopoGetSystem(struct ncclComm* comm, struct ncclTopoSystem** sy
   if (dumpXmlFile == NULL) NCCLCHECKGOTO(ncclTopoGetSystemFromXml(xml, system, getHostHash()), ret, fail);
 
 exit:
+  if (ret == ncclSuccess) {
+    ncclTruncateErrorStack(savedErrorStackSize);
+  }
   if (!comm->MNNVL && localRanks) free(localRanks);
   if (mem) free(mem);
   free(xml);

--- a/comms/ncclx/v2_28/src/include/debug.h
+++ b/comms/ncclx/v2_28/src/include/debug.h
@@ -79,6 +79,9 @@ void ncclResetDebugInit();
 
 void ncclSetMyThreadLoggingName(std::string_view name);
 
+size_t ncclGetErrorStackSize();
+void ncclTruncateErrorStack(size_t size);
+
 #define NCCL_NAMED_THREAD_START(threadName)       \
   do {                                            \
     ncclSetMyThreadLoggingName(threadName);       \

--- a/comms/utils/logger/LoggingFormat.cc
+++ b/comms/utils/logger/LoggingFormat.cc
@@ -361,6 +361,17 @@ void appendErrorToStack(std::string error) {
   lastCommsError.wlock()->lastErrorStack.push_back(std::move(error));
 }
 
+std::size_t getErrorStackSize() {
+  return lastCommsError.rlock()->lastErrorStack.size();
+}
+
+void truncateErrorStack(std::size_t size) {
+  auto locked = lastCommsError.wlock();
+  if (size < locked->lastErrorStack.size()) {
+    locked->lastErrorStack.resize(size);
+  }
+}
+
 NcclLogFormatter::NcclLogFormatter(
     std::string prefix,
     std::function<int(void)> threadContextFn)

--- a/comms/utils/logger/LoggingFormat.h
+++ b/comms/utils/logger/LoggingFormat.h
@@ -65,6 +65,10 @@ const char* getLastCommsError();
 
 void appendErrorToStack(std::string error);
 
+std::size_t getErrorStackSize();
+
+void truncateErrorStack(std::size_t size);
+
 class NcclLogFormatter : public folly::LogFormatter {
  public:
   NcclLogFormatter(


### PR DESCRIPTION
Summary:
ncclTopoGetSystem can pollute the process-global error stack (via                                                                                                                                              
  appendErrorToStack in NCCLCHECK/NCCLCHECKGOTO macros) even when returning
  ncclSuccess, causing ncclGetLastError to return stale warnings from                                                                                                                                            
  transient topology detection issues.                      

  Fix by saving the error stack depth at the start of ncclTopoGetSystem and
  restoring it when the function returns success. This ensures the function
  is a no-op on the error state when it succeeds, while preserving the full
  error trace on failure.

  - Add getErrorStackSize() and truncateErrorStack() to the comms logger API
  - Add ncclGetErrorStackSize() and ncclTruncateErrorStack() wrappers in
    debug.h/debug.cc (avoids including LoggingFormat.h from topo.cc where
    the NET macro conflicts with the logger's SubSystem enum)
  - Update topo_test to verify ncclTopoGetSystem does not modify the error
    state when returning success

Differential Revision: D95122172


