### PR TITLE
Add HostWindow::reset_signals() for CUDA graph replay support (#1295)

### DIFF
--- a/comms/pipes/window/HostWindow.cc
+++ b/comms/pipes/window/HostWindow.cc
@@ -99,6 +99,7 @@ HostWindow::HostWindow(
     if (nNvlPeers > 0) {
       auto nvlPeerSignalSize = getSignalBufferSize(
           static_cast<int>(nNvlPeers * config_.peerSignalCount));
+      nvlPeerSignalInboxSize_ = nvlPeerSignalSize;
       auto nvlBootstrap = transport_.nvl_bootstrap();
       if (nvlBootstrap) {
         nvlPeerSignalHandler_ = std::make_unique<GpuMemHandler>(
@@ -115,6 +116,7 @@ HostWindow::HostWindow(
 
     if (nIbgdaPeers > 0) {
       auto size = nIbgdaPeers * config_.peerSignalCount * sizeof(uint64_t);
+      ibgdaPeerSignalInboxSize_ = size;
       ibgdaPeerSignalLocalBuf_ = allocateIbgdaBuffer(size);
 
       ibgdaPeerSignalRemoteBufsDevice_ =
@@ -316,6 +318,21 @@ std::optional<NetworkLKey> HostWindow::registerLocalBuffer(
   auto ibgdaBuf = transport_.localRegisterIbgdaBuffer(ptr, size);
   registeredLocalBuffers_.push_back(ptr);
   return ibgdaBuf.lkey;
+}
+
+void HostWindow::reset_signals(cudaStream_t stream) const {
+  // Reset IBGDA signal inbox (written by remote NICs via RDMA atomics)
+  if (ibgdaPeerSignalLocalBuf_.ptr && ibgdaPeerSignalInboxSize_ > 0) {
+    CUDA_CHECK(cudaMemsetAsync(
+        ibgdaPeerSignalLocalBuf_.ptr, 0, ibgdaPeerSignalInboxSize_, stream));
+  }
+  // Reset NVL signal inbox (written by NVLink peers via store)
+  if (nvlPeerSignalHandler_ && nvlPeerSignalInboxSize_ > 0) {
+    auto* ptr = nvlPeerSignalHandler_->getLocalDeviceMemPtr();
+    if (ptr) {
+      CUDA_CHECK(cudaMemsetAsync(ptr, 0, nvlPeerSignalInboxSize_, stream));
+    }
+  }
 }
 
 void HostWindow::registerAndExchangeBuffer(void* ptr, std::size_t size) {

--- a/comms/pipes/window/HostWindow.h
+++ b/comms/pipes/window/HostWindow.h
@@ -171,6 +171,17 @@ class HostWindow {
   }
 
   /**
+   * reset_signals - Reset all signal inboxes to zero.
+   *
+   * Enqueues cudaMemsetAsync to zero both NVL and IBGDA signal inbox
+   * buffers on the given stream. Use before wait_signal_from in CUDA
+   * graph capture to ensure each replay starts with clean signal state.
+   *
+   * @param stream  CUDA stream for the async memset
+   */
+  void reset_signals(cudaStream_t stream) const;
+
+  /**
    * get_nvlink_address - Get the NVLink-mapped pointer to a peer's window buf.
    *
    * Returns the IPC-mapped device pointer for the given peer's registered
@@ -218,10 +229,12 @@ class HostWindow {
 
   // --- Per-peer signals (NVL side) ---
   std::unique_ptr<GpuMemHandler> nvlPeerSignalHandler_;
+  std::size_t nvlPeerSignalInboxSize_{0};
   std::unique_ptr<meta::comms::DeviceBuffer> nvlPeerSignalSpansDevice_;
 
   // --- Per-peer signals (IBGDA side) ---
   IbgdaLocalBuffer ibgdaPeerSignalLocalBuf_;
+  std::size_t ibgdaPeerSignalInboxSize_{0};
   std::unique_ptr<meta::comms::DeviceBuffer> ibgdaPeerSignalRemoteBufsDevice_;
 
   // --- Per-peer counters (IBGDA-only, local — no exchange) ---


### PR DESCRIPTION
Summary:

Add `reset_signals(cudaStream_t)` to HostWindow that resets both NVL and
IBGDA signal inbox buffers to zero via `cudaMemsetAsync`. This is needed
for CUDA graph replay — the monotonically increasing signal counter has
its threshold baked at capture time, so each replay must start with a
clean inbox (threshold fixed at 1, sender adds 1 per replay).

Both inbox sizes are stored at allocation time to avoid hardcoding
element type sizes in the accessor.

Differential Revision: D98339157
