### PR TITLE
feat: expose pipes transport ops to Triton via bitcode extern pattern (#1129)

### DIFF
--- a/comms/torchcomms/TorchComm.cpp
+++ b/comms/torchcomms/TorchComm.cpp
@@ -572,6 +572,10 @@ c10::intrusive_ptr<TorchWork> TorchComm::reconfigure(
   return impl_->reconfigure(opts);
 }
 
+int64_t TorchComm::get_device_transport() {
+  return impl_->get_device_transport();
+}
+
 // Communicator Management
 std::shared_ptr<TorchComm> TorchComm::split(
     const std::vector<int>& ranks,

--- a/comms/torchcomms/TorchComm.hpp
+++ b/comms/torchcomms/TorchComm.hpp
@@ -155,6 +155,10 @@ class TorchComm : public std::enable_shared_from_this<TorchComm> {
 
   std::string_view getBackendVersion() const;
 
+  // Device Transport API — returns device pointer as int64 for Triton kernels.
+  // Throws if not supported by the backend.
+  int64_t get_device_transport();
+
   std::shared_ptr<TorchCommBackend> getBackendImpl() const {
     return impl_;
   }

--- a/comms/torchcomms/TorchCommBackend.hpp
+++ b/comms/torchcomms/TorchCommBackend.hpp
@@ -268,6 +268,16 @@ class TorchCommBackend {
         std::string(getCommName()));
   }
 
+  // Device Transport API
+  // Returns a device pointer (as int64) to a transport handle for use in
+  // Triton/CUDA kernels. Only supported by backends with pipes transport.
+  virtual int64_t get_device_transport() {
+    throw std::runtime_error(
+        "[TorchCommBackend]: get_device_transport not implemented for "
+        "communicator:" +
+        std::string(getCommName()));
+  }
+
  protected:
   void runAbortHooks() {
     for (const auto& [_, hook] : abortHooks_) {

--- a/comms/torchcomms/TorchCommPy.cpp
+++ b/comms/torchcomms/TorchCommPy.cpp
@@ -1021,6 +1021,26 @@ Example:
           py::arg("timeout") = std::nullopt,
           py::arg("hints") = std::nullopt,
           py::call_guard<py::gil_scoped_release>())
+      .def(
+          "get_device_transport",
+          &TorchComm::get_device_transport,
+          R"(
+Get a device-allocated transport handle for pipes transport operations.
+
+Returns a device pointer (as int64) to a MultiPeerDeviceHandle that can be
+passed to Triton transport extern functions (transport.send, transport.recv,
+transport.signal, etc.).
+
+The handle is lazily created on first call and cached. The returned pointer
+is valid until the communicator is destroyed.
+
+Returns:
+    int: Device transport pointer as int64, suitable for passing to Triton kernels.
+
+Raises:
+    RuntimeError: If the backend does not support device transport.
+)",
+          py::call_guard<py::gil_scoped_release>())
 
       // Point-to-Point Operations
       .def(

--- a/comms/torchcomms/device/pipes/PipesDeviceBackend.cpp
+++ b/comms/torchcomms/device/pipes/PipesDeviceBackend.cpp
@@ -142,10 +142,10 @@ PipesDeviceBackend::Ptr PipesDeviceBackend::create_device_window(
 }
 
 // =============================================================================
-// get_device_transport Implementation
+// fetch_transport_handle Implementation
 // =============================================================================
 
-comms::pipes::MultiPeerDeviceHandle PipesDeviceBackend::get_device_transport(
+comms::pipes::MultiPeerDeviceHandle PipesDeviceBackend::fetch_transport_handle(
     ncclComm_t nccl_comm,
     torch::comms::NcclxApi* nccl_api) {
   void* transports_ptr = nullptr;
@@ -164,7 +164,7 @@ comms::pipes::MultiPeerDeviceHandle PipesDeviceBackend::get_device_transport(
 
   if (result != ncclSuccess) {
     throw std::runtime_error(
-        "[PipesDeviceBackend::get_device_transport] "
+        "[PipesDeviceBackend::fetch_transport_handle] "
         "Failed to get MultiPeerDeviceHandle. "
         "Ensure NCCL_CTRAN_USE_PIPES=1 is set.");
   }
@@ -178,6 +178,67 @@ comms::pipes::MultiPeerDeviceHandle PipesDeviceBackend::get_device_transport(
            n_ranks)},
       num_nvl_peers,
       num_ib_peers};
+}
+
+// =============================================================================
+// TransportHandleDeleter Implementation
+// =============================================================================
+
+void PipesDeviceBackend::TransportHandleDeleter::operator()(void* ptr) const {
+  if (ptr != nullptr && cuda_api != nullptr) {
+    CUDA_CHECK_IGNORE(
+        cuda_api, cuda_api->free(ptr), "Failed to free transport handle");
+  }
+}
+
+// =============================================================================
+// get_device_transport Implementation
+// =============================================================================
+
+PipesDeviceBackend::TransportHandleDevPtr
+PipesDeviceBackend::get_device_transport(
+    ncclComm_t nccl_comm,
+    torch::comms::NcclxApi* nccl_api,
+    torch::comms::CudaApi* cuda_api) {
+  if (nccl_api == nullptr || cuda_api == nullptr) {
+    throw std::runtime_error(
+        "[PipesDeviceBackend::get_device_transport]: "
+        "nccl_api and cuda_api must not be null");
+  }
+
+  // Get handle on host (private helper)
+  auto handle = fetch_transport_handle(nccl_comm, nccl_api);
+
+  // Allocate device memory
+  void* device_ptr = nullptr;
+  cudaError_t err = cuda_api->malloc(
+      &device_ptr, sizeof(comms::pipes::MultiPeerDeviceHandle));
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        "[PipesDeviceBackend::get_device_transport]: "
+        "cudaMalloc failed: " +
+        std::string(cuda_api->getErrorString(err)));
+  }
+
+  // Copy to device
+  // NOLINTNEXTLINE(facebook-hte-NullableDereference,facebook-security-vulnerable-memcpy)
+  err = cuda_api->memcpy(
+      device_ptr,
+      &handle,
+      sizeof(comms::pipes::MultiPeerDeviceHandle),
+      cudaMemcpyHostToDevice);
+  if (err != cudaSuccess) {
+    CUDA_CHECK_IGNORE(
+        cuda_api,
+        cuda_api->free(device_ptr),
+        "Failed to free transport handle during error cleanup");
+    throw std::runtime_error(
+        "[PipesDeviceBackend::get_device_transport]: "
+        "cudaMemcpy failed: " +
+        std::string(cuda_api->getErrorString(err)));
+  }
+
+  return TransportHandleDevPtr(device_ptr, TransportHandleDeleter{cuda_api});
 }
 
 } // namespace torchcomms::device

