### PR TITLE
GPE cudagraph support

### DIFF
--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -58,20 +58,65 @@ CtranGpe::Impl::Impl() {
 
   this->gpeKernelSyncPool =
       std::make_unique<GpeKernelSyncPool>(NCCL_CTRAN_NUM_GPE_KERNEL_SYNCS);
-
-  FB_CUDACHECKTHROW_EX(
-      cudaEventCreateWithFlags(&execEvent_, cudaEventDisableTiming),
-      comm->logMetaData_);
-  FB_CUDACHECKTHROW_EX(
-      cudaStreamCreateWithFlags(&execOrderStream_, cudaStreamNonBlocking),
-      comm->logMetaData_);
-
-  return;
 }
 
-CtranGpe::Impl::~Impl() {
-  FB_CUDACHECKTHROW_EX(cudaEventDestroy(execEvent_), comm->logMetaData_);
-  FB_CUDACHECKTHROW_EX(cudaStreamDestroy(execOrderStream_), comm->logMetaData_);
+CtranGpe::Impl::~Impl() = default;
+
+void OrderedWorkStreamGuard::init(const CommLogData& logMetaData) {
+  logMetaData_ = &logMetaData;
+  FB_CUDACHECKTHROW_EX(
+      cudaEventCreateWithFlags(&execModeSyncEvent_, cudaEventDisableTiming),
+      logMetaData);
+}
+
+OrderedWorkStreamGuard::~OrderedWorkStreamGuard() {
+  FB_CHECKABORT(
+      logMetaData_ != nullptr,
+      "OrderedWorkStreamGuard destroyed without init()");
+  FB_CUDACHECKTHROW_EX(cudaEventDestroy(execModeSyncEvent_), *logMetaData_);
+}
+
+OrderedWorkStreamGuard::Scope::Scope(
+    OrderedWorkStreamGuard& guard,
+    cudaStream_t userStream,
+    const ctran::utils::cudagraph::StreamCaptureInfo& captureInfo)
+    : guard_(&guard), userStream_(userStream), captureInfo_(captureInfo) {
+  status_ = guard_->doAcquire(userStream_, captureInfo_);
+}
+
+OrderedWorkStreamGuard::Scope::~Scope() {
+  if (guard_) {
+    guard_->doRelease(userStream_, captureInfo_);
+  }
+}
+
+OrderedWorkStreamGuard::Scope::Scope(Scope&& other) noexcept
+    : guard_(other.guard_),
+      userStream_(other.userStream_),
+      captureInfo_(other.captureInfo_),
+      status_(other.status_) {
+  other.guard_ = nullptr;
+}
+
+OrderedWorkStreamGuard::Scope& OrderedWorkStreamGuard::Scope::operator=(
+    Scope&& other) noexcept {
+  if (this != &other) {
+    if (guard_) {
+      guard_->doRelease(userStream_, captureInfo_);
+    }
+    guard_ = other.guard_;
+    userStream_ = other.userStream_;
+    captureInfo_ = other.captureInfo_;
+    status_ = other.status_;
+    other.guard_ = nullptr;
+  }
+  return *this;
+}
+
+OrderedWorkStreamGuard::Scope OrderedWorkStreamGuard::acquire(
+    cudaStream_t userStream,
+    const ctran::utils::cudagraph::StreamCaptureInfo& captureInfo) {
+  return Scope(*this, userStream, captureInfo);
 }
 
 struct cmdCbPlan {
@@ -95,19 +140,83 @@ void CUDART_CB CtranGpe::Impl::cmdDestroy(void* data) {
   delete cmd;
 }
 
-commResult_t CtranGpe::Impl::preKernelLaunch(cudaStream_t curStream) {
-  // check if we can skip stream wait when posting kernels on the same stream
-  if (curStream == lastUserStream_) {
-    return commSuccess;
+commResult_t OrderedWorkStreamGuard::doAcquire(
+    cudaStream_t userStream,
+    const utils::cudagraph::StreamCaptureInfo& captureInfo) {
+  const bool isCapturing = captureInfo.status == cudaStreamCaptureStatusActive;
+
+  bool isNewCapture = isCapturing && captureInfo.id != lastCaptureId_;
+  if (isNewCapture) {
+    lastCaptureId_ = captureInfo.id;
+    everCaptured_ = true;
   }
-  lastUserStream_ = curStream;
-  // wait on previously enqueued CTRAN kernels
-  return streamWaitStream(curStream, execOrderStream_, execEvent_);
+
+  auto doWait = [&]() -> commResult_t {
+#if defined(__HIP_PLATFORM_AMD__)
+    unsigned int flags =
+        isCapturing ? hipEventWaitExternal : hipEventWaitDefault;
+#else
+    unsigned int flags =
+        isCapturing ? cudaEventWaitExternal : cudaEventWaitDefault;
+#endif
+    FB_CUDACHECK(cudaStreamWaitEvent(userStream, execModeSyncEvent_, flags));
+    return commSuccess;
+  };
+
+  if (lastUserStream_ == nullptr) {
+    if (isCapturing) {
+      return doWait();
+    }
+    return commSuccess; // first submit ever
+  }
+
+  if (userStream == lastUserStream_ && lastWasCaptured_ == isCapturing &&
+      !isCapturing) {
+    return commSuccess; // same stream, same mode, no capture -- ordering
+                        // implicit
+  }
+
+  if (isCapturing && !isNewCapture && lastWasCaptured_) {
+    // Intra-capture cross-stream: add the RECORD node from the previous
+    // doRelease as a capture dependency of this stream. This creates an
+    // explicit graph edge, since cudaStreamWaitEvent cannot see RECORD
+    // nodes added via cudaGraphAddEventRecordNode.
+#if defined(__HIP_PLATFORM_AMD__)
+    FB_CUDACHECK(cudaStreamUpdateCaptureDependencies(
+        userStream, &lastRecordNode_, 1, hipStreamAddCaptureDependencies));
+#elif CUDART_VERSION >= 13000
+    FB_CUDACHECK(cudaStreamUpdateCaptureDependencies(
+        userStream,
+        &lastRecordNode_,
+        nullptr,
+        1,
+        cudaStreamAddCaptureDependencies));
+#else
+    FB_CUDACHECK(cudaStreamUpdateCaptureDependencies(
+        userStream, &lastRecordNode_, 1, cudaStreamAddCaptureDependencies));
+#endif
+  }
+
+  return doWait();
 }
 
-commResult_t CtranGpe::Impl::postKernelLaunch(cudaStream_t curStream) {
-  // add sync point execOrderStream_ to block future CTRAN kernels
-  return streamWaitStream(execOrderStream_, curStream, execEvent_);
+commResult_t OrderedWorkStreamGuard::doRelease(
+    cudaStream_t userStream,
+    const utils::cudagraph::StreamCaptureInfo& captureInfo) {
+  const bool isCapturing = captureInfo.status == cudaStreamCaptureStatusActive;
+
+  if (!isCapturing) {
+    FB_CUDACHECK(cudaEventRecord(execModeSyncEvent_, userStream));
+  } else {
+    FB_COMMCHECK(
+        utils::cudagraph::addEventRecordNodeToCapture(
+            userStream, captureInfo.g, execModeSyncEvent_, &lastRecordNode_));
+  }
+
+  lastUserStream_ = userStream;
+  lastWasCaptured_ = isCapturing;
+
+  return commSuccess;
 }
 
 commResult_t CtranGpe::Impl::submit(
@@ -200,6 +309,9 @@ commResult_t CtranGpe::Impl::submit(
       utils::cudagraph::getStreamCaptureInfo(
           kernelConfig.stream, streamCaptureInfo));
 
+  cudaStream_t launchStream = kernelConfig.stream;
+  std::optional<OrderedWorkStreamGuard::Scope> wsScope;
+
   size_t opGroupSize = 0;
   // Enqueue op to gpeThread if any op is appended
   if (!opGroup.empty()) {
@@ -240,12 +352,10 @@ commResult_t CtranGpe::Impl::submit(
     }
   }
 
-  // FIXME: the multi-stream order enforcement is not compatible with cuda graph
-  // capture; disable it under cuda graph capture as a workaround. We'd need
-  // proper fix to support the compatibility.
-  if (streamCaptureInfo.status != cudaStreamCaptureStatusActive &&
-      !kernelConfig.canConcurrent) {
-    FB_COMMCHECK(preKernelLaunch(kernelConfig.stream));
+  if (!kernelConfig.canConcurrent) {
+    wsScope = ws_.acquire(kernelConfig.stream, streamCaptureInfo);
+    FB_COMMCHECK(wsScope->status());
+    launchStream = wsScope->stream();
   }
 
   if (NCCL_CTRAN_ENALBE_CLUSTER_KERNEL_LAUNCH) {
@@ -283,7 +393,7 @@ commResult_t CtranGpe::Impl::submit(
     launchConfig.blockDimZ = blocks.z;
     launchConfig.attrs = launchAttrs;
     launchConfig.numAttrs = attrs;
-    launchConfig.hStream = kernelConfig.stream;
+    launchConfig.hStream = launchStream;
     CUfunction cuFn;
     FB_CUDACHECKGOTO(cudaGetFuncBySymbol(&cuFn, ncclKernel), res, fail);
     CLOGF_TRACE(COLL, "CTranGPE: submit {}", kernelConfig.toString());
@@ -329,7 +439,7 @@ commResult_t CtranGpe::Impl::submit(
             blocks,
             kernelArgs.data(),
             sharedMemBytes,
-            kernelConfig.stream),
+            launchStream),
         res,
         fail);
   }
@@ -352,7 +462,7 @@ commResult_t CtranGpe::Impl::submit(
           CHECKSUM_NUM_THREAD,
           args.data(),
           0,
-          kernelConfig.stream);
+          launchStream);
       if (res != cudaSuccess && checksumItem != nullptr) {
         // Do not return error if the internal checksum fails
         CLOGF(WARN, "CTranGPE: Failed to launch checksum kernel");
@@ -366,13 +476,8 @@ commResult_t CtranGpe::Impl::submit(
     }
   }
 
-  // FIXME: the multi-stream order enforcement is not compatible with cuda graph
-  // capture; disable it under cuda graph capture as a workaround. We'd need
-  // proper fix to support the compatibility.
-  if (streamCaptureInfo.status != cudaStreamCaptureStatusActive &&
-      !kernelConfig.canConcurrent) {
-    FB_COMMCHECK(postKernelLaunch(kernelConfig.stream));
-  }
+  // early release
+  wsScope.reset();
 
   if (colltraceHandle != nullptr) {
     colltraceHandle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel);
@@ -438,6 +543,7 @@ commResult_t CtranGpe::Impl::submitHost(
 }
 
 void CtranGpe::Impl::start() {
+  ws_.init(comm->logMetaData_);
   thread_ = std::thread([this] { gpeThreadFn(); });
 }
 

--- a/comms/ctran/gpe/CtranGpeImpl.h
+++ b/comms/ctran/gpe/CtranGpeImpl.h
@@ -21,6 +21,8 @@
 #include "comms/ctran/utils/ExtUtils.h"
 #include "comms/ctran/utils/PinnedHostPool.h"
 
+struct CommLogData;
+
 struct KernelFlagItem {
   using Self = KernelFlagItem;
 
@@ -184,6 +186,61 @@ commResult_t allocGpeKernelSyncs(
     int nworkers,
     std::vector<ctran::algos::GpeKernelSync*>& gpeKernelSyncs);
 
+class OrderedWorkStreamGuard {
+ public:
+  ~OrderedWorkStreamGuard();
+
+  void init(const CommLogData& logMetaData);
+
+  class Scope {
+   public:
+    Scope(
+        OrderedWorkStreamGuard& guard,
+        cudaStream_t userStream,
+        const ctran::utils::cudagraph::StreamCaptureInfo& captureInfo);
+    ~Scope();
+
+    Scope(const Scope&) = delete;
+    Scope& operator=(const Scope&) = delete;
+    Scope(Scope&& other) noexcept;
+    Scope& operator=(Scope&& other) noexcept;
+
+    commResult_t status() const {
+      return status_;
+    }
+    cudaStream_t stream() const {
+      return userStream_;
+    }
+
+   private:
+    OrderedWorkStreamGuard* guard_;
+    cudaStream_t userStream_;
+    ctran::utils::cudagraph::StreamCaptureInfo captureInfo_;
+    commResult_t status_;
+  };
+
+  Scope acquire(
+      cudaStream_t userStream,
+      const ctran::utils::cudagraph::StreamCaptureInfo& captureInfo);
+
+ private:
+  commResult_t doAcquire(
+      cudaStream_t userStream,
+      const ctran::utils::cudagraph::StreamCaptureInfo& captureInfo);
+  commResult_t doRelease(
+      cudaStream_t userStream,
+      const ctran::utils::cudagraph::StreamCaptureInfo& captureInfo);
+
+  cudaEvent_t execModeSyncEvent_{};
+  unsigned long long lastCaptureId_{0};
+  bool everCaptured_{false};
+  cudaStream_t lastUserStream_{nullptr};
+  bool lastWasCaptured_{false};
+  cudaGraphNode_t lastRecordNode_{};
+
+  const CommLogData* logMetaData_{nullptr};
+};
+
 class CtranGpe::Impl {
  public:
   Impl();
@@ -227,12 +284,6 @@ class CtranGpe::Impl {
     return commSuccess;
   }
 
-  // Maintain execution order between
-  // user streams before launching Ctran kernel,
-  commResult_t preKernelLaunch(cudaStream_t curStream);
-  // Ensure future work waits on just launched Ctran kernel
-  commResult_t postKernelLaunch(cudaStream_t curStream);
-
   CtranComm* comm{nullptr};
 
   std::unique_ptr<KernelElemPool> kernelElemPool;
@@ -250,14 +301,7 @@ class CtranGpe::Impl {
   folly::Synchronized<CmdQueue, std::mutex> cmdQueue_;
   std::condition_variable cmdQueueCv_;
   std::thread thread_;
-  // Internal event and stream used to manage execution order of Ctran kernels
-  // if multiple streams are used to submit ops
-  cudaEvent_t execEvent_;
-  cudaStream_t execOrderStream_;
-  // record the most recent user stream to allow a fast path bypass stream
-  // ordering
-  cudaStream_t lastUserStream_;
-
+  OrderedWorkStreamGuard ws_;
   // Main function called by the GPE thread. It waits and handles any  commands
   // submitted to cmdQueue until the TERMINATE command is received.
   void gpeThreadFn();

--- a/comms/ctran/gpe/tests/CtranGpeUT.cc
+++ b/comms/ctran/gpe/tests/CtranGpeUT.cc
@@ -13,7 +13,10 @@
 #include "comms/ctran/gpe/tests/CtranGpeUTKernels.h"
 #include "comms/ctran/tests/CtranTestUtils.h"
 #include "comms/testinfra/TestXPlatUtils.h"
-
+#if not defined(__HIP_PLATFORM_AMD__) and not defined(__HIP_PLATFORM_HCC__)
+#include <cupti.h>
+#include "comms/utils/test_utils/CudaGraphTestUtils.h"
+#endif
 class CtranGpeTest : public ::testing::Test {
  public:
   CtranGpe* gpe;
@@ -295,6 +298,1169 @@ TEST_F(CtranGpeTest, SubmitOnlyKernel) {
   CUDACHECK_TEST(cudaStreamDestroy(stream));
 }
 
+#if not defined(__HIP_PLATFORM_AMD__) and not defined(__HIP_PLATFORM_HCC__)
+// Verify multi-stream kernel submissions produce a valid captured graph.
+// Kernels launch on user streams (streamA, streamB). Cross-stream ordering
+// is enforced via execModeSyncEvent_ record/wait nodes. The graph should
+// contain 2 kernel nodes with kernelA -> kernelB (event ordering edge).
+//
+TEST_F(CtranGpeTest, SubmitOpKernelMultiStreamGraphCapture) {
+  auto gpe = std::unique_ptr<CtranGpe>(new CtranGpe(cudaDev, dummyComm));
+
+  cudaStream_t primaryStream;
+  CUDACHECK_TEST(cudaStreamCreate(&primaryStream));
+
+  cudaStream_t streamA, streamB;
+  CUDACHECK_TEST(cudaStreamCreate(&streamA));
+  CUDACHECK_TEST(cudaStreamCreate(&streamB));
+
+  cudaEvent_t forkEvent, joinEventA, joinEventB;
+  CUDACHECK_TEST(cudaEventCreate(&forkEvent));
+  CUDACHECK_TEST(cudaEventCreate(&joinEventA));
+  CUDACHECK_TEST(cudaEventCreate(&joinEventB));
+
+  constexpr int kVal = 42;
+  int* bufA = nullptr;
+  int* bufB = nullptr;
+  int* valPtr = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&bufA, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMalloc(&bufB, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMemset(bufA, 0, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMemset(bufB, 0, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMallocHost(&valPtr, sizeof(int)));
+  *valPtr = kVal;
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  CUDACHECK_TEST(
+      cudaStreamBeginCapture(primaryStream, cudaStreamCaptureModeRelaxed));
+
+  CUDACHECK_TEST(cudaEventRecord(forkEvent, primaryStream));
+  CUDACHECK_TEST(cudaStreamWaitEvent(streamA, forkEvent, 0));
+  CUDACHECK_TEST(cudaStreamWaitEvent(streamB, forkEvent, 0));
+
+  {
+    std::vector<std::unique_ptr<struct OpElem>> emptyOps;
+    constexpr uint64_t dummyOpCount = 0;
+    auto config = KernelConfig(
+        KernelConfig::KernelType::ALLGATHER,
+        streamA,
+        "dummyAlgo",
+        dummyOpCount);
+    ctranKernelSetAllGatherArgs(
+        bufA, valPtr, commInt8, count, dummyDevState_d, &config.args);
+    auto res = gpe->submit(
+        std::move(emptyOps),
+        nullptr,
+        config,
+        reinterpret_cast<void*>(CtranGpeTestKernel));
+    ASSERT_EQ(res, commSuccess);
+  }
+
+  {
+    std::vector<std::unique_ptr<struct OpElem>> emptyOps;
+    constexpr uint64_t dummyOpCount = 0;
+    auto config = KernelConfig(
+        KernelConfig::KernelType::ALLGATHER,
+        streamB,
+        "dummyAlgo",
+        dummyOpCount);
+    ctranKernelSetAllGatherArgs(
+        bufB, valPtr, commInt8, count, dummyDevState_d, &config.args);
+    auto res = gpe->submit(
+        std::move(emptyOps),
+        nullptr,
+        config,
+        reinterpret_cast<void*>(CtranGpeTestKernel));
+    ASSERT_EQ(res, commSuccess);
+  }
+
+  CUDACHECK_TEST(cudaEventRecord(joinEventA, streamA));
+  CUDACHECK_TEST(cudaEventRecord(joinEventB, streamB));
+  CUDACHECK_TEST(cudaStreamWaitEvent(primaryStream, joinEventA, 0));
+  CUDACHECK_TEST(cudaStreamWaitEvent(primaryStream, joinEventB, 0));
+
+  cudaGraph_t graph;
+  CUDACHECK_TEST(cudaStreamEndCapture(primaryStream, &graph));
+  ASSERT_NE(graph, nullptr);
+
+  // Verify graph topology: 2 GPE kernels on user streams (streamA, streamB).
+  // Cross-stream ordering via execModeSyncEvent_ record/wait nodes ensures
+  // kernelA -> kernelB.
+  // Each kernel should have a WAIT(E)/RECORD(E) pair from the guard.
+  {
+    auto topo = getGraphTopology(graph);
+    auto kernelNodes = topo.nodesOfType(cudaGraphNodeTypeKernel);
+    ASSERT_EQ(kernelNodes.size(), 2);
+
+    auto kernelA = kernelNodes[0];
+    auto kernelB = kernelNodes[1];
+    EXPECT_TRUE(topo.hasPath(kernelA, kernelB))
+        << "kernelB must transitively depend on kernelA";
+    EXPECT_FALSE(topo.hasPath(kernelB, kernelA))
+        << "kernelA must NOT depend on kernelB (would be a cycle)";
+
+    // Each kernel gets a WAIT(E)/RECORD(E) pair from the guard.
+    // User fork/join use regular cudaEventRecord/cudaStreamWaitEvent
+    // which create graph edges, not event nodes — so they don't
+    // contribute to the WAIT/RECORD node counts.
+    auto waitNodes = topo.nodesOfType(cudaGraphNodeTypeWaitEvent);
+    auto recordNodes = topo.nodesOfType(cudaGraphNodeTypeEventRecord);
+    EXPECT_EQ(waitNodes.size(), kernelNodes.size())
+        << "Each kernel should have one guard WAIT(E) node";
+    EXPECT_EQ(recordNodes.size(), kernelNodes.size())
+        << "Each kernel should have one guard RECORD(E) node";
+  }
+
+  cudaGraphExec_t graphExec;
+  CUDACHECK_TEST(cudaGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+
+  CUDACHECK_TEST(cudaGraphLaunch(graphExec, primaryStream));
+  CUDACHECK_TEST(cudaStreamSynchronize(primaryStream));
+
+  std::vector<int> hostA(count, 0);
+  std::vector<int> hostB(count, 0);
+  CUDACHECK_TEST(cudaMemcpy(
+      hostA.data(), bufA, sizeof(int) * count, cudaMemcpyDeviceToHost));
+  CUDACHECK_TEST(cudaMemcpy(
+      hostB.data(), bufB, sizeof(int) * count, cudaMemcpyDeviceToHost));
+  EXPECT_THAT(hostA, testing::Each(kVal));
+  EXPECT_THAT(hostB, testing::Each(kVal));
+
+  CUDACHECK_TEST(cudaGraphExecDestroy(graphExec));
+  CUDACHECK_TEST(cudaGraphDestroy(graph));
+  CUDACHECK_TEST(cudaEventDestroy(forkEvent));
+  CUDACHECK_TEST(cudaEventDestroy(joinEventA));
+  CUDACHECK_TEST(cudaEventDestroy(joinEventB));
+  CUDACHECK_TEST(cudaFree(bufA));
+  CUDACHECK_TEST(cudaFree(bufB));
+  CUDACHECK_TEST(cudaFreeHost(valPtr));
+  CUDACHECK_TEST(cudaStreamDestroy(primaryStream));
+  CUDACHECK_TEST(cudaStreamDestroy(streamA));
+  CUDACHECK_TEST(cudaStreamDestroy(streamB));
+}
+
+// RAII helper to count cudaStreamWaitEvent calls via CUPTI callback API.
+class CuptiWaitEventCounter {
+ public:
+  CuptiWaitEventCounter() {
+    auto cb = [](void* userdata,
+                 CUpti_CallbackDomain domain,
+                 CUpti_CallbackId cbid,
+                 const CUpti_CallbackData* cbdata) {
+      if (domain == CUPTI_CB_DOMAIN_RUNTIME_API &&
+          cbid == CUPTI_RUNTIME_TRACE_CBID_cudaStreamWaitEvent_v3020 &&
+          cbdata->callbackSite == CUPTI_API_ENTER) {
+        reinterpret_cast<std::atomic<int>*>(userdata)->fetch_add(1);
+      }
+    };
+    CHECK_EQ(
+        cuptiSubscribe(
+            &subscriber_, reinterpret_cast<CUpti_CallbackFunc>(+cb), &count_),
+        CUPTI_SUCCESS);
+    CHECK_EQ(
+        cuptiEnableCallback(
+            1,
+            subscriber_,
+            CUPTI_CB_DOMAIN_RUNTIME_API,
+            CUPTI_RUNTIME_TRACE_CBID_cudaStreamWaitEvent_v3020),
+        CUPTI_SUCCESS);
+  }
+
+  ~CuptiWaitEventCounter() {
+    cuptiUnsubscribe(subscriber_);
+  }
+
+  int count() const {
+    return count_.load();
+  }
+
+ private:
+  std::atomic<int> count_{0};
+  CUpti_SubscriberHandle subscriber_;
+};
+
+// Verify eager same-stream fast path: consecutive submits on the same
+// stream skip cudaStreamWaitEvent entirely (0 acquire calls per submit).
+TEST_F(CtranGpeTest, EagerSameStreamOrdering) {
+  auto gpe = std::unique_ptr<CtranGpe>(new CtranGpe(cudaDev, dummyComm));
+
+  cudaStream_t stream;
+  CUDACHECK_TEST(cudaStreamCreate(&stream));
+
+  constexpr int kVal1 = 11;
+  constexpr int kVal2 = 22;
+  constexpr int kVal3 = 33;
+  int* buf = nullptr;
+  int* valPtr1 = nullptr;
+  int* valPtr2 = nullptr;
+  int* valPtr3 = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMemset(buf, 0, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMallocHost(&valPtr1, sizeof(int)));
+  CUDACHECK_TEST(cudaMallocHost(&valPtr2, sizeof(int)));
+  CUDACHECK_TEST(cudaMallocHost(&valPtr3, sizeof(int)));
+  *valPtr1 = kVal1;
+  *valPtr2 = kVal2;
+  *valPtr3 = kVal3;
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  CuptiWaitEventCounter waitCounter;
+
+  // Three consecutive submits on the same stream
+  for (auto* valPtr : {valPtr1, valPtr2, valPtr3}) {
+    std::vector<std::unique_ptr<struct OpElem>> emptyOps;
+    constexpr uint64_t dummyOpCount = 0;
+    auto config = KernelConfig(
+        KernelConfig::KernelType::ALLGATHER, stream, "dummyAlgo", dummyOpCount);
+    ctranKernelSetAllGatherArgs(
+        buf, valPtr, commInt8, count, dummyDevState_d, &config.args);
+    ASSERT_EQ(
+        gpe->submit(
+            std::move(emptyOps),
+            nullptr,
+            config,
+            reinterpret_cast<void*>(CtranGpeTestKernel)),
+        commSuccess);
+  }
+
+  // Same-stream fast path: no cudaStreamWaitEvent calls
+  EXPECT_EQ(waitCounter.count(), 0)
+      << "Same-stream eager submits should skip cudaStreamWaitEvent";
+
+  CUDACHECK_TEST(cudaStreamSynchronize(stream));
+
+  // Last kernel wrote kVal3
+  std::vector<int> host(count, 0);
+  CUDACHECK_TEST(cudaMemcpy(
+      host.data(), buf, sizeof(int) * count, cudaMemcpyDeviceToHost));
+  EXPECT_THAT(host, testing::Each(kVal3));
+
+  CUDACHECK_TEST(cudaFree(buf));
+  CUDACHECK_TEST(cudaFreeHost(valPtr1));
+  CUDACHECK_TEST(cudaFreeHost(valPtr2));
+  CUDACHECK_TEST(cudaFreeHost(valPtr3));
+  CUDACHECK_TEST(cudaStreamDestroy(stream));
+}
+
+// Verify eager cross-stream path: submits on alternating streams must
+// call cudaStreamWaitEvent to enforce ordering.
+TEST_F(CtranGpeTest, EagerCrossStreamOrdering) {
+  auto gpe = std::unique_ptr<CtranGpe>(new CtranGpe(cudaDev, dummyComm));
+
+  cudaStream_t streamA, streamB;
+  CUDACHECK_TEST(cudaStreamCreate(&streamA));
+  CUDACHECK_TEST(cudaStreamCreate(&streamB));
+
+  constexpr int kVal1 = 11;
+  constexpr int kVal2 = 22;
+  int* buf = nullptr;
+  int* valPtr1 = nullptr;
+  int* valPtr2 = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMemset(buf, 0, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMallocHost(&valPtr1, sizeof(int)));
+  CUDACHECK_TEST(cudaMallocHost(&valPtr2, sizeof(int)));
+  *valPtr1 = kVal1;
+  *valPtr2 = kVal2;
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  CuptiWaitEventCounter waitCounter;
+
+  // Submit on streamA then streamB (cross-stream)
+  {
+    std::vector<std::unique_ptr<struct OpElem>> emptyOps;
+    auto config = KernelConfig(
+        KernelConfig::KernelType::ALLGATHER, streamA, "dummyAlgo", 0);
+    ctranKernelSetAllGatherArgs(
+        buf, valPtr1, commInt8, count, dummyDevState_d, &config.args);
+    ASSERT_EQ(
+        gpe->submit(
+            std::move(emptyOps),
+            nullptr,
+            config,
+            reinterpret_cast<void*>(CtranGpeTestKernel)),
+        commSuccess);
+  }
+  {
+    std::vector<std::unique_ptr<struct OpElem>> emptyOps;
+    auto config = KernelConfig(
+        KernelConfig::KernelType::ALLGATHER, streamB, "dummyAlgo", 1);
+    ctranKernelSetAllGatherArgs(
+        buf, valPtr2, commInt8, count, dummyDevState_d, &config.args);
+    ASSERT_EQ(
+        gpe->submit(
+            std::move(emptyOps),
+            nullptr,
+            config,
+            reinterpret_cast<void*>(CtranGpeTestKernel)),
+        commSuccess);
+  }
+
+  // Cross-stream: cudaStreamWaitEvent must have been called
+  EXPECT_GT(waitCounter.count(), 0)
+      << "Cross-stream eager submits must call cudaStreamWaitEvent";
+
+  CUDACHECK_TEST(cudaStreamSynchronize(streamA));
+  CUDACHECK_TEST(cudaStreamSynchronize(streamB));
+
+  // Last kernel wrote kVal2
+  std::vector<int> host(count, 0);
+  CUDACHECK_TEST(cudaMemcpy(
+      host.data(), buf, sizeof(int) * count, cudaMemcpyDeviceToHost));
+  EXPECT_THAT(host, testing::Each(kVal2));
+
+  CUDACHECK_TEST(cudaFree(buf));
+  CUDACHECK_TEST(cudaFreeHost(valPtr1));
+  CUDACHECK_TEST(cudaFreeHost(valPtr2));
+  CUDACHECK_TEST(cudaStreamDestroy(streamA));
+  CUDACHECK_TEST(cudaStreamDestroy(streamB));
+}
+
+// Verify that each kernel captured into a graph gets exactly one
+// WAIT(E)/RECORD(E) pair from the guard. This test captures a single kernel
+// on a single stream with no user fork/join, so the only event nodes in the
+// graph are from the guard.
+TEST_F(CtranGpeTest, GraphCaptureGuardWaitRecordPerKernel) {
+  auto gpe = std::unique_ptr<CtranGpe>(new CtranGpe(cudaDev, dummyComm));
+
+  cudaStream_t stream;
+  CUDACHECK_TEST(cudaStreamCreate(&stream));
+
+  int* buf = nullptr;
+  int* valPtr = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMemset(buf, 0, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMallocHost(&valPtr, sizeof(int)));
+  *valPtr = 42;
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  CUDACHECK_TEST(cudaStreamBeginCapture(stream, cudaStreamCaptureModeRelaxed));
+  {
+    std::vector<std::unique_ptr<struct OpElem>> emptyOps;
+    auto config = KernelConfig(
+        KernelConfig::KernelType::ALLGATHER, stream, "dummyAlgo", 0);
+    ctranKernelSetAllGatherArgs(
+        buf, valPtr, commInt8, count, dummyDevState_d, &config.args);
+    ASSERT_EQ(
+        gpe->submit(
+            std::move(emptyOps),
+            nullptr,
+            config,
+            reinterpret_cast<void*>(CtranGpeTestKernel)),
+        commSuccess);
+  }
+
+  cudaGraph_t graph;
+  CUDACHECK_TEST(cudaStreamEndCapture(stream, &graph));
+  ASSERT_NE(graph, nullptr);
+
+  {
+    auto topo = getGraphTopology(graph);
+    auto kernelNodes = topo.nodesOfType(cudaGraphNodeTypeKernel);
+    ASSERT_EQ(kernelNodes.size(), 1);
+
+    // No user fork/join — only guard event nodes.
+    // Each kernel should have exactly 1 WAIT(E) + 1 RECORD(E).
+    auto waitNodes = topo.nodesOfType(cudaGraphNodeTypeWaitEvent);
+    auto recordNodes = topo.nodesOfType(cudaGraphNodeTypeEventRecord);
+    EXPECT_EQ(waitNodes.size(), 1)
+        << "Guard should add 1 WAIT(E) node per kernel";
+    EXPECT_EQ(recordNodes.size(), 1)
+        << "Guard should add 1 RECORD(E) node per kernel";
+  }
+
+  cudaGraphExec_t graphExec;
+  CUDACHECK_TEST(cudaGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+  CUDACHECK_TEST(cudaGraphLaunch(graphExec, stream));
+  CUDACHECK_TEST(cudaStreamSynchronize(stream));
+
+  std::vector<int> host(count, 0);
+  CUDACHECK_TEST(cudaMemcpy(
+      host.data(), buf, sizeof(int) * count, cudaMemcpyDeviceToHost));
+  EXPECT_THAT(host, testing::Each(42));
+
+  CUDACHECK_TEST(cudaGraphExecDestroy(graphExec));
+  CUDACHECK_TEST(cudaGraphDestroy(graph));
+  CUDACHECK_TEST(cudaFree(buf));
+  CUDACHECK_TEST(cudaFreeHost(valPtr));
+  CUDACHECK_TEST(cudaStreamDestroy(stream));
+}
+
+// Verify that consecutive same-stream submits followed by a cross-stream
+// submit produce correct ordering. Same-stream kernels (kernelA1, kernelA2)
+// get implicit stream ordering on streamA. Cross-stream ordering to kernelB
+// on streamB is enforced via execModeSyncEvent_ record/wait nodes.
+//
+// Host call order:
+//
+//   gpe->submit(streamA, kernelA1)   // first submit on streamA
+//   gpe->submit(streamA, kernelA2)   // second submit on streamA (same stream)
+//   gpe->submit(streamB, kernelB)    // cross-stream submit
+//
+// kernelA1 -> kernelA2 (implicit, same stream)
+// kernelA2 -> kernelB  (event ordering)
+//
+TEST_F(CtranGpeTest, GraphCaptureSameStreamThenCrossStream) {
+  auto gpe = std::unique_ptr<CtranGpe>(new CtranGpe(cudaDev, dummyComm));
+
+  cudaStream_t primaryStream;
+  CUDACHECK_TEST(cudaStreamCreate(&primaryStream));
+  cudaStream_t streamA, streamB;
+  CUDACHECK_TEST(cudaStreamCreate(&streamA));
+  CUDACHECK_TEST(cudaStreamCreate(&streamB));
+
+  cudaEvent_t forkEvent, joinEventA, joinEventB;
+  CUDACHECK_TEST(cudaEventCreate(&forkEvent));
+  CUDACHECK_TEST(cudaEventCreate(&joinEventA));
+  CUDACHECK_TEST(cudaEventCreate(&joinEventB));
+
+  constexpr int kVal1 = 11;
+  constexpr int kVal2 = 22;
+  constexpr int kValB = 33;
+  int* bufA = nullptr;
+  int* bufB = nullptr;
+  int* valPtr1 = nullptr;
+  int* valPtr2 = nullptr;
+  int* valPtrB = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&bufA, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMalloc(&bufB, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMemset(bufA, 0, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMemset(bufB, 0, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMallocHost(&valPtr1, sizeof(int)));
+  CUDACHECK_TEST(cudaMallocHost(&valPtr2, sizeof(int)));
+  CUDACHECK_TEST(cudaMallocHost(&valPtrB, sizeof(int)));
+  *valPtr1 = kVal1;
+  *valPtr2 = kVal2;
+  *valPtrB = kValB;
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  CUDACHECK_TEST(
+      cudaStreamBeginCapture(primaryStream, cudaStreamCaptureModeRelaxed));
+
+  CUDACHECK_TEST(cudaEventRecord(forkEvent, primaryStream));
+  CUDACHECK_TEST(cudaStreamWaitEvent(streamA, forkEvent, 0));
+  CUDACHECK_TEST(cudaStreamWaitEvent(streamB, forkEvent, 0));
+
+  // First submit on streamA — writes kVal1 to bufA
+  {
+    std::vector<std::unique_ptr<struct OpElem>> emptyOps;
+    constexpr uint64_t dummyOpCount = 0;
+    auto config = KernelConfig(
+        KernelConfig::KernelType::ALLGATHER,
+        streamA,
+        "dummyAlgo",
+        dummyOpCount);
+    ctranKernelSetAllGatherArgs(
+        bufA, valPtr1, commInt8, count, dummyDevState_d, &config.args);
+    ASSERT_EQ(
+        gpe->submit(
+            std::move(emptyOps),
+            nullptr,
+            config,
+            reinterpret_cast<void*>(CtranGpeTestKernel)),
+        commSuccess);
+  }
+
+  // Second submit on streamA (same stream) — overwrites bufA with kVal2
+  {
+    std::vector<std::unique_ptr<struct OpElem>> emptyOps;
+    constexpr uint64_t dummyOpCount = 0;
+    auto config = KernelConfig(
+        KernelConfig::KernelType::ALLGATHER,
+        streamA,
+        "dummyAlgo",
+        dummyOpCount);
+    ctranKernelSetAllGatherArgs(
+        bufA, valPtr2, commInt8, count, dummyDevState_d, &config.args);
+    ASSERT_EQ(
+        gpe->submit(
+            std::move(emptyOps),
+            nullptr,
+            config,
+            reinterpret_cast<void*>(CtranGpeTestKernel)),
+        commSuccess);
+  }
+
+  // Cross-stream submit on streamB — writes kValB to bufB
+  {
+    std::vector<std::unique_ptr<struct OpElem>> emptyOps;
+    constexpr uint64_t dummyOpCount = 0;
+    auto config = KernelConfig(
+        KernelConfig::KernelType::ALLGATHER,
+        streamB,
+        "dummyAlgo",
+        dummyOpCount);
+    ctranKernelSetAllGatherArgs(
+        bufB, valPtrB, commInt8, count, dummyDevState_d, &config.args);
+    ASSERT_EQ(
+        gpe->submit(
+            std::move(emptyOps),
+            nullptr,
+            config,
+            reinterpret_cast<void*>(CtranGpeTestKernel)),
+        commSuccess);
+  }
+
+  CUDACHECK_TEST(cudaEventRecord(joinEventA, streamA));
+  CUDACHECK_TEST(cudaEventRecord(joinEventB, streamB));
+  CUDACHECK_TEST(cudaStreamWaitEvent(primaryStream, joinEventA, 0));
+  CUDACHECK_TEST(cudaStreamWaitEvent(primaryStream, joinEventB, 0));
+
+  cudaGraph_t graph;
+  CUDACHECK_TEST(cudaStreamEndCapture(primaryStream, &graph));
+  ASSERT_NE(graph, nullptr);
+
+  // Verify graph topology: 3 GPE kernels on user streams.
+  // kernelA1 -> kernelA2 (implicit, same stream)
+  // kernelA2 -> kernelB  (event ordering, cross-stream)
+  // Each kernel should have a WAIT(E)/RECORD(E) pair from the guard.
+  {
+    auto topo = getGraphTopology(graph);
+    auto kernelNodes = topo.nodesOfType(cudaGraphNodeTypeKernel);
+    ASSERT_EQ(kernelNodes.size(), 3);
+
+    auto kernelA1 = kernelNodes[0];
+    auto kernelA2 = kernelNodes[1];
+    auto kernelB = kernelNodes[2];
+
+    // kernelA1 -> kernelA2 (implicit, same user stream)
+    EXPECT_TRUE(topo.hasPath(kernelA1, kernelA2))
+        << "kernelA2 must depend on kernelA1";
+
+    // kernelA2 -> kernelB (event ordering, cross-stream)
+    EXPECT_TRUE(topo.hasPath(kernelA2, kernelB))
+        << "kernelB must depend on kernelA2";
+
+    // Transitively: kernelA1 -> kernelA2 -> kernelB
+    EXPECT_TRUE(topo.hasPath(kernelA1, kernelB))
+        << "kernelB must transitively depend on kernelA1";
+
+    // Each kernel gets a WAIT(E)/RECORD(E) pair from the guard.
+    // User fork/join use regular cudaEventRecord/cudaStreamWaitEvent
+    // which create graph edges, not event nodes.
+    auto waitNodes = topo.nodesOfType(cudaGraphNodeTypeWaitEvent);
+    auto recordNodes = topo.nodesOfType(cudaGraphNodeTypeEventRecord);
+    EXPECT_EQ(waitNodes.size(), kernelNodes.size())
+        << "Each kernel should have one guard WAIT(E) node";
+    EXPECT_EQ(recordNodes.size(), kernelNodes.size())
+        << "Each kernel should have one guard RECORD(E) node";
+  }
+
+  cudaGraphExec_t graphExec;
+  CUDACHECK_TEST(cudaGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+
+  CUDACHECK_TEST(cudaGraphLaunch(graphExec, primaryStream));
+  CUDACHECK_TEST(cudaStreamSynchronize(primaryStream));
+
+  // bufA should have kVal2 (second kernel overwrites first)
+  std::vector<int> hostA(count, 0);
+  CUDACHECK_TEST(cudaMemcpy(
+      hostA.data(), bufA, sizeof(int) * count, cudaMemcpyDeviceToHost));
+  EXPECT_THAT(hostA, testing::Each(kVal2));
+
+  // bufB should have kValB
+  std::vector<int> hostB(count, 0);
+  CUDACHECK_TEST(cudaMemcpy(
+      hostB.data(), bufB, sizeof(int) * count, cudaMemcpyDeviceToHost));
+  EXPECT_THAT(hostB, testing::Each(kValB));
+
+  CUDACHECK_TEST(cudaGraphExecDestroy(graphExec));
+  CUDACHECK_TEST(cudaGraphDestroy(graph));
+  CUDACHECK_TEST(cudaEventDestroy(forkEvent));
+  CUDACHECK_TEST(cudaEventDestroy(joinEventA));
+  CUDACHECK_TEST(cudaEventDestroy(joinEventB));
+  CUDACHECK_TEST(cudaFree(bufA));
+  CUDACHECK_TEST(cudaFree(bufB));
+  CUDACHECK_TEST(cudaFreeHost(valPtr1));
+  CUDACHECK_TEST(cudaFreeHost(valPtr2));
+  CUDACHECK_TEST(cudaFreeHost(valPtrB));
+  CUDACHECK_TEST(cudaStreamDestroy(primaryStream));
+  CUDACHECK_TEST(cudaStreamDestroy(streamA));
+  CUDACHECK_TEST(cudaStreamDestroy(streamB));
+}
+
+// Verify that non-GPE work enqueued on a user stream between two submit()
+// calls does not create false dependencies. Kernels launch on their
+// respective user streams. The memset on streamA is ordered after kernelA
+// (implicit stream ordering) but does not create a false dependency on
+// kernelB (which is on streamB, ordered via event after kernelA).
+//
+// Host call order:
+//
+//   gpe->submit(streamA, kernelA)
+//   cudaMemsetAsync(nonGpeBuf, ..., streamA)   <-- non-GPE work on user stream
+//   gpe->submit(streamB, kernelB)
+//
+// kernelA -> kernelB (event ordering, cross-stream).
+// memset on streamA, after kernelA (implicit), independent of kernelB.
+//
+TEST_F(CtranGpeTest, GraphCaptureNonGpeWorkBetweenSubmits) {
+  auto gpe = std::unique_ptr<CtranGpe>(new CtranGpe(cudaDev, dummyComm));
+
+  cudaStream_t primaryStream;
+  CUDACHECK_TEST(cudaStreamCreate(&primaryStream));
+  cudaStream_t streamA, streamB;
+  CUDACHECK_TEST(cudaStreamCreate(&streamA));
+  CUDACHECK_TEST(cudaStreamCreate(&streamB));
+
+  cudaEvent_t forkEvent, joinEventA, joinEventB;
+  CUDACHECK_TEST(cudaEventCreate(&forkEvent));
+  CUDACHECK_TEST(cudaEventCreate(&joinEventA));
+  CUDACHECK_TEST(cudaEventCreate(&joinEventB));
+
+  constexpr int kVal = 55;
+  int* bufA = nullptr;
+  int* bufB = nullptr;
+  int* nonGpeBuf = nullptr;
+  int* valPtr = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&bufA, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMalloc(&bufB, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMalloc(&nonGpeBuf, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMemset(bufA, 0, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMemset(bufB, 0, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMemset(nonGpeBuf, 0, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMallocHost(&valPtr, sizeof(int)));
+  *valPtr = kVal;
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  CUDACHECK_TEST(
+      cudaStreamBeginCapture(primaryStream, cudaStreamCaptureModeRelaxed));
+
+  CUDACHECK_TEST(cudaEventRecord(forkEvent, primaryStream));
+  CUDACHECK_TEST(cudaStreamWaitEvent(streamA, forkEvent, 0));
+  CUDACHECK_TEST(cudaStreamWaitEvent(streamB, forkEvent, 0));
+
+  {
+    std::vector<std::unique_ptr<struct OpElem>> emptyOps;
+    constexpr uint64_t dummyOpCount = 0;
+    auto config = KernelConfig(
+        KernelConfig::KernelType::ALLGATHER,
+        streamA,
+        "dummyAlgo",
+        dummyOpCount);
+    ctranKernelSetAllGatherArgs(
+        bufA, valPtr, commInt8, count, dummyDevState_d, &config.args);
+    ASSERT_EQ(
+        gpe->submit(
+            std::move(emptyOps),
+            nullptr,
+            config,
+            reinterpret_cast<void*>(CtranGpeTestKernel)),
+        commSuccess);
+  }
+
+  CUDACHECK_TEST(
+      cudaMemsetAsync(nonGpeBuf, 0xFF, sizeof(int) * count, streamA));
+
+  {
+    std::vector<std::unique_ptr<struct OpElem>> emptyOps;
+    constexpr uint64_t dummyOpCount = 0;
+    auto config = KernelConfig(
+        KernelConfig::KernelType::ALLGATHER,
+        streamB,
+        "dummyAlgo",
+        dummyOpCount);
+    ctranKernelSetAllGatherArgs(
+        bufB, valPtr, commInt8, count, dummyDevState_d, &config.args);
+    ASSERT_EQ(
+        gpe->submit(
+            std::move(emptyOps),
+            nullptr,
+            config,
+            reinterpret_cast<void*>(CtranGpeTestKernel)),
+        commSuccess);
+  }
+
+  CUDACHECK_TEST(cudaEventRecord(joinEventA, streamA));
+  CUDACHECK_TEST(cudaEventRecord(joinEventB, streamB));
+  CUDACHECK_TEST(cudaStreamWaitEvent(primaryStream, joinEventA, 0));
+  CUDACHECK_TEST(cudaStreamWaitEvent(primaryStream, joinEventB, 0));
+
+  cudaGraph_t graph;
+  CUDACHECK_TEST(cudaStreamEndCapture(primaryStream, &graph));
+  ASSERT_NE(graph, nullptr);
+
+  // Verify graph topology: 2 GPE kernels on user streams + memset on
+  // streamA. Cross-stream ordering via event ensures kernelA -> kernelB.
+  // The memset is on streamA after kernelA but independent of kernelB.
+  {
+    auto topo = getGraphTopology(graph);
+    auto kernelNodes = topo.nodesOfType(cudaGraphNodeTypeKernel);
+    ASSERT_EQ(kernelNodes.size(), 2);
+
+    auto kernelA = kernelNodes[0];
+    auto kernelB = kernelNodes[1];
+
+    // kernelB must depend on kernelA (event ordering, cross-stream)
+    EXPECT_TRUE(topo.hasPath(kernelA, kernelB))
+        << "kernelB must transitively depend on kernelA";
+  }
+
+  cudaGraphExec_t graphExec;
+  CUDACHECK_TEST(cudaGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+
+  CUDACHECK_TEST(cudaGraphLaunch(graphExec, primaryStream));
+  CUDACHECK_TEST(cudaStreamSynchronize(primaryStream));
+
+  std::vector<int> hostA(count, 0);
+  std::vector<int> hostB(count, 0);
+  CUDACHECK_TEST(cudaMemcpy(
+      hostA.data(), bufA, sizeof(int) * count, cudaMemcpyDeviceToHost));
+  CUDACHECK_TEST(cudaMemcpy(
+      hostB.data(), bufB, sizeof(int) * count, cudaMemcpyDeviceToHost));
+  EXPECT_THAT(hostA, testing::Each(kVal));
+  EXPECT_THAT(hostB, testing::Each(kVal));
+
+  std::vector<int> hostNonGpe(count, 0);
+  CUDACHECK_TEST(cudaMemcpy(
+      hostNonGpe.data(),
+      nonGpeBuf,
+      sizeof(int) * count,
+      cudaMemcpyDeviceToHost));
+
+  EXPECT_THAT(hostNonGpe, testing::Each(static_cast<int>(0xFFFFFFFF)));
+
+  CUDACHECK_TEST(cudaGraphExecDestroy(graphExec));
+  CUDACHECK_TEST(cudaGraphDestroy(graph));
+  CUDACHECK_TEST(cudaEventDestroy(forkEvent));
+  CUDACHECK_TEST(cudaEventDestroy(joinEventA));
+  CUDACHECK_TEST(cudaEventDestroy(joinEventB));
+  CUDACHECK_TEST(cudaFree(bufA));
+  CUDACHECK_TEST(cudaFree(bufB));
+  CUDACHECK_TEST(cudaFree(nonGpeBuf));
+  CUDACHECK_TEST(cudaFreeHost(valPtr));
+  CUDACHECK_TEST(cudaStreamDestroy(primaryStream));
+  CUDACHECK_TEST(cudaStreamDestroy(streamA));
+  CUDACHECK_TEST(cudaStreamDestroy(streamB));
+}
+
+// Verify ordering between graph replay and subsequent eager submissions.
+// The captured kernel launches on the user stream and its doRelease adds
+// an execModeSyncEvent_ record node to the graph. At replay time, this
+// records execModeSyncEvent_. A subsequent non-capture doAcquire waits on
+// execModeSyncEvent_ before launching on the user stream.
+//
+// Host call order:
+//   1. Eager kernel A (writes kVal1 to buf) on streamA
+//   2. Capture kernel B (writes kVal2 to buf) on streamA
+//   3. Replay graph on streamA
+//   4. Eager kernel C (writes kVal3 to buf) on streamB
+//   5. Sync and verify buf == kVal3 (C ran after graph replay)
+//
+TEST_F(CtranGpeTest, GraphReplayThenEagerOrdering) {
+  auto gpe = std::unique_ptr<CtranGpe>(new CtranGpe(cudaDev, dummyComm));
+
+  cudaStream_t streamA, streamB;
+  CUDACHECK_TEST(cudaStreamCreate(&streamA));
+  CUDACHECK_TEST(cudaStreamCreate(&streamB));
+
+  constexpr int kVal1 = 11;
+  constexpr int kVal2 = 22;
+  constexpr int kVal3 = 33;
+  int* buf = nullptr;
+  int* valPtr1 = nullptr;
+  int* valPtr2 = nullptr;
+  int* valPtr3 = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMemset(buf, 0, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMallocHost(&valPtr1, sizeof(int)));
+  CUDACHECK_TEST(cudaMallocHost(&valPtr2, sizeof(int)));
+  CUDACHECK_TEST(cudaMallocHost(&valPtr3, sizeof(int)));
+  *valPtr1 = kVal1;
+  *valPtr2 = kVal2;
+  *valPtr3 = kVal3;
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  // Step 1: Eager kernel A on streamA — writes kVal1 to buf
+  {
+    std::vector<std::unique_ptr<struct OpElem>> emptyOps;
+    constexpr uint64_t dummyOpCount = 0;
+    auto config = KernelConfig(
+        KernelConfig::KernelType::ALLGATHER,
+        streamA,
+        "dummyAlgo",
+        dummyOpCount);
+    ctranKernelSetAllGatherArgs(
+        buf, valPtr1, commInt8, count, dummyDevState_d, &config.args);
+    ASSERT_EQ(
+        gpe->submit(
+            std::move(emptyOps),
+            nullptr,
+            config,
+            reinterpret_cast<void*>(CtranGpeTestKernel)),
+        commSuccess);
+  }
+  CUDACHECK_TEST(cudaStreamSynchronize(streamA));
+
+  // Step 2: Capture kernel B on streamA — writes kVal2 to buf
+  cudaGraph_t graph;
+  cudaGraphExec_t graphExec;
+  CUDACHECK_TEST(cudaStreamBeginCapture(streamA, cudaStreamCaptureModeRelaxed));
+  {
+    std::vector<std::unique_ptr<struct OpElem>> emptyOps;
+    constexpr uint64_t dummyOpCount = 0;
+    auto config = KernelConfig(
+        KernelConfig::KernelType::ALLGATHER,
+        streamA,
+        "dummyAlgo",
+        dummyOpCount);
+    ctranKernelSetAllGatherArgs(
+        buf, valPtr2, commInt8, count, dummyDevState_d, &config.args);
+    ASSERT_EQ(
+        gpe->submit(
+            std::move(emptyOps),
+            nullptr,
+            config,
+            reinterpret_cast<void*>(CtranGpeTestKernel)),
+        commSuccess);
+  }
+  CUDACHECK_TEST(cudaStreamEndCapture(streamA, &graph));
+  ASSERT_NE(graph, nullptr);
+  CUDACHECK_TEST(cudaGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+
+  // Step 3: Replay graph on streamA
+  CUDACHECK_TEST(cudaGraphLaunch(graphExec, streamA));
+
+  // Step 4: Eager kernel C on streamB — writes kVal3 to buf.
+  // The unified event ensures C waits on the graph replay of B.
+  {
+    std::vector<std::unique_ptr<struct OpElem>> emptyOps;
+    constexpr uint64_t dummyOpCount = 0;
+    auto config = KernelConfig(
+        KernelConfig::KernelType::ALLGATHER,
+        streamB,
+        "dummyAlgo",
+        dummyOpCount);
+    ctranKernelSetAllGatherArgs(
+        buf, valPtr3, commInt8, count, dummyDevState_d, &config.args);
+    ASSERT_EQ(
+        gpe->submit(
+            std::move(emptyOps),
+            nullptr,
+            config,
+            reinterpret_cast<void*>(CtranGpeTestKernel)),
+        commSuccess);
+  }
+
+  // Step 5: Sync and verify
+  CUDACHECK_TEST(cudaStreamSynchronize(streamB));
+
+  std::vector<int> host(count, 0);
+  CUDACHECK_TEST(cudaMemcpy(
+      host.data(), buf, sizeof(int) * count, cudaMemcpyDeviceToHost));
+  EXPECT_THAT(host, testing::Each(kVal3));
+
+  CUDACHECK_TEST(cudaGraphExecDestroy(graphExec));
+  CUDACHECK_TEST(cudaGraphDestroy(graph));
+  CUDACHECK_TEST(cudaFree(buf));
+  CUDACHECK_TEST(cudaFreeHost(valPtr1));
+  CUDACHECK_TEST(cudaFreeHost(valPtr2));
+  CUDACHECK_TEST(cudaFreeHost(valPtr3));
+  CUDACHECK_TEST(cudaStreamDestroy(streamA));
+  CUDACHECK_TEST(cudaStreamDestroy(streamB));
+}
+
+// Verify ordering between eager submissions and subsequent graph replay.
+// The first capture sets everCaptured_. The eager kernel's doRelease records
+// execModeSyncEvent_ on the user stream. When the graph is replayed, its
+// WAIT node (with cudaEventWaitExternal) waits on execModeSyncEvent_'s
+// live state.
+//
+// Host call order:
+//   1. Capture kernel A (writes kVal1 to buf) on streamA
+//   2. Eager kernel B (writes kVal2 to buf) on streamA
+//   3. Replay graph on streamA (should wait on B via cudaEventWaitExternal)
+//   4. Sync and verify buf == kVal1 (graph replay ran after B)
+//
+TEST_F(CtranGpeTest, EagerThenGraphReplayOrdering) {
+  auto gpe = std::unique_ptr<CtranGpe>(new CtranGpe(cudaDev, dummyComm));
+
+  cudaStream_t streamA;
+  CUDACHECK_TEST(cudaStreamCreate(&streamA));
+
+  constexpr int kVal1 = 11;
+  constexpr int kVal2 = 22;
+  int* buf = nullptr;
+  int* valPtr1 = nullptr;
+  int* valPtr2 = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMemset(buf, 0, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMallocHost(&valPtr1, sizeof(int)));
+  CUDACHECK_TEST(cudaMallocHost(&valPtr2, sizeof(int)));
+  *valPtr1 = kVal1;
+  *valPtr2 = kVal2;
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  // Step 1: Capture kernel A on streamA — writes kVal1 to buf
+  cudaGraph_t graph;
+  cudaGraphExec_t graphExec;
+  CUDACHECK_TEST(cudaStreamBeginCapture(streamA, cudaStreamCaptureModeRelaxed));
+  {
+    std::vector<std::unique_ptr<struct OpElem>> emptyOps;
+    constexpr uint64_t dummyOpCount = 0;
+    auto config = KernelConfig(
+        KernelConfig::KernelType::ALLGATHER,
+        streamA,
+        "dummyAlgo",
+        dummyOpCount);
+    ctranKernelSetAllGatherArgs(
+        buf, valPtr1, commInt8, count, dummyDevState_d, &config.args);
+    ASSERT_EQ(
+        gpe->submit(
+            std::move(emptyOps),
+            nullptr,
+            config,
+            reinterpret_cast<void*>(CtranGpeTestKernel)),
+        commSuccess);
+  }
+  CUDACHECK_TEST(cudaStreamEndCapture(streamA, &graph));
+  ASSERT_NE(graph, nullptr);
+  CUDACHECK_TEST(cudaGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+
+  // Step 2: Eager kernel B on streamA — writes kVal2 to buf
+  {
+    std::vector<std::unique_ptr<struct OpElem>> emptyOps;
+    constexpr uint64_t dummyOpCount = 0;
+    auto config = KernelConfig(
+        KernelConfig::KernelType::ALLGATHER,
+        streamA,
+        "dummyAlgo",
+        dummyOpCount);
+    ctranKernelSetAllGatherArgs(
+        buf, valPtr2, commInt8, count, dummyDevState_d, &config.args);
+    ASSERT_EQ(
+        gpe->submit(
+            std::move(emptyOps),
+            nullptr,
+            config,
+            reinterpret_cast<void*>(CtranGpeTestKernel)),
+        commSuccess);
+  }
+
+  // Step 3: Replay graph on streamA. The cudaEventWaitExternal flag in the
+  // graph's WAIT node ensures it waits on B's event recording at replay time.
+  CUDACHECK_TEST(cudaGraphLaunch(graphExec, streamA));
+  CUDACHECK_TEST(cudaStreamSynchronize(streamA));
+
+  // Step 4: Verify buf == kVal1 (graph replay of A ran last, after B)
+  std::vector<int> host(count, 0);
+  CUDACHECK_TEST(cudaMemcpy(
+      host.data(), buf, sizeof(int) * count, cudaMemcpyDeviceToHost));
+  EXPECT_THAT(host, testing::Each(kVal1));
+
+  CUDACHECK_TEST(cudaGraphExecDestroy(graphExec));
+  CUDACHECK_TEST(cudaGraphDestroy(graph));
+  CUDACHECK_TEST(cudaFree(buf));
+  CUDACHECK_TEST(cudaFreeHost(valPtr1));
+  CUDACHECK_TEST(cudaFreeHost(valPtr2));
+  CUDACHECK_TEST(cudaStreamDestroy(streamA));
+}
+
+// Verify ordering: Replay -> Eager -> Replay.
+// The eager submit must wait on the first replay, and the second replay
+// must wait on the eager submit. Each transition exercises the cross-mode
+// bridge in alternating directions.
+//
+// Host call order:
+//   1. Capture kernel A (writes kVal1) into a graph
+//   2. Replay graph (buf = kVal1)
+//   3. Eager kernel B (writes kVal2, should overwrite kVal1)
+//   4. Replay graph again (buf = kVal1, should overwrite kVal2)
+//   5. Verify buf == kVal1
+//
+TEST_F(CtranGpeTest, ReplayEagerReplayOrdering) {
+  auto gpe = std::unique_ptr<CtranGpe>(new CtranGpe(cudaDev, dummyComm));
+
+  cudaStream_t stream;
+  CUDACHECK_TEST(cudaStreamCreate(&stream));
+
+  constexpr int kVal1 = 11;
+  constexpr int kVal2 = 22;
+  int* buf = nullptr;
+  int* valPtr1 = nullptr;
+  int* valPtr2 = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMemset(buf, 0, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMallocHost(&valPtr1, sizeof(int)));
+  CUDACHECK_TEST(cudaMallocHost(&valPtr2, sizeof(int)));
+  *valPtr1 = kVal1;
+  *valPtr2 = kVal2;
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  // Step 1: Capture kernel A — writes kVal1
+  cudaGraph_t graph;
+  cudaGraphExec_t graphExec;
+  CUDACHECK_TEST(cudaStreamBeginCapture(stream, cudaStreamCaptureModeRelaxed));
+  {
+    std::vector<std::unique_ptr<struct OpElem>> emptyOps;
+    constexpr uint64_t dummyOpCount = 0;
+    auto config = KernelConfig(
+        KernelConfig::KernelType::ALLGATHER, stream, "dummyAlgo", dummyOpCount);
+    ctranKernelSetAllGatherArgs(
+        buf, valPtr1, commInt8, count, dummyDevState_d, &config.args);
+    ASSERT_EQ(
+        gpe->submit(
+            std::move(emptyOps),
+            nullptr,
+            config,
+            reinterpret_cast<void*>(CtranGpeTestKernel)),
+        commSuccess);
+  }
+  CUDACHECK_TEST(cudaStreamEndCapture(stream, &graph));
+  ASSERT_NE(graph, nullptr);
+  CUDACHECK_TEST(cudaGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+
+  // Step 2: First replay — buf = kVal1
+  CUDACHECK_TEST(cudaGraphLaunch(graphExec, stream));
+
+  // Step 3: Eager kernel B — writes kVal2 (must wait on first replay)
+  {
+    std::vector<std::unique_ptr<struct OpElem>> emptyOps;
+    constexpr uint64_t dummyOpCount = 0;
+    auto config = KernelConfig(
+        KernelConfig::KernelType::ALLGATHER, stream, "dummyAlgo", dummyOpCount);
+    ctranKernelSetAllGatherArgs(
+        buf, valPtr2, commInt8, count, dummyDevState_d, &config.args);
+    ASSERT_EQ(
+        gpe->submit(
+            std::move(emptyOps),
+            nullptr,
+            config,
+            reinterpret_cast<void*>(CtranGpeTestKernel)),
+        commSuccess);
+  }
+
+  // Step 4: Second replay — buf = kVal1 (must wait on eager B)
+  CUDACHECK_TEST(cudaGraphLaunch(graphExec, stream));
+  CUDACHECK_TEST(cudaStreamSynchronize(stream));
+
+  // Step 5: Verify buf == kVal1 (second replay ran last)
+  std::vector<int> host(count, 0);
+  CUDACHECK_TEST(cudaMemcpy(
+      host.data(), buf, sizeof(int) * count, cudaMemcpyDeviceToHost));
+  EXPECT_THAT(host, testing::Each(kVal1));
+
+  CUDACHECK_TEST(cudaGraphExecDestroy(graphExec));
+  CUDACHECK_TEST(cudaGraphDestroy(graph));
+  CUDACHECK_TEST(cudaFree(buf));
+  CUDACHECK_TEST(cudaFreeHost(valPtr1));
+  CUDACHECK_TEST(cudaFreeHost(valPtr2));
+  CUDACHECK_TEST(cudaStreamDestroy(stream));
+}
+
+// Verify ordering: Eager -> Replay -> Eager.
+// The replay must wait on the first eager submit, and the second eager
+// submit must wait on the replay. Each transition exercises the cross-mode
+// bridge in alternating directions.
+//
+// Host call order:
+//   1. Capture kernel A (writes kVal1) into a graph
+//   2. Eager kernel B (writes kVal2)
+//   3. Replay graph (buf = kVal1, should overwrite kVal2)
+//   4. Eager kernel C (writes kVal3, should overwrite kVal1)
+//   5. Verify buf == kVal3
+//
+TEST_F(CtranGpeTest, EagerReplayEagerOrdering) {
+  auto gpe = std::unique_ptr<CtranGpe>(new CtranGpe(cudaDev, dummyComm));
+
+  cudaStream_t stream;
+  CUDACHECK_TEST(cudaStreamCreate(&stream));
+
+  constexpr int kVal1 = 11;
+  constexpr int kVal2 = 22;
+  constexpr int kVal3 = 33;
+  int* buf = nullptr;
+  int* valPtr1 = nullptr;
+  int* valPtr2 = nullptr;
+  int* valPtr3 = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMemset(buf, 0, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMallocHost(&valPtr1, sizeof(int)));
+  CUDACHECK_TEST(cudaMallocHost(&valPtr2, sizeof(int)));
+  CUDACHECK_TEST(cudaMallocHost(&valPtr3, sizeof(int)));
+  *valPtr1 = kVal1;
+  *valPtr2 = kVal2;
+  *valPtr3 = kVal3;
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  // Step 1: Capture kernel A — writes kVal1
+  cudaGraph_t graph;
+  cudaGraphExec_t graphExec;
+  CUDACHECK_TEST(cudaStreamBeginCapture(stream, cudaStreamCaptureModeRelaxed));
+  {
+    std::vector<std::unique_ptr<struct OpElem>> emptyOps;
+    constexpr uint64_t dummyOpCount = 0;
+    auto config = KernelConfig(
+        KernelConfig::KernelType::ALLGATHER, stream, "dummyAlgo", dummyOpCount);
+    ctranKernelSetAllGatherArgs(
+        buf, valPtr1, commInt8, count, dummyDevState_d, &config.args);
+    ASSERT_EQ(
+        gpe->submit(
+            std::move(emptyOps),
+            nullptr,
+            config,
+            reinterpret_cast<void*>(CtranGpeTestKernel)),
+        commSuccess);
+  }
+  CUDACHECK_TEST(cudaStreamEndCapture(stream, &graph));
+  ASSERT_NE(graph, nullptr);
+  CUDACHECK_TEST(cudaGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+
+  // Step 2: Eager kernel B — writes kVal2
+  {
+    std::vector<std::unique_ptr<struct OpElem>> emptyOps;
+    constexpr uint64_t dummyOpCount = 0;
+    auto config = KernelConfig(
+        KernelConfig::KernelType::ALLGATHER, stream, "dummyAlgo", dummyOpCount);
+    ctranKernelSetAllGatherArgs(
+        buf, valPtr2, commInt8, count, dummyDevState_d, &config.args);
+    ASSERT_EQ(
+        gpe->submit(
+            std::move(emptyOps),
+            nullptr,
+            config,
+            reinterpret_cast<void*>(CtranGpeTestKernel)),
+        commSuccess);
+  }
+
+  // Step 3: Replay graph — buf = kVal1 (must wait on eager B)
+  CUDACHECK_TEST(cudaGraphLaunch(graphExec, stream));
+
+  // Step 4: Eager kernel C — writes kVal3 (must wait on replay)
+  {
+    std::vector<std::unique_ptr<struct OpElem>> emptyOps;
+    constexpr uint64_t dummyOpCount = 0;
+    auto config = KernelConfig(
+        KernelConfig::KernelType::ALLGATHER, stream, "dummyAlgo", dummyOpCount);
+    ctranKernelSetAllGatherArgs(
+        buf, valPtr3, commInt8, count, dummyDevState_d, &config.args);
+    ASSERT_EQ(
+        gpe->submit(
+            std::move(emptyOps),
+            nullptr,
+            config,
+            reinterpret_cast<void*>(CtranGpeTestKernel)),
+        commSuccess);
+  }
+
+  CUDACHECK_TEST(cudaStreamSynchronize(stream));
+
+  // Step 5: Verify buf == kVal3 (second eager ran last)
+  std::vector<int> host(count, 0);
+  CUDACHECK_TEST(cudaMemcpy(
+      host.data(), buf, sizeof(int) * count, cudaMemcpyDeviceToHost));
+  EXPECT_THAT(host, testing::Each(kVal3));
+
+  CUDACHECK_TEST(cudaGraphExecDestroy(graphExec));
+  CUDACHECK_TEST(cudaGraphDestroy(graph));
+  CUDACHECK_TEST(cudaFree(buf));
+  CUDACHECK_TEST(cudaFreeHost(valPtr1));
+  CUDACHECK_TEST(cudaFreeHost(valPtr2));
+  CUDACHECK_TEST(cudaFreeHost(valPtr3));
+  CUDACHECK_TEST(cudaStreamDestroy(stream));
+}
+#endif
+
 TEST_F(CtranGpeTest, SubmitCustomKernArgs) {
   auto gpe = std::unique_ptr<CtranGpe>(new CtranGpe(cudaDev, dummyComm));
   cudaStream_t stream;
@@ -417,8 +1583,8 @@ TEST_F(CtranGpeTest, SubmitKernelWithStartAndExit) {
   // NOTE: we have no good way to drain the GPE thread activities in
   // startAndExit mode. Thus, we simply busy wait till all flags have been
   // returned. If leak happens, the test will timeout.
-  while (gpe->numInUseKernelFlags() > 0)
-    ;
+  while (gpe->numInUseKernelFlags() > 0) {
+  }
 }
 
 TEST_F(CtranGpeKernelTest, SubmitKernelWithKElems) {

--- a/comms/ctran/utils/CudaGraphUtils.h
+++ b/comms/ctran/utils/CudaGraphUtils.h
@@ -17,17 +17,13 @@ struct StreamCaptureInfo {
 inline cudaError_t getStreamCaptureInfo(
     cudaStream_t stream,
     StreamCaptureInfo& info) {
-#if CUDART_VERSION >= 13000
-  return cudaStreamGetCaptureInfo(stream, &info.status, &info.id, &info.g);
-#elif CUDART_VERSION >= 12030
-  return cudaStreamGetCaptureInfo_v3(stream, &info.status, &info.id, &info.g);
-#else
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIP_PLATFORM_HCC__)
   return hipStreamGetCaptureInfo_v2(stream, &info.status, &info.id, &info.g);
+#elif CUDART_VERSION >= 13000
+  return cudaStreamGetCaptureInfo(stream, &info.status, &info.id, &info.g);
 #else
-  return cudaStreamGetCaptureInfo_v2(stream, &info.status, &info.id, &info.g);
-#endif // defined(__HIP_PLATFORM_AMD__) || defined(__HIP_PLATFORM_HCC__)
-#endif // CUDART_VERSION >= 13000
+  return cudaStreamGetCaptureInfo_v3(stream, &info.status, &info.id, &info.g);
+#endif
 }
 
 inline commResult_t addHostNode(
@@ -53,4 +49,73 @@ inline commResult_t addHostNode(
       cudaGraphRetainUserObject(info.g, object, 1, cudaGraphUserObjectMove));
   return commSuccess;
 }
+// Add an event record node to a graph being captured on `capturedStream`.
+//
+// During graph capture, cudaEventRecord on a captured stream taints the
+// event's internal state, making subsequent live cudaStreamWaitEvent calls
+// fail with cudaErrorIllegalState. cudaGraphAddEventRecordNode avoids this
+// by creating a graph RECORD node that fires at replay time (updating the
+// event's live state) without modifying the event during capture.
+inline commResult_t addEventRecordNodeToCapture(
+    cudaStream_t capturedStream,
+    cudaGraph_t graph,
+    cudaEvent_t event,
+    cudaGraphNode_t* outRecordNode = nullptr) {
+  cudaGraphNode_t recordNode;
+  FB_CUDACHECK(
+      cudaGraphAddEventRecordNode(&recordNode, graph, nullptr, 0, event));
+
+  cudaStreamCaptureStatus status;
+  const cudaGraphNode_t* deps = nullptr;
+  size_t numDeps = 0;
+
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIP_PLATFORM_HCC__)
+  FB_CUDACHECK(hipStreamGetCaptureInfo_v2(
+      capturedStream, &status, nullptr, nullptr, &deps, &numDeps));
+  for (size_t i = 0; i < numDeps; i++) {
+    FB_CUDACHECK(cudaGraphAddDependencies(graph, &deps[i], &recordNode, 1));
+  }
+  FB_CUDACHECK(cudaStreamUpdateCaptureDependencies(
+      capturedStream, &recordNode, 1, cudaStreamSetCaptureDependencies));
+#else
+  const cudaGraphEdgeData* edges = nullptr;
+#if CUDART_VERSION >= 13000
+  FB_CUDACHECK(cudaStreamGetCaptureInfo(
+      capturedStream, &status, nullptr, nullptr, &deps, &edges, &numDeps));
+#else
+  FB_CUDACHECK(cudaStreamGetCaptureInfo_v3(
+      capturedStream, &status, nullptr, nullptr, &deps, &edges, &numDeps));
+#endif
+  for (size_t i = 0; i < numDeps; i++) {
+#if CUDART_VERSION >= 13000
+    FB_CUDACHECK(cudaGraphAddDependencies(
+        graph, &deps[i], &recordNode, edges ? &edges[i] : nullptr, 1));
+#else
+    if (edges) {
+      FB_CUDACHECK(cudaGraphAddDependencies_v2(
+          graph, &deps[i], &recordNode, &edges[i], 1));
+    } else {
+      FB_CUDACHECK(cudaGraphAddDependencies(graph, &deps[i], &recordNode, 1));
+    }
+#endif
+  }
+
+#if CUDART_VERSION >= 13000
+  FB_CUDACHECK(cudaStreamUpdateCaptureDependencies(
+      capturedStream,
+      &recordNode,
+      nullptr,
+      1,
+      cudaStreamSetCaptureDependencies));
+#else
+  FB_CUDACHECK(cudaStreamUpdateCaptureDependencies(
+      capturedStream, &recordNode, 1, cudaStreamSetCaptureDependencies));
+#endif
+#endif // defined(__HIP_PLATFORM_AMD__) || defined(__HIP_PLATFORM_HCC__)
+  if (outRecordNode) {
+    *outRecordNode = recordNode;
+  }
+  return commSuccess;
+}
+
 } // namespace ctran::utils::cudagraph


### PR DESCRIPTION
Summary:
# Background

Collectives can be submitted on different CUDA user streams and across eager/graph-capture modes.

***Without ordering enforcement, kernels on separate streams may execute concurrently and race on shared state.***

The previous implementation enforced ordering in eager mode via preKernelLaunch/postKernelLaunch, which routed all synchronization through a dedicated internal stream (execOrderStream_). However, this approach did not support CUDA graph capture -- ordering was explicitly skipped during capture with a FIXME:

```cpp
// FIXME: the multi-stream order enforcement is not compatible with cuda graph
// capture; disable it under cuda graph capture as a workaround. We'd need
// proper fix to support the compatibility.
if (streamCaptureInfo.status != cudaStreamCaptureStatusActive &&
    !kernelConfig.canConcurrent) {
    preKernelLaunch(kernelConfig.stream);
}
```

This meant that during graph capture, collectives on different user streams had no ordering guarantee. Cross-mode transitions (eager to capture or capture to eager) had the same gap -- no event bridged the two modes, so a kernel launched eagerly after a graph replay (or vice versa) had no ordering dependency on the prior work.
---
# Gaps this Design Addresses

## Graph-mode Stream Race
```cpp
cudaStreamBeginCapture(streamA, cudaStreamCaptureModeGlobal);

// capture kernel 1 on streamA
gpe->submit(allreduce_config, streamA);

// fork streamB into the capture session
cudaEventRecord(fork_event, streamA);
cudaStreamWaitEvent(streamB, fork_event, 0);

// capture kernel 2 on streamB
gpe->submit(allreduce_config, streamB);

// join streamB back
cudaEventRecord(join_event, streamB);
cudaStreamWaitEvent(streamA, join_event, 0);

cudaStreamEndCapture(streamA, &graph);
cudaGraphInstantiate(&graphExec, graph, 0);
cudaGraphLaunch(graphExec, streamA);
```
when replayed, kernels A and B execute concurrently (no graph edge).

## Eager-to-Graph-Replay Race
```cpp
gpe->submit(allreduce_config, streamA);   // kernel A enqueued on streamA
cudaGraphLaunch(graphExec, streamB);      // graph contains kernel B
```
streamB has no dependency on streamA's kernel A. The old code recorded execEvent_ on execOrderStream_ only during eager mode, but the graph replay on streamB doesn't wait on execOrderStream_ -- it was captured without any ordering. Kernels A and B can execute concurrently.

## Graph-Replay-to-Eager Race
```cpp
cudaGraphLaunch(graphExec, streamA);      // graph contains kernel A
gpe->submit(allreduce_config, streamB);   // kernel B enqueued on streamB
```
preKernelLaunch checks lastUserStream_ (set during eager submits), but the graph replay didn't go through submit() at all -- it was a raw cudaGraphLaunch. Even if it had, execOrderStream_ has no record of the graph's completion. Kernel B launches without waiting for kernel A.

# General Idea

Consider the case where 3 kernel submissions occur concurrently on streams A, B, A.

Previously, we would do the following: 

```
                      submit 1 (A)            submit 2 (B)                 submit 3 (A)
                   ┌───────────────┐     ┌────────────────────┐       ┌─────────────────────┐

streamA         ──[kernel 1]──record(E)─────────────────────────────wait(E)──[kernel 3]──record(E)───
                                 │                                     ▲                    │
                                 ▼                                     │                    ▼
execOrderStream ──────────────wait(E)──record(E)───────────wait(E)──record(E)─────────────wait(E)────
                                         │                    ▲
                                         ▼                    │
streamB         ──────────────────────wait(E)──[kernel 2]──record(E)─────────────────────────────────

E = execEvent_ (single shared event, reused for every record/wait)

Per cross-stream submit:
  pre:   cudaEventRecord(E, execOrderStream_)      ─┐ 2 calls
         cudaStreamWaitEvent(curStream, E)         ─┘
  post:  cudaEventRecord(E, curStream)             ─┐ 2 calls
         cudaStreamWaitEvent(execOrderStream_, E)  ─┘
```

Whereas now, we will do:

```
                    submit 1              submit 2              submit 3
                ┌──────────────┐    ┌──────────────────┐    ┌──────────────┐

streamA         ──[kernel 1]──record(E)──────────────────────wait(E)──[kernel 3]──record(E)──
                                    │                           ▲                     │
                                    └───────────┐    ┌──────────┘                     │
                                                ▼    │                            (next waits)
streamB         ────────────────────────────wait(E)──[kernel 2]──record(E)────────────────────
                                                                     │
                                                          (submit 3 waits on this)

E = execModeSyncEvent_ (single bare event, no internal stream)

  submit 1 (A):  acquire: first submit, skip            ─  0 calls
                 release: cudaEventRecord(E, A)         ─  1 call

  submit 2 (B):  acquire: B != A, cudaStreamWaitEvent   ─  1 call
                 release: cudaEventRecord(E, B)         ─  1 call

  submit 3 (A):  acquire: A != B, cudaStreamWaitEvent   ─  1 call
                 release: cudaEventRecord(E, A)         ─  1 call
```
Two fewer cuda calls per submission (4 --> 2), and a (subjectively) simpler execution topology.

If the submitting stream doesn't oscillate, we are able to reduce this to 1 per submission.

```
                    submit 1              submit 2              submit 3
                ┌──────────────┐    ┌──────────────────┐    ┌──────────────┐

streamA         ──[kernel 1]──record(E)──[kernel 2]──record(E)──[kernel 3]──record(E)──
                       │          │           │           │           │          │
                    acquire    release     acquire     release     acquire    release
```

Now consider the graph capture case where we have kernels being submitted on multiple streams...

```
                        submit 1                            submit 2
                ┌─────────────────────┐    ┌──────────────────────────────────┐

streamA         ──[kernel A]──addEventRecordNode(E, &node)─────────────────────────────────
                                                │
                                                │  updateCaptureDependencies(B, &node, ADD)
                                                │
streamB         ────────────────────────────────────[kernel B]──addEventRecordNode(E, &node)
```
During capture, we use `cudaStreamUpdateCaptureDependencies` to create an explicit graph edge from the previous record node to the upcoming kernel node, which enforces the serial topology between captured kernels.

the resulting DAG would look something like...

```
    ┌─────────┐    ┌──────────┐    ┌──────────┐    ┌─────────┐    ┌──────────┐    ┌──────────┐
───►│ WAIT(E) │───►│ KERNEL A │───►│ RECORD(E)│───►│ WAIT(E) │───►│ KERNEL B │───►│ RECORD(E)│
    └─────────┘    └──────────┘    └──────────┘    └─────────┘    └──────────┘    └──────────┘
                                        │                ▲                       
                                        │                │                               
    ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┼ ─ ─ ─ ─ ─ ─ ─ ─│─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ graph boundary
                                        │   eager exec   │                               
                                        └────────────────┘                               
                                      WAIT(E)        RECORD(E)                                         
```
We use external events in order to break the graph "boundary". We are effectively peeking outside of the graph after each kernel, and seeing if it has any work queued up before we start the next one.

Reviewed By: ngimel

Differential Revision: D95253327


