### PR TITLE
Add get_nvlink_address() to DeviceWindow and HostWindow

### DIFF
--- a/comms/pipes/tests/DeviceWindowTest.cc
+++ b/comms/pipes/tests/DeviceWindowTest.cc
@@ -841,4 +841,74 @@ TEST_F(DeviceWindowTestFixture, PeerIndexConversionRoundtripRank4Of8) {
   verifyPeerIndexConversionRoundtrip(4, 8);
 }
 
+// =============================================================================
+// get_nvlink_address Tests
+// =============================================================================
+
+TEST_F(DeviceWindowTestFixture, GetNvlinkAddress) {
+  const int myRank = 0;
+  const int nRanks = 4;
+
+  // Allocate a fake "window buffer" on device — all NVL peers point to this.
+  DeviceBuffer windowBuf(1024);
+
+  DeviceBuffer resultsBuf(nRanks * sizeof(int64_t));
+  auto* results_d = static_cast<int64_t*>(resultsBuf.get());
+
+  test::testDeviceWindowGetNvlinkAddress(
+      myRank, nRanks, windowBuf.get(), results_d);
+
+  std::vector<int64_t> results_h(nRanks);
+  CUDACHECK_TEST(cudaMemcpy(
+      results_h.data(),
+      results_d,
+      nRanks * sizeof(int64_t),
+      cudaMemcpyDeviceToHost));
+
+  // Self should return nullptr.
+  EXPECT_EQ(results_h[myRank], 0)
+      << "get_nvlink_address(self) should return nullptr";
+
+  // All NVL peers should return the window buffer pointer.
+  auto expected = reinterpret_cast<int64_t>(windowBuf.get());
+  for (int r = 0; r < nRanks; ++r) {
+    if (r == myRank) {
+      continue;
+    }
+    EXPECT_EQ(results_h[r], expected)
+        << "get_nvlink_address(" << r << ") should return window buf ptr";
+  }
+}
+
+TEST_F(DeviceWindowTestFixture, GetNvlinkAddressMiddleRank) {
+  const int myRank = 1;
+  const int nRanks = 3;
+
+  DeviceBuffer windowBuf(1024);
+
+  DeviceBuffer resultsBuf(nRanks * sizeof(int64_t));
+  auto* results_d = static_cast<int64_t*>(resultsBuf.get());
+
+  test::testDeviceWindowGetNvlinkAddress(
+      myRank, nRanks, windowBuf.get(), results_d);
+
+  std::vector<int64_t> results_h(nRanks);
+  CUDACHECK_TEST(cudaMemcpy(
+      results_h.data(),
+      results_d,
+      nRanks * sizeof(int64_t),
+      cudaMemcpyDeviceToHost));
+
+  auto expected = reinterpret_cast<int64_t>(windowBuf.get());
+  for (int r = 0; r < nRanks; ++r) {
+    if (r == myRank) {
+      EXPECT_EQ(results_h[r], 0)
+          << "get_nvlink_address(self) should return nullptr";
+    } else {
+      EXPECT_EQ(results_h[r], expected)
+          << "get_nvlink_address(" << r << ") should return window buf ptr";
+    }
+  }
+}
+
 } // namespace comms::pipes

--- a/comms/pipes/tests/DeviceWindowTest.cu
+++ b/comms/pipes/tests/DeviceWindowTest.cu
@@ -708,4 +708,29 @@ void testIbgdaSignalAggregateRead(
   CUDACHECK_TEST(cudaDeviceSynchronize());
 }
 
+// =============================================================================
+// DeviceWindow get_nvlink_address() Test
+// =============================================================================
+
+__global__ void
+getNvlinkAddressKernel(DeviceWindow dw, int nRanks, int64_t* results) {
+  for (int r = 0; r < nRanks; ++r) {
+    void* addr = dw.get_nvlink_address(r);
+    results[r] = reinterpret_cast<int64_t>(addr);
+  }
+}
+
+void testDeviceWindowGetNvlinkAddress(
+    int myRank,
+    int nRanks,
+    void* windowBuf_d,
+    int64_t* results) {
+  NvlOffsetPutDeviceWindowBuffers bufs;
+  auto dw = bufs.create_with_offset_put(myRank, nRanks, windowBuf_d);
+
+  getNvlinkAddressKernel<<<1, 1>>>(dw, nRanks, results);
+  CUDACHECK_TEST(cudaGetLastError());
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+}
+
 } // namespace comms::pipes::test

--- a/comms/pipes/tests/DeviceWindowTest.cuh
+++ b/comms/pipes/tests/DeviceWindowTest.cuh
@@ -219,4 +219,21 @@ void testDeviceWindowNvlBidirectionalOffsetPutSignal(
     std::size_t nbytes,
     int signalId);
 
