### PR TITLE
Expose Pipes transport (MultiPeerDeviceHandle) through TorchCommNCCLX (#1124)

### DIFF
--- a/comms/ncclx/v2_27/meta/rma/transport.cc
+++ b/comms/ncclx/v2_27/meta/rma/transport.cc
@@ -1,0 +1,58 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// Pipes transport API implementations (non-window transport operations).
+
+#if defined(ENABLE_PIPES)
+
+#include "checks.h"
+#include "comm.h"
+#include "comms/ctran/Ctran.h"
+#include "comms/pipes/MultiPeerDeviceHandle.cuh"
+#include "comms/pipes/MultiPeerTransport.h"
+
+#include "nccl.h"
+
+NCCL_API(
+    ncclResult_t,
+    ncclGetMultiPeerDeviceHandle,
+    ncclComm_t comm,
+    void** outTransportsPtr,
+    int* outMyRank,
+    int* outNRanks,
+    int* outNumNvlPeers,
+    int* outNumIbPeers);
+ncclResult_t ncclGetMultiPeerDeviceHandle(
+    ncclComm_t comm,
+    void** outTransportsPtr,
+    int* outMyRank,
+    int* outNRanks,
+    int* outNumNvlPeers,
+    int* outNumIbPeers) {
+  if (comm == nullptr || outTransportsPtr == nullptr || outMyRank == nullptr ||
+      outNRanks == nullptr || outNumNvlPeers == nullptr ||
+      outNumIbPeers == nullptr) {
+    return ncclInvalidArgument;
+  }
+
+  if (!ctranInitialized(comm->ctranComm_.get())) {
+    WARN("ncclGetMultiPeerDeviceHandle: ctran not initialized");
+    return ncclInternalError;
+  }
+
+  auto* mpt = comm->ctranComm_->multiPeerTransport_.get();
+  if (mpt == nullptr) {
+    WARN(
+        "ncclGetMultiPeerDeviceHandle: MultiPeerTransport not initialized. "
+        "Set NCCL_CTRAN_USE_PIPES=1");
+    return ncclInternalError;
+  }
+
+  auto handle = mpt->get_device_handle();
+  *outTransportsPtr = handle.transports.data();
+  *outMyRank = handle.myRank;
+  *outNRanks = handle.nRanks;
+  *outNumNvlPeers = handle.numNvlPeers;
+  *outNumIbPeers = handle.numIbPeers;
+  return ncclSuccess;
+}
+
+#endif // ENABLE_PIPES

--- a/comms/ncclx/v2_27/src/nccl.h.in
+++ b/comms/ncclx/v2_27/src/nccl.h.in
@@ -762,6 +762,24 @@ ncclResult_t ncclWinCreateDeviceWin(
  * Free device memory allocated by ncclWinCreateDeviceWin.
  */
 ncclResult_t ncclWinDestroyDeviceWin(void* devicePtr);
+
+/*
+ * Get the MultiPeerDeviceHandle components from the communicator's
+ * pipes transport. NON-COLLECTIVE — reads already-exchanged state.
+ *
+ * Returns the device pointer to the Transport[] array and metadata.
+ * The caller assembles a MultiPeerDeviceHandle from these fields.
+ *
+ * Requires NCCL_CTRAN_USE_PIPES=1 during communicator init.
+ * Returns ncclInternalError if pipes transport is not initialized.
+ */
+ncclResult_t ncclGetMultiPeerDeviceHandle(
+    ncclComm_t comm,
+    void** outTransportsPtr,
+    int* outMyRank,
+    int* outNRanks,
+    int* outNumNvlPeers,
+    int* outNumIbPeers);
 #endif // ENABLE_PIPES
 
 /*

--- a/comms/ncclx/v2_28/meta/rma/transport.cc
+++ b/comms/ncclx/v2_28/meta/rma/transport.cc
@@ -1,0 +1,58 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// Pipes transport API implementations (non-window transport operations).
+
+#if defined(ENABLE_PIPES)
+
+#include "checks.h"
+#include "comm.h"
+#include "comms/ctran/Ctran.h"
+#include "comms/pipes/MultiPeerDeviceHandle.cuh"
+#include "comms/pipes/MultiPeerTransport.h"
+
+#include "nccl.h"
+
+NCCL_API(
+    ncclResult_t,
+    ncclGetMultiPeerDeviceHandle,
+    ncclComm_t comm,
+    void** outTransportsPtr,
+    int* outMyRank,
+    int* outNRanks,
+    int* outNumNvlPeers,
+    int* outNumIbPeers);
+ncclResult_t ncclGetMultiPeerDeviceHandle(
+    ncclComm_t comm,
+    void** outTransportsPtr,
+    int* outMyRank,
+    int* outNRanks,
+    int* outNumNvlPeers,
+    int* outNumIbPeers) {
+  if (comm == nullptr || outTransportsPtr == nullptr || outMyRank == nullptr ||
+      outNRanks == nullptr || outNumNvlPeers == nullptr ||
+      outNumIbPeers == nullptr) {
+    return ncclInvalidArgument;
+  }
+
+  if (!ctranInitialized(comm->ctranComm_.get())) {
+    WARN("ncclGetMultiPeerDeviceHandle: ctran not initialized");
+    return ncclInternalError;
+  }
+
+  auto* mpt = comm->ctranComm_->multiPeerTransport_.get();
+  if (mpt == nullptr) {
+    WARN(
+        "ncclGetMultiPeerDeviceHandle: MultiPeerTransport not initialized. "
+        "Set NCCL_CTRAN_USE_PIPES=1");
+    return ncclInternalError;
+  }
+
+  auto handle = mpt->get_device_handle();
+  *outTransportsPtr = handle.transports.data();
+  *outMyRank = handle.myRank;
+  *outNRanks = handle.nRanks;
+  *outNumNvlPeers = handle.numNvlPeers;
+  *outNumIbPeers = handle.numIbPeers;
+  return ncclSuccess;
+}
+
+#endif // ENABLE_PIPES

--- a/comms/ncclx/v2_28/src/nccl.h.in
+++ b/comms/ncclx/v2_28/src/nccl.h.in
@@ -839,6 +839,24 @@ ncclResult_t ncclWinCreateDeviceWin(
  * Free device memory allocated by ncclWinCreateDeviceWin.
  */
 ncclResult_t ncclWinDestroyDeviceWin(void* devicePtr);
+
+/*
+ * Get the MultiPeerDeviceHandle components from the communicator's
+ * pipes transport. NON-COLLECTIVE — reads already-exchanged state.
+ *
+ * Returns the device pointer to the Transport[] array and metadata.
+ * The caller assembles a MultiPeerDeviceHandle from these fields.
+ *
+ * Requires NCCL_CTRAN_USE_PIPES=1 during communicator init.
+ * Returns ncclInternalError if pipes transport is not initialized.
+ */
+ncclResult_t ncclGetMultiPeerDeviceHandle(
+    ncclComm_t comm,
+    void** outTransportsPtr,
+    int* outMyRank,
+    int* outNRanks,
+    int* outNumNvlPeers,
+    int* outNumIbPeers);
 #endif // ENABLE_PIPES
 
 /*

--- a/comms/ncclx/v2_29/meta/rma/transport.cc
+++ b/comms/ncclx/v2_29/meta/rma/transport.cc
@@ -1,0 +1,58 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// Pipes transport API implementations (non-window transport operations).
+
+#if defined(ENABLE_PIPES)
+
+#include "checks.h"
+#include "comm.h"
+#include "comms/ctran/Ctran.h"
+#include "comms/pipes/MultiPeerDeviceHandle.cuh"
+#include "comms/pipes/MultiPeerTransport.h"
+
+#include "nccl.h"
+
+NCCL_API(
+    ncclResult_t,
+    ncclGetMultiPeerDeviceHandle,
+    ncclComm_t comm,
+    void** outTransportsPtr,
+    int* outMyRank,
+    int* outNRanks,
+    int* outNumNvlPeers,
+    int* outNumIbPeers);
+ncclResult_t ncclGetMultiPeerDeviceHandle(
+    ncclComm_t comm,
+    void** outTransportsPtr,
+    int* outMyRank,
+    int* outNRanks,
+    int* outNumNvlPeers,
+    int* outNumIbPeers) {
+  if (comm == nullptr || outTransportsPtr == nullptr || outMyRank == nullptr ||
+      outNRanks == nullptr || outNumNvlPeers == nullptr ||
+      outNumIbPeers == nullptr) {
+    return ncclInvalidArgument;
+  }
+
+  if (!ctranInitialized(comm->ctranComm_.get())) {
+    WARN("ncclGetMultiPeerDeviceHandle: ctran not initialized");
+    return ncclInternalError;
+  }
+
+  auto* mpt = comm->ctranComm_->multiPeerTransport_.get();
+  if (mpt == nullptr) {
+    WARN(
+        "ncclGetMultiPeerDeviceHandle: MultiPeerTransport not initialized. "
+        "Set NCCL_CTRAN_USE_PIPES=1");
+    return ncclInternalError;
+  }
+
+  auto handle = mpt->get_device_handle();
+  *outTransportsPtr = handle.transports.data();
+  *outMyRank = handle.myRank;
+  *outNRanks = handle.nRanks;
+  *outNumNvlPeers = handle.numNvlPeers;
+  *outNumIbPeers = handle.numIbPeers;
+  return ncclSuccess;
+}
+
+#endif // ENABLE_PIPES

--- a/comms/ncclx/v2_29/src/nccl.h.in
+++ b/comms/ncclx/v2_29/src/nccl.h.in
@@ -993,6 +993,24 @@ ncclResult_t ncclWinCreateDeviceWin(
  * Free device memory allocated by ncclWinCreateDeviceWin.
  */
 ncclResult_t ncclWinDestroyDeviceWin(void* devicePtr);
+
+/*
+ * Get the MultiPeerDeviceHandle components from the communicator's
+ * pipes transport. NON-COLLECTIVE — reads already-exchanged state.
+ *
+ * Returns the device pointer to the Transport[] array and metadata.
+ * The caller assembles a MultiPeerDeviceHandle from these fields.
+ *
+ * Requires NCCL_CTRAN_USE_PIPES=1 during communicator init.
+ * Returns ncclInternalError if pipes transport is not initialized.
+ */
+ncclResult_t ncclGetMultiPeerDeviceHandle(
+    ncclComm_t comm,
+    void** outTransportsPtr,
+    int* outMyRank,
+    int* outNRanks,
+    int* outNumNvlPeers,
+    int* outNumIbPeers);
 #endif // ENABLE_PIPES
 
 /*

--- a/comms/torchcomms/device/pipes/PipesDeviceBackend.cpp
+++ b/comms/torchcomms/device/pipes/PipesDeviceBackend.cpp
@@ -4,6 +4,7 @@
 #if defined(ENABLE_PIPES)
 
 #include "comms/torchcomms/device/pipes/PipesDeviceBackend.hpp"
+#include "comms/pipes/MultiPeerDeviceHandle.cuh"
 #include "comms/torchcomms/device/DeviceBackendTraits.hpp"
 #include "comms/torchcomms/device/TorchCommDeviceWindow.hpp"
 #include "comms/torchcomms/device/cuda/CudaApi.hpp"
@@ -138,6 +139,45 @@ PipesDeviceBackend::Ptr PipesDeviceBackend::create_device_window(
 
   DeviceWindowDeleter deleter(nccl_api, cuda_api, pipes_device_win);
   return Ptr(device_ptr, deleter);
+}
+
+// =============================================================================
+// get_device_transport Implementation
+// =============================================================================
+
+comms::pipes::MultiPeerDeviceHandle PipesDeviceBackend::get_device_transport(
+    ncclComm_t nccl_comm,
+    torch::comms::NcclxApi* nccl_api) {
+  void* transports_ptr = nullptr;
+  int my_rank = -1;
+  int n_ranks = 0;
+  int num_nvl_peers = 0;
+  int num_ib_peers = 0;
+
+  auto result = nccl_api->getMultiPeerDeviceHandle(
+      nccl_comm,
+      &transports_ptr,
+      &my_rank,
+      &n_ranks,
+      &num_nvl_peers,
+      &num_ib_peers);
+
+  if (result != ncclSuccess) {
+    throw std::runtime_error(
+        "[PipesDeviceBackend::get_device_transport] "
+        "Failed to get MultiPeerDeviceHandle. "
+        "Ensure NCCL_CTRAN_USE_PIPES=1 is set.");
+  }
+
+  return comms::pipes::MultiPeerDeviceHandle{
+      my_rank,
+      n_ranks,
+      {static_cast<comms::pipes::Transport*>(transports_ptr),
+       static_cast<
+           comms::pipes::DeviceSpan<comms::pipes::Transport>::size_type>(
+           n_ranks)},
+      num_nvl_peers,
+      num_ib_peers};
 }
 
 } // namespace torchcomms::device

--- a/comms/torchcomms/device/pipes/PipesDeviceBackend.hpp
+++ b/comms/torchcomms/device/pipes/PipesDeviceBackend.hpp
@@ -23,6 +23,7 @@
 
 namespace comms::pipes {
 class DeviceWindow;
+struct MultiPeerDeviceHandle;
 } // namespace comms::pipes
 
 namespace torch::comms {
@@ -148,6 +149,18 @@ struct PipesDeviceBackend {
         "[TorchCommWindowNCCLX][Pipes]: register_local_buffer is not yet "
         "supported for PipesDeviceBackend.");
   }
+
+  // Get the pipes transport device handle from the communicator.
+  // NON-COLLECTIVE — reads already-exchanged state.
+  //
+  // Returns a MultiPeerDeviceHandle by value. The handle contains a
+  // device pointer to the Transport[] array (already GPU-allocated by
+  // MultiPeerTransport::exchange() during ctran init).
+  //
+  // Throws std::runtime_error if pipes transport is not initialized.
+  static comms::pipes::MultiPeerDeviceHandle get_device_transport(
+      ncclComm_t nccl_comm,
+      torch::comms::NcclxApi* nccl_api);
 };
 
 } // namespace torchcomms::device

--- a/comms/torchcomms/ncclx/NcclxApi.cpp
+++ b/comms/torchcomms/ncclx/NcclxApi.cpp
@@ -539,6 +539,22 @@ ncclResult_t DefaultNcclxApi::winCreateDeviceWin(
 ncclResult_t DefaultNcclxApi::winDestroyDeviceWin(void* devicePtr) {
   return ncclWinDestroyDeviceWin(devicePtr);
 }
+
+ncclResult_t DefaultNcclxApi::getMultiPeerDeviceHandle(
+    ncclComm_t comm,
+    void** outTransportsPtr,
+    int* outMyRank,
+    int* outNRanks,
+    int* outNumNvlPeers,
+    int* outNumIbPeers) {
+  return ncclGetMultiPeerDeviceHandle(
+      comm,
+      outTransportsPtr,
+      outMyRank,
+      outNRanks,
+      outNumNvlPeers,
+      outNumIbPeers);
+}
 #endif // ENABLE_PIPES
 
 #ifdef TORCHCOMMS_HAS_NCCL_DEVICE_API

--- a/comms/torchcomms/ncclx/NcclxApi.hpp
+++ b/comms/torchcomms/ncclx/NcclxApi.hpp
@@ -335,6 +335,17 @@ class NcclxApi {
 
   // Free device memory allocated by winCreateDeviceWin.
   virtual ncclResult_t winDestroyDeviceWin(void* devicePtr) = 0;
+
+  // Get pipes transport device handle components from the communicator.
+  // NON-COLLECTIVE — reads already-exchanged state.
+  // Returns ncclInternalError if pipes transport is not initialized.
+  virtual ncclResult_t getMultiPeerDeviceHandle(
+      ncclComm_t comm,
+      void** outTransportsPtr,
+      int* outMyRank,
+      int* outNRanks,
+      int* outNumNvlPeers,
+      int* outNumIbPeers) = 0;
 #endif
 
   // Group operations
@@ -628,6 +639,13 @@ class DefaultNcclxApi : public NcclxApi {
       int barrier_count,
       void** outDevicePtr) override;
   ncclResult_t winDestroyDeviceWin(void* devicePtr) override;
+  ncclResult_t getMultiPeerDeviceHandle(
+      ncclComm_t comm,
+      void** outTransportsPtr,
+      int* outMyRank,
+      int* outNRanks,
+      int* outNumNvlPeers,
+      int* outNumIbPeers) override;
 #endif
 
   // Group operations

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -21,6 +21,10 @@
 #include "comms/torchcomms/utils/TracingGuard.hpp"
 #include "comms/torchcomms/utils/Utils.hpp"
 
+#if defined(ENABLE_PIPES)
+#include "comms/torchcomms/device/pipes/PipesDeviceBackend.hpp"
+#endif
+
 namespace torch::comms {
 
 namespace {
@@ -2392,5 +2396,12 @@ class NCCLXRegistration {
 
 static const NCCLXRegistration registration{};
 } // namespace
+
+#if defined(ENABLE_PIPES)
+::comms::pipes::MultiPeerDeviceHandle TorchCommNCCLX::get_device_transport() {
+  return torchcomms::device::PipesDeviceBackend::get_device_transport(
+      nccl_comm_, nccl_api_.get());
+}
+#endif
 
 } // namespace torch::comms

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
@@ -25,6 +25,10 @@
 #include "comms/torchcomms/ncclx/TorchCommWindowNCCLX.hpp"
 #include "comms/torchcomms/ncclx/TorchWorkNCCLX.hpp"
 
+#if defined(ENABLE_PIPES)
+#include "comms/pipes/MultiPeerDeviceHandle.cuh"
+#endif
+
 namespace torch::comms {
 
 // Hint key names for NCCLX backend configuration
@@ -296,6 +300,19 @@ class TorchCommNCCLX : public TorchCommBackend,
   const at::Device& getDevice() const override {
     return device_;
   }
+
+#if defined(ENABLE_PIPES)
+  // Get the pipes transport device handle for passing to CUDA kernels.
+  // NON-COLLECTIVE — reads already-exchanged state.
+  //
+  // Usage:
+  //   auto handle = ncclx_comm->get_device_transport();
+  //   myKernel<<<grid, block>>>(handle, ...);
+  //   // In kernel: handle.get_nvl(peer).send(group, src, nbytes);
+  //
+  // Throws std::runtime_error if pipes transport is not initialized.
+  ::comms::pipes::MultiPeerDeviceHandle get_device_transport();
+#endif
 
  protected:
   // Event management for friend classes

--- a/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.hpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.hpp
@@ -352,6 +352,16 @@ class NcclxMock : public NcclxApi {
        void** outDevicePtr),
       (override));
   MOCK_METHOD(ncclResult_t, winDestroyDeviceWin, (void* devicePtr), (override));
+  MOCK_METHOD(
+      ncclResult_t,
+      getMultiPeerDeviceHandle,
+      (ncclComm_t comm,
+       void** outTransportsPtr,
+       int* outMyRank,
+       int* outNRanks,
+       int* outNumNvlPeers,
+       int* outNumIbPeers),
+      (override));
 #endif
 
   // Group operations

--- a/comms/torchcomms/tests/integration/cpp/PipesTransportApiTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/PipesTransportApiTest.cpp
@@ -1,0 +1,157 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// TorchComms Pipes Transport API Integration Test
+
+#include "PipesTransportApiTest.hpp"
+
+#include <gtest/gtest.h>
+#include <algorithm>
+#include "PipesTransportApiTestKernels.cuh"
+#include "TorchCommTestHelpers.h"
+#include "comms/torchcomms/TorchComm.hpp"
+#include "comms/torchcomms/ncclx/TorchCommNCCLX.hpp"
+
+#include "comms/pipes/MultiPeerDeviceHandle.cuh"
+
+#include <cuda_runtime.h>
+#include <cstring>
+#include <vector>
+
+std::unique_ptr<TorchCommTestWrapper> PipesTransportApiTest::createWrapper() {
+  return std::make_unique<TorchCommTestWrapper>();
+}
+
+void PipesTransportApiTest::SetUp() {
+  // Check skip condition FIRST, before any initialization
+  if (checkIfSkip()) {
+    GTEST_SKIP() << "Skipping Pipes Transport API tests "
+                    "(RUN_PIPES_TRANSPORT_API_TEST not set)";
+  }
+
+  wrapper_ = createWrapper();
+  torchcomm_ = wrapper_->getTorchComm();
+  rank_ = torchcomm_->getRank();
+  num_ranks_ = torchcomm_->getSize();
+  int device_count = 0;
+  cudaGetDeviceCount(&device_count);
+  device_index_ = (device_count > 0) ? rank_ % device_count : 0;
+}
+
+void PipesTransportApiTest::TearDown() {
+  torchcomm_.reset();
+  wrapper_.reset();
+}
+
+bool PipesTransportApiTest::checkIfSkip() {
+  // Check RUN_PIPES_TRANSPORT_API_TEST env var
+  const char* run_env = getenv("RUN_PIPES_TRANSPORT_API_TEST");
+  if (!run_env) {
+    return true; // skip if not set
+  }
+  std::string val(run_env);
+  std::transform(val.begin(), val.end(), val.begin(), ::tolower);
+  if (val != "1" && val != "true") {
+    return true; // skip if not enabled
+  }
+
+  return false;
+}
+
+// =============================================================================
+// Get Device Transport Test
+// =============================================================================
+// Validates that TorchCommNCCLX::get_device_transport() returns a valid
+// MultiPeerDeviceHandle with correct rank info and non-null transport array.
+
+void PipesTransportApiTest::testGetDeviceTransport() {
+  SCOPED_TRACE(::testing::Message() << "Testing get_device_transport()");
+
+  auto ncclx = std::dynamic_pointer_cast<torch::comms::TorchCommNCCLX>(
+      torchcomm_->getBackendImpl());
+  ASSERT_NE(ncclx, nullptr) << "Backend is not TorchCommNCCLX";
+
+  try {
+    auto handle = ncclx->get_device_transport();
+    EXPECT_EQ(handle.myRank, rank_);
+    EXPECT_EQ(handle.nRanks, num_ranks_);
+    EXPECT_NE(handle.transports.data(), nullptr);
+    EXPECT_GE(handle.numNvlPeers, 0);
+    EXPECT_GE(handle.numIbPeers, 0);
+  } catch (const std::runtime_error& e) {
+    GTEST_SKIP() << "Pipes transport not available: " << e.what();
+  }
+}
+
+TEST_F(PipesTransportApiTest, GetDeviceTransport) {
+  testGetDeviceTransport();
+}
+
+// =============================================================================
+// NVL Send/Recv Test
+// =============================================================================
+// Rank 0 sends a buffer filled with 0x42 to rank 1 via NVLink transport.
+// Rank 1 verifies the received data matches.
+// Requires at least 2 ranks and NVL peers.
+
+void PipesTransportApiTest::testNvlSendRecv(size_t nbytes) {
+  SCOPED_TRACE(
+      ::testing::Message() << "Testing NVL send/recv with nbytes=" << nbytes);
+
+  ASSERT_GE(num_ranks_, 2) << "Need at least 2 ranks for send/recv test";
+
+  auto ncclx = std::dynamic_pointer_cast<torch::comms::TorchCommNCCLX>(
+      torchcomm_->getBackendImpl());
+  ASSERT_NE(ncclx, nullptr) << "Backend is not TorchCommNCCLX";
+
+  auto handle = ncclx->get_device_transport();
+
+  if (handle.numNvlPeers == 0) {
+    GTEST_SKIP() << "No NVL peers available — send/recv requires NVLink";
+  }
+
+  void* buf_d = nullptr;
+  auto cuda_err = cudaMalloc(&buf_d, nbytes);
+  ASSERT_EQ(cuda_err, cudaSuccess) << "cudaMalloc failed";
+
+  int peer = (rank_ == 0) ? 1 : 0;
+
+  if (rank_ == 0) {
+    cuda_err = cudaMemset(buf_d, 0x42, nbytes);
+    ASSERT_EQ(cuda_err, cudaSuccess);
+  } else {
+    cuda_err = cudaMemset(buf_d, 0x00, nbytes);
+    ASSERT_EQ(cuda_err, cudaSuccess);
+  }
+
+  torchcomm_->barrier(false);
+
+  if (rank_ == 0) {
+    torchcomms::device::test::launchNvlSendKernel(handle, peer, buf_d, nbytes);
+  } else if (rank_ == 1) {
+    torchcomms::device::test::launchNvlRecvKernel(handle, peer, buf_d, nbytes);
+  }
+
+  cuda_err = cudaDeviceSynchronize();
+  ASSERT_EQ(cuda_err, cudaSuccess) << "Kernel execution failed";
+
+  if (rank_ == 1) {
+    std::vector<uint8_t> host_buf(nbytes);
+    cuda_err =
+        cudaMemcpy(host_buf.data(), buf_d, nbytes, cudaMemcpyDeviceToHost);
+    ASSERT_EQ(cuda_err, cudaSuccess);
+
+    std::vector<uint8_t> expected(nbytes, 0x42);
+    ASSERT_EQ(memcmp(host_buf.data(), expected.data(), nbytes), 0)
+        << "Data mismatch in received buffer";
+  }
+
+  torchcomm_->barrier(false);
+  ASSERT_EQ(cudaFree(buf_d), cudaSuccess) << "cudaFree failed";
+}
+
+TEST_F(PipesTransportApiTest, NvlSendRecvSmall) {
+  testNvlSendRecv(4096);
+}
+
+TEST_F(PipesTransportApiTest, NvlSendRecvLarge) {
+  testNvlSendRecv(1024 * 1024);
+}

--- a/comms/torchcomms/tests/integration/cpp/PipesTransportApiTest.hpp
+++ b/comms/torchcomms/tests/integration/cpp/PipesTransportApiTest.hpp
@@ -1,0 +1,48 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// TorchComms Pipes Transport API Integration Test
+//
+// This test validates get_device_transport() on TorchCommNCCLX and exercises
+// NVL send/recv through the returned MultiPeerDeviceHandle.
+//
+// NOTE: This test requires NCCLX with Pipes support (ENABLE_PIPES defined
+// at compile time).
+//
+// Runtime prerequisites:
+//   - RUN_PIPES_TRANSPORT_API_TEST=true (skip gate)
+//   - NCCL_CTRAN_USE_PIPES=1 (initialize ctran multiPeerTransport)
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+
+#include "TorchCommTestHelpers.h"
+#include "comms/torchcomms/TorchComm.hpp"
+
+class PipesTransportApiTest : public ::testing::Test {
+ protected:
+  void SetUp() override;
+  void TearDown() override;
+
+  // Check if test should be skipped
+  bool checkIfSkip();
+
+  // Create a wrapper for TorchComm
+  std::unique_ptr<TorchCommTestWrapper> createWrapper();
+
+  // Test functions
+
+  // Verify that get_device_transport() returns a valid MultiPeerDeviceHandle.
+  void testGetDeviceTransport();
+
+  // Test NVL send/recv: rank 0 sends nbytes to rank 1 via NVLink transport.
+  void testNvlSendRecv(size_t nbytes);
+
+  // Member variables
+  std::unique_ptr<TorchCommTestWrapper> wrapper_;
+  std::shared_ptr<torch::comms::TorchComm> torchcomm_;
+  int rank_{0};
+  int num_ranks_{0};
+  int device_index_{0};
+};

--- a/comms/torchcomms/tests/integration/cpp/PipesTransportApiTestKernels.cu
+++ b/comms/torchcomms/tests/integration/cpp/PipesTransportApiTestKernels.cu
@@ -1,0 +1,82 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// CUDA kernels for PipesTransportApiTest - tests NVL send/recv through
+// the pipes MultiPeerDeviceHandle obtained via torchcomms.
+
+#include "PipesTransportApiTestKernels.cuh"
+
+#include "comms/pipes/P2pNvlTransportDevice.cuh"
+#include "comms/pipes/ThreadGroup.cuh"
+#include "comms/pipes/Transport.cuh"
+
+#include <stdexcept>
+#include <string>
+
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define CUDA_LAUNCH_CHECK()                                                   \
+  do {                                                                        \
+    cudaError_t err__ = cudaGetLastError();                                   \
+    if (err__ != cudaSuccess) {                                               \
+      throw std::runtime_error(                                               \
+          std::string("Kernel launch failed: ") + cudaGetErrorString(err__)); \
+    }                                                                         \
+  } while (0)
+
+namespace torchcomms::device::test {
+
+// =============================================================================
+// NVL Send Kernel
+// =============================================================================
+// Sends nbytes from src_d to the given peer via NVLink transport.
+// Uses a single warp (32 threads) for the send operation.
+
+__global__ void nvlSendKernel(
+    comms::pipes::MultiPeerDeviceHandle handle,
+    int peerRank,
+    void* src_d,
+    size_t nbytes) {
+  auto group = comms::pipes::make_warp_group();
+  auto& nvl = handle.get_nvl(peerRank);
+  nvl.send(group, src_d, nbytes);
+}
+
+// =============================================================================
+// NVL Recv Kernel
+// =============================================================================
+// Receives nbytes into dst_d from the given peer via NVLink transport.
+// Uses a single warp (32 threads) for the recv operation.
+
+__global__ void nvlRecvKernel(
+    comms::pipes::MultiPeerDeviceHandle handle,
+    int peerRank,
+    void* dst_d,
+    size_t nbytes) {
+  auto group = comms::pipes::make_warp_group();
+  auto& nvl = handle.get_nvl(peerRank);
+  nvl.recv(group, dst_d, nbytes);
+}
+
+// =============================================================================
+// Host-callable wrapper functions
+// =============================================================================
+
+void launchNvlSendKernel(
+    comms::pipes::MultiPeerDeviceHandle handle,
+    int peerRank,
+    void* src_d,
+    size_t nbytes,
+    cudaStream_t stream) {
+  nvlSendKernel<<<1, 32, 0, stream>>>(handle, peerRank, src_d, nbytes);
+  CUDA_LAUNCH_CHECK();
+}
+
+void launchNvlRecvKernel(
+    comms::pipes::MultiPeerDeviceHandle handle,
+    int peerRank,
+    void* dst_d,
+    size_t nbytes,
+    cudaStream_t stream) {
+  nvlRecvKernel<<<1, 32, 0, stream>>>(handle, peerRank, dst_d, nbytes);
+  CUDA_LAUNCH_CHECK();
+}
+
+} // namespace torchcomms::device::test

--- a/comms/torchcomms/tests/integration/cpp/PipesTransportApiTestKernels.cuh
+++ b/comms/torchcomms/tests/integration/cpp/PipesTransportApiTestKernels.cuh
@@ -1,0 +1,34 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// CUDA kernel declarations for PipesTransportApiTest
+//
+// This header provides function declarations for launching warp-level
+// NVL send/recv kernels via the pipes MultiPeerDeviceHandle.
+//
+// The full device implementations are only in the .cu file which is
+// compiled by nvcc.
+
+// NOLINTNEXTLINE(clang-diagnostic-pragma-once-outside-header)
+#pragma once
+
+#include <cuda_runtime.h>
+#include "comms/pipes/MultiPeerDeviceHandle.cuh"
+
+namespace torchcomms::device::test {
+
+// Launch a warp-level NVL send kernel.
+void launchNvlSendKernel(
+    comms::pipes::MultiPeerDeviceHandle handle,
+    int peerRank,
+    void* src_d,
+    size_t nbytes,
+    cudaStream_t stream = nullptr);
+
+// Launch a warp-level NVL recv kernel.
+void launchNvlRecvKernel(
+    comms::pipes::MultiPeerDeviceHandle handle,
+    int peerRank,
+    void* dst_d,
+    size_t nbytes,
+    cudaStream_t stream = nullptr);
+
+} // namespace torchcomms::device::test

--- a/comms/torchcomms/tests/integration/cpp/PipesTransportApiTestMain.cpp
+++ b/comms/torchcomms/tests/integration/cpp/PipesTransportApiTestMain.cpp
@@ -1,0 +1,13 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// TorchComms Pipes Transport API Integration Test Main
+//
+// NOTE: TEST_F macros are in PipesTransportApiTest.cpp (which is compiled with
+// TORCHCOMMS_HAS_NCCL_DEVICE_API=1 and ENABLE_PIPES=1) to ensure consistent
+// type resolution. This file only contains the main() entry point.
+
+#include <gtest/gtest.h>
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Summary:

Adds a get_device_transport() API to TorchCommNCCLX that returns a
comms::pipes::MultiPeerDeviceHandle by value, allowing users to directly access Pipes
transport-level operations (NVL send/recv) from device kernels without needing to create a
HostWindow/DeviceWindow.

The plumbing goes through three layers:

1. ncclx C API (ncclGetMultiPeerDeviceHandle) — new function in nccl.h.in that decomposes the
handle into C-compatible output params (void**, int*), implemented in window.cc across
v2_27/v2_28/v2_29.
2. torchcomms NcclxApi — virtual method getMultiPeerDeviceHandle() added to NcclxApi base class
with DefaultNcclxApi delegating to the ncclx C function.
3. PipesDeviceBackend / TorchCommNCCLX — static get_device_transport() on PipesDeviceBackend
reassembles the MultiPeerDeviceHandle struct. TorchCommNCCLX::get_device_transport() is the
public entry point.

Reviewed By: cenzhaometa

Differential Revision: D96825888
