### PR TITLE
Wire put/counter/flush operations and add integration tests (#1190)

### DIFF
--- a/comms/torchcomms/device/pipes/TorchCommDevicePipes.cuh
+++ b/comms/torchcomms/device/pipes/TorchCommDevicePipes.cuh
@@ -115,9 +115,6 @@ __device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::signal(
 // TorchCommDeviceWindow<PipesDeviceBackend> RMA Operations
 // =============================================================================
 
-// TODO: Implement put() using DeviceWindow::put() / put_signal() public API.
-// Requires resolving remote data pointers from window base + offsets.
-// Will be implemented when the DevicePut integration test is added.
 template <>
 __device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::put(
     size_t dst_offset,
@@ -128,17 +125,56 @@ __device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::put(
     int signal_id,
     int counter_id,
     CoopScope scope) {
-  // Not yet implemented for Pipes backend.
-  (void)dst_offset;
-  (void)src_buf;
-  (void)src_offset;
-  (void)dst_rank;
-  (void)bytes;
-  (void)signal_id;
-  (void)counter_id;
-  (void)scope;
-  __trap();
-  return -1;
+  auto& win = *window_;
+  auto group = detail::make_pipes_thread_group(scope);
+
+  // Build Pipes LocalBufferRegistration from RegisteredBuffer.
+  // Pipes uses lkey (IBGDA local key); GIN uses backend_window.
+  ::comms::pipes::LocalBufferRegistration pipes_src{
+      src_buf.base_ptr,
+      src_buf.size,
+      ::comms::pipes::NetworkLKey{src_buf.lkey}};
+
+  bool has_signal = signal_id >= 0;
+  bool has_counter = counter_id >= 0;
+
+  if (has_signal && has_counter) {
+    win.put_signal_counter(
+        group,
+        dst_rank,
+        dst_offset,
+        pipes_src,
+        src_offset,
+        bytes,
+        signal_id,
+        /*signalVal=*/1,
+        counter_id,
+        /*counterVal=*/1);
+  } else if (has_signal) {
+    win.put_signal(
+        group,
+        dst_rank,
+        dst_offset,
+        pipes_src,
+        src_offset,
+        bytes,
+        signal_id,
+        /*signalVal=*/1);
+  } else if (has_counter) {
+    win.put_counter(
+        group,
+        dst_rank,
+        dst_offset,
+        pipes_src,
+        src_offset,
+        bytes,
+        counter_id,
+        /*counterVal=*/1);
+  } else {
+    win.put(group, dst_rank, dst_offset, pipes_src, src_offset, bytes);
+  }
+
+  return 0;
 }
 
 // =============================================================================
@@ -202,44 +238,74 @@ __device__ inline void TorchCommDeviceWindow<PipesDeviceBackend>::reset_signal(
 // =============================================================================
 // TorchCommDeviceWindow<PipesDeviceBackend> Counter Operations
 // =============================================================================
-// Counters require a companion RDMA QP for loopback atomic signaling
-// (NIC completion tracking). Not supported in the initial Pipes implementation.
+// Counters use companion RDMA QP loopback atomic signaling for NIC completion
+// tracking. read_counter/reset_counter must precede wait_local (which calls
+// read_counter).
+
+template <>
+__device__ inline uint64_t
+TorchCommDeviceWindow<PipesDeviceBackend>::read_counter(int counter_id) const {
+  // Sum the counter across all peers (aggregate model).
+  auto& win = *window_;
+  int nPeers = win.num_peers();
+  uint64_t total = 0;
+  for (int peer_index = 0; peer_index < nPeers; ++peer_index) {
+    int r = win.peer_index_to_rank(peer_index);
+    total += win.read_counter(r, counter_id);
+  }
+  return total;
+}
+
+template <>
+__device__ inline void TorchCommDeviceWindow<PipesDeviceBackend>::reset_counter(
+    int counter_id) {
+  // Reset the counter for all peers.
+  auto& win = *window_;
+  int nPeers = win.num_peers();
+  for (int peer_index = 0; peer_index < nPeers; ++peer_index) {
+    int r = win.peer_index_to_rank(peer_index);
+    win.reset_counter(r, counter_id);
+  }
+}
 
 template <>
 __device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::wait_local(
     int op_id,
     CmpOp cmp,
     uint64_t value) {
-  (void)op_id;
-  (void)cmp;
-  (void)value;
-  auto& win = *window_;
-  // Drain all pending IBGDA operations.
-  int nPeers = win.num_peers();
-  for (int peer_index = 0; peer_index < nPeers; ++peer_index) {
-    int r = win.peer_index_to_rank(peer_index);
-    if (win.get_type(r) == comms::pipes::TransportType::P2P_IBGDA) {
-      win.get_ibgda(r).fence();
+  // op_id is the counter_id. Sum the counter across all peers and poll
+  // until the aggregate satisfies the comparison (same model as GIN:
+  // counter_id 0 with value 5 = 5 puts completed regardless of peer).
+  //
+  // Spin-poll: read_counter() already sums across all peers.
+  while (true) {
+    uint64_t total = read_counter(op_id);
+    bool satisfied = false;
+    switch (cmp) {
+      case CmpOp::EQ:
+        satisfied = (total == value);
+        break;
+      case CmpOp::NE:
+        satisfied = (total != value);
+        break;
+      case CmpOp::GE:
+        satisfied = (total >= value);
+        break;
+      case CmpOp::GT:
+        satisfied = (total > value);
+        break;
+      case CmpOp::LE:
+        satisfied = (total <= value);
+        break;
+      case CmpOp::LT:
+        satisfied = (total < value);
+        break;
+    }
+    if (satisfied) {
+      break;
     }
   }
   return 0;
-}
-
-template <>
-__device__ inline uint64_t
-TorchCommDeviceWindow<PipesDeviceBackend>::read_counter(int counter_id) const {
-  // Counters not supported for Pipes backend.
-  (void)counter_id;
-  __trap();
-  return 0;
-}
-
-template <>
-__device__ inline void TorchCommDeviceWindow<PipesDeviceBackend>::reset_counter(
-    int counter_id) {
-  // Counters not supported for Pipes backend.
-  (void)counter_id;
-  __trap();
 }
 
 // =============================================================================

--- a/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTest.cpp
@@ -549,3 +549,432 @@ void PipesDeviceApiTest::testDeviceBarrier() {
 TEST_F(PipesDeviceApiTest, DeviceBarrier) {
   testDeviceBarrier();
 }
+
+// =============================================================================
+// Device Put Test (Pipes)
+// =============================================================================
+// Ring pattern: rank i puts data to rank (i+1) % num_ranks
+//   1. Each rank fills src_tensor with (rank+1)
+//   2. put() with signal to next rank's window slot
+//   3. wait_signal on receiver side
+//   4. Verify data with at::allclose
+
+void PipesDeviceApiTest::testDevicePut(int count, at::ScalarType dtype) {
+  SCOPED_TRACE(
+      ::testing::Message() << "Testing Pipes Device Put with count=" << count
+                           << " and dtype=" << getDtypeName(dtype));
+
+  auto put_stream = at::cuda::getStreamFromPool(false, device_index_);
+  auto wait_stream = at::cuda::getStreamFromPool(false, device_index_);
+
+  auto mem_pool = std::make_unique<at::cuda::MemPool>(
+      std::static_pointer_cast<c10::cuda::CUDACachingAllocator::CUDAAllocator>(
+          allocator_));
+  c10::cuda::CUDACachingAllocator::beginAllocateToPool(
+      mem_pool->device(), mem_pool->id(), [](cudaStream_t) { return true; });
+
+  auto options =
+      at::TensorOptions().dtype(dtype).device(at::kCUDA, device_index_);
+  at::Tensor win_tensor = at::zeros({count * num_ranks_}, options);
+
+  at::Tensor src_tensor = at::zeros({count}, options);
+  src_tensor.fill_(static_cast<float>(rank_ + 1));
+
+  c10::cuda::CUDACachingAllocator::endAllocateToPool(
+      mem_pool->device(), mem_pool->id());
+
+  torchcomm_->barrier(false);
+  auto base_win = torchcomm_->new_window();
+  base_win->tensor_register(win_tensor);
+  torchcomm_->barrier(false);
+
+  auto* win =
+      dynamic_cast<torch::comms::TorchCommWindowNCCLXPipes*>(base_win.get());
+  ASSERT_NE(win, nullptr) << "Window should be TorchCommWindowNCCLXPipes. "
+                             "Is NCCL_CTRAN_USE_PIPES=1 set?";
+
+  int signal_count = num_ranks_;
+  decltype(win->get_device_window()) dev_win = nullptr;
+  try {
+    dev_win = win->get_device_window(signal_count, -1, 1);
+  } catch (const std::runtime_error& e) {
+    base_win->tensor_deregister();
+    base_win.reset();
+    mem_pool.reset();
+    GTEST_SKIP() << "Skipping: IBGDA/Pipes hardware not available: "
+                 << e.what();
+  }
+  ASSERT_NE(dev_win, nullptr);
+
+  auto src_buf = win->register_local_buffer(src_tensor);
+  ASSERT_NE(src_buf.base_ptr, nullptr);
+
+  int dst_rank = (rank_ + 1) % num_ranks_;
+  int src_rank = (rank_ - 1 + num_ranks_) % num_ranks_;
+  constexpr int kSignalId = 0;
+
+  size_t elem_size = win_tensor.element_size();
+  size_t bytes = count * elem_size;
+  size_t src_offset = 0;
+  size_t dst_offset = rank_ * bytes;
+
+  // Put to next rank with signal
+  {
+    c10::cuda::CUDAStreamGuard guard(put_stream);
+    torchcomms::device::test::launchPipesPutKernel(
+        dev_win,
+        src_buf,
+        src_offset,
+        dst_offset,
+        bytes,
+        dst_rank,
+        kSignalId,
+        put_stream.stream());
+  }
+
+  // Wait for signal indicating data arrived from previous rank
+  {
+    c10::cuda::CUDAStreamGuard guard(wait_stream);
+    torchcomms::device::test::launchPipesWaitSignalKernel(
+        dev_win, kSignalId, 1, wait_stream.stream());
+  }
+
+  put_stream.synchronize();
+  wait_stream.synchronize();
+
+  // Verify: slot at src_rank's index should contain src_rank's data
+  at::Tensor result_slice = win_tensor.index(
+      {at::indexing::Slice(src_rank * count, (src_rank + 1) * count)});
+  at::Tensor result_cpu = result_slice.cpu();
+
+  auto cpu_options = at::TensorOptions().dtype(dtype).device(at::kCPU);
+  at::Tensor expected_cpu = at::zeros({count}, cpu_options);
+  expected_cpu.fill_(static_cast<float>(src_rank + 1));
+
+  bool equal = at::allclose(result_cpu, expected_cpu);
+  ASSERT_TRUE(equal) << "Device put data mismatch: expected value "
+                     << (src_rank + 1) << " from rank " << src_rank
+                     << ", got first element: " << result_cpu[0].item<float>();
+
+  win->deregister_local_buffer(src_buf);
+  base_win->tensor_deregister();
+  base_win.reset();
+  mem_pool.reset();
+
+  torchcomm_->barrier(false);
+}
+
+TEST_F(PipesDeviceApiTest, DevicePutFloat) {
+  testDevicePut(1024, at::kFloat);
+}
+
+// =============================================================================
+// Device Put with Counter Test (Pipes)
+// =============================================================================
+// Ring pattern with counter-based local completion tracking:
+//   1. put_signal_counter to next rank (signal + counter)
+//   2. wait_local on counter (verifies NIC completion via companion QP)
+//   3. wait_signal on receiver side (verifies data arrival)
+//   4. Verify data + read_counter value
+
+void PipesDeviceApiTest::testDevicePutCounter(int count, at::ScalarType dtype) {
+  SCOPED_TRACE(
+      ::testing::Message() << "Testing Pipes Device Put with Counter, count="
+                           << count << " and dtype=" << getDtypeName(dtype));
+
+  auto put_stream = at::cuda::getStreamFromPool(false, device_index_);
+  auto wait_stream = at::cuda::getStreamFromPool(false, device_index_);
+
+  auto mem_pool = std::make_unique<at::cuda::MemPool>(
+      std::static_pointer_cast<c10::cuda::CUDACachingAllocator::CUDAAllocator>(
+          allocator_));
+  c10::cuda::CUDACachingAllocator::beginAllocateToPool(
+      mem_pool->device(), mem_pool->id(), [](cudaStream_t) { return true; });
+
+  auto options =
+      at::TensorOptions().dtype(dtype).device(at::kCUDA, device_index_);
+  at::Tensor win_tensor = at::zeros({count * num_ranks_}, options);
+
+  at::Tensor src_tensor = at::zeros({count}, options);
+  src_tensor.fill_(static_cast<float>(rank_ + 1));
+
+  c10::cuda::CUDACachingAllocator::endAllocateToPool(
+      mem_pool->device(), mem_pool->id());
+
+  torchcomm_->barrier(false);
+  auto base_win = torchcomm_->new_window();
+  base_win->tensor_register(win_tensor);
+  torchcomm_->barrier(false);
+
+  auto* win =
+      dynamic_cast<torch::comms::TorchCommWindowNCCLXPipes*>(base_win.get());
+  ASSERT_NE(win, nullptr) << "Window should be TorchCommWindowNCCLXPipes. "
+                             "Is NCCL_CTRAN_USE_PIPES=1 set?";
+
+  int signal_count = num_ranks_;
+  int counter_count = num_ranks_;
+  decltype(win->get_device_window()) dev_win = nullptr;
+  try {
+    dev_win = win->get_device_window(signal_count, counter_count, 1);
+  } catch (const std::runtime_error& e) {
+    base_win->tensor_deregister();
+    base_win.reset();
+    mem_pool.reset();
+    GTEST_SKIP() << "Skipping: IBGDA/Pipes hardware not available: "
+                 << e.what();
+  }
+  ASSERT_NE(dev_win, nullptr);
+
+  auto src_buf = win->register_local_buffer(src_tensor);
+  ASSERT_NE(src_buf.base_ptr, nullptr);
+
+  int dst_rank = (rank_ + 1) % num_ranks_;
+  int src_rank = (rank_ - 1 + num_ranks_) % num_ranks_;
+  constexpr int kSignalId = 0;
+  constexpr int kCounterId = 0;
+
+  size_t elem_size = win_tensor.element_size();
+  size_t bytes = count * elem_size;
+  size_t src_offset = 0;
+  size_t dst_offset = rank_ * bytes;
+
+  // Put with signal + counter; kernel also calls wait_local on the counter
+  {
+    c10::cuda::CUDAStreamGuard guard(put_stream);
+    torchcomms::device::test::launchPipesPutCounterKernel(
+        dev_win,
+        src_buf,
+        src_offset,
+        dst_offset,
+        bytes,
+        dst_rank,
+        kSignalId,
+        kCounterId,
+        put_stream.stream());
+  }
+
+  // Wait for signal indicating data arrived from previous rank
+  {
+    c10::cuda::CUDAStreamGuard guard(wait_stream);
+    torchcomms::device::test::launchPipesWaitSignalKernel(
+        dev_win, kSignalId, 1, wait_stream.stream());
+  }
+
+  put_stream.synchronize();
+  wait_stream.synchronize();
+
+  // Read counter value.
+  // For IBGDA peers: companion QP loopback atomic increments counter → >= 1.
+  // For NVLink-only peers: counter is silently ignored → 0.
+  // Both are valid — we just verify the read doesn't crash.
+  uint64_t* d_counter_out = nullptr;
+  ASSERT_EQ(cudaMalloc(&d_counter_out, sizeof(uint64_t)), cudaSuccess);
+  {
+    c10::cuda::CUDAStreamGuard guard(put_stream);
+    torchcomms::device::test::launchPipesReadCounterKernel(
+        dev_win, kCounterId, d_counter_out, put_stream.stream());
+  }
+  put_stream.synchronize();
+
+  uint64_t h_counter = 0;
+  cudaMemcpy(
+      &h_counter, d_counter_out, sizeof(uint64_t), cudaMemcpyDeviceToHost);
+  cudaFree(d_counter_out);
+  // Log counter value for debugging (0 for NVLink, >= 1 for IBGDA)
+  SCOPED_TRACE(
+      ::testing::Message() << "Counter value after put: " << h_counter);
+
+  // Verify data
+  at::Tensor result_slice = win_tensor.index(
+      {at::indexing::Slice(src_rank * count, (src_rank + 1) * count)});
+  at::Tensor result_cpu = result_slice.cpu();
+
+  auto cpu_options = at::TensorOptions().dtype(dtype).device(at::kCPU);
+  at::Tensor expected_cpu = at::zeros({count}, cpu_options);
+  expected_cpu.fill_(static_cast<float>(src_rank + 1));
+
+  bool equal = at::allclose(result_cpu, expected_cpu);
+  ASSERT_TRUE(equal) << "Device put+counter data mismatch: expected value "
+                     << (src_rank + 1) << " from rank " << src_rank
+                     << ", got first element: " << result_cpu[0].item<float>();
+
+  // Reset counter for clean state
+  {
+    c10::cuda::CUDAStreamGuard guard(put_stream);
+    torchcomms::device::test::launchPipesResetCounterKernel(
+        dev_win, kCounterId, put_stream.stream());
+  }
+  put_stream.synchronize();
+
+  win->deregister_local_buffer(src_buf);
+  base_win->tensor_deregister();
+  base_win.reset();
+  mem_pool.reset();
+
+  torchcomm_->barrier(false);
+}
+
+TEST_F(PipesDeviceApiTest, DevicePutCounterFloat) {
+  testDevicePutCounter(1024, at::kFloat);
+}
+
+// =============================================================================
+// Wait Local (Counter) Test (Pipes)
+// =============================================================================
+// Validates wait_local() for local completion tracking:
+//   1. put_signal_counter to next rank (signal + counter)
+//   2. Read counter — if > 0 (IBGDA peers), call wait_local to verify it
+//      completes; if 0 (NVLink-only), skip wait_local (would spin forever)
+//   3. wait_signal on receiver side (verifies data arrival)
+//   4. Verify data with at::allclose
+
+void PipesDeviceApiTest::testWaitLocal(int count, at::ScalarType dtype) {
+  SCOPED_TRACE(
+      ::testing::Message() << "Testing Pipes wait_local with count=" << count
+                           << " and dtype=" << getDtypeName(dtype));
+
+  auto put_stream = at::cuda::getStreamFromPool(false, device_index_);
+  auto wait_stream = at::cuda::getStreamFromPool(false, device_index_);
+
+  auto mem_pool = std::make_unique<at::cuda::MemPool>(
+      std::static_pointer_cast<c10::cuda::CUDACachingAllocator::CUDAAllocator>(
+          allocator_));
+  c10::cuda::CUDACachingAllocator::beginAllocateToPool(
+      mem_pool->device(), mem_pool->id(), [](cudaStream_t) { return true; });
+
+  auto options =
+      at::TensorOptions().dtype(dtype).device(at::kCUDA, device_index_);
+  at::Tensor win_tensor = at::zeros({count * num_ranks_}, options);
+
+  at::Tensor src_tensor = at::zeros({count}, options);
+  src_tensor.fill_(static_cast<float>(rank_ + 1));
+
+  c10::cuda::CUDACachingAllocator::endAllocateToPool(
+      mem_pool->device(), mem_pool->id());
+
+  torchcomm_->barrier(false);
+  auto base_win = torchcomm_->new_window();
+  base_win->tensor_register(win_tensor);
+  torchcomm_->barrier(false);
+
+  auto* win =
+      dynamic_cast<torch::comms::TorchCommWindowNCCLXPipes*>(base_win.get());
+  ASSERT_NE(win, nullptr) << "Window should be TorchCommWindowNCCLXPipes. "
+                             "Is NCCL_CTRAN_USE_PIPES=1 set?";
+
+  int signal_count = num_ranks_;
+  int counter_count = num_ranks_;
+  decltype(win->get_device_window()) dev_win = nullptr;
+  try {
+    dev_win = win->get_device_window(signal_count, counter_count, 1);
+  } catch (const std::runtime_error& e) {
+    base_win->tensor_deregister();
+    base_win.reset();
+    mem_pool.reset();
+    GTEST_SKIP() << "Skipping: IBGDA/Pipes hardware not available: "
+                 << e.what();
+  }
+  ASSERT_NE(dev_win, nullptr);
+
+  auto src_buf = win->register_local_buffer(src_tensor);
+  ASSERT_NE(src_buf.base_ptr, nullptr);
+
+  int dst_rank = (rank_ + 1) % num_ranks_;
+  int src_rank = (rank_ - 1 + num_ranks_) % num_ranks_;
+  constexpr int kSignalId = 0;
+  constexpr int kCounterId = 0;
+
+  size_t elem_size = win_tensor.element_size();
+  size_t bytes = count * elem_size;
+  size_t src_offset = 0;
+  size_t dst_offset = rank_ * bytes;
+
+  // Put with signal + counter, then flush
+  {
+    c10::cuda::CUDAStreamGuard guard(put_stream);
+    torchcomms::device::test::launchPipesPutCounterKernel(
+        dev_win,
+        src_buf,
+        src_offset,
+        dst_offset,
+        bytes,
+        dst_rank,
+        kSignalId,
+        kCounterId,
+        put_stream.stream());
+  }
+  put_stream.synchronize();
+
+  // Read counter to determine if IBGDA peers exist
+  uint64_t* d_counter_out = nullptr;
+  ASSERT_EQ(cudaMalloc(&d_counter_out, sizeof(uint64_t)), cudaSuccess);
+  {
+    c10::cuda::CUDAStreamGuard guard(put_stream);
+    torchcomms::device::test::launchPipesReadCounterKernel(
+        dev_win, kCounterId, d_counter_out, put_stream.stream());
+  }
+  put_stream.synchronize();
+
+  uint64_t h_counter = 0;
+  cudaMemcpy(
+      &h_counter, d_counter_out, sizeof(uint64_t), cudaMemcpyDeviceToHost);
+  cudaFree(d_counter_out);
+
+  // wait_local: only valid when IBGDA peers incremented the counter.
+  // For NVLink-only configs, counter stays 0 and wait_local would spin forever.
+  if (h_counter > 0) {
+    c10::cuda::CUDAStreamGuard guard(put_stream);
+    torchcomms::device::test::launchPipesWaitLocalKernel(
+        dev_win,
+        kCounterId,
+        torchcomms::device::CmpOp::GE,
+        1,
+        put_stream.stream());
+    put_stream.synchronize();
+  } else {
+    SCOPED_TRACE(
+        ::testing::Message()
+        << "NVLink-only config: counter=0, skipping wait_local");
+  }
+
+  // Wait for signal indicating data arrived from previous rank
+  {
+    c10::cuda::CUDAStreamGuard guard(wait_stream);
+    torchcomms::device::test::launchPipesWaitSignalKernel(
+        dev_win, kSignalId, 1, wait_stream.stream());
+  }
+  wait_stream.synchronize();
+
+  // Verify data
+  at::Tensor result_slice = win_tensor.index(
+      {at::indexing::Slice(src_rank * count, (src_rank + 1) * count)});
+  at::Tensor result_cpu = result_slice.cpu();
+
+  auto cpu_options = at::TensorOptions().dtype(dtype).device(at::kCPU);
+  at::Tensor expected_cpu = at::zeros({count}, cpu_options);
+  expected_cpu.fill_(static_cast<float>(src_rank + 1));
+
+  bool equal = at::allclose(result_cpu, expected_cpu);
+  ASSERT_TRUE(equal) << "wait_local data mismatch: expected value "
+                     << (src_rank + 1) << " from rank " << src_rank
+                     << ", got first element: " << result_cpu[0].item<float>();
+
+  // Reset counter for clean state
+  {
+    c10::cuda::CUDAStreamGuard guard(put_stream);
+    torchcomms::device::test::launchPipesResetCounterKernel(
+        dev_win, kCounterId, put_stream.stream());
+  }
+  put_stream.synchronize();
+
+  win->deregister_local_buffer(src_buf);
+  base_win->tensor_deregister();
+  base_win.reset();
+  mem_pool.reset();
+
+  torchcomm_->barrier(false);
+}
+
+TEST_F(PipesDeviceApiTest, WaitLocalFloat) {
+  testWaitLocal(1024, at::kFloat);
+}

--- a/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTest.hpp
+++ b/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTest.hpp
@@ -11,7 +11,6 @@
 //   - RUN_PIPES_DEVICE_API_TEST=true (skip gate)
 //   - NCCL_CTRAN_USE_PIPES=1 (initialize ctran multiPeerTransport and select
 //     Pipes backend in new_window())
-//   - NCCL_P2P_DISABLE=1 (route traffic through ctran/RDMA path)
 
 #pragma once
 
@@ -64,6 +63,17 @@ class PipesDeviceApiTest : public ::testing::Test {
 
   // Test local buffer registration: register_local_buffer returns valid lkey.
   void testLocalBufferRegistration(int count, at::ScalarType dtype);
+
+  // Test device put: ring put with signal, verify data arrives correctly.
+  void testDevicePut(int count, at::ScalarType dtype);
+
+  // Test device put with counter: ring put_signal_counter + wait_local,
+  // verify data + counter value.
+  void testDevicePutCounter(int count, at::ScalarType dtype);
+
+  // Test wait_local: put_signal_counter, then wait_local on sender side
+  // to verify local completion tracking via companion QP counter.
+  void testWaitLocal(int count, at::ScalarType dtype);
 
   // Member variables
   std::unique_ptr<TorchCommTestWrapper> wrapper_;

--- a/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTestKernels.cu
+++ b/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTestKernels.cu
@@ -114,6 +114,97 @@ __global__ void pipesBarrierKernel(DeviceWindowPipes* win, int barrier_id) {
 }
 
 // =============================================================================
+// Put with Signal Kernel
+// =============================================================================
+// Performs a put operation to dst_rank with signal notification.
+// Single thread performs the put + flush (CoopScope::THREAD).
+
+__global__ void pipesPutKernel(
+    DeviceWindowPipes* win,
+    RegisteredBufferPipes src_buf,
+    size_t src_offset,
+    size_t dst_offset,
+    size_t bytes,
+    int dst_rank,
+    int signal_id) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    win->put(dst_offset, src_buf, src_offset, dst_rank, bytes, signal_id, -1);
+    win->flush();
+  }
+}
+
+// =============================================================================
+// Put with Signal + Counter Kernel
+// =============================================================================
+// Performs a put with both signal and counter.
+// Counter is only incremented for IBGDA peers (companion QP loopback atomic).
+// For NVLink-only peers, counter stays 0 (silently ignored, same as GIN LSA).
+// Caller should NOT wait_local for NVLink-only configs — it would spin forever.
+
+__global__ void pipesPutCounterKernel(
+    DeviceWindowPipes* win,
+    RegisteredBufferPipes src_buf,
+    size_t src_offset,
+    size_t dst_offset,
+    size_t bytes,
+    int dst_rank,
+    int signal_id,
+    int counter_id) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    win->put(
+        dst_offset,
+        src_buf,
+        src_offset,
+        dst_rank,
+        bytes,
+        signal_id,
+        counter_id);
+    win->flush();
+  }
+}
+
+// =============================================================================
+// Read Counter Kernel
+// =============================================================================
+// Reads the aggregated counter value (summed across all peers).
+
+__global__ void
+pipesReadCounterKernel(DeviceWindowPipes* win, int counter_id, uint64_t* out) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    *out = win->read_counter(counter_id);
+  }
+}
+
+// =============================================================================
+// Reset Counter Kernel
+// =============================================================================
+// Resets counter for all peers.
+
+__global__ void pipesResetCounterKernel(
+    DeviceWindowPipes* win,
+    int counter_id) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    win->reset_counter(counter_id);
+  }
+}
+
+// =============================================================================
+// Wait Local (Counter) Kernel
+// =============================================================================
+// Spin-polls aggregated counter until it satisfies the comparison.
+// Only meaningful for IBGDA peers — NVLink counters stay 0.
+
+__global__ void pipesWaitLocalKernel(
+    DeviceWindowPipes* win,
+    int counter_id,
+    CmpOp cmp,
+    uint64_t value) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    win->wait_local(counter_id, cmp, value);
+  }
+}
+
+// =============================================================================
 // Host-callable wrapper functions
 // =============================================================================
 
