### PR TITLE
Part 2b: LL Ops (Forward) (#1232)

### DIFF
--- a/comms/common/AtomicUtils.cuh
+++ b/comms/common/AtomicUtils.cuh
@@ -485,6 +485,48 @@ store128_volatile_global(volatile uint64_t* ptr, uint64_t v0, uint64_t v1) {
 }
 
 // =============================================================================
+// 128-bit Volatile Load/Store (v4.u32 — for LL protocol 16-byte lines)
+// =============================================================================
+
+__device__ __forceinline__ void load_v4_volatile_global(
+    const volatile uint32_t* ptr,
+    uint32_t& v0,
+    uint32_t& v1,
+    uint32_t& v2,
+    uint32_t& v3) {
+#if defined(__HIP_PLATFORM_AMD__)
+  v0 = ptr[0];
+  v1 = ptr[1];
+  v2 = ptr[2];
+  v3 = ptr[3];
+#else
+  asm volatile("ld.volatile.global.v4.u32 {%0,%1,%2,%3}, [%4];"
+               : "=r"(v0), "=r"(v1), "=r"(v2), "=r"(v3)
+               : "l"(ptr)
+               : "memory");
+#endif
+}
+
+__device__ __forceinline__ void store_v4_volatile_global(
+    volatile uint32_t* ptr,
+    uint32_t v0,
+    uint32_t v1,
+    uint32_t v2,
+    uint32_t v3) {
+#if defined(__HIP_PLATFORM_AMD__)
+  ptr[0] = v0;
+  ptr[1] = v1;
+  ptr[2] = v2;
+  ptr[3] = v3;
+#else
+  asm volatile("st.volatile.global.v4.u32 [%0], {%1,%2,%3,%4};"
+               :
+               : "l"(ptr), "r"(v0), "r"(v1), "r"(v2), "r"(v3)
+               : "memory");
+#endif
+}
+
+// =============================================================================
 // Atomic Operation
 // =============================================================================
 

--- a/comms/pipes/ll/LlOps.cuh
+++ b/comms/pipes/ll/LlOps.cuh
@@ -1,0 +1,269 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// @lint-ignore-every CLANGTIDY facebook-modularize-issue-check
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include "comms/pipes/DeviceCheck.cuh"
+#include "comms/pipes/ThreadGroup.cuh"
+#include "comms/pipes/Timeout.cuh"
+#include "comms/pipes/ll/LlPacket.cuh"
+
+namespace comms::pipes {
+
+// =============================================================================
+// LL Send/Recv/Forward Operations
+// =============================================================================
+//
+// Low-level LL operations for point-to-point communication.
+//
+// THREAD ORGANIZATION:
+//   - Warp-based (32 threads per warp)
+//   - Each thread handles one LlLine (16 bytes) per iteration independently
+//   - One warp handles 32 lines (256 bytes of payload) per iteration
+//   - No sub-warp grouping needed (unlike LL128's 8-thread groups)
+//
+// THREAD-TO-DATA MAPPING:
+//   Each warp independently handles all lines in the message.
+//   Thread tid handles lines at offsets: tid, tid + kLlLinesPerWarp,
+//   tid + 2*kLlLinesPerWarp, ... (stride = 32 lines per iteration)
+//
+// MEMORY ORDERING:
+//   All operations use ld.volatile.global.v4.u32 / st.volatile.global.v4.u32
+//   (bypass L1, NVLink-visible). The 16-byte volatile store is atomic on
+//   NVLink.
+//
+// PER-THREAD POLLING:
+//   Each thread independently polls its own line's flags (flag1 and flag2).
+//   Dual-flag checking confirms the full 16B store landed intact.
+//   No __shfl_sync needed.
+//
+// WINDOWED BUFFER (when buffer_num_lines > 0):
+//   When the LL buffer is smaller than the message, the single warp loops
+//   over the message using modular buffer indexing (line_idx %
+//   aligned_buf_lines) and per-line flag increments (line_idx /
+//   aligned_buf_lines) to prevent ABA issues.
+//
+// CHUNKING / WINDOWED BUFFER PROTOCOL:
+//   Same two-state invariant as LL128:
+//   - Sender polls for kLlReadyToWrite (slot free) -> writes data with
+//     pkt_flag_value
+//   - Receiver polls for pkt_flag_value (data ready) -> reads data ->
+//     ACKs with kLlReadyToWrite
+//   - Per-round flag increments prevent ABA within a step
+//   - ACK reset prevents ABA between steps
+//
+// MULTI-STEP USAGE:
+//   flag_value is hardcoded to 1. Multi-step works because the receiver ACKs
+//   every slot with kLlReadyToWrite after reading, resetting the state machine.
+
+/**
+ * ll_send — Send data to a remote LL buffer.
+ *
+ * The sender reads user data from a local source buffer, packs it into
+ * LlLines with flag values, and volatile-stores each line to the remote
+ * (receiver's) LL buffer.
+ *
+ * Each invocation independently processes the entire message using a single
+ * warp. When multiple warps call concurrently, the caller must provide each
+ * warp with its own buffer partition to avoid races.
+ *
+ * @param group     ThreadGroup (auto-converted to warp scope)
+ * @param src       Local source buffer (8-byte aligned)
+ * @param nbytes    Total message size in bytes (must be a multiple of 8)
+ * @param remote_ll_buf  Pointer to receiver's LL line buffer
+ * @param timeout   Timeout for flag polling
+ * @param buffer_num_lines  Number of lines in the LL buffer.
+ *                          0 = buffer is pre-sized to fit the entire message.
+ *                          >0 and < total lines = windowed/chunked mode.
+ *                          Must be >= kLlLinesPerWarp (32) when chunking.
+ */
+__device__ __forceinline__ void ll_send(
+    const ThreadGroup& group,
+    const char* __restrict__ src,
+    size_t nbytes,
+    LlLine* __restrict__ remote_ll_buf,
+    const Timeout& timeout,
+    size_t buffer_num_lines = 0) {
+#ifdef __CUDA_ARCH__
+  const uint32_t flag_value = 1;
+  const int tid = group.to_warp_group().thread_id_in_group;
+
+  if (nbytes == 0) {
+    return;
+  }
+
+  PIPES_DEVICE_CHECK(can_use_ll(src, nbytes, buffer_num_lines));
+
+  const size_t total_lines = ll_num_lines(nbytes);
+
+  const size_t buf_lines =
+      (buffer_num_lines > 0 && buffer_num_lines < total_lines)
+      ? buffer_num_lines
+      : total_lines;
+
+  // Align buf_lines down to warp boundary for modular indexing.
+  // Safe: PIPES_DEVICE_CHECK above guarantees buf_lines >= kLlLinesPerWarp
+  // when chunking.
+  const size_t aligned_buf_lines = (buf_lines < total_lines)
+      ? (buf_lines / kLlLinesPerWarp) * kLlLinesPerWarp
+      : buf_lines;
+
+  for (size_t base = 0; base < total_lines; base += kLlLinesPerWarp) {
+    const size_t line_idx = base + tid;
+    const bool active = line_idx < total_lines;
+
+    const size_t buf_idx = active ? (line_idx % aligned_buf_lines) : 0;
+    const uint32_t pkt_flag_value = flag_value +
+        static_cast<uint32_t>(active ? (line_idx / aligned_buf_lines) : 0);
+
+    // Poll for kLlReadyToWrite (slot free).
+    // The || condition loops until BOTH flag1 and flag2 equal kLlReadyToWrite,
+    // confirming the slot is in READY_TO_WRITE state. Dual-flag checking
+    // matches NCCL LL protocol convention and guards against torn reads.
+    if (active) {
+      LlLine poll;
+      do {
+        ll_load_line(&remote_ll_buf[buf_idx], poll);
+        if (poll.flag1 != kLlReadyToWrite || poll.flag2 != kLlReadyToWrite) {
+          TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+              timeout,
+              "ll_send: waiting for READY_TO_WRITE on line %llu (buf_idx=%llu)",
+              (unsigned long long)line_idx,
+              (unsigned long long)buf_idx);
+        }
+      } while (poll.flag1 != kLlReadyToWrite || poll.flag2 != kLlReadyToWrite);
+    }
+
+    // Pack user data into LlLine and write
+    if (active) {
+      const size_t payload_offset = line_idx * kLlPayloadPerLine;
+      const auto* src_u32 =
+          reinterpret_cast<const uint32_t*>(src + payload_offset);
+
+      LlLine out;
+      out.data1 = src_u32[0];
+      out.flag1 = pkt_flag_value;
+      out.data2 = src_u32[1];
+      out.flag2 = pkt_flag_value;
+
+      ll_store_line(&remote_ll_buf[buf_idx], out);
+    }
+  }
+#else
+  (void)group;
+  (void)src;
+  (void)nbytes;
+  (void)remote_ll_buf;
+  (void)timeout;
+  (void)buffer_num_lines;
+#endif
+}
+
+/**
+ * ll_recv — Receive data from a local LL buffer.
+ *
+ * The receiver polls the local LL buffer (which the sender wrote to
+ * remotely), reads the payload to the output buffer, and ACKs by writing
+ * kLlReadyToWrite back to both flags.
+ *
+ * Each invocation independently processes the entire message using a single
+ * warp. When multiple warps call concurrently, the caller must provide each
+ * warp with its own buffer partition to avoid races.
+ *
+ * @param group     ThreadGroup (auto-converted to warp scope)
+ * @param dst       Local output buffer (8-byte aligned)
+ * @param nbytes    Total message size in bytes (must be a multiple of 8)
+ * @param local_ll_buf  Pointer to local LL line buffer
+ * @param timeout   Timeout for flag polling
+ * @param buffer_num_lines  Number of lines in the LL buffer.
+ *                          0 = buffer is pre-sized to fit the entire message.
+ *                          >0 and < total lines = windowed/chunked mode.
+ *                          Must be >= kLlLinesPerWarp (32) when chunking.
+ */
+__device__ __forceinline__ void ll_recv(
+    const ThreadGroup& group,
+    char* __restrict__ dst,
+    size_t nbytes,
+    LlLine* __restrict__ local_ll_buf,
+    const Timeout& timeout,
+    size_t buffer_num_lines = 0) {
+#ifdef __CUDA_ARCH__
+  const uint32_t flag_value = 1;
+  const int tid = group.to_warp_group().thread_id_in_group;
+
+  if (nbytes == 0) {
+    return;
+  }
+
+  PIPES_DEVICE_CHECK(can_use_ll(dst, nbytes, buffer_num_lines));
+
+  const size_t total_lines = ll_num_lines(nbytes);
+
+  const size_t buf_lines =
+      (buffer_num_lines > 0 && buffer_num_lines < total_lines)
+      ? buffer_num_lines
+      : total_lines;
+
+  // Align buf_lines down to warp boundary for modular indexing.
+  // Safe: PIPES_DEVICE_CHECK above guarantees buf_lines >= kLlLinesPerWarp
+  // when chunking.
+  const size_t aligned_buf_lines = (buf_lines < total_lines)
+      ? (buf_lines / kLlLinesPerWarp) * kLlLinesPerWarp
+      : buf_lines;
+
+  for (size_t base = 0; base < total_lines; base += kLlLinesPerWarp) {
+    const size_t line_idx = base + tid;
+    const bool active = line_idx < total_lines;
+
+    const size_t buf_idx = active ? (line_idx % aligned_buf_lines) : 0;
+    const uint32_t pkt_flag_value = flag_value +
+        static_cast<uint32_t>(active ? (line_idx / aligned_buf_lines) : 0);
+
+    // Poll for pkt_flag_value (data ready).
+    // The || condition loops until BOTH flag1 and flag2 match the expected
+    // value, confirming the sender's full 16B data store landed.
+    LlLine in;
+    if (active) {
+      do {
+        ll_load_line(&local_ll_buf[buf_idx], in);
+        if (in.flag1 != pkt_flag_value || in.flag2 != pkt_flag_value) {
+          TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+              timeout,
+              "ll_recv: waiting for flag=%u on line %llu (buf_idx=%llu, got flag1=%u flag2=%u)",
+              (unsigned)pkt_flag_value,
+              (unsigned long long)line_idx,
+              (unsigned long long)buf_idx,
+              (unsigned)in.flag1,
+              (unsigned)in.flag2);
+        }
+      } while (in.flag1 != pkt_flag_value || in.flag2 != pkt_flag_value);
+    }
+
+    // Copy payload to output
+    if (active) {
+      const size_t payload_offset = line_idx * kLlPayloadPerLine;
+      auto* dst_u32 = reinterpret_cast<uint32_t*>(dst + payload_offset);
+      dst_u32[0] = in.data1;
+      dst_u32[1] = in.data2;
+    }
+
+    // ACK: no sync needed because each thread handles exactly one LlLine per
+    // iteration, so this thread's ACK only depends on its own copy above.
+    if (active) {
+      ll_store_ack(&local_ll_buf[buf_idx]);
+    }
+  }
+#else
+  (void)group;
+  (void)dst;
+  (void)nbytes;
+  (void)local_ll_buf;
+  (void)timeout;
+  (void)buffer_num_lines;
+#endif
+}
+
+} // namespace comms::pipes

