### PR TITLE
Fix no-linkage warning for TorchCommWinAccessType

### DIFF
--- a/comms/torchcomms/TorchCommWindow.hpp
+++ b/comms/torchcomms/TorchCommWindow.hpp
@@ -10,7 +10,7 @@ namespace torch::comms {
 // Forward declaration
 class TorchWork;
 
-using TorchCommWinAccessType = enum {
+enum class TorchCommWinAccessType {
   WIN_ACCESS_TYPE_UNIFIED = 0,
   WIN_ACCESS_TYPE_SEPARATE = 1,
 };


### PR DESCRIPTION
Summary:
Change anonymous enum alias to a named enum to fix
-Wsubobject-linkage warning. The using alias to an
anonymous enum has no linkage, which is invalid when
used as a member of a class with external linkage.
This only shows up in the OSS builds.

Reviewed By: lilyjanjigian

Differential Revision: D95487118


