### PR TITLE
Consolidate pipes runtime flags: remove TORCHCOMMS_PIPES_DEVICE_API_ENABLE

### DIFF
--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -2160,9 +2160,9 @@ std::shared_ptr<TorchCommWindow> TorchCommNCCLX::new_window(
     const std::optional<at::Tensor>& tensor) {
   std::shared_ptr<TorchCommWindow> win;
 #if defined(ENABLE_PIPES)
-  // Select Pipes backend when explicitly requested via env var.
+  // Select Pipes backend when NCCL_CTRAN_USE_PIPES is enabled.
   // Pipes uses ctran IBGDA/NVLink instead of GIN for device-side P2P.
-  const char* pipes_env = std::getenv("TORCHCOMMS_PIPES_DEVICE_API_ENABLE");
+  const char* pipes_env = std::getenv("NCCL_CTRAN_USE_PIPES");
   if (pipes_env != nullptr && std::string_view(pipes_env) == "1") {
     win = std::make_shared<TorchCommWindowNCCLXPipes>(
         nccl_comm_, shared_from_this());

--- a/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommWindowNCCLXPipesTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommWindowNCCLXPipesTest.cpp
@@ -5,7 +5,7 @@
 //   1. register_local_buffer() throws "not yet supported" for Pipes backend
 //   2. get_device_window() throws when win_ is null (no tensor_register)
 //
-// Both tests set TORCHCOMMS_PIPES_DEVICE_API_ENABLE=1 in SetUp() so that
+// Both tests set NCCL_CTRAN_USE_PIPES=1 in SetUp() so that
 // TorchCommNCCLX::new_window() returns TorchCommWindowNCCLXPipes instead of
 // TorchCommWindowNCCLXGin.
 //
@@ -26,11 +26,11 @@ class TorchCommWindowNCCLXPipesTest : public TorchCommNCCLXTest {
   void SetUp() override {
     TorchCommNCCLXTest::SetUp();
     // Make new_window() return TorchCommWindowNCCLXPipes
-    setenv("TORCHCOMMS_PIPES_DEVICE_API_ENABLE", "1", 1);
+    setenv("NCCL_CTRAN_USE_PIPES", "1", 1);
   }
 
   void TearDown() override {
-    unsetenv("TORCHCOMMS_PIPES_DEVICE_API_ENABLE");
+    unsetenv("NCCL_CTRAN_USE_PIPES");
     TorchCommNCCLXTest::TearDown();
   }
 };
@@ -52,7 +52,7 @@ TEST_F(TorchCommWindowNCCLXPipesTest, RegisterLocalBufferThrowsNotSupported) {
   EXPECT_NO_THROW(comm->init(*device_, "test_name", default_options_));
 
   // new_window() returns TorchCommWindowNCCLXPipes because
-  // TORCHCOMMS_PIPES_DEVICE_API_ENABLE=1 is set in SetUp()
+  // NCCL_CTRAN_USE_PIPES=1 is set in SetUp()
   auto win_base = comm->new_window();
   auto win = std::dynamic_pointer_cast<TorchCommWindowNCCLXPipes>(win_base);
   ASSERT_NE(win, nullptr) << "Window should be TorchCommWindowNCCLXPipes";

--- a/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTest.cpp
@@ -19,7 +19,7 @@ void PipesDeviceApiTest::SetUp() {
   if (checkIfSkip()) {
     GTEST_SKIP() << "Skipping Pipes Device API tests "
                     "(RUN_PIPES_DEVICE_API_TEST not set or "
-                    "TORCHCOMMS_PIPES_DEVICE_API_ENABLE not enabled)";
+                    "NCCL_CTRAN_USE_PIPES not enabled)";
   }
 
   wrapper_ = createWrapper();
@@ -49,10 +49,10 @@ bool PipesDeviceApiTest::checkIfSkip() {
     return true; // skip if not enabled
   }
 
-  // Also check TORCHCOMMS_PIPES_DEVICE_API_ENABLE=1 is set.
+  // Also check NCCL_CTRAN_USE_PIPES=1 is set.
   // Without this, new_window() returns TorchCommWindowNCCLXGin instead of
   // Pipes.
-  const char* pipes_env = getenv("TORCHCOMMS_PIPES_DEVICE_API_ENABLE");
+  const char* pipes_env = getenv("NCCL_CTRAN_USE_PIPES");
   if (!pipes_env || std::string(pipes_env) != "1") {
     return true;
   }
@@ -99,7 +99,7 @@ std::string PipesDeviceApiTest::getDtypeName(at::ScalarType dtype) {
 //   4. Verify the returned device pointer is non-null
 //
 // NOTE: TEST_F macros MUST be in this file (compiled with
-// TORCHCOMMS_HAS_NCCL_DEVICE_API and ENABLE_PIPES) to ensure
+// TORCHCOMMS_HAS_NCCL_DEVICE_API and ENABLE_PIPES) so that
 // TorchCommWindowNCCLXPipes resolves to the correct type (PipesDeviceBackend).
 
 void PipesDeviceApiTest::testPipesDeviceWindowCreation(
@@ -134,11 +134,11 @@ void PipesDeviceApiTest::testPipesDeviceWindowCreation(
   torchcomm_->barrier(false);
 
   // Cast to Pipes window to access device API.
-  // TORCHCOMMS_PIPES_DEVICE_API_ENABLE=1 makes new_window() return Pipes.
+  // NCCL_CTRAN_USE_PIPES=1 makes new_window() return Pipes.
   auto* win =
       dynamic_cast<torch::comms::TorchCommWindowNCCLXPipes*>(base_win.get());
   ASSERT_NE(win, nullptr) << "Window should be TorchCommWindowNCCLXPipes. "
-                             "Is TORCHCOMMS_PIPES_DEVICE_API_ENABLE=1 set?";
+                             "Is NCCL_CTRAN_USE_PIPES=1 set?";
 
   // get_device_window() is COLLECTIVE: internally calls
   // ctran_win->get_device_win() which does an allGather to exchange IBGDA
@@ -210,7 +210,7 @@ void PipesDeviceApiTest::testPerPeerSignal() {
   auto* win =
       dynamic_cast<torch::comms::TorchCommWindowNCCLXPipes*>(base_win.get());
   ASSERT_NE(win, nullptr) << "Window should be TorchCommWindowNCCLXPipes. "
-                             "Is TORCHCOMMS_PIPES_DEVICE_API_ENABLE=1 set?";
+                             "Is NCCL_CTRAN_USE_PIPES=1 set?";
 
   int signal_count = num_ranks_;
   decltype(win->get_device_window()) dev_win = nullptr;
@@ -320,7 +320,7 @@ void PipesDeviceApiTest::testWaitSignalFrom() {
   auto* win =
       dynamic_cast<torch::comms::TorchCommWindowNCCLXPipes*>(base_win.get());
   ASSERT_NE(win, nullptr) << "Window should be TorchCommWindowNCCLXPipes. "
-                             "Is TORCHCOMMS_PIPES_DEVICE_API_ENABLE=1 set?";
+                             "Is NCCL_CTRAN_USE_PIPES=1 set?";
 
   int signal_count = num_ranks_;
   decltype(win->get_device_window()) dev_win = nullptr;
@@ -417,7 +417,7 @@ void PipesDeviceApiTest::testDeviceBarrier() {
   auto* win =
       dynamic_cast<torch::comms::TorchCommWindowNCCLXPipes*>(base_win.get());
   ASSERT_NE(win, nullptr) << "Window should be TorchCommWindowNCCLXPipes. "
-                             "Is TORCHCOMMS_PIPES_DEVICE_API_ENABLE=1 set?";
+                             "Is NCCL_CTRAN_USE_PIPES=1 set?";
 
   // Get device window with barrier support
   int barrier_count = 2;

--- a/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTest.hpp
+++ b/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTest.hpp
@@ -9,9 +9,9 @@
 //
 // Runtime prerequisites:
 //   - RUN_PIPES_DEVICE_API_TEST=true (skip gate)
-//   - TORCHCOMMS_PIPES_DEVICE_API_ENABLE=1 (select Pipes in new_window())
+//   - NCCL_CTRAN_USE_PIPES=1 (initialize ctran multiPeerTransport and select
+//     Pipes backend in new_window())
 //   - NCCL_P2P_DISABLE=1 (route traffic through ctran/RDMA path)
-//   - NCCL_CTRAN_USE_PIPES=1 (initialize ctran multiPeerTransport)
 
 #pragma once
 


### PR DESCRIPTION
Summary:
Previously, enabling Pipes end-to-end required setting three independent flags:
1. `ENABLE_PIPES` (build-time, default true)
2. `NCCL_CTRAN_USE_PIPES` (runtime, default false) — initializes MultiPeerTransport
3. `TORCHCOMMS_PIPES_DEVICE_API_ENABLE` (runtime) — selects Pipes window backend

This was confusing and error-prone. Flag (3) was redundant — if pipes transport
is enabled via `NCCL_CTRAN_USE_PIPES=1`, TorchComm's `new_window()` should use
the Pipes backend automatically.

This diff removes `TORCHCOMMS_PIPES_DEVICE_API_ENABLE` entirely and derives the
TorchComm window backend selection from `NCCL_CTRAN_USE_PIPES`. Now:
- `ENABLE_PIPES` (build-time) = compile-time gate (unchanged)
- `NCCL_CTRAN_USE_PIPES` (runtime) = single runtime flag for all pipes behavior

Also updates CLAUDE.md files for ctran and pipes with correct build flags
(`-c hpc_comms.use_ncclx=stable`).

Reviewed By: cenzhaometa

Differential Revision: D97134964


