### PR TITLE
HRDWRingBuffer

### DIFF
--- a/comms/utils/HRDWRingBuffer.cu
+++ b/comms/utils/HRDWRingBuffer.cu
@@ -1,0 +1,85 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+
+#include <cstdint>
+
+#include "comms/utils/HRDWRingBuffer.h"
+
+namespace meta::comms::colltrace {
+
+namespace {
+
+__device__ __forceinline__ uint64_t readGlobaltimer() {
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+  return wall_clock64();
+#else
+  uint64_t timer;
+  asm volatile("mov.u64 %0, %%globaltimer;" : "=l"(timer));
+  return timer;
+#endif
+}
+
+__global__ void ringBufferStartWriteKernel(
+    HRDWEntry* ring,
+    uint64_t* writeIdx,
+    uint32_t mask,
+    void* data,
+    uint64_t* slotOut) {
+  uint64_t slot =
+      atomicAdd(reinterpret_cast<unsigned long long*>(writeIdx), 1ULL);
+  uint64_t idx = slot & mask;
+  ring[idx].start_ns = readGlobaltimer();
+  ring[idx].data = data;
+  ring[idx].sequence = HRDW_RINGBUFFER_WRITE_PENDING;
+  // Ensure start_ns, data, and WRITE_PENDING are visible to the CPU before
+  // publishing the slot index. The CPU reader may observe sequence ==
+  // WRITE_PENDING and then snapshot start_ns/data for per-collective detection.
+  __threadfence_system();
+  *slotOut = slot;
+}
+
+__global__ void ringBufferEndWriteKernel(
+    HRDWEntry* ring,
+    uint64_t* slotIn,
+    uint32_t mask,
+    uint64_t* completionCounter) {
+  uint64_t slot = *slotIn;
+  uint64_t idx = slot & mask;
+  ring[idx].end_ns = readGlobaltimer();
+  // Ensure end_ns is visible to the CPU before the sequence stamp.
+  // The sequence acts as a release flag: the CPU reader checks
+  // sequence == slot before reading other fields.
+  __threadfence_system();
+  ring[idx].sequence = slot;
+  if (completionCounter) {
+    atomicAdd(reinterpret_cast<unsigned long long*>(completionCounter), 1ULL);
+  }
+}
+
+} // namespace
+
+cudaError_t launchRingBufferStartWrite(
+    cudaStream_t stream,
+    void* ring,
+    uint64_t* writeIdx,
+    uint32_t mask,
+    void* data,
+    uint64_t* slotOut) {
+  ringBufferStartWriteKernel<<<1, 1, 0, stream>>>(
+      static_cast<HRDWEntry*>(ring), writeIdx, mask, data, slotOut);
+  return cudaGetLastError();
+}
+
+cudaError_t launchRingBufferEndWrite(
+    cudaStream_t stream,
+    void* ring,
+    uint64_t* slotIn,
+    uint32_t mask,
+    uint64_t* completionCounter) {
+  ringBufferEndWriteKernel<<<1, 1, 0, stream>>>(
+      static_cast<HRDWEntry*>(ring), slotIn, mask, completionCounter);
+  return cudaGetLastError();
+}
+
+} // namespace meta::comms::colltrace

--- a/comms/utils/HRDWRingBuffer.h
+++ b/comms/utils/HRDWRingBuffer.h
@@ -1,0 +1,269 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda_runtime.h>
+
+#include <bit>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <utility>
+
+#define HRDW_RINGBUFFER_WRITE_PENDING UINT64_MAX
+
+namespace meta::comms::colltrace {
+
+// ==========================================================================
+// HRDWRingBuffer — Host-Read Device-Write ring buffer for GPU-to-CPU
+// timestamp transfer with lock-free, torn-read-safe polling.
+//
+// OVERVIEW
+//   GPU kernels claim ring buffer slots via atomic increment, write
+//   timestamps and user data, then stamp a sequence number. A CPU thread
+//   polls the ring buffer using a seqlock protocol that guarantees it
+//   never observes partially-overwritten entries.
+//
+// USAGE
+//   1. Create a ring buffer, specifying the size and a DataT for typed
+//      access to the per-entry user data pointer:
+//
+//        HRDWRingBuffer<MyContext*> buf(4096);
+//
+//   2. For each operation, launch the start and end kernels on a CUDA
+//      stream. The start kernel claims a slot, records globaltimer() as
+//      start_ns, stores your data pointer, and writes the slot index to
+//      slotStorage. The end kernel records end_ns and stamps the sequence:
+//
+//        launchRingBufferStartWrite(stream, buf.ring(), buf.writeIndex(),
+//                                   buf.mask(), myContextPtr, slotStorage);
+//        // ... collective / kernel work ...
+//        launchRingBufferEndWrite(stream, buf.ring(), slotStorage,
+//                                 buf.mask());
+//
+//   3. On the CPU, create a reader and poll periodically. The callback
+//      receives a typed Entry (with data_as() accessor) and the slot:
+//
+//        HRDWRingBufferReader<MyContext*> reader(buf);
+//        reader.poll([](const auto& entry, uint64_t slot) {
+//          MyContext* ctx = entry.data_as();
+//          auto start = entry.start_ns;
+//          auto end = entry.end_ns;
+//        });
+//
+// MEMORY ORDERING
+//   - The end kernel uses __threadfence_system() between writing data
+//     fields and stamping the sequence, ensuring the CPU sees consistent
+//     data when it observes a valid sequence.
+//   - The reader uses a seqlock protocol: it reads the sequence with
+//     acquire semantics BEFORE copying the entry, then re-reads after.
+//     If the sequence changed, the entry is discarded.
+//   - A post-read writeIndex check detects entries that were lapped
+//     during the read pass (torn reads). Affected entries are discarded
+//     and counted as lost.
+//
+// RING SIZING
+//   INVARIANT: The number of concurrent in-flight entries (start kernel
+//   fired, end kernel not yet stamped) must be less than ringSize / 2.
+//   If the ring wraps while an end kernel is still pending, the stale
+//   end kernel can corrupt a newer entry's data — this race cannot be
+//   prevented without making the entire start+end sequence atomic.
+//   CollTrace enforces this by sizing the ring to at least 2x the max
+//   number of concurrent collectives.
+//
+//   Entries that are overwritten after completion (the reader fell behind)
+//   are safely detected and reported as lost (PollResult::entriesLost).
+//   The size is automatically rounded up to the next power of 2.
+//
+// ENTRY LIFECYCLE
+//   slot claimed (start kernel) → sequence = WRITE_PENDING → data written
+//   → end kernel → end_ns written → __threadfence_system → sequence = slot
+//   → CPU can read
+// ==========================================================================
+
+// Entry stored in the ring buffer. The GPU kernels write start_ns, end_ns,
+// sequence, and data; the CPU reader polls and validates via the sequence
+// field (seqlock protocol).
+//
+// The `data` pointer is opaque to the ring buffer — callers can store
+// whatever context they need and access it via Entry::data_as() in the
+// poll callback.
+// Entries with sequence == HRDW_RINGBUFFER_WRITE_PENDING have a start kernel
+// that ran but whose end kernel hasn't stamped the final sequence yet.
+struct HRDWEntry {
+  uint64_t start_ns;
+  uint64_t end_ns;
+  uint64_t sequence;
+  void* data;
+};
+
+// Host-Read Device-Write (HRDW) ring buffer. Device kernels atomically claim
+// slots and stamp timestamps; the host polls with a seqlock mechanism to
+// protect against torn reads.
+//
+// DataT is the user-defined type stored in each entry's data pointer.
+// Access it via entry.data_as() which returns DataT& without requiring
+// a template argument.
+//
+// Owns the ring buffer and write index in mapped pinned memory (GPU-writable,
+// CPU-readable). Move-only — CUDA resources are not copyable.
+template <typename DataT>
+class HRDWRingBuffer {
+ public:
+  // Typed entry — extends HRDWEntry with a data_as() accessor that
+  // returns DataT& directly.
+  struct Entry : HRDWEntry {
+    __attribute__((always_inline)) DataT& data_as() {
+      return *static_cast<DataT*>(data);
+    }
+    __attribute__((always_inline)) const DataT& data_as() const {
+      return *static_cast<const DataT*>(data);
+    }
+  };
+
+  explicit HRDWRingBuffer(uint32_t size) {
+    // Round up to next power of 2 if needed.
+    if (size == 0) {
+      size = 1;
+    }
+    if (size > (1u << 31)) {
+      fprintf(
+          stderr,
+          "HRDWRingBuffer: size %u exceeds maximum power-of-2 size\n",
+          size);
+      return; // valid() will return false
+    }
+    if ((size & (size - 1)) != 0) {
+      uint32_t nextPowerOf2 = 1U << (std::bit_width(size - 1));
+      fprintf(
+          stderr,
+          "HRDWRingBuffer: size %u is not a power of 2, rounding up to %u\n",
+          size,
+          nextPowerOf2);
+      size = nextPowerOf2;
+    }
+
+    // x & mask == x % size
+    // but is just a single bitwise op
+    size_ = size;
+    mask_ = size - 1;
+
+    void* ringPtr = nullptr;
+    auto ringErr = cudaHostAlloc(
+        &ringPtr, sizeof(HRDWEntry) * size_, cudaHostAllocDefault);
+    if (ringErr == cudaSuccess) {
+      ring_ = static_cast<HRDWEntry*>(ringPtr);
+      for (uint32_t i = 0; i < size_; ++i) {
+        ring_[i] = {};
+        ring_[i].sequence = HRDW_RINGBUFFER_WRITE_PENDING;
+      }
+    } else {
+      fprintf(
+          stderr,
+          "HRDWRingBuffer: Failed to allocate ring buffer: %s\n",
+          cudaGetErrorString(ringErr));
+      return; // valid() will return false
+    }
+
+    void* writeIdxPtr = nullptr;
+    auto idxErr =
+        cudaHostAlloc(&writeIdxPtr, sizeof(uint64_t), cudaHostAllocDefault);
+    if (idxErr == cudaSuccess) {
+      writeIndex_ = static_cast<uint64_t*>(writeIdxPtr);
+      *writeIndex_ = 0;
+    } else {
+      fprintf(
+          stderr,
+          "HRDWRingBuffer: Failed to allocate write index: %s\n",
+          cudaGetErrorString(idxErr));
+    }
+  }
+
+  ~HRDWRingBuffer() {
+    if (ring_) {
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      cudaFreeHost(ring_);
+    }
+    if (writeIndex_) {
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      cudaFreeHost(writeIndex_);
+    }
+  }
+
+  // Move-only.
+  HRDWRingBuffer(const HRDWRingBuffer&) = delete;
+  HRDWRingBuffer& operator=(const HRDWRingBuffer&) = delete;
+
+  HRDWRingBuffer(HRDWRingBuffer&& other) noexcept
+      : ring_(std::exchange(other.ring_, nullptr)),
+        writeIndex_(std::exchange(other.writeIndex_, nullptr)),
+        size_(other.size_),
+        mask_(other.mask_) {}
+
+  HRDWRingBuffer& operator=(HRDWRingBuffer&& other) noexcept {
+    if (this != &other) {
+      if (ring_) {
+        // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+        cudaFreeHost(ring_);
+      }
+      if (writeIndex_) {
+        // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+        cudaFreeHost(writeIndex_);
+      }
+      ring_ = std::exchange(other.ring_, nullptr);
+      writeIndex_ = std::exchange(other.writeIndex_, nullptr);
+      size_ = other.size_;
+      mask_ = other.mask_;
+    }
+    return *this;
+  }
+
+  Entry* ring() const {
+    return static_cast<Entry*>(ring_);
+  }
+  uint64_t* writeIndex() const {
+    return writeIndex_;
+  }
+  uint32_t size() const {
+    return size_;
+  }
+  uint32_t mask() const {
+    return mask_;
+  }
+
+  // Returns true if all allocations succeeded.
+  bool valid() const {
+    return ring_ != nullptr && writeIndex_ != nullptr;
+  }
+
+ private:
+  HRDWEntry* ring_{nullptr};
+  uint64_t* writeIndex_{nullptr};
+  uint32_t size_{0};
+  uint32_t mask_{0};
+};
+
+// Launch a single-thread kernel that atomically claims a slot in the ring
+// buffer via *writeIdx, writes globaltimer() to the entry's start_ns, writes
+// data to the entry's data field, sets sequence =
+// HRDW_RINGBUFFER_WRITE_PENDING (write pending), and stores the raw slot index
+// to *slotOut.
+cudaError_t launchRingBufferStartWrite(
+    cudaStream_t stream,
+    void* ring,
+    uint64_t* writeIdx,
+    uint32_t mask,
+    void* data,
+    uint64_t* slotOut);
+
+// Launch a single-thread kernel that reads the slot from *slotIn, writes
+// globaltimer() to ring[slot & mask].end_ns, and stamps sequence = slot.
+// If completionCounter is non-null, atomically increments it after stamping.
+cudaError_t launchRingBufferEndWrite(
+    cudaStream_t stream,
+    void* ring,
+    uint64_t* slotIn,
+    uint32_t mask,
+    uint64_t* completionCounter = nullptr);
+
+} // namespace meta::comms::colltrace

