### PR TITLE
Export getDevMemType and getCudaDevFromPtr in version script

### DIFF
--- a/comms/ncclx/v2_27/src/version.script
+++ b/comms/ncclx/v2_27/src/version.script
@@ -11,6 +11,8 @@ cxa: Folly’s exception tracer intercepts all exceptions and uses
       *nccl*;
       *ctran*;
       *cxa*;
+      getDevMemType;
+      getCudaDevFromPtr;
   /* Transitive symbols (e.g. coming from static libs) are not exported */
   local:
       *;

--- a/comms/ncclx/v2_28/src/version.script
+++ b/comms/ncclx/v2_28/src/version.script
@@ -11,6 +11,8 @@ cxa: Folly’s exception tracer intercepts all exceptions and uses
       *nccl*;
       *ctran*;
       *cxa*;
+      getDevMemType;
+      getCudaDevFromPtr;
   /* Transitive symbols (e.g. coming from static libs) are not exported */
   local:
       *;

--- a/comms/ncclx/v2_29/src/version.script
+++ b/comms/ncclx/v2_29/src/version.script
@@ -11,6 +11,8 @@ cxa: Folly’s exception tracer intercepts all exceptions and uses
       *nccl*;
       *ctran*;
       *cxa*;
+      getDevMemType;
+      getCudaDevFromPtr;
   /* Transitive symbols (e.g. coming from static libs) are not exported */
   local:
       *;


### PR DESCRIPTION
Summary:
Add getDevMemType and getCudaDevFromPtr to the version script's global
section across v2_27, v2_28, and v2_29. These symbols from
comms/ctran/utils/DevMemType.cc are compiled into libnccl.so but were
hidden by the version script (only *nccl*, *ctran*, *cxa* patterns
were exported). When torchcomms _comms_ncclx.so dynamically links
against libnccl.so in conda builds (USE_SYSTEM_LIBS=1), the hidden
symbols cause an ImportError at runtime.

This was exposed by D96335937 which enabled ENABLE_PIPES=1 in the RL
conda, causing nccl_device headers to be installed, which enables
TORCHCOMMS_HAS_NCCL_DEVICE_API, which compiles the getDevMemType call
in TorchCommWindowNCCLX.cpp:127 (added by D97057976).

The issue only affects conda builds — Buck uses static linking where
the version script is not applied.

Differential Revision: D97687129


