### PR TITLE
Fix source files that did not follow [[nodiscard]] for AMD MI350 ROCm 7.0 (#1109)

### DIFF
--- a/comms/ctran/algos/AllReduce/AllReduceRing.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceRing.cc
@@ -110,10 +110,10 @@ inline bool shouldEnableBidirAg(size_t messageBytes) {
   if (maxSize == -2) {
     // Auto-tune: select threshold based on GPU architecture
     int cudaDev = 0;
-    (void)cudaGetDevice(&cudaDev);
+    FB_CUDACHECK(cudaGetDevice(&cudaDev));
     int smMajor = 0;
-    (void)cudaDeviceGetAttribute(
-        &smMajor, cudaDevAttrComputeCapabilityMajor, cudaDev);
+    FB_CUDACHECK(cudaDeviceGetAttribute(
+        &smMajor, cudaDevAttrComputeCapabilityMajor, cudaDev));
     maxSize = (smMajor < 10) ? static_cast<int64_t>(kHopperBidirAgMaxSize)
                              : static_cast<int64_t>(kDefaultBidirAgMaxSize);
   }


### PR DESCRIPTION
Summary:

[[nodiscard]] was upgrading to error in ROCm 7.0 in late Feb/early March but a few source code was not updated to be compatible with this.

Basically, adding [[nodiscard]] would require the return value not being discarded. the code I had issue with are the code with return type void, and the callsite was not explicitly "using" the void return value... This is not actually a functional bug IMO.

I tried to downgrade the error to warning with the following flags in BUCK command but no luck. 
```
 -c fbcode.extra_cflags=-Wno-error=unused-value -c fbcode.extra_cxxflags=-Wno-error=unused-value -c fbcode.global_compiler_flags=-Wno-error
```

Reviewed By: arttianezhu, optimisea

Differential Revision: D96413293


