### PR TITLE
Migrate put/put_signal callers to offset-based API, remove old overloads (#1123)

### DIFF
--- a/comms/pipes/P2pIbgdaTransportDevice.cuh
+++ b/comms/pipes/P2pIbgdaTransportDevice.cuh
@@ -506,6 +506,29 @@ class P2pIbgdaTransportDevice {
   }
 
   /**
+   * signal_remote_with_fence (group overload) - Group-aware fenced signal
+   *
+   * Group-level API: all threads in the group must call this together.
+   * Performs group.sync() for ordering, then the global leader executes
+   * signal_remote_with_fence().
+   *
+   * @param group ThreadGroup for group coordination.
+   * @param remoteBuf Remote signal buffer (window-owned, RDMA-registered)
+   * @param signalId Index into the remote signal buffer (uint64_t units)
+   * @param value Value to atomically add
+   */
+  __device__ void signal_remote_with_fence(
+      ThreadGroup& group,
+      const IbgdaRemoteBuffer& remoteBuf,
+      int signalId,
+      uint64_t value) {
+    group.sync();
+    if (group.is_global_leader()) {
+      signal_remote_with_fence(remoteBuf, signalId, value);
+    }
+  }
+
+  /**
    * put_signal_counter_remote - Data write + remote signal + local counter
    *
    * Compound operation using main QP (data + signal) and companion QP

--- a/comms/pipes/benchmarks/MultiPeerBenchmark.cu
+++ b/comms/pipes/benchmarks/MultiPeerBenchmark.cu
@@ -151,8 +151,7 @@ template <SyncScope S>
 __global__ void multiPeerPutPingPongKernel(
     DeviceWindow dw,
     int targetRank,
-    const void* localSrc,
-    void* remoteDst,
+    LocalBufferRegistration srcBuf,
     std::size_t nbytes,
     int nSteps) {
   auto group = makeGroup<S>();
@@ -169,8 +168,8 @@ __global__ void multiPeerPutPingPongKernel(
     bool myTurnToPut = ((step % 2) == myRank);
 
     if (myTurnToPut) {
-      // Put data to peer's buffer
-      dw.put(targetRank, group, remoteDst, localSrc, nbytes);
+      // Put data to peer's window buffer at offset 0
+      dw.put(group, targetRank, 0, srcBuf, 0, nbytes);
       // Sync to ensure put completes before signaling
       group.sync();
       // Signal peer that data is ready
@@ -191,8 +190,7 @@ template <SyncScope S>
 __global__ void multiPeerPutSignalPingPongKernel(
     DeviceWindow dw,
     int targetRank,
-    const void* localSrc,
-    void* remoteDst,
+    LocalBufferRegistration srcBuf,
     std::size_t nbytes,
     int nSteps) {
   auto group = makeGroup<S>();
@@ -209,8 +207,8 @@ __global__ void multiPeerPutSignalPingPongKernel(
     bool myTurnToPut = ((step % 2) == myRank);
 
     if (myTurnToPut) {
-      // Combined put + signal
-      dw.put_signal(targetRank, group, remoteDst, localSrc, nbytes, slotId, 1);
+      // Combined put + signal to peer's window buffer at offset 0
+      dw.put_signal(group, targetRank, 0, srcBuf, 0, nbytes, slotId, 1);
     } else {
       // Wait for (step/2 + 1) signals from peer
       uint64_t expectedValue = (step / 2) + 1;
@@ -227,15 +225,13 @@ __global__ void multiPeerPutSignalPingPongKernel(
 template __global__ void multiPeerPutPingPongKernel<SyncScope::WARP>(
     DeviceWindow,
     int,
-    const void*,
-    void*,
+    LocalBufferRegistration,
     std::size_t,
     int);
 template __global__ void multiPeerPutPingPongKernel<SyncScope::BLOCK>(
     DeviceWindow,
     int,
-    const void*,
-    void*,
+    LocalBufferRegistration,
     std::size_t,
     int);
 
@@ -243,15 +239,13 @@ template __global__ void multiPeerPutPingPongKernel<SyncScope::BLOCK>(
 template __global__ void multiPeerPutSignalPingPongKernel<SyncScope::WARP>(
     DeviceWindow,
     int,
-    const void*,
-    void*,
+    LocalBufferRegistration,
     std::size_t,
     int);
 template __global__ void multiPeerPutSignalPingPongKernel<SyncScope::BLOCK>(
     DeviceWindow,
     int,
-    const void*,
-    void*,
+    LocalBufferRegistration,
     std::size_t,
     int);
 

--- a/comms/pipes/benchmarks/MultiPeerBenchmark.cuh
+++ b/comms/pipes/benchmarks/MultiPeerBenchmark.cuh
@@ -69,8 +69,7 @@ __global__ void multiPeerSignalAllKernel(DeviceWindow dw, int nSteps);
  *
  * @param dw DeviceWindow for NVLink operations
  * @param targetRank The target rank to communicate with
- * @param localSrc Local source buffer to read from
- * @param remoteDst Remote destination buffer to write to (IPC-mapped)
+ * @param srcBuf Registered source buffer
  * @param nbytes Number of bytes to transfer per put
  * @param nSteps Number of ping-pong iterations
  */
@@ -78,8 +77,7 @@ template <SyncScope S>
 __global__ void multiPeerPutPingPongKernel(
     DeviceWindow dw,
     int targetRank,
-    const void* localSrc,
-    void* remoteDst,
+    LocalBufferRegistration srcBuf,
     std::size_t nbytes,
     int nSteps);
 
@@ -97,8 +95,7 @@ __global__ void multiPeerPutPingPongKernel(
  *
  * @param dw DeviceWindow for NVLink operations
  * @param targetRank The target rank to communicate with
- * @param localSrc Local source buffer to read from
- * @param remoteDst Remote destination buffer to write to (IPC-mapped)
+ * @param srcBuf Registered source buffer
  * @param nbytes Number of bytes to transfer per put
  * @param nSteps Number of ping-pong iterations
  */
@@ -106,8 +103,7 @@ template <SyncScope S>
 __global__ void multiPeerPutSignalPingPongKernel(
     DeviceWindow dw,
     int targetRank,
-    const void* localSrc,
-    void* remoteDst,
+    LocalBufferRegistration srcBuf,
     std::size_t nbytes,
     int nSteps);
 

--- a/comms/pipes/tests/DeviceWindowTest.cc
+++ b/comms/pipes/tests/DeviceWindowTest.cc
@@ -122,41 +122,6 @@ TEST_F(DeviceWindowTestFixture, ReadSignal) {
 }
 
 // =============================================================================
-// Generic NVL Put via DeviceWindow
-// =============================================================================
-
-TEST_F(DeviceWindowTestFixture, NvlPutViaGenericApi) {
-  const std::size_t nbytes = 4096;
-  const std::size_t numInts = nbytes / sizeof(int);
-  const int testValue = 0xCAFE;
-
-  DeviceBuffer srcBuffer(nbytes);
-  DeviceBuffer dstBuffer(nbytes);
-  auto src_d = static_cast<int*>(srcBuffer.get());
-  auto dst_d = static_cast<int*>(dstBuffer.get());
-
-  std::vector<int> srcHost(numInts, testValue);
-  CUDACHECK_TEST(
-      cudaMemcpy(src_d, srcHost.data(), nbytes, cudaMemcpyHostToDevice));
-  CUDACHECK_TEST(cudaMemset(dst_d, 0, nbytes));
-
-  test::testDeviceWindowNvlPut(
-      0,
-      2,
-      reinterpret_cast<char*>(dst_d),
-      reinterpret_cast<const char*>(src_d),
-      nbytes);
-  CUDACHECK_TEST(cudaDeviceSynchronize());
-
-  std::vector<int> dstHost(numInts);
-  CUDACHECK_TEST(
-      cudaMemcpy(dstHost.data(), dst_d, nbytes, cudaMemcpyDeviceToHost));
-
-  const std::vector<int> expected(numInts, testValue);
-  EXPECT_EQ(dstHost, expected) << "Generic NVL put should copy all data";
-}
-
-// =============================================================================
 // Offset-Based NVL Put via DeviceWindow
 // =============================================================================
 

--- a/comms/pipes/tests/DeviceWindowTest.cu
+++ b/comms/pipes/tests/DeviceWindowTest.cu
@@ -344,35 +344,6 @@ void testDeviceWindowReadSignalGroup(
 }
 
 // =============================================================================
-// DeviceWindow NVL Put via Generic API Test
-// =============================================================================
-
-__global__ void nvlPutKernel(
-    DeviceWindow dw,
-    int targetPeerRank,
-    char* remoteDst,
-    const char* localSrc,
-    std::size_t nbytes) {
-  auto group = make_block_group();
-  dw.put(targetPeerRank, group, remoteDst, localSrc, nbytes);
-}
-
-void testDeviceWindowNvlPut(
-    int myRank,
-    int nRanks,
-    char* dst_d,
-    const char* src_d,
-    std::size_t nbytes) {
-  NvlOnlyDeviceWindowBuffers bufs;
-  auto dw = bufs.create(myRank, nRanks, 1);
-
-  int targetPeerRank = (myRank == 0) ? 1 : 0;
-  nvlPutKernel<<<4, 256>>>(dw, targetPeerRank, dst_d, src_d, nbytes);
-  CUDACHECK_TEST(cudaGetLastError());
-  CUDACHECK_TEST(cudaDeviceSynchronize());
-}
-
-// =============================================================================
 // DeviceWindow Offset-Based NVL Put Test
 // =============================================================================
 

--- a/comms/pipes/tests/DeviceWindowTest.cuh
+++ b/comms/pipes/tests/DeviceWindowTest.cuh
@@ -100,19 +100,6 @@ void testDeviceWindowReadSignalGroup(
     uint64_t* results);
 
 /**
- * Test: DeviceWindow NVL put() via generic API
- *
- * Verifies the generic put() dispatches to NVL correctly
- * and copies data between buffers.
- */
-void testDeviceWindowNvlPut(
-    int myRank,
-    int nRanks,
-    char* dst_d,
-    const char* src_d,
-    std::size_t nbytes);
-
-/**
  * Test: DeviceWindow signal_all + read_signal aggregate
  *
  * Verifies signal_all() signals all peers and read_signal()

--- a/comms/pipes/tests/MultiPeerNvlTransportIntegrationTest.cc
+++ b/comms/pipes/tests/MultiPeerNvlTransportIntegrationTest.cc
@@ -1701,7 +1701,6 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, PutSignalOperation) {
     GTEST_SKIP() << "Requires exactly 2 ranks, got " << numRanks;
   }
 
-  // Use a transfer size that fits within the transport's data buffer
   constexpr std::size_t kTransferSize = 4096;
   MultiPeerNvlTransportConfig config{
       .dataBufferSize = kDefaultDataBufferSize,
@@ -1712,69 +1711,66 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, PutSignalOperation) {
       .peerSignalCount = kDefaultSignalCount,
   };
 
-  auto [transport, window, dw] = createTransport(config, wmConfig);
-
   int peerRank = (globalRank == 0) ? 1 : 0;
   const int testValue = 0xCD + globalRank;
 
-  // Get the P2pNvlTransportDevice to access IPC-mapped remote buffers
-  // The transport's remoteState_.dataBuffer is already IPC-mapped
-  auto p2pTransport = transport->get_p2p_nvl_transport_device(peerRank);
-
-  // POINTER RELATIONSHIP CLARIFICATION:
-  //
-  // remoteDataBuffer: This rank's IPC-mapped pointer to the PEER's local
-  // buffer.
-  //                   When this rank writes here, data appears in peer's
-  //                   memory.
-  //
-  // localDataBuffer: This rank's local staging buffer. When the PEER writes to
-  //                  their remoteDataBuffer, the data appears here.
-  //
-  // So for rank 0 writing to rank 1:
-  //   - rank 0's remoteDataBuffer == IPC pointer to rank 1's localDataBuffer
-  //   - rank 0 writes to its remoteDataBuffer
-  //   - rank 1 reads from its localDataBuffer (same physical memory)
-  //
-  char* remoteDataBuffer = p2pTransport.getRemoteState().dataBuffer;
-  char* localDataBuffer = p2pTransport.getLocalState().dataBuffer;
+  // Allocate per-rank window buffer (destination for put operations).
+  // The peer will write into this buffer via NVLink IPC.
+  DeviceBuffer windowBuffer(kTransferSize);
+  auto windowBuf_d = windowBuffer.get();
+  CUDACHECK_TEST(cudaMemset(windowBuf_d, 0, kTransferSize));
 
   // Allocate local source buffer and result buffer
   DeviceBuffer localSrcBuffer(kTransferSize);
   DeviceBuffer resultBuffer(sizeof(int));
-
-  auto localSrc_d = static_cast<int*>(localSrcBuffer.get());
+  auto localSrc_d = localSrcBuffer.get();
   auto result_d = static_cast<int*>(resultBuffer.get());
 
-  // Rank 0: fill local source buffer with test pattern
-  // Rank 1: the local data buffer (destination) will receive the data
+  // Rank 0 (writer): fill source buffer with test pattern
   if (globalRank == 0) {
-    test::fillBuffer(localSrc_d, testValue, kTransferSize / sizeof(int));
+    test::fillBuffer(
+        static_cast<int*>(localSrc_d), testValue, kTransferSize / sizeof(int));
   }
-
-  // Clear the local data buffer (this is where peer will write to via NVLink)
-  CUDACHECK_TEST(cudaMemset(localDataBuffer, 0, kTransferSize));
   CUDACHECK_TEST(cudaMemset(result_d, 0, sizeof(int)));
   CUDACHECK_TEST(cudaDeviceSynchronize());
 
+  // Set up transport + window with buffer registrations.
+  // Cannot use createTransport() helper because we need to register buffers
+  // between exchange() and getDeviceWindow().
+  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  MultiPeerTransportConfig transportConfig{
+      .nvlConfig = config,
+  };
+  auto transport = std::make_unique<MultiPeerTransport>(
+      globalRank, numRanks, localRank, bootstrap, transportConfig);
+  transport->exchange();
+
+  auto window = std::make_unique<HostWindow>(*transport, wmConfig);
+  window->exchange();
+
+  // Register the window buffer as the exchanged destination buffer
+  // (COLLECTIVE: all ranks must call together)
+  window->registerAndExchangeBuffer(windowBuf_d, kTransferSize);
+
+  // Register the source buffer locally (NOT collective)
+  window->registerLocalBuffer(localSrc_d, kTransferSize);
+
+  // Get DeviceWindow after all registrations
+  DeviceWindow dw = window->getDeviceWindow();
+
+  // Build LocalBufferRegistration for the source buffer.
+  // For NVL-only, lkey is unused.
+  LocalBufferRegistration srcBuf{localSrc_d, kTransferSize, NetworkLKey{}};
+
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 
-  // Rank 0 writes to rank 1's buffer using put_signal (via IPC-mapped ptr)
+  // Rank 0 writes to rank 1's window buffer using offset-based put_signal
   // Rank 1 waits for the signal
   bool isWriter = (globalRank == 0);
   constexpr int kSignalId = 0;
 
-  // remoteDataBuffer points to peer's local data buffer (via IPC)
-  // So rank 0's remoteDataBuffer points to rank 1's localDataBuffer
   test::testPutOperation(
-      dw,
-      peerRank,
-      isWriter ? remoteDataBuffer : nullptr, // Write to peer's buffer via IPC
-      isWriter ? localSrc_d : nullptr, // Source is our local data
-      kTransferSize,
-      kSignalId,
-      isWriter,
-      result_d);
+      dw, peerRank, srcBuf, kTransferSize, kSignalId, isWriter, result_d);
   CUDACHECK_TEST(cudaDeviceSynchronize());
 
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
@@ -1787,14 +1783,11 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, PutSignalOperation) {
                          << globalRank;
 
   // Verify data on receiver side
-  // Rank 1's localDataBuffer should now contain the data written by rank 0
+  // Rank 1's window buffer should now contain the data written by rank 0
   if (globalRank == 1) {
     std::vector<int> recvHost(kTransferSize / sizeof(int));
     CUDACHECK_TEST(cudaMemcpy(
-        recvHost.data(),
-        localDataBuffer,
-        kTransferSize,
-        cudaMemcpyDeviceToHost));
+        recvHost.data(), windowBuf_d, kTransferSize, cudaMemcpyDeviceToHost));
 
     const int expectedValue = 0xCD + 0; // Sender's testValue (rank 0)
     std::vector<int> expected(kTransferSize / sizeof(int), expectedValue);

--- a/comms/pipes/tests/MultiPeerNvlTransportIntegrationTest.cu
+++ b/comms/pipes/tests/MultiPeerNvlTransportIntegrationTest.cu
@@ -210,8 +210,7 @@ void testConcurrentSignalMultiBlock(
 __global__ void putOperationKernel(
     DeviceWindow& dw,
     int targetRank,
-    void* remoteDst,
-    const void* localSrc,
+    LocalBufferRegistration srcBuf,
     std::size_t nbytes,
     int signalId,
     bool isWriter,
@@ -219,7 +218,7 @@ __global__ void putOperationKernel(
   auto group = make_warp_group();
 
   if (isWriter) {
-    dw.put_signal(targetRank, group, remoteDst, localSrc, nbytes, signalId, 1);
+    dw.put_signal(group, targetRank, 0, srcBuf, 0, nbytes, signalId, 1);
   } else {
     dw.wait_signal(group, signalId, CmpOp::CMP_GE, 1);
   }
@@ -232,14 +231,13 @@ __global__ void putOperationKernel(
 void testPutOperation(
     DeviceWindow& dw,
     int targetRank,
-    void* remoteDst,
-    const void* localSrc,
+    const LocalBufferRegistration& srcBuf,
     std::size_t nbytes,
     int signalId,
     bool isWriter,
     int* result) {
   putOperationKernel<<<1, 32>>>(
-      dw, targetRank, remoteDst, localSrc, nbytes, signalId, isWriter, result);
+      dw, targetRank, srcBuf, nbytes, signalId, isWriter, result);
   CUDACHECK_TEST(cudaGetLastError());
 }
 

--- a/comms/pipes/tests/MultiPeerNvlTransportIntegrationTest.cuh
+++ b/comms/pipes/tests/MultiPeerNvlTransportIntegrationTest.cuh
@@ -324,12 +324,11 @@ void testBarrierPeer(
     int* result);
 
 /**
- * Test kernel: Test the put() operation
+ * Test kernel: Test the put() operation (offset-based)
  *
  * @param dw The DeviceWindow to use
  * @param targetRank Target rank
- * @param remoteDst Remote destination buffer
- * @param localSrc Local source buffer
+ * @param srcBuf Registered source buffer
  * @param nbytes Number of bytes to transfer
  * @param signalId Signal slot to use for completion notification
  * @param isWriter True if this rank writes, false if it waits
@@ -338,8 +337,7 @@ void testBarrierPeer(
 void testPutOperation(
     DeviceWindow& dw,
     int targetRank,
-    void* remoteDst,
-    const void* localSrc,
+    const LocalBufferRegistration& srcBuf,
     std::size_t nbytes,
     int signalId,
     bool isWriter,

--- a/comms/pipes/window/DeviceWindow.cuh
+++ b/comms/pipes/window/DeviceWindow.cuh
@@ -906,59 +906,6 @@ class DeviceWindow {
   }
 
   // ===========================================================================
-  // Put (generic — dispatches to NVL or IBGDA internally)
-  // ===========================================================================
-
-  /**
-   * put - One-sided write to a peer's remote buffer.
-   *
-   * Group-level API: all threads in the group must call this together.
-   * Dispatches internally based on peer transport type:
-   * - NVL: direct vectorized memcpy over NVLink (no staging buffer)
-   * - IBGDA: RDMA Write via NIC (lkey/rkey resolved from registration table)
-   *
-   * NOTE: This does NOT use the NVL staging buffer allocated by
-   * MultiPeerNvlTransportConfig.dataBufferSize. The staging buffer is
-   * only used by P2pNvlTransportDevice::send()/recv().
-   *
-   * PRECONDITION: localSrc must be within a buffer registered via
-   * HostWindow::registerLocalBuffer() or registerAndExchangeBuffer().
-   * remoteDst must be within a buffer exchanged via
-   * HostWindow::registerAndExchangeBuffer() on the target peer.
-   *
-   * @param target_rank  Rank to put to (must not be self).
-   * @param group        ThreadGroup for group coordination.
-   * @param remoteDst    Destination buffer on the target peer.
-   * @param localSrc     Source buffer on this rank.
-   * @param nbytes       Number of bytes to transfer.
-   */
-  __device__ __forceinline__ void put(
-      int target_rank,
-      ThreadGroup& group,
-      void* remoteDst,
-      const void* localSrc,
-      std::size_t nbytes) {
-    DEVICE_WINDOW_CHECK_RANK(target_rank, handle_.nRanks);
-    DEVICE_WINDOW_CHECK_NOT_SELF(target_rank, handle_.myRank);
-    if (handle_.get_type(target_rank) == TransportType::P2P_NVL) {
-      handle_.get_nvl(target_rank)
-          .put(
-              group,
-              static_cast<char*>(remoteDst),
-              static_cast<const char*>(localSrc),
-              nbytes);
-    } else {
-      int ibgdaIdx = rank_to_peer_index(target_rank);
-      IbgdaLocalBuffer localBuf(
-          const_cast<void*>(localSrc), lookupLocalLkey(localSrc));
-      IbgdaRemoteBuffer remoteBuf(
-          remoteDst, lookupRemoteRkey(ibgdaIdx, remoteDst));
-      handle_.get_ibgda(target_rank)
-          .put_group_global(group, localBuf, remoteBuf, nbytes);
-    }
-  }
-
-  // ===========================================================================
   // Put (offset-based — destination is window buffer, source is registered buf)
   // ===========================================================================
 
@@ -1002,73 +949,6 @@ class DeviceWindow {
       handle_.get_ibgda(target_rank)
           .put_group_global(
               group, localBuf, remoteBuf.subBuffer(dst_offset), nbytes);
-    }
-  }
-
-  // ===========================================================================
-  // Combined Put + Signal (generic — dispatches to NVL or IBGDA internally)
-  // ===========================================================================
-
-  /**
-   * put_signal - One-sided write + signal to a peer.
-   *
-   * Group-level API: all threads in the group must call this together.
-   * Dispatches internally:
-   * - NVL: vectorized memcpy + group.sync() + atomic signal via NVLink
-   * - IBGDA: RDMA Write + NIC-fenced atomic signal (HW-ordered),
-   *   single signal from global leader to match NVL semantics.
-   *
-   * PRECONDITION: localSrc must be within a buffer registered via
-   * HostWindow::registerLocalBuffer() or registerAndExchangeBuffer().
-   * remoteDst must be within a buffer exchanged via
-   * HostWindow::registerAndExchangeBuffer() on the target peer.
-   *
-   * @param target_rank  Rank to put to (must not be self).
-   * @param group        ThreadGroup for group coordination.
-   * @param remoteDst    Destination buffer on the target peer.
-   * @param localSrc     Source buffer on this rank.
-   * @param nbytes       Number of bytes to transfer.
-   * @param signalId     Signal slot index in [0, peerSignalCount).
-   * @param signalVal    Value to add to the signal (default: 1).
-   */
-  __device__ __forceinline__ void put_signal(
-      int target_rank,
-      ThreadGroup& group,
-      void* remoteDst,
-      const void* localSrc,
-      std::size_t nbytes,
-      int signalId,
-      uint64_t signalVal = 1) {
-    DEVICE_WINDOW_CHECK_RANK(target_rank, handle_.nRanks);
-    DEVICE_WINDOW_CHECK_NOT_SELF(target_rank, handle_.myRank);
-    if (handle_.get_type(target_rank) == TransportType::P2P_NVL) {
-      handle_.get_nvl(target_rank)
-          .put(
-              group,
-              static_cast<char*>(remoteDst),
-              static_cast<const char*>(localSrc),
-              nbytes);
-      signal_peer(
-          group, target_rank, signalId, SignalOp::SIGNAL_ADD, signalVal);
-      group.sync();
-    } else {
-      int ibgdaIdx = rank_to_peer_index(target_rank);
-      IbgdaLocalBuffer localBuf(
-          const_cast<void*>(localSrc), lookupLocalLkey(localSrc));
-      IbgdaRemoteBuffer remoteBuf(
-          remoteDst, lookupRemoteRkey(ibgdaIdx, remoteDst));
-      handle_.get_ibgda(target_rank)
-          .put_group_global(group, localBuf, remoteBuf, nbytes);
-      // Single fenced signal from global leader (matches NVL semantics)
-      if (group.is_global_leader()) {
-        // Remote buffer is pre-offset to "my row" in the peer's inbox
-        // (computed once at exchange time in HostWindow), so signalId
-        // is the only offset needed here.
-        handle_.get_ibgda(target_rank)
-            .signal_remote_with_fence(
-                ibgdaPeerSignalRemoteBufs_[ibgdaIdx], signalId, signalVal);
-      }
-      group.sync();
     }
   }
 
@@ -1123,12 +1003,12 @@ class DeviceWindow {
       handle_.get_ibgda(target_rank)
           .put_group_global(
               group, localBuf, remoteBuf.subBuffer(dst_offset), nbytes);
-      // Single fenced signal from global leader (matches NVL semantics)
-      if (group.is_global_leader()) {
-        handle_.get_ibgda(target_rank)
-            .signal_remote_with_fence(
-                ibgdaPeerSignalRemoteBufs_[ibgdaPeerIdx], signalId, signalVal);
-      }
+      handle_.get_ibgda(target_rank)
+          .signal_remote_with_fence(
+              group,
+              ibgdaPeerSignalRemoteBufs_[ibgdaPeerIdx],
+              signalId,
+              signalVal);
       group.sync();
     }
   }
