### PR TITLE
detect correct cuda arch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,10 +25,32 @@ message(STATUS "  USE_TRANSPORT  : ${USE_TRANSPORT}")
 message(STATUS "  USE_TRITON     : ${USE_TRITON}")
 message(STATUS "  BUILD_TESTS    : ${BUILD_TESTS}")
 
-if(NOT DEFINED ENV{TORCH_CUDA_ARCH_LIST})
-    set(TORCH_CUDA_ARCH_LIST "9.0")
-else()
+if(DEFINED ENV{TORCH_CUDA_ARCH_LIST})
     set(TORCH_CUDA_ARCH_LIST $ENV{TORCH_CUDA_ARCH_LIST})
+else()
+    # Auto-detect from nvidia-smi, fall back to 9.0.
+    # Without this, .cu kernels (e.g. AtomicAddKernel.cu) are compiled only
+    # for sm_90 and fail at runtime on other GPUs with
+    # "no kernel image is available for execution on the device".
+    # See also: comms/torchcomms/triton/CMakeLists.txt for the same pattern.
+    execute_process(
+        COMMAND nvidia-smi --query-gpu=compute_cap --format=csv,noheader
+        OUTPUT_VARIABLE _smi_output
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+        RESULT_VARIABLE _smi_result
+    )
+    if(_smi_result EQUAL 0 AND _smi_output)
+        # Deduplicate compute capabilities across all GPUs
+        # (e.g. "9.0\n9.0\n9.0\n9.0" -> "9.0")
+        string(REPLACE "\n" ";" _cc_list "${_smi_output}")
+        list(REMOVE_DUPLICATES _cc_list)
+        list(JOIN _cc_list ";" TORCH_CUDA_ARCH_LIST)
+        message(STATUS "Auto-detected CUDA architectures from nvidia-smi: ${TORCH_CUDA_ARCH_LIST}")
+    else()
+        set(TORCH_CUDA_ARCH_LIST "9.0")
+        message(STATUS "nvidia-smi not available, defaulting CUDA architecture to 9.0")
+    endif()
 endif()
 message(STATUS "TORCH_CUDA_ARCH_LIST : ${TORCH_CUDA_ARCH_LIST}")
 


### PR DESCRIPTION
Summary:
this should fix:

```
======================================================================
ERROR: test_graph_all_gather_single_input_deleted (__main__.AllGatherSingleTest.test_graph_all_gather_single_input_deleted) (count=1048576, dtype=torch.int32)
Test CUDA Graph all_gather_single with input deleted after graph creation.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/meta-pytorch/torchcomms/comms/torchcomms/tests/integration/py/AllGatherSingleTest.py", line 293, in test_graph_all_gather_single_input_deleted
    self._graph_all_gather_single_input_deleted(count, dtype)
  File "/meta-pytorch/torchcomms/comms/torchcomms/tests/integration/py/AllGatherSingleTest.py", line 193, in _graph_all_gather_single_input_deleted
    self.torchcomm.all_gather_single(output_tensor, input_tensor, False)
RuntimeError: Failed to record replay counter increment: no kernel image is available for execution on the device at /meta-pytorch/torchcomms/comms/torchcomms/ncclx/GraphEventTracker.cpp:83
```

when CI isn't running on H100's

Differential Revision: D97790394


