### PR TITLE
Fix CQ vector accumulation leak on reconfigure

### DIFF
--- a/comms/ctran/backends/ib/CtranIb.cc
+++ b/comms/ctran/backends/ib/CtranIb.cc
@@ -995,9 +995,6 @@ commResult_t CtranIb::initRemoteTransStates(void) {
     localVc = std::make_unique<LocalVirtualConn>(devices, ncclLogData);
   }
 
-  cqMutex.unlock();
-  localVcMutex.unlock();
-
   return commSuccess;
 }
 

--- a/comms/ctran/backends/ib/CtranIb.cc
+++ b/comms/ctran/backends/ib/CtranIb.cc
@@ -977,6 +977,14 @@ commResult_t CtranIb::initRemoteTransStates(void) {
   // create a new cq
   {
     std::unique_lock<std::mutex> lock(cqMutex);
+
+    // Clear old CQs before creating new ones (fixes accumulation on
+    // reconfigure).
+    for (int device = 0; device < NCCL_CTRAN_IB_DEVICES_PER_RANK; device++) {
+      devices[device].ibvCq = nullptr;
+    }
+    cqs.clear(); // IbvCq destructors call ibv_destroy_cq
+
     for (int device = 0; device < NCCL_CTRAN_IB_DEVICES_PER_RANK; device++) {
       auto createCqResult =
           devices[device].ibvDevice->createCq(maxCqe, nullptr, nullptr, 0);

--- a/comms/ctran/ibverbx/IbvCq.cc
+++ b/comms/ctran/ibverbx/IbvCq.cc
@@ -58,10 +58,22 @@ IbvCq::IbvCq(IbvCq&& other) noexcept {
 }
 
 IbvCq& IbvCq::operator=(IbvCq&& other) noexcept {
-  cq_ = other.cq_;
-  deviceId_ = other.deviceId_;
-  other.cq_ = nullptr;
-  other.deviceId_ = -1;
+  if (this != &other) {
+    if (cq_) {
+      int rc = ibvSymbols.ibv_internal_destroy_cq(cq_);
+      if (rc != 0) {
+        XLOGF(
+            ERR,
+            "Failed to destroy cq in move assignment rc: {}, {}",
+            rc,
+            strerror(errno));
+      }
+    }
+    cq_ = other.cq_;
+    deviceId_ = other.deviceId_;
+    other.cq_ = nullptr;
+    other.deviceId_ = -1;
+  }
   return *this;
 }
 

--- a/comms/ctran/ibverbx/tests/IbverbxTest.cc
+++ b/comms/ctran/ibverbx/tests/IbverbxTest.cc
@@ -458,6 +458,35 @@ TEST_F(IbverbxTestFixture, IbvCq) {
   ASSERT_EQ(cq2.cq(), cqRawPtr);
 }
 
+TEST_F(IbverbxTestFixture, IbvCqMoveAssignment) {
+  auto devices = IbvDevice::ibvGetDeviceList();
+  ASSERT_TRUE(devices);
+  auto& device = devices->at(0);
+
+  int cqe = 100;
+
+  // Create two CQs
+  auto cq1 = device.createCq(cqe, nullptr, nullptr, 0);
+  ASSERT_TRUE(cq1);
+  auto cq2 = device.createCq(cqe, nullptr, nullptr, 0);
+  ASSERT_TRUE(cq2);
+
+  auto cq2RawPtr = cq2->cq();
+
+  // Move assign cq2 into cq1.
+  // Old cq1 should be destroyed, not leaked
+  *cq1 = std::move(*cq2);
+  ASSERT_EQ(cq1->cq(), cq2RawPtr);
+  ASSERT_EQ(cq2->cq(), nullptr);
+
+  // Move assign into default-constructed (empty) CQ
+  IbvCq cq3;
+  ASSERT_EQ(cq3.cq(), nullptr);
+  cq3 = std::move(*cq1);
+  ASSERT_EQ(cq3.cq(), cq2RawPtr);
+  ASSERT_EQ(cq1->cq(), nullptr);
+}
+
 TEST_F(IbverbxTestFixture, IbvQp) {
   auto devices = IbvDevice::ibvGetDeviceList();
   ASSERT_TRUE(devices);


### PR DESCRIPTION
Summary:
`initRemoteTransStates()` is called on each reconfigure but never clears old CQs from the `cqs` vector before `emplace_back`-ing new ones. CQs accumulate, leaking kernel resources and corrupting device pointers (since `devices[device].ibvCq = &this->cqs[device]` points to stale vector entries after reallocation).

Fix by clearing old CQ pointers and destroying old CQs within a single `cqMutex` scope before creating new ones, avoiding deadlock from separate lock scopes on the same non-recursive mutex.

**Ownership Chain**
```
devices[device].ibvCq  →  (raw pointer, non-owning)  →  cqs[device]  (owning IbvCq)
                                                                ↓ destructor
                                                          ibv_destroy_cq(cq_)
```

Differential Revision: D96937704


