### PR TITLE
Fix ncclUid broadcast in NcclxBaseTestFixture for TCPStore mode (#1135)

### DIFF
--- a/comms/ncclx/v2_27/meta/logger/tests/MemoryLoggingTest.cc
+++ b/comms/ncclx/v2_27/meta/logger/tests/MemoryLoggingTest.cc
@@ -26,7 +26,6 @@
 #include "comm.h" // @manual
 #include "debug.h" // @manual
 #include "nccl.h" // @manual
-#include "transport.h" // @manual
 
 class MemoryLoggingTestFixture : public NcclxBaseTestFixture {
  public:

--- a/comms/ncclx/v2_27/meta/transport/tests/LazyConnectTest.cc
+++ b/comms/ncclx/v2_27/meta/transport/tests/LazyConnectTest.cc
@@ -127,8 +127,8 @@ class NcclxLazyConnectTestFixture : public NcclxBaseTestFixture {
 };
 
 TEST_P(NcclxLazyConnectTestFixture, InitOnly) {
-  NCCLCHECK_TEST(ncclCommInitRankConfig(
-      &rootComm, numRanks, ncclUid, globalRank, nullptr));
+  rootComm = createNcclComm(
+      globalRank, numRanks, localRank, false, nullptr, server.get());
   ASSERT_NE(nullptr, rootComm);
   // Nothing should be connected or initialized if no collective is called
   if (NCCL_RUNTIME_CONNECT) {
@@ -152,8 +152,8 @@ TEST_P(NcclxLazyConnectTestFixture, InitOnly) {
 
 TEST_P(NcclxLazyConnectTestFixture, AllReduceRing) {
   EnvRAII algo(NCCL_ALGO, std::string("RING"));
-  NCCLCHECK_TEST(ncclCommInitRankConfig(
-      &rootComm, numRanks, ncclUid, globalRank, nullptr));
+  rootComm = createNcclComm(
+      globalRank, numRanks, localRank, false, nullptr, server.get());
   ASSERT_NE(nullptr, rootComm);
 
   size_t count = 1 << 10; // 1K elements
@@ -181,8 +181,8 @@ TEST_P(NcclxLazyConnectTestFixture, AllReduceRing) {
 
 TEST_P(NcclxLazyConnectTestFixture, AllReduceTree) {
   EnvRAII algo(NCCL_ALGO, std::string("TREE"));
-  NCCLCHECK_TEST(ncclCommInitRankConfig(
-      &rootComm, numRanks, ncclUid, globalRank, nullptr));
+  rootComm = createNcclComm(
+      globalRank, numRanks, localRank, false, nullptr, server.get());
   ASSERT_NE(nullptr, rootComm);
 
   size_t count = 1 << 10; // 1K elements
@@ -210,8 +210,8 @@ TEST_P(NcclxLazyConnectTestFixture, AllReduceTree) {
 
 TEST_P(NcclxLazyConnectTestFixture, AllReduceTreeIncreaseChannel) {
   EnvRAII algo(NCCL_ALGO, std::string("TREE"));
-  NCCLCHECK_TEST(ncclCommInitRankConfig(
-      &rootComm, numRanks, ncclUid, globalRank, nullptr));
+  rootComm = createNcclComm(
+      globalRank, numRanks, localRank, false, nullptr, server.get());
   ASSERT_NE(nullptr, rootComm);
 
   size_t smallCount = 1 << 10; // 1K elements
@@ -240,8 +240,8 @@ TEST_P(NcclxLazyConnectTestFixture, AllReduceTreeIncreaseChannel) {
 }
 
 TEST_P(NcclxLazyConnectTestFixture, Alltoall) {
-  NCCLCHECK_TEST(ncclCommInitRankConfig(
-      &rootComm, numRanks, ncclUid, globalRank, nullptr));
+  rootComm = createNcclComm(
+      globalRank, numRanks, localRank, false, nullptr, server.get());
   ASSERT_NE(nullptr, rootComm);
 
   size_t count = 1 << 20; // 1M BF16 elements
@@ -291,8 +291,8 @@ TEST_P(NcclxLazyConnectTestFixture, Alltoall) {
 }
 
 TEST_P(NcclxLazyConnectTestFixture, AlltoallAndAllGather) {
-  NCCLCHECK_TEST(ncclCommInitRankConfig(
-      &rootComm, numRanks, ncclUid, globalRank, nullptr));
+  rootComm = createNcclComm(
+      globalRank, numRanks, localRank, false, nullptr, server.get());
   ASSERT_NE(nullptr, rootComm);
 
   size_t count = 1 << 20; // 1M BF16 elements
@@ -329,8 +329,8 @@ TEST_P(NcclxLazyConnectTestFixture, higherP2pChThanColl) {
   EnvRAII p2pMinCh(NCCL_MIN_P2P_NCHANNELS, (int64_t)MAXCHANNELS);
   EnvRAII p2pMaxCh(NCCL_MAX_P2P_NCHANNELS, (int64_t)MAXCHANNELS);
 
-  NCCLCHECK_TEST(ncclCommInitRankConfig(
-      &rootComm, numRanks, ncclUid, globalRank, nullptr));
+  rootComm = createNcclComm(
+      globalRank, numRanks, localRank, false, nullptr, server.get());
   ASSERT_NE(nullptr, rootComm);
   // p2p channels should be higher than collective channels
   EXPECT_GE(rootComm->p2pnChannels, rootComm->collChannels);
@@ -366,8 +366,8 @@ TEST_P(NcclxLazyConnectTestFixture, higherP2pChThanColl) {
 }
 
 TEST_P(NcclxLazyConnectTestFixture, ChildCommAllGather) {
-  NCCLCHECK_TEST(ncclCommInitRankConfig(
-      &rootComm, numRanks, ncclUid, globalRank, nullptr));
+  rootComm = createNcclComm(
+      globalRank, numRanks, localRank, false, nullptr, server.get());
   ASSERT_NE(nullptr, rootComm);
 
   ncclComm_t childComm;
@@ -517,8 +517,8 @@ TEST_P(NcclxLazyConnectTestFixture, ChildCommAllGather) {
 // }
 
 TEST_P(NcclxLazyConnectTestFixture, ChildCommLazyConfig) {
-  NCCLCHECK_TEST(ncclCommInitRankConfig(
-      &rootComm, numRanks, ncclUid, globalRank, nullptr));
+  rootComm = createNcclComm(
+      globalRank, numRanks, localRank, false, nullptr, server.get());
   ASSERT_NE(nullptr, rootComm);
   // split/duplicate a communicator always enable lazy connect and setup
   // channels
@@ -555,8 +555,8 @@ TEST_P(NcclxLazyConnectTestFixture, ChildCommLazyConfig) {
 }
 
 TEST_P(NcclxLazyConnectTestFixture, coalescedAllReduce) {
-  NCCLCHECK_TEST(
-      ncclCommInitRankConfig(&comm, numRanks, ncclUid, globalRank, nullptr));
+  comm = createNcclComm(
+      globalRank, numRanks, localRank, false, nullptr, server.get());
   ASSERT_NE(nullptr, comm);
 
   size_t count = 1 << 10; // 1K elements

--- a/comms/ncclx/v2_28/meta/logger/tests/MemoryLoggingTest.cc
+++ b/comms/ncclx/v2_28/meta/logger/tests/MemoryLoggingTest.cc
@@ -26,9 +26,6 @@
 #include "comm.h" // @manual
 #include "debug.h" // @manual
 #include "nccl.h" // @manual
-#include "transport.h" // @manual
-
-#include <sstream>
 
 class MemoryLoggingTestFixture : public NcclxBaseTestFixture {
  public:
@@ -261,8 +258,8 @@ TEST_P(MemoryLoggingTestFixture, ncclInternalBufferLogTest) {
   // First comm creation as well as first kernel launch has some extra memory
   // usage (https://fburl.com/code/rxjvjads), use second comm
   // creation/collective for testing
-  NCCLCHECK_TEST(
-      ncclCommInitRankConfig(&comm, numRanks, ncclUid, globalRank, nullptr));
+  comm = createNcclComm(
+      globalRank, numRanks, localRank, false, nullptr, server.get());
   std::cout << "Rank " << this->globalRank << " finished init, run AR"
             << std::endl;
   size_t count = 1 << 10; // 1K elements
@@ -363,8 +360,8 @@ TEST_P(MemoryLoggingTestFixture, userBufferLoggingTest) {
 
   auto logFileName = initLogger();
   EXPECT_EQ(NCCL_COMM_WORLD, nullptr);
-  NCCLCHECK_TEST(
-      ncclCommInitRankConfig(&comm, numRanks, ncclUid, globalRank, nullptr));
+  comm = createNcclComm(
+      globalRank, numRanks, localRank, false, nullptr, server.get());
 
   /* mapper registration logic */
   void *buf = nullptr, *segHdl = nullptr;

--- a/comms/ncclx/v2_28/meta/transport/tests/LazyConnectTest.cc
+++ b/comms/ncclx/v2_28/meta/transport/tests/LazyConnectTest.cc
@@ -126,8 +126,8 @@ class NcclxLazyConnectTestFixture : public NcclxBaseTestFixture {
 };
 
 TEST_P(NcclxLazyConnectTestFixture, InitOnly) {
-  NCCLCHECK_TEST(ncclCommInitRankConfig(
-      &rootComm, numRanks, ncclUid, globalRank, nullptr));
+  rootComm = createNcclComm(
+      globalRank, numRanks, localRank, false, nullptr, server.get());
   ASSERT_NE(nullptr, rootComm);
   // Nothing should be connected or initialized if no collective is called
   if (NCCL_RUNTIME_CONNECT) {
@@ -151,8 +151,8 @@ TEST_P(NcclxLazyConnectTestFixture, InitOnly) {
 
 TEST_P(NcclxLazyConnectTestFixture, AllReduceRing) {
   EnvRAII algo(NCCL_ALGO, std::string("RING"));
-  NCCLCHECK_TEST(ncclCommInitRankConfig(
-      &rootComm, numRanks, ncclUid, globalRank, nullptr));
+  rootComm = createNcclComm(
+      globalRank, numRanks, localRank, false, nullptr, server.get());
   ASSERT_NE(nullptr, rootComm);
 
   size_t count = 1 << 10; // 1K elements
@@ -180,8 +180,8 @@ TEST_P(NcclxLazyConnectTestFixture, AllReduceRing) {
 
 TEST_P(NcclxLazyConnectTestFixture, AllReduceTree) {
   EnvRAII algo(NCCL_ALGO, std::string("TREE"));
-  NCCLCHECK_TEST(ncclCommInitRankConfig(
-      &rootComm, numRanks, ncclUid, globalRank, nullptr));
+  rootComm = createNcclComm(
+      globalRank, numRanks, localRank, false, nullptr, server.get());
   ASSERT_NE(nullptr, rootComm);
 
   size_t count = 1 << 10; // 1K elements
@@ -209,8 +209,8 @@ TEST_P(NcclxLazyConnectTestFixture, AllReduceTree) {
 
 TEST_P(NcclxLazyConnectTestFixture, AllReduceTreeIncreaseChannel) {
   EnvRAII algo(NCCL_ALGO, std::string("TREE"));
-  NCCLCHECK_TEST(ncclCommInitRankConfig(
-      &rootComm, numRanks, ncclUid, globalRank, nullptr));
+  rootComm = createNcclComm(
+      globalRank, numRanks, localRank, false, nullptr, server.get());
   ASSERT_NE(nullptr, rootComm);
 
   size_t smallCount = 1 << 10; // 1K elements
@@ -239,8 +239,8 @@ TEST_P(NcclxLazyConnectTestFixture, AllReduceTreeIncreaseChannel) {
 }
 
 TEST_P(NcclxLazyConnectTestFixture, Alltoall) {
-  NCCLCHECK_TEST(ncclCommInitRankConfig(
-      &rootComm, numRanks, ncclUid, globalRank, nullptr));
+  rootComm = createNcclComm(
+      globalRank, numRanks, localRank, false, nullptr, server.get());
   ASSERT_NE(nullptr, rootComm);
 
   size_t count = 1 << 20; // 1M BF16 elements
@@ -290,8 +290,8 @@ TEST_P(NcclxLazyConnectTestFixture, Alltoall) {
 }
 
 TEST_P(NcclxLazyConnectTestFixture, AlltoallAndAllGather) {
-  NCCLCHECK_TEST(ncclCommInitRankConfig(
-      &rootComm, numRanks, ncclUid, globalRank, nullptr));
+  rootComm = createNcclComm(
+      globalRank, numRanks, localRank, false, nullptr, server.get());
   ASSERT_NE(nullptr, rootComm);
 
   size_t count = 1 << 20; // 1M BF16 elements
@@ -328,8 +328,8 @@ TEST_P(NcclxLazyConnectTestFixture, higherP2pChThanColl) {
   EnvRAII p2pMinCh(NCCL_MIN_P2P_NCHANNELS, (int64_t)MAXCHANNELS);
   EnvRAII p2pMaxCh(NCCL_MAX_P2P_NCHANNELS, (int64_t)MAXCHANNELS);
 
-  NCCLCHECK_TEST(ncclCommInitRankConfig(
-      &rootComm, numRanks, ncclUid, globalRank, nullptr));
+  rootComm = createNcclComm(
+      globalRank, numRanks, localRank, false, nullptr, server.get());
   ASSERT_NE(nullptr, rootComm);
   // p2p channels should be higher than collective channels
   EXPECT_GE(rootComm->p2pnChannels, rootComm->collChannels);
@@ -365,8 +365,8 @@ TEST_P(NcclxLazyConnectTestFixture, higherP2pChThanColl) {
 }
 
 TEST_P(NcclxLazyConnectTestFixture, ChildCommAllGather) {
-  NCCLCHECK_TEST(ncclCommInitRankConfig(
-      &rootComm, numRanks, ncclUid, globalRank, nullptr));
+  rootComm = createNcclComm(
+      globalRank, numRanks, localRank, false, nullptr, server.get());
   ASSERT_NE(nullptr, rootComm);
 
   ncclComm_t childComm;
@@ -516,8 +516,8 @@ TEST_P(NcclxLazyConnectTestFixture, ChildCommAllGather) {
 // }
 
 TEST_P(NcclxLazyConnectTestFixture, ChildCommLazyConfig) {
-  NCCLCHECK_TEST(ncclCommInitRankConfig(
-      &rootComm, numRanks, ncclUid, globalRank, nullptr));
+  rootComm = createNcclComm(
+      globalRank, numRanks, localRank, false, nullptr, server.get());
   ASSERT_NE(nullptr, rootComm);
   // split/duplicate a communicator always enable lazy connect and setup
   // channels
@@ -554,8 +554,8 @@ TEST_P(NcclxLazyConnectTestFixture, ChildCommLazyConfig) {
 }
 
 TEST_P(NcclxLazyConnectTestFixture, coalescedAllReduce) {
-  NCCLCHECK_TEST(
-      ncclCommInitRankConfig(&comm, numRanks, ncclUid, globalRank, nullptr));
+  comm = createNcclComm(
+      globalRank, numRanks, localRank, false, nullptr, server.get());
   ASSERT_NE(nullptr, comm);
 
   size_t count = 1 << 10; // 1K elements

--- a/comms/ncclx/v2_29/meta/logger/tests/MemoryLoggingTest.cc
+++ b/comms/ncclx/v2_29/meta/logger/tests/MemoryLoggingTest.cc
@@ -247,8 +247,8 @@ TEST_P(MemoryLoggingTestFixture, ncclInternalBufferLogTest) {
   // First comm creation as well as first kernel launch has some extra memory
   // usage (https://fburl.com/code/rxjvjads), use second comm
   // creation/collective for testing
-  NCCLCHECK_TEST(
-      ncclCommInitRankConfig(&comm, numRanks, ncclUid, globalRank, nullptr));
+  comm = createNcclComm(
+      globalRank, numRanks, localRank, false, nullptr, server.get());
   std::cout << "Rank " << this->globalRank << " finished init, run AR"
             << std::endl;
   size_t count = 1 << 10; // 1K elements
@@ -349,8 +349,8 @@ TEST_P(MemoryLoggingTestFixture, userBufferLoggingTest) {
 
   auto logFileName = initLogger();
   EXPECT_EQ(NCCL_COMM_WORLD, nullptr);
-  NCCLCHECK_TEST(
-      ncclCommInitRankConfig(&comm, numRanks, ncclUid, globalRank, nullptr));
+  comm = createNcclComm(
+      globalRank, numRanks, localRank, false, nullptr, server.get());
 
   /* mapper registration logic */
   void *buf = nullptr, *segHdl = nullptr;

--- a/comms/ncclx/v2_29/meta/transport/tests/LazyConnectTest.cc
+++ b/comms/ncclx/v2_29/meta/transport/tests/LazyConnectTest.cc
@@ -127,8 +127,8 @@ class NcclxLazyConnectTestFixture : public NcclxBaseTestFixture {
 };
 
 TEST_P(NcclxLazyConnectTestFixture, InitOnly) {
-  NCCLCHECK_TEST(ncclCommInitRankConfig(
-      &rootComm, numRanks, ncclUid, globalRank, nullptr));
+  rootComm = createNcclComm(
+      globalRank, numRanks, localRank, false, nullptr, server.get());
   ASSERT_NE(nullptr, rootComm);
   // Nothing should be connected or initialized if no collective is called
   if (NCCL_RUNTIME_CONNECT) {
@@ -152,8 +152,8 @@ TEST_P(NcclxLazyConnectTestFixture, InitOnly) {
 
 TEST_P(NcclxLazyConnectTestFixture, AllReduceRing) {
   EnvRAII algo(NCCL_ALGO, std::string("RING"));
-  NCCLCHECK_TEST(ncclCommInitRankConfig(
-      &rootComm, numRanks, ncclUid, globalRank, nullptr));
+  rootComm = createNcclComm(
+      globalRank, numRanks, localRank, false, nullptr, server.get());
   ASSERT_NE(nullptr, rootComm);
 
   size_t count = 1 << 10; // 1K elements
@@ -181,8 +181,8 @@ TEST_P(NcclxLazyConnectTestFixture, AllReduceRing) {
 
 TEST_P(NcclxLazyConnectTestFixture, AllReduceTree) {
   EnvRAII algo(NCCL_ALGO, std::string("TREE"));
-  NCCLCHECK_TEST(ncclCommInitRankConfig(
-      &rootComm, numRanks, ncclUid, globalRank, nullptr));
+  rootComm = createNcclComm(
+      globalRank, numRanks, localRank, false, nullptr, server.get());
   ASSERT_NE(nullptr, rootComm);
 
   size_t count = 1 << 10; // 1K elements
@@ -210,8 +210,8 @@ TEST_P(NcclxLazyConnectTestFixture, AllReduceTree) {
 
 TEST_P(NcclxLazyConnectTestFixture, AllReduceTreeIncreaseChannel) {
   EnvRAII algo(NCCL_ALGO, std::string("TREE"));
-  NCCLCHECK_TEST(ncclCommInitRankConfig(
-      &rootComm, numRanks, ncclUid, globalRank, nullptr));
+  rootComm = createNcclComm(
+      globalRank, numRanks, localRank, false, nullptr, server.get());
   ASSERT_NE(nullptr, rootComm);
 
   size_t smallCount = 1 << 10; // 1K elements
@@ -240,8 +240,8 @@ TEST_P(NcclxLazyConnectTestFixture, AllReduceTreeIncreaseChannel) {
 }
 
 TEST_P(NcclxLazyConnectTestFixture, Alltoall) {
-  NCCLCHECK_TEST(ncclCommInitRankConfig(
-      &rootComm, numRanks, ncclUid, globalRank, nullptr));
+  rootComm = createNcclComm(
+      globalRank, numRanks, localRank, false, nullptr, server.get());
   ASSERT_NE(nullptr, rootComm);
 
   size_t count = 1 << 20; // 1M BF16 elements
@@ -291,8 +291,8 @@ TEST_P(NcclxLazyConnectTestFixture, Alltoall) {
 }
 
 TEST_P(NcclxLazyConnectTestFixture, AlltoallAndAllGather) {
-  NCCLCHECK_TEST(ncclCommInitRankConfig(
-      &rootComm, numRanks, ncclUid, globalRank, nullptr));
+  rootComm = createNcclComm(
+      globalRank, numRanks, localRank, false, nullptr, server.get());
   ASSERT_NE(nullptr, rootComm);
 
   size_t count = 1 << 20; // 1M BF16 elements
@@ -329,8 +329,8 @@ TEST_P(NcclxLazyConnectTestFixture, higherP2pChThanColl) {
   EnvRAII p2pMinCh(NCCL_MIN_P2P_NCHANNELS, (int64_t)MAXCHANNELS);
   EnvRAII p2pMaxCh(NCCL_MAX_P2P_NCHANNELS, (int64_t)MAXCHANNELS);
 
-  NCCLCHECK_TEST(ncclCommInitRankConfig(
-      &rootComm, numRanks, ncclUid, globalRank, nullptr));
+  rootComm = createNcclComm(
+      globalRank, numRanks, localRank, false, nullptr, server.get());
   ASSERT_NE(nullptr, rootComm);
   // p2p channels should be higher than collective channels
   EXPECT_GE(rootComm->p2pnChannels, rootComm->collChannels);
@@ -366,8 +366,8 @@ TEST_P(NcclxLazyConnectTestFixture, higherP2pChThanColl) {
 }
 
 TEST_P(NcclxLazyConnectTestFixture, ChildCommAllGather) {
-  NCCLCHECK_TEST(ncclCommInitRankConfig(
-      &rootComm, numRanks, ncclUid, globalRank, nullptr));
+  rootComm = createNcclComm(
+      globalRank, numRanks, localRank, false, nullptr, server.get());
   ASSERT_NE(nullptr, rootComm);
 
   ncclComm_t childComm;
@@ -517,8 +517,8 @@ TEST_P(NcclxLazyConnectTestFixture, ChildCommAllGather) {
 // }
 
 TEST_P(NcclxLazyConnectTestFixture, ChildCommLazyConfig) {
-  NCCLCHECK_TEST(ncclCommInitRankConfig(
-      &rootComm, numRanks, ncclUid, globalRank, nullptr));
+  rootComm = createNcclComm(
+      globalRank, numRanks, localRank, false, nullptr, server.get());
   ASSERT_NE(nullptr, rootComm);
   // split/duplicate a communicator always enable lazy connect and setup
   // channels
@@ -555,8 +555,8 @@ TEST_P(NcclxLazyConnectTestFixture, ChildCommLazyConfig) {
 }
 
 TEST_P(NcclxLazyConnectTestFixture, coalescedAllReduce) {
-  NCCLCHECK_TEST(
-      ncclCommInitRankConfig(&comm, numRanks, ncclUid, globalRank, nullptr));
+  comm = createNcclComm(
+      globalRank, numRanks, localRank, false, nullptr, server.get());
   ASSERT_NE(nullptr, comm);
 
   size_t count = 1 << 10; // 1K elements


### PR DESCRIPTION
Summary:

D95974997 removed MPI from RE mode, but NcclxBaseTestFixture::SetUp() only broadcast ncclUid via MPI. In TCPStore mode (now always used in RE), SetUp returns early without broadcasting ncclUid, causing tests that call ncclCommInitRankConfig(..., ncclUid, ...) to pass an all-zeros uniqueId on non-rank-0 processes. This fails with "No ncclUniqueId provided in nccl baseline init mode" (v2.29.7 validation).

Fix:
- Delete NcclxBaseTestFixture::ncclUid member and its generation/broadcast code
- Replace all ncclCommInitRankConfig(..., ncclUid, ...) calls with createNcclComm() which handles ncclUid broadcast internally via TCPStore
- Move isFastInitDisabled lambda into #if TEST_ENABLE_FASTINIT guard to fix unused variable warning

Affected tests:
- MemoryLoggingTest.cc / MemoryTracerTest.cc (shared): 3 call sites
- LazyConnectTest.cc (v2_27, v2_28, v2_29): 10 call sites each

Reviewed By: mingrany

Differential Revision: D96573561
