### PR TITLE
Fix allgatherp test failures on devgpu (#1031)

### DIFF
--- a/comms/ctran/tests/CtranDistAllgatherPTests.cc
+++ b/comms/ctran/tests/CtranDistAllgatherPTests.cc
@@ -58,6 +58,7 @@ class CtranAllgatherPTest : public ctran::CtranDistTestFixture {
 
   void SetUp() override {
     setenv("NCCL_CTRAN_ENABLE", "1", 0);
+    setenv("NCCL_CTRAN_IPC_REGCACHE_ENABLE_ASYNC_SOCKET", "1", 0);
     CtranDistTestFixture::SetUp();
 
     CUDACHECK_TEST(cudaStreamCreate(&stream));
@@ -572,6 +573,13 @@ TEST_F(CtranAllgatherPTest, SharePersistentBuffer) {
   // Release resources
   for (int r = 0; r < requests.size(); r++) {
     ASSERT_EQ(ctran::allGatherPDestroy(requests[r]), commSuccess);
+  }
+
+  // Destroy test comms before deregistering buffers, since comm destruction
+  // releases IPC exports that reference the registered buffers
+  testComms.clear();
+  for (int c = 0; c < kComms; c++) {
+    CUDACHECK_TEST(cudaStreamDestroy(streams[c]));
   }
 
   // deregister buffers

--- a/comms/ctran/tests/CtranDistTestUtils.cc
+++ b/comms/ctran/tests/CtranDistTestUtils.cc
@@ -245,7 +245,8 @@ std::vector<std::string> CtranDistTestFixture::exchangeInitUrls(
 
 std::unique_ptr<CtranComm> CtranDistTestFixture::makeCtranComm() {
   const auto initType = getInitEnvType();
-  const std::string uuid{"0"};
+  const auto commId = testCount_.fetch_add(1);
+  const std::string uuid = std::to_string(commId);
   uint64_t commHash =
       ctran::utils::getHash(uuid.data(), static_cast<int>(uuid.size()));
   std::string commDesc = fmt::format("CtranTestComm-{}", globalRank);
@@ -317,7 +318,7 @@ std::unique_ptr<CtranComm> CtranDistTestFixture::makeCtranComm() {
 
     // Initialize the bootstrap with all URLs
     // void init(urls, myRank, uuid, abort, timeout)
-    bootstrap->init(urlVec, static_cast<size_t>(globalRank), 0 /* uuid */);
+    bootstrap->init(urlVec, static_cast<size_t>(globalRank), commId /* uuid */);
 
     comm->bootstrap_ =
         std::make_unique<mccl::bootstrap::CtranAdapter>(bootstrap);


### PR DESCRIPTION
Summary:

Fix three issues causing ctran_dist_allgatherp_1x8_init_ring_hybrid test failures:

1. Enable NCCL_CTRAN_IPC_REGCACHE_ENABLE_ASYNC_SOCKET in test SetUp. Without
this, the CtranMapper destructor hits a fatal assertion when IPC-exported memory
needs to be released but the async socket mechanism is disabled.

2. Use unique per-communicator UUID and commHash in makeCtranComm() instead of
hardcoded "0". When SharePersistentBuffer creates 20 communicators, they all
shared the same bootstrap UUID, causing connection conflicts between different
communicator bootstraps (quorum mismatches, stale TCPStore keys).

3. Fix SharePersistentBuffer cleanup order. The test was destroying testComms
after deregistering buffers from ctranComm, causing a use-after-free SIGSEGV in
IpcRegCache::remReleaseMem during mapper destruction. Now testComms are destroyed
before buffer deregistration.

Reviewed By: dsjohns2

Differential Revision: D96178454


