### PR TITLE
Add Pipes (IBGDA/NVLink) device API backend to TorchCommWindowNCCLX (#1048)

### DIFF
--- a/comms/ncclx/v2_27/meta/rma/window.cc
+++ b/comms/ncclx/v2_27/meta/rma/window.cc
@@ -206,3 +206,101 @@ ncclWinGetAttributes(int rank, ncclWindow_t win, ncclWinAttr_t* attr) {
   guard.dismiss();
   return ncclSuccess;
 }
+
+#if defined(ENABLE_PIPES)
+#include <cuda_runtime_api.h>
+
+#include "comms/pipes/window/DeviceWindow.cuh"
+#include "comms/pipes/window/HostWindow.h"
+
+NCCL_API(
+    ncclResult_t,
+    ncclWinCreateDeviceWin,
+    ncclWindow_t win,
+    int signal_count,
+    int counter_count,
+    int barrier_count,
+    void** outDevicePtr);
+ncclResult_t ncclWinCreateDeviceWin(
+    ncclWindow_t win,
+    int signal_count,
+    int counter_count,
+    int barrier_count,
+    void** outDevicePtr) {
+  // Creates a DeviceWindow in device memory from the ctran window underlying
+  // the given ncclWindow_t. This is a COLLECTIVE operation on first call —
+  // all ranks must call together because get_device_win() does an allGather.
+  //
+  // Subsequent calls on the same window return cached results (config ignored).
+  //
+  // The returned void* is a device pointer to comms::pipes::DeviceWindow.
+  // The caller must free it via ncclWinDestroyDeviceWin().
+  if (win == nullptr || outDevicePtr == nullptr) {
+    return ncclInvalidArgument;
+  }
+
+  ncclWin* nw = ncclWinMap().find(win);
+  if (nw == nullptr || nw->ctranWindow == nullptr) {
+    return ncclInternalError;
+  }
+
+  // Build WindowConfig from parameters.
+  comms::pipes::WindowConfig config{
+      .peerSignalCount = static_cast<std::size_t>(std::max(signal_count, 0)),
+      .peerCounterCount = static_cast<std::size_t>(std::max(counter_count, 0)),
+      .barrierCount = static_cast<std::size_t>(std::max(barrier_count, 0)),
+  };
+
+  // Populate DeviceWindow on host stack. get_device_win() fills in transport
+  // handles, remote buffer descriptors, and signal pointers.
+  comms::pipes::DeviceWindow host_dev_win{};
+  auto result = nw->ctranWindow->get_device_win(&host_dev_win, config);
+  if (result != commSuccess) {
+    WARN("ncclWinCreateDeviceWin: get_device_win failed with error %d", result);
+    return ncclInternalError;
+  }
+
+  // Allocate device memory for DeviceWindow.
+  // NOTE: Uses raw cudaMalloc; the caller frees via ncclWinDestroyDeviceWin()
+  // or cuda_api->free() (which wraps cudaFree — compatible).
+  comms::pipes::DeviceWindow* dev_ptr = nullptr;
+  cudaError_t cuda_err = cudaMalloc(
+      reinterpret_cast<void**>(&dev_ptr), sizeof(comms::pipes::DeviceWindow));
+  if (cuda_err != cudaSuccess) {
+    WARN(
+        "ncclWinCreateDeviceWin: cudaMalloc failed: %s",
+        cudaGetErrorString(cuda_err));
+    return ncclInternalError;
+  }
+
+  // Copy populated DeviceWindow from host to device.
+  // dev_ptr is non-null here (cudaMalloc succeeded above).
+  // NOLINTNEXTLINE(facebook-hte-NullableDereference,facebook-security-vulnerable-memcpy)
+  cuda_err = cudaMemcpy(
+      dev_ptr,
+      &host_dev_win,
+      sizeof(comms::pipes::DeviceWindow),
+      cudaMemcpyHostToDevice);
+  if (cuda_err != cudaSuccess) {
+    WARN(
+        "ncclWinCreateDeviceWin: cudaMemcpy failed: %s",
+        cudaGetErrorString(cuda_err));
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check,facebook-hte-NullableDereference)
+    cudaFree(dev_ptr);
+    return ncclInternalError;
+  }
+
+  *outDevicePtr = dev_ptr;
+  return ncclSuccess;
+}
+
+NCCL_API(ncclResult_t, ncclWinDestroyDeviceWin, void* devicePtr);
+ncclResult_t ncclWinDestroyDeviceWin(void* devicePtr) {
+  // Frees device memory allocated by ncclWinCreateDeviceWin.
+  if (devicePtr == nullptr) {
+    return ncclSuccess;
+  }
+  cudaError_t err = cudaFree(devicePtr);
+  return (err == cudaSuccess) ? ncclSuccess : ncclInternalError;
+}
+#endif // ENABLE_PIPES

--- a/comms/ncclx/v2_27/src/nccl.h.in
+++ b/comms/ncclx/v2_27/src/nccl.h.in
@@ -728,6 +728,27 @@ ncclResult_t pncclWinSharedQuery(int rank, ncclComm_t comm, ncclWindow_t win, vo
  */
 ncclResult_t ncclWinGetAttributes(int rank, ncclWindow_t win, ncclWinAttr_t* attr);
 
+#if defined(ENABLE_PIPES)
+/*
+ * Create a DeviceWindow in device memory from a ctran-registered ncclWindow_t.
+ * COLLECTIVE on first call — all ranks must call together.
+ * Subsequent calls return cached results (config parameters ignored).
+ *
+ * The returned device pointer must be freed via ncclWinDestroyDeviceWin().
+ */
+ncclResult_t ncclWinCreateDeviceWin(
+    ncclWindow_t win,
+    int signal_count,
+    int counter_count,
+    int barrier_count,
+    void** outDevicePtr);
+
+/*
+ * Free device memory allocated by ncclWinCreateDeviceWin.
+ */
+ncclResult_t ncclWinDestroyDeviceWin(void* devicePtr);
+#endif // ENABLE_PIPES
+
 /*
  * Free the window object and free the allocated memory allocated within the communicator.
  */

--- a/comms/ncclx/v2_28/meta/rma/window.cc
+++ b/comms/ncclx/v2_28/meta/rma/window.cc
@@ -204,3 +204,101 @@ ncclWinGetAttributes(int rank, ncclWindow_t win, ncclWinAttr_t* attr) {
   guard.dismiss();
   return ncclSuccess;
 }
+
+#if defined(ENABLE_PIPES)
+#include <cuda_runtime_api.h>
+
+#include "comms/pipes/window/DeviceWindow.cuh"
+#include "comms/pipes/window/HostWindow.h"
+
+NCCL_API(
+    ncclResult_t,
+    ncclWinCreateDeviceWin,
+    ncclWindow_t win,
+    int signal_count,
+    int counter_count,
+    int barrier_count,
+    void** outDevicePtr);
+ncclResult_t ncclWinCreateDeviceWin(
+    ncclWindow_t win,
+    int signal_count,
+    int counter_count,
+    int barrier_count,
+    void** outDevicePtr) {
+  // Creates a DeviceWindow in device memory from the ctran window underlying
+  // the given ncclWindow_t. This is a COLLECTIVE operation on first call —
+  // all ranks must call together because get_device_win() does an allGather.
+  //
+  // Subsequent calls on the same window return cached results (config ignored).
+  //
+  // The returned void* is a device pointer to comms::pipes::DeviceWindow.
+  // The caller must free it via ncclWinDestroyDeviceWin().
+  if (win == nullptr || outDevicePtr == nullptr) {
+    return ncclInvalidArgument;
+  }
+
+  ncclWin* nw = ncclWinMap().find(win);
+  if (nw == nullptr || nw->ctranWindow == nullptr) {
+    return ncclInternalError;
+  }
+
+  // Build WindowConfig from parameters.
+  comms::pipes::WindowConfig config{
+      .peerSignalCount = static_cast<std::size_t>(std::max(signal_count, 0)),
+      .peerCounterCount = static_cast<std::size_t>(std::max(counter_count, 0)),
+      .barrierCount = static_cast<std::size_t>(std::max(barrier_count, 0)),
+  };
+
+  // Populate DeviceWindow on host stack. get_device_win() fills in transport
+  // handles, remote buffer descriptors, and signal pointers.
+  comms::pipes::DeviceWindow host_dev_win{};
+  auto result = nw->ctranWindow->get_device_win(&host_dev_win, config);
+  if (result != commSuccess) {
+    WARN("ncclWinCreateDeviceWin: get_device_win failed with error %d", result);
+    return ncclInternalError;
+  }
+
+  // Allocate device memory for DeviceWindow.
+  // NOTE: Uses raw cudaMalloc; the caller frees via ncclWinDestroyDeviceWin()
+  // or cuda_api->free() (which wraps cudaFree — compatible).
+  comms::pipes::DeviceWindow* dev_ptr = nullptr;
+  cudaError_t cuda_err = cudaMalloc(
+      reinterpret_cast<void**>(&dev_ptr), sizeof(comms::pipes::DeviceWindow));
+  if (cuda_err != cudaSuccess) {
+    WARN(
+        "ncclWinCreateDeviceWin: cudaMalloc failed: %s",
+        cudaGetErrorString(cuda_err));
+    return ncclInternalError;
+  }
+
+  // Copy populated DeviceWindow from host to device.
+  // dev_ptr is non-null here (cudaMalloc succeeded above).
+  // NOLINTNEXTLINE(facebook-hte-NullableDereference,facebook-security-vulnerable-memcpy)
+  cuda_err = cudaMemcpy(
+      dev_ptr,
+      &host_dev_win,
+      sizeof(comms::pipes::DeviceWindow),
+      cudaMemcpyHostToDevice);
+  if (cuda_err != cudaSuccess) {
+    WARN(
+        "ncclWinCreateDeviceWin: cudaMemcpy failed: %s",
+        cudaGetErrorString(cuda_err));
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check,facebook-hte-NullableDereference)
+    cudaFree(dev_ptr);
+    return ncclInternalError;
+  }
+
+  *outDevicePtr = dev_ptr;
+  return ncclSuccess;
+}
+
+NCCL_API(ncclResult_t, ncclWinDestroyDeviceWin, void* devicePtr);
+ncclResult_t ncclWinDestroyDeviceWin(void* devicePtr) {
+  // Frees device memory allocated by ncclWinCreateDeviceWin.
+  if (devicePtr == nullptr) {
+    return ncclSuccess;
+  }
+  cudaError_t err = cudaFree(devicePtr);
+  return (err == cudaSuccess) ? ncclSuccess : ncclInternalError;
+}
+#endif // ENABLE_PIPES