@@ -1167,69 +1047,6 @@ class DeviceWindow {
     return false;
   }
 
-  /**
-   * Lookup local lkey for a source pointer from the registration table.
-   * Linear scan over registered buffers (typically 1-5 entries).
-   * Traps if pointer is not in any registered buffer.
-   */
-  __device__ __forceinline__ NetworkLKey
-  lookupLocalLkey(const void* ptr) const {
-    const auto* p = static_cast<const char*>(ptr);
-    for (int i = 0; i < static_cast<int>(localBufferRegistry_.size()); ++i) {
-      const auto& reg = localBufferRegistry_[i];
-      const auto* base = static_cast<const char*>(reg.base);
-      if (p >= base && p < base + reg.size) {
-        return reg.lkey;
-      }
-    }
-    printf(
-        "DeviceWindow: localSrc %p not in any registered buffer"
-        " at %s:%d block=(%u,%u,%u) thread=(%u,%u,%u)\n",
-        ptr,
-        __FILE__,
-        __LINE__,
-        blockIdx.x,
-        blockIdx.y,
-        blockIdx.z,
-        threadIdx.x,
-        threadIdx.y,
-        threadIdx.z);
-    __trap();
-    return NetworkLKey{};
-  }
-
-  /**
-   * Lookup remote rkey for a destination pointer on a specific IBGDA peer.
-   * There is exactly one exchanged dst buffer per DeviceWindow, so this
-   * is a direct peer-index lookup (no iteration).
-   * Traps if pointer is not within the exchanged buffer for that peer.
-   */
-  __device__ __forceinline__ NetworkRKey
-  lookupRemoteRkey(int ibgdaPeerIdx, const void* remotePtr) const {
-    if (remoteBufferRegistry_.size() > 0) {
-      const auto& reg = remoteBufferRegistry_[ibgdaPeerIdx];
-      const auto* base = static_cast<const char*>(reg.base);
-      const auto* p = static_cast<const char*>(remotePtr);
-      if (p >= base && p < base + reg.size) {
-        return reg.rkey;
-      }
-    }
-    printf(
-        "DeviceWindow: remoteDst %p not registered for IBGDA peer %d"
-        " at %s:%d block=(%u,%u,%u) thread=(%u,%u,%u)\n",
-        remotePtr,
-        ibgdaPeerIdx,
-        __FILE__,
-        __LINE__,
-        blockIdx.x,
-        blockIdx.y,
-        blockIdx.z,
-        threadIdx.x,
-        threadIdx.y,
-        threadIdx.z);
-    __trap();
-    return NetworkRKey{};
-  }
 #endif // __CUDACC__
 
   // Transport handle (provides get_type, get_nvl, get_ibgda, myRank, nRanks)


