### PR TITLE
Propagate nolocal topology to pipes p2pDisable

### DIFF
--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -93,7 +93,8 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     }
 
     config.disableIb = NCCL_CTRAN_PIPES_DISABLE_IB;
-    config.topoConfig.p2pDisable = NCCL_P2P_DISABLE;
+    config.topoConfig.p2pDisable = NCCL_P2P_DISABLE ||
+        NCCL_COMM_STATE_DEBUG_TOPO == NCCL_COMM_STATE_DEBUG_TOPO::nolocal;
 
     // Topology config: MNNVL mode and overrides
     config.topoConfig.mnnvlMode =


### PR DESCRIPTION
Summary:
When `NCCL_COMM_STATE_DEBUG_TOPO=nolocal` is set, ctran treats all peers as
IB (non-NVLink). However, pipes topology was not updated — pipes still
discovered NVL peers via its own topology detection, causing a mismatch:
`validatePipesCtranConsistency` would abort because pipes found NVL peers
while ctran had none.

Fix: propagate `nolocal` to `config.topoConfig.p2pDisable = true` so pipes
also skips NVL peer discovery and treats all peers as IBGDA. This is
consistent with `NCCL_CTRAN_PIPES_IB_ONLY=1` behavior.

Differential Revision: D98165519


