### PR TITLE
Fix channelReadyPtr doorbell mechanism

### DIFF
--- a/comms/ncclx/v2_27/meta/transport/transportProxy.cc
+++ b/comms/ncclx/v2_27/meta/transport/transportProxy.cc
@@ -3,6 +3,7 @@
 // TODO: Migrate to comms/ctran/utils/Alloc.h once we implement
 // "ncclCuMemHostAlloc" equivalent
 #include "alloc.h"
+#include "gdrwrap.h"
 
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/utils/Utils.h"
@@ -63,8 +64,8 @@ commResult_t tranportProxyShutdown(struct ncclComm* comm) {
 TransportProxy::TransportProxy(struct ncclComm* comm) : parentComm_(comm) {
   NCCLCHECKIGNORE(
       ncclCuMemHostAlloc((void**)&syncPoolPtr_, nullptr, kDefaultSyncPoolSize));
-  size_t nFlags = kDefaultSyncPoolSize / sizeof(uint64_t);
-  for (int elemOffset = 0; elemOffset < nFlags; elemOffset++) {
+  size_t nFlags = kDefaultSyncPoolSize / (sizeof(uint64_t) * MAXCHANNELS);
+  for (int elemOffset = 0; elemOffset < nFlags; elemOffset += MAXCHANNELS) {
     syncFlagPool_.push_back(syncPoolPtr_ + elemOffset);
   }
   if (getTransportProxyMode() != NCCL_USE_TRANSPORT_PROXY::none) {
@@ -132,22 +133,20 @@ inline bool TransportProxy::canSkipPrepBufs(ncclComm* comm, uint64_t opCount) {
   return false;
 }
 
-commResult_t TransportProxy::getNextChannelsReadyPtr(
-    uint64_t** channelsReadyPtr) {
+commResult_t TransportProxy::getNextChannelDoorBell(uint64_t** ptrToDoorBell) {
   std::unique_lock<std::mutex> lock(mutex_);
   if (syncFlagPool_.empty()) {
     FB_ERRORTHROW(
         commInternalError, "No available sync flag in transport worker thread");
   }
-  auto ptr = syncFlagPool_.front();
+  uint64_t* ptr = syncFlagPool_.front();
   syncFlagPool_.pop_front();
-
-  *channelsReadyPtr = ptr;
+  *ptrToDoorBell = ptr;
 
   CLOGF_SUBSYS(
       INFO,
       COLL,
-      "Transport proxy thread: get next sync flag pointer {:x}",
+      "Transport proxy thread: get next sync flag pointer {:#x}",
       (uintptr_t)ptr);
 
   return commSuccess;
@@ -157,7 +156,7 @@ commResult_t TransportProxy::enqueuePrepRequest(
     ncclComm* comm,
     uint64_t channelMask,
     std::shared_ptr<void> peerReconnInfoMap,
-    uint64_t* channelsReadyPtr) {
+    uint64_t* channelsDoorBell) {
   std::unique_lock<std::mutex> lock(mutex_);
 
   auto opCount = incrOpCount(comm->commHash);
@@ -168,7 +167,7 @@ commResult_t TransportProxy::enqueuePrepRequest(
       channelMask,
       opCount,
       peerReconnInfoMap,
-      channelsReadyPtr,
+      channelsDoorBell,
       (canSkipPrepBufs(comm, opCount)) ? commSuccess : commInProgress);
 
   reqQueue_.push_back(req);
@@ -178,13 +177,14 @@ commResult_t TransportProxy::enqueuePrepRequest(
       INFO,
       COLL,
       "{}: Enqueued request to prepare resources for current kernel plan: "
-      "opCount={} (comm->opCount={}),channelMask={:x}, channelsReadyPtr={}({:#x})",
+      "opCount={} (comm->opCount={}),channelMask={:x}, channelsReady={}({:#x})",
       comm->config.commDesc,
       opCount,
       comm->opCount,
       channelMask,
-      *channelsReadyPtr,
-      (uintptr_t)channelsReadyPtr);
+      countReadyChannels(
+          reinterpret_cast<volatile uint64_t*>(channelsDoorBell)),
+      (uintptr_t)channelsDoorBell);
 
   return commSuccess;
 }
@@ -252,8 +252,10 @@ void TransportProxy::testAny() {
   // Once collective kernel complete the work and reset the flag, release the
   // buffers and move the flag back to the pool to reuse.
   for (const auto& req : activeOps_) {
-    auto ptr = req->channelsReadyPtr;
-    if (*ptr == 0) {
+    std::atomic_thread_fence(std::memory_order_seq_cst);
+    uint64_t* doorbell = req->channelsDoorBell;
+    if (countReadyChannels(reinterpret_cast<volatile uint64_t*>(doorbell)) ==
+        0) {
       FB_COMMCHECKTHROW(req->comm->memCache->release(req->bufKeys));
       CLOGF_SUBSYS(
           INFO,
@@ -261,13 +263,13 @@ void TransportProxy::testAny() {
           "Releasing {} bufKeys for comm {}",
           req->bufKeys.size(),
           ctran::utils::parseCommDesc(req->comm->config.commDesc));
-      syncFlagPool_.push_back(ptr);
+      syncFlagPool_.push_back(doorbell);
       req->state = commSuccess;
       CLOGF_SUBSYS(
           INFO,
           COLL,
           "Garbage collect sync flag pointer {:x}, {} collectives in progress",
-          (uintptr_t)ptr,
+          (uintptr_t)doorbell,
           activeOps_.size());
     }
   }
@@ -313,8 +315,6 @@ void TransportProxy::prepResources(std::shared_ptr<TransportRequest> req) {
   }
   // Update the mask to signal the NCCL kernel that transport resources are
   // ready to start collectives
-  *req->channelsReadyPtr = req->channelMask;
-
   CLOGF_SUBSYS(
       INFO,
       COLL,
@@ -322,10 +322,12 @@ void TransportProxy::prepResources(std::shared_ptr<TransportRequest> req) {
       req->comm->config.commDesc,
       req->opCount,
       req->channelMask,
-      *req->channelsReadyPtr,
-      (uintptr_t)req->channelsReadyPtr);
+      *req->channelsDoorBell,
+      (uintptr_t)req->channelsDoorBell);
   {
     std::lock_guard<std::mutex> lock(mutex_);
+    markReadyChannels(req->channelsDoorBell, req->channelMask);
+    wc_store_fence();
     // reset the state to indicate in-progress of collective kernel
     req->state = commInProgress;
     activeOps_.push_back(req);

--- a/comms/ncclx/v2_27/meta/transport/transportProxy.h
+++ b/comms/ncclx/v2_27/meta/transport/transportProxy.h
@@ -18,7 +18,7 @@
 
 namespace ncclx::transport {
 
-constexpr size_t kDefaultSyncPoolSize = 1 << 21; // 2MiB
+constexpr size_t kDefaultSyncPoolSize = 1 << 27; // 128MiB
 
 enum class TransportRequestType : int {
   UNSET = 0,
@@ -35,7 +35,8 @@ struct TransportRequest {
   uint64_t opCount{0};
   std::shared_ptr<void> peerReconnInfoMap{nullptr};
   std::vector<std::string> bufKeys;
-  uint64_t* channelsReadyPtr{nullptr};
+  uint64_t* channelsDoorBell; // Length MAXCHANNELS int array, each int used to
+                              // indicate whether a channel is ready to run
   commResult_t state{commInProgress};
   // Following fields are only used for p2p/coll preconnect
   std::array<bool, NCCL_NUM_ALGORITHMS> algoNeedConnect{false};
@@ -49,14 +50,14 @@ struct TransportRequest {
       uint64_t channelMask,
       uint64_t opCount,
       std::shared_ptr<void> peerReconnInfoMap,
-      uint64_t* channelsReadyPtr,
+      uint64_t* channelsDoorBell,
       commResult_t initState)
       : type(type),
         comm(comm),
         channelMask(channelMask),
         opCount(opCount),
         peerReconnInfoMap(std::move(peerReconnInfoMap)),
-        channelsReadyPtr(channelsReadyPtr),
+        channelsDoorBell(channelsDoorBell),
         state(initState) {}
 
   // For PRECONNECT_P2P request
@@ -83,21 +84,21 @@ class TransportProxy {
   TransportProxy(ncclComm* comm);
   ~TransportProxy();
 
-  // Get the next available sync flag to synchronize with NCCL kernels
-  commResult_t getNextChannelsReadyPtr(uint64_t** channelsReadyPtr);
+  // Get the next available sync flags to synchronize with NCCL kernels
+  commResult_t getNextChannelDoorBell(uint64_t** ptrToDoorBell);
   // Enqueue a request to the transport proxy for preparing transport resources,
   // if needed, for the current kernel plan.
   //  @param[IN] comm: communicator, the ncclComm struct
   //  @param[IN] channelMask: the bit mask of channels to prepare resources for
   //  @param[IN] peerReconnInfoMap: the map of peer ranks to their transport
   //  connection state
-  //  @param[IN] channelsReadyPtr: pointer to the channels ready flag to
+  //  @param[IN] ptrToDoorBell: pointer to the channels ready flag to
   //  synchronize
   commResult_t enqueuePrepRequest(
       ncclComm* comm,
       uint64_t channelMask,
       std::shared_ptr<void> peerReconnInfoMap,
-      uint64_t* channelsReadyPtr);
+      uint64_t* channelsDoorBell);
   // Enqueue a request to the transport proxy for pre-connecting to p2p peers
   //  @param[IN] comm: communicator, the ncclComm struct
   commResult_t enqueueP2pPreconnect(ncclComm* comm);
@@ -127,6 +128,26 @@ class TransportProxy {
       opCountMap_[commHash] = 0;
     }
     return folly::get_default(opCountMap_, commHash);
+  }
+
+  inline int countReadyChannels(volatile uint64_t* channelsDoorBell) {
+    int count = 0;
+    for (int i = 0; i < MAXCHANNELS; i++) {
+      if (channelsDoorBell[i] == 1) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  inline void markReadyChannels(
+      volatile uint64_t* channelsDoorBell,
+      uint64_t channelMask) {
+    while (channelMask) {
+      unsigned pos = std::countr_zero(channelMask); // index of lowest set bit
+      channelsDoorBell[pos] = 1;
+      channelMask &= (channelMask - 1); // clear that bit
+    }
   }
 
   // request queue for worker thread to process

--- a/comms/ncclx/v2_27/src/device/common.h
+++ b/comms/ncclx/v2_27/src/device/common.h
@@ -345,7 +345,14 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
   // do better when we know all threads are querying the same bitmask.
   if (tid < MAXCHANNELS && (args->channelMask & (1ull<<tid))) {
     int n = __popcll(args->channelMask & ((1ull<<tid)-1));
-    if (blockIdx.x == n) ncclShmem.channelId = tid;
+    if (blockIdx.x == n) {
+      ncclShmem.channelId = tid;
+      if (args->comm->buffsShared) {
+        while (!(ld_acquire_sys_global(args->channelsDoorBell + tid))) {
+          __nanosleep(10);
+        }
+      }
+    }
   }
   __syncthreads(); // publish ncclShmem.{args, channelId}
   /* set abort flag to 0 */
@@ -381,19 +388,6 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
     } break;
   }
   __syncthreads(); // publish ncclShmem
-  
-  // wait CPU transport proxy thread signals that resources are ready
-  if (ncclShmem.comm.buffsShared) {
-    if (tid == 0) {
-      volatile uint64_t* flag = ncclShmem.args.channelsReadyPtr;
-      auto channelBit = (1ull << ncclShmem.channelId);
-      while (!(*flag & channelBit)) {
-        __nanosleep(10);
-      }
-    }
-    __syncthreads();
-  }
-
   while (ncclShmem.aborted == 0) {
     profiler(START);
     if (0 <= SpecializedFnId && ncclShmem.funcId == (unsigned)SpecializedFnId) {
@@ -413,10 +407,9 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
   if (ncclShmem.comm.buffsShared) {
     __syncthreads();
     if (tid == 0) {
-      auto channelBit = (1ull << ncclShmem.channelId);
-      // Each block associates with a different channel, use an amotic op to flip the corresponding bit,
+      // Each block associates with a different channel, to flip the corresponding flag,
       // so CPU thread can reuse the flag once all blocks/channels consume the flag.
-      atomicXor_system((unsigned long long*)(ncclShmem.args.channelsReadyPtr), channelBit);
+      st_release_sys_global(ncclShmem.args.channelsDoorBell + ncclShmem.channelId, 0);
     }
   }
   profiler(FINI);

--- a/comms/ncclx/v2_27/src/device/prims_simple.h
+++ b/comms/ncclx/v2_27/src/device/prims_simple.h
@@ -675,7 +675,7 @@ private:
         struct ncclPatPeer* peer = ((struct ncclPatPeer*)recvPeers)+tid;
         struct ncclConnInfo* conn = peer->conn = ncclShmem.channel.peers[recvPeer]->recv+connIndexRecv;
         peer->step = conn->step;
-        peer->buff = conn->buffs[NCCL_PROTO_SIMPLE];
+        peer->buff = (void*)conn->buffs[NCCL_PROTO_SIMPLE];
         peer->stepCache = loadStepValue(peer->tailPtr = conn->tail);
         peer->headPtr = conn->head;
         peer->accSize = 0;
@@ -686,7 +686,7 @@ private:
         conn = peer->conn = ncclShmem.channel.peers[sendPeer]->send+connIndexSend;
         peer->step = conn->step;
         peer->connFifo = conn->connFifo;
-        peer->buff = conn->buffs[NCCL_PROTO_SIMPLE];
+        peer->buff = (void*)conn->buffs[NCCL_PROTO_SIMPLE];
         peer->stepCache = loadStepValue(peer->headPtr = conn->head);
         peer->tailPtr = conn->tail;
         peer->accSize = 0;

--- a/comms/ncclx/v2_27/src/enqueue.cc
+++ b/comms/ncclx/v2_27/src/enqueue.cc
@@ -195,8 +195,8 @@ static void finishPlan(struct ncclComm* comm, struct ncclKernelPlan* plan) {
           comm,
           plan->channelMask,
           std::move(plan->peerReconnInfoMap),
-          plan->channelsReadyPtr)));
-    plan->kernelArgs->channelsReadyPtr = plan->channelsReadyPtr;
+          plan->channelsDoorBell)));
+    plan->kernelArgs->channelsDoorBell = plan->channelsDoorBell;
   }
 
   // Put batches into the kernel arguments. The first batch for each channel
@@ -1451,8 +1451,8 @@ ncclResult_t ncclLaunchPrepare(struct ncclComm* comm) {
         plan->bufKeys.reserve(nChannels * nPeers * 2);
         NCCLCHECKIGNORE(
           metaCommToNccl(
-            comm->transportProxy_->getNextChannelsReadyPtr(
-              &plan->channelsReadyPtr)));
+            comm->transportProxy_->getNextChannelDoorBell(
+              &plan->channelsDoorBell)));
       }
 
       if (planner->isSymColl) {

--- a/comms/ncclx/v2_27/src/include/comm.h
+++ b/comms/ncclx/v2_27/src/include/comm.h
@@ -298,7 +298,8 @@ struct ncclKernelPlan {
   // buffer keys used in plan, used to reserve and release buffers
   std::vector<std::string> bufKeys;
   // pointer to be used to synchronize with the kernel for the current plan
-  uint64_t* channelsReadyPtr{nullptr};
+  // fixed size region of MAXCHANNELS ints
+  uint64_t* channelsDoorBell{nullptr};
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/comms/ncclx/v2_27/src/include/device.h
+++ b/comms/ncclx/v2_27/src/include/device.h
@@ -128,7 +128,7 @@ static_assert(NCCL_LL_CLEAN_MASK % NCCL_STEPS == 0, "Invalid NCCL_LL_CLEAN_MASK 
 
 struct ncclConnInfo {
   // Regular comm mechanism
-  char *buffs[NCCL_NUM_PROTOCOLS]; // Local for recv, remote for send
+  volatile char *buffs[NCCL_NUM_PROTOCOLS]; // Local for recv, remote for send
   void* mhandles[NCCL_NUM_PROTOCOLS];
   uint64_t *tail;     // Local for recv, remote for send
   uint64_t *head;     // Local for send, remote for recv
@@ -460,7 +460,7 @@ struct alignas(16) ncclDevKernelArgs {
   // A channel's first batch is at `blockIdx.x`. Use `nextJump` to follow rest of list.
   // struct ncclDevWorkBatch batches[];
   // Pointer to the flag indicating if resources are ready for this kernel
-  volatile uint64_t *channelsReadyPtr;
+  uint64_t* channelsDoorBell;
 };
 
 __host__ __device__ constexpr int ncclMaxKernelArgsSize(/*int cudaDriver, */int cudaArch=NCCL_CUDA_ARCH) {

--- a/comms/ncclx/v2_27/src/transport/shm.cc
+++ b/comms/ncclx/v2_27/src/transport/shm.cc
@@ -179,7 +179,7 @@ static ncclResult_t shmSendConnect(struct ncclComm* comm, struct ncclConnect* co
     send->conn.connFifo = resources->devRemHostMem->connFifo;
   }
   if (useMemcpySend) {
-    struct shmProxyInfo proxyInfo = { NULL, NULL, send->conn.buffs[NCCL_PROTO_SIMPLE], resources->hostMem, resources->remHostMem };
+    struct shmProxyInfo proxyInfo = { NULL, NULL, (char*)send->conn.buffs[NCCL_PROTO_SIMPLE], resources->hostMem, resources->remHostMem };
     NCCLCHECK(ncclProxyCallBlocking(comm, &send->proxyConn, ncclProxyMsgConnect, &proxyInfo, sizeof(struct shmProxyInfo), &proxyInfo, sizeof(struct shmProxyInfo)));
     send->conn.buffs[NCCL_PROTO_SIMPLE] = proxyInfo.devFifo;
     send->conn.tail = &proxyInfo.ceRecvMem->tail;
@@ -210,7 +210,7 @@ static ncclResult_t shmRecvConnect(struct ncclComm* comm, struct ncclConnect* co
   recv->conn.stepSize = comm->buffSizes[NCCL_PROTO_SIMPLE]/NCCL_STEPS;
 
   if (useMemcpyRecv) {
-    struct shmProxyInfo proxyInfo = { NULL, NULL, recv->conn.buffs[NCCL_PROTO_SIMPLE], resources->remHostMem, resources->hostMem };
+    struct shmProxyInfo proxyInfo = { NULL, NULL, (char*)recv->conn.buffs[NCCL_PROTO_SIMPLE], resources->remHostMem, resources->hostMem };
     NCCLCHECK(ncclProxyCallBlocking(comm, &recv->proxyConn, ncclProxyMsgConnect, &proxyInfo, sizeof(struct shmProxyInfo), &proxyInfo, sizeof(struct shmProxyInfo)));
     recv->conn.buffs[NCCL_PROTO_SIMPLE] = proxyInfo.devFifo;
     recv->conn.tail = &proxyInfo.ceRecvMem->tail;


### PR DESCRIPTION
Summary:
Fixed a few bugs in existing memCache logic:

1: On host side, acquire/release fence need to be added when updating pinned host memory ptr;
2: On Device side:
Inside common.h:
a) acquire fence need to be added when reading the channelReadyPtr
b) the kernel spinning call needs to be moved to before when channel metadata has been updated (which includes the updated buffer location)
c) Nvidia reported in meetings atomicXor_system() call may have bugs on H100 systems. Switching to Ctran style per block integer as flag for now. 

Inside device.h:
Changed protocol buffer pointer inside ncclConnInfo to be volatile. (Had to cast two other places manually to convince compiler, this is only used for RING/TREE cases for now)

Differential Revision: D82744108