--- a/comms/utils/HRDWRingBufferReader.h
+++ b/comms/utils/HRDWRingBufferReader.h
@@ -1,0 +1,228 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include "comms/utils/HRDWRingBuffer.h"
+
+namespace meta::comms::colltrace {
+
+// Acquire-semantics load from GPU-mapped pinned memory. On x86 this compiles
+// to a plain load (TSO provides acquire semantics); on ARM it emits ldar.
+__attribute__((always_inline)) inline uint64_t acquireLoad(
+    const uint64_t* ptr) {
+  return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
+}
+
+// Result of a single poll() call.
+struct PollResult {
+  uint64_t entriesRead{0};
+  uint64_t entriesLost{0};
+  uint64_t entriesInFlight{0};
+  bool tornReadDetected{false};
+};
+
+// CPU-side snapshot-and-validate consumer for a HRDWRingBuffer. Tracks the
+// last-read index and implements the standard pattern:
+//   1. Snapshot writeIndex via acquire load
+//   2. Skip ahead if behind by more than buffer size (returns lost count)
+//   3. For each entry: seqlock pre-read, snapshot, seqlock post-read
+//   4. Post-read: re-read writeIndex, discard if lapped (torn read)
+//   5. Only invoke callbacks after validation passes
+//
+// Non-owning — the HRDWRingBuffer must outlive this reader. Single-threaded
+// (only the poll thread should call poll()).
+template <typename DataT>
+class HRDWRingBufferReader {
+  using Entry = typename HRDWRingBuffer<DataT>::Entry;
+
+ public:
+  explicit HRDWRingBufferReader(const HRDWRingBuffer<DataT>& buffer)
+      : ring_(buffer.ring()),
+        writeIndex_(buffer.writeIndex()),
+        size_(buffer.size()),
+        mask_(buffer.mask()) {}
+
+  // Poll for new entries. Calls callback(entry, slot) for each valid entry.
+  // The entry's data_as() method returns the typed data pointer.
+  // Callbacks are only invoked after the torn-read check passes — they never
+  // see partially-overwritten data.
+  //
+  // When scanIncomplete is true, the reader continues scanning past the
+  // first WRITE_PENDING entry and delivers write-pending entries through
+  // the same callback. The callback can distinguish them by checking
+  // entry.sequence == HRDW_RINGBUFFER_WRITE_PENDING. Only start_ns and
+  // data are valid on write-pending entries (end_ns is not yet stamped).
+  // When false (default), the reader breaks at the first WRITE_PENDING.
+  //
+  // Returns a PollResult with counts of entries read, lost, and whether a
+  // torn read was detected (in which case no callbacks are invoked).
+  template <typename Callback>
+  PollResult poll(Callback&& callback, bool scanIncomplete = false) {
+    PollResult result;
+
+    if (ring_ == nullptr || writeIndex_ == nullptr) {
+      return result;
+    }
+
+    auto snapshotWriteIdx = acquireLoad(writeIndex_);
+
+    if (snapshotWriteIdx <= lastReadIndex_) {
+      return result;
+    }
+
+    uint64_t readStart = lastReadIndex_;
+
+    // If we fell behind by more than the ring size, some entries are lost.
+    if (snapshotWriteIdx - readStart > size_) {
+      result.entriesLost = snapshotWriteIdx - readStart - size_;
+      readStart = snapshotWriteIdx - size_;
+    }
+
+    uint64_t newEntries = snapshotWriteIdx - readStart;
+
+    // Snapshot valid entries into a local buffer. Callbacks are deferred
+    // until after the post-read torn-read check so they never observe
+    // partially-overwritten data.
+    //
+    // Write-pending entries (sequence == HRDW_RINGBUFFER_WRITE_PENDING) are
+    // not lost — they just haven't been stamped by the end kernel yet. We
+    // don't advance lastReadIndex_ past the first one, so it will be
+    // retried on the next poll. When scanIncomplete is true, we continue
+    // scanning and snapshot write-pending entries into validEntries_ so
+    // the callback can identify which collectives are in-flight.
+    // NOLINTNEXTLINE(cppcoreguidelines-special-member-functions)
+    struct ClearGuard {
+      std::vector<std::pair<Entry, uint64_t>>& v;
+      ~ClearGuard() {
+        v.clear();
+      }
+    } guard{validEntries_};
+
+    bool hitFirstIncomplete = false;
+    for (uint64_t i = 0; i < newEntries; ++i) {
+      uint64_t slot = readStart + i;
+      uint64_t idx = slot & mask_;
+
+      // Seqlock: read sequence BEFORE data to establish ordering.
+      // The acquire load ensures subsequent reads see at least the
+      // memory state from when sequence was written.
+      auto preSeq = acquireLoad(&ring_[idx].sequence);
+
+      if (preSeq == HRDW_RINGBUFFER_WRITE_PENDING) {
+        // In-flight: start kernel ran, end kernel hasn't stamped yet.
+        // Don't advance past the first write-pending slot — retry on
+        // next poll.
+        if (!hitFirstIncomplete) {
+          hitFirstIncomplete = true;
+          result.entriesInFlight = snapshotWriteIdx - slot;
+          snapshotWriteIdx = slot;
+          if (!scanIncomplete) {
+            break;
+          }
+        }
+
+        // Snapshot start_ns and data (guaranteed visible by the start
+        // kernel's __threadfence_system()).
+        Entry entryCopy;
+        entryCopy.start_ns = ring_[idx].start_ns;
+        entryCopy.data = ring_[idx].data;
+        entryCopy.sequence = HRDW_RINGBUFFER_WRITE_PENDING;
+        entryCopy.end_ns = 0;
+
+        // Re-read sequence to confirm still WRITE_PENDING — if the end
+        // kernel stamped between our reads, skip (it'll be picked up
+        // as a completed entry on the next poll).
+        auto confirmSeq = acquireLoad(&ring_[idx].sequence);
+        if (confirmSeq == HRDW_RINGBUFFER_WRITE_PENDING) {
+          validEntries_.emplace_back(std::move(entryCopy), slot);
+        }
+        continue;
+      }
+
+      // Once past the first incomplete, don't collect completed entries
+      // — they'll be picked up after the incomplete one finishes.
+      if (hitFirstIncomplete) {
+        continue;
+      }
+
+      if (preSeq != slot) {
+        ++result.entriesLost;
+        continue;
+      }
+
+      // Copy data fields. The acquire fence above ensures we see data
+      // at least as new as when sequence was stamped.
+      Entry entryCopy = ring_[idx];
+
+      // Post-read: re-check sequence. If it changed, the entry was
+      // overwritten during our copy — discard.
+      auto postSeq = acquireLoad(&ring_[idx].sequence);
+      if (postSeq != preSeq) {
+        if (postSeq == HRDW_RINGBUFFER_WRITE_PENDING) {
+          if (!hitFirstIncomplete) {
+            hitFirstIncomplete = true;
+            result.entriesInFlight = snapshotWriteIdx - slot;
+            snapshotWriteIdx = slot;
+            if (!scanIncomplete) {
+              break;
+            }
+          }
+          Entry pendingCopy;
+          pendingCopy.start_ns = ring_[idx].start_ns;
+          pendingCopy.data = ring_[idx].data;
+          pendingCopy.sequence = HRDW_RINGBUFFER_WRITE_PENDING;
+          pendingCopy.end_ns = 0;
+          auto confirmSeq = acquireLoad(&ring_[idx].sequence);
+          if (confirmSeq == HRDW_RINGBUFFER_WRITE_PENDING) {
+            validEntries_.emplace_back(std::move(pendingCopy), slot);
+          }
+          continue;
+        }
+        ++result.entriesLost;
+        continue;
+      }
+
+      validEntries_.emplace_back(std::move(entryCopy), slot);
+    }
+
+    // Re-read writeIndex after the read pass. If writers advanced by
+    // more than bufferSize since the earliest slot we read, that slot has
+    // been overwritten (torn read). Discard everything from this pass.
+    if (auto newWriteIdx = acquireLoad(writeIndex_);
+        newWriteIdx - readStart > size_) {
+      result.tornReadDetected = true;
+      result.entriesRead = 0;
+      result.entriesLost = newWriteIdx - lastReadIndex_;
+      lastReadIndex_ = newWriteIdx;
+    } else {
+      // Validation passed — invoke callbacks with snapshotted entries.
+      for (const auto& [entry, slot] : validEntries_) {
+        callback(entry, slot);
+      }
+      result.entriesRead = validEntries_.size();
+      lastReadIndex_ = snapshotWriteIdx;
+    }
+
+    return result;
+  }
+
+  uint64_t lastReadIndex() const {
+    return lastReadIndex_;
+  }
+
+ private:
+  Entry* ring_;
+  uint64_t* writeIndex_;
+  uint32_t size_;
+  uint32_t mask_;
+  uint64_t lastReadIndex_{0};
+
+  // Reusable buffer for snapshotted entries — avoids allocation per poll().
+  std::vector<std::pair<Entry, uint64_t>> validEntries_;
+};
+
+} // namespace meta::comms::colltrace

