### PR TITLE
Add iterated device API stress tests for NCCLX and Pipes backends (#1253)

### DIFF
--- a/comms/torchcomms/tests/integration/cpp/DeviceApiIteratedTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/DeviceApiIteratedTest.cpp
@@ -1,0 +1,763 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Iterated functional tests for TorchComm Device API — NCCLx (GIN+LSA) backend.
+
+#include "DeviceApiIteratedTest.hpp"
+
+#include <gtest/gtest.h>
+#include "DeviceApiIteratedTestKernels.cuh"
+#include "IteratedTestHelpers.hpp"
+#include "TorchCommTestHelpers.h"
+#include "comms/torchcomms/TorchComm.hpp"
+
+using namespace torchcomms::device;
+using namespace torchcomms::device::test;
+
+// =============================================================================
+// Setup / Teardown
+// =============================================================================
+
+void DeviceApiIteratedTest::SetUp() {
+  if (!shouldRunIteratedTest()) {
+    GTEST_SKIP()
+        << "Skipping iterated tests (RUN_DEVICE_ITERATED_TEST not set)";
+  }
+
+  config_ = parseIteratedTestConfig();
+  wrapper_ = std::make_unique<TorchCommTestWrapper>();
+  torchcomm_ = wrapper_->getTorchComm();
+  rank_ = torchcomm_->getRank();
+  num_ranks_ = torchcomm_->getSize();
+  device_index_ = rank_ % at::cuda::device_count();
+  allocator_ = torch::comms::get_mem_allocator(torchcomm_->getBackend());
+}
+
+void DeviceApiIteratedTest::TearDown() {
+  torchcomm_.reset();
+  wrapper_.reset();
+}
+
+// =============================================================================
+// Helper: create MemPool, allocate tensors, create window, get device window
+// =============================================================================
+
+namespace {
+
+struct WindowSetup {
+  std::unique_ptr<at::cuda::MemPool> mem_pool;
+  at::Tensor win_tensor;
+  at::Tensor src_tensor;
+  std::shared_ptr<torch::comms::TorchCommWindow> win;
+  DeviceWindowNCCL* dev_win{nullptr};
+  RegisteredBufferNCCL src_buf{};
+};
+
+WindowSetup createWindowSetup(
+    std::shared_ptr<torch::comms::TorchComm>& torchcomm,
+    std::shared_ptr<c10::Allocator>& allocator,
+    int device_index,
+    int num_ranks,
+    size_t count,
+    int signal_count,
+    int counter_count,
+    int barrier_count) {
+  WindowSetup s;
+
+  s.mem_pool = std::make_unique<at::cuda::MemPool>(
+      std::static_pointer_cast<c10::cuda::CUDACachingAllocator::CUDAAllocator>(
+          allocator));
+  c10::cuda::CUDACachingAllocator::beginAllocateToPool(
+      s.mem_pool->device(), s.mem_pool->id(), [](cudaStream_t) {
+        return true;
+      });
+
+  auto options =
+      at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, device_index);
+  s.win_tensor = at::zeros({static_cast<int64_t>(count * num_ranks)}, options);
+
+  c10::cuda::CUDACachingAllocator::endAllocateToPool(
+      s.mem_pool->device(), s.mem_pool->id());
+
+  // Allocate src_tensor OUTSIDE the pool to ensure it gets its own cuMem
+  // allocation. When both tensors share the same cuMem block and the src_tensor
+  // is not 4096-aligned within that block, NCCL LOCAL_ONLY window registration
+  // truncates ginOffset4K, and NVLink put with P2P disabled fails to deliver
+  // data. Separate allocations avoid this issue.
+  s.src_tensor = at::zeros({static_cast<int64_t>(count)}, options);
+
+  torchcomm->barrier(false);
+  s.win = torchcomm->new_window();
+  s.win->tensor_register(s.win_tensor);
+  torchcomm->barrier(false);
+
+  s.dev_win = static_cast<DeviceWindowNCCL*>(
+      s.win->get_device_window(signal_count, counter_count, barrier_count));
+
+  s.src_buf = s.win->register_local_buffer(s.src_tensor);
+
+  // Ensure both ranks have completed all registration before kernels launch
+  torchcomm->barrier(false);
+
+  // Ensure all GPU work (tensor zeroing, registration) is complete before
+  // kernels launch on a different stream
+  cudaDeviceSynchronize();
+
+  return s;
+}
+
+void teardownWindow(
+    WindowSetup& s,
+    std::shared_ptr<torch::comms::TorchComm>& torchcomm) {
+  s.win->deregister_local_buffer(s.src_buf);
+  s.win->tensor_deregister();
+  s.win.reset();
+  s.mem_pool.reset();
+  torchcomm->barrier(false);
+}
+
+// Allocate device int array, check results on host after kernel completion.
+void checkKernelResults(
+    int* d_results,
+    int iterations,
+    const std::string& tag) {
+  std::vector<int> h_results(iterations);
+  cudaMemcpy(
+      h_results.data(),
+      d_results,
+      iterations * sizeof(int),
+      cudaMemcpyDeviceToHost);
+  for (int i = 0; i < iterations; i++) {
+    ASSERT_EQ(h_results[i], 1)
+        << tag << ": verification failed at iteration " << i;
+  }
+}
+
+} // namespace
+
+// =============================================================================
+// Category 1: Iterated Correctness
+// =============================================================================
+
+void DeviceApiIteratedTest::testIteratedPut(size_t msg_bytes, CoopScope scope) {
+  size_t count = msg_bytes / sizeof(float);
+  if (count == 0) {
+    count = 1;
+  }
+  int num_threads = threadsForScope(scope);
+  int iterations = config_.num_iterations;
+
+  SCOPED_TRACE(
+      ::testing::Message() << "IteratedPut msg=" << formatBytes(msg_bytes)
+                           << " scope=" << scopeName(scope)
+                           << " iters=" << iterations);
+
+  auto s = createWindowSetup(
+      torchcomm_,
+      allocator_,
+      device_index_,
+      num_ranks_,
+      count,
+      /*signal_count=*/num_ranks_,
+      /*counter_count=*/-1,
+      /*barrier_count=*/2);
+
+  int dst_rank = (rank_ + 1) % num_ranks_;
+  int src_rank = (rank_ - 1 + num_ranks_) % num_ranks_;
+  size_t bytes = count * sizeof(float);
+  size_t src_offset = 0;
+  size_t dst_offset = rank_ * bytes;
+
+  // Allocate results buffer on device
+  int* d_results = nullptr;
+  ASSERT_EQ(cudaMalloc(&d_results, iterations * sizeof(int)), cudaSuccess);
+  ASSERT_EQ(cudaMemset(d_results, 0, iterations * sizeof(int)), cudaSuccess);
+
+  auto stream = at::cuda::getStreamFromPool(false, device_index_);
+  {
+    c10::cuda::CUDAStreamGuard guard(stream);
+    launchIteratedPutKernel(
+        s.dev_win,
+        s.src_buf,
+        s.src_tensor.data_ptr<float>(),
+        s.win_tensor.data_ptr<float>(),
+        src_offset,
+        dst_offset,
+        bytes,
+        count,
+        dst_rank,
+        src_rank,
+        /*signal_id=*/0,
+        iterations,
+        scope,
+        num_threads,
+        d_results,
+        stream.stream());
+  }
+  stream.synchronize();
+
+  checkKernelResults(
+      d_results,
+      iterations,
+      "IteratedPut(" + formatBytes(msg_bytes) + "," + scopeName(scope) + ")");
+
+  cudaFree(d_results);
+  teardownWindow(s, torchcomm_);
+}
+
+void DeviceApiIteratedTest::testIteratedSignal(CoopScope scope) {
+  int iterations = config_.num_iterations;
+  int num_threads = threadsForScope(scope);
+
+  SCOPED_TRACE(
+      ::testing::Message() << "IteratedSignal scope=" << scopeName(scope)
+                           << " iters=" << iterations);
+
+  // Minimal window — only need signal infrastructure
+  size_t count = 1;
+  auto s = createWindowSetup(
+      torchcomm_,
+      allocator_,
+      device_index_,
+      num_ranks_,
+      count,
+      /*signal_count=*/num_ranks_,
+      /*counter_count=*/-1,
+      /*barrier_count=*/1);
+
+  int dst_rank = (rank_ + 1) % num_ranks_;
+  int src_rank = (rank_ - 1 + num_ranks_) % num_ranks_;
+
+  auto stream = at::cuda::getStreamFromPool(false, device_index_);
+  {
+    c10::cuda::CUDAStreamGuard guard(stream);
+    launchIteratedSignalKernel(
+        s.dev_win,
+        dst_rank,
+        src_rank,
+        /*signal_id=*/0,
+        iterations,
+        scope,
+        num_threads,
+        stream.stream());
+  }
+  // If signal is broken, this hangs — timeout is the failure signal.
+  stream.synchronize();
+
+  teardownWindow(s, torchcomm_);
+}
+
+void DeviceApiIteratedTest::testIteratedBarrier(CoopScope scope) {
+  int iterations = config_.num_iterations;
+  int num_threads = threadsForScope(scope);
+
+  SCOPED_TRACE(
+      ::testing::Message() << "IteratedBarrier scope=" << scopeName(scope)
+                           << " iters=" << iterations);
+
+  size_t count = 1;
+  auto s = createWindowSetup(
+      torchcomm_,
+      allocator_,
+      device_index_,
+      num_ranks_,
+      count,
+      /*signal_count=*/-1,
+      /*counter_count=*/-1,
+      /*barrier_count=*/2);
+
+  auto stream = at::cuda::getStreamFromPool(false, device_index_);
+  {
+    c10::cuda::CUDAStreamGuard guard(stream);
+    launchIteratedBarrierKernel(
+        s.dev_win, iterations, scope, num_threads, stream.stream());
+  }
+  stream.synchronize();
+
+  teardownWindow(s, torchcomm_);
+}
+
+void DeviceApiIteratedTest::testIteratedCombined(size_t msg_bytes) {
+  size_t count = msg_bytes / sizeof(float);
+  if (count == 0) {
+    count = 1;
+  }
+  int iterations = config_.num_iterations;
+
+  SCOPED_TRACE(
+      ::testing::Message() << "IteratedCombined msg=" << formatBytes(msg_bytes)
+                           << " iters=" << iterations);
+
+  auto s = createWindowSetup(
+      torchcomm_,
+      allocator_,
+      device_index_,
+      num_ranks_,
+      count,
+      /*signal_count=*/num_ranks_,
+      /*counter_count=*/-1,
+      /*barrier_count=*/4);
+
+  int dst_rank = (rank_ + 1) % num_ranks_;
+  int src_rank = (rank_ - 1 + num_ranks_) % num_ranks_;
+  size_t bytes = count * sizeof(float);
+  size_t src_offset = 0;
+  size_t dst_offset = rank_ * bytes;
+
+  int* d_results = nullptr;
+  ASSERT_EQ(cudaMalloc(&d_results, iterations * sizeof(int)), cudaSuccess);
+  ASSERT_EQ(cudaMemset(d_results, 0, iterations * sizeof(int)), cudaSuccess);
+
+  auto stream = at::cuda::getStreamFromPool(false, device_index_);
+  {
+    c10::cuda::CUDAStreamGuard guard(stream);
+    launchIteratedCombinedKernel(
+        s.dev_win,
+        s.src_buf,
+        s.src_tensor.data_ptr<float>(),
+        s.win_tensor.data_ptr<float>(),
+        src_offset,
+        dst_offset,
+        bytes,
+        count,
+        dst_rank,
+        src_rank,
+        /*signal_id=*/0,
+        /*barrier_id_base=*/0,
+        iterations,
+        d_results,
+        stream.stream());
+  }
+  stream.synchronize();
+
+  checkKernelResults(
+      d_results,
+      iterations,
+      "IteratedCombined(" + formatBytes(msg_bytes) + ")");
+
+  cudaFree(d_results);
+  teardownWindow(s, torchcomm_);
+}
+
+// =============================================================================
+// Category 2: Concurrency
+// =============================================================================
+
+void DeviceApiIteratedTest::testMultiWindow() {
+  int num_windows = config_.window_count;
+  int iterations = config_.num_iterations / 2; // fewer iters per window
+  size_t count = 1024; // 4KB per window
+
+  SCOPED_TRACE(
+      ::testing::Message() << "MultiWindow windows=" << num_windows
+                           << " iters=" << iterations);
+
+  int dst_rank = (rank_ + 1) % num_ranks_;
+  int src_rank = (rank_ - 1 + num_ranks_) % num_ranks_;
+
+  // Create multiple windows on the same communicator
+  std::vector<WindowSetup> windows;
+  windows.reserve(num_windows);
+  for (int w = 0; w < num_windows; w++) {
+    windows.push_back(createWindowSetup(
+        torchcomm_,
+        allocator_,
+        device_index_,
+        num_ranks_,
+        count,
+        /*signal_count=*/num_ranks_,
+        /*counter_count=*/-1,
+        /*barrier_count=*/2));
+  }
+
+  // Run put iterations on each window sequentially (different streams)
+  std::vector<int*> d_results_vec(num_windows, nullptr);
+  std::vector<at::cuda::CUDAStream> streams;
+  streams.reserve(num_windows);
+
+  for (int w = 0; w < num_windows; w++) {
+    ASSERT_EQ(
+        cudaMalloc(&d_results_vec[w], iterations * sizeof(int)), cudaSuccess);
+    ASSERT_EQ(
+        cudaMemset(d_results_vec[w], 0, iterations * sizeof(int)), cudaSuccess);
+
+    auto stream = at::cuda::getStreamFromPool(false, device_index_);
+    streams.push_back(stream);
+
+    size_t bytes = count * sizeof(float);
+    c10::cuda::CUDAStreamGuard guard(stream);
+    launchIteratedPutKernel(
+        windows[w].dev_win,
+        windows[w].src_buf,
+        windows[w].src_tensor.data_ptr<float>(),
+        windows[w].win_tensor.data_ptr<float>(),
+        /*src_offset=*/0,
+        /*dst_offset=*/rank_ * bytes,
+        bytes,
+        count,
+        dst_rank,
+        src_rank,
+        /*signal_id=*/0,
+        iterations,
+        CoopScope::THREAD,
+        1,
+        d_results_vec[w],
+        stream.stream());
+  }
+
+  // Wait for all
+  for (auto& stream : streams) {
+    stream.synchronize();
+  }
+
+  // Verify all windows
+  for (int w = 0; w < num_windows; w++) {
+    checkKernelResults(
+        d_results_vec[w], iterations, "MultiWindow[" + std::to_string(w) + "]");
+    cudaFree(d_results_vec[w]);
+  }
+
+  for (auto& ws : windows) {
+    teardownWindow(ws, torchcomm_);
+  }
+}
+
+void DeviceApiIteratedTest::testMultiComm() {
+  int num_comms = config_.comm_count;
+  int iterations = config_.num_iterations / 2;
+  size_t count = 1024;
+
+  SCOPED_TRACE(
+      ::testing::Message() << "MultiComm comms=" << num_comms
+                           << " iters=" << iterations);
+
+  // Create multiple communicators
+  std::vector<std::unique_ptr<TorchCommTestWrapper>> wrappers;
+  wrappers.reserve(num_comms);
+  std::vector<std::shared_ptr<torch::comms::TorchComm>> comms;
+  comms.reserve(num_comms);
+  for (int c = 0; c < num_comms; c++) {
+    auto w = std::make_unique<TorchCommTestWrapper>();
+    comms.push_back(w->getTorchComm());
+    wrappers.push_back(std::move(w));
+  }
+
+  int dst_rank = (rank_ + 1) % num_ranks_;
+  int src_rank = (rank_ - 1 + num_ranks_) % num_ranks_;
+
+  // Create a window per communicator
+  std::vector<WindowSetup> windows;
+  windows.reserve(num_comms);
+  for (int c = 0; c < num_comms; c++) {
+    windows.push_back(createWindowSetup(
+        comms[c],
+        allocator_,
+        device_index_,
+        num_ranks_,
+        count,
+        /*signal_count=*/num_ranks_,
+        /*counter_count=*/-1,
+        /*barrier_count=*/2));
+  }
+
+  // Run iterated put on each comm's window
+  std::vector<int*> d_results_vec(num_comms, nullptr);
+  std::vector<at::cuda::CUDAStream> streams;
+  streams.reserve(num_comms);
+
+  for (int c = 0; c < num_comms; c++) {
+    ASSERT_EQ(
+        cudaMalloc(&d_results_vec[c], iterations * sizeof(int)), cudaSuccess);
+    ASSERT_EQ(
+        cudaMemset(d_results_vec[c], 0, iterations * sizeof(int)), cudaSuccess);
+
+    auto stream = at::cuda::getStreamFromPool(false, device_index_);
+    streams.push_back(stream);
+
+    size_t bytes = count * sizeof(float);
+    c10::cuda::CUDAStreamGuard guard(stream);
+    launchIteratedPutKernel(
+        windows[c].dev_win,
+        windows[c].src_buf,
+        windows[c].src_tensor.data_ptr<float>(),
+        windows[c].win_tensor.data_ptr<float>(),
+        /*src_offset=*/0,
+        /*dst_offset=*/rank_ * bytes,
+        bytes,
+        count,
+        dst_rank,
+        src_rank,
+        /*signal_id=*/0,
+        iterations,
+        CoopScope::THREAD,
+        1,
+        d_results_vec[c],
+        stream.stream());
+  }
+
+  for (auto& stream : streams) {
+    stream.synchronize();
+  }
+
+  for (int c = 0; c < num_comms; c++) {
+    checkKernelResults(
+        d_results_vec[c], iterations, "MultiComm[" + std::to_string(c) + "]");
+    cudaFree(d_results_vec[c]);
+  }
+
+  for (int c = 0; c < num_comms; c++) {
+    teardownWindow(windows[c], comms[c]);
+  }
+
+  comms.clear();
+  wrappers.clear();
+}
+
+// =============================================================================
+// Category 3: Resource Exhaustion
+// =============================================================================
+
+void DeviceApiIteratedTest::testWindowLifecycle() {
+  int cycles = config_.lifecycle_cycles;
+  size_t count = 256; // Small window per cycle
+
+  SCOPED_TRACE(::testing::Message() << "WindowLifecycle cycles=" << cycles);
+
+  int dst_rank = (rank_ + 1) % num_ranks_;
+  int src_rank = (rank_ - 1 + num_ranks_) % num_ranks_;
+
+  for (int cycle = 0; cycle < cycles; cycle++) {
+    auto s = createWindowSetup(
+        torchcomm_,
+        allocator_,
+        device_index_,
+        num_ranks_,
+        count,
+        /*signal_count=*/num_ranks_,
+        /*counter_count=*/-1,
+        /*barrier_count=*/2);
+
+    // Do one put+verify per cycle
+    int* d_result = nullptr;
+    ASSERT_EQ(cudaMalloc(&d_result, sizeof(int)), cudaSuccess);
+    ASSERT_EQ(cudaMemset(d_result, 0, sizeof(int)), cudaSuccess);
+
+    size_t bytes = count * sizeof(float);
+    auto stream = at::cuda::getStreamFromPool(false, device_index_);
+    {
+      c10::cuda::CUDAStreamGuard guard(stream);
+      launchIteratedPutKernel(
+          s.dev_win,
+          s.src_buf,
+          s.src_tensor.data_ptr<float>(),
+          s.win_tensor.data_ptr<float>(),
+          /*src_offset=*/0,
+          /*dst_offset=*/rank_ * bytes,
+          bytes,
+          count,
+          dst_rank,
+          src_rank,
+          /*signal_id=*/0,
+          /*iterations=*/1,
+          CoopScope::THREAD,
+          1,
+          d_result,
+          stream.stream());
+    }
+    stream.synchronize();
+
+    checkKernelResults(
+        d_result, 1, "WindowLifecycle[" + std::to_string(cycle) + "]");
+    cudaFree(d_result);
+
+    teardownWindow(s, torchcomm_);
+  }
+}
+
+void DeviceApiIteratedTest::testBufferRegistrationChurn() {
+  int cycles = config_.lifecycle_cycles;
+  size_t count = 256;
+
+  SCOPED_TRACE(
+      ::testing::Message() << "BufferRegistrationChurn cycles=" << cycles);
+
+  // Create window once, repeatedly register/deregister source buffers
+  auto mem_pool = std::make_unique<at::cuda::MemPool>(
+      std::static_pointer_cast<c10::cuda::CUDACachingAllocator::CUDAAllocator>(
+          allocator_));
+  c10::cuda::CUDACachingAllocator::beginAllocateToPool(
+      mem_pool->device(), mem_pool->id(), [](cudaStream_t) { return true; });
+
+  auto options =
+      at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, device_index_);
+  at::Tensor win_tensor =
+      at::zeros({static_cast<int64_t>(count * num_ranks_)}, options);
+
+  c10::cuda::CUDACachingAllocator::endAllocateToPool(
+      mem_pool->device(), mem_pool->id());
+
+  torchcomm_->barrier(false);
+  auto win = torchcomm_->new_window();
+  win->tensor_register(win_tensor);
+  torchcomm_->barrier(false);
+
+  auto* dev_win =
+      static_cast<DeviceWindowNCCL*>(win->get_device_window(num_ranks_, -1, 1));
+  ASSERT_NE(dev_win, nullptr);
+
+  int dst_rank = (rank_ + 1) % num_ranks_;
+  int src_rank = (rank_ - 1 + num_ranks_) % num_ranks_;
+
+  for (int cycle = 0; cycle < cycles; cycle++) {
+    // Create a new source tensor and register it
+    at::Tensor src = at::zeros({static_cast<int64_t>(count)}, options);
+    auto src_buf = win->register_local_buffer(src);
+    ASSERT_NE(src_buf.base_ptr, nullptr)
+        << "Cycle " << cycle << ": register_local_buffer returned null";
+
+    // Do one put
+    int* d_result = nullptr;
+    ASSERT_EQ(cudaMalloc(&d_result, sizeof(int)), cudaSuccess);
+    ASSERT_EQ(cudaMemset(d_result, 0, sizeof(int)), cudaSuccess);
+
+    size_t bytes = count * sizeof(float);
+    auto stream = at::cuda::getStreamFromPool(false, device_index_);
+    {
+      c10::cuda::CUDAStreamGuard guard(stream);
+      launchIteratedPutKernel(
+          dev_win,
+          src_buf,
+          src.data_ptr<float>(),
+          win_tensor.data_ptr<float>(),
+          /*src_offset=*/0,
+          /*dst_offset=*/rank_ * bytes,
+          bytes,
+          count,
+          dst_rank,
+          src_rank,
+          /*signal_id=*/0,
+          /*iterations=*/1,
+          CoopScope::THREAD,
+          1,
+          d_result,
+          stream.stream());
+    }
+    stream.synchronize();
+
+    checkKernelResults(
+        d_result, 1, "BufferChurn[" + std::to_string(cycle) + "]");
+    cudaFree(d_result);
+
+    win->deregister_local_buffer(src_buf);
+  }
+
+  win->tensor_deregister();
+  win.reset();
+  mem_pool.reset();
+  torchcomm_->barrier(false);
+}
+
+// =============================================================================
+// Parameterized Test Registrations
+// =============================================================================
+
+// --- Put: parameterized by (msg_bytes, scope) ---
+
+struct PutParam {
+  size_t msg_bytes;
+  CoopScope scope;
+};
+
+class DeviceApiIteratedPutTest
+    : public DeviceApiIteratedTest,
+      public ::testing::WithParamInterface<PutParam> {};
+
+TEST_P(DeviceApiIteratedPutTest, Put) {
+  testIteratedPut(GetParam().msg_bytes, GetParam().scope);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    IteratedPut,
+    DeviceApiIteratedPutTest,
+    ::testing::Values(
+        PutParam{4, CoopScope::THREAD},
+        PutParam{1024, CoopScope::THREAD},
+        PutParam{1048576, CoopScope::THREAD},
+        PutParam{16777216, CoopScope::THREAD},
+        PutParam{1024, CoopScope::WARP},
+        PutParam{1024, CoopScope::BLOCK},
+        PutParam{1048576, CoopScope::WARP},
+        PutParam{1048576, CoopScope::BLOCK}),
+    [](const auto& info) {
+      return std::to_string(info.param.msg_bytes) + "B_" +
+          scopeName(info.param.scope);
+    });
+
+// --- Signal: parameterized by scope ---
+
+class DeviceApiIteratedSignalTest
+    : public DeviceApiIteratedTest,
+      public ::testing::WithParamInterface<CoopScope> {};
+
+TEST_P(DeviceApiIteratedSignalTest, Signal) {
+  testIteratedSignal(GetParam());
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    IteratedSignal,
+    DeviceApiIteratedSignalTest,
+    ::testing::Values(CoopScope::THREAD, CoopScope::WARP, CoopScope::BLOCK),
+    [](const ::testing::TestParamInfo<CoopScope>& info) {
+      return std::string(scopeName(info.param));
+    });
+
+// --- Barrier: parameterized by scope ---
+
+class DeviceApiIteratedBarrierTest
+    : public DeviceApiIteratedTest,
+      public ::testing::WithParamInterface<CoopScope> {};
+
+TEST_P(DeviceApiIteratedBarrierTest, Barrier) {
+  testIteratedBarrier(GetParam());
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    IteratedBarrier,
+    DeviceApiIteratedBarrierTest,
+    ::testing::Values(CoopScope::THREAD, CoopScope::WARP, CoopScope::BLOCK),
+    [](const ::testing::TestParamInfo<CoopScope>& info) {
+      return std::string(scopeName(info.param));
+    });
+
+// --- Combined: parameterized by msg_bytes ---
+
+class DeviceApiIteratedCombinedTest
+    : public DeviceApiIteratedTest,
+      public ::testing::WithParamInterface<size_t> {};
+
+TEST_P(DeviceApiIteratedCombinedTest, Combined) {
+  testIteratedCombined(GetParam());
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    IteratedCombined,
+    DeviceApiIteratedCombinedTest,
+    ::testing::Values(static_cast<size_t>(1024), static_cast<size_t>(1048576)),
+    [](const auto& info) { return std::to_string(info.param) + "B"; });
+
+// --- Non-parameterized tests ---
+
+TEST_F(DeviceApiIteratedTest, MultiWindow) {
+  testMultiWindow();
+}
+
+TEST_F(DeviceApiIteratedTest, MultiComm) {
+  testMultiComm();
+}
+
+TEST_F(DeviceApiIteratedTest, WindowLifecycle) {
+  testWindowLifecycle();
+}
+
+TEST_F(DeviceApiIteratedTest, BufferRegistrationChurn) {
+  testBufferRegistrationChurn();
+}

