### PR TITLE
Introduce NcclxGlobalApi framework (#1034)

### DIFF
--- a/comms/torchcomms/ncclx/NcclxGlobalApi.cpp
+++ b/comms/torchcomms/ncclx/NcclxGlobalApi.cpp
@@ -1,0 +1,12 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/torchcomms/ncclx/NcclxGlobalApi.hpp"
+
+namespace torch::comms {
+
+const char* DefaultNcclxGlobalApi::getErrorString(ncclResult_t result) {
+  std::lock_guard<std::mutex> lock(api_mutex_);
+  return ncclGetErrorString(result);
+}
+
+} // namespace torch::comms

--- a/comms/torchcomms/ncclx/NcclxGlobalApi.hpp
+++ b/comms/torchcomms/ncclx/NcclxGlobalApi.hpp
@@ -1,0 +1,38 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <mutex>
+#include <string>
+
+#include <nccl.h> // @manual=//comms/ncclx:nccl
+
+namespace torch::comms {
+
+/**
+ * Abstract interface for communicator-independent NCCL API operations.
+ * This allows for dependency injection and testing by providing
+ * a way to override global NCCL API calls.
+ */
+class NcclxGlobalApi {
+ public:
+  virtual ~NcclxGlobalApi() = default;
+
+  // Error handling
+  virtual const char* getErrorString(ncclResult_t result) = 0;
+};
+
+/**
+ * Default implementation that calls the underlying NCCL APIs directly.
+ */
+class DefaultNcclxGlobalApi : public NcclxGlobalApi {
+ public:
+  ~DefaultNcclxGlobalApi() override = default;
+
+  const char* getErrorString(ncclResult_t result) override;
+
+ private:
+  mutable std::mutex api_mutex_;
+};
+
+} // namespace torch::comms

--- a/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxGlobalMock.hpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxGlobalMock.hpp
@@ -1,0 +1,34 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <gmock/gmock.h>
+#include <nccl.h> // @manual
+#include "comms/torchcomms/ncclx/NcclxGlobalApi.hpp"
+
+namespace torch::comms::test {
+
+/**
+ * Mock implementation of NcclxGlobalApi using Google Mock.
+ */
+class NcclxGlobalMock : public NcclxGlobalApi {
+ public:
+  ~NcclxGlobalMock() override = default;
+
+  MOCK_METHOD(const char*, getErrorString, (ncclResult_t result), (override));
+
+  void setupDefaultBehaviors() {
+    using ::testing::_;
+    using ::testing::Return;
+
+    ON_CALL(*this, getErrorString(_))
+        .WillByDefault(Return("mock nccl error string"));
+  }
+
+  void reset() {
+    ::testing::Mock::VerifyAndClearExpectations(this);
+    setupDefaultBehaviors();
+  }
+};
+
+} // namespace torch::comms::test


### PR DESCRIPTION
Summary:

Introduce NcclxGlobalApi as an abstract interface for communicator-independent NCCL operations, mirroring the existing NcclxApi pattern:
- `NcclxGlobalApi` abstract class with `getErrorString` virtual method
- `DefaultNcclxGlobalApi` concrete implementation with mutex-guarded NCCL calls
- `NcclxGlobalMock` Google Mock class for unit testing
- BUCK targets: `ncclx-global-api` (cpp_library) and `nccl-global-mock` (header-only)

This framework will host `ncclCommDumpAll` and future comm-independent NCCL APIs in follow-up diffs.

Reviewed By: YulunW

Differential Revision: D95436687
