### PR TITLE
add util for graph replay address introspection (#1188)

### DIFF
--- a/comms/torchcomms/tests/helpers/cpp/cuda_graph_utils.cpp
+++ b/comms/torchcomms/tests/helpers/cpp/cuda_graph_utils.cpp
@@ -1,0 +1,44 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+// Defined in write_addr_kernel.cu
+void launchWriteAddr(const void* buf, int64_t* probe, cudaStream_t stream);
+
+namespace py = pybind11;
+
+namespace {
+
+/// Launch a kernel that writes &buf into probe[0].
+/// buf_ptr and probe_ptr are device pointers (from tensor.data_ptr()).
+/// stream_ptr is a cudaStream_t (from torch.cuda.current_stream().cuda_stream).
+void writeAddr(uintptr_t buf_ptr, uintptr_t probe_ptr, uintptr_t stream_ptr) {
+  launchWriteAddr(
+      reinterpret_cast<const void*>( // NOLINT(performance-no-int-to-ptr)
+          buf_ptr),
+      reinterpret_cast<int64_t*>( // NOLINT(performance-no-int-to-ptr)
+          probe_ptr),
+      reinterpret_cast<cudaStream_t>( // NOLINT(performance-no-int-to-ptr)
+          stream_ptr));
+  auto err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("writeAddr kernel launch failed: ") +
+        cudaGetErrorString(err));
+  }
+}
+
+} // namespace
+
+PYBIND11_MODULE(cuda_graph_utils, m) {
+  m.def(
+      "write_addr",
+      &writeAddr,
+      py::arg("buf_ptr"),
+      py::arg("probe_ptr"),
+      py::arg("stream_ptr"),
+      "Launch a kernel that writes the address of buf into probe[0].\n"
+      "All arguments are raw device pointers (int from tensor.data_ptr()).");
+}

--- a/comms/torchcomms/tests/helpers/cu/write_addr_kernel.cu
+++ b/comms/torchcomms/tests/helpers/cu/write_addr_kernel.cu
@@ -1,0 +1,12 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <cstdint>
+
+__global__ void writeAddrKernel(const void* buf, int64_t* probe) {
+  probe[0] = reinterpret_cast<int64_t>(buf);
+}
+
+void launchWriteAddr(const void* buf, int64_t* probe, cudaStream_t stream) {
+  writeAddrKernel<<<1, 1, 0, stream>>>(buf, probe);
+}

--- a/comms/torchcomms/tests/helpers/py/cuda_graph_test_helpers.py
+++ b/comms/torchcomms/tests/helpers/py/cuda_graph_test_helpers.py
@@ -98,6 +98,10 @@ class CudaGraphInfo:
         """Check if a and b can execute concurrently (no path in either direction)."""
         return not self.are_sequential(node_a, node_b)
 
+    def memcpy_nodes(self) -> list[CudaGraphNode]:
+        """Return MEMCPY nodes."""
+        return self.nodes_of_type("MEMCPY")
+
 
 def _collect_dot_elements(
     graph: pydot.Dot | pydot.Subgraph,
@@ -110,6 +114,27 @@ def _collect_dot_elements(
         nodes.extend(sub_nodes)
         edges.extend(sub_edges)
     return nodes, edges
+
+
+def probe_tensor_addr(
+    buf: torch.Tensor,
+    probe: torch.Tensor,
+) -> None:
+    """Launch a GPU kernel that writes the device address of ``buf`` into
+    ``probe[0]``.  When called during CUDA graph capture, the kernel is
+    captured; at replay it writes the actual address the graph assigned to
+    ``buf``, allowing the caller to verify address reuse from Python.
+
+    ``probe`` must be a 1-element int64 CUDA tensor.
+    """
+    # pyre-ignore[21, 16]: C++ pybind11 extension not visible to Pyre
+    from torchcomms.tests.helpers.cpp.cuda_graph_utils import (
+        write_addr as _cpp_write_addr,
+    )
+
+    assert probe.dtype == torch.int64 and probe.numel() >= 1
+    stream = torch.cuda.current_stream().cuda_stream
+    _cpp_write_addr(buf.data_ptr(), probe.data_ptr(), stream)  # pyre-ignore[16]
 
 
 def _wait(work: object | None) -> None:


### PR DESCRIPTION
Summary:

i'd like to be able to get the address of a kernel input at graph replay time. we can create a kernel that does just that - create some "probe object" outside of the graph into which we will write the address of a graph-local object during graph replay. then after the replay, we can do things like compare two probed addresses for equality.

Reviewed By: minsii

Differential Revision: D97119514


