### PR TITLE
Support per-comm virtual clique size override via ncclx::Config hints (#969)

### DIFF
--- a/comms/ctran/commstate/CommStateX.cc
+++ b/comms/ctran/commstate/CommStateX.cc
@@ -50,7 +50,8 @@ CommStateX::CommStateX(
     std::vector<RankTopology> rankTopologies,
     std::vector<int> commRanksToWorldRanks,
     const std::string& commDesc,
-    bool noLocal)
+    bool noLocal,
+    int vCliqueSize)
     : rank_(rank),
       nRanks_(nRanks),
       cudaDev_(cudaDev),
@@ -58,7 +59,8 @@ CommStateX::CommStateX(
       busId_(busId),
       commHash_(commHash),
       commDesc_(commDesc),
-      noLocal_(noLocal) {
+      noLocal_(noLocal),
+      vCliqueSize_(vCliqueSize) {
   setRankStatesTopologies(std::move(rankTopologies));
   setCommRankToWorldRanks(std::move(commRanksToWorldRanks));
 }
@@ -105,6 +107,10 @@ void CommStateX::initRankTopologyVnode(const int nLocalRanks) {
 void CommStateX::initRankStatesTopology(meta::comms::IBootstrap* bootstrap) {
   if (noLocal_) {
     initRankTopologyNolocal();
+    return;
+  }
+  if (vCliqueSize_ > 0) {
+    initRankTopologyVnode(vCliqueSize_);
     return;
   }
   auto myTopo = ctran::commstate::loadTopology(rank_, NCCL_TOPO_FILE_PATH);
@@ -162,33 +168,10 @@ void CommStateX::setNvlFabricTopos(
   if (!nvlFabricEnabled_) {
     return;
   }
+
+  // Step 1: Always parse the system NVL fabric topology first.
   nvlFabricCliqueEnabled_ = nvlFabricEnabled_ && NCCL_MNNVL_CLIQUE_SIZE > 0 &&
       NCCL_MNNVL_DETERMINISTIC_COLLECTIVE_ENABLE;
-
-  // When noLocal is set, override NVL fabric maps so each rank appears as its
-  // own NVL domain with nLocalRanks=1, while keeping NVL fabric enabled for
-  // transport.
-  if (noLocal_) {
-    nvlFabricRankStates_.resize(nRanks_);
-    for (int i = 0; i < nRanks_; i++) {
-      auto& state = nvlFabricRankStates_.at(i);
-      state.rank = i;
-      state.nvlDomainIndex = i;
-      state.nvlDomainRank = 0;
-      state.nNvlDomainRanks = 1;
-      state.nvlDomainRankToRank = {i};
-      nvlDomainRanks_.emplace_back(std::vector<int>{i});
-      if (nvlFabricCliqueEnabled_) {
-        state.cliqueIndex = i;
-        state.cliqueRank = 0;
-        state.nCliqueRanks = 1;
-        state.cliqueRankToRank = {i};
-        cliqueRanks_.emplace_back(std::vector<int>{i});
-      }
-    }
-    myNvlFabricRankState_ = nvlFabricRankStates_.at(rank_);
-    return;
-  }
 
   std::unordered_map<std::string, int> clusterIdToNvlDomainIndex;
   // cliqueIds might not be contiguous, within the same communicator.
@@ -231,6 +214,7 @@ void CommStateX::setNvlFabricTopos(
       }
     }
   }
+
   // another loop to update the other stats of nvlFabricRankStates_
   for (int i = 0; i < nRanks_; i++) {
     if (nvlFabricTopos_.at(i).supportNvlFabric) {
@@ -261,6 +245,65 @@ void CommStateX::setNvlFabricTopos(
       "size of cliqueIdToCliqueIndex : {} not equal to size cliqueRanks_: {}",
       cliqueIdToCliqueIndex.size(),
       cliqueRanks_.size());
+
+  // Step 2: noLocal is equivalent to vCliqueSize=1. When either is set,
+  // override the parsed NVL fabric topology with virtual domains.
+  // We validate against system state parsed above.
+  const int effectiveVCliqueSize = noLocal_ ? 1 : vCliqueSize_;
+  if (effectiveVCliqueSize > 0) {
+    FB_CHECKABORT(
+        nRanks_ % effectiveVCliqueSize == 0,
+        "nRanks ({}) must be evenly divisible by effectiveVCliqueSize ({})",
+        nRanks_,
+        effectiveVCliqueSize);
+    // Validate against system clique size if cliques were parsed
+    if (nvlFabricCliqueEnabled_ && !cliqueRanks_.empty()) {
+      int systemCliqueRanks = cliqueRanks_.at(0).size();
+      FB_CHECKABORT(
+          systemCliqueRanks % effectiveVCliqueSize == 0,
+          "system nCliqueRanks ({}) must be evenly divisible by effectiveVCliqueSize ({})",
+          systemCliqueRanks,
+          effectiveVCliqueSize);
+    }
+
+    // Override with virtual domains of the given size
+    nvlFabricCliqueEnabled_ = true;
+    nvlFabricRankStates_.clear();
+    nvlFabricRankStates_.resize(nRanks_);
+    nvlDomainRanks_.clear();
+    cliqueRanks_.clear();
+    for (int i = 0; i < nRanks_; i++) {
+      auto& state = nvlFabricRankStates_.at(i);
+      state.rank = i;
+      int domainIdx = i / effectiveVCliqueSize;
+      int domainRank = i % effectiveVCliqueSize;
+      state.nvlDomainIndex = domainIdx;
+      state.nvlDomainRank = domainRank;
+      state.nNvlDomainRanks = effectiveVCliqueSize;
+      if (domainRank == 0) {
+        nvlDomainRanks_.emplace_back();
+      }
+      nvlDomainRanks_.at(domainIdx).emplace_back(i);
+      state.cliqueIndex = domainIdx;
+      state.cliqueRank = domainRank;
+      state.nCliqueRanks = effectiveVCliqueSize;
+      if (domainRank == 0) {
+        cliqueRanks_.emplace_back();
+      }
+      cliqueRanks_.at(domainIdx).emplace_back(i);
+    }
+    // Second pass to set rank-to-rank mappings
+    for (int i = 0; i < nRanks_; i++) {
+      auto& state = nvlFabricRankStates_.at(i);
+      state.nvlDomainRankToRank = nvlDomainRanks_.at(state.nvlDomainIndex);
+      state.cliqueRankToRank = cliqueRanks_.at(state.cliqueIndex);
+    }
+    myNvlFabricRankState_ = nvlFabricRankStates_.at(rank_);
+    XLOGF(
+        INFO,
+        "CommStateX: effectiveVCliqueSize={} override NVL fabric topology",
+        effectiveVCliqueSize);
+  }
 }
 
 void CommStateX::setRankStatesTopologies(

--- a/comms/ctran/commstate/CommStateX.h
+++ b/comms/ctran/commstate/CommStateX.h
@@ -81,7 +81,8 @@ class CommStateX {
       std::vector<RankTopology> rankTopologies,
       std::vector<int> commRanksToWorldRanks,
       const std::string& commDesc = "",
-      bool noLocal = false);
+      bool noLocal = false,
+      int vCliqueSize = 0);
 
   ~CommStateX();
 
@@ -290,6 +291,11 @@ class CommStateX {
   // When true, treat every rank as if it is on its own node. Affects
   // initRankStatesTopology() and setNvlFabricTopos() behavior.
   const bool noLocal_{false};
+
+  // Per-communicator virtual NVLink clique size override.
+  // When > 0, partitions ranks into virtual cliques of this size,
+  // overriding both rank topology and NVL fabric topology.
+  const int vCliqueSize_{0};
 
   // flag to indicate if this rank has enabled NVL Fabric, if this flag is on,
   //  we assume all the nvl communication from/to this rank is through

--- a/comms/ctran/commstate/tests/CommStateXTest.cc
+++ b/comms/ctran/commstate/tests/CommStateXTest.cc
@@ -430,6 +430,82 @@ TEST(CommStateXTest, nvlFabricCliqueTest) {
   }
 }
 
+TEST(CommStateXTest, nvlFabricVCliqueSizeHint) {
+  const int rank = 0;
+  const int nRanks = 8;
+  const int cudaDev = 0;
+  const int cudaArch = 90;
+  const int64_t busId = 25;
+  const uint64_t commHash = 0;
+
+  std::vector<NvlFabricTopology> nvlFabricTopologies{};
+  for (int i = 0; i < nRanks; ++i) {
+    nvlFabricTopologies.emplace_back(
+        createNvlFabricTopology(i, kNvlFabricClusterId1, 0));
+  }
+
+  std::vector<RankTopology> rankTopologies{};
+  const std::string kSu = "";
+  rankTopologies.emplace_back(
+      createRankTopology(0, kDc, kZone, kSu, kRtsw0, kHost0));
+  rankTopologies.emplace_back(
+      createRankTopology(1, kDc, kZone, kSu, kRtsw0, kHost0));
+  rankTopologies.emplace_back(
+      createRankTopology(2, kDc, kZone, kSu, kRtsw0, kHost1));
+  rankTopologies.emplace_back(
+      createRankTopology(3, kDc, kZone, kSu, kRtsw0, kHost1));
+  rankTopologies.emplace_back(
+      createRankTopology(4, kDc, kZone, kSu, kRtsw1, kHost2));
+  rankTopologies.emplace_back(
+      createRankTopology(5, kDc, kZone, kSu, kRtsw1, kHost2));
+  rankTopologies.emplace_back(
+      createRankTopology(6, kDc, kZone, kSu, kRtsw1, kHost3));
+  rankTopologies.emplace_back(
+      createRankTopology(7, kDc, kZone, kSu, kRtsw1, kHost3));
+
+  auto makeCommState = [&](int vCliqueSize = 0) {
+    return std::make_unique<CommStateX>(
+        rank,
+        nRanks,
+        cudaDev,
+        cudaArch,
+        busId,
+        commHash,
+        rankTopologies,
+        std::vector<int>{},
+        "" /* commDesc */,
+        false /* noLocal */,
+        vCliqueSize);
+  };
+
+  // vCliqueSize=4 partitions 8 ranks into 2 virtual domains of 4
+  {
+    auto cs = makeCommState(4);
+    cs->setNvlFabricTopos(nvlFabricTopologies, true);
+    EXPECT_TRUE(cs->nvlFabricCliqueEnabled());
+    EXPECT_EQ(cs->nNodes(), 2);
+    for (int i = 0; i < nRanks; ++i) {
+      EXPECT_EQ(cs->localRank(i), i % 4);
+      EXPECT_EQ(cs->nLocalRanks(i), 4);
+    }
+  }
+
+  // vCliqueSize=0 does not override (no CVARs set either)
+  {
+    auto cs = makeCommState(0);
+    cs->setNvlFabricTopos(nvlFabricTopologies, true);
+    EXPECT_FALSE(cs->nvlFabricCliqueEnabled());
+  }
+
+  // vCliqueSize=3 is invalid (8 ranks not divisible by 3)
+  {
+    auto cs = makeCommState(3);
+    EXPECT_DEATH(
+        cs->setNvlFabricTopos(nvlFabricTopologies, true),
+        "nRanks.*must be evenly divisible by effectiveVCliqueSize");
+  }
+}
+
 TEST(CommStateXTest, TopologyFailure) {
   const int rank = 0;
   const int nRanks = 8;

--- a/comms/ncclx/v2_27/meta/NcclxConfig.cc
+++ b/comms/ncclx/v2_27/meta/NcclxConfig.cc
@@ -197,6 +197,20 @@ Config::Config(const ncclConfig_t* config) {
           "pipesUseDualStateBuffer", NCCL_CTRAN_PIPES_USE_DUAL_STATE_BUFFER);
     }
   }
+
+  // vCliqueSize: hint only (no flat ncclConfig_t field)
+  {
+    auto val = getHintStr("vCliqueSize");
+    if (!val.empty()) {
+      try {
+        vCliqueSize = std::stoi(val);
+      } catch (const std::exception&) {
+        WARN(
+            "NCCLX hint 'vCliqueSize': invalid integer value '%s'",
+            val.c_str());
+      }
+    }
+  }
 }
 
 } // namespace ncclx

--- a/comms/ncclx/v2_27/meta/NcclxConfig.h
+++ b/comms/ncclx/v2_27/meta/NcclxConfig.h
@@ -35,6 +35,7 @@ class Config {
   // When set, override the corresponding CVARs for this communicator.
   std::optional<size_t> pipesNvlChunkSize;
   std::optional<bool> pipesUseDualStateBuffer;
+  int vCliqueSize = 0;
 };
 
 // Hint keys corresponding to Config fields above.  Used by
@@ -49,6 +50,7 @@ inline const std::vector<std::string>& knownHintKeys() {
       "fastInitMode",
       "pipesNvlChunkSize",
       "pipesUseDualStateBuffer",
+      "vCliqueSize",
   };
   return keys;
 }

