### PR TITLE
Fix build_ncclx.sh for v2.29 compatibility (#1065)

### DIFF
--- a/build_ncclx.sh
+++ b/build_ncclx.sh
@@ -377,6 +377,29 @@ if [ "$CLEAN_BUILD" == 1 ]; then
 fi
 
 mkdir -p "$BUILDDIR"
+
+# Pre-generate nccl_git_version.h before the make build starts.
+# The Makefile has a rule for this, but it fails with re-cc/distcc because
+# the generated header is not available on the remote compilation machine.
+GIT_VERSION_DIR="$BUILDDIR/obj/include"
+mkdir -p "$GIT_VERSION_DIR"
+if [ -f "${NCCL_HOME}/src/misc/generate_git_version.py" ]; then
+  python3 "${NCCL_HOME}/src/misc/generate_git_version.py" "$GIT_VERSION_DIR/nccl_git_version.h"
+else
+  cat > "$GIT_VERSION_DIR/nccl_git_version.h" <<HEADER
+/* Auto-generated fallback. */
+#ifndef NCCL_GIT_VERSION_H
+#define NCCL_GIT_VERSION_H
+#ifndef NCCL_GIT_BRANCH
+#define NCCL_GIT_BRANCH "unknown"
+#endif
+#ifndef NCCL_GIT_COMMIT_HASH
+#define NCCL_GIT_COMMIT_HASH "${DEV_SIGNATURE:-unknown}"
+#endif
+#endif /* NCCL_GIT_VERSION_H */
+HEADER
+fi
+
 pushd "${NCCL_HOME}"
 
 function build_nccl {
@@ -419,23 +442,27 @@ fi
 
 # sanity check
 if [ -n "${NCCL_RUN_SANITY_CHECK}" ]; then
-    pushd examples
-    export NCCL_DEBUG=WARN
-    export LD_LIBRARY_PATH=$BUILDDIR/lib
+    if [ -f examples/Makefile ]; then
+        pushd examples
+        export NCCL_DEBUG=WARN
+        export LD_LIBRARY_PATH=$BUILDDIR/lib
 
-    make all \
-      NVCC_GENCODE="$NVCC_GENCODE" \
-      CUDA_HOME="$CUDA_HOME" \
-      NCCL_HOME="$CONDA_PREFIX"
+        make all \
+          NVCC_GENCODE="$NVCC_GENCODE" \
+          CUDA_HOME="$CUDA_HOME" \
+          NCCL_HOME="$CONDA_PREFIX"
 
-    set +e
+        set +e
 
-    TIMEOUT=10s
-    timeout $TIMEOUT "$BUILDDIR"/examples/HelloWorld
-    if [ "$?" == "124" ]; then
-        echo "Program TIMEOUT in ${TIMEOUT}. Terminate."
+        TIMEOUT=10s
+        timeout $TIMEOUT "$BUILDDIR"/examples/HelloWorld
+        if [ "$?" == "124" ]; then
+            echo "Program TIMEOUT in ${TIMEOUT}. Terminate."
+        fi
+        popd
+    else
+        echo "Skipping sanity check: examples/Makefile not found"
     fi
-    popd
 fi
 
 popd

--- a/comms/ncclx/v2_29/src/Makefile
+++ b/comms/ncclx/v2_29/src/Makefile
@@ -27,7 +27,7 @@ INCEXPORTS  := nccl.h nccl_device.h CtranEx.h CtranExComm.h \
 
 
 LIBSRCFILES := \
- 	$(filter-out ${SRCDIR}/enhcompat.cc,$(wildcard ${SRCDIR}/*.cc)) \
+ 	$(filter-out ${SRCDIR}/enhcompat.cc ${SRCDIR}/init_nvtx.cc,$(wildcard ${SRCDIR}/*.cc)) \
 	$(wildcard ${SRCDIR}/graph/*.cc) \
 	$(wildcard ${SRCDIR}/misc/*.cc) \
 	$(wildcard ${SRCDIR}/transport/*.cc) \


### PR DESCRIPTION
Summary:

Two build fixes for the NCCLX v2.29 upgrade:

1. **Pre-generate** `nccl_git_version.h` before *make* starts. The Makefile includes a rule to generate this header, but it fails under `re-cc`/`distcc` because the generated file isn’t available on the remote compilation host. If the generator script isn’t present, it should fall back to a static header.
2. **Exclude `init_nvtx.cc` from the NCCLX source build,** similar to the existing exclusion for `enhcompat.cc` - avoiding double linking init_nvtx.cc
3. **Guard the sanity check** so it skips cleanly when `examples/Makefile` is missing, since the `examples` directory isn’t included in the OSS build.

Reviewed By: max7255

Differential Revision: D95566666