+/**
+ * Test: DeviceWindow get_nvlink_address()
+ *
+ * Verifies that get_nvlink_address() returns the correct NVL-mapped
+ * pointer for NVL peers and nullptr for self.
+ *
+ * @param myRank Rank ID
+ * @param nRanks Total number of ranks
+ * @param windowBuf_d Device buffer used as the "window buffer" for peers
+ * @param results Output: one int64 per rank (the returned pointer value)
+ */
+void testDeviceWindowGetNvlinkAddress(
+    int myRank,
+    int nRanks,
+    void* windowBuf_d,
+    int64_t* results);
+
 } // namespace comms::pipes::test

--- a/comms/pipes/window/DeviceWindow.cuh
+++ b/comms/pipes/window/DeviceWindow.cuh
@@ -293,6 +293,35 @@ class DeviceWindow {
   }
 
   // ===========================================================================
+  // NVLink Address Query
+  // ===========================================================================
+
+#ifdef __CUDACC__
+  /**
+   * get_nvlink_address - Get the NVLink-mapped pointer to a peer's window buf.
+   *
+   * Thread-level API (idempotent): any thread may call independently.
+   *
+   * @param peer   Global rank of the peer.
+   * @param offset Byte offset into the peer's window buffer (default 0).
+   * @return NVLink-mapped device pointer, or nullptr if peer is not NVL.
+   */
+  __device__ __forceinline__ void* get_nvlink_address(
+      int peer,
+      std::size_t offset = 0) const {
+    DEVICE_WINDOW_CHECK_RANK(peer, handle_.nRanks);
+    if (peer == handle_.myRank) {
+      return nullptr;
+    }
+    if (handle_.get_type(peer) != TransportType::P2P_NVL) {
+      return nullptr;
+    }
+    int nvlIdx = rankToNvlPeerIndex_[peer];
+    return static_cast<char*>(windowNvlPeerPtrs_[nvlIdx]) + offset;
+  }
+#endif
+
+  // ===========================================================================
   // Transport Access
   // ===========================================================================
 

--- a/comms/pipes/window/HostWindow.cc
+++ b/comms/pipes/window/HostWindow.cc
@@ -169,6 +169,23 @@ HostWindow::~HostWindow() {
   // DeviceBuffers are freed by DeviceBuffer destructors (RAII)
 }
 
+void* HostWindow::get_nvlink_address(int peer, std::size_t offset) const {
+  if (exchangedNvlMappedPtrs_.empty() || peer == myRank_ || peer < 0 ||
+      peer >= nRanks_) {
+    return nullptr;
+  }
+  // Find peer in NVL peer list (sorted by global rank).
+  for (int i = 0; i < static_cast<int>(nvlPeerRanks_.size()); ++i) {
+    if (nvlPeerRanks_[i] == peer) {
+      // Map nvlPeerIdx → nvlLocalRank (skip self's slot).
+      int nvlLocal = (i < nvlLocalRank_) ? i : (i + 1);
+      auto* base = static_cast<char*>(exchangedNvlMappedPtrs_[nvlLocal]);
+      return base ? base + offset : nullptr;
+    }
+  }
+  return nullptr;
+}
+
 void HostWindow::exchange() {
   if (exchanged_) {
     throw std::runtime_error("HostWindow::exchange() called more than once");

--- a/comms/pipes/window/HostWindow.h
+++ b/comms/pipes/window/HostWindow.h
@@ -179,6 +179,19 @@ class HostWindow {
     return static_cast<int>(ibgdaPeerRanks_.size());
   }
 
+  /**
+   * get_nvlink_address - Get the NVLink-mapped pointer to a peer's window buf.
+   *
+   * Returns the IPC-mapped device pointer for the given peer's registered
+   * window buffer. Returns nullptr if the peer is not NVLink-accessible,
+   * is self, or no buffer has been registered/exchanged.
+   *
+   * @param peer   Global rank of the peer.
+   * @param offset Byte offset into the peer's window buffer (default 0).
+   * @return Host-visible device pointer, or nullptr.
+   */
+  void* get_nvlink_address(int peer, std::size_t offset = 0) const;
+
  private:
   void uploadRegistrationsToDevice();
 


### PR DESCRIPTION
Summary:
Add get_nvlink_address(peer, offset) API to the Pipes DeviceWindow
and HostWindow, mirroring D95908486 which added the same for the
NCCLX backend.

The NVL-mapped peer buffer pointers already exist on the device side
(windowNvlPeerPtrs_, populated during registerAndExchangeBuffer()),
but were only used internally by offset-based put(). This diff
exposes them through a public accessor.

Device-side (DeviceWindow):
- Returns windowNvlPeerPtrs_[nvlPeerIdx] + offset for NVL peers
- Returns nullptr for self and IBGDA peers
- Thread-level API (idempotent, no synchronization needed)

Host-side (HostWindow):
- Returns exchangedNvlMappedPtrs_[nvlLocalRank] + offset for NVL peers
- Returns nullptr for self, IBGDA peers, or when no buffer is exchanged

Reviewed By: siyengar

Differential Revision: D96985181