--- a/comms/ncclx/v2_27/meta/commstate/FactoryCommStateX.cc
+++ b/comms/ncclx/v2_27/meta/commstate/FactoryCommStateX.cc
@@ -53,7 +53,8 @@ std::unique_ptr<CommStateX> createCommStateXFromNcclComm(void* _comm) {
       std::vector<RankTopology>(), /* rankTopologies */
       std::vector<int>(), /* commRanksToWorldRanks */
       NCCLX_CONFIG_FIELD(comm->config, commDesc),
-      comm->noLocal_);
+      comm->noLocal_,
+      NCCLX_CONFIG_FIELD(comm->config, vCliqueSize));
 
   if (comm->noLocal_ ||
       NCCL_COMM_STATE_DEBUG_TOPO == NCCL_COMM_STATE_DEBUG_TOPO::nolocal) {
@@ -132,7 +133,8 @@ ncclResult_t initNvlFabricTopologies(ncclComm* ncclComm, CtranComm* ctranComm) {
     }
     nvlFabricTopos.emplace_back(std::move(topo));
   }
-  ctranComm->statex_->setNvlFabricTopos(std::move(nvlFabricTopos));
+  ctranComm->statex_->setNvlFabricTopos(
+      std::move(nvlFabricTopos), std::nullopt);
   return ncclSuccess;
 }
 

