### PR TITLE
revise da2a api

### DIFF
--- a/comms/ctran/Ctran.h
+++ b/comms/ctran/Ctran.h
@@ -132,8 +132,6 @@ commResult_t ctranDeviceAllToAllv(
     void* recvbuff,
     const int64_t* sendcounts_d,
     const int64_t* recvcounts_d,
-    const int64_t* senddispls_d,
-    const int64_t* recvdispls_d,
     commDataType_t datatype,
     CtranComm* comm,
     cudaStream_t stream);

--- a/comms/ctran/algos/AllToAll/AllToAll.cc
+++ b/comms/ctran/algos/AllToAll/AllToAll.cc
@@ -207,8 +207,6 @@ commResult_t ctranDeviceAllToAllv(
     void* recvbuff,
     const int64_t* sendcounts_d,
     const int64_t* recvcounts_d,
-    const int64_t* senddispls_d,
-    const int64_t* recvdispls_d,
     commDataType_t datatype,
     CtranComm* comm,
     cudaStream_t stream) {
@@ -227,8 +225,6 @@ commResult_t ctranDeviceAllToAllv(
           recvbuff,
           sendcounts_d,
           recvcounts_d,
-          senddispls_d,
-          recvdispls_d,
           datatype,
           comm,
           config,
@@ -281,8 +277,6 @@ commResult_t ctranDeviceAllToAllv(
     void* /*recvbuff*/,
     const int64_t* /*sendcounts_d*/,
     const int64_t* /*recvcounts_d*/,
-    const int64_t* /*senddispls_d*/,
-    const int64_t* /*recvdispls_d*/,
     commDataType_t /*datatype*/,
     CtranComm* /*comm*/,
     cudaStream_t /*stream*/) {

--- a/comms/ctran/algos/AllToAll/DeviceAllToAllvPipes.cu
+++ b/comms/ctran/algos/AllToAll/DeviceAllToAllvPipes.cu
@@ -11,6 +11,20 @@
 #include "comms/pipes/DeviceSpan.cuh"
 #include "comms/pipes/Transport.cuh"
 
+// Compute the exclusive prefix sum of counts[0..rank-1] to get the
+// displacement for the given rank. Each thread computes its own peer's
+// offset independently — no shared memory or __syncthreads() needed.
+// For GB200 the NVL domain can have up to 72 ranks, so this is at most
+// 71 additions from L1-cached global memory.
+__device__ __forceinline__ int64_t
+computeDisplacement(const int64_t* counts_d, int rank) {
+  int64_t displ = 0;
+  for (int r = 0; r < rank; r++) {
+    displ += counts_d[r];
+  }
+  return displ;
+}
+
 __global__ void ncclKernelDeviceAllToAllvPipes(
     int* flag,
     CtranAlgoDeviceState* devState,
@@ -34,8 +48,10 @@ __global__ void ncclKernelDeviceAllToAllvPipes(
     // Single local rank — self-copy only
     int globalRank = args.localRankToGlobalRank[0];
     size_t sendBytes = args.sendcounts_d[globalRank] * elementSize;
-    size_t sendOffset = args.senddispls_d[globalRank] * elementSize;
-    size_t recvOffset = args.recvdispls_d[globalRank] * elementSize;
+    size_t sendOffset =
+        computeDisplacement(args.sendcounts_d, globalRank) * elementSize;
+    size_t recvOffset =
+        computeDisplacement(args.recvcounts_d, globalRank) * elementSize;
 
     transports[globalRank].self.put(
         group,
@@ -51,11 +67,14 @@ __global__ void ncclKernelDeviceAllToAllvPipes(
 
     int peerGlobalRank = args.localRankToGlobalRank[local_peer_idx];
 
-    // Read counts and displacements from device memory (indexed by global rank)
+    // Read counts from device memory (indexed by global rank)
     size_t sendBytes = args.sendcounts_d[peerGlobalRank] * elementSize;
     size_t recvBytes = args.recvcounts_d[peerGlobalRank] * elementSize;
-    size_t sendOffset = args.senddispls_d[peerGlobalRank] * elementSize;
-    size_t recvOffset = args.recvdispls_d[peerGlobalRank] * elementSize;
+    // Compute displacements as exclusive prefix sums of counts
+    size_t sendOffset =
+        computeDisplacement(args.sendcounts_d, peerGlobalRank) * elementSize;
+    size_t recvOffset =
+        computeDisplacement(args.recvcounts_d, peerGlobalRank) * elementSize;
 
     if (peerGlobalRank == myRank) {
       // Self-copy: only one partition does it

--- a/comms/ctran/algos/AllToAll/DeviceAllToAllvPipesImpl.cc
+++ b/comms/ctran/algos/AllToAll/DeviceAllToAllvPipesImpl.cc
@@ -11,8 +11,6 @@ commResult_t setupKernelConfig(
     void* recvbuff,
     const int64_t* sendcounts_d,
     const int64_t* recvcounts_d,
-    const int64_t* senddispls_d,
-    const int64_t* recvdispls_d,
     commDataType_t datatype,
     CtranComm* comm,
     KernelConfig& config,
@@ -25,11 +23,9 @@ commResult_t setupKernelConfig(
   kernArgs.myRank = statex->rank();
   kernArgs.nLocalRanks = statex->nLocalRanks();
 
-  // Device pointers to split sizes and displacements
+  // Device pointers to split sizes
   kernArgs.sendcounts_d = sendcounts_d;
   kernArgs.recvcounts_d = recvcounts_d;
-  kernArgs.senddispls_d = senddispls_d;
-  kernArgs.recvdispls_d = recvdispls_d;
 
   // Build local rank → global rank mapping
   if (kernArgs.nLocalRanks > CTRAN_MAX_NVL_PEERS) {

--- a/comms/ctran/algos/AllToAll/DeviceAllToAllvPipesImpl.h
+++ b/comms/ctran/algos/AllToAll/DeviceAllToAllvPipesImpl.h
@@ -12,8 +12,6 @@ commResult_t setupKernelConfig(
     void* recvbuff,
     const int64_t* sendcounts_d,
     const int64_t* recvcounts_d,
-    const int64_t* senddispls_d,
-    const int64_t* recvdispls_d,
     commDataType_t datatype,
     CtranComm* comm,
     KernelConfig& config,

--- a/comms/ctran/algos/AllToAll/Types.h
+++ b/comms/ctran/algos/AllToAll/Types.h
@@ -40,10 +40,6 @@ struct KernArgs {
   const int64_t* sendcounts_d; // [nRanks] send counts per rank
   const int64_t* recvcounts_d; // [nRanks] recv counts per rank
 
-  // Device pointers to displacements (int64_t, indexed by global rank)
-  const int64_t* senddispls_d; // [nRanks] send displacements per rank
-  const int64_t* recvdispls_d; // [nRanks] recv displacements per rank
-
   // Maps local rank index [0..nLocalRanks) to global rank
   int localRankToGlobalRank[CTRAN_MAX_NVL_PEERS];
 

--- a/comms/ctran/tests/DeviceAllToAllvTest.cc
+++ b/comms/ctran/tests/DeviceAllToAllvTest.cc
@@ -71,21 +71,13 @@ TEST_F(DeviceAllToAllvTest, UniformSplit) {
       cudaMemcpyHostToDevice));
   CUDACHECK_TEST(cudaMemset(recvBuf, 0, totalSize * sizeof(float)));
 
-  // Create device count/offset arrays (uniform split)
+  // Create device count arrays (uniform split)
   std::vector<int64_t> h_counts(nRanks, static_cast<int64_t>(chunkSize));
-  std::vector<int64_t> h_offsets(nRanks);
-  for (int i = 0; i < nRanks; i++) {
-    h_offsets[i] = static_cast<int64_t>(i * chunkSize);
-  }
 
   int64_t* d_sendcounts = nullptr;
   int64_t* d_recvcounts = nullptr;
-  int64_t* d_senddispls = nullptr;
-  int64_t* d_recvdispls = nullptr;
   CUDACHECK_TEST(cudaMalloc(&d_sendcounts, nRanks * sizeof(int64_t)));
   CUDACHECK_TEST(cudaMalloc(&d_recvcounts, nRanks * sizeof(int64_t)));
-  CUDACHECK_TEST(cudaMalloc(&d_senddispls, nRanks * sizeof(int64_t)));
-  CUDACHECK_TEST(cudaMalloc(&d_recvdispls, nRanks * sizeof(int64_t)));
 
   CUDACHECK_TEST(cudaMemcpy(
       d_sendcounts,
@@ -95,16 +87,6 @@ TEST_F(DeviceAllToAllvTest, UniformSplit) {
   CUDACHECK_TEST(cudaMemcpy(
       d_recvcounts,
       h_counts.data(),
-      nRanks * sizeof(int64_t),
-      cudaMemcpyHostToDevice));
-  CUDACHECK_TEST(cudaMemcpy(
-      d_senddispls,
-      h_offsets.data(),
-      nRanks * sizeof(int64_t),
-      cudaMemcpyHostToDevice));
-  CUDACHECK_TEST(cudaMemcpy(
-      d_recvdispls,
-      h_offsets.data(),
       nRanks * sizeof(int64_t),
       cudaMemcpyHostToDevice));
 
@@ -114,8 +96,6 @@ TEST_F(DeviceAllToAllvTest, UniformSplit) {
       recvBuf,
       d_sendcounts,
       d_recvcounts,
-      d_senddispls,
-      d_recvdispls,
       commFloat,
       comm.get(),
       stream_);
@@ -143,8 +123,6 @@ TEST_F(DeviceAllToAllvTest, UniformSplit) {
   CUDACHECK_TEST(cudaFree(recvBuf));
   CUDACHECK_TEST(cudaFree(d_sendcounts));
   CUDACHECK_TEST(cudaFree(d_recvcounts));
-  CUDACHECK_TEST(cudaFree(d_senddispls));
-  CUDACHECK_TEST(cudaFree(d_recvdispls));
 }
 
 // CUDA graph tests: capture ctranDeviceAllToAllv into a graph and replay.
@@ -179,19 +157,11 @@ TEST_F(DeviceAllToAllvTest, UniformSplitCudaGraph) {
   CUDACHECK_TEST(cudaMemset(recvBuf, 0, totalSize * sizeof(float)));
 
   std::vector<int64_t> h_counts(nRanks, static_cast<int64_t>(chunkSize));
-  std::vector<int64_t> h_offsets(nRanks);
-  for (int i = 0; i < nRanks; i++) {
-    h_offsets[i] = static_cast<int64_t>(i * chunkSize);
-  }
 
   int64_t* d_sendcounts = nullptr;
   int64_t* d_recvcounts = nullptr;
-  int64_t* d_senddispls = nullptr;
-  int64_t* d_recvdispls = nullptr;
   CUDACHECK_TEST(cudaMalloc(&d_sendcounts, nRanks * sizeof(int64_t)));
   CUDACHECK_TEST(cudaMalloc(&d_recvcounts, nRanks * sizeof(int64_t)));
-  CUDACHECK_TEST(cudaMalloc(&d_senddispls, nRanks * sizeof(int64_t)));
-  CUDACHECK_TEST(cudaMalloc(&d_recvdispls, nRanks * sizeof(int64_t)));
   CUDACHECK_TEST(cudaMemcpy(
       d_sendcounts,
       h_counts.data(),
@@ -200,16 +170,6 @@ TEST_F(DeviceAllToAllvTest, UniformSplitCudaGraph) {
   CUDACHECK_TEST(cudaMemcpy(
       d_recvcounts,
       h_counts.data(),
-      nRanks * sizeof(int64_t),
-      cudaMemcpyHostToDevice));
-  CUDACHECK_TEST(cudaMemcpy(
-      d_senddispls,
-      h_offsets.data(),
-      nRanks * sizeof(int64_t),
-      cudaMemcpyHostToDevice));
-  CUDACHECK_TEST(cudaMemcpy(
-      d_recvdispls,
-      h_offsets.data(),
       nRanks * sizeof(int64_t),
       cudaMemcpyHostToDevice));
 
@@ -227,8 +187,6 @@ TEST_F(DeviceAllToAllvTest, UniformSplitCudaGraph) {
       recvBuf,
       d_sendcounts,
       d_recvcounts,
-      d_senddispls,
-      d_recvdispls,
       commFloat,
       comm.get(),
       cudagraph_stream);
@@ -261,8 +219,6 @@ TEST_F(DeviceAllToAllvTest, UniformSplitCudaGraph) {
   CUDACHECK_TEST(cudaFree(recvBuf));
   CUDACHECK_TEST(cudaFree(d_sendcounts));
   CUDACHECK_TEST(cudaFree(d_recvcounts));
-  CUDACHECK_TEST(cudaFree(d_senddispls));
-  CUDACHECK_TEST(cudaFree(d_recvdispls));
 }
 
 TEST_F(DeviceAllToAllvTest, UniformSplitCudaGraphMultiReplay) {
@@ -291,19 +247,11 @@ TEST_F(DeviceAllToAllvTest, UniformSplitCudaGraphMultiReplay) {
       cudaMemcpyHostToDevice));
 
   std::vector<int64_t> h_counts(nRanks, static_cast<int64_t>(chunkSize));
-  std::vector<int64_t> h_offsets(nRanks);
-  for (int i = 0; i < nRanks; i++) {
-    h_offsets[i] = static_cast<int64_t>(i * chunkSize);
-  }
 
   int64_t* d_sendcounts = nullptr;
   int64_t* d_recvcounts = nullptr;
-  int64_t* d_senddispls = nullptr;
-  int64_t* d_recvdispls = nullptr;
   CUDACHECK_TEST(cudaMalloc(&d_sendcounts, nRanks * sizeof(int64_t)));
   CUDACHECK_TEST(cudaMalloc(&d_recvcounts, nRanks * sizeof(int64_t)));
-  CUDACHECK_TEST(cudaMalloc(&d_senddispls, nRanks * sizeof(int64_t)));
-  CUDACHECK_TEST(cudaMalloc(&d_recvdispls, nRanks * sizeof(int64_t)));
   CUDACHECK_TEST(cudaMemcpy(
       d_sendcounts,
       h_counts.data(),
@@ -312,16 +260,6 @@ TEST_F(DeviceAllToAllvTest, UniformSplitCudaGraphMultiReplay) {
   CUDACHECK_TEST(cudaMemcpy(
       d_recvcounts,
       h_counts.data(),
-      nRanks * sizeof(int64_t),
-      cudaMemcpyHostToDevice));
-  CUDACHECK_TEST(cudaMemcpy(
-      d_senddispls,
-      h_offsets.data(),
-      nRanks * sizeof(int64_t),
-      cudaMemcpyHostToDevice));
-  CUDACHECK_TEST(cudaMemcpy(
-      d_recvdispls,
-      h_offsets.data(),
       nRanks * sizeof(int64_t),
       cudaMemcpyHostToDevice));
 
@@ -337,8 +275,6 @@ TEST_F(DeviceAllToAllvTest, UniformSplitCudaGraphMultiReplay) {
       recvBuf,
       d_sendcounts,
       d_recvcounts,
-      d_senddispls,
-      d_recvdispls,
       commFloat,
       comm.get(),
       cudagraph_stream);
@@ -376,8 +312,6 @@ TEST_F(DeviceAllToAllvTest, UniformSplitCudaGraphMultiReplay) {
   CUDACHECK_TEST(cudaFree(recvBuf));
   CUDACHECK_TEST(cudaFree(d_sendcounts));
   CUDACHECK_TEST(cudaFree(d_recvcounts));
-  CUDACHECK_TEST(cudaFree(d_senddispls));
-  CUDACHECK_TEST(cudaFree(d_recvdispls));
 }
 
 TEST_F(DeviceAllToAllvTest, UniformSplitCudaGraphChangedData) {
@@ -399,19 +333,11 @@ TEST_F(DeviceAllToAllvTest, UniformSplitCudaGraphChangedData) {
   CUDACHECK_TEST(cudaMalloc(&recvBuf, totalSize * sizeof(float)));
 
   std::vector<int64_t> h_counts(nRanks, static_cast<int64_t>(chunkSize));
-  std::vector<int64_t> h_offsets(nRanks);
-  for (int i = 0; i < nRanks; i++) {
-    h_offsets[i] = static_cast<int64_t>(i * chunkSize);
-  }
 
   int64_t* d_sendcounts = nullptr;
   int64_t* d_recvcounts = nullptr;
-  int64_t* d_senddispls = nullptr;
-  int64_t* d_recvdispls = nullptr;
   CUDACHECK_TEST(cudaMalloc(&d_sendcounts, nRanks * sizeof(int64_t)));
   CUDACHECK_TEST(cudaMalloc(&d_recvcounts, nRanks * sizeof(int64_t)));
-  CUDACHECK_TEST(cudaMalloc(&d_senddispls, nRanks * sizeof(int64_t)));
-  CUDACHECK_TEST(cudaMalloc(&d_recvdispls, nRanks * sizeof(int64_t)));
   CUDACHECK_TEST(cudaMemcpy(
       d_sendcounts,
       h_counts.data(),
@@ -420,16 +346,6 @@ TEST_F(DeviceAllToAllvTest, UniformSplitCudaGraphChangedData) {
   CUDACHECK_TEST(cudaMemcpy(
       d_recvcounts,
       h_counts.data(),
-      nRanks * sizeof(int64_t),
-      cudaMemcpyHostToDevice));
-  CUDACHECK_TEST(cudaMemcpy(
-      d_senddispls,
-      h_offsets.data(),
-      nRanks * sizeof(int64_t),
-      cudaMemcpyHostToDevice));
-  CUDACHECK_TEST(cudaMemcpy(
-      d_recvdispls,
-      h_offsets.data(),
       nRanks * sizeof(int64_t),
       cudaMemcpyHostToDevice));
 
@@ -453,8 +369,6 @@ TEST_F(DeviceAllToAllvTest, UniformSplitCudaGraphChangedData) {
       recvBuf,
       d_sendcounts,
       d_recvcounts,
-      d_senddispls,
-      d_recvdispls,
       commFloat,
       comm.get(),
       cudagraph_stream);
@@ -502,8 +416,6 @@ TEST_F(DeviceAllToAllvTest, UniformSplitCudaGraphChangedData) {
   CUDACHECK_TEST(cudaFree(recvBuf));
   CUDACHECK_TEST(cudaFree(d_sendcounts));
   CUDACHECK_TEST(cudaFree(d_recvcounts));
-  CUDACHECK_TEST(cudaFree(d_senddispls));
-  CUDACHECK_TEST(cudaFree(d_recvdispls));
 }
 
 #endif // TEST_CUDA_GRAPH_MODE

--- a/comms/ncclx/v2_27/src/collectives.cc
+++ b/comms/ncclx/v2_27/src/collectives.cc
@@ -431,8 +431,6 @@ ncclResult_t ncclx::deviceAllToAllv(
     void* recvbuff,
     const int64_t* sendcounts_d,
     const int64_t* recvcounts_d,
-    const int64_t* senddispls_d,
-    const int64_t* recvdispls_d,
     ncclDataType_t datatype,
     ncclComm_t comm,
     cudaStream_t stream) {
@@ -446,8 +444,6 @@ ncclResult_t ncclx::deviceAllToAllv(
       recvbuff,
       sendcounts_d,
       recvcounts_d,
-      senddispls_d,
-      recvdispls_d,
       ncclToMetaComm(datatype),
       comm->ctranComm_.get(),
       stream));
@@ -459,8 +455,6 @@ ncclResult_t ncclx::deviceAllToAllv(
     void* /*recvbuff*/,
     const int64_t* /*sendcounts_d*/,
     const int64_t* /*recvcounts_d*/,
-    const int64_t* /*senddispls_d*/,
-    const int64_t* /*recvdispls_d*/,
     ncclDataType_t /*datatype*/,
     ncclComm_t /*comm*/,
     cudaStream_t /*stream*/) {

--- a/comms/ncclx/v2_27/src/nccl.h.in
+++ b/comms/ncclx/v2_27/src/nccl.h.in
@@ -948,7 +948,6 @@ ncclResult_t alltoallvDynamicCombine( const void* sendbuff, const size_t* sendSp
 
 ncclResult_t deviceAllToAllv(const void* sendbuff, void* recvbuff,
     const int64_t* sendcounts_d, const int64_t* recvcounts_d,
-    const int64_t* senddispls_d, const int64_t* recvdispls_d,
     ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream);
 
 /*

--- a/comms/ncclx/v2_28/src/collectives.cc
+++ b/comms/ncclx/v2_28/src/collectives.cc
@@ -483,8 +483,6 @@ ncclResult_t ncclx::deviceAllToAllv(
     void* recvbuff,
     const int64_t* sendcounts_d,
     const int64_t* recvcounts_d,
-    const int64_t* senddispls_d,
-    const int64_t* recvdispls_d,
     ncclDataType_t datatype,
     ncclComm_t comm,
     cudaStream_t stream) {
@@ -498,8 +496,6 @@ ncclResult_t ncclx::deviceAllToAllv(
       recvbuff,
       sendcounts_d,
       recvcounts_d,
-      senddispls_d,
-      recvdispls_d,
       ncclToMetaComm(datatype),
       comm->ctranComm_.get(),
       stream));
@@ -511,8 +507,6 @@ ncclResult_t ncclx::deviceAllToAllv(
     void* /*recvbuff*/,
     const int64_t* /*sendcounts_d*/,
     const int64_t* /*recvcounts_d*/,
-    const int64_t* /*senddispls_d*/,
-    const int64_t* /*recvdispls_d*/,
     ncclDataType_t /*datatype*/,
     ncclComm_t /*comm*/,
     cudaStream_t /*stream*/) {

--- a/comms/ncclx/v2_28/src/nccl.h.in
+++ b/comms/ncclx/v2_28/src/nccl.h.in
@@ -1044,7 +1044,6 @@ ncclResult_t alltoallvDynamicCombine( const void* sendbuff, const size_t* sendSp
 
 ncclResult_t deviceAllToAllv(const void* sendbuff, void* recvbuff,
     const int64_t* sendcounts_d, const int64_t* recvcounts_d,
-    const int64_t* senddispls_d, const int64_t* recvdispls_d,
     ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream);
 
 /*

--- a/comms/ncclx/v2_29/src/collectives.cc
+++ b/comms/ncclx/v2_29/src/collectives.cc
@@ -487,8 +487,6 @@ ncclResult_t ncclx::deviceAllToAllv(
     void* recvbuff,
     const int64_t* sendcounts_d,
     const int64_t* recvcounts_d,
-    const int64_t* senddispls_d,
-    const int64_t* recvdispls_d,
     ncclDataType_t datatype,
     ncclComm_t comm,
     cudaStream_t stream) {
@@ -502,8 +500,6 @@ ncclResult_t ncclx::deviceAllToAllv(
       recvbuff,
       sendcounts_d,
       recvcounts_d,
-      senddispls_d,
-      recvdispls_d,
       ncclToMetaComm(datatype),
       comm->ctranComm_.get(),
       stream));
@@ -515,8 +511,6 @@ ncclResult_t ncclx::deviceAllToAllv(
     void* /*recvbuff*/,
     const int64_t* /*sendcounts_d*/,
     const int64_t* /*recvcounts_d*/,
-    const int64_t* /*senddispls_d*/,
-    const int64_t* /*recvdispls_d*/,
     ncclDataType_t /*datatype*/,
     ncclComm_t /*comm*/,
     cudaStream_t /*stream*/) {

--- a/comms/ncclx/v2_29/src/nccl.h.in
+++ b/comms/ncclx/v2_29/src/nccl.h.in
@@ -1191,13 +1191,13 @@ ncclResult_t alltoallvDynamicCombine( const void* sendbuff, const size_t* sendSp
 /*
  * Device AllToAllv: AllToAllv where split sizes are device tensors.
  * Unlike regular AllToAllv where counts/displacements are host arrays,
- * this variant takes device pointers for sendcounts, recvcounts,
- * senddispls, and recvdispls. This is useful when split sizes are
- * computed on the GPU and not known on the host beforehand.
+ * this variant takes device pointers for sendcounts and recvcounts.
+ * Displacements are computed internally as exclusive prefix sums of
+ * the counts. This is useful when split sizes are computed on the GPU
+ * and not known on the host beforehand.
  */
 ncclResult_t deviceAllToAllv(const void* sendbuff, void* recvbuff,
     const int64_t* sendcounts_d, const int64_t* recvcounts_d,
-    const int64_t* senddispls_d, const int64_t* recvdispls_d,
     ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream);
 
 /*

--- a/comms/torchcomms/ncclx/NcclxApi.cpp
+++ b/comms/torchcomms/ncclx/NcclxApi.cpp
@@ -236,22 +236,12 @@ ncclResult_t DefaultNcclxApi::deviceAllToAllv(
     void* recvbuff,
     const int64_t* sendcounts_d,
     const int64_t* recvcounts_d,
-    const int64_t* senddispls_d,
-    const int64_t* recvdispls_d,
     ncclDataType_t datatype,
     ncclComm_t comm,
     cudaStream_t stream) {
   std::lock_guard<std::mutex> lock(api_mutex_);
   return ncclx::deviceAllToAllv(
-      sendbuff,
-      recvbuff,
-      sendcounts_d,
-      recvcounts_d,
-      senddispls_d,
-      recvdispls_d,
-      datatype,
-      comm,
-      stream);
+      sendbuff, recvbuff, sendcounts_d, recvcounts_d, datatype, comm, stream);
 }
 
 ncclResult_t DefaultNcclxApi::alltoallvDynamicDispatch(

--- a/comms/torchcomms/ncclx/NcclxApi.hpp
+++ b/comms/torchcomms/ncclx/NcclxApi.hpp
@@ -203,8 +203,6 @@ class NcclxApi {
       void* recvbuff,
       const int64_t* sendcounts_d,
       const int64_t* recvcounts_d,
-      const int64_t* senddispls_d,
-      const int64_t* recvdispls_d,
       ncclDataType_t datatype,
       ncclComm_t comm,
       cudaStream_t stream) {
@@ -515,8 +513,6 @@ class DefaultNcclxApi : public NcclxApi {
       void* recvbuff,
       const int64_t* sendcounts_d,
       const int64_t* recvcounts_d,
-      const int64_t* senddispls_d,
-      const int64_t* recvdispls_d,
       ncclDataType_t datatype,
       ncclComm_t comm,
       cudaStream_t stream) override;

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -1507,8 +1507,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::device_alltoallv_single(
     const at::Tensor& input,
     const at::Tensor& output_split_sizes,
     const at::Tensor& input_split_sizes,
-    const at::Tensor& output_split_offsets,
-    const at::Tensor& input_split_offsets,
     bool async_op) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
@@ -1516,14 +1514,10 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::device_alltoallv_single(
   ensureTensorContiguous(input);
   ensureTensorContiguous(output_split_sizes);
   ensureTensorContiguous(input_split_sizes);
-  ensureTensorContiguous(output_split_offsets);
-  ensureTensorContiguous(input_split_offsets);
 
   // Validate metadata tensor types - all must be int64_t (torch.int64)
   validateInt64Dtype(input_split_sizes, "input_split_sizes");
   validateInt64Dtype(output_split_sizes, "output_split_sizes");
-  validateInt64Dtype(input_split_offsets, "input_split_offsets");
-  validateInt64Dtype(output_split_offsets, "output_split_offsets");
 
   // Validate metadata tensors are on CUDA
   TORCH_CHECK(
@@ -1532,12 +1526,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::device_alltoallv_single(
   TORCH_CHECK(
       output_split_sizes.is_cuda(),
       "output_split_sizes must be a CUDA tensor for device_alltoallv_single");
-  TORCH_CHECK(
-      input_split_offsets.is_cuda(),
-      "input_split_offsets must be a CUDA tensor for device_alltoallv_single");
-  TORCH_CHECK(
-      output_split_offsets.is_cuda(),
-      "output_split_offsets must be a CUDA tensor for device_alltoallv_single");
 
   TracingGuard tracingGuard(
       name_, comm_size_, "device_alltoallv_single", rank_, input, output);
@@ -1547,10 +1535,9 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::device_alltoallv_single(
   auto work = createWork(
       stream,
       options_.timeout,
-      async_op
-          ? std::vector<
-                at::Tensor>{input, input_split_sizes, output_split_sizes, input_split_offsets, output_split_offsets}
-          : std::vector<at::Tensor>{});
+      async_op ? std::vector<
+                     at::Tensor>{input, input_split_sizes, output_split_sizes}
+               : std::vector<at::Tensor>{});
 
   // Record start event before NCCL operation
   work->recordStart("device_alltoallv_single");
@@ -1560,8 +1547,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::device_alltoallv_single(
       output.data_ptr(),
       input_split_sizes.data_ptr<int64_t>(),
       output_split_sizes.data_ptr<int64_t>(),
-      input_split_offsets.data_ptr<int64_t>(),
-      output_split_offsets.data_ptr<int64_t>(),
       getNcclDataType(input),
       nccl_comm_,
       stream);

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
@@ -185,8 +185,6 @@ class TorchCommNCCLX : public TorchCommBackend,
       const at::Tensor& input,
       const at::Tensor& output_split_sizes,
       const at::Tensor& input_split_sizes,
-      const at::Tensor& output_split_offsets,
-      const at::Tensor& input_split_offsets,
       bool async_op);
 
   c10::intrusive_ptr<TorchWork> alltoallv_dynamic_dispatch(

--- a/comms/torchcomms/ncclx/TorchCommNCCLXPy.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXPy.cpp
@@ -48,32 +48,23 @@ PYBIND11_MODULE(_comms_ncclx, m) {
              const at::Tensor& input,
              const at::Tensor& output_split_sizes,
              const at::Tensor& input_split_sizes,
-             const at::Tensor& output_split_offsets,
-             const at::Tensor& input_split_offsets,
              bool async_op) {
             return self.device_alltoallv_single(
-                output,
-                input,
-                output_split_sizes,
-                input_split_sizes,
-                output_split_offsets,
-                input_split_offsets,
-                async_op);
+                output, input, output_split_sizes, input_split_sizes, async_op);
           },
           R"(
-All-to-all-v operation where split sizes and offsets are device tensors (on GPU).
+All-to-all-v operation where split sizes are device tensors (on GPU).
 
 Unlike all_to_all_v_single where split sizes are host vectors, this API takes
-split sizes and displacements as CUDA tensors, allowing the GPU to read them
-directly without host-device synchronization.
+split sizes as CUDA tensors, allowing the GPU to read them directly without
+host-device synchronization. Displacements are computed internally by the
+kernel as exclusive prefix sums of the counts.
 
 Args:
     output: Output tensor to receive data.
     input: Input tensor containing data to send.
     output_split_sizes: CUDA int64 tensor of receive counts per rank.
     input_split_sizes: CUDA int64 tensor of send counts per rank.
-    output_split_offsets: CUDA int64 tensor of receive displacements per rank.
-    input_split_offsets: CUDA int64 tensor of send displacements per rank.
     async_op: Whether to perform the operation asynchronously.
 
 Returns:
@@ -83,8 +74,6 @@ Returns:
           py::arg("input"),
           py::arg("output_split_sizes"),
           py::arg("input_split_sizes"),
-          py::arg("output_split_offsets"),
-          py::arg("input_split_offsets"),
           py::arg("async_op"),
           py::call_guard<py::gil_scoped_release>())
       .def(

--- a/comms/torchcomms/ncclx/_comms_ncclx.pyi
+++ b/comms/torchcomms/ncclx/_comms_ncclx.pyi
@@ -39,8 +39,6 @@ class TorchCommNCCLX:
         input: torch.Tensor,
         output_split_sizes: torch.Tensor,
         input_split_sizes: torch.Tensor,
-        output_split_offsets: torch.Tensor,
-        input_split_offsets: torch.Tensor,
         async_op: bool,
     ) -> TorchWork: ...
     def alltoallv_dynamic_dispatch(

--- a/comms/torchcomms/ncclx/tests/integration/py/DeviceAllToAllvSingleTest.py
+++ b/comms/torchcomms/ncclx/tests/integration/py/DeviceAllToAllvSingleTest.py
@@ -15,9 +15,10 @@ from torchcomms.tests.integration.py.TorchCommTestHelpers import (
 class DeviceAllToAllvSingleTest(unittest.TestCase):
     """Test class for device_alltoallv_single operation.
 
-    This tests the device_alltoallv_single API where split sizes and offsets
-    are CUDA tensors (on GPU), unlike all_to_all_v_single where they are
-    host vectors.
+    This tests the device_alltoallv_single API where split sizes are
+    CUDA tensors (on GPU), unlike all_to_all_v_single where they are
+    host vectors. Displacements are computed internally by the kernel
+    as exclusive prefix sums of the counts.
 
     Test pattern:
     - Each rank creates an input tensor filled with its rank value
@@ -67,27 +68,13 @@ class DeviceAllToAllvSingleTest(unittest.TestCase):
         )
         output_tensor = torch.zeros(total_size, dtype=dtype, device=self.device)
 
-        # Create device tensors for split sizes and offsets
+        # Create device tensors for split sizes
         # Uniform split: each rank sends/receives chunk_size elements
         send_counts = torch.full(
             (self.num_ranks,), chunk_size, dtype=torch.int64, device=self.device
         )
         recv_counts = torch.full(
             (self.num_ranks,), chunk_size, dtype=torch.int64, device=self.device
-        )
-        send_offsets = torch.arange(
-            0,
-            total_size,
-            chunk_size,
-            dtype=torch.int64,
-            device=self.device,
-        )
-        recv_offsets = torch.arange(
-            0,
-            total_size,
-            chunk_size,
-            dtype=torch.int64,
-            device=self.device,
         )
 
         print(f"[Rank {self.rank}] input shape={input_tensor.shape}, value={self.rank}")
@@ -98,8 +85,6 @@ class DeviceAllToAllvSingleTest(unittest.TestCase):
             input_tensor,
             recv_counts,
             send_counts,
-            recv_offsets,
-            send_offsets,
             False,  # async_op
         )
 
@@ -145,10 +130,7 @@ class DeviceAllToAllvSingleTest(unittest.TestCase):
         )
         output_tensor = torch.zeros(total_recv, dtype=dtype, device=self.device)
 
-        # Compute offsets (prefix sum)
-        send_offsets_list = [0]
-        for s in send_sizes[:-1]:
-            send_offsets_list.append(send_offsets_list[-1] + s)
+        # Compute expected offsets for verification (prefix sum)
         recv_offsets_list = [0]
         for r in recv_sizes[:-1]:
             recv_offsets_list.append(recv_offsets_list[-1] + r)
@@ -156,12 +138,6 @@ class DeviceAllToAllvSingleTest(unittest.TestCase):
         # Create device tensors
         send_counts = torch.tensor(send_sizes, dtype=torch.int64, device=self.device)
         recv_counts = torch.tensor(recv_sizes, dtype=torch.int64, device=self.device)
-        send_offsets = torch.tensor(
-            send_offsets_list, dtype=torch.int64, device=self.device
-        )
-        recv_offsets = torch.tensor(
-            recv_offsets_list, dtype=torch.int64, device=self.device
-        )
 
         print(f"[Rank {self.rank}] send_sizes={send_sizes}, recv_sizes={recv_sizes}")
 
@@ -171,8 +147,6 @@ class DeviceAllToAllvSingleTest(unittest.TestCase):
             input_tensor,
             recv_counts,
             send_counts,
-            recv_offsets,
-            send_offsets,
             False,  # async_op
         )
 


### PR DESCRIPTION
Summary:
## Summary

Remove `senddispls_d` and `recvdispls_d` (displacement/offset) parameters from the `device_alltoallv` / `device_alltoallv_single` API across all layers. Displacements are now computed inside the CUDA kernel by each thread as exclusive prefix sums of the counts arrays.

### Motivation

The displacement arrays were always just prefix sums of the counts arrays, so passing them separately was redundant. Computing them in-kernel:
- Simplifies the API (fewer arguments to manage)
- Eliminates the need for callers to allocate, compute, and pass offset tensors
- The computation is trivial (at most 7 additions for N ≤ 8 NVLink peers) and reads from L1-cached global memory

### Changes

**Kernel (DeviceAllToAllvPipes.cu):**
- Added `computeDisplacement()` device function that computes an exclusive prefix sum of counts for a given rank
- Updated kernel to call `computeDisplacement()` instead of reading from displacement arrays

**API layers (all remove senddispls_d/recvdispls_d params):**
- `Ctran.h` — `ctranDeviceAllToAllv` declaration
- `AllToAll.cc` — Implementation + fallback stub
- `DeviceAllToAllvPipesImpl.cc/.h` — Kernel setup
- `Types.h` — `KernArgs` struct
- `ncclx v2_28 & v2_29 collectives.cc / nccl.h.in` — ncclx library API
- `NcclxApi.cpp/.hpp` — Torchcomms ncclx wrapper
- `TorchCommNCCLX.cpp/.hpp` — Torch comm backend
- `TorchCommNCCLXPy.cpp` — Python bindings
- `_comms_ncclx.pyi` — Python type stubs

**Tests:**
- `DeviceAllToAllvTest.cc` — Removed offset allocation/memcpy/free from all test cases
- `DeviceAllToAllvSingleTest.py` — Removed offset tensor creation from both uniform and variable split tests

Differential Revision: D97389967


