### PR TITLE
Fix InfoExtAllReduceTest build failure

### DIFF
--- a/comms/ncclx/v2_29/meta/tests/InfoExtAllReduceTest.cc
+++ b/comms/ncclx/v2_29/meta/tests/InfoExtAllReduceTest.cc
@@ -54,19 +54,19 @@ TEST_P(InfoExtAllReduceTest, Override) {
       param.algorithm, param.protocol, param.nMaxChannels, param.nWarps);
 
   struct ncclInfo info = {
-      ncclFuncAllReduce,
-      "AllReduce",
-      sendbuff,
-      recvbuff,
-      param.count,
-      ncclFloat,
-      ncclSum,
-      0,
-      commGuard.get(),
-      stream,
-      ALLREDUCE_CHUNKSTEPS,
-      ALLREDUCE_SLICESTEPS,
-      ext};
+      .coll = ncclFuncAllReduce,
+      .opName = "AllReduce",
+      .sendbuff = sendbuff,
+      .recvbuff = recvbuff,
+      .count = param.count,
+      .datatype = ncclFloat,
+      .op = ncclSum,
+      .root = 0,
+      .comm = commGuard.get(),
+      .stream = stream,
+      .chunkSteps = ALLREDUCE_CHUNKSTEPS,
+      .sliceSteps = ALLREDUCE_SLICESTEPS,
+      .ext = ext};
 
   ASSERT_EQ(ncclEnqueueCheck(&info), ncclSuccess);
   CUDACHECK_TEST(cudaStreamSynchronize(stream));


### PR DESCRIPTION
Summary:
The test used positional aggregate initialization for
ncclInfo, which broke when new one-sided and wait-signal
fields were added between sliceSteps and ext.  The
ncclInfoExt value ended up being matched to the
peerWinOffset (size_t) field instead of the ext field.

Fix by switching to designated initializers so the
initialization is field-name-based.

NOTE: This is a very unsafe test.  It relies on a very
specific set of parameters being initialized in the info
struct with no checks to see if there are any other fields
added.  We should consider deleting it.

Reviewed By: dolpm

Differential Revision: D96509570