--- a/comms/torchcomms/tests/integration/cpp/DeviceApiIteratedTest.hpp
+++ b/comms/torchcomms/tests/integration/cpp/DeviceApiIteratedTest.hpp
@@ -1,0 +1,69 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Iterated functional tests for TorchComm Device API — NCCLx (GIN+LSA) backend.
+// Runs each device API operation many times with data verification to catch
+// correctness issues under sustained load.
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include <memory>
+#include <vector>
+
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDACachingAllocator.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAStream.h>
+
+#include <ATen/cuda/MemPool.h>
+
+#include "IteratedTestHelpers.hpp"
+#include "TorchCommTestHelpers.h"
+#include "comms/torchcomms/TorchComm.hpp"
+#include "comms/torchcomms/device/TorchCommDeviceWindow.hpp"
+#include "comms/torchcomms/ncclx/TorchCommWindowNCCLX.hpp"
+
+class DeviceApiIteratedTest : public ::testing::Test {
+ protected:
+  void SetUp() override;
+  void TearDown() override;
+
+  // --- Category 1: Iterated correctness (in-kernel loops) ---
+
+  // Put soak: ring put with fill/verify per iteration, parameterized by scope
+  void testIteratedPut(size_t msg_bytes, torchcomms::device::CoopScope scope);
+
+  // Signal soak: ring signal+wait_signal_from per iteration
+  void testIteratedSignal(torchcomms::device::CoopScope scope);
+
+  // Barrier soak: barrier called repeatedly
+  void testIteratedBarrier(torchcomms::device::CoopScope scope);
+
+  // Combined: barrier -> put -> wait -> verify per iteration
+  void testIteratedCombined(size_t msg_bytes);
+
+  // --- Category 2: Concurrency (host-side orchestration) ---
+
+  // Multiple windows on the same communicator, each doing independent puts
+  void testMultiWindow();
+
+  // Multiple communicators, each doing independent puts
+  void testMultiComm();
+
+  // --- Category 3: Resource exhaustion (host-side loops) ---
+
+  // Repeated window create/register/operate/deregister/destroy
+  void testWindowLifecycle();
+
+  // Repeated register_local_buffer / put / deregister_local_buffer
+  void testBufferRegistrationChurn();
+
+  // Member variables
+  torchcomms::device::test::IteratedTestConfig config_;
+  std::unique_ptr<TorchCommTestWrapper> wrapper_;
+  std::shared_ptr<torch::comms::TorchComm> torchcomm_;
+  std::shared_ptr<c10::Allocator> allocator_;
+  int rank_{0};
+  int num_ranks_{0};
+  int device_index_{0};
+};