--- a/comms/utils/colltrace/GpuClockCalibration.cu
+++ b/comms/utils/colltrace/GpuClockCalibration.cu
@@ -1,0 +1,89 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+
+#include "comms/utils/colltrace/GpuClockCalibration.h"
+
+// simple fprintf-based check for this .cu file.
+#define CUDA_CHECK_CU(cmd)             \
+  do {                                 \
+    auto _err = (cmd);                 \
+    if (_err != cudaSuccess) {         \
+      fprintf(                         \
+          stderr,                      \
+          "CUDA error %s:%d %s: %s\n", \
+          __FILE__,                    \
+          __LINE__,                    \
+          #cmd,                        \
+          cudaGetErrorString(_err));   \
+      abort();                         \
+    }                                  \
+  } while (0)
+
+namespace {
+
+__device__ __forceinline__ uint64_t readGlobaltimer() {
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+  return wall_clock64();
+#else
+  uint64_t timer;
+  asm volatile("mov.u64 %0, %%globaltimer;" : "=l"(timer));
+  return timer;
+#endif
+}
+
+__global__ void readGlobaltimerKernel(uint64_t* out) {
+  *out = readGlobaltimer();
+}
+
+} // namespace
+
+namespace meta::comms::colltrace {
+
+cudaError_t launchReadGlobaltimer(cudaStream_t stream, uint64_t* out) {
+  readGlobaltimerKernel<<<1, 1, 0, stream>>>(out);
+  return cudaGetLastError();
+}
+
+std::chrono::system_clock::time_point GlobaltimerCalibration::toWallClock(
+    uint64_t gpu_ns) const {
+  // globaltimer values are in nanoseconds. Compute signed delta to handle
+  // timestamps both before and after the calibration point.
+  auto delta_ns =
+      static_cast<int64_t>(gpu_ns) - static_cast<int64_t>(device_ns);
+  return host_time + std::chrono::nanoseconds(delta_ns);
+}
+
+/* static */ const GlobaltimerCalibration& GlobaltimerCalibration::get() {
+  static const GlobaltimerCalibration instance = [] {
+    GlobaltimerCalibration cal{};
+
+    // Allocate a single uint64_t in mapped pinned memory for the kernel to
+    // write the globaltimer value.
+    uint64_t* mapped_ptr = nullptr;
+    CUDA_CHECK_CU(cudaHostAlloc(
+        reinterpret_cast<void**>(&mapped_ptr),
+        sizeof(uint64_t),
+        cudaHostAllocDefault));
+    *mapped_ptr = 0;
+
+    // Launch a calibration kernel on the default stream and synchronize.
+    launchReadGlobaltimer(nullptr, mapped_ptr);
+    CUDA_CHECK_CU(cudaDeviceSynchronize());
+
+    cal.device_ns = *mapped_ptr;
+    cal.host_time = std::chrono::system_clock::now();
+
+    CUDA_CHECK_CU(cudaFreeHost(mapped_ptr));
+    return cal;
+  }();
+  return instance;
+}
+
+#undef CUDA_CHECK_CU
+
+} // namespace meta::comms::colltrace

--- a/comms/utils/colltrace/GpuClockCalibration.h
+++ b/comms/utils/colltrace/GpuClockCalibration.h
@@ -1,0 +1,28 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda_runtime.h>
+
+#include <chrono>
+#include <cstdint>
+
+namespace meta::comms::colltrace {
+
+// One-time calibration point mapping globaltimer nanoseconds to system_clock.
+// Thread-safe; lazily initialized on first call.
+struct GlobaltimerCalibration {
+  uint64_t device_ns{};
+  std::chrono::system_clock::time_point host_time;
+
+  // Convert a device globaltimer nanosecond value to a system_clock time_point.
+  std::chrono::system_clock::time_point toWallClock(uint64_t gpu_ns) const;
+
+  // Get the process-global calibration singleton.
+  static const GlobaltimerCalibration& get();
+};
+
+// Launch a single-thread kernel that writes globaltimer() to *out.
+cudaError_t launchReadGlobaltimer(cudaStream_t stream, uint64_t* out);
+
+} // namespace meta::comms::colltrace

