### PR TITLE
Use `-Wl,--emit-relocs` and `-fno-jump-tables` as a pre-requisite to enabling BOLT on GB200 for NCCL binaries (#1021)

### DIFF
--- a/build_ncclx.sh
+++ b/build_ncclx.sh
@@ -341,6 +341,19 @@ else
   THIRD_PARTY_LDFLAGS+="-lglog -lgflags -lboost_context -lfmt -lssl -lcrypto"
 fi
 
+# BOLT-able binary support:
+# To make binaries compatible with BOLT optimization, we need:
+# 1. --emit-relocs: Emit relocation information in the binary for BOLT to use
+# 2. -fno-jump-tables: Disable jump tables on arm64 (required for BOLT)
+#    See: https://fburl.com/code/3xpb6kha (fbcode/tools/build/buck/wrappers/defs.bzl)
+#    On arm64, jump tables prevent BOLT from properly analyzing control flow.
+if [[ -n "${EMIT_RELOCS}" ]]; then
+  THIRD_PARTY_LDFLAGS+=" -Wl,--emit-relocs"
+fi
+if [[ -n "${FNO_JUMP_TABLES}" ]]; then
+  export CXXFLAGS="${CXXFLAGS} -fno-jump-tables"
+fi
+
 echo "$THIRD_PARTY_LDFLAGS"
 
 if [[ -z "${NVCC_GENCODE-}" ]]; then


### PR DESCRIPTION
Summary:

Turns out that libnccl.so is one of the top CPU consumers on GB200 on the benchmark perception_v5g_tpp_800:TIER4_20B_BENCH_NIGHTLY


As seen in this perf report

{F1985268007}

This diff will enable us to BOLT that binary in a subsequent diff. Building with these flags is a pre-requisites to BOLTing this binary

Reviewed By: aaupov

Differential Revision: D92469856


