### PR TITLE
Add getPipesHostWindow accessor to CtranWin

### DIFF
--- a/comms/ctran/window/CtranWin.h
+++ b/comms/ctran/window/CtranWin.h
@@ -120,6 +120,13 @@ struct CtranWin {
   commResult_t get_device_win(
       comms::pipes::DeviceWindow* devWin,
       const comms::pipes::WindowConfig& config);
+
+  // Returns the pipes HostWindow pointer for this window.
+  // The caller does not take ownership.
+  // Returns nullptr if pipes device window is not initialized.
+  comms::pipes::HostWindow* getPipesHostWindow() const {
+    return hostWindow_.get();
+  }
 #endif
 
   commResult_t free();


### PR DESCRIPTION
Summary:
Expose the pipes HostWindow pointer from CtranWin so that callers
(e.g., AFDComm) can register local buffers and access the HostWindow
for pipes DeviceWindow initialization without reaching into ctran internals.

Reviewed By: Scusemua

Differential Revision: D98559375


