### PR TITLE
Fix MCCL dynamic regime crash by lazy-initializing ranks_ in getRanks()

### DIFF
--- a/comms/torchcomms/TorchComm.cpp
+++ b/comms/torchcomms/TorchComm.cpp
@@ -47,12 +47,9 @@ TorchComm::TorchComm(
     const std::string& backend_name,
     std::shared_ptr<TorchCommBackend> impl)
     : backend_(backend_name), impl_(std::move(impl)) {
-  // Initialize ranks_ for root communicator: [0, 1, 2, ..., size-1]
-  int size = impl_->getSize();
-  ranks_.reserve(size);
-  for (int i = 0; i < size; ++i) {
-    ranks_.push_back(i);
-  }
+  // ranks_ is lazily initialized in getRanks() to support backends
+  // that defer initialization (e.g., MCCL dynamic regime where getSize()
+  // is not valid until reconfigure() is called).
 }
 
 TorchComm::TorchComm(
@@ -88,6 +85,17 @@ int TorchComm::getSize() const {
 }
 
 std::vector<int> TorchComm::getRanks() const {
+  // Lazy initialization for root communicators. Split communicators have
+  // ranks_ set explicitly in their constructor. Root communicators defer
+  // initialization to here so that backends with deferred init (e.g., MCCL
+  // dynamic regime) don't crash when getSize() is called before reconfigure().
+  if (ranks_.empty()) {
+    int size = impl_->getSize();
+    ranks_.reserve(size);
+    for (int i = 0; i < size; ++i) {
+      ranks_.push_back(i);
+    }
+  }
   return ranks_;
 }
 

--- a/comms/torchcomms/TorchComm.hpp
+++ b/comms/torchcomms/TorchComm.hpp
@@ -265,9 +265,11 @@ class TorchComm : public std::enable_shared_from_this<TorchComm> {
   std::unordered_map<int64_t, PreHook> preHooks_;
   std::unordered_map<int64_t, PostHook> postHooks_;
   // Global ranks of the members of this communicator.
-  // For root communicators: [0, 1, 2, ..., size-1]
-  // For split communicators: global ranks from the parent communicator
-  std::vector<int> ranks_;
+  // For root communicators: lazily initialized in getRanks() as [0, 1, ...,
+  // size-1] For split communicators: set explicitly in constructor from parent
+  // ranks Mutable because getRanks() lazily initializes it for root
+  // communicators.
+  mutable std::vector<int> ranks_;
 };
 
 // Constructor that creates the appropriate backend implementation


### PR DESCRIPTION
Summary:
D94240481 added `impl_->getSize()` to the TorchComm root constructor to populate
`ranks_` for FlightRecorder. This breaks MCCL dynamic-regime backends (used by PAFT
inter-replica communication) because `getSize()` is guarded by
`TC_MCCL_CHECK_INITIALIZED()` and `initState_` is intentionally left UNINITIALIZED
until `reconfigure()` is called.

The fix moves `ranks_` initialization from the constructor to `getRanks()` (lazy init).
This is safe because:
- FlightRecorder (the only consumer) calls `getRanks()` after the comm is fully initialized
- Split communicators still get `ranks_` set explicitly in their 3-arg constructor
- `ranks_` is made `mutable` so the `const` `getRanks()` can lazy-init it

Differential Revision: D97981229


