### PR TITLE
Add device_alltoallv with pipes transport (#1044)

### DIFF
--- a/comms/ctran/Ctran.cc
+++ b/comms/ctran/Ctran.cc
@@ -17,6 +17,7 @@
 #include "comms/ctran/utils/CommGroupUtils.h"
 
 #if defined(ENABLE_PIPES)
+#include "comms/pipes/MultiPeerDeviceHandle.cuh"
 #include "comms/pipes/MultiPeerTransport.h"
 #endif // defined(ENABLE_PIPES)
 
@@ -93,6 +94,19 @@ uint64_t Ctran::getOpCount() const {
 uint64_t Ctran::getCtranOpCount() const {
   return comm_->getCtranOpCount();
 }
+
+#if defined(ENABLE_PIPES)
+comms::pipes::Transport* CtranComm::getMultiPeerTransportsPtr() const {
+  if (!multiPeerTransport_) {
+    return nullptr;
+  }
+  return multiPeerTransport_->get_device_handle().transports.data();
+}
+#else
+comms::pipes::Transport* CtranComm::getMultiPeerTransportsPtr() const {
+  return nullptr;
+}
+#endif // defined(ENABLE_PIPES)
 
 commResult_t ctranInit(CtranComm* comm) {
   NcclScubaEvent initEvent(&comm->logMetaData_);

--- a/comms/ctran/Ctran.h
+++ b/comms/ctran/Ctran.h
@@ -125,6 +125,19 @@ commResult_t ctranAllToAll(
 
 bool ctranAllToAllvSupport(CtranComm* comm);
 
+bool ctranDeviceAllToAllvSupport(CtranComm* comm);
+
+commResult_t ctranDeviceAllToAllv(
+    const void* sendbuff,
+    void* recvbuff,
+    const int64_t* sendcounts_d,
+    const int64_t* recvcounts_d,
+    const int64_t* senddispls_d,
+    const int64_t* recvdispls_d,
+    commDataType_t datatype,
+    CtranComm* comm,
+    cudaStream_t stream);
+
 commResult_t ctranAllToAllv(
     const void* sendbuff,
     const size_t sendcounts[],

--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -16,6 +16,11 @@
 #include "comms/utils/colltrace/CollTraceInterface.h"
 #include "comms/utils/commSpecs.h"
 
+namespace comms::pipes {
+class MultiPeerTransport;
+struct Transport;
+} // namespace comms::pipes
+
 using meta::comms::CommBackend;
 struct ctranConfig {
   int blocking{-1};
@@ -125,6 +130,11 @@ class CtranComm {
   // TODO: after finish refactoring remove factory method and define proper
   // constructor
   friend commResult_t setCtranCommBase(ncclComm* comm);
+
+  // Get a pointer to the Transport array from MultiPeerTransport,
+  // indexed by global rank. Returns nullptr if MultiPeerTransport is not
+  // initialized.
+  comms::pipes::Transport* getMultiPeerTransportsPtr() const;
 
   // fields are public to allow access from external code and tests
   // TODO: remove config_, it's redundant

--- a/comms/ctran/algos/AllToAll/AllToAll.cc
+++ b/comms/ctran/algos/AllToAll/AllToAll.cc
@@ -8,10 +8,22 @@
 #include "comms/ctran/algos/AllToAll/AllToAllImpl.h"
 #include "comms/ctran/algos/AllToAll/AllToAllPImpl.h"
 #include "comms/ctran/algos/AllToAll/AllToAllvImpl.h"
+#if defined(ENABLE_PIPES)
+#include "comms/ctran/algos/AllToAll/DeviceAllToAllvPipesImpl.h"
+#include "comms/pipes/MultiPeerTransport.h"
+#include "comms/pipes/Transport.cuh"
+#endif
 #include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/ctran/gpe/CtranGpe.h"
 #include "comms/ctran/utils/CtranPerf.h"
 #include "comms/utils/cvars/nccl_cvars.h"
+
+#if defined(ENABLE_PIPES)
+extern __global__ void ncclKernelDeviceAllToAllvPipes(
+    int* flag,
+    CtranAlgoDeviceState* devState,
+    ctran::device_alltoallv_pipes::KernArgs args);
+#endif
 
 #define RETURN_ALLTOALLV_IB_IMPL(perfconfig) \
   return ctranAllToAllvIbImpl<perfconfig>(   \
@@ -182,3 +194,102 @@ bool ctranAllToAllSupport(
     return false;
   }
 }
+
+#if defined(ENABLE_PIPES)
+// ============================================================================
+// Device AllToAllv (split sizes on device)
+// NVLink domain only — all peers must be reachable via NVLink.
+// IB support will be added in a follow-up via IBGDA (not CPU proxy).
+// ============================================================================
+
+commResult_t ctranDeviceAllToAllv(
+    const void* sendbuff,
+    void* recvbuff,
+    const int64_t* sendcounts_d,
+    const int64_t* recvcounts_d,
+    const int64_t* senddispls_d,
+    const int64_t* recvdispls_d,
+    commDataType_t datatype,
+    CtranComm* comm,
+    cudaStream_t stream) {
+  auto opCount = comm->ctran_->getOpCount();
+
+  KernelConfig config = KernelConfig(
+      KernelConfig::KernelType::DEVICE_ALLTOALLV,
+      stream,
+      "DeviceAllToAllvPipes",
+      opCount);
+
+  ctran::device_alltoallv_pipes::KernArgs kernArgs;
+  FB_COMMCHECK(
+      ctran::device_alltoallv_pipes::setupKernelConfig(
+          sendbuff,
+          recvbuff,
+          sendcounts_d,
+          recvcounts_d,
+          senddispls_d,
+          recvdispls_d,
+          datatype,
+          comm,
+          config,
+          kernArgs));
+
+  // NVLink-only: no GPE op needed (no IB fallback)
+  std::vector<std::unique_ptr<struct OpElem>> opGroup;
+
+  FB_COMMCHECK(comm->ctran_->gpe->submit(
+      std::move(opGroup),
+      nullptr,
+      config,
+      reinterpret_cast<void*>(ncclKernelDeviceAllToAllvPipes)));
+
+  return commSuccess;
+}
+
+bool ctranDeviceAllToAllvSupport(CtranComm* comm) {
+  if (!ctranInitialized(comm)) {
+    return false;
+  }
+
+  // Require MultiPeerTransport (pipes)
+  if (!comm->multiPeerTransport_) {
+    return false;
+  }
+
+  // NVLink domain only: verify ALL peers are reachable via NVLink (or self).
+  // Reject communicators with any IB-only peers to prevent silent data loss.
+  // Use host-side API — getMultiPeerTransportsPtr() returns a device pointer
+  // that cannot be dereferenced on the host.
+  const auto statex = comm->statex_.get();
+  for (int rank = 0; rank < statex->nRanks(); rank++) {
+    auto type = comm->multiPeerTransport_->get_transport_type(rank);
+    if (type != comms::pipes::TransportType::P2P_NVL &&
+        type != comms::pipes::TransportType::SELF) {
+      return false;
+    }
+  }
+
+  return true;
+}
+#endif // ENABLE_PIPES
+
+// Stubs when ENABLE_PIPES is not defined — prevents linker errors from
+// unconditional declarations in Ctran.h.
+#if !defined(ENABLE_PIPES)
+commResult_t ctranDeviceAllToAllv(
+    const void* /*sendbuff*/,
+    void* /*recvbuff*/,
+    const int64_t* /*sendcounts_d*/,
+    const int64_t* /*recvcounts_d*/,
+    const int64_t* /*senddispls_d*/,
+    const int64_t* /*recvdispls_d*/,
+    commDataType_t /*datatype*/,
+    CtranComm* /*comm*/,
+    cudaStream_t /*stream*/) {
+  return commInternalError;
+}
+
+bool ctranDeviceAllToAllvSupport(CtranComm* /*comm*/) {
+  return false;
+}
+#endif // !ENABLE_PIPES

--- a/comms/ctran/algos/AllToAll/DeviceAllToAllvPipes.cu
+++ b/comms/ctran/algos/AllToAll/DeviceAllToAllvPipes.cu
@@ -1,0 +1,89 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#if defined(ENABLE_PIPES)
+
+#include <cstddef>
+#include "comms/ctran/algos/AllToAll/Types.h"
+#include "comms/ctran/algos/CtranAlgoDev.h"
+#include "comms/ctran/algos/DevAlgoImpl.cuh"
+#include "comms/ctran/algos/DevCommon.cuh"
+#include "comms/ctran/gpe/CtranGpeDev.h"
+#include "comms/pipes/DeviceSpan.cuh"
+#include "comms/pipes/Transport.cuh"
+
+__global__ void ncclKernelDeviceAllToAllvPipes(
+    int* flag,
+    CtranAlgoDeviceState* devState,
+    ctran::device_alltoallv_pipes::KernArgs args) {
+  const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
+
+  if (flag && gtIdx == 0) {
+    ctran::device::devLoadAbortFlags(flag, devState);
+    ctran::device::KernelStartGpe(flag);
+  }
+
+  const int nLocalRanks = args.nLocalRanks;
+  const int myRank = args.myRank;
+  const size_t elementSize = args.elementSize;
+  auto* transports = args.transports;
+
+  auto group = args.useBlockGroup ? comms::pipes::make_block_group()
+                                  : comms::pipes::make_warp_group();
+
+  if (nLocalRanks == 1) {
+    // Single local rank — self-copy only
+    int globalRank = args.localRankToGlobalRank[0];
+    size_t sendBytes = args.sendcounts_d[globalRank] * elementSize;
+    size_t sendOffset = args.senddispls_d[globalRank] * elementSize;
+    size_t recvOffset = args.recvdispls_d[globalRank] * elementSize;
+
+    transports[globalRank].self.put(
+        group,
+        static_cast<char*>(args.recvbuff) + recvOffset,
+        static_cast<const char*>(args.sendbuff) + sendOffset,
+        sendBytes);
+  } else {
+    // Split into send and recv halves
+    auto [partition_id, send_recv_group] = group.partition_interleaved(2);
+    // Distribute across local peers
+    auto [local_peer_idx, group_per_peer] =
+        send_recv_group.partition_interleaved(nLocalRanks);
+
+    int peerGlobalRank = args.localRankToGlobalRank[local_peer_idx];
+
+    // Read counts and displacements from device memory (indexed by global rank)
+    size_t sendBytes = args.sendcounts_d[peerGlobalRank] * elementSize;
+    size_t recvBytes = args.recvcounts_d[peerGlobalRank] * elementSize;
+    size_t sendOffset = args.senddispls_d[peerGlobalRank] * elementSize;
+    size_t recvOffset = args.recvdispls_d[peerGlobalRank] * elementSize;
+
+    if (peerGlobalRank == myRank) {
+      // Self-copy: only one partition does it
+      if (partition_id == 0) {
+        transports[peerGlobalRank].self.put(
+            group_per_peer,
+            static_cast<char*>(args.recvbuff) + recvOffset,
+            static_cast<const char*>(args.sendbuff) + sendOffset,
+            sendBytes);
+      }
+    } else if (partition_id == 0) {
+      // Send to peer via NVL
+      transports[peerGlobalRank].p2p_nvl.send(
+          group_per_peer,
+          static_cast<char*>(const_cast<void*>(args.sendbuff)) + sendOffset,
+          sendBytes);
+    } else {
+      // Recv from peer via NVL
+      transports[peerGlobalRank].p2p_nvl.recv(
+          group_per_peer,
+          static_cast<char*>(args.recvbuff) + recvOffset,
+          recvBytes);
+    }
+  }
+
+  if (flag && gtIdx == 0) {
+    ctran::device::KernelWaitGpeTerminate(flag);
+  }
+}
+
+#endif // ENABLE_PIPES

--- a/comms/ctran/algos/AllToAll/DeviceAllToAllvPipesImpl.cc
+++ b/comms/ctran/algos/AllToAll/DeviceAllToAllvPipesImpl.cc
@@ -1,0 +1,98 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/ctran/algos/AllToAll/DeviceAllToAllvPipesImpl.h"
+#include "comms/ctran/algos/CtranAlgoDev.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+
+namespace ctran::device_alltoallv_pipes {
+
+commResult_t setupKernelConfig(
+    const void* sendbuff,
+    void* recvbuff,
+    const int64_t* sendcounts_d,
+    const int64_t* recvcounts_d,
+    const int64_t* senddispls_d,
+    const int64_t* recvdispls_d,
+    commDataType_t datatype,
+    CtranComm* comm,
+    KernelConfig& config,
+    ctran::device_alltoallv_pipes::KernArgs& kernArgs) {
+  const auto statex = comm->statex_.get();
+
+  kernArgs.sendbuff = sendbuff;
+  kernArgs.recvbuff = recvbuff;
+  kernArgs.elementSize = commTypeSize(datatype);
+  kernArgs.myRank = statex->rank();
+  kernArgs.nLocalRanks = statex->nLocalRanks();
+
+  // Device pointers to split sizes and displacements
+  kernArgs.sendcounts_d = sendcounts_d;
+  kernArgs.recvcounts_d = recvcounts_d;
+  kernArgs.senddispls_d = senddispls_d;
+  kernArgs.recvdispls_d = recvdispls_d;
+
+  // Build local rank → global rank mapping
+  if (kernArgs.nLocalRanks > CTRAN_MAX_NVL_PEERS) {
+    return commInternalError;
+  }
+  for (int lr = 0; lr < kernArgs.nLocalRanks; lr++) {
+    kernArgs.localRankToGlobalRank[lr] = statex->localRankToRank(lr);
+  }
+
+  // Set transport array from MultiPeerTransport
+  kernArgs.transports = comm->getMultiPeerTransportsPtr();
+
+  // Scheduling: warp (default) vs block
+  const char* blockSchedEnv = getenv("NCCL_CTRAN_DA2A_BLOCK_SCHEDULING");
+  kernArgs.useBlockGroup = (blockSchedEnv && std::atoi(blockSchedEnv) == 1);
+
+  // Grid/block config — parameterizable via env vars for tuning
+  unsigned int numBlocks = std::max(1, kernArgs.nLocalRanks * 2);
+
+  // Block scheduling requires at least 2 * nLocalRanks blocks
+  // (one send + one recv block per peer)
+  if (kernArgs.useBlockGroup) {
+    numBlocks = std::max(
+        numBlocks, static_cast<unsigned int>(kernArgs.nLocalRanks * 2));
+  }
+  const char* numBlocksEnv = getenv("NCCL_CTRAN_DA2A_NBLOCKS");
+  if (numBlocksEnv) {
+    numBlocks = static_cast<unsigned int>(std::atoi(numBlocksEnv));
+  }
+
+  unsigned int clusterSize = NCCL_CTRAN_CGA_CLUSTER_SIZE;
+  if (clusterSize > 1 && numBlocks % clusterSize != 0) {
+    numBlocks = ((numBlocks + clusterSize - 1) / clusterSize) * clusterSize;
+  }
+
+  // DeviceAllToAllvPipes doesn't use GPE ops (opGroup is empty) or per-block
+  // sync structures (CtranAlgoDeviceSync, KernelElem). Only flag[0] is used
+  // by thread 0 for start/terminate. The CTRAN_ALGO_MAX_THREAD_BLOCKS limit
+  // doesn't apply here. See AllToAllvDedup (AlgoImpl.cc) for same pattern.
+  config.numBlocks = numBlocks;
+
+  unsigned int numThreads = 256;
+  const char* numThreadsEnv = getenv("NCCL_CTRAN_DA2A_NTHREADS");
+  if (numThreadsEnv) {
+    numThreads = static_cast<unsigned int>(std::atoi(numThreadsEnv));
+  } else if (NCCL_CTRAN_ALLTOALL_THREAD_BLOCK_SIZE > 0) {
+    numThreads = NCCL_CTRAN_ALLTOALL_THREAD_BLOCK_SIZE;
+  }
+  config.numThreads = numThreads;
+
+  // Performance tuning env vars (all read at runtime, no recompile needed):
+  //   NCCL_CTRAN_DA2A_NBLOCKS  — override block count (default: nLocalRanks*2)
+  //   NCCL_CTRAN_DA2A_NTHREADS — override thread count (default: 256)
+  //   NCCL_CTRAN_DA2A_BLOCK_SCHEDULING=1 — use block-level scheduling
+  //     (each block handles one peer) instead of warp-level (default)
+  //   NCCL_CTRAN_ENALBE_CLUSTER_KERNEL_LAUNCH=1 — enable cluster launch
+  //   NCCL_CTRAN_CGA_CLUSTER_SIZE — cluster size (default: 4)
+  //   NCCL_CTRAN_PIPES_NVL_CHUNK_SIZE — NVL chunk size bytes (default: 512KB)
+
+  config.args.devState_d = comm->ctran_->algo->getDevState();
+  config.algoArgs = &kernArgs;
+
+  return commSuccess;
+}
+
+} // namespace ctran::device_alltoallv_pipes

--- a/comms/ctran/algos/AllToAll/DeviceAllToAllvPipesImpl.h
+++ b/comms/ctran/algos/AllToAll/DeviceAllToAllvPipesImpl.h
@@ -1,0 +1,22 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#pragma once
+
+#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/algos/AllToAll/Types.h"
+#include "comms/ctran/algos/CtranAlgo.h"
+
+namespace ctran::device_alltoallv_pipes {
+
+commResult_t setupKernelConfig(
+    const void* sendbuff,
+    void* recvbuff,
+    const int64_t* sendcounts_d,
+    const int64_t* recvcounts_d,
+    const int64_t* senddispls_d,
+    const int64_t* recvdispls_d,
+    commDataType_t datatype,
+    CtranComm* comm,
+    KernelConfig& config,
+    ctran::device_alltoallv_pipes::KernArgs& kernArgs);
+
+} // namespace ctran::device_alltoallv_pipes

--- a/comms/ctran/algos/AllToAll/Types.h
+++ b/comms/ctran/algos/AllToAll/Types.h
@@ -2,10 +2,15 @@
 
 #pragma once
 
+#include "comms/ctran/algos/CtranAlgoDev.h" // for CTRAN_MAX_NVL_PEERS
 #include "comms/utils/commSpecs.h"
 
-// Forward declaration
+// Forward declarations
 struct KernelElem;
+
+namespace comms::pipes {
+struct Transport;
+}
 
 #define CTRAN_MAX_TOTAL_RANK (128)
 
@@ -21,6 +26,38 @@ struct KernelArgs {
 };
 
 } // namespace alltoall
+
+namespace device_alltoallv_pipes {
+
+struct KernArgs {
+  const void* sendbuff;
+  void* recvbuff;
+  int nLocalRanks; // number of ranks on this node
+  int myRank; // global rank of this process
+  size_t elementSize; // bytes per element (commTypeSize(datatype))
+
+  // Device pointers to split sizes (int64_t, indexed by global rank)
+  const int64_t* sendcounts_d; // [nRanks] send counts per rank
+  const int64_t* recvcounts_d; // [nRanks] recv counts per rank
+
+  // Device pointers to displacements (int64_t, indexed by global rank)
+  const int64_t* senddispls_d; // [nRanks] send displacements per rank
+  const int64_t* recvdispls_d; // [nRanks] recv displacements per rank
+
+  // Maps local rank index [0..nLocalRanks) to global rank
+  int localRankToGlobalRank[CTRAN_MAX_NVL_PEERS];
+
+  // Transport array from MultiPeerTransport, indexed by global rank
+  comms::pipes::Transport* transports;
+
+  // If true, use block-level scheduling (make_block_group) instead of
+  // warp-level scheduling (make_warp_group). Block scheduling dedicates
+  // all threads in a block to one peer; warp scheduling distributes
+  // warps across peers for chunk-level pipelining.
+  bool useBlockGroup;
+};
+
+} // namespace device_alltoallv_pipes
 
 namespace alltoallv {
 

--- a/comms/ctran/colltrace/CollTraceWrapper.cc
+++ b/comms/ctran/colltrace/CollTraceWrapper.cc
@@ -199,6 +199,18 @@ CollectiveMetadata getCollectiveMetadata(
           .count = allToAllArgs.count,
       };
     }
+    case KernelConfig::KernelType::DEVICE_ALLTOALLV: {
+      auto* pipesArgs =
+          static_cast<const ctran::device_alltoallv_pipes::KernArgs*>(
+              kernelConfig.algoArgs);
+      return CollectiveMetadata{
+          .opName = "DeviceAllToAllv_Pipes",
+          .algoName = kernelConfig.algoName,
+          .opCount = opCount,
+          .sendbuff = reinterpret_cast<uintptr_t>(pipesArgs->sendbuff),
+          .recvbuff = reinterpret_cast<uintptr_t>(pipesArgs->recvbuff),
+      };
+    }
     case KernelConfig::KernelType::ALLTOALLV: {
       auto allToAllvArgs = kernelConfig.args.collective.alltoallv;
       return CollectiveMetadata{

--- a/comms/ctran/gpe/CtranGpe.cc
+++ b/comms/ctran/gpe/CtranGpe.cc
@@ -324,6 +324,7 @@ static std::unordered_map<KernelConfig::KernelType, std::string>
         {KernelConfig::KernelType::ALLGATHER, "ALLGATHER"},
         {KernelConfig::KernelType::ALLREDUCE, "ALLREDUCE"},
         {KernelConfig::KernelType::ALLTOALL, "ALLTOALL"},
+        {KernelConfig::KernelType::DEVICE_ALLTOALLV, "DEVICE_ALLTOALLV"},
         {KernelConfig::KernelType::ALLTOALLV, "ALLTOALLV"},
         {KernelConfig::KernelType::ALLTOALL_DEDUP, "ALLTOALL_DEDUP"},
         {KernelConfig::KernelType::ALLTOALLV_DYNAMIC, "ALLTOALLV_DYNAMIC"},

--- a/comms/ctran/gpe/CtranGpe.h
+++ b/comms/ctran/gpe/CtranGpe.h
@@ -46,6 +46,7 @@ struct OpElem {
     ALLTOALL,
     ALLTOALLP,
     ALLTOALLV,
+    DEVICE_ALLTOALLV,
     ALLTOALLV_DYNAMIC,
     ALLTOALLV_DYNAMIC_SPLIT,
     ALLTOALLV_DYNAMIC_SPLIT_NON_CONTIG,
@@ -156,6 +157,13 @@ struct OpElem {
       std::vector<size_t> rdispls;
       commDataType_t datatype;
     } alltoallv;
+    struct {
+      const void* sendbuff;
+      void* recvbuff;
+      const int64_t* sendcounts_d; // device pointer
+      const int64_t* recvcounts_d; // device pointer
+      commDataType_t datatype;
+    } device_alltoallv;
     struct {
       const void* const* sendbuffs;
       void* const* recvbuffs;
@@ -293,6 +301,7 @@ struct KernelConfig {
     SENDRECV_STAGED,
     SENDRECV_P2P,
     ALLTOALL,
+    DEVICE_ALLTOALLV,
     ALLTOALLV,
     ALLTOALLV_DYNAMIC,
     ALLTOALLV_DYNAMIC_SPLIT,

--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -38,6 +38,7 @@ static std::unordered_map<KernelConfig::KernelType, const std::string>
         {KernelConfig::KernelType::RECV, "Recv"},
         {KernelConfig::KernelType::SENDRECV, "SendRecv"},
         {KernelConfig::KernelType::ALLTOALL, "AllToAll"},
+        {KernelConfig::KernelType::DEVICE_ALLTOALLV, "DeviceAllToAllvPipes"},
         {KernelConfig::KernelType::ALLTOALLV, "AllToAllv"},
         {KernelConfig::KernelType::ALLTOALLV_DYNAMIC, "AllToAllvDynamic"},
         {KernelConfig::KernelType::ALLTOALLV_DYNAMIC_SPLIT,

--- a/comms/ctran/tests/DeviceAllToAllvTest.cc
+++ b/comms/ctran/tests/DeviceAllToAllvTest.cc
@@ -1,0 +1,165 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#include <numeric>
+#include <vector>
+
+#include <folly/init/Init.h>
+
+#include "comms/ctran/Ctran.h"
+#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/tests/CtranDistTestUtils.h"
+#include "comms/ctran/tests/CtranTestUtils.h"
+#include "comms/testinfra/TestXPlatUtils.h"
+
+using namespace meta::comms;
+
+class DeviceAllToAllvEnvironment : public ctran::CtranEnvironmentBase {
+ public:
+  void SetUp() override {
+    ctran::CtranEnvironmentBase::SetUp();
+    setenv("NCCL_CTRAN_USE_PIPES", "1", 1);
+    setenv("NCCL_CTRAN_ENABLE", "1", 1);
+  }
+};
+
+class DeviceAllToAllvTest : public ctran::CtranDistTestFixture {
+ public:
+  void SetUp() override {
+    CtranDistTestFixture::SetUp();
+    CUDACHECK_TEST(cudaStreamCreate(&stream_));
+  }
+
+  void TearDown() override {
+    CUDACHECK_TEST(cudaStreamDestroy(stream_));
+    CtranDistTestFixture::TearDown();
+  }
+
+ protected:
+  cudaStream_t stream_;
+};
+
+// Uniform split: each rank sends/receives chunkSize elements to/from every peer
+TEST_F(DeviceAllToAllvTest, UniformSplit) {
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+  ASSERT_NE(comm->multiPeerTransport_, nullptr);
+
+  // Check support — skip if not all NVLink peers
+  if (!ctranDeviceAllToAllvSupport(comm.get())) {
+    GTEST_SKIP() << "deviceAllToAllv not supported (requires all NVLink peers)";
+  }
+
+  const int nRanks = numRanks;
+  const size_t chunkSize = 1024; // CTRAN minimum
+  const size_t totalSize = chunkSize * nRanks;
+
+  // Allocate GPU buffers
+  float* sendBuf = nullptr;
+  float* recvBuf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&sendBuf, totalSize * sizeof(float)));
+  CUDACHECK_TEST(cudaMalloc(&recvBuf, totalSize * sizeof(float)));
+
+  // Fill send buffer with rank value
+  std::vector<float> h_send(totalSize, static_cast<float>(globalRank));
+  CUDACHECK_TEST(cudaMemcpy(
+      sendBuf,
+      h_send.data(),
+      totalSize * sizeof(float),
+      cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(cudaMemset(recvBuf, 0, totalSize * sizeof(float)));
+
+  // Create device count/offset arrays (uniform split)
+  std::vector<int64_t> h_counts(nRanks, static_cast<int64_t>(chunkSize));
+  std::vector<int64_t> h_offsets(nRanks);
+  for (int i = 0; i < nRanks; i++) {
+    h_offsets[i] = static_cast<int64_t>(i * chunkSize);
+  }
+
+  int64_t* d_sendcounts = nullptr;
+  int64_t* d_recvcounts = nullptr;
+  int64_t* d_senddispls = nullptr;
+  int64_t* d_recvdispls = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&d_sendcounts, nRanks * sizeof(int64_t)));
+  CUDACHECK_TEST(cudaMalloc(&d_recvcounts, nRanks * sizeof(int64_t)));
+  CUDACHECK_TEST(cudaMalloc(&d_senddispls, nRanks * sizeof(int64_t)));
+  CUDACHECK_TEST(cudaMalloc(&d_recvdispls, nRanks * sizeof(int64_t)));
+
+  CUDACHECK_TEST(cudaMemcpy(
+      d_sendcounts,
+      h_counts.data(),
+      nRanks * sizeof(int64_t),
+      cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(cudaMemcpy(
+      d_recvcounts,
+      h_counts.data(),
+      nRanks * sizeof(int64_t),
+      cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(cudaMemcpy(
+      d_senddispls,
+      h_offsets.data(),
+      nRanks * sizeof(int64_t),
+      cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(cudaMemcpy(
+      d_recvdispls,
+      h_offsets.data(),
+      nRanks * sizeof(int64_t),
+      cudaMemcpyHostToDevice));
+
+  // Run deviceAllToAllv
+  auto result = ctranDeviceAllToAllv(
+      sendBuf,
+      recvBuf,
+      d_sendcounts,
+      d_recvcounts,
+      d_senddispls,
+      d_recvdispls,
+      commFloat,
+      comm.get(),
+      stream_);
+  ASSERT_EQ(result, commSuccess);
+  CUDACHECK_TEST(cudaStreamSynchronize(stream_));
+
+  // Verify: segment j should contain value j (sent from rank j)
+  std::vector<float> h_recv(totalSize);
+  CUDACHECK_TEST(cudaMemcpy(
+      h_recv.data(),
+      recvBuf,
+      totalSize * sizeof(float),
+      cudaMemcpyDeviceToHost));
+
+  for (int j = 0; j < nRanks; j++) {
+    for (size_t k = 0; k < chunkSize; k++) {
+      EXPECT_EQ(h_recv[j * chunkSize + k], static_cast<float>(j))
+          << "Rank " << globalRank << ": segment " << j << " element " << k
+          << " expected " << j << " got " << h_recv[j * chunkSize + k];
+    }
+  }
+
+  // Cleanup
+  CUDACHECK_TEST(cudaFree(sendBuf));
+  CUDACHECK_TEST(cudaFree(recvBuf));
+  CUDACHECK_TEST(cudaFree(d_sendcounts));
+  CUDACHECK_TEST(cudaFree(d_recvcounts));
+  CUDACHECK_TEST(cudaFree(d_senddispls));
+  CUDACHECK_TEST(cudaFree(d_recvdispls));
+}
+
+// Verify support check passes when pipes is initialized
+TEST_F(DeviceAllToAllvTest, SupportedWithPipes) {
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+  ASSERT_NE(comm->multiPeerTransport_, nullptr);
+
+  // Should be supported with MultiPeerTransport and NVLink peers
+  EXPECT_TRUE(ctranDeviceAllToAllvSupport(comm.get()));
+}
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new DeviceAllToAllvEnvironment);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ncclx/v2_27/meta/colltrace/CollTraceFunc.cc
+++ b/comms/ncclx/v2_27/meta/colltrace/CollTraceFunc.cc
@@ -395,6 +395,10 @@ bool collTraceRecordCtranKernelInfo(
       coll.count = allToAllArgs.count;
       break;
     }
+    case KernelConfig::KernelType::DEVICE_ALLTOALLV: {
+      coll.opName = "DeviceAllToAllvPipes";
+      break;
+    }
     case KernelConfig::KernelType::ALLTOALLV: {
       coll.opName = "AllToAllV";
       auto allToAllvArgs = kernelConfig.args.collective.alltoallv;
@@ -519,6 +523,12 @@ bool collTraceRecordCtranCollective(
       coll.dataType = metaCommToNccl(gpeOp.alltoallv.datatype);
       // Explicitly leave count as nullopt because there is no single count for
       // AllToAllV
+      break;
+    case OpElem::DEVICE_ALLTOALLV:
+      coll.opName = "DeviceAllToAllV";
+      coll.sendbuff = gpeOp.device_alltoallv.sendbuff;
+      coll.recvbuff = gpeOp.device_alltoallv.recvbuff;
+      coll.dataType = metaCommToNccl(gpeOp.device_alltoallv.datatype);
       break;
     case OpElem::ALLTOALLP: {
       coll.opName = "AllToAllP";

--- a/comms/ncclx/v2_27/src/device/Makefile
+++ b/comms/ncclx/v2_27/src/device/Makefile
@@ -35,6 +35,11 @@ NVCUFLAGS += --compiler-options "-DCTRAN_DISABLE_TCPDM"
 NVCUFLAGS_SYM += --compiler-options "-DCTRAN_DISABLE_TCPDM"
 endif
 
+ifeq ($(ENABLE_PIPES),1)
+NVCUFLAGS += --compiler-options "-DENABLE_PIPES"
+NVCUFLAGS_SYM += --compiler-options "-DENABLE_PIPES"
+endif
+
 SAY = @bash -c 'path="$$2"; [[ "$$(realpath "$$2")" =~ ^$(subst .,\.,$(abspath $(NCCLDIR)))/(.*)$$ ]] && path="$${BASH_REMATCH[1]}"; printf "%-15s %s\n" "$$1" "$$path"' SAY
 
 COMPILE.cu = $(NVCC) $(NVCUFLAGS) -dc $2 -o $1
@@ -102,6 +107,7 @@ $(OBJDIR)/gensrc/symmetric/rules.mk: $(OBJDIR)/gensrc/symmetric ;
 
 SRCS = common.cu onerank.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllToAll/AllToAllPImpl.cu
+SRCS += ${BASE_DIR}/comms/ctran/algos/AllToAll/DeviceAllToAllvPipes.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllGather/AllGatherRing.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllGather/AllGatherRecDbl.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllReduce/AllReduceShm.cu

--- a/comms/ncclx/v2_28/meta/colltrace/CollTraceFunc.cc
+++ b/comms/ncclx/v2_28/meta/colltrace/CollTraceFunc.cc
@@ -395,6 +395,10 @@ bool collTraceRecordCtranKernelInfo(
       coll.count = allToAllArgs.count;
       break;
     }
+    case KernelConfig::KernelType::DEVICE_ALLTOALLV: {
+      coll.opName = "DeviceAllToAllvPipes";
+      break;
+    }
     case KernelConfig::KernelType::ALLTOALLV: {
       coll.opName = "AllToAllV";
       auto allToAllvArgs = kernelConfig.args.collective.alltoallv;
@@ -519,6 +523,12 @@ bool collTraceRecordCtranCollective(
       coll.dataType = metaCommToNccl(gpeOp.alltoallv.datatype);
       // Explicitly leave count as nullopt because there is no single count for
       // AllToAllV
+      break;
+    case OpElem::DEVICE_ALLTOALLV:
+      coll.opName = "DeviceAllToAllV";
+      coll.sendbuff = gpeOp.device_alltoallv.sendbuff;
+      coll.recvbuff = gpeOp.device_alltoallv.recvbuff;
+      coll.dataType = metaCommToNccl(gpeOp.device_alltoallv.datatype);
       break;
     case OpElem::ALLTOALLP: {
       coll.opName = "AllToAllP";

--- a/comms/ncclx/v2_28/src/device/Makefile
+++ b/comms/ncclx/v2_28/src/device/Makefile
@@ -35,6 +35,11 @@ NVCUFLAGS += --compiler-options "-DCTRAN_DISABLE_TCPDM"
 NVCUFLAGS_SYM += --compiler-options "-DCTRAN_DISABLE_TCPDM"
 endif
 
+ifeq ($(ENABLE_PIPES),1)
+NVCUFLAGS += --compiler-options "-DENABLE_PIPES"
+NVCUFLAGS_SYM += --compiler-options "-DENABLE_PIPES"
+endif
+
 SAY = @bash -c 'path="$$2"; [[ "$$(realpath "$$2")" =~ ^$(subst .,\.,$(abspath $(NCCLDIR)))/(.*)$$ ]] && path="$${BASH_REMATCH[1]}"; printf "%-15s %s\n" "$$1" "$$path"' SAY
 
 COMPILE.cu = $(NVCC) $(NVCUFLAGS) -dc $2 -o $1
@@ -107,6 +112,7 @@ $(OBJDIR)/gensrc/symmetric/rules.mk: $(OBJDIR)/gensrc/symmetric ;
 
 SRCS = common.cu onerank.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllToAll/AllToAllPImpl.cu
+SRCS += ${BASE_DIR}/comms/ctran/algos/AllToAll/DeviceAllToAllvPipes.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllGather/AllGatherRing.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllGather/AllGatherRecDbl.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllReduce/AllReduceShm.cu

--- a/comms/ncclx/v2_29/meta/colltrace/CollTraceFunc.cc
+++ b/comms/ncclx/v2_29/meta/colltrace/CollTraceFunc.cc
@@ -395,6 +395,10 @@ bool collTraceRecordCtranKernelInfo(
       coll.count = allToAllArgs.count;
       break;
     }
+    case KernelConfig::KernelType::DEVICE_ALLTOALLV: {
+      coll.opName = "DeviceAllToAllvPipes";
+      break;
+    }
     case KernelConfig::KernelType::ALLTOALLV: {
       coll.opName = "AllToAllV";
       auto allToAllvArgs = kernelConfig.args.collective.alltoallv;
@@ -519,6 +523,12 @@ bool collTraceRecordCtranCollective(
       coll.dataType = metaCommToNccl(gpeOp.alltoallv.datatype);
       // Explicitly leave count as nullopt because there is no single count for
       // AllToAllV
+      break;
+    case OpElem::DEVICE_ALLTOALLV:
+      coll.opName = "DeviceAllToAllV";
+      coll.sendbuff = gpeOp.device_alltoallv.sendbuff;
+      coll.recvbuff = gpeOp.device_alltoallv.recvbuff;
+      coll.dataType = metaCommToNccl(gpeOp.device_alltoallv.datatype);
       break;
     case OpElem::ALLTOALLP: {
       coll.opName = "AllToAllP";

--- a/comms/ncclx/v2_29/src/device/Makefile
+++ b/comms/ncclx/v2_29/src/device/Makefile
@@ -37,6 +37,11 @@ NVCUFLAGS += --compiler-options "-DCTRAN_DISABLE_TCPDM"
 NVCUFLAGS_SYM += --compiler-options "-DCTRAN_DISABLE_TCPDM"
 endif
 
+ifeq ($(ENABLE_PIPES),1)
+NVCUFLAGS += --compiler-options "-DENABLE_PIPES"
+NVCUFLAGS_SYM += --compiler-options "-DENABLE_PIPES"
+endif
+
 SAY = @bash -c 'path="$$2"; [[ "$$(realpath "$$2")" =~ ^$(subst .,\.,$(abspath $(NCCLDIR)))/(.*)$$ ]] && path="$${BASH_REMATCH[1]}"; printf "%-15s %s\n" "$$1" "$$path"' SAY
 
 COMPILE.cu = $(NVCC) $(NVCUFLAGS) -dc $2 -o $1
@@ -109,6 +114,7 @@ $(OBJDIR)/gensrc/symmetric/rules.mk: $(OBJDIR)/gensrc/symmetric ;
 
 SRCS = common.cu onerank.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllToAll/AllToAllPImpl.cu
+SRCS += ${BASE_DIR}/comms/ctran/algos/AllToAll/DeviceAllToAllvPipes.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllGather/AllGatherRing.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllGather/AllGatherRecDbl.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllReduce/AllReduceShm.cu


### PR DESCRIPTION
Summary:

Add a new `deviceAllToAllv` collective to CTRAN where split sizes and
displacements are device pointers (GPU memory), eliminating host-device
synchronization for dynamic token routing in MoE workloads.

NVLink domain only — all peers must be reachable via NVLink (including
GB200 MNNVL). The support check uses the host-side `get_transport_type()`
API per peer and rejects communicators with any IB-only peers.
IB support via IBGDA will be added in a follow-up (D96224817).

## Implementation

### CUDA Kernel (`DeviceAllToAllvPipes.cu`)
- Warp-group partitioned into send/recv halves via `partition_interleaved(2)`,
  then distributed across NVLink peers via `partition_interleaved(nLocalRanks)`.
- Each thread reads only its assigned peer's counts/displacements from device
  memory (2-4 global memory reads per thread).
- Self-copies use the self transport; peer copies use `p2p_nvl.send()`/`recv()`.
- Single local rank optimization: skips send/recv partitioning for self-copy only.
- Entire file guarded by `#if defined(ENABLE_PIPES)`.

### Host-Side Setup (`DeviceAllToAllvPipesImpl.cc`)
- Builds local-rank-to-global-rank mapping via `statex->localRankToRank()`.
- Configures grid/block dimensions with runtime-tunable env vars.
- Sets transport array from `MultiPeerTransport` device handle.
- Supports both warp-level (default) and block-level scheduling modes.

### Entry Point (`AllToAll.cc`)
- `ctranDeviceAllToAllv()`: submits kernel via GPE with no IB fallback.
- `ctranDeviceAllToAllvSupport()`: validates all peers are P2P_NVL or SELF
  using host-side `get_transport_type()` API.
- `#else` stubs provided for non-ENABLE_PIPES builds to prevent linker errors
  from unconditional declarations in `Ctran.h`.

### CtranComm Integration (`Ctran.cc`, `CtranComm.h`)
- `getMultiPeerTransportsPtr()` accessor returns the device Transport* array
  from MultiPeerTransport (with `#else nullptr` stub).
- Forward declarations for `comms::pipes::MultiPeerTransport` and `Transport`.

### GPE Integration
- `DEVICE_ALLTOALLV` opType and KernelType added to `CtranGpe.h`.
- Colltrace support with `DeviceAllToAllv_Pipes` op name across v2_27/28/29.

### Device Makefile Fix (v2_27, v2_28, v2_29)
- Added `ENABLE_PIPES` propagation to `NVCUFLAGS` and `NVCUFLAGS_SYM` in
  `src/device/Makefile` for all NCCLX versions.
- Without this fix, `DeviceAllToAllvPipes.cu` compiles to an empty translation
  unit in the conda/Makefile build because `-DENABLE_PIPES` was only added to
  host `CXXFLAGS` (in `src/Makefile`) but not to device `NVCUFLAGS`.
- Follows the existing `ENABLE_TCPDM` pattern on the same file.

### Build System (`BUCK`)
- `DeviceAllToAllvPipes.cu` added to `hetero_ctran_device_lib` sources.
- `DeviceAllToAllvPipes.cu` added to device Makefile `SRCS` (v2_27/28/29).
- Test target `device_alltoallv_test` with 2-GPU distributed config.

## Runtime Tuning Env Vars (no recompile needed)
- `NCCL_CTRAN_DA2A_NBLOCKS`: override block count (default: nLocalRanks*2)
- `NCCL_CTRAN_DA2A_NTHREADS`: override thread count (default: 256)
- `NCCL_CTRAN_DA2A_BLOCK_SCHEDULING=1`: use block-level scheduling
- `NCCL_CTRAN_ENALBE_CLUSTER_KERNEL_LAUNCH=1`: enable cluster launch
- `NCCL_CTRAN_CGA_CLUSTER_SIZE`: cluster size (default: 4)
- `NCCL_CTRAN_PIPES_NVL_CHUNK_SIZE`: NVL chunk size bytes (default: 512KB)

Reviewed By: siyengar

Differential Revision: D96206017


