### PR TITLE
Migrate Comm basic tests to ncclx::test:: APIs (CommDesc/CommRegister/CommGetUniqueHash/CommWithCtran/CommWithNoLocal) (#1224)

### DIFF
--- a/comms/ncclx/v2_27/meta/tests/CommDescTest.cc
+++ b/comms/ncclx/v2_27/meta/tests/CommDescTest.cc
@@ -13,27 +13,32 @@
 #include "meta/NcclxConfig.h"
 #include "nccl.h"
 
-class commDescTest : public ::testing::Test {
+#include <gmock/gmock.h>
+
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
+
+class commDescTest : public NcclxBaseTest {
  public:
   commDescTest() = default;
 
  protected:
   void SetUp() override {
-    std::tie(this->localRank, this->globalRank, this->numRanks) = getMpiInfo();
+    NcclxBaseTest::SetUp();
   }
 
-  void TearDown() override {}
-
-  int localRank{0};
-  int globalRank{0};
-  int numRanks{0};
+  void TearDown() override {
+    NcclxBaseTest::TearDown();
+  }
 };
 
 TEST_F(commDescTest, getUndefinedCommDesc) {
-  NcclCommRAII comm(this->globalRank, this->numRanks, this->localRank);
+  ncclx::test::NcclCommRAII comm(
+      globalRank, numRanks, localRank, bootstrap_.get());
   ASSERT_NE(nullptr, static_cast<ncclComm_t>(comm));
 
-  EXPECT_EQ(NCCLX_CONFIG_FIELD(comm->config, commDesc), "nccl_ut");
+  EXPECT_THAT(
+      NCCLX_CONFIG_FIELD(comm->config, commDesc),
+      testing::StartsWith("nccl_ut_"));
 }
 
 TEST_F(commDescTest, getDefinedCommDesc) {
@@ -41,8 +46,7 @@ TEST_F(commDescTest, getDefinedCommDesc) {
   if (globalRank == 0) {
     NCCLCHECK_TEST(ncclGetUniqueId(&ncclId));
   }
-  MPICHECK_TEST(
-      MPI_Bcast((void*)&ncclId, sizeof(ncclId), MPI_BYTE, 0, MPI_COMM_WORLD));
+  oobBroadcast(&ncclId, 1, 0);
   CUDACHECK_TEST(cudaSetDevice(this->localRank));
 
   ncclComm_t comm;
@@ -65,8 +69,7 @@ TEST_F(commDescTest, InvalidPointerAccess) {
   if (globalRank == 0) {
     NCCLCHECK_TEST(ncclGetUniqueId(&ncclId));
   }
-  MPICHECK_TEST(
-      MPI_Bcast((void*)&ncclId, sizeof(ncclId), MPI_BYTE, 0, MPI_COMM_WORLD));
+  oobBroadcast(&ncclId, 1, 0);
   CUDACHECK_TEST(cudaSetDevice(this->localRank));
 
   ncclComm_t comm;

--- a/comms/ncclx/v2_27/meta/tests/CommGetUniqueHashTest.cc
+++ b/comms/ncclx/v2_27/meta/tests/CommGetUniqueHashTest.cc
@@ -7,28 +7,28 @@
 
 #include <nccl.h>
 #include "comm.h"
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
 
-class CommGetUniqueHashTest : public ::testing::Test {
+class CommGetUniqueHashTest : public NcclxBaseTest {
  public:
   CommGetUniqueHashTest() = default;
 
   void SetUp() override {
-    std::tie(this->localRank, this->globalRank, this->numRanks) = getMpiInfo();
+    NcclxBaseTest::SetUp();
   }
 
-  void TearDown() override {}
-
-  int localRank{0};
-  int globalRank{0};
-  int numRanks{0};
+  void TearDown() override {
+    NcclxBaseTest::TearDown();
+  }
 };
 
 TEST_F(CommGetUniqueHashTest, DefaultComm) {
   auto res = ncclSuccess;
 
-  NcclCommRAII comm{this->globalRank, this->numRanks, this->localRank};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   uint64_t commHash = 0;
   res = ncclCommGetUniqueHash(comm, &commHash);
   ASSERT_EQ(res, ncclSuccess);
@@ -36,18 +36,16 @@ TEST_F(CommGetUniqueHashTest, DefaultComm) {
   EXPECT_EQ(commHash, comm->commHash);
 
   // check all ranks have the same commHash
-  uint64_t commHashMin = 0, commHashMax = 0;
-  MPI_Allreduce(
-      &commHash, &commHashMin, 1, MPI_UINT64_T, MPI_MIN, MPI_COMM_WORLD);
-  MPI_Allreduce(
-      &commHash, &commHashMax, 1, MPI_UINT64_T, MPI_MIN, MPI_COMM_WORLD);
-  EXPECT_TRUE(commHashMin == commHashMax && commHashMax == commHash);
+  uint64_t rootHash = commHash;
+  oobBroadcast(&rootHash, 1, /*root=*/0);
+  EXPECT_EQ(rootHash, commHash) << "commHash mismatch vs rank 0";
 }
 
 TEST_F(CommGetUniqueHashTest, ParentChildComm) {
   auto res = ncclSuccess;
 
-  NcclCommRAII comm{this->globalRank, this->numRanks, this->localRank};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
 
   // Split into two groups, one with odd ranks and one with even ranks
   ncclComm_t childComm = NCCL_COMM_NULL;
@@ -71,7 +69,8 @@ TEST_F(CommGetUniqueHashTest, ParentChildComm) {
 TEST_F(CommGetUniqueHashTest, ParentChildCommSplitGroup) {
   auto res = ncclSuccess;
 
-  NcclCommRAII comm{this->globalRank, this->numRanks, this->localRank};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
 
   ncclConfig_t inputConfig = NCCL_CONFIG_INITIALIZER;
   inputConfig.splitGroupSize = this->numRanks / 2;
@@ -120,7 +119,8 @@ TEST_F(CommGetUniqueHashTest, InvalidComm) {
 }
 
 TEST_F(CommGetUniqueHashTest, GetHashAfteCommDestroy) {
-  NcclCommRAII comm{this->globalRank, this->numRanks, this->localRank};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   // Split into two groups, one with odd ranks and one with even ranks
   ncclComm_t childComm = NCCL_COMM_NULL;
   NCCLCHECK_TEST(ncclCommSplit(
@@ -141,7 +141,8 @@ TEST_F(CommGetUniqueHashTest, GetHashAfteCommDestroy) {
 TEST_F(CommGetUniqueHashTest, DISABLED_TwoChildCommsSameColor) {
   auto res = ncclSuccess;
 
-  NcclCommRAII comm{this->globalRank, this->numRanks, this->localRank};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
 
   // Make two child comms from commSplit with same color, compare commHash
   // between them

--- a/comms/ncclx/v2_27/meta/tests/CommRegisterTest.cc
+++ b/comms/ncclx/v2_27/meta/tests/CommRegisterTest.cc
@@ -12,6 +12,8 @@
 #include "comms/testinfra/TestsDistUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
+
 class CommRegisterTest : public NcclxBaseTest {
  public:
   CommRegisterTest() = default;
@@ -33,7 +35,8 @@ class CommRegisterTestParam
 
 TEST_P(CommRegisterTestParam, RegularUsage) {
   const auto& [nbytes, memType, ctranRegist] = GetParam();
-  NcclCommRAII comm(globalRank, numRanks, localRank);
+  ncclx::test::NcclCommRAII comm(
+      globalRank, numRanks, localRank, bootstrap_.get());
   EnvRAII env(NCCL_CTRAN_REGISTER, ctranRegist);
   EnvRAII env2(NCCL_LOCAL_REGISTER, (int64_t)0);
 
@@ -71,7 +74,8 @@ TEST_P(CommRegisterTestParam, RegularUsage) {
 }
 
 TEST_F(CommRegisterTest, InvalidHybridUsage) {
-  NcclCommRAII comm(globalRank, numRanks, localRank);
+  ncclx::test::NcclCommRAII comm(
+      globalRank, numRanks, localRank, bootstrap_.get());
   EnvRAII env1(NCCL_CTRAN_REGISTER, NCCL_CTRAN_REGISTER::lazy);
   EnvRAII env2(NCCL_LOCAL_REGISTER, (int64_t)1);
   constexpr size_t nbytes = 8192;
@@ -92,7 +96,8 @@ TEST_F(CommRegisterTest, InvalidHybridUsage) {
 }
 
 TEST_F(CommRegisterTest, InvalidHandle) {
-  NcclCommRAII comm(globalRank, numRanks, localRank);
+  ncclx::test::NcclCommRAII comm(
+      globalRank, numRanks, localRank, bootstrap_.get());
 
   auto res = ncclCommDeregister(comm, nullptr);
   ASSERT_EQ(res, ncclInvalidArgument);

--- a/comms/ncclx/v2_27/meta/tests/CommWithCtranTest.cc
+++ b/comms/ncclx/v2_27/meta/tests/CommWithCtranTest.cc
@@ -7,31 +7,28 @@
 #include <gtest/gtest.h>
 
 #include "comm.h"
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
 #include "meta/hints/GlobalHints.h" // @manual
 #include "nccl.h"
 
-class CommWithCtranTest : public ::testing::Test {
+class CommWithCtranTest : public NcclxBaseTest {
  public:
-  CommWithCtranTest() = default;
-
   void SetUp() override {
     // Init NCCL env so that creating communicator in each test case will not
     // initialize CVAR again, and we can override.
-    initEnv();
-    std::tie(this->localRank, this->globalRank, this->numRanks) = getMpiInfo();
+    NcclxBaseTest::SetUp();
   }
 
-  void TearDown() override {}
-
-  int localRank{0};
-  int globalRank{0};
-  int numRanks{0};
+  void TearDown() override {
+    NcclxBaseTest::TearDown();
+  }
 };
 
 TEST_F(CommWithCtranTest, CtranEnable) {
   EnvRAII env(NCCL_CTRAN_ENABLE, true);
-  ncclComm_t comm = createNcclComm(globalRank, numRanks, localRank);
+  ncclComm_t comm = ncclx::test::createNcclComm(
+      globalRank, numRanks, localRank, bootstrap_.get());
   ASSERT_NE(comm, nullptr);
   ASSERT_NE(comm->ctranComm_.get(), nullptr);
   ASSERT_TRUE(ctranInitialized(comm->ctranComm_.get()));
@@ -40,7 +37,8 @@ TEST_F(CommWithCtranTest, CtranEnable) {
 
 TEST_F(CommWithCtranTest, CtranDisable) {
   EnvRAII env(NCCL_CTRAN_ENABLE, false);
-  ncclComm_t comm = createNcclComm(globalRank, numRanks, localRank);
+  ncclComm_t comm = ncclx::test::createNcclComm(
+      globalRank, numRanks, localRank, bootstrap_.get());
   ASSERT_NE(comm, nullptr);
 
   // FIXME: currently ctranComm is used also for other modules, we should remove
@@ -63,14 +61,14 @@ TEST_P(CommWithCtranTestParam, CtranEnableByHint) {
 
   EnvRAII env(NCCL_CTRAN_ENABLE, false);
   // Default disabled
-  ncclComm_t comm1 = createNcclComm(globalRank, numRanks, localRank);
+  ncclComm_t comm1 = ncclx::test::createNcclComm(
+      globalRank, numRanks, localRank, bootstrap_.get());
   ASSERT_NE(comm1, nullptr);
   ASSERT_FALSE(ctranInitialized(comm1->ctranComm_.get()));
 
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
   config.blocking = blockingInit ? 1 : 0;
-  const auto commDescStr = fmt::format("{}-{}", kNcclUtCommDesc, "useCtran");
-  ncclx::Hints ctranHints({{"commDesc", commDescStr}});
+  ncclx::Hints ctranHints;
   config.hints = &ctranHints;
 
   // Enable by hint
@@ -79,11 +77,11 @@ TEST_P(CommWithCtranTestParam, CtranEnableByHint) {
       ncclSuccess);
   ncclComm_t comm2;
   if (createMode == TestCommCreateMode::kDefault) {
-    comm2 = createNcclComm(globalRank, numRanks, localRank, false, &config);
+    comm2 = ncclx::test::createNcclComm(
+        globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
   } else {
     ASSERT_EQ(
-        ncclCommSplit(comm1, 1, this->globalRank, &comm2, &config),
-        ncclSuccess);
+        ncclCommSplit(comm1, 1, globalRank, &comm2, &config), ncclSuccess);
   }
   ASSERT_NE(comm2, nullptr);
 
@@ -104,7 +102,8 @@ TEST_P(CommWithCtranTestParam, CtranEnableByHint) {
       ncclx::resetGlobalHint(std::string(ncclx::HintKeys::kCommUseCtran)));
 
   // Now it should be disabled again after hint reset
-  ncclComm_t comm3 = createNcclComm(globalRank, numRanks, localRank);
+  ncclComm_t comm3 = ncclx::test::createNcclComm(
+      globalRank, numRanks, localRank, bootstrap_.get());
   ASSERT_NE(comm3, nullptr);
   ASSERT_FALSE(ctranInitialized(comm3->ctranComm_.get()));
 

--- a/comms/ncclx/v2_27/meta/tests/CommWithNoLocalTest.cc
+++ b/comms/ncclx/v2_27/meta/tests/CommWithNoLocalTest.cc
@@ -20,28 +20,27 @@
 #include "comms/ctran/mapper/CtranMapperTypes.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
+
 // Hint lifecycle tests
 
-class CommWithNoLocalTest : public ::testing::Test {
+class CommWithNoLocalTest : public NcclxBaseTest {
  public:
   CommWithNoLocalTest() = default;
 
   void SetUp() override {
-    initEnv();
-    std::tie(this->localRank, this->globalRank, this->numRanks) = getMpiInfo();
+    NcclxBaseTest::SetUp();
   }
 
   void TearDown() override {
     ncclx::resetGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal));
+    NcclxBaseTest::TearDown();
   }
-
-  int localRank{0};
-  int globalRank{0};
-  int numRanks{0};
 };
 
 TEST_F(CommWithNoLocalTest, NoLocalDisabledByDefault) {
-  NcclCommRAII comm{globalRank, numRanks, localRank};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_NE(comm.get(), nullptr);
   EXPECT_FALSE(comm->noLocal_);
 }
@@ -59,7 +58,8 @@ TEST_P(CommWithNoLocalTestParam, NoLocalEnableByHint) {
   const auto& [createMode, blockingInit] = GetParam();
 
   // Default disabled
-  NcclCommRAII comm1{globalRank, numRanks, localRank};
+  ncclx::test::NcclCommRAII comm1{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_NE(comm1.get(), nullptr);
   EXPECT_FALSE(comm1->noLocal_);
 
@@ -75,11 +75,12 @@ TEST_P(CommWithNoLocalTestParam, NoLocalEnableByHint) {
       ncclSuccess);
 
   // Use appropriate RAII wrapper based on creation mode
-  std::optional<NcclCommRAII> comm2Default;
-  std::optional<NcclCommSplitRAII> comm2Split;
+  std::optional<ncclx::test::NcclCommRAII> comm2Default;
+  std::optional<ncclx::test::NcclCommSplitRAII> comm2Split;
   ncclComm_t comm2;
   if (createMode == TestCommCreateMode::kDefault) {
-    comm2Default.emplace(globalRank, numRanks, localRank, false, &config);
+    comm2Default.emplace(
+        globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
     comm2 = comm2Default->get();
   } else {
     comm2Split.emplace(comm1.get(), 1, this->globalRank, &config);
@@ -105,7 +106,8 @@ TEST_P(CommWithNoLocalTestParam, NoLocalEnableByHint) {
 
   // Now disabled again
   {
-    NcclCommRAII comm3{globalRank, numRanks, localRank};
+    ncclx::test::NcclCommRAII comm3{
+        globalRank, numRanks, localRank, bootstrap_.get()};
     ASSERT_NE(comm3.get(), nullptr);
     EXPECT_FALSE(comm3->noLocal_);
   }
@@ -333,8 +335,8 @@ TEST_P(CommWithNoLocalCollTest, BaselineRun) {
         ncclSuccess);
   }
 
-  NcclCommRAII comm{
-      globalRank, numRanks, localRank, false, nullptr, server.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_NE(comm.get(), nullptr);
   EXPECT_EQ(comm->noLocal_, noLocal);
 
@@ -353,8 +355,8 @@ TEST_P(CommWithNoLocalCollTest, CtranRun) {
       ncclx::setGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal), "1"),
       ncclSuccess);
 
-  NcclCommRAII comm{
-      globalRank, numRanks, localRank, false, nullptr, server.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_NE(comm.get(), nullptr);
   EXPECT_TRUE(comm->noLocal_);
 

--- a/comms/ncclx/v2_28/meta/tests/CommDescTest.cc
+++ b/comms/ncclx/v2_28/meta/tests/CommDescTest.cc
@@ -13,27 +13,32 @@
 #include "meta/NcclxConfig.h"
 #include "nccl.h"
 
-class commDescTest : public ::testing::Test {
+#include <gmock/gmock.h>
+
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
+
+class commDescTest : public NcclxBaseTest {
  public:
   commDescTest() = default;
 
  protected:
   void SetUp() override {
-    std::tie(this->localRank, this->globalRank, this->numRanks) = getMpiInfo();
+    NcclxBaseTest::SetUp();
   }
 
-  void TearDown() override {}
-
-  int localRank{0};
-  int globalRank{0};
-  int numRanks{0};
+  void TearDown() override {
+    NcclxBaseTest::TearDown();
+  }
 };
 
 TEST_F(commDescTest, getUndefinedCommDesc) {
-  NcclCommRAII comm(this->globalRank, this->numRanks, this->localRank);
+  ncclx::test::NcclCommRAII comm(
+      globalRank, numRanks, localRank, bootstrap_.get());
   ASSERT_NE(nullptr, static_cast<ncclComm_t>(comm));
 
-  EXPECT_EQ(NCCLX_CONFIG_FIELD(comm->config, commDesc), "nccl_ut");
+  EXPECT_THAT(
+      NCCLX_CONFIG_FIELD(comm->config, commDesc),
+      testing::StartsWith("nccl_ut_"));
 }
 
 TEST_F(commDescTest, getDefinedCommDesc) {
@@ -41,8 +46,7 @@ TEST_F(commDescTest, getDefinedCommDesc) {
   if (globalRank == 0) {
     NCCLCHECK_TEST(ncclGetUniqueId(&ncclId));
   }
-  MPICHECK_TEST(
-      MPI_Bcast((void*)&ncclId, sizeof(ncclId), MPI_BYTE, 0, MPI_COMM_WORLD));
+  oobBroadcast(&ncclId, 1, 0);
   CUDACHECK_TEST(cudaSetDevice(this->localRank));
 
   ncclComm_t comm;
@@ -65,8 +69,7 @@ TEST_F(commDescTest, InvalidPointerAccess) {
   if (globalRank == 0) {
     NCCLCHECK_TEST(ncclGetUniqueId(&ncclId));
   }
-  MPICHECK_TEST(
-      MPI_Bcast((void*)&ncclId, sizeof(ncclId), MPI_BYTE, 0, MPI_COMM_WORLD));
+  oobBroadcast(&ncclId, 1, 0);
   CUDACHECK_TEST(cudaSetDevice(this->localRank));
 
   ncclComm_t comm;

--- a/comms/ncclx/v2_28/meta/tests/CommGetUniqueHashTest.cc
+++ b/comms/ncclx/v2_28/meta/tests/CommGetUniqueHashTest.cc
@@ -7,28 +7,28 @@
 
 #include <nccl.h>
 #include "comm.h"
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
 
-class CommGetUniqueHashTest : public ::testing::Test {
+class CommGetUniqueHashTest : public NcclxBaseTest {
  public:
   CommGetUniqueHashTest() = default;
 
   void SetUp() override {
-    std::tie(this->localRank, this->globalRank, this->numRanks) = getMpiInfo();
+    NcclxBaseTest::SetUp();
   }
 
-  void TearDown() override {}
-
-  int localRank{0};
-  int globalRank{0};
-  int numRanks{0};
+  void TearDown() override {
+    NcclxBaseTest::TearDown();
+  }
 };
 
 TEST_F(CommGetUniqueHashTest, DefaultComm) {
   auto res = ncclSuccess;
 
-  NcclCommRAII comm{this->globalRank, this->numRanks, this->localRank};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   uint64_t commHash = 0;
   res = ncclCommGetUniqueHash(comm, &commHash);
   ASSERT_EQ(res, ncclSuccess);
@@ -36,18 +36,16 @@ TEST_F(CommGetUniqueHashTest, DefaultComm) {
   EXPECT_EQ(commHash, comm->commHash);
 
   // check all ranks have the same commHash
-  uint64_t commHashMin = 0, commHashMax = 0;
-  MPI_Allreduce(
-      &commHash, &commHashMin, 1, MPI_UINT64_T, MPI_MIN, MPI_COMM_WORLD);
-  MPI_Allreduce(
-      &commHash, &commHashMax, 1, MPI_UINT64_T, MPI_MIN, MPI_COMM_WORLD);
-  EXPECT_TRUE(commHashMin == commHashMax && commHashMax == commHash);
+  uint64_t rootHash = commHash;
+  oobBroadcast(&rootHash, 1, /*root=*/0);
+  EXPECT_EQ(rootHash, commHash) << "commHash mismatch vs rank 0";
 }
 
 TEST_F(CommGetUniqueHashTest, ParentChildComm) {
   auto res = ncclSuccess;
 
-  NcclCommRAII comm{this->globalRank, this->numRanks, this->localRank};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
 
   // Split into two groups, one with odd ranks and one with even ranks
   ncclComm_t childComm = NCCL_COMM_NULL;
@@ -71,7 +69,8 @@ TEST_F(CommGetUniqueHashTest, ParentChildComm) {
 TEST_F(CommGetUniqueHashTest, ParentChildCommSplitGroup) {
   auto res = ncclSuccess;
 
-  NcclCommRAII comm{this->globalRank, this->numRanks, this->localRank};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
 
   ncclConfig_t inputConfig = NCCL_CONFIG_INITIALIZER;
   inputConfig.splitGroupSize = this->numRanks / 2;
@@ -120,7 +119,8 @@ TEST_F(CommGetUniqueHashTest, InvalidComm) {
 }
 
 TEST_F(CommGetUniqueHashTest, GetHashAfteCommDestroy) {
-  NcclCommRAII comm{this->globalRank, this->numRanks, this->localRank};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   // Split into two groups, one with odd ranks and one with even ranks
   ncclComm_t childComm = NCCL_COMM_NULL;
   NCCLCHECK_TEST(ncclCommSplit(
@@ -141,7 +141,8 @@ TEST_F(CommGetUniqueHashTest, GetHashAfteCommDestroy) {
 TEST_F(CommGetUniqueHashTest, DISABLED_TwoChildCommsSameColor) {
   auto res = ncclSuccess;
 
-  NcclCommRAII comm{this->globalRank, this->numRanks, this->localRank};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
 
   // Make two child comms from commSplit with same color, compare commHash
   // between them

--- a/comms/ncclx/v2_28/meta/tests/CommRegisterTest.cc
+++ b/comms/ncclx/v2_28/meta/tests/CommRegisterTest.cc
@@ -11,6 +11,8 @@
 #include "comms/testinfra/TestsDistUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
+
 class CommRegisterTest : public NcclxBaseTest {
  public:
   CommRegisterTest() = default;
@@ -32,7 +34,8 @@ class CommRegisterTestParam
 
 TEST_P(CommRegisterTestParam, RegularUsage) {
   const auto& [nbytes, memType, ctranRegist] = GetParam();
-  NcclCommRAII comm(globalRank, numRanks, localRank);
+  ncclx::test::NcclCommRAII comm(
+      globalRank, numRanks, localRank, bootstrap_.get());
   EnvRAII env(NCCL_CTRAN_REGISTER, ctranRegist);
   EnvRAII env2(NCCL_LOCAL_REGISTER, (int64_t)0);
 
@@ -66,7 +69,8 @@ TEST_P(CommRegisterTestParam, RegularUsage) {
 }
 
 TEST_F(CommRegisterTest, InvalidHybridUsage) {
-  NcclCommRAII comm(globalRank, numRanks, localRank);
+  ncclx::test::NcclCommRAII comm(
+      globalRank, numRanks, localRank, bootstrap_.get());
   EnvRAII env1(NCCL_CTRAN_REGISTER, NCCL_CTRAN_REGISTER::lazy);
   EnvRAII env2(NCCL_LOCAL_REGISTER, (int64_t)1);
   constexpr size_t nbytes = 8192;
@@ -87,7 +91,8 @@ TEST_F(CommRegisterTest, InvalidHybridUsage) {
 }
 
 TEST_F(CommRegisterTest, InvalidHandle) {
-  NcclCommRAII comm(globalRank, numRanks, localRank);
+  ncclx::test::NcclCommRAII comm(
+      globalRank, numRanks, localRank, bootstrap_.get());
 
   auto res = ncclCommDeregister(comm, nullptr);
   ASSERT_EQ(res, ncclInvalidArgument);

--- a/comms/ncclx/v2_28/meta/tests/CommWithCtranTest.cc
+++ b/comms/ncclx/v2_28/meta/tests/CommWithCtranTest.cc
@@ -7,31 +7,28 @@
 #include <gtest/gtest.h>
 
 #include "comm.h"
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
 #include "meta/hints/GlobalHints.h" // @manual
 #include "nccl.h"
 
-class CommWithCtranTest : public ::testing::Test {
+class CommWithCtranTest : public NcclxBaseTest {
  public:
-  CommWithCtranTest() = default;
-
   void SetUp() override {
     // Init NCCL env so that creating communicator in each test case will not
     // initialize CVAR again, and we can override.
-    initEnv();
-    std::tie(this->localRank, this->globalRank, this->numRanks) = getMpiInfo();
+    NcclxBaseTest::SetUp();
   }
 
-  void TearDown() override {}
-
-  int localRank{0};
-  int globalRank{0};
-  int numRanks{0};
+  void TearDown() override {
+    NcclxBaseTest::TearDown();
+  }
 };
 
 TEST_F(CommWithCtranTest, CtranEnable) {
   EnvRAII env(NCCL_CTRAN_ENABLE, true);
-  ncclComm_t comm = createNcclComm(globalRank, numRanks, localRank);
+  ncclComm_t comm = ncclx::test::createNcclComm(
+      globalRank, numRanks, localRank, bootstrap_.get());
   ASSERT_NE(comm, nullptr);
   ASSERT_NE(comm->ctranComm_.get(), nullptr);
   ASSERT_TRUE(ctranInitialized(comm->ctranComm_.get()));
@@ -40,7 +37,8 @@ TEST_F(CommWithCtranTest, CtranEnable) {
 
 TEST_F(CommWithCtranTest, CtranDisable) {
   EnvRAII env(NCCL_CTRAN_ENABLE, false);
-  ncclComm_t comm = createNcclComm(globalRank, numRanks, localRank);
+  ncclComm_t comm = ncclx::test::createNcclComm(
+      globalRank, numRanks, localRank, bootstrap_.get());
   ASSERT_NE(comm, nullptr);
 
   // FIXME: currently ctranComm is used also for other modules, we should remove
@@ -63,14 +61,14 @@ TEST_P(CommWithCtranTestParam, CtranEnableByHint) {
 
   EnvRAII env(NCCL_CTRAN_ENABLE, false);
   // Default disabled
-  ncclComm_t comm1 = createNcclComm(globalRank, numRanks, localRank);
+  ncclComm_t comm1 = ncclx::test::createNcclComm(
+      globalRank, numRanks, localRank, bootstrap_.get());
   ASSERT_NE(comm1, nullptr);
   ASSERT_FALSE(ctranInitialized(comm1->ctranComm_.get()));
 
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
   config.blocking = blockingInit ? 1 : 0;
-  const auto commDescStr = fmt::format("{}-{}", kNcclUtCommDesc, "useCtran");
-  ncclx::Hints ctranHints({{"commDesc", commDescStr}});
+  ncclx::Hints ctranHints;
   config.hints = &ctranHints;
 
   // Enable by hint
@@ -79,11 +77,11 @@ TEST_P(CommWithCtranTestParam, CtranEnableByHint) {
       ncclSuccess);
   ncclComm_t comm2;
   if (createMode == TestCommCreateMode::kDefault) {
-    comm2 = createNcclComm(globalRank, numRanks, localRank, false, &config);
+    comm2 = ncclx::test::createNcclComm(
+        globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
   } else {
     ASSERT_EQ(
-        ncclCommSplit(comm1, 1, this->globalRank, &comm2, &config),
-        ncclSuccess);
+        ncclCommSplit(comm1, 1, globalRank, &comm2, &config), ncclSuccess);
   }
   ASSERT_NE(comm2, nullptr);
 
@@ -104,7 +102,8 @@ TEST_P(CommWithCtranTestParam, CtranEnableByHint) {
       ncclx::resetGlobalHint(std::string(ncclx::HintKeys::kCommUseCtran)));
 
   // Now it should be disabled again after hint reset
-  ncclComm_t comm3 = createNcclComm(globalRank, numRanks, localRank);
+  ncclComm_t comm3 = ncclx::test::createNcclComm(
+      globalRank, numRanks, localRank, bootstrap_.get());
   ASSERT_NE(comm3, nullptr);
   ASSERT_FALSE(ctranInitialized(comm3->ctranComm_.get()));
 

--- a/comms/ncclx/v2_28/meta/tests/CommWithNoLocalTest.cc
+++ b/comms/ncclx/v2_28/meta/tests/CommWithNoLocalTest.cc
@@ -22,28 +22,27 @@
 
 #include "VerifyAlgoStatsUtil.h"
 
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
+
 // Hint lifecycle tests
 
-class CommWithNoLocalTest : public ::testing::Test {
+class CommWithNoLocalTest : public NcclxBaseTest {
  public:
   CommWithNoLocalTest() = default;
 
   void SetUp() override {
-    initEnv();
-    std::tie(this->localRank, this->globalRank, this->numRanks) = getMpiInfo();
+    NcclxBaseTest::SetUp();
   }
 
   void TearDown() override {
     ncclx::resetGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal));
+    NcclxBaseTest::TearDown();
   }
-
-  int localRank{0};
-  int globalRank{0};
-  int numRanks{0};
 };
 
 TEST_F(CommWithNoLocalTest, NoLocalDisabledByDefault) {
-  NcclCommRAII comm{globalRank, numRanks, localRank};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_NE(comm.get(), nullptr);
   EXPECT_FALSE(comm->noLocal_);
 }
@@ -61,7 +60,8 @@ TEST_P(CommWithNoLocalTestParam, NoLocalEnableByHint) {
   const auto& [createMode, blockingInit] = GetParam();
 
   // Default disabled
-  NcclCommRAII comm1{globalRank, numRanks, localRank};
+  ncclx::test::NcclCommRAII comm1{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_NE(comm1.get(), nullptr);
   EXPECT_FALSE(comm1->noLocal_);
 
@@ -77,11 +77,12 @@ TEST_P(CommWithNoLocalTestParam, NoLocalEnableByHint) {
       ncclSuccess);
 
   // Use appropriate RAII wrapper based on creation mode
-  std::optional<NcclCommRAII> comm2Default;
-  std::optional<NcclCommSplitRAII> comm2Split;
+  std::optional<ncclx::test::NcclCommRAII> comm2Default;
+  std::optional<ncclx::test::NcclCommSplitRAII> comm2Split;
   ncclComm_t comm2;
   if (createMode == TestCommCreateMode::kDefault) {
-    comm2Default.emplace(globalRank, numRanks, localRank, false, &config);
+    comm2Default.emplace(
+        globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
     comm2 = comm2Default->get();
   } else {
     comm2Split.emplace(comm1.get(), 1, this->globalRank, &config);
@@ -107,7 +108,8 @@ TEST_P(CommWithNoLocalTestParam, NoLocalEnableByHint) {
 
   // Now disabled again
   {
-    NcclCommRAII comm3{globalRank, numRanks, localRank};
+    ncclx::test::NcclCommRAII comm3{
+        globalRank, numRanks, localRank, bootstrap_.get()};
     ASSERT_NE(comm3.get(), nullptr);
     EXPECT_FALSE(comm3->noLocal_);
   }
@@ -337,8 +339,8 @@ TEST_P(CommWithNoLocalCollTest, BaselineRun) {
         ncclSuccess);
   }
 
-  NcclCommRAII comm{
-      globalRank, numRanks, localRank, false, nullptr, server.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_NE(comm.get(), nullptr);
   EXPECT_EQ(comm->noLocal_, noLocal);
 
@@ -361,8 +363,8 @@ TEST_P(CommWithNoLocalCollTest, CtranRun) {
       ncclx::setGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal), "1"),
       ncclSuccess);
 
-  NcclCommRAII comm{
-      globalRank, numRanks, localRank, false, nullptr, server.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_NE(comm.get(), nullptr);
   EXPECT_TRUE(comm->noLocal_);
 

--- a/comms/ncclx/v2_29/meta/tests/CommDescTest.cc
+++ b/comms/ncclx/v2_29/meta/tests/CommDescTest.cc
@@ -13,27 +13,32 @@
 #include "meta/NcclxConfig.h"
 #include "nccl.h"
 
-class commDescTest : public ::testing::Test {
+#include <gmock/gmock.h>
+
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
+
+class commDescTest : public NcclxBaseTest {
  public:
   commDescTest() = default;
 
  protected:
   void SetUp() override {
-    std::tie(this->localRank, this->globalRank, this->numRanks) = getMpiInfo();
+    NcclxBaseTest::SetUp();
   }
 
-  void TearDown() override {}
-
-  int localRank{0};
-  int globalRank{0};
-  int numRanks{0};
+  void TearDown() override {
+    NcclxBaseTest::TearDown();
+  }
 };
 
 TEST_F(commDescTest, getUndefinedCommDesc) {
-  NcclCommRAII comm(this->globalRank, this->numRanks, this->localRank);
+  ncclx::test::NcclCommRAII comm(
+      globalRank, numRanks, localRank, bootstrap_.get());
   ASSERT_NE(nullptr, static_cast<ncclComm_t>(comm));
 
-  EXPECT_EQ(NCCLX_CONFIG_FIELD(comm->config, commDesc), "nccl_ut");
+  EXPECT_THAT(
+      NCCLX_CONFIG_FIELD(comm->config, commDesc),
+      testing::StartsWith("nccl_ut_"));
 }
 
 TEST_F(commDescTest, getDefinedCommDesc) {
@@ -41,8 +46,7 @@ TEST_F(commDescTest, getDefinedCommDesc) {
   if (globalRank == 0) {
     NCCLCHECK_TEST(ncclGetUniqueId(&ncclId));
   }
-  MPICHECK_TEST(
-      MPI_Bcast((void*)&ncclId, sizeof(ncclId), MPI_BYTE, 0, MPI_COMM_WORLD));
+  oobBroadcast(&ncclId, 1, 0);
   CUDACHECK_TEST(cudaSetDevice(this->localRank));
 
   ncclComm_t comm;
@@ -65,8 +69,7 @@ TEST_F(commDescTest, InvalidPointerAccess) {
   if (globalRank == 0) {
     NCCLCHECK_TEST(ncclGetUniqueId(&ncclId));
   }
-  MPICHECK_TEST(
-      MPI_Bcast((void*)&ncclId, sizeof(ncclId), MPI_BYTE, 0, MPI_COMM_WORLD));
+  oobBroadcast(&ncclId, 1, 0);
   CUDACHECK_TEST(cudaSetDevice(this->localRank));
 
   ncclComm_t comm;

--- a/comms/ncclx/v2_29/meta/tests/CommGetUniqueHashTest.cc
+++ b/comms/ncclx/v2_29/meta/tests/CommGetUniqueHashTest.cc
@@ -7,28 +7,28 @@
 
 #include <nccl.h>
 #include "comm.h"
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
 
-class CommGetUniqueHashTest : public ::testing::Test {
+class CommGetUniqueHashTest : public NcclxBaseTest {
  public:
   CommGetUniqueHashTest() = default;
 
   void SetUp() override {
-    std::tie(this->localRank, this->globalRank, this->numRanks) = getMpiInfo();
+    NcclxBaseTest::SetUp();
   }
 
-  void TearDown() override {}
-
-  int localRank{0};
-  int globalRank{0};
-  int numRanks{0};
+  void TearDown() override {
+    NcclxBaseTest::TearDown();
+  }
 };
 
 TEST_F(CommGetUniqueHashTest, DefaultComm) {
   auto res = ncclSuccess;
 
-  NcclCommRAII comm{this->globalRank, this->numRanks, this->localRank};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   uint64_t commHash = 0;
   res = ncclCommGetUniqueHash(comm, &commHash);
   ASSERT_EQ(res, ncclSuccess);
@@ -36,18 +36,16 @@ TEST_F(CommGetUniqueHashTest, DefaultComm) {
   EXPECT_EQ(commHash, comm->commHash);
 
   // check all ranks have the same commHash
-  uint64_t commHashMin = 0, commHashMax = 0;
-  MPI_Allreduce(
-      &commHash, &commHashMin, 1, MPI_UINT64_T, MPI_MIN, MPI_COMM_WORLD);
-  MPI_Allreduce(
-      &commHash, &commHashMax, 1, MPI_UINT64_T, MPI_MIN, MPI_COMM_WORLD);
-  EXPECT_TRUE(commHashMin == commHashMax && commHashMax == commHash);
+  uint64_t rootHash = commHash;
+  oobBroadcast(&rootHash, 1, /*root=*/0);
+  EXPECT_EQ(rootHash, commHash) << "commHash mismatch vs rank 0";
 }
 
 TEST_F(CommGetUniqueHashTest, ParentChildComm) {
   auto res = ncclSuccess;
 
-  NcclCommRAII comm{this->globalRank, this->numRanks, this->localRank};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
 
   // Split into two groups, one with odd ranks and one with even ranks
   ncclComm_t childComm = NCCL_COMM_NULL;
@@ -71,7 +69,8 @@ TEST_F(CommGetUniqueHashTest, ParentChildComm) {
 TEST_F(CommGetUniqueHashTest, ParentChildCommSplitGroup) {
   auto res = ncclSuccess;
 
-  NcclCommRAII comm{this->globalRank, this->numRanks, this->localRank};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
 
   ncclConfig_t inputConfig = NCCL_CONFIG_INITIALIZER;
   inputConfig.splitGroupSize = this->numRanks / 2;
@@ -120,7 +119,8 @@ TEST_F(CommGetUniqueHashTest, InvalidComm) {
 }
 
 TEST_F(CommGetUniqueHashTest, GetHashAfteCommDestroy) {
-  NcclCommRAII comm{this->globalRank, this->numRanks, this->localRank};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   // Split into two groups, one with odd ranks and one with even ranks
   ncclComm_t childComm = NCCL_COMM_NULL;
   NCCLCHECK_TEST(ncclCommSplit(
@@ -141,7 +141,8 @@ TEST_F(CommGetUniqueHashTest, GetHashAfteCommDestroy) {
 TEST_F(CommGetUniqueHashTest, DISABLED_TwoChildCommsSameColor) {
   auto res = ncclSuccess;
 
-  NcclCommRAII comm{this->globalRank, this->numRanks, this->localRank};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
 
   // Make two child comms from commSplit with same color, compare commHash
   // between them

--- a/comms/ncclx/v2_29/meta/tests/CommRegisterTest.cc
+++ b/comms/ncclx/v2_29/meta/tests/CommRegisterTest.cc
@@ -11,6 +11,8 @@
 #include "comms/testinfra/TestsDistUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
+
 class CommRegisterTest : public NcclxBaseTest {
  public:
   CommRegisterTest() = default;
@@ -32,7 +34,8 @@ class CommRegisterTestParam
 
 TEST_P(CommRegisterTestParam, RegularUsage) {
   const auto& [nbytes, memType, ctranRegist] = GetParam();
-  NcclCommRAII comm(globalRank, numRanks, localRank);
+  ncclx::test::NcclCommRAII comm(
+      globalRank, numRanks, localRank, bootstrap_.get());
   EnvRAII env(NCCL_CTRAN_REGISTER, ctranRegist);
   EnvRAII env2(NCCL_LOCAL_REGISTER, (int64_t)0);
 
@@ -66,7 +69,8 @@ TEST_P(CommRegisterTestParam, RegularUsage) {
 }
 
 TEST_F(CommRegisterTest, InvalidHybridUsage) {
-  NcclCommRAII comm(globalRank, numRanks, localRank);
+  ncclx::test::NcclCommRAII comm(
+      globalRank, numRanks, localRank, bootstrap_.get());
   EnvRAII env1(NCCL_CTRAN_REGISTER, NCCL_CTRAN_REGISTER::lazy);
   EnvRAII env2(NCCL_LOCAL_REGISTER, (int64_t)1);
   constexpr size_t nbytes = 8192;
@@ -87,7 +91,8 @@ TEST_F(CommRegisterTest, InvalidHybridUsage) {
 }
 
 TEST_F(CommRegisterTest, InvalidHandle) {
-  NcclCommRAII comm(globalRank, numRanks, localRank);
+  ncclx::test::NcclCommRAII comm(
+      globalRank, numRanks, localRank, bootstrap_.get());
 
   auto res = ncclCommDeregister(comm, nullptr);
   ASSERT_EQ(res, ncclInvalidArgument);

--- a/comms/ncclx/v2_29/meta/tests/CommWithCtranTest.cc
+++ b/comms/ncclx/v2_29/meta/tests/CommWithCtranTest.cc
@@ -7,31 +7,28 @@
 #include <gtest/gtest.h>
 
 #include "comm.h"
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
 #include "meta/hints/GlobalHints.h" // @manual
 #include "nccl.h"
 
-class CommWithCtranTest : public ::testing::Test {
+class CommWithCtranTest : public NcclxBaseTest {
  public:
-  CommWithCtranTest() = default;
-
   void SetUp() override {
     // Init NCCL env so that creating communicator in each test case will not
     // initialize CVAR again, and we can override.
-    initEnv();
-    std::tie(this->localRank, this->globalRank, this->numRanks) = getMpiInfo();
+    NcclxBaseTest::SetUp();
   }
 
-  void TearDown() override {}
-
-  int localRank{0};
-  int globalRank{0};
-  int numRanks{0};
+  void TearDown() override {
+    NcclxBaseTest::TearDown();
+  }
 };
 
 TEST_F(CommWithCtranTest, CtranEnable) {
   EnvRAII env(NCCL_CTRAN_ENABLE, true);
-  ncclComm_t comm = createNcclComm(globalRank, numRanks, localRank);
+  ncclComm_t comm = ncclx::test::createNcclComm(
+      globalRank, numRanks, localRank, bootstrap_.get());
   ASSERT_NE(comm, nullptr);
   ASSERT_NE(comm->ctranComm_.get(), nullptr);
   ASSERT_TRUE(ctranInitialized(comm->ctranComm_.get()));
@@ -40,7 +37,8 @@ TEST_F(CommWithCtranTest, CtranEnable) {
 
 TEST_F(CommWithCtranTest, CtranDisable) {
   EnvRAII env(NCCL_CTRAN_ENABLE, false);
-  ncclComm_t comm = createNcclComm(globalRank, numRanks, localRank);
+  ncclComm_t comm = ncclx::test::createNcclComm(
+      globalRank, numRanks, localRank, bootstrap_.get());
   ASSERT_NE(comm, nullptr);
 
   // FIXME: currently ctranComm is used also for other modules, we should remove
@@ -63,14 +61,14 @@ TEST_P(CommWithCtranTestParam, CtranEnableByHint) {
 
   EnvRAII env(NCCL_CTRAN_ENABLE, false);
   // Default disabled
-  ncclComm_t comm1 = createNcclComm(globalRank, numRanks, localRank);
+  ncclComm_t comm1 = ncclx::test::createNcclComm(
+      globalRank, numRanks, localRank, bootstrap_.get());
   ASSERT_NE(comm1, nullptr);
   ASSERT_FALSE(ctranInitialized(comm1->ctranComm_.get()));
 
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
   config.blocking = blockingInit ? 1 : 0;
-  const auto commDescStr = fmt::format("{}-{}", kNcclUtCommDesc, "useCtran");
-  ncclx::Hints ctranHints({{"commDesc", commDescStr}});
+  ncclx::Hints ctranHints;
   config.hints = &ctranHints;
 
   // Enable by hint
@@ -79,11 +77,11 @@ TEST_P(CommWithCtranTestParam, CtranEnableByHint) {
       ncclSuccess);
   ncclComm_t comm2;
   if (createMode == TestCommCreateMode::kDefault) {
-    comm2 = createNcclComm(globalRank, numRanks, localRank, false, &config);
+    comm2 = ncclx::test::createNcclComm(
+        globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
   } else {
     ASSERT_EQ(
-        ncclCommSplit(comm1, 1, this->globalRank, &comm2, &config),
-        ncclSuccess);
+        ncclCommSplit(comm1, 1, globalRank, &comm2, &config), ncclSuccess);
   }
   ASSERT_NE(comm2, nullptr);
 
@@ -104,7 +102,8 @@ TEST_P(CommWithCtranTestParam, CtranEnableByHint) {
       ncclx::resetGlobalHint(std::string(ncclx::HintKeys::kCommUseCtran)));
 
   // Now it should be disabled again after hint reset
-  ncclComm_t comm3 = createNcclComm(globalRank, numRanks, localRank);
+  ncclComm_t comm3 = ncclx::test::createNcclComm(
+      globalRank, numRanks, localRank, bootstrap_.get());
   ASSERT_NE(comm3, nullptr);
   ASSERT_FALSE(ctranInitialized(comm3->ctranComm_.get()));
 

--- a/comms/ncclx/v2_29/meta/tests/CommWithNoLocalTest.cc
+++ b/comms/ncclx/v2_29/meta/tests/CommWithNoLocalTest.cc
@@ -22,28 +22,27 @@
 
 #include "VerifyAlgoStatsUtil.h"
 
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
+
 // Hint lifecycle tests
 
-class CommWithNoLocalTest : public ::testing::Test {
+class CommWithNoLocalTest : public NcclxBaseTest {
  public:
   CommWithNoLocalTest() = default;
 
   void SetUp() override {
-    initEnv();
-    std::tie(this->localRank, this->globalRank, this->numRanks) = getMpiInfo();
+    NcclxBaseTest::SetUp();
   }
 
   void TearDown() override {
     ncclx::resetGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal));
+    NcclxBaseTest::TearDown();
   }
-
-  int localRank{0};
-  int globalRank{0};
-  int numRanks{0};
 };
 
 TEST_F(CommWithNoLocalTest, NoLocalDisabledByDefault) {
-  NcclCommRAII comm{globalRank, numRanks, localRank};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_NE(comm.get(), nullptr);
   EXPECT_FALSE(comm->noLocal_);
 }
@@ -61,7 +60,8 @@ TEST_P(CommWithNoLocalTestParam, NoLocalEnableByHint) {
   const auto& [createMode, blockingInit] = GetParam();
 
   // Default disabled
-  NcclCommRAII comm1{globalRank, numRanks, localRank};
+  ncclx::test::NcclCommRAII comm1{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_NE(comm1.get(), nullptr);
   EXPECT_FALSE(comm1->noLocal_);
 
@@ -77,11 +77,12 @@ TEST_P(CommWithNoLocalTestParam, NoLocalEnableByHint) {
       ncclSuccess);
 
   // Use appropriate RAII wrapper based on creation mode
-  std::optional<NcclCommRAII> comm2Default;
-  std::optional<NcclCommSplitRAII> comm2Split;
+  std::optional<ncclx::test::NcclCommRAII> comm2Default;
+  std::optional<ncclx::test::NcclCommSplitRAII> comm2Split;
   ncclComm_t comm2;
   if (createMode == TestCommCreateMode::kDefault) {
-    comm2Default.emplace(globalRank, numRanks, localRank, false, &config);
+    comm2Default.emplace(
+        globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
     comm2 = comm2Default->get();
   } else {
     comm2Split.emplace(comm1.get(), 1, this->globalRank, &config);
@@ -107,7 +108,8 @@ TEST_P(CommWithNoLocalTestParam, NoLocalEnableByHint) {
 
   // Now disabled again
   {
-    NcclCommRAII comm3{globalRank, numRanks, localRank};
+    ncclx::test::NcclCommRAII comm3{
+        globalRank, numRanks, localRank, bootstrap_.get()};
     ASSERT_NE(comm3.get(), nullptr);
     EXPECT_FALSE(comm3->noLocal_);
   }
@@ -337,8 +339,8 @@ TEST_P(CommWithNoLocalCollTest, BaselineRun) {
         ncclSuccess);
   }
 
-  NcclCommRAII comm{
-      globalRank, numRanks, localRank, false, nullptr, server.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_NE(comm.get(), nullptr);
   EXPECT_EQ(comm->noLocal_, noLocal);
 
@@ -361,8 +363,8 @@ TEST_P(CommWithNoLocalCollTest, CtranRun) {
       ncclx::setGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal), "1"),
       ncclSuccess);
 
-  NcclCommRAII comm{
-      globalRank, numRanks, localRank, false, nullptr, server.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_NE(comm.get(), nullptr);
   EXPECT_TRUE(comm->noLocal_);
 


### PR DESCRIPTION
Summary:

Migrate 5 basic Comm tests across all 3 ncclx versions (v2_27/v2_28/v2_29) to use ncclx::test:: APIs:
- Replace createNcclComm/finalizeNcclComm with ncclx::test::createNcclComm and ncclx::test::NcclCommRAII
- Remove unnecessary this-> on globalRank/numRanks/localRank in migration lines
- Add NcclCommUtils.h include and AddGlobalTestEnvironment(new DistEnvironmentBase) in main()
- Update BUCK files to add ncclx_comm_utils dependency

Reviewed By: Regina8023

Differential Revision: D97796140
