### PR TITLE
Fix MultiCommTest port conflict in ThreeCommsMixedStore

### DIFF
--- a/comms/torchcomms/tests/integration/cpp/MultiCommTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/MultiCommTest.cpp
@@ -397,9 +397,10 @@ TEST_F(MultiCommTest, ThreeCommsMixedStore) {
   std::vector<std::unique_ptr<TorchCommTestWrapper>> wrappers;
   std::vector<std::shared_ptr<torch::comms::TorchComm>> comms;
 
-  // Create a shared store for the first two communicators
-  auto store1 = createStore();
-  auto store2 = createStore();
+  // Create a single store and wrap with prefixes to avoid port conflicts
+  auto store = createStore();
+  auto store1 = wrapPrefixStore("comm1", store);
+  auto store2 = wrapPrefixStore("comm2", store);
 
   // Create first communicator using the store
   wrappers.push_back(std::make_unique<TorchCommTestWrapper>(store1));
@@ -411,6 +412,7 @@ TEST_F(MultiCommTest, ThreeCommsMixedStore) {
 
   destroyStoreAndSyncStream(std::move(store1), comms[0]);
   destroyStoreAndSyncStream(std::move(store2), comms[1]);
+  destroyStoreAndSyncStream(std::move(store), comms[0]);
 
   // Create third communicator using no store
   wrappers.push_back(std::make_unique<TorchCommTestWrapper>());

--- a/comms/torchcomms/tests/integration/cpp/TorchCommTestHelpers.cpp
+++ b/comms/torchcomms/tests/integration/cpp/TorchCommTestHelpers.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include "comms/torchcomms/tests/integration/cpp/TorchCommTestHelpers.h"
+#include "torch/csrc/distributed/c10d/PrefixStore.hpp" // @manual=//caffe2:torch-cpp-cpu
 #include "torch/csrc/distributed/c10d/TCPStore.hpp" // @manual=//caffe2:torch-cpp-cpu
 
 #include "comms/torchcomms/TorchCommLogging.hpp"
@@ -141,6 +142,12 @@ c10::intrusive_ptr<c10d::Store> createStore() {
   opts.useLibUV = true;
   opts.timeout = std::chrono::milliseconds(60000);
   return c10::make_intrusive<c10d::TCPStore>(std::string{host}, opts);
+}
+
+c10::intrusive_ptr<c10d::Store> wrapPrefixStore(
+    const std::string& name,
+    c10::intrusive_ptr<c10d::Store> store) {
+  return c10::make_intrusive<c10d::PrefixStore>(name, store);
 }
 
 void destroyStore(

--- a/comms/torchcomms/tests/integration/cpp/TorchCommTestHelpers.h
+++ b/comms/torchcomms/tests/integration/cpp/TorchCommTestHelpers.h
@@ -18,6 +18,9 @@ std::string getDtypeName(at::ScalarType dtype);
 std::string getOpName(const torch::comms::ReduceOp& op);
 std::tuple<int, int> getRankAndSize();
 c10::intrusive_ptr<c10d::Store> createStore();
+c10::intrusive_ptr<c10d::Store> wrapPrefixStore(
+    const std::string& name,
+    c10::intrusive_ptr<c10d::Store> store);
 void destroyStore(
     c10::intrusive_ptr<c10d::Store>&& store,
     const std::shared_ptr<torch::comms::TorchComm>& torchcomm);

--- a/comms/torchcomms/tests/integration/py/MultiCommTest.py
+++ b/comms/torchcomms/tests/integration/py/MultiCommTest.py
@@ -10,6 +10,7 @@ from torchcomms.tests.integration.py.TorchCommTestHelpers import (
     create_store,
     TorchCommTestWrapper,
     verify_tensor_equality,
+    wrap_prefix_store,
 )
 
 
@@ -349,9 +350,10 @@ class MultiCommTest(unittest.TestCase):
         wrappers = []
         comms = []
 
-        # Create a shared store for the first two communicators
-        store1 = create_store()
-        store2 = create_store()
+        # Create a single store and wrap with prefixes to avoid port conflicts
+        store = create_store()
+        store1 = wrap_prefix_store("comm1", store)
+        store2 = wrap_prefix_store("comm2", store)
 
         # Create first communicator using the store
         wrappers.append(TorchCommTestWrapper(store=store1))
@@ -361,7 +363,11 @@ class MultiCommTest(unittest.TestCase):
         wrappers.append(TorchCommTestWrapper(store=store2))
         comms.append(wrappers[-1].get_torchcomm())
 
-        # Cleanup our store
+        # Cleanup stores
+        store1 = None
+        store2 = None
+        store_deletion_barrier(comms[0])
+        store = None
         store_deletion_barrier(comms[0])
 
         # Create third communicator with no store

--- a/comms/torchcomms/tests/integration/py/TorchCommTestHelpers.py
+++ b/comms/torchcomms/tests/integration/py/TorchCommTestHelpers.py
@@ -174,6 +174,11 @@ def create_store():
     return PrefixStore(f"test_comm_{NEXT_STORE_ID}", _root_store)
 
 
+def wrap_prefix_store(name, store):
+    """Wrap a store with a PrefixStore using the given name."""
+    return PrefixStore(name, store)
+
+
 def verify_tensor_equality(
     output: torch.Tensor,
     expected: Union[torch.Tensor, int, float],


### PR DESCRIPTION
Summary:
The ThreeCommsMixedStore test was creating two separate
TCPStore instances on the same MASTER_PORT simultaneously,
causing a port conflict and test timeout. Fix by creating
a single store and wrapping it with PrefixStore for each
communicator, then properly destroying all stores before
creating the third no-store communicator.

Add wrapPrefixStore helper (C++) and wrap_prefix_store
helper (Python) to wrap a store with a PrefixStore.

Differential Revision: D95854526