@@ -172,6 +263,69 @@ void launchPipesBarrierKernel(
     cudaStream_t stream) {
   // Launch with 32 threads (1 warp) to match CoopScope::WARP in the kernel.
   pipesBarrierKernel<<<1, 32, 0, stream>>>(win, barrier_id);
+  CUDA_LAUNCH_CHECK();
+}
+
+void launchPipesPutKernel(
+    DeviceWindowPipes* win,
+    RegisteredBufferPipes src_buf,
+    size_t src_offset,
+    size_t dst_offset,
+    size_t bytes,
+    int dst_rank,
+    int signal_id,
+    cudaStream_t stream) {
+  pipesPutKernel<<<1, 1, 0, stream>>>(
+      win, src_buf, src_offset, dst_offset, bytes, dst_rank, signal_id);
+  CUDA_LAUNCH_CHECK();
+}
+
+void launchPipesPutCounterKernel(
+    DeviceWindowPipes* win,
+    RegisteredBufferPipes src_buf,
+    size_t src_offset,
+    size_t dst_offset,
+    size_t bytes,
+    int dst_rank,
+    int signal_id,
+    int counter_id,
+    cudaStream_t stream) {
+  pipesPutCounterKernel<<<1, 1, 0, stream>>>(
+      win,
+      src_buf,
+      src_offset,
+      dst_offset,
+      bytes,
+      dst_rank,
+      signal_id,
+      counter_id);
+  CUDA_LAUNCH_CHECK();
+}
+
+void launchPipesReadCounterKernel(
+    DeviceWindowPipes* win,
+    int counter_id,
+    uint64_t* out,
+    cudaStream_t stream) {
+  pipesReadCounterKernel<<<1, 1, 0, stream>>>(win, counter_id, out);
+  CUDA_LAUNCH_CHECK();
+}
+
+void launchPipesResetCounterKernel(
+    DeviceWindowPipes* win,
+    int counter_id,
+    cudaStream_t stream) {
+  pipesResetCounterKernel<<<1, 1, 0, stream>>>(win, counter_id);
+  CUDA_LAUNCH_CHECK();
+}
+
+void launchPipesWaitLocalKernel(
+    DeviceWindowPipes* win,
+    int counter_id,
+    CmpOp cmp,
+    uint64_t value,
+    cudaStream_t stream) {
+  pipesWaitLocalKernel<<<1, 1, 0, stream>>>(win, counter_id, cmp, value);
   CUDA_LAUNCH_CHECK();
 }
 