--- a/comms/pipes/ll/LlOps.cuh
+++ b/comms/pipes/ll/LlOps.cuh
@@ -266,4 +266,120 @@ __device__ __forceinline__ void ll_recv(
 #endif
 }
 
+/**
+ * ll_forward — Receive from predecessor and forward to successor.
+ *
+ * For intermediate ranks in a broadcast ring. Reads data from the local
+ * LL buffer (written by predecessor), forwards it to the successor's
+ * remote LL buffer, copies payload to the local output buffer, and
+ * ACKs the predecessor.
+ *
+ * Each invocation independently processes the entire message using a single
+ * warp. When multiple warps call concurrently, the caller must provide each
+ * warp with its own buffer partition to avoid races.
+ *
+ * @param group     ThreadGroup (auto-converted to warp scope)
+ * @param dst       Local output buffer (8-byte aligned)
+ * @param nbytes    Total message size in bytes (must be a multiple of 8)
+ * @param local_ll_buf   Pointer to local LL buffer (predecessor wrote)
+ * @param remote_ll_buf  Pointer to successor's LL buffer
+ * @param timeout   Timeout for flag polling
+ * @param buffer_num_lines  Number of lines in the LL buffer.
+ *                          0 = buffer is pre-sized to fit the entire message.
+ *                          >0 and < total lines = windowed/chunked mode.
+ *                          Must be >= kLlLinesPerWarp (32) when chunking.
+ */
+__device__ __forceinline__ void ll_forward(
+    const ThreadGroup& group,
+    char* __restrict__ dst,
+    size_t nbytes,
+    LlLine* __restrict__ local_ll_buf,
+    LlLine* __restrict__ remote_ll_buf,
+    const Timeout& timeout,
+    size_t buffer_num_lines = 0) {
+#ifdef __CUDA_ARCH__
+  const uint32_t flag_value = 1;
+  const int tid = group.to_warp_group().thread_id_in_group;
+
+  if (nbytes == 0) {
+    return;
+  }
+
+  PIPES_DEVICE_CHECK(can_use_ll(dst, nbytes, buffer_num_lines));
+
+  const size_t total_lines = ll_num_lines(nbytes);
+
+  const size_t buf_lines =
+      (buffer_num_lines > 0 && buffer_num_lines < total_lines)
+      ? buffer_num_lines
+      : total_lines;
+  const size_t aligned_buf_lines = (buf_lines < total_lines)
+      ? (buf_lines / kLlLinesPerWarp) * kLlLinesPerWarp
+      : buf_lines;
+
+  for (size_t base = 0; base < total_lines; base += kLlLinesPerWarp) {
+    const size_t line_idx = base + tid;
+    const bool active = line_idx < total_lines;
+
+    const size_t buf_idx = active ? (line_idx % aligned_buf_lines) : 0;
+    const uint32_t pkt_flag_value = flag_value +
+        static_cast<uint32_t>(active ? (line_idx / aligned_buf_lines) : 0);
+
+    // Phase 1: Poll local buffer for data from predecessor
+    LlLine in;
+    if (active) {
+      do {
+        ll_load_line(&local_ll_buf[buf_idx], in);
+        if (in.flag1 != pkt_flag_value || in.flag2 != pkt_flag_value) {
+          TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+              timeout,
+              "ll_forward: waiting for flag=%u on local line %llu (buf_idx=%llu)",
+              (unsigned)pkt_flag_value,
+              (unsigned long long)line_idx,
+              (unsigned long long)buf_idx);
+        }
+      } while (in.flag1 != pkt_flag_value || in.flag2 != pkt_flag_value);
+    }
+
+    // Phase 2: Poll remote buffer for kLlReadyToWrite (slot free)
+    if (active) {
+      LlLine poll;
+      do {
+        ll_load_line(&remote_ll_buf[buf_idx], poll);
+        if (poll.flag1 != kLlReadyToWrite || poll.flag2 != kLlReadyToWrite) {
+          TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+              timeout,
+              "ll_forward: waiting for READY_TO_WRITE on remote line %llu (buf_idx=%llu)",
+              (unsigned long long)line_idx,
+              (unsigned long long)buf_idx);
+        }
+      } while (poll.flag1 != kLlReadyToWrite || poll.flag2 != kLlReadyToWrite);
+    }
+
+    // Phase 3: Forward to remote + copy to local output + ACK local
+    if (active) {
+      // in.flag1/flag2 already == pkt_flag_value (guaranteed by poll loop)
+      ll_store_line(&remote_ll_buf[buf_idx], in);
+
+      // Copy payload to local output
+      const size_t payload_offset = line_idx * kLlPayloadPerLine;
+      auto* dst_u32 = reinterpret_cast<uint32_t*>(dst + payload_offset);
+      dst_u32[0] = in.data1;
+      dst_u32[1] = in.data2;
+
+      // ACK predecessor's local buffer
+      ll_store_ack(&local_ll_buf[buf_idx]);
+    }
+  }
+#else
+  (void)group;
+  (void)dst;
+  (void)nbytes;
+  (void)local_ll_buf;
+  (void)remote_ll_buf;
+  (void)timeout;
+  (void)buffer_num_lines;
+#endif
+}
+
 } // namespace comms::pipes

