### PR TITLE
Use -isystem for CUDA includes to prevent header conflicts

### DIFF
--- a/comms/ncclx/v2_28/makefiles/common.mk
+++ b/comms/ncclx/v2_28/makefiles/common.mk
@@ -72,7 +72,7 @@ CXXSTD ?= -std=c++17
 
 CXXFLAGS   := -DCUDA_MAJOR=$(CUDA_MAJOR) -DCUDA_MINOR=$(CUDA_MINOR) -fPIC -fvisibility=hidden \
               -Wall -Wno-unused-function -Wno-sign-compare -std=c++2a -Wvla \
-              -I $(CUDA_INC) -I $(CUDA_INC)/cccl \
+              -isystem $(CUDA_INC) -isystem $(CUDA_INC)/cccl \
               $(CXXFLAGS)
 # Maxrregcount needs to be set accordingly to NCCL_MAX_NTHREADS (otherwise it will cause kernel launch errors)
 # 512 : 120, 640 : 96, 768 : 80, 1024 : 60

--- a/comms/ncclx/v2_29/makefiles/common.mk
+++ b/comms/ncclx/v2_29/makefiles/common.mk
@@ -74,7 +74,7 @@ CXXSTD ?= -std=c++17
 
 CXXFLAGS   := -DCUDA_MAJOR=$(CUDA_MAJOR) -DCUDA_MINOR=$(CUDA_MINOR) -fPIC -fvisibility=hidden \
               -Wall -Wno-unused-function -Wno-sign-compare -std=c++2a -Wvla \
-              -I $(CUDA_INC) -I $(CUDA_INC)/cccl \
+              -isystem $(CUDA_INC) -isystem $(CUDA_INC)/cccl \
               $(CXXFLAGS)
 # Maxrregcount needs to be set accordingly to NCCL_MAX_NTHREADS (otherwise it will cause kernel launch errors)
 # 512 : 120, 640 : 96, 768 : 80, 1024 : 60


### PR DESCRIPTION
Summary:
The pytorch/almalinux-builder:cuda12.8 docker image was updated on
2026-03-17 to include CUDA 12.8 toolkit with NCCL 2.29 device headers
at /usr/local/cuda-12.8/targets/x86_64-linux/include/nccl_device/.

This broke the torchcomms OSS CI because the ncclx Makefile's common.mk
prepends -I $(CUDA_INC) to CXXFLAGS, which gets searched before the ncclx
source tree's own -I../include. The NCCL 2.29 headers define
NCCL_GIN_MAX_CONNECTIONS (renamed from v2.28's NCCL_GIN_MAX_CONTEXTS),
and the shared include guard _NCCL_GIN_DEVICE_HOST_COMMON_H_ causes
the v2.28 version to be silently skipped, leading to:

  error: 'NCCL_GIN_MAX_CONTEXTS' was not declared in this scope

Fix by changing -I to -isystem for CUDA toolkit include paths. The
-isystem flag gives these paths lower priority than -I paths, so ncclx's
own headers always take precedence. This is also semantically correct
since CUDA toolkit headers are system headers.

Applied to both v2_28 and v2_29 makefiles.

Reviewed By: pavanbalaji

Differential Revision: D96954078


