### PR TITLE
v2.29: Use third-party doca-gpunetio instead of vendored copy

### DIFF
--- a/comms/ncclx/v2_29/src/include/nccl_device/gin/gdaki/gin_gdaki.h
+++ b/comms/ncclx/v2_29/src/include/nccl_device/gin/gdaki/gin_gdaki.h
@@ -9,21 +9,27 @@
 #define _NCCL_DEVICE_GIN_GDAKI_H_
 
 #include <cstdint>
-#ifndef DOCA_VERBS_USE_CUDA_WRAPPER
-#define DOCA_VERBS_USE_CUDA_WRAPPER
-#endif
-
-#ifndef DOCA_VERBS_USE_NET_WRAPPER
-#define DOCA_VERBS_USE_NET_WRAPPER
-#endif
 
 #ifdef NCCL_DEVICE_GIN_GDAKI_ENABLE_DEBUG
 #define DOCA_GPUNETIO_VERBS_ENABLE_DEBUG 1
 #endif
 
+#ifndef DOCA_VERBS_USE_META_THIRD_PARTY
+#ifndef DOCA_VERBS_USE_CUDA_WRAPPER
+#define DOCA_VERBS_USE_CUDA_WRAPPER
+#endif
+#ifndef DOCA_VERBS_USE_NET_WRAPPER
+#define DOCA_VERBS_USE_NET_WRAPPER
+#endif
+#endif
+
 #include "../gin_device_common.h"
 #include "gin_gdaki_device_host_common.h"
+#ifdef DOCA_VERBS_USE_META_THIRD_PARTY
+#include "doca_gpunetio_device.h"
+#else
 #include "transport/net_ib/gdaki/doca-gpunetio/include/doca_gpunetio_device.h"
+#endif
 
 #ifdef NCCL_DEVICE_GIN_GDAKI_ENABLE_DEBUG
 #include <stdio.h>

--- a/comms/ncclx/v2_29/src/transport/net_ib/gdaki/gin_host_gdaki.h
+++ b/comms/ncclx/v2_29/src/transport/net_ib/gdaki/gin_host_gdaki.h
@@ -8,12 +8,13 @@
 #ifndef _GIN_HOST_GDAKI_H_
 #define _GIN_HOST_GDAKI_H_
 
+#ifndef DOCA_VERBS_USE_META_THIRD_PARTY
 #ifndef DOCA_VERBS_USE_CUDA_WRAPPER
 #define DOCA_VERBS_USE_CUDA_WRAPPER
 #endif
-
 #ifndef DOCA_VERBS_USE_NET_WRAPPER
 #define DOCA_VERBS_USE_NET_WRAPPER
+#endif
 #endif
 
 #include <stdbool.h>


### PR DESCRIPTION
Summary:
Make NCCLx v2.29 use the third-party doca-gpunetio library instead of compiling
its own vendored copy. This resolves duplicate symbol errors when tests link both
NCCL (with internal doca) and ctran/pipes (with third-party doca).

Changes:
- Remove vendored doca-gpunetio source/header globs from def_build.bzl
- Add fbsource//third-party/nvidia-doca/gpunetio:doca_gpunetio dependency
- Exclude vendored doca .cpp files from transport/**/*.cpp glob
- Add DOCA_VERBS_USE_META_THIRD_PARTY macro to gate Meta vs OSS build paths
- Conditionally set wrapper defines and include paths based on build target

Differential Revision: D95653707


