### PR TITLE
Initialize colltrace in standalone makeCtranComm for ctran tests to use

### DIFF
--- a/comms/ctran/tests/CtranDistTestUtils.cc
+++ b/comms/ctran/tests/CtranDistTestUtils.cc
@@ -8,6 +8,8 @@
 #include "comms/ctran/utils/CudaUtils.h"
 #include "comms/ctran/utils/Utils.h"
 #include "comms/testinfra/DistEnvironmentBase.h"
+#include "comms/utils/colltrace/CollTrace.h"
+#include "comms/utils/colltrace/plugins/CommDumpPlugin.h"
 
 namespace ctran {
 
@@ -21,6 +23,7 @@ void CtranDistEnvironment::SetUp() {
   // Ctran-specific env vars
   setenv("NCCL_CTRAN_PROFILING", "none", 1);
   setenv("NCCL_CTRAN_ENABLE", "1", 0);
+  setenv("NCCL_COLLTRACE", "trace", 0);
   setenv("NCCL_COLLTRACE_USE_NEW_COLLTRACE", "1", 0);
 
 #ifdef NCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL
@@ -132,7 +135,43 @@ std::unique_ptr<CtranComm> CtranDistTestFixture::makeCtranComm() {
 
   COMMCHECK_TEST(ctranInit(comm.get()));
   CHECK(ctranInitialized(comm.get())) << "Ctran not initialized";
+
+  // Initialize standalone colltrace with CommDumpPlugin so tests can verify
+  // colltrace records without requiring a full ncclComm
+  {
+    meta::comms::colltrace::CollTraceConfig collTraceConfig;
+    std::vector<std::unique_ptr<meta::comms::colltrace::ICollTracePlugin>>
+        plugins;
+    plugins.push_back(
+        std::make_unique<meta::comms::colltrace::CommDumpPlugin>(
+            meta::comms::colltrace::CommDumpConfig{.pastCollSize = 1024}));
+    comm->colltraceNew_ = std::shared_ptr<meta::comms::colltrace::ICollTrace>(
+        new meta::comms::colltrace::CollTrace(
+            collTraceConfig,
+            comm->logMetaData_,
+            []() -> meta::comms::CommsMaybeVoid { return folly::unit; },
+            std::move(plugins)));
+  }
+
   return comm;
+}
+
+std::unordered_map<std::string, std::string> dumpCollTrace(CtranComm* comm) {
+  using namespace meta::comms::colltrace;
+  if (comm->colltraceNew_ == nullptr) {
+    return {};
+  }
+  auto* plugin = comm->colltraceNew_->getPluginByName(
+      std::string{CommDumpPlugin::kCommDumpPluginName});
+  auto* commDumpPlugin = dynamic_cast<CommDumpPlugin*>(plugin);
+  if (commDumpPlugin == nullptr) {
+    return {};
+  }
+  auto dump = commDumpPlugin->dump();
+  if (dump.hasError()) {
+    return {};
+  }
+  return commDumpToMap(dump.value());
 }
 
 } // namespace ctran

--- a/comms/ctran/tests/CtranDistTestUtils.h
+++ b/comms/ctran/tests/CtranDistTestUtils.h
@@ -5,6 +5,7 @@
 #include <atomic>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "comms/ctran/CtranComm.h"
@@ -37,5 +38,10 @@ class CtranDistTestFixture : public CtranTestFixtureBase,
 
   bool enableNolocal{false};
 };
+
+// Dump colltrace records from a standalone CtranComm's colltraceNew_.
+// Returns a map with keys like "CT_pastColls", "CT_pendingColls",
+// "CT_currentColl". Returns empty map if colltrace is not initialized.
+std::unordered_map<std::string, std::string> dumpCollTrace(CtranComm* comm);
 
 } // namespace ctran


### PR DESCRIPTION
Summary: Ctran collective tests need colltrace to verify right algo usage, etc: so we need to init colltrace in standalone ctran comm.

Reviewed By: YulunW

Differential Revision: D98391509


