### PR TITLE
Add HintParsingTest for NCCLX backend config hints

### DIFF
--- a/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
@@ -317,6 +317,17 @@ class TorchCommNCCLX : public TorchCommBackend,
 
   void checkGraphEvents();
 
+  struct Configs {
+    size_t max_event_pool_size_{kDefaultMaxEventPoolSize};
+    size_t garbage_collect_interval_ms_{kDefaultGarbageCollectIntervalMs};
+    bool enable_cuda_graph_support_{kDefaultEnableCudaGraphSupport};
+    size_t graph_timeout_check_interval_ms_{
+        kDefaultGraphTimeoutCheckIntervalMs};
+  };
+  Configs configs_;
+
+  bool high_priority_stream_{false};
+
  private:
   // Helper that automatically cleans up premul sums.
   struct RedOpRAII {
@@ -419,15 +430,6 @@ class TorchCommNCCLX : public TorchCommBackend,
   size_t split_counter_{};
   CommOptions options_;
 
-  struct Configs {
-    size_t max_event_pool_size_{kDefaultMaxEventPoolSize};
-    size_t garbage_collect_interval_ms_{kDefaultGarbageCollectIntervalMs};
-    bool enable_cuda_graph_support_{kDefaultEnableCudaGraphSupport};
-    size_t graph_timeout_check_interval_ms_{
-        kDefaultGraphTimeoutCheckIntervalMs};
-  };
-  Configs configs_;
-
   cudaStream_t internal_stream_{};
   void* barrier_buffer_{}; // Pre-allocated CUDA buffer for barrier operations
   enum class InitializationState {
@@ -459,7 +461,6 @@ class TorchCommNCCLX : public TorchCommBackend,
   std::condition_variable timeout_cv_;
   std::mutex timeout_mutex_;
 
-  bool high_priority_stream_{false};
   std::string name_;
 
   // Tracks ad-hoc events for CUDA graph-captured collectives and monitors

--- a/comms/torchcomms/ncclx/tests/unit/cpp/HintParsingTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/HintParsingTest.cpp
@@ -1,0 +1,152 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTestBase.hpp"
+
+namespace torch::comms::test {
+
+class HintParsingTest : public TorchCommNCCLXTest {
+ protected:
+  CommOptions createOptions() {
+    CommOptions options;
+    options.timeout = std::chrono::milliseconds(2000);
+    options.abort_process_on_timeout_or_error = false;
+    options.store = store_;
+    return options;
+  }
+
+  void setupFinalizeExpectations(TestTorchCommNCCLX& comm) {
+    EXPECT_CALL(*cuda_mock_, eventDestroy(_))
+        .WillRepeatedly(Return(cudaSuccess));
+    EXPECT_CALL(*cuda_mock_, free(_)).WillOnce(Return(cudaSuccess));
+    EXPECT_CALL(*cuda_mock_, streamDestroy(_)).WillOnce(Return(cudaSuccess));
+    EXPECT_CALL(*nccl_mock_, commDestroy(_)).WillOnce(Return(ncclSuccess));
+    comm.finalize();
+  }
+};
+
+TEST_F(HintParsingTest, DefaultConfigValues) {
+  setupCCAExpectations(1, 2, 1);
+  auto comm = createMockedTorchComm();
+  cuda_mock_->setupDefaultBehaviors();
+  nccl_mock_->setupDefaultBehaviors();
+
+  const auto options = createOptions();
+  comm->init(*device_, "test_defaults", options);
+
+  EXPECT_FALSE(comm->testGetHighPriorityStream());
+  EXPECT_EQ(comm->testGetMaxEventPoolSize(), 1000);
+  EXPECT_EQ(comm->testGetGarbageCollectIntervalMs(), 100);
+  EXPECT_TRUE(comm->testGetEnableCudaGraphSupport());
+  EXPECT_EQ(comm->testGetGraphTimeoutCheckIntervalMs(), 1000);
+
+  setupFinalizeExpectations(*comm);
+}
+
+TEST_F(HintParsingTest, MaxEventPoolSizeHint) {
+  setupCCAExpectations(1, 2, 1);
+  auto comm = createMockedTorchComm();
+  cuda_mock_->setupDefaultBehaviors();
+  nccl_mock_->setupDefaultBehaviors();
+
+  auto options = createOptions();
+  options.hints["max_event_pool_size"] = "500";
+  comm->init(*device_, "test_max_event_pool", options);
+
+  EXPECT_EQ(comm->testGetMaxEventPoolSize(), 500);
+
+  setupFinalizeExpectations(*comm);
+}
+
+TEST_F(HintParsingTest, GarbageCollectIntervalMsHint) {
+  setupCCAExpectations(1, 2, 1);
+  auto comm = createMockedTorchComm();
+  cuda_mock_->setupDefaultBehaviors();
+  nccl_mock_->setupDefaultBehaviors();
+
+  auto options = createOptions();
+  options.hints["garbage_collect_interval_ms"] = "200";
+  comm->init(*device_, "test_gc_interval", options);
+
+  EXPECT_EQ(comm->testGetGarbageCollectIntervalMs(), 200);
+
+  setupFinalizeExpectations(*comm);
+}
+
+TEST_F(HintParsingTest, EnableCudaGraphSupportHint) {
+  setupCCAExpectations(1, 2, 1);
+  auto comm = createMockedTorchComm();
+  cuda_mock_->setupDefaultBehaviors();
+  nccl_mock_->setupDefaultBehaviors();
+
+  auto options = createOptions();
+  options.hints["enable_cuda_graph_support"] = "false";
+  comm->init(*device_, "test_cuda_graph_off", options);
+
+  EXPECT_FALSE(comm->testGetEnableCudaGraphSupport());
+
+  setupFinalizeExpectations(*comm);
+}
+
+TEST_F(HintParsingTest, GraphTimeoutCheckIntervalMsHint) {
+  setupCCAExpectations(1, 2, 1);
+  auto comm = createMockedTorchComm();
+  cuda_mock_->setupDefaultBehaviors();
+  nccl_mock_->setupDefaultBehaviors();
+
+  auto options = createOptions();
+  options.hints["graph_timeout_check_interval_ms"] = "2000";
+  comm->init(*device_, "test_graph_timeout_interval", options);
+
+  EXPECT_EQ(comm->testGetGraphTimeoutCheckIntervalMs(), 2000);
+
+  setupFinalizeExpectations(*comm);
+}
+
+TEST_F(HintParsingTest, AllHintsCombined) {
+  setupCCAExpectations(1, 2, 1);
+  auto comm = createMockedTorchComm();
+  cuda_mock_->setupDefaultBehaviors();
+  nccl_mock_->setupDefaultBehaviors();
+
+  // high_priority_stream hint triggers getStreamPriorityRange call
+  ON_CALL(*cuda_mock_, getStreamPriorityRange(_, _))
+      .WillByDefault(DoAll(
+          SetArgPointee<0>(0), SetArgPointee<1>(-10), Return(cudaSuccess)));
+
+  auto options = createOptions();
+  options.hints["max_event_pool_size"] = "2000";
+  options.hints["garbage_collect_interval_ms"] = "50";
+  options.hints["enable_cuda_graph_support"] = "false";
+  options.hints["high_priority_stream"] = "true";
+  options.hints["graph_timeout_check_interval_ms"] = "3000";
+  comm->init(*device_, "test_all_hints", options);
+
+  EXPECT_TRUE(comm->testGetHighPriorityStream());
+  EXPECT_EQ(comm->testGetMaxEventPoolSize(), 2000);
+  EXPECT_EQ(comm->testGetGarbageCollectIntervalMs(), 50);
+  EXPECT_FALSE(comm->testGetEnableCudaGraphSupport());
+  EXPECT_EQ(comm->testGetGraphTimeoutCheckIntervalMs(), 3000);
+
+  setupFinalizeExpectations(*comm);
+}
+
+TEST_F(HintParsingTest, UnknownHintsIgnored) {
+  setupCCAExpectations(1, 2, 1);
+  auto comm = createMockedTorchComm();
+  cuda_mock_->setupDefaultBehaviors();
+  nccl_mock_->setupDefaultBehaviors();
+
+  auto options = createOptions();
+  options.hints["some_other_backend::key"] = "value";
+  options.hints["unrelated_key"] = "42";
+  comm->init(*device_, "test_non_prefixed", options);
+
+  // Defaults unchanged
+  EXPECT_EQ(comm->testGetMaxEventPoolSize(), 1000);
+  EXPECT_EQ(comm->testGetGarbageCollectIntervalMs(), 100);
+  EXPECT_TRUE(comm->testGetEnableCudaGraphSupport());
+
+  setupFinalizeExpectations(*comm);
+}
+
+} // namespace torch::comms::test

--- a/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTestBase.hpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTestBase.hpp
@@ -87,6 +87,27 @@ class TorchCommNCCLXTest : public ::testing::Test {
     void checkGraphEvents() {
       TorchCommNCCLX::checkGraphEvents();
     }
+
+    // Hint parsing test accessors
+    bool testGetHighPriorityStream() const {
+      return high_priority_stream_;
+    }
+
+    size_t testGetMaxEventPoolSize() const {
+      return configs_.max_event_pool_size_;
+    }
+
+    size_t testGetGarbageCollectIntervalMs() const {
+      return configs_.garbage_collect_interval_ms_;
+    }
+
+    bool testGetEnableCudaGraphSupport() const {
+      return configs_.enable_cuda_graph_support_;
+    }
+
+    size_t testGetGraphTimeoutCheckIntervalMs() const {
+      return configs_.graph_timeout_check_interval_ms_;
+    }
   };
 
   void setupEventsForWork(TestTorchCommNCCLX& torchcomm, size_t numWork);


### PR DESCRIPTION
Summary:
We didn't have a proper test for hint parsing. This diff adds it.
- Moved `Configs` struct and `high_priority_stream_` from private to protected for test accessor access.                                    
- Added `HintParsingTest` (6 tests) covering: default config values, each hint individually, all hints combined, and unknown hints ignored.

Reviewed By: dolpm

Differential Revision: D94595135


