### PR TITLE
Remove libcuda.so.1 DT_NEEDED, add version script and --no-undefined (#1058)

### DIFF
--- a/comms/pipes/CudaDriverLazy.cc
+++ b/comms/pipes/CudaDriverLazy.cc
@@ -1,0 +1,92 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/CudaDriverLazy.h"
+
+#include <cstdio>
+#include <mutex>
+
+namespace comms::pipes {
+
+// Function pointer globals (initially nullptr).
+PFN_cuDeviceGet_v2000 pfn_cuDeviceGet = nullptr;
+PFN_cuDeviceGetAttribute_v2000 pfn_cuDeviceGetAttribute = nullptr;
+PFN_cuCtxGetCurrent_v4000 pfn_cuCtxGetCurrent = nullptr;
+PFN_cuGetErrorString_v6000 pfn_cuGetErrorString = nullptr;
+PFN_cuMemCreate_v10020 pfn_cuMemCreate = nullptr;
+PFN_cuMemRelease_v10020 pfn_cuMemRelease = nullptr;
+PFN_cuMemAddressReserve_v10020 pfn_cuMemAddressReserve = nullptr;
+PFN_cuMemAddressFree_v10020 pfn_cuMemAddressFree = nullptr;
+PFN_cuMemMap_v10020 pfn_cuMemMap = nullptr;
+PFN_cuMemUnmap_v10020 pfn_cuMemUnmap = nullptr;
+PFN_cuMemSetAccess_v10020 pfn_cuMemSetAccess = nullptr;
+PFN_cuMemGetAllocationGranularity_v10020 pfn_cuMemGetAllocationGranularity =
+    nullptr;
+PFN_cuMemExportToShareableHandle_v10020 pfn_cuMemExportToShareableHandle =
+    nullptr;
+PFN_cuMemImportFromShareableHandle_v10020 pfn_cuMemImportFromShareableHandle =
+    nullptr;
+PFN_cuMemGetAllocationPropertiesFromHandle_v10020
+    pfn_cuMemGetAllocationPropertiesFromHandle = nullptr;
+PFN_cuMemRetainAllocationHandle_v11000 pfn_cuMemRetainAllocationHandle =
+    nullptr;
+PFN_cuMemGetAddressRange_v3020 pfn_cuMemGetAddressRange = nullptr;
+
+namespace {
+
+std::once_flag init_flag;
+int init_result = -1;
+
+int load_sym(const char* name, void** ptr) {
+  cudaDriverEntryPointQueryResult status;
+  auto res = cudaGetDriverEntryPoint(name, ptr, cudaEnableDefault, &status);
+  if (res != cudaSuccess || status != cudaDriverEntryPointSuccess) {
+    fprintf(
+        stderr,
+        "pipes: failed to resolve CUDA driver symbol %s "
+        "(cudaError=%d, status=%d)\n",
+        name,
+        static_cast<int>(res),
+        static_cast<int>(status));
+    return -1;
+  }
+  return 0;
+}
+
+void do_init() {
+#define LOAD(symbol)                                                     \
+  if (load_sym(#symbol, reinterpret_cast<void**>(&pfn_##symbol)) != 0) { \
+    init_result = -1;                                                    \
+    return;                                                              \
+  }
+
+  LOAD(cuDeviceGet);
+  LOAD(cuDeviceGetAttribute);
+  LOAD(cuCtxGetCurrent);
+  LOAD(cuGetErrorString);
+  LOAD(cuMemCreate);
+  LOAD(cuMemRelease);
+  LOAD(cuMemAddressReserve);
+  LOAD(cuMemAddressFree);
+  LOAD(cuMemMap);
+  LOAD(cuMemUnmap);
+  LOAD(cuMemSetAccess);
+  LOAD(cuMemGetAllocationGranularity);
+  LOAD(cuMemExportToShareableHandle);
+  LOAD(cuMemImportFromShareableHandle);
+  LOAD(cuMemGetAllocationPropertiesFromHandle);
+  LOAD(cuMemRetainAllocationHandle);
+  LOAD(cuMemGetAddressRange);
+
+#undef LOAD
+
+  init_result = 0;
+}
+
+} // namespace
+
+int cuda_driver_lazy_init() {
+  std::call_once(init_flag, do_init);
+  return init_result;
+}
+
+} // namespace comms::pipes

--- a/comms/pipes/CudaDriverLazy.h
+++ b/comms/pipes/CudaDriverLazy.h
@@ -1,0 +1,65 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+// Lazy-loaded CUDA driver API function pointers.
+//
+// Uses cudaGetDriverEntryPoint (from cudart) to resolve CUDA driver API
+// symbols at runtime, avoiding a link-time dependency on libcuda.so.1.
+// This is the same mechanism ncclx uses in cudawrap.cc.
+//
+// Usage:
+//   if (comms::pipes::cuda_driver_lazy_init() != 0) {
+//     // CUDA driver not available
+//   }
+//   CUresult err = comms::pipes::pfn_cuMemCreate(&handle, size, &prop, 0);
+
+#include <cuda.h>
+
+#include <cudaTypedefs.h>
+#include <cuda_runtime.h>
+
+namespace comms::pipes {
+
+/// Initialize CUDA driver function pointers via cudaGetDriverEntryPoint.
+/// Thread-safe (uses std::call_once). Returns 0 on success, non-zero if
+/// the CUDA driver is unavailable (e.g., on CPU-only machines).
+int cuda_driver_lazy_init();
+
+// Device queries
+extern PFN_cuDeviceGet_v2000 pfn_cuDeviceGet;
+extern PFN_cuDeviceGetAttribute_v2000 pfn_cuDeviceGetAttribute;
+
+// Context
+extern PFN_cuCtxGetCurrent_v4000 pfn_cuCtxGetCurrent;
+
+// Error handling
+extern PFN_cuGetErrorString_v6000 pfn_cuGetErrorString;
+
+// VMM allocation
+extern PFN_cuMemCreate_v10020 pfn_cuMemCreate;
+extern PFN_cuMemRelease_v10020 pfn_cuMemRelease;
+
+// VMM address management
+extern PFN_cuMemAddressReserve_v10020 pfn_cuMemAddressReserve;
+extern PFN_cuMemAddressFree_v10020 pfn_cuMemAddressFree;
+
+// VMM mapping
+extern PFN_cuMemMap_v10020 pfn_cuMemMap;
+extern PFN_cuMemUnmap_v10020 pfn_cuMemUnmap;
+extern PFN_cuMemSetAccess_v10020 pfn_cuMemSetAccess;
+extern PFN_cuMemGetAllocationGranularity_v10020
+    pfn_cuMemGetAllocationGranularity;
+
+// Fabric handle sharing
+extern PFN_cuMemExportToShareableHandle_v10020 pfn_cuMemExportToShareableHandle;
+extern PFN_cuMemImportFromShareableHandle_v10020
+    pfn_cuMemImportFromShareableHandle;
+extern PFN_cuMemGetAllocationPropertiesFromHandle_v10020
+    pfn_cuMemGetAllocationPropertiesFromHandle;
+
+// Allocation queries
+extern PFN_cuMemRetainAllocationHandle_v11000 pfn_cuMemRetainAllocationHandle;
+extern PFN_cuMemGetAddressRange_v3020 pfn_cuMemGetAddressRange;
+
+} // namespace comms::pipes

--- a/comms/pipes/GpuMemHandler.cc
+++ b/comms/pipes/GpuMemHandler.cc
@@ -2,6 +2,8 @@
 
 #include "comms/pipes/GpuMemHandler.h"
 
+#include "comms/pipes/CudaDriverLazy.h"
+
 #include <glog/logging.h>
 #include <mutex>
 #include <stdexcept>
@@ -19,7 +21,7 @@ void checkCudaError(cudaError_t err, const char* msg) {
 void checkCuError(CUresult err, const char* msg) {
   if (err != CUDA_SUCCESS) {
     const char* errStr = nullptr;
-    cuGetErrorString(err, &errStr);
+    pfn_cuGetErrorString(err, &errStr);
     throw std::runtime_error(
         std::string(msg) + ": " + (errStr ? errStr : "unknown error"));
   }
@@ -34,6 +36,10 @@ bool checkFabricHandleSupportedImpl() {
 #if CUDART_VERSION < 12030
   return false;
 #else
+  if (cuda_driver_lazy_init() != 0) {
+    return false;
+  }
+
   int cudaDev = 0;
   CUdevice cuDev;
 
@@ -43,14 +49,14 @@ bool checkFabricHandleSupportedImpl() {
     return false;
   }
 
-  CUresult cuErr = cuDeviceGet(&cuDev, cudaDev);
+  CUresult cuErr = pfn_cuDeviceGet(&cuDev, cudaDev);
   if (cuErr != CUDA_SUCCESS) {
     return false;
   }
 
   // 2. Check device attribute for fabric handle support
   int fabricSupported = 0;
-  cuErr = cuDeviceGetAttribute(
+  cuErr = pfn_cuDeviceGetAttribute(
       &fabricSupported,
       CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED,
       cuDev);
@@ -68,7 +74,7 @@ bool checkFabricHandleSupportedImpl() {
   prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_FABRIC;
 
   size_t granularity = 0;
-  cuErr = cuMemGetAllocationGranularity(
+  cuErr = pfn_cuMemGetAllocationGranularity(
       &granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM);
   if (cuErr != CUDA_SUCCESS) {
     return false;
@@ -78,22 +84,22 @@ bool checkFabricHandleSupportedImpl() {
       ((kTrialAllocSize + granularity - 1) / granularity) * granularity;
 
   CUmemGenericAllocationHandle handle;
-  cuErr = cuMemCreate(&handle, allocSize, &prop, 0);
+  cuErr = pfn_cuMemCreate(&handle, allocSize, &prop, 0);
   if (cuErr != CUDA_SUCCESS) {
     return false;
   }
 
   CUdeviceptr ptr;
-  cuErr = cuMemAddressReserve(&ptr, allocSize, granularity, 0, 0);
+  cuErr = pfn_cuMemAddressReserve(&ptr, allocSize, granularity, 0, 0);
   if (cuErr != CUDA_SUCCESS) {
-    cuMemRelease(handle);
+    pfn_cuMemRelease(handle);
     return false;
   }
 
-  cuErr = cuMemMap(ptr, allocSize, 0, handle, 0);
+  cuErr = pfn_cuMemMap(ptr, allocSize, 0, handle, 0);
   if (cuErr != CUDA_SUCCESS) {
-    cuMemAddressFree(ptr, allocSize);
-    cuMemRelease(handle);
+    pfn_cuMemAddressFree(ptr, allocSize);
+    pfn_cuMemRelease(handle);
     return false;
   }
 
@@ -101,43 +107,43 @@ bool checkFabricHandleSupportedImpl() {
   accessDesc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
   accessDesc.location.id = cuDev;
   accessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
-  cuErr = cuMemSetAccess(ptr, allocSize, &accessDesc, 1);
+  cuErr = pfn_cuMemSetAccess(ptr, allocSize, &accessDesc, 1);
   if (cuErr != CUDA_SUCCESS) {
-    cuMemUnmap(ptr, allocSize);
-    cuMemAddressFree(ptr, allocSize);
-    cuMemRelease(handle);
+    pfn_cuMemUnmap(ptr, allocSize);
+    pfn_cuMemAddressFree(ptr, allocSize);
+    pfn_cuMemRelease(handle);
     return false;
   }
 
   // 4. Trial export to fabric handle
   CUmemFabricHandle fabricHandle;
-  cuErr = cuMemExportToShareableHandle(
+  cuErr = pfn_cuMemExportToShareableHandle(
       &fabricHandle, handle, CU_MEM_HANDLE_TYPE_FABRIC, 0);
   if (cuErr != CUDA_SUCCESS) {
-    cuMemUnmap(ptr, allocSize);
-    cuMemAddressFree(ptr, allocSize);
-    cuMemRelease(handle);
+    pfn_cuMemUnmap(ptr, allocSize);
+    pfn_cuMemAddressFree(ptr, allocSize);
+    pfn_cuMemRelease(handle);
     return false;
   }
 
   // 5. Trial import from fabric handle
   CUmemGenericAllocationHandle importedHandle;
-  cuErr = cuMemImportFromShareableHandle(
+  cuErr = pfn_cuMemImportFromShareableHandle(
       &importedHandle, &fabricHandle, CU_MEM_HANDLE_TYPE_FABRIC);
   if (cuErr != CUDA_SUCCESS) {
-    cuMemUnmap(ptr, allocSize);
-    cuMemAddressFree(ptr, allocSize);
-    cuMemRelease(handle);
+    pfn_cuMemUnmap(ptr, allocSize);
+    pfn_cuMemAddressFree(ptr, allocSize);
+    pfn_cuMemRelease(handle);
     return false;
   }
 
   // Import increases ref count, release it
-  cuMemRelease(importedHandle);
+  pfn_cuMemRelease(importedHandle);
 
   // Cleanup trial allocation
-  cuMemUnmap(ptr, allocSize);
-  cuMemAddressFree(ptr, allocSize);
-  cuMemRelease(handle);
+  pfn_cuMemUnmap(ptr, allocSize);
+  pfn_cuMemAddressFree(ptr, allocSize);
+  pfn_cuMemRelease(handle);
 
   return true;
 #endif
@@ -269,11 +275,15 @@ void GpuMemHandler::allocateFabricMemory(size_t size) {
 #if CUDART_VERSION < 12030
   throw std::runtime_error("Fabric handles require CUDA 12.3+");
 #else
+  if (cuda_driver_lazy_init() != 0) {
+    throw std::runtime_error("CUDA driver not available");
+  }
+
   int cudaDev = 0;
   CUdevice cuDev;
 
   checkCudaError(cudaGetDevice(&cudaDev), "cudaGetDevice failed");
-  checkCuError(cuDeviceGet(&cuDev, cudaDev), "cuDeviceGet failed");
+  checkCuError(pfn_cuDeviceGet(&cuDev, cudaDev), "cuDeviceGet failed");
 
   // Set up allocation properties with fabric handle support
   CUmemAllocationProp prop = {};
@@ -284,7 +294,7 @@ void GpuMemHandler::allocateFabricMemory(size_t size) {
 
   // Check for GPUDirect RDMA support
   int rdmaSupported = 0;
-  cuDeviceGetAttribute(
+  pfn_cuDeviceGetAttribute(
       &rdmaSupported, CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_SUPPORTED, cuDev);
   if (rdmaSupported) {
     prop.allocFlags.gpuDirectRDMACapable = 1;
@@ -293,7 +303,7 @@ void GpuMemHandler::allocateFabricMemory(size_t size) {
   // Get allocation granularity
   size_t granularity = 0;
   checkCuError(
-      cuMemGetAllocationGranularity(
+      pfn_cuMemGetAllocationGranularity(
           &granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM),
       "cuMemGetAllocationGranularity failed");
 
@@ -302,17 +312,19 @@ void GpuMemHandler::allocateFabricMemory(size_t size) {
 
   // Create the physical memory allocation
   checkCuError(
-      cuMemCreate(&fabricLocalAllocHandle_, allocatedSize_, &prop, 0),
+      pfn_cuMemCreate(&fabricLocalAllocHandle_, allocatedSize_, &prop, 0),
       "cuMemCreate failed");
 
   // Reserve virtual address space
   checkCuError(
-      cuMemAddressReserve(&fabricLocalPtr_, allocatedSize_, granularity, 0, 0),
+      pfn_cuMemAddressReserve(
+          &fabricLocalPtr_, allocatedSize_, granularity, 0, 0),
       "cuMemAddressReserve failed");
 
   // Map the physical memory to virtual address
   checkCuError(
-      cuMemMap(fabricLocalPtr_, allocatedSize_, 0, fabricLocalAllocHandle_, 0),
+      pfn_cuMemMap(
+          fabricLocalPtr_, allocatedSize_, 0, fabricLocalAllocHandle_, 0),
       "cuMemMap failed");
 
   // Set access permissions
@@ -321,12 +333,12 @@ void GpuMemHandler::allocateFabricMemory(size_t size) {
   accessDesc.location.id = cuDev;
   accessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
   checkCuError(
-      cuMemSetAccess(fabricLocalPtr_, allocatedSize_, &accessDesc, 1),
+      pfn_cuMemSetAccess(fabricLocalPtr_, allocatedSize_, &accessDesc, 1),
       "cuMemSetAccess failed");
 
   // Export to fabric handle for sharing with peers
   checkCuError(
-      cuMemExportToShareableHandle(
+      pfn_cuMemExportToShareableHandle(
           &fabricLocalHandle_,
           fabricLocalAllocHandle_,
           CU_MEM_HANDLE_TYPE_FABRIC,
@@ -382,15 +394,19 @@ void GpuMemHandler::importFabricPeerMemory(
 #if CUDART_VERSION < 12030
   throw std::runtime_error("Fabric handles require CUDA 12.3+");
 #else
+  if (cuda_driver_lazy_init() != 0) {
+    throw std::runtime_error("CUDA driver not available");
+  }
+
   int cudaDev = 0;
   CUdevice cuDev;
 
   checkCudaError(cudaGetDevice(&cudaDev), "cudaGetDevice failed");
-  checkCuError(cuDeviceGet(&cuDev, cudaDev), "cuDeviceGet failed");
+  checkCuError(pfn_cuDeviceGet(&cuDev, cudaDev), "cuDeviceGet failed");
 
   // Import the fabric handle to get allocation handle
   checkCuError(
-      cuMemImportFromShareableHandle(
+      pfn_cuMemImportFromShareableHandle(
           &fabricPeerAllocHandles_[rank],
           const_cast<void*>(static_cast<const void*>(&handle)),
           CU_MEM_HANDLE_TYPE_FABRIC),
@@ -399,25 +415,25 @@ void GpuMemHandler::importFabricPeerMemory(
   // Get allocation properties for granularity
   CUmemAllocationProp prop = {};
   checkCuError(
-      cuMemGetAllocationPropertiesFromHandle(
+      pfn_cuMemGetAllocationPropertiesFromHandle(
           &prop, fabricPeerAllocHandles_[rank]),
       "cuMemGetAllocationPropertiesFromHandle failed");
 
   size_t granularity = 0;
   checkCuError(
-      cuMemGetAllocationGranularity(
+      pfn_cuMemGetAllocationGranularity(
           &granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM),
       "cuMemGetAllocationGranularity failed");
 
   // Reserve virtual address space for peer memory
   checkCuError(
-      cuMemAddressReserve(
+      pfn_cuMemAddressReserve(
           &fabricPeerPtrs_[rank], peerAllocatedSize, granularity, 0, 0),
       "cuMemAddressReserve for peer failed");
 
   // Map peer's physical memory to our virtual address
   checkCuError(
-      cuMemMap(
+      pfn_cuMemMap(
           fabricPeerPtrs_[rank],
           peerAllocatedSize,
           0,
@@ -431,7 +447,8 @@ void GpuMemHandler::importFabricPeerMemory(
   accessDesc.location.id = cuDev;
   accessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
   checkCuError(
-      cuMemSetAccess(fabricPeerPtrs_[rank], peerAllocatedSize, &accessDesc, 1),
+      pfn_cuMemSetAccess(
+          fabricPeerPtrs_[rank], peerAllocatedSize, &accessDesc, 1),
       "cuMemSetAccess for peer failed");
 #endif
 }
@@ -440,7 +457,8 @@ void GpuMemHandler::cleanupFabric() {
 #if CUDART_VERSION >= 12030
   // Check if CUDA context is still valid
   CUcontext ctx = nullptr;
-  if (cuCtxGetCurrent(&ctx) != CUDA_SUCCESS || ctx == nullptr) {
+  if (pfn_cuCtxGetCurrent == nullptr ||
+      pfn_cuCtxGetCurrent(&ctx) != CUDA_SUCCESS || ctx == nullptr) {
     return;
   }
 
@@ -450,24 +468,25 @@ void GpuMemHandler::cleanupFabric() {
       continue;
     }
     if (fabricPeerPtrs_[rank] != 0) {
-      cuMemUnmap(fabricPeerPtrs_[rank], fabricPeerAllocatedSizes_[rank]);
-      cuMemAddressFree(fabricPeerPtrs_[rank], fabricPeerAllocatedSizes_[rank]);
+      pfn_cuMemUnmap(fabricPeerPtrs_[rank], fabricPeerAllocatedSizes_[rank]);
+      pfn_cuMemAddressFree(
+          fabricPeerPtrs_[rank], fabricPeerAllocatedSizes_[rank]);
       fabricPeerPtrs_[rank] = 0;
     }
     if (fabricPeerAllocHandles_[rank] != 0) {
-      cuMemRelease(fabricPeerAllocHandles_[rank]);
+      pfn_cuMemRelease(fabricPeerAllocHandles_[rank]);
       fabricPeerAllocHandles_[rank] = 0;
     }
   }
 
   // Release local allocation
   if (fabricLocalPtr_ != 0) {
-    cuMemUnmap(fabricLocalPtr_, allocatedSize_);
-    cuMemAddressFree(fabricLocalPtr_, allocatedSize_);
+    pfn_cuMemUnmap(fabricLocalPtr_, allocatedSize_);
+    pfn_cuMemAddressFree(fabricLocalPtr_, allocatedSize_);
     fabricLocalPtr_ = 0;
   }
   if (fabricLocalAllocHandle_ != 0) {
-    cuMemRelease(fabricLocalAllocHandle_);
+    pfn_cuMemRelease(fabricLocalAllocHandle_);
     fabricLocalAllocHandle_ = 0;
   }
 #endif

--- a/comms/pipes/MultiPeerTransport.cc
+++ b/comms/pipes/MultiPeerTransport.cc
@@ -13,6 +13,7 @@
 #include <cuda_runtime.h>
 #include <glog/logging.h>
 
+#include "comms/pipes/CudaDriverLazy.h"
 #include "comms/pipes/MultiPeerDeviceHandle.cuh"
 #include "comms/pipes/MultipeerIbgdaDeviceTransport.cuh"
 #include "comms/pipes/TopologyDiscovery.h"
@@ -37,7 +38,7 @@ namespace {
     CUresult err = (cmd);                                                      \
     if (err != CUDA_SUCCESS) {                                                 \
       const char* errStr = nullptr;                                            \
-      cuGetErrorString(err, &errStr);                                          \
+      pfn_cuGetErrorString(err, &errStr);                                      \
       throw std::runtime_error(                                                \
           std::string("CUDA driver error: ") + (errStr ? errStr : "unknown") + \
           " at " + __FILE__ + ":" + std::to_string(__LINE__));                 \
@@ -144,6 +145,11 @@ MultiPeerTransport::~MultiPeerTransport() {
 }
 
 void MultiPeerTransport::exchange() {
+  if (cuda_driver_lazy_init() != 0) {
+    throw std::runtime_error(
+        "MultiPeerTransport::exchange: failed to initialize CUDA driver API");
+  }
+
   if (nvlTransport_) {
     nvlTransport_->exchange();
   }
@@ -233,25 +239,29 @@ std::vector<IbgdaRemoteBuffer> MultiPeerTransport::exchangeIbgdaBuffer(
 MultiPeerTransport::NvlMemMode MultiPeerTransport::detectNvlMemMode(
     void* ptr) const {
 #if CUDART_VERSION >= 12030
+  if (cuda_driver_lazy_init() != 0) {
+    throw std::runtime_error("detectNvlMemMode: CUDA driver not available");
+  }
+
   CUmemGenericAllocationHandle handle;
-  CUresult ret = cuMemRetainAllocationHandle(&handle, ptr);
+  CUresult ret = pfn_cuMemRetainAllocationHandle(&handle, ptr);
   if (ret == CUDA_ERROR_INVALID_VALUE) {
     return NvlMemMode::kCudaIpc;
   }
   if (ret != CUDA_SUCCESS) {
     const char* errStr = nullptr;
-    cuGetErrorString(ret, &errStr);
+    pfn_cuGetErrorString(ret, &errStr);
     throw std::runtime_error(
         std::string("detectNvlMemMode: cuMemRetainAllocationHandle failed: ") +
         (errStr ? errStr : "unknown"));
   }
 
   CUmemAllocationProp prop = {};
-  CUresult propRet = cuMemGetAllocationPropertiesFromHandle(&prop, handle);
-  cuMemRelease(handle);
+  CUresult propRet = pfn_cuMemGetAllocationPropertiesFromHandle(&prop, handle);
+  pfn_cuMemRelease(handle);
   if (propRet != CUDA_SUCCESS) {
     const char* errStr = nullptr;
-    cuGetErrorString(propRet, &errStr);
+    pfn_cuGetErrorString(propRet, &errStr);
     throw std::runtime_error(
         std::string(
             "detectNvlMemMode: cuMemGetAllocationPropertiesFromHandle failed: ") +
@@ -312,20 +322,25 @@ std::vector<void*> MultiPeerTransport::exchangeNvlBufferFabric(
 #if CUDART_VERSION < 12030
   throw std::runtime_error("Fabric handles require CUDA 12.3+");
 #else
+  if (cuda_driver_lazy_init() != 0) {
+    throw std::runtime_error(
+        "exchangeNvlBufferFabric: CUDA driver not available");
+  }
+
   // Retain allocation handle and export fabric handle
   CUmemGenericAllocationHandle allocHandle;
-  CU_CHECK(cuMemRetainAllocationHandle(&allocHandle, localPtr));
+  CU_CHECK(pfn_cuMemRetainAllocationHandle(&allocHandle, localPtr));
 
   FabricHandle localFabricHandle{};
-  CU_CHECK(cuMemExportToShareableHandle(
+  CU_CHECK(pfn_cuMemExportToShareableHandle(
       &localFabricHandle, allocHandle, CU_MEM_HANDLE_TYPE_FABRIC, 0));
-  CU_CHECK(cuMemRelease(allocHandle));
+  CU_CHECK(pfn_cuMemRelease(allocHandle));
 
   // Get actual allocated size (may be larger due to granularity)
   CUdeviceptr basePtr;
   size_t allocatedSize = 0;
-  CU_CHECK(
-      cuMemGetAddressRange(&basePtr, &allocatedSize, (CUdeviceptr)localPtr));
+  CU_CHECK(pfn_cuMemGetAddressRange(
+      &basePtr, &allocatedSize, (CUdeviceptr)localPtr));
 
   // Exchange fabric handles + allocated sizes
   struct ExchangeData {
@@ -350,7 +365,7 @@ std::vector<void*> MultiPeerTransport::exchangeNvlBufferFabric(
   int cudaDev = 0;
   CUdevice cuDev;
   CUDA_CHECK(cudaGetDevice(&cudaDev));
-  CU_CHECK(cuDeviceGet(&cuDev, cudaDev));
+  CU_CHECK(pfn_cuDeviceGet(&cuDev, cudaDev));
 
   NvlExchangeRecord record;
   record.mode = NvlMemMode::kFabric;
@@ -369,23 +384,23 @@ std::vector<void*> MultiPeerTransport::exchangeNvlBufferFabric(
     size_t peerAllocatedSize = allData[rank].allocatedSize;
     record.cuMemPeerSizes[rank] = peerAllocatedSize;
 
-    CU_CHECK(cuMemImportFromShareableHandle(
+    CU_CHECK(pfn_cuMemImportFromShareableHandle(
         &record.cuMemPeerAllocHandles[rank],
         const_cast<void*>(static_cast<const void*>(&allData[rank].handle)),
         CU_MEM_HANDLE_TYPE_FABRIC));
 
     CUmemAllocationProp prop = {};
-    CU_CHECK(cuMemGetAllocationPropertiesFromHandle(
+    CU_CHECK(pfn_cuMemGetAllocationPropertiesFromHandle(
         &prop, record.cuMemPeerAllocHandles[rank]));
 
     size_t granularity = 0;
-    CU_CHECK(cuMemGetAllocationGranularity(
+    CU_CHECK(pfn_cuMemGetAllocationGranularity(
         &granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM));
 
-    CU_CHECK(cuMemAddressReserve(
+    CU_CHECK(pfn_cuMemAddressReserve(
         &record.cuMemPeerPtrs[rank], peerAllocatedSize, granularity, 0, 0));
 
-    CU_CHECK(cuMemMap(
+    CU_CHECK(pfn_cuMemMap(
         record.cuMemPeerPtrs[rank],
         peerAllocatedSize,
         0,
@@ -396,7 +411,7 @@ std::vector<void*> MultiPeerTransport::exchangeNvlBufferFabric(
     accessDesc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
     accessDesc.location.id = cuDev;
     accessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
-    CU_CHECK(cuMemSetAccess(
+    CU_CHECK(pfn_cuMemSetAccess(
         record.cuMemPeerPtrs[rank], peerAllocatedSize, &accessDesc, 1));
 
     mappedPtrs[rank] = reinterpret_cast<void*>(record.cuMemPeerPtrs[rank]);
@@ -415,20 +430,25 @@ std::vector<void*> MultiPeerTransport::exchangeNvlBufferPosixFd(
 #if CUDART_VERSION < 12030
   throw std::runtime_error("POSIX FD cuMem handles require CUDA 12.3+");
 #else
+  if (cuda_driver_lazy_init() != 0) {
+    throw std::runtime_error(
+        "exchangeNvlBufferPosixFd: CUDA driver not available");
+  }
+
   // Retain allocation handle and export as POSIX file descriptor
   CUmemGenericAllocationHandle allocHandle;
-  CU_CHECK(cuMemRetainAllocationHandle(&allocHandle, localPtr));
+  CU_CHECK(pfn_cuMemRetainAllocationHandle(&allocHandle, localPtr));
 
   int localFd = -1;
-  CU_CHECK(cuMemExportToShareableHandle(
+  CU_CHECK(pfn_cuMemExportToShareableHandle(
       &localFd, allocHandle, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0));
-  CU_CHECK(cuMemRelease(allocHandle));
+  CU_CHECK(pfn_cuMemRelease(allocHandle));
 
   // Get actual allocated size (may be larger due to granularity)
   CUdeviceptr basePtr;
   size_t allocatedSize = 0;
-  CU_CHECK(
-      cuMemGetAddressRange(&basePtr, &allocatedSize, (CUdeviceptr)localPtr));
+  CU_CHECK(pfn_cuMemGetAddressRange(
+      &basePtr, &allocatedSize, (CUdeviceptr)localPtr));
 
   // Exchange {pid, fd, allocatedSize} with NVL peers.
   // Peers will use pidfd_getfd to duplicate our fd into their fd table.
@@ -455,7 +475,7 @@ std::vector<void*> MultiPeerTransport::exchangeNvlBufferPosixFd(
   int cudaDev = 0;
   CUdevice cuDev;
   CUDA_CHECK(cudaGetDevice(&cudaDev));
-  CU_CHECK(cuDeviceGet(&cuDev, cudaDev));
+  CU_CHECK(pfn_cuDeviceGet(&cuDev, cudaDev));
 
   NvlExchangeRecord record;
   record.mode = NvlMemMode::kPosixFd;
@@ -492,7 +512,7 @@ std::vector<void*> MultiPeerTransport::exchangeNvlBufferPosixFd(
     size_t peerAllocatedSize = allData[rank].allocatedSize;
     record.cuMemPeerSizes[rank] = peerAllocatedSize;
 
-    CU_CHECK(cuMemImportFromShareableHandle(
+    CU_CHECK(pfn_cuMemImportFromShareableHandle(
         &record.cuMemPeerAllocHandles[rank],
         reinterpret_cast<void*>(static_cast<uintptr_t>(importedFd)),
         CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR));
@@ -501,17 +521,17 @@ std::vector<void*> MultiPeerTransport::exchangeNvlBufferPosixFd(
     close(importedFd);
 
     CUmemAllocationProp prop = {};
-    CU_CHECK(cuMemGetAllocationPropertiesFromHandle(
+    CU_CHECK(pfn_cuMemGetAllocationPropertiesFromHandle(
         &prop, record.cuMemPeerAllocHandles[rank]));
 
     size_t granularity = 0;
-    CU_CHECK(cuMemGetAllocationGranularity(
+    CU_CHECK(pfn_cuMemGetAllocationGranularity(
         &granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM));
 
-    CU_CHECK(cuMemAddressReserve(
+    CU_CHECK(pfn_cuMemAddressReserve(
         &record.cuMemPeerPtrs[rank], peerAllocatedSize, granularity, 0, 0));
 
-    CU_CHECK(cuMemMap(
+    CU_CHECK(pfn_cuMemMap(
         record.cuMemPeerPtrs[rank],
         peerAllocatedSize,
         0,
@@ -522,7 +542,7 @@ std::vector<void*> MultiPeerTransport::exchangeNvlBufferPosixFd(
     accessDesc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
     accessDesc.location.id = cuDev;
     accessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
-    CU_CHECK(cuMemSetAccess(
+    CU_CHECK(pfn_cuMemSetAccess(
         record.cuMemPeerPtrs[rank], peerAllocatedSize, &accessDesc, 1));
 
     mappedPtrs[rank] = reinterpret_cast<void*>(record.cuMemPeerPtrs[rank]);
@@ -577,18 +597,22 @@ void MultiPeerTransport::unmapNvlBuffers(const std::vector<void*>& mappedPtrs) {
 
   if (isCuMem) {
 #if CUDART_VERSION >= 12030
+    if (cuda_driver_lazy_init() != 0) {
+      return;
+    }
+
     auto& record = it->second;
     for (int rank = 0; rank < static_cast<int>(mappedPtrs.size()); ++rank) {
       if (rank == nvlLocalRank_) {
         continue;
       }
       if (record.cuMemPeerPtrs[rank] != 0) {
-        cuMemUnmap(record.cuMemPeerPtrs[rank], record.cuMemPeerSizes[rank]);
-        cuMemAddressFree(
+        pfn_cuMemUnmap(record.cuMemPeerPtrs[rank], record.cuMemPeerSizes[rank]);
+        pfn_cuMemAddressFree(
             record.cuMemPeerPtrs[rank], record.cuMemPeerSizes[rank]);
       }
       if (record.cuMemPeerAllocHandles[rank] != 0) {
-        cuMemRelease(record.cuMemPeerAllocHandles[rank]);
+        pfn_cuMemRelease(record.cuMemPeerAllocHandles[rank]);
       }
     }
     if (record.localExportedFd >= 0) {


### PR DESCRIPTION
Summary:

Remove libcuda.so.1 link-time dependency from libpipes.so and libdoca_gpunetio.so, harden the linker, and fix symbol visibility. Both libraries previously linked CUDA::cuda_driver, creating a hard DT_NEEDED on libcuda.so.1. This causes load-time failures on CPU-only machines (e.g., Sandcastle CI) where the GPU driver is absent.

Changes:

1. Lazy-load CUDA driver API (CudaDriverLazy.{h,cc}): Resolve all cu* symbols at runtime via cudaGetDriverEntryPoint() from cudart, populating typed pfn_cu* function pointers. This is the same mechanism ncclx uses in cudawrap.cc. Converted all call sites in GpuMemHandler.cc and MultiPeerTransport.cc (both Fabric and POSIX FD paths).
2. Enable doca's built-in lazy loading: Set DOCA_VERBS_USE_CUDA_WRAPPER to activate doca's dlopen wrapper for its 4 cu* calls, matching ncclx's common.mk build.
3. Version script for symbol visibility (version.script): Replace --exclude-libs,ALL + -Bsymbolic + -fvisibility=hidden with a linker version script that exports only *comms*pipes* and *cxa* symbols. This is more precise — it hides all transitive symbols (folly, glog, gflags) while ensuring __cxa_throw interposition works for folly's ExceptionTracerLib (matching libnccl.so pattern).
4. Add --no-undefined linker flag: Reject unresolved symbols at link time. Without this, missing dependencies are silently accepted by libpipes.so but cause failures when linked into downstream consumers like NCCL (which already uses --no-undefined).
5. Add -lboost_context: Explicitly link Boost.Context (jump_fcontext), a transitive dependency of folly's fiber implementation not included in folly's pkg-config output. Required by --no-undefined.
6. Add ldd verification in pipes_iter.sh to catch any DT_NEEDED on libcuda.so regressions.

Reviewed By: siyengar, snarayankh

Differential Revision: D95912998


