### PR TITLE
Add transport-agnostic connection verdict enums (#1273)

### DIFF
--- a/comms/analyzer/if/NCCLAnalyzerVerdict.thrift
+++ b/comms/analyzer/if/NCCLAnalyzerVerdict.thrift
@@ -37,6 +37,11 @@ enum BrokenRankType {
   RANK_UNRESPONSIVE_OVER_HTTP_TOO_LONG = 14,
   IB_COMPLETION_ERROR_TYPE = 15,
   CUDA_ERROR_TYPE = 16,
+  // Transport-agnostic replacements for HTTP-named variants above.
+  // Old values kept for Scuba backwards compatibility.
+  NO_CONNECTION = 17,
+  FLAKY_OR_SLOW_CONNECTION = 18,
+  RANK_UNRESPONSIVE_TOO_LONG = 19,
 }
 
 @thrift.DeprecatedUnvalidatedAnnotations{items = {"hash": "1"}}
@@ -69,6 +74,9 @@ enum VerdictType {
   IB_COMPLETION_ERROR = 25,
   CUDA_ERROR = 26,
   CUDA_NVLINK_UNCORRECTABLE_ERROR = 27,
+  // Transport-agnostic replacement for RANKS_UNRESPONSIVE_OVER_HTTP_TOO_LONG.
+  // Old value kept for Scuba backwards compatibility.
+  RANKS_UNRESPONSIVE_TOO_LONG = 28,
 }
 
 struct SlowRankLeastCommsVerdict {


### PR DESCRIPTION
Summary:

The BrokenRankType and VerdictType enums reference "HTTP" in their
names (NO_CONNECTION_VIA_HTTP, FLAKY_OR_SLOW_CONNECTION_VIA_HTTP,
RANKS_UNRESPONSIVE_OVER_HTTP_TOO_LONG), but the analyzer connects
via HTTP, Thrift, and CommsTracingServiceThrift. The names are
misleading when a Thrift connection fails.

Add new transport-agnostic enum values and update code to use them.
Old values kept for Scuba backwards compatibility.

New BrokenRankType values:
- NO_CONNECTION (17) — replaces NO_CONNECTION_VIA_HTTP (1)
- FLAKY_OR_SLOW_CONNECTION (18) — replaces FLAKY_OR_SLOW_CONNECTION_VIA_HTTP (2)
- RANK_UNRESPONSIVE_TOO_LONG (19) — replaces RANK_UNRESPONSIVE_OVER_HTTP_TOO_LONG (14)

New VerdictType value:
- RANKS_UNRESPONSIVE_TOO_LONG (28) — replaces RANKS_UNRESPONSIVE_OVER_HTTP_TOO_LONG (21)

Differential Revision: D98171181
