### PR TITLE
Add counter support to DeviceWindow put operations (#1193)

### DIFF
--- a/comms/pipes/P2pIbgdaTransportDevice.cuh
+++ b/comms/pipes/P2pIbgdaTransportDevice.cuh
@@ -645,6 +645,56 @@ class P2pIbgdaTransportDevice {
   }
 
   /**
+   * put_counter_local - One-sided write + local counter (no signal)
+   *
+   * Compound operation: data write on the main QP, then the companion QP
+   * WAITs for completion and increments a local counter via loopback RDMA
+   * atomic.  Same as put_signal_counter_remote but without the signal.
+   *
+   * All buffer addresses are caller-provided (window-owned).
+   *
+   * @param localDataBuf Source data buffer (local GPU memory)
+   * @param remoteDataBuf Destination data buffer (remote GPU memory)
+   * @param nbytes Number of data bytes to transfer
+   * @param localCounterBuf Local counter buffer (window-owned)
+   * @param counterId Counter slot index
+   * @param counterVal Counter value to atomically add (typically 1)
+   */
+  __device__ void put_counter_local(
+      const IbgdaLocalBuffer& localDataBuf,
+      const IbgdaRemoteBuffer& remoteDataBuf,
+      std::size_t nbytes,
+      const IbgdaLocalBuffer& localCounterBuf,
+      int counterId,
+      uint64_t counterVal) {
+    doca_gpu_dev_verbs_addr laddr = {
+        .addr = reinterpret_cast<uint64_t>(localDataBuf.ptr),
+        .key = localDataBuf.lkey.value};
+    doca_gpu_dev_verbs_addr raddr = {
+        .addr = reinterpret_cast<uint64_t>(remoteDataBuf.ptr),
+        .key = remoteDataBuf.rkey.value};
+
+    doca_gpu_dev_verbs_addr counterRemoteAddr = {
+        .addr = reinterpret_cast<uint64_t>(
+            static_cast<uint64_t*>(localCounterBuf.ptr) + counterId),
+        .key = localCounterBuf.lkey.value};
+    doca_gpu_dev_verbs_addr counterSinkAddr = {
+        .addr = 0, .key = sinkLkey_.value};
+
+    doca_gpu_dev_verbs_put_counter<
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+        DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(
+        qp_,
+        raddr,
+        laddr,
+        nbytes,
+        companionQp_,
+        counterRemoteAddr,
+        counterSinkAddr,
+        counterVal);
+  }
+
+  /**
    * wait_local - Wait for local completion of an RDMA operation
    *
    * Blocks until the RDMA operation identified by the work handle has completed

--- a/comms/pipes/tests/DeviceWindowTest.cc
+++ b/comms/pipes/tests/DeviceWindowTest.cc
@@ -876,4 +876,128 @@ TEST_F(DeviceWindowTestFixture, GetNvlinkAddressMiddleRank) {
   }
 }
 
+// =============================================================================
+// Offset-Based NVL Put + Signal + Counter via DeviceWindow
+// =============================================================================
+
+TEST_F(DeviceWindowTestFixture, NvlOffsetPutSignalCounter) {
+  // Source buffer: 8KB filled with 0xFACE
+  const std::size_t srcBufSize = 8192;
+  const std::size_t srcNumInts = srcBufSize / sizeof(int);
+  const int testValue = 0xFACE;
+
+  // Window buffer: 16KB, zero-initialized
+  const std::size_t windowBufSize = 16384;
+  const std::size_t windowNumInts = windowBufSize / sizeof(int);
+
+  DeviceBuffer srcBuffer(srcBufSize);
+  DeviceBuffer windowBuffer(windowBufSize);
+  auto src_d = static_cast<int*>(srcBuffer.get());
+  auto window_d = static_cast<int*>(windowBuffer.get());
+
+  std::vector<int> srcHost(srcNumInts, testValue);
+  CUDACHECK_TEST(
+      cudaMemcpy(src_d, srcHost.data(), srcBufSize, cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(cudaMemset(window_d, 0, windowBufSize));
+
+  // Copy 4KB from src_offset=0 to dst_offset=8192
+  const size_t dst_offset = 8192;
+  const size_t src_offset = 0;
+  const std::size_t nbytes = 4096;
+  const int signalId = 0;
+  const uint64_t signalVal = 1;
+  const int counterId = 0;
+  const uint64_t counterVal = 1;
+
+  test::testDeviceWindowNvlOffsetPutSignalCounter(
+      0,
+      2,
+      reinterpret_cast<char*>(window_d),
+      reinterpret_cast<const char*>(src_d),
+      srcBufSize,
+      dst_offset,
+      src_offset,
+      nbytes,
+      signalId,
+      signalVal,
+      counterId,
+      counterVal);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<int> windowHost(windowNumInts);
+  CUDACHECK_TEST(cudaMemcpy(
+      windowHost.data(), window_d, windowBufSize, cudaMemcpyDeviceToHost));
+
+  // Expected: zeros everywhere except [dst_offset, dst_offset+nbytes)
+  const std::size_t dstStartInt = dst_offset / sizeof(int);
+  const std::size_t copyNumInts = nbytes / sizeof(int);
+  std::vector<int> expected(windowNumInts, 0);
+  std::fill(
+      expected.begin() + dstStartInt,
+      expected.begin() + dstStartInt + copyNumInts,
+      testValue);
+  EXPECT_EQ(windowHost, expected)
+      << "put_signal_counter should copy data to correct region (NVL path)";
+}
+
+// =============================================================================
+// Offset-Based NVL Put + Counter (No Signal) via DeviceWindow
+// =============================================================================
+
+TEST_F(DeviceWindowTestFixture, NvlOffsetPutCounter) {
+  // Source buffer: 8KB filled with 0xDADA
+  const std::size_t srcBufSize = 8192;
+  const std::size_t srcNumInts = srcBufSize / sizeof(int);
+  const int testValue = 0xDADA;
+
+  // Window buffer: 16KB, zero-initialized
+  const std::size_t windowBufSize = 16384;
+  const std::size_t windowNumInts = windowBufSize / sizeof(int);
+
+  DeviceBuffer srcBuffer(srcBufSize);
+  DeviceBuffer windowBuffer(windowBufSize);
+  auto src_d = static_cast<int*>(srcBuffer.get());
+  auto window_d = static_cast<int*>(windowBuffer.get());
+
+  std::vector<int> srcHost(srcNumInts, testValue);
+  CUDACHECK_TEST(
+      cudaMemcpy(src_d, srcHost.data(), srcBufSize, cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(cudaMemset(window_d, 0, windowBufSize));
+
+  // Copy 4KB from src_offset=2048 to dst_offset=4096
+  const size_t dst_offset = 4096;
+  const size_t src_offset = 2048;
+  const std::size_t nbytes = 4096;
+  const int counterId = 0;
+  const uint64_t counterVal = 1;
+
+  test::testDeviceWindowNvlOffsetPutCounter(
+      0,
+      2,
+      reinterpret_cast<char*>(window_d),
+      reinterpret_cast<const char*>(src_d),
+      srcBufSize,
+      dst_offset,
+      src_offset,
+      nbytes,
+      counterId,
+      counterVal);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<int> windowHost(windowNumInts);
+  CUDACHECK_TEST(cudaMemcpy(
+      windowHost.data(), window_d, windowBufSize, cudaMemcpyDeviceToHost));
+
+  // Expected: zeros everywhere except [dst_offset, dst_offset+nbytes)
+  const std::size_t dstStartInt = dst_offset / sizeof(int);
+  const std::size_t copyNumInts = nbytes / sizeof(int);
+  std::vector<int> expected(windowNumInts, 0);
+  std::fill(
+      expected.begin() + dstStartInt,
+      expected.begin() + dstStartInt + copyNumInts,
+      testValue);
+  EXPECT_EQ(windowHost, expected)
+      << "put_counter should copy data to correct region (NVL path)";
+}
+
 } // namespace comms::pipes

--- a/comms/pipes/tests/DeviceWindowTest.cu
+++ b/comms/pipes/tests/DeviceWindowTest.cu
@@ -704,4 +704,120 @@ void testDeviceWindowGetNvlinkAddress(
   CUDACHECK_TEST(cudaDeviceSynchronize());
 }
 
+// =============================================================================
+// DeviceWindow Offset-Based NVL Put + Signal + Counter Test
+// =============================================================================
+
+__global__ void nvlOffsetPutSignalCounterKernel(
+    DeviceWindow dw,
+    int targetPeerRank,
+    std::size_t dst_offset,
+    LocalBufferRegistration src_buf,
+    std::size_t src_offset,
+    std::size_t nbytes,
+    int signalId,
+    uint64_t signalVal,
+    int counterId,
+    uint64_t counterVal) {
+  auto group = make_block_group();
+  dw.put_signal_counter(
+      group,
+      targetPeerRank,
+      dst_offset,
+      src_buf,
+      src_offset,
+      nbytes,
+      signalId,
+      signalVal,
+      counterId,
+      counterVal);
+}
+
+void testDeviceWindowNvlOffsetPutSignalCounter(
+    int myRank,
+    int nRanks,
+    char* windowBuf_d,
+    const char* srcBuf_d,
+    std::size_t srcBufSize,
+    std::size_t dst_offset,
+    std::size_t src_offset,
+    std::size_t nbytes,
+    int signalId,
+    uint64_t signalVal,
+    int counterId,
+    uint64_t counterVal) {
+  NvlOffsetPutDeviceWindowBuffers bufs;
+  auto dw = bufs.create_with_offset_put(myRank, nRanks, windowBuf_d);
+
+  int targetPeerRank = (myRank == 0) ? 1 : 0;
+  LocalBufferRegistration src_buf{srcBuf_d, srcBufSize, NetworkLKey{}};
+  nvlOffsetPutSignalCounterKernel<<<4, 256>>>(
+      dw,
+      targetPeerRank,
+      dst_offset,
+      src_buf,
+      src_offset,
+      nbytes,
+      signalId,
+      signalVal,
+      counterId,
+      counterVal);
+  CUDACHECK_TEST(cudaGetLastError());
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+}
+
+// =============================================================================
+// DeviceWindow Offset-Based NVL Put + Counter (No Signal) Test
+// =============================================================================
+
+__global__ void nvlOffsetPutCounterKernel(
+    DeviceWindow dw,
+    int targetPeerRank,
+    std::size_t dst_offset,
+    LocalBufferRegistration src_buf,
+    std::size_t src_offset,
+    std::size_t nbytes,
+    int counterId,
+    uint64_t counterVal) {
+  auto group = make_block_group();
+  dw.put_counter(
+      group,
+      targetPeerRank,
+      dst_offset,
+      src_buf,
+      src_offset,
+      nbytes,
+      counterId,
+      counterVal);
+}
+
+void testDeviceWindowNvlOffsetPutCounter(
+    int myRank,
+    int nRanks,
+    char* windowBuf_d,
+    const char* srcBuf_d,
+    std::size_t srcBufSize,
+    std::size_t dst_offset,
+    std::size_t src_offset,
+    std::size_t nbytes,
+    int counterId,
+    uint64_t counterVal) {
+  NvlOffsetPutDeviceWindowBuffers bufs;
+  auto dw = bufs.create_with_offset_put(myRank, nRanks, windowBuf_d);
+
+  int targetPeerRank = (myRank == 0) ? 1 : 0;
+  LocalBufferRegistration src_buf{srcBuf_d, srcBufSize, NetworkLKey{}};
+  nvlOffsetPutCounterKernel<<<4, 256>>>(
+      dw,
+      targetPeerRank,
+      dst_offset,
+      src_buf,
+      src_offset,
+      nbytes,
+      counterId,
+      counterVal);
+  CUDACHECK_TEST(cudaGetLastError());
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+}
+
 } // namespace comms::pipes::test

--- a/comms/pipes/tests/DeviceWindowTest.cuh
+++ b/comms/pipes/tests/DeviceWindowTest.cuh
@@ -223,4 +223,44 @@ void testDeviceWindowGetNvlinkAddress(
     void* windowBuf_d,
     int64_t* results);
 
+/**
+ * Test: DeviceWindow offset-based NVL put_signal_counter()
+ *
+ * Verifies the offset-based put_signal_counter() copies data to the
+ * correct region and signals the target peer. On NVL, the counter
+ * parameter is silently ignored (same as put_signal).
+ */
+void testDeviceWindowNvlOffsetPutSignalCounter(
+    int myRank,
+    int nRanks,
+    char* windowBuf_d,
+    const char* srcBuf_d,
+    std::size_t srcBufSize,
+    std::size_t dst_offset,
+    std::size_t src_offset,
+    std::size_t nbytes,
+    int signalId,
+    uint64_t signalVal,
+    int counterId,
+    uint64_t counterVal);
+
+/**
+ * Test: DeviceWindow offset-based NVL put_counter()
+ *
+ * Verifies the offset-based put_counter() copies data to the correct
+ * region. On NVL, the counter parameter is silently ignored (same as
+ * plain put).
+ */
+void testDeviceWindowNvlOffsetPutCounter(
+    int myRank,
+    int nRanks,
+    char* windowBuf_d,
+    const char* srcBuf_d,
+    std::size_t srcBufSize,
+    std::size_t dst_offset,
+    std::size_t src_offset,
+    std::size_t nbytes,
+    int counterId,
+    uint64_t counterVal);
+
 } // namespace comms::pipes::test

