### PR TITLE
Add DCI Streams support to ibverbx for per-stream fault isolation (#958)

### DIFF
--- a/comms/ctran/ibverbx/IbverbxSymbols.cc
+++ b/comms/ctran/ibverbx/IbverbxSymbols.cc
@@ -398,6 +398,24 @@ void linked_mlx5dv_wr_set_dc_addr(
       remote_dctn,
       remote_dc_key);
 }
+
+void linked_mlx5dv_wr_set_dc_addr_stream(
+    struct mlx5dv_qp_ex* mqp,
+    struct ibv_ah* ah,
+    uint32_t remote_dctn,
+    uint64_t remote_dc_key,
+    uint16_t stream_id) {
+  mlx5dv_wr_set_dc_addr_stream(
+      reinterpret_cast<::mlx5dv_qp_ex*>(mqp),
+      reinterpret_cast<::ibv_ah*>(ah),
+      remote_dctn,
+      remote_dc_key,
+      stream_id);
+}
+
+int linked_mlx5dv_dci_stream_id_reset(struct ibv_qp* qp, uint16_t stream_id) {
+  return mlx5dv_dci_stream_id_reset(reinterpret_cast<::ibv_qp*>(qp), stream_id);
+}
 #endif
 
 // Wrapper functions for extended QP operations
@@ -505,6 +523,10 @@ int buildIbvSymbols(IbvSymbols& symbols, const std::string& ibv_path) {
   symbols.ibv_internal_wr_set_sge_list = &linked_wr_set_sge_list;
   symbols.ibv_internal_wr_complete = &linked_wr_complete;
   symbols.mlx5dv_internal_wr_set_dc_addr = &linked_mlx5dv_wr_set_dc_addr;
+  symbols.mlx5dv_internal_wr_set_dc_addr_stream =
+      &linked_mlx5dv_wr_set_dc_addr_stream;
+  symbols.mlx5dv_internal_dci_stream_id_reset =
+      &linked_mlx5dv_dci_stream_id_reset;
 
   return 0;
 #else
@@ -659,6 +681,11 @@ int buildIbvSymbols(IbvSymbols& symbols, const std::string& ibv_path) {
       "mlx5dv_reg_dmabuf_mr",
       symbols.mlx5dv_internal_reg_dmabuf_mr,
       "MLX5_1.25");
+  // Cherry-pick the mlx5dv_dci_stream_id_reset API from MLX5 1.21
+  LOAD_MLX5DV_SYM_VERSION(
+      "mlx5dv_dci_stream_id_reset",
+      symbols.mlx5dv_internal_dci_stream_id_reset,
+      "MLX5_1.21");
 
   // all symbols were loaded successfully, dismiss guard
   guard.dismiss();

--- a/comms/ctran/ibverbx/IbverbxSymbols.h
+++ b/comms/ctran/ibverbx/IbverbxSymbols.h
@@ -179,6 +179,17 @@ struct IbvSymbols {
       struct ibv_ah* ah,
       uint32_t remote_dctn,
       uint64_t remote_dc_key) = nullptr;
+
+  /* DCI Streams support */
+  void (*mlx5dv_internal_wr_set_dc_addr_stream)(
+      struct mlx5dv_qp_ex* mqp,
+      struct ibv_ah* ah,
+      uint32_t remote_dctn,
+      uint64_t remote_dc_key,
+      uint16_t stream_id) = nullptr;
+  int (*mlx5dv_internal_dci_stream_id_reset)(
+      struct ibv_qp* qp,
+      uint16_t stream_id) = nullptr;
 };
 
 extern IbvSymbols ibvSymbols;

--- a/comms/ctran/ibverbx/benchmarks/IbverbxDcBenchUtils.h
+++ b/comms/ctran/ibverbx/benchmarks/IbverbxDcBenchUtils.h
@@ -775,6 +775,25 @@ inline int postDcRdmaWrite(
       exQp, dvQp, ah, target.dctNum, target.rkey, target.remoteAddr, sge, wrId);
 }
 
