### PR TITLE
reset window signal during replay

### DIFF
--- a/comms/ctran/algos/RMA/PutSignal.cc
+++ b/comms/ctran/algos/RMA/PutSignal.cc
@@ -332,9 +332,8 @@ commResult_t ctranPutSignal(
 static commResult_t
 waitSignalDriverApi(int peer, CtranWin* win, cudaStream_t stream) {
 #if CUDART_VERSION >= 11070
-  // Check if hardware wait is available at runtime
-  if (FB_CUPFN(cuStreamWaitValue64) == nullptr) {
-    return commInternalError;
+  if (!ctran::utils::canUse64BitStreamMemOps()) {
+    return commInvalidUsage;
   }
 
   // Get the signal address
@@ -342,13 +341,48 @@ waitSignalDriverApi(int peer, CtranWin* win, cudaStream_t stream) {
   // Get the expected compare value
   uint64_t cmpVal = win->ctranNextWaitSignalVal(peer);
 
-  // Use hardware-accelerated stream wait (zero GPU overhead!)
-  // This uses hardware memory polling
-  CUresult result = FB_CUPFN(cuStreamWaitValue64)(
-      (CUstream)stream,
-      (CUdeviceptr)signalAddr,
-      cmpVal,
-      CU_STREAM_WAIT_VALUE_GEQ);
+  cudaStreamCaptureStatus captureStatus{};
+  cudaStreamGetCaptureInfo(stream, &captureStatus, nullptr);
+
+  CUresult result;
+
+  if (captureStatus == cudaStreamCaptureStatusActive) {
+    if (!ctran::utils::canUseCuStreamBatchMemOp()) {
+      return commInvalidUsage;
+    }
+
+    // During CUDA graph capture, use cuStreamBatchMemOp to atomically
+    // wait for the signal and then reset it to 0.  The reset prepares
+    // the slot for the next graph replay.
+    //
+    // This follows the pattern established by NCCL's CE collective path
+    // in ncclMemOpSync() (comms/ncclx/v2_28/src/ce_coll.cc lines 212-222),
+    // which batches waits + resets in a single cuStreamBatchMemOp during
+    // graph capture.  The batch is atomic on the stream — the wait
+    // completes before the reset runs, and no remote signal for the next
+    // replay can interleave.
+    CUstreamBatchMemOpParams ops[2] = {};
+
+    // wait for signal GEQ cmpVal
+    ops[0].waitValue.operation = CU_STREAM_MEM_OP_WAIT_VALUE_64;
+    ops[0].waitValue.address = (CUdeviceptr)signalAddr;
+    ops[0].waitValue.value64 = cmpVal;
+    ops[0].waitValue.flags = CU_STREAM_WAIT_VALUE_GEQ;
+
+    // reset signal to 0
+    ops[1].writeValue.operation = CU_STREAM_MEM_OP_WRITE_VALUE_64;
+    ops[1].writeValue.address = (CUdeviceptr)signalAddr;
+    ops[1].writeValue.value64 = 0;
+    ops[1].writeValue.flags = CU_STREAM_WRITE_VALUE_DEFAULT;
+
+    result = FB_CUPFN(cuStreamBatchMemOp)((CUstream)stream, 2, ops, 0);
+  } else {
+    result = FB_CUPFN(cuStreamWaitValue64)(
+        (CUstream)stream,
+        (CUdeviceptr)signalAddr,
+        cmpVal,
+        CU_STREAM_WAIT_VALUE_GEQ);
+  }
 
   if (result != CUDA_SUCCESS) {
     const char* errStr = nullptr;

--- a/comms/ctran/utils/CudaWrap.cc
+++ b/comms/ctran/utils/CudaWrap.cc
@@ -253,6 +253,61 @@ static commResult_t cudaPfnFuncLoader(void) {
 #endif
 }
 
+// CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS was renamed to _V1 in CUDA 12+.
+// Both are enum values (not macros), so use the _V1 name which is available
+// across all supported CUDA versions.
+bool canUseCuStreamBatchMemOp() {
+#if defined(__HIP_PLATFORM_AMD__)
+  return false;
+#else
+  static bool supported = [] {
+    int cudaDev;
+    if (cudaGetDevice(&cudaDev) != cudaSuccess) {
+      return false;
+    }
+    CUdevice dev;
+    if (FB_CUPFN(cuDeviceGet) == nullptr ||
+        FB_CUPFN(cuDeviceGetAttribute) == nullptr) {
+      return false;
+    }
+    if (FB_CUPFN(cuDeviceGet)(&dev, cudaDev) != CUDA_SUCCESS) {
+      return false;
+    }
+    int value = 0;
+    auto st = FB_CUPFN(cuDeviceGetAttribute)(
+        &value, CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS_V1, dev);
+    return st == CUDA_SUCCESS && value != 0;
+  }();
+  return supported;
+#endif
+}
+
+bool canUse64BitStreamMemOps() {
+#if defined(__HIP_PLATFORM_AMD__)
+  return false;
+#else
+  static bool supported = [] {
+    int cudaDev;
+    if (cudaGetDevice(&cudaDev) != cudaSuccess) {
+      return false;
+    }
+    CUdevice dev;
+    if (FB_CUPFN(cuDeviceGet) == nullptr ||
+        FB_CUPFN(cuDeviceGetAttribute) == nullptr) {
+      return false;
+    }
+    if (FB_CUPFN(cuDeviceGet)(&dev, cudaDev) != CUDA_SUCCESS) {
+      return false;
+    }
+    int value = 0;
+    auto st = FB_CUPFN(cuDeviceGetAttribute)(
+        &value, CU_DEVICE_ATTRIBUTE_CAN_USE_64_BIT_STREAM_MEM_OPS_V1, dev);
+    return st == CUDA_SUCCESS && value != 0;
+  }();
+  return supported;
+#endif
+}
+
 static std::once_flag commCudaLibraryInitFlag;
 static commResult_t commCudaLibraryInitResult;
 

--- a/comms/ctran/utils/CudaWrap.h
+++ b/comms/ctran/utils/CudaWrap.h
@@ -256,6 +256,7 @@ FB_DECLARE_CUDA_PFN_EXTERN(cuMemGetAllocationPropertiesFromHandle, 10020);
 FB_DECLARE_CUDA_PFN_EXTERN(cuPointerGetAttribute, 4000);
 #if CUDA_VERSION >= 11070
 FB_DECLARE_CUDA_PFN_EXTERN(cuMemGetHandleForAddressRange, 11070);
+FB_DECLARE_CUDA_PFN_EXTERN(cuStreamBatchMemOp, 11070);
 FB_DECLARE_CUDA_PFN_EXTERN(cuStreamWaitValue64, 11070);
 #endif
 #if CUDA_VERSION >= 12010
@@ -387,6 +388,10 @@ inline int getCuMemDmaBufFd(
 bool getCuMemSysSupported();
 
 bool isCuMemSupported();
+
+bool canUseCuStreamBatchMemOp();
+
+bool canUse64BitStreamMemOps();
 
 commResult_t commCudaLibraryInit();
 

--- a/comms/ctran/window/tests/CtranWinTests.cc
+++ b/comms/ctran/window/tests/CtranWinTests.cc
@@ -601,6 +601,130 @@ TEST_F(CtranWinDistTest, asymmetricWindowPutGet) {
   EXPECT_EQ(res, commSuccess);
 }
 
+// Verify that the cuStreamBatchMemOp signal reset in waitSignalDriverApi
+// correctly resets signal values between CUDA graph replays.  Without the
+// reset, replay N>0 would see stale GEQ values from replay N-1 and the
+// wait would pass prematurely (before the peer's put data arrives).
+TEST_F(CtranWinDistTest, signalResetAcrossGraphReplays) {
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+
+  auto statex = comm->statex_.get();
+  ASSERT_NE(statex, nullptr);
+
+  if (statex->nRanks() < 2) {
+    GTEST_SKIP() << "Need at least 2 ranks";
+  }
+
+  const int rank = statex->rank();
+  const int numRanks = statex->nRanks();
+  const int nextPeer = (rank + 1) % numRanks;
+  const int prevPeer = (rank + numRanks - 1) % numRanks;
+  const size_t count = 1024;
+  const size_t winSizeBytes = count * sizeof(int) * numRanks;
+
+  // Allocate window
+  CtranWin* win = nullptr;
+  void* winBase = nullptr;
+  COMMCHECK_TEST(ctranWinAllocate(winSizeBytes, comm.get(), &winBase, &win));
+  ASSERT_NE(winBase, nullptr);
+
+  // Put buffer: rank * 1000 + index
+  int* putBuf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&putBuf, count * sizeof(int)));
+  assignChunkValue(putBuf, count, rank * 1000, 1);
+
+  cudaStream_t captureStream, putStream, waitStream;
+  CUDACHECK_TEST(
+      cudaStreamCreateWithFlags(&captureStream, cudaStreamNonBlocking));
+  CUDACHECK_TEST(cudaStreamCreateWithFlags(&putStream, cudaStreamNonBlocking));
+  CUDACHECK_TEST(cudaStreamCreateWithFlags(&waitStream, cudaStreamNonBlocking));
+
+  this->barrier(comm.get());
+
+  // Capture put + signal + wait_signal into a graph
+  CUDACHECK_TEST(
+      cudaStreamBeginCapture(captureStream, cudaStreamCaptureModeRelaxed));
+
+  // Fork to putStream
+  cudaEvent_t forkEvent, joinEvent;
+  CUDACHECK_TEST(cudaEventCreate(&forkEvent));
+  CUDACHECK_TEST(cudaEventCreate(&joinEvent));
+
+  CUDACHECK_TEST(cudaEventRecord(forkEvent, captureStream));
+  CUDACHECK_TEST(cudaStreamWaitEvent(putStream, forkEvent, 0));
+
+  COMMCHECK_TEST(ctranPutSignal(
+      putBuf, count, commInt32, nextPeer, count * rank, win, putStream, true));
+
+  // Join putStream back, fork to waitStream
+  CUDACHECK_TEST(cudaEventRecord(joinEvent, putStream));
+  CUDACHECK_TEST(cudaStreamWaitEvent(waitStream, joinEvent, 0));
+
+  COMMCHECK_TEST(ctranWaitSignal(prevPeer, win, waitStream));
+
+  // Join waitStream back to captureStream
+  cudaEvent_t joinEvent2;
+  CUDACHECK_TEST(cudaEventCreate(&joinEvent2));
+  CUDACHECK_TEST(cudaEventRecord(joinEvent2, waitStream));
+  CUDACHECK_TEST(cudaStreamWaitEvent(captureStream, joinEvent2, 0));
+
+  cudaGraph_t graph;
+  CUDACHECK_TEST(cudaStreamEndCapture(captureStream, &graph));
+  ASSERT_NE(graph, nullptr);
+
+  cudaGraphExec_t graphExec;
+  CUDACHECK_TEST(cudaGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+
+  this->barrier(comm.get());
+
+  // Replay multiple times — each replay should deliver fresh data
+  constexpr int kNumReplays = 5;
+  for (int replay = 0; replay < kNumReplays; replay++) {
+    // Zero the window buffer so we can detect fresh data
+    CUDACHECK_TEST(cudaMemset(winBase, 0, winSizeBytes));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    this->barrier(comm.get());
+
+    CUDACHECK_TEST(cudaGraphLaunch(graphExec, captureStream));
+    CUDACHECK_TEST(cudaStreamSynchronize(captureStream));
+    this->barrier(comm.get());
+
+    // Verify data from previous peer arrived correctly
+    int* winBufInt = reinterpret_cast<int*>(winBase);
+    std::vector<int> recvData(count, -1);
+    CUDACHECK_TEST(cudaMemcpy(
+        recvData.data(),
+        winBufInt + count * prevPeer,
+        count * sizeof(int),
+        cudaMemcpyDefault));
+
+    int errs = 0;
+    for (size_t i = 0; i < count; ++i) {
+      int expected = prevPeer * 1000 + static_cast<int>(i);
+      if (recvData[i] != expected && errs++ < 5) {
+        XLOG(ERR) << "Replay " << replay << ": Rank " << rank << ": data[" << i
+                  << "] = " << recvData[i] << ", expected = " << expected;
+      }
+    }
+    EXPECT_EQ(errs, 0) << "Replay " << replay
+                       << ": signal reset failed — stale data";
+  }
+
+  // Cleanup
+  CUDACHECK_TEST(cudaGraphExecDestroy(graphExec));
+  CUDACHECK_TEST(cudaGraphDestroy(graph));
+  CUDACHECK_TEST(cudaFree(putBuf));
+  CUDACHECK_TEST(cudaStreamDestroy(captureStream));
+  CUDACHECK_TEST(cudaStreamDestroy(putStream));
+  CUDACHECK_TEST(cudaStreamDestroy(waitStream));
+  CUDACHECK_TEST(cudaEventDestroy(forkEvent));
+  CUDACHECK_TEST(cudaEventDestroy(joinEvent));
+  CUDACHECK_TEST(cudaEventDestroy(joinEvent2));
+  COMMCHECK_TEST(ctranWinFree(win));
+  this->barrier(comm.get());
+}
+
 INSTANTIATE_TEST_SUITE_P(
     CtranWinInstance,
     CtranWinTestParam,


### PR DESCRIPTION
Summary:
During CUDA graph replay, baked-in signal values from capture are
replayed identically each time.  Without resetting, WAIT_VALUE_64
(GEQ 1) passes prematurely on replay N>0 from stale values left by
replay N-1.

Fix: In waitSignalDriverApi(), use cuStreamBatchMemOp during graph
capture to atomically batch the wait + reset-to-0.  This follows
NCCL's CE collective pattern (ce_coll.cc ncclMemOpSync) which resets
sync values after waits within a cuStreamBatchMemOp.

Changes:
- PutSignal.cc: cuStreamBatchMemOp with WAIT_VALUE_64 + WRITE_VALUE_64 during capture; standalone cuStreamWaitValue64 outside capture.

Reviewed By: minsii

Differential Revision: D97118960


