### PR TITLE
Wire pipes into torchcomms conda build and update toml configs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ option(USE_RCCLX "Whether to build RCCLX or not" OFF)
 option(USE_XCCL "Whether to build XCCL or not" OFF)
 option(USE_TRANSPORT "Whether to build TRANSPORT or not" ON)
 option(USE_TRITON "Whether to build Triton device bitcode or not" OFF)
+option(USE_PIPES "Whether to link against libpipes.so for dispatch/combine" OFF)
 option(BUILD_TESTS "Whether to build tests or not" OFF)
 message(STATUS "  USE_NCCL : ${USE_NCCL}")
 message(STATUS "  USE_NCCLX : ${USE_NCCLX}")
@@ -23,6 +24,7 @@ message(STATUS "  USE_RCCLX  : ${USE_RCCLX}")
 message(STATUS "  USE_XCCL  : ${USE_XCCL}")
 message(STATUS "  USE_TRANSPORT  : ${USE_TRANSPORT}")
 message(STATUS "  USE_TRITON     : ${USE_TRITON}")
+message(STATUS "  USE_PIPES      : ${USE_PIPES}")
 message(STATUS "  BUILD_TESTS    : ${BUILD_TESTS}")
 
 if(NOT DEFINED ENV{TORCH_CUDA_ARCH_LIST})
@@ -223,6 +225,23 @@ if (USE_TRITON)
     include(comms/torchcomms/triton/CMakeLists.txt)
 endif()
 include(comms/torchcomms/hooks/fr/CMakeLists.txt)
+
+# --- Pipes (optional: device API headers + libpipes.so) ---
+if (USE_PIPES)
+    # Existence check only -- pipes is header-only for
+    # torchcomms (no linking needed). The ncclx backend
+    # includes pipes device headers (CopyUtils.cuh etc.)
+    # but does not call into libpipes.so at link time;
+    # all pipes functionality is invoked at runtime by
+    # MCCL which links libpipes.so directly.
+    find_library(PIPES_LIBRARY pipes PATHS ${CONDA_LIB} REQUIRED)
+    message(STATUS "Found libpipes.so: ${PIPES_LIBRARY}")
+
+    # Make pipes headers available to the ncclx target (for CopyUtils.cuh etc.)
+    if(TARGET torchcomms_comms_ncclx)
+        target_compile_definitions(torchcomms_comms_ncclx PRIVATE USE_PIPES=1)
+    endif()
+endif()
 
 # Install targets to Python package structure
 install(TARGETS torchcomms

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ IS_ROCM = hasattr(torch.version, "hip") and torch.version.hip is not None
 # Transport is CUDA-only; disable by default on ROCm but allow explicit opt-in.
 USE_TRANSPORT = flag_enabled("USE_TRANSPORT", not IS_ROCM)
 USE_TRITON = flag_enabled("USE_TRITON", False)
+USE_PIPES = flag_enabled("USE_PIPES", False)
 
 requirement_path = os.path.join(ROOT, "requirements.txt")
 try:
@@ -132,6 +133,7 @@ class build_ext(build_ext_orig):
             f"-DUSE_XCCL={flag_str(USE_XCCL)}",
             f"-DUSE_TRANSPORT={flag_str(USE_TRANSPORT)}",
             f"-DUSE_TRITON={flag_str(USE_TRITON)}",
+            f"-DUSE_PIPES={flag_str(USE_PIPES)}",
         ]
         build_args = ["--", "-j"]
 


### PR DESCRIPTION
Summary:
Wire the pipes conda feedstock into the torchcomms build and update
downstream conda configs to include doca + pipes packages.

When USE_PIPES=1, torchcomms adds a USE_PIPES=1 compile definition to
the ncclx target so it can resolve Pipes device headers (e.g.
CopyUtils.cuh for memcpy_vectorized) from the conda environment.
The find_library(pipes) call is an existence check only — pipes is
header-only for torchcomms; MCCL links libpipes.so directly at
runtime.

## Changes

- **setup.py**: Add USE_PIPES flag (default OFF), forward to CMake.
- **CMakeLists.txt**: Add USE_PIPES option + find_library existence
  check + USE_PIPES=1 compile def on ncclx target.
- **conda_build_torchcomms.sh**: Auto-detect libpipes.so in conda env
  and set USE_PIPES accordingly.
- **recipe.yaml**: Add pipes as host + run dependency.
- **torchcomms.toml / torchcomms_gb200.toml**: Add doca + pipes
  feedstocks for test environments.
- **llama4x build.toml**: Add doca + pipes feedstocks and specs.
- **msl/rl build.toml + fair/build.toml**: Add pipes feedstock + spec.

Differential Revision: D94942789


