### PR TITLE
Support all sendrecv algo variants in AlgoConfig hint string-to-enum conversion

### DIFF
--- a/comms/ncclx/v2_27/meta/algoconf/AlgoConfig.cc
+++ b/comms/ncclx/v2_27/meta/algoconf/AlgoConfig.cc
@@ -27,6 +27,12 @@ inline const std::string algoValToStr(enum NCCL_SENDRECV_ALGO val) {
 inline void algoStrToVal(const std::string& str, enum NCCL_SENDRECV_ALGO& val) {
   if (str == "ctran") {
     val = NCCL_SENDRECV_ALGO::ctran;
+  } else if (str == "ctzcopy") {
+    val = NCCL_SENDRECV_ALGO::ctzcopy;
+  } else if (str == "ctstaged") {
+    val = NCCL_SENDRECV_ALGO::ctstaged;
+  } else if (str == "ctp2p") {
+    val = NCCL_SENDRECV_ALGO::ctp2p;
   } else {
     val = NCCL_SENDRECV_ALGO::orig;
   }

--- a/comms/ncclx/v2_27/meta/algoconf/tests/AlgoConfigTest.cc
+++ b/comms/ncclx/v2_27/meta/algoconf/tests/AlgoConfigTest.cc
@@ -47,21 +47,30 @@ TEST_F(AlgoConfigUT, SendRecvAlgoHintOverride) {
   ASSERT_EQ(getSendRecvAlgo(), NCCL_SENDRECV_ALGO::orig);
 
   // set/reset multiple times
+  std::unordered_map<enum NCCL_SENDRECV_ALGO, const char*> overrideAlgos = {
+      {NCCL_SENDRECV_ALGO::ctran, "ctran"},
+      {NCCL_SENDRECV_ALGO::ctzcopy, "ctzcopy"},
+      {NCCL_SENDRECV_ALGO::ctstaged, "ctstaged"},
+      {NCCL_SENDRECV_ALGO::ctp2p, "ctp2p"},
+  };
+
   const int iter = 10;
   for (int i = 0; i < iter; i++) {
-    ASSERT_TRUE(ncclx::setGlobalHint(hintName, "ctran"));
+    for (auto& [algo, hintVal] : overrideAlgos) {
+      ASSERT_TRUE(ncclx::setGlobalHint(hintName, hintVal));
 
-    auto getHintVal = ncclx::getGlobalHint(hintName);
-    ASSERT_TRUE(getHintVal.has_value());
-    ASSERT_EQ(getHintVal.value(), "ctran");
+      auto getHintVal = ncclx::getGlobalHint(hintName);
+      ASSERT_TRUE(getHintVal.has_value());
+      ASSERT_EQ(getHintVal.value(), hintVal);
 
-    ASSERT_EQ(getSendRecvAlgo(), NCCL_SENDRECV_ALGO::ctran);
+      ASSERT_EQ(getSendRecvAlgo(), algo);
 
-    ASSERT_TRUE(ncclx::resetGlobalHint(hintName));
-    getHintVal = ncclx::getGlobalHint(hintName);
-    ASSERT_FALSE(getHintVal.has_value());
+      ASSERT_TRUE(ncclx::resetGlobalHint(hintName));
+      getHintVal = ncclx::getGlobalHint(hintName);
+      ASSERT_FALSE(getHintVal.has_value());
 
-    ASSERT_EQ(getSendRecvAlgo(), NCCL_SENDRECV_ALGO::orig);
+      ASSERT_EQ(getSendRecvAlgo(), NCCL_SENDRECV_ALGO::orig);
+    }
   }
 }
 

--- a/comms/ncclx/v2_28/meta/algoconf/AlgoConfig.cc
+++ b/comms/ncclx/v2_28/meta/algoconf/AlgoConfig.cc
@@ -27,6 +27,12 @@ inline const std::string algoValToStr(enum NCCL_SENDRECV_ALGO val) {
 inline void algoStrToVal(const std::string& str, enum NCCL_SENDRECV_ALGO& val) {
   if (str == "ctran") {
     val = NCCL_SENDRECV_ALGO::ctran;
+  } else if (str == "ctzcopy") {
+    val = NCCL_SENDRECV_ALGO::ctzcopy;
+  } else if (str == "ctstaged") {
+    val = NCCL_SENDRECV_ALGO::ctstaged;
+  } else if (str == "ctp2p") {
+    val = NCCL_SENDRECV_ALGO::ctp2p;
   } else {
     val = NCCL_SENDRECV_ALGO::orig;
   }

--- a/comms/ncclx/v2_28/meta/algoconf/tests/AlgoConfigTest.cc
+++ b/comms/ncclx/v2_28/meta/algoconf/tests/AlgoConfigTest.cc
@@ -47,21 +47,30 @@ TEST_F(AlgoConfigUT, SendRecvAlgoHintOverride) {
   ASSERT_EQ(getSendRecvAlgo(), NCCL_SENDRECV_ALGO::orig);
 
   // set/reset multiple times
+  std::unordered_map<enum NCCL_SENDRECV_ALGO, const char*> overrideAlgos = {
+      {NCCL_SENDRECV_ALGO::ctran, "ctran"},
+      {NCCL_SENDRECV_ALGO::ctzcopy, "ctzcopy"},
+      {NCCL_SENDRECV_ALGO::ctstaged, "ctstaged"},
+      {NCCL_SENDRECV_ALGO::ctp2p, "ctp2p"},
+  };
+
   const int iter = 10;
   for (int i = 0; i < iter; i++) {
-    ASSERT_TRUE(ncclx::setGlobalHint(hintName, "ctran"));
+    for (auto& [algo, hintVal] : overrideAlgos) {
+      ASSERT_TRUE(ncclx::setGlobalHint(hintName, hintVal));
 
-    auto getHintVal = ncclx::getGlobalHint(hintName);
-    ASSERT_TRUE(getHintVal.has_value());
-    ASSERT_EQ(getHintVal.value(), "ctran");
+      auto getHintVal = ncclx::getGlobalHint(hintName);
+      ASSERT_TRUE(getHintVal.has_value());
+      ASSERT_EQ(getHintVal.value(), hintVal);
 
-    ASSERT_EQ(getSendRecvAlgo(), NCCL_SENDRECV_ALGO::ctran);
+      ASSERT_EQ(getSendRecvAlgo(), algo);
 
-    ASSERT_TRUE(ncclx::resetGlobalHint(hintName));
-    getHintVal = ncclx::getGlobalHint(hintName);
-    ASSERT_FALSE(getHintVal.has_value());
+      ASSERT_TRUE(ncclx::resetGlobalHint(hintName));
+      getHintVal = ncclx::getGlobalHint(hintName);
+      ASSERT_FALSE(getHintVal.has_value());
 
-    ASSERT_EQ(getSendRecvAlgo(), NCCL_SENDRECV_ALGO::orig);
+      ASSERT_EQ(getSendRecvAlgo(), NCCL_SENDRECV_ALGO::orig);
+    }
   }
 }
 

--- a/comms/ncclx/v2_29/meta/algoconf/AlgoConfig.cc
+++ b/comms/ncclx/v2_29/meta/algoconf/AlgoConfig.cc
@@ -27,6 +27,12 @@ inline const std::string algoValToStr(enum NCCL_SENDRECV_ALGO val) {
 inline void algoStrToVal(const std::string& str, enum NCCL_SENDRECV_ALGO& val) {
   if (str == "ctran") {
     val = NCCL_SENDRECV_ALGO::ctran;
+  } else if (str == "ctzcopy") {
+    val = NCCL_SENDRECV_ALGO::ctzcopy;
+  } else if (str == "ctstaged") {
+    val = NCCL_SENDRECV_ALGO::ctstaged;
+  } else if (str == "ctp2p") {
+    val = NCCL_SENDRECV_ALGO::ctp2p;
   } else {
     val = NCCL_SENDRECV_ALGO::orig;
   }

--- a/comms/ncclx/v2_29/meta/algoconf/tests/AlgoConfigTest.cc
+++ b/comms/ncclx/v2_29/meta/algoconf/tests/AlgoConfigTest.cc
@@ -47,21 +47,30 @@ TEST_F(AlgoConfigUT, SendRecvAlgoHintOverride) {
   ASSERT_EQ(getSendRecvAlgo(), NCCL_SENDRECV_ALGO::orig);
 
   // set/reset multiple times
+  std::unordered_map<enum NCCL_SENDRECV_ALGO, const char*> overrideAlgos = {
+      {NCCL_SENDRECV_ALGO::ctran, "ctran"},
+      {NCCL_SENDRECV_ALGO::ctzcopy, "ctzcopy"},
+      {NCCL_SENDRECV_ALGO::ctstaged, "ctstaged"},
+      {NCCL_SENDRECV_ALGO::ctp2p, "ctp2p"},
+  };
+
   const int iter = 10;
   for (int i = 0; i < iter; i++) {
-    ASSERT_TRUE(ncclx::setGlobalHint(hintName, "ctran"));
+    for (auto& [algo, hintVal] : overrideAlgos) {
+      ASSERT_TRUE(ncclx::setGlobalHint(hintName, hintVal));
 
-    auto getHintVal = ncclx::getGlobalHint(hintName);
-    ASSERT_TRUE(getHintVal.has_value());
-    ASSERT_EQ(getHintVal.value(), "ctran");
+      auto getHintVal = ncclx::getGlobalHint(hintName);
+      ASSERT_TRUE(getHintVal.has_value());
+      ASSERT_EQ(getHintVal.value(), hintVal);
 
-    ASSERT_EQ(getSendRecvAlgo(), NCCL_SENDRECV_ALGO::ctran);
+      ASSERT_EQ(getSendRecvAlgo(), algo);
 
-    ASSERT_TRUE(ncclx::resetGlobalHint(hintName));
-    getHintVal = ncclx::getGlobalHint(hintName);
-    ASSERT_FALSE(getHintVal.has_value());
+      ASSERT_TRUE(ncclx::resetGlobalHint(hintName));
+      getHintVal = ncclx::getGlobalHint(hintName);
+      ASSERT_FALSE(getHintVal.has_value());
 
-    ASSERT_EQ(getSendRecvAlgo(), NCCL_SENDRECV_ALGO::orig);
+      ASSERT_EQ(getSendRecvAlgo(), NCCL_SENDRECV_ALGO::orig);
+    }
   }
 }
 


### PR DESCRIPTION
Summary:
algoStrToVal for NCCL_SENDRECV_ALGO only recognized "ctran" as a valid hint value — all other strings (including valid algorithms like "ctp2p", "ctstaged", "ctzcopy") silently mapped to orig. This was inconsistent with other algo overloads (e.g., NCCL_ALLGATHER_ALGO) which already supported all their variants.

This meant that setting pipeline_parallel_ncclx_algos = "sendrecv:ctp2p" from the trainer would be silently converted to orig by AlgoConfig, disabling CTRAN for sendrecv entirely.

Added "ctzcopy", "ctstaged", and "ctp2p" branches to algoStrToVal for NCCL_SENDRECV_ALGO, matching the pattern used by the other algo string converters. Updated the SendRecvAlgoHintOverride unit test to cover all four non-orig values.

Differential Revision: D96069273


