### PR TITLE
Migrate AllGather/AllReduce tests to shared dir (Batch 2)

### DIFF
--- a/comms/ncclx/meta/tests/AllGatherTest.cc
+++ b/comms/ncclx/meta/tests/AllGatherTest.cc
@@ -1,0 +1,257 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <comm.h>
+#include <folly/init/Init.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <nccl.h>
+#include <stdlib.h>
+#include <cstddef>
+#include "comms/ctran/Ctran.h"
+#include "comms/ctran/algos/AllGather/AllGatherImpl.h"
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
+#include "comms/ncclx/meta/tests/NcclxBaseTest.h"
+#include "comms/testinfra/AlgoTestUtils.h"
+#include "comms/testinfra/TestUtils.h"
+#include "comms/testinfra/TestsCuUtils.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+
+using testinfra::AlgoRAII;
+
+class AllGatherTest : public NcclxBaseTestFixture {
+ public:
+  AllGatherTest() = default;
+  void SetUp() override {
+    NcclxBaseTestFixture::SetUp();
+    this->comm = ncclx::test::createNcclComm(
+        globalRank, numRanks, localRank, bootstrap_.get());
+
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+    CUDACHECK_TEST(cudaStreamCreate(&stream));
+  }
+
+  void TearDown() override {
+    NCCLCHECK_TEST(ncclCommDestroy(comm));
+    CUDACHECK_TEST(cudaStreamDestroy(stream));
+    NcclxBaseTestFixture::TearDown();
+  }
+
+  void runTest(
+      enum NCCL_ALLGATHER_ALGO algo,
+      bool inplace,
+      bool registFlag,
+      bool useCudaGraph,
+      MemAllocType memType,
+      size_t count) {
+    auto algoGuard = AlgoRAII(NCCL_ALLGATHER_ALGO, algo);
+
+    if ((memType == kMemNcclMemAlloc || memType == kCuMemAllocDisjoint) &&
+        ncclIsCuMemSupported() == false) {
+      GTEST_SKIP() << "CuMem not supported, skip test";
+    }
+
+    if (algo != NCCL_ALLGATHER_ALGO::orig) {
+#ifdef TEST_ENABLE_CTRAN
+      if (!ctranAllGatherSupport(comm->ctranComm_.get(), algo)) {
+        GTEST_SKIP() << "Ctran algorithm is not supported, skip test";
+      }
+
+      // FIXME: this should be fixed in Ctran algo level!
+      if (memType == kMemCudaMalloc &&
+          comm->ctranComm_->statex_->nLocalRanks() > 1) {
+        GTEST_SKIP()
+            << "Ctran does not support cudaMalloc-ed buffer with nLocalRanks > 1, skip test";
+      }
+#else
+      GTEST_SKIP() << "Ctran is not enabled, skip test";
+#endif
+    }
+
+    // Create and register buffers. If inplace, we use the same buffer for send
+    // and recv.
+    int *sendBuf = nullptr, *recvBuf = nullptr;
+    std::vector<TestMemSegment> recvBufSegs, sendBufSegs;
+    std::vector<void*> segHandles;
+
+    recvBuf = reinterpret_cast<int*>(
+        testAllocBuf(count * numRanks * sizeof(int), memType, recvBufSegs));
+    ASSERT_NE(recvBuf, nullptr);
+
+    if (inplace) {
+      sendBuf = recvBuf + count * globalRank;
+    } else {
+      sendBuf = reinterpret_cast<int*>(
+          testAllocBuf(count * sizeof(int), memType, sendBufSegs));
+      ASSERT_NE(sendBuf, nullptr);
+    }
+
+    assignChunkValue(recvBuf, count * numRanks, -1);
+    assignChunkValue(sendBuf, count, globalRank + 1);
+
+    if (registFlag) {
+      if (!inplace) {
+        for (auto& reg : sendBufSegs) {
+          void* handle = nullptr;
+          NCCLCHECK_TEST(ncclCommRegister(comm, reg.ptr, reg.size, &handle));
+          segHandles.push_back(handle);
+        }
+      }
+      for (auto& reg : recvBufSegs) {
+        void* handle = nullptr;
+        NCCLCHECK_TEST(ncclCommRegister(comm, reg.ptr, reg.size, &handle));
+        segHandles.push_back(handle);
+      }
+    }
+
+    auto fn = [&]() {
+      // Run communication
+      for (int i = 0; i < 5; i++) {
+        auto res =
+            ncclAllGather(sendBuf, recvBuf, count, ncclInt, comm, stream);
+        ASSERT_EQ(res, ncclSuccess);
+      }
+    };
+
+    if (useCudaGraph) {
+      cudaGraph_t graph;
+
+      // Capture the graph
+      CUDACHECK_TEST(
+          cudaStreamBeginCapture(stream, cudaStreamCaptureModeGlobal));
+      fn();
+      CUDACHECK_TEST(cudaStreamEndCapture(stream, &graph));
+
+      // Instantiate the graph
+      cudaGraphExec_t graphExec;
+      CUDACHECK_TEST(
+          cudaGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+      // Launch the graph
+      CUDACHECK_TEST(cudaGraphLaunch(graphExec, stream));
+
+      // Destroy the graph
+      CUDACHECK_TEST(cudaGraphExecDestroy(graphExec));
+      CUDACHECK_TEST(cudaGraphDestroy(graph));
+    } else {
+      fn();
+    }
+
+    CUDACHECK_TEST(cudaStreamSynchronize(stream));
+
+    // Check each received chunk
+    for (int r = 0; r < numRanks; r++) {
+      int expectedVal = r + 1;
+      int errs = checkChunkValue(recvBuf + r * count, count, expectedVal);
+      EXPECT_EQ(errs, 0) << "rank " << globalRank << " checked chunk " << r
+                         << " at " << recvBuf + r * count << " with " << errs
+                         << " errors";
+    }
+
+    // Deregister and free buffers
+    if (registFlag) {
+      for (auto& handle : segHandles) {
+        NCCLCHECK_TEST(ncclCommDeregister(comm, handle));
+      }
+    }
+
+    if (!inplace) {
+      testFreeBuf(sendBuf, count * sizeof(int), memType);
+    }
+    testFreeBuf(recvBuf, count * numRanks * sizeof(int), memType);
+  }
+
+ protected:
+  ncclComm_t comm{};
+  cudaStream_t stream{};
+};
+
+class AllgatherTestParam : public AllGatherTest,
+                           public ::testing::WithParamInterface<std::tuple<
+                               enum NCCL_ALLGATHER_ALGO,
+                               bool,
+                               bool,
+                               MemAllocType,
+                               size_t>> {};
+
+TEST_P(AllgatherTestParam, Test) {
+  const auto& [algo, inplace, registFlag, memType, count] = GetParam();
+  runTest(algo, inplace, registFlag, false /*useCudaGraph*/, memType, count);
+}
+
+class AllgatherMemtypeGraphTestParam
+    : public AllGatherTest,
+      public ::testing::WithParamInterface<
+          std::tuple<enum NCCL_ALLGATHER_ALGO, MemAllocType, bool>> {};
+
+TEST_P(AllgatherMemtypeGraphTestParam, Test) {
+  const auto& [algo, memType, useCudaGraph] = GetParam();
+  auto registFlag = false;
+  constexpr size_t count = 10e6 * 8;
+
+  auto GRAPH_REGISTER_OVERRIDE = 1L;
+  // TODO: we should throw proper error in the unsupported case in baseline
+  // NCCL graph register
+  if (algo == NCCL_ALLGATHER_ALGO::orig && useCudaGraph &&
+      memType == kCuMemAllocDisjoint) {
+    GRAPH_REGISTER_OVERRIDE = 0L;
+  }
+
+  auto envGuard = EnvRAII(NCCL_GRAPH_REGISTER, GRAPH_REGISTER_OVERRIDE);
+  runTest(algo, false /* inplace */, registFlag, useCudaGraph, memType, count);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AllGatherTestInstance,
+    AllgatherMemtypeGraphTestParam,
+    ::testing::Combine(
+        ::testing::Values(
+            NCCL_ALLGATHER_ALGO::orig,
+            NCCL_ALLGATHER_ALGO::ctran),
+        ::testing::Values(
+            kMemCudaMalloc,
+            kMemNcclMemAlloc,
+            kCuMemAllocDisjoint),
+        ::testing::Values(true, false)),
+    [&](const testing::TestParamInfo<AllgatherMemtypeGraphTestParam::ParamType>&
+            info) {
+      auto str = allGatherAlgoName(std::get<0>(info.param)) + "_" +
+          testMemAllocTypeToStr(std::get<1>(info.param));
+      if (std::get<2>(info.param)) {
+        str = str + "_graph";
+      }
+      return str;
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    AllGatherTestInstance,
+    AllgatherTestParam,
+    ::testing::Combine(
+        ::testing::Values(
+            NCCL_ALLGATHER_ALGO::orig,
+            NCCL_ALLGATHER_ALGO::ctran,
+            NCCL_ALLGATHER_ALGO::ctrd,
+            NCCL_ALLGATHER_ALGO::ctring,
+            NCCL_ALLGATHER_ALGO::ctdirect,
+            NCCL_ALLGATHER_ALGO::ctbrucks),
+        ::testing::Values(true, false), // inplace
+        ::testing::Values(true, false), // registFlag
+        ::testing::Values(
+            kMemCudaMalloc,
+            kMemNcclMemAlloc,
+            kCuMemAllocDisjoint),
+        ::testing::Values(1048576, 1)),
+
+    // algo, inplace, registFlag, memType, count
+    [&](const testing::TestParamInfo<AllgatherTestParam::ParamType>& info) {
+      return allGatherAlgoName(std::get<0>(info.param)) + "_inplace" +
+          std::to_string(std::get<1>(info.param)) + "_register" +
+          std::to_string(std::get<2>(info.param)) + "_" +
+          testMemAllocTypeToStr(std::get<3>(info.param)) + "_count" +
+          std::to_string(std::get<4>(info.param));
+    });
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ncclx/meta/tests/AllReduceNumericOffsetTest.cc
+++ b/comms/ncclx/meta/tests/AllReduceNumericOffsetTest.cc
@@ -1,0 +1,221 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <stdlib.h>
+#include <cstddef>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <folly/init/Init.h>
+
+#include <comm.h>
+#include <nccl.h>
+#include "checks.h"
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
+#include "comms/ncclx/meta/tests/NcclxBaseTest.h"
+#include "comms/testinfra/TestUtils.h"
+
+#include "meta/wrapper/MetaFactory.h"
+
+constexpr size_t VAL_RANGE = 1024;
+
+/**
+ * Template test class for tensor slicing and AllReduce operations.
+ *
+ * This test implements the following scenario:
+ *   tensorA = baseTensor.copy()[0:tensorASize]   // Full tensor copy
+ *   tensorB = baseTensor.copy()[offset:tensorASize]  // Slice starting from
+ * offset allreduce(tensorA, comm) allreduce(tensorB, comm) max_diff = tensorB -
+ * tensorA[offset:tensorASize] // Compare overlapping sections
+ *
+ */
+template <typename TYPE>
+class AllReduceNumericOffsetTest : public NcclxBaseTestFixture {
+ public:
+  AllReduceNumericOffsetTest() = default;
+
+  void SetUp() override {
+    NcclxBaseTestFixture::SetUp();
+
+    comm = ncclx::test::createNcclComm(
+        globalRank, numRanks, localRank, bootstrap_.get());
+
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+    CUDACHECK_TEST(cudaStreamCreate(&stream));
+  }
+
+  void TearDown() override {
+    NCCLCHECK_TEST(ncclCommDestroy(comm));
+    CUDACHECK_TEST(cudaStreamDestroy(stream));
+    NcclxBaseTestFixture::TearDown();
+  }
+
+  void verifyMaxDiff(
+      TYPE* tensorA,
+      TYPE* tensorB,
+      size_t tensorASize,
+      size_t tensorBSize,
+      size_t offset,
+      bool expectedEqual) {
+    // Copy results back to host
+    std::vector<TYPE> tensorAResult(tensorASize);
+    std::vector<TYPE> tensorBResult(tensorBSize);
+
+    CUDACHECK_TEST(cudaMemcpy(
+        tensorAResult.data(),
+        tensorA,
+        tensorASize * sizeof(TYPE),
+        cudaMemcpyDefault));
+
+    CUDACHECK_TEST(cudaMemcpy(
+        tensorBResult.data(),
+        tensorB,
+        tensorBSize * sizeof(TYPE),
+        cudaMemcpyDefault));
+
+    // Calculate max_diff = tensorB - tensorA[offset:tensorASize]
+    TYPE max_diff = 0;
+    int nDiffs = 0;
+    for (int i = 0; i < tensorBSize; i++) {
+      TYPE b = tensorBResult[i];
+      TYPE a = tensorAResult[i + offset];
+      TYPE diff =
+          (a > b) ? (a - b) : (b - a); // Manual abs to avoid std::abs ambiguity
+      if (diff > max_diff) {
+        max_diff = diff;
+        nDiffs++;
+      }
+    }
+
+    EXPECT_EQ(nDiffs == 0, expectedEqual)
+        << "max_diff should be " << (expectedEqual ? "0" : "non-zero")
+        << " but got " << float(max_diff) << " on rank " << this->globalRank;
+  }
+
+  void run(
+      ncclDataType_t dataType,
+      size_t tensorASize,
+      size_t tensorBSize,
+      size_t offset,
+      bool expectedEqual) {
+    TYPE *tensorA = nullptr, *tensorB = nullptr;
+
+    // create and register buffers
+    NCCLCHECK_TEST(ncclMemAlloc((void**)&tensorA, tensorASize * sizeof(TYPE)));
+    NCCLCHECK_TEST(ncclMemAlloc((void**)&tensorB, tensorBSize * sizeof(TYPE)));
+
+    // Initialize tensorA with rank-specific values
+    std::vector<TYPE> hostTensorA(tensorASize);
+    for (size_t i = 0; i < tensorASize; i++) {
+      auto val = i % VAL_RANGE + globalRank;
+      hostTensorA[i] = (TYPE)(val);
+    }
+    CUDACHECK_TEST(cudaMemcpy(
+        tensorA,
+        hostTensorA.data(),
+        tensorASize * sizeof(TYPE),
+        cudaMemcpyDefault));
+
+    // Initialize tensorB as slice of tensorA (tensorA[offset:])
+    std::vector<TYPE> hostTensorB(tensorBSize);
+    for (size_t i = 0; i < tensorBSize; i++) {
+      hostTensorB[i] = hostTensorA[i + offset];
+    }
+    CUDACHECK_TEST(cudaMemcpy(
+        tensorB,
+        hostTensorB.data(),
+        tensorBSize * sizeof(TYPE),
+        cudaMemcpyDefault));
+
+    void *tensorAHandle = nullptr, *tensorBHandle = nullptr;
+    NCCLCHECK_TEST(ncclCommRegister(
+        comm, tensorA, tensorASize * sizeof(TYPE), &tensorAHandle));
+    NCCLCHECK_TEST(ncclCommRegister(
+        comm, tensorB, tensorBSize * sizeof(TYPE), &tensorBHandle));
+
+    // Perform allreduce on tensorA
+    ncclResult_t res1 = ncclAllReduce(
+        tensorA, tensorA, tensorASize, dataType, ncclSum, comm, stream);
+    ASSERT_EQ(res1, ncclSuccess);
+
+    // Perform allreduce on tensorB
+    ncclResult_t res2 = ncclAllReduce(
+        tensorB, tensorB, tensorBSize, dataType, ncclSum, comm, stream);
+    ASSERT_EQ(res2, ncclSuccess);
+
+    CUDACHECK_TEST(cudaStreamSynchronize(stream));
+
+    // Verify that overlapping sections are identical
+    verifyMaxDiff(
+        tensorA, tensorB, tensorASize, tensorBSize, offset, expectedEqual);
+
+    NCCLCHECK_TEST(ncclCommDeregister(comm, tensorAHandle));
+    NCCLCHECK_TEST(ncclCommDeregister(comm, tensorBHandle));
+    NCCLCHECK_TEST(ncclMemFree(tensorA));
+    NCCLCHECK_TEST(ncclMemFree(tensorB));
+  }
+
+ protected:
+  ncclComm_t comm{};
+  cudaStream_t stream{};
+};
+
+// Typed test classes for specific data types
+class AllReduceNumericOffsetTestParamInt32
+    : public AllReduceNumericOffsetTest<int>,
+      public ::testing::WithParamInterface<std::tuple<size_t, size_t, size_t>> {
+};
+
+TEST_P(AllReduceNumericOffsetTestParamInt32, StableSliceTestInt32) {
+  const auto& [tensorASize, tensorBSize, offset] = GetParam();
+  run(ncclInt32, tensorASize, tensorBSize, offset, true);
+}
+
+class AllReduceNumericOffsetTestParamBF16
+    : public AllReduceNumericOffsetTest<__nv_bfloat16>,
+      public ::testing::WithParamInterface<std::tuple<size_t, size_t, size_t>> {
+};
+
+TEST_P(AllReduceNumericOffsetTestParamBF16, StableSliceTestBF16) {
+  const auto& [tensorASize, tensorBSize, offset] = GetParam();
+  run(ncclBfloat16, tensorASize, tensorBSize, offset, false);
+}
+
+// Test parameters: {tensorASize, tensorBSize, offset}
+auto stableTestingValues = ::testing::Values(
+    std::make_tuple(100, 90, 10), // Basic slice test
+    std::make_tuple(1000, 500, 250), // Larger slice test
+    std::make_tuple(64, 32, 16), // Power of 2 sizes
+    std::make_tuple(1024, 512, 256), // Larger power of 2 sizes
+    std::make_tuple(8195, 4000, 1000) // Non-power of 2 sizes
+);
+
+// common function to get test name from test parameter
+inline std::string getStableTestName(
+    const testing::TestParamInfo<
+        AllReduceNumericOffsetTestParamBF16::ParamType>& info) {
+  return "TensorA_" + std::to_string(std::get<0>(info.param)) + "_TensorB_" +
+      std::to_string(std::get<1>(info.param)) + "_Offset_" +
+      std::to_string(std::get<2>(info.param));
+}
+
+// Tests for Int32
+INSTANTIATE_TEST_SUITE_P(
+    AllReduceStableTests,
+    AllReduceNumericOffsetTestParamInt32,
+    stableTestingValues,
+    getStableTestName);
+
+// Tests for BFloat16
+INSTANTIATE_TEST_SUITE_P(
+    AllReduceStableTests,
+    AllReduceNumericOffsetTestParamBF16,
+    stableTestingValues,
+    getStableTestName);
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ncclx/meta/tests/AllReduceNumericStableTest.cc
+++ b/comms/ncclx/meta/tests/AllReduceNumericStableTest.cc
@@ -1,0 +1,227 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <stdlib.h>
+#include <cstddef>
+#include <limits>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <folly/Random.h>
+#include <folly/init/Init.h>
+
+#include <comm.h>
+#include <nccl.h>
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
+#include "comms/ncclx/meta/tests/NcclxBaseTest.h"
+#include "comms/testinfra/TestUtils.h"
+
+#include "meta/wrapper/MetaFactory.h"
+
+/**
+ * Template test class for testing AllReduce stability with identical input
+ * values. This test verifies that multiple AllReduce operations with identical
+ * inputs produce identical outputs, ensuring numerical stability.
+ */
+template <typename TYPE>
+class AllReduceStableTest : public NcclxBaseTestFixture {
+ public:
+  AllReduceStableTest() = default;
+
+  void SetUp() override {
+    NcclxBaseTestFixture::SetUp();
+
+    comm = ncclx::test::createNcclComm(
+        globalRank, numRanks, localRank, bootstrap_.get());
+
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+    CUDACHECK_TEST(cudaStreamCreate(&stream));
+  }
+
+  void TearDown() override {
+    NCCLCHECK_TEST(ncclCommDestroy(comm));
+    CUDACHECK_TEST(cudaStreamDestroy(stream));
+    NcclxBaseTestFixture::TearDown();
+  }
+
+ protected:
+  ncclComm_t comm{};
+  cudaStream_t stream{};
+};
+
+template <typename TYPE>
+class AllReduceStableTestIdenticalInput
+    : public AllReduceStableTest<TYPE>,
+      public ::testing::WithParamInterface<std::tuple<size_t, ncclDataType_t>> {
+ public:
+  int checkChunkValue(TYPE* tensorA, TYPE* tensorB, size_t count) {
+    std::vector<TYPE> observedA(count, -1);
+    std::vector<TYPE> observedB(count, -1);
+    CUDACHECK_TEST(cudaMemcpy(
+        observedA.data(), tensorA, count * sizeof(TYPE), cudaMemcpyDefault));
+    CUDACHECK_TEST(cudaMemcpy(
+        observedB.data(), tensorB, count * sizeof(TYPE), cudaMemcpyDefault));
+    int errs = 0;
+
+    // Use manual print rather than EXPECT_THAT to print failing location
+    for (auto i = 0; i < count; ++i) {
+      if (observedA[i] != observedB[i]) {
+        if (errs < 10) {
+          printf(
+              "[%d] observedA[%d] = %f, observedB = %f\n",
+              this->globalRank,
+              i,
+              static_cast<float>(observedA[i]),
+              static_cast<float>(observedB[i]));
+        }
+        errs++;
+      }
+    }
+    return errs;
+  }
+
+  void runTest(size_t tensorSize, ncclDataType_t dataType) {
+    TYPE *tensorA = nullptr, *tensorB = nullptr;
+
+    NCCLCHECK_TEST(ncclMemAlloc((void**)&tensorA, tensorSize * sizeof(TYPE)));
+    NCCLCHECK_TEST(ncclMemAlloc((void**)&tensorB, tensorSize * sizeof(TYPE)));
+
+    std::vector<TYPE> randomValues(tensorSize);
+    for (size_t i = 0; i < tensorSize; i++) {
+      if constexpr (std::is_same_v<TYPE, float>) {
+        randomValues[i] = static_cast<TYPE>(folly::Random::rand32()) /
+            static_cast<TYPE>(std::numeric_limits<uint32_t>::max());
+      } else {
+        randomValues[i] = static_cast<TYPE>(folly::Random::rand32() % 1000);
+      }
+    }
+
+    CUDACHECK_TEST(cudaMemcpy(
+        tensorA,
+        randomValues.data(),
+        tensorSize * sizeof(TYPE),
+        cudaMemcpyDefault));
+    CUDACHECK_TEST(cudaMemcpy(
+        tensorB,
+        randomValues.data(),
+        tensorSize * sizeof(TYPE),
+        cudaMemcpyDefault));
+
+    void *tensorAHandle = nullptr, *tensorBHandle = nullptr;
+    NCCLCHECK_TEST(ncclCommRegister(
+        this->comm, tensorA, tensorSize * sizeof(TYPE), &tensorAHandle));
+    NCCLCHECK_TEST(ncclCommRegister(
+        this->comm, tensorB, tensorSize * sizeof(TYPE), &tensorBHandle));
+
+    ncclResult_t res1 = ncclAllReduce(
+        tensorA,
+        tensorA,
+        tensorSize,
+        dataType,
+        ncclSum,
+        this->comm,
+        this->stream);
+    ASSERT_EQ(res1, ncclSuccess);
+
+    ncclResult_t res2 = ncclAllReduce(
+        tensorB,
+        tensorB,
+        tensorSize,
+        dataType,
+        ncclSum,
+        this->comm,
+        this->stream);
+    ASSERT_EQ(res2, ncclSuccess);
+
+    CUDACHECK_TEST(cudaStreamSynchronize(this->stream));
+
+    // Check tensorA results
+    int errs = checkChunkValue(tensorA, tensorB, tensorSize);
+    EXPECT_EQ(errs, 0) << "TensorA and TensorB has " << errs
+                       << " mismatched values on rank " << this->globalRank;
+
+    NCCLCHECK_TEST(ncclCommDeregister(this->comm, tensorAHandle));
+    NCCLCHECK_TEST(ncclCommDeregister(this->comm, tensorBHandle));
+    NCCLCHECK_TEST(ncclMemFree(tensorA));
+    NCCLCHECK_TEST(ncclMemFree(tensorB));
+  }
+};
+
+class AllReduceStableTestIdenticalInputFloat
+    : public AllReduceStableTestIdenticalInput<float> {};
+
+TEST_P(AllReduceStableTestIdenticalInputFloat, IdenticalInputValuesFloat) {
+  const auto& [tensorSize, dataType] = GetParam();
+  runTest(tensorSize, dataType);
+}
+
+class AllReduceStableTestIdenticalInputInt32
+    : public AllReduceStableTestIdenticalInput<int> {};
+
+TEST_P(AllReduceStableTestIdenticalInputInt32, IdenticalInputValuesInt32) {
+  const auto& [tensorSize, dataType] = GetParam();
+  runTest(tensorSize, dataType);
+}
+
+class AllReduceStableTestIdenticalInputBF16
+    : public AllReduceStableTestIdenticalInput<__nv_bfloat16> {};
+
+TEST_P(AllReduceStableTestIdenticalInputBF16, IdenticalInputValuesBF16) {
+  const auto& [tensorSize, dataType] = GetParam();
+  runTest(tensorSize, dataType);
+}
+
+// Test parameters: {tensorSize, dataType}
+auto identicalInputTestParamsFloat = ::testing::Values(
+    std::make_tuple(64, ncclFloat32),
+    std::make_tuple(256, ncclFloat32),
+    std::make_tuple(1024, ncclFloat32),
+    std::make_tuple(4096, ncclFloat32),
+    std::make_tuple(8195, ncclFloat32));
+
+auto identicalInputTestParamsInt32 = ::testing::Values(
+    std::make_tuple(64, ncclInt32),
+    std::make_tuple(256, ncclInt32),
+    std::make_tuple(1024, ncclInt32),
+    std::make_tuple(4096, ncclInt32),
+    std::make_tuple(8195, ncclInt32));
+
+auto identicalInputTestParamsBF16 = ::testing::Values(
+    std::make_tuple(64, ncclBfloat16),
+    std::make_tuple(256, ncclBfloat16),
+    std::make_tuple(1024, ncclBfloat16),
+    std::make_tuple(4096, ncclBfloat16),
+    std::make_tuple(8195, ncclBfloat16));
+
+inline std::string getIdenticalInputTestName(
+    const testing::TestParamInfo<std::tuple<size_t, ncclDataType_t>>& info) {
+  return "TensorSize_" + std::to_string(std::get<0>(info.param));
+}
+
+// Tests for Float
+INSTANTIATE_TEST_SUITE_P(
+    AllReduceStableTests,
+    AllReduceStableTestIdenticalInputFloat,
+    identicalInputTestParamsFloat,
+    getIdenticalInputTestName);
+
+// Tests for Int32
+INSTANTIATE_TEST_SUITE_P(
+    AllReduceStableTests,
+    AllReduceStableTestIdenticalInputInt32,
+    identicalInputTestParamsInt32,
+    getIdenticalInputTestName);
+
+INSTANTIATE_TEST_SUITE_P(
+    AllReduceStableTests,
+    AllReduceStableTestIdenticalInputBF16,
+    identicalInputTestParamsBF16,
+    getIdenticalInputTestName);
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ncclx/meta/tests/AllReduceSingleRankTest.cc
+++ b/comms/ncclx/meta/tests/AllReduceSingleRankTest.cc
@@ -1,0 +1,258 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This test verifies allreduce behavior with a single rank (world_size=1).
+// In this case, the output should equal the input since there's nothing to
+// reduce. This test targets the same class of bugs as the reduce_scatter
+// single-rank test where the oneRankReduce kernel could miss processing
+// some elements.
+
+#include <comm.h>
+#include <fmt/core.h>
+#include <folly/init/Init.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <nccl.h>
+#include <stdlib.h>
+#include <cstddef>
+#include <random>
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
+#include "comms/ncclx/meta/tests/NcclxBaseTest.h"
+#include "comms/testinfra/TestUtils.h"
+#include "comms/testinfra/TestsCuUtils.h"
+
+class AllReduceSingleRankTest : public NcclxBaseTestFixture {
+ public:
+  AllReduceSingleRankTest() = default;
+
+  void SetUp() override {
+    NcclxBaseTestFixture::SetUp();
+    // This test is specifically for single-rank scenarios
+    if (numRanks != 1) {
+      GTEST_SKIP() << "This test requires exactly 1 rank, got " << numRanks;
+    }
+    comm = ncclx::test::createNcclComm(
+        globalRank, numRanks, localRank, bootstrap_.get());
+    CUDACHECK_TEST(cudaStreamCreate(&stream));
+  }
+
+  void TearDown() override {
+    if (comm != nullptr) {
+      NCCLCHECK_TEST(ncclCommDestroy(comm));
+    }
+    if (stream != nullptr) {
+      CUDACHECK_TEST(cudaStreamDestroy(stream));
+    }
+    NcclxBaseTestFixture::TearDown();
+  }
+
+ protected:
+  ncclComm_t comm = nullptr;
+  cudaStream_t stream = nullptr;
+};
+
+// Test parameters: <ncclRedOp_t, ncclDataType_t, count>
+class AllReduceSingleRankTestParam
+    : public AllReduceSingleRankTest,
+      public ::testing::WithParamInterface<
+          std::tuple<ncclRedOp_t, ncclDataType_t, size_t>> {};
+
+TEST_P(AllReduceSingleRankTestParam, OutputEqualsInput) {
+  const auto& [redOp, dataType, count] = GetParam();
+
+  // Skip if single rank requirement not met (handled in SetUp but double-check)
+  if (numRanks != 1) {
+    GTEST_SKIP() << "Test requires exactly 1 rank";
+  }
+
+  // Determine element size based on data type
+  size_t elemSize;
+  switch (dataType) {
+    case ncclFloat16:
+    case ncclBfloat16:
+      elemSize = 2;
+      break;
+    case ncclFloat32:
+      elemSize = 4;
+      break;
+    case ncclFloat64:
+      elemSize = 8;
+      break;
+    default:
+      elemSize = 4; // Default to 4 bytes
+      break;
+  }
+
+  size_t bufSize = count * elemSize;
+
+  // Allocate input and output buffers
+  void* sendBuf = nullptr;
+  void* recvBuf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&sendBuf, bufSize));
+  CUDACHECK_TEST(cudaMalloc(&recvBuf, bufSize));
+
+  // Allocate host buffers for verification
+  std::vector<uint8_t> hostInput(bufSize);
+  std::vector<uint8_t> hostOutput(bufSize);
+
+  // Initialize input with valid floating point values
+  // We generate normalized float values and convert them to the target type
+  // to avoid issues with NaN/Inf/denormalized numbers where x*1.0 != x
+  std::mt19937 rng(42);
+  std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+
+  switch (dataType) {
+    case ncclFloat16: {
+      uint16_t* ptr = reinterpret_cast<uint16_t*>(hostInput.data());
+      for (size_t i = 0; i < count; ++i) {
+        float val = dist(rng);
+        // Convert float to fp16 representation
+        uint32_t floatBits;
+        std::memcpy(&floatBits, &val, sizeof(float));
+        // Simple float32 to float16 conversion (truncate mantissa)
+        uint16_t sign = (floatBits >> 16) & 0x8000;
+        int32_t exp = ((floatBits >> 23) & 0xFF) - 127 + 15;
+        uint16_t mant = (floatBits >> 13) & 0x3FF;
+        if (exp <= 0) {
+          ptr[i] = sign; // Flush to zero
+        } else if (exp >= 31) {
+          ptr[i] = sign | 0x7C00; // Infinity
+        } else {
+          ptr[i] = sign | (exp << 10) | mant;
+        }
+      }
+      break;
+    }
+    case ncclBfloat16: {
+      uint16_t* ptr = reinterpret_cast<uint16_t*>(hostInput.data());
+      for (size_t i = 0; i < count; ++i) {
+        float val = dist(rng);
+        uint32_t floatBits;
+        std::memcpy(&floatBits, &val, sizeof(float));
+        ptr[i] = static_cast<uint16_t>(floatBits >> 16);
+      }
+      break;
+    }
+    case ncclFloat32: {
+      float* ptr = reinterpret_cast<float*>(hostInput.data());
+      for (size_t i = 0; i < count; ++i) {
+        ptr[i] = dist(rng);
+      }
+      break;
+    }
+    case ncclFloat64: {
+      double* ptr = reinterpret_cast<double*>(hostInput.data());
+      std::uniform_real_distribution<double> ddist(-1.0, 1.0);
+      for (size_t i = 0; i < count; ++i) {
+        ptr[i] = ddist(rng);
+      }
+      break;
+    }
+    default: {
+      // For integer types, use random bytes
+      for (size_t i = 0; i < bufSize; ++i) {
+        hostInput[i] = static_cast<uint8_t>(rng() % 256);
+      }
+      break;
+    }
+  }
+
+  // Copy input to device
+  CUDACHECK_TEST(
+      cudaMemcpy(sendBuf, hostInput.data(), bufSize, cudaMemcpyHostToDevice));
+
+  // Initialize output with different pattern to detect if it's overwritten
+  std::memset(hostOutput.data(), 0xAB, bufSize);
+  CUDACHECK_TEST(
+      cudaMemcpy(recvBuf, hostOutput.data(), bufSize, cudaMemcpyHostToDevice));
+
+  // Perform allreduce - with single rank, output should equal input
+  constexpr int numIterations = 10;
+  for (int iter = 0; iter < numIterations; ++iter) {
+    auto res =
+        ncclAllReduce(sendBuf, recvBuf, count, dataType, redOp, comm, stream);
+    ASSERT_EQ(res, ncclSuccess) << "ncclAllReduce failed on iteration " << iter;
+    CUDACHECK_TEST(cudaStreamSynchronize(stream));
+
+    // Copy output back to host
+    CUDACHECK_TEST(cudaMemcpy(
+        hostOutput.data(), recvBuf, bufSize, cudaMemcpyDeviceToHost));
+
+    // Verify output equals input
+    int errs = 0;
+    for (size_t i = 0; i < bufSize; ++i) {
+      if (hostInput[i] != hostOutput[i]) {
+        if (errs < 10) {
+          printf(
+              "[iter %d] Mismatch at byte %zu: input=0x%02x, output=0x%02x\n",
+              iter,
+              i,
+              hostInput[i],
+              hostOutput[i]);
+        }
+        errs++;
+      }
+    }
+    EXPECT_EQ(errs, 0) << "Iteration " << iter << ": Found " << errs
+                       << " byte mismatches between input and output. "
+                       << "For single-rank allreduce, output must equal input.";
+  }
+
+  CUDACHECK_TEST(cudaFree(sendBuf));
+  CUDACHECK_TEST(cudaFree(recvBuf));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AllReduceSingleRankTestInstance,
+    AllReduceSingleRankTestParam,
+    ::testing::Combine(
+        ::testing::Values(ncclSum, ncclAvg),
+        ::testing::Values(ncclBfloat16, ncclFloat32),
+        ::testing::Values(8191, 8192, 16777213, 16777216)),
+    [](const testing::TestParamInfo<AllReduceSingleRankTestParam::ParamType>&
+           info) {
+      const char* opName;
+      switch (std::get<0>(info.param)) {
+        case ncclSum:
+          opName = "Sum";
+          break;
+        case ncclAvg:
+          opName = "Avg";
+          break;
+        case ncclMax:
+          opName = "Max";
+          break;
+        case ncclMin:
+          opName = "Min";
+          break;
+        default:
+          opName = "Unknown";
+          break;
+      }
+      const char* typeName;
+      switch (std::get<1>(info.param)) {
+        case ncclFloat16:
+          typeName = "Float16";
+          break;
+        case ncclBfloat16:
+          typeName = "Bfloat16";
+          break;
+        case ncclFloat32:
+          typeName = "Float32";
+          break;
+        case ncclFloat64:
+          typeName = "Float64";
+          break;
+        default:
+          typeName = "Unknown";
+          break;
+      }
+      return fmt::format(
+          "{}_{}_{}count", opName, typeName, std::get<2>(info.param));
+    });
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ncclx/meta/tests/AllReduceUniformTest.cc
+++ b/comms/ncclx/meta/tests/AllReduceUniformTest.cc
@@ -1,0 +1,239 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <stdlib.h>
+#include <cstddef>
+#include <random>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <folly/init/Init.h>
+
+#include <comm.h>
+#include <nccl.h>
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
+#include "comms/ncclx/meta/tests/NcclxBaseTest.h"
+#include "comms/testinfra/TestUtils.h"
+
+#include "meta/wrapper/MetaFactory.h"
+
+/**
+ * Template test class for testing AllReduce with uniform input per rank.
+ *
+ * This test verifies that when each rank has all identical values in their
+ * input tensor (but different across ranks), the AllReduce output has all
+ * identical values.
+ *
+ * Example:
+ *   Rank 0: [a, a, a, ...]
+ *   Rank 1: [b, b, b, ...]
+ *   Rank 2: [c, c, c, ...]
+ *   ...
+ *   After AllReduce(Sum): All ranks should have [a+b+c+..., a+b+c+..., ...]
+ */
+
+enum class AllReduceAlgo { SingleRing, SingleTree };
+
+template <typename TYPE>
+class AllReduceUniformTest : public NcclxBaseTestFixture {
+ public:
+  AllReduceUniformTest() = default;
+
+  void SetUp() override {
+    NcclxBaseTestFixture::SetUp();
+
+    comm = ncclx::test::createNcclComm(
+        globalRank, numRanks, localRank, bootstrap_.get());
+
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+    CUDACHECK_TEST(cudaStreamCreate(&stream));
+  }
+
+  void TearDown() override {
+    NCCLCHECK_TEST(ncclCommDestroy(comm));
+    CUDACHECK_TEST(cudaStreamDestroy(stream));
+    NcclxBaseTestFixture::TearDown();
+  }
+
+ protected:
+  ncclComm_t comm{};
+  cudaStream_t stream{};
+};
+
+template <typename TYPE>
+class AllReduceUniformTestBF16
+    : public AllReduceUniformTest<TYPE>,
+      public ::testing::WithParamInterface<std::tuple<size_t, AllReduceAlgo>> {
+ public:
+  /**
+   * Verify all elements in the tensor are identical
+   */
+  bool verifyAllElementsIdentical(TYPE* tensor, size_t count) {
+    std::vector<TYPE> observed(count);
+    CUDACHECK_TEST(cudaMemcpy(
+        observed.data(), tensor, count * sizeof(TYPE), cudaMemcpyDefault));
+
+    if (count == 0) {
+      return true;
+    }
+
+    TYPE firstValue = observed[0];
+    int diffCount = 0;
+    float maxDiff = 0.0f;
+
+    for (size_t i = 1; i < count; ++i) {
+      if (observed[i] != firstValue) {
+        float diff = std::abs(
+            static_cast<float>(observed[i]) - static_cast<float>(firstValue));
+        if (diffCount < 10) {
+          printf(
+              "[Rank %d] Element mismatch at index %zu: expected %f, got %f (diff: %f)\n",
+              this->globalRank,
+              i,
+              static_cast<float>(firstValue),
+              static_cast<float>(observed[i]),
+              diff);
+        }
+        diffCount++;
+        maxDiff = std::max(maxDiff, diff);
+      }
+    }
+
+    if (diffCount > 0) {
+      printf(
+          "[Rank %d] Total mismatches: %d / %zu, max diff: %f\n",
+          this->globalRank,
+          diffCount,
+          count,
+          maxDiff);
+    }
+
+    return diffCount == 0;
+  }
+
+  void runTest(size_t tensorSize, AllReduceAlgo algoType) {
+    if (algoType == AllReduceAlgo::SingleRing) {
+      NCCL_ALGO = "ring";
+      NCCL_MAX_NCHANNELS = 1;
+    } else if (algoType == AllReduceAlgo::SingleTree) {
+      NCCL_ALGO = "tree";
+      NCCL_MAX_NCHANNELS = 1;
+    } else {
+      throw std::runtime_error("Invalid AllReduceAlgo");
+    }
+
+    if (algoType == AllReduceAlgo::SingleRing) {
+      // See details in https://fburl.com/gdoc/ho8vil04
+      GTEST_SKIP()
+          << "SingleRing AllReduce is not position invariant due to data chunking";
+    }
+
+    TYPE* inputTensor = nullptr;
+
+    // Allocate device memory
+    NCCLCHECK_TEST(
+        ncclMemAlloc((void**)&inputTensor, tensorSize * sizeof(TYPE)));
+
+    // Generate a single random BF16 value per rank
+    std::random_device rd;
+    std::mt19937 gen(
+        rd() +
+        this->globalRank); // Seed with rank for different values per rank
+    std::uniform_real_distribution<float> dis(0.1f, 10.0f);
+
+    float rankValue = dis(gen);
+    TYPE uniformValue = static_cast<TYPE>(rankValue);
+
+    // Fill entire input tensor with the same value
+    std::vector<TYPE> hostInput(tensorSize, uniformValue);
+
+    printf(
+        "[Rank %d] Filling tensor with uniform value: %f\n",
+        this->globalRank,
+        static_cast<float>(uniformValue));
+
+    CUDACHECK_TEST(cudaMemcpy(
+        inputTensor,
+        hostInput.data(),
+        tensorSize * sizeof(TYPE),
+        cudaMemcpyDefault));
+
+    // Register buffer
+    void* inputHandle = nullptr;
+    NCCLCHECK_TEST(ncclCommRegister(
+        this->comm, inputTensor, tensorSize * sizeof(TYPE), &inputHandle));
+
+    // Perform AllReduce (in-place)
+    ncclResult_t res = ncclAllReduce(
+        inputTensor,
+        inputTensor,
+        tensorSize,
+        ncclBfloat16,
+        ncclSum,
+        this->comm,
+        this->stream);
+    ASSERT_EQ(res, ncclSuccess);
+
+    CUDACHECK_TEST(cudaStreamSynchronize(this->stream));
+
+    // Verify all elements in output are identical
+    bool allIdentical = verifyAllElementsIdentical(inputTensor, tensorSize);
+
+    EXPECT_TRUE(allIdentical)
+        << "Not all elements are identical after AllReduce on rank "
+        << this->globalRank << " with tensor size " << tensorSize;
+
+    // Cleanup
+    NCCLCHECK_TEST(ncclCommDeregister(this->comm, inputHandle));
+    NCCLCHECK_TEST(ncclMemFree(inputTensor));
+  }
+};
+
+using AllReduceUniformTestBF16Inst = AllReduceUniformTestBF16<__nv_bfloat16>;
+
+// FIXME(T254162415): Test disabled due to mpirun runtime failure.
+// The test has been broken since 2025-11-06 (codemod c6494ace57c2).
+TEST_P(AllReduceUniformTestBF16Inst, DISABLED_UniformInputPerRank) {
+  const auto [tensorSize, algoType] = GetParam();
+  runTest(tensorSize, algoType);
+}
+
+// Test parameters: different tensor sizes
+auto uniformTestParams = ::testing::Values(
+    // single ring
+    std::make_tuple(256, AllReduceAlgo::SingleRing), // Small
+    std::make_tuple(1024, AllReduceAlgo::SingleRing), // 1K
+    std::make_tuple(4096, AllReduceAlgo::SingleRing), // 4K
+    std::make_tuple(8195, AllReduceAlgo::SingleRing), // Non-power of 2
+    std::make_tuple(16384, AllReduceAlgo::SingleRing), // 16K
+    std::make_tuple(65536, AllReduceAlgo::SingleRing), // 64K
+    // SingleTree
+    std::make_tuple(256, AllReduceAlgo::SingleTree), // Small
+    std::make_tuple(1024, AllReduceAlgo::SingleTree), // 1K
+    std::make_tuple(4096, AllReduceAlgo::SingleTree), // 4K
+    std::make_tuple(8195, AllReduceAlgo::SingleTree), // Non-power of 2
+    std::make_tuple(16384, AllReduceAlgo::SingleTree), // 16K
+    std::make_tuple(65536, AllReduceAlgo::SingleTree) // 64K
+); // 64K
+
+inline std::string getUniformTestName(
+    const testing::TestParamInfo<std::tuple<size_t, AllReduceAlgo>>& info) {
+  const auto& [tensorSize, algoType] = info.param;
+  std::string algoName =
+      (algoType == AllReduceAlgo::SingleRing) ? "SingleRing" : "SingleTree";
+  return "TensorSize_" + std::to_string(tensorSize) + "_" + algoName;
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AllReduceUniformTests,
+    AllReduceUniformTestBF16Inst,
+    uniformTestParams,
+    getUniformTestName);
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ncclx/meta/tests/NcclxBaseTest.h
+++ b/comms/ncclx/meta/tests/NcclxBaseTest.h
@@ -12,6 +12,9 @@
 #include "comms/testinfra/TestUtils.h"
 #include "nccl.h" // @manual
 
+// Re-export DistEnvironmentBase so test main() files can use it unqualified.
+using meta::comms::DistEnvironmentBase;
+
 // TODO: Long-term, migrate all tests from #ifdef compiler flags to NcclxEnvs
 // params.
 using NcclxEnvs = std::vector<std::pair<std::string, std::string>>;


### PR DESCRIPTION
Summary:
- Move AllGatherTest, AllReduceSingleRankTest, AllReduceUniformTest, AllReduceNumericStableTest, AllReduceNumericOffsetTest from per-version dirs to comms/ncclx/meta/tests/
- Replace NcclxBaseTest with NcclxBaseTestFixture, update includes to NcclxBaseTest.h
- Add ncclx_meta_distributed_unittest_suite targets in shared BUCK with version_deps
- Remove corresponding entries from v2_27, v2_28, v2_29 per-version BUCK files
- Add DistEnvironmentBase using-declaration to NcclxBaseTest.h for unqualified usage in test main()

Reviewed By: MogicianWu

Differential Revision: D98232103


