### PR TITLE
Use NCCL_FASTINIT_MODE cvar instead of NCCL_FAST_INIT_MODE_DEFAULT macro in NcclxConfig

### DIFF
--- a/comms/ncclx/v2_27/meta/NcclxConfig.cc
+++ b/comms/ncclx/v2_27/meta/NcclxConfig.cc
@@ -175,7 +175,9 @@ Config::Config(const ncclConfig_t* config) {
   if (config->fastInitMode != NCCL_CONFIG_UNDEF_INT) {
     fastInitMode = config->fastInitMode != 0;
   } else {
-    fastInitMode = parseHintBool("fastInitMode", NCCL_FAST_INIT_MODE_DEFAULT);
+    // NCCL_FASTINIT_MODE is a enum, we could not directly convert it to bool
+    fastInitMode = parseHintBool(
+        "fastInitMode", NCCL_FASTINIT_MODE == NCCL_FASTINIT_MODE::ring_hybrid);
   }
 }
 

--- a/comms/ncclx/v2_28/meta/NcclxConfig.cc
+++ b/comms/ncclx/v2_28/meta/NcclxConfig.cc
@@ -175,7 +175,9 @@ Config::Config(const ncclConfig_t* config) {
   if (config->fastInitMode != NCCL_CONFIG_UNDEF_INT) {
     fastInitMode = config->fastInitMode != 0;
   } else {
-    fastInitMode = parseHintBool("fastInitMode", NCCL_FAST_INIT_MODE_DEFAULT);
+    // NCCL_FASTINIT_MODE is a enum, we could not directly convert it to bool
+    fastInitMode = parseHintBool(
+        "fastInitMode", NCCL_FASTINIT_MODE == NCCL_FASTINIT_MODE::ring_hybrid);
   }
 }
 

--- a/comms/ncclx/v2_29/meta/NcclxConfig.cc
+++ b/comms/ncclx/v2_29/meta/NcclxConfig.cc
@@ -175,7 +175,9 @@ Config::Config(const ncclConfig_t* config) {
   if (config->fastInitMode != NCCL_CONFIG_UNDEF_INT) {
     fastInitMode = config->fastInitMode != 0;
   } else {
-    fastInitMode = parseHintBool("fastInitMode", NCCL_FAST_INIT_MODE_DEFAULT);
+    // NCCL_FASTINIT_MODE is a enum, we could not directly convert it to bool
+    fastInitMode = parseHintBool(
+        "fastInitMode", NCCL_FASTINIT_MODE == NCCL_FASTINIT_MODE::ring_hybrid);
   }
 }
 


### PR DESCRIPTION
Summary:
NCCL_FAST_INIT_MODE_DEFAULT is a compile-time macro from nccl.h.in that evaluates to false.
NCCL_FASTINIT_MODE is a runtime cvar (defined in nccl_cvars.yaml) that respects the
NCCL_FASTINIT_MODE env var. The default value for fastInitMode should check whether
the cvar is set to ring_hybrid, not use the hardcoded macro.

Applied to v2_27, v2_28, and v2_29.

Differential Revision: D97340523


