### PR TITLE
Fix p2p_ibgda_transport_device_test to match refactored API

### DIFF
--- a/comms/pipes/tests/P2pIbgdaTransportDeviceTest.cu
+++ b/comms/pipes/tests/P2pIbgdaTransportDeviceTest.cu
@@ -12,25 +12,11 @@ namespace comms::pipes::tests {
 // Device-side test kernels
 // =============================================================================
 
-__global__ void testP2pTransportConstruction(
-    IbgdaLocalBuffer localBuf,
-    IbgdaRemoteBuffer remoteBuf,
-    bool* success) {
-  // Create transport on device with the given buffers (no real QP)
-  P2pIbgdaTransportDevice transport(nullptr, localBuf, remoteBuf);
+__global__ void testP2pTransportConstruction(bool* success) {
+  // Create transport on device with null QP
+  P2pIbgdaTransportDevice transport(nullptr);
 
   *success = true;
-
-  // Verify buffer accessors work
-  auto localSig = transport.getLocalSignalBuffer();
-  auto remoteSig = transport.getRemoteSignalBuffer();
-
-  if (localSig.ptr != localBuf.ptr || localSig.lkey != localBuf.lkey) {
-    *success = false;
-  }
-  if (remoteSig.ptr != remoteBuf.ptr || remoteSig.rkey != remoteBuf.rkey) {
-    *success = false;
-  }
 
   // QP should be null in this test (no real DOCA setup)
   if (transport.getQp() != nullptr) {
@@ -48,82 +34,23 @@ __global__ void testP2pTransportDefaultConstruction(bool* success) {
   if (transport.getQp() != nullptr) {
     *success = false;
   }
-
-  // Local signal buffer should have null ptr
-  auto localSig = transport.getLocalSignalBuffer();
-  if (localSig.ptr != nullptr) {
-    *success = false;
-  }
-
-  // Remote signal buffer should have null ptr
-  auto remoteSig = transport.getRemoteSignalBuffer();
-  if (remoteSig.ptr != nullptr) {
-    *success = false;
-  }
-
-  // Default numSignals should be 1
-  if (transport.getNumSignals() != 1) {
-    *success = false;
-  }
-}
-
-__global__ void testP2pTransportNumSignals(
-    IbgdaLocalBuffer localBuf,
-    IbgdaRemoteBuffer remoteBuf,
-    int numSignals,
-    bool* success) {
-  P2pIbgdaTransportDevice transport(nullptr, localBuf, remoteBuf, numSignals);
-
-  *success = (transport.getNumSignals() == numSignals);
-}
-
-__global__ void testP2pTransportSignalPointerArithmetic(
-    IbgdaLocalBuffer localBuf,
-    IbgdaRemoteBuffer remoteBuf,
-    int numSignals,
-    bool* success) {
-  P2pIbgdaTransportDevice transport(nullptr, localBuf, remoteBuf, numSignals);
-
-  *success = true;
-
-  // The transport stores base pointers and calculates signal[i] as base + i
-  // We can verify this by checking the buffer accessors still point to base
-  auto localSig = transport.getLocalSignalBuffer();
-  auto remoteSig = transport.getRemoteSignalBuffer();
-
-  // Base pointers should match what we passed in
-  if (localSig.ptr != localBuf.ptr) {
-    *success = false;
-  }
-  if (remoteSig.ptr != remoteBuf.ptr) {
-    *success = false;
-  }
-
-  // Keys should be preserved
-  if (localSig.lkey != localBuf.lkey) {
-    *success = false;
-  }
-  if (remoteSig.rkey != remoteBuf.rkey) {
-    *success = false;
-  }
 }
 
 __global__ void testP2pTransportReadSignal(
     uint64_t* d_signalBuf,
     IbgdaLocalBuffer localBuf,
-    IbgdaRemoteBuffer remoteBuf,
     int numSignals,
     bool* success) {
   // The localBuf should point to d_signalBuf which is pre-initialized with
   // known values: d_signalBuf[i] = (i + 1) * 100
-  P2pIbgdaTransportDevice transport(nullptr, localBuf, remoteBuf, numSignals);
+  P2pIbgdaTransportDevice transport(nullptr);
 
   *success = true;
 
   // Test read_signal for each slot
   for (int i = 0; i < numSignals; ++i) {
     uint64_t expected = static_cast<uint64_t>(i + 1) * 100;
-    uint64_t actual = transport.read_signal(i);
+    uint64_t actual = transport.read_signal(localBuf, i);
     if (actual != expected) {
       *success = false;
     }
@@ -157,102 +84,16 @@ __global__ void testIbgdaWork(bool* success) {
 // wait_signal test kernels
 // =============================================================================
 
-__global__ void testWaitSignalEQ(
-    uint64_t* d_signalBuf,
-    IbgdaLocalBuffer localBuf,
-    IbgdaRemoteBuffer remoteBuf,
-    uint64_t targetValue,
-    bool* success) {
-  P2pIbgdaTransportDevice transport(nullptr, localBuf, remoteBuf, 1);
-
-  // Signal buffer is pre-set to targetValue by host
-  // wait_signal with EQ should return immediately
-  transport.wait_signal(0, IbgdaCmpOp::EQ, targetValue);
-
-  // If we get here, the wait completed successfully
-  *success = true;
-}
-
-__global__ void testWaitSignalNE(
-    uint64_t* d_signalBuf,
-    IbgdaLocalBuffer localBuf,
-    IbgdaRemoteBuffer remoteBuf,
-    uint64_t signalValue,
-    uint64_t targetValue,
-    bool* success) {
-  P2pIbgdaTransportDevice transport(nullptr, localBuf, remoteBuf, 1);
-
-  // Signal buffer is pre-set to signalValue (which != targetValue)
-  // wait_signal with NE should return immediately
-  transport.wait_signal(0, IbgdaCmpOp::NE, targetValue);
-
-  // If we get here, the wait completed successfully
-  *success = true;
-}
-
 __global__ void testWaitSignalGE(
     uint64_t* d_signalBuf,
     IbgdaLocalBuffer localBuf,
-    IbgdaRemoteBuffer remoteBuf,
-    uint64_t signalValue,
     uint64_t targetValue,
     bool* success) {
-  P2pIbgdaTransportDevice transport(nullptr, localBuf, remoteBuf, 1);
+  P2pIbgdaTransportDevice transport(nullptr);
 
-  // Signal buffer is pre-set to signalValue (which >= targetValue)
-  // wait_signal with GE should return immediately
-  transport.wait_signal(0, IbgdaCmpOp::GE, targetValue);
-
-  // If we get here, the wait completed successfully
-  *success = true;
-}
-
-__global__ void testWaitSignalGT(
-    uint64_t* d_signalBuf,
-    IbgdaLocalBuffer localBuf,
-    IbgdaRemoteBuffer remoteBuf,
-    uint64_t signalValue,
-    uint64_t targetValue,
-    bool* success) {
-  P2pIbgdaTransportDevice transport(nullptr, localBuf, remoteBuf, 1);
-
-  // Signal buffer is pre-set to signalValue (which > targetValue)
-  // wait_signal with GT should return immediately
-  transport.wait_signal(0, IbgdaCmpOp::GT, targetValue);
-
-  // If we get here, the wait completed successfully
-  *success = true;
-}
-
-__global__ void testWaitSignalLE(
-    uint64_t* d_signalBuf,
-    IbgdaLocalBuffer localBuf,
-    IbgdaRemoteBuffer remoteBuf,
-    uint64_t signalValue,
-    uint64_t targetValue,
-    bool* success) {
-  P2pIbgdaTransportDevice transport(nullptr, localBuf, remoteBuf, 1);
-
-  // Signal buffer is pre-set to signalValue (which <= targetValue)
-  // wait_signal with LE should return immediately
-  transport.wait_signal(0, IbgdaCmpOp::LE, targetValue);
-
-  // If we get here, the wait completed successfully
-  *success = true;
-}
-
-__global__ void testWaitSignalLT(
-    uint64_t* d_signalBuf,
-    IbgdaLocalBuffer localBuf,
-    IbgdaRemoteBuffer remoteBuf,
-    uint64_t signalValue,
-    uint64_t targetValue,
-    bool* success) {
-  P2pIbgdaTransportDevice transport(nullptr, localBuf, remoteBuf, 1);
-
-  // Signal buffer is pre-set to signalValue (which < targetValue)
-  // wait_signal with LT should return immediately
-  transport.wait_signal(0, IbgdaCmpOp::LT, targetValue);
+  // Signal buffer is pre-set to a value >= targetValue by host
+  // wait_signal should return immediately
+  transport.wait_signal(localBuf, 0, targetValue);
 
   // If we get here, the wait completed successfully
   *success = true;
@@ -261,21 +102,20 @@ __global__ void testWaitSignalLT(
 __global__ void testWaitSignalMultipleSlots(
     uint64_t* d_signalBuf,
     IbgdaLocalBuffer localBuf,
-    IbgdaRemoteBuffer remoteBuf,
     int numSignals,
     bool* success) {
-  P2pIbgdaTransportDevice transport(nullptr, localBuf, remoteBuf, numSignals);
+  P2pIbgdaTransportDevice transport(nullptr);
 
   *success = true;
 
   // Signal buffer is pre-set: slot[i] = (i + 1) * 100
-  // Test wait_signal on each slot with matching EQ condition
+  // Test wait_signal on each slot with matching GE condition
   for (int i = 0; i < numSignals; ++i) {
     uint64_t expectedValue = static_cast<uint64_t>(i + 1) * 100;
-    transport.wait_signal(i, IbgdaCmpOp::EQ, expectedValue);
+    transport.wait_signal(localBuf, i, expectedValue);
 
     // Verify read_signal returns the same value
-    uint64_t readValue = transport.read_signal(i);
+    uint64_t readValue = transport.read_signal(localBuf, i);
     if (readValue != expectedValue) {
       *success = false;
     }
@@ -286,122 +126,42 @@ __global__ void testWaitSignalMultipleSlots(
 // Wrapper functions to launch the kernels (called from .cc test file)
 // =============================================================================
 
-void runTestP2pTransportConstruction(
-    IbgdaLocalBuffer localBuf,
-    IbgdaRemoteBuffer remoteBuf,
-    bool* d_success) {
-  testP2pTransportConstruction<<<1, 1>>>(localBuf, remoteBuf, d_success);
+void runTestP2pTransportConstruction(bool* d_success) {
+  testP2pTransportConstruction<<<1, 1>>>(d_success);
 }
 
 void runTestP2pTransportDefaultConstruction(bool* d_success) {
   testP2pTransportDefaultConstruction<<<1, 1>>>(d_success);
 }
 
-void runTestP2pTransportNumSignals(
-    IbgdaLocalBuffer localBuf,
-    IbgdaRemoteBuffer remoteBuf,
-    int numSignals,
-    bool* d_success) {
-  testP2pTransportNumSignals<<<1, 1>>>(
-      localBuf, remoteBuf, numSignals, d_success);
-}
-
-void runTestP2pTransportSignalPointerArithmetic(
-    IbgdaLocalBuffer localBuf,
-    IbgdaRemoteBuffer remoteBuf,
-    int numSignals,
-    bool* d_success) {
-  testP2pTransportSignalPointerArithmetic<<<1, 1>>>(
-      localBuf, remoteBuf, numSignals, d_success);
-}
-
 void runTestP2pTransportReadSignal(
     uint64_t* d_signalBuf,
     IbgdaLocalBuffer localBuf,
-    IbgdaRemoteBuffer remoteBuf,
     int numSignals,
     bool* d_success) {
   testP2pTransportReadSignal<<<1, 1>>>(
-      d_signalBuf, localBuf, remoteBuf, numSignals, d_success);
+      d_signalBuf, localBuf, numSignals, d_success);
 }
 
 void runTestIbgdaWork(bool* d_success) {
   testIbgdaWork<<<1, 1>>>(d_success);
 }
 
-void runTestWaitSignalEQ(
-    uint64_t* d_signalBuf,
-    IbgdaLocalBuffer localBuf,
-    IbgdaRemoteBuffer remoteBuf,
-    uint64_t targetValue,
-    bool* d_success) {
-  testWaitSignalEQ<<<1, 1>>>(
-      d_signalBuf, localBuf, remoteBuf, targetValue, d_success);
-}
-
-void runTestWaitSignalNE(
-    uint64_t* d_signalBuf,
-    IbgdaLocalBuffer localBuf,
-    IbgdaRemoteBuffer remoteBuf,
-    uint64_t signalValue,
-    uint64_t targetValue,
-    bool* d_success) {
-  testWaitSignalNE<<<1, 1>>>(
-      d_signalBuf, localBuf, remoteBuf, signalValue, targetValue, d_success);
-}
-
 void runTestWaitSignalGE(
     uint64_t* d_signalBuf,
     IbgdaLocalBuffer localBuf,
-    IbgdaRemoteBuffer remoteBuf,
-    uint64_t signalValue,
     uint64_t targetValue,
     bool* d_success) {
-  testWaitSignalGE<<<1, 1>>>(
-      d_signalBuf, localBuf, remoteBuf, signalValue, targetValue, d_success);
-}
-
-void runTestWaitSignalGT(
-    uint64_t* d_signalBuf,
-    IbgdaLocalBuffer localBuf,
-    IbgdaRemoteBuffer remoteBuf,
-    uint64_t signalValue,
-    uint64_t targetValue,
-    bool* d_success) {
-  testWaitSignalGT<<<1, 1>>>(
-      d_signalBuf, localBuf, remoteBuf, signalValue, targetValue, d_success);
-}
-
-void runTestWaitSignalLE(
-    uint64_t* d_signalBuf,
-    IbgdaLocalBuffer localBuf,
-    IbgdaRemoteBuffer remoteBuf,
-    uint64_t signalValue,
-    uint64_t targetValue,
-    bool* d_success) {
-  testWaitSignalLE<<<1, 1>>>(
-      d_signalBuf, localBuf, remoteBuf, signalValue, targetValue, d_success);
-}
-
-void runTestWaitSignalLT(
-    uint64_t* d_signalBuf,
-    IbgdaLocalBuffer localBuf,
-    IbgdaRemoteBuffer remoteBuf,
-    uint64_t signalValue,
-    uint64_t targetValue,
-    bool* d_success) {
-  testWaitSignalLT<<<1, 1>>>(
-      d_signalBuf, localBuf, remoteBuf, signalValue, targetValue, d_success);
+  testWaitSignalGE<<<1, 1>>>(d_signalBuf, localBuf, targetValue, d_success);
 }
 
 void runTestWaitSignalMultipleSlots(
     uint64_t* d_signalBuf,
     IbgdaLocalBuffer localBuf,
-    IbgdaRemoteBuffer remoteBuf,
     int numSignals,
     bool* d_success) {
   testWaitSignalMultipleSlots<<<1, 1>>>(
-      d_signalBuf, localBuf, remoteBuf, numSignals, d_success);
+      d_signalBuf, localBuf, numSignals, d_success);
 }
 
 // =============================================================================
@@ -631,16 +391,15 @@ void runTestPutGroupPartitioningBlock(bool* d_success) {
 __global__ void testWaitSignalTimeout(
     uint64_t* d_signalBuf,
     IbgdaLocalBuffer localBuf,
-    IbgdaRemoteBuffer remoteBuf,
     Timeout timeout) {
   // Start the timeout timer
   timeout.start();
 
-  P2pIbgdaTransportDevice transport(nullptr, localBuf, remoteBuf, 1);
+  P2pIbgdaTransportDevice transport(nullptr);
 
   // Signal buffer is pre-set to 0 by host.
-  // Waiting for GE 999 will never succeed, so timeout should fire.
-  transport.wait_signal(0, IbgdaCmpOp::GE, 999, timeout);
+  // Waiting for >= 999 will never succeed, so timeout should fire.
+  transport.wait_signal(localBuf, 0, 999, timeout);
 }
 
 // Kernel that calls wait_signal with a long timeout on a signal that is
@@ -648,17 +407,16 @@ __global__ void testWaitSignalTimeout(
 __global__ void testWaitSignalNoTimeout(
     uint64_t* d_signalBuf,
     IbgdaLocalBuffer localBuf,
-    IbgdaRemoteBuffer remoteBuf,
     Timeout timeout,
     bool* success) {
   // Start the timeout timer
   timeout.start();
 
-  P2pIbgdaTransportDevice transport(nullptr, localBuf, remoteBuf, 1);
+  P2pIbgdaTransportDevice transport(nullptr);
 
   // Signal buffer is pre-set to 42 by host.
-  // Waiting for GE 42 will succeed immediately, no timeout.
-  transport.wait_signal(0, IbgdaCmpOp::GE, 42, timeout);
+  // Waiting for >= 42 will succeed immediately, no timeout.
+  transport.wait_signal(localBuf, 0, 42, timeout);
 
   *success = true;
 }
@@ -670,14 +428,13 @@ __global__ void testWaitSignalNoTimeout(
 void runTestWaitSignalTimeout(
     uint64_t* d_signalBuf,
     IbgdaLocalBuffer localBuf,
-    IbgdaRemoteBuffer remoteBuf,
     int device,
     uint32_t timeout_ms) {
   Timeout timeout = makeTimeout(timeout_ms, device);
 
   // Intentionally unchecked - we expect the kernel to trap
   // NOLINTNEXTLINE(facebook-cuda-safe-kernel-call-check)
-  testWaitSignalTimeout<<<1, 1>>>(d_signalBuf, localBuf, remoteBuf, timeout);
+  testWaitSignalTimeout<<<1, 1>>>(d_signalBuf, localBuf, timeout);
   // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
   cudaDeviceSynchronize();
 }
@@ -685,14 +442,12 @@ void runTestWaitSignalTimeout(
 void runTestWaitSignalNoTimeout(
     uint64_t* d_signalBuf,
     IbgdaLocalBuffer localBuf,
-    IbgdaRemoteBuffer remoteBuf,
     int device,
     uint32_t timeout_ms,
     bool* d_success) {
   Timeout timeout = makeTimeout(timeout_ms, device);
 
-  testWaitSignalNoTimeout<<<1, 1>>>(
-      d_signalBuf, localBuf, remoteBuf, timeout, d_success);
+  testWaitSignalNoTimeout<<<1, 1>>>(d_signalBuf, localBuf, timeout, d_success);
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 

--- a/comms/pipes/tests/P2pIbgdaTransportDeviceTest.cuh
+++ b/comms/pipes/tests/P2pIbgdaTransportDeviceTest.cuh
@@ -8,32 +8,11 @@
 
 namespace comms::pipes::tests {
 
-// Wrapper function to launch test kernel (defined in .cu, called from .cc)
-// This function creates a P2pIbgdaTransportDevice on the device with the given
-// buffers and verifies its accessors work correctly.
-void runTestP2pTransportConstruction(
-    IbgdaLocalBuffer localBuf,
-    IbgdaRemoteBuffer remoteBuf,
-    bool* d_success);
+// Test transport construction on device (null QP)
+void runTestP2pTransportConstruction(bool* d_success);
 
 // Test default construction - all members should be initialized to null/zero
 void runTestP2pTransportDefaultConstruction(bool* d_success);
-
-// Test getNumSignals accessor with various values
-void runTestP2pTransportNumSignals(
-    IbgdaLocalBuffer localBuf,
-    IbgdaRemoteBuffer remoteBuf,
-    int numSignals,
-    bool* d_success);
-
-// Test signal pointer arithmetic - verify correct offsets for multi-signal
-// setup This tests the internal getLocalSignalPtr/getRemoteSignalPtr logic by
-// checking buffer accessors return pointers at expected offsets.
-void runTestP2pTransportSignalPointerArithmetic(
-    IbgdaLocalBuffer localBuf,
-    IbgdaRemoteBuffer remoteBuf,
-    int numSignals,
-    bool* d_success);
 
 // Test read_signal returns the value at the correct signal slot.
 // This writes known values to the signal buffer and verifies read_signal
@@ -41,7 +20,6 @@ void runTestP2pTransportSignalPointerArithmetic(
 void runTestP2pTransportReadSignal(
     uint64_t* d_signalBuf,
     IbgdaLocalBuffer localBuf,
-    IbgdaRemoteBuffer remoteBuf,
     int numSignals,
     bool* d_success);
 
@@ -49,67 +27,16 @@ void runTestP2pTransportReadSignal(
 void runTestIbgdaWork(bool* d_success);
 
 // =============================================================================
-// wait_signal tests - Test each comparison operation
+// wait_signal tests - Test GE (>=) comparison (only supported operation)
 // These tests pre-set the signal buffer to a value that satisfies the condition
 // so wait_signal returns immediately without blocking.
 // =============================================================================
-
-// Test wait_signal with EQ (equal) comparison
-// Pre-sets signal to targetValue, waits for EQ targetValue
-void runTestWaitSignalEQ(
-    uint64_t* d_signalBuf,
-    IbgdaLocalBuffer localBuf,
-    IbgdaRemoteBuffer remoteBuf,
-    uint64_t targetValue,
-    bool* d_success);
-
-// Test wait_signal with NE (not equal) comparison
-// Pre-sets signal to a value != targetValue, waits for NE targetValue
-void runTestWaitSignalNE(
-    uint64_t* d_signalBuf,
-    IbgdaLocalBuffer localBuf,
-    IbgdaRemoteBuffer remoteBuf,
-    uint64_t signalValue,
-    uint64_t targetValue,
-    bool* d_success);
 
 // Test wait_signal with GE (greater or equal) comparison
 // Pre-sets signal to a value >= targetValue, waits for GE targetValue
 void runTestWaitSignalGE(
     uint64_t* d_signalBuf,
     IbgdaLocalBuffer localBuf,
-    IbgdaRemoteBuffer remoteBuf,
-    uint64_t signalValue,
-    uint64_t targetValue,
-    bool* d_success);
-
-// Test wait_signal with GT (greater than) comparison
-// Pre-sets signal to a value > targetValue, waits for GT targetValue
-void runTestWaitSignalGT(
-    uint64_t* d_signalBuf,
-    IbgdaLocalBuffer localBuf,
-    IbgdaRemoteBuffer remoteBuf,
-    uint64_t signalValue,
-    uint64_t targetValue,
-    bool* d_success);
-
-// Test wait_signal with LE (less or equal) comparison
-// Pre-sets signal to a value <= targetValue, waits for LE targetValue
-void runTestWaitSignalLE(
-    uint64_t* d_signalBuf,
-    IbgdaLocalBuffer localBuf,
-    IbgdaRemoteBuffer remoteBuf,
-    uint64_t signalValue,
-    uint64_t targetValue,
-    bool* d_success);
-
-// Test wait_signal with LT (less than) comparison
-// Pre-sets signal to a value < targetValue, waits for LT targetValue
-void runTestWaitSignalLT(
-    uint64_t* d_signalBuf,
-    IbgdaLocalBuffer localBuf,
-    IbgdaRemoteBuffer remoteBuf,
-    uint64_t signalValue,
     uint64_t targetValue,
     bool* d_success);
 
@@ -118,7 +45,6 @@ void runTestWaitSignalLT(
 void runTestWaitSignalMultipleSlots(
     uint64_t* d_signalBuf,
     IbgdaLocalBuffer localBuf,
-    IbgdaRemoteBuffer remoteBuf,
     int numSignals,
     bool* d_success);
 
@@ -165,7 +91,6 @@ void runTestPutGroupPartitioningBlock(bool* d_success);
 void runTestWaitSignalTimeout(
     uint64_t* d_signalBuf,
     IbgdaLocalBuffer localBuf,
-    IbgdaRemoteBuffer remoteBuf,
     int device,
     uint32_t timeout_ms);
 
@@ -174,7 +99,6 @@ void runTestWaitSignalTimeout(
 void runTestWaitSignalNoTimeout(
     uint64_t* d_signalBuf,
     IbgdaLocalBuffer localBuf,
-    IbgdaRemoteBuffer remoteBuf,
     int device,
     uint32_t timeout_ms,
     bool* d_success);

--- a/comms/pipes/tests/P2pIbgdaTransportDeviceTestMain.cc
+++ b/comms/pipes/tests/P2pIbgdaTransportDeviceTestMain.cc
@@ -59,84 +59,15 @@ class P2pIbgdaTransportDeviceTestFixture : public ::testing::Test {
 // =============================================================================
 
 TEST_F(P2pIbgdaTransportDeviceTestFixture, DeviceConstruction) {
-  // Test that transport can be copied to device and accessed there
-
-  // Create mock buffers for signal data
-  char localSignalData[64];
-  char remoteSignalData[64];
-  IbgdaLocalBuffer localBuf(localSignalData, NetworkLKey(0xAAAA));
-  IbgdaRemoteBuffer remoteBuf(remoteSignalData, NetworkRKey(0xBBBB));
-
-  runAndVerify([&](bool* d_success) {
-    runTestP2pTransportConstruction(localBuf, remoteBuf, d_success);
-  });
+  // Test that transport can be constructed on device with null QP
+  runAndVerify(
+      [](bool* d_success) { runTestP2pTransportConstruction(d_success); });
 }
 
 TEST_F(P2pIbgdaTransportDeviceTestFixture, DefaultConstruction) {
   // Test that default-constructed transport has null values
   runAndVerify([](bool* d_success) {
     runTestP2pTransportDefaultConstruction(d_success);
-  });
-}
-
-TEST_F(P2pIbgdaTransportDeviceTestFixture, NumSignalsDefault) {
-  // Test default numSignals (should be 1)
-  char localSignalData[64];
-  char remoteSignalData[64];
-  IbgdaLocalBuffer localBuf(localSignalData, NetworkLKey(0x1111));
-  IbgdaRemoteBuffer remoteBuf(remoteSignalData, NetworkRKey(0x2222));
-
-  // When numSignals is not specified, default is 1
-  DeviceBuffer successBuf(sizeof(bool));
-  auto* d_success = static_cast<bool*>(successBuf.get());
-
-  bool initSuccess = true;
-  CUDACHECK_TEST(cudaMemcpy(
-      d_success, &initSuccess, sizeof(bool), cudaMemcpyHostToDevice));
-
-  // numSignals = 1 (default)
-  runTestP2pTransportNumSignals(localBuf, remoteBuf, 1, d_success);
-  CUDACHECK_TEST(cudaDeviceSynchronize());
-
-  bool success = false;
-  CUDACHECK_TEST(
-      cudaMemcpy(&success, d_success, sizeof(bool), cudaMemcpyDeviceToHost));
-  EXPECT_TRUE(success) << "Default numSignals should be 1";
-}
-
-// Parameterized test for different numSignals values
-class NumSignalsTestFixture : public P2pIbgdaTransportDeviceTestFixture,
-                              public ::testing::WithParamInterface<int> {};
-
-TEST_P(NumSignalsTestFixture, NumSignalsAccessor) {
-  int numSignals = GetParam();
-
-  char localSignalData[512]; // Enough for multiple signals
-  char remoteSignalData[512];
-  IbgdaLocalBuffer localBuf(localSignalData, NetworkLKey(0x1111));
-  IbgdaRemoteBuffer remoteBuf(remoteSignalData, NetworkRKey(0x2222));
-
-  runAndVerify([&](bool* d_success) {
-    runTestP2pTransportNumSignals(localBuf, remoteBuf, numSignals, d_success);
-  });
-}
-
-INSTANTIATE_TEST_SUITE_P(
-    NumSignalsVariations,
-    NumSignalsTestFixture,
-    ::testing::Values(1, 2, 4, 8, 16, 32));
-
-TEST_F(P2pIbgdaTransportDeviceTestFixture, SignalPointerArithmetic) {
-  // Test that signal pointer arithmetic works correctly for multi-signal setup
-  const int numSignals = 4;
-  char localSignalData[numSignals * sizeof(uint64_t)];
-  char remoteSignalData[numSignals * sizeof(uint64_t)];
-  IbgdaLocalBuffer localBuf(localSignalData, NetworkLKey(0x3333));
-  IbgdaRemoteBuffer remoteBuf(remoteSignalData, NetworkRKey(0x4444));
-
-  runAndVerify([&](bool* d_success) {
-    runTestP2pTransportSignalPointerArithmetic(
-        localBuf, remoteBuf, numSignals, d_success);
   });
 }
 
@@ -159,13 +90,11 @@ TEST_F(P2pIbgdaTransportDeviceTestFixture, ReadSignal) {
       numSignals * sizeof(uint64_t),
       cudaMemcpyHostToDevice));
 
-  // Create buffers pointing to device memory
+  // Create buffer pointing to device memory
   IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKey(0x5555));
-  IbgdaRemoteBuffer remoteBuf(d_signalBuf, NetworkRKey(0x6666));
 
   runAndVerify([&](bool* d_success) {
-    runTestP2pTransportReadSignal(
-        d_signalBuf, localBuf, remoteBuf, numSignals, d_success);
+    runTestP2pTransportReadSignal(d_signalBuf, localBuf, numSignals, d_success);
   });
 }
 
@@ -174,8 +103,9 @@ TEST_F(P2pIbgdaTransportDeviceTestFixture, IbgdaWorkConstruction) {
   runAndVerify([](bool* d_success) { runTestIbgdaWork(d_success); });
 }
 
-TEST_F(P2pIbgdaTransportDeviceTestFixture, BufferSubBufferWithTransport) {
-  // Test that sub-buffers work correctly with transport construction
+TEST_F(P2pIbgdaTransportDeviceTestFixture, BufferSubBuffer) {
+  // Test that sub-buffers work correctly (pointer arithmetic and key
+  // preservation)
   const size_t offset = 32;
   char localSignalData[128];
   char remoteSignalData[128];
@@ -195,61 +125,14 @@ TEST_F(P2pIbgdaTransportDeviceTestFixture, BufferSubBufferWithTransport) {
   // Verify keys are preserved
   EXPECT_EQ(subLBuf.lkey, baseLBuf.lkey);
   EXPECT_EQ(subRBuf.rkey, baseRBuf.rkey);
-
-  // Test transport construction with sub-buffers
-  runAndVerify([&](bool* d_success) {
-    runTestP2pTransportConstruction(subLBuf, subRBuf, d_success);
-  });
 }
 
 // =============================================================================
 // wait_signal Tests
-// These tests verify the spin-wait logic for each comparison operation.
+// These tests verify the spin-wait logic for GE (>=) comparison.
 // Signal buffers are pre-set to values that satisfy the condition so
 // wait_signal returns immediately without blocking.
 // =============================================================================
-
-TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalEQ) {
-  // Test wait_signal with EQ comparison
-  const uint64_t targetValue = 42;
-
-  // Allocate device memory for signal buffer
-  DeviceBuffer signalBuf(sizeof(uint64_t));
-  auto* d_signalBuf = static_cast<uint64_t*>(signalBuf.get());
-
-  // Pre-set signal to targetValue so EQ condition is satisfied
-  CUDACHECK_TEST(cudaMemcpy(
-      d_signalBuf, &targetValue, sizeof(uint64_t), cudaMemcpyHostToDevice));
-
-  IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKey(0x1111));
-  IbgdaRemoteBuffer remoteBuf(d_signalBuf, NetworkRKey(0x2222));
-
-  runAndVerify([&](bool* d_success) {
-    runTestWaitSignalEQ(
-        d_signalBuf, localBuf, remoteBuf, targetValue, d_success);
-  });
-}
-
-TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalNE) {
-  // Test wait_signal with NE comparison
-  const uint64_t signalValue = 100;
-  const uint64_t targetValue = 42; // Different from signalValue
-
-  DeviceBuffer signalBuf(sizeof(uint64_t));
-  auto* d_signalBuf = static_cast<uint64_t*>(signalBuf.get());
-
-  // Pre-set signal to signalValue (which != targetValue) so NE is satisfied
-  CUDACHECK_TEST(cudaMemcpy(
-      d_signalBuf, &signalValue, sizeof(uint64_t), cudaMemcpyHostToDevice));
-
-  IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKey(0x1111));
-  IbgdaRemoteBuffer remoteBuf(d_signalBuf, NetworkRKey(0x2222));
-
-  runAndVerify([&](bool* d_success) {
-    runTestWaitSignalNE(
-        d_signalBuf, localBuf, remoteBuf, signalValue, targetValue, d_success);
-  });
-}
 
 TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalGE_Equal) {
   // Test wait_signal with GE comparison when signal == target
@@ -263,11 +146,9 @@ TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalGE_Equal) {
       d_signalBuf, &signalValue, sizeof(uint64_t), cudaMemcpyHostToDevice));
 
   IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKey(0x1111));
-  IbgdaRemoteBuffer remoteBuf(d_signalBuf, NetworkRKey(0x2222));
 
   runAndVerify([&](bool* d_success) {
-    runTestWaitSignalGE(
-        d_signalBuf, localBuf, remoteBuf, signalValue, targetValue, d_success);
+    runTestWaitSignalGE(d_signalBuf, localBuf, targetValue, d_success);
   });
 }
 
@@ -283,91 +164,9 @@ TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalGE_Greater) {
       d_signalBuf, &signalValue, sizeof(uint64_t), cudaMemcpyHostToDevice));
 
   IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKey(0x1111));
-  IbgdaRemoteBuffer remoteBuf(d_signalBuf, NetworkRKey(0x2222));
 
   runAndVerify([&](bool* d_success) {
-    runTestWaitSignalGE(
-        d_signalBuf, localBuf, remoteBuf, signalValue, targetValue, d_success);
-  });
-}
-
-TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalGT) {
-  // Test wait_signal with GT comparison
-  const uint64_t signalValue = 100;
-  const uint64_t targetValue = 50; // Less than signal
-
-  DeviceBuffer signalBuf(sizeof(uint64_t));
-  auto* d_signalBuf = static_cast<uint64_t*>(signalBuf.get());
-
-  CUDACHECK_TEST(cudaMemcpy(
-      d_signalBuf, &signalValue, sizeof(uint64_t), cudaMemcpyHostToDevice));
-
-  IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKey(0x1111));
-  IbgdaRemoteBuffer remoteBuf(d_signalBuf, NetworkRKey(0x2222));
-
-  runAndVerify([&](bool* d_success) {
-    runTestWaitSignalGT(
-        d_signalBuf, localBuf, remoteBuf, signalValue, targetValue, d_success);
-  });
-}
-
-TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalLE_Equal) {
-  // Test wait_signal with LE comparison when signal == target
-  const uint64_t signalValue = 50;
-  const uint64_t targetValue = 50; // Equal
-
-  DeviceBuffer signalBuf(sizeof(uint64_t));
-  auto* d_signalBuf = static_cast<uint64_t*>(signalBuf.get());
-
-  CUDACHECK_TEST(cudaMemcpy(
-      d_signalBuf, &signalValue, sizeof(uint64_t), cudaMemcpyHostToDevice));
-
-  IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKey(0x1111));
-  IbgdaRemoteBuffer remoteBuf(d_signalBuf, NetworkRKey(0x2222));
-
-  runAndVerify([&](bool* d_success) {
-    runTestWaitSignalLE(
-        d_signalBuf, localBuf, remoteBuf, signalValue, targetValue, d_success);
-  });
-}
-
-TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalLE_Less) {
-  // Test wait_signal with LE comparison when signal < target
-  const uint64_t signalValue = 25;
-  const uint64_t targetValue = 50; // Greater than signal
-
-  DeviceBuffer signalBuf(sizeof(uint64_t));
-  auto* d_signalBuf = static_cast<uint64_t*>(signalBuf.get());
-
-  CUDACHECK_TEST(cudaMemcpy(
-      d_signalBuf, &signalValue, sizeof(uint64_t), cudaMemcpyHostToDevice));
-
-  IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKey(0x1111));
-  IbgdaRemoteBuffer remoteBuf(d_signalBuf, NetworkRKey(0x2222));
-
-  runAndVerify([&](bool* d_success) {
-    runTestWaitSignalLE(
-        d_signalBuf, localBuf, remoteBuf, signalValue, targetValue, d_success);
-  });
-}
-
-TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalLT) {
-  // Test wait_signal with LT comparison
-  const uint64_t signalValue = 25;
-  const uint64_t targetValue = 50; // Greater than signal
-
-  DeviceBuffer signalBuf(sizeof(uint64_t));
-  auto* d_signalBuf = static_cast<uint64_t*>(signalBuf.get());
-
-  CUDACHECK_TEST(cudaMemcpy(
-      d_signalBuf, &signalValue, sizeof(uint64_t), cudaMemcpyHostToDevice));
-
-  IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKey(0x1111));
-  IbgdaRemoteBuffer remoteBuf(d_signalBuf, NetworkRKey(0x2222));
-
-  runAndVerify([&](bool* d_success) {
-    runTestWaitSignalLT(
-        d_signalBuf, localBuf, remoteBuf, signalValue, targetValue, d_success);
+    runTestWaitSignalGE(d_signalBuf, localBuf, targetValue, d_success);
   });
 }
 
@@ -390,16 +189,17 @@ TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalMultipleSlots) {
       cudaMemcpyHostToDevice));
 
   IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKey(0x3333));
