### PR TITLE
Add scuba algo profiling to all ctran AllGather algorithms (#1313)

### DIFF
--- a/comms/ctran/algos/AllGather/AllGatherBrucksFF.cc
+++ b/comms/ctran/algos/AllGather/AllGatherBrucksFF.cc
@@ -2,6 +2,7 @@
 
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/AllGather/AllGatherImpl.h"
+#include "comms/ctran/profiler/Profiler.h"
 #include "comms/ctran/utils/DevUtils.cuh"
 
 static const auto myAlgo = NCCL_ALLGATHER_ALGO::ctbrucks;
@@ -75,6 +76,12 @@ static commResult_t impl(
 
   CtranAlgoLogger logger(allGatherAlgoName(myAlgo), op->opCount, comm);
 
+  ctran::Profiler* profiler = comm->ctran_->profiler.get();
+  if (profiler) {
+    profiler->initForEachColl(
+        op->opCount, NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT);
+  }
+
   void* memHdl;
   std::vector<void*> remoteRecvBuffs(nSteps);
   std::vector<struct CtranMapperRemoteAccessKey> remoteAccessKeys(nSteps);
@@ -91,9 +98,23 @@ static commResult_t impl(
       allGatherAlgoName(myAlgo), sendSize, sendSize * nRanks);
   comm->ctran_->mapper->setContext(std::move(context));
 
+  CTRAN_PROFILER_IF(profiler, {
+    auto& algoContext = profiler->algoContext;
+    algoContext.algorithmName = allGatherAlgoName(myAlgo);
+    algoContext.sendContext.messageSizes = std::to_string(sendSize);
+    algoContext.recvContext.messageSizes = std::to_string(sendSize * nRanks);
+  });
+
   bool localMemReg{false};
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::BUF_REG));
   FB_COMMCHECK(comm->ctran_->mapper->searchRegHandle(
       recvbuff, nRanks * sendSize, &memHdl, &localMemReg));
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::BUF_REG));
+
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_CTRL));
 
   // Post receives for memory handles
   for (size_t i = 0; i < nSteps; i++) {
@@ -125,6 +146,11 @@ static commResult_t impl(
   auto dstPeer = dstAtStep(nRanks, rank, 0);
   FB_COMMCHECK(comm->ctran_->mapper->waitRequest(irecvReq[0].get()));
   timestamp->recvCtrl.push_back(CtranMapperTimestampPoint(dstPeer));
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_CTRL));
+
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_DATA));
 
   // Post first half of pipelined message
   CtranMapperRequest* putReqPtr = nullptr;
@@ -238,6 +264,9 @@ static commResult_t impl(
     timestamp->putComplete.push_back(CtranMapperTimestampPoint(dstPeer));
   }
 
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_DATA));
+
   for (int i = 0; i < nSteps; i++) {
     FB_COMMCHECK(comm->ctran_->mapper->waitRequest(isendReq[i].get()));
   }