--- a/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTestKernels.cuh
+++ b/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTestKernels.cuh
@@ -73,4 +73,53 @@ void launchPipesBarrierKernel(
     int barrier_id,
     cudaStream_t stream);
 
+// Launch device put kernel with signal - performs put with signal notification.
+// Ring pattern: rank puts data to dst_rank's window at dst_offset, signals
+// signal_id on completion.
+void launchPipesPutKernel(
+    DeviceWindowPipes* win,
+    RegisteredBufferPipes src_buf,
+    size_t src_offset,
+    size_t dst_offset,
+    size_t bytes,
+    int dst_rank,
+    int signal_id,
+    cudaStream_t stream);
+
+// Launch device put kernel with signal + counter - performs put_signal_counter
+// followed by flush. Does NOT call wait_local (counter may be 0 for NVLink).
+void launchPipesPutCounterKernel(
+    DeviceWindowPipes* win,
+    RegisteredBufferPipes src_buf,
+    size_t src_offset,
+    size_t dst_offset,
+    size_t bytes,
+    int dst_rank,
+    int signal_id,
+    int counter_id,
+    cudaStream_t stream);
+
+// Launch read counter kernel - reads aggregated counter value into output
+// buffer. out must be a device pointer to a single uint64_t.
+void launchPipesReadCounterKernel(
+    DeviceWindowPipes* win,
+    int counter_id,
+    uint64_t* out,
+    cudaStream_t stream);
+
+// Launch reset counter kernel - resets counter for all peers.
+void launchPipesResetCounterKernel(
+    DeviceWindowPipes* win,
+    int counter_id,
+    cudaStream_t stream);
+
+// Launch wait_local kernel - spin-polls aggregated counter until satisfied.
+// Only meaningful for IBGDA peers (counter stays 0 for NVLink-only).
+void launchPipesWaitLocalKernel(
+    DeviceWindowPipes* win,
+    int counter_id,
+    CmpOp cmp,
+    uint64_t value,
+    cudaStream_t stream);
+
 } // namespace torchcomms::device::test


### PR DESCRIPTION
Summary:

Wire the remaining TorchComm device API operations for the Pipes backend:
- put() with signal, counter, or signal+counter dispatch
- wait_local() spin-polls aggregated counter across all peers
- read_counter() sums per-peer counters (aggregate model matching GIN)
- reset_counter() resets counter for all peers
- flush() drains IBGDA QPs via fence() after group sync
- fence() compiler barrier

Also adds integration tests to PipesDeviceApiTest:
- DevicePutFloat: ring put with signal, verifies data via at::allclose
- DevicePutCounterFloat: ring put with signal+counter, reads counter value
  (0 for NVLink-only, >=1 for IBGDA), verifies data

Key fix: reorder read_counter/reset_counter before wait_local in
TorchCommDevicePipes.cuh — nvcc requires explicit specializations to precede
their first use.

Note: counter (wait_local) only fires for IBGDA peers via companion QP
loopback atomic. For NVLink-only configs, counter is silently ignored
(same behavior as GIN's LSA path).

Reviewed By: cenzhaometa

Differential Revision: D97398927
