### PR TITLE
Move device API to base class and remove get_nccl_window (#1221)

### DIFF
--- a/comms/torchcomms/TorchCommPy.cpp
+++ b/comms/torchcomms/TorchCommPy.cpp
@@ -770,6 +770,98 @@ Example:
 
       )",
           py::arg("rank"),
+          py::call_guard<py::gil_scoped_release>())
+      .def(
+          "get_device_window",
+          [](TorchCommWindow& self, int sc, int cc, int bc) {
+            return reinterpret_cast<int64_t>(
+                self.get_device_window(sc, cc, bc));
+          },
+          R"(
+Get a device-side window handle for GPU-initiated operations.
+
+Returns a pointer (as int64) that can be passed to Triton kernels via
+the torchcomms_* extern functions (put_block, signal_block, etc.).
+
+The window is lazily created on first call and cached. Requires NCCLX
+backend with device API support (NCCLX 2.28+).
+
+Args:
+    signal_count: Number of signal slots to allocate (-1 for default).
+    counter_count: Number of counter slots to allocate (-1 for default).
+    barrier_count: Number of barrier slots to allocate (default 1).
+
+Returns:
+    int: Device window pointer as int64.
+
+Raises:
+    RuntimeError: If this backend does not yet support the device API.
+)",
+          py::arg("signal_count") = -1,
+          py::arg("counter_count") = -1,
+          py::arg("barrier_count") = 1,
+          py::call_guard<py::gil_scoped_release>())
+      .def(
+          "register_local_buffer",
+          [](TorchCommWindow& self, const at::Tensor& tensor) {
+            TorchCommWindow::DeviceBuffer buf;
+            {
+              py::gil_scoped_release release;
+              buf = self.register_local_buffer(tensor);
+            }
+            return py::make_tuple(
+                reinterpret_cast<int64_t>(buf.base_ptr),
+                static_cast<int64_t>(buf.size),
+                reinterpret_cast<int64_t>(buf.backend_window),
+                static_cast<int64_t>(buf.lkey));
+          },
+          R"(
+Register a local buffer for use as source in device-side put operations.
+
+NON-COLLECTIVE. Must call tensor_register() then get_device_window() first.
+
+Args:
+    tensor: Source tensor to register as a local buffer.
+
+Returns:
+    tuple: (base_ptr, size, backend_window, lkey) as int64 values.
+
+Raises:
+    RuntimeError: If this backend does not yet support the device API.
+)",
+          py::arg("tensor"))
+      .def(
+          "deregister_local_buffer",
+          [](TorchCommWindow& self,
+             int64_t base_ptr,
+             int64_t size,
+             int64_t backend_window,
+             int64_t lkey) {
+            TorchCommWindow::DeviceBuffer buf;
+            // NOLINTNEXTLINE(performance-no-int-to-ptr)
+            buf.base_ptr = reinterpret_cast<void*>(base_ptr);
+            buf.size = static_cast<size_t>(size);
+            // NOLINTNEXTLINE(performance-no-int-to-ptr)
+            buf.backend_window = reinterpret_cast<void*>(backend_window);
+            buf.lkey = static_cast<uint32_t>(lkey);
+            self.deregister_local_buffer(buf);
+          },
+          R"(
+Deregister a previously registered local buffer. NON-COLLECTIVE.
+
+Args:
+    base_ptr: From register_local_buffer() return tuple.
+    size: From register_local_buffer() return tuple.
+    backend_window: From register_local_buffer() return tuple.
+    lkey: From register_local_buffer() return tuple.
+
+Raises:
+    RuntimeError: If this backend does not yet support the device API.
+)",
+          py::arg("base_ptr"),
+          py::arg("size"),
+          py::arg("backend_window"),
+          py::arg("lkey"),
           py::call_guard<py::gil_scoped_release>());
 
   // Bind BatchSendRecv::P2POp class