--- a/comms/torchcomms/device/pipes/PipesDeviceBackend.hpp
+++ b/comms/torchcomms/device/pipes/PipesDeviceBackend.hpp
@@ -29,6 +29,7 @@ struct MultiPeerDeviceHandle;
 namespace torch::comms {
 class CudaApi;
 class NcclxApi;
+class TorchCommNCCLX;
 } // namespace torch::comms
 
 namespace torchcomms::device {
@@ -150,6 +151,26 @@ struct PipesDeviceBackend {
         "supported for PipesDeviceBackend.");
   }
 
+  // =========================================================================
+  // Transport device handle (device-allocated MultiPeerDeviceHandle)
+  // =========================================================================
+
+  struct TransportHandleDeleter {
+    torch::comms::CudaApi* cuda_api{nullptr};
+    void operator()(void* ptr) const;
+  };
+  using TransportHandleDevPtr = std::unique_ptr<void, TransportHandleDeleter>;
+
+  // Get a device-allocated MultiPeerDeviceHandle for Triton and CUDA
+  // kernels. Calls fetch_transport_handle() internally to get handle by value,
+  // then cudaMalloc + cudaMemcpy to device memory.
+  // Returns managed pointer — cudaFree on destruction.
+  static TransportHandleDevPtr get_device_transport(
+      ncclComm_t nccl_comm,
+      torch::comms::NcclxApi* nccl_api,
+      torch::comms::CudaApi* cuda_api);
+
+ private:
   // Get the pipes transport device handle from the communicator.
   // NON-COLLECTIVE — reads already-exchanged state.
   //
