### PR TITLE
Fix CLANGTIDY suppressions and test improvements

### DIFF
--- a/comms/torchcomms/device/pipes/PipesDeviceBackend.cpp
+++ b/comms/torchcomms/device/pipes/PipesDeviceBackend.cpp
@@ -102,6 +102,7 @@ PipesDeviceBackend::Ptr PipesDeviceBackend::create_device_window(
       sizeof(TorchCommDeviceWindow<PipesDeviceBackend>));
   if (cuda_result != cudaSuccess) {
     // Clean up Pipes DeviceWindow on failure.
+    // NOLINTNEXTLINE(facebook-hte-NullableDereference)
     auto destroy_result = nccl_api->winDestroyDeviceWin(pipes_device_win);
     if (destroy_result != ncclSuccess) {
       TC_LOG(ERROR) << "[PipesDeviceBackend]: Failed to clean up Pipes device "
@@ -126,6 +127,7 @@ PipesDeviceBackend::Ptr PipesDeviceBackend::create_device_window(
         cuda_api,
         cuda_api->free(device_ptr),
         "Failed to free device window during error cleanup");
+    // NOLINTNEXTLINE(facebook-hte-NullableDereference)
     auto destroy_result = nccl_api->winDestroyDeviceWin(pipes_device_win);
     if (destroy_result != ncclSuccess) {
       TC_LOG(ERROR) << "[PipesDeviceBackend]: Failed to clean up Pipes device "

--- a/comms/torchcomms/tests/integration/cpp/PipesTransportApiTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/PipesTransportApiTest.cpp
@@ -12,7 +12,6 @@
 
 #include "comms/pipes/MultiPeerDeviceHandle.cuh"
 
-#include <cuda_runtime.h>
 #include <cstring>
 #include <vector>
 
@@ -32,7 +31,8 @@ void PipesTransportApiTest::SetUp() {
   rank_ = torchcomm_->getRank();
   num_ranks_ = torchcomm_->getSize();
   int device_count = 0;
-  cudaGetDeviceCount(&device_count);
+  ASSERT_EQ(cudaGetDeviceCount(&device_count), cudaSuccess)
+      << "cudaGetDeviceCount failed";
   device_index_ = (device_count > 0) ? rank_ % device_count : 0;
 }
 


### PR DESCRIPTION
Summary:
**C++ lint fixes (2 files):**
- `device/pipes/PipesDeviceBackend.cpp`: Add NOLINTNEXTLINE for
  facebook-hte-NullableDereference on lines 105/129. These are false
  positives — pipes_device_win is guaranteed non-null in these error paths
  (only reachable after successful winCreateDeviceWin).
- `tests/integration/cpp/PipesTransportApiTest.cpp`: Remove unused
  `#include <cuda_runtime.h>` (available transitively via TorchCommNCCLX.hpp).
  Add ASSERT_EQ error check on cudaGetDeviceCount() call in SetUp().

Reviewed By: cenzhaometa

Differential Revision: D97241357
