### PR TITLE
Instrument AllReduceDirect with ctran::Profiler (#1094)

### DIFF
--- a/comms/ctran/Ctran.cc
+++ b/comms/ctran/Ctran.cc
@@ -21,7 +21,10 @@
 #include "comms/pipes/MultiPeerTransport.h"
 #endif // defined(ENABLE_PIPES)
 
-Ctran::Ctran(CtranComm* comm) : comm_(comm) {
+Ctran::Ctran(
+    CtranComm* comm,
+    std::unique_ptr<ctran::IProfilerReporter> reporter)
+    : comm_(comm) {
   ctran::logging::initCtranLogging();
 
   mapper = std::make_unique<CtranMapper>(comm_);
@@ -30,7 +33,7 @@ Ctran::Ctran(CtranComm* comm) : comm_(comm) {
   algo = std::make_unique<CtranAlgo>(comm, this);
 
   if (NCCL_CTRAN_TRANSPORT_PROFILER) {
-    profiler = std::make_unique<ctran::Profiler>(comm);
+    profiler = std::make_unique<ctran::Profiler>(comm, std::move(reporter));
   }
 }
 
@@ -108,11 +111,13 @@ comms::pipes::Transport* CtranComm::getMultiPeerTransportsPtr() const {
 }
 #endif // defined(ENABLE_PIPES)
 
-commResult_t ctranInit(CtranComm* comm) {
+commResult_t ctranInit(
+    CtranComm* comm,
+    std::unique_ptr<ctran::IProfilerReporter> reporter) {
   NcclScubaEvent initEvent(&comm->logMetaData_);
   initEvent.lapAndRecord("CtranInit START");
   try {
-    comm->ctran_ = std::make_shared<Ctran>(comm);
+    comm->ctran_ = std::make_shared<Ctran>(comm, std::move(reporter));
   } catch (std::exception& e) {
     CLOGF(ERR, "Ctran initialization failed: {}", e.what());
     return commInternalError;

--- a/comms/ctran/Ctran.h
+++ b/comms/ctran/Ctran.h
@@ -23,7 +23,9 @@
 
 class Ctran : public ICtran {
  public:
-  Ctran(CtranComm* comm);
+  Ctran(
+      CtranComm* comm,
+      std::unique_ptr<ctran::IProfilerReporter> reporter = nullptr);
   ~Ctran();
 
   bool isInitialized() const override;

--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -154,6 +154,12 @@ class CtranComm {
   // TODO: remove config_, it's redundant
   ctranConfig config_;
   CommLogData logMetaData_;
+
+  // Opaque context for the algo profiler reporter. Set by the caller (e.g.,
+  // MCCL sets this to McclCommLogMetadata*) before ctranInit(). The registered
+  // reporter factory uses this to construct the appropriate reporter.
+  const void* algoProfilerReporterCtx_{nullptr};
+
   // opCount to be updated per kernel submit.
   // - Default points to the internal ctranOpCount_ field.
   // - When used with NCCL, will be updated to point to the NCCL opCount

--- a/comms/ctran/algos/AllReduce/AllReduceDirect.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceDirect.cc
@@ -8,6 +8,7 @@
 #include "comms/ctran/algos/AllReduce/AllReduceImpl.h"
 #include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/ctran/mapper/CtranMapper.h"
+#include "comms/ctran/profiler/Profiler.h"
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/LogUtils.h"
@@ -87,6 +88,21 @@ static commResult_t impl(
 
   CtranAlgoLogger logger(allReduceAlgoName(myAlgo), op->opCount, comm);
 
+  ctran::Profiler* profiler = comm->ctran_->profiler.get();
+  if (profiler) {
+    profiler->initForEachColl(
+        op->opCount, NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT);
+  }
+
+  CTRAN_PROFILER_IF(profiler, {
+    auto& algoContext = profiler->algoContext;
+    algoContext.algorithmName = allReduceAlgoName(myAlgo);
+    algoContext.sendContext.totalBytes = size;
+    algoContext.sendContext.messageSizes = std::to_string(size);
+    algoContext.recvContext.totalBytes = size;
+    algoContext.recvContext.messageSizes = std::to_string(size);
+  });
+
   /* intra-node */
   std::vector<void*> intraNodeRemoteSendBuffs(nLocalRanks);
   std::vector<void*> intraNodeRemoteRecvBuffs(nLocalRanks);
@@ -118,10 +134,14 @@ static commResult_t impl(
       std::unique_ptr<CtranMapperTimestamp>(
           new CtranMapperTimestamp(allReduceAlgoName(myAlgo)));
 
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::BUF_REG));
   FB_COMMCHECK(comm->ctran_->mapper->searchRegHandle(
       op->allreduce.sendbuff, size, &sendHdl, &localRegSend));
   FB_COMMCHECK(comm->ctran_->mapper->searchRegHandle(
       op->allreduce.recvbuff, size, &recvHdl, &localRegRecv));
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::BUF_REG));
 
   CtranMapperContext context(allReduceAlgoName(myAlgo), size, size);
   comm->ctran_->mapper->setContext(std::move(context));
@@ -130,6 +150,9 @@ static commResult_t impl(
   // so we first exchange control messages for the sendbuff, wait for
   // it to complete, and then exchange control messages for the
   // recvbuff.
+
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_CTRL));
 
   // Issue sendbuff control messages within the node
   for (int lr = 0; lr < nLocalRanks; lr++) {
@@ -235,6 +258,11 @@ static commResult_t impl(
           interNodeLocalRecvbuffReq[n].get()));
     }
   }
+
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_CTRL));
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_DATA));
 
   auto [tmpBuf, tmpbufRegHdl] = comm->ctran_->algo->getTmpBufInfo(
       CtranAlgo::TmpbufType::INTERNODE_TMPBUF);
@@ -508,12 +536,17 @@ static commResult_t impl(
         "ctdirect step 7: remainder inter-node allreduce");
   }
 
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_DATA));
+
   if (localRegSend == true) {
     FB_COMMCHECK(comm->ctran_->mapper->deregDynamic(sendHdl));
   }
   if (localRegRecv == true) {
     FB_COMMCHECK(comm->ctran_->mapper->deregDynamic(recvHdl));
   }
+
+  CTRAN_PROFILER_IF(profiler, { profiler->reportToScuba(); });
 
   comm->ctran_->mapper->timestamps.emplace_back(std::move(timestamp));
   comm->ctran_->mapper->reportProfiling();

