### PR TITLE
Fix rdma-core/nvidia-doca header conflict in MultipeerIbgdaTransport

### DIFF
--- a/comms/pipes/MultipeerIbgdaTransport.cc
+++ b/comms/pipes/MultipeerIbgdaTransport.cc
@@ -17,7 +17,7 @@
 #include "comms/pipes/IbverbsLazy.h"
 #include "comms/pipes/MultipeerIbgdaDeviceTransport.cuh"
 #include "comms/pipes/MultipeerIbgdaTransportCuda.cuh"
-#include "comms/pipes/rdma/NicDiscovery.h"
+#include "comms/pipes/rdma/NicDiscoveryHelper.h"
 
 #include "doca_verbs_net_wrapper.h"
 
@@ -115,7 +115,7 @@ void MultipeerIbgdaTransport::initDocaGpu() {
         std::string(cudaGetErrorString(cudaErr)));
   }
 
-  gpuPciBusId_ = GpuNicDiscovery::getCudaPciBusId(config_.cudaDevice);
+  gpuPciBusId_ = NicDiscoveryHelper::getCudaPciBusId(config_.cudaDevice);
 
   VLOG(1) << "MultipeerIbgdaTransport: GPU " << config_.cudaDevice << " PCIe "
           << gpuPciBusId_;
@@ -149,9 +149,8 @@ void MultipeerIbgdaTransport::openIbDevice() {
 
   // Priority 2: Auto-discovery if no config override
   if (nicDeviceName_.empty()) {
-    auto discovery = GpuNicDiscovery(config_.cudaDevice, config_.ibHca);
-    const auto& candidates = discovery.getCandidates();
-    nicDeviceName_ = candidates[0].name;
+    nicDeviceName_ =
+        NicDiscoveryHelper::discoverBestNic(config_.cudaDevice, config_.ibHca);
     VLOG(1) << "MultipeerIbgdaTransport: using NIC " << nicDeviceName_
             << " for GPU device " << config_.cudaDevice;
   }

--- a/comms/pipes/rdma/NicDiscoveryHelper.cc
+++ b/comms/pipes/rdma/NicDiscoveryHelper.cc
@@ -1,0 +1,20 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/rdma/NicDiscoveryHelper.h"
+
+#include "comms/pipes/rdma/NicDiscovery.h"
+
+namespace comms::pipes {
+
+std::string NicDiscoveryHelper::getCudaPciBusId(int cudaDevice) {
+  return GpuNicDiscovery::getCudaPciBusId(cudaDevice);
+}
+
+std::string NicDiscoveryHelper::discoverBestNic(
+    int cudaDevice,
+    const std::string& ibHca) {
+  auto discovery = GpuNicDiscovery(cudaDevice, ibHca);
+  return discovery.getCandidates()[0].name;
+}
+
+} // namespace comms::pipes

--- a/comms/pipes/rdma/NicDiscoveryHelper.h
+++ b/comms/pipes/rdma/NicDiscoveryHelper.h
@@ -1,0 +1,32 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <string>
+
+namespace comms::pipes {
+
+/**
+ * Thin wrapper around GpuNicDiscovery to isolate rdma-core headers
+ * (infiniband/mlx5dv.h) from compilation units that include nvidia-doca
+ * headers. Both define the same structs (mlx5dv_ah, mlx5dv_pd, mlx5dv_obj),
+ * causing redefinition errors when included together.
+ */
+struct NicDiscoveryHelper {
+  /**
+   * Get PCIe bus ID string from CUDA device.
+   * Delegates to GpuNicDiscovery::getCudaPciBusId().
+   */
+  static std::string getCudaPciBusId(int cudaDevice);
+
+  /**
+   * Discover the best NIC for a given CUDA device.
+   * Returns the device name (e.g., "mlx5_0") of the best candidate.
+   *
+   * @param cudaDevice CUDA device index
+   * @param ibHca NCCL_IB_HCA-style filter string (empty = no filtering)
+   */
+  static std::string discoverBestNic(int cudaDevice, const std::string& ibHca);
+};
+
+} // namespace comms::pipes


### PR DESCRIPTION
Summary:
MultipeerIbgdaTransport.cc includes both rdma-core headers (via NicDiscovery.h)
and nvidia-doca headers (via MultipeerIbgdaTransport.h). Both define the same
structs (mlx5dv_ah, mlx5dv_pd, mlx5dv_obj), causing redefinition errors under
opt+GPU builds.

Create a thin NicDiscoveryHelper wrapper that isolates the rdma-core includes
into a separate compilation unit, exposing only std::string results. This
prevents the conflicting headers from being included in the same translation
unit.

Differential Revision: D97301002