--- a/comms/pipes/ll/LlPacket.cuh
+++ b/comms/pipes/ll/LlPacket.cuh
@@ -1,0 +1,216 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include "comms/common/AtomicUtils.cuh"
+#include "comms/common/DeviceConstants.cuh"
+
+namespace comms::pipes {
+
+using comms::device::kWarpSize;
+
+// =============================================================================
+// LL Protocol Constants
+// =============================================================================
+
+/// Total size of one LL line (packet unit).
+static constexpr size_t kLlLineSize = 16;
+
+/// Usable payload bytes per line (data1 + data2 = 8 bytes).
+static constexpr size_t kLlPayloadPerLine = 8;
+
+/// Number of lines processed by one warp per iteration (one line per thread).
+static constexpr int kLlLinesPerWarp = kWarpSize;
+
+/// LL flag sentinel: both flag1 and flag2 are set to this value to indicate
+/// the slot is free for the sender to overwrite.
+/// Valid flag values are in [1, kLlMaxFlag], so kLlReadyToWrite never collides.
+static constexpr uint32_t kLlReadyToWrite = 0xFFFFFFFF;
+
+/// Maximum valid flag value. Flag values are in [1, kLlMaxFlag].
+static constexpr uint32_t kLlMaxFlag = kLlReadyToWrite - 1; // 0xFFFFFFFE
+
+static_assert(kLlMaxFlag > 0, "kLlMaxFlag must be positive");
+static_assert(
+    kLlMaxFlag < kLlReadyToWrite,
+    "kLlMaxFlag must be below sentinel");
+
+/// Byte value used with cudaMemset to initialize all LL line fields
+/// (including flags) to kLlReadyToWrite.
+static constexpr int kLlMemsetInitByte = 0xFF;
+
+// =============================================================================
+// LlLine — 16-byte packet unit with inline flags
+// =============================================================================
+
+/**
+ * LlLine - A 16-byte packet unit for the LL protocol.
+ *
+ * Layout:
+ *   data1 (4B) — lower 4 bytes of payload
+ *   flag1 (4B) — flag word (must match expected value)
+ *   data2 (4B) — upper 4 bytes of payload
+ *   flag2 (4B) — flag word (must match expected value)
+ *   Total: 16B = 8B payload + 8B flags
+ *
+ * The two flag words carry the same value. The receiver polls until both
+ * flag1 and flag2 match the expected value. This provides the atomicity
+ * indicator for the 16-byte volatile store over NVLink.
+ *
+ * Each thread handles one LlLine independently — no sub-warp coordination.
+ */
+struct LlLine {
+  uint32_t data1;
+  uint32_t flag1;
+  uint32_t data2;
+  uint32_t flag2;
+};
+
+static_assert(sizeof(LlLine) == 16, "LlLine must be exactly 16B");
+
+// =============================================================================
+// Device-side Volatile Load/Store (v4.u32)
+// =============================================================================
+
+/**
+ * Volatile-load a 16-byte LL line from global memory.
+ *
+ * Uses ld.volatile.global.v4.u32 to bypass L1 cache and ensure NVLink
+ * visibility. The load is atomic at the 16-byte level on NVLink.
+ *
+ * @param src  Pointer to the LlLine in global memory
+ * @param line Output LlLine to populate
+ */
+__device__ __forceinline__ void ll_load_line(const LlLine* src, LlLine& line) {
+  comms::device::load_v4_volatile_global(
+      reinterpret_cast<const volatile uint32_t*>(src),
+      line.data1,
+      line.flag1,
+      line.data2,
+      line.flag2);
+}
+
+/**
+ * Volatile-store a 16-byte LL line to global memory.
+ *
+ * Uses st.volatile.global.v4.u32 to bypass L1 cache and ensure NVLink
+ * visibility. The store is atomic at the 16-byte level on NVLink.
+ *
+ * @param dst  Pointer to the LlLine in global memory
+ * @param line LlLine to store
+ */
+__device__ __forceinline__ void ll_store_line(LlLine* dst, const LlLine& line) {
+  comms::device::store_v4_volatile_global(
+      reinterpret_cast<volatile uint32_t*>(dst),
+      line.data1,
+      line.flag1,
+      line.data2,
+      line.flag2);
+}
+
+/**
+ * ACK a buffer slot by writing kLlReadyToWrite to both flags and zeroing data.
+ *
+ * @param dst  Pointer to the LlLine in global memory
+ */
+__device__ __forceinline__ void ll_store_ack(LlLine* dst) {
+  LlLine ack;
+  ack.data1 = 0;
+  ack.flag1 = kLlReadyToWrite;
+  ack.data2 = 0;
+  ack.flag2 = kLlReadyToWrite;
+  ll_store_line(dst, ack);
+}
+
+// =============================================================================
+// Host/Device Utility Functions
+// =============================================================================
+
+/**
+ * Compute the number of LL lines needed for a message of @p nbytes.
+ *
+ * @param nbytes Message size in bytes (should be a multiple of 8)
+ * @return Number of lines (0 if nbytes == 0)
+ */
+__host__ __device__ __forceinline__ size_t ll_num_lines(size_t nbytes) {
+  if (nbytes == 0) {
+    return 0;
+  }
+  return (nbytes + kLlPayloadPerLine - 1) / kLlPayloadPerLine;
+}
+
+/**
+ * Compute the LL buffer size in bytes needed for a given max message size.
+ *
+ * @param max_message_size Maximum message size in bytes
+ * @return Buffer size in bytes (multiple of 16)
+ */
+__host__ __device__ __forceinline__ size_t
+ll_buffer_size(size_t max_message_size) {
+  return ll_num_lines(max_message_size) * kLlLineSize;
+}
+
+/**
+ * Compute the max payload bytes that fit in an LL buffer of a given size.
+ *
+ * Result is rounded down to an 8-byte multiple (LL alignment requirement).
+ *
+ * @param buffer_size_bytes Size of the LL buffer in bytes
+ * @return Maximum payload capacity in bytes (8-byte aligned)
+ */
+__host__ __device__ __forceinline__ size_t
+ll_buffer_payload_capacity(size_t buffer_size_bytes) {
+  size_t num_lines = buffer_size_bytes / kLlLineSize;
+  size_t raw_capacity = num_lines * kLlPayloadPerLine;
+  return (raw_capacity / 8) * 8;
+}
+
+/**
+ * Check whether the given pointer and byte count are eligible for LL.
+ *
+ * LL requires:
+ *   - nbytes is a multiple of 8
+ *   - ptr is 8-byte aligned (or nullptr when nbytes == 0)
+ *   - when buffer_num_lines > 0 and the buffer is smaller than the message,
+ *     buffer_num_lines >= kLlLinesPerWarp (warp-stride alignment requirement)
+ *
+ * @param ptr              Pointer to user data buffer (src or dst)
+ * @param nbytes           Message size in bytes
+ * @param buffer_num_lines Number of lines in the LL buffer (0 = no buffer
+ * constraint)
+ * @return true if the arguments satisfy LL requirements
+ */
+__host__ __device__ __forceinline__ bool
+can_use_ll(const void* ptr, size_t nbytes, size_t buffer_num_lines = 0) {
+  if (nbytes == 0) {
+    return true;
+  }
+  if ((nbytes % 8 != 0) || (reinterpret_cast<uintptr_t>(ptr) % 8 != 0)) {
+    return false;
+  }
+  if (buffer_num_lines > 0) {
+    const size_t total_lines = ll_num_lines(nbytes);
+    if (buffer_num_lines < total_lines &&
+        buffer_num_lines < static_cast<size_t>(kLlLinesPerWarp)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Compute the flag value for a given step.
+ *
+ * Maps any step index into the valid flag range [1, kLlMaxFlag] using modular
+ * arithmetic, so the result is never 0 or kLlReadyToWrite.
+ *
+ * @param step Zero-based step index (any value is safe)
+ * @return Flag value in [1, kLlMaxFlag]
+ */
+__host__ __device__ __forceinline__ uint32_t ll_flag(size_t step) {
+  return static_cast<uint32_t>(step % kLlMaxFlag) + 1;
+}
+
+} // namespace comms::pipes

--- a/comms/pipes/ll/tests/LlOpsTest.cc
+++ b/comms/pipes/ll/tests/LlOpsTest.cc
@@ -1,0 +1,460 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include "comms/pipes/TimeoutUtils.h"
+#include "comms/pipes/ll/LlPacket.cuh"
+#include "comms/pipes/ll/tests/LlOpsTest.cuh"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/CudaRAII.h"
+
+using meta::comms::DeviceBuffer;
+
+namespace comms::pipes {
+
+// =============================================================================
+// Param struct and name generator
+// =============================================================================
+
+struct LlOpsTestParam {
+  std::string name;
+  size_t nbytes;
+  int num_blocks = 1;
+  int block_size = 32;
+  size_t buffer_num_lines = 0;
+  int num_steps = 1;
+};
+
+std::string ll_test_name(const ::testing::TestParamInfo<LlOpsTestParam>& info) {
+  return info.param.name;
+}
+
+// =============================================================================
+// Test fixture
+// =============================================================================
+
+class LlOpsTestFixture : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    CUDACHECK_TEST(cudaSetDevice(0));
+  }
+
+  void TearDown() override {
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+  }
+
+  std::vector<char> make_pattern(size_t nbytes, int seed = 0) {
+    std::vector<char> pattern(nbytes);
+    for (size_t i = 0; i < nbytes; ++i) {
+      pattern[i] = static_cast<char>((i + seed) & 0xFF);
+    }
+    return pattern;
+  }
+
+  void
+  run_send_recv_test(size_t nbytes, int num_blocks = 1, int block_size = 32) {
+    auto pattern = make_pattern(nbytes);
+
+    DeviceBuffer srcBuffer(nbytes);
+    DeviceBuffer dstBuffer(nbytes);
+    size_t llBufSize = ll_buffer_size(nbytes);
+    DeviceBuffer llBuffer(llBufSize);
+
+    auto* src_d = static_cast<char*>(srcBuffer.get());
+    auto* dst_d = static_cast<char*>(dstBuffer.get());
+    auto* ll_buf = static_cast<LlLine*>(llBuffer.get());
+
+    CUDACHECK_TEST(
+        cudaMemcpy(src_d, pattern.data(), nbytes, cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(cudaMemset(dst_d, 0, nbytes));
+
+    test::test_ll_send_recv(
+        src_d, dst_d, nbytes, ll_buf, num_blocks, block_size);
+
+    std::vector<char> result(nbytes);
+    CUDACHECK_TEST(
+        cudaMemcpy(result.data(), dst_d, nbytes, cudaMemcpyDeviceToHost));
+
+    for (size_t i = 0; i < nbytes; ++i) {
+      ASSERT_EQ(result[i], pattern[i])
+          << "Mismatch at byte " << i << " for nbytes=" << nbytes;
+    }
+  }
+
+  /// Pack user data into LL line format on the host.
+  std::vector<char> pack_ll_host(
+      const std::vector<char>& payload,
+      uint32_t flag_value) {
+    size_t nbytes = payload.size();
+    size_t num_lines = ll_num_lines(nbytes);
+    size_t buf_size = num_lines * kLlLineSize;
+    std::vector<char> buf(buf_size, 0);
+
+    for (size_t l = 0; l < num_lines; ++l) {
+      size_t payload_offset = l * kLlPayloadPerLine;
+      auto* line = reinterpret_cast<LlLine*>(buf.data() + l * kLlLineSize);
+
+      const auto* src_u32 =
+          reinterpret_cast<const uint32_t*>(payload.data() + payload_offset);
+      line->data1 = src_u32[0];
+      line->flag1 = flag_value;
+      line->data2 = src_u32[1];
+      line->flag2 = flag_value;
+    }
+    return buf;
+  }
+
+  void run_send_recv_chunked_test(
+      size_t nbytes,
+      size_t buffer_num_lines,
+      int num_blocks = 1,
+      int block_size = 32) {
+    auto pattern = make_pattern(nbytes);
+
+    DeviceBuffer srcBuffer(nbytes);
+    DeviceBuffer dstBuffer(nbytes);
+    size_t llBufSize = buffer_num_lines * kLlLineSize;
+    DeviceBuffer llBuffer(llBufSize);
+
+    auto* src_d = static_cast<char*>(srcBuffer.get());
+    auto* dst_d = static_cast<char*>(dstBuffer.get());
+    auto* ll_buf = static_cast<LlLine*>(llBuffer.get());
+
+    CUDACHECK_TEST(
+        cudaMemcpy(src_d, pattern.data(), nbytes, cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(cudaMemset(dst_d, 0, nbytes));
+
+    test::test_ll_send_recv_chunked(
+        src_d, dst_d, nbytes, ll_buf, buffer_num_lines, num_blocks, block_size);
+
+    std::vector<char> result(nbytes);
+    CUDACHECK_TEST(
+        cudaMemcpy(result.data(), dst_d, nbytes, cudaMemcpyDeviceToHost));
+
+    for (size_t i = 0; i < nbytes; ++i) {
+      ASSERT_EQ(result[i], pattern[i])
+          << "Chunked: mismatch at byte " << i << " for nbytes=" << nbytes
+          << " buffer_num_lines=" << buffer_num_lines;
+    }
+  }
+
+  void run_multi_step_send_recv_test(
+      size_t nbytes,
+      int num_steps,
+      int num_blocks = 1,
+      int block_size = 32) {
+    auto pattern = make_pattern(nbytes);
+
+    DeviceBuffer srcBuffer(nbytes);
+    DeviceBuffer dstBuffer(nbytes);
+    size_t llBufSize = ll_buffer_size(nbytes);
+    DeviceBuffer llBuffer(llBufSize);
+
+    auto* src_d = static_cast<char*>(srcBuffer.get());
+    auto* dst_d = static_cast<char*>(dstBuffer.get());
+    auto* ll_buf = static_cast<LlLine*>(llBuffer.get());
+
+    CUDACHECK_TEST(
+        cudaMemcpy(src_d, pattern.data(), nbytes, cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(cudaMemset(dst_d, 0, nbytes));
+
+    test::test_ll_multi_step_send_recv(
+        src_d, dst_d, nbytes, ll_buf, num_steps, num_blocks, block_size);
+
+    std::vector<char> result(nbytes);
+    CUDACHECK_TEST(
+        cudaMemcpy(result.data(), dst_d, nbytes, cudaMemcpyDeviceToHost));
+
+    for (size_t i = 0; i < nbytes; ++i) {
+      ASSERT_EQ(result[i], pattern[i]) << "MultiStep: mismatch at byte " << i;
+    }
+  }
+
+  void run_multi_step_chunked_test(
+      size_t nbytes,
+      size_t buffer_num_lines,
+      int num_steps,
+      int num_blocks = 1,
+      int block_size = 32) {
+    auto pattern = make_pattern(nbytes);
+
+    DeviceBuffer srcBuffer(nbytes);
+    DeviceBuffer dstBuffer(nbytes);
+    size_t llBufSize = buffer_num_lines * kLlLineSize;
+    DeviceBuffer llBuffer(llBufSize);
+
+    auto* src_d = static_cast<char*>(srcBuffer.get());
+    auto* dst_d = static_cast<char*>(dstBuffer.get());
+    auto* ll_buf = static_cast<LlLine*>(llBuffer.get());
+
+    CUDACHECK_TEST(
+        cudaMemcpy(src_d, pattern.data(), nbytes, cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(cudaMemset(dst_d, 0, nbytes));
+
+    test::test_ll_multi_step_send_recv_chunked(
+        src_d,
+        dst_d,
+        nbytes,
+        ll_buf,
+        buffer_num_lines,
+        num_steps,
+        num_blocks,
+        block_size);
+
+    std::vector<char> result(nbytes);
+    CUDACHECK_TEST(
+        cudaMemcpy(result.data(), dst_d, nbytes, cudaMemcpyDeviceToHost));
+
+    for (size_t i = 0; i < nbytes; ++i) {
+      ASSERT_EQ(result[i], pattern[i])
+          << "Chunked MultiStep: mismatch at byte " << i;
+    }
+  }
+
+  void run_varying_data_multi_step_test(
+      size_t nbytes,
+      size_t buffer_num_lines,
+      int num_steps,
+      int num_blocks = 1,
+      int block_size = 32) {
+    const size_t total_bytes = num_steps * nbytes;
+
+    size_t llBufSize = (buffer_num_lines == 0) ? ll_buffer_size(nbytes)
+                                               : buffer_num_lines * kLlLineSize;
+
+    DeviceBuffer srcBuffer(total_bytes);
+    DeviceBuffer dstBuffer(total_bytes);
+    DeviceBuffer llBuffer(llBufSize);
+
+    auto* src_d = static_cast<char*>(srcBuffer.get());
+    auto* dst_d = static_cast<char*>(dstBuffer.get());
+    auto* ll_buf = static_cast<LlLine*>(llBuffer.get());
+
+    std::vector<char> src_host(total_bytes);
+    for (int step = 0; step < num_steps; ++step) {
+      auto pattern = make_pattern(nbytes, /*seed=*/step * 37);
+      memcpy(src_host.data() + step * nbytes, pattern.data(), nbytes);
+    }
+    CUDACHECK_TEST(cudaMemcpy(
+        src_d, src_host.data(), total_bytes, cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(cudaMemset(dst_d, 0, total_bytes));
+
+    test::test_ll_varying_data_multi_step_send_recv(
+        src_d,
+        dst_d,
+        nbytes,
+        ll_buf,
+        buffer_num_lines,
+        num_steps,
+        num_blocks,
+        block_size);
+
+    std::vector<char> result(total_bytes);
+    CUDACHECK_TEST(
+        cudaMemcpy(result.data(), dst_d, total_bytes, cudaMemcpyDeviceToHost));
+    for (int step = 0; step < num_steps; ++step) {
+      auto pattern = make_pattern(nbytes, /*seed=*/step * 37);
+      for (size_t i = 0; i < nbytes; ++i) {
+        ASSERT_EQ(result[step * nbytes + i], pattern[i])
+            << "VaryingData step " << step << ": mismatch at byte " << i;
+      }
+    }
+  }
+};
+
+// =============================================================================
+// Group A: SendRecv — various sizes (LL uses 8-byte alignment)
+// =============================================================================
+
+class LlOpsSendRecvTest : public LlOpsTestFixture,
+                          public ::testing::WithParamInterface<LlOpsTestParam> {
+};
+
+TEST_P(LlOpsSendRecvTest, SendRecv) {
+  const auto& p = GetParam();
+  run_send_recv_test(p.nbytes, p.num_blocks, p.block_size);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    LlOps,
+    LlOpsSendRecvTest,
+    ::testing::Values(
+        LlOpsTestParam{.name = "8Bytes", .nbytes = 8},
+        LlOpsTestParam{.name = "16Bytes", .nbytes = 16},
+        LlOpsTestParam{.name = "64Bytes", .nbytes = 64},
+        LlOpsTestParam{.name = "256Bytes", .nbytes = 256},
+        LlOpsTestParam{.name = "1KB", .nbytes = 1024},
+        LlOpsTestParam{.name = "4KB", .nbytes = 4096},
+        LlOpsTestParam{.name = "64KB", .nbytes = 65536}),
+    ll_test_name);
+
+// =============================================================================
+// Group C: Chunked SendRecv (TODO: Add 'Forward' test as Group B)
+// =============================================================================
+
+class LlOpsChunkedSendRecvTest
+    : public LlOpsTestFixture,
+      public ::testing::WithParamInterface<LlOpsTestParam> {};
+
+TEST_P(LlOpsChunkedSendRecvTest, ChunkedSendRecv) {
+  const auto& p = GetParam();
+  run_send_recv_chunked_test(
+      p.nbytes, p.buffer_num_lines, p.num_blocks, p.block_size);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    LlOps,
+    LlOpsChunkedSendRecvTest,
+    ::testing::Values(
+        // ll_num_lines(4096) = 4096/8 = 512 lines
+        LlOpsTestParam{
+            .name = "4KB_32Lines",
+            .nbytes = 4096,
+            .buffer_num_lines = 32},
+        LlOpsTestParam{
+            .name = "4KB_64Lines",
+            .nbytes = 4096,
+            .buffer_num_lines = 64},
+        LlOpsTestParam{
+            .name = "64KB_64Lines",
+            .nbytes = 65536,
+            .buffer_num_lines = 64},
+        // Exact fit: 4096/8 = 512 lines
+        LlOpsTestParam{
+            .name = "ExactFit",
+            .nbytes = 4096,
+            .buffer_num_lines = 512},
+        LlOpsTestParam{
+            .name = "ChunkedSmallBuffer",
+            .nbytes = 65536,
+            .buffer_num_lines = 32}),
+    ll_test_name);
+
+// =============================================================================
+// Group D: MultiStep SendRecv
+// =============================================================================
+
+class LlOpsMultiStepSendRecvTest
+    : public LlOpsTestFixture,
+      public ::testing::WithParamInterface<LlOpsTestParam> {};
+
+TEST_P(LlOpsMultiStepSendRecvTest, MultiStepSendRecv) {
+  const auto& p = GetParam();
+  run_multi_step_send_recv_test(
+      p.nbytes, p.num_steps, p.num_blocks, p.block_size);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    LlOps,
+    LlOpsMultiStepSendRecvTest,
+    ::testing::Values(
+        LlOpsTestParam{.name = "InKernel", .nbytes = 4096, .num_steps = 10},
+        LlOpsTestParam{.name = "ABA", .nbytes = 4096, .num_steps = 100}),
+    ll_test_name);
+
+// =============================================================================
+// Group E: MultiStep Chunked SendRecv
+// =============================================================================
+
+class LlOpsMultiStepChunkedSendRecvTest
+    : public LlOpsTestFixture,
+      public ::testing::WithParamInterface<LlOpsTestParam> {};
+
+TEST_P(LlOpsMultiStepChunkedSendRecvTest, MultiStepChunkedSendRecv) {
+  const auto& p = GetParam();
+  run_multi_step_chunked_test(
+      p.nbytes, p.buffer_num_lines, p.num_steps, p.num_blocks, p.block_size);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    LlOps,
+    LlOpsMultiStepChunkedSendRecvTest,
+    ::testing::Values(
+        LlOpsTestParam{
+            .name = "4KB_64lines_10steps",
+            .nbytes = 4096,
+            .buffer_num_lines = 64,
+            .num_steps = 10},
+        LlOpsTestParam{
+            .name = "ABA_32lines_100steps",
+            .nbytes = 4096,
+            .block_size = 32,
+            .buffer_num_lines = 32,
+            .num_steps = 100}),
+    ll_test_name);
+
+// =============================================================================
+// Group G: VaryingData MultiStep SendRecv
+// =============================================================================
+
+class LlOpsVaryingDataSendRecvTest
+    : public LlOpsTestFixture,
+      public ::testing::WithParamInterface<LlOpsTestParam> {};
+
+TEST_P(LlOpsVaryingDataSendRecvTest, VaryingDataSendRecv) {
+  const auto& p = GetParam();
+  run_varying_data_multi_step_test(
+      p.nbytes, p.buffer_num_lines, p.num_steps, p.num_blocks, p.block_size);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    LlOps,
+    LlOpsVaryingDataSendRecvTest,
+    ::testing::Values(
+        LlOpsTestParam{.name = "NonChunked", .nbytes = 4096, .num_steps = 10},
+        LlOpsTestParam{
+            .name = "Chunked",
+            .nbytes = 4096,
+            .buffer_num_lines = 64,
+            .num_steps = 10}),
+    ll_test_name);
+
+// =============================================================================
+// Standalone tests
+// =============================================================================
+
+TEST_F(LlOpsTestFixture, SendRecv_ZeroBytes) {
+  DeviceBuffer llBuffer(kLlLineSize);
+  auto* ll_buf = static_cast<LlLine*>(llBuffer.get());
+  CUDACHECK_TEST(cudaMemset(ll_buf, kLlMemsetInitByte, kLlLineSize));
+  test::test_ll_send_recv(nullptr, nullptr, 0, ll_buf, 1, 32);
+}
+
+TEST_F(LlOpsTestFixture, SendRecv_Stress) {
+  constexpr int kStressIterations = 50;
+  const size_t nbytes = 4096;
+
+  DeviceBuffer srcBuffer(nbytes);
+  DeviceBuffer dstBuffer(nbytes);
+  size_t llBufSize = ll_buffer_size(nbytes);
+  DeviceBuffer llBuffer(llBufSize);
+
+  auto* src_d = static_cast<char*>(srcBuffer.get());
+  auto* dst_d = static_cast<char*>(dstBuffer.get());
+  auto* ll_buf = static_cast<LlLine*>(llBuffer.get());
+
+  for (int iter = 0; iter < kStressIterations; ++iter) {
+    auto pattern = make_pattern(nbytes, /*seed=*/iter);
+
+    CUDACHECK_TEST(
+        cudaMemcpy(src_d, pattern.data(), nbytes, cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(cudaMemset(dst_d, 0, nbytes));
+
+    test::test_ll_send_recv(src_d, dst_d, nbytes, ll_buf, 1, 32);
+
+    std::vector<char> result(nbytes);
+    CUDACHECK_TEST(
+        cudaMemcpy(result.data(), dst_d, nbytes, cudaMemcpyDeviceToHost));
+
+    for (size_t i = 0; i < nbytes; ++i) {
+      ASSERT_EQ(result[i], pattern[i])
+          << "Stress iter " << iter << ": mismatch at byte " << i;
+    }
+  }
+}
+
+} // namespace comms::pipes

--- a/comms/pipes/ll/tests/LlOpsTest.cc
+++ b/comms/pipes/ll/tests/LlOpsTest.cc
@@ -85,6 +85,47 @@ class LlOpsTestFixture : public ::testing::Test {
     }
   }
 
+  void
+  run_forward_test(size_t nbytes, int num_blocks = 1, int block_size = 32) {
+    auto pattern = make_pattern(nbytes);
+    size_t llBufSize = ll_buffer_size(nbytes);
+
+    DeviceBuffer dstBuffer(nbytes);
+    DeviceBuffer localLlBuffer(llBufSize);
+    DeviceBuffer remoteLlBuffer(llBufSize);
+
+    auto* dst_d = static_cast<char*>(dstBuffer.get());
+    auto* local_ll = static_cast<LlLine*>(localLlBuffer.get());
+    auto* remote_ll = static_cast<LlLine*>(remoteLlBuffer.get());
+
+    auto packed = pack_ll_host(pattern, /*flag_value=*/1);
+    CUDACHECK_TEST(
+        cudaMemcpy(local_ll, packed.data(), llBufSize, cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(cudaMemset(dst_d, 0, nbytes));
+
+    test::test_ll_forward(
+        dst_d, nbytes, local_ll, remote_ll, num_blocks, block_size);
+
+    std::vector<char> result(nbytes);
+    CUDACHECK_TEST(
+        cudaMemcpy(result.data(), dst_d, nbytes, cudaMemcpyDeviceToHost));
+    for (size_t i = 0; i < nbytes; ++i) {
+      ASSERT_EQ(result[i], pattern[i]) << "Forward: dst mismatch at byte " << i;
+    }
+
+    // Verify remote LL buffer flags are flag_value=1
+    std::vector<char> remote_host(llBufSize);
+    CUDACHECK_TEST(cudaMemcpy(
+        remote_host.data(), remote_ll, llBufSize, cudaMemcpyDeviceToHost));
+    size_t num_lines = ll_num_lines(nbytes);
+    for (size_t l = 0; l < num_lines; ++l) {
+      auto* line =
+          reinterpret_cast<LlLine*>(remote_host.data() + l * kLlLineSize);
+      EXPECT_EQ(line->flag1, 1u) << "Remote line " << l << " flag1 should be 1";
+      EXPECT_EQ(line->flag2, 1u) << "Remote line " << l << " flag2 should be 1";
+    }
+  }
+
   /// Pack user data into LL line format on the host.
   std::vector<char> pack_ll_host(
       const std::vector<char>& payload,
@@ -215,6 +256,59 @@ class LlOpsTestFixture : public ::testing::Test {
     }
   }
 
+  void run_multi_step_forward_test(
+      size_t nbytes,
+      int num_steps,
+      int num_blocks = 1,
+      int block_size = 32) {
+    auto pattern = make_pattern(nbytes);
+
+    size_t llBufSize = ll_buffer_size(nbytes);
+    DeviceBuffer srcBuffer(nbytes);
+    DeviceBuffer fwdDstBuffer(nbytes);
+    DeviceBuffer recvDstBuffer(nbytes);
+    DeviceBuffer llBufA(llBufSize);
+    DeviceBuffer llBufB(llBufSize);
+
+    auto* src_d = static_cast<char*>(srcBuffer.get());
+    auto* fwd_dst_d = static_cast<char*>(fwdDstBuffer.get());
+    auto* recv_dst_d = static_cast<char*>(recvDstBuffer.get());
+    auto* ll_buf_a = static_cast<LlLine*>(llBufA.get());
+    auto* ll_buf_b = static_cast<LlLine*>(llBufB.get());
+
+    CUDACHECK_TEST(
+        cudaMemcpy(src_d, pattern.data(), nbytes, cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(cudaMemset(fwd_dst_d, 0, nbytes));
+    CUDACHECK_TEST(cudaMemset(recv_dst_d, 0, nbytes));
+
+    test::test_ll_multi_step_forward(
+        src_d,
+        fwd_dst_d,
+        recv_dst_d,
+        nbytes,
+        ll_buf_a,
+        ll_buf_b,
+        num_steps,
+        num_blocks,
+        block_size);
+
+    std::vector<char> fwd_result(nbytes);
+    CUDACHECK_TEST(cudaMemcpy(
+        fwd_result.data(), fwd_dst_d, nbytes, cudaMemcpyDeviceToHost));
+    for (size_t i = 0; i < nbytes; ++i) {
+      ASSERT_EQ(fwd_result[i], pattern[i])
+          << "Forward MultiStep: fwd_dst mismatch at byte " << i;
+    }
+
+    std::vector<char> recv_result(nbytes);
+    CUDACHECK_TEST(cudaMemcpy(
+        recv_result.data(), recv_dst_d, nbytes, cudaMemcpyDeviceToHost));
+    for (size_t i = 0; i < nbytes; ++i) {
+      ASSERT_EQ(recv_result[i], pattern[i])
+          << "Forward MultiStep: recv_dst mismatch at byte " << i;
+    }
+  }
+
   void run_varying_data_multi_step_test(
       size_t nbytes,
       size_t buffer_num_lines,
@@ -264,6 +358,71 @@ class LlOpsTestFixture : public ::testing::Test {
       }
     }
   }
+
+  void run_varying_data_multi_step_forward_test(
+      size_t nbytes,
+      size_t buffer_num_lines,
+      int num_steps,
+      int num_blocks = 1,
+      int block_size = 32) {
+    const size_t total_bytes = num_steps * nbytes;
+
+    size_t llBufSize = (buffer_num_lines == 0) ? ll_buffer_size(nbytes)
+                                               : buffer_num_lines * kLlLineSize;
+
+    DeviceBuffer srcBuffer(total_bytes);
+    DeviceBuffer fwdDstBuffer(total_bytes);
+    DeviceBuffer recvDstBuffer(total_bytes);
+    DeviceBuffer llBufA(llBufSize);
+    DeviceBuffer llBufB(llBufSize);
+
+    auto* src_d = static_cast<char*>(srcBuffer.get());
+    auto* fwd_dst_d = static_cast<char*>(fwdDstBuffer.get());
+    auto* recv_dst_d = static_cast<char*>(recvDstBuffer.get());
+    auto* ll_buf_a = static_cast<LlLine*>(llBufA.get());
+    auto* ll_buf_b = static_cast<LlLine*>(llBufB.get());
+
+    std::vector<char> src_host(total_bytes);
+    for (int step = 0; step < num_steps; ++step) {
+      auto pattern = make_pattern(nbytes, /*seed=*/step * 37);
+      memcpy(src_host.data() + step * nbytes, pattern.data(), nbytes);
+    }
+    CUDACHECK_TEST(cudaMemcpy(
+        src_d, src_host.data(), total_bytes, cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(cudaMemset(fwd_dst_d, 0, total_bytes));
+    CUDACHECK_TEST(cudaMemset(recv_dst_d, 0, total_bytes));
+
+    test::test_ll_varying_data_multi_step_forward(
+        src_d,
+        fwd_dst_d,
+        recv_dst_d,
+        nbytes,
+        ll_buf_a,
+        ll_buf_b,
+        buffer_num_lines,
+        num_steps,
+        num_blocks,
+        block_size);
+
+    std::vector<char> fwd_result(total_bytes);
+    CUDACHECK_TEST(cudaMemcpy(
+        fwd_result.data(), fwd_dst_d, total_bytes, cudaMemcpyDeviceToHost));
+    std::vector<char> recv_result(total_bytes);
+    CUDACHECK_TEST(cudaMemcpy(
+        recv_result.data(), recv_dst_d, total_bytes, cudaMemcpyDeviceToHost));
+
+    for (int step = 0; step < num_steps; ++step) {
+      auto pattern = make_pattern(nbytes, /*seed=*/step * 37);
+      for (size_t i = 0; i < nbytes; ++i) {
+        ASSERT_EQ(fwd_result[step * nbytes + i], pattern[i])
+            << "Forward VaryingData step " << step
+            << ": fwd_dst mismatch at byte " << i;
+        ASSERT_EQ(recv_result[step * nbytes + i], pattern[i])
+            << "Forward VaryingData step " << step
+            << ": recv_dst mismatch at byte " << i;
+      }
+    }
+  }
 };
 
 // =============================================================================
@@ -293,7 +452,29 @@ INSTANTIATE_TEST_SUITE_P(
     ll_test_name);
 
 // =============================================================================
-// Group C: Chunked SendRecv (TODO: Add 'Forward' test as Group B)
+// Group C: Forward
+// =============================================================================
+
+class LlOpsForwardTest : public LlOpsTestFixture,
+                         public ::testing::WithParamInterface<LlOpsTestParam> {
+};
+
+TEST_P(LlOpsForwardTest, Forward) {
+  const auto& p = GetParam();
+  run_forward_test(p.nbytes, p.num_blocks, p.block_size);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    LlOps,
+    LlOpsForwardTest,
+    ::testing::Values(
+        LlOpsTestParam{.name = "64Bytes", .nbytes = 64},
+        LlOpsTestParam{.name = "4KB", .nbytes = 4096},
+        LlOpsTestParam{.name = "64KB", .nbytes = 65536}),
+    ll_test_name);
+
+// =============================================================================
+// Group C: Chunked SendRecv
 // =============================================================================
 
 class LlOpsChunkedSendRecvTest
@@ -388,6 +569,27 @@ INSTANTIATE_TEST_SUITE_P(
     ll_test_name);
 
 // =============================================================================
+// Group F: MultiStep Forward
+// =============================================================================
+
+class LlOpsMultiStepForwardTest
+    : public LlOpsTestFixture,
+      public ::testing::WithParamInterface<LlOpsTestParam> {};
+
+TEST_P(LlOpsMultiStepForwardTest, MultiStepForward) {
+  const auto& p = GetParam();
+  run_multi_step_forward_test(
+      p.nbytes, p.num_steps, p.num_blocks, p.block_size);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    LlOps,
+    LlOpsMultiStepForwardTest,
+    ::testing::Values(
+        LlOpsTestParam{.name = "4KB_10steps", .nbytes = 4096, .num_steps = 10}),
+    ll_test_name);
+
+// =============================================================================
 // Group G: VaryingData MultiStep SendRecv
 // =============================================================================
 
@@ -404,6 +606,32 @@ TEST_P(LlOpsVaryingDataSendRecvTest, VaryingDataSendRecv) {
 INSTANTIATE_TEST_SUITE_P(
     LlOps,
     LlOpsVaryingDataSendRecvTest,
+    ::testing::Values(
+        LlOpsTestParam{.name = "NonChunked", .nbytes = 4096, .num_steps = 10},
+        LlOpsTestParam{
+            .name = "Chunked",
+            .nbytes = 4096,
+            .buffer_num_lines = 64,
+            .num_steps = 10}),
+    ll_test_name);
+
+// =============================================================================
+// Group H: VaryingData MultiStep Forward
+// =============================================================================
+
+class LlOpsVaryingDataForwardTest
+    : public LlOpsTestFixture,
+      public ::testing::WithParamInterface<LlOpsTestParam> {};
+
+TEST_P(LlOpsVaryingDataForwardTest, VaryingDataForward) {
+  const auto& p = GetParam();
+  run_varying_data_multi_step_forward_test(
+      p.nbytes, p.buffer_num_lines, p.num_steps, p.num_blocks, p.block_size);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    LlOps,
+    LlOpsVaryingDataForwardTest,
     ::testing::Values(
         LlOpsTestParam{.name = "NonChunked", .nbytes = 4096, .num_steps = 10},
         LlOpsTestParam{

--- a/comms/pipes/ll/tests/LlOpsTest.cu
+++ b/comms/pipes/ll/tests/LlOpsTest.cu
@@ -1,0 +1,209 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <cstddef>
+#include <cstdint>
+
+#include "comms/pipes/ThreadGroup.cuh"
+#include "comms/pipes/Timeout.cuh"
+#include "comms/pipes/TimeoutUtils.h"
+#include "comms/pipes/ll/LlOps.cuh"
+#include "comms/pipes/ll/LlPacket.cuh"
+#include "comms/pipes/tests/Checks.h"
+
+namespace comms::pipes::test {
+
+using namespace comms::pipes;
+
+// =============================================================================
+// Combined send/recv kernel via partition_interleaved(2)
+// =============================================================================
+
+__global__ void ll_multi_step_combined_kernel(
+    const char* src,
+    char* dst,
+    size_t nbytes,
+    LlLine* ll_buf,
+    int num_steps) {
+  auto group = make_warp_group();
+  auto [partition_id, subgroup] = group.partition_interleaved(2);
+
+  Timeout timeout;
+  timeout.start();
+
+  if (partition_id == 0) {
+    for (int i = 0; i < num_steps; i++) {
+      ll_send(subgroup, src, nbytes, ll_buf, timeout);
+    }
+  } else {
+    for (int i = 0; i < num_steps; i++) {
+      ll_recv(subgroup, dst, nbytes, ll_buf, timeout);
+    }
+  }
+}
+
+// =============================================================================
+// Chunked combined kernel with buffer_num_lines
+// =============================================================================
+
+__global__ void ll_chunked_combined_kernel(
+    const char* src,
+    char* dst,
+    size_t nbytes,
+    LlLine* ll_buf,
+    size_t buffer_num_lines,
+    int num_steps,
+    Timeout timeout) {
+  auto group = make_warp_group();
+  auto [partition_id, subgroup] = group.partition_interleaved(2);
+
+  timeout.start();
+
+  if (partition_id == 0) {
+    for (int i = 0; i < num_steps; i++) {
+      ll_send(subgroup, src, nbytes, ll_buf, timeout, buffer_num_lines);
+    }
+  } else {
+    for (int i = 0; i < num_steps; i++) {
+      ll_recv(subgroup, dst, nbytes, ll_buf, timeout, buffer_num_lines);
+    }
+  }
+}
+
+// =============================================================================
+// Varying-data multi-step combined kernel
+// =============================================================================
+
+__global__ void ll_varying_data_multi_step_combined_kernel(
+    const char* src,
+    char* dst,
+    size_t nbytes,
+    LlLine* ll_buf,
+    size_t buffer_num_lines,
+    int num_steps) {
+  auto group = make_warp_group();
+  auto [partition_id, subgroup] = group.partition_interleaved(2);
+
+  Timeout timeout;
+  timeout.start();
+
+  if (partition_id == 0) {
+    for (int i = 0; i < num_steps; i++) {
+      ll_send(
+          subgroup,
+          src + i * nbytes,
+          nbytes,
+          ll_buf,
+          timeout,
+          buffer_num_lines);
+    }
+  } else {
+    for (int i = 0; i < num_steps; i++) {
+      ll_recv(
+          subgroup,
+          dst + i * nbytes,
+          nbytes,
+          ll_buf,
+          timeout,
+          buffer_num_lines);
+    }
+  }
+}
+
+// =============================================================================
+// Host-callable wrappers
+// =============================================================================
+
+void test_ll_multi_step_send_recv(
+    const char* src_d,
+    char* dst_d,
+    size_t nbytes,
+    LlLine* ll_buf,
+    int num_steps,
+    int num_blocks,
+    int block_size) {
+  size_t buf_size = ll_buffer_size(nbytes);
+  PIPES_CUDA_CHECK(cudaMemset(ll_buf, kLlMemsetInitByte, buf_size));
+  PIPES_CUDA_CHECK(cudaDeviceSynchronize());
+
+  int total_blocks = 2 * num_blocks;
+  ll_multi_step_combined_kernel<<<total_blocks, block_size>>>(
+      src_d, dst_d, nbytes, ll_buf, num_steps);
+  PIPES_KERNEL_LAUNCH_CHECK();
+  PIPES_CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+void test_ll_send_recv(
+    const char* src_d,
+    char* dst_d,
+    size_t nbytes,
+    LlLine* ll_buf,
+    int num_blocks,
+    int block_size) {
+  test_ll_multi_step_send_recv(
+      src_d, dst_d, nbytes, ll_buf, /*num_steps=*/1, num_blocks, block_size);
+}
+
+void test_ll_multi_step_send_recv_chunked(
+    const char* src_d,
+    char* dst_d,
+    size_t nbytes,
+    LlLine* ll_buf,
+    size_t buffer_num_lines,
+    int num_steps,
+    int num_blocks,
+    int block_size) {
+  size_t buf_size = buffer_num_lines * kLlLineSize;
+  PIPES_CUDA_CHECK(cudaMemset(ll_buf, kLlMemsetInitByte, buf_size));
+  PIPES_CUDA_CHECK(cudaDeviceSynchronize());
+
+  auto timeout = makeTimeout(20000);
+
+  int total_blocks = 2 * num_blocks;
+  ll_chunked_combined_kernel<<<total_blocks, block_size>>>(
+      src_d, dst_d, nbytes, ll_buf, buffer_num_lines, num_steps, timeout);
+  PIPES_KERNEL_LAUNCH_CHECK();
+  PIPES_CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+void test_ll_send_recv_chunked(
+    const char* src_d,
+    char* dst_d,
+    size_t nbytes,
+    LlLine* ll_buf,
+    size_t buffer_num_lines,
+    int num_blocks,
+    int block_size) {
+  test_ll_multi_step_send_recv_chunked(
+      src_d,
+      dst_d,
+      nbytes,
+      ll_buf,
+      buffer_num_lines,
+      /*num_steps=*/1,
+      num_blocks,
+      block_size);
+}
+
+void test_ll_varying_data_multi_step_send_recv(
+    const char* src_d,
+    char* dst_d,
+    size_t nbytes,
+    LlLine* ll_buf,
+    size_t buffer_num_lines,
+    int num_steps,
+    int num_blocks,
+    int block_size) {
+  size_t buf_size = (buffer_num_lines > 0) ? buffer_num_lines * kLlLineSize
+                                           : ll_buffer_size(nbytes);
+  PIPES_CUDA_CHECK(cudaMemset(ll_buf, kLlMemsetInitByte, buf_size));
+  PIPES_CUDA_CHECK(cudaDeviceSynchronize());
+
+  int total_blocks = 2 * num_blocks;
+  ll_varying_data_multi_step_combined_kernel<<<total_blocks, block_size>>>(
+      src_d, dst_d, nbytes, ll_buf, buffer_num_lines, num_steps);
+  PIPES_KERNEL_LAUNCH_CHECK();
+  PIPES_CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+} // namespace comms::pipes::test

--- a/comms/pipes/ll/tests/LlOpsTest.cu
+++ b/comms/pipes/ll/tests/LlOpsTest.cu
@@ -16,6 +16,21 @@ namespace comms::pipes::test {
 using namespace comms::pipes;
 
 // =============================================================================
+// Forward kernel
+// =============================================================================
+
+__global__ void ll_forward_kernel(
+    char* dst,
+    size_t nbytes,
+    LlLine* local_ll_buf,
+    LlLine* remote_ll_buf) {
+  auto group = make_warp_group();
+  Timeout timeout;
+  timeout.start();
+  ll_forward(group, dst, nbytes, local_ll_buf, remote_ll_buf, timeout);
+}
+
+// =============================================================================
 // Combined send/recv kernel via partition_interleaved(2)
 // =============================================================================
 
@@ -38,6 +53,38 @@ __global__ void ll_multi_step_combined_kernel(
   } else {
     for (int i = 0; i < num_steps; i++) {
       ll_recv(subgroup, dst, nbytes, ll_buf, timeout);
+    }
+  }
+}
+
+// =============================================================================
+// 3-role kernel: send → forward → recv
+// =============================================================================
+
+__global__ void ll_multi_step_send_forward_recv_kernel(
+    const char* src,
+    char* fwd_dst,
+    char* recv_dst,
+    size_t nbytes,
+    LlLine* ll_buf_a,
+    LlLine* ll_buf_b,
+    int num_steps) {
+  auto group = make_warp_group();
+  auto [partition_id, subgroup] = group.partition_interleaved(3);
+  Timeout timeout;
+  timeout.start();
+
+  if (partition_id == 0) {
+    for (int i = 0; i < num_steps; i++) {
+      ll_send(subgroup, src, nbytes, ll_buf_a, timeout);
+    }
+  } else if (partition_id == 1) {
+    for (int i = 0; i < num_steps; i++) {
+      ll_forward(subgroup, fwd_dst, nbytes, ll_buf_a, ll_buf_b, timeout);
+    }
+  } else {
+    for (int i = 0; i < num_steps; i++) {
+      ll_recv(subgroup, recv_dst, nbytes, ll_buf_b, timeout);
     }
   }
 }
@@ -111,6 +158,58 @@ __global__ void ll_varying_data_multi_step_combined_kernel(
 }
 
 // =============================================================================
+// Varying-data multi-step 3-role kernel
+// =============================================================================
+
+__global__ void ll_varying_data_multi_step_send_forward_recv_kernel(
+    const char* src,
+    char* fwd_dst,
+    char* recv_dst,
+    size_t nbytes,
+    LlLine* ll_buf_a,
+    LlLine* ll_buf_b,
+    size_t buffer_num_lines,
+    int num_steps) {
+  auto group = make_warp_group();
+  auto [partition_id, subgroup] = group.partition_interleaved(3);
+  Timeout timeout;
+  timeout.start();
+
+  if (partition_id == 0) {
+    for (int i = 0; i < num_steps; i++) {
+      ll_send(
+          subgroup,
+          src + i * nbytes,
+          nbytes,
+          ll_buf_a,
+          timeout,
+          buffer_num_lines);
+    }
+  } else if (partition_id == 1) {
+    for (int i = 0; i < num_steps; i++) {
+      ll_forward(
+          subgroup,
+          fwd_dst + i * nbytes,
+          nbytes,
+          ll_buf_a,
+          ll_buf_b,
+          timeout,
+          buffer_num_lines);
+    }
+  } else {
+    for (int i = 0; i < num_steps; i++) {
+      ll_recv(
+          subgroup,
+          recv_dst + i * nbytes,
+          nbytes,
+          ll_buf_b,
+          timeout,
+          buffer_num_lines);
+    }
+  }
+}
+
+// =============================================================================
 // Host-callable wrappers
 // =============================================================================
 
@@ -142,6 +241,46 @@ void test_ll_send_recv(
     int block_size) {
   test_ll_multi_step_send_recv(
       src_d, dst_d, nbytes, ll_buf, /*num_steps=*/1, num_blocks, block_size);
+}
+
+void test_ll_forward(
+    char* dst_d,
+    size_t nbytes,
+    LlLine* local_ll_buf,
+    LlLine* remote_ll_buf,
+    int num_blocks,
+    int block_size) {
+  size_t remote_buf_size = ll_buffer_size(nbytes);
+  PIPES_CUDA_CHECK(
+      cudaMemset(remote_ll_buf, kLlMemsetInitByte, remote_buf_size));
+  PIPES_CUDA_CHECK(cudaDeviceSynchronize());
+
+  ll_forward_kernel<<<num_blocks, block_size>>>(
+      dst_d, nbytes, local_ll_buf, remote_ll_buf);
+  PIPES_KERNEL_LAUNCH_CHECK();
+  PIPES_CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+void test_ll_multi_step_forward(
+    const char* src_d,
+    char* fwd_dst_d,
+    char* recv_dst_d,
+    size_t nbytes,
+    LlLine* ll_buf_a,
+    LlLine* ll_buf_b,
+    int num_steps,
+    int num_blocks,
+    int block_size) {
+  size_t buf_size = ll_buffer_size(nbytes);
+  PIPES_CUDA_CHECK(cudaMemset(ll_buf_a, kLlMemsetInitByte, buf_size));
+  PIPES_CUDA_CHECK(cudaMemset(ll_buf_b, kLlMemsetInitByte, buf_size));
+  PIPES_CUDA_CHECK(cudaDeviceSynchronize());
+
+  int total_blocks = 3 * num_blocks;
+  ll_multi_step_send_forward_recv_kernel<<<total_blocks, block_size>>>(
+      src_d, fwd_dst_d, recv_dst_d, nbytes, ll_buf_a, ll_buf_b, num_steps);
+  PIPES_KERNEL_LAUNCH_CHECK();
+  PIPES_CUDA_CHECK(cudaDeviceSynchronize());
 }
 
 void test_ll_multi_step_send_recv_chunked(
@@ -202,6 +341,39 @@ void test_ll_varying_data_multi_step_send_recv(
   int total_blocks = 2 * num_blocks;
   ll_varying_data_multi_step_combined_kernel<<<total_blocks, block_size>>>(
       src_d, dst_d, nbytes, ll_buf, buffer_num_lines, num_steps);
+  PIPES_KERNEL_LAUNCH_CHECK();
+  PIPES_CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+void test_ll_varying_data_multi_step_forward(
+    const char* src_d,
+    char* fwd_dst_d,
+    char* recv_dst_d,
+    size_t nbytes,
+    LlLine* ll_buf_a,
+    LlLine* ll_buf_b,
+    size_t buffer_num_lines,
+    int num_steps,
+    int num_blocks,
+    int block_size) {
+  size_t buf_size = (buffer_num_lines > 0) ? buffer_num_lines * kLlLineSize
+                                           : ll_buffer_size(nbytes);
+  PIPES_CUDA_CHECK(cudaMemset(ll_buf_a, kLlMemsetInitByte, buf_size));
+  PIPES_CUDA_CHECK(cudaMemset(ll_buf_b, kLlMemsetInitByte, buf_size));
+  PIPES_CUDA_CHECK(cudaDeviceSynchronize());
+
+  int total_blocks = 3 * num_blocks;
+  ll_varying_data_multi_step_send_forward_recv_kernel<<<
+      total_blocks,
+      block_size>>>(
+      src_d,
+      fwd_dst_d,
+      recv_dst_d,
+      nbytes,
+      ll_buf_a,
+      ll_buf_b,
+      buffer_num_lines,
+      num_steps);
   PIPES_KERNEL_LAUNCH_CHECK();
   PIPES_CUDA_CHECK(cudaDeviceSynchronize());
 }

--- a/comms/pipes/ll/tests/LlOpsTest.cuh
+++ b/comms/pipes/ll/tests/LlOpsTest.cuh
@@ -18,6 +18,27 @@ void test_ll_send_recv(
     int num_blocks,
     int block_size);
 
+/// Test LL forward: read from local LL buf, forward to remote, copy to dst.
+void test_ll_forward(
+    char* dst_d,
+    size_t nbytes,
+    comms::pipes::LlLine* local_ll_buf,
+    comms::pipes::LlLine* remote_ll_buf,
+    int num_blocks,
+    int block_size);
+
+/// Test LL multi-step send→forward→recv pipeline.
+void test_ll_multi_step_forward(
+    const char* src_d,
+    char* fwd_dst_d,
+    char* recv_dst_d,
+    size_t nbytes,
+    comms::pipes::LlLine* ll_buf_a,
+    comms::pipes::LlLine* ll_buf_b,
+    int num_steps,
+    int num_blocks,
+    int block_size);
+
 /// Test LL multi-step send/recv on the same buffer.
 void test_ll_multi_step_send_recv(
     const char* src_d,
@@ -55,6 +76,19 @@ void test_ll_varying_data_multi_step_send_recv(
     char* dst_d,
     size_t nbytes,
     comms::pipes::LlLine* ll_buf,
+    size_t buffer_num_lines,
+    int num_steps,
+    int num_blocks,
+    int block_size);
+
+/// Test LL varying-data multi-step send→forward→recv pipeline.
+void test_ll_varying_data_multi_step_forward(
+    const char* src_d,
+    char* fwd_dst_d,
+    char* recv_dst_d,
+    size_t nbytes,
+    comms::pipes::LlLine* ll_buf_a,
+    comms::pipes::LlLine* ll_buf_b,
     size_t buffer_num_lines,
     int num_steps,
     int num_blocks,

--- a/comms/pipes/ll/tests/LlOpsTest.cuh
+++ b/comms/pipes/ll/tests/LlOpsTest.cuh
@@ -1,0 +1,63 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "comms/pipes/ll/LlPacket.cuh"
+
+namespace comms::pipes::test {
+
+/// Test LL send/recv round-trip between two buffers on same GPU.
+void test_ll_send_recv(
+    const char* src_d,
+    char* dst_d,
+    size_t nbytes,
+    comms::pipes::LlLine* ll_buf,
+    int num_blocks,
+    int block_size);
+
+/// Test LL multi-step send/recv on the same buffer.
+void test_ll_multi_step_send_recv(
+    const char* src_d,
+    char* dst_d,
+    size_t nbytes,
+    comms::pipes::LlLine* ll_buf,
+    int num_steps,
+    int num_blocks,
+    int block_size);
+
+/// Test LL chunked send/recv: buffer is smaller than the message.
+void test_ll_send_recv_chunked(
+    const char* src_d,
+    char* dst_d,
+    size_t nbytes,
+    comms::pipes::LlLine* ll_buf,
+    size_t buffer_num_lines,
+    int num_blocks,
+    int block_size);
+
+/// Test LL chunked multi-step send/recv.
+void test_ll_multi_step_send_recv_chunked(
+    const char* src_d,
+    char* dst_d,
+    size_t nbytes,
+    comms::pipes::LlLine* ll_buf,
+    size_t buffer_num_lines,
+    int num_steps,
+    int num_blocks,
+    int block_size);
+
+/// Test LL varying-data multi-step send/recv.
+void test_ll_varying_data_multi_step_send_recv(
+    const char* src_d,
+    char* dst_d,
+    size_t nbytes,
+    comms::pipes::LlLine* ll_buf,
+    size_t buffer_num_lines,
+    int num_steps,
+    int num_blocks,
+    int block_size);
+
+} // namespace comms::pipes::test

--- a/comms/pipes/ll/tests/LlPacketTest.cc
+++ b/comms/pipes/ll/tests/LlPacketTest.cc
@@ -1,0 +1,188 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+#include <cstdint>
+
+#include "comms/pipes/ll/LlPacket.cuh"
+#include "comms/pipes/ll/tests/LlPacketTest.cuh"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/CudaRAII.h"
+
+using meta::comms::DeviceBuffer;
+
+namespace comms::pipes {
+
+class LlPacketTestFixture : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    CUDACHECK_TEST(cudaSetDevice(0));
+  }
+
+  void TearDown() override {
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+  }
+
+  template <typename F>
+  void expect_no_device_errors(F&& launcher, const char* fail_msg) {
+    DeviceBuffer errorCountBuffer(sizeof(uint32_t));
+    auto* errorCount_d = static_cast<uint32_t*>(errorCountBuffer.get());
+    CUDACHECK_TEST(cudaMemset(errorCount_d, 0, sizeof(uint32_t)));
+    launcher(errorCount_d);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    uint32_t errorCount_h = 0;
+    CUDACHECK_TEST(cudaMemcpy(
+        &errorCount_h, errorCount_d, sizeof(uint32_t), cudaMemcpyDeviceToHost));
+    EXPECT_EQ(errorCount_h, 0) << fail_msg;
+  }
+};
+
+TEST_F(LlPacketTestFixture, LineSize) {
+  expect_no_device_errors(test::test_ll_line_size, "LlLine size checks failed");
+}
+
+TEST_F(LlPacketTestFixture, FlagReadWrite) {
+  DeviceBuffer lineBuffer(sizeof(LlLine));
+  CUDACHECK_TEST(cudaMemset(lineBuffer.get(), 0, sizeof(LlLine)));
+  expect_no_device_errors(
+      [&](uint32_t* ec) {
+        test::test_ll_flag_read_write(lineBuffer.get(), ec);
+      },
+      "Flag read/write round-trip failed");
+}
+
+TEST_F(LlPacketTestFixture, NumLines) {
+  expect_no_device_errors(
+      test::test_ll_num_lines, "Num lines calculation failed");
+}
+
+TEST_F(LlPacketTestFixture, BufferSize) {
+  expect_no_device_errors(
+      test::test_ll_buffer_size, "Buffer size calculation failed");
+}
+
+TEST_F(LlPacketTestFixture, BufferPayloadCapacity) {
+  expect_no_device_errors(
+      test::test_ll_buffer_payload_capacity,
+      "Buffer payload capacity calculation failed");
+}
+
+TEST_F(LlPacketTestFixture, FlagInitViaCudaMemset) {
+  DeviceBuffer lineBuffer(sizeof(LlLine));
+  CUDACHECK_TEST(
+      cudaMemset(lineBuffer.get(), kLlMemsetInitByte, sizeof(LlLine)));
+  expect_no_device_errors(
+      [&](uint32_t* ec) { test::test_ll_flag_init(lineBuffer.get(), ec); },
+      "cudaMemset 0xFF should produce flags == kLlReadyToWrite");
+}
+
+TEST_F(LlPacketTestFixture, HostNumLinesCalculation) {
+  EXPECT_EQ(ll_num_lines(0), 0u);
+  EXPECT_EQ(ll_num_lines(1), 1u);
+  EXPECT_EQ(ll_num_lines(7), 1u);
+  EXPECT_EQ(ll_num_lines(8), 1u);
+  EXPECT_EQ(ll_num_lines(9), 2u);
+  EXPECT_EQ(ll_num_lines(16), 2u);
+  EXPECT_EQ(ll_num_lines(17), 3u);
+  EXPECT_EQ(ll_num_lines(65536), 8192u);
+
+  EXPECT_EQ(ll_buffer_size(0), 0u);
+  EXPECT_EQ(ll_buffer_size(8), 16u);
+  EXPECT_EQ(ll_buffer_size(16), 32u);
+  EXPECT_EQ(ll_buffer_size(65536), 131072u);
+
+  EXPECT_EQ(ll_buffer_payload_capacity(0), 0u);
+  EXPECT_EQ(ll_buffer_payload_capacity(16), 8u);
+  EXPECT_EQ(ll_buffer_payload_capacity(32), 16u);
+  EXPECT_EQ(ll_buffer_payload_capacity(131072), 65536u);
+}
+
+TEST_F(LlPacketTestFixture, HostCanUseLl) {
+  // nbytes == 0 is always eligible
+  EXPECT_TRUE(can_use_ll(nullptr, 0));
+  EXPECT_TRUE(can_use_ll(reinterpret_cast<const void*>(uintptr_t(1)), 0));
+
+  // Aligned pointer (0x100) + multiple of 8
+  auto* aligned = reinterpret_cast<const void*>(uintptr_t(0x100));
+  EXPECT_TRUE(can_use_ll(aligned, 8));
+  EXPECT_TRUE(can_use_ll(aligned, 16));
+  EXPECT_TRUE(can_use_ll(aligned, 1024));
+
+  // Aligned pointer + NOT multiple of 8
+  EXPECT_FALSE(can_use_ll(aligned, 1));
+  EXPECT_FALSE(can_use_ll(aligned, 7));
+  EXPECT_FALSE(can_use_ll(aligned, 9));
+
+  // Misaligned pointer (0x101) + multiple of 8
+  auto* misaligned = reinterpret_cast<const void*>(uintptr_t(0x101));
+  EXPECT_FALSE(can_use_ll(misaligned, 8));
+  EXPECT_FALSE(can_use_ll(misaligned, 16));
+
+  // Misaligned + not multiple of 8
+  EXPECT_FALSE(can_use_ll(misaligned, 9));
+
+  // buffer_num_lines checks (third parameter)
+
+  // buffer_num_lines=0 (default) -- no buffer constraint
+  EXPECT_TRUE(can_use_ll(aligned, 8, 0));
+
+  // nbytes=0 with buffer_num_lines>0 -- early return, always eligible
+  EXPECT_TRUE(can_use_ll(nullptr, 0, 64));
+
+  // buffer >= message -- always fine
+  EXPECT_TRUE(can_use_ll(aligned, 64, 8)); // 8 lines needed, 8 provided
+  EXPECT_TRUE(can_use_ll(aligned, 64, 100)); // 8 lines needed, 100 provided
+
+  // buffer < message but >= kLlLinesPerWarp -- fine (chunking)
+  EXPECT_TRUE(can_use_ll(aligned, 1024, 32)); // 128 lines needed, 32 provided
+  EXPECT_TRUE(can_use_ll(aligned, 1024, 64)); // 128 lines needed, 64 provided
+
+  // buffer < message and < kLlLinesPerWarp -- rejected
+  EXPECT_FALSE(can_use_ll(aligned, 1024, 16)); // 128 lines needed, 16 < 32
+  EXPECT_FALSE(can_use_ll(aligned, 1024, 1)); // 128 lines needed, 1 < 32
+}
+
+TEST_F(LlPacketTestFixture, HostLlFlag) {
+  // Basic values
+  EXPECT_EQ(ll_flag(0), 1u);
+  EXPECT_EQ(ll_flag(1), 2u);
+  EXPECT_EQ(ll_flag(41), 42u);
+
+  // Flag values should never be 0 or kLlReadyToWrite
+  EXPECT_NE(ll_flag(0), 0u);
+  EXPECT_NE(ll_flag(0), kLlReadyToWrite);
+
+  // Boundary: step = kLlMaxFlag - 1 produces maximum valid flag
+  EXPECT_EQ(ll_flag(static_cast<size_t>(kLlMaxFlag - 1)), kLlMaxFlag);
+
+  // Boundary: step = kLlMaxFlag wraps back to 1
+  EXPECT_EQ(ll_flag(static_cast<size_t>(kLlMaxFlag)), 1u);
+
+  // Boundary: step = kLlMaxFlag + 1 wraps to 2
+  EXPECT_EQ(ll_flag(static_cast<size_t>(kLlMaxFlag) + 1), 2u);
+
+  // Boundary: step = 0xFFFFFFFE (would have been kLlReadyToWrite with old impl)
+  EXPECT_EQ(ll_flag(static_cast<size_t>(0xFFFFFFFE)), 1u);
+  EXPECT_NE(ll_flag(static_cast<size_t>(0xFFFFFFFE)), kLlReadyToWrite);
+
+  // Boundary: step = 0xFFFFFFFF (would have wrapped to 0 with old impl)
+  EXPECT_EQ(ll_flag(static_cast<size_t>(0xFFFFFFFF)), 2u);
+  EXPECT_NE(ll_flag(static_cast<size_t>(0xFFFFFFFF)), 0u);
+}
+
+TEST_F(LlPacketTestFixture, CanUseLl) {
+  DeviceBuffer alignedBuffer(256);
+  expect_no_device_errors(
+      [&](uint32_t* ec) {
+        test::test_can_use_ll(
+            static_cast<const char*>(alignedBuffer.get()), ec);
+      },
+      "can_use_ll device-side checks failed");
+}
+
+TEST_F(LlPacketTestFixture, LlFlag) {
+  expect_no_device_errors(
+      test::test_ll_flag, "ll_flag device-side checks failed");
+}
+
+} // namespace comms::pipes

--- a/comms/pipes/ll/tests/LlPacketTest.cu
+++ b/comms/pipes/ll/tests/LlPacketTest.cu
@@ -1,0 +1,341 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <cstdint>
+
+#include "comms/pipes/ll/LlPacket.cuh"
+#include "comms/pipes/tests/Checks.h"
+
+namespace comms::pipes::test {
+
+using namespace comms::pipes;
+
+// =============================================================================
+// Size Tests
+// =============================================================================
+
+__global__ void test_ll_line_size_kernel(uint32_t* errorCount) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    if (sizeof(LlLine) != 16) {
+      printf(
+          "LlLine size mismatch: expected 16, got %llu\n",
+          (unsigned long long)sizeof(LlLine));
+      atomicAdd(errorCount, 1);
+    }
+  }
+}
+
+void test_ll_line_size(uint32_t* errorCount_d) {
+  test_ll_line_size_kernel<<<1, 1>>>(errorCount_d);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+// =============================================================================
+// Flag Read/Write Tests
+// =============================================================================
+
+__global__ void test_ll_flag_read_write_kernel(
+    LlLine* line,
+    uint32_t* errorCount) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    // Write a line with flag_value = 42
+    LlLine out;
+    out.data1 = 0xAAAAAAAA;
+    out.flag1 = 42;
+    out.data2 = 0xBBBBBBBB;
+    out.flag2 = 42;
+    ll_store_line(line, out);
+
+    // Read it back
+    LlLine in;
+    ll_load_line(line, in);
+
+    if (in.data1 != 0xAAAAAAAA) {
+      printf(
+          "data1 mismatch: expected 0xAAAAAAAA, got 0x%X\n",
+          (unsigned)in.data1);
+      atomicAdd(errorCount, 1);
+    }
+    if (in.flag1 != 42) {
+      printf("flag1 mismatch: expected 42, got %u\n", (unsigned)in.flag1);
+      atomicAdd(errorCount, 1);
+    }
+    if (in.data2 != 0xBBBBBBBB) {
+      printf(
+          "data2 mismatch: expected 0xBBBBBBBB, got 0x%X\n",
+          (unsigned)in.data2);
+      atomicAdd(errorCount, 1);
+    }
+    if (in.flag2 != 42) {
+      printf("flag2 mismatch: expected 42, got %u\n", (unsigned)in.flag2);
+      atomicAdd(errorCount, 1);
+    }
+
+    // Test ACK
+    ll_store_ack(line);
+    ll_load_line(line, in);
+    if (in.flag1 != kLlReadyToWrite || in.flag2 != kLlReadyToWrite) {
+      printf(
+          "ACK flag mismatch: expected 0x%X, got flag1=0x%X flag2=0x%X\n",
+          (unsigned)kLlReadyToWrite,
+          (unsigned)in.flag1,
+          (unsigned)in.flag2);
+      atomicAdd(errorCount, 1);
+    }
+    if (in.data1 != 0 || in.data2 != 0) {
+      printf(
+          "ACK data mismatch: expected 0, got data1=0x%X data2=0x%X\n",
+          (unsigned)in.data1,
+          (unsigned)in.data2);
+      atomicAdd(errorCount, 1);
+    }
+  }
+}
+
+void test_ll_flag_read_write(void* line_d, uint32_t* errorCount_d) {
+  test_ll_flag_read_write_kernel<<<1, 1>>>(
+      static_cast<LlLine*>(line_d), errorCount_d);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+// =============================================================================
+// Num Lines Tests
+// =============================================================================
+
+__global__ void test_ll_num_lines_kernel(uint32_t* errorCount) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    if (ll_num_lines(0) != 0)
+      atomicAdd(errorCount, 1);
+    if (ll_num_lines(1) != 1)
+      atomicAdd(errorCount, 1);
+    if (ll_num_lines(7) != 1)
+      atomicAdd(errorCount, 1);
+    if (ll_num_lines(8) != 1)
+      atomicAdd(errorCount, 1);
+    if (ll_num_lines(9) != 2)
+      atomicAdd(errorCount, 1);
+    if (ll_num_lines(16) != 2)
+      atomicAdd(errorCount, 1);
+    if (ll_num_lines(17) != 3)
+      atomicAdd(errorCount, 1);
+    // 64KB = 65536 bytes -> 65536/8 = 8192 lines
+    if (ll_num_lines(65536) != 8192)
+      atomicAdd(errorCount, 1);
+  }
+}
+
+void test_ll_num_lines(uint32_t* errorCount_d) {
+  test_ll_num_lines_kernel<<<1, 1>>>(errorCount_d);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+// =============================================================================
+// Buffer Size Tests
+// =============================================================================
+
+__global__ void test_ll_buffer_size_kernel(uint32_t* errorCount) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    if (ll_buffer_size(0) != 0)
+      atomicAdd(errorCount, 1);
+    // 8 bytes -> 1 line -> 16 bytes
+    if (ll_buffer_size(8) != 16)
+      atomicAdd(errorCount, 1);
+    // 16 bytes -> 2 lines -> 32 bytes
+    if (ll_buffer_size(16) != 32)
+      atomicAdd(errorCount, 1);
+    // 64KB -> 8192 lines -> 131072 bytes
+    if (ll_buffer_size(65536) != 131072)
+      atomicAdd(errorCount, 1);
+  }
+}
+
+void test_ll_buffer_size(uint32_t* errorCount_d) {
+  test_ll_buffer_size_kernel<<<1, 1>>>(errorCount_d);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+// =============================================================================
+// Buffer Payload Capacity Tests
+// =============================================================================
+
+__global__ void test_ll_buffer_payload_capacity_kernel(uint32_t* errorCount) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    // 0 bytes buffer -> 0 capacity
+    if (ll_buffer_payload_capacity(0) != 0)
+      atomicAdd(errorCount, 1);
+    // 16 bytes buffer -> 1 line -> 8 bytes payload
+    if (ll_buffer_payload_capacity(16) != 8)
+      atomicAdd(errorCount, 1);
+    // 32 bytes buffer -> 2 lines -> 16 bytes payload
+    if (ll_buffer_payload_capacity(32) != 16)
+      atomicAdd(errorCount, 1);
+    // 131072 bytes buffer -> 8192 lines -> 65536 bytes payload
+    if (ll_buffer_payload_capacity(131072) != 65536)
+      atomicAdd(errorCount, 1);
+    // 15 bytes buffer (not a full line) -> 0 lines -> 0 payload
+    if (ll_buffer_payload_capacity(15) != 0)
+      atomicAdd(errorCount, 1);
+  }
+}
+
+void test_ll_buffer_payload_capacity(uint32_t* errorCount_d) {
+  test_ll_buffer_payload_capacity_kernel<<<1, 1>>>(errorCount_d);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+// =============================================================================
+// Flag Initialization Test (cudaMemset 0xFF -> kLlReadyToWrite)
+// =============================================================================
+
+__global__ void test_ll_flag_init_kernel(LlLine* line, uint32_t* errorCount) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    LlLine in;
+    ll_load_line(line, in);
+    if (in.flag1 != kLlReadyToWrite) {
+      printf(
+          "Flag1 init mismatch: expected 0x%X, got 0x%X\n",
+          (unsigned)kLlReadyToWrite,
+          (unsigned)in.flag1);
+      atomicAdd(errorCount, 1);
+    }
+    if (in.flag2 != kLlReadyToWrite) {
+      printf(
+          "Flag2 init mismatch: expected 0x%X, got 0x%X\n",
+          (unsigned)kLlReadyToWrite,
+          (unsigned)in.flag2);
+      atomicAdd(errorCount, 1);
+    }
+  }
+}
+
+void test_ll_flag_init(void* line_d, uint32_t* errorCount_d) {
+  test_ll_flag_init_kernel<<<1, 1>>>(
+      static_cast<LlLine*>(line_d), errorCount_d);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+// =============================================================================
+// can_use_ll Tests
+// =============================================================================
+
+__global__ void test_can_use_ll_kernel(
+    const char* aligned_ptr,
+    uint32_t* errorCount) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    // nbytes == 0 always eligible
+    if (!can_use_ll(nullptr, 0))
+      atomicAdd(errorCount, 1);
+    if (!can_use_ll(aligned_ptr + 1, 0))
+      atomicAdd(errorCount, 1);
+
+    // Aligned + multiple of 8
+    if (!can_use_ll(aligned_ptr, 8))
+      atomicAdd(errorCount, 1);
+    if (!can_use_ll(aligned_ptr, 16))
+      atomicAdd(errorCount, 1);
+    if (!can_use_ll(aligned_ptr, 64))
+      atomicAdd(errorCount, 1);
+
+    // Aligned + NOT multiple of 8
+    if (can_use_ll(aligned_ptr, 1))
+      atomicAdd(errorCount, 1);
+    if (can_use_ll(aligned_ptr, 7))
+      atomicAdd(errorCount, 1);
+    if (can_use_ll(aligned_ptr, 9))
+      atomicAdd(errorCount, 1);
+
+    // Misaligned (ptr+1) + multiple of 8
+    if (can_use_ll(aligned_ptr + 1, 8))
+      atomicAdd(errorCount, 1);
+
+    // Misaligned + not multiple of 8
+    if (can_use_ll(aligned_ptr + 1, 9))
+      atomicAdd(errorCount, 1);
+
+    // buffer_num_lines checks (third parameter)
+
+    // buffer_num_lines=0 (default) -- no buffer constraint
+    if (!can_use_ll(aligned_ptr, 8, 0))
+      atomicAdd(errorCount, 1);
+
+    // nbytes=0 with buffer_num_lines>0 -- early return
+    if (!can_use_ll(nullptr, 0, 64))
+      atomicAdd(errorCount, 1);
+
+    // buffer >= message
+    if (!can_use_ll(aligned_ptr, 64, 8))
+      atomicAdd(errorCount, 1);
+    if (!can_use_ll(aligned_ptr, 64, 100))
+      atomicAdd(errorCount, 1);
+
+    // buffer < message but >= kLlLinesPerWarp (chunking OK)
+    if (!can_use_ll(aligned_ptr, 1024, 32))
+      atomicAdd(errorCount, 1);
+    if (!can_use_ll(aligned_ptr, 1024, 64))
+      atomicAdd(errorCount, 1);
+
+    // buffer < message and < kLlLinesPerWarp (rejected)
+    if (can_use_ll(aligned_ptr, 1024, 16))
+      atomicAdd(errorCount, 1);
+    if (can_use_ll(aligned_ptr, 1024, 1))
+      atomicAdd(errorCount, 1);
+  }
+}
+
+void test_can_use_ll(const char* aligned_ptr_d, uint32_t* errorCount_d) {
+  test_can_use_ll_kernel<<<1, 1>>>(aligned_ptr_d, errorCount_d);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+// =============================================================================
+// ll_flag Tests
+// =============================================================================
+
+__global__ void test_ll_flag_kernel(uint32_t* errorCount) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    // Basic values
+    if (ll_flag(0) != 1)
+      atomicAdd(errorCount, 1);
+    if (ll_flag(1) != 2)
+      atomicAdd(errorCount, 1);
+    if (ll_flag(41) != 42)
+      atomicAdd(errorCount, 1);
+
+    // Flag values should never be 0 or kLlReadyToWrite
+    if (ll_flag(0) == 0)
+      atomicAdd(errorCount, 1);
+    if (ll_flag(0) == kLlReadyToWrite)
+      atomicAdd(errorCount, 1);
+
+    // Boundary: max valid flag
+    if (ll_flag(static_cast<size_t>(kLlMaxFlag - 1)) != kLlMaxFlag)
+      atomicAdd(errorCount, 1);
+
+    // Boundary: wrap-around
+    if (ll_flag(static_cast<size_t>(kLlMaxFlag)) != 1)
+      atomicAdd(errorCount, 1);
+
+    // Boundary: wrap-around + 1
+    if (ll_flag(static_cast<size_t>(kLlMaxFlag) + 1) != 2)
+      atomicAdd(errorCount, 1);
+
+    // Boundary: step = 0xFFFFFFFE (old impl would produce kLlReadyToWrite)
+    if (ll_flag(static_cast<size_t>(0xFFFFFFFE)) == kLlReadyToWrite) {
+      printf("ll_flag(0xFFFFFFFE) collides with kLlReadyToWrite\n");
+      atomicAdd(errorCount, 1);
+    }
+
+    // Boundary: step = 0xFFFFFFFF (old impl would wrap to 0)
+    if (ll_flag(static_cast<size_t>(0xFFFFFFFF)) == 0) {
+      printf("ll_flag(0xFFFFFFFF) produced 0\n");
+      atomicAdd(errorCount, 1);
+    }
+  }
+}
+
+void test_ll_flag(uint32_t* errorCount_d) {
+  test_ll_flag_kernel<<<1, 1>>>(errorCount_d);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+} // namespace comms::pipes::test

--- a/comms/pipes/ll/tests/LlPacketTest.cuh
+++ b/comms/pipes/ll/tests/LlPacketTest.cuh
@@ -1,0 +1,33 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+
+namespace comms::pipes::test {
+
+/// Test that LlLine is 16 bytes.
+void test_ll_line_size(uint32_t* errorCount_d);
+
+/// Test flag read/write round-trip via volatile helpers.
+void test_ll_flag_read_write(void* line_d, uint32_t* errorCount_d);
+
+/// Test ll_num_lines for various message sizes.
+void test_ll_num_lines(uint32_t* errorCount_d);
+
+/// Test ll_buffer_size for various message sizes.
+void test_ll_buffer_size(uint32_t* errorCount_d);
+
+/// Test ll_buffer_payload_capacity.
+void test_ll_buffer_payload_capacity(uint32_t* errorCount_d);
+
+/// Test flag initialization to kLlReadyToWrite via cudaMemset 0xFF.
+void test_ll_flag_init(void* line_d, uint32_t* errorCount_d);
+
+/// Test can_use_ll on device side.
+void test_can_use_ll(const char* aligned_ptr_d, uint32_t* errorCount_d);
+
+/// Test ll_flag function.
+void test_ll_flag(uint32_t* errorCount_d);
+
+} // namespace comms::pipes::test


### PR DESCRIPTION
Summary:

Adds the last core LL point-to-point operation (`forward`) on top of the `LlLine` packet primitive.

**`LlOps.cuh`** additionally defines:
- `ll_forward()`: for intermediate ranks in a broadcast ring: polls local buffer (predecessor wrote), polls remote buffer (successor slot free), forwards the line to the successor, copies payload locally, and ACKs the predecessor.

Reviewed By: siyengar

Differential Revision: D97955396


