### PR TITLE
AllReduceRing: autotune-derived QP scaling threshold (#1258)

### DIFF
--- a/comms/ctran/algos/AllReduce/AllReduceRing.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceRing.cc
@@ -332,9 +332,8 @@ inline void progressSendPostTrans(
   char* tmpSendBuf = reinterpret_cast<char*>(resource.tmpSendBuf) +
       tmpChunkId * algoCtx.chunkSize;
 
-  // Get allreduce specific IB config
-  static thread_local auto allReduceConfig =
-      resource.comm->ctran_->algo->getCollToVcConfig(CollType::ALLREDUCE);
+  CtranIbConfig* allReduceConfig =
+      resource.ibConfig ? &*resource.ibConfig : nullptr;
 
   CtranMapperRequest* req;
   FB_COMMCHECKTHROW_EX(
@@ -712,8 +711,8 @@ inline void progressRevSendPostTrans(
   char* tmpSendBufRev = reinterpret_cast<char*>(resource.tmpSendBufRev) +
       tmpChunkId * algoCtx.chunkSize;
 
-  static thread_local auto allReduceConfig =
-      resource.comm->ctran_->algo->getCollToVcConfig(CollType::ALLREDUCE);
+  CtranIbConfig* allReduceConfig =
+      resource.ibConfig ? &*resource.ibConfig : nullptr;
 
   CtranMapperRequest* req;
   FB_COMMCHECKTHROW_EX(
@@ -1177,7 +1176,9 @@ commResult_t getPipelineConfiguration(
     size_t* pipelineChunkSize,
     bool log_decision,
     size_t typeSize,
-    GpuArch arch) {
+    GpuArch arch,
+    CtranComm* comm,
+    std::optional<CtranIbConfig>* ibConfig) {
   int cudaOccupancyNumBlocks, cudaOccupancyBlockSize;
   FB_COMMCHECK(
       ctran::allreduce::ring::getNumBlocksAndThreads(
@@ -1206,6 +1207,11 @@ commResult_t getPipelineConfiguration(
   *pipelineNumChunks = params.pipeline.numChunks;
   *numBlocks = params.block.numBlocks;
   *numThreads = params.block.blockSize;
+
+  *ibConfig = ctran::allreduce::ring::resolveIbConfig(
+      comm->ctran_->algo->getCollToVcConfig(CollType::ALLREDUCE),
+      arch,
+      params.pipeline.chunkSize);
 
   return commSuccess;
 }
@@ -1288,6 +1294,7 @@ commResult_t ctranAllReduceRing(
   int numThreads = 0;
   size_t pipelineChunkSize = 0;
   size_t pipelineNumChunks = 0;
+  std::optional<CtranIbConfig> ibConfig;
 
   FB_COMMCHECK(
       ctran::allreduce::ring::getPipelineConfiguration(
@@ -1300,7 +1307,9 @@ commResult_t ctranAllReduceRing(
           &pipelineChunkSize,
           /*log_decision=*/rank == 0,
           typeSize,
-          arch));
+          arch,
+          comm,
+          &ibConfig));
 
   FB_COMMCHECK(comm->ctran_->algo->initTmpBufs());
 
@@ -1333,6 +1342,7 @@ commResult_t ctranAllReduceRing(
   hostResource.revRecvCopySync = gpeKernelSyncs[4];
   hostResource.chunkSize = pipelineChunkSize;
   hostResource.numChunks = pipelineNumChunks;
+  hostResource.ibConfig = ibConfig;
 
   std::tie(hostResource.tmpSendBuf, hostResource.tmpSendBufHdl) =
       comm->ctran_->algo->getTmpBufInfo(

--- a/comms/ctran/algos/AllReduce/AllReduceRingAutoTune.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceRingAutoTune.cc
@@ -167,6 +167,31 @@ BlockParams getAutoTunedBlockParams(
   return {};
 }
 
+bool isQpScalingOverrideEnabled() {
+  return NCCL_CTRAN_ALLREDUCE_RING_QP_SCALING_TH_MIN >= 0 &&
+      NCCL_CTRAN_ALLREDUCE_RING_QP_SCALING_TH_MAX > 0 &&
+      NCCL_CTRAN_ALLREDUCE_RING_QP_SCALING_TH_MAX >=
+      NCCL_CTRAN_ALLREDUCE_RING_QP_SCALING_TH_MIN;
+}
+
+std::optional<CtranIbConfig> deriveIbConfig(size_t chunkSize) {
+  if (!isQpScalingOverrideEnabled()) {
+    return std::nullopt;
+  }
+  auto minTh = NCCL_CTRAN_ALLREDUCE_RING_QP_SCALING_TH_MIN;
+  auto maxTh = NCCL_CTRAN_ALLREDUCE_RING_QP_SCALING_TH_MAX;
+  CtranIbConfig config{};
+  auto maxQps = std::max(NCCL_CTRAN_IB_MAX_QPS, 1);
+  auto devicesPerRank = std::max(NCCL_CTRAN_IB_DEVICES_PER_RANK, 1);
+  config.qpScalingTh = std::clamp(
+      chunkSize /
+          (static_cast<size_t>(maxQps) * static_cast<size_t>(devicesPerRank)),
+      static_cast<size_t>(minTh),
+      static_cast<size_t>(maxTh));
+  config.vcMode = NCCL_CTRAN_IB_VC_MODE;
+  return config;
+}
+
 } // namespace
 
 AutoTuneParams getAutoTunedParams(
@@ -224,6 +249,14 @@ void logAutoTuneDecisions(
     GpuArch arch) {
   static_assert(
       sizeof(size_t) >= 8, "logAutoTuneDecisions assumes 64-bit size_t");
+  auto qpThMin = NCCL_CTRAN_ALLREDUCE_RING_QP_SCALING_TH_MIN;
+  auto qpThMax = NCCL_CTRAN_ALLREDUCE_RING_QP_SCALING_TH_MAX;
+  CLOGF(
+      DBG,
+      "AutoTune QP scaling: ThMin={}, ThMax={}, {}",
+      qpThMin,
+      qpThMax,
+      isQpScalingOverrideEnabled() ? "enabled" : "DISABLED");
   static constexpr int kPow2MaxExponent = 25; // 32GB
   static constexpr size_t kKB = 1024ULL;
   for (int i = 0; i <= kPow2MaxExponent; i++) {
@@ -264,6 +297,17 @@ void logAutoTuneDecisions(
           mat.pipeline.chunkSize);
     }
   }
+}
+
+std::optional<CtranIbConfig>
+resolveIbConfig(CtranIbConfig* explicitConfig, GpuArch arch, size_t chunkSize) {
+  if (explicitConfig) {
+    return *explicitConfig;
+  }
+  if (arch == GpuArch::Default) {
+    return deriveIbConfig(chunkSize);
+  }
+  return std::nullopt;
 }
 
 } // namespace ctran::allreduce::ring

--- a/comms/ctran/algos/AllReduce/AllReduceRingAutoTune.h
+++ b/comms/ctran/algos/AllReduce/AllReduceRingAutoTune.h
@@ -3,6 +3,9 @@
 #pragma once
 
 #include <cstddef>
+#include <optional>
+
+#include "comms/ctran/backends/CtranCtrl.h"
 
 namespace ctran::allreduce::ring {
 
@@ -53,5 +56,10 @@ void logAutoTuneDecisions(
     int maxOccupancyBlockSize,
     size_t typeSize,
     GpuArch arch = GpuArch::Default);
+
+// Resolve IB config: explicit ALGO cvar > autotune-derived (Blackwell+) >
+// nullopt.
+std::optional<CtranIbConfig>
+resolveIbConfig(CtranIbConfig* explicitConfig, GpuArch arch, size_t chunkSize);
 
 } // namespace ctran::allreduce::ring

--- a/comms/ctran/algos/AllReduce/Types.h
+++ b/comms/ctran/algos/AllReduce/Types.h
@@ -44,8 +44,10 @@ struct KernelArgs {
 #if !defined(__CUDACC__)
 
 #include <memory>
+#include <optional>
 
 #include "comms/ctran/algos/common/GpeKernelSync.h"
+#include "comms/ctran/backends/CtranCtrl.h"
 #include "comms/ctran/mapper/CtranMapperTypes.h"
 
 class CtranComm;
@@ -112,6 +114,7 @@ struct HostResource {
 
   size_t chunkSize{0};
   size_t numChunks{0};
+  std::optional<CtranIbConfig> ibConfig{std::nullopt};
   void* tmpSendBuf{nullptr};
   void* tmpSendBufHdl{nullptr};
   void* tmpRecvBuf{nullptr};

--- a/comms/ctran/algos/AllReduce/tests/AllReduceRingAutoTuneTest.cc
+++ b/comms/ctran/algos/AllReduce/tests/AllReduceRingAutoTuneTest.cc
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <bit>
+#include <optional>
 #include <set>
 #include <stdexcept>
 #include <vector>
@@ -14,10 +15,21 @@
 
 using ctran::allreduce::ring::getAutoTunedParams;
 using ctran::allreduce::ring::GpuArch;
+using ctran::allreduce::ring::resolveIbConfig;
 
 constexpr size_t KB = 1024ULL;
 constexpr size_t MB = 1024ULL * 1024;
 constexpr size_t GB = 1024ULL * 1024 * 1024;
+
+// Initialize all cvars to their YAML defaults before any tests run.
+class CvarInit : public ::testing::Environment {
+ public:
+  void SetUp() override {
+    ncclCvarInit();
+  }
+};
+static auto* const kCvarEnv __attribute__((unused)) =
+    ::testing::AddGlobalTestEnvironment(new CvarInit);
 
 // RAII guard for the maxBDP CVAR override. Restores to default on destruction.
 class MaxBDPOverride {
@@ -91,6 +103,30 @@ class StagingBufSizeOverride {
   }
 };
 
+// RAII guard for QP_SCALING_TH_MIN CVAR.
+class QpScalingThMinOverride {
+ public:
+  explicit QpScalingThMinOverride(int64_t v) {
+    NCCL_CTRAN_ALLREDUCE_RING_QP_SCALING_TH_MIN = v;
+  }
+  ~QpScalingThMinOverride() {
+    NCCL_CTRAN_ALLREDUCE_RING_QP_SCALING_TH_MIN =
+        NCCL_CTRAN_ALLREDUCE_RING_QP_SCALING_TH_MIN_DEFAULTCVARVALUE;
+  }
+};
+
+// RAII guard for QP_SCALING_TH_MAX CVAR.
+class QpScalingThMaxOverride {
+ public:
+  explicit QpScalingThMaxOverride(int64_t v) {
+    NCCL_CTRAN_ALLREDUCE_RING_QP_SCALING_TH_MAX = v;
+  }
+  ~QpScalingThMaxOverride() {
+    NCCL_CTRAN_ALLREDUCE_RING_QP_SCALING_TH_MAX =
+        NCCL_CTRAN_ALLREDUCE_RING_QP_SCALING_TH_MAX_DEFAULTCVARVALUE;
+  }
+};
+
 // ============================================================================
 // getAutoTunedParams golden tables: different arch / BDP & nranks.
 // ============================================================================
@@ -125,6 +161,20 @@ void verifyAutoTune(
         << "chunkSize mismatch at msg=" << c.msgBytes;
     EXPECT_EQ(at.pipeline.numChunks, c.numChunks)
         << "numChunks mismatch at msg=" << c.msgBytes;
+    auto resolved = resolveIbConfig(nullptr, arch, at.pipeline.chunkSize);
+    if (arch == GpuArch::Default) {
+      ASSERT_TRUE(resolved.has_value())
+          << "resolveIbConfig(Default) should return value at msg="
+          << c.msgBytes;
+      EXPECT_GE(
+          resolved->qpScalingTh,
+          static_cast<size_t>(NCCL_CTRAN_ALLREDUCE_RING_QP_SCALING_TH_MIN))
+          << "qpScalingTh below minimum at msg=" << c.msgBytes;
+    } else {
+      EXPECT_FALSE(resolved.has_value())
+          << "resolveIbConfig(Hopper) should return nullopt at msg="
+          << c.msgBytes;
+    }
   }
 }
 
@@ -1279,6 +1329,99 @@ void checkChunkAlignment(
   }
 }
 
+// ============================================================================
+// resolveIbConfig tests
+// ============================================================================
+
+TEST(ResolveIbConfig, ExplicitConfigTakesPrecedence) {
+  CtranIbConfig explicit_cfg{};
+  explicit_cfg.qpScalingTh = 42;
+  auto result = resolveIbConfig(&explicit_cfg, GpuArch::Default, 1 * MB);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->qpScalingTh, 42u);
+}
+
+TEST(ResolveIbConfig, BlackwellDerives) {
+  auto result = resolveIbConfig(nullptr, GpuArch::Default, 1 * MB);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_GE(
+      result->qpScalingTh,
+      static_cast<size_t>(NCCL_CTRAN_ALLREDUCE_RING_QP_SCALING_TH_MIN));
+}
+
+TEST(ResolveIbConfig, HopperReturnsNullopt) {
+  auto result = resolveIbConfig(nullptr, GpuArch::Hopper, 1 * MB);
+  EXPECT_FALSE(result.has_value());
+}
+
+TEST(ResolveIbConfig, ExplicitOverridesEvenOnHopper) {
+  CtranIbConfig explicit_cfg{};
+  explicit_cfg.qpScalingTh = 99;
+  auto result = resolveIbConfig(&explicit_cfg, GpuArch::Hopper, 1 * MB);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->qpScalingTh, 99u);
+}
+
+TEST(ResolveIbConfig, DisableConditionSweep) {
+  // Sweep ThMin/ThMax boundary values around the disable conditions:
+  //   disabled when: ThMin < 0 || ThMax <= 0 || ThMax < ThMin
+  struct Case {
+    int64_t thMin;
+    int64_t thMax;
+    bool expectEnabled;
+  };
+  // clang-format off
+  const std::vector<Case> cases = {
+      // ThMin < 0
+      {-2, 524288, false},
+      {-1, 524288, false},
+      // ThMax <= 0
+      {262144, -2, false},
+      {262144, -1, false},
+      {262144,  0, false},
+      // ThMax < ThMin
+      {1000, 999, false},
+      {1000, 500, false},
+      // Both negative
+      {-1, -1, false},
+      // Boundary: ThMin == 0 is valid (not < 0)
+      {0, 1, true},
+      {0, 524288, true},
+      // ThMax == ThMin (equal is valid, clamp returns that value)
+      {1000, 1000, true},
+      // Normal defaults
+      {262144, 524288, true},
+      // ThMax == 1 (minimal positive)
+      {0, 1, true},
+      {1, 1, true},
+      {2, 1, false},  // ThMax < ThMin
+  };
+  // clang-format on
+  for (const auto& c : cases) {
+    QpScalingThMinOverride oMin(c.thMin);
+    QpScalingThMaxOverride oMax(c.thMax);
+    auto result = resolveIbConfig(nullptr, GpuArch::Default, 1 * MB);
+    if (c.expectEnabled) {
+      ASSERT_TRUE(result.has_value())
+          << "Expected enabled at ThMin=" << c.thMin << " ThMax=" << c.thMax;
+      EXPECT_GE(result->qpScalingTh, static_cast<size_t>(c.thMin));
+      EXPECT_LE(result->qpScalingTh, static_cast<size_t>(c.thMax));
+    } else {
+      EXPECT_FALSE(result.has_value())
+          << "Expected disabled at ThMin=" << c.thMin << " ThMax=" << c.thMax;
+    }
+  }
+}
+
+TEST(ResolveIbConfig, CustomThMinThMaxClamps) {
+  QpScalingThMinOverride oMin(100000);
+  QpScalingThMaxOverride oMax(200000);
+  auto result = resolveIbConfig(nullptr, GpuArch::Default, 1 * MB);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_GE(result->qpScalingTh, 100000u);
+  EXPECT_LE(result->qpScalingTh, 200000u);
+}
+
 // Combined invariant checks over the full (maxBDP, nRanks, msgBytes) space.
 // For each combination we verify:
 //   1. Non-pow2 msgBytes produces same tuning as nearest pow2
@@ -1313,6 +1456,22 @@ TEST_F(AutoTuneInvariantTest, CombinedInvariants) {
             << " stagingBufSize=" << stagingBufSize
             << " chunkSize=" << at.pipeline.chunkSize
             << " numChunks=" << at.pipeline.numChunks;
+
+        // resolveIbConfig: Default returns value in [ThMin, ThMax], Hopper
+        // nullopt
+        auto resolved =
+            resolveIbConfig(nullptr, GpuArch::Default, at.pipeline.chunkSize);
+        ASSERT_TRUE(resolved.has_value())
+            << "resolveIbConfig(Default) should return value at msgBytes="
+            << msgBytes;
+        EXPECT_GE(
+            resolved->qpScalingTh,
+            static_cast<size_t>(NCCL_CTRAN_ALLREDUCE_RING_QP_SCALING_TH_MIN));
+
+        auto hopperResolved =
+            resolveIbConfig(nullptr, GpuArch::Hopper, at.pipeline.chunkSize);
+        EXPECT_FALSE(hopperResolved.has_value())
+            << "resolveIbConfig(Hopper) should return nullopt";
       }
     }
   }

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2867,6 +2867,24 @@ cvars:
      with per-message-size optimal values. Set to 0 to use static CVAR
      values instead.
 
+ - name        : NCCL_CTRAN_ALLREDUCE_RING_QP_SCALING_TH_MIN
+   type        : int64_t
+   default     : 262144
+   description : |-
+     Lower bound (in bytes) for the QP scaling threshold in AllReduceRing autotune.
+     The threshold is clamped to [this value, TH_MAX]. Default: 262144 (256KB).
+     Autotune-derived QP scaling is disabled when TH_MIN < 0, TH_MAX <= 0,
+     or TH_MAX < TH_MIN.
+
+ - name        : NCCL_CTRAN_ALLREDUCE_RING_QP_SCALING_TH_MAX
+   type        : int64_t
+   default     : 524288
+   description : |-
+     Upper bound (in bytes) for the QP scaling threshold in AllReduceRing autotune.
+     The threshold is clamped to [TH_MIN, this value]. Default: 524288 (512KB).
+     Autotune-derived QP scaling is disabled when TH_MIN < 0, TH_MAX <= 0,
+     or TH_MAX < TH_MIN.
+
  - name        : NCCL_CTRAN_ALLREDUCE_RING_STAGING_BUF_SIZE
    type        : int64_t
    default     : 0


### PR DESCRIPTION
Summary:

Derive CtranIbConfig from autotune chunkSize for AllReduceRing iput() calls, so QP scaling threshold adapts per message size without requiring env vars.

Formula:
```
qpScalingTh = clamp(chunkSize /
  (NCCL_CTRAN_IB_DEVICES_PER_RANK * NCCL_CTRAN_IB_MAX_QPS),
NCCL_CTRAN_ALLREDUCE_RING_QP_SCALING_TH_MIN,
NCCL_CTRAN_ALLREDUCE_RING_QP_SCALING_TH_MAX)

NCCL_CTRAN_ALLREDUCE_RING_QP_SCALING_TH_MIN (default is 256K)
NCCL_CTRAN_ALLREDUCE_RING_QP_SCALING_TH_MAX (default is 512K)
```

Override precedence (highest to lowest):
1. Explicit NCCL_CTRAN_IB_QP_CONFIG_ALGO cvar (user override)
2. Autotune-derived CtranIbConfig (Blackwell+ only)
3. Per-peer topology defaults (XRACK/XZONE/XDC cvars)
4. Global defaults

Gated on GpuArch: only active on Blackwell+ (GB200). On Hopper (H100), ibConfig_ remains nullptr and per-peer defaults are used, matching existing behavior.

All sizes 1M-128M are within ±2.8% — no regression on H100. The larger sizes (256M, 512M) show more variance but this is consistent with typical run-to-run noise at those sizes.

Differential Revision: D97988334
