### PR TITLE
AllReduceRing fix device side copy calls to be more efficient (#1022)

### DIFF
--- a/comms/ctran/algos/AllReduce/AllReduceRing.cuh
+++ b/comms/ctran/algos/AllReduce/AllReduceRing.cuh
@@ -187,7 +187,7 @@ __device__ __forceinline__ void _progressSend(
       tmpSendBuf,
       roundArgs.numel);
 
-  ctranKernCopy<T>(
+  ctranKernCopyRaw<T>(
       send_data, tmpSendBuf, roundArgs.numel, blockIdx.x, gridDim.x);
 
   // Notify host side its completion
@@ -222,7 +222,7 @@ __device__ __forceinline__ void _progressRevSend(
   T* tmpSendBufRev =
       getBufAtByteOffset<T>(args.tmpSendBufRev, tmpChunkId * args.chunkSize);
 
-  ctranKernCopy<T>(
+  ctranKernCopyRaw<T>(
       recv_data, tmpSendBufRev, roundArgs.numel, blockIdx.x, gridDim.x);
 
   complete(args.revSendCopySync, blockIdx.x, round);
@@ -265,13 +265,16 @@ __device__ __forceinline__ void _progressRevRecv(
 
   if (isRevFwd) {
     // Copy to both forward send buffer and output
-    ctranKernCopy<T>(
-        tmpRecvBufRev, tmpSendBufRev, roundArgs.numel, blockIdx.x, gridDim.x);
-    ctranKernCopy<T>(
-        tmpRecvBufRev, recv_data, roundArgs.numel, blockIdx.x, gridDim.x);
+    ctranKernCopyMultiDestRaw<T>(
+        tmpRecvBufRev,
+        tmpSendBufRev,
+        recv_data,
+        roundArgs.numel,
+        blockIdx.x,
+        gridDim.x);
   } else {
     // Last reverse step: copy to output only
-    ctranKernCopy<T>(
+    ctranKernCopyRaw<T>(
         tmpRecvBufRev, recv_data, roundArgs.numel, blockIdx.x, gridDim.x);
   }
 


### PR DESCRIPTION
Summary:

As title, we forgot to fuse the copies on the reverse AG.

The `raw` variants are introduced perviously to skip the check to see if src and dst buffers are the same. This is a valid assumption to make for AllReduce Ring:

In AllReduce Ring implementation, src and dst buffers are never the same. We never copy from user buffer to user buffer. We only copy
- from user buffer to staging send buffer
- staging recv buffer to staging send buffer
- staging recv buffer to user buffer.

Reviewed By: dboyda

Differential Revision: D96062007
