### PR TITLE
Gate min traffic per channel count for 2.29 (#1071)

### DIFF
--- a/comms/ncclx/v2_29/src/enqueue.cc
+++ b/comms/ncclx/v2_29/src/enqueue.cc
@@ -609,7 +609,7 @@ static ncclResult_t scheduleCollTasksToPlan(
   int nChannels[2*2] = {0, 0, 0, 0}; // [collnet][nvls]
   int const nMaxChannels[2*2] = {comm->nChannels, comm->nvlsChannels, // [collnet][nvls]
                                  comm->nChannels, std::min(comm->nChannels, comm->nvlsChannels)};
-  constexpr size_t MinTrafficPerChannel = 32 << 10; // 32K traffic as minimal
+  size_t MinTrafficPerChannel = NCCL_TOPO_BOND_V228 ? (32 << 10) : (16 << 10);
   do {
     size_t workBytes = 0;
     struct ncclTaskColl* task = ncclIntruQueueHead(&planner->collTaskQueue);
@@ -642,7 +642,9 @@ static ncclResult_t scheduleCollTasksToPlan(
 
     int kind = 2*task->isCollnet + task->isNvls;
     if (kind != kindPrev) {
-      trafficPerChannel = divUp(trafficBytes[kind] / nChannels[kind], 16) * 16;
+      trafficPerChannel = NCCL_TOPO_BOND_V228
+        ? divUp(trafficBytes[kind] / nChannels[kind], 16) * 16
+        : std::max<size_t>(MinTrafficPerChannel, trafficBytes[kind]/nChannels[kind]);
       kindPrev = kind;
       channelId = 0;
       currentTraffic = 0;


### PR DESCRIPTION
Summary:



NCCLX 2.29 changed two aspects of the collective channel count calculation in enqueue.cc:
  1. MinTrafficPerChannel was increased 
  2. trafficPerChannel formula changed
 This diff gates both changes on NCCL_TOPO_BOND_V228:
  - NCCL_TOPO_BOND_V228=true: uses v2.29 behavior
  - NCCL_TOPO_BOND_V228=false: uses v2.27/v2.28 behavior

Reviewed By: tanquer, max7255

Differential Revision: D96369919


