### PR TITLE
Use ncclx::Hints for NCCLx-specific config fields

### DIFF
--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -2226,24 +2226,26 @@ std::shared_ptr<TorchCommBackend> TorchCommNCCLX::split(
 
   // Create a new NCCL communicator
   ncclComm_t new_comm;
-  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
   std::string commDesc = fmt::format(
       "{}::split::{}_{}_{}", name_, color, split_name, split_counter_++);
-  config.commDesc = commDesc.c_str();
 
-  // Set splitGroupRanks and splitGroupSize hints automatically based on ranks
-  // parameter
-  if (!ranks.empty()) {
-    config.splitGroupRanks = const_cast<int*>(ranks.data());
-    config.splitGroupSize = static_cast<int>(ranks.size());
-  }
-
-  // Populate NCCL config from user-provided hints.  NCCLx-specific fields
-  // are passed via the hints object; upstream NCCL fields are set directly
-  // on the config struct.
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
   ncclx::Hints hints;
-  populateNcclConfigFromHints(config, hints, options, commDesc);
   config.hints = &hints;
+  populateNcclConfig(config, options, commDesc);
+  hints.set("ncclx::commDesc", commDesc);
+
+  // Set splitGroupRanks hint automatically based on ranks parameter
+  if (!ranks.empty()) {
+    std::string rankStr;
+    for (size_t i = 0; i < ranks.size(); ++i) {
+      if (i > 0) {
+        rankStr += ',';
+      }
+      rankStr += std::to_string(ranks[i]);
+    }
+    hints.set("ncclx::splitGroupRanks", rankStr);
+  }
 
   // Verify the correct CUDA device is set before calling ncclCommSplit.
   // NCCL expects the caller to have set the device matching the communicator.

--- a/comms/torchcomms/ncclx/TorchCommNCCLXBootstrap.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXBootstrap.cpp
@@ -25,10 +25,7 @@ const std::string kUniqueidXchgMethodAuto = "auto";
 const std::string kUniqueidXchgMethodTCPStore = "tcpstore";
 const std::string kUniqueidXchgMethodDefault = kUniqueidXchgMethodAuto;
 
-bool isFastInitEnable(const ncclConfig_t& config, const ncclx::Hints& hints) {
-  if (config.fastInitMode == NCCL_FAST_INIT_MODE_RING) {
-    return true;
-  }
+bool isFastInitEnable(const ncclx::Hints& hints) {
   std::string fastInitVal;
   if (hints.get("ncclx::fastInitMode", fastInitVal) == ncclSuccess &&
       std::stoi(fastInitVal) == NCCL_FAST_INIT_MODE_RING) {
@@ -218,14 +215,11 @@ static const std::set<std::string> kTorchCommLayerHints = {
     std::string(kHintGraphTimeoutCheckIntervalMs),
 };
 
-// Helper function to populate NCCL config from hints.  Upstream NCCL config
-// fields are set directly on the config struct.  NCCLx-specific fields use
-// the "ncclx::" key prefix and are passed via the hints object.
-void populateNcclConfigFromHints(
+void populateNcclConfig(
     ncclConfig_t& config,
-    ncclx::Hints& hints,
     const CommOptions& options,
     const std::string& name) {
+  auto* hints = static_cast<ncclx::Hints*>(config.hints);
   constexpr std::string_view kNcclxPrefix = "ncclx::";
 
   // Iterate over the hints and set the corresponding fields.  Keys with
@@ -238,7 +232,17 @@ void populateNcclConfigFromHints(
   for (const auto& [key, val] : options.hints) {
     // NCCLx-specific fields -- pass via ncclx::Hints
     if (key.compare(0, kNcclxPrefix.size(), kNcclxPrefix) == 0) {
-      hints.set(key, val);
+      if (key == "ncclx::commDesc") {
+        throw std::invalid_argument(
+            "ncclx::commDesc must not be set in hints; "
+            "it is derived internally");
+      }
+      if (key == "ncclx::splitGroupRanks") {
+        throw std::invalid_argument(
+            "ncclx::splitGroupRanks must not be set in hints; "
+            "it is derived from the ranks parameter");
+      }
+      hints->set(key, val);
       TC_LOG(INFO, nullptr)
           << "[comm=" << name << "] Setting hint " << key << "=" << val;
     }
@@ -308,10 +312,8 @@ void populateNcclConfigFromHints(
   }
 }
 
-bool TorchCommNCCLXBootstrap::useFastInit(
-    ncclConfig_t config,
-    const ncclx::Hints& hints) {
-  if (isFastInitEnable(config, hints)) {
+bool TorchCommNCCLXBootstrap::useFastInit(const ncclx::Hints& hints) {
+  if (isFastInitEnable(hints)) {
     // Use raw dynamic_cast instead of c10::dynamic_intrusive_pointer_cast
     // because the latter has a refcount leak when the cast fails (the
     // by-value intrusive_ptr parameter is release()'d before the cast,
@@ -344,18 +346,15 @@ ncclComm_t TorchCommNCCLXBootstrap::createNcclComm(
   // TODO: add logging on failures and successes
   // TODO: use scalable init
   // TODO: get the local rank
-  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
-  config.commDesc = name.c_str();
   createStore(name);
 
-  // Populate NCCL config from user-provided hints.  NCCLx-specific fields
-  // are passed via the hints object; upstream NCCL fields are set directly
-  // on the config struct.
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
   ncclx::Hints hints;
-  populateNcclConfigFromHints(config, hints, options, name);
   config.hints = &hints;
+  populateNcclConfig(config, options, name);
+  hints.set("ncclx::commDesc", name);
 
-  if (useFastInit(config, hints)) {
+  if (useFastInit(hints)) {
     uniqueId = ncclUniqueId{};
   } else {
     uniqueId = exchangeUniqueId();

--- a/comms/torchcomms/ncclx/TorchCommNCCLXBootstrap.hpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXBootstrap.hpp
@@ -54,7 +54,7 @@ class TorchCommNCCLXBootstrap {
  private:
   ncclUniqueId exchangeUniqueId();
   void createStore(std::string_view name);
-  bool useFastInit(ncclConfig_t config, const ncclx::Hints& hints);
+  bool useFastInit(const ncclx::Hints& hints);
   void cleanupTCPStore(ncclComm_t nccl_comm);
 
  private:
@@ -73,12 +73,13 @@ class TorchCommNCCLXBootstrap {
   std::string uniqueid_xchg_method_;
 };
 
-// Helper function to populate NCCL config from hints.  Upstream NCCL
-// config fields are set directly on the config struct.  NCCLx-specific
-// fields are passed via the hints object.
-void populateNcclConfigFromHints(
+// Populate an ncclConfig_t from user-provided CommOptions.  Upstream
+// NCCL config fields are set directly on the config struct; NCCLx-specific
+// fields (keyed with the "ncclx::" prefix) are stored in the ncclx::Hints
+// object pointed to by config.hints.  The caller must set config.hints
+// before calling this function.
+void populateNcclConfig(
     ncclConfig_t& config,
-    ncclx::Hints& hints,
     const CommOptions& options,
     const std::string& name);
 


### PR DESCRIPTION
Summary:
Migrate NCCLx-specific config fields (commDesc, splitGroupRanks,
splitGroupSize, fastInitMode) from direct ncclConfig_t assignment
to the ncclx::Hints mechanism.

In createNcclComm, commDesc is now set via hints instead of
config.commDesc. In split, commDesc and splitGroupRanks are set
via hints, with validation that the user didn't set them in their
own hints (since these are derived from split parameters).

isFastInitEnable no longer checks config.fastInitMode directly;
it only checks the ncclx::fastInitMode hint and the env var
fallback.

Reviewed By: dolpm

Differential Revision: D97240345


