### PR TITLE
Fix torchcomms Triton bitcode build with CUDA 13

### DIFF
--- a/comms/torchcomms/triton/CMakeLists.txt
+++ b/comms/torchcomms/triton/CMakeLists.txt
@@ -57,6 +57,17 @@ elseif(EXISTS "${NCCLX_INCLUDE}/nccl_device/gin/gdaki/doca_gpunetio"
         SYMBOLIC)
 endif()
 
+# CUDA 13 removed texture_fetch_functions.h (deprecated texture reference API).
+# Clang's __clang_cuda_runtime_wrapper.h unconditionally includes it, causing a
+# fatal error. Provide an empty stub so clang's wrapper resolves the include.
+# Torchcomms device code does not use texture references.
+if(NOT EXISTS "${CUDA_PATH}/include/texture_fetch_functions.h")
+    file(WRITE "${TRITON_TMPINC}/texture_fetch_functions.h"
+        "// Empty stub: texture_fetch_functions.h was removed in CUDA 13.\n"
+        "// Provided for clang CUDA wrapper compatibility.\n")
+    message(STATUS "  Created texture_fetch_functions.h stub for CUDA 13+ compatibility")
+endif()
+
 set(TRITON_BC_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/comms/torchcomms/triton/fb/libtorchcomms_device.bc")
 
 # Ensure output directory exists
@@ -77,6 +88,8 @@ add_custom_command(
         -fcuda-flush-denormals-to-zero
         "--cuda-path=${CUDA_PATH}"
         -isystem "${CUDA_PATH}/include"
+        -isystem "${CUDA_PATH}/include/cccl"
+        -isystem "${CONDA_INCLUDE}/cccl"
         "-I${TRITON_SRC}/ir_include"
         "-I${TRITON_TMPINC}"
         "-I${NCCLX_INCLUDE}"


### PR DESCRIPTION
Summary:
The torchcomms Triton device bitcode build fails on CUDA 13 with two issues:

1. `texture_fetch_functions.h` not found: CUDA 13 removed this deprecated
   header but clang's internal `__clang_cuda_runtime_wrapper.h` still
   includes it. Fix: create an empty stub in the temp include directory.

2. `cuda/atomic` not found: NCCLX device headers (`nccl_device/utility.h`)
   include `<cuda/atomic>` from CCCL (libcudacxx). The clang include paths
   were missing CCCL directories. Fix: add `-isystem` paths for both
   `${CUDA_PATH}/include/cccl` (toolkit CCCL) and `${CONDA_INCLUDE}/cccl`
   (conda-installed CCCL for CUDA 13+), matching the pattern used by
   ncclx CMake builds.

CUDA 12 works because it ships both headers and has CCCL bundled in the
toolkit. The Buck build also works because it pins clang 19 + CUDA 12.8.

Reviewed By: kapilsh

Differential Revision: D95705402