--- a/comms/torchcomms/TorchCommWindow.hpp
+++ b/comms/torchcomms/TorchCommWindow.hpp
@@ -65,6 +65,43 @@ class TorchCommWindow {
 
   virtual std::shared_ptr<TorchCommWindowAttr> get_attr(int peerRank) = 0;
 
+  // ==========================================================================
+  // Device API — virtual methods for GPU-initiated communication.
+  //
+  // Default implementations throw so that existing backends (NCCL, Gloo, RCCL)
+  // continue to build and fail loudly at runtime until they add support.
+  // When all backends implement these, the defaults can be made pure virtual.
+  // ==========================================================================
+
+  // Buffer descriptor for a locally-registered source buffer.
+  // Passed to device-side put() as (base_ptr, size, backend_window).
+  struct DeviceBuffer {
+    void* base_ptr{nullptr};
+    size_t size{0};
+    void* backend_window{nullptr};
+    // RDMA local key in network byte order for IBGDA puts (PipesDeviceBackend).
+    // Zero for backends that do not use IBGDA (e.g., NCCLDeviceBackend).
+    uint32_t lkey{0};
+  };
+
+  virtual void* get_device_window(
+      int /*signal_count*/ = -1,
+      int /*counter_count*/ = -1,
+      int /*barrier_count*/ = 1) {
+    throw std::runtime_error(
+        "get_device_window is not yet supported by this backend");
+  }
+
+  virtual DeviceBuffer register_local_buffer(const at::Tensor&) {
+    throw std::runtime_error(
+        "register_local_buffer is not yet supported by this backend");
+  }
+
+  virtual void deregister_local_buffer(DeviceBuffer&) {
+    throw std::runtime_error(
+        "deregister_local_buffer is not yet supported by this backend");
+  }
+
   // Get the registered buffer's dtype (for torch.compile meta kernel)
   at::ScalarType getDtype() const {
     return buf_dtype_;

--- a/comms/torchcomms/_comms.pyi
+++ b/comms/torchcomms/_comms.pyi
@@ -264,6 +264,16 @@ class TorchCommWindow:
         rank: int,
     ) -> Any: ...
     def get_attr(self, peer_rank: int) -> TorchCommWindowAttr: ...
+    def get_device_window(
+        self,
+        signal_count: int = -1,
+        counter_count: int = -1,
+        barrier_count: int = 1,
+    ) -> int: ...
+    def register_local_buffer(self, tensor: Any) -> tuple[int, int, int, int]: ...
+    def deregister_local_buffer(
+        self, base_ptr: int, size: int, backend_window: int, lkey: int
+    ) -> None: ...
 
 class P2POpType(Enum):
     SEND = auto()

--- a/comms/torchcomms/ncclx/TorchCommNCCLXPy.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXPy.cpp
@@ -24,39 +24,6 @@ PYBIND11_MODULE(_comms_ncclx, m) {
 
   py::class_<TorchCommNCCLX, std::shared_ptr<TorchCommNCCLX>>(
       m, "TorchCommNCCLX")
-#ifdef TORCHCOMMS_HAS_NCCL_DEVICE_API
-      .def(
-          "new_window",
-          [](TorchCommNCCLX& self, const std::optional<at::Tensor>& tensor) {
-            py::gil_scoped_release release;
-            auto base = self.new_window(tensor);
-
-            // Try GIN backend first
-            auto gin_window =
-                std::dynamic_pointer_cast<TorchCommWindowNCCLXGin>(base);
-            if (gin_window) {
-              py::gil_scoped_acquire acquire;
-              return py::cast(std::move(gin_window));
-            }
-
-#if defined(ENABLE_PIPES)
-            // Try Pipes backend
-            auto pipes_window =
-                std::dynamic_pointer_cast<TorchCommWindowNCCLXPipes>(base);
-            if (pipes_window) {
-              py::gil_scoped_acquire acquire;
-              return py::cast(std::move(pipes_window));
-            }
-#endif
-
-            py::gil_scoped_acquire acquire;
-            throw std::runtime_error(
-                "new_window() returned an unknown window type. "
-                "This is an internal error.");
-            return py::object(); // unreachable, silences compiler warning
-          },
-          py::arg("tensor") = std::nullopt)
-#endif
       .def(
           "device_alltoallv_single",
           [](TorchCommNCCLX& self,
@@ -355,206 +322,22 @@ Returns:
       py::call_guard<py::gil_scoped_release>());
 
 #ifdef TORCHCOMMS_HAS_NCCL_DEVICE_API
-  // ==========================================================================
-  // Device API Bindings (requires NCCLX 2.28+)
-  // ==========================================================================
-  //
-  // These bindings expose the device window API for use with Triton kernels.
-  // The get_device_window() method returns a pointer (as int64) that can be
-  // passed to Triton extern functions (torchcomms_put, torchcomms_signal, etc.)
-  //
-  // Both GIN (TorchCommWindowNCCLXGin) and Pipes (TorchCommWindowNCCLXPipes)
-  // backends share the same template API. bind_window_common() registers
-  // the shared methods; backend-specific methods are added separately.
-
-  // Helper: bind methods common to both GIN and Pipes window classes.
-  auto bind_window_common = [](auto& cls) {
-    using WindowType = typename std::remove_reference_t<decltype(cls)>::type;
-
-    cls.def(
-           "tensor_register",
-           &WindowType::tensor_register,
-           R"(
-Register a tensor with this window.
-
-The tensor must be allocated from the RDMA-compatible memory pool
-obtained via torchcomms.get_mem_allocator(backend).
-
-Args:
-    tensor: A torch.Tensor allocated from the RDMA memory pool.
-    owning: If True (default), the window holds a reference to the tensor,
-        keeping its storage alive. If False, the window does NOT hold a
-        reference — the caller must ensure the tensor remains alive for the
-        window's lifetime. Use owning=False in CUDA graph capture mode to
-        allow tensor memory reuse within the graph.
-
-Example:
-    >>> pool = torch.cuda.MemPool(allocator)
-    >>> with torch.cuda.use_mem_pool(pool):
-    ...     buf = torch.zeros(1024, device='cuda')
-    >>> window.tensor_register(buf)
-)",
-           py::arg("tensor"),
-           py::arg("owning") = true,
-           py::call_guard<py::gil_scoped_release>())
-        .def(
-            "tensor_deregister",
-            &WindowType::tensor_deregister,
-            R"(
-Deregister the tensor from this window.
-
-Must be called before the window is destroyed if tensor_register was called.
-)",
-            py::call_guard<py::gil_scoped_release>())
-        .def(
-            "get_device_window",
-            [](WindowType& self,
-               int signal_count,
-               int counter_count,
-               int barrier_count) {
-              auto* ptr = self.get_device_window(
-                  signal_count, counter_count, barrier_count);
-              // Return as int64 for safe passage through Python to Triton
-              return reinterpret_cast<int64_t>(ptr);
-            },
-            R"(
-Get a device-side window handle for GPU-initiated operations.
-
-Returns a pointer (as int64) that can be passed to Triton kernels via
-the torchcomms_* extern functions (torchcomms_put, torchcomms_signal, etc.).
-
-The window is lazily created on first call and cached. The returned pointer
-is valid until this host window is destroyed.
-
-Args:
-    signal_count: Number of signal slots to allocate (-1 for default).
-    counter_count: Number of counter slots to allocate (-1 for default).
-    barrier_count: Number of barrier slots to allocate (default 1).
-
-Returns:
-    int: Device window pointer as int64, suitable for passing to Triton kernels.
-
-Example:
-    >>> window = comm.new_window()
-    >>> window.tensor_register(buffer)
-    >>> dev_win_ptr = window.get_device_window(signal_count=8)
-    >>> # Pass dev_win_ptr to Triton kernel
-)",
-            py::arg("signal_count") = -1,
-            py::arg("counter_count") = -1,
-            py::arg("barrier_count") = 1,
-            py::call_guard<py::gil_scoped_release>())
-        .def(
-            "register_local_buffer",
-            [](WindowType& self, const at::Tensor& tensor) {
-              // Release GIL only during the C++ call, then reacquire for tuple
-              // creation
-              typename WindowType::DeviceRegisteredBuffer buf;
-              {
-                py::gil_scoped_release release;
-                buf = self.register_local_buffer(tensor);
-              }
-              // GIL is held here - safe to create Python objects
-              // Return RegisteredBuffer as a tuple of (base_ptr, size,
-              // backend_window) All as int64 for safe passage through Python to
-              // Triton
-              return py::make_tuple(
-                  reinterpret_cast<int64_t>(buf.base_ptr),
-                  static_cast<int64_t>(buf.size),
-                  reinterpret_cast<int64_t>(buf.backend_window));
-            },
-            R"(
-Register a local buffer for use as source in device-side put operations.
-
-This is a NON-COLLECTIVE operation - only the calling rank participates.
-The registered buffer can only be used as a source for put operations,
-not as a destination.
-
-Prerequisites: Must call tensor_register() then get_device_window() before
-this method.
-
-Args:
-    tensor: A torch.Tensor to register as a local source buffer.
-
-Returns:
-    tuple: (base_ptr, size, backend_window) as int64 values.
-           These can be used with create_local_registered_buffer().
-
-Example:
-    >>> dst_win = comm.new_window()
-    >>> dst_win.tensor_register(dst_buf)
-    >>> dev_win_ptr = window.get_device_window(signal_count=8)
-    >>> # Now register a local source buffer (non-collective)
-    >>> src_buf_info = window.register_local_buffer(src_tensor)
-)",
-            py::arg("tensor"))
-        .def(
-            "deregister_local_buffer",
-            [](WindowType& self,
-               int64_t base_ptr,
-               int64_t size,
-               int64_t backend_window) {
-              // Reconstruct RegisteredBuffer from tuple components
-              typename WindowType::DeviceRegisteredBuffer buf;
-              // NOLINTNEXTLINE(performance-no-int-to-ptr)
-              buf.base_ptr = reinterpret_cast<void*>(base_ptr);
-              buf.size = static_cast<size_t>(size);
-              // NOLINTNEXTLINE(performance-no-int-to-ptr)
-              buf.backend_window = reinterpret_cast<void*>(backend_window);
-              self.deregister_local_buffer(buf);
-            },
-            R"(
-Deregister a previously registered local buffer.
-
-This is a NON-COLLECTIVE operation. Must be called before the window
-is destroyed if register_local_buffer() was called.
-
-Args:
-    base_ptr: The base_ptr from register_local_buffer() return tuple.
-    size: The size from register_local_buffer() return tuple.
-    backend_window: The backend_window from register_local_buffer() return tuple.
-
-Example:
-    >>> src_buf_info = window.register_local_buffer(src_tensor)
-    >>> # ... use in put operations ...
-    >>> window.deregister_local_buffer(*src_buf_info)
-)",
-            py::arg("base_ptr"),
-            py::arg("size"),
-            py::arg("backend_window"),
-            py::call_guard<py::gil_scoped_release>());
-  };
+  // Device API methods (get_device_window, register_local_buffer,
+  // deregister_local_buffer) are bound on the TorchCommWindow base class
+  // in TorchCommPy.cpp and inherited by both GIN and Pipes subclasses.
 
   // --- GIN backend window class ---
   auto gin_cls = py::class_<
       TorchCommWindowNCCLXGin,
       TorchCommWindow,
       std::shared_ptr<TorchCommWindowNCCLXGin>>(m, "TorchCommWindowNCCLXGin");
