### PR TITLE
Enable lazy init by default for Gloo transport (#1161)

### DIFF
--- a/comms/torchcomms/gloo/TorchCommGloo.cpp
+++ b/comms/torchcomms/gloo/TorchCommGloo.cpp
@@ -337,9 +337,12 @@ void TorchCommGloo::init(
   if (hints.contains("interface")) {
     attr.iface = hints.at("interface");
   }
-  auto gloo_device = hints.contains("lazy")
-      ? ::gloo::transport::tcp::CreateLazyDevice(attr)
-      : ::gloo::transport::tcp::CreateDevice(attr);
+  bool lazy = env_to_value<bool>("TORCHCOMM_GLOO_LAZY_INIT", true);
+  if (hints.contains("lazy")) {
+    lazy = string_to_bool(hints.at("lazy"));
+  }
+  auto gloo_device = lazy ? ::gloo::transport::tcp::CreateLazyDevice(attr)
+                          : ::gloo::transport::tcp::CreateDevice(attr);
   auto context =
       std::make_shared<::gloo::rendezvous::Context>(rank_, comm_size_);
   context->setTimeout(options.timeout);


### PR DESCRIPTION
Summary:

Adds `TORCHCOMM_GLOO_LAZY_INIT` environment variable to control lazy initialization for Gloo device creation, defaulting to `true` (lazy init enabled). The explicit `"lazy"` hint in options still takes precedence over the environment variable when provided.

This reduces initialization overhead by deferring device setup until first use.

This should be safe in all cases since torchcomms does not support "recv from any" semantics which caused initialization order issues in the past.

Differential Revision: D97108086
