### PR TITLE
Add algo parameter to ctranGroupEndHook

### DIFF
--- a/comms/ctran/Ctran.h
+++ b/comms/ctran/Ctran.h
@@ -67,8 +67,10 @@ void ctranSendRecvCleanOpGroup();
 
 commResult_t ctranGroupEndHook(
     std::deque<OpElem*>& opGroup,
+    enum NCCL_SENDRECV_ALGO algo,
     std::optional<std::chrono::milliseconds> timeout = std::nullopt);
 commResult_t ctranGroupEndHook(
+    enum NCCL_SENDRECV_ALGO algo,
     std::optional<std::chrono::milliseconds> timeout = std::nullopt);
 
 bool ctranAllGatherSupport(CtranComm* comm, enum NCCL_ALLGATHER_ALGO algo);

--- a/comms/ctran/algos/SendRecv/SendRecv.cc
+++ b/comms/ctran/algos/SendRecv/SendRecv.cc
@@ -101,8 +101,8 @@ commResult_t ctranRecv(
 }
 
 commResult_t ctranGroupEndHook(
+    enum NCCL_SENDRECV_ALGO algo,
     std::optional<std::chrono::milliseconds> timeout) {
-  auto algo = NCCL_SENDRECV_ALGO;
   // By default, use zero-copy kernel for sendrecv.
   if (algo == NCCL_SENDRECV_ALGO::ctran) {
     algo = NCCL_SENDRECV_ALGO::ctzcopy;

--- a/comms/ctran/tests/CtranDistSendRecvUT.cc
+++ b/comms/ctran/tests/CtranDistSendRecvUT.cc
@@ -198,7 +198,7 @@ class CtranTestFixture : public NcclxBaseTest, public CtranBaseTest {
 
       // Indicating end of group
       commGroupDepth--;
-      EXPECT_EQ(ctranGroupEndHook(), commSuccess);
+      EXPECT_EQ(ctranGroupEndHook(NCCL_SENDRECV_ALGO), commSuccess);
       CUDACHECK_TEST(cudaStreamSynchronize(stream));
 
       if (doSendRecv) {

--- a/comms/ctran/tests/CtranSendRecvTest.cc
+++ b/comms/ctran/tests/CtranSendRecvTest.cc
@@ -120,7 +120,7 @@ class CtranSendRecvTest : public CtranIntraProcessFixture {
               state.ctranComm.get(),
               state.stream));
     }
-    EXPECT_EQ(commSuccess, ctranGroupEndHook(timeout));
+    EXPECT_EQ(commSuccess, ctranGroupEndHook(NCCL_SENDRECV_ALGO, timeout));
 
     // ensure async execution completion and no error
     EXPECT_EQ(cudaSuccess, cudaStreamSynchronize(state.stream));

--- a/comms/ncclx/v2_27/src/group.cc
+++ b/comms/ncclx/v2_27/src/group.cc
@@ -14,6 +14,7 @@
 #include "bootstrap.h"
 
 #include "comms/ctran/Ctran.h"
+#include "meta/algoconf/AlgoConfig.h"
 #include "meta/transport/transportExt.h"
 #include "meta/transport/transportConnect.h"
 #include "meta/transport/transportProxy.h"
@@ -692,7 +693,7 @@ ncclResult_t ncclGroupEndInternal(ncclSimInfo_t* simInfo) {
 
   if ((--ncclGroupDepth) > 0) goto exit;
 
-  NCCLCHECKGOTO(metaCommToNccl(ctranGroupEndHook()), ret, fail);
+  NCCLCHECKGOTO(metaCommToNccl(ctranGroupEndHook(ncclx::algoconf::getSendRecvAlgo())), ret, fail);
 
   if ((ret = ncclGroupError) != ncclSuccess) goto fail;
 

--- a/comms/ncclx/v2_28/src/group.cc
+++ b/comms/ncclx/v2_28/src/group.cc
@@ -17,6 +17,7 @@
 #include "nvtx.h"
 
 #include "comms/ctran/Ctran.h"
+#include "meta/algoconf/AlgoConfig.h"
 #include "meta/transport/transportExt.h"
 #include "meta/transport/transportConnect.h"
 #include "meta/transport/transportProxy.h"
@@ -693,7 +694,7 @@ ncclResult_t ncclGroupEndInternal(ncclSimInfo_t* simInfo) {
 
   if ((--ncclGroupDepth) > 0) goto exit;
 
-  NCCLCHECKGOTO(metaCommToNccl(ctranGroupEndHook()), ret, fail);
+  NCCLCHECKGOTO(metaCommToNccl(ctranGroupEndHook(ncclx::algoconf::getSendRecvAlgo())), ret, fail);
 
   if ((ret = ncclGroupError) != ncclSuccess) goto fail;
 

--- a/comms/ncclx/v2_29/src/group.cc
+++ b/comms/ncclx/v2_29/src/group.cc
@@ -21,6 +21,7 @@
 #include "argcheck.h"
 
 #include "comms/ctran/Ctran.h"
+#include "meta/algoconf/AlgoConfig.h"
 #include "meta/transport/transportExt.h"
 #include "meta/transport/transportConnect.h"
 #include "meta/transport/transportProxy.h"
@@ -783,7 +784,7 @@ ncclResult_t ncclGroupEndInternal(ncclSimInfo_t* simInfo) {
 
   if ((--ncclGroupDepth) > 0) goto exit;
 
-  NCCLCHECKGOTO(metaCommToNccl(ctranGroupEndHook()), ret, fail);
+  NCCLCHECKGOTO(metaCommToNccl(ctranGroupEndHook(ncclx::algoconf::getSendRecvAlgo())), ret, fail);
 
   if ((ret = ncclGroupError) != ncclSuccess) goto fail;
 


### PR DESCRIPTION
Summary:
ctranGroupEndHook previously read the sendrecv algorithm internally via the raw NCCL_SENDRECV_ALGO CVAR, bypassing the AlgoConfig singleton that ncclSend/ncclRecv use at the entry point. This meant runtime hint overrides set via GlobalHints had no effect on sub-algorithm selection.

Add a required `enum NCCL_SENDRECV_ALGO algo` parameter to ctranGroupEndHook so the caller owns the algo decision. NCCLx callsites pass ncclx::algoconf::getSendRecvAlgo() (which respects GlobalHints), while MCCL and test callsites pass the CVAR directly, matching their existing patterns.

Differential Revision: D96069749


