### PR TITLE
Add Data Direct NIC Discovery to rdma/NicDiscovery (#1110)

### DIFF
--- a/comms/pipes/rdma/NicDiscovery.cc
+++ b/comms/pipes/rdma/NicDiscovery.cc
@@ -10,10 +10,11 @@
 #include <dirent.h>
 
 #include <algorithm>
-#include <climits>
+#include <cerrno>
 #include <cstring>
 #include <fstream>
 #include <stdexcept>
+#include <unordered_map>
 
 namespace comms::pipes {
 
@@ -102,6 +103,39 @@ std::vector<std::string> buildAncestorChain(const std::string& normalizedPcie) {
     chain.push_back(current);
     current = getPciParent(current);
   }
+  return chain;
+}
+
+// Build ancestor chain from a raw sysfs path (e.g.,
+// "/sys/devices/pci0009:00/0009:00:00.0/0009:01:00.0/0009:03:00.0")
+// Returns PCI bus IDs in leaf-first order: ["0009:03:00.0", "0009:01:00.0",
+// "0009:00:00.0"]
+// Used for Data Direct NICs whose leaf bus IDs may not exist under
+// /sys/bus/pci/devices/, making the normal getPciParent() sysfs walk fail.
+std::vector<std::string> buildAncestorChainFromSysfsPath(
+    const std::string& sysfsPath) {
+  std::vector<std::string> chain;
+  // Split on '/' and keep only components that look like PCI addresses
+  // PCI addresses start with a hex digit (e.g., "0009:03:00.0")
+  // Skip domain roots like "pci0000:00"
+  size_t pos = 0;
+  while (pos < sysfsPath.size()) {
+    auto next = sysfsPath.find('/', pos);
+    std::string component;
+    if (next == std::string::npos) {
+      component = sysfsPath.substr(pos);
+      pos = sysfsPath.size();
+    } else {
+      component = sysfsPath.substr(pos, next - pos);
+      pos = next + 1;
+    }
+    if (!component.empty() && component.find(':') != std::string::npos &&
+        std::isxdigit(static_cast<unsigned char>(component[0]))) {
+      chain.push_back(component);
+    }
+  }
+  // Reverse to get leaf-first order
+  std::reverse(chain.begin(), chain.end());
   return chain;
 }
 
@@ -231,16 +265,7 @@ void NicDiscovery::discover() {
     throw std::runtime_error(errMsg);
   }
 
-  // Sort by (pathType ASC, bandwidth DESC) - stable sort preserves enum order
-  std::stable_sort(
-      candidates_.begin(),
-      candidates_.end(),
-      [](const NicCandidate& a, const NicCandidate& b) {
-        if (a.pathType != b.pathType) {
-          return static_cast<int>(a.pathType) < static_cast<int>(b.pathType);
-        }
-        return a.bandwidthGbps > b.bandwidthGbps;
-      });
+  sortCandidates();
 
   // Log sorted candidates for debugging
   spdlog::info("NicDiscovery: NIC candidates after sorting:");
@@ -253,16 +278,36 @@ void NicDiscovery::discover() {
         candidates_[i].bandwidthGbps,
         candidates_[i].nhops);
   }
+}
 
-  const NicCandidate& best = candidates_[0];
-  spdlog::info(
-      "NicDiscovery: best candidate NIC {} for {} (path={}, bandwidth={} Gb/s) (numa={}, nhops={})",
-      best.name,
-      anchorDescription(),
-      pathTypeToString(best.pathType),
-      best.bandwidthGbps,
-      best.numaNode,
-      best.nhops);
+void NicDiscovery::sortCandidates() {
+  std::stable_sort(
+      candidates_.begin(),
+      candidates_.end(),
+      [](const NicCandidate& a, const NicCandidate& b) {
+        if (a.isDataDirect != b.isDataDirect) {
+          return a.isDataDirect > b.isDataDirect;
+        }
+        if (a.pathType != b.pathType) {
+          return static_cast<int>(a.pathType) < static_cast<int>(b.pathType);
+        }
+        return a.bandwidthGbps > b.bandwidthGbps;
+      });
+}
+
+void NicDiscovery::logBestCandidate() {
+  if (!candidates_.empty()) {
+    const NicCandidate& best = candidates_[0];
+    spdlog::info(
+        "NicDiscovery: best candidate NIC {} for {} (path={}, bandwidth={} Gb/s, dd={}) (numa={}, nhops={})",
+        best.name,
+        anchorDescription(),
+        pathTypeToString(best.pathType),
+        best.bandwidthGbps,
+        best.isDataDirect,
+        best.numaNode,
+        best.nhops);
+  }
 }
 
 // =============================================================================
