### PR TITLE
Add offset-based put/put_signal to DeviceWindow (#1111)

### DIFF
--- a/comms/pipes/tests/DeviceWindowTest.cc
+++ b/comms/pipes/tests/DeviceWindowTest.cc
@@ -157,6 +157,203 @@ TEST_F(DeviceWindowTestFixture, NvlPutViaGenericApi) {
 }
 
 // =============================================================================
+// Offset-Based NVL Put via DeviceWindow
+// =============================================================================
+
+TEST_F(DeviceWindowTestFixture, NvlOffsetPut) {
+  // Source buffer: 8KB filled with 0xCAFE
+  const std::size_t srcBufSize = 8192;
+  const std::size_t srcNumInts = srcBufSize / sizeof(int);
+  const int testValue = 0xCAFE;
+
+  // Window buffer: 16KB, zero-initialized
+  const std::size_t windowBufSize = 16384;
+  const std::size_t windowNumInts = windowBufSize / sizeof(int);
+
+  DeviceBuffer srcBuffer(srcBufSize);
+  DeviceBuffer windowBuffer(windowBufSize);
+  auto src_d = static_cast<int*>(srcBuffer.get());
+  auto window_d = static_cast<int*>(windowBuffer.get());
+
+  std::vector<int> srcHost(srcNumInts, testValue);
+  CUDACHECK_TEST(
+      cudaMemcpy(src_d, srcHost.data(), srcBufSize, cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(cudaMemset(window_d, 0, windowBufSize));
+
+  // Copy 4KB from src_offset=2048 to dst_offset=4096
+  const size_t dst_offset = 4096;
+  const size_t src_offset = 2048;
+  const std::size_t nbytes = 4096;
+
+  test::testDeviceWindowNvlOffsetPut(
+      0,
+      2,
+      reinterpret_cast<char*>(window_d),
+      reinterpret_cast<const char*>(src_d),
+      srcBufSize,
+      dst_offset,
+      src_offset,
+      nbytes);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<int> windowHost(windowNumInts);
+  CUDACHECK_TEST(cudaMemcpy(
+      windowHost.data(), window_d, windowBufSize, cudaMemcpyDeviceToHost));
+
+  // Expected: zeros everywhere except [dst_offset, dst_offset+nbytes)
+  const std::size_t dstStartInt = dst_offset / sizeof(int);
+  const std::size_t copyNumInts = nbytes / sizeof(int);
+  std::vector<int> expected(windowNumInts, 0);
+  std::fill(
+      expected.begin() + dstStartInt,
+      expected.begin() + dstStartInt + copyNumInts,
+      testValue);
+  EXPECT_EQ(windowHost, expected)
+      << "Offset put should copy data to correct region only";
+}
+
+// =============================================================================
+// Offset-Based NVL Put + Signal via DeviceWindow
+// =============================================================================
+
+TEST_F(DeviceWindowTestFixture, NvlOffsetPutSignal) {
+  // Source buffer: 8KB filled with 0xBEEF
+  const std::size_t srcBufSize = 8192;
+  const std::size_t srcNumInts = srcBufSize / sizeof(int);
+  const int testValue = 0xBEEF;
+
+  // Window buffer: 16KB, zero-initialized
+  const std::size_t windowBufSize = 16384;
+  const std::size_t windowNumInts = windowBufSize / sizeof(int);
+
+  DeviceBuffer srcBuffer(srcBufSize);
+  DeviceBuffer windowBuffer(windowBufSize);
+  auto src_d = static_cast<int*>(srcBuffer.get());
+  auto window_d = static_cast<int*>(windowBuffer.get());
+
+  std::vector<int> srcHost(srcNumInts, testValue);
+  CUDACHECK_TEST(
+      cudaMemcpy(src_d, srcHost.data(), srcBufSize, cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(cudaMemset(window_d, 0, windowBufSize));
+
+  // Copy 4KB from src_offset=0 to dst_offset=8192
+  const size_t dst_offset = 8192;
+  const size_t src_offset = 0;
+  const std::size_t nbytes = 4096;
+  const int signalId = 0;
+
+  test::testDeviceWindowNvlOffsetPutSignal(
+      0,
+      2,
+      reinterpret_cast<char*>(window_d),
+      reinterpret_cast<const char*>(src_d),
+      srcBufSize,
+      dst_offset,
+      src_offset,
+      nbytes,
+      signalId);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<int> windowHost(windowNumInts);
+  CUDACHECK_TEST(cudaMemcpy(
+      windowHost.data(), window_d, windowBufSize, cudaMemcpyDeviceToHost));
+
+  // Expected: zeros everywhere except [dst_offset, dst_offset+nbytes)
+  const std::size_t dstStartInt = dst_offset / sizeof(int);
+  const std::size_t copyNumInts = nbytes / sizeof(int);
+  std::vector<int> expected(windowNumInts, 0);
+  std::fill(
+      expected.begin() + dstStartInt,
+      expected.begin() + dstStartInt + copyNumInts,
+      testValue);
+  EXPECT_EQ(windowHost, expected)
+      << "Offset put_signal should copy data to correct region only";
+}
+
+// =============================================================================
+// Bidirectional Offset-Based NVL Put + Signal via DeviceWindow
+// =============================================================================
+
+TEST_F(DeviceWindowTestFixture, NvlBidirectionalOffsetPutSignal) {
+  // Two source buffers with different patterns
+  const std::size_t srcBufSize = 8192;
+  const std::size_t srcNumInts = srcBufSize / sizeof(int);
+  const int testValue0 = 0xAAAA; // rank 0's data
+  const int testValue1 = 0xBBBB; // rank 1's data
+
+  // Two window buffers (one per rank), zero-initialized
+  const std::size_t windowBufSize = 16384;
+  const std::size_t windowNumInts = windowBufSize / sizeof(int);
+
+  DeviceBuffer srcBuffer0(srcBufSize);
+  DeviceBuffer srcBuffer1(srcBufSize);
+  DeviceBuffer windowBuffer0(windowBufSize);
+  DeviceBuffer windowBuffer1(windowBufSize);
+
+  auto src0_d = static_cast<int*>(srcBuffer0.get());
+  auto src1_d = static_cast<int*>(srcBuffer1.get());
+  auto window0_d = static_cast<int*>(windowBuffer0.get());
+  auto window1_d = static_cast<int*>(windowBuffer1.get());
+
+  // Fill source buffers with distinct patterns
+  std::vector<int> srcHost0(srcNumInts, testValue0);
+  std::vector<int> srcHost1(srcNumInts, testValue1);
+  CUDACHECK_TEST(
+      cudaMemcpy(src0_d, srcHost0.data(), srcBufSize, cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(
+      cudaMemcpy(src1_d, srcHost1.data(), srcBufSize, cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(cudaMemset(window0_d, 0, windowBufSize));
+  CUDACHECK_TEST(cudaMemset(window1_d, 0, windowBufSize));
+
+  // Both ranks put 4KB from src_offset=0 to dst_offset=4096
+  const std::size_t dst_offset = 4096;
+  const std::size_t src_offset = 0;
+  const std::size_t nbytes = 4096;
+  const int signalId = 0;
+
+  test::testDeviceWindowNvlBidirectionalOffsetPutSignal(
+      reinterpret_cast<char*>(window0_d),
+      reinterpret_cast<char*>(window1_d),
+      reinterpret_cast<const char*>(src0_d),
+      reinterpret_cast<const char*>(src1_d),
+      srcBufSize,
+      dst_offset,
+      src_offset,
+      nbytes,
+      signalId);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  // Verify rank 0's put landed in windowBuffer1
+  const std::size_t dstStartInt = dst_offset / sizeof(int);
+  const std::size_t copyNumInts = nbytes / sizeof(int);
+
+  std::vector<int> window1Host(windowNumInts);
+  CUDACHECK_TEST(cudaMemcpy(
+      window1Host.data(), window1_d, windowBufSize, cudaMemcpyDeviceToHost));
+
+  std::vector<int> expected1(windowNumInts, 0);
+  std::fill(
+      expected1.begin() + dstStartInt,
+      expected1.begin() + dstStartInt + copyNumInts,
+      testValue0);
+  EXPECT_EQ(window1Host, expected1)
+      << "Rank 0's put_signal should write 0xAAAA into rank 1's window buffer";
+
+  // Verify rank 1's put landed in windowBuffer0
+  std::vector<int> window0Host(windowNumInts);
+  CUDACHECK_TEST(cudaMemcpy(
+      window0Host.data(), window0_d, windowBufSize, cudaMemcpyDeviceToHost));
+
+  std::vector<int> expected0(windowNumInts, 0);
+  std::fill(
+      expected0.begin() + dstStartInt,
+      expected0.begin() + dstStartInt + copyNumInts,
+      testValue1);
+  EXPECT_EQ(window0Host, expected0)
+      << "Rank 1's put_signal should write 0xBBBB into rank 0's window buffer";
+}
+
+// =============================================================================
 // signal_all + read_signal Aggregate
 // =============================================================================
 

--- a/comms/pipes/tests/DeviceWindowTest.cu
+++ b/comms/pipes/tests/DeviceWindowTest.cu
@@ -373,6 +373,147 @@ void testDeviceWindowNvlPut(
 }
 
 // =============================================================================
+// DeviceWindow Offset-Based NVL Put Test
+// =============================================================================
+
+__global__ void nvlOffsetPutKernel(
+    DeviceWindow dw,
+    int targetPeerRank,
+    std::size_t dst_offset,
+    LocalBufferRegistration src_buf,
+    std::size_t src_offset,
+    std::size_t nbytes) {
+  auto group = make_block_group();
+  dw.put(group, targetPeerRank, dst_offset, src_buf, src_offset, nbytes);
+}
+
+// Extended NVL helper that also sets up window buffer pointers
+// for offset-based put/put_signal tests.
+struct NvlOffsetPutDeviceWindowBuffers : NvlOnlyDeviceWindowBuffers {
+  std::unique_ptr<meta::comms::DeviceBuffer> windowPtrsBuf;
+
+  DeviceWindow
+  create_with_offset_put(int myRank, int nRanks, void* windowBuf_d) {
+    auto dw = create(myRank, nRanks, 1);
+    int nPeers = nRanks - 1;
+
+    // windowNvlPeerPtrs_: each NVL peer's "window buffer" pointer
+    windowPtrsBuf = std::make_unique<meta::comms::DeviceBuffer>(
+        std::max(1, nPeers) * sizeof(void*));
+    {
+      std::vector<void*> hostPtrs(nPeers, windowBuf_d);
+      CUDACHECK_TEST(cudaMemcpy(
+          windowPtrsBuf->get(),
+          hostPtrs.data(),
+          nPeers * sizeof(void*),
+          cudaMemcpyHostToDevice));
+    }
+    new (&dw.windowNvlPeerPtrs_)
+        DeviceSpan<void*>(static_cast<void**>(windowPtrsBuf->get()), nPeers);
+
+    return dw;
+  }
+};
+
+void testDeviceWindowNvlOffsetPut(
+    int myRank,
+    int nRanks,
+    char* windowBuf_d,
+    const char* srcBuf_d,
+    std::size_t srcBufSize,
+    std::size_t dst_offset,
+    std::size_t src_offset,
+    std::size_t nbytes) {
+  NvlOffsetPutDeviceWindowBuffers bufs;
+  auto dw = bufs.create_with_offset_put(myRank, nRanks, windowBuf_d);
+
+  int targetPeerRank = (myRank == 0) ? 1 : 0;
+  LocalBufferRegistration src_buf{srcBuf_d, srcBufSize, NetworkLKey{}};
+  nvlOffsetPutKernel<<<4, 256>>>(
+      dw, targetPeerRank, dst_offset, src_buf, src_offset, nbytes);
+  CUDACHECK_TEST(cudaGetLastError());
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+}
+
+// =============================================================================
+// DeviceWindow Offset-Based NVL Put + Signal Test
+// =============================================================================
+
+__global__ void nvlOffsetPutSignalKernel(
+    DeviceWindow dw,
+    int targetPeerRank,
+    std::size_t dst_offset,
+    LocalBufferRegistration src_buf,
+    std::size_t src_offset,
+    std::size_t nbytes,
+    int signalId) {
+  auto group = make_block_group();
+  dw.put_signal(
+      group, targetPeerRank, dst_offset, src_buf, src_offset, nbytes, signalId);
+}
+
+void testDeviceWindowNvlOffsetPutSignal(
+    int myRank,
+    int nRanks,
+    char* windowBuf_d,
+    const char* srcBuf_d,
+    std::size_t srcBufSize,
+    std::size_t dst_offset,
+    std::size_t src_offset,
+    std::size_t nbytes,
+    int signalId) {
+  NvlOffsetPutDeviceWindowBuffers bufs;
+  auto dw = bufs.create_with_offset_put(myRank, nRanks, windowBuf_d);
+
+  int targetPeerRank = (myRank == 0) ? 1 : 0;
+  LocalBufferRegistration src_buf{srcBuf_d, srcBufSize, NetworkLKey{}};
+  nvlOffsetPutSignalKernel<<<4, 256>>>(
+      dw, targetPeerRank, dst_offset, src_buf, src_offset, nbytes, signalId);
+  CUDACHECK_TEST(cudaGetLastError());
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+}
+
+// =============================================================================
+// DeviceWindow Bidirectional Offset-Based NVL Put + Signal Test
+// =============================================================================
+
+void testDeviceWindowNvlBidirectionalOffsetPutSignal(
+    char* windowBuf0_d,
+    char* windowBuf1_d,
+    const char* srcBuf0_d,
+    const char* srcBuf1_d,
+    std::size_t srcBufSize,
+    std::size_t dst_offset,
+    std::size_t src_offset,
+    std::size_t nbytes,
+    int signalId) {
+  const int nRanks = 2;
+
+  // Rank 0's DeviceWindow: peer is rank 1, peer's window = windowBuf1_d
+  NvlOffsetPutDeviceWindowBuffers bufs0;
+  auto dw0 = bufs0.create_with_offset_put(0, nRanks, windowBuf1_d);
+
+  // Rank 1's DeviceWindow: peer is rank 0, peer's window = windowBuf0_d
+  NvlOffsetPutDeviceWindowBuffers bufs1;
+  auto dw1 = bufs1.create_with_offset_put(1, nRanks, windowBuf0_d);
+
+  LocalBufferRegistration srcReg0{srcBuf0_d, srcBufSize, NetworkLKey{}};
+  LocalBufferRegistration srcReg1{srcBuf1_d, srcBufSize, NetworkLKey{}};
+
+  // Rank 0 puts to rank 1's window buffer
+  nvlOffsetPutSignalKernel<<<4, 256>>>(
+      dw0, 1, dst_offset, srcReg0, src_offset, nbytes, signalId);
+  CUDACHECK_TEST(cudaGetLastError());
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  // Rank 1 puts to rank 0's window buffer
+  nvlOffsetPutSignalKernel<<<4, 256>>>(
+      dw1, 0, dst_offset, srcReg1, src_offset, nbytes, signalId);
+  CUDACHECK_TEST(cudaGetLastError());
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+}
+
+// =============================================================================
 // DeviceWindow signal_all + read_signal Aggregate Test
 // =============================================================================
 

--- a/comms/pipes/tests/DeviceWindowTest.cuh
+++ b/comms/pipes/tests/DeviceWindowTest.cuh
@@ -157,4 +157,66 @@ void testIbgdaSignalAggregateRead(
     int nPeers,
     uint64_t* result);
 
+/**
+ * Test: DeviceWindow offset-based NVL put()
+ *
+ * Verifies the offset-based put() overload correctly resolves
+ * dst_offset into the window buffer and src_buf + src_offset
+ * into a registered source buffer, then copies the data.
+ */
+void testDeviceWindowNvlOffsetPut(
+    int myRank,
+    int nRanks,
+    char* windowBuf_d,
+    const char* srcBuf_d,
+    std::size_t srcBufSize,
+    std::size_t dst_offset,
+    std::size_t src_offset,
+    std::size_t nbytes);
+
+/**
+ * Test: DeviceWindow offset-based NVL put_signal()
+ *
+ * Verifies the offset-based put_signal() overload copies data
+ * to the correct region and signals the target peer.
+ */
+void testDeviceWindowNvlOffsetPutSignal(
+    int myRank,
+    int nRanks,
+    char* windowBuf_d,
+    const char* srcBuf_d,
+    std::size_t srcBufSize,
+    std::size_t dst_offset,
+    std::size_t src_offset,
+    std::size_t nbytes,
+    int signalId);
+
+/**
+ * Test: Bidirectional offset-based NVL put_signal()
+ *
+ * Simulates 2 ranks on a single GPU. Each rank does put_signal()
+ * to the other's window buffer with different data patterns,
+ * verifying both directions land correctly.
+ *
+ * @param windowBuf0_d Window buffer for rank 0 (rank 1 writes here)
+ * @param windowBuf1_d Window buffer for rank 1 (rank 0 writes here)
+ * @param srcBuf0_d Source buffer for rank 0
+ * @param srcBuf1_d Source buffer for rank 1
+ * @param srcBufSize Size of each source buffer in bytes
+ * @param dst_offset Byte offset into destination window buffer
+ * @param src_offset Byte offset into source buffer
+ * @param nbytes Number of bytes to copy
+ * @param signalId Signal slot to use
+ */
+void testDeviceWindowNvlBidirectionalOffsetPutSignal(
+    char* windowBuf0_d,
+    char* windowBuf1_d,
+    const char* srcBuf0_d,
+    const char* srcBuf1_d,
+    std::size_t srcBufSize,
+    std::size_t dst_offset,
+    std::size_t src_offset,
+    std::size_t nbytes,
+    int signalId);
+
 } // namespace comms::pipes::test

--- a/comms/pipes/window/DeviceWindow.cuh
+++ b/comms/pipes/window/DeviceWindow.cuh
@@ -25,6 +25,7 @@ namespace comms::pipes {
 // Forward declaration for test helper
 namespace test {
 struct NvlOnlyDeviceWindowBuffers;
+struct NvlOffsetPutDeviceWindowBuffers;
 struct IbgdaOnlyDeviceWindowBuffers;
 } // namespace test
 
@@ -958,6 +959,53 @@ class DeviceWindow {
   }
 
   // ===========================================================================
+  // Put (offset-based — destination is window buffer, source is registered buf)
+  // ===========================================================================
+
+  /**
+   * put - Offset-based one-sided write to a peer's window buffer.
+   *
+   * Group-level API: all threads in the group must call this together.
+   * Destination is the peer's window buffer (the userBuffer from HostWindow
+   * constructor). Source is a registered buffer (from
+   * HostWindow::registerLocalBuffer).
+   *
+   * @param group        ThreadGroup for group coordination.
+   * @param target_rank  Rank to put to (must not be self).
+   * @param dst_offset   Byte offset into the target peer's window buffer.
+   * @param src_buf      Registered source buffer.
+   * @param src_offset   Byte offset into the source buffer.
+   * @param nbytes       Number of bytes to transfer.
+   */
+  __device__ __forceinline__ void put(
+      ThreadGroup& group,
+      int target_rank,
+      std::size_t dst_offset,
+      const LocalBufferRegistration& src_buf,
+      std::size_t src_offset,
+      std::size_t nbytes) {
+    DEVICE_WINDOW_CHECK_RANK(target_rank, handle_.nRanks);
+    DEVICE_WINDOW_CHECK_NOT_SELF(target_rank, handle_.myRank);
+    const auto* localSrc = static_cast<const char*>(src_buf.base) + src_offset;
+    if (handle_.get_type(target_rank) == TransportType::P2P_NVL) {
+      int nvlPeerIdx = rankToNvlPeerIndex_[target_rank];
+      auto* remoteDst =
+          static_cast<char*>(windowNvlPeerPtrs_[nvlPeerIdx]) + dst_offset;
+      handle_.get_nvl(target_rank).put(group, remoteDst, localSrc, nbytes);
+    } else {
+      int ibgdaPeerIdx = rank_to_peer_index(target_rank);
+      IbgdaLocalBuffer localBuf(
+          const_cast<void*>(static_cast<const void*>(localSrc)), src_buf.lkey);
+      IbgdaRemoteBuffer remoteBuf(
+          const_cast<void*>(remoteBufferRegistry_[ibgdaPeerIdx].base),
+          remoteBufferRegistry_[ibgdaPeerIdx].rkey);
+      handle_.get_ibgda(target_rank)
+          .put_group_global(
+              group, localBuf, remoteBuf.subBuffer(dst_offset), nbytes);
+    }
+  }
+
+  // ===========================================================================
   // Combined Put + Signal (generic — dispatches to NVL or IBGDA internally)
   // ===========================================================================
 
@@ -1000,9 +1048,9 @@ class DeviceWindow {
               static_cast<char*>(remoteDst),
               static_cast<const char*>(localSrc),
               nbytes);
-      group.sync();
       signal_peer(
           group, target_rank, signalId, SignalOp::SIGNAL_ADD, signalVal);
+      group.sync();
     } else {
       int ibgdaIdx = rank_to_peer_index(target_rank);
       IbgdaLocalBuffer localBuf(
@@ -1019,6 +1067,67 @@ class DeviceWindow {
         handle_.get_ibgda(target_rank)
             .signal_remote_with_fence(
                 ibgdaPeerSignalRemoteBufs_[ibgdaIdx], signalId, signalVal);
+      }
+      group.sync();
+    }
+  }
+
+  // ===========================================================================
+  // Combined Put + Signal (offset-based — window buffer dest, registered src)
+  // ===========================================================================
+
+  /**
+   * put_signal - Offset-based one-sided write + signal to a peer.
+   *
+   * Group-level API: all threads in the group must call this together.
+   * Same as offset-based put(), followed by a signal to the target peer.
+   * NVL: put + sync + atomic signal via NVLink + sync.
+   * IBGDA: put + NIC-fenced atomic signal (HW-ordered) + sync.
+   *
+   * @param group        ThreadGroup for group coordination.
+   * @param target_rank  Rank to put to (must not be self).
+   * @param dst_offset   Byte offset into the target peer's window buffer.
+   * @param src_buf      Registered source buffer.
+   * @param src_offset   Byte offset into the source buffer.
+   * @param nbytes       Number of bytes to transfer.
+   * @param signalId     Signal slot index in [0, peerSignalCount).
+   * @param signalVal    Value to add to the signal (default: 1).
+   */
+  __device__ __forceinline__ void put_signal(
+      ThreadGroup& group,
+      int target_rank,
+      std::size_t dst_offset,
+      const LocalBufferRegistration& src_buf,
+      std::size_t src_offset,
+      std::size_t nbytes,
+      int signalId,
+      uint64_t signalVal = 1) {
+    DEVICE_WINDOW_CHECK_RANK(target_rank, handle_.nRanks);
+    DEVICE_WINDOW_CHECK_NOT_SELF(target_rank, handle_.myRank);
+    const auto* localSrc = static_cast<const char*>(src_buf.base) + src_offset;
+    if (handle_.get_type(target_rank) == TransportType::P2P_NVL) {
+      int nvlPeerIdx = rankToNvlPeerIndex_[target_rank];
+      auto* remoteDst =
+          static_cast<char*>(windowNvlPeerPtrs_[nvlPeerIdx]) + dst_offset;
+      handle_.get_nvl(target_rank).put(group, remoteDst, localSrc, nbytes);
+      signal_peer(
+          group, target_rank, signalId, SignalOp::SIGNAL_ADD, signalVal);
+      group.sync();
+    } else {
+      int ibgdaPeerIdx = rank_to_peer_index(target_rank);
+      IbgdaLocalBuffer localBuf(
+          const_cast<void*>(static_cast<const void*>(localSrc)), src_buf.lkey);
+      IbgdaRemoteBuffer remoteBuf(
+          const_cast<void*>(remoteBufferRegistry_[ibgdaPeerIdx].base),
+          remoteBufferRegistry_[ibgdaPeerIdx].rkey);
+      handle_.get_ibgda(target_rank)
+          .put_group_global(
+              group, localBuf, remoteBuf.subBuffer(dst_offset), nbytes);
+      // Single fenced signal from global leader (matches NVL semantics)
+      if (group.is_global_leader()) {
+        handle_.get_ibgda(target_rank)
+            .signal_remote_with_fence(
+                ibgdaPeerSignalRemoteBufs_[ibgdaPeerIdx], signalId, signalVal);
       }
       group.sync();
     }
@@ -1163,12 +1272,19 @@ class DeviceWindow {
   // Indexed directly by ibgdaPeerIdx (one entry per IBGDA peer).
   DeviceSpan<RemoteBufferRegistration> remoteBufferRegistry_;
 
+  // --- Window buffer NVL peer pointers (for offset-based put/put_signal) ---
+  // IPC-mapped pointers to each NVL peer's window buffer.
+  // Indexed by nvlPeerIdx (from rankToNvlPeerIndex_[globalRank]).
+  // IBGDA uses remoteBufferRegistry_ (the window buffer is the exchanged buf).
+  DeviceSpan<void*> windowNvlPeerPtrs_;
+
   // HostWindow constructs DeviceWindow directly
   friend class HostWindow;
 
   // Test helper for unit tests (constructs minimal DeviceWindow without
   // HostWindow)
   friend struct comms::pipes::test::NvlOnlyDeviceWindowBuffers;
+  friend struct comms::pipes::test::NvlOffsetPutDeviceWindowBuffers;
   friend struct comms::pipes::test::IbgdaOnlyDeviceWindowBuffers;
 };
 

--- a/comms/pipes/window/HostWindow.cc
+++ b/comms/pipes/window/HostWindow.cc
@@ -310,11 +310,12 @@ int HostWindow::registerLocalBuffer(void* ptr, std::size_t size) {
 }
 
 int HostWindow::registerAndExchangeBuffer(void* ptr, std::size_t size) {
-  if (!remoteRegistrations_.empty()) {
+  if (userBufferRegistered_) {
     throw std::runtime_error(
         "HostWindow::registerAndExchangeBuffer() called more than once. "
         "Each DeviceWindow supports exactly one exchanged dst buffer.");
   }
+  userBufferRegistered_ = true;
 
   int regIdx = static_cast<int>(localRegistrations_.size());
   int nIbgdaPeers = static_cast<int>(ibgdaPeerRanks_.size());
@@ -338,6 +339,25 @@ int HostWindow::registerAndExchangeBuffer(void* ptr, std::size_t size) {
   // NVL side: IPC exchange
   if (nNvlPeers > 0) {
     exchangedNvlMappedPtrs_ = transport_.exchangeNvlBuffer(ptr, size);
+
+    // Upload NVL peer pointers to device for offset-based put/put_signal.
+    // exchangedNvlMappedPtrs_ is indexed by NVL local rank; extract peers
+    // in nvlPeerIdx order (skip self).
+    std::vector<void*> nvlPeerPtrs;
+    nvlPeerPtrs.reserve(nNvlPeers);
+    for (int nvlLocal = 0; nvlLocal < nvlNRanks_; ++nvlLocal) {
+      if (nvlLocal == nvlLocalRank_) {
+        continue;
+      }
+      nvlPeerPtrs.push_back(exchangedNvlMappedPtrs_[nvlLocal]);
+    }
+    userNvlPeerPtrsDevice_ =
+        std::make_unique<meta::comms::DeviceBuffer>(nNvlPeers * sizeof(void*));
+    CUDA_CHECK(cudaMemcpy(
+        userNvlPeerPtrsDevice_->get(),
+        nvlPeerPtrs.data(),
+        nNvlPeers * sizeof(void*),
+        cudaMemcpyDefault));
   }
 
   localRegistrations_.push_back(localReg);
@@ -448,6 +468,13 @@ DeviceWindow HostWindow::getDeviceWindow() const {
         static_cast<RemoteBufferRegistration*>(
             remoteRegistrationsDevice_->get()),
         nIbgdaPeers);
+  }
+
+  // Window buffer NVL peer pointers (for offset-based put/put_signal).
+  // IBGDA uses remoteBufferRegistry_ (the window buffer is the exchanged buf).
+  if (userNvlPeerPtrsDevice_ && nNvlPeers > 0) {
+    new (&dw.windowNvlPeerPtrs_) DeviceSpan<void*>(
+        static_cast<void**>(userNvlPeerPtrsDevice_->get()), nNvlPeers);
   }
 
   return dw;

--- a/comms/pipes/window/HostWindow.h
+++ b/comms/pipes/window/HostWindow.h
@@ -239,6 +239,11 @@ class HostWindow {
   std::unique_ptr<meta::comms::DeviceBuffer> localRegistrationsDevice_;
   std::unique_ptr<meta::comms::DeviceBuffer> remoteRegistrationsDevice_;
 
+  // --- Window buffer NVL peer pointers (for offset-based put/put_signal) ---
+  // Device copy of NVL peers' IPC-mapped window buffer pointers.
+  std::unique_ptr<meta::comms::DeviceBuffer> userNvlPeerPtrsDevice_;
+
+  bool userBufferRegistered_{false};
   bool exchanged_{false};
 };
 


### PR DESCRIPTION
Summary:

Add offset-based `put()` and `put_signal()` overloads to `DeviceWindow` where
the destination is implicitly the peer's window buffer (the `userBuffer` from
`HostWindow` constructor) and the source is identified by a `registerBuffer()`
ID + byte offset.

The existing pointer-based `put()`/`put_signal()` require raw remote pointers,
which aren't available in the torchcomms device `put()` API that uses
offset-based addressing (dst_offset, src_buf_id, src_offset). These new
overloads bridge that gap with O(1) addressing — no linear scan of the
registration table for lkey/rkey lookup.

The remote info for the window buffer (NVL IPC-mapped peer pointers and IBGDA
remote buffer descriptors) is already exchanged and on-device; this diff just
wires it into `DeviceWindow`'s fields so the new overloads can access it.

Changes:
- `DeviceWindow.cuh`: Add `windowNvlPeerPtrs_` and `windowIbgdaRemoteBufs_`
  fields; add offset-based `put()` and `put_signal()` methods.
- `HostWindow.cc`: Wire `userNvlPeerPtrsDevice_` and `userRemoteBufsDevice_`
  into `getDeviceWindow()`.
- `DeviceWindowTest.{cc,cu,cuh}`: Add `NvlOffsetPut` test verifying offset-based
  `put()` copies data to the correct region of the window buffer.

Reviewed By: cenzhaometa

Differential Revision: D96341520