--- a/comms/ncclx/v2_28/meta/NcclxConfig.cc
+++ b/comms/ncclx/v2_28/meta/NcclxConfig.cc
@@ -197,6 +197,20 @@ Config::Config(const ncclConfig_t* config) {
           "pipesUseDualStateBuffer", NCCL_CTRAN_PIPES_USE_DUAL_STATE_BUFFER);
     }
   }
+
+  // vCliqueSize: hint only (no flat ncclConfig_t field)
+  {
+    auto val = getHintStr("vCliqueSize");
+    if (!val.empty()) {
+      try {
+        vCliqueSize = std::stoi(val);
+      } catch (const std::exception&) {
+        WARN(
+            "NCCLX hint 'vCliqueSize': invalid integer value '%s'",
+            val.c_str());
+      }
+    }
+  }
 }
 
 } // namespace ncclx

--- a/comms/ncclx/v2_28/meta/NcclxConfig.h
+++ b/comms/ncclx/v2_28/meta/NcclxConfig.h
@@ -35,6 +35,7 @@ class Config {
   // When set, override the corresponding CVARs for this communicator.
   std::optional<size_t> pipesNvlChunkSize;
   std::optional<bool> pipesUseDualStateBuffer;
+  int vCliqueSize = 0;
 };
 
 // Hint keys corresponding to Config fields above.  Used by
