### PR TITLE
Fix doubleDeregMem test to match new freeSegment no-op behavior

### DIFF
--- a/comms/ctran/mapper/tests/CtranMapperUT.cc
+++ b/comms/ctran/mapper/tests/CtranMapperUT.cc
@@ -366,7 +366,7 @@ TEST_F(CtranMapperTest, doubleDeregMem) {
   EXPECT_EQ(res, commSuccess);
 
   res = mapper->deregMem(hdl);
-  EXPECT_EQ(res, commInvalidUsage);
+  EXPECT_EQ(res, commSuccess);
 
   // Check profiled registration events
   auto snapshot = regCache->profiler.rlock()->getSnapshot();


### PR DESCRIPTION
Summary:
D94978820 changed `freeSegment()` to return `commSuccess` (no-op) instead of
`commInvalidUsage` when a segment is not found (already freed). This broke the
`CtranMapperTest.doubleDeregMem` test which expected `commInvalidUsage` on a
double deregistration.

Update the test assertion to expect `commSuccess`, matching the new intended
behavior where double-deregistration is a harmless no-op.

Reviewed By: elvinlife

Differential Revision: D95695700


