### PR TITLE
Add batched CE broadcast to reduce NVSwitch incast on large NVL domains (#1089)

### DIFF
--- a/comms/ctran/algos/AllGatherP/CommUtils.h
+++ b/comms/ctran/algos/AllGatherP/CommUtils.h
@@ -6,13 +6,14 @@
 #include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/ctran/mapper/CtranMapper.h"
 #include "comms/ctran/utils/ExtUtils.h"
+#include "comms/utils/cvars/nccl_cvars.h"
 
 namespace ctran::allgatherp {
 inline void* getPtr(void* base, size_t offset) {
   return (void*)((uintptr_t)base + offset);
 }
 
-inline commResult_t nvlBarrier(CtranComm* comm, cudaStream_t stream) {
+inline commResult_t scheduleNvlBarrier(CtranComm* comm, cudaStream_t stream) {
   const auto statex = comm->statex_.get();
   const auto localRank = statex->localRank();
   const auto nLocalRanks = statex->nLocalRanks();
@@ -57,7 +58,7 @@ inline commResult_t nvlCeBcast(
   // Barrier to make sure all local ranks has arrived before CE bcast, to
   // avoid unwanted incast traffic congestion
   if (barrier) {
-    nvlBarrier(comm, stream);
+    scheduleNvlBarrier(comm, stream);
   }
 
   const size_t numOps = nLocalRanks - 1;
@@ -94,19 +95,173 @@ inline commResult_t nvlCeBcast(
     sizes.at(r - 1) = sendSize;
   }
 
-#if CUDART_VERSION >= 13000
+#if CUDART_VERSION >= 12080
   cudaMemcpyAttributes attr = {};
   attr.srcAccessOrder = cudaMemcpySrcAccessOrderStream;
   attr.flags = cudaMemcpyFlagPreferOverlapWithCompute;
 
+#if CUDART_VERSION == 12080
+  size_t failIdx = 0;
+  FB_CUDACHECK(cudaMemcpyBatchAsync(
+      dsts.data(), srcs.data(), sizes.data(), numOps, attr, &failIdx, stream));
+#else
   FB_CUDACHECK(cudaMemcpyBatchAsync(
       dsts.data(), srcs.data(), sizes.data(), numOps, attr, stream));
+#endif
+
 #else
   auto mapper = comm->ctran_->mapper.get();
   for (size_t i = 0; i < numOps; i++) {
     FB_COMMCHECK(mapper->icopy(dsts.at(i), srcs.at(i), sizes.at(i), stream));
   }
 #endif
+
+  return commSuccess;
+}
+
+inline int resolveCeBatchSize(int nLocalRanks, size_t sendSize) {
+  int batchSize = NCCL_CTRAN_ALLGATHER_P_DIRECT_BATCH_SIZE;
+  if (batchSize == 0) {
+    if (nLocalRanks <= 8 ||
+        sendSize < static_cast<size_t>(
+                       NCCL_CTRAN_ALLGATHER_P_DIRECT_BATCH_THRESHOLD)) {
+      // H100 HGX or small messages (< 16MB per rank): unbatched.
+      // Barrier overhead outweighs incast benefit for small messages.
+      batchSize = nLocalRanks - 1;
+    } else {
+      // Large messages (>= 16MB per rank) on NVL36/NVL64/NVL72:
+      // aggressive batching to bound NVSwitch incast.
+      // Target ~8 concurrent CE copies per wave, cap at 16.
+      const int nPeers = nLocalRanks - 1;
+      batchSize = std::min((nPeers + 7) / 8, 16);
+    }
+  }
+  return batchSize;
+}
+
+inline commResult_t nvlCeBcastBatched(
+    CtranComm* comm,
+    const void* sendBuff,
+    const size_t sendSize,
+    const size_t recvOffset,
+    PersistArgs& pArgs,
+    cudaStream_t stream,
+    int batchSize,
+    bool barrier = true) {
+  const auto statex = comm->statex_.get();
+  const auto rank = statex->rank();
+  const auto localRank = statex->localRank();
+  const auto nLocalRanks = statex->nLocalRanks();
+
+  if (nLocalRanks <= 1) {
+    return commSuccess;
+  }
+
+  const int nPeers = nLocalRanks - 1;
+
+  // If batchSize is not set or >= nPeers, fall back to unbatched nvlCeBcast
+  if (batchSize <= 0 || batchSize >= nPeers) {
+    return nvlCeBcast(
+        comm, sendBuff, sendSize, recvOffset, pArgs, stream, barrier);
+  }
+
+  // ── PRE-BARRIER ──
+  // Ensures all local ranks have arrived before any CE writes begin.
+  if (barrier) {
+    FB_COMMCHECK(scheduleNvlBarrier(comm, stream));
+  }
+
+  const int nWaves = (nPeers + batchSize - 1) / batchSize;
+
+  for (int wave = 0; wave < nWaves; wave++) {
+    const int waveStart = wave * batchSize;
+    const int waveEnd = std::min(waveStart + batchSize, nPeers);
+    const size_t waveOps = waveEnd - waveStart;
+
+    // Build dst/src/size vectors for this wave's CE copies.
+    // Anti-diagonal round-robin: offset r = i+1, peer = (localRank+r)%N.
+    // Within each wave, every source targets a unique destination set,
+    // so max incast at any destination = batchSize.
+    std::vector<void*> dsts(waveOps);
+    std::vector<void*> srcs(waveOps);
+    std::vector<size_t> sizes(waveOps);
+
+    for (int i = waveStart; i < waveEnd; i++) {
+      const int r = i + 1;
+      const auto localPeer = (localRank + r) % nLocalRanks;
+      const auto peer = statex->localRankToRank(localPeer);
+
+      if (pArgs.remoteAccessKeys[peer].backend != CtranMapperBackend::NVL) {
+        FB_ERRORRETURN(
+            commInvalidArgument,
+            "Peer {} has non-NVL backend in nvlCeBcastBatched",
+            peer);
+      }
+
+      auto recvPtr = getPtr(pArgs.remoteRecvBuffs[peer], recvOffset);
+      CLOGF_TRACE(
+          COLL,
+          "Rank {} CE copy to peer {} (wave {}/{}, batch idx {}), "
+          "sendBuff {} -> recvBuff {} ({} + recvOffset {}), sendSize {}",
+          rank,
+          peer,
+          wave,
+          nWaves,
+          i - waveStart,
+          sendBuff,
+          recvPtr,
+          pArgs.remoteRecvBuffs[peer],
+          recvOffset,
+          sendSize);
+      dsts.at(i - waveStart) = recvPtr;
+      srcs.at(i - waveStart) = const_cast<void*>(sendBuff);
+      sizes.at(i - waveStart) = sendSize;
+    }
+
+    // Issue this wave's CE copies as a batch
+#if CUDART_VERSION >= 12080
+    cudaMemcpyAttributes attr = {};
+    attr.srcAccessOrder = cudaMemcpySrcAccessOrderStream;
+    attr.flags = cudaMemcpyFlagPreferOverlapWithCompute;
+
+#if CUDART_VERSION == 12080
+    size_t failIdx = 0;
+    FB_CUDACHECK(cudaMemcpyBatchAsync(
+        dsts.data(),
+        srcs.data(),
+        sizes.data(),
+        waveOps,
+        attr,
+        &failIdx,
+        stream));
+#else
+    FB_CUDACHECK(cudaMemcpyBatchAsync(
+        dsts.data(), srcs.data(), sizes.data(), waveOps, attr, stream));
+#endif
+
+#else
+    {
+      auto mapper = comm->ctran_->mapper.get();
+      for (size_t j = 0; j < waveOps; j++) {
+        FB_COMMCHECK(
+            mapper->icopy(dsts.at(j), srcs.at(j), sizes.at(j), stream));
+      }
+    }
+#endif
+
+    // ── INTER-WAVE BARRIER ──
+    // Synchronize all GPUs between waves. This bounds incast:
+    //   - All GPUs finish wave W before any GPU starts wave W+1
+    //   - The barrier kernel won't execute until this wave's CE copies
+    //     complete on this GPU (stream ordering)
+    //   - The barrier then waits for all other GPUs' barriers too
+    //
+    // Skip after the last wave — matches nvlCeBcast which has no
+    // post-barrier (caller handles post-synchronization).
+    if (wave < nWaves - 1) {
+      FB_COMMCHECK(scheduleNvlBarrier(comm, stream));
+    }
+  }
 
   return commSuccess;
 }

--- a/comms/ctran/algos/AllGatherP/DirectImpl.cc
+++ b/comms/ctran/algos/AllGatherP/DirectImpl.cc
@@ -145,8 +145,14 @@ commResult_t AlgoImpl::execDirect(
   }
 
   // Copy data to other local ranks
-  FB_COMMCHECK(
-      nvlCeBcast(comm_, sendbuff, sendSize, myRank * sendSize, pArgs, stream_));
+  FB_COMMCHECK(nvlCeBcastBatched(
+      comm_,
+      sendbuff,
+      sendSize,
+      myRank * sendSize,
+      pArgs,
+      stream_,
+      resolveCeBatchSize(nLocalRanks, sendSize)));
 
   auto op = std::make_unique<OpElem>(
       OpElem::opType::ALLGATHERP, stream_, comm_, opCount);

--- a/comms/ctran/algos/AllGatherP/PipelineImpl.cc
+++ b/comms/ctran/algos/AllGatherP/PipelineImpl.cc
@@ -213,8 +213,14 @@ commResult_t AlgoImpl::execPipeline(
   if (nLocalRanks > 1) {
     // - Step 0: Broadcast local chunk to intra-node peers
     // Copy data to other local ranks
-    FB_COMMCHECK(nvlCeBcast(
-        comm_, sendbuff, sendSize, myRank * sendSize, pArgs, stream_));
+    FB_COMMCHECK(nvlCeBcastBatched(
+        comm_,
+        sendbuff,
+        sendSize,
+        myRank * sendSize,
+        pArgs,
+        stream_,
+        resolveCeBatchSize(nLocalRanks, sendSize)));
 
     const int upPeer = (nRanks + myRank - nLocalRanks) & (nRanks - 1);
 
@@ -238,8 +244,14 @@ commResult_t AlgoImpl::execPipeline(
       const auto offset =
           getRecvChunkIdxInRail(upPeer, step, nLocalRanks, nRanks) * sendSize;
       const auto sendPtr = getPtr(pArgs.recvbuff, offset);
-      FB_COMMCHECK(
-          nvlCeBcast(comm_, sendPtr, sendSize, offset, pArgs, stream_));
+      FB_COMMCHECK(nvlCeBcastBatched(
+          comm_,
+          sendPtr,
+          sendSize,
+          offset,
+          pArgs,
+          stream_,
+          resolveCeBatchSize(nLocalRanks, sendSize)));
     }
 
     PipeEndKernArgs kernArgs = {

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2033,6 +2033,33 @@ cvars:
      When enabled, ReduceScatter with ncclAvg uses FuncPatAvg for true floating-point
      division instead of FuncSumPostDiv (which only supports unsigned integers).
 
+ - name        : NCCL_CTRAN_ALLGATHER_P_DIRECT_BATCH_SIZE
+   type        : int
+   default     : 0
+   description : |-
+     Batch size for AllGatherP CE broadcast (nvlCeBcast) to control
+     NVSwitch incast congestion on large NVL domains.
+     0 = auto-select based on NVL domain size and message size:
+         nLocalRanks <= 8:  unbatched (current behavior)
+         nLocalRanks > 8 AND sendSize < BATCH_THRESHOLD:
+             unbatched (barrier overhead outweighs incast benefit)
+         nLocalRanks > 8 AND sendSize >= BATCH_THRESHOLD:
+             batchSize = min(ceil(nPeers/8), 16) — ~8 waves
+     N > 0 = use exactly N concurrent CE copies per wave, with an
+     nvlBarrier between waves to re-synchronize all GPUs.
+
+ - name        : NCCL_CTRAN_ALLGATHER_P_DIRECT_BATCH_THRESHOLD
+   type        : uint64_t
+   default     : 16777216
+   description : |-
+     Per-rank send size threshold (in bytes) above which AllGatherP
+     uses batched CE broadcast on large NVL domains (nLocalRanks > 8).
+     Above this threshold: aggressive batching (~8 waves).
+     Below this threshold: unbatched (no extra barriers).
+     Only effective when NCCL_CTRAN_ALLGATHER_P_DIRECT_BATCH_SIZE is 0
+     (auto-select mode).
+     Default: 16777216 (16 MB per rank).
+
  - name        : NCCL_ALLTOALL_ALGO
    type        : enum
    default     : orig


### PR DESCRIPTION
Summary:

On NVL36/NVL64/NVL72, AllGatherP's CE broadcast creates N-1:1 incast at
each NVSwitch destination (up to 63:1 on NVL64). This causes severe
bandwidth degradation for large messages (>= 16MB per rank) on GB200.

This diff adds nvlCeBcastBatched() which splits CE copies into waves of
~8 concurrent copies each, with an nvlBarrier between waves to bound
max incast to batchSize:1. Anti-diagonal round-robin peer ordering
ensures within each wave every source targets a unique destination.

Behavior:
- B200/H100 (8 GPU): unchanged — unbatched, no extra barriers
- NVL36/NVL64/NVL72 + sendSize < 16MB/rank: unbatched (no regression)
- NVL36/NVL64/NVL72 + sendSize >= 16MB/rank: batched (~8 waves)
- Two CVARs for runtime tuning:
  NCCL_CTRAN_ALLGATHER_P_DIRECT_BATCH_SIZE (0=auto, N=explicit)
  NCCL_CTRAN_ALLGATHER_P_DIRECT_BATCH_THRESHOLD (default 16MB)

Stacks on D89303565 (cudaMemcpyBatchAsync). Uses cudaMemcpyBatchAsync
per wave on CUDA 12.8+, falls back to mapper->icopy on CUDA < 12.8.

Performance — allgather_perf GB200 NVL64 (64 GPUs, CUDA 12.8 ):
  (base/batched+cudaMemcpyBatchAsync, algbw OOP GB/s)
    32MB:  72.65/134.79 GB/s   +86%
    64MB:  121.57/237.74 GB/s  +96%
    128MB: 181.52/351.17 GB/s  +93%
    256MB: 251.05/481.88 GB/s  +92%
    512MB: 296.33/590.04 GB/s  +99%
  1GB total (16MB/rank):  +148% OOP (179->443 GB/s)
  2GB total (32MB/rank):  +149% OOP (218->542 GB/s)
  4GB total (64MB/rank):  +107% OOP (302->625 GB/s)
  8GB total (128MB/rank):  +70% OOP (397->674 GB/s)

Performance — allgather_perf GB300 NVL64 (64 GPUs, CUDA 13.0 ):
  All sizes: 0% regression (within run-to-run noise)
  32MB:  144 GB/s     256MB: 479 GB/s    2GB: 577 GB/s
  64MB:  240 GB/s     512MB: 594 GB/s    4GB: 667 GB/s
  128MB: 357 GB/s     1GB:   457 GB/s    8GB: 723 GB/s
  (no bandwidth cliff; batching adds no overhead)

Differential Revision: D96068771