--- a/comms/pipes/window/DeviceWindow.cuh
+++ b/comms/pipes/window/DeviceWindow.cuh
@@ -1041,6 +1041,135 @@ class DeviceWindow {
       group.sync();
     }
   }
+  // ===========================================================================
+  // Combined Put + Signal + Counter (offset-based)
+  // ===========================================================================
+
+  /**
+   * put_signal_counter - Offset-based one-sided write + signal + counter.
+   *
+   * Group-level API: all threads in the group must call this together.
+   * Same as put_signal(), but also increments the local counter for
+   * the target peer via companion-QP loopback RDMA atomic (IBGDA) or
+   * is silently ignored (NVL, same as NCCLDeviceBackend LSA path).
+   *
+   * @param group        ThreadGroup for group coordination.
+   * @param target_rank  Rank to put to (must not be self).
+   * @param dst_offset   Byte offset into the target peer's window buffer.
+   * @param src_buf      Registered source buffer.
+   * @param src_offset   Byte offset into the source buffer.
+   * @param nbytes       Number of bytes to transfer.
+   * @param signalId     Signal slot index in [0, peerSignalCount).
+   * @param signalVal    Value to add to the signal (default: 1).
+   * @param counterId    Counter slot index in [0, peerCounterCount).
+   * @param counterVal   Value to add to the counter (default: 1).
+   */
+  __device__ __forceinline__ void put_signal_counter(
+      ThreadGroup& group,
+      int target_rank,
+      std::size_t dst_offset,
+      const LocalBufferRegistration& src_buf,
+      std::size_t src_offset,
+      std::size_t nbytes,
+      int signalId,
+      uint64_t signalVal,
+      int counterId,
+      uint64_t counterVal = 1) {
+    DEVICE_WINDOW_CHECK_RANK(target_rank, handle_.nRanks);
+    DEVICE_WINDOW_CHECK_NOT_SELF(target_rank, handle_.myRank);
+    const auto* localSrc = static_cast<const char*>(src_buf.base) + src_offset;
+    if (handle_.get_type(target_rank) == TransportType::P2P_NVL) {
+      // NVL path: put + signal, counter silently ignored
+      int nvlPeerIdx = rankToNvlPeerIndex_[target_rank];
+      auto* remoteDst =
+          static_cast<char*>(windowNvlPeerPtrs_[nvlPeerIdx]) + dst_offset;
+      handle_.get_nvl(target_rank).put(group, remoteDst, localSrc, nbytes);
+      signal_peer(
+          group, target_rank, signalId, SignalOp::SIGNAL_ADD, signalVal);
+      group.sync();
+    } else {
+      int ibgdaPeerIdx = rank_to_peer_index(target_rank);
+      IbgdaLocalBuffer localBuf(
+          const_cast<void*>(static_cast<const void*>(localSrc)), src_buf.lkey);
+      IbgdaRemoteBuffer remoteBuf(
+          const_cast<void*>(remoteBufferRegistry_[ibgdaPeerIdx].base),
+          remoteBufferRegistry_[ibgdaPeerIdx].rkey);
+      IbgdaLocalBuffer counterBuf(ibgdaPeerCounterBuf_, ibgdaPeerCounterLkey_);
+      int counterSlot = ibgdaPeerIdx * peerCounterCount_ + counterId;
+      handle_.get_ibgda(target_rank)
+          .put_signal_counter_remote(
+              localBuf,
+              remoteBuf.subBuffer(dst_offset),
+              nbytes,
+              ibgdaPeerSignalRemoteBufs_[ibgdaPeerIdx],
+              signalId,
+              signalVal,
+              counterBuf,
+              counterSlot,
+              counterVal);
+      group.sync();
+    }
+  }
+
+  // ===========================================================================
+  // Combined Put + Counter (offset-based, no signal)
+  // ===========================================================================
+
+  /**
+   * put_counter - Offset-based one-sided write + counter (no signal).
+   *
+   * Group-level API: all threads in the group must call this together.
+   * Same as put(), but also increments the local counter for the target
+   * peer via companion-QP loopback RDMA atomic (IBGDA) or is silently
+   * ignored (NVL, same as NCCLDeviceBackend LSA path).
+   *
+   * @param group        ThreadGroup for group coordination.
+   * @param target_rank  Rank to put to (must not be self).
+   * @param dst_offset   Byte offset into the target peer's window buffer.
+   * @param src_buf      Registered source buffer.
+   * @param src_offset   Byte offset into the source buffer.
+   * @param nbytes       Number of bytes to transfer.
+   * @param counterId    Counter slot index in [0, peerCounterCount).
+   * @param counterVal   Value to add to the counter (default: 1).
+   */
+  __device__ __forceinline__ void put_counter(
+      ThreadGroup& group,
+      int target_rank,
+      std::size_t dst_offset,
+      const LocalBufferRegistration& src_buf,
+      std::size_t src_offset,
+      std::size_t nbytes,
+      int counterId,
+      uint64_t counterVal = 1) {
+    DEVICE_WINDOW_CHECK_RANK(target_rank, handle_.nRanks);
+    DEVICE_WINDOW_CHECK_NOT_SELF(target_rank, handle_.myRank);
+    const auto* localSrc = static_cast<const char*>(src_buf.base) + src_offset;
+    if (handle_.get_type(target_rank) == TransportType::P2P_NVL) {
+      // NVL path: put only, counter silently ignored
+      int nvlPeerIdx = rankToNvlPeerIndex_[target_rank];
+      auto* remoteDst =
+          static_cast<char*>(windowNvlPeerPtrs_[nvlPeerIdx]) + dst_offset;
+      handle_.get_nvl(target_rank).put(group, remoteDst, localSrc, nbytes);
+    } else {
+      int ibgdaPeerIdx = rank_to_peer_index(target_rank);
+      IbgdaLocalBuffer localBuf(
+          const_cast<void*>(static_cast<const void*>(localSrc)), src_buf.lkey);
+      IbgdaRemoteBuffer remoteBuf(
+          const_cast<void*>(remoteBufferRegistry_[ibgdaPeerIdx].base),
+          remoteBufferRegistry_[ibgdaPeerIdx].rkey);
+      IbgdaLocalBuffer counterBuf(ibgdaPeerCounterBuf_, ibgdaPeerCounterLkey_);
+      int counterSlot = ibgdaPeerIdx * peerCounterCount_ + counterId;
+      handle_.get_ibgda(target_rank)
+          .put_counter_local(
+              localBuf,
+              remoteBuf.subBuffer(dst_offset),
+              nbytes,
+              counterBuf,
+              counterSlot,
+              counterVal);
+    }
+  }
+
 #endif // __CUDACC__
 
   // ===========================================================================