@@ -245,6 +274,8 @@ static commResult_t impl(
   if (localMemReg) {
     FB_COMMCHECK(comm->ctran_->mapper->deregDynamic(memHdl));
   }
+
+  CTRAN_PROFILER_IF(profiler, { profiler->reportToScuba(); });
 
   comm->ctran_->mapper->timestamps.push_back(std::move(timestamp));
   comm->ctran_->mapper->reportProfiling();

--- a/comms/ctran/algos/AllGather/AllGatherDirect.cc
+++ b/comms/ctran/algos/AllGather/AllGatherDirect.cc
@@ -7,6 +7,7 @@
 #include "comms/ctran/algos/AllGather/AllGatherImpl.h"
 #include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/ctran/mapper/CtranMapper.h"
+#include "comms/ctran/profiler/Profiler.h"
 #include "comms/ctran/utils/ExtUtils.h"
 
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -24,6 +25,12 @@ static commResult_t impl(
   CtranComm* comm = opGroup.front()->comm_;
 
   CtranAlgoLogger logger(allGatherAlgoName(myAlgo), op->opCount, comm);
+
+  ctran::Profiler* profiler = comm->ctran_->profiler.get();
+  if (profiler) {
+    profiler->initForEachColl(
+        op->opCount, NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT);
+  }
 
   const auto statex = comm->statex_.get();
   const int rank = statex->rank();
@@ -47,8 +54,23 @@ static commResult_t impl(
   CtranMapperContext context(
       allGatherAlgoName(myAlgo), sendSize, sendSize * nRanks);
   comm->ctran_->mapper->setContext(std::move(context));
+
+  CTRAN_PROFILER_IF(profiler, {
+    auto& algoContext = profiler->algoContext;
+    algoContext.algorithmName = allGatherAlgoName(myAlgo);
+    algoContext.sendContext.messageSizes = std::to_string(sendSize);
+    algoContext.recvContext.messageSizes = std::to_string(sendSize * nRanks);
+  });
+
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::BUF_REG));
   FB_COMMCHECK(comm->ctran_->mapper->searchRegHandle(
       op->allgather.recvbuff, nRanks * sendSize, &memHdl, &localMemReg));
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::BUF_REG));
+
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_CTRL));
 
   // Issue control messages for send and recv operations
   for (int p = 1; p < nRanks; p++) {
@@ -101,6 +123,9 @@ static commResult_t impl(
 
   elem->post();
 
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_DATA));
+
   // Post remaining inter-node puts
   bool pendingRecv;
   do {
@@ -140,6 +165,9 @@ static commResult_t impl(
     }
   } while (pendingRecv == true);
 
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_CTRL));
+
   // Wait for all PUTs to complete
   for (int p = 1; p < nRanks; p++) {
     int peer = (rank + p) % nRanks;
@@ -161,9 +189,14 @@ static commResult_t impl(
   // Wait for intranode bcast to complete
   elem->wait();
 
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_DATA));
+
   if (localMemReg) {
     FB_COMMCHECK(comm->ctran_->mapper->deregDynamic(memHdl));
   }
+
+  CTRAN_PROFILER_IF(profiler, { profiler->reportToScuba(); });
 
   comm->ctran_->mapper->timestamps.emplace_back(std::move(timestamp));
   comm->ctran_->mapper->reportProfiling();

--- a/comms/ctran/algos/AllGather/AllGatherRecDbl.cc
+++ b/comms/ctran/algos/AllGather/AllGatherRecDbl.cc
@@ -3,6 +3,7 @@
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/AllGather/AllGatherImpl.h"
 #include "comms/ctran/algos/CtranAlgo.h"
+#include "comms/ctran/profiler/Profiler.h"
 #include "comms/ctran/utils/DevUtils.cuh"
 #include "comms/utils/cvars/nccl_cvars.h"
 
