### PR TITLE
nightly ld errors (#1061)

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -57,10 +57,10 @@ jobs:
             gpu-arch-type: "cuda"
             gpu-arch-version: "12.8"
             torch-version: "stable"
-          # - runs-on: "linux.g5.12xlarge.nvidia.gpu"
-          #   gpu-arch-type: "cuda"
-          #   gpu-arch-version: "12.8"
-          #   torch-version: "nightly"
+          - runs-on: "linux.g5.12xlarge.nvidia.gpu"
+            gpu-arch-type: "cuda"
+            gpu-arch-version: "12.8"
+            torch-version: "nightly"
 
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     permissions:

--- a/comms/torchcomms/tests/unit/cpp/CMakeLists.txt
+++ b/comms/torchcomms/tests/unit/cpp/CMakeLists.txt
@@ -44,9 +44,11 @@ target_include_directories(TorchCommOptionsTest PRIVATE
 target_compile_features(TorchCommOptionsTest PRIVATE cxx_std_20)
 target_link_libraries(TorchCommOptionsTest PRIVATE
     torchcomms
-    ${TORCH_LIBRARIES}
     GTest::gtest_main
     GTest::gmock
+)
+target_link_options(TorchCommOptionsTest PRIVATE
+    "LINKER:--allow-shlib-undefined"
 )
 
 # TorchCommFactoryTest - factory and backend tests
@@ -63,6 +65,9 @@ target_link_libraries(TorchCommFactoryTest PRIVATE
     ${TORCH_LIBRARIES}
     GTest::gtest_main
     GTest::gmock
+)
+target_link_options(TorchCommFactoryTest PRIVATE
+    "LINKER:--allow-shlib-undefined"
 )
 
 # Add dependency so dummy backend is built before factory test runs


### PR DESCRIPTION
Summary:



pytorch nightly ci was seeing:

```
[618/630] Linking CXX executable comms/torchcomms/tests/unit/cpp/TorchCommOptionsTest
FAILED: comms/torchcomms/tests/unit/cpp/TorchCommOptionsTest comms/torchcomms/tests/unit/cpp/TorchCommOptionsTest[1]_tests.cmake /meta-pytorch/torchcomms/build_tests/comms/torchcomms/tests/unit/cpp/TorchCommOptionsTest[1]_tests.cmake
: && /opt/rh/gcc-toolset-13/root/usr/bin/c++   comms/torchcomms/tests/unit/cpp/CMakeFiles/TorchCommOptionsTest.dir/TorchCommOptionsTest.cpp.o -o comms/torchcomms/tests/unit/cpp/TorchCommOptionsTest -L/lib/intel64   -L/lib/intel64_win   -L/lib/win-x64 -Wl,-rpath,/lib/intel64:/lib/intel64_win:/lib/win-x64:/meta-pytorch/torchcomms/build_tests/comms/torchcomms:/opt/conda/envs/venv/lib/python3.12/site-packages/torch/lib:/usr/local/cuda-12.8/lib64  comms/torchcomms/libtorchcomms.so  /opt/conda/envs/venv/lib/python3.12/site-packages/torch/lib/libtorch.so  /opt/conda/envs/venv/lib/python3.12/site-packages/torch/lib/libc10.so  /usr/local/cuda-12.8/lib64/libnvrtc.so  /opt/conda/envs/venv/lib/python3.12/site-packages/torch/lib/libc10_cuda.so  lib/libgtest_main.a  lib/libgmock.a  -Wl,--no-as-needed,"/opt/conda/envs/venv/lib/python3.12/site-packages/torch/lib/libtorch_cpu.so" -Wl,--as-needed  -Wl,--no-as-needed,"/opt/conda/envs/venv/lib/python3.12/site-packages/torch/lib/libtorch_cuda.so" -Wl,--as-needed  /opt/conda/envs/venv/lib/python3.12/site-packages/torch/lib/libc10_cuda.so  /opt/conda/envs/venv/lib/python3.12/site-packages/torch/lib/libc10.so  /usr/local/cuda-12.8/lib64/libcudart.so  -Wl,--no-as-needed,"/opt/conda/envs/venv/lib/python3.12/site-packages/torch/lib/libtorch.so" -Wl,--as-needed  lib/libgtest.a  -lpthread && cd /meta-pytorch/torchcomms/build_tests/comms/torchcomms/tests/unit/cpp && /usr/bin/cmake -D TEST_TARGET=TorchCommOptionsTest -D TEST_EXECUTABLE=/meta-pytorch/torchcomms/build_tests/comms/torchcomms/tests/unit/cpp/TorchCommOptionsTest -D TEST_EXECUTOR= -D TEST_WORKING_DIR=/meta-pytorch/torchcomms/build_tests/comms/torchcomms/tests/unit/cpp -D TEST_EXTRA_ARGS= -D TEST_PROPERTIES= -D TEST_PREFIX= -D TEST_SUFFIX= -D TEST_FILTER= -D NO_PRETTY_TYPES=FALSE -D NO_PRETTY_VALUES=FALSE -D TEST_LIST=TorchCommOptionsTest_TESTS -D CTEST_FILE=/meta-pytorch/torchcomms/build_tests/comms/torchcomms/tests/unit/cpp/TorchCommOptionsTest[1]_tests.cmake -D TEST_DISCOVERY_TIMEOUT=5 -D TEST_XML_OUTPUT_DIR= -P /usr/share/cmake/Modules/GoogleTestAddTests.cmake
/opt/rh/gcc-toolset-13/root/usr/libexec/gcc/x86_64-redhat-linux/13/ld: /opt/conda/envs/venv/lib/python3.12/site-packages/torch/lib/libtorch_cuda.so: undefined reference to `ncclGetLsaMultimemDevicePointer'
/opt/rh/gcc-toolset-13/root/usr/libexec/gcc/x86_64-redhat-linux/13/ld: /opt/conda/envs/venv/lib/python3.12/site-packages/torch/lib/libtorch_cuda.so: undefined reference to `ncclWaitSignal'
/opt/rh/gcc-toolset-13/root/usr/libexec/gcc/x86_64-redhat-linux/13/ld: /opt/conda/envs/venv/lib/python3.12/site-packages/torch/lib/libtorch_cuda.so: undefined reference to `ncclGetPeerDevicePointer'
/opt/rh/gcc-toolset-13/root/usr/libexec/gcc/x86_64-redhat-linux/13/ld: /opt/conda/envs/venv/lib/python3.12/site-packages/torch/lib/libtorch_cuda.so: undefined reference to `ncclPutSignal'
/opt/rh/gcc-toolset-13/root/usr/libexec/gcc/x86_64-redhat-linux/13/ld: /opt/conda/envs/venv/lib/python3.12/site-packages/torch/lib/libtorch_cuda.so: undefined reference to `ncclSignal'
collect2: error: ld returned 1 exit status
```

our tests don't need these symbols directly, so we can just use --allow-shlib-undefined to ignore them.

```
make -B build_tests -G Ninja -DBUILD_TESTS=ON -DCMAKE_PREFIX_PATH=$(python -c "import torch; print(torch.utils.cmake_prefix_path)") && cmake --build build_tests && cd build_tests && ctest --output-on-failure
```

```
    Start 1: TorchCommOptionsTest.EnvToValueImplBool
1/3 Test #1: TorchCommOptionsTest.EnvToValueImplBool ...   Passed    0.63 sec
    Start 2: TorchCommOptionsTest.StringToBool
2/3 Test #2: TorchCommOptionsTest.StringToBool .........   Passed    0.73 sec
    Start 3: TorchCommFactoryTest
3/3 Test #3: TorchCommFactoryTest ......................   Passed    0.67 sec

100% tests passed, 0 tests failed out of 3
```

imported-using-ghimport

Test Plan: Imported from OSS

Reviewed By: tanquer

Differential Revision: D96374026

Pulled By: dolpm


