### PR TITLE
Fix DeviceWindow buffer registration: decouple local and remote registries (#1069)

### DIFF
--- a/comms/pipes/tests/HostWindowTest.cc
+++ b/comms/pipes/tests/HostWindowTest.cc
@@ -110,6 +110,155 @@ TEST_F(HostWindowTestFixture, WithBarriersAndCounters) {
 // header that requires CUDA compilation. Its success and error paths are
 // validated by the DeviceWindow unit tests and integration tests.
 
+// =============================================================================
+// registerLocalBuffer Tests
+// =============================================================================
+
+TEST_F(HostWindowTestFixture, RegisterLocalBufferBeforeExchange) {
+  auto transport = createTransport();
+  WindowConfig config{.peerSignalCount = 1};
+  HostWindow window(*transport, config);
+
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, 1024));
+
+  EXPECT_EQ(window.registerLocalBuffer(buf, 1024), 0);
+
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+TEST_F(HostWindowTestFixture, RegisterLocalBufferAfterExchange) {
+  auto transport = createTransport();
+  WindowConfig config{.peerSignalCount = 1};
+  HostWindow window(*transport, config);
+  window.exchange();
+
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, 4096));
+
+  int regIdx = window.registerLocalBuffer(buf, 4096);
+  EXPECT_EQ(regIdx, 0);
+
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+TEST_F(HostWindowTestFixture, RegisterMultipleLocalBuffers) {
+  auto transport = createTransport();
+  WindowConfig config{.peerSignalCount = 1};
+  HostWindow window(*transport, config);
+  window.exchange();
+
+  void* buf0 = nullptr;
+  void* buf1 = nullptr;
+  void* buf2 = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf0, 1024));
+  CUDACHECK_TEST(cudaMalloc(&buf1, 2048));
+  CUDACHECK_TEST(cudaMalloc(&buf2, 4096));
+
+  EXPECT_EQ(window.registerLocalBuffer(buf0, 1024), 0);
+  EXPECT_EQ(window.registerLocalBuffer(buf1, 2048), 1);
+  EXPECT_EQ(window.registerLocalBuffer(buf2, 4096), 2);
+
+  CUDACHECK_TEST(cudaFree(buf0));
+  CUDACHECK_TEST(cudaFree(buf1));
+  CUDACHECK_TEST(cudaFree(buf2));
+}
+
+// =============================================================================
+// registerAndExchangeBuffer Tests
+// =============================================================================
+
+TEST_F(HostWindowTestFixture, RegisterAndExchangeBufferBeforeExchange) {
+  auto transport = createTransport();
+  WindowConfig config{.peerSignalCount = 1};
+  HostWindow window(*transport, config);
+
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, 1024));
+
+  EXPECT_EQ(window.registerAndExchangeBuffer(buf, 1024), 0);
+
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+TEST_F(HostWindowTestFixture, RegisterAndExchangeBufferAfterExchange) {
+  auto transport = createTransport();
+  WindowConfig config{.peerSignalCount = 1};
+  HostWindow window(*transport, config);
+  window.exchange();
+
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, 4096));
+
+  int regIdx = window.registerAndExchangeBuffer(buf, 4096);
+  EXPECT_EQ(regIdx, 0);
+
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+TEST_F(HostWindowTestFixture, RegisterAndExchangeBufferCalledTwiceThrows) {
+  auto transport = createTransport();
+  WindowConfig config{.peerSignalCount = 1};
+  HostWindow window(*transport, config);
+  window.exchange();
+
+  void* buf0 = nullptr;
+  void* buf1 = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf0, 1024));
+  CUDACHECK_TEST(cudaMalloc(&buf1, 1024));
+
+  window.registerAndExchangeBuffer(buf0, 1024);
+  EXPECT_THROW(
+      window.registerAndExchangeBuffer(buf1, 1024), std::runtime_error);
+
+  CUDACHECK_TEST(cudaFree(buf0));
+  CUDACHECK_TEST(cudaFree(buf1));
+}
+
+// =============================================================================
+// Mixed registration Tests
+// =============================================================================
+
+TEST_F(HostWindowTestFixture, LocalThenExchangeBufferIndicesAreSequential) {
+  auto transport = createTransport();
+  WindowConfig config{.peerSignalCount = 1};
+  HostWindow window(*transport, config);
+  window.exchange();
+
+  void* localBuf = nullptr;
+  void* dstBuf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&localBuf, 1024));
+  CUDACHECK_TEST(cudaMalloc(&dstBuf, 2048));
+
+  EXPECT_EQ(window.registerLocalBuffer(localBuf, 1024), 0);
+  EXPECT_EQ(window.registerAndExchangeBuffer(dstBuf, 2048), 1);
+
+  CUDACHECK_TEST(cudaFree(localBuf));
+  CUDACHECK_TEST(cudaFree(dstBuf));
+}
+
+TEST_F(HostWindowTestFixture, ExchangeThenLocalBufferIndicesAreSequential) {
+  auto transport = createTransport();
+  WindowConfig config{.peerSignalCount = 1};
+  HostWindow window(*transport, config);
+  window.exchange();
+
+  void* dstBuf = nullptr;
+  void* localBuf0 = nullptr;
+  void* localBuf1 = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&dstBuf, 2048));
+  CUDACHECK_TEST(cudaMalloc(&localBuf0, 1024));
+  CUDACHECK_TEST(cudaMalloc(&localBuf1, 4096));
+
+  EXPECT_EQ(window.registerAndExchangeBuffer(dstBuf, 2048), 0);
+  EXPECT_EQ(window.registerLocalBuffer(localBuf0, 1024), 1);
+  EXPECT_EQ(window.registerLocalBuffer(localBuf1, 4096), 2);
+
+  CUDACHECK_TEST(cudaFree(dstBuf));
+  CUDACHECK_TEST(cudaFree(localBuf0));
+  CUDACHECK_TEST(cudaFree(localBuf1));
+}
+
 } // namespace comms::pipes::tests
 
 int main(int argc, char** argv) {

--- a/comms/pipes/window/DeviceWindow.cuh
+++ b/comms/pipes/window/DeviceWindow.cuh
@@ -216,7 +216,8 @@ struct RemoteBufferRegistration {
  *   transport.exchange();
  *   HostWindow window(transport, windowConfig);
  *   window.exchange();
- *   window.registerBuffer(myBuf, bufSize);  // collective, for put/put_signal
+ *   window.registerLocalBuffer(srcBuf, srcSize);   // local-only, for put src
+ *   window.registerAndExchangeBuffer(dstBuf, dstSize);  // collective, dst
  *   DeviceWindow dw = window.getDeviceWindow();
  *
  *   // Kernel
@@ -229,7 +230,9 @@ struct RemoteBufferRegistration {
  *
  * DATA TRANSFER APIS:
  * - put/put_signal: Generic one-sided write, dispatches to NVL or IBGDA
- *   internally. Buffers must be registered via HostWindow::registerBuffer().
+ *   internally. Source buffers must be registered via
+ *   HostWindow::registerLocalBuffer() or registerAndExchangeBuffer().
+ *   Destination buffers must be exchanged via registerAndExchangeBuffer().
  * - send/recv are NOT on DeviceWindow — use get_handle().get_nvl(rank)
  *   directly for two-sided operations.
  *
@@ -917,8 +920,10 @@ class DeviceWindow {
    * MultiPeerNvlTransportConfig.dataBufferSize. The staging buffer is
    * only used by P2pNvlTransportDevice::send()/recv().
    *
-   * PRECONDITION: Both localSrc and remoteDst must be within buffers
-   * previously registered via HostWindow::registerBuffer().
+   * PRECONDITION: localSrc must be within a buffer registered via
+   * HostWindow::registerLocalBuffer() or registerAndExchangeBuffer().
+   * remoteDst must be within a buffer exchanged via
+   * HostWindow::registerAndExchangeBuffer() on the target peer.
    *
    * @param target_rank  Rank to put to (must not be self).
    * @param group        ThreadGroup for group coordination.
@@ -965,8 +970,10 @@ class DeviceWindow {
    * - IBGDA: RDMA Write + NIC-fenced atomic signal (HW-ordered),
    *   single signal from global leader to match NVL semantics.
    *
-   * PRECONDITION: Both localSrc and remoteDst must be within buffers
-   * previously registered via HostWindow::registerBuffer().
+   * PRECONDITION: localSrc must be within a buffer registered via
+   * HostWindow::registerLocalBuffer() or registerAndExchangeBuffer().
+   * remoteDst must be within a buffer exchanged via
+   * HostWindow::registerAndExchangeBuffer() on the target peer.
    *
    * @param target_rank  Rank to put to (must not be self).
    * @param group        ThreadGroup for group coordination.
@@ -1084,16 +1091,16 @@ class DeviceWindow {
 
   /**
    * Lookup remote rkey for a destination pointer on a specific IBGDA peer.
-   * Linear scan over registered buffers.
-   * Traps if pointer is not in any registered buffer for that peer.
+   * There is exactly one exchanged dst buffer per DeviceWindow, so this
+   * is a direct peer-index lookup (no iteration).
+   * Traps if pointer is not within the exchanged buffer for that peer.
    */
   __device__ __forceinline__ NetworkRKey
   lookupRemoteRkey(int ibgdaPeerIdx, const void* remotePtr) const {
-    const auto* p = static_cast<const char*>(remotePtr);
-    int nRegs = static_cast<int>(localBufferRegistry_.size());
-    for (int i = 0; i < nRegs; ++i) {
-      const auto& reg = remoteBufferRegistry_[i * nIbgdaPeers_ + ibgdaPeerIdx];
+    if (remoteBufferRegistry_.size() > 0) {
+      const auto& reg = remoteBufferRegistry_[ibgdaPeerIdx];
       const auto* base = static_cast<const char*>(reg.base);
+      const auto* p = static_cast<const char*>(remotePtr);
       if (p >= base && p < base + reg.size) {
         return reg.rkey;
       }
@@ -1149,10 +1156,11 @@ class DeviceWindow {
   uint64_t barrierExpected_{0};
 
   // --- Buffer registration table (for generic put/put_signal) ---
-  // Local: lkey lookup for source buffers
+  // Local: lkey lookup for source buffers (registered via
+  // registerLocalBuffer or registerAndExchangeBuffer)
   DeviceSpan<LocalBufferRegistration> localBufferRegistry_;
-  // Remote: rkey lookup for destination buffers
-  // Flattened: [regIdx * nIbgdaPeers + ibgdaPeerIdx]
+  // Remote: rkey lookup for the single exchanged dst buffer.
+  // Indexed directly by ibgdaPeerIdx (one entry per IBGDA peer).
   DeviceSpan<RemoteBufferRegistration> remoteBufferRegistry_;
 
   // HostWindow constructs DeviceWindow directly

--- a/comms/pipes/window/HostWindow.cc
+++ b/comms/pipes/window/HostWindow.cc
@@ -40,6 +40,7 @@ HostWindow::HostWindow(
       ibgdaPeerRanks_(transport.ibgda_peer_ranks()),
       nvlLocalRank_(transport.nvl_local_rank()),
       nvlNRanks_(transport.nvl_n_ranks()),
+      userBuffer_(userBuffer),
       userBufferSize_(userBufferSize) {
   int nNvlPeers = static_cast<int>(nvlPeerRanks_.size());
   int nIbgdaPeers = static_cast<int>(ibgdaPeerRanks_.size());
@@ -129,23 +130,6 @@ HostWindow::HostWindow(
     auto size = nIbgdaPeers * config_.peerCounterCount * sizeof(uint64_t);
     ibgdaPeerCounterLocalBuf_ = allocateIbgdaBuffer(size);
   }
-
-  // ==========================================================================
-  // User data buffer (optional)
-  // ==========================================================================
-  if (userBuffer && userBufferSize > 0) {
-    // Store the user buffer pointer; lkey set during exchange().
-    userLocalBuf_ = IbgdaLocalBuffer(userBuffer, NetworkLKey{});
-
-    if (nIbgdaPeers > 0) {
-      userRemoteBufsDevice_ = std::make_unique<meta::comms::DeviceBuffer>(
-          nIbgdaPeers * sizeof(IbgdaRemoteBuffer));
-    }
-    if (nNvlPeers > 0) {
-      userNvlPeerPtrsDevice_ = std::make_unique<meta::comms::DeviceBuffer>(
-          nNvlPeers * sizeof(void*));
-    }
-  }
 }
 
 HostWindow::~HostWindow() {
@@ -171,26 +155,14 @@ HostWindow::~HostWindow() {
     cudaFree(ibgdaPeerCounterLocalBuf_.ptr);
   }
 
-  // User buffer: deregister IBGDA (if registered) but do NOT cudaFree —
-  // the user owns the buffer.
-  if (userLocalBuf_.ptr && userLocalBuf_.lkey != NetworkLKey{}) {
-    transport_.localDeregisterIbgdaBuffer(userLocalBuf_.ptr);
-  }
-  // Unmap NVL user buffer mappings
-  if (!userNvlMappedPtrs_.empty()) {
-    transport_.unmapNvlBuffers(userNvlMappedPtrs_);
-  }
-
   // Clean up registered buffers
   for (const auto& reg : localRegistrations_) {
     if (reg.lkey != NetworkLKey{}) {
       transport_.localDeregisterIbgdaBuffer(const_cast<void*>(reg.base));
     }
   }
-  for (auto& mappedPtrs : registeredNvlMappedPtrs_) {
-    if (!mappedPtrs.empty()) {
-      transport_.unmapNvlBuffers(mappedPtrs);
-    }
+  if (!exchangedNvlMappedPtrs_.empty()) {
+    transport_.unmapNvlBuffers(exchangedNvlMappedPtrs_);
   }
 
   // NVL signal/barrier buffers are freed by GpuMemHandler destructors (RAII)
@@ -313,53 +285,35 @@ void HostWindow::exchange() {
         ibgdaPeerCounterLocalBuf_.ptr, size);
   }
 
-  // ==========================================================================
-  // User buffer exchange (IBGDA + NVL)
-  // ==========================================================================
-  if (userLocalBuf_.ptr) {
-    // IBGDA side: register + exchange
-    if (nIbgdaPeers > 0) {
-      userLocalBuf_ = transport_.localRegisterIbgdaBuffer(
-          userLocalBuf_.ptr, userBufferSize_);
-      auto remoteBufs = transport_.exchangeIbgdaBuffer(userLocalBuf_);
-
-      CUDA_CHECK(cudaMemcpy(
-          userRemoteBufsDevice_->get(),
-          remoteBufs.data(),
-          nIbgdaPeers * sizeof(IbgdaRemoteBuffer),
-          cudaMemcpyDefault));
-    }
-
-    // NVL side: IPC exchange
-    if (nNvlPeers > 0) {
-      userNvlMappedPtrs_ =
-          transport_.exchangeNvlBuffer(userLocalBuf_.ptr, userBufferSize_);
-
-      std::vector<void*> peerPtrs(nNvlPeers);
-      for (int nvlLocalPeer = 0; nvlLocalPeer < nvlNRanks_; ++nvlLocalPeer) {
-        if (nvlLocalPeer == nvlLocalRank_) {
-          continue;
-        }
-        int peerIdx =
-            (nvlLocalPeer < nvlLocalRank_) ? nvlLocalPeer : (nvlLocalPeer - 1);
-        peerPtrs[peerIdx] = userNvlMappedPtrs_[nvlLocalPeer];
-      }
-
-      CUDA_CHECK(cudaMemcpy(
-          userNvlPeerPtrsDevice_->get(),
-          peerPtrs.data(),
-          nNvlPeers * sizeof(void*),
-          cudaMemcpyDefault));
-    }
+  if (userBuffer_ && userBufferSize_ > 0) {
+    registerAndExchangeBuffer(userBuffer_, userBufferSize_);
   }
 
   exchanged_ = true;
 }
 
-int HostWindow::registerBuffer(void* ptr, std::size_t size) {
-  if (!exchanged_) {
+int HostWindow::registerLocalBuffer(void* ptr, std::size_t size) {
+  int regIdx = static_cast<int>(localRegistrations_.size());
+  int nIbgdaPeers = static_cast<int>(ibgdaPeerRanks_.size());
+
+  LocalBufferRegistration localReg{ptr, size, NetworkLKey{}};
+
+  if (nIbgdaPeers > 0) {
+    auto ibgdaBuf = transport_.localRegisterIbgdaBuffer(ptr, size);
+    localReg.lkey = ibgdaBuf.lkey;
+  }
+
+  localRegistrations_.push_back(localReg);
+  uploadRegistrationsToDevice();
+
+  return regIdx;
+}
+
+int HostWindow::registerAndExchangeBuffer(void* ptr, std::size_t size) {
+  if (!remoteRegistrations_.empty()) {
     throw std::runtime_error(
-        "HostWindow::registerBuffer() called before exchange()");
+        "HostWindow::registerAndExchangeBuffer() called more than once. "
+        "Each DeviceWindow supports exactly one exchanged dst buffer.");
   }
 
   int regIdx = static_cast<int>(localRegistrations_.size());
@@ -383,8 +337,7 @@ int HostWindow::registerBuffer(void* ptr, std::size_t size) {
 
   // NVL side: IPC exchange
   if (nNvlPeers > 0) {
-    auto mappedPtrs = transport_.exchangeNvlBuffer(ptr, size);
-    registeredNvlMappedPtrs_.push_back(std::move(mappedPtrs));
+    exchangedNvlMappedPtrs_ = transport_.exchangeNvlBuffer(ptr, size);
   }
 
   localRegistrations_.push_back(localReg);
@@ -494,7 +447,7 @@ DeviceWindow HostWindow::getDeviceWindow() const {
     new (&dw.remoteBufferRegistry_) DeviceSpan<RemoteBufferRegistration>(
         static_cast<RemoteBufferRegistration*>(
             remoteRegistrationsDevice_->get()),
-        static_cast<int>(remoteRegistrations_.size()));
+        nIbgdaPeers);
   }
 
   return dw;

--- a/comms/pipes/window/HostWindow.h
+++ b/comms/pipes/window/HostWindow.h
@@ -79,10 +79,9 @@ class HostWindow {
    * Extracts topology, rank info, and transport handles from the
    * MultiPeerTransport instance. The transport must outlive this object.
    *
-   * If a user buffer is provided, HostWindow registers and exchanges it on
-   * both NVL (IPC) and IBGDA (RDMA) sides. After exchange(), use
-   * getUserLocalBuffer(), getUserRemoteBuffers(), getUserNvlPeerPtrs()
-   * to access the registered buffer info for kernels.
+   * If a user buffer is provided, HostWindow auto-registers and exchanges it
+   * via registerAndExchangeBuffer() during exchange(). The buffer is then
+   * accessible through the DeviceWindow's buffer registration table.
    *
    * @param transport MultiPeerTransport providing topology and buffer APIs
    * @param config Window memory configuration
@@ -117,55 +116,50 @@ class HostWindow {
    * uses MultiPeerDeviceHandle for transport dispatch and pre-computed
    * peer index maps for O(1) rank-to-peer-index lookup.
    *
-   * Must be called after exchange() and after all registerBuffer() calls.
+   * Must be called after exchange() and after all registerLocalBuffer()
+   * and registerAndExchangeBuffer() calls.
    */
   DeviceWindow getDeviceWindow() const;
 
   // --- Buffer registration for generic put/put_signal ---
 
   /**
-   * Register a user buffer for use in DeviceWindow::put/put_signal.
+   * Register a local buffer for use as a source in
+   * DeviceWindow::put/put_signal.
+   *
+   * NOT collective: only registers locally for IBGDA (gets lkey).
+   * Does not exchange with peers. Use for source-only buffers.
+   *
+   * May be called before or after exchange(). Call getDeviceWindow() after
+   * exchange() and all registration calls to get a DeviceWindow with the
+   * registration table.
+   *
+   * @param ptr   Local GPU buffer pointer
+   * @param size  Buffer size in bytes
+   * @return      Local buffer registration index
+   */
+  int registerLocalBuffer(void* ptr, std::size_t size);
+
+  /**
+   * Register and exchange a buffer for use as a destination in
+   * DeviceWindow::put/put_signal.
    *
    * COLLECTIVE: all ranks must call together, each with their local buffer.
    * Registers locally for IBGDA (gets lkey) and exchanges with all IBGDA
    * peers (gets rkeys). For NVL peers, exchanges IPC/fabric handles.
    *
-   * Must be called after exchange(). Call getDeviceWindow() after all
-   * registerBuffer() calls to get a DeviceWindow with the registration table.
+   * Each DeviceWindow supports exactly one exchanged dst buffer. Calling
+   * this more than once is an error.
+   *
+   * May be called before or after exchange(). Call getDeviceWindow() after
+   * exchange() and all registration calls to get a DeviceWindow with the
+   * registration table.
    *
    * @param ptr   Local GPU buffer pointer
    * @param size  Buffer size in bytes
-   * @return      Buffer registration index
+   * @return      Local buffer registration index
    */
-  int registerBuffer(void* ptr, std::size_t size);
-
-  // --- User buffer accessors (valid after exchange()) ---
-
-  /**
-   * @return IBGDA-registered local buffer descriptor (lkey for RDMA).
-   *         Only valid if a user buffer was provided.
-   */
-  const IbgdaLocalBuffer& getUserLocalBuffer() const {
-    return userLocalBuf_;
-  }
-
-  /**
-   * @return Device-accessible span of IBGDA remote buffer descriptors
-   *         (one per IBGDA peer, for RDMA writes to their buffers).
-   *         Only valid if a user buffer was provided and after exchange().
-   */
-  void* getUserRemoteBuffersDevice() const {
-    return userRemoteBufsDevice_ ? userRemoteBufsDevice_->get() : nullptr;
-  }
-
-  /**
-   * @return Device-accessible span of NVL peer pointers
-   *         (IPC-mapped, for direct NVLink access to peer buffers).
-   *         Only valid if a user buffer was provided and after exchange().
-   */
-  void* getUserNvlPeerPtrsDevice() const {
-    return userNvlPeerPtrsDevice_ ? userNvlPeerPtrsDevice_->get() : nullptr;
-  }
+  int registerAndExchangeBuffer(void* ptr, std::size_t size);
 
   int rank() const {
     return myRank_;
@@ -229,19 +223,19 @@ class HostWindow {
   // --- Per-peer counters (IBGDA-only, local — no exchange) ---
   IbgdaLocalBuffer ibgdaPeerCounterLocalBuf_;
 
-  // --- User data buffer (optional) ---
+  // --- User data buffer (optional, auto-registered via
+  //     registerAndExchangeBuffer) ---
+  void* userBuffer_{nullptr};
   std::size_t userBufferSize_{0};
-  IbgdaLocalBuffer userLocalBuf_;
-  std::unique_ptr<meta::comms::DeviceBuffer> userRemoteBufsDevice_;
-  std::vector<void*> userNvlMappedPtrs_;
-  std::unique_ptr<meta::comms::DeviceBuffer> userNvlPeerPtrsDevice_;
 
   // --- Buffer registration table (for generic put/put_signal) ---
   std::vector<LocalBufferRegistration> localRegistrations_;
-  // Flattened: [regIdx * nIbgdaPeers + ibgdaPeerIdx]
+  // Remote registrations for the single exchanged dst buffer (one per IBGDA
+  // peer)
   std::vector<RemoteBufferRegistration> remoteRegistrations_;
-  // Per-registration NVL mapped pointers (per-rank, includes self as nullptr)
-  std::vector<std::vector<void*>> registeredNvlMappedPtrs_;
+  // NVL mapped pointers for the exchanged dst buffer (per-rank, includes self
+  // as nullptr)
+  std::vector<void*> exchangedNvlMappedPtrs_;
   std::unique_ptr<meta::comms::DeviceBuffer> localRegistrationsDevice_;
   std::unique_ptr<meta::comms::DeviceBuffer> remoteRegistrationsDevice_;
 


### PR DESCRIPTION
Summary:

[pipes] Fix DeviceWindow buffer registration: decouple local and remote registries

Fix bug in DeviceWindow where lookupRemoteRkey used localBufferRegistry_.size()
to iterate over remoteBufferRegistry_, incorrectly coupling local source buffers
with the remote destination buffer registry.

Split HostWindow::registerBuffer() into two distinct APIs:
- registerLocalBuffer(): local-only IBGDA registration (lkey), not collective.
  For source-only buffers used in put/put_signal.
- registerAndExchangeBuffer(): collective register + exchange (lkey + rkeys).
  For the single destination buffer per DeviceWindow.

Simplify lookupRemoteRkey to a direct peer-index lookup (no loop) since there
is exactly one exchanged dst buffer per DeviceWindow. Add guard for empty
remoteBufferRegistry_ to preserve diagnostic trap on misuse.

Differential Revision: D96376210


