### PR TITLE
Auto-detect GPU arch in CMakeLists.txt instead of hardcoding sm_90

### DIFF
--- a/comms/torchcomms/triton/CMakeLists.txt
+++ b/comms/torchcomms/triton/CMakeLists.txt
@@ -68,6 +68,59 @@ if(NOT EXISTS "${CUDA_PATH}/include/texture_fetch_functions.h")
     message(STATUS "  Created texture_fetch_functions.h stub for CUDA 13+ compatibility")
 endif()
 
+# ---- GPU architecture detection ----
+# Priority: TORCHCOMMS_CUDA_ARCH > TORCH_CUDA_ARCH_LIST > nvidia-smi auto-detect > sm_90 default
+#
+# Clang's NVPTX backend doesn't support all SM codes that nvcc does (e.g.
+# sm_103, sm_100a, sm_100f, sm_103a are not recognized by clang 21). Map
+# unsupported codes to the nearest clang-supported base SM. Device bitcode
+# compiled for the base SM is forward-compatible with higher SM variants.
+if(DEFINED TORCHCOMMS_CUDA_ARCH)
+    set(_raw_sm "${TORCHCOMMS_CUDA_ARCH}")
+elseif(DEFINED ENV{TORCHCOMMS_CUDA_ARCH})
+    set(_raw_sm "$ENV{TORCHCOMMS_CUDA_ARCH}")
+elseif(DEFINED TORCH_CUDA_ARCH_LIST)
+    # TORCH_CUDA_ARCH_LIST uses dot notation (e.g. "9.0;9.0a;10.0")
+    # Take the first entry and convert to SM code.
+    list(GET TORCH_CUDA_ARCH_LIST 0 _first_arch)
+    string(REPLACE "." "" _raw_sm "${_first_arch}")
+elseif(DEFINED ENV{TORCH_CUDA_ARCH_LIST})
+    string(REPLACE " " ";" _arch_list "$ENV{TORCH_CUDA_ARCH_LIST}")
+    list(GET _arch_list 0 _first_arch)
+    string(REPLACE "." "" _raw_sm "${_first_arch}")
+else()
+    # Auto-detect from nvidia-smi
+    execute_process(
+        COMMAND nvidia-smi --query-gpu=compute_cap --format=csv,noheader
+        OUTPUT_VARIABLE _smi_output
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+        RESULT_VARIABLE _smi_result
+    )
+    if(_smi_result EQUAL 0 AND _smi_output)
+        # Take the first GPU's compute capability (e.g. "9.0" -> "90", "10.0" -> "100")
+        string(REGEX MATCH "[0-9]+\\.[0-9]+" _first_cc "${_smi_output}")
+        if(_first_cc)
+            string(REPLACE "." "" _raw_sm "${_first_cc}")
+        else()
+            set(_raw_sm "90")
+        endif()
+    else()
+        set(_raw_sm "90")
+    endif()
+endif()
+
+# Apply clang SM overrides for unsupported SM codes
+if(_raw_sm STREQUAL "100a" OR _raw_sm STREQUAL "100f"
+   OR _raw_sm STREQUAL "103" OR _raw_sm STREQUAL "103a")
+    set(_clang_sm "100")
+else()
+    set(_clang_sm "${_raw_sm}")
+endif()
+
+set(TRITON_GPU_ARCH_FLAG "--cuda-gpu-arch=sm_${_clang_sm}")
+message(STATUS "  TRITON GPU arch  : sm_${_clang_sm} (raw: ${_raw_sm})")
+
 set(TRITON_BC_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/comms/torchcomms/triton/fb/libtorchcomms_device.bc")
 
 # Ensure output directory exists
@@ -79,7 +132,7 @@ add_custom_command(
     COMMAND ${CMAKE_COMMAND} -E echo "Building Triton device bitcode..."
     COMMAND "${CLANG_EXECUTABLE}"
         -x cuda --cuda-device-only
-        --cuda-gpu-arch=sm_90
+        ${TRITON_GPU_ARCH_FLAG}
         -c -emit-llvm -O1
         -std=gnu++17
         -D__clang_llvm_bitcode_lib__


### PR DESCRIPTION
Summary:
The CMake build for torchcomms triton bitcode had --cuda-gpu-arch=sm_90 hardcoded, causing builds to fail on GB300 (SM 100+). This mirrors the BUCK file's dynamic arch detection
 by checking TORCHCOMMS_CUDA_ARCH, TORCH_CUDA_ARCH_LIST, and nvidia-smi in that order, with the same clang SM override map for unsupported codes (103/103a/100a/100f → 100).

Differential Revision: D96482028


