### PR TITLE
comment out nightly cpp test workflow since it is broken

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -57,10 +57,10 @@ jobs:
             gpu-arch-type: "cuda"
             gpu-arch-version: "12.8"
             torch-version: "stable"
-          - runs-on: "linux.g5.12xlarge.nvidia.gpu"
-            gpu-arch-type: "cuda"
-            gpu-arch-version: "12.8"
-            torch-version: "nightly"
+          # - runs-on: "linux.g5.12xlarge.nvidia.gpu"
+          #   gpu-arch-type: "cuda"
+          #   gpu-arch-version: "12.8"
+          #   torch-version: "nightly"
 
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     permissions:


### PR DESCRIPTION
Summary:
nightly libtorch_cuda.so requires nccl 2.29 which will cause our cpp unit test has issue
```
2026-03-12T10:10:10.5166761Z /opt/rh/gcc-toolset-13/root/usr/libexec/gcc/x86_64-redhat-linux/13/ld: /opt/conda/envs/venv/lib/python3.12/site-packages/torch/lib/libtorch_cuda.so: undefined reference to `ncclGetLsaMultimemDevicePointer'
2026-03-12T10:10:10.5168372Z /opt/rh/gcc-toolset-13/root/usr/libexec/gcc/x86_64-redhat-linux/13/ld: /opt/conda/envs/venv/lib/python3.12/site-packages/torch/lib/libtorch_cuda.so: undefined reference to `ncclWaitSignal'
2026-03-12T10:10:10.5170009Z /opt/rh/gcc-toolset-13/root/usr/libexec/gcc/x86_64-redhat-linux/13/ld: /opt/conda/envs/venv/lib/python3.12/site-packages/torch/lib/libtorch_cuda.so: undefined reference to `ncclGetPeerDevicePointer'
2026-03-12T10:10:10.5171557Z /opt/rh/gcc-toolset-13/root/usr/libexec/gcc/x86_64-redhat-linux/13/ld: /opt/conda/envs/venv/lib/python3.12/site-packages/torch/lib/libtorch_cuda.so: undefined reference to `ncclPutSignal'
2026-03-12T10:10:10.5173363Z /opt/rh/gcc-toolset-13/root/usr/libexec/gcc/x86_64-redhat-linux/13/ld: /opt/conda/envs/venv/lib/python3.12/site-packages/torch/lib/libtorch_cuda.so: undefined reference to `ncclSignal'
2026-03-12T10:10:10.5174377Z collect2: error: ld returned 1 exit statuslibtorch_cuda.so
```
Comment it out until nccl 2.29 is updated.

Differential Revision: D96312466


