### PR TITLE
Add allgatherp to NCCLX backend (#1332)

### DIFF
--- a/comms/torchcomms/ncclx/NcclxApi.cpp
+++ b/comms/torchcomms/ncclx/NcclxApi.cpp
@@ -407,6 +407,32 @@ ncclResult_t DefaultNcclxApi::alltoallvDedupCombine(
       "NCCLX allToAllvDedupCombine is not supported in this build");
 }
 
+ncclResult_t DefaultNcclxApi::allGatherInit(
+    void* recvbuff,
+    size_t maxRecvCount,
+    const std::unordered_map<std::string, std::string>& hints,
+    ncclDataType_t datatype,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    void** request) {
+  std::lock_guard<std::mutex> lock(api_mutex_);
+  ncclx::Hints ncclxHints;
+  for (const auto& [key, value] : hints) {
+    ncclxHints.set(key, value);
+  }
+  return ncclx::allGatherInit(
+      recvbuff, maxRecvCount, ncclxHints, datatype, comm, stream, request);
+}
+
+ncclResult_t DefaultNcclxApi::allGatherExec(
+    const void* sendbuff,
+    size_t count,
+    ncclDataType_t datatype,
+    void* request) {
+  std::lock_guard<std::mutex> lock(api_mutex_);
+  return ncclx::allGatherExec(sendbuff, count, datatype, request);
+}
+
 ncclResult_t DefaultNcclxApi::pFree(void* request) {
   std::lock_guard<std::mutex> lock(api_mutex_);
   return ncclx::pFree(request);

--- a/comms/torchcomms/ncclx/NcclxApi.hpp
+++ b/comms/torchcomms/ncclx/NcclxApi.hpp
@@ -283,6 +283,22 @@ class NcclxApi {
       void* recvBuff,
       void* request) = 0;
 
+  // Persistent AllGather operations
+  [[nodiscard]] virtual ncclResult_t allGatherInit(
+      void* recvbuff,
+      size_t maxRecvCount,
+      const std::unordered_map<std::string, std::string>& hints,
+      ncclDataType_t datatype,
+      ncclComm_t comm,
+      cudaStream_t stream,
+      void** request) = 0;
+
+  [[nodiscard]] virtual ncclResult_t allGatherExec(
+      const void* sendbuff,
+      size_t count,
+      ncclDataType_t datatype,
+      void* request) = 0;
+
   [[nodiscard]] virtual ncclResult_t pFree(void* request) = 0;
 
   [[nodiscard]] virtual ncclResult_t commWindowRegister(
@@ -609,6 +625,22 @@ class DefaultNcclxApi : public NcclxApi {
       const int* fwdIdx,
       const int* recvIdx,
       void* recvBuff,
+      void* request) override;
+
+  // Persistent AllGather operations
+  [[nodiscard]] ncclResult_t allGatherInit(
+      void* recvbuff,
+      size_t maxRecvCount,
+      const std::unordered_map<std::string, std::string>& hints,
+      ncclDataType_t datatype,
+      ncclComm_t comm,
+      cudaStream_t stream,
+      void** request) override;
+
+  [[nodiscard]] ncclResult_t allGatherExec(
+      const void* sendbuff,
+      size_t count,
+      ncclDataType_t datatype,
       void* request) override;
 
   [[nodiscard]] ncclResult_t pFree(void* request) override;

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -1007,6 +1007,87 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::all_gather_single(
   return work;
 }
 
+// Persistent AllGather operations
+
+TorchCommBackend::AllGatherPHandle TorchCommNCCLX::all_gather_p_init(
+    at::Tensor& output,
+    const AllGatherPInitOptions& options) {
+  checkInitialized();
+  checkAndAbortIfTimedOutOrError();
+  ensureTensorContiguous(output);
+
+  size_t maxRecvCount = output.numel();
+  size_t bufferSize = maxRecvCount * output.element_size();
+
+  // Register the output buffer if not already registered
+  void* dataPtr = output.data_ptr();
+  auto it = memoryRegistrationHandles_.find(dataPtr);
+  if (it == memoryRegistrationHandles_.end()) {
+    void* regHandle = nullptr;
+    NCCLX_CHECK(
+        nccl_api_,
+        nccl_comm_,
+        nccl_api_->commRegister(nccl_comm_, dataPtr, bufferSize, &regHandle),
+        "NCCLX commRegister failed for AllGatherP output buffer");
+    memoryRegistrationHandles_.emplace(dataPtr, RegistrationHandle(regHandle));
+  }
+
+  void* request = nullptr;
+  NCCLX_CHECK(
+      nccl_api_,
+      nccl_comm_,
+      nccl_api_->allGatherInit(
+          dataPtr,
+          maxRecvCount,
+          options.hints,
+          getNcclDataType(output),
+          nccl_comm_,
+          getInternalStream(),
+          &request),
+      "NCCLX allGatherInit failed");
+
+  return request;
+}
+
+c10::intrusive_ptr<TorchWork> TorchCommNCCLX::all_gather_p_exec(
+    AllGatherPHandle handle,
+    const at::Tensor& input,
+    bool async_op,
+    const AllGatherPExecOptions& options) {
+  checkInitialized();
+  checkAndAbortIfTimedOutOrError();
+  ensureTensorContiguous(input);
+
+  TracingGuard tracingGuard(
+      name_, comm_size_, "all_gather_p_exec", rank_, {input}, {});
+
+  cudaStream_t stream = getOperationStream(async_op);
+  graph_event_tracker_.initOnGraphStart(stream);
+  auto work = createWork(
+      stream, getOperationTimeout(options.timeout, options_.timeout), {input});
+
+  work->recordStart("all_gather_p_exec");
+
+  NCCLX_CHECK(
+      nccl_api_,
+      nccl_comm_,
+      nccl_api_->allGatherExec(
+          input.data_ptr(), input.numel(), getNcclDataType(input), handle),
+      "NCCLX allGatherExec failed");
+
+  work->recordEnd();
+  enqueueWork(work, stream);
+
+  return work;
+}
+
+void TorchCommNCCLX::all_gather_p_free(AllGatherPHandle handle) {
+  if (handle == nullptr) {
+    return;
+  }
+  NCCLX_CHECK_IGNORE(nccl_api_, nccl_api_->pFree(handle), "NCCLX pFree failed");
+}
+
 c10::intrusive_ptr<TorchWork> TorchCommNCCLX::reduce_scatter(
     at::Tensor& output,
     const std::vector<at::Tensor>& input_list,

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
@@ -230,6 +230,17 @@ class TorchCommNCCLX : public TorchCommBackend,
       const at::Tensor& recv_indices,
       at::intrusive_ptr<TorchCommNCCLXPersistentRequest> pReq);
 
+  // Persistent AllGather operations
+  AllGatherPHandle all_gather_p_init(
+      at::Tensor& output,
+      const AllGatherPInitOptions& options = {}) override;
+  c10::intrusive_ptr<TorchWork> all_gather_p_exec(
+      AllGatherPHandle handle,
+      const at::Tensor& input,
+      bool async_op,
+      const AllGatherPExecOptions& options = {}) override;
+  void all_gather_p_free(AllGatherPHandle handle) override;
+
   c10::intrusive_ptr<TorchWork> barrier(
       bool async_op,
       const BarrierOptions& options = {}) override;

--- a/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.hpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.hpp
@@ -280,6 +280,28 @@ class NcclxMock : public NcclxApi {
        void* request),
       (override));
 
+  // Persistent AllGather operations
+  MOCK_METHOD(
+      ncclResult_t,
+      allGatherInit,
+      (void* recvbuff,
+       size_t maxRecvCount,
+       (const NcclxCommDumpMap& hints),
+       ncclDataType_t datatype,
+       ncclComm_t comm,
+       cudaStream_t stream,
+       void** request),
+      (override));
+
+  MOCK_METHOD(
+      ncclResult_t,
+      allGatherExec,
+      (const void* sendbuff,
+       size_t count,
+       ncclDataType_t datatype,
+       void* request),
+      (override));
+
   MOCK_METHOD(ncclResult_t, pFree, (void* request), (override));
 
   MOCK_METHOD(

--- a/comms/torchcomms/tests/integration/py/AllGatherPTest.py
+++ b/comms/torchcomms/tests/integration/py/AllGatherPTest.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# pyre-unsafe
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""Tests for allgatherp (CE-based persistent allgather) via the torchcomms NCCLX backend.
+
+Validates that allgatherp init/exec/free work correctly through the
+TorchCommNCCLX Python API, and that the output buffer can be reused for
+SM compute after the CE-based collective completes.
+"""
+
+import os
+import unittest
+
+import torch
+import torchcomms
+from torchcomms.tests.integration.py.TorchCommTestHelpers import TorchCommTestWrapper
+
+
+class AllGatherPTest(unittest.TestCase):
+    """Tests for allgatherp eager execution via the torchcomms NCCLX backend."""
+
+    NUM_REPLAYS = 3
+    ELEM_COUNT = 1024
+
+    def setUp(self) -> None:
+        self.wrapper = TorchCommTestWrapper()
+        self.comm = self.wrapper.get_torchcomm()
+        self.rank = self.comm.get_rank()
+        self.size = self.comm.get_size()
+        self.device = self.comm.get_device()
+
+    def tearDown(self) -> None:
+        del self.comm
+        del self.wrapper
+
+    @unittest.skipIf(
+        os.getenv("NCCL_CTRAN_ENABLE") != "true",
+        "Requires ctran transport (NCCL_CTRAN_ENABLE=true)",
+    )
+    def test_allgatherp(self) -> None:
+        """Eager allgatherp followed by compute on the output buffer."""
+        count = self.ELEM_COUNT
+
+        input_tensor = (
+            torch.ones(count, dtype=torch.float32, device=self.device) * self.rank
+        )
+
+        allocator = torchcomms.get_mem_allocator(self.comm.get_backend())
+        pool = torch.cuda.MemPool(allocator)
+        with torch.cuda.use_mem_pool(pool):
+            output_tensor = torch.zeros(
+                count * self.size, dtype=torch.float32, device=self.device
+            )
+
+        handle = self.comm.all_gather_p_init(output_tensor)
+        self.comm.barrier(False)
+
+        for _ in range(self.NUM_REPLAYS):
+            work = self.comm.all_gather_p_exec(handle, input_tensor, async_op=True)
+            work.wait()
+            torch.cuda.synchronize()
+
+            # Verify allgather correctness
+            for r in range(self.size):
+                chunk = output_tensor[r * count : (r + 1) * count]
+                expected = (
+                    torch.ones(count, dtype=torch.float32, device=self.device) * r
+                )
+                torch.testing.assert_close(
+                    chunk,
+                    expected,
+                    rtol=1e-5,
+                    atol=1e-5,
+                    msg=f"Rank {self.rank}: chunk for rank {r} mismatch",
+                )
+
+            # Reuse the output buffer for compute
+            compute_result = output_tensor.sum()
+            expected_sum = sum(r * count for r in range(self.size))
+            self.assertAlmostEqual(
+                compute_result.item(),
+                float(expected_sum),
+                places=0,
+                msg=f"Rank {self.rank}: compute on allgatherp output mismatch",
+            )
+
+        self.comm.all_gather_p_free(handle)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:

Add allGatherInit/allGatherExec to NcclxApi and TorchCommNCCLX, exposing
ctran's persistent allgather through the torchcomms Python API. Includes an
eager-mode integration test that verifies allgatherp correctness and
demonstrates output buffer reuse for SM compute after CE-based collectives.

Reviewed By: sudharssun

Differential Revision: D98551734
