### PR TITLE
Fix rdma-core/DOCA header redefinition errors

### DIFF
--- a/comms/pipes/rdma/NicDiscovery.cc
+++ b/comms/pipes/rdma/NicDiscovery.cc
@@ -2,6 +2,9 @@
 
 #include "comms/pipes/rdma/NicDiscovery.h"
 
+#include <infiniband/mlx5dv.h>
+#include <infiniband/verbs.h>
+
 #include <cuda_runtime.h>
 #include <spdlog/spdlog.h>
 #include <sys/syscall.h>

--- a/comms/pipes/rdma/NicDiscovery.h
+++ b/comms/pipes/rdma/NicDiscovery.h
@@ -13,6 +13,12 @@
 #include "comms/pipes/IbverbsLazy.h"
 #include "comms/pipes/rdma/IbHcaParser.h"
 
+// Forward declarations for ibverbs/mlx5 types used as pointers in the API.
+// Full definitions are in <infiniband/verbs.h> and <infiniband/mlx5dv.h>,
+// included only in NicDiscovery.cc to avoid conflicts with DOCA wrapper headers.
+struct ibv_device;
+struct ibv_context;
+
 namespace comms::pipes {
 
 /**


### PR DESCRIPTION
Summary:
Move rdma-core includes from NicDiscovery.h to NicDiscovery.cc and use
forward declarations in the header.  NicDiscovery.h only uses
ibv_device* and ibv_context* as pointer types, so forward declarations
suffice. This avoids redefinition errors when
MultipeerIbgdaTransport.cc includes both NicDiscovery.h (rdma-core
headers) and DOCA wrapper headers (doca_verbs_ibv_wrapper.h) which
define the same structs/enums.

Differential Revision: D97322908
