### PR TITLE
Fix undefined symbol getTransportsArray() link error

### DIFF
--- a/comms/pipes/MultiPeerNvlTransport.h
+++ b/comms/pipes/MultiPeerNvlTransport.h
@@ -176,29 +176,6 @@ class MultiPeerNvlTransport {
   P2pNvlTransportDevice getP2pTransportDevice(int peerRank);
 
   /**
-   * getTransportsArray - Get preallocated Transport array on device memory
-   *
-   * Returns a pointer to the device-side Transport array containing all
-   * transport handles (P2pSelfTransportDevice for self, P2pNvlTransportDevice
-   * for all peers). This array can be passed directly to CUDA kernels for
-   * all-to-all communication patterns without per-launch H2D copies.
-   *
-   * PRECONDITION: exchange() must have been called by all ranks first.
-   *
-   * Array layout: [Transport for rank 0, Transport for rank 1, ..., Transport
-   * for rank nRanks-1]
-   * - transports_d_[myRank_] contains P2pSelfTransportDevice
-   * - transports_d_[peerRank] contains P2pNvlTransportDevice for peer
-   *
-   * @return Pointer to Transport array on device memory (size = nRanks)
-   *
-   * @note Thread-safe after exchange() completes
-   * @note The returned pointer is valid until this MultiPeerNvlTransport is
-   * destroyed
-   */
-  Transport* getTransportsArray();
-
-  /**
    * getNRanks - Get total number of ranks
    *
    * @return Total number of ranks in the communicator

--- a/comms/pipes/collectives/benchmarks/AllToAllvBenchmark.cc
+++ b/comms/pipes/collectives/benchmarks/AllToAllvBenchmark.cc
@@ -241,11 +241,7 @@ class AllToAllvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     MultiPeerNvlTransport transport(globalRank, nranks, bootstrap, nvlConfig);
     transport.exchange();
 
-    // Get preallocated transport array from MultiPeerNvlTransport
-    // (includes P2pSelfTransportDevice for self and P2pNvlTransportDevice for
-    // peers)
-    DeviceSpan<Transport> transports_span(
-        transport.getTransportsArray(), nranks);
+    auto transports_span = transport.getDeviceTransports();
 
     // Create chunk info arrays (equal size for all peers)
     std::vector<ChunkInfo> h_send_chunks, h_recv_chunks;

--- a/comms/pipes/tests/AllGatherTest.cc
+++ b/comms/pipes/tests/AllGatherTest.cc
@@ -116,11 +116,7 @@ TEST_P(AllGatherTest, AllGatherBasic) {
   transport.exchange();
   XLOGF(DBG1, "Rank {} created transport and exchanged IPC", globalRank);
 
-  // Use preallocated Transport array from MultiPeerNvlTransport
-  // (includes P2pSelfTransportDevice for self and P2pNvlTransportDevice for
-  // peers)
-  DeviceSpan<Transport> transports_span(
-      transport.getTransportsArray(), numRanks);
+  auto transports_span = transport.getDeviceTransports();
 
   // Allocate send and recv buffers
   // sendbuff: numIntsPerRank ints (my local data)
@@ -312,11 +308,7 @@ TEST_P(AllGatherLargeTest, AllGatherLarge) {
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
   transport.exchange();
 
-  // Use preallocated Transport array from MultiPeerNvlTransport
-  // (includes P2pSelfTransportDevice for self and P2pNvlTransportDevice for
-  // peers)
-  DeviceSpan<Transport> transports_span(
-      transport.getTransportsArray(), numRanks);
+  auto transports_span = transport.getDeviceTransports();
 
   DeviceBuffer sendBuffer(sendcount);
   DeviceBuffer recvBuffer(recvBufferSize);

--- a/comms/pipes/tests/AllToAllvTest.cc
+++ b/comms/pipes/tests/AllToAllvTest.cc
@@ -115,12 +115,7 @@ TEST_P(AllToAllvEqualSizeTest, AllToAllvEqualSize) {
   transport.exchange();
   XLOGF(DBG1, "Rank {} created transport and exchanged IPC", globalRank);
 
-  // Get transport devices for all peer ranks
-  // Use preallocated Transport array from MultiPeerNvlTransport
-  // (includes P2pSelfTransportDevice for self and P2pNvlTransportDevice for
-  // peers)
-  DeviceSpan<Transport> transports_span(
-      transport.getTransportsArray(), numRanks);
+  auto transports_span = transport.getDeviceTransports();
 
   // Allocate send and recv buffers based on test parameters
   DeviceBuffer sendBuffer(bufferSize);
@@ -350,12 +345,7 @@ TEST_P(AllToAllvUnequalSizeTest, AllToAllvUnequalSize) {
   transport.exchange();
   XLOGF(DBG1, "Rank {} created transport and exchanged IPC", globalRank);
 
-  // Get transport devices for all peer ranks
-  // Use preallocated Transport array from MultiPeerNvlTransport
-  // (includes P2pSelfTransportDevice for self and P2pNvlTransportDevice for
-  // peers)
-  DeviceSpan<Transport> transports_span(
-      transport.getTransportsArray(), numRanks);
+  auto transports_span = transport.getDeviceTransports();
 
   // Calculate variable chunk sizes using symmetric formula
   // Rank i sends to rank j: (i + j + 1) * base_ints * sizeof(int32_t) bytes


### PR DESCRIPTION
Summary:
`getTransportsArray()` is declared in `MultiPeerNvlTransport.h` but was never implemented, causing a linker error when called:

```
ld.lld: error: undefined symbol: comms::pipes::MultiPeerNvlTransport::getTransportsArray()
```

The equivalent method `getDeviceTransports()` already exists and does the same thing (lazy init via `initializeTransportsArray()`, returns `DeviceSpan<Transport>`). All callers were manually wrapping the raw pointer in a `DeviceSpan` anyway, so switching to `getDeviceTransports()` is a direct 1:1 replacement.

Changes:
- Replace 5 calls to `getTransportsArray()` with `getDeviceTransports()` across test and benchmark files
- Remove the orphaned `getTransportsArray()` declaration from `MultiPeerNvlTransport.h`

Differential Revision: D96001554