-  IbgdaRemoteBuffer remoteBuf(d_signalBuf, NetworkRKey(0x4444));
 
   runAndVerify([&](bool* d_success) {
     runTestWaitSignalMultipleSlots(
-        d_signalBuf, localBuf, remoteBuf, numSignals, d_success);
+        d_signalBuf, localBuf, numSignals, d_success);
   });
 }
 
 TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalZeroValue) {
   // Test wait_signal with zero value (edge case)
+  // For uint64_t, any value >= 0 is always true, so this should pass
+  // immediately
   const uint64_t targetValue = 0;
 
   DeviceBuffer signalBuf(sizeof(uint64_t));
@@ -409,11 +209,9 @@ TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalZeroValue) {
   CUDACHECK_TEST(cudaMemset(d_signalBuf, 0, sizeof(uint64_t)));
 
   IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKey(0x1111));
-  IbgdaRemoteBuffer remoteBuf(d_signalBuf, NetworkRKey(0x2222));
 
   runAndVerify([&](bool* d_success) {
-    runTestWaitSignalEQ(
-        d_signalBuf, localBuf, remoteBuf, targetValue, d_success);
+    runTestWaitSignalGE(d_signalBuf, localBuf, targetValue, d_success);
   });
 }
 
@@ -428,11 +226,9 @@ TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalMaxValue) {
       d_signalBuf, &targetValue, sizeof(uint64_t), cudaMemcpyHostToDevice));
 
   IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKey(0x1111));