@@ -158,7 +179,7 @@ struct PipesDeviceBackend {
   // MultiPeerTransport::exchange() during ctran init).
   //
   // Throws std::runtime_error if pipes transport is not initialized.
-  static comms::pipes::MultiPeerDeviceHandle get_device_transport(
+  static comms::pipes::MultiPeerDeviceHandle fetch_transport_handle(
       ncclComm_t nccl_comm,
       torch::comms::NcclxApi* nccl_api);
 };

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -2398,9 +2398,13 @@ static const NCCLXRegistration registration{};
 } // namespace
 
 #if defined(ENABLE_PIPES)
-::comms::pipes::MultiPeerDeviceHandle TorchCommNCCLX::get_device_transport() {
-  return torchcomms::device::PipesDeviceBackend::get_device_transport(
-      nccl_comm_, nccl_api_.get());
+int64_t TorchCommNCCLX::get_device_transport() {
+  if (!device_transport_handle_) {
+    device_transport_handle_ =
+        torchcomms::device::PipesDeviceBackend::get_device_transport(
+            nccl_comm_, nccl_api_.get(), cuda_api_.get());
+  }
+  return reinterpret_cast<int64_t>(device_transport_handle_.get());
 }
 #endif
 

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
@@ -26,7 +26,7 @@
 #include "comms/torchcomms/ncclx/TorchWorkNCCLX.hpp"
 
 #if defined(ENABLE_PIPES)
-#include "comms/pipes/MultiPeerDeviceHandle.cuh"
+#include "comms/torchcomms/device/pipes/PipesDeviceBackend.hpp"
 #endif
 
 namespace torch::comms {
@@ -302,16 +302,10 @@ class TorchCommNCCLX : public TorchCommBackend,
   }
 
 #if defined(ENABLE_PIPES)
-  // Get the pipes transport device handle for passing to CUDA kernels.
-  // NON-COLLECTIVE — reads already-exchanged state.
-  //
-  // Usage:
-  //   auto handle = ncclx_comm->get_device_transport();
-  //   myKernel<<<grid, block>>>(handle, ...);
-  //   // In kernel: handle.get_nvl(peer).send(group, src, nbytes);
-  //
-  // Throws std::runtime_error if pipes transport is not initialized.
-  ::comms::pipes::MultiPeerDeviceHandle get_device_transport();
+  // Get device-allocated transport handle for Triton/CUDA kernels.
+  // Returns device pointer as int64 (same pointer on subsequent calls).
+  // The handle is freed when TorchCommNCCLX is destroyed.
+  int64_t get_device_transport() override;
 #endif
 
  protected:
@@ -471,6 +465,11 @@ class TorchCommNCCLX : public TorchCommBackend,
 
   void attachMemoryHook();
   void detachMemoryHook();
+
+#if defined(ENABLE_PIPES)
+  torchcomms::device::PipesDeviceBackend::TransportHandleDevPtr
+      device_transport_handle_;
+#endif
 
   // Member variables
   ncclComm_t nccl_comm_{};

--- a/comms/torchcomms/tests/integration/cpp/PipesTransportApiTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/PipesTransportApiTest.cpp
@@ -70,7 +70,19 @@ void PipesTransportApiTest::testGetDeviceTransport() {
   ASSERT_NE(ncclx, nullptr) << "Backend is not TorchCommNCCLX";
 
   try {
-    auto handle = ncclx->get_device_transport();
+    auto handle_ptr = ncclx->get_device_transport();
+    ASSERT_NE(handle_ptr, 0) << "get_device_transport returned null";
+
+    // Copy the device-allocated handle back to host for validation
+    comms::pipes::MultiPeerDeviceHandle handle{};
+    auto copy_err = cudaMemcpy(
+        &handle,
+        reinterpret_cast<void*>(handle_ptr),
+        sizeof(comms::pipes::MultiPeerDeviceHandle),
+        cudaMemcpyDeviceToHost);
+    ASSERT_EQ(copy_err, cudaSuccess)
+        << "Failed to copy transport handle to host";
+
     EXPECT_EQ(handle.myRank, rank_);
     EXPECT_EQ(handle.nRanks, num_ranks_);
     EXPECT_NE(handle.transports.data(), nullptr);
@@ -102,7 +114,17 @@ void PipesTransportApiTest::testNvlSendRecv(size_t nbytes) {
       torchcomm_->getBackendImpl());
   ASSERT_NE(ncclx, nullptr) << "Backend is not TorchCommNCCLX";
 
-  auto handle = ncclx->get_device_transport();
+  auto handle_ptr = ncclx->get_device_transport();
+  ASSERT_NE(handle_ptr, 0) << "get_device_transport returned null";
+
+  // Copy the device-allocated handle back to host for kernel launch
+  comms::pipes::MultiPeerDeviceHandle handle{};
+  auto copy_err = cudaMemcpy(
+      &handle,
+      reinterpret_cast<void*>(handle_ptr),
+      sizeof(comms::pipes::MultiPeerDeviceHandle),
+      cudaMemcpyDeviceToHost);
+  ASSERT_EQ(copy_err, cudaSuccess) << "Failed to copy transport handle to host";
 
   if (handle.numNvlPeers == 0) {
     GTEST_SKIP() << "No NVL peers available — send/recv requires NVLink";

--- a/comms/torchcomms/triton/CMakeLists.txt
+++ b/comms/torchcomms/triton/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # =============================================================================
-# Triton device bitcode (libtorchcomms_device.bc)
+# Triton device bitcode (libdevice_window.bc)
 #
 # Compiles TorchComms device API to LLVM bitcode (.bc) for Triton's extern_libs.
 # Uses clang with CUDA device-only mode to produce portable bitcode.
-# Mirrors the Buck genrule torchcomms_device_bitcode in
+# Mirrors the Buck genrule device_window_bitcode in
 # comms/torchcomms/triton/BUCK.
 #
 # Key flags:
@@ -16,7 +16,7 @@
 if(NOT EXISTS "${CONDA_INCLUDE}/nccl_device/core.h")
     message(STATUS
         "Triton bitcode: NCCL Device API headers NOT found"
-        " (requires NCCLX 2.28+), skipping libtorchcomms_device.bc build")
+        " (requires NCCLX 2.28+), skipping libdevice_window.bc build")
     return()
 endif()
 
@@ -140,7 +140,7 @@ endif()
 set(TRITON_GPU_ARCH_FLAG "--cuda-gpu-arch=sm_${_clang_sm}")
 message(STATUS "  TRITON GPU arch  : sm_${_clang_sm} (raw: ${_raw_sm})")
 
-set(TRITON_BC_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/comms/torchcomms/triton/fb/libtorchcomms_device.bc")
+set(TRITON_BC_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/comms/torchcomms/triton/fb/libdevice_window.bc")
 
 # Ensure output directory exists
 get_filename_component(TRITON_BC_DIR "${TRITON_BC_OUTPUT}" DIRECTORY)
@@ -168,11 +168,11 @@ add_custom_command(
         "-I${NCCLX_INCLUDE}"
         "-I${NCCLX_INCLUDE}/nccl_device"
         "-I${ROOT}"
-        "${TRITON_SRC}/torchcomms_device.cu"
+        "${TRITON_SRC}/device_window.cu"
         -o "${TRITON_BC_OUTPUT}"
     DEPENDS
-        "${TRITON_SRC}/torchcomms_device.cu"
-        "${TRITON_SRC}/torchcomms_device.h"
+        "${TRITON_SRC}/device_window.cu"
+        "${TRITON_SRC}/device_window.h"
         "${TRITON_SRC}/ir_include/nccl.h"
     COMMENT "Compiling TorchComms Triton device bitcode"
     VERBATIM

--- a/comms/torchcomms/triton/device_transport.cu
+++ b/comms/torchcomms/triton/device_transport.cu
@@ -1,0 +1,104 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// TorchComms Transport API - implementations for LLVM bitcode
+//
+// Extern C wrappers around comms::pipes P2pNvlTransportDevice methods.
+// All operations construct a block-scope ThreadGroup internally.
+
+#include <cuda_runtime.h>
+
+#include "comms/pipes/MultiPeerDeviceHandle.cuh"
+#include "comms/pipes/ThreadGroup.cuh"
+
+using namespace comms::pipes;
+
+extern "C" {
+
+// --- Data Transfer ---
+
+__device__ __noinline__ int torchcomms_transport_send(
+    void* handle_ptr,
+    int peer,
+    void* src_ptr,
+    unsigned long long nbytes) {
+  auto* handle = reinterpret_cast<MultiPeerDeviceHandle*>(handle_ptr);
+  auto group = make_block_group();
+  handle->get_nvl(peer).send(group, src_ptr, static_cast<size_t>(nbytes));
+  return 0;
+}
+
+__device__ __noinline__ int torchcomms_transport_recv(
+    void* handle_ptr,
+    int peer,
+    void* dst_ptr,
+    unsigned long long nbytes) {
+  auto* handle = reinterpret_cast<MultiPeerDeviceHandle*>(handle_ptr);
+  auto group = make_block_group();
+  handle->get_nvl(peer).recv(group, dst_ptr, static_cast<size_t>(nbytes));
+  return 0;
+}
+
+// --- Signaling ---
+
+__device__ int torchcomms_transport_signal(
+    void* handle_ptr,
+    int peer,
+    int signal_id,
+    int op,
+    unsigned long long value) {
+  auto* handle = reinterpret_cast<MultiPeerDeviceHandle*>(handle_ptr);
+  auto group = make_block_group();
+  handle->get_nvl(peer).signal_threadgroup(
+      group,
+      static_cast<uint64_t>(signal_id),
+      static_cast<SignalOp>(op),
+      static_cast<uint64_t>(value));
+  return 0;
+}
+
+__device__ int torchcomms_transport_wait_signal(
+    void* handle_ptr,
+    int peer,
+    int signal_id,
+    int op,
+    unsigned long long value) {
+  auto* handle = reinterpret_cast<MultiPeerDeviceHandle*>(handle_ptr);
+  auto group = make_block_group();
+  handle->get_nvl(peer).wait_signal_until_threadgroup(
+      group,
+      static_cast<uint64_t>(signal_id),
+      static_cast<CmpOp>(op),
+      static_cast<uint64_t>(value));
+  return 0;
+}
+
+// --- Barrier ---
+
+__device__ int
+torchcomms_transport_barrier(void* handle_ptr, int peer, int barrier_id) {
+  auto* handle = reinterpret_cast<MultiPeerDeviceHandle*>(handle_ptr);
+  auto group = make_block_group();
+  handle->get_nvl(peer).barrier_sync_threadgroup(
+      group, static_cast<uint64_t>(barrier_id));
+  return 0;
+}
+
+// --- Properties ---
+
+__device__ int torchcomms_transport_my_rank(void* handle_ptr) {
+  return reinterpret_cast<MultiPeerDeviceHandle*>(handle_ptr)->myRank;
+}
+
+__device__ int torchcomms_transport_n_ranks(void* handle_ptr) {
+  return reinterpret_cast<MultiPeerDeviceHandle*>(handle_ptr)->nRanks;
+}
+
+__device__ int torchcomms_transport_num_nvl_peers(void* handle_ptr) {
+  return reinterpret_cast<MultiPeerDeviceHandle*>(handle_ptr)->numNvlPeers;
+}
+
+__device__ int torchcomms_transport_get_type(void* handle_ptr, int rank) {
+  return static_cast<int>(
+      reinterpret_cast<MultiPeerDeviceHandle*>(handle_ptr)->get_type(rank));
+}
+
+} // extern "C"

--- a/comms/torchcomms/triton/device_transport.h
+++ b/comms/torchcomms/triton/device_transport.h
@@ -1,0 +1,76 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// TorchComms Transport API - C-style declarations for LLVM bitcode
+//
+// Declares extern C wrappers for pipes transport operations
+// (P2pNvlTransportDevice send/recv/signal/barrier).
+// Compiled to LLVM bitcode with clang for linking with Triton kernels.
+//
+// Handle: void* device pointer to comms::pipes::MultiPeerDeviceHandle,
+// allocated by PipesDeviceBackend::create_device_transport().
+//
+// All operations use comms::pipes::make_block_group() internally —
+// all 128 Triton threads cooperate as one block group.
+// Send/recv are __noinline__ to prevent memcpy_vectorized alloca inlining.
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void* TorchCommsTransportHandle;
+
+// --- Data Transfer (block-cooperative, pipelined NVLink) ---
+
+__device__ int torchcomms_transport_send(
+    TorchCommsTransportHandle handle,
+    int peer,
+    void* src_ptr,
+    unsigned long long nbytes);
+
+__device__ int torchcomms_transport_recv(
+    TorchCommsTransportHandle handle,
+    int peer,
+    void* dst_ptr,
+    unsigned long long nbytes);
+
+// --- Signaling ---
+
+// op: 0=SIGNAL_SET, 1=SIGNAL_ADD
+__device__ int torchcomms_transport_signal(
+    TorchCommsTransportHandle handle,
+    int peer,
+    int signal_id,
+    int op,
+    unsigned long long value);
+
+// op: 0=CMP_EQ, 1=CMP_GT, 2=CMP_LT, 3=CMP_GE, 4=CMP_LE, 5=CMP_NE
+__device__ int torchcomms_transport_wait_signal(
+    TorchCommsTransportHandle handle,
+    int peer,
+    int signal_id,
+    int op,
+    unsigned long long value);
+
+// --- Barrier ---
+
+__device__ int torchcomms_transport_barrier(
+    TorchCommsTransportHandle handle,
+    int peer,
+    int barrier_id);
+
+// --- Properties ---
+
+__device__ int torchcomms_transport_my_rank(TorchCommsTransportHandle handle);
+__device__ int torchcomms_transport_n_ranks(TorchCommsTransportHandle handle);
+__device__ int torchcomms_transport_num_nvl_peers(
+    TorchCommsTransportHandle handle);
+
+// Returns TransportType as int: 0=SELF, 1=P2P_NVL, 2=P2P_IBGDA
+__device__ int torchcomms_transport_get_type(
+    TorchCommsTransportHandle handle,
+    int rank);
+
+#ifdef __cplusplus
+}
+#endif

--- a/comms/torchcomms/triton/device_window.cu
+++ b/comms/torchcomms/triton/device_window.cu
@@ -1,5 +1,5 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
-// TorchComms Triton Device API - nvcc-compiled implementations
+// TorchComms Triton Device Window - nvcc-compiled implementations
 //
 // This file provides extern "C" wrappers around TorchCommDeviceWindow methods.
 // Compiled with nvcc to support NCCLX GIN templates.

--- a/comms/torchcomms/triton/device_window.h
+++ b/comms/torchcomms/triton/device_window.h
@@ -5,7 +5,7 @@
 // Compiled to LLVM bitcode with clang for linking with Triton kernels.
 //
 // All functions use opaque void* handles to avoid C++ type dependencies.
-// The actual implementations (in torchcomms_device.cu) cast these to the
+// The actual implementations (in device_window.cu) cast these to the
 // appropriate TorchComms types.
 //
 // Usage:


### PR DESCRIPTION
Summary:

- Rename torchcomms_device.{h,cu} to device_window.{h,cu} with clean BUCK target rename
- Add device_transport.{h,cu}: C-style extern wrappers for pipes P2pNvlTransportDevice
  (send/recv/signal/wait_signal/barrier + properties)
- Add PipesDeviceBackend::create_device_transport(): device-allocates MultiPeerDeviceHandle
  (cudaMalloc + cudaMemcpy), returns managed TransportHandlePtr
- Add BUCK genrule device_transport_bitcode to compile transport externs to LLVM bitcode
- Update requires_torchcomms decorator to load both window + transport bitcode
  (transport silently skipped if not found)
- Add torchcomms.triton.fb.transport Python sub-namespace with Triton JIT wrappers
- Add get_device_transport Python binding on TorchCommNCCLX (ENABLE_PIPES)
- Add test_transport_my_rank e2e test
- Update CMakeLists.txt and tests for new filenames

Reviewed By: cenzhaometa

Differential Revision: D96954418
