### PR TITLE
Remove NCCL_CTRAN_NVL_FABRIC_ENABLE env var, auto-detect fabric support at runtime (#1015)

### DIFF
--- a/comms/ctran/commstate/CommStateX.cc
+++ b/comms/ctran/commstate/CommStateX.cc
@@ -6,6 +6,7 @@
 
 #include "CommStateX.h"
 #include "comms/ctran/commstate/Topology.h"
+#include "comms/ctran/utils/Alloc.h"
 #include "comms/ctran/utils/Checks.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
@@ -139,7 +140,10 @@ void CommStateX::initRankStatesTopology(meta::comms::IBootstrap* bootstrap) {
 }
 
 void CommStateX::setNvlFabricTopos(
-    std::vector<NvlFabricTopology> nvlFabricTopologies) {
+    std::vector<NvlFabricTopology> nvlFabricTopologies,
+    std::optional<bool> fabricHwSupportedForTest) {
+  bool fabricHwSupported =
+      fabricHwSupportedForTest.value_or(ctran::utils::isCuMemFabricEnabled());
   FB_CHECKABORT(
       nvlFabricTopologies.size() == nRanks_,
       "size of nvlFabricTopologies not equal to nRanks_: {}",
@@ -147,8 +151,8 @@ void CommStateX::setNvlFabricTopos(
   nvlFabricTopos_ = std::move(nvlFabricTopologies);
   nvlFabricRankStates_.clear();
   nvlDomainRanks_.clear();
-  nvlFabricEnabled_ = NCCL_CTRAN_NVL_FABRIC_ENABLE &&
-      nvlFabricTopos_.at(rank_).supportNvlFabric;
+  nvlFabricEnabled_ =
+      fabricHwSupported && nvlFabricTopos_.at(rank_).supportNvlFabric;
   if (!nvlFabricEnabled_) {
     return;
   }

--- a/comms/ctran/commstate/CommStateX.h
+++ b/comms/ctran/commstate/CommStateX.h
@@ -5,6 +5,7 @@
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -92,7 +93,11 @@ class CommStateX {
 
   /* Setters */
   void setRankTopologies(std::vector<RankTopology> rankTopologies);
-  void setNvlFabricTopos(std::vector<NvlFabricTopology> nvlFabricTopologies);
+  // fabricHwSupportedForTest: optional override for testing; when not provided,
+  // uses runtime detection via getCuMemAllocHandleType()
+  void setNvlFabricTopos(
+      std::vector<NvlFabricTopology> nvlFabricTopologies,
+      std::optional<bool> fabricHwSupportedForTest = std::nullopt);
 
   /* Getters */
   const std::vector<ncclx::RankTopology>& rankTopologiesRef() const;

--- a/comms/ctran/commstate/tests/CommStateXTest.cc
+++ b/comms/ctran/commstate/tests/CommStateXTest.cc
@@ -236,8 +236,7 @@ TEST(CommStateXTest, ValidEorTopology) {
   }
 }
 TEST(CommStateXTest, multiRackTest) {
-  EnvRAII env1(NCCL_CTRAN_NVL_FABRIC_ENABLE, true);
-  EnvRAII env2(NCCL_MNNVL_TRUNK_DISABLE, true);
+  EnvRAII env(NCCL_MNNVL_TRUNK_DISABLE, true);
   const int rank = 0;
   const int nRanks = 3;
   const int cudaDev = 0;
@@ -268,8 +267,6 @@ TEST(CommStateXTest, multiRackTest) {
 }
 
 TEST(CommStateXTest, nvlFabricTest) {
-  // set NCCL_CTRAN_NVL_FABRIC_ENABLE to true
-  EnvRAII env(NCCL_CTRAN_NVL_FABRIC_ENABLE, true);
   const int rank = 0;
   const int nRanks = 8;
   const int cudaDev = 0;
@@ -324,7 +321,7 @@ TEST(CommStateXTest, nvlFabricTest) {
       commHash,
       rankTopologies,
       std::vector<int>{});
-  commState->setNvlFabricTopos(nvlFabricTopologies);
+  commState->setNvlFabricTopos(nvlFabricTopologies, true);
 
   for (int i = 0; i < nRanks; ++i) {
     if (i < 4) {
@@ -343,11 +340,10 @@ TEST(CommStateXTest, nvlFabricTest) {
     EXPECT_EQ(commState->localRankToRanks().size(), 4);
   }
   EXPECT_TRUE(commState->nvlFabricEnabled());
-  // reset NCCL_CTRAN_NVL_FABRIC_ENABLE to false
+  // Test with fabricHwSupported = false
   {
-    EnvRAII env(NCCL_CTRAN_NVL_FABRIC_ENABLE, false);
-    // reload nvlFabricTopologies
-    commState->setNvlFabricTopos(std::move(nvlFabricTopologies));
+    // reload nvlFabricTopologies with fabric HW not supported
+    commState->setNvlFabricTopos(std::move(nvlFabricTopologies), false);
     EXPECT_FALSE(commState->nvlFabricEnabled());
     for (int i = 0; i < nRanks; ++i) {
       EXPECT_FALSE(commState->isSameNvlFabric(0, i));
@@ -357,9 +353,8 @@ TEST(CommStateXTest, nvlFabricTest) {
 
 TEST(CommStateXTest, nvlFabricCliqueTest) {
   // enable clique and NVL software partioning mode
-  EnvRAII env1(NCCL_CTRAN_NVL_FABRIC_ENABLE, true);
-  EnvRAII env2(NCCL_MNNVL_DETERMINISTIC_COLLECTIVE_ENABLE, true);
-  EnvRAII env3(NCCL_MNNVL_CLIQUE_SIZE, 2);
+  EnvRAII env1(NCCL_MNNVL_DETERMINISTIC_COLLECTIVE_ENABLE, true);
+  EnvRAII env2(NCCL_MNNVL_CLIQUE_SIZE, 2);
   const int rank = 0;
   const int nRanks = 8;
   const int cudaDev = 0;
@@ -414,7 +409,7 @@ TEST(CommStateXTest, nvlFabricCliqueTest) {
       commHash,
       rankTopologies,
       std::vector<int>{});
-  commState->setNvlFabricTopos(nvlFabricTopologies);
+  commState->setNvlFabricTopos(nvlFabricTopologies, true);
   EXPECT_TRUE(commState->nvlFabricEnabled());
   EXPECT_TRUE(commState->nvlFabricCliqueEnabled());
 

--- a/comms/ctran/utils/Alloc.cc
+++ b/comms/ctran/utils/Alloc.cc
@@ -5,27 +5,6 @@
 #include "comms/ctran/utils/CudaWrap.h"
 #include "comms/ctran/utils/DevUtils.cuh"
 
-namespace {
-#if CUDART_VERSION >= 12040
-constexpr size_t kCtranAllocMinSize = 2097152UL;
-#endif
-CUmemAllocationHandleType cuMemAllocHandleType =
-    CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
-std::once_flag initCuMemAllocHandleTypeFlag;
-
-void initCuMemAllocHandleTypeOnce() {
-#if CUDART_VERSION < 12040
-  return;
-#else
-  if (ctran::utils::isCuMemFabricHandleSupported()) {
-    cuMemAllocHandleType =
-        (CUmemAllocationHandleType)(CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR |
-                                    CU_MEM_HANDLE_TYPE_FABRIC);
-  }
-#endif
-}
-} // namespace
-
 namespace ctran::utils {
 
 commResult_t commCuMemAlloc(
@@ -125,21 +104,25 @@ commResult_t commCuMemFree(void* ptr, const CommLogData* logMetaData) {
   return commSuccess;
 }
 
+namespace {
+
+#if CUDART_VERSION >= 12040
+constexpr size_t kCtranAllocMinSize = 2097152UL;
+#endif
+CUmemAllocationHandleType cuMemAllocHandleType =
+    CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+std::once_flag initCuMemAllocHandleTypeFlag;
+
 bool isCuMemFabricHandleSupported() {
 #if CUDART_VERSION < 12040
   return false;
 #else
-  // 1: For safty, a manual ENV to gate all NVL FABRIC features
-  if (!NCCL_CTRAN_NVL_FABRIC_ENABLE) {
-    return false;
-  }
-
-  // 2: checking cumem support
+  // 1: checking cumem support
   if (!isCuMemSupported()) {
     return false;
   }
 
-  // 3: checking cuDeviceGetAttribute
+  // 2: checking cuDeviceGetAttribute
   CUdevice currentDev;
   int cudaDev;
   int flag = 0;
@@ -154,25 +137,52 @@ bool isCuMemFabricHandleSupported() {
     return false;
   }
 
-  // 4: checking if fabric handle type of memory can be allocated
+  // 3: checking if fabric handle type of memory can be allocated
+  // NOTE: We intentionally use raw CU calls here instead of commCuMemAlloc
+  // because this is a probe that is expected to fail on non-fabric platforms
+  // (e.g., H100), and we don't want to log errors for expected failures.
   void* addr = nullptr;
   CUmemGenericAllocationHandle allocHandle;
+  CUmemAllocationProp prop = {};
+  prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+  prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  prop.location.id = currentDev;
+  prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_FABRIC;
 
-  commResult_t result = commCuMemAlloc(
-      &addr,
-      &allocHandle,
-      CU_MEM_HANDLE_TYPE_FABRIC,
-      kCtranAllocMinSize,
-      nullptr /* CommLogData */,
-      "isCuMemFabricHandleSupported");
-  if (result != commSuccess) {
-    if (addr) {
-      commCuMemFree(addr, nullptr /* CommLogData */);
-    }
+  size_t granularity = 0;
+  if (FB_CUPFN(cuMemGetAllocationGranularity(
+          &granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM)) !=
+      CUDA_SUCCESS) {
+    return false;
+  }
+  size_t size = ctran::utils::roundUp(kCtranAllocMinSize, granularity);
+  if (FB_CUPFN(cuMemCreate(&allocHandle, size, &prop, 0)) != CUDA_SUCCESS) {
+    return false;
+  }
+  if (FB_CUPFN(cuMemAddressReserve(
+          (CUdeviceptr*)&addr, size, granularity, 0, 0)) != CUDA_SUCCESS) {
+    FB_CUPFN(cuMemRelease(allocHandle));
+    return false;
+  }
+  if (FB_CUPFN(cuMemMap((CUdeviceptr)addr, size, 0, allocHandle, 0)) !=
+      CUDA_SUCCESS) {
+    FB_CUPFN(cuMemAddressFree((CUdeviceptr)addr, size));
+    FB_CUPFN(cuMemRelease(allocHandle));
+    return false;
+  }
+  CUmemAccessDesc accessDesc = {};
+  accessDesc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  accessDesc.location.id = currentDev;
+  accessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+  if (FB_CUPFN(cuMemSetAccess((CUdeviceptr)addr, size, &accessDesc, 1)) !=
+      CUDA_SUCCESS) {
+    FB_CUPFN(cuMemUnmap((CUdeviceptr)addr, size));
+    FB_CUPFN(cuMemAddressFree((CUdeviceptr)addr, size));
+    FB_CUPFN(cuMemRelease(allocHandle));
     return false;
   }
 
-  // 5: checking if import/export fabric handle type is supported
+  // 4: checking if import/export fabric handle type is supported
   CUmemFabricHandle sharedHandle;
   if (FB_CUPFN(cuMemExportToShareableHandle(
           &sharedHandle, allocHandle, CU_MEM_HANDLE_TYPE_FABRIC, 0)) !=
@@ -196,6 +206,20 @@ bool isCuMemFabricHandleSupported() {
   return true;
 #endif
 }
+
+void initCuMemAllocHandleTypeOnce() {
+#if CUDART_VERSION < 12040
+  return;
+#else
+  if (isCuMemFabricHandleSupported()) {
+    cuMemAllocHandleType =
+        (CUmemAllocationHandleType)(CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR |
+                                    CU_MEM_HANDLE_TYPE_FABRIC);
+  }
+#endif
+}
+
+} // namespace
 
 CUmemAllocationHandleType getCuMemAllocHandleType() {
   std::call_once(initCuMemAllocHandleTypeFlag, initCuMemAllocHandleTypeOnce);

--- a/comms/ctran/utils/Alloc.h
+++ b/comms/ctran/utils/Alloc.h
@@ -41,6 +41,15 @@ inline std::string cuMemHandleTypeStr(CUmemAllocationHandleType handleType) {
 
 CUmemAllocationHandleType getCuMemAllocHandleType();
 
+inline bool isCuMemFabricEnabled() {
+#if defined(__HIP_PLATFORM_AMD__) || CUDART_VERSION < 12040
+  return false;
+#else
+  return static_cast<bool>(
+      getCuMemAllocHandleType() & CU_MEM_HANDLE_TYPE_FABRIC);
+#endif
+}
+
 commResult_t commCuMemAlloc(
     void** ptr,
     CUmemGenericAllocationHandle* handlep,
@@ -50,8 +59,6 @@ commResult_t commCuMemAlloc(
     const char* callsite);
 
 commResult_t commCuMemFree(void* ptr, const CommLogData* logMetaData = nullptr);
-
-bool isCuMemFabricHandleSupported();
 
 template <typename T>
 commResult_t commCudaMallocDebug(

--- a/comms/ctran/utils/CtranIpc.cc
+++ b/comms/ctran/utils/CtranIpc.cc
@@ -78,8 +78,7 @@ static inline CUmemAllocationHandleType getCuMemExportHandleType(
   CUmemAllocationHandleType exportHandleType =
       CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
 #if CUDART_VERSION >= 12040
-  if (NCCL_CTRAN_NVL_FABRIC_ENABLE &&
-      (cuMemHandleType & CU_MEM_HANDLE_TYPE_FABRIC)) {
+  if (cuMemHandleType & CU_MEM_HANDLE_TYPE_FABRIC) {
     exportHandleType = CU_MEM_HANDLE_TYPE_FABRIC;
   }
 #endif
@@ -262,10 +261,8 @@ inline commResult_t ctran::utils::CtranIpcMem::tryLoadCuMem(
   // when
   //   allocating ctran internal buffers (ALLOC mode). Always includes POSIX.
   // - getCuMemExportHandleType(): Determines the export handle type based on
-  // CVAR
-  //   enable flag (NCCL_CTRAN_NVL_FABRIC_ENABLE) and the allocation's handle
-  //   type. Used in LOAD mode to validate that user-provided memory can be
-  //   exported.
+  //   the allocation's handle type. Used in LOAD mode to validate that
+  //   user-provided memory can be exported.
 
   // temp linear loop through physical allocations, could be faster to get from
   // pytorch level

--- a/comms/ctran/utils/tests/AllocUT.cc
+++ b/comms/ctran/utils/tests/AllocUT.cc
@@ -52,9 +52,14 @@ TEST_F(CommAllocTest, CuMemAllocation) {
   if (!ctran::utils::getCuMemSysSupported()) {
     GTEST_SKIP() << "CuMem not supported, skip CuMemAllocation test";
   }
-  if (gpuName_.find("GB200") == std::string::npos) {
-    // by default NCCL_CTRAN_NVL_FABRIC_ENABLE is false, we use posix file
-    // descriptor for cuda allocation
+  // TODO: device attribute query
+  // (CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED) doesn't give us
+  // trustable info about if fabric handle is supported, so we use this
+  // hardcoded GPU name to test. See:
+  // https://forums.developer.nvidia.com/t/cudevicegetattribute-shows-i-can-use-fabric-handle-but-actually-i-cannot/336426/10
+  if (gpuName_.find("GB") == std::string::npos) {
+    // on non-GB (Grace Blackwell) platforms, fabric is not supported, we use
+    // posix file descriptor for cuda allocation
     ensureDeviceMemNoLeak([this]() {
       void* ptr{nullptr};
       CUmemGenericAllocationHandle handle;
@@ -74,8 +79,8 @@ TEST_F(CommAllocTest, CuMemAllocation) {
     });
   } else {
 #if !defined(USE_ROCM)
-    // for GB200 platform, set NCCL_CTRAN_NVL_FABRIC_ENABLE to true.
-    EnvRAII env1(NCCL_CTRAN_NVL_FABRIC_ENABLE, true);
+    // for GB (Grace Blackwell) platforms, fabric handle is auto-detected as
+    // supported.
     ensureDeviceMemNoLeak([this]() {
       void* ptr{nullptr};
       CUmemGenericAllocationHandle handle;
@@ -99,19 +104,19 @@ TEST_F(CommAllocTest, CuMemAllocation) {
 }
 
 TEST_F(CommAllocTest, isCuMemFabricHandleSupported) {
-  // for any platform, if NCCL_CTRAN_NVL_FABRIC_ENABLE is false,
-  // isCuMemFabricHandleSupported should return false
-  ensureDeviceMemNoLeak([this]() {
-    EnvRAII env1(NCCL_CTRAN_NVL_FABRIC_ENABLE, false);
-    EXPECT_FALSE(isCuMemFabricHandleSupported());
-  });
-  // for GB200 platform, set NCCL_CTRAN_NVL_FABRIC_ENABLE to true,
-  // isCuMemFabricHandleSupported should return true
-  if (gpuName_.find("GB200") != std::string::npos) {
-    ensureDeviceMemNoLeak([this]() {
-      EnvRAII env1(NCCL_CTRAN_NVL_FABRIC_ENABLE, true);
-      EXPECT_TRUE(isCuMemFabricHandleSupported());
-    });
+  // getCuMemAllocHandleType() triggers runtime fabric detection internally
+  // (alloc/export/import probe), so we cannot wrap it in ensureDeviceMemNoLeak
+  // since the CUDA allocator may retain internal memory pools after the probe
+  // even though all allocations are freed.
+  bool fabricSupported = isCuMemFabricEnabled();
+  if (gpuName_.find("GB") == std::string::npos) {
+    // on non-GB (Grace Blackwell) platforms, fabric handle should not be
+    // supported
+    EXPECT_FALSE(fabricSupported);
+  } else {
+    // for GB (Grace Blackwell) platforms, fabric handle should be auto-detected
+    // as supported
+    EXPECT_TRUE(fabricSupported);
   }
 }
 

--- a/comms/ctran/utils/tests/IpcUT.cc
+++ b/comms/ctran/utils/tests/IpcUT.cc
@@ -59,10 +59,13 @@ TEST_F(IpcUT, TryLoadCuMemRejectsNoneHandleType) {
   ctran::commMemFreeDisjoint(ptr, segmentSizes);
 }
 
-// Test Case 2: tryLoad should reject FABRIC-only memory when FABRIC is disabled
-// Currently this test is expected to FAIL because tryLoad does not validate
-// this
-TEST_F(IpcUT, TryLoadCuMemRejectsFabricOnlyWhenFabricDisabled) {
+// Test Case 2: tryLoad behavior for FABRIC-only memory depends on whether
+// the system auto-detects fabric support at runtime.
+// On GB200: fabric is auto-detected as supported, so FABRIC-only memory
+//   should be loadable (tryLoad succeeds).
+// On non-GB200 with CUDA 12.4+: fabric is not supported, so this test
+//   is skipped because FABRIC allocation would silently downgrade.
+TEST_F(IpcUT, TryLoadCuMemFabricOnlyHandleType) {
 #if CUDART_VERSION < 12040
   GTEST_SKIP() << "CUDA < 12.04, FABRIC handle type not available";
 #else
@@ -73,7 +76,6 @@ TEST_F(IpcUT, TryLoadCuMemRejectsFabricOnlyWhenFabricDisabled) {
   // Skip if system doesn't support FABRIC - allocation would silently downgrade
   // to NONE (see D90902516 for details on CUDA's silent downgrade behavior)
   {
-    EnvRAII fabricDisabled(NCCL_CTRAN_NVL_FABRIC_ENABLE, true);
     CUmemAllocationHandleType systemSupported =
         ctran::utils::getCuMemAllocHandleType();
     if ((systemSupported & CU_MEM_HANDLE_TYPE_FABRIC) == 0) {
@@ -82,9 +84,9 @@ TEST_F(IpcUT, TryLoadCuMemRejectsFabricOnlyWhenFabricDisabled) {
     }
   }
 
-  // Disable FABRIC support in ctran
-  EnvRAII fabricDisabled(NCCL_CTRAN_NVL_FABRIC_ENABLE, false);
-
+  // On systems where fabric is auto-detected as supported (e.g. GB200),
+  // FABRIC-only memory should be loadable since getCuMemExportHandleType()
+  // will use FABRIC for export.
   constexpr size_t size = 2 * 1024 * 1024; // 2MB
   std::vector<size_t> segmentSizes = {size};
   std::vector<TestMemSegment> segments;
@@ -100,15 +102,13 @@ TEST_F(IpcUT, TryLoadCuMemRejectsFabricOnlyWhenFabricDisabled) {
   // Create CtranIpcMem in LOAD mode
   auto ipcMem = std::make_unique<CtranIpcMem>(0, dummyDesc_);
 
-  // tryLoad should fail because ctran would try to export as POSIX
-  // but the allocation only supports FABRIC
+  // On fabric-supported systems, tryLoad should succeed because
+  // getCuMemExportHandleType() will match the FABRIC handle type.
   bool supported = false;
   (void)ipcMem->tryLoad(ptr, size, supported, false);
 
-  // Expected: tryLoad should return error or set supported=false
-  // because FABRIC-only memory cannot be exported as POSIX
-  EXPECT_FALSE(supported)
-      << "tryLoad should reject FABRIC-only memory when FABRIC export is disabled";
+  EXPECT_TRUE(supported)
+      << "tryLoad should accept FABRIC-only memory when fabric is supported";
 
   ctran::commMemFreeDisjoint(ptr, segmentSizes);
 #endif

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1454,12 +1454,6 @@ cvars:
      share its own data with all the other peers, similar to a bcast or incast
      pattern.
 
- - name        : NCCL_CTRAN_NVL_FABRIC_ENABLE
-   type        : bool
-   default     : false
-   description : |-
-     Enable the use of NVL fabric in CTRAN.
-
  - name        : NCCL_CTRAN_IB_DMABUF_ENABLE
    type        : bool
    default     : true


### PR DESCRIPTION
Summary:

Remove the NCCL_CTRAN_NVL_FABRIC_ENABLE environment variable and replace it
with runtime fabric support detection via isCuMemFabricHandleSupported().

Instead of requiring users to manually set an env var to enable NVL fabric,
the system now auto-detects fabric support at runtime by:
1. Checking CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED device attribute
2. Trying to allocate memory with CU_MEM_HANDLE_TYPE_FABRIC
3. Trying to export/import a fabric handle

This follows the same pattern as isFabricSupported() in PyTorch c10/cuda/PeerToPeerAccess.cpp.

Changes:
- Alloc.cc: Removed NCCL_CTRAN_NVL_FABRIC_ENABLE gate; use raw CU calls in fabric probe to avoid logging errors for expected failures on non-fabric
  platforms (e.g., H100)
- Alloc.h: Added isCuMemFabricEnabled() helper to encapsulate fabric check
  with proper preprocessor guards for AMD GPU/older CUDA builds
- CommStateX.cc: Replaced direct CU_MEM_HANDLE_TYPE_FABRIC usage with
  isCuMemFabricEnabled() helper; added overload with bool fabricHwSupported param for testability
- CommStateX.h: Added optional fabricHwSupportedForTest param to setNvlFabricTopos()
- CtranIpc.cc: Removed env var from getCuMemExportHandleType()
- CommStateXTest.cc: Updated tests to use setNvlFabricTopos(topos, bool) overload
- AllocUT.cc: Updated GPU detection to use \"GB\" prefix instead of \"GB200\"
  for future GPU support (GB300, etc.); added TODO explaining hardcoded
  GPU name detection
- IpcUT.cc: Removed env var usage from fabric handle tests
- nccl_cvars.yaml: Removed NCCL_CTRAN_NVL_FABRIC_ENABLE cvar

Reviewed By: minsii

Differential Revision: D96026371
