### PR TITLE
implement collective duration in flight recorder (#1312)

### DIFF
--- a/comms/torchcomms/hooks/fr/FlightRecorder.cpp
+++ b/comms/torchcomms/hooks/fr/FlightRecorder.cpp
@@ -3,6 +3,7 @@
 #include "comms/torchcomms/hooks/fr/FlightRecorder.hpp"
 #include "comms/torchcomms/hooks/common/OpNameHelper.hpp"
 
+#include <c10/core/impl/DeviceGuardImplInterface.h>
 #include <c10/util/ApproximateClock.h>
 #include <c10/util/WaitCounter.h>
 #include <c10/util/irange.h>
@@ -145,8 +146,8 @@ void FlightRecorder::record(
     std::string profiling_name,
     const std::vector<at::Tensor>& inputs,
     const std::vector<at::Tensor>& outputs,
-    c10::Event* start,
-    c10::Event* end,
+    std::unique_ptr<c10::Event> start,
+    std::unique_ptr<c10::Event> end,
     std::chrono::milliseconds timeout_ms,
     std::shared_ptr<ProcessGroupStatus> pg_status) {
   if (!enabled_) {
@@ -156,7 +157,14 @@ void FlightRecorder::record(
   auto traceback =
       torch::CapturedTraceback::gather(true, true, capture_cpp_stack_);
 
+  c10::Event* start_ptr = start.get();
+  c10::Event* end_ptr = end.get();
+
   std::lock_guard<std::mutex> guard(mutex_);
+
+  if (start) {
+    pending_events_[op_id] = EventPair{std::move(start), std::move(end)};
+  }
 
   if (all_pg_status_.find(pg_id) == all_pg_status_.end()) {
     // Current pg_status is not in FR.
@@ -178,8 +186,8 @@ void FlightRecorder::record(
       op_id,
       std::move(profiling_name),
       std::move(traceback),
-      start,
-      end,
+      start_ptr,
+      end_ptr,
       c10::getTime(),
       timeout_ms.count(),
       std::nullopt,
@@ -323,59 +331,124 @@ std::optional<FlightRecorder::Entry> FlightRecorder::getEntry(
 
 void FlightRecorder::retire_id(
     std::optional<size_t> id,
+    const at::Device& device,
     bool compute_duration) {
   if (!enabled_ || !id) {
     return;
   }
 
-  bool can_compute_duration = false;
-  c10::Event* startEvent = nullptr;
-  c10::Event* endEvent = nullptr;
-  std::optional<float> duration = std::nullopt;
+  // Move the EventPair out of pending_events_ into a local so that the
+  // events outlive any concurrent record() that may overwrite
+  // pending_events_[*id] while we release the lock below. This also
+  // serves as a single cleanup point: when this function returns (normal
+  // or via exception), the local `events` is destroyed and the map no
+  // longer holds the entry — preventing leaks on all paths.
+  EventPair events;
+  {
+    std::lock_guard<std::mutex> extract_guard(mutex_);
+    auto events_it = pending_events_.find(*id);
+    if (events_it != pending_events_.end()) {
+      events = std::move(events_it->second);
+      pending_events_.erase(events_it);
+    }
+  }
+
+  // Record end event if available. Only attempt for CUDA devices to match
+  // the gating in onPreHook; other backends never populate pending_events_.
+  //
+  // Performed WITHOUT holding mutex_: CUDA event record() and
+  // getDeviceGuardImpl() can block (stream contention, queue back-pressure,
+  // device issues) and we never want a stalled CUDA call to also stall
+  // dump() and other callers waiting on mutex_.
+  bool events_invalid = false;
+  if (events.end && device.type() == c10::DeviceType::CUDA) {
+    try {
+      auto* guard_impl = c10::impl::getDeviceGuardImpl(device.type());
+      events.end->record(guard_impl->getStream(device));
+    } catch (const std::exception&) {
+      // Device record failed; the events are unusable for timing. Reset
+      // them so the raw pointers stored on the entry (which alias them)
+      // don't get dereferenced below.
+      events.start.reset();
+      events.end.reset();
+      events_invalid = true;
+    }
+  }
 
   std::unique_lock<std::mutex> guard(mutex_);
 
   // Look up the (id_, reset_epoch_) pair for this op_id
   auto it = op_id_to_id_and_epoch_.find(*id);
   if (it == op_id_to_id_and_epoch_.end()) {
-    return; // op_id not found
+    return; // op_id not found — `events` is destroyed via RAII
   }
   auto [internal_id, reset_epoch] = it->second;
   op_id_to_id_and_epoch_.erase(it);
 
+  bool can_compute_duration = false;
   Entry* entry = &entries_.at(getIdxFromId(internal_id, reset_epoch));
   if (entry->id_ == internal_id && entry->reset_epoch_ == reset_epoch) {
+    // If we destroyed the events due to a record-time exception, the
+    // entry's raw start_/end_ pointers now reference destroyed memory.
+    // Null them out before update_state to avoid use-after-free.
+    if (events_invalid) {
+      entry->start_ = entry->end_ = nullptr;
+    }
     update_state(*entry);
 
     if (compute_duration) {
       can_compute_duration = entry->time_discovered_completed_.has_value() &&
           entry->start_ && entry->end_;
-      startEvent = entry->start_;
-      endEvent = entry->end_;
+
+      // CPU-observed elapsed-time fallback. Used when device events are
+      // unavailable (CPU backends, backends without DeviceGuardImpl) or
+      // when events exist but have not yet been observed completed.
+      //
+      // NOTE: this is NOT a device-measured kernel duration. It measures
+      // wall-clock time between when `record()` ran on the pre-hook
+      // thread and `retire_id()` ran on the post-hook thread, which
+      // includes CPU scheduling, queueing, and post-hook dispatch
+      // latency. Treat `duration_ms` in this fallback as an upper bound
+      // on the actual collective runtime, not the runtime itself.
+      if (!can_compute_duration) {
+        auto now = c10::getTime();
+        entry->duration_ =
+            static_cast<float>(now - entry->time_created_) / 1e6f; // ns to ms
+      }
     }
     entry->retired_ = true;
     entry->start_ = entry->end_ = nullptr;
   }
 
   if (can_compute_duration) {
-    // Compute duration without without holding the lock, because
+    // Compute duration without holding the lock, because
     // cudaEventDuration() can hang, and we need to acquire the lock before we
     // can dump(), which we never want to block.
+    //
+    // The events are owned by the local `events`, so they survive any
+    // concurrent record() that may have rewritten pending_events_[*id].
     guard.unlock();
-    duration = getDurationFromEvent(*startEvent, *endEvent);
+    std::optional<float> duration;
+    try {
+      duration = getDurationFromEvent(*events.start, *events.end);
+    } catch (const std::exception& e) {
+      LOG(ERROR) << "Failed to compute duration for op_id " << *id << ": "
+                 << e.what();
+    }
     guard.lock();
 
-    // Refresh the entry pointer, see if the entry has been overwritten
-    entry = &entries_.at(getIdxFromId(*id, reset_epoch));
-    if (!(entry->id_ == *id && entry->reset_epoch_ == reset_epoch)) {
+    // Refresh the entry pointer in case it was overwritten while unlocked.
+    entry = &entries_.at(getIdxFromId(internal_id, reset_epoch));
+    if (entry->id_ == internal_id && entry->reset_epoch_ == reset_epoch) {
+      if (duration.has_value()) {
+        entry->duration_ = duration;
+      }
+    } else {
       LOG(INFO) << "retire_id abandoned for id " << *id
                 << ", event was overwritten while waiting to compute duration.";
-      return;
-    }
-    if (duration.has_value()) {
-      entry->duration_ = duration;
     }
   }
+  // `events` destroyed here — single cleanup point for pending_events_.
 }
 
 void FlightRecorder::reset_all() {
@@ -786,10 +859,11 @@ void DebugInfoWriter::registerWriter(std::unique_ptr<DebugInfoWriter> writer) {
 std::unique_ptr<DebugInfoWriter> DebugInfoWriter::writer_ = nullptr;
 std::atomic<bool> DebugInfoWriter::hasWriterRegistered_(false);
 
-float getDurationFromEvent(
-    [[maybe_unused]] c10::Event& startEvent,
-    [[maybe_unused]] c10::Event& endEvent) {
-  TORCH_CHECK(false, "getDuration not supported by c10::Event.");
+float getDurationFromEvent(c10::Event& startEvent, c10::Event& endEvent) {
+  TORCH_CHECK(
+      endEvent.query(),
+      "getDurationFromEvent can only be called after the end event has completed.");
+  return static_cast<float>(startEvent.elapsedTime(endEvent));
 }
 
 // ============================================================================
@@ -836,17 +910,20 @@ void FlightRecorderHook::registerWithComm(std::shared_ptr<TorchComm> comm) {
 
   auto self = shared_from_this();
 
+  auto device = comm->getDevice();
+
   // Register pre-hook - records the operation
-  auto pre_hook_handle = comm->registerPreHook(
-      [self, comm_name, pg_id, pg_desc](size_t op_id, const PreHookArgs& args) {
-        self->onPreHook(comm_name, pg_id, pg_desc, op_id, args);
+  auto pre_hook_handle =
+      comm->registerPreHook([self, comm_name, pg_id, pg_desc, device](
+                                size_t op_id, const PreHookArgs& args) {
+        self->onPreHook(comm_name, pg_id, pg_desc, device, op_id, args);
       });
 
   // Register post-hook - called via work callback when work completes
   // The post-hook is invoked by TorchComm when the work's callback fires
-  auto post_hook_handle =
-      comm->registerPostHook([self](size_t op_id, const PostHookArgs& args) {
-        self->onPostHook(op_id, args);
+  auto post_hook_handle = comm->registerPostHook(
+      [self, device](size_t op_id, const PostHookArgs& args) {
+        self->onPostHook(device, op_id, args);
       });
 
   // Register abort hook - called before aborting to dump flight recorder data
@@ -861,6 +938,7 @@ void FlightRecorderHook::onPreHook(
     const std::string& comm_name,
     size_t pg_id,
     const std::string& pg_desc,
+    const at::Device& device,
     size_t op_id,
     const PreHookArgs& args) {
   auto name = getOpName(args);
@@ -927,8 +1005,26 @@ void FlightRecorderHook::onPreHook(
   std::string profiling_name =
       std::string(pg_desc) + ":" + std::string(opToString(name));
 
-  // TODO: Create start/end events for accurate timing
-  // For now, pass nullptr - timing will be based on CPU timestamps
+  // Create events for GPU-accurate timing on CUDA devices only.
+  // Other accelerator backends (XPU, MTIA) may not handle per-collective
+  // event creation gracefully; for those, fall back to wall-clock duration.
+  std::unique_ptr<c10::Event> start_event;
+  std::unique_ptr<c10::Event> end_event;
+  if (device.type() == c10::DeviceType::CUDA) {
+    try {
+      auto* guard_impl = c10::impl::getDeviceGuardImpl(device.type());
+      start_event = std::make_unique<c10::Event>(
+          device.type(), c10::EventFlag::BACKEND_DEFAULT);
+      end_event = std::make_unique<c10::Event>(
+          device.type(), c10::EventFlag::BACKEND_DEFAULT);
+      start_event->record(guard_impl->getStream(device));
+    } catch (const std::exception&) {
+      // Backend does not support DeviceGuardImpl or events.
+      // Fall back to no event tracking — duration will use wall-clock.
+      start_event.reset();
+      end_event.reset();
+    }
+  }
 
   recorder_->record(
       pg_id,
@@ -937,21 +1033,25 @@ void FlightRecorderHook::onPreHook(
       std::move(profiling_name),
       inputs,
       outputs,
-      nullptr, // start event
-      nullptr, // end event
+      std::move(start_event),
+      std::move(end_event),
       std::chrono::milliseconds(600000), // 10 minute default timeout
       nullptr // pg_status
   );
 }
 
-void FlightRecorderHook::onPostHook(size_t op_id, const PostHookArgs& args) {
+void FlightRecorderHook::onPostHook(
+    const at::Device& device,
+    size_t op_id,
+    const PostHookArgs& args) {
   if (!enabled_) {
     return;
   }
+
   if (std::get_if<FinalizePostHookArgs>(&args)) {
     return;
   }
-  recorder_->retire_id(op_id, false);
+  recorder_->retire_id(op_id, device, /*compute_duration=*/true);
 
   // Handle split operations - register the new communicator with flight
   // recorder

--- a/comms/torchcomms/hooks/fr/FlightRecorder.hpp
+++ b/comms/torchcomms/hooks/fr/FlightRecorder.hpp
@@ -236,8 +236,8 @@ class FlightRecorder {
       std::string profiling_name,
       const std::vector<at::Tensor>& inputs,
       const std::vector<at::Tensor>& outputs,
-      c10::Event* start,
-      c10::Event* end,
+      std::unique_ptr<c10::Event> start,
+      std::unique_ptr<c10::Event> end,
       std::chrono::milliseconds timeout_ms,
       std::shared_ptr<ProcessGroupStatus> pg_status);
 
@@ -249,17 +249,18 @@ class FlightRecorder {
 
   std::vector<Entry> dump_entries();
 
-  /*
-  Mark an Event as completed and free its events.
-  This is called by the watchdog thread, and is asynchronous from the
-  perspective of the main thread.
-  compute_duration defaults to true since retire_id is only called in the
-  watchdog thread, which is currently a place we call cuda APIs which may hang,
-  but care should be taken to avoid computing duration in any function that must
-  never hang. (timing must also be enabled for compute_duration - see
-  TORCH_NCCL_ENABLE_TIMING).
-  */
-  void retire_id(std::optional<size_t> id, bool compute_duration = true);
+  // Stores start/end events per op_id for GPU-accurate timing.
+  struct EventPair {
+    std::unique_ptr<c10::Event> start;
+    std::unique_ptr<c10::Event> end;
+  };
+
+  // Record end event on the device stream, retire the entry, and cleanup
+  // stored events. Acquires mutex_ internally.
+  void retire_id(
+      std::optional<size_t> id,
+      const at::Device& device,
+      bool compute_duration = true);
 
   void reset_all();
 
@@ -329,6 +330,9 @@ class FlightRecorder {
   std::string comm_lib_version_;
   // Map from op_id to (id_, reset_epoch_) to pass correct values when retiring
   std::unordered_map<size_t, std::pair<size_t, size_t>> op_id_to_id_and_epoch_;
+
+  // Pending events for GPU-accurate timing, keyed by op_id.
+  std::unordered_map<size_t, EventPair> pending_events_;
 };
 
 // ============================================================================
@@ -418,14 +422,17 @@ class FlightRecorderHook
       const std::string& comm_name,
       size_t pg_id,
       const std::string& pg_desc,
+      const at::Device& device,
       size_t op_id,
       const PreHookArgs& args);
 
-  void onPostHook(size_t op_id, const PostHookArgs& args);
+  void
+  onPostHook(const at::Device& device, size_t op_id, const PostHookArgs& args);
 
   FlightRecorder* recorder_;
   bool owns_recorder_{false}; // True when using isolated instance
 
+  // Track registered communicators
   struct CommRegistration {
     std::weak_ptr<TorchComm> comm;
     size_t pg_id;

--- a/comms/torchcomms/hooks/fr/tests/py/FlightRecorderTest.py
+++ b/comms/torchcomms/hooks/fr/tests/py/FlightRecorderTest.py
@@ -1188,6 +1188,129 @@ class TestFlightRecorderHook(unittest.TestCase):
         level1_comm.finalize()
         comm.finalize()
 
+    def test_duration_recorded_for_collective(self) -> None:
+        """Test that duration_ms is recorded for collective operations.
+
+        For CPU backends, duration is computed from wall-clock timestamps.
+        For device backends, duration is computed from device events.
+        In both cases, retired entries should have a positive duration_ms.
+        """
+        backend = os.environ["TEST_BACKEND"]
+        device = torch.device(os.environ.get("TEST_DEVICE", "cuda"))
+        comm = torchcomms.new_comm(
+            backend=backend,
+            device=device,
+            name="test_duration",
+            timeout=timedelta(seconds=300),
+        )
+
+        recorder = FlightRecorderHook(max_entries=100, isolated=True)
+        recorder.register_with_comm(comm)
+
+        # Run a collective operation
+        t = torch.rand(10, 10, device=device)
+        comm.all_reduce(t, op=torchcomms.ReduceOp.SUM, async_op=False)
+
+        # Wait for the work to complete so postHook fires
+        # (for CPU backends this is synchronous, for CUDA we need to sync)
+        if device.type == "cuda":
+            torch.cuda.synchronize(device)
+
+        # Parse JSON and check duration
+        json_str = recorder.dump_json()
+        data = json.loads(json_str)
+        entries = data.get("entries", [])
+        self.assertGreater(len(entries), 0, "Should have at least one entry")
+
+        entry = entries[0]
+        self._validate_entry_format(entry)
+        self.assertTrue(entry["retired"], "Entry should be retired")
+        self.assertIn("duration_ms", entry, "Retired entry should have duration_ms")
+        self.assertGreater(entry["duration_ms"], 0, "duration_ms should be positive")
+
+        comm.finalize()
+
+    def test_duration_recorded_for_multiple_operations(self) -> None:
+        """Test that duration_ms is recorded for multiple different operations."""
+        backend = os.environ["TEST_BACKEND"]
+        device = torch.device(os.environ.get("TEST_DEVICE", "cuda"))
+        comm = torchcomms.new_comm(
+            backend=backend,
+            device=device,
+            name="test_duration_multi",
+            timeout=timedelta(seconds=300),
+        )
+
+        recorder = FlightRecorderHook(max_entries=100, isolated=True)
+        recorder.register_with_comm(comm)
+
+        t = torch.rand(10, 10, device=device)
+
+        # Run several different collective operations
+        comm.all_reduce(t, op=torchcomms.ReduceOp.SUM, async_op=False)
+        comm.broadcast(t, root=0, async_op=False)
+        comm.barrier(async_op=False)
+
+        if device.type == "cuda":
+            torch.cuda.synchronize(device)
+
+        json_str = recorder.dump_json()
+        data = json.loads(json_str)
+        entries = data.get("entries", [])
+        self.assertGreaterEqual(len(entries), 3, "Should have at least 3 entries")
+
+        for entry in entries:
+            self._validate_entry_format(entry)
+            self.assertTrue(entry["retired"], "Entry should be retired")
+            self.assertIn(
+                "duration_ms",
+                entry,
+                f"Entry {entry['profiling_name']} missing duration",
+            )
+            self.assertGreater(
+                entry["duration_ms"],
+                0,
+                f"duration_ms should be positive for {entry['profiling_name']}",
+            )
+
+        comm.finalize()
+
+    def test_duration_ordering(self) -> None:
+        """Test that a longer operation has greater or equal duration."""
+        backend = os.environ["TEST_BACKEND"]
+        device = torch.device(os.environ.get("TEST_DEVICE", "cuda"))
+        comm = torchcomms.new_comm(
+            backend=backend,
+            device=device,
+            name="test_duration_order",
+            timeout=timedelta(seconds=300),
+        )
+
+        recorder = FlightRecorderHook(max_entries=100, isolated=True)
+        recorder.register_with_comm(comm)
+
+        # Small tensor - should be fast
+        t_small = torch.rand(1, device=device)
+        comm.all_reduce(t_small, op=torchcomms.ReduceOp.SUM, async_op=False)
+
+        # Large tensor - should take longer (or at least not less)
+        t_large = torch.rand(1000, 1000, device=device)
+        comm.all_reduce(t_large, op=torchcomms.ReduceOp.SUM, async_op=False)
+
+        if device.type == "cuda":
+            torch.cuda.synchronize(device)
+
+        json_str = recorder.dump_json()
+        data = json.loads(json_str)
+        entries = data.get("entries", [])
+        self.assertEqual(len(entries), 2, "Should have exactly 2 entries")
+
+        for entry in entries:
+            self.assertIn("duration_ms", entry)
+            self.assertGreater(entry["duration_ms"], 0)
+
+        comm.finalize()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary:

Enable collective operation duration tracking in the flight recorder.

The flight recorder previously had no timing support for collective operations—start/end events were stubbed as nullptr and `getDurationFromEvent` was hardcoded to fail.

This change wires up `c10::Event`-based GPU-accurate timing around backend calls, with a CPU wall-clock fallback for non-device backends, so that every retired entry now reports a meaningful `duration_ms`.

Reviewed By: d4l3k

Differential Revision: D98504353