-  IbgdaRemoteBuffer remoteBuf(d_signalBuf, NetworkRKey(0x2222));
 
   runAndVerify([&](bool* d_success) {
-    runTestWaitSignalEQ(
-        d_signalBuf, localBuf, remoteBuf, targetValue, d_success);
+    runTestWaitSignalGE(d_signalBuf, localBuf, targetValue, d_success);
   });
 }
 
@@ -521,10 +317,9 @@ TEST_F(P2pIbgdaWaitSignalTimeoutTest, WaitSignalTimeoutTraps) {
   CUDACHECK_TEST(cudaMemset(d_signalBuf, 0, sizeof(uint64_t)));
 
   IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKey(0x1111));
-  IbgdaRemoteBuffer remoteBuf(d_signalBuf, NetworkRKey(0x2222));
 
   // 10ms timeout - should trigger quickly
-  runTestWaitSignalTimeout(d_signalBuf, localBuf, remoteBuf, 0, 10);
+  runTestWaitSignalTimeout(d_signalBuf, localBuf, 0, 10);
 
   cudaError_t err = cudaGetLastError();
   EXPECT_TRUE(isExpectedTrapError(err))
@@ -543,7 +338,6 @@ TEST_F(P2pIbgdaWaitSignalTimeoutTest, WaitSignalNoTimeoutWhenSatisfied) {
       d_signalBuf, &signalValue, sizeof(uint64_t), cudaMemcpyHostToDevice));
 
   IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKey(0x1111));
