### PR TITLE
Fix IBGDA build break: move rdma-core includes from NicDiscovery.h to .cc (#1146)

### DIFF
--- a/comms/pipes/rdma/NicDiscovery.cc
+++ b/comms/pipes/rdma/NicDiscovery.cc
@@ -2,6 +2,9 @@
 
 #include "comms/pipes/rdma/NicDiscovery.h"
 
+#include <infiniband/mlx5dv.h>
+#include <infiniband/verbs.h>
+
 #include <cuda_runtime.h>
 #include <spdlog/spdlog.h>
 #include <sys/syscall.h>

--- a/comms/pipes/rdma/NicDiscovery.h
+++ b/comms/pipes/rdma/NicDiscovery.h
@@ -2,8 +2,10 @@
 
 #pragma once
 
-#include <infiniband/mlx5dv.h>
-#include <infiniband/verbs.h>
+// Forward declarations — only pointer types used in this header.
+// Full headers included in NicDiscovery.cc where the types are needed.
+struct ibv_device;
+struct ibv_context;
 
 #include <string>
 #include <unordered_set>


### PR DESCRIPTION
Summary:

D96833981 switched multipeer_ibgda_transport from doca_gpunetio (direct
linking) to doca_gpunetio_dl (dlopen). The dlopen variant defines
ibverbs/mlx5 types in wrapper headers (doca_verbs_ibv_wrapper.h,
doca_verbs_mlx5dv_wrapper.h). But NicDiscovery.h directly includes
<infiniband/verbs.h> and <infiniband/mlx5dv.h> from rdma-core, causing
type redefinition errors when both headers are in the same TU:

  error: redefinition of 'mlx5dv_obj_type'
  doca_verbs_mlx5dv_wrapper.h:92: note: previous definition is here

Fix: Move the rdma-core includes from NicDiscovery.h to NicDiscovery.cc.
The header only uses ibv_device* and ibv_context* (pointer types), so
forward declarations are sufficient.

Reviewed By: zhiyongww

Differential Revision: D97196977
