### PR TITLE
Add extraSegments support in CtranIpcMem::ipcExport() and CtranIpcRemMem::import() (#1218)

### DIFF
--- a/comms/ctran/regcache/tests/DistRegCacheUT.cc
+++ b/comms/ctran/regcache/tests/DistRegCacheUT.cc
@@ -237,7 +237,8 @@ TEST_P(DistRegCacheTestSuite, ExportImportMem) {
 
     EXPECT_EQ(msg.type, ControlMsgType::NVL_EXPORT_MEM);
     EXPECT_EQ(msg.ipcDesc.desc.range, ipcMem->getRange());
-    EXPECT_EQ(msg.ipcDesc.desc.numSegments, 1);
+    EXPECT_EQ(msg.ipcDesc.desc.numInlineSegments(), 1);
+    EXPECT_EQ(msg.ipcDesc.desc.totalSegments, 1);
     EXPECT_NE(msg.ipcDesc.desc.segments[0].sharedHandle.fd, 0);
     EXPECT_GT(msg.ipcDesc.desc.segments[0].range, 0);
     EXPECT_EQ(msg.ipcDesc.desc.pid, getpid());
@@ -329,7 +330,8 @@ TEST_F(DistRegCacheTest, ExportReleaseMemCb) {
       struct ctran::regcache::IpcDesc IpcDesc;
       COMMCHECK_TEST(ipcRegCache->exportMem(data, ipcRegElem, IpcDesc));
       EXPECT_EQ(IpcDesc.desc.range, ipcMemSize);
-      EXPECT_EQ(IpcDesc.desc.numSegments, 1);
+      EXPECT_EQ(IpcDesc.desc.numInlineSegments(), 1);
+      EXPECT_EQ(IpcDesc.desc.totalSegments, 1);
       EXPECT_GT(IpcDesc.desc.segments[0].range, 0);
       COMMCHECK_TEST(ipcRegCache->notifyRemoteIpcExport(
           myId, peerServerAddrs[peer], IpcDesc, &exportReqs[peer - 1]));

--- a/comms/ctran/utils/CtranIpc.cc
+++ b/comms/ctran/utils/CtranIpc.cc
@@ -86,14 +86,64 @@ static inline CUmemAllocationHandleType getCuMemExportHandleType(
 }
 
 commResult_t ctran::utils::CtranIpcMem::ipcExport(CtranIpcDesc& ipcDesc) {
-  // FIXME: we need either fallback to IB or support numSegments > 2 case via
-  // variable length control msg
-  if (allocHandles_.size() > CTRAN_IPC_INLINE_SEGMENTS) {
+  std::vector<CtranIpcSegDesc> extraSegments;
+  FB_COMMCHECK(ipcExport(ipcDesc, extraSegments));
+  if (!extraSegments.empty()) {
     CLOGF(
         ERR,
         "CTRAN-IPC: tried to export CtranIpcMem backed by too many physical memory allocations. [{}]",
         this->toString());
     return commInternalError;
+  }
+  return commSuccess;
+}
+
+inline commResult_t ctran::utils::CtranIpcMem::exportSegmentSharedHandle(
+    int segIdx,
+    CUmemAllocationHandleType exportHandleType) {
+  if (sharedHandlesInitialized_[segIdx]) {
+    return commSuccess;
+  }
+
+  if (memType_ == DevMemType::kCumem) {
+    bool isCumemFabric = false;
+#if CUDART_VERSION >= 12040
+    isCumemFabric = (exportHandleType == CU_MEM_HANDLE_TYPE_FABRIC);
+#endif
+    if (isCumemFabric) {
+      FB_CUCHECK(cuMemExportToShareableHandle(
+          &sharedHandles_[segIdx].handle,
+          allocHandles_[segIdx],
+          exportHandleType,
+          0));
+    } else {
+      FB_CUCHECK(cuMemExportToShareableHandle(
+          &sharedHandles_[segIdx].fd,
+          allocHandles_[segIdx],
+          CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR,
+          0));
+    }
+  } else if (memType_ == DevMemType::kCudaMalloc) {
+    void* p = (void*)pbase_;
+    FB_CUDACHECK(cudaIpcGetMemHandle(&sharedHandles_[segIdx].cudaIpcHandle, p));
+  } else {
+    FB_ERRORRETURN(
+        commInternalError,
+        "CTRAN-IPC: unsupported memory type {}",
+        devMemTypeStr(memType_));
+  }
+
+  sharedHandlesInitialized_[segIdx] = true;
+  return commSuccess;
+}
+
+commResult_t ctran::utils::CtranIpcMem::ipcExport(
+    CtranIpcDesc& ipcDesc,
+    std::vector<CtranIpcSegDesc>& extraSegments) {
+  const int totalSegments = allocHandles_.size();
+
+  if (totalSegments <= 0) {
+    FB_ERRORRETURN(commInvalidArgument, "CTRAN-IPC: no segments to export");
   }
 
   // Export handle
@@ -103,52 +153,40 @@ commResult_t ctran::utils::CtranIpcMem::ipcExport(CtranIpcDesc& ipcDesc) {
   ipcDesc.memType = memType_;
   ipcDesc.cuMemHandleType = exportHandleType;
 
-  for (int i = 0; i < allocHandles_.size(); i++) {
-    // Reuse handle if already exported
-    if (!sharedHandlesInitialized_[i]) {
-      if (memType_ == DevMemType::kCumem) {
-        bool isCumemFabric = false;
-#if CUDART_VERSION >= 12040
-        isCumemFabric = (exportHandleType == CU_MEM_HANDLE_TYPE_FABRIC);
-#endif
-        if (isCumemFabric) {
-          FB_CUCHECK(cuMemExportToShareableHandle(
-              &sharedHandles_[i].handle,
-              allocHandles_[i],
-              exportHandleType,
-              0));
-        } else {
-          FB_CUCHECK(cuMemExportToShareableHandle(
-              &sharedHandles_[i].fd,
-              allocHandles_[i],
-              CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR,
-              0));
-        }
-      } else if (memType_ == DevMemType::kCudaMalloc) {
-        void* p = (void*)pbase_;
-        FB_CUDACHECK(cudaIpcGetMemHandle(&sharedHandles_[i].cudaIpcHandle, p));
-      } else {
-        FB_ERRORRETURN(
-            commInternalError,
-            "CTRAN-IPC: unsupported memory type {}",
-            devMemTypeStr(ipcDesc.memType));
-      }
-    }
+  const int inlineEnd = std::min(totalSegments, CTRAN_IPC_INLINE_SEGMENTS);
 
-    sharedHandlesInitialized_[i] = true;
+  // Fill the inline segments in ipcDesc
+  for (int i = 0; i < inlineEnd; i++) {
+    FB_COMMCHECK(exportSegmentSharedHandle(i, exportHandleType));
     ipcDesc.segments[i].sharedHandle = sharedHandles_[i];
     ipcDesc.segments[i].range = segmentRanges_[i];
   }
 
-  ipcDesc.numSegments = allocHandles_.size();
+  // Zero out unused inline slots
+  for (int i = inlineEnd; i < CTRAN_IPC_INLINE_SEGMENTS; i++) {
+    ipcDesc.segments[i] = CtranIpcSegDesc{};
+  }
+
+  // Fill extra segments beyond CTRAN_IPC_INLINE_SEGMENTS
+  extraSegments.clear();
+  for (int i = CTRAN_IPC_INLINE_SEGMENTS; i < totalSegments; i++) {
+    FB_COMMCHECK(exportSegmentSharedHandle(i, exportHandleType));
+    CtranIpcSegDesc seg;
+    seg.sharedHandle = sharedHandles_[i];
+    seg.range = segmentRanges_[i];
+    extraSegments.push_back(seg);
+  }
+
+  ipcDesc.totalSegments = totalSegments;
   ipcDesc.pid = getpid();
   ipcDesc.base = this->getBase();
   ipcDesc.range = this->getRange();
 
   CLOGF_TRACE(
       ALLOC,
-      "CTRAN-IPC: exported mem [{}] to ipcDesc: {}",
+      "CTRAN-IPC: exported mem [{}] to ipcDesc (extraSegments={}): {}",
       this->toString(),
+      extraSegments.size(),
       ipcDesc.toString());
 
   return commSuccess;
@@ -264,8 +302,8 @@ inline commResult_t ctran::utils::CtranIpcMem::tryLoadCuMem(
   //   the allocation's handle type. Used in LOAD mode to validate that
   //   user-provided memory can be exported.
 
-  // temp linear loop through physical allocations, could be faster to get from
-  // pytorch level
+  // temp linear loop through physical allocations, could be faster to get
+  // from pytorch level
   size_t cur_offset = 0;
   while (cur_offset < len) {
     const void* cur_ptr = (char*)ptr + cur_offset;
@@ -354,8 +392,8 @@ inline commResult_t CtranIpcMem::tryLoadCudaMallocMem(
 }
 
 commResult_t ctran::utils::CtranIpcMem::free() {
-  // In case context has already been destroyed by PyTorch, all resources should
-  // already be released. Thus, safe to skip here.
+  // In case context has already been destroyed by PyTorch, all resources
+  // should already be released. Thus, safe to skip here.
   CUcontext pctx;
   FB_CUCHECK(cuCtxGetCurrent(&pctx));
   if (pctx == nullptr) {
@@ -428,7 +466,8 @@ ctran::utils::CtranIpcRemMem::CtranIpcRemMem(
     const CtranIpcDesc& ipcDesc,
     const int cudaDev,
     const struct CommLogData* logMetaData,
-    const char* desc)
+    const char* desc,
+    const std::vector<CtranIpcSegDesc>& extraSegments)
     : cudaDev_(cudaDev),
       logMetaData_(logMetaData),
       desc_(desc),
@@ -437,7 +476,7 @@ ctran::utils::CtranIpcRemMem::CtranIpcRemMem(
   if (!CtranIpcSupport()) {
     FB_COMMCHECKTHROW_EX_NOCOMM(commInternalError);
   }
-  FB_COMMCHECKTHROW_EX_NOCOMM(this->import(ipcDesc));
+  FB_COMMCHECKTHROW_EX_NOCOMM(this->import(ipcDesc, extraSegments));
 };
 
 ctran::utils::CtranIpcRemMem::~CtranIpcRemMem() {
@@ -449,17 +488,30 @@ ctran::utils::CtranIpcRemMem::~CtranIpcRemMem() {
   // https://stackoverflow.com/questions/130117/if-you-shouldnt-throw-exceptions-in-a-destructor-how-do-you-handle-errors-in-i
 }
 
-commResult_t ctran::utils::CtranIpcRemMem::import(const CtranIpcDesc& ipcDesc) {
+commResult_t ctran::utils::CtranIpcRemMem::import(
+    const CtranIpcDesc& ipcDesc,
+    const std::vector<CtranIpcSegDesc>& extraSegments) {
   range_ = ipcDesc.range;
   remPid_ = ipcDesc.pid;
 
-  remHandles_.resize(ipcDesc.numSegments);
-  segmentRanges_.resize(ipcDesc.numSegments);
-  allocHandles_.resize(ipcDesc.numSegments);
+  remHandles_.resize(ipcDesc.totalSegments);
+  segmentRanges_.resize(ipcDesc.totalSegments);
+  allocHandles_.resize(ipcDesc.totalSegments);
 
-  for (int i = 0; i < ipcDesc.numSegments; i++) {
+  // Copy inline segments from ipcDesc
+  for (int i = 0; i < ipcDesc.numInlineSegments(); i++) {
     remHandles_[i] = ipcDesc.segments[i].sharedHandle;
     segmentRanges_[i] = ipcDesc.segments[i].range;
+  }
+
+  // Copy extra segments
+  for (size_t i = 0; i < extraSegments.size(); i++) {
+    int idx = CTRAN_IPC_INLINE_SEGMENTS + i;
+    if (idx >= ipcDesc.totalSegments) {
+      break;
+    }
+    remHandles_[idx] = extraSegments[i].sharedHandle;
+    segmentRanges_[idx] = extraSegments[i].range;
   }
 
   if (ipcDesc.memType == DevMemType::kCumem) {
@@ -538,11 +590,11 @@ commResult_t CtranIpcRemMem::importCuMem(const CtranIpcDesc& ipcDesc) {
 }
 
 commResult_t CtranIpcRemMem::importCudaMallocMem(const CtranIpcDesc& ipcDesc) {
-  if (ipcDesc.numSegments != 1) {
+  if (ipcDesc.totalSegments != 1) {
     CLOGF(
         ERR,
         "CTRAN-IPC: Number of segments is expected to be 1, but got {}",
-        ipcDesc.numSegments);
+        ipcDesc.totalSegments);
     return commInternalError;
   }
 
@@ -557,8 +609,8 @@ commResult_t CtranIpcRemMem::importCudaMallocMem(const CtranIpcDesc& ipcDesc) {
 }
 
 commResult_t ctran::utils::CtranIpcRemMem::release() {
-  // In case context has already been destroyed by PyTorch, all resources should
-  // already be released. Thus, safe to skip here.
+  // In case context has already been destroyed by PyTorch, all resources
+  // should already be released. Thus, safe to skip here.
   CUcontext pctx;
   FB_CUCHECK(cuCtxGetCurrent(&pctx));
   if (pctx == nullptr) {

--- a/comms/ctran/utils/CtranIpc.h
+++ b/comms/ctran/utils/CtranIpc.h
@@ -3,6 +3,7 @@
 #ifndef CTRAN_IPC_H_
 #define CTRAN_IPC_H_
 
+#include <algorithm>
 #include <sstream>
 #include <vector>
 
@@ -90,7 +91,8 @@ static inline void printHandle(
 #define CTRAN_IPC_INLINE_SEGMENTS 2
 
 struct CtranIpcDesc {
-  int numSegments{0};
+  // Total number of segments including any extra segments beyond inline.
+  int totalSegments{0};
   void* base{nullptr};
   size_t range{0};
   // pass local pid for peer to import sharedHandle as file descriptor
@@ -100,6 +102,11 @@ struct CtranIpcDesc {
 
   // Preallocated payload for multi-segment IPC memory.
   CtranIpcSegDesc segments[CTRAN_IPC_INLINE_SEGMENTS] = {};
+
+  // Number of valid entries in the inline segments[] array.
+  int numInlineSegments() const {
+    return std::min(totalSegments, CTRAN_IPC_INLINE_SEGMENTS);
+  }
 
   std::string toString() const {
     std::stringstream ss;
@@ -172,12 +179,19 @@ class CtranIpcMem {
       // work on AMD
       bool shouldSupportCudaMalloc = false);
 
-  // Export the memory range to a CtranIpcDesc for remote process importing
-  // Input arguments:
-  //   - ipcDesc: the information to be filled with the memory range exporting.
-  //              Caller is responsible for sending the descriptor to the remote
-  //              process.
+  // Export the memory range to a CtranIpcDesc for remote process importing.
+  // The first min(totalSegments, CTRAN_IPC_INLINE_SEGMENTS) segments are placed
+  // into ipcDesc.segments[]. ipcDesc.totalSegments is set to the full segment
+  // count.
+  // remaining segments beyond INLINE are returned in extraSegments (empty when
+  // totalSegments <= CTRAN_IPC_INLINE_SEGMENTS).
+  // Returns commInternalError via the no-extraSegments overload when
+  // totalSegments > CTRAN_IPC_INLINE_SEGMENTS and the caller cannot handle
+  // them.
   commResult_t ipcExport(CtranIpcDesc& ipcDesc);
+  commResult_t ipcExport(
+      CtranIpcDesc& ipcDesc,
+      std::vector<CtranIpcSegDesc>& extraSegments);
 
   // Free the memory range and associated handles.
   // Note: recommending call free explicitly to check potential cuda failure.
@@ -228,6 +242,9 @@ class CtranIpcMem {
  private:
   commResult_t alloc(const size_t size);
 
+  inline commResult_t exportSegmentSharedHandle(
+      int segIdx,
+      CUmemAllocationHandleType exportHandleType);
   inline commResult_t freeCuMem();
   inline commResult_t freeCudaMallocMem();
 
@@ -264,11 +281,14 @@ class CtranIpcRemMem {
   //   - logMetaData: logMetaData of the communicator for memory logging
   //                  purposes
   //   - desc: description of the usage of the memory range to be imported
+  //   - extraSegments: extra segment descriptors beyond
+  //   CTRAN_IPC_INLINE_SEGMENTS
   CtranIpcRemMem(
       const CtranIpcDesc& ipcDesc,
       const int cudaDev,
       const struct CommLogData* logMetaData,
-      const char* desc);
+      const char* desc,
+      const std::vector<CtranIpcSegDesc>& extraSegments = {});
 
   // Release the memory range and associated handles
   ~CtranIpcRemMem();
@@ -319,7 +339,9 @@ class CtranIpcRemMem {
   }
 
  private:
-  commResult_t import(const CtranIpcDesc& ipcDesc);
+  commResult_t import(
+      const CtranIpcDesc& ipcDesc,
+      const std::vector<CtranIpcSegDesc>& extraSegments = {});
   commResult_t importCuMem(const CtranIpcDesc& ipcDesc);
   commResult_t importCudaMallocMem(const CtranIpcDesc& ipcDesc);
 

--- a/comms/ctran/utils/tests/IpcDistUT.cc
+++ b/comms/ctran/utils/tests/IpcDistUT.cc
@@ -219,7 +219,7 @@ TEST_P(IpcExportImportTest, ExportImport) {
   EXPECT_EQ(ipcDesc.base, ipcMem->getBase());
   EXPECT_EQ(ipcDesc.pid, getpid());
   EXPECT_EQ(ipcDesc.cuMemHandleType, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR);
-  EXPECT_EQ(ipcDesc.numSegments, 1);
+  EXPECT_EQ(ipcDesc.numInlineSegments(), 1);
   EXPECT_NE(ipcDesc.segments[0].sharedHandle.fd, 0);
   for (int i = 1; i < CTRAN_IPC_INLINE_SEGMENTS; i++) {
     EXPECT_EQ(ipcDesc.segments[i].sharedHandle.fd, 0);
@@ -233,7 +233,7 @@ TEST_P(IpcExportImportTest, ExportImport) {
   EXPECT_GE(peerIpcDesc.range, size);
   EXPECT_NE(peerIpcDesc.base, nullptr);
   EXPECT_NE(peerIpcDesc.pid, 0);
-  EXPECT_EQ(peerIpcDesc.numSegments, 1);
+  EXPECT_EQ(peerIpcDesc.numInlineSegments(), 1);
   EXPECT_EQ(
       peerIpcDesc.cuMemHandleType, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR);
   EXPECT_NE(peerIpcDesc.segments[0].sharedHandle.fd, 0);
@@ -334,8 +334,8 @@ TEST_F(IpcTest, DisjointExportImport) {
   EXPECT_EQ(ipcDesc.base, ipcMem->getBase());
   EXPECT_EQ(ipcDesc.pid, getpid());
   EXPECT_EQ(ipcDesc.cuMemHandleType, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR);
-  EXPECT_EQ(ipcDesc.numSegments, disjointSegmentSizes.size());
-  for (int i = 0; i < ipcDesc.numSegments; i++) {
+  EXPECT_EQ(ipcDesc.numInlineSegments(), disjointSegmentSizes.size());
+  for (int i = 0; i < ipcDesc.numInlineSegments(); i++) {
     EXPECT_NE(ipcDesc.segments[i].sharedHandle.fd, 0);
     EXPECT_EQ(ipcDesc.segments[i].range, disjointSegmentSizes[i]);
   }
@@ -348,10 +348,10 @@ TEST_F(IpcTest, DisjointExportImport) {
   EXPECT_GE(peerIpcDesc.range, size);
   EXPECT_NE(peerIpcDesc.base, nullptr);
   EXPECT_NE(peerIpcDesc.pid, 0);
-  EXPECT_EQ(peerIpcDesc.numSegments, disjointSegmentSizes.size());
+  EXPECT_EQ(peerIpcDesc.numInlineSegments(), disjointSegmentSizes.size());
   EXPECT_EQ(
       peerIpcDesc.cuMemHandleType, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR);
-  for (int i = 0; i < peerIpcDesc.numSegments; i++) {
+  for (int i = 0; i < peerIpcDesc.numInlineSegments(); i++) {
     EXPECT_NE(peerIpcDesc.segments[i].sharedHandle.fd, 0);
     EXPECT_EQ(peerIpcDesc.segments[i].range, disjointSegmentSizes[i]);
   }
@@ -438,8 +438,8 @@ TEST_F(IpcTest, DisjointExportOffset) {
   EXPECT_EQ(ipcDesc.base, ipcMem->getBase());
   EXPECT_EQ(ipcDesc.pid, getpid());
   EXPECT_EQ(ipcDesc.cuMemHandleType, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR);
-  EXPECT_EQ(ipcDesc.numSegments, disjointSegmentSizes.size());
-  for (int i = 0; i < ipcDesc.numSegments; i++) {
+  EXPECT_EQ(ipcDesc.numInlineSegments(), disjointSegmentSizes.size());
+  for (int i = 0; i < ipcDesc.numInlineSegments(); i++) {
     EXPECT_NE(ipcDesc.segments[i].sharedHandle.fd, 0);
     EXPECT_EQ(ipcDesc.segments[i].range, disjointSegmentSizes[i]);
   }
@@ -492,8 +492,32 @@ TEST_F(IpcTest, DisjointExportTooManyPhysicalBackings) {
   auto res = ipcMem->ipcExport(ipcDescs[rank]);
   EXPECT_EQ(res, commInternalError);
 
+  // The extraSegments overload succeeds and returns all segments
+  ctran::utils::CtranIpcDesc firstDesc{};
+  std::vector<ctran::utils::CtranIpcSegDesc> extraSegments;
+  res = ipcMem->ipcExport(firstDesc, extraSegments);
+  EXPECT_EQ(res, commSuccess);
+  EXPECT_EQ(
+      firstDesc.totalSegments, static_cast<int>(disjointSegmentSizes.size()));
+  EXPECT_EQ(firstDesc.numInlineSegments(), CTRAN_IPC_INLINE_SEGMENTS);
+  // First CTRAN_IPC_INLINE_SEGMENTS segments are in the descriptor
+  for (int i = 0; i < CTRAN_IPC_INLINE_SEGMENTS; i++) {
+    EXPECT_NE(firstDesc.segments[i].sharedHandle.fd, 0);
+    EXPECT_EQ(firstDesc.segments[i].range, disjointSegmentSizes[i]);
+  }
+  // Remaining segments are returned in extraSegments
+  ASSERT_EQ(
+      extraSegments.size(),
+      disjointSegmentSizes.size() - CTRAN_IPC_INLINE_SEGMENTS);
+  for (size_t i = 0; i < extraSegments.size(); i++) {
+    EXPECT_NE(extraSegments[i].sharedHandle.fd, 0);
+    EXPECT_EQ(
+        extraSegments[i].range,
+        disjointSegmentSizes[i + CTRAN_IPC_INLINE_SEGMENTS]);
+  }
+
   EXPECT_EQ(ipcMem->free(), commSuccess);
-  // Check IPC created in this test have been freed
+  EXPECT_EQ(ncclMemFreeDisjoint(buf, disjointSegmentSizes), ncclSuccess);
   EXPECT_EQ(ctran::utils::getActiveIpcMemCount(), commIpcCount);
   EXPECT_EQ(ctran::utils::getActiveIpcRemMemCount(), commIpcRemCount);
 }


### PR DESCRIPTION
Summary:

Due to size limit of `CtranIpcDesc` and further `ControlMsg`, we have to support multiple packets transport for exported memory segments.

To send >2 `CtranIpcSegDesc`:
1. we first add a `CtranIpcDesc` with an additional argument `totalSegments` to signal how many memory segments are there in this transaction / transportation
2. wrap additional `CtranIpcSegDesc`s directly into `ControlMsg`
3. send them to the peer, and depending on the # of segments, we may send multiple `ControlMsg`s.

This is only for allGatherCtrl, and since the algos using it (AllGatherP and Window) won't insert other IB WRs while invoking the allGatherCtrl, and the fact IB won't mess up the order of the packets, this design works and is free of out-of-order problems. The receiver knows exactly how many additional packets to expect and will issue the `iRecvCtrlImpl`s correctly.

Differential Revision: D96228113
