### PR TITLE
Part 1: LLPacket (#1230)

### DIFF
--- a/comms/common/AtomicUtils.cuh
+++ b/comms/common/AtomicUtils.cuh
@@ -485,6 +485,48 @@ store128_volatile_global(volatile uint64_t* ptr, uint64_t v0, uint64_t v1) {
 }
 
 // =============================================================================
+// 128-bit Volatile Load/Store (v4.u32 — for LL protocol 16-byte lines)
+// =============================================================================
+
+__device__ __forceinline__ void load_v4_volatile_global(
+    const volatile uint32_t* ptr,
+    uint32_t& v0,
+    uint32_t& v1,
+    uint32_t& v2,
+    uint32_t& v3) {
+#if defined(__HIP_PLATFORM_AMD__)
+  v0 = ptr[0];
+  v1 = ptr[1];
+  v2 = ptr[2];
+  v3 = ptr[3];
+#else
+  asm volatile("ld.volatile.global.v4.u32 {%0,%1,%2,%3}, [%4];"
+               : "=r"(v0), "=r"(v1), "=r"(v2), "=r"(v3)
+               : "l"(ptr)
+               : "memory");
+#endif
+}
+
+__device__ __forceinline__ void store_v4_volatile_global(
+    volatile uint32_t* ptr,
+    uint32_t v0,
+    uint32_t v1,
+    uint32_t v2,
+    uint32_t v3) {
+#if defined(__HIP_PLATFORM_AMD__)
+  ptr[0] = v0;
+  ptr[1] = v1;
+  ptr[2] = v2;
+  ptr[3] = v3;
+#else
+  asm volatile("st.volatile.global.v4.u32 [%0], {%1,%2,%3,%4};"
+               :
+               : "l"(ptr), "r"(v0), "r"(v1), "r"(v2), "r"(v3)
+               : "memory");
+#endif
+}
+
+// =============================================================================
 // Atomic Operation
 // =============================================================================
 

--- a/comms/pipes/ll/LlPacket.cuh
+++ b/comms/pipes/ll/LlPacket.cuh
@@ -1,0 +1,216 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include "comms/common/AtomicUtils.cuh"
+#include "comms/common/DeviceConstants.cuh"
+
+namespace comms::pipes {
+
+using comms::device::kWarpSize;
+
+// =============================================================================
+// LL Protocol Constants
+// =============================================================================
+
+/// Total size of one LL line (packet unit).
+static constexpr size_t kLlLineSize = 16;
+
+/// Usable payload bytes per line (data1 + data2 = 8 bytes).
+static constexpr size_t kLlPayloadPerLine = 8;
+
+/// Number of lines processed by one warp per iteration (one line per thread).
+static constexpr int kLlLinesPerWarp = kWarpSize;
+
+/// LL flag sentinel: both flag1 and flag2 are set to this value to indicate
+/// the slot is free for the sender to overwrite.
+/// Valid flag values are in [1, kLlMaxFlag], so kLlReadyToWrite never collides.
+static constexpr uint32_t kLlReadyToWrite = 0xFFFFFFFF;
+
+/// Maximum valid flag value. Flag values are in [1, kLlMaxFlag].
+static constexpr uint32_t kLlMaxFlag = kLlReadyToWrite - 1; // 0xFFFFFFFE
+
+static_assert(kLlMaxFlag > 0, "kLlMaxFlag must be positive");
+static_assert(
+    kLlMaxFlag < kLlReadyToWrite,
+    "kLlMaxFlag must be below sentinel");
+
+/// Byte value used with cudaMemset to initialize all LL line fields
+/// (including flags) to kLlReadyToWrite.
+static constexpr int kLlMemsetInitByte = 0xFF;
+
+// =============================================================================
+// LlLine — 16-byte packet unit with inline flags
+// =============================================================================
+
+/**
+ * LlLine - A 16-byte packet unit for the LL protocol.
+ *
+ * Layout:
+ *   data1 (4B) — lower 4 bytes of payload
+ *   flag1 (4B) — flag word (must match expected value)
+ *   data2 (4B) — upper 4 bytes of payload
+ *   flag2 (4B) — flag word (must match expected value)
+ *   Total: 16B = 8B payload + 8B flags
+ *
+ * The two flag words carry the same value. The receiver polls until both
+ * flag1 and flag2 match the expected value. This provides the atomicity
+ * indicator for the 16-byte volatile store over NVLink.
+ *
+ * Each thread handles one LlLine independently — no sub-warp coordination.
+ */
+struct LlLine {
+  uint32_t data1;
+  uint32_t flag1;
+  uint32_t data2;
+  uint32_t flag2;
+};
+
+static_assert(sizeof(LlLine) == 16, "LlLine must be exactly 16B");
+
+// =============================================================================
+// Device-side Volatile Load/Store (v4.u32)
+// =============================================================================
+
+/**
+ * Volatile-load a 16-byte LL line from global memory.
+ *
+ * Uses ld.volatile.global.v4.u32 to bypass L1 cache and ensure NVLink
+ * visibility. The load is atomic at the 16-byte level on NVLink.
+ *
+ * @param src  Pointer to the LlLine in global memory
+ * @param line Output LlLine to populate
+ */
+__device__ __forceinline__ void ll_load_line(const LlLine* src, LlLine& line) {
+  comms::device::load_v4_volatile_global(
+      reinterpret_cast<const volatile uint32_t*>(src),
+      line.data1,
+      line.flag1,
+      line.data2,
+      line.flag2);
+}
+
+/**
+ * Volatile-store a 16-byte LL line to global memory.
+ *
+ * Uses st.volatile.global.v4.u32 to bypass L1 cache and ensure NVLink
+ * visibility. The store is atomic at the 16-byte level on NVLink.
+ *
+ * @param dst  Pointer to the LlLine in global memory
+ * @param line LlLine to store
+ */
+__device__ __forceinline__ void ll_store_line(LlLine* dst, const LlLine& line) {
+  comms::device::store_v4_volatile_global(
+      reinterpret_cast<volatile uint32_t*>(dst),
+      line.data1,
+      line.flag1,
+      line.data2,
+      line.flag2);
+}
+
+/**
+ * ACK a buffer slot by writing kLlReadyToWrite to both flags and zeroing data.
+ *
+ * @param dst  Pointer to the LlLine in global memory
+ */
+__device__ __forceinline__ void ll_store_ack(LlLine* dst) {
+  LlLine ack;
+  ack.data1 = 0;
+  ack.flag1 = kLlReadyToWrite;
+  ack.data2 = 0;
+  ack.flag2 = kLlReadyToWrite;
+  ll_store_line(dst, ack);
+}
+
+// =============================================================================
+// Host/Device Utility Functions
+// =============================================================================
+
+/**
+ * Compute the number of LL lines needed for a message of @p nbytes.
+ *
+ * @param nbytes Message size in bytes (should be a multiple of 8)
+ * @return Number of lines (0 if nbytes == 0)
+ */
+__host__ __device__ __forceinline__ size_t ll_num_lines(size_t nbytes) {
+  if (nbytes == 0) {
+    return 0;
+  }
+  return (nbytes + kLlPayloadPerLine - 1) / kLlPayloadPerLine;
+}
+
+/**
+ * Compute the LL buffer size in bytes needed for a given max message size.
+ *
+ * @param max_message_size Maximum message size in bytes
+ * @return Buffer size in bytes (multiple of 16)
+ */
+__host__ __device__ __forceinline__ size_t
+ll_buffer_size(size_t max_message_size) {
+  return ll_num_lines(max_message_size) * kLlLineSize;
+}
+
+/**
+ * Compute the max payload bytes that fit in an LL buffer of a given size.
+ *
+ * Result is rounded down to an 8-byte multiple (LL alignment requirement).
+ *
+ * @param buffer_size_bytes Size of the LL buffer in bytes
+ * @return Maximum payload capacity in bytes (8-byte aligned)
+ */
+__host__ __device__ __forceinline__ size_t
+ll_buffer_payload_capacity(size_t buffer_size_bytes) {
+  size_t num_lines = buffer_size_bytes / kLlLineSize;
+  size_t raw_capacity = num_lines * kLlPayloadPerLine;
+  return (raw_capacity / 8) * 8;
+}
+
+/**
+ * Check whether the given pointer and byte count are eligible for LL.
+ *
+ * LL requires:
+ *   - nbytes is a multiple of 8
+ *   - ptr is 8-byte aligned (or nullptr when nbytes == 0)
+ *   - when buffer_num_lines > 0 and the buffer is smaller than the message,
+ *     buffer_num_lines >= kLlLinesPerWarp (warp-stride alignment requirement)
+ *
+ * @param ptr              Pointer to user data buffer (src or dst)
+ * @param nbytes           Message size in bytes
+ * @param buffer_num_lines Number of lines in the LL buffer (0 = no buffer
+ * constraint)
+ * @return true if the arguments satisfy LL requirements
+ */
+__host__ __device__ __forceinline__ bool
+can_use_ll(const void* ptr, size_t nbytes, size_t buffer_num_lines = 0) {
+  if (nbytes == 0) {
+    return true;
+  }
+  if ((nbytes % 8 != 0) || (reinterpret_cast<uintptr_t>(ptr) % 8 != 0)) {
+    return false;
+  }
+  if (buffer_num_lines > 0) {
+    const size_t total_lines = ll_num_lines(nbytes);
+    if (buffer_num_lines < total_lines &&
+        buffer_num_lines < static_cast<size_t>(kLlLinesPerWarp)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Compute the flag value for a given step.
+ *
+ * Maps any step index into the valid flag range [1, kLlMaxFlag] using modular
+ * arithmetic, so the result is never 0 or kLlReadyToWrite.
+ *
+ * @param step Zero-based step index (any value is safe)
+ * @return Flag value in [1, kLlMaxFlag]
+ */
+__host__ __device__ __forceinline__ uint32_t ll_flag(size_t step) {
+  return static_cast<uint32_t>(step % kLlMaxFlag) + 1;
+}
+
+} // namespace comms::pipes

--- a/comms/pipes/ll/tests/LlPacketTest.cc
+++ b/comms/pipes/ll/tests/LlPacketTest.cc
@@ -1,0 +1,188 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+#include <cstdint>
+
+#include "comms/pipes/ll/LlPacket.cuh"
+#include "comms/pipes/ll/tests/LlPacketTest.cuh"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/CudaRAII.h"
+
+using meta::comms::DeviceBuffer;
+
+namespace comms::pipes {
+
+class LlPacketTestFixture : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    CUDACHECK_TEST(cudaSetDevice(0));
+  }
+
+  void TearDown() override {
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+  }
+
+  template <typename F>
+  void expect_no_device_errors(F&& launcher, const char* fail_msg) {
+    DeviceBuffer errorCountBuffer(sizeof(uint32_t));
+    auto* errorCount_d = static_cast<uint32_t*>(errorCountBuffer.get());
+    CUDACHECK_TEST(cudaMemset(errorCount_d, 0, sizeof(uint32_t)));
+    launcher(errorCount_d);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    uint32_t errorCount_h = 0;
+    CUDACHECK_TEST(cudaMemcpy(
+        &errorCount_h, errorCount_d, sizeof(uint32_t), cudaMemcpyDeviceToHost));
+    EXPECT_EQ(errorCount_h, 0) << fail_msg;
+  }
+};
+
+TEST_F(LlPacketTestFixture, LineSize) {
+  expect_no_device_errors(test::test_ll_line_size, "LlLine size checks failed");
+}
+
+TEST_F(LlPacketTestFixture, FlagReadWrite) {
+  DeviceBuffer lineBuffer(sizeof(LlLine));
+  CUDACHECK_TEST(cudaMemset(lineBuffer.get(), 0, sizeof(LlLine)));
+  expect_no_device_errors(
+      [&](uint32_t* ec) {
+        test::test_ll_flag_read_write(lineBuffer.get(), ec);
+      },
+      "Flag read/write round-trip failed");
+}
+
+TEST_F(LlPacketTestFixture, NumLines) {
+  expect_no_device_errors(
+      test::test_ll_num_lines, "Num lines calculation failed");
+}
+
+TEST_F(LlPacketTestFixture, BufferSize) {
+  expect_no_device_errors(
+      test::test_ll_buffer_size, "Buffer size calculation failed");
+}
+
+TEST_F(LlPacketTestFixture, BufferPayloadCapacity) {
+  expect_no_device_errors(
+      test::test_ll_buffer_payload_capacity,
+      "Buffer payload capacity calculation failed");
+}
+
+TEST_F(LlPacketTestFixture, FlagInitViaCudaMemset) {
+  DeviceBuffer lineBuffer(sizeof(LlLine));
+  CUDACHECK_TEST(
+      cudaMemset(lineBuffer.get(), kLlMemsetInitByte, sizeof(LlLine)));
+  expect_no_device_errors(
+      [&](uint32_t* ec) { test::test_ll_flag_init(lineBuffer.get(), ec); },
+      "cudaMemset 0xFF should produce flags == kLlReadyToWrite");
+}
+
+TEST_F(LlPacketTestFixture, HostNumLinesCalculation) {
+  EXPECT_EQ(ll_num_lines(0), 0u);
+  EXPECT_EQ(ll_num_lines(1), 1u);
+  EXPECT_EQ(ll_num_lines(7), 1u);
+  EXPECT_EQ(ll_num_lines(8), 1u);
+  EXPECT_EQ(ll_num_lines(9), 2u);
+  EXPECT_EQ(ll_num_lines(16), 2u);
+  EXPECT_EQ(ll_num_lines(17), 3u);
+  EXPECT_EQ(ll_num_lines(65536), 8192u);
+
+  EXPECT_EQ(ll_buffer_size(0), 0u);
+  EXPECT_EQ(ll_buffer_size(8), 16u);
+  EXPECT_EQ(ll_buffer_size(16), 32u);
+  EXPECT_EQ(ll_buffer_size(65536), 131072u);
+
+  EXPECT_EQ(ll_buffer_payload_capacity(0), 0u);
+  EXPECT_EQ(ll_buffer_payload_capacity(16), 8u);
+  EXPECT_EQ(ll_buffer_payload_capacity(32), 16u);
+  EXPECT_EQ(ll_buffer_payload_capacity(131072), 65536u);
+}
+
+TEST_F(LlPacketTestFixture, HostCanUseLl) {
+  // nbytes == 0 is always eligible
+  EXPECT_TRUE(can_use_ll(nullptr, 0));
+  EXPECT_TRUE(can_use_ll(reinterpret_cast<const void*>(uintptr_t(1)), 0));
+
+  // Aligned pointer (0x100) + multiple of 8
+  auto* aligned = reinterpret_cast<const void*>(uintptr_t(0x100));
+  EXPECT_TRUE(can_use_ll(aligned, 8));
+  EXPECT_TRUE(can_use_ll(aligned, 16));
+  EXPECT_TRUE(can_use_ll(aligned, 1024));
+
+  // Aligned pointer + NOT multiple of 8
+  EXPECT_FALSE(can_use_ll(aligned, 1));
+  EXPECT_FALSE(can_use_ll(aligned, 7));
+  EXPECT_FALSE(can_use_ll(aligned, 9));
+
+  // Misaligned pointer (0x101) + multiple of 8
+  auto* misaligned = reinterpret_cast<const void*>(uintptr_t(0x101));
+  EXPECT_FALSE(can_use_ll(misaligned, 8));
+  EXPECT_FALSE(can_use_ll(misaligned, 16));
+
+  // Misaligned + not multiple of 8
+  EXPECT_FALSE(can_use_ll(misaligned, 9));
+
+  // buffer_num_lines checks (third parameter)
+
+  // buffer_num_lines=0 (default) -- no buffer constraint
+  EXPECT_TRUE(can_use_ll(aligned, 8, 0));
+
+  // nbytes=0 with buffer_num_lines>0 -- early return, always eligible
+  EXPECT_TRUE(can_use_ll(nullptr, 0, 64));
+
+  // buffer >= message -- always fine
+  EXPECT_TRUE(can_use_ll(aligned, 64, 8)); // 8 lines needed, 8 provided
+  EXPECT_TRUE(can_use_ll(aligned, 64, 100)); // 8 lines needed, 100 provided
+
+  // buffer < message but >= kLlLinesPerWarp -- fine (chunking)
+  EXPECT_TRUE(can_use_ll(aligned, 1024, 32)); // 128 lines needed, 32 provided
+  EXPECT_TRUE(can_use_ll(aligned, 1024, 64)); // 128 lines needed, 64 provided
+
+  // buffer < message and < kLlLinesPerWarp -- rejected
+  EXPECT_FALSE(can_use_ll(aligned, 1024, 16)); // 128 lines needed, 16 < 32
+  EXPECT_FALSE(can_use_ll(aligned, 1024, 1)); // 128 lines needed, 1 < 32
+}
+
+TEST_F(LlPacketTestFixture, HostLlFlag) {
+  // Basic values
+  EXPECT_EQ(ll_flag(0), 1u);
+  EXPECT_EQ(ll_flag(1), 2u);
+  EXPECT_EQ(ll_flag(41), 42u);
+
+  // Flag values should never be 0 or kLlReadyToWrite
+  EXPECT_NE(ll_flag(0), 0u);
+  EXPECT_NE(ll_flag(0), kLlReadyToWrite);
+
+  // Boundary: step = kLlMaxFlag - 1 produces maximum valid flag
+  EXPECT_EQ(ll_flag(static_cast<size_t>(kLlMaxFlag - 1)), kLlMaxFlag);
+
+  // Boundary: step = kLlMaxFlag wraps back to 1
+  EXPECT_EQ(ll_flag(static_cast<size_t>(kLlMaxFlag)), 1u);
+
+  // Boundary: step = kLlMaxFlag + 1 wraps to 2
+  EXPECT_EQ(ll_flag(static_cast<size_t>(kLlMaxFlag) + 1), 2u);
+
+  // Boundary: step = 0xFFFFFFFE (would have been kLlReadyToWrite with old impl)
+  EXPECT_EQ(ll_flag(static_cast<size_t>(0xFFFFFFFE)), 1u);
+  EXPECT_NE(ll_flag(static_cast<size_t>(0xFFFFFFFE)), kLlReadyToWrite);
+
+  // Boundary: step = 0xFFFFFFFF (would have wrapped to 0 with old impl)
+  EXPECT_EQ(ll_flag(static_cast<size_t>(0xFFFFFFFF)), 2u);
+  EXPECT_NE(ll_flag(static_cast<size_t>(0xFFFFFFFF)), 0u);
+}
+
+TEST_F(LlPacketTestFixture, CanUseLl) {
+  DeviceBuffer alignedBuffer(256);
+  expect_no_device_errors(
+      [&](uint32_t* ec) {
+        test::test_can_use_ll(
+            static_cast<const char*>(alignedBuffer.get()), ec);
+      },
+      "can_use_ll device-side checks failed");
+}
+
+TEST_F(LlPacketTestFixture, LlFlag) {
+  expect_no_device_errors(
+      test::test_ll_flag, "ll_flag device-side checks failed");
+}
+
+} // namespace comms::pipes

--- a/comms/pipes/ll/tests/LlPacketTest.cu
+++ b/comms/pipes/ll/tests/LlPacketTest.cu
@@ -1,0 +1,341 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <cstdint>
+
+#include "comms/pipes/ll/LlPacket.cuh"
+#include "comms/pipes/tests/Checks.h"
+
+namespace comms::pipes::test {
+
+using namespace comms::pipes;
+
+// =============================================================================
+// Size Tests
+// =============================================================================
+
+__global__ void test_ll_line_size_kernel(uint32_t* errorCount) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    if (sizeof(LlLine) != 16) {
+      printf(
+          "LlLine size mismatch: expected 16, got %llu\n",
+          (unsigned long long)sizeof(LlLine));
+      atomicAdd(errorCount, 1);
+    }
+  }
+}
+
+void test_ll_line_size(uint32_t* errorCount_d) {
+  test_ll_line_size_kernel<<<1, 1>>>(errorCount_d);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+// =============================================================================
+// Flag Read/Write Tests
+// =============================================================================
+
+__global__ void test_ll_flag_read_write_kernel(
+    LlLine* line,
+    uint32_t* errorCount) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    // Write a line with flag_value = 42
+    LlLine out;
+    out.data1 = 0xAAAAAAAA;
+    out.flag1 = 42;
+    out.data2 = 0xBBBBBBBB;
+    out.flag2 = 42;
+    ll_store_line(line, out);
+
+    // Read it back
+    LlLine in;
+    ll_load_line(line, in);
+
+    if (in.data1 != 0xAAAAAAAA) {
+      printf(
+          "data1 mismatch: expected 0xAAAAAAAA, got 0x%X\n",
+          (unsigned)in.data1);
+      atomicAdd(errorCount, 1);
+    }
+    if (in.flag1 != 42) {
+      printf("flag1 mismatch: expected 42, got %u\n", (unsigned)in.flag1);
+      atomicAdd(errorCount, 1);
+    }
+    if (in.data2 != 0xBBBBBBBB) {
+      printf(
+          "data2 mismatch: expected 0xBBBBBBBB, got 0x%X\n",
+          (unsigned)in.data2);
+      atomicAdd(errorCount, 1);
+    }
+    if (in.flag2 != 42) {
+      printf("flag2 mismatch: expected 42, got %u\n", (unsigned)in.flag2);
+      atomicAdd(errorCount, 1);
+    }
+
+    // Test ACK
+    ll_store_ack(line);
+    ll_load_line(line, in);
+    if (in.flag1 != kLlReadyToWrite || in.flag2 != kLlReadyToWrite) {
+      printf(
+          "ACK flag mismatch: expected 0x%X, got flag1=0x%X flag2=0x%X\n",
+          (unsigned)kLlReadyToWrite,
+          (unsigned)in.flag1,
+          (unsigned)in.flag2);
+      atomicAdd(errorCount, 1);
+    }
+    if (in.data1 != 0 || in.data2 != 0) {
+      printf(
+          "ACK data mismatch: expected 0, got data1=0x%X data2=0x%X\n",
+          (unsigned)in.data1,
+          (unsigned)in.data2);
+      atomicAdd(errorCount, 1);
+    }
+  }
+}
+
+void test_ll_flag_read_write(void* line_d, uint32_t* errorCount_d) {
+  test_ll_flag_read_write_kernel<<<1, 1>>>(
+      static_cast<LlLine*>(line_d), errorCount_d);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+// =============================================================================
+// Num Lines Tests
+// =============================================================================
+
+__global__ void test_ll_num_lines_kernel(uint32_t* errorCount) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    if (ll_num_lines(0) != 0)
+      atomicAdd(errorCount, 1);
+    if (ll_num_lines(1) != 1)
+      atomicAdd(errorCount, 1);
+    if (ll_num_lines(7) != 1)
+      atomicAdd(errorCount, 1);
+    if (ll_num_lines(8) != 1)
+      atomicAdd(errorCount, 1);
+    if (ll_num_lines(9) != 2)
+      atomicAdd(errorCount, 1);
+    if (ll_num_lines(16) != 2)
+      atomicAdd(errorCount, 1);
+    if (ll_num_lines(17) != 3)
+      atomicAdd(errorCount, 1);
+    // 64KB = 65536 bytes -> 65536/8 = 8192 lines
+    if (ll_num_lines(65536) != 8192)
+      atomicAdd(errorCount, 1);
+  }
+}
+
+void test_ll_num_lines(uint32_t* errorCount_d) {
+  test_ll_num_lines_kernel<<<1, 1>>>(errorCount_d);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+// =============================================================================
+// Buffer Size Tests
+// =============================================================================
+
+__global__ void test_ll_buffer_size_kernel(uint32_t* errorCount) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    if (ll_buffer_size(0) != 0)
+      atomicAdd(errorCount, 1);
+    // 8 bytes -> 1 line -> 16 bytes
+    if (ll_buffer_size(8) != 16)
+      atomicAdd(errorCount, 1);
+    // 16 bytes -> 2 lines -> 32 bytes
+    if (ll_buffer_size(16) != 32)
+      atomicAdd(errorCount, 1);
+    // 64KB -> 8192 lines -> 131072 bytes
+    if (ll_buffer_size(65536) != 131072)
+      atomicAdd(errorCount, 1);
+  }
+}
+
+void test_ll_buffer_size(uint32_t* errorCount_d) {
+  test_ll_buffer_size_kernel<<<1, 1>>>(errorCount_d);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+// =============================================================================
+// Buffer Payload Capacity Tests
+// =============================================================================
+
+__global__ void test_ll_buffer_payload_capacity_kernel(uint32_t* errorCount) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    // 0 bytes buffer -> 0 capacity
+    if (ll_buffer_payload_capacity(0) != 0)
+      atomicAdd(errorCount, 1);
+    // 16 bytes buffer -> 1 line -> 8 bytes payload
+    if (ll_buffer_payload_capacity(16) != 8)
+      atomicAdd(errorCount, 1);
+    // 32 bytes buffer -> 2 lines -> 16 bytes payload
+    if (ll_buffer_payload_capacity(32) != 16)
+      atomicAdd(errorCount, 1);
+    // 131072 bytes buffer -> 8192 lines -> 65536 bytes payload
+    if (ll_buffer_payload_capacity(131072) != 65536)
+      atomicAdd(errorCount, 1);
+    // 15 bytes buffer (not a full line) -> 0 lines -> 0 payload
+    if (ll_buffer_payload_capacity(15) != 0)
+      atomicAdd(errorCount, 1);
+  }
+}
+
+void test_ll_buffer_payload_capacity(uint32_t* errorCount_d) {
+  test_ll_buffer_payload_capacity_kernel<<<1, 1>>>(errorCount_d);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+// =============================================================================
+// Flag Initialization Test (cudaMemset 0xFF -> kLlReadyToWrite)
+// =============================================================================
+
+__global__ void test_ll_flag_init_kernel(LlLine* line, uint32_t* errorCount) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    LlLine in;
+    ll_load_line(line, in);
+    if (in.flag1 != kLlReadyToWrite) {
+      printf(
+          "Flag1 init mismatch: expected 0x%X, got 0x%X\n",
+          (unsigned)kLlReadyToWrite,
+          (unsigned)in.flag1);
+      atomicAdd(errorCount, 1);
+    }
+    if (in.flag2 != kLlReadyToWrite) {
+      printf(
+          "Flag2 init mismatch: expected 0x%X, got 0x%X\n",
+          (unsigned)kLlReadyToWrite,
+          (unsigned)in.flag2);
+      atomicAdd(errorCount, 1);
+    }
+  }
+}
+
+void test_ll_flag_init(void* line_d, uint32_t* errorCount_d) {
+  test_ll_flag_init_kernel<<<1, 1>>>(
+      static_cast<LlLine*>(line_d), errorCount_d);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+// =============================================================================
+// can_use_ll Tests
+// =============================================================================
+
+__global__ void test_can_use_ll_kernel(
+    const char* aligned_ptr,
+    uint32_t* errorCount) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    // nbytes == 0 always eligible
+    if (!can_use_ll(nullptr, 0))
+      atomicAdd(errorCount, 1);
+    if (!can_use_ll(aligned_ptr + 1, 0))
+      atomicAdd(errorCount, 1);
+
+    // Aligned + multiple of 8
+    if (!can_use_ll(aligned_ptr, 8))
+      atomicAdd(errorCount, 1);
+    if (!can_use_ll(aligned_ptr, 16))
+      atomicAdd(errorCount, 1);
+    if (!can_use_ll(aligned_ptr, 64))
+      atomicAdd(errorCount, 1);
+
+    // Aligned + NOT multiple of 8
+    if (can_use_ll(aligned_ptr, 1))
+      atomicAdd(errorCount, 1);
+    if (can_use_ll(aligned_ptr, 7))
+      atomicAdd(errorCount, 1);
+    if (can_use_ll(aligned_ptr, 9))
+      atomicAdd(errorCount, 1);
+
+    // Misaligned (ptr+1) + multiple of 8
+    if (can_use_ll(aligned_ptr + 1, 8))
+      atomicAdd(errorCount, 1);
+
+    // Misaligned + not multiple of 8
+    if (can_use_ll(aligned_ptr + 1, 9))
+      atomicAdd(errorCount, 1);
+
+    // buffer_num_lines checks (third parameter)
+
+    // buffer_num_lines=0 (default) -- no buffer constraint
+    if (!can_use_ll(aligned_ptr, 8, 0))
+      atomicAdd(errorCount, 1);
+
+    // nbytes=0 with buffer_num_lines>0 -- early return
+    if (!can_use_ll(nullptr, 0, 64))
+      atomicAdd(errorCount, 1);
+
+    // buffer >= message
+    if (!can_use_ll(aligned_ptr, 64, 8))
+      atomicAdd(errorCount, 1);
+    if (!can_use_ll(aligned_ptr, 64, 100))
+      atomicAdd(errorCount, 1);
+
+    // buffer < message but >= kLlLinesPerWarp (chunking OK)
+    if (!can_use_ll(aligned_ptr, 1024, 32))
+      atomicAdd(errorCount, 1);
+    if (!can_use_ll(aligned_ptr, 1024, 64))
+      atomicAdd(errorCount, 1);
+
+    // buffer < message and < kLlLinesPerWarp (rejected)
+    if (can_use_ll(aligned_ptr, 1024, 16))
+      atomicAdd(errorCount, 1);
+    if (can_use_ll(aligned_ptr, 1024, 1))
+      atomicAdd(errorCount, 1);
+  }
+}
+
+void test_can_use_ll(const char* aligned_ptr_d, uint32_t* errorCount_d) {
+  test_can_use_ll_kernel<<<1, 1>>>(aligned_ptr_d, errorCount_d);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+// =============================================================================
+// ll_flag Tests
+// =============================================================================
+
+__global__ void test_ll_flag_kernel(uint32_t* errorCount) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    // Basic values
+    if (ll_flag(0) != 1)
+      atomicAdd(errorCount, 1);
+    if (ll_flag(1) != 2)
+      atomicAdd(errorCount, 1);
+    if (ll_flag(41) != 42)
+      atomicAdd(errorCount, 1);
+
+    // Flag values should never be 0 or kLlReadyToWrite
+    if (ll_flag(0) == 0)
+      atomicAdd(errorCount, 1);
+    if (ll_flag(0) == kLlReadyToWrite)
+      atomicAdd(errorCount, 1);
+
+    // Boundary: max valid flag
+    if (ll_flag(static_cast<size_t>(kLlMaxFlag - 1)) != kLlMaxFlag)
+      atomicAdd(errorCount, 1);
+
+    // Boundary: wrap-around
+    if (ll_flag(static_cast<size_t>(kLlMaxFlag)) != 1)
+      atomicAdd(errorCount, 1);
+
+    // Boundary: wrap-around + 1
+    if (ll_flag(static_cast<size_t>(kLlMaxFlag) + 1) != 2)
+      atomicAdd(errorCount, 1);
+
+    // Boundary: step = 0xFFFFFFFE (old impl would produce kLlReadyToWrite)
+    if (ll_flag(static_cast<size_t>(0xFFFFFFFE)) == kLlReadyToWrite) {
+      printf("ll_flag(0xFFFFFFFE) collides with kLlReadyToWrite\n");
+      atomicAdd(errorCount, 1);
+    }
+
+    // Boundary: step = 0xFFFFFFFF (old impl would wrap to 0)
+    if (ll_flag(static_cast<size_t>(0xFFFFFFFF)) == 0) {
+      printf("ll_flag(0xFFFFFFFF) produced 0\n");
+      atomicAdd(errorCount, 1);
+    }
+  }
+}
+
+void test_ll_flag(uint32_t* errorCount_d) {
+  test_ll_flag_kernel<<<1, 1>>>(errorCount_d);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+} // namespace comms::pipes::test

