### PR TITLE
Add local buffer registration support for Pipes backend

### DIFF
--- a/comms/ncclx/v2_27/meta/rma/window.cc
+++ b/comms/ncclx/v2_27/meta/rma/window.cc
@@ -210,6 +210,7 @@ ncclWinGetAttributes(int rank, ncclWindow_t win, ncclWinAttr_t* attr) {
 #if defined(ENABLE_PIPES)
 #include <cuda_runtime_api.h>
 
+#include "comms/pipes/MultiPeerTransport.h"
 #include "comms/pipes/window/DeviceWindow.cuh"
 #include "comms/pipes/window/HostWindow.h"
 
@@ -302,5 +303,75 @@ ncclResult_t ncclWinDestroyDeviceWin(void* devicePtr) {
   }
   cudaError_t err = cudaFree(devicePtr);
   return (err == cudaSuccess) ? ncclSuccess : ncclInternalError;
+}
+NCCL_API(
+    ncclResult_t,
+    ncclWinLocalRegisterBuffer,
+    ncclComm_t comm,
+    void* ptr,
+    size_t size,
+    uint32_t* outLkey);
+ncclResult_t ncclWinLocalRegisterBuffer(
+    ncclComm_t comm,
+    void* ptr,
+    size_t size,
+    uint32_t* outLkey) {
+  if (comm == nullptr || ptr == nullptr || outLkey == nullptr) {
+    return ncclInvalidArgument;
+  }
+
+  if (!ctranInitialized(comm->ctranComm_.get())) {
+    WARN("ncclWinLocalRegisterBuffer: ctran not initialized");
+    return ncclInternalError;
+  }
+
+  auto* mpt = comm->ctranComm_->multiPeerTransport_.get();
+  if (mpt == nullptr) {
+    WARN(
+        "ncclWinLocalRegisterBuffer: MultiPeerTransport not initialized. "
+        "Set NCCL_CTRAN_USE_PIPES=1");
+    return ncclInternalError;
+  }
+
+  try {
+    auto ibgdaBuf = mpt->localRegisterIbgdaBuffer(ptr, size);
+    *outLkey = ibgdaBuf.lkey.value;
+    return ncclSuccess;
+  } catch (const std::exception& e) {
+    WARN("ncclWinLocalRegisterBuffer: %s", e.what());
+    return ncclInternalError;
+  }
+}
+
+NCCL_API(
+    ncclResult_t,
+    ncclWinLocalDeregisterBuffer,
+    ncclComm_t comm,
+    void* ptr);
+ncclResult_t ncclWinLocalDeregisterBuffer(ncclComm_t comm, void* ptr) {
+  if (comm == nullptr || ptr == nullptr) {
+    return ncclInvalidArgument;
+  }
+
+  if (!ctranInitialized(comm->ctranComm_.get())) {
+    WARN("ncclWinLocalDeregisterBuffer: ctran not initialized");
+    return ncclInternalError;
+  }
+
+  auto* mpt = comm->ctranComm_->multiPeerTransport_.get();
+  if (mpt == nullptr) {
+    WARN(
+        "ncclWinLocalDeregisterBuffer: MultiPeerTransport not initialized. "
+        "Set NCCL_CTRAN_USE_PIPES=1");
+    return ncclInternalError;
+  }
+
+  try {
+    mpt->localDeregisterIbgdaBuffer(ptr);
+    return ncclSuccess;
+  } catch (const std::exception& e) {
+    WARN("ncclWinLocalDeregisterBuffer: %s", e.what());
+    return ncclInternalError;
+  }
 }
 #endif // ENABLE_PIPES

--- a/comms/ncclx/v2_27/src/nccl.h.in
+++ b/comms/ncclx/v2_27/src/nccl.h.in
@@ -780,6 +780,30 @@ ncclResult_t ncclGetMultiPeerDeviceHandle(
     int* outNRanks,
     int* outNumNvlPeers,
     int* outNumIbPeers);