--- a/comms/torchcomms/tests/integration/cpp/DeviceApiIteratedTestKernels.cu
+++ b/comms/torchcomms/tests/integration/cpp/DeviceApiIteratedTestKernels.cu
@@ -1,0 +1,247 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// CUDA kernel implementations for DeviceApiIteratedTest (NCCLx backend).
+
+#include "DeviceApiIteratedTestKernels.cuh"
+#include "IteratedTestKernelUtils.cuh"
+
+#include "comms/torchcomms/device/ncclx/TorchCommDeviceNCCLX.cuh"
+
+// Kernel launch error check for test code.
+#define KERNEL_LAUNCH_CHECK()                        \
+  do {                                               \
+    cudaError_t err__ = cudaGetLastError();          \
+    assert(err__ == cudaSuccess && "kernel launch"); \
+    (void)err__;                                     \
+  } while (0)
+
+namespace torchcomms::device::test {
+
+// ---------------------------------------------------------------------------
+// Iterated Put Kernel
+// ---------------------------------------------------------------------------
+// Each iteration: fill src -> put to dst_rank -> wait signal from src_rank ->
+// verify received data. Uses monotonic signal values (signal = iter+1).
+__global__ void iteratedPutKernel(
+    DeviceWindowNCCL* win,
+    RegisteredBufferNCCL src_buf,
+    float* src_ptr,
+    float* win_base,
+    size_t src_offset,
+    size_t dst_offset,
+    size_t bytes,
+    size_t count,
+    int dst_rank,
+    int src_rank,
+    int signal_id,
+    int iterations,
+    CoopScope scope,
+    int* results) {
+  int rank = win->rank();
+
+  for (int iter = 0; iter < iterations; iter++) {
+    // Fill source buffer with pattern for this iteration
+    fillPattern(src_ptr, count, rank, iter);
+    __syncthreads();
+
+    // Put to destination with signal notification
+    // Use monotonic signal values: each put increments signal by 1
+    win->put(
+        dst_offset, src_buf, src_offset, dst_rank, bytes, signal_id, -1, scope);
+    win->flush(scope);
+
+    // Wait for signal from src_rank (monotonic: iter+1)
+    win->wait_signal(
+        signal_id, CmpOp::GE, static_cast<uint64_t>(iter + 1), scope);
+
+    // Verify received data from src_rank
+    float* recv_slot = win_base + src_rank * count;
+    verifyPattern(recv_slot, count, src_rank, iter, &results[iter]);
+
+    // Barrier ensures both ranks finish reading before either starts the next
+    // iteration's put (which overwrites the receive slot)
+    win->barrier(iter % 2, scope);
+  }
+}
+
+void launchIteratedPutKernel(
+    DeviceWindowNCCL* win,
+    RegisteredBufferNCCL src_buf,
+    float* src_ptr,
+    float* win_base,
+    size_t src_offset,
+    size_t dst_offset,
+    size_t bytes,
+    size_t count,
+    int dst_rank,
+    int src_rank,
+    int signal_id,
+    int iterations,
+    CoopScope scope,
+    int num_threads,
+    int* results,
+    cudaStream_t stream) {
+  iteratedPutKernel<<<1, num_threads, 0, stream>>>(
+      win,
+      src_buf,
+      src_ptr,
+      win_base,
+      src_offset,
+      dst_offset,
+      bytes,
+      count,
+      dst_rank,
+      src_rank,
+      signal_id,
+      iterations,
+      scope,
+      results);
+  KERNEL_LAUNCH_CHECK();
+}
+
+// ---------------------------------------------------------------------------
+// Iterated Signal Kernel
+// ---------------------------------------------------------------------------
+// Ring signal pattern: rank i signals rank (i+1), waits for signal from (i-1).
+// Uses monotonic signal values.
+
+__global__ void iteratedSignalKernel(
+    DeviceWindowNCCL* win,
+    int dst_rank,
+    int src_rank,
+    int signal_id,
+    int iterations,
+    CoopScope scope) {
+  for (int iter = 0; iter < iterations; iter++) {
+    // All threads must call signal() — GIN cooperative ops (ncclCoopWarp,
+    // ncclCoopCta) require all threads in the group to participate.
+    win->signal(dst_rank, signal_id, SignalOp::ADD, 1, scope);
+    __syncthreads();
+
+    // Wait for signal from previous rank (monotonic)
+    win->wait_signal_from(
+        src_rank, signal_id, CmpOp::GE, static_cast<uint64_t>(iter + 1), scope);
+  }
+}
+
+void launchIteratedSignalKernel(
+    DeviceWindowNCCL* win,
+    int dst_rank,
+    int src_rank,
+    int signal_id,
+    int iterations,
+    CoopScope scope,
+    int num_threads,
+    cudaStream_t stream) {
+  iteratedSignalKernel<<<1, num_threads, 0, stream>>>(
+      win, dst_rank, src_rank, signal_id, iterations, scope);
+  KERNEL_LAUNCH_CHECK();
+}
+
+// ---------------------------------------------------------------------------
+// Iterated Barrier Kernel
+// ---------------------------------------------------------------------------
+// Calls barrier repeatedly, alternating between two barrier IDs.
+
+__global__ void
+iteratedBarrierKernel(DeviceWindowNCCL* win, int iterations, CoopScope scope) {
+  for (int iter = 0; iter < iterations; iter++) {
+    int barrier_id = iter % 2;
+    win->barrier(barrier_id, scope);
+  }
+}
+
+void launchIteratedBarrierKernel(
+    DeviceWindowNCCL* win,
+    int iterations,
+    CoopScope scope,
+    int num_threads,
+    cudaStream_t stream) {
+  iteratedBarrierKernel<<<1, num_threads, 0, stream>>>(win, iterations, scope);
+  KERNEL_LAUNCH_CHECK();
+}
+
+// ---------------------------------------------------------------------------
+// Combined Ops Kernel
+// ---------------------------------------------------------------------------
+// Each iteration: barrier -> fill -> put -> wait_signal -> verify -> barrier
+
+__global__ void iteratedCombinedKernel(
+    DeviceWindowNCCL* win,
+    RegisteredBufferNCCL src_buf,
+    float* src_ptr,
+    float* win_base,
+    size_t src_offset,
+    size_t dst_offset,
+    size_t bytes,
+    size_t count,
+    int dst_rank,
+    int src_rank,
+    int signal_id,
+    int barrier_id_base,
+    int iterations,
+    int* results) {
+  int rank = win->rank();
+
+  for (int iter = 0; iter < iterations; iter++) {
+    // Pre-barrier: synchronize all ranks before this iteration
+    win->barrier(barrier_id_base + (iter % 2));
+
+    // Fill source with iteration-specific pattern
+    fillPattern(src_ptr, count, rank, iter);
+
+    // Put with signal (thread scope for combined test)
+    if (threadIdx.x == 0) {
+      win->put(dst_offset, src_buf, src_offset, dst_rank, bytes, signal_id, -1);
+      win->flush();
+    }
+    __syncthreads();
+
+    // Wait for data from src_rank
+    if (threadIdx.x == 0) {
+      win->wait_signal(signal_id, CmpOp::GE, static_cast<uint64_t>(iter + 1));
+    }
+    __syncthreads();
+
+    // Verify received data
+    float* recv_slot = win_base + src_rank * count;
+    verifyPattern(recv_slot, count, src_rank, iter, &results[iter]);
+    __syncthreads();
+  }
+}
+
+void launchIteratedCombinedKernel(
+    DeviceWindowNCCL* win,
+    RegisteredBufferNCCL src_buf,
+    float* src_ptr,
+    float* win_base,
+    size_t src_offset,
+    size_t dst_offset,
+    size_t bytes,
+    size_t count,
+    int dst_rank,
+    int src_rank,
+    int signal_id,
+    int barrier_id_base,
+    int iterations,
+    int* results,
+    cudaStream_t stream) {
+  iteratedCombinedKernel<<<1, 1, 0, stream>>>(
+      win,
+      src_buf,
+      src_ptr,
+      win_base,
+      src_offset,
+      dst_offset,
+      bytes,
+      count,
+      dst_rank,
+      src_rank,
+      signal_id,
+      barrier_id_base,
+      iterations,
+      results);
+  KERNEL_LAUNCH_CHECK();
+}
+
+} // namespace torchcomms::device::test

