### PR TITLE
Fix cvar initialization ordering in ncclCommInitRankConfig and ncclCommInitAll (#1140)

### DIFF
--- a/comms/ncclx/v2_27/src/init.cc
+++ b/comms/ncclx/v2_27/src/init.cc
@@ -2151,13 +2151,14 @@ ncclResult_t ncclCommInitAll(ncclComm_t* comms, int ndev, const int* devlist) {
   int totalnDev;
   int *gpuFlags = NULL;
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
-  NCCLCHECK(ncclxParseCommConfig(&config));
   int oldDev = 0;
   ncclUniqueId uniqueId;
 
   NVTX3_RANGE(NcclNvtxParamsCommInitAll);
 
   initEnv();
+
+  NCCLCHECK(ncclxParseCommConfig(&config));
 
   // Load the CUDA driver and dlsym hooks (can fail on old drivers)
   (void)ncclCudaLibraryInit();
@@ -2233,9 +2234,16 @@ ncclResult_t ncclCommInitRankConfig(ncclComm_t *newcomm, int nranks, ncclUniqueI
   ncclResult_t ret = ncclSuccess;
   ncclConfig_t internalConfig = NCCL_CONFIG_INITIALIZER;
   ncclConfig_t *internalConfigPtr = config ? config : &internalConfig;
-  NCCLCHECK(ncclxParseCommConfig(internalConfigPtr));
 
+  // initEnv must be called before ncclxParseCommConfig because the Config
+  // constructor reads cvars (e.g. NCCL_RUNTIME_CONNECT) that are only
+  // initialized inside initEnv/ncclCvarInit.  Without this ordering,
+  // non-root ranks (which skip ncclGetUniqueId) would read uninitialized
+  // cvar values, leading to mismatched runtimeConn across ranks and hangs
+  // during init.
   initEnv();
+
+  NCCLCHECK(ncclxParseCommConfig(internalConfigPtr));
 
   char allZeroUniqueId[NCCL_UNIQUE_ID_BYTES] = {0};
   bool uniqueIdIsInitialized = memcmp(commId.internal, allZeroUniqueId, NCCL_UNIQUE_ID_BYTES) != 0;

--- a/comms/ncclx/v2_28/src/init.cc
+++ b/comms/ncclx/v2_28/src/init.cc
@@ -1737,7 +1737,7 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
     timers[TIMER_INIT_BOOTSTRAP] = clockNano() - timers[TIMER_INIT_BOOTSTRAP];
   }
   comm->cudaArch = cudaArch;
-  
+
   // init this communicator's  Logger fields
   comm->logMetaData.commId = commIdHash;
   comm->logMetaData.commHash = comm->commHash;
@@ -2329,7 +2329,6 @@ ncclResult_t ncclCommInitAll(ncclComm_t* comms, int ndev, const int* devlist) {
   int totalnDev;
   int *gpuFlags = NULL;
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
-  NCCLCHECK(ncclxParseCommConfig(&config));
   int oldDev = 0;
 
   ncclUniqueId uniqueId;
@@ -2338,6 +2337,15 @@ ncclResult_t ncclCommInitAll(ncclComm_t* comms, int ndev, const int* devlist) {
 
   // Load the CUDA driver and dlsym hooks (can fail on old drivers)
   (void)ncclCudaLibraryInit();
+
+  // ncclInitEnv must be called before ncclxParseCommConfig because the Config
+  // constructor reads cvars (e.g. NCCL_RUNTIME_CONNECT) that are only
+  // initialized inside ncclInitEnv/ncclCvarInit.  Without this ordering,
+  // non-root ranks (which skip ncclGetUniqueId) would read uninitialized
+  // cvar values, leading to mismatched runtimeConn across ranks and hangs
+  // during init.
+  NCCLCHECK(ncclInitEnv());
+  NCCLCHECK(ncclxParseCommConfig(&config));
 
   CUDACHECK(cudaGetDevice(&oldDev));
   NCCLCHECKGOTO(PtrCheck(comms, "CommInitAll", "comms"), ret, fail);
@@ -2407,9 +2415,16 @@ ncclResult_t ncclCommInitRankConfig(ncclComm_t *newcomm, int nranks, ncclUniqueI
   ncclResult_t ret = ncclSuccess;
   ncclConfig_t internalConfig = NCCL_CONFIG_INITIALIZER;
   ncclConfig_t *internalConfigPtr = config ? config : &internalConfig;
-  NCCLCHECK(ncclxParseCommConfig(internalConfigPtr));
 
+  // ncclInitEnv must be called before ncclxParseCommConfig because the Config
+  // constructor reads cvars (e.g. NCCL_RUNTIME_CONNECT) that are only
+  // initialized inside ncclInitEnv/ncclCvarInit.  Without this ordering,
+  // non-root ranks (which skip ncclGetUniqueId) would read uninitialized
+  // cvar values, leading to mismatched runtimeConn across ranks and hangs
+  // during init.
   NCCLCHECK(ncclInitEnv());
+
+  NCCLCHECK(ncclxParseCommConfig(internalConfigPtr));
 
   char allZeroUniqueId[NCCL_UNIQUE_ID_BYTES] = {0};
   bool uniqueIdIsInitialized = memcmp(commId.internal, allZeroUniqueId, NCCL_UNIQUE_ID_BYTES) != 0;

--- a/comms/ncclx/v2_29/src/init.cc
+++ b/comms/ncclx/v2_29/src/init.cc
@@ -2527,7 +2527,6 @@ ncclResult_t ncclCommInitAll(ncclComm_t* comms, int ndev, const int* devlist) {
   int totalnDev;
   int *gpuFlags = NULL;
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
-  NCCLCHECK(ncclxParseCommConfig(&config));
   int oldDev = 0;
 
   ncclUniqueId uniqueId;
@@ -2536,6 +2535,15 @@ ncclResult_t ncclCommInitAll(ncclComm_t* comms, int ndev, const int* devlist) {
 
   // Load the CUDA driver and dlsym hooks (can fail on old drivers)
   (void)ncclCudaLibraryInit();
+
+  // ncclInitEnv must be called before ncclxParseCommConfig because the Config
+  // constructor reads cvars (e.g. NCCL_RUNTIME_CONNECT) that are only
+  // initialized inside ncclInitEnv/ncclCvarInit.  Without this ordering,
+  // non-root ranks (which skip ncclGetUniqueId) would read uninitialized
+  // cvar values, leading to mismatched runtimeConn across ranks and hangs
+  // during init.
+  NCCLCHECK(ncclInitEnv());
+  NCCLCHECK(ncclxParseCommConfig(&config));
 
   CUDACHECK(cudaGetDevice(&oldDev));
   NCCLCHECKGOTO(PtrCheck(comms, "CommInitAll", "comms"), ret, fail);
@@ -2605,9 +2613,16 @@ ncclResult_t ncclCommInitRankConfig(ncclComm_t *newcomm, int nranks, ncclUniqueI
   ncclResult_t ret = ncclSuccess;
   ncclConfig_t internalConfig = NCCL_CONFIG_INITIALIZER;
   ncclConfig_t *internalConfigPtr = config ? config : &internalConfig;
-  NCCLCHECK(ncclxParseCommConfig(internalConfigPtr));
 
+  // ncclInitEnv must be called before ncclxParseCommConfig because the Config
+  // constructor reads cvars (e.g. NCCL_RUNTIME_CONNECT) that are only
+  // initialized inside ncclInitEnv/ncclCvarInit.  Without this ordering,
+  // non-root ranks (which skip ncclGetUniqueId) would read uninitialized
+  // cvar values, leading to mismatched runtimeConn across ranks and hangs
+  // during init.
   NCCLCHECK(ncclInitEnv());
+
+  NCCLCHECK(ncclxParseCommConfig(internalConfigPtr));
 
   char allZeroUniqueId[NCCL_UNIQUE_ID_BYTES] = {0};
   bool uniqueIdIsInitialized = memcmp(commId.internal, allZeroUniqueId, NCCL_UNIQUE_ID_BYTES) != 0;


### PR DESCRIPTION
Summary:

The Config refactor (D95714602) moved `ncclxParseCommConfig` before
`initEnv`/`ncclInitEnv` in `ncclCommInitRankConfig` and `ncclCommInitAll`.
This caused non-root ranks to read uninitialized cvar values (e.g.
`NCCL_RUNTIME_CONNECT` defaulting to 0 instead of 1) because cvars are
only initialized inside `initEnv`/`ncclInitEnv`/`ncclCvarInit`.

Root rank (rank 0) was unaffected because `ncclGetUniqueId` triggers
`initEnv` before `ncclCommInitRankConfig` is called. Non-root ranks
call `ncclCommInitRankConfig` directly, so cvars were uninitialized.

This caused rank 0 to take the `runtimeConn` init branch (skip transport
connections) while all other ranks took the full connection branch
(ring+tree+PAT). During PAT connect, non-root ranks blocked on bootstrap
send/recv with rank 0, which had already finished init - resulting in a
deadlock.

The fix moves `initEnv`/`ncclInitEnv` before `ncclxParseCommConfig` in
both `ncclCommInitRankConfig` and `ncclCommInitAll` across v2.27, v2.28,
and v2.29.

Reviewed By: kapilsh

Differential Revision: D97070346