+// Post DC RDMA write with DCI stream ID (DcBusinessCard variant)
+inline int postDcRdmaWriteStream(
+    ibv_qp_ex* exQp,
+    mlx5dv_qp_ex* dvQp,
+    IbvAh& ah,
+    const DcBusinessCard& target,
+    ibv_sge& sge,
+    uint64_t wrId,
+    uint16_t streamId) {
+  ibvSymbols.ibv_internal_wr_start(exQp);
+  exQp->wr_id = wrId;
+  exQp->wr_flags = IBV_SEND_SIGNALED;
+  ibvSymbols.ibv_internal_wr_rdma_write(exQp, target.rkey, target.remoteAddr);
+  ibvSymbols.ibv_internal_wr_set_sge_list(exQp, 1, &sge);
+  ibvSymbols.mlx5dv_internal_wr_set_dc_addr_stream(
+      dvQp, ah.ah(), target.dctNum, DC_KEY, streamId);
+  return ibvSymbols.ibv_internal_wr_complete(exQp);
+}
+
 // Standalone RC QP connection (INIT -> RTR -> RTS)
 inline bool
 connectRcQp(IbvQp& localQp, const ibv_gid& remoteGid, uint32_t remoteQpNum) {

--- a/comms/ctran/ibverbx/benchmarks/IbverbxDcOneToManyBench.cc
+++ b/comms/ctran/ibverbx/benchmarks/IbverbxDcOneToManyBench.cc
@@ -11,6 +11,8 @@
  *   Peer count sweep (N=2..2048, msg_size = 128MB / N):
  *     dcScalability           — DC baseline (1 AH, 1 MR, 1 DCI, 1 receiver NIC)
  *     dcMultiDci{2,4,8,16}    — multiple DCIs/DCTs on 1 receiver NIC
+ *     dcStreams{4,16}         — 1 DCI with DCI Streams enabled
+ *     dcMultiDci4Streams4     — 4 DCIs with 4 streams per DCI
  *     dcMultiNicRoundRobin    — multi-NIC receivers, round-robin write ordering
  *     dcMultiNicSorted        — multi-NIC receivers, writes grouped by dest NIC
  *     rcScalability           — RC baseline for comparison
@@ -213,7 +215,8 @@ static void dcMultiDciCore(
     size_t msgSize,
     int numDcis,
     folly::UserCounters& counters,
-    const char* benchName);
+    const char* benchName,
+    uint8_t logNumConcurrentStreams = 0);
 
 static void dcScalabilityCore(
     uint32_t iters,
@@ -550,11 +553,20 @@ static void dcMultiDciCore(
     size_t msgSize,
     int numDcis,
     folly::UserCounters& counters,
-    const char* benchName) {
+    const char* benchName,
+    uint8_t logNumConcurrentStreams) {
   if (!g_rdmaAvailability.checkDcAvailable()) {
     setSkipped(counters);
     return;
   }
+
+  bool useStreams = logNumConcurrentStreams > 0;
+  if (useStreams &&
+      !ibverbx::ibvSymbols.mlx5dv_internal_wr_set_dc_addr_stream) {
+    setSkipped(counters);
+    return;
+  }
+  int numStreamsPerDci = useStreams ? (1 << logNumConcurrentStreams) : 0;
 
   int numReceivers = static_cast<int>(numPeers) - 1;
   if (numReceivers < 1) {
@@ -594,9 +606,12 @@ static void dcMultiDciCore(
   };
   std::vector<DciState> dcis(numDcis);
   for (int d = 0; d < numDcis; ++d) {
-    auto dciResult = createDCILargeSq(*sender.pd, *sender.cq, kDciSqDepth);
+    auto dciResult = useStreams
+        ? createDCILargeSqWithStreams(
+              *sender.pd, *sender.cq, kDciSqDepth, logNumConcurrentStreams)
+        : createDCILargeSq(*sender.pd, *sender.cq, kDciSqDepth);
     if (!dciResult) {
-      setError(counters);
+      useStreams ? setSkipped(counters) : setError(counters);
       return;
     }
     dcis[d].qp = std::make_unique<ibverbx::IbvQp>(std::move(*dciResult));
@@ -684,6 +699,22 @@ static void dcMultiDciCore(
   // Batch size: match all-to-all formula (numDcis * SQ depth, capped by CQ)
   int batch = std::min(numDcis * kDciSqDepth, kSharedCqDepth);
 
+  auto postWrite = [&](int idx) {
+    int d = idx % numDcis;
+    if (useStreams) {
+      return postDcRdmaWriteStream(
+          dcis[d].exQp,
+          dcis[d].dvQp,
+          *ah,
+          recvCards[idx],
+          sge,
+          idx,
+          static_cast<uint16_t>(idx % numStreamsPerDci));
+    }
+    return postDcRdmaWrite(
+        dcis[d].exQp, dcis[d].dvQp, *ah, recvCards[idx], sge, idx);
+  };
+
   // Warmup
   for (int w = 0; w < kWarmupIters; ++w) {
     int rem = numReceivers;
@@ -691,10 +722,7 @@ static void dcMultiDciCore(
     while (rem > 0) {
       int b = std::min(rem, batch);
       for (int j = 0; j < b; ++j) {
-        int d = idx % numDcis;
-        if (postDcRdmaWrite(
-                dcis[d].exQp, dcis[d].dvQp, *ah, recvCards[idx], sge, idx) !=
-            0) {
+        if (postWrite(idx) != 0) {
           setError(counters);
           return;
         }
@@ -721,10 +749,7 @@ static void dcMultiDciCore(
 
       auto postStart = std::chrono::high_resolution_clock::now();
       for (int j = 0; j < thisBatch; ++j) {
-        int d = idx % numDcis;
-        if (postDcRdmaWrite(
-                dcis[d].exQp, dcis[d].dvQp, *ah, recvCards[idx], sge, idx) !=
-            0) {
+        if (postWrite(idx) != 0) {
           setError(counters);
           return;
         }
@@ -772,6 +797,8 @@ static void dcMultiDciCore(
   counters["num_receiver_nics"] =
       folly::UserMetric(1, folly::UserMetric::Type::METRIC);
   counters["num_ahs"] = folly::UserMetric(1, folly::UserMetric::Type::METRIC);
+  counters["num_streams_per_dci"] =
+      folly::UserMetric(numStreamsPerDci, folly::UserMetric::Type::METRIC);
 
   recordRawResult(
       benchName,
@@ -812,6 +839,44 @@ dcMultiDci16(uint32_t iters, size_t numPeers, folly::UserCounters& counters) {
       16,
       counters,
       "dcMultiDci_16");
+}
+
+static void
+dcStreams4(uint32_t iters, size_t numPeers, folly::UserCounters& counters) {
+  dcMultiDciCore(
+      iters,
+      numPeers,
+      kTotalInputSize / numPeers,
+      1,
+      counters,
+      "dcStreams_4",
+      2); // log2(4) = 2
+}
+
+static void
+dcStreams16(uint32_t iters, size_t numPeers, folly::UserCounters& counters) {
+  dcMultiDciCore(
+      iters,
+      numPeers,
+      kTotalInputSize / numPeers,
+      1,
+      counters,
+      "dcStreams_16",
+      4); // log2(16) = 4
+}
+
+static void dcMultiDci4Streams4(
+    uint32_t iters,
+    size_t numPeers,
+    folly::UserCounters& counters) {
+  dcMultiDciCore(
+      iters,
+      numPeers,
+      kTotalInputSize / numPeers,
+      4,
+      counters,
+      "dcMultiDci4_streams4",
+      2); // log2(4) = 2
 }
 
 // Wrapper: message size sweep with 4 DCIs at N=2048
@@ -1144,6 +1209,51 @@ REGISTER_SCALABILITY_BENCH(dcMultiDci16, N256, 256);
 REGISTER_SCALABILITY_BENCH(dcMultiDci16, N512, 512);
 REGISTER_SCALABILITY_BENCH(dcMultiDci16, N1024, 1024);
 REGISTER_SCALABILITY_BENCH(dcMultiDci16, N2048, 2048);
+
+BENCHMARK_DRAW_LINE();
+
+// DC Streams (4 concurrent streams, 1 DCI)
+REGISTER_SCALABILITY_BENCH(dcStreams4, N2, 2);
+REGISTER_SCALABILITY_BENCH(dcStreams4, N4, 4);
+REGISTER_SCALABILITY_BENCH(dcStreams4, N8, 8);
+REGISTER_SCALABILITY_BENCH(dcStreams4, N16, 16);
+REGISTER_SCALABILITY_BENCH(dcStreams4, N32, 32);
+REGISTER_SCALABILITY_BENCH(dcStreams4, N64, 64);
+REGISTER_SCALABILITY_BENCH(dcStreams4, N128, 128);
+REGISTER_SCALABILITY_BENCH(dcStreams4, N256, 256);
+REGISTER_SCALABILITY_BENCH(dcStreams4, N512, 512);
+REGISTER_SCALABILITY_BENCH(dcStreams4, N1024, 1024);
+REGISTER_SCALABILITY_BENCH(dcStreams4, N2048, 2048);
+
+BENCHMARK_DRAW_LINE();
+
+// DC Streams (16 concurrent streams, 1 DCI)
+REGISTER_SCALABILITY_BENCH(dcStreams16, N2, 2);
+REGISTER_SCALABILITY_BENCH(dcStreams16, N4, 4);
+REGISTER_SCALABILITY_BENCH(dcStreams16, N8, 8);
+REGISTER_SCALABILITY_BENCH(dcStreams16, N16, 16);
+REGISTER_SCALABILITY_BENCH(dcStreams16, N32, 32);
+REGISTER_SCALABILITY_BENCH(dcStreams16, N64, 64);
+REGISTER_SCALABILITY_BENCH(dcStreams16, N128, 128);
+REGISTER_SCALABILITY_BENCH(dcStreams16, N256, 256);
+REGISTER_SCALABILITY_BENCH(dcStreams16, N512, 512);
+REGISTER_SCALABILITY_BENCH(dcStreams16, N1024, 1024);
+REGISTER_SCALABILITY_BENCH(dcStreams16, N2048, 2048);
+
+BENCHMARK_DRAW_LINE();
+
+// DC Multi-DCI (4 DCIs) + Streams (4 concurrent streams per DCI)
+REGISTER_SCALABILITY_BENCH(dcMultiDci4Streams4, N2, 2);
+REGISTER_SCALABILITY_BENCH(dcMultiDci4Streams4, N4, 4);
+REGISTER_SCALABILITY_BENCH(dcMultiDci4Streams4, N8, 8);
+REGISTER_SCALABILITY_BENCH(dcMultiDci4Streams4, N16, 16);
+REGISTER_SCALABILITY_BENCH(dcMultiDci4Streams4, N32, 32);
+REGISTER_SCALABILITY_BENCH(dcMultiDci4Streams4, N64, 64);
+REGISTER_SCALABILITY_BENCH(dcMultiDci4Streams4, N128, 128);
+REGISTER_SCALABILITY_BENCH(dcMultiDci4Streams4, N256, 256);
+REGISTER_SCALABILITY_BENCH(dcMultiDci4Streams4, N512, 512);
+REGISTER_SCALABILITY_BENCH(dcMultiDci4Streams4, N1024, 1024);
+REGISTER_SCALABILITY_BENCH(dcMultiDci4Streams4, N2048, 2048);
 
 BENCHMARK_DRAW_LINE();
 

--- a/comms/ctran/ibverbx/tests/IbverbxDciStreamsTest.cc
+++ b/comms/ctran/ibverbx/tests/IbverbxDciStreamsTest.cc
@@ -1,0 +1,436 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <chrono>
+#include <optional>
+#include <vector>
+
+#include <folly/init/Init.h>
+#include <folly/logging/Init.h>
+#include <folly/logging/xlog.h>
+#include <gtest/gtest.h>
+
+#include "comms/ctran/ibverbx/Ibverbx.h"
+#include "comms/ctran/ibverbx/IbverbxSymbols.h"
+#include "comms/ctran/ibverbx/benchmarks/IbverbxDcBenchUtils.h"
+#include "comms/ctran/ibverbx/tests/dc_utils.h"
+
+FOLLY_INIT_LOGGING_CONFIG(
+    ".=WARNING"
+    ";default:async=true,sync_level=WARNING");
+
+namespace ibverbx {
+
+class DciStreamsTestFixture : public ::testing::Test {
+ protected:
+  void SetUp() override {
+#if defined(__HIP_PLATFORM_AMD__)
+    GTEST_SKIP() << "DCI Streams not supported on AMD platform";
+#else
+    ASSERT_TRUE(ibvInit());
+    initTwoDctStreamContext();
+    initBufferAndAddressHandles();
+#endif
+  }
+
+  void initTwoDctStreamContext() {
+    auto devices = IbvDevice::ibvGetDeviceList({kNicPrefix});
+    ASSERT_TRUE(devices);
+    devices_.emplace(std::move(*devices));
+    auto& device = devices_->at(0);
+
+    auto pd = device.allocPd();
+    ASSERT_TRUE(pd);
+    pd_.emplace(std::move(*pd));
+
+    auto cq = device.createCq(kCqe, nullptr, nullptr, 0);
+    ASSERT_TRUE(cq);
+    cq_.emplace(std::move(*cq));
+
+    auto srq = createSRQ(*pd_);
+    if (srq.hasError() && srq.error().errNum == ENOSYS) {
+      GTEST_SKIP() << "ibv_create_srq not available";
+    }
+    ASSERT_TRUE(srq) << "createSRQ failed: " << srq.error().errStr;
+    srq_.emplace(std::move(*srq));
+
+    auto dctA = createDCT(*pd_, *cq_, *srq_);
+    if (dctA.hasError() && dctA.error().errNum == ENOTSUP) {
+      GTEST_SKIP() << "DC QP creation not supported";
+    }
+    ASSERT_TRUE(dctA) << "createDCT(A) failed: " << dctA.error().errStr;
+    dctA_.emplace(std::move(*dctA));
+
+    auto dctB = createDCT(*pd_, *cq_, *srq_);
+    ASSERT_TRUE(dctB) << "createDCT(B) failed: " << dctB.error().errStr;
+    dctB_.emplace(std::move(*dctB));
+
+    auto dctARtr = transitionDCTToRtr(*dctA_, kPortNum, kDefaultMtu);
+    ASSERT_TRUE(dctARtr) << "DCT-A RTR failed: " << dctARtr.error().errStr;
+
+    auto dctBRtr = transitionDCTToRtr(*dctB_, kPortNum, kDefaultMtu);
+    ASSERT_TRUE(dctBRtr) << "DCT-B RTR failed: " << dctBRtr.error().errStr;
+
+    auto dci = createDCIWithStreams(*pd_, *cq_);
+    if (dci.hasError()) {
+      GTEST_SKIP() << "DCI Streams not supported on this NIC (errno="
+                   << dci.error().errNum << ": " << dci.error().errStr << ")";
+    }
+    dci_.emplace(std::move(*dci));
+
+    auto dciRts = transitionDCIToRts(*dci_, kPortNum, kDefaultMtu);
+    ASSERT_TRUE(dciRts) << "DCI RTS failed: " << dciRts.error().errStr;
+
+    ASSERT_NE(ibvSymbols.mlx5dv_internal_wr_set_dc_addr_stream, nullptr)
+        << "mlx5dv_wr_set_dc_addr_stream not available";
+
+    exQp_ = ibvSymbols.ibv_internal_qp_to_qp_ex(dci_->qp());
+    dvQp_ = ibvSymbols.mlx5dv_internal_qp_ex_from_ibv_qp_ex(exQp_);
+    ASSERT_NE(exQp_, nullptr);
+    ASSERT_NE(dvQp_, nullptr);
+
+    auto gid = device.queryGid(kPortNum, kGidIndex);
+    ASSERT_TRUE(gid);
+    gid_ = *gid;
+  }
+
+  void initBufferAndAddressHandles() {
+    buf_.resize(kBufSize, 0);
+    auto mr = pd_->regMr(buf_.data(), buf_.size(), defaultMrAccess());
+    ASSERT_TRUE(mr);
+    mr_.emplace(std::move(*mr));
+
+    sge_.addr = reinterpret_cast<uint64_t>(buf_.data());
+    sge_.length = 64;
+    sge_.lkey = mr_->mr()->lkey;
+
+    cardA_ = makeDcBusinessCard(
+        dctA_->qp()->qp_num,
+        gid_,
+        reinterpret_cast<uint64_t>(buf_.data()),
+        mr_->mr()->rkey);
+    cardB_ = makeDcBusinessCard(
+        dctB_->qp()->qp_num,
+        gid_,
+        reinterpret_cast<uint64_t>(buf_.data()),
+        mr_->mr()->rkey);
+
+    auto ahA = createAddressHandle(*pd_, cardA_);
+    ASSERT_TRUE(ahA) << "createAddressHandle(A) failed: " << ahA.error().errStr;
+    ahA_.emplace(std::move(*ahA));
+
+    auto ahB = createAddressHandle(*pd_, cardB_);
+    ASSERT_TRUE(ahB) << "createAddressHandle(B) failed: " << ahB.error().errStr;
+    ahB_.emplace(std::move(*ahB));
+  }
+
+  static ibv_access_flags defaultMrAccess() {
+    return static_cast<ibv_access_flags>(
+        IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE |
+        IBV_ACCESS_REMOTE_READ);
+  }
+
+  static constexpr int kCqe = 1024;
+  static constexpr size_t kBufSize = 4096;
+
+  std::optional<std::vector<IbvDevice>> devices_;
+  std::optional<IbvPd> pd_;
+  std::optional<IbvCq> cq_;
+  std::optional<IbvSrq> srq_;
+  std::optional<IbvQp> dctA_;
+  std::optional<IbvQp> dctB_;
+  std::optional<IbvQp> dci_;
+  std::optional<IbvMr> mr_;
+  std::optional<IbvAh> ahA_;
+  std::optional<IbvAh> ahB_;
+  std::vector<uint8_t> buf_;
+  ibv_sge sge_{};
+  ibv_gid gid_{};
+  DcBusinessCard cardA_{};
+  DcBusinessCard cardB_{};
+  ibv_qp_ex* exQp_{nullptr};
+  mlx5dv_qp_ex* dvQp_{nullptr};
+};
+
+// Verify that RDMA writes using different stream_ids to different DCTs
+// complete successfully through a stream-enabled DCI.
+TEST_F(DciStreamsTestFixture, DciStreamsMultiTargetWrite) {
+  // Post RDMA write with stream_id=0 to DCT-A
+  ASSERT_EQ(postDcRdmaWriteStream(exQp_, dvQp_, *ahA_, cardA_, sge_, 0, 0), 0)
+      << "wr_complete failed for stream 0 -> DCT-A";
+
+  auto pollOk1 = pollCqForCompletions(0, *cq_, 1);
+  ASSERT_TRUE(pollOk1) << "stream 0 -> DCT-A poll failed: "
+                       << pollOk1.error().errStr;
+  XLOG(INFO) << "stream_id=0 -> DCT-A: success";
+
+  // Post RDMA write with stream_id=1 to DCT-B
+  ASSERT_EQ(postDcRdmaWriteStream(exQp_, dvQp_, *ahB_, cardB_, sge_, 1, 1), 0)
+      << "wr_complete failed for stream 1 -> DCT-B";
+
+  auto pollOk2 = pollCqForCompletions(0, *cq_, 1);
+  ASSERT_TRUE(pollOk2) << "stream 1 -> DCT-B poll failed: "
+                       << pollOk2.error().errStr;
+  XLOG(INFO) << "stream_id=1 -> DCT-B: success";
+
+  // Verify DCI is still in RTS after successful multi-stream writes
+  {
+    auto queryResult = dci_->queryQp(IBV_QP_STATE);
+    ASSERT_TRUE(queryResult) << "queryQp failed";
+    auto& [qpAttr, qpInitAttr] = *queryResult;
+    EXPECT_EQ(qpAttr.qp_state, IBV_QPS_RTS)
+        << "DCI should remain in RTS after successful writes";
+  }
+
+  XLOG(INFO) << "Multi-target stream writes verified successfully.";
+}
+
+// Kill one peer (DCT-B), keep sending on both streams.
+// Verify: stream to live DCT-A still delivers, stream to dead DCT-B errors,
+// and the DCI stays operational for the healthy stream.
+TEST_F(DciStreamsTestFixture, DciStreamsFaultIsolation) {
+  // --- Step 1: Verify both streams work before killing peer ---
+  ASSERT_EQ(
+      postDcRdmaWriteStream(exQp_, dvQp_, *ahA_, cardA_, sge_, 100, 0), 0);
+  auto preOk = pollCqForCompletions(0, *cq_, 1);
+  ASSERT_TRUE(preOk) << "Pre-kill stream 0 -> DCT-A failed";
+  XLOG(INFO) << "Pre-kill: stream_id=0 -> DCT-A: success";
+
+  // --- Step 2: Kill DCT-B (simulate peer going down) ---
+  XLOG(INFO) << "Destroying DCT-B (simulating peer failure)";
+  dctB_.reset();
+
+  // --- Step 3: Send to dead DCT-B on stream 1 → expect error ---
+  ASSERT_EQ(postDcRdmaWriteStream(exQp_, dvQp_, *ahB_, cardB_, sge_, 1, 1), 0);
+
+  // Poll for the error completion on the dead stream
+  {
+    auto startTime = std::chrono::steady_clock::now();
+    bool gotError = false;
+    while (!gotError) {
+      auto wcs = cq_->pollCq(1);
+      ASSERT_TRUE(wcs);
+      if (!wcs->empty()) {
+        auto& wc = wcs->at(0);
+        EXPECT_NE(wc.status, IBV_WC_SUCCESS)
+            << "Expected error completion for dead DCT-B";
+        EXPECT_EQ(wc.wr_id, 1u) << "Error should be for stream 1 (wr_id=1)";
+        gotError = true;
+        XLOGF(
+            INFO,
+            "stream_id=1 -> dead DCT-B: error status={}, vendor_err={}",
+            wc.status,
+            wc.vendor_err);
+      }
+      auto elapsed = std::chrono::steady_clock::now() - startTime;
+      if (std::chrono::duration_cast<std::chrono::seconds>(elapsed).count() >
+          30) {
+        FAIL() << "Timed out waiting for error completion on stream 1";
+      }
+    }
+  }
+
+  // --- Step 4: Check DCI state ---
+  {
+    auto queryResult = dci_->queryQp(IBV_QP_STATE);
+    ASSERT_TRUE(queryResult) << "queryQp failed";
+    auto& [qpAttr, qpInitAttr] = *queryResult;
+    XLOGF(INFO, "DCI QP state after stream error: {}", qpAttr.qp_state);
+
+    if (qpAttr.qp_state != IBV_QPS_RTS) {
+      XLOGF(
+          WARN,
+          "DCI moved to state {} (not RTS). HW max_log_num_errored may be 0, "
+          "meaning 1 errored stream pushes the DCI to ERR. Fault isolation "
+          "requires max_log_num_errored > 0.",
+          qpAttr.qp_state);
+      // Report what happened but don't hard-fail — document the behavior
+      GTEST_SKIP()
+          << "DCI entered ERR state after stream error (qp_state="
+          << qpAttr.qp_state << "). Fault isolation not available on this NIC "
+          << "(max_log_num_errored likely 0). "
+          << "The errored stream was correctly isolated to stream_id=1.";
+    }
+  }
+
+  // --- Step 5: Keep sending on healthy stream 0 to live DCT-A ---
+  // With max_log_num_errored=0, the DCI may report RTS but still fail on
+  // other streams. True fault isolation requires max_log_num_errored > 0.
+  XLOG(INFO) << "DCI still in RTS — sending on healthy stream to live peer";
+  ASSERT_EQ(postDcRdmaWriteStream(exQp_, dvQp_, *ahA_, cardA_, sge_, 2, 0), 0);
+
+  // Poll — on HW with max_log_num_errored=0, this may fail even though the
+  // DCI is in RTS, because the errored stream contaminates the DCI.
+  auto pollOk = pollCqForCompletions(0, *cq_, 1);
+  if (pollOk.hasError()) {
+    XLOGF(
+        WARN,
+        "Post-kill stream 0 -> DCT-A failed: {}. "
+        "DCI is in RTS but errored stream contaminated other streams. "
+        "True fault isolation requires firmware with max_log_num_errored > 0.",
+        pollOk.error().errStr);
+    GTEST_SKIP()
+        << "Healthy stream failed after peer kill despite DCI in RTS. "
+        << "Firmware max_log_num_errored=0 does not provide true fault "
+        << "isolation: " << pollOk.error().errStr;
+  }
+  XLOG(INFO)
+      << "Post-kill: stream_id=0 -> DCT-A: success. Fault isolation verified.";
+
+  // --- Step 6: Try resetting the errored stream if supported ---
+  auto resetResult = resetDciStream(*dci_, 1);
+  if (resetResult.hasError()) {
+    XLOGF(
+        INFO,
+        "dci_stream_id_reset not supported (errno={}): {}",
+        resetResult.error().errNum,
+        resetResult.error().errStr);
+  } else {
+    XLOG(INFO) << "stream_id=1 reset successfully";
+  }
+}
+
+// Post multiple WRs on two streams to two DCTs, kill one DCT, then drain
+// the CQ. Classify every completion by wr_id to show which stream's WRs
+// succeeded, which errored, and which never completed (stuck).
+TEST_F(DciStreamsTestFixture, DciStreamsCompletionClassification) {
+  // --- Step 1: Post 3 WRs on stream 0 to DCT-A (all should succeed) ---
+  constexpr int kWrsPerStream = 3;
+  for (int i = 0; i < kWrsPerStream; i++) {
+    ASSERT_EQ(
+        postDcRdmaWriteStream(
+            exQp_, dvQp_, *ahA_, cardA_, sge_, static_cast<uint64_t>(i * 2), 0),
+        0);
+  }
+
+  // Poll all 3 to ensure they complete before we kill DCT-B
+  auto preOk = pollCqForCompletions(0, *cq_, kWrsPerStream);
+  ASSERT_TRUE(preOk) << "Pre-kill stream 0 writes failed: "
+                     << preOk.error().errStr;
+  XLOG(INFO) << "Pre-kill: 3 WRs on stream 0 -> DCT-A all succeeded";
+
+  // --- Step 2: Kill DCT-B ---
+  XLOG(INFO) << "Destroying DCT-B (simulating peer failure)";
+  dctB_.reset();
+
+  // --- Step 3: Post 3 WRs on stream 1 to dead DCT-B ---
+  for (int i = 0; i < kWrsPerStream; i++) {
+    ASSERT_EQ(
+        postDcRdmaWriteStream(
+            exQp_,
+            dvQp_,
+            *ahB_,
+            cardB_,
+            sge_,
+            static_cast<uint64_t>(i * 2 + 1),
+            1),
+        0);
+  }
+
+  // --- Step 4: Post 3 more WRs on stream 0 to live DCT-A ---
+  for (int i = 0; i < kWrsPerStream; i++) {
+    ASSERT_EQ(
+        postDcRdmaWriteStream(
+            exQp_,
+            dvQp_,
+            *ahA_,
+            cardA_,
+            sge_,
+            static_cast<uint64_t>((kWrsPerStream + i) * 2),
+            0),
+        0);
+  }
+
+  // --- Step 5: Drain CQ and classify all completions ---
+  // We posted 6 WRs total (3 on stream 1, 3 on stream 0).
+  // Some may succeed, some may error, some may never complete.
+  constexpr int kTotalPosted = kWrsPerStream * 2;
+  int stream0Success = 0;
+  int stream0Error = 0;
+  int stream1Success = 0;
+  int stream1Error = 0;
+  int totalPolled = 0;
+
+  auto startTime = std::chrono::steady_clock::now();
+  constexpr int kTimeoutSec = 30;
+
+  while (totalPolled < kTotalPosted) {
+    auto wcs = cq_->pollCq(kTotalPosted);
+    ASSERT_TRUE(wcs);
+
+    for (const auto& wc : *wcs) {
+      uint16_t sid = static_cast<uint16_t>(wc.wr_id % 2);
+      uint64_t seq = wc.wr_id / 2;
+      bool ok = (wc.status == IBV_WC_SUCCESS);
+
+      if (sid == 0) {
+        ok ? stream0Success++ : stream0Error++;
+      } else {
+        ok ? stream1Success++ : stream1Error++;
+      }
+
+      XLOGF(
+          INFO,
+          "  WC: stream={}, seq={}, status={}, vendor_err={} [{}]",
+          sid,
+          seq,
+          wc.status,
+          wc.vendor_err,
+          ok ? "OK" : "ERR");
+      totalPolled++;
+    }
+
+    if (wcs->empty()) {
+      auto elapsed = std::chrono::steady_clock::now() - startTime;
+      if (std::chrono::duration_cast<std::chrono::seconds>(elapsed).count() >
+          kTimeoutSec) {
+        break; // Some WRs may be stuck — that's data too
+      }
+    }
+  }
+
+  int stuck = kTotalPosted - totalPolled;
+
+  XLOG(INFO) << "=== Completion Classification ===";
+  XLOGF(
+      INFO,
+      "  Stream 0 (live DCT-A):  {} success, {} error",
+      stream0Success,
+      stream0Error);
+  XLOGF(
+      INFO,
+      "  Stream 1 (dead DCT-B): {} success, {} error",
+      stream1Success,
+      stream1Error);
+  XLOGF(INFO, "  Stuck (no completion):  {}", stuck);
+
+  // Stream 1 should have errors (sent to dead DCT)
+  EXPECT_GT(stream1Error, 0) << "Expected errors on stream 1 (dead DCT-B)";
+  EXPECT_EQ(stream1Success, 0) << "No success expected on dead DCT-B";
+
+  // Log the DCI state for analysis
+  {
+    auto queryResult = dci_->queryQp(IBV_QP_STATE);
+    ASSERT_TRUE(queryResult);
+    auto& [qpAttr, qpInitAttr] = *queryResult;
+    XLOGF(INFO, "  DCI QP state: {}", qpAttr.qp_state);
+  }
+
+  // On HW with max_log_num_errored=0, stream 0's post-kill WRs may also
+  // error or be stuck. Log it either way — the classification is the value.
+  if (stream0Error > 0 || stuck > 0) {
+    XLOG(INFO) << "  Note: stream 0 WRs also affected — fault isolation not "
+               << "available (max_log_num_errored likely 0)";
+  }
+  if (stream0Success == kWrsPerStream && stream0Error == 0) {
+    XLOG(INFO) << "  Fault isolation confirmed: stream 0 fully operational "
+               << "despite stream 1 errors";
+  }
+}
+
+} // namespace ibverbx
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ctran/ibverbx/tests/dc_utils.cc
+++ b/comms/ctran/ibverbx/tests/dc_utils.cc
@@ -7,6 +7,8 @@
 #include <fmt/format.h>
 #include <folly/logging/xlog.h>
 
+#include "comms/ctran/ibverbx/IbverbxSymbols.h"
+
 namespace ibverbx {
 
 std::ostream& operator<<(std::ostream& out, DcBusinessCard const& card) {
@@ -47,6 +49,52 @@ folly::Expected<IbvQp, Error> createDCI(IbvPd& pd, IbvCq& cq) {
   dvInitAttr.dc_init_attr.dc_type = MLX5DV_DCTYPE_DCI;
 
   return pd.createDcQp(&initAttr, &dvInitAttr);
+}
+
+folly::Expected<IbvQp, Error> createDCIWithStreams(
+    IbvPd& pd,
+    IbvCq& cq,
+    uint8_t logNumConcurrent,
+    uint8_t logNumErrored) {
+  mlx5dv_qp_init_attr dvInitAttr{};
+  ibv_qp_init_attr_ex initAttr{};
+
+  initAttr.qp_type = IBV_QPT_DRIVER;
+  initAttr.send_cq = cq.cq();
+  initAttr.recv_cq = cq.cq();
+  initAttr.comp_mask = IBV_QP_INIT_ATTR_PD;
+
+  initAttr.cap.max_send_wr = 1024;
+  initAttr.cap.max_send_sge = 1;
+  initAttr.comp_mask |= IBV_QP_INIT_ATTR_SEND_OPS_FLAGS;
+  initAttr.send_ops_flags = IBV_QP_EX_WITH_RDMA_WRITE;
+
+  dvInitAttr.comp_mask =
+      MLX5DV_QP_INIT_ATTR_MASK_DC | MLX5DV_QP_INIT_ATTR_MASK_DCI_STREAMS;
+  dvInitAttr.dc_init_attr.dc_type = MLX5DV_DCTYPE_DCI;
+  dvInitAttr.dc_init_attr.dci_streams.log_num_concurent = logNumConcurrent;
+  dvInitAttr.dc_init_attr.dci_streams.log_num_errored = logNumErrored;
+
+  return pd.createDcQp(&initAttr, &dvInitAttr);
+}
+
+folly::Expected<folly::Unit, Error> resetDciStream(
+    IbvQp& qp,
+    uint16_t streamId) {
+  if (ibvSymbols.mlx5dv_internal_dci_stream_id_reset == nullptr) {
+    return folly::makeUnexpected(
+        Error(ENOTSUP, "mlx5dv_dci_stream_id_reset not available"));
+  }
+  int ret = ibvSymbols.mlx5dv_internal_dci_stream_id_reset(qp.qp(), streamId);
+  if (ret != 0) {
+    return folly::makeUnexpected(Error(
+        ret,
+        fmt::format(
+            "mlx5dv_dci_stream_id_reset failed for stream_id={}: errno={}",
+            streamId,
+            ret)));
+  }
+  return folly::unit;
 }
 
 folly::Expected<IbvQp, Error>

--- a/comms/ctran/ibverbx/tests/dc_utils.h
+++ b/comms/ctran/ibverbx/tests/dc_utils.h
@@ -50,6 +50,16 @@ createSRQ(IbvPd& pd, int maxWr = 256, int maxSge = 1);
 
 folly::Expected<IbvQp, Error> createDCI(IbvPd& pd, IbvCq& cq);
 
+folly::Expected<IbvQp, Error> createDCIWithStreams(
+    IbvPd& pd,
+    IbvCq& cq,
+    uint8_t logNumConcurrent = 2,
+    uint8_t logNumErrored = 0);
+
+folly::Expected<folly::Unit, Error> resetDciStream(
+    IbvQp& qp,
+    uint16_t streamId);
+
 folly::Expected<IbvQp, Error>
 createDCT(IbvPd& pd, IbvCq& cq, IbvSrq& srq, uint64_t dcKey = DC_KEY);
 


### PR DESCRIPTION
Summary:

DC transport currently has a fault-isolation limitation: if a remote DCT becomes unreachable during an in-flight operation, the DCI can enter `IBV_QPS_ERR` and disrupt communication to other peers. DCI Streams is a ConnectX mlx5 feature that adds a stream ID to each DC work request so hardware can isolate stream-level errors when firmware supports it.

Note: Current ConnectX firmware on the tested hosts only supports `log_num_errored=0`, so one errored stream can still affect the full DCI. The fault-isolation test accounts for this by checking QP state and skipping assertions that require multi-stream error tolerance. When firmware support is added, the same test path will validate full isolation without code changes.

Infrastructure:

- `mlx5dv_internal_wr_set_dc_addr_stream` sets the DC target plus `stream_id` per work request in linked mode.
- `mlx5dv_internal_dci_stream_id_reset` wraps `mlx5dv_dci_stream_id_reset` from `MLX5_1.21`.
- `createDCIWithStreams(pd, cq, logNumConcurrent, logNumErrored)` creates a stream-enabled DCI.
- `resetDciStream(qp, streamId)` exposes stream reset with error handling.
- `postDcRdmaWriteStream` in `IbverbxDcBenchUtils.h` shares the streamed RDMA write posting sequence between tests and benchmarks.

Fault isolation test (`IbverbxDciStreamsTest.cc`): creates two DCTs and a stream-enabled DCI, verifies successful writes to both streams, destroys one DCT, posts writes to the dead stream, classifies completions by stream ID, and gracefully skips full-isolation assertions on firmware that cannot isolate errored streams yet.

Streams scalability benchmark (`IbverbxDcOneToManyBench.cc`): extends `dcMultiDciCore` with `logNumConcurrentStreams` so `dcStreams_4`, `dcStreams_16`, and `dcMultiDci4_streams4` reuse the same benchmark setup, warmup, timed loop, stats, and raw-result path as the non-streamed multi-DCI benchmarks.

Reviewed By: rmahidhar

Differential Revision: D95453131