--- a/comms/torchcomms/tests/integration/cpp/DeviceApiIteratedTestKernels.cuh
+++ b/comms/torchcomms/tests/integration/cpp/DeviceApiIteratedTestKernels.cuh
@@ -1,0 +1,92 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// CUDA kernel declarations for DeviceApiIteratedTest (NCCLx backend).
+// Host-safe header — can be included from .cpp files compiled by clang.
+
+// NOLINTNEXTLINE(clang-diagnostic-pragma-once-outside-header)
+#pragma once
+
+#include <cuda_runtime.h>
+#include "comms/torchcomms/device/ncclx/TorchCommDeviceNCCLXTypes.hpp"
+
+namespace torchcomms::device::test {
+
+// Iterated put kernel: performs put+signal in a loop, writing src_buf to
+// dst_rank's window. Uses monotonic signal values (signal value = iteration+1).
+// Receiver waits for signal to reach the monotonic target before verifying.
+// The kernel fills src with a rank+iteration pattern each iteration.
+//
+// Parameters:
+//   win         - device window pointer (device memory)
+//   src_buf     - registered local source buffer
+//   src_ptr     - raw float pointer to source buffer (for fill pattern)
+//   win_base    - raw float pointer to window base (for verification)
+//   src_offset  - byte offset within src_buf
+//   dst_offset  - byte offset within destination window
+//   bytes       - bytes to put per iteration
+//   count       - number of float elements (bytes / sizeof(float))
+//   dst_rank    - destination rank in ring
+//   src_rank    - source rank (who sends to us)
+//   signal_id   - signal slot to use
+//   iterations  - number of put iterations
+//   scope       - cooperative scope (THREAD, WARP, BLOCK)
+//   results     - device int array[iterations], 1=pass 0=fail per iteration
+void launchIteratedPutKernel(
+    DeviceWindowNCCL* win,
+    RegisteredBufferNCCL src_buf,
+    float* src_ptr,
+    float* win_base,
+    size_t src_offset,
+    size_t dst_offset,
+    size_t bytes,
+    size_t count,
+    int dst_rank,
+    int src_rank,
+    int signal_id,
+    int iterations,
+    CoopScope scope,
+    int num_threads,
+    int* results,
+    cudaStream_t stream);
+
+// Iterated signal kernel: sends signal to dst_rank in a ring, waits for
+// signal from src_rank, repeated iterations times. Uses monotonic values.
+void launchIteratedSignalKernel(
+    DeviceWindowNCCL* win,
+    int dst_rank,
+    int src_rank,
+    int signal_id,
+    int iterations,
+    CoopScope scope,
+    int num_threads,
+    cudaStream_t stream);
+
+// Iterated barrier kernel: calls barrier iterations times, alternating
+// between barrier_id 0 and 1.
+void launchIteratedBarrierKernel(
+    DeviceWindowNCCL* win,
+    int iterations,
+    CoopScope scope,
+    int num_threads,
+    cudaStream_t stream);
+
+// Combined ops kernel: barrier -> fill -> put -> wait_signal -> verify ->
+// barrier per iteration. Tests interleaved operations.
+void launchIteratedCombinedKernel(
+    DeviceWindowNCCL* win,
+    RegisteredBufferNCCL src_buf,
+    float* src_ptr,
+    float* win_base,
+    size_t src_offset,
+    size_t dst_offset,
+    size_t bytes,
+    size_t count,
+    int dst_rank,
+    int src_rank,
+    int signal_id,
+    int barrier_id_base,
+    int iterations,
+    int* results,
+    cudaStream_t stream);
+
+} // namespace torchcomms::device::test

