### PR TITLE
AllReduceRing restrict Staging Buffer size (#1064)

### DIFF
--- a/comms/ctran/algos/AllReduce/AllReduceRingAutoTune.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceRingAutoTune.cc
@@ -27,6 +27,13 @@ inline size_t getArchMaxBDP(GpuArch arch) {
   }
 }
 
+inline size_t getMaxBDP(GpuArch arch) {
+  if (NCCL_CTRAN_ALLREDUCE_RING_AUTO_TUNE_MAX_BDP > 0) {
+    return static_cast<size_t>(NCCL_CTRAN_ALLREDUCE_RING_AUTO_TUNE_MAX_BDP);
+  }
+  return getArchMaxBDP(arch);
+}
+
 // Round n to the nearest power of 2. Ties (exact midpoint) round up.
 // Returns 1 for n <= 1.
 size_t roundToNearestPow2(size_t n) {
@@ -45,10 +52,9 @@ size_t roundToNearestPow2(size_t n) {
 
 PipelineParams
 getAutoTunedPipeline(size_t messageBytes, int nRanks, GpuArch arch) {
-  size_t maxBDP = getArchMaxBDP(arch);
-  if (NCCL_CTRAN_ALLREDUCE_RING_AUTO_TUNE_MAX_BDP > 0) {
-    maxBDP = static_cast<size_t>(NCCL_CTRAN_ALLREDUCE_RING_AUTO_TUNE_MAX_BDP);
-  }
+  // TODO(T259485262): remove this legacy constant from best AutoTune v1 perf
+  const size_t maxBDP = getMaxBDP(arch);
+  const size_t stagingBufSize = getStagingBufSize();
 
   static constexpr size_t kMinChunkSize = 1;
   static constexpr size_t kMaxChunkSize = 16ULL * 1024 * 1024;
@@ -97,12 +103,18 @@ getAutoTunedPipeline(size_t messageBytes, int nRanks, GpuArch arch) {
   // Round nRanks up to nearest pow2 so that chunkSize (partitionMessageBytes /
   // numChunks) is always a power-of-2, guaranteeing typeSize alignment and
   // exact BDP fit. For pow2 ranks (the common case) this is a no-op.
-  size_t numChunks =
-      pipelineDepth * roundToNearestPow2(static_cast<size_t>(nRanks));
+  const size_t nShards = roundToNearestPow2(static_cast<size_t>(nRanks));
+  size_t numChunks = pipelineDepth * nShards;
   size_t chunkSize = partitionMessageBytes / numChunks;
   chunkSize = std::clamp(chunkSize, kMinChunkSize, kMaxChunkSize);
   numChunks =
       std::max((partitionMessageBytes + chunkSize - 1) / chunkSize, 1UL);
+
+  const size_t scaleDown =
+      (partitionMessageBytes + stagingBufSize - 1) / stagingBufSize;
+  if (partitionMessageBytes > stagingBufSize) {
+    numChunks = std::max(numChunks / scaleDown, size_t{1});
+  }
 
   return {chunkSize, numChunks};
 }

--- a/comms/ctran/algos/AllReduce/tests/AllReduceRingAutoTuneTest.cc
+++ b/comms/ctran/algos/AllReduce/tests/AllReduceRingAutoTuneTest.cc
@@ -9,6 +9,7 @@
 #include <gtest/gtest.h>
 
 #include "comms/ctran/algos/AllReduce/AllReduceRingAutoTune.h"
+#include "comms/ctran/algos/CtranAlgoConsts.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
 using ctran::allreduce::ring::getAutoTunedParams;
@@ -75,6 +76,18 @@ class BlockSizeOverride {
   ~BlockSizeOverride() {
     NCCL_CTRAN_ALLREDUCE_RING_THREAD_BLOCK_SIZE =
         NCCL_CTRAN_ALLREDUCE_RING_THREAD_BLOCK_SIZE_DEFAULTCVARVALUE;
+  }
+};
+
+// RAII guard for STAGING_BUF_SIZE CVAR.
+class StagingBufSizeOverride {
+ public:
+  explicit StagingBufSizeOverride(int64_t v) {
+    NCCL_CTRAN_ALLREDUCE_RING_STAGING_BUF_SIZE = v;
+  }
+  ~StagingBufSizeOverride() {
+    NCCL_CTRAN_ALLREDUCE_RING_STAGING_BUF_SIZE =
+        NCCL_CTRAN_ALLREDUCE_RING_STAGING_BUF_SIZE_DEFAULTCVARVALUE;
   }
 };
 
@@ -221,17 +234,17 @@ TEST(AutoTuneCombinedDefault, MaxBDP64M_8Ranks) {
       {      8 * MB, 8, 512,    256 * KB, 32},
       {     16 * MB, 8, 512,    512 * KB, 32},
       {     32 * MB, 8, 512,      1 * MB, 32},
-      {     64 * MB, 8, 512,      2 * MB, 32},
-      {    128 * MB, 8, 512,      4 * MB, 16},
-      {    256 * MB, 8, 512,      8 * MB, 8},
-      {    512 * MB, 8, 512,      8 * MB, 8},
-      {      1 * GB, 8, 512,      8 * MB, 8},
-      {      2 * GB, 8, 512,      8 * MB, 8},
-      {      4 * GB, 8, 512,      8 * MB, 8},
-      {      8 * GB, 8, 512,      8 * MB, 8},
-      {     16 * GB, 8, 512,      8 * MB, 8},
-      {     32 * GB, 8, 512,      8 * MB, 8},
-      {     64 * GB, 8, 512,      8 * MB, 8},
+      {     64 * MB, 8, 512,      2 * MB, 16},
+      {    128 * MB, 8, 512,      4 * MB, 8},
+      {    256 * MB, 8, 512,      8 * MB, 4},
+      {    512 * MB, 8, 512,      8 * MB, 4},
+      {      1 * GB, 8, 512,      8 * MB, 4},
+      {      2 * GB, 8, 512,      8 * MB, 4},
+      {      4 * GB, 8, 512,      8 * MB, 4},
+      {      8 * GB, 8, 512,      8 * MB, 4},
+      {     16 * GB, 8, 512,      8 * MB, 4},
+      {     32 * GB, 8, 512,      8 * MB, 4},
+      {     64 * GB, 8, 512,      8 * MB, 4},
   };
   // clang-format on
 
@@ -262,17 +275,17 @@ TEST(AutoTuneCombinedDefault, MaxBDP128M_8Ranks) {
       {      8 * MB, 8, 512,    256 * KB, 32},
       {     16 * MB, 8, 512,    512 * KB, 32},
       {     32 * MB, 8, 512,      1 * MB, 32},
-      {     64 * MB, 8, 512,      2 * MB, 32},
-      {    128 * MB, 8, 512,      8 * MB, 16},
-      {    256 * MB, 8, 512,     16 * MB, 8},
-      {    512 * MB, 8, 512,     16 * MB, 8},
-      {      1 * GB, 8, 512,     16 * MB, 8},
-      {      2 * GB, 8, 512,     16 * MB, 8},
-      {      4 * GB, 8, 512,     16 * MB, 8},
-      {      8 * GB, 8, 512,     16 * MB, 8},
-      {     16 * GB, 8, 512,     16 * MB, 8},
-      {     32 * GB, 8, 512,     16 * MB, 8},
-      {     64 * GB, 8, 512,     16 * MB, 8},
+      {     64 * MB, 8, 512,      2 * MB, 16},
+      {    128 * MB, 8, 512,      8 * MB, 4},
+      {    256 * MB, 8, 512,     16 * MB, 2},
+      {    512 * MB, 8, 512,     16 * MB, 2},
+      {      1 * GB, 8, 512,     16 * MB, 2},
+      {      2 * GB, 8, 512,     16 * MB, 2},
+      {      4 * GB, 8, 512,     16 * MB, 2},
+      {      8 * GB, 8, 512,     16 * MB, 2},
+      {     16 * GB, 8, 512,     16 * MB, 2},
+      {     32 * GB, 8, 512,     16 * MB, 2},
+      {     64 * GB, 8, 512,     16 * MB, 2},
   };
   // clang-format on
 
@@ -392,17 +405,17 @@ TEST(AutoTuneCombinedHopper, MaxBDP64M_8Ranks) {
       {      8 * MB, 2, 512,    256 * KB, 32},
       {     16 * MB, 4, 512,    512 * KB, 32},
       {     32 * MB, 4, 512,      2 * MB, 16},
-      {     64 * MB, 4, 512,      8 * MB, 8},
-      {    128 * MB, 4, 512,      8 * MB, 8},
-      {    256 * MB, 4, 512,      8 * MB, 8},
-      {    512 * MB, 4, 512,      8 * MB, 8},
-      {      1 * GB, 4, 512,      8 * MB, 8},
-      {      2 * GB, 4, 512,      8 * MB, 8},
-      {      4 * GB, 4, 512,      8 * MB, 8},
-      {      8 * GB, 4, 512,      8 * MB, 8},
-      {     16 * GB, 4, 512,      8 * MB, 8},
-      {     32 * GB, 4, 512,      8 * MB, 8},
-      {     64 * GB, 4, 512,      8 * MB, 8},
+      {     64 * MB, 4, 512,      8 * MB, 4},
+      {    128 * MB, 4, 512,      8 * MB, 4},
+      {    256 * MB, 4, 512,      8 * MB, 4},
+      {    512 * MB, 4, 512,      8 * MB, 4},
+      {      1 * GB, 4, 512,      8 * MB, 4},
+      {      2 * GB, 4, 512,      8 * MB, 4},
+      {      4 * GB, 4, 512,      8 * MB, 4},
+      {      8 * GB, 4, 512,      8 * MB, 4},
+      {     16 * GB, 4, 512,      8 * MB, 4},
+      {     32 * GB, 4, 512,      8 * MB, 4},
+      {     64 * GB, 4, 512,      8 * MB, 4},
   };
   // clang-format on
 
@@ -434,17 +447,17 @@ TEST(AutoTuneCombinedHopper, MaxBDP128M_8Ranks) {
       {      8 * MB, 2, 512,    256 * KB, 32},
       {     16 * MB, 4, 512,    512 * KB, 32},
       {     32 * MB, 4, 512,      2 * MB, 16},
-      {     64 * MB, 4, 512,      8 * MB, 8},
-      {    128 * MB, 4, 512,     16 * MB, 8},
-      {    256 * MB, 4, 512,     16 * MB, 8},
-      {    512 * MB, 4, 512,     16 * MB, 8},
-      {      1 * GB, 4, 512,     16 * MB, 8},
-      {      2 * GB, 4, 512,     16 * MB, 8},
-      {      4 * GB, 4, 512,     16 * MB, 8},
-      {      8 * GB, 4, 512,     16 * MB, 8},
-      {     16 * GB, 4, 512,     16 * MB, 8},
-      {     32 * GB, 4, 512,     16 * MB, 8},
-      {     64 * GB, 4, 512,     16 * MB, 8},
+      {     64 * MB, 4, 512,      8 * MB, 4},
+      {    128 * MB, 4, 512,     16 * MB, 2},
+      {    256 * MB, 4, 512,     16 * MB, 2},
+      {    512 * MB, 4, 512,     16 * MB, 2},
+      {      1 * GB, 4, 512,     16 * MB, 2},
+      {      2 * GB, 4, 512,     16 * MB, 2},
+      {      4 * GB, 4, 512,     16 * MB, 2},
+      {      8 * GB, 4, 512,     16 * MB, 2},
+      {     16 * GB, 4, 512,     16 * MB, 2},
+      {     32 * GB, 4, 512,     16 * MB, 2},
+      {     64 * GB, 4, 512,     16 * MB, 2},
   };
   // clang-format on
 
@@ -478,17 +491,17 @@ TEST(AutoTuneDefaultRankSweep, DefaultBDP_8Ranks) {
       {      8 * MB, 8, 512,    256 * KB, 32},
       {     16 * MB, 8, 512,    512 * KB, 32},
       {     32 * MB, 8, 512,      1 * MB, 32},
-      {     64 * MB, 8, 512,      2 * MB, 32},
-      {    128 * MB, 8, 512,      8 * MB, 16},
-      {    256 * MB, 8, 512,     16 * MB, 8},
-      {    512 * MB, 8, 512,     16 * MB, 8},
-      {      1 * GB, 8, 512,     16 * MB, 8},
-      {      2 * GB, 8, 512,     16 * MB, 8},
-      {      4 * GB, 8, 512,     16 * MB, 8},
-      {      8 * GB, 8, 512,     16 * MB, 8},
-      {     16 * GB, 8, 512,     16 * MB, 8},
-      {     32 * GB, 8, 512,     16 * MB, 8},
-      {     64 * GB, 8, 512,     16 * MB, 8},
+      {     64 * MB, 8, 512,      2 * MB, 16},
+      {    128 * MB, 8, 512,      8 * MB, 4},
+      {    256 * MB, 8, 512,     16 * MB, 2},
+      {    512 * MB, 8, 512,     16 * MB, 2},
+      {      1 * GB, 8, 512,     16 * MB, 2},
+      {      2 * GB, 8, 512,     16 * MB, 2},
+      {      4 * GB, 8, 512,     16 * MB, 2},
+      {      8 * GB, 8, 512,     16 * MB, 2},
+      {     16 * GB, 8, 512,     16 * MB, 2},
+      {     32 * GB, 8, 512,     16 * MB, 2},
+      {     64 * GB, 8, 512,     16 * MB, 2},
   };
   // clang-format on
 
@@ -518,17 +531,17 @@ TEST(AutoTuneDefaultRankSweep, DefaultBDP_16Ranks) {
       {      8 * MB, 8, 512,    256 * KB, 32},
       {     16 * MB, 8, 512,    256 * KB, 64},
       {     32 * MB, 8, 512,    512 * KB, 64},
-      {     64 * MB, 8, 512,      1 * MB, 64},
-      {    128 * MB, 8, 512,      2 * MB, 64},
-      {    256 * MB, 8, 512,      4 * MB, 32},
-      {    512 * MB, 8, 512,      8 * MB, 16},
-      {      1 * GB, 8, 512,      8 * MB, 16},
-      {      2 * GB, 8, 512,      8 * MB, 16},
-      {      4 * GB, 8, 512,      8 * MB, 16},
-      {      8 * GB, 8, 512,      8 * MB, 16},
-      {     16 * GB, 8, 512,      8 * MB, 16},
-      {     32 * GB, 8, 512,      8 * MB, 16},
-      {     64 * GB, 8, 512,      8 * MB, 16},
+      {     64 * MB, 8, 512,      1 * MB, 32},
+      {    128 * MB, 8, 512,      2 * MB, 16},
+      {    256 * MB, 8, 512,      4 * MB, 8},
+      {    512 * MB, 8, 512,      8 * MB, 4},
+      {      1 * GB, 8, 512,      8 * MB, 4},
+      {      2 * GB, 8, 512,      8 * MB, 4},
+      {      4 * GB, 8, 512,      8 * MB, 4},
+      {      8 * GB, 8, 512,      8 * MB, 4},
+      {     16 * GB, 8, 512,      8 * MB, 4},
+      {     32 * GB, 8, 512,      8 * MB, 4},
+      {     64 * GB, 8, 512,      8 * MB, 4},
   };
   // clang-format on
 
@@ -558,17 +571,17 @@ TEST(AutoTuneDefaultRankSweep, DefaultBDP_32Ranks) {
       {      8 * MB, 8, 512,    128 * KB, 64},
       {     16 * MB, 8, 512,    256 * KB, 64},
       {     32 * MB, 8, 512,    256 * KB, 128},
-      {     64 * MB, 8, 512,    512 * KB, 128},
-      {    128 * MB, 8, 512,      1 * MB, 128},
-      {    256 * MB, 8, 512,      1 * MB, 128},
-      {    512 * MB, 8, 512,      2 * MB, 64},
-      {      1 * GB, 8, 512,      4 * MB, 32},
-      {      2 * GB, 8, 512,      4 * MB, 32},
-      {      4 * GB, 8, 512,      4 * MB, 32},
-      {      8 * GB, 8, 512,      4 * MB, 32},
-      {     16 * GB, 8, 512,      4 * MB, 32},
-      {     32 * GB, 8, 512,      4 * MB, 32},
-      {     64 * GB, 8, 512,      4 * MB, 32},
+      {     64 * MB, 8, 512,    512 * KB, 64},
+      {    128 * MB, 8, 512,      1 * MB, 32},
+      {    256 * MB, 8, 512,      1 * MB, 32},
+      {    512 * MB, 8, 512,      2 * MB, 16},
+      {      1 * GB, 8, 512,      4 * MB, 8},
+      {      2 * GB, 8, 512,      4 * MB, 8},
+      {      4 * GB, 8, 512,      4 * MB, 8},
+      {      8 * GB, 8, 512,      4 * MB, 8},
+      {     16 * GB, 8, 512,      4 * MB, 8},
+      {     32 * GB, 8, 512,      4 * MB, 8},
+      {     64 * GB, 8, 512,      4 * MB, 8},
   };
   // clang-format on
 
@@ -598,17 +611,17 @@ TEST(AutoTuneDefaultRankSweep, DefaultBDP_64Ranks) {
       {      8 * MB, 8, 512,     64 * KB, 128},
       {     16 * MB, 8, 512,    128 * KB, 128},
       {     32 * MB, 8, 512,    256 * KB, 128},
-      {     64 * MB, 8, 512,    256 * KB, 256},
-      {    128 * MB, 8, 512,    512 * KB, 256},
-      {    256 * MB, 8, 512,    512 * KB, 256},
-      {    512 * MB, 8, 512,    512 * KB, 256},
-      {      1 * GB, 8, 512,      1 * MB, 128},
-      {      2 * GB, 8, 512,      2 * MB, 64},
-      {      4 * GB, 8, 512,      2 * MB, 64},
-      {      8 * GB, 8, 512,      2 * MB, 64},
-      {     16 * GB, 8, 512,      2 * MB, 64},
-      {     32 * GB, 8, 512,      2 * MB, 64},
-      {     64 * GB, 8, 512,      2 * MB, 64},
+      {     64 * MB, 8, 512,    256 * KB, 128},
+      {    128 * MB, 8, 512,    512 * KB, 64},
+      {    256 * MB, 8, 512,    512 * KB, 64},
+      {    512 * MB, 8, 512,    512 * KB, 64},
+      {      1 * GB, 8, 512,      1 * MB, 32},
+      {      2 * GB, 8, 512,      2 * MB, 16},
+      {      4 * GB, 8, 512,      2 * MB, 16},
+      {      8 * GB, 8, 512,      2 * MB, 16},
+      {     16 * GB, 8, 512,      2 * MB, 16},
+      {     32 * GB, 8, 512,      2 * MB, 16},
+      {     64 * GB, 8, 512,      2 * MB, 16},
   };
   // clang-format on
 
@@ -988,6 +1001,28 @@ TEST_F(AutoTuneCVAROverrideTest, AllFourOverrides) {
   EXPECT_EQ(at.block.blockSize, 256);
 }
 
+// STAGING_BUF_SIZE CVAR affects getStagingBufSize() but not pipeline params.
+TEST_F(AutoTuneCVAROverrideTest, StagingBufSizeOverride) {
+  using namespace ctran::allreduce::ring;
+
+  // Default: kStagingBufSize
+  EXPECT_EQ(getStagingBufSize(), kStagingBufSize);
+
+  // Explicit STAGING_BUF_SIZE CVAR
+  {
+    StagingBufSizeOverride sb(64 * MB);
+    EXPECT_EQ(getStagingBufSize(), 64 * MB);
+  }
+
+  // Chunk override takes priority over STAGING_BUF_SIZE
+  {
+    ChunkSizeOverride cs(static_cast<int>(2 * MB));
+    NumChunksOverride nc(4);
+    StagingBufSizeOverride sb(64 * MB);
+    EXPECT_EQ(getStagingBufSize(), 8 * MB);
+  }
+}
+
 // ============================================================================
 // AutoTuned Invariants
 // ============================================================================
@@ -1086,9 +1121,9 @@ std::vector<T> buildProbes(const std::vector<T>& basePoints) {
       // clang-format off
       probes.insert(p);          // exact p
       probes.insert(p + 1);      // just above p
-      probes.insert(mid - 1);     // just below midpoint
-      probes.insert(mid);         // exact midpoint
-      probes.insert(mid + 1);     // just above midpoint
+      probes.insert(mid - 1);    // just below midpoint
+      probes.insert(mid);        // exact midpoint
+      probes.insert(mid + 1);    // just above midpoint
       probes.insert(pNext - 1);  // just below pNext
       probes.insert(pNext);      // exact pNext
       // clang-format on
@@ -1256,6 +1291,7 @@ TEST_F(AutoTuneInvariantTest, CombinedInvariants) {
 
   for (auto maxBDP : maxBDPs) {
     MaxBDPOverride o(maxBDP);
+    size_t stagingBufSize = ctran::allreduce::ring::getStagingBufSize();
     for (auto nRanks : rankProbes) {
       if (nRanks < 2) {
         continue;
@@ -1267,6 +1303,16 @@ TEST_F(AutoTuneInvariantTest, CombinedInvariants) {
             msgBytes, nRanks, kMaxOccNumBlocks, kMaxOccBlockSize, maxBDP);
         checkChunkAlignment(
             msgBytes, nRanks, kMaxOccNumBlocks, kMaxOccBlockSize, maxBDP);
+
+        // Pipeline footprint must fit within the staging buffer.
+        auto at = getAutoTunedParams(
+            msgBytes, nRanks, kMaxOccNumBlocks, kMaxOccBlockSize, 1);
+        EXPECT_LE(at.pipeline.chunkSize * at.pipeline.numChunks, stagingBufSize)
+            << "Staging buf violated: msgBytes=" << msgBytes
+            << " ranks=" << nRanks << " maxBDP=" << maxBDP
+            << " stagingBufSize=" << stagingBufSize
+            << " chunkSize=" << at.pipeline.chunkSize
+            << " numChunks=" << at.pipeline.numChunks;
       }
     }
   }

--- a/comms/ctran/algos/CtranAlgo.cc
+++ b/comms/ctran/algos/CtranAlgo.cc
@@ -811,19 +811,9 @@ commResult_t CtranAlgo::initTmpBufs() {
       TmpbufType::RECVCOUNTS_TMPBUF,
       sizeof(size_t) * all2allvDynamicMaxSendcounts);
 
-  // Ring buffer must be large enough for the maximum BDP the auto-tune may
-  // produce at runtime. Priority: (1) explicit chunk_size * num_chunks CVARs,
-  // (2) AUTO_TUNE_MAX_BDP CVAR, (3) kMaxBDP fallback.
-  size_t ringBufSize = NCCL_CTRAN_ALLREDUCE_RING_AUTO_TUNE_MAX_BDP;
-  if (NCCL_CTRAN_ALLREDUCE_RING_TMPBUF_CHUNK_SIZE > 0 &&
-      NCCL_CTRAN_ALLREDUCE_RING_TMPBUF_NUM_CHUNKS > 0) {
-    ringBufSize =
-        static_cast<size_t>(NCCL_CTRAN_ALLREDUCE_RING_TMPBUF_CHUNK_SIZE) *
-        NCCL_CTRAN_ALLREDUCE_RING_TMPBUF_NUM_CHUNKS;
-  }
-  if (ringBufSize <= 0) {
-    ringBufSize = ctran::allreduce::ring::kMaxBDP;
-  }
+  // Ring buffer sizing: delegates to deriveBufSize() which applies
+  // CVAR priority (chunk override > STAGING_BUF_SIZE > kStagingBufSize).
+  size_t ringBufSize = ctran::allreduce::ring::getStagingBufSize();
   segmentManager.insert(TmpbufType::RING_TMP_SEND_BUF, ringBufSize);
   segmentManager.insert(TmpbufType::RING_TMP_RECV_BUF, ringBufSize);
 

--- a/comms/ctran/algos/CtranAlgoConsts.h
+++ b/comms/ctran/algos/CtranAlgoConsts.h
@@ -4,6 +4,8 @@
 
 #include <cstddef>
 
+#include "comms/utils/cvars/nccl_cvars.h"
+
 namespace ctran::allreduce::ring {
 
 // Maximum BDP (bandwidth-delay product) per GPU architecture.
@@ -25,5 +27,32 @@ constexpr size_t kMaxBDP = kDefaultMaxBDP;
 
 static_assert(kMaxBDP >= kDefaultMaxBDP);
 static_assert(kMaxBDP >= kHopperMaxBDP);
+
+// --- Staging Buffer Size helpers ---
+
+constexpr size_t kStagingBufSize = 32ULL * 1024 * 1024;
+
+// Returns the chunk override product (or 0 if CVARs not set).
+inline size_t getStagingBufSizeFromChunkOverride() {
+  if (NCCL_CTRAN_ALLREDUCE_RING_TMPBUF_CHUNK_SIZE > 0 &&
+      NCCL_CTRAN_ALLREDUCE_RING_TMPBUF_NUM_CHUNKS > 0) {
+    return static_cast<size_t>(NCCL_CTRAN_ALLREDUCE_RING_TMPBUF_CHUNK_SIZE) *
+        NCCL_CTRAN_ALLREDUCE_RING_TMPBUF_NUM_CHUNKS;
+  }
+  return 0;
+}
+
+// Derives the physical staging buffer size (for allocation).
+// Priority: (1) chunk override, (2) STAGING_BUF_SIZE CVAR, (3) kStagingBufSize.
+inline size_t getStagingBufSize() {
+  size_t result = getStagingBufSizeFromChunkOverride();
+  if (result > 0) {
+    return result;
+  }
+  if (NCCL_CTRAN_ALLREDUCE_RING_STAGING_BUF_SIZE > 0) {
+    return static_cast<size_t>(NCCL_CTRAN_ALLREDUCE_RING_STAGING_BUF_SIZE);
+  }
+  return kStagingBufSize;
+}
 
 } // namespace ctran::allreduce::ring

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2865,6 +2865,13 @@ cvars:
      with per-message-size optimal values. Set to 0 to use static CVAR
      values instead.
 
+ - name        : NCCL_CTRAN_ALLREDUCE_RING_STAGING_BUF_SIZE
+   type        : int64_t
+   default     : 0
+   description : |-
+     Size of the staging (tmp send/recv) buffer per direction in bytes.
+     When set to 0 (default), uses the built-in kStagingBufSize constant (32MB).
+
  - name        : NCCL_CTRAN_ALLREDUCE_RING_BIDIR_AG_MAX_SIZE
    type        : int64_t
    default     : -2


### PR DESCRIPTION
Summary:

Add separate Ctran AllReduce Ring Staging Buffer Size control independent from the BDP pipeline budget. `NCCL_CTRAN_ALLREDUCE_RING_STAGING_BUF_SIZE` CVAR as an override.

When the partition message size exceeds the staging buffer, numChunks is
scaled down so the pipeline footprint fits within the allocated buffer.
This prevents out-of-bounds access when maxBDP > stagingBufSize.

Refactor buffer sizing into helper functions in CtranAlgoConsts.h:
  - getStagingBufSize(): derives buffer size (chunk override > STAGING_BUF_SIZE CVAR > kStagingBufSize)
  - getStagingBufSizeFromChunkOverride(): shared helper for chunk CVAR product
  - getMaxBDP(): local helper wrapping arch default + MAX_BDP CVAR

Differential Revision: D96305529
