### PR TITLE
Add nolocal test with nvl fabric to show failing

### DIFF
--- a/comms/ctran/commstate/tests/CommStateXTest.cc
+++ b/comms/ctran/commstate/tests/CommStateXTest.cc
@@ -565,4 +565,59 @@ TEST(CommStateXTest, TopologySetInvalidNvlFabricTopos) {
   EXPECT_DEATH(commState->setNvlFabricTopos(nvlFabricTopologies), "");
 }
 
+TEST(CommStateXTest, DISABLED_nvlFabricWithNoLocal) {
+  const int rank = 0;
+  const int nRanks = 8;
+  const int cudaDev = 0;
+  const int cudaArch = 90;
+  const int64_t busId = 25;
+  const uint64_t commHash = 0;
+
+  // Create CommStateX with empty rank topologies (will be set by
+  // initRankTopologyNolocal)
+  auto commState = std::make_unique<CommStateX>(
+      rank,
+      nRanks,
+      cudaDev,
+      cudaArch,
+      busId,
+      commHash,
+      std::vector<RankTopology>{},
+      std::vector<int>{});
+
+  // Simulate noLocal init path: set noLocal topology then enable NVL fabric
+  commState->initRankTopologyNolocal();
+
+  // Set up NVL fabric with 2 clusters of 4 ranks each (e.g. GB200 2-GPU trays)
+  std::vector<NvlFabricTopology> nvlFabricTopologies{};
+  nvlFabricTopologies.emplace_back(
+      createNvlFabricTopology(0, kNvlFabricClusterId1, kNvlFabricCliqueId1));
+  nvlFabricTopologies.emplace_back(
+      createNvlFabricTopology(1, kNvlFabricClusterId1, kNvlFabricCliqueId1));
+  nvlFabricTopologies.emplace_back(
+      createNvlFabricTopology(2, kNvlFabricClusterId1, kNvlFabricCliqueId1));
+  nvlFabricTopologies.emplace_back(
+      createNvlFabricTopology(3, kNvlFabricClusterId1, kNvlFabricCliqueId1));
+  nvlFabricTopologies.emplace_back(
+      createNvlFabricTopology(4, kNvlFabricClusterId2, kNvlFabricCliqueId1));
+  nvlFabricTopologies.emplace_back(
+      createNvlFabricTopology(5, kNvlFabricClusterId2, kNvlFabricCliqueId1));
+  nvlFabricTopologies.emplace_back(
+      createNvlFabricTopology(6, kNvlFabricClusterId2, kNvlFabricCliqueId1));
+  nvlFabricTopologies.emplace_back(
+      createNvlFabricTopology(7, kNvlFabricClusterId2, kNvlFabricCliqueId1));
+  commState->setNvlFabricTopos(nvlFabricTopologies, true);
+
+  // NVL fabric should still be enabled (for transport)
+  EXPECT_TRUE(commState->nvlFabricEnabled());
+
+  // But topology getters should respect noLocal: each rank is its own node
+  for (int i = 0; i < nRanks; ++i) {
+    EXPECT_EQ(commState->nLocalRanks(i), 1);
+    EXPECT_EQ(commState->localRank(i), 0);
+    EXPECT_EQ(commState->node(i), i);
+  }
+  EXPECT_EQ(commState->nNodes(), nRanks);
+}
+
 } // namespace ncclx


### PR DESCRIPTION
Summary: Nolocal setting not respected with nvl fabric. Test is failing, so disable. Fix in followup diff.

Differential Revision: D98184681


