### PR TITLE
Switch IBGDA transport from direct linking to dlopen for doca/ibverbs/mlx5 (#1137)

### DIFF
--- a/comms/pipes/IbverbsLazy.cc
+++ b/comms/pipes/IbverbsLazy.cc
@@ -1,0 +1,94 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/IbverbsLazy.h"
+
+#include <dlfcn.h>
+#include <glog/logging.h>
+
+#include <mutex>
+
+namespace comms::pipes {
+
+namespace {
+
+// Function pointer types for ibverbs functions we load via dlopen.
+using IbvRegMrIova2Fn =
+    struct ibv_mr* (*)(struct ibv_pd*, void*, size_t, uint64_t, unsigned int);
+
+using IbvRegDmabufMrFn =
+    struct ibv_mr* (*)(struct ibv_pd*, uint64_t, size_t, uint64_t, int, int);
+
+// Loaded function pointers (populated by load_ibverbs_lazy).
+IbvRegMrIova2Fn gIbvRegMrIova2 = nullptr;
+IbvRegDmabufMrFn gIbvRegDmabufMr = nullptr;
+
+std::once_flag gLoadFlag;
+int gLoadResult = -1;
+
+void do_load() {
+  void* handle = dlopen("libibverbs.so.1", RTLD_NOW | RTLD_NOLOAD);
+  if (!handle) {
+    // Not already loaded — open fresh
+    handle = dlopen("libibverbs.so.1", RTLD_NOW);
+  }
+  if (!handle) {
+    LOG(ERROR) << "IbverbsLazy: failed to dlopen libibverbs.so.1: "
+               << dlerror();
+    gLoadResult = 1;
+    return;
+  }
+
+  // ibv_reg_mr_iova2 — available since IBVERBS 1.8
+  gIbvRegMrIova2 = reinterpret_cast<IbvRegMrIova2Fn>(
+      dlvsym(handle, "ibv_reg_mr_iova2", "IBVERBS_1.8"));
+  if (!gIbvRegMrIova2) {
+    LOG(WARNING) << "IbverbsLazy: ibv_reg_mr_iova2 not available: "
+                 << dlerror();
+  }
+
+  // ibv_reg_dmabuf_mr — available since IBVERBS 1.12
+  gIbvRegDmabufMr = reinterpret_cast<IbvRegDmabufMrFn>(
+      dlvsym(handle, "ibv_reg_dmabuf_mr", "IBVERBS_1.12"));
+  if (!gIbvRegDmabufMr) {
+    LOG(WARNING) << "IbverbsLazy: ibv_reg_dmabuf_mr not available: "
+                 << dlerror();
+  }
+
+  gLoadResult = 0;
+}
+
+int load_ibverbs_lazy() {
+  std::call_once(gLoadFlag, do_load);
+  return gLoadResult;
+}
+
+} // namespace
+
+struct ibv_mr* lazy_ibv_reg_mr_iova2(
+    struct ibv_pd* pd,
+    void* addr,
+    size_t length,
+    uint64_t iova,
+    unsigned int access) {
+  load_ibverbs_lazy();
+  if (!gIbvRegMrIova2) {
+    return nullptr;
+  }
+  return gIbvRegMrIova2(pd, addr, length, iova, access);
+}
+
+struct ibv_mr* lazy_ibv_reg_dmabuf_mr(
+    struct ibv_pd* pd,
+    uint64_t offset,
+    size_t length,
+    uint64_t iova,
+    int fd,
+    int access) {
+  load_ibverbs_lazy();
+  if (!gIbvRegDmabufMr) {
+    return nullptr;
+  }
+  return gIbvRegDmabufMr(pd, offset, length, iova, fd, access);
+}
+
+} // namespace comms::pipes

--- a/comms/pipes/IbverbsLazy.h
+++ b/comms/pipes/IbverbsLazy.h
@@ -1,0 +1,143 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+// Ibverbs type definitions and dlopen'd function wrappers for pipes.
+//
+// When pipes uses doca_gpunetio_dl (dlopen variant), neither libibverbs nor
+// libmlx5 are linked at build time. DOCA internally handles its own ibverbs
+// calls through its wrapper layer. However, pipes also calls a few ibverbs
+// functions directly (e.g., ibv_reg_mr_iova2, ibv_reg_dmabuf_mr) that are
+// NOT covered by DOCA's wrapper. This header provides:
+//
+//   1. Struct/enum definitions for ibverbs types that pipes accesses by value
+//      (ibv_mr, ibv_port_attr, ibv_mtu, etc.). These mirror the ABI-stable
+//      layouts from <infiniband/verbs.h>.
+//
+//   2. dlopen-based wrappers for ibverbs functions not covered by DOCA's
+//      doca_verbs_wrapper_ibv_* API.
+//
+// Include order: include this header AFTER <doca_gpunetio_host.h> so that
+// any forward declarations from DOCA headers are completed here.
+
+#include <cstddef>
+#include <cstdint>
+
+// If infiniband/verbs.h is already included (e.g., via doca_verbs_ibv_wrapper.h
+// in conda builds where rdma-core headers are installed), skip our type
+// definitions and only provide the dlopen wrappers below.
+#ifndef INFINIBAND_VERBS_H
+
+// Forward declarations — these may already be forward-declared by DOCA
+// wrapper headers. Repeating a forward declaration is valid C++.
+struct ibv_context;
+struct ibv_pd;
+struct ibv_device;
+
+// ============================================================================
+// ibv_mtu — MTU enum (matches libibverbs ABI)
+// ============================================================================
+enum ibv_mtu {
+  IBV_MTU_256 = 1,
+  IBV_MTU_512 = 2,
+  IBV_MTU_1024 = 3,
+  IBV_MTU_2048 = 4,
+  IBV_MTU_4096 = 5,
+};
+
+// ============================================================================
+// ibv_port_state — Port state enum
+// ============================================================================
+enum ibv_port_state {
+  IBV_PORT_NOP = 0,
+  IBV_PORT_DOWN = 1,
+  IBV_PORT_INIT = 2,
+  IBV_PORT_ARMED = 3,
+  IBV_PORT_ACTIVE = 4,
+  IBV_PORT_ACTIVE_DEFER = 5,
+};
+
+// ============================================================================
+// ibv_port_attr — Port attributes (matches libibverbs ABI layout)
+// ============================================================================
+struct ibv_port_attr {
+  enum ibv_port_state state;
+  enum ibv_mtu max_mtu;
+  enum ibv_mtu active_mtu;
+  int gid_tbl_len;
+  uint32_t port_cap_flags;
+  uint32_t max_msg_sz;
+  uint32_t bad_pkey_cntr;
+  uint32_t qkey_viol_cntr;
+  uint16_t pkey_tbl_len;
+  uint16_t lid;
+  uint16_t sm_lid;
+  uint8_t lmc;
+  uint8_t max_vl_num;
+  uint8_t sm_sl;
+  uint8_t subnet_timeout;
+  uint8_t init_type_reply;
+  uint8_t active_width;
+  uint8_t active_speed;
+  uint8_t phys_state;
+  uint8_t link_layer;
+  uint8_t flags;
+  uint16_t port_cap_flags2;
+  uint32_t active_speed_ex;
+};
+
+// Link-layer constants
+constexpr uint8_t IBV_LINK_LAYER_INFINIBAND = 1;
+constexpr uint8_t IBV_LINK_LAYER_ETHERNET = 2;
+
+// ============================================================================
+// ibv_mr — Memory region (matches libibverbs ABI layout)
+// DOCA's ibv wrapper only forward-declares ibv_mr as an opaque type;
+// we provide the full definition so pipes can access lkey/rkey fields.
+// ============================================================================
+struct ibv_mr {
+  struct ibv_context* context;
+  struct ibv_pd* pd;
+  void* addr;
+  size_t length;
+  uint32_t handle;
+  uint32_t lkey;
+  uint32_t rkey;
+};
+
+#endif // INFINIBAND_VERBS_H
+
+namespace comms::pipes {
+
+// ============================================================================
+// dlopen'd ibverbs functions not covered by DOCA's wrapper API
+// ============================================================================
+
+/**
+ * ibv_reg_mr_iova2 — Register MR with explicit IOVA (zero-based MR support).
+ * Wraps the libibverbs ibv_reg_mr_iova2() function loaded via dlopen.
+ *
+ * @return ibv_mr* on success, nullptr on failure.
+ */
+struct ibv_mr* lazy_ibv_reg_mr_iova2(
+    struct ibv_pd* pd,
+    void* addr,
+    size_t length,
+    uint64_t iova,
+    unsigned int access);
+
+/**
+ * ibv_reg_dmabuf_mr — Register DMA-BUF memory region.
+ * Wraps the libibverbs ibv_reg_dmabuf_mr() function loaded via dlopen.
+ *
+ * @return ibv_mr* on success, nullptr on failure.
+ */
+struct ibv_mr* lazy_ibv_reg_dmabuf_mr(
+    struct ibv_pd* pd,
+    uint64_t offset,
+    size_t length,
+    uint64_t iova,
+    int fd,
+    int access);
+
+} // namespace comms::pipes

--- a/comms/pipes/MultipeerIbgdaTransport.cc
+++ b/comms/pipes/MultipeerIbgdaTransport.cc
@@ -13,9 +13,12 @@
 
 #include <fmt/core.h>
 
+#include "comms/pipes/IbverbsLazy.h"
 #include "comms/pipes/MultipeerIbgdaDeviceTransport.cuh"
 #include "comms/pipes/MultipeerIbgdaTransportCuda.cuh"
 #include "comms/pipes/rdma/NicDiscovery.h"
+
+#include "doca_verbs_net_wrapper.h"
 
 namespace comms::pipes {
 
@@ -126,10 +129,12 @@ void MultipeerIbgdaTransport::initDocaGpu() {
 }
 
 void MultipeerIbgdaTransport::openIbDevice() {
-  // Get all IB devices
+  // Get all IB devices via DOCA's dlopen wrapper
   int numDevices = 0;
-  ibv_device** deviceList = ibv_get_device_list(&numDevices);
-  if (!deviceList || numDevices == 0) {
+  ibv_device** deviceList = nullptr;
+  doca_error_t docaRet =
+      doca_verbs_wrapper_ibv_get_device_list(&numDevices, &deviceList);
+  if (docaRet != DOCA_SUCCESS || !deviceList || numDevices == 0) {
     throw std::runtime_error("No IB devices found");
   }
 
@@ -153,13 +158,15 @@ void MultipeerIbgdaTransport::openIbDevice() {
   // Find the NIC by name
   int nicIdx = -1;
   for (int i = 0; i < numDevices; i++) {
-    if (nicDeviceName_ == deviceList[i]->name) {
+    const char* devName = nullptr;
+    doca_verbs_wrapper_ibv_get_device_name(deviceList[i], &devName);
+    if (devName && nicDeviceName_ == devName) {
       nicIdx = i;
       break;
     }
   }
   if (nicIdx < 0) {
-    ibv_free_device_list(deviceList);
+    doca_verbs_wrapper_ibv_free_device_list(deviceList);
     throw std::runtime_error("Specified NIC not found: " + nicDeviceName_);
   }
   VLOG(1) << "MultipeerIbgdaTransport: found NIC " << nicDeviceName_
@@ -169,20 +176,21 @@ void MultipeerIbgdaTransport::openIbDevice() {
           << " for GPU " << gpuPciBusId_;
 
   // Open the device
-  ibvCtx_ = ibv_open_device(deviceList[nicIdx]);
-  ibv_free_device_list(deviceList);
-  if (!ibvCtx_) {
+  docaRet = doca_verbs_wrapper_ibv_open_device(deviceList[nicIdx], &ibvCtx_);
+  doca_verbs_wrapper_ibv_free_device_list(deviceList);
+  if (docaRet != DOCA_SUCCESS || !ibvCtx_) {
     throw std::runtime_error("Failed to open IB device: " + nicDeviceName_);
   }
 
   // Allocate PD
-  ibvPd_ = ibv_alloc_pd(ibvCtx_);
-  if (!ibvPd_) {
+  docaRet = doca_verbs_wrapper_ibv_alloc_pd(ibvCtx_, &ibvPd_);
+  if (docaRet != DOCA_SUCCESS || !ibvPd_) {
     throw std::runtime_error("Failed to allocate protection domain");
   }
 
   // Query GID
-  if (ibv_query_gid(ibvCtx_, 1, gidIndex_, &localGid_) != 0) {
+  docaRet = doca_verbs_wrapper_ibv_query_gid(ibvCtx_, 1, gidIndex_, &localGid_);
+  if (docaRet != DOCA_SUCCESS) {
     throw std::runtime_error(
         "Failed to query GID at index " + std::to_string(gidIndex_));
   }
@@ -212,7 +220,8 @@ void MultipeerIbgdaTransport::openIbDevice() {
 
   // Query port to determine link layer (IB vs Ethernet)
   ibv_port_attr portAttr{};
-  if (ibv_query_port(ibvCtx_, 1, &portAttr) != 0) {
+  docaRet = doca_verbs_wrapper_ibv_query_port(ibvCtx_, 1, &portAttr);
+  if (docaRet != DOCA_SUCCESS) {
     throw std::runtime_error("Failed to query port attributes");
   }
 
@@ -303,7 +312,7 @@ void MultipeerIbgdaTransport::registerMemory() {
       doca_gpu_dmabuf_fd(docaGpu_, sinkBuffer_, sinkBufferSize_, &sinkDmabufFd);
   if (err == DOCA_SUCCESS && sinkDmabufFd >= 0) {
     // ibv_reg_dmabuf_mr: 4th param is iova — set to 0 for zero-based MR
-    sinkMr_ = ibv_reg_dmabuf_mr(
+    sinkMr_ = lazy_ibv_reg_dmabuf_mr(
         ibvPd_,
         0,
         sinkBufferSize_,
@@ -313,8 +322,8 @@ void MultipeerIbgdaTransport::registerMemory() {
   }
   if (!sinkMr_) {
     // Fallback: use ibv_reg_mr_iova2 with iova=0 for zero-based MR
-    sinkMr_ =
-        ibv_reg_mr_iova2(ibvPd_, sinkBuffer_, sinkBufferSize_, 0, accessFlags);
+    sinkMr_ = lazy_ibv_reg_mr_iova2(
+        ibvPd_, sinkBuffer_, sinkBufferSize_, 0, accessFlags);
     if (!sinkMr_) {
       throw std::runtime_error("Failed to register sink memory region");
     }
@@ -340,7 +349,7 @@ void MultipeerIbgdaTransport::createQpGroups() {
 
   // Query IB device capabilities for debugging
   ibv_device_attr devAttr{};
-  if (ibv_query_device(ibvCtx_, &devAttr) == 0) {
+  if (doca_verbs_wrapper_ibv_query_device(ibvCtx_, &devAttr) == DOCA_SUCCESS) {
     VLOG(1) << "MultipeerIbgdaTransport: IB device - max_qp=" << devAttr.max_qp
             << " max_cq=" << devAttr.max_cq << " max_mr=" << devAttr.max_mr
             << " max_qp_wr=" << devAttr.max_qp_wr;
@@ -420,7 +429,8 @@ void MultipeerIbgdaTransport::connectQp(
 
   // Query port for IB-specific parameters
   ibv_port_attr portAttr{};
-  if (ibv_query_port(ibvCtx_, 1, &portAttr) != 0) {
+  if (doca_verbs_wrapper_ibv_query_port(ibvCtx_, 1, &portAttr) !=
+      DOCA_SUCCESS) {
     LOG(WARNING) << "Failed to query port for IB-specific parameters";
   } else if (portAttr.link_layer == IBV_LINK_LAYER_INFINIBAND) {
     err = doca_verbs_ah_attr_set_dlid(ahAttr_, peerInfo.lid);
@@ -591,13 +601,13 @@ void MultipeerIbgdaTransport::cleanup() {
 
   // Destroy user buffer MRs
   for (auto& [_, mr] : registeredBuffers_) {
-    ibv_dereg_mr(mr);
+    doca_verbs_wrapper_ibv_dereg_mr(mr);
   }
   registeredBuffers_.clear();
 
   // Destroy sink MR
   if (sinkMr_) {
-    ibv_dereg_mr(sinkMr_);
+    doca_verbs_wrapper_ibv_dereg_mr(sinkMr_);
     sinkMr_ = nullptr;
   }
 
@@ -615,13 +625,13 @@ void MultipeerIbgdaTransport::cleanup() {
 
   // Destroy PD
   if (ibvPd_) {
-    ibv_dealloc_pd(ibvPd_);
+    doca_verbs_wrapper_ibv_dealloc_pd(ibvPd_);
     ibvPd_ = nullptr;
   }
 
   // Close device
   if (ibvCtx_) {
-    ibv_close_device(ibvCtx_);
+    doca_verbs_wrapper_ibv_close_device(ibvCtx_);
     ibvCtx_ = nullptr;
   }
 
@@ -656,7 +666,8 @@ void MultipeerIbgdaTransport::exchange() {
 
   // Query port for LID (IB only)
   ibv_port_attr exchPortAttr{};
-  if (ibv_query_port(ibvCtx_, 1, &exchPortAttr) != 0) {
+  if (doca_verbs_wrapper_ibv_query_port(ibvCtx_, 1, &exchPortAttr) !=
+      DOCA_SUCCESS) {
     LOG(WARNING) << "Failed to query port for LID";
   } else {
     myInfo.lid = exchPortAttr.lid;
@@ -723,7 +734,8 @@ void MultipeerIbgdaTransport::exchange() {
 
     // Query port for local LID (IB fabrics)
     ibv_port_attr loopbackPortAttr{};
-    if (ibv_query_port(ibvCtx_, 1, &loopbackPortAttr) == 0) {
+    if (doca_verbs_wrapper_ibv_query_port(ibvCtx_, 1, &loopbackPortAttr) ==
+        DOCA_SUCCESS) {
       selfInfo.lid = loopbackPortAttr.lid;
     }
 
@@ -823,7 +835,7 @@ IbgdaLocalBuffer MultipeerIbgdaTransport::registerBuffer(
   int dmabufFd = -1;
   doca_error_t err = doca_gpu_dmabuf_fd(docaGpu_, ptr, size, &dmabufFd);
   if (err == DOCA_SUCCESS && dmabufFd >= 0) {
-    mr = ibv_reg_dmabuf_mr(
+    mr = lazy_ibv_reg_dmabuf_mr(
         ibvPd_,
         0,
         size,
@@ -832,8 +844,9 @@ IbgdaLocalBuffer MultipeerIbgdaTransport::registerBuffer(
         accessFlags);
   }
   if (!mr) {
-    mr = ibv_reg_mr(ibvPd_, ptr, size, accessFlags);
-    if (!mr) {
+    doca_error_t regErr =
+        doca_verbs_wrapper_ibv_reg_mr(ibvPd_, ptr, size, accessFlags, &mr);
+    if (regErr != DOCA_SUCCESS || !mr) {
       throw std::runtime_error("Failed to register buffer with RDMA");
     }
   }
@@ -854,7 +867,7 @@ void MultipeerIbgdaTransport::deregisterBuffer(void* ptr) {
     return;
   }
 
-  ibv_dereg_mr(it->second);
+  doca_verbs_wrapper_ibv_dereg_mr(it->second);
   registeredBuffers_.erase(it);
 
   VLOG(1) << "MultipeerIbgdaTransport: deregistered buffer ptr=" << ptr;

--- a/comms/pipes/MultipeerIbgdaTransport.h
+++ b/comms/pipes/MultipeerIbgdaTransport.h
@@ -10,11 +10,12 @@
 #include <unordered_map>
 #include <vector>
 
-#include <infiniband/verbs.h>
-
 #include <doca_gpunetio_host.h>
+#include "doca_verbs_net_wrapper.h"
+
 #include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/pipes/IbgdaBuffer.h"
+#include "comms/pipes/IbverbsLazy.h"
 
 // Forward declarations for device types (defined in .cuh files)
 namespace comms::pipes {


### PR DESCRIPTION
Summary:

Switch comms/pipes IBGDA transport targets from doca_gpunetio (direct
linking) to doca_gpunetio_dl (dlopen variant), removing link-time
dependencies on rdma-core:ibverbs and rdma-core:mlx5.

Direct ibverbs calls are replaced with DOCA's doca_verbs_wrapper_ibv_*
functions (which internally dlopen libibverbs). For ibv_reg_mr_iova2 and
ibv_reg_dmabuf_mr (not covered by DOCA's wrapper), a temporary
IbverbsLazy module provides dlopen-based wrappers.

NOTE: IbverbsLazy is a temporary solution. The plan is to migrate pipes
to use ibverbx (comms/ctran/ibverbx/) which already provides a complete,
well-tested dlopen wrapper for all ibverbs/mlx5 functions.

Differential Revision: D96833981


