### PR TITLE
Add broadcast to bootstrap hierarchy + oobBroadcast to DistBaseTest (#1154)

### DIFF
--- a/comms/common/bootstrap/IBootstrap.h
+++ b/comms/common/bootstrap/IBootstrap.h
@@ -113,6 +113,25 @@ class IBootstrap {
    */
   virtual folly::SemiFuture<int>
   recv(void* buf, int len, int peer, int tag) = 0;
+
+  // Broadcast `len` bytes from `root` to all ranks.
+  // `buf` is input on root, output on all other ranks.
+  virtual folly::SemiFuture<int>
+  broadcast(void* buf, int len, int root, int rank, int nranks) {
+    constexpr int kBcastTag = 0x42;
+    if (rank != root) {
+      return recv(buf, len, root, kBcastTag);
+    }
+    for (int r = 0; r < nranks; r++) {
+      if (r != root) {
+        auto rc = send(buf, len, r, kBcastTag).get();
+        if (rc != 0) {
+          return folly::makeSemiFuture(rc);
+        }
+      }
+    }
+    return folly::makeSemiFuture(0);
+  }
 };
 
 } // namespace meta::comms


### PR DESCRIPTION
Summary:

Add `broadcast` primitive to the bootstrap interface for broadcasting data from a root rank to all others:
- `IBootstrap::broadcast`: virtual method with default send/recv-based implementation
- `TcpStoreBootstrap::broadcast`: optimized override using TCPStore set/wait/get with opCounter-based unique keys
- `MpiBootstrap::broadcast`: override using MPI_Bcast
- `DistBaseTest::oobBroadcast`: convenience template method wrapping bootstrap_->broadcast

This enables stateless multi-comm creation via bootstrap (no static testCount keys), which will be used by new createNcclComm overloads in a follow-up commit.

Reviewed By: siyengar

Differential Revision: D97192841
