### PR TITLE
Create memtrace module to extend memory logging (#1155)

### DIFF
--- a/comms/utils/memtrace/MemoryTrace.cc
+++ b/comms/utils/memtrace/MemoryTrace.cc
@@ -1,0 +1,115 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/utils/memtrace/MemoryTrace.h"
+
+#include <algorithm>
+
+#include <folly/Synchronized.h>
+#include <folly/json/dynamic.h>
+#include <folly/json/json.h>
+
+#include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/logger/alloc.h"
+
+namespace meta::comms::memtrace {
+
+namespace {
+// Maps commHash to per-communicator MemoryTrace instance.
+// Dual ownership: this map holds a shared_ptr (created at first allocation,
+// before CommsMonitor::registerComm), and NcclCommMonitorInfo adopts a
+// shared_ptr later at registerComm time.
+folly::Synchronized<std::unordered_map<uint64_t, std::shared_ptr<MemoryTrace>>>
+    tracers;
+} // namespace
+
+std::shared_ptr<MemoryTrace> MemoryTrace::getOrCreate(uint64_t commHash) {
+  auto locked = tracers.wlock();
+  auto it = locked->find(commHash);
+  if (it != locked->end()) {
+    return it->second;
+  }
+  auto trace = std::make_shared<MemoryTrace>();
+  locked->emplace(commHash, trace);
+  return trace;
+}
+
+void MemoryTrace::recordAlloc(uintptr_t addr, int64_t bytes) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  allocMap_[addr] = bytes;
+  stats_.totalAllocated += bytes;
+  stats_.currentUsage += bytes;
+  stats_.peakUsage = std::max(stats_.peakUsage, stats_.currentUsage);
+}
+
+void MemoryTrace::recordFree(uintptr_t addr, std::optional<int64_t> bytes) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  int64_t freedBytes = 0;
+  if (bytes.has_value()) {
+    freedBytes = bytes.value();
+  } else {
+    auto it = allocMap_.find(addr);
+    if (it != allocMap_.end()) {
+      freedBytes = it->second;
+    }
+  }
+  allocMap_.erase(addr);
+  stats_.totalFreed += freedBytes;
+  stats_.currentUsage -= freedBytes;
+}
+
+MemoryStats MemoryTrace::getStats() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return stats_;
+}
+
+std::string MemoryTrace::dump() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  folly::dynamic obj = folly::dynamic::object(
+      "totalAllocated", stats_.totalAllocated)("totalFreed", stats_.totalFreed)(
+      "currentUsage", stats_.currentUsage)("peakUsage", stats_.peakUsage);
+  return folly::toJson(obj);
+}
+
+// Free function implementations
+
+void recordAlloc(
+    const CommLogData& logMetaData,
+    const std::string& callsite,
+    const std::string& use,
+    uintptr_t addr,
+    int64_t bytes,
+    std::optional<int> numSegments,
+    std::optional<int64_t> durationUs) {
+  logMemoryEvent(
+      logMetaData, callsite, use, addr, bytes, numSegments, durationUs);
+}
+
+void recordFree(
+    const CommLogData& logMetaData,
+    const std::string& callsite,
+    const std::string& use,
+    uintptr_t addr,
+    std::optional<int64_t> bytes) {
+  logMemoryEvent(logMetaData, callsite, use, addr, bytes);
+}
+
+void recordReg(
+    const CommLogData& logMetaData,
+    const std::string& callsite,
+    const std::string& use,
+    uintptr_t addr,
+    std::optional<int64_t> bytes,
+    std::optional<int> numSegments,
+    std::optional<int64_t> durationUs) {
+  logMemoryEvent(
+      logMetaData,
+      callsite,
+      use,
+      addr,
+      bytes,
+      numSegments,
+      durationUs,
+      /*isRegMemEvent=*/true);
+}
+
+} // namespace meta::comms::memtrace

--- a/comms/utils/memtrace/MemoryTrace.h
+++ b/comms/utils/memtrace/MemoryTrace.h
@@ -1,0 +1,84 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// Single entry point for all NCCLX memory event recording.
+// Each event is forwarded to Scuba (via logMemoryEvent) and recorded in a
+// per-communicator MemoryTrace for local stats exposed through commDump.
+//
+// This header is safe to include from CUDA device-side code (stdlib only,
+// no folly deps). All heavy implementation lives in MemoryTrace.cc.
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+#include "comms/utils/commSpecs.h"
+
+namespace meta::comms::memtrace {
+
+// --- Recording API ---
+
+void recordAlloc(
+    const CommLogData& logMetaData,
+    const std::string& callsite,
+    const std::string& use,
+    uintptr_t addr,
+    int64_t bytes,
+    std::optional<int> numSegments = std::nullopt,
+    std::optional<int64_t> durationUs = std::nullopt);
+
+void recordFree(
+    const CommLogData& logMetaData,
+    const std::string& callsite,
+    const std::string& use,
+    uintptr_t addr,
+    std::optional<int64_t> bytes = std::nullopt);
+
+void recordReg(
+    const CommLogData& logMetaData,
+    const std::string& callsite,
+    const std::string& use,
+    uintptr_t addr,
+    std::optional<int64_t> bytes = std::nullopt,
+    std::optional<int> numSegments = std::nullopt,
+    std::optional<int64_t> durationUs = std::nullopt);
+
+// --- Per-communicator in-memory stats ---
+
+struct MemoryStats {
+  int64_t totalAllocated{0};
+  int64_t totalFreed{0};
+  int64_t currentUsage{0};
+  int64_t peakUsage{0};
+};
+
+// Per-communicator memory tracker with aggregate stats.
+//
+// Dual ownership: a file-local static map in MemoryTrace.cc holds a shared_ptr
+// (created at first allocation, before CommsMonitor::registerComm), and
+// NcclCommMonitorInfo adopts a shared_ptr later at registerComm time.
+// This is necessary because memory allocations happen during ncclCommInit
+// before CommLogData/CommStateX fields are populated, so registerComm()
+// cannot be called that early.
+class MemoryTrace {
+ public:
+  static std::shared_ptr<MemoryTrace> getOrCreate(uint64_t commHash);
+
+  void recordAlloc(uintptr_t addr, int64_t bytes);
+  void recordFree(uintptr_t addr, std::optional<int64_t> bytes);
+  MemoryStats getStats() const;
+  std::string dump() const;
+
+ private:
+  mutable std::mutex mutex_;
+  MemoryStats stats_;
+  // Caches addr→bytes from recordAlloc; needed because some free paths
+  // (e.g. ncclCudaFree) don't know the allocation size at free time.
+  std::unordered_map<uintptr_t, int64_t> allocMap_;
+};
+
+} // namespace meta::comms::memtrace

