### PR TITLE
Remove GPE signaling from DeviceAllToAllvPipes kernel (#1267)

### DIFF
--- a/comms/ctran/algos/AllToAll/DeviceAllToAllvPipes.cu
+++ b/comms/ctran/algos/AllToAll/DeviceAllToAllvPipes.cu
@@ -5,9 +5,6 @@
 #include <cstddef>
 #include "comms/ctran/algos/AllToAll/Types.h"
 #include "comms/ctran/algos/CtranAlgoDev.h"
-#include "comms/ctran/algos/DevAlgoImpl.cuh"
-#include "comms/ctran/algos/DevCommon.cuh"
-#include "comms/ctran/gpe/CtranGpeDev.h"
 #include "comms/pipes/DeviceSpan.cuh"
 #include "comms/pipes/Transport.cuh"
 
@@ -26,16 +23,9 @@ computeDisplacement(const int64_t* counts_d, int rank) {
 }
 
 __global__ void ncclKernelDeviceAllToAllvPipes(
-    int* flag,
-    CtranAlgoDeviceState* devState,
+    int* /* flag */,
+    CtranAlgoDeviceState* /* devState */,
     ctran::device_alltoallv_pipes::KernArgs args) {
-  const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
-
-  if (flag && gtIdx == 0) {
-    ctran::device::devLoadAbortFlags(flag, devState);
-    ctran::device::KernelStartGpe(flag);
-  }
-
   const int nLocalRanks = args.nLocalRanks;
   const int myRank = args.myRank;
   const size_t elementSize = args.elementSize;
@@ -103,10 +93,6 @@ __global__ void ncclKernelDeviceAllToAllvPipes(
           static_cast<char*>(args.recvbuff) + recvOffset,
           recvBytes);
     }
-  }
-
-  if (flag && gtIdx == 0) {
-    ctran::device::KernelWaitGpeTerminate(flag);
   }
 }
 


### PR DESCRIPTION
Summary:

The DeviceAllToAllvPipes kernel is NVL-only (no IB path). The opGroup submitted to GPE is always empty, so gpe->submit() sets kernelFlag to nullptr. This means the GPE signaling code in the kernel (KernelStartGpe, KernelWaitGpeTerminate, devLoadAbortFlags) is dead code — the if (flag && ...) guards always evaluate to false.

Remove this dead GPE signaling code to simplify the kernel and make the NVL-only intent explicit. Also remove unused includes that were only needed for the GPE signaling functions.

Reviewed By: snarayankh

Differential Revision: D98174448