--- a/comms/ctran/algos/AllReduce/AllReduceRing.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceRing.cc
@@ -23,6 +23,7 @@
 #include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/ctran/algos/CtranAlgoConsts.h"
 #include "comms/ctran/mapper/CtranMapper.h"
+#include "comms/ctran/profiler/Profiler.h"
 #include "comms/ctran/utils/CudaUtils.h"
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -1009,6 +1010,45 @@ inline commResult_t completeHostResourceSetup(
         std::string(desc));                                                  \
   }
 
+// Dedicated ctrl exchange for straggler detection, separate from the data
+// credit flow. Each rank signals "I'm ready" to both ring neighbors and waits
+// for both to signal back. The measured duration captures pure setup latency
+// (how long until the slowest neighbor is ready) with no data transfer noise.
+static void neighborReadinessBarrier(
+    CtranComm* comm,
+    const ctran::allreduce::ring::HostArgs& args) {
+  CtranMapperRequest recvFromRight;
+  CtranMapperRequest recvFromLeft;
+  CtranMapperRequest sendToLeft;
+  CtranMapperRequest sendToRight;
+
+  // Post receives first to avoid missed signals
+  FB_COMMCHECKTHROW_EX(
+      comm->ctran_->mapper->irecvCtrl(args.rightRank, &recvFromRight),
+      comm->logMetaData_);
+  FB_COMMCHECKTHROW_EX(
+      comm->ctran_->mapper->irecvCtrl(args.leftRank, &recvFromLeft),
+      comm->logMetaData_);
+
+  // Signal both neighbors
+  FB_COMMCHECKTHROW_EX(
+      comm->ctran_->mapper->isendCtrl(args.leftRank, &sendToLeft),
+      comm->logMetaData_);
+  FB_COMMCHECKTHROW_EX(
+      comm->ctran_->mapper->isendCtrl(args.rightRank, &sendToRight),
+      comm->logMetaData_);
+
+  // Wait for peer readiness
+  FB_COMMCHECKTHROW_EX(
+      comm->ctran_->mapper->waitRequest(&recvFromRight), comm->logMetaData_);
+  FB_COMMCHECKTHROW_EX(
+      comm->ctran_->mapper->waitRequest(&recvFromLeft), comm->logMetaData_);
+  FB_COMMCHECKTHROW_EX(
+      comm->ctran_->mapper->waitRequest(&sendToLeft), comm->logMetaData_);
+  FB_COMMCHECKTHROW_EX(
+      comm->ctran_->mapper->waitRequest(&sendToRight), comm->logMetaData_);
+}
+
 static commResult_t impl(
     const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
   FB_CHECKTHROW_EX_NOCOMM(
@@ -1017,16 +1057,27 @@ static commResult_t impl(
   CtranComm* comm = opGroup.front()->comm_;
   CtranAlgoLogger logger(allReduceAlgoName(myAlgo), op->opCount, comm);
 
+  ctran::Profiler* profiler = comm->ctran_->profiler.get();
+  if (profiler) {
+    profiler->initForEachColl(
+        op->opCount, NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT);
+  }
+
   // hostArgs/hostResource are direct members of OpElem — owned by OpElem,
   // destroyed when OpElem is destroyed (after single impl() in eager mode,
   // when graph is destroyed in CUDA graph persistent mode).
   auto& args = op->allreduce.hostArgs;
   auto& resource = op->allreduce.hostResource;
 
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_CTRL));
   if (!resource.setupComplete) {
     FB_COMMCHECK(completeHostResourceSetup(comm, args, resource));
     resource.setupComplete = true;
   }
+  neighborReadinessBarrier(comm, args);
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_CTRL));
 
   // setup algoCtx
   AlgoContext algoCtx = {
@@ -1040,6 +1091,17 @@ static commResult_t impl(
   };
   setupAlgoCtxImpl(algoCtx);
 
+  const size_t messageSize =
+      op->allreduce.count * commTypeSize(op->allreduce.datatype);
+  CTRAN_PROFILER_IF(profiler, {
+    auto& algoContext = profiler->algoContext;
+    algoContext.algorithmName = allReduceAlgoName(myAlgo);
+    algoContext.sendContext.totalBytes = messageSize;
+    algoContext.sendContext.messageSizes = std::to_string(messageSize);
+    algoContext.recvContext.totalBytes = messageSize;
+    algoContext.recvContext.messageSizes = std::to_string(messageSize);
+  });
+
   // Forward direction request vectors
   std::vector<std::unique_ptr<CtranMapperRequest>> dataSResps;
   std::vector<std::unique_ptr<CtranMapperRequest>> bufSyncSResps;
@@ -1052,6 +1114,8 @@ static commResult_t impl(
   std::vector<std::unique_ptr<CtranMapperRequest>> revBufSyncRResps;
   std::vector<std::unique_ptr<CtranMapperRequest>> revFlushResps;
 
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_DATA));
   while (algoCtx.partitionOffset < algoCtx.numElements) {
     updatePartitionCtxHost(args, resource, algoCtx);
     CLOGF_TRACE(
@@ -1140,6 +1204,10 @@ static commResult_t impl(
     updatePartitionDone(algoCtx);
     HOST_ABORT(fmt::format("ctring after partition {}", algoCtx.partition));
   } // end of partition loop
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_DATA));
+
+  CTRAN_PROFILER_IF(profiler, { profiler->reportToScuba(); });
 
   // Reset flags for next allreduce to reuse. Only clear sync status (post/
   // complete flags); do not release to pool (inuse stays true). Pool release

--- a/comms/ctran/interfaces/ICtran.h
+++ b/comms/ctran/interfaces/ICtran.h
@@ -2,6 +2,9 @@
 
 #pragma once
 
+#include <memory>
+
+#include "comms/ctran/profiler/IProfilerReporter.h"
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
@@ -59,7 +62,9 @@ inline bool ctranIsUsed() {
   return (NCCL_SENDRECV_ALGO == NCCL_SENDRECV_ALGO::ctran);
 }
 
-commResult_t ctranInit(CtranComm* comm);
+commResult_t ctranInit(
+    CtranComm* comm,
+    std::unique_ptr<ctran::IProfilerReporter> reporter = nullptr);
 // Check whether the default CTran associated with the comm is initialized.
 // If to check a dedicated CTran instance, use ctran->isInitialized() instead.
 bool ctranInitialized(CtranComm* comm);

