### PR TITLE
Fix AllGather algo dispatch to use hint-connected AlgoConfig (#1076)

### DIFF
--- a/comms/ncclx/v2_27/src/collectives.cc
+++ b/comms/ncclx/v2_27/src/collectives.cc
@@ -93,14 +93,8 @@ ncclResult_t ncclAllGather(const void* sendbuff, void* recvbuff, size_t sendcoun
   NVTX3_FUNC_WITH_PARAMS(AllGather, NcclNvtxParamsAllGather,
     NVTX3_PAYLOAD(comm ? comm->commHash : 0, msgsize));
 
-  // Set algo to global config
-  auto algo = NCCL_ALLGATHER_ALGO;
-  // Override algo if comm config is set
-  if (ctranInitialized(comm->ctranComm_.get())) {
-    algo = comm->ctranComm_->ctran_->algo->getAllGatherAlgo();
-  }
+  auto algo = ncclx::algoconf::getAllGatherAlgo();
 
-  // Use ctran allgather if user specified and ctran is supported
   if (algo != NCCL_ALLGATHER_ALGO::orig && ctranAllGatherSupport(comm->ctranComm_.get(), algo)) {
     return metaCommToNccl(ctranAllGather(
         sendbuff, recvbuff, sendcount, ncclToMetaComm(datatype), comm->ctranComm_.get(), stream, algo));

--- a/comms/ncclx/v2_28/src/collectives.cc
+++ b/comms/ncclx/v2_28/src/collectives.cc
@@ -96,14 +96,8 @@ ncclResult_t ncclAllGather(const void* sendbuff, void* recvbuff, size_t sendcoun
   NVTX3_FUNC_WITH_PARAMS(AllGather, NcclNvtxParamsAllGather,
     NVTX3_PAYLOAD(comm ? comm->commHash : 0, sendcount * ncclTypeSize(datatype)));
 
-  // Set algo to global config
-  auto algo = NCCL_ALLGATHER_ALGO;
-  // Override algo if comm config is set
-  if (ctranInitialized(comm->ctranComm_.get())) {
-    algo = comm->ctranComm_->ctran_->algo->getAllGatherAlgo();
-  }
+  auto algo = ncclx::algoconf::getAllGatherAlgo();
 
-  // Use ctran allgather if user specified and ctran is supported
   if (algo != NCCL_ALLGATHER_ALGO::orig && ctranAllGatherSupport(comm->ctranComm_.get(), algo)) {
     return metaCommToNccl(ctranAllGather(
         sendbuff, recvbuff, sendcount, ncclToMetaComm(datatype), comm->ctranComm_.get(), stream, algo));

--- a/comms/ncclx/v2_29/src/collectives.cc
+++ b/comms/ncclx/v2_29/src/collectives.cc
@@ -100,14 +100,8 @@ ncclResult_t ncclAllGather(const void* sendbuff, void* recvbuff, size_t sendcoun
   NVTX3_FUNC_WITH_PARAMS(AllGather, NcclNvtxParamsAllGather,
     NVTX3_PAYLOAD(comm ? comm->commHash : 0, sendcount * ncclTypeSize(datatype)));
 
-  // Set algo to global config
-  auto algo = NCCL_ALLGATHER_ALGO;
-  // Override algo if comm config is set
-  if (ctranInitialized(comm->ctranComm_.get())) {
-    algo = comm->ctranComm_->ctran_->algo->getAllGatherAlgo();
-  }
+  auto algo = ncclx::algoconf::getAllGatherAlgo();
 
-  // Use ctran allgather if user specified and ctran is supported
   if (algo != NCCL_ALLGATHER_ALGO::orig && ctranAllGatherSupport(comm->ctranComm_.get(), algo)) {
     return metaCommToNccl(ctranAllGather(
         sendbuff, recvbuff, sendcount, ncclToMetaComm(datatype), comm->ctranComm_.get(), stream, algo));


### PR DESCRIPTION
Summary:

The `ncclAllGather()` dispatch in `collectives.cc` was reading the algorithm selection from the `NCCL_ALLGATHER_ALGO` cvar (environment variable) and the per-comm `CtranAlgo::getAllGatherAlgo()` override, instead of from `ncclx::algoconf::getAllGatherAlgo()` (the AlgoConfig singleton). This meant that dynamic hint overrides via `setHint("algo_allgather", ...)` had no effect on AllGather dispatch, because the hint system updates AlgoConfig but the dispatch was reading the raw cvar.

This was inconsistent with SendRecv and AllReduce, which both read directly from `ncclx::algoconf::getSendRecvAlgo()` / `ncclx::algoconf::getAllReduceAlgo()` and correctly respond to hints.

Reviewed By: minsii

Differential Revision: D96423081
