### PR TITLE
Fix P2pNvl benchmark build errors (pointer dereference)

### DIFF
--- a/comms/pipes/benchmarks/P2pNvlSendRecvBenchmark.cc
+++ b/comms/pipes/benchmarks/P2pNvlSendRecvBenchmark.cc
@@ -634,7 +634,7 @@ TEST_F(P2pSendRecvBenchmarkFixture, UnidirectionalBenchmark) {
     result.ncclBandwidth = runNcclBenchmark(config, result.ncclTime);
 
     // Run P2P NVL benchmark
-    result.p2pBandwidth = runP2pNvlBenchmark(p2p, config, result.p2pTime);
+    result.p2pBandwidth = runP2pNvlBenchmark(*p2p, config, result.p2pTime);
 
     // Calculate speedup
     result.p2pSpeedup = (result.ncclBandwidth > 0)
@@ -822,7 +822,7 @@ TEST_F(P2pSendRecvBenchmarkFixture, BidirectionalBenchmark) {
 
     // Run P2P NVL bidirectional benchmark
     result.p2pBandwidth =
-        runP2pNvlBidirectionalBenchmark(p2p, config, result.p2pTime);
+        runP2pNvlBidirectionalBenchmark(*p2p, config, result.p2pTime);
 
     // Calculate speedup
     result.p2pSpeedup = (result.ncclBandwidth > 0)

--- a/comms/pipes/benchmarks/P2pNvlSignalBenchmark.cc
+++ b/comms/pipes/benchmarks/P2pNvlSignalBenchmark.cc
@@ -201,7 +201,7 @@ TEST_F(P2pSignalBenchmarkFixture, SignalBenchmark) {
     transport.exchange();
 
     auto p2p = transport.getP2pTransportDevice(peerRank);
-    runSignalBenchmark(p2p, warmupConfig, nSteps); // Discard result
+    runSignalBenchmark(*p2p, warmupConfig, nSteps); // Discard result
   }
 
   std::vector<BenchmarkResult> results;
@@ -230,7 +230,7 @@ TEST_F(P2pSignalBenchmarkFixture, SignalBenchmark) {
 
     BenchmarkResult result;
     result.testName = config.name;
-    result.p2pTime = runSignalBenchmark(p2p, config, nSteps);
+    result.p2pTime = runSignalBenchmark(*p2p, config, nSteps);
     results.push_back(result);
   }
 


### PR DESCRIPTION
Summary:
getP2pTransportDevice() now returns a pointer instead of a reference.
Update the two benchmark files to dereference the pointer.

Differential Revision: D95737401


