### PR TITLE
Always initEnv when calling ncclxParseCommConfig (#1162)

### DIFF
--- a/comms/ncclx/v2_27/meta/NcclxConfig.cc
+++ b/comms/ncclx/v2_27/meta/NcclxConfig.cc
@@ -4,6 +4,7 @@
 
 #include "debug.h"
 #include "nccl.h" // @manual
+#include "param.h"
 
 #include "comms/utils/cvars/nccl_cvars.h"
 
@@ -16,6 +17,8 @@
 namespace ncclx {
 
 Config::Config(const ncclConfig_t* config) {
+  initEnv();
+
   if (!config) {
     WARN("ncclx::Config: config is null");
     throw std::invalid_argument("config is null");

--- a/comms/ncclx/v2_28/meta/NcclxConfig.cc
+++ b/comms/ncclx/v2_28/meta/NcclxConfig.cc
@@ -4,6 +4,7 @@
 
 #include "debug.h"
 #include "nccl.h" // @manual
+#include "param.h"
 
 #include "comms/utils/cvars/nccl_cvars.h"
 
@@ -16,6 +17,8 @@
 namespace ncclx {
 
 Config::Config(const ncclConfig_t* config) {
+  initEnv();
+
   if (!config) {
     WARN("ncclx::Config: config is null");
     throw std::invalid_argument("config is null");

--- a/comms/ncclx/v2_29/meta/NcclxConfig.cc
+++ b/comms/ncclx/v2_29/meta/NcclxConfig.cc
@@ -4,6 +4,7 @@
 
 #include "debug.h"
 #include "nccl.h" // @manual
+#include "param.h"
 
 #include "comms/utils/cvars/nccl_cvars.h"
 
@@ -16,6 +17,8 @@
 namespace ncclx {
 
 Config::Config(const ncclConfig_t* config) {
+  initEnv();
+
   if (!config) {
     WARN("ncclx::Config: config is null");
     throw std::invalid_argument("config is null");


### PR DESCRIPTION
Summary:

The Config refactor (D95714602) moved `ncclxParseCommConfig` before
`initEnv`/`ncclInitEnv` in `ncclCommInitRankConfig` and `ncclCommInitAll`.
This caused non-root ranks to read uninitialized cvar values (e.g.
`NCCL_RUNTIME_CONNECT` defaulting to 0 instead of 1) because cvars are
only initialized inside `initEnv`/`ncclInitEnv`/`ncclCvarInit`.

Always call initEnv in ncclxParseCommConfig to ensure cvars are initialized before parsing the config

Reviewed By: pavanbalaji

Differential Revision: D97166054


