### PR TITLE
resize PinnedHostPool when exhausted

### DIFF
--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -245,28 +245,6 @@ commResult_t CtranGpe::Impl::submit(
     PreLaunchGraphPrepareFn graphPrepareFn) {
   commResult_t res = commSuccess;
 
-  // Reclaim once to gain back available flags
-  if (this->kernelFlagPool->size() == 0) {
-    this->kernelFlagPool->reclaim();
-  }
-
-  if (this->checksumPool->size() == 0) {
-    this->checksumPool->reclaim();
-  }
-
-  // We do not expect such high amount of inuse flags, return error here to
-  // avoid hang. If there can be really such a high usage case, either
-  // increase the pool size or set a timeout here to reclaim multiple times.
-  // Avoid timeout logic for now to avoid complexity.
-  if (this->kernelFlagPool->size() == 0) {
-    CLOGF(
-        ERR,
-        "CTRAN-GPE: Internal KernelFlag pool has unexpected high usage (capacity: {}, available: {}). It is likely that some COMM kernels are not released properly",
-        kernelFlagPool->capacity(),
-        kernelFlagPool->size());
-    return commInternalError;
-  }
-
   // Error checking before GPE cmd and kernel submission
   if (kernelConfig.args.devState_d == nullptr) {
     CLOGF(
@@ -1053,31 +1031,8 @@ commResult_t allocGpeKernelSyncs(
     size_t count,
     int nworkers,
     std::vector<ctran::algos::GpeKernelSync*>& gpeKernelSyncs) {
-  // reclaim from outstanding kernels once if pool items are insufficient
-  if (gpeKernelSyncPool->size() < count) {
-    gpeKernelSyncPool->reclaim();
-
-    // We do not expect such high amount of inuse pool items, return error here
-    // to avoid hang. If there can be really such a high usage case, either
-    // increase the pool size or set a timeout here to reclaim multiple times.
-    // Avoid timeout logic for now to avoid complexity.
-    if (count > gpeKernelSyncPool->size()) {
-      CLOGF(
-          WARN,
-          "CTRAN-GPE: Internal KernelSync pool has unexpected high usage (capacity: {}, available: {}, current request: {}). "
-          "It is likely that some COMM kernels are not released properly",
-          gpeKernelSyncPool->capacity(),
-          gpeKernelSyncPool->size(),
-          count);
-      return ErrorStackTraceUtil::log(commInternalError);
-    }
-  }
-
-  for (int i = 0; i < count; i++) {
+  for (size_t i = 0; i < count; i++) {
     auto* g = gpeKernelSyncPool->pop();
-    if (!g) {
-      return ErrorStackTraceUtil::log(commInternalError);
-    }
     // essentially the constructor (note resetStatus() is needed since we didn't
     // set nworkers before this point)
     g->nworkers = nworkers;

--- a/comms/ctran/utils/PinnedHostPool.h
+++ b/comms/ctran/utils/PinnedHostPool.h
@@ -9,6 +9,7 @@ using cudaHostAlloc. It is NOT thread-safe.
 
 #include <list>
 #include <stack>
+#include <vector>
 
 #include "comms/ctran/utils/Checks.h"
 
@@ -38,40 +39,41 @@ class PinnedHostPool {
  public:
   PinnedHostPool() = delete;
 
-  explicit PinnedHostPool(size_t capacity) : capacity_(capacity) {
-    FB_CUDACHECKTHROW_EX_NOCOMM(cudaHostAlloc(
-        &this->memPtr_, this->capacity_ * sizeof(T), cudaHostAllocDefault));
-
-    for (int i = 0; i < capacity_; ++i) {
-      T* item = reinterpret_cast<T*>(this->memPtr_) + i;
-      item->reset();
-      this->freeItems_.push(item);
-    }
+  explicit PinnedHostPool(size_t startCapacity) : chunkSize_(startCapacity) {
+    allocChunk();
   }
 
   ~PinnedHostPool() {
     this->reclaim();
     if (this->inuseItems_.size()) {
       CLOGF(
-          WARN,
+          INFO,
           "CTRAN-GPE: Internal {} pool has {} inuse items, indicating same amount of unfinished kernel",
           T::name(),
           this->inuseItems_.size());
     }
-    FB_CUDACHECKIGNORE(cudaFreeHost(this->memPtr_));
+    for (void* chunk : chunks_) {
+      FB_CUDACHECKIGNORE(cudaFreeHost(chunk));
+    }
 
-    // Dot not throw exception in destructor to avoid early termination in stack
+    // Do not throw exception in destructor to avoid early termination in stack
     // unwind. See discussion in
     // https://stackoverflow.com/questions/130117/if-you-shouldnt-throw-exceptions-in-a-destructor-how-do-you-handle-errors-in-i
   }
 
   T* pop() {
     if (this->freeItems_.size() == 0) {
+      this->reclaim();
+    }
+
+    if (this->freeItems_.size() == 0) {
       CLOGF(
-          WARN,
-          "CTRAN-GPE: Internal {} pool ran out of available items",
-          T::name());
-      return nullptr;
+          INFO,
+          "CTRAN-GPE: {} pool exhausted ({} capacity), growing by {}",
+          T::name(),
+          capacity_,
+          chunkSize_);
+      allocChunk();
     }
 
     T* item = this->freeItems_.top();
@@ -117,10 +119,25 @@ class PinnedHostPool {
   }
 
  private:
+  void allocChunk() {
+    void* mem = nullptr;
+    FB_CUDACHECKTHROW_EX_NOCOMM(
+        cudaHostAlloc(&mem, chunkSize_ * sizeof(T), cudaHostAllocDefault));
+    chunks_.push_back(mem);
+
+    for (size_t i = 0; i < chunkSize_; ++i) {
+      T* item = reinterpret_cast<T*>(mem) + i;
+      item->reset();
+      this->freeItems_.push(item);
+    }
+    capacity_ += chunkSize_;
+  }
+
   std::stack<T*> freeItems_;
   std::list<T*> inuseItems_;
-  const size_t capacity_{0};
-  void* memPtr_{nullptr};
+  std::vector<void*> chunks_;
+  const size_t chunkSize_{0};
+  size_t capacity_{0};
 
   PinnedHostPool(const PinnedHostPool&) = delete;
   PinnedHostPool& operator=(const PinnedHostPool&) = delete;

--- a/comms/ctran/utils/tests/PinnedHostPoolUT.cc
+++ b/comms/ctran/utils/tests/PinnedHostPoolUT.cc
@@ -64,9 +64,118 @@ TEST_F(PinnedHostPoolTest, PopTest) {
     // Capacity is unchanged
     EXPECT_EQ(pool->capacity(), poolSize);
   }
+}
 
-  auto another_item = pool->pop();
-  EXPECT_EQ(another_item, nullptr);
+// Verify pool auto-grows when exhausted: popping beyond initial capacity
+// allocates a new chunk, increasing capacity.
+TEST_F(PinnedHostPoolTest, AutoGrowOnExhaustion) {
+  constexpr int chunkSize = 4;
+  auto pool = std::make_unique<TestItemPool>(chunkSize);
+
+  EXPECT_EQ(pool->size(), chunkSize);
+  EXPECT_EQ(pool->capacity(), chunkSize);
+
+  std::vector<TestItem*> items;
+  for (int i = 0; i < chunkSize; ++i) {
+    auto* item = pool->pop();
+    ASSERT_NE(item, nullptr);
+    items.push_back(item);
+  }
+  EXPECT_EQ(pool->size(), 0);
+  EXPECT_EQ(pool->capacity(), chunkSize);
+
+  auto* overflow = pool->pop();
+  ASSERT_NE(overflow, nullptr);
+  EXPECT_EQ(pool->capacity(), chunkSize * 2);
+  EXPECT_EQ(pool->size(), chunkSize - 1);
+
+  for (int i = 0; i < chunkSize - 1; ++i) {
+    auto* item = pool->pop();
+    ASSERT_NE(item, nullptr);
+    items.push_back(item);
+  }
+  EXPECT_EQ(pool->size(), 0);
+
+  auto* overflow2 = pool->pop();
+  ASSERT_NE(overflow2, nullptr);
+  EXPECT_EQ(pool->capacity(), chunkSize * 3);
+
+  for (auto* item : items) {
+    item->inUse_ = false;
+  }
+  overflow->inUse_ = false;
+  overflow2->inUse_ = false;
+  pool->reclaim();
+  EXPECT_EQ(pool->size(), pool->capacity());
+}
+
+// Verify that items marked as not in use are reclaimed automatically on
+// subsequent pops, ensuring no pool element leaks without explicit reclaim.
+TEST_F(PinnedHostPoolTest, NoLeakAcrossPopReclaimCycles) {
+  constexpr int chunkSize = 8;
+  auto pool = std::make_unique<TestItemPool>(chunkSize);
+
+  for (int cycle = 0; cycle < 3; ++cycle) {
+    std::vector<TestItem*> items;
+    for (int i = 0; i < chunkSize; ++i) {
+      auto* item = pool->pop();
+      ASSERT_NE(item, nullptr);
+      items.push_back(item);
+    }
+    EXPECT_EQ(pool->size(), 0);
+
+    // Mark all as done — do NOT call reclaim explicitly
+    for (auto* item : items) {
+      item->inUse_ = false;
+    }
+
+    // The next pop should trigger an automatic reclaim inside pop(),
+    // recovering all items rather than growing the pool.
+    auto* next = pool->pop();
+    ASSERT_NE(next, nullptr);
+    // Capacity should not have grown — reclaim recovered items
+    EXPECT_EQ(pool->capacity(), chunkSize);
+    // All items minus the one we just popped should be free
+    EXPECT_EQ(pool->size(), chunkSize - 1);
+
+    next->inUse_ = false;
+  }
+}
+
+// Verify that reclaim across grown chunks returns all items correctly and
+// that repeated pop/reclaim cycles don't leak elements from any chunk.
+TEST_F(PinnedHostPoolTest, NoLeakAcrossChunks) {
+  constexpr int chunkSize = 4;
+  auto pool = std::make_unique<TestItemPool>(chunkSize);
+
+  // Pop all items to exhaust the first chunk, then trigger growth
+  std::vector<TestItem*> items;
+  items.reserve(chunkSize + 1);
+  for (int i = 0; i < chunkSize + 1; ++i) {
+    items.push_back(pool->pop());
+  }
+  EXPECT_EQ(pool->capacity(), chunkSize * 2);
+
+  // Mark all as done and reclaim
+  for (auto* item : items) {
+    item->inUse_ = false;
+  }
+  pool->reclaim();
+  EXPECT_EQ(pool->size(), pool->capacity());
+
+  // Pop everything again (spans both chunks) and reclaim
+  items.clear();
+  const size_t total = pool->size();
+  for (size_t i = 0; i < total; ++i) {
+    items.push_back(pool->pop());
+  }
+  EXPECT_EQ(pool->size(), 0);
+
+  for (auto* item : items) {
+    item->inUse_ = false;
+  }
+  pool->reclaim();
+  EXPECT_EQ(pool->size(), pool->capacity());
 }
 
 TEST_F(PinnedHostPoolTest, ReclaimTest) {


### PR DESCRIPTION
Summary:
cudagraphs have the potential to exhaust host pools if there are a bunch of graphs that live for the duration of the program (and as a result, they will hold needed pool resources for the duration of the program).

we can modify the pool to allocate in a chunks.  i.e., if we run out of free items, we allocate another chunk of memory. note that the pool size is monotonically increasing (created chunks are not freed until the pool is destructed).

Reviewed By: minsii

Differential Revision: D96825549