--- a/comms/ctran/profiler/AlgoProfilerReport.h
+++ b/comms/ctran/profiler/AlgoProfilerReport.h
@@ -1,0 +1,40 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+struct CommLogData;
+
+namespace ctran {
+
+struct DataContext {
+  uint64_t totalBytes{0};
+  std::string messageSizes{};
+};
+
+struct AlgoContext {
+  std::string deviceName{};
+  std::string algorithmName{};
+  DataContext sendContext{};
+  DataContext recvContext{};
+  uint64_t peerRank{0};
+};
+
+// Data struct capturing all profiled algo metrics, decoupled from Profiler
+// internals. Passed to IProfilerReporter::report().
+struct AlgoProfilerReport {
+  AlgoContext const* algoContext{nullptr};
+  const CommLogData* logMetaData{nullptr};
+  uint64_t opCount{0};
+  uint64_t bufferRegistrationTimeUs{0};
+  uint64_t controlSyncTimeUs{0};
+  uint64_t dataTransferTimeUs{0};
+  uint64_t collectiveDurationUs{0};
+  uint64_t readyTs{0};
+  uint64_t controlTs{0};
+  uint64_t timeFromDataToCollEndUs{0};
+};
+
+} // namespace ctran

--- a/comms/ctran/profiler/DefaultAlgoProfilerReporter.cc
+++ b/comms/ctran/profiler/DefaultAlgoProfilerReporter.cc
@@ -1,0 +1,39 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/ctran/profiler/DefaultAlgoProfilerReporter.h"
+#include "comms/utils/logger/EventMgr.h"
+#include "comms/utils/logger/ScubaLogger.h"
+
+namespace ctran {
+
+void DefaultAlgoProfilerReporter::report(const AlgoProfilerReport& report) {
+  if (!report.algoContext) {
+    return;
+  }
+  NcclScubaEvent scubaEvent(
+      std::make_unique<CtranProfilerAlgoEvent>(
+          report.logMetaData,
+          "algoProfilingV2",
+          "",
+          0,
+          report.algoContext->peerRank,
+          report.algoContext->deviceName,
+          "",
+          report.algoContext->algorithmName,
+          report.algoContext->sendContext.messageSizes,
+          report.algoContext->recvContext.messageSizes,
+          "",
+          report.algoContext->sendContext.totalBytes,
+          report.algoContext->recvContext.totalBytes,
+          report.bufferRegistrationTimeUs,
+          report.controlSyncTimeUs,
+          report.dataTransferTimeUs,
+          report.opCount,
+          report.readyTs,
+          report.controlTs,
+          report.timeFromDataToCollEndUs,
+          report.collectiveDurationUs));
+  scubaEvent.record();
+}
+
+} // namespace ctran

--- a/comms/ctran/profiler/DefaultAlgoProfilerReporter.h
+++ b/comms/ctran/profiler/DefaultAlgoProfilerReporter.h
@@ -1,0 +1,16 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include "comms/ctran/profiler/IProfilerReporter.h"
+
+namespace ctran {
+
+// Default reporter that logs algo profiling data to a scuba table.
+class DefaultAlgoProfilerReporter : public IProfilerReporter {
+ public:
+  ~DefaultAlgoProfilerReporter() override = default;
+  void report(const AlgoProfilerReport& report) override;
+};
+
+} // namespace ctran

--- a/comms/ctran/profiler/IProfilerReporter.h
+++ b/comms/ctran/profiler/IProfilerReporter.h
@@ -1,0 +1,17 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include "comms/ctran/profiler/AlgoProfilerReport.h"
+
+namespace ctran {
+
+// Abstract interface for reporting algo profiling data to a scuba backend.
+// Implementations can target different scuba tables.
+class IProfilerReporter {
+ public:
+  virtual ~IProfilerReporter() = default;
+  virtual void report(const AlgoProfilerReport& report) = 0;
+};
+
+} // namespace ctran

--- a/comms/ctran/profiler/Profiler.cc
+++ b/comms/ctran/profiler/Profiler.cc
@@ -2,6 +2,8 @@
 #include "comms/ctran/profiler/Profiler.h"
 #include "comms/ctran/profiler/DefaultAlgoProfilerReporter.h"
 
