### PR TITLE
Add missing cstdint include in Utils.cpp

### DIFF
--- a/comms/torchcomms/utils/Utils.cpp
+++ b/comms/torchcomms/utils/Utils.cpp
@@ -2,6 +2,7 @@
 
 #include "comms/torchcomms/utils/Utils.hpp"
 #include <algorithm>
+#include <cstdint>
 #include <sstream>
 #include <stdexcept>
 #include <string>


### PR DESCRIPTION
Summary:
Fix build error caused by uint64_t being used without
including <cstdint>. This only shows up in the OSS
builds.

Reviewed By: siyengar

Differential Revision: D95487116


