### PR TITLE
Export getDevMemType, getCudaDevFromPtr, StreamCaptureModeGuard for conda builds

### DIFF
--- a/comms/ctran/utils/DevMemType.h
+++ b/comms/ctran/utils/DevMemType.h
@@ -47,7 +47,7 @@ inline const char* devMemTypeStr(DevMemType memType) {
  *         commInternalError for unsupported cuMem handle types or other
  * internal errors
  */
-commResult_t
+__attribute__((visibility("default"))) commResult_t
 getDevMemType(const void* addr, const int cudaDev, DevMemType& memType);
 
 /**
@@ -62,4 +62,5 @@ getDevMemType(const void* addr, const int cudaDev, DevMemType& memType);
  * @return commSuccess on successful determination
  *         commInvalidUsage if addr is nullptr
  */
-commResult_t getCudaDevFromPtr(const void* addr, int& cudaDev);
+__attribute__((visibility("default"))) commResult_t
+getCudaDevFromPtr(const void* addr, int& cudaDev);

--- a/comms/ncclx/v2_27/src/version.script
+++ b/comms/ncclx/v2_27/src/version.script
@@ -11,6 +11,9 @@ cxa: Folly’s exception tracer intercepts all exceptions and uses
       *nccl*;
       *ctran*;
       *cxa*;
+      *getDevMemType*;
+      *getCudaDevFromPtr*;
+      *StreamCaptureModeGuard*;
   /* Transitive symbols (e.g. coming from static libs) are not exported */
   local:
       *;

--- a/comms/ncclx/v2_28/src/version.script
+++ b/comms/ncclx/v2_28/src/version.script
@@ -11,6 +11,9 @@ cxa: Folly’s exception tracer intercepts all exceptions and uses
       *nccl*;
       *ctran*;
       *cxa*;
+      *getDevMemType*;
+      *getCudaDevFromPtr*;
+      *StreamCaptureModeGuard*;
   /* Transitive symbols (e.g. coming from static libs) are not exported */
   local:
       *;

--- a/comms/ncclx/v2_29/src/version.script
+++ b/comms/ncclx/v2_29/src/version.script
@@ -11,6 +11,9 @@ cxa: Folly’s exception tracer intercepts all exceptions and uses
       *nccl*;
       *ctran*;
       *cxa*;
+      *getDevMemType*;
+      *getCudaDevFromPtr*;
+      *StreamCaptureModeGuard*;
   /* Transitive symbols (e.g. coming from static libs) are not exported */
   local:
       *;

--- a/comms/utils/CudaRAII.h
+++ b/comms/utils/CudaRAII.h
@@ -86,7 +86,8 @@ class StreamCaptureModeGuard {
  public:
   using ExchangeFn = cudaError_t (*)(void*, cudaStreamCaptureMode*);
 
-  explicit StreamCaptureModeGuard(cudaStreamCaptureMode desiredMode);
+  __attribute__((visibility("default"))) explicit StreamCaptureModeGuard(
+      cudaStreamCaptureMode desiredMode);
 
   template <typename Api>
   StreamCaptureModeGuard(Api* api, cudaStreamCaptureMode desiredMode)
@@ -98,7 +99,7 @@ class StreamCaptureModeGuard {
     init();
   }
 
-  ~StreamCaptureModeGuard();
+  __attribute__((visibility("default"))) ~StreamCaptureModeGuard();
 
   StreamCaptureModeGuard(const StreamCaptureModeGuard&) = delete;
   StreamCaptureModeGuard& operator=(const StreamCaptureModeGuard&) = delete;
@@ -106,7 +107,7 @@ class StreamCaptureModeGuard {
   StreamCaptureModeGuard& operator=(StreamCaptureModeGuard&&) = delete;
 
  private:
-  void init();
+  __attribute__((visibility("default"))) void init();
 
   void* ctx_{nullptr};
   ExchangeFn exchangeFn_{nullptr};


### PR DESCRIPTION
Summary:
Add `__attribute__((visibility("default")))` to `getDevMemType`,
`getCudaDevFromPtr` (DevMemType.h), and `StreamCaptureModeGuard`
constructor/destructor/init (CudaRAII.h). Also add wildcard patterns
to the version script (v2_27, v2_28, v2_29) so these symbols are
exported from libnccl.so in conda builds.

Without this fix, the conda build compiles libnccl.so with
`-fvisibility=hidden`, hiding these symbols. When torchcomms
`_comms_ncclx.so` dynamically links against libnccl.so
(USE_SYSTEM_LIBS=1), the hidden symbols cause ImportError at runtime.

This was exposed by enabling ENABLE_PIPES=1 in conda configs
(D96335937), which installs nccl_device headers, enabling
TORCHCOMMS_HAS_NCCL_DEVICE_API, which compiles the getDevMemType
call in TorchCommWindowNCCLX.cpp (added by D97057976).

The visibility attribute overrides -fvisibility=hidden at the
per-symbol level, and the version script wildcards ensure the
symbols pass the export filter. This is the same pattern used by
CtranEx, CtranExComm, and other exported symbols in the codebase.

Differential Revision: D97849686