-  bind_window_common(gin_cls);
 
-  // GIN-specific methods
-  gin_cls.def(
-      "get_nccl_window",
-      [](TorchCommWindowNCCLXGin& self) {
-        // Return as int64 for safe passage through Python
-        return reinterpret_cast<int64_t>(self.get_nccl_window());
-      },
-      R"(
-Get the host-side NCCL window handle.
-
-Returns the ncclWindow_t as an int64, useful for advanced use cases
-where the raw NCCL window handle is needed.
-
-Returns:
-    int: NCCL window handle as int64.
-)",
-      py::call_guard<py::gil_scoped_release>());
+  // GIN-specific methods (not on base class)
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)
   gin_cls.def(
       "get_nvlink_address",
       [](TorchCommWindowNCCLXGin& self, int peer, int64_t offset) {
         void* ptr = self.get_nvlink_address(peer, static_cast<size_t>(offset));
-        // Return as int64 for safe passage through Python
         return reinterpret_cast<int64_t>(ptr);
       },
       R"(
@@ -572,13 +355,6 @@ Args:
 
 Returns:
     int: NVLink-mapped device pointer as int64, or 0 if not accessible.
-
-Example:
-    >>> window = comm.new_window()
-    >>> window.tensor_register(buffer)
-    >>> nvlink_ptr = window.get_nvlink_address(peer=1)
-    >>> if nvlink_ptr != 0:
-    ...     print("NVLink accessible!")
 )",
       py::arg("peer"),
       py::arg("offset") = 0,
@@ -586,13 +362,12 @@ Example:
 #endif
 
 #if defined(ENABLE_PIPES)
-  // --- Pipes backend window class ---
-  auto pipes_cls = py::class_<
+  // --- Pipes backend window class (no additional methods) ---
+  py::class_<
       TorchCommWindowNCCLXPipes,
       TorchCommWindow,
       std::shared_ptr<TorchCommWindowNCCLXPipes>>(
       m, "TorchCommWindowNCCLXPipes");
-  bind_window_common(pipes_cls);
 #endif
 
 #endif

