### PR TITLE
Standalone window integration with MultiPeerTransport

### DIFF
--- a/comms/pipes/MultiPeerNvlTransport.cc
+++ b/comms/pipes/MultiPeerNvlTransport.cc
@@ -35,40 +35,52 @@ MultiPeerNvlTransport::MultiPeerNvlTransport(
   // Calculate per-peer buffer sizes with pipelining
   perPeerDataBufferSize_ = config_.pipelineDepth * config_.dataBufferSize;
 
-  // Calculate state buffer size based on chunk size and pipeline depth
-  const std::size_t numChunksPerStep =
-      (config_.dataBufferSize + config_.chunkSize - 1) / config_.chunkSize;
-  const std::size_t numChunksPerPeer = config_.pipelineDepth * numChunksPerStep;
-  perPeerChunkStateBufferSize_ = numChunksPerPeer * sizeof(ChunkState);
   perPeerSignalBufferSize_ = getSignalBufferSize(config_.p2pSignalCount);
 
-  // Allocate buffers for (nRanks - 1) peers using GpuMemHandler
-  const std::size_t totalDataBufferSize =
-      perPeerDataBufferSize_ * (nRanks_ - 1);
-  const std::size_t totalChunkStateBufferSize =
-      perPeerChunkStateBufferSize_ * (nRanks_ - 1);
+  // Allocate signal buffer (always needed)
   const std::size_t totalSignalBufferSize =
       perPeerSignalBufferSize_ * (nRanks_ - 1);
 
   signalBufferHandler_ = std::make_unique<GpuMemHandler>(
       bootstrap_, myRank_, nRanks_, totalSignalBufferSize, memSharingMode_);
 
-  dataBufferHandler_ = std::make_unique<GpuMemHandler>(
-      bootstrap_, myRank_, nRanks_, totalDataBufferSize, memSharingMode_);
+  // Staging data + state buffers are only needed for send()/recv().
+  // When dataBufferSize=0, skip allocation — put() works without staging.
+  if (config_.dataBufferSize > 0) {
+    // Calculate state buffer size based on chunk size and pipeline depth
+    const std::size_t numChunksPerStep =
+        (config_.dataBufferSize + config_.chunkSize - 1) / config_.chunkSize;
+    const std::size_t numChunksPerPeer =
+        config_.pipelineDepth * numChunksPerStep;
+    perPeerChunkStateBufferSize_ = numChunksPerPeer * sizeof(ChunkState);
 
-  stateBufferHandler_ = std::make_unique<GpuMemHandler>(
-      bootstrap_, myRank_, nRanks_, totalChunkStateBufferSize, memSharingMode_);
+    // Allocate buffers for (nRanks - 1) peers using GpuMemHandler
+    const std::size_t totalDataBufferSize =
+        perPeerDataBufferSize_ * (nRanks_ - 1);
+    const std::size_t totalChunkStateBufferSize =
+        perPeerChunkStateBufferSize_ * (nRanks_ - 1);
 
-  // Initialize state buffer to READY_TO_SEND for all pipeline slots
-  auto statePtr =
-      static_cast<ChunkState*>(stateBufferHandler_->getLocalDeviceMemPtr());
-  const std::size_t totalNumChunksAllPeers = numChunksPerPeer * (nRanks_ - 1);
-  std::vector<ChunkState> initStates(totalNumChunksAllPeers);
-  CUDA_CHECK(cudaMemcpy(
-      statePtr,
-      initStates.data(),
-      totalChunkStateBufferSize,
-      cudaMemcpyDefault));
+    dataBufferHandler_ = std::make_unique<GpuMemHandler>(
+        bootstrap_, myRank_, nRanks_, totalDataBufferSize, memSharingMode_);
+
+    stateBufferHandler_ = std::make_unique<GpuMemHandler>(
+        bootstrap_,
+        myRank_,
+        nRanks_,
+        totalChunkStateBufferSize,
+        memSharingMode_);
+
+    // Initialize state buffer to READY_TO_SEND for all pipeline slots
+    auto statePtr =
+        static_cast<ChunkState*>(stateBufferHandler_->getLocalDeviceMemPtr());
+    const std::size_t totalNumChunksAllPeers = numChunksPerPeer * (nRanks_ - 1);
+    std::vector<ChunkState> initStates(totalNumChunksAllPeers);
+    CUDA_CHECK(cudaMemcpy(
+        statePtr,
+        initStates.data(),
+        totalChunkStateBufferSize,
+        cudaMemcpyDefault));
+  }
 
   // Initialize signal state buffer to 0 for all ranks
   auto signalPtr =
@@ -84,8 +96,12 @@ MultiPeerNvlTransport::MultiPeerNvlTransport(
 
 void MultiPeerNvlTransport::exchange() {
   // Exchange P2P transport buffer pointers
-  dataBufferHandler_->exchangeMemPtrs();
-  stateBufferHandler_->exchangeMemPtrs();
+  if (dataBufferHandler_) {
+    dataBufferHandler_->exchangeMemPtrs();
+  }
+  if (stateBufferHandler_) {
+    stateBufferHandler_->exchangeMemPtrs();
+  }
   signalBufferHandler_->exchangeMemPtrs();
 }
 
@@ -133,18 +149,50 @@ P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
       .chunkSize = config_.chunkSize,
       .pipelineDepth = config_.pipelineDepth};
 
-  // Calculate number of chunk states per pipeline slot
+  auto* localSignalPtr =
+      static_cast<char*>(signalBufferHandler_->getLocalDeviceMemPtr());
+  auto* remoteSignalPtr =
+      static_cast<char*>(signalBufferHandler_->getPeerDeviceMemPtr(peerRank));
+
+  DeviceSpan<SignalState> localSignalSpan(
+      reinterpret_cast<SignalState*>(localSignalPtr + localSignalBufferOffset),
+      config_.p2pSignalCount);
+  DeviceSpan<SignalState> remoteSignalSpan(
+      reinterpret_cast<SignalState*>(
+          remoteSignalPtr + remoteSignalBufferOffset),
+      config_.p2pSignalCount);
+
+  // When dataBufferSize=0, staging buffers are not allocated.
+  // Set data/state to nullptr/empty — send()/recv() will trap.
+  if (!dataBufferHandler_ || !stateBufferHandler_) {
+    LocalState localState{
+        .dataBuffer = nullptr,
+        .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+        .signalBuffer = localSignalSpan,
+    };
+    RemoteState remoteState{
+        .dataBuffer = nullptr,
+        .stateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+        .signalBuffer = remoteSignalSpan,
+    };
+    return P2pNvlTransportDevice(
+        myRank_, peerRank, options, localState, remoteState);
+  }
+
   const std::size_t numChunksPerStep =
       (config_.dataBufferSize + config_.chunkSize - 1) / config_.chunkSize;
   const auto numChunksPerPeer =
       static_cast<uint32_t>(config_.pipelineDepth * numChunksPerStep);
 
-  auto* localSignalPtr =
-      static_cast<char*>(signalBufferHandler_->getLocalDeviceMemPtr());
   auto* localDataPtr =
       static_cast<char*>(dataBufferHandler_->getLocalDeviceMemPtr());
   auto* localStatePtr =
       static_cast<char*>(stateBufferHandler_->getLocalDeviceMemPtr());
+
+  auto* remoteDataPtr =
+      static_cast<char*>(dataBufferHandler_->getPeerDeviceMemPtr(peerRank));
+  auto* remoteChunkStatePtr =
+      static_cast<char*>(stateBufferHandler_->getPeerDeviceMemPtr(peerRank));
 
   LocalState localState{
       .dataBuffer = localDataPtr + localDataBufferOffset,
@@ -152,18 +200,8 @@ P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
           reinterpret_cast<ChunkState*>(
               localStatePtr + localChunkStateBufferOffset),
           numChunksPerPeer),
-      .signalBuffer = DeviceSpan<SignalState>(
-          reinterpret_cast<SignalState*>(
-              localSignalPtr + localSignalBufferOffset),
-          config_.p2pSignalCount),
+      .signalBuffer = localSignalSpan,
   };
-
-  auto* remoteDataPtr =
-      static_cast<char*>(dataBufferHandler_->getPeerDeviceMemPtr(peerRank));
-  auto* remoteChunkStatePtr =
-      static_cast<char*>(stateBufferHandler_->getPeerDeviceMemPtr(peerRank));
-  auto* remoteSignalPtr =
-      static_cast<char*>(signalBufferHandler_->getPeerDeviceMemPtr(peerRank));
 
   RemoteState remoteState{
       .dataBuffer = remoteDataPtr + remoteDataBufferOffset,
@@ -171,10 +209,7 @@ P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
           reinterpret_cast<ChunkState*>(
               remoteChunkStatePtr + remoteChunkStateBufferOffset),
           numChunksPerPeer),
