### PR TITLE
Move future->markCompleted to TorchWork, so we can have platform specific overrides

### DIFF
--- a/comms/torchcomms/BackendWrapper.cpp
+++ b/comms/torchcomms/BackendWrapper.cpp
@@ -68,11 +68,10 @@ WorkWrapper::WorkWrapper(
     std::vector<at::Tensor> outputTensors)
     : work_(std::move(work)), outputTensors_(std::move(outputTensors)) {
   std::vector<c10::Device> devices;
-  // MTIA, CPU needs to wait for the TorchWork to complete before marking Future
+  // CPU needs to wait for the TorchWork to complete before marking Future
   // as completed
   for (const auto& tensor : outputTensors_) {
-    if (tensor.device().type() != c10::DeviceType::CPU &&
-        tensor.device().type() != c10::DeviceType::MTIA) {
+    if (tensor.device().type() != c10::DeviceType::CPU) {
       devices.push_back(tensor.device());
       break;
     }
@@ -80,18 +79,17 @@ WorkWrapper::WorkWrapper(
   future_ = c10::make_intrusive<c10::ivalue::Future>(
       c10::ListType::create(c10::TensorType::get()), devices);
 
+  // If we are doing a barrier collective, for all device types, devices vector
+  // would be empty we would fallback to same CPU synchronization logic
   if (!devices.empty()) {
-    // CUDA: resolve immediately. Future records a CUDA event on the current
-    // stream via markCompleted(). Device guard ensures getCurrentStream()
-    // returns the correct device's stream.
-    c10::OptionalDeviceGuard guard(devices[0]);
-    future_->markCompleted(c10::IValue(outputTensors_));
+    work_->markCompleted(
+        c10::intrusive_ptr<c10::ivalue::Future>(future_), outputTensors_);
   } else if (work_->isCompleted()) {
-    // For other device types (CPU, MTIA etc.) synchronous op already finished —
+    // For other device types (CPU) synchronous op already finished —
     // resolve now.
     future_->markCompleted(c10::IValue(outputTensors_));
   } else {
-    // For other device types (CPU, MTIA etc.) async: register callback so
+    // For other device types (CPU) async: register callback so
     // future completes when setStatus fires.
     work_->setCallback([future = future_, tensors = outputTensors_]() {
       if (!future->completed()) {

--- a/comms/torchcomms/TorchWork.cpp
+++ b/comms/torchcomms/TorchWork.cpp
@@ -2,7 +2,22 @@
 
 #include "comms/torchcomms/TorchWork.hpp"
 
+#include <c10/core/DeviceGuard.h> // @manual=//caffe2:c10
+
 namespace torch::comms {
+
+void TorchWork::markCompleted(
+    c10::intrusive_ptr<c10::ivalue::Future> future_,
+    std::vector<at::Tensor> outputTensors_) {
+  TORCH_CHECK(
+      outputTensors_.size() > 0, "Atleast one tensor should be present");
+  // CUDA: resolve immediately. Future records a CUDA event on the current
+  // stream via markCompleted(). Device guard ensures getCurrentStream()
+  // returns the correct device's stream.
+  const auto device = outputTensors_[0].device();
+  c10::OptionalDeviceGuard guard(device);
+  future_->markCompleted(c10::IValue(outputTensors_));
+}
 
 TorchWorkCompleted::TorchWorkCompleted() {
   setStatus(WorkStatus::COMPLETED);

--- a/comms/torchcomms/TorchWork.hpp
+++ b/comms/torchcomms/TorchWork.hpp
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <ATen/core/ivalue.h> // @manual=//caffe2:ATen-core
 #include <c10/util/intrusive_ptr.h>
 #include <chrono>
 #include <functional>
@@ -97,6 +98,10 @@ class TorchWork : public c10::intrusive_ptr_target {
   void release_resources() override {
     callback_ = nullptr;
   }
+
+  virtual void markCompleted(
+      c10::intrusive_ptr<c10::ivalue::Future> future_,
+      std::vector<at::Tensor> outputTensors_);
 
   template <typename T, typename NullType>
   friend class c10::intrusive_ptr;


### PR DESCRIPTION
Summary: Moving future completion to TorchWork, to have backend specific implementations.

Differential Revision: D95938680


