### PR TITLE
add cvar to config CQ max length (#1314)

### DIFF
--- a/comms/ctran/backends/ib/CtranIb.cc
+++ b/comms/ctran/backends/ib/CtranIb.cc
@@ -296,7 +296,8 @@ CtranIb::CtranIb(
     CtranComm* comm,
     CtranCtrlManager* ctrlMgr,
     std::optional<bool> enableLocalFlush,
-    std::shared_ptr<ctran::bootstrap::ISocketFactory> socketFactory)
+    std::shared_ptr<ctran::bootstrap::ISocketFactory> socketFactory,
+    std::optional<int> maxNumCqe)
     : comm(comm) {
   // enableLocalFlush: whether to support local flush. If true, CtranIb
   // will enable resource required for local flush.
@@ -325,7 +326,8 @@ CtranIb::CtranIb(
       BootstrapMode::kDefaultServer,
       std::nullopt,
       ::ctran::utils::createAbort(/*enabled=*/false),
-      socketFactory);
+      socketFactory,
+      maxNumCqe);
   CLOGF_SUBSYS(
       INFO,
       INIT,
@@ -347,7 +349,8 @@ CtranIb::CtranIb(
     const BootstrapMode bootstrapMode,
     std::optional<const SocketServerAddr*> qpServerAddr,
     std::shared_ptr<Abort> abortCtrl,
-    std::shared_ptr<ctran::bootstrap::ISocketFactory> socketFactory) {
+    std::shared_ptr<ctran::bootstrap::ISocketFactory> socketFactory,
+    std::optional<int> maxNumCqe) {
   init(
       nullptr,
       rank,
@@ -359,7 +362,8 @@ CtranIb::CtranIb(
       bootstrapMode,
       qpServerAddr,
       abortCtrl,
-      socketFactory);
+      socketFactory,
+      maxNumCqe);
 
   CLOGF_SUBSYS(
       INFO,
@@ -383,7 +387,8 @@ void CtranIb::init(
     const BootstrapMode bootstrapMode,
     std::optional<const SocketServerAddr*> qpServerAddr,
     std::shared_ptr<Abort> abortCtrl,
-    std::shared_ptr<ctran::bootstrap::ISocketFactory> socketFactory) {
+    std::shared_ptr<ctran::bootstrap::ISocketFactory> socketFactory,
+    std::optional<int> maxNumCqe) {
   bool foundPort = false;
   this->comm = comm;
   this->rank = rank;
@@ -539,6 +544,24 @@ void CtranIb::init(
 #else
     maxCqe = devAttr.max_cqe;
 #endif
+
+    // Cap CQ size to avoid excessive memory usage.
+    // Per-transport maxNumCqe takes precedence over env
+    // NCCL_CTRAN_IB_MAX_NUM_CQE. Default -1 (or nullopt) to use the
+    // device-reported maximum.
+    const int cqeCap = maxNumCqe.value_or(NCCL_CTRAN_IB_MAX_NUM_CQE);
+    if (cqeCap > 0 && maxCqe > cqeCap) {
+      CLOGF(
+          INFO,
+          "CTRAN-IB: Capping CQ size from {} to {} ({}) to reduce memory overhead",
+          maxCqe,
+          cqeCap,
+          maxNumCqe.has_value() ? "per-transport"
+                                : "NCCL_CTRAN_IB_MAX_NUM_CQE");
+      maxCqe = cqeCap;
+    } else {
+      CLOGF(INFO, "CTRAN-IB: CQ size is {}", maxCqe);
+    }
 
     // Skip lock for cq and localVc in constructor since no other thread can
     // access it yet.

--- a/comms/ctran/backends/ib/CtranIb.h
+++ b/comms/ctran/backends/ib/CtranIb.h
@@ -51,8 +51,8 @@ class CtranIb {
       CtranComm* comm,
       CtranCtrlManager* ctrlMgr,
       std::optional<bool> enableLocalFlush = std::nullopt,
-      std::shared_ptr<ctran::bootstrap::ISocketFactory> socketFactory =
-          nullptr);
+      std::shared_ptr<ctran::bootstrap::ISocketFactory> socketFactory = nullptr,
+      std::optional<int> maxNumCqe = std::nullopt);
 
   // Creates local IB resources without pre-existing communicator. It is used
   // for use cases directly control the local transport (see CtranEx). In
@@ -86,8 +86,8 @@ class CtranIb {
       std::optional<const SocketServerAddr*> qpServerAddr = std::nullopt,
       std::shared_ptr<Abort> abortCtrl =
           ::ctran::utils::createAbort(/*enabled=*/false),
-      std::shared_ptr<ctran::bootstrap::ISocketFactory> socketFactory =
-          nullptr);
+      std::shared_ptr<ctran::bootstrap::ISocketFactory> socketFactory = nullptr,
+      std::optional<int> maxNumCqe = std::nullopt);
 
   ~CtranIb();
 
@@ -496,6 +496,10 @@ class CtranIb {
     return commDesc;
   }
 
+  int getMaxCqe() const {
+    return maxCqe;
+  }
+
  private:
   friend class CtranIbRequest;
   void init(
@@ -510,8 +514,8 @@ class CtranIb {
       std::optional<const SocketServerAddr*> qpServerAddr = std::nullopt,
       std::shared_ptr<Abort> abortCtrl =
           ::ctran::utils::createAbort(/*enabled=*/false),
-      std::shared_ptr<ctran::bootstrap::ISocketFactory> socketFactory =
-          nullptr);
+      std::shared_ptr<ctran::bootstrap::ISocketFactory> socketFactory = nullptr,
+      std::optional<int> maxNumCqe = std::nullopt);
 
   void bootstrapStart(std::optional<const SocketServerAddr*> qpServerAddr);
   static void bootstrapAccept(CtranIb* ib);

--- a/comms/ctran/backends/ib/tests/CtranIbBootstrapTest.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbBootstrapTest.cc
@@ -125,7 +125,8 @@ std::unique_ptr<CtranIb> createCtranIb(
     CtranIb::BootstrapMode mode,
     AbortPtr abortCtrl,
     std::optional<const SocketServerAddr*> qpServerAddr = std::nullopt,
-    std::shared_ptr<ctran::bootstrap::ISocketFactory> socketFactory = nullptr) {
+    std::shared_ptr<ctran::bootstrap::ISocketFactory> socketFactory = nullptr,
+    std::optional<int> maxNumCqe = std::nullopt) {
   const uint64_t commHash = 0x12345678;
   const std::string commDesc = "test";
 
@@ -144,7 +145,8 @@ std::unique_ptr<CtranIb> createCtranIb(
       mode,
       qpServerAddr,
       abortCtrl,
-      socketFactory);
+      socketFactory,
+      maxNumCqe);
 }
 // Helper class to run two-rank tests with address exchange
 class TwoRankTestHelper {
@@ -244,8 +246,8 @@ class CtranIbBootstrapTestBase : public ::testing::Test {
       CtranIb::BootstrapMode mode,
       AbortPtr abortCtrl,
       std::optional<const SocketServerAddr*> qpServerAddr = std::nullopt,
-      std::shared_ptr<ctran::bootstrap::ISocketFactory> socketFactory =
-          nullptr) {
+      std::shared_ptr<ctran::bootstrap::ISocketFactory> socketFactory = nullptr,
+      std::optional<int> maxNumCqe = std::nullopt) {
     const uint64_t commHash = 0x12345678;
     const std::string commDesc = "test";
 
@@ -264,7 +266,8 @@ class CtranIbBootstrapTestBase : public ::testing::Test {
         mode,
         qpServerAddr,
         abortCtrl,
-        socketFactory);
+        socketFactory,
+        maxNumCqe);
   }
 };
 
@@ -1426,4 +1429,48 @@ TEST_P(CtranIbBootstrapParameterizedTest, ListenAddrConsistency) {
       addr1.value().getIPAddress().str(), addr2.value().getIPAddress().str());
   EXPECT_EQ(
       addr1.value().getIPAddress().str(), addr3.value().getIPAddress().str());
+}
+
+// Test NCCL_CTRAN_IB_MAX_NUM_CQE: global cvar, per-transport, and precedence
+TEST_F(CtranIbBootstrapCommonTest, MaxNumCqe) {
+  unsetenv("NCCL_CTRAN_IB_MAX_NUM_CQE");
+  ncclCvarInit();
+  SCOPE_EXIT {
+    unsetenv("NCCL_CTRAN_IB_MAX_NUM_CQE");
+    ncclCvarInit();
+  };
+
+  auto makeIb = [&](std::optional<int> maxNumCqe = std::nullopt) {
+    auto abortCtrl = ctran::utils::createAbort(/*enabled=*/true);
+    return createCtranIb(
+        /*rank=*/0,
+        CtranIb::BootstrapMode::kDefaultServer,
+        abortCtrl,
+        std::nullopt,
+        nullptr,
+        maxNumCqe);
+  };
+
+  // Default: no cap, uses device-reported max
+  const int deviceMaxCqe = makeIb()->getMaxCqe();
+  EXPECT_GT(deviceMaxCqe, 2048);
+
+  // Global CVAR cap
+  setenv("NCCL_CTRAN_IB_MAX_NUM_CQE", "4096", 1);
+  ncclCvarInit();
+  EXPECT_EQ(makeIb()->getMaxCqe(), 4096);
+
+  // nullopt falls through to CVAR
+  EXPECT_EQ(makeIb(std::nullopt)->getMaxCqe(), 4096);
+
+  // Per-transport cap overrides CVAR (smaller)
+  EXPECT_EQ(makeIb(2048)->getMaxCqe(), 2048);
+
+  // Per-transport cap overrides CVAR (larger)
+  EXPECT_EQ(makeIb(8192)->getMaxCqe(), 8192);
+
+  // Per-transport cap without CVAR
+  unsetenv("NCCL_CTRAN_IB_MAX_NUM_CQE");
+  ncclCvarInit();
+  EXPECT_EQ(makeIb(2048)->getMaxCqe(), 2048);
 }