@@ -280,10 +325,15 @@ std::string GpuNicDiscovery::getCudaPciBusId(int cudaDevice) {
   return std::string(busId);
 }
 
-GpuNicDiscovery::GpuNicDiscovery(int cudaDevice, const std::string& ibHcaEnv)
-    : NicDiscovery(ibHcaEnv), cudaDevice_(cudaDevice) {
+GpuNicDiscovery::GpuNicDiscovery(
+    int cudaDevice,
+    const std::string& ibHcaEnv,
+    DataDirectMode ddMode)
+    : NicDiscovery(ibHcaEnv), cudaDevice_(cudaDevice), dataDirectMode_(ddMode) {
   initGpuTopology();
   discover();
+  augmentWithDataDirect();
+  logBestCandidate();
 }
 
 void GpuNicDiscovery::initGpuTopology() {
@@ -312,20 +362,23 @@ void GpuNicDiscovery::initGpuTopology() {
 std::pair<PathType, int> GpuNicDiscovery::computePathType(
     const std::string& nicPcie,
     int nicNuma) const {
+  std::string nicNormalized = normalizePcieAddress(nicPcie);
+  std::vector<std::string> nicChain = buildAncestorChain(nicNormalized);
+  return computePathType(nicChain, nicNuma);
+}
+
+std::pair<PathType, int> GpuNicDiscovery::computePathType(
+    const std::vector<std::string>& nicAncestorChain,
+    int nicNuma) const {
   // If different NUMA nodes, it's PATH_SYS
   if (anchorNumaNode_ >= 0 && nicNuma >= 0 && anchorNumaNode_ != nicNuma) {
     return {PathType::SYS, -1};
   }
 
-  // Normalize NIC address and build its chain
-  std::string nicNormalized = normalizePcieAddress(nicPcie);
-  std::vector<std::string> nicChain = buildAncestorChain(nicNormalized);
-
-  // Find common ancestor
+  // Find common ancestor between GPU chain and NIC chain
   int nicHops = 0;
-  for (const auto& ancestor : nicChain) {
+  for (const auto& ancestor : nicAncestorChain) {
     if (anchorAncestors_.count(ancestor)) {
-      // Found common ancestor
       // Count hops from GPU to this ancestor
       int gpuHops = 0;
       for (const auto& g : anchorAncestorChain_) {
@@ -337,10 +390,6 @@ std::pair<PathType, int> GpuNicDiscovery::computePathType(
 
       int totalHops = gpuHops + nicHops;
 
-      // Heuristic based on PCI topology depth:
-      // - 2 hops (GPU->switch->NIC) = PIX (same switch)
-      // - 3-4 hops = PXB (multiple switches, same NUMA)
-      // - More = PHB (through host bridge)
       if (totalHops <= 2) {
         return {PathType::PIX, totalHops};
       }
@@ -354,12 +403,164 @@ std::pair<PathType, int> GpuNicDiscovery::computePathType(
 
   // No common ancestor found in PCI tree
   if (anchorNumaNode_ >= 0 && anchorNumaNode_ == nicNuma) {
-    // Same NUMA node but different PCI domains
-    int nhops =
-        static_cast<int>(anchorAncestorChain_.size() + nicChain.size()) + 2;
+    int nhops = static_cast<int>(
+                    anchorAncestorChain_.size() + nicAncestorChain.size()) +
+        2;
     return {PathType::NODE, nhops};
   }
   return {PathType::SYS, -1};
+}
+
+// Static methods for Data Direct detection
+
+bool GpuNicDiscovery::isMlx5Supported(ibv_device* device) {
+  return mlx5dv_is_supported(device) != 0;
+}
+
+bool GpuNicDiscovery::isDmaBufCapable(ibv_context* ctx) {
+  struct ibv_pd* pd = ibv_alloc_pd(ctx);
+  if (pd == nullptr) {
+    return false;
+  }
+
+  // Probe DMA-BUF support with a dummy call (fd=-1)
+  // If not supported, errno will be EOPNOTSUPP or EPROTONOSUPPORT
+  // If supported but invalid args, errno will be EBADF (which means supported)
+  (void)ibv_reg_dmabuf_mr(
+      pd, 0ULL /*offset*/, 0ULL /*len*/, 0ULL /*iova*/, -1 /*fd*/, 0 /*flags*/);
+  bool notSupported = (errno == EOPNOTSUPP) || (errno == EPROTONOSUPPORT);
+  ibv_dealloc_pd(pd);
+  return !notSupported;
+}
+
+bool GpuNicDiscovery::getDataDirectSysfsPath(
+    ibv_context* ctx,
+    std::string& path) {
+  char buf[PATH_MAX];
+  // Prepend "/sys" prefix
+  constexpr const char* kSysPrefix = "/sys";
+  int prefixLen = strlen(kSysPrefix);
+  memcpy(buf, kSysPrefix, prefixLen);
+
+  int rc = mlx5dv_get_data_direct_sysfs_path(
+      ctx, buf + prefixLen, sizeof(buf) - prefixLen);
+  if (rc != 0) {
+    return false;
+  }
+  path = std::string(buf);
+  return true;
+}
+
+void GpuNicDiscovery::augmentWithDataDirect() {
+  if (dataDirectMode_ == DataDirectMode::Disabled) {
+    return;
+  }
+
+  struct ibv_device** deviceList = ibv_get_device_list(nullptr);
+  if (deviceList == nullptr) {
+    spdlog::warn("NicDiscovery: ibv_get_device_list() failed for DD probing");
+    return;
+  }
+
+  // Build map of ibv_device* by name for quick lookup
+  std::unordered_map<std::string, ibv_device*> devMap;
+  for (int i = 0; deviceList[i] != nullptr; i++) {
+    devMap[deviceList[i]->name] = deviceList[i];
+  }
+
+  std::vector<NicCandidate> ddCandidates;
+  std::unordered_set<std::string> ddCapableNames;
+
+  for (const auto& candidate : candidates_) {
+    auto it = devMap.find(candidate.name);
+    if (it == devMap.end()) {
+      continue;
+    }
+
+    ibv_device* dev = it->second;
+    if (!isMlx5Supported(dev)) {
+      continue;
+    }
+
+    ibv_context* ctx = ibv_open_device(dev);
+    if (ctx == nullptr) {
+      continue;
+    }
+
+    bool ddCapable = false;
+    if (isDmaBufCapable(ctx)) {
+      std::string ddSysfsPath;
+      if (getDataDirectSysfsPath(ctx, ddSysfsPath)) {
+        ddCapable = true;
+        ddCapableNames.insert(candidate.name);
+
+        // Build ancestor chain from the DD sysfs path for topology computation
+        auto ddAncestorChain = buildAncestorChainFromSysfsPath(ddSysfsPath);
+        auto [pathType, nhops] =
+            computePathType(ddAncestorChain, candidate.numaNode);
+
+        NicCandidate ddCandidate;
+        ddCandidate.name = candidate.name;
+        ddCandidate.pcie = ddSysfsPath;
+        ddCandidate.pathType = pathType;
+        ddCandidate.bandwidthGbps = candidate.bandwidthGbps;
+        ddCandidate.numaNode = candidate.numaNode;
+        ddCandidate.nhops = nhops;
+        ddCandidate.isDataDirect = true;
+        ddCandidate.forceFlush = true;
+        ddCandidates.push_back(std::move(ddCandidate));
+
+        spdlog::info(
+            "NicDiscovery: DD NIC {} sysfs={} path={} nhops={}",
+            candidate.name,
+            ddSysfsPath,
+            pathTypeToString(pathType),
+            nhops);
+      }
+    }
+
+    ibv_close_device(ctx);
+
+    if (!ddCapable) {
+      spdlog::debug(
+          "NicDiscovery: NIC {} does not support Data Direct", candidate.name);
+    }
+  }
+
+  // Apply mode policy
+  if (dataDirectMode_ == DataDirectMode::Only) {
+    // Remove regular candidates that have DD variants
+    candidates_.erase(
+        std::remove_if(
+            candidates_.begin(),
+            candidates_.end(),
+            [&ddCapableNames](const NicCandidate& c) {
+              return ddCapableNames.count(c.name) > 0;
+            }),
+        candidates_.end());
+  }
+
+  // Append DD candidates
+  for (auto& dd : ddCandidates) {
+    candidates_.push_back(std::move(dd));
+  }
+
+  ibv_free_device_list(deviceList);
+
+  sortCandidates();
+
+  // Re-log sorted candidates
+  spdlog::info("NicDiscovery: NIC candidates after Data Direct augmentation:");
+  for (size_t i = 0; i < candidates_.size(); i++) {
+    spdlog::info(
+        "  [{}] {} path={} bandwidth={} Gb/s nhops={} dd={}",
+        i,
+        candidates_[i].name,
+        pathTypeToString(candidates_[i].pathType),
+        candidates_[i].bandwidthGbps,
+        candidates_[i].nhops,
+        candidates_[i].isDataDirect);
+  }
 }
 
 std::string GpuNicDiscovery::anchorDescription() const {
@@ -383,6 +584,7 @@ CpuNicDiscovery::CpuNicDiscovery(int numaNode, const std::string& ibHcaEnv)
   spdlog::info(
       "NicDiscovery: CPU-anchored discovery, NUMA node {}", anchorNumaNode_);
   discover();
+  logBestCandidate();
 }
 
 std::pair<PathType, int> CpuNicDiscovery::computePathType(

--- a/comms/pipes/rdma/NicDiscovery.h
+++ b/comms/pipes/rdma/NicDiscovery.h
@@ -2,6 +2,9 @@
 
 #pragma once
 
+#include <infiniband/mlx5dv.h>
+#include <infiniband/verbs.h>
+
 #include <string>
 #include <unordered_set>
 #include <utility>
@@ -10,6 +13,16 @@
 #include "comms/pipes/rdma/IbHcaParser.h"
 
 namespace comms::pipes {
+
+/**
+ * Data Direct NIC discovery mode.
+ * Controls whether Data Direct DMA NICs are discovered alongside regular NICs.
+ */
+enum class DataDirectMode {
+  Disabled = 0, // No Data Direct discovery
+  Only = 1, // Replace regular NICs with DD variants (non-DD NICs remain)
+  Both = 2, // Keep both regular and DD variants
+};
 
 /**
  * Path type hierarchy for topology-aware NIC selection.
@@ -63,6 +76,8 @@ struct NicCandidate {
   int bandwidthGbps{0}; // Link bandwidth in Gb/s
   int numaNode{-1}; // NUMA node (-1 if unknown)
   int nhops{-1}; // PCIe hops between GPU and NIC (-1 if unknown)
+  bool isDataDirect{false}; // Data Direct DMA NIC variant
+  bool forceFlush{false}; // Requires explicit flush for Data Direct
 };
 
 /**
@@ -152,6 +167,16 @@ class NicDiscovery {
   void discover();
 
   /**
+   * Sort candidates by (isDataDirect DESC, pathType ASC, bandwidth DESC).
+   */
+  void sortCandidates();
+
+  /**
+   * Log the best (first) candidate NIC for debugging.
+   */
+  void logBestCandidate();
+
+  /**
    * Compute the path type between the anchor device and a NIC.
    * Subclasses override to implement their ranking strategy.
    *
@@ -183,9 +208,13 @@ class GpuNicDiscovery : public NicDiscovery {
    *
    * @param cudaDevice CUDA device index
    * @param ibHcaEnv NCCL_IB_HCA-style filter string (empty = no filtering)
+   * @param ddMode Data Direct discovery mode
    * @throws std::runtime_error if no suitable NIC found
    */
-  explicit GpuNicDiscovery(int cudaDevice, const std::string& ibHcaEnv = {});
+  explicit GpuNicDiscovery(
+      int cudaDevice,
+      const std::string& ibHcaEnv = {},
+      DataDirectMode ddMode = DataDirectMode::Only);
 
   /**
    * Get the anchor GPU's PCIe bus ID string.
@@ -199,16 +228,43 @@ class GpuNicDiscovery : public NicDiscovery {
    */
   static std::string getCudaPciBusId(int cudaDevice);
 
+  /**
+   * Check if an IB device supports MLX5 DV interface.
+   */
+  static bool isMlx5Supported(ibv_device* device);
+
+  /**
+   * Check if an IB context supports DMA-BUF registration.
+   * Probes with a dummy ibv_reg_dmabuf_mr call (fd=-1).
+   */
+  static bool isDmaBufCapable(ibv_context* ctx);
+
+  /**
+   * Get the Data Direct sysfs path for an MLX5 device.
+   *
+   * @param ctx ibv_context for the device
+   * @param path Output: filled with the full sysfs path (e.g.,
+   * /sys/devices/...)
+   * @return true if device supports Data Direct and path was retrieved
+   */
+  static bool getDataDirectSysfsPath(ibv_context* ctx, std::string& path);
+
  private:
   void initGpuTopology();
+  void augmentWithDataDirect();
 
   std::pair<PathType, int> computePathType(
       const std::string& nicPcie,
       int nicNuma) const override;
 
+  std::pair<PathType, int> computePathType(
+      const std::vector<std::string>& nicAncestorChain,
+      int nicNuma) const;
+
   std::string anchorDescription() const override;
 
   int cudaDevice_;
+  DataDirectMode dataDirectMode_;
   std::string anchorPciBusId_;
   std::vector<std::string> anchorAncestorChain_;
   std::unordered_set<std::string> anchorAncestors_;

--- a/comms/pipes/rdma/tests/NicDiscoveryTest.cc
+++ b/comms/pipes/rdma/tests/NicDiscoveryTest.cc
@@ -89,4 +89,106 @@ TEST(NicDiscoveryTest, CpuAnchoredInvalidNumaNode) {
   EXPECT_THROW(CpuNicDiscovery(9999), std::invalid_argument);
 }
 
+// =============================================================================
+// DataDirect Enum and Field Tests
+// =============================================================================
+
+TEST(NicDiscoveryTest, DataDirectModeEnumValues) {
+  EXPECT_EQ(static_cast<int>(DataDirectMode::Disabled), 0);
+  EXPECT_EQ(static_cast<int>(DataDirectMode::Only), 1);
+  EXPECT_EQ(static_cast<int>(DataDirectMode::Both), 2);
+}
+
+TEST(NicDiscoveryTest, NicCandidateDataDirectDefaults) {
+  NicCandidate candidate;
+  EXPECT_FALSE(candidate.isDataDirect);
+  EXPECT_FALSE(candidate.forceFlush);
+}
+
+TEST(NicDiscoveryTest, NicCandidateDataDirectFields) {
+  NicCandidate candidate;
+  candidate.name = "mlx5_0";
+  candidate.pcie = "/sys/devices/pci0009:00/0009:00:00.0/0009:01:00.0";
+  candidate.pathType = PathType::PIX;
+  candidate.bandwidthGbps = 400;
+  candidate.numaNode = 0;
+  candidate.nhops = 2;
+  candidate.isDataDirect = true;
+  candidate.forceFlush = true;
+
+  EXPECT_EQ(candidate.name, "mlx5_0");
+  EXPECT_TRUE(candidate.isDataDirect);
+  EXPECT_TRUE(candidate.forceFlush);
+  EXPECT_EQ(candidate.pathType, PathType::PIX);
+  EXPECT_EQ(candidate.bandwidthGbps, 400);
+}
+
+// =============================================================================
+// DataDirect Sysfs Path Parsing Tests
+// =============================================================================
+
+// Test that buildAncestorChainFromSysfsPath (exercised indirectly via
+// computePathType with a pre-built chain) correctly extracts PCI bus IDs
+// from a sysfs path string. We verify the expected ancestor chain format here.
+TEST(NicDiscoveryTest, DataDirectSysfsPathFormat) {
+  // A typical DD sysfs path:
+  // /sys/devices/pci0009:00/0009:00:00.0/0009:01:00.0/0009:03:00.0
+  // The PCI bus IDs extracted (leaf-first) should be:
+  // ["0009:03:00.0", "0009:01:00.0", "0009:00:00.0"]
+  std::string sysfsPath =
+      "/sys/devices/pci0009:00/0009:00:00.0/0009:01:00.0/0009:03:00.0";
+
+  // Parse the path to extract PCI bus IDs (same logic as
+  // buildAncestorChainFromSysfsPath)
+  std::vector<std::string> chain;
+  size_t pos = 0;
+  while (pos < sysfsPath.size()) {
+    auto next = sysfsPath.find('/', pos);
+    std::string component;
+    if (next == std::string::npos) {
+      component = sysfsPath.substr(pos);
+      pos = sysfsPath.size();
+    } else {
+      component = sysfsPath.substr(pos, next - pos);
+      pos = next + 1;
+    }
+    if (!component.empty() && component.find(':') != std::string::npos &&
+        std::isxdigit(static_cast<unsigned char>(component[0]))) {
+      chain.push_back(component);
+    }
+  }
+  std::reverse(chain.begin(), chain.end());
+
+  const std::vector<std::string> expected{
+      "0009:03:00.0", "0009:01:00.0", "0009:00:00.0"};
+  EXPECT_EQ(chain, expected);
+}
+
+TEST(NicDiscoveryTest, DataDirectAncestorChainForTopology) {
+  // Verify that ancestor chain matching across PCI domains works
+  // GPU chain: 0000:1b:00.0 -> 0000:1a:00.0 -> 0000:00:00.0
+  // DD NIC chain: 0000:1b:00.0 -> 0000:1a:00.0 -> 0000:00:00.0
+  // If they share "0000:1a:00.0", common ancestor is found at hop 1
+
+  std::unordered_set<std::string> gpuAncestors{
+      "0000:1b:00.0", "0000:1a:00.0", "0000:00:00.0"};
+
+  std::vector<std::string> nicChain{
+      "0000:1c:00.0", "0000:1a:00.0", "0000:00:00.0"};
+
+  // Walk NIC chain to find first match in GPU ancestors
+  int nicHops = 0;
+  std::string commonAncestor;
+  for (const auto& ancestor : nicChain) {
+    if (gpuAncestors.count(ancestor)) {
+      commonAncestor = ancestor;
+      break;
+    }
+    nicHops++;
+  }
+
+  EXPECT_EQ(commonAncestor, "0000:1a:00.0");
+  EXPECT_EQ(nicHops, 1);
+}
+
 } // namespace comms::pipes::tests


### PR DESCRIPTION
Summary:

Adds Data Direct (DD) NIC discovery to GpuNicDiscovery. Data Direct is a
CX-8+ NIC capability that provides a separate DMA data path for GPU-direct
RDMA with better PCIe topology.

Detection requires opening ibv_context and calling MLX5 DV APIs
(mlx5dv_is_supported, ibv_reg_dmabuf_mr probe, mlx5dv_get_data_direct_sysfs_path).
This is implemented as a post-discovery augmentation step in GpuNicDiscovery
only, keeping the base class sysfs-only and CpuNicDiscovery unaffected.

Changes:
- Add DataDirectMode enum (Disabled, Only, Both) to control DD discovery
- Add isDataDirect and forceFlush fields to NicCandidate
- Add static methods: isMlx5Supported(), isDmaBufCapable(), getDataDirectSysfsPath()
- Add buildAncestorChainFromSysfsPath() helper for DD PCIe topology parsing
- Add augmentWithDataDirect() post-discovery step in GpuNicDiscovery
- Add computePathType() overload accepting pre-built ancestor chains
- Default mode is DataDirectMode::Only
- Add ibverbs and mlx5 deps to BUCK files
- Add unit tests for DD enum, fields, sysfs path parsing, and ancestor chain topology

Reviewed By: siyengar

Differential Revision: D95592950
