### PR TITLE
xccl: bootstrap race fix + logging and lifetime cleanups

### DIFF
--- a/comms/torchcomms/xccl/TorchCommXCCL.cpp
+++ b/comms/torchcomms/xccl/TorchCommXCCL.cpp
@@ -228,6 +228,12 @@ TorchCommXCCL::~TorchCommXCCL() {
       xccl_comm_ = nullptr;
     }
   }
+
+  // Release the caller's store in case init() threw before it could drop
+  // our internal reference. No-op on the successful-init path.
+  if (options_.store) {
+    options_.store.reset();
+  }
 }
 
 void TorchCommXCCL::init(
@@ -451,6 +457,13 @@ void TorchCommXCCL::finalize() {
                     << xccl_api_->getErrorString(result);
     }
     xccl_comm_ = nullptr;
+  }
+
+  // Drop any lingering store reference. init() already releases on the
+  // happy path; this guards against future code paths that might retain it
+  // so callers can rely on finalize() to free the store.
+  if (options_.store) {
+    options_.store.reset();
   }
 }
 

--- a/comms/torchcomms/xccl/TorchCommXCCL.cpp
+++ b/comms/torchcomms/xccl/TorchCommXCCL.cpp
@@ -223,7 +223,10 @@ TorchCommXCCL::~TorchCommXCCL() {
     if (xccl_comm_) {
       if (xccl_api_) {
         // Use destroy to free resources since oneCCL doesn't have abort api
-        xccl_api_->commDestroy(xccl_comm_);
+        onecclResult_t result = xccl_api_->commDestroy(xccl_comm_);
+        if (result != onecclSuccess) {
+          TC_LOG(ERROR, this) << "Failed to destroy XCCL communicator";
+        }
       }
       xccl_comm_ = nullptr;
     }
@@ -354,6 +357,11 @@ void TorchCommXCCL::init(
   xccl_api_->setVersionInfo();
   backend_version_ = std::to_string(xccl_api_->getVersion());
 
+  TC_LOG(INFO, this) << "XCCL Version: " << xccl_api_->getVersion()
+                     << " (Major: " << xccl_api_->getMajorVersion()
+                     << " Minor: " << xccl_api_->getMinorVersion()
+                     << " Patch: " << xccl_api_->getPatchVersion() << ")";
+
   result = xccl_api_->commCount(xccl_comm_, &comm_size_);
   if (result != onecclSuccess) [[unlikely]] {
     throw std::runtime_error("XCCL commCount failed");
@@ -453,8 +461,8 @@ void TorchCommXCCL::finalize() {
   if (xccl_comm_) {
     onecclResult_t result = xccl_api_->commDestroy(xccl_comm_);
     if (result != onecclSuccess) [[unlikely]] {
-      TC_LOG(ERROR) << "XCCL commDestroy failed: "
-                    << xccl_api_->getErrorString(result);
+      TC_LOG(ERROR, this) << "XCCL commDestroy failed: "
+                          << xccl_api_->getErrorString(result);
     }
     xccl_comm_ = nullptr;
   }
@@ -473,7 +481,7 @@ void TorchCommXCCL::abortXcclComm() {
     xccl_comm_ = nullptr;
   }
   if (options_.abort_process_on_timeout_or_error) {
-    TC_LOG(ERROR) << "Aborting process due to timeout";
+    TC_LOG(ERROR, this) << "Aborting process due to timeout";
     abort();
   }
 }
@@ -687,7 +695,7 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::batch_op_issue(
         onecclResult_t result_cleanup =
             xccl_api_->groupEnd(); // Clean up group on error
         if (result_cleanup != onecclSuccess) {
-          TC_LOG(ERROR)
+          TC_LOG(ERROR, this)
               << "XCCL groupEnd failed during error cleanup after send failure in batch_op_issue: "
               << xccl_api_->getErrorString(result_cleanup);
         }
@@ -707,7 +715,7 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::batch_op_issue(
         onecclResult_t result_cleanup =
             xccl_api_->groupEnd(); // Clean up group on error
         if (result_cleanup != onecclSuccess) {
-          TC_LOG(ERROR)
+          TC_LOG(ERROR, this)
               << "XCCL groupEnd failed during error cleanup after recv failure in batch_op_issue: "
               << xccl_api_->getErrorString(result_cleanup);
         }
@@ -760,8 +768,7 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::broadcast(
   // TODO: Consider removing this check once oneCCL supports zero-sized tensors
   // in broadcast operation.
   if (tensor.numel() == 0) [[unlikely]] {
-    TC_LOG(WARNING) << "XCCL broadcast called with empty tensor on rank "
-                    << rank_;
+    TC_LOG(WARNING, this) << "XCCL broadcast called with empty tensor";
     work->recordEnd();
     enqueueWork(work, stream);
     return work;
@@ -813,8 +820,7 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::all_reduce(
   // TODO: Consider removing this check once oneCCL supports zero-sized tensors
   // for all_reduce operation.
   if (tensor.numel() == 0) [[unlikely]] {
-    TC_LOG(WARNING) << "XCCL all_reduce called with empty input tensor on rank "
-                    << rank_;
+    TC_LOG(WARNING, this) << "XCCL all_reduce called with empty input tensor";
     work->recordEnd();
     enqueueWork(work, stream);
     return work;
@@ -908,8 +914,7 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::reduce(
   // TODO: Consider removing this check once oneCCL supports zero-sized tensors
   // in reduce operations.
   if (tensor.numel() == 0) [[unlikely]] {
-    TC_LOG(WARNING) << "XCCL reduce called with empty input tensor on rank "
-                    << rank_;
+    TC_LOG(WARNING, this) << "XCCL reduce called with empty input tensor";
     work->recordEnd();
     enqueueWork(work, stream);
     return work;
@@ -1012,8 +1017,7 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::all_gather(
   // TODO: Consider removing this check once oneCCL supports zero-sized tensors
   // in broadcast operation.
   if (tensor.numel() == 0) [[unlikely]] {
-    TC_LOG(WARNING) << "XCCL all_gather called with empty input tensor on rank "
-                    << rank_;
+    TC_LOG(WARNING, this) << "XCCL all_gather called with empty input tensor";
     work->recordEnd();
     enqueueWork(work, stream);
     return work;
@@ -1114,7 +1118,7 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::all_gather_v(
       onecclResult_t result_cleanup =
           xccl_api_->groupEnd(); // clean up group before throwing
       if (result_cleanup != onecclSuccess) {
-        TC_LOG(ERROR)
+        TC_LOG(ERROR, this)
             << "XCCL groupEnd failed during error cleanup after broadcast failure in all_gather_v: "
             << xccl_api_->getErrorString(result_cleanup);
       }
@@ -1172,9 +1176,8 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::all_gather_single(
   // TODO: Consider removing this check once oneCCL supports zero-sized tensors
   // in all_gather operations.
   if (input.numel() == 0) [[unlikely]] {
-    TC_LOG(WARNING)
-        << "XCCL all_gather_single called with empty input tensor on rank "
-        << rank_;
+    TC_LOG(WARNING, this)
+        << "XCCL all_gather_single called with empty input tensor";
     work->recordEnd();
     enqueueWork(work, stream);
     return work;
@@ -1361,8 +1364,8 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::reduce_scatter_v(
   for (int i = 0; i < comm_size_; ++i) {
     auto& input_tensor = maybe_scaled_input_list[i];
     if (input_tensor.numel() == 0) [[unlikely]] {
-      TC_LOG(WARNING) << "XCCL skipping empty input tensor for rank " << i
-                      << " in reduce_scatter_v";
+      TC_LOG(WARNING, this) << "XCCL skipping empty input tensor for rank " << i
+                            << " in reduce_scatter_v";
       continue; // skip empty tensors
     }
     const auto dataType = getXcclDataType(input_tensor);
@@ -1383,7 +1386,7 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::reduce_scatter_v(
       onecclResult_t result_cleanup =
           xccl_api_->groupEnd(); // clean up group before throwing
       if (result_cleanup != onecclSuccess) {
-        TC_LOG(ERROR)
+        TC_LOG(ERROR, this)
             << "XCCL groupEnd failed during error cleanup after reduce failure in reduce_scatter_v: "
             << xccl_api_->getErrorString(result_cleanup);
       }
@@ -1460,9 +1463,8 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::reduce_scatter_single(
   // TODO: Consider removing this check once oneCCL supports zero-sized tensors
   // in reduce operations.
   if (input.numel() == 0) [[unlikely]] {
-    TC_LOG(WARNING)
-        << "XCCL reduce_scatter_single called with empty input tensor on rank "
-        << rank_;
+    TC_LOG(WARNING, this)
+        << "XCCL reduce_scatter_single called with empty input tensor";
     work->recordEnd();
     enqueueWork(work, stream);
     return work;
@@ -1719,7 +1721,7 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::all_to_all_v_single(
           onecclResult_t result_cleanup =
               xccl_api_->groupEnd(); // clean up group before throwing
           if (result_cleanup != onecclSuccess) {
-            TC_LOG(ERROR)
+            TC_LOG(ERROR, this)
                 << "XCCL groupEnd failed during error cleanup after send failure in all_to_all_v_single: "
                 << xccl_api_->getErrorString(result_cleanup);
           }
@@ -1741,7 +1743,7 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::all_to_all_v_single(
         onecclResult_t result_cleanup =
             xccl_api_->groupEnd(); // clean up group before throwing
         if (result_cleanup != onecclSuccess) {
-          TC_LOG(ERROR)
+          TC_LOG(ERROR, this)
               << "XCCL groupEnd failed during error cleanup after recv failure in all_to_all_v_single: "
               << xccl_api_->getErrorString(result_cleanup);
         }
@@ -1849,7 +1851,7 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::all_to_all(
         onecclResult_t result_cleanup =
             xccl_api_->groupEnd(); // clean up group before throwing
         if (result_cleanup != onecclSuccess) {
-          TC_LOG(ERROR)
+          TC_LOG(ERROR, this)
               << "XCCL groupEnd failed during error cleanup after send failure in all_to_all: "
               << xccl_api_->getErrorString(result_cleanup);
         }
@@ -1870,7 +1872,7 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::all_to_all(
       onecclResult_t result_cleanup =
           xccl_api_->groupEnd(); // clean up group before throwing
       if (result_cleanup != onecclSuccess) {
-        TC_LOG(ERROR)
+        TC_LOG(ERROR, this)
             << "XCCL groupEnd failed during error cleanup after recv failure in all_to_all: "
             << xccl_api_->getErrorString(result_cleanup);
       }
@@ -1978,8 +1980,7 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::scatter(
   // TODO: Remove this check once oneCCL supports zero-sized tensors
   // in scatter operations.
   if (output_tensor.numel() == 0) [[unlikely]] {
-    TC_LOG(WARNING) << "XCCL scatter called with empty tensor on rank "
-                    << rank_;
+    TC_LOG(WARNING, this) << "XCCL scatter called with empty tensor";
     work->recordEnd();
     enqueueWork(work, stream);
     return work;
@@ -2011,7 +2012,7 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::scatter(
           onecclResult_t result_cleanup =
               xccl_api_->groupEnd(); // Clean up group on error
           if (result_cleanup != onecclSuccess) {
-            TC_LOG(ERROR)
+            TC_LOG(ERROR, this)
                 << "XCCL groupEnd failed during error cleanup after send failure in scatter: "
                 << xccl_api_->getErrorString(result_cleanup);
           }
@@ -2044,7 +2045,7 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::scatter(
       onecclResult_t result_cleanup =
           xccl_api_->groupEnd(); // Clean up group on error
       if (result_cleanup != onecclSuccess) {
-        TC_LOG(ERROR)
+        TC_LOG(ERROR, this)
             << "XCCL groupEnd failed during error cleanup after recv failure in scatter: "
             << xccl_api_->getErrorString(result_cleanup);
       }
@@ -2119,8 +2120,7 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::gather(
   // TODO: Consider removing this check once oneCCL supports zero-sized tensors
   // in send/recv operations.
   if (input_tensor.numel() == 0) [[unlikely]] {
-    TC_LOG(WARNING) << "XCCL gather called with empty input tensor on rank "
-                    << rank_;
+    TC_LOG(WARNING, this) << "XCCL gather called with empty input tensor";
     work->recordEnd();
     enqueueWork(work, stream);
     return work;
@@ -2150,7 +2150,7 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::gather(
           onecclResult_t result_cleanup =
               xccl_api_->groupEnd(); // Clean up group on error
           if (result_cleanup != onecclSuccess) {
-            TC_LOG(ERROR)
+            TC_LOG(ERROR, this)
                 << "XCCL groupEnd failed during error cleanup after recv failure in gather: "
                 << xccl_api_->getErrorString(result_cleanup);
           }
@@ -2181,7 +2181,7 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::gather(
       onecclResult_t result_cleanup =
           xccl_api_->groupEnd(); // Clean up group on error
       if (result_cleanup != onecclSuccess) {
-        TC_LOG(ERROR)
+        TC_LOG(ERROR, this)
             << "XCCL groupEnd failed during error cleanup after send failure in gather: "
             << xccl_api_->getErrorString(result_cleanup);
       }

--- a/comms/torchcomms/xccl/TorchCommXCCLBootstrap.cpp
+++ b/comms/torchcomms/xccl/TorchCommXCCLBootstrap.cpp
@@ -123,6 +123,8 @@ onecclUniqueId TorchCommXCCLBootstrap::exchangeUniqueIdStore() {
         reinterpret_cast<uint8_t*>(&uniqueId) + sizeof(uniqueId));
     store_->set(key, vec);
   } else {
+    // Block until rank 0 has written the unique ID into the store
+    store_->wait({key}, timeout_);
     // Other ranks read the broadcast ID
     auto vec = store_->get(key);
 

--- a/comms/torchcomms/xccl/XcclApi.cpp
+++ b/comms/torchcomms/xccl/XcclApi.cpp
@@ -268,7 +268,6 @@ void DefaultXcclApi::setVersionInfo() {
   if (res != onecclSuccess) {
     TC_LOG(ERROR) << "XCCL extractVersionComponents failed with error: "
                   << getErrorString(res);
-    TC_LOG(INFO) << "XCCL Version: " << version_info_.version;
     TC_LOG(WARNING) << "XCCL Major/Minor/Patch info not available";
     return;
   }
@@ -276,11 +275,6 @@ void DefaultXcclApi::setVersionInfo() {
   version_info_.major = major;
   version_info_.minor = minor;
   version_info_.patch = patch;
-
-  TC_LOG(INFO) << "XCCL Version: " << version_info_.version
-               << " (Major: " << version_info_.major
-               << " Minor: " << version_info_.minor
-               << " Patch: " << version_info_.patch << ")";
 }
 
 } // namespace torch::comms


### PR DESCRIPTION
Three XCCL backend improvements:

- **fix(xccl/bootstrap): wait for rank 0 to publish unique ID before reading it**
  Non-zero ranks were racing with rank 0's write of the unique ID into the store. Added `store_->wait()` with the configured timeout so readers block until the key is present.

- **refactor(xccl): ensure store reference is released in destructor and finalize()**
  Defensively reset `options_.store` in `~TorchCommXCCL()` and `finalize()`. No-op on the happy path, but guarantees the caller's store is released even if `init()` throws before clearing the internal reference.

- **refactor(xccl): add comm context to log lines and move version log to init()**
  Pass `this` to `TC_LOG` throughout so every line is tagged with the communicator (name/rank). Move the XCCL version logging from `DefaultXcclApi::setVersionInfo()` into `TorchCommXCCL::init()` so it prints with comm context, and log (rather than silently discard) a `commDestroy` failure in the destructor.