### PR TITLE
Skip collective impl() in GPE thread when comm is aborted (#1206)

### DIFF
--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -658,10 +658,35 @@ void CtranGpe::Impl::gpeThreadFn() {
         // TODO: lost peerRank info which would be useful for some errors (e.g.,
         // commRemoteError). We may want to enrich commResult_t to contain such
         // info at failure or throw exception from bottom.
-        CTRAN_ASYNC_ERR_GUARD_FAULT_TOLERANCE(comm, {
-          FB_COMMCHECKTHROW_EX(
-              cmd->coll.func(cmd->coll.opGroup), comm->logMetaData_);
-        });
+        if (comm->testAbort()) {
+          // Comm already aborted — skip collective to prevent
+          // progressInternal() from accessing stale VC queue entries
+          // left by a previously aborted collective (double-complete bug).
+          CLOGF(
+              WARN,
+              "Communicator aborted, skipping collective (opType={}, opCount={}) on rank {} commHash {:x}",
+              cmd->coll.opGroup.empty()
+                  ? -1
+                  : static_cast<int>(cmd->coll.opGroup.front()->type),
+              cmd->coll.opGroup.empty() ? 0UL
+                                        : cmd->coll.opGroup.front()->opCount,
+              statex->rank(),
+              statex->commHash());
+          // Ensure async error is set so callers see a non-success result
+          // via getResult(). The abort flag may have been set externally
+          // (e.g. comm->abort()) without setting the async exception.
+          if (comm->getAsyncError()->getAsyncResult() == commSuccess) {
+            comm->getAsyncError()->setAsyncException(
+                ctran::utils::Exception(
+                    "collective skipped: communicator aborted",
+                    commRemoteError));
+          }
+        } else {
+          CTRAN_ASYNC_ERR_GUARD_FAULT_TOLERANCE(comm, {
+            FB_COMMCHECKTHROW_EX(
+                cmd->coll.func(cmd->coll.opGroup), comm->logMetaData_);
+          });
+        }
 
         if (cmd->persistent) {
           for (const auto& x : cmd->coll.opGroup) {

--- a/comms/ctran/gpe/tests/CtranGpeFaultToleranceUT.cc
+++ b/comms/ctran/gpe/tests/CtranGpeFaultToleranceUT.cc
@@ -176,7 +176,9 @@ class CtranGpeFaultToleranceTestBase : public ::ctran::CtranStandaloneFixture {
       void* kernelFn,
       cudaStream_t stream,
       FtTestSync* sync,
-      std::optional<std::chrono::milliseconds> timeout = std::nullopt);
+      std::optional<std::chrono::milliseconds> timeout = std::nullopt,
+      opFunc func = &CtranGpeFtTestAlgoFn,
+      const void* sendbuff = nullptr);
 };
 
 void CtranGpeFaultToleranceTestBase::launchKernelFn(
@@ -184,15 +186,17 @@ void CtranGpeFaultToleranceTestBase::launchKernelFn(
     void* kernelFn,
     cudaStream_t stream,
     FtTestSync* sync,
-    std::optional<std::chrono::milliseconds> timeout) {
+    std::optional<std::chrono::milliseconds> timeout,
+    opFunc func,
+    const void* sendbuff) {
   commResult_t res = commSuccess;
 
   uint64_t dummyOpCount = 100;
   std::vector<std::unique_ptr<struct OpElem>> ops;
   auto op = std::make_unique<struct OpElem>(
       OpElem::opType::SEND, stream, ctranComm.get(), dummyOpCount);
-  // hack to pass sync to the test opFunc
-  op->send.sendbuff = sync;
+  // hack to pass sync/data to the test opFunc via sendbuff
+  op->send.sendbuff = sendbuff ? sendbuff : sync;
   op->send.count = 0;
   op->send.datatype = commInt8;
   op->send.peerRank = 0;
@@ -207,8 +211,7 @@ void CtranGpeFaultToleranceTestBase::launchKernelFn(
   args.terminate = oobKernelTerminateFlag;
   kernelConfig.algoArgs = &args;
 
-  res = gpe->submit(
-      std::move(ops), &CtranGpeFtTestAlgoFn, kernelConfig, kernelFn, timeout);
+  res = gpe->submit(std::move(ops), func, kernelConfig, kernelFn, timeout);
 
   EXPECT_EQ(res, commSuccess);
 }
@@ -519,5 +522,60 @@ INSTANTIATE_TEST_SUITE_P(
         CtranGpeFTEnabledAbortFromErrorTest::ParamType>& info) {
       return std::get<0>(info.param);
     });
+
+// Impl function that sets a global flag to prove it was called.
+static std::atomic<bool> g_secondImplCalled{false};
+
+commResult_t CtranGpeFtTestRecordCallAlgoFn(
+    const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
+  g_secondImplCalled.store(true);
+  return commSuccess;
+}
+
+// Test: after abort from first collective, second collective's impl is skipped.
+// This verifies the fix for the double-complete bug where progressInternal()
+// would access stale VC queue entries from the previously aborted collective.
+TEST_F(CtranGpeFTEnabledTest, SecondCollectiveSkippedAfterAbort) {
+  ASSERT_TRUE(ctranComm->abortEnabled());
+  g_secondImplCalled.store(false);
+
+  auto gpe = std::make_unique<CtranGpe>(cudaDev, ctranComm.get());
+
+  // Collective 1: will throw, causing abort
+  FtTestSync sync1;
+  sync1.setException(
+      ctran::utils::Exception("test abort exception", commRemoteError));
+
+  this->launchKernelFn(
+      gpe.get(),
+      (void*)CtranGpeTestFtEnabledOobTerminateKernel,
+      stream,
+      &sync1);
+
+  // Let OobKernel terminate and unblock collective 1's impl
+  *oobKernelTerminateFlag = true;
+  sync1.signal();
+
+  // Wait for collective 1 to complete and abort to be set
+  tryQueryStreamFor(stream, kHostAlgoFnWait + std::chrono::milliseconds(1000));
+  ASSERT_TRUE(ctranComm->testAbort()) << "comm should be aborted after coll 1";
+
+  // Submit collective 2 with a different impl — should be skipped
+  this->launchKernelFn(
+      gpe.get(),
+      (void*)CtranGpeTestFtEnabledOobTerminateKernel,
+      stream,
+      nullptr,
+      std::nullopt,
+      &CtranGpeFtTestRecordCallAlgoFn);
+
+  // Wait for GPE thread to process collective 2.
+  // Busy-wait on kernel flags rather than sleeping to avoid flakiness.
+  while (gpe->numInUseKernelFlags() > 0) {
+  }
+
+  EXPECT_FALSE(g_secondImplCalled.load())
+      << "second collective's impl should be skipped after abort";
+}
 
 } // namespace ctran::fttesting


### PR DESCRIPTION
Summary:

P2245791250

After a PAFT abort, the GPE thread continues processing queued collectives.
Each collective's impl() calls progressInternal() (via waitRequest/testRequest),
which polls the IB CQ and hits stale postedReqs_ entries left by the previously
aborted collective. Due to stack address reuse, the stale entries point to the
same memory as the new collective's requests, causing deterministic
double-complete (refCount_ < 0) or segfault.

The root cause is that the GPE loop had no abort check between dequeuing a
command and calling cmd->coll.func(). All 11 algorithm impl() functions call
progressInternal() before any abort check.

This fix adds a comm->testAbort() guard before cmd->coll.func() in the GPE
thread. When the communicator is already aborted, the collective impl() is
skipped entirely. The kernel handshake (wait for KERNEL_STARTED) and kernel
teardown (KERNEL_HOST_ABORT) are unaffected.

**The stale VC queue entries hold dangling references** (reference_wrapper,
CtranIbRequest&, CtranIbRequest*) to destroyed request objects. Dereferencing
any of them is undefined behavior — that is exactly the bug. After this fix
they are never dereferenced:

- GPE loop after abort: the guard skips impl(), and nothing else in the loop
  calls progressInternal(). Stale deque entries are never accessed.
- GPE thread termination: ~CtranGpe enqueues TERMINATE, GPE thread exits,
  thread_.join() completes. The thread is fully stopped.
- VC/CQ destruction: ~CtranMapper -> ~CtranIb -> releaseRemoteTransStates()
  -> rankToVcMap.clear() -> ~CtranIbVirtualConn. Deque destructors destroy
  reference_wrappers, unique_ptr<ControlPendingSendWr> (defaulted dtor), and
  raw pointers — all no-ops that never dereference the target. The hardware CQ
  is destroyed after VCs, discarding stale CQEs.
- Order guarantee: ICtran.h declares mapper before gpe, so C++ destroys gpe
  first (terminates thread), then mapper (destroys IB/VCs/CQ). No concurrent
  access is possible.

Reviewed By: arttianezhu

Differential Revision: D97566618