+
+/*
+ * Register a local buffer for use as source in device-side RDMA put operations.
+ * NON-COLLECTIVE — purely local memory registration (lkey only, no rkey exchange).
+ *
+ * The returned lkey is in network byte order, suitable for IBGDA WQE construction.
+ * Deregister with ncclWinLocalDeregisterBuffer() when no longer needed.
+ *
+ * Requires NCCL_CTRAN_USE_PIPES=1 during communicator init.
+ * Returns ncclInternalError if pipes transport is not initialized.
+ */
+ncclResult_t ncclWinLocalRegisterBuffer(
+    ncclComm_t comm,
+    void* ptr,
+    size_t size,
+    uint32_t* outLkey);
+
+/*
+ * Deregister a buffer previously registered with ncclWinLocalRegisterBuffer().
+ * NON-COLLECTIVE.
+ */
+ncclResult_t ncclWinLocalDeregisterBuffer(
+    ncclComm_t comm,
+    void* ptr);
 #endif // ENABLE_PIPES
 
 /*

--- a/comms/ncclx/v2_28/meta/rma/window.cc
+++ b/comms/ncclx/v2_28/meta/rma/window.cc
@@ -208,6 +208,7 @@ ncclWinGetAttributes(int rank, ncclWindow_t win, ncclWinAttr_t* attr) {
 #if defined(ENABLE_PIPES)
 #include <cuda_runtime_api.h>
 
+#include "comms/pipes/MultiPeerTransport.h"
 #include "comms/pipes/window/DeviceWindow.cuh"
 #include "comms/pipes/window/HostWindow.h"
 
@@ -300,5 +301,75 @@ ncclResult_t ncclWinDestroyDeviceWin(void* devicePtr) {
   }
   cudaError_t err = cudaFree(devicePtr);
   return (err == cudaSuccess) ? ncclSuccess : ncclInternalError;
+}
+NCCL_API(
+    ncclResult_t,
+    ncclWinLocalRegisterBuffer,
+    ncclComm_t comm,
+    void* ptr,
+    size_t size,
+    uint32_t* outLkey);
+ncclResult_t ncclWinLocalRegisterBuffer(
+    ncclComm_t comm,
+    void* ptr,
+    size_t size,
+    uint32_t* outLkey) {
+  if (comm == nullptr || ptr == nullptr || outLkey == nullptr) {
+    return ncclInvalidArgument;
+  }
+
+  if (!ctranInitialized(comm->ctranComm_.get())) {
+    WARN("ncclWinLocalRegisterBuffer: ctran not initialized");
+    return ncclInternalError;
+  }
+
+  auto* mpt = comm->ctranComm_->multiPeerTransport_.get();
+  if (mpt == nullptr) {
+    WARN(
+        "ncclWinLocalRegisterBuffer: MultiPeerTransport not initialized. "
+        "Set NCCL_CTRAN_USE_PIPES=1");
+    return ncclInternalError;
+  }
+
+  try {
+    auto ibgdaBuf = mpt->localRegisterIbgdaBuffer(ptr, size);
+    *outLkey = ibgdaBuf.lkey.value;
+    return ncclSuccess;
+  } catch (const std::exception& e) {
+    WARN("ncclWinLocalRegisterBuffer: %s", e.what());
+    return ncclInternalError;
+  }
+}
+
+NCCL_API(
+    ncclResult_t,
+    ncclWinLocalDeregisterBuffer,
+    ncclComm_t comm,
+    void* ptr);
+ncclResult_t ncclWinLocalDeregisterBuffer(ncclComm_t comm, void* ptr) {
+  if (comm == nullptr || ptr == nullptr) {
+    return ncclInvalidArgument;
+  }
+
+  if (!ctranInitialized(comm->ctranComm_.get())) {
+    WARN("ncclWinLocalDeregisterBuffer: ctran not initialized");
+    return ncclInternalError;
+  }
+
+  auto* mpt = comm->ctranComm_->multiPeerTransport_.get();
+  if (mpt == nullptr) {
+    WARN(
+        "ncclWinLocalDeregisterBuffer: MultiPeerTransport not initialized. "
+        "Set NCCL_CTRAN_USE_PIPES=1");
+    return ncclInternalError;
+  }
+
+  try {
+    mpt->localDeregisterIbgdaBuffer(ptr);
+    return ncclSuccess;
+  } catch (const std::exception& e) {
+    WARN("ncclWinLocalDeregisterBuffer: %s", e.what());
+    return ncclInternalError;
+  }
 }
 #endif // ENABLE_PIPES

--- a/comms/ncclx/v2_28/src/nccl.h.in
+++ b/comms/ncclx/v2_28/src/nccl.h.in
@@ -857,6 +857,30 @@ ncclResult_t ncclGetMultiPeerDeviceHandle(
     int* outNRanks,
     int* outNumNvlPeers,
     int* outNumIbPeers);
+
+/*
+ * Register a local buffer for use as source in device-side RDMA put operations.
+ * NON-COLLECTIVE — purely local memory registration (lkey only, no rkey exchange).
+ *
+ * The returned lkey is in network byte order, suitable for IBGDA WQE construction.
+ * Deregister with ncclWinLocalDeregisterBuffer() when no longer needed.
+ *
+ * Requires NCCL_CTRAN_USE_PIPES=1 during communicator init.
+ * Returns ncclInternalError if pipes transport is not initialized.
+ */
+ncclResult_t ncclWinLocalRegisterBuffer(
+    ncclComm_t comm,
+    void* ptr,
+    size_t size,
+    uint32_t* outLkey);
+
+/*
+ * Deregister a buffer previously registered with ncclWinLocalRegisterBuffer().
+ * NON-COLLECTIVE.
+ */
+ncclResult_t ncclWinLocalDeregisterBuffer(
+    ncclComm_t comm,
+    void* ptr);
 #endif // ENABLE_PIPES
 
 /*

--- a/comms/ncclx/v2_29/meta/rma/window.cc
+++ b/comms/ncclx/v2_29/meta/rma/window.cc
@@ -208,6 +208,7 @@ ncclWinGetAttributes(int rank, ncclWindow_t win, ncclWinAttr_t* attr) {
 #if defined(ENABLE_PIPES)
 #include <cuda_runtime_api.h>
 
+#include "comms/pipes/MultiPeerTransport.h"
 #include "comms/pipes/window/DeviceWindow.cuh"
 #include "comms/pipes/window/HostWindow.h"
 
@@ -300,5 +301,76 @@ ncclResult_t ncclWinDestroyDeviceWin(void* devicePtr) {
   }
   cudaError_t err = cudaFree(devicePtr);
   return (err == cudaSuccess) ? ncclSuccess : ncclInternalError;
+}
+
+NCCL_API(
+    ncclResult_t,
+    ncclWinLocalRegisterBuffer,
+    ncclComm_t comm,
+    void* ptr,
+    size_t size,
+    uint32_t* outLkey);
+ncclResult_t ncclWinLocalRegisterBuffer(
+    ncclComm_t comm,
+    void* ptr,
+    size_t size,
+    uint32_t* outLkey) {
+  if (comm == nullptr || ptr == nullptr || outLkey == nullptr) {
+    return ncclInvalidArgument;
+  }
+
+  if (!ctranInitialized(comm->ctranComm_.get())) {
+    WARN("ncclWinLocalRegisterBuffer: ctran not initialized");
+    return ncclInternalError;
+  }
+
+  auto* mpt = comm->ctranComm_->multiPeerTransport_.get();
+  if (mpt == nullptr) {
+    WARN(
+        "ncclWinLocalRegisterBuffer: MultiPeerTransport not initialized. "
+        "Set NCCL_CTRAN_USE_PIPES=1");
+    return ncclInternalError;
+  }
+
+  try {
+    auto ibgdaBuf = mpt->localRegisterIbgdaBuffer(ptr, size);
+    *outLkey = ibgdaBuf.lkey.value;
+    return ncclSuccess;
+  } catch (const std::exception& e) {
+    WARN("ncclWinLocalRegisterBuffer: %s", e.what());
+    return ncclInternalError;
+  }
+}
+
+NCCL_API(
+    ncclResult_t,
+    ncclWinLocalDeregisterBuffer,
+    ncclComm_t comm,
+    void* ptr);
+ncclResult_t ncclWinLocalDeregisterBuffer(ncclComm_t comm, void* ptr) {
+  if (comm == nullptr || ptr == nullptr) {
+    return ncclInvalidArgument;
+  }
+
+  if (!ctranInitialized(comm->ctranComm_.get())) {
+    WARN("ncclWinLocalDeregisterBuffer: ctran not initialized");
+    return ncclInternalError;
+  }
+
+  auto* mpt = comm->ctranComm_->multiPeerTransport_.get();
+  if (mpt == nullptr) {
+    WARN(
+        "ncclWinLocalDeregisterBuffer: MultiPeerTransport not initialized. "
+        "Set NCCL_CTRAN_USE_PIPES=1");
+    return ncclInternalError;
+  }
+
+  try {
+    mpt->localDeregisterIbgdaBuffer(ptr);
+    return ncclSuccess;
+  } catch (const std::exception& e) {
+    WARN("ncclWinLocalDeregisterBuffer: %s", e.what());
+    return ncclInternalError;
+  }
 }
 #endif // ENABLE_PIPES

--- a/comms/ncclx/v2_29/src/nccl.h.in
+++ b/comms/ncclx/v2_29/src/nccl.h.in
@@ -1011,6 +1011,30 @@ ncclResult_t ncclGetMultiPeerDeviceHandle(
     int* outNRanks,
     int* outNumNvlPeers,
     int* outNumIbPeers);
+
+/*
+ * Register a local buffer for use as source in device-side RDMA put operations.
+ * NON-COLLECTIVE — purely local memory registration (lkey only, no rkey exchange).
+ *
+ * The returned lkey is in network byte order, suitable for IBGDA WQE construction.
+ * Deregister with ncclWinLocalDeregisterBuffer() when no longer needed.
+ *
+ * Requires NCCL_CTRAN_USE_PIPES=1 during communicator init.
+ * Returns ncclInternalError if pipes transport is not initialized.
+ */
+ncclResult_t ncclWinLocalRegisterBuffer(
+    ncclComm_t comm,
+    void* ptr,
+    size_t size,
+    uint32_t* outLkey);
+
+/*
+ * Deregister a buffer previously registered with ncclWinLocalRegisterBuffer().
+ * NON-COLLECTIVE.
+ */
+ncclResult_t ncclWinLocalDeregisterBuffer(
+    ncclComm_t comm,
+    void* ptr);
 #endif // ENABLE_PIPES
 
 /*

--- a/comms/torchcomms/device/DeviceBackendTraits.hpp
+++ b/comms/torchcomms/device/DeviceBackendTraits.hpp
@@ -29,6 +29,7 @@ namespace torchcomms::device {
 
 // Forward declarations
 struct DeviceBackendConfig;
+struct RegisteredBuffer;
 template <typename Backend>
 class TorchCommDeviceWindow;
 
@@ -151,10 +152,20 @@ struct NCCLDeviceBackend {
     return nccl_orig_win;
   }
 
-  // Validate that register_local_buffer is supported. Throws if not.
-  static void validate_local_buffer_support() {
-    // Supported for GIN backend — no-op.
-  }
+  // Register a local buffer for device-side put operations (GIN path).
+  // Uses NCCL_WIN_DEVICE_API | NCCL_WIN_LOCAL_ONLY for non-collective
+  // registration with local lkey only (no rkey allGather).
+  static RegisteredBuffer register_local_buffer(
+      torch::comms::NcclxApi* nccl_api,
+      ncclComm_t nccl_comm,
+      void* ptr,
+      size_t size);
+
+  // Deregister a previously registered local buffer (GIN path).
+  static void deregister_local_buffer(
+      torch::comms::NcclxApi* nccl_api,
+      ncclComm_t nccl_comm,
+      RegisteredBuffer& buf);
 };
 
 // Type alias for backward compatibility

--- a/comms/torchcomms/device/ncclx/NCCLDeviceBackend.cpp
+++ b/comms/torchcomms/device/ncclx/NCCLDeviceBackend.cpp
@@ -190,6 +190,55 @@ void NCCLDeviceBackend::deregister_extra_window(
   }
 }
 
+RegisteredBuffer NCCLDeviceBackend::register_local_buffer(
+    torch::comms::NcclxApi* nccl_api,
+    ncclComm_t nccl_comm,
+    void* ptr,
+    size_t size) {
+  ncclWindow_t local_win = nullptr;
+  CHECK_EQ(
+      nccl_api->commWindowRegister(
+          ptr,
+          size,
+          nccl_comm,
+          &local_win,
+          NCCL_WIN_DEVICE_API | NCCL_WIN_LOCAL_ONLY),
+      ncclSuccess)
+      << "[NCCLDeviceBackend]: Local buffer registration failed";
+
+  // GIN put uses backend_window (ncclWindow_t) for RDMA/NVLink transfers.
+  // lkey is unused by GIN — only the Pipes (IBGDA) backend needs it.
+  RegisteredBuffer buf;
+  buf.base_ptr = ptr;
+  buf.size = size;
+  buf.backend_window = static_cast<void*>(local_win);
+  buf.lkey = 0;
+  return buf;
+}
+
+void NCCLDeviceBackend::deregister_local_buffer(
+    torch::comms::NcclxApi* nccl_api,
+    ncclComm_t nccl_comm,
+    RegisteredBuffer& buf) {
+  if (buf.backend_window == nullptr) {
+    return;
+  }
+  auto result = nccl_api->commWindowDeregister(
+      nccl_comm, static_cast<ncclWindow_t>(buf.backend_window));
+  if (result != ncclSuccess) {
+    TC_LOG(ERROR) << "[NCCLDeviceBackend]: Failed to deregister local buffer";
+  }
+
+  // ncclCommWindowDeregister may leave a sticky CUDA error in the runtime
+  // error queue. Consume it to prevent the next CUDA API call from failing.
+  cudaDeviceSynchronize();
+  cudaGetLastError();
+
+  buf.backend_window = nullptr;
+  buf.base_ptr = nullptr;
+  buf.size = 0;
+}
+
 void NCCLDeviceBackend::destroy_device_comm(Ptr& device_window) {
   if (!device_window) {
     return;

--- a/comms/torchcomms/device/pipes/PipesDeviceBackend.cpp
+++ b/comms/torchcomms/device/pipes/PipesDeviceBackend.cpp
@@ -142,6 +142,50 @@ PipesDeviceBackend::Ptr PipesDeviceBackend::create_device_window(
 }
 
 // =============================================================================
+// register_local_buffer / deregister_local_buffer Implementation
+// =============================================================================
+
+RegisteredBuffer PipesDeviceBackend::register_local_buffer(
+    torch::comms::NcclxApi* nccl_api,
+    ncclComm_t nccl_comm,
+    void* ptr,
+    size_t size) {
+  uint32_t lkey = 0;
+  auto result = nccl_api->winLocalRegisterBuffer(nccl_comm, ptr, size, &lkey);
+  if (result != ncclSuccess) {
+    throw std::runtime_error(
+        "[PipesDeviceBackend::register_local_buffer]: "
+        "winLocalRegisterBuffer failed");
+  }
+
+  // Pipes (IBGDA) put uses lkey for WQE construction during RDMA writes.
+  // backend_window is unused by Pipes — only the GIN backend needs it.
+  RegisteredBuffer buf;
+  buf.base_ptr = ptr;
+  buf.size = size;
+  buf.backend_window = nullptr;
+  buf.lkey = lkey;
+  return buf;
+}
+
+void PipesDeviceBackend::deregister_local_buffer(
+    torch::comms::NcclxApi* nccl_api,
+    ncclComm_t nccl_comm,
+    RegisteredBuffer& buf) {
+  if (buf.base_ptr == nullptr) {
+    return;
+  }
+  auto result = nccl_api->winLocalDeregisterBuffer(nccl_comm, buf.base_ptr);
+  if (result != ncclSuccess) {
+    TC_LOG(ERROR) << "[PipesDeviceBackend]: Failed to deregister local buffer";
+  }
+  buf.backend_window = nullptr;
+  buf.base_ptr = nullptr;
+  buf.size = 0;
+  buf.lkey = 0;
+}
+
+// =============================================================================
 // fetch_transport_handle Implementation
 // =============================================================================
 

--- a/comms/torchcomms/device/pipes/PipesDeviceBackend.hpp
+++ b/comms/torchcomms/device/pipes/PipesDeviceBackend.hpp
@@ -35,6 +35,7 @@ class TorchCommNCCLX;
 namespace torchcomms::device {
 
 struct DeviceBackendConfig;
+struct RegisteredBuffer;
 
 template <typename Backend>
 class TorchCommDeviceWindow;
@@ -144,12 +145,20 @@ struct PipesDeviceBackend {
     return win;
   }
 
-  // register_local_buffer not yet supported for Pipes.
-  [[noreturn]] static void validate_local_buffer_support() {
-    throw std::runtime_error(
-        "[TorchCommWindowNCCLX][Pipes]: register_local_buffer is not yet "
-        "supported for PipesDeviceBackend.");
-  }
+  // Register a local buffer for device-side put operations (Pipes/IBGDA path).
+  // Uses MultiPeerTransport::localRegisterIbgdaBuffer for non-collective
+  // local memory registration. Returns RegisteredBuffer with lkey.
+  static torchcomms::device::RegisteredBuffer register_local_buffer(
+      torch::comms::NcclxApi* nccl_api,
+      ncclComm_t nccl_comm,
+      void* ptr,
+      size_t size);
+
+  // Deregister a previously registered local buffer (Pipes/IBGDA path).
+  static void deregister_local_buffer(
+      torch::comms::NcclxApi* nccl_api,
+      ncclComm_t nccl_comm,
+      torchcomms::device::RegisteredBuffer& buf);
 
   // =========================================================================
   // Transport device handle (device-allocated MultiPeerDeviceHandle)

--- a/comms/torchcomms/ncclx/NcclxApi.cpp
+++ b/comms/torchcomms/ncclx/NcclxApi.cpp
@@ -555,6 +555,20 @@ ncclResult_t DefaultNcclxApi::getMultiPeerDeviceHandle(
       outNumNvlPeers,
       outNumIbPeers);
 }
+
+ncclResult_t DefaultNcclxApi::winLocalRegisterBuffer(
+    ncclComm_t comm,
+    void* ptr,
+    size_t size,
+    uint32_t* outLkey) {
+  return ncclWinLocalRegisterBuffer(comm, ptr, size, outLkey);
+}
+
+ncclResult_t DefaultNcclxApi::winLocalDeregisterBuffer(
+    ncclComm_t comm,
+    void* ptr) {
+  return ncclWinLocalDeregisterBuffer(comm, ptr);
+}
 #endif // ENABLE_PIPES
 
 #ifdef TORCHCOMMS_HAS_NCCL_DEVICE_API

--- a/comms/torchcomms/ncclx/NcclxApi.hpp
+++ b/comms/torchcomms/ncclx/NcclxApi.hpp
@@ -346,6 +346,21 @@ class NcclxApi {
       int* outNRanks,
       int* outNumNvlPeers,
       int* outNumIbPeers) = 0;
+
+  // Register a local buffer for device-side RDMA put operations.
+  // NON-COLLECTIVE — purely local memory registration (lkey only).
+  // Returns lkey in network byte order via outLkey.
+  [[nodiscard]] virtual ncclResult_t winLocalRegisterBuffer(
+      ncclComm_t comm,
+      void* ptr,
+      size_t size,
+      uint32_t* outLkey) = 0;
+
+  // Deregister a buffer previously registered with winLocalRegisterBuffer.
+  // NON-COLLECTIVE.
+  [[nodiscard]] virtual ncclResult_t winLocalDeregisterBuffer(
+      ncclComm_t comm,
+      void* ptr) = 0;
 #endif
 
   // Group operations
@@ -646,6 +661,14 @@ class DefaultNcclxApi : public NcclxApi {
       int* outNRanks,
       int* outNumNvlPeers,
       int* outNumIbPeers) override;
+  [[nodiscard]] ncclResult_t winLocalRegisterBuffer(
+      ncclComm_t comm,
+      void* ptr,
+      size_t size,
+      uint32_t* outLkey) override;
+  [[nodiscard]] ncclResult_t winLocalDeregisterBuffer(
+      ncclComm_t comm,
+      void* ptr) override;
 #endif
 
   // Group operations

--- a/comms/torchcomms/ncclx/TorchCommWindowNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommWindowNCCLX.cpp
@@ -34,15 +34,10 @@ TorchCommWindowNCCLX<Backend>::TorchCommWindowNCCLX(
 template <typename Backend>
 TorchCommWindowNCCLX<Backend>::~TorchCommWindowNCCLX() noexcept {
 #ifdef TORCHCOMMS_HAS_NCCL_DEVICE_API
-  // Cleanup registered local buffers (registered with parent comm using
-  // NCCL_WIN_LOCAL_ONLY)
+  // Cleanup registered local buffers via backend-specific deregistration
   for (auto& buf : registered_local_buffers_) {
-    if (buf.backend_window != nullptr && nccl_comm_ != nullptr) {
-      NCCLX_CHECK_IGNORE(
-          nccl_api_,
-          nccl_api_->commWindowDeregister(
-              nccl_comm_, static_cast<NcclxWindow>(buf.backend_window)),
-          "NCCLX local buffer deregister failed in destructor");
+    if (nccl_comm_ != nullptr) {
+      Backend::deregister_local_buffer(nccl_api_, nccl_comm_, buf);
     }
   }
   registered_local_buffers_.clear();
@@ -301,21 +296,10 @@ typename TorchCommWindowNCCLX<Backend>::DeviceRegisteredBuffer
 TorchCommWindowNCCLX<Backend>::register_local_buffer(const at::Tensor& tensor) {
   checkCommAndThrow();
 
-  // Throws for backends that don't support local buffer registration (Pipes).
-  Backend::validate_local_buffer_support();
-
-  // GIN must be enabled via prior get_device_window() call.
-  // tensor_register creates nccl_orig_win_ but doesn't enable GIN.
-  // get_device_window() calls ncclDevCommCreate which enables GIN.
-  if (nccl_orig_win_ == nullptr) {
-    throw std::runtime_error(
-        "[TorchCommWindowNCCLX]: Device API not initialized. "
-        "Call tensor_register first.");
-  }
   if (device_window_ == nullptr) {
     throw std::runtime_error(
-        "[TorchCommWindowNCCLX]: GIN not enabled. "
-        "Call get_device_window() first to enable GIN before registering local buffers.");
+        "[TorchCommWindowNCCLX]: Device window not initialized. "
+        "Call get_device_window() first before registering local buffers.");
   }
 
   if (!tensor.defined() || !tensor.is_contiguous()) {
@@ -325,70 +309,35 @@ TorchCommWindowNCCLX<Backend>::register_local_buffer(const at::Tensor& tensor) {
 
   checkDeviceAndThrow(tensor);
 
-  DeviceRegisteredBuffer buf;
-  buf.base_ptr = tensor.data_ptr();
-  buf.size = tensor.numel() * tensor.element_size();
+  auto buf = Backend::register_local_buffer(
+      nccl_api_,
+      nccl_comm_,
+      tensor.data_ptr(),
+      tensor.numel() * tensor.element_size());
 
-  // Use NCCL_WIN_LOCAL_ONLY flag with parent comm for non-collective
-  // registration. This uses the parent's PD but skips the rkey allGather,
-  // making it truly local. The resulting window can only be used as a source
-  // buffer for put operations (lkey only, no rkeys).
-  NcclxWindow local_win = nullptr;
-  CHECK_EQ(
-      nccl_api_->commWindowRegister(
-          buf.base_ptr,
-          buf.size,
-          nccl_comm_,
-          &local_win,
-          NCCL_WIN_DEVICE_API | NCCL_WIN_LOCAL_ONLY),
-      ncclSuccess)
-      << "[TorchCommWindowNCCLX]: Local buffer registration failed";
-
-  buf.backend_window = static_cast<void*>(local_win);
   registered_local_buffers_.push_back(buf);
-
   return buf;
 }
 
 template <typename Backend>
 void TorchCommWindowNCCLX<Backend>::deregister_local_buffer(
     DeviceRegisteredBuffer& buf) {
-  if (buf.backend_window == nullptr) {
+  if (buf.base_ptr == nullptr && buf.backend_window == nullptr) {
     return;
   }
 
-  // Use parent comm for deregistration (matches register_local_buffer)
-  auto result = nccl_api_->commWindowDeregister(
-      nccl_comm_, static_cast<NcclxWindow>(buf.backend_window));
-  if (result != ncclSuccess) {
-    TC_LOG(ERROR) << "Failed to deregister local buffer";
-  }
-
-  // ncclCommWindowDeregister may leave a sticky CUDA error in the runtime
-  // error queue.  The internal path (ncclCommDeregister -> async IPC release
-  // -> cuMemUnmap on remote peers, plus GIN ibv_dereg_mr -> DMA-BUF cleanup)
-  // can set cudaErrorHostMemoryAlreadyRegistered (712) as a deferred error.
-  // This is NOT a kernel error, so cudaDeviceSynchronize alone would not
-  // clear it.  We must call cudaGetLastError() to consume the sticky error
-  // before the next CUDA runtime API call (e.g. cudaMemset via tensor.zero_()
-  // in the next iteration) encounters it and throws.
-  cudaDeviceSynchronize();
-  cudaGetLastError();
-
-  // Remove from tracking vector
+  // Remove from tracking vector before deregistration
   auto it = std::find_if(
       registered_local_buffers_.begin(),
       registered_local_buffers_.end(),
       [&buf](const DeviceRegisteredBuffer& b) {
-        return b.backend_window == buf.backend_window;
+        return b.base_ptr == buf.base_ptr;
       });
   if (it != registered_local_buffers_.end()) {
     registered_local_buffers_.erase(it);
   }
 
-  buf.backend_window = nullptr;
-  buf.base_ptr = nullptr;
-  buf.size = 0;
+  Backend::deregister_local_buffer(nccl_api_, nccl_comm_, buf);
 }
 
 template <typename Backend>

--- a/comms/torchcomms/ncclx/TorchCommWindowNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchCommWindowNCCLX.hpp
@@ -106,13 +106,15 @@ class TorchCommWindowNCCLX : public TorchCommWindow {
   // ==========================================================================
 
   // Register a local buffer for use as source in device-side put operations.
-  // This is NON-COLLECTIVE because it uses NCCL_WIN_LOCAL_ONLY flag which
-  // registers with local lkey only (no rkey allGather). The resulting window
-  // can only be used as a source buffer for put operations.
+  // NON-COLLECTIVE — registration is purely local (lkey only, no rkey
+  // exchange). The resulting buffer can only be used as a source for put
+  // operations.
   //
-  // Prerequisites: Must call tensor_register() then get_device_window() before
-  // this method. get_device_window() triggers ncclDevCommCreate which enables
-  // GIN - required for local buffer registration to work.
+  // Backend dispatch:
+  //   - NCCLDeviceBackend: NCCL_WIN_DEVICE_API | NCCL_WIN_LOCAL_ONLY
+  //   - PipesDeviceBackend: MultiPeerTransport::localRegisterIbgdaBuffer
+  //
+  // Prerequisites: Must call tensor_register() then get_device_window() first.
   DeviceRegisteredBuffer register_local_buffer(const at::Tensor& tensor);
 
   // Deregister a previously registered local buffer. NON-COLLECTIVE.

--- a/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommWindowNCCLXPipesTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommWindowNCCLXPipesTest.cpp
@@ -2,7 +2,7 @@
 // Unit tests for TorchCommWindowNCCLX with PipesDeviceBackend.
 //
 // These tests verify Pipes-specific error paths without real hardware:
-//   1. register_local_buffer() throws "not yet supported" for Pipes backend
+//   1. register_local_buffer() throws when device window not initialized
 //   2. get_device_window() throws when win_ is null (no tensor_register)
 //
 // Both tests set NCCL_CTRAN_USE_PIPES=1 in SetUp() so that
@@ -35,12 +35,14 @@ class TorchCommWindowNCCLXPipesTest : public TorchCommNCCLXTest {
   }
 };
 
-TEST_F(TorchCommWindowNCCLXPipesTest, RegisterLocalBufferThrowsNotSupported) {
-  // Verifies: register_local_buffer() throws immediately for Pipes backend.
-  // IBGDA lkey registration requires ctran MR integration (planned follow-up).
+TEST_F(
+    TorchCommWindowNCCLXPipesTest,
+    RegisterLocalBufferThrowsIfDeviceWindowNotInit) {
+  // Verifies: register_local_buffer() throws when get_device_window() has not
+  // been called first (device_window_ is null).
   //
-  // Code path: register_local_buffer() → Pipes constexpr branch → throw
-  // Production value: Clear error when the unsupported Pipes API path is used.
+  // Code path: register_local_buffer() → device_window_ null check → throw
+  // Production value: Clear error when the API is called out of order.
 
   setupRankAndSize(0, 2);
   setupCCAExpectations(1, 2, 1);
@@ -59,15 +61,18 @@ TEST_F(TorchCommWindowNCCLXPipesTest, RegisterLocalBufferThrowsNotSupported) {
 
   auto src_tensor = createTestTensor({5, 5});
 
-  // register_local_buffer should throw immediately for Pipes (no MR support)
+  // register_local_buffer should throw because device window not initialized
   EXPECT_THROW(
       {
         try {
           win->register_local_buffer(src_tensor);
         } catch (const std::runtime_error& e) {
           std::string error_msg = e.what();
-          EXPECT_TRUE(error_msg.find("not yet supported") != std::string::npos)
-              << "Error should indicate not yet supported, got: " << error_msg;
+          EXPECT_TRUE(
+              error_msg.find("Device window not initialized") !=
+              std::string::npos)
+              << "Error should indicate device window not initialized, got: "
+              << error_msg;
           throw;
         }
       },
@@ -113,6 +118,82 @@ TEST_F(TorchCommWindowNCCLXPipesTest, GetDeviceWindowThrowsIfWinNull) {
         }
       },
       std::runtime_error);
+
+  EXPECT_NO_THROW(comm->finalize());
+}
+
+TEST_F(TorchCommWindowNCCLXPipesTest, RegisterLocalBufferSuccess) {
+  // Verifies: register_local_buffer() succeeds for the Pipes backend and
+  // returns a RegisteredBuffer with the correct lkey from
+  // winLocalRegisterBuffer, and backend_window == nullptr (Pipes doesn't use
+  // backend_window — only GIN does).
+  //
+  // Also verifies deregister_local_buffer() calls winLocalDeregisterBuffer.
+
+  setupRankAndSize(0, 2);
+  setupCCAExpectations(1, 2, 1);
+  auto comm = createMockedTorchComm();
+
+  cuda_mock_->setupDefaultBehaviors();
+  nccl_mock_->setupDefaultBehaviors();
+
+  EXPECT_NO_THROW(comm->init(*device_, "test_name", default_options_));
+
+  auto win_base = comm->new_window();
+  auto win = std::dynamic_pointer_cast<TorchCommWindowNCCLXPipes>(win_base);
+  ASSERT_NE(win, nullptr) << "Window should be TorchCommWindowNCCLXPipes";
+
+  // tensor_register() — uses default mock for commWindowRegister
+  auto dst_tensor = createTestTensor({5, 5});
+  EXPECT_NO_THROW(win->tensor_register(dst_tensor));
+
+  // Mock winCreateDeviceWin to succeed — returns a fake device pointer.
+  // PipesDeviceBackend::create_device_window() calls this, then malloc+memcpy.
+  void* fake_pipes_dev_win = reinterpret_cast<void*>(0xBEEF);
+  EXPECT_CALL(*nccl_mock_, winCreateDeviceWin(_, _, _, _, _))
+      .WillOnce(
+          DoAll(SetArgPointee<4>(fake_pipes_dev_win), Return(ncclSuccess)));
+
+  // Mock cuda malloc/memcpy for creating TorchCommDeviceWindow in device mem
+  void* fake_dev_window_ptr = reinterpret_cast<void*>(0xDEAD);
+  EXPECT_CALL(*cuda_mock_, malloc(_, _))
+      .WillOnce(
+          DoAll(SetArgPointee<0>(fake_dev_window_ptr), Return(cudaSuccess)));
+  EXPECT_CALL(*cuda_mock_, memcpy(_, _, _, cudaMemcpyHostToDevice))
+      .WillOnce(Return(cudaSuccess));
+
+  // get_device_window() — creates the Pipes device window
+  auto* dev_win = win->get_device_window();
+  ASSERT_NE(dev_win, nullptr) << "Device window should not be null";
+
+  // Mock winLocalRegisterBuffer to return a specific lkey
+  const uint32_t expected_lkey = 0x12345678;
+  EXPECT_CALL(*nccl_mock_, winLocalRegisterBuffer(_, _, _, _))
+      .WillOnce(DoAll(SetArgPointee<3>(expected_lkey), Return(ncclSuccess)));
+
+  auto src_tensor = createTestTensor({5, 5});
+  auto buf = win->register_local_buffer(src_tensor);
+
+  // Pipes backend: lkey is set, backend_window is nullptr
+  EXPECT_EQ(buf.lkey, expected_lkey);
+  EXPECT_EQ(buf.backend_window, nullptr)
+      << "Pipes backend should not set backend_window";
+  EXPECT_NE(buf.base_ptr, nullptr);
+  EXPECT_GT(buf.size, 0u);
+
+  // Deregister and verify winLocalDeregisterBuffer is called
+  EXPECT_CALL(*nccl_mock_, winLocalDeregisterBuffer(_, buf.base_ptr))
+      .WillOnce(Return(ncclSuccess));
+  win->deregister_local_buffer(buf);
+
+  EXPECT_EQ(buf.base_ptr, nullptr)
+      << "base_ptr should be cleared after deregister";
+  EXPECT_EQ(buf.lkey, 0u) << "lkey should be cleared after deregister";
+
+  // Cleanup mocks for destruction — use ON_CALL since finalize() also
+  // triggers other free/destroy calls (barrier buffer, etc.)
+  ON_CALL(*nccl_mock_, winDestroyDeviceWin(_))
+      .WillByDefault(Return(ncclSuccess));
 
   EXPECT_NO_THROW(comm->finalize());
 }

--- a/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.hpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.hpp
@@ -362,6 +362,16 @@ class NcclxMock : public NcclxApi {
        int* outNumNvlPeers,
        int* outNumIbPeers),
       (override));
+  MOCK_METHOD(
+      ncclResult_t,
+      winLocalRegisterBuffer,
+      (ncclComm_t comm, void* ptr, size_t size, uint32_t* outLkey),
+      (override));
+  MOCK_METHOD(
+      ncclResult_t,
+      winLocalDeregisterBuffer,
+      (ncclComm_t comm, void* ptr),
+      (override));
 #endif
 
   // Group operations

--- a/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTest.cpp
@@ -173,6 +173,90 @@ TEST_F(PipesDeviceApiTest, PipesDeviceWindowCreationFloat) {
 }
 
 // =============================================================================
+// Local Buffer Registration Test (Pipes)
+// =============================================================================
+// Validates register_local_buffer() for the Pipes (IBGDA) backend:
+//   1. Create window, register tensor, create device window
+//   2. Register a separate source tensor as a local buffer
+//   3. Verify RegisteredBuffer has valid lkey (used for IBGDA WQE construction)
+//   4. Verify backend_window is null (only GIN uses backend_window)
+//   5. Deregister and verify cleanup
+
+void PipesDeviceApiTest::testLocalBufferRegistration(
+    int count,
+    at::ScalarType dtype) {
+  SCOPED_TRACE(
+      ::testing::Message()
+      << "Testing Pipes Local Buffer Registration with count=" << count
+      << " and dtype=" << getDtypeName(dtype));
+
+  // Create MemPool for RDMA-compatible memory allocation (cuMem-based).
+  auto mem_pool = std::make_unique<at::cuda::MemPool>(
+      std::static_pointer_cast<c10::cuda::CUDACachingAllocator::CUDAAllocator>(
+          allocator_));
+  c10::cuda::CUDACachingAllocator::beginAllocateToPool(
+      mem_pool->device(), mem_pool->id(), [](cudaStream_t) { return true; });
+
+  auto options =
+      at::TensorOptions().dtype(dtype).device(at::kCUDA, device_index_);
+  at::Tensor win_tensor = at::zeros({count * num_ranks_}, options);
+
+  at::Tensor src_tensor = at::zeros({count}, options);
+  src_tensor.fill_(static_cast<float>(rank_ + 1));
+
+  c10::cuda::CUDACachingAllocator::endAllocateToPool(
+      mem_pool->device(), mem_pool->id());
+
+  // All ranks must register the tensor collectively
+  torchcomm_->barrier(false);
+  auto base_win = torchcomm_->new_window();
+  base_win->tensor_register(win_tensor);
+  torchcomm_->barrier(false);
+
+  auto* win =
+      dynamic_cast<torch::comms::TorchCommWindowNCCLXPipes*>(base_win.get());
+  ASSERT_NE(win, nullptr) << "Window should be TorchCommWindowNCCLXPipes. "
+                             "Is NCCL_CTRAN_USE_PIPES=1 set?";
+
+  // get_device_window() is COLLECTIVE — must be called before
+  // register_local_buffer() to initialize the Pipes device window.
+  decltype(win->get_device_window()) dev_win = nullptr;
+  try {
+    dev_win = win->get_device_window();
+  } catch (const std::runtime_error& e) {
+    base_win->tensor_deregister();
+    base_win.reset();
+    mem_pool.reset();
+    GTEST_SKIP() << "Skipping: IBGDA/Pipes hardware not available: "
+                 << e.what();
+  }
+  ASSERT_NE(dev_win, nullptr) << "Device window should not be null";
+
+  auto src_buf = win->register_local_buffer(src_tensor);
+
+  // Pipes backend: lkey is set (used for IBGDA WQE construction),
+  // backend_window is null (only GIN uses backend_window).
+  ASSERT_NE(src_buf.base_ptr, nullptr) << "Buffer base_ptr should not be null";
+  ASSERT_GT(src_buf.size, 0u) << "Buffer size should be positive";
+  EXPECT_NE(src_buf.lkey, 0u) << "Pipes backend should set lkey for IBGDA put";
+  EXPECT_EQ(src_buf.backend_window, nullptr)
+      << "Pipes backend should not set backend_window";
+
+  // Deregister and verify cleanup
+  win->deregister_local_buffer(src_buf);
+
+  base_win->tensor_deregister();
+  base_win.reset();
+  mem_pool.reset();
+
+  torchcomm_->barrier(false);
+}
+
+TEST_F(PipesDeviceApiTest, LocalBufferRegistrationFloat) {
+  testLocalBufferRegistration(1024, at::kFloat);
+}
+
+// =============================================================================
 // Per-Peer Signal Test (Pipes)
 // =============================================================================
 // Ring pattern: rank i signals rank (i+1) % num_ranks

--- a/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTest.hpp
+++ b/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTest.hpp
@@ -62,6 +62,9 @@ class PipesDeviceApiTest : public ::testing::Test {
   // Test device barrier: all ranks synchronize via barrier().
   void testDeviceBarrier();
 
+  // Test local buffer registration: register_local_buffer returns valid lkey.
+  void testLocalBufferRegistration(int count, at::ScalarType dtype);
+
   // Member variables
   std::unique_ptr<TorchCommTestWrapper> wrapper_;
   std::shared_ptr<torch::comms::TorchComm> torchcomm_;


### PR DESCRIPTION
Summary:
Adds `register_local_buffer` / `deregister_local_buffer` support for the Pipes
(IBGDA) backend, enabling the device-side `put()` API to work with Pipes transport.

The key change is moving buffer registration logic from the generic
`TorchCommWindowNCCLX` template into backend-specific static methods:

- **NCCLDeviceBackend** (GIN): calls `commWindowRegister` with
  `NCCL_WIN_DEVICE_API | NCCL_WIN_LOCAL_ONLY`, returns `RegisteredBuffer` with
  `backend_window` (used by GIN put) and `lkey=0` (unused).

- **PipesDeviceBackend** (IBGDA): calls new ncclx C API
  `ncclWinLocalRegisterBuffer` which routes through
  `ctranComm_->multiPeerTransport_->localRegisterIbgdaBuffer()`, returns
  `RegisteredBuffer` with `lkey` (used by IBGDA put WQE) and
  `backend_window=nullptr` (unused).

New ncclx C APIs added under `#if defined(ENABLE_PIPES)`:
- `ncclWinLocalRegisterBuffer(comm, ptr, size, &outLkey)` — local MR registration
- `ncclWinLocalDeregisterBuffer(comm, ptr)` — local MR deregistration

These are non-collective, local-only operations (no cross-rank coordination).

Reviewed By: siyengar

Differential Revision: D97364721


