### PR TITLE
Support cudaMemcpyBatchAsync for CUDA 12.8

### DIFF
--- a/comms/ctran/algos/AllGatherP/CommUtils.h
+++ b/comms/ctran/algos/AllGatherP/CommUtils.h
@@ -94,13 +94,20 @@ inline commResult_t nvlCeBcast(
     sizes.at(r - 1) = sendSize;
   }
 
-#if CUDART_VERSION >= 13000
+#if CUDART_VERSION >= 12080
   cudaMemcpyAttributes attr = {};
   attr.srcAccessOrder = cudaMemcpySrcAccessOrderStream;
   attr.flags = cudaMemcpyFlagPreferOverlapWithCompute;
 
+#if CUDART_VERSION < 13000
+  size_t failIdx = 0;
+  FB_CUDACHECK(cudaMemcpyBatchAsync(
+      dsts.data(), srcs.data(), sizes.data(), numOps, attr, &failIdx, stream));
+#else
   FB_CUDACHECK(cudaMemcpyBatchAsync(
       dsts.data(), srcs.data(), sizes.data(), numOps, attr, stream));
+#endif
+
 #else
   auto mapper = comm->ctran_->mapper.get();
   for (size_t i = 0; i < numOps; i++) {


### PR DESCRIPTION
Summary:
The cudaMemcpyBatchAsync API was introduced in CUDA 12.8 but with a
different signature that includes a `failIdx` output parameter. In
CUDA 13.0+ the `failIdx` parameter was removed. This change lowers
the CUDART_VERSION guard from 13000 to 12080 and dispatches to the
correct API signature based on the CUDA version, enabling the
batched memcpy path for CUDA 12.8 builds.

Differential Revision: D98765390


