### PR TITLE
Fix MI300X conveyor build failure

### DIFF
--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -154,8 +154,9 @@ commResult_t OrderedWorkStreamGuard::doAcquire(
 
   auto doWait = [&]() -> commResult_t {
 #if defined(__HIP_PLATFORM_AMD__)
-    unsigned int flags =
-        isCapturing ? hipEventWaitExternal : hipEventWaitDefault;
+    // hipify doesn't map cudaEventWaitExternal/cudaEventWaitDefault;
+    // use raw values: 0x01 = cudaEventWaitExternal, 0x00 = cudaEventWaitDefault
+    unsigned int flags = isCapturing ? 0x01 : 0x00;
 #else
     unsigned int flags =
         isCapturing ? cudaEventWaitExternal : cudaEventWaitDefault;


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/pytorch/pull/177503

Two HIP/ROCm 6.2.1 build fixes for the MI300X conveyor: https://www.internalfb.com/conveyor/admarket/sigrid_predictor_hip/releases

**1. `CUDACachingAllocator.cpp`**

D96556656 ("[ROCm] Enable expandable segments") introduced `prop.requestedHandleTypes` (plural) in `CUDACachingAllocator.cpp`, which is the correct CUDA API field name. However, the HIP/ROCm 6.2.1 equivalent is `requestedHandleType` (singular), causing a compilation failure when the file is hipified.

This fix adds `#ifdef USE_ROCM` guards to:
1. Use `prop.requestedHandleType = hipMemHandleTypePosixFileDescriptor` for ROCm (singular field, HIP constant)
2. Use `prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR` for CUDA (plural field, CUDA constant)
3. Skip the `CU_MEM_HANDLE_TYPE_FABRIC` assignment entirely on ROCm, as `hipMemHandleTypeFabric` does not exist in HIP

**2. `CtranGpeImpl.cc`**

D95253327 ("[ctran] GPE cudagraph support") added `hipEventWaitExternal` and `hipEventWaitDefault` under a `__HIP_PLATFORM_AMD__` guard, but these symbols are not available across all ROCm versions. The fix replaces them with raw flag values (`0x01` for wait-external, `0x00` for wait-default) for all HIP builds.

Reviewed By: dolpm

Differential Revision: D96652342


