### PR TITLE
Add Conveyor cogwheel config for comms test fbpkg

### DIFF
--- a/comms/ctran/cogwheel/comms_dist_test.py
+++ b/comms/ctran/cogwheel/comms_dist_test.py
@@ -1,0 +1,100 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+import asyncio
+import logging
+
+from comms.ctran.cogwheel.comms_mast import (
+    build_app,
+    COMMS_FBPKG_NAME,
+    JOB_TIMEOUT_SEC,
+    MAST_CFG,
+)
+from hpc_comms.cclops.cogwheel.common import BenchmarkCogwheelTest
+from torchx.runner import get_runner
+from torchx.specs import AppState
+from windtunnel.cogwheel.test import cogwheel_test
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+POLL_INTERVAL_SEC = 60
+
+
+class CommsDistTest(BenchmarkCogwheelTest):
+    """Cogwheel test for comms distributed tests via Conveyor.
+
+    Builds the comms test fbpkg via Conveyor and schedules a single MAST
+    job on 2 H100 nodes that runs all test binaries sequentially.
+    """
+
+    _app_handle: str | None = None
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._app_handle = None
+        self._runner = get_runner()
+
+    def tearDown(self) -> None:
+        if self._app_handle is not None:
+            try:
+                self._runner.cancel(self._app_handle)
+                logger.info("Cancelled MAST job: %s", self._app_handle)
+            except Exception as e:
+                logger.error("Failed to cancel MAST job %s: %s", self._app_handle, e)
+        super().tearDown()
+
+    @cogwheel_test
+    async def test_comms_dist(self) -> None:
+        """Build comms test fbpkg and run all tests sequentially in one MAST job."""
+        fbpkg_version = self.get_fbpkg_version(COMMS_FBPKG_NAME)
+        fbpkg_id = f"{COMMS_FBPKG_NAME}:{fbpkg_version}"
+        logger.info("Comms test fbpkg: %s", fbpkg_id)
+        self.add_custom_link(
+            "comms_test_fbpkg",
+            f"https://www.internalfb.com/intern/fbpkg/?name={COMMS_FBPKG_NAME}&version={fbpkg_version}",
+        )
+
+        version_prefix = fbpkg_version[:12]
+        job_name = f"comms-dist-test-{version_prefix}"
+        app = build_app(fbpkg_id, job_name)
+
+        logger.info("Scheduling MAST job: %s", job_name)
+        dryrun_info = self._runner.dryrun(app=app, scheduler="mast", cfg=MAST_CFG)
+        self._app_handle = self._runner.schedule(dryrun_info)
+
+        status = self._runner.status(self._app_handle)
+        if status and status.ui_url:
+            self.add_custom_link("mast_job", status.ui_url)
+        logger.info("Scheduled MAST job: %s (handle=%s)", job_name, self._app_handle)
+
+        # Poll until completion.
+        elapsed = 0
+        while elapsed < JOB_TIMEOUT_SEC:
+            await asyncio.sleep(POLL_INTERVAL_SEC)
+            elapsed += POLL_INTERVAL_SEC
+            status = self._runner.status(self._app_handle)
+            if status is None:
+                self.fail(f"MAST job no longer exists ({self._app_handle})")
+            state = status.state
+            logger.info(
+                "MAST job status: %s (%ds/%ds)",
+                state.name,
+                elapsed,
+                JOB_TIMEOUT_SEC,
+            )
+            if state == AppState.SUCCEEDED:
+                self._app_handle = None
+                return
+            if state in (AppState.FAILED, AppState.CANCELLED):
+                self.fail(f"MAST job {state.name}: {self._app_handle}")
+
+        self.fail(f"MAST job did not complete within {JOB_TIMEOUT_SEC}s")
+
+
+def main() -> None:
+    CommsDistTest().main()
+
+
+if __name__ == "__main__":
+    main()