--- a/comms/utils/tests/HRDWRingBufferStressTest.cc
+++ b/comms/utils/tests/HRDWRingBufferStressTest.cc
@@ -1,0 +1,462 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// GPU stress tests for HRDWRingBuffer. These exercise real GPU-CPU concurrency
+// to validate __threadfence_system() ordering, torn-read detection, and the
+// snapshot-before-callback design.
+
+#include <cuda_runtime.h> // @manual=third-party//cuda:cuda-lazy
+
+#include <atomic>
+#include <cstdint>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "comms/utils/HRDWRingBuffer.h"
+#include "comms/utils/HRDWRingBufferReader.h"
+
+using meta::comms::colltrace::HRDWRingBuffer;
+using meta::comms::colltrace::HRDWRingBufferReader;
+using meta::comms::colltrace::launchRingBufferEndWrite;
+using meta::comms::colltrace::launchRingBufferStartWrite;
+
+namespace {
+
+// RAII wrapper for per-collective pinned memory (slot storage).
+struct PerCollState {
+  uint64_t* slotStorage{nullptr};
+
+  PerCollState() {
+    void* ptr = nullptr;
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaHostAlloc(&ptr, sizeof(uint64_t), cudaHostAllocDefault);
+    slotStorage = static_cast<uint64_t*>(ptr);
+    *slotStorage = 0;
+  }
+
+  ~PerCollState() {
+    if (slotStorage) {
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      cudaFreeHost(slotStorage);
+    }
+  }
+
+  PerCollState(const PerCollState&) = delete;
+  PerCollState& operator=(const PerCollState&) = delete;
+};
+
+} // namespace
+
+class HRDWRingBufferStressTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Skip if no GPU available.
+    int deviceCount = 0;
+    auto err = cudaGetDeviceCount(&deviceCount);
+    if (err != cudaSuccess || deviceCount == 0) {
+      GTEST_SKIP() << "No CUDA device available";
+    }
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaSetDevice(0);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Stress config: shared by both eager and graph tests.
+//   ringSize   — ring buffer size (power of 2)
+//   numStreams  — number of concurrent streams (eager) or colls per graph
+//   numWrites  — writes per stream (eager) or replays (graph)
+// ---------------------------------------------------------------------------
+
+struct StressConfig {
+  uint32_t ringSize;
+  int numStreams;
+  int numWrites;
+
+  int totalWrites() const {
+    return numStreams * numWrites;
+  }
+};
+
+static const StressConfig kStressConfigs[] = {
+    {64, 4, 500}, // Small ring, forces lapping.
+    {256, 8, 200}, // Medium ring, balanced.
+    {4096, 1, 2000}, // Single stream, no lapping, monotonic ordering.
+    {4096, 10, 200}, // Large ring, many streams/colls.
+    {16, 1, 1000}, // Tiny ring, maximum lapping pressure.
+};
+
+// Helper: launch totalWrites start+end pairs across numStreams streams.
+static void launchEagerWrites(
+    const std::vector<cudaStream_t>& streams,
+    HRDWRingBuffer<void*>& buf,
+    std::vector<std::unique_ptr<PerCollState>>& states) {
+  auto totalWrites = static_cast<int>(states.size());
+  auto numStreams = static_cast<int>(streams.size());
+  for (int i = 0; i < totalWrites; ++i) {
+    auto streamIdx = i % numStreams;
+    launchRingBufferStartWrite(
+        streams[streamIdx],
+        buf.ring(),
+        buf.writeIndex(),
+        buf.mask(),
+        nullptr,
+        states[i]->slotStorage);
+    launchRingBufferEndWrite(
+        streams[streamIdx], buf.ring(), states[i]->slotStorage, buf.mask());
+  }
+}
+
+// Define an eager stress test that iterates over all configs. Provides:
+//   cfg       — StressConfig
+//   buf       — HRDWRingBuffer<void*>
+//   streams   — vector of cudaStream_t (cfg.numStreams)
+//   states    — vector of PerCollState (cfg.totalWrites())
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define EAGER_STRESS_TEST(name)                                 \
+  static void eagerStressBody_##name(                           \
+      const StressConfig&,                                      \
+      HRDWRingBuffer<void*>&,                                   \
+      std::vector<cudaStream_t>&,                               \
+      std::vector<std::unique_ptr<PerCollState>>&);             \
+  TEST_F(HRDWRingBufferStressTest, name) {                      \
+    for (const auto& cfg : kStressConfigs) {                    \
+      SCOPED_TRACE(                                             \
+          "ring=" + std::to_string(cfg.ringSize) +              \
+          " streams=" + std::to_string(cfg.numStreams) +        \
+          " writes=" + std::to_string(cfg.numWrites));          \
+      HRDWRingBuffer<void*> buf(cfg.ringSize);                  \
+      ASSERT_TRUE(buf.valid());                                 \
+      std::vector<cudaStream_t> streams(cfg.numStreams);        \
+      for (auto& s : streams) {                                 \
+        ASSERT_EQ(cudaStreamCreate(&s), cudaSuccess);           \
+      }                                                         \
+      std::vector<std::unique_ptr<PerCollState>> states;        \
+      states.reserve(cfg.totalWrites());                        \
+      for (int i = 0; i < cfg.totalWrites(); ++i) {             \
+        states.push_back(std::make_unique<PerCollState>());     \
+      }                                                         \
+      eagerStressBody_##name(cfg, buf, streams, states);        \
+      for (auto& s : streams) {                                 \
+        /* NOLINTNEXTLINE(facebook-cuda-safe-api-call-check) */ \
+        cudaStreamDestroy(s);                                   \
+      }                                                         \
+    }                                                           \
+  }                                                             \
+  static void eagerStressBody_##name(                           \
+      const StressConfig& cfg,                                  \
+      HRDWRingBuffer<void*>& buf,                               \
+      std::vector<cudaStream_t>& streams,                       \
+      std::vector<std::unique_ptr<PerCollState>>& states)
+
+// Launch start+end pairs across multiple streams, sync, then poll.
+// Every delivered entry must have valid timestamps.
+EAGER_STRESS_TEST(MultiStreamTimestampOrdering) {
+  HRDWRingBufferReader<void*> reader(buf);
+  launchEagerWrites(streams, buf, states);
+
+  for (auto& s : streams) {
+    ASSERT_EQ(cudaStreamSynchronize(s), cudaSuccess);
+  }
+
+  uint64_t badEntries = 0;
+  auto result = reader.poll([&](const auto& e, uint64_t) {
+    if (e.start_ns == 0 || e.end_ns == 0 || e.end_ns < e.start_ns) {
+      ++badEntries;
+    }
+  });
+
+  EXPECT_EQ(badEntries, 0u)
+      << "Entries with invalid timestamps (threadfence_system ordering failure)";
+  EXPECT_EQ(
+      result.entriesRead + result.entriesLost,
+      static_cast<uint64_t>(cfg.totalWrites()));
+}
+
+// Launch writes while a background CPU thread polls continuously.
+EAGER_STRESS_TEST(ConcurrentWriteAndPoll) {
+  std::atomic<uint64_t> totalRead{0};
+  std::atomic<uint64_t> totalLost{0};
+  std::atomic<uint64_t> totalBad{0};
+  std::atomic<bool> writersDone{false};
+
+  std::thread readerThread([&]() {
+    HRDWRingBufferReader<void*> reader(buf);
+    while (!writersDone.load(std::memory_order_acquire)) {
+      auto result = reader.poll([&](const auto& e, uint64_t) {
+        if (e.start_ns == 0 || e.end_ns == 0 || e.end_ns < e.start_ns) {
+          totalBad.fetch_add(1, std::memory_order_relaxed);
+        }
+      });
+      totalRead.fetch_add(result.entriesRead, std::memory_order_relaxed);
+      totalLost.fetch_add(result.entriesLost, std::memory_order_relaxed);
+    }
+    // Final drain.
+    auto result = reader.poll([&](const auto& e, uint64_t) {
+      if (e.start_ns == 0 || e.end_ns == 0 || e.end_ns < e.start_ns) {
+        totalBad.fetch_add(1, std::memory_order_relaxed);
+      }
+    });
+    totalRead.fetch_add(result.entriesRead, std::memory_order_relaxed);
+    totalLost.fetch_add(result.entriesLost, std::memory_order_relaxed);
+  });
+
+  launchEagerWrites(streams, buf, states);
+
+  for (auto& s : streams) {
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaStreamSynchronize(s);
+  }
+  writersDone.store(true, std::memory_order_release);
+  readerThread.join();
+
+  EXPECT_EQ(totalBad.load(), 0u)
+      << "Corrupted entries during concurrent polling";
+
+  auto accounted = totalRead.load() + totalLost.load();
+  EXPECT_EQ(accounted, static_cast<uint64_t>(cfg.totalWrites()));
+}
+
+// Single-stream configs only: verify monotonic timestamp ordering.
+// On a single stream, start_ns of entry N+1 >= end_ns of entry N.
+EAGER_STRESS_TEST(SingleStreamMonotonicOrdering) {
+  if (cfg.numStreams != 1) {
+    return; // Only meaningful for single-stream configs.
+  }
+
+  HRDWRingBufferReader<void*> reader(buf);
+  launchEagerWrites(streams, buf, states);
+  ASSERT_EQ(cudaStreamSynchronize(streams[0]), cudaSuccess);
+
+  uint64_t badEntries = 0;
+  uint64_t prevEndNs = 0;
+  auto result = reader.poll([&](const auto& e, uint64_t) {
+    if (e.start_ns == 0 || e.end_ns == 0 || e.end_ns < e.start_ns) {
+      ++badEntries;
+    }
+    if (prevEndNs > 0 && e.start_ns < prevEndNs) {
+      ++badEntries;
+    }
+    prevEndNs = e.end_ns;
+  });
+
+  EXPECT_EQ(badEntries, 0u);
+  EXPECT_EQ(
+      result.entriesRead + result.entriesLost,
+      static_cast<uint64_t>(cfg.totalWrites()));
+  EXPECT_FALSE(result.tornReadDetected);
+}
+
+// NOTE: graph tests reuse kStressConfigs: numStreams = numColls, numWrites =
+// replays.
+
+// Helper: capture N serial start+end pairs into a graph, return the
+// graph and instance. Caller owns cleanup.
+struct CapturedGraph {
+  cudaGraph_t graph{nullptr};
+  cudaGraphExec_t instance{nullptr};
+  std::vector<std::unique_ptr<PerCollState>> states;
+};
+
+static CapturedGraph
+captureGraph(cudaStream_t stream, HRDWRingBuffer<void*>& buf, int numColls) {
+  CapturedGraph cg;
+  cg.states.reserve(numColls);
+  for (int i = 0; i < numColls; ++i) {
+    cg.states.push_back(std::make_unique<PerCollState>());
+  }
+
+  cudaStreamBeginCapture(stream, cudaStreamCaptureModeGlobal);
+  for (int i = 0; i < numColls; ++i) {
+    launchRingBufferStartWrite(
+        stream,
+        buf.ring(),
+        buf.writeIndex(),
+        buf.mask(),
+        // NOLINTNEXTLINE(performance-no-int-to-ptr)
+        reinterpret_cast<void*>(static_cast<uintptr_t>(i)),
+        cg.states[i]->slotStorage);
+    launchRingBufferEndWrite(
+        stream, buf.ring(), cg.states[i]->slotStorage, buf.mask());
+  }
+  cudaStreamEndCapture(stream, &cg.graph);
+  if (cg.graph) {
+    cudaGraphInstantiate(&cg.instance, cg.graph, nullptr, nullptr, 0);
+  }
+  return cg;
+}
+
+static void destroyGraph(CapturedGraph& cg) {
+  if (cg.instance) {
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaGraphExecDestroy(cg.instance);
+  }
+  if (cg.graph) {
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaGraphDestroy(cg.graph);
+  }
+}
+
+// Define a graph stress test that iterates over all configs. Provides:
+//   cfg.ringSize, cfg.numStreams, cfg.numWrites
+//   buf     — HRDWRingBuffer<void*> sized to cfg.ringSize
+//   stream  — cudaStream_t
+//   cg      — CapturedGraph with cfg.numStreams start+end pairs
+// The test body goes after the macro invocation as a brace-enclosed block.
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define GRAPH_STRESS_TEST(name)                               \
+  static void graphStressBody_##name(                         \
+      const StressConfig&,                                    \
+      HRDWRingBuffer<void*>&,                                 \
+      cudaStream_t,                                           \
+      CapturedGraph&);                                        \
+  TEST_F(HRDWRingBufferStressTest, name) {                    \
+    for (const auto& cfg : kStressConfigs) {                  \
+      SCOPED_TRACE(                                           \
+          "ring=" + std::to_string(cfg.ringSize) +            \
+          " colls=" + std::to_string(cfg.numStreams) +        \
+          " replays=" + std::to_string(cfg.numWrites));       \
+      HRDWRingBuffer<void*> buf(cfg.ringSize);                \
+      ASSERT_TRUE(buf.valid());                               \
+      cudaStream_t stream;                                    \
+      ASSERT_EQ(cudaStreamCreate(&stream), cudaSuccess);      \
+      auto cg = captureGraph(stream, buf, cfg.numStreams);    \
+      ASSERT_NE(cg.graph, nullptr);                           \
+      ASSERT_NE(cg.instance, nullptr);                        \
+      graphStressBody_##name(cfg, buf, stream, cg);           \
+      destroyGraph(cg);                                       \
+      /* NOLINTNEXTLINE(facebook-cuda-safe-api-call-check) */ \
+      cudaStreamDestroy(stream);                              \
+    }                                                         \
+  }                                                           \
+  static void graphStressBody_##name(                         \
+      const StressConfig& cfg,                                \
+      [[maybe_unused]] HRDWRingBuffer<void*>& buf,            \
+      cudaStream_t stream,                                    \
+      CapturedGraph& cg)
+
+// Replay graph, then poll. Every delivered entry must have valid timestamps.
+GRAPH_STRESS_TEST(GraphReplayTimestampOrdering) {
+  HRDWRingBufferReader<void*> reader(buf);
+
+  for (int r = 0; r < cfg.numWrites; ++r) {
+    ASSERT_EQ(cudaGraphLaunch(cg.instance, stream), cudaSuccess);
+  }
+  ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+
+  uint64_t badEntries = 0;
+  auto result = reader.poll([&](const auto& e, uint64_t) {
+    if (e.start_ns == 0 || e.end_ns == 0 || e.end_ns < e.start_ns) {
+      ++badEntries;
+    }
+  });
+
+  EXPECT_EQ(badEntries, 0u)
+      << "Graph replay produced entries with invalid timestamps";
+
+  uint64_t totalWrites = static_cast<uint64_t>(cfg.numStreams) * cfg.numWrites;
+  EXPECT_EQ(result.entriesRead + result.entriesLost, totalWrites);
+}
+
+// Replay graph while a background CPU thread polls continuously.
+GRAPH_STRESS_TEST(GraphReplayConcurrentPoll) {
+  std::atomic<uint64_t> totalRead{0};
+  std::atomic<uint64_t> totalLost{0};
+  std::atomic<uint64_t> totalBad{0};
+  std::atomic<bool> replaysDone{false};
+
+  std::thread readerThread([&]() {
+    HRDWRingBufferReader<void*> reader(buf);
+    while (!replaysDone.load(std::memory_order_acquire)) {
+      auto result = reader.poll([&](const auto& e, uint64_t) {
+        if (e.start_ns == 0 || e.end_ns == 0 || e.end_ns < e.start_ns) {
+          totalBad.fetch_add(1, std::memory_order_relaxed);
+        }
+      });
+      totalRead.fetch_add(result.entriesRead, std::memory_order_relaxed);
+      totalLost.fetch_add(result.entriesLost, std::memory_order_relaxed);
+    }
+    // Final drain.
+    auto result = reader.poll([&](const auto& e, uint64_t) {
+      if (e.start_ns == 0 || e.end_ns == 0 || e.end_ns < e.start_ns) {
+        totalBad.fetch_add(1, std::memory_order_relaxed);
+      }
+    });
+    totalRead.fetch_add(result.entriesRead, std::memory_order_relaxed);
+    totalLost.fetch_add(result.entriesLost, std::memory_order_relaxed);
+  });
+
+  for (int r = 0; r < cfg.numWrites; ++r) {
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaGraphLaunch(cg.instance, stream);
+  }
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaStreamSynchronize(stream);
+  replaysDone.store(true, std::memory_order_release);
+  readerThread.join();
+
+  EXPECT_EQ(totalBad.load(), 0u)
+      << "Graph replay produced corrupted entries during concurrent polling";
+
+  auto accounted = totalRead.load() + totalLost.load();
+  EXPECT_EQ(accounted, static_cast<uint64_t>(cfg.totalWrites()));
+}
+
+// Replay with scanIncomplete=true to exercise per-collective in-flight
+// detection. Verify write-pending entries have valid collId tags.
+GRAPH_STRESS_TEST(GraphReplayIncompleteDetection) {
+  std::atomic<uint64_t> totalCompleted{0};
+  std::atomic<uint64_t> totalLost{0};
+  std::atomic<uint64_t> totalPending{0};
+  std::atomic<uint64_t> totalBad{0};
+  std::atomic<bool> replaysDone{false};
+
+  std::thread readerThread([&]() {
+    HRDWRingBufferReader<void*> reader(buf);
+    while (!replaysDone.load(std::memory_order_acquire)) {
+      auto result = reader.poll(
+          [&](const auto& e, uint64_t) {
+            auto tag =
+                static_cast<uint32_t>(reinterpret_cast<uintptr_t>(e.data));
+            if (tag >= static_cast<uint32_t>(cfg.numStreams)) {
+              totalBad.fetch_add(1, std::memory_order_relaxed);
+            }
+            if (e.sequence == HRDW_RINGBUFFER_WRITE_PENDING) {
+              totalPending.fetch_add(1, std::memory_order_relaxed);
+            } else {
+              if (e.start_ns == 0 || e.end_ns == 0 || e.end_ns < e.start_ns) {
+                totalBad.fetch_add(1, std::memory_order_relaxed);
+              }
+              totalCompleted.fetch_add(1, std::memory_order_relaxed);
+            }
+          },
+          /*scanIncomplete=*/true);
+      totalLost.fetch_add(result.entriesLost, std::memory_order_relaxed);
+    }
+    // Final drain.
+    auto result = reader.poll(
+        [&](const auto& e, uint64_t) {
+          if (e.sequence != HRDW_RINGBUFFER_WRITE_PENDING) {
+            totalCompleted.fetch_add(1, std::memory_order_relaxed);
+          }
+        },
+        /*scanIncomplete=*/true);
+    totalLost.fetch_add(result.entriesLost, std::memory_order_relaxed);
+  });
+
+  for (int r = 0; r < cfg.numWrites; ++r) {
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaGraphLaunch(cg.instance, stream);
+  }
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaStreamSynchronize(stream);
+  replaysDone.store(true, std::memory_order_release);
+  readerThread.join();
+
+  EXPECT_EQ(totalBad.load(), 0u)
+      << "Write-pending or completed entries had invalid data";
+
+  auto accounted = totalCompleted.load() + totalLost.load();
+  EXPECT_EQ(accounted, static_cast<uint64_t>(cfg.totalWrites()));
+}

