### PR TITLE
Fix Category A2: remove redundant getMpiInfo() from NcclxBaseTest subclasses

### DIFF
--- a/comms/ncclx/v2_27/meta/colltrace/tests/CollTraceDistTest.cc
+++ b/comms/ncclx/v2_27/meta/colltrace/tests/CollTraceDistTest.cc
@@ -51,7 +51,6 @@ class CollTraceTest : public NcclxBaseTest {
     setenv("NCCL_CTRAN_ENABLE", "1", 0);
 
     NcclxBaseTest::SetUp();
-    std::tie(this->localRank, this->globalRank, this->numRanks) = getMpiInfo();
 
     CUDACHECK_TEST(cudaSetDevice(this->localRank));
     CUDACHECK_TEST(cudaStreamCreate(&this->stream));
@@ -159,9 +158,6 @@ class CollTraceTest : public NcclxBaseTest {
   }
 
  protected:
-  int localRank{0};
-  int globalRank{0};
-  int numRanks{0};
   int* sendBuf{nullptr};
   int* recvBuf{nullptr};
   void* sendHandle{nullptr};

--- a/comms/ncclx/v2_27/meta/colltrace/tests/MapperTraceDistTest.cc
+++ b/comms/ncclx/v2_27/meta/colltrace/tests/MapperTraceDistTest.cc
@@ -46,7 +46,6 @@ class MapperTraceTest : public NcclxBaseTest {
     setenv("NCCL_CTRAN_ENABLE", "1", 0);
 
     NcclxBaseTest::SetUp();
-    std::tie(this->localRank, this->globalRank, this->numRanks) = getMpiInfo();
 
     CUDACHECK_TEST(cudaSetDevice(this->localRank));
     CUDACHECK_TEST(cudaStreamCreate(&this->stream));
@@ -68,9 +67,6 @@ class MapperTraceTest : public NcclxBaseTest {
   }
 
  protected:
-  int localRank{0};
-  int globalRank{0};
-  int numRanks{0};
   int* sendBuf{nullptr};
   int* recvBuf{nullptr};
   void* sendHandle{nullptr};

--- a/comms/ncclx/v2_27/meta/colltrace/tests/NewCollTraceDistTestLocal.cc
+++ b/comms/ncclx/v2_27/meta/colltrace/tests/NewCollTraceDistTestLocal.cc
@@ -41,7 +41,6 @@ class CollTraceTestLocal : public NcclxBaseTest {
     setenv("NCCL_CTRAN_IB_EPOCH_LOCK_ENFORCE_CHECK", "true", 0);
 
     NcclxBaseTest::SetUp();
-    std::tie(this->localRank, this->globalRank, this->numRanks) = getMpiInfo();
 
     CUDACHECK_TEST(cudaSetDevice(this->localRank));
     CUDACHECK_TEST(cudaStreamCreate(&this->stream));
@@ -66,9 +65,6 @@ class CollTraceTestLocal : public NcclxBaseTest {
   }
 
  protected:
-  int localRank{0};
-  int globalRank{0};
-  int numRanks{0};
   int* sendBuf{nullptr};
   int* recvBuf{nullptr};
   void* sendHandle{nullptr};

--- a/comms/ncclx/v2_27/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
+++ b/comms/ncclx/v2_27/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
@@ -47,7 +47,6 @@ class CollTraceTest : public NcclxBaseTest {
     setenv("NCCL_COLLTRACE_USE_NEW_COLLTRACE", "1", 0);
 
     NcclxBaseTest::SetUp();
-    std::tie(this->localRank, this->globalRank, this->numRanks) = getMpiInfo();
 
     CUDACHECK_TEST(cudaSetDevice(this->localRank));
     CUDACHECK_TEST(cudaStreamCreate(&this->stream));
@@ -155,9 +154,6 @@ class CollTraceTest : public NcclxBaseTest {
   }
 
  protected:
-  int localRank{0};
-  int globalRank{0};
-  int numRanks{0};
   int* sendBuf{nullptr};
   int* recvBuf{nullptr};
   void* sendHandle{nullptr};

--- a/comms/ncclx/v2_27/meta/comms-monitor/tests/CommsMonitorDist.cc
+++ b/comms/ncclx/v2_27/meta/comms-monitor/tests/CommsMonitorDist.cc
@@ -30,7 +30,6 @@ class CommsMonitorDist : public NcclxBaseTest {
  public:
   void SetUp() override {
     NcclxBaseTest::SetUp();
-    std::tie(this->localRank, this->globalRank, this->numRanks) = getMpiInfo();
 
     ncclCvarInit();
     NCCL_COMMSMONITOR_ENABLE = true;
@@ -53,9 +52,6 @@ class CommsMonitorDist : public NcclxBaseTest {
   }
 
  protected:
-  int localRank{0};
-  int globalRank{0};
-  int numRanks{0};
   int* sendBuf{nullptr};
   int* recvBuf{nullptr};
   void* sendHandle{nullptr};

--- a/comms/ncclx/v2_28/meta/colltrace/tests/CollTraceDistTest.cc
+++ b/comms/ncclx/v2_28/meta/colltrace/tests/CollTraceDistTest.cc
@@ -51,7 +51,6 @@ class CollTraceTest : public NcclxBaseTest {
     setenv("NCCL_CTRAN_ENABLE", "1", 0);
 
     NcclxBaseTest::SetUp();
-    std::tie(this->localRank, this->globalRank, this->numRanks) = getMpiInfo();
 
     CUDACHECK_TEST(cudaSetDevice(this->localRank));
     CUDACHECK_TEST(cudaStreamCreate(&this->stream));
@@ -159,9 +158,6 @@ class CollTraceTest : public NcclxBaseTest {
   }
 
  protected:
-  int localRank{0};
-  int globalRank{0};
-  int numRanks{0};
   int* sendBuf{nullptr};
   int* recvBuf{nullptr};
   void* sendHandle{nullptr};

--- a/comms/ncclx/v2_28/meta/colltrace/tests/MapperTraceDistTest.cc
+++ b/comms/ncclx/v2_28/meta/colltrace/tests/MapperTraceDistTest.cc
@@ -46,7 +46,6 @@ class MapperTraceTest : public NcclxBaseTest {
     setenv("NCCL_CTRAN_ENABLE", "1", 0);
 
     NcclxBaseTest::SetUp();
-    std::tie(this->localRank, this->globalRank, this->numRanks) = getMpiInfo();
 
     CUDACHECK_TEST(cudaSetDevice(this->localRank));
     CUDACHECK_TEST(cudaStreamCreate(&this->stream));
@@ -68,9 +67,6 @@ class MapperTraceTest : public NcclxBaseTest {
   }
 
  protected:
-  int localRank{0};
-  int globalRank{0};
-  int numRanks{0};
   int* sendBuf{nullptr};
   int* recvBuf{nullptr};
   void* sendHandle{nullptr};

--- a/comms/ncclx/v2_28/meta/colltrace/tests/NewCollTraceDistTestLocal.cc
+++ b/comms/ncclx/v2_28/meta/colltrace/tests/NewCollTraceDistTestLocal.cc
@@ -41,7 +41,6 @@ class CollTraceTestLocal : public NcclxBaseTest {
     setenv("NCCL_CTRAN_IB_EPOCH_LOCK_ENFORCE_CHECK", "true", 0);
 
     NcclxBaseTest::SetUp();
-    std::tie(this->localRank, this->globalRank, this->numRanks) = getMpiInfo();
 
     CUDACHECK_TEST(cudaSetDevice(this->localRank));
     CUDACHECK_TEST(cudaStreamCreate(&this->stream));
@@ -66,9 +65,6 @@ class CollTraceTestLocal : public NcclxBaseTest {
   }
 
  protected:
-  int localRank{0};
-  int globalRank{0};
-  int numRanks{0};
   int* sendBuf{nullptr};
   int* recvBuf{nullptr};
   void* sendHandle{nullptr};

--- a/comms/ncclx/v2_28/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
+++ b/comms/ncclx/v2_28/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
@@ -47,7 +47,6 @@ class CollTraceTest : public NcclxBaseTest {
     setenv("NCCL_COLLTRACE_USE_NEW_COLLTRACE", "1", 0);
 
     NcclxBaseTest::SetUp();
-    std::tie(this->localRank, this->globalRank, this->numRanks) = getMpiInfo();
 
     CUDACHECK_TEST(cudaSetDevice(this->localRank));
     CUDACHECK_TEST(cudaStreamCreate(&this->stream));
@@ -155,9 +154,6 @@ class CollTraceTest : public NcclxBaseTest {
   }
 
  protected:
-  int localRank{0};
-  int globalRank{0};
-  int numRanks{0};
   int* sendBuf{nullptr};
   int* recvBuf{nullptr};
   void* sendHandle{nullptr};

--- a/comms/ncclx/v2_28/meta/comms-monitor/tests/CommsMonitorDist.cc
+++ b/comms/ncclx/v2_28/meta/comms-monitor/tests/CommsMonitorDist.cc
@@ -30,7 +30,6 @@ class CommsMonitorDist : public NcclxBaseTest {
  public:
   void SetUp() override {
     NcclxBaseTest::SetUp();
-    std::tie(this->localRank, this->globalRank, this->numRanks) = getMpiInfo();
 
     ncclCvarInit();
     NCCL_COMMSMONITOR_ENABLE = true;
@@ -53,9 +52,6 @@ class CommsMonitorDist : public NcclxBaseTest {
   }
 
  protected:
-  int localRank{0};
-  int globalRank{0};
-  int numRanks{0};
   int* sendBuf{nullptr};
   int* recvBuf{nullptr};
   void* sendHandle{nullptr};

--- a/comms/ncclx/v2_29/meta/colltrace/tests/CollTraceDistTest.cc
+++ b/comms/ncclx/v2_29/meta/colltrace/tests/CollTraceDistTest.cc
@@ -51,7 +51,6 @@ class CollTraceTest : public NcclxBaseTest {
     setenv("NCCL_CTRAN_ENABLE", "1", 0);
 
     NcclxBaseTest::SetUp();
-    std::tie(this->localRank, this->globalRank, this->numRanks) = getMpiInfo();
 
     CUDACHECK_TEST(cudaSetDevice(this->localRank));
     CUDACHECK_TEST(cudaStreamCreate(&this->stream));
@@ -159,9 +158,6 @@ class CollTraceTest : public NcclxBaseTest {
   }
 
  protected:
-  int localRank{0};
-  int globalRank{0};
-  int numRanks{0};
   int* sendBuf{nullptr};
   int* recvBuf{nullptr};
   void* sendHandle{nullptr};

--- a/comms/ncclx/v2_29/meta/colltrace/tests/MapperTraceDistTest.cc
+++ b/comms/ncclx/v2_29/meta/colltrace/tests/MapperTraceDistTest.cc
@@ -46,7 +46,6 @@ class MapperTraceTest : public NcclxBaseTest {
     setenv("NCCL_CTRAN_ENABLE", "1", 0);
 
     NcclxBaseTest::SetUp();
-    std::tie(this->localRank, this->globalRank, this->numRanks) = getMpiInfo();
 
     CUDACHECK_TEST(cudaSetDevice(this->localRank));
     CUDACHECK_TEST(cudaStreamCreate(&this->stream));
@@ -68,9 +67,6 @@ class MapperTraceTest : public NcclxBaseTest {
   }
 
  protected:
-  int localRank{0};
-  int globalRank{0};
-  int numRanks{0};
   int* sendBuf{nullptr};
   int* recvBuf{nullptr};
   void* sendHandle{nullptr};

--- a/comms/ncclx/v2_29/meta/colltrace/tests/NewCollTraceDistTestLocal.cc
+++ b/comms/ncclx/v2_29/meta/colltrace/tests/NewCollTraceDistTestLocal.cc
@@ -41,7 +41,6 @@ class CollTraceTestLocal : public NcclxBaseTest {
     setenv("NCCL_CTRAN_IB_EPOCH_LOCK_ENFORCE_CHECK", "true", 0);
 
     NcclxBaseTest::SetUp();
-    std::tie(this->localRank, this->globalRank, this->numRanks) = getMpiInfo();
 
     CUDACHECK_TEST(cudaSetDevice(this->localRank));
     CUDACHECK_TEST(cudaStreamCreate(&this->stream));
@@ -66,9 +65,6 @@ class CollTraceTestLocal : public NcclxBaseTest {
   }
 
  protected:
-  int localRank{0};
-  int globalRank{0};
-  int numRanks{0};
   int* sendBuf{nullptr};
   int* recvBuf{nullptr};
   void* sendHandle{nullptr};

--- a/comms/ncclx/v2_29/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
+++ b/comms/ncclx/v2_29/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
@@ -47,7 +47,6 @@ class CollTraceTest : public NcclxBaseTest {
     setenv("NCCL_COLLTRACE_USE_NEW_COLLTRACE", "1", 0);
 
     NcclxBaseTest::SetUp();
-    std::tie(this->localRank, this->globalRank, this->numRanks) = getMpiInfo();
 
     CUDACHECK_TEST(cudaSetDevice(this->localRank));
     CUDACHECK_TEST(cudaStreamCreate(&this->stream));
@@ -155,9 +154,6 @@ class CollTraceTest : public NcclxBaseTest {
   }
 
  protected:
-  int localRank{0};
-  int globalRank{0};
-  int numRanks{0};
   int* sendBuf{nullptr};
   int* recvBuf{nullptr};
   void* sendHandle{nullptr};

--- a/comms/ncclx/v2_29/meta/comms-monitor/tests/CommsMonitorDist.cc
+++ b/comms/ncclx/v2_29/meta/comms-monitor/tests/CommsMonitorDist.cc
@@ -30,7 +30,6 @@ class CommsMonitorDist : public NcclxBaseTest {
  public:
   void SetUp() override {
     NcclxBaseTest::SetUp();
-    std::tie(this->localRank, this->globalRank, this->numRanks) = getMpiInfo();
 
     ncclCvarInit();
     NCCL_COMMSMONITOR_ENABLE = true;
@@ -53,9 +52,6 @@ class CommsMonitorDist : public NcclxBaseTest {
   }
 
  protected:
-  int localRank{0};
-  int globalRank{0};
-  int numRanks{0};
   int* sendBuf{nullptr};
   int* recvBuf{nullptr};
   void* sendHandle{nullptr};


### PR DESCRIPTION
Summary:
Remove redundant `getMpiInfo()` calls and shadowing member variables from 5 test classes that already inherit `NcclxBaseTest`. The base class's `SetUp()` calls `getTcpStoreOrMpiInfo()` which correctly populates `this->localRank`, `this->globalRank`, `this->numRanks` — the redundant `getMpiInfo()` call crashes under RE TCPStore mode because MPI is never initialized.

Changes per file (× 3 versions v2_27/v2_28/v2_29 = 15 files):
- Remove `std::tie(this->localRank, this->globalRank, this->numRanks) = getMpiInfo();`
- Remove shadowing `int localRank{0}; int globalRank{0}; int numRanks{0};` declarations

Affected tests: CommsMonitorDist, MapperTraceDistTest, CollTraceDistTest, NewCollTraceDistTestLocal, NewCollTraceDistTestNoLocal

Reviewed By: Regina8023

Differential Revision: D96979952


