### PR TITLE
Add CoopScope to wait_signal, wait_counter, and reset APIs

### DIFF
--- a/comms/torchcomms/device/TorchCommDeviceWindow.hpp
+++ b/comms/torchcomms/device/TorchCommDeviceWindow.hpp
@@ -187,19 +187,35 @@ class TorchCommDeviceWindow {
       uint64_t value = 1,
       CoopScope scope = CoopScope::THREAD);
 
-  __device__ int wait_signal(int signal_id, CmpOp cmp, uint64_t value);
-  __device__ int
-  wait_signal_from(int peer, int signal_id, CmpOp cmp, uint64_t value);
+  __device__ int wait_signal(
+      int signal_id,
+      CmpOp cmp,
+      uint64_t value,
+      CoopScope scope = CoopScope::THREAD);
+  __device__ int wait_signal_from(
+      int peer,
+      int signal_id,
+      CmpOp cmp,
+      uint64_t value,
+      CoopScope scope = CoopScope::THREAD);
   __device__ uint64_t read_signal(int signal_id) const;
-  __device__ void reset_signal(int signal_id);
+  __device__ void reset_signal(
+      int signal_id,
+      CoopScope scope = CoopScope::THREAD);
 
   // =========================================================================
   // Counter Operations (Local Completion)
   // =========================================================================
 
-  __device__ int wait_counter(int counter_id, CmpOp cmp, uint64_t value);
+  __device__ int wait_counter(
+      int counter_id,
+      CmpOp cmp,
+      uint64_t value,
+      CoopScope scope = CoopScope::THREAD);
   __device__ uint64_t read_counter(int counter_id) const;
-  __device__ void reset_counter(int counter_id);
+  __device__ void reset_counter(
+      int counter_id,
+      CoopScope scope = CoopScope::THREAD);
 
   // =========================================================================
   // Synchronization & Completion