@@ -22,6 +23,12 @@ static commResult_t impl(
 
   CtranAlgoLogger logger(allGatherAlgoName(myAlgo), op->opCount, comm);
 
+  ctran::Profiler* profiler = comm->ctran_->profiler.get();
+  if (profiler) {
+    profiler->initForEachColl(
+        op->opCount, NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT);
+  }
+
   void* memHdl;
   std::vector<size_t> peers(nSteps);
   std::vector<size_t> dists(nSteps);
@@ -39,6 +46,13 @@ static commResult_t impl(
       allGatherAlgoName(myAlgo), sendSize, sendSize * nRanks);
   comm->ctran_->mapper->setContext(std::move(context));
 
+  CTRAN_PROFILER_IF(profiler, {
+    auto& algoContext = profiler->algoContext;
+    algoContext.algorithmName = allGatherAlgoName(myAlgo);
+    algoContext.sendContext.messageSizes = std::to_string(sendSize);
+    algoContext.recvContext.messageSizes = std::to_string(sendSize * nRanks);
+  });
+
   bool localMemReg{false};
 
   // Calculate distance and peer per step
@@ -48,9 +62,15 @@ static commResult_t impl(
     peers[i] = pos == 0 ? rank + dists[i] : rank - dists[i];
   }
 
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::BUF_REG));
   FB_COMMCHECK(comm->ctran_->mapper->searchRegHandle(
       recvbuff, nRanks * sendSize, &memHdl, &localMemReg));
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::BUF_REG));
 
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_CTRL));
   // Exchange memory handles with relevant peers
   for (size_t i = 0; i < nSteps; i++) {
     auto peer = peers[i];
@@ -71,9 +91,14 @@ static commResult_t impl(
     FB_COMMCHECK(
         comm->ctran_->mapper->initNotify(peer, memHdl, notifyVec[i].get()));
   }
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_CTRL));
 
   for (size_t i = 0; i < nSteps; i++) {
     auto peer = peers[i];
+    // Measure only the ctrl wait time (accumulates across steps)
+    CTRAN_PROFILER_IF(
+        profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_CTRL));
 
     if (NCCL_CTRAN_AG_RD_RTR) {
       CtranMapperRequest* sendReq = nullptr;
@@ -85,6 +110,13 @@ static commResult_t impl(
     // Block until we have handle for this peer
     FB_COMMCHECK(comm->ctran_->mapper->waitRequest(irecvReq[i].get()));
     timestamp->recvCtrl.push_back(CtranMapperTimestampPoint(peer));
+
+    CTRAN_PROFILER_IF(
+        profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_CTRL));
+
+    // Measure only data transfer time (accumulates across steps)
+    CTRAN_PROFILER_IF(
+        profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_DATA));
 
     for (size_t j = 0; j < (1 << i); j++) {
       size_t putOffset = j * (nRanks / (1 << i)) + rank % (nRanks / (1 << i));
@@ -126,6 +158,9 @@ static commResult_t impl(
     // Capture duration ended at last put when it is completed
     timestamp->putComplete.push_back(CtranMapperTimestampPoint(peer));
     FB_COMMCHECK(comm->ctran_->mapper->waitNotify(notifyVec[i].get()));
+
+    CTRAN_PROFILER_IF(
+        profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_DATA));
   }
 
   for (int i = 0; i < nSteps; i++) {
@@ -135,6 +170,8 @@ static commResult_t impl(
   if (localMemReg) {
     FB_COMMCHECK(comm->ctran_->mapper->deregDynamic(memHdl));
   }
+
+  CTRAN_PROFILER_IF(profiler, { profiler->reportToScuba(); });
 
   comm->ctran_->mapper->timestamps.push_back(std::move(timestamp));
   comm->ctran_->mapper->reportProfiling();

--- a/comms/ctran/algos/AllGather/AllGatherRing.cc
+++ b/comms/ctran/algos/AllGather/AllGatherRing.cc
@@ -5,6 +5,7 @@
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/AllGather/AllGatherImpl.h"
 #include "comms/ctran/algos/CtranAlgo.h"
+#include "comms/ctran/profiler/Profiler.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
 struct PutQElem {
@@ -33,9 +34,22 @@ static commResult_t impl(
 
   CtranAlgoLogger logger(allGatherAlgoName(myAlgo), op->opCount, comm);
 
+  ctran::Profiler* profiler = comm->ctran_->profiler.get();
+  if (profiler) {
+    profiler->initForEachColl(
+        op->opCount, NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT);
+  }
+
   CtranMapperContext context(
       allGatherAlgoName(myAlgo), sendSize, sendSize * nRanks);
   mapper->setContext(std::move(context));
+
+  CTRAN_PROFILER_IF(profiler, {
+    auto& algoContext = profiler->algoContext;
+    algoContext.algorithmName = allGatherAlgoName(myAlgo);
+    algoContext.sendContext.messageSizes = std::to_string(sendSize);
+    algoContext.recvContext.messageSizes = std::to_string(sendSize * nRanks);
+  });
 
   if (nRanks == 1) {
     return commSuccess;
@@ -61,8 +75,15 @@ static commResult_t impl(
   uint64_t blockNum{0};
   uint64_t stepInBlock{0};
 
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::BUF_REG));
   FB_COMMCHECK(mapper->searchRegHandle(
       op->allgather.recvbuff, nRanks * sendSize, &memHdl, &localMemReg));
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::BUF_REG));
+
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_CTRL));
 
   CtranMapperRequest* req = nullptr;
   FB_COMMCHECK(
@@ -74,10 +95,15 @@ static commResult_t impl(
 
   FB_COMMCHECK(mapper->waitRequest(irecvReq.get()));
   timestamp->recvCtrl.push_back(CtranMapperTimestampPoint(right));
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_CTRL));
 
   // Initialize notify flag to receive from left
   notifyLeft = std::make_unique<CtranMapperNotify>();
   FB_COMMCHECK(mapper->initNotify(left, memHdl, notifyLeft.get()));
