### PR TITLE
Dynamically Connected vs. Reliably Connected RDMA Benchmarking (#972)

### DIFF
--- a/comms/ctran/ibverbx/benchmarks/IbverbxDcBenchUtils.h
+++ b/comms/ctran/ibverbx/benchmarks/IbverbxDcBenchUtils.h
@@ -1,0 +1,862 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include <fmt/format.h>
+#include <folly/Expected.h>
+#include <folly/logging/xlog.h>
+
+#include "comms/ctran/ibverbx/Ibverbx.h"
+#include "comms/ctran/ibverbx/IbverbxSymbols.h"
+#include "comms/ctran/ibverbx/tests/dc_utils.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+
+namespace ibverbx {
+
+// Constants
+constexpr int kDefaultCqe = 1024;
+constexpr int kDefaultSrqMaxWr = 1024;
+constexpr int kDefaultPollTimeoutMs = 30000;
+constexpr ibv_mtu kDefaultMtu = IBV_MTU_4096;
+constexpr int kDefaultMtuValue = static_cast<int>(kDefaultMtu);
+
+// BusinessCard for RC connections (simpler than DC - no DCT number needed)
+struct RcBusinessCard {
+  uint32_t qpNum{0};
+  uint8_t port{0};
+  uint64_t subnetPrefix{0};
+  uint64_t interfaceId{0};
+  uint64_t remoteAddr{0};
+  uint32_t rkey{0};
+  uint32_t psn{0}; // Packet sequence number for RTR
+};
+
+inline DcBusinessCard makeDcBusinessCard(
+    uint32_t dctNum,
+    const ibv_gid& gid,
+    uint64_t remoteAddr = 0,
+    uint32_t rkey = 0,
+    int32_t rank = -1) {
+  return DcBusinessCard{
+      .mtu = kDefaultMtuValue,
+      .dctNum = dctNum,
+      .port = kPortNum,
+      .subnetPrefix = gid.global.subnet_prefix,
+      .interfaceId = gid.global.interface_id,
+      .rank = rank,
+      .remoteAddr = remoteAddr,
+      .rkey = rkey,
+  };
+}
+
+struct RdmaResources {
+  std::unique_ptr<IbvDevice> device;
+  std::unique_ptr<IbvPd> pd;
+  std::unique_ptr<IbvCq> cq;
+  ibv_gid gid{};
+
+  void reset() {
+    cq.reset();
+    pd.reset();
+    device.reset();
+  }
+};
+
+inline folly::Expected<RdmaResources, Error> initRdmaResources(
+    int deviceIndex,
+    int cqDepth) {
+  auto devices = IbvDevice::ibvGetDeviceList(NCCL_IB_HCA, NCCL_IB_HCA_PREFIX);
+  if (!devices) {
+    return folly::makeUnexpected(Error(ENODEV, "Failed to get device list"));
+  }
+
+  XLOGF(DBG, "Found {} RDMA devices", devices->size());
+  for (size_t i = 0; i < devices->size(); ++i) {
+    XLOGF(DBG, "  Device {}: {}", i, devices->at(i).device()->name);
+  }
+
+  if (deviceIndex < 0 || deviceIndex >= static_cast<int>(devices->size())) {
+    return folly::makeUnexpected(Error(
+        EINVAL,
+        fmt::format(
+            "Device index {} out of range (have {} devices)",
+            deviceIndex,
+            devices->size())));
+  }
+
+  RdmaResources resources;
+  resources.device =
+      std::make_unique<IbvDevice>(std::move(devices->at(deviceIndex)));
+  XLOGF(
+      DBG,
+      "Using device {}: {}",
+      deviceIndex,
+      resources.device->device()->name);
+
+  auto pd = resources.device->allocPd();
+  if (!pd) {
+    return folly::makeUnexpected(pd.error());
+  }
+  resources.pd = std::make_unique<IbvPd>(std::move(*pd));
+
+  auto cq = resources.device->createCq(cqDepth, nullptr, nullptr, 0);
+  if (!cq) {
+    return folly::makeUnexpected(cq.error());
+  }
+  resources.cq = std::make_unique<IbvCq>(std::move(*cq));
+
+  auto gid = resources.device->queryGid(kPortNum, kGidIndex);
+  if (!gid) {
+    return folly::makeUnexpected(gid.error());
+  }
+  resources.gid = *gid;
+
+  return std::move(resources);
+}
+
+// Base endpoint class with common RDMA resources
+class EndPointBase {
+ public:
+  EndPointBase() = default;
+  virtual ~EndPointBase() = default;
+
+  // Non-copyable, movable
+  EndPointBase(const EndPointBase&) = delete;
+  EndPointBase& operator=(const EndPointBase&) = delete;
+  EndPointBase(EndPointBase&&) = default;
+  EndPointBase& operator=(EndPointBase&&) = default;
+
+  // Initialize common RDMA resources (device, PD, CQ)
+  folly::Expected<folly::Unit, Error> init(int deviceIndex) {
+    auto resources = initRdmaResources(deviceIndex, kDefaultCqe);
+    if (!resources) {
+      return folly::makeUnexpected(resources.error());
+    }
+    device_ = std::move(resources->device);
+    pd_ = std::move(resources->pd);
+    cq_ = std::move(resources->cq);
+    gid_ = resources->gid;
+
+    return folly::unit;
+  }
+
+  // Register a memory region
+  folly::Expected<IbvMr, Error> registerMr(void* buf, size_t size) {
+    auto access = static_cast<ibv_access_flags>(
+        IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE |
+        IBV_ACCESS_REMOTE_READ);
+    return pd_->regMr(buf, size, access);
+  }
+
+  // Poll CQ for a single completion (non-blocking)
+  folly::Expected<std::vector<ibv_wc>, Error> pollCq(int maxEntries = 1) {
+    return cq_->pollCq(maxEntries);
+  }
+
+  // Poll CQ with busy-spin for benchmarking (no sleep, no allocation)
+  // Returns false on error or timeout.
+  bool pollCqBusySpin(
+      int expectedCompletions,
+      int timeoutMs = kDefaultPollTimeoutMs) {
+    int completed = 0;
+    ibv_wc wc{};
+    auto* rawCq = cq_->cq();
+    auto start = std::chrono::steady_clock::now();
+
+    while (completed < expectedCompletions) {
+      int n = rawCq->context->ops.poll_cq(rawCq, 1, &wc);
+      if (n < 0) {
+        XLOGF(ERR, "CQ poll error: returned {}", n);
+        return false;
+      }
+      if (n == 1) {
+        if (wc.status != IBV_WC_SUCCESS) {
+          XLOGF(
+              ERR,
+              "WC error: status={}, opcode={}, vendor_err={}",
+              wc.status,
+              wc.opcode,
+              wc.vendor_err);
+          return false;
+        }
+        completed++;
+      } else {
+        // Check timeout periodically to avoid infinite spin
+        auto elapsed = std::chrono::steady_clock::now() - start;
+        if (std::chrono::duration_cast<std::chrono::milliseconds>(elapsed)
+                .count() > timeoutMs) {
+          XLOGF(
+              ERR,
+              "CQ busy-spin timeout: got {}/{} completions",
+              completed,
+              expectedCompletions);
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  // Poll CQ until we get expected completions (blocking with timeout)
+  bool pollCqBlocking(
+      int expectedCompletions,
+      int timeoutMs = kDefaultPollTimeoutMs) {
+    int completed = 0;
+    auto start = std::chrono::steady_clock::now();
+
+    while (completed < expectedCompletions) {
+      auto result = cq_->pollCq(expectedCompletions - completed);
+      if (result.hasError()) {
+        XLOGF(ERR, "CQ poll error: {}", result.error().errStr);
+        return false;
+      }
+
+      for (const auto& wc : *result) {
+        if (wc.status != IBV_WC_SUCCESS) {
+          XLOGF(
+              ERR,
+              "WC error: status={}, opcode={}, vendor_err={}",
+              wc.status,
+              wc.opcode,
+              wc.vendor_err);
+          return false;
+        }
+        completed++;
+      }
+
+      auto elapsed = std::chrono::steady_clock::now() - start;
+      if (std::chrono::duration_cast<std::chrono::milliseconds>(elapsed)
+              .count() > timeoutMs) {
+        XLOGF(
+            ERR,
+            "CQ poll timeout: got {}/{} completions",
+            completed,
+            expectedCompletions);
+        return false;
+      }
+
+      if (completed < expectedCompletions && result->empty()) {
+        // Brief sleep to avoid busy-wait
+        std::this_thread::sleep_for(std::chrono::microseconds(10));
+      }
+    }
+    return true;
+  }
+
+  IbvDevice& device() {
+    return *device_;
+  }
+  IbvPd& pd() {
+    return *pd_;
+  }
+  IbvCq& cq() {
+    return *cq_;
+  }
+  const ibv_gid& gid() const {
+    return gid_;
+  }
+
+ protected:
+  std::unique_ptr<IbvDevice> device_;
+  std::unique_ptr<IbvPd> pd_;
+  std::unique_ptr<IbvCq> cq_;
+  ibv_gid gid_{};
+};
+
+// DC Endpoint: DCI (sender) + DCT (receiver) + SRQ
+class DcEndPoint : public EndPointBase {
+ public:
+  DcEndPoint() = default;
+
+  // Initialize DC-specific resources (after base init)
+  folly::Expected<folly::Unit, Error> initDc() {
+    // Create SRQ
+    auto srqResult = createSRQ(*pd_, kDefaultSrqMaxWr);
+    if (!srqResult) {
+      return folly::makeUnexpected(Error(
+          srqResult.error().errNum,
+          "SRQ creation failed: " + srqResult.error().errStr));
+    }
+    srq_ = std::make_unique<IbvSrq>(std::move(*srqResult));
+
+    // Create DCI
+    auto dciResult = createDCI(*pd_, *cq_);
+    if (!dciResult) {
+      return folly::makeUnexpected(Error(
+          dciResult.error().errNum,
+          "DCI creation failed: " + dciResult.error().errStr));
+    }
+    dci_ = std::make_unique<IbvQp>(std::move(*dciResult));
+
+    // Create DCT
+    auto dctResult = createDCT(*pd_, *cq_, *srq_);
+    if (!dctResult) {
+      return folly::makeUnexpected(Error(
+          dctResult.error().errNum,
+          "DCT creation failed: " + dctResult.error().errStr));
+    }
+    dct_ = std::make_unique<IbvQp>(std::move(*dctResult));
+
+    // Get extended QP interface
+    exQp_ = ibvSymbols.ibv_internal_qp_to_qp_ex(dci_->qp());
+    dvQp_ = ibvSymbols.mlx5dv_internal_qp_ex_from_ibv_qp_ex(exQp_);
+
+    if (!exQp_ || !dvQp_) {
+      return folly::makeUnexpected(Error(
+          ENOTSUP,
+          fmt::format(
+              "Failed to get extended QP interface: exQp_={}, dvQp_={}",
+              exQp_ != nullptr,
+              dvQp_ != nullptr)));
+    }
+
+    // Transition DCI to RTS
+    auto dciTransition = transitionDCIToRts(*dci_, kPortNum, kDefaultMtu);
+    if (!dciTransition) {
+      return folly::makeUnexpected(dciTransition.error());
+    }
+
+    // Transition DCT to RTR
+    auto dctTransition = transitionDCTToRtr(*dct_, kPortNum, kDefaultMtu);
+    if (!dctTransition) {
+      return folly::makeUnexpected(dctTransition.error());
+    }
+
+    return folly::unit;
+  }
+
+  // Create business card for exchange
+  DcBusinessCard createBusinessCard(void* buf, uint32_t rkey) const {
+    return makeDcBusinessCard(
+        dct_->qp()->qp_num, gid_, reinterpret_cast<uint64_t>(buf), rkey, 0);
+  }
+
+  // Create address handle for remote DCT
+  folly::Expected<IbvAh, Error> createAh(const DcBusinessCard& remoteCard) {
+    return createAddressHandle(*pd_, remoteCard);
+  }
+
+  // Post RDMA write using extended QP API (plain write, one-sided)
+  int postRdmaWrite(
+      IbvAh& ah,
+      const DcBusinessCard& targetCard,
+      ibv_sge& sge,
+      uint64_t wrId = 0) {
+    ibvSymbols.ibv_internal_wr_start(exQp_);
+    exQp_->wr_id = wrId;
+    exQp_->wr_flags = IBV_SEND_SIGNALED;
+    ibvSymbols.ibv_internal_wr_rdma_write(
+        exQp_, targetCard.rkey, targetCard.remoteAddr);
+    ibvSymbols.ibv_internal_wr_set_sge_list(exQp_, 1, &sge);
+    ibvSymbols.mlx5dv_internal_wr_set_dc_addr(
+        dvQp_, ah.ah(), targetCard.dctNum, DC_KEY);
+    return ibvSymbols.ibv_internal_wr_complete(exQp_);
+  }
+
+  IbvQp& dci() {
+    return *dci_;
+  }
+  IbvQp& dct() {
+    return *dct_;
+  }
+  IbvSrq& srq() {
+    return *srq_;
+  }
+
+ private:
+  std::unique_ptr<IbvSrq> srq_;
+  std::unique_ptr<IbvQp> dci_;
+  std::unique_ptr<IbvQp> dct_;
+  ibv_qp_ex* exQp_{nullptr};
+  mlx5dv_qp_ex* dvQp_{nullptr};
+};
+
+class RdmaAvailabilityChecker {
+ public:
+  bool checkRdmaAvailable() {
+    if (rdmaChecked_) {
+      return rdmaAvailable_;
+    }
+    rdmaChecked_ = true;
+
+    ncclCvarInit();
+    if (!ibvInit()) {
+      XLOG(WARNING) << "Failed to initialize ibverbs";
+      return false;
+    }
+
+    auto devices = IbvDevice::ibvGetDeviceList(NCCL_IB_HCA, NCCL_IB_HCA_PREFIX);
+    if (!devices || devices->empty()) {
+      XLOG(WARNING) << "No RDMA devices found";
+      return false;
+    }
+
+    if (devices->size() < 2) {
+      XLOG(WARNING) << "Need at least 2 RDMA devices, found "
+                    << devices->size();
+      return false;
+    }
+
+    rdmaAvailable_ = true;
+    return true;
+  }
+
+  bool checkDcAvailable() {
+    if (dcChecked_) {
+      return dcAvailable_;
+    }
+    dcChecked_ = true;
+
+    if (!checkRdmaAvailable()) {
+      XLOG(WARNING) << "DC check: RDMA not available";
+      return false;
+    }
+
+    ncclCvarInit();
+    auto devices = IbvDevice::ibvGetDeviceList(NCCL_IB_HCA, NCCL_IB_HCA_PREFIX);
+    if (!devices || devices->empty()) {
+      XLOG(WARNING) << "DC check: No RDMA devices found";
+      return false;
+    }
+
+    std::vector<int> dcCapableDevices;
+    for (size_t i = 0; i < devices->size(); ++i) {
+      DcEndPoint testEndpoint;
+      auto initResult = testEndpoint.init(static_cast<int>(i));
+      if (!initResult) {
+        XLOGF(
+            WARNING,
+            "DC check: device {} ({}) init failed: {}",
+            i,
+            devices->at(i).device()->name,
+            initResult.error().errStr);
+        continue;
+      }
+
+      auto dcResult = testEndpoint.initDc();
+      if (!dcResult) {
+        XLOGF(
+            WARNING,
+            "DC check: device {} ({}) initDc failed: {}",
+            i,
+            devices->at(i).device()->name,
+            dcResult.error().errStr);
+        continue;
+      }
+
+      XLOGF(
+          DBG,
+          "DC check: device {} ({}) supports DC",
+          i,
+          devices->at(i).device()->name);
+      dcCapableDevices.push_back(static_cast<int>(i));
+    }
+
+    if (dcCapableDevices.size() < 2) {
+      XLOGF(
+          WARNING,
+          "Need at least 2 DC-capable devices, found {}",
+          dcCapableDevices.size());
+      return false;
+    }
+
+    dcCapableDevices_ = std::move(dcCapableDevices);
+    dcAvailable_ = true;
+    XLOGF(
+        DBG,
+        "DC transport is available - using devices {} and {} for benchmarks",
+        dcCapableDevices_[0],
+        dcCapableDevices_[1]);
+    return true;
+  }
+
+  const std::vector<int>& dcCapableDevices() const {
+    return dcCapableDevices_;
+  }
+
+ private:
+  bool rdmaAvailable_{false};
+  bool rdmaChecked_{false};
+  bool dcAvailable_{false};
+  bool dcChecked_{false};
+  std::vector<int> dcCapableDevices_;
+};
+
+inline folly::Expected<folly::Unit, Error> transitionRcQpToInit(IbvQp& qp) {
+  ibv_qp_attr attr{};
+  attr.qp_state = IBV_QPS_INIT;
+  attr.pkey_index = 0;
+  attr.port_num = kPortNum;
+  attr.qp_access_flags =
+      IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ;
+
+  int mask =
+      IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_ACCESS_FLAGS;
+
+  auto result = qp.modifyQp(&attr, mask);
+  if (result.hasError()) {
+    return folly::makeUnexpected(
+        Error(result.error().errNum, "Failed to transition QP to INIT"));
+  }
+  return folly::unit;
+}
+
+inline folly::Expected<folly::Unit, Error> transitionRcQpToRtr(
+    IbvQp& qp,
+    const ibv_gid& remoteGid,
+    uint32_t remoteQpNum,
+    uint32_t remotePsn = 0) {
+  ibv_qp_attr attr{};
+  attr.qp_state = IBV_QPS_RTR;
+  attr.path_mtu = kDefaultMtu;
+  attr.dest_qp_num = remoteQpNum;
+  attr.rq_psn = remotePsn;
+  attr.max_dest_rd_atomic = 1;
+  attr.min_rnr_timer = 12;
+  attr.ah_attr.is_global = 1;
+  attr.ah_attr.grh.dgid = remoteGid;
+  attr.ah_attr.grh.sgid_index = kGidIndex;
+  attr.ah_attr.grh.hop_limit = 255;
+  attr.ah_attr.grh.traffic_class = 0;
+  attr.ah_attr.grh.flow_label = 0;
+  attr.ah_attr.dlid = 0;
+  attr.ah_attr.sl = 0;
+  attr.ah_attr.src_path_bits = 0;
+  attr.ah_attr.port_num = kPortNum;
+
+  int mask = IBV_QP_STATE | IBV_QP_AV | IBV_QP_PATH_MTU | IBV_QP_DEST_QPN |
+      IBV_QP_RQ_PSN | IBV_QP_MAX_DEST_RD_ATOMIC | IBV_QP_MIN_RNR_TIMER;
+
+  auto result = qp.modifyQp(&attr, mask);
+  if (result.hasError()) {
+    return folly::makeUnexpected(
+        Error(result.error().errNum, "Failed to transition QP to RTR"));
+  }
+  return folly::unit;
+}
+
+inline folly::Expected<folly::Unit, Error> transitionRcQpToRts(
+    IbvQp& qp,
+    uint32_t psn = 0) {
+  ibv_qp_attr attr{};
+  attr.qp_state = IBV_QPS_RTS;
+  attr.sq_psn = psn;
+  attr.timeout = 14;
+  attr.retry_cnt = 7;
+  attr.rnr_retry = 7;
+  attr.max_rd_atomic = 1;
+
+  int mask = IBV_QP_STATE | IBV_QP_SQ_PSN | IBV_QP_TIMEOUT | IBV_QP_RETRY_CNT |
+      IBV_QP_RNR_RETRY | IBV_QP_MAX_QP_RD_ATOMIC;
+
+  auto result = qp.modifyQp(&attr, mask);
+  if (result.hasError()) {
+    return folly::makeUnexpected(
+        Error(result.error().errNum, "Failed to transition QP to RTS"));
+  }
+  return folly::unit;
+}
+
+// RC Endpoint: Standard Reliable Connection QP
+class RcEndPoint : public EndPointBase {
+ public:
+  RcEndPoint() = default;
+
+  // Initialize RC QP
+  folly::Expected<folly::Unit, Error> initRc() {
+    // Create RC QP
+    ibv_qp_init_attr initAttr{};
+    initAttr.send_cq = cq_->cq();
+    initAttr.recv_cq = cq_->cq();
+    initAttr.qp_type = IBV_QPT_RC;
+    initAttr.cap.max_send_wr = 1024;
+    initAttr.cap.max_recv_wr = 1024;
+    initAttr.cap.max_send_sge = 1;
+    initAttr.cap.max_recv_sge = 1;
+
+    auto qpResult = pd_->createQp(&initAttr);
+    if (!qpResult) {
+      return folly::makeUnexpected(qpResult.error());
+    }
+    qp_ = std::make_unique<IbvQp>(std::move(*qpResult));
+
+    return folly::unit;
+  }
+
+  // Transition RC QP to INIT state
+  folly::Expected<folly::Unit, Error> transitionToInit() {
+    return transitionRcQpToInit(*qp_);
+  }
+
+  // Transition RC QP to RTR state (needs remote info)
+  folly::Expected<folly::Unit, Error> transitionToRtr(
+      const RcBusinessCard& remoteCard) {
+    ibv_gid remoteGid{};
+    remoteGid.global.subnet_prefix = remoteCard.subnetPrefix;
+    remoteGid.global.interface_id = remoteCard.interfaceId;
+    return transitionRcQpToRtr(
+        *qp_, remoteGid, remoteCard.qpNum, remoteCard.psn);
+  }
+
+  // Transition RC QP to RTS state
+  folly::Expected<folly::Unit, Error> transitionToRts() {
+    return transitionRcQpToRts(*qp_, psn_);
+  }
+
+  // Connect to remote RC endpoint
+  folly::Expected<folly::Unit, Error> connect(
+      const RcBusinessCard& remoteCard) {
+    auto initResult = transitionToInit();
+    if (!initResult) {
+      return initResult;
+    }
+
+    auto rtrResult = transitionToRtr(remoteCard);
+    if (!rtrResult) {
+      return rtrResult;
+    }
+
+    auto rtsResult = transitionToRts();
+    if (!rtsResult) {
+      return rtsResult;
+    }
+
+    return folly::unit;
+  }
+
+  // Create business card for exchange
+  RcBusinessCard createBusinessCard(void* buf, uint32_t rkey) const {
+    return RcBusinessCard{
+        .qpNum = qp_->qp()->qp_num,
+        .port = kPortNum,
+        .subnetPrefix = gid_.global.subnet_prefix,
+        .interfaceId = gid_.global.interface_id,
+        .remoteAddr = reinterpret_cast<uint64_t>(buf),
+        .rkey = rkey,
+        .psn = psn_,
+    };
+  }
+
+  // Post RDMA write
+  int postRdmaWrite(
+      const RcBusinessCard& targetCard,
+      ibv_sge& sge,
+      uint64_t wrId = 0) {
+    ibv_send_wr wr{};
+    wr.wr_id = wrId;
+    wr.next = nullptr;
+    wr.sg_list = &sge;
+    wr.num_sge = 1;
+    wr.opcode = IBV_WR_RDMA_WRITE;
+    wr.send_flags = IBV_SEND_SIGNALED;
+    wr.wr.rdma.remote_addr = targetCard.remoteAddr;
+    wr.wr.rdma.rkey = targetCard.rkey;
+
+    ibv_send_wr* badWr = nullptr;
+    auto result = qp_->postSend(&wr, badWr);
+    return result.hasError() ? -1 : 0;
+  }
+
+  IbvQp& qp() {
+    return *qp_;
+  }
+  uint32_t psn() const {
+    return psn_;
+  }
+
+ private:
+  std::unique_ptr<IbvQp> qp_;
+  uint32_t psn_{0}; // Packet sequence number
+};
+
+// =============================================================================
+// Standalone utility functions for benchmarks that don't use endpoint classes
+// =============================================================================
+
+// Create DCI with configurable SQ depth (for high-throughput benchmarks)
+inline folly::Expected<IbvQp, Error>
+createDCILargeSq(IbvPd& pd, IbvCq& cq, int sqDepth) {
+  ibv_qp_init_attr_ex initAttr{};
+  mlx5dv_qp_init_attr dvInitAttr{};
+  memset(&initAttr, 0, sizeof(initAttr));
+  memset(&dvInitAttr, 0, sizeof(dvInitAttr));
+
+  initAttr.qp_type = IBV_QPT_DRIVER;
+  initAttr.send_cq = cq.cq();
+  initAttr.recv_cq = cq.cq();
+  initAttr.comp_mask = IBV_QP_INIT_ATTR_PD;
+  initAttr.cap.max_send_wr = sqDepth;
+  initAttr.cap.max_send_sge = 1;
+  initAttr.comp_mask |= IBV_QP_INIT_ATTR_SEND_OPS_FLAGS;
+  initAttr.send_ops_flags = IBV_QP_EX_WITH_RDMA_WRITE;
+
+  dvInitAttr.comp_mask = MLX5DV_QP_INIT_ATTR_MASK_DC;
+  dvInitAttr.dc_init_attr.dc_type = MLX5DV_DCTYPE_DCI;
+
+  return pd.createDcQp(&initAttr, &dvInitAttr);
+}
+
+// Standalone busy-spin CQ poll (for benchmarks not using endpoint classes)
+inline bool pollCqBusySpin(
+    ibv_cq* rawCq,
+    int expected,
+    int timeoutMs = kDefaultPollTimeoutMs) {
+  int completed = 0;
+  ibv_wc wc{};
+  auto start = std::chrono::steady_clock::now();
+  while (completed < expected) {
+    int n = rawCq->context->ops.poll_cq(rawCq, 1, &wc);
+    if (n < 0) {
+      XLOGF(ERR, "CQ poll error: returned {}", n);
+      return false;
+    }
+    if (n == 1) {
+      if (wc.status != IBV_WC_SUCCESS) {
+        XLOGF(
+            ERR,
+            "WC error: status={}, opcode={}, vendor_err={}",
+            wc.status,
+            wc.opcode,
+            wc.vendor_err);
+        return false;
+      }
+      completed++;
+    } else {
+      auto elapsed = std::chrono::steady_clock::now() - start;
+      if (std::chrono::duration_cast<std::chrono::milliseconds>(elapsed)
+              .count() > timeoutMs) {
+        XLOGF(
+            ERR,
+            "CQ busy-spin timeout: got {}/{} completions",
+            completed,
+            expected);
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+// Post DC RDMA write (raw parameters variant)
+inline int postDcRdmaWrite(
+    ibv_qp_ex* exQp,
+    mlx5dv_qp_ex* dvQp,
+    IbvAh& ah,
+    uint32_t dctNum,
+    uint32_t rkey,
+    uint64_t remoteAddr,
+    ibv_sge& sge,
+    uint64_t wrId) {
+  ibvSymbols.ibv_internal_wr_start(exQp);
+  exQp->wr_id = wrId;
+  exQp->wr_flags = IBV_SEND_SIGNALED;
+  ibvSymbols.ibv_internal_wr_rdma_write(exQp, rkey, remoteAddr);
+  ibvSymbols.ibv_internal_wr_set_sge_list(exQp, 1, &sge);
+  ibvSymbols.mlx5dv_internal_wr_set_dc_addr(dvQp, ah.ah(), dctNum, DC_KEY);
+  return ibvSymbols.ibv_internal_wr_complete(exQp);
+}
+
+// Post DC RDMA write (DcBusinessCard variant)
+inline int postDcRdmaWrite(
+    ibv_qp_ex* exQp,
+    mlx5dv_qp_ex* dvQp,
+    IbvAh& ah,
+    const DcBusinessCard& target,
+    ibv_sge& sge,
+    uint64_t wrId) {
+  return postDcRdmaWrite(
+      exQp, dvQp, ah, target.dctNum, target.rkey, target.remoteAddr, sge, wrId);
+}
+
+// Standalone RC QP connection (INIT -> RTR -> RTS)
+inline bool
+connectRcQp(IbvQp& localQp, const ibv_gid& remoteGid, uint32_t remoteQpNum) {
+  return transitionRcQpToInit(localQp).hasValue() &&
+      transitionRcQpToRtr(localQp, remoteGid, remoteQpNum).hasValue() &&
+      transitionRcQpToRts(localQp).hasValue();
+}
+
+// Standalone RC RDMA write post (raw parameters variant)
+inline int postRcRdmaWrite(
+    IbvQp& qp,
+    uint32_t rkey,
+    uint64_t remoteAddr,
+    ibv_sge& sge,
+    uint64_t wrId) {
+  ibv_send_wr wr{};
+  wr.wr_id = wrId;
+  wr.next = nullptr;
+  wr.sg_list = &sge;
+  wr.num_sge = 1;
+  wr.opcode = IBV_WR_RDMA_WRITE;
+  wr.send_flags = IBV_SEND_SIGNALED;
+  wr.wr.rdma.remote_addr = remoteAddr;
+  wr.wr.rdma.rkey = rkey;
+
+  ibv_send_wr* badWr = nullptr;
+  auto result = qp.postSend(&wr, badWr);
+  return result.hasError() ? -1 : 0;
+}
+
+// Standalone RC RDMA write post (RcBusinessCard variant)
+inline int postRcRdmaWrite(
+    IbvQp& qp,
+    const RcBusinessCard& target,
+    ibv_sge& sge,
+    uint64_t wrId) {
+  return postRcRdmaWrite(qp, target.rkey, target.remoteAddr, sge, wrId);
+}
+
+// Connect an RC QP pair (both sender and receiver through INIT -> RTR -> RTS)
+inline bool connectRcQpPair(
+    IbvQp& senderQp,
+    IbvQp& receiverQp,
+    const ibv_gid& senderGid,
+    const ibv_gid& receiverGid) {
+  if (!connectRcQp(senderQp, receiverGid, receiverQp.qp()->qp_num)) {
+    return false;
+  }
+  if (!connectRcQp(receiverQp, senderGid, senderQp.qp()->qp_num)) {
+    return false;
+  }
+  return true;
+}
+
+// Create DCI with configurable SQ depth and DCI Streams enabled
+inline folly::Expected<IbvQp, Error> createDCILargeSqWithStreams(
+    IbvPd& pd,
+    IbvCq& cq,
+    int sqDepth,
+    uint8_t logNumConcurrent,
+    uint8_t logNumErrored = 0) {
+  ibv_qp_init_attr_ex initAttr{};
+  mlx5dv_qp_init_attr dvInitAttr{};
+  memset(&initAttr, 0, sizeof(initAttr));
+  memset(&dvInitAttr, 0, sizeof(dvInitAttr));
+
+  initAttr.qp_type = IBV_QPT_DRIVER;
+  initAttr.send_cq = cq.cq();
+  initAttr.recv_cq = cq.cq();
+  initAttr.comp_mask = IBV_QP_INIT_ATTR_PD;
+  initAttr.cap.max_send_wr = sqDepth;
+  initAttr.cap.max_send_sge = 1;
+  initAttr.comp_mask |= IBV_QP_INIT_ATTR_SEND_OPS_FLAGS;
+  initAttr.send_ops_flags = IBV_QP_EX_WITH_RDMA_WRITE;
+
+  dvInitAttr.comp_mask =
+      MLX5DV_QP_INIT_ATTR_MASK_DC | MLX5DV_QP_INIT_ATTR_MASK_DCI_STREAMS;
+  dvInitAttr.dc_init_attr.dc_type = MLX5DV_DCTYPE_DCI;
+  dvInitAttr.dc_init_attr.dci_streams.log_num_concurent = logNumConcurrent;
+  dvInitAttr.dc_init_attr.dci_streams.log_num_errored = logNumErrored;
+
+  return pd.createDcQp(&initAttr, &dvInitAttr);
+}
+
+} // namespace ibverbx

--- a/comms/ctran/ibverbx/benchmarks/IbverbxDcConnectionProbeBench.cc
+++ b/comms/ctran/ibverbx/benchmarks/IbverbxDcConnectionProbeBench.cc
@@ -1,0 +1,353 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+/**
+ * DC Connection Persistence Probe
+ *
+ * Uses MPI with 16 ranks across 2 nodes (8 ranks/node).
+ * Each rank writes to exactly 2 remote peers on different NICs with two
+ * patterns to determine whether the DCI caches connections or only holds
+ * them via SQ look-ahead:
+ *
+ *   sorted:      AAAA...BBBB (1 DCT switch)
+ *   alternating: ABABABAB... (N DCT switches)
+ *
+ * If DCI caches connections (cache >= 2):
+ *   both patterns perform similarly after warmup
+ * If DCI only holds connection via SQ look-ahead (no cache):
+ *   alternating degrades proportionally to switch count
+ */
+
+#include <chrono>
+#include <vector>
+
+#include <folly/init/Init.h>
+#include <folly/logging/Init.h>
+#include <folly/logging/xlog.h>
+#include <gtest/gtest.h>
+
+#include "comms/ctran/ibverbx/Ibverbx.h"
+#include "comms/ctran/ibverbx/IbverbxSymbols.h"
+#include "comms/ctran/ibverbx/benchmarks/IbverbxDcBenchUtils.h"
+#include "comms/ctran/ibverbx/tests/dc_utils.h"
+#include "comms/testinfra/mpi/MpiTestUtils.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+
+using ibverbx::createAddressHandle;
+using ibverbx::createDCILargeSq;
+using ibverbx::createDCT;
+using ibverbx::createSRQ;
+using ibverbx::DC_KEY;
+using ibverbx::DcBusinessCard;
+using ibverbx::kDefaultMtu;
+using ibverbx::kDefaultMtuValue;
+using ibverbx::kGidIndex;
+using ibverbx::kPortNum;
+using ibverbx::pollCqBusySpin;
+using ibverbx::transitionDCIToRts;
+using ibverbx::transitionDCTToRtr;
+
+FOLLY_INIT_LOGGING_CONFIG(
+    ".=WARNING"
+    ";default:async=true,sync_level=WARNING");
+
+namespace {
+
+constexpr int kWarmupIters = 10;
+constexpr int kBenchIters = 100;
+constexpr int kCqDepth = 8192;
+constexpr int kDciSqDepth = 8192;
+constexpr int kPollTimeoutMs = 30000;
+constexpr int kPpn = 8;
+
+// MPI exchange card
+struct ExchangeCard {
+  uint32_t dctNum;
+  uint64_t subnetPrefix;
+  uint64_t interfaceId;
+  uint64_t recvBufAddr;
+  uint32_t rkey;
+  int nicIdx;
+};
+
+// Compute the slot index for 'sender' in 'receiver's recv buffer.
+int peerSlot(int sender, int receiver) {
+  return sender < receiver ? sender : sender - 1;
+}
+
+} // namespace
+
+class DcConnectionProbeBench : public meta::comms::MpiBaseTestFixture {
+ protected:
+  void SetUp() override {
+    MpiBaseTestFixture::SetUp();
+    ncclCvarInit();
+    ASSERT_TRUE(ibverbx::ibvInit());
+  }
+
+  void runProbe(int writesPerPeer, size_t chunkSize);
+};
+
+void DcConnectionProbeBench::runProbe(int writesPerPeer, size_t chunkSize) {
+  ASSERT_EQ(numRanks, 2 * kPpn)
+      << "This benchmark requires exactly " << 2 * kPpn << " MPI ranks";
+
+  int sendDeviceIdx = localRank % 8;
+  int recvDeviceIdx = localRank % 8;
+  int totalWrites = 2 * writesPerPeer;
+  int numPeers = numRanks - 1;
+
+  auto devices =
+      ibverbx::IbvDevice::ibvGetDeviceList(NCCL_IB_HCA, NCCL_IB_HCA_PREFIX);
+  ASSERT_TRUE(devices);
+  ASSERT_GT(
+      devices->size(),
+      static_cast<size_t>(std::max(sendDeviceIdx, recvDeviceIdx)));
+
+  auto access = static_cast<ibverbx::ibv_access_flags>(
+      ibverbx::IBV_ACCESS_LOCAL_WRITE | ibverbx::IBV_ACCESS_REMOTE_WRITE |
+      ibverbx::IBV_ACCESS_REMOTE_READ);
+
+  // --- Send side ---
+  auto& sendDevice = devices->at(sendDeviceIdx);
+  auto sendPd = sendDevice.allocPd();
+  ASSERT_TRUE(sendPd);
+  auto sendCq = sendDevice.createCq(kCqDepth, nullptr, nullptr, 0);
+  ASSERT_TRUE(sendCq);
+
+  auto dciResult = createDCILargeSq(*sendPd, *sendCq, kDciSqDepth);
+  if (!dciResult) {
+    if (globalRank == 0) {
+      fprintf(
+          stderr,
+          "SKIP: DCI creation failed: %s\n",
+          dciResult.error().errStr.c_str());
+    }
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    GTEST_SKIP() << "DCI creation failed";
+  }
+  auto dci = std::make_unique<ibverbx::IbvQp>(std::move(*dciResult));
+  auto* exQp = ibverbx::ibvSymbols.ibv_internal_qp_to_qp_ex(dci->qp());
+  auto* dvQp = ibverbx::ibvSymbols.mlx5dv_internal_qp_ex_from_ibv_qp_ex(exQp);
+  ASSERT_NE(exQp, nullptr);
+  ASSERT_NE(dvQp, nullptr);
+  ASSERT_TRUE(transitionDCIToRts(*dci, kPortNum, kDefaultMtu));
+
+  std::vector<uint8_t> sendBuf(chunkSize, 0xAA);
+  auto sendMr = sendPd->regMr(sendBuf.data(), chunkSize, access);
+  ASSERT_TRUE(sendMr);
+
+  // --- Recv side ---
+  auto& recvDevice = devices->at(recvDeviceIdx);
+  auto recvPd = recvDevice.allocPd();
+  ASSERT_TRUE(recvPd);
+  auto recvCq = recvDevice.createCq(kCqDepth, nullptr, nullptr, 0);
+  ASSERT_TRUE(recvCq);
+  auto recvGid = recvDevice.queryGid(kPortNum, kGidIndex);
+  ASSERT_TRUE(recvGid);
+
+  auto srqResult = createSRQ(*recvPd, 1024);
+  ASSERT_TRUE(srqResult);
+  auto srq = std::make_unique<ibverbx::IbvSrq>(std::move(*srqResult));
+
+  auto dctResult = createDCT(*recvPd, *recvCq, *srq);
+  ASSERT_TRUE(dctResult);
+  auto dct = std::make_unique<ibverbx::IbvQp>(std::move(*dctResult));
+  ASSERT_TRUE(transitionDCTToRtr(*dct, kPortNum, kDefaultMtu));
+
+  // Recv buffer sized for all peers at their global slot
+  size_t recvBufSize = numPeers * writesPerPeer * chunkSize;
+  std::vector<uint8_t> recvBuf(recvBufSize, 0x00);
+  auto recvMr = recvPd->regMr(recvBuf.data(), recvBufSize, access);
+  ASSERT_TRUE(recvMr);
+
+  // Exchange cards
+  ExchangeCard myCard{};
+  myCard.dctNum = dct->qp()->qp_num;
+  myCard.subnetPrefix = recvGid->global.subnet_prefix;
+  myCard.interfaceId = recvGid->global.interface_id;
+  myCard.recvBufAddr = reinterpret_cast<uint64_t>(recvBuf.data());
+  myCard.rkey = recvMr->mr()->rkey;
+  myCard.nicIdx = recvDeviceIdx;
+
+  std::vector<ExchangeCard> allCards(numRanks);
+  MPI_CHECK(MPI_Allgather(
+      &myCard,
+      sizeof(ExchangeCard),
+      MPI_BYTE,
+      allCards.data(),
+      sizeof(ExchangeCard),
+      MPI_BYTE,
+      MPI_COMM_WORLD));
+
+  // Pick 2 remote peers on different recv NICs
+  int peerA = -1, peerB = -1;
+  for (int r = 0; r < numRanks; ++r) {
+    if (r == globalRank) {
+      continue;
+    }
+    if (peerA == -1) {
+      peerA = r;
+    } else if (allCards[r].nicIdx != allCards[peerA].nicIdx && peerB == -1) {
+      peerB = r;
+      break;
+    }
+  }
+  ASSERT_NE(peerA, -1);
+  ASSERT_NE(peerB, -1);
+
+  // Create AHs (different NICs = different GIDs = different AHs)
+  auto makeAh = [&](int r) {
+    DcBusinessCard card{};
+    card.mtu = kDefaultMtuValue;
+    card.dctNum = allCards[r].dctNum;
+    card.port = kPortNum;
+    card.subnetPrefix = allCards[r].subnetPrefix;
+    card.interfaceId = allCards[r].interfaceId;
+    return createAddressHandle(*sendPd, card);
+  };
+  auto ahA = std::make_unique<ibverbx::IbvAh>(std::move(*makeAh(peerA)));
+  auto ahB = std::make_unique<ibverbx::IbvAh>(std::move(*makeAh(peerB)));
+
+  ibverbx::ibv_sge sendSge{};
+  sendSge.addr = reinterpret_cast<uint64_t>(sendBuf.data());
+  sendSge.length = static_cast<uint32_t>(chunkSize);
+  sendSge.lkey = sendMr->mr()->lkey;
+
+  int batch = std::min(kDciSqDepth, kCqDepth);
+
+  // Write target for the schedule
+  struct WriteTarget {
+    ibverbx::IbvAh* ah;
+    uint32_t dctNum;
+    uint32_t rkey;
+    uint64_t addr;
+  };
+
+  // Build write schedule
+  int peers[2] = {peerA, peerB};
+  ibverbx::IbvAh* ahs[2] = {ahA.get(), ahB.get()};
+
+  auto buildSchedule = [&](bool sorted) {
+    std::vector<WriteTarget> sched;
+    sched.reserve(totalWrites);
+    if (sorted) {
+      for (int p = 0; p < 2; ++p) {
+        for (int w = 0; w < writesPerPeer; ++w) {
+          int slot = peerSlot(globalRank, peers[p]);
+          sched.push_back(
+              {ahs[p],
+               allCards[peers[p]].dctNum,
+               allCards[peers[p]].rkey,
+               allCards[peers[p]].recvBufAddr +
+                   static_cast<uint64_t>(slot) * writesPerPeer * chunkSize +
+                   static_cast<uint64_t>(w) * chunkSize});
+        }
+      }
+    } else {
+      for (int w = 0; w < writesPerPeer; ++w) {
+        for (int p = 0; p < 2; ++p) {
+          int slot = peerSlot(globalRank, peers[p]);
+          sched.push_back(
+              {ahs[p],
+               allCards[peers[p]].dctNum,
+               allCards[peers[p]].rkey,
+               allCards[peers[p]].recvBufAddr +
+                   static_cast<uint64_t>(slot) * writesPerPeer * chunkSize +
+                   static_cast<uint64_t>(w) * chunkSize});
+        }
+      }
+    }
+    return sched;
+  };
+
+  // Run a pattern and report results
+  auto runPattern = [&](const std::vector<WriteTarget>& sched,
+                        const char* label) {
+    auto postAll = [&]() -> bool {
+      int remaining = totalWrites;
+      int idx = 0;
+      while (remaining > 0) {
+        int thisBatch = std::min(remaining, batch);
+        ibverbx::ibvSymbols.ibv_internal_wr_start(exQp);
+        for (int j = 0; j < thisBatch; ++j) {
+          auto& t = sched[idx];
+          exQp->wr_id = static_cast<uint64_t>(idx);
+          exQp->wr_flags = ibverbx::IBV_SEND_SIGNALED;
+          ibverbx::ibvSymbols.ibv_internal_wr_rdma_write(exQp, t.rkey, t.addr);
+          ibverbx::ibvSymbols.ibv_internal_wr_set_sge_list(exQp, 1, &sendSge);
+          ibverbx::ibvSymbols.mlx5dv_internal_wr_set_dc_addr(
+              dvQp, t.ah->ah(), t.dctNum, DC_KEY);
+          idx++;
+        }
+        if (ibverbx::ibvSymbols.ibv_internal_wr_complete(exQp) != 0) {
+          return false;
+        }
+        if (!pollCqBusySpin(sendCq->cq(), thisBatch, kPollTimeoutMs)) {
+          return false;
+        }
+        remaining -= thisBatch;
+      }
+      return true;
+    };
+
+    for (int w = 0; w < kWarmupIters; ++w) {
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+      ASSERT_TRUE(postAll()) << label << " warmup failed at iter " << w;
+    }
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    auto start = std::chrono::high_resolution_clock::now();
+    for (int iter = 0; iter < kBenchIters; ++iter) {
+      ASSERT_TRUE(postAll()) << label << " timed failed at iter " << iter;
+    }
+    auto end = std::chrono::high_resolution_clock::now();
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    if (globalRank == 0) {
+      double elapsedUs =
+          std::chrono::duration_cast<std::chrono::nanoseconds>(end - start)
+              .count() /
+          1000.0;
+      double latencyUs = elapsedUs / kBenchIters;
+      size_t totalBytes = chunkSize * totalWrites;
+      double bwGbps = (static_cast<double>(totalBytes) * kBenchIters / 1e9) /
+          (elapsedUs / 1e6);
+      fprintf(
+          stderr,
+          "RAW,%s,%d,%.2f,%.6f,%zu,%d\n",
+          label,
+          writesPerPeer,
+          latencyUs,
+          bwGbps,
+          chunkSize,
+          totalWrites);
+    }
+  };
+
+  auto sortedSched = buildSchedule(true);
+  auto altSched = buildSchedule(false);
+
+  runPattern(sortedSched, "dcProbe_sorted");
+  runPattern(altSched, "dcProbe_alternating");
+}
+
+TEST_F(DcConnectionProbeBench, DcConnectionProbe) {
+  if (globalRank == 0) {
+    fprintf(
+        stderr,
+        "RAW,benchmark,writes_per_peer,latency_us,bw_gbps,chunk_bytes,total_writes\n");
+  }
+  // 1MB per peer, varying chunk count (= writes per peer)
+  // More writes = more DCT switches in alternating mode
+  for (int wpp : {16, 64, 256, 1024}) {
+    size_t chunk = 1024 * 1024 / wpp;
+    runProbe(wpp, chunk);
+  }
+}
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new meta::comms::MPIEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ctran/ibverbx/benchmarks/IbverbxDcOneToManyBench.cc
+++ b/comms/ctran/ibverbx/benchmarks/IbverbxDcOneToManyBench.cc
@@ -1,0 +1,1274 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * DC One-to-Many RDMA Scalability Benchmarks
+ *
+ * Single-process benchmarks that measure DC and RC RDMA write performance
+ * from one sender NIC to one or more receiver NICs on the same node.
+ *
+ * Benchmark families:
+ *
+ *   Peer count sweep (N=2..2048, msg_size = 128MB / N):
+ *     dcScalability           — DC baseline (1 AH, 1 MR, 1 DCI, 1 receiver NIC)
+ *     dcMultiDci{2,4,8,16}    — multiple DCIs/DCTs on 1 receiver NIC
+ *     dcMultiNicRoundRobin    — multi-NIC receivers, round-robin write ordering
+ *     dcMultiNicSorted        — multi-NIC receivers, writes grouped by dest NIC
+ *     rcScalability           — RC baseline for comparison
+ *
+ *   Message size sweep (N=2048 fixed, msg_size = 64B..1MB):
+ *     dcMsgSweep           — DC, 1 DCI
+ *     dcMultiDci4MsgSweep  — DC, 4 DCIs
+ *     rcMsgSweep           — RC baseline
+ *
+ * Setup: device 0 = sender, remaining devices = receivers.
+ * Sender posts N-1 RDMA writes per iteration.
+ *
+ * Design for fair comparison:
+ * - Shared CQ per device side (no serial per-endpoint CQ polling)
+ * - DCI with large SQ depth (8192) for fair batching at high N
+ * - Same batch formula for both DC and RC
+ */
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include <folly/logging/Init.h>
+#include <folly/logging/xlog.h>
+#include <gflags/gflags.h>
+
+#include "comms/ctran/ibverbx/Ibverbx.h"
+#include "comms/ctran/ibverbx/IbverbxSymbols.h"
+#include "comms/ctran/ibverbx/benchmarks/IbverbxDcBenchUtils.h"
+#include "comms/ctran/ibverbx/tests/dc_utils.h"
+#include "comms/testinfra/BenchUtils.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+
+FOLLY_INIT_LOGGING_CONFIG(
+    ".=WARNING"
+    ";default:async=true,sync_level=WARNING");
+
+DEFINE_bool(raw_only, true, "Print only RAW CSV results, suppress folly table");
+
+using namespace ibverbx;
+
+namespace {
+
+// Tuning constants
+constexpr int kSharedCqDepth = 8192;
+constexpr int kDciSqDepth = 8192;
+constexpr int kRcQpSqDepth = 1024;
+constexpr size_t kTotalInputSize = 128 * 1024 * 1024; // 128 MB
+constexpr int kWarmupIters = 10;
+constexpr int kMsgSweepNumPeers = 2048;
+
+RdmaAvailabilityChecker g_rdmaAvailability;
+
+void setMetric(folly::UserCounters& counters, const char* name) {
+  counters[name] = folly::UserMetric(1, folly::UserMetric::Type::METRIC);
+}
+
+void setError(folly::UserCounters& counters) {
+  setMetric(counters, "error");
+}
+
+void setSkipped(folly::UserCounters& counters) {
+  setMetric(counters, "skipped");
+}
+
+bool initResources(
+    RdmaResources& resources,
+    int deviceIndex,
+    folly::UserCounters& counters) {
+  auto result = initRdmaResources(deviceIndex, kSharedCqDepth);
+  if (!result) {
+    XLOGF(
+        ERR,
+        "Failed to initialize RDMA resources for device {}: {}",
+        deviceIndex,
+        result.error().errStr);
+    setError(counters);
+    return false;
+  }
+  resources = std::move(*result);
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Raw results collection
+// ---------------------------------------------------------------------------
+struct RawResult {
+  std::string name;
+  int numPeers;
+  double latencyUs;
+  double postUs;
+  double pollUs;
+  double bwGbps;
+  int batch;
+  size_t msgBytes;
+  int numDcis;
+  int numReceiverNics;
+  int numAhs;
+};
+std::vector<RawResult> g_rawResults;
+std::mutex g_rawResultsMutex;
+
+void recordRawResult(
+    const char* name,
+    int numPeers,
+    double latencyUs,
+    double postUs,
+    double pollUs,
+    double bwGbps,
+    int batch,
+    size_t msgBytes,
+    int numDcis,
+    int numReceiverNics,
+    int numAhs) {
+  std::lock_guard<std::mutex> lock(g_rawResultsMutex);
+  for (auto& r : g_rawResults) {
+    if (r.name == name && r.numPeers == numPeers && r.msgBytes == msgBytes) {
+      r = {
+          name,
+          numPeers,
+          latencyUs,
+          postUs,
+          pollUs,
+          bwGbps,
+          batch,
+          msgBytes,
+          numDcis,
+          numReceiverNics,
+          numAhs};
+      return;
+    }
+  }
+  g_rawResults.push_back(
+      {name,
+       numPeers,
+       latencyUs,
+       postUs,
+       pollUs,
+       bwGbps,
+       batch,
+       msgBytes,
+       numDcis,
+       numReceiverNics,
+       numAhs});
+}
+
+void printAllRawResults() {
+  fprintf(
+      stderr,
+      "RAW,benchmark,N,latency_us,post_us,poll_us,bw_gbps,batch,msg_bytes,num_dcis,num_receiver_nics,num_ahs\n");
+  for (const auto& r : g_rawResults) {
+    fprintf(
+        stderr,
+        "RAW,%s,%d,%.2f,%.2f,%.2f,%.6f,%d,%zu,%d,%d,%d\n",
+        r.name.c_str(),
+        r.numPeers,
+        r.latencyUs,
+        r.postUs,
+        r.pollUs,
+        r.bwGbps,
+        r.batch,
+        r.msgBytes,
+        r.numDcis,
+        r.numReceiverNics,
+        r.numAhs);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// DC Scalability Benchmark
+//
+// multiNic=false (default): all receivers on device 1 (single AH)
+// multiNic=true: receivers spread across all available DC-capable NICs
+//   (devices 1..K), each NIC with its own SRQ/DCT/buffer/MR/AH
+// sorted=false (default): round-robin write ordering across NICs
+// sorted=true: writes grouped by destination NIC
+// ---------------------------------------------------------------------------
+
+// Per-NIC receiver state (for multi-NIC mode, or single element for 1-NIC)
+struct ReceiverNicState {
+  RdmaResources res;
+  std::unique_ptr<ibverbx::IbvSrq> srq;
+  std::unique_ptr<ibverbx::IbvQp> dct;
+  std::vector<uint8_t> buf;
+  std::unique_ptr<ibverbx::IbvMr> mr;
+  std::unique_ptr<ibverbx::IbvAh> ah; // AH from sender PD to this NIC
+};
+
+static void dcMultiDciCore(
+    uint32_t iters,
+    size_t numPeers,
+    size_t msgSize,
+    int numDcis,
+    folly::UserCounters& counters,
+    const char* benchName);
+
+static void dcScalabilityCore(
+    uint32_t iters,
+    size_t numPeers,
+    size_t msgSize,
+    folly::UserCounters& counters,
+    const char* benchName,
+    bool multiNic = false,
+    bool sorted = false) {
+  if (!g_rdmaAvailability.checkDcAvailable()) {
+    setSkipped(counters);
+    return;
+  }
+
+  int numReceivers = static_cast<int>(numPeers) - 1;
+  if (numReceivers < 1) {
+    setError(counters);
+    return;
+  }
+
+  // Determine number of receiver NICs (cap at numReceivers so no NIC gets 0
+  // receivers, which would cause a 0-byte regMr failure)
+  int K = multiNic
+      ? static_cast<int>(g_rdmaAvailability.dcCapableDevices().size()) - 1
+      : 1;
+  if (K < 1) {
+    setError(counters);
+    return;
+  }
+  K = std::min(K, numReceivers);
+
+  // Sender shared resources on device 0
+  RdmaResources sender;
+  if (!initResources(
+          sender, g_rdmaAvailability.dcCapableDevices()[0], counters)) {
+    return;
+  }
+
+  // Create DCI with large SQ on sender side
+  auto dciResult = createDCILargeSq(*sender.pd, *sender.cq, kDciSqDepth);
+  if (!dciResult) {
+    setError(counters);
+    return;
+  }
+  auto dci = std::make_unique<ibverbx::IbvQp>(std::move(*dciResult));
+
+  // Get extended QP interface
+  auto* exQp = ibverbx::ibvSymbols.ibv_internal_qp_to_qp_ex(dci->qp());
+  auto* dvQp = ibverbx::ibvSymbols.mlx5dv_internal_qp_ex_from_ibv_qp_ex(exQp);
+  if (!exQp || !dvQp) {
+    setError(counters);
+    return;
+  }
+
+  // Transition DCI to RTS
+  if (!transitionDCIToRts(*dci, kPortNum, kDefaultMtu)) {
+    setError(counters);
+    return;
+  }
+
+  auto accessFlags = static_cast<ibverbx::ibv_access_flags>(
+      ibverbx::IBV_ACCESS_LOCAL_WRITE | ibverbx::IBV_ACCESS_REMOTE_WRITE |
+      ibverbx::IBV_ACCESS_REMOTE_READ);
+
+  // Allocate sender buffer and MR
+  std::vector<uint8_t> senderBuf(msgSize, 0xAA);
+  auto senderMrResult =
+      sender.pd->regMr(senderBuf.data(), senderBuf.size(), accessFlags);
+  if (!senderMrResult) {
+    setError(counters);
+    return;
+  }
+  auto senderMr = std::make_unique<ibverbx::IbvMr>(std::move(*senderMrResult));
+
+  ibverbx::ibv_sge sge{};
+  sge.addr = reinterpret_cast<uint64_t>(senderBuf.data());
+  sge.length = static_cast<uint32_t>(msgSize);
+  sge.lkey = senderMr->mr()->lkey;
+
+  // Setup K receiver NICs
+  std::vector<ReceiverNicState> nics(K);
+
+  // Count receivers per NIC (round-robin assignment)
+  std::vector<int> receiversPerNic(K, 0);
+  for (int i = 0; i < numReceivers; ++i) {
+    receiversPerNic[i % K]++;
+  }
+
+  for (int n = 0; n < K; ++n) {
+    auto& nic = nics[n];
+
+    if (!initResources(
+            nic.res, g_rdmaAvailability.dcCapableDevices()[n + 1], counters)) {
+      return;
+    }
+
+    auto srqResult = createSRQ(*nic.res.pd, 1024);
+    if (!srqResult) {
+      setError(counters);
+      return;
+    }
+    nic.srq = std::make_unique<ibverbx::IbvSrq>(std::move(*srqResult));
+
+    auto dctResult = createDCT(*nic.res.pd, *nic.res.cq, *nic.srq);
+    if (!dctResult) {
+      setError(counters);
+      return;
+    }
+    nic.dct = std::make_unique<ibverbx::IbvQp>(std::move(*dctResult));
+    if (!transitionDCTToRtr(*nic.dct, kPortNum, kDefaultMtu)) {
+      setError(counters);
+      return;
+    }
+
+    // Receiver buffer sized for the receivers assigned to this NIC
+    nic.buf.resize(static_cast<size_t>(receiversPerNic[n]) * msgSize, 0x00);
+    auto mrResult =
+        nic.res.pd->regMr(nic.buf.data(), nic.buf.size(), accessFlags);
+    if (!mrResult) {
+      setError(counters);
+      return;
+    }
+    nic.mr = std::make_unique<ibverbx::IbvMr>(std::move(*mrResult));
+
+    // AH from sender PD to this NIC
+    auto ahCard = makeDcBusinessCard(nic.dct->qp()->qp_num, nic.res.gid);
+    auto ahResult = createAddressHandle(*sender.pd, ahCard);
+    if (!ahResult) {
+      setError(counters);
+      return;
+    }
+    nic.ah = std::make_unique<ibverbx::IbvAh>(std::move(*ahResult));
+  }
+
+  // Build per-receiver business cards and AH index mapping.
+  // Default (round-robin): receiver i → NIC i%K
+  // Sorted: all receivers on NIC 0 first, then NIC 1, etc.
+  std::vector<DcBusinessCard> recvCards(numReceivers);
+  std::vector<int> ahIndex(numReceivers);
+  std::vector<int> nicWriteIdx(K, 0);
+
+  if (sorted && K > 1) {
+    // Sorted: group by destination NIC
+    int idx = 0;
+    for (int n = 0; n < K; ++n) {
+      for (int r = 0; r < receiversPerNic[n]; ++r) {
+        auto& nic = nics[n];
+        recvCards[idx] = makeDcBusinessCard(
+            nic.dct->qp()->qp_num,
+            nic.res.gid,
+            reinterpret_cast<uint64_t>(nic.buf.data()) +
+                static_cast<uint64_t>(r) * msgSize,
+            nic.mr->mr()->rkey,
+            idx);
+        ahIndex[idx] = n;
+        idx++;
+      }
+    }
+  } else {
+    // Round-robin (default)
+    for (int i = 0; i < numReceivers; ++i) {
+      int n = i % K;
+      auto& nic = nics[n];
+      recvCards[i] = makeDcBusinessCard(
+          nic.dct->qp()->qp_num,
+          nic.res.gid,
+          reinterpret_cast<uint64_t>(nic.buf.data()) +
+              static_cast<uint64_t>(nicWriteIdx[n]) * msgSize,
+          nic.mr->mr()->rkey,
+          i);
+      ahIndex[i] = n;
+      nicWriteIdx[n]++;
+    }
+  }
+
+  // Batch size: match all-to-all formula (SQ depth, capped by CQ)
+  int batch = std::min(kDciSqDepth, kSharedCqDepth);
+
+  // Warmup
+  for (int w = 0; w < kWarmupIters; ++w) {
+    int rem = numReceivers;
+    int idx = 0;
+    while (rem > 0) {
+      int b = std::min(rem, batch);
+      for (int j = 0; j < b; ++j) {
+        if (postDcRdmaWrite(
+                exQp, dvQp, *nics[ahIndex[idx]].ah, recvCards[idx], sge, idx) !=
+            0) {
+          setError(counters);
+          return;
+        }
+        idx++;
+      }
+      if (!pollCqBusySpin(sender.cq->cq(), b)) {
+        setError(counters);
+        return;
+      }
+      rem -= b;
+    }
+  }
+
+  // Timed iterations
+  auto start = std::chrono::high_resolution_clock::now();
+  std::chrono::nanoseconds totalPostNs{0};
+  std::chrono::nanoseconds totalPollNs{0};
+
+  for (uint32_t iter = 0; iter < iters; ++iter) {
+    int remaining = numReceivers;
+    int idx = 0;
+    while (remaining > 0) {
+      int thisBatch = std::min(remaining, batch);
+
+      auto postStart = std::chrono::high_resolution_clock::now();
+      for (int j = 0; j < thisBatch; ++j) {
+        if (postDcRdmaWrite(
+                exQp, dvQp, *nics[ahIndex[idx]].ah, recvCards[idx], sge, idx) !=
+            0) {
+          setError(counters);
+          return;
+        }
+        idx++;
+      }
+      auto postEnd = std::chrono::high_resolution_clock::now();
+      totalPostNs += (postEnd - postStart);
+
+      auto pollStart = std::chrono::high_resolution_clock::now();
+      if (!pollCqBusySpin(sender.cq->cq(), thisBatch)) {
+        setError(counters);
+        return;
+      }
+      auto pollEnd = std::chrono::high_resolution_clock::now();
+      totalPollNs += (pollEnd - pollStart);
+
+      remaining -= thisBatch;
+    }
+  }
+
+  auto end = std::chrono::high_resolution_clock::now();
+  double elapsedUs =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(end - start)
+          .count() /
+      1000.0;
+
+  double avgLatencyUs = elapsedUs / iters;
+  double avgPostUs = totalPostNs.count() / 1000.0 / iters;
+  double avgPollUs = totalPollNs.count() / 1000.0 / iters;
+  double bandwidthGBps =
+      (msgSize * numReceivers * iters / 1e9) / (elapsedUs / 1e6);
+
+  counters["latency_us"] =
+      folly::UserMetric(avgLatencyUs, folly::UserMetric::Type::METRIC);
+  counters["post_us"] =
+      folly::UserMetric(avgPostUs, folly::UserMetric::Type::METRIC);
+  counters["poll_us"] =
+      folly::UserMetric(avgPollUs, folly::UserMetric::Type::METRIC);
+  counters["bw_gbps"] =
+      folly::UserMetric(bandwidthGBps, folly::UserMetric::Type::METRIC);
+  counters["batch"] = folly::UserMetric(batch, folly::UserMetric::Type::METRIC);
+  counters["N"] = folly::UserMetric(numPeers, folly::UserMetric::Type::METRIC);
+  counters["num_dcis"] = folly::UserMetric(1, folly::UserMetric::Type::METRIC);
+  counters["num_receiver_nics"] =
+      folly::UserMetric(K, folly::UserMetric::Type::METRIC);
+  counters["num_ahs"] = folly::UserMetric(K, folly::UserMetric::Type::METRIC);
+  recordRawResult(
+      benchName,
+      static_cast<int>(numPeers),
+      avgLatencyUs,
+      avgPostUs,
+      avgPollUs,
+      bandwidthGBps,
+      batch,
+      msgSize,
+      1,
+      K,
+      K);
+}
+
+// Wrapper: peer count sweep (fixed total input, msg size = 128MB / N)
+static void
+dcScalability(uint32_t iters, size_t numPeers, folly::UserCounters& counters) {
+  dcMultiDciCore(
+      iters,
+      numPeers,
+      kTotalInputSize / numPeers,
+      1,
+      counters,
+      "dcScalability");
+}
+
+// Wrapper: peer count sweep with multi-NIC receivers (round-robin ordering)
+static void dcScalabilityMultiNicRoundRobin(
+    uint32_t iters,
+    size_t numPeers,
+    folly::UserCounters& counters) {
+  dcScalabilityCore(
+      iters,
+      numPeers,
+      kTotalInputSize / numPeers,
+      counters,
+      "dcMultiNicRoundRobin",
+      /*multiNic=*/true);
+}
+
+// Wrapper: peer count sweep with multi-NIC receivers (sorted by destination)
+static void dcScalabilityMultiNicSorted(
+    uint32_t iters,
+    size_t numPeers,
+    folly::UserCounters& counters) {
+  dcScalabilityCore(
+      iters,
+      numPeers,
+      kTotalInputSize / numPeers,
+      counters,
+      "dcMultiNicSorted",
+      /*multiNic=*/true,
+      /*sorted=*/true);
+}
+
+// Wrapper: message size sweep (fixed N=2048, varying per-peer msg size)
+static void
+dcMsgSweep(uint32_t iters, size_t msgSize, folly::UserCounters& counters) {
+  dcMultiDciCore(iters, kMsgSweepNumPeers, msgSize, 1, counters, "dcMsgSweep");
+}
+
+// ---------------------------------------------------------------------------
+// DC Multi-DCI Scalability Benchmark
+//
+// Same as dcScalability but with multiple DCIs and DCTs to test whether
+// NIC-level QP parallelism recovers performance.
+// ---------------------------------------------------------------------------
+static void dcMultiDciCore(
+    uint32_t iters,
+    size_t numPeers,
+    size_t msgSize,
+    int numDcis,
+    folly::UserCounters& counters,
+    const char* benchName) {
+  if (!g_rdmaAvailability.checkDcAvailable()) {
+    setSkipped(counters);
+    return;
+  }
+
+  int numReceivers = static_cast<int>(numPeers) - 1;
+  if (numReceivers < 1) {
+    setError(counters);
+    return;
+  }
+
+  // Cap DCIs at numReceivers (can't have more DCIs than targets)
+  numDcis = std::min(numDcis, numReceivers);
+
+  // Setup shared resources on two devices
+  RdmaResources sender, receiver;
+  if (!initResources(
+          sender, g_rdmaAvailability.dcCapableDevices()[0], counters) ||
+      !initResources(
+          receiver, g_rdmaAvailability.dcCapableDevices()[1], counters)) {
+    return;
+  }
+
+  // Create SRQ on receiver side (shared by all DCTs)
+  auto srqResult = createSRQ(*receiver.pd, 1024);
+  if (!srqResult) {
+    setError(counters);
+    return;
+  }
+  auto srq = std::make_unique<ibverbx::IbvSrq>(std::move(*srqResult));
+
+  auto accessFlags = static_cast<ibverbx::ibv_access_flags>(
+      ibverbx::IBV_ACCESS_LOCAL_WRITE | ibverbx::IBV_ACCESS_REMOTE_WRITE |
+      ibverbx::IBV_ACCESS_REMOTE_READ);
+
+  // Create numDcis DCIs on sender side
+  struct DciState {
+    std::unique_ptr<ibverbx::IbvQp> qp;
+    ibverbx::ibv_qp_ex* exQp = nullptr;
+    mlx5dv_qp_ex* dvQp = nullptr;
+  };
+  std::vector<DciState> dcis(numDcis);
+  for (int d = 0; d < numDcis; ++d) {
+    auto dciResult = createDCILargeSq(*sender.pd, *sender.cq, kDciSqDepth);
+    if (!dciResult) {
+      setError(counters);
+      return;
+    }
+    dcis[d].qp = std::make_unique<ibverbx::IbvQp>(std::move(*dciResult));
+    dcis[d].exQp =
+        ibverbx::ibvSymbols.ibv_internal_qp_to_qp_ex(dcis[d].qp->qp());
+    dcis[d].dvQp =
+        ibverbx::ibvSymbols.mlx5dv_internal_qp_ex_from_ibv_qp_ex(dcis[d].exQp);
+    if (!dcis[d].exQp || !dcis[d].dvQp) {
+      setError(counters);
+      return;
+    }
+    auto dciTrans = transitionDCIToRts(*dcis[d].qp, kPortNum, kDefaultMtu);
+    if (!dciTrans) {
+      setError(counters);
+      return;
+    }
+  }
+
+  // Create numDcis DCTs on receiver side (sharing SRQ)
+  std::vector<std::unique_ptr<ibverbx::IbvQp>> dcts;
+  dcts.reserve(numDcis);
+  for (int d = 0; d < numDcis; ++d) {
+    auto dctResult = createDCT(*receiver.pd, *receiver.cq, *srq);
+    if (!dctResult) {
+      setError(counters);
+      return;
+    }
+    dcts.push_back(std::make_unique<ibverbx::IbvQp>(std::move(*dctResult)));
+    auto dctTrans = transitionDCTToRtr(*dcts.back(), kPortNum, kDefaultMtu);
+    if (!dctTrans) {
+      setError(counters);
+      return;
+    }
+  }
+
+  // Allocate sender buffer and MR (shared across all DCIs)
+  std::vector<uint8_t> senderBuf(msgSize, 0xAA);
+  auto senderMrResult =
+      sender.pd->regMr(senderBuf.data(), senderBuf.size(), accessFlags);
+  if (!senderMrResult) {
+    setError(counters);
+    return;
+  }
+  auto senderMr = std::make_unique<ibverbx::IbvMr>(std::move(*senderMrResult));
+
+  ibverbx::ibv_sge sge{};
+  sge.addr = reinterpret_cast<uint64_t>(senderBuf.data());
+  sge.length = static_cast<uint32_t>(msgSize);
+  sge.lkey = senderMr->mr()->lkey;
+
+  // Create N-1 receiver buffers as one contiguous allocation with single MR
+  // (matches all-to-all setup for fair comparison)
+  std::vector<uint8_t> recvBuf(numReceivers * msgSize, 0x00);
+  auto recvMrResult =
+      receiver.pd->regMr(recvBuf.data(), recvBuf.size(), accessFlags);
+  if (!recvMrResult) {
+    setError(counters);
+    return;
+  }
+  auto recvMr = std::make_unique<ibverbx::IbvMr>(std::move(*recvMrResult));
+
+  // Single AH (all receivers are on the same remote device)
+  auto ahCard = makeDcBusinessCard(dcts[0]->qp()->qp_num, receiver.gid);
+  auto ahResult = createAddressHandle(*sender.pd, ahCard);
+  if (!ahResult) {
+    setError(counters);
+    return;
+  }
+  auto ah = std::make_unique<ibverbx::IbvAh>(std::move(*ahResult));
+
+  // Build per-receiver business cards (round-robin DCTs, same rkey, different
+  // offsets)
+  std::vector<DcBusinessCard> recvCards;
+  recvCards.reserve(numReceivers);
+  for (int i = 0; i < numReceivers; ++i) {
+    recvCards.push_back(makeDcBusinessCard(
+        dcts[i % numDcis]->qp()->qp_num,
+        receiver.gid,
+        reinterpret_cast<uint64_t>(recvBuf.data()) +
+            static_cast<uint64_t>(i) * msgSize,
+        recvMr->mr()->rkey,
+        i));
+  }
+
+  // Batch size: match all-to-all formula (numDcis * SQ depth, capped by CQ)
+  int batch = std::min(numDcis * kDciSqDepth, kSharedCqDepth);
+
+  // Warmup
+  for (int w = 0; w < kWarmupIters; ++w) {
+    int rem = numReceivers;
+    int idx = 0;
+    while (rem > 0) {
+      int b = std::min(rem, batch);
+      for (int j = 0; j < b; ++j) {
+        int d = idx % numDcis;
+        if (postDcRdmaWrite(
+                dcis[d].exQp, dcis[d].dvQp, *ah, recvCards[idx], sge, idx) !=
+            0) {
+          setError(counters);
+          return;
+        }
+        idx++;
+      }
+      if (!pollCqBusySpin(sender.cq->cq(), b)) {
+        setError(counters);
+        return;
+      }
+      rem -= b;
+    }
+  }
+
+  // Timed iterations
+  auto start = std::chrono::high_resolution_clock::now();
+  std::chrono::nanoseconds totalPostNs{0};
+  std::chrono::nanoseconds totalPollNs{0};
+
+  for (uint32_t iter = 0; iter < iters; ++iter) {
+    int remaining = numReceivers;
+    int idx = 0;
+    while (remaining > 0) {
+      int thisBatch = std::min(remaining, batch);
+
+      auto postStart = std::chrono::high_resolution_clock::now();
+      for (int j = 0; j < thisBatch; ++j) {
+        int d = idx % numDcis;
+        if (postDcRdmaWrite(
+                dcis[d].exQp, dcis[d].dvQp, *ah, recvCards[idx], sge, idx) !=
+            0) {
+          setError(counters);
+          return;
+        }
+        idx++;
+      }
+      auto postEnd = std::chrono::high_resolution_clock::now();
+      totalPostNs += (postEnd - postStart);
+
+      auto pollStart = std::chrono::high_resolution_clock::now();
+      if (!pollCqBusySpin(sender.cq->cq(), thisBatch)) {
+        setError(counters);
+        return;
+      }
+      auto pollEnd = std::chrono::high_resolution_clock::now();
+      totalPollNs += (pollEnd - pollStart);
+
+      remaining -= thisBatch;
+    }
+  }
+
+  auto end = std::chrono::high_resolution_clock::now();
+  double elapsedUs =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(end - start)
+          .count() /
+      1000.0;
+
+  double avgLatencyUs = elapsedUs / iters;
+  double avgPostUs = totalPostNs.count() / 1000.0 / iters;
+  double avgPollUs = totalPollNs.count() / 1000.0 / iters;
+  double bandwidthGBps =
+      (msgSize * numReceivers * iters / 1e9) / (elapsedUs / 1e6);
+
+  counters["latency_us"] =
+      folly::UserMetric(avgLatencyUs, folly::UserMetric::Type::METRIC);
+  counters["post_us"] =
+      folly::UserMetric(avgPostUs, folly::UserMetric::Type::METRIC);
+  counters["poll_us"] =
+      folly::UserMetric(avgPollUs, folly::UserMetric::Type::METRIC);
+  counters["bw_gbps"] =
+      folly::UserMetric(bandwidthGBps, folly::UserMetric::Type::METRIC);
+  counters["batch"] = folly::UserMetric(batch, folly::UserMetric::Type::METRIC);
+  counters["N"] = folly::UserMetric(numPeers, folly::UserMetric::Type::METRIC);
+  counters["num_dcis"] =
+      folly::UserMetric(numDcis, folly::UserMetric::Type::METRIC);
+  counters["num_receiver_nics"] =
+      folly::UserMetric(1, folly::UserMetric::Type::METRIC);
+  counters["num_ahs"] = folly::UserMetric(1, folly::UserMetric::Type::METRIC);
+
+  recordRawResult(
+      benchName,
+      static_cast<int>(numPeers),
+      avgLatencyUs,
+      avgPostUs,
+      avgPollUs,
+      bandwidthGBps,
+      batch,
+      msgSize,
+      numDcis,
+      1,
+      1);
+}
+
+// Wrappers: peer count sweep with specific DCI counts
+static void
+dcMultiDci2(uint32_t iters, size_t numPeers, folly::UserCounters& counters) {
+  dcMultiDciCore(
+      iters, numPeers, kTotalInputSize / numPeers, 2, counters, "dcMultiDci_2");
+}
+static void
+dcMultiDci4(uint32_t iters, size_t numPeers, folly::UserCounters& counters) {
+  dcMultiDciCore(
+      iters, numPeers, kTotalInputSize / numPeers, 4, counters, "dcMultiDci_4");
+}
+static void
+dcMultiDci8(uint32_t iters, size_t numPeers, folly::UserCounters& counters) {
+  dcMultiDciCore(
+      iters, numPeers, kTotalInputSize / numPeers, 8, counters, "dcMultiDci_8");
+}
+static void
+dcMultiDci16(uint32_t iters, size_t numPeers, folly::UserCounters& counters) {
+  dcMultiDciCore(
+      iters,
+      numPeers,
+      kTotalInputSize / numPeers,
+      16,
+      counters,
+      "dcMultiDci_16");
+}
+
+// Wrapper: message size sweep with 4 DCIs at N=2048
+static void dcMultiDci4MsgSweep(
+    uint32_t iters,
+    size_t msgSize,
+    folly::UserCounters& counters) {
+  dcMultiDciCore(
+      iters, kMsgSweepNumPeers, msgSize, 4, counters, "dcMultiDci4MsgSweep");
+}
+
+// ---------------------------------------------------------------------------
+// RC Scalability Benchmark
+// ---------------------------------------------------------------------------
+static void rcScalabilityCore(
+    uint32_t iters,
+    size_t numPeers,
+    size_t msgSize,
+    folly::UserCounters& counters,
+    const char* benchName) {
+  if (!g_rdmaAvailability.checkDcAvailable() &&
+      !g_rdmaAvailability.checkRdmaAvailable()) {
+    setSkipped(counters);
+    return;
+  }
+
+  int numConnections = static_cast<int>(numPeers) - 1;
+  if (numConnections < 1) {
+    setError(counters);
+    return;
+  }
+
+  // Use same devices as DC for fair comparison
+  int senderDevIdx = g_rdmaAvailability.dcCapableDevices().size() >= 2
+      ? g_rdmaAvailability.dcCapableDevices()[0]
+      : 0;
+  int receiverDevIdx = g_rdmaAvailability.dcCapableDevices().size() >= 2
+      ? g_rdmaAvailability.dcCapableDevices()[1]
+      : 1;
+
+  // Setup shared resources on two devices
+  RdmaResources sender, receiver;
+  if (!initResources(sender, senderDevIdx, counters) ||
+      !initResources(receiver, receiverDevIdx, counters)) {
+    return;
+  }
+
+  auto accessFlags = static_cast<ibverbx::ibv_access_flags>(
+      ibverbx::IBV_ACCESS_LOCAL_WRITE | ibverbx::IBV_ACCESS_REMOTE_WRITE |
+      ibverbx::IBV_ACCESS_REMOTE_READ);
+
+  // Allocate sender buffer and MR
+  std::vector<uint8_t> senderBuf(msgSize, 0xAA);
+  auto senderMrResult =
+      sender.pd->regMr(senderBuf.data(), senderBuf.size(), accessFlags);
+  if (!senderMrResult) {
+    setError(counters);
+    return;
+  }
+  auto senderMr = std::make_unique<ibverbx::IbvMr>(std::move(*senderMrResult));
+
+  ibverbx::ibv_sge sge{};
+  sge.addr = reinterpret_cast<uint64_t>(senderBuf.data());
+  sge.length = static_cast<uint32_t>(msgSize);
+  sge.lkey = senderMr->mr()->lkey;
+
+  // Create N-1 receiver buffers as one contiguous allocation with single MR
+  // (matches all-to-all setup for fair comparison)
+  std::vector<uint8_t> recvBuf(numConnections * msgSize, 0x00);
+  auto recvMrResult =
+      receiver.pd->regMr(recvBuf.data(), recvBuf.size(), accessFlags);
+  if (!recvMrResult) {
+    setError(counters);
+    return;
+  }
+  auto recvMr = std::make_unique<ibverbx::IbvMr>(std::move(*recvMrResult));
+
+  // Create N-1 QP pairs on shared resources
+  std::vector<std::unique_ptr<ibverbx::IbvQp>> senderQps;
+  std::vector<std::unique_ptr<ibverbx::IbvQp>> receiverQps;
+  std::vector<RcBusinessCard> rcCards;
+  senderQps.reserve(numConnections);
+  receiverQps.reserve(numConnections);
+  rcCards.reserve(numConnections);
+
+  for (int i = 0; i < numConnections; ++i) {
+    // Sender QP on shared PD/CQ
+    ibverbx::ibv_qp_init_attr sInitAttr{};
+    sInitAttr.send_cq = sender.cq->cq();
+    sInitAttr.recv_cq = sender.cq->cq();
+    sInitAttr.qp_type = ibverbx::IBV_QPT_RC;
+    sInitAttr.cap.max_send_wr = kRcQpSqDepth;
+    sInitAttr.cap.max_recv_wr = 1024;
+    sInitAttr.cap.max_send_sge = 1;
+    sInitAttr.cap.max_recv_sge = 1;
+    auto sqpResult = sender.pd->createQp(&sInitAttr);
+    if (!sqpResult) {
+      setError(counters);
+      return;
+    }
+    senderQps.push_back(
+        std::make_unique<ibverbx::IbvQp>(std::move(*sqpResult)));
+
+    // Receiver QP on shared PD/CQ
+    ibverbx::ibv_qp_init_attr rInitAttr{};
+    rInitAttr.send_cq = receiver.cq->cq();
+    rInitAttr.recv_cq = receiver.cq->cq();
+    rInitAttr.qp_type = ibverbx::IBV_QPT_RC;
+    rInitAttr.cap.max_send_wr = kRcQpSqDepth;
+    rInitAttr.cap.max_recv_wr = 1024;
+    rInitAttr.cap.max_send_sge = 1;
+    rInitAttr.cap.max_recv_sge = 1;
+    auto rqpResult = receiver.pd->createQp(&rInitAttr);
+    if (!rqpResult) {
+      setError(counters);
+      return;
+    }
+    receiverQps.push_back(
+        std::make_unique<ibverbx::IbvQp>(std::move(*rqpResult)));
+
+    // Connect the pair
+    if (!connectRcQpPair(
+            *senderQps.back(), *receiverQps.back(), sender.gid, receiver.gid)) {
+      setError(counters);
+      return;
+    }
+
+    // Build business card for this receiver (same rkey, different offsets)
+    RcBusinessCard card{};
+    card.qpNum = receiverQps.back()->qp()->qp_num;
+    card.port = kPortNum;
+    card.subnetPrefix = receiver.gid.global.subnet_prefix;
+    card.interfaceId = receiver.gid.global.interface_id;
+    card.remoteAddr = reinterpret_cast<uint64_t>(recvBuf.data()) +
+        static_cast<uint64_t>(i) * msgSize;
+    card.rkey = recvMr->mr()->rkey;
+    card.psn = 0;
+    rcCards.push_back(card);
+  }
+
+  // Batch size: match all-to-all formula (full CQ depth)
+  int batch = kSharedCqDepth;
+
+  // Warmup
+  for (int w = 0; w < kWarmupIters; ++w) {
+    int rem = numConnections;
+    int idx = 0;
+    while (rem > 0) {
+      int b = std::min(rem, batch);
+      for (int j = 0; j < b; ++j) {
+        if (postRcRdmaWrite(*senderQps[idx], rcCards[idx], sge, idx) != 0) {
+          setError(counters);
+          return;
+        }
+        idx++;
+      }
+      if (!pollCqBusySpin(sender.cq->cq(), b)) {
+        setError(counters);
+        return;
+      }
+      rem -= b;
+    }
+  }
+
+  // Timed iterations
+  auto start = std::chrono::high_resolution_clock::now();
+  std::chrono::nanoseconds totalPostNs{0};
+  std::chrono::nanoseconds totalPollNs{0};
+
+  for (uint32_t iter = 0; iter < iters; ++iter) {
+    int remaining = numConnections;
+    int idx = 0;
+    while (remaining > 0) {
+      int thisBatch = std::min(remaining, batch);
+
+      auto postStart = std::chrono::high_resolution_clock::now();
+      for (int j = 0; j < thisBatch; ++j) {
+        if (postRcRdmaWrite(*senderQps[idx], rcCards[idx], sge, idx) != 0) {
+          setError(counters);
+          return;
+        }
+        idx++;
+      }
+      auto postEnd = std::chrono::high_resolution_clock::now();
+      totalPostNs += (postEnd - postStart);
+
+      auto pollStart = std::chrono::high_resolution_clock::now();
+      if (!pollCqBusySpin(sender.cq->cq(), thisBatch)) {
+        setError(counters);
+        return;
+      }
+      auto pollEnd = std::chrono::high_resolution_clock::now();
+      totalPollNs += (pollEnd - pollStart);
+
+      remaining -= thisBatch;
+    }
+  }
+
+  auto end = std::chrono::high_resolution_clock::now();
+  double elapsedUs =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(end - start)
+          .count() /
+      1000.0;
+
+  double avgLatencyUs = elapsedUs / iters;
+  double avgPostUs = totalPostNs.count() / 1000.0 / iters;
+  double avgPollUs = totalPollNs.count() / 1000.0 / iters;
+  double bandwidthGBps =
+      (msgSize * numConnections * iters / 1e9) / (elapsedUs / 1e6);
+
+  counters["latency_us"] =
+      folly::UserMetric(avgLatencyUs, folly::UserMetric::Type::METRIC);
+  counters["post_us"] =
+      folly::UserMetric(avgPostUs, folly::UserMetric::Type::METRIC);
+  counters["poll_us"] =
+      folly::UserMetric(avgPollUs, folly::UserMetric::Type::METRIC);
+  counters["bw_gbps"] =
+      folly::UserMetric(bandwidthGBps, folly::UserMetric::Type::METRIC);
+  counters["batch"] = folly::UserMetric(batch, folly::UserMetric::Type::METRIC);
+  counters["N"] = folly::UserMetric(numPeers, folly::UserMetric::Type::METRIC);
+  counters["num_dcis"] = folly::UserMetric(0, folly::UserMetric::Type::METRIC);
+  counters["num_receiver_nics"] =
+      folly::UserMetric(1, folly::UserMetric::Type::METRIC);
+  counters["num_ahs"] = folly::UserMetric(0, folly::UserMetric::Type::METRIC);
+  recordRawResult(
+      benchName,
+      static_cast<int>(numPeers),
+      avgLatencyUs,
+      avgPostUs,
+      avgPollUs,
+      bandwidthGBps,
+      batch,
+      msgSize,
+      0,
+      1,
+      0);
+}
+
+// Wrapper: peer count sweep (fixed total input, msg size = 128MB / N)
+static void
+rcScalability(uint32_t iters, size_t numPeers, folly::UserCounters& counters) {
+  rcScalabilityCore(
+      iters, numPeers, kTotalInputSize / numPeers, counters, "rcScalability");
+}
+
+// Wrapper: message size sweep (fixed N=2048, varying per-peer msg size)
+static void
+rcMsgSweep(uint32_t iters, size_t msgSize, folly::UserCounters& counters) {
+  rcScalabilityCore(iters, kMsgSweepNumPeers, msgSize, counters, "rcMsgSweep");
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Benchmark Registration
+// ---------------------------------------------------------------------------
+
+#define REGISTER_SCALABILITY_BENCH(func, name, numPeers) \
+  BENCHMARK_MULTI_PARAM_COUNTERS(func, name, numPeers)
+
+// DC Scalability: varying peer count
+REGISTER_SCALABILITY_BENCH(dcScalability, N2, 2);
+REGISTER_SCALABILITY_BENCH(dcScalability, N4, 4);
+REGISTER_SCALABILITY_BENCH(dcScalability, N8, 8);
+REGISTER_SCALABILITY_BENCH(dcScalability, N16, 16);
+REGISTER_SCALABILITY_BENCH(dcScalability, N32, 32);
+REGISTER_SCALABILITY_BENCH(dcScalability, N64, 64);
+REGISTER_SCALABILITY_BENCH(dcScalability, N128, 128);
+REGISTER_SCALABILITY_BENCH(dcScalability, N256, 256);
+REGISTER_SCALABILITY_BENCH(dcScalability, N512, 512);
+REGISTER_SCALABILITY_BENCH(dcScalability, N1024, 1024);
+REGISTER_SCALABILITY_BENCH(dcScalability, N2048, 2048);
+
+BENCHMARK_DRAW_LINE();
+
+// DC Multi-DCI (2 DCIs): test if even 2 DCIs helps
+REGISTER_SCALABILITY_BENCH(dcMultiDci2, N2, 2);
+REGISTER_SCALABILITY_BENCH(dcMultiDci2, N4, 4);
+REGISTER_SCALABILITY_BENCH(dcMultiDci2, N8, 8);
+REGISTER_SCALABILITY_BENCH(dcMultiDci2, N16, 16);
+REGISTER_SCALABILITY_BENCH(dcMultiDci2, N32, 32);
+REGISTER_SCALABILITY_BENCH(dcMultiDci2, N64, 64);
+REGISTER_SCALABILITY_BENCH(dcMultiDci2, N128, 128);
+REGISTER_SCALABILITY_BENCH(dcMultiDci2, N256, 256);
+REGISTER_SCALABILITY_BENCH(dcMultiDci2, N512, 512);
+REGISTER_SCALABILITY_BENCH(dcMultiDci2, N1024, 1024);
+REGISTER_SCALABILITY_BENCH(dcMultiDci2, N2048, 2048);
+
+BENCHMARK_DRAW_LINE();
+
+// DC Multi-DCI (4 DCIs): test intermediate parallelism
+REGISTER_SCALABILITY_BENCH(dcMultiDci4, N2, 2);
+REGISTER_SCALABILITY_BENCH(dcMultiDci4, N4, 4);
+REGISTER_SCALABILITY_BENCH(dcMultiDci4, N8, 8);
+REGISTER_SCALABILITY_BENCH(dcMultiDci4, N16, 16);
+REGISTER_SCALABILITY_BENCH(dcMultiDci4, N32, 32);
+REGISTER_SCALABILITY_BENCH(dcMultiDci4, N64, 64);
+REGISTER_SCALABILITY_BENCH(dcMultiDci4, N128, 128);
+REGISTER_SCALABILITY_BENCH(dcMultiDci4, N256, 256);
+REGISTER_SCALABILITY_BENCH(dcMultiDci4, N512, 512);
+REGISTER_SCALABILITY_BENCH(dcMultiDci4, N1024, 1024);
+REGISTER_SCALABILITY_BENCH(dcMultiDci4, N2048, 2048);
+
+BENCHMARK_DRAW_LINE();
+
+// DC Multi-DCI (8 DCIs)
+REGISTER_SCALABILITY_BENCH(dcMultiDci8, N2, 2);
+REGISTER_SCALABILITY_BENCH(dcMultiDci8, N4, 4);
+REGISTER_SCALABILITY_BENCH(dcMultiDci8, N8, 8);
+REGISTER_SCALABILITY_BENCH(dcMultiDci8, N16, 16);
+REGISTER_SCALABILITY_BENCH(dcMultiDci8, N32, 32);
+REGISTER_SCALABILITY_BENCH(dcMultiDci8, N64, 64);
+REGISTER_SCALABILITY_BENCH(dcMultiDci8, N128, 128);
+REGISTER_SCALABILITY_BENCH(dcMultiDci8, N256, 256);
+REGISTER_SCALABILITY_BENCH(dcMultiDci8, N512, 512);
+REGISTER_SCALABILITY_BENCH(dcMultiDci8, N1024, 1024);
+REGISTER_SCALABILITY_BENCH(dcMultiDci8, N2048, 2048);
+
+BENCHMARK_DRAW_LINE();
+
+// DC Multi-DCI (16 DCIs)
+REGISTER_SCALABILITY_BENCH(dcMultiDci16, N2, 2);
+REGISTER_SCALABILITY_BENCH(dcMultiDci16, N4, 4);
+REGISTER_SCALABILITY_BENCH(dcMultiDci16, N8, 8);
+REGISTER_SCALABILITY_BENCH(dcMultiDci16, N16, 16);
+REGISTER_SCALABILITY_BENCH(dcMultiDci16, N32, 32);
+REGISTER_SCALABILITY_BENCH(dcMultiDci16, N64, 64);
+REGISTER_SCALABILITY_BENCH(dcMultiDci16, N128, 128);
+REGISTER_SCALABILITY_BENCH(dcMultiDci16, N256, 256);
+REGISTER_SCALABILITY_BENCH(dcMultiDci16, N512, 512);
+REGISTER_SCALABILITY_BENCH(dcMultiDci16, N1024, 1024);
+REGISTER_SCALABILITY_BENCH(dcMultiDci16, N2048, 2048);
+
+BENCHMARK_DRAW_LINE();
+
+// RC Scalability: same peer counts
+REGISTER_SCALABILITY_BENCH(rcScalability, N2, 2);
+REGISTER_SCALABILITY_BENCH(rcScalability, N4, 4);
+REGISTER_SCALABILITY_BENCH(rcScalability, N8, 8);
+REGISTER_SCALABILITY_BENCH(rcScalability, N16, 16);
+REGISTER_SCALABILITY_BENCH(rcScalability, N32, 32);
+REGISTER_SCALABILITY_BENCH(rcScalability, N64, 64);
+REGISTER_SCALABILITY_BENCH(rcScalability, N128, 128);
+REGISTER_SCALABILITY_BENCH(rcScalability, N256, 256);
+REGISTER_SCALABILITY_BENCH(rcScalability, N512, 512);
+REGISTER_SCALABILITY_BENCH(rcScalability, N1024, 1024);
+REGISTER_SCALABILITY_BENCH(rcScalability, N2048, 2048);
+
+BENCHMARK_DRAW_LINE();
+
+// ---------------------------------------------------------------------------
+// Message Size Sweep at N=2048
+// ---------------------------------------------------------------------------
+
+// DC (1 DCI) message size sweep
+REGISTER_SCALABILITY_BENCH(dcMsgSweep, 64B, 64);
+REGISTER_SCALABILITY_BENCH(dcMsgSweep, 256B, 256);
+REGISTER_SCALABILITY_BENCH(dcMsgSweep, 1KB, 1024);
+REGISTER_SCALABILITY_BENCH(dcMsgSweep, 4KB, 4096);
+REGISTER_SCALABILITY_BENCH(dcMsgSweep, 16KB, 16384);
+REGISTER_SCALABILITY_BENCH(dcMsgSweep, 64KB, 65536);
+REGISTER_SCALABILITY_BENCH(dcMsgSweep, 256KB, 262144);
+REGISTER_SCALABILITY_BENCH(dcMsgSweep, 1MB, 1048576);
+
+BENCHMARK_DRAW_LINE();
+
+// DC Multi-DCI (4 DCIs) message size sweep
+REGISTER_SCALABILITY_BENCH(dcMultiDci4MsgSweep, 64B, 64);
+REGISTER_SCALABILITY_BENCH(dcMultiDci4MsgSweep, 256B, 256);
+REGISTER_SCALABILITY_BENCH(dcMultiDci4MsgSweep, 1KB, 1024);
+REGISTER_SCALABILITY_BENCH(dcMultiDci4MsgSweep, 4KB, 4096);
+REGISTER_SCALABILITY_BENCH(dcMultiDci4MsgSweep, 16KB, 16384);
+REGISTER_SCALABILITY_BENCH(dcMultiDci4MsgSweep, 64KB, 65536);
+REGISTER_SCALABILITY_BENCH(dcMultiDci4MsgSweep, 256KB, 262144);
+REGISTER_SCALABILITY_BENCH(dcMultiDci4MsgSweep, 1MB, 1048576);
+
+BENCHMARK_DRAW_LINE();
+
+// RC message size sweep
+REGISTER_SCALABILITY_BENCH(rcMsgSweep, 64B, 64);
+REGISTER_SCALABILITY_BENCH(rcMsgSweep, 256B, 256);
+REGISTER_SCALABILITY_BENCH(rcMsgSweep, 1KB, 1024);
+REGISTER_SCALABILITY_BENCH(rcMsgSweep, 4KB, 4096);
+REGISTER_SCALABILITY_BENCH(rcMsgSweep, 16KB, 16384);
+REGISTER_SCALABILITY_BENCH(rcMsgSweep, 64KB, 65536);
+REGISTER_SCALABILITY_BENCH(rcMsgSweep, 256KB, 262144);
+REGISTER_SCALABILITY_BENCH(rcMsgSweep, 1MB, 1048576);
+
+BENCHMARK_DRAW_LINE();
+
+// DC Multi-NIC: receivers spread across all available NICs (round-robin writes)
+REGISTER_SCALABILITY_BENCH(dcScalabilityMultiNicRoundRobin, N2, 2);
+REGISTER_SCALABILITY_BENCH(dcScalabilityMultiNicRoundRobin, N4, 4);
+REGISTER_SCALABILITY_BENCH(dcScalabilityMultiNicRoundRobin, N8, 8);
+REGISTER_SCALABILITY_BENCH(dcScalabilityMultiNicRoundRobin, N16, 16);
+REGISTER_SCALABILITY_BENCH(dcScalabilityMultiNicRoundRobin, N32, 32);
+REGISTER_SCALABILITY_BENCH(dcScalabilityMultiNicRoundRobin, N64, 64);
+REGISTER_SCALABILITY_BENCH(dcScalabilityMultiNicRoundRobin, N128, 128);
+REGISTER_SCALABILITY_BENCH(dcScalabilityMultiNicRoundRobin, N256, 256);
+REGISTER_SCALABILITY_BENCH(dcScalabilityMultiNicRoundRobin, N512, 512);
+REGISTER_SCALABILITY_BENCH(dcScalabilityMultiNicRoundRobin, N1024, 1024);
+REGISTER_SCALABILITY_BENCH(dcScalabilityMultiNicRoundRobin, N2048, 2048);
+
+BENCHMARK_DRAW_LINE();
+
+// DC Multi-NIC Sorted: writes grouped by destination NIC
+REGISTER_SCALABILITY_BENCH(dcScalabilityMultiNicSorted, N2, 2);
+REGISTER_SCALABILITY_BENCH(dcScalabilityMultiNicSorted, N4, 4);
+REGISTER_SCALABILITY_BENCH(dcScalabilityMultiNicSorted, N8, 8);
+REGISTER_SCALABILITY_BENCH(dcScalabilityMultiNicSorted, N16, 16);
+REGISTER_SCALABILITY_BENCH(dcScalabilityMultiNicSorted, N32, 32);
+REGISTER_SCALABILITY_BENCH(dcScalabilityMultiNicSorted, N64, 64);
+REGISTER_SCALABILITY_BENCH(dcScalabilityMultiNicSorted, N128, 128);
+REGISTER_SCALABILITY_BENCH(dcScalabilityMultiNicSorted, N256, 256);
+REGISTER_SCALABILITY_BENCH(dcScalabilityMultiNicSorted, N512, 512);
+REGISTER_SCALABILITY_BENCH(dcScalabilityMultiNicSorted, N1024, 1024);
+REGISTER_SCALABILITY_BENCH(dcScalabilityMultiNicSorted, N2048, 2048);
+
+BENCHMARK_DRAW_LINE();
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+
+  XLOG(INFO) << "DC vs RC RDMA Scalability Benchmark";
+  XLOG(INFO) << "====================================";
+  XLOG(INFO) << "Total input size: " << kTotalInputSize << " bytes (128 MB)";
+  XLOG(INFO) << "Shared CQ depth: " << kSharedCqDepth;
+  XLOG(INFO) << "DCI SQ depth: " << kDciSqDepth;
+  XLOG(INFO) << "RC QP SQ depth: " << kRcQpSqDepth;
+
+  if (!g_rdmaAvailability.checkRdmaAvailable()) {
+    XLOG(ERR) << "RDMA not available - benchmarks will be skipped";
+  } else {
+    XLOG(INFO) << "RDMA devices available";
+  }
+
+  // Suppress folly benchmark table when --raw_only is set
+  int savedStdout = -1;
+  if (FLAGS_raw_only) {
+    savedStdout = dup(STDOUT_FILENO);
+    int devNull = open("/dev/null", O_WRONLY);
+    dup2(devNull, STDOUT_FILENO);
+    close(devNull);
+  }
+
+  folly::runBenchmarks();
+
+  if (FLAGS_raw_only && savedStdout >= 0) {
+    dup2(savedStdout, STDOUT_FILENO);
+    close(savedStdout);
+  }
+
+  printAllRawResults();
+
+  return 0;
+}

--- a/comms/ctran/ibverbx/benchmarks/IbverbxDcP2PBench.cc
+++ b/comms/ctran/ibverbx/benchmarks/IbverbxDcP2PBench.cc
@@ -1,0 +1,755 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * DC vs RC RDMA Single-Pair Benchmark
+ *
+ * This benchmark compares Dynamic Connection (DC) vs Reliable Connection (RC)
+ * RDMA performance for a single sender-receiver pair.
+ *
+ * Experiments:
+ * 1. Single-Pair Steady-State: DC vs RC latency/bandwidth for various sizes
+ * 2. QP Initialization Overhead: Time to create and transition QPs
+ *
+ * Methodology:
+ * - Warm-up phase before each benchmark
+ * - 1000 runs per message size
+ * - Message sizes: 1B to 2GB (32 sizes, powers of 2)
+ */
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include <folly/logging/Init.h>
+#include <folly/logging/xlog.h>
+#include <gflags/gflags.h>
+
+#include "comms/ctran/ibverbx/Ibverbx.h"
+#include "comms/ctran/ibverbx/IbverbxSymbols.h"
+#include "comms/ctran/ibverbx/benchmarks/IbverbxDcBenchUtils.h"
+#include "comms/ctran/ibverbx/tests/dc_utils.h"
+#include "comms/testinfra/BenchUtils.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+
+FOLLY_INIT_LOGGING_CONFIG(
+    ".=WARNING"
+    ";default:async=true,sync_level=WARNING");
+
+DEFINE_bool(raw_only, true, "Print only RAW CSV results, suppress folly table");
+DEFINE_int32(batch_size, 1, "Number of RDMA writes to batch before polling");
+
+using namespace ibverbx;
+
+namespace {
+
+RdmaAvailabilityChecker g_rdmaAvailability;
+
+// Benchmark setup state shared across iterations
+struct DcBenchmarkState {
+  std::unique_ptr<DcEndPoint> sender;
+  std::unique_ptr<DcEndPoint> receiver;
+  std::unique_ptr<IbvAh> ah;
+  std::unique_ptr<IbvMr> senderMr;
+  std::unique_ptr<IbvMr> receiverMr;
+  DcBusinessCard senderCard;
+  DcBusinessCard receiverCard;
+  std::vector<uint8_t> senderBuf;
+  std::vector<uint8_t> receiverBuf;
+  ibverbx::ibv_sge sge{};
+  bool initialized{false};
+
+  bool init(size_t bufferSize) {
+    if (initialized && senderBuf.size() == bufferSize) {
+      return true;
+    }
+
+    // Reset resources in correct order (AH, MRs before endpoints/PDs)
+    ah.reset();
+    senderMr.reset();
+    receiverMr.reset();
+    sender.reset();
+    receiver.reset();
+
+    // Allocate buffers
+    senderBuf.resize(bufferSize);
+    receiverBuf.resize(bufferSize);
+    std::memset(senderBuf.data(), 0xAA, bufferSize);
+    std::memset(receiverBuf.data(), 0x00, bufferSize);
+
+    // Create sender endpoint (use discovered DC-capable device)
+    sender = std::make_unique<DcEndPoint>();
+    auto senderInitResult =
+        sender->init(g_rdmaAvailability.dcCapableDevices()[0]);
+    if (!senderInitResult) {
+      XLOGF(ERR, "Sender init failed: {}", senderInitResult.error().errStr);
+      return false;
+    }
+    auto senderDcResult = sender->initDc();
+    if (!senderDcResult) {
+      XLOGF(ERR, "Sender DC init failed: {}", senderDcResult.error().errStr);
+      return false;
+    }
+
+    // Create receiver endpoint (use discovered DC-capable device)
+    receiver = std::make_unique<DcEndPoint>();
+    auto receiverInitResult =
+        receiver->init(g_rdmaAvailability.dcCapableDevices()[1]);
+    if (!receiverInitResult) {
+      XLOGF(ERR, "Receiver init failed: {}", receiverInitResult.error().errStr);
+      return false;
+    }
+    auto receiverDcResult = receiver->initDc();
+    if (!receiverDcResult) {
+      XLOGF(
+          ERR, "Receiver DC init failed: {}", receiverDcResult.error().errStr);
+      return false;
+    }
+
+    // Register memory
+    auto senderMrResult =
+        sender->registerMr(senderBuf.data(), senderBuf.size());
+    if (!senderMrResult) {
+      XLOGF(ERR, "Sender MR failed: {}", senderMrResult.error().errStr);
+      return false;
+    }
+    senderMr = std::make_unique<IbvMr>(std::move(*senderMrResult));
+
+    auto receiverMrResult =
+        receiver->registerMr(receiverBuf.data(), receiverBuf.size());
+    if (!receiverMrResult) {
+      XLOGF(ERR, "Receiver MR failed: {}", receiverMrResult.error().errStr);
+      return false;
+    }
+    receiverMr = std::make_unique<IbvMr>(std::move(*receiverMrResult));
+
+    // Create business cards
+    senderCard =
+        sender->createBusinessCard(senderBuf.data(), senderMr->mr()->lkey);
+    receiverCard = receiver->createBusinessCard(
+        receiverBuf.data(), receiverMr->mr()->rkey);
+
+    // Create address handle from sender to receiver
+    auto ahResult = sender->createAh(receiverCard);
+    if (!ahResult) {
+      XLOGF(ERR, "AH creation failed: {}", ahResult.error().errStr);
+      return false;
+    }
+    ah = std::make_unique<IbvAh>(std::move(*ahResult));
+
+    // Setup SGE for sends
+    sge.addr = reinterpret_cast<uint64_t>(senderBuf.data());
+    sge.length = static_cast<uint32_t>(bufferSize);
+    sge.lkey = senderMr->mr()->lkey;
+
+    initialized = true;
+    return true;
+  }
+};
+
+struct RcBenchmarkState {
+  std::unique_ptr<RcEndPoint> sender;
+  std::unique_ptr<RcEndPoint> receiver;
+  std::unique_ptr<IbvMr> senderMr;
+  std::unique_ptr<IbvMr> receiverMr;
+  RcBusinessCard senderCard;
+  RcBusinessCard receiverCard;
+  std::vector<uint8_t> senderBuf;
+  std::vector<uint8_t> receiverBuf;
+  ibverbx::ibv_sge sge{};
+  bool initialized{false};
+
+  bool init(size_t bufferSize) {
+    if (initialized && senderBuf.size() == bufferSize) {
+      return true;
+    }
+
+    // Reset resources in correct order (MRs before endpoints/PDs)
+    senderMr.reset();
+    receiverMr.reset();
+    sender.reset();
+    receiver.reset();
+
+    // Allocate buffers
+    senderBuf.resize(bufferSize);
+    receiverBuf.resize(bufferSize);
+    std::memset(senderBuf.data(), 0xAA, bufferSize);
+    std::memset(receiverBuf.data(), 0x00, bufferSize);
+
+    // Create sender endpoint (same device as DC sender, or device 0 if DC
+    // unavailable)
+    int senderDevIdx = g_rdmaAvailability.dcCapableDevices().size() >= 2
+        ? g_rdmaAvailability.dcCapableDevices()[0]
+        : 0;
+    int receiverDevIdx = g_rdmaAvailability.dcCapableDevices().size() >= 2
+        ? g_rdmaAvailability.dcCapableDevices()[1]
+        : 1;
+
+    sender = std::make_unique<RcEndPoint>();
+    auto senderInitResult = sender->init(senderDevIdx);
+    if (!senderInitResult) {
+      XLOGF(ERR, "Sender init failed: {}", senderInitResult.error().errStr);
+      return false;
+    }
+    auto senderRcResult = sender->initRc();
+    if (!senderRcResult) {
+      XLOGF(ERR, "Sender RC init failed: {}", senderRcResult.error().errStr);
+      return false;
+    }
+
+    // Create receiver endpoint (same device as DC receiver, or device 1 if DC
+    // unavailable)
+    receiver = std::make_unique<RcEndPoint>();
+    auto receiverInitResult = receiver->init(receiverDevIdx);
+    if (!receiverInitResult) {
+      XLOGF(ERR, "Receiver init failed: {}", receiverInitResult.error().errStr);
+      return false;
+    }
+    auto receiverRcResult = receiver->initRc();
+    if (!receiverRcResult) {
+      XLOGF(
+          ERR, "Receiver RC init failed: {}", receiverRcResult.error().errStr);
+      return false;
+    }
+
+    // Register memory
+    auto senderMrResult =
+        sender->registerMr(senderBuf.data(), senderBuf.size());
+    if (!senderMrResult) {
+      XLOGF(ERR, "Sender MR failed: {}", senderMrResult.error().errStr);
+      return false;
+    }
+    senderMr = std::make_unique<IbvMr>(std::move(*senderMrResult));
+
+    auto receiverMrResult =
+        receiver->registerMr(receiverBuf.data(), receiverBuf.size());
+    if (!receiverMrResult) {
+      XLOGF(ERR, "Receiver MR failed: {}", receiverMrResult.error().errStr);
+      return false;
+    }
+    receiverMr = std::make_unique<IbvMr>(std::move(*receiverMrResult));
+
+    // Create business cards
+    senderCard =
+        sender->createBusinessCard(senderBuf.data(), senderMr->mr()->lkey);
+    receiverCard = receiver->createBusinessCard(
+        receiverBuf.data(), receiverMr->mr()->rkey);
+
+    // Connect QPs (bidirectional)
+    auto senderConnectResult = sender->connect(receiverCard);
+    if (!senderConnectResult) {
+      XLOGF(
+          ERR, "Sender connect failed: {}", senderConnectResult.error().errStr);
+      return false;
+    }
+
+    auto receiverConnectResult = receiver->connect(senderCard);
+    if (!receiverConnectResult) {
+      XLOGF(
+          ERR,
+          "Receiver connect failed: {}",
+          receiverConnectResult.error().errStr);
+      return false;
+    }
+
+    // Setup SGE for sends
+    sge.addr = reinterpret_cast<uint64_t>(senderBuf.data());
+    sge.length = static_cast<uint32_t>(bufferSize);
+    sge.lkey = senderMr->mr()->lkey;
+
+    initialized = true;
+    return true;
+  }
+};
+thread_local std::unique_ptr<DcBenchmarkState> g_dcState;
+thread_local std::unique_ptr<RcBenchmarkState> g_rcState;
+
+struct RawResult {
+  std::string name;
+  size_t bufferBytes;
+  double latencyUs;
+  double postUs;
+  double pollUs;
+  double bwGbps;
+};
+std::vector<RawResult> g_rawResults;
+std::mutex g_rawResultsMutex;
+
+void recordRawResult(
+    const char* name,
+    size_t bufferBytes,
+    double latencyUs,
+    double postUs,
+    double pollUs,
+    double bwGbps) {
+  std::lock_guard<std::mutex> lock(g_rawResultsMutex);
+  // Overwrite if same name+size already exists (folly runs multiple times)
+  for (auto& r : g_rawResults) {
+    if (r.name == name && r.bufferBytes == bufferBytes) {
+      r = {name, bufferBytes, latencyUs, postUs, pollUs, bwGbps};
+      return;
+    }
+  }
+  g_rawResults.push_back(
+      {name, bufferBytes, latencyUs, postUs, pollUs, bwGbps});
+}
+
+void printAllRawResults() {
+  fprintf(
+      stderr,
+      "RAW,benchmark,buffer_bytes,latency_us,post_us,poll_us,bw_gbps\n");
+  for (const auto& r : g_rawResults) {
+    fprintf(
+        stderr,
+        "RAW,%s,%zu,%.3f,%.3f,%.3f,%.6f\n",
+        r.name.c_str(),
+        r.bufferBytes,
+        r.latencyUs,
+        r.postUs,
+        r.pollUs,
+        r.bwGbps);
+  }
+}
+
+} // namespace
+
+//------------------------------------------------------------------------------
+// DC RDMA Write Benchmark
+//------------------------------------------------------------------------------
+
+static void
+dcRdmaWrite(uint32_t iters, size_t bufferSize, folly::UserCounters& counters) {
+  if (!g_rdmaAvailability.checkDcAvailable()) {
+    counters["skipped"] = folly::UserMetric(1, folly::UserMetric::Type::METRIC);
+    return;
+  }
+
+  // Initialize or reuse state
+  if (!g_dcState) {
+    g_dcState = std::make_unique<DcBenchmarkState>();
+  }
+  if (!g_dcState->init(bufferSize)) {
+    counters["error"] = folly::UserMetric(1, folly::UserMetric::Type::METRIC);
+    return;
+  }
+
+  // Update SGE length for this buffer size
+  g_dcState->sge.length = static_cast<uint32_t>(bufferSize);
+
+  // Warm-up iterations
+  constexpr int kWarmupIters = 10;
+  for (int i = 0; i < kWarmupIters; ++i) {
+    int ret = g_dcState->sender->postRdmaWrite(
+        *g_dcState->ah, g_dcState->receiverCard, g_dcState->sge, i);
+    if (ret != 0) {
+      counters["error"] = folly::UserMetric(1, folly::UserMetric::Type::METRIC);
+      return;
+    }
+    // Poll sender CQ for send completion (no receiver poll with plain write)
+    if (!g_dcState->sender->pollCqBlocking(1)) {
+      counters["error"] = folly::UserMetric(1, folly::UserMetric::Type::METRIC);
+      return;
+    }
+  }
+
+  // Timed iterations — separate post and poll loops.
+  // Batch to avoid overflowing the send queue (max 1024 WRs).
+  constexpr uint32_t kBatchSize = 1;
+  const uint32_t batchSize = FLAGS_batch_size > 0
+      ? static_cast<uint32_t>(FLAGS_batch_size)
+      : kBatchSize;
+  auto start = std::chrono::high_resolution_clock::now();
+  std::chrono::nanoseconds totalPostNs{0};
+  std::chrono::nanoseconds totalPollNs{0};
+
+  uint32_t remaining = iters;
+  while (remaining > 0) {
+    uint32_t batch = std::min(remaining, batchSize);
+
+    // Post loop: submit all writes in a tight batch
+    auto postStart = std::chrono::high_resolution_clock::now();
+    for (uint32_t j = 0; j < batch; ++j) {
+      int ret = g_dcState->sender->postRdmaWrite(
+          *g_dcState->ah, g_dcState->receiverCard, g_dcState->sge, j);
+      if (ret != 0) {
+        counters["error"] =
+            folly::UserMetric(1, folly::UserMetric::Type::METRIC);
+        return;
+      }
+    }
+    auto postEnd = std::chrono::high_resolution_clock::now();
+    totalPostNs += (postEnd - postStart);
+
+    // Poll loop: drain all completions
+    auto pollStart = std::chrono::high_resolution_clock::now();
+    for (uint32_t j = 0; j < batch; ++j) {
+      if (!g_dcState->sender->pollCqBusySpin(1)) {
+        counters["error"] =
+            folly::UserMetric(1, folly::UserMetric::Type::METRIC);
+        return;
+      }
+    }
+    auto pollEnd = std::chrono::high_resolution_clock::now();
+    totalPollNs += (pollEnd - pollStart);
+
+    remaining -= batch;
+  }
+
+  auto end = std::chrono::high_resolution_clock::now();
+  double elapsedUs =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(end - start)
+          .count() /
+      1000.0;
+
+  double avgLatencyUs = elapsedUs / iters;
+  double avgPostUs =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(totalPostNs)
+          .count() /
+      1000.0 / iters;
+  double avgPollUs =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(totalPollNs)
+          .count() /
+      1000.0 / iters;
+  double bandwidthGBps = (bufferSize * iters / 1e9) / (elapsedUs / 1e6);
+
+  counters["latency_us"] =
+      folly::UserMetric(avgLatencyUs, folly::UserMetric::Type::METRIC);
+  counters["post_us"] =
+      folly::UserMetric(avgPostUs, folly::UserMetric::Type::METRIC);
+  counters["poll_us"] =
+      folly::UserMetric(avgPollUs, folly::UserMetric::Type::METRIC);
+  counters["bw_gbps"] =
+      folly::UserMetric(bandwidthGBps, folly::UserMetric::Type::METRIC);
+  counters["buffer_bytes"] =
+      folly::UserMetric(bufferSize, folly::UserMetric::Type::METRIC);
+  recordRawResult(
+      "dcRdmaWrite",
+      bufferSize,
+      avgLatencyUs,
+      avgPostUs,
+      avgPollUs,
+      bandwidthGBps);
+}
+
+//------------------------------------------------------------------------------
+// RC RDMA Write Benchmark
+//------------------------------------------------------------------------------
+
+static void
+rcRdmaWrite(uint32_t iters, size_t bufferSize, folly::UserCounters& counters) {
+  // Use checkDcAvailable to ensure g_rdmaAvailability.dcCapableDevices() is
+  // populated, so RC uses the same physical devices as DC for fair comparison.
+  // Falls back to checkRdmaAvailable if DC is not supported.
+  if (!g_rdmaAvailability.checkDcAvailable() &&
+      !g_rdmaAvailability.checkRdmaAvailable()) {
+    counters["skipped"] = folly::UserMetric(1, folly::UserMetric::Type::METRIC);
+    return;
+  }
+
+  // Initialize or reuse state
+  if (!g_rcState) {
+    g_rcState = std::make_unique<RcBenchmarkState>();
+  }
+  if (!g_rcState->init(bufferSize)) {
+    counters["error"] = folly::UserMetric(1, folly::UserMetric::Type::METRIC);
+    return;
+  }
+
+  // Update SGE length for this buffer size
+  g_rcState->sge.length = static_cast<uint32_t>(bufferSize);
+
+  // Warm-up iterations
+  constexpr int kWarmupIters = 10;
+  for (int i = 0; i < kWarmupIters; ++i) {
+    int ret = g_rcState->sender->postRdmaWrite(
+        g_rcState->receiverCard, g_rcState->sge, i);
+    if (ret != 0) {
+      counters["error"] = folly::UserMetric(1, folly::UserMetric::Type::METRIC);
+      return;
+    }
+    if (!g_rcState->sender->pollCqBlocking(1)) {
+      counters["error"] = folly::UserMetric(1, folly::UserMetric::Type::METRIC);
+      return;
+    }
+  }
+
+  // Timed iterations — separate post and poll loops.
+  // Batch to avoid overflowing the send queue (max 1024 WRs).
+  constexpr uint32_t kBatchSize = 1;
+  const uint32_t batchSize = FLAGS_batch_size > 0
+      ? static_cast<uint32_t>(FLAGS_batch_size)
+      : kBatchSize;
+  auto start = std::chrono::high_resolution_clock::now();
+  std::chrono::nanoseconds totalPostNs{0};
+  std::chrono::nanoseconds totalPollNs{0};
+
+  uint32_t remaining = iters;
+  while (remaining > 0) {
+    uint32_t batch = std::min(remaining, batchSize);
+
+    // Post loop: submit all writes in a tight batch
+    auto postStart = std::chrono::high_resolution_clock::now();
+    for (uint32_t j = 0; j < batch; ++j) {
+      int ret = g_rcState->sender->postRdmaWrite(
+          g_rcState->receiverCard, g_rcState->sge, j);
+      if (ret != 0) {
+        counters["error"] =
+            folly::UserMetric(1, folly::UserMetric::Type::METRIC);
+        return;
+      }
+    }
+    auto postEnd = std::chrono::high_resolution_clock::now();
+    totalPostNs += (postEnd - postStart);
+
+    // Poll loop: drain all completions
+    auto pollStart = std::chrono::high_resolution_clock::now();
+    for (uint32_t j = 0; j < batch; ++j) {
+      if (!g_rcState->sender->pollCqBusySpin(1)) {
+        counters["error"] =
+            folly::UserMetric(1, folly::UserMetric::Type::METRIC);
+        return;
+      }
+    }
+    auto pollEnd = std::chrono::high_resolution_clock::now();
+    totalPollNs += (pollEnd - pollStart);
+
+    remaining -= batch;
+  }
+
+  auto end = std::chrono::high_resolution_clock::now();
+  double elapsedUs =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(end - start)
+          .count() /
+      1000.0;
+
+  double avgLatencyUs = elapsedUs / iters;
+  double avgPostUs =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(totalPostNs)
+          .count() /
+      1000.0 / iters;
+  double avgPollUs =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(totalPollNs)
+          .count() /
+      1000.0 / iters;
+  double bandwidthGBps = (bufferSize * iters / 1e9) / (elapsedUs / 1e6);
+
+  counters["latency_us"] =
+      folly::UserMetric(avgLatencyUs, folly::UserMetric::Type::METRIC);
+  counters["post_us"] =
+      folly::UserMetric(avgPostUs, folly::UserMetric::Type::METRIC);
+  counters["poll_us"] =
+      folly::UserMetric(avgPollUs, folly::UserMetric::Type::METRIC);
+  counters["bw_gbps"] =
+      folly::UserMetric(bandwidthGBps, folly::UserMetric::Type::METRIC);
+  counters["buffer_bytes"] =
+      folly::UserMetric(bufferSize, folly::UserMetric::Type::METRIC);
+  recordRawResult(
+      "rcRdmaWrite",
+      bufferSize,
+      avgLatencyUs,
+      avgPostUs,
+      avgPollUs,
+      bandwidthGBps);
+}
+
+//------------------------------------------------------------------------------
+// QP Initialization Overhead Benchmarks
+//------------------------------------------------------------------------------
+
+static void dcQpCreation(uint32_t iters, folly::UserCounters& counters) {
+  if (!g_rdmaAvailability.checkDcAvailable()) {
+    counters["skipped"] = folly::UserMetric(1, folly::UserMetric::Type::METRIC);
+    return;
+  }
+
+  double totalTimeUs = 0;
+
+  for (uint32_t i = 0; i < iters; ++i) {
+    auto start = std::chrono::high_resolution_clock::now();
+
+    DcEndPoint endpoint;
+    auto initResult = endpoint.init(g_rdmaAvailability.dcCapableDevices()[0]);
+    if (!initResult) {
+      counters["error"] = folly::UserMetric(1, folly::UserMetric::Type::METRIC);
+      return;
+    }
+    auto dcResult = endpoint.initDc();
+    if (!dcResult) {
+      counters["error"] = folly::UserMetric(1, folly::UserMetric::Type::METRIC);
+      return;
+    }
+
+    auto end = std::chrono::high_resolution_clock::now();
+    totalTimeUs +=
+        std::chrono::duration_cast<std::chrono::nanoseconds>(end - start)
+            .count() /
+        1000.0;
+  }
+
+  double avgTimeUs = totalTimeUs / iters;
+  counters["qp_init_us"] =
+      folly::UserMetric(avgTimeUs, folly::UserMetric::Type::METRIC);
+}
+
+static void rcQpCreation(uint32_t iters, folly::UserCounters& counters) {
+  if (!g_rdmaAvailability.checkRdmaAvailable()) {
+    counters["skipped"] = folly::UserMetric(1, folly::UserMetric::Type::METRIC);
+    return;
+  }
+
+  double totalTimeUs = 0;
+
+  for (uint32_t i = 0; i < iters; ++i) {
+    auto start = std::chrono::high_resolution_clock::now();
+
+    RcEndPoint endpoint;
+    auto initResult = endpoint.init(0);
+    if (!initResult) {
+      counters["error"] = folly::UserMetric(1, folly::UserMetric::Type::METRIC);
+      return;
+    }
+    auto rcResult = endpoint.initRc();
+    if (!rcResult) {
+      counters["error"] = folly::UserMetric(1, folly::UserMetric::Type::METRIC);
+      return;
+    }
+
+    auto end = std::chrono::high_resolution_clock::now();
+    totalTimeUs +=
+        std::chrono::duration_cast<std::chrono::nanoseconds>(end - start)
+            .count() /
+        1000.0;
+  }
+
+  double avgTimeUs = totalTimeUs / iters;
+  counters["qp_init_us"] =
+      folly::UserMetric(avgTimeUs, folly::UserMetric::Type::METRIC);
+}
+
+//------------------------------------------------------------------------------
+// Benchmark Registration
+//------------------------------------------------------------------------------
+
+// Helper macro for registering RDMA write benchmarks with buffer size
+#define REGISTER_RDMA_BENCH(func, sizeName, sizeBytes) \
+  BENCHMARK_MULTI_PARAM_COUNTERS(func, sizeName, sizeBytes)
+
+// DC RDMA Write benchmarks - powers of 2 from 1B to 2GB
+REGISTER_RDMA_BENCH(dcRdmaWrite, 1B, 1);
+REGISTER_RDMA_BENCH(dcRdmaWrite, 2B, 2);
+REGISTER_RDMA_BENCH(dcRdmaWrite, 4B, 4);
+REGISTER_RDMA_BENCH(dcRdmaWrite, 8B, 8);
+REGISTER_RDMA_BENCH(dcRdmaWrite, 16B, 16);
+REGISTER_RDMA_BENCH(dcRdmaWrite, 32B, 32);
+REGISTER_RDMA_BENCH(dcRdmaWrite, 64B, 64);
+REGISTER_RDMA_BENCH(dcRdmaWrite, 128B, 128);
+REGISTER_RDMA_BENCH(dcRdmaWrite, 256B, 256);
+REGISTER_RDMA_BENCH(dcRdmaWrite, 512B, 512);
+REGISTER_RDMA_BENCH(dcRdmaWrite, 1KB, 1024);
+REGISTER_RDMA_BENCH(dcRdmaWrite, 2KB, 2048);
+REGISTER_RDMA_BENCH(dcRdmaWrite, 4KB, 4096);
+REGISTER_RDMA_BENCH(dcRdmaWrite, 8KB, 8192);
+REGISTER_RDMA_BENCH(dcRdmaWrite, 16KB, 16384);
+REGISTER_RDMA_BENCH(dcRdmaWrite, 32KB, 32768);
+REGISTER_RDMA_BENCH(dcRdmaWrite, 64KB, 65536);
+REGISTER_RDMA_BENCH(dcRdmaWrite, 128KB, 131072);
+REGISTER_RDMA_BENCH(dcRdmaWrite, 256KB, 262144);
+REGISTER_RDMA_BENCH(dcRdmaWrite, 512KB, 524288);
+REGISTER_RDMA_BENCH(dcRdmaWrite, 1MB, 1048576);
+REGISTER_RDMA_BENCH(dcRdmaWrite, 2MB, 2097152);
+REGISTER_RDMA_BENCH(dcRdmaWrite, 4MB, 4194304);
+REGISTER_RDMA_BENCH(dcRdmaWrite, 8MB, 8388608);
+REGISTER_RDMA_BENCH(dcRdmaWrite, 16MB, 16777216);
+REGISTER_RDMA_BENCH(dcRdmaWrite, 32MB, 33554432);
+REGISTER_RDMA_BENCH(dcRdmaWrite, 64MB, 67108864);
+REGISTER_RDMA_BENCH(dcRdmaWrite, 128MB, 134217728);
+REGISTER_RDMA_BENCH(dcRdmaWrite, 256MB, 268435456);
+REGISTER_RDMA_BENCH(dcRdmaWrite, 512MB, 536870912);
+REGISTER_RDMA_BENCH(dcRdmaWrite, 1GB, 1073741824);
+REGISTER_RDMA_BENCH(dcRdmaWrite, 2GB, 2147483648ULL);
+
+BENCHMARK_DRAW_LINE();
+
+// RC RDMA Write benchmarks - same sizes
+REGISTER_RDMA_BENCH(rcRdmaWrite, 1B, 1);
+REGISTER_RDMA_BENCH(rcRdmaWrite, 2B, 2);
+REGISTER_RDMA_BENCH(rcRdmaWrite, 4B, 4);
+REGISTER_RDMA_BENCH(rcRdmaWrite, 8B, 8);
+REGISTER_RDMA_BENCH(rcRdmaWrite, 16B, 16);
+REGISTER_RDMA_BENCH(rcRdmaWrite, 32B, 32);
+REGISTER_RDMA_BENCH(rcRdmaWrite, 64B, 64);
+REGISTER_RDMA_BENCH(rcRdmaWrite, 128B, 128);
+REGISTER_RDMA_BENCH(rcRdmaWrite, 256B, 256);
+REGISTER_RDMA_BENCH(rcRdmaWrite, 512B, 512);
+REGISTER_RDMA_BENCH(rcRdmaWrite, 1KB, 1024);
+REGISTER_RDMA_BENCH(rcRdmaWrite, 2KB, 2048);
+REGISTER_RDMA_BENCH(rcRdmaWrite, 4KB, 4096);
+REGISTER_RDMA_BENCH(rcRdmaWrite, 8KB, 8192);
+REGISTER_RDMA_BENCH(rcRdmaWrite, 16KB, 16384);
+REGISTER_RDMA_BENCH(rcRdmaWrite, 32KB, 32768);
+REGISTER_RDMA_BENCH(rcRdmaWrite, 64KB, 65536);
+REGISTER_RDMA_BENCH(rcRdmaWrite, 128KB, 131072);
+REGISTER_RDMA_BENCH(rcRdmaWrite, 256KB, 262144);
+REGISTER_RDMA_BENCH(rcRdmaWrite, 512KB, 524288);
+REGISTER_RDMA_BENCH(rcRdmaWrite, 1MB, 1048576);
+REGISTER_RDMA_BENCH(rcRdmaWrite, 2MB, 2097152);
+REGISTER_RDMA_BENCH(rcRdmaWrite, 4MB, 4194304);
+REGISTER_RDMA_BENCH(rcRdmaWrite, 8MB, 8388608);
+REGISTER_RDMA_BENCH(rcRdmaWrite, 16MB, 16777216);
+REGISTER_RDMA_BENCH(rcRdmaWrite, 32MB, 33554432);
+REGISTER_RDMA_BENCH(rcRdmaWrite, 64MB, 67108864);
+REGISTER_RDMA_BENCH(rcRdmaWrite, 128MB, 134217728);
+REGISTER_RDMA_BENCH(rcRdmaWrite, 256MB, 268435456);
+REGISTER_RDMA_BENCH(rcRdmaWrite, 512MB, 536870912);
+REGISTER_RDMA_BENCH(rcRdmaWrite, 1GB, 1073741824);
+REGISTER_RDMA_BENCH(rcRdmaWrite, 2GB, 2147483648ULL);
+
+BENCHMARK_DRAW_LINE();
+
+// QP Creation benchmarks
+BENCHMARK_MULTI_PARAM_COUNTERS(dcQpCreation, dc_qp_init);
+BENCHMARK_MULTI_PARAM_COUNTERS(rcQpCreation, rc_qp_init);
+
+//------------------------------------------------------------------------------
+// Main
+//------------------------------------------------------------------------------
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+
+  XLOG(INFO) << "DC vs RC RDMA Single-Pair Benchmark";
+  XLOG(INFO) << "===================================";
+
+  if (!g_rdmaAvailability.checkRdmaAvailable()) {
+    XLOG(ERR) << "RDMA not available - benchmarks will be skipped";
+  } else {
+    XLOG(INFO) << "RDMA devices available - running benchmarks";
+  }
+
+  // Suppress folly benchmark table when --raw_only is set
+  int savedStdout = -1;
+  if (FLAGS_raw_only) {
+    savedStdout = dup(STDOUT_FILENO);
+    int devNull = open("/dev/null", O_WRONLY);
+    dup2(devNull, STDOUT_FILENO);
+    close(devNull);
+  }
+
+  folly::runBenchmarks();
+
+  if (FLAGS_raw_only && savedStdout >= 0) {
+    dup2(savedStdout, STDOUT_FILENO);
+    close(savedStdout);
+  }
+
+  printAllRawResults();
+
+  return 0;
+}


### PR DESCRIPTION
Summary:

This diff adds a benchmarking suite comparing DC vs RC RDMA write performance across multiple dimensions.

Benchmarks:

1. P2P Single-Pair (`IbverbxDcP2PBench.cc`) — DC vs RC latency/bandwidth for message sizes from 1B to 4MB, plus QP initialization overhead. Batch size is configurable via `--batch_size` for latency vs throughput mode.

2. One-to-Many Scalability (`IbverbxDcOneToManyBench.cc`) — peer count sweep (`N=2..2048`) with fixed 128MB total input. DC baseline now reuses the same `dcMultiDciCore` path as the multi-DCI benchmarks with `numDcis=1`; multi-DCI variants test 2, 4, 8, and 16 DCIs; message-size sweeps run at `N=2048`; multi-NIC variants compare round-robin vs destination-sorted write ordering.

3. Connection Probing (`IbverbxDcConnectionProbeBench.cc`) — multi-node test where one DCI probes two DCTs in sorted order (`AAA...BBB...`) and alternating order (`ABAB...`) to measure whether connection locality changes performance. The streamed probe variant was removed; DCI streams are covered in the follow-up DCI Streams diff.

Output: Benchmarks print RAW CSV results by default. Pass `--noraw_only` to also display the folly benchmark table.

Shared utilities (`IbverbxDcBenchUtils.h`) provide `RdmaResources` initialization, RDMA availability checks, DC/RC endpoint wrappers, business-card helpers, RC transition helpers, CQ polling, and DC/RC RDMA write posting helpers used by the benchmark files.

Differential Revision: D92781246