-  IbgdaRemoteBuffer remoteBuf(d_signalBuf, NetworkRKey(0x2222));
 
   DeviceBuffer successBuf(sizeof(bool));
   auto* d_success = static_cast<bool*>(successBuf.get());
@@ -552,8 +346,7 @@ TEST_F(P2pIbgdaWaitSignalTimeoutTest, WaitSignalNoTimeoutWhenSatisfied) {
       d_success, &initSuccess, sizeof(bool), cudaMemcpyHostToDevice));
 
   // 1000ms timeout - kernel should complete well before this
-  runTestWaitSignalNoTimeout(
-      d_signalBuf, localBuf, remoteBuf, 0, 1000, d_success);
+  runTestWaitSignalNoTimeout(d_signalBuf, localBuf, 0, 1000, d_success);
   CUDACHECK_TEST(cudaDeviceSynchronize());
 
   bool success = false;


### PR DESCRIPTION
Summary:
The P2pIbgdaTransportDevice class was refactored to no longer store signal
buffers internally — they are now passed explicitly to wait_signal() and
read_signal(). The constructor was also simplified to (qp, companionQp,
sinkLkey) instead of (qp, localBuf, remoteBuf, numSignals). The
wait_signal API now only supports >= comparison, removing the IbgdaCmpOp
parameter.

Update all three test files (.cuh, .cu, .cc) to match:
- Constructor calls: use P2pIbgdaTransportDevice(nullptr) instead of
  passing signal buffers
- wait_signal: pass IbgdaLocalBuffer explicitly, remove IbgdaCmpOp param
- read_signal: pass IbgdaLocalBuffer explicitly
- Remove tests for deleted APIs: getLocalSignalBuffer(),
  getRemoteSignalBuffer(), getNumSignals()
- Remove tests for removed comparison ops (EQ, NE, GT, LE, LT)
- Add explicit //comms/pipes:timeout_utils dep in BUCK

Reviewed By: dmwu

Differential Revision: D95957423