--- a/comms/torchcomms/tests/integration/cpp/DeviceApiIteratedTestMain.cpp
+++ b/comms/torchcomms/tests/integration/cpp/DeviceApiIteratedTestMain.cpp
@@ -1,0 +1,11 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Entry point for DeviceApiIteratedTest (NCCLx backend).
+// Links against the test library which statically registers all TEST_F cases.
+
+#include <gtest/gtest.h>
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/torchcomms/tests/integration/cpp/IteratedTestHelpers.cpp
+++ b/comms/torchcomms/tests/integration/cpp/IteratedTestHelpers.cpp
@@ -1,0 +1,169 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "IteratedTestHelpers.hpp"
+
+#include <folly/String.h>
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <sstream>
+
+namespace torchcomms::device::test {
+
+namespace {
+
+// Parse a comma-separated list of integers from an env var.
+std::vector<size_t> parseSizeList(const char* env_val) {
+  std::vector<size_t> result;
+  std::vector<folly::StringPiece> parts;
+  folly::split(',', env_val, parts);
+  for (const auto& part : parts) {
+    if (!part.empty()) {
+      result.push_back(folly::to<size_t>(part));
+    }
+  }
+  return result;
+}
+
+// Parse a comma-separated list of scope names.
+std::vector<CoopScope> parseScopeList(const char* env_val) {
+  std::vector<CoopScope> result;
+  std::string s(env_val);
+  std::transform(s.begin(), s.end(), s.begin(), ::tolower);
+  std::vector<folly::StringPiece> parts;
+  folly::split(',', s, parts);
+  for (const auto& part : parts) {
+    if (part == "thread") {
+      result.push_back(CoopScope::THREAD);
+    } else if (part == "warp") {
+      result.push_back(CoopScope::WARP);
+    } else if (part == "block") {
+      result.push_back(CoopScope::BLOCK);
+    }
+  }
+  return result;
+}
+
+bool envBool(const char* name) {
+  const char* val = std::getenv(name);
+  if (!val) {
+    return false;
+  }
+  std::string s(val);
+  std::transform(s.begin(), s.end(), s.begin(), ::tolower);
+  return s == "1" || s == "true" || s == "yes" || s == "y" || s == "t";
+}
+
+int envInt(const char* name, int default_val) {
+  const char* val = std::getenv(name);
+  if (!val) {
+    return default_val;
+  }
+  return std::atoi(val);
+}
+
+} // namespace
+
+IteratedTestConfig parseIteratedTestConfig() {
+  IteratedTestConfig config;
+
+  config.num_iterations = envInt("NUM_ITERATIONS", config.num_iterations);
+  config.window_count = envInt("ITERATED_WINDOW_COUNT", config.window_count);
+  config.comm_count = envInt("ITERATED_COMM_COUNT", config.comm_count);
+  config.lifecycle_cycles =
+      envInt("ITERATED_LIFECYCLE_CYCLES", config.lifecycle_cycles);
+  config.verbose = envBool("ITERATED_VERBOSE");
+
+  const char* sizes_env = std::getenv("ITERATED_MSG_SIZES");
+  if (sizes_env) {
+    auto parsed = parseSizeList(sizes_env);
+    if (!parsed.empty()) {
+      config.msg_sizes = std::move(parsed);
+    }
+  }
+
+  const char* scopes_env = std::getenv("ITERATED_SCOPES");
+  if (scopes_env) {
+    auto parsed = parseScopeList(scopes_env);
+    if (!parsed.empty()) {
+      config.scopes = std::move(parsed);
+    }
+  }
+
+  return config;
+}
+
+bool shouldRunIteratedTest() {
+  return envBool("RUN_DEVICE_ITERATED_TEST");
+}
+
+int threadsForScope(CoopScope scope) {
+  switch (scope) {
+    case CoopScope::THREAD:
+      return 1;
+    case CoopScope::WARP:
+      return 32;
+    case CoopScope::BLOCK:
+      return 256;
+  }
+  return 1;
+}
+
+const char* scopeName(CoopScope scope) {
+  switch (scope) {
+    case CoopScope::THREAD:
+      return "thread";
+    case CoopScope::WARP:
+      return "warp";
+    case CoopScope::BLOCK:
+      return "block";
+  }
+  return "unknown";
+}
+
+std::string formatBytes(size_t bytes) {
+  const char* units[] = {"B", "KB", "MB", "GB"};
+  int unit_idx = 0;
+  double val = static_cast<double>(bytes);
+  while (val >= 1024.0 && unit_idx < 3) {
+    val /= 1024.0;
+    unit_idx++;
+  }
+  std::ostringstream oss;
+  if (unit_idx == 0) {
+    oss << bytes << " B";
+  } else {
+    oss << std::fixed;
+    oss.precision(2);
+    oss << val << " " << units[unit_idx];
+  }
+  return oss.str();
+}
+
+bool verifyFillPattern(
+    const float* data,
+    size_t count,
+    int expected_rank,
+    int expected_iteration,
+    size_t* out_first_bad_index,
+    float* out_got,
+    float* out_expected) {
+  float expected_val = fillPatternValue(expected_rank, expected_iteration);
+  for (size_t i = 0; i < count; i++) {
+    if (std::abs(data[i] - expected_val) > 1e-3f) {
+      if (out_first_bad_index) {
+        *out_first_bad_index = i;
+      }
+      if (out_got) {
+        *out_got = data[i];
+      }
+      if (out_expected) {
+        *out_expected = expected_val;
+      }
+      return false;
+    }
+  }
+  return true;
+}
+
+} // namespace torchcomms::device::test

--- a/comms/torchcomms/tests/integration/cpp/IteratedTestHelpers.hpp
+++ b/comms/torchcomms/tests/integration/cpp/IteratedTestHelpers.hpp
@@ -1,0 +1,83 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Shared helpers for iterated device API tests.
+// Provides configuration from environment variables, message size sweeps,
+// scope parameterization, and verification utilities.
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "comms/torchcomms/device/TorchCommDeviceWindow.hpp"
+
+namespace torchcomms::device::test {
+
+// Configuration parsed from environment variables.
+struct IteratedTestConfig {
+  // Number of iterations for soak-style tests (default: 100).
+  int num_iterations{100};
+
+  // Message sizes in bytes to sweep (default: 4B, 1KB, 1MB, 16MB).
+  std::vector<size_t> msg_sizes{4, 1024, 1048576, 16777216};
+
+  // Scopes to test (default: all three).
+  std::vector<CoopScope> scopes{
+      CoopScope::THREAD,
+      CoopScope::WARP,
+      CoopScope::BLOCK};
+
+  // Number of windows for multi-window tests (default: 4).
+  int window_count{4};
+
+  // Number of communicators for multi-comm tests (default: 2).
+  int comm_count{2};
+
+  // Number of create/destroy cycles for lifecycle tests (default: 50).
+  int lifecycle_cycles{50};
+
+  // Verbose logging per iteration.
+  bool verbose{false};
+};
+
+// Parse configuration from environment variables:
+//   NUM_ITERATIONS, ITERATED_MSG_SIZES (comma-separated bytes),
+//   ITERATED_SCOPES (comma-separated: thread,warp,block),
+//   ITERATED_WINDOW_COUNT, ITERATED_COMM_COUNT,
+//   ITERATED_LIFECYCLE_CYCLES, ITERATED_VERBOSE
+IteratedTestConfig parseIteratedTestConfig();
+
+// Check if iterated tests should run (RUN_DEVICE_ITERATED_TEST env var).
+// Returns true if the env var is set to "1" or "true".
+bool shouldRunIteratedTest();
+
+// Map CoopScope to the number of threads to launch.
+int threadsForScope(CoopScope scope);
+
+// Human-readable scope name.
+const char* scopeName(CoopScope scope);
+
+// Format a byte count for logging (e.g., "1.00 KB", "16.00 MB").
+std::string formatBytes(size_t bytes);
+
+// Fill pattern value for verification: encodes rank and iteration into data.
+// Pattern: (rank + 1) * 1000.0f + iteration
+// This uniquely identifies which rank and iteration produced the data.
+inline float fillPatternValue(int rank, int iteration) {
+  return static_cast<float>((rank + 1) * 1000 + iteration);
+}
+
+// Verify that a host-side float buffer matches the expected fill pattern.
+// Returns true if all elements match, false otherwise.
+// On mismatch, sets out_first_bad_index and out_got / out_expected.
+bool verifyFillPattern(
+    const float* data,
+    size_t count,
+    int expected_rank,
+    int expected_iteration,
+    size_t* out_first_bad_index = nullptr,
+    float* out_got = nullptr,
+    float* out_expected = nullptr);
+
+} // namespace torchcomms::device::test

--- a/comms/torchcomms/tests/integration/cpp/IteratedTestKernelUtils.cuh
+++ b/comms/torchcomms/tests/integration/cpp/IteratedTestKernelUtils.cuh
@@ -1,0 +1,59 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Shared CUDA device helpers for iterated device API tests.
+// These are __device__ functions that can be called from both NCCLx and Pipes
+// test kernels.
+
+// NOLINTNEXTLINE(clang-diagnostic-pragma-once-outside-header)
+#pragma once
+
+#include <cuda_runtime.h>
+#include <cstdint>
+
+namespace torchcomms::device::test {
+
+// Fill a float buffer with a pattern that encodes rank and iteration.
+// Pattern value: (rank + 1) * 1000.0f + iteration
+// Must match fillPatternValue() in IteratedTestHelpers.hpp.
+__device__ inline void
+fillPattern(float* buf, size_t count, int rank, int iteration) {
+  float val = static_cast<float>((rank + 1) * 1000 + iteration);
+  for (size_t i = threadIdx.x; i < count; i += blockDim.x) {
+    buf[i] = val;
+  }
+  __syncthreads();
+}
+
+// Verify a float buffer matches the expected fill pattern.
+// Writes 1 to *result if verification passes, 0 if any element mismatches.
+// Only thread 0 writes the result, but all threads participate in checking.
+__device__ inline void verifyPattern(
+    const float* buf,
+    size_t count,
+    int expected_rank,
+    int expected_iteration,
+    int* result) {
+  float expected_val =
+      static_cast<float>((expected_rank + 1) * 1000 + expected_iteration);
+
+  // Use shared memory for reduction
+  __shared__ int any_mismatch;
+  if (threadIdx.x == 0) {
+    any_mismatch = 0;
+  }
+  __syncthreads();
+
+  for (size_t i = threadIdx.x; i < count; i += blockDim.x) {
+    float diff = buf[i] - expected_val;
+    if (diff > 1e-3f || diff < -1e-3f) {
+      atomicExch(&any_mismatch, 1);
+    }
+  }
+  __syncthreads();
+
+  if (threadIdx.x == 0) {
+    *result = (any_mismatch == 0) ? 1 : 0;
+  }
+}
+
+} // namespace torchcomms::device::test