@@ -1101,6 +1230,7 @@ class DeviceWindow {
   // --- Per-peer counter buffers (IBGDA-only, local) ---
   int peerCounterCount_{0};
   uint64_t* ibgdaPeerCounterBuf_{nullptr};
+  NetworkLKey ibgdaPeerCounterLkey_{};
 
   // --- Barrier buffers (flat, per-peer-type) ---
   int barrierCount_{0};

--- a/comms/pipes/window/HostWindow.cc
+++ b/comms/pipes/window/HostWindow.cc
@@ -454,6 +454,7 @@ DeviceWindow HostWindow::getDeviceWindow() const {
   dw.peerCounterCount_ = static_cast<int>(config_.peerCounterCount);
   dw.ibgdaPeerCounterBuf_ =
       static_cast<uint64_t*>(ibgdaPeerCounterLocalBuf_.ptr);
+  dw.ibgdaPeerCounterLkey_ = ibgdaPeerCounterLocalBuf_.lkey;
 
   // Barrier
   dw.barrierCount_ = static_cast<int>(config_.barrierCount);


### PR DESCRIPTION
Summary:

Add `put_signal_counter()` and `put_counter()` to DeviceWindow, and
`put_counter_remote()` to P2pIbgdaTransportDevice.

Previously, DeviceWindow's `put()` and `put_signal()` had no counter
support — the counter buffer (`ibgdaPeerCounterBuf_`) was allocated
and `wait_counter()`/`read_counter()`/`reset_counter()` existed, but
nothing ever incremented the counters. Calling `wait_counter()` after
`put()` would spin forever.

Changes:
- `P2pIbgdaTransportDevice.cuh`: Add `put_counter_remote()` wrapping
  `doca_gpu_dev_verbs_put_counter()` — data write on main QP +
  companion QP WAIT + loopback RDMA atomic to increment local counter.
- `DeviceWindow.cuh`: Add `put_signal_counter()` (data + signal +
  counter) and `put_counter()` (data + counter, no signal). NVL path
  silently ignores counters (same as NCCLDeviceBackend LSA path).
  IBGDA path uses compound transport APIs with companion QP.
- `DeviceWindow.cuh`: Add `ibgdaPeerCounterLkey_` member to store the
  counter buffer's lkey for constructing IbgdaLocalBuffer.
- `HostWindow.cc`: Pass counter buffer lkey to DeviceWindow.

Reviewed By: siyengar

Differential Revision: D97389726


