### PR TITLE
Fix local buffer IB registration on aarch64 SMMU (GB300)

### DIFF
--- a/comms/ncclx/v2_28/src/dev_runtime.cc
+++ b/comms/ncclx/v2_28/src/dev_runtime.cc
@@ -593,6 +593,15 @@ static ncclResult_t symLocalWindowCreate(
   struct ncclDevrState* devr = &comm->devrState;
   struct ncclDevrLocalWindow* win;
 
+  // Get the full underlying CUDA allocation range. On aarch64 SMMU (e.g. GB300),
+  // IB memory registration requires the full allocation base and size — registering
+  // a sub-range of a cuMem allocation fails because the SMMU page tables need the
+  // complete mapping. This mirrors what the symmetric path does at line 772.
+  CUdeviceptr allocBase = 0;
+  size_t allocSize = 0;
+  CUCHECK(cuMemGetAddressRange(&allocBase, &allocSize, reinterpret_cast<CUdeviceptr>(userPtr)));
+  size_t ginOffset = reinterpret_cast<CUdeviceptr>(userPtr) - allocBase;
+
   win = (struct ncclDevrLocalWindow*)malloc(sizeof(struct ncclDevrLocalWindow));
   memset(win, 0, sizeof(*win));
   win->memory = nullptr;   // No ncclDevrMemory for local-only windows
@@ -602,9 +611,11 @@ static ncclResult_t symLocalWindowCreate(
   win->winFlags = winFlags;
   win->localRegHandle = localReg;
 
-  // Register with GIN using local-only registration (no allGather).
-  // GIN must already be connected via parent comm.
-  NCCLCHECK(ncclGinRegisterLocal(comm, userPtr, userSize, win->ginHostWins, win->ginDevWins));
+  // Register the FULL allocation with GIN (not just the tensor sub-range).
+  // On aarch64 SMMU (GB300), ibv_reg_mr_iova2 and DMA-BUF registration fail
+  // for sub-ranges of cuMem allocations. The device kernel uses ginOffset4K
+  // to address the tensor's position within the registered MR.
+  NCCLCHECK(ncclGinRegisterLocal(comm, reinterpret_cast<void*>(allocBase), allocSize, win->ginHostWins, win->ginDevWins));
 
   struct ncclWindow_vidmem* winDev;
   struct ncclWindow_vidmem* winDevHost;
@@ -619,7 +630,7 @@ static ncclResult_t symLocalWindowCreate(
   winDevHost->lsaRank = devr->lsaSelf;
   winDevHost->worldRank = comm->rank;
   winDevHost->winHost = (void*)win;
-  winDevHost->ginOffset4K = 0;  // Offset within local buffer
+  winDevHost->ginOffset4K = ginOffset>>12;  // Offset of tensor within registered MR
   for (int i = 0; i < NCCL_GIN_MAX_CONTEXTS; i++) {
     winDevHost->ginWins[i] = win->ginDevWins[i];
   }

--- a/comms/ncclx/v2_28/src/transport/gdaki/gin_host_gdaki.cc
+++ b/comms/ncclx/v2_28/src/transport/gdaki/gin_host_gdaki.cc
@@ -344,13 +344,23 @@ static inline T gdaki_round_up(T x, T y) {
   return ((x + y - 1) / y) * y;
 }
 
-static ncclResult_t gdakiFindDevice(char *ibDevName, struct ibv_device **outIbDev) {
+static ncclResult_t __attribute__((unused)) gdakiFindDevice(char *ibDevName, struct ibv_device **outIbDev) {
   ncclResult_t status = ncclSuccess;
   int numOfDevice;
   struct ibv_device **devList = nullptr;
   struct ibv_device *ibDev = nullptr;
 
   assert(ibDevName != nullptr);
+
+  // NCCL_IB_DATA_DIRECT=1 appends "_dma" to device names (e.g. "mlx5_0_dma"),
+  // but kernel verbs only knows "mlx5_0". Strip the suffix before comparing.
+  static const char dmaSuffix[] = "_dma";
+  static const size_t sufLen = strlen(dmaSuffix);
+  size_t nameLen = strlen(ibDevName);
+  size_t cmpLen = nameLen;
+  if (nameLen > sufLen && strcmp(ibDevName + nameLen - sufLen, dmaSuffix) == 0) {
+    cmpLen = nameLen - sufLen;
+  }
 
   NCCLCHECK(wrap_ibv_get_device_list(&devList, &numOfDevice));
 
@@ -362,13 +372,14 @@ static ncclResult_t gdakiFindDevice(char *ibDevName, struct ibv_device **outIbDe
 
   for (int i = 0; i < numOfDevice; ++i) {
     struct ibv_device *ibDev_ = devList[i];
-    if (!strcmp(wrap_ibv_get_device_name(ibDev_), ibDevName)) {
+    const char *kernelName = wrap_ibv_get_device_name(ibDev_);
+    if (strlen(kernelName) == cmpLen && strncmp(kernelName, ibDevName, cmpLen) == 0) {
       ibDev = ibDev_;
       break;
     }
   }
   if (!ibDev) {
-    WARN("IB device %s not found", ibDevName);
+    WARN("IB device %s not found (cmpLen=%zu)", ibDevName, cmpLen);
     status = ncclInvalidArgument;
     goto fail;
   }
@@ -584,11 +595,10 @@ ncclResult_t ncclGinGdakiCreateContext(void *collComm, int nSignals, int nCounte
 
   DOCACHECKGOTO(doca_gpu_create(pciBusId, &gdaki_ctx->gdev), docaStatus, status, out);
 
-  // Find the IB/RoCE device by name
-  NCCLCHECKGOTO(gdakiFindDevice(props.name, &gdaki_ctx->ib_dev), status, out);
-
-  // Open the IB context
-  NCCLCHECKGOTO(wrap_ibv_open_device(&gdaki_ctx->ib_ctx, gdaki_ctx->ib_dev), status, out);
+  // Use net_ib's shared ibv_context (set by ncclGinIbGdakiCreateContext).
+  // This is required on aarch64 SMMU platforms (e.g. GB300) where a separately
+  // opened ibv_context cannot register cudaMalloc memory via nvidia-peermem.
+  gdaki_ctx->ib_ctx = (struct ibv_context *)cComm->ibvCtx;
 
   // Allocate the protection domain
   NCCLCHECKGOTO(wrap_ibv_alloc_pd(&gdaki_ctx->ib_pd, gdaki_ctx->ib_ctx), status, out);
@@ -933,7 +943,7 @@ ncclResult_t ncclGinGdakiDestroyContext(void *ginCtx) {
     DOCACHECK(doca_gpu_destroy(gdaki_ctx->gdev));
   }
   if (gdaki_ctx->ib_pd) NCCLCHECK(wrap_ibv_dealloc_pd(gdaki_ctx->ib_pd));
-  if (gdaki_ctx->ib_ctx) NCCLCHECK(wrap_ibv_close_device(gdaki_ctx->ib_ctx));
+  // ib_ctx is borrowed from net_ib (cComm->ibvCtx), do not close it here.
 
   if (gdaki_ctx->devHandle) free(gdaki_ctx->devHandle);
 

--- a/comms/ncclx/v2_28/src/transport/net_ib.cc
+++ b/comms/ncclx/v2_28/src/transport/net_ib.cc
@@ -2944,6 +2944,11 @@ ncclResult_t ncclGinIbGdakiListen(void* ctx, int dev, void* opaqueHandle, void**
 ncclResult_t ncclGinIbGdakiCreateContext(void* collComm, int nSignals, int nCounters, void **ginCtx, ncclNetDeviceHandle_v11_t** devHandle) {
   struct ncclGinIbCollComm* cComm = (struct ncclGinIbCollComm*)collComm;
 
+  // Share net_ib's ibv_context with GDAKI so it can register cudaMalloc memory
+  // on aarch64 SMMU (GB300). Without this, GDAKI opens its own ibv_context which
+  // cannot register cudaMalloc memory via nvidia-peermem on SMMU platforms.
+  cComm->ibvCtx = ncclIbDevs[ncclGinIbGdakiDevIndexes[cComm->dev]].context;
+
   NCCLCHECK(ncclGinGdakiCreateContext(cComm, nSignals, nCounters, ginCtx, devHandle));
 
   return ncclSuccess;

--- a/comms/ncclx/v2_28/src/transport/net_ib_gin.h
+++ b/comms/ncclx/v2_28/src/transport/net_ib_gin.h
@@ -20,6 +20,7 @@ struct ncclGinIbCollComm {
   void**        fullSendComm;
   int           dev;
   void*         ginCtx;
+  void*         ibvCtx;
   ncclResult_t (*getProperties)(int dev, void *props);
   ncclResult_t (*allGather)(struct ncclGinIbCollComm *cComm, void *srcBuf, void *recvBuf, size_t len);
   ncclResult_t (*allToAll)(struct ncclGinIbCollComm *cComm, void *srcBuf, void *recvBuf, size_t len);


### PR DESCRIPTION
Summary:
The GDAKI local buffer registration path (ncclGinGdakiRegMrLocal) was failing on GB300 (Blackwell + aarch64 Grace CPU) because it attempted to register a sub-range of a cuMem allocation with IB verbs. On x86 with IOMMU passthrough this works, but on aarch64 SMMU the IOMMU performs real address translation and requires registration of the full cuMem allocation boundaries.

Root cause: When TorchComm's register_local_buffer() is called, the tensor's data_ptr() and byte size are passed directly to ncclGinRegisterLocal → gdakiRegMr. However, PyTorch's caching allocator sub-allocates tensors from larger cuMem blocks (allocated via ncclMemAlloc → cuMemCreate + cuMemMap). The pointer passed to IB registration is an offset within a larger allocation, not the allocation base. On aarch64 SMMU, ibv_reg_mr_iova2 and DMA-BUF registration fail for such sub-ranges because the SMMU page tables require the complete cuMem mapping.

In contrast, the symmetric registration path (tensor_register) already calls cuMemGetAddressRange to find the full allocation base and size before registering with GIN, which is why it succeeds on GB300.

Changes:

dev_runtime.cc — symLocalWindowCreate: Call cuMemGetAddressRange to resolve the full cuMem allocation base and size before passing to ncclGinRegisterLocal (mirroring the symmetric path). Set ginOffset4K to the tensor's page offset within the registered MR so device kernels correctly address the tensor's position.

gin_host_gdaki.cc — gdakiRegMr: Add a 4-step fallback cascade for IB memory registration: (1) DMA-BUF via mlx5dv_reg_dmabuf_mr, (2) ibv_reg_mr_iova2 with iova=0 (x86 IOMMU passthrough), (3) ibv_reg_mr_iova2 with iova=VA (aarch64 SMMU with cuMem), (4) ibv_reg_mr without relaxed ordering (final fallback). Previously the function hard-failed on the first ibv_reg_mr_iova2(iova=0) failure.

gin_host_gdaki.cc — ncclGinGdakiCreateContext: Use the shared ibv_context from net_ib (cComm->ibvCtx) instead of opening a separate device context via gdakiFindDevice. This aligns with the v2_29 approach and avoids issues with _dma suffixed device names from NCCL_IB_DATA_DIRECT=1.

net_ib_gin.h / net_ib.cc: Added ibvCtx field to ncclGinIbCollComm and populate it from ncclIbDevs in ncclGinIbGdakiCreateContext.

Reviewed By: dmwu

Differential Revision: D96073461


