### PR TITLE
Restructure ncclx config into separate Config class

### DIFF
--- a/comms/ncclx/v2_27/examples/HelloWorld.cc
+++ b/comms/ncclx/v2_27/examples/HelloWorld.cc
@@ -10,7 +10,9 @@ int main(int argc, char* argv[]) {
   cudaStream_t stream;
   int* userBuff = NULL;
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
-  config.commDesc = "example_pg";
+  ncclx::Hints hints;
+  hints.set("commDesc", "example_pg");
+  config.hints = &hints;
 
   ncclUniqueId ncclId;
   NCCLCHECK(ncclGetUniqueId(&ncclId));

--- a/comms/ncclx/v2_27/meta/NcclxConfig.h
+++ b/comms/ncclx/v2_27/meta/NcclxConfig.h
@@ -1,0 +1,51 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "nccl.h" // @manual
+
+namespace ncclx {
+
+struct Config {
+  // NCCLX-specific config fields (canonical storage).
+  // New fields should be added here, NOT to ncclConfig_t.
+  // When adding a new field, also add its key to knownHintKeys below.
+  std::string commDesc;
+  std::vector<int> splitGroupRanks;
+  std::string ncclAllGatherAlgo;
+  bool lazyConnect = false;
+  bool lazySetupChannels = false;
+  bool fastInitMode = false;
+};
+
+// Hint keys corresponding to Config fields above.  Used by
+// Hints::set() to warn on unrecognized keys (typo detection).
+inline const std::vector<std::string>& knownHintKeys() {
+  static const std::vector<std::string> keys = {
+      "commDesc",
+      "splitGroupRanks",
+      "ncclAllGatherAlgo",
+      "lazyConnect",
+      "lazySetupChannels",
+      "fastInitMode",
+  };
+  return keys;
+}
+
+} // namespace ncclx
+
+// Convenience macro: access an NCCLX-specific field from the canonical
+// ncclx::Config stored inside an ncclConfig_t.
+// Usage: NCCLX_CONFIG_FIELD(comm->config, commDesc)
+#define NCCLX_CONFIG_FIELD(cfg, field) \
+  (static_cast<ncclx::Config*>((cfg).ncclxConfig)->field)
+
+// Create ncclx::Config from config->hints (new format) or flat
+// ncclConfig_t fields (old format) with env-based defaults.  Returns
+// ncclInvalidArgument if a field is set in both formats.  Stores the
+// result in config->ncclxConfig.  Idempotent: does nothing if
+// ncclxConfig is already set.
+ncclResult_t ncclxParseCommConfig(ncclConfig_t* config);

--- a/comms/ncclx/v2_27/meta/commDump.cc
+++ b/comms/ncclx/v2_27/meta/commDump.cc
@@ -8,6 +8,7 @@
 #include <folly/json/json.h>
 
 #include "comm.h"
+#include "meta/NcclxConfig.h" // @manual
 #include "nccl.h"
 
 #include "comms/ctran/colltrace/MapperTrace.h"
@@ -95,7 +96,7 @@ static void dumpCommInfo(
   map["nRanks"] = std::to_string(comm->nRanks);
   map["localRanks"] = std::to_string(comm->localRanks);
   map["nNodes"] = std::to_string(comm->nNodes);
-  map["commDesc"] = toQuotedString(comm->config.commDesc);
+  map["commDesc"] = toQuotedString(NCCLX_CONFIG_FIELD(comm->config, commDesc));
 }
 
 static void dumpCommInfo(
@@ -235,7 +236,7 @@ __attribute__((visibility("default"))) ncclResult_t ncclCommDump(
         comm->rank,
         fmt::ptr(comm),
         comm->commHash,
-        comm->config.commDesc);
+        NCCLX_CONFIG_FIELD(comm->config, commDesc));
 
     dumpCommInfo(comm, map);
     if (NCCL_COLLTRACE_USE_NEW_COLLTRACE) {

--- a/comms/ncclx/v2_27/meta/comms-monitor/tests/CommsMonitorDist.cc
+++ b/comms/ncclx/v2_27/meta/comms-monitor/tests/CommsMonitorDist.cc
@@ -8,6 +8,7 @@
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
 #include "meta/comms-monitor/CommsMonitor.h"
+#include "nccl.h"
 
 using namespace ncclx::comms_monitor;
 
@@ -120,8 +121,9 @@ TEST_F(CommsMonitorDist, testCommSplit) {
   EXPECT_EQ(CommsMonitor::getNumOfCommMonitoring(), 1);
 
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
-  const std::string commDest = "split_comm";
-  config.commDesc = commDest.c_str();
+  ncclx::Hints splitHints;
+  splitHints.set("commDesc", "split_comm");
+  config.hints = &splitHints;
 
   ncclComm_t splitComm;
 
@@ -140,8 +142,9 @@ TEST_F(CommsMonitorDist, testCommSplitNoColor) {
   EXPECT_EQ(CommsMonitor::getNumOfCommMonitoring(), 1);
 
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
-  const std::string commDest = "split_comm";
-  config.commDesc = commDest.c_str();
+  ncclx::Hints noColorHints;
+  noColorHints.set("commDesc", "split_comm");
+  config.hints = &noColorHints;
 
   ncclComm_t splitComm;
 

--- a/comms/ncclx/v2_27/meta/comms-monitor/tests/CommsMonitorUT.cc
+++ b/comms/ncclx/v2_27/meta/comms-monitor/tests/CommsMonitorUT.cc
@@ -6,6 +6,7 @@
 #include "comm.h" // @manual
 #include "comms/ctran/Ctran.h" // @manual
 #include "comms/utils/cvars/nccl_cvars.h"
+#include "meta/NcclxConfig.h"
 #include "meta/colltrace/CollTrace.h" // @manual
 #include "meta/comms-monitor/CommsMonitor.h" // @manual
 #include "meta/wrapper/MetaFactory.h"
@@ -16,7 +17,9 @@ inline std::unique_ptr<ncclComm> createFakeNcclComm() {
   comm->nRanks = 1;
   comm->cudaDev = 0;
   comm->commHash = 0xfaceb00c;
-  comm->config.commDesc = "fake_comm";
+  auto* ncclxCfg = new ncclx::Config();
+  ncclxCfg->commDesc = "fake_comm";
+  comm->config.ncclxConfig = ncclxCfg;
   comm->localRank = 0;
   comm->localRanks = 1;
   comm->nNodes = 1;
@@ -31,7 +34,7 @@ inline std::unique_ptr<ncclComm> createFakeNcclComm() {
       comm->commHash,
       std::vector<ncclx::RankTopology>(), /* rankTopologies */
       std::vector<int>(), /* commRanksToWorldRanks */
-      comm->config.commDesc);
+      NCCLX_CONFIG_FIELD(comm->config, commDesc));
 
   return comm;
 }

--- a/comms/ncclx/v2_27/meta/commstate/FactoryCommStateX.cc
+++ b/comms/ncclx/v2_27/meta/commstate/FactoryCommStateX.cc
@@ -3,6 +3,7 @@
 #include "comm.h"
 #include "comms/ctran/commstate/CommStateX.h"
 #include "comms/ctran/utils/Checks.h"
+#include "meta/NcclxConfig.h" // @manual
 
 #include "bootstrap.h"
 #include "nvmlwrap.h"
@@ -51,7 +52,7 @@ std::unique_ptr<CommStateX> createCommStateXFromNcclComm(void* _comm) {
       comm->commHash,
       std::vector<RankTopology>(), /* rankTopologies */
       std::vector<int>(), /* commRanksToWorldRanks */
-      comm->config.commDesc);
+      NCCLX_CONFIG_FIELD(comm->config, commDesc));
 
   if (comm->noLocal_ ||
       NCCL_COMM_STATE_DEBUG_TOPO == NCCL_COMM_STATE_DEBUG_TOPO::nolocal) {

--- a/comms/ncclx/v2_27/meta/commstate/tests/CommStateXTest.cc
+++ b/comms/ncclx/v2_27/meta/commstate/tests/CommStateXTest.cc
@@ -11,6 +11,7 @@
 #include "comms/testinfra/TestUtils.h"
 
 #include "comms/ctran/commstate/CommStateX.h"
+#include "meta/NcclxConfig.h"
 #include "param.h" // @manual
 
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -40,7 +41,9 @@ static void fillDummyComm(ncclComm& comm, int numNvlDomain = 1) {
   comm.nRanks = 16;
   comm.cudaDev = 0;
   comm.commHash = 123456789;
-  comm.config.commDesc = "default_pg:0";
+  auto* ncclxCfg = new ncclx::Config();
+  ncclxCfg->commDesc = "default_pg:0";
+  comm.config.ncclxConfig = ncclxCfg;
 
   comm.localRank = 0;
   comm.localRanks = 8 / numNvlDomain; // local ranks in the same NVL domain
@@ -102,7 +105,7 @@ TEST(CommStateXTest, CreateVNodeFromNcclComm) {
   EXPECT_EQ(state->nLocalRanks(), nLocalRanks);
   EXPECT_EQ(state->nNodes(), comm.nRanks / nLocalRanks);
   EXPECT_EQ(state->commHash(), comm.commHash);
-  EXPECT_EQ(state->commDesc(), comm.config.commDesc);
+  EXPECT_EQ(state->commDesc(), NCCLX_CONFIG_FIELD(comm.config, commDesc));
   for (int i = 0; i < state->nRanks(); ++i) {
     EXPECT_EQ(state->node(i), i / nLocalRanks);
   }
@@ -146,7 +149,7 @@ TEST(CommStateXTest, CreateNoLocalFromNcclComm) {
   EXPECT_EQ(state->nLocalRanks(), 1);
   EXPECT_EQ(state->nNodes(), comm.nRanks);
   EXPECT_EQ(state->commHash(), comm.commHash);
-  EXPECT_EQ(state->commDesc(), comm.config.commDesc);
+  EXPECT_EQ(state->commDesc(), NCCLX_CONFIG_FIELD(comm.config, commDesc));
   for (int i = 0; i < state->nRanks(); ++i) {
     EXPECT_EQ(state->node(i), i);
   }
@@ -182,7 +185,7 @@ TEST_P(CommStateXNcclCommTestParamFixture, CreateFromNcclComm) {
   EXPECT_EQ(state->nRanks(), comm.nRanks);
   EXPECT_EQ(state->cudaDev(), comm.cudaDev);
   EXPECT_EQ(state->commHash(), comm.commHash);
-  EXPECT_EQ(state->commDesc(), comm.config.commDesc);
+  EXPECT_EQ(state->commDesc(), NCCLX_CONFIG_FIELD(comm.config, commDesc));
   EXPECT_EQ(state->localRank(), comm.localRank);
   EXPECT_EQ(state->nLocalRanks(), comm.localRanks);
   for (int i = 0; i < state->nRanks(); ++i) {

--- a/comms/ncclx/v2_27/meta/hints/Hints.cc
+++ b/comms/ncclx/v2_27/meta/hints/Hints.cc
@@ -7,7 +7,10 @@
 #include "comms/ctran/algos/AllToAll/AllToAllvDynamicHintUtils.h"
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/window/WinHintUtils.h"
+#include "meta/NcclxConfig.h" // @manual
 #include "meta/wrapper/MetaFactory.h"
+
+#include <algorithm>
 
 namespace ncclx {
 
@@ -34,7 +37,12 @@ Hints::set(const std::string& key, const std::string& val) {
     NCCLCHECK(metaCommToNccl(WinHintUtils::set(key, val, this->kv)));
     return ncclSuccess;
   } else {
-    return ncclInvalidArgument;
+    const auto& knownKeys = ncclx::knownHintKeys();
+    if (std::find(knownKeys.begin(), knownKeys.end(), key) == knownKeys.end()) {
+      WARN("NCCLX Hints: unknown key '%s'; check spelling", key.c_str());
+    }
+    this->kv[key] = val;
+    return ncclSuccess;
   }
 }
 

--- a/comms/ncclx/v2_27/meta/tests/CommDescTest.cc
+++ b/comms/ncclx/v2_27/meta/tests/CommDescTest.cc
@@ -10,6 +10,7 @@
 #include "comm.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
+#include "meta/NcclxConfig.h"
 #include "nccl.h"
 
 class commDescTest : public ::testing::Test {
@@ -32,7 +33,7 @@ TEST_F(commDescTest, getUndefinedCommDesc) {
   NcclCommRAII comm(this->globalRank, this->numRanks, this->localRank);
   ASSERT_NE(nullptr, static_cast<ncclComm_t>(comm));
 
-  EXPECT_STREQ(comm->config.commDesc, "nccl_ut");
+  EXPECT_EQ(NCCLX_CONFIG_FIELD(comm->config, commDesc), "nccl_ut");
 }
 
 TEST_F(commDescTest, getDefinedCommDesc) {
@@ -46,14 +47,16 @@ TEST_F(commDescTest, getDefinedCommDesc) {
 
   ncclComm_t comm;
   ncclConfig_t inputConfig = NCCL_CONFIG_INITIALIZER;
-  inputConfig.commDesc = "test_description";
+  ncclx::Hints hints;
+  hints.set("commDesc", "test_description");
+  inputConfig.hints = &hints;
 
   NCCLCHECK_TEST(ncclCommInitRankConfig(
       &comm, numRanks, ncclId, globalRank, &inputConfig));
   ASSERT_NE(nullptr, comm);
 
-  EXPECT_STRNE(comm->config.commDesc, "undefined");
-  EXPECT_STREQ(comm->config.commDesc, inputConfig.commDesc);
+  EXPECT_NE(NCCLX_CONFIG_FIELD(comm->config, commDesc), "undefined");
+  EXPECT_EQ(NCCLX_CONFIG_FIELD(comm->config, commDesc), "test_description");
 
   NCCLCHECK_TEST(ncclCommDestroy(comm));
 }
@@ -71,7 +74,9 @@ TEST_F(commDescTest, InvalidPointerAccess) {
   ncclConfig_t inputConfig = NCCL_CONFIG_INITIALIZER;
   const char* commDescConst = "test_description";
   char* commDesc = strdup(commDescConst);
-  inputConfig.commDesc = commDesc;
+  ncclx::Hints hints;
+  hints.set("commDesc", commDesc);
+  inputConfig.hints = &hints;
 
   NCCLCHECK_TEST(ncclCommInitRankConfig(
       &comm, numRanks, ncclId, globalRank, &inputConfig));
@@ -79,8 +84,8 @@ TEST_F(commDescTest, InvalidPointerAccess) {
 
   free(commDesc);
 
-  EXPECT_STRNE(comm->config.commDesc, "undefined");
-  EXPECT_STREQ(comm->config.commDesc, commDescConst);
+  EXPECT_NE(NCCLX_CONFIG_FIELD(comm->config, commDesc), "undefined");
+  EXPECT_EQ(NCCLX_CONFIG_FIELD(comm->config, commDesc), commDescConst);
 
   NCCLCHECK_TEST(ncclCommDestroy(comm));
 }

--- a/comms/ncclx/v2_27/meta/tests/CommDumpTest.cc
+++ b/comms/ncclx/v2_27/meta/tests/CommDumpTest.cc
@@ -12,6 +12,7 @@
 #include "comm.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
+#include "meta/NcclxConfig.h"
 #include "nccl.h"
 
 #include "comms/utils/StrUtils.h"
@@ -173,7 +174,9 @@ TEST_F(CommDumpTest, SingleComm) {
   EXPECT_EQ(dump.count("node"), 1);
   EXPECT_EQ(dump["node"], std::to_string(this->comm->node));
   EXPECT_EQ(dump.count("commDesc"), 1);
-  EXPECT_EQ(dump["commDesc"], toQuotedString(this->comm->config.commDesc));
+  EXPECT_EQ(
+      dump["commDesc"],
+      toQuotedString(NCCLX_CONFIG_FIELD(this->comm->config, commDesc)));
 
   EXPECT_EQ(dump.count("nRanks"), 1);
   EXPECT_EQ(dump["nRanks"], std::to_string(this->comm->nRanks));

--- a/comms/ncclx/v2_27/meta/tests/CommWithCtranTest.cc
+++ b/comms/ncclx/v2_27/meta/tests/CommWithCtranTest.cc
@@ -70,7 +70,9 @@ TEST_P(CommWithCtranTestParam, CtranEnableByHint) {
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
   config.blocking = blockingInit ? 1 : 0;
   const auto commDescStr = fmt::format("{}-{}", kNcclUtCommDesc, "useCtran");
-  config.commDesc = commDescStr.c_str();
+  ncclx::Hints ctranHints;
+  ctranHints.set("commDesc", commDescStr);
+  config.hints = &ctranHints;
 
   // Enable by hint
   ASSERT_EQ(

--- a/comms/ncclx/v2_27/meta/tests/CommWithNoLocalTest.cc
+++ b/comms/ncclx/v2_27/meta/tests/CommWithNoLocalTest.cc
@@ -66,7 +66,9 @@ TEST_P(CommWithNoLocalTestParam, NoLocalEnableByHint) {
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
   config.blocking = blockingInit ? 1 : 0;
   const auto commDescStr = fmt::format("{}-{}", kNcclUtCommDesc, "noLocal");
-  config.commDesc = commDescStr.c_str();
+  ncclx::Hints noLocalHints;
+  noLocalHints.set("commDesc", commDescStr);
+  config.hints = &noLocalHints;
 
   // Enable by hint
   ASSERT_EQ(

--- a/comms/ncclx/v2_27/meta/tests/FastInitTest.cc
+++ b/comms/ncclx/v2_27/meta/tests/FastInitTest.cc
@@ -11,6 +11,7 @@
 #include "comm.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
+#include "meta/NcclxConfig.h"
 #include "nccl.h"
 
 void printCommStateX(const ncclComm& comm) {
@@ -40,10 +41,14 @@ void validateCtranInitialization(
   EXPECT_EQ(comm->commHash, comm->ctranComm_->statex_->commHash());
 }
 
-ncclConfig_t ncclConfigInitHelper(bool enableFastInitConfig) {
+ncclConfig_t ncclConfigInitHelper(
+    bool enableFastInitConfig,
+    ncclx::Hints& hints) {
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
   if (enableFastInitConfig) {
-    config.fastInitMode = NCCL_FAST_INIT_MODE_RING;
+    hints = ncclx::Hints();
+    hints.set("fastInitMode", std::to_string(NCCL_FAST_INIT_MODE_RING));
+    config.hints = &hints;
   }
   return config;
 }
@@ -57,7 +62,8 @@ ncclResult_t ncclCommInitRankConfigHelper(
   if (!enableFastInitConfig) {
     return ncclCommInitRankConfig(comm, nRanks, commId, myRank, nullptr);
   } else {
-    ncclConfig_t config = ncclConfigInitHelper(enableFastInitConfig);
+    ncclx::Hints hints;
+    ncclConfig_t config = ncclConfigInitHelper(enableFastInitConfig, hints);
     return ncclCommInitRankConfig(comm, nRanks, commId, myRank, &config);
   }
 }
@@ -138,17 +144,28 @@ TEST_P(NcclxBaseTestFixture, NcclCommSplit) {
   validateCtranInitialization(rootComm, globalRank, numRanks, localRank);
 
   ncclComm_t childComm = nullptr;
-  ncclConfig_t childCommConfig = ncclConfigInitHelper(enableFastInitConfig);
+  ncclx::Hints fastInitHints;
+  ncclConfig_t childCommConfig =
+      ncclConfigInitHelper(enableFastInitConfig, fastInitHints);
   int color = globalRank % 2;
   std::string childCommDesc = "child_communicator_" + std::to_string(color);
-  childCommConfig.commDesc = childCommDesc.c_str();
   int groupSize = rootComm->ctranComm_->statex_.get()->nRanks() / 2;
   int* groupRanks = new int[groupSize];
   for (int i = 0; i < groupSize; ++i) {
     *(groupRanks + i) = 2 * i + globalRank % 2;
   }
-  childCommConfig.splitGroupRanks = groupRanks;
-  childCommConfig.splitGroupSize = groupSize;
+  ncclx::Hints splitHints;
+  splitHints.set("commDesc", childCommDesc);
+  {
+    std::string ranksStr;
+    for (int i = 0; i < groupSize; ++i) {
+      if (i > 0)
+        ranksStr += ",";
+      ranksStr += std::to_string(groupRanks[i]);
+    }
+    splitHints.set("splitGroupRanks", ranksStr);
+  }
+  childCommConfig.hints = &splitHints;
   NCCLCHECK_TEST(ncclCommSplit(
       rootComm, color, globalRank / 2, &childComm, &childCommConfig));
   ASSERT_NE(nullptr, childComm);
@@ -166,7 +183,9 @@ TEST_P(NcclxBaseTestFixture, NcclCommSplit) {
   EXPECT_EQ(statex1->nLocalRanks(), localSize / 2);
 
   ncclComm expectedComm;
-  expectedComm.config.commDesc = childCommConfig.commDesc;
+  auto* ncclxCfg = new ncclx::Config();
+  ncclxCfg->commDesc = childCommDesc;
+  expectedComm.config.ncclxConfig = ncclxCfg;
   setCtranCommBase(&expectedComm);
 
   expectedComm.ctranComm_->statex_ = std::make_unique<ncclx::CommStateX>(
@@ -204,17 +223,28 @@ TEST_P(NcclxBaseTestFixture, NcclCommSplitDuplicateGroups) {
   }
 
   // child comm config
-  ncclConfig_t childCommConfig = ncclConfigInitHelper(enableFastInitConfig);
+  ncclx::Hints fastInitHints;
+  ncclConfig_t childCommConfig =
+      ncclConfigInitHelper(enableFastInitConfig, fastInitHints);
   int color = globalRank % 2;
   std::string childCommDesc = "child_communicator_" + std::to_string(color);
-  childCommConfig.commDesc = childCommDesc.c_str();
   int groupSize = rootComm->ctranComm_->statex_.get()->nRanks() / 2;
   int* groupRanks = new int[groupSize];
   for (int i = 0; i < groupSize; ++i) {
     *(groupRanks + i) = 2 * i + globalRank % 2;
   }
-  childCommConfig.splitGroupRanks = groupRanks;
-  childCommConfig.splitGroupSize = groupSize;
+  ncclx::Hints dupSplitHints;
+  dupSplitHints.set("commDesc", childCommDesc);
+  {
+    std::string ranksStr;
+    for (int i = 0; i < groupSize; ++i) {
+      if (i > 0)
+        ranksStr += ",";
+      ranksStr += std::to_string(groupRanks[i]);
+    }
+    dupSplitHints.set("splitGroupRanks", ranksStr);
+  }
+  childCommConfig.hints = &dupSplitHints;
 
   ncclComm_t childComm1 = nullptr;
   NCCLCHECK_TEST(ncclCommSplit(
@@ -302,15 +332,26 @@ TEST_P(NcclxBaseTestFixture, ChildCommAllGather) {
   }
 
   ncclComm_t childComm = nullptr;
-  ncclConfig_t childCommConfig = ncclConfigInitHelper(enableFastInitConfig);
-  childCommConfig.commDesc = "child_communicator";
+  ncclx::Hints fastInitHints;
+  ncclConfig_t childCommConfig =
+      ncclConfigInitHelper(enableFastInitConfig, fastInitHints);
   int groupSize = rootComm->ctranComm_->statex_.get()->nRanks() / 2;
   int* groupRanks = new int[groupSize];
   for (int i = 0; i < groupSize; ++i) {
     *(groupRanks + i) = 2 * i + globalRank % 2;
   }
-  childCommConfig.splitGroupRanks = groupRanks;
-  childCommConfig.splitGroupSize = groupSize;
+  ncclx::Hints childAgHints;
+  childAgHints.set("commDesc", "child_communicator");
+  {
+    std::string ranksStr;
+    for (int i = 0; i < groupSize; ++i) {
+      if (i > 0)
+        ranksStr += ",";
+      ranksStr += std::to_string(groupRanks[i]);
+    }
+    childAgHints.set("splitGroupRanks", ranksStr);
+  }
+  childCommConfig.hints = &childAgHints;
   NCCLCHECK_TEST(ncclCommSplit(
       rootComm, globalRank % 2, globalRank / 2, &childComm, &childCommConfig));
   ASSERT_NE(nullptr, childComm);
@@ -358,10 +399,14 @@ TEST_P(NcclxBaseTestFixture, NcclCommSplitNoColor) {
   ncclComm_t rootComm = nullptr;
   ncclComm_t childComm = NCCL_COMM_NULL;
   ncclUniqueId commId;
-  ncclConfig_t rootConfig = ncclConfigInitHelper(enableFastInitConfig);
-  rootConfig.commDesc = "root_communicator";
-  ncclConfig_t childConfig = ncclConfigInitHelper(enableFastInitConfig);
-  childConfig.commDesc = "child_communicator";
+  ncclx::Hints fastInitHints;
+  ncclConfig_t rootConfig =
+      ncclConfigInitHelper(enableFastInitConfig, fastInitHints);
+  ncclx::Hints rootHints;
+  rootHints.set("commDesc", "root_communicator");
+  rootConfig.hints = &rootHints;
+  ncclConfig_t childConfig =
+      ncclConfigInitHelper(enableFastInitConfig, fastInitHints);
 
   NCCLCHECK_TEST(ncclCommInitRankConfig(
       &rootComm, numRanks, commId, globalRank, &rootConfig));
@@ -375,12 +420,23 @@ TEST_P(NcclxBaseTestFixture, NcclCommSplitNoColor) {
   EXPECT_EQ(statex->nRanks(), numRanks);
 
   // set up childConfig for split
-  childConfig.splitGroupSize = numRanks / 2;
-  std::vector<int> groupRanks(childConfig.splitGroupSize);
-  childConfig.splitGroupRanks = groupRanks.data();
-  for (int i = 0; i < childConfig.splitGroupSize; ++i) {
+  int splitGroupSize = numRanks / 2;
+  std::vector<int> groupRanks(splitGroupSize);
+  for (int i = 0; i < splitGroupSize; ++i) {
     groupRanks.at(i) = i * 2 + 1;
   }
+  ncclx::Hints childNoColorHints;
+  childNoColorHints.set("commDesc", "child_communicator");
+  {
+    std::string ranksStr;
+    for (int i = 0; i < splitGroupSize; ++i) {
+      if (i > 0)
+        ranksStr += ",";
+      ranksStr += std::to_string(groupRanks[i]);
+    }
+    childNoColorHints.set("splitGroupRanks", ranksStr);
+  }
+  childConfig.hints = &childNoColorHints;
   // do ncclCommSplit: even ranks have no color
   if (globalRank % 2 == 0) {
     NCCLCHECK_TEST(ncclCommSplit(
@@ -417,16 +473,23 @@ TEST_P(NcclxBaseTestFixture, NcclCommInitWithDifferentCommDesc) {
   ncclUniqueId commId1, commId2;
 
   // Create first comm with commDesc "comm_desc_1"
-  ncclConfig_t config1 = ncclConfigInitHelper(enableFastInitConfig);
-  config1.commDesc = "comm_desc_1";
+  ncclx::Hints fastInitHints;
+  ncclConfig_t config1 =
+      ncclConfigInitHelper(enableFastInitConfig, fastInitHints);
+  ncclx::Hints hints1;
+  hints1.set("commDesc", "comm_desc_1");
+  config1.hints = &hints1;
   NCCLCHECK_TEST(
       ncclCommInitRankConfig(&comm1, numRanks, commId1, globalRank, &config1));
   ASSERT_NE(nullptr, comm1);
   validateCtranInitialization(comm1, globalRank, numRanks, localRank);
 
   // Create second comm with commDesc "comm_desc_2"
-  ncclConfig_t config2 = ncclConfigInitHelper(enableFastInitConfig);
-  config2.commDesc = "comm_desc_2";
+  ncclConfig_t config2 =
+      ncclConfigInitHelper(enableFastInitConfig, fastInitHints);
+  ncclx::Hints hints2;
+  hints2.set("commDesc", "comm_desc_2");
+  config2.hints = &hints2;
   NCCLCHECK_TEST(
       ncclCommInitRankConfig(&comm2, numRanks, commId2, globalRank, &config2));
   ASSERT_NE(nullptr, comm2);

--- a/comms/ncclx/v2_27/meta/transport/tests/LazyConnectTest.cc
+++ b/comms/ncclx/v2_27/meta/transport/tests/LazyConnectTest.cc
@@ -9,6 +9,7 @@
 #include "comms/testinfra/TestsDistUtils.h"
 
 #include "comm.h"
+#include "meta/NcclxConfig.h"
 #include "nccl.h"
 
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -43,10 +44,14 @@ class NcclxLazyConnectTestFixture : public NcclxBaseTestFixture {
     NcclxBaseTestFixture::TearDown();
   }
 
+  ncclx::Hints splitCommHints_;
+
   void splitComm(ncclComm_t* newChildComm) {
     ncclComm_t childComm;
     ncclConfig_t childCommConfig = NCCL_CONFIG_INITIALIZER;
-    childCommConfig.commDesc = "child_communicator";
+    splitCommHints_ = ncclx::Hints();
+    splitCommHints_.set("commDesc", "child_communicator");
+    childCommConfig.hints = &splitCommHints_;
     // split rootComm into two communicators, in round-robin fashion
     // e.g. 8-rank rootComm ->
     //        ranks 0, 2, 4, 6 form 1st childComm
@@ -520,16 +525,18 @@ TEST_P(NcclxLazyConnectTestFixture, ChildCommLazyConfig) {
   // channels
   ncclComm_t childComm = nullptr;
   ncclConfig_t childCommConfig = NCCL_CONFIG_INITIALIZER;
-  childCommConfig.lazyConnect = 1;
-  childCommConfig.lazySetupChannels = 1;
+  ncclx::Hints lazyHints;
+  lazyHints.set("lazyConnect", "1");
+  lazyHints.set("lazySetupChannels", "1");
+  childCommConfig.hints = &lazyHints;
   NCCLCHECK_TEST(
       ncclCommSplit(rootComm, 0, globalRank, &childComm, &childCommConfig));
   ASSERT_NE(nullptr, childComm);
 
   // child comm should always have lazy connect and setup channels enabled and
   // not allocate any channels
-  EXPECT_EQ(childComm->config.lazyConnect, 1);
-  EXPECT_EQ(childComm->config.lazySetupChannels, 1);
+  EXPECT_TRUE(NCCLX_CONFIG_FIELD(childComm->config, lazyConnect));
+  EXPECT_TRUE(NCCLX_CONFIG_FIELD(childComm->config, lazySetupChannels));
   for (int a = 0; a < NCCL_NUM_ALGORITHMS; a++) {
     EXPECT_FALSE(childComm->initAlgoChannels[a]);
   }

--- a/comms/ncclx/v2_27/meta/transport/transportConnect.cc
+++ b/comms/ncclx/v2_27/meta/transport/transportConnect.cc
@@ -3,6 +3,7 @@
 #include "bootstrap.h"
 #include "channel.h"
 #include "group.h"
+#include "meta/NcclxConfig.h" // @manual
 #include "p2p.h"
 #include "transport.h"
 
@@ -44,7 +45,8 @@ ncclResult_t transportRingConnect(struct ncclComm* comm, int nChannels) {
     INFO(
         NCCL_INIT,
         "commDesc: %s set up P2P connections for rings with %s on channel %d",
-        ctran::utils::parseCommDesc(comm->config.commDesc),
+        ctran::utils::parseCommDesc(
+            NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()),
         ringSummary.toString().c_str(),
         c);
   }
@@ -77,7 +79,8 @@ ncclResult_t transportRingConnect(struct ncclComm* comm, int nChannels) {
   INFO(
       NCCL_INIT,
       "commDesc: %s connected rings from channel %d to %d, use ring PXN %d GDR %d",
-      ctran::utils::parseCommDesc(comm->config.commDesc),
+      ctran::utils::parseCommDesc(
+          NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()),
       comm->algoConnectedChannels[NCCL_ALGO_RING],
       nChannels - 1,
       comm->useNetPXN,
@@ -108,7 +111,8 @@ ncclResult_t transportTreeConnect(struct ncclComm* comm, int nChannels) {
     INFO(
         NCCL_INIT,
         "commDesc: %s set up P2P connections for tree downward connections with %s on channel %d",
-        ctran::utils::parseCommDesc(comm->config.commDesc),
+        ctran::utils::parseCommDesc(
+            NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()),
         treeUpwardSummary.toString().c_str(),
         c);
     connectionSummary treeDownwardSummary;
@@ -124,7 +128,8 @@ ncclResult_t transportTreeConnect(struct ncclComm* comm, int nChannels) {
     INFO(
         NCCL_INIT,
         "commDesc: %s set up P2P connections for tree upward connections with %s on channel %d",
-        ctran::utils::parseCommDesc(comm->config.commDesc),
+        ctran::utils::parseCommDesc(
+            NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()),
         treeDownwardSummary.toString().c_str(),
         c);
   }
@@ -132,7 +137,8 @@ ncclResult_t transportTreeConnect(struct ncclComm* comm, int nChannels) {
   INFO(
       NCCL_INIT,
       "commDesc: %s connected Trees from channel %d to %d",
-      ctran::utils::parseCommDesc(comm->config.commDesc),
+      ctran::utils::parseCommDesc(
+          NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()),
       comm->algoConnectedChannels[NCCL_ALGO_TREE],
       nChannels - 1);
   comm->algoConnectedChannels[NCCL_ALGO_TREE] = nChannels;
@@ -163,7 +169,8 @@ ncclResult_t transportPatConnect(struct ncclComm* comm, int nChannels) {
       INFO(
           NCCL_INIT,
           "commDesc: %s set up P2P connections for RS binomial trees with %s on channel %d",
-          ctran::utils::parseCommDesc(comm->config.commDesc),
+          ctran::utils::parseCommDesc(
+              NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()),
           rsSummary.toString().c_str(),
           c);
     }
@@ -183,7 +190,8 @@ ncclResult_t transportPatConnect(struct ncclComm* comm, int nChannels) {
       INFO(
           NCCL_INIT,
           "commDesc: %s set up P2P connections for AG binomial trees with %s on channel %d",
-          ctran::utils::parseCommDesc(comm->config.commDesc),
+          ctran::utils::parseCommDesc(
+              NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()),
           agSummary.toString().c_str(),
           c);
     }
@@ -192,7 +200,8 @@ ncclResult_t transportPatConnect(struct ncclComm* comm, int nChannels) {
   INFO(
       NCCL_INIT,
       "commDesc %s connected binomial trees channel from %d to %d",
-      ctran::utils::parseCommDesc(comm->config.commDesc),
+      ctran::utils::parseCommDesc(
+          NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()),
       comm->algoConnectedChannels[NCCL_ALGO_PAT],
       nChannels - 1);
   comm->algoConnectedChannels[NCCL_ALGO_PAT] = nChannels;
@@ -244,7 +253,8 @@ bool algoNeedConnect(struct ncclComm* comm, struct ncclTaskColl* task) {
     INFO(
         NCCL_INIT,
         "commDesc: %s commHash: %lx needs nChannels=%d (%d initialized) for op %s with %lu bytes using algo %s and protocol %s, (%d channels connected) %d total channels will be connected for this algo",
-        ctran::utils::parseCommDesc(comm->config.commDesc),
+        ctran::utils::parseCommDesc(
+            NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()),
         comm->commHash,
         task->nMaxChannels,
         comm->nChannelsReady,
@@ -275,7 +285,8 @@ void p2pNeedConnect(
   INFO(
       NCCL_INIT,
       "commDesc %s: commHash: %lx Channel-%d try %s connection setup for peer %d, nMaxChannelsNeedInit: %d",
-      ctran::utils::parseCommDesc(comm->config.commDesc),
+      ctran::utils::parseCommDesc(
+          NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()),
       comm->commHash,
       channelId,
       isSendNotRecv ? "send" : "recv",
@@ -291,7 +302,8 @@ ncclResult_t devCommSetupChannels(ncclComm_t comm) {
   INFO(
       NCCL_INIT,
       "commDesc: %s commHash: %lx devCommSetupChannels: copy channels' metadata, comm->nChannelsReady=%d",
-      ctran::utils::parseCommDesc(comm->config.commDesc),
+      ctran::utils::parseCommDesc(
+          NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()),
       comm->commHash,
       comm->nChannelsReady);
   auto sampleGuardBegin = EVENTS_SCUBA_UTIL_SAMPLE_GUARD("INIT");
@@ -360,7 +372,8 @@ ncclResult_t setupChannels(struct ncclComm* comm, int maxNchannels) {
   INFO(
       NCCL_INIT,
       "commDesc: %s: commHash: %lx setup %d channels and copy metadata to GPU from channel %d to %d",
-      ctran::utils::parseCommDesc(comm->config.commDesc),
+      ctran::utils::parseCommDesc(
+          NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()),
       comm->commHash,
       (maxNchannels - comm->nChannelsReady),
       comm->nChannelsReady,
@@ -637,7 +650,7 @@ ncclResult_t transportReConnect(
         ALLOC,
         "{}: comm {} re-connected all peers for current plan",
         __func__,
-        comm->config.commDesc);
+        NCCLX_CONFIG_FIELD(comm->config, commDesc));
     reqBufKeys.insert(
         reqBufKeys.end(),
         comm->connSetupBufKeys.begin(),
@@ -768,7 +781,8 @@ ncclResult_t p2pPreconnect(struct ncclComm* comm) {
   INFO(
       NCCL_INIT,
       "commDesc: %s new p2p send/recv needs to connect",
-      ctran::utils::parseCommDesc(comm->config.commDesc));
+      ctran::utils::parseCommDesc(
+          NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()));
   CUDACHECK(cudaSetDevice(comm->cudaDev));
   if (CPU_COUNT(&comm->cpuAffinity)) {
     sched_setaffinity(0, sizeof(cpu_set_t), &comm->cpuAffinity);
@@ -787,7 +801,8 @@ ncclResult_t p2pPreconnect(struct ncclComm* comm) {
   INFO(
       NCCL_INIT,
       "commDesc: %s new p2p send/recv finished preconnect",
-      ctran::utils::parseCommDesc(comm->config.commDesc));
+      ctran::utils::parseCommDesc(
+          NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()));
   return ncclSuccess;
 }
 
@@ -798,7 +813,8 @@ ncclResult_t collPreconnect(
   INFO(
       NCCL_INIT,
       "commDesc: %s new collective needs to connect",
-      ctran::utils::parseCommDesc(comm->config.commDesc));
+      ctran::utils::parseCommDesc(
+          NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()));
   CUDACHECK(cudaSetDevice(comm->cudaDev));
   if (CPU_COUNT(&comm->cpuAffinity)) {
     sched_setaffinity(0, sizeof(cpu_set_t), &comm->cpuAffinity);
@@ -857,7 +873,8 @@ ncclResult_t collPreconnect(
   INFO(
       NCCL_INIT,
       "commDesc: %s new collective finished preconnect",
-      ctran::utils::parseCommDesc(comm->config.commDesc));
+      ctran::utils::parseCommDesc(
+          NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()));
 
   return ret;
 }

--- a/comms/ncclx/v2_27/meta/transport/transportProxy.cc
+++ b/comms/ncclx/v2_27/meta/transport/transportProxy.cc
@@ -3,6 +3,7 @@
 // TODO: Migrate to comms/ctran/utils/Alloc.h once we implement
 // "ncclCuMemHostAlloc" equivalent
 #include "alloc.h"
+#include "meta/NcclxConfig.h" // @manual
 
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/utils/Utils.h"
@@ -179,7 +180,7 @@ commResult_t TransportProxy::enqueuePrepRequest(
       COLL,
       "{}: Enqueued request to prepare resources for current kernel plan: "
       "opCount={} (comm->opCount={}),channelMask={:x}, channelsReadyPtr={}({:#x})",
-      comm->config.commDesc,
+      NCCLX_CONFIG_FIELD(comm->config, commDesc),
       opCount,
       comm->opCount,
       channelMask,
@@ -260,7 +261,8 @@ void TransportProxy::testAny() {
           COLL,
           "Releasing {} bufKeys for comm {}",
           req->bufKeys.size(),
-          ctran::utils::parseCommDesc(req->comm->config.commDesc));
+          ctran::utils::parseCommDesc(
+              NCCLX_CONFIG_FIELD(req->comm->config, commDesc).c_str()));
       syncFlagPool_.push_back(ptr);
       req->state = commSuccess;
       CLOGF_SUBSYS(
@@ -319,7 +321,7 @@ void TransportProxy::prepResources(std::shared_ptr<TransportRequest> req) {
       INFO,
       COLL,
       "{}: Transport is ready for reqCount={}, req->channelMask={:x}, req->channelsReadyPtr={:x} ({:#x})",
-      req->comm->config.commDesc,
+      NCCLX_CONFIG_FIELD(req->comm->config, commDesc),
       req->opCount,
       req->channelMask,
       *req->channelsReadyPtr,

--- a/comms/ncclx/v2_27/meta/wrapper/CtranExComm.cc
+++ b/comms/ncclx/v2_27/meta/wrapper/CtranExComm.cc
@@ -2,6 +2,7 @@
 
 #include "checks.h"
 #include "comm.h"
+#include "meta/NcclxConfig.h" // @manual
 
 #include "comms/ctran/Ctran.h"
 #include "comms/ctran/CtranEx.h"
@@ -27,15 +28,23 @@ CtranExComm::CtranExComm(const ncclComm_t comm, const std::string& commDesc) {
   comm_ = NCCL_COMM_NULL;
 
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
-  config.commDesc = commDesc.c_str();
+  config.blocking = 1; // Ensure communicator is fully created upon return
+
+  ncclx::Hints hints;
+  hints.set("commDesc", commDesc);
   std::vector<int> globalRanks =
       comm->ctranComm_->statex_->commRanksToWorldRanksRef();
-  config.splitGroupRanks = globalRanks.data();
-  config.splitGroupSize = comm->ctranComm_->statex_->nRanks();
-  config.blocking = 1; // Ensure communicator is fully created upon return
-  // Enable lazy features to avoid allocating extra resources from baseline NCCL
-  config.lazyConnect = 1;
-  config.lazySetupChannels = 1;
+  std::string ranksStr;
+  for (size_t i = 0; i < globalRanks.size(); ++i) {
+    if (i > 0) {
+      ranksStr += ",";
+    }
+    ranksStr += std::to_string(globalRanks[i]);
+  }
+  hints.set("splitGroupRanks", ranksStr);
+  hints.set("lazyConnect", "1");
+  hints.set("lazySetupChannels", "1");
+  config.hints = &hints;
 
   // if parent comm is non-blocking, ncclCommSplit will be non-blocking
   // as well which would lead to undefined behavior. Adding a throw here to
@@ -44,7 +53,7 @@ CtranExComm::CtranExComm(const ncclComm_t comm, const std::string& commDesc) {
     CLOGF(
         ERR,
         "CTRAN-EX: parent communicator {} is non-blocking, which will cause CtranExComm commSplit to fail.",
-        comm->config.commDesc);
+        NCCLX_CONFIG_FIELD(comm->config, commDesc));
     throw std::runtime_error("CTRAN-EX: parent communicator is non-blocking");
   }
 

--- a/comms/ncclx/v2_27/meta/wrapper/MetaFactory.cc
+++ b/comms/ncclx/v2_27/meta/wrapper/MetaFactory.cc
@@ -8,6 +8,7 @@
 #include "comms/ctran/window/WinHintUtils.h"
 #include "comms/utils/checks.h"
 #include "comms/utils/commSpecs.h"
+#include "meta/NcclxConfig.h" // @manual
 #include "meta/wrapper/MetaFactory.h"
 
 using namespace ctran;
@@ -215,8 +216,9 @@ meta::comms::Hints ncclToMetaComm(const ncclx::Hints& hints) {
 ctranConfig makeCtranConfigFrom(ncclComm* comm) {
   struct ctranConfig tconfig = {
       .blocking = comm->config.blocking,
-      .commDesc = comm->config.commDesc ? comm->config.commDesc : "undefined",
-      .ncclAllGatherAlgo = comm->config.ncclAllGatherAlgo,
+      .commDesc = NCCLX_CONFIG_FIELD(comm->config, commDesc),
+      .ncclAllGatherAlgo =
+          NCCLX_CONFIG_FIELD(comm->config, ncclAllGatherAlgo).c_str(),
   };
   return tconfig;
 }

--- a/comms/ncclx/v2_27/meta/wrapper/tests/CtranExDistCommUT.cc
+++ b/comms/ncclx/v2_27/meta/wrapper/tests/CtranExDistCommUT.cc
@@ -69,7 +69,9 @@ TEST_F(CtranExCommTest, TestNonBlockingThrow) {
   ncclComm_t nonBlockingComm;
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
   config.blocking = 0;
-  config.commDesc = "nonBlockingParent";
+  ncclx::Hints nbHints;
+  nbHints.set("commDesc", "nonBlockingParent");
+  config.hints = &nbHints;
   ncclUniqueId id;
   // get NCCL unique ID at rank 0 and broadcast it to all others
   if (globalRank == 0) {

--- a/comms/ncclx/v2_27/src/bootstrap.cc
+++ b/comms/ncclx/v2_27/src/bootstrap.cc
@@ -5,6 +5,7 @@
  ************************************************************************/
 
 #include "nccl.h"
+#include "meta/NcclxConfig.h" // @manual
 #include "core.h"
 #include "utils.h"
 #include "bootstrap.h"
@@ -618,7 +619,7 @@ ncclResult_t formRingViaTcpStore(bootstrapState* state, ncclComm* comm) {
   myFollyAddr.setFromSockaddr(reinterpret_cast<sockaddr*>(&listenSockAddr), sizeof(listenSockAddr));
   INFO(NCCL_INIT, "rank %d listen on %s: %s", rank, bootstrapNetIfName, myFollyAddr.describe().c_str());
 
-  const std::string kKeyPrefix = std::string(kTcpStoreAddrKeyPrefix) + comm->config.commDesc + "-";
+  const std::string kKeyPrefix = std::string(kTcpStoreAddrKeyPrefix) + NCCLX_CONFIG_FIELD(comm->config, commDesc) + "-";
 
   // put my-rank's listenSockAddr e.g <rank0, info.extAddressListen>
   std::string myKey = kKeyPrefix + std::to_string(rank);
@@ -681,7 +682,7 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm) {
   state->abortFlag = comm->abortFlag;
   state->net = comm->ncclNet;
   state->logMetaDataPtr = &comm->logMetaData;
-  state->fastInitMode = comm->config.fastInitMode;
+  state->fastInitMode = NCCLX_CONFIG_FIELD(comm->config, fastInitMode);
   comm->bootstrap = state;
   comm->magic = state->magic = BOOTSTRAP_HANDLE(handles, 0)->magic; // state and comm magic set to the first magic ID
 
@@ -846,7 +847,7 @@ ncclResult_t bootstrapSplit(uint64_t magic, struct ncclComm* comm, struct ncclCo
   state->cudaDev = comm->cudaDev;
   state->abortFlag = comm->abortFlag;
   state->net = comm->ncclNet;
-  state->fastInitMode = comm->config.fastInitMode;
+  state->fastInitMode = NCCLX_CONFIG_FIELD(comm->config, fastInitMode);
   comm->bootstrap = state;
   comm->magic = state->magic = magic;
 

--- a/comms/ncclx/v2_27/src/enqueue.cc
+++ b/comms/ncclx/v2_27/src/enqueue.cc
@@ -5,6 +5,7 @@
  ************************************************************************/
 
 #include "enqueue.h"
+#include "meta/NcclxConfig.h" // @manual
 #include "argcheck.h"
 #include "coll_net.h"
 #include "gdrwrap.h"
@@ -2470,7 +2471,7 @@ ncclResult_t ncclEnqueueCheck(struct ncclInfo* info) {
 
   INFO(NCCL_COLL,"%s: opCount %lx sendbuff %p recvbuff %p count %zu datatype %d op %d root %d comm %p commHash %lx commDesc %s [nranks=%d, nNodes=%d] stream %p",
         info->opName, info->comm->opCount, info->sendbuff, info->recvbuff, info->count,
-        info->datatype, info->op, info->root, info->comm, info->comm->commHash, info->comm->config.commDesc, info->comm->nRanks, info->comm->nNodes, info->stream);
+        info->datatype, info->op, info->root, info->comm, info->comm->commHash, NCCLX_CONFIG_FIELD(info->comm->config, commDesc).c_str(), info->comm->nRanks, info->comm->nNodes, info->stream);
   TRACE_CALL("nccl%s(%" PRIx64 ",%" PRIx64 ",%zu,%d,%d,%d,%p,%p)", info->opName, reinterpret_cast<int64_t>(info->sendbuff), reinterpret_cast<int64_t>(info->recvbuff), info->count, info->datatype, info->op, info->root, info->comm, info->stream);
 
   NCCLCHECKGOTO(taskAppend(info->comm, info), ret, fail);

--- a/comms/ncclx/v2_27/src/group.cc
+++ b/comms/ncclx/v2_27/src/group.cc
@@ -5,6 +5,7 @@
  ************************************************************************/
 
 #include "group.h"
+#include "meta/NcclxConfig.h" // @manual
 #include "debug.h"
 #include "enqueue.h"
 #include "transport.h"
@@ -136,7 +137,7 @@ struct ncclPreconnectJob {
 ncclResult_t ncclP2PPreconnectFunc(struct ncclAsyncJob* job_) {
   struct ncclPreconnectJob* job = (struct ncclPreconnectJob*)job_;
   struct ncclComm* comm = job->comm;
-  INFO(NCCL_INIT, "commDesc: %s new p2p send/recv needs to connect", ctran::utils::parseCommDesc(comm->config.commDesc));
+  INFO(NCCL_INIT, "commDesc: %s new p2p send/recv needs to connect", ctran::utils::parseCommDesc(NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()));
   CUDACHECK(cudaSetDevice(comm->cudaDev));
   if (CPU_COUNT(&comm->cpuAffinity)) sched_setaffinity(0, sizeof(cpu_set_t), &comm->cpuAffinity);
   // setup channels if needed before setup transport
@@ -148,7 +149,7 @@ ncclResult_t ncclP2PPreconnectFunc(struct ncclAsyncJob* job_) {
   initEvent.lapAndRecord("p2pPreconnectFunc START");
   NCCLCHECK(ncclTransportP2pSetup(comm, NULL, 1));
   initEvent.lapAndRecord("p2pPreconnectFunc COMPLETE");
-  INFO(NCCL_INIT, "commDesc: %s new p2p send/recv finished preconnect", ctran::utils::parseCommDesc(comm->config.commDesc));
+  INFO(NCCL_INIT, "commDesc: %s new p2p send/recv finished preconnect", ctran::utils::parseCommDesc(NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()));
   return ncclSuccess;
 }
 
@@ -156,7 +157,7 @@ ncclResult_t ncclCollPreconnectFunc(struct ncclAsyncJob* job_) {
   struct ncclPreconnectJob* job = (struct ncclPreconnectJob*)job_;
   struct ncclComm* comm = job->comm;
   ncclResult_t ret = ncclSuccess;
-  INFO(NCCL_INIT, "commDesc: %s new collective needs to connect", ctran::utils::parseCommDesc(comm->config.commDesc));
+  INFO(NCCL_INIT, "commDesc: %s new collective needs to connect", ctran::utils::parseCommDesc(NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()));
   CUDACHECK(cudaSetDevice(comm->cudaDev));
   if (CPU_COUNT(&comm->cpuAffinity)) sched_setaffinity(0, sizeof(cpu_set_t), &comm->cpuAffinity);
   // setup channels if needed before setup transport
@@ -211,7 +212,7 @@ ncclResult_t ncclCollPreconnectFunc(struct ncclAsyncJob* job_) {
       initEvent.lapAndRecord(collpreStage + " COMPLETE");
     }
   }
-  INFO(NCCL_INIT, "commDesc: %s new collective finished preconnect", ctran::utils::parseCommDesc(comm->config.commDesc));
+  INFO(NCCL_INIT, "commDesc: %s new collective finished preconnect", ctran::utils::parseCommDesc(NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()));
 
 exit:
   free(job->algoNeedConnect);
@@ -326,7 +327,7 @@ static ncclResult_t doLaunches(struct ncclComm* head) {
             CUDACHECKGOTO(cudaSetDevice(comm->cudaDev), result, failure);
             NCCLCHECKGOTO(ncclLaunchKernelBefore_NoUncapturedCuda(comm, plan), result, failure);
             NCCLCHECKGOTO(ncclLaunchKernel(comm, plan), result, failure);
-            INFO(NCCL_COLL, "comm %s %p opCount %ld launched kernel for plan %p",  ctran::utils::parseCommDesc(comm->config.commDesc), comm, comm->opCount, plan);
+            INFO(NCCL_COLL, "comm %s %p opCount %ld launched kernel for plan %p",  ctran::utils::parseCommDesc(NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()), comm, comm->opCount, plan);
             // NOTE: bump up opCount right after launching kernel as this field is dedicated to track number of kernels
             // including both p2p and collective kernels, no matter proxyOp existance.
             // Known limitation: It won't be updated properly under cuda graph replay since it is not captured by the graph.
@@ -341,7 +342,7 @@ static ncclResult_t doLaunches(struct ncclComm* head) {
         } else { // Final round.
           CUDACHECKGOTO(cudaSetDevice(comm->cudaDev), result, failure);
           NCCLCHECKGOTO(ncclLaunchFinish(comm), result, failure);
-          INFO(NCCL_COLL, "comm %s opCount %ld finished launching kernel",  ctran::utils::parseCommDesc(comm->config.commDesc), comm->opCount);
+          INFO(NCCL_COLL, "comm %s opCount %ld finished launching kernel",  ctran::utils::parseCommDesc(NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()), comm->opCount);
         }
         comm = next;
       } while (comm != cliqueNextHead);

--- a/comms/ncclx/v2_27/src/include/bootstrap.h
+++ b/comms/ncclx/v2_27/src/include/bootstrap.h
@@ -65,7 +65,7 @@ struct bootstrapState {
 
   // Reference to CommLogData to object to facilicate logging
   struct CommLogData *logMetaDataPtr{nullptr};
-  int fastInitMode{NCCL_FAST_INIT_MODE_DEFAULT};
+  bool fastInitMode{false};
 };
 
 ncclResult_t bootstrapNetInit();

--- a/comms/ncclx/v2_27/src/include/utils.h
+++ b/comms/ncclx/v2_27/src/include/utils.h
@@ -31,7 +31,7 @@ uint64_t getHostHash();
 uint64_t getPidHash();
 ncclResult_t getRandomData(void* buffer, size_t bytes);
 
-bool isFastInitRingMode(int fastInitMode);
+bool isFastInitRingMode(bool fastInitMode);
 
 struct netIf {
   char prefix[64];

--- a/comms/ncclx/v2_27/src/init.cc
+++ b/comms/ncclx/v2_27/src/init.cc
@@ -5,6 +5,7 @@
  ************************************************************************/
 
 #include "nccl.h"
+#include "meta/NcclxConfig.h" // @manual
 #include "channel.h"
 #include "nvmlwrap.h"
 #include "gdrwrap.h"
@@ -31,6 +32,11 @@
 #include "param.h"
 #include "nvtx_payload_schemas.h"
 #include "utils.h"
+#include <algorithm>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
 
 #include "comms/ctran/Ctran.h"
 #include "meta/commstate/FactoryCommStateX.h"
@@ -188,9 +194,11 @@ void ncclCommPushCudaGdrFree(struct ncclComm* comm, void* handle) {
 
 // Free NCCLX-specific resources
 static void ncclxCommFree(ncclComm_t comm) {
-  if (comm->config.ncclAllGatherAlgo) {
-    free((void*)comm->config.ncclAllGatherAlgo);
-  }
+  // Free the canonical ncclx::Config
+  auto* ncclxCfg =
+      static_cast<ncclx::Config*>(comm->config.ncclxConfig);
+  delete ncclxCfg;
+  comm->config.ncclxConfig = nullptr;
   // dereference memory cache allocator, this has to be done after
   // proxy thread is destroryed in commFree
   if (comm->memCache) {
@@ -838,9 +846,9 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   timers[TIMER_INIT_ALLGATHER] = clockNano() - timers[TIMER_INIT_ALLGATHER];
 
   // Check for lazy channel setup support
-  comm->lazySetupChannels = comm->cuMemSupport && comm->config.lazySetupChannels;
+  comm->lazySetupChannels = comm->cuMemSupport && NCCLX_CONFIG_FIELD(comm->config, lazySetupChannels);
   // Check for runtime connect support
-  comm->runtimeConn = comm->cuMemSupport && comm->config.lazyConnect;
+  comm->runtimeConn = comm->cuMemSupport && NCCLX_CONFIG_FIELD(comm->config, lazyConnect);
 
   if (comm->runtimeConn == 0 && comm->lazySetupChannels == 1) {
     WARN("NCCL_RUNTIME_CONNECT is disabled but NCCL_LAZY_SETUP_CHANNELS is enabled, full lazy connect features will still be used");
@@ -1093,7 +1101,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   }
 
   INFO(NCCL_INIT, "commDesc: %s, commHash:%lx, comm %p rank %d nRanks %d nNodes %d localRanks %d localRank %d MNNVL %d",
-       ctran::utils::parseCommDesc(comm->config.commDesc), comm->commHash, comm, rank, comm->nRanks, comm->nNodes, comm->localRanks, comm->localRank, comm->MNNVL);
+       ctran::utils::parseCommDesc(NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()), comm->commHash, comm, rank, comm->nRanks, comm->nNodes, comm->localRanks, comm->localRank, comm->MNNVL);
 
   nChannelsOrig = comm->nChannels;
   NCCLCHECKGOTO(ncclCalloc(&allTopoRanks, comm->nRanks), ret, fail);
@@ -1148,7 +1156,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
     INFO(NCCL_GRAPH, "Ring %02d : %d -> %d -> %d", c, comm->channels[c].ring.prev, comm->rank, comm->channels[c].ring.next);
   }
   line[1023] = '\0';
-  INFO(NCCL_INIT, "commDesc: %s Trees%s", ctran::utils::parseCommDesc(comm->config.commDesc), line);
+  INFO(NCCL_INIT, "commDesc: %s Trees%s", ctran::utils::parseCommDesc(NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()), line);
 
   NCCLCHECKGOTO(computeBuffSizes(comm), ret, fail);
 
@@ -1245,7 +1253,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   if (comm->lazySetupChannels) {
     INFO(
         NCCL_INIT,
-        "commDesc: %s NCCL_LAZY_SETUP_CHANNELS=true, initializing minimal required channels at runtime when needed", ctran::utils::parseCommDesc(comm->config.commDesc));
+        "commDesc: %s NCCL_LAZY_SETUP_CHANNELS=true, initializing minimal required channels at runtime when needed", ctran::utils::parseCommDesc(NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()));
     // cache the ring info to be used for setupChannel later when needed
     comm->rings = std::vector<int>(rings, rings + nranks * MAXCHANNELS);
   } else if (comm->runtimeConn) {
@@ -1331,7 +1339,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   // Compute time models for algorithm and protocol combinations
   NCCLCHECKGOTO(ncclTopoTuneModel(comm, comm->minCompCap, comm->maxCompCap, graphs), ret, fail);
 
-  INFO(NCCL_INIT, "commDesc: %s, commHash: %lx, %d coll channels, %d collnet channels, %d nvls channels, %d p2p channels, %d p2p channels per peer", ctran::utils::parseCommDesc(comm->config.commDesc), comm->commHash, comm->nChannels, comm->nChannels, comm->nvlsChannels, comm->p2pnChannels, comm->p2pnChannelsPerPeer);
+  INFO(NCCL_INIT, "commDesc: %s, commHash: %lx, %d coll channels, %d collnet channels, %d nvls channels, %d p2p channels, %d p2p channels per peer", ctran::utils::parseCommDesc(NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()), comm->commHash, comm->nChannels, comm->nChannels, comm->nvlsChannels, comm->p2pnChannels, comm->p2pnChannelsPerPeer);
 
   if (comm->intraRank == 0) { // Load ncclParamLaunchMode
     const char* str = NCCL_LAUNCH_MODE.c_str();
@@ -1479,14 +1487,14 @@ static ncclResult_t ncclxCommGetSplitInfo(struct ncclComm* comm, struct ncclComm
     return ncclSuccess;
   }
   CHECKABORT(
-      comm && comm->config.splitGroupRanks && comm->config.splitGroupSize > 0,
-      "Empty comm or undefined config of splitGroupRanks or splitGroupSize passed to ncclxCommGetSplitInfo");
+      comm && !NCCLX_CONFIG_FIELD(comm->config, splitGroupRanks).empty(),
+      "Empty comm or undefined config of splitGroupRanks passed to ncclxCommGetSplitInfo");
 
-  *nRanksRet = comm->config.splitGroupSize;
+  *nRanksRet = static_cast<int>(NCCLX_CONFIG_FIELD(comm->config, splitGroupRanks).size());
   *myRankRet = -1;
-  for (int i = 0; i < comm->config.splitGroupSize; i++) {
-    parentRanksRet[i] = comm->config.splitGroupRanks[i];
-    if (parent->rank == comm->config.splitGroupRanks[i]) {
+  for (size_t i = 0; i < NCCLX_CONFIG_FIELD(comm->config, splitGroupRanks).size(); i++) {
+    parentRanksRet[i] = NCCLX_CONFIG_FIELD(comm->config, splitGroupRanks)[i];
+    if (parent->rank == NCCLX_CONFIG_FIELD(comm->config, splitGroupRanks)[i]) {
       *myRankRet = i;
     }
   }
@@ -1509,7 +1517,7 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
   CommLogData commLogData{
     job->parent ? 0 : getHash(job->commId, NCCL_UNIQUE_ID_BYTES),
     job->parent ? 0 : getHash(job->commId->internal, NCCL_UNIQUE_ID_BYTES),
-    comm && comm->config.commDesc ? comm->config.commDesc : "", job->myrank, job->nranks};
+    comm ? NCCLX_CONFIG_FIELD(comm->config, commDesc) : "", job->myrank, job->nranks};
   NcclScubaEvent commInitFuncEvent(&commLogData);
   NcclScubaEvent initBootstrapEvent(&commLogData);
 
@@ -1546,7 +1554,7 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
     if (job->excludeRanksCount) {
       NCCLCHECKGOTO(getParentRanks(job->parent->nRanks, job->parent->rank, job->excludeRanksList, job->excludeRanksCount, &job->nranks, &job->myrank, parentRanks), res, fail);
     } else {
-      if (isFastInitRingMode(job->parent->config.fastInitMode)) {
+      if (isFastInitRingMode(NCCLX_CONFIG_FIELD(job->parent->config, fastInitMode))) {
         NCCLCHECKGOTO(ncclxCommGetSplitInfo(comm, job->parent, job->color, job->key, &job->nranks, &job->myrank, parentRanks), res, fail);
       } else {
         NCCLCHECKGOTO(commGetSplitInfo(comm, job->parent, job->color, job->key, &job->nranks, &job->myrank, parentRanks), res, fail);
@@ -1578,7 +1586,7 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
     comm->commHash = commIdHash = getHash(job->commId->internal, NCCL_UNIQUE_ID_BYTES);
     // [Meta] Fast-init mode won't get unique commId for different communicators
     // use ctran helper function to generate unique hash
-    if (isFastInitRingMode(comm->config.fastInitMode)) {
+    if (isFastInitRingMode(NCCLX_CONFIG_FIELD(comm->config, fastInitMode))) {
       comm->commHash = commIdHash = ctran::utils::generateCommHash(job->nranks);
     }
     INFO(NCCL_INIT, "%s comm %p rank %d nranks %d cudaDev %d nvmlDev %d busId %lx commId 0x%llx - Init START", job->funcName,
@@ -1593,7 +1601,7 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
   // init this communicator's  Logger fields
   comm->logMetaData.commId = commIdHash;
   comm->logMetaData.commHash = comm->commHash;
-  comm->logMetaData.commDesc = comm->config.commDesc ? comm->config.commDesc : "undefined";
+  comm->logMetaData.commDesc = NCCLX_CONFIG_FIELD(comm->config, commDesc);
   comm->logMetaData.rank = comm->rank;
   comm->logMetaData.nRanks = comm->nRanks;
    if (NCCL_MEM_USE_SLAB_ALLOCATOR) {
@@ -1675,12 +1683,12 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
     /* unlink child abort flag. */
     __atomic_store_n(&job->parent->childAbortFlag, NULL, __ATOMIC_RELEASE);
     TRACE_CALL("ncclCommSplit(%p, %d, %d, %p, %d, %d)", job->parent, job->color, job->key, comm, comm->rank, comm->nRanks);
-    INFO(NCCL_INIT, "commDesc: %s comm %p rank %d nranks %d cudaDev %d nvmlDev %d busId %lx parent %p splitCount %d color %d key %d - Init COMPLETE", ctran::utils::parseCommDesc(comm->config.commDesc),
+    INFO(NCCL_INIT, "commDesc: %s comm %p rank %d nranks %d cudaDev %d nvmlDev %d busId %lx parent %p splitCount %d color %d key %d - Init COMPLETE", ctran::utils::parseCommDesc(NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()),
          comm, comm->rank, comm->nRanks, comm->cudaDev, comm->nvmlDev, comm->busId, job->parent, job->splitCount, job->color, job->key);
   } else {
     // the name for the replay tool is ncclCommInitRank for all the variations
     TRACE_CALL("ncclCommInitRank(%p, %d, 0x%llx, %d, %d)", comm, comm->nRanks, commIdHash, comm->rank, comm->cudaDev);
-    INFO(NCCL_INIT, "commDesc: %s comm %p rank %d nranks %d cudaDev %d nvmlDev %d busId %lx commId 0x%llx - Init COMPLETE", ctran::utils::parseCommDesc(comm->config.commDesc),
+    INFO(NCCL_INIT, "commDesc: %s comm %p rank %d nranks %d cudaDev %d nvmlDev %d busId %lx commId 0x%llx - Init COMPLETE", ctran::utils::parseCommDesc(NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()),
          comm, comm->rank, comm->nRanks, comm->cudaDev, comm->nvmlDev, comm->busId, commIdHash);
   }
   sum_timers = 0.0;
@@ -1827,84 +1835,157 @@ static ncclResult_t envConfigOverride(ncclComm_t comm) {
   return ret;
 }
 
-static void ncclxCopyCommConfig(ncclComm_t childComm, ncclComm_t parnet) {
-  childComm->config.ncclAllGatherAlgo = parnet->config.ncclAllGatherAlgo
-      ? strdup(parnet->config.ncclAllGatherAlgo)
-      : nullptr;
-}
-
-static ncclResult_t copyCommConfig(ncclComm_t childComm, ncclComm_t parnet) {
-  memcpy(&childComm->config, &parnet->config, sizeof(ncclConfig_t));
-  ncclxCopyCommConfig(childComm, parnet);
+static ncclResult_t copyCommConfig(ncclComm_t childComm, ncclComm_t parent) {
+  memcpy(&childComm->config, &parent->config, sizeof(ncclConfig_t));
+  if (parent->config.ncclxConfig) {
+    childComm->config.ncclxConfig = new ncclx::Config(
+        *static_cast<ncclx::Config*>(parent->config.ncclxConfig));
+  }
   NCCLCHECK(envConfigOverride(childComm));
   return ncclSuccess;
 }
 
-static void ncclxParseCommConfig(
-    ncclConfig_t* internalConfigPtr,
-    ncclComm_t comm) {
-  /* set default communicator description */
-  NCCL_CONFIG_DEFAULT(
-      internalConfigPtr,
-      commDesc,
-      NCCL_CONFIG_UNDEF_PTR,
-      "undefined",
-      "Comm description",
-      "%s");
-  NCCL_CONFIG_DEFAULT(
-      internalConfigPtr,
-      splitGroupRanks,
-      NCCL_CONFIG_UNDEF_PTR,
-      nullptr,
-      "splitGroupRanks in communicator",
-      "%p");
-  NCCL_CONFIG_DEFAULT(
-      internalConfigPtr,
-      splitGroupSize,
-      NCCL_CONFIG_UNDEF_INT,
-      0,
-      "splitGroupSize in communicator",
-      "%d");
-  NCCL_CONFIG_DEFAULT(
-      internalConfigPtr,
-      ncclAllGatherAlgo,
-      NCCL_CONFIG_UNDEF_PTR,
-      "undefined",
-      "ncclAllGatherAlgo",
-      "%s");
-  /* Set default lazy features: Honor user-specified config first.
-   * If not set, use environment variable. */
-  NCCL_CONFIG_DEFAULT(
-      internalConfigPtr,
-      lazyConnect,
-      NCCL_CONFIG_UNDEF_INT,
-      NCCL_RUNTIME_CONNECT,
-      "lazyConnect",
-      "%d");
-  NCCL_CONFIG_DEFAULT(
-      internalConfigPtr,
-      lazySetupChannels,
-      NCCL_CONFIG_UNDEF_INT,
-      NCCL_LAZY_SETUP_CHANNELS,
-      "lazySetupChannels",
-      "%d");
-  NCCL_CONFIG_DEFAULT(
-      internalConfigPtr,
-      fastInitMode,
-      NCCL_CONFIG_UNDEF_INT,
-      NCCL_FAST_INIT_MODE_DEFAULT,
-      "fastInitMode",
-      "%d");
+ncclResult_t ncclxParseCommConfig(ncclConfig_t* config) {
+  // Already created? (idempotent)
+  if (config->ncclxConfig != NCCL_CONFIG_UNDEF_PTR &&
+      config->ncclxConfig != nullptr) {
+    return ncclSuccess;
+  }
 
-  comm->config.commDesc = internalConfigPtr->commDesc;
-  comm->config.splitGroupRanks = internalConfigPtr->splitGroupRanks;
-  comm->config.splitGroupSize = internalConfigPtr->splitGroupSize;
-  comm->config.ncclAllGatherAlgo = internalConfigPtr->ncclAllGatherAlgo
-      ? strdup(internalConfigPtr->ncclAllGatherAlgo)
-      : nullptr;
-  comm->config.lazyConnect = internalConfigPtr->lazyConnect;
-  comm->config.lazySetupChannels = internalConfigPtr->lazySetupChannels;
-  comm->config.fastInitMode = internalConfigPtr->fastInitMode;
+  // Read hints (if any)
+  ncclx::Hints* hints = nullptr;
+  if (config->hints != NCCL_CONFIG_UNDEF_PTR &&
+      config->hints != nullptr) {
+    hints = static_cast<ncclx::Hints*>(config->hints);
+  }
+
+  // Check if a hint key is present
+  auto hasHint = [&](const char* key) -> bool {
+    if (!hints) {
+      return false;
+    }
+    std::string val;
+    return hints->get(key, val) == ncclSuccess;
+  };
+
+  // Detect conflicts: a field must not be set in both the flat
+  // ncclConfig_t (old format) and hints (new format).
+  bool conflict = false;
+  auto checkPtrConflict = [&](const char* key,
+                              const void* flatVal) {
+    if (flatVal != nullptr && hasHint(key)) {
+      WARN("NCCLX config field '%s' set in both ncclConfig_t and "
+           "hints; use one or the other, not both", key);
+      conflict = true;
+    }
+  };
+  auto checkIntConflict = [&](const char* key, int flatVal) {
+    if (flatVal != NCCL_CONFIG_UNDEF_INT && hasHint(key)) {
+      WARN("NCCLX config field '%s' set in both ncclConfig_t and "
+           "hints; use one or the other, not both", key);
+      conflict = true;
+    }
+  };
+
+  checkPtrConflict("commDesc", config->commDesc);
+  checkPtrConflict("splitGroupRanks", config->splitGroupRanks);
+  checkPtrConflict("ncclAllGatherAlgo", config->ncclAllGatherAlgo);
+  checkIntConflict("lazyConnect", config->lazyConnect);
+  checkIntConflict("lazySetupChannels", config->lazySetupChannels);
+  checkIntConflict("fastInitMode", config->fastInitMode);
+
+  if (conflict) {
+    return ncclInvalidArgument;
+  }
+
+  auto ncclxCfg = std::make_unique<ncclx::Config>();
+
+  // Helper: read bool from flat int field (old), hint (new), or
+  // default.  Accepts 0/1, yes/no, true/false, y/n, t/f (case
+  // insensitive) when reading from hints.
+  auto getBool = [&](const char* key, int flatVal, bool def) -> bool {
+    if (flatVal != NCCL_CONFIG_UNDEF_INT) {
+      return flatVal != 0;
+    }
+    if (hints) {
+      std::string val;
+      if (hints->get(key, val) == ncclSuccess) {
+        std::string lower(val.size(), '\0');
+        std::transform(val.begin(), val.end(), lower.begin(), ::tolower);
+        if (lower == "1" || lower == "yes" || lower == "true" ||
+            lower == "y" || lower == "t") {
+          return true;
+        }
+        if (lower == "0" || lower == "no" || lower == "false" ||
+            lower == "n" || lower == "f") {
+          return false;
+        }
+        return std::stoi(val) != 0;
+      }
+    }
+    return def;
+  };
+
+  // Helper: read string from flat field (old), hint (new), or
+  // default.
+  auto getStr = [&](const char* key, const char* flatVal,
+                    const char* def) -> std::string {
+    if (flatVal != nullptr) {
+      return flatVal;
+    }
+    if (hints) {
+      std::string val;
+      if (hints->get(key, val) == ncclSuccess) {
+        return val;
+      }
+    }
+    return def ? def : "";
+  };
+
+  // Helper: read comma-separated int array from hint, or use flat
+  // field pointer directly.
+  auto getIntArray = [&](const char* key, int* flatVal,
+                         int flatSize) -> std::vector<int> {
+    if (flatVal != nullptr) {
+      return std::vector<int>(flatVal, flatVal + flatSize);
+    }
+    if (!hints) {
+      return {};
+    }
+    std::string val;
+    if (hints->get(key, val) != ncclSuccess) {
+      return {};
+    }
+    std::vector<int> elems;
+    std::istringstream ss(val);
+    std::string tok;
+    while (std::getline(ss, tok, ',')) {
+      elems.push_back(std::stoi(tok));
+    }
+    return elems;
+  };
+
+  ncclxCfg->commDesc =
+      getStr("commDesc", config->commDesc, "undefined");
+  ncclxCfg->splitGroupRanks = getIntArray(
+      "splitGroupRanks", config->splitGroupRanks,
+      config->splitGroupSize != NCCL_CONFIG_UNDEF_INT
+          ? config->splitGroupSize : 0);
+  ncclxCfg->ncclAllGatherAlgo =
+      getStr("ncclAllGatherAlgo", config->ncclAllGatherAlgo,
+             "undefined");
+  ncclxCfg->lazyConnect =
+      getBool("lazyConnect", config->lazyConnect,
+              NCCL_RUNTIME_CONNECT);
+  ncclxCfg->lazySetupChannels =
+      getBool("lazySetupChannels", config->lazySetupChannels,
+              NCCL_LAZY_SETUP_CHANNELS);
+  ncclxCfg->fastInitMode =
+      getBool("fastInitMode", config->fastInitMode,
+              NCCL_FAST_INIT_MODE_DEFAULT);
+
+  config->ncclxConfig = ncclxCfg.release();
+  return ncclSuccess;
 }
 
 static ncclResult_t parseCommConfig(ncclComm_t comm, ncclConfig_t *config) {
@@ -2034,7 +2115,8 @@ static ncclResult_t parseCommConfig(ncclComm_t comm, ncclConfig_t *config) {
   comm->config.shrinkShare = internalConfigPtr->shrinkShare;
   comm->config.nvlsCTAs = internalConfigPtr->nvlsCTAs;
 
-  ncclxParseCommConfig(internalConfigPtr, comm);
+  NCCLCHECK(ncclxParseCommConfig(internalConfigPtr));
+  comm->config.ncclxConfig = internalConfigPtr->ncclxConfig;
 
   NCCLCHECKGOTO(envConfigOverride(comm), ret, fail);
 
@@ -2077,8 +2159,13 @@ static ncclResult_t ncclCommInitRankDev(ncclComm_t* newcomm, int nranks, int nId
   ncclComm_t comm = NULL;
   struct ncclCommInitRankAsyncJob* job = NULL;
   bool launchedJob = false;
+  std::string commDescForLog;
+  if (config && config->ncclxConfig != NCCL_CONFIG_UNDEF_PTR &&
+      config->ncclxConfig != nullptr) {
+    commDescForLog = NCCLX_CONFIG_FIELD(*config, commDesc);
+  }
   CommLogData commLogData{
-      0, getHash(commId->internal, NCCL_UNIQUE_ID_BYTES), config && config->commDesc ? config->commDesc : "", myrank, nranks};
+      0, getHash(commId->internal, NCCL_UNIQUE_ID_BYTES), commDescForLog, myrank, nranks};
   auto contextCommId = EventsScubaUtil::StickyContextGuard(ScubaContextKeys::comm_id, fmt::format("{}", commId->internal));
   sampleGuardBegin.sample().setCommunicatorMetadata(&commLogData);
 
@@ -2109,7 +2196,7 @@ static ncclResult_t ncclCommInitRankDev(ncclComm_t* newcomm, int nranks, int nId
   comm->useCtran_ = ncclx::commUseCtran();
   comm->noLocal_ = ncclx::commNoLocal();
   INFO(NCCL_INIT, "CommInit comm %p commHash 0x%lx commDesc %s useCtran %d noLocal %d: %s %s",
-       comm, getHash(commId->internal, NCCL_UNIQUE_ID_BYTES), ctran::utils::parseCommDesc(config->commDesc),
+       comm, getHash(commId->internal, NCCL_UNIQUE_ID_BYTES), ctran::utils::parseCommDesc(commDescForLog.c_str()),
        comm->useCtran_, comm->noLocal_, ncclx::getCommUseCtranConfig().c_str(),
        ncclx::getCommNoLocalConfig().c_str());
   *comm->abortFlagRefCount = 1;
@@ -2133,7 +2220,7 @@ static ncclResult_t ncclCommInitRankDev(ncclComm_t* newcomm, int nranks, int nId
   NCCLCHECKGOTO(ncclCalloc(&job->commId, nId), res, fail);
   memcpy(job->commId, commId, nId * NCCL_UNIQUE_ID_BYTES);
 
-  if (NCCL_COMM_ID.size() && myrank == 0 && !isFastInitRingMode(comm->config.fastInitMode)) {
+  if (NCCL_COMM_ID.size() && myrank == 0 && !isFastInitRingMode(NCCLX_CONFIG_FIELD(comm->config, fastInitMode))) {
     // create root-rank server in non-meta-fast-init mode
     commIdEnv = NCCL_COMM_ID.c_str();
     INFO(NCCL_ENV, "NCCL_COMM_ID set by environment to %s", commIdEnv);
@@ -2273,9 +2360,19 @@ ncclResult_t ncclCommInitRankConfig(ncclComm_t *newcomm, int nranks, ncclUniqueI
 
   initEnv();
 
+  // Apply hints early so that config fields are populated before any
+  // field-specific reads below (e.g., fastInitMode).
+  if (config) {
+    NCCLCHECK(ncclxParseCommConfig(config));
+  }
+
   char allZeroUniqueId[NCCL_UNIQUE_ID_BYTES] = {0};
   bool uniqueIdIsInitialized = memcmp(commId.internal, allZeroUniqueId, NCCL_UNIQUE_ID_BYTES) != 0;
-  int fastInitMode = config ? config->fastInitMode : NCCL_FAST_INIT_MODE_DEFAULT;
+  bool fastInitMode = false;
+  if (config && config->ncclxConfig != NCCL_CONFIG_UNDEF_PTR &&
+      config->ncclxConfig != nullptr) {
+    fastInitMode = NCCLX_CONFIG_FIELD(*config, fastInitMode);
+  }
   if (isFastInitRingMode(fastInitMode)) {
     // in meta-fast-init mode, we don't need commId
     if (uniqueIdIsInitialized) {
@@ -2289,8 +2386,13 @@ ncclResult_t ncclCommInitRankConfig(ncclComm_t *newcomm, int nranks, ncclUniqueI
   }
 
   NVTX3_RANGE(NcclNvtxParamsCommInitRankConfig);
+  std::string initCommDesc = "undefined";
+  if (config && config->ncclxConfig != NCCL_CONFIG_UNDEF_PTR &&
+      config->ncclxConfig != nullptr) {
+    initCommDesc = NCCLX_CONFIG_FIELD(*config, commDesc);
+  }
   CommLogData commLogData{
-    0, getHash(commId.internal, NCCL_UNIQUE_ID_BYTES), config && config->commDesc ? config->commDesc : "", myrank, nranks, };
+    0, getHash(commId.internal, NCCL_UNIQUE_ID_BYTES), initCommDesc, myrank, nranks, };
 
   NcclScubaEvent initEvent(&commLogData);
   sampleGuardBegin.sample().setCommunicatorMetadata(&commLogData);
@@ -2614,7 +2716,7 @@ static void commAbortLog(ncclComm_t comm, const std::string& abortScope) {
         "comm %p commHash %lx commDesc %s rank %d nRanks %d cudaDev %d busId %lx - Abort %s",
         comm,
         comm->commHash,
-        comm->config.commDesc,
+        NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str(),
         comm->rank,
         comm->nRanks,
         comm->cudaDev,
@@ -2649,7 +2751,7 @@ ncclResult_t ncclCommAbort(ncclComm_t comm) {
   if (comm == NULL) {
     return ncclSuccess;
   }
-  std::string commDesc = comm->config.commDesc;
+  std::string commDesc = NCCLX_CONFIG_FIELD(comm->config, commDesc);
   NcclScubaEvent abortEvent(&comm->logMetaData);
   commAbortLog(comm, "START");
   abortEvent.lapAndRecord("Abort START");
@@ -2756,7 +2858,7 @@ static ncclResult_t ncclCommInitChildComm(ncclComm_t comm, ncclComm_t* newcomm, 
     childComm->useCtran_ = ncclx::commUseCtran();
     childComm->noLocal_ = ncclx::commNoLocal();
     INFO(NCCL_INIT, "CommSplit comm %p commDesc %s useCtran %d noLocal %d: %s %s",
-        childComm, ctran::utils::parseCommDesc(childComm->config.commDesc),
+        childComm, ctran::utils::parseCommDesc(NCCLX_CONFIG_FIELD(childComm->config, commDesc).c_str()),
         childComm->useCtran_, childComm->noLocal_, ncclx::getCommUseCtranConfig().c_str(),
         ncclx::getCommNoLocalConfig().c_str());
   }
@@ -2823,7 +2925,12 @@ ncclResult_t ncclCommSplit(ncclComm_t comm, int color, int key, ncclComm_t *newc
   NVTX3_RANGE(NcclNvtxParamsCommSplit)
 
   ncclResult_t res = ncclSuccess;
-  CommLogData commLogData{0, 0, config && config->commDesc ? config->commDesc : "", -1, -1};
+  std::string splitCommDesc;
+  if (config && config->ncclxConfig != NCCL_CONFIG_UNDEF_PTR &&
+      config->ncclxConfig != nullptr) {
+    splitCommDesc = NCCLX_CONFIG_FIELD(*config, commDesc);
+  }
+  CommLogData commLogData{0, 0, splitCommDesc, -1, -1};
   NcclScubaEvent splitEvent(&commLogData);
   splitEvent.lapAndRecord("CommSplit START");
   NCCLCHECK(ncclGroupStartInternal());

--- a/comms/ncclx/v2_27/src/misc/utils.cc
+++ b/comms/ncclx/v2_27/src/misc/utils.cc
@@ -67,8 +67,8 @@ ncclResult_t getHostName(char* hostname, int maxlen, const char delim) {
   return ncclSuccess;
 }
 
-bool isFastInitRingMode(int fastInitMode) {
-  return fastInitMode == NCCL_FAST_INIT_MODE_RING || NCCL_FASTINIT_MODE == NCCL_FASTINIT_MODE::ring_hybrid;
+bool isFastInitRingMode(bool fastInitMode) {
+  return fastInitMode || NCCL_FASTINIT_MODE == NCCL_FASTINIT_MODE::ring_hybrid;
 }
 
 static uint64_t hostHashValue = 0;

--- a/comms/ncclx/v2_27/src/nccl.h.in
+++ b/comms/ncclx/v2_27/src/nccl.h.in
@@ -45,6 +45,7 @@ extern "C" {
 #define NCCL_COMM_DUMP
 #define NCCL_COMM_GET_UNIQUE_HASH
 #define NCCL_COLLTRACE_CUDA_GRAPH_COMPATIBLE
+#define NCCLX_CONFIG_SUPPORTED
 
 /* Opaque handle to communicator */
 typedef struct ncclComm* ncclComm_t;
@@ -143,6 +144,16 @@ typedef struct ncclConfig_v22700 {
 
   // control the fast init features
   int fastInitMode{NCCL_CONFIG_UNDEF_INT};
+
+  // Opaque pointer to an ncclx::Hints object.  When non-null, NCCLX
+  // will read key-value pairs from this object and apply them to
+  // config fields that are still at their undefined defaults.
+  void* hints{NCCL_CONFIG_UNDEF_PTR};
+
+  // Internal field — do not access directly.  This would be private
+  // if ncclConfig_t were a C++ class.  Populated by NCCLX during
+  // communicator creation; users must not read or write this field.
+  void* ncclxConfig{NCCL_CONFIG_UNDEF_PTR};
 } ncclConfig_t;
 
 /* Config initializer must be assigned to initialize config structure when it is created.
@@ -170,6 +181,8 @@ typedef struct ncclConfig_v22700 {
   NCCL_CONFIG_UNDEF_INT,                    /* lazyConnect */           \
   NCCL_CONFIG_UNDEF_INT,                    /* lazySetupChannels */     \
   NCCL_CONFIG_UNDEF_INT,                    /* fastInitMode */          \
+  NCCL_CONFIG_UNDEF_PTR,                    /* hints */                  \
+  NCCL_CONFIG_UNDEF_PTR,                    /* ncclxConfig */            \
 }
 
 /* This struct will be used by ncclGroupSimulateEnd() API to query information about simulation. */

--- a/comms/ncclx/v2_27/src/transport.cc
+++ b/comms/ncclx/v2_27/src/transport.cc
@@ -5,6 +5,7 @@
  ************************************************************************/
 
 #include "comm.h"
+#include "meta/NcclxConfig.h" // @manual
 #include "info.h"
 #include "bootstrap.h"
 #define ENABLE_TIMER 0
@@ -115,7 +116,9 @@ ncclResult_t ncclTransportCheckP2pType(struct ncclComm* comm, bool* isAllDirectP
   }
   *isAllDirectP2p = supportFlag;
   *directMode = directFlag;
-  if (comm->rank == 0) INFO(NCCL_INIT, "commDesc: %s Check P2P Type intraNodeP2pSupport %d directMode %d", ctran::utils::parseCommDesc(comm->config.commDesc), supportFlag, directFlag);
+  if (comm->rank == 0) {
+    INFO(NCCL_INIT, "commDesc: %s Check P2P Type intraNodeP2pSupport %d directMode %d", ctran::utils::parseCommDesc(NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()), supportFlag, directFlag);
+  }
   return ncclSuccess;
 }
 

--- a/comms/ncclx/v2_27/src/transport/p2p.cc
+++ b/comms/ncclx/v2_27/src/transport/p2p.cc
@@ -5,6 +5,7 @@
  ************************************************************************/
 
 #include "comm.h"
+#include "meta/NcclxConfig.h" // @manual
 #include "graph.h"
 #include "utils.h"
 #include "shmutils.h"
@@ -175,7 +176,7 @@ ncclResult_t p2pCanConnect(int* ret, struct ncclComm* comm, struct ncclTopoGraph
   int p2p;
   if (cudaDeviceCanAccessPeer(&p2p, cudaDev1, cudaDev2) != cudaSuccess) {
     INFO(NCCL_INIT|NCCL_P2P,"commDesc: %s peer query failed between dev %d(=%lx) and dev %d(=%lx)",
-         ctran::utils::parseCommDesc(comm->config.commDesc), cudaDev1, info1->busId, cudaDev2, info2->busId);
+         ctran::utils::parseCommDesc(NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()), cudaDev1, info1->busId, cudaDev2, info2->busId);
     *ret = 0;
     return ncclSuccess;
   }
@@ -194,7 +195,7 @@ ncclResult_t p2pCanConnect(int* ret, struct ncclComm* comm, struct ncclTopoGraph
     memLogMetaData = comm->logMetaData;
     NCCLCHECK(ncclCudaMalloc(&dummy, CUDA_IPC_MIN));
     if (cudaIpcGetMemHandle(&ipc, dummy) != cudaSuccess) {
-      INFO(NCCL_INIT|NCCL_P2P,"commDesc: %s Legacy IPC not supported", ctran::utils::parseCommDesc(comm->config.commDesc));
+      INFO(NCCL_INIT|NCCL_P2P,"commDesc: %s Legacy IPC not supported", ctran::utils::parseCommDesc(NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()));
       *ret = 0;
     }
     NCCLCHECK(ncclCudaFree(dummy));
@@ -204,7 +205,7 @@ ncclResult_t p2pCanConnect(int* ret, struct ncclComm* comm, struct ncclTopoGraph
 
   if (p2p == 0) {
     INFO(NCCL_INIT|NCCL_P2P,"commDesc: %s Could not enable P2P between dev %d(=%lx) and dev %d(=%lx)",
-         ctran::utils::parseCommDesc(comm->config.commDesc), cudaDev1, info1->busId, cudaDev2, info2->busId);
+         ctran::utils::parseCommDesc(NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()), cudaDev1, info1->busId, cudaDev2, info2->busId);
     *ret = 0;
     return ncclSuccess;
   }
@@ -252,7 +253,7 @@ ncclResult_t ncclP2pAllocateShareableBuffer(size_t size, int refcount, ncclIpcDe
       CUDACHECK(res);
     }
   }
-  INFO(NCCL_P2P|NCCL_ALLOC, "commDesc: %s Allocated shareable buffer %p size %zu ipcDesc %p for %s", ctran::utils::parseCommDesc(comm->config.commDesc), *ptr, size, ipcDesc, callsite);
+  INFO(NCCL_P2P|NCCL_ALLOC, "commDesc: %s Allocated shareable buffer %p size %zu ipcDesc %p for %s", ctran::utils::parseCommDesc(NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()), *ptr, size, ipcDesc, callsite);
 
   return ncclSuccess;
 }
@@ -313,7 +314,7 @@ ncclResult_t ncclP2pImportShareableBuffer(struct ncclComm *comm, int peer, size_
     CUDACHECK(cudaIpcOpenMemHandle(devMemPtr, ipcDesc->devIpc, cudaIpcMemLazyEnablePeerAccess));
   }
 
-  INFO(NCCL_P2P, "commDesc: %s Imported shareable buffer device %d size %zu ptr %p", ctran::utils::parseCommDesc(comm->config.commDesc), comm->cudaDev, size, *devMemPtr);
+  INFO(NCCL_P2P, "commDesc: %s Imported shareable buffer device %d size %zu ptr %p", ctran::utils::parseCommDesc(NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()), comm->cudaDev, size, *devMemPtr);
 
   return ncclSuccess;
 }

--- a/comms/ncclx/v2_28/examples/HelloWorld.cc
+++ b/comms/ncclx/v2_28/examples/HelloWorld.cc
@@ -10,7 +10,9 @@ int main(int argc, char* argv[]) {
   cudaStream_t stream;
   int* userBuff = NULL;
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
-  config.commDesc = "example_pg";
+  ncclx::Hints hints;
+  hints.set("commDesc", "example_pg");
+  config.hints = &hints;
 
   ncclUniqueId ncclId;
   NCCLCHECK(ncclGetUniqueId(&ncclId));

--- a/comms/ncclx/v2_28/meta/NcclxConfig.h
+++ b/comms/ncclx/v2_28/meta/NcclxConfig.h
@@ -1,0 +1,51 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "nccl.h" // @manual
+
+namespace ncclx {
+
+struct Config {
+  // NCCLX-specific config fields (canonical storage).
+  // New fields should be added here, NOT to ncclConfig_t.
+  // When adding a new field, also add its key to knownHintKeys below.
+  std::string commDesc;
+  std::vector<int> splitGroupRanks;
+  std::string ncclAllGatherAlgo;
+  bool lazyConnect = false;
+  bool lazySetupChannels = false;
+  bool fastInitMode = false;
+};
+
+// Hint keys corresponding to Config fields above.  Used by
+// Hints::set() to warn on unrecognized keys (typo detection).
+inline const std::vector<std::string>& knownHintKeys() {
+  static const std::vector<std::string> keys = {
+      "commDesc",
+      "splitGroupRanks",
+      "ncclAllGatherAlgo",
+      "lazyConnect",
+      "lazySetupChannels",
+      "fastInitMode",
+  };
+  return keys;
+}
+
+} // namespace ncclx
+
+// Convenience macro: access an NCCLX-specific field from the canonical
+// ncclx::Config stored inside an ncclConfig_t.
+// Usage: NCCLX_CONFIG_FIELD(comm->config, commDesc)
+#define NCCLX_CONFIG_FIELD(cfg, field) \
+  (static_cast<ncclx::Config*>((cfg).ncclxConfig)->field)
+
+// Create ncclx::Config from config->hints (new format) or flat
+// ncclConfig_t fields (old format) with env-based defaults.  Returns
+// ncclInvalidArgument if a field is set in both formats.  Stores the
+// result in config->ncclxConfig.  Idempotent: does nothing if
+// ncclxConfig is already set.
+ncclResult_t ncclxParseCommConfig(ncclConfig_t* config);

--- a/comms/ncclx/v2_28/meta/commDump.cc
+++ b/comms/ncclx/v2_28/meta/commDump.cc
@@ -8,6 +8,7 @@
 #include <folly/json/json.h>
 
 #include "comm.h"
+#include "meta/NcclxConfig.h" // @manual
 #include "nccl.h"
 
 #include "comms/ctran/colltrace/MapperTrace.h"
@@ -95,7 +96,7 @@ static void dumpCommInfo(
   map["nRanks"] = std::to_string(comm->nRanks);
   map["localRanks"] = std::to_string(comm->localRanks);
   map["nNodes"] = std::to_string(comm->nNodes);
-  map["commDesc"] = toQuotedString(comm->config.commDesc);
+  map["commDesc"] = toQuotedString(NCCLX_CONFIG_FIELD(comm->config, commDesc));
 }
 
 static void dumpCommInfo(
@@ -235,7 +236,7 @@ __attribute__((visibility("default"))) ncclResult_t ncclCommDump(
         comm->rank,
         fmt::ptr(comm),
         comm->commHash,
-        comm->config.commDesc);
+        NCCLX_CONFIG_FIELD(comm->config, commDesc));
 
     dumpCommInfo(comm, map);
     if (NCCL_COLLTRACE_USE_NEW_COLLTRACE) {

--- a/comms/ncclx/v2_28/meta/comms-monitor/tests/CommsMonitorDist.cc
+++ b/comms/ncclx/v2_28/meta/comms-monitor/tests/CommsMonitorDist.cc
@@ -8,6 +8,7 @@
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
 #include "meta/comms-monitor/CommsMonitor.h"
+#include "nccl.h"
 
 using namespace ncclx::comms_monitor;
 
@@ -120,8 +121,9 @@ TEST_F(CommsMonitorDist, testCommSplit) {
   EXPECT_EQ(CommsMonitor::getNumOfCommMonitoring(), 1);
 
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
-  const std::string commDest = "split_comm";
-  config.commDesc = commDest.c_str();
+  ncclx::Hints splitHints;
+  splitHints.set("commDesc", "split_comm");
+  config.hints = &splitHints;
 
   ncclComm_t splitComm;
 
@@ -140,8 +142,9 @@ TEST_F(CommsMonitorDist, testCommSplitNoColor) {
   EXPECT_EQ(CommsMonitor::getNumOfCommMonitoring(), 1);
 
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
-  const std::string commDest = "split_comm";
-  config.commDesc = commDest.c_str();
+  ncclx::Hints noColorHints;
+  noColorHints.set("commDesc", "split_comm");
+  config.hints = &noColorHints;
 
   ncclComm_t splitComm;
 

--- a/comms/ncclx/v2_28/meta/comms-monitor/tests/CommsMonitorUT.cc
+++ b/comms/ncclx/v2_28/meta/comms-monitor/tests/CommsMonitorUT.cc
@@ -6,6 +6,7 @@
 #include "comm.h" // @manual
 #include "comms/ctran/Ctran.h" // @manual
 #include "comms/utils/cvars/nccl_cvars.h"
+#include "meta/NcclxConfig.h"
 #include "meta/colltrace/CollTrace.h" // @manual
 #include "meta/comms-monitor/CommsMonitor.h" // @manual
 #include "meta/wrapper/MetaFactory.h"
@@ -16,7 +17,9 @@ inline std::unique_ptr<ncclComm> createFakeNcclComm() {
   comm->nRanks = 1;
   comm->cudaDev = 0;
   comm->commHash = 0xfaceb00c;
-  comm->config.commDesc = "fake_comm";
+  auto* ncclxCfg = new ncclx::Config();
+  ncclxCfg->commDesc = "fake_comm";
+  comm->config.ncclxConfig = ncclxCfg;
   comm->localRank = 0;
   comm->localRanks = 1;
   comm->nNodes = 1;
@@ -31,7 +34,7 @@ inline std::unique_ptr<ncclComm> createFakeNcclComm() {
       comm->commHash,
       std::vector<ncclx::RankTopology>(), /* rankTopologies */
       std::vector<int>(), /* commRanksToWorldRanks */
-      comm->config.commDesc);
+      NCCLX_CONFIG_FIELD(comm->config, commDesc));
 
   return comm;
 }

--- a/comms/ncclx/v2_28/meta/commstate/FactoryCommStateX.cc
+++ b/comms/ncclx/v2_28/meta/commstate/FactoryCommStateX.cc
@@ -3,6 +3,7 @@
 #include "comm.h"
 #include "comms/ctran/commstate/CommStateX.h"
 #include "comms/ctran/utils/Checks.h"
+#include "meta/NcclxConfig.h" // @manual
 
 #include "bootstrap.h"
 #include "nvmlwrap.h"
@@ -51,7 +52,7 @@ std::unique_ptr<CommStateX> createCommStateXFromNcclComm(void* _comm) {
       comm->commHash,
       std::vector<RankTopology>(), /* rankTopologies */
       std::vector<int>(), /* commRanksToWorldRanks */
-      comm->config.commDesc);
+      NCCLX_CONFIG_FIELD(comm->config, commDesc));
 
   if (comm->noLocal_ ||
       NCCL_COMM_STATE_DEBUG_TOPO == NCCL_COMM_STATE_DEBUG_TOPO::nolocal) {

--- a/comms/ncclx/v2_28/meta/commstate/tests/CommStateXTest.cc
+++ b/comms/ncclx/v2_28/meta/commstate/tests/CommStateXTest.cc
@@ -11,6 +11,7 @@
 #include "comms/testinfra/TestUtils.h"
 
 #include "comms/ctran/commstate/CommStateX.h"
+#include "meta/NcclxConfig.h"
 #include "param.h" // @manual
 
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -40,7 +41,9 @@ static void fillDummyComm(ncclComm& comm, int numNvlDomain = 1) {
   comm.nRanks = 16;
   comm.cudaDev = 0;
   comm.commHash = 123456789;
-  comm.config.commDesc = "default_pg:0";
+  auto* ncclxCfg = new ncclx::Config();
+  ncclxCfg->commDesc = "default_pg:0";
+  comm.config.ncclxConfig = ncclxCfg;
 
   comm.localRank = 0;
   comm.localRanks = 8 / numNvlDomain; // local ranks in the same NVL domain
@@ -102,7 +105,7 @@ TEST(CommStateXTest, CreateVNodeFromNcclComm) {
   EXPECT_EQ(state->nLocalRanks(), nLocalRanks);
   EXPECT_EQ(state->nNodes(), comm.nRanks / nLocalRanks);
   EXPECT_EQ(state->commHash(), comm.commHash);
-  EXPECT_EQ(state->commDesc(), comm.config.commDesc);
+  EXPECT_EQ(state->commDesc(), NCCLX_CONFIG_FIELD(comm.config, commDesc));
   for (int i = 0; i < state->nRanks(); ++i) {
     EXPECT_EQ(state->node(i), i / nLocalRanks);
   }
@@ -146,7 +149,7 @@ TEST(CommStateXTest, CreateNoLocalFromNcclComm) {
   EXPECT_EQ(state->nLocalRanks(), 1);
   EXPECT_EQ(state->nNodes(), comm.nRanks);
   EXPECT_EQ(state->commHash(), comm.commHash);
-  EXPECT_EQ(state->commDesc(), comm.config.commDesc);
+  EXPECT_EQ(state->commDesc(), NCCLX_CONFIG_FIELD(comm.config, commDesc));
   for (int i = 0; i < state->nRanks(); ++i) {
     EXPECT_EQ(state->node(i), i);
   }
@@ -182,7 +185,7 @@ TEST_P(CommStateXNcclCommTestParamFixture, CreateFromNcclComm) {
   EXPECT_EQ(state->nRanks(), comm.nRanks);
   EXPECT_EQ(state->cudaDev(), comm.cudaDev);
   EXPECT_EQ(state->commHash(), comm.commHash);
-  EXPECT_EQ(state->commDesc(), comm.config.commDesc);
+  EXPECT_EQ(state->commDesc(), NCCLX_CONFIG_FIELD(comm.config, commDesc));
   EXPECT_EQ(state->localRank(), comm.localRank);
   EXPECT_EQ(state->nLocalRanks(), comm.localRanks);
   for (int i = 0; i < state->nRanks(); ++i) {

--- a/comms/ncclx/v2_28/meta/hints/Hints.cc
+++ b/comms/ncclx/v2_28/meta/hints/Hints.cc
@@ -7,7 +7,10 @@
 #include "comms/ctran/algos/AllToAll/AllToAllvDynamicHintUtils.h"
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/window/WinHintUtils.h"
+#include "meta/NcclxConfig.h" // @manual
 #include "meta/wrapper/MetaFactory.h"
+
+#include <algorithm>
 
 namespace ncclx {
 
@@ -34,7 +37,12 @@ Hints::set(const std::string& key, const std::string& val) {
     NCCLCHECK(metaCommToNccl(WinHintUtils::set(key, val, this->kv)));
     return ncclSuccess;
   } else {
-    return ncclInvalidArgument;
+    const auto& knownKeys = ncclx::knownHintKeys();
+    if (std::find(knownKeys.begin(), knownKeys.end(), key) == knownKeys.end()) {
+      WARN("NCCLX Hints: unknown key '%s'; check spelling", key.c_str());
+    }
+    this->kv[key] = val;
+    return ncclSuccess;
   }
 }
 

--- a/comms/ncclx/v2_28/meta/tests/CommDescTest.cc
+++ b/comms/ncclx/v2_28/meta/tests/CommDescTest.cc
@@ -10,6 +10,7 @@
 #include "comm.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
+#include "meta/NcclxConfig.h"
 #include "nccl.h"
 
 class commDescTest : public ::testing::Test {
@@ -32,7 +33,7 @@ TEST_F(commDescTest, getUndefinedCommDesc) {
   NcclCommRAII comm(this->globalRank, this->numRanks, this->localRank);
   ASSERT_NE(nullptr, static_cast<ncclComm_t>(comm));
 
-  EXPECT_STREQ(comm->config.commDesc, "nccl_ut");
+  EXPECT_EQ(NCCLX_CONFIG_FIELD(comm->config, commDesc), "nccl_ut");
 }
 
 TEST_F(commDescTest, getDefinedCommDesc) {
@@ -46,14 +47,16 @@ TEST_F(commDescTest, getDefinedCommDesc) {
 
   ncclComm_t comm;
   ncclConfig_t inputConfig = NCCL_CONFIG_INITIALIZER;
-  inputConfig.commDesc = "test_description";
+  ncclx::Hints hints;
+  hints.set("commDesc", "test_description");
+  inputConfig.hints = &hints;
 
   NCCLCHECK_TEST(ncclCommInitRankConfig(
       &comm, numRanks, ncclId, globalRank, &inputConfig));
   ASSERT_NE(nullptr, comm);
 
-  EXPECT_STRNE(comm->config.commDesc, "undefined");
-  EXPECT_STREQ(comm->config.commDesc, inputConfig.commDesc);
+  EXPECT_NE(NCCLX_CONFIG_FIELD(comm->config, commDesc), "undefined");
+  EXPECT_EQ(NCCLX_CONFIG_FIELD(comm->config, commDesc), "test_description");
 
   NCCLCHECK_TEST(ncclCommDestroy(comm));
 }
@@ -71,7 +74,9 @@ TEST_F(commDescTest, InvalidPointerAccess) {
   ncclConfig_t inputConfig = NCCL_CONFIG_INITIALIZER;
   const char* commDescConst = "test_description";
   char* commDesc = strdup(commDescConst);
-  inputConfig.commDesc = commDesc;
+  ncclx::Hints hints;
+  hints.set("commDesc", commDesc);
+  inputConfig.hints = &hints;
 
   NCCLCHECK_TEST(ncclCommInitRankConfig(
       &comm, numRanks, ncclId, globalRank, &inputConfig));
@@ -79,8 +84,8 @@ TEST_F(commDescTest, InvalidPointerAccess) {
 
   free(commDesc);
 
-  EXPECT_STRNE(comm->config.commDesc, "undefined");
-  EXPECT_STREQ(comm->config.commDesc, commDescConst);
+  EXPECT_NE(NCCLX_CONFIG_FIELD(comm->config, commDesc), "undefined");
+  EXPECT_EQ(NCCLX_CONFIG_FIELD(comm->config, commDesc), commDescConst);
 
   NCCLCHECK_TEST(ncclCommDestroy(comm));
 }

--- a/comms/ncclx/v2_28/meta/tests/CommDumpTest.cc
+++ b/comms/ncclx/v2_28/meta/tests/CommDumpTest.cc
@@ -12,6 +12,7 @@
 #include "comm.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
+#include "meta/NcclxConfig.h"
 #include "nccl.h"
 
 #include "comms/utils/StrUtils.h"
@@ -173,7 +174,9 @@ TEST_F(CommDumpTest, SingleComm) {
   EXPECT_EQ(dump.count("node"), 1);
   EXPECT_EQ(dump["node"], std::to_string(this->comm->node));
   EXPECT_EQ(dump.count("commDesc"), 1);
-  EXPECT_EQ(dump["commDesc"], toQuotedString(this->comm->config.commDesc));
+  EXPECT_EQ(
+      dump["commDesc"],
+      toQuotedString(NCCLX_CONFIG_FIELD(this->comm->config, commDesc)));
 
   EXPECT_EQ(dump.count("nRanks"), 1);
   EXPECT_EQ(dump["nRanks"], std::to_string(this->comm->nRanks));

--- a/comms/ncclx/v2_28/meta/tests/CommWithCtranTest.cc
+++ b/comms/ncclx/v2_28/meta/tests/CommWithCtranTest.cc
@@ -70,7 +70,9 @@ TEST_P(CommWithCtranTestParam, CtranEnableByHint) {
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
   config.blocking = blockingInit ? 1 : 0;
   const auto commDescStr = fmt::format("{}-{}", kNcclUtCommDesc, "useCtran");
-  config.commDesc = commDescStr.c_str();
+  ncclx::Hints ctranHints;
+  ctranHints.set("commDesc", commDescStr);
+  config.hints = &ctranHints;
 
   // Enable by hint
   ASSERT_EQ(

--- a/comms/ncclx/v2_28/meta/tests/CommWithNoLocalTest.cc
+++ b/comms/ncclx/v2_28/meta/tests/CommWithNoLocalTest.cc
@@ -68,7 +68,9 @@ TEST_P(CommWithNoLocalTestParam, NoLocalEnableByHint) {
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
   config.blocking = blockingInit ? 1 : 0;
   const auto commDescStr = fmt::format("{}-{}", kNcclUtCommDesc, "noLocal");
-  config.commDesc = commDescStr.c_str();
+  ncclx::Hints noLocalHints;
+  noLocalHints.set("commDesc", commDescStr);
+  config.hints = &noLocalHints;
 
   // Enable by hint
   ASSERT_EQ(

--- a/comms/ncclx/v2_28/meta/tests/CommWithPatAvgTest.cc
+++ b/comms/ncclx/v2_28/meta/tests/CommWithPatAvgTest.cc
@@ -82,7 +82,9 @@ TEST_P(CommWithPatAvgTestParam, PatAvgEnableByHintWithModes) {
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
   config.blocking = blockingInit ? 1 : 0;
   const auto commDescStr = fmt::format("{}-{}", kNcclUtCommDesc, "usePatAvg");
-  config.commDesc = commDescStr.c_str();
+  ncclx::Hints patAvgHints;
+  patAvgHints.set("commDesc", commDescStr);
+  config.hints = &patAvgHints;
 
   // Enable by hint
   ASSERT_EQ(

--- a/comms/ncclx/v2_28/meta/tests/FastInitTest.cc
+++ b/comms/ncclx/v2_28/meta/tests/FastInitTest.cc
@@ -11,6 +11,7 @@
 #include "comm.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
+#include "meta/NcclxConfig.h"
 #include "nccl.h"
 
 void printCommStateX(const ncclComm& comm) {
@@ -40,10 +41,14 @@ void validateCtranInitialization(
   EXPECT_EQ(comm->commHash, comm->ctranComm_->statex_->commHash());
 }
 
-ncclConfig_t ncclConfigInitHelper(bool enableFastInitConfig) {
+ncclConfig_t ncclConfigInitHelper(
+    bool enableFastInitConfig,
+    ncclx::Hints& hints) {
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
   if (enableFastInitConfig) {
-    config.fastInitMode = NCCL_FAST_INIT_MODE_RING;
+    hints = ncclx::Hints();
+    hints.set("fastInitMode", std::to_string(NCCL_FAST_INIT_MODE_RING));
+    config.hints = &hints;
   }
   return config;
 }
@@ -57,7 +62,8 @@ ncclResult_t ncclCommInitRankConfigHelper(
   if (!enableFastInitConfig) {
     return ncclCommInitRankConfig(comm, nRanks, commId, myRank, nullptr);
   } else {
-    ncclConfig_t config = ncclConfigInitHelper(enableFastInitConfig);
+    ncclx::Hints hints;
+    ncclConfig_t config = ncclConfigInitHelper(enableFastInitConfig, hints);
     return ncclCommInitRankConfig(comm, nRanks, commId, myRank, &config);
   }
 }
@@ -138,17 +144,28 @@ TEST_P(NcclxBaseTestFixture, NcclCommSplit) {
   validateCtranInitialization(rootComm, globalRank, numRanks, localRank);
 
   ncclComm_t childComm = nullptr;
-  ncclConfig_t childCommConfig = ncclConfigInitHelper(enableFastInitConfig);
+  ncclx::Hints fastInitHints;
+  ncclConfig_t childCommConfig =
+      ncclConfigInitHelper(enableFastInitConfig, fastInitHints);
   int color = globalRank % 2;
   std::string childCommDesc = "child_communicator_" + std::to_string(color);
-  childCommConfig.commDesc = childCommDesc.c_str();
   int groupSize = rootComm->ctranComm_->statex_.get()->nRanks() / 2;
   int* groupRanks = new int[groupSize];
   for (int i = 0; i < groupSize; ++i) {
     *(groupRanks + i) = 2 * i + globalRank % 2;
   }
-  childCommConfig.splitGroupRanks = groupRanks;
-  childCommConfig.splitGroupSize = groupSize;
+  ncclx::Hints splitHints;
+  splitHints.set("commDesc", childCommDesc);
+  {
+    std::string ranksStr;
+    for (int i = 0; i < groupSize; ++i) {
+      if (i > 0)
+        ranksStr += ",";
+      ranksStr += std::to_string(groupRanks[i]);
+    }
+    splitHints.set("splitGroupRanks", ranksStr);
+  }
+  childCommConfig.hints = &splitHints;
   NCCLCHECK_TEST(ncclCommSplit(
       rootComm, color, globalRank / 2, &childComm, &childCommConfig));
   ASSERT_NE(nullptr, childComm);
@@ -166,7 +183,9 @@ TEST_P(NcclxBaseTestFixture, NcclCommSplit) {
   EXPECT_EQ(statex1->nLocalRanks(), localSize / 2);
 
   ncclComm expectedComm;
-  expectedComm.config.commDesc = childCommConfig.commDesc;
+  auto* ncclxCfg = new ncclx::Config();
+  ncclxCfg->commDesc = childCommDesc;
+  expectedComm.config.ncclxConfig = ncclxCfg;
   setCtranCommBase(&expectedComm);
 
   expectedComm.ctranComm_->statex_ = std::make_unique<ncclx::CommStateX>(
@@ -204,17 +223,28 @@ TEST_P(NcclxBaseTestFixture, NcclCommSplitDuplicateGroups) {
   }
 
   // child comm config
-  ncclConfig_t childCommConfig = ncclConfigInitHelper(enableFastInitConfig);
+  ncclx::Hints fastInitHints;
+  ncclConfig_t childCommConfig =
+      ncclConfigInitHelper(enableFastInitConfig, fastInitHints);
   int color = globalRank % 2;
   std::string childCommDesc = "child_communicator_" + std::to_string(color);
-  childCommConfig.commDesc = childCommDesc.c_str();
   int groupSize = rootComm->ctranComm_->statex_.get()->nRanks() / 2;
   int* groupRanks = new int[groupSize];
   for (int i = 0; i < groupSize; ++i) {
     *(groupRanks + i) = 2 * i + globalRank % 2;
   }
-  childCommConfig.splitGroupRanks = groupRanks;
-  childCommConfig.splitGroupSize = groupSize;
+  ncclx::Hints dupSplitHints;
+  dupSplitHints.set("commDesc", childCommDesc);
+  {
+    std::string ranksStr;
+    for (int i = 0; i < groupSize; ++i) {
+      if (i > 0)
+        ranksStr += ",";
+      ranksStr += std::to_string(groupRanks[i]);
+    }
+    dupSplitHints.set("splitGroupRanks", ranksStr);
+  }
+  childCommConfig.hints = &dupSplitHints;
 
   ncclComm_t childComm1 = nullptr;
   NCCLCHECK_TEST(ncclCommSplit(
@@ -302,15 +332,26 @@ TEST_P(NcclxBaseTestFixture, ChildCommAllGather) {
   }
 
   ncclComm_t childComm = nullptr;
-  ncclConfig_t childCommConfig = ncclConfigInitHelper(enableFastInitConfig);
-  childCommConfig.commDesc = "child_communicator";
+  ncclx::Hints fastInitHints;
+  ncclConfig_t childCommConfig =
+      ncclConfigInitHelper(enableFastInitConfig, fastInitHints);
   int groupSize = rootComm->ctranComm_->statex_.get()->nRanks() / 2;
   int* groupRanks = new int[groupSize];
   for (int i = 0; i < groupSize; ++i) {
     *(groupRanks + i) = 2 * i + globalRank % 2;
   }
-  childCommConfig.splitGroupRanks = groupRanks;
-  childCommConfig.splitGroupSize = groupSize;
+  ncclx::Hints childAgHints;
+  childAgHints.set("commDesc", "child_communicator");
+  {
+    std::string ranksStr;
+    for (int i = 0; i < groupSize; ++i) {
+      if (i > 0)
+        ranksStr += ",";
+      ranksStr += std::to_string(groupRanks[i]);
+    }
+    childAgHints.set("splitGroupRanks", ranksStr);
+  }
+  childCommConfig.hints = &childAgHints;
   NCCLCHECK_TEST(ncclCommSplit(
       rootComm, globalRank % 2, globalRank / 2, &childComm, &childCommConfig));
   ASSERT_NE(nullptr, childComm);
@@ -358,10 +399,14 @@ TEST_P(NcclxBaseTestFixture, NcclCommSplitNoColor) {
   ncclComm_t rootComm = nullptr;
   ncclComm_t childComm = NCCL_COMM_NULL;
   ncclUniqueId commId;
-  ncclConfig_t rootConfig = ncclConfigInitHelper(enableFastInitConfig);
-  rootConfig.commDesc = "root_communicator";
-  ncclConfig_t childConfig = ncclConfigInitHelper(enableFastInitConfig);
-  childConfig.commDesc = "child_communicator";
+  ncclx::Hints fastInitHints;
+  ncclConfig_t rootConfig =
+      ncclConfigInitHelper(enableFastInitConfig, fastInitHints);
+  ncclx::Hints rootHints;
+  rootHints.set("commDesc", "root_communicator");
+  rootConfig.hints = &rootHints;
+  ncclConfig_t childConfig =
+      ncclConfigInitHelper(enableFastInitConfig, fastInitHints);
 
   NCCLCHECK_TEST(ncclCommInitRankConfig(
       &rootComm, numRanks, commId, globalRank, &rootConfig));
@@ -375,12 +420,23 @@ TEST_P(NcclxBaseTestFixture, NcclCommSplitNoColor) {
   EXPECT_EQ(statex->nRanks(), numRanks);
 
   // set up childConfig for split
-  childConfig.splitGroupSize = numRanks / 2;
-  std::vector<int> groupRanks(childConfig.splitGroupSize);
-  childConfig.splitGroupRanks = groupRanks.data();
-  for (int i = 0; i < childConfig.splitGroupSize; ++i) {
+  int splitGroupSize = numRanks / 2;
+  std::vector<int> groupRanks(splitGroupSize);
+  for (int i = 0; i < splitGroupSize; ++i) {
     groupRanks.at(i) = i * 2 + 1;
   }
+  ncclx::Hints childNoColorHints;
+  childNoColorHints.set("commDesc", "child_communicator");
+  {
+    std::string ranksStr;
+    for (int i = 0; i < splitGroupSize; ++i) {
+      if (i > 0)
+        ranksStr += ",";
+      ranksStr += std::to_string(groupRanks[i]);
+    }
+    childNoColorHints.set("splitGroupRanks", ranksStr);
+  }
+  childConfig.hints = &childNoColorHints;
   // do ncclCommSplit: even ranks have no color
   if (globalRank % 2 == 0) {
     NCCLCHECK_TEST(ncclCommSplit(
@@ -417,16 +473,23 @@ TEST_P(NcclxBaseTestFixture, NcclCommInitWithDifferentCommDesc) {
   ncclUniqueId commId1, commId2;
 
   // Create first comm with commDesc "comm_desc_1"
-  ncclConfig_t config1 = ncclConfigInitHelper(enableFastInitConfig);
-  config1.commDesc = "comm_desc_1";
+  ncclx::Hints fastInitHints;
+  ncclConfig_t config1 =
+      ncclConfigInitHelper(enableFastInitConfig, fastInitHints);
+  ncclx::Hints hints1;
+  hints1.set("commDesc", "comm_desc_1");
+  config1.hints = &hints1;
   NCCLCHECK_TEST(
       ncclCommInitRankConfig(&comm1, numRanks, commId1, globalRank, &config1));
   ASSERT_NE(nullptr, comm1);
   validateCtranInitialization(comm1, globalRank, numRanks, localRank);
 
   // Create second comm with commDesc "comm_desc_2"
-  ncclConfig_t config2 = ncclConfigInitHelper(enableFastInitConfig);
-  config2.commDesc = "comm_desc_2";
+  ncclConfig_t config2 =
+      ncclConfigInitHelper(enableFastInitConfig, fastInitHints);
+  ncclx::Hints hints2;
+  hints2.set("commDesc", "comm_desc_2");
+  config2.hints = &hints2;
   NCCLCHECK_TEST(
       ncclCommInitRankConfig(&comm2, numRanks, commId2, globalRank, &config2));
   ASSERT_NE(nullptr, comm2);

--- a/comms/ncclx/v2_28/meta/transport/tests/LazyConnectTest.cc
+++ b/comms/ncclx/v2_28/meta/transport/tests/LazyConnectTest.cc
@@ -9,6 +9,7 @@
 #include "comms/testinfra/TestsDistUtils.h"
 
 #include "comm.h"
+#include "meta/NcclxConfig.h"
 #include "nccl.h"
 
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -20,6 +21,7 @@ class NcclxLazyConnectTestFixture : public NcclxBaseTestFixture {
   void* sendBuf{nullptr};
   void* recvBuf{nullptr};
   ncclDataType_t dataType{ncclBfloat16};
+  ncclx::Hints splitCommHints_;
 
  protected:
   void SetUp() override {
@@ -46,7 +48,9 @@ class NcclxLazyConnectTestFixture : public NcclxBaseTestFixture {
   void splitComm(ncclComm_t* newChildComm) {
     ncclComm_t childComm;
     ncclConfig_t childCommConfig = NCCL_CONFIG_INITIALIZER;
-    childCommConfig.commDesc = "child_communicator";
+    splitCommHints_ = ncclx::Hints();
+    splitCommHints_.set("commDesc", "child_communicator");
+    childCommConfig.hints = &splitCommHints_;
     // split rootComm into two communicators, in round-robin fashion
     // e.g. 8-rank rootComm ->
     //        ranks 0, 2, 4, 6 form 1st childComm
@@ -520,16 +524,18 @@ TEST_P(NcclxLazyConnectTestFixture, ChildCommLazyConfig) {
   // channels
   ncclComm_t childComm = nullptr;
   ncclConfig_t childCommConfig = NCCL_CONFIG_INITIALIZER;
-  childCommConfig.lazyConnect = 1;
-  childCommConfig.lazySetupChannels = 1;
+  ncclx::Hints lazyHints;
+  lazyHints.set("lazyConnect", "1");
+  lazyHints.set("lazySetupChannels", "1");
+  childCommConfig.hints = &lazyHints;
   NCCLCHECK_TEST(
       ncclCommSplit(rootComm, 0, globalRank, &childComm, &childCommConfig));
   ASSERT_NE(nullptr, childComm);
 
   // child comm should always have lazy connect and setup channels enabled and
   // not allocate any channels
-  EXPECT_EQ(childComm->config.lazyConnect, 1);
-  EXPECT_EQ(childComm->config.lazySetupChannels, 1);
+  EXPECT_TRUE(NCCLX_CONFIG_FIELD(childComm->config, lazyConnect));
+  EXPECT_TRUE(NCCLX_CONFIG_FIELD(childComm->config, lazySetupChannels));
   for (int a = 0; a < NCCL_NUM_ALGORITHMS; a++) {
     EXPECT_FALSE(childComm->initAlgoChannels[a]);
   }

--- a/comms/ncclx/v2_28/meta/transport/transportConnect.cc
+++ b/comms/ncclx/v2_28/meta/transport/transportConnect.cc
@@ -3,6 +3,7 @@
 #include "bootstrap.h"
 #include "channel.h"
 #include "group.h"
+#include "meta/NcclxConfig.h" // @manual
 #include "p2p.h"
 #include "transport.h"
 
@@ -44,7 +45,8 @@ ncclResult_t transportRingConnect(struct ncclComm* comm, int nChannels) {
     INFO(
         NCCL_INIT,
         "commDesc: %s set up P2P connections for rings with %s on channel %d",
-        ctran::utils::parseCommDesc(comm->config.commDesc),
+        ctran::utils::parseCommDesc(
+            NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()),
         ringSummary.toString().c_str(),
         c);
   }
@@ -77,7 +79,8 @@ ncclResult_t transportRingConnect(struct ncclComm* comm, int nChannels) {
   INFO(
       NCCL_INIT,
       "commDesc: %s connected rings from channel %d to %d, use ring PXN %d GDR %d",
-      ctran::utils::parseCommDesc(comm->config.commDesc),
+      ctran::utils::parseCommDesc(
+          NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()),
       comm->algoConnectedChannels[NCCL_ALGO_RING],
       nChannels - 1,
       comm->useNetPXN,
@@ -108,7 +111,8 @@ ncclResult_t transportTreeConnect(struct ncclComm* comm, int nChannels) {
     INFO(
         NCCL_INIT,
         "commDesc: %s set up P2P connections for tree downward connections with %s on channel %d",
-        ctran::utils::parseCommDesc(comm->config.commDesc),
+        ctran::utils::parseCommDesc(
+            NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()),
         treeUpwardSummary.toString().c_str(),
         c);
     connectionSummary treeDownwardSummary;
@@ -124,7 +128,8 @@ ncclResult_t transportTreeConnect(struct ncclComm* comm, int nChannels) {
     INFO(
         NCCL_INIT,
         "commDesc: %s set up P2P connections for tree upward connections with %s on channel %d",
-        ctran::utils::parseCommDesc(comm->config.commDesc),
+        ctran::utils::parseCommDesc(
+            NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()),
         treeDownwardSummary.toString().c_str(),
         c);
   }
@@ -132,7 +137,8 @@ ncclResult_t transportTreeConnect(struct ncclComm* comm, int nChannels) {
   INFO(
       NCCL_INIT,
       "commDesc: %s connected Trees from channel %d to %d",
-      ctran::utils::parseCommDesc(comm->config.commDesc),
+      ctran::utils::parseCommDesc(
+          NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()),
       comm->algoConnectedChannels[NCCL_ALGO_TREE],
       nChannels - 1);
   comm->algoConnectedChannels[NCCL_ALGO_TREE] = nChannels;
@@ -163,7 +169,8 @@ ncclResult_t transportPatConnect(struct ncclComm* comm, int nChannels) {
       INFO(
           NCCL_INIT,
           "commDesc: %s set up P2P connections for RS binomial trees with %s on channel %d",
-          ctran::utils::parseCommDesc(comm->config.commDesc),
+          ctran::utils::parseCommDesc(
+              NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()),
           rsSummary.toString().c_str(),
           c);
     }
@@ -183,7 +190,8 @@ ncclResult_t transportPatConnect(struct ncclComm* comm, int nChannels) {
       INFO(
           NCCL_INIT,
           "commDesc: %s set up P2P connections for AG binomial trees with %s on channel %d",
-          ctran::utils::parseCommDesc(comm->config.commDesc),
+          ctran::utils::parseCommDesc(
+              NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()),
           agSummary.toString().c_str(),
           c);
     }
@@ -192,7 +200,8 @@ ncclResult_t transportPatConnect(struct ncclComm* comm, int nChannels) {
   INFO(
       NCCL_INIT,
       "commDesc %s connected binomial trees channel from %d to %d",
-      ctran::utils::parseCommDesc(comm->config.commDesc),
+      ctran::utils::parseCommDesc(
+          NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()),
       comm->algoConnectedChannels[NCCL_ALGO_PAT],
       nChannels - 1);
   comm->algoConnectedChannels[NCCL_ALGO_PAT] = nChannels;
@@ -244,7 +253,8 @@ bool algoNeedConnect(struct ncclComm* comm, struct ncclTaskColl* task) {
     INFO(
         NCCL_INIT,
         "commDesc: %s commHash: %lx needs nChannels=%d (%d initialized) for op %s with %lu bytes using algo %s and protocol %s, (%d channels connected) %d total channels will be connected for this algo",
-        ctran::utils::parseCommDesc(comm->config.commDesc),
+        ctran::utils::parseCommDesc(
+            NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()),
         comm->commHash,
         task->nMaxChannels,
         comm->nChannelsReady,
@@ -275,7 +285,8 @@ void p2pNeedConnect(
   INFO(
       NCCL_INIT,
       "commDesc %s: commHash: %lx Channel-%d try %s connection setup for peer %d, nMaxChannelsNeedInit: %d",
-      ctran::utils::parseCommDesc(comm->config.commDesc),
+      ctran::utils::parseCommDesc(
+          NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()),
       comm->commHash,
       channelId,
       isSendNotRecv ? "send" : "recv",
@@ -291,7 +302,8 @@ ncclResult_t devCommSetupChannels(ncclComm_t comm) {
   INFO(
       NCCL_INIT,
       "commDesc: %s commHash: %lx devCommSetupChannels: copy channels' metadata, comm->nChannelsReady=%d",
-      ctran::utils::parseCommDesc(comm->config.commDesc),
+      ctran::utils::parseCommDesc(
+          NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()),
       comm->commHash,
       comm->nChannelsReady);
   auto sampleGuardBegin = EVENTS_SCUBA_UTIL_SAMPLE_GUARD("INIT");
@@ -360,7 +372,8 @@ ncclResult_t setupChannels(struct ncclComm* comm, int maxNchannels) {
   INFO(
       NCCL_INIT,
       "commDesc: %s: commHash: %lx setup %d channels and copy metadata to GPU from channel %d to %d",
-      ctran::utils::parseCommDesc(comm->config.commDesc),
+      ctran::utils::parseCommDesc(
+          NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()),
       comm->commHash,
       (maxNchannels - comm->nChannelsReady),
       comm->nChannelsReady,
@@ -637,7 +650,7 @@ ncclResult_t transportReConnect(
         ALLOC,
         "{}: comm {} re-connected all peers for current plan",
         __func__,
-        comm->config.commDesc);
+        NCCLX_CONFIG_FIELD(comm->config, commDesc));
     reqBufKeys.insert(
         reqBufKeys.end(),
         comm->connSetupBufKeys.begin(),
@@ -768,7 +781,8 @@ ncclResult_t p2pPreconnect(struct ncclComm* comm) {
   INFO(
       NCCL_INIT,
       "commDesc: %s new p2p send/recv needs to connect",
-      ctran::utils::parseCommDesc(comm->config.commDesc));
+      ctran::utils::parseCommDesc(
+          NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()));
   CUDACHECK(cudaSetDevice(comm->cudaDev));
   if (CPU_COUNT(&comm->cpuAffinity)) {
     sched_setaffinity(0, sizeof(cpu_set_t), &comm->cpuAffinity);
@@ -787,7 +801,8 @@ ncclResult_t p2pPreconnect(struct ncclComm* comm) {
   INFO(
       NCCL_INIT,
       "commDesc: %s new p2p send/recv finished preconnect",
-      ctran::utils::parseCommDesc(comm->config.commDesc));
+      ctran::utils::parseCommDesc(
+          NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()));
   return ncclSuccess;
 }
 
@@ -798,7 +813,8 @@ ncclResult_t collPreconnect(
   INFO(
       NCCL_INIT,
       "commDesc: %s new collective needs to connect",
-      ctran::utils::parseCommDesc(comm->config.commDesc));
+      ctran::utils::parseCommDesc(
+          NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()));
   CUDACHECK(cudaSetDevice(comm->cudaDev));
   if (CPU_COUNT(&comm->cpuAffinity)) {
     sched_setaffinity(0, sizeof(cpu_set_t), &comm->cpuAffinity);
@@ -857,7 +873,8 @@ ncclResult_t collPreconnect(
   INFO(
       NCCL_INIT,
       "commDesc: %s new collective finished preconnect",
-      ctran::utils::parseCommDesc(comm->config.commDesc));
+      ctran::utils::parseCommDesc(
+          NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()));
 
   return ret;
 }

--- a/comms/ncclx/v2_28/meta/transport/transportProxy.cc
+++ b/comms/ncclx/v2_28/meta/transport/transportProxy.cc
@@ -3,6 +3,7 @@
 // TODO: Migrate to comms/ctran/utils/Alloc.h once we implement
 // "ncclCuMemHostAlloc" equivalent
 #include "alloc.h"
+#include "meta/NcclxConfig.h" // @manual
 
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/utils/Utils.h"
@@ -179,7 +180,7 @@ commResult_t TransportProxy::enqueuePrepRequest(
       COLL,
       "{}: Enqueued request to prepare resources for current kernel plan: "
       "opCount={} (comm->opCount={}),channelMask={:x}, channelsReadyPtr={}({:#x})",
-      comm->config.commDesc,
+      NCCLX_CONFIG_FIELD(comm->config, commDesc),
       opCount,
       comm->opCount,
       channelMask,
@@ -260,7 +261,8 @@ void TransportProxy::testAny() {
           COLL,
           "Releasing {} bufKeys for comm {}",
           req->bufKeys.size(),
-          ctran::utils::parseCommDesc(req->comm->config.commDesc));
+          ctran::utils::parseCommDesc(
+              NCCLX_CONFIG_FIELD(req->comm->config, commDesc).c_str()));
       syncFlagPool_.push_back(ptr);
       req->state = commSuccess;
       CLOGF_SUBSYS(
@@ -319,7 +321,7 @@ void TransportProxy::prepResources(std::shared_ptr<TransportRequest> req) {
       INFO,
       COLL,
       "{}: Transport is ready for reqCount={}, req->channelMask={:x}, req->channelsReadyPtr={:x} ({:#x})",
-      req->comm->config.commDesc,
+      NCCLX_CONFIG_FIELD(req->comm->config, commDesc),
       req->opCount,
       req->channelMask,
       *req->channelsReadyPtr,

--- a/comms/ncclx/v2_28/meta/wrapper/CtranExComm.cc
+++ b/comms/ncclx/v2_28/meta/wrapper/CtranExComm.cc
@@ -2,6 +2,7 @@
 
 #include "checks.h"
 #include "comm.h"
+#include "meta/NcclxConfig.h" // @manual
 
 #include "comms/ctran/Ctran.h"
 #include "comms/ctran/CtranEx.h"
@@ -27,15 +28,23 @@ CtranExComm::CtranExComm(const ncclComm_t comm, const std::string& commDesc) {
   comm_ = NCCL_COMM_NULL;
 
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
-  config.commDesc = commDesc.c_str();
+  config.blocking = 1; // Ensure communicator is fully created upon return
+
+  ncclx::Hints hints;
+  hints.set("commDesc", commDesc);
   std::vector<int> globalRanks =
       comm->ctranComm_->statex_->commRanksToWorldRanksRef();
-  config.splitGroupRanks = globalRanks.data();
-  config.splitGroupSize = comm->ctranComm_->statex_->nRanks();
-  config.blocking = 1; // Ensure communicator is fully created upon return
-  // Enable lazy features to avoid allocating extra resources from baseline NCCL
-  config.lazyConnect = 1;
-  config.lazySetupChannels = 1;
+  std::string ranksStr;
+  for (size_t i = 0; i < globalRanks.size(); ++i) {
+    if (i > 0) {
+      ranksStr += ",";
+    }
+    ranksStr += std::to_string(globalRanks[i]);
+  }
+  hints.set("splitGroupRanks", ranksStr);
+  hints.set("lazyConnect", "1");
+  hints.set("lazySetupChannels", "1");
+  config.hints = &hints;
 
   // if parent comm is non-blocking, ncclCommSplit will be non-blocking
   // as well which would lead to undefined behavior. Adding a throw here to
@@ -44,7 +53,7 @@ CtranExComm::CtranExComm(const ncclComm_t comm, const std::string& commDesc) {
     CLOGF(
         ERR,
         "CTRAN-EX: parent communicator {} is non-blocking, which will cause CtranExComm commSplit to fail.",
-        comm->config.commDesc);
+        NCCLX_CONFIG_FIELD(comm->config, commDesc));
     throw std::runtime_error("CTRAN-EX: parent communicator is non-blocking");
   }
 

--- a/comms/ncclx/v2_28/meta/wrapper/MetaFactory.cc
+++ b/comms/ncclx/v2_28/meta/wrapper/MetaFactory.cc
@@ -8,6 +8,7 @@
 #include "comms/ctran/window/WinHintUtils.h"
 #include "comms/utils/checks.h"
 #include "comms/utils/commSpecs.h"
+#include "meta/NcclxConfig.h" // @manual
 #include "meta/wrapper/MetaFactory.h"
 
 using namespace ctran;
@@ -215,8 +216,9 @@ meta::comms::Hints ncclToMetaComm(const ncclx::Hints& hints) {
 ctranConfig makeCtranConfigFrom(ncclComm* comm) {
   struct ctranConfig tconfig = {
       .blocking = comm->config.blocking,
-      .commDesc = comm->config.commDesc ? comm->config.commDesc : "undefined",
-      .ncclAllGatherAlgo = comm->config.ncclAllGatherAlgo,
+      .commDesc = NCCLX_CONFIG_FIELD(comm->config, commDesc),
+      .ncclAllGatherAlgo =
+          NCCLX_CONFIG_FIELD(comm->config, ncclAllGatherAlgo).c_str(),
   };
   return tconfig;
 }

--- a/comms/ncclx/v2_28/meta/wrapper/tests/CtranExDistCommUT.cc
+++ b/comms/ncclx/v2_28/meta/wrapper/tests/CtranExDistCommUT.cc
@@ -63,7 +63,9 @@ TEST_F(CtranExCommTest, TestNonBlockingThrow) {
   ncclComm_t nonBlockingComm;
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
   config.blocking = 0;
-  config.commDesc = "nonBlockingParent";
+  ncclx::Hints nbHints;
+  nbHints.set("commDesc", "nonBlockingParent");
+  config.hints = &nbHints;
   ncclUniqueId id;
   // get NCCL unique ID at rank 0 and broadcast it to all others
   if (globalRank == 0) {

--- a/comms/ncclx/v2_28/src/bootstrap.cc
+++ b/comms/ncclx/v2_28/src/bootstrap.cc
@@ -5,6 +5,7 @@
  ************************************************************************/
 
 #include "nccl.h"
+#include "meta/NcclxConfig.h" // @manual
 #include "core.h"
 #include "utils.h"
 #include "bootstrap.h"
@@ -638,7 +639,7 @@ ncclResult_t formRingViaTcpStore(bootstrapState* state, ncclComm* comm) {
   myFollyAddr.setFromSockaddr(reinterpret_cast<sockaddr*>(&listenSockAddr), sizeof(listenSockAddr));
   INFO(NCCL_INIT, "rank %d listen on %s: %s", rank, bootstrapNetIfName, myFollyAddr.describe().c_str());
 
-  const std::string kKeyPrefix = std::string(kTcpStoreAddrKeyPrefix) + comm->config.commDesc + "-";
+  const std::string kKeyPrefix = std::string(kTcpStoreAddrKeyPrefix) + NCCLX_CONFIG_FIELD(comm->config, commDesc) + "-";
 
   // put my-rank's listenSockAddr e.g <rank0, info.extAddressListen>
   std::string myKey = kKeyPrefix + std::to_string(rank);
@@ -698,7 +699,7 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm) {
   state->cudaDev = comm->cudaDev;
   state->abortFlag = comm->abortFlag;
   state->net = comm->ncclNet;
-  state->fastInitMode = comm->config.fastInitMode;
+  state->fastInitMode = NCCLX_CONFIG_FIELD(comm->config, fastInitMode);
   comm->bootstrap = state;
   comm->magic = state->magic = BOOTSTRAP_HANDLE(handles, 0)->magic; // state and comm magic set to the first magic ID
 
@@ -859,7 +860,7 @@ ncclResult_t bootstrapSplit(uint64_t magic, struct ncclComm* comm, struct ncclCo
   state->cudaDev = comm->cudaDev;
   state->abortFlag = comm->abortFlag;
   state->net = comm->ncclNet;
-  state->fastInitMode = comm->config.fastInitMode;
+  state->fastInitMode = NCCLX_CONFIG_FIELD(comm->config, fastInitMode);
   comm->bootstrap = state;
   comm->magic = state->magic = magic;
 

--- a/comms/ncclx/v2_28/src/group.cc
+++ b/comms/ncclx/v2_28/src/group.cc
@@ -5,6 +5,7 @@
  ************************************************************************/
 
 #include "group.h"
+#include "meta/NcclxConfig.h" // @manual
 #include "debug.h"
 #include "enqueue.h"
 #include "transport.h"
@@ -326,7 +327,7 @@ static ncclResult_t doLaunches(struct ncclComm* head) {
             } else {
               NCCLCHECKGOTO(ncclLaunchKernel(comm, plan), result, failure);
             }
-            INFO(NCCL_COLL, "comm %s %p opCount %ld launched kernel for plan %p",  ctran::utils::parseCommDesc(comm->config.commDesc), comm, comm->opCount, plan);
+            INFO(NCCL_COLL, "comm %s %p opCount %ld launched kernel for plan %p",  ctran::utils::parseCommDesc(NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()), comm, comm->opCount, plan);
             // NOTE: bump up opCount right after launching kernel as this field is dedicated to track number of kernels
             // including both p2p and collective kernels, no matter proxyOp existance.
             // Known limitation: It won't be updated properly under cuda graph replay since it is not captured by the graph.

--- a/comms/ncclx/v2_28/src/include/bootstrap.h
+++ b/comms/ncclx/v2_28/src/include/bootstrap.h
@@ -65,7 +65,7 @@ struct bootstrapState {
 
   // Reference to CommLogData to object to facilicate logging
   struct CommLogData *logMetaDataPtr{nullptr};
-  int fastInitMode{NCCL_FAST_INIT_MODE_DEFAULT};
+  bool fastInitMode{false};
 };
 
 ncclResult_t bootstrapNetInit();

--- a/comms/ncclx/v2_28/src/include/utils.h
+++ b/comms/ncclx/v2_28/src/include/utils.h
@@ -31,7 +31,7 @@ uint64_t getHostHash();
 uint64_t getPidHash();
 ncclResult_t getRandomData(void* buffer, size_t bytes);
 
-bool isFastInitRingMode(int fastInitMode);
+bool isFastInitRingMode(bool fastInitMode);
 
 struct netIf {
   char prefix[64];

--- a/comms/ncclx/v2_28/src/init.cc
+++ b/comms/ncclx/v2_28/src/init.cc
@@ -5,6 +5,7 @@
  ************************************************************************/
 
 #include "nccl.h"
+#include "meta/NcclxConfig.h" // @manual
 #include "channel.h"
 #include "nvmlwrap.h"
 #include "gdrwrap.h"
@@ -33,6 +34,11 @@
 #include "nvtx_payload_schemas.h"
 #include "utils.h"
 #include <mutex>
+#include <algorithm>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
 #include "ce_coll.h"
 #include "nvtx.h"
 #include "env.h"
@@ -260,9 +266,11 @@ void ncclCommPushCudaGdrFree(struct ncclComm* comm, void* handle) {
 
 // Free NCCLX-specific resources
 static void ncclxCommFree(ncclComm_t comm) {
-  if (comm->config.ncclAllGatherAlgo) {
-    free((void*)comm->config.ncclAllGatherAlgo);
-  }
+  // Free the canonical ncclx::Config
+  auto* ncclxCfg =
+      static_cast<ncclx::Config*>(comm->config.ncclxConfig);
+  delete ncclxCfg;
+  comm->config.ncclxConfig = nullptr;
 }
 
 static ncclResult_t commFree(ncclComm_t comm) {
@@ -1017,9 +1025,9 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   timers[TIMER_INIT_ALLGATHER] = clockNano() - timers[TIMER_INIT_ALLGATHER];
 
   // Check for lazy channel setup support
-  comm->lazySetupChannels = comm->cuMemSupport && comm->config.lazySetupChannels;
+  comm->lazySetupChannels = comm->cuMemSupport && NCCLX_CONFIG_FIELD(comm->config, lazySetupChannels);
   // Check for runtime connect support
-  comm->runtimeConn = comm->cuMemSupport && comm->config.lazyConnect;
+  comm->runtimeConn = comm->cuMemSupport && NCCLX_CONFIG_FIELD(comm->config, lazyConnect);
 
   if (comm->runtimeConn == 0 && comm->lazySetupChannels == 1) {
     WARN("NCCL_RUNTIME_CONNECT is disabled but NCCL_LAZY_SETUP_CHANNELS is enabled, full lazy connect features will still be used");
@@ -1387,7 +1395,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   if (comm->lazySetupChannels) {
     INFO(
         NCCL_INIT,
-        "commDesc: %s NCCL_LAZY_SETUP_CHANNELS=true, initializing minimal required channels at runtime when needed", ctran::utils::parseCommDesc(comm->config.commDesc));
+        "commDesc: %s NCCL_LAZY_SETUP_CHANNELS=true, initializing minimal required channels at runtime when needed", ctran::utils::parseCommDesc(NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()));
     // cache the ring info to be used for setupChannel later when needed
     comm->rings = std::vector<int>(rings, rings + nranks * MAXCHANNELS);
   } else if (comm->runtimeConn) {
@@ -1638,14 +1646,14 @@ static ncclResult_t ncclxCommGetSplitInfo(struct ncclComm* comm, struct ncclComm
     return ncclSuccess;
   }
   CHECKABORT(
-      comm && comm->config.splitGroupRanks && comm->config.splitGroupSize > 0,
-      "Empty comm or undefined config of splitGroupRanks or splitGroupSize passed to ncclxCommGetSplitInfo");
+      comm && !NCCLX_CONFIG_FIELD(comm->config, splitGroupRanks).empty(),
+      "Empty comm or undefined config of splitGroupRanks passed to ncclxCommGetSplitInfo");
 
-  *nRanksRet = comm->config.splitGroupSize;
+  *nRanksRet = static_cast<int>(NCCLX_CONFIG_FIELD(comm->config, splitGroupRanks).size());
   *myRankRet = -1;
-  for (int i = 0; i < comm->config.splitGroupSize; i++) {
-    parentRanksRet[i] = comm->config.splitGroupRanks[i];
-    if (parent->rank == comm->config.splitGroupRanks[i]) {
+  for (size_t i = 0; i < NCCLX_CONFIG_FIELD(comm->config, splitGroupRanks).size(); i++) {
+    parentRanksRet[i] = NCCLX_CONFIG_FIELD(comm->config, splitGroupRanks)[i];
+    if (parent->rank == NCCLX_CONFIG_FIELD(comm->config, splitGroupRanks)[i]) {
       *myRankRet = i;
     }
   }
@@ -1688,7 +1696,7 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
     if (job->excludeRanksCount) {
       NCCLCHECKGOTO(getParentRanks(job->parent->nRanks, job->parent->rank, job->excludeRanksList, job->excludeRanksCount, &job->nranks, &job->myrank, parentRanks), res, fail);
     } else {
-      if (isFastInitRingMode(job->parent->config.fastInitMode)) {
+      if (isFastInitRingMode(NCCLX_CONFIG_FIELD(job->parent->config, fastInitMode))) {
         NCCLCHECKGOTO(ncclxCommGetSplitInfo(comm, job->parent, job->color, job->key, &job->nranks, &job->myrank, parentRanks), res, fail);
       } else {
         NCCLCHECKGOTO(commGetSplitInfo(comm, job->parent, job->color, job->key, &job->nranks, &job->myrank, parentRanks), res, fail);
@@ -1717,7 +1725,7 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
     comm->commHash = commIdHash = getHash(job->commId->internal, NCCL_UNIQUE_ID_BYTES);
     // [Meta] Fast-init mode won't get unique commId for different communicators
     // use ctran helper function to generate unique hash
-    if (isFastInitRingMode(comm->config.fastInitMode)) {
+    if (isFastInitRingMode(NCCLX_CONFIG_FIELD(comm->config, fastInitMode))) {
       comm->commHash = commIdHash = ctran::utils::generateCommHash(job->nranks);
     }
     timers[TIMER_INIT_ALLOC] = clockNano();
@@ -1734,7 +1742,7 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
   // init this communicator's  Logger fields
   comm->logMetaData.commId = commIdHash;
   comm->logMetaData.commHash = comm->commHash;
-  comm->logMetaData.commDesc = comm->config.commDesc ? comm->config.commDesc : "undefined";
+  comm->logMetaData.commDesc = NCCLX_CONFIG_FIELD(comm->config, commDesc);
   comm->logMetaData.rank = comm->rank;
   comm->logMetaData.nRanks = comm->nRanks;
 
@@ -1998,84 +2006,157 @@ static ncclResult_t envConfigOverride(ncclComm_t comm) {
   return ret;
 }
 
-static void ncclxCopyCommConfig(ncclComm_t childComm, ncclComm_t parnet) {
-  childComm->config.ncclAllGatherAlgo = parnet->config.ncclAllGatherAlgo
-      ? strdup(parnet->config.ncclAllGatherAlgo)
-      : nullptr;
-}
-
-static ncclResult_t copyCommConfig(ncclComm_t childComm, ncclComm_t parnet) {
-  memcpy(&childComm->config, &parnet->config, sizeof(ncclConfig_t));
-  ncclxCopyCommConfig(childComm, parnet);
+static ncclResult_t copyCommConfig(ncclComm_t childComm, ncclComm_t parent) {
+  memcpy(&childComm->config, &parent->config, sizeof(ncclConfig_t));
+  if (parent->config.ncclxConfig) {
+    childComm->config.ncclxConfig = new ncclx::Config(
+        *static_cast<ncclx::Config*>(parent->config.ncclxConfig));
+  }
   NCCLCHECK(envConfigOverride(childComm));
   return ncclSuccess;
 }
 
-static void ncclxParseCommConfig(
-    ncclConfig_t* internalConfigPtr,
-    ncclComm_t comm) {
-  /* set default communicator description */
-  NCCL_CONFIG_DEFAULT(
-      internalConfigPtr,
-      commDesc,
-      NCCL_CONFIG_UNDEF_PTR,
-      "undefined",
-      "Comm description",
-      "%s");
-  NCCL_CONFIG_DEFAULT(
-      internalConfigPtr,
-      splitGroupRanks,
-      NCCL_CONFIG_UNDEF_PTR,
-      nullptr,
-      "splitGroupRanks in communicator",
-      "%p");
-  NCCL_CONFIG_DEFAULT(
-      internalConfigPtr,
-      splitGroupSize,
-      NCCL_CONFIG_UNDEF_INT,
-      0,
-      "splitGroupSize in communicator",
-      "%d");
-  NCCL_CONFIG_DEFAULT(
-      internalConfigPtr,
-      ncclAllGatherAlgo,
-      NCCL_CONFIG_UNDEF_PTR,
-      "undefined",
-      "ncclAllGatherAlgo",
-      "%s");
-  /* Set default lazy features: Honor user-specified config first.
-   * If not set, use environment variable. */
-  NCCL_CONFIG_DEFAULT(
-      internalConfigPtr,
-      lazyConnect,
-      NCCL_CONFIG_UNDEF_INT,
-      NCCL_RUNTIME_CONNECT,
-      "lazyConnect",
-      "%d");
-  NCCL_CONFIG_DEFAULT(
-      internalConfigPtr,
-      lazySetupChannels,
-      NCCL_CONFIG_UNDEF_INT,
-      NCCL_LAZY_SETUP_CHANNELS,
-      "lazySetupChannels",
-      "%d");
-  NCCL_CONFIG_DEFAULT(
-      internalConfigPtr,
-      fastInitMode,
-      NCCL_CONFIG_UNDEF_INT,
-      NCCL_FAST_INIT_MODE_DEFAULT,
-      "fastInitMode",
-      "%d");
+ncclResult_t ncclxParseCommConfig(ncclConfig_t* config) {
+  // Already created? (idempotent)
+  if (config->ncclxConfig != NCCL_CONFIG_UNDEF_PTR &&
+      config->ncclxConfig != nullptr) {
+    return ncclSuccess;
+  }
 
-  comm->config.commDesc = internalConfigPtr->commDesc;
-  comm->config.splitGroupRanks = internalConfigPtr->splitGroupRanks;
-  comm->config.splitGroupSize = internalConfigPtr->splitGroupSize;
-  comm->config.ncclAllGatherAlgo = internalConfigPtr->ncclAllGatherAlgo
-      ? strdup(internalConfigPtr->ncclAllGatherAlgo)
-      : nullptr;
-  comm->config.lazyConnect = internalConfigPtr->lazyConnect;
-  comm->config.lazySetupChannels = internalConfigPtr->lazySetupChannels;
-  comm->config.fastInitMode = internalConfigPtr->fastInitMode;
+  // Read hints (if any)
+  ncclx::Hints* hints = nullptr;
+  if (config->hints != NCCL_CONFIG_UNDEF_PTR &&
+      config->hints != nullptr) {
+    hints = static_cast<ncclx::Hints*>(config->hints);
+  }
+
+  // Check if a hint key is present
+  auto hasHint = [&](const char* key) -> bool {
+    if (!hints) {
+      return false;
+    }
+    std::string val;
+    return hints->get(key, val) == ncclSuccess;
+  };
+
+  // Detect conflicts: a field must not be set in both the flat
+  // ncclConfig_t (old format) and hints (new format).
+  bool conflict = false;
+  auto checkPtrConflict = [&](const char* key,
+                              const void* flatVal) {
+    if (flatVal != nullptr && hasHint(key)) {
+      WARN("NCCLX config field '%s' set in both ncclConfig_t and "
+           "hints; use one or the other, not both", key);
+      conflict = true;
+    }
+  };
+  auto checkIntConflict = [&](const char* key, int flatVal) {
+    if (flatVal != NCCL_CONFIG_UNDEF_INT && hasHint(key)) {
+      WARN("NCCLX config field '%s' set in both ncclConfig_t and "
+           "hints; use one or the other, not both", key);
+      conflict = true;
+    }
+  };
+
+  checkPtrConflict("commDesc", config->commDesc);
+  checkPtrConflict("splitGroupRanks", config->splitGroupRanks);
+  checkPtrConflict("ncclAllGatherAlgo", config->ncclAllGatherAlgo);
+  checkIntConflict("lazyConnect", config->lazyConnect);
+  checkIntConflict("lazySetupChannels", config->lazySetupChannels);
+  checkIntConflict("fastInitMode", config->fastInitMode);
+
+  if (conflict) {
+    return ncclInvalidArgument;
+  }
+
+  auto ncclxCfg = std::make_unique<ncclx::Config>();
+
+  // Helper: read bool from flat int field (old), hint (new), or
+  // default.  Accepts 0/1, yes/no, true/false, y/n, t/f (case
+  // insensitive) when reading from hints.
+  auto getBool = [&](const char* key, int flatVal, bool def) -> bool {
+    if (flatVal != NCCL_CONFIG_UNDEF_INT) {
+      return flatVal != 0;
+    }
+    if (hints) {
+      std::string val;
+      if (hints->get(key, val) == ncclSuccess) {
+        std::string lower(val.size(), '\0');
+        std::transform(val.begin(), val.end(), lower.begin(), ::tolower);
+        if (lower == "1" || lower == "yes" || lower == "true" ||
+            lower == "y" || lower == "t") {
+          return true;
+        }
+        if (lower == "0" || lower == "no" || lower == "false" ||
+            lower == "n" || lower == "f") {
+          return false;
+        }
+        return std::stoi(val) != 0;
+      }
+    }
+    return def;
+  };
+
+  // Helper: read string from flat field (old), hint (new), or
+  // default.
+  auto getStr = [&](const char* key, const char* flatVal,
+                    const char* def) -> std::string {
+    if (flatVal != nullptr) {
+      return flatVal;
+    }
+    if (hints) {
+      std::string val;
+      if (hints->get(key, val) == ncclSuccess) {
+        return val;
+      }
+    }
+    return def ? def : "";
+  };
+
+  // Helper: read comma-separated int array from hint, or use flat
+  // field pointer directly.
+  auto getIntArray = [&](const char* key, int* flatVal,
+                         int flatSize) -> std::vector<int> {
+    if (flatVal != nullptr) {
+      return std::vector<int>(flatVal, flatVal + flatSize);
+    }
+    if (!hints) {
+      return {};
+    }
+    std::string val;
+    if (hints->get(key, val) != ncclSuccess) {
+      return {};
+    }
+    std::vector<int> elems;
+    std::istringstream ss(val);
+    std::string tok;
+    while (std::getline(ss, tok, ',')) {
+      elems.push_back(std::stoi(tok));
+    }
+    return elems;
+  };
+
+  ncclxCfg->commDesc =
+      getStr("commDesc", config->commDesc, "undefined");
+  ncclxCfg->splitGroupRanks = getIntArray(
+      "splitGroupRanks", config->splitGroupRanks,
+      config->splitGroupSize != NCCL_CONFIG_UNDEF_INT
+          ? config->splitGroupSize : 0);
+  ncclxCfg->ncclAllGatherAlgo =
+      getStr("ncclAllGatherAlgo", config->ncclAllGatherAlgo,
+             "undefined");
+  ncclxCfg->lazyConnect =
+      getBool("lazyConnect", config->lazyConnect,
+              NCCL_RUNTIME_CONNECT);
+  ncclxCfg->lazySetupChannels =
+      getBool("lazySetupChannels", config->lazySetupChannels,
+              NCCL_LAZY_SETUP_CHANNELS);
+  ncclxCfg->fastInitMode =
+      getBool("fastInitMode", config->fastInitMode,
+              NCCL_FAST_INIT_MODE_DEFAULT);
+
+  config->ncclxConfig = ncclxCfg.release();
+  return ncclSuccess;
 }
 
 static ncclResult_t parseCommConfig(ncclComm_t comm, ncclConfig_t *config) {
@@ -2224,8 +2305,8 @@ static ncclResult_t parseCommConfig(ncclComm_t comm, ncclConfig_t *config) {
   comm->config.nvlsCTAs = internalConfigPtr->nvlsCTAs;
   comm->config.nChannelsPerNetPeer = internalConfigPtr->nChannelsPerNetPeer;
   comm->config.nvlinkCentricSched = internalConfigPtr->nvlinkCentricSched;
-
-  ncclxParseCommConfig(internalConfigPtr, comm);
+  NCCLCHECK(ncclxParseCommConfig(internalConfigPtr));
+  comm->config.ncclxConfig = internalConfigPtr->ncclxConfig;
 
   NCCLCHECKGOTO(envConfigOverride(comm), ret, fail);
 
@@ -2291,7 +2372,11 @@ static ncclResult_t ncclCommInitRankDev(ncclComm_t* newcomm, int nranks, int nId
   comm->usePatAvg_ = ncclx::commUsePatAvg();
   comm->noLocal_ = ncclx::commNoLocal();
   INFO(NCCL_INIT, "CommInit comm %p commHash 0x%lx commDesc %s useCtran %d usePatAvg %d noLocal %d: %s %s %s",
-       comm, getHash(commId->internal, NCCL_UNIQUE_ID_BYTES), ctran::utils::parseCommDesc(config->commDesc),
+       comm, getHash(commId->internal, NCCL_UNIQUE_ID_BYTES),
+       ctran::utils::parseCommDesc(
+           (config->ncclxConfig != NCCL_CONFIG_UNDEF_PTR &&
+            config->ncclxConfig != nullptr)
+               ? NCCLX_CONFIG_FIELD(*config, commDesc).c_str() : "undefined"),
        comm->useCtran_, comm->usePatAvg_, comm->noLocal_, ncclx::getCommUseCtranConfig().c_str(),
        ncclx::getCommUsePatAvgConfig().c_str(), ncclx::getCommNoLocalConfig().c_str());
   *comm->abortFlagRefCount = 1;
@@ -2315,7 +2400,7 @@ static ncclResult_t ncclCommInitRankDev(ncclComm_t* newcomm, int nranks, int nId
   memcpy(job->commId, commId, nId * NCCL_UNIQUE_ID_BYTES);
 
   commIdEnv = ncclGetEnv("NCCL_COMM_ID");
-  if (commIdEnv && myrank == 0 && !isFastInitRingMode(comm->config.fastInitMode)) {
+  if (commIdEnv && myrank == 0 && !isFastInitRingMode(NCCLX_CONFIG_FIELD(comm->config, fastInitMode))) {
     INFO(NCCL_ENV, "NCCL_COMM_ID set by environment to %s", commIdEnv);
     if (nId > 1) {
       INFO(NCCL_INIT | NCCL_ENV, "NCCL_COMM_ID cannot be used with more than one ncclUniqueId");
@@ -2448,9 +2533,19 @@ ncclResult_t ncclCommInitRankConfig(ncclComm_t *newcomm, int nranks, ncclUniqueI
 
   NCCLCHECK(ncclInitEnv());
 
+  // Apply hints early so that config fields are populated before any
+  // field-specific reads below (e.g., fastInitMode).
+  if (config) {
+    NCCLCHECK(ncclxParseCommConfig(config));
+  }
+
   char allZeroUniqueId[NCCL_UNIQUE_ID_BYTES] = {0};
   bool uniqueIdIsInitialized = memcmp(commId.internal, allZeroUniqueId, NCCL_UNIQUE_ID_BYTES) != 0;
-  int fastInitMode = config ? config->fastInitMode : NCCL_FAST_INIT_MODE_DEFAULT;
+  bool fastInitMode = false;
+  if (config && config->ncclxConfig != NCCL_CONFIG_UNDEF_PTR &&
+      config->ncclxConfig != nullptr) {
+    fastInitMode = NCCLX_CONFIG_FIELD(*config, fastInitMode);
+  }
   if (isFastInitRingMode(fastInitMode)) {
     // in meta-fast-init mode, we don't need commId
     if (uniqueIdIsInitialized) {
@@ -2852,7 +2947,7 @@ static void commAbortLog(ncclComm_t comm, const std::string& abortScope) {
         "comm %p commHash %lx commDesc %s rank %d nRanks %d cudaDev %d busId %lx - Abort %s",
         comm,
         comm->commHash,
-        comm->config.commDesc,
+        NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str(),
         comm->rank,
         comm->nRanks,
         comm->cudaDev,
@@ -2985,7 +3080,7 @@ static ncclResult_t ncclCommInitChildComm(ncclComm_t comm, ncclComm_t* newcomm, 
     childComm->usePatAvg_ = ncclx::commUsePatAvg();
     childComm->noLocal_ = ncclx::commNoLocal();
     INFO(NCCL_INIT, "CommSplit comm %p commDesc %s useCtran %d usePatAvg %d noLocal %d: %s %s %s",
-        childComm, ctran::utils::parseCommDesc(childComm->config.commDesc),
+        childComm, ctran::utils::parseCommDesc(NCCLX_CONFIG_FIELD(childComm->config, commDesc).c_str()),
         childComm->useCtran_, childComm->usePatAvg_, childComm->noLocal_, ncclx::getCommUseCtranConfig().c_str(),
         ncclx::getCommUsePatAvgConfig().c_str(), ncclx::getCommNoLocalConfig().c_str());
   }

--- a/comms/ncclx/v2_28/src/misc/utils.cc
+++ b/comms/ncclx/v2_28/src/misc/utils.cc
@@ -66,8 +66,8 @@ ncclResult_t getHostName(char* hostname, int maxlen, const char delim) {
   return ncclSuccess;
 }
 
-bool isFastInitRingMode(int fastInitMode) {
-  return fastInitMode == NCCL_FAST_INIT_MODE_RING || NCCL_FASTINIT_MODE == NCCL_FASTINIT_MODE::ring_hybrid;
+bool isFastInitRingMode(bool fastInitMode) {
+  return fastInitMode || NCCL_FASTINIT_MODE == NCCL_FASTINIT_MODE::ring_hybrid;
 }
 
 static uint64_t hostHashValue = 0;

--- a/comms/ncclx/v2_28/src/nccl.h.in
+++ b/comms/ncclx/v2_28/src/nccl.h.in
@@ -47,6 +47,7 @@ extern "C" {
 #define NCCL_COMM_DUMP
 #define NCCL_COMM_GET_UNIQUE_HASH
 #define NCCL_COLLTRACE_CUDA_GRAPH_COMPATIBLE
+#define NCCLX_CONFIG_SUPPORTED
 
 /* Opaque handle to communicator */
 typedef struct ncclComm* ncclComm_t;
@@ -159,6 +160,16 @@ typedef struct ncclConfig_v22800 {
 
   // control the fast init features
   int fastInitMode{NCCL_CONFIG_UNDEF_INT};
+
+  // Opaque pointer to an ncclx::Hints object.  When non-null, NCCLX
+  // will read key-value pairs from this object and apply them to
+  // config fields that are still at their undefined defaults.
+  void* hints{NCCL_CONFIG_UNDEF_PTR};
+
+  // Internal field — do not access directly.  This would be private
+  // if ncclConfig_t were a C++ class.  Populated by NCCLX during
+  // communicator creation; users must not read or write this field.
+  void* ncclxConfig{NCCL_CONFIG_UNDEF_PTR};
 } ncclConfig_t;
 
 /* Config initializer must be assigned to initialize config structure when it is created.
@@ -188,6 +199,8 @@ typedef struct ncclConfig_v22800 {
   NCCL_CONFIG_UNDEF_INT,                    /* lazyConnect */           \
   NCCL_CONFIG_UNDEF_INT,                    /* lazySetupChannels */     \
   NCCL_CONFIG_UNDEF_INT,                    /* fastInitMode */          \
+  NCCL_CONFIG_UNDEF_PTR,                    /* hints */                  \
+  NCCL_CONFIG_UNDEF_PTR,                    /* ncclxConfig */            \
 }
 
 /* This struct will be used by ncclGroupSimulateEnd() API to query information about simulation. */

--- a/comms/ncclx/v2_28/src/transport/p2p.cc
+++ b/comms/ncclx/v2_28/src/transport/p2p.cc
@@ -5,6 +5,7 @@
  ************************************************************************/
 
 #include "comm.h"
+#include "meta/NcclxConfig.h" // @manual
 #include "graph.h"
 #include "utils.h"
 #include "shmutils.h"
@@ -254,7 +255,7 @@ ncclResult_t ncclP2pAllocateShareableBuffer(size_t size, int refcount, ncclIpcDe
       CUDACHECK(res);
     }
   }
-  INFO(NCCL_P2P|NCCL_ALLOC, "commDesc: %s Allocated shareable buffer %p size %zu ipcDesc %p for %s", ctran::utils::parseCommDesc(comm->config.commDesc), *ptr, size, ipcDesc, callsite);
+  INFO(NCCL_P2P|NCCL_ALLOC, "commDesc: %s Allocated shareable buffer %p size %zu ipcDesc %p for %s", ctran::utils::parseCommDesc(NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()), *ptr, size, ipcDesc, callsite);
 
   return ncclSuccess;
 }

--- a/comms/ncclx/v2_29/examples/HelloWorld.cc
+++ b/comms/ncclx/v2_29/examples/HelloWorld.cc
@@ -10,7 +10,9 @@ int main(int argc, char* argv[]) {
   cudaStream_t stream;
   int* userBuff = NULL;
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
-  config.commDesc = "example_pg";
+  ncclx::Hints hints;
+  hints.set("commDesc", "example_pg");
+  config.hints = &hints;
 
   ncclUniqueId ncclId;
   NCCLCHECK(ncclGetUniqueId(&ncclId));

--- a/comms/ncclx/v2_29/meta/NcclxConfig.h
+++ b/comms/ncclx/v2_29/meta/NcclxConfig.h
@@ -1,0 +1,51 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "nccl.h" // @manual
+
+namespace ncclx {
+
+struct Config {
+  // NCCLX-specific config fields (canonical storage).
+  // New fields should be added here, NOT to ncclConfig_t.
+  // When adding a new field, also add its key to knownHintKeys below.
+  std::string commDesc;
+  std::vector<int> splitGroupRanks;
+  std::string ncclAllGatherAlgo;
+  bool lazyConnect = false;
+  bool lazySetupChannels = false;
+  bool fastInitMode = false;
+};
+
+// Hint keys corresponding to Config fields above.  Used by
+// Hints::set() to warn on unrecognized keys (typo detection).
+inline const std::vector<std::string>& knownHintKeys() {
+  static const std::vector<std::string> keys = {
+      "commDesc",
+      "splitGroupRanks",
+      "ncclAllGatherAlgo",
+      "lazyConnect",
+      "lazySetupChannels",
+      "fastInitMode",
+  };
+  return keys;
+}
+
+} // namespace ncclx
+
+// Convenience macro: access an NCCLX-specific field from the canonical
+// ncclx::Config stored inside an ncclConfig_t.
+// Usage: NCCLX_CONFIG_FIELD(comm->config, commDesc)
+#define NCCLX_CONFIG_FIELD(cfg, field) \
+  (static_cast<ncclx::Config*>((cfg).ncclxConfig)->field)
+
+// Create ncclx::Config from config->hints (new format) or flat
+// ncclConfig_t fields (old format) with env-based defaults.  Returns
+// ncclInvalidArgument if a field is set in both formats.  Stores the
+// result in config->ncclxConfig.  Idempotent: does nothing if
+// ncclxConfig is already set.
+ncclResult_t ncclxParseCommConfig(ncclConfig_t* config);

--- a/comms/ncclx/v2_29/meta/commDump.cc
+++ b/comms/ncclx/v2_29/meta/commDump.cc
@@ -8,6 +8,7 @@
 #include <folly/json/json.h>
 
 #include "comm.h"
+#include "meta/NcclxConfig.h" // @manual
 #include "nccl.h"
 
 #include "comms/ctran/colltrace/MapperTrace.h"
@@ -95,7 +96,7 @@ static void dumpCommInfo(
   map["nRanks"] = std::to_string(comm->nRanks);
   map["localRanks"] = std::to_string(comm->localRanks);
   map["nNodes"] = std::to_string(comm->nNodes);
-  map["commDesc"] = toQuotedString(comm->config.commDesc);
+  map["commDesc"] = toQuotedString(NCCLX_CONFIG_FIELD(comm->config, commDesc));
 }
 
 static void dumpCommInfo(
@@ -235,7 +236,7 @@ __attribute__((visibility("default"))) ncclResult_t ncclCommDump(
         comm->rank,
         fmt::ptr(comm),
         comm->commHash,
-        comm->config.commDesc);
+        NCCLX_CONFIG_FIELD(comm->config, commDesc));
 
     dumpCommInfo(comm, map);
     if (NCCL_COLLTRACE_USE_NEW_COLLTRACE) {

--- a/comms/ncclx/v2_29/meta/comms-monitor/tests/CommsMonitorDist.cc
+++ b/comms/ncclx/v2_29/meta/comms-monitor/tests/CommsMonitorDist.cc
@@ -8,6 +8,7 @@
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
 #include "meta/comms-monitor/CommsMonitor.h"
+#include "nccl.h"
 
 using namespace ncclx::comms_monitor;
 
@@ -120,8 +121,9 @@ TEST_F(CommsMonitorDist, testCommSplit) {
   EXPECT_EQ(CommsMonitor::getNumOfCommMonitoring(), 1);
 
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
-  const std::string commDest = "split_comm";
-  config.commDesc = commDest.c_str();
+  ncclx::Hints splitHints;
+  splitHints.set("commDesc", "split_comm");
+  config.hints = &splitHints;
 
   ncclComm_t splitComm;
 
@@ -140,8 +142,9 @@ TEST_F(CommsMonitorDist, testCommSplitNoColor) {
   EXPECT_EQ(CommsMonitor::getNumOfCommMonitoring(), 1);
 
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
-  const std::string commDest = "split_comm";
-  config.commDesc = commDest.c_str();
+  ncclx::Hints noColorHints;
+  noColorHints.set("commDesc", "split_comm");
+  config.hints = &noColorHints;
 
   ncclComm_t splitComm;
 

--- a/comms/ncclx/v2_29/meta/comms-monitor/tests/CommsMonitorUT.cc
+++ b/comms/ncclx/v2_29/meta/comms-monitor/tests/CommsMonitorUT.cc
@@ -6,6 +6,7 @@
 #include "comm.h" // @manual
 #include "comms/ctran/Ctran.h" // @manual
 #include "comms/utils/cvars/nccl_cvars.h"
+#include "meta/NcclxConfig.h"
 #include "meta/colltrace/CollTrace.h" // @manual
 #include "meta/comms-monitor/CommsMonitor.h" // @manual
 #include "meta/wrapper/MetaFactory.h"
@@ -16,7 +17,9 @@ inline std::unique_ptr<ncclComm> createFakeNcclComm() {
   comm->nRanks = 1;
   comm->cudaDev = 0;
   comm->commHash = 0xfaceb00c;
-  comm->config.commDesc = "fake_comm";
+  auto* ncclxCfg = new ncclx::Config();
+  ncclxCfg->commDesc = "fake_comm";
+  comm->config.ncclxConfig = ncclxCfg;
   comm->localRank = 0;
   comm->localRanks = 1;
   comm->nNodes = 1;
@@ -31,7 +34,7 @@ inline std::unique_ptr<ncclComm> createFakeNcclComm() {
       comm->commHash,
       std::vector<ncclx::RankTopology>(), /* rankTopologies */
       std::vector<int>(), /* commRanksToWorldRanks */
-      comm->config.commDesc);
+      NCCLX_CONFIG_FIELD(comm->config, commDesc));
 
   return comm;
 }

--- a/comms/ncclx/v2_29/meta/commstate/FactoryCommStateX.cc
+++ b/comms/ncclx/v2_29/meta/commstate/FactoryCommStateX.cc
@@ -3,6 +3,7 @@
 #include "comm.h"
 #include "comms/ctran/commstate/CommStateX.h"
 #include "comms/ctran/utils/Checks.h"
+#include "meta/NcclxConfig.h" // @manual
 
 #include "bootstrap.h"
 #include "nvmlwrap.h"
@@ -51,7 +52,7 @@ std::unique_ptr<CommStateX> createCommStateXFromNcclComm(void* _comm) {
       comm->commHash,
       std::vector<RankTopology>(), /* rankTopologies */
       std::vector<int>(), /* commRanksToWorldRanks */
-      comm->config.commDesc);
+      NCCLX_CONFIG_FIELD(comm->config, commDesc));
 
   if (comm->noLocal_ ||
       NCCL_COMM_STATE_DEBUG_TOPO == NCCL_COMM_STATE_DEBUG_TOPO::nolocal) {

--- a/comms/ncclx/v2_29/meta/commstate/tests/CommStateXTest.cc
+++ b/comms/ncclx/v2_29/meta/commstate/tests/CommStateXTest.cc
@@ -11,6 +11,7 @@
 #include "comms/testinfra/TestUtils.h"
 
 #include "comms/ctran/commstate/CommStateX.h"
+#include "meta/NcclxConfig.h"
 #include "param.h" // @manual
 
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -40,7 +41,9 @@ static void fillDummyComm(ncclComm& comm, int numNvlDomain = 1) {
   comm.nRanks = 16;
   comm.cudaDev = 0;
   comm.commHash = 123456789;
-  comm.config.commDesc = "default_pg:0";
+  auto* ncclxCfg = new ncclx::Config();
+  ncclxCfg->commDesc = "default_pg:0";
+  comm.config.ncclxConfig = ncclxCfg;
 
   comm.localRank = 0;
   comm.localRanks = 8 / numNvlDomain; // local ranks in the same NVL domain
@@ -102,7 +105,7 @@ TEST(CommStateXTest, CreateVNodeFromNcclComm) {
   EXPECT_EQ(state->nLocalRanks(), nLocalRanks);
   EXPECT_EQ(state->nNodes(), comm.nRanks / nLocalRanks);
   EXPECT_EQ(state->commHash(), comm.commHash);
-  EXPECT_EQ(state->commDesc(), comm.config.commDesc);
+  EXPECT_EQ(state->commDesc(), NCCLX_CONFIG_FIELD(comm.config, commDesc));
   for (int i = 0; i < state->nRanks(); ++i) {
     EXPECT_EQ(state->node(i), i / nLocalRanks);
   }
@@ -146,7 +149,7 @@ TEST(CommStateXTest, CreateNoLocalFromNcclComm) {
   EXPECT_EQ(state->nLocalRanks(), 1);
   EXPECT_EQ(state->nNodes(), comm.nRanks);
   EXPECT_EQ(state->commHash(), comm.commHash);
-  EXPECT_EQ(state->commDesc(), comm.config.commDesc);
+  EXPECT_EQ(state->commDesc(), NCCLX_CONFIG_FIELD(comm.config, commDesc));
   for (int i = 0; i < state->nRanks(); ++i) {
     EXPECT_EQ(state->node(i), i);
   }
@@ -182,7 +185,7 @@ TEST_P(CommStateXNcclCommTestParamFixture, CreateFromNcclComm) {
   EXPECT_EQ(state->nRanks(), comm.nRanks);
   EXPECT_EQ(state->cudaDev(), comm.cudaDev);
   EXPECT_EQ(state->commHash(), comm.commHash);
-  EXPECT_EQ(state->commDesc(), comm.config.commDesc);
+  EXPECT_EQ(state->commDesc(), NCCLX_CONFIG_FIELD(comm.config, commDesc));
   EXPECT_EQ(state->localRank(), comm.localRank);
   EXPECT_EQ(state->nLocalRanks(), comm.localRanks);
   for (int i = 0; i < state->nRanks(); ++i) {

--- a/comms/ncclx/v2_29/meta/hints/Hints.cc
+++ b/comms/ncclx/v2_29/meta/hints/Hints.cc
@@ -7,7 +7,10 @@
 #include "comms/ctran/algos/AllToAll/AllToAllvDynamicHintUtils.h"
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/window/WinHintUtils.h"
+#include "meta/NcclxConfig.h" // @manual
 #include "meta/wrapper/MetaFactory.h"
+
+#include <algorithm>
 
 namespace ncclx {
 
@@ -34,7 +37,12 @@ Hints::set(const std::string& key, const std::string& val) {
     NCCLCHECK(metaCommToNccl(WinHintUtils::set(key, val, this->kv)));
     return ncclSuccess;
   } else {
-    return ncclInvalidArgument;
+    const auto& knownKeys = ncclx::knownHintKeys();
+    if (std::find(knownKeys.begin(), knownKeys.end(), key) == knownKeys.end()) {
+      WARN("NCCLX Hints: unknown key '%s'; check spelling", key.c_str());
+    }
+    this->kv[key] = val;
+    return ncclSuccess;
   }
 }
 

--- a/comms/ncclx/v2_29/meta/tests/CommDescTest.cc
+++ b/comms/ncclx/v2_29/meta/tests/CommDescTest.cc
@@ -10,6 +10,7 @@
 #include "comm.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
+#include "meta/NcclxConfig.h"
 #include "nccl.h"
 
 class commDescTest : public ::testing::Test {
@@ -32,7 +33,7 @@ TEST_F(commDescTest, getUndefinedCommDesc) {
   NcclCommRAII comm(this->globalRank, this->numRanks, this->localRank);
   ASSERT_NE(nullptr, static_cast<ncclComm_t>(comm));
 
-  EXPECT_STREQ(comm->config.commDesc, "nccl_ut");
+  EXPECT_EQ(NCCLX_CONFIG_FIELD(comm->config, commDesc), "nccl_ut");
 }
 
 TEST_F(commDescTest, getDefinedCommDesc) {
@@ -46,14 +47,16 @@ TEST_F(commDescTest, getDefinedCommDesc) {
 
   ncclComm_t comm;
   ncclConfig_t inputConfig = NCCL_CONFIG_INITIALIZER;
-  inputConfig.commDesc = "test_description";
+  ncclx::Hints hints;
+  hints.set("commDesc", "test_description");
+  inputConfig.hints = &hints;
 
   NCCLCHECK_TEST(ncclCommInitRankConfig(
       &comm, numRanks, ncclId, globalRank, &inputConfig));
   ASSERT_NE(nullptr, comm);
 
-  EXPECT_STRNE(comm->config.commDesc, "undefined");
-  EXPECT_STREQ(comm->config.commDesc, inputConfig.commDesc);
+  EXPECT_NE(NCCLX_CONFIG_FIELD(comm->config, commDesc), "undefined");
+  EXPECT_EQ(NCCLX_CONFIG_FIELD(comm->config, commDesc), "test_description");
 
   NCCLCHECK_TEST(ncclCommDestroy(comm));
 }
@@ -71,7 +74,9 @@ TEST_F(commDescTest, InvalidPointerAccess) {
   ncclConfig_t inputConfig = NCCL_CONFIG_INITIALIZER;
   const char* commDescConst = "test_description";
   char* commDesc = strdup(commDescConst);
-  inputConfig.commDesc = commDesc;
+  ncclx::Hints hints;
+  hints.set("commDesc", commDesc);
+  inputConfig.hints = &hints;
 
   NCCLCHECK_TEST(ncclCommInitRankConfig(
       &comm, numRanks, ncclId, globalRank, &inputConfig));
@@ -79,8 +84,8 @@ TEST_F(commDescTest, InvalidPointerAccess) {
 
   free(commDesc);
 
-  EXPECT_STRNE(comm->config.commDesc, "undefined");
-  EXPECT_STREQ(comm->config.commDesc, commDescConst);
+  EXPECT_NE(NCCLX_CONFIG_FIELD(comm->config, commDesc), "undefined");
+  EXPECT_EQ(NCCLX_CONFIG_FIELD(comm->config, commDesc), commDescConst);
 
   NCCLCHECK_TEST(ncclCommDestroy(comm));
 }

--- a/comms/ncclx/v2_29/meta/tests/CommDumpTest.cc
+++ b/comms/ncclx/v2_29/meta/tests/CommDumpTest.cc
@@ -12,6 +12,7 @@
 #include "comm.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
+#include "meta/NcclxConfig.h"
 #include "nccl.h"
 
 #include "comms/utils/StrUtils.h"
@@ -173,7 +174,9 @@ TEST_F(CommDumpTest, SingleComm) {
   EXPECT_EQ(dump.count("node"), 1);
   EXPECT_EQ(dump["node"], std::to_string(this->comm->node));
   EXPECT_EQ(dump.count("commDesc"), 1);
-  EXPECT_EQ(dump["commDesc"], toQuotedString(this->comm->config.commDesc));
+  EXPECT_EQ(
+      dump["commDesc"],
+      toQuotedString(NCCLX_CONFIG_FIELD(this->comm->config, commDesc)));
 
   EXPECT_EQ(dump.count("nRanks"), 1);
   EXPECT_EQ(dump["nRanks"], std::to_string(this->comm->nRanks));

--- a/comms/ncclx/v2_29/meta/tests/CommWithCtranTest.cc
+++ b/comms/ncclx/v2_29/meta/tests/CommWithCtranTest.cc
@@ -70,7 +70,9 @@ TEST_P(CommWithCtranTestParam, CtranEnableByHint) {
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
   config.blocking = blockingInit ? 1 : 0;
   const auto commDescStr = fmt::format("{}-{}", kNcclUtCommDesc, "useCtran");
-  config.commDesc = commDescStr.c_str();
+  ncclx::Hints ctranHints;
+  ctranHints.set("commDesc", commDescStr);
+  config.hints = &ctranHints;
 
   // Enable by hint
   ASSERT_EQ(

--- a/comms/ncclx/v2_29/meta/tests/CommWithNoLocalTest.cc
+++ b/comms/ncclx/v2_29/meta/tests/CommWithNoLocalTest.cc
@@ -68,7 +68,9 @@ TEST_P(CommWithNoLocalTestParam, NoLocalEnableByHint) {
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
   config.blocking = blockingInit ? 1 : 0;
   const auto commDescStr = fmt::format("{}-{}", kNcclUtCommDesc, "noLocal");
-  config.commDesc = commDescStr.c_str();
+  ncclx::Hints noLocalHints;
+  noLocalHints.set("commDesc", commDescStr);
+  config.hints = &noLocalHints;
 
   // Enable by hint
   ASSERT_EQ(

--- a/comms/ncclx/v2_29/meta/tests/CommWithPatAvgTest.cc
+++ b/comms/ncclx/v2_29/meta/tests/CommWithPatAvgTest.cc
@@ -82,7 +82,9 @@ TEST_P(CommWithPatAvgTestParam, PatAvgEnableByHintWithModes) {
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
   config.blocking = blockingInit ? 1 : 0;
   const auto commDescStr = fmt::format("{}-{}", kNcclUtCommDesc, "usePatAvg");
-  config.commDesc = commDescStr.c_str();
+  ncclx::Hints patAvgHints;
+  patAvgHints.set("commDesc", commDescStr);
+  config.hints = &patAvgHints;
 
   // Enable by hint
   ASSERT_EQ(

--- a/comms/ncclx/v2_29/meta/tests/FastInitTest.cc
+++ b/comms/ncclx/v2_29/meta/tests/FastInitTest.cc
@@ -11,6 +11,7 @@
 #include "comm.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
+#include "meta/NcclxConfig.h"
 #include "nccl.h"
 
 void printCommStateX(const ncclComm& comm) {
@@ -40,10 +41,14 @@ void validateCtranInitialization(
   EXPECT_EQ(comm->commHash, comm->ctranComm_->statex_->commHash());
 }
 
-ncclConfig_t ncclConfigInitHelper(bool enableFastInitConfig) {
+ncclConfig_t ncclConfigInitHelper(
+    bool enableFastInitConfig,
+    ncclx::Hints& hints) {
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
   if (enableFastInitConfig) {
-    config.fastInitMode = NCCL_FAST_INIT_MODE_RING;
+    hints = ncclx::Hints();
+    hints.set("fastInitMode", std::to_string(NCCL_FAST_INIT_MODE_RING));
+    config.hints = &hints;
   }
   return config;
 }
@@ -57,7 +62,8 @@ ncclResult_t ncclCommInitRankConfigHelper(
   if (!enableFastInitConfig) {
     return ncclCommInitRankConfig(comm, nRanks, commId, myRank, nullptr);
   } else {
-    ncclConfig_t config = ncclConfigInitHelper(enableFastInitConfig);
+    ncclx::Hints hints;
+    ncclConfig_t config = ncclConfigInitHelper(enableFastInitConfig, hints);
     return ncclCommInitRankConfig(comm, nRanks, commId, myRank, &config);
   }
 }
@@ -138,17 +144,28 @@ TEST_P(NcclxBaseTestFixture, NcclCommSplit) {
   validateCtranInitialization(rootComm, globalRank, numRanks, localRank);
 
   ncclComm_t childComm = nullptr;
-  ncclConfig_t childCommConfig = ncclConfigInitHelper(enableFastInitConfig);
+  ncclx::Hints fastInitHints;
+  ncclConfig_t childCommConfig =
+      ncclConfigInitHelper(enableFastInitConfig, fastInitHints);
   int color = globalRank % 2;
   std::string childCommDesc = "child_communicator_" + std::to_string(color);
-  childCommConfig.commDesc = childCommDesc.c_str();
   int groupSize = rootComm->ctranComm_->statex_.get()->nRanks() / 2;
   int* groupRanks = new int[groupSize];
   for (int i = 0; i < groupSize; ++i) {
     *(groupRanks + i) = 2 * i + globalRank % 2;
   }
-  childCommConfig.splitGroupRanks = groupRanks;
-  childCommConfig.splitGroupSize = groupSize;
+  ncclx::Hints splitHints;
+  splitHints.set("commDesc", childCommDesc);
+  {
+    std::string ranksStr;
+    for (int i = 0; i < groupSize; ++i) {
+      if (i > 0)
+        ranksStr += ",";
+      ranksStr += std::to_string(groupRanks[i]);
+    }
+    splitHints.set("splitGroupRanks", ranksStr);
+  }
+  childCommConfig.hints = &splitHints;
   NCCLCHECK_TEST(ncclCommSplit(
       rootComm, color, globalRank / 2, &childComm, &childCommConfig));
   ASSERT_NE(nullptr, childComm);
@@ -166,7 +183,9 @@ TEST_P(NcclxBaseTestFixture, NcclCommSplit) {
   EXPECT_EQ(statex1->nLocalRanks(), localSize / 2);
 
   ncclComm expectedComm;
-  expectedComm.config.commDesc = childCommConfig.commDesc;
+  auto* ncclxCfg = new ncclx::Config();
+  ncclxCfg->commDesc = childCommDesc;
+  expectedComm.config.ncclxConfig = ncclxCfg;
   setCtranCommBase(&expectedComm);
 
   expectedComm.ctranComm_->statex_ = std::make_unique<ncclx::CommStateX>(
@@ -204,17 +223,28 @@ TEST_P(NcclxBaseTestFixture, NcclCommSplitDuplicateGroups) {
   }
 
   // child comm config
-  ncclConfig_t childCommConfig = ncclConfigInitHelper(enableFastInitConfig);
+  ncclx::Hints fastInitHints;
+  ncclConfig_t childCommConfig =
+      ncclConfigInitHelper(enableFastInitConfig, fastInitHints);
   int color = globalRank % 2;
   std::string childCommDesc = "child_communicator_" + std::to_string(color);
-  childCommConfig.commDesc = childCommDesc.c_str();
   int groupSize = rootComm->ctranComm_->statex_.get()->nRanks() / 2;
   int* groupRanks = new int[groupSize];
   for (int i = 0; i < groupSize; ++i) {
     *(groupRanks + i) = 2 * i + globalRank % 2;
   }
-  childCommConfig.splitGroupRanks = groupRanks;
-  childCommConfig.splitGroupSize = groupSize;
+  ncclx::Hints dupSplitHints;
+  dupSplitHints.set("commDesc", childCommDesc);
+  {
+    std::string ranksStr;
+    for (int i = 0; i < groupSize; ++i) {
+      if (i > 0)
+        ranksStr += ",";
+      ranksStr += std::to_string(groupRanks[i]);
+    }
+    dupSplitHints.set("splitGroupRanks", ranksStr);
+  }
+  childCommConfig.hints = &dupSplitHints;
 
   ncclComm_t childComm1 = nullptr;
   NCCLCHECK_TEST(ncclCommSplit(
@@ -302,15 +332,26 @@ TEST_P(NcclxBaseTestFixture, ChildCommAllGather) {
   }
 
   ncclComm_t childComm = nullptr;
-  ncclConfig_t childCommConfig = ncclConfigInitHelper(enableFastInitConfig);
-  childCommConfig.commDesc = "child_communicator";
+  ncclx::Hints fastInitHints;
+  ncclConfig_t childCommConfig =
+      ncclConfigInitHelper(enableFastInitConfig, fastInitHints);
   int groupSize = rootComm->ctranComm_->statex_.get()->nRanks() / 2;
   int* groupRanks = new int[groupSize];
   for (int i = 0; i < groupSize; ++i) {
     *(groupRanks + i) = 2 * i + globalRank % 2;
   }
-  childCommConfig.splitGroupRanks = groupRanks;
-  childCommConfig.splitGroupSize = groupSize;
+  ncclx::Hints childAgHints;
+  childAgHints.set("commDesc", "child_communicator");
+  {
+    std::string ranksStr;
+    for (int i = 0; i < groupSize; ++i) {
+      if (i > 0)
+        ranksStr += ",";
+      ranksStr += std::to_string(groupRanks[i]);
+    }
+    childAgHints.set("splitGroupRanks", ranksStr);
+  }
+  childCommConfig.hints = &childAgHints;
   NCCLCHECK_TEST(ncclCommSplit(
       rootComm, globalRank % 2, globalRank / 2, &childComm, &childCommConfig));
   ASSERT_NE(nullptr, childComm);
@@ -358,10 +399,14 @@ TEST_P(NcclxBaseTestFixture, NcclCommSplitNoColor) {
   ncclComm_t rootComm = nullptr;
   ncclComm_t childComm = NCCL_COMM_NULL;
   ncclUniqueId commId;
-  ncclConfig_t rootConfig = ncclConfigInitHelper(enableFastInitConfig);
-  rootConfig.commDesc = "root_communicator";
-  ncclConfig_t childConfig = ncclConfigInitHelper(enableFastInitConfig);
-  childConfig.commDesc = "child_communicator";
+  ncclx::Hints fastInitHints;
+  ncclConfig_t rootConfig =
+      ncclConfigInitHelper(enableFastInitConfig, fastInitHints);
+  ncclx::Hints rootHints;
+  rootHints.set("commDesc", "root_communicator");
+  rootConfig.hints = &rootHints;
+  ncclConfig_t childConfig =
+      ncclConfigInitHelper(enableFastInitConfig, fastInitHints);
 
   NCCLCHECK_TEST(ncclCommInitRankConfig(
       &rootComm, numRanks, commId, globalRank, &rootConfig));
@@ -375,12 +420,23 @@ TEST_P(NcclxBaseTestFixture, NcclCommSplitNoColor) {
   EXPECT_EQ(statex->nRanks(), numRanks);
 
   // set up childConfig for split
-  childConfig.splitGroupSize = numRanks / 2;
-  std::vector<int> groupRanks(childConfig.splitGroupSize);
-  childConfig.splitGroupRanks = groupRanks.data();
-  for (int i = 0; i < childConfig.splitGroupSize; ++i) {
+  int splitGroupSize = numRanks / 2;
+  std::vector<int> groupRanks(splitGroupSize);
+  for (int i = 0; i < splitGroupSize; ++i) {
     groupRanks.at(i) = i * 2 + 1;
   }
+  ncclx::Hints childNoColorHints;
+  childNoColorHints.set("commDesc", "child_communicator");
+  {
+    std::string ranksStr;
+    for (int i = 0; i < splitGroupSize; ++i) {
+      if (i > 0)
+        ranksStr += ",";
+      ranksStr += std::to_string(groupRanks[i]);
+    }
+    childNoColorHints.set("splitGroupRanks", ranksStr);
+  }
+  childConfig.hints = &childNoColorHints;
   // do ncclCommSplit: even ranks have no color
   if (globalRank % 2 == 0) {
     NCCLCHECK_TEST(ncclCommSplit(
@@ -417,16 +473,23 @@ TEST_P(NcclxBaseTestFixture, NcclCommInitWithDifferentCommDesc) {
   ncclUniqueId commId1, commId2;
 
   // Create first comm with commDesc "comm_desc_1"
-  ncclConfig_t config1 = ncclConfigInitHelper(enableFastInitConfig);
-  config1.commDesc = "comm_desc_1";
+  ncclx::Hints fastInitHints;
+  ncclConfig_t config1 =
+      ncclConfigInitHelper(enableFastInitConfig, fastInitHints);
+  ncclx::Hints hints1;
+  hints1.set("commDesc", "comm_desc_1");
+  config1.hints = &hints1;
   NCCLCHECK_TEST(
       ncclCommInitRankConfig(&comm1, numRanks, commId1, globalRank, &config1));
   ASSERT_NE(nullptr, comm1);
   validateCtranInitialization(comm1, globalRank, numRanks, localRank);
 
   // Create second comm with commDesc "comm_desc_2"
-  ncclConfig_t config2 = ncclConfigInitHelper(enableFastInitConfig);
-  config2.commDesc = "comm_desc_2";
+  ncclConfig_t config2 =
+      ncclConfigInitHelper(enableFastInitConfig, fastInitHints);
+  ncclx::Hints hints2;
+  hints2.set("commDesc", "comm_desc_2");
+  config2.hints = &hints2;
   NCCLCHECK_TEST(
       ncclCommInitRankConfig(&comm2, numRanks, commId2, globalRank, &config2));
   ASSERT_NE(nullptr, comm2);

--- a/comms/ncclx/v2_29/meta/transport/tests/LazyConnectTest.cc
+++ b/comms/ncclx/v2_29/meta/transport/tests/LazyConnectTest.cc
@@ -9,6 +9,7 @@
 #include "comms/testinfra/TestsDistUtils.h"
 
 #include "comm.h"
+#include "meta/NcclxConfig.h"
 #include "nccl.h"
 
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -43,10 +44,14 @@ class NcclxLazyConnectTestFixture : public NcclxBaseTestFixture {
     NcclxBaseTestFixture::TearDown();
   }
 
+  ncclx::Hints splitCommHints_;
+
   void splitComm(ncclComm_t* newChildComm) {
     ncclComm_t childComm;
     ncclConfig_t childCommConfig = NCCL_CONFIG_INITIALIZER;
-    childCommConfig.commDesc = "child_communicator";
+    splitCommHints_ = ncclx::Hints();
+    splitCommHints_.set("commDesc", "child_communicator");
+    childCommConfig.hints = &splitCommHints_;
     // split rootComm into two communicators, in round-robin fashion
     // e.g. 8-rank rootComm ->
     //        ranks 0, 2, 4, 6 form 1st childComm
@@ -520,16 +525,18 @@ TEST_P(NcclxLazyConnectTestFixture, ChildCommLazyConfig) {
   // channels
   ncclComm_t childComm = nullptr;
   ncclConfig_t childCommConfig = NCCL_CONFIG_INITIALIZER;
-  childCommConfig.lazyConnect = 1;
-  childCommConfig.lazySetupChannels = 1;
+  ncclx::Hints lazyHints;
+  lazyHints.set("lazyConnect", "1");
+  lazyHints.set("lazySetupChannels", "1");
+  childCommConfig.hints = &lazyHints;
   NCCLCHECK_TEST(
       ncclCommSplit(rootComm, 0, globalRank, &childComm, &childCommConfig));
   ASSERT_NE(nullptr, childComm);
 
   // child comm should always have lazy connect and setup channels enabled and
   // not allocate any channels
-  EXPECT_EQ(childComm->config.lazyConnect, 1);
-  EXPECT_EQ(childComm->config.lazySetupChannels, 1);
+  EXPECT_TRUE(NCCLX_CONFIG_FIELD(childComm->config, lazyConnect));
+  EXPECT_TRUE(NCCLX_CONFIG_FIELD(childComm->config, lazySetupChannels));
   for (int a = 0; a < NCCL_NUM_ALGORITHMS; a++) {
     EXPECT_FALSE(childComm->initAlgoChannels[a]);
   }

--- a/comms/ncclx/v2_29/meta/transport/transportConnect.cc
+++ b/comms/ncclx/v2_29/meta/transport/transportConnect.cc
@@ -3,6 +3,7 @@
 #include "bootstrap.h"
 #include "channel.h"
 #include "group.h"
+#include "meta/NcclxConfig.h" // @manual
 #include "p2p.h"
 #include "transport.h"
 
@@ -44,7 +45,8 @@ ncclResult_t transportRingConnect(struct ncclComm* comm, int nChannels) {
     INFO(
         NCCL_INIT,
         "commDesc: %s set up P2P connections for rings with %s on channel %d",
-        ctran::utils::parseCommDesc(comm->config.commDesc),
+        ctran::utils::parseCommDesc(
+            NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()),
         ringSummary.toString().c_str(),
         c);
   }
@@ -77,7 +79,8 @@ ncclResult_t transportRingConnect(struct ncclComm* comm, int nChannels) {
   INFO(
       NCCL_INIT,
       "commDesc: %s connected rings from channel %d to %d, use ring PXN %d GDR %d",
-      ctran::utils::parseCommDesc(comm->config.commDesc),
+      ctran::utils::parseCommDesc(
+          NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()),
       comm->algoConnectedChannels[NCCL_ALGO_RING],
       nChannels - 1,
       comm->useNetPXN,
@@ -108,7 +111,8 @@ ncclResult_t transportTreeConnect(struct ncclComm* comm, int nChannels) {
     INFO(
         NCCL_INIT,
         "commDesc: %s set up P2P connections for tree downward connections with %s on channel %d",
-        ctran::utils::parseCommDesc(comm->config.commDesc),
+        ctran::utils::parseCommDesc(
+            NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()),
         treeUpwardSummary.toString().c_str(),
         c);
     connectionSummary treeDownwardSummary;
@@ -124,7 +128,8 @@ ncclResult_t transportTreeConnect(struct ncclComm* comm, int nChannels) {
     INFO(
         NCCL_INIT,
         "commDesc: %s set up P2P connections for tree upward connections with %s on channel %d",
-        ctran::utils::parseCommDesc(comm->config.commDesc),
+        ctran::utils::parseCommDesc(
+            NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()),
         treeDownwardSummary.toString().c_str(),
         c);
   }
@@ -132,7 +137,8 @@ ncclResult_t transportTreeConnect(struct ncclComm* comm, int nChannels) {
   INFO(
       NCCL_INIT,
       "commDesc: %s connected Trees from channel %d to %d",
-      ctran::utils::parseCommDesc(comm->config.commDesc),
+      ctran::utils::parseCommDesc(
+          NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()),
       comm->algoConnectedChannels[NCCL_ALGO_TREE],
       nChannels - 1);
   comm->algoConnectedChannels[NCCL_ALGO_TREE] = nChannels;
@@ -163,7 +169,8 @@ ncclResult_t transportPatConnect(struct ncclComm* comm, int nChannels) {
       INFO(
           NCCL_INIT,
           "commDesc: %s set up P2P connections for RS binomial trees with %s on channel %d",
-          ctran::utils::parseCommDesc(comm->config.commDesc),
+          ctran::utils::parseCommDesc(
+              NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()),
           rsSummary.toString().c_str(),
           c);
     }
@@ -183,7 +190,8 @@ ncclResult_t transportPatConnect(struct ncclComm* comm, int nChannels) {
       INFO(
           NCCL_INIT,
           "commDesc: %s set up P2P connections for AG binomial trees with %s on channel %d",
-          ctran::utils::parseCommDesc(comm->config.commDesc),
+          ctran::utils::parseCommDesc(
+              NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()),
           agSummary.toString().c_str(),
           c);
     }
@@ -192,7 +200,8 @@ ncclResult_t transportPatConnect(struct ncclComm* comm, int nChannels) {
   INFO(
       NCCL_INIT,
       "commDesc %s connected binomial trees channel from %d to %d",
-      ctran::utils::parseCommDesc(comm->config.commDesc),
+      ctran::utils::parseCommDesc(
+          NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()),
       comm->algoConnectedChannels[NCCL_ALGO_PAT],
       nChannels - 1);
   comm->algoConnectedChannels[NCCL_ALGO_PAT] = nChannels;
@@ -244,7 +253,8 @@ bool algoNeedConnect(struct ncclComm* comm, struct ncclTaskColl* task) {
     INFO(
         NCCL_INIT,
         "commDesc: %s commHash: %lx needs nChannels=%d (%d initialized) for op %s with %lu bytes using algo %s and protocol %s, (%d channels connected) %d total channels will be connected for this algo",
-        ctran::utils::parseCommDesc(comm->config.commDesc),
+        ctran::utils::parseCommDesc(
+            NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()),
         comm->commHash,
         task->nMaxChannels,
         comm->nChannelsReady,
@@ -275,7 +285,8 @@ void p2pNeedConnect(
   INFO(
       NCCL_INIT,
       "commDesc %s: commHash: %lx Channel-%d try %s connection setup for peer %d, nMaxChannelsNeedInit: %d",
-      ctran::utils::parseCommDesc(comm->config.commDesc),
+      ctran::utils::parseCommDesc(
+          NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()),
       comm->commHash,
       channelId,
       isSendNotRecv ? "send" : "recv",
@@ -291,7 +302,8 @@ ncclResult_t devCommSetupChannels(ncclComm_t comm) {
   INFO(
       NCCL_INIT,
       "commDesc: %s commHash: %lx devCommSetupChannels: copy channels' metadata, comm->nChannelsReady=%d",
-      ctran::utils::parseCommDesc(comm->config.commDesc),
+      ctran::utils::parseCommDesc(
+          NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()),
       comm->commHash,
       comm->nChannelsReady);
   auto sampleGuardBegin = EVENTS_SCUBA_UTIL_SAMPLE_GUARD("INIT");
@@ -360,7 +372,8 @@ ncclResult_t setupChannels(struct ncclComm* comm, int maxNchannels) {
   INFO(
       NCCL_INIT,
       "commDesc: %s: commHash: %lx setup %d channels and copy metadata to GPU from channel %d to %d",
-      ctran::utils::parseCommDesc(comm->config.commDesc),
+      ctran::utils::parseCommDesc(
+          NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()),
       comm->commHash,
       (maxNchannels - comm->nChannelsReady),
       comm->nChannelsReady,
@@ -637,7 +650,7 @@ ncclResult_t transportReConnect(
         ALLOC,
         "{}: comm {} re-connected all peers for current plan",
         __func__,
-        comm->config.commDesc);
+        NCCLX_CONFIG_FIELD(comm->config, commDesc));
     reqBufKeys.insert(
         reqBufKeys.end(),
         comm->connSetupBufKeys.begin(),
@@ -768,7 +781,8 @@ ncclResult_t p2pPreconnect(struct ncclComm* comm) {
   INFO(
       NCCL_INIT,
       "commDesc: %s new p2p send/recv needs to connect",
-      ctran::utils::parseCommDesc(comm->config.commDesc));
+      ctran::utils::parseCommDesc(
+          NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()));
   CUDACHECK(cudaSetDevice(comm->cudaDev));
   if (CPU_COUNT(&comm->cpuAffinity)) {
     sched_setaffinity(0, sizeof(cpu_set_t), &comm->cpuAffinity);
@@ -787,7 +801,8 @@ ncclResult_t p2pPreconnect(struct ncclComm* comm) {
   INFO(
       NCCL_INIT,
       "commDesc: %s new p2p send/recv finished preconnect",
-      ctran::utils::parseCommDesc(comm->config.commDesc));
+      ctran::utils::parseCommDesc(
+          NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()));
   return ncclSuccess;
 }
 
@@ -798,7 +813,8 @@ ncclResult_t collPreconnect(
   INFO(
       NCCL_INIT,
       "commDesc: %s new collective needs to connect",
-      ctran::utils::parseCommDesc(comm->config.commDesc));
+      ctran::utils::parseCommDesc(
+          NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()));
   CUDACHECK(cudaSetDevice(comm->cudaDev));
   if (CPU_COUNT(&comm->cpuAffinity)) {
     sched_setaffinity(0, sizeof(cpu_set_t), &comm->cpuAffinity);
@@ -857,7 +873,8 @@ ncclResult_t collPreconnect(
   INFO(
       NCCL_INIT,
       "commDesc: %s new collective finished preconnect",
-      ctran::utils::parseCommDesc(comm->config.commDesc));
+      ctran::utils::parseCommDesc(
+          NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()));
 
   return ret;
 }

--- a/comms/ncclx/v2_29/meta/transport/transportProxy.cc
+++ b/comms/ncclx/v2_29/meta/transport/transportProxy.cc
@@ -3,6 +3,7 @@
 // TODO: Migrate to comms/ctran/utils/Alloc.h once we implement
 // "ncclCuMemHostAlloc" equivalent
 #include "alloc.h"
+#include "meta/NcclxConfig.h" // @manual
 
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/utils/Utils.h"
@@ -179,7 +180,7 @@ commResult_t TransportProxy::enqueuePrepRequest(
       COLL,
       "{}: Enqueued request to prepare resources for current kernel plan: "
       "opCount={} (comm->opCount={}),channelMask={:x}, channelsReadyPtr={}({:#x})",
-      comm->config.commDesc,
+      NCCLX_CONFIG_FIELD(comm->config, commDesc),
       opCount,
       comm->opCount,
       channelMask,
@@ -260,7 +261,8 @@ void TransportProxy::testAny() {
           COLL,
           "Releasing {} bufKeys for comm {}",
           req->bufKeys.size(),
-          ctran::utils::parseCommDesc(req->comm->config.commDesc));
+          ctran::utils::parseCommDesc(
+              NCCLX_CONFIG_FIELD(req->comm->config, commDesc).c_str()));
       syncFlagPool_.push_back(ptr);
       req->state = commSuccess;
       CLOGF_SUBSYS(
@@ -319,7 +321,7 @@ void TransportProxy::prepResources(std::shared_ptr<TransportRequest> req) {
       INFO,
       COLL,
       "{}: Transport is ready for reqCount={}, req->channelMask={:x}, req->channelsReadyPtr={:x} ({:#x})",
-      req->comm->config.commDesc,
+      NCCLX_CONFIG_FIELD(req->comm->config, commDesc),
       req->opCount,
       req->channelMask,
       *req->channelsReadyPtr,

--- a/comms/ncclx/v2_29/meta/wrapper/CtranExComm.cc
+++ b/comms/ncclx/v2_29/meta/wrapper/CtranExComm.cc
@@ -2,6 +2,7 @@
 
 #include "checks.h"
 #include "comm.h"
+#include "meta/NcclxConfig.h" // @manual
 
 #include "comms/ctran/Ctran.h"
 #include "comms/ctran/CtranEx.h"
@@ -27,15 +28,23 @@ CtranExComm::CtranExComm(const ncclComm_t comm, const std::string& commDesc) {
   comm_ = NCCL_COMM_NULL;
 
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
-  config.commDesc = commDesc.c_str();
+  config.blocking = 1; // Ensure communicator is fully created upon return
+
+  ncclx::Hints hints;
+  hints.set("commDesc", commDesc);
   std::vector<int> globalRanks =
       comm->ctranComm_->statex_->commRanksToWorldRanksRef();
-  config.splitGroupRanks = globalRanks.data();
-  config.splitGroupSize = comm->ctranComm_->statex_->nRanks();
-  config.blocking = 1; // Ensure communicator is fully created upon return
-  // Enable lazy features to avoid allocating extra resources from baseline NCCL
-  config.lazyConnect = 1;
-  config.lazySetupChannels = 1;
+  std::string ranksStr;
+  for (size_t i = 0; i < globalRanks.size(); ++i) {
+    if (i > 0) {
+      ranksStr += ",";
+    }
+    ranksStr += std::to_string(globalRanks[i]);
+  }
+  hints.set("splitGroupRanks", ranksStr);
+  hints.set("lazyConnect", "1");
+  hints.set("lazySetupChannels", "1");
+  config.hints = &hints;
 
   // if parent comm is non-blocking, ncclCommSplit will be non-blocking
   // as well which would lead to undefined behavior. Adding a throw here to
@@ -44,7 +53,7 @@ CtranExComm::CtranExComm(const ncclComm_t comm, const std::string& commDesc) {
     CLOGF(
         ERR,
         "CTRAN-EX: parent communicator {} is non-blocking, which will cause CtranExComm commSplit to fail.",
-        comm->config.commDesc);
+        NCCLX_CONFIG_FIELD(comm->config, commDesc));
     throw std::runtime_error("CTRAN-EX: parent communicator is non-blocking");
   }
 

--- a/comms/ncclx/v2_29/meta/wrapper/MetaFactory.cc
+++ b/comms/ncclx/v2_29/meta/wrapper/MetaFactory.cc
@@ -8,6 +8,7 @@
 #include "comms/ctran/window/WinHintUtils.h"
 #include "comms/utils/checks.h"
 #include "comms/utils/commSpecs.h"
+#include "meta/NcclxConfig.h" // @manual
 #include "meta/wrapper/MetaFactory.h"
 
 using namespace ctran;
@@ -215,8 +216,9 @@ meta::comms::Hints ncclToMetaComm(const ncclx::Hints& hints) {
 ctranConfig makeCtranConfigFrom(ncclComm* comm) {
   struct ctranConfig tconfig = {
       .blocking = comm->config.blocking,
-      .commDesc = comm->config.commDesc ? comm->config.commDesc : "undefined",
-      .ncclAllGatherAlgo = comm->config.ncclAllGatherAlgo,
+      .commDesc = NCCLX_CONFIG_FIELD(comm->config, commDesc),
+      .ncclAllGatherAlgo =
+          NCCLX_CONFIG_FIELD(comm->config, ncclAllGatherAlgo).c_str(),
   };
   return tconfig;
 }

--- a/comms/ncclx/v2_29/meta/wrapper/tests/CtranExDistCommUT.cc
+++ b/comms/ncclx/v2_29/meta/wrapper/tests/CtranExDistCommUT.cc
@@ -63,7 +63,9 @@ TEST_F(CtranExCommTest, TestNonBlockingThrow) {
   ncclComm_t nonBlockingComm;
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
   config.blocking = 0;
-  config.commDesc = "nonBlockingParent";
+  ncclx::Hints nbHints;
+  nbHints.set("commDesc", "nonBlockingParent");
+  config.hints = &nbHints;
   ncclUniqueId id;
   // get NCCL unique ID at rank 0 and broadcast it to all others
   if (globalRank == 0) {

--- a/comms/ncclx/v2_29/src/bootstrap.cc
+++ b/comms/ncclx/v2_29/src/bootstrap.cc
@@ -6,6 +6,7 @@
  *************************************************************************/
 
 #include "nccl.h"
+#include "meta/NcclxConfig.h" // @manual
 #include "core.h"
 #include "utils.h"
 #include "bootstrap.h"
@@ -692,7 +693,7 @@ ncclResult_t formRingViaTcpStore(bootstrapState* state, ncclComm* comm) {
   myFollyAddr.setFromSockaddr(reinterpret_cast<sockaddr*>(&listenSockAddr), sizeof(listenSockAddr));
   INFO(NCCL_INIT, "rank %d listen on %s: %s", rank, bootstrapNetIfName, myFollyAddr.describe().c_str());
 
-  const std::string kKeyPrefix = std::string(kTcpStoreAddrKeyPrefix) + comm->config.commDesc + "-";
+  const std::string kKeyPrefix = std::string(kTcpStoreAddrKeyPrefix) + NCCLX_CONFIG_FIELD(comm->config, commDesc) + "-";
 
   // put my-rank's listenSockAddr e.g <rank0, info.extAddressListen>
   std::string myKey = kKeyPrefix + std::to_string(rank);
@@ -752,7 +753,7 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm, s
   state->cudaDev = comm->cudaDev;
   state->abortFlag = comm->abortFlag;
   state->net = comm->ncclNet;
-  state->fastInitMode = comm->config.fastInitMode;
+  state->fastInitMode = NCCLX_CONFIG_FIELD(comm->config, fastInitMode);
   comm->bootstrap = state;
 
   // Set magic: for grow existing ranks, receive from coordinator; otherwise use handle magic.
@@ -948,7 +949,7 @@ ncclResult_t bootstrapSplit(uint64_t magic, struct ncclComm* comm, struct ncclCo
   state->cudaDev = comm->cudaDev;
   state->abortFlag = comm->abortFlag;
   state->net = comm->ncclNet;
-  state->fastInitMode = comm->config.fastInitMode;
+  state->fastInitMode = NCCLX_CONFIG_FIELD(comm->config, fastInitMode);
   comm->bootstrap = state;
   comm->magic = state->magic = magic;
 

--- a/comms/ncclx/v2_29/src/group.cc
+++ b/comms/ncclx/v2_29/src/group.cc
@@ -6,6 +6,7 @@
  *************************************************************************/
 
 #include "group.h"
+#include "meta/NcclxConfig.h" // @manual
 #include "debug.h"
 #include "enqueue.h"
 #include "transport.h"
@@ -359,7 +360,7 @@ static ncclResult_t doLaunches(struct ncclComm* head) {
             } else {
               NCCLCHECKGOTO(ncclLaunchKernel(comm, plan), result, failure);
             }
-            INFO(NCCL_COLL, "comm %s %p opCount %ld launched kernel for plan %p",  ctran::utils::parseCommDesc(comm->config.commDesc), comm, comm->opCount, plan);
+            INFO(NCCL_COLL, "comm %s %p opCount %ld launched kernel for plan %p",  ctran::utils::parseCommDesc(NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()), comm, comm->opCount, plan);
             // NOTE: bump up opCount right after launching kernel as this field is dedicated to track number of kernels
             // including both p2p and collective kernels, no matter proxyOp existance.
             // Known limitation: It won't be updated properly under cuda graph replay since it is not captured by the graph.

--- a/comms/ncclx/v2_29/src/include/bootstrap.h
+++ b/comms/ncclx/v2_29/src/include/bootstrap.h
@@ -67,7 +67,7 @@ struct bootstrapState {
 
   // Reference to CommLogData to object to facilicate logging
   struct CommLogData *logMetaDataPtr{nullptr};
-  int fastInitMode{NCCL_FAST_INIT_MODE_DEFAULT};
+  bool fastInitMode{false};
 };
 
 ncclResult_t bootstrapNetInit();

--- a/comms/ncclx/v2_29/src/include/utils.h
+++ b/comms/ncclx/v2_29/src/include/utils.h
@@ -38,7 +38,7 @@ uint64_t getPidHash();
 uint64_t hashCombine(uint64_t baseHash, uint64_t value);
 ncclResult_t getRandomData(void* buffer, size_t bytes);
 
-bool isFastInitRingMode(int fastInitMode);
+bool isFastInitRingMode(bool fastInitMode);
 
 struct netIf {
   char prefix[64];

--- a/comms/ncclx/v2_29/src/init.cc
+++ b/comms/ncclx/v2_29/src/init.cc
@@ -6,6 +6,7 @@
  *************************************************************************/
 
 #include "nccl.h"
+#include "meta/NcclxConfig.h" // @manual
 #include "channel.h"
 #include "nvmlwrap.h"
 #include "gdrwrap.h"
@@ -23,7 +24,12 @@
 #include "compiler.h"
 #include "profiler.h"
 #include "mnnvl.h"
+#include <algorithm>
+#include <memory>
+#include <sstream>
+#include <string>
 #include <sys/stat.h>
+#include <vector>
 #include "param.h"
 #include "nvtx_payload_schemas.h"
 #include "utils.h"
@@ -279,9 +285,11 @@ void ncclCommPushCudaGdrFree(struct ncclComm* comm, void* handle) {
 
 // Free NCCLX-specific resources
 static void ncclxCommFree(ncclComm_t comm) {
-  if (comm->config.ncclAllGatherAlgo) {
-    free((void*)comm->config.ncclAllGatherAlgo);
-  }
+  // Free the canonical ncclx::Config
+  auto* ncclxCfg =
+      static_cast<ncclx::Config*>(comm->config.ncclxConfig);
+  delete ncclxCfg;
+  comm->config.ncclxConfig = nullptr;
 }
 
 static ncclResult_t commFree(ncclComm_t comm) {
@@ -1091,9 +1099,9 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   timers[TIMER_INIT_ALLGATHER] = clockNano() - timers[TIMER_INIT_ALLGATHER];
 
   // Check for lazy channel setup support
-  comm->lazySetupChannels = comm->cuMemSupport && comm->config.lazySetupChannels;
+  comm->lazySetupChannels = comm->cuMemSupport && NCCLX_CONFIG_FIELD(comm->config, lazySetupChannels);
   // Check for runtime connect support
-  comm->runtimeConn = comm->cuMemSupport && comm->config.lazyConnect;
+  comm->runtimeConn = comm->cuMemSupport && NCCLX_CONFIG_FIELD(comm->config, lazyConnect);
 
   if (comm->runtimeConn == 0 && comm->lazySetupChannels == 1) {
     WARN("NCCL_RUNTIME_CONNECT is disabled but NCCL_LAZY_SETUP_CHANNELS is enabled, full lazy connect features will still be used");
@@ -1480,7 +1488,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   if (comm->lazySetupChannels) {
     INFO(
         NCCL_INIT,
-        "commDesc: %s NCCL_LAZY_SETUP_CHANNELS=true, initializing minimal required channels at runtime when needed", ctran::utils::parseCommDesc(comm->config.commDesc));
+        "commDesc: %s NCCL_LAZY_SETUP_CHANNELS=true, initializing minimal required channels at runtime when needed", ctran::utils::parseCommDesc(NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()));
     // cache the ring info to be used for setupChannel later when needed
     comm->rings = std::vector<int>(rings, rings + nranks * MAXCHANNELS);
   } else if (comm->runtimeConn) {
@@ -1750,14 +1758,14 @@ static ncclResult_t ncclxCommGetSplitInfo(struct ncclComm* comm, struct ncclComm
     return ncclSuccess;
   }
   CHECKABORT(
-      comm && comm->config.splitGroupRanks && comm->config.splitGroupSize > 0,
-      "Empty comm or undefined config of splitGroupRanks or splitGroupSize passed to ncclxCommGetSplitInfo");
+      comm && !NCCLX_CONFIG_FIELD(comm->config, splitGroupRanks).empty(),
+      "Empty comm or undefined config of splitGroupRanks passed to ncclxCommGetSplitInfo");
 
-  *nRanksRet = comm->config.splitGroupSize;
+  *nRanksRet = static_cast<int>(NCCLX_CONFIG_FIELD(comm->config, splitGroupRanks).size());
   *myRankRet = -1;
-  for (int i = 0; i < comm->config.splitGroupSize; i++) {
-    parentRanksRet[i] = comm->config.splitGroupRanks[i];
-    if (parent->rank == comm->config.splitGroupRanks[i]) {
+  for (size_t i = 0; i < NCCLX_CONFIG_FIELD(comm->config, splitGroupRanks).size(); i++) {
+    parentRanksRet[i] = NCCLX_CONFIG_FIELD(comm->config, splitGroupRanks)[i];
+    if (parent->rank == NCCLX_CONFIG_FIELD(comm->config, splitGroupRanks)[i]) {
       *myRankRet = i;
     }
   }
@@ -1801,7 +1809,7 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
     if (job->excludeRanksCount) {
       NCCLCHECKGOTO(getParentRanks(job->parent->nRanks, job->parent->rank, job->excludeRanksList, job->excludeRanksCount, &job->nranks, &job->myrank, parentRanks), res, fail);
     } else {
-      if (isFastInitRingMode(job->parent->config.fastInitMode)) {
+      if (isFastInitRingMode(NCCLX_CONFIG_FIELD(job->parent->config, fastInitMode))) {
         NCCLCHECKGOTO(ncclxCommGetSplitInfo(comm, job->parent, job->color, job->key, &job->nranks, &job->myrank, parentRanks), res, fail);
       } else {
         NCCLCHECKGOTO(commGetSplitInfo(comm, job->parent, job->color, job->key, &job->nranks, &job->myrank, parentRanks), res, fail);
@@ -1830,7 +1838,7 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
     // GROW or NORMAL INIT: use bootstrapInit
     // [Meta] Fast-init mode won't get unique commId for different communicators
     // use ctran helper function to generate unique hash
-    if (isFastInitRingMode(comm->config.fastInitMode)) {
+    if (isFastInitRingMode(NCCLX_CONFIG_FIELD(comm->config, fastInitMode))) {
       comm->commHash = commIdHash = ctran::utils::generateCommHash(job->nranks);
     }
     if (job->isGrow) {
@@ -1859,7 +1867,7 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
   // init this communicator's  Logger fields
   comm->logMetaData.commId = commIdHash;
   comm->logMetaData.commHash = comm->commHash;
-  comm->logMetaData.commDesc = comm->config.commDesc ? comm->config.commDesc : "undefined";
+  comm->logMetaData.commDesc = NCCLX_CONFIG_FIELD(comm->config, commDesc);
   comm->logMetaData.rank = comm->rank;
   comm->logMetaData.nRanks = comm->nRanks;
 
@@ -2173,84 +2181,157 @@ static ncclResult_t envConfigOverride(ncclComm_t comm) {
   return ret;
 }
 
-static void ncclxCopyCommConfig(ncclComm_t childComm, ncclComm_t parnet) {
-  childComm->config.ncclAllGatherAlgo = parnet->config.ncclAllGatherAlgo
-      ? strdup(parnet->config.ncclAllGatherAlgo)
-      : nullptr;
-}
-
-static ncclResult_t copyCommConfig(ncclComm_t childComm, ncclComm_t parnet) {
-  memcpy(&childComm->config, &parnet->config, sizeof(ncclConfig_t));
-  ncclxCopyCommConfig(childComm, parnet);
+static ncclResult_t copyCommConfig(ncclComm_t childComm, ncclComm_t parent) {
+  memcpy(&childComm->config, &parent->config, sizeof(ncclConfig_t));
+  if (parent->config.ncclxConfig) {
+    childComm->config.ncclxConfig = new ncclx::Config(
+        *static_cast<ncclx::Config*>(parent->config.ncclxConfig));
+  }
   NCCLCHECK(envConfigOverride(childComm));
   return ncclSuccess;
 }
 
-static void ncclxParseCommConfig(
-    ncclConfig_t* internalConfigPtr,
-    ncclComm_t comm) {
-  /* set default communicator description */
-  NCCL_CONFIG_DEFAULT(
-      internalConfigPtr,
-      commDesc,
-      NCCL_CONFIG_UNDEF_PTR,
-      "undefined",
-      "Comm description",
-      "%s");
-  NCCL_CONFIG_DEFAULT(
-      internalConfigPtr,
-      splitGroupRanks,
-      NCCL_CONFIG_UNDEF_PTR,
-      nullptr,
-      "splitGroupRanks in communicator",
-      "%p");
-  NCCL_CONFIG_DEFAULT(
-      internalConfigPtr,
-      splitGroupSize,
-      NCCL_CONFIG_UNDEF_INT,
-      0,
-      "splitGroupSize in communicator",
-      "%d");
-  NCCL_CONFIG_DEFAULT(
-      internalConfigPtr,
-      ncclAllGatherAlgo,
-      NCCL_CONFIG_UNDEF_PTR,
-      "undefined",
-      "ncclAllGatherAlgo",
-      "%s");
-  /* Set default lazy features: Honor user-specified config first.
-   * If not set, use environment variable. */
-  NCCL_CONFIG_DEFAULT(
-      internalConfigPtr,
-      lazyConnect,
-      NCCL_CONFIG_UNDEF_INT,
-      NCCL_RUNTIME_CONNECT,
-      "lazyConnect",
-      "%d");
-  NCCL_CONFIG_DEFAULT(
-      internalConfigPtr,
-      lazySetupChannels,
-      NCCL_CONFIG_UNDEF_INT,
-      NCCL_LAZY_SETUP_CHANNELS,
-      "lazySetupChannels",
-      "%d");
-  NCCL_CONFIG_DEFAULT(
-      internalConfigPtr,
-      fastInitMode,
-      NCCL_CONFIG_UNDEF_INT,
-      NCCL_FAST_INIT_MODE_DEFAULT,
-      "fastInitMode",
-      "%d");
+ncclResult_t ncclxParseCommConfig(ncclConfig_t* config) {
+  // Already created? (idempotent)
+  if (config->ncclxConfig != NCCL_CONFIG_UNDEF_PTR &&
+      config->ncclxConfig != nullptr) {
+    return ncclSuccess;
+  }
 
-  comm->config.commDesc = internalConfigPtr->commDesc;
-  comm->config.splitGroupRanks = internalConfigPtr->splitGroupRanks;
-  comm->config.splitGroupSize = internalConfigPtr->splitGroupSize;
-  comm->config.ncclAllGatherAlgo = internalConfigPtr->ncclAllGatherAlgo
-      ? strdup(internalConfigPtr->ncclAllGatherAlgo)
-      : nullptr;
-  comm->config.lazyConnect = internalConfigPtr->lazyConnect;
-  comm->config.lazySetupChannels = internalConfigPtr->lazySetupChannels;
-  comm->config.fastInitMode = internalConfigPtr->fastInitMode;
+  // Read hints (if any)
+  ncclx::Hints* hints = nullptr;
+  if (config->hints != NCCL_CONFIG_UNDEF_PTR &&
+      config->hints != nullptr) {
+    hints = static_cast<ncclx::Hints*>(config->hints);
+  }
+
+  // Check if a hint key is present
+  auto hasHint = [&](const char* key) -> bool {
+    if (!hints) {
+      return false;
+    }
+    std::string val;
+    return hints->get(key, val) == ncclSuccess;
+  };
+
+  // Detect conflicts: a field must not be set in both the flat
+  // ncclConfig_t (old format) and hints (new format).
+  bool conflict = false;
+  auto checkPtrConflict = [&](const char* key,
+                              const void* flatVal) {
+    if (flatVal != nullptr && hasHint(key)) {
+      WARN("NCCLX config field '%s' set in both ncclConfig_t and "
+           "hints; use one or the other, not both", key);
+      conflict = true;
+    }
+  };
+  auto checkIntConflict = [&](const char* key, int flatVal) {
+    if (flatVal != NCCL_CONFIG_UNDEF_INT && hasHint(key)) {
+      WARN("NCCLX config field '%s' set in both ncclConfig_t and "
+           "hints; use one or the other, not both", key);
+      conflict = true;
+    }
+  };
+
+  checkPtrConflict("commDesc", config->commDesc);
+  checkPtrConflict("splitGroupRanks", config->splitGroupRanks);
+  checkPtrConflict("ncclAllGatherAlgo", config->ncclAllGatherAlgo);
+  checkIntConflict("lazyConnect", config->lazyConnect);
+  checkIntConflict("lazySetupChannels", config->lazySetupChannels);
+  checkIntConflict("fastInitMode", config->fastInitMode);
+
+  if (conflict) {
+    return ncclInvalidArgument;
+  }
+
+  auto ncclxCfg = std::make_unique<ncclx::Config>();
+
+  // Helper: read bool from flat int field (old), hint (new), or
+  // default.  Accepts 0/1, yes/no, true/false, y/n, t/f (case
+  // insensitive) when reading from hints.
+  auto getBool = [&](const char* key, int flatVal, bool def) -> bool {
+    if (flatVal != NCCL_CONFIG_UNDEF_INT) {
+      return flatVal != 0;
+    }
+    if (hints) {
+      std::string val;
+      if (hints->get(key, val) == ncclSuccess) {
+        std::string lower(val.size(), '\0');
+        std::transform(val.begin(), val.end(), lower.begin(), ::tolower);
+        if (lower == "1" || lower == "yes" || lower == "true" ||
+            lower == "y" || lower == "t") {
+          return true;
+        }
+        if (lower == "0" || lower == "no" || lower == "false" ||
+            lower == "n" || lower == "f") {
+          return false;
+        }
+        return std::stoi(val) != 0;
+      }
+    }
+    return def;
+  };
+
+  // Helper: read string from flat field (old), hint (new), or
+  // default.
+  auto getStr = [&](const char* key, const char* flatVal,
+                    const char* def) -> std::string {
+    if (flatVal != nullptr) {
+      return flatVal;
+    }
+    if (hints) {
+      std::string val;
+      if (hints->get(key, val) == ncclSuccess) {
+        return val;
+      }
+    }
+    return def ? def : "";
+  };
+
+  // Helper: read comma-separated int array from hint, or use flat
+  // field pointer directly.
+  auto getIntArray = [&](const char* key, int* flatVal,
+                         int flatSize) -> std::vector<int> {
+    if (flatVal != nullptr) {
+      return std::vector<int>(flatVal, flatVal + flatSize);
+    }
+    if (!hints) {
+      return {};
+    }
+    std::string val;
+    if (hints->get(key, val) != ncclSuccess) {
+      return {};
+    }
+    std::vector<int> elems;
+    std::istringstream ss(val);
+    std::string tok;
+    while (std::getline(ss, tok, ',')) {
+      elems.push_back(std::stoi(tok));
+    }
+    return elems;
+  };
+
+  ncclxCfg->commDesc =
+      getStr("commDesc", config->commDesc, "undefined");
+  ncclxCfg->splitGroupRanks = getIntArray(
+      "splitGroupRanks", config->splitGroupRanks,
+      config->splitGroupSize != NCCL_CONFIG_UNDEF_INT
+          ? config->splitGroupSize : 0);
+  ncclxCfg->ncclAllGatherAlgo =
+      getStr("ncclAllGatherAlgo", config->ncclAllGatherAlgo,
+             "undefined");
+  ncclxCfg->lazyConnect =
+      getBool("lazyConnect", config->lazyConnect,
+              NCCL_RUNTIME_CONNECT);
+  ncclxCfg->lazySetupChannels =
+      getBool("lazySetupChannels", config->lazySetupChannels,
+              NCCL_LAZY_SETUP_CHANNELS);
+  ncclxCfg->fastInitMode =
+      getBool("fastInitMode", config->fastInitMode,
+              NCCL_FAST_INIT_MODE_DEFAULT);
+
+  config->ncclxConfig = ncclxCfg.release();
+  return ncclSuccess;
 }
 
 static ncclResult_t parseCommConfig(ncclComm_t comm, ncclConfig_t *config) {
@@ -2401,8 +2482,6 @@ static ncclResult_t parseCommConfig(ncclComm_t comm, ncclConfig_t *config) {
   NCCL_CONFIG_DEFAULT(internalConfigPtr, nChannelsPerNetPeer, NCCL_CONFIG_UNDEF_INT,
                       NCCL_CONFIG_UNDEF_INT, "nChannelsPerNetPeer", "%d");
 
-  ncclxParseCommConfig(internalConfigPtr, comm);
-
   NCCL_CONFIG_DEFAULT(internalConfigPtr, nvlinkCentricSched, NCCL_CONFIG_UNDEF_INT, 0, "nvlinkCentricSched", "%d");
   NCCL_CONFIG_DEFAULT(internalConfigPtr, graphUsageMode, NCCL_CONFIG_UNDEF_INT, 2, "graphUsageMode", "%d");
   NCCL_CONFIG_DEFAULT(internalConfigPtr, numRmaCtx, NCCL_CONFIG_UNDEF_INT, 1, "numRmaCtx", "%d");
@@ -2424,6 +2503,8 @@ static ncclResult_t parseCommConfig(ncclComm_t comm, ncclConfig_t *config) {
   comm->config.nvlinkCentricSched = internalConfigPtr->nvlinkCentricSched;
   comm->config.graphUsageMode = internalConfigPtr->graphUsageMode;
   comm->config.numRmaCtx = internalConfigPtr->numRmaCtx;
+  NCCLCHECK(ncclxParseCommConfig(internalConfigPtr));
+  comm->config.ncclxConfig = internalConfigPtr->ncclxConfig;
   NCCLCHECKGOTO(envConfigOverride(comm), ret, fail);
 
 exit:
@@ -2488,7 +2569,11 @@ static ncclResult_t ncclCommInitRankDev(ncclComm_t* newcomm, int nranks, int nId
   comm->usePatAvg_ = ncclx::commUsePatAvg();
   comm->noLocal_ = ncclx::commNoLocal();
   INFO(NCCL_INIT, "CommInit comm %p commHash 0x%lx commDesc %s useCtran %d usePatAvg %d noLocal %d: %s %s %s",
-       comm, getHash(commId->internal, NCCL_UNIQUE_ID_BYTES), ctran::utils::parseCommDesc(config->commDesc),
+       comm, getHash(commId->internal, NCCL_UNIQUE_ID_BYTES),
+       ctran::utils::parseCommDesc(
+           (config->ncclxConfig != NCCL_CONFIG_UNDEF_PTR &&
+            config->ncclxConfig != nullptr)
+               ? NCCLX_CONFIG_FIELD(*config, commDesc).c_str() : "undefined"),
        comm->useCtran_, comm->usePatAvg_, comm->noLocal_, ncclx::getCommUseCtranConfig().c_str(),
        ncclx::getCommUsePatAvgConfig().c_str(), ncclx::getCommNoLocalConfig().c_str());
   *comm->abortFlagRefCount = 1;
@@ -2512,7 +2597,7 @@ static ncclResult_t ncclCommInitRankDev(ncclComm_t* newcomm, int nranks, int nId
   memcpy(job->commId, commId, nId * NCCL_UNIQUE_ID_BYTES);
 
   commIdEnv = ncclGetEnv("NCCL_COMM_ID");
-  if (commIdEnv && myrank == 0 && !isFastInitRingMode(comm->config.fastInitMode)) {
+  if (commIdEnv && myrank == 0 && !isFastInitRingMode(NCCLX_CONFIG_FIELD(comm->config, fastInitMode))) {
     INFO(NCCL_ENV, "NCCL_COMM_ID set by environment to %s", commIdEnv);
     if (nId > 1) {
       INFO(NCCL_INIT | NCCL_ENV, "NCCL_COMM_ID cannot be used with more than one ncclUniqueId");
@@ -2645,9 +2730,19 @@ ncclResult_t ncclCommInitRankConfig(ncclComm_t *newcomm, int nranks, ncclUniqueI
 
   NCCLCHECK(ncclInitEnv());
 
+  // Apply hints early so that config fields are populated before any
+  // field-specific reads below (e.g., fastInitMode).
+  if (config) {
+    NCCLCHECK(ncclxParseCommConfig(config));
+  }
+
   char allZeroUniqueId[NCCL_UNIQUE_ID_BYTES] = {0};
   bool uniqueIdIsInitialized = memcmp(commId.internal, allZeroUniqueId, NCCL_UNIQUE_ID_BYTES) != 0;
-  int fastInitMode = config ? config->fastInitMode : NCCL_FAST_INIT_MODE_DEFAULT;
+  bool fastInitMode = false;
+  if (config && config->ncclxConfig != NCCL_CONFIG_UNDEF_PTR &&
+      config->ncclxConfig != nullptr) {
+    fastInitMode = NCCLX_CONFIG_FIELD(*config, fastInitMode);
+  }
   if (isFastInitRingMode(fastInitMode)) {
     // in meta-fast-init mode, we don't need commId
     if (uniqueIdIsInitialized) {
@@ -3046,7 +3141,7 @@ static void commAbortLog(ncclComm_t comm, const std::string& abortScope) {
         "comm %p commHash %lx commDesc %s rank %d nRanks %d cudaDev %d busId %lx - Abort %s",
         comm,
         comm->commHash,
-        comm->config.commDesc,
+        NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str(),
         comm->rank,
         comm->nRanks,
         comm->cudaDev,
@@ -3179,7 +3274,7 @@ static ncclResult_t ncclCommInitChildComm(ncclComm_t comm, ncclComm_t* newcomm, 
     childComm->usePatAvg_ = ncclx::commUsePatAvg();
     childComm->noLocal_ = ncclx::commNoLocal();
     INFO(NCCL_INIT, "CommSplit comm %p commDesc %s useCtran %d usePatAvg %d noLocal %d: %s %s %s",
-        childComm, ctran::utils::parseCommDesc(childComm->config.commDesc),
+        childComm, ctran::utils::parseCommDesc(NCCLX_CONFIG_FIELD(childComm->config, commDesc).c_str()),
         childComm->useCtran_, childComm->usePatAvg_, childComm->noLocal_, ncclx::getCommUseCtranConfig().c_str(),
         ncclx::getCommUsePatAvgConfig().c_str(), ncclx::getCommNoLocalConfig().c_str());
   }

--- a/comms/ncclx/v2_29/src/misc/utils.cc
+++ b/comms/ncclx/v2_29/src/misc/utils.cc
@@ -80,8 +80,8 @@ ncclResult_t getHostName(char* hostname, int maxlen, const char delim) {
   return ncclSuccess;
 }
 
-bool isFastInitRingMode(int fastInitMode) {
-  return fastInitMode == NCCL_FAST_INIT_MODE_RING || NCCL_FASTINIT_MODE == NCCL_FASTINIT_MODE::ring_hybrid;
+bool isFastInitRingMode(bool fastInitMode) {
+  return fastInitMode || NCCL_FASTINIT_MODE == NCCL_FASTINIT_MODE::ring_hybrid;
 }
 
 static uint64_t hostHashValue = 0;

--- a/comms/ncclx/v2_29/src/nccl.h.in
+++ b/comms/ncclx/v2_29/src/nccl.h.in
@@ -48,6 +48,7 @@ extern "C" {
 #define NCCL_COMM_DUMP
 #define NCCL_COMM_GET_UNIQUE_HASH
 #define NCCL_COLLTRACE_CUDA_GRAPH_COMPATIBLE
+#define NCCLX_CONFIG_SUPPORTED
 
 /* Opaque handle to communicator */
 typedef struct ncclComm* ncclComm_t;
@@ -166,6 +167,16 @@ typedef struct ncclConfig_v22800 {
 
   // control the fast init features
   int fastInitMode{NCCL_CONFIG_UNDEF_INT};
+
+  // Opaque pointer to an ncclx::Hints object.  When non-null, NCCLX
+  // will read key-value pairs from this object and apply them to
+  // config fields that are still at their undefined defaults.
+  void* hints{NCCL_CONFIG_UNDEF_PTR};
+
+  // Internal field — do not access directly.  This would be private
+  // if ncclConfig_t were a C++ class.  Populated by NCCLX during
+  // communicator creation; users must not read or write this field.
+  void* ncclxConfig{NCCL_CONFIG_UNDEF_PTR};
 } ncclConfig_t;
 
 /* Config initializer must be assigned to initialize config structure when it is created.
@@ -197,6 +208,8 @@ typedef struct ncclConfig_v22800 {
   NCCL_CONFIG_UNDEF_INT,                    /* lazyConnect */           \
   NCCL_CONFIG_UNDEF_INT,                    /* lazySetupChannels */     \
   NCCL_CONFIG_UNDEF_INT,                    /* fastInitMode */          \
+  NCCL_CONFIG_UNDEF_PTR,                    /* hints */                  \
+  NCCL_CONFIG_UNDEF_PTR,                    /* ncclxConfig */            \
 }
 
 /* This struct will be used by ncclGroupSimulateEnd() API to query information about simulation. */

--- a/comms/ncclx/v2_29/src/transport/p2p.cc
+++ b/comms/ncclx/v2_29/src/transport/p2p.cc
@@ -7,6 +7,7 @@
 
 #include "checks.h"
 #include "comm.h"
+#include "meta/NcclxConfig.h" // @manual
 #include "graph.h"
 #include "utils.h"
 #include "shmutils.h"
@@ -265,7 +266,7 @@ ncclResult_t ncclP2pAllocateShareableBuffer(size_t size, int refcount, ncclIpcDe
       CUDACHECK(res);
     }
   }
-  INFO(NCCL_P2P|NCCL_ALLOC, "commDesc: %s Allocated shareable buffer %p size %zu ipcDesc %p for %s", ctran::utils::parseCommDesc(comm->config.commDesc), *ptr, size, ipcDesc, callsite);
+  INFO(NCCL_P2P|NCCL_ALLOC, "commDesc: %s Allocated shareable buffer %p size %zu ipcDesc %p for %s", ctran::utils::parseCommDesc(NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str()), *ptr, size, ipcDesc, callsite);
 
   return ncclSuccess;
 }


### PR DESCRIPTION
Summary:
Extract ncclx-specific configuration into a standalone
ncclx::Config class, decoupling it from the upstream
ncclConfig_t struct. This restructuring:

1. Allows adding new ncclx configs without modifying the
   upstream ncclConfig_t struct.
2. Simplifies upstreaming integration points to nvidia by
   minimizing ncclConfig_t changes to two opaque pointers
   (hints and ncclxConfig).
3. Modernizes fields to C++ types (std::string, std::vector,
   bool), allowing cleaner lifetime and access management.
4. Enables upper layers to get/set config fields through a
   dictionary (ncclx::Hints) instead of adding struct fields.

Applied identically to v2_27, v2_28, and v2_29.

Differential Revision: D95714602
