### PR TITLE
Reland: Migrate fbthrift to conda feedstock (#999)

### DIFF
--- a/build_ncclx.sh
+++ b/build_ncclx.sh
@@ -190,9 +190,6 @@ function build_third_party {
     build_fb_oss_library "https://github.com/facebook/mvfst" "$third_party_tag" quic
     build_fb_oss_library "https://github.com/facebook/wangle.git" "$third_party_tag" wangle "-DBUILD_TESTS=OFF"
     build_fb_oss_library "https://github.com/facebook/fbthrift.git" "$third_party_tag" thrift
-  else
-    # TODO: use feedstock fbthrift instead of github fbthrift for feedstock build
-    build_fb_oss_library "https://github.com/facebook/fbthrift.git" main thrift
   fi
   popd
 }
@@ -209,8 +206,13 @@ function build_comms_tracing_service {
   cp -r "${base_dir}/${include_prefix}"/* "$include_prefix"
   mv "$include_prefix"/CMakeLists.txt .
 
-  # set up the build config
-  cp -r /tmp/third-party/thrift/build .
+  if [[ -z "${NCCL_FEEDSTOCK_BUILD}" ]]; then
+    # Reuse thrift cmake build tree (source build path)
+    cp -r /tmp/third-party/thrift/build .
+  else
+    # fbthrift installed via conda — cmake finds it via CMAKE_PREFIX_PATH
+    mkdir -p build
+  fi
 
   # build the thrift service library
   cd build


### PR DESCRIPTION
Summary:

Reland of D95281925 and D97323845 (reverted by D97339147).

Migrate fbthrift from source build to conda feedstock dependency (T258498510):
- Gate the fbthrift `build_fb_oss_library` call behind `NCCL_FEEDSTOCK_BUILD` in
  `build_ncclx.sh`, so feedstock builds use the pre-built conda package instead
  of cloning from GitHub.
- Update `build_comms_tracing_service` to handle conda-installed fbthrift: when
  `NCCL_FEEDSTOCK_BUILD` is set, cmake finds fbthrift via `CMAKE_PREFIX_PATH`
  instead of copying the source build tree.
- Add `fbthrift` as a host dependency in `recipe.yaml`.
- Add cmake path fixups for fbthrift, wangle, and mvfst in `build.sh`.
- Add `fbthrift` feedstock to nccl test TOMLs (nccl.toml, nccl_gb200.toml).
- Add `fbthrift` feedstock and `folly`, `fizz`, `wangle`, `mvfst`, `fbthrift`
  install specs to flagship build TOMLs (h100, gb200, cu13, gbunified).
- Bump openssl and xz version pins in flagship build TOMLs to resolve
  dependency conflicts when rebuilding feedstocks (fizz needs xz>=5.8.2,
  folly needs openssl>=3.6.1).

Differential Revision: D97817807


