### PR TITLE
Fix build failures in AllGatherTest and MultiPeerNvlTransportIntegrationTest

### DIFF
--- a/comms/pipes/tests/AllGatherTest.cc
+++ b/comms/pipes/tests/AllGatherTest.cc
@@ -6,7 +6,6 @@
 #include <folly/logging/xlog.h>
 
 #include "comms/pipes/MultiPeerNvlTransport.h"
-#include "comms/pipes/P2pSelfTransportDevice.cuh"
 #include "comms/pipes/collectives/AllGather.cuh"
 #include "comms/pipes/tests/AllGatherTest.cuh"
 #include "comms/pipes/tests/Utils.cuh"
@@ -117,32 +116,11 @@ TEST_P(AllGatherTest, AllGatherBasic) {
   transport.exchange();
   XLOGF(DBG1, "Rank {} created transport and exchanged IPC", globalRank);
 
-  // Get transport devices for all peer ranks
-  P2pSelfTransportDevice selfTransport;
-
-  // Create transport array: rank 0, rank 1, ..., rank N-1
-  // For my rank, use SelfTransportDevice; for others, use P2pNvlTransportDevice
-  std::vector<Transport> h_transports;
-  h_transports.reserve(numRanks);
-
-  for (int rank = 0; rank < numRanks; rank++) {
-    if (rank == globalRank) {
-      h_transports.emplace_back(selfTransport);
-    } else {
-      h_transports.emplace_back(transport.getP2pTransportDevice(rank));
-    }
-  }
-
-  // Copy transports to device
-  DeviceBuffer d_transports(sizeof(Transport) * numRanks);
-  CUDACHECK_TEST(cudaMemcpy(
-      d_transports.get(),
-      h_transports.data(),
-      sizeof(Transport) * numRanks,
-      cudaMemcpyHostToDevice));
-
+  // Use preallocated Transport array from MultiPeerNvlTransport
+  // (includes P2pSelfTransportDevice for self and P2pNvlTransportDevice for
+  // peers)
   DeviceSpan<Transport> transports_span(
-      static_cast<Transport*>(d_transports.get()), numRanks);
+      transport.getTransportsArray(), numRanks);
 
   // Allocate send and recv buffers
   // sendbuff: numIntsPerRank ints (my local data)
@@ -334,27 +312,11 @@ TEST_P(AllGatherLargeTest, AllGatherLarge) {
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
   transport.exchange();
 
-  P2pSelfTransportDevice selfTransport;
-  std::vector<Transport> h_transports;
-  h_transports.reserve(numRanks);
-
-  for (int rank = 0; rank < numRanks; rank++) {
-    if (rank == globalRank) {
-      h_transports.emplace_back(selfTransport);
-    } else {
-      h_transports.emplace_back(transport.getP2pTransportDevice(rank));
-    }
-  }
-
-  DeviceBuffer d_transports(sizeof(Transport) * numRanks);
-  CUDACHECK_TEST(cudaMemcpy(
-      d_transports.get(),
-      h_transports.data(),
-      sizeof(Transport) * numRanks,
-      cudaMemcpyHostToDevice));
-
+  // Use preallocated Transport array from MultiPeerNvlTransport
+  // (includes P2pSelfTransportDevice for self and P2pNvlTransportDevice for
+  // peers)
   DeviceSpan<Transport> transports_span(
-      static_cast<Transport*>(d_transports.get()), numRanks);
+      transport.getTransportsArray(), numRanks);
 
   DeviceBuffer sendBuffer(sendcount);
   DeviceBuffer recvBuffer(recvBufferSize);

--- a/comms/pipes/tests/MultiPeerNvlTransportIntegrationTest.cc
+++ b/comms/pipes/tests/MultiPeerNvlTransportIntegrationTest.cc
@@ -1624,9 +1624,9 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, PutSignalOperation) {
   int peerRank = (globalRank == 0) ? 1 : 0;
   const int testValue = 0xCD + globalRank;
 
-  // Get the P2pNvlTransportDevice to access IPC-mapped remote buffers
+  // Get a host-side P2pNvlTransportDevice to access IPC-mapped remote buffers
   // The transport's remoteState_.dataBuffer is already IPC-mapped
-  auto p2pTransport = transport->getP2pTransportDevice(peerRank);
+  auto p2pTransport = transport->buildP2pTransportDevice(peerRank);
 
   // POINTER RELATIONSHIP CLARIFICATION:
   //

--- a/comms/pipes/tests/MultiPeerNvlTransportIntegrationTest.cu
+++ b/comms/pipes/tests/MultiPeerNvlTransportIntegrationTest.cu
@@ -161,10 +161,10 @@ __global__ void multiPeerSendRecvAllPeersKernel(
 
   if (partition_id == 0) {
     transport.send(
-        peer_rank, group_per_peer, srcBuffs[peer_idx], nbytesPerPeer, peer_idx);
+        peer_rank, group_per_peer, srcBuffs[peer_idx], nbytesPerPeer);
   } else {
     transport.recv(
-        peer_rank, group_per_peer, dstBuffs[peer_idx], nbytesPerPeer, peer_idx);
+        peer_rank, group_per_peer, dstBuffs[peer_idx], nbytesPerPeer);
   }
 }
 


### PR DESCRIPTION
Summary:
D91717513 changed `MultiPeerNvlTransport::getP2pTransportDevice()` to return
`P2pNvlTransportDevice*` (device pointer) instead of `P2pNvlTransportDevice`
(by value). This broke two test files that were using the return value on the
host side.

Fixes:
- AllGatherTest.cc: Use `buildP2pTransportDevice()` instead of
  `getP2pTransportDevice()` to construct host-side Transport objects
  (2 call sites)
- MultiPeerNvlTransportIntegrationTest.cc: Use `buildP2pTransportDevice()`
  to get a host-side P2pNvlTransportDevice for accessing IPC-mapped buffer
  pointers
- MultiPeerNvlTransportIntegrationTest.cu: Remove extra `peer_idx` argument
  from `transport.send()` and `transport.recv()` calls to match updated
  4-argument signatures

Differential Revision: D95759476


