### PR TITLE
Add NcclxBaseTestFixture and VerifyAlgoStatsUtil to shared dir

### DIFF
--- a/comms/ncclx/meta/tests/NcclxBaseTest.cc
+++ b/comms/ncclx/meta/tests/NcclxBaseTest.cc
@@ -1,0 +1,39 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/ncclx/meta/tests/NcclxBaseTest.h"
+
+#include <folly/logging/xlog.h>
+#include <cstdlib>
+
+void NcclxBaseTestFixture::SetUp(const NcclxEnvs& envs) {
+  distSetUp();
+
+  setenv("RANK", std::to_string(globalRank).c_str(), 1);
+
+  // Save old env values and apply overrides.
+  for (const auto& [key, value] : envs) {
+    const char* oldVal = getenv(key.c_str());
+    oldEnvs_[key] = oldVal ? std::optional<std::string>(oldVal) : std::nullopt;
+    setenv(key.c_str(), value.c_str(), 1);
+  }
+
+  CUDACHECKABORT(cudaSetDevice(localRank));
+
+  if (initEnvAtSetup) {
+    initEnv();
+    ncclCvarInit();
+  }
+}
+
+void NcclxBaseTestFixture::TearDown() {
+  // Restore original env values.
+  for (const auto& [key, value] : oldEnvs_) {
+    if (value) {
+      setenv(key.c_str(), value->c_str(), 1);
+    } else {
+      unsetenv(key.c_str());
+    }
+  }
+
+  distTearDown();
+}

--- a/comms/ncclx/meta/tests/NcclxBaseTest.h
+++ b/comms/ncclx/meta/tests/NcclxBaseTest.h
@@ -1,0 +1,59 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+#include "comms/testinfra/DistTestBase.h"
+#include "comms/testinfra/TestUtils.h"
+#include "nccl.h" // @manual
+
+// TODO: Long-term, migrate all tests from #ifdef compiler flags to NcclxEnvs
+// params.
+using NcclxEnvs = std::vector<std::pair<std::string, std::string>>;
+
+class NcclxBaseTestFixture : public ::testing::Test,
+                             protected meta::comms::DistBaseTest {
+ public:
+  ncclComm_t comm{nullptr};
+
+ protected:
+  // TODO: Migrate tests away from #ifdef compiler flags to NcclxEnvs params.
+  // Keep compiler-flag overrides only for envs that must override dist setup
+  // (e.g., TEST_ENABLE_FASTINIT to enforce TCPStore).
+  void SetUp() override {
+    NcclxEnvs envs;
+#ifdef NCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL
+    envs.push_back({"NCCL_COMM_STATE_DEBUG_TOPO", "nolocal"});
+#endif
+#ifdef NCCL_COMM_STATE_DEBUG_TOPO_VNODE
+    envs.push_back({"NCCL_COMM_STATE_DEBUG_TOPO", "vnode"});
+#endif
+#ifdef TEST_ENABLE_FASTINIT
+    envs.push_back({"NCCL_FASTINIT_MODE", "ring_hybrid"});
+#endif
+#ifdef TEST_ENABLE_CTRAN
+    envs.push_back({"NCCL_CTRAN_ENABLE", "1"});
+    envs.push_back({"NCCL_CTRAN_IPC_REGCACHE_ENABLE_ASYNC_SOCKET", "1"});
+#endif
+#ifdef TEST_ENABLE_LOCAL_REGISTER
+    envs.push_back({"NCCL_LOCAL_REGISTER", "1"});
+#endif
+#ifdef TEST_CUDA_GRAPH_MODE
+    envs.push_back({"NCCL_CTRAN_ALLOW_CUDA_GRAPH", "1"});
+#endif
+    SetUp(envs);
+  }
+
+  void SetUp(const NcclxEnvs& envs);
+  void TearDown() override;
+
+  bool initEnvAtSetup{true};
+
+ private:
+  std::unordered_map<std::string, std::optional<std::string>> oldEnvs_;
+};

