### PR TITLE
Fix missing null check for rlock timeout in CommDumpPlugin::dump()

### DIFF
--- a/comms/utils/colltrace/plugins/CommDumpPlugin.cc
+++ b/comms/utils/colltrace/plugins/CommDumpPlugin.cc
@@ -192,6 +192,16 @@ CommsMaybe<CollTraceDump> CommDumpPlugin::dump() noexcept {
   auto readLockedCollTraceDump =
       collTraceDump_.rlock(config_.dumpLockAcquireTimeout);
 
+  if (readLockedCollTraceDump.isNull()) {
+    XLOG_FIRST_N(
+        ERR,
+        2,
+        "Failed to acquire read lock for collTraceDump_ in CommDumpPlugin dump");
+    return folly::makeUnexpected(CommsError(
+        "Failed to acquire read lock for collTraceDump_ in CommDumpPlugin dump",
+        commInternalError));
+  }
+
   // Create a copy of the current state of collTraceDump_
   CollTraceDump dumpCopy = *readLockedCollTraceDump;
 

--- a/comms/utils/colltrace/plugins/tests/CommDumpPluginConcurrencyUT.cc
+++ b/comms/utils/colltrace/plugins/tests/CommDumpPluginConcurrencyUT.cc
@@ -1,0 +1,81 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include "comms/utils/colltrace/CollTraceEvent.h"
+#include "comms/utils/colltrace/plugins/CommDumpPlugin.h"
+#include "comms/utils/colltrace/tests/MockTypes.h"
+
+using namespace meta::comms::colltrace;
+
+namespace {
+
+CollTraceEvent createCollTraceEvent(uint64_t collId) {
+  auto metadata = std::make_unique<MockCollMetadata>();
+  auto collRecord = std::make_shared<CollRecord>(collId, std::move(metadata));
+
+  CollTraceEvent event;
+  event.collRecord = collRecord;
+  return event;
+}
+
+} // namespace
+
+// Verify that dump() returns an error when it cannot acquire the read lock
+// within dumpLockAcquireTimeout, rather than dereferencing a null LockedPtr.
+//
+// Uses a 1ms dumpLockAcquireTimeout. One thread runs the colltrace lifecycle
+// in a tight loop (acquiring wlock via afterCollKernelStart/End), while another
+// thread calls dump() concurrently. Under contention with such a short timeout,
+// the rlock in dump() will occasionally time out. Without the null check fix,
+// this would dereference a null LockedPtr and crash.
+TEST(CommDumpPluginConcurrencyTest, DumpReturnsErrorOnReadLockTimeout) {
+  constexpr int kNumRuns = 3;
+
+  for (int run = 0; run < kNumRuns; ++run) {
+    CommDumpConfig config;
+    config.dumpLockAcquireTimeout = std::chrono::milliseconds(1);
+    auto plugin = std::make_unique<CommDumpPlugin>(config);
+
+    std::atomic<bool> running{true};
+    std::atomic<int> errorCount{0};
+    std::atomic<uint64_t> collId{0};
+
+    // Colltrace thread: runs lifecycle in a tight loop, holding wlock
+    // frequently
+    std::thread colltraceThread([&] {
+      while (running.load(std::memory_order_relaxed)) {
+        auto id = collId.fetch_add(1, std::memory_order_relaxed);
+        auto ev = createCollTraceEvent(id);
+
+        plugin->afterCollKernelScheduled(ev);
+        plugin->afterCollKernelStart(ev);
+        plugin->afterCollKernelEnd(ev);
+      }
+    });
+
+    // Dump thread: calls dump() in a tight loop with the tiny timeout
+    std::thread dumpThread([&] {
+      while (running.load(std::memory_order_relaxed)) {
+        auto result = plugin->dump();
+        // Before the fix, a rlock timeout would dereference a null LockedPtr
+        // and crash. After the fix, it returns an error.
+        if (result.hasError()) {
+          errorCount.fetch_add(1, std::memory_order_relaxed);
+        }
+      }
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+    running.store(false, std::memory_order_relaxed);
+
+    colltraceThread.join();
+    dumpThread.join();
+
+    // If we get here without crashing, this run passed.
+  }
+}


### PR DESCRIPTION
Summary:
`CommDumpPlugin::dump()` acquires a timed `rlock` on `collTraceDump_` (default 1s timeout) but did not check whether the lock acquisition succeeded before dereferencing the `LockedPtr`. Under heavy collective traffic, the colltrace thread's `afterCollKernelStart`/`afterCollKernelEnd` repeatedly acquire untimed wlocks, which can starve the dump thread's rlock and cause the timeout to expire. Dereferencing the resulting null `LockedPtr` caused a SIGSEGV in production (in the `CollTraceDump` copy constructor at line 196).

The fix adds a null check on the `rlock` result, returning an error instead of crashing.

Also adds a concurrency stress test (`CommDumpPluginConcurrencyUT.cc`) that reproduces this by running the colltrace lifecycle and `dump()` concurrently with a 1ms lock timeout. Without the fix, this crashes; with the fix, it returns errors gracefully.

Differential Revision: D96068584


