### PR TITLE
Remove rdma-core link dependency from nic_discovery via dlopen

### DIFF
--- a/comms/pipes/IbverbsLazy.cc
+++ b/comms/pipes/IbverbsLazy.cc
@@ -11,34 +11,30 @@ namespace comms::pipes {
 
 namespace {
 
-// Function pointer types for ibverbs functions we load via dlopen.
+// ---- ibverbs function pointer types ----
 using IbvRegMrIova2Fn =
     struct ibv_mr* (*)(struct ibv_pd*, void*, size_t, uint64_t, unsigned int);
-
 using IbvRegDmabufMrFn =
     struct ibv_mr* (*)(struct ibv_pd*, uint64_t, size_t, uint64_t, int, int);
 
-// Loaded function pointers (populated by load_ibverbs_lazy).
 IbvRegMrIova2Fn gIbvRegMrIova2 = nullptr;
 IbvRegDmabufMrFn gIbvRegDmabufMr = nullptr;
 
-std::once_flag gLoadFlag;
-int gLoadResult = -1;
+std::once_flag gIbvLoadFlag;
+int gIbvLoadResult = -1;
 
-void do_load() {
+void do_load_ibverbs() {
   void* handle = dlopen("libibverbs.so.1", RTLD_NOW | RTLD_NOLOAD);
   if (!handle) {
-    // Not already loaded — open fresh
     handle = dlopen("libibverbs.so.1", RTLD_NOW);
   }
   if (!handle) {
     LOG(ERROR) << "IbverbsLazy: failed to dlopen libibverbs.so.1: "
                << dlerror();
-    gLoadResult = 1;
+    gIbvLoadResult = 1;
     return;
   }
 
-  // ibv_reg_mr_iova2 — available since IBVERBS 1.8
   gIbvRegMrIova2 = reinterpret_cast<IbvRegMrIova2Fn>(
       dlvsym(handle, "ibv_reg_mr_iova2", "IBVERBS_1.8"));
   if (!gIbvRegMrIova2) {
@@ -46,7 +42,6 @@ void do_load() {
                  << dlerror();
   }
 
-  // ibv_reg_dmabuf_mr — available since IBVERBS 1.12
   gIbvRegDmabufMr = reinterpret_cast<IbvRegDmabufMrFn>(
       dlvsym(handle, "ibv_reg_dmabuf_mr", "IBVERBS_1.12"));
   if (!gIbvRegDmabufMr) {
@@ -54,12 +49,59 @@ void do_load() {
                  << dlerror();
   }
 
-  gLoadResult = 0;
+  gIbvLoadResult = 0;
 }
 
 int load_ibverbs_lazy() {
-  std::call_once(gLoadFlag, do_load);
-  return gLoadResult;
+  std::call_once(gIbvLoadFlag, do_load_ibverbs);
+  return gIbvLoadResult;
+}
+
+// ---- mlx5dv function pointer types ----
+using Mlx5dvIsSupportedFn = int (*)(struct ibv_device*);
+using Mlx5dvGetDataDirectSysfsPathFn =
+    int (*)(struct ibv_context*, char*, size_t);
+
+Mlx5dvIsSupportedFn gMlx5dvIsSupported = nullptr;
+Mlx5dvGetDataDirectSysfsPathFn gMlx5dvGetDataDirectSysfsPath = nullptr;
+
+std::once_flag gMlx5LoadFlag;
+bool gMlx5Loaded = false;
+
+void do_load_mlx5() {
+  void* handle = dlopen("libmlx5.so", RTLD_NOW);
+  if (!handle) {
+    handle = dlopen("libmlx5.so.1", RTLD_NOW);
+  }
+  if (!handle) {
+    LOG(WARNING) << "IbverbsLazy: failed to dlopen libmlx5.so[.1]: "
+                 << dlerror()
+                 << ". Data Direct NIC discovery will be disabled.";
+    return;
+  }
+
+  gMlx5dvIsSupported = reinterpret_cast<Mlx5dvIsSupportedFn>(
+      dlsym(handle, "mlx5dv_is_supported"));
+  if (!gMlx5dvIsSupported) {
+    LOG(WARNING) << "IbverbsLazy: mlx5dv_is_supported not available: "
+                 << dlerror();
+  }
+
+  // mlx5dv_get_data_direct_sysfs_path — available since MLX5_1.25
+  gMlx5dvGetDataDirectSysfsPath =
+      reinterpret_cast<Mlx5dvGetDataDirectSysfsPathFn>(
+          dlvsym(handle, "mlx5dv_get_data_direct_sysfs_path", "MLX5_1.25"));
+  if (!gMlx5dvGetDataDirectSysfsPath) {
+    LOG(WARNING)
+        << "IbverbsLazy: mlx5dv_get_data_direct_sysfs_path not available: "
+        << dlerror();
+  }
+
+  gMlx5Loaded = true;
+}
+
+void load_mlx5_lazy() {
+  std::call_once(gMlx5LoadFlag, do_load_mlx5);
 }
 
 } // namespace
@@ -89,6 +131,25 @@ struct ibv_mr* lazy_ibv_reg_dmabuf_mr(
     return nullptr;
   }
   return gIbvRegDmabufMr(pd, offset, length, iova, fd, access);
+}
+
+int lazy_mlx5dv_is_supported(struct ibv_device* device) {
+  load_mlx5_lazy();
+  if (!gMlx5dvIsSupported) {
+    return 0;
+  }
+  return gMlx5dvIsSupported(device);
+}
+
+int lazy_mlx5dv_get_data_direct_sysfs_path(
+    struct ibv_context* ctx,
+    char* buf,
+    size_t buf_len) {
+  load_mlx5_lazy();
+  if (!gMlx5dvGetDataDirectSysfsPath) {
+    return -1;
+  }
+  return gMlx5dvGetDataDirectSysfsPath(ctx, buf, buf_len);
 }
 
 } // namespace comms::pipes

--- a/comms/pipes/IbverbsLazy.h
+++ b/comms/pipes/IbverbsLazy.h
@@ -23,16 +23,17 @@
 #include <cstddef>
 #include <cstdint>
 
+// Forward declarations — always safe to repeat even after full definitions.
+// Placed outside the INFINIBAND_VERBS_H guard so consumers can include this
+// header purely for opaque-pointer declarations without pulling in verbs.h.
+struct ibv_context;
+struct ibv_pd;
+struct ibv_device;
+
 // If infiniband/verbs.h is already included (e.g., via doca_verbs_ibv_wrapper.h
 // in conda builds where rdma-core headers are installed), skip our type
 // definitions and only provide the dlopen wrappers below.
 #ifndef INFINIBAND_VERBS_H
-
-// Forward declarations — these may already be forward-declared by DOCA
-// wrapper headers. Repeating a forward declaration is valid C++.
-struct ibv_context;
-struct ibv_pd;
-struct ibv_device;
 
 // ============================================================================
 // ibv_mtu — MTU enum (matches libibverbs ABI)
@@ -139,5 +140,28 @@ struct ibv_mr* lazy_ibv_reg_dmabuf_mr(
     uint64_t iova,
     int fd,
     int access);
+
+// ============================================================================
+// dlopen'd mlx5dv functions (from libmlx5)
+// ============================================================================
+
+/**
+ * mlx5dv_is_supported — Check if device supports mlx5 DV interface.
+ * Wraps the libmlx5 mlx5dv_is_supported() function loaded via dlopen.
+ *
+ * @return non-zero if supported, 0 if not or libmlx5 unavailable.
+ */
+int lazy_mlx5dv_is_supported(struct ibv_device* device);
+
+/**
+ * mlx5dv_get_data_direct_sysfs_path — Get Data Direct sysfs path.
+ * Wraps the libmlx5 mlx5dv_get_data_direct_sysfs_path() loaded via dlopen.
+ *
+ * @return 0 on success, non-zero on failure or libmlx5 unavailable.
+ */
+int lazy_mlx5dv_get_data_direct_sysfs_path(
+    struct ibv_context* ctx,
+    char* buf,
+    size_t buf_len);
 
 } // namespace comms::pipes

--- a/comms/pipes/rdma/NicDiscovery.cc
+++ b/comms/pipes/rdma/NicDiscovery.cc
@@ -414,22 +414,23 @@ std::pair<PathType, int> GpuNicDiscovery::computePathType(
 // Static methods for Data Direct detection
 
 bool GpuNicDiscovery::isMlx5Supported(ibv_device* device) {
-  return mlx5dv_is_supported(device) != 0;
+  return lazy_mlx5dv_is_supported(device) != 0;
 }
 
 bool GpuNicDiscovery::isDmaBufCapable(ibv_context* ctx) {
-  struct ibv_pd* pd = ibv_alloc_pd(ctx);
-  if (pd == nullptr) {
+  struct ibv_pd* pd = nullptr;
+  doca_error_t err = doca_verbs_wrapper_ibv_alloc_pd(ctx, &pd);
+  if (err != DOCA_SUCCESS || !pd) {
     return false;
   }
 
   // Probe DMA-BUF support with a dummy call (fd=-1)
   // If not supported, errno will be EOPNOTSUPP or EPROTONOSUPPORT
   // If supported but invalid args, errno will be EBADF (which means supported)
-  (void)ibv_reg_dmabuf_mr(
+  (void)lazy_ibv_reg_dmabuf_mr(
       pd, 0ULL /*offset*/, 0ULL /*len*/, 0ULL /*iova*/, -1 /*fd*/, 0 /*flags*/);
   bool notSupported = (errno == EOPNOTSUPP) || (errno == EPROTONOSUPPORT);
-  ibv_dealloc_pd(pd);
+  doca_verbs_wrapper_ibv_dealloc_pd(pd);
   return !notSupported;
 }
 
@@ -442,7 +443,7 @@ bool GpuNicDiscovery::getDataDirectSysfsPath(
   int prefixLen = strlen(kSysPrefix);
   memcpy(buf, kSysPrefix, prefixLen);
 
-  int rc = mlx5dv_get_data_direct_sysfs_path(
+  int rc = lazy_mlx5dv_get_data_direct_sysfs_path(
       ctx, buf + prefixLen, sizeof(buf) - prefixLen);
   if (rc != 0) {
     return false;
@@ -456,16 +457,23 @@ void GpuNicDiscovery::augmentWithDataDirect() {
     return;
   }
 
-  struct ibv_device** deviceList = ibv_get_device_list(nullptr);
-  if (deviceList == nullptr) {
+  int numDevices = 0;
+  struct ibv_device** deviceList = nullptr;
+  doca_error_t docaRet =
+      doca_verbs_wrapper_ibv_get_device_list(&numDevices, &deviceList);
+  if (docaRet != DOCA_SUCCESS || !deviceList || numDevices == 0) {
     spdlog::warn("NicDiscovery: ibv_get_device_list() failed for DD probing");
     return;
   }
 
   // Build map of ibv_device* by name for quick lookup
   std::unordered_map<std::string, ibv_device*> devMap;
-  for (int i = 0; deviceList[i] != nullptr; i++) {
-    devMap[deviceList[i]->name] = deviceList[i];
+  for (int i = 0; i < numDevices; i++) {
+    const char* devName = nullptr;
+    doca_verbs_wrapper_ibv_get_device_name(deviceList[i], &devName);
+    if (devName) {
+      devMap[devName] = deviceList[i];
+    }
   }
 
   std::vector<NicCandidate> ddCandidates;
@@ -482,8 +490,9 @@ void GpuNicDiscovery::augmentWithDataDirect() {
       continue;
     }
 
-    ibv_context* ctx = ibv_open_device(dev);
-    if (ctx == nullptr) {
+    ibv_context* ctx = nullptr;
+    docaRet = doca_verbs_wrapper_ibv_open_device(dev, &ctx);
+    if (docaRet != DOCA_SUCCESS || !ctx) {
       continue;
     }
 
@@ -519,7 +528,7 @@ void GpuNicDiscovery::augmentWithDataDirect() {
       }
     }
 
-    ibv_close_device(ctx);
+    doca_verbs_wrapper_ibv_close_device(ctx);
 
     if (!ddCapable) {
       spdlog::debug(
@@ -545,7 +554,7 @@ void GpuNicDiscovery::augmentWithDataDirect() {
     candidates_.push_back(std::move(dd));
   }
 
-  ibv_free_device_list(deviceList);
+  doca_verbs_wrapper_ibv_free_device_list(deviceList);
 
   sortCandidates();
 

--- a/comms/pipes/rdma/NicDiscovery.h
+++ b/comms/pipes/rdma/NicDiscovery.h
@@ -2,14 +2,15 @@
 
 #pragma once
 
-#include <infiniband/mlx5dv.h>
-#include <infiniband/verbs.h>
-
 #include <string>
 #include <unordered_set>
 #include <utility>
 #include <vector>
 
+#include <doca_gpunetio_host.h>
+#include <doca_verbs_net_wrapper.h>
+
+#include "comms/pipes/IbverbsLazy.h"
 #include "comms/pipes/rdma/IbHcaParser.h"
 
 namespace comms::pipes {


### PR DESCRIPTION
Summary:
D96833981 switched pipes IBGDA transport from direct linking to dlopen
for doca/ibverbs/mlx5, but nic_discovery still directly depended on
rdma-core:ibverbs and rdma-core:mlx5. When compiled together with
doca_gpunetio_dl (which defines its own ibverbs types via wrapper
headers), the same translation unit gets verbs.h types from two paths,
causing ~20 redefinition errors.

Fix:
- **NicDiscovery.h**: Replaced `#include <infiniband/verbs.h>` and
  `#include <infiniband/mlx5dv.h>` with DOCA wrapper + IbverbsLazy
  includes. The ibverbs-typed static methods (`isMlx5Supported`,
  `isDmaBufCapable`, `getDataDirectSysfsPath`) are preserved as public
  API using opaque pointer types from the DOCA/IbverbsLazy headers.

- **NicDiscovery.cc**: All direct ibverbs calls converted to DOCA's
  dlopen wrappers (`doca_verbs_wrapper_ibv_*`). mlx5 functions
  (`mlx5dv_is_supported`, `mlx5dv_get_data_direct_sysfs_path`) use
  new lazy wrappers from IbverbsLazy.

- **IbverbsLazy.{h,cc}**: Extended with libmlx5 dlopen support.
  Forward declarations moved outside `#ifndef INFINIBAND_VERBS_H`
  guard for unconditional availability. Added `lazy_mlx5dv_is_supported`
  and `lazy_mlx5dv_get_data_direct_sysfs_path` (using dlvsym with
  MLX5_1.25 version, matching ibverbx's approach).

- **rdma/BUCK**: Replaced rdma-core deps with doca_gpunetio_dl +
  ibverbs_lazy. No link-time rdma-core dependency remains.

NOTE: IbverbsLazy mlx5 wrappers are temporary. The plan is to migrate
pipes to use ibverbx (comms/ctran/ibverbx/) which already provides a
complete, well-tested dlopen wrapper for all ibverbs/mlx5 functions.

Differential Revision: D97205473