--- a/comms/torchcomms/tests/integration/cpp/PipesDeviceApiIteratedTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/PipesDeviceApiIteratedTest.cpp
@@ -1,0 +1,552 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Iterated functional tests for TorchComm Device API — Pipes (IBGDA+NVLink).
+// Key difference from NCCLx: uses DeviceWindowPipes type and monotonic signals
+// only (no reset_signal).
+
+#include "PipesDeviceApiIteratedTest.hpp"
+
+#include <gtest/gtest.h>
+#include <algorithm>
+#include <vector>
+#include "IteratedTestHelpers.hpp"
+#include "PipesDeviceApiIteratedTestKernels.cuh"
+#include "TorchCommTestHelpers.h"
+#include "comms/torchcomms/TorchComm.hpp"
+
+using namespace torchcomms::device;
+using namespace torchcomms::device::test;
+
+// =============================================================================
+// Setup / Teardown
+// =============================================================================
+
+void PipesDeviceApiIteratedTest::SetUp() {
+  if (!shouldRunIteratedTest()) {
+    GTEST_SKIP()
+        << "Skipping iterated tests (RUN_DEVICE_ITERATED_TEST not set)";
+  }
+  const char* pipes_env = getenv("RUN_PIPES_DEVICE_API_TEST");
+  if (!pipes_env) {
+    GTEST_SKIP()
+        << "Skipping Pipes iterated tests (RUN_PIPES_DEVICE_API_TEST not set)";
+  }
+
+  config_ = parseIteratedTestConfig();
+  wrapper_ = std::make_unique<TorchCommTestWrapper>();
+  torchcomm_ = wrapper_->getTorchComm();
+  rank_ = torchcomm_->getRank();
+  num_ranks_ = torchcomm_->getSize();
+  device_index_ = rank_ % at::cuda::device_count();
+  allocator_ = torch::comms::get_mem_allocator(torchcomm_->getBackend());
+}
+
+void PipesDeviceApiIteratedTest::TearDown() {
+  torchcomm_.reset();
+  wrapper_.reset();
+}
+
+// =============================================================================
+// Helpers (Pipes-specific: uses DeviceWindowPipes)
+// =============================================================================
+
+namespace {
+
+struct PipesWindowSetup {
+  std::unique_ptr<at::cuda::MemPool> mem_pool;
+  at::Tensor win_tensor;
+  at::Tensor src_tensor;
+  std::shared_ptr<torch::comms::TorchCommWindow> win;
+  DeviceWindowPipes* dev_win{nullptr};
+  RegisteredBufferPipes src_buf{};
+};
+
+PipesWindowSetup createPipesWindowSetup(
+    std::shared_ptr<torch::comms::TorchComm>& torchcomm,
+    std::shared_ptr<c10::Allocator>& allocator,
+    int device_index,
+    int num_ranks,
+    size_t count,
+    int signal_count,
+    int counter_count,
+    int barrier_count) {
+  PipesWindowSetup s;
+
+  s.mem_pool = std::make_unique<at::cuda::MemPool>(
+      std::static_pointer_cast<c10::cuda::CUDACachingAllocator::CUDAAllocator>(
+          allocator));
+  c10::cuda::CUDACachingAllocator::beginAllocateToPool(
+      s.mem_pool->device(), s.mem_pool->id(), [](cudaStream_t) {
+        return true;
+      });
+
+  auto options =
+      at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, device_index);
+  s.win_tensor = at::zeros({static_cast<int64_t>(count * num_ranks)}, options);
+
+  c10::cuda::CUDACachingAllocator::endAllocateToPool(
+      s.mem_pool->device(), s.mem_pool->id());
+
+  // Allocate src_tensor OUTSIDE the pool to ensure it gets its own cuMem
+  // allocation. When both tensors share the same cuMem block and the src_tensor
+  // is not 4096-aligned within that block, NCCL LOCAL_ONLY window registration
+  // truncates ginOffset4K, causing put failures with P2P disabled.
+  s.src_tensor = at::zeros({static_cast<int64_t>(count)}, options);
+
+  torchcomm->barrier(false);
+  s.win = torchcomm->new_window();
+  s.win->tensor_register(s.win_tensor);
+  torchcomm->barrier(false);
+
+  s.dev_win = static_cast<DeviceWindowPipes*>(
+      s.win->get_device_window(signal_count, counter_count, barrier_count));
+
+  s.src_buf = s.win->register_local_buffer(s.src_tensor);
+
+  // Ensure both ranks have completed all registration before kernels launch
+  torchcomm->barrier(false);
+
+  // Ensure all GPU work (tensor zeroing, registration) is complete before
+  // kernels launch on a different stream
+  cudaDeviceSynchronize();
+
+  return s;
+}
+
+void teardownPipesWindow(
+    PipesWindowSetup& s,
+    std::shared_ptr<torch::comms::TorchComm>& torchcomm) {
+  s.win->deregister_local_buffer(s.src_buf);
+  s.win->tensor_deregister();
+  s.win.reset();
+  s.mem_pool.reset();
+  torchcomm->barrier(false);
+}
+
+void checkKernelResults(
+    int* d_results,
+    int iterations,
+    const std::string& tag) {
+  std::vector<int> h_results(iterations);
+  cudaMemcpy(
+      h_results.data(),
+      d_results,
+      iterations * sizeof(int),
+      cudaMemcpyDeviceToHost);
+  for (int i = 0; i < iterations; i++) {
+    ASSERT_EQ(h_results[i], 1)
+        << tag << ": verification failed at iteration " << i;
+  }
+}
+
+} // namespace
+
+// =============================================================================
+// Test Implementations
+// =============================================================================
+
+void PipesDeviceApiIteratedTest::testIteratedPut(
+    size_t msg_bytes,
+    CoopScope scope) {
+  size_t count = msg_bytes / sizeof(float);
+  if (count == 0) {
+    count = 1;
+  }
+  int num_threads = threadsForScope(scope);
+  int iterations = config_.num_iterations;
+
+  SCOPED_TRACE(
+      ::testing::Message() << "PipesIteratedPut msg=" << formatBytes(msg_bytes)
+                           << " scope=" << scopeName(scope)
+                           << " iters=" << iterations);
+
+  // Need at least 2 signals: signal_id=0 for put, signal_id=1 for read-ack
+  int signal_count = std::max(num_ranks_, 2);
+  auto s = createPipesWindowSetup(
+      torchcomm_,
+      allocator_,
+      device_index_,
+      num_ranks_,
+      count,
+      signal_count,
+      -1,
+      -1);
+
+  int dst_rank = (rank_ + 1) % num_ranks_;
+  int src_rank = (rank_ - 1 + num_ranks_) % num_ranks_;
+  size_t bytes = count * sizeof(float);
+
+  int* d_results = nullptr;
+  ASSERT_EQ(cudaMalloc(&d_results, iterations * sizeof(int)), cudaSuccess);
+  ASSERT_EQ(cudaMemset(d_results, 0, iterations * sizeof(int)), cudaSuccess);
+
+  auto stream = at::cuda::getStreamFromPool(false, device_index_);
+  {
+    c10::cuda::CUDAStreamGuard guard(stream);
+    launchPipesIteratedPutKernel(
+        s.dev_win,
+        s.src_buf,
+        s.src_tensor.data_ptr<float>(),
+        s.win_tensor.data_ptr<float>(),
+        0,
+        rank_ * bytes,
+        bytes,
+        count,
+        dst_rank,
+        src_rank,
+        0,
+        iterations,
+        scope,
+        num_threads,
+        d_results,
+        stream.stream());
+  }
+  stream.synchronize();
+
+  checkKernelResults(
+      d_results,
+      iterations,
+      "PipesIteratedPut(" + formatBytes(msg_bytes) + "," + scopeName(scope) +
+          ")");
+  cudaFree(d_results);
+  teardownPipesWindow(s, torchcomm_);
+}
+
+void PipesDeviceApiIteratedTest::testIteratedSignal(CoopScope scope) {
+  int iterations = config_.num_iterations;
+  int num_threads = threadsForScope(scope);
+
+  SCOPED_TRACE(
+      ::testing::Message() << "PipesIteratedSignal scope=" << scopeName(scope));
+
+  auto s = createPipesWindowSetup(
+      torchcomm_, allocator_, device_index_, num_ranks_, 1, num_ranks_, -1, 1);
+
+  int dst_rank = (rank_ + 1) % num_ranks_;
+  int src_rank = (rank_ - 1 + num_ranks_) % num_ranks_;
+
+  auto stream = at::cuda::getStreamFromPool(false, device_index_);
+  {
+    c10::cuda::CUDAStreamGuard guard(stream);
+    launchPipesIteratedSignalKernel(
+        s.dev_win,
+        dst_rank,
+        src_rank,
+        0,
+        iterations,
+        scope,
+        num_threads,
+        stream.stream());
+  }
+  stream.synchronize();
+  teardownPipesWindow(s, torchcomm_);
+}
+
+void PipesDeviceApiIteratedTest::testIteratedBarrier(CoopScope scope) {
+  int iterations = config_.num_iterations;
+  int num_threads = threadsForScope(scope);
+
+  SCOPED_TRACE(
+      ::testing::Message() << "PipesIteratedBarrier scope="
+                           << scopeName(scope));
+
+  auto s = createPipesWindowSetup(
+      torchcomm_, allocator_, device_index_, num_ranks_, 1, -1, -1, 1);
+
+  auto stream = at::cuda::getStreamFromPool(false, device_index_);
+  {
+    c10::cuda::CUDAStreamGuard guard(stream);
+    launchPipesIteratedBarrierKernel(
+        s.dev_win, iterations, scope, num_threads, stream.stream());
+  }
+  stream.synchronize();
+  teardownPipesWindow(s, torchcomm_);
+}
+
+void PipesDeviceApiIteratedTest::testIteratedCombined(size_t msg_bytes) {
+  size_t count = msg_bytes / sizeof(float);
+  if (count == 0) {
+    count = 1;
+  }
+  int iterations = config_.num_iterations;
+
+  SCOPED_TRACE(
+      ::testing::Message() << "PipesIteratedCombined msg="
+                           << formatBytes(msg_bytes));
+
+  auto s = createPipesWindowSetup(
+      torchcomm_,
+      allocator_,
+      device_index_,
+      num_ranks_,
+      count,
+      num_ranks_,
+      -1,
+      4);
+
+  int dst_rank = (rank_ + 1) % num_ranks_;
+  int src_rank = (rank_ - 1 + num_ranks_) % num_ranks_;
+  size_t bytes = count * sizeof(float);
+
+  int* d_results = nullptr;
+  ASSERT_EQ(cudaMalloc(&d_results, iterations * sizeof(int)), cudaSuccess);
+  ASSERT_EQ(cudaMemset(d_results, 0, iterations * sizeof(int)), cudaSuccess);
+
+  auto stream = at::cuda::getStreamFromPool(false, device_index_);
+  {
+    c10::cuda::CUDAStreamGuard guard(stream);
+    launchPipesIteratedCombinedKernel(
+        s.dev_win,
+        s.src_buf,
+        s.src_tensor.data_ptr<float>(),
+        s.win_tensor.data_ptr<float>(),
+        0,
+        rank_ * bytes,
+        bytes,
+        count,
+        dst_rank,
+        src_rank,
+        0,
+        0,
+        iterations,
+        d_results,
+        stream.stream());
+  }
+  stream.synchronize();
+
+  checkKernelResults(
+      d_results,
+      iterations,
+      "PipesIteratedCombined(" + formatBytes(msg_bytes) + ")");
+  cudaFree(d_results);
+  teardownPipesWindow(s, torchcomm_);
+}
+
+void PipesDeviceApiIteratedTest::testMultiWindow() {
+  int num_windows = config_.window_count;
+  int iterations = config_.num_iterations / 2;
+  size_t count = 1024;
+
+  SCOPED_TRACE(
+      ::testing::Message() << "PipesMultiWindow windows=" << num_windows);
+
+  int dst_rank = (rank_ + 1) % num_ranks_;
+  int src_rank = (rank_ - 1 + num_ranks_) % num_ranks_;
+
+  std::vector<PipesWindowSetup> windows;
+  windows.reserve(num_windows);
+  for (int w = 0; w < num_windows; w++) {
+    windows.push_back(createPipesWindowSetup(
+        torchcomm_,
+        allocator_,
+        device_index_,
+        num_ranks_,
+        count,
+        std::max(num_ranks_, 2),
+        -1,
+        -1));
+  }
+
+  std::vector<int*> d_results_vec(num_windows, nullptr);
+  std::vector<at::cuda::CUDAStream> streams;
+  streams.reserve(num_windows);
+
+  for (int w = 0; w < num_windows; w++) {
+    ASSERT_EQ(
+        cudaMalloc(&d_results_vec[w], iterations * sizeof(int)), cudaSuccess);
+    ASSERT_EQ(
+        cudaMemset(d_results_vec[w], 0, iterations * sizeof(int)), cudaSuccess);
+
+    auto stream = at::cuda::getStreamFromPool(false, device_index_);
+    streams.push_back(stream);
+
+    size_t bytes = count * sizeof(float);
+    c10::cuda::CUDAStreamGuard guard(stream);
+    launchPipesIteratedPutKernel(
+        windows[w].dev_win,
+        windows[w].src_buf,
+        windows[w].src_tensor.data_ptr<float>(),
+        windows[w].win_tensor.data_ptr<float>(),
+        0,
+        rank_ * bytes,
+        bytes,
+        count,
+        dst_rank,
+        src_rank,
+        0,
+        iterations,
+        CoopScope::THREAD,
+        1,
+        d_results_vec[w],
+        stream.stream());
+  }
+
+  for (auto& stream : streams) {
+    stream.synchronize();
+  }
+
+  for (int w = 0; w < num_windows; w++) {
+    checkKernelResults(
+        d_results_vec[w],
+        iterations,
+        "PipesMultiWindow[" + std::to_string(w) + "]");
+    cudaFree(d_results_vec[w]);
+  }
+
+  for (auto& ws : windows) {
+    teardownPipesWindow(ws, torchcomm_);
+  }
+}
+
+void PipesDeviceApiIteratedTest::testWindowLifecycle() {
+  int cycles = config_.lifecycle_cycles;
+  size_t count = 256;
+
+  SCOPED_TRACE(
+      ::testing::Message() << "PipesWindowLifecycle cycles=" << cycles);
+
+  int dst_rank = (rank_ + 1) % num_ranks_;
+  int src_rank = (rank_ - 1 + num_ranks_) % num_ranks_;
+
+  for (int cycle = 0; cycle < cycles; cycle++) {
+    auto s = createPipesWindowSetup(
+        torchcomm_,
+        allocator_,
+        device_index_,
+        num_ranks_,
+        count,
+        std::max(num_ranks_, 2),
+        -1,
+        -1);
+
+    int* d_result = nullptr;
+    ASSERT_EQ(cudaMalloc(&d_result, sizeof(int)), cudaSuccess);
+    ASSERT_EQ(cudaMemset(d_result, 0, sizeof(int)), cudaSuccess);
+
+    size_t bytes = count * sizeof(float);
+    auto stream = at::cuda::getStreamFromPool(false, device_index_);
+    {
+      c10::cuda::CUDAStreamGuard guard(stream);
+      launchPipesIteratedPutKernel(
+          s.dev_win,
+          s.src_buf,
+          s.src_tensor.data_ptr<float>(),
+          s.win_tensor.data_ptr<float>(),
+          0,
+          rank_ * bytes,
+          bytes,
+          count,
+          dst_rank,
+          src_rank,
+          0,
+          1,
+          CoopScope::THREAD,
+          1,
+          d_result,
+          stream.stream());
+    }
+    stream.synchronize();
+
+    checkKernelResults(
+        d_result, 1, "PipesWindowLifecycle[" + std::to_string(cycle) + "]");
+    cudaFree(d_result);
+    teardownPipesWindow(s, torchcomm_);
+  }
+}
+
+// =============================================================================
+// Parameterized Test Registrations
+// =============================================================================
+
+// --- Put: parameterized by (msg_bytes, scope) ---
+
+struct PipesPutParam {
+  size_t msg_bytes;
+  CoopScope scope;
+};
+
+class PipesDeviceApiIteratedPutTest
+    : public PipesDeviceApiIteratedTest,
+      public ::testing::WithParamInterface<PipesPutParam> {};
+
+TEST_P(PipesDeviceApiIteratedPutTest, Put) {
+  testIteratedPut(GetParam().msg_bytes, GetParam().scope);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    IteratedPut,
+    PipesDeviceApiIteratedPutTest,
+    ::testing::Values(
+        PipesPutParam{1024, CoopScope::THREAD},
+        PipesPutParam{1048576, CoopScope::THREAD},
+        PipesPutParam{16777216, CoopScope::THREAD},
+        PipesPutParam{1024, CoopScope::WARP},
+        PipesPutParam{1024, CoopScope::BLOCK}),
+    [](const ::testing::TestParamInfo<PipesPutParam>& info) {
+      return std::to_string(info.param.msg_bytes) + "B_" +
+          scopeName(info.param.scope);
+    });
+
+// --- Signal: parameterized by scope ---
+
+class PipesDeviceApiIteratedSignalTest
+    : public PipesDeviceApiIteratedTest,
+      public ::testing::WithParamInterface<CoopScope> {};
+
+TEST_P(PipesDeviceApiIteratedSignalTest, Signal) {
+  testIteratedSignal(GetParam());
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    IteratedSignal,
+    PipesDeviceApiIteratedSignalTest,
+    ::testing::Values(CoopScope::THREAD, CoopScope::WARP),
+    [](const ::testing::TestParamInfo<CoopScope>& info) {
+      return std::string(scopeName(info.param));
+    });
+
+// --- Barrier: parameterized by scope ---
+
+class PipesDeviceApiIteratedBarrierTest
+    : public PipesDeviceApiIteratedTest,
+      public ::testing::WithParamInterface<CoopScope> {};
+
+TEST_P(PipesDeviceApiIteratedBarrierTest, Barrier) {
+  testIteratedBarrier(GetParam());
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    IteratedBarrier,
+    PipesDeviceApiIteratedBarrierTest,
+    ::testing::Values(CoopScope::THREAD, CoopScope::WARP),
+    [](const ::testing::TestParamInfo<CoopScope>& info) {
+      return std::string(scopeName(info.param));
+    });
+
+// --- Combined: parameterized by msg_bytes ---
+
+class PipesDeviceApiIteratedCombinedTest
+    : public PipesDeviceApiIteratedTest,
+      public ::testing::WithParamInterface<size_t> {};
+
+TEST_P(PipesDeviceApiIteratedCombinedTest, Combined) {
+  testIteratedCombined(GetParam());
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    IteratedCombined,
+    PipesDeviceApiIteratedCombinedTest,
+    ::testing::Values(static_cast<size_t>(1024), static_cast<size_t>(1048576)),
+    [](const ::testing::TestParamInfo<size_t>& info) {
+      return std::to_string(info.param) + "B";
+    });
+
+// --- Non-parameterized tests ---
+
+TEST_F(PipesDeviceApiIteratedTest, MultiWindow) {
+  testMultiWindow();
+}
+
+TEST_F(PipesDeviceApiIteratedTest, WindowLifecycle) {
+  testWindowLifecycle();
+}

