### PR TITLE
Create ICtranBootstrap interface

### DIFF
--- a/comms/common/bootstrap/IBootstrap.h
+++ b/comms/common/bootstrap/IBootstrap.h
@@ -43,7 +43,9 @@ class IBootstrap {
       int len,
       int localRank,
       int localNranks,
-      std::vector<int> localRankToCommRank) = 0;
+      std::vector<int> localRankToCommRank) {
+    throw std::runtime_error("not implemented");
+  }
 
   /*
    * `rank` must be a valid value between 0 and `nranks - 1`
@@ -59,20 +61,12 @@ class IBootstrap {
   virtual folly::SemiFuture<int> barrierIntraNode(
       int localRank,
       int localNranks,
-      std::vector<int> localRankToCommRank) = 0;
+      std::vector<int> localRankToCommRank) {
+    throw std::runtime_error("not implemented");
+  }
 
   /**
    * AllGather within an NVLink domain, which may span multiple hosts (MNNVL).
-   *
-   * `buf` refers to a continuous memory segment of size `nvlNranks * len`.
-   * `nvlLocalRank` is this rank's index within the NVL domain [0, nvlNranks).
-   * `nvlRankToCommRank` maps NVL-local indices to global communicator ranks.
-   *
-   * Unlike allGatherIntraNode (which uses a host-scoped communicator),
-   * this creates a dynamic subcommunicator from the specified global ranks,
-   * supporting cross-host NVLink domains like GB200 NVL72.
-   *
-   * Subclasses must override this if NVL domain operations are needed.
    */
   virtual folly::SemiFuture<int> allGatherNvlDomain(
       void* buf,
@@ -85,11 +79,6 @@ class IBootstrap {
 
   /**
    * Barrier within an NVLink domain, which may span multiple hosts (MNNVL).
-   *
-   * `nvlLocalRank` is this rank's index within the NVL domain [0, nvlNranks).
-   * `nvlRankToCommRank` maps NVL-local indices to global communicator ranks.
-   *
-   * Subclasses must override this if NVL domain operations are needed.
    */
   virtual folly::SemiFuture<int> barrierNvlDomain(
       int nvlLocalRank,

--- a/comms/ctran/bootstrap/ICtranBootstrap.h
+++ b/comms/ctran/bootstrap/ICtranBootstrap.h
@@ -1,0 +1,50 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <vector>
+
+#include "comms/common/bootstrap/IBootstrap.h"
+
+namespace meta::comms {
+
+/**
+ * Extended bootstrap interface for ctran.
+ *
+ * Adds intra-node collective operations (allGatherIntraNode, barrierIntraNode)
+ * needed by ctran for IPC handle exchange and local synchronization.
+ *
+ * Production implementations: BaselineBootstrap (ncclx), CtranAdapter (mccl).
+ * Pipes will use this interface too.
+ */
+class ICtranBootstrap : public IBootstrap {
+ public:
+  ~ICtranBootstrap() override = default;
+
+  /**
+   * AllGather among a subset of ranks identified by `localRankToCommRank`.
+   *
+   * `buf` is a continuous memory segment of size `localNranks * len`.
+   * `localRank` is this rank's index in [0, localNranks).
+   * `localRankToCommRank` maps local indices to global communicator ranks.
+   */
+  virtual folly::SemiFuture<int> allGatherIntraNode(
+      void* buf,
+      int len,
+      int localRank,
+      int localNranks,
+      std::vector<int> localRankToCommRank) = 0;
+
+  /**
+   * Barrier among a subset of ranks identified by `localRankToCommRank`.
+   *
+   * `localRank` is this rank's index in [0, localNranks).
+   * `localRankToCommRank` maps local indices to global communicator ranks.
+   */
+  virtual folly::SemiFuture<int> barrierIntraNode(
+      int localRank,
+      int localNranks,
+      std::vector<int> localRankToCommRank) = 0;
+};
+
+} // namespace meta::comms

--- a/comms/ctran/tests/bootstrap/IntraProcessBootstrap.h
+++ b/comms/ctran/tests/bootstrap/IntraProcessBootstrap.h
@@ -2,11 +2,11 @@
 
 #pragma once
 
-#include "comms/common/bootstrap/IBootstrap.h"
+#include "comms/ctran/bootstrap/ICtranBootstrap.h"
 
 namespace ctran::testing {
 
-class IntraProcessBootstrap : public meta::comms::IBootstrap {
+class IntraProcessBootstrap : public meta::comms::ICtranBootstrap {
  public:
   struct State {
     State() {

--- a/comms/ctran/tests/bootstrap/MockBootstrap.h
+++ b/comms/ctran/tests/bootstrap/MockBootstrap.h
@@ -5,12 +5,12 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include "comms/common/bootstrap/IBootstrap.h"
+#include "comms/ctran/bootstrap/ICtranBootstrap.h"
 
 namespace ctran::testing {
 
-// Mock IBootstrap for testing
-class MockBootstrap : public meta::comms::IBootstrap {
+// Mock ICtranBootstrap for testing
+class MockBootstrap : public meta::comms::ICtranBootstrap {
  public:
   MOCK_METHOD(
       folly::SemiFuture<int>,

--- a/comms/ncclx/v2_27/meta/ctran-integration/BaselineBootstrap.h
+++ b/comms/ncclx/v2_27/meta/ctran-integration/BaselineBootstrap.h
@@ -2,13 +2,13 @@
 
 #pragma once
 
-#include "comms/common/bootstrap/IBootstrap.h"
+#include "comms/ctran/bootstrap/ICtranBootstrap.h"
 
 #include "nccl.h" // @manual
 
 namespace ncclx {
 
-class BaselineBootstrap : public ::meta::comms::IBootstrap {
+class BaselineBootstrap : public ::meta::comms::ICtranBootstrap {
  public:
   explicit BaselineBootstrap(ncclComm_t comm) : comm_(comm) {}
 

--- a/comms/ncclx/v2_28/meta/ctran-integration/BaselineBootstrap.h
+++ b/comms/ncclx/v2_28/meta/ctran-integration/BaselineBootstrap.h
@@ -2,13 +2,13 @@
 
 #pragma once
 
-#include "comms/common/bootstrap/IBootstrap.h"
+#include "comms/ctran/bootstrap/ICtranBootstrap.h"
 
 #include "nccl.h" // @manual
 
 namespace ncclx {
 
-class BaselineBootstrap : public ::meta::comms::IBootstrap {
+class BaselineBootstrap : public ::meta::comms::ICtranBootstrap {
  public:
   explicit BaselineBootstrap(ncclComm_t comm) : comm_(comm) {}
 

--- a/comms/ncclx/v2_29/meta/ctran-integration/BaselineBootstrap.h
+++ b/comms/ncclx/v2_29/meta/ctran-integration/BaselineBootstrap.h
@@ -2,13 +2,13 @@
 
 #pragma once
 
-#include "comms/common/bootstrap/IBootstrap.h"
+#include "comms/ctran/bootstrap/ICtranBootstrap.h"
 
 #include "nccl.h" // @manual
 
 namespace ncclx {
 
-class BaselineBootstrap : public ::meta::comms::IBootstrap {
+class BaselineBootstrap : public ::meta::comms::ICtranBootstrap {
  public:
   explicit BaselineBootstrap(ncclComm_t comm) : comm_(comm) {}
 

--- a/comms/rcclx/develop/CMakeLists.txt
+++ b/comms/rcclx/develop/CMakeLists.txt
@@ -833,6 +833,7 @@ set(RCCLX_LIB_FILES
 set(CTRAN_FILES
   ${CTRAN_SOURCES}
   comms/common/bootstrap/IBootstrap.h
+  comms/ctran/bootstrap/ICtranBootstrap.h
   comms/tcp_devmem/transport.h # extra requirement
   comms/utils/MemUtils.h # extra requirement
 )

--- a/comms/rcclx/develop/meta/ctran/BaselineBootstrap.h
+++ b/comms/rcclx/develop/meta/ctran/BaselineBootstrap.h
@@ -2,12 +2,12 @@
 
 #pragma once
 
-#include "comms/common/bootstrap/IBootstrap.h" // @manual
+#include "comms/ctran/bootstrap/ICtranBootstrap.h" // @manual
 #include "nccl.h"
 
 namespace rcclx {
 
-class BaselineBootstrap : public ::meta::comms::IBootstrap {
+class BaselineBootstrap : public ::meta::comms::ICtranBootstrap {
  public:
   explicit BaselineBootstrap(ncclComm_t comm) : comm_(comm) {}
 


### PR DESCRIPTION
Summary:
This diff is part of comms bootstrap refactoring work: see detailed plan in D97793363

Introduce ICtranBootstrap, an extended bootstrap interface for ctran that
adds intra-node collective operations (allGatherIntraNode, barrierIntraNode) - will be renamed to nvlDomain in a later diff. Note that that bootstrap type in `CtranComm` is still `IBootstrap` in this diff - will be replaced by `ICtranBootstrap` in the next diff.

- Create ICtranBootstrap.h extending IBootstrap with pure virtual
  allGatherIntraNode and barrierIntraNode
- Make allGatherIntraNode/barrierIntraNode non-pure-virtual in IBootstrap
  (default throw) so plain IBootstrap users are not forced to implement them
- Change BaselineBootstrap (v2_27, v2_28, v2_29, rcclx), CtranAdapter (mccl),
  MockBootstrap, and IntraProcessBootstrap to inherit from ICtranBootstrap

Production implementations: BaselineBootstrap (ncclx), CtranAdapter (mccl).

Reviewed By: minsii

Differential Revision: D97823710


