### PR TITLE
Suppress unused return value warnings in CUDA calls (#1106)

### DIFF
--- a/comms/ctran/algos/AllReduce/AllReduceRing.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceRing.cc
@@ -110,9 +110,9 @@ inline bool shouldEnableBidirAg(size_t messageBytes) {
   if (maxSize == -2) {
     // Auto-tune: select threshold based on GPU architecture
     int cudaDev = 0;
-    cudaGetDevice(&cudaDev);
+    (void)cudaGetDevice(&cudaDev);
     int smMajor = 0;
-    cudaDeviceGetAttribute(
+    (void)cudaDeviceGetAttribute(
         &smMajor, cudaDevAttrComputeCapabilityMajor, cudaDev);
     maxSize = (smMajor < 10) ? static_cast<int64_t>(kHopperBidirAgMaxSize)
                              : static_cast<int64_t>(kDefaultBidirAgMaxSize);

--- a/comms/utils/CudaRAII.h
+++ b/comms/utils/CudaRAII.h
@@ -95,7 +95,7 @@ class StreamCaptureModeGuard {
           return static_cast<Api*>(ctx)->threadExchangeStreamCaptureMode(mode);
         }),
         prevMode_(desiredMode) {
-    exchangeFn_(ctx_, &prevMode_);
+    (void)exchangeFn_(ctx_, &prevMode_);
   }
 
   ~StreamCaptureModeGuard();


### PR DESCRIPTION
Summary:

Cast CUDA API return values to `(void)` to suppress unused return value compiler warnings which are hard errors on AMD. This affects `cudaGetDevice` and `cudaDeviceGetAttribute` in AllReduceRing.cc, and `exchangeFn_` in CudaRAII.h. The return values are intentionally discarded as these calls are used for their side effects.

Differential Revision: D96736215