--- a/comms/ncclx/v2_28/src/nccl.h.in
+++ b/comms/ncclx/v2_28/src/nccl.h.in
@@ -805,6 +805,27 @@ ncclResult_t pncclWinSharedQuery(int rank, ncclComm_t comm, ncclWindow_t win, vo
  */
 ncclResult_t ncclWinGetAttributes(int rank, ncclWindow_t win, ncclWinAttr_t* attr);
 
+#if defined(ENABLE_PIPES)
+/*
+ * Create a DeviceWindow in device memory from a ctran-registered ncclWindow_t.
+ * COLLECTIVE on first call — all ranks must call together.
+ * Subsequent calls return cached results (config parameters ignored).
+ *
+ * The returned device pointer must be freed via ncclWinDestroyDeviceWin().
+ */
+ncclResult_t ncclWinCreateDeviceWin(
+    ncclWindow_t win,
+    int signal_count,
+    int counter_count,
+    int barrier_count,
+    void** outDevicePtr);
+
+/*
+ * Free device memory allocated by ncclWinCreateDeviceWin.
+ */
+ncclResult_t ncclWinDestroyDeviceWin(void* devicePtr);
+#endif // ENABLE_PIPES
+
 /*
  * Free the window object and free the allocated memory
  */

--- a/comms/ncclx/v2_29/meta/rma/window.cc
+++ b/comms/ncclx/v2_29/meta/rma/window.cc
@@ -204,3 +204,101 @@ ncclWinGetAttributes(int rank, ncclWindow_t win, ncclWinAttr_t* attr) {
   guard.dismiss();
   return ncclSuccess;
 }
+
+#if defined(ENABLE_PIPES)
+#include <cuda_runtime_api.h>
+
+#include "comms/pipes/window/DeviceWindow.cuh"
+#include "comms/pipes/window/HostWindow.h"
+
+NCCL_API(
+    ncclResult_t,
+    ncclWinCreateDeviceWin,
+    ncclWindow_t win,
+    int signal_count,
+    int counter_count,
+    int barrier_count,
+    void** outDevicePtr);
+ncclResult_t ncclWinCreateDeviceWin(
+    ncclWindow_t win,
+    int signal_count,
+    int counter_count,
+    int barrier_count,
+    void** outDevicePtr) {
+  // Creates a DeviceWindow in device memory from the ctran window underlying
+  // the given ncclWindow_t. This is a COLLECTIVE operation on first call —
+  // all ranks must call together because get_device_win() does an allGather.
+  //
+  // Subsequent calls on the same window return cached results (config ignored).
+  //
+  // The returned void* is a device pointer to comms::pipes::DeviceWindow.
+  // The caller must free it via ncclWinDestroyDeviceWin().
+  if (win == nullptr || outDevicePtr == nullptr) {
+    return ncclInvalidArgument;
+  }
+
+  ncclWin* nw = ncclWinMap().find(win);
+  if (nw == nullptr || nw->ctranWindow == nullptr) {
+    return ncclInternalError;
+  }
+
+  // Build WindowConfig from parameters.
+  comms::pipes::WindowConfig config{
+      .peerSignalCount = static_cast<std::size_t>(std::max(signal_count, 0)),
+      .peerCounterCount = static_cast<std::size_t>(std::max(counter_count, 0)),
+      .barrierCount = static_cast<std::size_t>(std::max(barrier_count, 0)),
+  };
+
+  // Populate DeviceWindow on host stack. get_device_win() fills in transport
+  // handles, remote buffer descriptors, and signal pointers.
+  comms::pipes::DeviceWindow host_dev_win{};
+  auto result = nw->ctranWindow->get_device_win(&host_dev_win, config);
+  if (result != commSuccess) {
+    WARN("ncclWinCreateDeviceWin: get_device_win failed with error %d", result);
+    return ncclInternalError;
+  }
+
+  // Allocate device memory for DeviceWindow.
+  // NOTE: Uses raw cudaMalloc; the caller frees via ncclWinDestroyDeviceWin()
+  // or cuda_api->free() (which wraps cudaFree — compatible).
+  comms::pipes::DeviceWindow* dev_ptr = nullptr;
+  cudaError_t cuda_err = cudaMalloc(
+      reinterpret_cast<void**>(&dev_ptr), sizeof(comms::pipes::DeviceWindow));
+  if (cuda_err != cudaSuccess) {
+    WARN(
+        "ncclWinCreateDeviceWin: cudaMalloc failed: %s",
+        cudaGetErrorString(cuda_err));
+    return ncclInternalError;
+  }
+
+  // Copy populated DeviceWindow from host to device.
+  // dev_ptr is non-null here (cudaMalloc succeeded above).
+  // NOLINTNEXTLINE(facebook-hte-NullableDereference,facebook-security-vulnerable-memcpy)
+  cuda_err = cudaMemcpy(
+      dev_ptr,
+      &host_dev_win,
+      sizeof(comms::pipes::DeviceWindow),
+      cudaMemcpyHostToDevice);
+  if (cuda_err != cudaSuccess) {
+    WARN(
+        "ncclWinCreateDeviceWin: cudaMemcpy failed: %s",
+        cudaGetErrorString(cuda_err));
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check,facebook-hte-NullableDereference)
+    cudaFree(dev_ptr);
+    return ncclInternalError;
+  }
+
+  *outDevicePtr = dev_ptr;
+  return ncclSuccess;
+}
+
+NCCL_API(ncclResult_t, ncclWinDestroyDeviceWin, void* devicePtr);
+ncclResult_t ncclWinDestroyDeviceWin(void* devicePtr) {
+  // Frees device memory allocated by ncclWinCreateDeviceWin.
+  if (devicePtr == nullptr) {
+    return ncclSuccess;
+  }
+  cudaError_t err = cudaFree(devicePtr);
+  return (err == cudaSuccess) ? ncclSuccess : ncclInternalError;
+}
+#endif // ENABLE_PIPES

--- a/comms/ncclx/v2_29/src/nccl.h.in
+++ b/comms/ncclx/v2_29/src/nccl.h.in
@@ -959,6 +959,27 @@ ncclResult_t pncclWinSharedQuery(int rank, ncclComm_t comm, ncclWindow_t win, vo
  */
 ncclResult_t ncclWinGetAttributes(int rank, ncclWindow_t win, ncclWinAttr_t* attr);
 
+#if defined(ENABLE_PIPES)
+/*
+ * Create a DeviceWindow in device memory from a ctran-registered ncclWindow_t.
+ * COLLECTIVE on first call — all ranks must call together.
+ * Subsequent calls return cached results (config parameters ignored).
+ *
+ * The returned device pointer must be freed via ncclWinDestroyDeviceWin().
+ */
+ncclResult_t ncclWinCreateDeviceWin(
+    ncclWindow_t win,
+    int signal_count,
+    int counter_count,
+    int barrier_count,
+    void** outDevicePtr);
+
+/*
+ * Free device memory allocated by ncclWinCreateDeviceWin.
+ */
+ncclResult_t ncclWinDestroyDeviceWin(void* devicePtr);
+#endif // ENABLE_PIPES
+
 /*
  * Free the window object and free the allocated memory
  */

--- a/comms/torchcomms/device/DeviceBackendTraits.hpp
+++ b/comms/torchcomms/device/DeviceBackendTraits.hpp
@@ -115,6 +115,46 @@ struct NCCLDeviceBackend {
       Window host_window,
       void* base,
       size_t size);
+
+  // =========================================================================
+  // Backend-specific hooks called from TorchCommWindowNCCLX
+  // =========================================================================
+  //
+  // These static methods encapsulate backend-specific behavior so that the
+  // shared template code can call Backend::method() instead of using
+  // if constexpr to dispatch.
+
+  // Register the NCCL baseline window needed for GIN transport.
+  // This second window is registered with NCCL_WIN_DEVICE_API flag to enable
+  // GPU-initiated networking (GIN) device API support.
+  static void register_extra_window(
+      torch::comms::NcclxApi* nccl_api,
+      ncclComm_t nccl_comm,
+      ncclWindow_t* out_win,
+      void* ptr,
+      size_t size);
+
+  // Deregister the NCCL baseline window used for GIN transport.
+  static void deregister_extra_window(
+      torch::comms::NcclxApi* nccl_api,
+      ncclComm_t nccl_comm,
+      ncclWindow_t* win);
+
+  // Destroy backend-specific device communicator (GIN ncclDevComm).
+  static void destroy_device_comm(Ptr& device_window);
+
+  // Select which window handle to use for device window creation.
+  // GIN uses nccl_orig_win_ (device API flag).
+  static ncclWindow_t select_device_win(
+      ncclWindow_t /* win */,
+      ncclWindow_t nccl_orig_win) {
+    return nccl_orig_win;
+  }
+
+  // Validate that register_local_buffer is supported. Throws if not.
+  static void validate_local_buffer_support() {
+    // Supported for GIN backend — no-op.
+  }
 };
 
 // Type alias for backward compatibility

