### PR TITLE
Add missing FB_CUDACHECKs

### DIFF
--- a/comms/ctran/algos/AllReduce/AllReduceRing.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceRing.cc
@@ -110,10 +110,10 @@ inline bool shouldEnableBidirAg(size_t messageBytes) {
   if (maxSize == -2) {
     // Auto-tune: select threshold based on GPU architecture
     int cudaDev = 0;
-    cudaGetDevice(&cudaDev);
+    FB_CUDACHECK(cudaGetDevice(&cudaDev));
     int smMajor = 0;
-    cudaDeviceGetAttribute(
-        &smMajor, cudaDevAttrComputeCapabilityMajor, cudaDev);
+    FB_CUDACHECK(cudaDeviceGetAttribute(
+        &smMajor, cudaDevAttrComputeCapabilityMajor, cudaDev));
     maxSize = (smMajor < 10) ? static_cast<int64_t>(kHopperBidirAgMaxSize)
                              : static_cast<int64_t>(kDefaultBidirAgMaxSize);
   }


### PR DESCRIPTION
Summary:
AMD build fails:

```
buck-out/v2/art/fbcode/b0db3027d13c65bd/comms/ctran/__hetero_ctran_lib_hipify_gen__/out/algos/AllReduce/AllReduceRing.cc:114:5: error: ignoring return value of type 'hipError_t' declared with 'nodiscard' attribute [-Werror,-Wunused-value]
  114 |     hipGetDevice(&cudaDev);
      |     ^~~~~~~~~~~~ ~~~~~~~~
buck-out/v2/art/fbcode/b0db3027d13c65bd/comms/ctran/__hetero_ctran_lib_hipify_gen__/out/algos/AllReduce/AllReduceRing.cc:116:5: error: ignoring return value of type 'hipError_t' declared with 'nodiscard' attribute [-Werror,-Wunused-value]
  116 |     hipDeviceGetAttribute(
      |     ^~~~~~~~~~~~~~~~~~~~~
  117 |         &smMajor, hipDeviceAttributeComputeCapabilityMajor, cudaDev);
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Differential Revision: D96460398


