### PR TITLE
Fix NCCL_PARAM double-caching breaking EnvRAII test overrides (#1184)

### DIFF
--- a/comms/ncclx/v2_28/src/include/param.h
+++ b/comms/ncclx/v2_28/src/include/param.h
@@ -39,11 +39,9 @@ void ncclLoadParam(char const* env, int64_t deftVal, int64_t uninitialized, int6
   int64_t ncclParam##name() { \
     constexpr int64_t uninitialized = INT64_MIN; \
     static_assert(deftVal != uninitialized, "default value cannot be the uninitialized value."); \
-    static int64_t cache = uninitialized; \
-    if (__builtin_expect(__atomic_load_n(&cache, __ATOMIC_RELAXED) == uninitialized, false)) { \
-      ncclLoadParam("NCCL_" env, deftVal, uninitialized, &cache); \
-    } \
-    return cache; \
+    int64_t value = uninitialized; \
+    ncclLoadParam("NCCL_" env, deftVal, uninitialized, &value); \
+    return value; \
   }
 
 void initNcclLogger();

--- a/comms/ncclx/v2_29/src/include/param.h
+++ b/comms/ncclx/v2_29/src/include/param.h
@@ -40,13 +40,10 @@ int64_t ncclLoadParam(char const* env, int64_t deftVal, int64_t uninitialized, i
       "Unregistered CVAR \"NCCL_" env "\". Please add this CVAR to \"fbcode/comms/utils/cvars/nccl_cvars.yaml\", regenerate the nccl_cvars.(h|cc) files, and recompile."); \
   int64_t ncclParam##name() { \
     constexpr int64_t uninitialized = INT64_MIN; \
-    static int8_t noCache = /*uninitialized*/ -1; \
     static_assert(deftVal != uninitialized, "default value cannot be the uninitialized value."); \
-    static int64_t cache = uninitialized; \
-    if (COMPILER_EXPECT(COMPILER_ATOMIC_LOAD(&cache, std::memory_order_relaxed) == uninitialized, false)) { \
-      return ncclLoadParam("NCCL_" env, deftVal, uninitialized, &cache, &noCache); \
-    } \
-    return cache; \
+    int64_t cache = uninitialized; \
+    int8_t noCache = /*uninitialized*/ -1; \
+    return ncclLoadParam("NCCL_" env, deftVal, uninitialized, &cache, &noCache); \
   }
 
 void initNcclLogger();


### PR DESCRIPTION
Summary:

The `NCCL_PARAM` macro in v2_28 and v2_29 uses a `static int64_t cache` that reads the CVAR value once and never re-reads. When tests use `EnvRAII` to override CVAR globals at runtime, the static cache is stale; the override is invisible to code reading params through `ncclParam##name()`. This breaks tests like `comm_register_test_1x8`.

Root cause: Double caching. CVAR globals are the source of truth (and `EnvRAII` modifies them correctly), but `NCCL_PARAM` adds a second `static` cache layer on top that short-circuits all subsequent reads after the first call.

v2_27 had no issue because it accessed CVAR globals directly without `NCCL_PARAM`.

Fix: Remove the `static` qualifier from `cache` (and `noCache` in v2_29) in the `NCCL_PARAM` macro so every call reads from the CVAR global via `ncclLoadParam`. The `if` guard that skipped `ncclLoadParam` when cache was already initialized is also removed since it is now dead code.

The shared `nccl_baseline_adapter.cc` is NOT modified; since `cache` is now always initialized to `INT64_MIN` (uninitialized) on every call, the adapter's early-return check never triggers, so it always proceeds to read from the CVAR global.

**Follow-up note**: will be enhancing test coverage to try to catch such issues in a follow-up diff.

Reviewed By: zhiyongww

Differential Revision: D97501814


