### PR TITLE
Fix test build failures from RegCache rename

### DIFF
--- a/comms/ncclx/v2_27/meta/tests/CommRegisterTest.cc
+++ b/comms/ncclx/v2_27/meta/tests/CommRegisterTest.cc
@@ -7,7 +7,7 @@
 
 #include <nccl.h>
 #include "comms/ctran/Ctran.h"
-#include "comms/ctran/mapper/CtranMapperRegMem.h"
+#include "comms/ctran/regcache/RegCache.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -64,7 +64,7 @@ TEST_P(CommRegisterTestParam, RegularUsage) {
   }
 
   // Cleanup cached segments in global cache before we test memory leak
-  auto regCache = CtranMapperRegCache::getInstance();
+  auto regCache = ctran::RegCache::getInstance();
   EXPECT_EQ(regCache->destroy(), commSuccess);
 
   testFreeBuf(buf, nbytes, memType);
@@ -131,7 +131,8 @@ INSTANTIATE_TEST_SUITE_P(
         // CTRAN_MIN_REGISTRATION_SIZE)
         std::make_tuple(1, kMemNcclMemAlloc, NCCL_CTRAN_REGISTER::eager),
         std::make_tuple(1, kMemNcclMemAlloc, NCCL_CTRAN_REGISTER::lazy)),
-    [&](const testing::TestParamInfo<CommRegisterTestParam::ParamType>& info) {
+    [&](const ::testing::TestParamInfo<CommRegisterTestParam::ParamType>&
+            info) {
       return std::to_string(std::get<0>(info.param)) + "bytes_" +
           testMemAllocTypeToStr(std::get<1>(info.param)) + "_" +
           testCtranRegisterModeToStr(std::get<2>(info.param));

--- a/comms/ncclx/v2_27/meta/wrapper/tests/CtranExDistCommFailureUT.cc
+++ b/comms/ncclx/v2_27/meta/wrapper/tests/CtranExDistCommFailureUT.cc
@@ -121,8 +121,8 @@ INSTANTIATE_TEST_SUITE_P(
     CtranExCommFailureTest,
     CtranExCommFailureParamFixture,
     ::testing::Values(TestWaitType::TEST, TestWaitType::WAIT),
-    [&](const testing::TestParamInfo<CtranExCommFailureParamFixture::ParamType>&
-            info) {
+    [&](const ::testing::TestParamInfo<
+        CtranExCommFailureParamFixture::ParamType>& info) {
       const std::string waitType =
           info.param == TestWaitType::TEST ? "Test" : "Wait";
       return waitType;

--- a/comms/ncclx/v2_27/meta/wrapper/tests/CtranExDistCommUT.cc
+++ b/comms/ncclx/v2_27/meta/wrapper/tests/CtranExDistCommUT.cc
@@ -6,6 +6,7 @@
 
 #include <stdlib.h>
 #include "comms/ctran/CtranEx.h"
+#include "comms/ctran/regcache/RegCache.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
 #include "meta/wrapper/CtranExComm.h"
@@ -20,7 +21,7 @@ class CtranExCommTest : public CtranExBaseTest {
   void SetUp() override {
     CtranExBaseTest::SetUp();
 
-    regCache_ = CtranMapperRegCache::getInstance();
+    regCache_ = RegCache::getInstance();
     ASSERT_NE(regCache_, nullptr);
   }
 
@@ -56,7 +57,7 @@ class CtranExCommTest : public CtranExBaseTest {
     return errs;
   }
 
-  std::shared_ptr<CtranMapperRegCache> regCache_{nullptr};
+  std::shared_ptr<RegCache> regCache_{nullptr};
 };
 
 TEST_F(CtranExCommTest, Initialized) {
@@ -316,7 +317,7 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::Values(kTestInPlace, kTestOutOfPlace),
         // concurrentColl
         ::testing::Values(true)),
-    [&](const testing::TestParamInfo<CtranExCommBroadcastFixture::ParamType>&
+    [&](const ::testing::TestParamInfo<CtranExCommBroadcastFixture::ParamType>&
             info) {
       return std::to_string(std::get<0>(info.param)) + "int_" +
           testInPlaceTypeToStr(std::get<1>(info.param)) + "_concurrentColl_" +


### PR DESCRIPTION
Summary:
Update v2_27 tests for the CtranMapperRegCache ->
ctran::RegCache rename:
- CommRegisterTest.cc: update include path and class name
- CtranExDistCommUT.cc: add include and update class name
- CtranExDistCommFailureUT.cc: disambiguate testing::
  namespace

All three files also fix ambiguous 'testing' namespace
references caused by ctran::testing conflicting with
::testing from gtest.

Differential Revision: D95714490