@@ -49,6 +50,7 @@ inline const std::vector<std::string>& knownHintKeys() {
       "fastInitMode",
       "pipesNvlChunkSize",
       "pipesUseDualStateBuffer",
+      "vCliqueSize",
   };
   return keys;
 }

--- a/comms/ncclx/v2_28/meta/commstate/FactoryCommStateX.cc
+++ b/comms/ncclx/v2_28/meta/commstate/FactoryCommStateX.cc
@@ -53,7 +53,8 @@ std::unique_ptr<CommStateX> createCommStateXFromNcclComm(void* _comm) {
       std::vector<RankTopology>(), /* rankTopologies */
       std::vector<int>(), /* commRanksToWorldRanks */
       NCCLX_CONFIG_FIELD(comm->config, commDesc),
-      comm->noLocal_);
+      comm->noLocal_,
+      NCCLX_CONFIG_FIELD(comm->config, vCliqueSize));
 
   if (comm->noLocal_ ||
       NCCL_COMM_STATE_DEBUG_TOPO == NCCL_COMM_STATE_DEBUG_TOPO::nolocal) {
@@ -132,7 +133,8 @@ ncclResult_t initNvlFabricTopologies(ncclComm* ncclComm, CtranComm* ctranComm) {
     }
     nvlFabricTopos.emplace_back(std::move(topo));
   }
-  ctranComm->statex_->setNvlFabricTopos(std::move(nvlFabricTopos));
+  ctranComm->statex_->setNvlFabricTopos(
+      std::move(nvlFabricTopos), std::nullopt);
   return ncclSuccess;
 }
 

