### PR TITLE
Use ibverbx for ibverbs calls to match doca_gpunetio_dl

### DIFF
--- a/comms/ctran/ibverbx/IbvPd.cc
+++ b/comms/ctran/ibverbx/IbvPd.cc
@@ -73,6 +73,22 @@ IbvPd::regMr(void* addr, size_t length, ibv_access_flags access) const {
   return IbvMr(mr);
 }
 
+folly::Expected<IbvMr, Error> IbvPd::regMrIova2(
+    void* addr,
+    size_t length,
+    uint64_t iova,
+    ibv_access_flags access) const {
+  if (ibvSymbols.ibv_internal_reg_mr_iova2 == nullptr) {
+    return folly::makeUnexpected(Error(ENOSYS));
+  }
+  ibv_mr* mr =
+      ibvSymbols.ibv_internal_reg_mr_iova2(pd_, addr, length, iova, access);
+  if (!mr) {
+    return folly::makeUnexpected(Error(errno));
+  }
+  return IbvMr(mr);
+}
+
 folly::Expected<IbvMr, Error> IbvPd::regDmabufMr(
     uint64_t offset,
     size_t length,

--- a/comms/ctran/ibverbx/IbvPd.h
+++ b/comms/ctran/ibverbx/IbvPd.h
@@ -37,6 +37,12 @@ class IbvPd {
   folly::Expected<IbvMr, Error>
   regMr(void* addr, size_t length, ibv_access_flags access) const;
 
+  folly::Expected<IbvMr, Error> regMrIova2(
+      void* addr,
+      size_t length,
+      uint64_t iova,
+      ibv_access_flags access) const;
+
   folly::Expected<IbvMr, Error> regDmabufMr(
       uint64_t offset,
       size_t length,

--- a/comms/pipes/MultipeerIbgdaTransport.cc
+++ b/comms/pipes/MultipeerIbgdaTransport.cc
@@ -28,22 +28,22 @@ constexpr int kHopLimit = 255;
 // depth since they only carry WAIT + atomic operations (2 WQEs per round).
 constexpr uint32_t kCompanionQpDepth = 32;
 
-// Convert ibv_mtu enum to doca_verbs_mtu_size enum.
-doca_verbs_mtu_size ibv_mtu_to_doca_mtu(enum ibv_mtu ibvMtu) {
+// Convert ibverbx::ibv_mtu enum to doca_verbs_mtu_size enum.
+doca_verbs_mtu_size ibv_mtu_to_doca_mtu(enum ibverbx::ibv_mtu ibvMtu) {
   switch (ibvMtu) {
-    case IBV_MTU_256:
+    case ibverbx::IBV_MTU_256:
       return DOCA_VERBS_MTU_SIZE_256_BYTES;
-    case IBV_MTU_512:
+    case ibverbx::IBV_MTU_512:
       return DOCA_VERBS_MTU_SIZE_512_BYTES;
-    case IBV_MTU_1024:
+    case ibverbx::IBV_MTU_1024:
       return DOCA_VERBS_MTU_SIZE_1K_BYTES;
-    case IBV_MTU_2048:
+    case ibverbx::IBV_MTU_2048:
       return DOCA_VERBS_MTU_SIZE_2K_BYTES;
-    case IBV_MTU_4096:
+    case ibverbx::IBV_MTU_4096:
       return DOCA_VERBS_MTU_SIZE_4K_BYTES;
     default:
       throw std::runtime_error(
-          "Invalid ibv_mtu value: " + std::to_string(ibvMtu));
+          "Invalid ibverbx::ibv_mtu value: " + std::to_string(ibvMtu));
   }
 }
 
@@ -126,13 +126,6 @@ void MultipeerIbgdaTransport::initDocaGpu() {
 }
 
 void MultipeerIbgdaTransport::openIbDevice() {
-  // Get all IB devices
-  int numDevices = 0;
-  ibv_device** deviceList = ibv_get_device_list(&numDevices);
-  if (!deviceList || numDevices == 0) {
-    throw std::runtime_error("No IB devices found");
-  }
-
   // Priority 1: Explicit GPU-to-NIC mapping from config
   auto it = config_.gpuNicMap.find(config_.cudaDevice);
   if (it != config_.gpuNicMap.end() && !it->second.empty()) {
@@ -150,42 +143,30 @@ void MultipeerIbgdaTransport::openIbDevice() {
             << " for GPU device " << config_.cudaDevice;
   }
 
-  // Find the NIC by name
-  int nicIdx = -1;
-  for (int i = 0; i < numDevices; i++) {
-    if (nicDeviceName_ == deviceList[i]->name) {
-      nicIdx = i;
-      break;
-    }
+  // Get all IB devices and find the NIC by name
+  auto devicesResult = ibverbx::IbvDevice::ibvGetDeviceList({nicDeviceName_});
+  if (devicesResult.hasError() || devicesResult->empty()) {
+    throw std::runtime_error("No IB devices found for NIC: " + nicDeviceName_);
   }
-  if (nicIdx < 0) {
-    ibv_free_device_list(deviceList);
-    throw std::runtime_error("Specified NIC not found: " + nicDeviceName_);
-  }
-  VLOG(1) << "MultipeerIbgdaTransport: found NIC " << nicDeviceName_
-          << " at index " << nicIdx;
 
-  VLOG(1) << "MultipeerIbgdaTransport: selected NIC " << nicDeviceName_
+  ibvDevice_.emplace(std::move(devicesResult->at(0)));
+  VLOG(1) << "MultipeerIbgdaTransport: opened NIC " << nicDeviceName_
           << " for GPU " << gpuPciBusId_;
 
-  // Open the device
-  ibvCtx_ = ibv_open_device(deviceList[nicIdx]);
-  ibv_free_device_list(deviceList);
-  if (!ibvCtx_) {
-    throw std::runtime_error("Failed to open IB device: " + nicDeviceName_);
-  }
-
   // Allocate PD
-  ibvPd_ = ibv_alloc_pd(ibvCtx_);
-  if (!ibvPd_) {
+  auto pdResult = ibvDevice_->allocPd();
+  if (pdResult.hasError()) {
     throw std::runtime_error("Failed to allocate protection domain");
   }
+  ibvPd_.emplace(std::move(*pdResult));
 
   // Query GID
-  if (ibv_query_gid(ibvCtx_, 1, gidIndex_, &localGid_) != 0) {
+  auto gidResult = ibvDevice_->queryGid(1, gidIndex_);
+  if (gidResult.hasError()) {
     throw std::runtime_error(
         "Failed to query GID at index " + std::to_string(gidIndex_));
   }
+  localGid_ = *gidResult;
 
   // Print GID value for debugging
   auto gidStr = fmt::format(
@@ -211,16 +192,17 @@ void MultipeerIbgdaTransport::openIbDevice() {
           << gidStr;
 
   // Query port to determine link layer (IB vs Ethernet)
-  ibv_port_attr portAttr{};
-  if (ibv_query_port(ibvCtx_, 1, &portAttr) != 0) {
+  auto portResult = ibvDevice_->queryPort(1);
+  if (portResult.hasError()) {
     throw std::runtime_error("Failed to query port attributes");
   }
+  auto& portAttr = *portResult;
 
   VLOG(1) << "MultipeerIbgdaTransport: port 1 state=" << portAttr.state
           << " link_layer=" << (int)portAttr.link_layer << " (1=IB, 2=Ethernet)"
           << " active_mtu=" << portAttr.active_mtu;
 
-  if (portAttr.state != IBV_PORT_ACTIVE) {
+  if (portAttr.state != ibverbx::IBV_PORT_ACTIVE) {
     throw std::runtime_error(
         "Port 1 is not active (state=" + std::to_string(portAttr.state) + ")");
   }
@@ -232,7 +214,7 @@ void MultipeerIbgdaTransport::openIbDevice() {
   // For InfiniBand, always use IB_NO_GRH. For RoCE (Ethernet), use the
   // configured address family (similar to NCCL_IB_ADDR_FAMILY).
   doca_verbs_addr_type addrType;
-  if (portAttr.link_layer == IBV_LINK_LAYER_INFINIBAND) {
+  if (portAttr.link_layer == ibverbx::IBV_LINK_LAYER_INFINIBAND) {
     addrType = DOCA_VERBS_ADDR_TYPE_IB_NO_GRH;
   } else {
     addrType = (config_.addressFamily == AddressFamily::IPV4)
@@ -240,7 +222,8 @@ void MultipeerIbgdaTransport::openIbDevice() {
         : DOCA_VERBS_ADDR_TYPE_IPv6;
   }
 
-  doca_error_t err = doca_verbs_ah_attr_create(ibvCtx_, &ahAttr_);
+  doca_error_t err = doca_verbs_ah_attr_create(
+      reinterpret_cast<struct ibv_context*>(ibvDevice_->context()), &ahAttr_);
   checkDocaError(err, "Failed to create AH attributes");
 
   err = doca_verbs_ah_attr_set_addr_type(ahAttr_, addrType);
@@ -281,8 +264,9 @@ void MultipeerIbgdaTransport::allocateResources() {
 }
 
 void MultipeerIbgdaTransport::registerMemory() {
-  int accessFlags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE |
-      IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_ATOMIC;
+  int accessFlags = ibverbx::IBV_ACCESS_LOCAL_WRITE |
+      ibverbx::IBV_ACCESS_REMOTE_WRITE | ibverbx::IBV_ACCESS_REMOTE_READ |
+      ibverbx::IBV_ACCESS_REMOTE_ATOMIC;
 
   // Register sink buffer as a zero-based MR (iova=0).
   //
@@ -295,33 +279,39 @@ void MultipeerIbgdaTransport::registerMemory() {
   // addr=0 would be outside the MR's valid range → NIC local protection
   // error → QP error state → hang.
   //
-  // ibv_reg_mr_iova2(pd, addr, length, iova=0, access) creates a zero-based
-  // MR where IOVA range [0, length) maps to [addr, addr+length). This
-  // matches GIN's gdakiRegMr() pattern (gin_host_gdaki.cc).
+  // ibv_reg_mr_iova2(pd, addr, length, iova=0, access) creates a
+  // zero-based MR where IOVA range [0, length) maps to [addr, addr+length).
+  // This matches GIN's gdakiRegMr() pattern (gin_host_gdaki.cc).
   int sinkDmabufFd = -1;
   doca_error_t err =
       doca_gpu_dmabuf_fd(docaGpu_, sinkBuffer_, sinkBufferSize_, &sinkDmabufFd);
   if (err == DOCA_SUCCESS && sinkDmabufFd >= 0) {
     // ibv_reg_dmabuf_mr: 4th param is iova — set to 0 for zero-based MR
-    sinkMr_ = ibv_reg_dmabuf_mr(
-        ibvPd_,
+    auto dmabufResult = ibvPd_->regDmabufMr(
         0,
         sinkBufferSize_,
-        0, // iova=0: zero-based MR
+        0,
         sinkDmabufFd,
-        accessFlags);
+        static_cast<ibverbx::ibv_access_flags>(accessFlags));
+    if (!dmabufResult.hasError()) {
+      sinkMr_.emplace(std::move(*dmabufResult));
+    }
   }
   if (!sinkMr_) {
     // Fallback: use ibv_reg_mr_iova2 with iova=0 for zero-based MR
-    sinkMr_ =
-        ibv_reg_mr_iova2(ibvPd_, sinkBuffer_, sinkBufferSize_, 0, accessFlags);
-    if (!sinkMr_) {
+    auto iova2Result = ibvPd_->regMrIova2(
+        sinkBuffer_,
+        sinkBufferSize_,
+        0,
+        static_cast<ibverbx::ibv_access_flags>(accessFlags));
+    if (iova2Result.hasError()) {
       throw std::runtime_error("Failed to register sink memory region");
     }
+    sinkMr_.emplace(std::move(*iova2Result));
   }
 
   VLOG(1) << "MultipeerIbgdaTransport: registered sink buffer"
-          << " lkey=" << sinkMr_->lkey << " (zero-based MR, iova=0)";
+          << " lkey=" << sinkMr_->mr()->lkey << " (zero-based MR, iova=0)";
 }
 void MultipeerIbgdaTransport::createQpGroups() {
   const int numPeers = nRanks_ - 1;
@@ -339,8 +329,9 @@ void MultipeerIbgdaTransport::createQpGroups() {
           << currentDevice << " expected=" << config_.cudaDevice;
 
   // Query IB device capabilities for debugging
-  ibv_device_attr devAttr{};
-  if (ibv_query_device(ibvCtx_, &devAttr) == 0) {
+  auto devAttrResult = ibvDevice_->queryDevice();
+  if (!devAttrResult.hasError()) {
+    auto& devAttr = *devAttrResult;
     VLOG(1) << "MultipeerIbgdaTransport: IB device - max_qp=" << devAttr.max_qp
             << " max_cq=" << devAttr.max_cq << " max_mr=" << devAttr.max_mr
             << " max_qp_wr=" << devAttr.max_qp_wr;
@@ -348,7 +339,7 @@ void MultipeerIbgdaTransport::createQpGroups() {
 
   doca_gpu_verbs_qp_init_attr_hl initAttr{};
   initAttr.gpu_dev = docaGpu_;
-  initAttr.ibpd = ibvPd_;
+  initAttr.ibpd = reinterpret_cast<struct ibv_pd*>(ibvPd_->pd());
   initAttr.sq_nwqe = config_.qpDepth;
   initAttr.nic_handler = DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO;
   initAttr.mreg_type = DOCA_GPUNETIO_VERBS_MEM_REG_TYPE_DEFAULT;
@@ -385,7 +376,7 @@ void MultipeerIbgdaTransport::createLoopbackCompanionQps() {
 
   doca_gpu_verbs_qp_init_attr_hl initAttr{};
   initAttr.gpu_dev = docaGpu_;
-  initAttr.ibpd = ibvPd_;
+  initAttr.ibpd = reinterpret_cast<struct ibv_pd*>(ibvPd_->pd());
   initAttr.sq_nwqe = kCompanionQpDepth;
   initAttr.nic_handler = DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO;
   initAttr.mreg_type = DOCA_GPUNETIO_VERBS_MEM_REG_TYPE_DEFAULT;
@@ -419,10 +410,10 @@ void MultipeerIbgdaTransport::connectQp(
   checkDocaError(err, "Failed to set remote GID");
 
   // Query port for IB-specific parameters
-  ibv_port_attr portAttr{};
-  if (ibv_query_port(ibvCtx_, 1, &portAttr) != 0) {
+  auto portResult2 = ibvDevice_->queryPort(1);
+  if (portResult2.hasError()) {
     LOG(WARNING) << "Failed to query port for IB-specific parameters";
-  } else if (portAttr.link_layer == IBV_LINK_LAYER_INFINIBAND) {
+  } else if (portResult2->link_layer == ibverbx::IBV_LINK_LAYER_INFINIBAND) {
     err = doca_verbs_ah_attr_set_dlid(ahAttr_, peerInfo.lid);
     checkDocaError(err, "Failed to set DLID");
   }
@@ -589,17 +580,11 @@ void MultipeerIbgdaTransport::cleanup() {
   }
   loopbackCompanionQpHlList_.clear();
 
-  // Destroy user buffer MRs
-  for (auto& [_, mr] : registeredBuffers_) {
-    ibv_dereg_mr(mr);
-  }
+  // User buffer MRs — RAII handles deregistration
   registeredBuffers_.clear();
 
-  // Destroy sink MR
-  if (sinkMr_) {
-    ibv_dereg_mr(sinkMr_);
-    sinkMr_ = nullptr;
-  }
+  // Sink MR — RAII handles deregistration
+  sinkMr_.reset();
 
   // Free sink buffer
   if (sinkBuffer_ != nullptr) {
@@ -613,17 +598,9 @@ void MultipeerIbgdaTransport::cleanup() {
     ahAttr_ = nullptr;
   }
 
-  // Destroy PD
-  if (ibvPd_) {
-    ibv_dealloc_pd(ibvPd_);
-    ibvPd_ = nullptr;
-  }
-
-  // Close device
-  if (ibvCtx_) {
-    ibv_close_device(ibvCtx_);
-    ibvCtx_ = nullptr;
-  }
+  // PD and device — RAII handles deallocation/close
+  ibvPd_.reset();
+  ibvDevice_.reset();
 
   // Destroy DOCA GPU context
   if (docaGpu_ != nullptr) {
@@ -655,11 +632,11 @@ void MultipeerIbgdaTransport::exchange() {
   myInfo.mtu = localMtu_;
 
   // Query port for LID (IB only)
-  ibv_port_attr exchPortAttr{};
-  if (ibv_query_port(ibvCtx_, 1, &exchPortAttr) != 0) {
+  auto exchPortResult = ibvDevice_->queryPort(1);
+  if (exchPortResult.hasError()) {
     LOG(WARNING) << "Failed to query port for LID";
   } else {
-    myInfo.lid = exchPortAttr.lid;
+    myInfo.lid = exchPortResult->lid;
   }
 
   // Fill in per-target QPNs
@@ -722,9 +699,9 @@ void MultipeerIbgdaTransport::exchange() {
     selfInfo.mtu = localMtu_;
 
     // Query port for local LID (IB fabrics)
-    ibv_port_attr loopbackPortAttr{};
-    if (ibv_query_port(ibvCtx_, 1, &loopbackPortAttr) == 0) {
-      selfInfo.lid = loopbackPortAttr.lid;
+    auto loopbackPortResult = ibvDevice_->queryPort(1);
+    if (!loopbackPortResult.hasError()) {
+      selfInfo.lid = loopbackPortResult->lid;
     }
 
     for (int i = 0; i < numPeers; i++) {
@@ -758,7 +735,7 @@ void MultipeerIbgdaTransport::exchange() {
     checkDocaError(err, "Failed to get companion GPU QP handle");
 
     buildParams[i] = P2pIbgdaTransportBuildParams{
-        gpuQp, companionGpuQp, NetworkLKey(HostLKey(sinkMr_->lkey))};
+        gpuQp, companionGpuQp, NetworkLKey(HostLKey(sinkMr_->mr()->lkey))};
   }
 
   peerTransportsGpu_ = buildDeviceTransportsOnGpu(buildParams.data(), numPeers);
@@ -812,37 +789,42 @@ IbgdaLocalBuffer MultipeerIbgdaTransport::registerBuffer(
   // If already registered, return existing registration (no-op)
   auto existingIt = registeredBuffers_.find(ptr);
   if (existingIt != registeredBuffers_.end()) {
-    return IbgdaLocalBuffer(ptr, HostLKey(existingIt->second->lkey));
+    return IbgdaLocalBuffer(ptr, HostLKey(existingIt->second.mr()->lkey));
   }
 
-  int accessFlags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE |
-      IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_ATOMIC;
+  int accessFlags = ibverbx::IBV_ACCESS_LOCAL_WRITE |
+      ibverbx::IBV_ACCESS_REMOTE_WRITE | ibverbx::IBV_ACCESS_REMOTE_READ |
+      ibverbx::IBV_ACCESS_REMOTE_ATOMIC;
 
   // Try DMABUF registration first, fall back to regular reg_mr
-  ibv_mr* mr = nullptr;
+  std::optional<ibverbx::IbvMr> mrOpt;
   int dmabufFd = -1;
   doca_error_t err = doca_gpu_dmabuf_fd(docaGpu_, ptr, size, &dmabufFd);
   if (err == DOCA_SUCCESS && dmabufFd >= 0) {
-    mr = ibv_reg_dmabuf_mr(
-        ibvPd_,
+    auto result = ibvPd_->regDmabufMr(
         0,
         size,
         reinterpret_cast<uint64_t>(ptr),
         dmabufFd,
-        accessFlags);
-  }
-  if (!mr) {
-    mr = ibv_reg_mr(ibvPd_, ptr, size, accessFlags);
-    if (!mr) {
-      throw std::runtime_error("Failed to register buffer with RDMA");
+        static_cast<ibverbx::ibv_access_flags>(accessFlags));
+    if (!result.hasError()) {
+      mrOpt.emplace(std::move(*result));
     }
   }
+  if (!mrOpt) {
+    auto result = ibvPd_->regMr(
+        ptr, size, static_cast<ibverbx::ibv_access_flags>(accessFlags));
+    if (result.hasError()) {
+      throw std::runtime_error("Failed to register buffer with RDMA");
+    }
+    mrOpt.emplace(std::move(*result));
+  }
 
-  uint32_t lkey = mr->lkey;
-  registeredBuffers_.emplace(ptr, mr);
+  uint32_t lkey = mrOpt->mr()->lkey;
+  registeredBuffers_.emplace(ptr, std::move(*mrOpt));
 
   VLOG(1) << "MultipeerIbgdaTransport: registered user buffer ptr=" << ptr
-          << " size=" << size << " lkey=" << mr->lkey << " rkey=" << mr->rkey;
+          << " size=" << size << " lkey=" << lkey;
 
   return IbgdaLocalBuffer(ptr, HostLKey(lkey));
 }
@@ -854,8 +836,7 @@ void MultipeerIbgdaTransport::deregisterBuffer(void* ptr) {
     return;
   }
 
-  ibv_dereg_mr(it->second);
-  registeredBuffers_.erase(it);
+  registeredBuffers_.erase(it); // RAII handles ibv_dereg_mr
 
   VLOG(1) << "MultipeerIbgdaTransport: deregistered buffer ptr=" << ptr;
 }
@@ -877,7 +858,7 @@ std::vector<IbgdaRemoteBuffer> MultipeerIbgdaTransport::exchangeBuffer(
   // Write my info at my rank's slot
   allInfo[myRank_] = IbgdaBufferExchInfo{
       reinterpret_cast<uint64_t>(localBuf.ptr),
-      HostRKey(it->second->rkey),
+      HostRKey(it->second.mr()->rkey),
   };
 
   // Use allGather to exchange buffer info with all ranks

--- a/comms/pipes/MultipeerIbgdaTransport.h
+++ b/comms/pipes/MultipeerIbgdaTransport.h
@@ -10,7 +10,10 @@
 #include <unordered_map>
 #include <vector>
 
-#include <infiniband/verbs.h>
+#include "comms/ctran/ibverbx/IbvDevice.h"
+#include "comms/ctran/ibverbx/IbvMr.h"
+#include "comms/ctran/ibverbx/IbvPd.h"
+#include "comms/ctran/ibverbx/Ibvcore.h"
 
 #include <doca_gpunetio_host.h>
 #include "comms/common/bootstrap/IBootstrap.h"
@@ -132,7 +135,7 @@ struct IbgdaTransportExchInfo {
   uint16_t lid{0};
 
   // Port active MTU. Used to negotiate path MTU: min(local, remote).
-  enum ibv_mtu mtu { IBV_MTU_4096 };
+  enum ibverbx::ibv_mtu mtu{ibverbx::IBV_MTU_4096};
 };
 
 /**
@@ -155,7 +158,7 @@ struct IbgdaTransportExchInfoAll {
   uint16_t lid{0};
 
   // Port active MTU.
-  enum ibv_mtu mtu { IBV_MTU_4096 };
+  enum ibverbx::ibv_mtu mtu{ibverbx::IBV_MTU_4096};
 
   // Per-target-rank QPNs
   // qpnForRank[j] = QPN that this rank uses to connect to rank j
@@ -374,11 +377,11 @@ class MultipeerIbgdaTransport {
   // DOCA GPU context
   doca_gpu* docaGpu_{nullptr};
 
-  // IB verbs resources (raw rdma-core)
-  ibv_context* ibvCtx_{nullptr};
-  ibv_pd* ibvPd_{nullptr};
+  // IB verbs resources (ibverbx RAII objects)
+  std::optional<ibverbx::IbvDevice> ibvDevice_;
+  std::optional<ibverbx::IbvPd> ibvPd_;
   doca_verbs_ah_attr* ahAttr_{nullptr};
-  union ibv_gid localGid_{};
+  union ibverbx::ibv_gid localGid_{};
 
   // QP groups (one per peer): main QP + companion QP with shared UAR.
   // The companion QP is created with core_direct=true (required for WAIT WQE).
@@ -394,16 +397,16 @@ class MultipeerIbgdaTransport {
   // return value. We don't need it, so we use a small "sink" buffer.
   void* sinkBuffer_{nullptr};
   std::size_t sinkBufferSize_{0};
-  ibv_mr* sinkMr_{nullptr};
+  std::optional<ibverbx::IbvMr> sinkMr_;
 
-  // User-registered buffers (maps ptr -> ibv_mr*)
-  std::unordered_map<void*, ibv_mr*> registeredBuffers_;
+  // User-registered buffers (RAII — automatically deregistered on erase/clear)
+  std::unordered_map<void*, ibverbx::IbvMr> registeredBuffers_;
 
   // GPU PCIe bus ID and NIC device name
   std::string gpuPciBusId_;
   std::string nicDeviceName_;
   int gidIndex_{3}; // Default GID index
-  enum ibv_mtu localMtu_ { IBV_MTU_4096 };
+  enum ibverbx::ibv_mtu localMtu_{ibverbx::IBV_MTU_4096};
 
   // Per-peer device transports (GPU accessible)
   P2pIbgdaTransportDevice* peerTransportsGpu_{nullptr};


### PR DESCRIPTION
Summary:
Switch pipes MultipeerIbgdaTransport from direct-linked ibverbs calls to
ibverbx's dlopen-based function pointers (ibvSymbols). This ensures pipes
loads the same system libibverbs that NCCL and doca use, avoiding version
conflicts between the third-party rdma-core and the system library.

Without this change, pipes calls ibv_open_device() from the direct-linked
third-party rdma-core, creating an IB context with a different struct layout
than what doca_gpunetio_dl expects (which uses dlopen'd system libibverbs).
This mismatch causes mlx5dv_devx_umem_reg to fail with DOCA_ERROR_DRIVER.

Changes:
- Replace #include <infiniband/verbs.h> with ibverbx/Ibvcore.h
- Use ibverbx:: types throughout (ibv_context, ibv_pd, ibv_mr, etc.)
- Use ibverbx::ibvSymbols.ibv_internal_*() for all ibverbs function calls
- Add reinterpret_cast at doca API boundaries (ibverbx vs doca type namespaces)
- Remove rdma-core deps, add ibverbx:ibvcore and ibverbx:ibverbx-symbols deps
- Update BUCK deps from doca_gpunetio to doca_gpunetio_dl

Differential Revision: D95991077


