### PR TITLE
Add CQ pooling to CtranIbSingleton (#1128)

### DIFF
--- a/comms/ctran/backends/ib/CtranIb.cc
+++ b/comms/ctran/backends/ib/CtranIb.cc
@@ -102,6 +102,68 @@ CtranIbSingleton::CtranIbSingleton() {
   return;
 }
 
+folly::Expected<ibverbx::IbvCq, ibverbx::Error> CtranIbSingleton::checkoutCq(
+    int singletonDevIdx,
+    int maxCqe) {
+  if (NCCL_CTRAN_IB_CQ_POOL_ENABLE) {
+    ibverbx::IbvCq cq;
+    {
+      std::lock_guard<std::mutex> lock(cqPoolMutex_);
+      auto it = cqPool_.find(singletonDevIdx);
+      if (it != cqPool_.end() && !it->second.empty()) {
+        cq = std::move(it->second.back());
+        it->second.pop_back();
+      }
+    }
+    // Drain stale CQEs outside the lock (cheap — microseconds)
+    if (cq.cq()) {
+      bool drainOk = true;
+      while (true) {
+        constexpr int kDrainBatchSize = 256;
+        auto result = cq.pollCq(kDrainBatchSize);
+        if (result.hasError()) {
+          CLOGF(
+              WARN,
+              "CTRAN-IB: CQ drain pollCq error for device {}: {}, discarding pooled CQ",
+              singletonDevIdx,
+              result.error().errStr);
+          drainOk = false;
+          break;
+        }
+        if (result->empty()) {
+          break;
+        }
+      }
+      if (drainOk) {
+        // Pooled CQs retain the maxCqe from their original creation.
+        // This is safe because all callers derive maxCqe from devAttr.max_cqe,
+        // which is constant per device. IbvCq does not store its creation
+        // maxCqe, so this invariant cannot be verified at runtime.
+        CLOGF(DBG, "CTRAN-IB: CQ pool hit for device {}", singletonDevIdx);
+        return std::move(cq);
+      }
+      // Drain failed — discard CQ (destroyed by IbvCq destructor when `cq`
+      // goes out of scope) and fall through to create a fresh one.
+    }
+  }
+  // Pool miss or disabled — create new CQ (slow path, ~183ms)
+  CLOGF(
+      INFO,
+      "CTRAN-IB: CQ pool miss for device {}, creating new CQ",
+      singletonDevIdx);
+  return ibvDevices[singletonDevIdx].createCq(maxCqe, nullptr, nullptr, 0);
+}
+
+void CtranIbSingleton::checkinCq(int singletonDevIdx, ibverbx::IbvCq cq) {
+  if (NCCL_CTRAN_IB_CQ_POOL_ENABLE) {
+    std::lock_guard<std::mutex> lock(cqPoolMutex_);
+    cqPool_[singletonDevIdx].push_back(std::move(cq));
+    return;
+  }
+  // Pool disabled — CQ destroyed via IbvCq destructor when `cq` goes out of
+  // scope
+}
+
 commResult_t CtranIbSingleton::destroy() {
   // No-op if already destroyed and skipped
   if (destroySkipped_) {
@@ -135,6 +197,15 @@ commResult_t CtranIbSingleton::destroy() {
   // Below reports any resource leak and cleanup network resource.
   // NOTE: If any outstanding comm or IB registration exists, it is known that
   // the resource cleanup calls can fail.
+
+  // Defensive: drain CQ pool before PDs/devices are destroyed.
+  // Member declaration order already guarantees this in ~CtranIbSingleton(),
+  // but explicit clear ensures correctness if destroy() is called manually.
+  {
+    std::lock_guard<std::mutex> lock(cqPoolMutex_);
+    cqPool_.clear(); // IbvCq destructors call ibv_destroy_cq()
+  }
+
   this->comms_.withRLock([&](auto& comms) {
     if (comms.size()) {
       for (auto& it : comms) {
@@ -542,12 +613,10 @@ void CtranIb::init(
 
     // Skip lock for cq and localVc in constructor since no other thread can
     // access it yet.
-    auto maybeCq =
-        devices[device].ibvDevice->createCq(maxCqe, nullptr, nullptr, 0);
+    auto maybeCq = s->checkoutCq(singletonDevIdx, maxCqe);
     FOLLY_EXPECTED_CHECKTHROW_EX(maybeCq, ncclLogData);
     cqs.emplace_back(std::move(*maybeCq));
     devices[device].ibvCq = &cqs[device];
-    // FIXME: use initRemoteTransStates() to create cq
   }
 
   if (enableLocalFlush) {
@@ -713,6 +782,7 @@ CtranIb::~CtranIb(void) {
   }
 
   FB_COMMCHECKIGNORE(releaseRemoteTransStates(true /* fromDestructor */));
+  checkinCqs();
 
   CLOGF_SUBSYS(
       INFO,
@@ -962,6 +1032,28 @@ commResult_t CtranIb::releaseRemoteTransStates(bool fromDestructor) {
   return commSuccess;
 }
 
+void CtranIb::checkinCqs() {
+  auto s = CtranIbSingleton::getInstance();
+  if (!s) {
+    return;
+  }
+
+  // Hold cqMutex to synchronize with progressInternal() which reads
+  // devices[device].ibvCq under this lock.
+  // Lock ordering: cqMutex -> cqPoolMutex_ (via checkinCq).
+  std::lock_guard<std::mutex> lock(cqMutex);
+  for (int device = 0; device < NCCL_CTRAN_IB_DEVICES_PER_RANK; device++) {
+    devices[device].ibvCq = nullptr; // invalidate raw pointer first
+    if (device < static_cast<int>(cqs.size())) {
+      int singletonDevIdx = cudaDev * NCCL_CTRAN_IB_DEVICES_PER_RANK *
+              NCCL_CTRAN_IB_DEVICE_STRIDE +
+          device;
+      s->checkinCq(singletonDevIdx, std::move(cqs[device]));
+    }
+  }
+  cqs.clear();
+}
+
 // Reset CtranIb backend qps and cq state
 commResult_t CtranIb::initRemoteTransStates(void) {
   // Ensure no other thread is accessing the CtranIb object while releasing
@@ -972,14 +1064,24 @@ commResult_t CtranIb::initRemoteTransStates(void) {
   // resources; We still need per-object lock here to ensure the internal
   // listenThread doesn't read garbage data
 
+  auto s = CtranIbSingleton::getInstance();
+  CHECK_VALID_IB_SINGLETON(s);
+
+  // Return old CQs to pool and clear vector before creating new ones
+  // (fixes CQ accumulation bug on reconfigure)
+  checkinCqs();
+
   this->cqs.reserve(NCCL_CTRAN_IB_DEVICES_PER_RANK);
 
   // create a new cq
+  // Lock ordering: cqMutex -> cqPoolMutex_ (via checkoutCq).
   {
     std::unique_lock<std::mutex> lock(cqMutex);
     for (int device = 0; device < NCCL_CTRAN_IB_DEVICES_PER_RANK; device++) {
-      auto createCqResult =
-          devices[device].ibvDevice->createCq(maxCqe, nullptr, nullptr, 0);
+      int singletonDevIdx = cudaDev * NCCL_CTRAN_IB_DEVICES_PER_RANK *
+              NCCL_CTRAN_IB_DEVICE_STRIDE +
+          device;
+      auto createCqResult = s->checkoutCq(singletonDevIdx, maxCqe);
       FOLLY_EXPECTED_CHECK(createCqResult);
       cqs.emplace_back(std::move(*createCqResult));
       devices[device].ibvCq = &this->cqs[device];

--- a/comms/ctran/backends/ib/CtranIb.h
+++ b/comms/ctran/backends/ib/CtranIb.h
@@ -498,6 +498,11 @@ class CtranIb {
 
  private:
   friend class CtranIbRequest;
+  // Return all CQs to the singleton pool and clear the cqs vector.
+  // Must be called under appropriate synchronization (destructor or epoch
+  // lock).
+  void checkinCqs();
+
   void init(
       CtranComm* comm,
       int rank,

--- a/comms/ctran/backends/ib/CtranIbSingleton.h
+++ b/comms/ctran/backends/ib/CtranIbSingleton.h
@@ -4,6 +4,8 @@
 #define CTRAN_IB_SINGLETON_H_
 
 #include <memory>
+#include <mutex>
+#include <unordered_map>
 #include <vector>
 
 #include <folly/Singleton.h>
@@ -57,6 +59,16 @@ class CtranIbSingleton {
 
   bool getDevToDmaBufSupport(int cudaDev);
 
+  // Checkout a CQ from the per-device pool if CQ pooling is enabled and a
+  // pooled CQ is available, otherwise create a new CQ (~183ms syscall).
+  folly::Expected<ibverbx::IbvCq, ibverbx::Error> checkoutCq(
+      int singletonDevIdx,
+      int maxCqe);
+
+  // Return a CQ to the per-device pool for reuse. If CQ pooling is disabled,
+  // the CQ is destroyed immediately via IbvCq destructor.
+  void checkinCq(int singletonDevIdx, ibverbx::IbvCq cq);
+
   size_t getDeviceTrafficSnapshot(const int cudaDev);
 
   static IVerbsWrapper* getVerbsPtr();
@@ -75,6 +87,16 @@ class CtranIbSingleton {
   ~CtranIbSingleton();
   std::vector<ibverbx::IbvPd> ibvPds_;
   std::vector<std::unique_ptr<std::atomic<size_t>>> devBytes_;
+
+  // CQ pool: keyed by singletonDevIdx (CQs are bound to a specific
+  // ibv_context). Declared after ibvPds_ so implicit destruction order
+  // destroys pooled CQs before PDs/devices.
+  // Pool size per device is bounded in practice by the number of concurrent
+  // communicators sharing a device (typically 1-2).
+  // Lock ordering: when CtranIb::cqMutex is also needed, acquire cqMutex
+  // first (cqMutex -> cqPoolMutex_).
+  std::mutex cqPoolMutex_;
+  std::unordered_map<int, std::vector<ibverbx::IbvCq>> cqPool_;
 
   std::unordered_map<int, bool> devToDmaBufSupport;
   std::mutex dmaBufSupportMutex_;

--- a/comms/ctran/backends/ib/benchmarks/CtranIbCqPoolBench.cc
+++ b/comms/ctran/backends/ib/benchmarks/CtranIbCqPoolBench.cc
@@ -1,0 +1,123 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <benchmark/benchmark.h>
+#include <folly/init/Init.h>
+#include <folly/logging/Init.h>
+
+#include "comms/ctran/backends/ib/CtranIbSingleton.h"
+#include "comms/ctran/ibverbx/Ibverbx.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+
+FOLLY_INIT_LOGGING_CONFIG(
+    ".=WARNING"
+    ";default:async=true,sync_level=WARNING");
+
+namespace {
+
+struct CqPoolBenchFixture {
+  std::shared_ptr<CtranIbSingleton> singleton;
+  int devIdx = 0;
+  int maxCqe = 0;
+  bool initialized = false;
+
+  void ensureInit() {
+    if (initialized) {
+      return;
+    }
+    initialized = true;
+    singleton = CtranIbSingleton::getInstance();
+    if (!singleton || singleton->ibvDevices.empty()) {
+      return;
+    }
+    auto devAttr = singleton->ibvDevices[devIdx].queryDevice();
+    if (devAttr) {
+      maxCqe = devAttr->max_cqe;
+    }
+    if (maxCqe <= 0) {
+      singleton = nullptr;
+    }
+  }
+};
+
+CqPoolBenchFixture& getFixture() {
+  static CqPoolBenchFixture fixture;
+  fixture.ensureInit();
+  return fixture;
+}
+
+void BM_CqCreate_ColdPath(benchmark::State& state) {
+  auto& fix = getFixture();
+  if (!fix.singleton || fix.singleton->ibvDevices.empty()) {
+    state.SkipWithError("No IB hardware available");
+    return;
+  }
+
+  auto origPoolEnable = NCCL_CTRAN_IB_CQ_POOL_ENABLE;
+  NCCL_CTRAN_IB_CQ_POOL_ENABLE = false;
+
+  for (auto _ : state) {
+    auto cq = fix.singleton->checkoutCq(fix.devIdx, fix.maxCqe);
+    if (!cq) {
+      state.SkipWithError("checkoutCq failed");
+      break;
+    }
+    // IbvCq destructor calls ibv_destroy_cq at end of iteration
+  }
+
+  NCCL_CTRAN_IB_CQ_POOL_ENABLE = origPoolEnable;
+}
+
+void BM_CqCheckout_WarmPath(benchmark::State& state) {
+  auto& fix = getFixture();
+  if (!fix.singleton || fix.singleton->ibvDevices.empty()) {
+    state.SkipWithError("No IB hardware available");
+    return;
+  }
+
+  auto origPoolEnable = NCCL_CTRAN_IB_CQ_POOL_ENABLE;
+  NCCL_CTRAN_IB_CQ_POOL_ENABLE = true;
+
+  // Seed pool with 1 CQ
+  auto seedCq = fix.singleton->ibvDevices[fix.devIdx].createCq(
+      fix.maxCqe, nullptr, nullptr, 0);
+  if (!seedCq) {
+    state.SkipWithError("Failed to create seed CQ");
+    NCCL_CTRAN_IB_CQ_POOL_ENABLE = origPoolEnable;
+    return;
+  }
+  fix.singleton->checkinCq(fix.devIdx, std::move(*seedCq));
+
+  for (auto _ : state) {
+    auto cq = fix.singleton->checkoutCq(fix.devIdx, fix.maxCqe);
+    if (!cq) {
+      state.SkipWithError("checkoutCq failed");
+      break;
+    }
+    fix.singleton->checkinCq(fix.devIdx, std::move(*cq));
+  }
+
+  NCCL_CTRAN_IB_CQ_POOL_ENABLE = origPoolEnable;
+}
+
+} // namespace
+
+static auto* registered_cold_path =
+    benchmark::RegisterBenchmark("BM_CqCreate_ColdPath", BM_CqCreate_ColdPath)
+        ->UseRealTime()
+        ->Unit(benchmark::kMillisecond)
+        ->Iterations(10);
+
+static auto* registered_warm_path = benchmark::RegisterBenchmark(
+                                        "BM_CqCheckout_WarmPath",
+                                        BM_CqCheckout_WarmPath)
+                                        ->UseRealTime()
+                                        ->Unit(benchmark::kMicrosecond);
+
+int main(int argc, char** argv) {
+  ::benchmark::Initialize(&argc, argv);
+  folly::init(&argc, &argv);
+  ncclCvarInit();
+  ::benchmark::RunSpecifiedBenchmarks();
+  getFixture().singleton.reset();
+  return 0;
+}

--- a/comms/ctran/backends/ib/tests/CtranIbCqPoolUT.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbCqPoolUT.cc
@@ -1,0 +1,213 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+#include <atomic>
+#include <thread>
+#include <vector>
+
+#include "comms/ctran/backends/ib/CtranIbSingleton.h"
+#include "comms/ctran/ibverbx/Ibverbx.h"
+#include "comms/ctran/utils/LogInit.h"
+#include "comms/utils/cvars/nccl_cvars.h" // @manual
+
+class CqPoolTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    ncclCvarInit();
+    ctran::logging::initCtranLogging(true);
+    singleton_ = CtranIbSingleton::getInstance();
+    ASSERT_NE(singleton_, nullptr);
+    ASSERT_FALSE(singleton_->ibvDevices.empty());
+    devIdx_ = 0;
+    auto devAttr = singleton_->ibvDevices[devIdx_].queryDevice();
+    ASSERT_TRUE(devAttr) << devAttr.error().errStr;
+    maxCqe_ = devAttr->max_cqe;
+    origPoolEnable_ = NCCL_CTRAN_IB_CQ_POOL_ENABLE;
+  }
+
+  // TearDown only restores the CVAR. Pool cleanup is intentionally omitted:
+  // LIFO ordering guarantees each test controls its own pool top, so
+  // residual CQs from prior tests do not affect subsequent tests.
+  void TearDown() override {
+    NCCL_CTRAN_IB_CQ_POOL_ENABLE = origPoolEnable_;
+  }
+
+  // Helper: create a fresh CQ directly (bypassing pool).
+  ibverbx::IbvCq createCq(int devIdx) {
+    auto cq =
+        singleton_->ibvDevices[devIdx].createCq(maxCqe_, nullptr, nullptr, 0);
+    EXPECT_TRUE(cq) << cq.error().errStr;
+    if (!cq) {
+      return ibverbx::IbvCq{};
+    }
+    return std::move(*cq);
+  }
+
+  ibverbx::IbvCq createCq() {
+    return createCq(devIdx_);
+  }
+
+  std::shared_ptr<CtranIbSingleton> singleton_;
+  int devIdx_;
+  int maxCqe_;
+  bool origPoolEnable_;
+};
+
+// checkoutCq always returns a valid, non-null CQ regardless of pool state.
+TEST_F(CqPoolTest, Checkout_ReturnsValidCq) {
+  NCCL_CTRAN_IB_CQ_POOL_ENABLE = true;
+  auto cq = singleton_->checkoutCq(devIdx_, maxCqe_);
+  ASSERT_TRUE(cq) << cq.error().errStr;
+  EXPECT_NE(cq->cq(), nullptr);
+}
+
+// Pool hit: checkin a CQ, checkout returns same ibv_cq* pointer.
+TEST_F(CqPoolTest, CheckinThenCheckout_ReturnsSameCq) {
+  NCCL_CTRAN_IB_CQ_POOL_ENABLE = true;
+
+  auto cq = createCq();
+  ASSERT_NE(cq.cq(), nullptr);
+  auto* rawPtr = cq.cq();
+
+  singleton_->checkinCq(devIdx_, std::move(cq));
+
+  auto checkedOut = singleton_->checkoutCq(devIdx_, maxCqe_);
+  ASSERT_TRUE(checkedOut) << checkedOut.error().errStr;
+  EXPECT_EQ(checkedOut->cq(), rawPtr);
+}
+
+// LIFO ordering: 2 CQs checked in, checked out in reverse order.
+TEST_F(CqPoolTest, MultipleCheckinCheckout_LIFOOrder) {
+  NCCL_CTRAN_IB_CQ_POOL_ENABLE = true;
+
+  auto cq1 = createCq();
+  auto cq2 = createCq();
+  ASSERT_NE(cq1.cq(), nullptr);
+  ASSERT_NE(cq2.cq(), nullptr);
+
+  auto* ptr1 = cq1.cq();
+  auto* ptr2 = cq2.cq();
+
+  singleton_->checkinCq(devIdx_, std::move(cq1));
+  singleton_->checkinCq(devIdx_, std::move(cq2));
+
+  // LIFO: cq2 was pushed last, should come out first
+  auto out1 = singleton_->checkoutCq(devIdx_, maxCqe_);
+  ASSERT_TRUE(out1) << out1.error().errStr;
+  EXPECT_EQ(out1->cq(), ptr2);
+
+  auto out2 = singleton_->checkoutCq(devIdx_, maxCqe_);
+  ASSERT_TRUE(out2) << out2.error().errStr;
+  EXPECT_EQ(out2->cq(), ptr1);
+}
+
+// CQs keyed by singletonDevIdx don't leak across device indices.
+TEST_F(CqPoolTest, MultiDeviceIsolation) {
+  if (singleton_->ibvDevices.size() < 2) {
+    GTEST_SKIP() << "Need at least 2 IB devices for multi-device test";
+  }
+  NCCL_CTRAN_IB_CQ_POOL_ENABLE = true;
+
+  // Create and checkin a CQ for device 0
+  auto cq0 = createCq(0);
+  ASSERT_NE(cq0.cq(), nullptr);
+  auto* ptr0 = cq0.cq();
+  singleton_->checkinCq(0, std::move(cq0));
+
+  // Checkout from device 1 — must NOT get the device-0 CQ
+  auto devAttr1 = singleton_->ibvDevices[1].queryDevice();
+  ASSERT_TRUE(devAttr1) << devAttr1.error().errStr;
+
+  auto out1 = singleton_->checkoutCq(1, devAttr1->max_cqe);
+  ASSERT_TRUE(out1) << out1.error().errStr;
+  EXPECT_NE(out1->cq(), ptr0);
+}
+
+// CQ survives pool round-trip and remains functional.
+TEST_F(CqPoolTest, CqUsableAfterRoundTrip) {
+  NCCL_CTRAN_IB_CQ_POOL_ENABLE = true;
+
+  auto cq = createCq();
+  ASSERT_NE(cq.cq(), nullptr);
+
+  singleton_->checkinCq(devIdx_, std::move(cq));
+
+  auto checkedOut = singleton_->checkoutCq(devIdx_, maxCqe_);
+  ASSERT_TRUE(checkedOut) << checkedOut.error().errStr;
+  ASSERT_NE(checkedOut->cq(), nullptr);
+
+  // pollCq on an idle CQ should succeed with an empty result
+  auto result = checkedOut->pollCq(1);
+  ASSERT_TRUE(result) << result.error().errStr;
+  EXPECT_TRUE(result->empty());
+}
+
+// Pool-disabled creation path still returns a valid CQ.
+TEST_F(CqPoolTest, PoolDisabled_CheckoutCreatesValidCq) {
+  NCCL_CTRAN_IB_CQ_POOL_ENABLE = false;
+
+  auto cq = singleton_->checkoutCq(devIdx_, maxCqe_);
+  ASSERT_TRUE(cq) << cq.error().errStr;
+  EXPECT_NE(cq->cq(), nullptr);
+}
+
+// With pool disabled, checked-in CQs are destroyed, not pooled.
+TEST_F(CqPoolTest, PoolDisabled_CheckinDoesNotPool) {
+  NCCL_CTRAN_IB_CQ_POOL_ENABLE = true;
+
+  // Checkin a marker CQ with pool enabled — it sits at LIFO top
+  auto marker = createCq();
+  ASSERT_NE(marker.cq(), nullptr);
+  auto* markerPtr = marker.cq();
+  singleton_->checkinCq(devIdx_, std::move(marker));
+
+  // Disable pool, create and checkin another CQ — should be destroyed
+  NCCL_CTRAN_IB_CQ_POOL_ENABLE = false;
+  auto discarded = createCq();
+  ASSERT_NE(discarded.cq(), nullptr);
+  singleton_->checkinCq(devIdx_, std::move(discarded));
+
+  // Re-enable pool, checkout — should get the marker, proving the
+  // disabled-path CQ was not added to the pool
+  NCCL_CTRAN_IB_CQ_POOL_ENABLE = true;
+  auto out = singleton_->checkoutCq(devIdx_, maxCqe_);
+  ASSERT_TRUE(out) << out.error().errStr;
+  EXPECT_EQ(out->cq(), markerPtr);
+}
+
+// Thread safety under contention: concurrent checkout/checkin cycles.
+TEST_F(CqPoolTest, ConcurrentCheckoutCheckin_ThreadSafe) {
+  NCCL_CTRAN_IB_CQ_POOL_ENABLE = true;
+
+  constexpr int kNumThreads = 4;
+  constexpr int kIterations = 10;
+
+  // Pre-seed pool so concurrent checkouts get pool hits, avoiding
+  // ~183ms ibv_create_cq per miss
+  for (int i = 0; i < kNumThreads; i++) {
+    singleton_->checkinCq(devIdx_, createCq());
+  }
+
+  std::atomic<int> errors{0};
+  std::vector<std::thread> threads;
+  threads.reserve(kNumThreads);
+
+  for (int t = 0; t < kNumThreads; t++) {
+    threads.emplace_back([&]() {
+      for (int i = 0; i < kIterations; i++) {
+        auto cq = singleton_->checkoutCq(devIdx_, maxCqe_);
+        if (!cq || cq->cq() == nullptr) {
+          errors.fetch_add(1);
+          continue;
+        }
+        singleton_->checkinCq(devIdx_, std::move(*cq));
+      }
+    });
+  }
+
+  for (auto& t : threads) {
+    t.join();
+  }
+
+  EXPECT_EQ(errors.load(), 0);
+}

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1537,6 +1537,15 @@ cvars:
      Traffic class to use for control QPs. Note: To match NCCL_IB_TC, this
      directly sets the TC field, so multiply your DSCP value by 4.
 
+ - name        : NCCL_CTRAN_IB_CQ_POOL_ENABLE
+   type        : bool
+   default     : true
+   description : |-
+     Enable CQ pooling in CtranIbSingleton. When enabled, IB completion queues
+     are returned to a per-device pool on communicator destruction and reused
+     on subsequent communicator creation, avoiding the ~183ms ibv_create_cq
+     kernel syscall. Disable to fall back to per-communicator CQ creation.
+
  - name        : NCCL_CTRAN_IB_VC_MODE
    type        : enum
    default     : dqplb


### PR DESCRIPTION
Summary:

CQ creation (`ibv_create_cq`) costs ~183ms per call (99.95% of IB device setup). Pool CQs in `CtranIbSingleton` so subsequent inits/reconfigures reuse them (<1ms).

Add `checkoutCq()` which tries the per-device pool first (draining stale CQEs), falling back to `createCq` on miss. Add `checkinCq()` to return CQs to pool on communicator destruction.

Add `NCCL_CTRAN_IB_CQ_POOL_ENABLE` CVAR (default: true) to control the feature.

Differential Revision: D96937705


