### PR TITLE
Extract IAlgoProfilerReporter interface from ctran::Profiler (#1093)

### DIFF
--- a/comms/ctran/Ctran.cc
+++ b/comms/ctran/Ctran.cc
@@ -21,7 +21,10 @@
 #include "comms/pipes/MultiPeerTransport.h"
 #endif // defined(ENABLE_PIPES)
 
-Ctran::Ctran(CtranComm* comm) : comm_(comm) {
+Ctran::Ctran(
+    CtranComm* comm,
+    std::unique_ptr<ctran::IProfilerReporter> reporter)
+    : comm_(comm) {
   ctran::logging::initCtranLogging();
 
   mapper = std::make_unique<CtranMapper>(comm_);
@@ -30,7 +33,7 @@ Ctran::Ctran(CtranComm* comm) : comm_(comm) {
   algo = std::make_unique<CtranAlgo>(comm, this);
 
   if (NCCL_CTRAN_TRANSPORT_PROFILER) {
-    profiler = std::make_unique<ctran::Profiler>(comm);
+    profiler = std::make_unique<ctran::Profiler>(comm, std::move(reporter));
   }
 }
 
@@ -108,11 +111,13 @@ comms::pipes::Transport* CtranComm::getMultiPeerTransportsPtr() const {
 }
 #endif // defined(ENABLE_PIPES)
 
-commResult_t ctranInit(CtranComm* comm) {
+commResult_t ctranInit(
+    CtranComm* comm,
+    std::unique_ptr<ctran::IProfilerReporter> reporter) {
   NcclScubaEvent initEvent(&comm->logMetaData_);
   initEvent.lapAndRecord("CtranInit START");
   try {
-    comm->ctran_ = std::make_shared<Ctran>(comm);
+    comm->ctran_ = std::make_shared<Ctran>(comm, std::move(reporter));
   } catch (std::exception& e) {
     CLOGF(ERR, "Ctran initialization failed: {}", e.what());
     return commInternalError;

--- a/comms/ctran/Ctran.h
+++ b/comms/ctran/Ctran.h
@@ -23,7 +23,9 @@
 
 class Ctran : public ICtran {
  public:
-  Ctran(CtranComm* comm);
+  Ctran(
+      CtranComm* comm,
+      std::unique_ptr<ctran::IProfilerReporter> reporter = nullptr);
   ~Ctran();
 
   bool isInitialized() const override;

--- a/comms/ctran/interfaces/ICtran.h
+++ b/comms/ctran/interfaces/ICtran.h
@@ -2,6 +2,9 @@
 
 #pragma once
 
+#include <memory>
+
+#include "comms/ctran/profiler/IProfilerReporter.h"
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
@@ -59,7 +62,9 @@ inline bool ctranIsUsed() {
   return (NCCL_SENDRECV_ALGO == NCCL_SENDRECV_ALGO::ctran);
 }
 
-commResult_t ctranInit(CtranComm* comm);
+commResult_t ctranInit(
+    CtranComm* comm,
+    std::unique_ptr<ctran::IProfilerReporter> reporter = nullptr);
 // Check whether the default CTran associated with the comm is initialized.
 // If to check a dedicated CTran instance, use ctran->isInitialized() instead.
 bool ctranInitialized(CtranComm* comm);

--- a/comms/ctran/profiler/AlgoProfilerReport.h
+++ b/comms/ctran/profiler/AlgoProfilerReport.h
@@ -1,0 +1,40 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+struct CommLogData;
+
+namespace ctran {
+
+struct DataContext {
+  uint64_t totalBytes{0};
+  std::string messageSizes{};
+};
+
+struct AlgoContext {
+  std::string deviceName{};
+  std::string algorithmName{};
+  DataContext sendContext{};
+  DataContext recvContext{};
+  uint64_t peerRank{0};
+};
+
+// Data struct capturing all profiled algo metrics, decoupled from Profiler
+// internals. Passed to IProfilerReporter::report().
+struct AlgoProfilerReport {
+  AlgoContext const* algoContext{nullptr};
+  const CommLogData* logMetaData{nullptr};
+  uint64_t opCount{0};
+  uint64_t bufferRegistrationTimeUs{0};
+  uint64_t controlSyncTimeUs{0};
+  uint64_t dataTransferTimeUs{0};
+  uint64_t collectiveDurationUs{0};
+  uint64_t readyTs{0};
+  uint64_t controlTs{0};
+  uint64_t timeFromDataToCollEndUs{0};
+};
+
+} // namespace ctran

--- a/comms/ctran/profiler/DefaultAlgoProfilerReporter.cc
+++ b/comms/ctran/profiler/DefaultAlgoProfilerReporter.cc
@@ -1,0 +1,39 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/ctran/profiler/DefaultAlgoProfilerReporter.h"
+#include "comms/utils/logger/EventMgr.h"
+#include "comms/utils/logger/ScubaLogger.h"
+
+namespace ctran {
+
+void DefaultAlgoProfilerReporter::report(const AlgoProfilerReport& report) {
+  if (!report.algoContext) {
+    return;
+  }
+  NcclScubaEvent scubaEvent(
+      std::make_unique<CtranProfilerAlgoEvent>(
+          report.logMetaData,
+          "algoProfilingV2",
+          "",
+          0,
+          report.algoContext->peerRank,
+          report.algoContext->deviceName,
+          "",
+          report.algoContext->algorithmName,
+          report.algoContext->sendContext.messageSizes,
+          report.algoContext->recvContext.messageSizes,
+          "",
+          report.algoContext->sendContext.totalBytes,
+          report.algoContext->recvContext.totalBytes,
+          report.bufferRegistrationTimeUs,
+          report.controlSyncTimeUs,
+          report.dataTransferTimeUs,
+          report.opCount,
+          report.readyTs,
+          report.controlTs,
+          report.timeFromDataToCollEndUs,
+          report.collectiveDurationUs));
+  scubaEvent.record();
+}
+
+} // namespace ctran

--- a/comms/ctran/profiler/DefaultAlgoProfilerReporter.h
+++ b/comms/ctran/profiler/DefaultAlgoProfilerReporter.h
@@ -1,0 +1,16 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include "comms/ctran/profiler/IProfilerReporter.h"
+
+namespace ctran {
+
+// Default reporter that logs algo profiling data to a scuba table.
+class DefaultAlgoProfilerReporter : public IProfilerReporter {
+ public:
+  ~DefaultAlgoProfilerReporter() override = default;
+  void report(const AlgoProfilerReport& report) override;
+};
+
+} // namespace ctran

--- a/comms/ctran/profiler/IProfilerReporter.h
+++ b/comms/ctran/profiler/IProfilerReporter.h
@@ -1,0 +1,17 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include "comms/ctran/profiler/AlgoProfilerReport.h"
+
+namespace ctran {
+
+// Abstract interface for reporting algo profiling data to a scuba backend.
+// Implementations can target different scuba tables.
+class IProfilerReporter {
+ public:
+  virtual ~IProfilerReporter() = default;
+  virtual void report(const AlgoProfilerReport& report) = 0;
+};
+
+} // namespace ctran

--- a/comms/ctran/profiler/Profiler.cc
+++ b/comms/ctran/profiler/Profiler.cc
@@ -1,7 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 #include "comms/ctran/profiler/Profiler.h"
-#include "comms/utils/logger/EventMgr.h"
-#include "comms/utils/logger/ScubaLogger.h"
+#include "comms/ctran/profiler/DefaultAlgoProfilerReporter.h"
 
 namespace {
 
@@ -26,6 +25,14 @@ uint64_t getTimeStamp(TimePoint timePoint) {
 } // namespace
 
 namespace ctran {
+
+Profiler::Profiler(CtranComm* comm, std::unique_ptr<IProfilerReporter> reporter)
+    : comm_(comm),
+      reporter_(
+          reporter ? std::move(reporter)
+                   : std::make_unique<DefaultAlgoProfilerReporter>()) {}
+
+Profiler::~Profiler() = default;
 
 void Profiler::initForEachColl(int opCount, int samplingWeight) {
   shouldTrace_ = samplingWeight > 0 && (opCount % samplingWeight) == 0;
@@ -70,56 +77,40 @@ void Profiler::endEvent(
   }
 }
 
+AlgoProfilerReport Profiler::buildReport() const {
+  return {
+      .algoContext = &algoContext,
+      .logMetaData = &comm_->logMetaData_,
+      .opCount = opCount_,
+      .bufferRegistrationTimeUs =
+          durations_[static_cast<size_t>(ProfilerEvent::BUF_REG)],
+      .controlSyncTimeUs =
+          durations_[static_cast<size_t>(ProfilerEvent::ALGO_CTRL)],
+      .dataTransferTimeUs =
+          durations_[static_cast<size_t>(ProfilerEvent::ALGO_DATA)],
+      .collectiveDurationUs =
+          durations_[static_cast<size_t>(ProfilerEvent::ALGO_TOTAL)],
+      .readyTs = readyTs_,
+      .controlTs = controlTs_,
+      .timeFromDataToCollEndUs = getDurationUs(
+          timers_[static_cast<size_t>(ProfilerEvent::ALGO_DATA)]
+              .getCheckpoint(),
+          timers_[static_cast<size_t>(ProfilerEvent::ALGO_TOTAL)]
+              .getCheckpoint()),
+  };
+}
+
 void Profiler::reportToScuba() {
   if (!shouldTrace_) {
     return;
   }
   endEvent(ctran::ProfilerEvent::ALGO_TOTAL);
-  logNcclProfilingAlgo();
+
+  if (reporter_) {
+    reporter_->report(buildReport());
+  }
+
   shouldTrace_ = false;
-}
-
-void Profiler::logNcclProfilingAlgo() const {
-  const uint64_t bufferRegistrationTimeUs =
-      durations_[static_cast<size_t>(ProfilerEvent::BUF_REG)];
-
-  const uint64_t controlSyncTimeUs =
-      durations_[static_cast<size_t>(ProfilerEvent::ALGO_CTRL)];
-
-  const uint64_t dataTransferTimeUs =
-      durations_[static_cast<size_t>(ProfilerEvent::ALGO_DATA)];
-
-  const uint64_t timeFromDataToCollEndUs = getDurationUs(
-      timers_[static_cast<size_t>(ProfilerEvent::ALGO_DATA)].getCheckpoint(),
-      timers_[static_cast<size_t>(ProfilerEvent::ALGO_TOTAL)].getCheckpoint());
-
-  const uint64_t collDurationUs =
-      durations_[static_cast<size_t>(ProfilerEvent::ALGO_TOTAL)];
-
-  NcclScubaEvent scubaEvent(
-      std::make_unique<CtranProfilerAlgoEvent>(
-          &comm_->logMetaData_,
-          "algoProfilingV2",
-          "",
-          0,
-          algoContext.peerRank,
-          algoContext.deviceName,
-          "",
-          algoContext.algorithmName,
-          algoContext.sendContext.messageSizes,
-          algoContext.recvContext.messageSizes,
-          "",
-          algoContext.sendContext.totalBytes,
-          algoContext.recvContext.totalBytes,
-          bufferRegistrationTimeUs,
-          controlSyncTimeUs,
-          dataTransferTimeUs,
-          opCount_,
-          readyTs_,
-          controlTs_,
-          timeFromDataToCollEndUs,
-          collDurationUs));
-  scubaEvent.record();
 }
 
 } // namespace ctran

--- a/comms/ctran/profiler/Profiler.h
+++ b/comms/ctran/profiler/Profiler.h
@@ -2,7 +2,11 @@
 
 #pragma once
 
+#include <memory>
+
 #include "comms/ctran/CtranComm.h"
+#include "comms/ctran/profiler/AlgoProfilerReport.h"
+#include "comms/ctran/profiler/IProfilerReporter.h"
 #include "comms/ctran/utils/StopWatch.h"
 
 namespace ctran {
@@ -26,19 +30,6 @@ enum ProfilerEvent {
   NUM_PROFILER_EVENT_TYPES,
 };
 
-struct DataContext {
-  uint64_t totalBytes{0};
-  std::string messageSizes{};
-};
-
-struct AlgoContext {
-  std::string deviceName{};
-  std::string algorithmName{};
-  DataContext sendContext{};
-  DataContext recvContext{};
-  uint64_t peerRank{0};
-};
-
 class Profiler {
  public:
   using Clock = std::chrono::system_clock;
@@ -47,8 +38,13 @@ class Profiler {
       std::array<utils::StopWatch<Clock>, NUM_PROFILER_EVENT_TYPES>;
 
  public:
-  Profiler(CtranComm* comm) : comm_(comm) {};
-  ~Profiler() = default;
+  // Construct with a reporter. If nullptr, defaults to
+  // DefaultAlgoProfilerReporter.
+  // The reporter is immutable after construction.
+  Profiler(
+      CtranComm* comm,
+      std::unique_ptr<IProfilerReporter> reporter = nullptr);
+  ~Profiler();
 
   // This should be called at the beginning of the collective
   void initForEachColl(int opCount, int samplingWeight);
@@ -87,6 +83,7 @@ class Profiler {
   AlgoContext algoContext{};
 
  private:
+  AlgoProfilerReport buildReport() const;
   CtranComm* comm_{nullptr};
   bool shouldTrace_{false};
   uint64_t opCount_{std::numeric_limits<uint64_t>::max()};
@@ -94,10 +91,7 @@ class Profiler {
   EventTimerArray timers_{};
   uint64_t readyTs_{0};
   uint64_t controlTs_{0};
-
-  void logNcclProfilingAlgo() const;
-
-  friend class ProfilerTest;
+  std::unique_ptr<IProfilerReporter> reporter_;
 };
 
 } // namespace ctran

--- a/comms/ctran/profiler/tests/ProfilerTest.cc
+++ b/comms/ctran/profiler/tests/ProfilerTest.cc
@@ -1,30 +1,39 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include "comms/ctran/profiler/Profiler.h"
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include "comms/ctran/profiler/AlgoProfilerReport.h"
+#include "comms/ctran/profiler/IProfilerReporter.h"
 
 using namespace ::testing;
 
 namespace ctran {
 
+// Mock reporter using GMock for call verification
+class MockAlgoProfilerReporter : public IProfilerReporter {
+ public:
+  MOCK_METHOD(void, report, (const AlgoProfilerReport& report), (override));
+};
+
 class ProfilerTest : public ::testing::Test {
  public:
   void SetUp() override {
-    comm_ = new CtranComm();
-    profiler_ = std::make_shared<ctran::Profiler>(comm_);
+    // Allocate a zero-initialized CtranComm-sized buffer to avoid pulling in
+    // the heavy ctran_lib dependency. The Profiler only accesses
+    // comm_->logMetaData_ which is a trivial POD struct, so zero-init is safe.
+    commBuf_.resize(sizeof(CtranComm), 0);
+    comm_ = reinterpret_cast<CtranComm*>(commBuf_.data());
+    profiler_ = std::make_unique<ctran::Profiler>(comm_);
   }
   void TearDown() override {
-    delete comm_;
     comm_ = nullptr;
   }
 
-  uint64_t getOpCount() {
-    return profiler_->opCount_;
-  }
-
  protected:
+  std::vector<char> commBuf_;
   CtranComm* comm_{nullptr};
-  std::shared_ptr<ctran::Profiler> profiler_{nullptr};
+  std::unique_ptr<ctran::Profiler> profiler_{nullptr};
 };
 
 TEST_F(ProfilerTest, testInitForEachColl) {
@@ -32,28 +41,98 @@ TEST_F(ProfilerTest, testInitForEachColl) {
   // test negative sampling weight
   profiler_->initForEachColl(opCount, -1);
   EXPECT_FALSE(profiler_->shouldTrace());
-  EXPECT_NE(getOpCount(), opCount);
+  EXPECT_NE(profiler_->getOpCount(), opCount);
 
   // test zero sampling weight
   profiler_->initForEachColl(opCount, 0);
   EXPECT_FALSE(profiler_->shouldTrace());
-  EXPECT_NE(getOpCount(), opCount);
+  EXPECT_NE(profiler_->getOpCount(), opCount);
 
   // test sampling weight = 1
   profiler_->initForEachColl(opCount, 1);
   EXPECT_TRUE(profiler_->shouldTrace());
-  EXPECT_EQ(getOpCount(), opCount);
+  EXPECT_EQ(profiler_->getOpCount(), opCount);
 
   // test opCount is the multiple of sampling weight
   profiler_->initForEachColl(opCount, 20);
   EXPECT_TRUE(profiler_->shouldTrace());
-  EXPECT_EQ(getOpCount(), opCount);
+  EXPECT_EQ(profiler_->getOpCount(), opCount);
 
   // test opCount is not the multiple of sampling weight
   ++opCount;
   profiler_->initForEachColl(opCount, 20);
   EXPECT_FALSE(profiler_->shouldTrace());
-  EXPECT_NE(getOpCount(), opCount);
+  EXPECT_NE(profiler_->getOpCount(), opCount);
+}
+
+TEST_F(ProfilerTest, testDefaultReporterType) {
+  // Default constructor should use default reporter (no crash on reportToScuba)
+  auto profiler = std::make_unique<ctran::Profiler>(comm_);
+  profiler->initForEachColl(100, 1);
+  profiler->startEvent(ctran::ProfilerEvent::BUF_REG);
+  profiler->endEvent(ctran::ProfilerEvent::BUF_REG);
+  profiler->startEvent(ctran::ProfilerEvent::ALGO_CTRL);
+  profiler->endEvent(ctran::ProfilerEvent::ALGO_CTRL);
+  profiler->startEvent(ctran::ProfilerEvent::ALGO_DATA);
+  profiler->endEvent(ctran::ProfilerEvent::ALGO_DATA);
+  EXPECT_NO_THROW(profiler->reportToScuba());
+}
+
+TEST_F(ProfilerTest, testReportToScubaCallsReporter) {
+  auto mockReporter = std::make_unique<StrictMock<MockAlgoProfilerReporter>>();
+  auto* mockPtr = mockReporter.get();
+  profiler_ = std::make_unique<ctran::Profiler>(comm_, std::move(mockReporter));
+
+  // Set up profiler state
+  profiler_->initForEachColl(100, 1);
+  ASSERT_TRUE(profiler_->shouldTrace());
+
+  // Set algo context
+  profiler_->algoContext.algorithmName = "testAlgo";
+  profiler_->algoContext.deviceName = "gpu0";
+  profiler_->algoContext.sendContext.totalBytes = 1024;
+  profiler_->algoContext.recvContext.totalBytes = 2048;
+  profiler_->algoContext.peerRank = 3;
+
+  // Simulate event timing
+  profiler_->startEvent(ctran::ProfilerEvent::BUF_REG);
+  profiler_->endEvent(ctran::ProfilerEvent::BUF_REG);
+  profiler_->startEvent(ctran::ProfilerEvent::ALGO_CTRL);
+  profiler_->endEvent(ctran::ProfilerEvent::ALGO_CTRL);
+  profiler_->startEvent(ctran::ProfilerEvent::ALGO_DATA);
+  profiler_->endEvent(ctran::ProfilerEvent::ALGO_DATA);
+
+  // Expect exactly one call and capture the report
+  AlgoProfilerReport capturedReport;
+  AlgoContext capturedAlgoContext;
+  EXPECT_CALL(*mockPtr, report(_))
+      .WillOnce([&](const AlgoProfilerReport& report) {
+        capturedReport = report;
+        if (report.algoContext) {
+          capturedAlgoContext = *report.algoContext;
+        }
+      });
+
+  profiler_->reportToScuba();
+
+  // Verify captured report contents
+  EXPECT_EQ(capturedReport.opCount, 100);
+  EXPECT_EQ(capturedAlgoContext.algorithmName, "testAlgo");
+  EXPECT_EQ(capturedAlgoContext.deviceName, "gpu0");
+  EXPECT_EQ(capturedAlgoContext.sendContext.totalBytes, 1024);
+  EXPECT_EQ(capturedAlgoContext.recvContext.totalBytes, 2048);
+  EXPECT_EQ(capturedAlgoContext.peerRank, 3);
+
+  // shouldTrace should be reset after reportToScuba
+  EXPECT_FALSE(profiler_->shouldTrace());
+}
+
+TEST_F(ProfilerTest, testReportToScubaNotCalledWhenNotTracing) {
+  auto mockReporter = std::make_unique<StrictMock<MockAlgoProfilerReporter>>();
+  profiler_ = std::make_unique<ctran::Profiler>(comm_, std::move(mockReporter));
+
+  // Don't init tracing — StrictMock will fail if report() is called
+  profiler_->reportToScuba();
 }
 
 } // namespace ctran


### PR DESCRIPTION
Summary:

Refactor ctran::Profiler to use a dependency-injected IAlgoProfilerReporter
interface for scuba reporting. This decouples the profiler from the
nccl_profiler_algo table, enabling MCCL to inject its own reporter that writes
to mccl_operation_trace instead.

- Create AlgoProfilerReport data struct (+ move AlgoContext/DataContext here)
- Create IAlgoProfilerReporter abstract interface
- Create NcclxAlgoProfilerReporter (existing logNcclProfilingAlgo logic)
- Profiler defaults to NcclxAlgoProfilerReporter, so NCCLX behavior is unchanged

Reviewed By: arttianezhu

Differential Revision: D96435663
