### PR TITLE
Improve AllReduce timeout error reporting in ctran

### DIFF
--- a/comms/ctran/algos/AllReduce/AllReduceDirect.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceDirect.cc
@@ -52,12 +52,21 @@ static const auto myAlgo = NCCL_ALLREDUCE_ALGO::ctdirect;
  *         registers and reduces them into the receive buffer.
  */
 
-#define THROW_IF_ABORTED(code)                                        \
-  do {                                                                \
-    code;                                                             \
-    if (comm->testAbort()) {                                          \
-      throw ctran::utils::Exception("comm aborted", commRemoteError); \
-    }                                                                 \
+#define THROW_IF_ABORTED(code, ...)                                            \
+  do {                                                                         \
+    code;                                                                      \
+    if (comm->testAbort()) {                                                   \
+      auto _abort = comm->getAbort();                                          \
+      std::string _ctx =                                                       \
+          _abort->TimedOut() ? "comm aborted due to timeout" : "comm aborted"; \
+      std::string _desc{__VA_ARGS__};                                          \
+      throw ctran::utils::Exception(                                           \
+          _ctx,                                                                \
+          commRemoteError,                                                     \
+          comm->logMetaData_.rank,                                             \
+          comm->logMetaData_.commHash,                                         \
+          _desc.empty() ? std::nullopt : std::make_optional(_desc));           \
+    }                                                                          \
   } while (0)
 
 static commResult_t impl(
@@ -261,7 +270,9 @@ static commResult_t impl(
     }
 
     elem->post();
-    THROW_IF_ABORTED(elem->wait(comm->getAbort()));
+    THROW_IF_ABORTED(
+        elem->wait(comm->getAbort()),
+        "ctdirect step 1: intra-node reduce-scatter");
 
     /* Step 2: Inter-node Reduce-scatter */
     /* wait for inter-node data transfer to perform local reduction */
@@ -317,7 +328,9 @@ static commResult_t impl(
     elem->stridedReduce.stride = chunkCount;
     /* poke kernel to start the local reduction */
     elem->post();
-    THROW_IF_ABORTED(elem->wait(comm->getAbort()));
+    THROW_IF_ABORTED(
+        elem->wait(comm->getAbort()),
+        "ctdirect step 2: inter-node reduce-scatter");
 
     /* Step 3: Inter-node Allgather */
     /* wait for inter-node data transfer to perform local reduction */
@@ -358,7 +371,7 @@ static commResult_t impl(
         }
       }
     }
-    THROW_IF_ABORTED();
+    THROW_IF_ABORTED(, "ctdirect step 3: inter-node allgather");
 
     /* Step 4: Intra-node Allgather */
     elem = op->allreduce.kElemStepMap.at(
@@ -376,7 +389,8 @@ static commResult_t impl(
 
     /* poke kernel to start the allgather */
     elem->post();
-    THROW_IF_ABORTED(elem->wait(comm->getAbort()));
+    THROW_IF_ABORTED(
+        elem->wait(comm->getAbort()), "ctdirect step 4: intra-node allgather");
 
     op->allreduce.sendbuff =
         BUFOFFSET(op->allreduce.sendbuff, stepCount * typeSize);
@@ -420,7 +434,9 @@ static commResult_t impl(
       }
     }
     elem->post();
-    THROW_IF_ABORTED(elem->wait(comm->getAbort()));
+    THROW_IF_ABORTED(
+        elem->wait(comm->getAbort()),
+        "ctdirect step 5: remainder intra-node reduce");
 
     /* Step 6: Intra-node bcast */
     elem = op->allreduce.kElemStepMap.at(
@@ -434,7 +450,9 @@ static commResult_t impl(
       }
     }
     elem->post();
-    THROW_IF_ABORTED(elem->wait(comm->getAbort()));
+    THROW_IF_ABORTED(
+        elem->wait(comm->getAbort()),
+        "ctdirect step 6: remainder intra-node bcast");
 
     /* Step 7: Inter-node allreduce */
     /* wait for inter-node data transfer to perform local reduction */
@@ -485,7 +503,9 @@ static commResult_t impl(
     elem->stridedReduce.blockCount = remCount;
     elem->stridedReduce.stride = remCount;
     elem->post();
-    THROW_IF_ABORTED(elem->wait(comm->getAbort()));
+    THROW_IF_ABORTED(
+        elem->wait(comm->getAbort()),
+        "ctdirect step 7: remainder inter-node allreduce");
   }
 
   if (localRegSend == true) {

--- a/comms/ctran/algos/AllReduce/AllReduceRing.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceRing.cc
@@ -981,9 +981,17 @@ inline commResult_t completeHostResourceSetup(
 
 } // namespace
 
-#define HOST_ABORT()                                                \
-  if (comm->testAbort()) {                                          \
-    throw ctran::utils::Exception("comm aborted", commRemoteError); \
+#define HOST_ABORT(desc)                                                     \
+  if (comm->testAbort()) {                                                   \
+    auto _abort = comm->getAbort();                                          \
+    std::string _ctx =                                                       \
+        _abort->TimedOut() ? "comm aborted due to timeout" : "comm aborted"; \
+    throw ctran::utils::Exception(                                           \
+        _ctx,                                                                \
+        commRemoteError,                                                     \
+        comm->logMetaData_.rank,                                             \
+        comm->logMetaData_.commHash,                                         \
+        std::string(desc));                                                  \
   }
 
 static commResult_t impl(
@@ -1092,7 +1100,12 @@ static commResult_t impl(
       progressRecv(args, resource, algoCtx, bufSyncSResps, flushResps);
       progressRevSend(args, resource, algoCtx, revDataSResps, revBufSyncRResps);
       progressRevRecv(args, resource, algoCtx, revBufSyncSResps, revFlushResps);
-      HOST_ABORT();
+      HOST_ABORT(
+          fmt::format(
+              "ctring partition {}, rightPeer={}, leftPeer={}",
+              algoCtx.partition,
+              args.rightRank,
+              args.leftRank));
     }
 
     // Release any remaining resps before moving to next partition
@@ -1110,7 +1123,7 @@ static commResult_t impl(
     resource.revRecvCopySync->resetStatus();
 
     updatePartitionDone(algoCtx);
-    HOST_ABORT();
+    HOST_ABORT(fmt::format("ctring after partition {}", algoCtx.partition));
   } // end of partition loop
 
   // Reset flags for next allreduce to reuse. Only clear sync status (post/

--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -576,6 +576,20 @@ void CtranGpe::Impl::gpeThreadFn() {
         // if comm is aborted for any reason, we mark it as aborted to avoid
         // resetting the state.
         if (comm->testAbort()) {
+          auto abort = comm->getAbort();
+          if (abort->TimedOut()) {
+            CLOGF(
+                ERR,
+                "Communicator aborted due to timeout on rank {} commHash {:x}",
+                statex->rank(),
+                statex->commHash());
+          } else {
+            CLOGF(
+                ERR,
+                "Communicator aborted (explicit) on rank {} commHash {:x}",
+                statex->rank(),
+                statex->commHash());
+          }
           comm->setAbort();
         }
         comm->cancelTimeout();

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -1020,8 +1020,15 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     }
 
     if (comm->testAbort()) {
-      // TODO(T238821628): re-evaluate error code
-      throw ctran::utils::Exception("comm aborted", commRemoteError);
+      auto _abort = comm->getAbort();
+      std::string _ctx =
+          _abort->TimedOut() ? "comm aborted due to timeout" : "comm aborted";
+      throw ctran::utils::Exception(
+          _ctx,
+          commRemoteError,
+          comm->logMetaData_.rank,
+          comm->logMetaData_.commHash,
+          fmt::format("waitNotify for peer {}", notify->peer));
     }
 
     CLOGF_TRACE(
@@ -1062,8 +1069,15 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     }
 
     if (comm->testAbort()) {
-      // TODO(T238821628): re-evaluate error code
-      throw ctran::utils::Exception("comm aborted", commRemoteError);
+      auto _abort = comm->getAbort();
+      std::string _ctx =
+          _abort->TimedOut() ? "comm aborted due to timeout" : "comm aborted";
+      throw ctran::utils::Exception(
+          _ctx,
+          commRemoteError,
+          comm->logMetaData_.rank,
+          comm->logMetaData_.commHash,
+          fmt::format("waitRequest for peer {}", req->peer));
     }
 
     return commSuccess;

--- a/comms/ctran/utils/AsyncError.h
+++ b/comms/ctran/utils/AsyncError.h
@@ -36,15 +36,20 @@ namespace ctran::utils {
         asyncErr, ctran::utils::Exception(e.what(), commRemoteError)); \
   }
 
-#define CTRAN_ASYNC_ERR_HANDLE_IMPL_FAULT_TOLERANCE(comm, e) \
-  do {                                                       \
-    CTRAN_ASYNC_ERR_HANDLE_IMPL(comm->getAsyncError(), e);   \
-    if (comm->abortEnabled()) {                              \
-      XLOGF(ERR, "Fault tolerance enabled; aborting");       \
-      comm->setAbort();                                      \
-    } else {                                                 \
-      throw;                                                 \
-    }                                                        \
+#define CTRAN_ASYNC_ERR_HANDLE_IMPL_FAULT_TOLERANCE(comm, e)       \
+  do {                                                             \
+    CTRAN_ASYNC_ERR_HANDLE_IMPL(comm->getAsyncError(), e);         \
+    if (comm->abortEnabled()) {                                    \
+      XLOGF(                                                       \
+          ERR,                                                     \
+          "Fault tolerance enabled; marking communicator aborted " \
+          "(rank={}, commHash={:x})",                              \
+          comm->logMetaData_.rank,                                 \
+          comm->logMetaData_.commHash);                            \
+      comm->setAbort();                                            \
+    } else {                                                       \
+      throw;                                                       \
+    }                                                              \
   } while (0)
 
 #define CTRAN_ASYNC_ERR_GUARD_FAULT_TOLERANCE(comm, code)          \


### PR DESCRIPTION
Summary:
When an MCCL AllReduce times out, the error message was a generic
"Exception: comm aborted, , result: commRemoteError" with no indication
of why (timeout vs explicit abort), which rank detected the failure,
or what operation phase was running.

This diff enriches all abort/timeout throw sites with contextual
information:

1. **Exception throw sites** (AllReduceDirect, AllReduceRing, Mapper):
   - Distinguish "comm aborted due to timeout" vs "comm aborted"
     using `Abort::TimedOut()`
   - Include rank and commHash in the Exception
   - Include desc with step/phase context (e.g., "ctdirect step 1:
     intra-node reduce-scatter") or peer info (e.g., "waitRequest
     for peer 3")

2. **Abort-setting sites** (GPE SCOPE_EXIT, AsyncError FT guard):
   - GPE SCOPE_EXIT now logs when converting timeout to permanent
     abort, with rank/commHash and timeout vs explicit distinction
   - FT guard log now includes rank/commHash

Before:
```
Exception: comm aborted, , result: commRemoteError (commRemoteError)
```

After:
```
Encountered exception: Exception: comm aborted due to timeout,
  rank: 0, commHash: 402823d129824690, desc: waitRequest for peer 3,
  result: commRemoteError (commRemoteError); setting async error flag
Fault tolerance enabled; marking communicator aborted
  (rank=0, commHash=402823d129824690)
Communicator aborted due to timeout on rank 0
  commHash 402823d129824690
```

Reviewed By: dboyda

Differential Revision: D97433370


