### PR TITLE
Migrate Window dist tests to inherit CtranDistTestFixture (was NcclxBaseTest)

### DIFF
--- a/comms/ctran/window/tests/CtranWinTests.cc
+++ b/comms/ctran/window/tests/CtranWinTests.cc
@@ -7,19 +7,16 @@
 
 #include <folly/init/Init.h>
 
-#include "comm.h"
 #include "comms/ctran/Ctran.h"
 #include "comms/ctran/tests/CtranDistTestUtils.h"
 #include "comms/ctran/tests/CtranTestUtils.h"
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/window/CtranWin.h"
 #include "comms/testinfra/TestUtils.h"
-#include "comms/testinfra/TestsDistUtils.h"
-#include "nccl.h"
 
 using namespace ctran;
 
-class CtranWinTest : public NcclxBaseTest {
+class CtranWinTest : public ctran::CtranDistTestFixture {
  public:
   CtranWinTest() = default;
 
@@ -27,25 +24,16 @@ class CtranWinTest : public NcclxBaseTest {
   void SetUp() override {
     setenv("NCCL_CTRAN_ENABLE", "1", 0);
     setenv("NCCL_CTRAN_IB_EPOCH_LOCK_ENFORCE_CHECK", "true", 0);
-    NcclxBaseTest::SetUp();
-    CUDACHECK_TEST(cudaSetDevice(this->localRank));
+    ctran::CtranDistTestFixture::SetUp();
   }
   void TearDown() override {
     // Check that all allocated memory segments have been freed
     EXPECT_TRUE(segments.empty()) << "Not all memory segments were freed";
-  }
-
-  void barrier(ncclComm_t comm, cudaStream_t stream) {
-    // simple Allreduce as barrier before get data from other ranks
-    void* buf;
-    CUDACHECK_TEST(cudaMalloc(&buf, sizeof(char)));
-    NCCLCHECK_TEST(ncclAllReduce(buf, buf, 1, ncclChar, ncclSum, comm, stream));
-    CUDACHECK_TEST(cudaDeviceSynchronize());
-    CUDACHECK_TEST(cudaFree(buf));
+    ctran::CtranDistTestFixture::TearDown();
   }
 
   void createWin(
-      ncclComm_t comm,
+      CtranComm* comm,
       bool isUserBuf,
       MemAllocType bufType,
       void** winBasePtr,
@@ -53,12 +41,11 @@ class CtranWinTest : public NcclxBaseTest {
       size_t sizeBytes) {
     meta::comms::Hints hints;
     auto res = commSuccess;
-    // If userBuf is true, allocate buffer and use ctranWinRegister API
     if (isUserBuf) {
       *winBasePtr = commMemAlloc(sizeBytes, bufType, segments);
 
-      res = ctranWinRegister(
-          (void*)*winBasePtr, sizeBytes, comm->ctranComm_.get(), winPtr, hints);
+      res =
+          ctranWinRegister((void*)*winBasePtr, sizeBytes, comm, winPtr, hints);
 
     } else {
       hints.set(
@@ -67,8 +54,8 @@ class CtranWinTest : public NcclxBaseTest {
                   bufType == MemAllocType::kMemHostUnregistered
               ? "cpu"
               : "gpu");
-      res = ctranWinAllocate(
-          sizeBytes, comm->ctranComm_.get(), (void**)winBasePtr, winPtr, hints);
+      res =
+          ctranWinAllocate(sizeBytes, comm, (void**)winBasePtr, winPtr, hints);
     }
     ASSERT_EQ(res, commSuccess);
     ASSERT_NE(*winBasePtr, nullptr);
@@ -78,7 +65,6 @@ class CtranWinTest : public NcclxBaseTest {
   freeWinBuf(bool isUserBuf, void* ptr, size_t size, MemAllocType bufType) {
     if (isUserBuf) {
       commMemFree(ptr, size, bufType);
-      // Remove the segment from the tracking vector
       segments.erase(
           std::remove_if(
               segments.begin(),
@@ -97,29 +83,20 @@ class CtranWinTestParam
 TEST_P(CtranWinTestParam, winAllocCreate) {
   auto [bufType, userBuf] = GetParam();
 
-  ncclComm_t comm = createNcclComm(
-      this->globalRank,
-      this->numRanks,
-      this->localRank,
-      false,
-      nullptr,
-      server.get());
-
+  auto comm = makeCtranComm();
   ASSERT_NE(comm, nullptr);
 
-  auto statex = comm->ctranComm_->statex_.get();
+  auto statex = comm->statex_.get();
   ASSERT_NE(statex, nullptr);
 
-  cudaStream_t stream = 0;
   CtranWin* win = nullptr;
   size_t sizeBytes = 8192 * sizeof(int);
   void* winBase = nullptr;
-  createWin(comm, userBuf, bufType, &winBase, &win, sizeBytes);
+  createWin(comm.get(), userBuf, bufType, &winBase, &win, sizeBytes);
 
   EXPECT_THAT(win, ::testing::NotNull());
 
-  // Expect window allocation would trigger internal buffer registration export
-  const auto dump0 = comm->ctranComm_->ctran_->mapper->dumpExportRegCache();
+  const auto dump0 = comm->ctran_->mapper->dumpExportRegCache();
   EXPECT_GE(dump0.size(), 0);
 
   for (int peer = 0; peer < this->numRanks; peer++) {
@@ -128,12 +105,10 @@ TEST_P(CtranWinTestParam, winAllocCreate) {
     EXPECT_EQ(res, commSuccess);
     if (peer == statex->rank()) {
       EXPECT_EQ(remoteAddr, winBase);
-      // For CPU window or peers on remote node, remote address is null
     } else if (!(statex->node(peer) == statex->node() &&
                  win->nvlEnabled(peer))) {
       EXPECT_THAT(remoteAddr, ::testing::IsNull());
     } else {
-      // Do actual copy to validate remote address is accessible
       FB_CUDACHECKIGNORE(
           cudaMemcpy(remoteAddr, winBase, sizeBytes, cudaMemcpyDefault));
       EXPECT_THAT(remoteAddr, ::testing::NotNull());
@@ -148,47 +123,32 @@ TEST_P(CtranWinTestParam, winAllocCreate) {
         win->updateOpCount(next_peer, window::OpCountType::kWaitSignal), i);
   }
 
-  // Barrier to ensure all peers have finished creation and query
-  this->barrier(comm, stream);
+  oobBarrier();
 
   auto res = ctranWinFree(win);
   EXPECT_EQ(res, commSuccess);
 
-  // This test only exported buffers in window, thus expect all exported cache
-  // is freed upon window free
-  const auto dump1 = comm->ctranComm_->ctran_->mapper->dumpExportRegCache();
+  const auto dump1 = comm->ctran_->mapper->dumpExportRegCache();
   EXPECT_EQ(dump1.size(), 0);
 
   freeWinBuf(userBuf, winBase, sizeBytes, bufType);
-
-  finalizeNcclComm(globalRank, server.get());
-  NCCLCHECK_TEST(ncclCommDestroy(comm));
 }
 
 TEST_F(CtranWinTest, directCopy) {
-  ncclComm_t comm = createNcclComm(
-      this->globalRank,
-      this->numRanks,
-      this->localRank,
-      false,
-      nullptr,
-      server.get());
+  auto comm = makeCtranComm();
   ASSERT_NE(comm, nullptr);
 
-  auto statex = comm->ctranComm_->statex_.get();
+  auto statex = comm->statex_.get();
   ASSERT_NE(statex, nullptr);
 
   if (statex->nLocalRanks() == 1) {
-    NCCLCHECK_TEST(ncclCommDestroy(comm));
     GTEST_SKIP() << "Host needs to have at least 2 GPUs to run this test";
   }
 
-  cudaStream_t stream = 0;
   CtranWin* win = nullptr;
   size_t count = 8192;
   void* winBase = nullptr;
-  auto res = ctranWinAllocate(
-      count * sizeof(int), comm->ctranComm_.get(), &winBase, &win);
+  auto res = ctranWinAllocate(count * sizeof(int), comm.get(), &winBase, &win);
   EXPECT_EQ(res, commSuccess);
   ASSERT_NE(winBase, nullptr);
 
@@ -196,13 +156,11 @@ TEST_F(CtranWinTest, directCopy) {
   int seed = this->globalRank * count;
   assignChunkValue(localWinAddr, count, seed, 1);
 
-  // Barrier to ensure remote GPU has finished data write to window
-  this->barrier(comm, stream);
+  oobBarrier();
 
   srand(time(NULL));
   std::vector<int> remoteData_host(count, rand());
   for (int peer = 0; peer < this->numRanks; ++peer) {
-    // Direct remote memory access is only allowed for local GPUs
     if ((peer != this->globalRank) && (statex->node() == statex->node(peer))) {
       void* remoteWinBase = nullptr;
       res = ctranWinSharedQuery(peer, win, &remoteWinBase);
@@ -221,38 +179,26 @@ TEST_F(CtranWinTest, directCopy) {
     }
   }
 
-  // Barrier to ensure all peers have completed remote data access
-  this->barrier(comm, stream);
+  oobBarrier();
 
   res = ctranWinFree(win);
   EXPECT_EQ(res, commSuccess);
-
-  finalizeNcclComm(globalRank, server.get());
-  NCCLCHECK_TEST(ncclCommDestroy(comm));
 }
 
 TEST_F(CtranWinTest, nvlDisabled) {
   EnvRAII env1(
       NCCL_CTRAN_BACKENDS,
       std::vector<enum NCCL_CTRAN_BACKENDS>{NCCL_CTRAN_BACKENDS::ib});
-  ncclComm_t comm = createNcclComm(
-      this->globalRank,
-      this->numRanks,
-      this->localRank,
-      false,
-      nullptr,
-      server.get());
-
+  auto comm = makeCtranComm();
   ASSERT_NE(comm, nullptr);
 
-  auto statex = comm->ctranComm_->statex_.get();
+  auto statex = comm->statex_.get();
   ASSERT_NE(statex, nullptr);
 
   CtranWin* win = nullptr;
   size_t sizeBytes = 8192 * sizeof(int);
   void* winBase = nullptr;
-  auto res =
-      ctranWinAllocate(sizeBytes, comm->ctranComm_.get(), &winBase, &win);
+  auto res = ctranWinAllocate(sizeBytes, comm.get(), &winBase, &win);
   ASSERT_EQ(res, commSuccess);
   ASSERT_NE(winBase, nullptr);
 
@@ -262,7 +208,6 @@ TEST_F(CtranWinTest, nvlDisabled) {
     ASSERT_EQ(win->nvlEnabled(peer), false);
     void* remoteAddr = nullptr;
     ASSERT_EQ(ctranWinSharedQuery(peer, win, &remoteAddr), commSuccess);
-    // Expect can only directly access local GPU's window
     if (peer == statex->rank()) {
       EXPECT_EQ(remoteAddr, winBase);
     } else {
@@ -272,9 +217,6 @@ TEST_F(CtranWinTest, nvlDisabled) {
 
   res = ctranWinFree(win);
   EXPECT_EQ(res, commSuccess);
-
-  finalizeNcclComm(globalRank, server.get());
-  NCCLCHECK_TEST(ncclCommDestroy(comm));
 }
 
 // Test fixture using CtranDistTestFixture (without NCCL dependency)
@@ -291,13 +233,6 @@ class CtranWinDistTest : public ctran::CtranDistTestFixture {
 
   void TearDown() override {
     CtranDistTestFixture::TearDown();
-  }
-
-  void barrier(CtranComm* comm) {
-    auto resFuture = comm->bootstrap_->barrier(
-        comm->statex_->rank(), comm->statex_->nRanks());
-    ASSERT_EQ(
-        static_cast<commResult_t>(std::move(resFuture).get()), commSuccess);
   }
 };
 
@@ -421,7 +356,7 @@ TEST_F(CtranWinDistTest, asymmetricWindowDirectCopy) {
   assignChunkValue(localWinAddr, localCount, seed, 1);
 
   // Barrier to ensure all ranks have initialized their windows
-  this->barrier(comm.get());
+  oobBarrier();
 
   // Read from other local ranks and verify data
   for (int peer = 0; peer < this->numRanks; ++peer) {
@@ -452,13 +387,13 @@ TEST_F(CtranWinDistTest, asymmetricWindowDirectCopy) {
   }
 
   // Barrier before cleanup
-  this->barrier(comm.get());
+  oobBarrier();
 
   res = ctranWinFree(win);
   EXPECT_EQ(res, commSuccess);
 }
 
-// Test asymmetric window with PUT and GET operations between ranks
+// Test asymmetric window with direct
 TEST_F(CtranWinDistTest, asymmetricWindowPutGet) {
   auto comm = makeCtranComm();
   ASSERT_NE(comm, nullptr);
@@ -517,7 +452,7 @@ TEST_F(CtranWinDistTest, asymmetricWindowPutGet) {
   CUDACHECK_TEST(cudaStreamCreateWithFlags(&getStream, cudaStreamNonBlocking));
   CUDACHECK_TEST(cudaStreamCreateWithFlags(&waitStream, cudaStreamNonBlocking));
 
-  this->barrier(comm.get());
+  oobBarrier();
 
   // === PUT test: each rank PUTs to next peer ===
   const int kNumIters = 10;
@@ -555,7 +490,7 @@ TEST_F(CtranWinDistTest, asymmetricWindowPutGet) {
   }
   EXPECT_EQ(putErrs, 0) << "PUT verification failed";
 
-  this->barrier(comm.get());
+  oobBarrier();
 
   // === GET test: each rank GETs from next peer ===
   // After PUT phase, nextPeer's window has data from rank at offset
@@ -574,7 +509,7 @@ TEST_F(CtranWinDistTest, asymmetricWindowPutGet) {
   }
 
   CUDACHECK_TEST(cudaStreamSynchronize(getStream));
-  this->barrier(comm.get());
+  oobBarrier();
 
   // Verify GET: we should get back our own data that we PUT to nextPeer
   std::vector<int> getRecvData(localCount, -1);
@@ -640,7 +575,7 @@ TEST_F(CtranWinDistTest, signalResetAcrossGraphReplays) {
   CUDACHECK_TEST(cudaStreamCreateWithFlags(&putStream, cudaStreamNonBlocking));
   CUDACHECK_TEST(cudaStreamCreateWithFlags(&waitStream, cudaStreamNonBlocking));
 
-  this->barrier(comm.get());
+  oobBarrier();
 
   // Capture put + signal + wait_signal into a graph
   CUDACHECK_TEST(
@@ -676,19 +611,19 @@ TEST_F(CtranWinDistTest, signalResetAcrossGraphReplays) {
   cudaGraphExec_t graphExec;
   CUDACHECK_TEST(cudaGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
 
-  this->barrier(comm.get());
+  oobBarrier();
 
-  // Replay multiple times — each replay should deliver fresh data
+  // Replay multiple times
   constexpr int kNumReplays = 5;
   for (int replay = 0; replay < kNumReplays; replay++) {
     // Zero the window buffer so we can detect fresh data
     CUDACHECK_TEST(cudaMemset(winBase, 0, winSizeBytes));
     CUDACHECK_TEST(cudaDeviceSynchronize());
-    this->barrier(comm.get());
+    oobBarrier();
 
     CUDACHECK_TEST(cudaGraphLaunch(graphExec, captureStream));
     CUDACHECK_TEST(cudaStreamSynchronize(captureStream));
-    this->barrier(comm.get());
+    oobBarrier();
 
     // Verify data from previous peer arrived correctly
     int* winBufInt = reinterpret_cast<int*>(winBase);
@@ -722,7 +657,7 @@ TEST_F(CtranWinDistTest, signalResetAcrossGraphReplays) {
   CUDACHECK_TEST(cudaEventDestroy(joinEvent));
   CUDACHECK_TEST(cudaEventDestroy(joinEvent2));
   COMMCHECK_TEST(ctranWinFree(win));
-  this->barrier(comm.get());
+  oobBarrier();
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -739,7 +674,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
-  ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);
+  ::testing::AddGlobalTestEnvironment(new ctran::CtranDistEnvironment);
   folly::Init init(&argc, &argv);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Summary: Also simplify barrier to use `oobBarrier`

Reviewed By: minsii

Differential Revision: D98420371