--- a/comms/torchcomms/tests/integration/cpp/PipesDeviceApiIteratedTest.hpp
+++ b/comms/torchcomms/tests/integration/cpp/PipesDeviceApiIteratedTest.hpp
@@ -1,0 +1,42 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Iterated functional tests for TorchComm Device API — Pipes (IBGDA+NVLink)
+// backend.
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include <memory>
+
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDACachingAllocator.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAStream.h>
+
+#include <ATen/cuda/MemPool.h>
+
+#include "IteratedTestHelpers.hpp"
+#include "TorchCommTestHelpers.h"
+#include "comms/torchcomms/TorchComm.hpp"
+#include "comms/torchcomms/ncclx/TorchCommWindowNCCLX.hpp"
+
+class PipesDeviceApiIteratedTest : public ::testing::Test {
+ protected:
+  void SetUp() override;
+  void TearDown() override;
+
+  void testIteratedPut(size_t msg_bytes, torchcomms::device::CoopScope scope);
+  void testIteratedSignal(torchcomms::device::CoopScope scope);
+  void testIteratedBarrier(torchcomms::device::CoopScope scope);
+  void testIteratedCombined(size_t msg_bytes);
+  void testMultiWindow();
+  void testWindowLifecycle();
+
+  torchcomms::device::test::IteratedTestConfig config_;
+  std::unique_ptr<TorchCommTestWrapper> wrapper_;
+  std::shared_ptr<torch::comms::TorchComm> torchcomm_;
+  std::shared_ptr<c10::Allocator> allocator_;
+  int rank_{0};
+  int num_ranks_{0};
+  int device_index_{0};
+};

