### PR TITLE
Extract bootstrap-based NcclCommUtils with unique commDesc fix (#1217)

### DIFF
--- a/comms/ncclx/meta/tests/NcclCommUtils.cc
+++ b/comms/ncclx/meta/tests/NcclCommUtils.cc
@@ -1,0 +1,144 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
+
+#include <atomic>
+#include <string>
+
+#include "comms/testinfra/TestUtils.h"
+
+namespace ncclx::test {
+
+namespace {
+std::atomic<int> commCounter{
+    0}; // NOLINT(facebook-avoid-non-const-global-variables)
+
+int getNextCommId() {
+  return commCounter.fetch_add(1);
+}
+} // namespace
+
+ncclComm_t createNcclComm(
+    int globalRank,
+    int numRanks,
+    int devId,
+    meta::comms::ITestBootstrap* bootstrap,
+    bool isMock,
+    ncclConfig_t* customConfig) {
+  ncclComm_t comm = nullptr;
+  ncclConfig_t config;
+  if (customConfig) {
+    config = *customConfig;
+  } else {
+    config = NCCL_CONFIG_INITIALIZER;
+  }
+
+  // Generate a unique commDesc per communicator to avoid stale TCPStore keys
+  // when fast-init mode reuses the same TCPStore across multiple test cases.
+  // Only override when the caller didn't explicitly set commDesc via
+  // ncclConfig_t.commDesc or ncclConfig_t.hints.
+  const auto commDesc =
+      std::string(kNcclUtCommDesc) + "_" + std::to_string(getNextCommId());
+  const bool hasCommDescInHints = [&] {
+    if (config.hints == nullptr) {
+      return false;
+    }
+    std::string val;
+    const auto* hints = static_cast<const ncclx::Hints*>(config.hints);
+    return hints->get("commDesc", val) == ncclSuccess;
+  }();
+  if (config.commDesc == nullptr && !hasCommDescInHints) {
+    config.commDesc = commDesc.c_str();
+  }
+
+  ncclUniqueId id;
+  if (globalRank == 0) {
+    NCCLCHECK_TEST(ncclGetUniqueId(&id));
+  }
+  auto bcastRes =
+      bootstrap->broadcast(&id, sizeof(id), 0, globalRank, numRanks);
+  if (std::move(bcastRes).get() != 0) {
+    LOG(FATAL) << "broadcast ncclUniqueId failed";
+  }
+
+  CUDACHECK_TEST(cudaSetDevice(devId));
+
+  auto initRes =
+      ncclCommInitRankConfig(&comm, numRanks, id, globalRank, &config);
+  if (initRes != ncclInProgress) {
+    if (isMock) {
+      NCCLCHECKTHROW_TEST(initRes);
+    } else {
+      NCCLCHECK_TEST(initRes);
+    }
+  }
+
+  return comm;
+}
+
+// NcclCommRAII
+
+NcclCommRAII::NcclCommRAII(
+    int globalRank,
+    int numRanks,
+    int localRank,
+    meta::comms::ITestBootstrap* bootstrap,
+    bool isMock,
+    ncclConfig_t* config) {
+  comm_ = createNcclComm(
+      globalRank, numRanks, localRank, bootstrap, isMock, config);
+}
+
+NcclCommRAII::~NcclCommRAII() {
+  NCCLCHECK_TEST(ncclCommDestroy(comm_));
+}
+
+ncclComm& NcclCommRAII::operator*() {
+  return *comm_;
+}
+
+ncclComm_t NcclCommRAII::operator->() const {
+  return comm_;
+}
+
+ncclComm_t NcclCommRAII::get() const {
+  return comm_;
+}
+
+NcclCommRAII::operator ncclComm_t() const {
+  return comm_;
+}
+
+// NcclCommSplitRAII
+
+NcclCommSplitRAII::NcclCommSplitRAII(
+    ncclComm_t parentComm,
+    int color,
+    int key,
+    ncclConfig_t* config) {
+  const ncclResult_t res =
+      ncclCommSplit(parentComm, color, key, &comm_, config);
+  NCCLCHECK_TEST(res);
+}
+
+NcclCommSplitRAII::~NcclCommSplitRAII() {
+  NCCLCHECK_TEST(ncclCommDestroy(comm_));
+}
+
+ncclComm& NcclCommSplitRAII::operator*() {
+  return *comm_;
+}
+
+ncclComm_t NcclCommSplitRAII::operator->() const {
+  return comm_;
+}
+
+ncclComm_t NcclCommSplitRAII::get() const {
+  return comm_;
+}
+
+NcclCommSplitRAII::operator ncclComm_t() const {
+  return comm_;
+}
+
+} // namespace ncclx::test

--- a/comms/ncclx/meta/tests/NcclCommUtils.h
+++ b/comms/ncclx/meta/tests/NcclCommUtils.h
@@ -1,0 +1,72 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include "comms/testinfra/ITestBootstrap.h"
+#include "nccl.h" // @manual
+
+namespace ncclx::test {
+
+// Create a NCCL communicator using ITestBootstrap for ncclUniqueId broadcast.
+// Generates a unique commDesc per call to avoid stale TCPStore keys when
+// fast-init mode reuses the same TCPStore across multiple test cases.
+// Only overrides commDesc when the caller didn't explicitly set it.
+ncclComm_t createNcclComm(
+    int globalRank,
+    int numRanks,
+    int devId,
+    meta::comms::ITestBootstrap* bootstrap,
+    bool isMock = false,
+    ncclConfig_t* customConfig = nullptr);
+
+// RAII wrapper for ncclComm_t created via createNcclComm with bootstrap.
+// Automatically calls ncclCommDestroy in destructor.
+class NcclCommRAII {
+ public:
+  NcclCommRAII(
+      int globalRank,
+      int numRanks,
+      int localRank,
+      meta::comms::ITestBootstrap* bootstrap,
+      bool isMock = false,
+      ncclConfig_t* config = nullptr);
+
+  ~NcclCommRAII();
+
+  NcclCommRAII(const NcclCommRAII&) = delete;
+  NcclCommRAII& operator=(const NcclCommRAII&) = delete;
+
+  ncclComm& operator*();
+  ncclComm_t operator->() const;
+  ncclComm_t get() const;
+  operator ncclComm_t() const;
+
+ private:
+  ncclComm_t comm_;
+};
+
+// RAII wrapper for ncclComm_t created via ncclCommSplit.
+// Does not call finalizeNcclComm since the parent comm handles that.
+class NcclCommSplitRAII {
+ public:
+  NcclCommSplitRAII(
+      ncclComm_t parentComm,
+      int color,
+      int key,
+      ncclConfig_t* config = nullptr);
+
+  ~NcclCommSplitRAII();
+
+  NcclCommSplitRAII(const NcclCommSplitRAII&) = delete;
+  NcclCommSplitRAII& operator=(const NcclCommSplitRAII&) = delete;
+
+  ncclComm& operator*();
+  ncclComm_t operator->() const;
+  ncclComm_t get() const;
+  operator ncclComm_t() const;
+
+ private:
+  ncclComm_t comm_;
+};
+
+} // namespace ncclx::test


### PR DESCRIPTION
Summary:

Extract bootstrap-based createNcclComm, NcclCommRAII, and NcclCommSplitRAII into new ncclx::test namespace in comms/ncclx/meta/tests/NcclCommUtils.h/.cc:
- createNcclComm generates a unique commDesc per communicator via an atomic counter ("nccl_ut_0", "nccl_ut_1", ...) to avoid stale TCPStore keys when fast-init mode reuses the same TCPStore across multiple test cases
- Only overrides commDesc when the caller didn't explicitly set it (config.commDesc == nullptr), so tests like CommDescTest that set a custom commDesc are unaffected
- NcclCommRAII wraps createNcclComm with automatic ncclCommDestroy in destructor
- NcclCommSplitRAII wraps ncclCommSplit with automatic ncclCommDestroy
- Uses ncclx_meta_cpp_library macro to generate per-version targets (v2_27, v2_28, v2_29)

TODO: we will replace callsites of existing createNcclComm|NcclCommRAII| NcclCommSplitRAII, then finally remove the old APIs in `testinfra/TestsDistUtils.h`, to avoid implicit NCCL dependency outside ncclx/ tests

Reviewed By: Regina8023

Differential Revision: D97593186
