### PR TITLE
Revert fbthrift conda feedstock migration (D95281925, D97323845)

### DIFF
--- a/build_ncclx.sh
+++ b/build_ncclx.sh
@@ -190,6 +190,9 @@ function build_third_party {
     build_fb_oss_library "https://github.com/facebook/mvfst" "$third_party_tag" quic
     build_fb_oss_library "https://github.com/facebook/wangle.git" "$third_party_tag" wangle "-DBUILD_TESTS=OFF"
     build_fb_oss_library "https://github.com/facebook/fbthrift.git" "$third_party_tag" thrift
+  else
+    # TODO: use feedstock fbthrift instead of github fbthrift for feedstock build
+    build_fb_oss_library "https://github.com/facebook/fbthrift.git" main thrift
   fi
   popd
 }
@@ -206,13 +209,8 @@ function build_comms_tracing_service {
   cp -r "${base_dir}/${include_prefix}"/* "$include_prefix"
   mv "$include_prefix"/CMakeLists.txt .
 
-  if [[ -z "${NCCL_FEEDSTOCK_BUILD}" ]]; then
-    # Reuse thrift cmake build tree (source build path)
-    cp -r /tmp/third-party/thrift/build .
-  else
-    # fbthrift installed via conda — cmake finds it via CMAKE_PREFIX_PATH
-    mkdir -p build
-  fi
+  # set up the build config
+  cp -r /tmp/third-party/thrift/build .
 
   # build the thrift service library
   cd build


### PR DESCRIPTION
Summary:
Revert the fbthrift conda feedstock migration introduced in D95281925 and
D97323845. This restores the previous behavior of building fbthrift from
GitHub source for feedstock builds instead of using the pre-built conda
package.

Changes reverted:
- Restore the `else` branch in build_ncclx.sh that builds fbthrift from
  GitHub main for feedstock builds
- Revert build_comms_tracing_service to always copy the thrift build tree
- Remove fbthrift cmake path fixups and FBThriftConfig.cmake wrapper from
  nccl feedstock build.sh
- Remove fbthrift from nccl recipe.yaml host dependencies
- Remove fbthrift from nccl and torchcomms test TOMLs
- Remove fbthrift feedstock and install specs from flagship build TOMLs
  (h100, gb200, cu13, gbunified)
- Revert openssl and xz version pin bumps in flagship build TOMLs

Reviewed By: vickyuec

Differential Revision: D97339147


