### PR TITLE
rcclx: gate FP8 lp coll on CDNA3+ HW only

### DIFF
--- a/comms/rcclx/develop/meta/lpcoll/low_precision_allgather.cc
+++ b/comms/rcclx/develop/meta/lpcoll/low_precision_allgather.cc
@@ -25,6 +25,10 @@ HOT ncclResult_t ncclLowPrecisionAllGather(
   NCCLCHECK(ncclCommCount(comm, &nRanks));
   NCCLCHECK(ncclCommUserRank(comm, &rank));
 
+  if (!rcclGpuSupportsAmdFp8LpKernels()) {
+    return ncclInvalidUsage;
+  }
+
   // Calculate FP8 element count for supported data types
   // Input per rank: count elements → Output per rank: count FP8 elements (1:1
   // mapping) Total output: count*nRanks FP8 elements

--- a/comms/rcclx/develop/meta/lpcoll/low_precision_allreduce.cc
+++ b/comms/rcclx/develop/meta/lpcoll/low_precision_allreduce.cc
@@ -26,6 +26,10 @@ HOT ncclResult_t ncclLowPrecisionAllReduce(
   NCCLCHECK(ncclCommCount(comm, &nRanks));
   NCCLCHECK(ncclCommUserRank(comm, &rank));
 
+  if (!rcclGpuSupportsAmdFp8LpKernels()) {
+    return ncclInvalidUsage;
+  }
+
   if (count == 0) {
     return ncclSuccess;
   }

--- a/comms/rcclx/develop/meta/lpcoll/low_precision_alltoall.cc
+++ b/comms/rcclx/develop/meta/lpcoll/low_precision_alltoall.cc
@@ -24,6 +24,10 @@ HOT ncclResult_t ncclLowPrecisionAllToAll(
   NCCLCHECK(ncclCommCount(comm, &nRanks));
   NCCLCHECK(ncclCommUserRank(comm, &rank));
 
+  if (!rcclGpuSupportsAmdFp8LpKernels()) {
+    return ncclInvalidUsage;
+  }
+
   if (count == 0) {
     return ncclSuccess;
   }

--- a/comms/rcclx/develop/meta/lpcoll/low_precision_common.h
+++ b/comms/rcclx/develop/meta/lpcoll/low_precision_common.h
@@ -10,11 +10,43 @@
 
 #include <cstdlib>
 #include <cstring>
+
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+#include <hip/hip_runtime_api.h>
+#endif
+
 #include "low_precision_kernels.h"
 #include "low_precision_utility.h"
 
-// Helper function to check if low precision FP8 E4M3 is enabled
+/**
+ * True when the current HIP device has CDNA3+ FP8 convert instructions used
+ * by low-precision collectives (gfx940–gfx950 family). Always false on CUDA
+ * builds and pre-CDNA3 AMD GPUs.
+ */
+inline bool rcclGpuSupportsAmdFp8LpKernels() {
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+  int d = 0;
+  if (hipGetDevice(&d) != hipSuccess) {
+    return false;
+  }
+  hipDeviceProp_t p{};
+  if (hipGetDeviceProperties(&p, d) != hipSuccess) {
+    return false;
+  }
+  const char* n = p.gcnArchName ? p.gcnArchName : "";
+  return strstr(n, "gfx940") != nullptr || strstr(n, "gfx941") != nullptr ||
+      strstr(n, "gfx942") != nullptr || strstr(n, "gfx943") != nullptr ||
+      strstr(n, "gfx950") != nullptr;
+#else
+  return false;
+#endif
+}
+
+/** FP8 low-precision path: env RCCL_LOW_PRECISION_ENABLE=1 and HW support. */
 inline bool isLowPrecisionFp8E4M3Enabled() {
+  if (!rcclGpuSupportsAmdFp8LpKernels()) {
+    return false;
+  }
   const char* lowPrecisionEnable = getenv("RCCL_LOW_PRECISION_ENABLE");
   return (lowPrecisionEnable && strcmp(lowPrecisionEnable, "1") == 0);
 }

--- a/comms/rcclx/develop/meta/lpcoll/low_precision_kernels.h
+++ b/comms/rcclx/develop/meta/lpcoll/low_precision_kernels.h
@@ -22,6 +22,13 @@ __global__ void quantizeFloatToFp8Kernel(
     size_t totalCount,
     size_t chunkStart,
     size_t chunkSize) {
+#if !defined(RCCL_AMD_FP8_HW)
+  (void)input;
+  (void)output;
+  (void)totalCount;
+  (void)chunkStart;
+  (void)chunkSize;
+#else
   rccl_float8* fp8_output = static_cast<rccl_float8*>(output);
 
   // Calculate thread indexing for parallel processing
@@ -91,6 +98,7 @@ __global__ void quantizeFloatToFp8Kernel(
       fp8_output[globalIdx] = quantize_float_to_fp8_e4m3(input[globalIdx]);
     }
   }
+#endif
 }
 
 /**
@@ -105,6 +113,13 @@ __global__ void quantizeBF16ToFp8Kernel(
     size_t totalOutputCount,
     size_t chunkStart,
     size_t chunkSize) {
+#if !defined(RCCL_AMD_FP8_HW)
+  (void)bf16Input;
+  (void)fp8Output;
+  (void)totalOutputCount;
+  (void)chunkStart;
+  (void)chunkSize;
+#else
   rccl_float8* fp8_output = static_cast<rccl_float8*>(fp8Output);
 
   // Calculate thread indexing for parallel processing
@@ -203,6 +218,7 @@ __global__ void quantizeBF16ToFp8Kernel(
       fp8_output[globalIdx] = quantize_float_to_fp8_e4m3(temp_float);
     }
   }
+#endif
 }
 
 /**
@@ -313,6 +329,15 @@ __global__ void localReductionKernel(
     size_t chunkSize,
     int nRanks,
     int myRank) {
+#if !defined(RCCL_AMD_FP8_HW)
+  (void)fp8Input;
+  (void)floatOutput;
+  (void)totalCount;
+  (void)chunkStart;
+  (void)chunkSize;
+  (void)nRanks;
+  (void)myRank;
+#else
   const rccl_float8* fp8_input = static_cast<const rccl_float8*>(fp8Input);
 
   // Calculate thread indexing and grid configuration
@@ -352,6 +377,7 @@ __global__ void localReductionKernel(
       floatOutput[elemIdx] = accumulator;
     }
   }
+#endif
 }
 
 /**
@@ -366,6 +392,13 @@ __global__ void dequantizeFp8ToFloatKernel(
     size_t totalCount,
     size_t chunkStart,
     size_t chunkSize) {
+#if !defined(RCCL_AMD_FP8_HW)
+  (void)fp8Input;
+  (void)floatOutput;
+  (void)totalCount;
+  (void)chunkStart;
+  (void)chunkSize;
+#else
   const rccl_float8* fp8_input = static_cast<const rccl_float8*>(fp8Input);
 
   // Calculate thread indexing for parallel processing
@@ -437,6 +470,7 @@ __global__ void dequantizeFp8ToFloatKernel(
           dequantize_fp8_e4m3_to_float(fp8_input[globalIdx]);
     }
   }
+#endif
 }
 
 /**
@@ -451,6 +485,13 @@ __global__ void dequantizeFp8ToBF16Kernel(
     size_t totalCount,
     size_t chunkStart,
     size_t chunkSize) {
+#if !defined(RCCL_AMD_FP8_HW)
+  (void)fp8Input;
+  (void)bf16Output;
+  (void)totalCount;
+  (void)chunkStart;
+  (void)chunkSize;
+#else
   const rccl_float8* fp8_input = static_cast<const rccl_float8*>(fp8Input);
 
   // Calculate thread indexing for parallel processing
@@ -542,4 +583,5 @@ __global__ void dequantizeFp8ToBF16Kernel(
       bf16Output[globalIdx] = *reinterpret_cast<const T*>(&bf16_value);
     }
   }
+#endif
 }

--- a/comms/rcclx/develop/meta/lpcoll/low_precision_reduce_scatter.cc
+++ b/comms/rcclx/develop/meta/lpcoll/low_precision_reduce_scatter.cc
@@ -26,6 +26,10 @@ HOT ncclResult_t ncclLowPrecisionReduceScatter(
   NCCLCHECK(ncclCommCount(comm, &nRanks));
   NCCLCHECK(ncclCommUserRank(comm, &rank));
 
+  if (!rcclGpuSupportsAmdFp8LpKernels()) {
+    return ncclInvalidUsage;
+  }
+
   // Early exit for empty data
   if (count == 0) {
     return ncclSuccess;

--- a/comms/rcclx/develop/meta/lpcoll/low_precision_utility.h
+++ b/comms/rcclx/develop/meta/lpcoll/low_precision_utility.h
@@ -24,7 +24,15 @@
 // collectives
 #define CACHE_LINE_SIZE 128UL
 
-// Refer to MI300X CDNA3 ISA manual for more details on the HW intrinsics
+// CDNA3+ FP8 convert instructions (v_cvt_f32_fp8, v_cvt_pk_fp8_f32). Not on
+// gfx90a / CDNA2. Kernels that need these are no-ops when this is unset.
+#if defined(__HIP_DEVICE_COMPILE__) && \
+    (defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__) || \
+     defined(__gfx943__) || defined(__gfx950__))
+#define RCCL_AMD_FP8_HW 1
+#endif
+
+#if defined(RCCL_AMD_FP8_HW)
 
 /**
  * Converts a single float value to FP8 E4M3 format using AMD GPU instruction.
@@ -176,6 +184,7 @@ __device__ __forceinline__ void dequantize_fp8_batch_to_float8(
  * collective operations. Provides utilities for chunk partitioning, offset
  * calculation, and address mapping.
  */
+ #endif // RCCL_AMD_FP8_HW
 struct PhaseBufferLayout {
   enum LayoutType { CONTIGUOUS, INTERLEAVED };
 

--- a/comms/rcclx/develop/meta/lpcoll/tests/LowPrecisionCollectivesTest.cu
+++ b/comms/rcclx/develop/meta/lpcoll/tests/LowPrecisionCollectivesTest.cu
@@ -13,6 +13,7 @@
 #include "meta/lpcoll/low_precision_allgather.h"
 #include "meta/lpcoll/low_precision_allreduce.h"
 #include "meta/lpcoll/low_precision_alltoall.h"
+#include "meta/lpcoll/low_precision_common.h"
 #include "meta/lpcoll/low_precision_reduce_scatter.h"
 #include "nccl.h"
 
@@ -23,6 +24,9 @@ class LowPrecisionCollectivesTest : public ::testing::Test {
   LowPrecisionCollectivesTest() = default;
 
   void SetUp() override {
+    if (!rcclGpuSupportsAmdFp8LpKernels()) {
+      GTEST_SKIP() << "FP8 low-precision requires CDNA3+ (gfx940-gfx950)";
+    }
     setenv("RCCL_LOW_PRECISION_ENABLE", "1", 1);
 
     std::tie(this->localRank, this->globalRank, this->numRanks) = getMpiInfo();
@@ -32,16 +36,20 @@ class LowPrecisionCollectivesTest : public ::testing::Test {
   }
 
   void TearDown() override {
-    CUDACHECK_TEST(cudaStreamDestroy(this->stream));
-    NCCLCHECK_TEST(ncclCommDestroy(this->comm));
+    if (this->comm) {
+      NCCLCHECK_TEST(ncclCommDestroy(this->comm));
+    }
+    if (this->stream) {
+      CUDACHECK_TEST(cudaStreamDestroy(this->stream));
+    }
     unsetenv("RCCL_LOW_PRECISION_ENABLE");
   }
 
   int localRank{0};
   int globalRank{0};
   int numRanks{0};
-  ncclComm_t comm;
-  cudaStream_t stream;
+  ncclComm_t comm{nullptr};
+  cudaStream_t stream{};
 };
 
 TEST_F(LowPrecisionCollectivesTest, AllReduceFloat) {

--- a/comms/rcclx/develop/meta/lpcoll/tests/LowPrecisionKernelsTest.cu
+++ b/comms/rcclx/develop/meta/lpcoll/tests/LowPrecisionKernelsTest.cu
@@ -19,6 +19,9 @@ class LowPrecisionKernelsTest : public ::testing::Test {
   LowPrecisionKernelsTest() = default;
 
   void SetUp() override {
+    if (!rcclGpuSupportsAmdFp8LpKernels()) {
+      GTEST_SKIP() << "FP8 low-precision requires CDNA3+ (gfx940-gfx950)";
+    }
     setenv("RCCL_LOW_PRECISION_ENABLE", "1", 1);
 
     std::tie(this->localRank, this->globalRank, this->numRanks) = getMpiInfo();
@@ -28,16 +31,20 @@ class LowPrecisionKernelsTest : public ::testing::Test {
   }
 
   void TearDown() override {
-    CUDACHECK_TEST(cudaStreamDestroy(this->stream));
-    NCCLCHECK_TEST(ncclCommDestroy(this->comm));
+    if (this->comm) {
+      NCCLCHECK_TEST(ncclCommDestroy(this->comm));
+    }
+    if (this->stream) {
+      CUDACHECK_TEST(cudaStreamDestroy(this->stream));
+    }
     unsetenv("RCCL_LOW_PRECISION_ENABLE");
   }
 
   int localRank{0};
   int globalRank{0};
   int numRanks{0};
-  ncclComm_t comm;
-  cudaStream_t stream;
+  ncclComm_t comm{nullptr};
+  cudaStream_t stream{};
 };
 
 TEST_F(LowPrecisionKernelsTest, QuantizeFloatToFp8Basic) {


### PR DESCRIPTION
I am trying to get support for torchcomms on the Frontier Supercomputer, which is based on the gfx90a accelerator (MI250x). This is older hardware and doesn't support the fp8 primitives used for certain low precision operations. This branch guards this code for architectures with hardware support for fp8 so that older architectures can still use torchcomms.

- low_precision_utility: v_cvt_*_fp8 asm only for gfx940–gfx950 device builds
- low_precision_kernels: no-op kernels when !RCCL_AMD_FP8_HW (e.g. gfx90a link)
- low_precision_common: rcclGpuSupportsAmdFp8LpKernels via gcnArchName; tie env RCCL_LOW_PRECISION_ENABLE to HW support
- ncclLowPrecision* entry points return ncclInvalidUsage without FP8 ISA
- Tests skip on non-FP8 GPUs; safe TearDown on GTEST_SKIP

Made-with: Cursor