### PR TITLE
Add GPE execution tracing to mccl_operation_trace (#1319)

### DIFF
--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -25,6 +25,8 @@
 #include "comms/utils/colltrace/CollRecord.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/LogUtils.h"
+#include "comms/utils/logger/OperationTraceWriter.h"
+#include "comms/utils/logger/ScubaFileUtils.h"
 
 using namespace ctran;
 using namespace ncclx::colltrace;
@@ -307,6 +309,15 @@ commResult_t CtranGpe::Impl::submit(
     cmd->kernelFlag = kernelFlag;
     cmd->timeout = timeout;
     cmd->unpackPool = kernelConfig.unpackPool;
+
+    // Capture enqueue timing for GPE execution tracing
+    auto* traceWriter = comms::logger::OperationTraceWriterRegistry::get();
+    if (traceWriter && traceWriter->isEnabled()) {
+      cmd->timing.tEnqueueUs = comms::logger::getTimestampUs();
+      cmd->timing.kernelTypeName = kernelTypeToName[kernelConfig.type];
+      cmd->timing.numBlocks = kernelConfig.numBlocks;
+      cmd->timing.numThreads = kernelConfig.numThreads;
+    }
 
     if (type == CtranGpeCmd::TypeEnum::GRAPH_ENQUEUE) {
       cmd->coll.opGroup = std::move(opGroup);
@@ -602,17 +613,45 @@ void CtranGpe::Impl::gpeThreadFn() {
         return;
       }
 
-      // If kernelFlag is set, indicates it is a device memory communication
-      // thus, wait for the kernel to launch
+      // RAII operation guard: logs GPE_EXECUTION_START now,
+      // GPE_EXECUTION_END on destruction with total duration + context.
+      comms::logger::OperationTraceSample gpeSample;
+      gpeSample.mcclop = "GPE_EXECUTION";
+      gpeSample.rank = this->comm->logMetaData_.rank;
+      gpeSample.commHash =
+          static_cast<int64_t>(this->comm->logMetaData_.commHash);
+      gpeSample.commId = static_cast<int64_t>(this->comm->logMetaData_.commId);
+      gpeSample.worldSize = this->comm->logMetaData_.nRanks;
+      if (!cmd->coll.opGroup.empty()) {
+        gpeSample.opCount =
+            static_cast<int64_t>(cmd->coll.opGroup.front()->opCount);
+      }
+      gpeSample.gpeKernelType = cmd->timing.kernelTypeName;
+      gpeSample.gpeNumBlocks = cmd->timing.numBlocks;
+      gpeSample.gpeNumThreads = cmd->timing.numThreads;
+      gpeSample.gpePersistent = cmd->persistent;
+      comms::logger::OperationTraceGuard gpeGuard(
+          std::move(gpeSample), cmd->timing.tEnqueueUs);
+
+      // Queue wait phase: enqueue (submit thread) → dequeue (this thread)
+      {
+        comms::logger::EventLoggerGuard queueWait(
+            gpeGuard, "GPE_QUEUE_WAIT", cmd->timing.tEnqueueUs);
+      }
+
+      // Kernel wait phase: wait for GPU kernel to signal KERNEL_STARTED
       KernelFlagItem* kernelFlag = cmd->kernelFlag;
-      if (kernelFlag) {
-        volatile int* flag_d = kernelFlag->flag_;
-        // Here we check just flag_d[0]. This is ok because Kernel Start signal
-        // is only used for tracing purposes. Before the flags are freed below
-        // with reset, all block flags are checked.
-        while (flag_d[0] != KERNEL_STARTED &&
-               flag_d[0] != KERNEL_STARTED_AND_EXIT) {
-          std::this_thread::yield();
+      {
+        comms::logger::EventLoggerGuard kernelWait(gpeGuard, "GPE_KERNEL_WAIT");
+        if (kernelFlag) {
+          volatile int* flag_d = kernelFlag->flag_;
+          // Here we check just flag_d[0]. This is ok because Kernel Start
+          // signal is only used for tracing purposes. Before the flags are
+          // freed below with reset, all block flags are checked.
+          while (flag_d[0] != KERNEL_STARTED &&
+                 flag_d[0] != KERNEL_STARTED_AND_EXIT) {
+            std::this_thread::yield();
+          }
         }
       }
 
@@ -634,7 +673,10 @@ void CtranGpe::Impl::gpeThreadFn() {
             });
       }
 
+      // CPU execution phase: run collective function
       {
+        comms::logger::EventLoggerGuard cpuExec(gpeGuard, "GPE_CPU_EXECUTION");
+
         // comm may be dummy in GPE UT, although never happens in real.
         // Pass in nullptr mapper to skip lock.
         auto mapper =
@@ -692,35 +734,40 @@ void CtranGpe::Impl::gpeThreadFn() {
         }
       }
 
-      if (kernelFlag) {
-        volatile int* flag_d = kernelFlag->flag_;
-        if (flag_d[0] == KERNEL_STARTED_AND_EXIT) {
-          // Indicate kernel would exit without the terminate signal, thus free
-          // the flag now
-          while (!kernelFlag->testFlagAllGroups(KERNEL_STARTED_AND_EXIT)) {
-            std::this_thread::yield();
+      // GPU terminate phase: signal kernel to stop and wait
+      {
+        comms::logger::EventLoggerGuard gpuTerminate(
+            gpeGuard, "GPE_GPU_TERMINATE");
+        if (kernelFlag) {
+          volatile int* flag_d = kernelFlag->flag_;
+          if (flag_d[0] == KERNEL_STARTED_AND_EXIT) {
+            // Indicate kernel would exit without the terminate signal, thus
+            // free the flag now
+            while (!kernelFlag->testFlagAllGroups(KERNEL_STARTED_AND_EXIT)) {
+              std::this_thread::yield();
+            }
+            // After all blocks exited, we can safely reset.
+            kernelFlag->reset();
+          } else {
+            // In case of aborted comm, wait for kernel to start
+            while (comm->testAbort() &&
+                   !kernelFlag->testFlagAllGroups(KERNEL_STARTED)) {
+              std::this_thread::yield();
+            }
+            // Stop kernel and kernel will free up the flag after confirmed the
+            // termination
+            kernelFlag->setFlagPerGroup(
+                comm->testAbort() ? KERNEL_HOST_ABORT : KERNEL_TERMINATE);
           }
-          // After all blocks exited, we can safely reset.
-          kernelFlag->reset();
-        } else {
-          // In case of aborted comm, wait for kernel to start
-          while (comm->testAbort() &&
-                 !kernelFlag->testFlagAllGroups(KERNEL_STARTED)) {
-            std::this_thread::yield();
+          // Teardown unpack queue if it was allocated for this operation (TcpDM
+          // backend). Don't wait for kernel to finish, the pool manages
+          // the allocations in the round robin fashion to avoid immediate
+          // reuse.
+          if (cmd->unpackPool != nullptr) {
+            FB_COMMCHECKTHROW_EX(
+                comm->ctran_->mapper->teardownUnpackConsumer(cmd->unpackPool),
+                comm->logMetaData_);
           }
-          // Stop kernel and kernel will free up the flag after confirmed the
-          // termination
-          kernelFlag->setFlagPerGroup(
-              comm->testAbort() ? KERNEL_HOST_ABORT : KERNEL_TERMINATE);
-        }
-        // Teardown unpack queue if it was allocated for this operation (TcpDM
-        // backend). Don't wait for kernel to finish, the pool manages
-        // the allocations in the round robin fashion to avoid immediate
-        // reuse.
-        if (cmd->unpackPool != nullptr) {
-          FB_COMMCHECKTHROW_EX(
-              comm->ctran_->mapper->teardownUnpackConsumer(cmd->unpackPool),
-              comm->logMetaData_);
         }
       }
 

--- a/comms/ctran/gpe/CtranGpeImpl.h
+++ b/comms/ctran/gpe/CtranGpeImpl.h
@@ -153,6 +153,16 @@ class CtranGpeCmd {
 
   // Unpack queue to teardown after kernel completes (for TcpDM backend)
   void* unpackPool{nullptr};
+
+  // GPE execution tracing (mccl_operation_trace).
+  // tEnqueueUs is captured in submit(); kernel context is copied from
+  // KernelConfig which is not available on the GPE thread.
+  struct {
+    int64_t tEnqueueUs{0};
+    std::string kernelTypeName;
+    int numBlocks{0};
+    int numThreads{0};
+  } timing;
 };
 
 /**

--- a/comms/utils/logger/OperationTraceWriter.cc
+++ b/comms/utils/logger/OperationTraceWriter.cc
@@ -1,0 +1,113 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/utils/logger/OperationTraceWriter.h"
+
+#include "comms/utils/logger/ScubaFileUtils.h"
+
+namespace comms::logger {
+
+namespace {
+std::shared_ptr<IOperationTraceWriter>& writerInstance() {
+  static std::shared_ptr<IOperationTraceWriter> instance;
+  return instance;
+}
+} // namespace
+
+void OperationTraceWriterRegistry::set(
+    std::shared_ptr<IOperationTraceWriter> writer) {
+  writerInstance() = std::move(writer);
+}
+
+IOperationTraceWriter* OperationTraceWriterRegistry::get() {
+  return writerInstance().get();
+}
+
+namespace {
+// Helper to log a sample with the given event name.
+void logTraceSample(
+    IOperationTraceWriter* writer,
+    const OperationTraceSample& base,
+    const std::string& event,
+    std::optional<int64_t> durationUs = std::nullopt) {
+  OperationTraceSample s;
+  s.mcclop = base.mcclop;
+  s.event = event;
+  s.timestampUs = getTimestampUs();
+  s.rank = base.rank;
+  s.commHash = base.commHash;
+  s.commId = base.commId;
+  s.worldSize = base.worldSize;
+  s.opCount = base.opCount;
+  s.durationUs = durationUs;
+  writer->addSample(std::move(s));
+}
+} // namespace
+
+// --- OperationTraceGuard ---
+
+OperationTraceGuard::OperationTraceGuard(
+    OperationTraceSample sample,
+    int64_t startUs)
+    : sample_(std::move(sample)) {
+  auto* writer = OperationTraceWriterRegistry::get();
+  if (writer && writer->isEnabled()) {
+    active_ = true;
+    startUs_ = startUs > 0 ? startUs : getTimestampUs();
+    logTraceSample(writer, sample_, sample_.mcclop + "_START");
+  }
+}
+
+OperationTraceGuard::~OperationTraceGuard() {
+  if (dismissed_ || !active_) {
+    return;
+  }
+  auto* writer = OperationTraceWriterRegistry::get();
+  if (!writer) {
+    return;
+  }
+  auto now = getTimestampUs();
+  sample_.event = sample_.mcclop + "_END";
+  sample_.timestampUs = now;
+  if (!sample_.durationUs.has_value()) {
+    sample_.durationUs = now - startUs_;
+  }
+  writer->addSample(std::move(sample_));
+}
+
+OperationTraceGuard::OperationTraceGuard(OperationTraceGuard&& other) noexcept
+    : sample_(std::move(other.sample_)),
+      startUs_(other.startUs_),
+      dismissed_(other.dismissed_),
+      active_(other.active_) {
+  other.dismissed_ = true;
+}
+
+// --- EventLoggerGuard ---
+
+EventLoggerGuard::EventLoggerGuard(
+    const OperationTraceGuard& parent,
+    std::string event,
+    int64_t startUs)
+    : parent_(&parent), event_(std::move(event)), active_(parent.isActive()) {
+  if (active_) {
+    startUs_ = startUs > 0 ? startUs : getTimestampUs();
+    auto* writer = OperationTraceWriterRegistry::get();
+    if (writer) {
+      logTraceSample(writer, parent_->sample_, event_ + "_START");
+    }
+  }
+}
+
+EventLoggerGuard::~EventLoggerGuard() {
+  if (!active_) {
+    return;
+  }
+  auto* writer = OperationTraceWriterRegistry::get();
+  if (!writer) {
+    return;
+  }
+  auto now = getTimestampUs();
+  logTraceSample(writer, parent_->sample_, event_ + "_END", now - startUs_);
+}
+
+} // namespace comms::logger

--- a/comms/utils/logger/OperationTraceWriter.h
+++ b/comms/utils/logger/OperationTraceWriter.h
@@ -1,0 +1,144 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+
+namespace comms::logger {
+
+// Sample for operation trace logging to mccl_operation_trace scuba table.
+// Defines the schema for all columns that ctran (and other lower-level
+// components) can log through the DI writer, without depending on MCCL.
+//
+// Named fields document the scuba table schema. The writer implementation
+// serializes all set fields into the scuba sample.
+struct OperationTraceSample {
+  // === Identity (maps to existing mccl_operation_trace columns) ===
+  std::string mcclop; // Operation type (e.g., "GPE_EXECUTION")
+  std::string event; // Event name (e.g., "GPE_EXECUTION_END")
+  int64_t timestampUs{0}; // Timestamp in microseconds (scuba: "timestamp")
+  int rank{-1};
+  int64_t commHash{0};
+  int64_t commId{0};
+  int worldSize{-1};
+  int64_t opCount{-1};
+
+  // === Timing ===
+  std::optional<int64_t> durationUs; // scuba: "duration_us"
+
+  // === GPE Execution context ===
+  std::optional<std::string> gpeKernelType; // scuba: "gpe_kernel_type"
+  std::optional<int> gpeNumBlocks; // scuba: "gpe_num_blocks"
+  std::optional<int> gpeNumThreads; // scuba: "gpe_num_threads"
+  std::optional<bool> gpePersistent; // scuba: "gpe_persistent"
+};
+
+// Interface for operation trace writers.
+// Implementations route samples to their respective scuba tables
+// (e.g., mccl_operation_trace, ncclx_operation_trace).
+class IOperationTraceWriter {
+ public:
+  virtual ~IOperationTraceWriter() = default;
+  virtual bool isEnabled() const = 0;
+  virtual void addSample(OperationTraceSample sample) = 0;
+};
+
+// Global registry for the operation trace writer.
+// Set by the communication library (MCCL or NCCLX) during initialization;
+// queried by lower-level components (e.g., ctran) at runtime.
+class OperationTraceWriterRegistry {
+ public:
+  static void set(std::shared_ptr<IOperationTraceWriter> writer);
+  static IOperationTraceWriter* get();
+
+ private:
+  OperationTraceWriterRegistry() = delete;
+};
+
+// RAII guard for operation-level trace logging.
+// Logs {mcclop}_START on construction and {mcclop}_END on destruction
+// with computed duration and context fields.
+//
+// Usage:
+//   OperationTraceSample sample;
+//   sample.mcclop = "GPE_EXECUTION";
+//   sample.rank = rank;
+//   // ... fill identity fields ...
+//   OperationTraceGuard guard(std::move(sample));
+//   guard.sample().gpeKernelType = "AllGather";
+//   // ... do work ...
+//   // GPE_EXECUTION_END logged automatically with duration on destruction
+class OperationTraceGuard {
+ public:
+  // Construct with pre-filled sample (mcclop + identity fields).
+  // If startUs > 0, uses it as the start time; otherwise captures now.
+  // Logs {mcclop}_START immediately.
+  explicit OperationTraceGuard(
+      OperationTraceSample sample,
+      int64_t startUs = 0);
+  ~OperationTraceGuard();
+
+  OperationTraceGuard(const OperationTraceGuard&) = delete;
+  OperationTraceGuard& operator=(const OperationTraceGuard&) = delete;
+  OperationTraceGuard(OperationTraceGuard&& other) noexcept;
+  OperationTraceGuard& operator=(OperationTraceGuard&&) = delete;
+
+  // Access the sample to set additional fields before destruction.
+  OperationTraceSample& sample() {
+    return sample_;
+  }
+
+  // Whether tracing is active (writer available and enabled).
+  bool isActive() const {
+    return active_;
+  }
+
+  // Prevent logging on destruction.
+  void dismiss() {
+    dismissed_ = true;
+  }
+
+ private:
+  friend class EventLoggerGuard;
+  OperationTraceSample sample_;
+  int64_t startUs_{0};
+  bool dismissed_{false};
+  bool active_{false};
+};
+
+// RAII guard for event-level (sub-phase) trace logging within an operation.
+// Logs {event}_START on construction and {event}_END on destruction
+// with computed duration. Identity fields are copied from the parent
+// OperationTraceGuard.
+//
+// Usage:
+//   OperationTraceGuard opGuard(sample);
+//   {
+//     EventLoggerGuard evGuard(opGuard, "GPE_KERNEL_WAIT");
+//     // ... wait for kernel ...
+//   } // GPE_KERNEL_WAIT_END logged with duration
+class EventLoggerGuard {
+ public:
+  // Construct with parent guard and event base name (e.g., "GPE_QUEUE_WAIT").
+  // If startUs > 0, uses it as the start time; otherwise captures now.
+  // Logs {event}_START immediately.
+  EventLoggerGuard(
+      const OperationTraceGuard& parent,
+      std::string event,
+      int64_t startUs = 0);
+  ~EventLoggerGuard();
+
+  EventLoggerGuard(const EventLoggerGuard&) = delete;
+  EventLoggerGuard& operator=(const EventLoggerGuard&) = delete;
+
+ private:
+  const OperationTraceGuard* parent_;
+  std::string event_;
+  int64_t startUs_{0};
+  bool active_{false};
+};
+
+} // namespace comms::logger

--- a/comms/utils/logger/tests/OperationTraceWriterTest.cc
+++ b/comms/utils/logger/tests/OperationTraceWriterTest.cc
@@ -1,0 +1,173 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include "comms/utils/logger/OperationTraceWriter.h"
+
+using namespace comms::logger;
+
+namespace {
+
+// Simple mock writer that records calls for verification.
+class MockOperationTraceWriter : public IOperationTraceWriter {
+ public:
+  bool isEnabled() const override {
+    return enabled;
+  }
+
+  void addSample(OperationTraceSample sample) override {
+    samples.push_back(std::move(sample));
+  }
+
+  bool enabled{true};
+  std::vector<OperationTraceSample> samples;
+};
+
+class OperationTraceWriterTest : public ::testing::Test {
+ protected:
+  void TearDown() override {
+    // Reset the registry after each test to avoid cross-test contamination.
+    OperationTraceWriterRegistry::set(nullptr);
+  }
+};
+
+} // namespace
+
+// Verify get() returns nullptr when no writer has been registered.
+TEST_F(OperationTraceWriterTest, RegistryReturnsNullByDefault) {
+  EXPECT_EQ(OperationTraceWriterRegistry::get(), nullptr);
+}
+
+// Verify the full DI contract: register a writer, query it, send a sample,
+// and confirm all named fields arrive correctly.
+TEST_F(OperationTraceWriterTest, RegisteredWriterReceivesSamples) {
+  auto mock = std::make_shared<MockOperationTraceWriter>();
+  OperationTraceWriterRegistry::set(mock);
+
+  auto* writer = OperationTraceWriterRegistry::get();
+  ASSERT_NE(writer, nullptr);
+  EXPECT_TRUE(writer->isEnabled());
+
+  // Build and submit a sample (mirrors what ctran GPE tracing does)
+  OperationTraceSample sample;
+  sample.mcclop = "GPE_EXECUTION";
+  sample.event = "GPE_EXECUTION_END";
+  sample.timestampUs = 1000000;
+  sample.rank = 3;
+  sample.commHash = 12345;
+  sample.commId = 99;
+  sample.worldSize = 8;
+  sample.opCount = 42;
+  sample.durationUs = 500;
+  sample.gpeKernelType = "AllGather";
+  sample.gpeNumBlocks = 4;
+  sample.gpeNumThreads = 256;
+  sample.gpePersistent = false;
+  writer->addSample(std::move(sample));
+
+  ASSERT_EQ(mock->samples.size(), 1);
+  const auto& s = mock->samples[0];
+  EXPECT_EQ(s.mcclop, "GPE_EXECUTION");
+  EXPECT_EQ(s.event, "GPE_EXECUTION_END");
+  EXPECT_EQ(s.timestampUs, 1000000);
+  EXPECT_EQ(s.rank, 3);
+  EXPECT_EQ(s.commHash, 12345);
+  EXPECT_EQ(s.commId, 99);
+  EXPECT_EQ(s.worldSize, 8);
+  EXPECT_EQ(s.opCount, 42);
+  ASSERT_TRUE(s.durationUs.has_value());
+  EXPECT_EQ(s.durationUs.value(), 500);
+  ASSERT_TRUE(s.gpeKernelType.has_value());
+  EXPECT_EQ(s.gpeKernelType.value(), "AllGather");
+  ASSERT_TRUE(s.gpeNumBlocks.has_value());
+  EXPECT_EQ(s.gpeNumBlocks.value(), 4);
+  ASSERT_TRUE(s.gpeNumThreads.has_value());
+  EXPECT_EQ(s.gpeNumThreads.value(), 256);
+  ASSERT_TRUE(s.gpePersistent.has_value());
+  EXPECT_FALSE(s.gpePersistent.value());
+}
+
+// Verify that when the writer reports disabled, callers can skip work.
+TEST_F(OperationTraceWriterTest, DisabledWriterSkipsSamples) {
+  auto mock = std::make_shared<MockOperationTraceWriter>();
+  mock->enabled = false;
+  OperationTraceWriterRegistry::set(mock);
+
+  auto* writer = OperationTraceWriterRegistry::get();
+  ASSERT_NE(writer, nullptr);
+  EXPECT_FALSE(writer->isEnabled());
+
+  // Caller checks isEnabled() before building the sample — no sample added
+  if (writer->isEnabled()) {
+    OperationTraceSample sample;
+    writer->addSample(std::move(sample));
+  }
+  EXPECT_EQ(mock->samples.size(), 0);
+}
+
+// Verify OperationTraceGuard logs START on construction and END on
+// destruction with computed duration and context fields.
+TEST_F(OperationTraceWriterTest, OperationGuardLogsStartAndEnd) {
+  auto mock = std::make_shared<MockOperationTraceWriter>();
+  OperationTraceWriterRegistry::set(mock);
+
+  {
+    OperationTraceSample sample;
+    sample.mcclop = "GPE_EXECUTION";
+    sample.rank = 1;
+    sample.commHash = 999;
+    OperationTraceGuard guard(std::move(sample));
+    EXPECT_TRUE(guard.isActive());
+    guard.sample().gpeKernelType = "AllReduce";
+  }
+
+  ASSERT_EQ(mock->samples.size(), 2);
+
+  // START logged on construction
+  const auto& start = mock->samples[0];
+  EXPECT_EQ(start.event, "GPE_EXECUTION_START");
+  EXPECT_EQ(start.rank, 1);
+  EXPECT_EQ(start.commHash, 999);
+
+  // END logged on destruction with duration + context
+  const auto& end = mock->samples[1];
+  EXPECT_EQ(end.event, "GPE_EXECUTION_END");
+  EXPECT_EQ(end.rank, 1);
+  EXPECT_EQ(end.commHash, 999);
+  ASSERT_TRUE(end.durationUs.has_value());
+  EXPECT_GE(end.durationUs.value(), 0);
+  ASSERT_TRUE(end.gpeKernelType.has_value());
+  EXPECT_EQ(end.gpeKernelType.value(), "AllReduce");
+}
+
+// Verify EventLoggerGuard logs event START/END within a parent
+// operation guard, sharing identity fields.
+TEST_F(OperationTraceWriterTest, EventGuardLogsStartAndEnd) {
+  auto mock = std::make_shared<MockOperationTraceWriter>();
+  OperationTraceWriterRegistry::set(mock);
+
+  {
+    OperationTraceSample sample;
+    sample.mcclop = "GPE_EXECUTION";
+    sample.rank = 2;
+    sample.commHash = 777;
+    OperationTraceGuard opGuard(std::move(sample));
+
+    {
+      EventLoggerGuard evGuard(opGuard, "GPE_KERNEL_WAIT");
+    }
+    // Event guard destructor fires before operation guard
+  }
+
+  // Expected order: OP_START, EVENT_START, EVENT_END, OP_END
+  ASSERT_EQ(mock->samples.size(), 4);
+
+  EXPECT_EQ(mock->samples[0].event, "GPE_EXECUTION_START");
+  EXPECT_EQ(mock->samples[1].event, "GPE_KERNEL_WAIT_START");
+  EXPECT_EQ(mock->samples[1].rank, 2);
+  EXPECT_EQ(mock->samples[1].commHash, 777);
+  EXPECT_EQ(mock->samples[2].event, "GPE_KERNEL_WAIT_END");
+  ASSERT_TRUE(mock->samples[2].durationUs.has_value());
+  EXPECT_GE(mock->samples[2].durationUs.value(), 0);
+  EXPECT_EQ(mock->samples[3].event, "GPE_EXECUTION_END");
+}


### PR DESCRIPTION
Summary:

Add timing/tracing instrumentation for the GPE (GPU Processing Engine) execution pipeline, logging to the mccl_operation_trace scuba table.

**DI Interface** (`comms/utils/logger/OperationTraceWriter.h`):
- `OperationTraceSample` struct with named fields matching scuba columns
- `IOperationTraceWriter` interface for dependency injection (avoids ctran→MCCL circular dep)
- `OperationTraceWriterRegistry` singleton for global writer registration
- `OperationTraceGuard` RAII guard: logs `{mcclop}_START` on construction, `{mcclop}_END` on destruction with duration + context
- `EventLoggerGuard` RAII guard: logs `{event}_START`/`{event}_END` for sub-phases within an operation

**MCCL Writer** (`McclDataTableWrapper.h/.cpp`):
- `McclOperationTraceWriter` implements `IOperationTraceWriter`, converts `OperationTraceSample` → `McclOperationTraceData` → `toSample()` reusing existing serialization
- Registered during MCCL init via `McclOperationTraceWriter::registerWriter()`

**GPE Instrumentation** (`CtranGpeImpl.cc`):
- `submit()`: captures enqueue timestamp + kernel context on `CtranGpeCmd::timing`
- `gpeThreadFn()`: uses RAII guards to trace 4 phases:
  - `GPE_QUEUE_WAIT`: enqueue → dequeue
  - `GPE_KERNEL_WAIT`: waiting for GPU kernel flag
  - `GPE_CPU_EXECUTION`: running collective function
  - `GPE_GPU_TERMINATE`: kernel termination
- Overall `GPE_EXECUTION` operation wraps all phases with total duration

**New scuba columns** (schema-on-read, auto-created):
- `gpe_kernel_type`, `gpe_num_blocks`, `gpe_num_threads`, `gpe_persistent`

Differential Revision: D98563493


