### PR TITLE
Fix [[nodiscard]] build errors and BUCK deps in torchcomms

### DIFF
--- a/comms/ctran/backends/ib/ibutils.cc
+++ b/comms/ctran/backends/ib/ibutils.cc
@@ -141,7 +141,7 @@ void IbUtils::linkDownSetTimeout(const std::string& devName, const int port) {
   timeoutThread_ = std::thread{[=, this]() {
     // Set cuda device for the thread so that logging can correctly
     // identify the local rank of the thread.
-    cudaSetDevice(device);
+    (void)cudaSetDevice(device);
     commNamedThreadStart("IBtimeoutHandler");
     timeoutHandler(this, std::chrono::milliseconds(timeoutMs), devName, port);
   }};

--- a/comms/ctran/utils/LogInit.cc
+++ b/comms/ctran/utils/LogInit.cc
@@ -46,7 +46,7 @@ void initCtranLoggingImpl() {
               meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)),
           .threadContextFn = []() {
             int cudaDev = -1;
-            cudaGetDevice(&cudaDev);
+            (void)cudaGetDevice(&cudaDev);
             return cudaDev;
           }});
   // Init logging for CTRAN header
@@ -60,7 +60,7 @@ void initCtranLoggingImpl() {
               meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)),
           .threadContextFn = []() {
             int cudaDev = -1;
-            cudaGetDevice(&cudaDev);
+            (void)cudaGetDevice(&cudaDev);
             return cudaDev;
           }});
 #if defined(USE_ROCM)
@@ -74,7 +74,7 @@ void initCtranLoggingImpl() {
               meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)),
           .threadContextFn = []() {
             int cudaDev = -1;
-            cudaGetDevice(&cudaDev);
+            (void)cudaGetDevice(&cudaDev);
             return cudaDev;
           }});
 #endif

--- a/comms/rcclx/develop/src/misc/cudawrap.cc
+++ b/comms/rcclx/develop/src/misc/cudawrap.cc
@@ -279,13 +279,13 @@ static void initOnceFunc() {
    * This is a workaround needed in CUDA 12.2 and CUDA 12.3 which is fixed in 12.4. */
   if (ncclCuMemSupported && ncclCuMemHostEnable() && 12020 <= driverVersion && driverVersion <= 12030) {
     int deviceCnt, saveDevice;
-    cudaGetDevice(&saveDevice);
-    cudaGetDeviceCount(&deviceCnt);
+    (void)cudaGetDevice(&saveDevice);
+    (void)cudaGetDeviceCount(&deviceCnt);
     for (int i = 0; i < deviceCnt; ++i) {
-      cudaSetDevice(i);
-      cudaFree(NULL);
+      (void)cudaSetDevice(i);
+      (void)cudaFree(NULL);
     }
-    cudaSetDevice(saveDevice);
+    (void)cudaSetDevice(saveDevice);
   }
   initResult = ret;
   return;

--- a/comms/rcclx/develop/src/register/register.cc
+++ b/comms/rcclx/develop/src/register/register.cc
@@ -307,7 +307,7 @@ ncclResult_t ncclCommWindowRegister_impl(ncclComm_t comm, void* buff, size_t siz
 exit:
   ncclGroupErrCheck(ret);
   NCCLCHECK(ret = ncclGroupEndInternal());
-  cudaSetDevice(saveDev);
+  (void)cudaSetDevice(saveDev);
   return ret;
 fail:
   free(*win);


### PR DESCRIPTION
Summary:
ROCm 7.0+ HIP headers annotate API functions (hipStreamDestroy,
hipMemcpyAsync, hipStreamSynchronize, hipSetDevice, hipGetDevice, hipFree,
hipHostUnregister) with [[nodiscard]]. Combined with -Werror, this causes
build failures wherever return values are discarded.

Add (void) casts to suppress [[nodiscard]] warnings across comms/
(tcp_devmem, ctran, rcclx). Fix BUCK dependency issues in
comms/tcp_devmem/nccl (replace devmgr-client with common:common)
and comms/tcp_devmem/unpack (explicit glog dep path).

The (void) casts are no-ops on CUDA and older ROCm — safe to land
regardless of ROCm version.

ghstack-source-id: 0

Reviewed By: bbeckca, kapilsh

Differential Revision: D96004718


