### PR TITLE
Disable NCCL PXN by default in cvar.yaml (#1074)

### DIFF
--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -546,7 +546,7 @@ cvars:
 
  - name        : NCCL_PXN_DISABLE
    type        : int64_t
-   default     : 0
+   default     : 1
    description : https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html#nccl-pxn-disable
 
  - name        : NCCL_NCHANNELS_PER_NET_PEER


### PR DESCRIPTION
Summary:

Reasons:
1. NCCL PXN is always disabled by default in prod workloads;
2. Also the analysis in https://www.internalfb.com/code/fbsource/[D96316525-V1]/fbcode/nccl_v29_deadlock_summary.md shows enabling PXN in NCCL 2.29 will cause hang in PP SendRecv.

Reviewed By: minsii

Differential Revision: D96424600