--- a/comms/utils/tests/HRDWRingBufferUT.cc
+++ b/comms/utils/tests/HRDWRingBufferUT.cc
@@ -1,0 +1,590 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cstdint>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "comms/utils/HRDWRingBuffer.h"
+#include "comms/utils/HRDWRingBufferReader.h"
+
+using meta::comms::colltrace::HRDWRingBuffer;
+using meta::comms::colltrace::HRDWRingBufferReader;
+
+using TestBuffer = HRDWRingBuffer<void*>;
+using TestReader = HRDWRingBufferReader<void*>;
+using TestEntry = TestBuffer::Entry;
+
+// Helper to store/retrieve a uint32_t tag in the void* data field.
+static void* tagToData(uint32_t tag) {
+  // NOLINTNEXTLINE(performance-no-int-to-ptr)
+  return reinterpret_cast<void*>(static_cast<uintptr_t>(tag));
+}
+
+static uint32_t dataToTag(void* data) {
+  return static_cast<uint32_t>(reinterpret_cast<uintptr_t>(data));
+}
+
+TEST(HRDWRingBuffer, ConstructionAndAccessors) {
+  TestBuffer buf(64);
+  ASSERT_TRUE(buf.valid());
+  EXPECT_EQ(buf.size(), 64u);
+  EXPECT_EQ(buf.mask(), 63u);
+  EXPECT_NE(buf.ring(), nullptr);
+  EXPECT_NE(buf.writeIndex(), nullptr);
+  EXPECT_EQ(*buf.writeIndex(), 0u);
+}
+
+TEST(HRDWRingBuffer, InitialEntriesMarkedWritePending) {
+  TestBuffer buf(16);
+  ASSERT_TRUE(buf.valid());
+  for (uint32_t i = 0; i < 16; ++i) {
+    EXPECT_EQ(buf.ring()[i].sequence, HRDW_RINGBUFFER_WRITE_PENDING);
+  }
+}
+
+TEST(HRDWRingBuffer, MoveConstruction) {
+  TestBuffer buf(32);
+  ASSERT_TRUE(buf.valid());
+  auto* ring = buf.ring();
+  auto* writeIdx = buf.writeIndex();
+
+  TestBuffer moved(std::move(buf));
+  EXPECT_TRUE(moved.valid());
+  EXPECT_EQ(moved.ring(), ring);
+  EXPECT_EQ(moved.writeIndex(), writeIdx);
+  EXPECT_EQ(moved.size(), 32u);
+
+  // Moved-from should be invalid.
+  EXPECT_FALSE(buf.valid()); // NOLINT(bugprone-use-after-move)
+}
+
+TEST(HRDWRingBuffer, MoveAssignment) {
+  TestBuffer buf1(32);
+  TestBuffer buf2(64);
+  ASSERT_TRUE(buf1.valid());
+  ASSERT_TRUE(buf2.valid());
+  auto* ring2 = buf2.ring();
+
+  buf1 = std::move(buf2);
+  EXPECT_TRUE(buf1.valid());
+  EXPECT_EQ(buf1.ring(), ring2);
+  EXPECT_EQ(buf1.size(), 64u);
+  EXPECT_FALSE(buf2.valid()); // NOLINT(bugprone-use-after-move)
+}
+
+TEST(HRDWRingBuffer, RoundsUpZeroSize) {
+  TestBuffer buf(0);
+  EXPECT_TRUE(buf.valid());
+  EXPECT_EQ(buf.size(), 1u);
+  EXPECT_EQ(buf.mask(), 0u);
+}
+
+TEST(HRDWRingBuffer, RoundsUpNonPowerOfTwo) {
+  TestBuffer buf(10);
+  EXPECT_TRUE(buf.valid());
+  EXPECT_EQ(buf.size(), 16u);
+  EXPECT_EQ(buf.mask(), 15u);
+
+  TestBuffer buf2(7);
+  EXPECT_TRUE(buf2.valid());
+  EXPECT_EQ(buf2.size(), 8u);
+
+  // Already a power of 2 — no rounding.
+  TestBuffer buf3(8);
+  EXPECT_TRUE(buf3.valid());
+  EXPECT_EQ(buf3.size(), 8u);
+}
+
+class HRDWRingBufferReaderTest : public ::testing::Test {
+ protected:
+  static constexpr uint32_t kRingSize = 16;
+
+  void SetUp() override {
+    buf_.emplace(kRingSize);
+    ASSERT_TRUE(buf_->valid());
+    reader_.emplace(*buf_);
+  }
+
+  // Simulate a GPU writing a complete entry at the next slot.
+  void writeEntry(uint32_t tag, uint64_t startNs = 100, uint64_t endNs = 200) {
+    uint64_t slot = (*buf_->writeIndex())++;
+    uint64_t idx = slot & buf_->mask();
+    auto& entry = buf_->ring()[idx];
+    entry.start_ns = startNs;
+    entry.end_ns = endNs;
+    entry.data = tagToData(tag);
+    entry.sequence = slot; // Mark complete
+  }
+
+  // Simulate a GPU writing a write-pending entry (start kernel ran, end
+  // kernel hasn't stamped yet).
+  void writeIncompleteEntry(uint32_t tag, uint64_t startNs = 100) {
+    uint64_t slot = (*buf_->writeIndex())++;
+    uint64_t idx = slot & buf_->mask();
+    auto& entry = buf_->ring()[idx];
+    entry.start_ns = startNs;
+    entry.end_ns = 0;
+    entry.data = tagToData(tag);
+    entry.sequence = HRDW_RINGBUFFER_WRITE_PENDING;
+  }
+
+  std::optional<TestBuffer> buf_;
+  std::optional<TestReader> reader_;
+};
+
+TEST_F(HRDWRingBufferReaderTest, EmptyBufferReturnsNothing) {
+  std::vector<uint32_t> seen;
+  auto result = reader_->poll(
+      [&](const TestEntry& e, uint64_t) { seen.push_back(dataToTag(e.data)); });
+  EXPECT_EQ(result.entriesRead, 0u);
+  EXPECT_EQ(result.entriesLost, 0u);
+  EXPECT_FALSE(result.tornReadDetected);
+  EXPECT_TRUE(seen.empty());
+}
+
+TEST_F(HRDWRingBufferReaderTest, ReadsSingleEntry) {
+  writeEntry(42, 1000, 2000);
+
+  std::vector<uint32_t> seen;
+  auto result = reader_->poll([&](const TestEntry& e, uint64_t) {
+    seen.push_back(dataToTag(e.data));
+    EXPECT_EQ(e.start_ns, 1000u);
+    EXPECT_EQ(e.end_ns, 2000u);
+  });
+
+  EXPECT_EQ(result.entriesRead, 1u);
+  EXPECT_EQ(result.entriesLost, 0u);
+  EXPECT_FALSE(result.tornReadDetected);
+  const std::vector<uint32_t> expected{42};
+  EXPECT_EQ(seen, expected);
+}
+
+TEST_F(HRDWRingBufferReaderTest, ReadsMultipleEntries) {
+  writeEntry(1);
+  writeEntry(2);
+  writeEntry(3);
+
+  std::vector<uint32_t> seen;
+  auto result = reader_->poll(
+      [&](const TestEntry& e, uint64_t) { seen.push_back(dataToTag(e.data)); });
+
+  EXPECT_EQ(result.entriesRead, 3u);
+  const std::vector<uint32_t> expected{1, 2, 3};
+  EXPECT_EQ(seen, expected);
+}
+
+TEST_F(HRDWRingBufferReaderTest, DoesNotReReadOldEntries) {
+  writeEntry(1);
+  writeEntry(2);
+
+  // First poll reads entries 1 and 2.
+  reader_->poll([](const TestEntry&, uint64_t) {});
+
+  // Write a third entry.
+  writeEntry(3);
+
+  // Second poll should only see entry 3.
+  std::vector<uint32_t> seen;
+  auto result = reader_->poll(
+      [&](const TestEntry& e, uint64_t) { seen.push_back(dataToTag(e.data)); });
+
+  EXPECT_EQ(result.entriesRead, 1u);
+  const std::vector<uint32_t> expected{3};
+  EXPECT_EQ(seen, expected);
+}
+
+TEST_F(HRDWRingBufferReaderTest, StopsAtWritePendingEntry) {
+  writeEntry(1);
+  writeIncompleteEntry(
+      2); // This entry has sequence = HRDW_RINGBUFFER_WRITE_PENDING
+  writeEntry(3);
+
+  std::vector<uint32_t> seen;
+  auto result = reader_->poll(
+      [&](const TestEntry& e, uint64_t) { seen.push_back(dataToTag(e.data)); });
+
+  // Reader stops at entry 2 (in-flight). Only entry 1 is delivered.
+  // Entries 2 and 3 are deferred (entriesInFlight=2).
+  EXPECT_EQ(result.entriesRead, 1u);
+  EXPECT_EQ(result.entriesLost, 0u);
+  EXPECT_EQ(result.entriesInFlight, 2u);
+  const std::vector<uint32_t> expected{1};
+  EXPECT_EQ(seen, expected);
+  EXPECT_EQ(reader_->lastReadIndex(), 1u);
+
+  // Complete entry 2 — next poll picks up entries 2 and 3.
+  buf_->ring()[1].sequence = 1;
+  std::vector<uint32_t> seen2;
+  auto result2 = reader_->poll([&](const TestEntry& e, uint64_t) {
+    seen2.push_back(dataToTag(e.data));
+  });
+
+  EXPECT_EQ(result2.entriesRead, 2u);
+  EXPECT_EQ(result2.entriesLost, 0u);
+  EXPECT_EQ(result2.entriesInFlight, 0u);
+  const std::vector<uint32_t> expected2{2, 3};
+  EXPECT_EQ(seen2, expected2);
+}
+
+TEST_F(HRDWRingBufferReaderTest, DetectsLostEntriesWhenFarBehind) {
+  // Write more entries than the ring can hold, so the reader falls behind.
+  for (uint32_t i = 0; i < kRingSize + 5; ++i) {
+    writeEntry(i);
+  }
+
+  std::vector<uint32_t> seen;
+  auto result = reader_->poll(
+      [&](const TestEntry& e, uint64_t) { seen.push_back(dataToTag(e.data)); });
+
+  // The first 5 entries were overwritten before we could read them.
+  EXPECT_EQ(result.entriesLost, 5u);
+  // We should read the remaining kRingSize entries.
+  EXPECT_EQ(result.entriesRead, kRingSize);
+}
+
+TEST_F(HRDWRingBufferReaderTest, WrapAroundReadsCorrectly) {
+  // Fill the entire ring.
+  for (uint32_t i = 0; i < kRingSize; ++i) {
+    writeEntry(i);
+  }
+  reader_->poll([](const TestEntry&, uint64_t) {});
+
+  // Write a few more — these wrap around to the beginning of the ring.
+  writeEntry(100);
+  writeEntry(101);
+
+  std::vector<uint32_t> seen;
+  auto result = reader_->poll(
+      [&](const TestEntry& e, uint64_t) { seen.push_back(dataToTag(e.data)); });
+
+  EXPECT_EQ(result.entriesRead, 2u);
+  const std::vector<uint32_t> expected{100, 101};
+  EXPECT_EQ(seen, expected);
+}
+
+TEST_F(HRDWRingBufferReaderTest, CallbackReceivesCorrectSlot) {
+  writeEntry(10);
+  writeEntry(20);
+
+  std::vector<uint64_t> slots;
+  reader_->poll(
+      [&](const TestEntry&, uint64_t slot) { slots.push_back(slot); });
+
+  const std::vector<uint64_t> expected{0, 1};
+  EXPECT_EQ(slots, expected);
+}
+
+TEST_F(HRDWRingBufferReaderTest, MultiplePollCyclesAccumulate) {
+  uint64_t totalRead = 0;
+
+  for (int cycle = 0; cycle < 5; ++cycle) {
+    writeEntry(cycle);
+    writeEntry(cycle + 100);
+    auto result = reader_->poll([](const TestEntry&, uint64_t) {});
+    totalRead += result.entriesRead;
+  }
+
+  EXPECT_EQ(totalRead, 10u);
+  EXPECT_EQ(reader_->lastReadIndex(), 10u);
+}
+
+// Verify that callbacks receive copies of entries, not references to shared
+// memory. Mutate the ring entry after poll() captures it but before we
+// inspect what the callback received — the callback should see the original.
+TEST_F(HRDWRingBufferReaderTest, CallbackReceivesSnapshotNotReference) {
+  writeEntry(42, 1000, 2000);
+
+  uint64_t observedStartNs = 0;
+  auto result = reader_->poll(
+      [&](const TestEntry& e, uint64_t) { observedStartNs = e.start_ns; });
+
+  EXPECT_EQ(result.entriesRead, 1u);
+  EXPECT_EQ(observedStartNs, 1000u);
+
+  // Mutate the ring entry after poll completed. The callback already ran
+  // with a snapshot, so this mutation should not affect the observed value.
+  buf_->ring()[0].start_ns = 9999;
+  EXPECT_EQ(observedStartNs, 1000u);
+}
+
+// Verify that overwritten entries (where sequence is a different valid
+// slot from a later wrap-around) are counted as lost and never delivered.
+TEST_F(HRDWRingBufferReaderTest, OverwrittenEntriesNeverDelivered) {
+  // Write kRingSize entries to fill the buffer.
+  for (uint32_t i = 0; i < kRingSize; ++i) {
+    writeEntry(i);
+  }
+  // Read them all.
+  reader_->poll([](const TestEntry&, uint64_t) {});
+
+  // Write one more entry at slot kRingSize (ring index 0). Its sequence
+  // is kRingSize, which won't match the reader's expected slot.
+  writeEntry(100);
+
+  // Manually set sequence to a different valid slot to simulate an
+  // overwrite from a later wrap-around.
+  buf_->ring()[0].sequence = kRingSize + kRingSize; // wrong epoch
+
+  uint32_t callbackCount = 0;
+  auto result =
+      reader_->poll([&](const TestEntry&, uint64_t) { ++callbackCount; });
+
+  // The entry should be skipped (sequence mismatch), counted as lost.
+  EXPECT_EQ(callbackCount, 0u);
+  EXPECT_EQ(result.entriesRead, 0u);
+  EXPECT_EQ(result.entriesLost, 1u);
+}
+
+// Verify that write-pending entries are delivered through the callback
+// with sequence == HRDW_RINGBUFFER_WRITE_PENDING when scanIncomplete=true,
+// allowing consumers to identify exactly which collectives are in-flight.
+TEST_F(HRDWRingBufferReaderTest, WritePendingEntriesDeliveredViaCallback) {
+  // Write one complete entry, then two write-pending entries with distinct
+  // collId tags and start timestamps.
+  writeEntry(/*tag=*/10, /*startNs=*/1000, /*endNs=*/2000);
+  writeIncompleteEntry(/*tag=*/20, /*startNs=*/3000);
+  writeIncompleteEntry(/*tag=*/30, /*startNs=*/4000);
+
+  struct SeenEntry {
+    uint32_t tag;
+    uint64_t start_ns;
+    uint64_t slot;
+    bool isPending;
+  };
+  std::vector<SeenEntry> seen;
+  auto result = reader_->poll(
+      [&](const TestEntry& e, uint64_t slot) {
+        seen.push_back({
+            dataToTag(e.data),
+            e.start_ns,
+            slot,
+            e.sequence == HRDW_RINGBUFFER_WRITE_PENDING,
+        });
+      },
+      /*scanIncomplete=*/true);
+
+  // 3 entries delivered: 1 complete + 2 write-pending.
+  ASSERT_EQ(seen.size(), 3u);
+  EXPECT_EQ(result.entriesRead, 3u);
+  EXPECT_EQ(result.entriesInFlight, 2u);
+  EXPECT_EQ(reader_->lastReadIndex(), 1u);
+
+  // First entry: complete.
+  EXPECT_EQ(seen[0].tag, 10u);
+  EXPECT_FALSE(seen[0].isPending);
+
+  // Second and third: write-pending with correct start_ns and slot.
+  EXPECT_EQ(seen[1].tag, 20u);
+  EXPECT_TRUE(seen[1].isPending);
+  EXPECT_EQ(seen[1].start_ns, 3000u);
+  EXPECT_EQ(seen[1].slot, 1u);
+
+  EXPECT_EQ(seen[2].tag, 30u);
+  EXPECT_TRUE(seen[2].isPending);
+  EXPECT_EQ(seen[2].start_ns, 4000u);
+  EXPECT_EQ(seen[2].slot, 2u);
+
+  // Complete entry at slot 1 — next poll delivers slot 1 as complete,
+  // slot 2 still as write-pending.
+  buf_->ring()[1].end_ns = 3500;
+  buf_->ring()[1].sequence = 1;
+
+  std::vector<SeenEntry> seen2;
+  auto result2 = reader_->poll(
+      [&](const TestEntry& e, uint64_t slot) {
+        seen2.push_back({
+            dataToTag(e.data),
+            e.start_ns,
+            slot,
+            e.sequence == HRDW_RINGBUFFER_WRITE_PENDING,
+        });
+      },
+      /*scanIncomplete=*/true);
+
+  ASSERT_EQ(seen2.size(), 2u);
+  EXPECT_EQ(seen2[0].tag, 20u);
+  EXPECT_FALSE(seen2[0].isPending);
+  EXPECT_EQ(seen2[1].tag, 30u);
+  EXPECT_TRUE(seen2[1].isPending);
+  EXPECT_EQ(result2.entriesInFlight, 1u);
+
+  // Complete the last entry — everything clears.
+  buf_->ring()[2].end_ns = 5000;
+  buf_->ring()[2].sequence = 2;
+
+  std::vector<SeenEntry> seen3;
+  auto result3 = reader_->poll(
+      [&](const TestEntry& e, uint64_t slot) {
+        seen3.push_back({
+            dataToTag(e.data),
+            e.start_ns,
+            slot,
+            e.sequence == HRDW_RINGBUFFER_WRITE_PENDING,
+        });
+      },
+      /*scanIncomplete=*/true);
+  ASSERT_EQ(seen3.size(), 1u);
+  EXPECT_EQ(seen3[0].tag, 30u);
+  EXPECT_FALSE(seen3[0].isPending);
+  EXPECT_EQ(result3.entriesInFlight, 0u);
+  EXPECT_EQ(reader_->lastReadIndex(), 3u);
+}
+
+// Verify that when all entries are write-pending, they're all delivered
+// through the callback with the pending sentinel.
+TEST_F(HRDWRingBufferReaderTest, AllEntriesPendingDeliveredViaCallback) {
+  writeIncompleteEntry(/*tag=*/5, /*startNs=*/500);
+  writeIncompleteEntry(/*tag=*/6, /*startNs=*/600);
+  writeIncompleteEntry(/*tag=*/7, /*startNs=*/700);
+
+  struct SeenEntry {
+    uint32_t tag;
+    uint64_t start_ns;
+    bool isPending;
+  };
+  std::vector<SeenEntry> seen;
+  auto result = reader_->poll(
+      [&](const TestEntry& e, uint64_t) {
+        seen.push_back({
+            dataToTag(e.data),
+            e.start_ns,
+            e.sequence == HRDW_RINGBUFFER_WRITE_PENDING,
+        });
+      },
+      /*scanIncomplete=*/true);
+
+  // All three delivered as write-pending.
+  ASSERT_EQ(seen.size(), 3u);
+  EXPECT_EQ(result.entriesRead, 3u);
+  EXPECT_EQ(result.entriesInFlight, 3u);
+  EXPECT_EQ(reader_->lastReadIndex(), 0u);
+
+  EXPECT_EQ(seen[0].tag, 5u);
+  EXPECT_EQ(seen[0].start_ns, 500u);
+  EXPECT_TRUE(seen[0].isPending);
+  EXPECT_EQ(seen[1].tag, 6u);
+  EXPECT_EQ(seen[1].start_ns, 600u);
+  EXPECT_TRUE(seen[1].isPending);
+  EXPECT_EQ(seen[2].tag, 7u);
+  EXPECT_EQ(seen[2].start_ns, 700u);
+  EXPECT_TRUE(seen[2].isPending);
+}
+
+// Verify that the default scanIncomplete=false still breaks at the first
+// WRITE_PENDING and does NOT deliver pending entries via the callback.
+TEST_F(HRDWRingBufferReaderTest, DefaultPollDoesNotScanIncomplete) {
+  writeEntry(/*tag=*/1, /*startNs=*/100, /*endNs=*/200);
+  writeIncompleteEntry(/*tag=*/2, /*startNs=*/300);
+  writeIncompleteEntry(/*tag=*/3, /*startNs=*/400);
+
+  std::vector<uint32_t> seen;
+  auto result = reader_->poll(
+      [&](const TestEntry& e, uint64_t) { seen.push_back(dataToTag(e.data)); });
+
+  // Completed entry delivered, reader stopped at first WRITE_PENDING.
+  const std::vector<uint32_t> expectedSeen{1};
+  EXPECT_EQ(seen, expectedSeen);
+  EXPECT_EQ(result.entriesRead, 1u);
+  EXPECT_EQ(result.entriesInFlight, 2u);
+}
+
+// ---------------------------------------------------------------------------
+// Integration tests: simulate the pollGraphEvents() consumer pattern.
+//
+// These tests exercise the full reader → collId dispatch pipeline that
+// pollGraphEvents() uses: the callback checks entry.sequence to distinguish
+// complete vs. write-pending entries and dispatches per-collective actions.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// Minimal stand-in for GraphCollectiveEntry used in pollGraphEvents().
+struct FakeCollEntry {
+  uint32_t collId{};
+  bool progressingFired{false};
+  uint64_t detectedStartNs{0};
+};
+
+} // namespace
+
+// Simulate pollGraphEvents() with 4 collectives: 2 complete, 2 in-flight.
+// Verify that only the in-flight collectives get progressing actions, and
+// that the completed collectives are delivered normally.
+TEST_F(HRDWRingBufferReaderTest, PerCollectiveDispatchMixedState) {
+  writeEntry(/*tag=*/10, /*startNs=*/1000, /*endNs=*/1500);
+  writeEntry(/*tag=*/20, /*startNs=*/2000, /*endNs=*/2500);
+  writeIncompleteEntry(/*tag=*/30, /*startNs=*/3000);
+  writeIncompleteEntry(/*tag=*/40, /*startNs=*/4000);
+
+  FakeCollEntry coll10{10}, coll20{20}, coll30{30}, coll40{40};
+  std::unordered_map<uint32_t, FakeCollEntry*> collIdMap{
+      {10, &coll10}, {20, &coll20}, {30, &coll30}, {40, &coll40}};
+
+  std::vector<uint32_t> completedCollIds;
+  std::vector<uint32_t> progressingCollIds;
+  reader_->poll(
+      [&](const TestEntry& e, uint64_t) {
+        auto collId = dataToTag(e.data);
+        auto it = collIdMap.find(collId);
+        if (it == collIdMap.end()) {
+          return;
+        }
+        if (e.sequence == HRDW_RINGBUFFER_WRITE_PENDING) {
+          it->second->progressingFired = true;
+          it->second->detectedStartNs = e.start_ns;
+          progressingCollIds.push_back(collId);
+        } else {
+          completedCollIds.push_back(collId);
+        }
+      },
+      /*scanIncomplete=*/true);
+
+  const std::vector<uint32_t> expectedCompleted{10, 20};
+  EXPECT_EQ(completedCollIds, expectedCompleted);
+
+  const std::vector<uint32_t> expectedProgressing{30, 40};
+  EXPECT_EQ(progressingCollIds, expectedProgressing);
+
+  EXPECT_FALSE(coll10.progressingFired);
+  EXPECT_FALSE(coll20.progressingFired);
+  EXPECT_TRUE(coll30.progressingFired);
+  EXPECT_EQ(coll30.detectedStartNs, 3000u);
+  EXPECT_TRUE(coll40.progressingFired);
+  EXPECT_EQ(coll40.detectedStartNs, 4000u);
+}
+
+// Verify that a write-pending entry that completes between polls is
+// delivered as a normal completed entry on the next poll.
+TEST_F(HRDWRingBufferReaderTest, PendingEntryCompletedBetweenPolls) {
+  writeIncompleteEntry(/*tag=*/50, /*startNs=*/9000);
+
+  // Poll 1 — entry delivered as write-pending.
+  bool sawPending = false;
+  reader_->poll(
+      [&](const TestEntry& e, uint64_t) {
+        if (e.sequence == HRDW_RINGBUFFER_WRITE_PENDING) {
+          EXPECT_EQ(dataToTag(e.data), 50u);
+          sawPending = true;
+        }
+      },
+      /*scanIncomplete=*/true);
+  EXPECT_TRUE(sawPending);
+
+  // Complete the entry.
+  buf_->ring()[0].end_ns = 9500;
+  buf_->ring()[0].sequence = 0;
+
+  // Poll 2 — delivered as completed.
+  std::vector<uint32_t> completed;
+  auto result2 = reader_->poll(
+      [&](const TestEntry& e, uint64_t) {
+        EXPECT_NE(e.sequence, HRDW_RINGBUFFER_WRITE_PENDING);
+        completed.push_back(dataToTag(e.data));
+      },
+      /*scanIncomplete=*/true);
+
+  const std::vector<uint32_t> expectedCompleted{50};
+  EXPECT_EQ(completed, expectedCompleted);
+  EXPECT_EQ(result2.entriesInFlight, 0u);
+}


### PR DESCRIPTION
Summary: Extract a generic Host-Read Device-Write (HRDW) ring buffer from colltrace (see above commit for usage). GPU kernels atomically claim slots; the CPU polls w/ seqlock protocol.

Reviewed By: SuhitK

Differential Revision: D97972479