--- a/comms/torchcomms/ncclx/TorchCommWindowNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommWindowNCCLX.cpp
@@ -40,7 +40,12 @@ TorchCommWindowNCCLX<Backend>::~TorchCommWindowNCCLX() noexcept {
   // Cleanup registered local buffers via backend-specific deregistration
   for (auto& buf : registered_local_buffers_) {
     if (nccl_comm_ != nullptr) {
-      Backend::deregister_local_buffer(nccl_api_, nccl_comm_, buf);
+      torchcomms::device::RegisteredBuffer backend_buf;
+      backend_buf.base_ptr = buf.base_ptr;
+      backend_buf.size = buf.size;
+      backend_buf.backend_window = buf.backend_window;
+      backend_buf.lkey = buf.lkey;
+      Backend::deregister_local_buffer(nccl_api_, nccl_comm_, backend_buf);
     }
   }
   registered_local_buffers_.clear();
@@ -343,7 +348,7 @@ std::shared_ptr<TorchCommWindowAttr> TorchCommWindowNCCLX<Backend>::get_attr(
 #ifdef TORCHCOMMS_HAS_NCCL_DEVICE_API
 
 template <typename Backend>
-typename TorchCommWindowNCCLX<Backend>::DeviceRegisteredBuffer
+typename TorchCommWindowNCCLX<Backend>::DeviceBuffer
 TorchCommWindowNCCLX<Backend>::register_local_buffer(const at::Tensor& tensor) {
   checkCommAndThrow();
 
@@ -360,32 +365,24 @@ TorchCommWindowNCCLX<Backend>::register_local_buffer(const at::Tensor& tensor) {
 
   checkDeviceAndThrow(tensor);
 
-  // Graph capture mode: commWindowRegister calls require relaxed capture
-  // mode to execute eagerly rather than being captured into the graph.
-  DeviceRegisteredBuffer buf;
-  if (torch_comm_->getGraphCaptureMode()) {
-    meta::comms::StreamCaptureModeGuard captureGuard{
-        torch_comm_->getCudaApi(), cudaStreamCaptureModeRelaxed};
-    buf = Backend::register_local_buffer(
-        nccl_api_,
-        nccl_comm_,
-        tensor.data_ptr(),
-        tensor.numel() * tensor.element_size());
-  } else {
-    buf = Backend::register_local_buffer(
-        nccl_api_,
-        nccl_comm_,
-        tensor.data_ptr(),
-        tensor.numel() * tensor.element_size());
-  }
+  auto backend_buf = Backend::register_local_buffer(
+      nccl_api_,
+      nccl_comm_,
+      tensor.data_ptr(),
+      tensor.numel() * tensor.element_size());
+
+  DeviceBuffer buf;
+  buf.base_ptr = backend_buf.base_ptr;
+  buf.size = backend_buf.size;
+  buf.backend_window = backend_buf.backend_window;
+  buf.lkey = backend_buf.lkey;
 
   registered_local_buffers_.push_back(buf);
   return buf;
 }
 
 template <typename Backend>
-void TorchCommWindowNCCLX<Backend>::deregister_local_buffer(
-    DeviceRegisteredBuffer& buf) {
+void TorchCommWindowNCCLX<Backend>::deregister_local_buffer(DeviceBuffer& buf) {
   if (buf.base_ptr == nullptr && buf.backend_window == nullptr) {
     return;
   }
@@ -394,19 +391,28 @@ void TorchCommWindowNCCLX<Backend>::deregister_local_buffer(
   auto it = std::find_if(
       registered_local_buffers_.begin(),
       registered_local_buffers_.end(),
-      [&buf](const DeviceRegisteredBuffer& b) {
-        return b.base_ptr == buf.base_ptr;
-      });
+      [&buf](const DeviceBuffer& b) { return b.base_ptr == buf.base_ptr; });
   if (it != registered_local_buffers_.end()) {
     registered_local_buffers_.erase(it);
   }
 
-  Backend::deregister_local_buffer(nccl_api_, nccl_comm_, buf);
+  // Reconstruct backend-specific buffer type for deregistration
+  torchcomms::device::RegisteredBuffer backend_buf;
+  backend_buf.base_ptr = buf.base_ptr;
+  backend_buf.size = buf.size;
+  backend_buf.backend_window = buf.backend_window;
+  backend_buf.lkey = buf.lkey;
+  Backend::deregister_local_buffer(nccl_api_, nccl_comm_, backend_buf);
+
+  // Clear the caller's buffer to indicate it's no longer registered
+  buf.base_ptr = nullptr;
+  buf.size = 0;
+  buf.backend_window = nullptr;
+  buf.lkey = 0;
 }
 
 template <typename Backend>
-typename TorchCommWindowNCCLX<Backend>::DeviceWindow*
-TorchCommWindowNCCLX<Backend>::get_device_window(
+void* TorchCommWindowNCCLX<Backend>::get_device_window(
     int signal_count,
     int counter_count,
     int barrier_count) {
@@ -420,7 +426,7 @@ TorchCommWindowNCCLX<Backend>::get_device_window(
 
   // Return existing device window pointer if already created
   if (device_window_) {
-    return device_window_.get();
+    return static_cast<void*>(device_window_.get());
   }
 
   int commRank = 0;
@@ -475,7 +481,7 @@ TorchCommWindowNCCLX<Backend>::get_device_window(
         win_size_);
   }
 
-  return device_window_.get();
+  return static_cast<void*>(device_window_.get());
 }
 
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)

--- a/comms/torchcomms/ncclx/TorchCommWindowNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchCommWindowNCCLX.hpp
@@ -62,7 +62,6 @@ class TorchCommWindowNCCLX : public TorchCommWindow {
   // Type aliases for device-side types (only available with device API)
   // Backend::Comm is the raw communicator type (e.g., ncclDevComm)
   using DeviceWindow = torchcomms::device::TorchCommDeviceWindow<Backend>;
-  using DeviceRegisteredBuffer = torchcomms::device::RegisteredBuffer;
 #endif
 
   TorchCommWindowNCCLX() = delete;
@@ -115,10 +114,10 @@ class TorchCommWindowNCCLX : public TorchCommWindow {
   //   - PipesDeviceBackend: MultiPeerTransport::localRegisterIbgdaBuffer
   //
   // Prerequisites: Must call tensor_register() then get_device_window() first.
-  DeviceRegisteredBuffer register_local_buffer(const at::Tensor& tensor);
+  DeviceBuffer register_local_buffer(const at::Tensor& tensor) override;
 
   // Deregister a previously registered local buffer. NON-COLLECTIVE.
-  void deregister_local_buffer(DeviceRegisteredBuffer& buf);
+  void deregister_local_buffer(DeviceBuffer& buf) override;
 
   // Get a device-side window handle for GPU-initiated operations.
   // Returns a pointer to the cached device window. The window is lazily
@@ -138,19 +137,10 @@ class TorchCommWindowNCCLX : public TorchCommWindow {
   // Usage (Triton):
   //   The same pointer can be passed to Triton kernels via torchcomms_put(),
   //   torchcomms_signal(), etc. wrappers that take void* handles.
-  DeviceWindow* get_device_window(
+  void* get_device_window(
       int signal_count = -1,
       int counter_count = -1,
-      int barrier_count = 1);
-
-  // Get the host-side NCCL window handle (GIN backend only).
-  // Useful for creating RegisteredBuffer from host code when the device
-  // window's window_ field is in device memory and not directly accessible.
-  // TODO: Returns nullptr for PipesDeviceBackend (nccl_orig_win_ is not
-  // initialized). Gate or return win_ for Pipes if callers need it.
-  ncclWindow_t get_nccl_window() const {
-    return nccl_orig_win_;
-  }
+      int barrier_count = 1) override;
 
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)
   // Get the NVLink-mapped address of a peer's window memory.
@@ -200,7 +190,7 @@ class TorchCommWindowNCCLX : public TorchCommWindow {
   // The custom deleter handles both cudaFree and ncclDevCommDestroy.
   torchcomms::device::DeviceWindowPtr<Backend> device_window_;
 
-  std::vector<DeviceRegisteredBuffer> registered_local_buffers_;
+  std::vector<DeviceBuffer> registered_local_buffers_;
 
   // No ctran_win_ member needed — Pipes device windows are created
   // on-demand via nccl_api_->winCreateDeviceWin() in get_device_window().

--- a/comms/torchcomms/ncclx/_comms_ncclx.pyi
+++ b/comms/torchcomms/ncclx/_comms_ncclx.pyi
@@ -1,29 +1,15 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # pyre-strict
 
-from typing import Any, List, Union
+from typing import List
 
 import torch
+from torchcomms._comms import TorchCommWindow
 
-class TorchCommWindowNCCLXGin:
-    def tensor_register(self, tensor: torch.Tensor, owning: bool = True) -> None: ...
-    def tensor_deregister(self) -> None: ...
-    def get_device_window(
-        self,
-        signal_count: int = -1,
-        counter_count: int = -1,
-        barrier_count: int = 1,
-    ) -> int: ...
-    def get_nccl_window(self) -> int: ...
+class TorchCommWindowNCCLXGin(TorchCommWindow):
     def get_nvlink_address(self, peer: int, offset: int = 0) -> int: ...
-    def register_local_buffer(self, tensor: torch.Tensor) -> tuple[int, int, int]: ...
-    def deregister_local_buffer(
-        self, base_ptr: int, size: int, backend_window: int
-    ) -> None: ...
 
-def cast_to_ncclx_window(
-    base_window: Union[TorchCommWindowNCCLXGin, Any],
-) -> TorchCommWindowNCCLXGin: ...
+class TorchCommWindowNCCLXPipes(TorchCommWindow): ...
 
 class TorchWork:
     def is_completed(self) -> bool: ...

--- a/comms/torchcomms/tests/integration/cpp/DeviceApiTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/DeviceApiTest.cpp
@@ -8,7 +8,9 @@
 #include "DeviceApiTestKernels.cuh"
 #include "TorchCommTestHelpers.h"
 #include "comms/torchcomms/TorchComm.hpp"
-#include "comms/torchcomms/ncclx/TorchCommWindowNCCLX.hpp"
+
+// Bring device API types into scope (DeviceWindowNCCL, RegisteredBufferNCCL)
+using namespace torchcomms::device;
 
 std::unique_ptr<TorchCommTestWrapper> DeviceApiTest::createWrapper() {
   return std::make_unique<TorchCommTestWrapper>();
@@ -102,22 +104,18 @@ void DeviceApiTest::testDeviceWindowCreation(int count, at::ScalarType dtype) {
 
   // Create window and register tensor
   torchcomm_->barrier(false);
-  auto base_win = torchcomm_->new_window();
-  base_win->tensor_register(win_tensor);
+  auto win = torchcomm_->new_window();
+  win->tensor_register(win_tensor);
   torchcomm_->barrier(false);
 
-  // Cast to NCCLX window to access device API
-  auto* win =
-      dynamic_cast<torch::comms::TorchCommWindowNCCLXGin*>(base_win.get());
-  ASSERT_NE(win, nullptr) << "Window should be TorchCommWindowNCCLXGin";
-
   // Get device window (returns device pointer for use in CUDA/Triton kernels)
-  auto* dev_win = win->get_device_window();
+  DeviceWindowNCCL* dev_win =
+      static_cast<DeviceWindowNCCL*>(win->get_device_window());
   EXPECT_NE(dev_win, nullptr) << "Device window pointer should not be null";
 
   // Cleanup
-  base_win->tensor_deregister();
-  base_win.reset();
+  win->tensor_deregister();
+  win.reset();
   mem_pool.reset();
 
   torchcomm_->barrier(false);
@@ -151,19 +149,15 @@ void DeviceApiTest::testLocalBufferRegistration(
 
   // Create window and register tensor
   torchcomm_->barrier(false);
-  auto base_win = torchcomm_->new_window();
-  base_win->tensor_register(win_tensor);
+  auto win = torchcomm_->new_window();
+  win->tensor_register(win_tensor);
   torchcomm_->barrier(false);
-
-  // Cast to NCCLX window to access device API
-  auto* win =
-      dynamic_cast<torch::comms::TorchCommWindowNCCLXGin*>(base_win.get());
-  ASSERT_NE(win, nullptr) << "Window should be TorchCommWindowNCCLXGin";
 
   // Get device window first to ensure GIN is enabled.
   // GIN is only enabled when ncclDevCommCreate is called (inside
   // get_device_window), not during window registration.
-  auto* dev_win = win->get_device_window();
+  DeviceWindowNCCL* dev_win =
+      static_cast<DeviceWindowNCCL*>(win->get_device_window());
   ASSERT_NE(dev_win, nullptr) << "Device window should not be null";
 
   auto src_buf = win->register_local_buffer(src_tensor);
@@ -176,8 +170,8 @@ void DeviceApiTest::testLocalBufferRegistration(
 
   // Cleanup
   win->deregister_local_buffer(src_buf);
-  base_win->tensor_deregister();
-  base_win.reset();
+  win->tensor_deregister();
+  win.reset();
   mem_pool.reset();
 
   torchcomm_->barrier(false);
@@ -208,23 +202,19 @@ void DeviceApiTest::testDeviceWindowWithSignals(
 
   // Create window and register tensor
   torchcomm_->barrier(false);
-  auto base_win = torchcomm_->new_window();
-  base_win->tensor_register(win_tensor);
+  auto win = torchcomm_->new_window();
+  win->tensor_register(win_tensor);
   torchcomm_->barrier(false);
-
-  // Cast to NCCLX window to access device API
-  auto* win =
-      dynamic_cast<torch::comms::TorchCommWindowNCCLXGin*>(base_win.get());
-  ASSERT_NE(win, nullptr) << "Window should be TorchCommWindowNCCLXGin";
 
   // Get device window with signals (returns device pointer for use in kernels)
   int signal_count = num_ranks_;
-  auto* dev_win = win->get_device_window(signal_count, -1, 1);
+  DeviceWindowNCCL* dev_win = static_cast<DeviceWindowNCCL*>(
+      win->get_device_window(signal_count, -1, 1));
   EXPECT_NE(dev_win, nullptr) << "Device window pointer should not be null";
 
   // Cleanup
-  base_win->tensor_deregister();
-  base_win.reset();
+  win->tensor_deregister();
+  win.reset();
   mem_pool.reset();
 
   torchcomm_->barrier(false);
@@ -255,24 +245,20 @@ void DeviceApiTest::testDeviceWindowWithCounters(
 
   // Create window and register tensor
   torchcomm_->barrier(false);
-  auto base_win = torchcomm_->new_window();
-  base_win->tensor_register(win_tensor);
+  auto win = torchcomm_->new_window();
+  win->tensor_register(win_tensor);
   torchcomm_->barrier(false);
-
-  // Cast to NCCLX window to access device API
-  auto* win =
-      dynamic_cast<torch::comms::TorchCommWindowNCCLXGin*>(base_win.get());
-  ASSERT_NE(win, nullptr) << "Window should be TorchCommWindowNCCLXGin";
 
   // Get device window with signals and counters (returns device pointer)
   int signal_count = num_ranks_;
   int counter_count = num_ranks_;
-  auto* dev_win = win->get_device_window(signal_count, counter_count, 1);
+  DeviceWindowNCCL* dev_win = static_cast<DeviceWindowNCCL*>(
+      win->get_device_window(signal_count, counter_count, 1));
   EXPECT_NE(dev_win, nullptr) << "Device window pointer should not be null";
 
   // Cleanup
-  base_win->tensor_deregister();
-  base_win.reset();
+  win->tensor_deregister();
+  win.reset();
   mem_pool.reset();
 
   torchcomm_->barrier(false);
@@ -320,18 +306,14 @@ void DeviceApiTest::testDevicePut(int count, at::ScalarType dtype) {
 
   // Create destination window and register tensor
   torchcomm_->barrier(false);
-  auto base_win = torchcomm_->new_window();
-  base_win->tensor_register(win_tensor);
+  auto win = torchcomm_->new_window();
+  win->tensor_register(win_tensor);
   torchcomm_->barrier(false);
-
-  // Cast to NCCLX window to access device API
-  auto* win =
-      dynamic_cast<torch::comms::TorchCommWindowNCCLXGin*>(base_win.get());
-  ASSERT_NE(win, nullptr) << "Window should be TorchCommWindowNCCLXGin";
 
   // Get device window with signals (returns device pointer for use in kernels)
   int signal_count = num_ranks_;
-  auto* dev_win = win->get_device_window(signal_count, -1, 1);
+  DeviceWindowNCCL* dev_win = static_cast<DeviceWindowNCCL*>(
+      win->get_device_window(signal_count, -1, 1));
   EXPECT_NE(dev_win, nullptr) << "Device window pointer should not be null";
 
   // Register source buffer as a local-only window using NCCL_WIN_LOCAL_ONLY.
@@ -366,7 +348,8 @@ void DeviceApiTest::testDevicePut(int count, at::ScalarType dtype) {
     c10::cuda::CUDAStreamGuard guard(put_stream);
     torchcomms::device::test::launchDevicePutKernelWithOffsets(
         dev_win,
-        src_buf,
+        RegisteredBufferNCCL{
+            src_buf.base_ptr, src_buf.size, src_buf.backend_window},
         src_offset,
         dst_offset,
         bytes,
@@ -416,8 +399,8 @@ void DeviceApiTest::testDevicePut(int count, at::ScalarType dtype) {
   // Cleanup - deregister local source buffer (non-collective), then destination
   win->deregister_local_buffer(src_buf);
 
-  base_win->tensor_deregister();
-  base_win.reset();
+  win->tensor_deregister();
+  win.reset();
   mem_pool.reset();
 
   torchcomm_->barrier(false);
@@ -427,8 +410,7 @@ void DeviceApiTest::testDevicePut(int count, at::ScalarType dtype) {
 // GTest Test Cases
 // =============================================================================
 // TEST_F macros MUST be in this file (compiled with
-// TORCHCOMMS_HAS_NCCL_DEVICE_API) to ensure TorchCommWindowNCCLXGin resolves to
-// the correct type (NCCLDeviceBackend).
+// TORCHCOMMS_HAS_NCCL_DEVICE_API) to ensure device API types resolve correctly.
 
 TEST_F(DeviceApiTest, DeviceWindowCreationFloat) {
   testDeviceWindowCreation(1024, at::kFloat);
@@ -493,17 +475,14 @@ void DeviceApiTest::testGinAtomicAdd() {
 
   // Create window and register tensor
   torchcomm_->barrier(false);
-  auto base_win = torchcomm_->new_window();
-  base_win->tensor_register(win_tensor);
+  auto win = torchcomm_->new_window();
+  win->tensor_register(win_tensor);
   torchcomm_->barrier(false);
-
-  auto* win =
-      dynamic_cast<torch::comms::TorchCommWindowNCCLXGin*>(base_win.get());
-  ASSERT_NE(win, nullptr) << "Window should be TorchCommWindowNCCLXGin";
 
   // Get device window with signals for synchronization
   int signal_count = num_ranks_;
-  auto* dev_win = win->get_device_window(signal_count, -1, 1);
+  DeviceWindowNCCL* dev_win = static_cast<DeviceWindowNCCL*>(
+      win->get_device_window(signal_count, -1, 1));
   ASSERT_NE(dev_win, nullptr) << "Device window pointer should not be null";
 
   // Ring pattern: rank i atomicAdds to rank (i+1) % num_ranks
@@ -570,8 +549,8 @@ void DeviceApiTest::testGinAtomicAdd() {
   ASSERT_EQ(signal_value, 0) << "Signal should be reset to 0 after reset";
 
   // Cleanup
-  base_win->tensor_deregister();
-  base_win.reset();
+  win->tensor_deregister();
+  win.reset();
   mem_pool.reset();
 
   torchcomm_->barrier(false);
@@ -612,16 +591,13 @@ void DeviceApiTest::testPerPeerSignal() {
       mem_pool->device(), mem_pool->id());
 
   torchcomm_->barrier(false);
-  auto base_win = torchcomm_->new_window();
-  base_win->tensor_register(win_tensor);
+  auto win = torchcomm_->new_window();
+  win->tensor_register(win_tensor);
   torchcomm_->barrier(false);
 
-  auto* win =
-      dynamic_cast<torch::comms::TorchCommWindowNCCLXGin*>(base_win.get());
-  ASSERT_NE(win, nullptr);
-
   int signal_count = num_ranks_;
-  auto* dev_win = win->get_device_window(signal_count, -1, 1);
+  DeviceWindowNCCL* dev_win = static_cast<DeviceWindowNCCL*>(
+      win->get_device_window(signal_count, -1, 1));
   ASSERT_NE(dev_win, nullptr);
 
   // Ring pattern: rank i signals rank (i+1) % num_ranks
@@ -674,8 +650,8 @@ void DeviceApiTest::testPerPeerSignal() {
   }
   op_stream.synchronize();
 
-  base_win->tensor_deregister();
-  base_win.reset();
+  win->tensor_deregister();
+  win.reset();
   mem_pool.reset();
 
   torchcomm_->barrier(false);
@@ -714,16 +690,13 @@ void DeviceApiTest::testWaitSignalFrom() {
       mem_pool->device(), mem_pool->id());
 
   torchcomm_->barrier(false);
-  auto base_win = torchcomm_->new_window();
-  base_win->tensor_register(win_tensor);
+  auto win = torchcomm_->new_window();
+  win->tensor_register(win_tensor);
   torchcomm_->barrier(false);
 
-  auto* win =
-      dynamic_cast<torch::comms::TorchCommWindowNCCLXGin*>(base_win.get());
-  ASSERT_NE(win, nullptr);
-
   int signal_count = num_ranks_;
-  auto* dev_win = win->get_device_window(signal_count, -1, 1);
+  DeviceWindowNCCL* dev_win = static_cast<DeviceWindowNCCL*>(
+      win->get_device_window(signal_count, -1, 1));
   ASSERT_NE(dev_win, nullptr);
 
   // Ring: rank i signals rank (i+1), receiver expects signal from (i-1)
@@ -766,8 +739,8 @@ void DeviceApiTest::testWaitSignalFrom() {
   }
   op_stream.synchronize();
 
-  base_win->tensor_deregister();
-  base_win.reset();
+  win->tensor_deregister();
+  win.reset();
   mem_pool.reset();
 
   torchcomm_->barrier(false);
@@ -805,17 +778,14 @@ void DeviceApiTest::testDeviceBarrier() {
       mem_pool->device(), mem_pool->id());
 
   torchcomm_->barrier(false);
-  auto base_win = torchcomm_->new_window();
-  base_win->tensor_register(win_tensor);
+  auto win = torchcomm_->new_window();
+  win->tensor_register(win_tensor);
   torchcomm_->barrier(false);
-
-  auto* win =
-      dynamic_cast<torch::comms::TorchCommWindowNCCLXGin*>(base_win.get());
-  ASSERT_NE(win, nullptr);
 
   // Get device window with barrier support
   int barrier_count = 2;
-  auto* dev_win = win->get_device_window(-1, -1, barrier_count);
+  DeviceWindowNCCL* dev_win = static_cast<DeviceWindowNCCL*>(
+      win->get_device_window(-1, -1, barrier_count));
   ASSERT_NE(dev_win, nullptr);
 
   constexpr int kBarrierId = 0;
@@ -838,8 +808,8 @@ void DeviceApiTest::testDeviceBarrier() {
   }
   op_stream.synchronize();
 
-  base_win->tensor_deregister();
-  base_win.reset();
+  win->tensor_deregister();
+  win.reset();
   mem_pool.reset();
 
   torchcomm_->barrier(false);
@@ -887,16 +857,13 @@ void DeviceApiTest::testDevicePutScoped(
       mem_pool->device(), mem_pool->id());
 
   torchcomm_->barrier(false);
-  auto base_win = torchcomm_->new_window();
-  base_win->tensor_register(win_tensor);
+  auto win = torchcomm_->new_window();
+  win->tensor_register(win_tensor);
   torchcomm_->barrier(false);
 
-  auto* win =
-      dynamic_cast<torch::comms::TorchCommWindowNCCLXGin*>(base_win.get());
-  ASSERT_NE(win, nullptr) << "Window should be TorchCommWindowNCCLXGin";
-
   int signal_count = num_ranks_;
-  auto* dev_win = win->get_device_window(signal_count, -1, 1);
+  DeviceWindowNCCL* dev_win = static_cast<DeviceWindowNCCL*>(
+      win->get_device_window(signal_count, -1, 1));
   EXPECT_NE(dev_win, nullptr) << "Device window pointer should not be null";
 
   auto src_buf = win->register_local_buffer(src_tensor);
@@ -917,7 +884,8 @@ void DeviceApiTest::testDevicePutScoped(
     c10::cuda::CUDAStreamGuard guard(put_stream);
     torchcomms::device::test::launchDevicePutScopedKernel(
         dev_win,
-        src_buf,
+        RegisteredBufferNCCL{
+            src_buf.base_ptr, src_buf.size, src_buf.backend_window},
         src_offset,
         dst_offset,
         bytes,
@@ -962,8 +930,8 @@ void DeviceApiTest::testDevicePutScoped(
   put_stream.synchronize();
 
   win->deregister_local_buffer(src_buf);
-  base_win->tensor_deregister();
-  base_win.reset();
+  win->tensor_deregister();
+  win.reset();
   mem_pool.reset();
 
   torchcomm_->barrier(false);
@@ -1008,16 +976,13 @@ void DeviceApiTest::testDeviceBarrierScoped(
       mem_pool->device(), mem_pool->id());
 
   torchcomm_->barrier(false);
-  auto base_win = torchcomm_->new_window();
-  base_win->tensor_register(win_tensor);
+  auto win = torchcomm_->new_window();
+  win->tensor_register(win_tensor);
   torchcomm_->barrier(false);
 
-  auto* win =
-      dynamic_cast<torch::comms::TorchCommWindowNCCLXGin*>(base_win.get());
-  ASSERT_NE(win, nullptr);
-
   int barrier_count = 2;
-  auto* dev_win = win->get_device_window(-1, -1, barrier_count);
+  DeviceWindowNCCL* dev_win = static_cast<DeviceWindowNCCL*>(
+      win->get_device_window(-1, -1, barrier_count));
   ASSERT_NE(dev_win, nullptr);
 
   constexpr int kBarrierId = 0;
@@ -1038,8 +1003,8 @@ void DeviceApiTest::testDeviceBarrierScoped(
   }
   op_stream.synchronize();
 
-  base_win->tensor_deregister();
-  base_win.reset();
+  win->tensor_deregister();
+  win.reset();
   mem_pool.reset();
 
   torchcomm_->barrier(false);

--- a/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTest.cpp
@@ -10,6 +10,9 @@
 #include "comms/torchcomms/TorchComm.hpp"
 #include "comms/torchcomms/ncclx/TorchCommWindowNCCLX.hpp"
 
+// Bring device API types into scope (DeviceWindowPipes, RegisteredBufferPipes)
+using namespace torchcomms::device;
+
 std::unique_ptr<TorchCommTestWrapper> PipesDeviceApiTest::createWrapper() {
   return std::make_unique<TorchCommTestWrapper>();
 }
@@ -144,9 +147,9 @@ void PipesDeviceApiTest::testPipesDeviceWindowCreation(
   // ctran_win->get_device_win() which does an allGather to exchange IBGDA
   // buffer registration info and NVLink-mapped remote buffer pointers.
   // All ranks must call this simultaneously.
-  decltype(win->get_device_window()) dev_win = nullptr;
+  DeviceWindowPipes* dev_win = nullptr;
   try {
-    dev_win = win->get_device_window();
+    dev_win = static_cast<DeviceWindowPipes*>(win->get_device_window());
   } catch (const std::runtime_error& e) {
     // Gracefully skip if IBGDA hardware is not available.
     // Both ranks hit this simultaneously (multiPeerTransport is null on both),
@@ -220,9 +223,9 @@ void PipesDeviceApiTest::testLocalBufferRegistration(
 
   // get_device_window() is COLLECTIVE — must be called before
   // register_local_buffer() to initialize the Pipes device window.
-  decltype(win->get_device_window()) dev_win = nullptr;
+  DeviceWindowPipes* dev_win = nullptr;
   try {
-    dev_win = win->get_device_window();
+    dev_win = static_cast<DeviceWindowPipes*>(win->get_device_window());
   } catch (const std::runtime_error& e) {
     base_win->tensor_deregister();
     base_win.reset();
@@ -297,9 +300,10 @@ void PipesDeviceApiTest::testPerPeerSignal() {
                              "Is NCCL_CTRAN_USE_PIPES=1 set?";
 
   int signal_count = num_ranks_;
-  decltype(win->get_device_window()) dev_win = nullptr;
+  DeviceWindowPipes* dev_win = nullptr;
   try {
-    dev_win = win->get_device_window(signal_count, -1, 1);
+    dev_win = static_cast<DeviceWindowPipes*>(
+        win->get_device_window(signal_count, -1, 1));
   } catch (const std::runtime_error& e) {
     base_win->tensor_deregister();
     base_win.reset();
@@ -407,9 +411,10 @@ void PipesDeviceApiTest::testWaitSignalFrom() {
                              "Is NCCL_CTRAN_USE_PIPES=1 set?";
 
   int signal_count = num_ranks_;
-  decltype(win->get_device_window()) dev_win = nullptr;
+  DeviceWindowPipes* dev_win = nullptr;
   try {
-    dev_win = win->get_device_window(signal_count, -1, 1);
+    dev_win = static_cast<DeviceWindowPipes*>(
+        win->get_device_window(signal_count, -1, 1));
   } catch (const std::runtime_error& e) {
     base_win->tensor_deregister();
     base_win.reset();
@@ -505,9 +510,10 @@ void PipesDeviceApiTest::testDeviceBarrier() {
 
   // Get device window with barrier support
   int barrier_count = 2;
-  decltype(win->get_device_window()) dev_win = nullptr;
+  DeviceWindowPipes* dev_win = nullptr;
   try {
-    dev_win = win->get_device_window(-1, -1, barrier_count);
+    dev_win = static_cast<DeviceWindowPipes*>(
+        win->get_device_window(-1, -1, barrier_count));
   } catch (const std::runtime_error& e) {
     base_win->tensor_deregister();
     base_win.reset();
@@ -594,9 +600,10 @@ void PipesDeviceApiTest::testDevicePut(int count, at::ScalarType dtype) {
                              "Is NCCL_CTRAN_USE_PIPES=1 set?";
 
   int signal_count = num_ranks_;
-  decltype(win->get_device_window()) dev_win = nullptr;
+  DeviceWindowPipes* dev_win = nullptr;
   try {
-    dev_win = win->get_device_window(signal_count, -1, 1);
+    dev_win = static_cast<DeviceWindowPipes*>(
+        win->get_device_window(signal_count, -1, 1));
   } catch (const std::runtime_error& e) {
     base_win->tensor_deregister();
     base_win.reset();
@@ -623,7 +630,11 @@ void PipesDeviceApiTest::testDevicePut(int count, at::ScalarType dtype) {
     c10::cuda::CUDAStreamGuard guard(put_stream);
     torchcomms::device::test::launchPipesPutKernel(
         dev_win,
-        src_buf,
+        RegisteredBufferPipes{
+            src_buf.base_ptr,
+            src_buf.size,
+            src_buf.backend_window,
+            src_buf.lkey},
         src_offset,
         dst_offset,
         bytes,
@@ -713,9 +724,10 @@ void PipesDeviceApiTest::testDevicePutCounter(int count, at::ScalarType dtype) {
 
   int signal_count = num_ranks_;
   int counter_count = num_ranks_;
-  decltype(win->get_device_window()) dev_win = nullptr;
+  DeviceWindowPipes* dev_win = nullptr;
   try {
-    dev_win = win->get_device_window(signal_count, counter_count, 1);
+    dev_win = static_cast<DeviceWindowPipes*>(
+        win->get_device_window(signal_count, counter_count, 1));
   } catch (const std::runtime_error& e) {
     base_win->tensor_deregister();
     base_win.reset();
@@ -743,7 +755,11 @@ void PipesDeviceApiTest::testDevicePutCounter(int count, at::ScalarType dtype) {
     c10::cuda::CUDAStreamGuard guard(put_stream);
     torchcomms::device::test::launchPipesPutCounterKernel(
         dev_win,
-        src_buf,
+        RegisteredBufferPipes{
+            src_buf.base_ptr,
+            src_buf.size,
+            src_buf.backend_window,
+            src_buf.lkey},
         src_offset,
         dst_offset,
         bytes,
@@ -864,9 +880,10 @@ void PipesDeviceApiTest::testWaitLocal(int count, at::ScalarType dtype) {
 
   int signal_count = num_ranks_;
   int counter_count = num_ranks_;
-  decltype(win->get_device_window()) dev_win = nullptr;
+  DeviceWindowPipes* dev_win = nullptr;
   try {
-    dev_win = win->get_device_window(signal_count, counter_count, 1);
+    dev_win = static_cast<DeviceWindowPipes*>(
+        win->get_device_window(signal_count, counter_count, 1));
   } catch (const std::runtime_error& e) {
     base_win->tensor_deregister();
     base_win.reset();
@@ -894,7 +911,11 @@ void PipesDeviceApiTest::testWaitLocal(int count, at::ScalarType dtype) {
     c10::cuda::CUDAStreamGuard guard(put_stream);
     torchcomms::device::test::launchPipesPutCounterKernel(
         dev_win,
-        src_buf,
+        RegisteredBufferPipes{
+            src_buf.base_ptr,
+            src_buf.size,
+            src_buf.backend_window,
+            src_buf.lkey},
         src_offset,
         dst_offset,
         bytes,


### PR DESCRIPTION
Summary:

Move get_device_window(), register_local_buffer(), and deregister_local_buffer()
from NCCLX-specific pybind bindings to the TorchCommWindow base class as virtual
methods. This eliminates dynamic_pointer_cast in all callers and allows both GIN
and Pipes backends to be accessed through the unified base class interface.

Key changes:
- Add DeviceBuffer struct (with lkey field for IBGDA) and 3 virtual methods to
  TorchCommWindow base class with default-throw implementations
- TorchCommWindowNCCLX overrides return DeviceBuffer, converting to/from
  backend-specific RegisteredBuffer at the boundary
- Remove all device API bindings from TorchCommNCCLXPy.cpp (now on base class)
- Remove get_nccl_window (dead code — only consumer create_registered_buffer was
  already deleted)
- Remove create_registered_buffer and get_nccl_window from Triton __init__.py exports
- Update DeviceApiTest and PipesDeviceApiTest to use static_cast<DeviceWindow*>
  on the void* returned by get_device_window()
- Update Python e2e test for 4-tuple register_local_buffer return value

**TODO**

Since these APIs are moved to the base class, we have added DeviceBuffer struct but now
we need to manually convert between between DeviceBuffer (base class) and RegisteredBuffer (derived class) which it makes the code ugly.
Follow-up diff will clean this RegisteredBuffer, so no more manual conversion.

Reviewed By: cenzhaometa

Differential Revision: D97567359
