### PR TITLE
Add sub-MB sizes (256K, 512K, 1M, 2M)

### DIFF
--- a/comms/ctran/algos/common/benchmarks/ReduceKernelBench.cc
+++ b/comms/ctran/algos/common/benchmarks/ReduceKernelBench.cc
@@ -100,17 +100,17 @@ void* getReduceKernelFn() {
  * Benchmark reduce kernel with varying message sizes and reduction operations.
  *
  * Parameters:
- * - msgSizeMB: message size in megabytes
+ * - msgSizeKB: message size in megabytes
  * - nGroups: number of thread block groups
  * - nSrcs: number of source buffers
  * - nDsts: number of destination buffers
  * - op: reduction operation (sum or max)
  */
-template <size_t msgSizeMB, int nGroups, int nSrcs, int nDsts, commRedOp_t op>
+template <size_t msgSizeKB, int nGroups, int nSrcs, int nDsts, commRedOp_t op>
 static void ReduceKernelPerf(uint32_t iters, folly::UserCounters& counters) {
   const int cudaDev = 0;
   const int innerIters = 50;
-  constexpr size_t msgSizeBytes = msgSizeMB * 1024 * 1024;
+  constexpr size_t msgSizeBytes = msgSizeKB * 1024;
   constexpr size_t count = msgSizeBytes / sizeof(int);
 
   CHECK_EQ(cudaSetDevice(cudaDev), cudaSuccess);
@@ -152,7 +152,7 @@ static void ReduceKernelPerf(uint32_t iters, folly::UserCounters& counters) {
   counters["processBwGBs"] =
       folly::UserMetric(processBwGBs, folly::UserMetric::Type::METRIC);
   counters["msgSizeMB"] =
-      folly::UserMetric(msgSizeMB, folly::UserMetric::Type::METRIC);
+      folly::UserMetric(msgSizeKB / 1024.0, folly::UserMetric::Type::METRIC);
   counters["nGroups"] =
       folly::UserMetric(nGroups, folly::UserMetric::Type::METRIC);
   counters["nSrcs"] = folly::UserMetric(nSrcs, folly::UserMetric::Type::METRIC);
@@ -164,48 +164,60 @@ static void ReduceKernelPerf(uint32_t iters, folly::UserCounters& counters) {
 //------------------------------------------------------------------------------
 
 // Macro to define and register a benchmark
-// msgSizeMB: message size in megabytes
+// msgSizeKB: message size in kilobytes
 // nGroups: number of thread block groups
 // nSrcs: number of source buffers
 // nDsts: number of destination buffers
-#define DEFINE_REDUCE_BENCH(msgSizeMB, nGroups, nSrcs, nDsts)                      \
-  static void                                                                      \
-  ReduceKernelPerf_##msgSizeMB##MB_##nGroups##g_##nSrcs##src_##nDsts##dst_Sum(     \
-      uint32_t iters, folly::UserCounters& counters) {                             \
-    ReduceKernelPerf<msgSizeMB, nGroups, nSrcs, nDsts, commSum>(                   \
-        iters, counters);                                                          \
-  }                                                                                \
-  BENCHMARK_COUNTERS(                                                              \
-      ReduceKernelPerf_##msgSizeMB##MB_##nGroups##g_##nSrcs##src_##nDsts##dst_Sum, \
-      counters) {                                                                  \
-    ReduceKernelPerf_##msgSizeMB##MB_##nGroups##g_##nSrcs##src_##nDsts##dst_Sum(   \
-        1, counters);                                                              \
+#define DEFINE_REDUCE_BENCH(msgSizeKB, label, nGroups, nSrcs, nDsts)         \
+  static void                                                                \
+  ReduceKernelPerf_##label##_##nGroups##g_##nSrcs##src_##nDsts##dst_Sum(     \
+      uint32_t iters, folly::UserCounters& counters) {                       \
+    ReduceKernelPerf<msgSizeKB, nGroups, nSrcs, nDsts, commSum>(             \
+        iters, counters);                                                    \
+  }                                                                          \
+  BENCHMARK_COUNTERS(                                                        \
+      ReduceKernelPerf_##label##_##nGroups##g_##nSrcs##src_##nDsts##dst_Sum, \
+      counters) {                                                            \
+    ReduceKernelPerf_##label##_##nGroups##g_##nSrcs##src_##nDsts##dst_Sum(   \
+        1, counters);                                                        \
   }
 
 // Macro to define all src/dst combinations for a given message size and groups
 // Only 2 src, 1 dst and 2 src, 2 dst are needed
-#define DEFINE_REDUCE_BENCH_ALL_SRCDST(msgSizeMB, nGroups) \
-  DEFINE_REDUCE_BENCH(msgSizeMB, nGroups, 2, 1)            \
-  DEFINE_REDUCE_BENCH(msgSizeMB, nGroups, 2, 2)
+#define DEFINE_REDUCE_BENCH_ALL_SRCDST(msgSizeKB, label, nGroups) \
+  DEFINE_REDUCE_BENCH(msgSizeKB, label, nGroups, 2, 1)            \
+  DEFINE_REDUCE_BENCH(msgSizeKB, label, nGroups, 2, 2)
 
 // Macro to define all group counts for a given message size
-#define DEFINE_REDUCE_BENCH_ALL_GROUPS(msgSizeMB) \
-  DEFINE_REDUCE_BENCH_ALL_SRCDST(msgSizeMB, 2)    \
-  DEFINE_REDUCE_BENCH_ALL_SRCDST(msgSizeMB, 4)    \
-  DEFINE_REDUCE_BENCH_ALL_SRCDST(msgSizeMB, 8)
+#define DEFINE_REDUCE_BENCH_ALL_GROUPS(msgSizeKB, label) \
+  DEFINE_REDUCE_BENCH_ALL_SRCDST(msgSizeKB, label, 2)    \
+  DEFINE_REDUCE_BENCH_ALL_SRCDST(msgSizeKB, label, 4)    \
+  DEFINE_REDUCE_BENCH_ALL_SRCDST(msgSizeKB, label, 8)
 
 //------------------------------------------------------------------------------
 // Benchmark Definitions
 //------------------------------------------------------------------------------
 
+// 256KB message size with 2, 4, 8 groups
+DEFINE_REDUCE_BENCH_ALL_GROUPS(256, 256KB)
+
+// 512KB message size with 2, 4, 8 groups
+DEFINE_REDUCE_BENCH_ALL_GROUPS(512, 512KB)
+
+// 1MB message size with 2, 4, 8 groups
+DEFINE_REDUCE_BENCH_ALL_GROUPS(1024, 1MB)
+
+// 2MB message size with 2, 4, 8 groups
+DEFINE_REDUCE_BENCH_ALL_GROUPS(2048, 2MB)
+
 // 4MB message size with 2, 4, 8 groups
-DEFINE_REDUCE_BENCH_ALL_GROUPS(4)
+DEFINE_REDUCE_BENCH_ALL_GROUPS(4096, 4MB)
 
 // 8MB message size with 2, 4, 8 groups
-DEFINE_REDUCE_BENCH_ALL_GROUPS(8)
+DEFINE_REDUCE_BENCH_ALL_GROUPS(8192, 8MB)
 
 // 16MB message size with 2, 4, 8 groups
-DEFINE_REDUCE_BENCH_ALL_GROUPS(16)
+DEFINE_REDUCE_BENCH_ALL_GROUPS(16384, 16MB)
 
 int main(int argc, char** argv) {
   CHECK_GE(bench_utils::getNumCudaDevices(), 1);


### PR DESCRIPTION
Summary:
Add 256KB, 512KB, 1MB, and 2MB message sizes to ReduceKernelBench.
These correspond to the AllReduceRing chunk sizes selected by AutoTune
on GB200 (Default/Blackwell tier) at message sizes 16M-64M.

The previous smallest size (4MB) was insufficient for calibrating the
CTRAN AllReduceRing bounds model on GB200 where AutoTune produces
512K-2M chunks due to kDefaultMaxBDP=128MB and pipeline depth=4.

Changes:
- Refactor template parameter from `msgSizeMB` (MB, integer) to
  `msgSizeKB` (KB, integer) to support sub-MB sizes
- Add `label` parameter to macros for readable benchmark names
  (e.g. `ReduceKernelPerf_512KB_8g_2src_2dst_Sum`)
- Report `msgSizeMB` counter as `msgSizeKB / 1024.0` (float) for
  backward compatibility with existing analysis scripts
- Existing 4MB/8MB/16MB benchmarks produce identical results

Reviewed By: Scusemua

Differential Revision: D94926345