### PR DESCRIPTION
Summary:

Migrate all callers of the old pointer-based `put()`/`put_signal()` on
`DeviceWindow` to the new offset-based API (from D96341520), then remove
the old overloads.

Also adds a group-aware `signal_remote_with_fence(group, ...)` overload to
`P2pIbgdaTransportDevice`, unifying the IBGDA signal path with NVL's
group-aware pattern. Previously, IBGDA callers had to manually check
`is_global_leader()` before calling the thread-level signal, while NVL
uses `signal_peer(group, ...)` which handles this internally.

Changes:
- `DeviceWindow.cuh`: Remove old pointer-based `put()` and `put_signal()`
  overloads, plus now-unused `lookupLocalLkey()` and `lookupRemoteRkey()`
  helper methods (~195 lines removed).
- `P2pIbgdaTransportDevice.cuh`: Add group-aware
  `signal_remote_with_fence(ThreadGroup&, ...)` that does `group.sync()`
  + `is_global_leader()` internally.
- `DeviceWindow.cuh` (put_signal IBGDA path): Use the new group-aware
  `signal_remote_with_fence(group, ...)` instead of manual
  `is_global_leader()` checks.
- `MultiPeerBenchmark.{cu,cuh}`: Migrate put ping-pong and put+signal
  ping-pong kernels to offset-based API with `LocalBufferRegistration`.
- `MultiPeerNvlTransportIntegrationTest.{cc,cu,cuh}`: Migrate
  `putOperationKernel`/`testPutOperation` to offset-based API. Update
  host-side `PutSignalOperation` test to use `registerAndExchangeBuffer`
  + `registerLocalBuffer` instead of raw IPC pointers.
- `DeviceWindowTest.{cc,cu,cuh}`: Remove old `NvlPutViaGenericApi` test
  (superseded by offset-based tests).

Reviewed By: cenzhaometa

Differential Revision: D96835610