--- a/comms/pipes/ll/tests/LlPacketTest.cuh
+++ b/comms/pipes/ll/tests/LlPacketTest.cuh
@@ -1,0 +1,33 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+
+namespace comms::pipes::test {
+
+/// Test that LlLine is 16 bytes.
+void test_ll_line_size(uint32_t* errorCount_d);
+
+/// Test flag read/write round-trip via volatile helpers.
+void test_ll_flag_read_write(void* line_d, uint32_t* errorCount_d);
+
+/// Test ll_num_lines for various message sizes.
+void test_ll_num_lines(uint32_t* errorCount_d);
+
+/// Test ll_buffer_size for various message sizes.
+void test_ll_buffer_size(uint32_t* errorCount_d);
+
+/// Test ll_buffer_payload_capacity.
+void test_ll_buffer_payload_capacity(uint32_t* errorCount_d);
+
+/// Test flag initialization to kLlReadyToWrite via cudaMemset 0xFF.
+void test_ll_flag_init(void* line_d, uint32_t* errorCount_d);
+
+/// Test can_use_ll on device side.
+void test_can_use_ll(const char* aligned_ptr_d, uint32_t* errorCount_d);
+
+/// Test ll_flag function.
+void test_ll_flag(uint32_t* errorCount_d);
+
+} // namespace comms::pipes::test


