### PR TITLE
fix cmdCbPlan leak + omit heap alloc (#1139)

### DIFF
--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -120,14 +120,9 @@ OrderedWorkStreamGuard::Scope OrderedWorkStreamGuard::acquire(
   return Scope(*this, userStream, captureInfo);
 }
 
-struct cmdCbPlan {
-  CtranGpeCmd* cmd{nullptr};
-  CtranGpe* gpe{nullptr};
-};
-
 void CUDART_CB CtranGpe::Impl::cmdCb(void* data) {
-  struct cmdCbPlan* plan = reinterpret_cast<struct cmdCbPlan*>(data);
-  plan->gpe->pimpl->cmdEnqueue(plan->cmd);
+  CtranGpeCmd* cmd = reinterpret_cast<CtranGpeCmd*>(data);
+  cmd->gpe->pimpl->cmdEnqueue(cmd);
 }
 
 CtranGpeCmd::~CtranGpeCmd() {
@@ -349,24 +344,17 @@ commResult_t CtranGpe::Impl::submit(
     }
     if (streamCaptureInfo.status == cudaStreamCaptureStatusActive) {
       FB_COMMCHECK(preLaunchGraphPrepare(cmd, graphPrepareFn));
-      struct cmdCbPlan* plan = new struct cmdCbPlan;
-      plan->cmd = cmd;
-      plan->gpe = this->gpe;
       cmd->persistent = true;
       // Mark the flag as persistent so reclaim() won't steal it between
       // graph replays (the kernel writes KERNEL_UNSET after each replay).
       if (kernelFlag) {
         kernelFlag->setPersistent();
       }
+      cmd->gpe = this->gpe;
 
       FB_COMMCHECKGOTO(
           utils::cudagraph::addHostNode(
-              cmd,
-              reinterpret_cast<void*>(plan),
-              cmdCb,
-              cmdDestroy,
-              kernelConfig.stream,
-              streamCaptureInfo),
+              cmd, cmdCb, cmdDestroy, kernelConfig.stream, streamCaptureInfo),
           res,
           fail);
     } else {

--- a/comms/ctran/gpe/CtranGpeImpl.h
+++ b/comms/ctran/gpe/CtranGpeImpl.h
@@ -147,6 +147,7 @@ class CtranGpeCmd {
   std::shared_ptr<std::atomic_flag> cpuFlag{nullptr};
 
   bool persistent{false};
+  CtranGpe* gpe{nullptr};
 
   std::optional<std::chrono::milliseconds> timeout{std::nullopt};
 

--- a/comms/ctran/gpe/tests/CtranGpeUT.cc
+++ b/comms/ctran/gpe/tests/CtranGpeUT.cc
@@ -1579,6 +1579,74 @@ TEST_F(CtranGpeTest, GraphCaptureWithHostNode) {
 }
 #endif
 
+// Verify that destroying a captured graph triggers cmdDestroy, which resets
+// KernelElem statuses and frees the persistent cmd. After graph destruction,
+// all pool resources held by the graph should be reclaimable.
+//
+TEST_F(CtranGpeTest, GraphCaptureDestroyFreesResources) {
+  auto gpe = std::unique_ptr<CtranGpe>(new CtranGpe(cudaDev, dummyComm));
+  cudaStream_t stream;
+  CUDACHECK_TEST(cudaStreamCreate(&stream));
+
+  constexpr int kVal = 99;
+  int* buf = nullptr;
+  int* valPtr = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMemset(buf, 0, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMallocHost(&valPtr, sizeof(int)));
+  *valPtr = kVal;
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  CUDACHECK_TEST(cudaStreamBeginCapture(stream, cudaStreamCaptureModeRelaxed));
+
+  {
+    uint64_t dummyOpCount = 100;
+    std::vector<std::unique_ptr<struct OpElem>> ops;
+    auto& op = ops.emplace_back(
+        std::make_unique<OpElem>(
+            OpElem::opType::RECV, dummyComm, dummyOpCount));
+    op->recv.recvbuff = nullptr;
+    op->recv.count = 0;
+    op->recv.datatype = commInt8;
+    op->recv.peerRank = 0;
+
+    auto config = KernelConfig(
+        KernelConfig::KernelType::ALLGATHER, stream, "dummyAlgo", dummyOpCount);
+    ctranKernelSetAllGatherArgs(
+        buf, valPtr, commInt8, count, dummyDevState_d, &config.args);
+
+    auto res = gpe->submit(
+        std::move(ops),
+        &CtranGpeTestAlgoFunc,
+        config,
+        reinterpret_cast<void*>(CtranGpeTestKernel));
+    ASSERT_EQ(res, commSuccess);
+  }
+
+  cudaGraph_t graph;
+  CUDACHECK_TEST(cudaStreamEndCapture(stream, &graph));
+  ASSERT_NE(graph, nullptr);
+
+  cudaGraphExec_t graphExec;
+  CUDACHECK_TEST(cudaGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+
+  CUDACHECK_TEST(cudaGraphLaunch(graphExec, stream));
+  CUDACHECK_TEST(cudaStreamSynchronize(stream));
+
+  std::vector<int> hostBuf(count, 0);
+  CUDACHECK_TEST(cudaMemcpy(
+      hostBuf.data(), buf, sizeof(int) * count, cudaMemcpyDeviceToHost));
+  EXPECT_THAT(hostBuf, testing::Each(kVal));
+
+  CUDACHECK_TEST(cudaGraphExecDestroy(graphExec));
+  CUDACHECK_TEST(cudaGraphDestroy(graph));
+
+  EXPECT_EQ(gpe->numInUseKernelFlags(), 0);
+
+  CUDACHECK_TEST(cudaFree(buf));
+  CUDACHECK_TEST(cudaFreeHost(valPtr));
+  CUDACHECK_TEST(cudaStreamDestroy(stream));
+}
 TEST_F(CtranGpeTest, SubmitCustomKernArgs) {
   auto gpe = std::unique_ptr<CtranGpe>(new CtranGpe(cudaDev, dummyComm));
   cudaStream_t stream;

--- a/comms/ctran/utils/CudaGraphUtils.h
+++ b/comms/ctran/utils/CudaGraphUtils.h
@@ -27,16 +27,15 @@ inline cudaError_t getStreamCaptureInfo(
 }
 
 inline commResult_t addHostNode(
-    void* objectPtr,
-    void* data,
+    void* cmd,
     cudaHostFn_t execCallback,
     cudaHostFn_t destroyCallback,
     cudaStream_t stream,
     StreamCaptureInfo& info) {
-  FB_CUDACHECK(cudaLaunchHostFunc(stream, execCallback, data));
+  FB_CUDACHECK(cudaLaunchHostFunc(stream, execCallback, cmd));
   cudaUserObject_t object;
   FB_CUDACHECK(cudaUserObjectCreate(
-      &object, objectPtr, destroyCallback, 1, cudaUserObjectNoDestructorSync));
+      &object, cmd, destroyCallback, 1, cudaUserObjectNoDestructorSync));
 
   // Handover ownership to CUDA graph
   FB_CUDACHECK(


### PR DESCRIPTION
Summary:

for some reason we have cmdCbPlan, which bundles a cmd pointer and a gpe pointer for the host node callback. cmdCb received plan as its argument but never freed it. cmdDestroy received cmd (not plan) and deleted cmd only. nothing ever freed plan, resulting in one leak per graph-captured op

we can add a gpe field directly to CtranGpeCmd, eliminating the need for cmdCbPlan entirely. now cmd is passed directly as both the cudaLaunchHostFunc callback data and the cudaUserObjectCreate destroy object.

no intermediate allocation, no leak.

Reviewed By: dboyda

Differential Revision: D95406538
