### PR TITLE
Integrate LL128 protocol with DeviceAllToAllvPipes (#1185)

### DIFF
--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -14,6 +14,7 @@
 #if defined(ENABLE_PIPES)
 
 #include "comms/pipes/MultiPeerTransport.h"
+#include "comms/pipes/ll128/Ll128Packet.cuh"
 
 commResult_t ctranInitializePipes(CtranComm* comm) {
   if (!NCCL_CTRAN_USE_PIPES) {
@@ -45,6 +46,20 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     config.nvlConfig.useDualStateBuffer = (pc.useDualStateBuffer >= 0)
         ? (pc.useDualStateBuffer == 1)
         : NCCL_CTRAN_PIPES_USE_DUAL_STATE_BUFFER;
+
+    // LL128 buffer allocation for DeviceAllToAllv
+    if (NCCL_CTRAN_DA2A_LL128_THRESHOLD > 0) {
+      if (NCCL_CTRAN_DA2A_LL128_BUFFER_SIZE > 0) {
+        config.nvlConfig.ll128BufferSize = NCCL_CTRAN_DA2A_LL128_BUFFER_SIZE;
+      } else {
+        config.nvlConfig.ll128BufferSize =
+            comms::pipes::ll128_buffer_size(256 * 1024);
+      }
+      CLOGF(
+          INFO,
+          "Pipes LL128 buffer size configured (size={} per peer)",
+          config.nvlConfig.ll128BufferSize);
+    }
 
     // IBGDA config (ordered to match MultipeerIbgdaTransportConfig fields)
     config.ibgdaConfig.cudaDevice = comm->statex_->cudaDev();

--- a/comms/ctran/algos/AllToAll/AllToAll.cc
+++ b/comms/ctran/algos/AllToAll/AllToAll.cc
@@ -19,6 +19,7 @@
 #include "comms/utils/cvars/nccl_cvars.h"
 
 #if defined(ENABLE_PIPES)
+template <PipeProtocol Proto>
 extern __global__ void ncclKernelDeviceAllToAllvPipes(
     int* flag,
     CtranAlgoDeviceState* devState,
@@ -230,11 +231,12 @@ commResult_t ctranDeviceAllToAllv(
       INFO,
       COLL,
       "DeviceAllToAllvPipes: opCount {} numBlocks {} numThreads {} "
-      "blockScheduling {} hasHints {} [nLocalRanks={}]",
+      "blockScheduling {} ll128ThresholdBytes {} hasHints {} [nLocalRanks={}]",
       opCount,
       collConfig.numBlocks,
       collConfig.numThreads,
       collConfig.blockScheduling,
+      collConfig.ll128ThresholdBytes,
       (!hints.empty()),
       comm->statex_->nLocalRanks());
 
@@ -256,11 +258,12 @@ commResult_t ctranDeviceAllToAllv(
   // NVLink-only: no GPE op needed (no IB fallback)
   std::vector<std::unique_ptr<struct OpElem>> opGroup;
 
+  auto* kernel = (collConfig.ll128ThresholdBytes > 0)
+      ? ncclKernelDeviceAllToAllvPipes<PipeProtocol::LL128>
+      : ncclKernelDeviceAllToAllvPipes<PipeProtocol::Simple>;
+
   FB_COMMCHECK(comm->ctran_->gpe->submit(
-      std::move(opGroup),
-      nullptr,
-      config,
-      reinterpret_cast<void*>(ncclKernelDeviceAllToAllvPipes)));
+      std::move(opGroup), nullptr, config, reinterpret_cast<void*>(kernel)));
 
   return commSuccess;
 }

--- a/comms/ctran/algos/AllToAll/DeviceAllToAllvPipes.cu
+++ b/comms/ctran/algos/AllToAll/DeviceAllToAllvPipes.cu
@@ -6,7 +6,9 @@
 #include "comms/ctran/algos/AllToAll/Types.h"
 #include "comms/ctran/algos/CtranAlgoDev.h"
 #include "comms/pipes/DeviceSpan.cuh"
+#include "comms/pipes/Timeout.cuh"
 #include "comms/pipes/Transport.cuh"
+#include "comms/pipes/ll128/Ll128Packet.cuh"
 
 // Compute the exclusive prefix sum of counts[0..rank-1] to get the
 // displacement for the given rank. Each thread computes its own peer's
@@ -22,6 +24,52 @@ computeDisplacement(const int64_t* counts_d, int rank) {
   return displ;
 }
 
+// Select LL128 or Simple protocol and send data to peer via NVLink.
+template <PipeProtocol Proto>
+__device__ __forceinline__ void send_peer(
+    comms::pipes::Transport& transport,
+    comms::pipes::ThreadGroup& group,
+    const char* src,
+    size_t bytes,
+    size_t ll128ThresholdBytes,
+    comms::pipes::Timeout timeout) {
+  if constexpr (Proto == PipeProtocol::LL128) {
+    bool use_ll128 = (bytes <= ll128ThresholdBytes) &&
+        comms::pipes::can_use_ll128(src, bytes);
+    if (use_ll128) {
+      transport.p2p_nvl.ll128_send(
+          group, const_cast<char*>(src), bytes, timeout);
+    } else {
+      transport.p2p_nvl.send(group, const_cast<char*>(src), bytes, timeout);
+    }
+  } else {
+    transport.p2p_nvl.send(group, const_cast<char*>(src), bytes, timeout);
+  }
+}
+
+// Select LL128 or Simple protocol and receive data from peer via NVLink.
+template <PipeProtocol Proto>
+__device__ __forceinline__ void recv_peer(
+    comms::pipes::Transport& transport,
+    comms::pipes::ThreadGroup& group,
+    char* dst,
+    size_t bytes,
+    size_t ll128ThresholdBytes,
+    comms::pipes::Timeout timeout) {
+  if constexpr (Proto == PipeProtocol::LL128) {
+    bool use_ll128 = (bytes <= ll128ThresholdBytes) &&
+        comms::pipes::can_use_ll128(dst, bytes);
+    if (use_ll128) {
+      transport.p2p_nvl.ll128_recv(group, dst, bytes, timeout);
+    } else {
+      transport.p2p_nvl.recv(group, dst, bytes, timeout);
+    }
+  } else {
+    transport.p2p_nvl.recv(group, dst, bytes, timeout);
+  }
+}
+
+template <PipeProtocol Proto>
 __global__ void ncclKernelDeviceAllToAllvPipes(
     int* /* flag */,
     CtranAlgoDeviceState* /* devState */,
@@ -33,8 +81,20 @@ __global__ void ncclKernelDeviceAllToAllvPipes(
   const int64_t recvMultiplier = args.recvcountsMultiplier;
   auto* transports = args.transports;
 
-  auto group = args.useBlockGroup ? comms::pipes::make_block_group()
-                                  : comms::pipes::make_warp_group();
+  // LL128 requires warp-level scheduling; Simple supports both.
+  auto group = [&]() {
+    if constexpr (Proto == PipeProtocol::LL128) {
+      return comms::pipes::make_warp_group();
+    } else {
+      return args.useBlockGroup ? comms::pipes::make_block_group()
+                                : comms::pipes::make_warp_group();
+    }
+  }();
+
+  // Timeout for LL128 path (default = no timeout / infinite wait).
+  // Harmless for Simple path (send/recv accept optional Timeout with same
+  // default).
+  comms::pipes::Timeout timeout{};
 
   if (nLocalRanks == 1) {
     // Single local rank — self-copy only
@@ -71,29 +131,43 @@ __global__ void ncclKernelDeviceAllToAllvPipes(
     size_t recvOffset = computeDisplacement(args.recvcounts_d, peerGlobalRank) *
         recvMultiplier * elementSize;
 
+    const char* src_ptr = static_cast<const char*>(args.sendbuff) + sendOffset;
+    char* dst_ptr = static_cast<char*>(args.recvbuff) + recvOffset;
+
     if (peerGlobalRank == myRank) {
-      // Self-copy: only one partition does it
       if (partition_id == 0) {
         transports[peerGlobalRank].self.put(
-            group_per_peer,
-            static_cast<char*>(args.recvbuff) + recvOffset,
-            static_cast<const char*>(args.sendbuff) + sendOffset,
-            sendBytes);
+            group_per_peer, dst_ptr, src_ptr, sendBytes);
       }
     } else if (partition_id == 0) {
-      // Send to peer via NVL
-      transports[peerGlobalRank].p2p_nvl.send(
+      send_peer<Proto>(
+          transports[peerGlobalRank],
           group_per_peer,
-          static_cast<char*>(const_cast<void*>(args.sendbuff)) + sendOffset,
-          sendBytes);
+          src_ptr,
+          sendBytes,
+          args.ll128ThresholdBytes,
+          timeout);
     } else {
-      // Recv from peer via NVL
-      transports[peerGlobalRank].p2p_nvl.recv(
+      recv_peer<Proto>(
+          transports[peerGlobalRank],
           group_per_peer,
-          static_cast<char*>(args.recvbuff) + recvOffset,
-          recvBytes);
+          dst_ptr,
+          recvBytes,
+          args.ll128ThresholdBytes,
+          timeout);
     }
   }
 }
+
+// Explicit template instantiations for both protocols.
+template __global__ void ncclKernelDeviceAllToAllvPipes<PipeProtocol::Simple>(
+    int* flag,
+    CtranAlgoDeviceState* devState,
+    ctran::device_alltoallv_pipes::KernArgs args);
+
+template __global__ void ncclKernelDeviceAllToAllvPipes<PipeProtocol::LL128>(
+    int* flag,
+    CtranAlgoDeviceState* devState,
+    ctran::device_alltoallv_pipes::KernArgs args);
 
 #endif // ENABLE_PIPES

--- a/comms/ctran/algos/AllToAll/DeviceAllToAllvPipesImpl.cc
+++ b/comms/ctran/algos/AllToAll/DeviceAllToAllvPipesImpl.cc
@@ -1,5 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#if defined(ENABLE_PIPES)
+
 #include "comms/ctran/algos/AllToAll/DeviceAllToAllvPipesImpl.h"
 #include "comms/ctran/algos/CtranAlgoDev.h"
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -43,7 +45,7 @@ CollectiveConfig::CollectiveConfig(
     return -1; // not set
   };
 
-  // --- blockScheduling ---
+  // === Step 1: blockScheduling ===
   // hint > NCCL_CTRAN_DA2A_BLOCK_SCHEDULING env > default(false/warp)
   int bs = hintBool("blockScheduling");
   if (bs >= 0) {
@@ -53,8 +55,16 @@ CollectiveConfig::CollectiveConfig(
     blockScheduling = (env && std::atoi(env) == 1);
   }
 
-  // --- numBlocks ---
-  // hint > NCCL_CTRAN_DA2A_NBLOCKS env > default(nLocalRanks*2)
+  // === Step 2: LL128 threshold (CVAR-only) ===
+  // Note: per-collective opt-in/out via hints could be added here in the
+  // future if needed.
+  ll128ThresholdBytes = static_cast<size_t>(NCCL_CTRAN_DA2A_LL128_THRESHOLD);
+
+  // === Step 3: numBlocks ===
+  unsigned int defaultBlocks =
+      static_cast<unsigned int>(std::max(1, nLocalRanks * 2));
+
+  // hint > env > default (resolved once for both protocols)
   int nb = hintInt("numBlocks");
   if (nb >= 0) {
     numBlocks = static_cast<unsigned int>(nb);
@@ -63,25 +73,28 @@ CollectiveConfig::CollectiveConfig(
     if (env) {
       numBlocks = static_cast<unsigned int>(std::atoi(env));
     } else {
-      numBlocks = static_cast<unsigned int>(std::max(1, nLocalRanks * 2));
+      numBlocks = defaultBlocks;
     }
   }
 
-  // Align to cluster size if needed
-  unsigned int clusterSize = NCCL_CTRAN_CGA_CLUSTER_SIZE;
-  if (clusterSize > 1 && numBlocks % clusterSize != 0) {
-    numBlocks = ((numBlocks + clusterSize - 1) / clusterSize) * clusterSize;
+  // Align to CGA cluster size when LL128 is disabled
+  // (volatile stores bypass L1, cluster alignment not beneficial).
+  if (ll128ThresholdBytes == 0) {
+    unsigned int clusterSize = NCCL_CTRAN_CGA_CLUSTER_SIZE;
+    if (clusterSize > 1 && numBlocks % clusterSize != 0) {
+      numBlocks = ((numBlocks + clusterSize - 1) / clusterSize) * clusterSize;
+    }
   }
 
-  // If block scheduling requested but not enough blocks, fall back to warp
+  // If block scheduling requested but not enough blocks,
+  // fall back to warp scheduling.
   if (blockScheduling &&
       numBlocks < static_cast<unsigned int>(nLocalRanks * 2)) {
     blockScheduling = false;
   }
 
-  // --- numThreads ---
-  // hint > NCCL_CTRAN_DA2A_NTHREADS env > NCCL_CTRAN_ALLTOALL_THREAD_BLOCK_SIZE
-  // cvar > default(512)
+  // === Step 4: numThreads ===
+  // hint > env > CVAR > default(512)
   int nt = hintInt("numThreads");
   if (nt >= 0) {
     numThreads = static_cast<unsigned int>(nt);
@@ -141,6 +154,9 @@ commResult_t setupKernelConfig(
   // Set transport array from MultiPeerTransport
   kernArgs.transports = comm->getMultiPeerTransportsPtr();
 
+  // LL128 threshold from pre-resolved config
+  kernArgs.ll128ThresholdBytes = collConfig.ll128ThresholdBytes;
+
   // All config is pre-resolved in CollectiveConfig — just apply it.
   kernArgs.useBlockGroup = collConfig.blockScheduling;
   config.numBlocks = collConfig.numBlocks;
@@ -153,3 +169,5 @@ commResult_t setupKernelConfig(
 }
 
 } // namespace ctran::device_alltoallv_pipes
+
+#endif // ENABLE_PIPES

--- a/comms/ctran/algos/AllToAll/DeviceAllToAllvPipesImpl.h
+++ b/comms/ctran/algos/AllToAll/DeviceAllToAllvPipesImpl.h
@@ -19,9 +19,13 @@ struct CollectiveConfig {
   unsigned int numBlocks;
   unsigned int numThreads;
   bool blockScheduling; // false=warp(default), true=block scheduling
+  size_t ll128ThresholdBytes{0}; // 0 = Simple-only; >0 = LL128 threshold
 
   // Construct with all defaults resolved from env vars / cvars.
   // Per-collective hints (if any) override those defaults.
+  // Note: LL128 enable/disable is controlled by NCCL_CTRAN_DA2A_LL128_THRESHOLD
+  // (0 = disabled, non-zero = enabled with that threshold in bytes).
+  // Per-collective opt-in/out via hints could be added in the future if needed.
   explicit CollectiveConfig(
       int nLocalRanks,
       const std::unordered_map<std::string, std::string>* hints_ptr = nullptr);

--- a/comms/ctran/algos/AllToAll/Types.h
+++ b/comms/ctran/algos/AllToAll/Types.h
@@ -14,6 +14,11 @@ struct Transport;
 
 #define CTRAN_MAX_TOTAL_RANK (128)
 
+// Compile-time protocol selection for DeviceAllToAllv kernel.
+// Simple: standard send/recv via NVLink staging buffers.
+// LL128: 128-byte cache-line-atomic packets with inline flag signaling.
+enum class PipeProtocol { Simple, LL128 };
+
 namespace ctran {
 
 namespace alltoall {
@@ -58,6 +63,11 @@ struct KernArgs {
   // all threads in a block to one peer; warp scheduling distributes
   // warps across peers for chunk-level pipelining.
   bool useBlockGroup;
+
+  // Per-peer byte threshold for LL128 vs Simple protocol selection.
+  // When > 0, use LL128 for transfers <= this size (if alignment is met),
+  // Simple otherwise. When 0, always use Simple.
+  size_t ll128ThresholdBytes;
 };
 
 } // namespace device_alltoallv_pipes

--- a/comms/ctran/tests/DeviceAllToAllvLl128Test.cc
+++ b/comms/ctran/tests/DeviceAllToAllvLl128Test.cc
@@ -1,0 +1,665 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#include <vector>
+
+#include <folly/init/Init.h>
+
+#include "comms/ctran/Ctran.h"
+#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/tests/CtranDistTestUtils.h"
+#include "comms/ctran/tests/CtranTestUtils.h"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+
+using namespace meta::comms;
+
+class DeviceAllToAllvLl128Environment : public ctran::CtranEnvironmentBase {
+ public:
+  void SetUp() override {
+    ctran::CtranEnvironmentBase::SetUp();
+    setenv("NCCL_CTRAN_USE_PIPES", "1", 1);
+    setenv("NCCL_CTRAN_ENABLE", "1", 1);
+    setenv("NCCL_CTRAN_DA2A_LL128_THRESHOLD", "262144", 1);
+    setenv("NCCL_CTRAN_PIPES_DISABLE_IB", "1", 1);
+    setenv("NCCL_CTRAN_ALLOW_CUDA_GRAPH", "1", 1);
+  }
+
+  void TearDown() override {
+    unsetenv("NCCL_CTRAN_USE_PIPES");
+    unsetenv("NCCL_CTRAN_ENABLE");
+    unsetenv("NCCL_CTRAN_DA2A_LL128_THRESHOLD");
+    unsetenv("NCCL_CTRAN_PIPES_DISABLE_IB");
+    unsetenv("NCCL_CTRAN_ALLOW_CUDA_GRAPH");
+    ctran::CtranEnvironmentBase::TearDown();
+  }
+};
+
+// RAII wrapper for paired device count arrays.
+// Note: CUDACHECK_TEST (ASSERT_*) in ctor records failure but doesn't throw;
+// members default to nullptr so destructor is safe on failure.
+struct DeviceCounts {
+  int64_t* send_d = nullptr;
+  int64_t* recv_d = nullptr;
+
+  DeviceCounts(
+      const std::vector<int64_t>& h_send,
+      const std::vector<int64_t>& h_recv) {
+    size_t n = h_send.size();
+    CUDACHECK_TEST(cudaMalloc(&send_d, n * sizeof(int64_t)));
+    CUDACHECK_TEST(cudaMalloc(&recv_d, n * sizeof(int64_t)));
+    CUDACHECK_TEST(cudaMemcpy(
+        send_d, h_send.data(), n * sizeof(int64_t), cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(cudaMemcpy(
+        recv_d, h_recv.data(), n * sizeof(int64_t), cudaMemcpyHostToDevice));
+  }
+
+  ~DeviceCounts() {
+    cudaFree(send_d);
+    cudaFree(recv_d);
+  }
+
+  DeviceCounts(const DeviceCounts&) = delete;
+  DeviceCounts& operator=(const DeviceCounts&) = delete;
+};
+
+class DeviceAllToAllvLl128Test : public ctran::CtranDistTestFixture {
+ public:
+  void SetUp() override {
+    CtranDistTestFixture::SetUp();
+    CUDACHECK_TEST(cudaStreamCreate(&stream_));
+    comm_ = makeCtranComm();
+    ASSERT_NE(comm_, nullptr);
+    ASSERT_NE(comm_->multiPeerTransport_, nullptr);
+    if (!ctranDeviceAllToAllvSupport(comm_.get())) {
+      GTEST_SKIP()
+          << "deviceAllToAllv not supported (requires all NVLink peers)";
+    }
+  }
+
+  void TearDown() override {
+    comm_.reset();
+    CUDACHECK_TEST(cudaStreamDestroy(stream_));
+    CtranDistTestFixture::TearDown();
+  }
+
+ protected:
+  void verify_uniform_recv(
+      float* recvBuf,
+      size_t totalSize,
+      size_t elementsPerPeer,
+      const std::string& prefix = "") {
+    std::vector<float> h_recv(totalSize);
+    CUDACHECK_TEST(cudaMemcpy(
+        h_recv.data(),
+        recvBuf,
+        totalSize * sizeof(float),
+        cudaMemcpyDeviceToHost));
+    for (int j = 0; j < numRanks; j++) {
+      for (size_t k = 0; k < elementsPerPeer; k++) {
+        EXPECT_EQ(h_recv[j * elementsPerPeer + k], static_cast<float>(j))
+            << prefix << "Rank " << globalRank << ": segment " << j
+            << " element " << k;
+      }
+    }
+  }
+
+  cudaStream_t stream_;
+  std::unique_ptr<CtranComm> comm_;
+};
+
+// Parameterized fixture: bool param = true for CUDA graph mode, false for
+// eager.
+class DeviceAllToAllvLl128ParamTest
+    : public DeviceAllToAllvLl128Test,
+      public ::testing::WithParamInterface<bool> {
+ protected:
+  bool useCudaGraph() const {
+    return GetParam();
+  }
+
+  // Run ctranDeviceAllToAllv either eagerly or via CUDA graph capture.
+  commResult_t runAllToAllv(
+      const void* sendBuf,
+      void* recvBuf,
+      const int64_t* sendcounts_d,
+      const int64_t* recvcounts_d,
+      commDataType_t datatype,
+      int64_t sendcountsMultiplier = 1,
+      int64_t recvcountsMultiplier = 1) {
+    if (!useCudaGraph()) {
+      auto result = ctranDeviceAllToAllv(
+          sendBuf,
+          recvBuf,
+          sendcounts_d,
+          recvcounts_d,
+          datatype,
+          comm_.get(),
+          stream_,
+          sendcountsMultiplier,
+          recvcountsMultiplier);
+      if (result != commSuccess) {
+        return result;
+      }
+      CUDACHECK_TEST(cudaStreamSynchronize(stream_));
+      return commSuccess;
+    }
+
+    // CUDA graph capture flow
+    cudaGraph_t graph;
+    cudaGraphExec_t instance;
+    CUDACHECK_TEST(
+        cudaStreamBeginCapture(stream_, cudaStreamCaptureModeGlobal));
+    auto result = ctranDeviceAllToAllv(
+        sendBuf,
+        recvBuf,
+        sendcounts_d,
+        recvcounts_d,
+        datatype,
+        comm_.get(),
+        stream_,
+        sendcountsMultiplier,
+        recvcountsMultiplier);
+    if (result != commSuccess) {
+      cudaGraph_t abandoned;
+      cudaStreamEndCapture(stream_, &abandoned);
+      return result;
+    }
+    CUDACHECK_TEST(cudaStreamEndCapture(stream_, &graph));
+    CUDACHECK_TEST(cudaGraphInstantiate(&instance, graph, nullptr, nullptr, 0));
+    CUDACHECK_TEST(cudaGraphLaunch(instance, stream_));
+    CUDACHECK_TEST(cudaStreamSynchronize(stream_));
+    CUDACHECK_TEST(cudaGraphExecDestroy(instance));
+    CUDACHECK_TEST(cudaGraphDestroy(graph));
+    return commSuccess;
+  }
+};
+
+// Uniform split: each rank sends/receives chunkSize elements to/from every peer
+TEST_P(DeviceAllToAllvLl128ParamTest, UniformSplitLl128) {
+  const int nRanks = numRanks;
+  // chunkSize must be multiple of 4 for float32 to satisfy LL128 16-byte
+  // alignment
+  const size_t chunkSize = 1024;
+  const size_t totalSize = chunkSize * nRanks;
+
+  float* sendBuf = nullptr;
+  float* recvBuf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&sendBuf, totalSize * sizeof(float)));
+  CUDACHECK_TEST(cudaMalloc(&recvBuf, totalSize * sizeof(float)));
+
+  std::vector<float> h_send(totalSize, static_cast<float>(globalRank));
+  CUDACHECK_TEST(cudaMemcpy(
+      sendBuf,
+      h_send.data(),
+      totalSize * sizeof(float),
+      cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(cudaMemset(recvBuf, 0, totalSize * sizeof(float)));
+
+  std::vector<int64_t> h_counts(nRanks, static_cast<int64_t>(chunkSize));
+  DeviceCounts counts(h_counts, h_counts);
+
+  auto result =
+      runAllToAllv(sendBuf, recvBuf, counts.send_d, counts.recv_d, commFloat);
+  ASSERT_EQ(result, commSuccess);
+
+  verify_uniform_recv(recvBuf, totalSize, chunkSize);
+
+  CUDACHECK_TEST(cudaFree(sendBuf));
+  CUDACHECK_TEST(cudaFree(recvBuf));
+}
+
+// Variable split: each rank sends different amounts per peer
+TEST_P(DeviceAllToAllvLl128ParamTest, VariableSplitLl128) {
+  const int nRanks = numRanks;
+  // Base chunk + rank * 64 — all counts are multiples of 4 (float32 alignment)
+  const size_t baseChunk = 256;
+  const size_t step = 64;
+
+  // Compute per-peer counts
+  std::vector<int64_t> h_sendcounts(nRanks);
+  std::vector<int64_t> h_recvcounts(nRanks);
+
+  size_t sendTotal = 0;
+  size_t recvTotal = 0;
+  for (int i = 0; i < nRanks; i++) {
+    // Each rank sends baseChunk + i * step elements to peer i
+    h_sendcounts[i] = static_cast<int64_t>(baseChunk + i * step);
+    sendTotal += h_sendcounts[i];
+
+    // This rank receives baseChunk + globalRank * step from peer i
+    // (peer i sends baseChunk + globalRank * step to us)
+    h_recvcounts[i] = static_cast<int64_t>(baseChunk + globalRank * step);
+    recvTotal += h_recvcounts[i];
+  }
+
+  float* sendBuf = nullptr;
+  float* recvBuf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&sendBuf, sendTotal * sizeof(float)));
+  CUDACHECK_TEST(cudaMalloc(&recvBuf, recvTotal * sizeof(float)));
+
+  // Fill send buffer: each element = globalRank
+  std::vector<float> h_send(sendTotal, static_cast<float>(globalRank));
+  CUDACHECK_TEST(cudaMemcpy(
+      sendBuf,
+      h_send.data(),
+      sendTotal * sizeof(float),
+      cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(cudaMemset(recvBuf, 0, recvTotal * sizeof(float)));
+
+  DeviceCounts counts(h_sendcounts, h_recvcounts);
+
+  auto result =
+      runAllToAllv(sendBuf, recvBuf, counts.send_d, counts.recv_d, commFloat);
+  ASSERT_EQ(result, commSuccess);
+
+  std::vector<float> h_recv(recvTotal);
+  CUDACHECK_TEST(cudaMemcpy(
+      h_recv.data(),
+      recvBuf,
+      recvTotal * sizeof(float),
+      cudaMemcpyDeviceToHost));
+
+  // Verify: segment from peer j should contain value j
+  // Compute recv displacements for verification
+  size_t recvOffset = 0;
+  for (int j = 0; j < nRanks; j++) {
+    size_t count = h_recvcounts[j];
+    for (size_t k = 0; k < count; k++) {
+      EXPECT_EQ(h_recv[recvOffset + k], static_cast<float>(j))
+          << "Rank " << globalRank << ": from peer " << j << " element " << k
+          << " expected " << j << " got " << h_recv[recvOffset + k];
+    }
+    recvOffset += count;
+  }
+
+  CUDACHECK_TEST(cudaFree(sendBuf));
+  CUDACHECK_TEST(cudaFree(recvBuf));
+}
+
+// Zero count peer: all cross-rank traffic is zero (self-copy only)
+TEST_P(DeviceAllToAllvLl128ParamTest, ZeroCountPeerLl128) {
+  const int nRanks = numRanks;
+  const size_t chunkSize = 1024;
+
+  // Each rank self-copies chunkSize; all cross-rank counts are zero
+  std::vector<int64_t> h_sendcounts(nRanks);
+  std::vector<int64_t> h_recvcounts(nRanks);
+
+  size_t sendTotal = 0;
+  size_t recvTotal = 0;
+  for (int i = 0; i < nRanks; i++) {
+    if (i == globalRank) {
+      h_sendcounts[i] = static_cast<int64_t>(chunkSize);
+      h_recvcounts[i] = static_cast<int64_t>(chunkSize);
+    } else {
+      h_sendcounts[i] = 0;
+      h_recvcounts[i] = 0;
+    }
+    sendTotal += h_sendcounts[i];
+    recvTotal += h_recvcounts[i];
+  }
+
+  // Need at least 1 byte allocated even if total is 0
+  size_t sendAllocSize = std::max(sendTotal, static_cast<size_t>(1));
+  size_t recvAllocSize = std::max(recvTotal, static_cast<size_t>(1));
+
+  float* sendBuf = nullptr;
+  float* recvBuf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&sendBuf, sendAllocSize * sizeof(float)));
+  CUDACHECK_TEST(cudaMalloc(&recvBuf, recvAllocSize * sizeof(float)));
+
+  std::vector<float> h_send(sendAllocSize, static_cast<float>(globalRank));
+  CUDACHECK_TEST(cudaMemcpy(
+      sendBuf,
+      h_send.data(),
+      sendAllocSize * sizeof(float),
+      cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(cudaMemset(recvBuf, 0, recvAllocSize * sizeof(float)));
+
+  DeviceCounts counts(h_sendcounts, h_recvcounts);
+
+  auto result =
+      runAllToAllv(sendBuf, recvBuf, counts.send_d, counts.recv_d, commFloat);
+  ASSERT_EQ(result, commSuccess);
+
+  std::vector<float> h_recv(recvAllocSize);
+  CUDACHECK_TEST(cudaMemcpy(
+      h_recv.data(),
+      recvBuf,
+      recvAllocSize * sizeof(float),
+      cudaMemcpyDeviceToHost));
+
+  // Verify: segment from peer j (j != 0) should contain value j
+  // Compute recv displacements for verification
+  size_t recvOffset = 0;
+  for (int j = 0; j < nRanks; j++) {
+    size_t count = h_recvcounts[j];
+    for (size_t k = 0; k < count; k++) {
+      EXPECT_EQ(h_recv[recvOffset + k], static_cast<float>(j))
+          << "Rank " << globalRank << ": from peer " << j << " element " << k
+          << " expected " << j << " got " << h_recv[recvOffset + k];
+    }
+    recvOffset += count;
+  }
+
+  CUDACHECK_TEST(cudaFree(sendBuf));
+  CUDACHECK_TEST(cudaFree(recvBuf));
+}
+
+// Multi-dimensional uniform split: split sizes are "row counts" (dim-0 slices),
+// and each row has numCols elements. The kernel multiplies counts by
+// sendcountsMultiplier/recvcountsMultiplier to get actual element counts.
+TEST_P(DeviceAllToAllvLl128ParamTest, UniformSplitLl128MultiDim) {
+  const int nRanks = numRanks;
+  const size_t chunkRows = 1024; // rows per peer
+  const size_t numCols = 4; // elements per row (must keep 16-byte alignment)
+  const size_t totalRows = chunkRows * nRanks;
+  const size_t totalElements = totalRows * numCols;
+
+  float* sendBuf = nullptr;
+  float* recvBuf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&sendBuf, totalElements * sizeof(float)));
+  CUDACHECK_TEST(cudaMalloc(&recvBuf, totalElements * sizeof(float)));
+
+  std::vector<float> h_send(totalElements, static_cast<float>(globalRank));
+  CUDACHECK_TEST(cudaMemcpy(
+      sendBuf,
+      h_send.data(),
+      totalElements * sizeof(float),
+      cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(cudaMemset(recvBuf, 0, totalElements * sizeof(float)));
+
+  // Split sizes are ROW counts, not element counts
+  std::vector<int64_t> h_counts(nRanks, static_cast<int64_t>(chunkRows));
+  DeviceCounts counts(h_counts, h_counts);
+
+  // Pass scalingFactor = numCols to convert row counts to element counts
+  auto result = runAllToAllv(
+      sendBuf,
+      recvBuf,
+      counts.send_d,
+      counts.recv_d,
+      commFloat,
+      static_cast<int64_t>(numCols),
+      static_cast<int64_t>(numCols));
+  ASSERT_EQ(result, commSuccess);
+
+  verify_uniform_recv(recvBuf, totalElements, chunkRows * numCols);
+
+  CUDACHECK_TEST(cudaFree(sendBuf));
+  CUDACHECK_TEST(cudaFree(recvBuf));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    DeviceAllToAllvLl128,
+    DeviceAllToAllvLl128ParamTest,
+    ::testing::Bool(),
+    [](const ::testing::TestParamInfo<bool>& info) {
+      return info.param ? "CudaGraph" : "Eager";
+    });
+
+// Mixed protocol: set a low threshold so small per-peer transfers use LL128
+// and large transfers fall back to Simple within the same collective.
+TEST_F(DeviceAllToAllvLl128Test, MixedProtocolLl128Simple) {
+  const int nRanks = numRanks;
+  if (nRanks < 2) {
+    GTEST_SKIP() << "Mixed protocol test requires at least 2 ranks";
+  }
+
+  // Set threshold to 2KB — peers with <= 2KB use LL128, others use Simple
+  EnvRAII thresholdOverride(NCCL_CTRAN_DA2A_LL128_THRESHOLD, (int64_t)2048);
+
+  // Variable sizes: peer 0 gets 256 elements (1KB), others get 4096 (16KB)
+  // This ensures at least one peer is below threshold and at least one is
+  // above.
+  std::vector<int64_t> h_sendcounts(nRanks);
+  std::vector<int64_t> h_recvcounts(nRanks);
+  size_t sendTotal = 0, recvTotal = 0;
+
+  for (int i = 0; i < nRanks; i++) {
+    // Counts must be multiples of 4 (float32 × 4 = 16 bytes alignment)
+    h_sendcounts[i] = (i == 0) ? 256 : 4096;
+    h_recvcounts[i] = (globalRank == 0) ? 256 : 4096;
+    sendTotal += h_sendcounts[i];
+    recvTotal += h_recvcounts[i];
+  }
+
+  float* sendBuf = nullptr;
+  float* recvBuf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&sendBuf, sendTotal * sizeof(float)));
+  CUDACHECK_TEST(cudaMalloc(&recvBuf, recvTotal * sizeof(float)));
+
+  std::vector<float> h_send(sendTotal, static_cast<float>(globalRank));
+  CUDACHECK_TEST(cudaMemcpy(
+      sendBuf,
+      h_send.data(),
+      sendTotal * sizeof(float),
+      cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(cudaMemset(recvBuf, 0, recvTotal * sizeof(float)));
+
+  DeviceCounts counts(h_sendcounts, h_recvcounts);
+
+  auto result = ctranDeviceAllToAllv(
+      sendBuf,
+      recvBuf,
+      counts.send_d,
+      counts.recv_d,
+      commFloat,
+      comm_.get(),
+      stream_);
+  ASSERT_EQ(result, commSuccess);
+  CUDACHECK_TEST(cudaStreamSynchronize(stream_));
+
+  // Verify correctness
+  std::vector<float> h_recv(recvTotal);
+  CUDACHECK_TEST(cudaMemcpy(
+      h_recv.data(),
+      recvBuf,
+      recvTotal * sizeof(float),
+      cudaMemcpyDeviceToHost));
+
+  size_t recvOffset = 0;
+  for (int j = 0; j < nRanks; j++) {
+    size_t count = h_recvcounts[j];
+    for (size_t k = 0; k < count; k++) {
+      EXPECT_EQ(h_recv[recvOffset + k], static_cast<float>(j))
+          << "Rank " << globalRank << ": from peer " << j << " element " << k;
+    }
+    recvOffset += count;
+  }
+
+  CUDACHECK_TEST(cudaFree(sendBuf));
+  CUDACHECK_TEST(cudaFree(recvBuf));
+}
+
+// Threshold=0: forces Simple protocol for all peers (LL128 disabled).
+TEST_F(DeviceAllToAllvLl128Test, ThresholdZeroForcesSimple) {
+  EnvRAII thresholdOverride(NCCL_CTRAN_DA2A_LL128_THRESHOLD, (int64_t)0);
+
+  const int nRanks = numRanks;
+  const size_t chunkSize = 256;
+  const size_t totalSize = chunkSize * nRanks;
+
+  float* sendBuf = nullptr;
+  float* recvBuf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&sendBuf, totalSize * sizeof(float)));
+  CUDACHECK_TEST(cudaMalloc(&recvBuf, totalSize * sizeof(float)));
+
+  std::vector<float> h_send(totalSize, static_cast<float>(globalRank));
+  CUDACHECK_TEST(cudaMemcpy(
+      sendBuf,
+      h_send.data(),
+      totalSize * sizeof(float),
+      cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(cudaMemset(recvBuf, 0, totalSize * sizeof(float)));
+
+  std::vector<int64_t> h_counts(nRanks, static_cast<int64_t>(chunkSize));
+  DeviceCounts counts(h_counts, h_counts);
+
+  auto result = ctranDeviceAllToAllv(
+      sendBuf,
+      recvBuf,
+      counts.send_d,
+      counts.recv_d,
+      commFloat,
+      comm_.get(),
+      stream_);
+  ASSERT_EQ(result, commSuccess);
+  CUDACHECK_TEST(cudaStreamSynchronize(stream_));
+
+  verify_uniform_recv(recvBuf, totalSize, chunkSize);
+
+  CUDACHECK_TEST(cudaFree(sendBuf));
+  CUDACHECK_TEST(cudaFree(recvBuf));
+}
+
+// Advanced graph tests: multi-replay and changed-data verify graph correctness
+// beyond basic capture/launch. Kept as TEST_F since they test specific graph
+// behaviors that don't map to the eager/graph parameterization.
+TEST_F(DeviceAllToAllvLl128Test, CudaGraphMultiReplay) {
+  const int nRanks = numRanks;
+  const size_t chunkSize = 1024;
+  const size_t totalSize = chunkSize * nRanks;
+
+  float* sendBuf = nullptr;
+  float* recvBuf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&sendBuf, totalSize * sizeof(float)));
+  CUDACHECK_TEST(cudaMalloc(&recvBuf, totalSize * sizeof(float)));
+
+  std::vector<float> h_send(totalSize, static_cast<float>(globalRank));
+  CUDACHECK_TEST(cudaMemcpy(
+      sendBuf,
+      h_send.data(),
+      totalSize * sizeof(float),
+      cudaMemcpyHostToDevice));
+
+  std::vector<int64_t> h_counts(nRanks, static_cast<int64_t>(chunkSize));
+  DeviceCounts counts(h_counts, h_counts);
+
+  cudaStream_t cudagraph_stream;
+  CUDACHECK_TEST(cudaStreamCreate(&cudagraph_stream));
+
+  cudaGraph_t graph;
+  cudaGraphExec_t instance;
+  CUDACHECK_TEST(
+      cudaStreamBeginCapture(cudagraph_stream, cudaStreamCaptureModeGlobal));
+  auto result = ctranDeviceAllToAllv(
+      sendBuf,
+      recvBuf,
+      counts.send_d,
+      counts.recv_d,
+      commFloat,
+      comm_.get(),
+      cudagraph_stream);
+  ASSERT_EQ(result, commSuccess);
+  CUDACHECK_TEST(cudaStreamEndCapture(cudagraph_stream, &graph));
+  CUDACHECK_TEST(cudaGraphInstantiate(&instance, graph, nullptr, nullptr, 0));
+
+  // Replay 5 times, verify each time
+  constexpr int numIters = 5;
+  for (int iter = 0; iter < numIters; iter++) {
+    CUDACHECK_TEST(cudaMemsetAsync(
+        recvBuf, 0, totalSize * sizeof(float), cudagraph_stream));
+    CUDACHECK_TEST(cudaGraphLaunch(instance, cudagraph_stream));
+    CUDACHECK_TEST(cudaStreamSynchronize(cudagraph_stream));
+
+    std::string prefix = "Iter " + std::to_string(iter) + " ";
+    verify_uniform_recv(recvBuf, totalSize, chunkSize, prefix);
+  }
+
+  CUDACHECK_TEST(cudaGraphExecDestroy(instance));
+  CUDACHECK_TEST(cudaGraphDestroy(graph));
+  CUDACHECK_TEST(cudaStreamDestroy(cudagraph_stream));
+  CUDACHECK_TEST(cudaFree(sendBuf));
+  CUDACHECK_TEST(cudaFree(recvBuf));
+}
+
+TEST_F(DeviceAllToAllvLl128Test, CudaGraphChangedData) {
+  const int nRanks = numRanks;
+  const size_t chunkSize = 1024;
+  const size_t totalSize = chunkSize * nRanks;
+
+  float* sendBuf = nullptr;
+  float* recvBuf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&sendBuf, totalSize * sizeof(float)));
+  CUDACHECK_TEST(cudaMalloc(&recvBuf, totalSize * sizeof(float)));
+
+  std::vector<int64_t> h_counts(nRanks, static_cast<int64_t>(chunkSize));
+  DeviceCounts counts(h_counts, h_counts);
+
+  // Fill initial data for capture
+  std::vector<float> h_send(totalSize, static_cast<float>(globalRank));
+  CUDACHECK_TEST(cudaMemcpy(
+      sendBuf,
+      h_send.data(),
+      totalSize * sizeof(float),
+      cudaMemcpyHostToDevice));
+
+  cudaStream_t cudagraph_stream;
+  CUDACHECK_TEST(cudaStreamCreate(&cudagraph_stream));
+
+  cudaGraph_t graph;
+  cudaGraphExec_t instance;
+  CUDACHECK_TEST(
+      cudaStreamBeginCapture(cudagraph_stream, cudaStreamCaptureModeGlobal));
+  auto result = ctranDeviceAllToAllv(
+      sendBuf,
+      recvBuf,
+      counts.send_d,
+      counts.recv_d,
+      commFloat,
+      comm_.get(),
+      cudagraph_stream);
+  ASSERT_EQ(result, commSuccess);
+  CUDACHECK_TEST(cudaStreamEndCapture(cudagraph_stream, &graph));
+  CUDACHECK_TEST(cudaGraphInstantiate(&instance, graph, nullptr, nullptr, 0));
+
+  // Replay with different send data each iteration
+  constexpr int numIters = 3;
+  for (int iter = 0; iter < numIters; iter++) {
+    float fillVal = static_cast<float>(globalRank * 100 + iter);
+    std::vector<float> h_data(totalSize, fillVal);
+    // Use async memcpy on the graph stream to avoid ordering issues
+    CUDACHECK_TEST(cudaMemcpyAsync(
+        sendBuf,
+        h_data.data(),
+        totalSize * sizeof(float),
+        cudaMemcpyHostToDevice,
+        cudagraph_stream));
+    CUDACHECK_TEST(cudaMemsetAsync(
+        recvBuf, 0, totalSize * sizeof(float), cudagraph_stream));
+    CUDACHECK_TEST(cudaGraphLaunch(instance, cudagraph_stream));
+    CUDACHECK_TEST(cudaStreamSynchronize(cudagraph_stream));
+
+    std::vector<float> h_recv(totalSize);
+    CUDACHECK_TEST(cudaMemcpy(
+        h_recv.data(),
+        recvBuf,
+        totalSize * sizeof(float),
+        cudaMemcpyDeviceToHost));
+    for (int j = 0; j < nRanks; j++) {
+      float expected = static_cast<float>(j * 100 + iter);
+      for (size_t k = 0; k < chunkSize; k++) {
+        EXPECT_EQ(h_recv[j * chunkSize + k], expected)
+            << "Iter " << iter << " Rank " << globalRank << ": segment " << j
+            << " element " << k << " expected " << expected;
+      }
+    }
+  }
+
+  CUDACHECK_TEST(cudaGraphExecDestroy(instance));
+  CUDACHECK_TEST(cudaGraphDestroy(graph));
+  CUDACHECK_TEST(cudaStreamDestroy(cudagraph_stream));
+  CUDACHECK_TEST(cudaFree(sendBuf));
+  CUDACHECK_TEST(cudaFree(recvBuf));
+}
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new DeviceAllToAllvLl128Environment);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/pipes/collectives/AllToAllvLl128.h
+++ b/comms/pipes/collectives/AllToAllvLl128.h
@@ -6,6 +6,7 @@
 #include <chrono>
 
 #include "comms/pipes/collectives/AllToAllvLl128.cuh"
+#include "comms/pipes/ll128/Ll128AutoTune.cuh"
 
 namespace comms::pipes {
 
@@ -49,7 +50,7 @@ void all_to_allv_ll128(
     std::chrono::milliseconds timeout = std::chrono::milliseconds{0},
     cudaStream_t stream = nullptr,
     int num_blocks = 16,
-    int num_threads = 512);
+    int num_threads = kLl128ThreadsPerBlock);
 
 /**
  * Host wrapper for AllToAllv LL128 with pre-built Timeout.
@@ -81,6 +82,6 @@ void all_to_allv_ll128(
     Timeout timeout_config,
     cudaStream_t stream = nullptr,
     int num_blocks = 16,
-    int num_threads = 512);
+    int num_threads = kLl128ThreadsPerBlock);
 
 } // namespace comms::pipes

--- a/comms/pipes/collectives/benchmarks/AllToAllvLl128Benchmark.cc
+++ b/comms/pipes/collectives/benchmarks/AllToAllvLl128Benchmark.cc
@@ -17,6 +17,8 @@
 #include "comms/testinfra/TestXPlatUtils.h"
 #include "comms/utils/CudaRAII.h"
 
+#include <cstdlib>
+#include <fstream>
 #include <iomanip>
 #include <sstream>
 #include <vector>
@@ -95,6 +97,50 @@ class AllToAllvLl128BenchmarkFixture
     return id;
   }
 
+  void run_global_warmup() {
+    // --- Global warmup: trigger NCCL connection setup and GPU clock ramp ---
+    {
+      constexpr int kGlobalWarmupIters = 10;
+      constexpr std::size_t kWarmupBytes = 16 * 1024; // 16KB per peer
+      const std::size_t totalWarmupBytes = kWarmupBytes * worldSize;
+
+      DeviceBuffer warmupSend(totalWarmupBytes);
+      DeviceBuffer warmupRecv(totalWarmupBytes);
+      CUDA_CHECK_VOID(cudaMemset(warmupSend.get(), 1, totalWarmupBytes));
+      CUDA_CHECK_VOID(cudaMemset(warmupRecv.get(), 0, totalWarmupBytes));
+
+      std::vector<size_t> sendcounts(worldSize, kWarmupBytes);
+      std::vector<size_t> recvcounts(worldSize, kWarmupBytes);
+      std::vector<size_t> sdispls(worldSize);
+      std::vector<size_t> rdispls(worldSize);
+      for (int i = 0; i < worldSize; i++) {
+        sdispls[i] = i * kWarmupBytes;
+        rdispls[i] = i * kWarmupBytes;
+      }
+
+      bootstrap->barrierAll();
+      for (int i = 0; i < kGlobalWarmupIters; i++) {
+        NCCL_CHECK_VOID(ncclAllToAllv(
+            warmupSend.get(),
+            sendcounts.data(),
+            sdispls.data(),
+            warmupRecv.get(),
+            recvcounts.data(),
+            rdispls.data(),
+            ncclChar,
+            ncclComm_,
+            stream_));
+      }
+      CUDA_CHECK_VOID(cudaStreamSynchronize(stream_));
+      bootstrap->barrierAll();
+
+      if (globalRank == 0) {
+        XLOG(INFO) << "Global warmup complete (" << kGlobalWarmupIters
+                   << " NCCL iterations at 16KB/peer)";
+      }
+    }
+  }
+
   float run_nccl_benchmark(
       const Ll128BenchmarkConfig& config,
       float& latency_us) {
@@ -118,7 +164,7 @@ class AllToAllvLl128BenchmarkFixture
 
     CudaEvent start, stop;
     constexpr int kNIter = 100;
-    constexpr int kNWarmup = 5;
+    constexpr int kNWarmup = 10;
 
     bootstrap->barrierAll();
     for (int i = 0; i < kNWarmup; i++) {
@@ -133,6 +179,8 @@ class AllToAllvLl128BenchmarkFixture
           ncclComm_,
           stream_));
     }
+    CUDA_CHECK(cudaStreamSynchronize(stream_));
+    bootstrap->barrierAll();
 
     CUDA_CHECK(cudaEventRecord(start.get(), stream_));
     for (int i = 0; i < kNIter; i++) {
@@ -148,7 +196,7 @@ class AllToAllvLl128BenchmarkFixture
           stream_));
     }
     CUDA_CHECK(cudaEventRecord(stop.get(), stream_));
-    CUDA_CHECK(cudaStreamSynchronize(stream_));
+    CUDA_CHECK(cudaDeviceSynchronize());
 
     float totalTime_ms = 0.0f;
     CUDA_CHECK(cudaEventElapsedTime(&totalTime_ms, start.get(), stop.get()));
@@ -223,7 +271,7 @@ class AllToAllvLl128BenchmarkFixture
 
     CudaEvent start, stop;
     constexpr int kNIter = 100;
-    constexpr int kNWarmup = 5;
+    constexpr int kNWarmup = 10;
 
     bootstrap->barrierAll();
     for (int i = 0; i < kNWarmup; i++) {
@@ -240,6 +288,8 @@ class AllToAllvLl128BenchmarkFixture
           config.simpleNumThreads,
           clusterDimOpt);
     }
+    CUDA_CHECK(cudaDeviceSynchronize());
+    bootstrap->barrierAll();
 
     CUDA_CHECK(cudaEventRecord(start.get()));
     for (int i = 0; i < kNIter; i++) {
@@ -322,13 +372,13 @@ class AllToAllvLl128BenchmarkFixture
 
     CudaEvent start, stop;
     constexpr int kNIter = 100;
-    constexpr int kNWarmup = 5;
+    constexpr int kNWarmup = 10;
 
     // Create timeout ONCE outside the loop to avoid per-call
     // cudaGetDevice/cudaDeviceGetAttribute overhead.
     int device = 0;
     CUDA_CHECK(cudaGetDevice(&device));
-    Timeout timeout_config = makeTimeout(30000, device);
+    Timeout timeout_config = makeTimeout(5000, device);
 
     // Warmup: per-iteration sync to ensure each iteration completes
     bootstrap->barrierAll();
@@ -345,6 +395,10 @@ class AllToAllvLl128BenchmarkFixture
           config.ll128NumBlocks,
           config.ll128NumThreads);
     }
+    CUDA_CHECK(cudaDeviceSynchronize());
+    // Barrier ensures all ranks start timed iterations together after warmup.
+    // cudaDeviceSynchronize() only syncs the local GPU, not cross-rank.
+    bootstrap->barrierAll();
 
     // Timed loop
     CUDA_CHECK(cudaEventRecord(start.get()));
@@ -364,7 +418,7 @@ class AllToAllvLl128BenchmarkFixture
           config.ll128NumThreads);
     }
     CUDA_CHECK(cudaEventRecord(stop.get()));
-    CUDACHECK_TEST(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaDeviceSynchronize());
 
     float totalTime_ms = 0.0f;
     CUDA_CHECK(cudaEventElapsedTime(&totalTime_ms, start.get(), stop.get()));
@@ -591,6 +645,8 @@ TEST_F(AllToAllvLl128BenchmarkFixture, Ll128VsSimpleVsNccl) {
       .name = "1MB",
   });
 
+  run_global_warmup();
+
   std::vector<Ll128BenchmarkResult> results;
 
   for (const auto& config : configs) {
@@ -620,6 +676,189 @@ TEST_F(AllToAllvLl128BenchmarkFixture, Ll128VsSimpleVsNccl) {
   }
 
   print_results_table(results);
+}
+
+TEST_F(AllToAllvLl128BenchmarkFixture, LatencySweep) {
+  if (globalRank == 0) {
+    XLOG(INFO)
+        << "\n=== LL128 vs Simple vs NCCL Latency Sweep (for Triton comparison) ===\n";
+  }
+
+  const std::size_t kDataBufferSize = 8 * 1024 * 1024; // 8MB
+
+  auto auto_ll128_blocks = [&](std::size_t bytesPerPeer) {
+    return ll128_auto_tune_alltoallv(bytesPerPeer, worldSize).numBlocks;
+  };
+
+  // Sizes where LL128 is expected to compete (run all three protocols)
+  struct SizeConfig {
+    std::size_t bytesPerPeer;
+    int simpleNumBlocks;
+    std::size_t chunkSize;
+    bool runLl128;
+    bool simpleSpreadCluster;
+    std::string name;
+  };
+
+  std::vector<SizeConfig> sizes = {
+      // Small sizes: cluster OFF to reduce launch overhead
+      {4 * 1024, 8, 64 * 1024, true, false, "4KB"},
+      {16 * 1024, 8, 64 * 1024, true, false, "16KB"},
+      {64 * 1024, 8, 64 * 1024, true, false, "64KB"},
+      {128 * 1024, 8, 64 * 1024, true, false, "128KB"},
+      // Medium+ sizes: cluster ON (amortized by data volume)
+      {256 * 1024, 8, 64 * 1024, true, true, "256KB"},
+      {512 * 1024, 16, 64 * 1024, true, true, "512KB"},
+      {1024 * 1024, 16, 64 * 1024, true, true, "1MB"},
+      // Large sizes: NCCL+Simple only
+      {2 * 1024 * 1024, 16, 128 * 1024, false, true, "2MB"},
+      {4 * 1024 * 1024, 16, 128 * 1024, false, true, "4MB"},
+      {8 * 1024 * 1024, 16, 128 * 1024, false, true, "8MB"},
+      {16 * 1024 * 1024, 16, 128 * 1024, false, true, "16MB"},
+      {32 * 1024 * 1024, 16, 128 * 1024, false, true, "32MB"},
+  };
+
+  struct LatencySweepResult {
+    std::string name;
+    std::size_t bytesPerPeer;
+    float ncclLatency;
+    float simpleLatency;
+    float ll128Latency; // -1 if not run
+  };
+
+  run_global_warmup();
+
+  std::vector<LatencySweepResult> results;
+
+  for (const auto& sz : sizes) {
+    Ll128BenchmarkConfig config{
+        .bytesPerPeer = sz.bytesPerPeer,
+        .simpleNumBlocks = sz.simpleNumBlocks,
+        .simpleNumThreads = 512,
+        .simpleSpreadCluster = sz.simpleSpreadCluster,
+        .pipelineDepth = 2,
+        .chunkSize = sz.chunkSize,
+        .dataBufferSize = kDataBufferSize,
+        .ll128NumBlocks = sz.runLl128 ? auto_ll128_blocks(sz.bytesPerPeer) : 1,
+        .ll128NumThreads = 512,
+        .name = sz.name,
+    };
+
+    float ncclLatency = 0.0f;
+    run_nccl_benchmark(config, ncclLatency);
+
+    float simpleLatency = 0.0f;
+    run_simple_benchmark(config, simpleLatency);
+
+    float ll128Latency = -1.0f;
+    if (sz.runLl128) {
+      run_ll128_benchmark(config, ll128Latency);
+    }
+
+    if (globalRank == 0) {
+      results.push_back({
+          .name = sz.name,
+          .bytesPerPeer = sz.bytesPerPeer,
+          .ncclLatency = ncclLatency,
+          .simpleLatency = simpleLatency,
+          .ll128Latency = ll128Latency,
+      });
+    }
+
+    bootstrap->barrierAll();
+  }
+
+  // Print latency-focused table
+  if (globalRank == 0) {
+    auto format_bytes = [](std::size_t bytes) -> std::string {
+      if (bytes < 1024) {
+        return std::to_string(bytes) + "B";
+      }
+      if (bytes < 1024 * 1024) {
+        return std::to_string(bytes / 1024) + "KB";
+      }
+      return std::to_string(bytes / (1024 * 1024)) + "MB";
+    };
+
+    std::stringstream ss;
+    ss << "\n";
+    ss << std::string(90, '=') << "\n";
+    ss << "  LL128 vs Simple vs NCCL Latency Sweep (" << worldSize
+       << " ranks)\n";
+    ss << std::string(90, '=') << "\n";
+    ss << std::left << std::setw(12) << "Per-peer" << std::right
+       << std::setw(14) << "NCCL (us)" << std::right << std::setw(14)
+       << "Simple (us)" << std::right << std::setw(14) << "LL128 (us)"
+       << std::right << std::setw(14) << "LL128/NCCL" << std::right
+       << std::setw(14) << "LL128/Simple"
+       << "\n";
+    ss << std::string(90, '-') << "\n";
+
+    for (const auto& r : results) {
+      ss << std::left << std::setw(12) << format_bytes(r.bytesPerPeer)
+         << std::right << std::setw(14) << std::fixed << std::setprecision(1)
+         << r.ncclLatency << std::right << std::setw(14) << std::fixed
+         << std::setprecision(1) << r.simpleLatency;
+
+      if (r.ll128Latency >= 0) {
+        float ll128VsNccl =
+            r.ncclLatency > 0 ? r.ncclLatency / r.ll128Latency : 0;
+        float ll128VsSimple =
+            r.simpleLatency > 0 ? r.simpleLatency / r.ll128Latency : 0;
+        ss << std::right << std::setw(14) << std::fixed << std::setprecision(1)
+           << r.ll128Latency << std::right << std::setw(13) << std::fixed
+           << std::setprecision(2) << ll128VsNccl << "x" << std::right
+           << std::setw(13) << std::fixed << std::setprecision(2)
+           << ll128VsSimple << "x";
+      } else {
+        ss << std::right << std::setw(14) << "N/A" << std::right
+           << std::setw(14) << "N/A" << std::right << std::setw(14) << "N/A";
+      }
+      ss << "\n";
+    }
+
+    ss << std::string(90, '=') << "\n";
+    ss << "LL128/NCCL and LL128/Simple are speedup ratios (higher is better)\n";
+    ss << std::string(90, '=') << "\n";
+
+    XLOG(INFO) << ss.str();
+
+    // CSV output to file if BENCH_CSV_OUTPUT is set
+    const char* csvPath = std::getenv("BENCH_CSV_OUTPUT");
+    if (csvPath != nullptr) {
+      std::ofstream csvFile(csvPath);
+      if (csvFile.is_open()) {
+        csvFile << "per_peer_bytes,nccl_us,simple_us,ll128_us\n";
+        for (const auto& r : results) {
+          csvFile << r.bytesPerPeer << "," << std::fixed << std::setprecision(3)
+                  << r.ncclLatency << "," << r.simpleLatency << ",";
+          if (r.ll128Latency >= 0) {
+            csvFile << r.ll128Latency;
+          }
+          csvFile << "\n";
+        }
+        csvFile.close();
+        XLOG(INFO) << "CSV results written to: " << csvPath;
+      } else {
+        XLOG(ERR) << "Failed to open CSV output file: " << csvPath;
+      }
+    }
+
+    // Always print CSV to log output for easy extraction from buck2 test
+    ss.str("");
+    ss << "\n--- CSV START ---\n";
+    ss << "per_peer_bytes,nccl_us,simple_us,ll128_us\n";
+    for (const auto& r : results) {
+      ss << r.bytesPerPeer << "," << std::fixed << std::setprecision(3)
+         << r.ncclLatency << "," << r.simpleLatency << ",";
+      if (r.ll128Latency >= 0) {
+        ss << r.ll128Latency;
+      }
+      ss << "\n";
+    }
+    ss << "--- CSV END ---";
+    XLOG(INFO) << ss.str();
+  }
 }
 
 TEST_F(AllToAllvLl128BenchmarkFixture, Ll128BlockThreadSweep) {

--- a/comms/pipes/ll128/Ll128AutoTune.cuh
+++ b/comms/pipes/ll128/Ll128AutoTune.cuh
@@ -6,6 +6,9 @@
 
 namespace comms::pipes {
 
+/// Number of threads per block for LL128 kernels (16 warps/block).
+constexpr int kLl128ThreadsPerBlock = 512;
+
 /// Recommended launch configuration for LL128 kernels.
 struct Ll128LaunchConfig {
   int numBlocks;
@@ -34,7 +37,7 @@ inline __host__ __device__ Ll128LaunchConfig ll128_auto_tune(size_t nbytes) {
     return {0, 0}; // No kernel launch needed.
   }
 
-  // All configs use 512 threads (16 warps/block).
+  // All configs use kLl128ThreadsPerBlock threads (16 warps/block).
   //
   // Target: ~2-4 packets/warp.
   //   packets = ceil(nbytes / 120)
@@ -45,7 +48,7 @@ inline __host__ __device__ Ll128LaunchConfig ll128_auto_tune(size_t nbytes) {
   // just past the "knee" of the scaling curve (i.e., the point where adding
   // more blocks yields <5% additional bandwidth).
 
-  constexpr int kThreads = 512;
+  constexpr int kThreads = kLl128ThreadsPerBlock;
 
   if (nbytes <= 2 * 1024) {
     // 64B-2KB: 1 block, 16 warps.
@@ -148,7 +151,7 @@ ll128_auto_tune_alltoallv(size_t nbytes_per_peer, int nranks) {
     return {0, 0};
   }
 
-  constexpr int kThreads = 512;
+  constexpr int kThreads = kLl128ThreadsPerBlock;
 
   // Empirical lookup table for 8 ranks (from block-count sweep benchmarks).
   // Each entry is the block count at or near the knee of the scaling curve.

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3365,3 +3365,27 @@ cvars:
      arguments are checked symmetrically across all ranks to detect mismatched
      buffer addresses, counts, or operation types. Possible values: ""
      (default/disabled), "DEBUG_LOCAL", "DEBUG_GLOBAL".
+
+ - name        : NCCL_CTRAN_DA2A_LL128_BUFFER_SIZE
+   type        : int64_t
+   default     : 0
+   description : |-
+     Per-peer LL128 buffer size in bytes for DeviceAllToAllv. When set to 0
+     (default), the buffer size is auto-computed from a 256KB default using
+     ll128_buffer_size(256 * 1024). Override for workloads with known larger
+     per-peer message sizes. Only takes effect when
+     NCCL_CTRAN_DA2A_LL128_THRESHOLD is non-zero.
+
+ - name        : NCCL_CTRAN_DA2A_LL128_THRESHOLD
+   type        : int64_t
+   default     : 0
+   description : |-
+     Per-peer byte threshold for LL128 protocol selection in DeviceAllToAllv.
+     When non-zero, LL128 buffers are allocated at init time and the kernel
+     uses LL128 for per-peer transfers <= this many bytes (and meeting 16-byte
+     alignment), with Simple (send/recv) fallback for larger or misaligned
+     transfers. When 0 (default), LL128 is disabled and only Simple protocol
+     is used. Set to 262144 (256KB) to enable LL128 for typical workloads.
+     LL128 uses 128-byte cache-line-atomic packets with inline flag signaling,
+     providing better performance for small/medium messages. Requires per-peer
+     byte counts (count * elementSize) to be multiples of 16.


### PR DESCRIPTION
Summary:

Add LL128 (128-byte cache-line-atomic packet) protocol support to the Ctran `DeviceAllToAllvPipes` path. LL128 provides significantly better performance for small/medium messages (up to ~256KB per peer, benchmarked at 1.36x over NCCL) by using inline flag signaling instead of chunked NVLink pipelining.

**Changes:**
- Add CVAR `NCCL_CTRAN_DA2A_LL128_BUFFER_SIZE` (int64_t, default 0 = auto 256KB)
- Allocate LL128 buffers in `ctranInitializePipes()` when enabled
- Add `DeviceAllToAllvPipesLl128.cu` kernel using `ll128_send()`/`ll128_recv()` with warp-level scheduling, 512 threads, and auto-tuned block count
- Add kernel selection in `ctranDeviceAllToAllv()` based on CVAR
- Parameterize `setupKernelConfig()` with `useLl128` for grid/block branching
- Add `ll128_auto_tune` build dep for block count auto-tuning
- Add test file with 5 test cases: `UniformSplit`, `VariableSplit`, `ZeroCountPeer`, `CudaGraph`, and `CudaGraphMultiReplay`

The host API and IB path remain unchanged; only the kernel selection changes when the CVAR is enabled.

Reviewed By: siyengar

Differential Revision: D97361892