-      .signalBuffer = DeviceSpan<SignalState>(
-          reinterpret_cast<SignalState*>(
-              remoteSignalPtr + remoteSignalBufferOffset),
-          config_.p2pSignalCount),
+      .signalBuffer = remoteSignalSpan,
   };
 
   return P2pNvlTransportDevice(

--- a/comms/pipes/P2pNvlTransportDevice.cuh
+++ b/comms/pipes/P2pNvlTransportDevice.cuh
@@ -314,6 +314,14 @@ class P2pNvlTransportDevice {
       std::size_t nbytes,
       const Timeout& timeout = Timeout()) {
 #ifdef __CUDA_ARCH__
+    if (options_.dataBufferSize == 0) {
+      printf(
+          "P2pNvlTransportDevice::send() requires staging buffer"
+          " (dataBufferSize > 0) at %s:%d\n",
+          __FILE__,
+          __LINE__);
+      __trap();
+    }
     char* src = reinterpret_cast<char*>(srcbuff);
 
     // REMOTE-WRITE PATTERN:
@@ -416,6 +424,14 @@ class P2pNvlTransportDevice {
       std::size_t nbytes,
       const Timeout& timeout = Timeout()) {
 #ifdef __CUDA_ARCH__
+    if (options_.dataBufferSize == 0) {
+      printf(
+          "P2pNvlTransportDevice::recv() requires staging buffer"
+          " (dataBufferSize > 0) at %s:%d\n",
+          __FILE__,
+          __LINE__);
+      __trap();
+    }
     char* dst = reinterpret_cast<char*>(dstbuff);
 
     // REMOTE-WRITE PATTERN:

--- a/comms/pipes/benchmarks/IbgdaBenchmark.h
+++ b/comms/pipes/benchmarks/IbgdaBenchmark.h
@@ -28,7 +28,7 @@ void launchIbgdaPutSignalSingle(
     cudaStream_t stream);
 
 /**
- * Launch batched kernel: Multiple put+wait_local iterations in a single kernel
+ * Launch batched kernel: Multiple put+wait_local iterations
  *
  * This avoids per-operation kernel launch overhead and uses GPU cycle counters
  * for accurate timing of raw RDMA operations.

--- a/comms/pipes/benchmarks/MultiPeerBenchmark.cc
+++ b/comms/pipes/benchmarks/MultiPeerBenchmark.cc
@@ -1,0 +1,529 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+
+#include <folly/init/Init.h>
+#include <folly/logging/xlog.h>
+#include <gflags/gflags.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <iomanip>
+#include <sstream>
+#include <vector>
+
+#include "comms/common/DeviceConstants.cuh"
+#include "comms/pipes/MultiPeerTransport.h"
+#include "comms/pipes/benchmarks/MultiPeerBenchmark.cuh"
+#include "comms/pipes/window/HostWindow.h"
+#include "comms/testinfra/mpi/MpiBootstrap.h"
+#include "comms/testinfra/mpi/MpiTestUtils.h"
+#include "comms/utils/CudaRAII.h"
+
+// Command-line configurable parameters
+DEFINE_int32(benchmark_iters, 50, "Number of benchmark iterations");
+DEFINE_int32(steps_per_iter, 100, "Number of steps per kernel launch");
+DEFINE_int32(warmup_iters, 10, "Number of warmup iterations");
+DEFINE_int32(
+    put_message_size,
+    4096,
+    "Message size in bytes for put benchmarks");
+
+using meta::comms::CudaEvent;
+using meta::comms::MpiBaseTestFixture;
+using meta::comms::MPIEnvironmentBase;
+
+namespace comms::pipes::benchmark {
+namespace {
+
+constexpr int kDefaultThreads = 128; // Thread configuration
+
+// =============================================================================
+// Runtime Configuration Helpers
+// =============================================================================
+
+// Validate flag values are positive
+inline int getWarmupIters() {
+  CHECK_GT(FLAGS_warmup_iters, 0) << "warmup_iters must be positive";
+  return FLAGS_warmup_iters;
+}
+
+inline int getBenchmarkIters() {
+  CHECK_GT(FLAGS_benchmark_iters, 0) << "benchmark_iters must be positive";
+  return FLAGS_benchmark_iters;
+}
+
+inline int getStepsPerIter() {
+  CHECK_GT(FLAGS_steps_per_iter, 0) << "steps_per_iter must be positive";
+  return FLAGS_steps_per_iter;
+}
+
+// =============================================================================
+// Configuration and Results
+// =============================================================================
+
+struct MultiPeerBenchConfig {
+  int numBlocks{1};
+  bool useBlockGroups{false};
+  std::string name;
+
+  // Calculate number of thread groups (and required slots)
+  int numGroups() const {
+    return useBlockGroups
+        ? numBlocks
+        : numBlocks * (kDefaultThreads / comms::device::kWarpSize);
+  }
+
+  // Get scope string for display (returns const char* for efficiency)
+  const char* scopeString() const {
+    return useBlockGroups ? "block" : "warp";
+  }
+};
+
+struct MultiPeerBenchResult {
+  std::string configName;
+  int nRanks{};
+  std::string groupScope;
+  float latencyUs{};
+};
+
+// =============================================================================
+// Configuration Helpers
+// =============================================================================
+
+// Single source of truth for all configurations
+std::vector<MultiPeerBenchConfig> getStandardConfigs(bool reduced = false) {
+  // Full configuration list
+  static const std::vector<MultiPeerBenchConfig> kAllConfigs = {
+      {.numBlocks = 1, .useBlockGroups = false, .name = "1b_warp"},
+      {.numBlocks = 4, .useBlockGroups = false, .name = "4b_warp"},
+      {.numBlocks = 16, .useBlockGroups = false, .name = "16b_warp"},
+      {.numBlocks = 1, .useBlockGroups = true, .name = "1b_block"},
+      {.numBlocks = 4, .useBlockGroups = true, .name = "4b_block"},
+      {.numBlocks = 16, .useBlockGroups = true, .name = "16b_block"},
+  };
+
+  if (!reduced) {
+    return kAllConfigs;
+  }
+
+  // Reduced set for expensive operations (SignalAll) - filter from full list
+  std::vector<MultiPeerBenchConfig> filtered;
+  filtered.reserve(4);
+  for (const auto& c : kAllConfigs) {
+    if (c.numBlocks <= 4) {
+      filtered.push_back(c);
+    }
+  }
+  return filtered;
+}
+
+// Calculate max slots with validation for empty config list
+inline int getMaxSlots(const std::vector<MultiPeerBenchConfig>& configs) {
+  CHECK(!configs.empty()) << "Config list cannot be empty";
+  int maxSlots = 0;
+  for (const auto& c : configs) {
+    maxSlots = std::max(maxSlots, c.numGroups());
+  }
+  return maxSlots;
+}
+
+// =============================================================================
+// Benchmark Fixture
+// =============================================================================
+
+class MultiPeerBenchmarkFixture : public MpiBaseTestFixture {
+ protected:
+  void SetUp() override {
+    MpiBaseTestFixture::SetUp();
+    ASSERT_EQ(cudaSetDevice(localRank), cudaSuccess);
+    ASSERT_EQ(cudaStreamCreate(&stream_), cudaSuccess);
+  }
+
+  void TearDown() override {
+    ASSERT_EQ(cudaStreamDestroy(stream_), cudaSuccess);
+    MpiBaseTestFixture::TearDown();
+  }
+
+  // -------------------------------------------------------------------------
+  // Timing Result Structure
+  // -------------------------------------------------------------------------
+
+  struct TimingResult {
+    float avgLatencyUs{0.0f};
+    bool success{true};
+  };
+
+  // -------------------------------------------------------------------------
+  // Benchmark Execution Helper
+  // -------------------------------------------------------------------------
+
+  // Note: Lambda returns cudaError_t to avoid ASSERT inside lambda issues
+  template <typename LaunchFn>
+  TimingResult runBenchmark(
+      LaunchFn launchKernel,
+      int stepsPerIter,
+      bool useMpiBarrier = true) {
+    const int warmupIters = getWarmupIters();
+    const int benchIters = getBenchmarkIters();
+
+    TimingResult result;
+
+    // --- Warmup Phase ---
+    if (useMpiBarrier) {
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    }
+
+    for (int i = 0; i < warmupIters; ++i) {
+      cudaError_t err = launchKernel();
+      if (err != cudaSuccess) {
+        XLOGF(
+            ERR,
+            "Kernel launch failed during warmup: {}",
+            cudaGetErrorString(err));
+        result.success = false;
+        return result;
+      }
+      err = cudaStreamSynchronize(stream_);
+      if (err != cudaSuccess) {
+        XLOGF(
+            ERR,
+            "Stream sync failed during warmup: {}",
+            cudaGetErrorString(err));
+        result.success = false;
+        return result;
+      }
+    }
+
+    // Verify no CUDA errors accumulated after warmup
+    cudaError_t lastErr = cudaGetLastError();
+    if (lastErr != cudaSuccess) {
+      XLOGF(
+          ERR,
+          "CUDA error detected after warmup: {}",
+          cudaGetErrorString(lastErr));
+      result.success = false;
+      return result;
+    }
+
+    if (useMpiBarrier) {
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    }
+
+    // --- Batch Timing for Average ---
+    CudaEvent batchStart, batchStop;
+
+    cudaError_t err = cudaEventRecord(batchStart.get(), stream_);
+    if (err != cudaSuccess) {
+      result.success = false;
+      return result;
+    }
+
+    for (int i = 0; i < benchIters; ++i) {
+      err = launchKernel();
+      if (err != cudaSuccess) {
+        result.success = false;
+        return result;
+      }
+    }
+
+    err = cudaEventRecord(batchStop.get(), stream_);
+    if (err != cudaSuccess) {
+      result.success = false;
+      return result;
+    }
+
+    err = cudaStreamSynchronize(stream_);
+    if (err != cudaSuccess) {
+      result.success = false;
+      return result;
+    }
+
+    float totalTimeMs = 0.0f;
+    err = cudaEventElapsedTime(&totalTimeMs, batchStart.get(), batchStop.get());
+    if (err != cudaSuccess) {
+      result.success = false;
+      return result;
+    }
+
+    // Calculate average per-step latency
+    int totalSteps = benchIters * stepsPerIter;
+    result.avgLatencyUs = (totalTimeMs / totalSteps) * 1000.0f;
+
+    if (useMpiBarrier) {
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    }
+
+    return result;
+  }
+
+  // -------------------------------------------------------------------------
+  // Unified Table Printing
+  // -------------------------------------------------------------------------
+
+  void printResultsTable(
+      const std::string& title,
+      const std::string& latencyLabel,
+      const std::vector<MultiPeerBenchResult>& results,
+      bool showRanks = true) {
+    if (globalRank != 0) {
+      return;
+    }
+
+    std::stringstream ss;
+    ss << "\n";
+    ss << "========================================================================\n";
+    ss << "     " << title << "\n";
+    ss << "========================================================================\n";
+
+    // Header
+    ss << std::left << std::setw(12) << "Config";
+    if (showRanks) {
+      ss << std::right << std::setw(8) << "nRanks";
+    }
+    ss << std::right << std::setw(10) << "Scope" << std::right << std::setw(16)
+       << "Latency (us)\n";
+    ss << "------------------------------------------------------------------------\n";
+
+    // Rows
+    for (const auto& r : results) {
+      ss << std::left << std::setw(12) << r.configName;
+      if (showRanks) {
+        ss << std::right << std::setw(8) << r.nRanks;
+      }
+      ss << std::right << std::setw(10) << r.groupScope << std::right
+         << std::setw(16) << std::fixed << std::setprecision(3) << r.latencyUs
+         << "\n";
+    }
+
+    ss << "========================================================================\n";
+    ss << latencyLabel << "\n";
+    ss << "Each measurement: " << getBenchmarkIters() << " iterations x "
+       << getStepsPerIter() << " steps/iter\n";
+    ss << "========================================================================\n\n";
+
+    XLOG(INFO) << ss.str();
+  }
+
+  cudaStream_t stream_{};
+};
+
+// =============================================================================
+// Test: Barrier Latency (N-way synchronization)
+// =============================================================================
+
+TEST_F(MultiPeerBenchmarkFixture, BarrierLatency) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "Requires >= 2 ranks, got " << numRanks;
+  }
+
+  auto configs = getStandardConfigs();
+  std::vector<MultiPeerBenchResult> results;
+
+  // Create transport once with max slot count
+  int maxSlots = getMaxSlots(configs);
+  MultiPeerNvlTransportConfig nvlConfig{
+      .dataBufferSize = 1,
+      .chunkSize = 1,
+      .pipelineDepth = 1,
+  };
+  WindowConfig wmConfig{
+      .barrierCount = static_cast<std::size_t>(maxSlots),
+  };
+
+  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  MultiPeerTransportConfig transportConfig{
+      .nvlConfig = nvlConfig,
+  };
+  MultiPeerTransport transport(
+      globalRank, numRanks, localRank, bootstrap, transportConfig);
+  transport.exchange();
+
+  HostWindow window(transport, wmConfig);
+  window.exchange();
+
+  DeviceWindow dw = window.getDeviceWindow();
+
+  for (const auto& config : configs) {
+    void* kernelFunc = config.useBlockGroups
+        ? (void*)multiPeerBarrierKernel<SyncScope::BLOCK>
+        : (void*)multiPeerBarrierKernel<SyncScope::WARP>;
+
+    int nSteps = getStepsPerIter();
+    dim3 grid(config.numBlocks);
+    dim3 block(kDefaultThreads);
+    void* args[] = {&dw, &nSteps};
+
+    auto timing = runBenchmark(
+        [&]() -> cudaError_t {
+          return cudaLaunchKernel(kernelFunc, grid, block, args, 0, stream_);
+        },
+        nSteps,
+        /*useMpiBarrier=*/true);
+
+    ASSERT_TRUE(timing.success)
+        << "Benchmark failed for config: " << config.name;
+
+    results.push_back({
+        .configName = config.name,
+        .nRanks = numRanks,
+        .groupScope = config.scopeString(),
+        .latencyUs = timing.avgLatencyUs,
+    });
+  }
+
+  printResultsTable(
+      "MultiPeerDeviceTransport Barrier Benchmark (Half-Duplex)",
+      "Latency = Average time per barrier() call",
+      results);
+}
+
+// =============================================================================
+// Test: Signal-All Latency (N-way signaling)
+// =============================================================================
+
+TEST_F(MultiPeerBenchmarkFixture, SignalAllLatency) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "Requires >= 2 ranks, got " << numRanks;
+  }
+
+  // Use reduced config set for expensive operations
+  auto configs = getStandardConfigs(/*reduced=*/true);
+  std::vector<MultiPeerBenchResult> results;
+
+  int maxSlots = getMaxSlots(configs);
+  MultiPeerNvlTransportConfig nvlConfig{
+      .dataBufferSize = 1,
+      .chunkSize = 1,
+      .pipelineDepth = 1,
+  };
+  WindowConfig wmConfig{
+      .peerSignalCount = static_cast<std::size_t>(maxSlots),
+  };
+
+  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  MultiPeerTransportConfig transportConfig{
+      .nvlConfig = nvlConfig,
+  };
+  MultiPeerTransport transport(
+      globalRank, numRanks, localRank, bootstrap, transportConfig);
+  transport.exchange();
+
+  HostWindow window(transport, wmConfig);
+  window.exchange();
+
+  DeviceWindow dw = window.getDeviceWindow();
+
+  for (const auto& config : configs) {
+    void* kernelFunc = config.useBlockGroups
+        ? (void*)multiPeerSignalAllKernel<SyncScope::BLOCK>
+        : (void*)multiPeerSignalAllKernel<SyncScope::WARP>;
+
+    int nSteps = getStepsPerIter();
+    dim3 grid(config.numBlocks);
+    dim3 block(kDefaultThreads);
+    void* args[] = {&dw, &nSteps};
+
+    auto timing = runBenchmark(
+        [&]() -> cudaError_t {
+          return cudaLaunchKernel(kernelFunc, grid, block, args, 0, stream_);
+        },
+        nSteps,
+        /*useMpiBarrier=*/true);
+
+    ASSERT_TRUE(timing.success)
+        << "Benchmark failed for config: " << config.name;
+
+    results.push_back({
+        .configName = config.name,
+        .nRanks = numRanks,
+        .groupScope = config.scopeString(),
+        .latencyUs = timing.avgLatencyUs,
+    });
+  }
+
+  printResultsTable(
+      "Signal-All Benchmark",
+      "Latency = Average time per signalAll/waitAll cycle",
+      results);
+}
+
+// =============================================================================
+// Test: Signal Ping-Pong Latency (2-way signaling)
+// =============================================================================
+
+TEST_F(MultiPeerBenchmarkFixture, SignalPingPongLatency) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Requires exactly 2 ranks, got " << numRanks;
+  }
+
+  int peerRank = (globalRank == 0) ? 1 : 0;
+  auto configs = getStandardConfigs();
+  std::vector<MultiPeerBenchResult> results;
+
+  int maxSlots = getMaxSlots(configs);
+  MultiPeerNvlTransportConfig nvlConfig{
+      .dataBufferSize = 1,
+      .chunkSize = 1,
+      .pipelineDepth = 1,
+  };
+  WindowConfig wmConfig{
+      .peerSignalCount = static_cast<std::size_t>(maxSlots),
+  };
+
+  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  MultiPeerTransportConfig transportConfig{
+      .nvlConfig = nvlConfig,
+  };
+  MultiPeerTransport transport(
+      globalRank, numRanks, localRank, bootstrap, transportConfig);
+  transport.exchange();
+
+  HostWindow window(transport, wmConfig);
+  window.exchange();
+
+  DeviceWindow dw = window.getDeviceWindow();
+
+  for (const auto& config : configs) {
+    void* kernelFunc = config.useBlockGroups
+        ? (void*)multiPeerSignalPingPongKernel<SyncScope::BLOCK>
+        : (void*)multiPeerSignalPingPongKernel<SyncScope::WARP>;
+
+    int nSteps = getStepsPerIter();
+    dim3 grid(config.numBlocks);
+    dim3 block(kDefaultThreads);
+    void* args[] = {&dw, &peerRank, &nSteps};
+
+    auto timing = runBenchmark(
+        [&]() -> cudaError_t {
+          return cudaLaunchKernel(kernelFunc, grid, block, args, 0, stream_);
+        },
+        nSteps,
+        /*useMpiBarrier=*/true);
+
+    ASSERT_TRUE(timing.success)
+        << "Benchmark failed for config: " << config.name;
+
+    results.push_back({
+        .configName = config.name,
+        .nRanks = 2,
+        .groupScope = config.scopeString(),
+        .latencyUs = timing.avgLatencyUs,
+    });
+  }
+
+  printResultsTable(
+      "Signal Ping-Pong Benchmark (Half-Duplex)",
+      "Latency = Average time per signal/wait pair",
+      results);
+}
+
+} // namespace
+} // namespace comms::pipes::benchmark
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new MPIEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/pipes/benchmarks/MultiPeerBenchmark.cu
+++ b/comms/pipes/benchmarks/MultiPeerBenchmark.cu
@@ -1,0 +1,258 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/ThreadGroup.cuh"
+#include "comms/pipes/benchmarks/MultiPeerBenchmark.cuh"
+
+namespace comms::pipes::benchmark {
+
+// =============================================================================
+// Thread Group Helpers
+// =============================================================================
+
+template <SyncScope S>
+__device__ __forceinline__ auto makeGroup() {
+  return make_thread_group(S);
+}
+
+// Compute unique slot index for current thread group
+// Returns int to match barrier/signal slot API expectations
+template <SyncScope S>
+__device__ __forceinline__ int computeSlotIndex() {
+  if constexpr (S == SyncScope::BLOCK) {
+    // One slot per block
+    return static_cast<int>(blockIdx.x);
+  } else {
+    // One slot per warp - use comms::device::kWarpSize
+    auto warpsPerBlock = blockDim.x / comms::device::kWarpSize;
+    auto warpIdInBlock = threadIdx.x / comms::device::kWarpSize;
+    return static_cast<int>(blockIdx.x * warpsPerBlock + warpIdInBlock);
+  }
+}
+
+// =============================================================================
+// Explicit Template Instantiations for Helper Functions
+// =============================================================================
+
+// Note: These helpers are used by benchmark kernels added in later diffs.
+// The explicit instantiations ensure the templates are available for linking.
+
+template __device__ auto makeGroup<SyncScope::WARP>();
+template __device__ auto makeGroup<SyncScope::BLOCK>();
+
+template __device__ int computeSlotIndex<SyncScope::WARP>();
+template __device__ int computeSlotIndex<SyncScope::BLOCK>();
+
+// =============================================================================
+// Barrier Benchmark Kernel Implementation
+// =============================================================================
+
+template <SyncScope G>
+__global__ void multiPeerBarrierKernel(DeviceWindow dw, int nSteps) {
+  auto group = makeGroup<G>();
+  int slotId = computeSlotIndex<G>();
+
+  for (int step = 0; step < nSteps; ++step) {
+    dw.barrier(group, slotId);
+  }
+}
+
+// =============================================================================
+// Signal Ping-Pong Benchmark Kernel Implementation
+// =============================================================================
+
+template <SyncScope S>
+__global__ void
+multiPeerSignalPingPongKernel(DeviceWindow dw, int targetRank, int nSteps) {
+  auto group = makeGroup<S>();
+  int slotId = computeSlotIndex<S>();
+  int myRank = dw.rank();
+
+  // Ping-pong pattern:
+  // - Even steps: Rank 0 signals, Rank 1 waits
+  // - Odd steps: Rank 1 signals, Rank 0 waits
+  //
+  // Uses SIGNAL_ADD: each signal adds 1, wait for cumulative value.
+  // After N signals from peer, peer's cumulative value = N.
+
+  for (int step = 0; step < nSteps; ++step) {
+    bool myTurnToSignal = ((step % 2) == myRank);
+
+    if (myTurnToSignal) {
+      dw.signal_peer(group, targetRank, slotId, SignalOp::SIGNAL_ADD, 1);
+    } else {
+      // Wait for (step/2 + 1) signals from peer
+      uint64_t expectedValue = (step / 2) + 1;
+      dw.wait_signal(group, slotId, CmpOp::CMP_GE, expectedValue);
+    }
+  }
+}
+
+// =============================================================================
+// Signal-All Benchmark Kernel Implementation
+// =============================================================================
+
+template <SyncScope S>
+__global__ void multiPeerSignalAllKernel(DeviceWindow dw, int nSteps) {
+  auto group = makeGroup<S>();
+  int slotId = computeSlotIndex<S>();
+
+  // In the per-signal model, all (nRanks-1) peers write to the same slot.
+  // After step+1 iterations, accumulated value = (nRanks-1) * (step+1).
+  int nPeers = dw.n_ranks() - 1;
+
+  for (int step = 0; step < nSteps; ++step) {
+    // Signal all peers
+    dw.signal_all(group, slotId, SignalOp::SIGNAL_ADD, 1);
+
+    // Wait for accumulated signals from all peers
+    dw.wait_signal(
+        group,
+        slotId,
+        CmpOp::CMP_GE,
+        static_cast<uint64_t>(nPeers * (step + 1)));
+  }
+}
+
+// =============================================================================
+// Explicit Template Instantiations for Barrier Kernels
+// =============================================================================
+
+// Barrier kernels
+template __global__ void multiPeerBarrierKernel<SyncScope::WARP>(
+    DeviceWindow,
+    int);
+template __global__ void multiPeerBarrierKernel<SyncScope::BLOCK>(
+    DeviceWindow,
+    int);
+
+// =============================================================================
+// Explicit Template Instantiations for Signal Kernels
+// =============================================================================
+
+// Signal ping-pong kernels
+template __global__ void
+multiPeerSignalPingPongKernel<SyncScope::WARP>(DeviceWindow, int, int);
+template __global__ void
+multiPeerSignalPingPongKernel<SyncScope::BLOCK>(DeviceWindow, int, int);
+
+// Signal-all kernels
+template __global__ void multiPeerSignalAllKernel<SyncScope::WARP>(
+    DeviceWindow,
+    int);
+template __global__ void multiPeerSignalAllKernel<SyncScope::BLOCK>(
+    DeviceWindow,
+    int);
+
+// =============================================================================
+// Put Ping-Pong Benchmark Kernel Implementation
+// =============================================================================
+
+template <SyncScope S>
+__global__ void multiPeerPutPingPongKernel(
+    DeviceWindow dw,
+    int targetRank,
+    const void* localSrc,
+    void* remoteDst,
+    std::size_t nbytes,
+    int nSteps) {
+  auto group = makeGroup<S>();
+  int slotId = computeSlotIndex<S>();
+  int myRank = dw.rank();
+
+  // Ping-pong pattern using put() + signal_peer():
+  // - Even steps: Rank 0 puts data, Rank 1 waits
+  // - Odd steps: Rank 1 puts data, Rank 0 waits
+  //
+  // Uses SIGNAL_ADD: each signal adds 1, wait for cumulative value.
+
+  for (int step = 0; step < nSteps; ++step) {
+    bool myTurnToPut = ((step % 2) == myRank);
+
+    if (myTurnToPut) {
+      // Put data to peer's buffer
+      dw.put(targetRank, group, remoteDst, localSrc, nbytes);
+      // Sync to ensure put completes before signaling
+      group.sync();
+      // Signal peer that data is ready
+      dw.signal_peer(group, targetRank, slotId, SignalOp::SIGNAL_ADD, 1);
+    } else {
+      // Wait for (step/2 + 1) signals from peer
+      uint64_t expectedValue = (step / 2) + 1;
+      dw.wait_signal(group, slotId, CmpOp::CMP_GE, expectedValue);
+    }
+  }
+}
+
+// =============================================================================
+// Put+Signal Ping-Pong Benchmark Kernel Implementation
+// =============================================================================
+
+template <SyncScope S>
+__global__ void multiPeerPutSignalPingPongKernel(
+    DeviceWindow dw,
+    int targetRank,
+    const void* localSrc,
+    void* remoteDst,
+    std::size_t nbytes,
+    int nSteps) {
+  auto group = makeGroup<S>();
+  int slotId = computeSlotIndex<S>();
+  int myRank = dw.rank();
+
+  // Ping-pong pattern using put_signal():
+  // - Even steps: Rank 0 puts+signals, Rank 1 waits
+  // - Odd steps: Rank 1 puts+signals, Rank 0 waits
+  //
+  // Uses put_signal() convenience API which combines put + signal_peer.
+
+  for (int step = 0; step < nSteps; ++step) {
+    bool myTurnToPut = ((step % 2) == myRank);
+
+    if (myTurnToPut) {
+      // Combined put + signal
+      dw.put_signal(targetRank, group, remoteDst, localSrc, nbytes, slotId, 1);
+    } else {
+      // Wait for (step/2 + 1) signals from peer
+      uint64_t expectedValue = (step / 2) + 1;
+      dw.wait_signal(group, slotId, CmpOp::CMP_GE, expectedValue);
+    }
+  }
+}
+
+// =============================================================================
+// Explicit Template Instantiations for Put Kernels
+// =============================================================================
+
+// Put ping-pong kernels
+template __global__ void multiPeerPutPingPongKernel<SyncScope::WARP>(
+    DeviceWindow,
+    int,
+    const void*,
+    void*,
+    std::size_t,
+    int);
+template __global__ void multiPeerPutPingPongKernel<SyncScope::BLOCK>(
+    DeviceWindow,
+    int,
+    const void*,
+    void*,
+    std::size_t,
+    int);
+
+// Put+signal ping-pong kernels
+template __global__ void multiPeerPutSignalPingPongKernel<SyncScope::WARP>(
+    DeviceWindow,
+    int,
+    const void*,
+    void*,
+    std::size_t,
+    int);
+template __global__ void multiPeerPutSignalPingPongKernel<SyncScope::BLOCK>(
+    DeviceWindow,
+    int,
+    const void*,
+    void*,
+    std::size_t,
+    int);
+
+} // namespace comms::pipes::benchmark

