### PR TITLE
Fix CommStateX topology getters to respect noLocal when NVL fabric is enabled (#1266)

### DIFF
--- a/comms/ctran/commstate/CommStateX.cc
+++ b/comms/ctran/commstate/CommStateX.cc
@@ -49,14 +49,16 @@ CommStateX::CommStateX(
     uint64_t commHash,
     std::vector<RankTopology> rankTopologies,
     std::vector<int> commRanksToWorldRanks,
-    const std::string& commDesc)
+    const std::string& commDesc,
+    bool noLocal)
     : rank_(rank),
       nRanks_(nRanks),
       cudaDev_(cudaDev),
       cudaArch_(cudaArch),
       busId_(busId),
       commHash_(commHash),
-      commDesc_(commDesc) {
+      commDesc_(commDesc),
+      noLocal_(noLocal) {
   setRankStatesTopologies(std::move(rankTopologies));
   setCommRankToWorldRanks(std::move(commRanksToWorldRanks));
 }
@@ -101,6 +103,10 @@ void CommStateX::initRankTopologyVnode(const int nLocalRanks) {
 }
 
 void CommStateX::initRankStatesTopology(meta::comms::IBootstrap* bootstrap) {
+  if (noLocal_) {
+    initRankTopologyNolocal();
+    return;
+  }
   auto myTopo = ctran::commstate::loadTopology(rank_, NCCL_TOPO_FILE_PATH);
   if (!myTopo) {
     FB_CHECKTHROW_EX(
@@ -158,6 +164,32 @@ void CommStateX::setNvlFabricTopos(
   }
   nvlFabricCliqueEnabled_ = nvlFabricEnabled_ && NCCL_MNNVL_CLIQUE_SIZE > 0 &&
       NCCL_MNNVL_DETERMINISTIC_COLLECTIVE_ENABLE;
+
+  // When noLocal is set, override NVL fabric maps so each rank appears as its
+  // own NVL domain with nLocalRanks=1, while keeping NVL fabric enabled for
+  // transport.
+  if (noLocal_) {
+    nvlFabricRankStates_.resize(nRanks_);
+    for (int i = 0; i < nRanks_; i++) {
+      auto& state = nvlFabricRankStates_.at(i);
+      state.rank = i;
+      state.nvlDomainIndex = i;
+      state.nvlDomainRank = 0;
+      state.nNvlDomainRanks = 1;
+      state.nvlDomainRankToRank = {i};
+      nvlDomainRanks_.emplace_back(std::vector<int>{i});
+      if (nvlFabricCliqueEnabled_) {
+        state.cliqueIndex = i;
+        state.cliqueRank = 0;
+        state.nCliqueRanks = 1;
+        state.cliqueRankToRank = {i};
+        cliqueRanks_.emplace_back(std::vector<int>{i});
+      }
+    }
+    myNvlFabricRankState_ = nvlFabricRankStates_.at(rank_);
+    return;
+  }
+
   std::unordered_map<std::string, int> clusterIdToNvlDomainIndex;
   // cliqueIds might not be contiguous, within the same communicator.
   // CliqueIndex is contiguous fron 0 to nCliqueIds - 1.

--- a/comms/ctran/commstate/CommStateX.h
+++ b/comms/ctran/commstate/CommStateX.h
@@ -80,7 +80,8 @@ class CommStateX {
       uint64_t commHash,
       std::vector<RankTopology> rankTopologies,
       std::vector<int> commRanksToWorldRanks,
-      const std::string& commDesc = "");
+      const std::string& commDesc = "",
+      bool noLocal = false);
 
   ~CommStateX();
 
@@ -285,6 +286,10 @@ class CommStateX {
   std::vector<NvlFabricRankState> nvlFabricRankStates_{};
 
   NvlFabricRankState myNvlFabricRankState_{};
+
+  // When true, treat every rank as if it is on its own node. Affects
+  // initRankStatesTopology() and setNvlFabricTopos() behavior.
+  const bool noLocal_{false};
 
   // flag to indicate if this rank has enabled NVL Fabric, if this flag is on,
   //  we assume all the nvl communication from/to this rank is through

--- a/comms/ctran/commstate/tests/CommStateXTest.cc
+++ b/comms/ctran/commstate/tests/CommStateXTest.cc
@@ -565,7 +565,7 @@ TEST(CommStateXTest, TopologySetInvalidNvlFabricTopos) {
   EXPECT_DEATH(commState->setNvlFabricTopos(nvlFabricTopologies), "");
 }
 
-TEST(CommStateXTest, DISABLED_nvlFabricWithNoLocal) {
+TEST(CommStateXTest, nvlFabricWithNoLocal) {
   const int rank = 0;
   const int nRanks = 8;
   const int cudaDev = 0;
@@ -583,10 +583,13 @@ TEST(CommStateXTest, DISABLED_nvlFabricWithNoLocal) {
       busId,
       commHash,
       std::vector<RankTopology>{},
-      std::vector<int>{});
+      std::vector<int>{},
+      "" /* commDesc */,
+      true /* noLocal */);
 
-  // Simulate noLocal init path: set noLocal topology then enable NVL fabric
-  commState->initRankTopologyNolocal();
+  // noLocal is set at construction; initRankStatesTopology delegates to
+  // initRankTopologyNolocal
+  commState->initRankStatesTopology(nullptr);
 
   // Set up NVL fabric with 2 clusters of 4 ranks each (e.g. GB200 2-GPU trays)
   std::vector<NvlFabricTopology> nvlFabricTopologies{};

--- a/comms/ncclx/v2_27/meta/commstate/FactoryCommStateX.cc
+++ b/comms/ncclx/v2_27/meta/commstate/FactoryCommStateX.cc
@@ -52,7 +52,8 @@ std::unique_ptr<CommStateX> createCommStateXFromNcclComm(void* _comm) {
       comm->commHash,
       std::vector<RankTopology>(), /* rankTopologies */
       std::vector<int>(), /* commRanksToWorldRanks */
-      NCCLX_CONFIG_FIELD(comm->config, commDesc));
+      NCCLX_CONFIG_FIELD(comm->config, commDesc),
+      comm->noLocal_);
 
   if (comm->noLocal_ ||
       NCCL_COMM_STATE_DEBUG_TOPO == NCCL_COMM_STATE_DEBUG_TOPO::nolocal) {
@@ -149,11 +150,7 @@ ncclResult_t initCtranCommStatexFromNcclComm(
   }
 
   try {
-    if (ncclComm->noLocal_) {
-      ctranComm->statex_->initRankTopologyNolocal();
-    } else {
-      ctranComm->statex_->initRankStatesTopology(ctranComm->bootstrap_.get());
-    }
+    ctranComm->statex_->initRankStatesTopology(ctranComm->bootstrap_.get());
 
     NCCLCHECK(initNvlFabricTopologies(ncclComm, ctranComm));
 

--- a/comms/ncclx/v2_28/meta/commstate/FactoryCommStateX.cc
+++ b/comms/ncclx/v2_28/meta/commstate/FactoryCommStateX.cc
@@ -52,7 +52,8 @@ std::unique_ptr<CommStateX> createCommStateXFromNcclComm(void* _comm) {
       comm->commHash,
       std::vector<RankTopology>(), /* rankTopologies */
       std::vector<int>(), /* commRanksToWorldRanks */
-      NCCLX_CONFIG_FIELD(comm->config, commDesc));
+      NCCLX_CONFIG_FIELD(comm->config, commDesc),
+      comm->noLocal_);
 
   if (comm->noLocal_ ||
       NCCL_COMM_STATE_DEBUG_TOPO == NCCL_COMM_STATE_DEBUG_TOPO::nolocal) {
@@ -149,11 +150,7 @@ ncclResult_t initCtranCommStatexFromNcclComm(
   }
 
   try {
-    if (ncclComm->noLocal_) {
-      ctranComm->statex_->initRankTopologyNolocal();
-    } else {
-      ctranComm->statex_->initRankStatesTopology(ctranComm->bootstrap_.get());
-    }
+    ctranComm->statex_->initRankStatesTopology(ctranComm->bootstrap_.get());
 
     NCCLCHECK(initNvlFabricTopologies(ncclComm, ctranComm));
 

--- a/comms/ncclx/v2_29/meta/commstate/FactoryCommStateX.cc
+++ b/comms/ncclx/v2_29/meta/commstate/FactoryCommStateX.cc
@@ -52,7 +52,8 @@ std::unique_ptr<CommStateX> createCommStateXFromNcclComm(void* _comm) {
       comm->commHash,
       std::vector<RankTopology>(), /* rankTopologies */
       std::vector<int>(), /* commRanksToWorldRanks */
-      NCCLX_CONFIG_FIELD(comm->config, commDesc));
+      NCCLX_CONFIG_FIELD(comm->config, commDesc),
+      comm->noLocal_);
 
   if (comm->noLocal_ ||
       NCCL_COMM_STATE_DEBUG_TOPO == NCCL_COMM_STATE_DEBUG_TOPO::nolocal) {
@@ -149,11 +150,7 @@ ncclResult_t initCtranCommStatexFromNcclComm(
   }
 
   try {
-    if (ncclComm->noLocal_) {
-      ctranComm->statex_->initRankTopologyNolocal();
-    } else {
-      ctranComm->statex_->initRankStatesTopology(ctranComm->bootstrap_.get());
-    }
+    ctranComm->statex_->initRankStatesTopology(ctranComm->bootstrap_.get());
 
     NCCLCHECK(initNvlFabricTopologies(ncclComm, ctranComm));
 


### PR DESCRIPTION
Summary:

When a communicator is created with noLocal initRankTopologyNolocal() correctly sets rankStates_[r].nLocalRanks = 1. However, setNvlFabricTopos() then builds NVL fabric maps from physical hardware topology, and the topology getters (nLocalRanks, localRank, node, etc.) return the physical NVL domain rank count (e.g., 2 on GB200) instead of 1.

Fix: store noLocal as a hint on CommStateX via setNoLocal(). initRankStatesTopology() checks this hint and delegates to initRankTopologyNolocal() when set. setNvlFabricTopos() also checks the hint and overrides NVL fabric maps so each rank appears as its own NVL domain (nNvlDomainRanks=1), while keeping NVL fabric enabled for transport.

Differential Revision: D98184682
