### PR TITLE
Disable IB backend on machines without InfiniBand

### DIFF
--- a/comms/torchcomms/scripts/run_tests_integration_py.sh
+++ b/comms/torchcomms/scripts/run_tests_integration_py.sh
@@ -7,6 +7,14 @@
 
 set -ex
 
+# If no InfiniBand devices are present, disable the IB backend to avoid
+# CtranIbSingleton init failures ("Operation not permitted") and cascading
+# CUDA graph registration errors.
+if [ ! -d /sys/class/infiniband ] || [ -z "$(ls /sys/class/infiniband 2>/dev/null)" ]; then
+    echo "No InfiniBand devices found, disabling IB backend"
+    export NCCL_CTRAN_BACKENDS="socket"
+fi
+
 cd "$(dirname "$0")/../tests/integration/py"
 
 run_tests () {


### PR DESCRIPTION
Summary:
D91240027 switched memory registration from per-comm (ncclCommRegister) to
global (ncclGlobalRegisterWithPtr), which routes directly into ctran's RegCache.
This causes CtranIbSingleton to initialize earlier during attachMemoryHook(),
triggering dlopen("libibverbs.so.1") which fails with "Operation not permitted"
on OSS CI runners (AWS G5 instances) that lack InfiniBand hardware. The IB init
failure cascades into CUDA graph registration errors (e.g. test_graph_all_gather_single).

Fix: detect the absence of IB devices via /sys/class/infiniband and set
NCCL_CTRAN_BACKENDS="socket" to skip IB backend initialization. On machines
with IB hardware, the full set of backends is used unchanged.

Differential Revision: D97674101


