### PR TITLE
fix async replay hang logic

### DIFF
--- a/comms/torchcomms/ncclx/GraphEventTracker.cpp
+++ b/comms/torchcomms/ncclx/GraphEventTracker.cpp
@@ -210,25 +210,29 @@ GraphEventTracker::CheckResult GraphEventTracker::checkAll() {
         // end is notReady — this is the first incomplete collective on this
         // stream. All subsequent collectives on this stream cannot have
         // started, so we can skip them.
-        if (start_status == cudaSuccess) {
-          // Collective in progress — start or continue timing
-          if (!entry.start_completed_time.has_value()) {
+        if (!entry.start_completed_time.has_value()) {
+          if (start_status == cudaSuccess) {
+            // observation of collective in progress — start timer
             entry.start_completed_time = std::chrono::steady_clock::now();
+          } else {
+            // collective NEVER started — skip timer logic
+            break;
           }
-          auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
-              std::chrono::steady_clock::now() -
-              entry.start_completed_time.value());
-          if (entry.timeout.count() >= 0 && elapsed > entry.timeout) {
-            TC_LOG(ERROR, comm_)
-                << "Graph monitor: collective TIMED OUT for graph " << graph_id
-                << " collective " << i << " on rank " << comm_->getRank()
-                << " - elapsed " << elapsed.count() << "ms > timeout "
-                << entry.timeout.count() << "ms";
-            return CheckResult::TIMEOUT;
-          }
-        } else {
-          // Both notReady — replay hasn't reached this collective yet
-          entry.start_completed_time.reset();
+        }
+
+        // active timer. either started now, continued from a
+        // previous poll, or preserved after events were reset by a
+        // queued cudaGraphLaunch.
+        auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() -
+            entry.start_completed_time.value());
+        if (entry.timeout.count() >= 0 && elapsed > entry.timeout) {
+          TC_LOG(ERROR, comm_)
+              << "Graph monitor: collective TIMED OUT for graph " << graph_id
+              << " collective " << i << " on rank " << comm_->getRank()
+              << " - elapsed " << elapsed.count() << "ms > timeout "
+              << entry.timeout.count() << "ms";
+          return CheckResult::TIMEOUT;
         }
         break;
       }

--- a/comms/torchcomms/ncclx/docs/graph_timeout_design.md
+++ b/comms/torchcomms/ncclx/docs/graph_timeout_design.md
@@ -105,11 +105,12 @@ and determines the current state:
                                  ▼                        │
                        ┌──────────────────┐               │
             ┌─────────►│    COMPLETED     │───────────────┘
-            │          │  (between replays │
-            │          │   or coll done)   │
+            │          │ (between replays │
+            │          │  or coll done)   │
             │          └────────┬─────────┘
             │                   │ end = notReady
             │                   │ start = notReady
+            │                   │ timer NOT set
             │                   ▼
             │          ┌──────────────────┐
             │          │   NOT REACHED    │
@@ -118,6 +119,11 @@ and determines the current state:
             │          │   this coll)     │
             │          └────────┬─────────┘
             │                   │ start = success
+            │                   │  ── OR ──
+            │                   │ both notReady
+            │                   │ but timer set
+            │                   │ (events reset by
+            │                   │  queued replay)
             │                   ▼
   end =     │          ┌──────────────────┐
   success   │          │   IN PROGRESS    │  elapsed > timeout
@@ -128,8 +134,13 @@ and determines the current state:
 
 State detection (no enum — derived from event queries each poll):
 - **COMPLETED**: `end_event` query returns `cudaSuccess` → reset timer
-- **NOT REACHED**: both `start_event` and `end_event` return `cudaErrorNotReady` → reset timer
-- **IN PROGRESS**: `start_event` returns `cudaSuccess`, `end_event` returns `cudaErrorNotReady` → start/continue timer; if elapsed > timeout, return TIMEOUT
+- **NOT REACHED**: both events return `cudaErrorNotReady` AND timer is not set → collective hasn't started
+- **IN PROGRESS**: either `start_event` returns `cudaSuccess` (normal), or both events return `cudaErrorNotReady` but the timer is already set (events were reset by a queued `cudaGraphLaunch` while the previous replay's collective is hanging) → start/continue timer; if elapsed > timeout, return TIMEOUT
+
+The "timer already set" distinction handles the case where a new `cudaGraphLaunch`
+is submitted while a collective is hanging. The new replay is queued behind the
+hang, so the replay counter does not increment and events flip to notReady. Without
+this check, the watchdog would misinterpret this as "not reached" and kill the timer.
 
 ### Replay Boundary Detection
 

--- a/comms/torchcomms/ncclx/tests/unit/cpp/GraphEventTrackerTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/GraphEventTrackerTest.cpp
@@ -754,6 +754,52 @@ TEST_F(GraphEventTrackerTest, DestroyAllIgnoresReleasedFlag) {
       << "end event was not destroyed by destroyAll";
 }
 
+TEST_F(GraphEventTrackerTest, EventResetByReplayDefeatsTimeout) {
+  setupCCAExpectations(0, 0, 1);
+
+  EXPECT_DEATH(
+      {
+        cuda_mock_->setupDefaultBehaviors();
+        nccl_mock_->setupDefaultBehaviors();
+
+        auto options = createAbortModeOptions(std::chrono::milliseconds(100));
+        auto comm = createMockedTorchComm();
+        comm->init(*device_, "test_event_reset_defeats_timeout", options);
+
+        setupGraphCaptureMocks();
+        auto events = setupGraphCaptureEvents();
+        setupEventRecordMocks();
+
+        auto tensor = createTestTensor({10, 10});
+        auto work = comm->send(tensor, 1, true);
+
+        switchToReplayMode();
+
+        std::atomic<bool> events_reset{false};
+
+        ON_CALL(*cuda_mock_, eventQuery(events.start))
+            .WillByDefault(Invoke([&events_reset](cudaEvent_t) -> cudaError_t {
+              return events_reset.load(std::memory_order_relaxed)
+                  ? cudaErrorNotReady
+                  : cudaSuccess;
+            }));
+        ON_CALL(*cuda_mock_, eventQuery(events.end))
+            .WillByDefault(Return(cudaErrorNotReady));
+
+        // wait for watchdog poll to observe the collective
+        // NOLINTNEXTLINE(facebook-hte-BadCall-sleep_for)
+        std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+
+        // simulate new replay submission
+        events_reset.store(true, std::memory_order_relaxed);
+
+        // wait for another watchdog poll -- should timeout
+        // NOLINTNEXTLINE(facebook-hte-BadCall-sleep_for)
+        std::this_thread::sleep_for(std::chrono::seconds(5));
+      },
+      "Graph monitor: collective TIMED OUT for graph");
+}
+
 // ============================================================================
 // TENSOR LIFETIME TESTS IN GRAPH CAPTURE MODE
 // ============================================================================


### PR DESCRIPTION
Summary: if the timer is already running, we need to go straight to the timeout check regardless of the current event status. start_status only matters for deciding whether to start a new timer; once it's running, it can't be silently killed by events flipping to a "not ready" state.

Reviewed By: ngimel

Differential Revision: D95818450