--- a/comms/pipes/benchmarks/MultiPeerBenchmark.cuh
+++ b/comms/pipes/benchmarks/MultiPeerBenchmark.cuh
@@ -1,0 +1,114 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include "comms/common/DeviceConstants.cuh"
+#include "comms/pipes/ThreadGroup.cuh"
+#include "comms/pipes/window/DeviceWindow.cuh"
+
+namespace comms::pipes::benchmark {
+
+// Use SyncScope from ThreadGroup.cuh for thread group type selection
+
+// =============================================================================
+// Barrier Benchmark Kernel
+// =============================================================================
+
+/**
+ * N-way barrier benchmark kernel.
+ *
+ * Each thread group executes barrier() in a loop.
+ * Uses unique slot per group to avoid contention.
+ *
+ * Half-duplex measurement: all ranks synchronize together.
+ */
+template <SyncScope G>
+__global__ void multiPeerBarrierKernel(DeviceWindow dw, int nSteps);
+
+// =============================================================================
+// Signal Ping-Pong Benchmark Kernel
+// =============================================================================
+
+/**
+ * Signal ping-pong benchmark kernel (2 ranks only).
+ *
+ * Rank 0 and Rank 1 alternate signaling each other.
+ * Uses SIGNAL_ADD with cumulative wait values for reusability.
+ *
+ * Half-duplex measurement: one signal in flight at a time.
+ */
+template <SyncScope S>
+__global__ void
+multiPeerSignalPingPongKernel(DeviceWindow dw, int targetRank, int nSteps);
+
+// =============================================================================
+// Signal-All Benchmark Kernel
+// =============================================================================
+
+/**
+ * Signal-all benchmark kernel.
+ *
+ * Each rank signals all peers, then waits for all arrivals.
+ * Uses SIGNAL_ADD with cumulative wait values.
+ */
+template <SyncScope S>
+__global__ void multiPeerSignalAllKernel(DeviceWindow dw, int nSteps);
+
+// =============================================================================
+// Put Ping-Pong Benchmark Kernel
+// =============================================================================
+
+/**
+ * Put ping-pong benchmark kernel (2 ranks only).
+ *
+ * Rank 0 and Rank 1 alternate put() + signal_peer() operations.
+ * Measures NVLink write bandwidth for small messages combined with
+ * signal latency.
+ *
+ * Half-duplex measurement: one put in flight at a time.
+ *
+ * @param dw DeviceWindow for NVLink operations
+ * @param targetRank The target rank to communicate with
+ * @param localSrc Local source buffer to read from
+ * @param remoteDst Remote destination buffer to write to (IPC-mapped)
+ * @param nbytes Number of bytes to transfer per put
+ * @param nSteps Number of ping-pong iterations
+ */
+template <SyncScope S>
+__global__ void multiPeerPutPingPongKernel(
+    DeviceWindow dw,
+    int targetRank,
+    const void* localSrc,
+    void* remoteDst,
+    std::size_t nbytes,
+    int nSteps);
+
+// =============================================================================
+// Put+Signal Ping-Pong Benchmark Kernel
+// =============================================================================
+
+/**
+ * Put+Signal ping-pong benchmark kernel (2 ranks only).
+ *
+ * Rank 0 and Rank 1 alternate put_signal() operations.
+ * Measures combined NVLink write + signal latency using the convenience API.
+ *
+ * Half-duplex measurement: one put_signal in flight at a time.
+ *
+ * @param dw DeviceWindow for NVLink operations
+ * @param targetRank The target rank to communicate with
+ * @param localSrc Local source buffer to read from
+ * @param remoteDst Remote destination buffer to write to (IPC-mapped)
+ * @param nbytes Number of bytes to transfer per put
+ * @param nSteps Number of ping-pong iterations
+ */
+template <SyncScope S>
+__global__ void multiPeerPutSignalPingPongKernel(
+    DeviceWindow dw,
+    int targetRank,
+    const void* localSrc,
+    void* remoteDst,
+    std::size_t nbytes,
+    int nSteps);
+
+} // namespace comms::pipes::benchmark

--- a/comms/pipes/tests/MultiPeerNvlTransportIntegrationTest.cc
+++ b/comms/pipes/tests/MultiPeerNvlTransportIntegrationTest.cc
@@ -12,7 +12,8 @@
 #include "comms/pipes/MultiPeerTransport.h"
 #include "comms/pipes/tests/MultiPeerNvlTransportIntegrationTest.cuh"
 #include "comms/pipes/tests/Utils.cuh"
-#include "comms/pipes/window/WindowMemory.h"
+#include "comms/pipes/window/DeviceWindow.cuh"
+#include "comms/pipes/window/HostWindow.h"
 #include "comms/testinfra/TestXPlatUtils.h"
 #include "comms/testinfra/mpi/MpiBootstrap.h"
 #include "comms/testinfra/mpi/MpiTestUtils.h"
@@ -66,18 +67,18 @@ class MultiPeerNvlTransportIntegrationTestFixture : public MpiBaseTestFixture {
     MpiBaseTestFixture::TearDown();
   }
 
-  // Bundle that keeps transport and window memory alive.
+  // Bundle that keeps transport and window alive.
   struct TransportBundle {
     std::unique_ptr<MultiPeerTransport> transport;
-    std::unique_ptr<WindowMemory> windowMemory;
-    test::TestDeviceBundle bundle;
+    std::unique_ptr<HostWindow> window;
+    DeviceWindow dw;
   };
 
   // Helper to create a configured transport and get the
-  // TestDeviceBundle
+  // DeviceWindow
   TransportBundle createTransport(
       const MultiPeerNvlTransportConfig& nvlConfig,
-      const WindowMemoryConfig& wmConfig = {}) {
+      const WindowConfig& wmConfig = {}) {
     auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
     MultiPeerTransportConfig config{
         .nvlConfig = nvlConfig,
@@ -86,16 +87,11 @@ class MultiPeerNvlTransportIntegrationTestFixture : public MpiBaseTestFixture {
         globalRank, numRanks, localRank, bootstrap, config);
     transport->exchange();
 
-    auto wm = std::make_unique<WindowMemory>(
-        globalRank, numRanks, bootstrap, wmConfig);
-    wm->exchange();
+    auto window = std::make_unique<HostWindow>(*transport, wmConfig);
+    window->exchange();
 
-    test::TestDeviceBundle bundle{
-        transport->get_device_handle(),
-        wm->getDeviceWindowSignal(),
-        wm->getDeviceWindowBarrier(),
-    };
-    return {std::move(transport), std::move(wm), bundle};
+    DeviceWindow dw = window->getDeviceWindow();
+    return {std::move(transport), std::move(window), dw};
   }
 };
 
@@ -112,14 +108,14 @@ TEST_F(
       .pipelineDepth = kDefaultPipelineDepth,
   };
 
-  auto [transport, windowMemory, bundle] = createTransport(config);
+  auto [transport, window, dw] = createTransport(config);
 
   // Allocate result buffer on device
   DeviceBuffer resultsBuffer(3 * sizeof(int));
   auto results_d = static_cast<int*>(resultsBuffer.get());
 
   // Call test kernel to verify accessors
-  test::testMultiPeerDeviceTransportAccessors(bundle, results_d);
+  test::testMultiPeerDeviceTransportAccessors(dw, results_d);
   CUDACHECK_TEST(cudaDeviceSynchronize());
 
   // Copy results back to host
