### PR TITLE
replace per-replay host callback with DeviceCounter (#1203)

### DIFF
--- a/comms/torchcomms/ncclx/CMakeLists.txt
+++ b/comms/torchcomms/ncclx/CMakeLists.txt
@@ -3,8 +3,12 @@
 file(GLOB TORCHCOMMS_NCCLX_SOURCES
     "comms/torchcomms/ncclx/*.cpp"
 )
-file(GLOB TORCHCOMMS_CUDA_API_SOURCE "comms/torchcomms/device/cuda/CudaApi.cpp")
+file(GLOB TORCHCOMMS_CUDA_DEVICE_SOURCES
+    "comms/torchcomms/device/cuda/*.cpp"
+    "comms/torchcomms/device/cuda/*.cu"
+)
 
+enable_language(CUDA)
 find_package(CUDA)
 
 # NCCLX handling
@@ -76,7 +80,7 @@ endif()
 
 add_library(torchcomms_comms_ncclx MODULE
     ${TORCHCOMMS_NCCLX_SOURCES}
-    ${TORCHCOMMS_CUDA_API_SOURCE}
+    ${TORCHCOMMS_CUDA_DEVICE_SOURCES}
     ${TORCHCOMMS_DEVICE_NCCLX_SOURCE}
 )
 set_target_properties(torchcomms_comms_ncclx PROPERTIES

--- a/comms/torchcomms/ncclx/GraphEventTracker.cpp
+++ b/comms/torchcomms/ncclx/GraphEventTracker.cpp
@@ -72,14 +72,18 @@ void GraphEventTracker::maybeInitGraphState(
   SharedCallbackState* shared = allocateCallbackState();
   state.shared_ = shared;
 
-  // Set up replay counter — host node fires on each replay.
+  // Set up replay counter — kernel node fires on each replay.
   // Only installed when timeout monitoring is enabled; the cleanup callback
   // is always installed for GraphState lifecycle management.
   if (isGraphTimeoutMonitoringEnabled()) {
     CUDA_CHECK(
         api,
-        api->launchHostFunc(stream, replayCallback, &shared->replay_counter),
-        "Failed to launch replay counter host func");
+        DeviceCounter::create(api, state.replay_counter),
+        "Failed to create replay counter");
+    CUDA_CHECK(
+        api,
+        state.replay_counter->increment(stream),
+        "Failed to record replay counter increment");
   }
 
   // Set up deferred cleanup via a CUDA user object — when the graph is
@@ -152,15 +156,15 @@ void GraphEventTracker::addEntry(TorchWorkNCCLX* work) {
 // Timeout detection for graph-captured collectives.
 //
 // During a single replay, the GPU executes nodes in order:
-//   host_node (counter++) → start_event record → NCCL collective → end_event
-//   record
+//   kernel_node (counter++) → start_event record → NCCL collective →
+//   end_event record
 //
 // The watchdog may poll at any point. Possible observations:
 //
 //   (1) Between replays (previous end=success, counter unchanged):
 //       end=success → reset timer. Correct: collective is done.
 //
-//   (2) New replay started, GPU past host_node but before event records:
+//   (2) New replay started, GPU past kernel_node but before event records:
 //       counter changed → replay detection resets timer.
 //       end still=success from previous replay → reset timer (redundant,
 //       harmless).
@@ -168,13 +172,17 @@ void GraphEventTracker::addEntry(TorchWorkNCCLX* work) {
 //   (3) GPU past event records, collective in progress:
 //       start=success, end=notReady → start/continue timer. Correct.
 //
-//   (4) GPU past host_node but before this collective's start_event:
+//   (4) GPU past kernel_node but before this collective's start_event:
 //       both notReady → reset timer. Correct: collective hasn't started.
 //
 // Without the replay counter, case (2) could be missed if the watchdog
 // never observes end=success between consecutive replays, causing the
 // timer to span N replays and false-trigger a timeout.
 GraphEventTracker::CheckResult GraphEventTracker::checkAll() {
+  if (!isGraphTimeoutMonitoringEnabled()) {
+    return CheckResult::OK;
+  }
+
   CudaApi* api = comm_->getCudaApi();
   std::lock_guard<std::mutex> lock(mutex_);
 
@@ -183,8 +191,13 @@ GraphEventTracker::CheckResult GraphEventTracker::checkAll() {
 
   // Traverse remaining active graphs
   for (auto& [graph_id, graph_state] : graphs_) {
-    uint64_t current_replay =
-        graph_state.shared_->replay_counter.load(std::memory_order_acquire);
+    if (!graph_state.replay_counter) {
+      TC_LOG(ERROR, comm_) << "Graph monitor: replay counter is null for graph "
+                           << graph_id
+                           << " -- expected counter when monitoring is enabled";
+      return CheckResult::ERROR;
+    }
+    uint64_t current_replay = graph_state.replay_counter->read();
 
     // Collectives are ordered per stream — within each stream, if collective i
     // has not completed, collective i+1 cannot have started. This allows us to
@@ -276,12 +289,6 @@ void GraphEventTracker::cleanupReleasedGraphs() {
 void GraphEventTracker::destroyAll() {
   std::lock_guard<std::mutex> lock(mutex_);
   graphs_.clear();
-}
-
-// Static callback — fires on each graph replay to increment counter
-void CUDART_CB GraphEventTracker::replayCallback(void* userData) {
-  static_cast<std::atomic_uint64_t*>(userData)->fetch_add(
-      1, std::memory_order_release);
 }
 
 // Static callback — fires when graph is destroyed to set released flag

--- a/comms/torchcomms/ncclx/GraphEventTracker.hpp
+++ b/comms/torchcomms/ncclx/GraphEventTracker.hpp
@@ -14,6 +14,7 @@
 #include <ATen/ATen.h>
 
 #include "comms/torchcomms/device/cuda/CudaApi.hpp"
+#include "comms/torchcomms/device/cuda/DeviceCounter.h"
 
 namespace torch::comms {
 
@@ -38,13 +39,13 @@ struct GraphWork {
   }
 };
 
-// Shared state between CUDA callbacks and the tracker. Allocated from a static
-// pool so that callbacks only perform atomic stores, avoiding mutex acquisition
-// or CUDA API calls inside the callback (which violates CUDA docs). Resource is
-// automatically released when prcoess exits, so graph destruction and comm
-// finalization can occur in any order.
+// Shared state for the graph-release flag, read by the tracker's watchdog.
+// Allocated from a static pool so that the cleanup callback only performs
+// an atomic store, avoiding mutex acquisition or CUDA API calls inside
+// the callback (which violates CUDA docs). Resource is automatically
+// released when process exits, so graph destruction and comm finalization
+// can occur in any order.
 struct SharedCallbackState {
-  std::atomic_uint64_t replay_counter{0};
   std::atomic_bool released{false};
 };
 
@@ -57,6 +58,7 @@ struct GraphState {
   std::unordered_map<cudaStream_t, std::vector<GraphWork>> stream_entries;
   SharedCallbackState* shared_{nullptr};
   CudaApi* api_{nullptr};
+  std::unique_ptr<DeviceCounter> replay_counter;
   // CPU tensors that must be kept alive for the graph's lifetime.
   // This includes CPU pointer tensors used by alltoallv_dynamic_dispatch
   // operations. These tensors are moved from work objects during graph
@@ -72,9 +74,10 @@ struct GraphState {
 // taking ownership of each collective's start/end CUDA events and polling
 // them from the watchdog thread.
 //
-// Replay detection: a host-node callback increments a per-graph atomic
-// counter on every replay so the watchdog can distinguish "not yet replayed"
-// from "stuck during a replay."
+// Replay detection: a single-thread GPU kernel node atomically increments a
+// per-graph counter in mapped pinned memory on every replay, so the watchdog
+// can distinguish "not yet replayed" from "stuck during a replay" without
+// the CPU round-trip cost of a host-function callback.
 //
 // Cleanup: a CUDA user-object callback sets a released flag when the graph
 // is destroyed.  The watchdog's next checkAll() call sees the flag and
@@ -120,9 +123,7 @@ class GraphEventTracker {
  private:
   // Static callback for CUDA user object cleanup — sets released flag
   static void CUDART_CB cleanupCallback(void* userData);
-  // Static callback for replay detection (fires on each graph replay)
-  static void CUDART_CB replayCallback(void* userData);
-  // One-time per-graph setup: replay counter + cleanup user object.
+  // One-time per-graph setup: replay counter kernel + cleanup user object.
   // Must be called with mutex_ held.
   void maybeInitGraphState(
       cudaStream_t stream,

--- a/comms/torchcomms/ncclx/tests/unit/cpp/GraphEventTrackerTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/GraphEventTrackerTest.cpp
@@ -37,8 +37,6 @@ class GraphEventTrackerTest : public TorchCommNCCLXTest {
             SetArgPointee<2>(graph_id),
             SetArgPointee<3>(graph),
             Return(cudaSuccess)));
-    ON_CALL(*cuda_mock_, launchHostFunc(_, _, _))
-        .WillByDefault(Return(cudaSuccess));
     ON_CALL(*cuda_mock_, userObjectCreate(_, _, _, _, _))
         .WillByDefault(DoAll(
             SetArgPointee<0>(reinterpret_cast<cudaUserObject_t>(0x3000)),
@@ -75,7 +73,7 @@ class GraphEventTrackerTest : public TorchCommNCCLXTest {
   void setupFinalizeExpectations(TestTorchCommNCCLX& comm) {
     EXPECT_CALL(*cuda_mock_, eventDestroy(_))
         .WillRepeatedly(Return(cudaSuccess));
-    EXPECT_CALL(*cuda_mock_, free(_)).WillOnce(Return(cudaSuccess));
+    EXPECT_CALL(*cuda_mock_, free(_)).WillRepeatedly(Return(cudaSuccess));
     EXPECT_CALL(*cuda_mock_, streamDestroy(_)).WillOnce(Return(cudaSuccess));
     EXPECT_CALL(*nccl_mock_, commDestroy(_)).WillOnce(Return(ncclSuccess));
     comm.finalize();
@@ -285,14 +283,18 @@ TEST_F(GraphEventTrackerTest, ReplayCounterResetsTimer) {
   auto events = setupGraphCaptureEvents();
   setupEventRecordMocks();
 
-  cudaHostFn_t captured_replay_fn = nullptr;
-  void* captured_replay_data = nullptr;
-  // Override launchHostFunc to capture the replay callback
-  ON_CALL(*cuda_mock_, launchHostFunc(_, _, _))
-      .WillByDefault(DoAll(
-          SaveArg<1>(&captured_replay_fn),
-          SaveArg<2>(&captured_replay_data),
-          Return(cudaSuccess)));
+  // Capture the replay counter pointer from hostAlloc.
+  // DeviceCounter::create calls api->hostAlloc(sizeof(uint64_t)).
+  uint64_t* captured_counter = nullptr;
+  ON_CALL(*cuda_mock_, hostAlloc(_, _, _))
+      .WillByDefault(
+          [&captured_counter](void** ptr, size_t size, unsigned int) {
+            *ptr = std::calloc(1, size);
+            if (size == sizeof(uint64_t)) {
+              captured_counter = static_cast<uint64_t*>(*ptr);
+            }
+            return cudaSuccess;
+          });
 
   auto tensor = createTestTensor({10, 10});
   auto work = comm->send(tensor, 1, true);
@@ -304,8 +306,7 @@ TEST_F(GraphEventTrackerTest, ReplayCounterResetsTimer) {
   ON_CALL(*cuda_mock_, eventQuery(events.end))
       .WillByDefault(Return(cudaErrorNotReady));
 
-  ASSERT_NE(captured_replay_fn, nullptr);
-  ASSERT_NE(captured_replay_data, nullptr);
+  ASSERT_NE(captured_counter, nullptr);
 
   std::atomic<bool> stop_replays{false};
   std::thread replay_thread([&]() {
@@ -313,7 +314,10 @@ TEST_F(GraphEventTrackerTest, ReplayCounterResetsTimer) {
       // NOLINTNEXTLINE(facebook-hte-BadCall-sleep_for)
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
       if (!stop_replays.load()) {
-        captured_replay_fn(captured_replay_data);
+        // Simulate GPU kernel incrementing the counter on replay.
+        // In the mock, mapped memory is plain host memory, so a direct
+        // increment is equivalent to what launchAtomicAdd does.
+        ++(*captured_counter);
       }
     }
   });
@@ -367,7 +371,7 @@ TEST_F(GraphEventTrackerTest, DestroyAllCleansUpGraphEntryEvents) {
             destroyed_events.push_back(event);
           },
           Return(cudaSuccess)));
-  EXPECT_CALL(*cuda_mock_, free(_)).WillOnce(Return(cudaSuccess));
+  EXPECT_CALL(*cuda_mock_, free(_)).WillRepeatedly(Return(cudaSuccess));
   EXPECT_CALL(*cuda_mock_, streamDestroy(_)).WillOnce(Return(cudaSuccess));
   EXPECT_CALL(*nccl_mock_, commDestroy(_)).WillOnce(Return(ncclSuccess));
 
@@ -473,7 +477,7 @@ TEST_F(GraphEventTrackerTest, UserObjectCreateFailureCleanup) {
   // The work was never fully created, so cleanup needs to handle the
   // partially-initialized state gracefully.
   EXPECT_CALL(*cuda_mock_, eventDestroy(_)).WillRepeatedly(Return(cudaSuccess));
-  EXPECT_CALL(*cuda_mock_, free(_)).WillOnce(Return(cudaSuccess));
+  EXPECT_CALL(*cuda_mock_, free(_)).WillRepeatedly(Return(cudaSuccess));
   EXPECT_CALL(*cuda_mock_, streamDestroy(_)).WillOnce(Return(cudaSuccess));
   EXPECT_CALL(*nccl_mock_, commDestroy(_)).WillOnce(Return(ncclSuccess));
 
@@ -507,7 +511,7 @@ TEST_F(GraphEventTrackerTest, GraphRetainUserObjectFailureCleanup) {
   switchToReplayMode();
 
   EXPECT_CALL(*cuda_mock_, eventDestroy(_)).WillRepeatedly(Return(cudaSuccess));
-  EXPECT_CALL(*cuda_mock_, free(_)).WillOnce(Return(cudaSuccess));
+  EXPECT_CALL(*cuda_mock_, free(_)).WillRepeatedly(Return(cudaSuccess));
   EXPECT_CALL(*cuda_mock_, streamDestroy(_)).WillOnce(Return(cudaSuccess));
   EXPECT_CALL(*nccl_mock_, commDestroy(_)).WillOnce(Return(ncclSuccess));
 
@@ -709,7 +713,7 @@ TEST_F(GraphEventTrackerTest, DestroyAllIgnoresReleasedFlag) {
             destroyed_events.push_back(event);
           },
           Return(cudaSuccess)));
-  EXPECT_CALL(*cuda_mock_, free(_)).WillOnce(Return(cudaSuccess));
+  EXPECT_CALL(*cuda_mock_, free(_)).WillRepeatedly(Return(cudaSuccess));
   EXPECT_CALL(*cuda_mock_, streamDestroy(_)).WillOnce(Return(cudaSuccess));
   EXPECT_CALL(*nccl_mock_, commDestroy(_)).WillOnce(Return(ncclSuccess));
 


### PR DESCRIPTION
Summary:

GraphEventTracker previously used cudaLaunchHostFunc to increment a replay counter on every graph replay. this incurs a CPU round-trip (~26us).

we can now replace the host atomic with DeviceCounter (device memory mode): a single-thread GPU
kernel atomically increments a counter in device memory (~1.7us overhead), and the CPU watchdog reads it via D2H memcpy at ~100ms poll intervals.

Reading is a little more expensive, but it's async so that's fine.

Reviewed By: minsii

Differential Revision: D96172426


