### PR TITLE
Enable CommsMonitor by default

### DIFF
--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2509,7 +2509,7 @@ cvars:
 
  - name        : NCCL_COMMSMONITOR_ENABLE
    type        : bool
-   default     : false
+   default     : true
    description : |-
      Enable comms monitor to monitor the creation and destruction of NCCL
      communicators. This is required to be enabled for ncclCommDumpAll to


### PR DESCRIPTION
Summary: CommsMonitor is a component that holds the tracing + metadata for each communicator. It is meant to be used so that communicator information can be safely dumped even after the destruction of communicator is called. We wanted to also use it do memory logging, thus enable it by default.

Differential Revision: D95753544