@@ -148,7 +144,7 @@ TEST_F(
 TEST_F(
     MultiPeerNvlTransportIntegrationTestFixture,
     GetMultiPeerDeviceTransportRepeated) {
-  // Test that TestDeviceBundle can be constructed multiple times
+  // Test that MultiPeerDeviceTransport can be constructed multiple times
   // and returns consistent results
   MultiPeerNvlTransportConfig config{
       .dataBufferSize = kDefaultDataBufferSize,
@@ -164,16 +160,13 @@ TEST_F(
       globalRank, numRanks, localRank, bootstrap, transportConfig);
   mpt.exchange();
 
-  WindowMemory wm(globalRank, numRanks, bootstrap, WindowMemoryConfig{});
-  wm.exchange();
+  HostWindow window(mpt, WindowConfig{});
+  window.exchange();
 
-  // Construct TestDeviceBundle multiple times
-  auto handle = mpt.get_device_handle();
-  auto sig = wm.getDeviceWindowSignal();
-  auto bar = wm.getDeviceWindowBarrier();
-  test::TestDeviceBundle bundle1{handle, sig, bar};
-  test::TestDeviceBundle bundle2{handle, sig, bar};
-  test::TestDeviceBundle bundle3{handle, sig, bar};
+  // Construct DeviceWindow multiple times
+  auto dw1 = window.getDeviceWindow();
+  auto dw2 = window.getDeviceWindow();
+  auto dw3 = window.getDeviceWindow();
 
   // Allocate result buffers
   DeviceBuffer results1Buffer(3 * sizeof(int));
@@ -184,9 +177,9 @@ TEST_F(
   auto results2_d = static_cast<int*>(results2Buffer.get());
   auto results3_d = static_cast<int*>(results3Buffer.get());
 
-  test::testMultiPeerDeviceTransportAccessors(bundle1, results1_d);
-  test::testMultiPeerDeviceTransportAccessors(bundle2, results2_d);
-  test::testMultiPeerDeviceTransportAccessors(bundle3, results3_d);
+  test::testMultiPeerDeviceTransportAccessors(dw1, results1_d);
+  test::testMultiPeerDeviceTransportAccessors(dw2, results2_d);
+  test::testMultiPeerDeviceTransportAccessors(dw3, results3_d);
   CUDACHECK_TEST(cudaDeviceSynchronize());
 
   std::vector<int> results1_h(3), results2_h(3), results3_h(3);
@@ -199,13 +192,13 @@ TEST_F(
 
   // All calls should return the same values
   EXPECT_EQ(results1_h, results2_h)
-      << "Repeated TestDeviceBundle constructions returned different values";
+      << "Repeated DeviceWindow constructions returned different values";
   EXPECT_EQ(results1_h, results3_h)
-      << "Repeated TestDeviceBundle constructions returned different values";
+      << "Repeated DeviceWindow constructions returned different values";
 
   XLOGF(
       INFO,
-      "Rank {}: Repeated TestDeviceBundle construction test completed",
+      "Rank {}: Repeated DeviceWindow construction test completed",
       globalRank);
 }
 
@@ -223,11 +216,11 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, SignalWait) {
       .chunkSize = kDefaultChunkSize,
       .pipelineDepth = kDefaultPipelineDepth,
   };
-  WindowMemoryConfig wmConfig{
-      .signalCount = kDefaultSignalCount,
+  WindowConfig wmConfig{
+      .peerSignalCount = kDefaultSignalCount,
   };
 
-  auto [transport, windowMemory, bundle] = createTransport(config, wmConfig);
+  auto [transport, window, dw] = createTransport(config, wmConfig);
 
   int peerRank = (globalRank == 0) ? 1 : 0;
 
@@ -241,7 +234,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, SignalWait) {
   // Synchronize before starting
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 
-  test::testSignalWait(bundle, peerRank, 0, isSignaler, result_d);
+  test::testSignalWait(dw, peerRank, 0, isSignaler, result_d);
   CUDACHECK_TEST(cudaDeviceSynchronize());
 
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
@@ -274,11 +267,11 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, BidirectionalSignalWait) {
       .chunkSize = 1024,
       .pipelineDepth = 4,
   };
-  WindowMemoryConfig wmConfig{
-      .signalCount = kDefaultSignalCount,
+  WindowConfig wmConfig{
+      .peerSignalCount = kDefaultSignalCount,
   };
 
-  auto [transport, windowMemory, bundle] = createTransport(config, wmConfig);
+  auto [transport, window, dw] = createTransport(config, wmConfig);
 
   int peerRank = (globalRank == 0) ? 1 : 0;
 
@@ -297,7 +290,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, BidirectionalSignalWait) {
 
   // Phase 1: Rank 0 signals slot 0, Rank 1 waits on slot 0
   test::testSignalWait(
-      bundle, peerRank, kPhase1SignalSlot, globalRank == 0, result1_d);
+      dw, peerRank, kPhase1SignalSlot, globalRank == 0, result1_d);
   CUDACHECK_TEST(cudaDeviceSynchronize());
 
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
@@ -305,7 +298,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, BidirectionalSignalWait) {
   // Phase 2: Rank 1 signals slot 1, Rank 0 waits on slot 1
   // Using different slot to avoid signal value accumulation
   test::testSignalWait(
-      bundle, peerRank, kPhase2SignalSlot, globalRank == 1, result2_d);
+      dw, peerRank, kPhase2SignalSlot, globalRank == 1, result2_d);
   CUDACHECK_TEST(cudaDeviceSynchronize());
 
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
@@ -333,11 +326,11 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, Barrier) {
       .chunkSize = 1024,
       .pipelineDepth = 4,
   };
-  WindowMemoryConfig wmConfig{
+  WindowConfig wmConfig{
       .barrierCount = 1,
   };
 
-  auto [transport, windowMemory, bundle] = createTransport(config, wmConfig);
+  auto [transport, window, dw] = createTransport(config, wmConfig);
 
   DeviceBuffer resultBuffer(sizeof(int));
   auto result_d = static_cast<int*>(resultBuffer.get());
@@ -345,7 +338,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, Barrier) {
 
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 
-  test::testBarrier(bundle, 0, result_d);
+  test::testBarrier(dw, 0, result_d);
   CUDACHECK_TEST(cudaDeviceSynchronize());
 
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
@@ -374,11 +367,11 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, BarrierPeer) {
       .chunkSize = kDefaultChunkSize,
       .pipelineDepth = kDefaultPipelineDepth,
   };
-  WindowMemoryConfig wmConfig{
+  WindowConfig wmConfig{
       .barrierCount = 1,
   };
 
-  auto [transport, windowMemory, bundle] = createTransport(config, wmConfig);
+  auto [transport, window, dw] = createTransport(config, wmConfig);
 
   int peerRank = (globalRank == 0) ? 1 : 0;
 
@@ -389,7 +382,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, BarrierPeer) {
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 
   // Both ranks call barrier_peer with each other's rank
-  test::testBarrierPeer(bundle, peerRank, 0, result_d);
+  test::testBarrierPeer(dw, peerRank, 0, result_d);
   CUDACHECK_TEST(cudaDeviceSynchronize());
 
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
@@ -425,7 +418,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, SendRecv) {
       .pipelineDepth = 4,
   };
 
-  auto [transport, windowMemory, bundle] = createTransport(config);
+  auto [transport, window, dw] = createTransport(config);
 
   if (transport->nvl_peer_ranks().empty()) {
     GTEST_SKIP()
@@ -451,7 +444,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, SendRecv) {
 
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 
-    test::testSinglePeerSend(bundle, peerRank, src_d, nbytes, 4, 128);
+    test::testSinglePeerSend(dw, peerRank, src_d, nbytes, 4, 128);
     CUDACHECK_TEST(cudaDeviceSynchronize());
 
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
@@ -461,7 +454,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, SendRecv) {
 
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 
-    test::testSinglePeerRecv(bundle, peerRank, dst_d, nbytes, 4, 128);
+    test::testSinglePeerRecv(dw, peerRank, dst_d, nbytes, 4, 128);
     CUDACHECK_TEST(cudaDeviceSynchronize());
 
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
@@ -495,7 +488,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, BidirectionalSendRecv) {
       .pipelineDepth = 4,
   };
 
-  auto [transport, windowMemory, bundle] = createTransport(config);
+  auto [transport, window, dw] = createTransport(config);
 
   if (transport->nvl_peer_ranks().empty()) {
     GTEST_SKIP()
@@ -523,19 +516,19 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, BidirectionalSendRecv) {
 
   // Rank 0 sends then receives, Rank 1 receives then sends
   if (globalRank == 0) {
-    test::testSinglePeerSend(bundle, peerRank, send_d, nbytes, 4, 128);
+    test::testSinglePeerSend(dw, peerRank, send_d, nbytes, 4, 128);
     CUDACHECK_TEST(cudaDeviceSynchronize());
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 
-    test::testSinglePeerRecv(bundle, peerRank, recv_d, nbytes, 4, 128);
+    test::testSinglePeerRecv(dw, peerRank, recv_d, nbytes, 4, 128);
     CUDACHECK_TEST(cudaDeviceSynchronize());
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
   } else {
-    test::testSinglePeerRecv(bundle, peerRank, recv_d, nbytes, 4, 128);
+    test::testSinglePeerRecv(dw, peerRank, recv_d, nbytes, 4, 128);
     CUDACHECK_TEST(cudaDeviceSynchronize());
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 
-    test::testSinglePeerSend(bundle, peerRank, send_d, nbytes, 4, 128);
+    test::testSinglePeerSend(dw, peerRank, send_d, nbytes, 4, 128);
     CUDACHECK_TEST(cudaDeviceSynchronize());
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
   }
@@ -565,11 +558,11 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, MultipleBarriers) {
       .chunkSize = 1024,
       .pipelineDepth = 4,
   };
-  WindowMemoryConfig wmConfig{
+  WindowConfig wmConfig{
       .barrierCount = kNumBarrierSlots,
   };
 
-  auto [transport, windowMemory, bundle] = createTransport(config, wmConfig);
+  auto [transport, window, dw] = createTransport(config, wmConfig);
 
   const int numIterations = 10;
 
@@ -585,7 +578,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, MultipleBarriers) {
 
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 
-    test::testBarrier(bundle, slotIdx, result_d);
+    test::testBarrier(dw, slotIdx, result_d);
     CUDACHECK_TEST(cudaDeviceSynchronize());
 
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
@@ -623,7 +616,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, SendRecvStress) {
       .pipelineDepth = kDefaultPipelineDepth,
   };
 
-  auto [transport, windowMemory, bundle] = createTransport(config);
+  auto [transport, window, dw] = createTransport(config);
 
   if (transport->nvl_peer_ranks().empty()) {
     GTEST_SKIP()
@@ -649,7 +642,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, SendRecvStress) {
       MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 
       test::testSinglePeerSend(
-          bundle,
+          dw,
           peerRank,
           src_d,
           kSmallTransferSize,
@@ -664,7 +657,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, SendRecvStress) {
       MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 
       test::testSinglePeerRecv(
-          bundle,
+          dw,
           peerRank,
           dst_d,
           kSmallTransferSize,
@@ -712,11 +705,11 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, MultipleSignalSlots) {
       .chunkSize = 1024,
       .pipelineDepth = 4,
   };
-  WindowMemoryConfig wmConfig{
-      .signalCount = numSignalSlots,
+  WindowConfig wmConfig{
+      .peerSignalCount = numSignalSlots,
   };
 
-  auto [transport, windowMemory, bundle] = createTransport(config, wmConfig);
+  auto [transport, window, dw] = createTransport(config, wmConfig);
 
   int peerRank = (globalRank == 0) ? 1 : 0;
 
@@ -730,7 +723,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, MultipleSignalSlots) {
 
     // Alternate which rank signals vs waits for each slot
     bool isSignaler = ((globalRank + slotIdx) % 2 == 0);
-    test::testSignalWait(bundle, peerRank, slotIdx, isSignaler, result_d);
+    test::testSignalWait(dw, peerRank, slotIdx, isSignaler, result_d);
     CUDACHECK_TEST(cudaDeviceSynchronize());
 
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
@@ -762,11 +755,11 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, ConcurrentSignalSlots) {
       .chunkSize = 1024,
       .pipelineDepth = 4,
   };
-  WindowMemoryConfig wmConfig{
-      .signalCount = numSignalSlots,
+  WindowConfig wmConfig{
+      .peerSignalCount = numSignalSlots,
   };
 
-  auto [transport, windowMemory, bundle] = createTransport(config, wmConfig);
+  auto [transport, window, dw] = createTransport(config, wmConfig);
 
   int peerRank = (globalRank == 0) ? 1 : 0;
 
@@ -785,8 +778,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, ConcurrentSignalSlots) {
   // Signal/wait on all slots
   for (int slotIdx = 0; slotIdx < numSignalSlots; ++slotIdx) {
     bool isSignaler = (globalRank == 0);
-    test::testSignalWait(
-        bundle, peerRank, slotIdx, isSignaler, results_d[slotIdx]);
+    test::testSignalWait(dw, peerRank, slotIdx, isSignaler, results_d[slotIdx]);
   }
   CUDACHECK_TEST(cudaDeviceSynchronize());
 
@@ -820,11 +812,11 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, MultipleBarrierSlots) {
       .chunkSize = 1024,
       .pipelineDepth = 4,
   };
-  WindowMemoryConfig wmConfig{
+  WindowConfig wmConfig{
       .barrierCount = numBarrierSlots,
   };
 
-  auto [transport, windowMemory, bundle] = createTransport(config, wmConfig);
+  auto [transport, window, dw] = createTransport(config, wmConfig);
 
   // Test each barrier slot
   for (int slotIdx = 0; slotIdx < numBarrierSlots; ++slotIdx) {
@@ -834,7 +826,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, MultipleBarrierSlots) {
 
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 
-    test::testBarrier(bundle, slotIdx, result_d);
+    test::testBarrier(dw, slotIdx, result_d);
     CUDACHECK_TEST(cudaDeviceSynchronize());
 
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
@@ -863,11 +855,11 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, BarrierSlotStress) {
       .chunkSize = 1024,
       .pipelineDepth = 4,
   };
-  WindowMemoryConfig wmConfig{
+  WindowConfig wmConfig{
       .barrierCount = numBarrierSlots,
   };
 
-  auto [transport, windowMemory, bundle] = createTransport(config, wmConfig);
+  auto [transport, window, dw] = createTransport(config, wmConfig);
 
   DeviceBuffer resultBuffer(sizeof(int));
   auto result_d = static_cast<int*>(resultBuffer.get());
@@ -879,7 +871,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, BarrierSlotStress) {
 
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 
-    test::testBarrier(bundle, slotIdx, result_d);
+    test::testBarrier(dw, slotIdx, result_d);
     CUDACHECK_TEST(cudaDeviceSynchronize());
 
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
@@ -912,11 +904,11 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, BarrierMonotonicCounters) {
       .chunkSize = 1024,
       .pipelineDepth = 4,
   };
-  WindowMemoryConfig wmConfig{
+  WindowConfig wmConfig{
       .barrierCount = 1, // Single barrier slot, reused via monotonic counters
   };
 
-  auto [transport, windowMemory, bundle] = createTransport(config, wmConfig);
+  auto [transport, window, dw] = createTransport(config, wmConfig);
 
   DeviceBuffer resultBuffer(sizeof(int));
   auto result_d = static_cast<int*>(resultBuffer.get());
@@ -926,7 +918,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, BarrierMonotonicCounters) {
 
   // Launch a single kernel that performs kNumPhases barrier synchronizations
   // on the same slot. Counters accumulate monotonically — no reset needed.
-  test::testBarrierMonotonic(bundle, 0, kNumPhases, result_d);
+  test::testBarrierMonotonic(dw, 0, kNumPhases, result_d);
   CUDACHECK_TEST(cudaDeviceSynchronize());
 
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
@@ -959,11 +951,11 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, BarrierMultiBlockStress) {
       .chunkSize = 1024,
       .pipelineDepth = 4,
   };
-  WindowMemoryConfig wmConfig{
+  WindowConfig wmConfig{
       .barrierCount = kNumBarrierSlots,
   };
 
-  auto [transport, windowMemory, bundle] = createTransport(config, wmConfig);
+  auto [transport, window, dw] = createTransport(config, wmConfig);
 
   DeviceBuffer resultsBuffer(kNumBlocks * sizeof(int));
   auto results_d = static_cast<int*>(resultsBuffer.get());
@@ -972,7 +964,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, BarrierMultiBlockStress) {
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 
   test::testBarrierMultiBlockStress(
-      bundle, kNumBarrierSlots, results_d, kNumBlocks);
+      dw, kNumBarrierSlots, results_d, kNumBlocks);
   CUDACHECK_TEST(cudaDeviceSynchronize());
 
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
@@ -1016,12 +1008,12 @@ TEST_F(
       .chunkSize = 1024,
       .pipelineDepth = 4,
   };
-  WindowMemoryConfig wmConfig{
-      .signalCount = numSignalSlots,
+  WindowConfig wmConfig{
+      .peerSignalCount = numSignalSlots,
       .barrierCount = numBarrierSlots,
   };
 
-  auto [transport, windowMemory, bundle] = createTransport(config, wmConfig);
+  auto [transport, window, dw] = createTransport(config, wmConfig);
 
   int peerRank = (globalRank == 0) ? 1 : 0;
 
@@ -1033,7 +1025,7 @@ TEST_F(
 
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 
-    test::testSignalWait(bundle, peerRank, 0, globalRank == 0, result_d);
+    test::testSignalWait(dw, peerRank, 0, globalRank == 0, result_d);
     CUDACHECK_TEST(cudaDeviceSynchronize());
 
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
@@ -1052,7 +1044,7 @@ TEST_F(
 
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 
-    test::testBarrier(bundle, 0, result_d);
+    test::testBarrier(dw, 0, result_d);
     CUDACHECK_TEST(cudaDeviceSynchronize());
 
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
@@ -1072,7 +1064,7 @@ TEST_F(
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 
     test::testSignalWait(
-        bundle, peerRank, numSignalSlots - 1, globalRank == 1, result_d);
+        dw, peerRank, numSignalSlots - 1, globalRank == 1, result_d);
     CUDACHECK_TEST(cudaDeviceSynchronize());
 
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
@@ -1091,7 +1083,7 @@ TEST_F(
 
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 
-    test::testBarrier(bundle, numBarrierSlots - 1, result_d);
+    test::testBarrier(dw, numBarrierSlots - 1, result_d);
     CUDACHECK_TEST(cudaDeviceSynchronize());
 
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
@@ -1127,11 +1119,11 @@ TEST_F(
       .chunkSize = kDefaultChunkSize,
       .pipelineDepth = kDefaultPipelineDepth,
   };
-  WindowMemoryConfig wmConfig{
-      .signalCount = kMultiSlotSignalCount,
+  WindowConfig wmConfig{
+      .peerSignalCount = kMultiSlotSignalCount,
   };
 
-  auto [transport, windowMemory, bundle] = createTransport(config, wmConfig);
+  auto [transport, window, dw] = createTransport(config, wmConfig);
 
   int peerRank = (globalRank == 0) ? 1 : 0;
 
@@ -1144,12 +1136,7 @@ TEST_F(
   // Rank 0 signals on all slots, Rank 1 waits
   bool isSignaler = (globalRank == 0);
   test::testConcurrentSignalMultiBlock(
-      bundle,
-      peerRank,
-      kMultiSlotSignalCount,
-      isSignaler,
-      results_d,
-      kNumBlocks);
+      dw, peerRank, kMultiSlotSignalCount, isSignaler, results_d, kNumBlocks);
   CUDACHECK_TEST(cudaDeviceSynchronize());
 
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
@@ -1185,11 +1172,11 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, SignalResetBetweenPhases) {
       .chunkSize = kDefaultChunkSize,
       .pipelineDepth = kDefaultPipelineDepth,
   };
-  WindowMemoryConfig wmConfig{
-      .signalCount = kMultiSlotSignalCount,
+  WindowConfig wmConfig{
+      .peerSignalCount = kMultiSlotSignalCount,
   };
 
-  auto [transport, windowMemory, bundle] = createTransport(config, wmConfig);
+  auto [transport, window, dw] = createTransport(config, wmConfig);
 
   int peerRank = (globalRank == 0) ? 1 : 0;
   constexpr int kSignalSlot = 0;
@@ -1206,7 +1193,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, SignalResetBetweenPhases) {
 
     // Alternate which rank signals each phase
     bool isSignaler = ((globalRank + phase) % 2 == 0);
-    test::testSignalWait(bundle, peerRank, kSignalSlot, isSignaler, result_d);
+    test::testSignalWait(dw, peerRank, kSignalSlot, isSignaler, result_d);
     CUDACHECK_TEST(cudaDeviceSynchronize());
 
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
@@ -1251,11 +1238,11 @@ TEST_F(
       .chunkSize = kDefaultChunkSize,
       .pipelineDepth = kDefaultPipelineDepth,
   };
-  WindowMemoryConfig wmConfig{
-      .signalCount = kNumSignalSlots,
+  WindowConfig wmConfig{
+      .peerSignalCount = kNumSignalSlots,
   };
 
-  auto [transport, windowMemory, bundle] = createTransport(config, wmConfig);
+  auto [transport, window, dw] = createTransport(config, wmConfig);
 
   int peerRank = (globalRank == 0) ? 1 : 0;
 
@@ -1269,7 +1256,7 @@ TEST_F(
     // Alternate sender/receiver each iteration
     bool isSignaler = ((globalRank + iter) % 2 == 0);
     test::testConcurrentSignalMultiBlock(
-        bundle, peerRank, kNumSignalSlots, isSignaler, results_d, kNumBlocks);
+        dw, peerRank, kNumSignalSlots, isSignaler, results_d, kNumBlocks);
     CUDACHECK_TEST(cudaDeviceSynchronize());
 
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
@@ -1315,11 +1302,11 @@ TEST_F(
       .chunkSize = kDefaultChunkSize,
       .pipelineDepth = kDefaultPipelineDepth,
   };
-  WindowMemoryConfig wmConfig{
-      .signalCount = kNumSignalSlots,
+  WindowConfig wmConfig{
+      .peerSignalCount = kNumSignalSlots,
   };
 
-  auto [transport, windowMemory, bundle] = createTransport(config, wmConfig);
+  auto [transport, window, dw] = createTransport(config, wmConfig);
 
   int peerRank = (globalRank == 0) ? 1 : 0;
 
@@ -1332,7 +1319,7 @@ TEST_F(
   // Rank 0 signals, Rank 1 waits - each warp uses different slot
   bool isSignaler = (globalRank == 0);
   test::testConcurrentSignalWaitMultiWarp(
-      bundle, peerRank, kNumSignalSlots, isSignaler, results_d, kWarpsPerBlock);
+      dw, peerRank, kNumSignalSlots, isSignaler, results_d, kWarpsPerBlock);
   CUDACHECK_TEST(cudaDeviceSynchronize());
 
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
@@ -1368,14 +1355,14 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, TransportAccessorTypes) {
       .pipelineDepth = kDefaultPipelineDepth,
   };
 
-  auto [transport, windowMemory, bundle] = createTransport(config);
+  auto [transport, window, dw] = createTransport(config);
 
   // Allocate result buffer: [numPeers, selfType, peer0Type, peer1Type, ...]
   DeviceBuffer resultsBuffer((1 + numRanks) * sizeof(int));
   auto results_d = static_cast<int*>(resultsBuffer.get());
   CUDACHECK_TEST(cudaMemset(results_d, 0, (1 + numRanks) * sizeof(int)));
 
-  test::testTransportTypes(bundle, results_d);
+  test::testTransportTypes(dw, results_d);
   CUDACHECK_TEST(cudaDeviceSynchronize());
 
   std::vector<int> results_h(1 + numRanks);
@@ -1412,11 +1399,11 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, SignalAll) {
       .chunkSize = kDefaultChunkSize,
       .pipelineDepth = kDefaultPipelineDepth,
   };
-  WindowMemoryConfig wmConfig{
-      .signalCount = kDefaultSignalCount,
+  WindowConfig wmConfig{
+      .peerSignalCount = kDefaultSignalCount,
   };
 
-  auto [transport, windowMemory, bundle] = createTransport(config, wmConfig);
+  auto [transport, window, dw] = createTransport(config, wmConfig);
 
   constexpr int kSignalerRank = 0;
   constexpr int kSignalIdx = 0;
@@ -1428,7 +1415,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, SignalAll) {
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 
   // Rank 0 signals all peers, all other ranks wait for signal from rank 0
-  test::testSignalAll(bundle, kSignalerRank, kSignalIdx, result_d);
+  test::testSignalAll(dw, kSignalerRank, kSignalIdx, result_d);
   CUDACHECK_TEST(cudaDeviceSynchronize());
 
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
@@ -1463,11 +1450,11 @@ TEST_F(
       .chunkSize = kDefaultChunkSize,
       .pipelineDepth = kDefaultPipelineDepth,
   };
-  WindowMemoryConfig wmConfig{
-      .signalCount = kDefaultSignalCount,
+  WindowConfig wmConfig{
+      .peerSignalCount = kDefaultSignalCount,
   };
 
-  auto [transport, windowMemory, bundle] = createTransport(config, wmConfig);
+  auto [transport, window, dw] = createTransport(config, wmConfig);
 
   constexpr int kSignalIdx = 0;
 
@@ -1478,7 +1465,7 @@ TEST_F(
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 
   // All ranks signal all peers, then read aggregate via group-level API
-  test::testSignalAllAggregateDistributed(bundle, kSignalIdx, result_d);
+  test::testSignalAllAggregateDistributed(dw, kSignalIdx, result_d);
   CUDACHECK_TEST(cudaDeviceSynchronize());
 
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
@@ -1513,11 +1500,11 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, WaitSignalFromAll) {
       .chunkSize = kDefaultChunkSize,
       .pipelineDepth = kDefaultPipelineDepth,
   };
-  WindowMemoryConfig wmConfig{
-      .signalCount = kDefaultSignalCount,
+  WindowConfig wmConfig{
+      .peerSignalCount = kDefaultSignalCount,
   };
 
-  auto [transport, windowMemory, bundle] = createTransport(config, wmConfig);
+  auto [transport, window, dw] = createTransport(config, wmConfig);
 
   constexpr int kTargetRank = 0;
   constexpr int kSignalIdx = 0;
@@ -1529,7 +1516,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, WaitSignalFromAll) {
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 
   // All peers signal rank 0, rank 0 waits for signals from all peers
-  test::testWaitSignalFromAll(bundle, kTargetRank, kSignalIdx, result_d);
+  test::testWaitSignalFromAll(dw, kTargetRank, kSignalIdx, result_d);
   CUDACHECK_TEST(cudaDeviceSynchronize());
 
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
@@ -1562,11 +1549,11 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, WaitWithCmpEq) {
       .chunkSize = kDefaultChunkSize,
       .pipelineDepth = kDefaultPipelineDepth,
   };
-  WindowMemoryConfig wmConfig{
-      .signalCount = kDefaultSignalCount,
+  WindowConfig wmConfig{
+      .peerSignalCount = kDefaultSignalCount,
   };
 
-  auto [transport, windowMemory, bundle] = createTransport(config, wmConfig);
+  auto [transport, window, dw] = createTransport(config, wmConfig);
 
   int peerRank = (globalRank == 0) ? 1 : 0;
   constexpr int kSignalIdx = 0;
@@ -1581,7 +1568,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, WaitWithCmpEq) {
   // Rank 0 signals with exact value using SIGNAL_SET, Rank 1 waits with CMP_EQ
   bool isSignaler = (globalRank == 0);
   test::testWaitWithCmpEq(
-      bundle, peerRank, kSignalIdx, kExpectedValue, isSignaler, result_d);
+      dw, peerRank, kSignalIdx, kExpectedValue, isSignaler, result_d);
   CUDACHECK_TEST(cudaDeviceSynchronize());
 
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
@@ -1614,11 +1601,11 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, MonotonicWaitValues) {
       .chunkSize = kDefaultChunkSize,
       .pipelineDepth = kDefaultPipelineDepth,
   };
-  WindowMemoryConfig wmConfig{
-      .signalCount = kDefaultSignalCount,
+  WindowConfig wmConfig{
+      .peerSignalCount = kDefaultSignalCount,
   };
 
-  auto [transport, windowMemory, bundle] = createTransport(config, wmConfig);
+  auto [transport, window, dw] = createTransport(config, wmConfig);
 
   int peerRank = (globalRank == 0) ? 1 : 0;
   constexpr int kSignalIdx = 0;
@@ -1634,7 +1621,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, MonotonicWaitValues) {
   // signal(1), wait_for(1), signal(1), wait_for(2), etc.
   bool isSignaler = (globalRank == 0);
   test::testMonotonicWaitValues(
-      bundle, peerRank, kSignalIdx, kNumIterations, isSignaler, result_d);
+      dw, peerRank, kSignalIdx, kNumIterations, isSignaler, result_d);
   CUDACHECK_TEST(cudaDeviceSynchronize());
 
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
@@ -1667,11 +1654,11 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, SignalWithSet) {
       .chunkSize = kDefaultChunkSize,
       .pipelineDepth = kDefaultPipelineDepth,
   };
-  WindowMemoryConfig wmConfig{
-      .signalCount = kDefaultSignalCount,
+  WindowConfig wmConfig{
+      .peerSignalCount = kDefaultSignalCount,
   };
 
-  auto [transport, windowMemory, bundle] = createTransport(config, wmConfig);
+  auto [transport, window, dw] = createTransport(config, wmConfig);
 
   int peerRank = (globalRank == 0) ? 1 : 0;
   constexpr int kSignalIdx = 0;
@@ -1686,7 +1673,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, SignalWithSet) {
   // Rank 0 signals using SIGNAL_SET, Rank 1 waits for the set value
   bool isSignaler = (globalRank == 0);
   test::testSignalWithSet(
-      bundle, peerRank, kSignalIdx, kSetValue, isSignaler, result_d);
+      dw, peerRank, kSignalIdx, kSetValue, isSignaler, result_d);
   CUDACHECK_TEST(cudaDeviceSynchronize());
 
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
@@ -1721,16 +1708,16 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, PutSignalOperation) {
       .chunkSize = kDefaultChunkSize,
       .pipelineDepth = kDefaultPipelineDepth,
   };
-  WindowMemoryConfig wmConfig{
-      .signalCount = kDefaultSignalCount,
+  WindowConfig wmConfig{
+      .peerSignalCount = kDefaultSignalCount,
   };
 
-  auto [transport, windowMemory, bundle] = createTransport(config, wmConfig);
+  auto [transport, window, dw] = createTransport(config, wmConfig);
 
   int peerRank = (globalRank == 0) ? 1 : 0;
   const int testValue = 0xCD + globalRank;
 
-  // Get a host-side P2pNvlTransportDevice to access IPC-mapped remote buffers
+  // Get the P2pNvlTransportDevice to access IPC-mapped remote buffers
   // The transport's remoteState_.dataBuffer is already IPC-mapped
   auto p2pTransport = transport->get_p2p_nvl_transport_device(peerRank);
 
@@ -1780,7 +1767,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, PutSignalOperation) {
   // remoteDataBuffer points to peer's local data buffer (via IPC)
   // So rank 0's remoteDataBuffer points to rank 1's localDataBuffer
   test::testPutOperation(
-      bundle,
+      dw,
       peerRank,
       isWriter ? remoteDataBuffer : nullptr, // Write to peer's buffer via IPC
       isWriter ? localSrc_d : nullptr, // Source is our local data
@@ -1835,11 +1822,11 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, WaitSignalFromPeer) {
       .chunkSize = kDefaultChunkSize,
       .pipelineDepth = kDefaultPipelineDepth,
   };
-  WindowMemoryConfig wmConfig{
-      .signalCount = kDefaultSignalCount,
+  WindowConfig wmConfig{
+      .peerSignalCount = kDefaultSignalCount,
   };
 
-  auto [transport, windowMemory, bundle] = createTransport(config, wmConfig);
+  auto [transport, window, dw] = createTransport(config, wmConfig);
 
   int peerRank = (globalRank == 0) ? 1 : 0;
   constexpr int kSignalIdx = 0;
@@ -1852,8 +1839,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, WaitSignalFromPeer) {
 
   // Rank 0 signals, Rank 1 waits using wait_signal_from
   bool isSignaler = (globalRank == 0);
-  test::testWaitSignalFromPeer(
-      bundle, peerRank, kSignalIdx, isSignaler, result_d);
+  test::testWaitSignalFromPeer(dw, peerRank, kSignalIdx, isSignaler, result_d);
   CUDACHECK_TEST(cudaDeviceSynchronize());
 
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
@@ -1887,11 +1873,11 @@ TEST_F(
       .chunkSize = kDefaultChunkSize,
       .pipelineDepth = kDefaultPipelineDepth,
   };
-  WindowMemoryConfig wmConfig{
-      .signalCount = kDefaultSignalCount,
+  WindowConfig wmConfig{
+      .peerSignalCount = kDefaultSignalCount,
   };
 
-  auto [transport, windowMemory, bundle] = createTransport(config, wmConfig);
+  auto [transport, window, dw] = createTransport(config, wmConfig);
 
   constexpr int kTargetRank = 0;
   constexpr int kSignalIdx = 0;
@@ -1904,7 +1890,7 @@ TEST_F(
 
   // All peers signal rank 0 with different values, rank 0 verifies isolation
   test::testWaitSignalFromMultiPeerIsolation(
-      bundle, kTargetRank, kSignalIdx, result_d);
+      dw, kTargetRank, kSignalIdx, result_d);
   CUDACHECK_TEST(cudaDeviceSynchronize());
 
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
@@ -1939,11 +1925,11 @@ TEST_F(
       .chunkSize = kDefaultChunkSize,
       .pipelineDepth = kDefaultPipelineDepth,
   };
-  WindowMemoryConfig wmConfig{
-      .signalCount = kDefaultSignalCount,
+  WindowConfig wmConfig{
+      .peerSignalCount = kDefaultSignalCount,
   };
 
-  auto [transport, windowMemory, bundle] = createTransport(config, wmConfig);
+  auto [transport, window, dw] = createTransport(config, wmConfig);
 
   constexpr int kTargetRank = 0;
   constexpr int kSignalIdx = 0;
@@ -1956,7 +1942,7 @@ TEST_F(
 
   // All peers signal rank 0, rank 0 verifies both accumulated and per-peer
   test::testWaitSignalAndWaitSignalFromBothWork(
-      bundle, kTargetRank, kSignalIdx, result_d);
+      dw, kTargetRank, kSignalIdx, result_d);
   CUDACHECK_TEST(cudaDeviceSynchronize());
 
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
@@ -1989,11 +1975,11 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, SignalWaitBlockScope) {
       .chunkSize = kDefaultChunkSize,
       .pipelineDepth = kDefaultPipelineDepth,
   };
-  WindowMemoryConfig wmConfig{
-      .signalCount = kDefaultSignalCount,
+  WindowConfig wmConfig{
+      .peerSignalCount = kDefaultSignalCount,
   };
 
-  auto [transport, windowMemory, bundle] = createTransport(config, wmConfig);
+  auto [transport, window, dw] = createTransport(config, wmConfig);
 
   int peerRank = (globalRank == 0) ? 1 : 0;
 
@@ -2008,7 +1994,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, SignalWaitBlockScope) {
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 
   // Uses BLOCK scope - exercises non-WARP fallback path in wait_signal()
-  test::testSignalWaitBlockScope(bundle, peerRank, 0, isSignaler, result_d);
+  test::testSignalWaitBlockScope(dw, peerRank, 0, isSignaler, result_d);
   CUDACHECK_TEST(cudaDeviceSynchronize());
 
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));

--- a/comms/pipes/tests/MultiPeerNvlTransportIntegrationTest.cu
+++ b/comms/pipes/tests/MultiPeerNvlTransportIntegrationTest.cu
@@ -1,0 +1,763 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/tests/MultiPeerNvlTransportIntegrationTest.cuh"
+
+#include "comms/pipes/ThreadGroup.cuh"
+#include "comms/pipes/window/DeviceWindow.cuh"
+#include "comms/testinfra/TestXPlatUtils.h"
+
+namespace comms::pipes::test {
+
+// =============================================================================
+// DeviceWindow Accessors Test
+// =============================================================================
+
+__global__ void multiPeerDeviceTransportAccessorsKernel(
+    const DeviceWindow& dw,
+    int* results) {
+  results[0] = dw.rank();
+  results[1] = dw.n_ranks();
+  results[2] = dw.num_peers();
+}
+
+void testMultiPeerDeviceTransportAccessors(
+    const DeviceWindow& dw,
+    int* results) {
+  multiPeerDeviceTransportAccessorsKernel<<<1, 1>>>(dw, results);
+  CUDACHECK_TEST(cudaGetLastError());
+}
+
+// =============================================================================
+// Signal/Wait Test
+// =============================================================================
+
+__global__ void signalWaitKernel(
+    DeviceWindow& dw,
+    int targetRank,
+    int signalIdx,
+    bool isSignaler,
+    int* result) {
+  auto group = make_warp_group();
+
+  if (isSignaler) {
+    dw.signal_peer(group, targetRank, signalIdx, SignalOp::SIGNAL_ADD, 1);
+    *result = 1;
+  } else {
+    dw.wait_signal(group, signalIdx, CmpOp::CMP_GE, 1);
+    *result = 1;
+  }
+}
+
+void testSignalWait(
+    DeviceWindow& dw,
+    int targetRank,
+    int signalIdx,
+    bool isSignaler,
+    int* result) {
+  signalWaitKernel<<<1, 32>>>(dw, targetRank, signalIdx, isSignaler, result);
+  CUDACHECK_TEST(cudaGetLastError());
+}
+
+// =============================================================================
+// Barrier Test
+// =============================================================================
+
+__global__ void barrierKernel(DeviceWindow& dw, int barrierIdx, int* result) {
+  auto group = make_warp_group();
+
+  dw.barrier(group, barrierIdx);
+
+  *result = 1;
+}
+
+void testBarrier(DeviceWindow& dw, int barrierIdx, int* result) {
+  barrierKernel<<<1, 32>>>(dw, barrierIdx, result);
+  CUDACHECK_TEST(cudaGetLastError());
+}
+
+// =============================================================================
+// Single-Peer Send/Recv Tests
+// =============================================================================
+
+__global__ void singlePeerSendKernel(
+    DeviceWindow& dw,
+    int peerRank,
+    void* srcBuff,
+    std::size_t nbytes) {
+  auto group = make_warp_group();
+  dw.get_handle().get_nvl(peerRank).send(group, srcBuff, nbytes);
+}
+
+void testSinglePeerSend(
+    DeviceWindow& dw,
+    int peerRank,
+    void* srcBuff,
+    std::size_t nbytes,
+    int numBlocks,
+    int blockSize) {
+  singlePeerSendKernel<<<numBlocks, blockSize>>>(dw, peerRank, srcBuff, nbytes);
+  CUDACHECK_TEST(cudaGetLastError());
+}
+
+__global__ void singlePeerRecvKernel(
+    DeviceWindow& dw,
+    int peerRank,
+    void* dstBuff,
+    std::size_t nbytes) {
+  auto group = make_warp_group();
+  dw.get_handle().get_nvl(peerRank).recv(group, dstBuff, nbytes);
+}
+
+void testSinglePeerRecv(
+    DeviceWindow& dw,
+    int peerRank,
+    void* dstBuff,
+    std::size_t nbytes,
+    int numBlocks,
+    int blockSize) {
+  singlePeerRecvKernel<<<numBlocks, blockSize>>>(dw, peerRank, dstBuff, nbytes);
+  CUDACHECK_TEST(cudaGetLastError());
+}
+
+// =============================================================================
+// Multi-Peer Send/Recv Test (Parallel via Partition)
+// =============================================================================
+
+__global__ void multiPeerSendRecvAllPeersKernel(
+    DeviceWindow& dw,
+    void** srcBuffs,
+    void** dstBuffs,
+    std::size_t nbytesPerPeer) {
+  auto group = make_warp_group();
+
+  int myRank = dw.rank();
+  int numPeers = dw.num_peers();
+
+  // Partition into send and recv groups (interleaved for SM balance)
+  auto [partition_id, send_recv_group] = group.partition_interleaved(2);
+
+  // Further partition across peers
+  auto [peer_idx, group_per_peer] =
+      send_recv_group.partition_interleaved(numPeers);
+
+  // Map peer_idx to actual rank (skip self)
+  int peer_rank = peer_idx < myRank ? peer_idx : peer_idx + 1;
+
+  if (partition_id == 0) {
+    dw.get_handle().get_nvl(peer_rank).send(
+        group_per_peer, srcBuffs[peer_idx], nbytesPerPeer);
+  } else {
+    dw.get_handle().get_nvl(peer_rank).recv(
+        group_per_peer, dstBuffs[peer_idx], nbytesPerPeer);
+  }
+}
+
+void testMultiPeerSendRecvAllPeers(
+    DeviceWindow& dw,
+    void** srcBuffs,
+    void** dstBuffs,
+    std::size_t nbytesPerPeer,
+    int numBlocks,
+    int blockSize) {
+  multiPeerSendRecvAllPeersKernel<<<numBlocks, blockSize>>>(
+      dw, srcBuffs, dstBuffs, nbytesPerPeer);
+  CUDACHECK_TEST(cudaGetLastError());
+}
+
+// =============================================================================
+// Concurrent Signal Multi-Block Test
+// =============================================================================
+
+__global__ void concurrentSignalMultiBlockKernel(
+    DeviceWindow& dw,
+    int targetRank,
+    int numSlots,
+    bool isSignaler,
+    int* results) {
+  auto group = make_warp_group();
+
+  // Each block uses a different signal slot (blockIdx.x % numSlots)
+  auto slotId = blockIdx.x % numSlots;
+
+  if (isSignaler) {
+    dw.signal_peer(group, targetRank, slotId, SignalOp::SIGNAL_ADD, 1);
+  } else {
+    dw.wait_signal(group, slotId, CmpOp::CMP_GE, 1);
+  }
+
+  // Record success for this block
+  if (threadIdx.x == 0) {
+    results[blockIdx.x] = 1;
+  }
+}
+
+void testConcurrentSignalMultiBlock(
+    DeviceWindow& dw,
+    int targetRank,
+    int numSlots,
+    bool isSignaler,
+    int* results,
+    int numBlocks) {
+  concurrentSignalMultiBlockKernel<<<numBlocks, 32>>>(
+      dw, targetRank, numSlots, isSignaler, results);
+  CUDACHECK_TEST(cudaGetLastError());
+}
+
+// =============================================================================
+// Put Operation Test
+// =============================================================================
+
+__global__ void putOperationKernel(
+    DeviceWindow& dw,
+    int targetRank,
+    void* remoteDst,
+    const void* localSrc,
+    std::size_t nbytes,
+    int signalId,
+    bool isWriter,
+    int* result) {
+  auto group = make_warp_group();
+
+  if (isWriter) {
+    dw.put_signal(targetRank, group, remoteDst, localSrc, nbytes, signalId, 1);
+  } else {
+    dw.wait_signal(group, signalId, CmpOp::CMP_GE, 1);
+  }
+
+  if (threadIdx.x == 0) {
+    *result = 1;
+  }
+}
+
+void testPutOperation(
+    DeviceWindow& dw,
+    int targetRank,
+    void* remoteDst,
+    const void* localSrc,
+    std::size_t nbytes,
+    int signalId,
+    bool isWriter,
+    int* result) {
+  putOperationKernel<<<1, 32>>>(
+      dw, targetRank, remoteDst, localSrc, nbytes, signalId, isWriter, result);
+  CUDACHECK_TEST(cudaGetLastError());
+}
+
+// =============================================================================
+// Transport Types Test
+// =============================================================================
+
+__global__ void transportTypesKernel(const DeviceWindow& dw, int* results) {
+  // Output numPeers in results[0]
+  results[0] = dw.num_peers();
+
+  // Self transport type
+  int myRank = dw.rank();
+  results[1 + myRank] =
+      static_cast<int>(dw.get_handle().transports[myRank].type);
+
+  // Peer transport types
+  int nRanks = dw.n_ranks();
+  for (int r = 0; r < nRanks; ++r) {
+    if (r == myRank)
+      continue;
+    results[1 + r] = static_cast<int>(dw.get_handle().transports[r].type);
+  }
+}
+
+void testTransportTypes(const DeviceWindow& dw, int* results) {
+  transportTypesKernel<<<1, 1>>>(dw, results);
+  CUDACHECK_TEST(cudaGetLastError());
+}
+
+// =============================================================================
+// Concurrent Signal Multi-Warp Test
+// =============================================================================
+
+__global__ void concurrentSignalWaitMultiWarpKernel(
+    DeviceWindow& dw,
+    int targetRank,
+    int numSlots,
+    bool isSignaler,
+    int* results,
+    int warpsPerBlock) {
+  // Each warp uses a different signal slot based on its warp index
+  uint32_t warpIdx = threadIdx.x / 32;
+  uint32_t laneIdx = threadIdx.x % 32;
+
+  // Only process if this warp is within the configured range
+  if (warpIdx >= warpsPerBlock) {
+    return;
+  }
+
+  // Create a warp-level thread group
+  auto group = make_warp_group();
+
+  // Use different slot per warp (warpIdx % numSlots)
+  int slotId = warpIdx % numSlots;
+
+  if (isSignaler) {
+    dw.signal_peer(group, targetRank, slotId, SignalOp::SIGNAL_ADD, 1);
+  } else {
+    dw.wait_signal(group, slotId, CmpOp::CMP_GE, 1);
+  }
+
+  // Record success for this warp
+  if (laneIdx == 0) {
+    results[warpIdx] = 1;
+  }
+}
+
+void testConcurrentSignalWaitMultiWarp(
+    DeviceWindow& dw,
+    int targetRank,
+    int numSlots,
+    bool isSignaler,
+    int* results,
+    int warpsPerBlock) {
+  int blockSize = warpsPerBlock * 32; // 32 threads per warp
+  concurrentSignalWaitMultiWarpKernel<<<1, blockSize>>>(
+      dw, targetRank, numSlots, isSignaler, results, warpsPerBlock);
+  CUDACHECK_TEST(cudaGetLastError());
+}
+
+// =============================================================================
+// signal_all() Test
+// =============================================================================
+
+__global__ void signalAllKernel(
+    DeviceWindow& dw,
+    int signalerRank,
+    int signalIdx,
+    int* result) {
+  auto group = make_warp_group();
+  int myRank = dw.rank();
+
+  if (myRank == signalerRank) {
+    dw.signal_all(group, signalIdx, SignalOp::SIGNAL_ADD, 1);
+  } else {
+    dw.wait_signal(group, signalIdx, CmpOp::CMP_GE, 1);
+  }
+
+  *result = 1;
+}
+
+void testSignalAll(
+    DeviceWindow& dw,
+    int signalerRank,
+    int signalIdx,
+    int* result) {
+  signalAllKernel<<<1, 32>>>(dw, signalerRank, signalIdx, result);
+  CUDACHECK_TEST(cudaGetLastError());
+}
+
+// =============================================================================
+// signal_all() + read_signal() Aggregate Test
+// =============================================================================
+
+__global__ void signalAllAggregateDistributedKernel(
+    DeviceWindow dw,
+    int signalIdx,
+    uint64_t* result) {
+  auto group = make_warp_group();
+
+  // Every rank signals all peers with value 1
+  dw.signal_all(group, signalIdx, SignalOp::SIGNAL_ADD, 1);
+
+  // Wait until aggregate reaches nRanks-1 (all peers have signaled us)
+  dw.wait_signal(
+      group, signalIdx, CmpOp::CMP_GE, dw.num_peers(), Timeout(10000000000ULL));
+
+  // Read aggregate (thread-level API)
+  if (group.is_leader()) {
+    *result = dw.read_signal(signalIdx);
+  }
+}
+
+void testSignalAllAggregateDistributed(
+    DeviceWindow& dw,
+    int signalIdx,
+    uint64_t* result) {
+  signalAllAggregateDistributedKernel<<<1, 32>>>(dw, signalIdx, result);
+  CUDACHECK_TEST(cudaGetLastError());
+}
+
+// =============================================================================
+// wait_signal_from_all() Test
+// =============================================================================
+
+__global__ void waitSignalFromAllKernel(
+    DeviceWindow& dw,
+    int targetRank,
+    int signalIdx,
+    int* result) {
+  auto group = make_warp_group();
+  int myRank = dw.rank();
+
+  if (myRank == targetRank) {
+    int nRanks = dw.n_ranks();
+    dw.wait_signal(group, signalIdx, CmpOp::CMP_GE, nRanks - 1);
+  } else {
+    dw.signal_peer(group, targetRank, signalIdx, SignalOp::SIGNAL_ADD, 1);
+  }
+
+  *result = 1;
+}
+
+void testWaitSignalFromAll(
+    DeviceWindow& dw,
+    int targetRank,
+    int signalIdx,
+    int* result) {
+  waitSignalFromAllKernel<<<1, 32>>>(dw, targetRank, signalIdx, result);
+  CUDACHECK_TEST(cudaGetLastError());
+}
+
+// =============================================================================
+// Wait with CMP_EQ Test
+// =============================================================================
+
+__global__ void waitWithCmpEqKernel(
+    DeviceWindow& dw,
+    int targetRank,
+    int signalIdx,
+    uint64_t expectedValue,
+    bool isSignaler,
+    int* result) {
+  auto group = make_warp_group();
+
+  if (isSignaler) {
+    dw.signal_peer(
+        group, targetRank, signalIdx, SignalOp::SIGNAL_SET, expectedValue);
+  } else {
+    dw.wait_signal(group, signalIdx, CmpOp::CMP_EQ, expectedValue);
+  }
+
+  *result = 1;
+}
+
+void testWaitWithCmpEq(
+    DeviceWindow& dw,
+    int targetRank,
+    int signalIdx,
+    uint64_t expectedValue,
+    bool isSignaler,
+    int* result) {
+  waitWithCmpEqKernel<<<1, 32>>>(
+      dw, targetRank, signalIdx, expectedValue, isSignaler, result);
+  CUDACHECK_TEST(cudaGetLastError());
+}
+
+// =============================================================================
+// Monotonic Wait Values Test
+// =============================================================================
+
+__global__ void monotonicWaitValuesKernel(
+    DeviceWindow& dw,
+    int targetRank,
+    int signalIdx,
+    int numIterations,
+    bool isSignaler,
+    int* result) {
+  auto group = make_warp_group();
+
+  for (int i = 0; i < numIterations; ++i) {
+    if (isSignaler) {
+      dw.signal_peer(group, targetRank, signalIdx, SignalOp::SIGNAL_ADD, 1);
+    } else {
+      dw.wait_signal(group, signalIdx, CmpOp::CMP_GE, i + 1);
+    }
+    group.sync();
+  }
+
+  *result = 1;
+}
+
+void testMonotonicWaitValues(
+    DeviceWindow& dw,
+    int targetRank,
+    int signalIdx,
+    int numIterations,
+    bool isSignaler,
+    int* result) {
+  monotonicWaitValuesKernel<<<1, 32>>>(
+      dw, targetRank, signalIdx, numIterations, isSignaler, result);
+  CUDACHECK_TEST(cudaGetLastError());
+}
+
+// =============================================================================
+// SIGNAL_SET Integration Test
+// =============================================================================
+
+__global__ void signalWithSetKernel(
+    DeviceWindow& dw,
+    int targetRank,
+    int signalIdx,
+    uint64_t setValue,
+    bool isSignaler,
+    int* result) {
+  auto group = make_warp_group();
+
+  if (isSignaler) {
+    dw.signal_peer(
+        group, targetRank, signalIdx, SignalOp::SIGNAL_SET, setValue);
+  } else {
+    dw.wait_signal(group, signalIdx, CmpOp::CMP_GE, setValue);
+  }
+
+  *result = 1;
+}
+
+void testSignalWithSet(
+    DeviceWindow& dw,
+    int targetRank,
+    int signalIdx,
+    uint64_t setValue,
+    bool isSignaler,
+    int* result) {
+  signalWithSetKernel<<<1, 32>>>(
+      dw, targetRank, signalIdx, setValue, isSignaler, result);
+  CUDACHECK_TEST(cudaGetLastError());
+}
+
+// =============================================================================
+// Barrier Monotonic Counters Test
+// =============================================================================
+
+__global__ void barrierMonotonicKernel(
+    DeviceWindow& dw,
+    int barrierIdx,
+    int numPhases,
+    int* result) {
+  auto group = make_warp_group();
+
+  for (int phase = 0; phase < numPhases; ++phase) {
+    dw.barrier(group, barrierIdx);
+  }
+
+  if (threadIdx.x == 0) {
+    *result = 1;
+  }
+}
+
+void testBarrierMonotonic(
+    DeviceWindow& dw,
+    int barrierIdx,
+    int numPhases,
+    int* result) {
+  barrierMonotonicKernel<<<1, 32>>>(dw, barrierIdx, numPhases, result);
+  CUDACHECK_TEST(cudaGetLastError());
+}
+
+// =============================================================================
+// Barrier Multi-Block Stress Test
+// =============================================================================
+
+__global__ void
+barrierMultiBlockStressKernel(DeviceWindow& dw, int numSlots, int* results) {
+  auto group = make_warp_group();
+
+  uint32_t slotId = blockIdx.x % numSlots;
+
+  dw.barrier(group, slotId);
+
+  if (threadIdx.x == 0) {
+    results[blockIdx.x] = 1;
+  }
+}
+
+void testBarrierMultiBlockStress(
+    DeviceWindow& dw,
+    int numSlots,
+    int* results,
+    int numBlocks) {
+  barrierMultiBlockStressKernel<<<numBlocks, 32>>>(dw, numSlots, results);
+  CUDACHECK_TEST(cudaGetLastError());
+}
+
+// =============================================================================
+// Barrier Peer Test (Two-Sided Barrier)
+// =============================================================================
+
+__global__ void barrierPeerKernel(
+    DeviceWindow& dw,
+    int targetRank,
+    int barrierIdx,
+    int* result) {
+  auto group = make_warp_group();
+
+  dw.barrier_peer(targetRank, group, barrierIdx);
+
+  if (threadIdx.x == 0) {
+    *result = 1;
+  }
+}
+
+void testBarrierPeer(
+    DeviceWindow& dw,
+    int targetRank,
+    int barrierIdx,
+    int* result) {
+  barrierPeerKernel<<<1, 32>>>(dw, targetRank, barrierIdx, result);
+  CUDACHECK_TEST(cudaGetLastError());
+}
+
+// =============================================================================
+// wait_signal_from() Basic Test
+// =============================================================================
+
+__global__ void waitSignalFromPeerKernel(
+    DeviceWindow& dw,
+    int peerRank,
+    int signalIdx,
+    bool isSignaler,
+    int* result) {
+  auto group = make_warp_group();
+
+  if (isSignaler) {
+    dw.signal_peer(group, peerRank, signalIdx, SignalOp::SIGNAL_ADD, 1);
+  } else {
+    dw.wait_signal_from(group, peerRank, signalIdx, CmpOp::CMP_GE, 1);
+    uint64_t val = dw.read_signal_from(peerRank, signalIdx);
+    if (val < 1) {
+      *result = 0;
+      return;
+    }
+  }
+
+  *result = 1;
+}
+
+void testWaitSignalFromPeer(
+    DeviceWindow& dw,
+    int peerRank,
+    int signalIdx,
+    bool isSignaler,
+    int* result) {
+  waitSignalFromPeerKernel<<<1, 32>>>(
+      dw, peerRank, signalIdx, isSignaler, result);
+  CUDACHECK_TEST(cudaGetLastError());
+}
+
+// =============================================================================
+// wait_signal_from() Multi-Peer Isolation Test
+// =============================================================================
+
+__global__ void waitSignalFromMultiPeerIsolationKernel(
+    DeviceWindow& dw,
+    int targetRank,
+    int signalIdx,
+    int* result) {
+  auto group = make_warp_group();
+  int myRank = dw.rank();
+  int nRanks = dw.n_ranks();
+
+  if (myRank == targetRank) {
+    for (int r = 0; r < nRanks; ++r) {
+      if (r == myRank) {
+        continue;
+      }
+      uint64_t expectedValue = static_cast<uint64_t>(r + 1);
+      dw.wait_signal_from(group, r, signalIdx, CmpOp::CMP_GE, expectedValue);
+      uint64_t val = dw.read_signal_from(r, signalIdx);
+      if (val != expectedValue) {
+        *result = 0;
+        return;
+      }
+    }
+  } else {
+    uint64_t signalValue = static_cast<uint64_t>(myRank + 1);
+    dw.signal_peer(
+        group, targetRank, signalIdx, SignalOp::SIGNAL_SET, signalValue);
+  }
+
+  *result = 1;
+}
+
+void testWaitSignalFromMultiPeerIsolation(
+    DeviceWindow& dw,
+    int targetRank,
+    int signalIdx,
+    int* result) {
+  waitSignalFromMultiPeerIsolationKernel<<<1, 32>>>(
+      dw, targetRank, signalIdx, result);
+  CUDACHECK_TEST(cudaGetLastError());
+}
+
+// =============================================================================
+// wait_signal() and wait_signal_from() Both Work Test
+// =============================================================================
+
+__global__ void waitSignalAndWaitSignalFromBothWorkKernel(
+    DeviceWindow& dw,
+    int targetRank,
+    int signalIdx,
+    int* result) {
+  auto group = make_warp_group();
+  int myRank = dw.rank();
+  int nRanks = dw.n_ranks();
+
+  if (myRank == targetRank) {
+    dw.wait_signal(group, signalIdx, CmpOp::CMP_GE, nRanks - 1);
+
+    for (int r = 0; r < nRanks; ++r) {
+      if (r == myRank) {
+        continue;
+      }
+      dw.wait_signal_from(group, r, signalIdx, CmpOp::CMP_GE, 1);
+    }
+  } else {
+    dw.signal_peer(group, targetRank, signalIdx, SignalOp::SIGNAL_ADD, 1);
+  }
+
+  *result = 1;
+}
+
+void testWaitSignalAndWaitSignalFromBothWork(
+    DeviceWindow& dw,
+    int targetRank,
+    int signalIdx,
+    int* result) {
+  waitSignalAndWaitSignalFromBothWorkKernel<<<1, 32>>>(
+      dw, targetRank, signalIdx, result);
+  CUDACHECK_TEST(cudaGetLastError());
+}
+
+// =============================================================================
+// Signal/Wait Test (BLOCK Scope - exercises fallback path)
+// =============================================================================
+
+__global__ void signalWaitBlockScopeKernel(
+    DeviceWindow& dw,
+    int targetRank,
+    int signalIdx,
+    bool isSignaler,
+    int* result) {
+  auto group = make_block_group(); // Uses SyncScope::BLOCK
+
+  if (isSignaler) {
+    dw.signal_peer(group, targetRank, signalIdx, SignalOp::SIGNAL_ADD, 1);
+    if (threadIdx.x == 0) {
+      *result = 1;
+    }
+  } else {
+    dw.wait_signal(group, signalIdx, CmpOp::CMP_GE, 1);
+    if (threadIdx.x == 0) {
+      *result = 1;
+    }
+  }
+}
+
+void testSignalWaitBlockScope(
+    DeviceWindow& dw,
+    int targetRank,
+    int signalIdx,
+    bool isSignaler,
+    int* result) {
+  // Launch with 1 block of 128 threads (BLOCK scope = all 128 threads in block)
+  signalWaitBlockScopeKernel<<<1, 128>>>(
+      dw, targetRank, signalIdx, isSignaler, result);
+  CUDACHECK_TEST(cudaGetLastError());
+}
+
+} // namespace comms::pipes::test

--- a/comms/pipes/tests/MultiPeerNvlTransportIntegrationTest.cuh
+++ b/comms/pipes/tests/MultiPeerNvlTransportIntegrationTest.cuh
@@ -1,0 +1,423 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "comms/pipes/window/DeviceWindow.cuh"
+
+namespace comms::pipes::test {
+
+/**
+ * Test kernel: Verify DeviceWindow accessors on device
+ *
+ * @param dw The DeviceWindow to test
+ * @param results Output array: [0]=rank, [1]=nRanks, [2]=numPeers
+ */
+void testMultiPeerDeviceTransportAccessors(
+    const DeviceWindow& dw,
+    int* results);
+
+/**
+ * Test kernel: Signal from one rank to another and wait for it
+ *
+ * Uses inbox-model signaling: rank signals to peer's inbox, peer waits on own
+ * inbox.
+ *
+ * @param dw The DeviceWindow to use
+ * @param targetRank The target rank to signal/wait from
+ * @param signalIdx The signal slot index to use
+ * @param isSignaler If true, this rank signals; if false, this rank waits
+ * @param result Output: 1 if successful, 0 if failed
+ */
+void testSignalWait(
+    DeviceWindow& dw,
+    int targetRank,
+    int signalIdx,
+    bool isSignaler,
+    int* result);
+
+/**
+ * Test kernel: Execute barrier across all ranks
+ *
+ * This tests that the barrier correctly synchronizes all ranks.
+ *
+ * @param dw The DeviceWindow to use
+ * @param barrierIdx The barrier slot index to use
+ * @param result Output: 1 if barrier completed successfully
+ */
+void testBarrier(DeviceWindow& dw, int barrierIdx, int* result);
+
+/**
+ * Test kernel: Send data from this rank to a single peer
+ *
+ * @param dw The DeviceWindow to use
+ * @param targetRank The destination rank
+ * @param srcBuff Source buffer containing data to send
+ * @param nbytes Number of bytes to send
+ * @param numBlocks Number of thread blocks to launch
+ * @param blockSize Threads per block
+ */
+void testSinglePeerSend(
+    DeviceWindow& dw,
+    int targetRank,
+    void* srcBuff,
+    std::size_t nbytes,
+    int numBlocks,
+    int blockSize);
+
+/**
+ * Test kernel: Receive data from a single peer to this rank
+ *
+ * @param dw The DeviceWindow to use
+ * @param targetRank The source rank
+ * @param dstBuff Destination buffer for received data
+ * @param nbytes Number of bytes to receive
+ * @param numBlocks Number of thread blocks to launch
+ * @param blockSize Threads per block
+ */
+void testSinglePeerRecv(
+    DeviceWindow& dw,
+    int targetRank,
+    void* dstBuff,
+    std::size_t nbytes,
+    int numBlocks,
+    int blockSize);
+
+/**
+ * Test kernel: Parallel send/recv to all peers using partition
+ *
+ * Uses partition_interleaved to split warps between send and recv work,
+ * then further partitions across peers. This avoids deadlocks that can occur
+ * when send and recv are done sequentially.
+ *
+ * @param dw The DeviceWindow to use
+ * @param srcBuffs Array of source buffers, one per peer
+ * @param dstBuffs Array of destination buffers, one per peer
+ * @param nbytesPerPeer Number of bytes to transfer per peer
+ * @param numBlocks Number of thread blocks to launch
+ * @param blockSize Threads per block
+ */
+void testMultiPeerSendRecvAllPeers(
+    DeviceWindow& dw,
+    void** srcBuffs,
+    void** dstBuffs,
+    std::size_t nbytesPerPeer,
+    int numBlocks,
+    int blockSize);
+
+/**
+ * Test kernel: Concurrent signal/barrier using multiple blocks
+ *
+ * Each block uses different signal/barrier slots concurrently
+ * to verify no races or deadlocks.
+ *
+ * @param dw The DeviceWindow to use
+ * @param targetRank The target rank to signal/wait from
+ * @param numSlots Number of slots to test concurrently
+ * @param isSignaler If true, this rank signals; if false, waits
+ * @param results Output array: results[blockIdx] = 1 if successful
+ */
+void testConcurrentSignalMultiBlock(
+    DeviceWindow& dw,
+    int targetRank,
+    int numSlots,
+    bool isSignaler,
+    int* results,
+    int numBlocks);
+
+/**
+ * Test kernel: Verify transport type accessors
+ *
+ * Checks that get_peer_transport() and get_self_transport() return correct
+ * transport types for self vs peer.
+ *
+ * @param dw The DeviceWindow to use
+ * @param results Output array: [0]=numPeers, [1..nRanks]=transport types
+ */
+void testTransportTypes(const DeviceWindow& dw, int* results);
+
+/**
+ * Test kernel: Concurrent signal/wait from multiple warps within a block
+ *
+ * Each warp uses a different signal slot to verify thread-safety of
+ * signal operations when multiple warps operate concurrently.
+ *
+ * @param dw The DeviceWindow to use
+ * @param targetRank The target rank to signal/wait from
+ * @param numSlots Number of signal slots (should be >= warps per block)
+ * @param isSignaler If true, this rank signals; if false, waits
+ * @param results Output array: results[warpIdx] = 1 if successful
+ * @param warpsPerBlock Number of warps per block
+ */
+void testConcurrentSignalWaitMultiWarp(
+    DeviceWindow& dw,
+    int targetRank,
+    int numSlots,
+    bool isSignaler,
+    int* results,
+    int warpsPerBlock);
+
+/**
+ * Test kernel: signal_all() signals all peers at once
+ *
+ * Tests that signal_all() correctly signals all peers (excluding self).
+ * One rank signals, all other ranks wait for the signal.
+ *
+ * @param dw The DeviceWindow to use
+ * @param signalerRank The rank that will call signal_all()
+ * @param signalIdx The signal slot index to use
+ * @param result Output: 1 if successful
+ */
+void testSignalAll(
+    DeviceWindow& dw,
+    int signalerRank,
+    int signalIdx,
+    int* result);
+
+/**
+ * Test kernel: signal_all() + read_signal() aggregate across all ranks
+ *
+ * All ranks call signal_all() to signal every peer, then each rank
+ * waits for aggregate and reads it via read_signal().
+ * Verifies the aggregate equals nRanks-1 (one signal from each peer).
+ *
+ * @param dw The DeviceWindow to use
+ * @param signalIdx The signal slot index to use
+ * @param result Output: aggregate signal value read by this rank
+ */
+void testSignalAllAggregateDistributed(
+    DeviceWindow& dw,
+    int signalIdx,
+    uint64_t* result);
+
+/**
+ * Test kernel: wait_signal_from_all() barrier-like synchronization
+ *
+ * Tests that wait_signal_from_all() correctly waits for signals from
+ * all peers. All peers signal one rank, that rank waits for all.
+ *
+ * @param dw The DeviceWindow to use
+ * @param targetRank The rank that will call wait_signal_from_all()
+ * @param signalIdx The signal slot index to use
+ * @param result Output: 1 if successful
+ */
+void testWaitSignalFromAll(
+    DeviceWindow& dw,
+    int targetRank,
+    int signalIdx,
+    int* result);
+
+/**
+ * Test kernel: Wait with CMP_EQ comparison operation
+ *
+ * Tests exact equality comparison (vs CMP_GE which is more commonly used).
+ * Signals with exact value, waits with CMP_EQ.
+ *
+ * @param dw The DeviceWindow to use
+ * @param targetRank The target rank to signal/wait from
+ * @param signalIdx The signal slot index to use
+ * @param expectedValue The value to signal and wait for
+ * @param isSignaler If true, this rank signals; if false, waits
+ * @param result Output: 1 if successful
+ */
+void testWaitWithCmpEq(
+    DeviceWindow& dw,
+    int targetRank,
+    int signalIdx,
+    uint64_t expectedValue,
+    bool isSignaler,
+    int* result);
+
+/**
+ * Test kernel: Monotonically increasing wait values pattern
+ *
+ * Tests the recommended pattern of using monotonically increasing wait
+ * values (signal 1, wait for 1, signal 1, wait for 2, etc.) across
+ * multiple iterations.
+ *
+ * @param dw The DeviceWindow to use
+ * @param targetRank The target rank to signal/wait from
+ * @param signalIdx The signal slot index to use
+ * @param numIterations Number of iterations to perform
+ * @param isSignaler If true, this rank signals; if false, waits
+ * @param result Output: 1 if all iterations successful
+ */
+void testMonotonicWaitValues(
+    DeviceWindow& dw,
+    int targetRank,
+    int signalIdx,
+    int numIterations,
+    bool isSignaler,
+    int* result);
+
+/**
+ * Test kernel: SIGNAL_SET operation in multi-GPU context
+ *
+ * Tests that SIGNAL_SET correctly overwrites values in multi-GPU signaling.
+ *
+ * @param dw The DeviceWindow to use
+ * @param targetRank The target rank to signal/wait from
+ * @param signalIdx The signal slot index to use
+ * @param setValue The value to SET
+ * @param isSignaler If true, this rank signals; if false, waits
+ * @param result Output: 1 if successful
+ */
+void testSignalWithSet(
+    DeviceWindow& dw,
+    int targetRank,
+    int signalIdx,
+    uint64_t setValue,
+    bool isSignaler,
+    int* result);
+
+/**
+ * Test kernel: Barrier with monotonic counters across multiple phases
+ *
+ * Tests that a single barrier slot works across multiple phases via
+ * counter accumulation (no reset needed).
+ *
+ * @param dw The DeviceWindow to use
+ * @param barrierIdx The barrier slot index to use
+ * @param numPhases Number of barrier phases to execute
+ * @param result Output: 1 if successful
+ */
+void testBarrierMonotonic(
+    DeviceWindow& dw,
+    int barrierIdx,
+    int numPhases,
+    int* result);
+
+/**
+ * Test kernel: Multi-block barrier stress test
+ *
+ * Each block performs a barrier synchronization using a different slot.
+ * Tests concurrent barrier operations from multiple blocks.
+ *
+ * @param dw The DeviceWindow to use
+ * @param numSlots Number of barrier slots to use
+ * @param results Output array: results[blockIdx] = 1 if successful
+ * @param numBlocks Number of blocks to launch
+ */
+void testBarrierMultiBlockStress(
+    DeviceWindow& dw,
+    int numSlots,
+    int* results,
+    int numBlocks);
+
+/**
+ * Test kernel: Two-sided barrier with a specific peer
+ *
+ * Tests barrier_peer() which synchronizes with a single peer rather than
+ * all ranks. Both ranks must call barrier_peer() with each other's rank.
+ *
+ * @param dw The DeviceWindow to use
+ * @param targetRank The target rank to synchronize with
+ * @param barrierIdx The barrier slot index to use
+ * @param result Output: 1 if successful
+ */
+void testBarrierPeer(
+    DeviceWindow& dw,
+    int targetRank,
+    int barrierIdx,
+    int* result);
+
+/**
+ * Test kernel: Test the put() operation
+ *
+ * @param dw The DeviceWindow to use
+ * @param targetRank Target rank
+ * @param remoteDst Remote destination buffer
+ * @param localSrc Local source buffer
+ * @param nbytes Number of bytes to transfer
+ * @param signalId Signal slot to use for completion notification
+ * @param isWriter True if this rank writes, false if it waits
+ * @param result Output: 1 if successful
+ */
+void testPutOperation(
+    DeviceWindow& dw,
+    int targetRank,
+    void* remoteDst,
+    const void* localSrc,
+    std::size_t nbytes,
+    int signalId,
+    bool isWriter,
+    int* result);
+
+/**
+ * Test kernel: wait_signal_from() basic per-peer signal/wait
+ *
+ * Rank 0 signals rank 1, rank 1 uses wait_signal_from(0, ...) to wait
+ * for the specific peer's signal. Verifies read_signal_from() as well.
+ *
+ * @param dw The DeviceWindow to use
+ * @param peerRank The peer rank to signal/wait from
+ * @param signalIdx The signal slot index to use
+ * @param isSignaler If true, this rank signals; if false, waits
+ * @param result Output: 1 if successful
+ */
+void testWaitSignalFromPeer(
+    DeviceWindow& dw,
+    int peerRank,
+    int signalIdx,
+    bool isSignaler,
+    int* result);
+
+/**
+ * Test kernel: wait_signal_from() per-peer isolation
+ *
+ * All peers signal one target rank with different values using SIGNAL_SET.
+ * Target calls wait_signal_from() for each peer individually, verifying
+ * each peer's sub-slot has the correct independent value.
+ *
+ * @param dw The DeviceWindow to use
+ * @param targetRank The rank that all peers signal and that verifies isolation
+ * @param signalIdx The signal slot index to use
+ * @param result Output: 1 if successful
+ */
+void testWaitSignalFromMultiPeerIsolation(
+    DeviceWindow& dw,
+    int targetRank,
+    int signalIdx,
+    int* result);
+
+/**
+ * Test kernel: Both wait_signal() and wait_signal_from() work together
+ *
+ * All peers signal rank 0 with SIGNAL_ADD, 1. Rank 0 verifies:
+ * - wait_signal(signal_id, CMP_GE, nRanks-1) succeeds (accumulated sum)
+ * - wait_signal_from(peer, signal_id, CMP_GE, 1) succeeds for each peer
+ *
+ * @param dw The DeviceWindow to use
+ * @param targetRank The rank that waits for all signals
+ * @param signalIdx The signal slot index to use
+ * @param result Output: 1 if successful
+ */
+void testWaitSignalAndWaitSignalFromBothWork(
+    DeviceWindow& dw,
+    int targetRank,
+    int signalIdx,
+    int* result);
+
+/**
+ * Test kernel: Signal/Wait using BLOCK scope (exercises fallback path)
+ *
+ * Same as testSignalWait but uses make_block_group() instead of
+ * make_warp_group() to exercise the non-WARP fallback code path in
+ * DeviceWindowSignal::wait_signal().
+ *
+ * @param dw The DeviceWindow to use
+ * @param targetRank The target rank to signal/wait from
+ * @param signalIdx The signal slot index to use
+ * @param isSignaler If true, this rank signals; if false, this rank waits
+ * @param result Output: 1 if successful, 0 if failed
+ */
+void testSignalWaitBlockScope(
+    DeviceWindow& dw,
+    int targetRank,
+    int signalIdx,
+    bool isSignaler,
+    int* result);
+
+} // namespace comms::pipes::test

--- a/comms/pipes/tests/MultiPeerTransportTest.cc
+++ b/comms/pipes/tests/MultiPeerTransportTest.cc
@@ -1,11 +1,16 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
+#include <cstring>
+
+#include <unistd.h>
+
+#include <cuda.h>
 #include <cuda_runtime.h>
 #include <gtest/gtest.h>
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 
+#include "comms/pipes/GpuMemHandler.h"
 #include "comms/pipes/MultiPeerDeviceHandle.cuh"
 #include "comms/pipes/MultiPeerTransport.h"
 #include "comms/pipes/Transport.cuh"
@@ -19,12 +24,7 @@ using namespace meta::comms;
 namespace comms::pipes::tests {
 
 /**
- * Single-node test fixture for MultiPeerTransport (nnodes=1, ppn=4).
- *
- * All ranks run on the same host, so every peer is NVLink-connected.
- * Use this fixture to test basic transport construction, exchange,
- * topology queries, and device handle generation in a homogeneous
- * NVL-only environment.
+ * Test fixture for MultiPeerTransport.
  *
  * For multi-node tests that exercise mixed NVL + IBGDA topology
  * (cross-node peers), see MultiPeerTransportMultiNodeTest.cc.
@@ -37,7 +37,7 @@ class MultiPeerTransportTestFixture : public MpiBaseTestFixture {
     detectLocalSize();
   }
 
-  std::unique_ptr<MultiPeerTransport> create_transport_states() {
+  std::unique_ptr<MultiPeerTransport> createTransport() {
     MultiPeerTransportConfig config{
         .nvlConfig =
             {
@@ -51,9 +51,18 @@ class MultiPeerTransportTestFixture : public MpiBaseTestFixture {
                 .cudaDevice = localRank,
             },
     };
-    auto bootstrap = std::make_shared<MpiBootstrap>();
     return std::make_unique<MultiPeerTransport>(
-        globalRank, numRanks, localRank, bootstrap, config);
+        globalRank,
+        numRanks,
+        localRank,
+        std::make_shared<MpiBootstrap>(),
+        config);
+  }
+
+  // Returns true when NVL peers span multiple hosts (MNNVL).
+  // cudaIpc is host-local and cannot cross host boundaries.
+  bool nvlSpansMultipleHosts(const MultiPeerTransport& t) const {
+    return t.nvl_n_ranks() > localSize_;
   }
 
   // Verify exchangeNvlBuffer mappedPtrs: self entry == localBuf,
@@ -78,11 +87,6 @@ class MultiPeerTransportTestFixture : public MpiBaseTestFixture {
       EXPECT_NE(peerByte, 0)
           << "peer data at NVL rank " << rank << " should be non-zero";
     }
-  }
-
-  // Returns true if NVL peers span more than one host (MNNVL topology).
-  bool nvlSpansMultipleHosts(const MultiPeerTransport& t) {
-    return t.nvl_n_ranks() > localSize_;
   }
 
  private:
@@ -111,148 +115,103 @@ class MultiPeerTransportTestFixture : public MpiBaseTestFixture {
   int localSize_{0};
 };
 
-// Verify that topology discovery correctly classifies peers as NVL or IBGDA.
-// With nnodes=1, ppn=2, both ranks are on the same node so the peer should
-// be NVL (assuming GPUs support P2P access).
 TEST_F(MultiPeerTransportTestFixture, TopologyDiscovery) {
   if (numRanks < 2) {
     GTEST_SKIP() << "Requires >= 2 ranks, got " << numRanks;
   }
 
-  auto states = create_transport_states();
+  auto transport = createTransport();
+  int peer = (globalRank == 0) ? 1 : 0;
 
-  // On same node, peer should be NVL
-  int peerRank = (globalRank == 0) ? 1 : 0;
-  EXPECT_TRUE(states->is_nvl_peer(peerRank))
-      << "Rank " << globalRank << " expected peer " << peerRank
-      << " to be NVL (same node)";
-
-  // Self should be SELF
-  EXPECT_EQ(states->get_transport_type(globalRank), TransportType::SELF);
-  EXPECT_EQ(states->get_transport_type(peerRank), TransportType::P2P_NVL);
-
-  // Check peer rank vectors
-  EXPECT_FALSE(states->nvl_peer_ranks().empty());
-  // IBGDA is universal — it covers all non-self peers
-  EXPECT_EQ(static_cast<int>(states->ibgda_peer_ranks().size()), numRanks - 1);
-
-  XLOGF(
-      INFO,
-      "Rank {}: {} NVL peers, {} IBGDA peers",
-      globalRank,
-      states->nvl_peer_ranks().size(),
-      states->ibgda_peer_ranks().size());
+  EXPECT_EQ(transport->get_transport_type(globalRank), TransportType::SELF);
+  EXPECT_EQ(transport->get_transport_type(peer), TransportType::P2P_NVL);
+  EXPECT_FALSE(transport->nvl_peer_ranks().empty());
+  EXPECT_EQ(
+      static_cast<int>(transport->ibgda_peer_ranks().size()), numRanks - 1);
 
   MPI_Barrier(MPI_COMM_WORLD);
 }
 
-// Verify self transport type is always SELF regardless of rank count.
 TEST_F(MultiPeerTransportTestFixture, SelfTransportType) {
-  auto states = create_transport_states();
-  EXPECT_EQ(states->get_transport_type(globalRank), TransportType::SELF);
-  EXPECT_EQ(states->my_rank(), globalRank);
-  EXPECT_EQ(states->n_ranks(), numRanks);
+  auto transport = createTransport();
+  EXPECT_EQ(transport->get_transport_type(globalRank), TransportType::SELF);
+  EXPECT_EQ(transport->my_rank(), globalRank);
+  EXPECT_EQ(transport->n_ranks(), numRanks);
 
   MPI_Barrier(MPI_COMM_WORLD);
 }
 
-// Verify exchange() completes without error on all ranks.
 TEST_F(MultiPeerTransportTestFixture, ExchangeSucceeds) {
   if (numRanks < 2) {
     GTEST_SKIP() << "Requires >= 2 ranks, got " << numRanks;
   }
 
-  auto states = create_transport_states();
-  EXPECT_NO_THROW(states->exchange());
+  auto transport = createTransport();
+  EXPECT_NO_THROW(transport->exchange());
 
   MPI_Barrier(MPI_COMM_WORLD);
 }
 
-// Verify host-side NVL transport accessor returns valid device pointer after
-// exchange.
 TEST_F(MultiPeerTransportTestFixture, HostNvlAccessor) {
   if (numRanks < 2) {
     GTEST_SKIP() << "Requires >= 2 ranks, got " << numRanks;
   }
 
-  auto states = create_transport_states();
-  states->exchange();
+  auto transport = createTransport();
+  transport->exchange();
 
-  int peerRank = (globalRank == 0) ? 1 : 0;
-  auto p2p = states->get_p2p_nvl_transport_device(peerRank);
-
-  // The returned device handle is constructed by value.
-  // We can verify it was constructed without throwing; actual functionality
-  // is tested by device-side tests (P2pNvlTransportTest, AllToAllvTest, etc.).
-  (void)p2p;
+  int peer = (globalRank == 0) ? 1 : 0;
+  auto p2p = transport->get_p2p_nvl_transport_device(peer);
+  EXPECT_NE(p2p.getLocalState().dataBuffer, nullptr);
+  EXPECT_NE(p2p.getRemoteState().dataBuffer, nullptr);
 
   MPI_Barrier(MPI_COMM_WORLD);
 }
 
-// Verify the self transport accessor returns a valid (trivial) object.
 TEST_F(MultiPeerTransportTestFixture, SelfAccessor) {
-  auto states = create_transport_states();
-  auto selfTransport = states->get_p2p_self_transport_device();
-  // P2pSelfTransportDevice is stateless, just verify it constructs
-  (void)selfTransport;
+  auto transport = createTransport();
+  (void)transport->get_p2p_self_transport_device();
 
   MPI_Barrier(MPI_COMM_WORLD);
 }
 
-// Verify getDeviceHandle() returns a handle with correct metadata
-// after exchange.
 TEST_F(MultiPeerTransportTestFixture, DeviceHandleMetadata) {
   if (numRanks < 2) {
     GTEST_SKIP() << "Requires >= 2 ranks, got " << numRanks;
   }
 
-  auto states = create_transport_states();
-  states->exchange();
+  auto transport = createTransport();
+  transport->exchange();
 
-  auto handle = states->get_device_handle();
+  auto handle = transport->get_device_handle();
   EXPECT_EQ(handle.myRank, globalRank);
   EXPECT_EQ(handle.nRanks, numRanks);
-
-  // Unified transport array should have one entry per rank
-  EXPECT_FALSE(handle.transports.empty());
   EXPECT_EQ(handle.transports.size(), static_cast<uint32_t>(numRanks));
-
-  // On single-node with NVL peers, numNvlPeers should be positive
   EXPECT_GT(handle.numNvlPeers, 0);
-
-  // IBGDA is universal — all non-self peers
   EXPECT_EQ(handle.numIbPeers, numRanks - 1);
 
   MPI_Barrier(MPI_COMM_WORLD);
 }
 
-// Verify getDeviceHandle() throws before exchange() is called.
 TEST_F(MultiPeerTransportTestFixture, DeviceHandleBeforeExchange) {
-  auto states = create_transport_states();
-  EXPECT_THROW(states->get_device_handle(), std::runtime_error);
+  auto transport = createTransport();
+  EXPECT_THROW(transport->get_device_handle(), std::runtime_error);
 
   MPI_Barrier(MPI_COMM_WORLD);
 }
 
-// Verify that IBGDA transport is accessible even for an NVL peer.
-// This is the key capability: IBGDA is universal, NVL is the preferred overlay.
 TEST_F(MultiPeerTransportTestFixture, HostIbgdaAccessorForNvlPeer) {
   if (numRanks < 2) {
     GTEST_SKIP() << "Requires >= 2 ranks, got " << numRanks;
   }
 
-  auto states = create_transport_states();
-  states->exchange();
+  auto transport = createTransport();
+  transport->exchange();
 
-  int peerRank = (globalRank == 0) ? 1 : 0;
-
-  // Peer is NVL, but IBGDA should also be accessible
-  ASSERT_TRUE(states->is_nvl_peer(peerRank));
-  EXPECT_TRUE(states->has_ibgda(peerRank));
-
-  auto* ibgdaDev = states->get_p2p_ibgda_transport_device(peerRank);
-  EXPECT_NE(ibgdaDev, nullptr)
-      << "IBGDA transport should be accessible for NVL peer " << peerRank;
+  int peer = (globalRank == 0) ? 1 : 0;
+  ASSERT_TRUE(transport->is_nvl_peer(peer));
+  EXPECT_TRUE(transport->has_ibgda(peer));
+  EXPECT_NE(transport->get_p2p_ibgda_transport_device(peer), nullptr);
 
   MPI_Barrier(MPI_COMM_WORLD);
 }
@@ -263,7 +222,7 @@ TEST_F(MultiPeerTransportTestFixture, ExchangeNvlBufferCudaMalloc) {
     GTEST_SKIP() << "Requires >= 2 ranks, got " << numRanks;
   }
 
-  auto transport = create_transport_states();
+  auto transport = createTransport();
   transport->exchange();
 
   if (transport->nvl_peer_ranks().empty()) {
@@ -298,7 +257,7 @@ TEST_F(MultiPeerTransportTestFixture, ExchangeNvlBufferMultipleRoundTrips) {
     GTEST_SKIP() << "Requires >= 2 ranks, got " << numRanks;
   }
 
-  auto transport = create_transport_states();
+  auto transport = createTransport();
   transport->exchange();
 
   if (transport->nvl_peer_ranks().empty()) {
@@ -340,7 +299,7 @@ TEST_F(MultiPeerTransportTestFixture, ExchangeNvlBufferFabric) {
     GTEST_SKIP() << "Fabric handles not supported on this GPU/CUDA version";
   }
 
-  auto transport = create_transport_states();
+  auto transport = createTransport();
   transport->exchange();
 
   if (transport->nvl_peer_ranks().empty()) {

--- a/comms/pipes/tests/MultipeerIbgdaTransportTest.cu
+++ b/comms/pipes/tests/MultipeerIbgdaTransportTest.cu
@@ -55,7 +55,7 @@ void testPutAndSignal(
 }
 
 // =============================================================================
-// Kernel: Warp-group-collaborative put + signal
+// Kernel: Group-collaborative put + signal (warp group)
 // =============================================================================
 
 __global__ void putAndSignalGroupKernel(
@@ -105,6 +105,7 @@ void testPutAndSignalGroup(
 
 // =============================================================================
 // Kernel: Multi-warp group-collaborative put + signal
+// Multiple warps use put_group_global, each leader signals
 // =============================================================================
 
 __global__ void putAndSignalGroupMultiWarpKernel(
@@ -403,36 +404,6 @@ void verifyBufferPattern(
       nbytes,
       expectedBaseValue,
       errorCount);
-  cudaError_t err = cudaGetLastError();
-  if (err != cudaSuccess) {
-    throw std::runtime_error(
-        std::string("Kernel launch failed: ") + cudaGetErrorString(err));
-  }
-}
-
-// =============================================================================
-// Kernel: Reset signal
-// =============================================================================
-
-__global__ void resetSignalKernel(
-    P2pIbgdaTransportDevice* transport,
-    IbgdaRemoteBuffer remoteSignalBuf,
-    int signalId) {
-  auto group = make_block_group();
-  if (group.is_global_leader()) {
-    // reset_signal is now synchronous (includes fences and wait internally)
-    transport->reset_signal(remoteSignalBuf, signalId);
-  }
-}
-
-void testResetSignal(
-    P2pIbgdaTransportDevice* deviceTransportPtr,
-    const IbgdaRemoteBuffer& remoteSignalBuf,
-    int signalId,
-    int numBlocks,
-    int blockSize) {
-  resetSignalKernel<<<numBlocks, blockSize>>>(
-      deviceTransportPtr, remoteSignalBuf, signalId);
   cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     throw std::runtime_error(

--- a/comms/pipes/tests/MultipeerIbgdaTransportTest.cuh
+++ b/comms/pipes/tests/MultipeerIbgdaTransportTest.cuh
@@ -136,11 +136,6 @@ __global__ void putSignalCounterKernel(
     int counterId,
     uint64_t counterVal);
 
-__global__ void resetSignalKernel(
-    P2pIbgdaTransportDevice* transport,
-    IbgdaRemoteBuffer remoteSignalBuf,
-    int signalId);
-
 __global__ void waitCounterKernel(
     volatile uint64_t* counterBuf,
     int counterId,

--- a/comms/pipes/tests/MultipeerIbgdaTransportTest.h
+++ b/comms/pipes/tests/MultipeerIbgdaTransportTest.h
@@ -236,23 +236,6 @@ void verifyBufferPattern(
     int blockSize);
 
 /**
- * Test kernel: Reset a remote signal slot to zero
- *
- * Uses RDMA inline write to set the remote signal to zero.
- *
- * @param deviceTransportPtr Pointer to P2pIbgdaTransportDevice in device
- * memory
- * @param remoteSignalBuf Remote signal buffer (with rkey)
- * @param signalId Signal slot index
- */
-void testResetSignal(
-    P2pIbgdaTransportDevice* deviceTransportPtr,
-    const IbgdaRemoteBuffer& remoteSignalBuf,
-    int signalId,
-    int numBlocks,
-    int blockSize);
-
-/**
  * Test kernel: Wait for ready signal, then put data with signal
  *
  * Sender waits for the receiver's ready signal (volatile spin on local


### PR DESCRIPTION
Summary:
[pipes] Migrate all integration tests and benchmarks to DeviceWindow

Migrate all callers from the deleted MultiPeerDeviceTransport to the unified
DeviceWindow/HostWindow APIs. After this diff, no code outside the window layer
references the old per-transport device wrappers — all kernel launches go
through DeviceWindow.

IBGDA benchmarks (IbgdaBenchmark.*):
- Consolidate to the unified put_signal() API, removing the separate
  non-adaptive put() + signal_remote_with_fence() benchmark path. The
  non-adaptive path is no longer needed since put_signal() now handles NIC
  fencing internally via signal_remote_with_fence().
- Remove runPutSignalNonAdaptiveBenchmark and related kernels/declarations.

Multi-peer benchmarks (MultiPeerBenchmark.*):
- Kernel functions now take DeviceWindow& instead of MultiPeerDeviceTransport&.
- Host-side setup migrated from MultiPeerNvlTransport/WindowMemory to
  MultiPeerTransport/HostWindow.
- benchmarks/BUCK: replace multi_peer_device_transport deps with device_window
  and host_window.

NVL integration tests (MultiPeerNvlTransportIntegrationTest.*):
- All kernel functions and test cases migrated to DeviceWindow&.
- Replace separate DeviceWindowBarrier.cuh/DeviceWindowSignal.cuh includes
  with unified DeviceWindow.cuh.
- TransportBundle struct and createTransport helper updated to use
  MultiPeerTransport + HostWindow.
- WindowMemoryConfig replaced with WindowConfig{peerSignalCount}.

IBGDA tests (MultipeerIbgdaTransportTest.*):
- Kernel implementations migrated from put() + signal_remote_with_fence()
  to put_signal() API.
- Remove PutSignalNonAdaptiveBasic test and associated declarations.
- Code formatting cleanup (indentation normalization).

Reviewed By: siyengar

Differential Revision: D95014950
