### PR TITLE
Use FB_CUDACHECKTHROW for CUDA error checking in StreamCaptureModeGuard

### DIFF
--- a/comms/utils/CudaRAII.cc
+++ b/comms/utils/CudaRAII.cc
@@ -103,9 +103,16 @@ StreamCaptureModeGuard::StreamCaptureModeGuard(
   CUDA_CHECK(cudaThreadExchangeStreamCaptureMode(&prevMode_));
 }
 
+void StreamCaptureModeGuard::init() {
+  FB_CUDACHECKTHROW(exchangeFn_(ctx_, &prevMode_));
+}
+
 StreamCaptureModeGuard::~StreamCaptureModeGuard() {
   if (exchangeFn_) {
-    (void)exchangeFn_(ctx_, &prevMode_);
+    CUDA_CHECK_WITH_IGNORE(
+        exchangeFn_(ctx_, &prevMode_),
+        cudaErrorCudartUnloading,
+        cudaErrorContextIsDestroyed);
   } else {
     CUDA_CHECK_WITH_IGNORE(
         cudaThreadExchangeStreamCaptureMode(&prevMode_),

--- a/comms/utils/CudaRAII.h
+++ b/comms/utils/CudaRAII.h
@@ -95,7 +95,7 @@ class StreamCaptureModeGuard {
           return static_cast<Api*>(ctx)->threadExchangeStreamCaptureMode(mode);
         }),
         prevMode_(desiredMode) {
-    (void)exchangeFn_(ctx_, &prevMode_);
+    init();
   }
 
   ~StreamCaptureModeGuard();
@@ -106,6 +106,8 @@ class StreamCaptureModeGuard {
   StreamCaptureModeGuard& operator=(StreamCaptureModeGuard&&) = delete;
 
  private:
+  void init();
+
   void* ctx_{nullptr};
   ExchangeFn exchangeFn_{nullptr};
   cudaStreamCaptureMode prevMode_;


### PR DESCRIPTION
Summary:
Replace `(void)` cast on `exchangeFn_` return value with `FB_CUDACHECKTHROW` macro
for proper CUDA error checking in the template constructor of `StreamCaptureModeGuard`.
This ensures CUDA errors from `threadExchangeStreamCaptureMode` are properly detected
and thrown as exceptions rather than silently ignored.

Moves the `exchangeFn_` call from the template constructor body into a private
`init()` method defined in CudaRAII.cc to avoid exposing `checks.h` in the header
(which would conflict with `CUDA_CHECK` redefinitions in downstream consumers).

Conflict:
- https://fburl.com/code/690766mh
- https://fburl.com/code/49ftm15n

Follow-up to D96736215 which added `(void)` casts to suppress warnings.

Depends on D96736215

Reviewed By: dolpm

Differential Revision: D96952824