### PR DESCRIPTION
Summary:

Introduces the LL (Low-Latency) packet primitive layer for Pipes — the foundation for all subsequent LL diffs in this stack.

**`LlPacket.cuh`** defines:
- `LlLine`: 16-byte packet unit with interleaved data/flag layout (`{data1, flag1, data2, flag2}`). Each thread handles one line independently (no sub-warp coordination needed, unlike LL128's 8-thread groups). 8 bytes of payload per line.
- Volatile load/store helpers (`ll_load_line` / `ll_store_line`) using `ld/st.volatile.global.v4.u32` PTX for L1-bypass and NVLink atomicity.
- `ll_store_ack()`: writes `kLlReadyToWrite` (0xFFFFFFFF) to both flags, resetting the slot for the sender.
- Host/device utilities: `ll_num_lines()`, `ll_buffer_size()`, `ll_buffer_payload_capacity()`, `can_use_ll()`, `ll_flag()`.
- Protocol constants: `kLlLineSize`, `kLlPayloadPerLine`, `kLlLinesPerWarp`, `kLlReadyToWrite`, `kLlMemsetInitByte`.

**`LlPacketTest`** validates all of the above on both host and device, including flag round-trip via volatile load/store, `cudaMemset(0xFF)` initialization, and edge cases (0-byte messages, misaligned pointers).

This is Part 1 of 5 in the LL protocol stack. Subsequent parts build on this: LL ops (Part 2), transport integration (Part 3), AllToAllv collective (Part 4), and auto-tune (Part 5).

Reviewed By: siyengar

Differential Revision: D97780040