--- a/comms/ncclx/v2_29/meta/NcclxConfig.cc
+++ b/comms/ncclx/v2_29/meta/NcclxConfig.cc
@@ -197,6 +197,20 @@ Config::Config(const ncclConfig_t* config) {
           "pipesUseDualStateBuffer", NCCL_CTRAN_PIPES_USE_DUAL_STATE_BUFFER);
     }
   }
+
+  // vCliqueSize: hint only (no flat ncclConfig_t field)
+  {
+    auto val = getHintStr("vCliqueSize");
+    if (!val.empty()) {
+      try {
+        vCliqueSize = std::stoi(val);
+      } catch (const std::exception&) {
+        WARN(
+            "NCCLX hint 'vCliqueSize': invalid integer value '%s'",
+            val.c_str());
+      }
+    }
+  }
 }
 
 } // namespace ncclx

--- a/comms/ncclx/v2_29/meta/NcclxConfig.h
+++ b/comms/ncclx/v2_29/meta/NcclxConfig.h
@@ -35,6 +35,7 @@ class Config {
   // When set, override the corresponding CVARs for this communicator.
   std::optional<size_t> pipesNvlChunkSize;
   std::optional<bool> pipesUseDualStateBuffer;
+  int vCliqueSize = 0;
 };
 
 // Hint keys corresponding to Config fields above.  Used by
@@ -49,6 +50,7 @@ inline const std::vector<std::string>& knownHintKeys() {
       "fastInitMode",
       "pipesNvlChunkSize",
       "pipesUseDualStateBuffer",
+      "vCliqueSize",
   };
   return keys;
 }

--- a/comms/ncclx/v2_29/meta/commstate/FactoryCommStateX.cc
+++ b/comms/ncclx/v2_29/meta/commstate/FactoryCommStateX.cc
@@ -53,7 +53,8 @@ std::unique_ptr<CommStateX> createCommStateXFromNcclComm(void* _comm) {
       std::vector<RankTopology>(), /* rankTopologies */
       std::vector<int>(), /* commRanksToWorldRanks */
       NCCLX_CONFIG_FIELD(comm->config, commDesc),
-      comm->noLocal_);
+      comm->noLocal_,
+      NCCLX_CONFIG_FIELD(comm->config, vCliqueSize));
 
   if (comm->noLocal_ ||
       NCCL_COMM_STATE_DEBUG_TOPO == NCCL_COMM_STATE_DEBUG_TOPO::nolocal) {
@@ -132,7 +133,8 @@ ncclResult_t initNvlFabricTopologies(ncclComm* ncclComm, CtranComm* ctranComm) {
     }
     nvlFabricTopos.emplace_back(std::move(topo));
   }
-  ctranComm->statex_->setNvlFabricTopos(std::move(nvlFabricTopos));
+  ctranComm->statex_->setNvlFabricTopos(
+      std::move(nvlFabricTopos), std::nullopt);
   return ncclSuccess;
 }
 


### PR DESCRIPTION
Summary:

On GB200, we need to override the NVL fabric clique size per-communicator
to create virtual NVLink domain partitions for AGP algorithms. Since MAST
prevents setting NCCL_MNNVL_CLIQUE_SIZE directly, and NCCL_COMM_STATE_DEBUG_TOPO
is for debugging only, this uses the NCCLX per-communicator hints mechanism
via ncclConfig_t.hints / ncclx::Config instead.

This is truly per-communicator: the value travels with the ncclConfig_t
passed to ncclCommInitRankConfig, parsed into ncclx::Config, and read in
FactoryCommStateX when setting up NVL fabric topologies.

Changes:
- Add `vCliqueSize` field to `ncclx::Config` (NcclxConfig.h)
- Parse `vCliqueSize` from ncclConfig_t hints in NcclxConfig.cc
- Read from config via `NCCLX_CONFIG_FIELD` in FactoryCommStateX.cc and
  pass to `CommStateX::setNvlFabricTopos()`
- In `setNvlFabricTopos()`, when vCliqueSize > 0, force clique mode
  and set `cliqueId = rank / vCliqueSize`
- Applied to all three NCCLX versions (v2_27, v2_28, v2_29)

Usage (C++):
```cpp
ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
ncclx::Hints hints({{"vCliqueSize", "8"}});
config.hints = &hints;
ncclCommInitRankConfig(&comm, nRanks, commId, rank, &config);
```

Reviewed By: minsii

Differential Revision: D95145627