--- a/comms/ctran/cogwheel/comms_mast.py
+++ b/comms/ctran/cogwheel/comms_mast.py
@@ -1,0 +1,115 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""
+Shared TorchX MAST job configuration for comms distributed tests.
+
+Used by both the cogwheel test (comms_dist_test.py) and the manual
+launcher (manual_launch.py).
+"""
+
+from typing import Dict
+
+from torchx.specs import AppDef, CfgVal, named_resources, Role
+
+COMMS_FBPKG_NAME: str = "hpc_comms.tests.latest"
+COMMS_ENTITLEMENT: str = "infra_genai_ncclx"
+JOB_TIMEOUT_SEC: int = 3600
+
+# Test binaries included in the comms test fbpkg.
+# Keep in sync with _COMMS_TESTS in fbcode/comms/def_mast.bzl.
+COMMS_TEST_BINARIES: list[str] = [
+    "allgather_test_2x1",
+    "allgather_test_2x8",
+    "ctran_dist_rma_2x4",
+    "fast_init_test_2x8",
+    "multi_stream_test_2x8",
+]
+
+# Inline launch script for MAST tasks.
+# Runs all test binaries sequentially. For each binary, launches
+# LOCAL_SIZE processes (one per GPU) and waits for completion.
+RUN_SCRIPT: str = r"""
+set -euo pipefail
+FBPKG_NAME="${MAST_APPLICATION_PACKAGES%%:*}"
+IFS="," read -r -a hosts <<< "$MAST_HPC_TASK_GROUP_HOSTNAMES"
+NUM_HOSTS=${#hosts[@]}
+export MASTER_ADDR=${MASTER_ADDR:-${hosts[0]}}
+export MASTER_PORT=${MASTER_PORT:-29500}
+IDX=$TW_TASK_ID
+
+for binary_name in $TEST_BINARIES; do
+    binary="/packages/$FBPKG_NAME/$binary_name"
+    if [ ! -f "$binary" ]; then
+        echo "=== SKIP $binary_name (not found) ==="
+        continue
+    fi
+    local_size=$(echo "$binary_name" | grep -oP '\d+x\K\d+' | head -1)
+    local_size=${local_size:-8}
+    export LOCAL_SIZE=$local_size
+    export WORLD_SIZE=$(( NUM_HOSTS * local_size ))
+    echo "=== Running $binary_name (LOCAL_SIZE=$local_size, WORLD_SIZE=$WORLD_SIZE, MASTER_PORT=$MASTER_PORT) ==="
+    for i in $(seq 0 $((local_size - 1))); do
+        LOCAL_RANK=$i GLOBAL_RANK=$((IDX * local_size + i)) "$binary" &
+    done
+    wait
+    echo "=== Done $binary_name ==="
+done
+echo "=== All tests completed ==="
+""".strip()
+
+# TorchX scheduler config for MAST.
+MAST_CFG: Dict[str, CfgVal] = {
+    "rmAttribution": COMMS_ENTITLEMENT,
+    "hpcIdentity": "networkai_mast_job_identity",
+    "hpcClusterUuid": "MastProdCluster",
+    "hpcJobOncall": "networkai_comms",
+    "smcTier": "mast.api.write",
+    "runningTimeoutSec": JOB_TIMEOUT_SEC,
+    "useStrictName": True,
+}
+
+
+def build_app(
+    fbpkg_id: str,
+    job_name: str,
+    test_binaries: list[str] | None = None,
+) -> AppDef:
+    """Build a TorchX AppDef that runs test binaries sequentially on 2 H100 nodes.
+
+    Args:
+        fbpkg_id: fbpkg identifier (e.g. "hpc_comms.tests.latest:<hash>")
+        job_name: MAST job name
+        test_binaries: list of binary names to run. Defaults to COMMS_TEST_BINARIES.
+    """
+    if test_binaries is None:
+        test_binaries = COMMS_TEST_BINARIES
+
+    resource = named_resources["grandteton"]
+
+    role = Role(
+        name="trainer",
+        image=fbpkg_id,
+        entrypoint="/bin/bash",
+        args=["-c", RUN_SCRIPT],
+        num_replicas=2,
+        resource=resource,
+        env={
+            "TEST_BINARIES": " ".join(test_binaries),
+            "NCCL_DEBUG": "WARN",
+        },
+        port_map={"tcp": 29500},
+        max_retries=0,
+    )
+
+    return AppDef(
+        name=job_name,
+        roles=[role],
+        metadata={
+            "rmAttribution": COMMS_ENTITLEMENT,
+            "hpcIdentity": "networkai_mast_job_identity",
+            "hpcClusterUuid": "MastProdCluster",
+            "hpcJobOncall": "networkai_comms",
+        },
+    )

--- a/comms/ctran/cogwheel/manual_launch.py
+++ b/comms/ctran/cogwheel/manual_launch.py
@@ -1,0 +1,102 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""
+Manual launcher to test comms binaries on MAST via TorchX.
+
+Usage:
+  # Run all test binaries sequentially:
+  buck2 run //comms/ctran/cogwheel:manual_launch -- \
+    --img hpc_comms.tests.latest:<hash>
+
+  # Run a specific test binary:
+  buck2 run //comms/ctran/cogwheel:manual_launch -- \
+    --img hpc_comms.tests.latest:<hash> \
+    --test-binary fast_init_test_2x8
+"""
+
+import argparse
+import logging
+import sys
+import time
+
+from comms.ctran.cogwheel.comms_mast import build_app, COMMS_TEST_BINARIES, MAST_CFG
+from torchx.runner import get_runner
+from torchx.specs import AppState
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+    force=True,
+)
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Manual comms test MAST launcher")
+    parser.add_argument(
+        "--img",
+        required=True,
+        help="fbpkg image (e.g. hpc_comms.tests.latest:<hash>)",
+    )
+    parser.add_argument(
+        "--test-binary",
+        nargs="+",
+        default=None,
+        help="test binary name(s) to run (default: all)",
+    )
+    parser.add_argument("--job-name", default=None, help="custom job name")
+    parser.add_argument("--wait", action="store_true", help="wait for job to complete")
+    parser.add_argument(
+        "--timeout", type=int, default=3600, help="job timeout in seconds"
+    )
+    args = parser.parse_args()
+
+    test_binaries = args.test_binary or COMMS_TEST_BINARIES
+    job_name = args.job_name or "comms-dist-test-manual"
+    app = build_app(args.img, job_name, test_binaries)
+
+    runner = get_runner()
+    logger.info("Submitting job: %s", job_name)
+    logger.info("Image: %s", args.img)
+    logger.info("Test binaries: %s", " ".join(test_binaries))
+
+    dryrun_info = runner.dryrun(app=app, scheduler="mast", cfg=MAST_CFG)
+    handle = runner.schedule(dryrun_info)
+
+    status = runner.status(handle)
+    if status and status.ui_url:
+        logger.info("MAST job URL: %s", status.ui_url)
+    logger.info("App handle: %s", handle)
+
+    if not args.wait:
+        logger.info("Job submitted. Use --wait to poll until completion.")
+        return
+
+    logger.info("Waiting for job to complete (timeout=%ds)...", args.timeout)
+    elapsed = 0
+    poll_interval = 30
+    while elapsed < args.timeout:
+        time.sleep(poll_interval)
+        elapsed += poll_interval
+        status = runner.status(handle)
+        if status is None:
+            logger.error("Job no longer exists")
+            sys.exit(1)
+        state = status.state
+        logger.info("Status: %s (%ds/%ds)", state.name, elapsed, args.timeout)
+        if state in (AppState.SUCCEEDED, AppState.FAILED, AppState.CANCELLED):
+            if state == AppState.SUCCEEDED:
+                logger.info("Job SUCCEEDED")
+            else:
+                logger.error("Job %s", state.name)
+                sys.exit(1)
+            return
+
+    logger.error("Job timed out after %ds", args.timeout)
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Summary:
Set up Conveyor integration for comms distributed test fbpkg builds and MAST job scheduling.

**Cogwheel test** (`cogwheel_comms_dist_test`):
- Triggers Conveyor to build `hpc_comms.tests.latest` fbpkg via `fbpkg_builders`
- Monitors `comms/` path for changes (manual trigger, not diff-time)
- Schedules individual MAST jobs per test binary on 2 H100 nodes using TorchX
- Uses `specs.AppDef` + `specs.Role` with bash entrypoint and inline run script
- Jobs submitted via `get_runner().dryrun()` + `schedule()` with `scheduler="mast"`
- Polls job status via `runner.status()` and asserts `AppState.SUCCEEDED`
- Automatic job cancellation via `runner.cancel()` in tearDown if test fails/is interrupted
- Each test binary runs as a separate MAST job for isolation and fault tolerance
- Reports fbpkg version and per-test MAST job URLs as cogwheel links

Depends on D95135816 which defines the `hpc_comms.tests.{tag}` fbpkg builders.

Differential Revision: D97217117