--- a/comms/utils/memtrace/tests/MemoryTraceTest.cc
+++ b/comms/utils/memtrace/tests/MemoryTraceTest.cc
@@ -1,0 +1,80 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include <folly/json/dynamic.h>
+#include <folly/json/json.h>
+
+#include "comms/utils/memtrace/MemoryTrace.h"
+
+using namespace meta::comms::memtrace;
+
+TEST(MemoryTraceTest, RecordAllocUpdatesStats) {
+  auto trace = MemoryTrace::getOrCreate(0x1001);
+  auto before = trace->getStats();
+  trace->recordAlloc(0xAAAA, 1024);
+
+  auto after = trace->getStats();
+  EXPECT_EQ(after.totalAllocated, before.totalAllocated + 1024);
+  EXPECT_EQ(after.currentUsage, before.currentUsage + 1024);
+  EXPECT_GE(after.peakUsage, after.currentUsage);
+}
+
+TEST(MemoryTraceTest, RecordFreeUpdatesStats) {
+  auto trace = MemoryTrace::getOrCreate(0x1002);
+  trace->recordAlloc(0xBBBB, 2048);
+  auto before = trace->getStats();
+
+  trace->recordFree(0xBBBB, 2048);
+  auto after = trace->getStats();
+  EXPECT_EQ(after.totalFreed, before.totalFreed + 2048);
+  EXPECT_EQ(after.currentUsage, before.currentUsage - 2048);
+}
+
+TEST(MemoryTraceTest, RecordFreeWithoutBytesLooksUpAllocMap) {
+  auto trace = MemoryTrace::getOrCreate(0x1003);
+  trace->recordAlloc(0xCCCC, 4096);
+  auto before = trace->getStats();
+
+  trace->recordFree(0xCCCC, std::nullopt);
+  auto after = trace->getStats();
+  EXPECT_EQ(after.totalFreed, before.totalFreed + 4096);
+  EXPECT_EQ(after.currentUsage, before.currentUsage - 4096);
+}
+
+TEST(MemoryTraceTest, PeakUsageTracking) {
+  auto trace = MemoryTrace::getOrCreate(0x1004);
+  trace->recordAlloc(0xD001, 1000);
+  trace->recordAlloc(0xD002, 2000);
+
+  trace->recordFree(0xD001, 1000);
+  auto stats = trace->getStats();
+  EXPECT_GE(stats.peakUsage, 3000);
+  EXPECT_EQ(stats.currentUsage, 2000);
+}
+
+TEST(MemoryTraceTest, GetOrCreateReturnsSameInstance) {
+  auto t1 = MemoryTrace::getOrCreate(0x2001);
+  auto t2 = MemoryTrace::getOrCreate(0x2001);
+  EXPECT_EQ(t1.get(), t2.get());
+}
+
+TEST(MemoryTraceTest, GetOrCreateDifferentHash) {
+  auto t1 = MemoryTrace::getOrCreate(0x3001);
+  auto t2 = MemoryTrace::getOrCreate(0x3002);
+  EXPECT_NE(t1.get(), t2.get());
+}
+
+TEST(MemoryTraceTest, DumpProducesValidJson) {
+  auto trace = MemoryTrace::getOrCreate(0x4001);
+  trace->recordAlloc(0xEEEE, 8192);
+
+  auto jsonStr = trace->dump();
+  auto parsed = folly::parseJson(jsonStr);
+  EXPECT_TRUE(parsed.isObject());
+  EXPECT_TRUE(parsed.count("totalAllocated"));
+  EXPECT_TRUE(parsed.count("totalFreed"));
+  EXPECT_TRUE(parsed.count("currentUsage"));
+  EXPECT_TRUE(parsed.count("peakUsage"));
+  EXPECT_GE(parsed["totalAllocated"].asInt(), 8192);
+}


### PR DESCRIPTION
Summary:

Introduce comms/utils/memtrace/ as the single entry point for all memory event recording. This decouples memory tracking from the Scuba logger, enabling extension to track per-communicator memory stats and dump usage via commDump.
- MemoryTrace.h: CUDA-safe header (stdlib only, no folly) with recording API (recordAlloc/recordFree/recordReg free functions), MemoryStats struct, and MemoryTrace class for per-communicator aggregate stats
- MemoryTrace.cc: implementations including folly::Synchronized global map for MemoryTrace instances, Scuba forwarding via logMemoryEvent, and JSON dump for commDump integration
- Unit test (memory_trace_ut): 7 tests covering recordAlloc/recordFree stats, allocMap lookup for free-without-bytes, peak usage tracking, getOrCreate identity, and dump JSON validity

Reviewed By: YulunW

Differential Revision: D96010718
