### PR TITLE
Add external data buffer API to MultiPeerNvlTransport (#1122)

### DIFF
--- a/comms/pipes/MultiPeerNvlTransport.cc
+++ b/comms/pipes/MultiPeerNvlTransport.cc
@@ -29,7 +29,11 @@ MultiPeerNvlTransport::MultiPeerNvlTransport(
   // - No manual cleanup is needed in the constructor
   // - The destructor only needs to handle successfully constructed objects
   //
-  // Allocation order: signal -> data -> state
+  // Data buffers are NOT allocated here — they are either:
+  // - Allocated internally in exchange() (default)
+  // - Provided externally via setExternalDataBuffers() before exchange()
+  //
+  // Allocation order: signal -> state
   // Each handler's destructor will free its GPU memory if constructed.
 
   // Calculate per-peer buffer sizes with pipelining
@@ -64,14 +68,11 @@ MultiPeerNvlTransport::MultiPeerNvlTransport(
     perPeerChunkStateBufferSize_ =
         chunkStateMultiplier * numChunksPerPeer * sizeof(ChunkState);
 
-    // Allocate buffers for (nRanks - 1) peers using GpuMemHandler
-    const std::size_t totalDataBufferSize =
-        perPeerDataBufferSize_ * (nRanks_ - 1);
+    // Allocate state buffer for (nRanks - 1) peers using GpuMemHandler.
+    // Data buffer allocation is deferred to exchange() to allow
+    // setExternalDataBuffers() to be called first.
     const std::size_t totalChunkStateBufferSize =
         perPeerChunkStateBufferSize_ * (nRanks_ - 1);
-
-    dataBufferHandler_ = std::make_unique<GpuMemHandler>(
-        bootstrap_, myRank_, nRanks_, totalDataBufferSize, memSharingMode_);
 
     stateBufferHandler_ = std::make_unique<GpuMemHandler>(
         bootstrap_,
@@ -108,8 +109,56 @@ MultiPeerNvlTransport::MultiPeerNvlTransport(
       cudaMemcpyDefault));
 }
 
+void MultiPeerNvlTransport::setExternalDataBuffers(
+    ExternalStagingBuffers externalStagingBuffers) {
+  // Validate that the vectors are large enough to index by rank.
+  if (static_cast<int>(externalStagingBuffers.localBuffers.size()) < nRanks_ ||
+      static_cast<int>(externalStagingBuffers.remoteBuffers.size()) < nRanks_) {
+    throw std::runtime_error(
+        "setExternalDataBuffers: localBuffers.size()=" +
+        std::to_string(externalStagingBuffers.localBuffers.size()) +
+        " and remoteBuffers.size()=" +
+        std::to_string(externalStagingBuffers.remoteBuffers.size()) +
+        " must both be >= nRanks=" + std::to_string(nRanks_));
+  }
+
+  // Validate that every non-self peer buffer meets the minimum size.
+  for (int peer = 0; peer < nRanks_; ++peer) {
+    if (peer == myRank_) {
+      continue;
+    }
+    auto localSize = externalStagingBuffers.localBuffers[peer].size();
+    auto remoteSize = externalStagingBuffers.remoteBuffers[peer].size();
+    if (localSize < perPeerDataBufferSize_) {
+      throw std::runtime_error(
+          "setExternalDataBuffers: local buffer for peer " +
+          std::to_string(peer) + " has size " + std::to_string(localSize) +
+          " but requires at least " + std::to_string(perPeerDataBufferSize_) +
+          " (pipelineDepth * dataBufferSize)");
+    }
+    if (remoteSize < perPeerDataBufferSize_) {
+      throw std::runtime_error(
+          "setExternalDataBuffers: remote buffer for peer " +
+          std::to_string(peer) + " has size " + std::to_string(remoteSize) +
+          " but requires at least " + std::to_string(perPeerDataBufferSize_) +
+          " (pipelineDepth * dataBufferSize)");
+    }
+  }
+  externalStagingBuffers_ = std::move(externalStagingBuffers);
+}
+
 void MultiPeerNvlTransport::exchange() {
-  // Exchange P2P transport buffer pointers
+  // Allocate and exchange data buffers when:
+  // - No external buffers were provided, AND
+  // - dataBufferSize > 0 (staging buffers needed for send/recv)
+  if (!externalStagingBuffers_ && config_.dataBufferSize > 0) {
+    const std::size_t totalDataBufferSize =
+        perPeerDataBufferSize_ * (nRanks_ - 1);
+    dataBufferHandler_ = std::make_unique<GpuMemHandler>(
+        bootstrap_, myRank_, nRanks_, totalDataBufferSize, memSharingMode_);
+  }
+
+  // Exchange buffer pointers across all ranks
   if (dataBufferHandler_) {
     dataBufferHandler_->exchangeMemPtrs();
   }
@@ -179,7 +228,7 @@ P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
 
   // When dataBufferSize=0, staging buffers are not allocated.
   // Set data/state to nullptr/empty — send()/recv() will trap.
-  if (!dataBufferHandler_ || !stateBufferHandler_) {
+  if (!dataBufferHandler_ && !externalStagingBuffers_) {
     LocalState localState{
         .dataBuffer = nullptr,
         .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
@@ -201,16 +250,28 @@ P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
   const auto numChunksPerPeer =
       static_cast<uint32_t>(config_.pipelineDepth * numChunksPerStep);
 
-  auto* localDataPtr =
-      static_cast<char*>(dataBufferHandler_->getLocalDeviceMemPtr());
   auto* localStatePtr =
       static_cast<char*>(stateBufferHandler_->getLocalDeviceMemPtr());
+
+  // Data buffer pointers: use external buffers if provided, otherwise
+  // use internally allocated dataBufferHandler_.
+  char* localDataBuffer = nullptr;
+  char* remoteDataBuffer = nullptr;
+  if (externalStagingBuffers_) {
+    localDataBuffer = externalStagingBuffers_->localBuffers[peerRank].data();
+    remoteDataBuffer = externalStagingBuffers_->remoteBuffers[peerRank].data();
+  } else {
+    localDataBuffer =
+        static_cast<char*>(dataBufferHandler_->getLocalDeviceMemPtr()) +
+        localDataBufferOffset;
+    remoteDataBuffer =
+        static_cast<char*>(dataBufferHandler_->getPeerDeviceMemPtr(peerRank)) +
+        remoteDataBufferOffset;
+  }
 
   auto* localChunkStateBase = reinterpret_cast<ChunkState*>(
       localStatePtr + localChunkStateBufferOffset);
 
-  auto* remoteDataPtr =
-      static_cast<char*>(dataBufferHandler_->getPeerDeviceMemPtr(peerRank));
   auto* remoteChunkStatePtr =
       static_cast<char*>(stateBufferHandler_->getPeerDeviceMemPtr(peerRank));
 
@@ -233,7 +294,7 @@ P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
     //     [numChunksPerPeer, 2*numChunksPerPeer): peer's sender state buffer
     //     (I write READY_TO_SEND after reading)
     LocalState localState{
-        .dataBuffer = localDataPtr + localDataBufferOffset,
+        .dataBuffer = localDataBuffer,
         .receiverStateBuffer =
             DeviceSpan<ChunkState>(localChunkStateBase, numChunksPerPeer),
         .senderStateBuffer = DeviceSpan<ChunkState>(
@@ -242,7 +303,7 @@ P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
     };
 
     RemoteState remoteState{
-        .dataBuffer = remoteDataPtr + remoteDataBufferOffset,
+        .dataBuffer = remoteDataBuffer,
         .receiverStateBuffer =
             DeviceSpan<ChunkState>(remoteChunkStateBase, numChunksPerPeer),
         .senderStateBuffer = DeviceSpan<ChunkState>(
@@ -258,7 +319,7 @@ P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
     //   Remote buffer: only receiverStateBuffer is used (points to peer's
     //   receiverStateBuffer, sender writes to signal data ready)
     LocalState localState{
-        .dataBuffer = localDataPtr + localDataBufferOffset,
+        .dataBuffer = localDataBuffer,
         .receiverStateBuffer =
             DeviceSpan<ChunkState>(localChunkStateBase, numChunksPerPeer),
         .senderStateBuffer = DeviceSpan<ChunkState>(), // Not used
@@ -266,7 +327,7 @@ P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
     };
 
     RemoteState remoteState{
-        .dataBuffer = remoteDataPtr + remoteDataBufferOffset,
+        .dataBuffer = remoteDataBuffer,
         .receiverStateBuffer =
             DeviceSpan<ChunkState>(remoteChunkStateBase, numChunksPerPeer),
         .senderStateBuffer = DeviceSpan<ChunkState>(), // Not used

--- a/comms/pipes/MultiPeerNvlTransport.h
+++ b/comms/pipes/MultiPeerNvlTransport.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 
 #include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/pipes/GpuMemHandler.h"
@@ -79,6 +80,34 @@ struct MultiPeerNvlTransportConfig {
 };
 
 /**
+ * Pre-exchanged data buffer pointers for reuse by MultiPeerNvlTransport.
+ *
+ * Both vectors are indexed by NVL local rank. The entry at self rank is
+ * ignored (may be default-constructed / empty).
+ *
+ * - localBuffers[peerNvlRank]: this rank's data buffer region for receiving
+ *   from peerNvlRank (the peer writes here via NVLink).
+ * - remoteBuffers[peerNvlRank]: IPC-mapped pointer to peerNvlRank's data
+ *   buffer region that this rank writes into via NVLink.
+ *
+ * SIZE REQUIREMENTS:
+ *   Each per-peer buffer must be at least (pipelineDepth * dataBufferSize)
+ *   bytes, matching the config passed to MultiPeerNvlTransport.
+ *   setExternalDataBuffers() validates this and throws on mismatch.
+ *
+ * OWNERSHIP:
+ *   The caller retains ownership of the underlying GPU memory. The buffers
+ *   must remain valid and exclusively reserved for pipes' use for the
+ *   lifetime of the MultiPeerNvlTransport. Pipes will read/write these
+ *   buffers during send()/recv() operations — concurrent access by other
+ *   subsystems will cause data corruption.
+ */
+struct ExternalStagingBuffers {
+  std::vector<DeviceSpan<char>> localBuffers;
+  std::vector<DeviceSpan<char>> remoteBuffers;
+};
+
+/**
  * Host-side multi-peer NVLink transport manager.
  *
  * Manages NVLink communication across multiple GPU ranks by:
@@ -122,11 +151,15 @@ class MultiPeerNvlTransport {
    * Constructor - Initialize multi-peer NVLink transport
    *
    * Allocates local GPU buffers for multi-peer communication:
-   * - Data buffer: for staging data transfers (nRanks-1 peer regions)
    * - State buffer: for chunk-level synchronization states
+   * - Signal buffer: for P2P signal coordination
    * - P2pNvlTransportDevice array: preallocated on device memory for all peers
-   *   to allow stateful tranport and reduce kernel launch latency (avoids
+   *   to allow stateful transport and reduce kernel launch latency (avoids
    *   per-launch H2D copy)
+   *
+   * Data buffers are NOT allocated in the constructor. They are either:
+   * - Allocated internally in exchange() (default behavior)
+   * - Provided externally via setExternalDataBuffers() before exchange()
    *
    * Memory sharing mode is automatically detected:
    * - Fabric handles (H100+, CUDA 12.3+): Enables GB200 multi-node NVLink
@@ -158,17 +191,37 @@ class MultiPeerNvlTransport {
   ~MultiPeerNvlTransport() = default;
 
   /**
+   * setExternalDataBuffers - Provide pre-exchanged data buffers
+   *
+   * Call this BEFORE exchange() to use externally-managed data buffers instead
+   * of allocating internally. This enables reuse of data buffers that are
+   * already IPC-shared (e.g., ctran's staging buffers from SharedResource).
+   *
+   * When external data buffers are set:
+   * - exchange() will NOT allocate or exchange data buffers
+   * - State and signal buffers are still allocated and exchanged internally
+   * - buildP2pTransportDevice() uses the provided pointers for LocalState
+   *   and RemoteState dataBuffer fields
+   *
+   * See ExternalStagingBuffers for size requirements and ownership semantics.
+   */
+  void setExternalDataBuffers(ExternalStagingBuffers externalStagingBuffers);
+
+  /**
    * exchange - Exchange memory handles across all ranks
    *
    * COLLECTIVE OPERATION: All ranks MUST call this before using
    * getP2pTransportDevice().
    *
-   * Performs collective handle exchange using the bootstrap interface:
-   * 1. Each rank shares its local buffer's handle with all other ranks
-   * 2. Each rank receives handles from all other ranks
-   * 3. Builds and copies P2pNvlTransportDevice for each peer to the
+   * If setExternalDataBuffers() was called before exchange(), data buffers
+   * are used as-is (no allocation or exchange). Otherwise, data buffers are
+   * allocated internally and exchanged.
+   *
+   * In both cases:
+   * 1. State and signal buffer handles are exchanged across all ranks
+   * 2. Builds and copies P2pNvlTransportDevice for each peer to the
    *    preallocated device array (allocated in constructor)
-   * 4. Implicit barrier ensures all ranks complete before returning
+   * 3. Implicit barrier ensures all ranks complete before returning
    *
    * The type of handle (fabric or cudaIpc) depends on the automatically
    * detected memory sharing mode.
@@ -266,7 +319,7 @@ class MultiPeerNvlTransport {
    * @return kFabric for H100+/CUDA12.3+, kCudaIpc for fallback
    */
   MemSharingMode getMemSharingMode() const {
-    return dataBufferHandler_->getMode();
+    return memSharingMode_;
   }
 
  private:
@@ -288,9 +341,15 @@ class MultiPeerNvlTransport {
 
   // GpuMemHandler-based memory for data, state, and signal buffers
   // Automatically uses fabric handles on H100+/CUDA12.3+, falls back to cudaIpc
+  // dataBufferHandler_ is only allocated when external data buffers are NOT
+  // used. It is allocated lazily in exchange() rather than in the constructor.
   std::unique_ptr<GpuMemHandler> dataBufferHandler_;
   std::unique_ptr<GpuMemHandler> stateBufferHandler_;
   std::unique_ptr<GpuMemHandler> signalBufferHandler_;
+
+  // External data buffer pointers (set via setExternalDataBuffers()).
+  // When set, exchange() skips data buffer allocation/exchange.
+  std::optional<ExternalStagingBuffers> externalStagingBuffers_;
 
   // Device-accessible Transport array for multi-peer transport
   // Allocated on device and populated in initializeTransportsArray()

--- a/comms/pipes/MultiPeerTransport.cc
+++ b/comms/pipes/MultiPeerTransport.cc
@@ -144,6 +144,13 @@ MultiPeerTransport::~MultiPeerTransport() {
   free_device_handle();
 }
 
+void MultiPeerTransport::setExternalNvlDataBuffers(
+    ExternalStagingBuffers externalStagingBuffers) {
+  if (nvlTransport_) {
+    nvlTransport_->setExternalDataBuffers(std::move(externalStagingBuffers));
+  }
+}
+
 void MultiPeerTransport::exchange() {
   if (cuda_driver_lazy_init() != 0) {
     throw std::runtime_error(
@@ -189,6 +196,13 @@ P2pIbgdaTransportDevice* MultiPeerTransport::get_p2p_ibgda_transport_device(
         "get_p2p_ibgda_transport_device: IBGDA transport not available (nRanks == 1?)");
   }
   return ibgdaTransport_->getP2pTransportDevice(globalPeerRank);
+}
+
+Transport* /*nullable*/ MultiPeerTransport::get_nvl_transports_array() const {
+  if (!nvlTransport_) {
+    return nullptr;
+  }
+  return nvlTransport_->getDeviceTransports().data();
 }
 
 P2pSelfTransportDevice MultiPeerTransport::get_p2p_self_transport_device()

--- a/comms/pipes/MultiPeerTransport.h
+++ b/comms/pipes/MultiPeerTransport.h
@@ -143,6 +143,16 @@ class MultiPeerTransport {
     return nvlNRanks_;
   }
 
+  // --- External buffer configuration ---
+
+  /**
+   * Set external NVL data buffers for reuse instead of internal allocation.
+   *
+   * Call BEFORE exchange(). Delegates to
+   * MultiPeerNvlTransport::setExternalDataBuffers().
+   */
+  void setExternalNvlDataBuffers(ExternalStagingBuffers externalStagingBuffers);
+
   // --- Host-side transport accessors ---
 
   /**
@@ -151,6 +161,12 @@ class MultiPeerTransport {
    * peer.
    */
   P2pNvlTransportDevice get_p2p_nvl_transport_device(int globalPeerRank) const;
+
+  /**
+   * @return Pointer to the device-side Transport array from NVL transport,
+   *   indexed by NVL local rank. Returns nullptr if no NVL transport.
+   */
+  Transport* /*nullable*/ get_nvl_transports_array() const;
 
   /**
    * @param globalPeerRank Global rank of the IBGDA peer.

--- a/comms/pipes/tests/ExternalStagingBuffersTest.cc
+++ b/comms/pipes/tests/ExternalStagingBuffersTest.cc
@@ -1,0 +1,328 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include <folly/init/Init.h>
+#include <folly/logging/xlog.h>
+
+#include <memory>
+#include <vector>
+
+#include "comms/pipes/GpuMemHandler.h"
+#include "comms/pipes/MultiPeerNvlTransport.h"
+#include "comms/pipes/P2pNvlTransportDevice.cuh"
+#include "comms/pipes/tests/Utils.cuh"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/testinfra/mpi/MpiBootstrap.h"
+#include "comms/testinfra/mpi/MpiTestUtils.h"
+#include "comms/utils/CudaRAII.h"
+
+using meta::comms::DeviceBuffer;
+using meta::comms::MpiBaseTestFixture;
+using meta::comms::MpiBootstrap;
+using meta::comms::MPIEnvironmentBase;
+
+namespace comms::pipes::tests {
+
+namespace {
+constexpr std::size_t kDataBufferSize = 1024 * 1024; // 1MB per peer
+constexpr std::size_t kChunkSize = 1024;
+constexpr std::size_t kPipelineDepth = 4;
+constexpr std::size_t kNumElements = 256;
+} // namespace
+
+class ExternalStagingBuffersTestFixture : public MpiBaseTestFixture {
+ protected:
+  void SetUp() override {
+    MpiBaseTestFixture::SetUp();
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+  }
+
+  void TearDown() override {
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    MpiBaseTestFixture::TearDown();
+  }
+
+  MultiPeerNvlTransportConfig defaultConfig() {
+    return MultiPeerNvlTransportConfig{
+        .dataBufferSize = kDataBufferSize,
+        .chunkSize = kChunkSize,
+        .pipelineDepth = kPipelineDepth,
+    };
+  }
+
+  // Allocate external data buffers using GpuMemHandler to handle IPC sharing.
+  // Returns the GpuMemHandler (for lifetime management) and the
+  // ExternalStagingBuffers struct with per-peer buffer pointers.
+  struct ExternalBufferBundle {
+    std::unique_ptr<GpuMemHandler> handler;
+    ExternalStagingBuffers stagingBuffers;
+  };
+
+  ExternalBufferBundle allocateExternalBuffers(
+      std::shared_ptr<meta::comms::IBootstrap> bootstrap,
+      std::size_t perPeerSize) {
+    const std::size_t totalSize = perPeerSize * (numRanks - 1);
+    auto memSharingMode = GpuMemHandler::detectBestMode();
+    auto handler = std::make_unique<GpuMemHandler>(
+        bootstrap, globalRank, numRanks, totalSize, memSharingMode);
+    handler->exchangeMemPtrs();
+
+    // DeviceSpan is non-assignable (const pointer member), so build vectors
+    // sequentially via emplace_back.
+    std::vector<DeviceSpan<char>> localSpans;
+    std::vector<DeviceSpan<char>> remoteSpans;
+    localSpans.reserve(numRanks);
+    remoteSpans.reserve(numRanks);
+    const auto size = static_cast<uint32_t>(perPeerSize);
+
+    for (int peer = 0; peer < numRanks; ++peer) {
+      if (peer == globalRank) {
+        localSpans.emplace_back(nullptr, 0u);
+        remoteSpans.emplace_back(nullptr, 0u);
+        continue;
+      }
+      // Calculate offsets using same logic as MultiPeerNvlTransport
+      const int localPeerIndex = (peer < globalRank) ? peer : (peer - 1);
+      const int remotePeerIndex =
+          (globalRank < peer) ? globalRank : (globalRank - 1);
+
+      char* localPtr = static_cast<char*>(handler->getLocalDeviceMemPtr()) +
+          localPeerIndex * perPeerSize;
+      char* remotePtr = static_cast<char*>(handler->getPeerDeviceMemPtr(peer)) +
+          remotePeerIndex * perPeerSize;
+      localSpans.emplace_back(localPtr, size);
+      remoteSpans.emplace_back(remotePtr, size);
+    }
+
+    ExternalStagingBuffers staging;
+    staging.localBuffers = std::move(localSpans);
+    staging.remoteBuffers = std::move(remoteSpans);
+
+    return {std::move(handler), std::move(staging)};
+  }
+};
+
+// Verify that transport devices use external buffer pointers when set.
+// buildP2pTransportDevice() should return devices whose data buffer pointers
+// match the external buffers we provided.
+TEST_F(ExternalStagingBuffersTestFixture, TransportUsesExternalBuffers) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "Requires >= 2 ranks, got " << numRanks;
+  }
+
+  auto config = defaultConfig();
+  const std::size_t perPeerDataSize =
+      config.pipelineDepth * config.dataBufferSize;
+  auto bootstrap = std::make_shared<MpiBootstrap>();
+
+  // Allocate external buffers via IPC
+  auto extBuf = allocateExternalBuffers(bootstrap, perPeerDataSize);
+
+  // Create transport with external buffers
+  MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
+  transport.setExternalDataBuffers(std::move(extBuf.stagingBuffers));
+  transport.exchange();
+
+  // Verify that the transport device uses the external buffer pointers
+  for (int peer = 0; peer < numRanks; ++peer) {
+    if (peer == globalRank) {
+      continue;
+    }
+    auto p2p = transport.buildP2pTransportDevice(peer);
+    auto localData = p2p.getLocalState().dataBuffer;
+    auto remoteData = p2p.getRemoteState().dataBuffer;
+
+    // Re-compute expected pointers from the handler
+    const int localPeerIndex = (peer < globalRank) ? peer : (peer - 1);
+    const int remotePeerIndex =
+        (globalRank < peer) ? globalRank : (globalRank - 1);
+
+    char* expectedLocal =
+        static_cast<char*>(extBuf.handler->getLocalDeviceMemPtr()) +
+        localPeerIndex * perPeerDataSize;
+    char* expectedRemote =
+        static_cast<char*>(extBuf.handler->getPeerDeviceMemPtr(peer)) +
+        remotePeerIndex * perPeerDataSize;
+
+    EXPECT_EQ(localData, expectedLocal)
+        << "Rank " << globalRank << ": local data buffer for peer " << peer
+        << " does not match external buffer";
+    EXPECT_EQ(remoteData, expectedRemote)
+        << "Rank " << globalRank << ": remote data buffer for peer " << peer
+        << " does not match external buffer";
+  }
+
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
+// Verify that IPC memory access works through external data buffers.
+// Each rank writes a pattern to its local external buffer, then the peer
+// reads from the remote external buffer and verifies correctness.
+TEST_F(ExternalStagingBuffersTestFixture, IpcMemAccessThroughExternalBuffers) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Requires exactly 2 ranks, got " << numRanks;
+  }
+
+  const int peerRank = (globalRank == 0) ? 1 : 0;
+
+  auto config = defaultConfig();
+  config.dataBufferSize = sizeof(int) * kNumElements;
+  const std::size_t perPeerDataSize =
+      config.pipelineDepth * config.dataBufferSize;
+  auto bootstrap = std::make_shared<MpiBootstrap>();
+
+  // Allocate external buffers via IPC
+  auto extBuf = allocateExternalBuffers(bootstrap, perPeerDataSize);
+
+  // Create transport with external buffers
+  MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
+  transport.setExternalDataBuffers(std::move(extBuf.stagingBuffers));
+  transport.exchange();
+
+  // Get host-side copy of transport device to access buffer pointers
+  auto p2p = transport.buildP2pTransportDevice(peerRank);
+
+  auto localAddr =
+      static_cast<int*>(static_cast<void*>(p2p.getLocalState().dataBuffer));
+  auto remoteAddr =
+      static_cast<int*>(static_cast<void*>(p2p.getRemoteState().dataBuffer));
+
+  XLOGF(
+      INFO,
+      "Rank {}: localAddr={}, remoteAddr={}",
+      globalRank,
+      static_cast<void*>(localAddr),
+      static_cast<void*>(remoteAddr));
+
+  // Each rank writes its rank ID to its local data buffer
+  test::fillBuffer(localAddr, globalRank, kNumElements);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  // Barrier to ensure both ranks have written
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  // Read from peer's buffer via IPC and verify
+  DeviceBuffer errorCountBuffer(sizeof(int));
+  auto d_errorCount = static_cast<int*>(errorCountBuffer.get());
+  CUDACHECK_TEST(cudaMemset(d_errorCount, 0, sizeof(int)));
+
+  test::verifyBuffer(remoteAddr, peerRank, kNumElements, d_errorCount);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  int h_errorCount = 0;
+  CUDACHECK_TEST(cudaMemcpy(
+      &h_errorCount, d_errorCount, sizeof(int), cudaMemcpyDeviceToHost));
+
+  ASSERT_EQ(h_errorCount, 0)
+      << "Rank " << globalRank << " found " << h_errorCount
+      << " errors reading peer's external buffer";
+
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
+// Verify that the default path (no external buffers) still allocates internal
+// data buffers and works correctly.
+TEST_F(ExternalStagingBuffersTestFixture, DefaultPathAllocatesInternalBuffers) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Requires exactly 2 ranks, got " << numRanks;
+  }
+
+  const int peerRank = (globalRank == 0) ? 1 : 0;
+
+  auto config = defaultConfig();
+  config.dataBufferSize = sizeof(int) * kNumElements;
+  auto bootstrap = std::make_shared<MpiBootstrap>();
+
+  // Create transport WITHOUT external buffers (default path)
+  MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
+  transport.exchange();
+
+  // Verify data buffers are accessible and functional
+  auto p2p = transport.buildP2pTransportDevice(peerRank);
+
+  auto localAddr =
+      static_cast<int*>(static_cast<void*>(p2p.getLocalState().dataBuffer));
+  auto remoteAddr =
+      static_cast<int*>(static_cast<void*>(p2p.getRemoteState().dataBuffer));
+
+  // Buffer pointers should be non-null (internal allocation happened)
+  ASSERT_NE(localAddr, nullptr)
+      << "Default path: local data buffer should be non-null";
+  ASSERT_NE(remoteAddr, nullptr)
+      << "Default path: remote data buffer should be non-null";
+
+  // Write and verify through IPC to confirm functional
+  test::fillBuffer(localAddr, globalRank, kNumElements);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  DeviceBuffer errorCountBuffer(sizeof(int));
+  auto d_errorCount = static_cast<int*>(errorCountBuffer.get());
+  CUDACHECK_TEST(cudaMemset(d_errorCount, 0, sizeof(int)));
+  test::verifyBuffer(remoteAddr, peerRank, kNumElements, d_errorCount);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  int h_errorCount = 0;
+  CUDACHECK_TEST(cudaMemcpy(
+      &h_errorCount, d_errorCount, sizeof(int), cudaMemcpyDeviceToHost));
+  ASSERT_EQ(h_errorCount, 0)
+      << "Default path: IPC read through internal buffers failed";
+
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
+// Verify that state and signal buffers are still internally allocated when
+// external data buffers are provided.
+TEST_F(ExternalStagingBuffersTestFixture, StateAndSignalBuffersStillAllocated) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "Requires >= 2 ranks, got " << numRanks;
+  }
+
+  auto config = defaultConfig();
+  const std::size_t perPeerDataSize =
+      config.pipelineDepth * config.dataBufferSize;
+  auto bootstrap = std::make_shared<MpiBootstrap>();
+
+  auto extBuf = allocateExternalBuffers(bootstrap, perPeerDataSize);
+
+  MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
+  transport.setExternalDataBuffers(std::move(extBuf.stagingBuffers));
+  transport.exchange();
+
+  // Verify that state and signal buffers are non-null for each peer
+  for (int peer = 0; peer < numRanks; ++peer) {
+    if (peer == globalRank) {
+      continue;
+    }
+    auto p2p = transport.buildP2pTransportDevice(peer);
+
+    // State buffer spans should be non-empty (internally allocated)
+    EXPECT_FALSE(p2p.getLocalState().receiverStateBuffer.empty())
+        << "Rank " << globalRank << ": local state buffer for peer " << peer
+        << " should not be empty";
+    EXPECT_FALSE(p2p.getRemoteState().receiverStateBuffer.empty())
+        << "Rank " << globalRank << ": remote state buffer for peer " << peer
+        << " should not be empty";
+
+    // Signal buffer spans should be non-empty (internally allocated)
+    EXPECT_FALSE(p2p.getLocalState().signalBuffer.empty())
+        << "Rank " << globalRank << ": local signal buffer for peer " << peer
+        << " should not be empty";
+    EXPECT_FALSE(p2p.getRemoteState().signalBuffer.empty())
+        << "Rank " << globalRank << ": remote signal buffer for peer " << peer
+        << " should not be empty";
+  }
+
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
+} // namespace comms::pipes::tests
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new MPIEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Summary:

Allow MultiPeerNvlTransport to accept pre-exchanged data buffers via
setExternalDataBuffers() instead of allocating internally. This enables
buffer reuse when the caller already has IPC-shared staging buffers
(e.g., ctran's SharedResource).

- Move data buffer allocation from constructor into exchange()
- Add ExternalStagingBuffers struct and setExternalDataBuffers() method
- When external buffers are set, skip internal data buffer allocation
- State and signal buffers are still allocated/exchanged internally
- Add passthrough setExternalNvlDataBuffers() and get_nvl_transports_array()
  to MultiPeerTransport
- Add tests verifying external buffer pointer correctness, IPC data flow,
  default path, and state/signal buffer independence

Reviewed By: cenzhaometa

Differential Revision: D96574933
