### PR TITLE
Fix cmdCbPlan memory leak in CUDA graph capture

### DIFF
--- a/comms/ctran/gpe/CtranGpe.h
+++ b/comms/ctran/gpe/CtranGpe.h
@@ -403,6 +403,9 @@ class CtranGpe {
   commResult_t
   allocKernelElems(size_t numElems, int ngroups, KernelElem** elemsList);
 
+  // Returns number of live cmdCbPlan objects (for leak detection in tests)
+  static int liveCbPlanCount();
+
   // Return number of inuse kernel elements.
   // Used to check potential kelem leak in UT due to inproper usage in ctran
   // algorithm.

--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -122,7 +122,23 @@ OrderedWorkStreamGuard::Scope OrderedWorkStreamGuard::acquire(
 struct cmdCbPlan {
   CtranGpeCmd* cmd{nullptr};
   CtranGpe* gpe{nullptr};
+
+  // Leak detection counter: tracks live cmdCbPlan instances
+  static std::atomic<int>& liveCount() {
+    static std::atomic<int> count{0};
+    return count;
+  }
+  cmdCbPlan() {
+    liveCount().fetch_add(1);
+  }
+  ~cmdCbPlan() {
+    liveCount().fetch_sub(1);
+  }
 };
+
+int CtranGpe::liveCbPlanCount() {
+  return cmdCbPlan::liveCount().load();
+}
 
 void CUDART_CB CtranGpe::Impl::cmdCb(void* data) {
   struct cmdCbPlan* plan = reinterpret_cast<struct cmdCbPlan*>(data);
@@ -137,6 +153,8 @@ void CUDART_CB CtranGpe::Impl::cmdDestroy(void* data) {
   for (const auto& x : cmd->coll.opGroup) {
     x->setStatus(KernelElem::ElemStatus::RESET);
   }
+  // Free the host callback plan allocated during graph capture
+  delete reinterpret_cast<struct cmdCbPlan*>(cmd->cbPlan);
   delete cmd;
 }
 
@@ -336,6 +354,7 @@ commResult_t CtranGpe::Impl::submit(
       struct cmdCbPlan* plan = new struct cmdCbPlan;
       plan->cmd = cmd;
       plan->gpe = this->gpe;
+      cmd->cbPlan = plan;
       cmd->persistent = true;
 
       FB_COMMCHECKGOTO(

--- a/comms/ctran/gpe/CtranGpeImpl.h
+++ b/comms/ctran/gpe/CtranGpeImpl.h
@@ -134,6 +134,10 @@ class CtranGpeCmd {
 
   // Unpack queue to teardown after kernel completes (for TcpDM backend)
   void* unpackPool{nullptr};
+
+  // Host callback plan for CUDA graph mode. Allocated during graph capture,
+  // freed by cmdDestroy when the graph is destroyed.
+  void* cbPlan{nullptr};
 };
 
 /**

--- a/comms/ctran/gpe/tests/CtranGpeUT.cc
+++ b/comms/ctran/gpe/tests/CtranGpeUT.cc
@@ -1872,3 +1872,90 @@ TEST_F(CtranGpeTest, ThrowAsyncException) {
   EXPECT_EQ(e.commHash(), statex->commHash());
   EXPECT_EQ(e.rank(), statex->rank());
 }
+
+#if not defined(__HIP_PLATFORM_AMD__) and not defined(__HIP_PLATFORM_HCC__)
+// Verify that repeated graph capture + destroy does not leak memory.
+// The GPE allocates a cmdCbPlan for each graph capture. This plan must
+// be freed when the graph is destroyed (via cmdDestroy).
+//
+// Method: capture and destroy a graph kIterations times. Measure RSS
+// before and after. A 16-byte leak per iteration × 10000 = 160KB growth
+// which is detectable above noise.
+TEST_F(CtranGpeTest, GraphCaptureDestroyNoLeak) {
+  constexpr int kIterations = 10000;
+
+  auto gpe = std::unique_ptr<CtranGpe>(new CtranGpe(cudaDev, dummyComm));
+
+  cudaStream_t stream;
+  CUDACHECK_TEST(cudaStreamCreate(&stream));
+
+  int* buf = nullptr;
+  int* valPtr = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMallocHost(&valPtr, sizeof(int)));
+  *valPtr = 1;
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  // Dummy impl function for GPE thread (no-op)
+  auto dummyImpl =
+      [](const std::vector<std::unique_ptr<struct OpElem>>&) -> commResult_t {
+    return commSuccess;
+  };
+
+  auto captureAndDestroy = [&]() {
+    CUDACHECK_TEST(cudaStreamBeginCapture(stream, cudaStreamCaptureModeGlobal));
+
+    // Must pass non-empty opGroup to trigger cmdCbPlan creation
+    std::vector<std::unique_ptr<struct OpElem>> ops;
+    ops.push_back(
+        std::make_unique<OpElem>(
+            OpElem::opType::ALLGATHER, dummyComm, /*opCount=*/0));
+    constexpr uint64_t dummyOpCount = 0;
+    auto config = KernelConfig(
+        KernelConfig::KernelType::ALLGATHER, stream, "dummyAlgo", dummyOpCount);
+    ctranKernelSetAllGatherArgs(
+        buf, valPtr, commInt8, count, dummyDevState_d, &config.args);
+    auto res = gpe->submit(
+        std::move(ops),
+        dummyImpl,
+        config,
+        reinterpret_cast<void*>(CtranGpeTestKernel));
+    ASSERT_EQ(res, commSuccess);
+
+    cudaGraph_t graph;
+    CUDACHECK_TEST(cudaStreamEndCapture(stream, &graph));
+    ASSERT_NE(graph, nullptr);
+
+    cudaGraphExec_t graphExec;
+    CUDACHECK_TEST(
+        cudaGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+    CUDACHECK_TEST(cudaGraphLaunch(graphExec, stream));
+    CUDACHECK_TEST(cudaStreamSynchronize(stream));
+    CUDACHECK_TEST(cudaGraphExecDestroy(graphExec));
+    CUDACHECK_TEST(cudaGraphDestroy(graph));
+  };
+
+  int countBefore = CtranGpe::liveCbPlanCount();
+
+  for (int i = 0; i < kIterations; ++i) {
+    captureAndDestroy();
+  }
+
+  // CUDA may defer cmdDestroy callback by one operation; do an extra
+  // capture+destroy to flush any pending destruction.
+  captureAndDestroy();
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  int countAfter = CtranGpe::liveCbPlanCount();
+  int leaked = countAfter - countBefore;
+
+  // Without the fix: leaked == kIterations + 1 (one plan per capture)
+  // With the fix: leaked == 0 (or at most 1 from deferred destruction)
+  EXPECT_LE(leaked, 1) << "cmdCbPlan leak: " << leaked << " plans leaked over "
+                       << kIterations + 1 << " graph capture/destroy cycles";
+
+  CUDACHECK_TEST(cudaFree(buf));
+  CUDACHECK_TEST(cudaFreeHost(valPtr));
+  CUDACHECK_TEST(cudaStreamDestroy(stream));
+}
+#endif


### PR DESCRIPTION
Summary:
When a CUDA graph captures a GPE operation, a cmdCbPlan struct (16 bytes)
is heap-allocated to hold the host callback data (cmd + gpe pointers).
This plan is passed to cudaLaunchHostFunc as callback data. When the
graph is destroyed, cmdDestroy (the cudaUserObject callback) frees the
cmd but never frees the plan — leaking 16+ bytes per graph capture.

Fix: store the plan pointer in CtranGpeCmd::cbPlan. cmdDestroy frees it
alongside the cmd. Added cmdCbPlan constructor/destructor with a static
atomic counter for leak detection in tests.

Also adds CtranGpe::liveCbPlanCount() accessor and a unit test that
captures+destroys 10000 graphs and verifies no plans are leaked.

Differential Revision: D96607193


