### PR TITLE
Back out "Reland: Migrate fbthrift to conda feedstock"

### DIFF
--- a/build_ncclx.sh
+++ b/build_ncclx.sh
@@ -190,6 +190,9 @@ function build_third_party {
     build_fb_oss_library "https://github.com/facebook/mvfst" "$third_party_tag" quic
     build_fb_oss_library "https://github.com/facebook/wangle.git" "$third_party_tag" wangle "-DBUILD_TESTS=OFF"
     build_fb_oss_library "https://github.com/facebook/fbthrift.git" "$third_party_tag" thrift
+  else
+    # TODO: use feedstock fbthrift instead of github fbthrift for feedstock build
+    build_fb_oss_library "https://github.com/facebook/fbthrift.git" main thrift
   fi
   popd
 }
@@ -206,13 +209,8 @@ function build_comms_tracing_service {
   cp -r "${base_dir}/${include_prefix}"/* "$include_prefix"
   mv "$include_prefix"/CMakeLists.txt .
 
-  if [[ -z "${NCCL_FEEDSTOCK_BUILD}" ]]; then
-    # Reuse thrift cmake build tree (source build path)
-    cp -r /tmp/third-party/thrift/build .
-  else
-    # fbthrift installed via conda — cmake finds it via CMAKE_PREFIX_PATH
-    mkdir -p build
-  fi
+  # set up the build config
+  cp -r /tmp/third-party/thrift/build .
 
   # build the thrift service library
   cd build


### PR DESCRIPTION
Summary:
this breaks tbr conda builds. reverting it so we can do it again with a flag.

(original diff - D97817807)

Reviewed By: snarayankh

Differential Revision: D97877884


