### PR TITLE
Migrate Ctran comm to use ICtranBootstrap (was IBootstrap)

### DIFF
--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -7,7 +7,7 @@
 #include <cstdint>
 
 #include <folly/Synchronized.h>
-#include "comms/common/bootstrap/IBootstrap.h"
+#include "comms/ctran/bootstrap/ICtranBootstrap.h"
 #include "comms/ctran/commstate/CommStateX.h"
 #include "comms/ctran/interfaces/ICtran.h"
 #include "comms/ctran/utils/Abort.h"
@@ -169,7 +169,7 @@ class CtranComm {
   // TODO: change shared_prt to unique_ptr after refactor all ctran code using
   // CtranComm
   std::shared_ptr<ICtran> ctran_;
-  std::unique_ptr<meta::comms::IBootstrap> bootstrap_;
+  std::unique_ptr<meta::comms::ICtranBootstrap> bootstrap_;
   std::shared_ptr<CollTrace> collTrace_;
   std::shared_ptr<meta::comms::colltrace::ICollTrace> colltraceNew_;
   std::shared_ptr<ncclx::memory::memCacheAllocator> memCache_;

--- a/comms/ctran/tests/CtranDistTestUtils.cc
+++ b/comms/ctran/tests/CtranDistTestUtils.cc
@@ -2,27 +2,14 @@
 
 #include "CtranDistTestUtils.h"
 
-#include <chrono>
-#include <thread>
-
 #include <folly/logging/xlog.h>
 
+#include "comms/ctran/tests/bootstrap/CtranTestBootstrap.h"
 #include "comms/ctran/utils/CudaUtils.h"
 #include "comms/ctran/utils/Utils.h"
-#include "comms/mccl/bootstrap/Bootstrap.h"
-#include "comms/mccl/bootstrap/CtranAdapter.h"
-#include "comms/mccl/utils/Utils.h"
-#include "comms/testinfra/mpi/MpiBootstrap.h"
-#include "comms/testinfra/mpi/MpiTestUtils.h"
+#include "comms/testinfra/DistEnvironmentBase.h"
 
 namespace ctran {
-
-InitEnvType getInitEnvType() {
-  if (checkTcpStoreEnv()) {
-    return InitEnvType::TCP_STORE;
-  }
-  return InitEnvType::MPI;
-}
 
 // ============================================================================
 // CtranDistEnvironment Implementation
@@ -92,30 +79,7 @@ void CtranDistTestFixture::TearDown() {
   distTearDown();
 }
 
-std::vector<std::string> CtranDistTestFixture::exchangeInitUrls(
-    const std::string& selfUrl,
-    int numRanks,
-    int selfRank) {
-  constexpr size_t kMaxUrlLen = 256;
-  std::vector<char> buf(numRanks * kMaxUrlLen, 0);
-
-  CHECK(selfUrl.size() < kMaxUrlLen) << "URL too long for allGather buffer";
-  std::memcpy(
-      buf.data() + selfRank * kMaxUrlLen, selfUrl.data(), selfUrl.size());
-
-  auto res = bootstrap_->allGather(buf.data(), kMaxUrlLen, selfRank, numRanks);
-  CHECK_EQ(std::move(res).get(), 0) << "exchangeInitUrls allGather failed";
-
-  std::vector<std::string> urls;
-  urls.reserve(numRanks);
-  for (int i = 0; i < numRanks; ++i) {
-    urls.emplace_back(buf.data() + i * kMaxUrlLen);
-  }
-  return urls;
-}
-
 std::unique_ptr<CtranComm> CtranDistTestFixture::makeCtranComm() {
-  const auto initType = getInitEnvType();
   const std::string uuid{"0"};
   uint64_t commHash =
       ctran::utils::getHash(uuid.data(), static_cast<int>(uuid.size()));
@@ -128,10 +92,6 @@ std::unique_ptr<CtranComm> CtranDistTestFixture::makeCtranComm() {
   comm->logMetaData_.commDesc = commDesc;
   comm->logMetaData_.rank = globalRank;
   comm->logMetaData_.nRanks = numRanks;
-
-  const auto useVirtualTopo =
-      (NCCL_COMM_STATE_DEBUG_TOPO == NCCL_COMM_STATE_DEBUG_TOPO::nolocal ||
-       NCCL_COMM_STATE_DEBUG_TOPO == NCCL_COMM_STATE_DEBUG_TOPO::vnode);
 
   int cudaDev;
   CUDACHECK_TEST(cudaGetDevice(&cudaDev));
@@ -151,36 +111,22 @@ std::unique_ptr<CtranComm> CtranDistTestFixture::makeCtranComm() {
       commRanksToWorldRanks,
       commDesc);
 
-  if (initType == InitEnvType::MPI && useVirtualTopo) {
-    mccl::utils::initRankTopologyNoSystem(comm->statex_.get());
+  // Create global bootstrap (MPI or TcpStore depending on env)
+  std::unique_ptr<meta::comms::IBootstrap> commBootstrap(
+      meta::comms::createBootstrap("ctrancomm"));
 
-    const auto localRank = comm->statex_->localRank();
-    const auto node = comm->statex_->node();
-
-    comm->bootstrap_ =
-        std::make_unique<meta::comms::MpiBootstrap>(localRank, node);
-  } else if (initType == InitEnvType::MPI) {
-    comm->bootstrap_ = std::make_unique<meta::comms::MpiBootstrap>();
-    mccl::utils::initRankTopology(comm->statex_.get(), comm->bootstrap_.get());
+  // Initialize topology
+  if (NCCL_COMM_STATE_DEBUG_TOPO == NCCL_COMM_STATE_DEBUG_TOPO::nolocal) {
+    comm->statex_->initRankTopologyNolocal();
+  } else if (NCCL_COMM_STATE_DEBUG_TOPO == NCCL_COMM_STATE_DEBUG_TOPO::vnode) {
+    comm->statex_->initRankTopologyVnode(
+        NCCL_COMM_STATE_DEBUG_TOPO_VNODE_NLOCALRANKS);
   } else {
-    auto bootstrap = std::make_shared<mccl::bootstrap::Bootstrap>(
-        NCCL_SOCKET_IFNAME,
-        mccl::bootstrap::Options{
-            .port = 0, .ifAddrPrefix = NCCL_SOCKET_IPADDR_PREFIX});
-
-    std::string selfUrl = bootstrap->semi_getInitUrl().get();
-    XLOG(DBG) << "Rank " << globalRank << " initURL: " << selfUrl;
-
-    auto allUrls = exchangeInitUrls(selfUrl, numRanks, globalRank);
-
-    std::vector<mccl::InitURL> urlVec(allUrls.begin(), allUrls.end());
-
-    bootstrap->init(urlVec, static_cast<size_t>(globalRank), 0 /* uuid */);
-
-    comm->bootstrap_ =
-        std::make_unique<mccl::bootstrap::CtranAdapter>(bootstrap);
-    mccl::utils::initRankTopology(comm->statex_.get(), comm->bootstrap_.get());
+    comm->statex_->initRankStatesTopology(commBootstrap.get());
   }
+
+  comm->bootstrap_ = std::make_unique<ctran::testing::CtranTestBootstrap>(
+      std::move(commBootstrap));
 
   comm->config_.commDesc = comm->statex_->commDesc().c_str();
 

--- a/comms/ctran/tests/CtranDistTestUtils.h
+++ b/comms/ctran/tests/CtranDistTestUtils.h
@@ -13,9 +13,6 @@
 
 namespace ctran {
 
-// Detect which initialization environment to use
-InitEnvType getInitEnvType();
-
 // Ctran-specific environment that inherits DistEnvironmentBase and adds
 // ctran-specific env vars (NCCL_CTRAN_ENABLE, profiling, etc.)
 class CtranDistEnvironment : public meta::comms::DistEnvironmentBase {
@@ -39,10 +36,6 @@ class CtranDistTestFixture : public CtranTestFixtureBase,
   std::unique_ptr<CtranComm> makeCtranComm();
 
   bool enableNolocal{false};
-
- private:
-  std::vector<std::string>
-  exchangeInitUrls(const std::string& selfUrl, int numRanks, int selfRank);
 };
 
 } // namespace ctran


### PR DESCRIPTION
Summary:
### Summary

Migrate Ctran comm to use ICtranBootstrap (was IBootstrap); Rewrite `CtranDistTestFixture::makeCtranComm()` to use the new `CtranTestBootstrap` and `createBootstrap()` factory, eliminating all MCCL bootstrap dependencies from ctran tests.

### Changes

**`CtranComm.h`** — Change `bootstrap_` member type from `unique_ptr<IBootstrap>` to `unique_ptr<ICtranBootstrap>` and update the include accordingly. This allows `CtranComm` to depend on the ctran-specific bootstrap interface rather than the base one.

**`CtranDistTestUtils.cc`** — Rewrite `makeCtranComm()`:
- Replace the three-way `initType`/`useVirtualTopo` branching (MPI+virtual, MPI, TcpStore) with a single path: call `createBootstrap("ctrancomm")` to get a transport-agnostic `IBootstrap`, initialize topology via `statex_` methods directly (`initRankTopologyNolocal`, `initRankTopologyVnode`, `initRankStatesTopology`), and wrap the bootstrap in `CtranTestBootstrap`.
- Remove `getInitEnvType()` and `exchangeInitUrls()` — both were only needed for the old MCCL `Bootstrap::init()` URL-exchange handshake.
- Drop includes for `mccl/bootstrap/Bootstrap.h`, `mccl/bootstrap/CtranAdapter.h`, `mccl/utils/Utils.h`, `MpiBootstrap.h`, and `MpiTestUtils.h`.

**`CtranDistTestUtils.h`** — Remove `getInitEnvType()` declaration and `exchangeInitUrls()` private method.

**`DistEnvironmentBase.cc/.h`** — Add `createBootstrap(prefix)` factory function that creates either `MpiBootstrap` (MPI env) or `TcpStoreBootstrap` with a `PrefixStore` (TcpStore env), using the global dist environment state. This centralizes bootstrap creation so individual tests don't need to know the transport.

**`ctran/tests/BUCK`** — Replace five MCCL/MPI deps (`mccl/bootstrap:bootstrap`, `mccl/bootstrap:ctran_adapter`, `mccl/utils:mccl_utils`, `testinfra/mpi:mpi_bootstrap`, `testinfra/mpi:mpi_test_utils`) with two (`ctran_test_bootstrap`, `dist_environment_base`). Also drop unused `p2p_nvl_transport_device` and `cuda_raii` deps from `multi_peer_transport_test`.

Reviewed By: minsii

Differential Revision: D98025086


