### PR TITLE
Migrate AllReduce tests to ncclx::test:: APIs

### DIFF
--- a/comms/ncclx/v2_27/meta/tests/AllReduceNumericOffsetTest.cc
+++ b/comms/ncclx/v2_27/meta/tests/AllReduceNumericOffsetTest.cc
@@ -11,6 +11,7 @@
 #include <comm.h>
 #include <nccl.h>
 #include "checks.h"
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
 
@@ -36,8 +37,8 @@ class AllReduceNumericOffsetTest : public NcclxBaseTest {
   void SetUp() override {
     NcclxBaseTest::SetUp();
 
-    comm = createNcclComm(
-        globalRank, numRanks, localRank, false, nullptr, server.get());
+    comm = ncclx::test::createNcclComm(
+        globalRank, numRanks, localRank, bootstrap_.get());
 
     CUDACHECK_TEST(cudaSetDevice(localRank));
     CUDACHECK_TEST(cudaStreamCreate(&stream));
@@ -46,7 +47,6 @@ class AllReduceNumericOffsetTest : public NcclxBaseTest {
   void TearDown() override {
     NCCLCHECK_TEST(ncclCommDestroy(comm));
     CUDACHECK_TEST(cudaStreamDestroy(stream));
-    finalizeNcclComm(globalRank, server.get());
     NcclxBaseTest::TearDown();
   }
 

--- a/comms/ncclx/v2_27/meta/tests/AllReduceNumericStableTest.cc
+++ b/comms/ncclx/v2_27/meta/tests/AllReduceNumericStableTest.cc
@@ -13,6 +13,7 @@
 
 #include <comm.h>
 #include <nccl.h>
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
 
@@ -31,8 +32,8 @@ class AllReduceStableTest : public NcclxBaseTest {
   void SetUp() override {
     NcclxBaseTest::SetUp();
 
-    comm = createNcclComm(
-        globalRank, numRanks, localRank, false, nullptr, server.get());
+    comm = ncclx::test::createNcclComm(
+        globalRank, numRanks, localRank, bootstrap_.get());
 
     CUDACHECK_TEST(cudaSetDevice(localRank));
     CUDACHECK_TEST(cudaStreamCreate(&stream));
@@ -41,7 +42,6 @@ class AllReduceStableTest : public NcclxBaseTest {
   void TearDown() override {
     NCCLCHECK_TEST(ncclCommDestroy(comm));
     CUDACHECK_TEST(cudaStreamDestroy(stream));
-    finalizeNcclComm(globalRank, server.get());
     NcclxBaseTest::TearDown();
   }
 

--- a/comms/ncclx/v2_27/meta/tests/AllReduceSingleRankTest.cc
+++ b/comms/ncclx/v2_27/meta/tests/AllReduceSingleRankTest.cc
@@ -15,6 +15,7 @@
 #include <stdlib.h>
 #include <cstddef>
 #include <random>
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsCuUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
@@ -29,7 +30,8 @@ class AllReduceSingleRankTest : public NcclxBaseTest {
     if (numRanks != 1) {
       GTEST_SKIP() << "This test requires exactly 1 rank, got " << numRanks;
     }
-    comm = createNcclComm(globalRank, numRanks, localRank);
+    comm = ncclx::test::createNcclComm(
+        globalRank, numRanks, localRank, bootstrap_.get());
     CUDACHECK_TEST(cudaStreamCreate(&stream));
   }
 

--- a/comms/ncclx/v2_27/meta/tests/AllReduceTest.cc
+++ b/comms/ncclx/v2_27/meta/tests/AllReduceTest.cc
@@ -11,6 +11,7 @@
 #include <comm.h>
 #include <nccl.h>
 #include "checks.h"
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -27,8 +28,8 @@ class AllReduceTest : public NcclxBaseTest {
     // intra-node connection
     NcclxBaseTest::SetUp();
 
-    comm = createNcclComm(
-        globalRank, numRanks, localRank, false, nullptr, server.get());
+    comm = ncclx::test::createNcclComm(
+        globalRank, numRanks, localRank, bootstrap_.get());
 
     CUDACHECK_TEST(cudaSetDevice(localRank));
     CUDACHECK_TEST(cudaStreamCreate(&stream));
@@ -37,7 +38,6 @@ class AllReduceTest : public NcclxBaseTest {
   void TearDown() override {
     NCCLCHECK_TEST(ncclCommDestroy(comm));
     CUDACHECK_TEST(cudaStreamDestroy(stream));
-    finalizeNcclComm(globalRank, server.get());
     NcclxBaseTest::TearDown();
   }
 

--- a/comms/ncclx/v2_27/meta/tests/AllReduceUniformTest.cc
+++ b/comms/ncclx/v2_27/meta/tests/AllReduceUniformTest.cc
@@ -12,6 +12,7 @@
 
 #include <comm.h>
 #include <nccl.h>
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
 
@@ -42,8 +43,8 @@ class AllReduceUniformTest : public NcclxBaseTest {
   void SetUp() override {
     NcclxBaseTest::SetUp();
 
-    comm = createNcclComm(
-        globalRank, numRanks, localRank, false, nullptr, server.get());
+    comm = ncclx::test::createNcclComm(
+        globalRank, numRanks, localRank, bootstrap_.get());
 
     CUDACHECK_TEST(cudaSetDevice(localRank));
     CUDACHECK_TEST(cudaStreamCreate(&stream));
@@ -52,7 +53,6 @@ class AllReduceUniformTest : public NcclxBaseTest {
   void TearDown() override {
     NCCLCHECK_TEST(ncclCommDestroy(comm));
     CUDACHECK_TEST(cudaStreamDestroy(stream));
-    finalizeNcclComm(globalRank, server.get());
     NcclxBaseTest::TearDown();
   }
 

--- a/comms/ncclx/v2_28/meta/tests/AllReduceNumericOffsetTest.cc
+++ b/comms/ncclx/v2_28/meta/tests/AllReduceNumericOffsetTest.cc
@@ -11,6 +11,7 @@
 #include <comm.h>
 #include <nccl.h>
 #include "checks.h"
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
 
@@ -36,8 +37,8 @@ class AllReduceNumericOffsetTest : public NcclxBaseTest {
   void SetUp() override {
     NcclxBaseTest::SetUp();
 
-    comm = createNcclComm(
-        globalRank, numRanks, localRank, false, nullptr, server.get());
+    comm = ncclx::test::createNcclComm(
+        globalRank, numRanks, localRank, bootstrap_.get());
 
     CUDACHECK_TEST(cudaSetDevice(localRank));
     CUDACHECK_TEST(cudaStreamCreate(&stream));
@@ -46,7 +47,6 @@ class AllReduceNumericOffsetTest : public NcclxBaseTest {
   void TearDown() override {
     NCCLCHECK_TEST(ncclCommDestroy(comm));
     CUDACHECK_TEST(cudaStreamDestroy(stream));
-    finalizeNcclComm(globalRank, server.get());
     NcclxBaseTest::TearDown();
   }
 

--- a/comms/ncclx/v2_28/meta/tests/AllReduceNumericStableTest.cc
+++ b/comms/ncclx/v2_28/meta/tests/AllReduceNumericStableTest.cc
@@ -13,6 +13,7 @@
 
 #include <comm.h>
 #include <nccl.h>
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
 
@@ -31,8 +32,8 @@ class AllReduceStableTest : public NcclxBaseTest {
   void SetUp() override {
     NcclxBaseTest::SetUp();
 
-    comm = createNcclComm(
-        globalRank, numRanks, localRank, false, nullptr, server.get());
+    comm = ncclx::test::createNcclComm(
+        globalRank, numRanks, localRank, bootstrap_.get());
 
     CUDACHECK_TEST(cudaSetDevice(localRank));
     CUDACHECK_TEST(cudaStreamCreate(&stream));
@@ -41,7 +42,6 @@ class AllReduceStableTest : public NcclxBaseTest {
   void TearDown() override {
     NCCLCHECK_TEST(ncclCommDestroy(comm));
     CUDACHECK_TEST(cudaStreamDestroy(stream));
-    finalizeNcclComm(globalRank, server.get());
     NcclxBaseTest::TearDown();
   }
 

--- a/comms/ncclx/v2_28/meta/tests/AllReduceSingleRankTest.cc
+++ b/comms/ncclx/v2_28/meta/tests/AllReduceSingleRankTest.cc
@@ -15,6 +15,7 @@
 #include <stdlib.h>
 #include <cstddef>
 #include <random>
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsCuUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
@@ -29,7 +30,8 @@ class AllReduceSingleRankTest : public NcclxBaseTest {
     if (numRanks != 1) {
       GTEST_SKIP() << "This test requires exactly 1 rank, got " << numRanks;
     }
-    comm = createNcclComm(globalRank, numRanks, localRank);
+    comm = ncclx::test::createNcclComm(
+        globalRank, numRanks, localRank, bootstrap_.get());
     CUDACHECK_TEST(cudaStreamCreate(&stream));
   }
 

--- a/comms/ncclx/v2_28/meta/tests/AllReduceTest.cc
+++ b/comms/ncclx/v2_28/meta/tests/AllReduceTest.cc
@@ -11,6 +11,7 @@
 #include <comm.h>
 #include <nccl.h>
 #include "checks.h"
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -27,8 +28,8 @@ class AllReduceTest : public NcclxBaseTest {
     // intra-node connection
     NcclxBaseTest::SetUp();
 
-    comm = createNcclComm(
-        globalRank, numRanks, localRank, false, nullptr, server.get());
+    comm = ncclx::test::createNcclComm(
+        globalRank, numRanks, localRank, bootstrap_.get());
 
     CUDACHECK_TEST(cudaSetDevice(localRank));
     CUDACHECK_TEST(cudaStreamCreate(&stream));
@@ -37,7 +38,6 @@ class AllReduceTest : public NcclxBaseTest {
   void TearDown() override {
     NCCLCHECK_TEST(ncclCommDestroy(comm));
     CUDACHECK_TEST(cudaStreamDestroy(stream));
-    finalizeNcclComm(globalRank, server.get());
     NcclxBaseTest::TearDown();
   }
 

--- a/comms/ncclx/v2_28/meta/tests/AllReduceUniformTest.cc
+++ b/comms/ncclx/v2_28/meta/tests/AllReduceUniformTest.cc
@@ -12,6 +12,7 @@
 
 #include <comm.h>
 #include <nccl.h>
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
 
@@ -42,8 +43,8 @@ class AllReduceUniformTest : public NcclxBaseTest {
   void SetUp() override {
     NcclxBaseTest::SetUp();
 
-    comm = createNcclComm(
-        globalRank, numRanks, localRank, false, nullptr, server.get());
+    comm = ncclx::test::createNcclComm(
+        globalRank, numRanks, localRank, bootstrap_.get());
 
     CUDACHECK_TEST(cudaSetDevice(localRank));
     CUDACHECK_TEST(cudaStreamCreate(&stream));
@@ -52,7 +53,6 @@ class AllReduceUniformTest : public NcclxBaseTest {
   void TearDown() override {
     NCCLCHECK_TEST(ncclCommDestroy(comm));
     CUDACHECK_TEST(cudaStreamDestroy(stream));
-    finalizeNcclComm(globalRank, server.get());
     NcclxBaseTest::TearDown();
   }
 

--- a/comms/ncclx/v2_29/meta/tests/AllReduceNumericOffsetTest.cc
+++ b/comms/ncclx/v2_29/meta/tests/AllReduceNumericOffsetTest.cc
@@ -11,6 +11,7 @@
 #include <comm.h>
 #include <nccl.h>
 #include "checks.h"
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
 
@@ -36,8 +37,8 @@ class AllReduceNumericOffsetTest : public NcclxBaseTest {
   void SetUp() override {
     NcclxBaseTest::SetUp();
 
-    comm = createNcclComm(
-        globalRank, numRanks, localRank, false, nullptr, server.get());
+    comm = ncclx::test::createNcclComm(
+        globalRank, numRanks, localRank, bootstrap_.get());
 
     CUDACHECK_TEST(cudaSetDevice(localRank));
     CUDACHECK_TEST(cudaStreamCreate(&stream));
@@ -46,7 +47,6 @@ class AllReduceNumericOffsetTest : public NcclxBaseTest {
   void TearDown() override {
     NCCLCHECK_TEST(ncclCommDestroy(comm));
     CUDACHECK_TEST(cudaStreamDestroy(stream));
-    finalizeNcclComm(globalRank, server.get());
     NcclxBaseTest::TearDown();
   }
 

--- a/comms/ncclx/v2_29/meta/tests/AllReduceNumericStableTest.cc
+++ b/comms/ncclx/v2_29/meta/tests/AllReduceNumericStableTest.cc
@@ -13,6 +13,7 @@
 
 #include <comm.h>
 #include <nccl.h>
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
 
@@ -31,8 +32,8 @@ class AllReduceStableTest : public NcclxBaseTest {
   void SetUp() override {
     NcclxBaseTest::SetUp();
 
-    comm = createNcclComm(
-        globalRank, numRanks, localRank, false, nullptr, server.get());
+    comm = ncclx::test::createNcclComm(
+        globalRank, numRanks, localRank, bootstrap_.get());
 
     CUDACHECK_TEST(cudaSetDevice(localRank));
     CUDACHECK_TEST(cudaStreamCreate(&stream));
@@ -41,7 +42,6 @@ class AllReduceStableTest : public NcclxBaseTest {
   void TearDown() override {
     NCCLCHECK_TEST(ncclCommDestroy(comm));
     CUDACHECK_TEST(cudaStreamDestroy(stream));
-    finalizeNcclComm(globalRank, server.get());
     NcclxBaseTest::TearDown();
   }
 

--- a/comms/ncclx/v2_29/meta/tests/AllReduceSingleRankTest.cc
+++ b/comms/ncclx/v2_29/meta/tests/AllReduceSingleRankTest.cc
@@ -15,6 +15,7 @@
 #include <stdlib.h>
 #include <cstddef>
 #include <random>
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsCuUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
@@ -29,7 +30,8 @@ class AllReduceSingleRankTest : public NcclxBaseTest {
     if (numRanks != 1) {
       GTEST_SKIP() << "This test requires exactly 1 rank, got " << numRanks;
     }
-    comm = createNcclComm(globalRank, numRanks, localRank);
+    comm = ncclx::test::createNcclComm(
+        globalRank, numRanks, localRank, bootstrap_.get());
     CUDACHECK_TEST(cudaStreamCreate(&stream));
   }
 

--- a/comms/ncclx/v2_29/meta/tests/AllReduceTest.cc
+++ b/comms/ncclx/v2_29/meta/tests/AllReduceTest.cc
@@ -11,6 +11,7 @@
 #include <comm.h>
 #include <nccl.h>
 #include "checks.h"
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -27,8 +28,8 @@ class AllReduceTest : public NcclxBaseTest {
     // intra-node connection
     NcclxBaseTest::SetUp();
 
-    comm = createNcclComm(
-        globalRank, numRanks, localRank, false, nullptr, server.get());
+    comm = ncclx::test::createNcclComm(
+        globalRank, numRanks, localRank, bootstrap_.get());
 
     CUDACHECK_TEST(cudaSetDevice(localRank));
     CUDACHECK_TEST(cudaStreamCreate(&stream));
@@ -37,7 +38,6 @@ class AllReduceTest : public NcclxBaseTest {
   void TearDown() override {
     NCCLCHECK_TEST(ncclCommDestroy(comm));
     CUDACHECK_TEST(cudaStreamDestroy(stream));
-    finalizeNcclComm(globalRank, server.get());
     NcclxBaseTest::TearDown();
   }
 

--- a/comms/ncclx/v2_29/meta/tests/AllReduceUniformTest.cc
+++ b/comms/ncclx/v2_29/meta/tests/AllReduceUniformTest.cc
@@ -12,6 +12,7 @@
 
 #include <comm.h>
 #include <nccl.h>
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
 
@@ -42,8 +43,8 @@ class AllReduceUniformTest : public NcclxBaseTest {
   void SetUp() override {
     NcclxBaseTest::SetUp();
 
-    comm = createNcclComm(
-        globalRank, numRanks, localRank, false, nullptr, server.get());
+    comm = ncclx::test::createNcclComm(
+        globalRank, numRanks, localRank, bootstrap_.get());
 
     CUDACHECK_TEST(cudaSetDevice(localRank));
     CUDACHECK_TEST(cudaStreamCreate(&stream));
@@ -52,7 +53,6 @@ class AllReduceUniformTest : public NcclxBaseTest {
   void TearDown() override {
     NCCLCHECK_TEST(ncclCommDestroy(comm));
     CUDACHECK_TEST(cudaStreamDestroy(stream));
-    finalizeNcclComm(globalRank, server.get());
     NcclxBaseTest::TearDown();
   }
 


### PR DESCRIPTION
Summary:
Migrate 5 AllReduce tests across all 3 ncclx versions (v2_27/v2_28/v2_29) to use ncclx::test:: APIs:
- AllReduceTest, AllReduceNumericOffsetTest, AllReduceNumericStableTest, AllReduceSingleRankTest, AllReduceUniformTest
- Replace createNcclComm/finalizeNcclComm with ncclx::test::createNcclComm and ncclx::test::NcclCommRAII
- Add NcclCommUtils.h include and AddGlobalTestEnvironment(new DistEnvironmentBase) in main()

Reviewed By: Regina8023

Differential Revision: D97796143