--- a/comms/torchcomms/device/TorchCommDeviceWindow.hpp
+++ b/comms/torchcomms/device/TorchCommDeviceWindow.hpp
@@ -75,9 +75,13 @@ enum class CoopScope : int {
 // IMPORTANT: Must be used with the SAME DeviceWindow that created it.
 
 struct RegisteredBuffer {
-  void* base_ptr;
-  size_t size;
-  void* backend_window; // Backend-specific window handle (e.g., ncclWindow_t)
+  void* base_ptr{nullptr};
+  size_t size{0};
+  void* backend_window{
+      nullptr}; // Backend-specific window handle (e.g., ncclWindow_t)
+  // RDMA local key in network byte order for IBGDA puts (PipesDeviceBackend).
+  // Zero for backends that do not use IBGDA (e.g., NCCLDeviceBackend).
+  uint32_t lkey{0};
 
   __device__ void* ptr() const {
     return base_ptr;

--- a/comms/torchcomms/device/ncclx/NCCLDeviceBackend.cpp
+++ b/comms/torchcomms/device/ncclx/NCCLDeviceBackend.cpp
@@ -157,4 +157,52 @@ NCCLDeviceBackend::Ptr NCCLDeviceBackend::create_device_window(
   return Ptr(device_ptr, deleter);
 }
 
+// =============================================================================
+// Backend-specific hooks
+// =============================================================================
+
+void NCCLDeviceBackend::register_extra_window(
+    torch::comms::NcclxApi* nccl_api,
+    ncclComm_t nccl_comm,
+    ncclWindow_t* out_win,
+    void* ptr,
+    size_t size) {
+  if (*out_win != nullptr) {
+    return;
+  }
+  CHECK_EQ(
+      nccl_api->commWindowRegister(
+          ptr, size, nccl_comm, out_win, NCCL_WIN_DEVICE_API),
+      ncclSuccess)
+      << "[NCCLDeviceBackend]: Extra window registration failed";
+}
+
+void NCCLDeviceBackend::deregister_extra_window(
+    torch::comms::NcclxApi* nccl_api,
+    ncclComm_t nccl_comm,
+    ncclWindow_t* win) {
+  if (*win != nullptr) {
+    auto result = nccl_api->commWindowDeregister(nccl_comm, *win);
+    if (result != ncclSuccess) {
+      TC_LOG(ERROR) << "NCCLX orig window deregister failed";
+    }
+    *win = nullptr;
+  }
+}
+
+void NCCLDeviceBackend::destroy_device_comm(Ptr& device_window) {
+  if (!device_window) {
+    return;
+  }
+  auto& deleter = device_window.get_deleter();
+  if (deleter.nccl_comm != nullptr && deleter.nccl_api != nullptr) {
+    auto nccl_result =
+        deleter.nccl_api->devCommDestroy(deleter.nccl_comm, &deleter.dev_comm);
+    if (nccl_result != ncclSuccess) {
+      TC_LOG(ERROR) << "Failed to destroy NCCL device communicator: "
+                    << deleter.nccl_api->getErrorString(nccl_result);
+    }
+  }
+}
+
 } // namespace torchcomms::device

--- a/comms/torchcomms/device/pipes/PipesDeviceBackend.cpp
+++ b/comms/torchcomms/device/pipes/PipesDeviceBackend.cpp
@@ -1,0 +1,145 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// PipesDeviceBackend - Static method implementations
+
+#if defined(ENABLE_PIPES)
+
+#include "comms/torchcomms/device/pipes/PipesDeviceBackend.hpp"
+#include "comms/torchcomms/device/DeviceBackendTraits.hpp"
+#include "comms/torchcomms/device/TorchCommDeviceWindow.hpp"
+#include "comms/torchcomms/device/cuda/CudaApi.hpp"
+#include "comms/torchcomms/ncclx/NcclxApi.hpp"
+#include "comms/torchcomms/utils/Logging.hpp"
+
+#include <stdexcept>
+#include <string>
+
+namespace torchcomms::device {
+
+// =============================================================================
+// DeviceWindowDeleter Implementation
+// =============================================================================
+
+void PipesDeviceBackend::DeviceWindowDeleter::operator()(
+    TorchCommDeviceWindow<PipesDeviceBackend>* ptr) const {
+  if (cuda_api == nullptr) {
+    return;
+  }
+  // Destroy the Pipes DeviceWindow via the ncclx API.
+  // This mirrors the error-cleanup paths in create_device_window() and
+  // ensures ncclx internal state (CtranWin, HostWindow) is properly torn down.
+  if (pipes_device_window != nullptr && nccl_api != nullptr) {
+    auto result = nccl_api->winDestroyDeviceWin(pipes_device_window);
+    if (result != ncclSuccess) {
+      TC_LOG(ERROR) << "[PipesDeviceBackend]: winDestroyDeviceWin failed "
+                    << "during cleanup";
+    }
+  }
+  // Free the TorchCommDeviceWindow struct in device memory.
+  if (ptr != nullptr) {
+    CUDA_CHECK_IGNORE(
+        cuda_api, cuda_api->free(ptr), "Failed to free Pipes device window");
+  }
+}
+
+// =============================================================================
+// create_device_window Implementation
+// =============================================================================
+
+PipesDeviceBackend::Ptr PipesDeviceBackend::create_device_window(
+    ncclComm_t /* nccl_comm */,
+    torch::comms::NcclxApi* nccl_api,
+    torch::comms::CudaApi* cuda_api,
+    const DeviceBackendConfig& config,
+    ncclWindow_t nccl_win,
+    void* base,
+    size_t size) {
+  if (nccl_api == nullptr) {
+    throw std::runtime_error(
+        "[PipesDeviceBackend::create_device_window]: nccl_api cannot be null");
+  }
+  if (nccl_win == nullptr) {
+    throw std::runtime_error(
+        "[PipesDeviceBackend::create_device_window]: nccl_win cannot be null");
+  }
+  if (cuda_api == nullptr) {
+    throw std::runtime_error(
+        "[PipesDeviceBackend::create_device_window]: cuda_api cannot be null");
+  }
+
+  // Step 1: Create the Pipes DeviceWindow in device memory via ncclx.
+  // COLLECTIVE on first call — all ranks must call together.
+  void* pipes_device_win = nullptr;
+  auto nccl_result = nccl_api->winCreateDeviceWin(
+      nccl_win,
+      config.signal_count,
+      config.counter_count,
+      config.barrier_count,
+      &pipes_device_win);
+  if (nccl_result != ncclSuccess) {
+    throw std::runtime_error(
+        "[PipesDeviceBackend::create_device_window]: "
+        "winCreateDeviceWin failed");
+  }
+
+  // Step 2: Build TorchCommDeviceWindow<PipesDeviceBackend> on host.
+  // comm_ = nullptr (unused for Pipes; no separate communicator handle)
+  // window_ = typed device pointer to DeviceWindow
+  auto* device_win = static_cast<comms::pipes::DeviceWindow*>(pipes_device_win);
+  TorchCommDeviceWindow<PipesDeviceBackend> host_dev_window(
+      nullptr, // Comm = void*, unused for Pipes
+      device_win, // Window = DeviceWindow*, device pointer
+      base,
+      size,
+      config.comm_rank,
+      config.comm_size,
+      0 /* signal_buffer_handle, unused for Pipes */);
+
+  // Step 3: Allocate device memory for the TorchCommDeviceWindow struct.
+  TorchCommDeviceWindow<PipesDeviceBackend>* device_ptr = nullptr;
+  cudaError_t cuda_result = cuda_api->malloc(
+      reinterpret_cast<void**>(&device_ptr),
+      sizeof(TorchCommDeviceWindow<PipesDeviceBackend>));
+  if (cuda_result != cudaSuccess) {
+    // Clean up Pipes DeviceWindow on failure.
+    auto destroy_result = nccl_api->winDestroyDeviceWin(pipes_device_win);
+    if (destroy_result != ncclSuccess) {
+      TC_LOG(ERROR) << "[PipesDeviceBackend]: Failed to clean up Pipes device "
+                    << "window after malloc failure";
+    }
+    throw std::runtime_error(
+        "[PipesDeviceBackend::create_device_window]: Failed to allocate "
+        "device memory for TorchCommDeviceWindow. CUDA error: " +
+        std::string(cuda_api->getErrorString(cuda_result)));
+  }
+
+  // Step 4: Copy TorchCommDeviceWindow struct to device memory.
+  // NOLINTNEXTLINE(facebook-hte-NullableDereference,facebook-security-vulnerable-memcpy)
+  cuda_result = cuda_api->memcpy(
+      device_ptr,
+      &host_dev_window,
+      sizeof(TorchCommDeviceWindow<PipesDeviceBackend>),
+      cudaMemcpyHostToDevice);
+  if (cuda_result != cudaSuccess) {
+    // NOLINTNEXTLINE(facebook-hte-NullableDereference)
+    CUDA_CHECK_IGNORE(
+        cuda_api,
+        cuda_api->free(device_ptr),
+        "Failed to free device window during error cleanup");
+    auto destroy_result = nccl_api->winDestroyDeviceWin(pipes_device_win);
+    if (destroy_result != ncclSuccess) {
+      TC_LOG(ERROR) << "[PipesDeviceBackend]: Failed to clean up Pipes device "
+                    << "window after memcpy failure";
+    }
+    throw std::runtime_error(
+        "[PipesDeviceBackend::create_device_window]: Failed to copy "
+        "TorchCommDeviceWindow to device memory. CUDA error: " +
+        std::string(cuda_api->getErrorString(cuda_result)));
+  }
+
+  DeviceWindowDeleter deleter(nccl_api, cuda_api, pipes_device_win);
+  return Ptr(device_ptr, deleter);
+}
+
+} // namespace torchcomms::device
+
+#endif // ENABLE_PIPES

--- a/comms/torchcomms/device/pipes/PipesDeviceBackend.hpp
+++ b/comms/torchcomms/device/pipes/PipesDeviceBackend.hpp
@@ -1,0 +1,155 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// TorchComms Device API - Pipes Backend Traits
+//
+// Defines the PipesDeviceBackend trait type for compile-time polymorphism
+// in TorchCommDeviceWindow. Uses Pipes IBGDA and NVLink transports via the
+// ctran window infrastructure (accessed through opaque ncclx APIs).
+//
+// This backend replaces GIN (GPU Initiated Networking) with Pipes for
+// device-side P2P operations:
+//   - NVLink peers (same node): direct memcpy with NVLink-mapped pointers
+//   - IBGDA peers (cross-node): RDMA writes via DOCA GPUNetIO
+//
+// The Window type is a typed device pointer (comms::pipes::DeviceWindow*)
+// allocated by ncclx. Device-side code uses it directly without casting.
+
+#pragma once
+
+#if defined(ENABLE_PIPES)
+
+#include <memory>
+
+#include <nccl.h> // @manual=//comms/ncclx:nccl
+
+namespace comms::pipes {
+class DeviceWindow;
+} // namespace comms::pipes
+
+namespace torch::comms {
+class CudaApi;
+class NcclxApi;
+} // namespace torch::comms
+
+namespace torchcomms::device {
+
+struct DeviceBackendConfig;
+
+template <typename Backend>
+class TorchCommDeviceWindow;
+
+// =============================================================================
+// PipesDeviceBackend - IBGDA + NVLink backend
+// =============================================================================
+//
+// Types:
+//   - Comm:   void* — unused for Pipes (no separate communicator handle).
+//   - Window: comms::pipes::DeviceWindow* — typed device pointer to the
+//             transport window allocated by ncclx via winCreateDeviceWin().
+
+struct PipesDeviceBackend {
+  // Comm is unused for Pipes: there is no separate communicator handle.
+  // Set to nullptr in the TorchCommDeviceWindow constructor.
+  using Comm = void*;
+
+  // Typed device pointer to the Pipes DeviceWindow. Device-side code accesses
+  // transport handles, NVLink-mapped remote pointers, and IBGDA descriptors
+  // directly through this pointer without casting.
+  using Window = comms::pipes::DeviceWindow*;
+
+  // =========================================================================
+  // DeviceWindowDeleter - Custom deleter for device window cleanup
+  // =========================================================================
+  //
+  // Frees both the TorchCommDeviceWindow<PipesDeviceBackend> struct in device
+  // memory AND the separate DeviceWindow allocation.
+  struct DeviceWindowDeleter {
+    torch::comms::NcclxApi* nccl_api{nullptr};
+    torch::comms::CudaApi* cuda_api{nullptr};
+    // Opaque device pointer to DeviceWindow, allocated by ncclx via
+    // winCreateDeviceWin(). Must be freed via winDestroyDeviceWin() since
+    // it cannot be reached through ptr from host code (ptr is in device
+    // memory).
+    void* pipes_device_window{nullptr};
+
+    DeviceWindowDeleter() = default;
+    DeviceWindowDeleter(
+        torch::comms::NcclxApi* nccl_api,
+        torch::comms::CudaApi* cuda_api,
+        void* win_dev)
+        : nccl_api(nccl_api),
+          cuda_api(cuda_api),
+          pipes_device_window(win_dev) {}
+
+    void operator()(TorchCommDeviceWindow<PipesDeviceBackend>* ptr) const;
+  };
+
+  using Ptr = std::unique_ptr<
+      TorchCommDeviceWindow<PipesDeviceBackend>,
+      DeviceWindowDeleter>;
+
+  // Create fully initialized device window struct in DEVICE memory.
+  //
+  // Internally calls nccl_api->winCreateDeviceWin() to create the transport
+  // device window, then wraps it in a TorchCommDeviceWindow.
+  //
+  // COLLECTIVE on first call — all ranks must call simultaneously because
+  // winCreateDeviceWin() performs an allGather internally.
+  //
+  // Signature matches NCCLDeviceBackend::create_device_window for unified
+  // call sites. nccl_comm is unused for Pipes (no separate communicator).
+  //
+  // Parameters:
+  //   - nccl_comm:  NCCL communicator (unused, for API consistency with GIN)
+  //   - nccl_api:   NcclxApi for creating the transport device window
+  //   - cuda_api:   CUDA API abstraction (must not be null)
+  //   - config:     Device backend configuration (rank, size, signal/counter
+  //                 counts, etc.)
+  //   - nccl_win:   NCCL window handle (ncclWindow_t from tensor_register)
+  //   - base:       Window base pointer (local data buffer)
+  //   - size:       Window size in bytes
+  static Ptr create_device_window(
+      ncclComm_t nccl_comm,
+      torch::comms::NcclxApi* nccl_api,
+      torch::comms::CudaApi* cuda_api,
+      const DeviceBackendConfig& config,
+      ncclWindow_t nccl_win,
+      void* base,
+      size_t size);
+
+  // =========================================================================
+  // Backend-specific hooks called from TorchCommWindowNCCLX
+  // =========================================================================
+
+  // No additional window registration needed for Pipes.
+  static void register_extra_window(
+      torch::comms::NcclxApi*,
+      ncclComm_t,
+      ncclWindow_t*,
+      void*,
+      size_t) {}
+
+  // No additional window to deregister for Pipes.
+  static void
+  deregister_extra_window(torch::comms::NcclxApi*, ncclComm_t, ncclWindow_t*) {}
+
+  // Pipes deleter handles all cleanup via winDestroyDeviceWin.
+  static void destroy_device_comm(Ptr&) {}
+
+  // Pipes uses the regular ctran window for device window creation.
+  static ncclWindow_t select_device_win(
+      ncclWindow_t win,
+      ncclWindow_t /* nccl_orig_win */) {
+    return win;
+  }
+
+  // register_local_buffer not yet supported for Pipes.
+  [[noreturn]] static void validate_local_buffer_support() {
+    throw std::runtime_error(
+        "[TorchCommWindowNCCLX][Pipes]: register_local_buffer is not yet "
+        "supported for PipesDeviceBackend.");
+  }
+};
+
+} // namespace torchcomms::device
+
+#endif // ENABLE_PIPES

--- a/comms/torchcomms/device/pipes/TorchCommDevicePipes.cuh
+++ b/comms/torchcomms/device/pipes/TorchCommDevicePipes.cuh
@@ -1,0 +1,297 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// TorchComms Device API - Pipes Backend Implementation (IBGDA + NVLink)
+//
+// Device-side implementations for TorchComms using Pipes:
+//   - NVLink peers: direct vectorized memcpy via NVLink-mapped pointers
+//   - IBGDA peers: RDMA Write via DOCA GPUNetIO (P2pIbgdaTransportDevice)
+//   - SELF: NVLink local copy
+//
+// This file delegates to the comms::pipes::DeviceWindow public API for all
+// signal, barrier, and put operations. The DeviceWindow handles transport
+// dispatch (NVL vs IBGDA) internally.
+//
+// Header-only library — implementations are inline for template instantiation.
+//
+// IMPORTANT: Must only be included from .cu files compiled with nvcc.
+
+// NOLINTNEXTLINE(clang-diagnostic-pragma-once-outside-header)
+#pragma once
+
+#if defined(ENABLE_PIPES)
+
+#ifndef __CUDACC__
+#error "TorchCommDevicePipes.cuh must be compiled with nvcc."
+#endif
+
+#include <cuda_runtime.h>
+
+#include "comms/pipes/CopyUtils.cuh"
+#include "comms/pipes/IbgdaBuffer.h"
+#include "comms/pipes/MultiPeerDeviceHandle.cuh"
+#include "comms/pipes/P2pIbgdaTransportDevice.cuh"
+#include "comms/pipes/P2pNvlTransportDevice.cuh"
+#include "comms/pipes/Transport.cuh"
+#include "comms/pipes/window/DeviceWindow.cuh"
+#include "comms/torchcomms/device/pipes/PipesDeviceBackend.hpp"
+#include "comms/torchcomms/device/pipes/TorchCommDevicePipesTypes.hpp"
+
+namespace torchcomms::device {
+
+// =============================================================================
+// Internal Helpers
+// =============================================================================
+
+namespace detail {
+
+// Map TorchComms SignalOp to Pipes SignalOp.
+__device__ inline comms::pipes::SignalOp to_pipes_signal_op(SignalOp op) {
+  return (op == SignalOp::ADD) ? comms::pipes::SignalOp::SIGNAL_ADD
+                               : comms::pipes::SignalOp::SIGNAL_SET;
+}
+
+// Map TorchComms CmpOp to Pipes CmpOp.
+__device__ inline comms::pipes::CmpOp to_pipes_cmp_op(CmpOp cmp) {
+  switch (cmp) {
+    case CmpOp::EQ:
+      return comms::pipes::CmpOp::CMP_EQ;
+    case CmpOp::NE:
+      return comms::pipes::CmpOp::CMP_NE;
+    case CmpOp::LT:
+      return comms::pipes::CmpOp::CMP_LT;
+    case CmpOp::LE:
+      return comms::pipes::CmpOp::CMP_LE;
+    case CmpOp::GT:
+      return comms::pipes::CmpOp::CMP_GT;
+    case CmpOp::GE:
+      return comms::pipes::CmpOp::CMP_GE;
+  }
+  return comms::pipes::CmpOp::CMP_GE;
+}
+
+// Build a pipes::ThreadGroup for the given CoopScope.
+__device__ inline comms::pipes::ThreadGroup make_pipes_thread_group(
+    CoopScope scope) {
+  switch (scope) {
+    case CoopScope::WARP:
+      return comms::pipes::make_warp_group();
+    case CoopScope::BLOCK:
+      return comms::pipes::make_block_group();
+    case CoopScope::THREAD:
+      return comms::pipes::make_thread_solo();
+  }
+  __builtin_unreachable();
+}
+
+} // namespace detail
+
+// =============================================================================
+// TorchCommDeviceWindow<PipesDeviceBackend> Signal Operations
+// =============================================================================
+//
+// Delegates to comms::pipes::DeviceWindow::signal_peer() which handles
+// NVL vs IBGDA transport dispatch internally. Signal slots are indexed
+// by (peer, signal_id) pairs.
+
+template <>
+__device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::signal(
+    int peer,
+    int signal_id,
+    SignalOp op,
+    uint64_t value,
+    CoopScope scope) {
+  auto& win = *window_;
+  auto pipes_op = detail::to_pipes_signal_op(op);
+
+  if (scope == CoopScope::THREAD) {
+    win.signal_peer(peer, signal_id, pipes_op, value);
+  } else {
+    auto group = detail::make_pipes_thread_group(scope);
+    win.signal_peer(group, peer, signal_id, pipes_op, value);
+  }
+  return 0;
+}
+
+// =============================================================================
+// TorchCommDeviceWindow<PipesDeviceBackend> RMA Operations
+// =============================================================================
+
+// TODO: Implement put() using DeviceWindow::put() / put_signal() public API.
+// Requires resolving remote data pointers from window base + offsets.
+// Will be implemented when the DevicePut integration test is added.
+template <>
+__device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::put(
+    size_t dst_offset,
+    const RegisteredBuffer& src_buf,
+    size_t src_offset,
+    int dst_rank,
+    size_t bytes,
+    int signal_id,
+    int counter_id,
+    CoopScope scope) {
+  // Not yet implemented for Pipes backend.
+  (void)dst_offset;
+  (void)src_buf;
+  (void)src_offset;
+  (void)dst_rank;
+  (void)bytes;
+  (void)signal_id;
+  (void)counter_id;
+  (void)scope;
+  __trap();
+  return -1;
+}
+
+// =============================================================================
+// TorchCommDeviceWindow<PipesDeviceBackend> Wait Signal Operations
+// =============================================================================
+
+template <>
+__device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::wait_signal(
+    int signal_id,
+    CmpOp cmp,
+    uint64_t value) {
+  auto& win = *window_;
+  auto pipes_cmp = detail::to_pipes_cmp_op(cmp);
+  // TODO: Add CoopScope parameter to wait_signal in the base class
+  // (TorchCommDeviceWindow). Pipes wait_signal takes a ThreadGroup and
+  // benefits from leader-only polling + group sync. Currently forced to
+  // thread-solo (all threads poll independently). NCCLXGin doesn't support
+  // scope either, so will add it to both backends together.
+  auto group = comms::pipes::make_thread_solo();
+  win.wait_signal(group, signal_id, pipes_cmp, value);
+  return 0;
+}
+
+template <>
+__device__ inline int
+TorchCommDeviceWindow<PipesDeviceBackend>::wait_signal_from(
+    int peer,
+    int signal_id,
+    CmpOp cmp,
+    uint64_t value) {
+  auto& win = *window_;
+  auto pipes_cmp = detail::to_pipes_cmp_op(cmp);
+  win.wait_signal_from(peer, signal_id, pipes_cmp, value);
+  return 0;
+}
+
+template <>
+__device__ inline uint64_t
+TorchCommDeviceWindow<PipesDeviceBackend>::read_signal(int signal_id) const {
+  // window_ is DeviceWindow* (not const), so dereference works in const
+  // methods. DeviceWindow::read_signal() only reads inbox values despite being
+  // non-const.
+  auto& win = *window_;
+  return win.read_signal(signal_id);
+}
+
+template <>
+__device__ inline void TorchCommDeviceWindow<PipesDeviceBackend>::reset_signal(
+    int signal_id) {
+  // Pipes DeviceWindow does not support device-side signal reset.
+  // Recommended pattern: use monotonically increasing signal values, or
+  // reset signal buffers from the host side (cudaMemset) between kernel
+  // launches with proper synchronization.
+  //
+  // Calling reset_signal from device code is a programming error for the
+  // Pipes backend.
+  (void)signal_id;
+  __trap();
+}
+
+// =============================================================================
+// TorchCommDeviceWindow<PipesDeviceBackend> Counter Operations
+// =============================================================================
+// Counters require a companion RDMA QP for loopback atomic signaling
+// (NIC completion tracking). Not supported in the initial Pipes implementation.
+
+template <>
+__device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::wait_local(
+    int op_id,
+    CmpOp cmp,
+    uint64_t value) {
+  (void)op_id;
+  (void)cmp;
+  (void)value;
+  auto& win = *window_;
+  // Drain all pending IBGDA operations.
+  int nPeers = win.num_peers();
+  for (int peer_index = 0; peer_index < nPeers; ++peer_index) {
+    int r = win.peer_index_to_rank(peer_index);
+    if (win.get_type(r) == comms::pipes::TransportType::P2P_IBGDA) {
+      win.get_ibgda(r).fence();
+    }
+  }
+  return 0;
+}
+
+template <>
+__device__ inline uint64_t
+TorchCommDeviceWindow<PipesDeviceBackend>::read_counter(int counter_id) const {
+  // Counters not supported for Pipes backend.
+  (void)counter_id;
+  __trap();
+  return 0;
+}
+
+template <>
+__device__ inline void TorchCommDeviceWindow<PipesDeviceBackend>::reset_counter(
+    int counter_id) {
+  // Counters not supported for Pipes backend.
+  (void)counter_id;
+  __trap();
+}
+
+// =============================================================================
+// TorchCommDeviceWindow<PipesDeviceBackend> Synchronization Operations
+// =============================================================================
+
+template <>
+__device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::fence() {
+  // Compiler barrier: prevents reordering of put() calls across this point.
+  asm volatile("" ::: "memory");
+  return 0;
+}
+
+template <>
+__device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::flush(
+    CoopScope scope) {
+  // flush() = local completion: source buffers are safe to reuse.
+  //
+  // NVLink: puts are inline stores. group.sync() ensures all threads have
+  // completed their memcpy operations. No async NIC DMA to wait for.
+  //
+  // IBGDA: fence() drains each QP by posting a NOP WQE and waiting for
+  // completion, ensuring all prior puts have been handed off to the NIC.
+  auto group = detail::make_pipes_thread_group(scope);
+  group.sync();
+
+  auto& win = *window_;
+  int nPeers = win.num_peers();
+  for (int peer_index = 0; peer_index < nPeers; ++peer_index) {
+    int r = win.peer_index_to_rank(peer_index);
+    if (win.get_type(r) == comms::pipes::TransportType::P2P_IBGDA) {
+      if (group.is_leader()) {
+        win.get_ibgda(r).fence();
+      }
+    }
+  }
+
+  return 0;
+}
+
+template <>
+__device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::barrier(
+    int barrier_id,
+    CoopScope scope) {
+  // Delegate to DeviceWindow::barrier() which handles the full
+  // arrive + wait protocol across NVL and IBGDA peers.
+  auto& win = *window_;
+  auto group = detail::make_pipes_thread_group(scope);
+  win.barrier(group, barrier_id);
+  return 0;
+}
+
+} // namespace torchcomms::device
+
+#endif // ENABLE_PIPES

--- a/comms/torchcomms/device/pipes/TorchCommDevicePipesTypes.hpp
+++ b/comms/torchcomms/device/pipes/TorchCommDevicePipesTypes.hpp
@@ -1,0 +1,29 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// TorchComms Device API - Pipes Backend Type Definitions
+//
+// Provides type aliases for the Pipes device backend that are safe to include
+// from both CUDA (.cu) and non-CUDA (.cpp/.cc) code compiled with clang.
+//
+// For device-side implementations (IBGDA/NVLink usage), include
+// TorchCommDevicePipes.cuh instead - but ONLY from .cu files compiled with
+// nvcc.
+
+#pragma once
+
+#if defined(ENABLE_PIPES)
+
+#include "comms/torchcomms/device/TorchCommDeviceWindow.hpp"
+#include "comms/torchcomms/device/pipes/PipesDeviceBackend.hpp"
+
+namespace torchcomms::device {
+
+// =============================================================================
+// Type Aliases (safe for non-CUDA code)
+// =============================================================================
+
+using DeviceWindowPipes = TorchCommDeviceWindow<PipesDeviceBackend>;
+using RegisteredBufferPipes = RegisteredBuffer;
+
+} // namespace torchcomms::device
+
+#endif // ENABLE_PIPES

--- a/comms/torchcomms/ncclx/NcclxApi.cpp
+++ b/comms/torchcomms/ncclx/NcclxApi.cpp
@@ -502,6 +502,22 @@ ncclResult_t DefaultNcclxApi::commDump(
   return ::ncclCommDump(comm, map);
 }
 
+#if defined(ENABLE_PIPES)
+ncclResult_t DefaultNcclxApi::winCreateDeviceWin(
+    NcclxWindow win,
+    int signal_count,
+    int counter_count,
+    int barrier_count,
+    void** outDevicePtr) {
+  return ncclWinCreateDeviceWin(
+      win, signal_count, counter_count, barrier_count, outDevicePtr);
+}
+
+ncclResult_t DefaultNcclxApi::winDestroyDeviceWin(void* devicePtr) {
+  return ncclWinDestroyDeviceWin(devicePtr);
+}
+#endif // ENABLE_PIPES
+
 #ifdef TORCHCOMMS_HAS_NCCL_DEVICE_API
 ncclResult_t DefaultNcclxApi::devCommCreate(
     ncclComm_t comm,

--- a/comms/torchcomms/ncclx/NcclxApi.hpp
+++ b/comms/torchcomms/ncclx/NcclxApi.hpp
@@ -297,6 +297,22 @@ class NcclxApi {
       const ncclDevComm_t* devComm) = 0;
 #endif
 
+#if defined(ENABLE_PIPES)
+  // Create a DeviceWindow in device memory from a ctran-registered NcclxWindow.
+  // COLLECTIVE on first call — all ranks must call together.
+  // Returns opaque device pointer via outDevicePtr; free with
+  // winDestroyDeviceWin.
+  virtual ncclResult_t winCreateDeviceWin(
+      NcclxWindow win,
+      int signal_count,
+      int counter_count,
+      int barrier_count,
+      void** outDevicePtr) = 0;
+
+  // Free device memory allocated by winCreateDeviceWin.
+  virtual ncclResult_t winDestroyDeviceWin(void* devicePtr) = 0;
+#endif
+
   // Group operations
   [[nodiscard]] virtual ncclResult_t groupStart() = 0;
   [[nodiscard]] virtual ncclResult_t groupEnd() = 0;
@@ -559,6 +575,16 @@ class DefaultNcclxApi : public NcclxApi {
       ncclDevComm_t* outDevComm) override;
   ncclResult_t devCommDestroy(ncclComm_t comm, const ncclDevComm_t* devComm)
       override;
+#endif
+
+#if defined(ENABLE_PIPES)
+  ncclResult_t winCreateDeviceWin(
+      NcclxWindow win,
+      int signal_count,
+      int counter_count,
+      int barrier_count,
+      void** outDevicePtr) override;
+  ncclResult_t winDestroyDeviceWin(void* devicePtr) override;
 #endif
 
   // Group operations

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -2079,8 +2079,20 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::gather(
 // Window & One-sided Operations
 std::shared_ptr<TorchCommWindow> TorchCommNCCLX::new_window(
     const std::optional<at::Tensor>& tensor) {
-  auto win =
-      std::make_shared<TorchCommWindowNCCLXGin>(nccl_comm_, shared_from_this());
+  std::shared_ptr<TorchCommWindow> win;
+#if defined(ENABLE_PIPES)
+  // Select Pipes backend when explicitly requested via env var.
+  // Pipes uses ctran IBGDA/NVLink instead of GIN for device-side P2P.
+  const char* pipes_env = std::getenv("TORCHCOMMS_PIPES_DEVICE_API_ENABLE");
+  if (pipes_env != nullptr && std::string_view(pipes_env) == "1") {
+    win = std::make_shared<TorchCommWindowNCCLXPipes>(
+        nccl_comm_, shared_from_this());
+  } else
+#endif
+  {
+    win = std::make_shared<TorchCommWindowNCCLXGin>(
+        nccl_comm_, shared_from_this());
+  }
   if (tensor.has_value()) {
     win->tensor_register(tensor.value());
   }

--- a/comms/torchcomms/ncclx/TorchCommWindowNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommWindowNCCLX.cpp
@@ -11,6 +11,10 @@
 #include "comms/torchcomms/device/DeviceBackendTraits.hpp"
 #endif
 
+#if defined(ENABLE_PIPES)
+#include "comms/torchcomms/device/pipes/PipesDeviceBackend.hpp"
+#endif
+
 namespace torch::comms {
 
 // =============================================================================
@@ -43,30 +47,15 @@ TorchCommWindowNCCLX<Backend>::~TorchCommWindowNCCLX() noexcept {
   }
   registered_local_buffers_.clear();
 
-  // Destroy ncclDevComm using the dev_comm stored in the deleter
-  if (device_window_) {
-    auto& deleter = device_window_.get_deleter();
-    if (deleter.nccl_comm != nullptr && deleter.nccl_api != nullptr) {
-      auto nccl_result = deleter.nccl_api->devCommDestroy(
-          deleter.nccl_comm, &deleter.dev_comm);
-      if (nccl_result != ncclSuccess) {
-        TC_LOG(ERROR) << "Failed to destroy NCCL device communicator: "
-                      << deleter.nccl_api->getErrorString(nccl_result);
-      }
-    }
-  }
+  // Destroy backend-specific device communicator state.
+  // GIN: devCommDestroy. Pipes: no-op (cleanup via deleter).
+  Backend::destroy_device_comm(device_window_);
 
   // device_window_ unique_ptr destructor calls cudaFree via custom deleter
   device_window_.reset();
 
-  // Cleanup NCCL orig window
-  if (nccl_orig_win_ != nullptr) {
-    auto result = nccl_api_->commWindowDeregister(nccl_comm_, nccl_orig_win_);
-    if (result != ncclSuccess) {
-      TC_LOG(ERROR) << "NCCLX orig window deregister failed in destructor";
-    }
-    nccl_orig_win_ = nullptr;
-  }
+  // Deregister extra window (GIN nccl_orig_win_; Pipes: no-op).
+  Backend::deregister_extra_window(nccl_api_, nccl_comm_, &nccl_orig_win_);
 
 #endif
 
@@ -121,9 +110,10 @@ void TorchCommWindowNCCLX<Backend>::tensor_register(const at::Tensor& tensor) {
       << "[TorchCommWindowNCCLX]: NCCLX window registration failed.";
 
 #ifdef TORCHCOMMS_HAS_NCCL_DEVICE_API
-  // Initialize local communicator and NCCL orig window for device API
-  // initLocalComm();
-  initNcclOrigWindow(tensor.data_ptr(), win_size_);
+  // GIN: register a second window with NCCL_WIN_DEVICE_API flag.
+  // Pipes: no-op (device window creation deferred to get_device_window).
+  Backend::register_extra_window(
+      nccl_api_, nccl_comm_, &nccl_orig_win_, tensor.data_ptr(), win_size_);
 #endif
 
   // In graph capture mode, we create a non-owned buffer: the window does not
@@ -162,13 +152,8 @@ void TorchCommWindowNCCLX<Backend>::tensor_deregister() {
   win_size_ = 0;
 
 #ifdef TORCHCOMMS_HAS_NCCL_DEVICE_API
-  if (nccl_orig_win_ != nullptr) {
-    auto result = nccl_api_->commWindowDeregister(nccl_comm_, nccl_orig_win_);
-    if (result != ncclSuccess) {
-      TC_LOG(ERROR) << "NCCLX orig window deregister failed";
-    }
-    nccl_orig_win_ = nullptr;
-  }
+  // GIN: deregister nccl_orig_win_. Pipes: no-op.
+  Backend::deregister_extra_window(nccl_api_, nccl_comm_, &nccl_orig_win_);
 #endif
 
   buf_tensor_.reset();
@@ -312,22 +297,12 @@ std::shared_ptr<TorchCommWindowAttr> TorchCommWindowNCCLX<Backend>::get_attr(
 #ifdef TORCHCOMMS_HAS_NCCL_DEVICE_API
 
 template <typename Backend>
-void TorchCommWindowNCCLX<Backend>::initNcclOrigWindow(void* ptr, size_t size) {
-  if (nccl_orig_win_ != nullptr) {
-    return;
-  }
-
-  CHECK_EQ(
-      nccl_api_->commWindowRegister(
-          ptr, size, nccl_comm_, &nccl_orig_win_, NCCL_WIN_DEVICE_API),
-      ncclSuccess)
-      << "[TorchCommWindowNCCLX]: NCCL orig window registration failed";
-}
-
-template <typename Backend>
 typename TorchCommWindowNCCLX<Backend>::DeviceRegisteredBuffer
 TorchCommWindowNCCLX<Backend>::register_local_buffer(const at::Tensor& tensor) {
   checkCommAndThrow();
+
+  // Throws for backends that don't support local buffer registration (Pipes).
+  Backend::validate_local_buffer_support();
 
   // GIN must be enabled via prior get_device_window() call.
   // tensor_register creates nccl_orig_win_ but doesn't enable GIN.
@@ -413,9 +388,9 @@ TorchCommWindowNCCLX<Backend>::get_device_window(
     int barrier_count) {
   checkCommAndThrow();
 
-  if (nccl_orig_win_ == nullptr) {
+  if (Backend::select_device_win(win_, nccl_orig_win_) == nullptr) {
     throw std::runtime_error(
-        "[TorchCommWindowNCCLX]: NCCL orig window not initialized. "
+        "[TorchCommWindowNCCLX]: Window not initialized. "
         "Call tensor_register first.");
   }
 
@@ -443,13 +418,14 @@ TorchCommWindowNCCLX<Backend>::get_device_window(
   config.comm_rank = commRank;
   config.comm_size = commSize;
 
-  // Create device window - the custom deleter handles all cleanup
+  // Create device window - the custom deleter handles all cleanup.
+  // Both backends share the same create_device_window signature.
   device_window_ = Backend::create_device_window(
       nccl_comm_,
       nccl_api_,
       torch_comm_->getCudaApi(),
       config,
-      nccl_orig_win_,
+      Backend::select_device_win(win_, nccl_orig_win_),
       buf_tensor_.has_value() ? buf_tensor_->data_ptr() : nullptr,
       win_size_);
 
@@ -515,6 +491,9 @@ void TorchCommWindowNCCLX<Backend>::checkWindowAndThrow() const {
 
 #ifdef TORCHCOMMS_HAS_NCCL_DEVICE_API
 template class TorchCommWindowNCCLX<torchcomms::device::NCCLDeviceBackend>;
+#if defined(ENABLE_PIPES)
+template class TorchCommWindowNCCLX<torchcomms::device::PipesDeviceBackend>;
+#endif
 #else
 template class TorchCommWindowNCCLX<HostOnlyBackend>;
 #endif

--- a/comms/torchcomms/ncclx/TorchCommWindowNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchCommWindowNCCLX.hpp
@@ -18,6 +18,11 @@
 #include "comms/torchcomms/device/TorchCommDeviceWindow.hpp"
 #endif
 
+#if defined(ENABLE_PIPES)
+#include "comms/torchcomms/device/pipes/PipesDeviceBackend.hpp"
+#include "comms/torchcomms/device/pipes/TorchCommDevicePipesTypes.hpp"
+#endif
+
 namespace torch::comms {
 
 // =============================================================================
@@ -136,18 +141,20 @@ class TorchCommWindowNCCLX : public TorchCommWindow {
       int counter_count = -1,
       int barrier_count = 1);
 
-  // Get the host-side NCCL window handle.
+  // Get the host-side NCCL window handle (GIN backend only).
   // Useful for creating RegisteredBuffer from host code when the device
   // window's window_ field is in device memory and not directly accessible.
+  // TODO: Returns nullptr for PipesDeviceBackend (nccl_orig_win_ is not
+  // initialized). Gate or return win_ for Pipes if callers need it.
   ncclWindow_t get_nccl_window() const {
     return nccl_orig_win_;
   }
 #endif
 
  private:
-#ifdef TORCHCOMMS_HAS_NCCL_DEVICE_API
-  void initNcclOrigWindow(void* ptr, size_t size);
-#endif
+  // Backend-specific behavior is handled via static methods on the Backend
+  // type (e.g., Backend::register_extra_window(), Backend::select_device_win())
+  // instead of if constexpr dispatch.
 
   void checkRequestSizeAndThrow(size_t input_size) const;
   void checkDeviceAndThrow(const at::Tensor& tensor) const;
@@ -168,6 +175,9 @@ class TorchCommWindowNCCLX : public TorchCommWindow {
   torchcomms::device::DeviceWindowPtr<Backend> device_window_;
 
   std::vector<DeviceRegisteredBuffer> registered_local_buffers_;
+
+  // No ctran_win_ member needed — Pipes device windows are created
+  // on-demand via nccl_api_->winCreateDeviceWin() in get_device_window().
 #endif
 
   // NCCL API abstraction
@@ -183,6 +193,13 @@ using TorchCommWindowNCCLXGin =
     TorchCommWindowNCCLX<torchcomms::device::NCCLDeviceBackend>;
 #else
 using TorchCommWindowNCCLXGin = TorchCommWindowNCCLX<HostOnlyBackend>;
+#endif
+
+// Type alias for the Pipes backend (IBGDA + NVLink device-side P2P).
+// Only available when ENABLE_PIPES is defined (propagated from ctran_lib).
+#if defined(ENABLE_PIPES)
+using TorchCommWindowNCCLXPipes =
+    TorchCommWindowNCCLX<torchcomms::device::PipesDeviceBackend>;
 #endif
 
 } // namespace torch::comms

--- a/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommWindowNCCLXPipesTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommWindowNCCLXPipesTest.cpp
@@ -1,0 +1,123 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// Unit tests for TorchCommWindowNCCLX with PipesDeviceBackend.
+//
+// These tests verify Pipes-specific error paths without real hardware:
+//   1. register_local_buffer() throws "not yet supported" for Pipes backend
+//   2. get_device_window() throws when win_ is null (no tensor_register)
+//
+// Both tests set TORCHCOMMS_PIPES_DEVICE_API_ENABLE=1 in SetUp() so that
+// TorchCommNCCLX::new_window() returns TorchCommWindowNCCLXPipes instead of
+// TorchCommWindowNCCLXGin.
+//
+// Note: These tests use mocked NCCL/CUDA APIs and don't require real hardware.
+// Integration tests with real GPUs and ctran are in PipesDeviceApiTest.
+
+#include "comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTestBase.hpp"
+
+#ifdef TORCHCOMMS_HAS_NCCL_DEVICE_API
+#if defined(ENABLE_PIPES)
+
+#include "comms/torchcomms/ncclx/TorchCommWindowNCCLX.hpp"
+
+namespace torch::comms::test {
+
+class TorchCommWindowNCCLXPipesTest : public TorchCommNCCLXTest {
+ protected:
+  void SetUp() override {
+    TorchCommNCCLXTest::SetUp();
+    // Make new_window() return TorchCommWindowNCCLXPipes
+    setenv("TORCHCOMMS_PIPES_DEVICE_API_ENABLE", "1", 1);
+  }
+
+  void TearDown() override {
+    unsetenv("TORCHCOMMS_PIPES_DEVICE_API_ENABLE");
+    TorchCommNCCLXTest::TearDown();
+  }
+};
+
+TEST_F(TorchCommWindowNCCLXPipesTest, RegisterLocalBufferThrowsNotSupported) {
+  // Verifies: register_local_buffer() throws immediately for Pipes backend.
+  // IBGDA lkey registration requires ctran MR integration (planned follow-up).
+  //
+  // Code path: register_local_buffer() → Pipes constexpr branch → throw
+  // Production value: Clear error when the unsupported Pipes API path is used.
+
+  setupRankAndSize(0, 2);
+  setupCCAExpectations(1, 2, 1);
+  auto comm = createMockedTorchComm();
+
+  cuda_mock_->setupDefaultBehaviors();
+  nccl_mock_->setupDefaultBehaviors();
+
+  EXPECT_NO_THROW(comm->init(*device_, "test_name", default_options_));
+
+  // new_window() returns TorchCommWindowNCCLXPipes because
+  // TORCHCOMMS_PIPES_DEVICE_API_ENABLE=1 is set in SetUp()
+  auto win_base = comm->new_window();
+  auto win = std::dynamic_pointer_cast<TorchCommWindowNCCLXPipes>(win_base);
+  ASSERT_NE(win, nullptr) << "Window should be TorchCommWindowNCCLXPipes";
+
+  auto src_tensor = createTestTensor({5, 5});
+
+  // register_local_buffer should throw immediately for Pipes (no MR support)
+  EXPECT_THROW(
+      {
+        try {
+          win->register_local_buffer(src_tensor);
+        } catch (const std::runtime_error& e) {
+          std::string error_msg = e.what();
+          EXPECT_TRUE(error_msg.find("not yet supported") != std::string::npos)
+              << "Error should indicate not yet supported, got: " << error_msg;
+          throw;
+        }
+      },
+      std::runtime_error);
+
+  EXPECT_NO_THROW(comm->finalize());
+}
+
+TEST_F(TorchCommWindowNCCLXPipesTest, GetDeviceWindowThrowsIfWinNull) {
+  // Verifies: get_device_window() throws a Pipes-specific error when
+  // tensor_register() has not been called (win_ remains null).
+  //
+  // Code path: get_device_window() → Pipes win_ null check → throw
+  // Production value: Prevents silent failures when the API is misused.
+
+  setupRankAndSize(0, 2);
+  setupCCAExpectations(1, 2, 1);
+  auto comm = createMockedTorchComm();
+
+  cuda_mock_->setupDefaultBehaviors();
+  nccl_mock_->setupDefaultBehaviors();
+
+  EXPECT_NO_THROW(comm->init(*device_, "test_name", default_options_));
+
+  // Create Pipes window WITHOUT calling tensor_register → win_ stays null
+  auto win_base = comm->new_window();
+  auto win = std::dynamic_pointer_cast<TorchCommWindowNCCLXPipes>(win_base);
+  ASSERT_NE(win, nullptr) << "Window should be TorchCommWindowNCCLXPipes";
+
+  // get_device_window() should throw Pipes-specific error about win_ not init
+  EXPECT_THROW(
+      {
+        try {
+          win->get_device_window();
+        } catch (const std::runtime_error& e) {
+          std::string error_msg = e.what();
+          EXPECT_TRUE(
+              error_msg.find("Window not initialized") != std::string::npos ||
+              error_msg.find("tensor_register") != std::string::npos)
+              << "Error should indicate window not initialized, got: "
+              << error_msg;
+          throw;
+        }
+      },
+      std::runtime_error);
+
+  EXPECT_NO_THROW(comm->finalize());
+}
+
+} // namespace torch::comms::test
+
+#endif // ENABLE_PIPES
+#endif // TORCHCOMMS_HAS_NCCL_DEVICE_API

--- a/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.hpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.hpp
@@ -341,6 +341,19 @@ class NcclxMock : public NcclxApi {
       (override));
 #endif
 
+#if defined(ENABLE_PIPES)
+  MOCK_METHOD(
+      ncclResult_t,
+      winCreateDeviceWin,
+      (NcclxWindow win,
+       int signal_count,
+       int counter_count,
+       int barrier_count,
+       void** outDevicePtr),
+      (override));
+  MOCK_METHOD(ncclResult_t, winDestroyDeviceWin, (void* devicePtr), (override));
+#endif
+
   // Group operations
   MOCK_METHOD(ncclResult_t, groupStart, (), (override));
   MOCK_METHOD(ncclResult_t, groupEnd, (), (override));

--- a/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTest.cpp
@@ -1,0 +1,467 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// TorchComms Device API Integration Test - Pipes Backend
+
+#include "PipesDeviceApiTest.hpp"
+
+#include <gtest/gtest.h>
+#include <algorithm>
+#include "PipesDeviceApiTestKernels.cuh"
+#include "TorchCommTestHelpers.h"
+#include "comms/torchcomms/TorchComm.hpp"
+#include "comms/torchcomms/ncclx/TorchCommWindowNCCLX.hpp"
+
+std::unique_ptr<TorchCommTestWrapper> PipesDeviceApiTest::createWrapper() {
+  return std::make_unique<TorchCommTestWrapper>();
+}
+
+void PipesDeviceApiTest::SetUp() {
+  // Check skip condition FIRST, before any initialization
+  if (checkIfSkip()) {
+    GTEST_SKIP() << "Skipping Pipes Device API tests "
+                    "(RUN_PIPES_DEVICE_API_TEST not set or "
+                    "TORCHCOMMS_PIPES_DEVICE_API_ENABLE not enabled)";
+  }
+
+  wrapper_ = createWrapper();
+  torchcomm_ = wrapper_->getTorchComm();
+  rank_ = torchcomm_->getRank();
+  num_ranks_ = torchcomm_->getSize();
+  device_index_ = rank_ % at::cuda::device_count();
+
+  // Get allocator using global function - obtained once and reused
+  allocator_ = torch::comms::get_mem_allocator(torchcomm_->getBackend());
+}
+
+void PipesDeviceApiTest::TearDown() {
+  torchcomm_.reset();
+  wrapper_.reset();
+}
+
+bool PipesDeviceApiTest::checkIfSkip() {
+  // Check RUN_PIPES_DEVICE_API_TEST env var
+  const char* run_env = getenv("RUN_PIPES_DEVICE_API_TEST");
+  if (!run_env) {
+    return true; // skip if not set
+  }
+  std::string val(run_env);
+  std::transform(val.begin(), val.end(), val.begin(), ::tolower);
+  if (val != "1" && val != "true") {
+    return true; // skip if not enabled
+  }
+
+  // Also check TORCHCOMMS_PIPES_DEVICE_API_ENABLE=1 is set.
+  // Without this, new_window() returns TorchCommWindowNCCLXGin instead of
+  // Pipes.
+  const char* pipes_env = getenv("TORCHCOMMS_PIPES_DEVICE_API_ENABLE");
+  if (!pipes_env || std::string(pipes_env) != "1") {
+    return true;
+  }
+
+  return false;
+}
+
+at::Tensor PipesDeviceApiTest::createTestTensor(
+    int64_t count,
+    at::ScalarType dtype) {
+  auto options =
+      at::TensorOptions().dtype(dtype).device(at::kCUDA, device_index_);
+  return at::ones({count}, options) * (rank_ + 1);
+}
+
+std::string PipesDeviceApiTest::getDtypeName(at::ScalarType dtype) {
+  switch (dtype) {
+    case at::kFloat:
+      return "float32";
+    case at::kDouble:
+      return "float64";
+    case at::kHalf:
+      return "float16";
+    case at::kBFloat16:
+      return "bfloat16";
+    case at::kInt:
+      return "int32";
+    case at::kLong:
+      return "int64";
+    default:
+      return "unknown";
+  }
+}
+
+// =============================================================================
+// Pipes Device Window Creation Test
+// =============================================================================
+// Validates the Pipes device window creation flow:
+//   1. All ranks register the same-sized tensor in a symmetric window
+//   2. Barrier ensures all registrations complete before device window creation
+//   3. get_device_window() triggers ctran_win->get_device_win() (allGather):
+//      - IBGDA path: exchanges remote buffer registration info
+//      - NVLink path: exchanges NVLink-mapped remote pointers
+//   4. Verify the returned device pointer is non-null
+//
+// NOTE: TEST_F macros MUST be in this file (compiled with
+// TORCHCOMMS_HAS_NCCL_DEVICE_API and ENABLE_PIPES) to ensure
+// TorchCommWindowNCCLXPipes resolves to the correct type (PipesDeviceBackend).
+
+void PipesDeviceApiTest::testPipesDeviceWindowCreation(
+    int count,
+    at::ScalarType dtype) {
+  SCOPED_TRACE(
+      ::testing::Message() << "Testing Pipes Device Window Creation with count="
+                           << count << " and dtype=" << getDtypeName(dtype));
+
+  // Create MemPool for RDMA-compatible memory allocation (cuMem-based).
+  // ctran's window registration uses cuMem-allocated buffers for IBGDA rkey
+  // and NVLink mapping. Regular cudaMalloc may not support this.
+  auto mem_pool = std::make_unique<at::cuda::MemPool>(
+      std::static_pointer_cast<c10::cuda::CUDACachingAllocator::CUDAAllocator>(
+          allocator_));
+  c10::cuda::CUDACachingAllocator::beginAllocateToPool(
+      mem_pool->device(), mem_pool->id(), [](cudaStream_t) { return true; });
+
+  // Window layout: [rank0_slot | rank1_slot | ... | rankN-1_slot]
+  auto options =
+      at::TensorOptions().dtype(dtype).device(at::kCUDA, device_index_);
+  at::Tensor win_tensor = at::zeros({count * num_ranks_}, options);
+
+  // End pool context immediately after allocation
+  c10::cuda::CUDACachingAllocator::endAllocateToPool(
+      mem_pool->device(), mem_pool->id());
+
+  // All ranks must register the tensor collectively
+  torchcomm_->barrier(false);
+  auto base_win = torchcomm_->new_window();
+  base_win->tensor_register(win_tensor);
+  torchcomm_->barrier(false);
+
+  // Cast to Pipes window to access device API.
+  // TORCHCOMMS_PIPES_DEVICE_API_ENABLE=1 makes new_window() return Pipes.
+  auto* win =
+      dynamic_cast<torch::comms::TorchCommWindowNCCLXPipes*>(base_win.get());
+  ASSERT_NE(win, nullptr) << "Window should be TorchCommWindowNCCLXPipes. "
+                             "Is TORCHCOMMS_PIPES_DEVICE_API_ENABLE=1 set?";
+
+  // get_device_window() is COLLECTIVE: internally calls
+  // ctran_win->get_device_win() which does an allGather to exchange IBGDA
+  // buffer registration info and NVLink-mapped remote buffer pointers.
+  // All ranks must call this simultaneously.
+  decltype(win->get_device_window()) dev_win = nullptr;
+  try {
+    dev_win = win->get_device_window();
+  } catch (const std::runtime_error& e) {
+    // Gracefully skip if IBGDA hardware is not available.
+    // Both ranks hit this simultaneously (multiPeerTransport is null on both),
+    // so no deadlock: both will skip cleanly.
+    base_win->tensor_deregister();
+    base_win.reset();
+    mem_pool.reset();
+    GTEST_SKIP() << "Skipping: IBGDA/Pipes hardware not available: "
+                 << e.what();
+  }
+  EXPECT_NE(dev_win, nullptr)
+      << "Pipes device window pointer should not be null";
+
+  // Cleanup
+  base_win->tensor_deregister();
+  base_win.reset();
+  mem_pool.reset();
+
+  torchcomm_->barrier(false);
+}
+
+TEST_F(PipesDeviceApiTest, PipesDeviceWindowCreationFloat) {
+  testPipesDeviceWindowCreation(1024, at::kFloat);
+}
+
+// =============================================================================
+// Per-Peer Signal Test (Pipes)
+// =============================================================================
+// Ring pattern: rank i signals rank (i+1) % num_ranks
+//   1. Each rank sends ADD 1 to the next rank via device kernel
+//   2. Each rank waits for the aggregated signal to reach expected value
+//   3. Verifies read_signal returns the correct aggregated value
+
+void PipesDeviceApiTest::testPerPeerSignal() {
+  SCOPED_TRACE(::testing::Message() << "Testing per-peer signal slots (Pipes)");
+
+  auto op_stream = at::cuda::getStreamFromPool(false, device_index_);
+  auto wait_stream = at::cuda::getStreamFromPool(false, device_index_);
+
+  // Create MemPool for RDMA-compatible memory allocation
+  auto mem_pool = std::make_unique<at::cuda::MemPool>(
+      std::static_pointer_cast<c10::cuda::CUDACachingAllocator::CUDAAllocator>(
+          allocator_));
+  c10::cuda::CUDACachingAllocator::beginAllocateToPool(
+      mem_pool->device(), mem_pool->id(), [](cudaStream_t) { return true; });
+
+  // Minimal window — we only need the signal infrastructure, not data
+  auto options =
+      at::TensorOptions().dtype(at::kLong).device(at::kCUDA, device_index_);
+  at::Tensor win_tensor = at::zeros({1}, options);
+
+  c10::cuda::CUDACachingAllocator::endAllocateToPool(
+      mem_pool->device(), mem_pool->id());
+
+  torchcomm_->barrier(false);
+  auto base_win = torchcomm_->new_window();
+  base_win->tensor_register(win_tensor);
+  torchcomm_->barrier(false);
+
+  // Cast to Pipes window to access device API.
+  auto* win =
+      dynamic_cast<torch::comms::TorchCommWindowNCCLXPipes*>(base_win.get());
+  ASSERT_NE(win, nullptr) << "Window should be TorchCommWindowNCCLXPipes. "
+                             "Is TORCHCOMMS_PIPES_DEVICE_API_ENABLE=1 set?";
+
+  int signal_count = num_ranks_;
+  decltype(win->get_device_window()) dev_win = nullptr;
+  try {
+    dev_win = win->get_device_window(signal_count, -1, 1);
+  } catch (const std::runtime_error& e) {
+    base_win->tensor_deregister();
+    base_win.reset();
+    mem_pool.reset();
+    GTEST_SKIP() << "Skipping: IBGDA/Pipes hardware not available: "
+                 << e.what();
+  }
+  ASSERT_NE(dev_win, nullptr);
+
+  // Ring pattern: rank i signals rank (i+1) % num_ranks
+  int dst_rank = (rank_ + 1) % num_ranks_;
+  constexpr int kSignalId = 0;
+
+  // Each rank sends ADD 1 to the next rank
+  {
+    c10::cuda::CUDAStreamGuard guard(op_stream);
+    torchcomms::device::test::launchPipesSignalKernel(
+        dev_win,
+        dst_rank,
+        kSignalId,
+        torchcomms::device::SignalOp::ADD,
+        1,
+        op_stream.stream());
+  }
+
+  // Each rank receives one signal, so aggregate sum should be >= 1
+  {
+    c10::cuda::CUDAStreamGuard guard(wait_stream);
+    torchcomms::device::test::launchPipesWaitSignalKernel(
+        dev_win, kSignalId, 1, wait_stream.stream());
+  }
+
+  op_stream.synchronize();
+  wait_stream.synchronize();
+
+  // Read signal value via kernel and verify on host
+  uint64_t* d_out = nullptr;
+  ASSERT_EQ(cudaMalloc(&d_out, sizeof(uint64_t)), cudaSuccess);
+  {
+    c10::cuda::CUDAStreamGuard guard(op_stream);
+    torchcomms::device::test::launchPipesReadSignalKernel(
+        dev_win, kSignalId, d_out, op_stream.stream());
+  }
+  op_stream.synchronize();
+
+  uint64_t h_out = 0;
+  cudaMemcpy(&h_out, d_out, sizeof(uint64_t), cudaMemcpyDeviceToHost);
+  cudaFree(d_out);
+
+  ASSERT_GE(h_out, 1u) << "Expected aggregated signal >= 1, got " << h_out;
+
+  // NOTE: Pipes DeviceWindow does not support device-side signal reset.
+  // Use monotonically increasing signal values or host-side cudaMemset
+  // between kernel launches. No reset needed here since the window is
+  // being destroyed.
+
+  base_win->tensor_deregister();
+  base_win.reset();
+  mem_pool.reset();
+
+  torchcomm_->barrier(false);
+}
+
+TEST_F(PipesDeviceApiTest, PerPeerSignal) {
+  testPerPeerSignal();
+}
+
+// =============================================================================
+// Wait Signal From Specific Peer Test (Pipes)
+// =============================================================================
+// Ring pattern: rank i signals rank (i+1) % num_ranks
+//   1. Each rank sends ADD 1 to the next rank
+//   2. Receiver uses wait_signal_from(src_rank, ...) to wait for the
+//      specific sender's slot (not aggregated)
+//   3. Verifies completion without deadlock
+
+void PipesDeviceApiTest::testWaitSignalFrom() {
+  SCOPED_TRACE(::testing::Message() << "Testing wait_signal_from (Pipes)");
+
+  auto op_stream = at::cuda::getStreamFromPool(false, device_index_);
+  auto wait_stream = at::cuda::getStreamFromPool(false, device_index_);
+
+  // Create MemPool for RDMA-compatible memory allocation
+  auto mem_pool = std::make_unique<at::cuda::MemPool>(
+      std::static_pointer_cast<c10::cuda::CUDACachingAllocator::CUDAAllocator>(
+          allocator_));
+  c10::cuda::CUDACachingAllocator::beginAllocateToPool(
+      mem_pool->device(), mem_pool->id(), [](cudaStream_t) { return true; });
+
+  auto options =
+      at::TensorOptions().dtype(at::kLong).device(at::kCUDA, device_index_);
+  at::Tensor win_tensor = at::zeros({1}, options);
+
+  c10::cuda::CUDACachingAllocator::endAllocateToPool(
+      mem_pool->device(), mem_pool->id());
+
+  torchcomm_->barrier(false);
+  auto base_win = torchcomm_->new_window();
+  base_win->tensor_register(win_tensor);
+  torchcomm_->barrier(false);
+
+  auto* win =
+      dynamic_cast<torch::comms::TorchCommWindowNCCLXPipes*>(base_win.get());
+  ASSERT_NE(win, nullptr) << "Window should be TorchCommWindowNCCLXPipes. "
+                             "Is TORCHCOMMS_PIPES_DEVICE_API_ENABLE=1 set?";
+
+  int signal_count = num_ranks_;
+  decltype(win->get_device_window()) dev_win = nullptr;
+  try {
+    dev_win = win->get_device_window(signal_count, -1, 1);
+  } catch (const std::runtime_error& e) {
+    base_win->tensor_deregister();
+    base_win.reset();
+    mem_pool.reset();
+    GTEST_SKIP() << "Skipping: IBGDA/Pipes hardware not available: "
+                 << e.what();
+  }
+  ASSERT_NE(dev_win, nullptr);
+
+  // Ring: rank i signals rank (i+1), receiver expects signal from (i-1)
+  int dst_rank = (rank_ + 1) % num_ranks_;
+  int src_rank = (rank_ - 1 + num_ranks_) % num_ranks_;
+  constexpr int kSignalId = 0;
+
+  // Send signal to next rank
+  {
+    c10::cuda::CUDAStreamGuard guard(op_stream);
+    torchcomms::device::test::launchPipesSignalKernel(
+        dev_win,
+        dst_rank,
+        kSignalId,
+        torchcomms::device::SignalOp::ADD,
+        1,
+        op_stream.stream());
+  }
+
+  // Wait for signal from previous rank (point-to-point)
+  {
+    c10::cuda::CUDAStreamGuard guard(wait_stream);
+    torchcomms::device::test::launchPipesWaitSignalFromKernel(
+        dev_win,
+        src_rank,
+        kSignalId,
+        torchcomms::device::CmpOp::GE,
+        1,
+        wait_stream.stream());
+  }
+
+  op_stream.synchronize();
+  wait_stream.synchronize();
+
+  // No device-side signal reset for Pipes. Window destruction handles cleanup.
+
+  base_win->tensor_deregister();
+  base_win.reset();
+  mem_pool.reset();
+
+  torchcomm_->barrier(false);
+}
+
+TEST_F(PipesDeviceApiTest, WaitSignalFrom) {
+  testWaitSignalFrom();
+}
+
+// =============================================================================
+// Device Barrier Test (Pipes)
+// =============================================================================
+// Validates the device-side barrier:
+//   1. All ranks launch a barrier kernel
+//   2. Barrier synchronizes all ranks via DeviceWindow::barrier()
+//   3. All ranks complete successfully
+//   4. Second barrier verifies reusability
+
+void PipesDeviceApiTest::testDeviceBarrier() {
+  SCOPED_TRACE(::testing::Message() << "Testing device barrier (Pipes)");
+
+  auto op_stream = at::cuda::getStreamFromPool(false, device_index_);
+
+  // Create MemPool for RDMA-compatible memory allocation
+  auto mem_pool = std::make_unique<at::cuda::MemPool>(
+      std::static_pointer_cast<c10::cuda::CUDACachingAllocator::CUDAAllocator>(
+          allocator_));
+  c10::cuda::CUDACachingAllocator::beginAllocateToPool(
+      mem_pool->device(), mem_pool->id(), [](cudaStream_t) { return true; });
+
+  // Minimal window for barrier infrastructure
+  auto options =
+      at::TensorOptions().dtype(at::kLong).device(at::kCUDA, device_index_);
+  at::Tensor win_tensor = at::zeros({1}, options);
+
+  c10::cuda::CUDACachingAllocator::endAllocateToPool(
+      mem_pool->device(), mem_pool->id());
+
+  torchcomm_->barrier(false);
+  auto base_win = torchcomm_->new_window();
+  base_win->tensor_register(win_tensor);
+  torchcomm_->barrier(false);
+
+  auto* win =
+      dynamic_cast<torch::comms::TorchCommWindowNCCLXPipes*>(base_win.get());
+  ASSERT_NE(win, nullptr) << "Window should be TorchCommWindowNCCLXPipes. "
+                             "Is TORCHCOMMS_PIPES_DEVICE_API_ENABLE=1 set?";
+
+  // Get device window with barrier support
+  int barrier_count = 2;
+  decltype(win->get_device_window()) dev_win = nullptr;
+  try {
+    dev_win = win->get_device_window(-1, -1, barrier_count);
+  } catch (const std::runtime_error& e) {
+    base_win->tensor_deregister();
+    base_win.reset();
+    mem_pool.reset();
+    GTEST_SKIP() << "Skipping: IBGDA/Pipes hardware not available: "
+                 << e.what();
+  }
+  ASSERT_NE(dev_win, nullptr);
+
+  constexpr int kBarrierId = 0;
+
+  // Launch barrier kernel - all ranks must participate
+  {
+    c10::cuda::CUDAStreamGuard guard(op_stream);
+    torchcomms::device::test::launchPipesBarrierKernel(
+        dev_win, kBarrierId, op_stream.stream());
+  }
+
+  // If barrier works, all ranks complete together
+  op_stream.synchronize();
+
+  // Second barrier to verify reusability via monotonic counter pattern.
+  // Pipes barrier uses monotonic counters — reuse the same barrier_id.
+  // The inbox accumulates (1, 2, ...) and barrierExpected_ tracks in lockstep.
+  {
+    c10::cuda::CUDAStreamGuard guard(op_stream);
+    torchcomms::device::test::launchPipesBarrierKernel(
+        dev_win, kBarrierId, op_stream.stream());
+  }
+  op_stream.synchronize();
+
+  base_win->tensor_deregister();
+  base_win.reset();
+  mem_pool.reset();
+
+  torchcomm_->barrier(false);
+}
+
+TEST_F(PipesDeviceApiTest, DeviceBarrier) {
+  testDeviceBarrier();
+}

--- a/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTest.hpp
+++ b/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTest.hpp
@@ -1,0 +1,73 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// TorchComms Device API Integration Test - Pipes Backend (IBGDA + NVLink)
+//
+// This test validates device window creation using the Pipes backend.
+// It exercises tensor_register() and get_device_window() from the host side.
+//
+// NOTE: This test requires NCCLX 2.28+ with device API headers and Pipes
+// support (ENABLE_PIPES defined at compile time).
+//
+// Runtime prerequisites:
+//   - RUN_PIPES_DEVICE_API_TEST=true (skip gate)
+//   - TORCHCOMMS_PIPES_DEVICE_API_ENABLE=1 (select Pipes in new_window())
+//   - NCCL_P2P_DISABLE=1 (route traffic through ctran/RDMA path)
+//   - NCCL_CTRAN_USE_PIPES=1 (initialize ctran multiPeerTransport)
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDACachingAllocator.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAStream.h>
+
+#include <ATen/cuda/MemPool.h>
+
+#include "TorchCommTestHelpers.h"
+#include "comms/torchcomms/TorchComm.hpp"
+#include "comms/torchcomms/ncclx/TorchCommWindowNCCLX.hpp"
+
+class PipesDeviceApiTest : public ::testing::Test {
+ protected:
+  void SetUp() override;
+  void TearDown() override;
+
+  // Check if test should be skipped
+  bool checkIfSkip();
+
+  // Create a wrapper for TorchComm
+  std::unique_ptr<TorchCommTestWrapper> createWrapper();
+
+  // Test helper functions
+  at::Tensor createTestTensor(int64_t count, at::ScalarType dtype);
+  std::string getDtypeName(at::ScalarType dtype);
+
+  // Test functions
+
+  // Verify that tensor_register() + get_device_window() succeeds.
+  // get_device_window() is COLLECTIVE: all ranks call
+  // ctran_win->get_device_win() which performs an allGather to exchange IBGDA
+  // registration info and NVLink-mapped pointers.
+  void testPipesDeviceWindowCreation(int count, at::ScalarType dtype);
+
+  // Test per-peer signal via device kernels (ring pattern: signal + wait).
+  void testPerPeerSignal();
+
+  // Test wait_signal_from: point-to-point signal wait from a specific peer.
+  void testWaitSignalFrom();
+
+  // Test device barrier: all ranks synchronize via barrier().
+  void testDeviceBarrier();
+
+  // Member variables
+  std::unique_ptr<TorchCommTestWrapper> wrapper_;
+  std::shared_ptr<torch::comms::TorchComm> torchcomm_;
+  std::shared_ptr<c10::Allocator> allocator_;
+  int rank_{0};
+  int num_ranks_{0};
+  int device_index_{0};
+  at::DeviceType device_type_{at::kCUDA};
+};

--- a/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTestKernels.cu
+++ b/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTestKernels.cu
@@ -1,0 +1,178 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// CUDA kernels for PipesDeviceApiTest - tests device-side communication
+// primitives using the Pipes backend (IBGDA + NVLink)
+
+#include "PipesDeviceApiTestKernels.cuh"
+
+// Include the Pipes device API implementation (header-only)
+#include "comms/torchcomms/device/pipes/TorchCommDevicePipes.cuh"
+
+#include <stdexcept>
+#include <string>
+
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define CUDA_LAUNCH_CHECK()                                                   \
+  do {                                                                        \
+    cudaError_t err__ = cudaGetLastError();                                   \
+    if (err__ != cudaSuccess) {                                               \
+      throw std::runtime_error(                                               \
+          std::string("Kernel launch failed: ") + cudaGetErrorString(err__)); \
+    }                                                                         \
+  } while (0)
+
+namespace torchcomms::device::test {
+
+// =============================================================================
+// Standalone Signal Test Kernel
+// =============================================================================
+// Sends a signal to a peer without any associated data transfer.
+// Used to test the per-peer signal model via Pipes transport.
+//
+// Signal semantics for Pipes:
+//   - signal_id is ignored (slots are indexed by sender rank, not signal_id)
+//   - NVL path: atomicAdd/store to remote signal slot at nvl_remote_signal_ptr
+//   - IBGDA path: signal_remote_with_fence to peer's remote signal buffer
+
+__global__ void pipesSignalKernel(
+    DeviceWindowPipes* win,
+    int peer,
+    int signal_id,
+    SignalOp op,
+    uint64_t value) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    win->signal(peer, signal_id, op, value);
+  }
+}
+
+// =============================================================================
+// Wait Signal Kernel
+// =============================================================================
+// Waits for aggregated signal from all peers to reach expected_value.
+// Pipes aggregates by summing all per-sender slots in local signal buffer.
+
+__global__ void pipesWaitSignalKernel(
+    DeviceWindowPipes* win,
+    int signal_id,
+    uint64_t expected_value) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    win->wait_signal(signal_id, CmpOp::GE, expected_value);
+  }
+}
+
+// =============================================================================
+// Reset Signal Kernel
+// =============================================================================
+// Resets all per-sender signal slots to 0.
+
+__global__ void pipesResetSignalKernel(DeviceWindowPipes* win, int signal_id) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    win->reset_signal(signal_id);
+  }
+}
+
+// =============================================================================
+// Read Signal Kernel
+// =============================================================================
+// Reads the aggregated signal value (sum of all per-sender slots).
+
+__global__ void
+pipesReadSignalKernel(DeviceWindowPipes* win, int signal_id, uint64_t* out) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    *out = win->read_signal(signal_id);
+  }
+}
+
+// =============================================================================
+// Wait Signal From Specific Peer Kernel
+// =============================================================================
+// Waits for a signal from a specific peer rank (point-to-point, not
+// aggregated).
+
+__global__ void pipesWaitSignalFromKernel(
+    DeviceWindowPipes* win,
+    int peer,
+    int signal_id,
+    CmpOp cmp,
+    uint64_t value) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    win->wait_signal_from(peer, signal_id, cmp, value);
+  }
+}
+
+// =============================================================================
+// Barrier Kernel
+// =============================================================================
+// Synchronizes all ranks via DeviceWindow::barrier().
+
+__global__ void pipesBarrierKernel(DeviceWindowPipes* win, int barrier_id) {
+  // WARP scope: all 32 threads participate in the barrier collectively.
+  // NOTE: Pipes barriers use monotonic counters (barrierExpected_ accumulates).
+  // When DeviceWindow is accessed via pointer (not by value), barrierExpected_
+  // persists across kernel launches. Multiple barriers must reuse the same
+  // barrier_id (counters accumulate in lockstep).
+  win->barrier(barrier_id, CoopScope::WARP);
+}
+
+// =============================================================================
+// Host-callable wrapper functions
+// =============================================================================
+
+void launchPipesSignalKernel(
+    DeviceWindowPipes* win,
+    int peer,
+    int signal_id,
+    SignalOp op,
+    uint64_t value,
+    cudaStream_t stream) {
+  pipesSignalKernel<<<1, 1, 0, stream>>>(win, peer, signal_id, op, value);
+  CUDA_LAUNCH_CHECK();
+}
+
+void launchPipesWaitSignalKernel(
+    DeviceWindowPipes* win,
+    int signal_id,
+    uint64_t expected_value,
+    cudaStream_t stream) {
+  pipesWaitSignalKernel<<<1, 1, 0, stream>>>(win, signal_id, expected_value);
+  CUDA_LAUNCH_CHECK();
+}
+
+void launchPipesResetSignalKernel(
+    DeviceWindowPipes* win,
+    int signal_id,
+    cudaStream_t stream) {
+  pipesResetSignalKernel<<<1, 1, 0, stream>>>(win, signal_id);
+  CUDA_LAUNCH_CHECK();
+}
+
+void launchPipesReadSignalKernel(
+    DeviceWindowPipes* win,
+    int signal_id,
+    uint64_t* out,
+    cudaStream_t stream) {
+  pipesReadSignalKernel<<<1, 1, 0, stream>>>(win, signal_id, out);
+  CUDA_LAUNCH_CHECK();
+}
+
+void launchPipesWaitSignalFromKernel(
+    DeviceWindowPipes* win,
+    int peer,
+    int signal_id,
+    CmpOp cmp,
+    uint64_t value,
+    cudaStream_t stream) {
+  pipesWaitSignalFromKernel<<<1, 1, 0, stream>>>(
+      win, peer, signal_id, cmp, value);
+  CUDA_LAUNCH_CHECK();
+}
+
+void launchPipesBarrierKernel(
+    DeviceWindowPipes* win,
+    int barrier_id,
+    cudaStream_t stream) {
+  // Launch with 32 threads (1 warp) to match CoopScope::WARP in the kernel.
+  pipesBarrierKernel<<<1, 32, 0, stream>>>(win, barrier_id);
+  CUDA_LAUNCH_CHECK();
+}
+
+} // namespace torchcomms::device::test

--- a/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTestKernels.cuh
+++ b/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTestKernels.cuh
@@ -1,0 +1,76 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// CUDA kernel declarations for PipesDeviceApiTest
+//
+// This header provides function declarations that can be included from
+// both .cpp (host code, compiled by clang) and .cu (CUDA code, compiled
+// by nvcc) files.
+//
+// The type aliases (DeviceWindowPipes, RegisteredBufferPipes) are defined in
+// TorchCommDevicePipesTypes.hpp which is safe to include from host code.
+// The full device implementations (Pipes transport usage, etc.) are only in
+// the .cu file which is compiled by nvcc.
+
+// NOLINTNEXTLINE(clang-diagnostic-pragma-once-outside-header)
+#pragma once
+
+#include <cuda_runtime.h>
+// Include the host-safe header that provides type aliases
+// (DeviceWindowPipes = TorchCommDeviceWindow<PipesDeviceBackend>)
+// This does NOT include the device implementation code that requires nvcc.
+#include "comms/torchcomms/device/pipes/TorchCommDevicePipesTypes.hpp"
+
+namespace torchcomms::device::test {
+
+// Host-callable wrapper functions to launch CUDA kernels
+// These are defined in PipesDeviceApiTestKernels.cu
+
+// Launch standalone signal kernel - signals a peer without data transfer.
+// Tests per-peer signal model via Pipes transport (NVLink/IBGDA).
+void launchPipesSignalKernel(
+    DeviceWindowPipes* win,
+    int peer,
+    int signal_id,
+    SignalOp op,
+    uint64_t value,
+    cudaStream_t stream);
+
+// Launch device wait signal kernel - waits for aggregated signal from all peers
+// Note: DeviceWindowPipes* is a DEVICE pointer (allocated via cudaMalloc)
+void launchPipesWaitSignalKernel(
+    DeviceWindowPipes* win,
+    int signal_id,
+    uint64_t expected_value,
+    cudaStream_t stream);
+
+// Launch device reset signal kernel - resets all signal slots to 0
+// Note: DeviceWindowPipes* is a DEVICE pointer (allocated via cudaMalloc)
+void launchPipesResetSignalKernel(
+    DeviceWindowPipes* win,
+    int signal_id,
+    cudaStream_t stream);
+
+// Launch read signal kernel - reads aggregated signal value into output buffer.
+// out must be a device pointer to a single uint64_t.
+void launchPipesReadSignalKernel(
+    DeviceWindowPipes* win,
+    int signal_id,
+    uint64_t* out,
+    cudaStream_t stream);
+
+// Launch wait signal from specific peer kernel - waits for signal from a
+// single peer (not aggregated). Tests point-to-point synchronization.
+void launchPipesWaitSignalFromKernel(
+    DeviceWindowPipes* win,
+    int peer,
+    int signal_id,
+    CmpOp cmp,
+    uint64_t value,
+    cudaStream_t stream);
+
+// Launch device barrier kernel - synchronizes all ranks via barrier
+void launchPipesBarrierKernel(
+    DeviceWindowPipes* win,
+    int barrier_id,
+    cudaStream_t stream);
+
+} // namespace torchcomms::device::test

--- a/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTestMain.cpp
+++ b/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTestMain.cpp
@@ -1,0 +1,13 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// TorchComms Pipes Device API Integration Test Main
+//
+// NOTE: TEST_F macros are in PipesDeviceApiTest.cpp (which is compiled with
+// TORCHCOMMS_HAS_NCCL_DEVICE_API=1 and ENABLE_PIPES=1) to ensure consistent
+// type resolution. This file only contains the main() entry point.
+
+#include <gtest/gtest.h>
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Summary:

Adds the Pipes (IBGDA + NVLink) device API path into TorchCommWindowNCCLX, paralleling the existing GIN
(NCCLDeviceBackend) device API path. Pipes replaces GIN for device-side P2P operations: NVLink peers use direct
 memcpy with NVLink-mapped pointers, IBGDA peers use RDMA writes via DOCA GPUNetIO.

New ncclx API surface (v2_28):
- ncclWinCreateDeviceWin(win, signal_count, counter_count, barrier_count, &outDevicePtr): creates a
comms::pipes::DeviceWindow in device memory from a ctran-registered ncclWindow_t. COLLECTIVE on first call
(allGather to exchange IBGDA rkeys and NVLink-mapped remote pointers). Returns opaque void* device pointer.
- ncclWinDestroyDeviceWin(devicePtr): frees the device memory.
- winCreateDeviceWin() / winDestroyDeviceWin() in NcclxApi: virtual wrappers for the above, gated by
ENABLE_PIPES.

New device backend (torchcomms/device/pipes/):
- PipesDeviceBackend: backend traits struct (Comm = void* unused, Window = void* opaque device pointer to
DeviceWindow). create_device_window() calls nccl_api->winCreateDeviceWin() then wraps the result in a
TorchCommDeviceWindow, allocated and copied to device memory.
- TorchCommDevicePipes.cuh: device-side template specializations (signal, wait_signal, wait_signal_from,
read_signal, barrier, fence, flush, wait_local) that cast window_ to comms::pipes::DeviceWindow* and delegate
to the Pipes transport layer. put() and counter ops are stubbed with __trap() (planned follow-ups).
- TorchCommDevicePipesTypes.hpp: type aliases (DeviceWindowPipes, RegisteredBufferPipes).

Host-layer wiring (TorchCommWindowNCCLX):
- tensor_register: Pipes path skips the second NCCL_WIN_DEVICE_API window registration (no nccl_orig_win_).
Device window creation is deferred to get_device_window().
- tensor_deregister: Pipes path skips nccl_orig_win_ cleanup (doesn't exist).
- register_local_buffer: throws "not yet supported" for Pipes (requires ctran MR integration for IBGDA lkey —
planned follow-up).
- get_device_window: dispatches to 6-arg PipesDeviceBackend::create_device_window(nccl_api, win_, cuda_api,
config, base, size) vs 7-arg NCCLDeviceBackend variant.
- new_window() in TorchCommNCCLX: returns TorchCommWindowNCCLXPipes when TORCHCOMMS_PIPES_DEVICE_API_ENABLE=1
env var is set.
- Backend dispatch uses if constexpr (std::is_same_v<Backend, PipesDeviceBackend>) inside #if
defined(ENABLE_PIPES) guards for compile-time polymorphism.

lkey in RegisteredBuffer:
Added uint32_t lkey{0} for IBGDA local key (zero for NCCLDeviceBackend). Will be populated once
register_local_buffer is implemented for Pipes.

Tests:
- Unit: TorchCommWindowNCCLXPipesTest — validates Pipes-specific error paths (register_local_buffer throws,
get_device_window throws when win_ is null) using mocked NCCL/CUDA APIs, no real hardware.
- Integration: PipesDeviceApiTest — validates tensor_register → get_device_window → signal/wait_signal/barrier
on real hardware with device kernels. Tests: device window creation, per-peer signal (ring pattern),
wait_signal_from (point-to-point), and device barrier (with reuse). Skips gracefully when IBGDA transport is
unavailable.

Reviewed By: dmwu

Differential Revision: D96216712
