### PR TITLE
Fix ctring allreduce CUDA graph persistent mode double-free (#1096)

### DIFF
--- a/comms/ctran/algos/AllReduce/AllReduceRing.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceRing.cc
@@ -19,6 +19,7 @@
 #include "comms/ctran/algos/AllReduce/AllReduceImpl.h"
 #include "comms/ctran/algos/AllReduce/AllReduceRingAutoTune.h"
 #include "comms/ctran/algos/AllReduce/AllReduceRingCommon.cuh"
+#include "comms/ctran/algos/AllReduce/Types.h"
 #include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/ctran/algos/CtranAlgoConsts.h"
 #include "comms/ctran/mapper/CtranMapper.h"
@@ -125,55 +126,7 @@ inline bool shouldEnableBidirAg(size_t messageBytes) {
   return messageBytes <= static_cast<size_t>(maxSize);
 }
 
-struct HostArgs {
-  int32_t rank{-1};
-  int32_t leftRank{-1};
-  int32_t rightRank{-1};
-
-  size_t minShardSize{0};
-
-  unsigned int numBlocks{0};
-  unsigned int numThreads{0};
-
-  // Enable bi-directional AllGather optimization
-  bool enableBidirAg{true};
-
-  // Forward: remote receive buffer on right
-  void* rightRemBuf{nullptr};
-  CtranMapperRemoteAccessKey rightRemKey;
-
-  // Forward: receive notifications from left
-  std::unique_ptr<CtranMapperNotify> leftNotify{nullptr};
-
-  // Reverse: remote receive buffer on left (left neighbor's tmpRecvBufRev)
-  void* leftRemBufRev{nullptr};
-  CtranMapperRemoteAccessKey leftRemKeyRev;
-
-  // Reverse: receive notifications from right
-  std::unique_ptr<CtranMapperNotify> rightNotify{nullptr};
-};
-struct HostResource {
-  CtranComm* comm{nullptr};
-
-  ctran::algos::GpeKernelSync* sendCopySync{nullptr};
-  ctran::algos::GpeKernelSync* recvRedCopySync{nullptr};
-  ctran::algos::GpeKernelSync* partitionSync{nullptr};
-
-  size_t chunkSize{0};
-  size_t numChunks{0};
-  void* tmpSendBuf{nullptr};
-  void* tmpSendBufHdl{nullptr};
-  void* tmpRecvBuf{nullptr};
-  void* tmpRecvBufHdl{nullptr};
-
-  // Reverse direction
-  ctran::algos::GpeKernelSync* revSendCopySync{nullptr};
-  ctran::algos::GpeKernelSync* revRecvCopySync{nullptr};
-  void* tmpSendBufRev{nullptr};
-  void* tmpSendBufRevHdl{nullptr};
-  void* tmpRecvBufRev{nullptr};
-  void* tmpRecvBufRevHdl{nullptr};
-};
+// HostArgs and HostResource are defined in AllReduce/Types.h
 
 namespace {
 
@@ -1041,16 +994,16 @@ static commResult_t impl(
   CtranComm* comm = opGroup.front()->comm_;
   CtranAlgoLogger logger(allReduceAlgoName(myAlgo), op->opCount, comm);
 
-  using HostArgs = ctran::allreduce::ring::HostArgs;
-  using HostResource = ctran::allreduce::ring::HostResource;
-  auto argsGuard = std::unique_ptr<HostArgs>(
-      reinterpret_cast<HostArgs*>(op->allreduce.args));
-  auto resourceGuard = std::unique_ptr<HostResource>(
-      reinterpret_cast<HostResource*>(op->allreduce.resource));
-  auto& args = *argsGuard;
-  auto& resource = *resourceGuard;
+  // hostArgs/hostResource are direct members of OpElem — owned by OpElem,
+  // destroyed when OpElem is destroyed (after single impl() in eager mode,
+  // when graph is destroyed in CUDA graph persistent mode).
+  auto& args = op->allreduce.hostArgs;
+  auto& resource = op->allreduce.hostResource;
 
-  FB_COMMCHECK(completeHostResourceSetup(comm, args, resource));
+  if (!resource.setupComplete) {
+    FB_COMMCHECK(completeHostResourceSetup(comm, args, resource));
+    resource.setupComplete = true;
+  }
 
   // setup algoCtx
   AlgoContext algoCtx = {
@@ -1160,12 +1113,15 @@ static commResult_t impl(
     HOST_ABORT();
   } // end of partition loop
 
-  // Reset flags for next allreduce to reuse
-  resource.sendCopySync->reset();
-  resource.recvRedCopySync->reset();
-  resource.partitionSync->reset();
-  resource.revSendCopySync->reset();
-  resource.revRecvCopySync->reset();
+  // Reset flags for next allreduce to reuse. Only clear sync status (post/
+  // complete flags); do not release to pool (inuse stays true). Pool release
+  // happens in ~OpElem when the owning OpElem is destroyed, which for
+  // graph-captured operations occurs at graph destruction time.
+  resource.sendCopySync->resetStatus();
+  resource.recvRedCopySync->resetStatus();
+  resource.partitionSync->resetStatus();
+  resource.revSendCopySync->resetStatus();
+  resource.revRecvCopySync->resetStatus();
 
   return commSuccess;
 }
@@ -1338,9 +1294,8 @@ commResult_t ctranAllReduceRing(
   op->allreduce.datatype = datatype;
   op->allreduce.op = redOp;
 
-  auto* hostResource = new ctran::allreduce::ring::HostResource();
-  op->allreduce.resource = hostResource;
-  hostResource->comm = comm;
+  auto& hostResource = op->allreduce.hostResource;
+  hostResource.comm = comm;
   std::vector<ctran::algos::GpeKernelSync*> gpeKernelSyncs;
   // 3 forward (sendCopy, recvRedCopy, partition) + 2 reverse (revSendCopy,
   // revRecvCopy)
@@ -1351,24 +1306,24 @@ commResult_t ctranAllReduceRing(
       gpeKernelSyncs.size() == kAllReduceRingNumSyncs,
       comm->logMetaData_,
       "Failed to allocate GpeKernelSync");
-  hostResource->sendCopySync = gpeKernelSyncs[0];
-  hostResource->recvRedCopySync = gpeKernelSyncs[1];
-  hostResource->partitionSync = gpeKernelSyncs[2];
-  hostResource->revSendCopySync = gpeKernelSyncs[3];
-  hostResource->revRecvCopySync = gpeKernelSyncs[4];
-  hostResource->chunkSize = pipelineChunkSize;
-  hostResource->numChunks = pipelineNumChunks;
+  hostResource.sendCopySync = gpeKernelSyncs[0];
+  hostResource.recvRedCopySync = gpeKernelSyncs[1];
+  hostResource.partitionSync = gpeKernelSyncs[2];
+  hostResource.revSendCopySync = gpeKernelSyncs[3];
+  hostResource.revRecvCopySync = gpeKernelSyncs[4];
+  hostResource.chunkSize = pipelineChunkSize;
+  hostResource.numChunks = pipelineNumChunks;
 
-  std::tie(hostResource->tmpSendBuf, hostResource->tmpSendBufHdl) =
+  std::tie(hostResource.tmpSendBuf, hostResource.tmpSendBufHdl) =
       comm->ctran_->algo->getTmpBufInfo(
           CtranAlgo::TmpbufType::RING_TMP_SEND_BUF);
-  std::tie(hostResource->tmpRecvBuf, hostResource->tmpRecvBufHdl) =
+  std::tie(hostResource.tmpRecvBuf, hostResource.tmpRecvBufHdl) =
       comm->ctran_->algo->getTmpBufInfo(
           CtranAlgo::TmpbufType::RING_TMP_RECV_BUF);
-  std::tie(hostResource->tmpSendBufRev, hostResource->tmpSendBufRevHdl) =
+  std::tie(hostResource.tmpSendBufRev, hostResource.tmpSendBufRevHdl) =
       comm->ctran_->algo->getTmpBufInfo(
           CtranAlgo::TmpbufType::RING_TMP_SEND_BUF_REV);
-  std::tie(hostResource->tmpRecvBufRev, hostResource->tmpRecvBufRevHdl) =
+  std::tie(hostResource.tmpRecvBufRev, hostResource.tmpRecvBufRevHdl) =
       comm->ctran_->algo->getTmpBufInfo(
           CtranAlgo::TmpbufType::RING_TMP_RECV_BUF_REV);
   CLOGF(
@@ -1376,19 +1331,18 @@ commResult_t ctranAllReduceRing(
       "AutoTune: {} blocks of {} threads, tmpbuf {} x {} chunks, bidirAg={}",
       numBlocks,
       numThreads,
-      hostResource->numChunks,
-      hostResource->chunkSize,
+      hostResource.numChunks,
+      hostResource.chunkSize,
       enableBidirAg);
 
-  auto* hostArgs = new ctran::allreduce::ring::HostArgs();
-  op->allreduce.args = hostArgs;
-  hostArgs->rank = rank;
-  hostArgs->leftRank = (rank - 1 + nRanks) % nRanks;
-  hostArgs->rightRank = (rank + 1) % nRanks;
-  hostArgs->minShardSize = NCCL_CTRAN_ALLREDUCE_RING_MIN_SHARD_SIZE;
-  hostArgs->numBlocks = numBlocks;
-  hostArgs->numThreads = numThreads;
-  hostArgs->enableBidirAg = enableBidirAg;
+  auto& hostArgs = op->allreduce.hostArgs;
+  hostArgs.rank = rank;
+  hostArgs.leftRank = (rank - 1 + nRanks) % nRanks;
+  hostArgs.rightRank = (rank + 1) % nRanks;
+  hostArgs.minShardSize = NCCL_CTRAN_ALLREDUCE_RING_MIN_SHARD_SIZE;
+  hostArgs.numBlocks = numBlocks;
+  hostArgs.numThreads = numThreads;
+  hostArgs.enableBidirAg = enableBidirAg;
   // rightRemBuf, rightRemKey, leftNotify init from gpe thread for EpochLock
 
   opGroup.push_back(std::move(op));
@@ -1408,18 +1362,18 @@ commResult_t ctranAllReduceRing(
       .datatype = datatype,
       .redOp = redOp,
       .count = count,
-      .chunkSize = hostResource->chunkSize,
-      .numChunks = hostResource->numChunks,
-      .minShardSize = hostArgs->minShardSize,
-      .sendCopySync = hostResource->sendCopySync,
-      .recvRedCopySync = hostResource->recvRedCopySync,
-      .partitionSync = hostResource->partitionSync,
-      .tmpSendBuf = hostResource->tmpSendBuf,
-      .tmpRecvBuf = hostResource->tmpRecvBuf,
-      .revSendCopySync = hostResource->revSendCopySync,
-      .revRecvCopySync = hostResource->revRecvCopySync,
-      .tmpSendBufRev = hostResource->tmpSendBufRev,
-      .tmpRecvBufRev = hostResource->tmpRecvBufRev,
+      .chunkSize = hostResource.chunkSize,
+      .numChunks = hostResource.numChunks,
+      .minShardSize = hostArgs.minShardSize,
+      .sendCopySync = hostResource.sendCopySync,
+      .recvRedCopySync = hostResource.recvRedCopySync,
+      .partitionSync = hostResource.partitionSync,
+      .tmpSendBuf = hostResource.tmpSendBuf,
+      .tmpRecvBuf = hostResource.tmpRecvBuf,
+      .revSendCopySync = hostResource.revSendCopySync,
+      .revRecvCopySync = hostResource.revRecvCopySync,
+      .tmpSendBufRev = hostResource.tmpSendBufRev,
+      .tmpRecvBufRev = hostResource.tmpRecvBufRev,
   };
   // Used only in gpe->submit, copied as a Kernel Launch Arg.
   config.algoArgs = &kernArgs;

--- a/comms/ctran/algos/AllReduce/Types.h
+++ b/comms/ctran/algos/AllReduce/Types.h
@@ -38,3 +38,99 @@ struct KernelArgs {
 };
 
 } // namespace ctran::allreduce
+
+// Ring host types are only used by CPU code (AllReduceRing.cc, CtranGpe.cc).
+// Guard against nvcc which cannot compile folly XLOG in transitive includes.
+#if !defined(__CUDACC__)
+
+#include <memory>
+
+#include "comms/ctran/algos/common/GpeKernelSync.h"
+#include "comms/ctran/mapper/CtranMapperTypes.h"
+
+class CtranComm;
+class CtranMapperNotify;
+
+namespace ctran::allreduce::ring {
+
+struct HostArgs {
+  int32_t rank{-1};
+  int32_t leftRank{-1};
+  int32_t rightRank{-1};
+
+  size_t minShardSize{0};
+
+  unsigned int numBlocks{0};
+  unsigned int numThreads{0};
+
+  // Enable bi-directional AllGather optimization
+  bool enableBidirAg{true};
+
+  // Forward: remote receive buffer on right
+  void* rightRemBuf{nullptr};
+  CtranMapperRemoteAccessKey rightRemKey;
+
+  // Forward: receive notifications from left
+  std::unique_ptr<CtranMapperNotify> leftNotify{nullptr};
+
+  // Reverse: remote receive buffer on left (left neighbor's tmpRecvBufRev)
+  void* leftRemBufRev{nullptr};
+  CtranMapperRemoteAccessKey leftRemKeyRev;
+
+  // Reverse: receive notifications from right
+  std::unique_ptr<CtranMapperNotify> rightNotify{nullptr};
+};
+
+struct HostResource {
+  ~HostResource() {
+    // Release GpeKernelSyncs back to pool (sets inuse=false so pool can
+    // reclaim). For graph-captured ops, this runs at graph destruction time
+    // via cmdDestroy -> delete cmd -> ~OpElem -> ~HostResource, preventing
+    // premature reuse by concurrent eager operations.
+    if (sendCopySync) {
+      sendCopySync->reset();
+    }
+    if (recvRedCopySync) {
+      recvRedCopySync->reset();
+    }
+    if (partitionSync) {
+      partitionSync->reset();
+    }
+    if (revSendCopySync) {
+      revSendCopySync->reset();
+    }
+    if (revRecvCopySync) {
+      revRecvCopySync->reset();
+    }
+  }
+
+  CtranComm* comm{nullptr};
+
+  ctran::algos::GpeKernelSync* sendCopySync{nullptr};
+  ctran::algos::GpeKernelSync* recvRedCopySync{nullptr};
+  ctran::algos::GpeKernelSync* partitionSync{nullptr};
+
+  size_t chunkSize{0};
+  size_t numChunks{0};
+  void* tmpSendBuf{nullptr};
+  void* tmpSendBufHdl{nullptr};
+  void* tmpRecvBuf{nullptr};
+  void* tmpRecvBufHdl{nullptr};
+
+  // Reverse direction
+  ctran::algos::GpeKernelSync* revSendCopySync{nullptr};
+  ctran::algos::GpeKernelSync* revRecvCopySync{nullptr};
+  void* tmpSendBufRev{nullptr};
+  void* tmpSendBufRevHdl{nullptr};
+  void* tmpRecvBufRev{nullptr};
+  void* tmpRecvBufRevHdl{nullptr};
+
+  // Set to true after completeHostResourceSetup() runs.
+  // In CUDA graph mode, impl() is called on every replay but
+  // IB resource setup must only happen once.
+  bool setupComplete{false};
+};
+
+} // namespace ctran::allreduce::ring
+
+#endif // !defined(__CUDACC__)

--- a/comms/ctran/gpe/CtranGpe.cc
+++ b/comms/ctran/gpe/CtranGpe.cc
@@ -143,6 +143,9 @@ OpElem::OpElem(
       new (&this->allreduce.remoteAccessKeys)
           std::vector<struct CtranMapperRemoteAccessKey>;
       this->allreduce.remoteAccessKeys.resize(comm_->statex_->nRanks());
+      new (&this->allreduce.hostArgs) ctran::allreduce::ring::HostArgs();
+      new (&this->allreduce.hostResource)
+          ctran::allreduce::ring::HostResource();
       break;
     default:
       break;
@@ -217,6 +220,9 @@ OpElem::~OpElem() {
       this->allreduce.kElemStepMap.~unordered_map();
       this->allreduce.remoteRecvBuffs.~vector();
       this->allreduce.remoteAccessKeys.~vector();
+      this->allreduce.hostArgs.~HostArgs();
+      // ~HostResource releases GpeKernelSyncs back to pool
+      this->allreduce.hostResource.~HostResource();
       break;
     }
     case ALLTOALLV_DYNAMIC: {

--- a/comms/ctran/gpe/CtranGpe.h
+++ b/comms/ctran/gpe/CtranGpe.h
@@ -114,8 +114,12 @@ struct OpElem {
       std::vector<void*> remoteRecvBuffs;
       std::vector<struct CtranMapperRemoteAccessKey> remoteAccessKeys;
 
-      void* args;
-      void* resource;
+#if !defined(__CUDACC__)
+      // Ring algorithm host state. Owned by OpElem — constructed in
+      // OpElem(), destroyed in ~OpElem(). Unused by ctdirect.
+      ctran::allreduce::ring::HostArgs hostArgs;
+      ctran::allreduce::ring::HostResource hostResource;
+#endif
     } allreduce;
     struct {
       const void* sendbuff;


### PR DESCRIPTION
Summary:

ctring's impl() function (AllReduceRing.cc:1046) wraps heap-allocated
HostArgs and HostResource in unique_ptr guards that free them when
impl() returns. In CUDA graph persistent mode, impl() is called on
every graph replay with the same OpElem. This causes:
- 2nd replay: use-after-free reading freed HostArgs/HostResource
- 2nd replay return: double-free via unique_ptr destructor
- Subsequent allocations: jemalloc detects heap corruption

The corruption is silent until a later allocation triggers jemalloc's
safety checks (e.g., creating a new comm after graph cleanup).

Fix: move HostArgs/HostResource ownership from impl() to ~OpElem().
- impl() now uses raw references instead of unique_ptr guards. The
  data lives in OpElem for the full lifetime of the command — one call
  in normal mode, multiple replays in graph mode.
- ~OpElem() deletes args/resource for ALLREDUCE (called once: when cmd
  is deleted in normal mode, or when graph is destroyed via cmdDestroy
  in persistent mode).
- HostResource gains a setupComplete flag so completeHostResourceSetup()
  only runs on the first replay. This prevents re-creation of
  CtranMapperNotify objects on each replay (which would leak/conflict
  with previous notify state). The IB tmp buffer exchange inside
  exchangePeerTmpbuf is already self-guarding via CtranAlgo's cached
  remoteTmpAccessKeys.
- ctdirect's OpElem now initializes args/resource to nullptr since the
  union is not zero-initialized and ~OpElem now deletes them.
- HostArgs/HostResource structs moved from AllReduceRing.cc to
  AllReduceRingTypes.h so ~OpElem (in CtranGpe.cc) can access the types.

Note: ctdirect was NOT affected — it uses stack-allocated locals in
impl() and doesn't use HostArgs/HostResource.

Detailed analysis: P2236762521

Reviewed By: saifhhasan

Differential Revision: D96606129


