### PR TITLE
Triton alltoallv_dynamic: GPU-initiated variable-length zero-copy all-to-all collective

### DIFF
--- a/comms/ncclx/v2_28/src/transport/gdaki/doca-gpunetio/src/doca_gpunetio.cpp
+++ b/comms/ncclx/v2_28/src/transport/gdaki/doca-gpunetio/src/doca_gpunetio.cpp
@@ -551,7 +551,12 @@ doca_error_t doca_gpu_verbs_export_uar(uint64_t *sq_db, uint64_t **uar_addr_gpu)
         cudaHostRegisterPortable | cudaHostRegisterMapped | cudaHostRegisterIoMemory);
     if (cuda_status == cudaSuccess)
         registered = true;
-    else if (cuda_status != cudaErrorHostMemoryAlreadyRegistered) {
+    else if (cuda_status == cudaErrorHostMemoryAlreadyRegistered) {
+        // Clear the sticky CUDA error to prevent it from affecting subsequent CUDA calls.
+        // cudaHostRegister sets the CUDA runtime error state even when we handle
+        // the "already registered" case gracefully.
+        cudaGetLastError();
+    } else {
         DOCA_LOG(LOG_ERR,
                  "Function cudaHostRegister (err %d) "
                  "failed on addr %p size %d",

--- a/comms/pipes/collectives/triton/__init__.py
+++ b/comms/pipes/collectives/triton/__init__.py
@@ -1,0 +1,49 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# pyre-unsafe
+"""
+Pipes Triton Collectives Module.
+
+This module provides device-initiated collective operations implemented
+using TorchComms Triton APIs. These collectives run entirely on GPU
+without CPU involvement in the data path.
+
+Available Collectives:
+    device_alltoallv_dynamic: AlltoAllv with GPU-resident counts
+
+High-level API (recommended — MSL-compatible signature):
+    AlltoallvOp: Token-level alltoallv with internal buffer management
+
+Helpers:
+    alloc_comms_buffer: Transport-compatible buffer allocation helper
+
+Key Feature: GPU-Resident Counts
+--------------------------------
+Unlike traditional CPU-initiated collectives where counts must be known on
+the host before launch, these implementations read counts directly from GPU
+memory. This enables fused compute + communication pipelines without CPU
+roundtrips.
+"""
+
+from comms.pipes.collectives.triton.alltoallv_op import AlltoallvOp
+from comms.pipes.collectives.triton.device_alltoallv_dynamic import (
+    auto_tune_alltoallv_params,
+    compute_offsets_from_sizes,
+    device_alltoallv_dynamic,
+    exchange_offsets,
+    prewarm_completion_counters,
+)
+from comms.pipes.collectives.triton.utils import alloc_comms_buffer
+
+
+__all__ = [
+    # High-level API (recommended — MSL-compatible signature)
+    "AlltoallvOp",
+    # Helpers
+    "alloc_comms_buffer",
+    # Raw collective APIs
+    "device_alltoallv_dynamic",
+    "auto_tune_alltoallv_params",
+    "compute_offsets_from_sizes",
+    "exchange_offsets",
+    "prewarm_completion_counters",
+]

--- a/comms/pipes/collectives/triton/alltoallv_op.py
+++ b/comms/pipes/collectives/triton/alltoallv_op.py
@@ -1,0 +1,965 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# pyre-unsafe
+"""High-level alltoallv operation with MSL-compatible signature.
+
+``AlltoallvOp`` provides a simplified API matching the MSL ``all_to_all_op``
+signature while preserving the zero-copy one-sided-put architecture of
+the underlying ``device_alltoallv_dynamic`` kernel.
+
+Output Layout
+-------------
+The output is always returned in **packed uniform layout**:
+    - Shape: ``(sum(output_split_sizes), D)``
+    - Contiguous: ``[peer_0_data, peer_1_data, ..., peer_{W-1}_data]``
+    - Zero-copy view of internal buffer (no gather kernel needed)
+
+**IMPORTANT**: Only uniform distribution is supported. All peers must send
+exactly ``max_recv_tokens_per_peer`` tokens. Non-uniform distributions will
+raise a ``ValueError``.
+
+Internally, data lands in fixed-slot positions in the receive buffer
+(one slot per peer). For uniform distribution, slots are back-to-back,
+so the output is directly a view of the contiguous buffer.
+
+Internally it:
+
+* Pre-allocates transport-compatible send/recv buffers sized to the caller's
+  declared maximum token count.
+* Registers those buffers once during ``setup()`` (create window, enable GIN).
+* Uses **fixed-slot** recv buffer layout — one contiguous slot of
+  ``max_recv_tokens_per_peer`` rows per peer — so that destination
+  offsets are deterministic and computed locally (no exchange needed).
+* Converts token-level split sizes to byte-level sizes/offsets per call
+  with zero CPU↔GPU synchronisation and zero per-call collectives.
+
+Two usage patterns are supported:
+
+Copy-in mode (simple)::
+
+    op = AlltoallvOp(comm, max_input_tokens=1024, D=4096,
+                     dtype=torch.bfloat16, device="cuda:0")
+    with op:
+        output = op.alltoallv(input_tensor, output_split_sizes,
+                              input_split_sizes)
+        # output is contiguous: shape (sum(output_split_sizes), D)
+
+Zero-copy mode (maximum performance)::
+
+    op = AlltoallvOp(comm, max_input_tokens=1024, D=4096,
+                     dtype=torch.bfloat16, device="cuda:0")
+    with op:
+        send_buf = op.get_send_buffer(num_tokens=512)
+        # Fill send_buf directly (e.g. from a gather / routing kernel)
+        send_buf[:] = my_data
+        output = op.alltoallv_from_buffer(output_split_sizes,
+                                          input_split_sizes,
+                                          num_input_tokens=512)
+        # output is contiguous: shape (sum(output_split_sizes), D)
+
+CUDA Graph Support
+------------------
+AlltoallvOp is fully CUDA graph compatible. The iteration counter and
+cross-rank synchronization are handled internally via device-side kernels
+that get captured in the graph. Simply call ``graph.replay()`` - no special
+wrapper method needed!
+
+CUDA Graph Usage Example::
+
+    op = AlltoallvOp(comm, max_input_tokens, D, dtype, device)
+    with op:
+        send_buf = op.get_send_buffer(max_input_tokens)
+
+        # Warmup (uses iteration 0)
+        send_buf[:] = warmup_data
+        op.alltoallv_from_buffer(output_splits, input_splits,
+                                 num_input_tokens=max_input_tokens)
+
+        # Capture graph (uses iteration 1 during capture)
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, pool=op.get_graph_pool_id()):
+            output = op.alltoallv_from_buffer(output_splits, input_splits,
+                                              num_input_tokens=max_input_tokens)
+
+        # Replay with different content per iteration
+        # Just use graph.replay() - cross-rank sync is in the kernel!
+        for i in range(num_iterations):
+            send_buf[:] = iteration_data[i]
+            graph.replay()  # Internal device-side sync + iteration advancement
+            # Output is valid here
+
+Output lifetime
+---------------
+The returned tensor is a **view** of the internal pre-registered receive
+buffer. It remains valid until the next ``alltoallv`` / ``alltoallv_from_buffer``
+call. If the caller needs the data to persist beyond that point it must
+``.clone()`` the output.
+"""
+
+from typing import Any, Optional, TYPE_CHECKING, Union
+
+import torch
+import triton  # @manual
+import triton.language as tl  # @manual
+from comms.pipes.collectives.triton.device_alltoallv_dynamic import (
+    auto_tune_alltoallv_params,
+    device_alltoallv_dynamic,
+)
+from comms.pipes.collectives.triton.utils import alloc_comms_buffer
+
+
+# =============================================================================
+# GIN-safe Triton kernels
+# =============================================================================
+
+
+@triton.jit
+def _triton_copy_1d_kernel(src_ptr, dst_ptr, N, BLOCK_SIZE: tl.constexpr):
+    """Copy N elements from src to dst.  GIN-safe (pure device stores)."""
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < N
+    data = tl.load(src_ptr + offsets, mask=mask)
+    tl.store(dst_ptr + offsets, data, mask=mask)
+
+
+@triton.jit
+def _sum_int64_kernel(input_ptr, output_ptr, N: tl.constexpr):
+    """GIN-safe kernel to compute sum of int64 tensor."""
+    offsets = tl.arange(0, N)
+    vals = tl.load(input_ptr + offsets)
+    total = tl.sum(vals, axis=0)
+    tl.store(output_ptr, total)
+
+
+@triton.jit
+def _prepare_alltoallv_kernel(
+    input_splits_ptr,
+    output_splits_ptr,
+    row_bytes,
+    send_sizes_ptr,
+    send_offsets_ptr,
+    recv_sizes_ptr,
+    W,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Token splits → byte sizes/offsets.  Single-block, GIN-safe.
+
+    Performs two operations entirely on GPU in one kernel launch:
+    1. Multiply token counts by ``row_bytes`` to get byte sizes.
+    2. Exclusive prefix sum of send byte sizes → contiguous send offsets.
+    """
+    idxs = tl.arange(0, BLOCK_SIZE)
+    mask = idxs < W
+
+    # Token counts → byte sizes
+    input_splits = tl.load(input_splits_ptr + idxs, mask=mask, other=0)
+    send_sizes = input_splits * row_bytes
+    tl.store(send_sizes_ptr + idxs, send_sizes, mask=mask)
+
+    output_splits = tl.load(output_splits_ptr + idxs, mask=mask, other=0)
+    recv_sizes = output_splits * row_bytes
+    tl.store(recv_sizes_ptr + idxs, recv_sizes, mask=mask)
+
+    # Exclusive prefix sum for contiguous send offsets
+    cumsum = tl.cumsum(send_sizes, axis=0)
+    send_offsets = cumsum - send_sizes
+    tl.store(send_offsets_ptr + idxs, send_offsets, mask=mask)
+
+
+if TYPE_CHECKING:
+    from torchcomms import TorchComm
+
+
+__all__ = [
+    "AlltoallvOp",
+]
+
+
+class AlltoallvOp:
+    """High-level alltoallv operation with an MSL-compatible signature.
+
+    Encapsulates buffer allocation, registration, and byte-level plumbing
+    behind a token-level API.
+    behind a token-level API.  The caller works exclusively in token counts and
+    2-D ``(T, D)`` tensors; the op handles the conversion to byte sizes /
+    offsets internally.
+
+    Buffer layout
+    ~~~~~~~~~~~~~
+    * **Send buffer** — flat, contiguously packed:
+      ``[tokens_for_peer_0, tokens_for_peer_1, …]``.  ``send_offsets`` are
+      computed as the exclusive prefix sum of per-peer byte sizes each call.
+    * **Receive buffer** — fixed-slot:
+      ``[slot_0, slot_1, …, slot_{W-1}]`` where each slot is exactly
+      ``max_recv_tokens_per_peer * D`` elements.  Data from peer *i* always
+      lands at slot *i*.  This makes ``dst_offsets`` (the offsets the *sender*
+      writes to on the *receiver's* buffer) fully deterministic and
+      computable locally (no exchange needed).
+
+    Parameters
+    ----------
+    comm : TorchComm
+        TorchComms communicator.  All ranks in this communicator participate
+        in the collective.
+    max_input_tokens : int
+        Maximum total input tokens (rows in the input tensor) that any single
+        call will ever pass.  This determines the size of the send buffer.
+        **All ranks MUST use the same value.**
+    D : int
+        Hidden dimension (number of columns per token row).  Must be constant
+        across all calls.
+    dtype : torch.dtype
+        Element data type (e.g. ``torch.bfloat16``).
+    device : str | torch.device
+        CUDA device (e.g. ``"cuda:0"``).
+    max_recv_tokens_per_peer : int
+        Maximum tokens that can be received from any single peer.  This
+        determines the size of each slot in the receive buffer.  For uniform
+        distribution workloads where each peer sends equal amounts, this
+        should be set to ``max_input_tokens // world_size``.
+        **All ranks MUST use the same value.**
+
+    Notes
+    -----
+    * The op auto-tunes kernel parameters (``blocks_per_peer``,
+      ``num_warps``, ``chunk_size``) per call based on the maximum per-peer
+      message size.
+    * The iteration counter is auto-incremented after every collective call.
+      Do **not** mix raw ``device_alltoallv_dynamic`` calls on the same
+      window — signal counters will diverge and cause deadlocks.
+    """
+
+    # Module-level cache: one AlltoallvOp per unique configuration.
+    _CACHE: dict[tuple, "AlltoallvOp"] = {}
+
+    def __init__(
+        self,
+        comm: "TorchComm",
+        max_input_tokens: int,
+        D: int,
+        dtype: torch.dtype,
+        device: Union[str, torch.device],
+        max_recv_tokens_per_peer: int,
+        sync_buffer: bool = True,
+    ) -> None:
+        """Initialize AlltoallvOp.
+
+        Args:
+            comm: TorchComm communicator.
+            max_input_tokens: Maximum total input tokens (sum across all peers).
+            D: Hidden dimension.
+            dtype: Data type.
+            device: CUDA device.
+            max_recv_tokens_per_peer: Maximum tokens receivable from each peer.
+                For uniform distribution, this should be ``max_input_tokens // world_size``.
+                **All ranks MUST use the same value.** This is a required parameter
+                because only uniform distribution is supported.
+            sync_buffer: If True (default), enables BUFFER_READY cross-rank
+                synchronization for safe buffer reuse across iterations. This is
+                REQUIRED when:
+                - Using CUDA graph capture with multiple iterations (graph or non-graph)
+                - Replaying CUDA graphs multiple times with the same recv_buf
+                - Any scenario where recv_buf is reused without explicit host sync
+
+                Without this flag, a fast sender on rank A could overwrite the
+                recv_buf on rank B before rank B has finished reading iteration N-1's
+                data, causing data corruption.
+
+                The protocol works by having receivers signal BUFFER_READY at the
+                start of iteration N (indicating iteration N-1 is complete), and
+                senders wait for this signal before sending iteration N's data.
+
+                Adds ~1-3us per-peer latency overhead. Set to False only for
+                microbenchmarking raw kernel throughput without synchronization.
+        """
+        self.comm = comm
+        self.rank: int = comm.get_rank()
+        self.world_size: int = comm.get_size()
+        self.max_input_tokens = max_input_tokens
+        self.D = D
+        self.dtype = dtype
+        self.device = device
+        self.sync_buffer = sync_buffer
+        self._setup_done = False
+
+        # max_recv_tokens_per_peer is required - uniform distribution only.
+        # Typically set to max_input_tokens // world_size.
+        self.max_recv_tokens_per_peer: int = max_recv_tokens_per_peer
+
+        self._elem_bytes: int = torch.tensor([], dtype=dtype).element_size()
+        # Bytes per token row: D elements × element_size
+        self._bytes_per_token: int = D * self._elem_bytes
+
+        # Fixed slot size per peer in the receive buffer (bytes).
+        # Each peer's data lands in a slot of max_recv_tokens_per_peer × D elements.
+        self._bytes_per_peer_slot: int = (
+            max_recv_tokens_per_peer * self._bytes_per_token
+        )
+
+        # -----------------------------------------------------------------
+        # Allocate transport-compatible buffers
+        # -----------------------------------------------------------------
+        backend: str = comm.get_backend()
+
+        # Send buffer: contiguously packed, holds up to max_input_tokens rows.
+        max_input_elems = max_input_tokens * D
+        self.send_buf, self._send_pool = alloc_comms_buffer(
+            max_input_elems, dtype, device, backend
+        )
+
+        # Receive buffer: fixed-slot layout, one slot per peer.
+        # Each slot holds max_recv_tokens_per_peer tokens.
+        recv_total_elems = self.world_size * max_recv_tokens_per_peer * D
+        self.recv_buf, self._recv_pool = alloc_comms_buffer(
+            recv_total_elems, dtype, device, backend
+        )
+
+        # Compute recv_offsets: fixed slot layout where peer i's data lands at slot i.
+        # Data lands in slotted positions internally; we run a local gather kernel
+        # to pack it contiguously when returning to the caller.
+        #
+        # Naming clarification:
+        #   _local_recv_slot_offsets: Receiver's view - offsets within MY local
+        #       recv buffer where each peer's data lands
+        #   _remote_write_offsets: Sender's view - offsets on REMOTE peers'
+        #       recv buffers where I should write my data
+        self._local_recv_slot_offsets = (
+            torch.arange(self.world_size, dtype=torch.int64, device=device)
+            * self._bytes_per_peer_slot
+        )
+
+        # Internal state tensors (byte-level sizes/offsets for the kernel).
+        # These are written by _prepare_alltoallv_kernel and read by
+        # device_alltoallv_dynamic. They persist across calls, enabling
+        # automatic skip of the prep kernel when split sizes are static.
+        self._send_sizes_bytes: Optional[torch.Tensor] = torch.empty(
+            self.world_size, dtype=torch.int64, device=device
+        )
+        self._send_offsets_bytes: Optional[torch.Tensor] = torch.empty(
+            self.world_size, dtype=torch.int64, device=device
+        )
+        self._recv_sizes_bytes: Optional[torch.Tensor] = torch.empty(
+            self.world_size, dtype=torch.int64, device=device
+        )
+
+        # Flag to track if prep kernel has run since setup().
+        # Used for auto-skipping prep on subsequent calls with static splits.
+        self._prep_done: bool = False
+
+        # Pre-allocate buffer for total tokens sum (GIN-safe operation).
+        # Must be allocated before GIN is activated.
+        self._total_tokens_buf = torch.empty(1, dtype=torch.int64, device=device)
+
+        # BLOCK_SIZE for the preparation kernel (next power-of-2 of world_size).
+        self._prep_block_size: int = triton.next_power_of_2(self.world_size)
+
+        # Auto-tune: select kernel params once from the worst-case message
+        # size (all max_input_tokens routed to a single peer).  This avoids
+        # per-call GPU→CPU synchronisation (.item()) and keeps the hot path
+        # entirely on GPU.
+        worst_case_msg_bytes = max_input_tokens * self._bytes_per_token
+        params = auto_tune_alltoallv_params(worst_case_msg_bytes)
+        self._blocks_per_peer: int = params["blocks_per_peer"]
+        self._num_warps: int = params["num_warps"]
+        self._chunk_size: int = params["chunk_size"]
+
+        # Internal comms state (populated by setup()).
+        self._window: Any = None
+        self._dev_win_ptr: Optional[int] = None
+        self._src_info: Optional[tuple[int, int, int]] = None
+        self._remote_write_offsets: Optional[torch.Tensor] = None
+
+    # ------------------------------------------------------------------
+    # Factory / caching
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def get_or_create(
+        cls,
+        comm: "TorchComm",
+        max_input_tokens: int,
+        D: int,
+        dtype: torch.dtype,
+        device: Union[str, torch.device],
+        max_recv_tokens_per_peer: int,
+        sync_buffer: bool = True,
+    ) -> "AlltoallvOp":
+        """Get or create a cached ``AlltoallvOp`` for the given parameters.
+
+        The op is cached by communicator identity and buffer dimensions.
+        If a matching op already exists it is returned; otherwise a new one
+        is created and ``setup()`` is called automatically.
+
+        Args:
+            comm: TorchComms communicator.
+            max_input_tokens: Maximum total input tokens per call.
+            D: Hidden dimension.
+            dtype: Tensor dtype.
+            device: CUDA device.
+            max_recv_tokens_per_peer: Maximum tokens receivable from each peer.
+                For uniform distribution, this should be ``max_input_tokens // world_size``.
+            sync_buffer: If True, enables buffer-ready synchronization.
+
+        Returns:
+            A set-up ``AlltoallvOp`` ready for ``alltoallv`` calls.
+        """
+        key = (
+            id(comm),
+            max_input_tokens,
+            D,
+            dtype,
+            str(device),
+            max_recv_tokens_per_peer,
+            sync_buffer,
+        )
+        if key not in cls._CACHE:
+            op = cls(
+                comm,
+                max_input_tokens,
+                D,
+                dtype,
+                device,
+                max_recv_tokens_per_peer=max_recv_tokens_per_peer,
+                sync_buffer=sync_buffer,
+            )
+            op.setup()
+            cls._CACHE[key] = op
+        return cls._CACHE[key]
+
+    @classmethod
+    def clear_cache(cls) -> None:
+        """Teardown and remove all cached ``AlltoallvOp`` instances."""
+        for op in cls._CACHE.values():
+            op.teardown()
+        cls._CACHE.clear()
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def setup(self) -> None:
+        """Perform one-time collective comms setup.
+
+        1. Pre-allocate completion counters (before GIN activation).
+        2. Compute ``dst_offsets`` locally (no exchange needed for slotted
+           layout since all ranks use identical recv_offsets).
+        3. Create a comms window, register the recv buffer, obtain a device
+           window handle, and register the send buffer.
+
+        All ranks MUST call ``setup()`` collectively.
+
+        Raises
+        ------
+        RuntimeError
+            If ``setup()`` is called twice without an intervening
+            ``teardown()``.
+        """
+        if self._window is not None:
+            raise RuntimeError("AlltoallvOp.setup() called twice without teardown()")
+
+        # Reset prep state for new setup cycle.
+        self._prep_done = False
+
+        # Pre-allocate completion counters BEFORE GIN activation.
+        # GIN (GPU-Initiated NCCL) blocks regular CUDA allocations after
+        # get_device_window() is called.
+        from comms.pipes.collectives.triton import prewarm_completion_counters
+
+        # Convert device to torch.device if string
+        device_for_prewarm = (
+            torch.device(self.device) if isinstance(self.device, str) else self.device
+        )
+        # pyre-ignore[6]: device_for_prewarm is always torch.device after the conditional
+        prewarm_completion_counters(self.world_size, device_for_prewarm)
+
+        # Compute dst_offsets locally (same for both slotted and packed).
+        #
+        # All ranks have identical recv_offsets because they all use the same
+        # max_recv_tokens_per_peer and D. Therefore:
+        #   recv_offsets = [0, slot_bytes, 2*slot_bytes, ..., (W-1)*slot_bytes]
+        # dst_offsets[peer] = where MY data lands on PEER's recv buffer
+        #                   = peer's recv_offsets[my_rank]
+        #                   = my_rank * slot_bytes (same for all peers)
+        #
+        # Data always lands in slotted positions. For uniform distribution
+        # (where all peers send max_recv_tokens_per_peer), slots are back-to-back,
+        # so we return a zero-copy view of the contiguous buffer.
+        # Non-uniform distribution is NOT supported.
+        #
+        # _remote_write_offsets[peer] = where MY data lands on PEER's recv buffer
+        #                             = peer's _local_recv_slot_offsets[my_rank]
+        #                             = my_rank * slot_bytes (same for all peers)
+        self._remote_write_offsets = torch.full(
+            (self.world_size,),
+            self.rank * self._bytes_per_peer_slot,
+            dtype=torch.int64,
+            device=self.device,
+        )
+
+        self.comm.barrier(False)
+        self._window = self.comm.new_window()
+
+        # tensor_register maps recv_buf for one-sided operations (collective).
+        self._window.tensor_register(self.recv_buf)
+        self.comm.barrier(False)
+
+        # get_device_window triggers ncclDevCommCreate (enables GIN).
+        # When sync_buffer is enabled, allocate 2x signal slots:
+        # signal_id=0 for DATA_COMPLETE, signal_id=1 for BUFFER_READY
+        signal_count = self.world_size * 2 if self.sync_buffer else self.world_size
+        self._dev_win_ptr = self._window.get_device_window(signal_count=signal_count)
+
+        # register_local_buffer maps send_buf for one-sided puts.
+        self._src_info = self._window.register_local_buffer(self.send_buf)
+
+        # Reset iteration counter to match fresh signal memory state.
+        # Without this, cross-session hangs occur because the iteration counter
+        # persists globally but signal memory is recreated per-window.
+        from comms.pipes.collectives.triton.device_alltoallv_dynamic import (
+            _reset_iteration_counter,
+        )
+
+        _reset_iteration_counter(self.world_size, device_for_prewarm)
+
+    def teardown(self) -> None:
+        """Release comms resources and all buffers.  Safe to call multiple times."""
+        # First deregister comms buffers
+        if self._src_info is not None:
+            self._window.deregister_local_buffer(*self._src_info)
+            self._src_info = None
+        if self._window is not None:
+            self._window.tensor_deregister()
+            self._window = None
+        self._dev_win_ptr = None
+
+        # Release all GPU buffers to free memory immediately.
+        # Without this, Python GC may defer collection and cause OOM.
+        self.send_buf = None
+        self.recv_buf = None
+        self._local_recv_slot_offsets = None
+        self._send_sizes_bytes = None
+        self._send_offsets_bytes = None
+        self._recv_sizes_bytes = None
+        self._total_tokens_buf = None
+        self._remote_write_offsets = None
+
+        # Release MemPools AFTER buffers (buffers use the pools)
+        self._send_pool = None
+        self._recv_pool = None
+
+    def __enter__(self) -> "AlltoallvOp":
+        self.setup()
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self.teardown()
+
+    # ------------------------------------------------------------------
+    # CUDA Graph Support
+    # ------------------------------------------------------------------
+
+    def get_graph_pool_id(self) -> int:
+        """Return the memory pool ID for CUDA graph capture.
+
+        When capturing a CUDA graph that includes ``alltoallv`` calls, pass
+        this pool ID to ``torch.cuda.graph()`` to ensure memory allocations
+        during capture use the same transport-compatible pool.
+
+        **Critical**: Buffer registration must occur BEFORE graph capture.
+        Call ``setup()`` first, then warmup, then capture with this pool.
+
+        Example::
+
+            op = AlltoallvOp(comm, max_input_tokens=1024, D=4096,
+                             dtype=torch.bfloat16, device="cuda:0")
+            with op:
+                # 1. Warmup (compiles kernels, outside graph capture)
+                for _ in range(10):
+                    _ = op.alltoallv(input_tensor, output_splits, input_splits)
+                torch.cuda.synchronize()
+
+                # 2. Capture graph using op's memory pool
+                graph = torch.cuda.CUDAGraph()
+                with torch.cuda.graph(graph, pool=op.get_graph_pool_id()):
+                    _ = op.alltoallv(input_tensor, output_splits, input_splits,
+                                     packed_output_tokens=total_tokens)
+
+                # 3. Replay
+                graph.replay()
+
+        Returns:
+            int: The CUDA memory pool ID to pass to ``torch.cuda.graph(pool=...)``.
+        """
+        # Use recv_pool since it's the larger allocation and will be used
+        # for any internal allocations during alltoallv execution.
+        return self._recv_pool.id
+
+    # ------------------------------------------------------------------
+    # Send buffer access (zero-copy path)
+    # ------------------------------------------------------------------
+
+    def get_send_buffer(self, num_tokens: int) -> torch.Tensor:
+        """Return a 2-D view into the registered send buffer for zero-copy writes.
+
+        The returned tensor has shape ``(num_tokens, D)`` and is backed by the
+        pre-registered send buffer.  The caller can fill it directly
+        (e.g. via ``torch.gather(..., out=send_buf)``) and then call
+        :meth:`alltoallv_from_buffer` to perform the collective **without**
+        copying into the send buffer.
+
+        Args:
+            num_tokens: Number of token rows to expose.  Must be
+                ``≤ max_input_tokens``.
+
+        Returns:
+            A ``(num_tokens, D)`` tensor view of the registered send buffer.
+
+        Raises:
+            ValueError: If ``num_tokens > max_input_tokens``.
+
+        Example::
+
+            send_buf = op.get_send_buffer(512)
+            torch.gather(hidden_states, 0,
+                         routed_indices.unsqueeze(1).expand(-1, D),
+                         out=send_buf)
+            output = op.alltoallv_from_buffer(
+                recv_splits, send_splits, num_input_tokens=512)
+        """
+        if num_tokens > self.max_input_tokens:
+            raise ValueError(
+                f"num_tokens ({num_tokens}) exceeds max_input_tokens "
+                f"({self.max_input_tokens})"
+            )
+        return self.send_buf[: num_tokens * self.D].view(num_tokens, self.D)
+
+    def fill_send_buffer(
+        self,
+        input_tensor: torch.Tensor,
+        num_tokens: Optional[int] = None,
+    ) -> torch.Tensor:
+        """Fill the registered send buffer with data from input_tensor (GIN-safe).
+
+        This method uses a Triton kernel internally, making it safe to call
+        after ``setup()`` when GIN (GPU-Initiated NCCL) is active. Regular
+        CUDA operations like ``send_buf[:] = input`` fail after GIN activation
+        because GIN locks GPU memory pages for RDMA access.
+
+        Use this method for back-to-back iterations where you need to update
+        the send buffer contents between collective calls.
+
+        Args:
+            input_tensor: Source tensor of shape ``(N, D)`` or ``(N * D,)``.
+            num_tokens: Number of tokens to copy. If ``None``, inferred from
+                ``input_tensor.shape[0]`` (for 2D) or
+                ``input_tensor.numel() // D`` (for 1D).
+
+        Returns:
+            A ``(num_tokens, D)`` view of the send buffer containing the
+            copied data.
+
+        Raises:
+            ValueError: If ``num_tokens > max_input_tokens``.
+            RuntimeError: If ``input_tensor`` has fewer elements than required.
+
+        Example (back-to-back iterations)::
+
+            op = AlltoallvOp(comm, max_input_tokens, D, dtype, device)
+            with op:
+                for iteration in range(num_iters):
+                    # Compute new data each iteration (e.g., from a Triton kernel)
+                    input_data = compute_tokens_to_send()
+
+                    # Fill send buffer (GIN-safe) and call collective
+                    op.fill_send_buffer(input_data)
+                    output = op.alltoallv_from_buffer(
+                        output_split_sizes, input_split_sizes,
+                        num_input_tokens=num_tokens
+                    )
+        """
+        # Infer num_tokens from input shape if not provided
+        if num_tokens is None:
+            if input_tensor.dim() == 2:
+                num_tokens = input_tensor.shape[0]
+            else:
+                num_tokens = input_tensor.numel() // self.D
+
+        if num_tokens > self.max_input_tokens:
+            raise ValueError(
+                f"num_tokens ({num_tokens}) exceeds max_input_tokens "
+                f"({self.max_input_tokens})"
+            )
+
+        # Validate input tensor size
+        expected_elems = num_tokens * self.D
+        if input_tensor.numel() < expected_elems:
+            raise RuntimeError(
+                f"input_tensor has {input_tensor.numel()} elements but "
+                f"num_tokens={num_tokens} requires {expected_elems} elements"
+            )
+
+        # Use GIN-safe Triton copy kernel
+        n_elems = num_tokens * self.D
+        grid = (triton.cdiv(n_elems, 1024),)
+        _triton_copy_1d_kernel[grid](
+            input_tensor.reshape(-1),
+            self.send_buf,
+            n_elems,
+            # pyre-fixme[6]: Triton constexpr accepts int at runtime
+            BLOCK_SIZE=1024,
+        )
+
+        return self.send_buf[:n_elems].view(num_tokens, self.D)
+
+    # ------------------------------------------------------------------
+    # Public collective calls
+    # ------------------------------------------------------------------
+
+    def alltoallv(
+        self,
+        input_tensor: torch.Tensor,
+        output_split_sizes: torch.Tensor,
+        input_split_sizes: torch.Tensor,
+        packed_output_tokens: Optional[int] = None,
+        skip_prep: Optional[bool] = None,
+    ) -> torch.Tensor:
+        """Perform alltoallv collective.
+
+        Args:
+            input_tensor: Token tensor ``(N, D)`` where ``N ≤ max_input_tokens``.
+            output_split_sizes: int64 tensor ``[world_size]`` — per-peer
+                token counts to receive.
+            input_split_sizes: int64 tensor ``[world_size]`` — per-peer
+                token counts to send.
+            packed_output_tokens: Pre-computed total output tokens. If provided,
+                avoids a GPU→CPU sync (``.item()`` call) to sum output_split_sizes.
+                Required for CUDA graph capture.
+            skip_prep: Controls whether to skip the prep kernel:
+                 - ``None`` (default): Auto-detect. Runs prep on first call after
+                   setup(), skips on subsequent calls. Best for
+                   static splits (typical MoE scenario).
+                 - ``True``: Always skip. User guarantees sizes/offsets are valid.
+                 - ``False``: Always run. Use when split sizes change between calls.
+
+        Returns:
+            ``(sum(output_split_sizes), D)`` packed tensor. Only uniform
+            distribution is supported (all peers send exactly
+            ``max_recv_tokens_per_peer`` tokens).
+        """
+        self._ensure_setup()
+        iT = input_tensor.shape[0]
+        if iT > self.max_input_tokens:
+            raise ValueError(
+                f"input_tensor has {iT} rows but max_input_tokens is "
+                f"{self.max_input_tokens}"
+            )
+
+        # Copy into the pre-registered send buffer using a Triton kernel.
+        # Regular CUDA copy (tensor.copy_) fails when GIN is active
+        # (cudaErrorHostMemoryAlreadyRegistered).  Triton kernels use
+        # device-side loads/stores that are GIN-safe.
+        n_elems = iT * self.D
+        grid = (triton.cdiv(n_elems, 1024),)
+        _triton_copy_1d_kernel[grid](
+            input_tensor.reshape(-1),
+            self.send_buf,
+            n_elems,
+            # pyre-fixme[6]: Triton constexpr accepts int at runtime
+            BLOCK_SIZE=1024,
+        )
+
+        return self._run_alltoallv(
+            output_split_sizes,
+            input_split_sizes,
+            packed_output_tokens,
+            skip_prep,
+        )
+
+    def alltoallv_from_buffer(
+        self,
+        output_split_sizes: torch.Tensor,
+        input_split_sizes: torch.Tensor,
+        num_input_tokens: int,
+        packed_output_tokens: Optional[int] = None,
+        skip_prep: Optional[bool] = None,
+    ) -> torch.Tensor:
+        """Perform alltoallv using data already in the send buffer.
+
+        The caller must have previously obtained the send buffer via
+        :meth:`get_send_buffer` and filled it with data.  This method skips
+        the ``copy_`` into the send buffer, achieving **true zero-copy**
+        end-to-end.
+
+        Args:
+            output_split_sizes: int64 tensor ``[world_size]`` — per-peer
+                token counts to receive.
+            input_split_sizes: int64 tensor ``[world_size]`` — per-peer
+                token counts to send.
+            num_input_tokens: Number of valid token rows in the send buffer.
+                Must match the ``num_tokens`` passed to
+                :meth:`get_send_buffer`.
+            packed_output_tokens: Pre-computed total output tokens. If provided,
+                avoids a GPU→CPU sync (``.item()`` call) to sum output_split_sizes.
+                Required for CUDA graph capture.
+            skip_prep: Controls whether to skip the prep kernel:
+                 - ``None`` (default): Auto-detect. Runs prep on first call after
+                   setup(), skips on subsequent calls. Best for
+                   static splits (typical MoE scenario).
+                 - ``True``: Always skip. User guarantees sizes/offsets are valid.
+                 - ``False``: Always run. Use when split sizes change between calls.
+
+        Returns:
+            ``(sum(output_split_sizes), D)`` packed tensor. Only uniform
+            distribution is supported (all peers send exactly
+            ``max_recv_tokens_per_peer`` tokens).
+        """
+        self._ensure_setup()
+        if num_input_tokens > self.max_input_tokens:
+            raise ValueError(
+                f"num_input_tokens={num_input_tokens} exceeds "
+                f"max_input_tokens={self.max_input_tokens}"
+            )
+
+        return self._run_alltoallv(
+            output_split_sizes,
+            input_split_sizes,
+            packed_output_tokens,
+            skip_prep,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _ensure_setup(self) -> None:
+        """Raise if ``setup()`` has not been called."""
+        if self._window is None or self._src_info is None:
+            raise RuntimeError(
+                "AlltoallvOp has not been set up.  "
+                "Call setup() or use the context manager (with statement) first."
+            )
+
+    def _run_alltoallv(
+        self,
+        output_split_sizes: torch.Tensor,
+        input_split_sizes: torch.Tensor,
+        packed_output_tokens: Optional[int] = None,
+        skip_prep: Optional[bool] = None,
+    ) -> torch.Tensor:
+        """Shared kernel-launch logic for both copy-in and zero-copy paths.
+
+        Args:
+            output_split_sizes: Per-peer token counts to receive.
+            input_split_sizes: Per-peer token counts to send.
+            packed_output_tokens: Total output tokens for packed mode.
+            skip_prep: Controls whether to skip the _prepare_alltoallv_kernel:
+                - None (default): Auto-detect. Runs prep on first call after
+                  setup(), skips on subsequent calls. Best for static splits
+                  (typical MoE scenario).
+                - True: Always skip. User guarantees sizes/offsets are valid.
+                - False: Always run. Use when split sizes change between calls.
+
+        Note:
+            Cached byte sizes/offsets are stored in:
+            - self._send_sizes_bytes: byte sizes for sending to each peer
+            - self._send_offsets_bytes: byte offsets into send buffer
+            - self._recv_sizes_bytes: byte sizes for receiving from each peer
+            These persist across calls and are computed by _prepare_alltoallv_kernel.
+        """
+        # Determine whether to run prep kernel.
+        # Auto-detect: skip if prep has already run since setup().
+        should_run_prep = (skip_prep is None and not self._prep_done) or (
+            skip_prep is False
+        )
+
+        if should_run_prep:
+            # Single Triton kernel: token splits → byte sizes and contiguous
+            # offsets.  Entirely GPU-side, no CUDA runtime calls (GIN-safe).
+            _prepare_alltoallv_kernel[(1,)](
+                input_split_sizes,
+                output_split_sizes,
+                self._bytes_per_token,
+                self._send_sizes_bytes,
+                self._send_offsets_bytes,
+                self._recv_sizes_bytes,
+                self.world_size,
+                # pyre-fixme[6]: Triton constexpr accepts int at runtime
+                BLOCK_SIZE=self._prep_block_size,
+            )
+            self._prep_done = True
+
+        assert self._dev_win_ptr is not None
+        assert self._src_info is not None
+        assert self._remote_write_offsets is not None
+        assert self._send_sizes_bytes is not None
+        assert self._send_offsets_bytes is not None
+        assert self._recv_sizes_bytes is not None
+
+        device_alltoallv_dynamic(
+            self.send_buf,
+            self.recv_buf,
+            self._send_sizes_bytes,
+            self._send_offsets_bytes,
+            self._recv_sizes_bytes,
+            self._local_recv_slot_offsets,
+            self._remote_write_offsets,
+            self._dev_win_ptr,
+            self._src_info,
+            self.rank,
+            self.world_size,
+            auto_tune=False,
+            blocks_per_peer=self._blocks_per_peer,
+            num_warps=self._num_warps,
+            chunk_size=self._chunk_size,
+            sync_buffer=self.sync_buffer,
+        )
+
+        # NOTE: Iteration counter is now managed internally by
+        # device_alltoallv_dynamic, which auto-increments after each call.
+        # Cross-rank synchronization is handled via the BUFFER_READY
+        # signal/wait protocol. At each iteration N > 0, senders wait for
+        # BUFFER_READY=N from receivers before sending. Receivers signal
+        # BUFFER_READY=N at the start of iteration N. This naturally chains
+        # iterations across ranks without requiring an explicit barrier.
+
+        # Return a 2-D view of the receive buffer with fixed-slot layout.
+        # Each slot has max_recv_tokens_per_peer rows, regardless of actual data.
+        # Shape: (world_size * max_recv_tokens_per_peer, D)
+        slotted_output = self.recv_buf.view(
+            self.world_size * self.max_recv_tokens_per_peer, self.D
+        )
+
+        # Packed output: For uniform distribution (where each peer sends
+        # exactly max_recv_tokens_per_peer), data lands contiguously because
+        # slots are back-to-back with no gaps. We return a direct view.
+        #
+        # Non-uniform distribution is NOT supported and will raise an error.
+
+        # Determine total tokens
+        if packed_output_tokens is not None:
+            total_tokens = packed_output_tokens
+        else:
+            # Sum using GIN-safe kernel to avoid CUDA error when GIN is active
+            _sum_int64_kernel[(1,)](
+                output_split_sizes,
+                self._total_tokens_buf,
+                # pyre-fixme[6]: Triton constexpr accepts int at runtime
+                N=self.world_size,
+            )
+            total_tokens = int(self._total_tokens_buf.item())
+
+        # Check if distribution is uniform (all peers send max_recv_tokens_per_peer)
+        # For uniform distribution, slots are back-to-back, so slotted = packed.
+        expected_uniform_total = self.world_size * self.max_recv_tokens_per_peer
+        if total_tokens != expected_uniform_total:
+            raise ValueError(
+                f"Non-uniform distribution not supported. "
+                f"Expected total tokens: {expected_uniform_total} "
+                f"(world_size={self.world_size} × "
+                f"max_recv_tokens_per_peer={self.max_recv_tokens_per_peer}), "
+                f"but got: {total_tokens}. "
+                f"All peers must send exactly max_recv_tokens_per_peer tokens."
+            )
+
+        # Uniform distribution: return direct view (zero-copy)
+        return slotted_output[:total_tokens]

--- a/comms/pipes/collectives/triton/device_alltoallv_dynamic.py
+++ b/comms/pipes/collectives/triton/device_alltoallv_dynamic.py
@@ -1,0 +1,860 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# pyre-unsafe
+"""
+Device-initiated AlltoAllv Dynamic implementation using TorchComms Triton APIs.
+
+This module provides GPU-initiated alltoallv collectives with DYNAMIC per-rank
+counts that perform all-to-all communication with variable message sizes
+directly from Triton kernels without CPU involvement.
+
+Simplified Wrapper (Recommended)
+--------------------------------
+For most users, the ``AlltoallvOp`` wrapper provides a much simpler,
+token-level API that handles buffer registration and iteration tracking
+automatically (no offset exchange needed due to fixed-slot layout)::
+
+    from comms.pipes.collectives.triton import AlltoallvOp
+
+    op = AlltoallvOp(comm, max_input_tokens=1024, D=4096,
+                     dtype=torch.bfloat16, device="cuda:0")
+    with op:
+        output = op.alltoallv(input_tensor, output_split_sizes,
+                              input_split_sizes)
+
+See ``AlltoallvOp`` for full documentation.
+
+Key Feature: GPU-Resident Counts
+---------------------------------
+Unlike traditional CPU-initiated alltoallv where send counts must be known on
+the host before launch, this implementation reads send/receive counts directly
+from GPU memory. This enables:
+
+1. Fused compute + communication: A preceding kernel can compute how much data
+   to send to each peer, store counts in GPU memory, and this kernel reads them
+   directly - no CPU roundtrip needed.
+
+2. Dynamic workloads: Supports workloads where message sizes are data-dependent
+   (e.g., sparse operations, filtering, load balancing, MoE token routing).
+
+3. Zero CPU involvement: The entire compute→count→communicate pipeline stays
+   on GPU, eliminating synchronization overhead.
+
+Raw API Usage (Advanced):
+    # 1. Compute phase (preceding kernel computes variable counts)
+    compute_kernel[grid](data, send_counts_gpu, send_offsets_gpu)
+
+    # 2. Communication phase (reads counts from GPU, no CPU copy)
+    device_alltoallv_dynamic(
+        send_buf, recv_buf,
+        send_counts_gpu,    # GPU tensor - read directly by kernel
+        send_offsets_gpu,   # GPU tensor - read directly by kernel
+        recv_counts_gpu,
+        recv_offsets_gpu,
+        comm, window
+    )
+"""
+
+from typing import TYPE_CHECKING
+
+import torch
+import triton  # @manual
+import triton.language as tl  # @manual
+from torchcomms.triton.fb import (
+    flush_block,
+    put_block_direct,
+    put_warp_chunked_direct,
+    requires_torchcomms,
+    self_copy_block,
+    signal_block,
+    wait_signal_from,
+)
+
+
+if TYPE_CHECKING:
+    from torchcomms import TorchComm
+
+
+__all__ = [
+    "device_alltoallv_dynamic",
+    "auto_tune_alltoallv_params",
+    "compute_offsets_from_sizes",
+    "exchange_offsets",
+    "prewarm_completion_counters",
+]
+
+
+# =============================================================================
+# Internal Iteration Tensor Cache
+# =============================================================================
+
+
+# Pre-allocated iteration tensor cache to track iteration count per
+# (device, world_size) pair. This is managed internally - users don't need
+# to create or manage iteration tensors.
+_ITERATION_TENSOR_CACHE: dict = {}
+
+
+def _get_iteration_tensor(world_size: int, device: torch.device) -> torch.Tensor:
+    """Return a cached int32 scalar tensor for iteration counting.
+
+    The tensor is allocated once on first use and reused across all
+    subsequent calls. The iteration value grows monotonically.
+
+    IMPORTANT: This must be called BEFORE GIN (GPU-Initiated NCCL) is
+    activated via get_device_window(). Once GIN is active, regular CUDA
+    allocations fail with cudaErrorHostMemoryAlreadyRegistered.
+    """
+    key = (device, world_size)
+    if key not in _ITERATION_TENSOR_CACHE:
+        _ITERATION_TENSOR_CACHE[key] = torch.zeros(1, dtype=torch.int32, device=device)
+    return _ITERATION_TENSOR_CACHE[key]
+
+
+def _reset_iteration_counter(world_size: int, device: torch.device) -> None:
+    """Reset the iteration counter to zero for a given (device, world_size) pair.
+
+    This is an internal function called automatically by AlltoallvOp.setup().
+    It MUST be called when creating a new window (after get_device_window())
+    to ensure the iteration counter matches the fresh signal memory state.
+
+    Without this reset, cross-session hangs occur:
+    1. Session1 runs with iteration counter 0, signals BUFFER_READY(1)
+    2. Session1 teardown destroys window (signal memory freed)
+    3. Session2 creates new window (fresh signal memory = 0)
+    4. Iteration counter is still 1 (global, not reset)
+    5. Session2's send block waits for BUFFER_READY(1) from signal memory that's 0
+    6. HANG!
+
+    The iteration counter and signal memory must be synchronized:
+    - When signal memory is fresh (new window), iteration counter must be 0
+    - This ensures send blocks don't wait for signals from "previous iterations"
+      that were actually in a different window's signal memory
+
+    Note: This function uses a GIN-safe Triton kernel to reset the counter,
+    so it's safe to call after GIN is activated.
+
+    Args:
+        world_size: Number of ranks in the communicator.
+        device: CUDA device where the iteration tensor is stored.
+    """
+    key = (device, world_size)
+    if key in _ITERATION_TENSOR_CACHE:
+        # Use a GIN-safe kernel to reset the counter
+        _fill_int32_kernel[(1,)](_ITERATION_TENSOR_CACHE[key], 0, N=1)
+
+
+@requires_torchcomms
+@triton.jit
+def _increment_iteration_kernel(iteration_ptr):
+    """Increment the iteration counter tensor by 1.
+
+    This kernel is called after each alltoallv operation. It gets captured in
+    CUDA graphs, allowing multiple alltoallv calls within a single graph
+    capture to use correct iteration values.
+    """
+    old_val = tl.load(iteration_ptr)
+    tl.store(iteration_ptr, old_val + 1)
+
+
+# =============================================================================
+# Helper: cached completion counters
+# =============================================================================
+
+
+# Pre-allocated completion counters cache to avoid per-call CUDA allocator
+# overhead.  Keyed by (device, world_size) → torch.Tensor(int32).
+_COMPLETION_COUNTERS_CACHE: dict = {}
+
+
+@requires_torchcomms
+@triton.jit
+def _fill_int32_kernel(ptr, value, N: tl.constexpr):
+    """GIN-safe kernel to fill an int32 tensor with a scalar value."""
+    idx = tl.program_id(0)
+    if idx < N:
+        tl.store(ptr + idx, value)
+
+
+@requires_torchcomms
+@triton.jit
+def _fill_completion_counters_from_iteration_kernel(
+    counters_ptr,
+    iteration_ptr,
+    BLOCKS_PER_PEER: tl.constexpr,
+    N: tl.constexpr,
+):
+    """GIN-safe kernel to reset completion counters based on iteration.
+
+    Reads iteration from GPU memory and computes expected_base = BLOCKS_PER_PEER * iteration.
+    This is CUDA graph compatible since iteration is read from GPU, not host.
+    """
+    idx = tl.program_id(0)
+    if idx < N:
+        iteration = tl.load(iteration_ptr)
+        expected_base = BLOCKS_PER_PEER * iteration
+        tl.store(counters_ptr + idx, expected_base)
+
+
+def _fill_completion_counters_gin_safe(
+    counters: torch.Tensor, value: int, world_size: int
+) -> None:
+    """Fill completion counters using a GIN-safe Triton kernel.
+
+    Regular CUDA operations like tensor.fill_() fail when GIN is active
+    (cudaErrorHostMemoryAlreadyRegistered).  This function uses a Triton
+    kernel which only does device-side stores and is GIN-safe.
+    """
+    _fill_int32_kernel[(world_size,)](counters, value, N=world_size)
+
+
+def _fill_completion_counters_from_iteration(
+    counters: torch.Tensor,
+    iteration_tensor: torch.Tensor,
+    blocks_per_peer: int,
+    world_size: int,
+) -> None:
+    """Reset completion counters based on iteration value from GPU tensor.
+
+    This is CUDA graph compatible - reads iteration from GPU memory and
+    computes expected_base = blocks_per_peer * iteration entirely on GPU.
+
+    Args:
+        counters: GPU tensor [world_size] of int32 counters.
+        iteration_tensor: GPU scalar tensor containing iteration count.
+        blocks_per_peer: Number of blocks per peer.
+        world_size: Number of ranks.
+    """
+    _fill_completion_counters_from_iteration_kernel[(world_size,)](
+        counters,
+        iteration_tensor,
+        BLOCKS_PER_PEER=blocks_per_peer,
+        N=world_size,
+    )
+
+
+def _get_completion_counters(world_size: int, device: torch.device) -> torch.Tensor:
+    """Return a cached int32 tensor of shape [world_size] on device.
+
+    The tensor is allocated once (via torch.zeros) on first use and reused
+    across all subsequent calls.  Counters grow monotonically with each
+    iteration (no in-kernel reset) to avoid race conditions with CUDA
+    block scheduling.
+
+    IMPORTANT: This must be called BEFORE GIN (GPU-Initiated NCCL) is
+    activated via get_device_window().  Once GIN is active, regular CUDA
+    allocations fail with cudaErrorHostMemoryAlreadyRegistered.
+    """
+    key = (device, world_size)
+    if key not in _COMPLETION_COUNTERS_CACHE:
+        _COMPLETION_COUNTERS_CACHE[key] = torch.zeros(
+            world_size, dtype=torch.int32, device=device
+        )
+    return _COMPLETION_COUNTERS_CACHE[key]
+
+
+def prewarm_completion_counters(world_size: int, device: torch.device) -> None:
+    """Pre-allocate completion counters and iteration tensor before GIN is activated.
+
+    This function MUST be called BEFORE get_device_window() to avoid CUDA
+    allocation failures when GIN is active.  GIN (GPU-Initiated NCCL)
+    registers GPU memory which blocks subsequent regular CUDA allocations.
+
+    Args:
+        world_size: Number of ranks in the communicator.
+        device: CUDA device to allocate on.
+
+    Example:
+        >>> # Before GIN activation
+        >>> prewarm_completion_counters(world_size, device)
+        >>> # Now activate GIN
+        >>> dev_win_ptr = window.get_device_window(signal_count=world_size)
+        >>> # Now device_alltoallv_dynamic can be called safely
+    """
+    _get_completion_counters(world_size, device)
+    _get_iteration_tensor(world_size, device)
+
+
+# =============================================================================
+# Non-Pipelined Implementation
+# =============================================================================
+
+
+@requires_torchcomms
+@triton.jit
+def _device_alltoallv_dynamic_kernel(
+    # Window handles
+    dst_win_ptr,
+    src_base_ptr,
+    src_size,
+    src_nccl_win,
+    # Buffer pointers for self-copy (typed by Triton from tensors)
+    send_buf_ptr,
+    recv_buf_ptr,
+    # Offset/size arrays (pass tensors directly, Triton handles pointer conversion)
+    send_offsets_ptr,
+    send_sizes_ptr,
+    recv_offsets_ptr,
+    recv_sizes_ptr,
+    dst_offsets_ptr,
+    # Constants
+    my_rank: tl.constexpr,
+    world_size: tl.constexpr,
+    signal_id: tl.constexpr,
+    # Iteration counter - pointer to GPU scalar (always read from GPU memory)
+    iteration_ptr,
+    ELEM_BYTES: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    BLOCKS_PER_PEER: tl.constexpr,
+    CHUNK_SIZE: tl.constexpr,
+    completion_counters_ptr,
+    # Sync buffer mode for buffer-ready synchronization
+    SYNC_BUFFER: tl.constexpr,
+    BUFFER_READY_SIGNAL_ID: tl.constexpr,
+):
+    """
+    Device-initiated AlltoAllv Dynamic kernel.
+
+    Key Feature: Reads send counts and offsets directly from GPU memory,
+    enabling fused compute + communication without CPU involvement.
+
+    Algorithm:
+    1. Load phase: Read per-peer counts/offsets from GPU memory
+    2. Send phase: Put data to all peers using per-peer dst_offsets
+    3. Flush phase: Wait for all outgoing transfers to complete
+    4. Completion: Coordinate multi-block signaling (if BLOCKS_PER_PEER > 1)
+    5. Receive phase: Wait for signals from all peers
+
+    Grid layout: (world_size * BLOCKS_PER_PEER + world_size,) total blocks.
+    The first (world_size * BLOCKS_PER_PEER) blocks are SEND blocks.
+    The last world_size blocks are RECV blocks (one per peer).
+
+    Send blocks (pid < world_size * BLOCKS_PER_PEER):
+        Each peer is served by BLOCKS_PER_PEER consecutive blocks.  When
+        BLOCKS_PER_PEER == 1, the kernel behaves identically to the
+        single-block-per-peer version.  With BLOCKS_PER_PEER > 1, each
+        peer's send data is split into BLOCKS_PER_PEER contiguous chunks
+        and each block handles its portion.  Send blocks NEVER call
+        wait_signal_from, so they run uninterrupted.
+
+    Recv blocks (pid >= world_size * BLOCKS_PER_PEER):
+        Each recv block waits for data from one peer via wait_signal_from.
+        These run concurrently with send blocks on separate SMs, fully
+        overlapping send and recv.
+
+    Chunked transfer: All transfers use put_block_chunked, which
+    distributes CHUNK_SIZE-byte chunks across warps within the block
+    using CoopScope::WARP.  This creates multiple concurrent NVLink
+    write streams from a single block (one per warp), matching the
+    pipes/collectives warp-level architecture.  For messages that fit
+    in a single chunk, put_block_chunked falls back to CoopScope::BLOCK
+    (equivalent to put_block).  No per-chunk flush is needed — a single
+    __syncthreads at the end of put_block_chunked ensures all warps
+    complete before the caller signals.
+
+    Signaling:
+    - BLOCKS_PER_PEER == 1: The single block calls signal_block after
+      put_block_chunked + flush_block.  Release semantics on the signal
+      guarantee all prior stores (including all warp-parallel chunks)
+      are visible.
+    - BLOCKS_PER_PEER > 1: No block signals during puts.  After each
+      block completes put_block_chunked + flush_block, it atomically
+      increments completion_counters[peer].  The last block to complete
+      (atomic result == BLOCKS_PER_PEER - 1) calls signal_block.
+      Because flush_block guarantees each block's NVLink writes are
+      globally visible before incrementing the counter, the signal is
+      only sent after ALL blocks have completed their transfers.
+
+    Args:
+        dst_win_ptr: TorchComms device window handle for destination
+        src_base_ptr: Base pointer of registered source buffer
+        src_size: Size of source buffer in bytes
+        src_nccl_win: NCCL window handle for source buffer
+        send_offsets_ptr: GPU tensor [world_size] - byte offsets into src
+        send_sizes_ptr: GPU tensor [world_size] - bytes to send per peer
+        recv_offsets_ptr: GPU tensor [world_size] - byte offsets into local dst
+        recv_sizes_ptr: GPU tensor [world_size] - bytes expected from each peer
+        dst_offsets_ptr: GPU tensor [world_size] - byte offsets on each peer's
+                        recv_buf (obtained via all_to_all_single exchange)
+        my_rank: This rank's ID (constexpr)
+        world_size: Total number of ranks (constexpr)
+        signal_id: Signal ID to use for notifications (constexpr)
+        iteration: 0-based iteration counter (non-constexpr runtime arg).
+                   Since put_block increments signals via SignalOp::ADD,
+                   the kernel waits for signal >= iteration + 1.
+        ELEM_BYTES: Size of each element in bytes (constexpr), e.g. 4 for
+                    float32, 2 for float16/bfloat16, 8 for float64.
+        BLOCKS_PER_PEER: Number of send blocks assigned to each peer
+                         (constexpr). Default: 1 (original behavior).
+        CHUNK_SIZE: Chunk size for warp-level distribution in
+                    put_block_chunked (constexpr).  Each warp processes
+                    chunks of this size in round-robin.  Larger values
+                    reduce per-warp overhead; smaller values increase
+                    warp-level parallelism.
+                    Default: 262144 (256KB).
+        completion_counters_ptr: GPU tensor [world_size] of int32 counters
+                    (zeroed before each call).  Used for multi-block
+                    completion coordination when BLOCKS_PER_PEER > 1.
+                    Unused (but still passed) when BLOCKS_PER_PEER == 1.
+    """
+    pid = tl.program_id(axis=0)
+
+    # Load iteration counter from GPU memory.
+    # Using a GPU tensor ensures correct behavior for both CUDA graph and
+    # non-graph modes. The tensor is incremented via add_(1) at the end of
+    # each alltoallv call, which is capturable in CUDA graphs.
+    iteration = tl.load(iteration_ptr)
+
+    total_send_blocks: tl.constexpr = world_size * BLOCKS_PER_PEER
+
+    # ── Recv block path ──
+    # The last world_size blocks are dedicated recv blocks.
+    # Each recv block waits for data from one peer.  These run on
+    # separate SMs from send blocks, fully overlapping send and recv.
+    #
+    # For sync_buffer mode (SYNC_BUFFER=True):
+    #   Signal BUFFER_READY at the START of the kernel (before waiting for
+    #   new data) to tell the sender "I've consumed the previous iteration's
+    #   data, you can send new data now". This ensures proper cross-rank
+    #   synchronization: the sender in iteration N cannot proceed until the
+    #   receiver has started iteration N (meaning it finished processing
+    #   iteration N-1's data, including any clone operations in user code).
+    #
+    #   Signaling flow:
+    #     iter0: recv waits for DATA_COMPLETE(0), no BUFFER_READY signal (skip)
+    #     iter1: recv signals BUFFER_READY(1), then waits for DATA_COMPLETE(1)
+    #     iterN: recv signals BUFFER_READY(N), then waits for DATA_COMPLETE(N)
+    #
+    #   The sender waits for BUFFER_READY(N) before sending iteration N's data.
+    #   Since BUFFER_READY(N) is signaled at the start of recv's iteration N,
+    #   the receiver has necessarily finished with iteration N-1's data.
+    if pid >= total_send_blocks:
+        recv_peer = pid - total_send_blocks
+        if recv_peer < world_size and recv_peer != my_rank:
+            if SYNC_BUFFER:
+                # Signal BUFFER_READY at START of iteration N.
+                # This tells the sender that we've entered iteration N, meaning
+                # we've completed iteration N-1 (including any operations like
+                # spin loops that run AFTER the alltoallv kernel in the graph).
+                #
+                # Signal value: We ADD 1 each iteration (not iteration number) because
+                # signal_block uses SignalOp::ADD semantics. The cumulative signal
+                # value after N iterations is N, which matches wait_signal_from's
+                # expected value of iteration (>= N).
+                if iteration > 0:
+                    # Add 1 to signal, making cumulative value = iteration
+                    signal_block(dst_win_ptr, recv_peer, BUFFER_READY_SIGNAL_ID, 1)
+
+                peer_recv_size = tl.load(recv_sizes_ptr + recv_peer)
+                if peer_recv_size > 0:
+                    # Wait for monotonically increasing signal value.
+                    # Each iteration signals BLOCKS_PER_PEER * (iteration + 1).
+                    expected_signal = BLOCKS_PER_PEER * (iteration + 1)
+                    wait_signal_from(dst_win_ptr, recv_peer, signal_id, expected_signal)
+
+        return
+
+    # ── Send block path ──
+    # Map program_id → (peer, block_idx within that peer)
+    peer = pid // BLOCKS_PER_PEER
+    block_idx = pid % BLOCKS_PER_PEER
+
+    # Skip if peer is out of range (grid may be larger than world_size)
+    if peer >= world_size:
+        return
+
+    # NOTE: No counter reset here. Counters grow monotonically with each
+    # iteration to avoid race conditions from non-deterministic CUDA block
+    # scheduling. With reset, block1 could execute before block0's reset,
+    # causing incorrect signal values. The monotonic approach ensures
+    # correctness regardless of block execution order.
+
+    # Load send parameters for this peer from GPU memory
+    send_offset = tl.load(send_offsets_ptr + peer)
+    send_size = tl.load(send_sizes_ptr + peer)
+
+    # SYNC_BUFFER: Wait for BUFFER_READY signal from receiver before sending.
+    # The receiver signals BUFFER_READY(N) at the START of iteration N to indicate
+    # it has entered iteration N (meaning iteration N-1 is fully complete, including
+    # any operations like spin loops that run after the alltoallv kernel).
+    # The sender at iteration N must wait for BUFFER_READY(N) to ensure the receiver
+    # has entered iteration N before the sender overwrites the recv_buf with new data.
+    # Only block 0 for each peer waits; other blocks proceed after unblock.
+    # Skip on iteration 0 since there's no previous data to wait for.
+    if SYNC_BUFFER and iteration > 0 and peer != my_rank and send_size > 0:
+        if block_idx == 0:
+            # Wait for receiver to signal that it has entered iteration N.
+            # This means the receiver has completed iteration N-1.
+            expected_signal = iteration
+            wait_signal_from(dst_win_ptr, peer, BUFFER_READY_SIGNAL_ID, expected_signal)
+
+    # Phase 0: Self-copy (peer == my_rank) using self_copy_block extern.
+    # Uses a CUDA extern with memcpy_vectorized instead of Triton's
+    # tl.load/tl.store with masks.  The Triton masked-copy pattern generates
+    # ~85 comparison/mask SSA values in the LLVM IR (tl.arange, icmp, select,
+    # predicated ld/st), adding register pressure to the main kernel even
+    # though self-copy only executes for 1 of 8 peers.  The extern approach
+    # keeps the self-copy IR in a separate function, reducing register
+    # pressure on the hot memcpy path.
+    if peer == my_rank and send_size > 0:
+        dst_offset = tl.load(recv_offsets_ptr + my_rank)
+        block_bytes = send_size // BLOCKS_PER_PEER
+        block_start_bytes = block_bytes * block_idx
+        if block_idx == BLOCKS_PER_PEER - 1:
+            block_bytes = send_size - block_start_bytes
+        if block_bytes > 0:
+            self_copy_block(
+                recv_buf_ptr,
+                dst_offset + block_start_bytes,
+                send_buf_ptr,
+                send_offset + block_start_bytes,
+                block_bytes,
+            )
+
+    # Phase 1: Send data to peer (skip self and zero-length messages).
+    # Send blocks NEVER call wait_signal_from — they run uninterrupted.
+    if peer != my_rank and send_size > 0:
+        # Split send_size across BLOCKS_PER_PEER blocks.
+        block_portion = send_size // BLOCKS_PER_PEER
+        block_start = block_portion * block_idx
+        # Last block absorbs any remainder bytes from integer division
+        if block_idx == BLOCKS_PER_PEER - 1:
+            block_portion = send_size - block_start
+
+        if block_portion > 0:
+            # Per-peer destination offset on the peer's receive buffer.
+            dst_offset = tl.load(dst_offsets_ptr + peer)
+
+            # Split NVLink put into two separate externs to avoid
+            # dual-alloca register pressure.  Each extern has ONE
+            # memcpy_vectorized instantiation = ONE alloca [8 x uint4].
+            # The single put_block_chunked had TWO allocas (BLOCK + WARP
+            # paths) causing 42 register spills in the hot loop.
+            if block_portion <= CHUNK_SIZE:
+                put_block_direct(
+                    dst_win_ptr,
+                    dst_offset + block_start,
+                    src_nccl_win,
+                    send_offset + block_start,
+                    peer,
+                    block_portion,
+                )
+            else:
+                put_warp_chunked_direct(
+                    dst_win_ptr,
+                    dst_offset + block_start,
+                    src_nccl_win,
+                    send_offset + block_start,
+                    peer,
+                    block_portion,
+                    CHUNK_SIZE,
+                )
+
+            # Flush + signal AFTER all data is sent.
+            # Signal value: We ADD BLOCKS_PER_PEER each iteration because signal_block
+            # uses SignalOp::ADD semantics. The cumulative signal value after N+1
+            # iterations is BLOCKS_PER_PEER * (N+1), which matches wait_signal_from's
+            # expected value of BLOCKS_PER_PEER * (iteration + 1).
+            flush_block(dst_win_ptr)
+            if SYNC_BUFFER:
+                if BLOCKS_PER_PEER == 1:
+                    # Add BLOCKS_PER_PEER to signal, making cumulative value = BLOCKS_PER_PEER * (iteration + 1)
+                    signal_block(dst_win_ptr, peer, signal_id, BLOCKS_PER_PEER)
+                else:
+                    # Atomically increment counter. Last block to complete signals.
+                    # Counter grows monotonically: iteration 0 ends at BLOCKS_PER_PEER,
+                    # iteration 1 ends at 2*BLOCKS_PER_PEER, etc.
+                    old = tl.atomic_add(completion_counters_ptr + peer, 1)
+                    expected_count = BLOCKS_PER_PEER * (iteration + 1)
+                    if old + 1 == expected_count:
+                        # Add BLOCKS_PER_PEER to signal, making cumulative value = BLOCKS_PER_PEER * (iteration + 1)
+                        signal_block(dst_win_ptr, peer, signal_id, BLOCKS_PER_PEER)
+
+
+def exchange_offsets(
+    local_recv_slot_offsets: torch.Tensor,
+    comm: "TorchComm",
+) -> torch.Tensor:
+    """
+    Exchange local_recv_slot_offsets across all ranks to compute remote_write_offsets.
+
+    Each rank's local_recv_slot_offsets[peer] tells where peer's data should
+    land in this rank's recv_buf.  After the exchange, remote_write_offsets[peer]
+    contains where THIS rank's data should land on peer's recv_buf.
+
+    This is a collective operation (all_to_all_single) and should be called
+    ONCE during setup, not per-iteration.
+
+    Args:
+        local_recv_slot_offsets: GPU tensor of shape [world_size] with offsets
+            within "my local" recv buffer where each peer's data lands.
+        comm: TorchComm communicator.
+
+    Returns:
+        remote_write_offsets: GPU tensor of shape [world_size] with offsets on
+            "remote peers" recv buffers where I should write.
+    """
+    remote_write_offsets = torch.empty_like(local_recv_slot_offsets)
+    comm.all_to_all_single(remote_write_offsets, local_recv_slot_offsets, False)
+    return remote_write_offsets
+
+
+def auto_tune_alltoallv_params(
+    max_msg_size_bytes: int,
+) -> dict:
+    """
+    Select optimal kernel parameters based on maximum per-peer message size.
+
+    Based on benchmark data across message sizes, the optimal configuration is:
+    - ≤1KB: 1 block/peer, 4 warps (Gw4)
+    - >1KB, ≤4KB: 1 block/peer, 8 warps (Gw8)
+    - >4KB, ≤8KB: 1 block/peer, 16 warps (Gw16)
+    - >8KB, ≤16KB: 1 block/peer, 32 warps (Gw32)
+    - >16KB, ≤256KB: 8 blocks/peer, 16 warps (GB8)
+    - >256KB: 16 blocks/peer, 16 warps, 64KB chunks (GB16c64)
+
+    Benchmark sweep (1MB-16MB) confirmed GB16c64 is consistently the best
+    config across all large message sizes.
+
+    Thread count (num_warps) rationale:
+    - Small messages (<4KB): fewer warps (4-8) reduce launch overhead
+    - Medium messages (4KB-64KB): moderate warps (16) balance occupancy
+    - Large messages (>64KB): more warps (32) maximize memory bandwidth
+    - Multi-block (>128KB): 16 warps/block with multiple blocks for parallelism
+
+    Args:
+        max_msg_size_bytes: Maximum per-peer message size in bytes.
+
+    Returns:
+        dict with keys: blocks_per_peer, num_warps, chunk_size
+    """
+    if max_msg_size_bytes <= 1 * 1024:
+        return {"blocks_per_peer": 1, "num_warps": 4, "chunk_size": 64 * 1024}
+    if max_msg_size_bytes <= 2 * 1024:
+        return {"blocks_per_peer": 1, "num_warps": 8, "chunk_size": 64 * 1024}
+    elif max_msg_size_bytes <= 4 * 1024:
+        return {"blocks_per_peer": 1, "num_warps": 8, "chunk_size": 64 * 1024}
+    elif max_msg_size_bytes <= 8 * 1024:
+        return {"blocks_per_peer": 1, "num_warps": 16, "chunk_size": 64 * 1024}
+    elif max_msg_size_bytes <= 16 * 1024:
+        return {"blocks_per_peer": 1, "num_warps": 16, "chunk_size": 64 * 1024}
+    elif max_msg_size_bytes <= 32 * 1024:
+        return {"blocks_per_peer": 1, "num_warps": 16, "chunk_size": 64 * 1024}
+    elif max_msg_size_bytes <= 64 * 1024:
+        return {"blocks_per_peer": 1, "num_warps": 32, "chunk_size": 64 * 1024}
+    elif max_msg_size_bytes <= 128 * 1024:
+        return {"blocks_per_peer": 8, "num_warps": 16, "chunk_size": 64 * 1024}
+    elif max_msg_size_bytes <= 256 * 1024:
+        return {"blocks_per_peer": 8, "num_warps": 16, "chunk_size": 64 * 1024}
+    else:
+        return {"blocks_per_peer": 16, "num_warps": 16, "chunk_size": 64 * 1024}
+
+
+def device_alltoallv_dynamic(
+    send_buf: torch.Tensor,
+    recv_buf: torch.Tensor,
+    send_sizes: torch.Tensor,
+    send_offsets: torch.Tensor,
+    recv_sizes: torch.Tensor,
+    local_recv_slot_offsets: torch.Tensor,
+    remote_write_offsets: torch.Tensor,
+    dev_win_ptr: int,
+    src_info: tuple,
+    my_rank: int,
+    world_size: int,
+    num_warps: int = 16,
+    blocks_per_peer: int = 1,
+    chunk_size: int = 64 * 1024,
+    auto_tune: bool = False,
+    sync_buffer: bool = True,
+) -> None:
+    """
+    Perform device-initiated AlltoAllv with dynamic per-rank counts.
+
+    This is a lean collective with zero host-side overhead — no barriers,
+    no torch.cuda.synchronize(), no CUDA allocations, no offset exchange.
+    It simply launches the Triton kernel.  All setup (buffer registration,
+    offset exchange, get_device_window) is done once by the caller.
+
+    This matches the pipes/collectives and ctran patterns where the
+    collective call is just a kernel launch with no per-call overhead.
+
+    Iteration tracking is managed internally — users don't need to create
+    or manage iteration tensors. The function auto-increments the iteration
+    counter after each call, enabling correct CUDA graph replay behavior.
+
+    Args:
+        send_buf: Source tensor containing data to send.
+        recv_buf: Destination tensor to receive data into.
+        send_sizes: GPU tensor [world_size] with byte counts per peer.
+        send_offsets: GPU tensor [world_size] with send buffer offsets.
+        recv_sizes: GPU tensor [world_size] with byte counts expected from
+                    each peer (used to gate wait_signal_from).
+        local_recv_slot_offsets: GPU tensor [world_size] with offsets within
+                     "my local" recv buffer where each peer's data lands.
+        remote_write_offsets: GPU tensor [world_size] with offsets on "remote
+                     peers" recv buffers where I should write (from
+                     exchange_offsets()).
+        dev_win_ptr: Device window handle (from get_device_window()).
+        src_info: Pre-registered send buffer info (from register_local_buffer()).
+        my_rank: This rank's ID.
+        world_size: Total number of ranks.
+        num_warps: Number of warps per block (default: 16, i.e. 512 threads).
+                   Controls thread-level parallelism for NVLink memcpy in
+                   put_block. Higher values increase copy bandwidth but may
+                   reduce occupancy due to register pressure. Valid range:
+                   1-32 (CUDA max 1024 threads/block). The pipes AllToAllv
+                   benchmarks use 16 warps/block (512 threads) for comparison.
+        blocks_per_peer: Number of blocks per peer (default: 1).  With
+                         blocks_per_peer > 1, each peer's send data is split
+                         into contiguous chunks and each block issues its own
+                         put_block — increasing NVLink parallelism for large
+                         messages.  Only the last block signals the peer, so
+                         the signaling protocol is unchanged.
+        sync_buffer: If True (default), enables BUFFER_READY cross-rank
+                     synchronization for safe buffer reuse across iterations.
+                     This is REQUIRED when using CUDA graphs or replaying
+                     multiple iterations without explicit host sync. Adds
+                     ~1-3us per-peer latency overhead. Set to False only for
+                     microbenchmarking raw kernel throughput.
+
+    Example:
+        >>> # One-time setup (call prewarm_completion_counters BEFORE GIN activation)
+        >>> prewarm_completion_counters(world_size, device)
+        >>> window = comm.new_window()
+        >>> window.tensor_register(recv_buf)
+        >>> dev_win_ptr = get_device_window(window, signal_count=world_size)
+        >>> src_info = register_local_buffer(send_buf, window)
+        >>> remote_write_offsets = exchange_offsets(local_recv_slot_offsets, comm)
+        >>>
+        >>> # Hot loop — zero per-call overhead, iteration managed internally
+        >>> for i in range(iterations):
+        ...     device_alltoallv_dynamic(
+        ...         send_buf, recv_buf,
+        ...         send_sizes, send_offsets,
+        ...         recv_sizes, local_recv_slot_offsets, remote_write_offsets,
+        ...         dev_win_ptr, src_info, my_rank, world_size,
+        ...     )
+        >>>
+        >>> # Cleanup
+        >>> deregister_local_buffer(src_info, window)
+    """
+    src_base_ptr, src_size, src_nccl_win = src_info
+
+    # Get internal iteration tensor (cached per device/world_size).
+    # This is managed internally - users don't need to create or track it.
+    iteration_tensor = _get_iteration_tensor(world_size, send_buf.device)
+
+    # Auto-tune: select optimal parameters based on max message size.
+    # Reads send_sizes.max() from GPU (~5us overhead, negligible for
+    # messages >16KB where auto-tuning matters).
+    if auto_tune:
+        max_msg_size_bytes = int(send_sizes.max().item())
+        params = auto_tune_alltoallv_params(max_msg_size_bytes)
+        blocks_per_peer = params["blocks_per_peer"]
+        num_warps = params["num_warps"]
+        chunk_size = params["chunk_size"]
+
+    # Completion counters for multi-block coordination.
+    # Pre-allocated via _get_completion_counters() to avoid per-call
+    # CUDA allocator overhead.  The cache is keyed by (device, world_size)
+    # and lazily created on first use.
+    # For BLOCKS_PER_PEER == 1 the kernel never accesses these, but we
+    # still need a valid pointer for the uniform launch signature.
+    #
+    # IMPORTANT: Reset counters to the expected base value for this iteration.
+    # The kernel expects counters to start at BLOCKS_PER_PEER * iteration
+    # (the value after the previous iteration).  Without this reset,
+    # counters would accumulate across independent kernel launches,
+    # causing the signal condition (old + 1 == expected_count) to fail.
+    #
+    # We use _fill_completion_counters_from_iteration() which reads the
+    # iteration value from GPU memory, making it CUDA graph compatible.
+    completion_counters = _get_completion_counters(world_size, send_buf.device)
+    if blocks_per_peer > 1:
+        # Reset each peer's counter using a GIN-safe Triton kernel that
+        # reads iteration from GPU memory.  This is CUDA graph compatible.
+        _fill_completion_counters_from_iteration(
+            completion_counters, iteration_tensor, blocks_per_peer, world_size
+        )
+
+    grid = (world_size * blocks_per_peer + world_size,)
+
+    _device_alltoallv_dynamic_kernel[grid](
+        dev_win_ptr,
+        src_base_ptr,
+        src_size,
+        src_nccl_win,
+        send_buf,
+        recv_buf,
+        send_offsets,
+        send_sizes,
+        local_recv_slot_offsets,
+        recv_sizes,
+        remote_write_offsets,
+        my_rank=my_rank,
+        world_size=world_size,
+        signal_id=0,
+        # Read iteration from internal GPU tensor - works for both CUDA graph
+        # and non-graph modes. The tensor is auto-incremented at the end of
+        # this function.
+        iteration_ptr=iteration_tensor,
+        ELEM_BYTES=send_buf.element_size(),
+        BLOCK_SIZE=1024,
+        BLOCKS_PER_PEER=blocks_per_peer,
+        CHUNK_SIZE=chunk_size,
+        num_warps=num_warps,
+        completion_counters_ptr=completion_counters,
+        # Sync buffer mode for buffer-ready synchronization
+        SYNC_BUFFER=sync_buffer,
+        BUFFER_READY_SIGNAL_ID=1,  # Use signal_id=1 for BUFFER_READY (signal_id=0 is DATA_COMPLETE)
+    )
+
+    # Auto-increment iteration counter on GPU.
+    # Using a Triton kernel is a pure GPU operation that can be captured in
+    # CUDA graphs, enabling correct cross-rank synchronization across
+    # multiple graph replays.
+    _increment_iteration_kernel[(1,)](iteration_tensor)
+
+
+# =============================================================================
+# Helper Functions
+# =============================================================================
+
+
+def compute_offsets_from_sizes(
+    sizes: torch.Tensor,
+    offsets: torch.Tensor,
+) -> None:
+    """
+    Compute exclusive prefix sum of sizes to get offsets.
+
+    This utility enables the dynamic workflow:
+    1. Kernel computes per-peer sizes
+    2. This function computes offsets from sizes (stays on GPU)
+    3. device_alltoallv_dynamic uses both
+
+    Uses PyTorch's torch.cumsum which runs efficiently on GPU when
+    tensors are on GPU.
+
+    Args:
+        sizes: GPU tensor of shape [N] with per-peer byte counts
+        offsets: GPU tensor of shape [N] to store computed offsets
+                 (must be pre-allocated)
+
+    Example:
+        >>> sizes = torch.tensor([100, 200, 150, 250], dtype=torch.int64, device='cuda')
+        >>> offsets = torch.zeros_like(sizes)
+        >>> compute_offsets_from_sizes(sizes, offsets)
+        >>> print(offsets)  # tensor([0, 100, 300, 450])
+    """
+    N = sizes.shape[0]
+    if N == 0:
+        return
+    elif N == 1:
+        offsets[0] = 0
+    else:
+        # Compute exclusive prefix sum using torch.cumsum
+        # exclusive_prefix_sum[i] = sum(sizes[0:i])
+        cumsum = torch.cumsum(sizes, dim=0)
+        offsets[0] = 0
+        offsets[1:] = cumsum[:-1]

--- a/comms/pipes/collectives/triton/tests/autotune_sweep.py
+++ b/comms/pipes/collectives/triton/tests/autotune_sweep.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# pyre-unsafe
+"""
+Auto-tune sweep orchestrator for Triton alltoallv_dynamic.
+
+Launches the existing benchmark binary via buck2 run with batches of
+custom configs, parses the sweep table output, and tracks the best
+config per message size across all batches.
+
+This script runs LOCALLY (not via buck2 run) — it orchestrates
+benchmark runs by invoking buck2 as a subprocess.
+
+Usage:
+    cd fbsource
+    python3 fbcode/comms/torchcomms/triton/fb/tests/autotune_sweep.py
+"""
+
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+
+
+BUCK_CMD_PREFIX = [
+    "buck2",
+    "run",
+    "@fbcode//mode/opt",
+    "-c",
+    "nccl.enable_scuba=false",
+    "-c",
+    "comms.envs=NCCL_DEBUG=WARN;NCCL_GIN_ENABLE=1;NCCL_GIN_TYPE=-1;"
+    "NCCL_COMM_EVENT_LOGGING=;RUN_DEVICE_API_TEST=true;"
+    "TEST_BACKEND=ncclx;TEST_FILTER=",
+    "-c",
+    "fbcode.enable_gpu_sections=true",
+    "-c",
+    "fbcode.platform010_cuda_version=12.8",
+    "-c",
+    "fbcode.nvcc_arch=h100a",
+    "-c",
+    "hpc_comms.use_ncclx=stable",
+    "fbcode//comms/torchcomms/triton/fb/tests:benchmark_device_alltoallv_dynamic",
+    "--",
+]
+
+
+def format_size(size_bytes: int) -> str:
+    if size_bytes >= 1024 * 1024 * 1024:
+        return f"{size_bytes / (1024**3):.0f}GB"
+    elif size_bytes >= 1024 * 1024:
+        return f"{size_bytes / (1024**2):.0f}MB"
+    elif size_bytes >= 1024:
+        return f"{size_bytes / 1024:.0f}KB"
+    return f"{size_bytes}B"
+
+
+def parse_sweep_output(raw: str) -> Dict[int, List[Tuple[str, float]]]:
+    """Parse the sweep table from rank-0 stdout lines.
+    Returns {msg_size_bytes: [(config_name, latency_us), ...]}.
+    """
+    # Extract rank-0 stdout
+    lines = []
+    for line in raw.split("\n"):
+        if "[1,0]<stdout>:" in line:
+            lines.append(line.split("[1,0]<stdout>:")[1])
+
+    results: Dict[int, List[Tuple[str, float]]] = {}
+    header_cols: List[str] = []
+
+    for line in lines:
+        line = line.strip()
+
+        # Header row
+        if line.startswith("Size") and "|" in line:
+            header_cols = [p.strip() for p in line.split("|")][1:]
+            continue
+
+        if not header_cols or "|" not in line:
+            continue
+
+        # Data row: "  1.0MB |  37.12 | ..."
+        parts = [p.strip() for p in line.split("|")]
+        if len(parts) < 2:
+            continue
+
+        size_str = parts[0]
+        try:
+            if "KB" in size_str:
+                msg_size = int(float(size_str.replace("KB", "")) * 1024)
+            elif "MB" in size_str:
+                msg_size = int(float(size_str.replace("MB", "")) * 1024 * 1024)
+            elif "GB" in size_str:
+                msg_size = int(float(size_str.replace("GB", "")) * 1024**3)
+            else:
+                continue
+        except ValueError:
+            continue
+
+        row = []
+        for i, val in enumerate(parts[1:]):
+            if i >= len(header_cols):
+                break
+            name = header_cols[i]
+            try:
+                row.append((name, float(val)))
+            except ValueError:
+                pass
+        if row:
+            results[msg_size] = row
+
+    return results
+
+
+def run_sweep(
+    min_size: int, max_size: int, custom_configs: str, iters: int = 10, warmup: int = 3
+) -> str:
+    """Run one benchmark sweep and return the combined stdout+stderr."""
+    cmd = list(BUCK_CMD_PREFIX) + [
+        "--sweep-warps",
+        f"--min-size={min_size}",
+        f"--max-size={max_size}",
+        f"--iters={iters}",
+        f"--warmup={warmup}",
+    ]
+    if custom_configs:
+        cmd.append(f"--custom-configs={custom_configs}")
+
+    print(f"  CMD: ...{' '.join(cmd[-5:])}", flush=True)
+    r = subprocess.run(cmd, capture_output=True, text=True, timeout=7200)
+    return r.stdout + "\n" + r.stderr
+
+
+def main() -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Auto-tune sweep orchestrator")
+    parser.add_argument(
+        "--mode",
+        choices=["full", "sweep"],
+        default="full",
+        help=(
+            "full: test 120 custom configs in batches (10i/3w). "
+            "sweep: run default sweep only with 100i/10w, no custom configs."
+        ),
+    )
+    args = parser.parse_args()
+
+    if args.mode == "sweep":
+        return run_sweep_only()
+    else:
+        return run_full_sweep()
+
+
+def run_sweep_only() -> int:
+    """Run the default sweep (no custom configs) with 100 iters / 10 warmup."""
+    size_ranges = [
+        (1024, 16 * 1024 * 1024, 100, 10),
+        (32 * 1024 * 1024, 256 * 1024 * 1024, 20, 10),
+        (512 * 1024 * 1024, 1024 * 1024 * 1024, 10, 5),
+    ]
+
+    print("Sweep-only mode: default configs (Gw4-32, GB2-32, GB16c64, Auto)")
+    print(
+        f"Ranges: {[(format_size(a), format_size(b), f'{i}i/{w}w') for a, b, i, w in size_ranges]}"
+    )
+    print(flush=True)
+
+    best: Dict[int, Tuple[str, float]] = {}
+
+    for ri, (lo, hi, iters, warmup) in enumerate(size_ranges):
+        print(f"\n{'=' * 80}")
+        print(
+            f"Range {ri + 1}/{len(size_ranges)}: {format_size(lo)} – {format_size(hi)} ({iters}i/{warmup}w)"
+        )
+        print(f"{'=' * 80}", flush=True)
+
+        try:
+            raw = run_sweep(lo, hi, "", iters=iters, warmup=warmup)
+            results = parse_sweep_output(raw)
+
+            for ms, entries in results.items():
+                for name, lat in entries:
+                    if name in ("Auto", "AutoCfg", "Best", "NCCLgr"):
+                        continue
+                    if ms not in best or lat < best[ms][1]:
+                        old = best.get(ms)
+                        best[ms] = (name, lat)
+                        if old and (old[1] - lat) / old[1] > 0.01:
+                            print(
+                                f"  ↑ {format_size(ms):>8s}: {name:>14s} "
+                                f"{lat:.2f}µs (was {old[0]} {old[1]:.2f}µs)",
+                                flush=True,
+                            )
+        except subprocess.TimeoutExpired:
+            print("  ✗ timed out", flush=True)
+        except Exception as e:
+            print(f"  ✗ {e}", flush=True)
+
+        # Report
+        print(f"\n{'=' * 80}")
+        print(f"Best after {format_size(lo)}–{format_size(hi)}")
+        print(f"{'=' * 80}")
+        print(f"{'Size':>10s} | {'Config':>14s} | {'Latency':>10s}")
+        print(f"{'-' * 10}-+-{'-' * 14}-+-{'-' * 10}")
+        for ms in sorted(best):
+            c, l = best[ms]
+            print(f"{format_size(ms):>10s} | {c:>14s} | {l:>10.2f}")
+        print(f"{'=' * 80}\n", flush=True)
+
+    # Final
+    print("\n" + "=" * 80)
+    print("FINAL AUTO-TUNE TABLE (sweep-only, no custom configs)")
+    print("=" * 80)
+    for ms in sorted(best):
+        c, l = best[ms]
+        print(f"{format_size(ms):>10s} | {c:>14s} | {l:>10.2f}")
+    print("=" * 80)
+    return 0
+
+
+def run_full_sweep() -> int:
+    """Run the full sweep with custom configs."""
+    # Config search space (BxWxC_kb strings for --custom-configs)
+    configs: List[str] = []
+    for b in [1, 2, 4, 8, 16, 32]:
+        for w in [4, 8, 16, 32]:
+            for c in [32, 64, 128, 256, 512]:
+                # Skip configs the default sweep already tests
+                if b == 1 and c == 64 and w in (4, 8, 16, 32):
+                    continue
+                if w == 16 and c == 64 and b in (2, 4, 8, 16, 32):
+                    continue
+                if b == 16 and w == 16 and c == 64:
+                    continue
+                configs.append(f"{b}x{w}x{c}")
+
+    batch_size = 8
+    batches = [configs[i : i + batch_size] for i in range(0, len(configs), batch_size)]
+
+    size_ranges = [
+        (1024, 16 * 1024 * 1024, 10, 3),  # 1KB-16MB: 10 iters, 3 warmup
+        (32 * 1024 * 1024, 256 * 1024 * 1024, 10, 3),  # 32MB-256MB: 10 iters, 3 warmup
+        (512 * 1024 * 1024, 1024 * 1024 * 1024, 10, 3),  # 512MB-1GB: 10 iters, 3 warmup
+    ]
+
+    print(f"Auto-tune: {len(configs)} custom configs in {len(batches)} batches")
+    print(
+        f"Ranges: {[(format_size(a), format_size(b), f'{i}i/{w}w') for a, b, i, w in size_ranges]}"
+    )
+    print(f"Total benchmark runs: {len(batches) * len(size_ranges)}")
+    print(flush=True)
+
+    best: Dict[int, Tuple[str, float]] = {}
+
+    for ri, (lo, hi, iters, warmup) in enumerate(size_ranges):
+        print(f"\n{'=' * 80}")
+        print(
+            f"Range {ri + 1}/{len(size_ranges)}: {format_size(lo)} – {format_size(hi)} ({iters} iters, {warmup} warmup)"
+        )
+        print(f"{'=' * 80}", flush=True)
+
+        for bi, batch in enumerate(batches):
+            cc = ",".join(batch)
+            print(f"\nBatch {bi + 1}/{len(batches)}: {cc}", flush=True)
+
+            try:
+                raw = run_sweep(lo, hi, cc)
+                results = parse_sweep_output(raw)
+
+                for ms, entries in results.items():
+                    for name, lat in entries:
+                        if name in ("Auto", "AutoCfg", "Best", "NCCLgr"):
+                            continue
+                        if ms not in best or lat < best[ms][1]:
+                            old = best.get(ms)
+                            best[ms] = (name, lat)
+                            if old and (old[1] - lat) / old[1] > 0.01:
+                                print(
+                                    f"  ↑ {format_size(ms):>8s}: {name:>14s} "
+                                    f"{lat:.2f}µs (was {old[0]} {old[1]:.2f}µs)",
+                                    flush=True,
+                                )
+            except subprocess.TimeoutExpired:
+                print(f"  ✗ timed out", flush=True)
+            except Exception as e:
+                print(f"  ✗ {e}", flush=True)
+
+        # Progress report
+        print(f"\n{'=' * 80}")
+        print(f"Best after {format_size(lo)}–{format_size(hi)}")
+        print(f"{'=' * 80}")
+        print(f"{'Size':>10s} | {'Config':>14s} | {'Latency':>10s}")
+        print(f"{'-' * 10}-+-{'-' * 14}-+-{'-' * 10}")
+        for ms in sorted(best):
+            c, l = best[ms]
+            print(f"{format_size(ms):>10s} | {c:>14s} | {l:>10.2f}")
+        print(f"{'=' * 80}\n", flush=True)
+
+    # Final
+    print("\n" + "=" * 80)
+    print("FINAL AUTO-TUNE TABLE")
+    print("=" * 80)
+    for ms in sorted(best):
+        c, l = best[ms]
+        print(f"{format_size(ms):>10s} | {c:>14s} | {l:>10.2f}")
+    print("=" * 80)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/comms/pipes/collectives/triton/tests/benchmark_device_alltoallv_dynamic.py
+++ b/comms/pipes/collectives/triton/tests/benchmark_device_alltoallv_dynamic.py
@@ -1,0 +1,1446 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# pyre-unsafe
+"""
+Benchmark tests comparing Triton device_alltoallv_dynamic against NCCL alltoallv.
+
+IMPORTANT: Understanding the Comparison
+========================================
+
+This benchmark compares two fundamentally different approaches:
+
+1. NCCL alltoallv (CPU-initiated):
+   - Counts/sizes are Python lists (CPU/host memory)
+   - CPU calls NCCL API with these values
+   - In a real dynamic workload, this REQUIRES a D2H copy if counts
+     were computed on GPU
+   - This is standard NCCL - there is NO "NCCL alltoallv_dynamic"
+
+2. Triton device_alltoallv_dynamic (GPU-initiated):
+   - Counts/sizes are GPU tensors (device memory)
+   - Kernel reads counts directly from GPU memory via tl.load()
+   - NO D2H copy needed - counts stay on GPU
+   - The "dynamic" refers to GPU-resident counts (NCCL doesn't have this)
+
+The key insight: NCCL does NOT have a GPU-resident counts API.
+Therefore, comparing against CPU-initiated NCCL alltoallv IS the correct
+baseline, as it represents what users would do today.
+
+The performance benefit of device_alltoallv_dynamic:
+- Eliminating CPU synchronization point
+- Eliminating D2H copy of counts (in real workflows)
+- Enabling fused compute+communicate patterns
+
+Run with:
+    buck2 run @fbcode//mode/opt \
+        -c fbcode.enable_gpu_sections=true \
+        -c fbcode.platform010_cuda_version=12.8 \
+        -c fbcode.nvcc_arch=h100a \
+        -c hpc_comms.use_ncclx=stable \
+        fbcode//comms/torchcomms/triton/fb/tests:benchmark_device_alltoallv_dynamic
+"""
+
+import argparse
+import gc
+import os
+import sys
+import time
+from dataclasses import dataclass, field
+from typing import List, Optional, TYPE_CHECKING
+
+import torch
+from torch.utils._triton import has_triton
+
+if TYPE_CHECKING:
+    from torchcomms import TorchComm
+
+
+TRITON_AVAILABLE = has_triton()
+RUN_DEVICE_API_TEST = os.environ.get("RUN_DEVICE_API_TEST", "false").lower() == "true"
+
+
+@dataclass
+class BenchmarkResult:
+    """Results from a single benchmark run."""
+
+    name: str
+    msg_size_bytes: int
+    num_ranks: int
+    latency_us: float  # average latency
+    bandwidth_gbps: float  # bandwidth computed from average latency
+    iterations: int
+    min_latency_us: float = 0.0
+    max_latency_us: float = 0.0
+    avg_latency_us: float = 0.0
+    p99_latency_us: float = 0.0
+    per_iter_latencies_us: List[float] = field(default_factory=list)
+
+
+@dataclass
+class BenchmarkConfig:
+    """Configuration for benchmark runs."""
+
+    warmup_iters: int = 10
+    bench_iters: int = 100
+    msg_sizes: Optional[List[int]] = None
+
+    def __post_init__(self) -> None:
+        if self.msg_sizes is None:
+            # Default message sizes (bytes per peer, equal for all peers).
+            # Matches the Pipes AllToAllvBenchmark sizing convention.
+            # Total buffer per rank = msg_size * num_ranks; must fit in pool.
+            self.msg_sizes = [
+                1024,  # 1KB
+                2 * 1024,  # 2KB
+                4 * 1024,  # 4KB
+                8 * 1024,  # 8KB
+                16 * 1024,  # 16KB
+                32 * 1024,  # 32KB
+                64 * 1024,  # 64KB
+                128 * 1024,  # 128KB
+                256 * 1024,  # 256KB
+                512 * 1024,  # 512KB
+                1024 * 1024,  # 1MB
+                2 * 1024 * 1024,  # 2MB
+                4 * 1024 * 1024,  # 4MB
+                8 * 1024 * 1024,  # 8MB
+                16 * 1024 * 1024,  # 16MB
+            ]
+
+
+class AlltoallvDynamicBenchmark:
+    """
+    Benchmark suite for device_alltoallv_dynamic vs NCCL comparison.
+
+    This benchmark measures the performance difference between:
+    - NCCL alltoallv: CPU-initiated, counts on host (Python lists)
+    - Triton device_alltoallv_dynamic: GPU-initiated, counts on device (GPU tensors)
+
+    Note: NCCL does not support GPU-resident counts. The comparison is fair
+    because it measures what users would do TODAY without device_alltoallv_dynamic.
+    """
+
+    def __init__(self, comm: "TorchComm", max_msg_size: int = 16 * 1024 * 1024) -> None:
+        import torchcomms
+        from comms.pipes.collectives.triton import alloc_comms_buffer
+
+        self.comm = comm
+        self.rank = comm.get_rank()
+        self.num_ranks = comm.get_size()
+        self.device = comm.get_device()
+        self.allocator = torchcomms.get_mem_allocator(comm.get_backend())
+        # Pool capacity must hold the largest possible buffer:
+        # total_buf = max_msg_size * num_ranks (uniform benchmark).
+        # Derived from --max-size so the user never hits SKIPPED messages.
+        self.pool_capacity = max_msg_size * self.num_ranks
+
+        # Pre-allocate fixed-size buffers from the NCCL allocator via
+        # alloc_comms_buffer, which handles transport-compatible allocation.
+        alloc_elems = self.pool_capacity // 4
+        self.recv_buf, self.recv_pool = alloc_comms_buffer(
+            alloc_elems, torch.float32, self.device, comm.get_backend()
+        )
+        self.send_buf, self.send_pool = alloc_comms_buffer(
+            alloc_elems, torch.float32, self.device, comm.get_backend()
+        )
+
+        # Register the NCCL window once, reuse across all Triton benchmarks.
+        self.comm.barrier(False)
+        self.window = self.comm.new_window()
+        self.window.tensor_register(self.recv_buf)
+
+        # get_device_window must be called before register_local_buffer to enable GIN
+        self.dev_win_ptr = self.window.get_device_window(signal_count=self.num_ranks)
+        self.src_info = self.window.register_local_buffer(self.send_buf)
+        self.comm.barrier(False)
+
+        # Storage for raw kernel benchmark graph (uses class-level pools).
+        # Must be cleaned up before pool cleanup to avoid MemPool conflicts.
+        self._current_raw_kernel_graph = None
+
+    def _deregister_src(self) -> None:
+        """Deregister send buffer so it can be modified."""
+        if self.src_info is not None:
+            self.window.deregister_local_buffer(*self.src_info)
+            self.src_info = None
+
+    def _register_src(self) -> None:
+        """Re-register send buffer after modification."""
+        if self.src_info is None:
+            self.window.get_device_window(signal_count=self.num_ranks)
+            self.src_info = self.window.register_local_buffer(self.send_buf)
+
+    def cleanup(self) -> None:
+        """Deregister window and release pools (mirrors e2e tearDownClass)."""
+        # Clean up ALL graphs FIRST, then ops, then pools.
+        # Graphs hold references to memory allocated from MemPools.
+        # If MemPools are destroyed while graphs still reference them,
+        # we get `captures_underway.empty() INTERNAL ASSERT FAILED`.
+
+        # 1. Clean up raw kernel benchmark graph (uses class-level pools)
+        if self._current_raw_kernel_graph is not None:
+            del self._current_raw_kernel_graph
+            self._current_raw_kernel_graph = None
+            torch.cuda.synchronize()
+
+        # 2. Clean up class-level window and pools
+        self.comm.barrier(False)
+        if self.src_info is not None:
+            self.window.deregister_local_buffer(*self.src_info)
+            self.src_info = None
+        if self.window is not None:
+            self.window.tensor_deregister()
+            self.window = None
+
+        # 4. Clean up class-level pools LAST (after all graphs are destroyed)
+        self.recv_buf = None
+        self.send_buf = None
+        self.recv_pool = None  # pyre-ignore[8]: Intentional cleanup
+        self.send_pool = None  # pyre-ignore[8]: Intentional cleanup
+        self.allocator = None
+        gc.collect()
+        torch.cuda.synchronize()
+
+    def benchmark_nccl_alltoallv(
+        self,
+        msg_size: int,
+        config: BenchmarkConfig,
+    ) -> BenchmarkResult:
+        """
+        Benchmark standard NCCL alltoallv (CPU-initiated).
+
+        This is standard NCCL alltoallv - NOT "alltoallv_dynamic". NCCL does not
+        have a GPU-resident counts API.
+
+        IMPORTANT: This uses CPU-resident counts (Python lists) because that's
+        how NCCL's alltoallv API works.
+
+        In a real dynamic workload where counts are computed on GPU, using NCCL
+        would ALSO require a D2H copy to get counts to CPU - which is NOT
+        included in this benchmark timing (making NCCL appear faster than it
+        would be in practice).
+
+        Equal sizes per peer: msg_size bytes per peer (matches Pipes benchmark).
+        Reuses the shared pre-allocated buffers (same pattern as e2e tests).
+        """
+        # Equal sizes per peer (matching Pipes AllToAllvBenchmark)
+        dtype = torch.float32
+        element_size = dtype.itemsize  # 4 bytes for float32
+        elems_per_peer = msg_size // element_size
+        # NOTE: These are Python lists (CPU memory) - this is NCCL's API requirement
+        # Sizes are in number of elements (not bytes) to match all_to_all_v_single API
+        send_sizes = [elems_per_peer] * self.num_ranks
+        recv_sizes = [elems_per_peer] * self.num_ranks
+        total_send = elems_per_peer * self.num_ranks
+        total_recv = elems_per_peer * self.num_ranks
+
+        # Deregister before buffer modifications, re-register after
+        self._deregister_src()
+        self.send_buf.zero_()
+        self.recv_buf.zero_()
+        self.send_buf[:total_send].normal_()
+        self._register_src()
+
+        # Warmup
+        for _ in range(config.warmup_iters):
+            self.comm.all_to_all_v_single(
+                self.recv_buf, self.send_buf, recv_sizes, send_sizes, async_op=False
+            )
+
+        # Benchmark — single event pair wrapping all iterations (matches Pipes
+        # AllToAllvBenchmark methodology: avoids per-iteration event overhead
+        # that inflates small-message latencies by ~1-2us per event pair).
+        start_ev = torch.cuda.Event(enable_timing=True)
+        end_ev = torch.cuda.Event(enable_timing=True)
+        start_ev.record()
+        for _ in range(config.bench_iters):
+            self.comm.all_to_all_v_single(
+                self.recv_buf, self.send_buf, recv_sizes, send_sizes, async_op=False
+            )
+        end_ev.record()
+        torch.cuda.synchronize()
+
+        total_ms = start_ev.elapsed_time(end_ev)
+        avg_us = total_ms * 1e3 / config.bench_iters
+        total_bytes = (total_send + total_recv) * element_size
+        bandwidth_gbps = total_bytes / (avg_us * 1e-6) / 1e9
+
+        return BenchmarkResult(
+            name="nccl_alltoallv",
+            msg_size_bytes=msg_size,
+            num_ranks=self.num_ranks,
+            latency_us=avg_us,
+            bandwidth_gbps=bandwidth_gbps,
+            iterations=config.bench_iters,
+            avg_latency_us=avg_us,
+        )
+
+    def benchmark_nccl_alltoallv_graph(
+        self,
+        msg_size: int,
+        config: BenchmarkConfig,
+    ) -> BenchmarkResult:
+        """
+        Benchmark NCCL alltoallv using CUDA graph capture + replay.
+
+        Captures ALL iterations inside a single CUDA graph, then replays
+        once.  This eliminates all per-iteration CPU overhead (mutexes,
+        event creation, heap allocations, cudaGraphLaunch) and isolates
+        the pure GPU-side NCCL transfer time.
+        """
+        dtype = torch.float32
+        element_size = dtype.itemsize
+        elems_per_peer = msg_size // element_size
+        send_sizes = [elems_per_peer] * self.num_ranks
+        recv_sizes = [elems_per_peer] * self.num_ranks
+        total_send = elems_per_peer * self.num_ranks
+        total_recv = elems_per_peer * self.num_ranks
+
+        self._deregister_src()
+        self.send_buf.zero_()
+        self.recv_buf.zero_()
+        self.send_buf[:total_send].normal_()
+        self._register_src()
+
+        # Warmup (eager, to initialize NCCL internals)
+        for _ in range(config.warmup_iters):
+            self.comm.all_to_all_v_single(
+                self.recv_buf, self.send_buf, recv_sizes, send_sizes, async_op=False
+            )
+        torch.cuda.synchronize()
+
+        # Capture bench_iters iterations in a single CUDA graph
+        graph_stream = torch.cuda.Stream()
+        with torch.cuda.stream(graph_stream):
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                for _ in range(config.bench_iters):
+                    self.comm.all_to_all_v_single(
+                        self.recv_buf,
+                        self.send_buf,
+                        recv_sizes,
+                        send_sizes,
+                        async_op=False,
+                    )
+
+        # Warmup graph replay.
+        # NOTE: Signal counters accumulate across replays (ADD-based).
+        # After the first replay, subsequent replays see pre-satisfied
+        # waits because the baked-in iteration thresholds are already
+        # exceeded.  This matches NCCL graph replay behavior.
+        with torch.cuda.stream(graph_stream):
+            for _ in range(config.warmup_iters):
+                graph.replay()
+        torch.cuda.synchronize()
+
+        # Benchmark: single graph replay = bench_iters iterations
+        start_ev = torch.cuda.Event(enable_timing=True)
+        end_ev = torch.cuda.Event(enable_timing=True)
+        with torch.cuda.stream(graph_stream):
+            start_ev.record()
+            graph.replay()
+            end_ev.record()
+        torch.cuda.synchronize()
+
+        total_ms = start_ev.elapsed_time(end_ev)
+        avg_us = total_ms * 1e3 / config.bench_iters
+        total_bytes = (total_send + total_recv) * element_size
+        bandwidth_gbps = total_bytes / (avg_us * 1e-6) / 1e9
+
+        del graph
+
+        return BenchmarkResult(
+            name="nccl_graph",
+            msg_size_bytes=msg_size,
+            num_ranks=self.num_ranks,
+            latency_us=avg_us,
+            bandwidth_gbps=bandwidth_gbps,
+            iterations=config.bench_iters,
+            avg_latency_us=avg_us,
+        )
+
+    def benchmark_triton_alltoallv_dynamic(
+        self,
+        msg_size: int,
+        config: BenchmarkConfig,
+        num_warps: int = 16,
+        blocks_per_peer: int = 1,
+        chunk_size: int = 256 * 1024,
+    ) -> BenchmarkResult:
+        """
+        Benchmark Triton device_alltoallv_dynamic (GPU-initiated).
+
+        This uses GPU-resident counts (torch tensors on CUDA). The kernel reads
+        counts directly from GPU memory via tl.load() - no CPU involvement.
+
+        Uses the pre-allocated shared buffers and window (same pattern as e2e tests).
+        """
+        from comms.pipes.collectives.triton import (
+            compute_offsets_from_sizes,
+            device_alltoallv_dynamic,
+            exchange_offsets,
+        )
+
+        # Equal sizes per peer in BYTES (matches Pipes AllToAllvBenchmark)
+        send_sizes_list = [msg_size] * self.num_ranks
+        recv_sizes_list = [msg_size] * self.num_ranks
+        total_send = msg_size * self.num_ranks
+        total_recv = msg_size * self.num_ranks
+
+        # Deregister before buffer modifications, re-register after
+        self._deregister_src()
+        self.send_buf.zero_()
+        self.recv_buf.zero_()
+        self.send_buf[: total_send // 4].normal_()
+
+        # NOTE: These are GPU tensors — create before GIN is active
+        send_sizes = torch.tensor(
+            send_sizes_list, dtype=torch.int64, device=self.device
+        )
+        send_offsets = torch.zeros_like(send_sizes)
+        compute_offsets_from_sizes(send_sizes, send_offsets)
+
+        recv_sizes = torch.tensor(
+            recv_sizes_list, dtype=torch.int64, device=self.device
+        )
+        recv_offsets = torch.zeros_like(recv_sizes)
+        compute_offsets_from_sizes(recv_sizes, recv_offsets)
+
+        # Pre-compute dst_offsets once (offset exchange) before registration
+        dst_offsets = exchange_offsets(recv_offsets, self.comm)
+
+        self._register_src()
+        self.comm.barrier(False)
+
+        # Warmup
+        for _ in range(config.warmup_iters):
+            device_alltoallv_dynamic(
+                self.send_buf,
+                self.recv_buf,
+                send_sizes,
+                send_offsets,
+                recv_sizes,
+                recv_offsets,
+                dst_offsets,
+                self.dev_win_ptr,
+                self.src_info,
+                self.rank,
+                self.num_ranks,
+                num_warps=num_warps,
+                blocks_per_peer=blocks_per_peer,
+                chunk_size=chunk_size,
+                sync_buffer=False,  # Benchmark: measure raw kernel throughput
+            )
+        torch.cuda.synchronize()
+
+        self.comm.barrier(False)
+
+        # Benchmark — single event pair wrapping all iterations (matches Pipes
+        # AllToAllvBenchmark methodology).
+        start_ev = torch.cuda.Event(enable_timing=True)
+        end_ev = torch.cuda.Event(enable_timing=True)
+        start_ev.record()
+        for _ in range(config.bench_iters):
+            device_alltoallv_dynamic(
+                self.send_buf,
+                self.recv_buf,
+                send_sizes,
+                send_offsets,
+                recv_sizes,
+                recv_offsets,
+                dst_offsets,
+                self.dev_win_ptr,
+                self.src_info,
+                self.rank,
+                self.num_ranks,
+                num_warps=num_warps,
+                blocks_per_peer=blocks_per_peer,
+                chunk_size=chunk_size,
+                sync_buffer=False,  # Benchmark: measure raw kernel throughput
+            )
+        end_ev.record()
+        torch.cuda.synchronize()
+
+        total_ms = start_ev.elapsed_time(end_ev)
+        avg_us = total_ms * 1e3 / config.bench_iters
+        total_bytes = total_send + total_recv
+        bandwidth_gbps = total_bytes / (avg_us * 1e-6) / 1e9
+
+        return BenchmarkResult(
+            name=f"triton_dynamic_w{num_warps} (GPU counts)",
+            msg_size_bytes=msg_size,
+            num_ranks=self.num_ranks,
+            latency_us=avg_us,
+            bandwidth_gbps=bandwidth_gbps,
+            iterations=config.bench_iters,
+            avg_latency_us=avg_us,
+        )
+
+    def benchmark_triton_alltoallv_dynamic_graph(
+        self,
+        msg_size: int,
+        config: BenchmarkConfig,
+        num_warps: int = 16,
+        blocks_per_peer: int = 1,
+        chunk_size: int = 256 * 1024,
+    ) -> BenchmarkResult:
+        """
+        Benchmark Triton device_alltoallv_dynamic using CUDA graph capture + replay.
+
+        Captures ALL iterations inside a single CUDA graph, then replays
+        once.  This eliminates per-iteration Python/CPU overhead and isolates
+        the pure GPU-side Triton kernel time.
+        """
+        from comms.pipes.collectives.triton import (
+            compute_offsets_from_sizes,
+            device_alltoallv_dynamic,
+            exchange_offsets,
+        )
+
+        send_sizes_list = [msg_size] * self.num_ranks
+        recv_sizes_list = [msg_size] * self.num_ranks
+        total_send = msg_size * self.num_ranks
+        total_recv = msg_size * self.num_ranks
+
+        self._deregister_src()
+        self.send_buf.zero_()
+        self.recv_buf.zero_()
+        self.send_buf[: total_send // 4].normal_()
+
+        send_sizes = torch.tensor(
+            send_sizes_list, dtype=torch.int64, device=self.device
+        )
+        send_offsets = torch.zeros_like(send_sizes)
+        compute_offsets_from_sizes(send_sizes, send_offsets)
+
+        recv_sizes = torch.tensor(
+            recv_sizes_list, dtype=torch.int64, device=self.device
+        )
+        recv_offsets = torch.zeros_like(recv_sizes)
+        compute_offsets_from_sizes(recv_sizes, recv_offsets)
+
+        dst_offsets = exchange_offsets(recv_offsets, self.comm)
+
+        self._register_src()
+        self.comm.barrier(False)
+
+        # Warmup (eager, to compile Triton kernel and initialize state)
+        for _ in range(config.warmup_iters):
+            device_alltoallv_dynamic(
+                self.send_buf,
+                self.recv_buf,
+                send_sizes,
+                send_offsets,
+                recv_sizes,
+                recv_offsets,
+                dst_offsets,
+                self.dev_win_ptr,
+                self.src_info,
+                self.rank,
+                self.num_ranks,
+                num_warps=num_warps,
+                blocks_per_peer=blocks_per_peer,
+                chunk_size=chunk_size,
+                sync_buffer=False,  # Benchmark: measure raw kernel throughput
+            )
+        torch.cuda.synchronize()
+
+        self.comm.barrier(False)
+
+        # Capture bench_iters iterations in a single CUDA graph.
+        # The iteration tensor is incremented via add_(1) inside the captured
+        # graph, ensuring each iteration sees a monotonically increasing value.
+        # This enables correct wait_signal_from behavior during graph replay.
+        #
+        # Store graph at class level to control cleanup order. The graph
+        # uses class-level pools (recv_pool, send_pool) and must be deleted
+        # BEFORE those pools to avoid MemPool cleanup conflicts.
+        if self._current_raw_kernel_graph is not None:
+            del self._current_raw_kernel_graph
+            self._current_raw_kernel_graph = None
+            torch.cuda.synchronize()
+
+        graph_stream = torch.cuda.Stream()
+        with torch.cuda.stream(graph_stream):
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                for _ in range(config.bench_iters):
+                    device_alltoallv_dynamic(
+                        self.send_buf,
+                        self.recv_buf,
+                        send_sizes,
+                        send_offsets,
+                        recv_sizes,
+                        recv_offsets,
+                        dst_offsets,
+                        self.dev_win_ptr,
+                        self.src_info,
+                        self.rank,
+                        self.num_ranks,
+                        num_warps=num_warps,
+                        blocks_per_peer=blocks_per_peer,
+                        chunk_size=chunk_size,
+                        sync_buffer=False,  # Benchmark: measure raw kernel throughput
+                    )
+
+        # Store graph at class level to prevent cleanup during function return
+        self._current_raw_kernel_graph = graph
+
+        # Warmup graph replay
+        with torch.cuda.stream(graph_stream):
+            for _ in range(config.warmup_iters):
+                graph.replay()
+        torch.cuda.synchronize()
+
+        # Benchmark: single graph replay = bench_iters iterations
+        start_ev = torch.cuda.Event(enable_timing=True)
+        end_ev = torch.cuda.Event(enable_timing=True)
+        with torch.cuda.stream(graph_stream):
+            start_ev.record()
+            graph.replay()
+            end_ev.record()
+        torch.cuda.synchronize()
+
+        total_ms = start_ev.elapsed_time(end_ev)
+        avg_us = total_ms * 1e3 / config.bench_iters
+        total_bytes = total_send + total_recv
+        bandwidth_gbps = total_bytes / (avg_us * 1e-6) / 1e9
+
+        del graph
+
+        return BenchmarkResult(
+            name=f"triton_graph_w{num_warps}",
+            msg_size_bytes=msg_size,
+            num_ranks=self.num_ranks,
+            latency_us=avg_us,
+            bandwidth_gbps=bandwidth_gbps,
+            iterations=config.bench_iters,
+            avg_latency_us=avg_us,
+        )
+
+    def benchmark_alltoallv_op(
+        self,
+        msg_size: int,
+        config: BenchmarkConfig,
+    ) -> BenchmarkResult:
+        """
+        Benchmark AlltoallvOp (packed output is now the default).
+
+        Uses CUDA graph capture/replay for accurate latency measurement.
+        Returns contiguous packed output for MSL API compatibility.
+
+        NOTE: Only uniform distribution is supported. For uniform distribution
+        (benchmark case), packed output is a zero-copy view of the internal
+        data since slots are back-to-back.
+        """
+        from comms.pipes.collectives.triton import AlltoallvOp
+
+        dtype = torch.float32
+        element_size = dtype.itemsize
+        D = 128  # Hidden dimension for benchmark
+        elems_per_peer = msg_size // element_size // D
+        if elems_per_peer == 0:
+            elems_per_peer = 1
+        # max_input_tokens is the total tokens we send (to all peers combined).
+        # max_recv_tokens_per_peer is the max tokens received from any single peer.
+        # For uniform distribution, each peer sends elems_per_peer to each other peer.
+        max_input_tokens = elems_per_peer * self.num_ranks
+        max_recv_tokens_per_peer = (
+            elems_per_peer  # uniform: each peer sends same amount
+        )
+
+        # Create AlltoallvOp with sync_buffer=False for raw kernel overhead measurement.
+        # NOTE: This is NOT production-safe. Use sync_buffer=True (the default) for
+        # production code involving CUDA graphs or buffer reuse across iterations.
+        op = AlltoallvOp(
+            self.comm,
+            max_input_tokens=max_input_tokens,
+            D=D,
+            dtype=dtype,
+            device=self.device,
+            max_recv_tokens_per_peer=max_recv_tokens_per_peer,
+            sync_buffer=False,
+        )
+
+        input_split_sizes = torch.full(
+            (self.num_ranks,), elems_per_peer, dtype=torch.int64, device=self.device
+        )
+        output_split_sizes = input_split_sizes.clone()
+
+        # Pre-compute packed_output_tokens for CUDA graph capture.
+        # For uniform split sizes, this is simply elems_per_peer * num_ranks.
+        packed_output_tokens = elems_per_peer * self.num_ranks
+
+        # Zero-copy path: fill send buffer BEFORE setup (GIN blocks regular fills)
+        send_buf = op.get_send_buffer(max_input_tokens)
+        send_buf.normal_()  # Fill with random data once
+
+        # Setup (enables GIN, registers buffers)
+        op.setup()
+
+        # Warmup (eager, to compile Triton kernels).
+        # First call auto-runs prep kernel; subsequent calls auto-skip.
+        for _ in range(config.warmup_iters):
+            _ = op.alltoallv_from_buffer(
+                output_split_sizes,
+                input_split_sizes,
+                num_input_tokens=max_input_tokens,
+                packed_output_tokens=packed_output_tokens,
+            )
+        torch.cuda.synchronize()
+        self.comm.barrier(False)
+
+        # Capture bench_iters iterations in the graph (as users would do).
+        # Pass pool=op.get_graph_pool_id() to ensure allocations use the
+        # same transport-compatible pool as AlltoallvOp's buffers.
+        # Pass packed_output_tokens to avoid .item() call during capture.
+        # Prep kernel is auto-skipped since it ran during warmup.
+        graph_stream = torch.cuda.Stream()
+        with torch.cuda.stream(graph_stream):
+            graph = torch.cuda.CUDAGraph()
+            # pyre-fixme[6]: Pyre doesn't recognize pool ID as valid _POOL_HANDLE
+            with torch.cuda.graph(graph, pool=op.get_graph_pool_id()):  # type: ignore[arg-type]
+                for _ in range(config.bench_iters):
+                    _ = op.alltoallv_from_buffer(
+                        output_split_sizes,
+                        input_split_sizes,
+                        num_input_tokens=max_input_tokens,
+                        packed_output_tokens=packed_output_tokens,
+                    )
+
+        # Warmup graph replay (like the raw kernel benchmark does)
+        with torch.cuda.stream(graph_stream):
+            for _ in range(config.warmup_iters):
+                graph.replay()
+        torch.cuda.synchronize()
+
+        # Benchmark: single graph replay = bench_iters iterations
+        start_ev = torch.cuda.Event(enable_timing=True)
+        end_ev = torch.cuda.Event(enable_timing=True)
+        with torch.cuda.stream(graph_stream):
+            start_ev.record()
+            graph.replay()
+            end_ev.record()
+        torch.cuda.synchronize()
+
+        total_ms = start_ev.elapsed_time(end_ev)
+        avg_us = total_ms * 1e3 / config.bench_iters
+        total_bytes = msg_size * self.num_ranks * 2  # send + recv
+        bandwidth_gbps = total_bytes / (avg_us * 1e-6) / 1e9
+
+        # Clean up graph and op after benchmark.
+        del graph
+        op.teardown()
+        del op
+        gc.collect()
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()
+
+        return BenchmarkResult(
+            name="op_packed_graph",
+            msg_size_bytes=msg_size,
+            num_ranks=self.num_ranks,
+            latency_us=avg_us,
+            bandwidth_gbps=bandwidth_gbps,
+            iterations=config.bench_iters,
+            avg_latency_us=avg_us,
+        )
+
+    def benchmark_alltoallv_op_sync_buffer(
+        self,
+        msg_size: int,
+        config: BenchmarkConfig,
+    ) -> BenchmarkResult:
+        """
+        Benchmark AlltoallvOp with sync_buffer=True (buffer-ready synchronization).
+
+        Uses CUDA graph capture/replay for accurate latency measurement.
+        This measures the overhead of buffer-ready synchronization, which is
+        required for safe buffer reuse in fused compute+communication kernels.
+
+        The sync_buffer mode adds ~1-3us per-peer latency overhead due to additional
+        BUFFER_READY signal exchanges. This overhead is acceptable for fused
+        kernels where buffer safety is required, but unnecessary for standalone
+        alltoallv calls.
+
+        Best for: Persistent/mega-kernels, fused MoE dispatch+alltoallv+combine.
+        """
+        from comms.pipes.collectives.triton import AlltoallvOp
+
+        dtype = torch.float32
+        element_size = dtype.itemsize
+        D = 128  # Hidden dimension for benchmark
+        elems_per_peer = msg_size // element_size // D
+        if elems_per_peer == 0:
+            elems_per_peer = 1
+        # max_input_tokens is the total tokens we send (to all peers combined).
+        # max_recv_tokens_per_peer is the max tokens received from any single peer.
+        # For uniform distribution, each peer sends elems_per_peer to each other peer.
+        max_input_tokens = elems_per_peer * self.num_ranks
+        max_recv_tokens_per_peer = (
+            elems_per_peer  # uniform: each peer sends same amount
+        )
+
+        # Create AlltoallvOp with sync_buffer=True (the default) for production-safe
+        # buffer-ready synchronization across iterations.
+        op = AlltoallvOp(
+            self.comm,
+            max_input_tokens=max_input_tokens,
+            D=D,
+            dtype=dtype,
+            device=self.device,
+            max_recv_tokens_per_peer=max_recv_tokens_per_peer,
+            # sync_buffer=True is the default, explicit for clarity
+        )
+
+        input_split_sizes = torch.full(
+            (self.num_ranks,), elems_per_peer, dtype=torch.int64, device=self.device
+        )
+        output_split_sizes = input_split_sizes.clone()
+
+        # Pre-compute packed_output_tokens for CUDA graph capture.
+        # For uniform split sizes, this is simply elems_per_peer * num_ranks.
+        # This avoids .item() call during graph capture which would cause errors.
+        packed_output_tokens = elems_per_peer * self.num_ranks
+
+        # Zero-copy path: fill send buffer BEFORE setup (GIN blocks regular fills)
+        send_buf = op.get_send_buffer(max_input_tokens)
+        send_buf.normal_()  # Fill with random data once
+
+        # Setup (enables GIN, registers buffers)
+        op.setup()
+
+        # Warmup (eager, to compile Triton kernels).
+        # First call auto-runs prep kernel; subsequent calls auto-skip.
+        for _ in range(config.warmup_iters):
+            _ = op.alltoallv_from_buffer(
+                output_split_sizes,
+                input_split_sizes,
+                num_input_tokens=max_input_tokens,
+                packed_output_tokens=packed_output_tokens,
+            )
+        torch.cuda.synchronize()
+        self.comm.barrier(False)
+
+        # Capture bench_iters iterations in the graph (as users would do).
+        # Pass pool=op.get_graph_pool_id() to ensure allocations use the
+        # same transport-compatible pool as AlltoallvOp's buffers.
+        # Pass packed_output_tokens to avoid .item() call during capture.
+        # Prep kernel is auto-skipped since it ran during warmup.
+        graph_stream = torch.cuda.Stream()
+        with torch.cuda.stream(graph_stream):
+            graph = torch.cuda.CUDAGraph()
+            # pyre-fixme[6]: Pyre doesn't recognize pool ID as valid _POOL_HANDLE
+            with torch.cuda.graph(graph, pool=op.get_graph_pool_id()):  # type: ignore[arg-type]
+                for _ in range(config.bench_iters):
+                    _ = op.alltoallv_from_buffer(
+                        output_split_sizes,
+                        input_split_sizes,
+                        num_input_tokens=max_input_tokens,
+                        packed_output_tokens=packed_output_tokens,
+                    )
+
+        # Warmup graph replay (like the raw kernel benchmark does)
+        with torch.cuda.stream(graph_stream):
+            for _ in range(config.warmup_iters):
+                graph.replay()
+        torch.cuda.synchronize()
+
+        # Benchmark: single graph replay = bench_iters iterations
+        start_ev = torch.cuda.Event(enable_timing=True)
+        end_ev = torch.cuda.Event(enable_timing=True)
+        with torch.cuda.stream(graph_stream):
+            start_ev.record()
+            graph.replay()
+            end_ev.record()
+        torch.cuda.synchronize()
+
+        total_ms = start_ev.elapsed_time(end_ev)
+        avg_us = total_ms * 1e3 / config.bench_iters
+        total_bytes = msg_size * self.num_ranks * 2  # send + recv
+        bandwidth_gbps = total_bytes / (avg_us * 1e-6) / 1e9
+
+        # Clean up graph and op after benchmark.
+        del graph
+        op.teardown()
+        del op
+        gc.collect()
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()
+
+        return BenchmarkResult(
+            name="op_fused_graph",
+            msg_size_bytes=msg_size,
+            num_ranks=self.num_ranks,
+            latency_us=avg_us,
+            bandwidth_gbps=bandwidth_gbps,
+            iterations=config.bench_iters,
+            avg_latency_us=avg_us,
+        )
+
+    def run_comparison(
+        self,
+        config: BenchmarkConfig,
+        test_filter: str = "",
+        include_op_benchmarks: bool = False,
+    ) -> List[BenchmarkResult]:
+        """
+        Run full comparison benchmark suite.
+
+        Compares:
+        - NCCL alltoallv (CPU-initiated, counts in Python lists)
+        - Triton device_alltoallv_dynamic (GPU-initiated, counts in GPU tensors)
+        - (Optional) AlltoallvOp benchmarks for API overhead comparison
+
+        All tests use equal sizes per peer: msg_size bytes per peer
+        (matches Pipes AllToAllvBenchmark convention).
+
+        Args:
+            test_filter: If non-empty, only run benchmarks whose name contains
+                this substring.  Supported names: "nccl", "triton".
+                Matches are case-insensitive.  An empty string runs everything.
+            include_op_benchmarks: If True, also run AlltoallvOp
+                benchmarks for API overhead comparison.
+        """
+        # Determine which benchmarks to run based on filter
+        run_nccl = not test_filter or "nccl" in test_filter.lower()
+        run_triton = (
+            not test_filter
+            or "triton" in test_filter.lower()
+            or "alltoallv" in test_filter.lower()
+        )
+        if not test_filter:
+            run_nccl = run_triton = True
+
+        all_results = []
+        table_width = 0
+
+        if self.rank == 0:
+            # Build header first to determine table width
+            if include_op_benchmarks:
+                header = f"{'Size':>12} | {'NCCLgr(us)':>12} | {'TRTgr(us)':>12} | {'TRTop(us)':>12} | {'TRTsync(us)':>12} | {'Sync Ovhd':>10} | {'Speedup':>10}"
+            else:
+                header = f"{'Size':>12} | {'NCCLgr(us)':>12} | {'TRTgr(us)':>12} | {'Speedup':>10}"
+            table_width = len(header)
+
+            print(f"\n{'=' * table_width}")
+            print(f"AlltoAllv Dynamic Benchmark: {self.num_ranks} ranks")
+            print("=" * table_width)
+            print("Comparison:")
+            print(
+                "  - NCCL alltoallv:       CPU-initiated, counts in Python lists (host memory)"
+            )
+            print(
+                "  - Triton dynamic:       GPU-initiated, counts in GPU tensors (device memory)"
+            )
+            if include_op_benchmarks:
+                print("  - TRTop:                AlltoallvOp benchmark (API overhead)")
+                print(
+                    "  - TRTsync:              AlltoallvOp with sync_buffer=True (buffer-ready sync)"
+                )
+            print()
+            print(
+                "NOTE: NCCL does NOT support GPU-resident counts. In real dynamic workloads"
+            )
+            print(
+                "      where counts are computed on GPU, NCCL would also require D2H copy."
+            )
+            print("=" * table_width)
+            print("Equal sizes per peer: msg_size bytes per peer")
+            print(f"Warmup: {config.warmup_iters}, Iterations: {config.bench_iters}")
+            print("=" * table_width)
+
+            print(header)
+            print("-" * table_width)
+
+        assert config.msg_sizes is not None
+        for msg_size in config.msg_sizes:  # pyre-ignore[16]
+            # Validate that total buffer fits within pool capacity.
+            # Equal sizes: total = msg_size * num_ranks.
+            total_buf = msg_size * self.num_ranks
+            if total_buf > self.pool_capacity:
+                if self.rank == 0:
+                    size_str = self._format_size(msg_size)
+                    print(f"{size_str:>12} | {'SKIPPED - exceeds pool capacity':>30}")
+                continue
+
+            nccl_result = None
+            triton_result = None
+            op_result = None
+            sync_buffer_result = None
+
+            # Run NCCL via CUDA graph (baseline)
+            if run_nccl:
+                nccl_result = self.benchmark_nccl_alltoallv_graph(msg_size, config)
+                all_results.append(nccl_result)
+
+            # Run Triton raw kernel via CUDA graph (auto-tuned parameters)
+            if run_triton:
+                from comms.pipes.collectives.triton.device_alltoallv_dynamic import (
+                    auto_tune_alltoallv_params,
+                )
+
+                auto_params = auto_tune_alltoallv_params(msg_size)
+                triton_result = self.benchmark_triton_alltoallv_dynamic_graph(
+                    msg_size,
+                    config,
+                    num_warps=auto_params["num_warps"],
+                    blocks_per_peer=auto_params["blocks_per_peer"],
+                    chunk_size=auto_params["chunk_size"],
+                )
+                all_results.append(triton_result)
+
+            # Optionally run AlltoallvOp benchmarks for API overhead comparison
+            if run_triton and include_op_benchmarks:
+                op_result = self.benchmark_alltoallv_op(msg_size, config)
+                all_results.append(op_result)
+                # Ensure full cleanup before running next benchmark to avoid
+                # graph pool conflicts between different AlltoallvOp instances.
+                # The barrier + sleep ensures all ranks have completed cleanup
+                # before creating new CUDA resources.
+                torch.cuda.synchronize()
+                gc.collect()
+                torch.cuda.empty_cache()
+                self.comm.barrier(False)
+                time.sleep(0.1)  # Allow background threads to settle
+                sync_buffer_result = self.benchmark_alltoallv_op_sync_buffer(
+                    msg_size, config
+                )
+                all_results.append(sync_buffer_result)
+
+            if self.rank == 0:
+                size_str = self._format_size(msg_size)
+                nccl_str = (
+                    f"{nccl_result.latency_us:>12.2f}"
+                    if nccl_result
+                    else f"{'skip':>12}"
+                )
+                triton_str = (
+                    f"{triton_result.latency_us:>12.2f}"
+                    if triton_result
+                    else f"{'skip':>12}"
+                )
+
+                if include_op_benchmarks:
+                    op_str = (
+                        f"{op_result.latency_us:>12.2f}"
+                        if op_result
+                        else f"{'skip':>12}"
+                    )
+                    sync_str = (
+                        f"{sync_buffer_result.latency_us:>12.2f}"
+                        if sync_buffer_result
+                        else f"{'skip':>12}"
+                    )
+                    # Calculate sync_buffer overhead compared to op_result (baseline)
+                    if sync_buffer_result and op_result:
+                        overhead_us = (
+                            sync_buffer_result.latency_us - op_result.latency_us
+                        )
+                        overhead_per_peer = overhead_us / max(1, self.num_ranks - 1)
+                        overhead_str = (
+                            f"+{overhead_us:>4.1f}({overhead_per_peer:.1f}/p)"
+                        )
+                    else:
+                        overhead_str = f"{'-':>10}"
+                    row = f"{size_str:>12} | {nccl_str} | {triton_str} | {op_str} | {sync_str} | {overhead_str:>10}"
+                else:
+                    row = f"{size_str:>12} | {nccl_str} | {triton_str}"
+
+                # Compute speedup vs NCCL (using raw kernel for fair comparison)
+                if nccl_result and triton_result:
+                    speedup = nccl_result.latency_us / triton_result.latency_us
+                    row += f" | {speedup:>10.2f}x"
+                else:
+                    row += f" | {'-':>10}"
+
+                print(row)
+
+        if self.rank == 0:
+            print("=" * table_width)
+
+        return all_results
+
+    def run_num_warps_sweep(
+        self,
+        config: BenchmarkConfig,
+        warp_counts: Optional[List[int]] = None,
+        block_counts: Optional[List[int]] = None,
+        custom_configs: Optional[List[dict]] = None,
+    ) -> List[BenchmarkResult]:
+        """
+        Sweep num_warps and blocks_per_peer for eager and graph kernels.
+
+        Produces a table showing how latency varies with warp count and
+        blocks_per_peer across all message sizes for all modes.
+
+        Column groups (left to right):
+        - NCCL(us), NCCLgr(us): baselines
+        - w{N}(us): eager, 1 block/peer, sweeping warps
+        - Gw{N}(us): CUDA graph, 1 block/peer, sweeping warps
+        - B{B}(us): eager, {B} blocks/peer, fixed 16 warps
+        - GB{B}(us): CUDA graph, {B} blocks/peer, fixed 16 warps
+
+        Args:
+            config: Benchmark configuration with message sizes, warmup, etc.
+            warp_counts: List of num_warps values to test (default: [4, 8, 16, 32]).
+            block_counts: List of blocks_per_peer values to test
+                          (default: [2, 4, 8, 16, 32]).  Only applied to
+                          eager and graph variants at 16 warps/block.
+        """
+        if warp_counts is None:
+            warp_counts = [4, 8, 16, 32]
+        if block_counts is None:
+            block_counts = [2, 4, 8, 16, 32]
+
+        # Build human-readable labels for custom configs
+        custom_labels = []
+        if custom_configs:
+            for cc in custom_configs:
+                b, w, c = cc["blocks_per_peer"], cc["num_warps"], cc["chunk_size"]
+                if b == 1:
+                    custom_labels.append(f"Gw{w}")
+                else:
+                    custom_labels.append(f"B{b}w{w}c{c // 1024}")
+
+        all_results = []
+        table_width = 0
+
+        if self.rank == 0:
+            # Build header — use compact widths to fit ~240-char terminal
+            header = f"{'Size':>10} | {'NCCLgr':>9}"
+            for w in warp_counts:
+                header += f" | {'Gw' + str(w):>8}"
+            for b in block_counts:
+                header += f" | {'GB' + str(b):>8}"
+            header += f" | {'GB16c64':>9}"
+            for lbl in custom_labels:
+                header += f" | {lbl:>10}"
+            header += f" | {'Auto':>8}"
+            header += f" | {'AutoCfg':>10}"
+            header += f" | {'Best':>14}"
+            table_width = len(header)
+
+            print(f"\n{'=' * table_width}")
+            print(f"Num Warps + Blocks/Peer Sweep: {self.num_ranks} ranks")
+            print("=" * table_width)
+            print("Compares eager and CUDA-graph kernels.")
+            print("Higher warps = more threads for NVLink memcpy in put_block.")
+            print(
+                "Higher blocks/peer = more parallel put_block calls "
+                "per peer (splits data into chunks)."
+            )
+            print(
+                f"Warp counts: {warp_counts}  "
+                f"(threads per block: {[w * 32 for w in warp_counts]})"
+            )
+            print(
+                f"Blocks/peer: {block_counts}  (at 16 warps/block = 512 threads/block)"
+            )
+            print("All values in microseconds (us).")
+            print("=" * table_width)
+
+            print(header)
+            print("-" * table_width)
+
+        assert config.msg_sizes is not None
+        for msg_size in config.msg_sizes:  # pyre-ignore[16]
+            total_buf = msg_size * self.num_ranks
+            if total_buf > self.pool_capacity:
+                if self.rank == 0:
+                    size_str = self._format_size(msg_size)
+                    print(f"{size_str:>10} | {'SKIPPED - exceeds pool capacity':>30}")
+                continue
+
+            # NCCL via CUDA graph
+            nccl_graph_result = self.benchmark_nccl_alltoallv_graph(msg_size, config)
+            all_results.append(nccl_graph_result)
+
+            # Graph warp sweep (1 block/peer)
+            g_results = {}
+            for w in warp_counts:
+                r = self.benchmark_triton_alltoallv_dynamic_graph(
+                    msg_size, config, num_warps=w
+                )
+                g_results[w] = r
+                all_results.append(r)
+
+            # Graph blocks_per_peer sweep (16 warps)
+            gbp_results = {}
+            for b in block_counts:
+                r = self.benchmark_triton_alltoallv_dynamic_graph(
+                    msg_size, config, num_warps=16, blocks_per_peer=b
+                )
+                gbp_results[b] = r
+                all_results.append(r)
+
+            # Multi-SM config: 16 blocks/peer, 8 warps/block, 64KB chunks
+            msm_graph_result = self.benchmark_triton_alltoallv_dynamic_graph(
+                msg_size,
+                config,
+                num_warps=8,
+                blocks_per_peer=16,
+                chunk_size=64 * 1024,
+            )
+            all_results.append(msm_graph_result)
+
+            # Custom configs
+            cc_results = {}
+            if custom_configs:
+                for i, cc in enumerate(custom_configs):
+                    r = self.benchmark_triton_alltoallv_dynamic_graph(
+                        msg_size,
+                        config,
+                        num_warps=cc["num_warps"],
+                        blocks_per_peer=cc["blocks_per_peer"],
+                        chunk_size=cc["chunk_size"],
+                    )
+                    cc_results[i] = r
+                    all_results.append(r)
+
+            # Auto-tuned
+
+            # Auto-tuned: select optimal parameters based on msg_size
+            from comms.pipes.collectives.triton.device_alltoallv_dynamic import (
+                auto_tune_alltoallv_params,
+            )
+
+            auto_params = auto_tune_alltoallv_params(msg_size)
+            auto_result = self.benchmark_triton_alltoallv_dynamic_graph(
+                msg_size,
+                config,
+                num_warps=auto_params["num_warps"],
+                blocks_per_peer=auto_params["blocks_per_peer"],
+                chunk_size=auto_params["chunk_size"],
+            )
+            all_results.append(auto_result)
+
+            # Derive a human-readable label for the auto-tuned config
+            # so the report shows which specific config Auto maps to.
+            ap_bpp = auto_params["blocks_per_peer"]
+            ap_nw = auto_params["num_warps"]
+            ap_cs = auto_params["chunk_size"]
+            if ap_bpp == 1:
+                auto_config_label = f"Gw{ap_nw}"
+            else:
+                chunk_kb = ap_cs // 1024
+                auto_config_label = f"GB{ap_bpp}c{chunk_kb}"
+
+            if self.rank == 0:
+                size_str = self._format_size(msg_size)
+                row = f"{size_str:>10} | {nccl_graph_result.latency_us:>9.2f}"
+                for w in warp_counts:
+                    row += f" | {g_results[w].latency_us:>8.2f}"
+                for b in block_counts:
+                    row += f" | {gbp_results[b].latency_us:>8.2f}"
+                row += f" | {msm_graph_result.latency_us:>9.2f}"
+                for i in range(len(custom_labels)):
+                    row += f" | {cc_results[i].latency_us:>10.2f}"
+                row += f" | {auto_result.latency_us:>8.2f}"
+                row += f" | {auto_config_label:>10}"
+
+                # Find overall best across all Triton graph variants.
+                # When Auto ties the best latency, prefer Auto — it is the
+                # recommended default and should be reported as best when it
+                # matches any specific configuration.
+                all_triton: List[tuple] = []
+                for w, r in g_results.items():
+                    all_triton.append((f"Gw{w}", r))
+                for b, r in gbp_results.items():
+                    all_triton.append((f"GB{b}", r))
+                all_triton.append(("GB16c64", msm_graph_result))
+                for i, lbl in enumerate(custom_labels):
+                    all_triton.append((lbl, cc_results[i]))
+                all_triton.append(("Auto", auto_result))
+                best_name, best_result = min(all_triton, key=lambda x: x[1].latency_us)
+                if auto_result.latency_us <= best_result.latency_us:
+                    best_name = "Auto"
+                    best_result = auto_result
+                speedup = nccl_graph_result.latency_us / best_result.latency_us
+                speedup_str = f"{best_name} ({speedup:.2f}x)"
+                row += f" | {speedup_str:>14}"
+                print(row)
+
+            gc.collect()
+            torch.cuda.synchronize()
+
+        if self.rank == 0:
+            print("=" * table_width)
+            print()
+
+        return all_results
+
+    @staticmethod
+    def _format_size(size_bytes: int) -> str:
+        """Format byte size as human-readable string."""
+        if size_bytes >= 1024**3:
+            return f"{size_bytes / 1024**3:.1f}GB"
+        elif size_bytes >= 1024**2:
+            return f"{size_bytes / 1024**2:.1f}MB"
+        elif size_bytes >= 1024:
+            return f"{size_bytes / 1024:.1f}KB"
+        return f"{size_bytes}B"
+
+
+def main() -> int:
+    """Run benchmark suite."""
+    parser = argparse.ArgumentParser(
+        description="AlltoAllv Dynamic Benchmark: Triton vs NCCL"
+    )
+    parser.add_argument("--warmup", type=int, default=10, help="Warmup iterations")
+    parser.add_argument("--iters", type=int, default=100, help="Benchmark iterations")
+    parser.add_argument(
+        "--min-size",
+        type=int,
+        default=1024,
+        help="Minimum per-peer message size (bytes)",
+    )
+    parser.add_argument(
+        "--max-size",
+        type=int,
+        default=16 * 1024 * 1024,
+        help="Maximum per-peer message size (bytes, default: 16MB)",
+    )
+    parser.add_argument(
+        "--sweep-warps",
+        action="store_true",
+        help="Run num_warps sweep (4, 8, 16, 32) across all message sizes",
+    )
+    parser.add_argument(
+        "--warp-counts",
+        type=str,
+        default="4,8,16,32",
+        help="Comma-separated list of num_warps values for --sweep-warps (default: 4,8,16,32)",
+    )
+    parser.add_argument(
+        "--block-counts",
+        type=str,
+        default="2,4,8,16,32",
+        help="Comma-separated list of blocks_per_peer values for --sweep-warps (default: 2,4,8,16,32)",
+    )
+    parser.add_argument(
+        "--custom-configs",
+        type=str,
+        default="",
+        help=(
+            "Comma-separated list of custom configs to benchmark in the sweep. "
+            "Each config is BxWxC where B=blocks_per_peer, W=num_warps, "
+            "C=chunk_size in KB. Examples: '16x8x64' (GB16 w8 64KB chunks), "
+            "'8x16x32,16x4x8' (two custom configs). "
+            "These appear as additional columns in the sweep table."
+        ),
+    )
+    parser.add_argument(
+        "--test-filter",
+        type=str,
+        default="",
+        help=(
+            "Only run benchmarks whose name contains this substring "
+            "(case-insensitive). Supported: 'nccl', 'triton'. "
+            "Can also be set via TEST_FILTER env var."
+        ),
+    )
+    parser.add_argument(
+        "--include-op-benchmarks",
+        action="store_true",
+        help=(
+            "Include AlltoallvOp benchmarks in addition to "
+            "the raw kernel benchmark. Useful for comparing API overhead. Sync mode "
+            "measures buffer-ready synchronization overhead (adds ~1-3us per-peer)."
+        ),
+    )
+    args = parser.parse_args()
+
+    # TEST_FILTER: CLI flag takes precedence over env var (matching e2e test pattern)
+    test_filter = args.test_filter or os.environ.get("TEST_FILTER", "")
+
+    if not RUN_DEVICE_API_TEST:
+        print("Set RUN_DEVICE_API_TEST=true to run benchmarks")
+        return 1
+
+    if not TRITON_AVAILABLE:
+        print("Triton not available")
+        return 1
+
+    # Parse warp counts and block counts
+    warp_counts = [int(w) for w in args.warp_counts.split(",")]
+    block_counts = [int(b) for b in args.block_counts.split(",")]
+
+    # Parse custom configs: each is BxWxC (blocks x warps x chunk_kb)
+    custom_configs = []
+    if args.custom_configs:
+        for spec in args.custom_configs.split(","):
+            parts = spec.strip().split("x")
+            if len(parts) != 3:
+                print(f"Invalid custom config '{spec}': expected BxWxC (e.g. 16x8x64)")
+                return 1
+            b, w, c_kb = int(parts[0]), int(parts[1]), int(parts[2])
+            if w <= 0 or (w & (w - 1)) != 0:
+                print(
+                    f"Skipping custom config '{spec}': "
+                    f"num_warps={w} must be a power of 2"
+                )
+                continue
+            if b <= 0:
+                print(
+                    f"Skipping custom config '{spec}': blocks_per_peer={b} must be > 0"
+                )
+                continue
+            custom_configs.append(
+                {"blocks_per_peer": b, "num_warps": w, "chunk_size": c_kb * 1024}
+            )
+
+    # Initialize TorchComm
+    from torchcomms.tests.integration.py.TorchCommTestHelpers import (
+        TorchCommTestWrapper,
+    )
+
+    wrapper = TorchCommTestWrapper()
+    comm = wrapper.get_torchcomm()
+
+    # Build message sizes
+    msg_sizes = []
+    size = args.min_size
+    while size <= args.max_size:
+        msg_sizes.append(size)
+        size *= 2
+
+    config = BenchmarkConfig(
+        warmup_iters=args.warmup,
+        bench_iters=args.iters,
+        msg_sizes=msg_sizes,
+    )
+
+    benchmark = AlltoallvDynamicBenchmark(comm, max_msg_size=args.max_size)
+
+    try:
+        if args.sweep_warps:
+            # Run num_warps sweep across all message sizes
+            benchmark.run_num_warps_sweep(
+                config,
+                warp_counts=warp_counts,
+                block_counts=block_counts,
+                custom_configs=custom_configs if custom_configs else None,
+            )
+        else:
+            # Run full comparison
+            benchmark.run_comparison(
+                config,
+                test_filter=test_filter,
+                include_op_benchmarks=args.include_op_benchmarks,
+            )
+    finally:
+        benchmark.cleanup()
+        # Release comm and wrapper (mirrors e2e tearDownClass ordering).
+        # time.sleep(2) allows folly background threads to settle before
+        # process exit, avoiding std::system_error on thread creation.
+        comm = None
+        wrapper = None
+        gc.collect()
+        torch.cuda.synchronize()
+        time.sleep(2)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/comms/pipes/collectives/triton/tests/test_alltoallv_op_e2e.py
+++ b/comms/pipes/collectives/triton/tests/test_alltoallv_op_e2e.py
@@ -1,0 +1,2248 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# pyre-unsafe
+"""
+End-to-end integration tests for AlltoallvOp (high-level MSL-compatible API).
+
+Tests the simplified token-level API covering:
+- Copy-in mode with uniform splits (alltoallv)
+- Zero-copy mode via get_send_buffer + alltoallv_from_buffer
+- Repeated calls with auto-incrementing iteration counter
+- get_or_create() caching factory
+- Error handling (double setup, alltoallv without setup, oversized input)
+
+NOTE: Only uniform distribution is supported. Non-uniform distributions will
+raise a ValueError.
+
+Each test class contains a SINGLE test to avoid P2P mapping races
+between tests sharing the same NCCL allocator.  register_local_buffer
+maps GPU memory via ibv_reg_mr_iova2, and deregister_local_buffer's
+unmap can race with the next test's torch.zeros (cudaMemset).
+
+Run with:
+    buck2 test @fbcode//mode/opt \\
+        -c fbcode.enable_gpu_sections=true \\
+        -c fbcode.platform010_cuda_version=12.8 \\
+        -c fbcode.nvcc_arch=h100a \\
+        -c hpc_comms.use_ncclx=stable \\
+        fbcode//comms/torchcomms/triton/fb/tests:test_alltoallv_op_e2e
+"""
+
+import gc
+import os
+import sys
+import time
+import unittest
+from typing import Optional
+
+import torch
+from torch.utils._triton import has_triton
+from torchcomms.tests.integration.py.TorchCommTestHelpers import TorchCommTestWrapper
+
+
+TRITON_AVAILABLE = has_triton()
+RUN_DEVICE_API_TEST = os.environ.get("RUN_DEVICE_API_TEST", "false").lower() == "true"
+
+
+def _skip_if_not_ready() -> bool:
+    return TRITON_AVAILABLE and torch.cuda.is_available() and RUN_DEVICE_API_TEST
+
+
+# =============================================================================
+# Base Test Class
+# =============================================================================
+
+
+class _OpTestBase(unittest.TestCase):
+    """Base class providing common helpers for AlltoallvOp tests."""
+
+    wrapper: Optional[TorchCommTestWrapper] = None
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        if not _skip_if_not_ready():
+            raise unittest.SkipTest("E2E test environment not ready")
+
+        torch.cuda.synchronize()
+        cls.wrapper = TorchCommTestWrapper()
+        cls.torchcomm = cls.wrapper.get_torchcomm()
+        cls.rank = cls.torchcomm.get_rank()
+        cls.world_size = cls.torchcomm.get_size()
+        cls.device = cls.torchcomm.get_device()
+        cls.dtype = torch.float32
+        cls.backend = cls.torchcomm.get_backend()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        from comms.pipes.collectives.triton import AlltoallvOp
+
+        AlltoallvOp.clear_cache()
+        if cls.torchcomm is not None:
+            cls.torchcomm.barrier(False)
+        cls.torchcomm = None
+        cls.wrapper = None
+        gc.collect()
+        torch.cuda.synchronize()
+        time.sleep(2)
+
+    def _verify_packed_data(
+        self,
+        output: torch.Tensor,
+        D: int,
+        output_split_sizes: torch.Tensor,
+        test_name: str = "",
+    ) -> None:
+        """Verify data in packed contiguous layout.
+
+        The output is contiguous: [peer_0_data, peer_1_data, ..., peer_{W-1}_data].
+        Each element should be peer * 1000 + rank.
+        """
+        offset = 0
+        for peer in range(self.world_size):
+            count = int(output_split_sizes[peer].item())
+            if count == 0:
+                continue
+            actual = output[offset : offset + count, :].cpu()
+            expected_value = float(peer * 1000 + self.rank)
+            expected = torch.full_like(actual, expected_value)
+            torch.testing.assert_close(
+                actual,
+                expected,
+                msg=(
+                    f"[{test_name}] Rank {self.rank}: Data from peer {peer} at "
+                    f"offset {offset} is incorrect. Expected {expected_value}, "
+                    f"got {actual[0, :5].tolist()}..."
+                ),
+            )
+            offset += count
+
+
+# =============================================================================
+# Test: Copy-In Mode with Uniform Splits
+# =============================================================================
+
+
+class TestOpUniformSplitsCopyIn(_OpTestBase):
+    """Test alltoallv() copy-in path with uniform per-peer token counts."""
+
+    def test_uniform_splits_copy_in(self) -> None:
+        from comms.pipes.collectives.triton import AlltoallvOp
+
+        tokens_per_peer = 64
+        D = 16
+        max_input_tokens = tokens_per_peer * self.world_size
+
+        # Build the input tensor: tokens_for_peer_0 ++ tokens_for_peer_1 ++ …
+        input_tensor = torch.empty(
+            max_input_tokens, D, dtype=self.dtype, device=self.device
+        )
+        for peer in range(self.world_size):
+            start = peer * tokens_per_peer
+            input_tensor[start : start + tokens_per_peer] = float(
+                self.rank * 1000 + peer
+            )
+
+        input_split_sizes = torch.full(
+            (self.world_size,), tokens_per_peer, dtype=torch.int64, device=self.device
+        )
+        # Uniform: everyone sends the same amount → everyone receives the same.
+        output_split_sizes = input_split_sizes.clone()
+
+        op = AlltoallvOp(
+            self.torchcomm,
+            max_input_tokens,
+            D,
+            self.dtype,
+            self.device,
+            max_recv_tokens_per_peer=tokens_per_peer,
+            sync_buffer=True,
+        )
+        with op:
+            output = op.alltoallv(input_tensor, output_split_sizes, input_split_sizes)
+
+        torch.cuda.synchronize()
+        total_tokens = tokens_per_peer * self.world_size
+        self.assertEqual(
+            output.shape,
+            (total_tokens, D),
+        )
+        self._verify_packed_data(output, D, output_split_sizes, "uniform_copy_in")
+
+
+# =============================================================================
+# Test: Zero-Copy Mode via get_send_buffer
+# =============================================================================
+
+
+class TestOpZeroCopy(_OpTestBase):
+    """Test get_send_buffer() + alltoallv_from_buffer() zero-copy path."""
+
+    def test_zero_copy_send(self) -> None:
+        from comms.pipes.collectives.triton import AlltoallvOp
+
+        tokens_per_peer = 64
+        D = 16
+        max_input_tokens = tokens_per_peer * self.world_size
+        total_tokens = tokens_per_peer * self.world_size
+
+        input_split_sizes = torch.full(
+            (self.world_size,), tokens_per_peer, dtype=torch.int64, device=self.device
+        )
+        output_split_sizes = input_split_sizes.clone()
+
+        op = AlltoallvOp(
+            self.torchcomm,
+            max_input_tokens,
+            D,
+            self.dtype,
+            self.device,
+            max_recv_tokens_per_peer=tokens_per_peer,
+        )
+
+        # Fill send buffer BEFORE setup — GIN blocks regular CUDA fill ops.
+        send_buf = op.get_send_buffer(total_tokens)
+        self.assertEqual(send_buf.shape, (total_tokens, D))
+        for peer in range(self.world_size):
+            start = peer * tokens_per_peer
+            send_buf[start : start + tokens_per_peer] = float(self.rank * 1000 + peer)
+
+        with op:
+            output = op.alltoallv_from_buffer(
+                output_split_sizes,
+                input_split_sizes,
+                num_input_tokens=total_tokens,
+            )
+
+        torch.cuda.synchronize()
+        self.assertEqual(output.shape, (total_tokens, D))
+        self._verify_packed_data(output, D, output_split_sizes, "zero_copy")
+
+
+# =============================================================================
+# Test: Repeated Calls (Iteration Counter)
+# =============================================================================
+
+
+class TestOpRepeatedCalls(_OpTestBase):
+    """Test multiple consecutive alltoallv calls with iteration tracking."""
+
+    def test_repeated_calls(self) -> None:
+        from comms.pipes.collectives.triton import AlltoallvOp
+
+        tokens_per_peer = 64
+        D = 16
+        max_input_tokens = tokens_per_peer * self.world_size
+        num_iterations = 5
+
+        input_tensor = torch.empty(
+            max_input_tokens, D, dtype=self.dtype, device=self.device
+        )
+        for peer in range(self.world_size):
+            start = peer * tokens_per_peer
+            input_tensor[start : start + tokens_per_peer] = float(
+                self.rank * 1000 + peer
+            )
+
+        input_split_sizes = torch.full(
+            (self.world_size,), tokens_per_peer, dtype=torch.int64, device=self.device
+        )
+        output_split_sizes = input_split_sizes.clone()
+
+        op = AlltoallvOp(
+            self.torchcomm,
+            max_input_tokens,
+            D,
+            self.dtype,
+            self.device,
+            max_recv_tokens_per_peer=tokens_per_peer,
+        )
+        with op:
+            output = None
+            for _ in range(num_iterations):
+                output = op.alltoallv(
+                    input_tensor, output_split_sizes, input_split_sizes
+                )
+            torch.cuda.synchronize()
+
+        # Verify final output (teardown already happened via __exit__).
+        self.torchcomm.barrier(False)
+        total_tokens = tokens_per_peer * self.world_size
+        self.assertIsNotNone(output)
+        self.assertEqual(output.shape, (total_tokens, D))
+        self._verify_packed_data(output, D, output_split_sizes, "repeated_calls")
+
+
+# =============================================================================
+# Test: get_or_create() Caching Factory
+# =============================================================================
+
+
+class TestOpGetOrCreate(_OpTestBase):
+    """Test that get_or_create() returns a cached, ready-to-use op."""
+
+    def test_get_or_create_returns_same_instance(self) -> None:
+        from comms.pipes.collectives.triton import AlltoallvOp
+
+        tokens_per_peer = 32
+        D = 16
+        max_input_tokens = tokens_per_peer * self.world_size
+
+        # Create and fill input tensor BEFORE get_or_create (which calls
+        # setup and activates GIN, blocking regular CUDA fill ops).
+        input_tensor = torch.empty(
+            max_input_tokens, D, dtype=self.dtype, device=self.device
+        )
+        for peer in range(self.world_size):
+            start = peer * tokens_per_peer
+            input_tensor[start : start + tokens_per_peer] = float(
+                self.rank * 1000 + peer
+            )
+
+        input_split_sizes = torch.full(
+            (self.world_size,), tokens_per_peer, dtype=torch.int64, device=self.device
+        )
+        output_split_sizes = input_split_sizes.clone()
+
+        # First call creates and sets up the op.
+        op1 = AlltoallvOp.get_or_create(
+            self.torchcomm,
+            max_input_tokens,
+            D,
+            self.dtype,
+            self.device,
+            max_recv_tokens_per_peer=tokens_per_peer,
+        )
+        # Second call should return the exact same object.
+        op2 = AlltoallvOp.get_or_create(
+            self.torchcomm,
+            max_input_tokens,
+            D,
+            self.dtype,
+            self.device,
+            max_recv_tokens_per_peer=tokens_per_peer,
+        )
+        self.assertIs(op1, op2)
+
+        # The cached op should be ready to use (no explicit setup needed).
+        # alltoallv uses a Triton copy kernel internally (GIN-safe).
+        output = op1.alltoallv(input_tensor, output_split_sizes, input_split_sizes)
+        torch.cuda.synchronize()
+
+        total_tokens = tokens_per_peer * self.world_size
+        self.assertEqual(output.shape, (total_tokens, D))
+        self._verify_packed_data(output, D, output_split_sizes, "get_or_create")
+
+        # Cleanup: clear cache so tearDownClass can proceed cleanly.
+        AlltoallvOp.clear_cache()
+
+
+# =============================================================================
+# Test: Error Handling
+# =============================================================================
+
+
+class TestOpDoubleSetupRaises(_OpTestBase):
+    """Test that calling setup() twice without teardown() raises."""
+
+    def test_double_setup_raises(self) -> None:
+        from comms.pipes.collectives.triton import AlltoallvOp
+
+        D = 16
+        max_input_tokens = 64
+        tokens_per_peer = max_input_tokens // self.world_size
+
+        op = AlltoallvOp(
+            self.torchcomm,
+            max_input_tokens,
+            D,
+            self.dtype,
+            self.device,
+            max_recv_tokens_per_peer=tokens_per_peer,
+        )
+        op.setup()
+        with self.assertRaises(RuntimeError):
+            op.setup()
+        # Sync all ranks BEFORE teardown to avoid race conditions where one
+        # rank tears down while another is still using shared NCCL resources.
+        torch.cuda.synchronize()
+        self.torchcomm.barrier(False)
+        op.teardown()
+
+
+class TestOpAlltoallvWithoutSetupRaises(_OpTestBase):
+    """Test that calling alltoallv() without setup() raises."""
+
+    def test_alltoallv_without_setup_raises(self) -> None:
+        from comms.pipes.collectives.triton import AlltoallvOp
+
+        D = 16
+        max_input_tokens = 64
+        tokens_per_peer = max_input_tokens // self.world_size
+
+        op = AlltoallvOp(
+            self.torchcomm,
+            max_input_tokens,
+            D,
+            self.dtype,
+            self.device,
+            max_recv_tokens_per_peer=tokens_per_peer,
+        )
+        input_tensor = torch.empty(
+            max_input_tokens, D, dtype=self.dtype, device=self.device
+        )
+        split_sizes = torch.full(
+            (self.world_size,),
+            max_input_tokens // self.world_size,
+            dtype=torch.int64,
+            device=self.device,
+        )
+
+        with self.assertRaises(RuntimeError):
+            op.alltoallv(input_tensor, split_sizes, split_sizes)
+
+        # Sync all ranks BEFORE teardown to avoid race conditions where one
+        # rank tears down while another is still using shared NCCL resources.
+        torch.cuda.synchronize()
+        self.torchcomm.barrier(False)
+        op.teardown()
+
+
+class TestOpOversizedInputRaises(_OpTestBase):
+    """Test that passing an input exceeding max_input_tokens raises."""
+
+    def test_oversized_input_raises(self) -> None:
+        from comms.pipes.collectives.triton import AlltoallvOp
+
+        D = 16
+        max_input_tokens = 128
+        tokens_per_peer = max_input_tokens // self.world_size
+
+        # Oversized by 1 token
+        oversized_input = torch.empty(
+            max_input_tokens + 1, D, dtype=self.dtype, device=self.device
+        )
+        split_sizes = torch.full(
+            (self.world_size,),
+            tokens_per_peer,
+            dtype=torch.int64,
+            device=self.device,
+        )
+
+        op = AlltoallvOp(
+            self.torchcomm,
+            max_input_tokens,
+            D,
+            self.dtype,
+            self.device,
+            max_recv_tokens_per_peer=tokens_per_peer,
+        )
+        op.setup()
+
+        with self.assertRaises(ValueError):
+            op.alltoallv(oversized_input, split_sizes, split_sizes)
+
+        # Sync all ranks BEFORE teardown to avoid race conditions where one
+        # rank tears down while another is still using shared NCCL resources.
+        torch.cuda.synchronize()
+        self.torchcomm.barrier(False)
+        op.teardown()
+
+
+class TestOpOversizedGetSendBufferRaises(_OpTestBase):
+    """Test that get_send_buffer() with too many tokens raises."""
+
+    def test_oversized_get_send_buffer_raises(self) -> None:
+        from comms.pipes.collectives.triton import AlltoallvOp
+
+        D = 16
+        max_input_tokens = 64
+        tokens_per_peer = max_input_tokens // self.world_size
+
+        op = AlltoallvOp(
+            self.torchcomm,
+            max_input_tokens,
+            D,
+            self.dtype,
+            self.device,
+            max_recv_tokens_per_peer=tokens_per_peer,
+        )
+        with self.assertRaises(ValueError):
+            op.get_send_buffer(max_input_tokens + 1)
+
+        # Sync all ranks BEFORE teardown to avoid race conditions where one
+        # rank tears down while another is still using shared NCCL resources.
+        # Even though setup() was not called, the op still holds buffers
+        # that must be released cleanly.
+        torch.cuda.synchronize()
+        self.torchcomm.barrier(False)
+        op.teardown()
+
+
+class TestOpTeardownIdempotent(_OpTestBase):
+    """Test that teardown() can be called multiple times safely."""
+
+    def test_teardown_idempotent(self) -> None:
+        from comms.pipes.collectives.triton import AlltoallvOp
+
+        D = 16
+        max_input_tokens = 64
+        tokens_per_peer = max_input_tokens // self.world_size
+
+        op = AlltoallvOp(
+            self.torchcomm,
+            max_input_tokens,
+            D,
+            self.dtype,
+            self.device,
+            max_recv_tokens_per_peer=tokens_per_peer,
+        )
+        op.setup()
+        op.teardown()
+        op.teardown()  # Should not raise
+        # Sync all ranks before test ends to avoid cleanup race conditions.
+        torch.cuda.synchronize()
+        self.torchcomm.barrier(False)
+
+
+# =============================================================================
+# Test: Packed Output Mode - Uniform Splits
+# =============================================================================
+
+
+class TestOpPackedOutputUniform(_OpTestBase):
+    """Test alltoallv() with packed_output mode (now the default) and uniform splits."""
+
+    def test_packed_output_uniform(self) -> None:
+        from comms.pipes.collectives.triton import AlltoallvOp
+
+        tokens_per_peer = 64
+        D = 16
+        max_input_tokens = tokens_per_peer * self.world_size
+
+        # Build input tensor
+        input_tensor = torch.empty(
+            max_input_tokens, D, dtype=self.dtype, device=self.device
+        )
+        for peer in range(self.world_size):
+            start = peer * tokens_per_peer
+            input_tensor[start : start + tokens_per_peer] = float(
+                self.rank * 1000 + peer
+            )
+
+        input_split_sizes = torch.full(
+            (self.world_size,), tokens_per_peer, dtype=torch.int64, device=self.device
+        )
+        output_split_sizes = input_split_sizes.clone()
+
+        # Pre-compute total tokens to avoid .item() call when GIN is active
+        packed_output_tokens = tokens_per_peer * self.world_size
+
+        # Use packed_output mode (now the default) for contiguous output
+        op = AlltoallvOp(
+            self.torchcomm,
+            max_input_tokens,
+            D,
+            self.dtype,
+            self.device,
+            max_recv_tokens_per_peer=tokens_per_peer,
+        )
+        with op:
+            output = op.alltoallv(
+                input_tensor,
+                output_split_sizes,
+                input_split_sizes,
+                packed_output_tokens=packed_output_tokens,
+            )
+
+        torch.cuda.synchronize()
+
+        # Verify packed output shape
+        self.assertEqual(output.shape, (packed_output_tokens, D))
+
+        # Verify packed output data
+        self._verify_packed_data(output, D, output_split_sizes, "packed_uniform")
+
+    def _verify_packed_data(
+        self,
+        output: torch.Tensor,
+        D: int,
+        output_split_sizes: torch.Tensor,
+        test_name: str = "",
+    ) -> None:
+        """Verify data in packed contiguous layout."""
+        offset = 0
+        for peer in range(self.world_size):
+            count = int(output_split_sizes[peer].item())
+            if count == 0:
+                continue
+            actual = output[offset : offset + count, :].cpu()
+            expected_value = float(peer * 1000 + self.rank)
+            expected = torch.full_like(actual, expected_value)
+            torch.testing.assert_close(
+                actual,
+                expected,
+                msg=(
+                    f"[{test_name}] Rank {self.rank}: Data from peer {peer} at "
+                    f"offset {offset} is incorrect. Expected {expected_value}, "
+                    f"got {actual[0, :5].tolist()}..."
+                ),
+            )
+            offset += count
+
+
+# =============================================================================
+# Test: fill_send_buffer() GIN-Safe Buffer Update
+# =============================================================================
+
+
+class TestOpFillSendBufferBasic(_OpTestBase):
+    """Test fill_send_buffer() basic functionality."""
+
+    def test_fill_send_buffer_basic(self) -> None:
+        """Test that fill_send_buffer works after GIN is active."""
+        from comms.pipes.collectives.triton import AlltoallvOp
+
+        tokens_per_peer = 64
+        D = 16
+        max_input_tokens = tokens_per_peer * self.world_size
+        total_tokens = tokens_per_peer * self.world_size
+
+        # Pre-allocate input tensor BEFORE context (GIN blocks torch.empty)
+        input_tensor = torch.empty(
+            total_tokens, D, dtype=self.dtype, device=self.device
+        )
+        for peer in range(self.world_size):
+            start = peer * tokens_per_peer
+            input_tensor[start : start + tokens_per_peer] = float(
+                self.rank * 1000 + peer
+            )
+
+        input_split_sizes = torch.full(
+            (self.world_size,), tokens_per_peer, dtype=torch.int64, device=self.device
+        )
+        output_split_sizes = input_split_sizes.clone()
+
+        op = AlltoallvOp(
+            self.torchcomm,
+            max_input_tokens,
+            D,
+            self.dtype,
+            self.device,
+            max_recv_tokens_per_peer=tokens_per_peer,
+        )
+
+        with op:
+            # Use fill_send_buffer (GIN-safe) instead of direct assignment
+            send_view = op.fill_send_buffer(input_tensor)
+            self.assertEqual(send_view.shape, (total_tokens, D))
+
+            output = op.alltoallv_from_buffer(
+                output_split_sizes,
+                input_split_sizes,
+                num_input_tokens=total_tokens,
+            )
+
+        torch.cuda.synchronize()
+        self.assertEqual(output.shape, (total_tokens, D))
+        self._verify_packed_data(
+            output, D, output_split_sizes, "fill_send_buffer_basic"
+        )
+
+
+class TestOpFillSendBufferBackToBack(_OpTestBase):
+    """Test fill_send_buffer() for back-to-back iterations."""
+
+    def test_fill_send_buffer_back_to_back(self) -> None:
+        """Test multiple iterations with fill_send_buffer inside 'with op:'."""
+        from comms.pipes.collectives.triton import AlltoallvOp
+
+        tokens_per_peer = 32
+        D = 16
+        max_input_tokens = tokens_per_peer * self.world_size
+        total_tokens = tokens_per_peer * self.world_size
+        num_iterations = 5
+
+        input_split_sizes = torch.full(
+            (self.world_size,), tokens_per_peer, dtype=torch.int64, device=self.device
+        )
+        output_split_sizes = input_split_sizes.clone()
+
+        # Pre-allocate input tensor BEFORE entering context
+        input_tensor = torch.empty(
+            total_tokens, D, dtype=self.dtype, device=self.device
+        )
+        for peer in range(self.world_size):
+            start = peer * tokens_per_peer
+            input_tensor[start : start + tokens_per_peer] = float(
+                self.rank * 1000 + peer
+            )
+
+        op = AlltoallvOp(
+            self.torchcomm,
+            max_input_tokens,
+            D,
+            self.dtype,
+            self.device,
+            max_recv_tokens_per_peer=tokens_per_peer,
+        )
+
+        output = None
+        with op:
+            for _iteration in range(num_iterations):
+                # Use fill_send_buffer to copy into registered buffer (GIN-safe)
+                op.fill_send_buffer(input_tensor, num_tokens=total_tokens)
+
+                output = op.alltoallv_from_buffer(
+                    output_split_sizes,
+                    input_split_sizes,
+                    num_input_tokens=total_tokens,
+                )
+        assert output is not None
+
+        torch.cuda.synchronize()
+        self.assertEqual(output.shape, (total_tokens, D))
+        self._verify_packed_data(
+            output,
+            D,
+            output_split_sizes,
+            "fill_send_buffer_back_to_back",
+        )
+
+
+class TestOpFillSendBufferOversizedRaises(_OpTestBase):
+    """Test that fill_send_buffer raises for oversized input."""
+
+    def test_fill_send_buffer_oversized_raises(self) -> None:
+        from comms.pipes.collectives.triton import AlltoallvOp
+
+        D = 16
+        max_input_tokens = 64
+        tokens_per_peer = max_input_tokens // self.world_size
+
+        # Create oversized input BEFORE context
+        oversized_input = torch.ones(
+            max_input_tokens + 10, D, dtype=self.dtype, device=self.device
+        )
+
+        op = AlltoallvOp(
+            self.torchcomm,
+            max_input_tokens,
+            D,
+            self.dtype,
+            self.device,
+            max_recv_tokens_per_peer=tokens_per_peer,
+        )
+
+        with op:
+            with self.assertRaises(ValueError):
+                op.fill_send_buffer(oversized_input)
+
+
+class TestOpFillSendBufferWithExplicitNumTokens(_OpTestBase):
+    """Test fill_send_buffer with explicit num_tokens parameter."""
+
+    def test_fill_send_buffer_explicit_num_tokens(self) -> None:
+        """Test fill_send_buffer with smaller num_tokens than input size."""
+        from comms.pipes.collectives.triton import AlltoallvOp
+
+        tokens_per_peer = 32
+        D = 16
+        max_input_tokens = tokens_per_peer * self.world_size
+        # Use fewer tokens than allocated
+        actual_tokens = tokens_per_peer * self.world_size // 2
+
+        # Pre-allocate larger buffer
+        input_tensor = torch.empty(
+            max_input_tokens, D, dtype=self.dtype, device=self.device
+        )
+        # Fill only the portion we'll use
+        half_tokens_per_peer = tokens_per_peer // 2
+        for peer in range(self.world_size):
+            start = peer * half_tokens_per_peer
+            input_tensor[start : start + half_tokens_per_peer] = float(
+                self.rank * 1000 + peer
+            )
+
+        input_split_sizes = torch.full(
+            (self.world_size,),
+            half_tokens_per_peer,
+            dtype=torch.int64,
+            device=self.device,
+        )
+        output_split_sizes = input_split_sizes.clone()
+
+        op = AlltoallvOp(
+            self.torchcomm,
+            max_input_tokens,
+            D,
+            self.dtype,
+            self.device,
+            max_recv_tokens_per_peer=half_tokens_per_peer,
+        )
+
+        with op:
+            # Explicitly specify num_tokens to copy less than full input
+            send_view = op.fill_send_buffer(input_tensor, num_tokens=actual_tokens)
+            self.assertEqual(send_view.shape, (actual_tokens, D))
+
+            output = op.alltoallv_from_buffer(
+                output_split_sizes,
+                input_split_sizes,
+                num_input_tokens=actual_tokens,
+            )
+
+        torch.cuda.synchronize()
+        actual_recv_tokens = actual_tokens  # Same as sent in uniform distribution
+        self.assertEqual(output.shape, (actual_recv_tokens, D))
+        self._verify_packed_data(
+            output,
+            D,
+            output_split_sizes,
+            "fill_send_buffer_explicit_num_tokens",
+        )
+
+
+# =============================================================================
+# Main
+# =============================================================================
+
+# =============================================================================
+# Test: Multi-Iteration with Different Input Content (Graph & Non-Graph)
+# =============================================================================
+
+
+class TestOpMultiIterDifferentContentPackedNonGraph(_OpTestBase):
+    """Test zero-copy mode with varying content across iterations (packed output).
+
+    Similar to TestOpMultiIterDifferentContentPackedGraph but WITHOUT graph capture.
+    Uses op.get_send_buffer() to get the internal send buffer, then fills it
+    with different data for each iteration. Packed output mode.
+    Cross-rank synchronization is used.
+    """
+
+    def test_multi_iter_different_content_packed_non_graph(self) -> None:
+        from comms.pipes.collectives.triton import AlltoallvOp
+
+        tokens_per_peer = 32
+        D = 16
+        max_input_tokens = tokens_per_peer * self.world_size
+        num_iterations = 3
+        packed_output_tokens = tokens_per_peer * self.world_size
+
+        input_split_sizes = torch.full(
+            (self.world_size,), tokens_per_peer, dtype=torch.int64, device=self.device
+        )
+        output_split_sizes = input_split_sizes.clone()
+
+        # Use a dedicated stream for operations (consistent with graph mode tests)
+        op_stream = torch.cuda.Stream()
+
+        # proper cross-rank synchronization via the BUFFER_READY signal protocol.
+        op = AlltoallvOp(
+            self.torchcomm,
+            max_input_tokens,
+            D,
+            self.dtype,
+            self.device,
+            max_recv_tokens_per_peer=tokens_per_peer,
+            sync_buffer=True,  # Required for multi-iteration
+        )
+
+        with op:
+            # Get send buffer for zero-copy writes
+            send_buf = op.get_send_buffer(max_input_tokens)
+
+            # Pre-allocate buffers to capture output state after each iteration.
+            # This avoids validation racing with the next iteration's buffer updates.
+            validation_buffers = []
+
+            for iteration in range(num_iterations):
+                with torch.cuda.stream(op_stream):
+                    # Fill send buffer with iteration-specific content
+                    for peer in range(self.world_size):
+                        start = peer * tokens_per_peer
+                        value = float(iteration * 10000 + self.rank * 1000 + peer)
+                        send_buf[start : start + tokens_per_peer] = value
+
+                    output = op.alltoallv_from_buffer(
+                        output_split_sizes,
+                        input_split_sizes,
+                        num_input_tokens=max_input_tokens,
+                        packed_output_tokens=packed_output_tokens,
+                    )
+
+                    # Clone output on op_stream to capture this iteration's data
+                    # before the next iteration overwrites it
+                    validation_buffers.append(output.clone())
+
+            # Wait for all operations to complete
+            op_stream.synchronize()
+
+            # Now validate all iterations on CPU (safe since all GPU work is done)
+            for iteration in range(num_iterations):
+                output_snapshot = validation_buffers[iteration]
+
+                # Verify packed output shape
+                self.assertEqual(output_snapshot.shape, (packed_output_tokens, D))
+
+                # Verify packed output data
+                offset = 0
+                for peer in range(self.world_size):
+                    count = int(output_split_sizes[peer].item())
+                    actual = output_snapshot[offset : offset + count, :].cpu()
+                    expected_value = float(iteration * 10000 + peer * 1000 + self.rank)
+                    expected = torch.full_like(actual, expected_value)
+                    torch.testing.assert_close(
+                        actual,
+                        expected,
+                        msg=(
+                            f"Zero-copy packed iter {iteration}, Rank {self.rank}: Data "
+                            f"from peer {peer} incorrect. Expected {expected_value}, "
+                            f"got {actual[0, 0].item()}"
+                        ),
+                    )
+                    offset += count
+
+
+class TestOpMultiIterDifferentContentPackedNonGraphCopyIn(_OpTestBase):
+    """Test multiple iterations with different input content per iteration (packed, non-graph)."""
+
+    def test_multi_iter_different_content_packed_non_graph(self) -> None:
+        """Test packed output with different input content per iteration (non-graph mode).
+
+        This test verifies that packed output mode correctly handles different
+        data per iteration. Cross-rank synchronization ensures proper
+        cross-rank synchronization between iterations.
+        """
+        from comms.pipes.collectives.triton import AlltoallvOp
+
+        tokens_per_peer = 32
+        D = 16
+        max_input_tokens = tokens_per_peer * self.world_size
+        num_iterations = 3
+        packed_output_tokens = tokens_per_peer * self.world_size
+
+        input_split_sizes = torch.full(
+            (self.world_size,), tokens_per_peer, dtype=torch.int64, device=self.device
+        )
+        output_split_sizes = input_split_sizes.clone()
+
+        # Use a dedicated stream for operations (consistent with graph mode tests)
+        op_stream = torch.cuda.Stream()
+
+        # proper cross-rank synchronization via the BUFFER_READY signal protocol.
+        op = AlltoallvOp(
+            self.torchcomm,
+            max_input_tokens,
+            D,
+            self.dtype,
+            self.device,
+            max_recv_tokens_per_peer=tokens_per_peer,
+            sync_buffer=True,  # Required for multi-iteration
+        )
+
+        with op:
+            # Pre-allocate buffers to capture output state after each iteration.
+            # This avoids validation racing with the next iteration's buffer updates.
+            validation_buffers = []
+
+            for iteration in range(num_iterations):
+                with torch.cuda.stream(op_stream):
+                    # Build unique input tensor for this iteration
+                    input_tensor = torch.empty(
+                        max_input_tokens, D, dtype=self.dtype, device=self.device
+                    )
+                    for peer in range(self.world_size):
+                        start = peer * tokens_per_peer
+                        value = float(iteration * 10000 + self.rank * 1000 + peer)
+                        input_tensor[start : start + tokens_per_peer] = value
+
+                    output = op.alltoallv(
+                        input_tensor,
+                        output_split_sizes,
+                        input_split_sizes,
+                        packed_output_tokens=packed_output_tokens,
+                    )
+
+                    # Clone output on op_stream to capture this iteration's data
+                    # before the next iteration overwrites it
+                    validation_buffers.append(output.clone())
+
+            # Wait for all operations to complete
+            op_stream.synchronize()
+
+            # Now validate all iterations on CPU (safe since all GPU work is done)
+            for iteration in range(num_iterations):
+                output_snapshot = validation_buffers[iteration]
+
+                # Verify packed output shape
+                self.assertEqual(output_snapshot.shape, (packed_output_tokens, D))
+
+                # Verify packed output data
+                offset = 0
+                for peer in range(self.world_size):
+                    count = int(output_split_sizes[peer].item())
+                    actual = output_snapshot[offset : offset + count, :].cpu()
+                    expected_value = float(iteration * 10000 + peer * 1000 + self.rank)
+                    expected = torch.full_like(actual, expected_value)
+                    torch.testing.assert_close(
+                        actual,
+                        expected,
+                        msg=(
+                            f"Packed iter {iteration}, Rank {self.rank}: Data from peer "
+                            f"{peer} incorrect. Expected {expected_value}, got "
+                            f"{actual[0, 0].item()}"
+                        ),
+                    )
+                    offset += count
+
+
+class TestOpMultiIterDifferentContentPackedGraph(_OpTestBase):
+    """Test CUDA graph replay with varying input data per iteration (packed output).
+
+    This test verifies the vLLM production use case (piecewise CUDA graphs):
+    - Capture a SINGLE graph with one alltoallv call
+    - Update input buffer OUTSIDE the graph before each replay
+    - Replay the same graph multiple times with different data
+    - Validate only the final iteration's output (CUDA graph internal
+      synchronization for intermediate snapshots has known limitations)
+    """
+
+    def test_multi_iter_different_content_packed_graph(self) -> None:
+        """Test packed output with single graph replayed with different data.
+
+        vLLM-style approach:
+        1. Pre-stage input data for all iterations
+        2. Capture a SINGLE graph with one alltoallv call
+        3. Before each replay: copy staged input to send buffer (outside graph)
+        4. Replay the same graph - it sees the updated buffer contents
+        5. Verify final output data matches expected values
+        """
+        from comms.pipes.collectives.triton import AlltoallvOp
+
+        tokens_per_peer = 32
+        D = 16
+        max_input_tokens = tokens_per_peer * self.world_size
+        num_iterations = 3
+        packed_output_tokens = tokens_per_peer * self.world_size
+
+        input_split_sizes = torch.full(
+            (self.world_size,), tokens_per_peer, dtype=torch.int64, device=self.device
+        )
+        output_split_sizes = input_split_sizes.clone()
+
+        op = AlltoallvOp(
+            self.torchcomm,
+            max_input_tokens,
+            D,
+            self.dtype,
+            self.device,
+            max_recv_tokens_per_peer=tokens_per_peer,
+            sync_buffer=True,  # Required for multi-iteration CUDA graph replays
+        )
+
+        with op:
+            # Get send buffer for zero-copy writes
+            send_buf = op.get_send_buffer(max_input_tokens)
+
+            # Pre-stage input data for ALL iterations before graph capture
+            staged_inputs = []
+            for iteration in range(num_iterations):
+                staged_input = torch.empty(
+                    max_input_tokens, D, dtype=self.dtype, device=self.device
+                )
+                for peer in range(self.world_size):
+                    start = peer * tokens_per_peer
+                    value = float(iteration * 10000 + self.rank * 1000 + peer)
+                    staged_input[start : start + tokens_per_peer] = value
+                staged_inputs.append(staged_input)
+
+            # Initialize send buffer with first iteration's data for warmup
+            send_buf.copy_(staged_inputs[0])
+
+            # Warmup (compile Triton kernels before graph capture)
+            op.alltoallv_from_buffer(
+                output_split_sizes,
+                input_split_sizes,
+                num_input_tokens=max_input_tokens,
+                packed_output_tokens=packed_output_tokens,
+            )
+            torch.cuda.synchronize()
+
+            # Capture a SINGLE graph with alltoallv
+            graph_stream = torch.cuda.Stream()
+            with torch.cuda.stream(graph_stream):
+                graph = torch.cuda.CUDAGraph()
+                # pyre-fixme[6]: Pyre doesn't recognize pool ID as valid _POOL_HANDLE
+                with torch.cuda.graph(graph, pool=op.get_graph_pool_id()):  # type: ignore[arg-type]
+                    graph_output = op.alltoallv_from_buffer(
+                        output_split_sizes,
+                        input_split_sizes,
+                        num_input_tokens=max_input_tokens,
+                        packed_output_tokens=packed_output_tokens,
+                    )
+            torch.cuda.synchronize()
+
+            # Replay the SAME graph multiple times with different input data
+            # and validate each iteration
+            for iteration in range(num_iterations):
+                with torch.cuda.stream(graph_stream):
+                    send_buf.copy_(staged_inputs[iteration])
+                    graph.replay()
+
+                # Wait for this iteration to complete before validating
+                graph_stream.synchronize()
+
+                # Clone output for this iteration
+                iter_output = graph_output.clone()
+
+                # Verify packed output shape
+                self.assertEqual(iter_output.shape, (packed_output_tokens, D))
+
+                # Verify packed data for this iteration
+                offset = 0
+                for peer in range(self.world_size):
+                    count = int(output_split_sizes[peer].item())
+                    actual = iter_output[offset : offset + count, :].cpu()
+                    expected_value = float(iteration * 10000 + peer * 1000 + self.rank)
+                    expected = torch.full_like(actual, expected_value)
+                    torch.testing.assert_close(
+                        actual,
+                        expected,
+                        msg=(
+                            f"Graph iteration {iteration}, Rank {self.rank}: "
+                            f"Packed data from peer {peer} incorrect. "
+                            f"Expected {expected_value}, got {actual[0, 0].item()}"
+                        ),
+                    )
+                    offset += count
+
+
+class TestOpMultiIterDifferentContentPackedGraphCopyIn(_OpTestBase):
+    """Test CUDA graph replay with varying input data per iteration (packed, copy-in).
+
+    This test verifies the vLLM production use case (piecewise CUDA graphs):
+    - Capture a SINGLE graph with one alltoallv call
+    - Update input tensor OUTSIDE the graph before each replay
+    - Replay the same graph multiple times with different data
+    - Validate only the final iteration's output (CUDA graph internal
+      synchronization for intermediate snapshots has known limitations)
+    """
+
+    def test_multi_iter_different_content_packed_graph_copy_in(self) -> None:
+        """Test packed output with single graph replayed with different data (copy-in).
+
+        vLLM-style approach with copy-in API:
+        1. Pre-stage input data for all iterations
+        2. Capture a SINGLE graph with one alltoallv call
+        3. Before each replay: copy staged input to input tensor (outside graph)
+        4. Replay the same graph - it sees the updated tensor contents
+        5. Verify final output data matches expected values
+        """
+        from comms.pipes.collectives.triton import AlltoallvOp
+
+        tokens_per_peer = 32
+        D = 16
+        max_input_tokens = tokens_per_peer * self.world_size
+        num_iterations = 3
+        packed_output_tokens = tokens_per_peer * self.world_size
+
+        input_split_sizes = torch.full(
+            (self.world_size,), tokens_per_peer, dtype=torch.int64, device=self.device
+        )
+        output_split_sizes = input_split_sizes.clone()
+
+        op = AlltoallvOp(
+            self.torchcomm,
+            max_input_tokens,
+            D,
+            self.dtype,
+            self.device,
+            max_recv_tokens_per_peer=tokens_per_peer,
+            sync_buffer=True,  # Required for multi-iteration CUDA graph replays
+        )
+
+        with op:
+            # Create a persistent input tensor that will be reused
+            input_tensor = torch.empty(
+                max_input_tokens, D, dtype=self.dtype, device=self.device
+            )
+
+            # Pre-stage input data for ALL iterations before graph capture
+            staged_inputs = []
+            for iteration in range(num_iterations):
+                staged_input = torch.empty(
+                    max_input_tokens, D, dtype=self.dtype, device=self.device
+                )
+                for peer in range(self.world_size):
+                    start = peer * tokens_per_peer
+                    value = float(iteration * 10000 + self.rank * 1000 + peer)
+                    staged_input[start : start + tokens_per_peer] = value
+                staged_inputs.append(staged_input)
+
+            # Initialize input tensor with first iteration's data for warmup
+            input_tensor.copy_(staged_inputs[0])
+
+            # Warmup (compile Triton kernels before graph capture)
+            op.alltoallv(
+                input_tensor,
+                output_split_sizes,
+                input_split_sizes,
+                packed_output_tokens=packed_output_tokens,
+            )
+            torch.cuda.synchronize()
+
+            # Capture a SINGLE graph with alltoallv
+            graph_stream = torch.cuda.Stream()
+            with torch.cuda.stream(graph_stream):
+                graph = torch.cuda.CUDAGraph()
+                # pyre-fixme[6]: Pyre doesn't recognize pool ID as valid _POOL_HANDLE
+                with torch.cuda.graph(graph, pool=op.get_graph_pool_id()):  # type: ignore[arg-type]
+                    graph_output = op.alltoallv(
+                        input_tensor,
+                        output_split_sizes,
+                        input_split_sizes,
+                        packed_output_tokens=packed_output_tokens,
+                    )
+            torch.cuda.synchronize()
+
+            # Replay the SAME graph multiple times with different input data
+            # and validate each iteration
+            for iteration in range(num_iterations):
+                with torch.cuda.stream(graph_stream):
+                    input_tensor.copy_(staged_inputs[iteration])
+                    graph.replay()
+
+                # Wait for this iteration to complete before validating
+                graph_stream.synchronize()
+
+                # Clone output for this iteration
+                iter_output = graph_output.clone()
+
+                # Verify packed output shape
+                self.assertEqual(iter_output.shape, (packed_output_tokens, D))
+
+                # Verify packed data for this iteration
+                offset = 0
+                for peer in range(self.world_size):
+                    count = int(output_split_sizes[peer].item())
+                    actual = iter_output[offset : offset + count, :].cpu()
+                    expected_value = float(iteration * 10000 + peer * 1000 + self.rank)
+                    expected = torch.full_like(actual, expected_value)
+                    torch.testing.assert_close(
+                        actual,
+                        expected,
+                        msg=(
+                            f"Graph iteration {iteration}, Rank {self.rank}: "
+                            f"Packed data from peer {peer} incorrect. "
+                            f"Expected {expected_value}, got {actual[0, 0].item()}"
+                        ),
+                    )
+                    offset += count
+
+
+def _update_send_buffer_kernel(
+    send_buf: torch.Tensor,
+    loop_index: torch.Tensor,
+    base_value: float,
+    tokens_per_peer: int,
+    world_size: int,
+) -> None:
+    """Simple kernel to update send buffer with loop-iteration-specific values.
+
+    This kernel is captured in the CUDA graph along with the alltoallv call.
+    On each iteration of the captured loop, it reads the loop_index tensor
+    (which was filled with a different constant for each iteration during capture)
+    and updates the send buffer accordingly.
+
+    IMPORTANT: This function must be CUDA graph-compatible. We cannot use
+    .item() or any host-CPU sync operations inside graph capture. Instead,
+    we use pure tensor operations that stay on the GPU.
+
+    Args:
+        send_buf: The send buffer to update (shape: [max_tokens, D])
+        loop_index: Tensor containing the current loop iteration index
+        base_value: Base value (typically rank * 1000)
+        tokens_per_peer: Number of tokens per peer
+        world_size: Number of peers
+    """
+    # Compute iteration-specific offset using GPU tensor ops (no .item()!)
+    # iter_offset = loop_index * 10000 (stays on GPU)
+    iter_offset = loop_index * 10000
+
+    # Update buffer with iteration-specific values using broadcasting
+    # Value format: loop_iter * 10000 + rank * 1000 + peer
+    # We use tensor operations that are CUDA graph-compatible
+    for peer in range(world_size):
+        start = peer * tokens_per_peer
+        end = start + tokens_per_peer
+        # Use iter_offset tensor (on GPU) + scalars for base_value and peer
+        # The tensor + scalar operations are graph-compatible
+        value = iter_offset.float() + base_value + peer
+        send_buf[start:end, :] = value
+
+
+class TestOpMultiIterDifferentContentPackedGraphLoop(_OpTestBase):
+    """Test multi-iteration with loop captured in graph (packed output).
+
+    Validates only the final iteration's output per replay (CUDA graph internal
+    synchronization for intermediate snapshots has known limitations).
+    """
+
+    def test_multi_iter_different_content_packed_graph_loop(self) -> None:
+        """Test packed output with iteration loop captured in CUDA graph.
+
+        Unlike the regular graph test where we capture one iteration and replay
+        multiple times, here we capture the entire iteration loop in the graph
+        and replay the loop as a whole.
+
+        Each iteration within the captured loop sees DIFFERENT data because we
+        include a compute kernel that updates the send buffer based on a
+        loop_index tensor. The loop_index.fill_(i) operations are captured
+        with different constant values for each iteration.
+
+        This tests the scenario where multiple alltoallv calls with varying
+        data are captured in a single CUDA graph with packed output mode.
+        Only validates the final loop iteration's output per replay.
+        """
+        from comms.pipes.collectives.triton import AlltoallvOp
+
+        tokens_per_peer = 32
+        D = 16
+        max_input_tokens = tokens_per_peer * self.world_size
+        num_iterations_in_loop = 3  # Number of iterations captured in the loop
+        packed_output_tokens = tokens_per_peer * self.world_size
+
+        input_split_sizes = torch.full(
+            (self.world_size,), tokens_per_peer, dtype=torch.int64, device=self.device
+        )
+        output_split_sizes = input_split_sizes.clone()
+
+        op = AlltoallvOp(
+            self.torchcomm,
+            max_input_tokens,
+            D,
+            self.dtype,
+            self.device,
+            max_recv_tokens_per_peer=tokens_per_peer,
+            sync_buffer=True,  # Required for multi-iteration CUDA graph replays
+        )
+
+        with op:
+            # Get send buffer for zero-copy writes
+            send_buf = op.get_send_buffer(max_input_tokens)
+
+            # Tensor to hold the current loop index (updated inside the captured loop)
+            loop_index = torch.zeros(1, dtype=torch.int64, device=self.device)
+
+            # Base value for this rank (rank * 1000)
+            base_value = float(self.rank * 1000)
+
+            # Warmup (compile Triton kernels before graph capture)
+            _update_send_buffer_kernel(
+                send_buf, loop_index, base_value, tokens_per_peer, self.world_size
+            )
+            op.alltoallv_from_buffer(
+                output_split_sizes,
+                input_split_sizes,
+                num_input_tokens=max_input_tokens,
+                packed_output_tokens=packed_output_tokens,
+            )
+            torch.cuda.synchronize()
+
+            # Capture the entire iteration loop in a single graph.
+            # We only keep the final iteration's output for validation.
+            graph_stream = torch.cuda.Stream()
+
+            with torch.cuda.stream(graph_stream):
+                graph = torch.cuda.CUDAGraph()
+                # pyre-fixme[6]: Pyre doesn't recognize pool ID as valid _POOL_HANDLE
+                with torch.cuda.graph(graph, pool=op.get_graph_pool_id()):  # type: ignore[arg-type]
+                    for loop_iter in range(num_iterations_in_loop):
+                        # Update loop index - this is captured with constant loop_iter
+                        loop_index.fill_(loop_iter)
+
+                        # Update send buffer based on loop index
+                        _update_send_buffer_kernel(
+                            send_buf,
+                            loop_index,
+                            base_value,
+                            tokens_per_peer,
+                            self.world_size,
+                        )
+
+                        # Perform alltoallv
+                        graph_output = op.alltoallv_from_buffer(
+                            output_split_sizes,
+                            input_split_sizes,
+                            num_input_tokens=max_input_tokens,
+                            packed_output_tokens=packed_output_tokens,
+                        )
+            torch.cuda.synchronize()
+
+            # Replay the captured loop multiple times and validate after each replay.
+            num_replays = 2
+
+            for replay in range(num_replays):
+                with torch.cuda.stream(graph_stream):
+                    graph.replay()
+
+                # Wait for this replay to complete before validating
+                graph_stream.synchronize()
+
+                # Clone output after this replay
+                replay_output = graph_output.clone()
+
+                # Verify packed output shape
+                self.assertEqual(replay_output.shape, (packed_output_tokens, D))
+
+                # Validate the final loop iteration's output for this replay.
+                # Each replay produces the same final loop iteration output.
+                final_loop_iter = num_iterations_in_loop - 1
+
+                # Verify packed output data for final loop iteration
+                offset = 0
+                for peer in range(self.world_size):
+                    count = int(output_split_sizes[peer].item())
+                    actual = replay_output[offset : offset + count, :].cpu()
+                    # Expected: final_loop_iter * 10000 + peer * 1000 + self.rank
+                    expected_value = float(
+                        final_loop_iter * 10000 + peer * 1000 + self.rank
+                    )
+                    expected = torch.full_like(actual, expected_value)
+                    torch.testing.assert_close(
+                        actual,
+                        expected,
+                        msg=(
+                            f"Replay {replay}, final loop iteration {final_loop_iter}, "
+                            f"Rank {self.rank}: Data from peer {peer} incorrect. "
+                            f"Expected {expected_value}, got {actual[0, 0].item()}"
+                        ),
+                    )
+                    offset += count
+
+
+def _update_input_tensor_kernel(
+    input_tensor: torch.Tensor,
+    loop_index: torch.Tensor,
+    base_value: float,
+    tokens_per_peer: int,
+    world_size: int,
+) -> None:
+    """Simple kernel to update input tensor with loop-iteration-specific values.
+
+    Similar to _update_send_buffer_kernel but for copy-in mode where we update
+    the user's input tensor instead of the send buffer.
+
+    IMPORTANT: This function must be CUDA graph-compatible. We cannot use
+    .item() or any host-CPU sync operations inside graph capture. Instead,
+    we use pure tensor operations that stay on the GPU.
+
+    Args:
+        input_tensor: The input tensor to update (shape: [max_tokens, D])
+        loop_index: Tensor containing the current loop iteration index
+        base_value: Base value (typically rank * 1000)
+        tokens_per_peer: Number of tokens per peer
+        world_size: Number of peers
+    """
+    # Compute iteration-specific offset using GPU tensor ops (no .item()!)
+    iter_offset = loop_index * 10000
+
+    for peer in range(world_size):
+        start = peer * tokens_per_peer
+        end = start + tokens_per_peer
+        # Use iter_offset tensor (on GPU) + scalars for base_value and peer
+        value = iter_offset.float() + base_value + peer
+        input_tensor[start:end, :] = value
+
+
+class TestOpMultiIterDifferentContentPackedGraphLoopCopyIn(_OpTestBase):
+    """Test multi-iteration with loop captured in graph (packed, copy-in).
+
+    Validates only the final iteration's output per replay (CUDA graph internal
+    synchronization for intermediate snapshots has known limitations).
+    """
+
+    def test_multi_iter_different_content_packed_graph_loop_copy_in(self) -> None:
+        """Test packed output with iteration loop captured in CUDA graph (copy-in).
+
+        Only validates the final loop iteration's output per replay.
+        """
+        from comms.pipes.collectives.triton import AlltoallvOp
+
+        tokens_per_peer = 32
+        D = 16
+        max_input_tokens = tokens_per_peer * self.world_size
+        num_iterations_in_loop = 3
+        packed_output_tokens = tokens_per_peer * self.world_size
+
+        input_split_sizes = torch.full(
+            (self.world_size,), tokens_per_peer, dtype=torch.int64, device=self.device
+        )
+        output_split_sizes = input_split_sizes.clone()
+
+        op = AlltoallvOp(
+            self.torchcomm,
+            max_input_tokens,
+            D,
+            self.dtype,
+            self.device,
+            max_recv_tokens_per_peer=tokens_per_peer,
+            sync_buffer=True,  # Required for multi-iteration CUDA graph replays
+        )
+
+        with op:
+            input_tensor = torch.empty(
+                max_input_tokens, D, dtype=self.dtype, device=self.device
+            )
+            loop_index = torch.zeros(1, dtype=torch.int64, device=self.device)
+
+            base_value = float(self.rank * 1000)
+
+            # Warmup
+            _update_input_tensor_kernel(
+                input_tensor, loop_index, base_value, tokens_per_peer, self.world_size
+            )
+            op.alltoallv(
+                input_tensor,
+                output_split_sizes,
+                input_split_sizes,
+                packed_output_tokens=packed_output_tokens,
+            )
+            torch.cuda.synchronize()
+
+            # Capture the iteration loop
+            graph_stream = torch.cuda.Stream()
+
+            with torch.cuda.stream(graph_stream):
+                graph = torch.cuda.CUDAGraph()
+                # pyre-fixme[6]: Pyre doesn't recognize pool ID as valid _POOL_HANDLE
+                with torch.cuda.graph(graph, pool=op.get_graph_pool_id()):  # type: ignore[arg-type]
+                    for loop_iter in range(num_iterations_in_loop):
+                        loop_index.fill_(loop_iter)
+                        _update_input_tensor_kernel(
+                            input_tensor,
+                            loop_index,
+                            base_value,
+                            tokens_per_peer,
+                            self.world_size,
+                        )
+                        graph_output = op.alltoallv(
+                            input_tensor,
+                            output_split_sizes,
+                            input_split_sizes,
+                            packed_output_tokens=packed_output_tokens,
+                        )
+            torch.cuda.synchronize()
+
+            # Replay the captured loop multiple times and validate after each replay.
+            num_replays = 2
+
+            for replay in range(num_replays):
+                with torch.cuda.stream(graph_stream):
+                    graph.replay()
+
+                # Wait for this replay to complete before validating
+                graph_stream.synchronize()
+
+                # Clone output after this replay
+                replay_output = graph_output.clone()
+
+                # Verify packed output shape
+                self.assertEqual(replay_output.shape, (packed_output_tokens, D))
+
+                # Validate the final loop iteration's output for this replay.
+                # Each replay produces the same final loop iteration output.
+                final_loop_iter = num_iterations_in_loop - 1
+
+                # Verify packed output data for final loop iteration
+                offset = 0
+                for peer in range(self.world_size):
+                    count = int(output_split_sizes[peer].item())
+                    actual = replay_output[offset : offset + count, :].cpu()
+                    # Expected: final_loop_iter * 10000 + peer * 1000 + self.rank
+                    expected_value = float(
+                        final_loop_iter * 10000 + peer * 1000 + self.rank
+                    )
+                    expected = torch.full_like(actual, expected_value)
+                    torch.testing.assert_close(
+                        actual,
+                        expected,
+                        msg=(
+                            f"Replay {replay}, final loop iteration {final_loop_iter}, "
+                            f"Rank {self.rank}: Data from peer {peer} incorrect. "
+                            f"Expected {expected_value}, got {actual[0, 0].item()}"
+                        ),
+                    )
+                    offset += count
+
+
+# =============================================================================
+# Sync Buffer Mode Tests
+# =============================================================================
+
+
+class TestOpSyncBufferBasic(_OpTestBase):
+    """Test AlltoallvOp with sync_buffer=True basic functionality."""
+
+    def test_sync_buffer_single_call(self) -> None:
+        from comms.pipes.collectives.triton import AlltoallvOp
+
+        tokens_per_peer = 64
+        D = 16
+        max_input_tokens = tokens_per_peer * self.world_size
+
+        input_tensor = torch.empty(
+            max_input_tokens, D, dtype=self.dtype, device=self.device
+        )
+        for peer in range(self.world_size):
+            start = peer * tokens_per_peer
+            input_tensor[start : start + tokens_per_peer] = float(
+                self.rank * 1000 + peer
+            )
+
+        input_split_sizes = torch.full(
+            (self.world_size,), tokens_per_peer, dtype=torch.int64, device=self.device
+        )
+        output_split_sizes = input_split_sizes.clone()
+
+        # Create op with sync_buffer=True
+        op = AlltoallvOp(
+            self.torchcomm,
+            max_input_tokens,
+            D,
+            self.dtype,
+            self.device,
+            max_recv_tokens_per_peer=tokens_per_peer,
+            sync_buffer=True,  # Enable buffer-ready synchronization
+        )
+        with op:
+            output = op.alltoallv(input_tensor, output_split_sizes, input_split_sizes)
+
+        torch.cuda.synchronize()
+        total_tokens = tokens_per_peer * self.world_size
+        self.assertEqual(output.shape, (total_tokens, D))
+        self._verify_packed_data(output, D, output_split_sizes, "sync_buffer_single")
+
+
+class TestOpSyncBufferRepeatedCalls(_OpTestBase):
+    """Test AlltoallvOp with sync_buffer=True and multiple iterations.
+
+    This is the critical test for sync_buffer mode - verifies buffer-ready
+    synchronization prevents race conditions across iterations.
+    """
+
+    def test_sync_buffer_repeated_calls(self) -> None:
+        from comms.pipes.collectives.triton import AlltoallvOp
+
+        tokens_per_peer = 64
+        D = 16
+        max_input_tokens = tokens_per_peer * self.world_size
+        num_iterations = 5
+
+        input_tensor = torch.empty(
+            max_input_tokens, D, dtype=self.dtype, device=self.device
+        )
+        for peer in range(self.world_size):
+            start = peer * tokens_per_peer
+            input_tensor[start : start + tokens_per_peer] = float(
+                self.rank * 1000 + peer
+            )
+
+        input_split_sizes = torch.full(
+            (self.world_size,), tokens_per_peer, dtype=torch.int64, device=self.device
+        )
+        output_split_sizes = input_split_sizes.clone()
+
+        op = AlltoallvOp(
+            self.torchcomm,
+            max_input_tokens,
+            D,
+            self.dtype,
+            self.device,
+            max_recv_tokens_per_peer=tokens_per_peer,
+            sync_buffer=True,
+        )
+        with op:
+            output = None
+            for _iteration in range(num_iterations):
+                output = op.alltoallv(
+                    input_tensor, output_split_sizes, input_split_sizes
+                )
+            torch.cuda.synchronize()
+
+            assert output is not None
+            total_tokens = tokens_per_peer * self.world_size
+            self.assertEqual(output.shape, (total_tokens, D))
+            self._verify_packed_data(
+                output, D, output_split_sizes, "sync_buffer_repeated"
+            )
+
+
+class TestOpSyncBufferZeroCopy(_OpTestBase):
+    """Test AlltoallvOp sync_buffer with zero-copy send buffer."""
+
+    def test_sync_buffer_zero_copy(self) -> None:
+        from comms.pipes.collectives.triton import AlltoallvOp
+
+        tokens_per_peer = 64
+        D = 16
+        max_input_tokens = tokens_per_peer * self.world_size
+        total_tokens = tokens_per_peer * self.world_size
+
+        input_split_sizes = torch.full(
+            (self.world_size,), tokens_per_peer, dtype=torch.int64, device=self.device
+        )
+        output_split_sizes = input_split_sizes.clone()
+
+        op = AlltoallvOp(
+            self.torchcomm,
+            max_input_tokens,
+            D,
+            self.dtype,
+            self.device,
+            max_recv_tokens_per_peer=tokens_per_peer,
+            sync_buffer=True,
+        )
+
+        # Fill send buffer BEFORE setup
+        send_buf = op.get_send_buffer(total_tokens)
+        for peer in range(self.world_size):
+            start = peer * tokens_per_peer
+            send_buf[start : start + tokens_per_peer] = float(self.rank * 1000 + peer)
+
+        with op:
+            output = op.alltoallv_from_buffer(
+                output_split_sizes,
+                input_split_sizes,
+                num_input_tokens=total_tokens,
+            )
+
+        torch.cuda.synchronize()
+        self.assertEqual(output.shape, (total_tokens, D))
+        self._verify_packed_data(output, D, output_split_sizes, "sync_buffer_zero_copy")
+
+
+class TestOpSyncBufferPackedOutput(_OpTestBase):
+    """Test AlltoallvOp sync_buffer with packed output."""
+
+    def test_sync_buffer_packed_output(self) -> None:
+        from comms.pipes.collectives.triton import AlltoallvOp
+
+        tokens_per_peer = 64
+        D = 16
+        max_input_tokens = tokens_per_peer * self.world_size
+
+        input_tensor = torch.empty(
+            max_input_tokens, D, dtype=self.dtype, device=self.device
+        )
+        for peer in range(self.world_size):
+            start = peer * tokens_per_peer
+            input_tensor[start : start + tokens_per_peer] = float(
+                self.rank * 1000 + peer
+            )
+
+        input_split_sizes = torch.full(
+            (self.world_size,), tokens_per_peer, dtype=torch.int64, device=self.device
+        )
+        output_split_sizes = input_split_sizes.clone()
+        total_output_tokens = int(output_split_sizes.sum().item())
+
+        # Create op with both sync_buffer and packed_output
+        op = AlltoallvOp(
+            self.torchcomm,
+            max_input_tokens,
+            D,
+            self.dtype,
+            self.device,
+            max_recv_tokens_per_peer=tokens_per_peer,
+            sync_buffer=True,
+        )
+        with op:
+            # Pass packed_output_tokens to enable CUDA graph compatibility
+            # (avoids .item() call during graph capture)
+            output = op.alltoallv(
+                input_tensor,
+                output_split_sizes,
+                input_split_sizes,
+                packed_output_tokens=total_output_tokens,
+            )
+
+        torch.cuda.synchronize()
+        self.assertEqual(output.shape, (total_output_tokens, D))
+
+
+class TestOpSyncBufferAttribute(_OpTestBase):
+    """Test that sync_buffer is correctly stored as an attribute."""
+
+    def test_sync_buffer_attribute_stored(self) -> None:
+        from comms.pipes.collectives.triton import AlltoallvOp
+
+        tokens_per_peer = 64
+        D = 16
+        max_input_tokens = tokens_per_peer * self.world_size
+
+        # Create op with sync_buffer=True
+        op_sync = AlltoallvOp(
+            self.torchcomm,
+            max_input_tokens,
+            D,
+            self.dtype,
+            self.device,
+            max_recv_tokens_per_peer=tokens_per_peer,
+            sync_buffer=True,
+        )
+        self.assertTrue(op_sync.sync_buffer)
+
+        # Create op with sync_buffer=False (default)
+        op_non_sync = AlltoallvOp(
+            self.torchcomm,
+            max_input_tokens,
+            D,
+            self.dtype,
+            self.device,
+            max_recv_tokens_per_peer=tokens_per_peer,
+            sync_buffer=False,
+        )
+        self.assertFalse(op_non_sync.sync_buffer)
+
+
+# =============================================================================
+# Test: Intentional Race Condition for Debugging
+# =============================================================================
+
+
+@unittest.skipIf(not _skip_if_not_ready(), "Skipping without device API test flag")
+class TestOpRaceConditionDebug(_OpTestBase):
+    """
+    Test that intentionally creates a race condition by delaying graph completion
+    on some ranks using a spin loop kernel. This helps identify protocol violations
+    by comparing failing runs with passing runs.
+
+    The race condition occurs when:
+    1. Some ranks finish their graph early and start send_buf.copy_() for next iteration
+    2. Other ranks are still executing the previous graph and reading from send buffers
+    3. The early ranks overwrite their send buffers while other ranks are still reading
+
+    Run with:
+        TEST_FILTER=TestOpRaceConditionDebug$ buck2 run ...
+    """
+
+    def test_race_condition_debug(self) -> None:
+        """
+        Create intentional race by delaying graph completion on odd ranks.
+        Even ranks finish quickly, odd ranks spin for extra cycles.
+        This creates a window where even ranks may overwrite send buffers
+        while odd ranks are still reading.
+        """
+        import triton
+        import triton.language as tl
+        from comms.pipes.collectives.triton import AlltoallvOp
+
+        # Spin loop kernel to delay execution on specific ranks
+        @triton.jit
+        def spin_loop_kernel(
+            spin_cycles: tl.constexpr,
+        ):
+            """Busy-wait spin loop to delay GPU execution."""
+            # Simple spin loop - each iteration takes a few cycles
+            for _ in range(spin_cycles):
+                # Use a volatile memory operation to prevent optimization
+                tl.debug_barrier()
+
+        tokens_per_peer = 32
+        D = 16
+        max_input_tokens = tokens_per_peer * self.world_size
+        num_iterations = 5  # More iterations to increase chance of hitting race
+        packed_output_tokens = tokens_per_peer * self.world_size
+
+        # Spin cycles for odd ranks to create timing skew
+        # Higher value = more delay = higher chance of race
+        SPIN_CYCLES_ODD_RANKS = 100000  # Tune this to create race window
+
+        input_split_sizes = torch.full(
+            (self.world_size,), tokens_per_peer, dtype=torch.int64, device=self.device
+        )
+        output_split_sizes = input_split_sizes.clone()
+
+        op = AlltoallvOp(
+            self.torchcomm,
+            max_input_tokens,
+            D,
+            self.dtype,
+            self.device,
+            max_recv_tokens_per_peer=tokens_per_peer,
+            sync_buffer=True,
+        )
+
+        with op:
+            send_buf = op.get_send_buffer(max_input_tokens)
+
+            # Pre-stage all iteration inputs to verify data integrity
+            # Value encoding: iteration * 10000 + my_rank * 1000 + dest_rank
+            staged_inputs = []
+            for iteration in range(num_iterations):
+                staged_input = torch.zeros_like(send_buf)
+                for dest_rank in range(self.world_size):
+                    start_idx = dest_rank * tokens_per_peer
+                    end_idx = start_idx + tokens_per_peer
+                    value = float(iteration * 10000 + self.rank * 1000 + dest_rank)
+                    staged_input[start_idx:end_idx, :] = value
+                staged_inputs.append(staged_input)
+
+            # Warmup iteration to establish baseline signals
+            send_buf.copy_(staged_inputs[0])
+            op.alltoallv_from_buffer(
+                output_split_sizes,
+                input_split_sizes,
+                num_input_tokens=max_input_tokens,
+                packed_output_tokens=packed_output_tokens,
+            )
+            torch.cuda.synchronize()
+
+            # Create a staging buffer for graph capture
+            # The staging buffer holds the input data that will be copied to send_buf
+            # inside the graph, AFTER the BUFFER_READY wait
+            staging_buffer = torch.zeros_like(send_buf)
+
+            # Capture graph with copy INSIDE the graph
+            # This ensures the copy happens on the GPU stream, synchronized with
+            # the BUFFER_READY wait in the alltoallv kernel
+            graph_stream = torch.cuda.Stream()
+            with torch.cuda.stream(graph_stream):
+                graph = torch.cuda.CUDAGraph()
+                # pyre-fixme[6]: Pyre doesn't recognize pool ID as valid _POOL_HANDLE
+                with torch.cuda.graph(graph, pool=op.get_graph_pool_id()):  # type: ignore[arg-type]
+                    # Copy from staging to send_buf INSIDE the graph
+                    # This copy will be captured and replayed
+                    send_buf.copy_(staging_buffer)
+                    # Then run alltoallv
+                    graph_output = op.alltoallv_from_buffer(
+                        output_split_sizes,
+                        input_split_sizes,
+                        num_input_tokens=max_input_tokens,
+                        packed_output_tokens=packed_output_tokens,
+                    )
+                    # Add spin loop AFTER alltoallv for ODD ranks only
+                    # This delays graph completion, creating a race window
+                    if self.rank % 2 == 1:
+                        # pyre-fixme[6]: Triton constexpr not recognized
+                        spin_loop_kernel[(1,)](SPIN_CYCLES_ODD_RANKS)  # type: ignore[arg-type]
+            torch.cuda.synchronize()
+
+            # Track outputs per iteration
+            outputs_per_iter = []
+
+            for iteration in range(num_iterations):
+                with torch.cuda.stream(graph_stream):
+                    staging_buffer.copy_(staged_inputs[iteration])
+                    graph.replay()
+
+                # Wait for graph to complete before cloning
+                graph_stream.synchronize()
+
+                # Clone output on graph_stream to ensure it completes BEFORE
+                # the next iteration starts (which signals BUFFER_READY)
+                with torch.cuda.stream(graph_stream):
+                    output_snapshot = graph_output.clone()
+
+                # Synchronize to ensure clone is complete before next iteration
+                graph_stream.synchronize()
+
+                outputs_per_iter.append(output_snapshot)
+
+            # Final synchronize
+            torch.cuda.synchronize()
+
+            # Validate all peer communications
+            errors = []
+            for iteration in range(num_iterations):
+                output = outputs_per_iter[iteration]
+                for peer in range(self.world_size):
+                    if peer == self.rank:
+                        continue
+                    expected_val = float(iteration * 10000 + peer * 1000 + self.rank)
+                    start_idx = peer * tokens_per_peer
+                    actual_val = output[start_idx, 0].item()
+                    if abs(actual_val - expected_val) > 0.1:
+                        errors.append(
+                            f"Iter {iteration}, from peer {peer}: expected {expected_val:.0f}, got {actual_val:.0f}"
+                        )
+
+            if errors:
+                print(
+                    f"\n[Rank {self.rank}] RACE CONDITION DETECTED! {len(errors)} errors found.",
+                    flush=True,
+                )
+                for error in errors[:10]:
+                    print(f"[Rank {self.rank}] ERROR: {error}", file=sys.stderr)
+                self.fail(
+                    f"Race condition detected on rank {self.rank}: {len(errors)} mismatches\n"
+                    + "\n".join(errors[:10])
+                )
+            else:
+                print(
+                    f"\n[Rank {self.rank}] All {num_iterations} iterations validated successfully.",
+                    flush=True,
+                )
+
+
+@unittest.skipIf(not _skip_if_not_ready(), "Skipping without device API test flag")
+class TestOpRaceConditionDebugMultiBlock(_OpTestBase):
+    """
+    Test race conditions with BLOCKS_PER_PEER > 1 code paths.
+
+    Similar to TestOpRaceConditionDebug but uses larger message sizes to trigger
+    multi-block code paths (BLOCKS_PER_PEER = 8 for 64KB-256KB messages).
+
+    The multi-block path uses atomic completion counters and different signaling
+    logic that needs to be tested separately.
+
+    Run with:
+        TEST_FILTER=TestOpRaceConditionDebugMultiBlock$ buck2 run ...
+    """
+
+    def test_race_condition_debug_multi_block(self) -> None:
+        """
+        Create intentional race by delaying graph completion on odd ranks.
+        Uses large message sizes to trigger BLOCKS_PER_PEER > 1.
+        """
+        import triton
+        import triton.language as tl
+        from comms.pipes.collectives.triton import AlltoallvOp
+
+        # Spin loop kernel to delay execution on specific ranks
+        @triton.jit
+        def spin_loop_kernel(
+            spin_cycles: tl.constexpr,
+        ):
+            """Busy-wait spin loop to delay GPU execution."""
+            for _ in range(spin_cycles):
+                tl.debug_barrier()
+
+        # Use larger tokens_per_peer and D to get > 64KB per peer
+        # With bfloat16 (2 bytes): 2048 * 32 * 2 = 131072 bytes = 128KB per peer
+        # This triggers BLOCKS_PER_PEER = 8 (for 64KB-256KB range)
+        tokens_per_peer = 2048
+        D = 32
+        max_input_tokens = tokens_per_peer * self.world_size
+        num_iterations = 5
+        packed_output_tokens = tokens_per_peer * self.world_size
+
+        # Calculate expected per-peer message size
+        elem_bytes = 2  # bfloat16
+        per_peer_bytes = tokens_per_peer * D * elem_bytes
+        print(
+            f"[Rank {self.rank}] Per-peer message size: {per_peer_bytes} bytes ({per_peer_bytes / 1024:.1f} KB)",
+            flush=True,
+        )
+
+        # Spin cycles for odd ranks to create timing skew
+        SPIN_CYCLES_ODD_RANKS = 100000
+
+        input_split_sizes = torch.full(
+            (self.world_size,), tokens_per_peer, dtype=torch.int64, device=self.device
+        )
+        output_split_sizes = input_split_sizes.clone()
+
+        op = AlltoallvOp(
+            self.torchcomm,
+            max_input_tokens,
+            D,
+            self.dtype,
+            self.device,
+            max_recv_tokens_per_peer=tokens_per_peer,
+            sync_buffer=True,
+        )
+
+        with op:
+            send_buf = op.get_send_buffer(max_input_tokens)
+
+            # Pre-stage all iteration inputs to verify data integrity
+            # Value encoding: iteration * 10000 + my_rank * 1000 + dest_rank
+            staged_inputs = []
+            for iteration in range(num_iterations):
+                staged_input = torch.zeros_like(send_buf)
+                for dest_rank in range(self.world_size):
+                    start_idx = dest_rank * tokens_per_peer
+                    end_idx = start_idx + tokens_per_peer
+                    value = float(iteration * 10000 + self.rank * 1000 + dest_rank)
+                    staged_input[start_idx:end_idx, :] = value
+                staged_inputs.append(staged_input)
+
+            # Warmup iteration to establish baseline signals
+            send_buf.copy_(staged_inputs[0])
+            op.alltoallv_from_buffer(
+                output_split_sizes,
+                input_split_sizes,
+                num_input_tokens=max_input_tokens,
+                packed_output_tokens=packed_output_tokens,
+            )
+            torch.cuda.synchronize()
+
+            # Create a staging buffer for graph capture
+            staging_buffer = torch.zeros_like(send_buf)
+
+            # Capture graph with copy INSIDE the graph
+            graph_stream = torch.cuda.Stream()
+            with torch.cuda.stream(graph_stream):
+                graph = torch.cuda.CUDAGraph()
+                # pyre-fixme[6]: Pyre doesn't recognize pool ID as valid _POOL_HANDLE
+                with torch.cuda.graph(graph, pool=op.get_graph_pool_id()):  # type: ignore[arg-type]
+                    send_buf.copy_(staging_buffer)
+                    graph_output = op.alltoallv_from_buffer(
+                        output_split_sizes,
+                        input_split_sizes,
+                        num_input_tokens=max_input_tokens,
+                        packed_output_tokens=packed_output_tokens,
+                    )
+                    # Add spin loop AFTER alltoallv for ODD ranks only
+                    if self.rank % 2 == 1:
+                        # pyre-fixme[6]: Triton constexpr not recognized
+                        spin_loop_kernel[(1,)](SPIN_CYCLES_ODD_RANKS)  # type: ignore[arg-type]
+            torch.cuda.synchronize()
+
+            # Track outputs per iteration
+            outputs_per_iter = []
+
+            for iteration in range(num_iterations):
+                with torch.cuda.stream(graph_stream):
+                    staging_buffer.copy_(staged_inputs[iteration])
+                    graph.replay()
+
+                # Wait for graph to complete before cloning
+                graph_stream.synchronize()
+
+                # Clone output on graph_stream
+                with torch.cuda.stream(graph_stream):
+                    output_snapshot = graph_output.clone()
+
+                graph_stream.synchronize()
+                outputs_per_iter.append(output_snapshot)
+
+            torch.cuda.synchronize()
+
+            # Validate all peer communications
+            errors = []
+            for iteration in range(num_iterations):
+                output = outputs_per_iter[iteration]
+                for peer in range(self.world_size):
+                    if peer == self.rank:
+                        continue
+                    expected_val = float(iteration * 10000 + peer * 1000 + self.rank)
+                    start_idx = peer * tokens_per_peer
+                    actual_val = output[start_idx, 0].item()
+                    if abs(actual_val - expected_val) > 0.1:
+                        errors.append(
+                            f"Iter {iteration}, from peer {peer}: expected {expected_val:.0f}, got {actual_val:.0f}"
+                        )
+
+            if errors:
+                print(
+                    f"\n[Rank {self.rank}] RACE CONDITION DETECTED! {len(errors)} errors found.",
+                    flush=True,
+                )
+                for error in errors[:10]:
+                    print(f"[Rank {self.rank}] ERROR: {error}", file=sys.stderr)
+                self.fail(
+                    f"Race condition detected on rank {self.rank}: {len(errors)} mismatches\n"
+                    + "\n".join(errors[:10])
+                )
+            else:
+                print(
+                    f"\n[Rank {self.rank}] All {num_iterations} iterations validated successfully.",
+                    flush=True,
+                )
+
+
+# =============================================================================
+# Main Registry
+# =============================================================================
+
+ALL_TEST_CLASSES = [
+    TestOpUniformSplitsCopyIn,
+    TestOpZeroCopy,
+    TestOpRepeatedCalls,
+    TestOpGetOrCreate,
+    TestOpDoubleSetupRaises,
+    TestOpAlltoallvWithoutSetupRaises,
+    TestOpOversizedInputRaises,
+    TestOpOversizedGetSendBufferRaises,
+    TestOpTeardownIdempotent,
+    TestOpPackedOutputUniform,
+    TestOpFillSendBufferBasic,
+    # Multi-iteration tests (different content per iteration)
+    TestOpFillSendBufferBackToBack,
+    TestOpFillSendBufferOversizedRaises,
+    TestOpFillSendBufferWithExplicitNumTokens,
+    # Sync buffer mode tests
+    TestOpSyncBufferBasic,
+    TestOpSyncBufferRepeatedCalls,
+    TestOpSyncBufferZeroCopy,
+    TestOpSyncBufferPackedOutput,
+    TestOpSyncBufferAttribute,
+    # Multi-iteration tests (different content per iteration)
+    # Non-graph: zero-copy API
+    TestOpMultiIterDifferentContentPackedNonGraph,
+    # Non-graph: copy-in API
+    TestOpMultiIterDifferentContentPackedNonGraphCopyIn,
+    # Graph: zero-copy API
+    TestOpMultiIterDifferentContentPackedGraph,
+    # Graph: copy-in API
+    TestOpMultiIterDifferentContentPackedGraphCopyIn,
+    # GraphLoop: zero-copy API (loop captured in graph)
+    TestOpMultiIterDifferentContentPackedGraphLoop,
+    # GraphLoop: copy-in API (loop captured in graph)
+    TestOpMultiIterDifferentContentPackedGraphLoopCopyIn,
+    # Debug: intentional race condition test (BLOCKS_PER_PEER == 1)
+    TestOpRaceConditionDebug,
+    # Debug: intentional race condition test (BLOCKS_PER_PEER > 1)
+    TestOpRaceConditionDebugMultiBlock,
+]
+
+
+def main() -> int:
+    import re
+
+    loader = unittest.TestLoader()
+    suite = unittest.TestSuite()
+    test_filter = os.environ.get("TEST_FILTER", "")
+
+    if test_filter:
+        # Compile regex pattern for matching
+        try:
+            pattern = re.compile(test_filter)
+        except re.error:
+            # If invalid regex, treat as literal substring
+            pattern = re.compile(re.escape(test_filter))
+
+        for cls in ALL_TEST_CLASSES:
+            class_name = cls.__name__
+            # Check if class name matches the pattern
+            if pattern.search(class_name):
+                suite.addTests(loader.loadTestsFromTestCase(cls))
+            else:
+                # Check individual test methods
+                for name in loader.getTestCaseNames(cls):
+                    full_name = f"{class_name}.{name}"
+                    if pattern.search(full_name) or pattern.search(name):
+                        suite.addTest(cls(name))
+
+        if suite.countTestCases() == 0:
+            print(
+                f"WARNING: TEST_FILTER='{test_filter}' matched no tests. "
+                f"Running all {len(ALL_TEST_CLASSES)} test classes.",
+                file=sys.stderr,
+            )
+            for cls in ALL_TEST_CLASSES:
+                suite.addTests(loader.loadTestsFromTestCase(cls))
+    else:
+        for cls in ALL_TEST_CLASSES:
+            suite.addTests(loader.loadTestsFromTestCase(cls))
+
+    runner = unittest.TextTestRunner(verbosity=2)
+    result = runner.run(suite)
+    return 0 if result.wasSuccessful() else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/comms/pipes/collectives/triton/tests/test_device_alltoallv_dynamic.py
+++ b/comms/pipes/collectives/triton/tests/test_device_alltoallv_dynamic.py
@@ -1,0 +1,572 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# pyre-unsafe
+"""
+Unit tests for device_alltoallv_dynamic kernel implementation.
+
+This module tests:
+1. API availability and exports
+2. compute_offsets_from_sizes helper function
+3. Module structure and imports
+
+Run with:
+    buck2 test //comms/pipes/collectives/triton/tests:test_device_alltoallv_dynamic
+"""
+
+import sys
+import unittest
+
+import torch
+from torch.utils._triton import has_triton
+
+
+TRITON_AVAILABLE = has_triton()
+CUDA_AVAILABLE = torch.cuda.is_available()
+
+
+# =============================================================================
+# API Availability Tests
+# =============================================================================
+
+
+class TestDeviceAlltoallvDynamicAPIAvailability(unittest.TestCase):
+    """Tests for device_alltoallv_dynamic API availability and exports."""
+
+    @unittest.skipUnless(TRITON_AVAILABLE, "Triton not available")
+    def test_device_alltoallv_dynamic_importable(self) -> None:
+        """Test that device_alltoallv_dynamic can be imported."""
+        from comms.pipes.collectives.triton import device_alltoallv_dynamic
+
+        self.assertTrue(callable(device_alltoallv_dynamic))
+
+    @unittest.skipUnless(TRITON_AVAILABLE, "Triton not available")
+    def test_compute_offsets_from_sizes_importable(self) -> None:
+        """Test that compute_offsets_from_sizes can be imported."""
+        from comms.pipes.collectives.triton import compute_offsets_from_sizes
+
+        self.assertTrue(callable(compute_offsets_from_sizes))
+
+    @unittest.skipUnless(TRITON_AVAILABLE, "Triton not available")
+    def test_all_exports_present(self) -> None:
+        """Test that all expected functions are in __all__."""
+        from comms.pipes.collectives import triton as collectives
+
+        expected_exports = [
+            "device_alltoallv_dynamic",
+            "compute_offsets_from_sizes",
+            "exchange_offsets",
+        ]
+
+        for export in expected_exports:
+            self.assertIn(
+                export,
+                collectives.__all__,
+                f"Expected export '{export}' missing from __all__",
+            )
+
+    @unittest.skipUnless(TRITON_AVAILABLE, "Triton not available")
+    def test_module_docstring_present(self) -> None:
+        """Test that the module has a docstring."""
+        from comms.pipes.collectives.triton import device_alltoallv_dynamic as mod
+
+        # The module should have documentation
+        self.assertIsNotNone(mod.__doc__)
+
+
+# =============================================================================
+# compute_offsets_from_sizes Tests
+# =============================================================================
+
+
+class TestComputeOffsetsFromSizes(unittest.TestCase):
+    """Tests for the compute_offsets_from_sizes helper function."""
+
+    @unittest.skipUnless(TRITON_AVAILABLE, "Triton not available")
+    @unittest.skipUnless(CUDA_AVAILABLE, "CUDA not available")
+    def test_basic_offsets_computation(self) -> None:
+        """Test basic exclusive prefix sum computation."""
+        from comms.pipes.collectives.triton import compute_offsets_from_sizes
+
+        # Input: sizes for 4 peers
+        sizes = torch.tensor([100, 200, 150, 250], dtype=torch.int64, device="cuda")
+        offsets = torch.zeros_like(sizes)
+
+        # Compute offsets
+        compute_offsets_from_sizes(sizes, offsets)
+
+        # Expected: [0, 100, 300, 450]
+        # offset[0] = 0 (start)
+        # offset[1] = 0 + 100 = 100
+        # offset[2] = 0 + 100 + 200 = 300
+        # offset[3] = 0 + 100 + 200 + 150 = 450
+        expected = torch.tensor([0, 100, 300, 450], dtype=torch.int64, device="cuda")
+
+        torch.testing.assert_close(offsets, expected)
+
+    @unittest.skipUnless(TRITON_AVAILABLE, "Triton not available")
+    @unittest.skipUnless(CUDA_AVAILABLE, "CUDA not available")
+    def test_offsets_with_zeros(self) -> None:
+        """Test offset computation when some sizes are zero."""
+        from comms.pipes.collectives.triton import compute_offsets_from_sizes
+
+        # Some peers have zero-length messages
+        sizes = torch.tensor([100, 0, 150, 0, 250], dtype=torch.int64, device="cuda")
+        offsets = torch.zeros_like(sizes)
+
+        compute_offsets_from_sizes(sizes, offsets)
+
+        # Expected: [0, 100, 100, 250, 250]
+        expected = torch.tensor(
+            [0, 100, 100, 250, 250], dtype=torch.int64, device="cuda"
+        )
+
+        torch.testing.assert_close(offsets, expected)
+
+    @unittest.skipUnless(TRITON_AVAILABLE, "Triton not available")
+    @unittest.skipUnless(CUDA_AVAILABLE, "CUDA not available")
+    def test_offsets_single_element(self) -> None:
+        """Test offset computation with single element."""
+        from comms.pipes.collectives.triton import compute_offsets_from_sizes
+
+        sizes = torch.tensor([500], dtype=torch.int64, device="cuda")
+        offsets = torch.zeros_like(sizes)
+
+        compute_offsets_from_sizes(sizes, offsets)
+
+        # Single element always starts at 0
+        expected = torch.tensor([0], dtype=torch.int64, device="cuda")
+
+        torch.testing.assert_close(offsets, expected)
+
+    @unittest.skipUnless(TRITON_AVAILABLE, "Triton not available")
+    @unittest.skipUnless(CUDA_AVAILABLE, "CUDA not available")
+    def test_offsets_all_same_size(self) -> None:
+        """Test offset computation with uniform sizes."""
+        from comms.pipes.collectives.triton import compute_offsets_from_sizes
+
+        # All peers have same size (256 bytes each)
+        sizes = torch.full((8,), 256, dtype=torch.int64, device="cuda")
+        offsets = torch.zeros_like(sizes)
+
+        compute_offsets_from_sizes(sizes, offsets)
+
+        # Expected: [0, 256, 512, 768, 1024, 1280, 1536, 1792]
+        expected = torch.arange(8, dtype=torch.int64, device="cuda") * 256
+
+        torch.testing.assert_close(offsets, expected)
+
+    @unittest.skipUnless(TRITON_AVAILABLE, "Triton not available")
+    @unittest.skipUnless(CUDA_AVAILABLE, "CUDA not available")
+    def test_offsets_large_values(self) -> None:
+        """Test offset computation with large byte counts (>4GB total)."""
+        from comms.pipes.collectives.triton import compute_offsets_from_sizes
+
+        # Large sizes that exceed 32-bit range when summed
+        one_gb = 1024 * 1024 * 1024
+        sizes = torch.tensor(
+            [one_gb, one_gb, one_gb, one_gb, one_gb],
+            dtype=torch.int64,
+            device="cuda",
+        )
+        offsets = torch.zeros_like(sizes)
+
+        compute_offsets_from_sizes(sizes, offsets)
+
+        # Expected: [0, 1GB, 2GB, 3GB, 4GB]
+        expected = torch.tensor(
+            [0, one_gb, 2 * one_gb, 3 * one_gb, 4 * one_gb],
+            dtype=torch.int64,
+            device="cuda",
+        )
+
+        torch.testing.assert_close(offsets, expected)
+
+    @unittest.skipUnless(TRITON_AVAILABLE, "Triton not available")
+    @unittest.skipUnless(CUDA_AVAILABLE, "CUDA not available")
+    def test_offsets_preserves_input(self) -> None:
+        """Test that compute_offsets_from_sizes doesn't modify the input sizes."""
+        from comms.pipes.collectives.triton import compute_offsets_from_sizes
+
+        sizes = torch.tensor([100, 200, 300], dtype=torch.int64, device="cuda")
+        sizes_original = sizes.clone()
+        offsets = torch.zeros_like(sizes)
+
+        compute_offsets_from_sizes(sizes, offsets)
+
+        # Sizes should be unchanged
+        torch.testing.assert_close(sizes, sizes_original)
+
+
+# =============================================================================
+# Kernel Structure Tests
+# =============================================================================
+
+
+class TestKernelStructure(unittest.TestCase):
+    """Tests for kernel function structure and decorators."""
+
+    @unittest.skipUnless(TRITON_AVAILABLE, "Triton not available")
+    def test_non_pipelined_kernel_exists(self) -> None:
+        """Test that the non-pipelined kernel function exists."""
+        from comms.pipes.collectives.triton.device_alltoallv_dynamic import (
+            _device_alltoallv_dynamic_kernel,
+        )
+
+        # The kernel exists if we can import it without error
+        # With @requires_torchcomms decorator, it may not be directly callable
+        self.assertIsNotNone(_device_alltoallv_dynamic_kernel)
+
+    @unittest.skipUnless(TRITON_AVAILABLE, "Triton not available")
+    def test_compute_offsets_kernel_exists(self) -> None:
+        """Test that the offset computation helper exists."""
+        from comms.pipes.collectives.triton import compute_offsets_from_sizes
+
+        # The public API is compute_offsets_from_sizes (uses PyTorch cumsum internally)
+        self.assertTrue(callable(compute_offsets_from_sizes))
+
+
+# =============================================================================
+# Function Signature Tests
+# =============================================================================
+
+
+class TestFunctionSignatures(unittest.TestCase):
+    """Tests for function signatures and required parameters."""
+
+    @unittest.skipUnless(TRITON_AVAILABLE, "Triton not available")
+    def test_device_alltoallv_dynamic_signature(self) -> None:
+        """Test device_alltoallv_dynamic has expected parameters."""
+        import inspect
+
+        from comms.pipes.collectives.triton import device_alltoallv_dynamic
+
+        sig = inspect.signature(device_alltoallv_dynamic)
+        params = list(sig.parameters.keys())
+
+        expected_params = [
+            "send_buf",
+            "recv_buf",
+            "send_sizes",
+            "send_offsets",
+            "recv_sizes",
+            "local_recv_slot_offsets",
+            "remote_write_offsets",
+            "dev_win_ptr",
+            "src_info",
+            "my_rank",
+            "world_size",
+            "num_warps",
+        ]
+
+        for param in expected_params:
+            self.assertIn(
+                param, params, f"Expected parameter '{param}' not in signature"
+            )
+
+    @unittest.skipUnless(TRITON_AVAILABLE, "Triton not available")
+    def test_compute_offsets_from_sizes_signature(self) -> None:
+        """Test compute_offsets_from_sizes has expected parameters."""
+        import inspect
+
+        from comms.pipes.collectives.triton import compute_offsets_from_sizes
+
+        sig = inspect.signature(compute_offsets_from_sizes)
+        params = list(sig.parameters.keys())
+
+        expected_params = ["sizes", "offsets"]
+
+        self.assertEqual(params, expected_params)
+
+
+# =============================================================================
+# Docstring Tests
+# =============================================================================
+
+
+class TestDocstrings(unittest.TestCase):
+    """Tests for function documentation."""
+
+    @unittest.skipUnless(TRITON_AVAILABLE, "Triton not available")
+    def test_device_alltoallv_dynamic_has_docstring(self) -> None:
+        """Test device_alltoallv_dynamic has documentation."""
+        from comms.pipes.collectives.triton import device_alltoallv_dynamic
+
+        self.assertIsNotNone(device_alltoallv_dynamic.__doc__)
+        self.assertGreater(len(device_alltoallv_dynamic.__doc__), 100)
+
+    @unittest.skipUnless(TRITON_AVAILABLE, "Triton not available")
+    def test_compute_offsets_from_sizes_has_docstring(self) -> None:
+        """Test compute_offsets_from_sizes has documentation."""
+        from comms.pipes.collectives.triton import compute_offsets_from_sizes
+
+        self.assertIsNotNone(compute_offsets_from_sizes.__doc__)
+
+
+# =============================================================================
+# Multi-dtype Support Tests
+# =============================================================================
+
+
+class TestMultiDtypeSupport(unittest.TestCase):
+    """Tests that element_size() plumbing works for all supported dtypes."""
+
+    @unittest.skipUnless(TRITON_AVAILABLE, "Triton not available")
+    @unittest.skipUnless(CUDA_AVAILABLE, "CUDA not available")
+    def test_element_size_float32(self) -> None:
+        """Verify element_size() returns 4 for float32 tensors."""
+        buf = torch.zeros(16, dtype=torch.float32, device="cuda")
+        self.assertEqual(buf.element_size(), 4)
+
+    @unittest.skipUnless(TRITON_AVAILABLE, "Triton not available")
+    @unittest.skipUnless(CUDA_AVAILABLE, "CUDA not available")
+    def test_element_size_float16(self) -> None:
+        """Verify element_size() returns 2 for float16 tensors."""
+        buf = torch.zeros(16, dtype=torch.float16, device="cuda")
+        self.assertEqual(buf.element_size(), 2)
+
+    @unittest.skipUnless(TRITON_AVAILABLE, "Triton not available")
+    @unittest.skipUnless(CUDA_AVAILABLE, "CUDA not available")
+    def test_element_size_bfloat16(self) -> None:
+        """Verify element_size() returns 2 for bfloat16 tensors."""
+        buf = torch.zeros(16, dtype=torch.bfloat16, device="cuda")
+        self.assertEqual(buf.element_size(), 2)
+
+    @unittest.skipUnless(TRITON_AVAILABLE, "Triton not available")
+    @unittest.skipUnless(CUDA_AVAILABLE, "CUDA not available")
+    def test_element_size_float64(self) -> None:
+        """Verify element_size() returns 8 for float64 tensors."""
+        buf = torch.zeros(16, dtype=torch.float64, device="cuda")
+        self.assertEqual(buf.element_size(), 8)
+
+    @unittest.skipUnless(TRITON_AVAILABLE, "Triton not available")
+    @unittest.skipUnless(CUDA_AVAILABLE, "CUDA not available")
+    def test_element_size_int8(self) -> None:
+        """Verify element_size() returns 1 for int8 tensors."""
+        buf = torch.zeros(16, dtype=torch.int8, device="cuda")
+        self.assertEqual(buf.element_size(), 1)
+
+    @unittest.skipUnless(TRITON_AVAILABLE, "Triton not available")
+    @unittest.skipUnless(CUDA_AVAILABLE, "CUDA not available")
+    def test_compute_offsets_works_with_int32_sizes(self) -> None:
+        """Test compute_offsets_from_sizes works with int32 size tensors."""
+        from comms.pipes.collectives.triton import compute_offsets_from_sizes
+
+        sizes = torch.tensor([100, 200, 150], dtype=torch.int32, device="cuda")
+        offsets = torch.zeros_like(sizes)
+        compute_offsets_from_sizes(sizes, offsets)
+
+        expected = torch.tensor([0, 100, 300], dtype=torch.int32, device="cuda")
+        torch.testing.assert_close(offsets, expected)
+
+
+# =============================================================================
+# Dependency Tests (verify required APIs are available)
+# =============================================================================
+
+
+class TestRequiredAPIsAvailable(unittest.TestCase):
+    """Tests that required TorchComms APIs are available."""
+
+    @unittest.skipUnless(TRITON_AVAILABLE, "Triton not available")
+    def test_wait_signal_from_available(self) -> None:
+        """Test that wait_signal_from API is available (required for correctness)."""
+        from torchcomms.triton.fb import wait_signal_from
+
+        self.assertTrue(callable(wait_signal_from))
+
+    @unittest.skipUnless(TRITON_AVAILABLE, "Triton not available")
+    def test_put_block_available(self) -> None:
+        """Test that put_block API is available."""
+        from torchcomms.triton.fb import put_block
+
+        self.assertTrue(callable(put_block))
+
+    @unittest.skipUnless(TRITON_AVAILABLE, "Triton not available")
+    def test_flush_block_available(self) -> None:
+        """Test that flush_block API is available."""
+        from torchcomms.triton.fb import flush_block
+
+        self.assertTrue(callable(flush_block))
+
+    @unittest.skipUnless(TRITON_AVAILABLE, "Triton not available")
+    def test_requires_torchcomms_decorator_available(self) -> None:
+        """Test that requires_torchcomms decorator is available."""
+        from torchcomms.triton.fb import requires_torchcomms
+
+        self.assertTrue(callable(requires_torchcomms))
+
+
+# =============================================================================
+# Monotonic Signal Counter Tests
+# =============================================================================
+
+
+class TestMonotonicSignalCounter(unittest.TestCase):
+    """Tests for monotonic signal counter behavior."""
+
+    @unittest.skipUnless(TRITON_AVAILABLE, "Triton not available")
+    def test_completion_counters_initialized_to_zero(self) -> None:
+        """Test that completion counters start at zero."""
+        # Clear cache to ensure fresh counters
+        from comms.pipes.collectives.triton.device_alltoallv_dynamic import (
+            _COMPLETION_COUNTERS_CACHE,
+            _get_completion_counters,
+        )
+
+        _COMPLETION_COUNTERS_CACHE.clear()
+
+        if not CUDA_AVAILABLE:
+            return
+
+        world_size = 8
+        device = torch.device("cuda")
+
+        counters = _get_completion_counters(world_size, device)
+
+        # Counters should be zeros
+        expected = torch.zeros(world_size, dtype=torch.int32, device=device)
+        torch.testing.assert_close(counters, expected)
+
+    @unittest.skipUnless(TRITON_AVAILABLE, "Triton not available")
+    @unittest.skipUnless(CUDA_AVAILABLE, "CUDA not available")
+    def test_completion_counters_cached(self) -> None:
+        """Test that completion counters are cached and reused."""
+        from comms.pipes.collectives.triton.device_alltoallv_dynamic import (
+            _COMPLETION_COUNTERS_CACHE,
+            _get_completion_counters,
+        )
+
+        _COMPLETION_COUNTERS_CACHE.clear()
+
+        world_size = 4
+        device = torch.device("cuda")
+
+        counters1 = _get_completion_counters(world_size, device)
+        counters2 = _get_completion_counters(world_size, device)
+
+        # Should return the same tensor (same data_ptr)
+        self.assertEqual(counters1.data_ptr(), counters2.data_ptr())
+
+
+# =============================================================================
+# Tests: sync_buffer API
+# =============================================================================
+
+
+class TestSyncBufferAPIAvailability(unittest.TestCase):
+    """Tests for sync_buffer API availability and parameter handling."""
+
+    @unittest.skipUnless(TRITON_AVAILABLE, "Triton not available")
+    def test_sync_buffer_parameter_exists(self) -> None:
+        """Test that device_alltoallv_dynamic accepts sync_buffer parameter."""
+        import inspect
+
+        from comms.pipes.collectives.triton import device_alltoallv_dynamic
+
+        sig = inspect.signature(device_alltoallv_dynamic)
+        self.assertIn(
+            "sync_buffer",
+            sig.parameters,
+            "device_alltoallv_dynamic should accept sync_buffer parameter",
+        )
+
+    @unittest.skipUnless(TRITON_AVAILABLE, "Triton not available")
+    def test_sync_buffer_default_is_true(self) -> None:
+        """Test that sync_buffer defaults to True."""
+        import inspect
+
+        from comms.pipes.collectives.triton import device_alltoallv_dynamic
+
+        sig = inspect.signature(device_alltoallv_dynamic)
+        sync_buffer_param = sig.parameters["sync_buffer"]
+        self.assertEqual(
+            sync_buffer_param.default,
+            True,
+            "sync_buffer should default to True",
+        )
+
+    @unittest.skipUnless(TRITON_AVAILABLE, "Triton not available")
+    def test_sync_buffer_documented(self) -> None:
+        """Test that sync_buffer is documented in the function docstring."""
+        from comms.pipes.collectives.triton import device_alltoallv_dynamic
+
+        docstring = device_alltoallv_dynamic.__doc__
+        self.assertIsNotNone(docstring, "Function should have a docstring")
+        self.assertIn(
+            "sync_buffer",
+            docstring,
+            "sync_buffer should be documented in the docstring",
+        )
+
+
+class TestSyncBufferAlltoallvOp(unittest.TestCase):
+    """Tests for sync_buffer in AlltoallvOp class."""
+
+    @unittest.skipUnless(TRITON_AVAILABLE, "Triton not available")
+    def test_alltoallv_op_sync_buffer_parameter(self) -> None:
+        """Test that AlltoallvOp accepts sync_buffer parameter."""
+        import inspect
+
+        from comms.pipes.collectives.triton import AlltoallvOp
+
+        sig = inspect.signature(AlltoallvOp.__init__)
+        self.assertIn(
+            "sync_buffer",
+            sig.parameters,
+            "AlltoallvOp.__init__ should accept sync_buffer parameter",
+        )
+
+    @unittest.skipUnless(TRITON_AVAILABLE, "Triton not available")
+    def test_alltoallv_op_sync_buffer_default_is_true(self) -> None:
+        """Test that AlltoallvOp sync_buffer defaults to True."""
+        import inspect
+
+        from comms.pipes.collectives.triton import AlltoallvOp
+
+        sig = inspect.signature(AlltoallvOp.__init__)
+        sync_buffer_param = sig.parameters["sync_buffer"]
+        self.assertEqual(
+            sync_buffer_param.default,
+            True,
+            "sync_buffer should default to True",
+        )
+
+    @unittest.skipUnless(TRITON_AVAILABLE, "Triton not available")
+    def test_alltoallv_op_get_or_create_accepts_sync_buffer(self) -> None:
+        """Test that AlltoallvOp.get_or_create accepts sync_buffer parameter."""
+        import inspect
+
+        from comms.pipes.collectives.triton import AlltoallvOp
+
+        sig = inspect.signature(AlltoallvOp.get_or_create)
+        self.assertIn(
+            "sync_buffer",
+            sig.parameters,
+            "AlltoallvOp.get_or_create should accept sync_buffer parameter",
+        )
+
+
+def main() -> int:
+    """Run all tests."""
+    loader = unittest.TestLoader()
+    suite = unittest.TestSuite()
+
+    # Add all test classes
+    suite.addTests(
+        loader.loadTestsFromTestCase(TestDeviceAlltoallvDynamicAPIAvailability)
+    )
+    suite.addTests(loader.loadTestsFromTestCase(TestComputeOffsetsFromSizes))
+    suite.addTests(loader.loadTestsFromTestCase(TestKernelStructure))
+    suite.addTests(loader.loadTestsFromTestCase(TestFunctionSignatures))
+    suite.addTests(loader.loadTestsFromTestCase(TestDocstrings))
+    suite.addTests(loader.loadTestsFromTestCase(TestMultiDtypeSupport))
+    suite.addTests(loader.loadTestsFromTestCase(TestRequiredAPIsAvailable))
+    suite.addTests(loader.loadTestsFromTestCase(TestMonotonicSignalCounter))
+
+    runner = unittest.TextTestRunner(verbosity=2)
+    result = runner.run(suite)
+
+    return 0 if result.wasSuccessful() else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/comms/pipes/collectives/triton/tests/test_device_alltoallv_dynamic_e2e.py
+++ b/comms/pipes/collectives/triton/tests/test_device_alltoallv_dynamic_e2e.py
@@ -1,0 +1,957 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# pyre-unsafe
+"""
+End-to-end integration tests for device_alltoallv_dynamic.
+
+Each test class contains a SINGLE test to avoid P2P mapping races
+between tests sharing the same NCCL allocator.  register_local_buffer
+maps GPU memory via ibv_reg_mr_iova2, and deregister_local_buffer's
+unmap can race with the next test's torch.zeros (cudaMemset).
+
+Run with:
+    buck2 run @fbcode//mode/opt \
+        -c hpc_comms.use_ncclx=stable \
+        fbcode//comms/torchcomms/triton/fb/tests:test_device_alltoallv_dynamic_e2e
+"""
+
+import gc
+import os
+import sys
+import time
+import unittest
+from typing import Optional
+
+import torch
+import torchcomms
+from torch.utils._triton import has_triton
+from torchcomms.tests.integration.py.TorchCommTestHelpers import TorchCommTestWrapper
+
+
+TRITON_AVAILABLE = has_triton()
+RUN_DEVICE_API_TEST = os.environ.get("RUN_DEVICE_API_TEST", "false").lower() == "true"
+
+
+def _skip_if_not_ready() -> bool:
+    return TRITON_AVAILABLE and torch.cuda.is_available() and RUN_DEVICE_API_TEST
+
+
+# =============================================================================
+# Test Base Class
+# =============================================================================
+
+
+class _SingleTestBase(unittest.TestCase):
+    """Allocates pool + window once, runs one test, tears down."""
+
+    wrapper: Optional[TorchCommTestWrapper] = None
+    recv_pool: Optional["torch.cuda.MemPool"] = None
+    send_pool: Optional["torch.cuda.MemPool"] = None
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        if not _skip_if_not_ready():
+            raise unittest.SkipTest("E2E test environment not ready")
+        from comms.pipes.collectives.triton import (
+            alloc_comms_buffer,
+            prewarm_completion_counters,
+        )
+
+        torch.cuda.synchronize()
+        cls.wrapper = TorchCommTestWrapper()
+        cls.torchcomm = cls.wrapper.get_torchcomm()
+        cls.rank = cls.torchcomm.get_rank()
+        cls.world_size = cls.torchcomm.get_size()
+        cls.device = cls.torchcomm.get_device()
+        cls.allocator = torchcomms.get_mem_allocator(cls.torchcomm.get_backend())
+        # 4MiB default pool capacity, matching NCCL DEFAULT_BUFFSIZE.
+        cls.pool_capacity = 4 * 1024 * 1024
+
+        cls.dtype = torch.float32
+        alloc_elems = (
+            cls.pool_capacity // torch.tensor([], dtype=cls.dtype).element_size()
+        )
+        cls.recv_buf, cls.recv_pool = alloc_comms_buffer(
+            alloc_elems, cls.dtype, cls.device, cls.torchcomm.get_backend()
+        )
+        cls.send_buf, cls.send_pool = alloc_comms_buffer(
+            alloc_elems, cls.dtype, cls.device, cls.torchcomm.get_backend()
+        )
+
+        # Pre-allocate completion counters BEFORE GIN activation.
+        # GIN (GPU-Initiated NCCL) blocks regular CUDA allocations after
+        # get_device_window() is called.  The counters must be allocated
+        # here while regular CUDA operations still work.
+        prewarm_completion_counters(cls.world_size, cls.device)
+
+        cls.torchcomm.barrier(False)
+        cls.window = cls.torchcomm.new_window()
+        cls.window.tensor_register(cls.recv_buf)
+        cls.torchcomm.barrier(False)
+
+        # Cached setup values for the lean collective API
+        cls.my_rank = cls.rank
+        cls.src_info = None
+        cls.dev_win_ptr = None
+
+    def setUp(self) -> None:
+        """Register send buffer for one-sided operations after test data has been filled."""
+        # Subclass tests call _fill_uniform / manual fill first, then register.
+        # We don't register here because data isn't filled yet.
+        pass
+
+    def _register_send_buf(self) -> None:
+        """Register send_buf for one-sided operations and cache dev_win_ptr."""
+        if self.src_info is None:
+            # Use signal_count = world_size * 2 for BUFFER_READY and DATA_COMPLETE signals
+            self.dev_win_ptr = self.window.get_device_window(
+                signal_count=self.world_size * 2
+            )
+            self.src_info = self.window.register_local_buffer(self.send_buf)
+            # Reset iteration counter to match fresh signal memory state.
+            # Without this, cross-test hangs occur because the iteration counter
+            # persists across tests but signal memory is recreated per-window.
+            from comms.pipes.collectives.triton.device_alltoallv_dynamic import (
+                _reset_iteration_counter,
+            )
+
+            _reset_iteration_counter(self.world_size, self.device)
+
+    def _deregister_send_buf(self) -> None:
+        """Deregister send_buf after collective, before next data fill."""
+        if self.src_info is not None:
+            self.window.deregister_local_buffer(*self.src_info)
+            self.src_info = None
+
+    def tearDown(self) -> None:
+        """Deregister send buffer after each test."""
+        self._deregister_send_buf()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        if cls.torchcomm is not None:
+            cls.torchcomm.barrier(False)
+        if hasattr(cls, "src_info") and cls.src_info is not None:
+            cls.window.deregister_local_buffer(*cls.src_info)
+            cls.src_info = None
+        if hasattr(cls, "window") and cls.window is not None:
+            cls.window.tensor_deregister()
+            cls.window = None
+        cls.recv_buf = None
+        cls.send_buf = None
+        cls.recv_pool = None
+        cls.send_pool = None
+        cls.allocator = None
+        cls.torchcomm = None
+        cls.wrapper = None
+        gc.collect()
+        torch.cuda.synchronize()
+        time.sleep(2)
+
+    # ---- helpers ----
+
+    def _verify_received_data(
+        self,
+        recv_buf: torch.Tensor,
+        local_recv_slot_offsets: torch.Tensor,
+        recv_sizes: torch.Tensor,
+        test_name: str = "",
+    ) -> None:
+        elem_size = recv_buf.element_size()
+        for peer in range(self.world_size):
+            recv_size = recv_sizes[peer].item()
+            if recv_size == 0:
+                continue
+            recv_offset = local_recv_slot_offsets[peer].item()
+            num_elements = recv_size // elem_size
+            start_idx = recv_offset // elem_size
+            actual = recv_buf[start_idx : start_idx + num_elements].cpu()
+            expected_value = float(peer * 1000 + self.rank)
+            expected = torch.full_like(actual, expected_value)
+            torch.testing.assert_close(
+                actual,
+                expected,
+                msg=(
+                    f"[{test_name}] Rank {self.rank}: Data from peer {peer} is "
+                    f"incorrect. Expected all values to be {expected_value}, "
+                    f"got {actual[:5].tolist()}..."
+                ),
+            )
+
+    def _fill_uniform(self, msg_size: int) -> tuple:
+        """Fill shared buffers with uniform-size identifiable patterns.
+
+        Returns (send_sizes, send_offsets, recv_sizes, local_recv_slot_offsets, remote_write_offsets).
+        All tensors and offset exchange are done here (before GIN is active)
+        so that no CUDA tensor operations happen after _register_send_buf().
+        """
+        from comms.pipes.collectives.triton import exchange_offsets
+
+        elem_size = self.send_buf.element_size()
+        num_elements_per_peer = msg_size // elem_size
+        self.send_buf.zero_()
+        self.recv_buf.zero_()
+        for peer in range(self.world_size):
+            start = peer * num_elements_per_peer
+            self.send_buf[start : start + num_elements_per_peer] = float(
+                self.rank * 1000 + peer
+            )
+        send_sizes = torch.full(
+            (self.world_size,), msg_size, dtype=torch.int64, device=self.device
+        )
+        send_offsets = (
+            torch.arange(self.world_size, dtype=torch.int64, device=self.device)
+            * msg_size
+        )
+        recv_sizes = send_sizes.clone()
+        local_recv_slot_offsets = send_offsets.clone()
+        remote_write_offsets = exchange_offsets(local_recv_slot_offsets, self.torchcomm)
+        return (
+            send_sizes,
+            send_offsets,
+            recv_sizes,
+            local_recv_slot_offsets,
+            remote_write_offsets,
+        )
+
+
+# =============================================================================
+# Non-Pipelined Tests
+# =============================================================================
+
+
+class TestUniformSizesBasic(_SingleTestBase):
+    """Test basic alltoallv with uniform message sizes."""
+
+    def test_uniform_sizes_basic(self) -> None:
+        from comms.pipes.collectives.triton import device_alltoallv_dynamic
+
+        (
+            send_sizes,
+            send_offsets,
+            recv_sizes,
+            local_recv_slot_offsets,
+            remote_write_offsets,
+        ) = self._fill_uniform(1024)
+        self._register_send_buf()
+        device_alltoallv_dynamic(
+            self.send_buf,
+            self.recv_buf,
+            send_sizes,
+            send_offsets,
+            recv_sizes,
+            local_recv_slot_offsets,
+            remote_write_offsets,
+            self.dev_win_ptr,
+            self.src_info,
+            self.my_rank,
+            self.world_size,
+        )
+        torch.cuda.synchronize()
+        self._verify_received_data(
+            self.recv_buf, send_offsets, send_sizes, "uniform_sizes_basic"
+        )
+
+
+class TestLargeMessages(_SingleTestBase):
+    """Test alltoallv with large messages that fill the pool."""
+
+    def test_large_messages(self) -> None:
+        from comms.pipes.collectives.triton import device_alltoallv_dynamic
+
+        elem_size = self.send_buf.element_size()
+        msg_size = (self.pool_capacity // self.world_size // elem_size) * elem_size
+        (
+            send_sizes,
+            send_offsets,
+            recv_sizes,
+            local_recv_slot_offsets,
+            remote_write_offsets,
+        ) = self._fill_uniform(msg_size)
+        self._register_send_buf()
+        device_alltoallv_dynamic(
+            self.send_buf,
+            self.recv_buf,
+            send_sizes,
+            send_offsets,
+            recv_sizes,
+            local_recv_slot_offsets,
+            remote_write_offsets,
+            self.dev_win_ptr,
+            self.src_info,
+            self.my_rank,
+            self.world_size,
+        )
+        torch.cuda.synchronize()
+        self._verify_received_data(
+            self.recv_buf, send_offsets, send_sizes, "large_messages"
+        )
+
+
+# =============================================================================
+# Edge-Case Tests
+# =============================================================================
+
+
+class TestMinimumMessageSize(_SingleTestBase):
+    """Test with minimum viable message size (4 bytes = 1 float32)."""
+
+    def test_minimum_message_size(self) -> None:
+        from comms.pipes.collectives.triton import device_alltoallv_dynamic
+
+        (
+            send_sizes,
+            send_offsets,
+            recv_sizes,
+            local_recv_slot_offsets,
+            remote_write_offsets,
+        ) = self._fill_uniform(4)
+        self._register_send_buf()
+        device_alltoallv_dynamic(
+            self.send_buf,
+            self.recv_buf,
+            send_sizes,
+            send_offsets,
+            recv_sizes,
+            local_recv_slot_offsets,
+            remote_write_offsets,
+            self.dev_win_ptr,
+            self.src_info,
+            self.my_rank,
+            self.world_size,
+        )
+        torch.cuda.synchronize()
+        self._verify_received_data(
+            self.recv_buf, send_offsets, send_sizes, "minimum_message_size"
+        )
+
+
+class TestRepeatedCalls(_SingleTestBase):
+    """Test multiple consecutive alltoallv calls for correctness."""
+
+    def test_repeated_calls(self) -> None:
+        from comms.pipes.collectives.triton import device_alltoallv_dynamic
+
+        msg_size = 1024
+        for iteration in range(5):
+            self._deregister_send_buf()
+            (
+                send_sizes,
+                send_offsets,
+                recv_sizes,
+                local_recv_slot_offsets,
+                remote_write_offsets,
+            ) = self._fill_uniform(msg_size)
+            self._register_send_buf()
+            device_alltoallv_dynamic(
+                self.send_buf,
+                self.recv_buf,
+                send_sizes,
+                send_offsets,
+                recv_sizes,
+                local_recv_slot_offsets,
+                remote_write_offsets,
+                self.dev_win_ptr,
+                self.src_info,
+                self.my_rank,
+                self.world_size,
+            )
+            # Must sync all ranks before next iteration's deregister +
+            # exchange_offsets (a collective requiring all ranks).
+            torch.cuda.synchronize()
+            self.torchcomm.barrier(False)
+            self._verify_received_data(
+                self.recv_buf,
+                send_offsets,
+                send_sizes,
+                f"repeated_calls_iter_{iteration}",
+            )
+
+
+# =============================================================================
+# Num Warps Tests (Phase 1: warp parallelism tuning)
+# =============================================================================
+
+
+class TestNumWarps4(_SingleTestBase):
+    """Test non-pipelined alltoallv with num_warps=4 (minimum, old default)."""
+
+    def test_num_warps_4(self) -> None:
+        from comms.pipes.collectives.triton import device_alltoallv_dynamic
+
+        (
+            send_sizes,
+            send_offsets,
+            recv_sizes,
+            local_recv_slot_offsets,
+            remote_write_offsets,
+        ) = self._fill_uniform(1024)
+        self._register_send_buf()
+        device_alltoallv_dynamic(
+            self.send_buf,
+            self.recv_buf,
+            send_sizes,
+            send_offsets,
+            recv_sizes,
+            local_recv_slot_offsets,
+            remote_write_offsets,
+            self.dev_win_ptr,
+            self.src_info,
+            self.my_rank,
+            self.world_size,
+            num_warps=4,
+        )
+        torch.cuda.synchronize()
+        self._verify_received_data(
+            self.recv_buf, send_offsets, send_sizes, "num_warps_4"
+        )
+
+
+class TestNumWarps32(_SingleTestBase):
+    """Test non-pipelined alltoallv with num_warps=32 (maximum, 1024 threads)."""
+
+    def test_num_warps_32(self) -> None:
+        from comms.pipes.collectives.triton import device_alltoallv_dynamic
+
+        (
+            send_sizes,
+            send_offsets,
+            recv_sizes,
+            local_recv_slot_offsets,
+            remote_write_offsets,
+        ) = self._fill_uniform(1024)
+        self._register_send_buf()
+        device_alltoallv_dynamic(
+            self.send_buf,
+            self.recv_buf,
+            send_sizes,
+            send_offsets,
+            recv_sizes,
+            local_recv_slot_offsets,
+            remote_write_offsets,
+            self.dev_win_ptr,
+            self.src_info,
+            self.my_rank,
+            self.world_size,
+            num_warps=32,
+        )
+        torch.cuda.synchronize()
+        self._verify_received_data(
+            self.recv_buf, send_offsets, send_sizes, "num_warps_32"
+        )
+
+
+# =============================================================================
+# Blocks-Per-Peer Tests (Phase 2: block parallelism tuning)
+# =============================================================================
+
+
+class TestBlocksPerPeer2Uniform(_SingleTestBase):
+    """Test non-pipelined alltoallv with blocks_per_peer=2 and uniform sizes."""
+
+    def test_blocks_per_peer_2_uniform(self) -> None:
+        from comms.pipes.collectives.triton import device_alltoallv_dynamic
+
+        (
+            send_sizes,
+            send_offsets,
+            recv_sizes,
+            local_recv_slot_offsets,
+            remote_write_offsets,
+        ) = self._fill_uniform(1024)
+        self._register_send_buf()
+        device_alltoallv_dynamic(
+            self.send_buf,
+            self.recv_buf,
+            send_sizes,
+            send_offsets,
+            recv_sizes,
+            local_recv_slot_offsets,
+            remote_write_offsets,
+            self.dev_win_ptr,
+            self.src_info,
+            self.my_rank,
+            self.world_size,
+            blocks_per_peer=2,
+        )
+        torch.cuda.synchronize()
+        self._verify_received_data(
+            self.recv_buf, send_offsets, send_sizes, "blocks_per_peer_2_uniform"
+        )
+
+
+class TestBlocksPerPeer4Uniform(_SingleTestBase):
+    """Test non-pipelined alltoallv with blocks_per_peer=4 and uniform sizes."""
+
+    def test_blocks_per_peer_4_uniform(self) -> None:
+        from comms.pipes.collectives.triton import device_alltoallv_dynamic
+
+        (
+            send_sizes,
+            send_offsets,
+            recv_sizes,
+            local_recv_slot_offsets,
+            remote_write_offsets,
+        ) = self._fill_uniform(1024)
+        self._register_send_buf()
+        device_alltoallv_dynamic(
+            self.send_buf,
+            self.recv_buf,
+            send_sizes,
+            send_offsets,
+            recv_sizes,
+            local_recv_slot_offsets,
+            remote_write_offsets,
+            self.dev_win_ptr,
+            self.src_info,
+            self.my_rank,
+            self.world_size,
+            blocks_per_peer=4,
+        )
+        torch.cuda.synchronize()
+        self._verify_received_data(
+            self.recv_buf, send_offsets, send_sizes, "blocks_per_peer_4_uniform"
+        )
+
+
+class TestBlocksPerPeer4Large(_SingleTestBase):
+    """Test non-pipelined alltoallv with blocks_per_peer=4 and large messages.
+
+    Large messages are the primary use case for blocks_per_peer > 1:
+    multiple blocks issue parallel put_block calls, each copying a chunk,
+    which increases aggregate NVLink bandwidth utilization.
+    """
+
+    def test_blocks_per_peer_4_large(self) -> None:
+        from comms.pipes.collectives.triton import device_alltoallv_dynamic
+
+        elem_size = self.send_buf.element_size()
+        msg_size = (self.pool_capacity // self.world_size // elem_size) * elem_size
+        (
+            send_sizes,
+            send_offsets,
+            recv_sizes,
+            local_recv_slot_offsets,
+            remote_write_offsets,
+        ) = self._fill_uniform(msg_size)
+        self._register_send_buf()
+        device_alltoallv_dynamic(
+            self.send_buf,
+            self.recv_buf,
+            send_sizes,
+            send_offsets,
+            recv_sizes,
+            local_recv_slot_offsets,
+            remote_write_offsets,
+            self.dev_win_ptr,
+            self.src_info,
+            self.my_rank,
+            self.world_size,
+            blocks_per_peer=4,
+        )
+        torch.cuda.synchronize()
+        self._verify_received_data(
+            self.recv_buf, send_offsets, send_sizes, "blocks_per_peer_4_large"
+        )
+
+
+class TestBlocksPerPeerConsistency(_SingleTestBase):
+    """Verify blocks_per_peer=1 and blocks_per_peer=4 produce identical results.
+
+    The multi-block path splits each peer's data into BLOCKS_PER_PEER
+    chunks and reassembles via independent put_block calls.  This test
+    confirms that chunked transfer produces byte-identical recv_buf
+    contents as the single-block baseline.
+    """
+
+    def test_blocks_per_peer_consistency(self) -> None:
+        from comms.pipes.collectives.triton import device_alltoallv_dynamic
+
+        msg_size = 1024
+        (
+            send_sizes,
+            send_offsets,
+            recv_sizes,
+            local_recv_slot_offsets,
+            remote_write_offsets,
+        ) = self._fill_uniform(msg_size)
+
+        # Run with blocks_per_peer=1 (iteration 0)
+        self._register_send_buf()
+        device_alltoallv_dynamic(
+            self.send_buf,
+            self.recv_buf,
+            send_sizes,
+            send_offsets,
+            recv_sizes,
+            local_recv_slot_offsets,
+            remote_write_offsets,
+            self.dev_win_ptr,
+            self.src_info,
+            self.my_rank,
+            self.world_size,
+            blocks_per_peer=1,
+        )
+        torch.cuda.synchronize()
+        # Deregister before clone() — GIN prevents regular CUDA allocations
+        self._deregister_send_buf()
+        result_single_block = self.recv_buf.clone()
+
+        # Re-fill and run with blocks_per_peer=4 (iteration 1)
+        (
+            send_sizes,
+            send_offsets,
+            recv_sizes,
+            local_recv_slot_offsets,
+            remote_write_offsets,
+        ) = self._fill_uniform(msg_size)
+        self._register_send_buf()
+        device_alltoallv_dynamic(
+            self.send_buf,
+            self.recv_buf,
+            send_sizes,
+            send_offsets,
+            recv_sizes,
+            local_recv_slot_offsets,
+            remote_write_offsets,
+            self.dev_win_ptr,
+            self.src_info,
+            self.my_rank,
+            self.world_size,
+            blocks_per_peer=4,
+        )
+        torch.cuda.synchronize()
+
+        torch.testing.assert_close(
+            result_single_block,
+            self.recv_buf,
+            msg=(
+                f"Rank {self.rank}: blocks_per_peer=1 and blocks_per_peer=4 "
+                f"results differ!"
+            ),
+        )
+
+
+class TestRepeatedCallsMultiBlock(_SingleTestBase):
+    """Test multiple iterations with blocks_per_peer > 1.
+
+    This test validates the monotonic signal counter fix for the race
+    condition identified in review comment #6 (line 257).  With the old
+    code, block scheduling non-determinism could cause:
+        block1(inc→1) → block0(reset→0) → signal(0) ← WRONG!
+
+    The fix uses monotonic signal values:
+        iteration 0 signals BLOCKS_PER_PEER * 1
+        iteration 1 signals BLOCKS_PER_PEER * 2
+        etc.
+
+    This test verifies that multiple iterations with blocks_per_peer > 1
+    complete successfully without races or deadlocks.
+    """
+
+    def test_repeated_calls_multi_block(self) -> None:
+        from comms.pipes.collectives.triton import device_alltoallv_dynamic
+
+        msg_size = 2048  # Larger message to exercise chunking
+        num_iterations = 5
+        blocks_per_peer = 4
+
+        for iteration in range(num_iterations):
+            self._deregister_send_buf()
+            (
+                send_sizes,
+                send_offsets,
+                recv_sizes,
+                local_recv_slot_offsets,
+                remote_write_offsets,
+            ) = self._fill_uniform(msg_size)
+            self._register_send_buf()
+            device_alltoallv_dynamic(
+                self.send_buf,
+                self.recv_buf,
+                send_sizes,
+                send_offsets,
+                recv_sizes,
+                local_recv_slot_offsets,
+                remote_write_offsets,
+                self.dev_win_ptr,
+                self.src_info,
+                self.my_rank,
+                self.world_size,
+                blocks_per_peer=blocks_per_peer,
+            )
+            # Must sync all ranks before next iteration's deregister +
+            # exchange_offsets (a collective requiring all ranks).
+            torch.cuda.synchronize()
+            self.torchcomm.barrier(False)
+            self._verify_received_data(
+                self.recv_buf,
+                send_offsets,
+                send_sizes,
+                f"repeated_calls_multi_block_iter_{iteration}",
+            )
+
+
+class TestRepeatedCallsVaryingBlocksPerPeer(_SingleTestBase):
+    """Test iterations with varying blocks_per_peer values.
+
+    This test validates that the monotonic signal counter works correctly
+    when blocks_per_peer changes between iterations.  The signal value
+    is BLOCKS_PER_PEER * (iteration + 1), which must be correctly
+    computed for each call regardless of previous calls' BLOCKS_PER_PEER.
+    """
+
+    def test_repeated_calls_varying_blocks_per_peer(self) -> None:
+        from comms.pipes.collectives.triton import device_alltoallv_dynamic
+
+        msg_size = 2048
+        # Test with varying blocks_per_peer across iterations
+        blocks_per_peer_sequence = [1, 2, 4, 2, 1, 8]
+
+        for iteration, bpp in enumerate(blocks_per_peer_sequence):
+            self._deregister_send_buf()
+            (
+                send_sizes,
+                send_offsets,
+                recv_sizes,
+                local_recv_slot_offsets,
+                remote_write_offsets,
+            ) = self._fill_uniform(msg_size)
+            self._register_send_buf()
+            device_alltoallv_dynamic(
+                self.send_buf,
+                self.recv_buf,
+                send_sizes,
+                send_offsets,
+                recv_sizes,
+                local_recv_slot_offsets,
+                remote_write_offsets,
+                self.dev_win_ptr,
+                self.src_info,
+                self.my_rank,
+                self.world_size,
+                blocks_per_peer=bpp,
+            )
+            torch.cuda.synchronize()
+            self.torchcomm.barrier(False)
+            self._verify_received_data(
+                self.recv_buf,
+                send_offsets,
+                send_sizes,
+                f"varying_bpp_iter_{iteration}_bpp_{bpp}",
+            )
+
+
+# =============================================================================
+# Sync Buffer Mode Tests
+# =============================================================================
+
+
+class TestSyncBufferBasic(_SingleTestBase):
+    """Test sync_buffer=True with basic uniform message sizes."""
+
+    def test_sync_buffer_uniform_single_iteration(self) -> None:
+        """Test sync_buffer=True works correctly with single iteration."""
+        from comms.pipes.collectives.triton import device_alltoallv_dynamic
+
+        (
+            send_sizes,
+            send_offsets,
+            recv_sizes,
+            local_recv_slot_offsets,
+            remote_write_offsets,
+        ) = self._fill_uniform(1024)
+        self._register_send_buf()
+        device_alltoallv_dynamic(
+            self.send_buf,
+            self.recv_buf,
+            send_sizes,
+            send_offsets,
+            recv_sizes,
+            local_recv_slot_offsets,
+            remote_write_offsets,
+            self.dev_win_ptr,
+            self.src_info,
+            self.my_rank,
+            self.world_size,
+            sync_buffer=True,  # Enable buffer-ready synchronization
+        )
+        torch.cuda.synchronize()
+        self._verify_received_data(
+            self.recv_buf, send_offsets, send_sizes, "sync_buffer_single_iter"
+        )
+
+
+class TestSyncBufferRepeatedCalls(_SingleTestBase):
+    """Test sync_buffer=True with repeated calls (critical for buffer-ready sync)."""
+
+    def test_sync_buffer_repeated_calls(self) -> None:
+        """Test sync_buffer=True works correctly with multiple iterations.
+
+        This is the key test for sync_buffer mode - it verifies that buffer-ready
+        synchronization correctly prevents sender from overwriting data that
+        receiver hasn't consumed yet.
+
+        IMPORTANT: This test does NOT refill buffers between iterations because:
+        1. get_device_window() enables GIN, which blocks regular CUDA ops like zero_()
+        2. Signal buffers must persist across iterations for sync_buffer mode to work
+
+        The test verifies correctness by running multiple iterations with the same
+        data and checking that no hangs or data corruption occur.
+        """
+        from comms.pipes.collectives.triton import device_alltoallv_dynamic
+
+        msg_size = 1024
+        num_iterations = 5
+
+        # Setup buffers ONCE before all iterations (before GIN is activated)
+        (
+            send_sizes,
+            send_offsets,
+            recv_sizes,
+            local_recv_slot_offsets,
+            remote_write_offsets,
+        ) = self._fill_uniform(msg_size)
+
+        # Register send buffer ONCE (this activates GIN)
+        self._register_send_buf()
+
+        for _iteration in range(num_iterations):
+            device_alltoallv_dynamic(
+                self.send_buf,
+                self.recv_buf,
+                send_sizes,
+                send_offsets,
+                recv_sizes,
+                local_recv_slot_offsets,
+                remote_write_offsets,
+                self.dev_win_ptr,
+                self.src_info,
+                self.my_rank,
+                self.world_size,
+                sync_buffer=True,  # Enable buffer-ready synchronization
+            )
+            torch.cuda.synchronize()
+            self.torchcomm.barrier(False)
+
+        # Verify final data after all iterations complete
+        self._verify_received_data(
+            self.recv_buf,
+            send_offsets,
+            send_sizes,
+            "sync_buffer_repeated_calls",
+        )
+
+
+class TestSyncBufferMultiBlock(_SingleTestBase):
+    """Test sync_buffer=True with multi-block per peer configuration."""
+
+    def test_sync_buffer_multi_block(self) -> None:
+        """Test sync_buffer=True with blocks_per_peer > 1."""
+        from comms.pipes.collectives.triton import device_alltoallv_dynamic
+
+        msg_size = 2048  # Larger message for multi-block
+        blocks_per_peer = 4
+
+        (
+            send_sizes,
+            send_offsets,
+            recv_sizes,
+            local_recv_slot_offsets,
+            remote_write_offsets,
+        ) = self._fill_uniform(msg_size)
+        self._register_send_buf()
+        device_alltoallv_dynamic(
+            self.send_buf,
+            self.recv_buf,
+            send_sizes,
+            send_offsets,
+            recv_sizes,
+            local_recv_slot_offsets,
+            remote_write_offsets,
+            self.dev_win_ptr,
+            self.src_info,
+            self.my_rank,
+            self.world_size,
+            blocks_per_peer=blocks_per_peer,
+            sync_buffer=True,
+        )
+        torch.cuda.synchronize()
+        self._verify_received_data(
+            self.recv_buf, send_offsets, send_sizes, "sync_buffer_multi_block"
+        )
+
+
+# =============================================================================
+# Test Registry
+# =============================================================================
+
+ALL_TEST_CLASSES = [
+    TestUniformSizesBasic,
+    TestLargeMessages,
+    TestMinimumMessageSize,
+    TestRepeatedCalls,
+    TestNumWarps4,
+    TestNumWarps32,
+    TestBlocksPerPeer2Uniform,
+    TestBlocksPerPeer4Uniform,
+    TestBlocksPerPeer4Large,
+    TestBlocksPerPeerConsistency,
+    TestRepeatedCallsMultiBlock,
+    TestRepeatedCallsVaryingBlocksPerPeer,
+    # Sync buffer mode tests
+    TestSyncBufferBasic,
+    TestSyncBufferRepeatedCalls,
+    TestSyncBufferMultiBlock,
+]
+
+
+def main() -> int:
+    import re
+
+    loader = unittest.TestLoader()
+    suite = unittest.TestSuite()
+    test_filter = os.environ.get("TEST_FILTER", "")
+
+    if test_filter:
+        # Compile regex pattern for matching
+        try:
+            pattern = re.compile(test_filter)
+        except re.error:
+            # If invalid regex, treat as literal substring
+            pattern = re.compile(re.escape(test_filter))
+
+        for cls in ALL_TEST_CLASSES:
+            class_name = cls.__name__
+            # Check if class name matches the pattern
+            if pattern.search(class_name):
+                suite.addTests(loader.loadTestsFromTestCase(cls))
+            else:
+                # Check individual test methods
+                for name in loader.getTestCaseNames(cls):
+                    full_name = f"{class_name}.{name}"
+                    if pattern.search(full_name) or pattern.search(name):
+                        suite.addTest(cls(name))
+
+        # If the filter matched nothing, fall back to running all tests.
+        # This handles the case where TEST_FILTER is set to the buck target
+        # name (e.g. "TestDeviceAlltoallvDynamicE2E") rather than a specific
+        # test class or method name.
+        if suite.countTestCases() == 0:
+            print(
+                f"WARNING: TEST_FILTER='{test_filter}' matched no tests. "
+                f"Running all {len(ALL_TEST_CLASSES)} test classes.",
+                file=sys.stderr,
+            )
+            for cls in ALL_TEST_CLASSES:
+                suite.addTests(loader.loadTestsFromTestCase(cls))
+    else:
+        for cls in ALL_TEST_CLASSES:
+            suite.addTests(loader.loadTestsFromTestCase(cls))
+
+    runner = unittest.TextTestRunner(verbosity=2)
+    result = runner.run(suite)
+    return 0 if result.wasSuccessful() else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/comms/pipes/collectives/triton/utils.py
+++ b/comms/pipes/collectives/triton/utils.py
@@ -1,0 +1,60 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# pyre-unsafe
+"""
+Utility helpers for the AlltoallvOp high-level wrapper.
+
+Provides convenience functions for transport-compatible buffer allocation,
+eliminating boilerplate that users would otherwise need to write manually.
+"""
+
+from typing import Sequence, Union
+
+import torch
+import torchcomms
+
+
+__all__ = [
+    "alloc_comms_buffer",
+]
+
+
+def alloc_comms_buffer(
+    shape: Union[int, Sequence[int]],
+    dtype: torch.dtype,
+    device: Union[str, torch.device],
+    backend: str = "ncclx",
+) -> tuple[torch.Tensor, "torch.cuda.MemPool"]:
+    """
+    Allocate a CUDA tensor using the TorchComms memory allocator,
+    sized exactly to the requested shape.
+
+    This allocator returns buffers that are compatible with one-sided put
+    operations over any transport (NVLink, RDMA, etc.).
+
+    Args:
+        shape: Tensor shape (int for 1-D, or a sequence of ints).
+        dtype: Tensor dtype (e.g., torch.float32).
+        device: CUDA device (e.g., "cuda:0" or torch.device("cuda", 0)).
+        backend: TorchComms backend name (default: "ncclx").  Must match
+                 the backend used by the TorchComm communicator.  Obtain
+                 via ``comm.get_backend()``.
+
+    Returns:
+        (tensor, pool) — the allocated tensor and its memory pool.
+        ``AlltoallvOp`` manages pools internally; this helper is primarily
+        used by ``AlltoallvOp.__init__`` and advanced callers who need
+        direct transport-compatible buffer allocation.
+
+    Note:
+        The returned ``pool`` object MUST remain alive for as long as the
+        tensor is registered for one-sided operations. If the pool is garbage
+        collected while the tensor is still registered, the underlying memory
+        deregistration will race with active DMA and cause GPU faults.
+    """
+    allocator = torchcomms.get_mem_allocator(backend)
+    pool = torch.cuda.MemPool(allocator)
+    # Normalize shape to a tuple for torch.zeros
+    size: Sequence[int] = (shape,) if isinstance(shape, int) else tuple(shape)
+    with torch.cuda.use_mem_pool(pool):
+        tensor = torch.zeros(size, dtype=dtype, device=device)
+    return tensor, pool

--- a/comms/torchcomms/ncclx/TorchCommNCCLXCCA.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXCCA.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include "comms/torchcomms/ncclx/TorchCommNCCLXCCA.hpp"
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAStream.h>
 #include <c10/cuda/driver_api.h>
 
 // Helper function to get allocation granularity for a device
@@ -85,6 +87,32 @@ void CachingAllocatorHookImpl::regDeregMem(
     // Register the memory through ncclCommRegister and add to commRegHandles_
     for (auto& comm : registeredComms_) {
       if (te.device_ == comm->getDevice().index()) {
+        // Check if we're inside CUDA graph capture. If so, skip registration.
+        // Memory allocated during graph capture is from a capture pool and will
+        // be freed after capture ends. We don't need to register it with NCCL.
+        // Use the current PyTorch CUDA stream to check capture status.
+        cudaStreamCaptureStatus captureStatus = cudaStreamCaptureStatusNone;
+        try {
+          cudaStream_t currentStream =
+              at::cuda::getCurrentCUDAStream(te.device_).stream();
+          cudaError_t err = cudaStreamGetCaptureInfo(
+              currentStream,
+              &captureStatus,
+              nullptr,
+              nullptr,
+              nullptr,
+              nullptr);
+
+          // Ignore errors - if we can't determine capture status, proceed
+          // with registration
+          if (err == cudaSuccess &&
+              captureStatus != cudaStreamCaptureStatusNone) {
+            continue;
+          }
+        } catch (const c10::Error&) {
+          // CUDA not available (e.g., unit tests), proceed with registration
+        }
+
         comm->register_address(TorchCommNCCLX::AddressWithLen(addr, len));
       }
     }
@@ -128,6 +156,29 @@ void CachingAllocatorHookImpl::regDeregMem(
       // Register the memory through ncclCommRegister
       for (auto& comm : registeredComms_) {
         if (te.device_ == comm->getDevice().index()) {
+          // Check if we're inside CUDA graph capture. If so, skip registration.
+          // Memory allocated during graph capture is from a capture pool and
+          // will be freed after capture ends. We don't need to register it with
+          // NCCL. Use the current PyTorch CUDA stream to check capture status.
+          cudaStreamCaptureStatus captureStatus = cudaStreamCaptureStatusNone;
+          try {
+            cudaStream_t currentStream =
+                at::cuda::getCurrentCUDAStream(te.device_).stream();
+            cudaError_t err = cudaStreamGetCaptureInfo(
+                currentStream,
+                &captureStatus,
+                nullptr,
+                nullptr,
+                nullptr,
+                nullptr);
+            if (err == cudaSuccess &&
+                captureStatus != cudaStreamCaptureStatusNone) {
+              continue;
+            }
+          } catch (const c10::Error&) {
+            // CUDA not available (e.g., unit tests), proceed with registration
+          }
+
           comm->register_address(
               TorchCommNCCLX::AddressWithLen(chunk_addr, chunk_size));
         }

--- a/comms/torchcomms/ncclx/TorchCommWindowNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommWindowNCCLX.cpp
@@ -364,6 +364,17 @@ void TorchCommWindowNCCLX<Backend>::deregister_local_buffer(
     TC_LOG(ERROR) << "Failed to deregister local buffer";
   }
 
+  // ncclCommWindowDeregister may leave a sticky CUDA error in the runtime
+  // error queue.  The internal path (ncclCommDeregister -> async IPC release
+  // -> cuMemUnmap on remote peers, plus GIN ibv_dereg_mr -> DMA-BUF cleanup)
+  // can set cudaErrorHostMemoryAlreadyRegistered (712) as a deferred error.
+  // This is NOT a kernel error, so cudaDeviceSynchronize alone would not
+  // clear it.  We must call cudaGetLastError() to consume the sticky error
+  // before the next CUDA runtime API call (e.g. cudaMemset via tensor.zero_()
+  // in the next iteration) encounters it and throws.
+  cudaDeviceSynchronize();
+  cudaGetLastError();
+
   // Remove from tracking vector
   auto it = std::find_if(
       registered_local_buffers_.begin(),

--- a/comms/torchcomms/triton/torchcomms_device.cu
+++ b/comms/torchcomms/triton/torchcomms_device.cu
@@ -57,6 +57,30 @@ extern "C" {
 // See the file-level design comment for details per function.
 // =============================================================================
 
+// torchcomms_self_copy_block: block-cooperative local memory copy for
+// self-send (peer == my_rank) in alltoallv.
+//
+// Performs a direct memory copy from send_buf to recv_buf using all threads
+// in the block.  This replaces the Triton tl.load/tl.store self-copy loop,
+// which generated 85+ comparison/mask SSA values in the LLVM IR and added
+// significant register pressure to the main alltoallv kernel.
+//
+// By moving self-copy to a CUDA extern, the Triton kernel's IR is smaller
+// and the register allocator has fewer live values to manage in the hot
+// memcpy path.
+__device__ int torchcomms_self_copy_block(
+    void* dst_ptr,
+    unsigned long long dst_offset,
+    void* src_ptr,
+    unsigned long long src_offset,
+    unsigned long long bytes) {
+  auto* dst = reinterpret_cast<char*>(dst_ptr) + dst_offset;
+  auto* src = reinterpret_cast<const char*>(src_ptr) + src_offset;
+  auto group = detail::make_thread_group(CoopScope::BLOCK);
+  comms::pipes::memcpy_vectorized(dst, src, static_cast<size_t>(bytes), group);
+  return 0;
+}
+
 // torchcomms_put_block: block-cooperative data transfer.
 //
 // win->put(CoopScope::BLOCK) handles LSA and GIN internally:
@@ -95,6 +119,248 @@ __device__ int torchcomms_put_block(
       signal_id,
       counter_id,
       CoopScope::BLOCK);
+}
+
+// =============================================================================
+// Inline PTX memcpy — zero allocas, zero register spills
+//
+// Replaces pipes::memcpy_vectorized which uses VecType v[kUnroll] arrays
+// that LLVM lowers to alloca [8 x uint4] (128 bytes = 32 registers).
+// When multiple memcpy_vectorized instantiations exist in the same
+// compilation unit (even in separate functions), Triton's LLVM→PTX
+// lowering inlines everything into a single kernel entry, causing
+// all allocas to coexist and generating 42+ register spills.
+//
+// This inline PTX approach uses only 4 registers per thread for the
+// copy (val.x, val.y, val.z, val.w) — no alloca, no spills.  The
+// PTX instructions are emitted directly by clang into the bitcode
+// and pass through to the final PTX unchanged.
+//
+// Two variants with different unroll factors:
+//   nvl_memcpy_ptx_u1: 1 uint4 per iteration (4 regs, zero spills)
+//   nvl_memcpy_ptx_u2: 2 uint4 per iteration (8 regs, zero spills,
+//                       better ILP from overlapping load/store)
+// =============================================================================
+
+// Single-uint4 loop: 4 registers, zero spills, max simplicity.
+__device__ __forceinline__ void nvl_memcpy_ptx(
+    char* __restrict__ dst,
+    const char* __restrict__ src,
+    size_t bytes,
+    int tid,
+    int nthreads) {
+  // Each thread copies 16 bytes (one uint4) per iteration, strided by nthreads.
+  // This gives perfect coalescing: 32 threads × 16 bytes = 512 bytes per warp.
+  size_t stride = static_cast<size_t>(nthreads) * 16;
+  size_t aligned_bytes = (bytes / stride) * stride;
+
+  // Main aligned loop: uint4 (128-bit) loads and stores
+  for (size_t off = static_cast<size_t>(tid) * 16; off < aligned_bytes;
+       off += stride) {
+    unsigned int v0, v1, v2, v3;
+    asm volatile("ld.global.v4.u32 {%0,%1,%2,%3}, [%4];"
+                 : "=r"(v0), "=r"(v1), "=r"(v2), "=r"(v3)
+                 : "l"(src + off));
+    asm volatile("st.global.v4.u32 [%4], {%0,%1,%2,%3};"
+                 :
+                 : "r"(v0), "r"(v1), "r"(v2), "r"(v3), "l"(dst + off));
+  }
+
+  // Remainder: handle tail bytes not aligned to stride.
+  // First handle full uint4 chunks, then byte-level for the final < 16 bytes.
+  size_t uint4_end = (bytes / 16) * 16;
+  for (size_t off = aligned_bytes + static_cast<size_t>(tid) * 16;
+       off < uint4_end;
+       off += stride) {
+    unsigned int v0, v1, v2, v3;
+    asm volatile("ld.global.v4.u32 {%0,%1,%2,%3}, [%4];"
+                 : "=r"(v0), "=r"(v1), "=r"(v2), "=r"(v3)
+                 : "l"(src + off));
+    asm volatile("st.global.v4.u32 [%4], {%0,%1,%2,%3};"
+                 :
+                 : "r"(v0), "r"(v1), "r"(v2), "r"(v3), "l"(dst + off));
+  }
+
+  // Byte-level tail: copy the final bytes that don't fill a uint4 (< 16 bytes).
+  // This handles minimum-size messages (e.g., 4 bytes = 1 float).
+  for (size_t off = uint4_end + static_cast<size_t>(tid); off < bytes;
+       off += static_cast<size_t>(nthreads)) {
+    dst[off] = src[off];
+  }
+}
+
+// =============================================================================
+// GIN (RDMA) fallback — __noinline__ to prevent its alloca from polluting
+// the NVLink hot path's register allocation.
+//
+// When Triton inlines all functions into one PTX kernel entry, any
+// memcpy_vectorized alloca [8 x uint4] from the GIN path would coexist
+// with the NVLink inline PTX path, causing register spills.  By marking
+// the GIN fallback __noinline__, its alloca stays in a separate function
+// and doesn't affect the NVLink path's register budget.
+// =============================================================================
+
+__device__ __noinline__ int gin_put_fallback(
+    DeviceWindow* win,
+    size_t dst_offset,
+    void* src_base_ptr,
+    size_t src_size,
+    void* src_nccl_win,
+    size_t src_offset,
+    int dst_rank,
+    size_t bytes) {
+  RegisteredBuffer src_buf;
+  src_buf.base_ptr = src_base_ptr;
+  src_buf.size = src_size;
+  src_buf.backend_window = src_nccl_win;
+  return win->put(
+      dst_offset,
+      src_buf,
+      src_offset,
+      dst_rank,
+      bytes,
+      -1,
+      -1,
+      CoopScope::BLOCK);
+}
+
+__device__ __noinline__ int gin_put_warp_fallback(
+    DeviceWindow* win,
+    size_t dst_offset,
+    void* src_base_ptr,
+    size_t src_size,
+    void* src_nccl_win,
+    size_t src_offset,
+    int dst_rank,
+    size_t bytes) {
+  RegisteredBuffer src_buf;
+  src_buf.base_ptr = src_base_ptr;
+  src_buf.size = src_size;
+  src_buf.backend_window = src_nccl_win;
+  return win->put(
+      dst_offset,
+      src_buf,
+      src_offset,
+      dst_rank,
+      bytes,
+      -1,
+      -1,
+      CoopScope::WARP);
+}
+
+// =============================================================================
+// NVLink-optimized put with GIN fallback
+//
+// These functions check if the peer is on the LSA (NVLink) team:
+//   - NVLink: uses inline PTX memcpy (zero allocas, zero spills)
+//   - GIN: falls back to win->put() via __noinline__ helper
+//
+// The two functions are intentionally SEPARATE to avoid having two
+// memcpy instantiations in the same function (see register pressure
+// analysis in the plan document).
+// =============================================================================
+
+__device__ int torchcomms_put_block_direct(
+    void* win_ptr,
+    unsigned long long dst_offset,
+    void* src_nccl_win,
+    unsigned long long src_offset,
+    int dst_rank,
+    unsigned long long bytes) {
+  auto* win = reinterpret_cast<DeviceWindow*>(win_ptr);
+  const ncclDevComm& dev_comm = win->comm();
+
+  if (ncclTeamRankIsMember(
+          ncclTeamLsa(dev_comm), ncclTeamWorld(dev_comm), dst_rank)) {
+    // NVLink path: inline PTX memcpy, zero allocas, zero spills.
+    ncclWindow_t dst_win = win->window();
+    ncclWindow_t src_win = static_cast<ncclWindow_t>(src_nccl_win);
+    char* dst_base =
+        static_cast<char*>(ncclGetPeerPointer(dst_win, 0, dst_rank));
+    char* src_base = static_cast<char*>(ncclGetLocalPointer(src_win, 0));
+
+    nvl_memcpy_ptx(
+        dst_base + static_cast<size_t>(dst_offset),
+        src_base + static_cast<size_t>(src_offset),
+        static_cast<size_t>(bytes),
+        threadIdx.x,
+        blockDim.x);
+  } else {
+    // GIN (RDMA) fallback: __noinline__ to isolate register pressure.
+    gin_put_fallback(
+        win,
+        static_cast<size_t>(dst_offset),
+        nullptr,
+        0,
+        src_nccl_win,
+        static_cast<size_t>(src_offset),
+        dst_rank,
+        static_cast<size_t>(bytes));
+  }
+
+  __syncthreads();
+  return 0;
+}
+
+__device__ int torchcomms_put_warp_chunked_direct(
+    void* win_ptr,
+    unsigned long long dst_offset,
+    void* src_nccl_win,
+    unsigned long long src_offset,
+    int dst_rank,
+    unsigned long long total_bytes,
+    unsigned long long chunk_size) {
+  auto* win = reinterpret_cast<DeviceWindow*>(win_ptr);
+  const ncclDevComm& dev_comm = win->comm();
+
+  auto total = static_cast<size_t>(total_bytes);
+  auto chunk = static_cast<size_t>(chunk_size);
+  auto num_chunks = (total + chunk - 1) / chunk;
+
+  if (ncclTeamRankIsMember(
+          ncclTeamLsa(dev_comm), ncclTeamWorld(dev_comm), dst_rank)) {
+    // NVLink path: inline PTX memcpy, zero allocas, zero spills.
+    ncclWindow_t dst_win = win->window();
+    ncclWindow_t src_win = static_cast<ncclWindow_t>(src_nccl_win);
+    char* dst_base =
+        static_cast<char*>(ncclGetPeerPointer(dst_win, 0, dst_rank));
+    char* src_base = static_cast<char*>(ncclGetLocalPointer(src_win, 0));
+
+    auto warp_id = threadIdx.x / 32;
+    auto num_warps = blockDim.x / 32;
+
+    for (size_t c = warp_id; c < num_chunks; c += num_warps) {
+      auto off = c * chunk;
+      auto len = (off + chunk <= total) ? chunk : (total - off);
+      nvl_memcpy_ptx(
+          dst_base + static_cast<size_t>(dst_offset) + off,
+          src_base + static_cast<size_t>(src_offset) + off,
+          len,
+          threadIdx.x % 32,
+          32);
+    }
+  } else {
+    // GIN (RDMA) fallback: __noinline__ to isolate register pressure.
+    auto warp_id = threadIdx.x / 32;
+    auto num_warps = blockDim.x / 32;
+
+    for (size_t c = warp_id; c < num_chunks; c += num_warps) {
+      auto off = c * chunk;
+      auto len = (off + chunk <= total) ? chunk : (total - off);
+      gin_put_warp_fallback(
+          win,
+          static_cast<size_t>(dst_offset) + off,
+          nullptr,
+          0,
+          src_nccl_win,
+          static_cast<size_t>(src_offset) + off,
+          dst_rank,
+          len);
+    }
+  }
+
+  __syncthreads();
+  return 0;
 }
 
 __device__ int torchcomms_signal_block(
@@ -161,6 +427,18 @@ __device__ int torchcomms_wait_signal(
     unsigned long long expected_value) {
   auto* win = reinterpret_cast<DeviceWindow*>(win_ptr);
   return win->wait_signal(signal_id, CmpOp::GE, expected_value);
+}
+
+// Wait for signal from a specific peer to reach expected value.
+// Used for per-peer synchronization in alltoallv and similar patterns.
+// Thread-scope (idempotent) — all 128 threads can call; same result.
+__device__ int torchcomms_wait_signal_from(
+    void* win_ptr,
+    int peer,
+    int signal_id,
+    unsigned long long expected_value) {
+  auto* win = reinterpret_cast<DeviceWindow*>(win_ptr);
+  return win->wait_signal_from(peer, signal_id, CmpOp::GE, expected_value);
 }
 
 __device__ unsigned long long torchcomms_read_signal(

--- a/comms/torchcomms/triton/torchcomms_device.h
+++ b/comms/torchcomms/triton/torchcomms_device.h
@@ -79,6 +79,52 @@ __device__ int torchcomms_put_block(
     int signal_id,
     int counter_id);
 
+// Block-scope self-copy: local memory copy using all block threads.
+// Used for self-send (peer == my_rank) in alltoallv.
+// Returns: 0 on success
+__device__ int torchcomms_self_copy_block(
+    void* dst_ptr,
+    unsigned long long dst_offset,
+    void* src_ptr,
+    unsigned long long src_offset,
+    unsigned long long bytes);
+
+// NVLink-optimized block-scope put with GIN fallback.
+//
+// Multi-transport put: automatically selects optimal path based on peer
+// topology.
+//   - NVLink peers (intra-node): Uses inline PTX memcpy (zero allocas, zero
+//     register spills) for maximum performance via direct GPU-to-GPU copy.
+//   - IB/GIN peers (inter-node): Falls back to RDMA put via __noinline__
+//   helper,
+//     using GPU-Initiated Networking through the TorchComms/NCCL
+//     infrastructure.
+//
+// The transport selection happens automatically based on
+// win->is_nvlink_peer(dst_rank).
+//
+// Returns: 0 on success, negative on error
+__device__ int torchcomms_put_block_direct(
+    TorchCommsWindowHandle win,
+    unsigned long long dst_offset,
+    void* src_nccl_win,
+    unsigned long long src_offset,
+    int dst_rank,
+    unsigned long long bytes);
+
+// NVLink-optimized warp-distributed chunked put with GIN fallback.
+// NVLink: distributes chunks across warps using inline PTX memcpy.
+// GIN: falls back to win->put() via __noinline__ helper.
+// Returns: 0 on success, negative on error
+__device__ int torchcomms_put_warp_chunked_direct(
+    TorchCommsWindowHandle win,
+    unsigned long long dst_offset,
+    void* src_nccl_win,
+    unsigned long long src_offset,
+    int dst_rank,
+    unsigned long long total_bytes,
+    unsigned long long chunk_size);
+
 // Block-scope signal: all block threads cooperate.
 // Returns: 0 on success, negative on error
 __device__ int torchcomms_signal_block(
@@ -109,6 +155,16 @@ __device__ int torchcomms_barrier_block(
 // Returns: 0 on success, negative on error
 __device__ int torchcomms_wait_signal(
     TorchCommsWindowHandle win,
+    int signal_id,
+    unsigned long long expected_value);
+
+// Wait for signal from a specific peer to reach expected value (>=)
+// Used for per-peer synchronization in alltoallv and similar patterns.
+// Thread-scope (idempotent) — all 128 threads can call; same result.
+// Returns: 0 on success, negative on error
+__device__ int torchcomms_wait_signal_from(
+    TorchCommsWindowHandle win,
+    int peer,
     int signal_id,
     unsigned long long expected_value);
 


### PR DESCRIPTION
Summary:
This diff implements alltoallv_dynamic, a Triton-based variable-length all-to-all collective that runs entirely on the GPU—reading per-peer send/receive counts directly from device memory and performing one-sided RDMA/NVLink transfers via TorchComms primitives (put_block, flush_block, wait_signal_from), eliminating CPU synchronization from the critical path. The implementation is pure Python/Triton and can be called directly from user code with standard PyTorch tensors.

Alltoallv benchmark results comparison
==============================
- NCCL alltoallv: CPU-initiated, counts in Python lists (host memory)
- Triton dynamic: GPU-initiated, counts in GPU tensors (device memory)
- Equal sizes per peer: msg_size bytes per peer

```
===========================================================
        Size |   NCCLgr(us) |    TRTgr(us) |   Best Speedup
-----------------------------------------------------------
       1.0KB |         7.21 |         6.58 |  TRTgr (1.09x)
       2.0KB |         7.64 |         6.69 |  TRTgr (1.14x)
       4.0KB |         7.51 |         6.77 |  TRTgr (1.11x)
       8.0KB |         8.63 |         6.81 |  TRTgr (1.27x)
      16.0KB |         8.52 |         7.18 |  TRTgr (1.19x)
      32.0KB |         8.75 |         7.71 |  TRTgr (1.13x)
      64.0KB |        10.67 |         8.31 |  TRTgr (1.28x)
     128.0KB |        15.18 |        10.16 |  TRTgr (1.49x)
     256.0KB |        22.16 |        12.39 |  TRTgr (1.79x)
     512.0KB |        37.79 |        17.88 |  TRTgr (2.11x)
       1.0MB |        37.21 |        29.01 |  TRTgr (1.28x)
       2.0MB |        58.35 |        55.87 |  TRTgr (1.04x)
       4.0MB |       110.84 |       105.19 |  TRTgr (1.05x)
       8.0MB |       202.68 |       192.58 |  TRTgr (1.05x)
      16.0MB |       377.58 |       363.46 |  TRTgr (1.04x)
      32.0MB |       738.15 |       725.70 |  TRTgr (1.02x)
      64.0MB |      1473.91 |      1438.68 |  TRTgr (1.02x)
     128.0MB |      2848.02 |      2800.20 |  TRTgr (1.02x)
     256.0MB |      5394.23 |      5642.64 |  TRTgr (0.96x)
     512.0MB |     10784.17 |     11332.71 |  TRTgr (0.95x)
       1.0GB |     21486.78 |     22692.38 |  TRTgr (0.95x)
===========================================================
```

User API 
=======
Two usage patterns are supported:

Copy-in mode (simple)
-----------------------
```
    op = AlltoallvOp(comm, max_input_tokens=1024, D=4096,
                     dtype=torch.bfloat16, device="cuda:0")
    with op:
        output = op.alltoallv(input_tensor, output_split_sizes,
                              input_split_sizes)
```

Zero-copy mode (maximum performance)
-------------------------------------------
```
    op = AlltoallvOp(comm, max_input_tokens=1024, D=4096,
                     dtype=torch.bfloat16, device="cuda:0")
    with op:
        send_buf = op.get_send_buffer(num_tokens=512)
        # Fill send_buf directly (e.g. from a gather / routing kernel)
        send_buf[:] = my_data
        output = op.alltoallv_from_buffer(output_split_sizes,
                                          input_split_sizes,
                                          num_input_tokens=512)
```

Reviewed By: cenzhaometa

Differential Revision: D95322815


