### PR TITLE
Part 3c: 3-GPU NVLink Integration Tests (#1243)

### DIFF
--- a/comms/pipes/MultiPeerNvlTransport.cc
+++ b/comms/pipes/MultiPeerNvlTransport.cc
@@ -6,6 +6,7 @@
 
 #include "comms/pipes/P2pSelfTransportDevice.cuh"
 #include "comms/pipes/Transport.cuh"
+#include "comms/pipes/ll/LlPacket.cuh"
 #include "comms/pipes/ll128/Ll128Packet.cuh"
 #include "comms/utils/checks.h"
 
@@ -163,8 +164,23 @@ MultiPeerNvlTransport::MultiPeerNvlTransport(
     // Data payload bytes are also 0xFF but get overwritten before first read.
     auto* ll128Ptr = ll128BufferHandler_->getLocalDeviceMemPtr();
     CUDA_CHECK(cudaMemset(ll128Ptr, kLl128MemsetInitByte, totalLl128Size));
-    CUDA_CHECK(
-        cudaDeviceSynchronize()); // Ensure init completes before exchange
+  }
+
+  // Conditionally allocate LL buffers
+  if (config_.llBufferSize > 0) {
+    perPeerLlBufferSize_ = config_.llBufferSize;
+    std::size_t totalLlSize = perPeerLlBufferSize_ * (nRanks_ - 1);
+    llBufferHandler_ = std::make_unique<GpuMemHandler>(
+        bootstrap_, myRank_, nRanks_, totalLlSize, memSharingMode_);
+
+    // Initialize all LL line flags to kLlReadyToWrite (0xFFFFFFFF).
+    auto* llPtr = llBufferHandler_->getLocalDeviceMemPtr();
+    CUDA_CHECK(cudaMemset(llPtr, kLlMemsetInitByte, totalLlSize));
+  }
+
+  // Ensure all buffer initialization completes before exchange
+  if (config_.ll128BufferSize > 0 || config_.llBufferSize > 0) {
+    CUDA_CHECK(cudaDeviceSynchronize());
   }
 }
 
@@ -235,6 +251,10 @@ void MultiPeerNvlTransport::exchange() {
   if (tileSignalHandler_) {
     tileSignalHandler_->exchangeMemPtrs();
   }
+
+  if (llBufferHandler_) {
+    llBufferHandler_->exchangeMemPtrs();
+  }
 }
 
 P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
@@ -282,6 +302,7 @@ P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
       .pipelineDepth = config_.pipelineDepth,
       .useDualStateBuffer = config_.useDualStateBuffer,
       .ll128BufferNumPackets = perPeerLl128BufferSize_ / kLl128PacketSize,
+      .llBufferNumLines = perPeerLlBufferSize_ / kLlLineSize,
   };
 
   auto* localSignalPtr =
@@ -323,6 +344,34 @@ P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
   };
   auto [localBarrierSpan, remoteBarrierSpan] = makeBarrierSpans();
 