--- a/comms/ncclx/meta/tests/VerifyAlgoStatsUtil.cc
+++ b/comms/ncclx/meta/tests/VerifyAlgoStatsUtil.cc
@@ -1,0 +1,91 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "VerifyAlgoStatsUtil.h"
+
+#include <fmt/core.h>
+#include <gtest/gtest.h>
+#include <unordered_map>
+#include "meta/colltrace/AlgoStats.h"
+
+namespace ncclx::test {
+
+namespace {
+
+using AlgoStatsMap = std::unordered_map<std::string, int64_t>;
+
+// Retrieve per-algorithm stats for a collective.
+// Returns the algo name -> call count map; empty if collective not found.
+AlgoStatsMap getAlgoStats(ncclComm_t comm, const std::string& collective) {
+  std::unordered_map<std::string, std::unordered_map<std::string, int64_t>>
+      stats;
+  ncclx::colltrace::dumpAlgoStat(comm, stats);
+
+  auto it = stats.find(collective);
+  EXPECT_NE(it, stats.end())
+      << collective << " not found in AlgoStats. Stats may not be enabled.";
+  if (it == stats.end()) {
+    return {};
+  }
+  return std::move(it->second);
+}
+
+// Format algo stats map as "algo1(count1), algo2(count2), ...".
+std::string formatAlgoStats(const AlgoStatsMap& algoStats) {
+  std::string result;
+  for (const auto& [algoName, callCount] : algoStats) {
+    if (!result.empty()) {
+      result += ", ";
+    }
+    result += fmt::format("{}({})", algoName, callCount);
+  }
+  return result;
+}
+
+// Check if any algorithm matching the substring was used (callCount > 0).
+bool findAlgoWithCalls(
+    const AlgoStatsMap& stats,
+    const std::string& algoSubstr) {
+  for (const auto& [algoName, callCount] : stats) {
+    if (algoName.find(algoSubstr) != std::string::npos && callCount > 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+} // namespace
+
+void VerifyAlgoStatsHelper::enable() {
+  colltraceGuard_.emplace(NCCL_COLLTRACE, std::vector<std::string>{"algostat"});
+}
+
+void VerifyAlgoStatsHelper::dump(ncclComm_t comm, const std::string& collective)
+    const {
+  auto stats = getAlgoStats(comm, collective);
+  fmt::print(
+      stderr, "AlgoStats[{}]: [{}]\n", collective, formatAlgoStats(stats));
+}
+
+void VerifyAlgoStatsHelper::verify(
+    ncclComm_t comm,
+    const std::string& collective,
+    const std::string& expectedAlgoSubstr) const {
+  auto stats = getAlgoStats(comm, collective);
+  EXPECT_TRUE(findAlgoWithCalls(stats, expectedAlgoSubstr))
+      << "Expected algorithm containing '" << expectedAlgoSubstr
+      << "' not found in " << collective << ". Found algorithms: ["
+      << formatAlgoStats(stats) << "]";
+}
+
+void VerifyAlgoStatsHelper::verifyNot(
+    ncclComm_t comm,
+    const std::string& collective,
+    const std::string& unexpectedAlgoSubstr) const {
+  auto stats = getAlgoStats(comm, collective);
+  EXPECT_FALSE(findAlgoWithCalls(stats, unexpectedAlgoSubstr))
+      << "Unexpected algorithm containing '" << unexpectedAlgoSubstr
+      << "' was used in " << collective << ". Found algorithms: ["
+      << formatAlgoStats(stats) << "]";
+}
+
+} // namespace ncclx::test

--- a/comms/ncclx/meta/tests/VerifyAlgoStatsUtil.h
+++ b/comms/ncclx/meta/tests/VerifyAlgoStatsUtil.h
@@ -1,0 +1,68 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+#include "comms/testinfra/TestUtils.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+#include "nccl.h" // @manual
+
+namespace ncclx::test {
+
+// Helper class for algorithm statistics verification in tests.
+//
+// Usage:
+//   class MyTest : public NcclxBaseTestFixture {
+//    protected:
+//     VerifyAlgoStatsHelper algoStats_;
+//
+//     void SetUp() override {
+//       NcclxBaseTestFixture::SetUp();
+//       algoStats_.enable();  // Must be called before comm creation
+//     }
+//   };
+//
+//   TEST_F(MyTest, Foo) {
+//     // ... run collective ...
+//     algoStats_.verify(comm, "ReduceScatter", "PAT");
+//   }
+class VerifyAlgoStatsHelper {
+ public:
+  VerifyAlgoStatsHelper() = default;
+
+  // Enable AlgoStats tracing. Must be called after Cvars are initialized
+  // (e.g., via initEnv()) and before NCCL comm creation.
+  void enable();
+
+  // Dump all algorithm statistics to stderr.
+  // @param comm The NCCL communicator to query stats from
+  // @param collective The collective name (e.g., "ReduceScatter", "AllReduce")
+  void dump(ncclComm_t comm, const std::string& collective) const;
+
+  // Verify that the expected algorithm was used via AlgoStats.
+  // @param comm The NCCL communicator to query stats from
+  // @param collective The collective name (e.g., "ReduceScatter", "AllReduce")
+  // @param expectedAlgoSubstr Substring to match in algorithm name (e.g.,
+  // "PAT", "Ring")
+  void verify(
+      ncclComm_t comm,
+      const std::string& collective,
+      const std::string& expectedAlgoSubstr) const;
+
+  // Verify that the given algorithm was NOT used via AlgoStats.
+  // @param comm The NCCL communicator to query stats from
+  // @param collective The collective name (e.g., "ReduceScatter", "AllReduce")
+  // @param unexpectedAlgoSubstr Substring that must NOT appear in any algorithm
+  // name with nonzero call count
+  void verifyNot(
+      ncclComm_t comm,
+      const std::string& collective,
+      const std::string& unexpectedAlgoSubstr) const;
+
+ private:
+  std::optional<EnvRAII<std::vector<std::string>>> colltraceGuard_;
+};
+
+} // namespace ncclx::test


### PR DESCRIPTION
Summary:
- Create NcclxBaseTestFixture in comms/ncclx/meta/tests/ with #ifdef-based SetUp() delegating to env-override SetUp(envs), replacing both NcclxBaseTest and parameterized NcclxBaseTestFixture from TestsDistUtils.h
- Copy VerifyAlgoStatsUtil.{h,cc} from v2_28/meta/tests/ to shared dir with versions=["2.28","2.29"] (AlgoStats not available in v2_27)
- Add ncclx_meta_cpp_library targets for both in shared BUCK

Differential Revision: D97876589


