### PR TITLE
add internal-only cvar default overrides infrastructure

### DIFF
--- a/comms/utils/cvars/extractcvars.py
+++ b/comms/utils/cvars/extractcvars.py
@@ -798,6 +798,39 @@ def get_script_and_output_directories() -> tuple[pathlib.Path, pathlib.Path]:
     return output_dir, script_dir
 
 
+def apply_internal_overrides(cvars, script_dir):
+    """
+    Apply internal-only cvar default overrides from nccl_cvars_internal.yaml.
+    This file is only present in Buck builds (included as a resource);
+    OSS builds use the base defaults from nccl_cvars.yaml.
+    """
+    internal_file = os.path.join(script_dir, "fb", "nccl_cvars_internal.yaml")
+    if not os.path.exists(internal_file):
+        return cvars
+
+    print(f"Applying internal overrides from {internal_file}")
+    with open(internal_file, "r") as f:
+        internal_data = yaml.safe_load(f)
+
+    if not internal_data or not internal_data.get("cvars"):
+        return cvars
+
+    # Build a map of override name -> override fields
+    overrides = {o["name"]: o for o in internal_data["cvars"]}
+
+    for cvar in cvars:
+        if cvar["name"] in overrides:
+            override = overrides[cvar["name"]]
+            for key, value in override.items():
+                if key != "name":
+                    print(
+                        f"  Override {cvar['name']}.{key}: {cvar.get(key)} -> {value}"
+                    )
+                    cvar[key] = value
+
+    return cvars
+
+
 def main():
     output_dir, script_dir = get_script_and_output_directories()
     config_file = os.path.join(script_dir, "nccl_cvars.yaml")
@@ -807,6 +840,8 @@ def main():
         data = yaml.safe_load(f)
     if data["cvars"] is None:
         data["cvars"] = []
+
+    data["cvars"] = apply_internal_overrides(data["cvars"], script_dir)
 
     loadedCvars = sorted(data["cvars"], key=lambda x: x["name"])
 

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -60,7 +60,7 @@ cvars:
 
  - name        : NCCL_SLOW_RANK_LOGGING
    type        : string
-   default     : "scuba:nccl_profiler_slow_rank"
+   default     : ""
    description : |-
       File location for logging communicator profiler events. By default,
       all data is logged to scuba table nccl_profiler_slow_rank.
@@ -68,7 +68,7 @@ cvars:
 
  - name        : NCCL_CTRAN_ALGO_PROFILING_LOGGING
    type        : string
-   default     : "scuba:nccl_profiler_algo"
+   default     : ""
    description : |-
       File location for logging communicator profiler events. By default,
       all data is logged to scuba table nccl_profiler_algo.
@@ -83,14 +83,14 @@ cvars:
 
  - name        : NCCL_SLOW_COLL_LOGGING
    type        : string
-   default     : "pipe:nccl_slow_coll"
+   default     : ""
    description : |-
       File location for logging slow collectives.
       (the same format with NCCL_COMM_EVENT_LOGGING)
 
  - name        : NCCL_COLL_STATS_LOGGING
    type        : string
-   default     : "pipe:nccl_collective_stats"
+   default     : ""
    description : |-
       File location for logging collective stats.
       (the same format with NCCL_COMM_EVENT_LOGGING)
@@ -2219,7 +2219,7 @@ cvars:
 
  - name        : NCCL_TOPO_FILE_PATH
    type        : string
-   default     : "/etc/fbwhoami"
+   default     : ""
    description : |-
      [NCCLX] File that contains topology information in KEY=VALUE format
 


### PR DESCRIPTION
Summary:
Add infrastructure to override cvar defaults for internal (Buck) builds
without changing OSS defaults. Internal overrides are defined in
`nccl_cvars_internal.yaml` and applied on top of `nccl_cvars.yaml`
during code generation.

Move NCCL_TOPO_FILE_PATH default from "/etc/fbwhoami" to "" in the
base config, with the internal override restoring "/etc/fbwhoami" for
Buck builds.

Differential Revision: D97240869


