### PR TITLE
Use swap idiom for all ibverbx RAII move assignments

### DIFF
--- a/comms/ctran/backends/ib/CtranIb.cc
+++ b/comms/ctran/backends/ib/CtranIb.cc
@@ -995,9 +995,6 @@ commResult_t CtranIb::initRemoteTransStates(void) {
     localVc = std::make_unique<LocalVirtualConn>(devices, ncclLogData);
   }
 
-  cqMutex.unlock();
-  localVcMutex.unlock();
-
   return commSuccess;
 }
 

--- a/comms/ctran/backends/ib/CtranIb.cc
+++ b/comms/ctran/backends/ib/CtranIb.cc
@@ -977,6 +977,14 @@ commResult_t CtranIb::initRemoteTransStates(void) {
   // create a new cq
   {
     std::unique_lock<std::mutex> lock(cqMutex);
+
+    // Clear old CQs before creating new ones (fixes accumulation on
+    // reconfigure).
+    for (int device = 0; device < NCCL_CTRAN_IB_DEVICES_PER_RANK; device++) {
+      devices[device].ibvCq = nullptr;
+    }
+    cqs.clear(); // IbvCq destructors call ibv_destroy_cq
+
     for (int device = 0; device < NCCL_CTRAN_IB_DEVICES_PER_RANK; device++) {
       auto createCqResult =
           devices[device].ibvDevice->createCq(maxCqe, nullptr, nullptr, 0);

--- a/comms/ctran/ibverbx/IbvAh.cc
+++ b/comms/ctran/ibverbx/IbvAh.cc
@@ -2,6 +2,8 @@
 
 #include "comms/ctran/ibverbx/IbvAh.h"
 
+#include <utility>
+
 #include <folly/logging/xlog.h>
 #include "comms/ctran/ibverbx/IbverbxSymbols.h"
 
@@ -19,8 +21,7 @@ IbvAh::IbvAh(IbvAh&& other) noexcept {
 }
 
 IbvAh& IbvAh::operator=(IbvAh&& other) noexcept {
-  ah_ = other.ah_;
-  other.ah_ = nullptr;
+  std::swap(ah_, other.ah_);
   return *this;
 }
 

--- a/comms/ctran/ibverbx/IbvCq.cc
+++ b/comms/ctran/ibverbx/IbvCq.cc
@@ -2,6 +2,8 @@
 
 #include <cuda.h>
 #include <cuda_runtime.h>
+#include <utility>
+
 #include <fmt/format.h>
 #include <folly/logging/xlog.h>
 
@@ -58,10 +60,8 @@ IbvCq::IbvCq(IbvCq&& other) noexcept {
 }
 
 IbvCq& IbvCq::operator=(IbvCq&& other) noexcept {
-  cq_ = other.cq_;
-  deviceId_ = other.deviceId_;
-  other.cq_ = nullptr;
-  other.deviceId_ = -1;
+  std::swap(cq_, other.cq_);
+  std::swap(deviceId_, other.deviceId_);
   return *this;
 }
 

--- a/comms/ctran/ibverbx/IbvDevice.cc
+++ b/comms/ctran/ibverbx/IbvDevice.cc
@@ -1,6 +1,9 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include "comms/ctran/ibverbx/IbvDevice.h"
+
+#include <utility>
+
 #include "comms/ctran/ibverbx/IbverbxSymbols.h"
 
 namespace ibverbx {
@@ -226,15 +229,11 @@ IbvDevice::IbvDevice(IbvDevice&& other) noexcept {
 }
 
 IbvDevice& IbvDevice::operator=(IbvDevice&& other) noexcept {
-  device_ = other.device_;
-  context_ = other.context_;
-  port_ = other.port_;
-  dataDirect_ = other.dataDirect_;
-  deviceId_ = other.deviceId_;
-
-  other.device_ = nullptr;
-  other.context_ = nullptr;
-  other.deviceId_ = -1;
+  std::swap(device_, other.device_);
+  std::swap(context_, other.context_);
+  std::swap(port_, other.port_);
+  std::swap(dataDirect_, other.dataDirect_);
+  std::swap(deviceId_, other.deviceId_);
   return *this;
 }
 

--- a/comms/ctran/ibverbx/IbvMr.cc
+++ b/comms/ctran/ibverbx/IbvMr.cc
@@ -1,6 +1,8 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 #include "comms/ctran/ibverbx/IbvMr.h"
 
+#include <utility>
+
 #include <folly/logging/xlog.h>
 #include "comms/ctran/ibverbx/IbverbxSymbols.h"
 
@@ -18,8 +20,7 @@ IbvMr::IbvMr(IbvMr&& other) noexcept {
 }
 
 IbvMr& IbvMr::operator=(IbvMr&& other) noexcept {
-  mr_ = other.mr_;
-  other.mr_ = nullptr;
+  std::swap(mr_, other.mr_);
   return *this;
 }
 

--- a/comms/ctran/ibverbx/IbvPd.cc
+++ b/comms/ctran/ibverbx/IbvPd.cc
@@ -1,5 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#include <utility>
+
 #include "comms/ctran/ibverbx/IbvPd.h"
 #include "comms/ctran/ibverbx/IbvVirtualCq.h"
 #include "comms/ctran/ibverbx/IbverbxSymbols.h"
@@ -22,11 +24,9 @@ IbvPd::IbvPd(IbvPd&& other) noexcept {
 }
 
 IbvPd& IbvPd::operator=(IbvPd&& other) noexcept {
-  pd_ = other.pd_;
-  dataDirect_ = other.dataDirect_;
-  deviceId_ = other.deviceId_;
-  other.pd_ = nullptr;
-  other.deviceId_ = -1;
+  std::swap(pd_, other.pd_);
+  std::swap(dataDirect_, other.dataDirect_);
+  std::swap(deviceId_, other.deviceId_);
   return *this;
 }
 

--- a/comms/ctran/ibverbx/IbvQp.cc
+++ b/comms/ctran/ibverbx/IbvQp.cc
@@ -5,6 +5,7 @@
 #include <fmt/format.h>
 #include <folly/json.h>
 #include <folly/logging/xlog.h>
+#include <utility>
 
 #include "comms/ctran/ibverbx/IbvQp.h"
 #include "comms/ctran/ibverbx/Ibvcore.h"
@@ -37,12 +38,10 @@ IbvQp::IbvQp(IbvQp&& other) noexcept {
 }
 
 IbvQp& IbvQp::operator=(IbvQp&& other) noexcept {
-  qp_ = other.qp_;
-  physicalSendWrStatus_ = std::move(other.physicalSendWrStatus_);
-  physicalRecvWrStatus_ = std::move(other.physicalRecvWrStatus_);
-  deviceId_ = other.deviceId_;
-  other.qp_ = nullptr;
-  other.deviceId_ = -1;
+  std::swap(qp_, other.qp_);
+  std::swap(physicalSendWrStatus_, other.physicalSendWrStatus_);
+  std::swap(physicalRecvWrStatus_, other.physicalRecvWrStatus_);
+  std::swap(deviceId_, other.deviceId_);
   return *this;
 }
 

--- a/comms/ctran/ibverbx/IbvSrq.cc
+++ b/comms/ctran/ibverbx/IbvSrq.cc
@@ -2,6 +2,8 @@
 
 #include "comms/ctran/ibverbx/IbvSrq.h"
 
+#include <utility>
+
 #include <folly/logging/xlog.h>
 #include "comms/ctran/ibverbx/IbverbxSymbols.h"
 
@@ -19,8 +21,7 @@ IbvSrq::IbvSrq(IbvSrq&& other) noexcept {
 }
 
 IbvSrq& IbvSrq::operator=(IbvSrq&& other) noexcept {
-  srq_ = other.srq_;
-  other.srq_ = nullptr;
+  std::swap(srq_, other.srq_);
   return *this;
 }
 

--- a/comms/ctran/ibverbx/tests/IbverbxTest.cc
+++ b/comms/ctran/ibverbx/tests/IbverbxTest.cc
@@ -2,11 +2,24 @@
 
 #include "comms/ctran/ibverbx/tests/IbverbxTestFixture.h"
 
+#include <folly/ScopeGuard.h>
+#include "comms/ctran/ibverbx/IbverbxSymbols.h"
+
 FOLLY_INIT_LOGGING_CONFIG(
     ".=WARNING"
     ";default:async=true,sync_level=WARNING");
 
 namespace ibverbx {
+
+namespace {
+int g_destroyCqCount = 0;
+int (*g_origDestroyCq)(ibv_cq*) = nullptr;
+
+int countingDestroyCq(ibv_cq* cq) {
+  g_destroyCqCount++;
+  return g_origDestroyCq(cq);
+}
+} // namespace
 
 TEST_F(IbverbxTestFixture, MultiThreadInit) {
   std::thread t1([]() { ASSERT_TRUE(ibvInit()); });
@@ -456,6 +469,70 @@ TEST_F(IbverbxTestFixture, IbvCq) {
   IbvCq cq2(std::move(cq1));
   ASSERT_EQ(cq1.cq(), nullptr);
   ASSERT_EQ(cq2.cq(), cqRawPtr);
+}
+
+TEST_F(IbverbxTestFixture, IbvCqMoveAssignment) {
+  auto devices = IbvDevice::ibvGetDeviceList();
+  ASSERT_TRUE(devices);
+  auto& device = devices->at(0);
+
+  int cqe = 100;
+
+  // Create two CQs
+  auto cq1 = device.createCq(cqe, nullptr, nullptr, 0);
+  ASSERT_TRUE(cq1);
+  auto cq2 = device.createCq(cqe, nullptr, nullptr, 0);
+  ASSERT_TRUE(cq2);
+
+  auto cq1RawPtr = cq1->cq();
+  auto cq2RawPtr = cq2->cq();
+
+  // Move assign cq2 into cq1.
+  // Swap idiom: cq1 gets cq2's resource, cq2 gets cq1's old resource
+  *cq1 = std::move(*cq2);
+  ASSERT_EQ(cq1->cq(), cq2RawPtr);
+  ASSERT_EQ(cq2->cq(), cq1RawPtr);
+
+  // Move assign into default-constructed (empty) CQ
+  IbvCq cq3;
+  ASSERT_EQ(cq3.cq(), nullptr);
+  cq3 = std::move(*cq1);
+  ASSERT_EQ(cq3.cq(), cq2RawPtr);
+  ASSERT_EQ(cq1->cq(), nullptr);
+}
+
+TEST_F(IbverbxTestFixture, IbvCqMoveAssignmentDestroysOldCq) {
+  auto devices = IbvDevice::ibvGetDeviceList();
+  ASSERT_TRUE(devices);
+  auto& device = devices->at(0);
+  int cqe = 100;
+
+  g_origDestroyCq = ibvSymbols.ibv_internal_destroy_cq;
+  ibvSymbols.ibv_internal_destroy_cq = countingDestroyCq;
+  auto guard = folly::makeGuard(
+      [] { ibvSymbols.ibv_internal_destroy_cq = g_origDestroyCq; });
+
+  // Verify old CQ is destroyed after move assignment.
+  // Swap idiom defers destruction to the source's destructor,
+  // so we scope the source to trigger it before the assertion.
+  auto cq1 = device.createCq(cqe, nullptr, nullptr, 0);
+  ASSERT_TRUE(cq1);
+  {
+    auto cq2 = device.createCq(cqe, nullptr, nullptr, 0);
+    ASSERT_TRUE(cq2);
+    g_destroyCqCount = 0;
+    *cq1 = std::move(*cq2);
+  }
+  // cq2 destroyed — its destructor cleans up the old cq1 resource
+  EXPECT_EQ(g_destroyCqCount, 1)
+      << "Move assignment must destroy the old CQ to prevent kernel resource leak";
+
+  // Move-assign into empty CQ — no destroy expected
+  g_destroyCqCount = 0;
+  IbvCq cq3;
+  cq3 = std::move(*cq1);
+  EXPECT_EQ(g_destroyCqCount, 0)
+      << "Move assignment into empty CQ should not call destroy";
 }
 
 TEST_F(IbverbxTestFixture, IbvQp) {


### PR DESCRIPTION
Summary:
A reviewer on D96937709 suggested using the swap idiom for `IbvCq::operator=` instead of duplicating the destroy call. We applied that fix there. The same principle (keep native IB verbs calls centralized in one place) applies to all six other RAII wrappers in `ibverbx`.

Each `operator=(T&&)` overwrites the resource pointer without destroying the old one, leaking kernel resources if called on an already-initialized object. The swap idiom delegates cleanup to the destructor (which already handles it), avoiding code duplication and ensuring future teardown changes only need updating in one place.

**Affected classes:** `IbvQp`, `IbvMr`, `IbvPd`, `IbvAh`, `IbvSrq`, `IbvDevice`.

Differential Revision: D96969267