+
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_DATA));
 
   // Push addresses for first block onto deque
   for (int i = 0; i < stepsPerBlock; ++i) {
@@ -144,11 +170,16 @@ static commResult_t impl(
     }
   }
 
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_DATA));
+
   FB_COMMCHECK(mapper->waitRequest(isendReq.get()));
 
   if (localMemReg) {
     FB_COMMCHECK(mapper->deregDynamic(memHdl));
   }
+
+  CTRAN_PROFILER_IF(profiler, { profiler->reportToScuba(); });
 
   mapper->timestamps.push_back(std::move(timestamp));
   mapper->reportProfiling();

--- a/comms/ctran/tests/CtranDistAllgatherTests.cc
+++ b/comms/ctran/tests/CtranDistAllgatherTests.cc
@@ -12,6 +12,7 @@
 #include "comms/ctran/algos/AllGather/AllGatherImpl.h"
 #include "comms/ctran/algos/AllReduce/AllReduceImpl.h"
 #include "comms/ctran/colltrace/CollTraceWrapper.h"
+#include "comms/ctran/profiler/Profiler.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsCuUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
@@ -39,10 +40,35 @@ class CtranAllgatherTest : public CtranDistBaseTest {
     setenv("NCCL_COLLTRACE_USE_NEW_COLLTRACE", "1", 0);
     // -1 for not limiting the number of colls to trace
     setenv("NCCL_COLLTRACE_RECORD_MAX", "-1", 0);
+    setenv("NCCL_CTRAN_TRANSPORT_PROFILER", "1", 0);
+    setenv("NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT", "1", 0);
     CtranDistBaseTest::SetUp();
     comm = commWorld;
     segments.clear();
     segHandles.clear();
+  }
+
+  static void checkProfiler(ctran::Profiler* profiler) {
+    if (!profiler) {
+      return;
+    }
+    uint64_t algoTotal =
+        profiler->getEventDurationUs(ctran::ProfilerEvent::ALGO_TOTAL);
+    uint64_t algoCtrl =
+        profiler->getEventDurationUs(ctran::ProfilerEvent::ALGO_CTRL);
+    uint64_t algoData =
+        profiler->getEventDurationUs(ctran::ProfilerEvent::ALGO_DATA);
+    uint64_t bufReg =
+        profiler->getEventDurationUs(ctran::ProfilerEvent::BUF_REG);
+    uint64_t oneMinUs = 1000 * 1000 * 60;
+    EXPECT_GE(algoTotal, 0);
+    EXPECT_LE(algoTotal, oneMinUs);
+    EXPECT_GE(algoCtrl, 0);
+    EXPECT_LE(algoCtrl, oneMinUs);
+    EXPECT_GE(algoData, 0);
+    EXPECT_LE(algoData, oneMinUs);
+    EXPECT_GE(bufReg, 0);
+    EXPECT_LE(bufReg, oneMinUs);
   }
 
   void TearDown() override {
@@ -191,6 +217,9 @@ TEST_P(CtranAllgatherTestParam, AllgatherAlgo) {
       EXPECT_EQ(res, commSuccess);
     }
     CUDACHECK_TEST(cudaStreamSynchronize(stream));
+
+    // Verify profiler event durations are populated
+    checkProfiler(comm->ctranComm_->ctran_->profiler.get());
   }
 
   size_t sCommBytes = count * commTypeSize(dt);


### PR DESCRIPTION
Summary:

All ctran AllGather algorithms (RecursiveDoubling, Ring, Direct, BrucksFF) were
missing the ctran::Profiler integration that SendRecv and AllToAllv already
have. This adds the same profiling instrumentation so that AllGather collectives
are logged to the nccl_profiler_algo scuba table with timing breakdowns for
buffer registration, control sync, and data transfer phases.

After this change, rows with algorithmName in {CtranAllGatherRd,
CtranAllGatherRing, CtranAllGatherDirect, CtranBrucksFF} will
appear in the nccl_profiler_algo scuba table.

Reviewed By: minsii

Differential Revision: D98528576


