### PR TITLE
Add CudaRAII.cc to ncclx CMake build

### DIFF
--- a/comms/torchcomms/ncclx/CMakeLists.txt
+++ b/comms/torchcomms/ncclx/CMakeLists.txt
@@ -82,6 +82,7 @@ add_library(torchcomms_comms_ncclx MODULE
     ${TORCHCOMMS_NCCLX_SOURCES}
     ${TORCHCOMMS_CUDA_DEVICE_SOURCES}
     ${TORCHCOMMS_DEVICE_NCCLX_SOURCE}
+    comms/utils/CudaRAII.cc
 )
 set_target_properties(torchcomms_comms_ncclx PROPERTIES
     PREFIX ""


### PR DESCRIPTION
Summary:
The _comms_ncclx Python extension references
meta::comms::StreamCaptureModeGuard, added in D96172316 and D97057976,
but the CMake build never compiled CudaRAII.cc into the shared object.
The Buck build handles this via the //comms/utils:cuda_raii
dependency, but the CMake build for conda packaging was missing it,
causing an undefined symbol error at import time:

```
  ImportError: undefined symbol:
    _ZN4meta5comms22StreamCaptureModeGuard4initEv
```

Add comms/utils/CudaRAII.cc to the _comms_ncclx MODULE sources so that
StreamCaptureModeGuard::init() and the destructor are linked into the
.so.

Differential Revision: D97881411


