### PR TITLE
Add missing <cstdint> include for uint64_t

### DIFF
--- a/comms/torchcomms/utils/Utils.hpp
+++ b/comms/torchcomms/utils/Utils.hpp
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <string_view>
 


### PR DESCRIPTION
Summary:
The explicit template instantiation of env_to_value<uint64_t>
in Utils.cpp requires uint64_t to be defined. Add #include
<cstdint> to the header so the type is available both for
the implementation and for callers.

Differential Revision: D95509323