+  // Compute LL128 buffer pointers (nullptr when LL128 is disabled)
+  Ll128Packet* localLl128 = nullptr;
+  Ll128Packet* remoteLl128 = nullptr;
+  if (ll128BufferHandler_) {
+    auto* localLl128Ptr =
+        static_cast<char*>(ll128BufferHandler_->getLocalDeviceMemPtr());
+    localLl128 = reinterpret_cast<Ll128Packet*>(
+        localLl128Ptr + localPeerIndex * perPeerLl128BufferSize_);
+    auto* remoteLl128Ptr =
+        static_cast<char*>(ll128BufferHandler_->getPeerDeviceMemPtr(peerRank));
+    remoteLl128 = reinterpret_cast<Ll128Packet*>(
+        remoteLl128Ptr + remotePeerIndex * perPeerLl128BufferSize_);
+  }
+
+  // Compute LL buffer pointers (nullptr when LL is disabled)
+  LlLine* localLl = nullptr;
+  LlLine* remoteLl = nullptr;
+  if (llBufferHandler_) {
+    auto* localLlPtr =
+        static_cast<char*>(llBufferHandler_->getLocalDeviceMemPtr());
+    localLl = reinterpret_cast<LlLine*>(
+        localLlPtr + localPeerIndex * perPeerLlBufferSize_);
+    auto* remoteLlPtr =
+        static_cast<char*>(llBufferHandler_->getPeerDeviceMemPtr(peerRank));
+    remoteLl = reinterpret_cast<LlLine*>(
+        remoteLlPtr + remotePeerIndex * perPeerLlBufferSize_);
+  }
+
   // When dataBufferSize=0, staging buffers are not allocated.
   // Set data/state to nullptr/empty — send()/recv() will trap.
   if (!dataBufferHandler_ && !externalStagingBuffers_) {
@@ -332,6 +381,8 @@ P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
         .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
         .signalBuffer = localSignalSpan,
         .barrierBuffer = localBarrierSpan,
+        .ll128Buffer = localLl128,
+        .llBuffer = localLl,
     };
     RemoteState remoteState{
         .dataBuffer = nullptr,
@@ -339,6 +390,8 @@ P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
         .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
         .signalBuffer = remoteSignalSpan,
         .barrierBuffer = remoteBarrierSpan,
+        .ll128Buffer = remoteLl128,
+        .llBuffer = remoteLl,
     };
     auto buildTileState = [&]() -> NvlinkTransportTileState {
       if (!tileStepStateBuffer_) {
@@ -399,20 +452,6 @@ P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
   auto* remoteChunkStatePtr =
       static_cast<char*>(stateBufferHandler_->getPeerDeviceMemPtr(peerRank));
 
-  // Compute LL128 buffer pointers (nullptr when LL128 is disabled)
-  Ll128Packet* localLl128 = nullptr;
-  Ll128Packet* remoteLl128 = nullptr;
-  if (ll128BufferHandler_) {
-    auto* localLl128Ptr =
-        static_cast<char*>(ll128BufferHandler_->getLocalDeviceMemPtr());
-    localLl128 = reinterpret_cast<Ll128Packet*>(
-        localLl128Ptr + localPeerIndex * perPeerLl128BufferSize_);
-    auto* remoteLl128Ptr =
-        static_cast<char*>(ll128BufferHandler_->getPeerDeviceMemPtr(peerRank));
-    remoteLl128 = reinterpret_cast<Ll128Packet*>(
-        remoteLl128Ptr + remotePeerIndex * perPeerLl128BufferSize_);
-  }
-
   auto* remoteChunkStateBase = reinterpret_cast<ChunkState*>(
       remoteChunkStatePtr + remoteChunkStateBufferOffset);
 
@@ -420,17 +459,6 @@ P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
   // Note: Using direct initialization since DeviceSpan has const members
   // that prevent copy-assignment
   if (config_.useDualStateBuffer) {
-    // Dual state mode: 2x chunk states per peer
-    //   Local buffer layout:
-    //     [0, numChunksPerPeer): receiver state buffer (state to poll if
-    //     I am a receiver)
-    //     [numChunksPerPeer, 2*numChunksPerPeer): sender state buffer
-    //     (state to poll if I am a sender)
-    //   Remote buffer layout (on peer's memory via NVLink):
-    //     [0, numChunksPerPeer): peer's receiver state buffer (I write to
-    //     signal data ready)
-    //     [numChunksPerPeer, 2*numChunksPerPeer): peer's sender state buffer
-    //     (I write READY_TO_SEND after reading)
     LocalState localState{
         .dataBuffer = localDataBuffer,
         .receiverStateBuffer =
@@ -440,6 +468,7 @@ P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
         .signalBuffer = localSignalSpan,
         .barrierBuffer = localBarrierSpan,
         .ll128Buffer = localLl128,
+        .llBuffer = localLl,
     };
 
     RemoteState remoteState{
@@ -451,6 +480,7 @@ P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
         .signalBuffer = remoteSignalSpan,
         .barrierBuffer = remoteBarrierSpan,
         .ll128Buffer = remoteLl128,
+        .llBuffer = remoteLl,
     };
 
     auto buildTileState = [&]() -> NvlinkTransportTileState {
@@ -481,10 +511,6 @@ P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
         myRank_, peerRank, options, localState, remoteState, buildTileState());
     return device;
   } else {
-    // Single state mode: 1x chunk state per peer (on receiver side only)
-    //   Local buffer: only receiverStateBuffer is used (receiver waits here)
-    //   Remote buffer: only receiverStateBuffer is used (points to peer's
-    //   receiverStateBuffer, sender writes to signal data ready)
     LocalState localState{
         .dataBuffer = localDataBuffer,
         .receiverStateBuffer =
@@ -493,6 +519,7 @@ P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
         .signalBuffer = localSignalSpan,
         .barrierBuffer = localBarrierSpan,
         .ll128Buffer = localLl128,
+        .llBuffer = localLl,
     };
 
     RemoteState remoteState{
@@ -503,6 +530,7 @@ P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
         .signalBuffer = remoteSignalSpan,
         .barrierBuffer = remoteBarrierSpan,
         .ll128Buffer = remoteLl128,
+        .llBuffer = remoteLl,
     };
 
     auto buildTileState = [&]() -> NvlinkTransportTileState {

--- a/comms/pipes/MultiPeerNvlTransport.h
+++ b/comms/pipes/MultiPeerNvlTransport.h
@@ -95,6 +95,12 @@ struct MultiPeerNvlTransportConfig {
   // 0 (default), LL128 is disabled. Use ll128_buffer_size() from
   // Ll128Packet.cuh to compute from message size.
   std::size_t ll128BufferSize{0};
+
+  // Size of LL line buffer per peer (bytes).
+  // When > 0, allocates LL buffers and enables ll_send/recv/forward
+  // on P2pNvlTransportDevice. When 0 (default), LL is disabled.
+  // Use ll_buffer_size() from LlPacket.cuh to compute from message size.
+  std::size_t llBufferSize{0};
 };
 
 /**
@@ -368,6 +374,8 @@ class MultiPeerNvlTransport {
       ll128BufferHandler_; // nullptr when ll128BufferSize == 0
   std::unique_ptr<GpuMemHandler>
       barrierBufferHandler_; // nullptr when p2pBarrierCount == 0
+  std::unique_ptr<GpuMemHandler>
+      llBufferHandler_; // nullptr when llBufferSize == 0
 
   // External data buffer pointers (set via setExternalDataBuffers()).
   // When set, exchange() skips data buffer allocation/exchange.
@@ -391,6 +399,7 @@ class MultiPeerNvlTransport {
   std::unique_ptr<GpuMemHandler>
       tileSignalHandler_; // 2*maxBlocks signals, exchanged
   std::size_t perPeerTileSignalSize_{0};
+  std::size_t perPeerLlBufferSize_{0};
 
   // Flag to track if multi-peer device arrays have been initialized
   bool multiPeerInitialized_{false};

--- a/comms/pipes/P2pNvlTransportDevice.cuh
+++ b/comms/pipes/P2pNvlTransportDevice.cuh
@@ -15,6 +15,7 @@
 #include "comms/pipes/SignalState.cuh"
 #include "comms/pipes/ThreadGroup.cuh"
 #include "comms/pipes/Timeout.cuh"
+#include "comms/pipes/ll/LlOps.cuh"
 #include "comms/pipes/ll128/Ll128Ops.cuh"
 
 namespace comms::pipes {
@@ -51,6 +52,7 @@ struct LocalState {
   DeviceSpan<SignalState> signalBuffer;
   DeviceSpan<BarrierState> barrierBuffer;
   Ll128Packet* ll128Buffer{nullptr};
+  LlLine* llBuffer{nullptr};
 };
 
 /**
@@ -84,6 +86,7 @@ struct RemoteState {
   DeviceSpan<SignalState> signalBuffer;
   DeviceSpan<BarrierState> barrierBuffer;
   Ll128Packet* ll128Buffer{nullptr};
+  LlLine* llBuffer{nullptr};
 };
 
 /**
@@ -146,6 +149,7 @@ struct P2pNvlTransportOptions {
   std::size_t pipelineDepth;
   bool useDualStateBuffer{false}; // Default to single state buffer mode
   std::size_t ll128BufferNumPackets{0}; // 0 = no chunking
+  std::size_t llBufferNumLines{0}; // 0 = no chunking
 };
 
 /**
@@ -1809,6 +1813,219 @@ class P2pNvlTransportDevice {
   }
   __device__ RemoteState& remote_state() {
     return remoteState_;
+  }
+
+  // ===========================================================================
+  // LL Protocol Operations
+  // ===========================================================================
+
+  /**
+   * ll_send — Send data to peer's LL buffer via NVLink.
+   *
+   * Packs user data into LL lines and volatile-stores them to the
+   * peer's LL buffer with inline flag signaling.
+   *
+   * PRECONDITION: llBufferSize > 0 in transport config.
+   *
+   * @param group         ThreadGroup (auto-converted to warp scope)
+   * @param src           Local source buffer (8-byte aligned)
+   * @param nbytes        Total bytes (must be a multiple of 8)
+   * @param active_groups Number of groups calling concurrently.
+   *   0 = default to max groups the LL buffer can support.
+   *   >0 = explicit group count; buffer partitioned per group.group_id.
+   * @param timeout       Timeout for flag polling
+   */
+  __device__ __forceinline__ void ll_send(
+      const ThreadGroup& group,
+      const char* src,
+      size_t nbytes,
+      int active_groups = 0,
+      const Timeout& timeout = Timeout()) {
+#ifdef __CUDA_ARCH__
+    PIPES_DEVICE_CHECK(remoteState_.llBuffer != nullptr);
+    PIPES_DEVICE_CHECK(can_use_ll(src, nbytes, options_.llBufferNumLines));
+
+    const int maxGroups =
+        (options_.llBufferNumLines >= static_cast<size_t>(kLlLinesPerWarp))
+        ? static_cast<int>(options_.llBufferNumLines / kLlLinesPerWarp)
+        : 1;
+    const int effActive = active_groups > 0 ? active_groups : maxGroups;
+
+    PIPES_DEVICE_CHECK(static_cast<uint32_t>(effActive) <= group.total_groups);
+    PIPES_DEVICE_CHECK(group.group_id < static_cast<uint32_t>(effActive));
+
+    const size_t perGroupLines = options_.llBufferNumLines / effActive;
+    if (effActive > 1 && options_.llBufferNumLines > 0) {
+      PIPES_DEVICE_CHECK(perGroupLines >= kLlLinesPerWarp);
+    }
+    const size_t bufferOffset = group.group_id * perGroupLines;
+
+    comms::pipes::ll_send(
+        group,
+        src,
+        nbytes,
+        remoteState_.llBuffer + bufferOffset,
+        timeout,
+        perGroupLines);
+#else
+    (void)group;
+    (void)src;
+    (void)nbytes;
+    (void)active_groups;
+    (void)timeout;
+#endif
+  }
+
+  /**
+   * ll_recv — Receive data from local LL buffer.
+   *
+   * Polls the local LL buffer (written remotely by peer), reads
+   * payload to output buffer, and ACKs with kLlReadyToWrite.
+   *
+   * PRECONDITION: llBufferSize > 0 in transport config.
+   *
+   * @param group         ThreadGroup (auto-converted to warp scope)
+   * @param dst           Local output buffer (8-byte aligned)
+   * @param nbytes        Total bytes (must be a multiple of 8)
+   * @param active_groups Number of groups calling concurrently.
+   *   0 = default to max groups the LL buffer can support.
+   *   >0 = explicit group count; buffer partitioned per group.group_id.
+   * @param timeout       Timeout for flag polling
+   */
+  __device__ __forceinline__ void ll_recv(
+      const ThreadGroup& group,
+      char* dst,
+      size_t nbytes,
+      int active_groups = 0,
+      const Timeout& timeout = Timeout()) {
+#ifdef __CUDA_ARCH__
+    PIPES_DEVICE_CHECK(localState_.llBuffer != nullptr);
+    PIPES_DEVICE_CHECK(can_use_ll(dst, nbytes, options_.llBufferNumLines));
+
+    const int maxGroups =
+        (options_.llBufferNumLines >= static_cast<size_t>(kLlLinesPerWarp))
+        ? static_cast<int>(options_.llBufferNumLines / kLlLinesPerWarp)
+        : 1;
+    const int effActive = active_groups > 0 ? active_groups : maxGroups;
+
+    PIPES_DEVICE_CHECK(static_cast<uint32_t>(effActive) <= group.total_groups);
+    PIPES_DEVICE_CHECK(group.group_id < static_cast<uint32_t>(effActive));
+
+    const size_t perGroupLines = options_.llBufferNumLines / effActive;
+    if (effActive > 1 && options_.llBufferNumLines > 0) {
+      PIPES_DEVICE_CHECK(perGroupLines >= kLlLinesPerWarp);
+    }
+    const size_t bufferOffset = group.group_id * perGroupLines;
+
+    comms::pipes::ll_recv(
+        group,
+        dst,
+        nbytes,
+        localState_.llBuffer + bufferOffset,
+        timeout,
+        perGroupLines);
+#else
+    (void)group;
+    (void)dst;
+    (void)nbytes;
+    (void)active_groups;
+    (void)timeout;
+#endif
+  }
+
+  /**
+   * ll_forward — Receive from predecessor and forward to successor.
+   *
+   * Reads from this transport's local LL buffer (predecessor wrote here),
+   * forwards to successor_transport's remote LL buffer, copies payload
+   * to local output, and ACKs predecessor.
+   *
+   * PRECONDITION: llBufferSize > 0 in both this and successor transport.
+   *
+   * @param group                ThreadGroup (auto-converted to warp scope)
+   * @param dst                  Local output buffer (8-byte aligned)
+   * @param nbytes               Total bytes (must be a multiple of 8)
+   * @param successor_transport  Transport for the successor peer
+   * @param active_groups        Number of groups calling concurrently.
+   *   0 = default to max groups the LL buffer can support.
+   *   >0 = explicit group count; buffer partitioned per group.group_id.
+   * @param timeout              Timeout for flag polling
+   */
+  __device__ __forceinline__ void ll_forward(
+      const ThreadGroup& group,
+      char* dst,
+      size_t nbytes,
+      const P2pNvlTransportDevice& successor_transport,
+      int active_groups = 0,
+      const Timeout& timeout = Timeout()) {
+#ifdef __CUDA_ARCH__
+    PIPES_DEVICE_CHECK(localState_.llBuffer != nullptr);
+    PIPES_DEVICE_CHECK(successor_transport.remoteState_.llBuffer != nullptr);
+    PIPES_DEVICE_CHECK(can_use_ll(dst, nbytes, options_.llBufferNumLines));
+
+    const int myMax =
+        (options_.llBufferNumLines >= static_cast<size_t>(kLlLinesPerWarp))
+        ? static_cast<int>(options_.llBufferNumLines / kLlLinesPerWarp)
+        : 1;
+    const int succMax = (successor_transport.options_.llBufferNumLines >=
+                         static_cast<size_t>(kLlLinesPerWarp))
+        ? static_cast<int>(
+              successor_transport.options_.llBufferNumLines / kLlLinesPerWarp)
+        : 1;
+    const int maxGroups = myMax < succMax ? myMax : succMax;
+    const int effActive = active_groups > 0 ? active_groups : maxGroups;
+
+    PIPES_DEVICE_CHECK(static_cast<uint32_t>(effActive) <= group.total_groups);
+    PIPES_DEVICE_CHECK(group.group_id < static_cast<uint32_t>(effActive));
+
+    const size_t myPerGroup = options_.llBufferNumLines / effActive;
+    const size_t succPerGroup =
+        successor_transport.options_.llBufferNumLines / effActive;
+    if (effActive > 1) {
+      if (options_.llBufferNumLines > 0) {
+        PIPES_DEVICE_CHECK(myPerGroup >= kLlLinesPerWarp);
+      }
+      if (successor_transport.options_.llBufferNumLines > 0) {
+        PIPES_DEVICE_CHECK(succPerGroup >= kLlLinesPerWarp);
+      }
+    }
+    const size_t myOffset = group.group_id * myPerGroup;
+    const size_t succOffset = group.group_id * succPerGroup;
+
+    // Asymmetric buffer sizing: 0 means "pre-sized to fit message."
+    // Use the non-zero value when only one side is chunked.
+    size_t effectiveLines;
+    if (myPerGroup > 0 && succPerGroup > 0) {
+      effectiveLines = myPerGroup < succPerGroup ? myPerGroup : succPerGroup;
+    } else if (myPerGroup > 0) {
+      effectiveLines = myPerGroup;
+    } else {
+      effectiveLines = succPerGroup;
+    }
+
+    comms::pipes::ll_forward(
+        group,
+        dst,
+        nbytes,
+        localState_.llBuffer + myOffset,
+        successor_transport.remoteState_.llBuffer + succOffset,
+        timeout,
+        effectiveLines);
+#else
+    (void)group;
+    (void)dst;
+    (void)nbytes;
+    (void)successor_transport;
+    (void)active_groups;
+    (void)timeout;
+#endif
+  }
+
+  /**
+   * get_ll_buffer_num_lines — Get the number of LL lines in the buffer.
+   */
+  __device__ __forceinline__ size_t get_ll_buffer_num_lines() const {
+    return options_.llBufferNumLines;
   }
 
  private:

--- a/comms/pipes/ll/tests/LlOpsNvlink3GpuTest.cc
+++ b/comms/pipes/ll/tests/LlOpsNvlink3GpuTest.cc
@@ -1,0 +1,192 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+#include <cstddef>
+#include <vector>
+
+#include "comms/pipes/ll/LlPacket.cuh"
+#include "comms/pipes/ll/tests/LlOpsNvlinkTest.cuh"
+#include "comms/testinfra/TestXPlatUtils.h"
+
+namespace comms::pipes {
+
+// =============================================================================
+// Three-GPU Test Fixture for 3-distinct-GPU LL forward tests
+// =============================================================================
+
+class LlOpsNvlink3GpuTestFixture : public ::testing::Test {
+ protected:
+  static constexpr int kGpu0 = 0;
+  static constexpr int kGpu1 = 1;
+  static constexpr int kGpu2 = 2;
+
+  void SetUp() override {
+    int deviceCount = 0;
+    CUDACHECK_TEST(cudaGetDeviceCount(&deviceCount));
+    if (deviceCount < 3) {
+      GTEST_SKIP() << "Test requires at least 3 GPUs";
+    }
+
+    // Check P2P access between all pairs
+    int canAccess01 = 0, canAccess10 = 0;
+    int canAccess12 = 0, canAccess21 = 0;
+    int canAccess02 = 0, canAccess20 = 0;
+    CUDACHECK_TEST(cudaDeviceCanAccessPeer(&canAccess01, kGpu0, kGpu1));
+    CUDACHECK_TEST(cudaDeviceCanAccessPeer(&canAccess10, kGpu1, kGpu0));
+    CUDACHECK_TEST(cudaDeviceCanAccessPeer(&canAccess12, kGpu1, kGpu2));
+    CUDACHECK_TEST(cudaDeviceCanAccessPeer(&canAccess21, kGpu2, kGpu1));
+    CUDACHECK_TEST(cudaDeviceCanAccessPeer(&canAccess02, kGpu0, kGpu2));
+    CUDACHECK_TEST(cudaDeviceCanAccessPeer(&canAccess20, kGpu2, kGpu0));
+    if (!canAccess01 || !canAccess10 || !canAccess12 || !canAccess21 ||
+        !canAccess02 || !canAccess20) {
+      GTEST_SKIP() << "Test requires P2P access between GPUs 0, 1, and 2";
+    }
+
+    // Enable P2P access between all pairs
+    auto enable_peer = [](int from, int to) {
+      CUDACHECK_TEST(cudaSetDevice(from));
+      auto err = cudaDeviceEnablePeerAccess(to, 0);
+      if (err == cudaErrorPeerAccessAlreadyEnabled) {
+        (void)cudaGetLastError();
+      } else if (err != cudaSuccess) {
+        CUDACHECK_TEST(err);
+      }
+    };
+    enable_peer(kGpu0, kGpu1);
+    enable_peer(kGpu0, kGpu2);
+    enable_peer(kGpu1, kGpu0);
+    enable_peer(kGpu1, kGpu2);
+    enable_peer(kGpu2, kGpu0);
+    enable_peer(kGpu2, kGpu1);
+  }
+
+  void TearDown() override {
+    (void)cudaSetDevice(kGpu0);
+    (void)cudaDeviceSynchronize();
+    (void)cudaSetDevice(kGpu1);
+    (void)cudaDeviceSynchronize();
+    (void)cudaSetDevice(kGpu2);
+    (void)cudaDeviceSynchronize();
+  }
+
+  /// Run a 3-GPU forward test: GPU0 sends, GPU1 forwards, GPU2 receives.
+  void run_forward_3gpu_test(
+      size_t nbytes,
+      int num_blocks = 1,
+      int block_size = 32,
+      size_t buffer_num_lines = 0,
+      int num_steps = 1) {
+    auto pattern = test::make_pattern(nbytes);
+
+    // src on GPU0 (sender)
+    CUDACHECK_TEST(cudaSetDevice(kGpu0));
+    char* src_d;
+    CUDACHECK_TEST(cudaMalloc(&src_d, nbytes));
+    CUDACHECK_TEST(
+        cudaMemcpy(src_d, pattern.data(), nbytes, cudaMemcpyHostToDevice));
+
+    // fwd_dst + buf_a on GPU1 (forwarder)
+    CUDACHECK_TEST(cudaSetDevice(kGpu1));
+    char* fwd_dst_d;
+    CUDACHECK_TEST(cudaMalloc(&fwd_dst_d, nbytes));
+    CUDACHECK_TEST(cudaMemset(fwd_dst_d, 0, nbytes));
+    size_t buf_size = (buffer_num_lines > 0) ? buffer_num_lines * kLlLineSize
+                                             : ll_buffer_size(nbytes);
+    LlLine* ll_buf_a;
+    CUDACHECK_TEST(cudaMalloc(&ll_buf_a, buf_size));
+
+    // recv_dst + buf_b on GPU2 (receiver)
+    CUDACHECK_TEST(cudaSetDevice(kGpu2));
+    char* recv_dst_d;
+    CUDACHECK_TEST(cudaMalloc(&recv_dst_d, nbytes));
+    CUDACHECK_TEST(cudaMemset(recv_dst_d, 0, nbytes));
+    LlLine* ll_buf_b;
+    CUDACHECK_TEST(cudaMalloc(&ll_buf_b, buf_size));
+
+    test::test_ll_nvlink_forward_3gpu(
+        kGpu0,
+        kGpu1,
+        kGpu2,
+        src_d,
+        fwd_dst_d,
+        recv_dst_d,
+        nbytes,
+        ll_buf_a,
+        ll_buf_b,
+        num_blocks,
+        block_size,
+        buffer_num_lines,
+        num_steps);
+
+    // Verify forwarder's local copy
+    std::vector<char> fwd_result(nbytes);
+    CUDACHECK_TEST(cudaSetDevice(kGpu1));
+    CUDACHECK_TEST(cudaMemcpy(
+        fwd_result.data(), fwd_dst_d, nbytes, cudaMemcpyDeviceToHost));
+    for (size_t i = 0; i < nbytes; ++i) {
+      ASSERT_EQ(fwd_result[i], pattern[i])
+          << "3GPU Forward: fwd_dst mismatch at byte " << i;
+    }
+
+    // Verify receiver's output
+    std::vector<char> recv_result(nbytes);
+    CUDACHECK_TEST(cudaSetDevice(kGpu2));
+    CUDACHECK_TEST(cudaMemcpy(
+        recv_result.data(), recv_dst_d, nbytes, cudaMemcpyDeviceToHost));
+    for (size_t i = 0; i < nbytes; ++i) {
+      ASSERT_EQ(recv_result[i], pattern[i])
+          << "3GPU Forward: recv_dst mismatch at byte " << i;
+    }
+
+    // Cleanup
+    CUDACHECK_TEST(cudaSetDevice(kGpu0));
+    CUDACHECK_TEST(cudaFree(src_d));
+    CUDACHECK_TEST(cudaSetDevice(kGpu1));
+    CUDACHECK_TEST(cudaFree(fwd_dst_d));
+    CUDACHECK_TEST(cudaFree(ll_buf_a));
+    CUDACHECK_TEST(cudaSetDevice(kGpu2));
+    CUDACHECK_TEST(cudaFree(recv_dst_d));
+    CUDACHECK_TEST(cudaFree(ll_buf_b));
+  }
+};
+
+// =============================================================================
+// 3-GPU Forward tests — sender ≠ forwarder ≠ receiver
+// =============================================================================
+
+TEST_F(LlOpsNvlink3GpuTestFixture, Forward_4KB_3GPU) {
+  run_forward_3gpu_test(4096);
+}
+
+TEST_F(LlOpsNvlink3GpuTestFixture, Forward_4KB_3GPU_MultiStep_10) {
+  run_forward_3gpu_test(
+      4096,
+      /*num_blocks=*/1,
+      /*block_size=*/32,
+      /*buffer_num_lines=*/0,
+      /*num_steps=*/10);
+}
+
+TEST_F(LlOpsNvlink3GpuTestFixture, Forward_4KB_3GPU_Chunked_64lines) {
+  run_forward_3gpu_test(
+      4096,
+      /*num_blocks=*/1,
+      /*block_size=*/32,
+      /*buffer_num_lines=*/64);
+}
+
+TEST_F(LlOpsNvlink3GpuTestFixture, Forward_64KB_3GPU) {
+  run_forward_3gpu_test(65536);
+}
+
+TEST_F(LlOpsNvlink3GpuTestFixture, Forward_3GPU_Chunked_MultiStep) {
+  run_forward_3gpu_test(
+      4096,
+      /*num_blocks=*/1,
+      /*block_size=*/32,
+      /*buffer_num_lines=*/64,
+      /*num_steps=*/10);
+}
+
+} // namespace comms::pipes

--- a/comms/pipes/ll/tests/LlOpsNvlinkTest.cc
+++ b/comms/pipes/ll/tests/LlOpsNvlinkTest.cc
@@ -1,0 +1,615 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+#include <cstddef>
+#include <string>
+#include <vector>
+
+#include "comms/pipes/ll/LlPacket.cuh"
+#include "comms/pipes/ll/tests/LlOpsNvlinkTest.cuh"
+#include "comms/testinfra/TestXPlatUtils.h"
+
+namespace comms::pipes {
+
+// =============================================================================
+// Test parameters
+// =============================================================================
+
+struct TestParam {
+  std::string name;
+  size_t nbytes;
+  int num_blocks = 1;
+  int block_size = 32;
+  size_t buffer_num_lines = 0;
+  int num_steps = 1;
+};
+
+// =============================================================================
+// Two-GPU Test Fixture for cross-GPU LL ops
+// =============================================================================
+
+class LlOpsNvlinkTestFixture : public ::testing::Test {
+ protected:
+  static constexpr int kGpu0 = 0;
+  static constexpr int kGpu1 = 1;
+
+  void SetUp() override {
+    int deviceCount = 0;
+    CUDACHECK_TEST(cudaGetDeviceCount(&deviceCount));
+    if (deviceCount < 2) {
+      GTEST_SKIP() << "Test requires at least 2 GPUs";
+    }
+
+    int canAccessPeer01 = 0;
+    int canAccessPeer10 = 0;
+    CUDACHECK_TEST(cudaDeviceCanAccessPeer(&canAccessPeer01, kGpu0, kGpu1));
+    CUDACHECK_TEST(cudaDeviceCanAccessPeer(&canAccessPeer10, kGpu1, kGpu0));
+    if (!canAccessPeer01 || !canAccessPeer10) {
+      GTEST_SKIP() << "Test requires P2P access between GPU 0 and GPU 1";
+    }
+
+    // Enable bidirectional P2P access
+    CUDACHECK_TEST(cudaSetDevice(kGpu0));
+    auto err0 = cudaDeviceEnablePeerAccess(kGpu1, 0);
+    if (err0 == cudaErrorPeerAccessAlreadyEnabled) {
+      (void)cudaGetLastError();
+    } else if (err0 != cudaSuccess) {
+      CUDACHECK_TEST(err0);
+    }
+
+    CUDACHECK_TEST(cudaSetDevice(kGpu1));
+    auto err1 = cudaDeviceEnablePeerAccess(kGpu0, 0);
+    if (err1 == cudaErrorPeerAccessAlreadyEnabled) {
+      (void)cudaGetLastError();
+    } else if (err1 != cudaSuccess) {
+      CUDACHECK_TEST(err1);
+    }
+  }
+
+  void TearDown() override {
+    (void)cudaSetDevice(kGpu0);
+    (void)cudaDeviceSynchronize();
+    (void)cudaSetDevice(kGpu1);
+    (void)cudaDeviceSynchronize();
+  }
+
+  /// Run a cross-GPU send/recv test: GPU0 sends, GPU1 receives via NVLink.
+  void run_send_recv_test(
+      size_t nbytes,
+      int num_blocks = 1,
+      int block_size = 32,
+      size_t buffer_num_lines = 0,
+      int num_steps = 1,
+      int seed = 0) {
+    auto pattern = test::make_pattern(nbytes, seed);
+
+    // Allocate src on GPU0
+    CUDACHECK_TEST(cudaSetDevice(kGpu0));
+    char* src_d;
+    CUDACHECK_TEST(cudaMalloc(&src_d, nbytes));
+    CUDACHECK_TEST(
+        cudaMemcpy(src_d, pattern.data(), nbytes, cudaMemcpyHostToDevice));
+
+    // Allocate dst + LL buffer on GPU1
+    CUDACHECK_TEST(cudaSetDevice(kGpu1));
+    char* dst_d;
+    CUDACHECK_TEST(cudaMalloc(&dst_d, nbytes));
+    CUDACHECK_TEST(cudaMemset(dst_d, 0, nbytes));
+
+    size_t buf_size = (buffer_num_lines > 0) ? buffer_num_lines * kLlLineSize
+                                             : ll_buffer_size(nbytes);
+    LlLine* ll_buf;
+    CUDACHECK_TEST(cudaMalloc(&ll_buf, buf_size));
+
+    // Run test
+    test::test_ll_nvlink_send_recv(
+        kGpu0,
+        kGpu1,
+        src_d,
+        dst_d,
+        nbytes,
+        ll_buf,
+        buffer_num_lines,
+        num_steps,
+        num_blocks,
+        block_size);
+
+    // Verify
+    std::vector<char> result(nbytes);
+    CUDACHECK_TEST(
+        cudaMemcpy(result.data(), dst_d, nbytes, cudaMemcpyDeviceToHost));
+    for (size_t i = 0; i < nbytes; ++i) {
+      ASSERT_EQ(result[i], pattern[i]) << "Mismatch at byte " << i;
+    }
+
+    // Cleanup
+    CUDACHECK_TEST(cudaSetDevice(kGpu0));
+    CUDACHECK_TEST(cudaFree(src_d));
+    CUDACHECK_TEST(cudaSetDevice(kGpu1));
+    CUDACHECK_TEST(cudaFree(dst_d));
+    CUDACHECK_TEST(cudaFree(ll_buf));
+  }
+
+  /// Run a 3-role forward test: GPU0→GPU1(forward)→GPU0.
+  void run_forward_test(
+      size_t nbytes,
+      int num_blocks = 1,
+      int block_size = 32,
+      size_t buffer_num_lines = 0,
+      int num_steps = 1) {
+    auto pattern = test::make_pattern(nbytes);
+
+    // src on GPU0
+    CUDACHECK_TEST(cudaSetDevice(kGpu0));
+    char* src_d;
+    CUDACHECK_TEST(cudaMalloc(&src_d, nbytes));
+    CUDACHECK_TEST(
+        cudaMemcpy(src_d, pattern.data(), nbytes, cudaMemcpyHostToDevice));
+
+    // fwd_dst + buf_a on GPU1 (forwarder)
+    CUDACHECK_TEST(cudaSetDevice(kGpu1));
+    char* fwd_dst_d;
+    CUDACHECK_TEST(cudaMalloc(&fwd_dst_d, nbytes));
+    CUDACHECK_TEST(cudaMemset(fwd_dst_d, 0, nbytes));
+    size_t buf_size = (buffer_num_lines > 0) ? buffer_num_lines * kLlLineSize
+                                             : ll_buffer_size(nbytes);
+    LlLine* ll_buf_a;
+    CUDACHECK_TEST(cudaMalloc(&ll_buf_a, buf_size));
+
+    // recv_dst + buf_b on GPU0 (receiver = sender GPU)
+    CUDACHECK_TEST(cudaSetDevice(kGpu0));
+    char* recv_dst_d;
+    CUDACHECK_TEST(cudaMalloc(&recv_dst_d, nbytes));
+    CUDACHECK_TEST(cudaMemset(recv_dst_d, 0, nbytes));
+    LlLine* ll_buf_b;
+    CUDACHECK_TEST(cudaMalloc(&ll_buf_b, buf_size));
+
+    test::test_ll_nvlink_forward(
+        kGpu0,
+        kGpu1,
+        kGpu0,
+        src_d,
+        fwd_dst_d,
+        recv_dst_d,
+        nbytes,
+        ll_buf_a,
+        ll_buf_b,
+        num_blocks,
+        block_size,
+        buffer_num_lines,
+        num_steps);
+
+    // Verify forwarder's local copy
+    std::vector<char> fwd_result(nbytes);
+    CUDACHECK_TEST(cudaSetDevice(kGpu1));
+    CUDACHECK_TEST(cudaMemcpy(
+        fwd_result.data(), fwd_dst_d, nbytes, cudaMemcpyDeviceToHost));
+    for (size_t i = 0; i < nbytes; ++i) {
+      ASSERT_EQ(fwd_result[i], pattern[i])
+          << "Forward: fwd_dst mismatch at byte " << i;
+    }
+
+    // Verify receiver's output
+    std::vector<char> recv_result(nbytes);
+    CUDACHECK_TEST(cudaSetDevice(kGpu0));
+    CUDACHECK_TEST(cudaMemcpy(
+        recv_result.data(), recv_dst_d, nbytes, cudaMemcpyDeviceToHost));
+    for (size_t i = 0; i < nbytes; ++i) {
+      ASSERT_EQ(recv_result[i], pattern[i])
+          << "Forward: recv_dst mismatch at byte " << i;
+    }
+
+    // Cleanup
+    CUDACHECK_TEST(cudaSetDevice(kGpu0));
+    CUDACHECK_TEST(cudaFree(src_d));
+    CUDACHECK_TEST(cudaFree(recv_dst_d));
+    CUDACHECK_TEST(cudaFree(ll_buf_b));
+    CUDACHECK_TEST(cudaSetDevice(kGpu1));
+    CUDACHECK_TEST(cudaFree(fwd_dst_d));
+    CUDACHECK_TEST(cudaFree(ll_buf_a));
+  }
+
+  /// Run a bidirectional test: GPU0↔GPU1 simultaneous send/recv.
+  void run_bidirectional_test(
+      size_t nbytes,
+      int num_blocks = 1,
+      int block_size = 32,
+      size_t buffer_num_lines = 0,
+      int num_steps = 1) {
+    auto pattern0 = test::make_pattern(nbytes, /*seed=*/0);
+    auto pattern1 = test::make_pattern(nbytes, /*seed=*/42);
+
+    // GPU0: src0, dst0, ll_buf_on_gpu0
+    CUDACHECK_TEST(cudaSetDevice(kGpu0));
+    char* src0_d;
+    CUDACHECK_TEST(cudaMalloc(&src0_d, nbytes));
+    CUDACHECK_TEST(
+        cudaMemcpy(src0_d, pattern0.data(), nbytes, cudaMemcpyHostToDevice));
+    char* dst0_d;
+    CUDACHECK_TEST(cudaMalloc(&dst0_d, nbytes));
+    CUDACHECK_TEST(cudaMemset(dst0_d, 0, nbytes));
+    size_t buf_size = (buffer_num_lines > 0) ? buffer_num_lines * kLlLineSize
+                                             : ll_buffer_size(nbytes);
+    LlLine* ll_buf_on_gpu0;
+    CUDACHECK_TEST(cudaMalloc(&ll_buf_on_gpu0, buf_size));
+
+    // GPU1: src1, dst1, ll_buf_on_gpu1
+    CUDACHECK_TEST(cudaSetDevice(kGpu1));
+    char* src1_d;
+    CUDACHECK_TEST(cudaMalloc(&src1_d, nbytes));
+    CUDACHECK_TEST(
+        cudaMemcpy(src1_d, pattern1.data(), nbytes, cudaMemcpyHostToDevice));
+    char* dst1_d;
+    CUDACHECK_TEST(cudaMalloc(&dst1_d, nbytes));
+    CUDACHECK_TEST(cudaMemset(dst1_d, 0, nbytes));
+    LlLine* ll_buf_on_gpu1;
+    CUDACHECK_TEST(cudaMalloc(&ll_buf_on_gpu1, buf_size));
+
+    test::test_ll_nvlink_bidirectional(
+        src0_d,
+        dst0_d,
+        src1_d,
+        dst1_d,
+        nbytes,
+        ll_buf_on_gpu0,
+        ll_buf_on_gpu1,
+        num_blocks,
+        block_size,
+        buffer_num_lines,
+        num_steps);
+
+    // Verify GPU0->GPU1
+    std::vector<char> result1(nbytes);
+    CUDACHECK_TEST(cudaSetDevice(kGpu1));
+    CUDACHECK_TEST(
+        cudaMemcpy(result1.data(), dst1_d, nbytes, cudaMemcpyDeviceToHost));
+    for (size_t i = 0; i < nbytes; ++i) {
+      ASSERT_EQ(result1[i], pattern0[i])
+          << "Bidirectional GPU0->GPU1: mismatch at byte " << i;
+    }
+
+    // Verify GPU1->GPU0
+    std::vector<char> result0(nbytes);
+    CUDACHECK_TEST(cudaSetDevice(kGpu0));
+    CUDACHECK_TEST(
+        cudaMemcpy(result0.data(), dst0_d, nbytes, cudaMemcpyDeviceToHost));
+    for (size_t i = 0; i < nbytes; ++i) {
+      ASSERT_EQ(result0[i], pattern1[i])
+          << "Bidirectional GPU1->GPU0: mismatch at byte " << i;
+    }
+
+    // Cleanup
+    CUDACHECK_TEST(cudaSetDevice(kGpu0));
+    CUDACHECK_TEST(cudaFree(src0_d));
+    CUDACHECK_TEST(cudaFree(dst0_d));
+    CUDACHECK_TEST(cudaFree(ll_buf_on_gpu0));
+    CUDACHECK_TEST(cudaSetDevice(kGpu1));
+    CUDACHECK_TEST(cudaFree(src1_d));
+    CUDACHECK_TEST(cudaFree(dst1_d));
+    CUDACHECK_TEST(cudaFree(ll_buf_on_gpu1));
+  }
+};
+
+// =============================================================================
+// SendRecv — parameterized suite
+// =============================================================================
+
+class LlOpsNvlinkSendRecvTest
+    : public LlOpsNvlinkTestFixture,
+      public ::testing::WithParamInterface<TestParam> {};
+
+TEST_P(LlOpsNvlinkSendRecvTest, SendRecv) {
+  const auto& p = GetParam();
+  run_send_recv_test(
+      p.nbytes, p.num_blocks, p.block_size, p.buffer_num_lines, p.num_steps);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    LlNvlinkSendRecv,
+    LlOpsNvlinkSendRecvTest,
+    ::testing::Values(
+        // Sub-line and boundary sizes (LL uses 8-byte granularity)
+        TestParam{"8B", 8},
+        TestParam{"64B", 64},
+        TestParam{"128B", 128},
+        TestParam{"512B", 512},
+        // Standard sizes
+        TestParam{"4KB", 4096},
+        TestParam{"64KB", 65536},
+        TestParam{"256KB", 256 * 1024},
+        // Edge case
+        TestParam{"ZeroBytes", 0},
+        // Multi-step (buffer reuse / ABA prevention)
+        TestParam{"MultiStep_10", 4096, 1, 32, 0, 10},
+        TestParam{"MultiStep_ABA_100", 4096, 1, 32, 0, 100},
+        // Chunked (windowed buffer)
+        TestParam{"Chunked_4KB_64lines", 4096, 1, 32, 64},
+        TestParam{"Chunked_MultiStep_10", 4096, 1, 32, 64, 10},
+        TestParam{"Chunked_64KB_64lines", 65536, 1, 32, 64},
+        TestParam{"Chunked_256KB_64lines", 256 * 1024, 1, 32, 64},
+        // Windowed mode with smaller buffers
+        TestParam{"Windowed_4KB_32lines", 4096, 1, 32, 32},
+        TestParam{"Windowed_64KB_128lines", 65536, 1, 32, 128}),
+    [](const auto& info) { return info.param.name; });
+
+// =============================================================================
+// SendRecv — stress tests
+// =============================================================================
+
+TEST_F(LlOpsNvlinkTestFixture, SendRecv_Stress_50) {
+  constexpr int kStressIterations = 50;
+  const size_t nbytes = 4096;
+
+  // Allocate once, reuse across iterations
+  CUDACHECK_TEST(cudaSetDevice(kGpu0));
+  char* src_d;
+  CUDACHECK_TEST(cudaMalloc(&src_d, nbytes));
+
+  CUDACHECK_TEST(cudaSetDevice(kGpu1));
+  char* dst_d;
+  CUDACHECK_TEST(cudaMalloc(&dst_d, nbytes));
+  size_t buf_size = ll_buffer_size(nbytes);
+  LlLine* ll_buf;
+  CUDACHECK_TEST(cudaMalloc(&ll_buf, buf_size));
+
+  for (int iter = 0; iter < kStressIterations; ++iter) {
+    auto pattern = test::make_pattern(nbytes, /*seed=*/iter);
+
+    CUDACHECK_TEST(cudaSetDevice(kGpu0));
+    CUDACHECK_TEST(
+        cudaMemcpy(src_d, pattern.data(), nbytes, cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(cudaSetDevice(kGpu1));
+    CUDACHECK_TEST(cudaMemset(dst_d, 0, nbytes));
+
+    test::test_ll_nvlink_send_recv(
+        kGpu0,
+        kGpu1,
+        src_d,
+        dst_d,
+        nbytes,
+        ll_buf,
+        /*buffer_num_lines=*/0,
+        /*num_steps=*/1,
+        /*num_blocks=*/1,
+        /*block_size=*/32);
+
+    std::vector<char> result(nbytes);
+    CUDACHECK_TEST(
+        cudaMemcpy(result.data(), dst_d, nbytes, cudaMemcpyDeviceToHost));
+    for (size_t i = 0; i < nbytes; ++i) {
+      ASSERT_EQ(result[i], pattern[i])
+          << "Stress iter " << iter << ": mismatch at byte " << i;
+    }
+  }
+
+  CUDACHECK_TEST(cudaSetDevice(kGpu0));
+  CUDACHECK_TEST(cudaFree(src_d));
+  CUDACHECK_TEST(cudaSetDevice(kGpu1));
+  CUDACHECK_TEST(cudaFree(dst_d));
+  CUDACHECK_TEST(cudaFree(ll_buf));
+}
+
+TEST_F(LlOpsNvlinkTestFixture, SendRecv_Chunked_Stress_50) {
+  constexpr int kStressIterations = 50;
+  const size_t nbytes = 4096;
+  const size_t buffer_num_lines = 64;
+
+  CUDACHECK_TEST(cudaSetDevice(kGpu0));
+  char* src_d;
+  CUDACHECK_TEST(cudaMalloc(&src_d, nbytes));
+
+  CUDACHECK_TEST(cudaSetDevice(kGpu1));
+  char* dst_d;
+  CUDACHECK_TEST(cudaMalloc(&dst_d, nbytes));
+  size_t buf_size = buffer_num_lines * kLlLineSize;
+  LlLine* ll_buf;
+  CUDACHECK_TEST(cudaMalloc(&ll_buf, buf_size));
+
+  for (int iter = 0; iter < kStressIterations; ++iter) {
+    auto pattern = test::make_pattern(nbytes, /*seed=*/iter);
+
+    CUDACHECK_TEST(cudaSetDevice(kGpu0));
+    CUDACHECK_TEST(
+        cudaMemcpy(src_d, pattern.data(), nbytes, cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(cudaSetDevice(kGpu1));
+    CUDACHECK_TEST(cudaMemset(dst_d, 0, nbytes));
+
+    test::test_ll_nvlink_send_recv(
+        kGpu0,
+        kGpu1,
+        src_d,
+        dst_d,
+        nbytes,
+        ll_buf,
+        buffer_num_lines,
+        /*num_steps=*/1,
+        /*num_blocks=*/1,
+        /*block_size=*/32);
+
+    std::vector<char> result(nbytes);
+    CUDACHECK_TEST(
+        cudaMemcpy(result.data(), dst_d, nbytes, cudaMemcpyDeviceToHost));
+    for (size_t i = 0; i < nbytes; ++i) {
+      ASSERT_EQ(result[i], pattern[i])
+          << "Chunked stress iter " << iter << ": mismatch at byte " << i;
+    }
+  }
+
+  CUDACHECK_TEST(cudaSetDevice(kGpu0));
+  CUDACHECK_TEST(cudaFree(src_d));
+  CUDACHECK_TEST(cudaSetDevice(kGpu1));
+  CUDACHECK_TEST(cudaFree(dst_d));
+  CUDACHECK_TEST(cudaFree(ll_buf));
+}
+
+// =============================================================================
+// SendRecv — varying-data multi-step
+// =============================================================================
+
+TEST_F(LlOpsNvlinkTestFixture, SendRecv_VaryingData_MultiStep) {
+  const size_t nbytes = 4096;
+  const int num_steps = 10;
+  const size_t total_bytes = num_steps * nbytes;
+
+  // Build per-step patterns
+  std::vector<char> src_host(total_bytes);
+  for (int step = 0; step < num_steps; ++step) {
+    for (size_t i = 0; i < nbytes; ++i) {
+      src_host[step * nbytes + i] = static_cast<char>((i + step * 37) & 0xFF);
+    }
+  }
+
+  // Allocate src on GPU0
+  CUDACHECK_TEST(cudaSetDevice(kGpu0));
+  char* src_d;
+  CUDACHECK_TEST(cudaMalloc(&src_d, total_bytes));
+  CUDACHECK_TEST(
+      cudaMemcpy(src_d, src_host.data(), total_bytes, cudaMemcpyHostToDevice));
+
+  // Allocate dst + LL buffer on GPU1
+  CUDACHECK_TEST(cudaSetDevice(kGpu1));
+  char* dst_d;
+  CUDACHECK_TEST(cudaMalloc(&dst_d, total_bytes));
+  CUDACHECK_TEST(cudaMemset(dst_d, 0, total_bytes));
+  size_t buf_size = ll_buffer_size(nbytes);
+  LlLine* ll_buf;
+  CUDACHECK_TEST(cudaMalloc(&ll_buf, buf_size));
+
+  test::test_ll_nvlink_varying_send_recv(
+      kGpu0,
+      kGpu1,
+      src_d,
+      dst_d,
+      nbytes,
+      ll_buf,
+      /*buffer_num_lines=*/0,
+      num_steps,
+      /*num_blocks=*/1,
+      /*block_size=*/32);
+
+  std::vector<char> result(total_bytes);
+  CUDACHECK_TEST(
+      cudaMemcpy(result.data(), dst_d, total_bytes, cudaMemcpyDeviceToHost));
+  for (int step = 0; step < num_steps; ++step) {
+    for (size_t i = 0; i < nbytes; ++i) {
+      ASSERT_EQ(result[step * nbytes + i], src_host[step * nbytes + i])
+          << "VaryingData NVLink step " << step << ": mismatch at byte " << i;
+    }
+  }
+
+  CUDACHECK_TEST(cudaSetDevice(kGpu0));
+  CUDACHECK_TEST(cudaFree(src_d));
+  CUDACHECK_TEST(cudaSetDevice(kGpu1));
+  CUDACHECK_TEST(cudaFree(dst_d));
+  CUDACHECK_TEST(cudaFree(ll_buf));
+}
+
+TEST_F(LlOpsNvlinkTestFixture, SendRecv_VaryingData_MultiStep_Chunked) {
+  const size_t nbytes = 4096;
+  const int num_steps = 10;
+  const size_t buffer_num_lines = 64;
+  const size_t total_bytes = num_steps * nbytes;
+
+  std::vector<char> src_host(total_bytes);
+  for (int step = 0; step < num_steps; ++step) {
+    for (size_t i = 0; i < nbytes; ++i) {
+      src_host[step * nbytes + i] = static_cast<char>((i + step * 37) & 0xFF);
+    }
+  }
+
+  CUDACHECK_TEST(cudaSetDevice(kGpu0));
+  char* src_d;
+  CUDACHECK_TEST(cudaMalloc(&src_d, total_bytes));
+  CUDACHECK_TEST(
+      cudaMemcpy(src_d, src_host.data(), total_bytes, cudaMemcpyHostToDevice));
+
+  CUDACHECK_TEST(cudaSetDevice(kGpu1));
+  char* dst_d;
+  CUDACHECK_TEST(cudaMalloc(&dst_d, total_bytes));
+  CUDACHECK_TEST(cudaMemset(dst_d, 0, total_bytes));
+  size_t buf_size = buffer_num_lines * kLlLineSize;
+  LlLine* ll_buf;
+  CUDACHECK_TEST(cudaMalloc(&ll_buf, buf_size));
+
+  test::test_ll_nvlink_varying_send_recv(
+      kGpu0,
+      kGpu1,
+      src_d,
+      dst_d,
+      nbytes,
+      ll_buf,
+      buffer_num_lines,
+      num_steps,
+      /*num_blocks=*/1,
+      /*block_size=*/32);
+
+  std::vector<char> result(total_bytes);
+  CUDACHECK_TEST(
+      cudaMemcpy(result.data(), dst_d, total_bytes, cudaMemcpyDeviceToHost));
+  for (int step = 0; step < num_steps; ++step) {
+    for (size_t i = 0; i < nbytes; ++i) {
+      ASSERT_EQ(result[step * nbytes + i], src_host[step * nbytes + i])
+          << "VaryingData chunked NVLink step " << step << ": mismatch at byte "
+          << i;
+    }
+  }
+
+  CUDACHECK_TEST(cudaSetDevice(kGpu0));
+  CUDACHECK_TEST(cudaFree(src_d));
+  CUDACHECK_TEST(cudaSetDevice(kGpu1));
+  CUDACHECK_TEST(cudaFree(dst_d));
+  CUDACHECK_TEST(cudaFree(ll_buf));
+}
+
+// =============================================================================
+// Forward — parameterized suite
+// =============================================================================
+
+class LlOpsNvlinkForwardTest : public LlOpsNvlinkTestFixture,
+                               public ::testing::WithParamInterface<TestParam> {
+};
+
+TEST_P(LlOpsNvlinkForwardTest, Forward) {
+  const auto& p = GetParam();
+  run_forward_test(
+      p.nbytes, p.num_blocks, p.block_size, p.buffer_num_lines, p.num_steps);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    LlNvlinkForward,
+    LlOpsNvlinkForwardTest,
+    ::testing::Values(
+        TestParam{"4KB", 4096},
+        TestParam{"4KB_MultiStep_10", 4096, 1, 32, 0, 10},
+        TestParam{"64KB", 65536},
+        TestParam{"4KB_Chunked_64lines", 4096, 1, 32, 64},
+        TestParam{"4KB_Chunked_64lines_MultiStep_10", 4096, 1, 32, 64, 10},
+        TestParam{"Chunked_MultiStep", 65536, 1, 32, 64, 10}),
+    [](const auto& info) { return info.param.name; });
+
+// =============================================================================
+// Bidirectional — parameterized suite
+// =============================================================================
+
+class LlOpsNvlinkBidirectionalTest
+    : public LlOpsNvlinkTestFixture,
+      public ::testing::WithParamInterface<TestParam> {};
+
+TEST_P(LlOpsNvlinkBidirectionalTest, Bidirectional) {
+  const auto& p = GetParam();
+  run_bidirectional_test(
+      p.nbytes, p.num_blocks, p.block_size, p.buffer_num_lines, p.num_steps);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    LlNvlinkBidirectional,
+    LlOpsNvlinkBidirectionalTest,
+    ::testing::Values(
+        TestParam{"4KB", 4096},
+        TestParam{"Chunked_4KB_64lines", 4096, 1, 32, 64},
+        TestParam{"Chunked_MultiStep_10", 4096, 1, 32, 64, 10},
+        TestParam{"MultiStep_10", 4096, 1, 32, 0, 10}),
+    [](const auto& info) { return info.param.name; });
+
+} // namespace comms::pipes

--- a/comms/pipes/ll/tests/LlOpsNvlinkTest.cu
+++ b/comms/pipes/ll/tests/LlOpsNvlinkTest.cu
@@ -1,0 +1,436 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <cstddef>
+
+#include "comms/pipes/ThreadGroup.cuh"
+#include "comms/pipes/Timeout.cuh"
+#include "comms/pipes/ll/LlOps.cuh"
+#include "comms/pipes/ll/LlPacket.cuh"
+#include "comms/pipes/ll/tests/LlOpsNvlinkTest.cuh"
+#include "comms/pipes/tests/Checks.h"
+
+namespace comms::pipes::test {
+
+using namespace comms::pipes;
+
+// =============================================================================
+// Kernels — consolidated send/recv/forward for cross-GPU tests
+// =============================================================================
+
+__global__ void ll_nvlink_send_kernel(
+    const char* src,
+    size_t nbytes,
+    LlLine* remote_ll_buf,
+    size_t buffer_num_lines,
+    int num_steps) {
+  auto group = make_warp_group();
+  Timeout timeout;
+  timeout.start();
+  for (int i = 0; i < num_steps; i++) {
+    ll_send(group, src, nbytes, remote_ll_buf, timeout, buffer_num_lines);
+  }
+}
+
+__global__ void ll_nvlink_recv_kernel(
+    char* dst,
+    size_t nbytes,
+    LlLine* local_ll_buf,
+    size_t buffer_num_lines,
+    int num_steps) {
+  auto group = make_warp_group();
+  Timeout timeout;
+  timeout.start();
+  for (int i = 0; i < num_steps; i++) {
+    ll_recv(group, dst, nbytes, local_ll_buf, timeout, buffer_num_lines);
+  }
+}
+
+__global__ void ll_nvlink_forward_kernel(
+    char* fwd_dst,
+    size_t nbytes,
+    LlLine* local_ll_buf,
+    LlLine* remote_ll_buf,
+    size_t buffer_num_lines,
+    int num_steps) {
+  auto group = make_warp_group();
+  Timeout timeout;
+  timeout.start();
+  for (int i = 0; i < num_steps; i++) {
+    ll_forward(
+        group,
+        fwd_dst,
+        nbytes,
+        local_ll_buf,
+        remote_ll_buf,
+        timeout,
+        buffer_num_lines);
+  }
+}
+
+// =============================================================================
+// Combined send+recv kernel for forward tests.
+// When sender and receiver share the same GPU, separate kernels on different
+// streams may not be scheduled concurrently, causing deadlock when buffer
+// reuse requires the receiver to ACK before the forwarder/sender can proceed.
+// partition_interleaved(2) guarantees both roles execute concurrently.
+// =============================================================================
+
+__global__ void ll_nvlink_send_recv_kernel(
+    const char* src,
+    char* dst,
+    size_t nbytes,
+    LlLine* remote_send_buf,
+    LlLine* local_recv_buf,
+    size_t buffer_num_lines,
+    int num_steps) {
+  auto group = make_warp_group();
+  auto [partition_id, subgroup] = group.partition_interleaved(2);
+  Timeout timeout;
+  timeout.start();
+  if (partition_id == 0) {
+    for (int i = 0; i < num_steps; i++) {
+      ll_send(
+          subgroup, src, nbytes, remote_send_buf, timeout, buffer_num_lines);
+    }
+  } else {
+    for (int i = 0; i < num_steps; i++) {
+      ll_recv(subgroup, dst, nbytes, local_recv_buf, timeout, buffer_num_lines);
+    }
+  }
+}
+
+// =============================================================================
+// Host-callable wrappers
+// =============================================================================
+
+void test_ll_nvlink_send_recv(
+    int sender_gpu,
+    int receiver_gpu,
+    const char* src_d,
+    char* dst_d,
+    size_t nbytes,
+    LlLine* ll_buf,
+    size_t buffer_num_lines,
+    int num_steps,
+    int num_blocks,
+    int block_size) {
+  // Compute buffer size and init LL buffer on receiver GPU
+  size_t buf_size = (buffer_num_lines > 0) ? buffer_num_lines * kLlLineSize
+                                           : ll_buffer_size(nbytes);
+  PIPES_CUDA_CHECK(cudaSetDevice(receiver_gpu));
+  PIPES_CUDA_CHECK(cudaMemset(ll_buf, kLlMemsetInitByte, buf_size));
+  PIPES_CUDA_CHECK(cudaDeviceSynchronize());
+
+  // Launch sender on sender_gpu
+  cudaStream_t send_stream;
+  PIPES_CUDA_CHECK(cudaSetDevice(sender_gpu));
+  PIPES_CUDA_CHECK(cudaStreamCreate(&send_stream));
+  ll_nvlink_send_kernel<<<num_blocks, block_size, 0, send_stream>>>(
+      src_d, nbytes, ll_buf, buffer_num_lines, num_steps);
+  PIPES_KERNEL_LAUNCH_CHECK();
+
+  // Launch receiver on receiver_gpu
+  cudaStream_t recv_stream;
+  PIPES_CUDA_CHECK(cudaSetDevice(receiver_gpu));
+  PIPES_CUDA_CHECK(cudaStreamCreate(&recv_stream));
+  ll_nvlink_recv_kernel<<<num_blocks, block_size, 0, recv_stream>>>(
+      dst_d, nbytes, ll_buf, buffer_num_lines, num_steps);
+  PIPES_KERNEL_LAUNCH_CHECK();
+
+  // Wait for both to complete
+  PIPES_CUDA_CHECK(cudaSetDevice(sender_gpu));
+  PIPES_CUDA_CHECK(cudaStreamSynchronize(send_stream));
+  PIPES_CUDA_CHECK(cudaStreamDestroy(send_stream));
+  PIPES_CUDA_CHECK(cudaSetDevice(receiver_gpu));
+  PIPES_CUDA_CHECK(cudaStreamSynchronize(recv_stream));
+  PIPES_CUDA_CHECK(cudaStreamDestroy(recv_stream));
+}
+
+void test_ll_nvlink_forward(
+    int sender_gpu,
+    int forwarder_gpu,
+    int receiver_gpu,
+    const char* src_d,
+    char* fwd_dst_d,
+    char* recv_dst_d,
+    size_t nbytes,
+    LlLine* ll_buf_a,
+    LlLine* ll_buf_b,
+    int num_blocks,
+    int block_size,
+    size_t buffer_num_lines,
+    int num_steps) {
+  // The combined send+recv kernel requires sender and receiver on the same GPU.
+  PIPES_CUDA_CHECK(
+      sender_gpu == receiver_gpu ? cudaSuccess : cudaErrorInvalidValue);
+
+  size_t buf_size = (buffer_num_lines > 0) ? buffer_num_lines * kLlLineSize
+                                           : ll_buffer_size(nbytes);
+
+  // Init both LL buffers on their respective GPUs
+  PIPES_CUDA_CHECK(cudaSetDevice(forwarder_gpu));
+  PIPES_CUDA_CHECK(cudaMemset(ll_buf_a, kLlMemsetInitByte, buf_size));
+  PIPES_CUDA_CHECK(cudaDeviceSynchronize());
+
+  PIPES_CUDA_CHECK(cudaSetDevice(receiver_gpu));
+  PIPES_CUDA_CHECK(cudaMemset(ll_buf_b, kLlMemsetInitByte, buf_size));
+  PIPES_CUDA_CHECK(cudaDeviceSynchronize());
+
+  // Combined sender+receiver on sender_gpu.
+  // Uses partition_interleaved(2): needs 2x blocks so each role gets
+  // num_blocks effective warps.
+  cudaStream_t send_recv_stream;
+  PIPES_CUDA_CHECK(cudaSetDevice(sender_gpu));
+  PIPES_CUDA_CHECK(cudaStreamCreate(&send_recv_stream));
+  ll_nvlink_send_recv_kernel<<<
+      2 * num_blocks,
+      block_size,
+      0,
+      send_recv_stream>>>(
+      src_d,
+      recv_dst_d,
+      nbytes,
+      ll_buf_a,
+      ll_buf_b,
+      buffer_num_lines,
+      num_steps);
+  PIPES_KERNEL_LAUNCH_CHECK();
+
+  // Forwarder on forwarder_gpu: reads local buf_a, writes buf_b on
+  // receiver_gpu via NVLink, copies to fwd_dst
+  cudaStream_t fwd_stream;
+  PIPES_CUDA_CHECK(cudaSetDevice(forwarder_gpu));
+  PIPES_CUDA_CHECK(cudaStreamCreate(&fwd_stream));
+  ll_nvlink_forward_kernel<<<num_blocks, block_size, 0, fwd_stream>>>(
+      fwd_dst_d, nbytes, ll_buf_a, ll_buf_b, buffer_num_lines, num_steps);
+  PIPES_KERNEL_LAUNCH_CHECK();
+
+  // Wait for both to complete
+  PIPES_CUDA_CHECK(cudaSetDevice(sender_gpu));
+  PIPES_CUDA_CHECK(cudaStreamSynchronize(send_recv_stream));
+  PIPES_CUDA_CHECK(cudaStreamDestroy(send_recv_stream));
+  PIPES_CUDA_CHECK(cudaSetDevice(forwarder_gpu));
+  PIPES_CUDA_CHECK(cudaStreamSynchronize(fwd_stream));
+  PIPES_CUDA_CHECK(cudaStreamDestroy(fwd_stream));
+}
+
+void test_ll_nvlink_bidirectional(
+    const char* src0_d,
+    char* dst0_d,
+    const char* src1_d,
+    char* dst1_d,
+    size_t nbytes,
+    LlLine* ll_buf_on_gpu0,
+    LlLine* ll_buf_on_gpu1,
+    int num_blocks,
+    int block_size,
+    size_t buffer_num_lines,
+    int num_steps) {
+  size_t buf_size = (buffer_num_lines > 0) ? buffer_num_lines * kLlLineSize
+                                           : ll_buffer_size(nbytes);
+
+  // Init both buffers
+  PIPES_CUDA_CHECK(cudaSetDevice(0));
+  PIPES_CUDA_CHECK(cudaMemset(ll_buf_on_gpu0, kLlMemsetInitByte, buf_size));
+  PIPES_CUDA_CHECK(cudaDeviceSynchronize());
+  PIPES_CUDA_CHECK(cudaSetDevice(1));
+  PIPES_CUDA_CHECK(cudaMemset(ll_buf_on_gpu1, kLlMemsetInitByte, buf_size));
+  PIPES_CUDA_CHECK(cudaDeviceSynchronize());
+
+  // Stream A (GPU0): send src0 → ll_buf_on_gpu1
+  cudaStream_t stream_a;
+  PIPES_CUDA_CHECK(cudaSetDevice(0));
+  PIPES_CUDA_CHECK(cudaStreamCreate(&stream_a));
+  ll_nvlink_send_kernel<<<num_blocks, block_size, 0, stream_a>>>(
+      src0_d, nbytes, ll_buf_on_gpu1, buffer_num_lines, num_steps);
+  PIPES_KERNEL_LAUNCH_CHECK();
+
+  // Stream B (GPU1): recv from ll_buf_on_gpu1 → dst1
+  cudaStream_t stream_b;
+  PIPES_CUDA_CHECK(cudaSetDevice(1));
+  PIPES_CUDA_CHECK(cudaStreamCreate(&stream_b));
+  ll_nvlink_recv_kernel<<<num_blocks, block_size, 0, stream_b>>>(
+      dst1_d, nbytes, ll_buf_on_gpu1, buffer_num_lines, num_steps);
+  PIPES_KERNEL_LAUNCH_CHECK();
+
+  // Stream C (GPU1): send src1 → ll_buf_on_gpu0
+  cudaStream_t stream_c;
+  PIPES_CUDA_CHECK(cudaSetDevice(1));
+  PIPES_CUDA_CHECK(cudaStreamCreate(&stream_c));
+  ll_nvlink_send_kernel<<<num_blocks, block_size, 0, stream_c>>>(
+      src1_d, nbytes, ll_buf_on_gpu0, buffer_num_lines, num_steps);
+  PIPES_KERNEL_LAUNCH_CHECK();
+
+  // Stream D (GPU0): recv from ll_buf_on_gpu0 → dst0
+  cudaStream_t stream_d;
+  PIPES_CUDA_CHECK(cudaSetDevice(0));
+  PIPES_CUDA_CHECK(cudaStreamCreate(&stream_d));
+  ll_nvlink_recv_kernel<<<num_blocks, block_size, 0, stream_d>>>(
+      dst0_d, nbytes, ll_buf_on_gpu0, buffer_num_lines, num_steps);
+  PIPES_KERNEL_LAUNCH_CHECK();
+
+  // Synchronize all streams
+  PIPES_CUDA_CHECK(cudaSetDevice(0));
+  PIPES_CUDA_CHECK(cudaStreamSynchronize(stream_a));
+  PIPES_CUDA_CHECK(cudaStreamDestroy(stream_a));
+  PIPES_CUDA_CHECK(cudaStreamSynchronize(stream_d));
+  PIPES_CUDA_CHECK(cudaStreamDestroy(stream_d));
+  PIPES_CUDA_CHECK(cudaSetDevice(1));
+  PIPES_CUDA_CHECK(cudaStreamSynchronize(stream_b));
+  PIPES_CUDA_CHECK(cudaStreamDestroy(stream_b));
+  PIPES_CUDA_CHECK(cudaStreamSynchronize(stream_c));
+  PIPES_CUDA_CHECK(cudaStreamDestroy(stream_c));
+}
+
+void test_ll_nvlink_forward_3gpu(
+    int sender_gpu,
+    int forwarder_gpu,
+    int receiver_gpu,
+    const char* src_d,
+    char* fwd_dst_d,
+    char* recv_dst_d,
+    size_t nbytes,
+    LlLine* ll_buf_a,
+    LlLine* ll_buf_b,
+    int num_blocks,
+    int block_size,
+    size_t buffer_num_lines,
+    int num_steps) {
+  size_t buf_size = (buffer_num_lines > 0) ? buffer_num_lines * kLlLineSize
+                                           : ll_buffer_size(nbytes);
+
+  // Init both LL buffers on their respective GPUs
+  PIPES_CUDA_CHECK(cudaSetDevice(forwarder_gpu));
+  PIPES_CUDA_CHECK(cudaMemset(ll_buf_a, kLlMemsetInitByte, buf_size));
+  PIPES_CUDA_CHECK(cudaDeviceSynchronize());
+
+  PIPES_CUDA_CHECK(cudaSetDevice(receiver_gpu));
+  PIPES_CUDA_CHECK(cudaMemset(ll_buf_b, kLlMemsetInitByte, buf_size));
+  PIPES_CUDA_CHECK(cudaDeviceSynchronize());
+
+  // Sender on sender_gpu: writes to ll_buf_a on forwarder_gpu
+  cudaStream_t send_stream;
+  PIPES_CUDA_CHECK(cudaSetDevice(sender_gpu));
+  PIPES_CUDA_CHECK(cudaStreamCreate(&send_stream));
+  ll_nvlink_send_kernel<<<num_blocks, block_size, 0, send_stream>>>(
+      src_d, nbytes, ll_buf_a, buffer_num_lines, num_steps);
+  PIPES_KERNEL_LAUNCH_CHECK();
+
+  // Forwarder on forwarder_gpu: reads local buf_a, writes buf_b on
+  // receiver_gpu, copies to fwd_dst
+  cudaStream_t fwd_stream;
+  PIPES_CUDA_CHECK(cudaSetDevice(forwarder_gpu));
+  PIPES_CUDA_CHECK(cudaStreamCreate(&fwd_stream));
+  ll_nvlink_forward_kernel<<<num_blocks, block_size, 0, fwd_stream>>>(
+      fwd_dst_d, nbytes, ll_buf_a, ll_buf_b, buffer_num_lines, num_steps);
+  PIPES_KERNEL_LAUNCH_CHECK();
+
+  // Receiver on receiver_gpu: reads local buf_b to recv_dst
+  cudaStream_t recv_stream;
+  PIPES_CUDA_CHECK(cudaSetDevice(receiver_gpu));
+  PIPES_CUDA_CHECK(cudaStreamCreate(&recv_stream));
+  ll_nvlink_recv_kernel<<<num_blocks, block_size, 0, recv_stream>>>(
+      recv_dst_d, nbytes, ll_buf_b, buffer_num_lines, num_steps);
+  PIPES_KERNEL_LAUNCH_CHECK();
+
+  // Wait for all to complete
+  PIPES_CUDA_CHECK(cudaSetDevice(sender_gpu));
+  PIPES_CUDA_CHECK(cudaStreamSynchronize(send_stream));
+  PIPES_CUDA_CHECK(cudaStreamDestroy(send_stream));
+  PIPES_CUDA_CHECK(cudaSetDevice(forwarder_gpu));
+  PIPES_CUDA_CHECK(cudaStreamSynchronize(fwd_stream));
+  PIPES_CUDA_CHECK(cudaStreamDestroy(fwd_stream));
+  PIPES_CUDA_CHECK(cudaSetDevice(receiver_gpu));
+  PIPES_CUDA_CHECK(cudaStreamSynchronize(recv_stream));
+  PIPES_CUDA_CHECK(cudaStreamDestroy(recv_stream));
+}
+
+// =============================================================================
+// Varying-data NVLink kernels — each step offsets src/dst by i * nbytes
+// =============================================================================
+
+__global__ void ll_nvlink_varying_send_kernel(
+    const char* src,
+    size_t nbytes,
+    LlLine* remote_ll_buf,
+    size_t buffer_num_lines,
+    int num_steps) {
+  auto group = make_warp_group();
+  Timeout timeout;
+  timeout.start();
+  for (int i = 0; i < num_steps; i++) {
+    ll_send(
+        group,
+        src + i * nbytes,
+        nbytes,
+        remote_ll_buf,
+        timeout,
+        buffer_num_lines);
+  }
+}
+
+__global__ void ll_nvlink_varying_recv_kernel(
+    char* dst,
+    size_t nbytes,
+    LlLine* local_ll_buf,
+    size_t buffer_num_lines,
+    int num_steps) {
+  auto group = make_warp_group();
+  Timeout timeout;
+  timeout.start();
+  for (int i = 0; i < num_steps; i++) {
+    ll_recv(
+        group,
+        dst + i * nbytes,
+        nbytes,
+        local_ll_buf,
+        timeout,
+        buffer_num_lines);
+  }
+}
+
+// =============================================================================
+// Varying-data NVLink host-callable wrapper
+// =============================================================================
+
+void test_ll_nvlink_varying_send_recv(
+    int sender_gpu,
+    int receiver_gpu,
+    const char* src_d,
+    char* dst_d,
+    size_t nbytes,
+    LlLine* ll_buf,
+    size_t buffer_num_lines,
+    int num_steps,
+    int num_blocks,
+    int block_size) {
+  size_t buf_size = (buffer_num_lines > 0) ? buffer_num_lines * kLlLineSize
+                                           : ll_buffer_size(nbytes);
+  PIPES_CUDA_CHECK(cudaSetDevice(receiver_gpu));
+  PIPES_CUDA_CHECK(cudaMemset(ll_buf, kLlMemsetInitByte, buf_size));
+  PIPES_CUDA_CHECK(cudaDeviceSynchronize());
+
+  cudaStream_t send_stream;
+  PIPES_CUDA_CHECK(cudaSetDevice(sender_gpu));
+  PIPES_CUDA_CHECK(cudaStreamCreate(&send_stream));
+  ll_nvlink_varying_send_kernel<<<num_blocks, block_size, 0, send_stream>>>(
+      src_d, nbytes, ll_buf, buffer_num_lines, num_steps);
+  PIPES_KERNEL_LAUNCH_CHECK();
+
+  cudaStream_t recv_stream;
+  PIPES_CUDA_CHECK(cudaSetDevice(receiver_gpu));
+  PIPES_CUDA_CHECK(cudaStreamCreate(&recv_stream));
+  ll_nvlink_varying_recv_kernel<<<num_blocks, block_size, 0, recv_stream>>>(
+      dst_d, nbytes, ll_buf, buffer_num_lines, num_steps);
+  PIPES_KERNEL_LAUNCH_CHECK();
+
+  PIPES_CUDA_CHECK(cudaSetDevice(sender_gpu));
+  PIPES_CUDA_CHECK(cudaStreamSynchronize(send_stream));
+  PIPES_CUDA_CHECK(cudaStreamDestroy(send_stream));
+  PIPES_CUDA_CHECK(cudaSetDevice(receiver_gpu));
+  PIPES_CUDA_CHECK(cudaStreamSynchronize(recv_stream));
+  PIPES_CUDA_CHECK(cudaStreamDestroy(recv_stream));
+}
+
+} // namespace comms::pipes::test

--- a/comms/pipes/ll/tests/LlOpsNvlinkTest.cuh
+++ b/comms/pipes/ll/tests/LlOpsNvlinkTest.cuh
@@ -1,0 +1,132 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+#include "comms/pipes/ll/LlPacket.cuh"
+
+namespace comms::pipes::test {
+
+inline std::vector<char> make_pattern(size_t nbytes, int seed = 0) {
+  std::vector<char> pattern(nbytes);
+  for (size_t i = 0; i < nbytes; ++i) {
+    pattern[i] = static_cast<char>((i + seed) & 0xFF);
+  }
+  return pattern;
+}
+
+/// Cross-GPU LL send/recv test. Launches sender on sender_gpu writing to
+/// ll_buf (on receiver_gpu) via NVLink, and receiver on receiver_gpu
+/// reading from its local ll_buf.
+///
+/// @param sender_gpu GPU index for the sender kernel
+/// @param receiver_gpu GPU index for the receiver kernel
+/// @param src_d Source buffer (on sender_gpu)
+/// @param dst_d Destination buffer (on receiver_gpu)
+/// @param nbytes Message size (multiple of 8)
+/// @param ll_buf LL line buffer (on receiver_gpu)
+/// @param buffer_num_lines Lines in ll_buf (0 = sized to fit message)
+/// @param num_steps Number of send/recv iterations
+/// @param num_blocks Blocks per kernel launch
+/// @param block_size Threads per block
+void test_ll_nvlink_send_recv(
+    int sender_gpu,
+    int receiver_gpu,
+    const char* src_d,
+    char* dst_d,
+    size_t nbytes,
+    comms::pipes::LlLine* ll_buf,
+    size_t buffer_num_lines,
+    int num_steps,
+    int num_blocks,
+    int block_size);
+
+/// Cross-GPU LL forward test. Exercises NVLink on both hops:
+///   sender_gpu → buf_a on forwarder_gpu (NVLink write)
+///   forwarder_gpu reads local buf_a → writes buf_b on receiver_gpu (NVLink)
+///   receiver_gpu reads local buf_b
+///
+/// @param sender_gpu GPU for sender
+/// @param forwarder_gpu GPU for forwarder
+/// @param receiver_gpu GPU for receiver
+/// @param src_d Source buffer (on sender_gpu)
+/// @param fwd_dst_d Forwarder's local copy destination (on forwarder_gpu)
+/// @param recv_dst_d Receiver's destination (on receiver_gpu)
+/// @param nbytes Message size (multiple of 8)
+/// @param ll_buf_a LL buffer on forwarder_gpu
+/// @param ll_buf_b LL buffer on receiver_gpu
+/// @param num_blocks Blocks per kernel launch
+/// @param block_size Threads per block
+void test_ll_nvlink_forward(
+    int sender_gpu,
+    int forwarder_gpu,
+    int receiver_gpu,
+    const char* src_d,
+    char* fwd_dst_d,
+    char* recv_dst_d,
+    size_t nbytes,
+    comms::pipes::LlLine* ll_buf_a,
+    comms::pipes::LlLine* ll_buf_b,
+    int num_blocks,
+    int block_size,
+    size_t buffer_num_lines = 0,
+    int num_steps = 1);
+
+/// Cross-GPU LL bidirectional test. Two independent send/recv pairs
+/// running simultaneously:
+///   GPU0 sends to GPU1's ll_buf_on_gpu1 + GPU1 recvs from it
+///   GPU1 sends to GPU0's ll_buf_on_gpu0 + GPU0 recvs from it
+/// All 4 kernels run concurrently on separate streams.
+void test_ll_nvlink_bidirectional(
+    const char* src0_d,
+    char* dst0_d,
+    const char* src1_d,
+    char* dst1_d,
+    size_t nbytes,
+    comms::pipes::LlLine* ll_buf_on_gpu0,
+    comms::pipes::LlLine* ll_buf_on_gpu1,
+    int num_blocks,
+    int block_size,
+    size_t buffer_num_lines = 0,
+    int num_steps = 1);
+
+/// Cross-GPU LL forward test for 3 distinct GPUs.
+/// All 3 roles run on separate GPUs/streams — no combined kernel needed.
+///   sender_gpu writes to ll_buf_a on forwarder_gpu
+///   forwarder_gpu reads local buf_a, writes buf_b on receiver_gpu, copies to
+///   fwd_dst receiver_gpu reads local buf_b to recv_dst
+void test_ll_nvlink_forward_3gpu(
+    int sender_gpu,
+    int forwarder_gpu,
+    int receiver_gpu,
+    const char* src_d,
+    char* fwd_dst_d,
+    char* recv_dst_d,
+    size_t nbytes,
+    comms::pipes::LlLine* ll_buf_a,
+    comms::pipes::LlLine* ll_buf_b,
+    int num_blocks,
+    int block_size,
+    size_t buffer_num_lines = 0,
+    int num_steps = 1);
+
+/// Cross-GPU LL varying-data send/recv test. Each step offsets src/dst
+/// by i * nbytes to detect stale buffer contents across steps.
+/// @param src_d Source buffer (num_steps * nbytes total, on sender_gpu)
+/// @param dst_d Destination buffer (num_steps * nbytes total, on receiver_gpu)
+/// @param buffer_num_lines Lines in ll_buf (0 = sized to fit message)
+void test_ll_nvlink_varying_send_recv(
+    int sender_gpu,
+    int receiver_gpu,
+    const char* src_d,
+    char* dst_d,
+    size_t nbytes,
+    comms::pipes::LlLine* ll_buf,
+    size_t buffer_num_lines,
+    int num_steps,
+    int num_blocks,
+    int block_size);
+
+} // namespace comms::pipes::test

--- a/comms/pipes/tests/P2pNvlTransportDeviceTest.cu
+++ b/comms/pipes/tests/P2pNvlTransportDeviceTest.cu
@@ -1,6 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include "comms/pipes/P2pNvlTransportDevice.cuh"
+#include "comms/pipes/TiledBuffer.cuh"
 #include "comms/pipes/tests/Checks.h"
 #include "comms/pipes/tests/P2pNvlTransportDeviceTest.cuh"
 
@@ -242,6 +243,77 @@ void testLl128SendRecv(
   PIPES_KERNEL_LAUNCH_CHECK();
 
   // Wait for both to complete and destroy streams
+  PIPES_CUDA_CHECK(cudaSetDevice(0));
+  PIPES_CUDA_CHECK(cudaStreamSynchronize(send_stream));
+  PIPES_CUDA_CHECK(cudaStreamDestroy(send_stream));
+  PIPES_CUDA_CHECK(cudaSetDevice(1));
+  PIPES_CUDA_CHECK(cudaStreamSynchronize(recv_stream));
+  PIPES_CUDA_CHECK(cudaStreamDestroy(recv_stream));
+}
+
+// =============================================================================
+// LL tiled (non-cooperative) send/recv test kernels
+// =============================================================================
+
+__global__ void testLlTiledSendKernel(
+    P2pNvlTransportDevice p2p,
+    const char* src,
+    size_t nbytes,
+    int num_steps) {
+  auto group = make_warp_group();
+  auto [dir, subgroup] = group.partition_interleaved(2);
+  const int active = subgroup.total_groups;
+  Timeout timeout;
+  timeout.start();
+  if (dir == 0) {
+    for (int i = 0; i < num_steps; i++) {
+      TiledBuffer<char> tile(const_cast<char*>(src), nbytes, subgroup);
+      p2p.ll_send(subgroup, tile.data(), tile.bytes(), active, timeout);
+    }
+  }
+}
+
+__global__ void testLlTiledRecvKernel(
+    P2pNvlTransportDevice p2p,
+    char* dst,
+    size_t nbytes,
+    int num_steps) {
+  auto group = make_warp_group();
+  auto [dir, subgroup] = group.partition_interleaved(2);
+  const int active = subgroup.total_groups;
+  Timeout timeout;
+  timeout.start();
+  if (dir == 1) {
+    for (int i = 0; i < num_steps; i++) {
+      TiledBuffer<char> tile(dst, nbytes, subgroup);
+      p2p.ll_recv(subgroup, tile.data(), tile.bytes(), active, timeout);
+    }
+  }
+}
+
+void testLlTiledSendRecv(
+    P2pNvlTransportDevice sender,
+    P2pNvlTransportDevice receiver,
+    const char* src_d,
+    char* dst_d,
+    size_t nbytes,
+    int numBlocks,
+    int blockSize) {
+  constexpr int kNumSteps = 1;
+  cudaStream_t send_stream, recv_stream;
+
+  PIPES_CUDA_CHECK(cudaSetDevice(0));
+  PIPES_CUDA_CHECK(cudaStreamCreate(&send_stream));
+  testLlTiledSendKernel<<<numBlocks, blockSize, 0, send_stream>>>(
+      sender, src_d, nbytes, kNumSteps);
+  PIPES_KERNEL_LAUNCH_CHECK();
+
+  PIPES_CUDA_CHECK(cudaSetDevice(1));
+  PIPES_CUDA_CHECK(cudaStreamCreate(&recv_stream));
+  testLlTiledRecvKernel<<<numBlocks, blockSize, 0, recv_stream>>>(
+      receiver, dst_d, nbytes, kNumSteps);
+  PIPES_KERNEL_LAUNCH_CHECK();
+
   PIPES_CUDA_CHECK(cudaSetDevice(0));
   PIPES_CUDA_CHECK(cudaStreamSynchronize(send_stream));
   PIPES_CUDA_CHECK(cudaStreamDestroy(send_stream));

--- a/comms/pipes/tests/P2pNvlTransportDeviceTest.cuh
+++ b/comms/pipes/tests/P2pNvlTransportDeviceTest.cuh
@@ -129,4 +129,19 @@ void testLl128SendRecv(
     int numBlocks,
     int blockSize);
 
+// =============================================================================
+// LL tiled (non-cooperative) send/recv test helpers
+// These test the ll_send()/ll_recv() methods with active_groups > 1,
+// where each warp independently sends/receives its own tile via TiledBuffer.
+// =============================================================================
+
+void testLlTiledSendRecv(
+    P2pNvlTransportDevice sender,
+    P2pNvlTransportDevice receiver,
+    const char* src_d,
+    char* dst_d,
+    size_t nbytes,
+    int numBlocks,
+    int blockSize);
+
 } // namespace comms::pipes::test

--- a/comms/pipes/tests/P2pNvlTransportTest.cc
+++ b/comms/pipes/tests/P2pNvlTransportTest.cc
@@ -3465,6 +3465,12 @@ TEST_F(P2pNvlTransportTestFixture, Ll128BufferWiring_Disabled) {
   ASSERT_EQ(p2p.getRemoteState().ll128Buffer, nullptr)
       << "Rank " << globalRank
       << ": remoteState.ll128Buffer should be null when ll128BufferSize == 0";
+  ASSERT_EQ(p2p.getLocalState().llBuffer, nullptr)
+      << "Rank " << globalRank
+      << ": localState.llBuffer should be null when llBufferSize == 0";
+  ASSERT_EQ(p2p.getRemoteState().llBuffer, nullptr)
+      << "Rank " << globalRank
+      << ": remoteState.llBuffer should be null when llBufferSize == 0";
 
   XLOGF(INFO, "Rank {}: Ll128BufferWiring_Disabled test completed", globalRank);
 }
@@ -4500,6 +4506,76 @@ INSTANTIATE_TEST_SUITE_P(
             .useDualStateBuffer = false,
             .name = "Off5_OddSize"}),
     forwardUnalignedParamName);
+
+// =============================================================================
+// LL Buffer Wiring Tests
+// Verify MultiPeerNvlTransport correctly wires LL buffer pointers into
+// P2pNvlTransportDevice handles.
+// =============================================================================
+
+TEST_F(P2pNvlTransportTestFixture, LlBufferWiring_Enabled) {
+  if (numRanks != 2) {
+    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    return;
+  }
+
+  int peerRank = (globalRank == 0) ? 1 : 0;
+
+  MultiPeerNvlTransportConfig config{
+      .dataBufferSize = 4096,
+      .chunkSize = 256,
+      .pipelineDepth = 2,
+      .llBufferSize = ll_buffer_size(4096),
+  };
+
+  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
+  transport.exchange();
+
+  auto p2p = transport.buildP2pTransportDevice(peerRank);
+
+  ASSERT_NE(p2p.getLocalState().llBuffer, nullptr)
+      << "Rank " << globalRank
+      << ": localState.llBuffer should be non-null when llBufferSize > 0";
+  ASSERT_NE(p2p.getRemoteState().llBuffer, nullptr)
+      << "Rank " << globalRank
+      << ": remoteState.llBuffer should be non-null when llBufferSize > 0";
+  ASSERT_NE(p2p.getLocalState().llBuffer, p2p.getRemoteState().llBuffer)
+      << "Rank " << globalRank
+      << ": local and remote llBuffer should point to different ranks' buffers";
+
+  XLOGF(INFO, "Rank {}: LlBufferWiring_Enabled test completed", globalRank);
+}
+
+TEST_F(P2pNvlTransportTestFixture, LlBufferWiring_Disabled) {
+  if (numRanks != 2) {
+    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    return;
+  }
+
+  int peerRank = (globalRank == 0) ? 1 : 0;
+
+  MultiPeerNvlTransportConfig config{
+      .dataBufferSize = 4096,
+      .chunkSize = 256,
+      .pipelineDepth = 2,
+  };
+
+  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
+  transport.exchange();
+
+  auto p2p = transport.buildP2pTransportDevice(peerRank);
+
+  ASSERT_EQ(p2p.getLocalState().llBuffer, nullptr)
+      << "Rank " << globalRank
+      << ": localState.llBuffer should be null when llBufferSize == 0";
+  ASSERT_EQ(p2p.getRemoteState().llBuffer, nullptr)
+      << "Rank " << globalRank
+      << ": remoteState.llBuffer should be null when llBufferSize == 0";
+
+  XLOGF(INFO, "Rank {}: LlBufferWiring_Disabled test completed", globalRank);
+}
 
 } // namespace comms::pipes::tests
 


### PR DESCRIPTION
Summary:

Another new test target to exercise C++ LL ops over real NVLink P2P paths (as opposed to the single-GPU simulation tests in Part 2):

- `LlOpsNvlink3GpuTest` (3-GPU): 5 tests with all three roles (sender, forwarder, receiver) on distinct GPUs, covering basic, multi-step, chunked, and multi-block scenarios.

This is Part 3c of 6 in the LL protocol stack.

Reviewed By: siyengar

Differential Revision: D97980994