--- a/comms/torchcomms/device/ncclx/TorchCommDeviceNCCLX.cuh
+++ b/comms/torchcomms/device/ncclx/TorchCommDeviceNCCLX.cuh
@@ -289,23 +289,31 @@ template <>
 __device__ inline int TorchCommDeviceWindow<NCCLDeviceBackend>::wait_signal(
     int signal_id,
     CmpOp cmp,
-    uint64_t value) {
-  const ncclDevComm& dev_comm = comm_;
-  uint64_t* base = detail::signal_slot_base(
-      dev_comm, signal_buffer_handle_, signal_id, num_ranks_);
+    uint64_t value,
+    CoopScope scope) {
+  auto group = detail::make_thread_group(scope);
 
-  // Spin-poll with acquire loads
-  // that once we see a signal value, all prior stores from the signaler
-  // (i.e. the data written by put()) are visible to us.
-  for (;;) {
-    uint64_t sum = 0;
-    for (int i = 0; i < num_ranks_; i++) {
-      sum += comms::device::ld_acquire_sys_global(base + i);
-    }
-    if (detail::cmp_op(cmp, sum, value)) {
-      return 0;
+  if (group.is_leader()) {
+    const ncclDevComm& dev_comm = comm_;
+    uint64_t* base = detail::signal_slot_base(
+        dev_comm, signal_buffer_handle_, signal_id, num_ranks_);
+
+    // Spin-poll with acquire loads
+    // that once we see a signal value, all prior stores from the signaler
+    // (i.e. the data written by put()) are visible to us.
+    for (;;) {
+      uint64_t sum = 0;
+      for (int i = 0; i < num_ranks_; i++) {
+        sum += comms::device::ld_acquire_sys_global(base + i);
+      }
+      if (detail::cmp_op(cmp, sum, value)) {
+        break;
+      }
     }
   }
+
+  group.sync();
+  return 0;
 }
 
 template <>
@@ -314,18 +322,27 @@ TorchCommDeviceWindow<NCCLDeviceBackend>::wait_signal_from(
     int peer,
     int signal_id,
     CmpOp cmp,
-    uint64_t value) {
-  const ncclDevComm& dev_comm = comm_;
-  uint64_t* slot = detail::signal_slot_base(
-                       dev_comm, signal_buffer_handle_, signal_id, num_ranks_) +
-      peer;
+    uint64_t value,
+    CoopScope scope) {
+  auto group = detail::make_thread_group(scope);
 
-  for (;;) {
-    uint64_t val = comms::device::ld_acquire_sys_global(slot);
-    if (detail::cmp_op(cmp, val, value)) {
-      return 0;
+  if (group.is_leader()) {
+    const ncclDevComm& dev_comm = comm_;
+    uint64_t* slot =
+        detail::signal_slot_base(
+            dev_comm, signal_buffer_handle_, signal_id, num_ranks_) +
+        peer;
+
+    for (;;) {
+      uint64_t val = comms::device::ld_acquire_sys_global(slot);
+      if (detail::cmp_op(cmp, val, value)) {
+        break;
+      }
     }
   }
+
+  group.sync();
+  return 0;
 }
 
 template <>
@@ -344,13 +361,19 @@ TorchCommDeviceWindow<NCCLDeviceBackend>::read_signal(int signal_id) const {
 
 template <>
 __device__ inline void TorchCommDeviceWindow<NCCLDeviceBackend>::reset_signal(
-    int signal_id) {
-  const ncclDevComm& dev_comm = comm_;
-  uint64_t* base = detail::signal_slot_base(
-      dev_comm, signal_buffer_handle_, signal_id, num_ranks_);
+    int signal_id,
+    CoopScope scope) {
+  auto group = detail::make_thread_group(scope);
+  group.sync();
 
-  for (int i = 0; i < num_ranks_; i++) {
-    comms::device::st_release_sys_global(base + i, 0ULL);
+  if (group.is_leader()) {
+    const ncclDevComm& dev_comm = comm_;
+    uint64_t* base = detail::signal_slot_base(
+        dev_comm, signal_buffer_handle_, signal_id, num_ranks_);
+
+    for (int i = 0; i < num_ranks_; i++) {
+      comms::device::st_release_sys_global(base + i, 0ULL);
+    }
   }
 }
 
@@ -364,7 +387,8 @@ template <>
 __device__ inline int TorchCommDeviceWindow<NCCLDeviceBackend>::wait_counter(
     int counter_id,
     CmpOp cmp,
-    uint64_t value) {
+    uint64_t value,
+    CoopScope scope) {
   if (cmp != CmpOp::GE) {
     // GIN hardware counters only support GE comparison.
     __trap();
@@ -374,11 +398,13 @@ __device__ inline int TorchCommDeviceWindow<NCCLDeviceBackend>::wait_counter(
   const ncclDevComm& dev_comm = comm_;
   ncclGin gin(dev_comm, kDefaultGinContextIndex);
 
-  gin.waitCounter(
-      ncclCoopThread{},
-      static_cast<ncclGinCounter_t>(counter_id),
-      value,
-      kDefaultCounterBits);
+  detail::nccl_coop_dispatch(scope, [&](auto coop) {
+    gin.waitCounter(
+        coop,
+        static_cast<ncclGinCounter_t>(counter_id),
+        value,
+        kDefaultCounterBits);
+  });
 
   return 0;
 }
@@ -395,11 +421,16 @@ TorchCommDeviceWindow<NCCLDeviceBackend>::read_counter(int counter_id) const {
 
 template <>
 __device__ inline void TorchCommDeviceWindow<NCCLDeviceBackend>::reset_counter(
-    int counter_id) {
-  const ncclDevComm& dev_comm = comm_;
-  ncclGin gin(dev_comm, kDefaultGinContextIndex);
+    int counter_id,
+    CoopScope scope) {
+  auto group = detail::make_thread_group(scope);
+  group.sync();
 
-  gin.resetCounter(static_cast<ncclGinCounter_t>(counter_id));
+  if (group.is_leader()) {
+    const ncclDevComm& dev_comm = comm_;
+    ncclGin gin(dev_comm, kDefaultGinContextIndex);
+    gin.resetCounter(static_cast<ncclGinCounter_t>(counter_id));
+  }
 }
 
 // =============================================================================

--- a/comms/torchcomms/device/pipes/TorchCommDevicePipes.cuh
+++ b/comms/torchcomms/device/pipes/TorchCommDevicePipes.cuh
@@ -185,15 +185,11 @@ template <>
 __device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::wait_signal(
     int signal_id,
     CmpOp cmp,
-    uint64_t value) {
+    uint64_t value,
+    CoopScope scope) {
   auto& win = *window_;
   auto pipes_cmp = detail::to_pipes_cmp_op(cmp);
-  // TODO: Add CoopScope parameter to wait_signal in the base class
-  // (TorchCommDeviceWindow). Pipes wait_signal takes a ThreadGroup and
-  // benefits from leader-only polling + group sync. Currently forced to
-  // thread-solo (all threads poll independently). NCCLXGin doesn't support
-  // scope either, so will add it to both backends together.
-  auto group = comms::pipes::make_thread_solo();
+  auto group = detail::make_pipes_thread_group(scope);
   win.wait_signal(group, signal_id, pipes_cmp, value);
   return 0;
 }
@@ -204,10 +200,12 @@ TorchCommDeviceWindow<PipesDeviceBackend>::wait_signal_from(
     int peer,
     int signal_id,
     CmpOp cmp,
-    uint64_t value) {
+    uint64_t value,
+    CoopScope scope) {
   auto& win = *window_;
   auto pipes_cmp = detail::to_pipes_cmp_op(cmp);
-  win.wait_signal_from(peer, signal_id, pipes_cmp, value);
+  auto group = detail::make_pipes_thread_group(scope);
+  win.wait_signal_from(group, peer, signal_id, pipes_cmp, value);
   return 0;
 }
 
@@ -223,15 +221,12 @@ TorchCommDeviceWindow<PipesDeviceBackend>::read_signal(int signal_id) const {
 
 template <>
 __device__ inline void TorchCommDeviceWindow<PipesDeviceBackend>::reset_signal(
-    int signal_id) {
+    int signal_id,
+    CoopScope scope) {
   // Pipes DeviceWindow does not support device-side signal reset.
-  // Recommended pattern: use monotonically increasing signal values, or
-  // reset signal buffers from the host side (cudaMemset) between kernel
-  // launches with proper synchronization.
-  //
-  // Calling reset_signal from device code is a programming error for the
-  // Pipes backend.
+  // Use monotonically increasing signal values, or reset from host side.
   (void)signal_id;
+  (void)scope;
   __trap();
 }
 
@@ -258,13 +253,18 @@ TorchCommDeviceWindow<PipesDeviceBackend>::read_counter(int counter_id) const {
 
 template <>
 __device__ inline void TorchCommDeviceWindow<PipesDeviceBackend>::reset_counter(
-    int counter_id) {
-  // Reset the counter for all peers.
-  auto& win = *window_;
-  int nPeers = win.num_peers();
-  for (int peer_index = 0; peer_index < nPeers; ++peer_index) {
-    int r = win.peer_index_to_rank(peer_index);
-    win.reset_counter(r, counter_id);
+    int counter_id,
+    CoopScope scope) {
+  auto group = detail::make_pipes_thread_group(scope);
+  group.sync();
+
+  if (group.is_leader()) {
+    auto& win = *window_;
+    int nPeers = win.num_peers();
+    for (int peer_index = 0; peer_index < nPeers; ++peer_index) {
+      int r = win.peer_index_to_rank(peer_index);
+      win.reset_counter(r, counter_id);
+    }
   }
 }
 
@@ -272,39 +272,41 @@ template <>
 __device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::wait_counter(
     int counter_id,
     CmpOp cmp,
-    uint64_t value) {
-  // Sum the counter across all peers and poll until the aggregate satisfies
-  // the comparison (same model as GIN: counter_id 0 with value 5 = 5 puts
-  // completed regardless of peer).
-  //
-  // Spin-poll: read_counter() already sums across all peers.
-  while (true) {
-    uint64_t total = read_counter(counter_id);
-    bool satisfied = false;
-    switch (cmp) {
-      case CmpOp::EQ:
-        satisfied = (total == value);
+    uint64_t value,
+    CoopScope scope) {
+  auto group = detail::make_pipes_thread_group(scope);
+
+  if (group.is_leader()) {
+    while (true) {
+      uint64_t total = read_counter(counter_id);
+      bool satisfied = false;
+      switch (cmp) {
+        case CmpOp::EQ:
+          satisfied = (total == value);
+          break;
+        case CmpOp::NE:
+          satisfied = (total != value);
+          break;
+        case CmpOp::GE:
+          satisfied = (total >= value);
+          break;
+        case CmpOp::GT:
+          satisfied = (total > value);
+          break;
+        case CmpOp::LE:
+          satisfied = (total <= value);
+          break;
+        case CmpOp::LT:
+          satisfied = (total < value);
+          break;
+      }
+      if (satisfied) {
         break;
-      case CmpOp::NE:
-        satisfied = (total != value);
-        break;
-      case CmpOp::GE:
-        satisfied = (total >= value);
-        break;
-      case CmpOp::GT:
-        satisfied = (total > value);
-        break;
-      case CmpOp::LE:
-        satisfied = (total <= value);
-        break;
-      case CmpOp::LT:
-        satisfied = (total < value);
-        break;
-    }
-    if (satisfied) {
-      break;
+      }
     }
   }
+
+  group.sync();
   return 0;
 }
 

--- a/comms/torchcomms/tests/integration/cpp/DeviceApiTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/DeviceApiTest.cpp
@@ -1015,3 +1015,117 @@ TEST_F(DeviceApiTest, DeviceBarrierWarpScope) {
 TEST_F(DeviceApiTest, DeviceBarrierBlockScope) {
   testDeviceBarrierScoped(torchcomms::device::CoopScope::BLOCK, 256);
 }
+
+// =============================================================================
+// Scope-Aware Wait/Reset Signal Tests
+// =============================================================================
+// Validates wait_signal and reset_signal with CoopScope::WARP and BLOCK.
+// Ring signal from rank i to (i+1)%N, wait with scoped kernel, reset with
+// scoped kernel, verify signal is 0 after reset.
+
+void DeviceApiTest::testWaitSignalScoped(
+    torchcomms::device::CoopScope scope,
+    int num_threads) {
+  std::string scope_name =
+      (scope == torchcomms::device::CoopScope::WARP) ? "WARP" : "BLOCK";
+  SCOPED_TRACE(
+      ::testing::Message() << "Testing Scoped WaitSignal (" << scope_name
+                           << ", threads=" << num_threads << ")");
+
+  auto op_stream = at::cuda::getStreamFromPool(false, device_index_);
+  auto wait_stream = at::cuda::getStreamFromPool(false, device_index_);
+
+  auto mem_pool = std::make_unique<at::cuda::MemPool>(
+      std::static_pointer_cast<c10::cuda::CUDACachingAllocator::CUDAAllocator>(
+          allocator_));
+  c10::cuda::CUDACachingAllocator::beginAllocateToPool(
+      mem_pool->device(), mem_pool->id(), [](cudaStream_t) { return true; });
+
+  auto options =
+      at::TensorOptions().dtype(at::kLong).device(at::kCUDA, device_index_);
+  at::Tensor win_tensor = at::zeros({1}, options);
+
+  c10::cuda::CUDACachingAllocator::endAllocateToPool(
+      mem_pool->device(), mem_pool->id());
+
+  torchcomm_->barrier(false);
+  auto win = torchcomm_->new_window();
+  win->tensor_register(win_tensor);
+  torchcomm_->barrier(false);
+
+  int signal_count = num_ranks_;
+  DeviceWindowNCCL* dev_win = static_cast<DeviceWindowNCCL*>(
+      win->get_device_window(signal_count, -1, 1));
+  ASSERT_NE(dev_win, nullptr);
+
+  int dst_rank = (rank_ + 1) % num_ranks_;
+  constexpr int kSignalId = 0;
+
+  // Signal next rank (thread scope)
+  {
+    c10::cuda::CUDAStreamGuard guard(op_stream);
+    torchcomms::device::test::launchDeviceSignalKernel(
+        dev_win,
+        dst_rank,
+        kSignalId,
+        torchcomms::device::SignalOp::ADD,
+        1,
+        op_stream.stream());
+  }
+
+  // Wait for signal using scoped kernel
+  {
+    c10::cuda::CUDAStreamGuard guard(wait_stream);
+    torchcomms::device::test::launchDeviceWaitSignalScopedKernel(
+        dev_win, kSignalId, 1, scope, num_threads, wait_stream.stream());
+  }
+
+  op_stream.synchronize();
+  wait_stream.synchronize();
+
+  // Reset signal using scoped kernel
+  {
+    c10::cuda::CUDAStreamGuard guard(op_stream);
+    torchcomms::device::test::launchDeviceResetSignalScopedKernel(
+        dev_win, kSignalId, scope, num_threads, op_stream.stream());
+  }
+  op_stream.synchronize();
+
+  // Verify signal is 0 after reset
+  uint64_t* d_out = nullptr;
+  ASSERT_EQ(cudaMalloc(&d_out, sizeof(uint64_t)), cudaSuccess);
+  {
+    c10::cuda::CUDAStreamGuard guard(op_stream);
+    torchcomms::device::test::launchDeviceReadSignalKernel(
+        dev_win, kSignalId, d_out, op_stream.stream());
+  }
+  op_stream.synchronize();
+
+  uint64_t h_out = 0;
+  cudaMemcpy(&h_out, d_out, sizeof(uint64_t), cudaMemcpyDeviceToHost);
+  cudaFree(d_out);
+  ASSERT_EQ(h_out, 0u) << "Signal should be 0 after scoped reset";
+
+  win->tensor_deregister();
+  win.reset();
+  mem_pool.reset();
+
+  torchcomm_->barrier(false);
+}
+
+class DeviceApiScopedWaitSignalTest
+    : public DeviceApiTest,
+      public ::testing::WithParamInterface<
+          std::tuple<torchcomms::device::CoopScope, int>> {};
+
+TEST_P(DeviceApiScopedWaitSignalTest, WaitSignalScoped) {
+  auto [scope, num_threads] = GetParam();
+  testWaitSignalScoped(scope, num_threads);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ScopeTests,
+    DeviceApiScopedWaitSignalTest,
+    ::testing::Values(
+        std::make_tuple(torchcomms::device::CoopScope::WARP, 32),
+        std::make_tuple(torchcomms::device::CoopScope::BLOCK, 256)));

--- a/comms/torchcomms/tests/integration/cpp/DeviceApiTest.hpp
+++ b/comms/torchcomms/tests/integration/cpp/DeviceApiTest.hpp
@@ -75,6 +75,11 @@ class DeviceApiTest : public ::testing::Test {
       torchcomms::device::CoopScope scope,
       int num_threads);
 
+  // Scope-aware wait_signal + reset_signal test
+  void testWaitSignalScoped(
+      torchcomms::device::CoopScope scope,
+      int num_threads);
+
   // Member variables
   std::unique_ptr<TorchCommTestWrapper> wrapper_;
   std::shared_ptr<torch::comms::TorchComm> torchcomm_;

--- a/comms/torchcomms/tests/integration/cpp/DeviceApiTestKernels.cu
+++ b/comms/torchcomms/tests/integration/cpp/DeviceApiTestKernels.cu
@@ -328,4 +328,52 @@ void launchDeviceBarrierScopedKernel(
       win, barrier_id, scope);
 }
 
+// =============================================================================
+// Scope-Aware Wait Signal Test Kernel
+// =============================================================================
+
+__global__ void deviceWaitSignalScopedKernel(
+    DeviceWindowNCCL* win,
+    int signal_id,
+    uint64_t expected_value,
+    CoopScope scope) {
+  if (blockIdx.x == 0) {
+    win->wait_signal(signal_id, CmpOp::GE, expected_value, scope);
+  }
+}
+
+void launchDeviceWaitSignalScopedKernel(
+    DeviceWindowNCCL* win,
+    int signal_id,
+    uint64_t expected_value,
+    CoopScope scope,
+    int num_threads,
+    cudaStream_t stream) {
+  deviceWaitSignalScopedKernel<<<1, num_threads, 0, stream>>>(
+      win, signal_id, expected_value, scope);
+}
+
+// =============================================================================
+// Scope-Aware Reset Signal Test Kernel
+// =============================================================================
+
+__global__ void deviceResetSignalScopedKernel(
+    DeviceWindowNCCL* win,
+    int signal_id,
+    CoopScope scope) {
+  if (blockIdx.x == 0) {
+    win->reset_signal(signal_id, scope);
+  }
+}
+
+void launchDeviceResetSignalScopedKernel(
+    DeviceWindowNCCL* win,
+    int signal_id,
+    CoopScope scope,
+    int num_threads,
+    cudaStream_t stream) {
+  deviceResetSignalScopedKernel<<<1, num_threads, 0, stream>>>(
+      win, signal_id, scope);
+}
+
 } // namespace torchcomms::device::test

--- a/comms/torchcomms/tests/integration/cpp/DeviceApiTestKernels.cuh
+++ b/comms/torchcomms/tests/integration/cpp/DeviceApiTestKernels.cuh
@@ -134,4 +134,21 @@ void launchDeviceBarrierScopedKernel(
     int num_threads,
     cudaStream_t stream);
 
+// Launch scope-aware wait_signal kernel
+void launchDeviceWaitSignalScopedKernel(
+    DeviceWindowNCCL* win,
+    int signal_id,
+    uint64_t expected_value,
+    CoopScope scope,
+    int num_threads,
+    cudaStream_t stream);
+
+// Launch scope-aware reset_signal kernel
+void launchDeviceResetSignalScopedKernel(
+    DeviceWindowNCCL* win,
+    int signal_id,
+    CoopScope scope,
+    int num_threads,
+    cudaStream_t stream);
+
 } // namespace torchcomms::device::test

--- a/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTest.cpp
@@ -993,3 +993,106 @@ void PipesDeviceApiTest::testWaitCounter(int count, at::ScalarType dtype) {
 TEST_F(PipesDeviceApiTest, WaitCounterFloat) {
   testWaitCounter(1024, at::kFloat);
 }
+
+// =============================================================================
+// Scoped Wait Signal Test (Pipes)
+// =============================================================================
+// Ring pattern with scoped wait: rank i signals rank (i+1) % num_ranks
+//   1. Each rank sends ADD 1 to the next rank via thread-scope signal
+//   2. Each rank waits with scoped wait_signal kernel (WARP or BLOCK)
+//   3. Verifies completion (no hang = pass)
+
+void PipesDeviceApiTest::testWaitSignalScoped(
+    CoopScope scope,
+    int num_threads) {
+  SCOPED_TRACE(
+      ::testing::Message() << "Testing scoped wait_signal (Pipes), threads="
+                           << num_threads);
+
+  auto op_stream = at::cuda::getStreamFromPool(false, device_index_);
+  auto wait_stream = at::cuda::getStreamFromPool(false, device_index_);
+
+  auto mem_pool = std::make_unique<at::cuda::MemPool>(
+      std::static_pointer_cast<c10::cuda::CUDACachingAllocator::CUDAAllocator>(
+          allocator_));
+  c10::cuda::CUDACachingAllocator::beginAllocateToPool(
+      mem_pool->device(), mem_pool->id(), [](cudaStream_t) { return true; });
+
+  auto options =
+      at::TensorOptions().dtype(at::kLong).device(at::kCUDA, device_index_);
+  at::Tensor win_tensor = at::zeros({1}, options);
+
+  c10::cuda::CUDACachingAllocator::endAllocateToPool(
+      mem_pool->device(), mem_pool->id());
+
+  torchcomm_->barrier(false);
+  auto base_win = torchcomm_->new_window();
+  base_win->tensor_register(win_tensor);
+  torchcomm_->barrier(false);
+
+  auto* win =
+      dynamic_cast<torch::comms::TorchCommWindowNCCLXPipes*>(base_win.get());
+  ASSERT_NE(win, nullptr) << "Window should be TorchCommWindowNCCLXPipes. "
+                             "Is NCCL_CTRAN_USE_PIPES=1 set?";
+
+  int signal_count = num_ranks_;
+  DeviceWindowPipes* dev_win = nullptr;
+  try {
+    dev_win = static_cast<DeviceWindowPipes*>(
+        win->get_device_window(signal_count, -1, 1));
+  } catch (const std::runtime_error& e) {
+    base_win->tensor_deregister();
+    base_win.reset();
+    mem_pool.reset();
+    GTEST_SKIP() << "Skipping: IBGDA/Pipes hardware not available: "
+                 << e.what();
+  }
+  ASSERT_NE(dev_win, nullptr);
+
+  int dst_rank = (rank_ + 1) % num_ranks_;
+  constexpr int kSignalId = 0;
+
+  // Signal next rank (thread scope)
+  {
+    c10::cuda::CUDAStreamGuard guard(op_stream);
+    torchcomms::device::test::launchPipesSignalKernel(
+        dev_win,
+        dst_rank,
+        kSignalId,
+        torchcomms::device::SignalOp::ADD,
+        1,
+        op_stream.stream());
+  }
+
+  // Wait for signal using scoped kernel
+  {
+    c10::cuda::CUDAStreamGuard guard(wait_stream);
+    torchcomms::device::test::launchPipesWaitSignalScopedKernel(
+        dev_win, kSignalId, 1, scope, num_threads, wait_stream.stream());
+  }
+
+  op_stream.synchronize();
+  wait_stream.synchronize();
+
+  base_win->tensor_deregister();
+  base_win.reset();
+  mem_pool.reset();
+
+  torchcomm_->barrier(false);
+}
+
+class PipesDeviceApiScopedWaitSignalTest
+    : public PipesDeviceApiTest,
+      public ::testing::WithParamInterface<std::tuple<CoopScope, int>> {};
+
+TEST_P(PipesDeviceApiScopedWaitSignalTest, WaitSignalScoped) {
+  auto [scope, num_threads] = GetParam();
+  testWaitSignalScoped(scope, num_threads);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ScopeTests,
+    PipesDeviceApiScopedWaitSignalTest,
+    ::testing::Values(
+        std::make_tuple(CoopScope::WARP, 32),
+        std::make_tuple(CoopScope::BLOCK, 256)));

--- a/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTest.hpp
+++ b/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTest.hpp
@@ -27,6 +27,7 @@
 
 #include "TorchCommTestHelpers.h"
 #include "comms/torchcomms/TorchComm.hpp"
+#include "comms/torchcomms/device/TorchCommDeviceWindow.hpp"
 #include "comms/torchcomms/ncclx/TorchCommWindowNCCLX.hpp"
 
 class PipesDeviceApiTest : public ::testing::Test {
@@ -74,6 +75,11 @@ class PipesDeviceApiTest : public ::testing::Test {
   // Test wait_counter: put_signal_counter, then wait_counter on sender side
   // to verify local completion tracking via companion QP counter.
   void testWaitCounter(int count, at::ScalarType dtype);
+
+  // Test wait_signal with CoopScope (WARP/BLOCK)
+  void testWaitSignalScoped(
+      torchcomms::device::CoopScope scope,
+      int num_threads);
 
   // Member variables
   std::unique_ptr<TorchCommTestWrapper> wrapper_;

--- a/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTestKernels.cu
+++ b/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTestKernels.cu
@@ -330,4 +330,87 @@ void launchPipesWaitCounterKernel(
   CUDA_LAUNCH_CHECK();
 }
 
+// =============================================================================
+// Scoped Wait Signal Kernel
+// =============================================================================
+// Waits for aggregated signal using the specified CoopScope.
+
+__global__ void pipesWaitSignalScopedKernel(
+    DeviceWindowPipes* win,
+    int signal_id,
+    uint64_t expected_value,
+    CoopScope scope) {
+  if (blockIdx.x == 0) {
+    win->wait_signal(signal_id, CmpOp::GE, expected_value, scope);
+  }
+}
+
+void launchPipesWaitSignalScopedKernel(
+    DeviceWindowPipes* win,
+    int signal_id,
+    uint64_t expected_value,
+    CoopScope scope,
+    int num_threads,
+    cudaStream_t stream) {
+  pipesWaitSignalScopedKernel<<<1, num_threads, 0, stream>>>(
+      win, signal_id, expected_value, scope);
+  CUDA_LAUNCH_CHECK();
+}
+
+// =============================================================================
+// Scoped Wait Signal From Kernel
+// =============================================================================
+// Waits for signal from a specific peer using the specified CoopScope.
+
+__global__ void pipesWaitSignalFromScopedKernel(
+    DeviceWindowPipes* win,
+    int src_rank,
+    int signal_id,
+    CmpOp cmp,
+    uint64_t value,
+    CoopScope scope) {
+  if (blockIdx.x == 0) {
+    win->wait_signal_from(src_rank, signal_id, cmp, value, scope);
+  }
+}
+
+void launchPipesWaitSignalFromScopedKernel(
+    DeviceWindowPipes* win,
+    int src_rank,
+    int signal_id,
+    CmpOp cmp,
+    uint64_t value,
+    CoopScope scope,
+    int num_threads,
+    cudaStream_t stream) {
+  pipesWaitSignalFromScopedKernel<<<1, num_threads, 0, stream>>>(
+      win, src_rank, signal_id, cmp, value, scope);
+  CUDA_LAUNCH_CHECK();
+}
+
+// =============================================================================
+// Scoped Reset Counter Kernel
+// =============================================================================
+// Resets counter for all peers using the specified CoopScope.
+
+__global__ void pipesResetCounterScopedKernel(
+    DeviceWindowPipes* win,
+    int counter_id,
+    CoopScope scope) {
+  if (blockIdx.x == 0) {
+    win->reset_counter(counter_id, scope);
+  }
+}
+
+void launchPipesResetCounterScopedKernel(
+    DeviceWindowPipes* win,
+    int counter_id,
+    CoopScope scope,
+    int num_threads,
+    cudaStream_t stream) {
+  pipesResetCounterScopedKernel<<<1, num_threads, 0, stream>>>(
+      win, counter_id, scope);
+  CUDA_LAUNCH_CHECK();
+}
+
 } // namespace torchcomms::device::test

--- a/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTestKernels.cuh
+++ b/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTestKernels.cuh
@@ -122,4 +122,32 @@ void launchPipesWaitCounterKernel(
     uint64_t value,
     cudaStream_t stream);
 
+// Scope-aware wait_signal kernel
+void launchPipesWaitSignalScopedKernel(
+    DeviceWindowPipes* win,
+    int signal_id,
+    uint64_t expected_value,
+    CoopScope scope,
+    int num_threads,
+    cudaStream_t stream);
+
+// Scope-aware wait_signal_from kernel
+void launchPipesWaitSignalFromScopedKernel(
+    DeviceWindowPipes* win,
+    int src_rank,
+    int signal_id,
+    CmpOp cmp,
+    uint64_t value,
+    CoopScope scope,
+    int num_threads,
+    cudaStream_t stream);
+
+// Scope-aware reset_counter kernel
+void launchPipesResetCounterScopedKernel(
+    DeviceWindowPipes* win,
+    int counter_id,
+    CoopScope scope,
+    int num_threads,
+    cudaStream_t stream);
+
 } // namespace torchcomms::device::test


### PR DESCRIPTION
Summary:
Add CoopScope parameter (default THREAD) to wait_signal, wait_signal_from,
wait_counter, reset_signal, and reset_counter in the TorchComm device API.

- wait operations: leader-only polling + group.sync() reduces memory
  bandwidth waste from redundant spin-polls in WARP/BLOCK scope
- reset operations: leader-only write + group.sync() so callers don't
  need to manually gate on threadIdx
- Both NCCLx (GIN+LSA) and Pipes (IBGDA+NVLink) backends updated
- Default CoopScope::THREAD preserves backward compatibility
- Triton externs unchanged (thread-scope by design)
- read_signal/read_counter left as thread-only (value-returning queries)

Differential Revision: D98180722