+#include <unordered_map>
+
 namespace {
 
 template <typename Duration>
@@ -26,11 +28,35 @@ uint64_t getTimeStamp(TimePoint timePoint) {
 
 namespace ctran {
 
-Profiler::Profiler(CtranComm* comm, std::unique_ptr<IProfilerReporter> reporter)
-    : comm_(comm),
-      reporter_(
-          reporter ? std::move(reporter)
-                   : std::make_unique<DefaultAlgoProfilerReporter>()) {}
+namespace {
+
+std::unordered_map<ReporterType, AlgoProfilerReporterFactory>&
+getFactoryRegistry() {
+  static std::unordered_map<ReporterType, AlgoProfilerReporterFactory> registry;
+  return registry;
+}
+
+std::unique_ptr<IProfilerReporter> createReporter(
+    ReporterType type,
+    CtranComm* comm) {
+  auto& registry = getFactoryRegistry();
+  auto it = registry.find(type);
+  if (it != registry.end()) {
+    return it->second(comm);
+  }
+  return std::make_unique<DefaultAlgoProfilerReporter>();
+}
+
+} // namespace
+
+void registerAlgoProfilerReporterFactory(
+    ReporterType type,
+    AlgoProfilerReporterFactory factory) {
+  getFactoryRegistry()[type] = std::move(factory);
+}
+
+Profiler::Profiler(CtranComm* comm, ReporterType reporterType)
+    : comm_(comm), reporter_(createReporter(reporterType, comm)) {}
 
 Profiler::~Profiler() = default;
 

--- a/comms/ctran/profiler/Profiler.cc
+++ b/comms/ctran/profiler/Profiler.cc
@@ -1,7 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 #include "comms/ctran/profiler/Profiler.h"
-#include "comms/utils/logger/EventMgr.h"
-#include "comms/utils/logger/ScubaLogger.h"
+#include "comms/ctran/profiler/DefaultAlgoProfilerReporter.h"
 
 namespace {
 
@@ -26,6 +25,14 @@ uint64_t getTimeStamp(TimePoint timePoint) {
 } // namespace
 
 namespace ctran {
+
+Profiler::Profiler(CtranComm* comm, std::unique_ptr<IProfilerReporter> reporter)
+    : comm_(comm),
+      reporter_(
+          reporter ? std::move(reporter)
+                   : std::make_unique<DefaultAlgoProfilerReporter>()) {}
+
+Profiler::~Profiler() = default;
 
 void Profiler::initForEachColl(int opCount, int samplingWeight) {
   shouldTrace_ = samplingWeight > 0 && (opCount % samplingWeight) == 0;
@@ -70,56 +77,40 @@ void Profiler::endEvent(
   }
 }
 
+AlgoProfilerReport Profiler::buildReport() const {
+  return {
+      .algoContext = &algoContext,
+      .logMetaData = &comm_->logMetaData_,
+      .opCount = opCount_,
+      .bufferRegistrationTimeUs =
+          durations_[static_cast<size_t>(ProfilerEvent::BUF_REG)],
+      .controlSyncTimeUs =
+          durations_[static_cast<size_t>(ProfilerEvent::ALGO_CTRL)],
+      .dataTransferTimeUs =
+          durations_[static_cast<size_t>(ProfilerEvent::ALGO_DATA)],
+      .collectiveDurationUs =
+          durations_[static_cast<size_t>(ProfilerEvent::ALGO_TOTAL)],
+      .readyTs = readyTs_,
+      .controlTs = controlTs_,
+      .timeFromDataToCollEndUs = getDurationUs(
+          timers_[static_cast<size_t>(ProfilerEvent::ALGO_DATA)]
+              .getCheckpoint(),
+          timers_[static_cast<size_t>(ProfilerEvent::ALGO_TOTAL)]
+              .getCheckpoint()),
+  };
+}
+
 void Profiler::reportToScuba() {
   if (!shouldTrace_) {
     return;
   }
   endEvent(ctran::ProfilerEvent::ALGO_TOTAL);
-  logNcclProfilingAlgo();
+
+  if (reporter_) {
+    reporter_->report(buildReport());
+  }
+
   shouldTrace_ = false;
-}
-
-void Profiler::logNcclProfilingAlgo() const {
-  const uint64_t bufferRegistrationTimeUs =
-      durations_[static_cast<size_t>(ProfilerEvent::BUF_REG)];
-
-  const uint64_t controlSyncTimeUs =
-      durations_[static_cast<size_t>(ProfilerEvent::ALGO_CTRL)];
-
-  const uint64_t dataTransferTimeUs =
-      durations_[static_cast<size_t>(ProfilerEvent::ALGO_DATA)];
-
-  const uint64_t timeFromDataToCollEndUs = getDurationUs(
-      timers_[static_cast<size_t>(ProfilerEvent::ALGO_DATA)].getCheckpoint(),
-      timers_[static_cast<size_t>(ProfilerEvent::ALGO_TOTAL)].getCheckpoint());
-
-  const uint64_t collDurationUs =
-      durations_[static_cast<size_t>(ProfilerEvent::ALGO_TOTAL)];
-
-  NcclScubaEvent scubaEvent(
-      std::make_unique<CtranProfilerAlgoEvent>(
-          &comm_->logMetaData_,
-          "algoProfilingV2",
-          "",
-          0,
-          algoContext.peerRank,
-          algoContext.deviceName,
-          "",
-          algoContext.algorithmName,
-          algoContext.sendContext.messageSizes,
-          algoContext.recvContext.messageSizes,
-          "",
-          algoContext.sendContext.totalBytes,
-          algoContext.recvContext.totalBytes,
-          bufferRegistrationTimeUs,
-          controlSyncTimeUs,
-          dataTransferTimeUs,
-          opCount_,
-          readyTs_,
-          controlTs_,
-          timeFromDataToCollEndUs,
-          collDurationUs));
-  scubaEvent.record();
 }
 
 } // namespace ctran

--- a/comms/ctran/profiler/Profiler.h
+++ b/comms/ctran/profiler/Profiler.h
@@ -79,6 +79,11 @@ class Profiler {
 
   void reportToScuba();
 
+  // Replace the reporter (for testing with mock reporters).
+  void setReporter(std::unique_ptr<IAlgoProfilerReporter> reporter) {
+    reporter_ = std::move(reporter);
+  }
+
  public:
   AlgoContext algoContext{};
 

--- a/comms/ctran/profiler/Profiler.h
+++ b/comms/ctran/profiler/Profiler.h
@@ -30,6 +30,18 @@ enum ProfilerEvent {
   NUM_PROFILER_EVENT_TYPES,
 };
 
+// Factory function type for creating custom algo profiler reporters.
+// Callers (e.g., MCCL) can register a factory to inject their own reporter
+// without ctran needing to depend on caller-specific libraries.
+using AlgoProfilerReporterFactory =
+    std::function<std::unique_ptr<IAlgoProfilerReporter>(CtranComm*)>;
+
+// Register a factory for the given reporter type. Must be called before
+// ctranInit() so that the Profiler can use it during construction.
+void registerAlgoProfilerReporterFactory(
+    ReporterType type,
+    AlgoProfilerReporterFactory factory);
+
 class Profiler {
  public:
   using Clock = std::chrono::system_clock;

--- a/comms/ctran/profiler/Profiler.h
+++ b/comms/ctran/profiler/Profiler.h
@@ -2,7 +2,11 @@
 
 #pragma once
 
+#include <memory>
+
 #include "comms/ctran/CtranComm.h"
+#include "comms/ctran/profiler/AlgoProfilerReport.h"
+#include "comms/ctran/profiler/IProfilerReporter.h"
 #include "comms/ctran/utils/StopWatch.h"
 
 namespace ctran {
@@ -26,19 +30,6 @@ enum ProfilerEvent {
   NUM_PROFILER_EVENT_TYPES,
 };
 
-struct DataContext {
-  uint64_t totalBytes{0};
-  std::string messageSizes{};
-};
-
-struct AlgoContext {
-  std::string deviceName{};
-  std::string algorithmName{};
-  DataContext sendContext{};
-  DataContext recvContext{};
-  uint64_t peerRank{0};
-};
-
 class Profiler {
  public:
   using Clock = std::chrono::system_clock;
@@ -47,8 +38,13 @@ class Profiler {
       std::array<utils::StopWatch<Clock>, NUM_PROFILER_EVENT_TYPES>;
 
  public:
-  Profiler(CtranComm* comm) : comm_(comm) {};
-  ~Profiler() = default;
+  // Construct with a reporter. If nullptr, defaults to
+  // DefaultAlgoProfilerReporter.
+  // The reporter is immutable after construction.
+  Profiler(
+      CtranComm* comm,
+      std::unique_ptr<IProfilerReporter> reporter = nullptr);
+  ~Profiler();
 
   // This should be called at the beginning of the collective
   void initForEachColl(int opCount, int samplingWeight);
@@ -87,6 +83,7 @@ class Profiler {
   AlgoContext algoContext{};
 
  private:
+  AlgoProfilerReport buildReport() const;
   CtranComm* comm_{nullptr};
   bool shouldTrace_{false};
   uint64_t opCount_{std::numeric_limits<uint64_t>::max()};
@@ -94,10 +91,7 @@ class Profiler {
   EventTimerArray timers_{};
   uint64_t readyTs_{0};
   uint64_t controlTs_{0};
-
-  void logNcclProfilingAlgo() const;
-
-  friend class ProfilerTest;
+  std::unique_ptr<IProfilerReporter> reporter_;
 };
 
 } // namespace ctran

--- a/comms/ctran/profiler/tests/MockAlgoProfilerReporter.h
+++ b/comms/ctran/profiler/tests/MockAlgoProfilerReporter.h
@@ -1,0 +1,18 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <gmock/gmock.h>
+#include "comms/ctran/profiler/AlgoProfilerReport.h"
+#include "comms/ctran/profiler/IProfilerReporter.h"
+
+namespace ctran {
+
+// Mock reporter using GMock for call verification.
+// Extracted from ProfilerTest.cc for reuse across test files.
+class MockAlgoProfilerReporter : public IProfilerReporter {
+ public:
+  MOCK_METHOD(void, report, (const AlgoProfilerReport& report), (override));
+};
+
+} // namespace ctran

--- a/comms/ctran/profiler/tests/ProfilerTest.cc
+++ b/comms/ctran/profiler/tests/ProfilerTest.cc
@@ -1,30 +1,39 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include "comms/ctran/profiler/Profiler.h"
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include "comms/ctran/profiler/AlgoProfilerReport.h"
+#include "comms/ctran/profiler/IProfilerReporter.h"
 
 using namespace ::testing;
 
 namespace ctran {
 
+// Mock reporter using GMock for call verification
+class MockAlgoProfilerReporter : public IProfilerReporter {
+ public:
+  MOCK_METHOD(void, report, (const AlgoProfilerReport& report), (override));
+};
+
 class ProfilerTest : public ::testing::Test {
  public:
   void SetUp() override {
-    comm_ = new CtranComm();
-    profiler_ = std::make_shared<ctran::Profiler>(comm_);
+    // Allocate a zero-initialized CtranComm-sized buffer to avoid pulling in
+    // the heavy ctran_lib dependency. The Profiler only accesses
+    // comm_->logMetaData_ which is a trivial POD struct, so zero-init is safe.
+    commBuf_.resize(sizeof(CtranComm), 0);
+    comm_ = reinterpret_cast<CtranComm*>(commBuf_.data());
+    profiler_ = std::make_unique<ctran::Profiler>(comm_);
   }
   void TearDown() override {
-    delete comm_;
     comm_ = nullptr;
   }
 
-  uint64_t getOpCount() {
-    return profiler_->opCount_;
-  }
-
  protected:
+  std::vector<char> commBuf_;
   CtranComm* comm_{nullptr};
-  std::shared_ptr<ctran::Profiler> profiler_{nullptr};
+  std::unique_ptr<ctran::Profiler> profiler_{nullptr};
 };
 
 TEST_F(ProfilerTest, testInitForEachColl) {
@@ -32,28 +41,98 @@ TEST_F(ProfilerTest, testInitForEachColl) {
   // test negative sampling weight
   profiler_->initForEachColl(opCount, -1);
   EXPECT_FALSE(profiler_->shouldTrace());
-  EXPECT_NE(getOpCount(), opCount);
+  EXPECT_NE(profiler_->getOpCount(), opCount);
 
   // test zero sampling weight
   profiler_->initForEachColl(opCount, 0);
   EXPECT_FALSE(profiler_->shouldTrace());
-  EXPECT_NE(getOpCount(), opCount);
+  EXPECT_NE(profiler_->getOpCount(), opCount);
 
   // test sampling weight = 1
   profiler_->initForEachColl(opCount, 1);
   EXPECT_TRUE(profiler_->shouldTrace());
-  EXPECT_EQ(getOpCount(), opCount);
+  EXPECT_EQ(profiler_->getOpCount(), opCount);
 
   // test opCount is the multiple of sampling weight
   profiler_->initForEachColl(opCount, 20);
   EXPECT_TRUE(profiler_->shouldTrace());
-  EXPECT_EQ(getOpCount(), opCount);
+  EXPECT_EQ(profiler_->getOpCount(), opCount);
 
   // test opCount is not the multiple of sampling weight
   ++opCount;
   profiler_->initForEachColl(opCount, 20);
   EXPECT_FALSE(profiler_->shouldTrace());
-  EXPECT_NE(getOpCount(), opCount);
+  EXPECT_NE(profiler_->getOpCount(), opCount);
+}
+
+TEST_F(ProfilerTest, testDefaultReporterType) {
+  // Default constructor should use default reporter (no crash on reportToScuba)
+  auto profiler = std::make_unique<ctran::Profiler>(comm_);
+  profiler->initForEachColl(100, 1);
+  profiler->startEvent(ctran::ProfilerEvent::BUF_REG);
+  profiler->endEvent(ctran::ProfilerEvent::BUF_REG);
+  profiler->startEvent(ctran::ProfilerEvent::ALGO_CTRL);
+  profiler->endEvent(ctran::ProfilerEvent::ALGO_CTRL);
+  profiler->startEvent(ctran::ProfilerEvent::ALGO_DATA);
+  profiler->endEvent(ctran::ProfilerEvent::ALGO_DATA);
+  EXPECT_NO_THROW(profiler->reportToScuba());
+}
+
+TEST_F(ProfilerTest, testReportToScubaCallsReporter) {
+  auto mockReporter = std::make_unique<StrictMock<MockAlgoProfilerReporter>>();
+  auto* mockPtr = mockReporter.get();
+  profiler_ = std::make_unique<ctran::Profiler>(comm_, std::move(mockReporter));
+
+  // Set up profiler state
+  profiler_->initForEachColl(100, 1);
+  ASSERT_TRUE(profiler_->shouldTrace());
+
+  // Set algo context
+  profiler_->algoContext.algorithmName = "testAlgo";
+  profiler_->algoContext.deviceName = "gpu0";
+  profiler_->algoContext.sendContext.totalBytes = 1024;
+  profiler_->algoContext.recvContext.totalBytes = 2048;
+  profiler_->algoContext.peerRank = 3;
+
+  // Simulate event timing
+  profiler_->startEvent(ctran::ProfilerEvent::BUF_REG);
+  profiler_->endEvent(ctran::ProfilerEvent::BUF_REG);
+  profiler_->startEvent(ctran::ProfilerEvent::ALGO_CTRL);
+  profiler_->endEvent(ctran::ProfilerEvent::ALGO_CTRL);
+  profiler_->startEvent(ctran::ProfilerEvent::ALGO_DATA);
+  profiler_->endEvent(ctran::ProfilerEvent::ALGO_DATA);
+
+  // Expect exactly one call and capture the report
+  AlgoProfilerReport capturedReport;
+  AlgoContext capturedAlgoContext;
+  EXPECT_CALL(*mockPtr, report(_))
+      .WillOnce([&](const AlgoProfilerReport& report) {
+        capturedReport = report;
+        if (report.algoContext) {
+          capturedAlgoContext = *report.algoContext;
+        }
+      });
+
+  profiler_->reportToScuba();
+
+  // Verify captured report contents
+  EXPECT_EQ(capturedReport.opCount, 100);
+  EXPECT_EQ(capturedAlgoContext.algorithmName, "testAlgo");
+  EXPECT_EQ(capturedAlgoContext.deviceName, "gpu0");
+  EXPECT_EQ(capturedAlgoContext.sendContext.totalBytes, 1024);
+  EXPECT_EQ(capturedAlgoContext.recvContext.totalBytes, 2048);
+  EXPECT_EQ(capturedAlgoContext.peerRank, 3);
+
+  // shouldTrace should be reset after reportToScuba
+  EXPECT_FALSE(profiler_->shouldTrace());
+}
+
+TEST_F(ProfilerTest, testReportToScubaNotCalledWhenNotTracing) {
+  auto mockReporter = std::make_unique<StrictMock<MockAlgoProfilerReporter>>();
+  profiler_ = std::make_unique<ctran::Profiler>(comm_, std::move(mockReporter));
+
+  // Don't init tracing — StrictMock will fail if report() is called
+  profiler_->reportToScuba();
 }
 
 } // namespace ctran

--- a/comms/ctran/profiler/tests/ProfilerTest.cc
+++ b/comms/ctran/profiler/tests/ProfilerTest.cc
@@ -3,18 +3,11 @@
 #include "comms/ctran/profiler/Profiler.h"
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include "comms/ctran/profiler/AlgoProfilerReport.h"
-#include "comms/ctran/profiler/IProfilerReporter.h"
+#include "comms/ctran/profiler/tests/MockAlgoProfilerReporter.h"
 
 using namespace ::testing;
 
 namespace ctran {
-
-// Mock reporter using GMock for call verification
-class MockAlgoProfilerReporter : public IProfilerReporter {
- public:
-  MOCK_METHOD(void, report, (const AlgoProfilerReport& report), (override));
-};
 
 class ProfilerTest : public ::testing::Test {
  public:
@@ -28,6 +21,14 @@ class ProfilerTest : public ::testing::Test {
   }
   void TearDown() override {
     comm_ = nullptr;
+  }
+
+  uint64_t getOpCount() {
+    return profiler_->opCount_;
+  }
+
+  void setReporter(std::unique_ptr<ctran::IProfilerReporter> reporter) {
+    profiler_->setReporter(std::move(reporter));
   }
 
  protected:

--- a/comms/ctran/profiler/tests/ProfilerTest.cc
+++ b/comms/ctran/profiler/tests/ProfilerTest.cc
@@ -1,9 +1,15 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include "comms/ctran/profiler/Profiler.h"
+#include <folly/json/json.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "comms/ctran/profiler/tests/MockAlgoProfilerReporter.h"
+#include "comms/mccl/utils/logger/McclAlgoProfilerReporter.h"
+#include "comms/mccl/utils/logger/McclDataTableWrapper.h"
+#include "comms/mccl/utils/logger/McclOperationTraceTypes.h"
+#include "comms/mccl/utils/logger/tests/MockMcclDataTable.h"
+#include "comms/utils/cvars/nccl_cvars.h"
 
 using namespace ::testing;
 
@@ -134,6 +140,120 @@ TEST_F(ProfilerTest, testReportToScubaNotCalledWhenNotTracing) {
 
   // Don't init tracing — StrictMock will fail if report() is called
   profiler_->reportToScuba();
+}
+
+// Verify that constructing a Profiler with ReporterType::MCCL
+// creates a McclAlgoProfilerReporter that writes samples to the MCCL scuba
+// table with correct comm metadata and algo profiling fields.
+TEST_F(ProfilerTest, testMcclReporterFactoryWiring) {
+  using mccl::logger::McclCommLogMetadata;
+  using mccl::logger::McclDataTableWrapper;
+  using mccl::logger::testing::MockMcclDataTableFactory;
+  using mccl::logger::testing::ThreadSafeFakeTable;
+
+  // Test constants
+  constexpr int64_t kCommId = 12345;
+  constexpr int64_t kCommHash = 67890;
+  constexpr int kRank = 2;
+  constexpr int kNRanks = 8;
+  constexpr int kGpuId = 3;
+  constexpr int64_t kMcclcommUuid = 999;
+  const std::string kHostname = "devgpu001";
+  const std::string kJobId = "job_42";
+  constexpr int kOpCount = 100;
+  constexpr int kSamplingWeight = 1;
+  const std::string kAlgoName = "ctdirect";
+  constexpr size_t kSendBytes = 1024;
+  constexpr size_t kRecvBytes = 2048;
+
+  // Enable MCCL scuba logging
+  MCCL_SCUBA_ENABLED = true;
+  MCCL_SCUBA_LOG_LEVEL = MCCL_SCUBA_LOG_LEVEL::LOW;
+
+  // Set up fake scuba table to capture samples
+  auto fakeTable = std::make_unique<ThreadSafeFakeTable>();
+  auto* fakeTablePtr = fakeTable.get();
+  McclDataTableWrapper::init(
+      std::make_unique<MockMcclDataTableFactory>(std::move(fakeTable)));
+
+  // Set up comm metadata on the CtranComm buffer
+  McclCommLogMetadata commMeta;
+  commMeta.commId = kCommId;
+  commMeta.commHash = kCommHash;
+  commMeta.rank = kRank;
+  commMeta.nRanks = kNRanks;
+  commMeta.gpuId = kGpuId;
+  commMeta.mcclcommUuid = kMcclcommUuid;
+  commMeta.hostname = kHostname;
+  commMeta.jobId = kJobId;
+
+  // Wire the context pointer, simulating what McclComm::init does
+  comm_->algoProfilerReporterCtx_ = &commMeta;
+
+  // Register the MCCL reporter factory before constructing the profiler
+  ctran::registerMcclAlgoProfilerReporter();
+
+  // Construct profiler with MCCL reporter type — exercises the factory
+  auto mcclProfiler =
+      std::make_shared<ctran::Profiler>(comm_, ctran::ReporterType::MCCL);
+
+  // Set up profiler state and run through events
+  mcclProfiler->initForEachColl(kOpCount, kSamplingWeight);
+  ASSERT_TRUE(mcclProfiler->shouldTrace());
+
+  mcclProfiler->algoContext.algorithmName = kAlgoName;
+  mcclProfiler->algoContext.sendContext.totalBytes = kSendBytes;
+  mcclProfiler->algoContext.sendContext.messageSizes =
+      std::to_string(kSendBytes);
+  mcclProfiler->algoContext.recvContext.totalBytes = kRecvBytes;
+  mcclProfiler->algoContext.recvContext.messageSizes =
+      std::to_string(kRecvBytes);
+
+  mcclProfiler->startEvent(ctran::ProfilerEvent::BUF_REG);
+  mcclProfiler->endEvent(ctran::ProfilerEvent::BUF_REG);
+  mcclProfiler->startEvent(ctran::ProfilerEvent::ALGO_CTRL);
+  mcclProfiler->endEvent(ctran::ProfilerEvent::ALGO_CTRL);
+  mcclProfiler->startEvent(ctran::ProfilerEvent::ALGO_DATA);
+  mcclProfiler->endEvent(ctran::ProfilerEvent::ALGO_DATA);
+
+  mcclProfiler->reportToScuba();
+
+  // Verify sample was written to the MCCL scuba table
+  ASSERT_EQ(fakeTablePtr->getSampleCount(), 1);
+
+  auto jsons = fakeTablePtr->getSampleJsons();
+  auto json = folly::parseJson(jsons[0]);
+
+  // Verify comm metadata was propagated through the factory
+  EXPECT_EQ(json["int"]["comm_id"].getInt(), kCommId);
+  EXPECT_EQ(json["int"]["comm_hash"].getInt(), kCommHash);
+  EXPECT_EQ(json["int"]["rank"].getInt(), kRank);
+  EXPECT_EQ(json["int"]["world_size"].getInt(), kNRanks);
+  EXPECT_EQ(json["int"]["gpu_id"].getInt(), kGpuId);
+  EXPECT_EQ(json["int"]["mcclcomm_uuid"].getInt(), kMcclcommUuid);
+  EXPECT_EQ(json["normal"]["hostname"].getString(), kHostname);
+  EXPECT_EQ(json["normal"]["job_id"].getString(), kJobId);
+
+  // Verify algo profiling fields
+  EXPECT_EQ(json["normal"]["ctran_algo"].getString(), kAlgoName);
+  EXPECT_EQ(json["int"]["op_count"].getInt(), kOpCount);
+  EXPECT_EQ(
+      json["int"]["send_total_bytes"].getInt(),
+      static_cast<int64_t>(kSendBytes));
+  EXPECT_EQ(
+      json["int"]["recv_total_bytes"].getInt(),
+      static_cast<int64_t>(kRecvBytes));
+  EXPECT_EQ(
+      json["normal"]["send_message_sizes"].getString(),
+      std::to_string(kSendBytes));
+  EXPECT_EQ(
+      json["normal"]["recv_message_sizes"].getString(),
+      std::to_string(kRecvBytes));
+
+  // Clean up
+  mcclProfiler.reset();
+  McclDataTableWrapper::shutdown();
+  MCCL_SCUBA_ENABLED = false;
 }
 
 } // namespace ctran

--- a/comms/ctran/tests/CtranAllReduceTest.cc
+++ b/comms/ctran/tests/CtranAllReduceTest.cc
@@ -11,6 +11,8 @@
 #include <folly/synchronization/Baton.h>
 
 #include "comms/ctran/Ctran.h"
+#include "comms/ctran/profiler/Profiler.h"
+#include "comms/ctran/profiler/tests/MockAlgoProfilerReporter.h"
 #include "comms/ctran/tests/CtranTestUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
@@ -268,6 +270,52 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Values(
         std::make_tuple("ctring", NCCL_ALLREDUCE_ALGO::ctring),
         std::make_tuple("ctdirect", NCCL_ALLREDUCE_ALGO::ctdirect)),
+    [](const ::testing::TestParamInfo<AllReduceTestParam>& info) {
+      return std::get<0>(info.param);
+    });
+
+// Profiler test subclass: enables profiler in SetUp so ctran::Profiler is
+// created during ctranInit, then injects MockAlgoProfilerReporter.
+class CtranAllReduceProfilerTest : public CtranAllReduceTest {
+ protected:
+  void SetUp() override {
+    setenv("NCCL_CTRAN_TRANSPORT_PROFILER", "1", 1);
+    setenv("NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT", "1", 1);
+    CtranAllReduceTest::SetUp();
+  }
+};
+
+TEST_P(CtranAllReduceProfilerTest, ProfilerReportsValidData) {
+  auto [algoName, algo] = GetParam();
+
+  startWorkers(/*abortEnabled=*/false);
+  for (int rank = 0; rank < kNRanks; ++rank) {
+    run(rank, [this, algo](PerRankState& state) {
+      auto mockReporter = std::make_unique<ctran::MockAlgoProfilerReporter>();
+      auto* mockPtr = mockReporter.get();
+      auto* profiler = state.ctranComm->ctran_->profiler.get();
+      ASSERT_NE(profiler, nullptr);
+      profiler->setReporter(std::move(mockReporter));
+
+      runAllReduce(kBufferNElem, state, algo);
+
+      ASSERT_TRUE(mockPtr->reportCalled_);
+      EXPECT_GE(mockPtr->reportCount_, 1);
+      EXPECT_EQ(
+          mockPtr->capturedAlgoContext_.algorithmName, "CtranAllReduceRing");
+      EXPECT_GT(mockPtr->capturedAlgoContext_.sendContext.totalBytes, 0);
+      EXPECT_GT(mockPtr->capturedAlgoContext_.recvContext.totalBytes, 0);
+      EXPECT_GT(mockPtr->lastReport_.collectiveDurationUs, 0);
+      EXPECT_GE(mockPtr->lastReport_.controlSyncTimeUs, 0);
+      EXPECT_GE(mockPtr->lastReport_.dataTransferTimeUs, 0);
+    });
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ProfilerCombinations,
+    CtranAllReduceProfilerTest,
+    ::testing::Values(std::make_tuple("ctring", NCCL_ALLREDUCE_ALGO::ctring)),
     [](const ::testing::TestParamInfo<AllReduceTestParam>& info) {
       return std::get<0>(info.param);
     });

--- a/comms/ctran/tests/CtranAllReduceTest.cc
+++ b/comms/ctran/tests/CtranAllReduceTest.cc
@@ -544,4 +544,114 @@ TEST_F(CtranAllReduceRingOneRankTest, SmallMessageSize) {
   this->runAllReduce(/*nElem=*/1);
 }
 
+// Test fixture with transport profiler enabled to verify profiler
+// instrumentation in AllReduce algorithms.
+class CtranAllReduceProfilerTest
+    : public CtranIntraProcessFixture,
+      public ::testing::WithParamInterface<AllReduceTestParam> {
+ protected:
+  static constexpr int kNRanks = 4;
+  static constexpr commRedOp_t kReduceOpType = commSum;
+  static constexpr commDataType_t kDataType = commFloat32;
+  static constexpr size_t kTypeSize = sizeof(float);
+  static constexpr size_t kBufferNElem = kBufferSize / kTypeSize;
+
+  void SetUp() override {
+    setenv("NCCL_COMM_STATE_DEBUG_TOPO", "nolocal", 1);
+    setenv("NCCL_IGNORE_TOPO_LOAD_FAILURE", "1", 1);
+
+    // Enable transport profiler via env vars so ncclCvarInit() picks them up.
+    // Direct C++ assignment can be overwritten by ncclCvarInit() which reads
+    // from the environment.
+    setenv("NCCL_CTRAN_TRANSPORT_PROFILER", "true", 1);
+    setenv("NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT", "1", 1);
+    ncclCvarInit();
+
+    CtranIntraProcessFixture::SetUp();
+  }
+
+  void TearDown() override {
+    CtranIntraProcessFixture::TearDown();
+    unsetenv("NCCL_CTRAN_TRANSPORT_PROFILER");
+    unsetenv("NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT");
+    ncclCvarInit();
+  }
+};
+
+// Verify that the profiler is invoked and records valid event durations
+// after running an AllReduce collective.
+TEST_P(CtranAllReduceProfilerTest, ProfilerRecordsEvents) {
+  auto [algoName, algo] = GetParam();
+
+  std::vector<std::shared_ptr<::ctran::utils::Abort>> aborts;
+  CtranIntraProcessFixture::startWorkers(kNRanks, /*aborts=*/aborts);
+
+  for (int rank = 0; rank < kNRanks; ++rank) {
+    run(rank, [this, algo](PerRankState& state) {
+      void* srcHandle;
+      void* dstHandle;
+      ASSERT_EQ(
+          commSuccess,
+          state.ctranComm->ctran_->commRegister(
+              state.srcBuffer, kBufferSize, &srcHandle));
+      ASSERT_EQ(
+          commSuccess,
+          state.ctranComm->ctran_->commRegister(
+              state.dstBuffer, kBufferSize, &dstHandle));
+      SCOPE_EXIT {
+        state.ctranComm->ctran_->commDeregister(dstHandle);
+        state.ctranComm->ctran_->commDeregister(srcHandle);
+      };
+
+      EXPECT_EQ(
+          commSuccess,
+          ctranAllReduce(
+              state.srcBuffer,
+              state.dstBuffer,
+              kBufferNElem,
+              kDataType,
+              kReduceOpType,
+              state.ctranComm.get(),
+              state.stream,
+              algo));
+      EXPECT_EQ(cudaSuccess, cudaStreamSynchronize(state.stream));
+      EXPECT_EQ(commSuccess, state.ctranComm->getAsyncResult());
+
+      // Verify profiler exists and recorded event durations
+      auto* profiler = state.ctranComm->ctran_->profiler.get();
+      ASSERT_NE(profiler, nullptr);
+
+      constexpr uint64_t kOneMinUs = 1000 * 1000 * 60;
+
+      EXPECT_GT(
+          profiler->getEventDurationUs(ctran::ProfilerEvent::ALGO_TOTAL), 0);
+      EXPECT_LE(
+          profiler->getEventDurationUs(ctran::ProfilerEvent::ALGO_TOTAL),
+          kOneMinUs);
+
+      EXPECT_GT(
+          profiler->getEventDurationUs(ctran::ProfilerEvent::ALGO_CTRL), 0);
+      EXPECT_LE(
+          profiler->getEventDurationUs(ctran::ProfilerEvent::ALGO_CTRL),
+          kOneMinUs);
+
+      EXPECT_GT(
+          profiler->getEventDurationUs(ctran::ProfilerEvent::ALGO_DATA), 0);
+      EXPECT_LE(
+          profiler->getEventDurationUs(ctran::ProfilerEvent::ALGO_DATA),
+          kOneMinUs);
+    });
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AllAlgos,
+    CtranAllReduceProfilerTest,
+    ::testing::Values(
+        std::make_tuple("ctring", NCCL_ALLREDUCE_ALGO::ctring),
+        std::make_tuple("ctdirect", NCCL_ALLREDUCE_ALGO::ctdirect)),
+    [](const ::testing::TestParamInfo<AllReduceTestParam>& info) {
+      return std::get<0>(info.param);
+    });
+
 } // namespace ctran::testing


### PR DESCRIPTION
Summary:

Add profiler instrumentation to AllReduceDirect following the same
pattern used in SendRecvImpl. This enables algo-level profiling
(BUF_REG, ALGO_CTRL, ALGO_DATA timings) for the ctdirect allreduce
algorithm, making the data available via the injected reporter.

Differential Revision: D96436804
