### PR TITLE
Fix DMABUF registration for user tensor sub-allocations (#1171)

### DIFF
--- a/comms/pipes/DocaHostUtils.h
+++ b/comms/pipes/DocaHostUtils.h
@@ -2,26 +2,95 @@
 
 #pragma once
 
+#include <cuda.h>
 #include <doca_gpunetio_host.h>
 #include <glog/logging.h>
 #include <unistd.h>
 #include <cstddef>
+#include <cstdint>
+#include <optional>
+
+#include "comms/pipes/CudaDriverLazy.h"
 
 namespace comms::pipes {
 
-// Wrapper around doca_gpu_dmabuf_fd that aligns size to host page size.
-// DMA-BUF exports require both address and size aligned to host page size
-// (64KB on aarch64/Grace). Returns the aligned size via output parameter
-// for use in subsequent operations (e.g., ibv_reg_dmabuf_mr).
-inline doca_error_t
-getDmaBufFdAligned(doca_gpu* gpu, void* ptr, size_t size, int* fd) {
-  static const size_t pageSize = sysconf(_SC_PAGESIZE);
-  const size_t alignedSize = ((size + pageSize - 1) / pageSize) * pageSize;
-  if (alignedSize != size) {
-    VLOG(1) << "getDmaBufFdAligned: aligning DMA-BUF size from " << size
-            << " to " << alignedSize << " bytes (page size " << pageSize << ")";
+// Result of page-aligning a CUDA allocation for DMA-BUF export.
+struct DmaBufAlignment {
+  void* alignedBase;
+  size_t alignedSize;
+  uint64_t dmabufOffset; // offset of the user pointer within the aligned range
+};
+
+// Compute page-aligned base address and size for DMA-BUF export.
+//
+// cuMemGetHandleForAddressRange (inside doca_gpu_dmabuf_fd) requires both
+// address and size aligned to the host page size. cudaMalloc may return
+// addresses not aligned to the 64KB Grace page size. This function takes
+// the allocation base/size from cuMemGetAddressRange and computes the
+// aligned range that covers the full allocation.
+//
+// @param allocBase  Allocation base from cuMemGetAddressRange
+// @param allocSize  Allocation size from cuMemGetAddressRange
+// @param ptr        User buffer pointer (within the allocation)
+// @param pageSize   Host page size (sysconf(_SC_PAGESIZE))
+inline DmaBufAlignment compute_dmabuf_alignment(
+    uintptr_t allocBase,
+    size_t allocSize,
+    void* ptr,
+    size_t pageSize) {
+  auto alignedBase = allocBase & ~(pageSize - 1);
+  size_t baseOffset = allocBase - alignedBase;
+  size_t alignedSize =
+      ((allocSize + baseOffset + pageSize - 1) / pageSize) * pageSize;
+  uint64_t dmabufOffset = reinterpret_cast<uintptr_t>(ptr) - alignedBase;
+  return {reinterpret_cast<void*>(alignedBase), alignedSize, dmabufOffset};
+}
+
+// Result of exporting a GPU buffer as DMA-BUF with page alignment.
+struct DmaBufExport {
+  int fd; // DMA-BUF file descriptor
+  DmaBufAlignment alignment; // alignment info for ibv_reg_dmabuf_mr
+};
+
+// Export a GPU buffer as DMA-BUF with proper page alignment.
+//
+// Handles the full flow for cudaMalloc buffers on Grace/aarch64:
+//   1. cuMemGetAddressRange → find CUDA allocation base
+//   2. compute_dmabuf_alignment → align base/size to host page size
+//   3. doca_gpu_dmabuf_fd → export as DMA-BUF
+//
+// Returns std::nullopt on failure (caller can fall back to ibv_reg_mr).
+// The returned DmaBufExport contains the fd and alignment info needed
+// for ibv_reg_dmabuf_mr (dmabufOffset as offset, ptr as iova).
+inline std::optional<DmaBufExport>
+export_gpu_dmabuf_aligned(doca_gpu* gpu, void* ptr, size_t size) {
+  CUdeviceptr allocBase = 0;
+  size_t allocSize = 0;
+  cuda_driver_lazy_init();
+  CUresult cuRes =
+      pfn_cuMemGetAddressRange(&allocBase, &allocSize, (CUdeviceptr)ptr);
+  if (cuRes != CUDA_SUCCESS || allocBase == 0) {
+    LOG(WARNING) << "export_gpu_dmabuf_aligned: cuMemGetAddressRange failed"
+                 << " err=" << cuRes << " ptr=" << ptr << " size=" << size;
+    return std::nullopt;
   }
-  return doca_gpu_dmabuf_fd(gpu, ptr, alignedSize, fd);
+
+  static const size_t pageSize = sysconf(_SC_PAGESIZE);
+  auto alignment =
+      compute_dmabuf_alignment(allocBase, allocSize, ptr, pageSize);
+
+  int fd = -1;
+  doca_error_t err = doca_gpu_dmabuf_fd(
+      gpu, alignment.alignedBase, alignment.alignedSize, &fd);
+  if (err != DOCA_SUCCESS || fd < 0) {
+    LOG(WARNING) << "export_gpu_dmabuf_aligned: doca_gpu_dmabuf_fd failed"
+                 << " err=" << err << " ptr=" << ptr
+                 << " alignedBase=" << alignment.alignedBase
+                 << " alignedSize=" << alignment.alignedSize;
+    return std::nullopt;
+  }
+
+  return DmaBufExport{fd, alignment};
 }
 
 } // namespace comms::pipes

--- a/comms/pipes/MultipeerIbgdaTransport.cc
+++ b/comms/pipes/MultipeerIbgdaTransport.cc
@@ -308,18 +308,18 @@ void MultipeerIbgdaTransport::registerMemory() {
   // ibv_reg_mr_iova2(pd, addr, length, iova=0, access) creates a zero-based
   // MR where IOVA range [0, length) maps to [addr, addr+length). This
   // matches GIN's gdakiRegMr() pattern (gin_host_gdaki.cc).
-  int sinkDmabufFd = -1;
-  doca_error_t err =
-      getDmaBufFdAligned(docaGpu_, sinkBuffer_, sinkBufferSize_, &sinkDmabufFd);
-  if (err == DOCA_SUCCESS && sinkDmabufFd >= 0) {
+  auto sinkDmabuf =
+      export_gpu_dmabuf_aligned(docaGpu_, sinkBuffer_, sinkBufferSize_);
+  if (sinkDmabuf) {
     // ibv_reg_dmabuf_mr: 4th param is iova — set to 0 for zero-based MR
     sinkMr_ = lazy_ibv_reg_dmabuf_mr(
         ibvPd_,
-        0,
+        sinkDmabuf->alignment.dmabufOffset,
         sinkBufferSize_,
         0, // iova=0: zero-based MR
-        sinkDmabufFd,
+        sinkDmabuf->fd,
         accessFlags);
+    close(sinkDmabuf->fd);
   }
   if (!sinkMr_) {
     // Fallback: use ibv_reg_mr_iova2 with iova=0 for zero-based MR
@@ -831,18 +831,20 @@ IbgdaLocalBuffer MultipeerIbgdaTransport::registerBuffer(
   int accessFlags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE |
       IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_ATOMIC;
 
-  // Try DMABUF registration first, fall back to regular reg_mr
+  // Try DMABUF registration first, fall back to regular reg_mr.
+  // export_gpu_dmabuf_aligned handles cuMemGetAddressRange + page alignment +
+  // doca_gpu_dmabuf_fd, returning nullopt on failure.
   ibv_mr* mr = nullptr;
-  int dmabufFd = -1;
-  doca_error_t err = getDmaBufFdAligned(docaGpu_, ptr, size, &dmabufFd);
-  if (err == DOCA_SUCCESS && dmabufFd >= 0) {
+  auto dmabuf = export_gpu_dmabuf_aligned(docaGpu_, ptr, size);
+  if (dmabuf) {
     mr = lazy_ibv_reg_dmabuf_mr(
         ibvPd_,
-        0,
+        dmabuf->alignment.dmabufOffset,
         size,
         reinterpret_cast<uint64_t>(ptr),
-        dmabufFd,
+        dmabuf->fd,
         accessFlags);
+    close(dmabuf->fd);
   }
   if (!mr) {
     doca_error_t regErr =

--- a/comms/pipes/tests/DocaHostUtilsTest.cc
+++ b/comms/pipes/tests/DocaHostUtilsTest.cc
@@ -1,0 +1,142 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+#include "comms/pipes/DocaHostUtils.h"
+
+namespace comms::pipes::tests {
+
+static const size_t kPageSize = sysconf(_SC_PAGESIZE);
+
+// Helper: round addr down to page boundary
+static uintptr_t pageFloor(uintptr_t addr) {
+  return addr & ~(kPageSize - 1);
+}
+
+// Helper: round size up to page boundary
+static size_t pageCeil(size_t size) {
+  return ((size + kPageSize - 1) / kPageSize) * kPageSize;
+}
+
+// Helper: verify the alignment invariants that every result must satisfy
+static void verifyInvariants(
+    const DmaBufAlignment& result,
+    uintptr_t allocBase,
+    size_t allocSize,
+    void* ptr) {
+  auto alignedBaseAddr = reinterpret_cast<uintptr_t>(result.alignedBase);
+  // Base must be page-aligned and <= allocBase
+  EXPECT_EQ(alignedBaseAddr % kPageSize, 0u);
+  EXPECT_LE(alignedBaseAddr, allocBase);
+  // Size must be page-aligned
+  EXPECT_EQ(result.alignedSize % kPageSize, 0u);
+  // Aligned range must cover the full allocation
+  EXPECT_GE(alignedBaseAddr + result.alignedSize, allocBase + allocSize);
+  // dmabufOffset must equal ptr - alignedBase
+  EXPECT_EQ(
+      result.dmabufOffset, reinterpret_cast<uintptr_t>(ptr) - alignedBaseAddr);
+}
+
+TEST(DmaBufAlignmentTest, AlreadyAligned) {
+  // Both base and size are already page-aligned
+  uintptr_t allocBase = kPageSize * 4;
+  size_t allocSize = kPageSize * 2;
+  void* ptr = reinterpret_cast<void*>(allocBase);
+
+  auto result = compute_dmabuf_alignment(allocBase, allocSize, ptr, kPageSize);
+
+  verifyInvariants(result, allocBase, allocSize, ptr);
+  EXPECT_EQ(result.alignedBase, reinterpret_cast<void*>(allocBase));
+  EXPECT_EQ(result.alignedSize, allocSize);
+  EXPECT_EQ(result.dmabufOffset, 0u);
+}
+
+TEST(DmaBufAlignmentTest, BaseNotAligned) {
+  // allocBase is mid-page (e.g., cudaMalloc sub-allocation)
+  uintptr_t allocBase = kPageSize * 4 + kPageSize / 2;
+  size_t allocSize = kPageSize / 4;
+  void* ptr = reinterpret_cast<void*>(allocBase);
+
+  auto result = compute_dmabuf_alignment(allocBase, allocSize, ptr, kPageSize);
+
+  verifyInvariants(result, allocBase, allocSize, ptr);
+  EXPECT_EQ(reinterpret_cast<uintptr_t>(result.alignedBase), kPageSize * 4);
+  EXPECT_EQ(result.dmabufOffset, kPageSize / 2);
+}
+
+TEST(DmaBufAlignmentTest, SizeNotAligned) {
+  // Base is aligned but size is tiny (e.g., 8-byte sink buffer)
+  uintptr_t allocBase = kPageSize * 4;
+  size_t allocSize = 8;
+  void* ptr = reinterpret_cast<void*>(allocBase);
+
+  auto result = compute_dmabuf_alignment(allocBase, allocSize, ptr, kPageSize);
+
+  verifyInvariants(result, allocBase, allocSize, ptr);
+  EXPECT_EQ(result.alignedSize, kPageSize);
+  EXPECT_EQ(result.dmabufOffset, 0u);
+}
+
+TEST(DmaBufAlignmentTest, BothUnaligned) {
+  // Neither base nor size is aligned
+  uintptr_t allocBase = kPageSize * 3 + 0x345;
+  size_t allocSize = 0x100;
+  void* ptr = reinterpret_cast<void*>(allocBase);
+
+  auto result = compute_dmabuf_alignment(allocBase, allocSize, ptr, kPageSize);
+
+  verifyInvariants(result, allocBase, allocSize, ptr);
+}
+
+TEST(DmaBufAlignmentTest, PtrWithinAllocation) {
+  // User pointer is offset within a large allocation
+  uintptr_t allocBase = kPageSize * 4;
+  size_t allocSize = kPageSize * 8;
+  void* ptr = reinterpret_cast<void*>(allocBase + kPageSize * 2);
+
+  auto result = compute_dmabuf_alignment(allocBase, allocSize, ptr, kPageSize);
+
+  verifyInvariants(result, allocBase, allocSize, ptr);
+  EXPECT_EQ(result.dmabufOffset, kPageSize * 2);
+}
+
+TEST(DmaBufAlignmentTest, ExactPageBoundary) {
+  // Allocation exactly fills one page
+  uintptr_t allocBase = kPageSize * 4;
+  size_t allocSize = kPageSize;
+  void* ptr = reinterpret_cast<void*>(allocBase);
+
+  auto result = compute_dmabuf_alignment(allocBase, allocSize, ptr, kPageSize);
+
+  verifyInvariants(result, allocBase, allocSize, ptr);
+  EXPECT_EQ(result.alignedSize, kPageSize);
+  EXPECT_EQ(result.dmabufOffset, 0u);
+}
+
+TEST(DmaBufAlignmentTest, AllocationSpansPageBoundary) {
+  // Allocation starts near end of one page and crosses into next
+  uintptr_t allocBase = kPageSize * 5 - kPageSize / 4;
+  size_t allocSize = kPageSize / 2; // crosses the boundary
+
+  void* ptr = reinterpret_cast<void*>(allocBase);
+
+  auto result = compute_dmabuf_alignment(allocBase, allocSize, ptr, kPageSize);
+
+  verifyInvariants(result, allocBase, allocSize, ptr);
+  // Must span at least 2 pages
+  EXPECT_EQ(result.alignedSize, 2 * kPageSize);
+}
+
+TEST(DmaBufAlignmentTest, LargeAllocationUnalignedBase) {
+  // Large allocation with unaligned base — realistic cudaMalloc scenario
+  uintptr_t allocBase = kPageSize * 100 + 0x200;
+  size_t allocSize = kPageSize * 16;
+  void* ptr = reinterpret_cast<void*>(allocBase + kPageSize);
+
+  auto result = compute_dmabuf_alignment(allocBase, allocSize, ptr, kPageSize);
+
+  verifyInvariants(result, allocBase, allocSize, ptr);
+}
+
+} // namespace comms::pipes::tests


### PR DESCRIPTION
Summary:

getDmaBufFdAligned only aligns the size to host page size and passes the
user pointer directly to doca_gpu_dmabuf_fd. This fails for user tensors
(e.g., PyTorch caching allocator sub-allocations) where ptr is not at the
start of the underlying cudaMalloc allocation.

Fix: replace getDmaBufFdAligned with export_gpu_dmabuf() which uses
cuMemGetAddressRange to find the CUDA allocation base (guaranteed
page-aligned by the driver), aligns size up to host page boundary, and
exports the DMA-BUF from that base. The returned dmabufOffset gives the
offset of ptr within the exported range for ibv_reg_dmabuf_mr. Also
closes the DMA-BUF fd after registration to avoid leaking file
descriptors.

Reviewed By: goelayu

Differential Revision: D96842834
