### PR TITLE
Add per-collective hints for deviceAllToAllv (#1170)

### DIFF
--- a/comms/ctran/Ctran.h
+++ b/comms/ctran/Ctran.h
@@ -136,7 +136,8 @@ commResult_t ctranDeviceAllToAllv(
     CtranComm* comm,
     cudaStream_t stream,
     int64_t sendcountsMultiplier = 1,
-    int64_t recvcountsMultiplier = 1);
+    int64_t recvcountsMultiplier = 1,
+    const std::unordered_map<std::string, std::string>& hints = {});
 
 commResult_t ctranAllToAllv(
     const void* sendbuff,

--- a/comms/ctran/algos/AllToAll/AllToAll.cc
+++ b/comms/ctran/algos/AllToAll/AllToAll.cc
@@ -211,7 +211,8 @@ commResult_t ctranDeviceAllToAllv(
     CtranComm* comm,
     cudaStream_t stream,
     int64_t sendcountsMultiplier,
-    int64_t recvcountsMultiplier) {
+    int64_t recvcountsMultiplier,
+    const std::unordered_map<std::string, std::string>& hints) {
   auto opCount = comm->ctran_->getOpCount();
 
   KernelConfig config = KernelConfig(
@@ -219,6 +220,23 @@ commResult_t ctranDeviceAllToAllv(
       stream,
       "DeviceAllToAllvPipes",
       opCount);
+
+  // CollectiveConfig resolves all settings in its constructor:
+  // per-collective hint > cvar > default
+  ctran::device_alltoallv_pipes::CollectiveConfig collConfig(
+      comm->statex_->nLocalRanks(), &hints);
+
+  CLOGF_SUBSYS(
+      INFO,
+      COLL,
+      "DeviceAllToAllvPipes: opCount {} numBlocks {} numThreads {} "
+      "blockScheduling {} hasHints {} [nLocalRanks={}]",
+      opCount,
+      collConfig.numBlocks,
+      collConfig.numThreads,
+      collConfig.blockScheduling,
+      (!hints.empty()),
+      comm->statex_->nLocalRanks());
 
   ctran::device_alltoallv_pipes::KernArgs kernArgs;
   FB_COMMCHECK(
@@ -232,7 +250,8 @@ commResult_t ctranDeviceAllToAllv(
           config,
           kernArgs,
           sendcountsMultiplier,
-          recvcountsMultiplier));
+          recvcountsMultiplier,
+          collConfig));
 
   // NVLink-only: no GPE op needed (no IB fallback)
   std::vector<std::unique_ptr<struct OpElem>> opGroup;
@@ -285,7 +304,8 @@ commResult_t ctranDeviceAllToAllv(
     CtranComm* /*comm*/,
     cudaStream_t /*stream*/,
     int64_t /*sendcountsMultiplier*/,
-    int64_t /*recvcountsMultiplier*/) {
+    int64_t /*recvcountsMultiplier*/,
+    const std::unordered_map<std::string, std::string>& /*hints*/) {
   return commInternalError;
 }
 

--- a/comms/ctran/algos/AllToAll/DeviceAllToAllvPipesImpl.cc
+++ b/comms/ctran/algos/AllToAll/DeviceAllToAllvPipesImpl.cc
@@ -4,8 +4,104 @@
 #include "comms/ctran/algos/CtranAlgoDev.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
+#include <algorithm>
+#include <cstdlib>
+
 namespace ctran::device_alltoallv_pipes {
 
+// ---------------------------------------------------------------------------
+// CollectiveConfig constructor — resolves all settings up front.
+// Priority: per-collective hint > env var > CVAR > built-in default
+// ---------------------------------------------------------------------------
+CollectiveConfig::CollectiveConfig(
+    int nLocalRanks,
+    const std::unordered_map<std::string, std::string>* hints_ptr) {
+  auto hintInt = [&](const std::string& key) -> int {
+    if (hints_ptr) {
+      auto it = hints_ptr->find(key);
+      if (it != hints_ptr->end()) {
+        try {
+          return std::stoi(it->second);
+        } catch (...) {
+        }
+      }
+    }
+    return -1;
+  };
+
+  auto hintBool = [&](const std::string& key) -> int {
+    if (hints_ptr) {
+      auto it = hints_ptr->find(key);
+      if (it != hints_ptr->end()) {
+        const auto& v = it->second;
+        if (v == "1" || v == "true")
+          return 1;
+        if (v == "0" || v == "false")
+          return 0;
+      }
+    }
+    return -1; // not set
+  };
+
+  // --- blockScheduling ---
+  // hint > NCCL_CTRAN_DA2A_BLOCK_SCHEDULING env > default(false/warp)
+  int bs = hintBool("blockScheduling");
+  if (bs >= 0) {
+    blockScheduling = (bs == 1);
+  } else {
+    const char* env = getenv("NCCL_CTRAN_DA2A_BLOCK_SCHEDULING");
+    blockScheduling = (env && std::atoi(env) == 1);
+  }
+
+  // --- numBlocks ---
+  // hint > NCCL_CTRAN_DA2A_NBLOCKS env > default(nLocalRanks*2)
+  int nb = hintInt("numBlocks");
+  if (nb >= 0) {
+    numBlocks = static_cast<unsigned int>(nb);
+  } else {
+    const char* env = getenv("NCCL_CTRAN_DA2A_NBLOCKS");
+    if (env) {
+      numBlocks = static_cast<unsigned int>(std::atoi(env));
+    } else {
+      numBlocks = static_cast<unsigned int>(std::max(1, nLocalRanks * 2));
+    }
+  }
+
+  // Align to cluster size if needed
+  unsigned int clusterSize = NCCL_CTRAN_CGA_CLUSTER_SIZE;
+  if (clusterSize > 1 && numBlocks % clusterSize != 0) {
+    numBlocks = ((numBlocks + clusterSize - 1) / clusterSize) * clusterSize;
+  }
+
+  // If block scheduling requested but not enough blocks, fall back to warp
+  if (blockScheduling &&
+      numBlocks < static_cast<unsigned int>(nLocalRanks * 2)) {
+    blockScheduling = false;
+  }
+
+  // --- numThreads ---
+  // hint > NCCL_CTRAN_DA2A_NTHREADS env > NCCL_CTRAN_ALLTOALL_THREAD_BLOCK_SIZE
+  // cvar > default(512)
+  int nt = hintInt("numThreads");
+  if (nt >= 0) {
+    numThreads = static_cast<unsigned int>(nt);
+  } else {
+    const char* env = getenv("NCCL_CTRAN_DA2A_NTHREADS");
+    if (env) {
+      numThreads = static_cast<unsigned int>(std::atoi(env));
+    } else if (NCCL_CTRAN_ALLTOALL_THREAD_BLOCK_SIZE > 0) {
+      numThreads =
+          static_cast<unsigned int>(NCCL_CTRAN_ALLTOALL_THREAD_BLOCK_SIZE);
+    } else {
+      numThreads = 512;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// setupKernelConfig — populates KernelConfig + KernArgs from comm state
+// and the fully-resolved CollectiveConfig.
+// ---------------------------------------------------------------------------
 commResult_t setupKernelConfig(
     const void* sendbuff,
     void* recvbuff,
@@ -16,7 +112,8 @@ commResult_t setupKernelConfig(
     KernelConfig& config,
     ctran::device_alltoallv_pipes::KernArgs& kernArgs,
     int64_t sendcountsMultiplier,
-    int64_t recvcountsMultiplier) {
+    int64_t recvcountsMultiplier,
+    const CollectiveConfig& collConfig) {
   const auto statex = comm->statex_.get();
 
   kernArgs.sendbuff = sendbuff;
@@ -33,7 +130,7 @@ commResult_t setupKernelConfig(
   kernArgs.sendcountsMultiplier = sendcountsMultiplier;
   kernArgs.recvcountsMultiplier = recvcountsMultiplier;
 
-  // Build local rank → global rank mapping
+  // Build local rank -> global rank mapping
   if (kernArgs.nLocalRanks > CTRAN_MAX_NVL_PEERS) {
     return commInternalError;
   }
@@ -44,52 +141,10 @@ commResult_t setupKernelConfig(
   // Set transport array from MultiPeerTransport
   kernArgs.transports = comm->getMultiPeerTransportsPtr();
 
-  // Scheduling: warp (default) vs block
-  const char* blockSchedEnv = getenv("NCCL_CTRAN_DA2A_BLOCK_SCHEDULING");
-  kernArgs.useBlockGroup = (blockSchedEnv && std::atoi(blockSchedEnv) == 1);
-
-  // Grid/block config — parameterizable via env vars for tuning
-  unsigned int numBlocks = std::max(1, kernArgs.nLocalRanks * 2);
-
-  // Block scheduling requires at least 2 * nLocalRanks blocks
-  // (one send + one recv block per peer)
-  if (kernArgs.useBlockGroup) {
-    numBlocks = std::max(
-        numBlocks, static_cast<unsigned int>(kernArgs.nLocalRanks * 2));
-  }
-  const char* numBlocksEnv = getenv("NCCL_CTRAN_DA2A_NBLOCKS");
-  if (numBlocksEnv) {
-    numBlocks = static_cast<unsigned int>(std::atoi(numBlocksEnv));
-  }
-
-  unsigned int clusterSize = NCCL_CTRAN_CGA_CLUSTER_SIZE;
-  if (clusterSize > 1 && numBlocks % clusterSize != 0) {
-    numBlocks = ((numBlocks + clusterSize - 1) / clusterSize) * clusterSize;
-  }
-
-  // DeviceAllToAllvPipes doesn't use GPE ops (opGroup is empty) or per-block
-  // sync structures (CtranAlgoDeviceSync, KernelElem). Only flag[0] is used
-  // by thread 0 for start/terminate. The CTRAN_ALGO_MAX_THREAD_BLOCKS limit
-  // doesn't apply here. See AllToAllvDedup (AlgoImpl.cc) for same pattern.
-  config.numBlocks = numBlocks;
-
-  unsigned int numThreads = 256;
-  const char* numThreadsEnv = getenv("NCCL_CTRAN_DA2A_NTHREADS");
-  if (numThreadsEnv) {
-    numThreads = static_cast<unsigned int>(std::atoi(numThreadsEnv));
-  } else if (NCCL_CTRAN_ALLTOALL_THREAD_BLOCK_SIZE > 0) {
-    numThreads = NCCL_CTRAN_ALLTOALL_THREAD_BLOCK_SIZE;
-  }
-  config.numThreads = numThreads;
-
-  // Performance tuning env vars (all read at runtime, no recompile needed):
-  //   NCCL_CTRAN_DA2A_NBLOCKS  — override block count (default: nLocalRanks*2)
-  //   NCCL_CTRAN_DA2A_NTHREADS — override thread count (default: 256)
-  //   NCCL_CTRAN_DA2A_BLOCK_SCHEDULING=1 — use block-level scheduling
-  //     (each block handles one peer) instead of warp-level (default)
-  //   NCCL_CTRAN_ENALBE_CLUSTER_KERNEL_LAUNCH=1 — enable cluster launch
-  //   NCCL_CTRAN_CGA_CLUSTER_SIZE — cluster size (default: 4)
-  //   NCCL_CTRAN_PIPES_NVL_CHUNK_SIZE — NVL chunk size bytes (default: 512KB)
+  // All config is pre-resolved in CollectiveConfig — just apply it.
+  kernArgs.useBlockGroup = collConfig.blockScheduling;
+  config.numBlocks = collConfig.numBlocks;
+  config.numThreads = collConfig.numThreads;
 
   config.args.devState_d = comm->ctran_->algo->getDevState();
   config.algoArgs = &kernArgs;

--- a/comms/ctran/algos/AllToAll/DeviceAllToAllvPipesImpl.h
+++ b/comms/ctran/algos/AllToAll/DeviceAllToAllvPipesImpl.h
@@ -1,11 +1,31 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 #pragma once
 
+#include <string>
+#include <unordered_map>
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/AllToAll/Types.h"
 #include "comms/ctran/algos/CtranAlgo.h"
 
 namespace ctran::device_alltoallv_pipes {
+
+// Fully-resolved kernel configuration for deviceAllToAllv.
+// The constructor merges per-collective hints with env var / cvar defaults
+// so that consumers read final values directly — no fallback logic needed.
+//
+// Resolution priority (highest wins):
+//   per-collective hint (from map) > env var > CVAR > built-in default
+struct CollectiveConfig {
+  unsigned int numBlocks;
+  unsigned int numThreads;
+  bool blockScheduling; // false=warp(default), true=block scheduling
+
+  // Construct with all defaults resolved from env vars / cvars.
+  // Per-collective hints (if any) override those defaults.
+  explicit CollectiveConfig(
+      int nLocalRanks,
+      const std::unordered_map<std::string, std::string>* hints_ptr = nullptr);
+};
 
 commResult_t setupKernelConfig(
     const void* sendbuff,
@@ -17,6 +37,7 @@ commResult_t setupKernelConfig(
     KernelConfig& config,
     ctran::device_alltoallv_pipes::KernArgs& kernArgs,
     int64_t sendcountsMultiplier = 1,
-    int64_t recvcountsMultiplier = 1);
+    int64_t recvcountsMultiplier = 1,
+    const CollectiveConfig& collConfig = CollectiveConfig(0));
 
 } // namespace ctran::device_alltoallv_pipes

--- a/comms/ncclx/v2_27/src/collectives.cc
+++ b/comms/ncclx/v2_27/src/collectives.cc
@@ -435,7 +435,8 @@ ncclResult_t ncclx::deviceAllToAllv(
     ncclComm_t comm,
     cudaStream_t stream,
     int64_t sendcountsMultiplier,
-    int64_t recvcountsMultiplier) {
+    int64_t recvcountsMultiplier,
+    const std::unordered_map<std::string, std::string>& hints) {
   if (!ctranDeviceAllToAllvSupport(comm->ctranComm_.get())) {
     FB_ERRORRETURN(
         ncclInvalidUsage,
@@ -450,7 +451,8 @@ ncclResult_t ncclx::deviceAllToAllv(
       comm->ctranComm_.get(),
       stream,
       sendcountsMultiplier,
-      recvcountsMultiplier));
+      recvcountsMultiplier,
+      hints));
 }
 #else
 __attribute__((visibility("default")))
@@ -463,7 +465,8 @@ ncclResult_t ncclx::deviceAllToAllv(
     ncclComm_t /*comm*/,
     cudaStream_t /*stream*/,
     int64_t /*sendcountsMultiplier*/,
-    int64_t /*recvcountsMultiplier*/) {
+    int64_t /*recvcountsMultiplier*/,
+    const std::unordered_map<std::string, std::string>& /*hints*/) {
   return ncclInvalidUsage;
 }
 #endif // ENABLE_PIPES

--- a/comms/ncclx/v2_27/src/nccl.h.in
+++ b/comms/ncclx/v2_27/src/nccl.h.in
@@ -970,10 +970,12 @@ ncclResult_t alltoallvDynamicCombine( const void* sendbuff, const size_t* sendSp
     size_t maxSendcount, size_t maxRecvcount, const ncclx::Hints& hints, ncclDataType_t datatype,
     ncclComm_t comm, cudaStream_t stream);
 
+// Per-collective hint keys: numBlocks, numThreads, blockScheduling
 ncclResult_t deviceAllToAllv(const void* sendbuff, void* recvbuff,
     const int64_t* sendcounts_d, const int64_t* recvcounts_d,
     ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream,
-    int64_t sendcountsMultiplier = 1, int64_t recvcountsMultiplier = 1);
+    int64_t sendcountsMultiplier = 1, int64_t recvcountsMultiplier = 1,
+    const std::unordered_map<std::string, std::string>& hints = {});
 
 /*
  * Persistent All-Gather similar to ncclAllgather, the key difference is that

--- a/comms/ncclx/v2_28/src/collectives.cc
+++ b/comms/ncclx/v2_28/src/collectives.cc
@@ -487,7 +487,8 @@ ncclResult_t ncclx::deviceAllToAllv(
     ncclComm_t comm,
     cudaStream_t stream,
     int64_t sendcountsMultiplier,
-    int64_t recvcountsMultiplier) {
+    int64_t recvcountsMultiplier,
+    const std::unordered_map<std::string, std::string>& hints) {
   if (!ctranDeviceAllToAllvSupport(comm->ctranComm_.get())) {
     FB_ERRORRETURN(
         ncclInvalidUsage,
@@ -502,7 +503,8 @@ ncclResult_t ncclx::deviceAllToAllv(
       comm->ctranComm_.get(),
       stream,
       sendcountsMultiplier,
-      recvcountsMultiplier));
+      recvcountsMultiplier,
+      hints));
 }
 #else
 __attribute__((visibility("default")))
@@ -515,7 +517,8 @@ ncclResult_t ncclx::deviceAllToAllv(
     ncclComm_t /*comm*/,
     cudaStream_t /*stream*/,
     int64_t /*sendcountsMultiplier*/,
-    int64_t /*recvcountsMultiplier*/) {
+    int64_t /*recvcountsMultiplier*/,
+    const std::unordered_map<std::string, std::string>& /*hints*/) {
   return ncclInvalidUsage;
 }
 #endif // ENABLE_PIPES

--- a/comms/ncclx/v2_28/src/nccl.h.in
+++ b/comms/ncclx/v2_28/src/nccl.h.in
@@ -1066,10 +1066,12 @@ ncclResult_t alltoallvDynamicCombine( const void* sendbuff, const size_t* sendSp
     size_t maxSendcount, size_t maxRecvcount, const ncclx::Hints& hints, ncclDataType_t datatype,
     ncclComm_t comm, cudaStream_t stream);
 
+// Per-collective hint keys: numBlocks, numThreads, blockScheduling
 ncclResult_t deviceAllToAllv(const void* sendbuff, void* recvbuff,
     const int64_t* sendcounts_d, const int64_t* recvcounts_d,
     ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream,
-    int64_t sendcountsMultiplier = 1, int64_t recvcountsMultiplier = 1);
+    int64_t sendcountsMultiplier = 1, int64_t recvcountsMultiplier = 1,
+    const std::unordered_map<std::string, std::string>& hints = {});
 
 /*
  * Persistent All-Gather similar to ncclAllgather, the key difference is that

--- a/comms/ncclx/v2_29/src/collectives.cc
+++ b/comms/ncclx/v2_29/src/collectives.cc
@@ -491,7 +491,8 @@ ncclResult_t ncclx::deviceAllToAllv(
     ncclComm_t comm,
     cudaStream_t stream,
     int64_t sendcountsMultiplier,
-    int64_t recvcountsMultiplier) {
+    int64_t recvcountsMultiplier,
+    const std::unordered_map<std::string, std::string>& hints) {
   if (!ctranDeviceAllToAllvSupport(comm->ctranComm_.get())) {
     FB_ERRORRETURN(
         ncclInvalidUsage,
@@ -506,7 +507,8 @@ ncclResult_t ncclx::deviceAllToAllv(
       comm->ctranComm_.get(),
       stream,
       sendcountsMultiplier,
-      recvcountsMultiplier));
+      recvcountsMultiplier,
+      hints));
 }
 #else
 __attribute__((visibility("default")))
@@ -519,7 +521,8 @@ ncclResult_t ncclx::deviceAllToAllv(
     ncclComm_t /*comm*/,
     cudaStream_t /*stream*/,
     int64_t /*sendcountsMultiplier*/,
-    int64_t /*recvcountsMultiplier*/) {
+    int64_t /*recvcountsMultiplier*/,
+    const std::unordered_map<std::string, std::string>& /*hints*/) {
   return ncclInvalidUsage;
 }
 #endif // ENABLE_PIPES

--- a/comms/ncclx/v2_29/src/nccl.h.in
+++ b/comms/ncclx/v2_29/src/nccl.h.in
@@ -1220,10 +1220,12 @@ ncclResult_t alltoallvDynamicCombine( const void* sendbuff, const size_t* sendSp
  * the counts. This is useful when split sizes are computed on the GPU
  * and not known on the host beforehand.
  */
+// Per-collective hint keys: numBlocks, numThreads, blockScheduling
 ncclResult_t deviceAllToAllv(const void* sendbuff, void* recvbuff,
     const int64_t* sendcounts_d, const int64_t* recvcounts_d,
     ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream,
-    int64_t sendcountsMultiplier = 1, int64_t recvcountsMultiplier = 1);
+    int64_t sendcountsMultiplier = 1, int64_t recvcountsMultiplier = 1,
+    const std::unordered_map<std::string, std::string>& hints = {});
 
 /*
  * Persistent All-Gather similar to ncclAllgather, the key difference is that

--- a/comms/torchcomms/ncclx/NcclxApi.cpp
+++ b/comms/torchcomms/ncclx/NcclxApi.cpp
@@ -240,7 +240,8 @@ ncclResult_t DefaultNcclxApi::deviceAllToAllv(
     ncclComm_t comm,
     cudaStream_t stream,
     int64_t sendcountsMultiplier,
-    int64_t recvcountsMultiplier) {
+    int64_t recvcountsMultiplier,
+    const std::unordered_map<std::string, std::string>& hints) {
   std::lock_guard<std::mutex> lock(api_mutex_);
   return ncclx::deviceAllToAllv(
       sendbuff,
@@ -251,7 +252,8 @@ ncclResult_t DefaultNcclxApi::deviceAllToAllv(
       comm,
       stream,
       sendcountsMultiplier,
-      recvcountsMultiplier);
+      recvcountsMultiplier,
+      hints);
 }
 
 ncclResult_t DefaultNcclxApi::alltoallvDynamicDispatch(

--- a/comms/torchcomms/ncclx/NcclxApi.hpp
+++ b/comms/torchcomms/ncclx/NcclxApi.hpp
@@ -207,7 +207,8 @@ class NcclxApi {
       ncclComm_t comm,
       cudaStream_t stream,
       int64_t sendcountsMultiplier = 1,
-      int64_t recvcountsMultiplier = 1) {
+      int64_t recvcountsMultiplier = 1,
+      const std::unordered_map<std::string, std::string>& hints = {}) {
     return ncclInvalidUsage;
   }
 
@@ -534,7 +535,8 @@ class DefaultNcclxApi : public NcclxApi {
       ncclComm_t comm,
       cudaStream_t stream,
       int64_t sendcountsMultiplier = 1,
-      int64_t recvcountsMultiplier = 1) override;
+      int64_t recvcountsMultiplier = 1,
+      const std::unordered_map<std::string, std::string>& hints = {}) override;
 
   [[nodiscard]] ncclResult_t alltoallvDynamicDispatch(
       const void* sendbuff,

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -1507,7 +1507,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::device_alltoallv_single(
     const at::Tensor& input,
     const at::Tensor& output_split_sizes,
     const at::Tensor& input_split_sizes,
-    bool async_op) {
+    bool async_op,
+    const std::unordered_map<std::string, std::string>& hints) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output);
@@ -1562,7 +1563,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::device_alltoallv_single(
       nccl_comm_,
       stream,
       send_elements_per_slice,
-      recv_elements_per_slice);
+      recv_elements_per_slice,
+      hints);
 
   NCCLX_CHECK(nccl_api_, nccl_comm_, result, "NCCLX deviceAllToAllv failed");
 

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
@@ -185,7 +185,8 @@ class TorchCommNCCLX : public TorchCommBackend,
       const at::Tensor& input,
       const at::Tensor& output_split_sizes,
       const at::Tensor& input_split_sizes,
-      bool async_op);
+      bool async_op,
+      const std::unordered_map<std::string, std::string>& hints = {});
 
   c10::intrusive_ptr<TorchWork> alltoallv_dynamic_dispatch(
       const std::vector<at::Tensor>& output_tensor_list,


### PR DESCRIPTION
Summary:

Add per-collective config hints for the deviceAllToAllv kernel.

`CollectiveConfig` resolves all kernel tuning parameters in its constructor,
merging per-collective hints with CVAR defaults so that `setupKernelConfig`
reads final values directly with no fallback logic.

Resolution priority (highest wins):
  per-collective hint > CVAR > built-in default

Supported hint keys (passed as `std::unordered_map<string,string>`):
  - `numBlocks`: thread blocks (CVAR: NCCL_CTRAN_ALLTOALL_NUM_THREAD_BLOCKS, default: nLocalRanks*2)
  - `numThreads`: threads per block (CVAR: NCCL_CTRAN_ALLTOALL_THREAD_BLOCK_SIZE, default: 512)
  - `blockScheduling`: "1"=block, "0"=warp (CVAR: NCCL_CTRAN_ALLTOALL_BLOCK_SCHEDULING, default: false)

Block scheduling falls back to warp scheduling if numBlocks < 2*nLocalRanks.

Also:
  - Changed NCCL_CTRAN_ALLTOALL_THREAD_BLOCK_SIZE default from 256 to 512
  - Added NCCL_CTRAN_ALLTOALL_BLOCK_SCHEDULING cvar
  - Use CVARs directly instead of raw getenv calls

Reviewed By: snarayankh

Differential Revision: D97396334


