### PR TITLE
Fix P2pNvlTransportTest compilation error: return type mismatch

### DIFF
--- a/comms/pipes/tests/P2pNvlTransportTest.cc
+++ b/comms/pipes/tests/P2pNvlTransportTest.cc
@@ -227,12 +227,19 @@ class TransportTestHelper {
     // cannot be copy-assigned
     p2pHost_ = std::make_unique<P2pNvlTransportDevice>(
         transport_->buildP2pTransportDevice(peerRank_));
+
+    p2pDevice_ = std::make_unique<DeviceBuffer>(sizeof(P2pNvlTransportDevice));
+    CUDACHECK_TEST(cudaMemcpy(
+        p2pDevice_->get(),
+        p2pHost_.get(),
+        sizeof(P2pNvlTransportDevice),
+        cudaMemcpyHostToDevice));
   }
 
   // Returns pointer to preallocated P2pNvlTransportDevice on device
   // This pointer is managed by MultiPeerNvlTransport
   P2pNvlTransportDevice* getDevicePtr() {
-    return transport_->getP2pTransportDevice(peerRank_);
+    return static_cast<P2pNvlTransportDevice*>(p2pDevice_->get());
   }
 
   // Returns reference to host copy (for accessing state pointers from host)
@@ -255,6 +262,7 @@ class TransportTestHelper {
   std::shared_ptr<meta::comms::MpiBootstrap> bootstrap_;
   std::unique_ptr<MultiPeerNvlTransport> transport_;
   std::unique_ptr<P2pNvlTransportDevice> p2pHost_;
+  std::unique_ptr<DeviceBuffer> p2pDevice_;
 };
 
 // =============================================================================


### PR DESCRIPTION
Summary:
## Problem

`TransportTestHelper::getDevicePtr()` in `P2pNvlTransportTest.cc` declares return type `P2pNvlTransportDevice*` but calls `transport_->getP2pTransportDevice(peerRank_)`, which just returns a `P2pNvlTransportDevice` by value. This causes the compilation error:

```sh
error: no viable conversion from returned value of type 'P2pNvlTransportDevice' to function return type 'P2pNvlTransportDevice *'
```

## Solution

The CUDA test kernels (e.g., `testSendKernel` in `P2pNvlTransportTest.cu`) take `P2pNvlTransportDevice*` and dereference it on the GPU, so the pointer must point to device memory. The fix needs to allocate device memory, copy the host-built transport device into it, and return that device pointer. So, I modified `TransportTestHelper` in `comms/pipes/tests/P2pNvlTransportTest.cc` as follows:

1. Add a `DeviceBuffer` member (`p2pDevice_`) to hold device memory for the `P2pNvlTransportDevice`.
2. In the constructor, after building `p2pHost_`, allocate device memory and `cudaMemcpy` the host transport into it.
3. Change `getDevicePtr()` to return a pointer into the device buffer.

Differential Revision: D96149995


