### PR TITLE
Implement NCCL_CTRAN_PIPES_DISABLE_IB in MultiPeerTransport (#1033)

### DIFF
--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -77,6 +77,8 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
           static_cast<uint8_t>(NCCL_CTRAN_IBGDA_RNR_RETRY);
     }
 
+    config.disableIb = NCCL_CTRAN_PIPES_DISABLE_IB;
+
     // Topology config: MNNVL mode and overrides
     config.topoConfig.mnnvlMode =
         static_cast<comms::pipes::MnnvlMode>(NCCL_MNNVL_ENABLE);

--- a/comms/pipes/MultiPeerTransport.cc
+++ b/comms/pipes/MultiPeerTransport.cc
@@ -7,6 +7,7 @@
 #include <stdexcept>
 
 #include <cuda_runtime.h>
+#include <glog/logging.h>
 
 #include "comms/pipes/MultiPeerDeviceHandle.cuh"
 #include "comms/pipes/MultipeerIbgdaDeviceTransport.cuh"
@@ -46,14 +47,23 @@ MultiPeerTransport::MultiPeerTransport(
     int nRanks,
     int deviceId,
     std::shared_ptr<meta::comms::IBootstrap> bootstrap,
-    const MultiPeerTransportConfig& config)
+    const MultiPeerTransportConfig& config,
+    std::optional<TopologyResult> topo)
     : myRank_(myRank),
       nRanks_(nRanks),
       deviceId_(deviceId),
       bootstrap_(std::move(bootstrap)) {
-  TopologyDiscovery topoDiscovery;
-  auto topo = topoDiscovery.discover(
-      myRank_, nRanks_, deviceId_, *bootstrap_, config.topoConfig);
+  if (!topo.has_value()) {
+    TopologyDiscovery topoDiscovery;
+    topo = topoDiscovery.discover(
+        myRank_, nRanks_, deviceId_, *bootstrap_, config.topoConfig);
+  }
+  initFromTopology(std::move(*topo), config);
+}
+
+void MultiPeerTransport::initFromTopology(
+    TopologyResult topo,
+    const MultiPeerTransportConfig& config) {
   nvlPeerRanks_ = std::move(topo.nvlPeerRanks);
   globalToNvlLocal_ = std::move(topo.globalToNvlLocal);
 
@@ -62,19 +72,42 @@ MultiPeerTransport::MultiPeerTransport(
   nvlLocalRank_ = globalToNvlLocal_.at(myRank_);
 
   typePerRank_.resize(nRanks_);
-  for (int r = 0; r < nRanks_; ++r) {
-    if (r == myRank_) {
-      typePerRank_[r] = TransportType::SELF;
-    } else if (globalToNvlLocal_.count(r)) {
-      typePerRank_[r] = TransportType::P2P_NVL;
-    } else {
-      typePerRank_[r] = TransportType::P2P_IBGDA;
-    }
-  }
 
-  for (int r = 0; r < nRanks_; ++r) {
-    if (r != myRank_) {
-      ibgdaPeerRanks_.push_back(r);
+  if (config.disableIb) {
+    // NVL-only mode: validate all non-self peers are NVL-reachable, then
+    // force every non-self rank to P2P_NVL. IBGDA is never constructed.
+    LOG(INFO) << "MultiPeerTransport: rank " << myRank_
+              << " IBGDA disabled by config, NVL-only mode";
+
+    for (int r = 0; r < nRanks_; ++r) {
+      if (r == myRank_) {
+        typePerRank_.at(r) = TransportType::SELF;
+      } else if (globalToNvlLocal_.count(r)) {
+        typePerRank_.at(r) = TransportType::P2P_NVL;
+      } else {
+        throw std::runtime_error(
+            "MultiPeerTransport: IBGDA disabled but rank " + std::to_string(r) +
+            " is not NVL-reachable from rank " + std::to_string(myRank_) +
+            ". All ranks must be in the same NVL domain when "
+            "NCCL_CTRAN_PIPES_DISABLE_IB=1.");
+      }
+    }
+    // ibgdaPeerRanks_ stays empty; ibgdaTransport_ stays nullptr.
+  } else {
+    for (int r = 0; r < nRanks_; ++r) {
+      if (r == myRank_) {
+        typePerRank_.at(r) = TransportType::SELF;
+      } else if (globalToNvlLocal_.count(r)) {
+        typePerRank_.at(r) = TransportType::P2P_NVL;
+      } else {
+        typePerRank_.at(r) = TransportType::P2P_IBGDA;
+      }
+    }
+
+    for (int r = 0; r < nRanks_; ++r) {
+      if (r != myRank_) {
+        ibgdaPeerRanks_.push_back(r);
+      }
     }
   }
 
@@ -94,7 +127,7 @@ MultiPeerTransport::MultiPeerTransport(
 
   // Always create IBGDA transport — it is the universal fallback for all peers.
   // NVL is preferred when available, but IBGDA covers every non-self rank.
-  if (nRanks_ > 1) {
+  if (!config.disableIb && nRanks_ > 1) {
     auto ibgdaConfig = config.ibgdaConfig;
     ibgdaConfig.cudaDevice = deviceId_;
     ibgdaTransport_ = std::make_unique<MultipeerIbgdaTransport>(

--- a/comms/pipes/MultiPeerTransport.h
+++ b/comms/pipes/MultiPeerTransport.h
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <unordered_map>
 #include <vector>
 
@@ -31,6 +32,10 @@ struct MultiPeerTransportConfig {
   // MNNVL topology overrides for UUID and clique ID.
   // See TopologyConfig for field-level documentation.
   TopologyConfig topoConfig;
+
+  // When true, IBGDA transport is never constructed and all non-self peers
+  // are routed over NVLink. Requires all ranks in the same NVL domain.
+  bool disableIb{false};
 };
 
 /**
@@ -56,12 +61,15 @@ struct MultiPeerTransportConfig {
  */
 class MultiPeerTransport {
  public:
+  /// When topo is provided, bypasses TopologyDiscovery and uses the
+  /// pre-computed topology directly (primarily for unit testing).
   MultiPeerTransport(
       int myRank,
       int nRanks,
       int deviceId,
       std::shared_ptr<meta::comms::IBootstrap> bootstrap,
-      const MultiPeerTransportConfig& config);
+      const MultiPeerTransportConfig& config,
+      std::optional<TopologyResult> topo = std::nullopt);
 
   ~MultiPeerTransport();
 
@@ -91,7 +99,7 @@ class MultiPeerTransport {
   /** @return True if IBGDA transport is available for peerRank (all non-self).
    */
   bool has_ibgda(int peerRank) const {
-    return peerRank != myRank_;
+    return ibgdaTransport_ != nullptr && peerRank != myRank_;
   }
 
   /** @return True if IBGDA is the preferred transport (no NVL available). */
@@ -242,6 +250,9 @@ class MultiPeerTransport {
   bool deviceHandleBuilt_{false};
 
   // --- Private helpers ---
+  void initFromTopology(
+      TopologyResult topo,
+      const MultiPeerTransportConfig& config);
   void build_device_handle();
   void free_device_handle();
 

--- a/comms/pipes/tests/MultiPeerTransportTest.cc
+++ b/comms/pipes/tests/MultiPeerTransportTest.cc
@@ -6,6 +6,7 @@
 
 #include <cuda.h>
 #include <cuda_runtime.h>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <folly/init/Init.h>
@@ -13,7 +14,9 @@
 #include "comms/pipes/GpuMemHandler.h"
 #include "comms/pipes/MultiPeerDeviceHandle.cuh"
 #include "comms/pipes/MultiPeerTransport.h"
+#include "comms/pipes/TopologyDiscovery.h"
 #include "comms/pipes/Transport.cuh"
+#include "comms/pipes/tests/MockBootstrap.h"
 #include "comms/testinfra/TestXPlatUtils.h"
 #include "comms/testinfra/mpi/MpiBootstrap.h"
 #include "comms/testinfra/mpi/MpiTestUtils.h"
@@ -50,6 +53,29 @@ class MultiPeerTransportTestFixture : public MpiBaseTestFixture {
             {
                 .cudaDevice = localRank,
             },
+    };
+    return std::make_unique<MultiPeerTransport>(
+        globalRank,
+        numRanks,
+        localRank,
+        std::make_shared<MpiBootstrap>(),
+        config);
+  }
+
+  std::unique_ptr<MultiPeerTransport> createDisableIbTransport() {
+    MultiPeerTransportConfig config{
+        .nvlConfig =
+            {
+                .dataBufferSize = 256 * 1024,
+                .chunkSize = 512,
+                .pipelineDepth = 4,
+                .p2pSignalCount = 4,
+            },
+        .ibgdaConfig =
+            {
+                .cudaDevice = localRank,
+            },
+        .disableIb = true,
     };
     return std::make_unique<MultiPeerTransport>(
         globalRank,
@@ -365,6 +391,206 @@ TEST_F(MultiPeerTransportTestFixture, ExchangeNvlBufferFabric) {
 #endif
 
   MPI_Barrier(MPI_COMM_WORLD);
+}
+
+// =============================================================================
+// disableIb tests — NVL-only mode
+// =============================================================================
+
+TEST_F(MultiPeerTransportTestFixture, DisableIb_AllPeersNvl) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "Requires >= 2 ranks, got " << numRanks;
+  }
+
+  auto transport = createDisableIbTransport();
+
+  // All non-self peers should be NVL (single-node setup).
+  for (int r = 0; r < numRanks; ++r) {
+    if (r == globalRank) {
+      EXPECT_EQ(transport->get_transport_type(r), TransportType::SELF);
+    } else {
+      EXPECT_EQ(transport->get_transport_type(r), TransportType::P2P_NVL)
+          << "Peer " << r << " should be P2P_NVL with disableIb";
+    }
+  }
+
+  EXPECT_TRUE(transport->ibgda_peer_ranks().empty());
+  for (int r = 0; r < numRanks; ++r) {
+    EXPECT_FALSE(transport->has_ibgda(r));
+  }
+
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
+TEST_F(MultiPeerTransportTestFixture, DisableIb_ExchangeSucceeds) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "Requires >= 2 ranks, got " << numRanks;
+  }
+
+  auto transport = createDisableIbTransport();
+
+  EXPECT_NO_THROW(transport->exchange());
+
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
+TEST_F(MultiPeerTransportTestFixture, DisableIb_DeviceHandleZeroIbPeers) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "Requires >= 2 ranks, got " << numRanks;
+  }
+
+  auto transport = createDisableIbTransport();
+
+  transport->exchange();
+  auto handle = transport->get_device_handle();
+
+  EXPECT_EQ(handle.myRank, globalRank);
+  EXPECT_EQ(handle.nRanks, numRanks);
+  EXPECT_EQ(handle.numIbPeers, 0);
+  EXPECT_GT(handle.numNvlPeers, 0);
+
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
+TEST_F(MultiPeerTransportTestFixture, DisableIb_NvlBufferExchange) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "Requires >= 2 ranks, got " << numRanks;
+  }
+
+  auto transport = createDisableIbTransport();
+  transport->exchange();
+
+  if (nvlSpansMultipleHosts(*transport)) {
+    GTEST_SKIP() << "cudaIpc does not work across hosts";
+  }
+
+  const size_t nbytes = 4096;
+  void* localBuf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&localBuf, nbytes));
+  CUDACHECK_TEST(cudaMemset(localBuf, globalRank + 1, nbytes));
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  auto mappedPtrs = transport->exchangeNvlBuffer(localBuf, nbytes);
+  verifyMappedPtrs(*transport, mappedPtrs, localBuf);
+
+  transport->unmapNvlBuffers(mappedPtrs);
+  CUDACHECK_TEST(cudaFree(localBuf));
+
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
+// =============================================================================
+// disableIb mock-based tests — pre-computed TopologyResult, no GPU/MPI needed
+// =============================================================================
+
+namespace {
+
+/// Build a TopologyResult where only the given NVL ranks are reachable.
+/// Self (myRank) is always included in globalToNvlLocal.
+TopologyResult makeTopology(int myRank, const std::vector<int>& nvlPeers) {
+  TopologyResult topo;
+  topo.nvlPeerRanks = nvlPeers;
+
+  int nvlIdx = 0;
+  topo.globalToNvlLocal[myRank] = nvlIdx++;
+  for (int peer : nvlPeers) {
+    topo.globalToNvlLocal[peer] = nvlIdx++;
+  }
+  return topo;
+}
+
+} // namespace
+
+TEST(MultiPeerTransportDisableIbTest, ThrowsWhenPeerNotNvlReachable) {
+  constexpr int kMyRank = 0;
+  constexpr int kNRanks = 3;
+
+  // Rank 1 is NVL-reachable, rank 2 is NOT.
+  auto topo = makeTopology(kMyRank, {1});
+
+  MultiPeerTransportConfig config{.disableIb = true};
+  auto bootstrap = std::make_shared<testing::MockBootstrap>();
+
+  EXPECT_THROW(
+      MultiPeerTransport(
+          kMyRank, kNRanks, /*deviceId=*/0, bootstrap, config, std::move(topo)),
+      std::runtime_error);
+}
+
+TEST(MultiPeerTransportDisableIbTest, ErrorMessageContainsRank) {
+  constexpr int kMyRank = 0;
+  constexpr int kNRanks = 2;
+
+  // No NVL peers — rank 1 is unreachable.
+  auto topo = makeTopology(kMyRank, {});
+
+  MultiPeerTransportConfig config{.disableIb = true};
+  auto bootstrap = std::make_shared<testing::MockBootstrap>();
+
+  try {
+    MultiPeerTransport(
+        kMyRank, kNRanks, /*deviceId=*/0, bootstrap, config, std::move(topo));
+    FAIL() << "Expected std::runtime_error";
+  } catch (const std::runtime_error& e) {
+    EXPECT_THAT(e.what(), ::testing::HasSubstr("not NVL-reachable"));
+    EXPECT_THAT(e.what(), ::testing::HasSubstr("rank 1"));
+  }
+}
+
+// Simulates the NCCL_P2P_DISABLE + NCCL_CTRAN_PIPES_DISABLE_IB scenario:
+// P2P disabled means topology discovery finds zero NVL peers, and disableIb
+// means IBGDA is also unavailable — every non-self peer is unreachable.
+TEST(MultiPeerTransportDisableIbTest, ThrowsWhenP2pDisabledAndIbDisabled) {
+  constexpr int kMyRank = 0;
+  constexpr int kNRanks = 4;
+
+  // Empty NVL peers simulates NCCL_P2P_DISABLE: no peer is NVL-reachable.
+  auto topo = makeTopology(kMyRank, {});
+
+  MultiPeerTransportConfig config{.disableIb = true};
+  auto bootstrap = std::make_shared<testing::MockBootstrap>();
+
+  try {
+    MultiPeerTransport(
+        kMyRank, kNRanks, /*deviceId=*/0, bootstrap, config, std::move(topo));
+    FAIL() << "Expected std::runtime_error when both P2P and IB are disabled";
+  } catch (const std::runtime_error& e) {
+    EXPECT_THAT(e.what(), ::testing::HasSubstr("not NVL-reachable"));
+    EXPECT_THAT(
+        e.what(), ::testing::HasSubstr("NCCL_CTRAN_PIPES_DISABLE_IB=1"));
+  }
+}
+
+TEST(MultiPeerTransportDisableIbTest, SucceedsWhenAllPeersNvl) {
+  constexpr int kMyRank = 0;
+  constexpr int kNRanks = 3;
+
+  // All peers NVL-reachable.
+  auto topo = makeTopology(kMyRank, {1, 2});
+
+  MultiPeerTransportConfig config{.disableIb = true};
+  auto bootstrap = std::make_shared<testing::MockBootstrap>();
+
+  // Construction succeeds up to the disableIb validation. NVL transport
+  // creation may fail without GPU — we catch that; the validation itself
+  // is what we're testing.
+  try {
+    MultiPeerTransport transport(
+        kMyRank, kNRanks, /*deviceId=*/0, bootstrap, config, std::move(topo));
+
+    for (int r = 0; r < kNRanks; ++r) {
+      if (r == kMyRank) {
+        EXPECT_EQ(transport.get_transport_type(r), TransportType::SELF);
+      } else {
+        EXPECT_EQ(transport.get_transport_type(r), TransportType::P2P_NVL);
+      }
+    }
+    EXPECT_TRUE(transport.ibgda_peer_ranks().empty());
+  } catch (const std::exception&) {
+    // NVL transport creation failed (expected without GPU).
+  }
 }
 
 } // namespace comms::pipes::tests


### PR DESCRIPTION
Summary:

Wire the NCCL_CTRAN_PIPES_DISABLE_IB CVAR through CtranPipes config into
MultiPeerTransport. When disableIb is true:
- Validate all non-self peers are NVL-reachable (throw otherwise)
- Force all typePerRank_ to P2P_NVL for non-self peers
- Skip ibgdaPeerRanks_ population and IBGDA transport creation
- Fix has_ibgda() to also check ibgdaTransport_ != nullptr

Add unit tests: DisableIb_AllPeersNvl, DisableIb_ExchangeSucceeds,
DisableIb_DeviceHandleZeroIbPeers, DisableIb_NvlBufferExchange.

Reviewed By: cenzhaometa

Differential Revision: D96086424