--- a/comms/torchcomms/transport/RdmaTransport.cpp
+++ b/comms/torchcomms/transport/RdmaTransport.cpp
@@ -100,7 +100,10 @@ struct RdmaTransport::Work {
   std::chrono::steady_clock::time_point creationTime;
 };
 
-RdmaTransport::RdmaTransport(int cudaDev, folly::EventBase* evb)
+RdmaTransport::RdmaTransport(
+    int cudaDev,
+    folly::EventBase* evb,
+    std::optional<int> maxNumCqe)
     : cudaDev_(cudaDev), evb_(evb) {
   initEnvironment();
   // Create IB Instance
@@ -111,7 +114,11 @@ RdmaTransport::RdmaTransport(int cudaDev, folly::EventBase* evb)
       "RDMA-Transport",
       nullptr /* ctrlManager */,
       true /* enableLocalFlush */,
-      CtranIb::BootstrapMode::kExternal);
+      CtranIb::BootstrapMode::kExternal,
+      std::nullopt /* qpServerAddr */,
+      ::ctran::utils::createAbort(/*enabled=*/false),
+      nullptr /* socketFactory */,
+      maxNumCqe);
 
   if (evb_) {
     // Optionally create progress timeout; skip it if the transport is never

--- a/comms/torchcomms/transport/RdmaTransport.h
+++ b/comms/torchcomms/transport/RdmaTransport.h
@@ -316,8 +316,13 @@ class __attribute__((visibility("default"))) RdmaTransport {
    * cudaDev - Transport needs to use NIC for I/O. It does so by identifying
    *           the NIC associated with specified cudaDevice.
    * evb - EventLoop to drive the RDMA operations.
+   * maxNumCqe - Optional per-transport CQ size cap. When set, overrides
+   *             the global NCCL_CTRAN_IB_MAX_NUM_CQE env var.
    */
-  explicit RdmaTransport(int cudaDev, folly::EventBase* evb = nullptr);
+  explicit RdmaTransport(
+      int cudaDev,
+      folly::EventBase* evb = nullptr,
+      std::optional<int> maxNumCqe = std::nullopt);
 
   ~RdmaTransport();
 

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1517,6 +1517,16 @@ cvars:
      complete and CQEs are generated, new messages will be posted to keep the
      send queue full of this many WQEs.
 
+ - name        : NCCL_CTRAN_IB_MAX_NUM_CQE
+   type        : int
+   default     : -1
+   description : |-
+     Maximum number of Completion Queue Entries (CQEs). When set to a
+     positive value, caps the CQ size to reduce memory overhead. ConnectX
+     NICs report max_cqe ~4M which causes the driver to allocate ~256MB
+     per CQ. For example, setting to 32768 keeps per-CQ memory at ~2MB.
+     Default -1 to use the device-reported maximum.
+
  - name        : NCCL_CTRAN_IB_DEVICES_PER_RANK
    type        : int
    default     : 1

--- a/comms/utils/cvars/tests/CvarUT.cc
+++ b/comms/utils/cvars/tests/CvarUT.cc
@@ -221,6 +221,28 @@ TEST_F(CvarTest, CvarMapsPopulation) {
   unsetenv("__NCCL_UNIT_TEST_INT64_T_CVAR__");
 }
 
+// Test NCCL_CTRAN_IB_MAX_NUM_CQE cvar reads correct values
+TEST_F(CvarTest, CtranIbMaxCqSize_DefaultNoCap) {
+  // Default -1 to use the device-reported maximum
+  unsetenv("NCCL_CTRAN_IB_MAX_NUM_CQE");
+  ncclCvarInit();
+  EXPECT_EQ(NCCL_CTRAN_IB_MAX_NUM_CQE, -1);
+}
+
+TEST_F(CvarTest, CtranIbMaxCqSize_SetCap) {
+  setenv("NCCL_CTRAN_IB_MAX_NUM_CQE", "32768", 1);
+  ncclCvarInit();
+  EXPECT_EQ(NCCL_CTRAN_IB_MAX_NUM_CQE, 32768);
+  unsetenv("NCCL_CTRAN_IB_MAX_NUM_CQE");
+}
+
+TEST_F(CvarTest, CtranIbMaxCqSize_CustomCap) {
+  setenv("NCCL_CTRAN_IB_MAX_NUM_CQE", "65536", 1);
+  ncclCvarInit();
+  EXPECT_EQ(NCCL_CTRAN_IB_MAX_NUM_CQE, 65536);
+  unsetenv("NCCL_CTRAN_IB_MAX_NUM_CQE");
+}
+
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::AddGlobalTestEnvironment(new NCCLEnvironment);


### PR DESCRIPTION
Summary:
# Why we need configurable CQE cap

Problem: ConnectX NICs report max_cqe ~4M (4,194,303), which causes the IB driver to allocate ~256MB per Completion Queue. Each CtranIb instance creates one CQ per IB device (NCCL_CTRAN_IB_DEVICES_PER_RANK). In elastic training with many RDMA transports (one per peer connection), this causes significant memory overhead:  
 - 8 peers × 1 CQ × 256MB = ~2GB of CQ memory alone per trainer rank

# Make the CQ size configurable at two levels:
  1. Global env var NCCL_CTRAN_IB_MAX_NUM_CQE — caps CQ size across all transports. Setting to 32768 reduces per-CQ memory from ~256MB to ~2MB.
  2. Per-transport maxNumCqe parameter — allows callers (e.g., RdmaTransport, shard_service) to override the global cap per instance. Per-transport takes precedence over the env var.

Default behavior is unchanged: Default -1 uses the device-reported maximum, preserving backward compatibility. The cap only takes effect when explicitly configured.

NOTE: Behavior if we have too small CQE
verified with D98587071, output: P2253819049:

```
Bottom line: When maxCqe is too small relative to outstanding work requests:
  - The HCA silently drops completions until the QP enters an error state
  - Eventually produces IBV_WC_WR_FLUSH_ERR error CQEs
  - All remaining in-flight work is lost
```


Differential Revision: D98533894


