### PR TITLE
Init CUDA driver lazy pointers in MultipeerIbgdaTransport (#1192)

### DIFF
--- a/comms/pipes/DocaHostUtils.h
+++ b/comms/pipes/DocaHostUtils.h
@@ -66,7 +66,6 @@ inline std::optional<DmaBufExport>
 export_gpu_dmabuf_aligned(doca_gpu* gpu, void* ptr, size_t size) {
   CUdeviceptr allocBase = 0;
   size_t allocSize = 0;
-  cuda_driver_lazy_init();
   CUresult cuRes =
       pfn_cuMemGetAddressRange(&allocBase, &allocSize, (CUdeviceptr)ptr);
   if (cuRes != CUDA_SUCCESS || allocBase == 0) {

--- a/comms/pipes/MultipeerIbgdaTransport.cc
+++ b/comms/pipes/MultipeerIbgdaTransport.cc
@@ -13,6 +13,7 @@
 
 #include <fmt/core.h>
 
+#include "comms/pipes/CudaDriverLazy.h"
 #include "comms/pipes/DocaHostUtils.h"
 #include "comms/pipes/IbverbsLazy.h"
 #include "comms/pipes/MultipeerIbgdaDeviceTransport.cuh"
@@ -547,6 +548,11 @@ MultipeerIbgdaTransport::MultipeerIbgdaTransport(
     throw std::invalid_argument("Need at least 2 ranks");
   }
   try {
+    // Resolve CUDA driver function pointers
+    if (cuda_driver_lazy_init() != 0) {
+      throw std::runtime_error("CUDA driver not available");
+    }
+
     // Initialize DOCA GPU context
     initDocaGpu();
 


### PR DESCRIPTION
Summary:

Call cuda_driver_lazy_init() once in initDocaGpu() — the transport's
single init entry point — matching NCCL's pattern of calling
ncclCudaLibraryInit() once in ncclCommInitRank.

This ensures pfn_cuMemGetAddressRange and other CUDA driver function
pointers are resolved (via cudaGetDriverEntryPoint) before any
downstream code uses them, without requiring per-call-site init.

Reviewed By: goelayu

Differential Revision: D97538802


