### PR TITLE
adopt NCCL API logic changes

### DIFF
--- a/comms/ncclx/v2_29/src/dev_runtime.cc
+++ b/comms/ncclx/v2_29/src/dev_runtime.cc
@@ -1270,7 +1270,7 @@ ncclResult_t ncclCommWindowRegister(ncclComm_t comm, void* buff, size_t size, nc
     return ncclInvalidArgument;
   }
 
-  if (!comm->symmetricSupport) {
+  if (!comm->symmetricSupport && !ncclParamLocalRegister()) {
     return ncclSuccess;
   }
 

--- a/comms/torchcomms/device/ncclx/NCCLDeviceBackend.cpp
+++ b/comms/torchcomms/device/ncclx/NCCLDeviceBackend.cpp
@@ -78,6 +78,10 @@ NCCLDeviceBackend::Ptr NCCLDeviceBackend::create_device_window(
   // Set up ncclDevCommRequirements with GIN enabled using designated
   // initializers
   ncclDevCommRequirements reqs = {
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 7)
+      .magic = NCCL_API_MAGIC,
+      .version = NCCL_VERSION_CODE,
+#endif
       .resourceRequirementsList =
           (signal_buffer_size > 0) ? &signal_resource_reqs : nullptr,
       .teamRequirementsList = nullptr,


### PR DESCRIPTION
Summary:
Baseline NCCL 2.29.7 added version and magic check for ncclDevCommCreate() API call, we need to adopt this change in TorchComms.

Also additional gating was introduced for symmetric memory, see https://github.com/NVIDIA/nccl/blob/v2.29.7-1/src/init.cc#L1471-L1476. It is also mutually exclusive with fused nic setup, so we need to block NCCL from fusing in order to run tests.

Differential Revision: D95483619


