### PR TITLE
Remove XCCL custom range check, use TorchComm::validateRank

### DIFF
--- a/comms/torchcomms/xccl/TorchCommXCCL.cpp
+++ b/comms/torchcomms/xccl/TorchCommXCCL.cpp
@@ -707,7 +707,6 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::broadcast(
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
   checkAllTensorsOnXPUorCPU({tensor});
-  checkRankRange(root);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "broadcast", root, tensor, tensor);
@@ -856,7 +855,6 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::reduce(
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
   checkAllTensorsOnXPUorCPU({tensor});
-  checkRankRange(root);
 
   TracingGuard tracingGuard(name_, comm_size_, "reduce", root, tensor, tensor);
 
@@ -1909,7 +1907,6 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::scatter(
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output_tensor);
   checkAllTensorsOnXPUorCPU(input_tensor_list, {output_tensor});
-  checkRankRange(root);
 
   // Only the root rank needs valid tensors
   if (rank_ == root) {
@@ -2045,7 +2042,6 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::gather(
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(input_tensor);
   checkAllTensorsOnXPUorCPU({input_tensor}, output_tensor_list);
-  checkRankRange(root);
 
   // Only the root rank needs valid output tensors
   if (rank_ == root) {
@@ -2180,7 +2176,13 @@ std::shared_ptr<TorchCommBackend> TorchCommXCCL::split(
   checkAndAbortIfTimedOutOrError();
   std::unordered_set<int> rank_seen;
   for (int rank : ranks) {
-    checkRankRange(rank);
+    if (rank < 0 || rank >= comm_size_) {
+      throw std::runtime_error(
+          fmt::format(
+              "Invalid rank {} in ranks. Valid ranks are 0 to {}",
+              rank,
+              comm_size_ - 1));
+    }
     if (rank_seen.find(rank) != rank_seen.end()) [[unlikely]] {
       throw std::runtime_error(
           "Rank " + std::to_string(rank) + " appears multiple times in ranks");

--- a/comms/torchcomms/xccl/TorchCommXCCL.hpp
+++ b/comms/torchcomms/xccl/TorchCommXCCL.hpp
@@ -237,8 +237,6 @@ class TorchCommXCCL : public TorchCommBackend,
       std::chrono::milliseconds timeout,
       const at::Tensor& inputTensor);
 
-  void checkRankRange(int rank) const;
-
  private:
   // Helper that automatically cleans up premul sums.
   struct RedOpRAII {

--- a/comms/torchcomms/xccl/TorchCommXCCLUtils.cpp
+++ b/comms/torchcomms/xccl/TorchCommXCCLUtils.cpp
@@ -55,14 +55,6 @@ void createPreMulSum(
 
 } // namespace
 
-void TorchCommXCCL::checkRankRange(int rank) const {
-  if (rank < 0 || rank >= comm_size_) [[unlikely]] {
-    throw std::runtime_error(
-        "Rank " + std::to_string(rank) + " is out of valid range [0, " +
-        std::to_string(comm_size_ - 1) + "]");
-  }
-}
-
 TorchCommXCCL::RedOpRAII::RedOpRAII(onecclRedOp_t op)
     : xcclRedOp_(op), comm_(nullptr) {}
 


### PR DESCRIPTION
We remove `TorchCommXCCL::checkRankRange()` since this is redundant with the existing `TorchComm::validateRank` which validates the rank before the call to the underlying implementation.