### PR TITLE
add DeviceCounter benchmark (#1201)

### DIFF
--- a/comms/torchcomms/device/cuda/CudaApi.cpp
+++ b/comms/torchcomms/device/cuda/CudaApi.cpp
@@ -143,6 +143,10 @@ DefaultCudaApi::hostAlloc(void** pHost, size_t size, unsigned int flags) {
   return cudaHostAlloc(pHost, size, flags);
 }
 
+cudaError_t DefaultCudaApi::hostFree(void* ptr) {
+  return cudaFreeHost(ptr);
+}
+
 cudaError_t DefaultCudaApi::malloc(void** devPtr, size_t size) {
   return cudaMalloc(devPtr, size);
 }

--- a/comms/torchcomms/device/cuda/CudaApi.hpp
+++ b/comms/torchcomms/device/cuda/CudaApi.hpp
@@ -99,6 +99,7 @@ class CudaApi {
 
   [[nodiscard]] virtual cudaError_t
   hostAlloc(void** pHost, size_t size, unsigned int flags) = 0;
+  [[nodiscard]] virtual cudaError_t hostFree(void* ptr) = 0;
 
   // Memory management
   [[nodiscard]] virtual cudaError_t malloc(void** devPtr, size_t size) = 0;
@@ -199,6 +200,7 @@ class DefaultCudaApi : public CudaApi {
 
   [[nodiscard]] cudaError_t
   hostAlloc(void** pHost, size_t size, unsigned int flags) override;
+  [[nodiscard]] cudaError_t hostFree(void* ptr) override;
 
   // Memory management
   [[nodiscard]] cudaError_t malloc(void** devPtr, size_t size) override;

--- a/comms/torchcomms/device/cuda/DeviceCounter.cpp
+++ b/comms/torchcomms/device/cuda/DeviceCounter.cpp
@@ -31,7 +31,7 @@ cudaError_t DeviceCounter::create(
 DeviceCounter::~DeviceCounter() {
   if (counter_) {
     CUDA_CHECK_IGNORE(
-        api_, cudaFreeHost(counter_), "Failed to free host counter");
+        api_, api_->hostFree(counter_), "Failed to free host counter");
   }
 }
 

--- a/comms/torchcomms/ncclx/tests/unit/cpp/mocks/CudaMock.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/mocks/CudaMock.cpp
@@ -88,6 +88,11 @@ void CudaMock::setupDefaultBehaviors() {
         return cudaSuccess;
       });
 
+  ON_CALL(*this, hostFree(_)).WillByDefault([](void* ptr) {
+    std::free(ptr);
+    return cudaSuccess;
+  });
+
   // Memory management - return success by default
   ON_CALL(*this, malloc(_, _))
       .WillByDefault(DoAll(

--- a/comms/torchcomms/ncclx/tests/unit/cpp/mocks/CudaMock.hpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/mocks/CudaMock.hpp
@@ -121,6 +121,7 @@ class CudaMock : public CudaApi {
       hostAlloc,
       (void** pHost, size_t size, unsigned int flags),
       (override));
+  MOCK_METHOD(cudaError_t, hostFree, (void* ptr), (override));
 
   // Memory management
   MOCK_METHOD(cudaError_t, malloc, (void** devPtr, size_t size), (override));


### PR DESCRIPTION
Summary:

```
===========================================================================================
[...]enchmarks/CudaGraphD2HCounterBench.cc     relative  time/iter   iters/s  gpuOverheadUs
===========================================================================================
HostCallbackReplay                                         44.58us    22.43K          24.14
DeviceCounterIncrement                                     21.92us    45.63K           3.03
DeviceCounterRead                                           1.50ns   668.57M            NaN
===========================================================================================
```

Reviewed By: minsii

Differential Revision: D96172640


