### PR TITLE
add StreamCaptureModeGuard RAII utility

### DIFF
--- a/comms/utils/CudaRAII.cc
+++ b/comms/utils/CudaRAII.cc
@@ -97,4 +97,21 @@ cudaEvent_t CudaEvent::get() const {
   return event_;
 }
 
+StreamCaptureModeGuard::StreamCaptureModeGuard(
+    cudaStreamCaptureMode desiredMode)
+    : prevMode_(desiredMode) {
+  CUDA_CHECK(cudaThreadExchangeStreamCaptureMode(&prevMode_));
+}
+
+StreamCaptureModeGuard::~StreamCaptureModeGuard() {
+  if (exchangeFn_) {
+    (void)exchangeFn_(ctx_, &prevMode_);
+  } else {
+    CUDA_CHECK_WITH_IGNORE(
+        cudaThreadExchangeStreamCaptureMode(&prevMode_),
+        cudaErrorCudartUnloading,
+        cudaErrorContextIsDestroyed);
+  }
+}
+
 } // namespace meta::comms

--- a/comms/utils/CudaRAII.h
+++ b/comms/utils/CudaRAII.h
@@ -4,7 +4,6 @@
 
 #include <cuda.h>
 #include <cuda_runtime.h>
-
 namespace meta::comms {
 
 // RAII helper for device buffer pointers
@@ -66,6 +65,50 @@ class CudaEvent {
 
  private:
   cudaEvent_t event_{nullptr};
+};
+
+// RAII guard that sets the calling thread's CUDA stream capture interaction
+// mode and restores the previous mode on destruction.
+//
+// Two constructors:
+//   1. Standalone — calls cudaThreadExchangeStreamCaptureMode directly.
+//   2. Mockable — accepts any object with threadExchangeStreamCaptureMode(),
+//      captured via template at construction time. No hard dependency on the
+//      API type.
+//
+// Usage:
+//   // standalone
+//   StreamCaptureModeGuard guard{cudaStreamCaptureModeRelaxed};
+//
+//   // mockable (e.g. torchcomms CudaApi)
+//   StreamCaptureModeGuard guard{api, cudaStreamCaptureModeRelaxed};
+class StreamCaptureModeGuard {
+ public:
+  using ExchangeFn = cudaError_t (*)(void*, cudaStreamCaptureMode*);
+
+  explicit StreamCaptureModeGuard(cudaStreamCaptureMode desiredMode);
+
+  template <typename Api>
+  StreamCaptureModeGuard(Api* api, cudaStreamCaptureMode desiredMode)
+      : ctx_(api),
+        exchangeFn_([](void* ctx, cudaStreamCaptureMode* mode) {
+          return static_cast<Api*>(ctx)->threadExchangeStreamCaptureMode(mode);
+        }),
+        prevMode_(desiredMode) {
+    exchangeFn_(ctx_, &prevMode_);
+  }
+
+  ~StreamCaptureModeGuard();
+
+  StreamCaptureModeGuard(const StreamCaptureModeGuard&) = delete;
+  StreamCaptureModeGuard& operator=(const StreamCaptureModeGuard&) = delete;
+  StreamCaptureModeGuard(StreamCaptureModeGuard&&) = delete;
+  StreamCaptureModeGuard& operator=(StreamCaptureModeGuard&&) = delete;
+
+ private:
+  void* ctx_{nullptr};
+  ExchangeFn exchangeFn_{nullptr};
+  cudaStreamCaptureMode prevMode_;
 };
 
 } // namespace meta::comms

--- a/comms/utils/tests/StreamCaptureModeGuardTest.cc
+++ b/comms/utils/tests/StreamCaptureModeGuardTest.cc
@@ -1,0 +1,55 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/utils/CudaRAII.h"
+
+#include <gtest/gtest.h>
+
+using namespace meta::comms;
+
+TEST(StreamCaptureModeGuardTest, StandaloneRestoresMode) {
+  cudaStreamCaptureMode before = cudaStreamCaptureModeGlobal;
+  ASSERT_EQ(cudaThreadExchangeStreamCaptureMode(&before), cudaSuccess);
+  ASSERT_EQ(cudaThreadExchangeStreamCaptureMode(&before), cudaSuccess);
+
+  {
+    StreamCaptureModeGuard guard{cudaStreamCaptureModeRelaxed};
+    cudaStreamCaptureMode during = cudaStreamCaptureModeGlobal;
+    ASSERT_EQ(cudaThreadExchangeStreamCaptureMode(&during), cudaSuccess);
+    EXPECT_EQ(during, cudaStreamCaptureModeRelaxed);
+    ASSERT_EQ(cudaThreadExchangeStreamCaptureMode(&during), cudaSuccess);
+  }
+
+  cudaStreamCaptureMode after = cudaStreamCaptureModeRelaxed;
+  ASSERT_EQ(cudaThreadExchangeStreamCaptureMode(&after), cudaSuccess);
+  EXPECT_EQ(after, before);
+  ASSERT_EQ(cudaThreadExchangeStreamCaptureMode(&after), cudaSuccess);
+}
+
+struct MockCudaApi {
+  int exchangeCallCount{0};
+  cudaStreamCaptureMode lastRequestedMode{cudaStreamCaptureModeGlobal};
+
+  cudaError_t threadExchangeStreamCaptureMode(cudaStreamCaptureMode* mode) {
+    ++exchangeCallCount;
+    lastRequestedMode = *mode;
+    std::swap(*mode, storedMode_);
+    return cudaSuccess;
+  }
+
+ private:
+  cudaStreamCaptureMode storedMode_{cudaStreamCaptureModeGlobal};
+};
+
+TEST(StreamCaptureModeGuardTest, TemplateConstructorCallsApi) {
+  MockCudaApi mock;
+  ASSERT_EQ(mock.exchangeCallCount, 0);
+
+  {
+    StreamCaptureModeGuard guard{&mock, cudaStreamCaptureModeRelaxed};
+    EXPECT_EQ(mock.exchangeCallCount, 1);
+    EXPECT_EQ(mock.lastRequestedMode, cudaStreamCaptureModeRelaxed);
+  }
+
+  EXPECT_EQ(mock.exchangeCallCount, 2);
+  EXPECT_EQ(mock.lastRequestedMode, cudaStreamCaptureModeGlobal);
+}


### PR DESCRIPTION
Summary:
RAII guard that sets the calling thread's CUDA stream capture mode and
restores it on destruction. Two constructors:
- Standalone: calls cudaThreadExchangeStreamCaptureMode directly.
  Usable by any layer (ctran, torchcomms, etc.)
- Mockable: routes through CudaApi, usable by torchcomms.

Differential Revision: D95485489