--- a/comms/torchcomms/tests/integration/cpp/PipesDeviceApiIteratedTestKernels.cu
+++ b/comms/torchcomms/tests/integration/cpp/PipesDeviceApiIteratedTestKernels.cu
@@ -1,0 +1,244 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// CUDA kernel implementations for PipesDeviceApiIteratedTest (Pipes backend).
+// Key difference from NCCLx: Pipes does NOT support reset_signal (traps!).
+// All signal patterns use monotonic values.
+
+#include "IteratedTestKernelUtils.cuh"
+#include "PipesDeviceApiIteratedTestKernels.cuh"
+
+#include "comms/torchcomms/device/pipes/TorchCommDevicePipes.cuh"
+
+// Kernel launch error check for test code.
+#define KERNEL_LAUNCH_CHECK()                        \
+  do {                                               \
+    cudaError_t err__ = cudaGetLastError();          \
+    assert(err__ == cudaSuccess && "kernel launch"); \
+    (void)err__;                                     \
+  } while (0)
+
+namespace torchcomms::device::test {
+
+// ---------------------------------------------------------------------------
+// Iterated Put Kernel (Pipes)
+// ---------------------------------------------------------------------------
+__global__ void pipesIteratedPutKernel(
+    DeviceWindowPipes* win,
+    RegisteredBufferPipes src_buf,
+    float* src_ptr,
+    float* win_base,
+    size_t src_offset,
+    size_t dst_offset,
+    size_t bytes,
+    size_t count,
+    int dst_rank,
+    int src_rank,
+    int signal_id,
+    int iterations,
+    CoopScope scope,
+    int* results) {
+  int rank = win->rank();
+
+  for (int iter = 0; iter < iterations; iter++) {
+    fillPattern(src_ptr, count, rank, iter);
+    __syncthreads();
+
+    // Monotonic signals: each put adds 1 to signal_id on destination
+    win->put(
+        dst_offset, src_buf, src_offset, dst_rank, bytes, signal_id, -1, scope);
+    win->flush(scope);
+
+    // Wait for monotonic signal value (no reset — Pipes doesn't support it)
+    win->wait_signal(
+        signal_id, CmpOp::GE, static_cast<uint64_t>(iter + 1), scope);
+
+    float* recv_slot = win_base + src_rank * count;
+    verifyPattern(recv_slot, count, src_rank, iter, &results[iter]);
+    __syncthreads();
+
+    // Reverse signal: tell the sender we're done reading, so it can safely
+    // overwrite our receive slot in the next iteration.
+    // All threads must call signal() — Pipes signal_peer(group, ...) has
+    // group.sync() internally, so all threads in the group must participate.
+    win->signal(src_rank, signal_id + 1, SignalOp::ADD, 1, scope);
+    __syncthreads();
+
+    // Wait for receiver of our data to finish reading before next put
+    win->wait_signal(
+        signal_id + 1, CmpOp::GE, static_cast<uint64_t>(iter + 1), scope);
+  }
+}
+
+void launchPipesIteratedPutKernel(
+    DeviceWindowPipes* win,
+    RegisteredBufferPipes src_buf,
+    float* src_ptr,
+    float* win_base,
+    size_t src_offset,
+    size_t dst_offset,
+    size_t bytes,
+    size_t count,
+    int dst_rank,
+    int src_rank,
+    int signal_id,
+    int iterations,
+    CoopScope scope,
+    int num_threads,
+    int* results,
+    cudaStream_t stream) {
+  pipesIteratedPutKernel<<<1, num_threads, 0, stream>>>(
+      win,
+      src_buf,
+      src_ptr,
+      win_base,
+      src_offset,
+      dst_offset,
+      bytes,
+      count,
+      dst_rank,
+      src_rank,
+      signal_id,
+      iterations,
+      scope,
+      results);
+  KERNEL_LAUNCH_CHECK();
+}
+
+// ---------------------------------------------------------------------------
+// Iterated Signal Kernel (Pipes)
+// ---------------------------------------------------------------------------
+__global__ void pipesIteratedSignalKernel(
+    DeviceWindowPipes* win,
+    int dst_rank,
+    int src_rank,
+    int signal_id,
+    int iterations,
+    CoopScope scope) {
+  for (int iter = 0; iter < iterations; iter++) {
+    // All threads must call signal() — Pipes signal_peer(group, ...) has
+    // group.sync() internally, so all threads in the group must participate.
+    win->signal(dst_rank, signal_id, SignalOp::ADD, 1, scope);
+    __syncthreads();
+
+    win->wait_signal_from(
+        src_rank, signal_id, CmpOp::GE, static_cast<uint64_t>(iter + 1), scope);
+  }
+}
+
+void launchPipesIteratedSignalKernel(
+    DeviceWindowPipes* win,
+    int dst_rank,
+    int src_rank,
+    int signal_id,
+    int iterations,
+    CoopScope scope,
+    int num_threads,
+    cudaStream_t stream) {
+  pipesIteratedSignalKernel<<<1, num_threads, 0, stream>>>(
+      win, dst_rank, src_rank, signal_id, iterations, scope);
+  KERNEL_LAUNCH_CHECK();
+}
+
+// ---------------------------------------------------------------------------
+// Iterated Barrier Kernel (Pipes)
+// ---------------------------------------------------------------------------
+__global__ void pipesIteratedBarrierKernel(
+    DeviceWindowPipes* win,
+    int iterations,
+    CoopScope scope) {
+  for (int iter = 0; iter < iterations; iter++) {
+    // Pipes uses a shared barrierExpected_ counter across all barrier IDs,
+    // so we must reuse the same barrier_id (not alternate like NCCLx).
+    win->barrier(0, scope);
+  }
+}
+
+void launchPipesIteratedBarrierKernel(
+    DeviceWindowPipes* win,
+    int iterations,
+    CoopScope scope,
+    int num_threads,
+    cudaStream_t stream) {
+  pipesIteratedBarrierKernel<<<1, num_threads, 0, stream>>>(
+      win, iterations, scope);
+  KERNEL_LAUNCH_CHECK();
+}
+
+// ---------------------------------------------------------------------------
+// Combined Ops Kernel (Pipes)
+// ---------------------------------------------------------------------------
+__global__ void pipesIteratedCombinedKernel(
+    DeviceWindowPipes* win,
+    RegisteredBufferPipes src_buf,
+    float* src_ptr,
+    float* win_base,
+    size_t src_offset,
+    size_t dst_offset,
+    size_t bytes,
+    size_t count,
+    int dst_rank,
+    int src_rank,
+    int signal_id,
+    int barrier_id_base,
+    int iterations,
+    int* results) {
+  int rank = win->rank();
+
+  for (int iter = 0; iter < iterations; iter++) {
+    // Pipes uses a shared barrierExpected_ counter — must reuse same ID
+    win->barrier(barrier_id_base);
+
+    fillPattern(src_ptr, count, rank, iter);
+
+    if (threadIdx.x == 0) {
+      win->put(dst_offset, src_buf, src_offset, dst_rank, bytes, signal_id, -1);
+      win->flush();
+    }
+    __syncthreads();
+
+    if (threadIdx.x == 0) {
+      win->wait_signal(signal_id, CmpOp::GE, static_cast<uint64_t>(iter + 1));
+    }
+    __syncthreads();
+
+    float* recv_slot = win_base + src_rank * count;
+    verifyPattern(recv_slot, count, src_rank, iter, &results[iter]);
+    __syncthreads();
+  }
+}
+
+void launchPipesIteratedCombinedKernel(
+    DeviceWindowPipes* win,
+    RegisteredBufferPipes src_buf,
+    float* src_ptr,
+    float* win_base,
+    size_t src_offset,
+    size_t dst_offset,
+    size_t bytes,
+    size_t count,
+    int dst_rank,
+    int src_rank,
+    int signal_id,
+    int barrier_id_base,
+    int iterations,
+    int* results,
+    cudaStream_t stream) {
+  pipesIteratedCombinedKernel<<<1, 1, 0, stream>>>(
+      win,
+      src_buf,
+      src_ptr,
+      win_base,
+      src_offset,
+      dst_offset,
+      bytes,
+      count,
+      dst_rank,
+      src_rank,
+      signal_id,
+      barrier_id_base,
+      iterations,
+      results);
+  KERNEL_LAUNCH_CHECK();
+}
+
+} // namespace torchcomms::device::test

--- a/comms/torchcomms/tests/integration/cpp/PipesDeviceApiIteratedTestKernels.cuh
+++ b/comms/torchcomms/tests/integration/cpp/PipesDeviceApiIteratedTestKernels.cuh
@@ -1,0 +1,73 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// CUDA kernel declarations for PipesDeviceApiIteratedTest (Pipes backend).
+// Host-safe header — can be included from .cpp files compiled by clang.
+
+// NOLINTNEXTLINE(clang-diagnostic-pragma-once-outside-header)
+#pragma once
+
+#include <cuda_runtime.h>
+#include "comms/torchcomms/device/pipes/TorchCommDevicePipesTypes.hpp"
+
+namespace torchcomms::device::test {
+
+// Iterated put kernel for Pipes backend.
+// Uses monotonic signal values (Pipes does NOT support reset_signal).
+void launchPipesIteratedPutKernel(
+    DeviceWindowPipes* win,
+    RegisteredBufferPipes src_buf,
+    float* src_ptr,
+    float* win_base,
+    size_t src_offset,
+    size_t dst_offset,
+    size_t bytes,
+    size_t count,
+    int dst_rank,
+    int src_rank,
+    int signal_id,
+    int iterations,
+    CoopScope scope,
+    int num_threads,
+    int* results,
+    cudaStream_t stream);
+
+// Iterated signal kernel for Pipes backend.
+// Ring pattern with monotonic signal values.
+void launchPipesIteratedSignalKernel(
+    DeviceWindowPipes* win,
+    int dst_rank,
+    int src_rank,
+    int signal_id,
+    int iterations,
+    CoopScope scope,
+    int num_threads,
+    cudaStream_t stream);
+
+// Iterated barrier kernel for Pipes backend.
+void launchPipesIteratedBarrierKernel(
+    DeviceWindowPipes* win,
+    int iterations,
+    CoopScope scope,
+    int num_threads,
+    cudaStream_t stream);
+
+// Combined ops kernel for Pipes backend.
+// barrier -> fill -> put -> wait_signal -> verify -> barrier per iteration.
+void launchPipesIteratedCombinedKernel(
+    DeviceWindowPipes* win,
+    RegisteredBufferPipes src_buf,
+    float* src_ptr,
+    float* win_base,
+    size_t src_offset,
+    size_t dst_offset,
+    size_t bytes,
+    size_t count,
+    int dst_rank,
+    int src_rank,
+    int signal_id,
+    int barrier_id_base,
+    int iterations,
+    int* results,
+    cudaStream_t stream);
+
+} // namespace torchcomms::device::test

--- a/comms/torchcomms/tests/integration/cpp/PipesDeviceApiIteratedTestMain.cpp
+++ b/comms/torchcomms/tests/integration/cpp/PipesDeviceApiIteratedTestMain.cpp
@@ -1,0 +1,8 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Summary:

Adds iterated (soak-style) integration tests that exercise the TorchComms
device API repeatedly in a single persistent kernel to catch race conditions,
resource leaks, and signal/barrier correctness issues that only manifest
under sustained operation.

**Two test suites:**

1. **DeviceApiIteratedTest (NCCLx/GIN)** — 20 parameterized tests covering:
   - Iterated put with data verification (4B/1KB/1MB/16MB × THREAD/WARP/BLOCK)
   - Iterated signal (ring pattern, monotonic values, THREAD/WARP/BLOCK)
   - Iterated barrier (alternating IDs, THREAD/WARP/BLOCK)
   - Combined ops (barrier + put + signal + verify, 1KB/1MB)
   - Multi-window (4 concurrent windows)
   - Multi-communicator (2 concurrent comms)
   - Window/comm lifecycle (create/destroy cycles)
   - Buffer registration churn

2. **PipesDeviceApiIteratedTest (Pipes/IBGDA+NVLink)** — 13 parameterized tests covering:
   - Same operations adapted for Pipes semantics:
     - Monotonic signals only (no reset_signal — traps on Pipes)
     - Single barrier_id reuse (Pipes barrierExpected_ is shared across IDs)
     - Reverse signal pattern for put read-after-write protection
   - Multi-window and window lifecycle tests

**Reviewer comment changes (v2):**
- Refactored to parameterized tests (TEST_P + INSTANTIATE_TEST_SUITE_P)
- Replaced std::istringstream parsing with folly::split
- Added KERNEL_LAUNCH_CHECK() after all kernel launches
- Added vector::reserve() for known-size vectors
- Added NOLINTNEXTLINE for pragma once in .cuh files
- Removed blockIdx.x != 0 guards (launch grid already <<<1, N>>>)
- Pass CoopScope consistently to wait_signal/wait_signal_from (not just put/signal/barrier)

**Shared infrastructure:**
- IteratedTestHelpers: config parsing from env vars (folly::split), formatting utilities
- IteratedTestKernelUtils: device-side fillPattern/verifyPattern with
  shared-memory reduction

**Key Pipes learnings (bugs found & fixed during development):**
- Pipes signal_peer(group, ...) has group.sync() internally — callers must
  NOT guard with if(threadIdx.x==0) when using WARP/BLOCK scope
- Pipes barrierExpected_ is shared across all barrier IDs — must reuse
  same barrier_id (not alternate like NCCLx)
- cudaDeviceSynchronize() needed after setup to sync tensor zeroing across
  streams

Reviewed By: cenzhaometa

Differential Revision: D98015066
