### PR TITLE
Add OperationTraceWriter DI interface for mccl_operation_trace logging (#1337)

### DIFF
--- a/comms/utils/logger/OperationTraceWriter.cc
+++ b/comms/utils/logger/OperationTraceWriter.cc
@@ -1,0 +1,23 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/utils/logger/OperationTraceWriter.h"
+
+namespace comms::logger {
+
+namespace {
+std::shared_ptr<IOperationTraceWriter>& writerInstance() {
+  static std::shared_ptr<IOperationTraceWriter> instance;
+  return instance;
+}
+} // namespace
+
+void OperationTraceWriterRegistry::set(
+    std::shared_ptr<IOperationTraceWriter> writer) {
+  writerInstance() = std::move(writer);
+}
+
+IOperationTraceWriter* OperationTraceWriterRegistry::get() {
+  return writerInstance().get();
+}
+
+} // namespace comms::logger

--- a/comms/utils/logger/OperationTraceWriter.h
+++ b/comms/utils/logger/OperationTraceWriter.h
@@ -1,0 +1,49 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+
+namespace comms::logger {
+
+// Sample for operation trace logging to mccl_operation_trace scuba table.
+// Defines the schema for all columns that ctran (and other lower-level
+// components) can log through the DI writer, without depending on MCCL.
+struct OperationTraceSample {
+  std::string mcclop; // Operation type (e.g., "GPE_EXECUTION")
+  std::string event; // Event name (e.g., "GPE_EXECUTION_END")
+  int64_t timestampUs{0}; // Timestamp in microseconds
+  int rank{-1};
+  int64_t commHash{0};
+  int64_t commId{0};
+  int worldSize{-1};
+  int64_t opCount{-1};
+  std::optional<int64_t> durationUs;
+};
+
+// Interface for operation trace writers.
+// Implementations route samples to their respective scuba tables
+// (e.g., mccl_operation_trace, ncclx_operation_trace).
+class IOperationTraceWriter {
+ public:
+  virtual ~IOperationTraceWriter() = default;
+  virtual bool isEnabled() const = 0;
+  virtual void addSample(OperationTraceSample sample) = 0;
+};
+
+// Global registry for the operation trace writer.
+// Set by the communication library (MCCL or NCCLX) during initialization;
+// queried by lower-level components (e.g., ctran) at runtime.
+class OperationTraceWriterRegistry {
+ public:
+  static void set(std::shared_ptr<IOperationTraceWriter> writer);
+  static IOperationTraceWriter* get();
+
+ private:
+  OperationTraceWriterRegistry() = delete;
+};
+
+} // namespace comms::logger

--- a/comms/utils/logger/tests/OperationTraceWriterTest.cc
+++ b/comms/utils/logger/tests/OperationTraceWriterTest.cc
@@ -1,0 +1,88 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include "comms/utils/logger/OperationTraceWriter.h"
+
+using comms::logger::IOperationTraceWriter;
+using comms::logger::OperationTraceSample;
+using comms::logger::OperationTraceWriterRegistry;
+
+namespace {
+
+class MockOperationTraceWriter : public IOperationTraceWriter {
+ public:
+  bool isEnabled() const override {
+    return enabled;
+  }
+
+  void addSample(OperationTraceSample sample) override {
+    samples.push_back(std::move(sample));
+  }
+
+  bool enabled{true};
+  std::vector<OperationTraceSample> samples;
+};
+
+class OperationTraceWriterTest : public ::testing::Test {
+ protected:
+  void TearDown() override {
+    OperationTraceWriterRegistry::set(nullptr);
+  }
+};
+
+} // namespace
+
+TEST_F(OperationTraceWriterTest, RegistryReturnsNullByDefault) {
+  EXPECT_EQ(OperationTraceWriterRegistry::get(), nullptr);
+}
+
+TEST_F(OperationTraceWriterTest, RegisteredWriterReceivesSamples) {
+  auto mock = std::make_shared<MockOperationTraceWriter>();
+  OperationTraceWriterRegistry::set(mock);
+
+  auto* writer = OperationTraceWriterRegistry::get();
+  ASSERT_NE(writer, nullptr);
+  EXPECT_TRUE(writer->isEnabled());
+
+  OperationTraceSample sample;
+  sample.mcclop = "TEST_OP";
+  sample.event = "TEST_OP_END";
+  sample.timestampUs = 1000000;
+  sample.rank = 3;
+  sample.commHash = 12345;
+  sample.commId = 99;
+  sample.worldSize = 8;
+  sample.opCount = 42;
+  sample.durationUs = 500;
+  writer->addSample(std::move(sample));
+
+  ASSERT_EQ(mock->samples.size(), 1);
+  const auto& s = mock->samples[0];
+  EXPECT_EQ(s.mcclop, "TEST_OP");
+  EXPECT_EQ(s.event, "TEST_OP_END");
+  EXPECT_EQ(s.timestampUs, 1000000);
+  EXPECT_EQ(s.rank, 3);
+  EXPECT_EQ(s.commHash, 12345);
+  EXPECT_EQ(s.commId, 99);
+  EXPECT_EQ(s.worldSize, 8);
+  EXPECT_EQ(s.opCount, 42);
+  ASSERT_TRUE(s.durationUs.has_value());
+  EXPECT_EQ(s.durationUs.value(), 500);
+}
+
+TEST_F(OperationTraceWriterTest, DisabledWriterSkipsSamples) {
+  auto mock = std::make_shared<MockOperationTraceWriter>();
+  mock->enabled = false;
+  OperationTraceWriterRegistry::set(mock);
+
+  auto* writer = OperationTraceWriterRegistry::get();
+  ASSERT_NE(writer, nullptr);
+  EXPECT_FALSE(writer->isEnabled());
+
+  if (writer->isEnabled()) {
+    OperationTraceSample sample;
+    writer->addSample(std::move(sample));
+  }
+  EXPECT_EQ(mock->samples.size(), 0);
+}


### PR DESCRIPTION
Summary:

Add a dependency-injected operation trace writer interface that allows
lower-level components (e.g., ctran) to log events and timestamps to
the mccl_operation_trace scuba table without depending on MCCL.

Components:
- `OperationTraceSample`: struct with named fields matching scuba columns
  (mcclop, event, timestamp, rank, commHash, commId, worldSize, opCount,
  durationUs)
- `IOperationTraceWriter`: abstract interface with `isEnabled()` and
  `addSample()` methods
- `OperationTraceWriterRegistry`: singleton for global writer registration,
  set during communicator init, queried at runtime

Differential Revision: D98770697


