### PR TITLE
Make local buffer registration a no-op when IB is disabled (#1250)

### DIFF
--- a/comms/ncclx/v2_27/meta/rma/window.cc
+++ b/comms/ncclx/v2_27/meta/rma/window.cc
@@ -333,6 +333,16 @@ ncclResult_t ncclWinLocalRegisterBuffer(
     return ncclInternalError;
   }
 
+  // If no IBGDA peers exist (e.g. IB disabled, NVLink-only topology),
+  // skip registration and return success with a zero lkey. The lkey is
+  // only used for IBGDA WQE construction during RDMA writes; NVLink puts
+  // never read it.  This mirrors HostWindow::registerLocalBuffer which
+  // guards the same call with nIbgdaPeers > 0.
+  if (mpt->ibgda_peer_ranks().empty()) {
+    *outLkey = 0;
+    return ncclSuccess;
+  }
+
   try {
     auto ibgdaBuf = mpt->localRegisterIbgdaBuffer(ptr, size);
     *outLkey = ibgdaBuf.lkey.value;

--- a/comms/ncclx/v2_28/meta/rma/window.cc
+++ b/comms/ncclx/v2_28/meta/rma/window.cc
@@ -331,6 +331,16 @@ ncclResult_t ncclWinLocalRegisterBuffer(
     return ncclInternalError;
   }
 
+  // If no IBGDA peers exist (e.g. IB disabled, NVLink-only topology),
+  // skip registration and return success with a zero lkey. The lkey is
+  // only used for IBGDA WQE construction during RDMA writes; NVLink puts
+  // never read it.  This mirrors HostWindow::registerLocalBuffer which
+  // guards the same call with nIbgdaPeers > 0.
+  if (mpt->ibgda_peer_ranks().empty()) {
+    *outLkey = 0;
+    return ncclSuccess;
+  }
+
   try {
     auto ibgdaBuf = mpt->localRegisterIbgdaBuffer(ptr, size);
     *outLkey = ibgdaBuf.lkey.value;

--- a/comms/ncclx/v2_29/meta/rma/window.cc
+++ b/comms/ncclx/v2_29/meta/rma/window.cc
@@ -332,6 +332,16 @@ ncclResult_t ncclWinLocalRegisterBuffer(
     return ncclInternalError;
   }
 
+  // If no IBGDA peers exist (e.g. IB disabled, NVLink-only topology),
+  // skip registration and return success with a zero lkey. The lkey is
+  // only used for IBGDA WQE construction during RDMA writes; NVLink puts
+  // never read it.  This mirrors HostWindow::registerLocalBuffer which
+  // guards the same call with nIbgdaPeers > 0.
+  if (mpt->ibgda_peer_ranks().empty()) {
+    *outLkey = 0;
+    return ncclSuccess;
+  }
+
   try {
     auto ibgdaBuf = mpt->localRegisterIbgdaBuffer(ptr, size);
     *outLkey = ibgdaBuf.lkey.value;

--- a/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTest.cpp
@@ -241,7 +241,8 @@ void PipesDeviceApiTest::testLocalBufferRegistration(
   // backend_window is null (only GIN uses backend_window).
   ASSERT_NE(src_buf.base_ptr, nullptr) << "Buffer base_ptr should not be null";
   ASSERT_GT(src_buf.size, 0u) << "Buffer size should be positive";
-  EXPECT_NE(src_buf.lkey, 0u) << "Pipes backend should set lkey for IBGDA put";
+  // lkey is only set when IBGDA peers exist; on NVLink-only topologies
+  // (IB disabled) it will be 0, which is valid — NVLink puts never use lkey.
   EXPECT_EQ(src_buf.backend_window, nullptr)
       << "Pipes backend should not set backend_window";
 


### PR DESCRIPTION
Summary:

When calling `register_local_buffer` through the torchcomms/NCCLx path
on a NVLink-only topology (IB disabled), `ncclWinLocalRegisterBuffer`
unconditionally called `MultiPeerTransport::localRegisterIbgdaBuffer`,
which throws when `ibgdaTransport_` is null. This caused a
`RuntimeError` in Python and a `std::runtime_error` in C++.

The Pipes `HostWindow::registerLocalBuffer` already handles this
correctly by guarding the call with `nIbgdaPeers > 0`. The GIN
(NCCLx) backend also handles it — `ncclCommWindowRegister` returns
`ncclSuccess` with `*win = nullptr` when `symmetricSupport` is false.

This diff adds the same guard to `ncclWinLocalRegisterBuffer` across
all three ncclx versions (v2_27, v2_28, v2_29): if there are no IBGDA
peers, return `ncclSuccess` with `lkey = 0`. The lkey is only used for
IBGDA WQE construction during RDMA writes; NVLink puts never read it.

Also relaxes a test assertion in `PipesDeviceApiTest` that expected
`lkey != 0`, which is only valid on IB-enabled topologies.

Reviewed By: cenzhaometa

Differential Revision: D97997156
