### PR TITLE
Fix SIGSEGV and error propagation on abort during sendRecvImpl

### DIFF
--- a/comms/ctran/algos/SendRecv/SendRecvImpl.h
+++ b/comms/ctran/algos/SendRecv/SendRecvImpl.h
@@ -275,6 +275,17 @@ inline commResult_t sendRecvImpl(
     }
   }
 
+  // If abort fired during PUT issue loop, not all PUTs were issued.
+  // Throw immediately — no point waiting for issued PUTs since
+  // waitRequest would just detect the abort and throw.
+  if (putReqs.size() < sendOpGroup.size() && comm->testAbort()) {
+    throw ctran::utils::Exception(
+        "comm aborted during sendRecv PUT issuance",
+        commRemoteError,
+        comm->logMetaData_.rank,
+        comm->logMetaData_.commHash);
+  }
+
   // Wait for all PUT messages to complete
   for (auto i = 0; i < sendOpGroup.size(); i++) {
     auto op = sendOpGroup[i];


### PR DESCRIPTION
Summary:
When the communicator is aborted mid-send, the PUT issue loop exits early
leaving `putReqs` partially populated. Previously, the wait loop would access
missing map entries (inserting null unique_ptrs) and crash in `waitRequestImpl`
when dereferencing `req->peer` at offset 0x58 from null.

throw retryable exception immediately when abort is detected after incomplete
PUT issuance, avoiding both the null dereference and ensuring the abort error
propagates to callers via `workHandle->getResult()`.

Differential Revision: D98057229


