### PR TITLE
Add iterated stress tests for P2pNvlTransportDevice APIs (#1339)

### DIFF
--- a/comms/torchcomms/tests/integration/cpp/PipesDeviceApiIteratedTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/PipesDeviceApiIteratedTest.cpp
@@ -42,6 +42,16 @@ void PipesDeviceApiIteratedTest::SetUp() {
 }
 
 void PipesDeviceApiIteratedTest::TearDown() {
+  // Barrier + GPU sync before destroy to prevent cross-rank desynchronization.
+  // Without this, fast ranks can start creating the next communicator (which
+  // requires collective bootstrap) while slow ranks are still destroying DOCA
+  // IBGDA resources (QP teardown, cudaFree implicit sync, ibv_close_device).
+  // On GB200 multi-node, this desync causes the next comm's exchangeUniqueId()
+  // to hang because ranks never rendezvous on the same bootstrap operation.
+  if (torchcomm_) {
+    torchcomm_->barrier(false);
+    cudaDeviceSynchronize();
+  }
   torchcomm_.reset();
   wrapper_.reset();
 }

--- a/comms/torchcomms/tests/integration/cpp/PipesTransportApiTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/PipesTransportApiTest.cpp
@@ -23,7 +23,7 @@ void PipesTransportApiTest::SetUp() {
   // Check skip condition FIRST, before any initialization
   if (checkIfSkip()) {
     GTEST_SKIP() << "Skipping Pipes Transport API tests "
-                    "(RUN_PIPES_TRANSPORT_API_TEST not set)";
+                    "(RUN_PIPES_DEVICE_API_TEST not set)";
   }
 
   wrapper_ = createWrapper();
@@ -42,8 +42,8 @@ void PipesTransportApiTest::TearDown() {
 }
 
 bool PipesTransportApiTest::checkIfSkip() {
-  // Check RUN_PIPES_TRANSPORT_API_TEST env var
-  const char* run_env = getenv("RUN_PIPES_TRANSPORT_API_TEST");
+  // Check RUN_PIPES_DEVICE_API_TEST env var (unified gate for all pipes tests)
+  const char* run_env = getenv("RUN_PIPES_DEVICE_API_TEST");
   if (!run_env) {
     return true; // skip if not set
   }
@@ -54,6 +54,34 @@ bool PipesTransportApiTest::checkIfSkip() {
   }
 
   return false;
+}
+
+// =============================================================================
+// Helper: fetch transport handle
+// =============================================================================
+
+bool PipesTransportApiTest::getTransportHandle(
+    comms::pipes::MultiPeerDeviceHandle& handle) {
+  auto ncclx = std::dynamic_pointer_cast<torch::comms::TorchCommNCCLX>(
+      torchcomm_->getBackendImpl());
+  EXPECT_NE(ncclx, nullptr) << "Backend is not TorchCommNCCLX";
+  if (!ncclx) {
+    return false;
+  }
+
+  auto handle_ptr = ncclx->get_device_transport();
+  EXPECT_NE(handle_ptr, 0) << "get_device_transport returned null";
+  if (handle_ptr == 0) {
+    return false;
+  }
+
+  auto copy_err = cudaMemcpy(
+      &handle,
+      reinterpret_cast<void*>(handle_ptr),
+      sizeof(comms::pipes::MultiPeerDeviceHandle),
+      cudaMemcpyDeviceToHost);
+  EXPECT_EQ(copy_err, cudaSuccess) << "Failed to copy transport handle";
+  return copy_err == cudaSuccess;
 }
 
 // =============================================================================
@@ -176,4 +204,116 @@ TEST_F(PipesTransportApiTest, NvlSendRecvSmall) {
 
 TEST_F(PipesTransportApiTest, NvlSendRecvLarge) {
   testNvlSendRecv(1024 * 1024);
+}
+
+// =============================================================================
+// NVL Signal Test
+// =============================================================================
+// Both ranks signal each other (ADD 1 on signal_id 0) and wait (GE 1).
+// Validates cross-GPU signal/wait via the transport handle.
+
+void PipesTransportApiTest::testNvlSignal() {
+  SCOPED_TRACE(::testing::Message() << "Testing NVL signal");
+
+  ASSERT_GE(num_ranks_, 2) << "Need at least 2 ranks for signal test";
+
+  comms::pipes::MultiPeerDeviceHandle handle{};
+  ASSERT_TRUE(getTransportHandle(handle));
+
+  if (handle.numNvlPeers == 0) {
+    GTEST_SKIP() << "No NVL peers available — signal requires NVLink";
+  }
+
+  int peer = (rank_ == 0) ? 1 : 0;
+
+  torchcomm_->barrier(false);
+
+  torchcomms::device::test::launchNvlSignalKernel(handle, peer);
+
+  auto cuda_err = cudaDeviceSynchronize();
+  ASSERT_EQ(cuda_err, cudaSuccess) << "Signal kernel execution failed";
+
+  torchcomm_->barrier(false);
+}
+
+TEST_F(PipesTransportApiTest, NvlSignal) {
+  testNvlSignal();
+}
+
+// =============================================================================
+// NVL LL128 Send/Recv Test
+// =============================================================================
+// Rank 0 sends a buffer filled with 0xAB to rank 1 via LL128 protocol.
+// Rank 1 receives and verifies the data.
+// LL128 requires 16-byte alignment and nbytes multiple of 16.
+
+void PipesTransportApiTest::testNvlLl128SendRecv(size_t nbytes) {
+  SCOPED_TRACE(
+      ::testing::Message() << "Testing NVL LL128 send/recv nbytes=" << nbytes);
+
+  ASSERT_GE(num_ranks_, 2) << "Need at least 2 ranks for LL128 test";
+  ASSERT_EQ(nbytes % 16, 0u) << "LL128 requires nbytes multiple of 16";
+
+  comms::pipes::MultiPeerDeviceHandle handle{};
+  ASSERT_TRUE(getTransportHandle(handle));
+
+  if (handle.numNvlPeers == 0) {
+    GTEST_SKIP() << "No NVL peers available — LL128 requires NVLink";
+  }
+
+  // Check LL128 availability on host side BEFORE launching kernels.
+  // Both ranks must agree on skip/run to avoid one side hanging.
+  int peer = (rank_ == 0) ? 1 : 0;
+  int ll128_available =
+      torchcomms::device::test::checkLl128Available(handle, peer);
+  if (!ll128_available) {
+    GTEST_SKIP() << "LL128 not configured on this hardware";
+  }
+
+  void* buf_d = nullptr;
+  auto cuda_err = cudaMalloc(&buf_d, nbytes);
+  ASSERT_EQ(cuda_err, cudaSuccess) << "cudaMalloc failed";
+
+  if (rank_ == 0) {
+    cuda_err = cudaMemset(buf_d, 0xAB, nbytes);
+    ASSERT_EQ(cuda_err, cudaSuccess);
+  } else {
+    cuda_err = cudaMemset(buf_d, 0x00, nbytes);
+    ASSERT_EQ(cuda_err, cudaSuccess);
+  }
+
+  torchcomm_->barrier(false);
+
+  if (rank_ == 0) {
+    torchcomms::device::test::launchNvlLl128SendKernel(
+        handle, peer, buf_d, nbytes);
+  } else if (rank_ == 1) {
+    torchcomms::device::test::launchNvlLl128RecvKernel(
+        handle, peer, buf_d, nbytes);
+  }
+
+  cuda_err = cudaDeviceSynchronize();
+  ASSERT_EQ(cuda_err, cudaSuccess) << "LL128 kernel execution failed";
+
+  if (rank_ == 1) {
+    std::vector<uint8_t> host_buf(nbytes);
+    cuda_err =
+        cudaMemcpy(host_buf.data(), buf_d, nbytes, cudaMemcpyDeviceToHost);
+    ASSERT_EQ(cuda_err, cudaSuccess);
+
+    std::vector<uint8_t> expected(nbytes, 0xAB);
+    ASSERT_EQ(memcmp(host_buf.data(), expected.data(), nbytes), 0)
+        << "Data mismatch in LL128 received buffer";
+  }
+
+  torchcomm_->barrier(false);
+  ASSERT_EQ(cudaFree(buf_d), cudaSuccess) << "cudaFree failed";
+}
+
+TEST_F(PipesTransportApiTest, NvlLl128SendRecvSmall) {
+  testNvlLl128SendRecv(1024);
+}
+
+TEST_F(PipesTransportApiTest, NvlLl128SendRecvLarge) {
+  testNvlLl128SendRecv(65536);
 }

--- a/comms/torchcomms/tests/integration/cpp/PipesTransportApiTest.hpp
+++ b/comms/torchcomms/tests/integration/cpp/PipesTransportApiTest.hpp
@@ -18,6 +18,7 @@
 #include <string>
 
 #include "TorchCommTestHelpers.h"
+#include "comms/pipes/MultiPeerDeviceHandle.cuh"
 #include "comms/torchcomms/TorchComm.hpp"
 
 class PipesTransportApiTest : public ::testing::Test {
@@ -31,6 +32,9 @@ class PipesTransportApiTest : public ::testing::Test {
   // Create a wrapper for TorchComm
   std::unique_ptr<TorchCommTestWrapper> createWrapper();
 
+  // Helper to get transport handle (returns false + skips if unavailable)
+  bool getTransportHandle(comms::pipes::MultiPeerDeviceHandle& handle);
+
   // Test functions
 
   // Verify that get_device_transport() returns a valid MultiPeerDeviceHandle.
@@ -38,6 +42,12 @@ class PipesTransportApiTest : public ::testing::Test {
 
   // Test NVL send/recv: rank 0 sends nbytes to rank 1 via NVLink transport.
   void testNvlSendRecv(size_t nbytes);
+
+  // Test NVL signal: both ranks signal each other and wait.
+  void testNvlSignal();
+
+  // Test NVL LL128 send/recv: rank 0 sends, rank 1 receives via LL128.
+  void testNvlLl128SendRecv(size_t nbytes);
 
   // Member variables
   std::unique_ptr<TorchCommTestWrapper> wrapper_;

--- a/comms/torchcomms/tests/integration/cpp/PipesTransportApiTestKernels.cu
+++ b/comms/torchcomms/tests/integration/cpp/PipesTransportApiTestKernels.cu
@@ -56,6 +56,50 @@ __global__ void nvlRecvKernel(
 }
 
 // =============================================================================
+// NVL Signal Kernel
+// =============================================================================
+// Both ranks signal each other (ADD 1 on signal_id 0) and wait (GE 1).
+
+__global__ void nvlSignalKernel(
+    comms::pipes::MultiPeerDeviceHandle handle,
+    int peerRank) {
+  auto group = comms::pipes::make_warp_group();
+  auto& nvl = handle.get_nvl(peerRank);
+  nvl.signal_threadgroup(group, 0, comms::pipes::SignalOp::SIGNAL_ADD, 1);
+  nvl.wait_signal_until_threadgroup(group, 0, comms::pipes::CmpOp::CMP_GE, 1);
+}
+
+// =============================================================================
+// NVL LL128 Send/Recv Kernels
+// =============================================================================
+
+__global__ void nvlLl128SendKernel(
+    comms::pipes::MultiPeerDeviceHandle handle,
+    int peerRank,
+    char* src_d,
+    size_t nbytes) {
+  auto group = comms::pipes::make_warp_group();
+  auto& nvl = handle.get_nvl(peerRank);
+  if (nvl.get_ll128_buffer_num_packets() == 0) {
+    return; // LL128 not configured — skip
+  }
+  nvl.ll128_send(group, src_d, nbytes);
+}
+
+__global__ void nvlLl128RecvKernel(
+    comms::pipes::MultiPeerDeviceHandle handle,
+    int peerRank,
+    char* dst_d,
+    size_t nbytes) {
+  auto group = comms::pipes::make_warp_group();
+  auto& nvl = handle.get_nvl(peerRank);
+  if (nvl.get_ll128_buffer_num_packets() == 0) {
+    return; // LL128 not configured — skip
+  }
+  nvl.ll128_recv(group, dst_d, nbytes);
+}
+
+// =============================================================================
 // Host-callable wrapper functions
 // =============================================================================
 
@@ -77,6 +121,76 @@ void launchNvlRecvKernel(
     cudaStream_t stream) {
   nvlRecvKernel<<<1, 32, 0, stream>>>(handle, peerRank, dst_d, nbytes);
   CUDA_LAUNCH_CHECK();
+}
+
+void launchNvlSignalKernel(
+    comms::pipes::MultiPeerDeviceHandle handle,
+    int peerRank,
+    cudaStream_t stream) {
+  nvlSignalKernel<<<1, 32, 0, stream>>>(handle, peerRank);
+  CUDA_LAUNCH_CHECK();
+}
+
+void launchNvlLl128SendKernel(
+    comms::pipes::MultiPeerDeviceHandle handle,
+    int peerRank,
+    void* src_d,
+    size_t nbytes,
+    cudaStream_t stream) {
+  nvlLl128SendKernel<<<1, 32, 0, stream>>>(
+      handle, peerRank, static_cast<char*>(src_d), nbytes);
+  CUDA_LAUNCH_CHECK();
+}
+
+void launchNvlLl128RecvKernel(
+    comms::pipes::MultiPeerDeviceHandle handle,
+    int peerRank,
+    void* dst_d,
+    size_t nbytes,
+    cudaStream_t stream) {
+  nvlLl128RecvKernel<<<1, 32, 0, stream>>>(
+      handle, peerRank, static_cast<char*>(dst_d), nbytes);
+  CUDA_LAUNCH_CHECK();
+}
+
+// =============================================================================
+// LL128 Availability Check
+// =============================================================================
+// Single-thread kernel that writes get_ll128_buffer_num_packets() to *result_d.
+
+__global__ void ll128AvailableKernel(
+    comms::pipes::MultiPeerDeviceHandle handle,
+    int peerRank,
+    int* result_d) {
+  auto& nvl = handle.get_nvl(peerRank);
+  *result_d = static_cast<int>(nvl.get_ll128_buffer_num_packets());
+}
+
+int checkLl128Available(
+    comms::pipes::MultiPeerDeviceHandle handle,
+    int peerRank,
+    cudaStream_t stream) {
+  int* d_result = nullptr;
+  auto err = cudaMalloc(&d_result, sizeof(int));
+  if (err != cudaSuccess) {
+    return 0;
+  }
+  cudaMemset(d_result, 0, sizeof(int));
+  ll128AvailableKernel<<<1, 1, 0, stream>>>(handle, peerRank, d_result);
+  err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    cudaFree(d_result);
+    return 0;
+  }
+  err = cudaDeviceSynchronize();
+  if (err != cudaSuccess) {
+    cudaFree(d_result);
+    return 0;
+  }
+  int h_result = 0;
+  cudaMemcpy(&h_result, d_result, sizeof(int), cudaMemcpyDeviceToHost);
+  cudaFree(d_result);
+  return h_result;
 }
 
 } // namespace torchcomms::device::test

--- a/comms/torchcomms/tests/integration/cpp/PipesTransportApiTestKernels.cuh
+++ b/comms/torchcomms/tests/integration/cpp/PipesTransportApiTestKernels.cuh
@@ -2,7 +2,7 @@
 // CUDA kernel declarations for PipesTransportApiTest
 //
 // This header provides function declarations for launching warp-level
-// NVL send/recv kernels via the pipes MultiPeerDeviceHandle.
+// NVL transport kernels via the pipes MultiPeerDeviceHandle.
 //
 // The full device implementations are only in the .cu file which is
 // compiled by nvcc.
@@ -29,6 +29,36 @@ void launchNvlRecvKernel(
     int peerRank,
     void* dst_d,
     size_t nbytes,
+    cudaStream_t stream = nullptr);
+
+// Launch signal kernel: signals peer (ADD 1 on signal_id 0) and waits for
+// peer's signal (GE 1 on signal_id 0). Both ranks must call.
+void launchNvlSignalKernel(
+    comms::pipes::MultiPeerDeviceHandle handle,
+    int peerRank,
+    cudaStream_t stream = nullptr);
+
+// Launch LL128 send kernel (warp-only, 16-byte aligned).
+void launchNvlLl128SendKernel(
+    comms::pipes::MultiPeerDeviceHandle handle,
+    int peerRank,
+    void* src_d,
+    size_t nbytes,
+    cudaStream_t stream = nullptr);
+
+// Launch LL128 recv kernel (warp-only, 16-byte aligned).
+void launchNvlLl128RecvKernel(
+    comms::pipes::MultiPeerDeviceHandle handle,
+    int peerRank,
+    void* dst_d,
+    size_t nbytes,
+    cudaStream_t stream = nullptr);
+
+// Host-side check: returns non-zero if LL128 is available for the given peer.
+// Launches a tiny kernel to query get_ll128_buffer_num_packets() on device.
+int checkLl128Available(
+    comms::pipes::MultiPeerDeviceHandle handle,
+    int peerRank,
     cudaStream_t stream = nullptr);
 
 } // namespace torchcomms::device::test

--- a/comms/torchcomms/tests/integration/cpp/PipesTransportIteratedTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/PipesTransportIteratedTest.cpp
@@ -1,0 +1,369 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Iterated stress tests for P2pNvlTransportDevice APIs.
+
+#include "PipesTransportIteratedTest.hpp"
+
+#include <gtest/gtest.h>
+#include <algorithm>
+#include <cstring>
+#include <vector>
+
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAStream.h>
+
+#include "IteratedTestHelpers.hpp"
+#include "PipesTransportIteratedTestKernels.cuh"
+#include "TorchCommTestHelpers.h"
+#include "comms/torchcomms/TorchComm.hpp"
+#include "comms/torchcomms/ncclx/TorchCommNCCLX.hpp"
+
+using namespace torchcomms::device::test;
+
+// =============================================================================
+// Setup / Teardown
+// =============================================================================
+
+void PipesTransportIteratedTest::SetUp() {
+  if (!shouldRunIteratedTest()) {
+    GTEST_SKIP()
+        << "Skipping iterated tests (RUN_DEVICE_ITERATED_TEST not set)";
+  }
+  const char* pipes_env = getenv("RUN_PIPES_DEVICE_API_TEST");
+  if (!pipes_env) {
+    GTEST_SKIP()
+        << "Skipping Pipes iterated tests (RUN_PIPES_DEVICE_API_TEST not set)";
+  }
+
+  config_ = parseIteratedTestConfig();
+  wrapper_ = std::make_unique<TorchCommTestWrapper>();
+  torchcomm_ = wrapper_->getTorchComm();
+  rank_ = torchcomm_->getRank();
+  num_ranks_ = torchcomm_->getSize();
+  device_index_ = rank_ % at::cuda::device_count();
+
+  ASSERT_GE(num_ranks_, 2) << "Need at least 2 ranks for transport tests";
+
+  // Get device transport handle
+  auto ncclx = std::dynamic_pointer_cast<torch::comms::TorchCommNCCLX>(
+      torchcomm_->getBackendImpl());
+  ASSERT_NE(ncclx, nullptr) << "Backend is not TorchCommNCCLX";
+
+  auto handle_ptr = ncclx->get_device_transport();
+  ASSERT_NE(handle_ptr, 0) << "get_device_transport returned null";
+
+  auto copy_err = cudaMemcpy(
+      &handle_,
+      reinterpret_cast<void*>(handle_ptr),
+      sizeof(comms::pipes::MultiPeerDeviceHandle),
+      cudaMemcpyDeviceToHost);
+  ASSERT_EQ(copy_err, cudaSuccess) << "Failed to copy transport handle";
+  ASSERT_EQ(handle_.myRank, rank_);
+
+  if (handle_.numNvlPeers == 0) {
+    GTEST_SKIP() << "No NVL peers available — transport tests require NVLink";
+  }
+
+  // Ring pattern: peer is the other rank
+  peer_ = (rank_ == 0) ? 1 : 0;
+}
+
+void PipesTransportIteratedTest::TearDown() {
+  torchcomm_.reset();
+  wrapper_.reset();
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+namespace {
+
+void checkKernelResults(
+    int* d_results,
+    int iterations,
+    const std::string& tag) {
+  std::vector<int> h_results(iterations);
+  cudaMemcpy(
+      h_results.data(),
+      d_results,
+      iterations * sizeof(int),
+      cudaMemcpyDeviceToHost);
+  for (int i = 0; i < iterations; i++) {
+    ASSERT_EQ(h_results[i], 1)
+        << tag << ": verification failed at iteration " << i;
+  }
+}
+
+const char* scopeNameForThreads(int num_threads) {
+  return (num_threads >= 256) ? "BLOCK" : "WARP";
+}
+
+} // namespace
+
+// =============================================================================
+// Test Implementations
+// =============================================================================
+
+void PipesTransportIteratedTest::testIteratedSendRecv(
+    size_t msg_bytes,
+    int num_threads) {
+  size_t count = msg_bytes / sizeof(float);
+  if (count == 0) {
+    count = 1;
+  }
+  int iterations = config_.num_iterations;
+
+  SCOPED_TRACE(
+      ::testing::Message() << "TransportIteratedSendRecv msg="
+                           << formatBytes(msg_bytes)
+                           << " scope=" << scopeNameForThreads(num_threads)
+                           << " iters=" << iterations);
+
+  float* d_buf = nullptr;
+  ASSERT_EQ(cudaMalloc(&d_buf, count * sizeof(float)), cudaSuccess);
+
+  int* d_results = nullptr;
+  ASSERT_EQ(cudaMalloc(&d_results, iterations * sizeof(int)), cudaSuccess);
+  ASSERT_EQ(cudaMemset(d_results, 0, iterations * sizeof(int)), cudaSuccess);
+
+  torchcomm_->barrier(false);
+
+  auto stream = at::cuda::getStreamFromPool(false, device_index_);
+  {
+    c10::cuda::CUDAStreamGuard guard(stream);
+    launchTransportIteratedSendRecvKernel(
+        handle_,
+        d_buf,
+        count,
+        peer_,
+        iterations,
+        num_threads,
+        d_results,
+        stream.stream());
+  }
+  stream.synchronize();
+
+  checkKernelResults(
+      d_results,
+      iterations,
+      "TransportSendRecv(" + formatBytes(msg_bytes) + "," +
+          scopeNameForThreads(num_threads) + ")");
+
+  cudaFree(d_results);
+  cudaFree(d_buf);
+  torchcomm_->barrier(false);
+}
+
+void PipesTransportIteratedTest::testIteratedSignal(int num_threads) {
+  int iterations = config_.num_iterations;
+
+  SCOPED_TRACE(
+      ::testing::Message() << "TransportIteratedSignal scope="
+                           << scopeNameForThreads(num_threads));
+
+  torchcomm_->barrier(false);
+
+  auto stream = at::cuda::getStreamFromPool(false, device_index_);
+  {
+    c10::cuda::CUDAStreamGuard guard(stream);
+    launchTransportIteratedSignalKernel(
+        handle_, peer_, iterations, num_threads, stream.stream());
+  }
+  stream.synchronize();
+  torchcomm_->barrier(false);
+}
+
+void PipesTransportIteratedTest::testIteratedCombined(
+    size_t msg_bytes,
+    int num_threads) {
+  size_t count = msg_bytes / sizeof(float);
+  if (count == 0) {
+    count = 1;
+  }
+  int iterations = config_.num_iterations;
+
+  SCOPED_TRACE(
+      ::testing::Message() << "TransportIteratedCombined msg="
+                           << formatBytes(msg_bytes)
+                           << " scope=" << scopeNameForThreads(num_threads));
+
+  float* d_buf = nullptr;
+  ASSERT_EQ(cudaMalloc(&d_buf, count * sizeof(float)), cudaSuccess);
+
+  int* d_results = nullptr;
+  ASSERT_EQ(cudaMalloc(&d_results, iterations * sizeof(int)), cudaSuccess);
+  ASSERT_EQ(cudaMemset(d_results, 0, iterations * sizeof(int)), cudaSuccess);
+
+  torchcomm_->barrier(false);
+
+  auto stream = at::cuda::getStreamFromPool(false, device_index_);
+  {
+    c10::cuda::CUDAStreamGuard guard(stream);
+    launchTransportIteratedCombinedKernel(
+        handle_,
+        d_buf,
+        count,
+        peer_,
+        iterations,
+        num_threads,
+        d_results,
+        stream.stream());
+  }
+  stream.synchronize();
+
+  checkKernelResults(
+      d_results,
+      iterations,
+      "TransportCombined(" + formatBytes(msg_bytes) + "," +
+          scopeNameForThreads(num_threads) + ")");
+
+  cudaFree(d_results);
+  cudaFree(d_buf);
+  torchcomm_->barrier(false);
+}
+
+void PipesTransportIteratedTest::testIteratedLl128(size_t nbytes) {
+  int iterations = config_.num_iterations;
+
+  // LL128 requires 16-byte alignment and multiple-of-16 size
+  ASSERT_EQ(nbytes % 16, 0u) << "LL128 requires nbytes multiple of 16";
+
+  SCOPED_TRACE(
+      ::testing::Message() << "TransportIteratedLl128 nbytes="
+                           << formatBytes(nbytes));
+
+  char* d_buf = nullptr;
+  ASSERT_EQ(cudaMalloc(&d_buf, nbytes), cudaSuccess);
+
+  int* d_results = nullptr;
+  ASSERT_EQ(cudaMalloc(&d_results, iterations * sizeof(int)), cudaSuccess);
+  ASSERT_EQ(cudaMemset(d_results, 0, iterations * sizeof(int)), cudaSuccess);
+
+  torchcomm_->barrier(false);
+
+  auto stream = at::cuda::getStreamFromPool(false, device_index_);
+  {
+    c10::cuda::CUDAStreamGuard guard(stream);
+    launchTransportIteratedLl128Kernel(
+        handle_, d_buf, nbytes, peer_, iterations, d_results, stream.stream());
+  }
+  stream.synchronize();
+
+  checkKernelResults(
+      d_results, iterations, "TransportLl128(" + formatBytes(nbytes) + ")");
+
+  cudaFree(d_results);
+  cudaFree(d_buf);
+  torchcomm_->barrier(false);
+}
+
+// =============================================================================
+// Parameterized Test Registrations
+// =============================================================================
+
+// --- SendRecv: parameterized by (msg_bytes, num_threads) ---
+
+struct TransportSendRecvParam {
+  size_t msg_bytes;
+  int num_threads; // 32 = WARP, 256 = BLOCK
+};
+
+class TransportIteratedSendRecvTest
+    : public PipesTransportIteratedTest,
+      public ::testing::WithParamInterface<TransportSendRecvParam> {};
+
+TEST_P(TransportIteratedSendRecvTest, SendRecv) {
+  testIteratedSendRecv(GetParam().msg_bytes, GetParam().num_threads);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    IteratedSendRecv,
+    TransportIteratedSendRecvTest,
+    ::testing::Values(
+        // WARP scope (32 threads)
+        TransportSendRecvParam{1024, 32}, // 1KB
+        TransportSendRecvParam{1048576, 32}, // 1MB
+        TransportSendRecvParam{16777216, 32}, // 16MB
+        TransportSendRecvParam{536870912, 32}, // 512MB
+        // BLOCK scope (256 threads)
+        TransportSendRecvParam{1024, 256}, // 1KB
+        TransportSendRecvParam{1048576, 256}, // 1MB
+        TransportSendRecvParam{16777216, 256}, // 16MB
+        TransportSendRecvParam{536870912, 256} // 512MB
+        ),
+    [](const ::testing::TestParamInfo<TransportSendRecvParam>& info) {
+      return std::to_string(info.param.msg_bytes) + "B_" +
+          std::string(info.param.num_threads >= 256 ? "BLOCK" : "WARP");
+    });
+
+// --- Signal: parameterized by num_threads ---
+
+class TransportIteratedSignalTest : public PipesTransportIteratedTest,
+                                    public ::testing::WithParamInterface<int> {
+};
+
+TEST_P(TransportIteratedSignalTest, Signal) {
+  testIteratedSignal(GetParam());
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    IteratedSignal,
+    TransportIteratedSignalTest,
+    ::testing::Values(32, 256),
+    [](const ::testing::TestParamInfo<int>& info) {
+      return std::string(info.param >= 256 ? "BLOCK" : "WARP");
+    });
+
+// --- Combined: parameterized by (msg_bytes, num_threads) ---
+
+struct TransportCombinedParam {
+  size_t msg_bytes;
+  int num_threads;
+};
+
+class TransportIteratedCombinedTest
+    : public PipesTransportIteratedTest,
+      public ::testing::WithParamInterface<TransportCombinedParam> {};
+
+TEST_P(TransportIteratedCombinedTest, Combined) {
+  testIteratedCombined(GetParam().msg_bytes, GetParam().num_threads);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    IteratedCombined,
+    TransportIteratedCombinedTest,
+    ::testing::Values(
+        // WARP scope
+        TransportCombinedParam{1024, 32},
+        TransportCombinedParam{1048576, 32},
+        TransportCombinedParam{536870912, 32},
+        // BLOCK scope
+        TransportCombinedParam{1024, 256},
+        TransportCombinedParam{1048576, 256},
+        TransportCombinedParam{536870912, 256}),
+    [](const ::testing::TestParamInfo<TransportCombinedParam>& info) {
+      return std::to_string(info.param.msg_bytes) + "B_" +
+          std::string(info.param.num_threads >= 256 ? "BLOCK" : "WARP");
+    });
+
+// --- LL128: parameterized by nbytes (warp-only) ---
+
+class TransportIteratedLl128Test
+    : public PipesTransportIteratedTest,
+      public ::testing::WithParamInterface<size_t> {};
+
+TEST_P(TransportIteratedLl128Test, Ll128) {
+  testIteratedLl128(GetParam());
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    IteratedLl128,
+    TransportIteratedLl128Test,
+    ::testing::Values(
+        static_cast<size_t>(1024), // 1KB
+        static_cast<size_t>(65536)), // 64KB
+    [](const ::testing::TestParamInfo<size_t>& info) {
+      return std::to_string(info.param) + "B";
+    });

--- a/comms/torchcomms/tests/integration/cpp/PipesTransportIteratedTest.hpp
+++ b/comms/torchcomms/tests/integration/cpp/PipesTransportIteratedTest.hpp
@@ -1,0 +1,35 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Iterated stress tests for P2pNvlTransportDevice APIs.
+// Tests transport-layer send/recv, signal, combined, and LL128
+// operations under sustained load to catch race conditions and leaks.
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include <memory>
+
+#include "IteratedTestHelpers.hpp"
+#include "TorchCommTestHelpers.h"
+#include "comms/pipes/MultiPeerDeviceHandle.cuh"
+#include "comms/torchcomms/TorchComm.hpp"
+
+class PipesTransportIteratedTest : public ::testing::Test {
+ protected:
+  void SetUp() override;
+  void TearDown() override;
+
+  void testIteratedSendRecv(size_t msg_bytes, int num_threads);
+  void testIteratedSignal(int num_threads);
+  void testIteratedCombined(size_t msg_bytes, int num_threads);
+  void testIteratedLl128(size_t nbytes);
+
+  torchcomms::device::test::IteratedTestConfig config_;
+  std::unique_ptr<TorchCommTestWrapper> wrapper_;
+  std::shared_ptr<torch::comms::TorchComm> torchcomm_;
+  comms::pipes::MultiPeerDeviceHandle handle_;
+  int rank_{0};
+  int num_ranks_{0};
+  int device_index_{0};
+  int peer_{-1};
+};

--- a/comms/torchcomms/tests/integration/cpp/PipesTransportIteratedTestKernels.cu
+++ b/comms/torchcomms/tests/integration/cpp/PipesTransportIteratedTestKernels.cu
@@ -1,0 +1,286 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// CUDA kernel implementations for PipesTransportIteratedTest.
+// Tests P2pNvlTransportDevice APIs under iterated stress.
+
+#include "IteratedTestKernelUtils.cuh"
+#include "PipesTransportIteratedTestKernels.cuh"
+
+#include "comms/pipes/P2pNvlTransportDevice.cuh"
+#include "comms/pipes/ThreadGroup.cuh"
+#include "comms/pipes/Transport.cuh"
+
+// Transport layer uses SIGNAL_ADD / CMP_GE (not window layer's ADD / GE)
+using comms::pipes::CmpOp;
+using comms::pipes::SignalOp;
+
+// Kernel launch error check for test code.
+#define TRANSPORT_KERNEL_LAUNCH_CHECK()              \
+  do {                                               \
+    cudaError_t err__ = cudaGetLastError();          \
+    assert(err__ == cudaSuccess && "kernel launch"); \
+    (void)err__;                                     \
+  } while (0)
+
+namespace torchcomms::device::test {
+
+// ---------------------------------------------------------------------------
+// Helper: create thread group based on launch configuration
+// ---------------------------------------------------------------------------
+__device__ inline comms::pipes::ThreadGroup make_group_for_launch() {
+  if (blockDim.x >= 256) {
+    return comms::pipes::make_block_group();
+  }
+  return comms::pipes::make_warp_group();
+}
+
+// ---------------------------------------------------------------------------
+// Iterated Send/Recv Kernel
+// ---------------------------------------------------------------------------
+// Rank 0 fills buffer with pattern, sends to rank 1 via NVLink transport.
+// Rank 1 receives, verifies data. Barrier sync between iterations.
+__global__ void transportIteratedSendRecvKernel(
+    comms::pipes::MultiPeerDeviceHandle handle,
+    float* buf,
+    size_t count,
+    int peer,
+    int iterations,
+    int* results) {
+  auto group = make_group_for_launch();
+  auto& nvl = handle.get_nvl(peer);
+  int rank = handle.myRank;
+  size_t nbytes = count * sizeof(float);
+
+  for (int iter = 0; iter < iterations; iter++) {
+    if (rank == 0) {
+      // Fill src with identifiable pattern
+      fillPattern(buf, count, rank, iter);
+      group.sync();
+      nvl.send(group, buf, nbytes);
+      // Sender always passes
+      if (group.thread_id_in_group == 0) {
+        results[iter] = 1;
+      }
+    } else {
+      // Clear dst before recv
+      for (size_t i = group.thread_id_in_group; i < count;
+           i += group.group_size) {
+        buf[i] = 0.0f;
+      }
+      group.sync();
+      nvl.recv(group, buf, nbytes);
+      // Verify received data matches sender's pattern
+      verifyPattern(buf, count, 0 /* sender rank */, iter, &results[iter]);
+    }
+    group.sync();
+
+    // Signal-based barrier: both ranks signal and wait before next iteration.
+    // Barrier buffers are not available via get_device_transport(), so we use
+    // monotonic signal ADD/GE on signal_id 0 as a barrier replacement.
+    nvl.signal_threadgroup(group, 0, SignalOp::SIGNAL_ADD, 1);
+    nvl.wait_signal_until_threadgroup(
+        group, 0, CmpOp::CMP_GE, static_cast<uint64_t>(iter + 1));
+  }
+}
+
+void launchTransportIteratedSendRecvKernel(
+    comms::pipes::MultiPeerDeviceHandle handle,
+    float* buf,
+    size_t count,
+    int peer,
+    int iterations,
+    int num_threads,
+    int* results,
+    cudaStream_t stream) {
+  transportIteratedSendRecvKernel<<<1, num_threads, 0, stream>>>(
+      handle, buf, count, peer, iterations, results);
+  TRANSPORT_KERNEL_LAUNCH_CHECK();
+}
+
+// ---------------------------------------------------------------------------
+// Iterated Signal Kernel
+// ---------------------------------------------------------------------------
+// Both ranks signal each other and wait in a ring pattern.
+// Uses monotonic ADD signals with GE waits.
+__global__ void transportIteratedSignalKernel(
+    comms::pipes::MultiPeerDeviceHandle handle,
+    int peer,
+    int iterations) {
+  auto group = make_group_for_launch();
+  auto& nvl = handle.get_nvl(peer);
+
+  for (int iter = 0; iter < iterations; iter++) {
+    // Signal peer: add 1 to signal_id 0
+    nvl.signal_threadgroup(group, 0, SignalOp::SIGNAL_ADD, 1);
+    // Wait for peer's signal: expect monotonically increasing value
+    nvl.wait_signal_until_threadgroup(
+        group, 0, CmpOp::CMP_GE, static_cast<uint64_t>(iter + 1));
+  }
+}
+
+void launchTransportIteratedSignalKernel(
+    comms::pipes::MultiPeerDeviceHandle handle,
+    int peer,
+    int iterations,
+    int num_threads,
+    cudaStream_t stream) {
+  transportIteratedSignalKernel<<<1, num_threads, 0, stream>>>(
+      handle, peer, iterations);
+  TRANSPORT_KERNEL_LAUNCH_CHECK();
+}
+
+// ---------------------------------------------------------------------------
+// Combined Ops Kernel
+// ---------------------------------------------------------------------------
+// Exercises barrier + send/recv + signal/wait per iteration.
+__global__ void transportIteratedCombinedKernel(
+    comms::pipes::MultiPeerDeviceHandle handle,
+    float* buf,
+    size_t count,
+    int peer,
+    int iterations,
+    int* results) {
+  auto group = make_group_for_launch();
+  auto& nvl = handle.get_nvl(peer);
+  int rank = handle.myRank;
+  size_t nbytes = count * sizeof(float);
+
+  for (int iter = 0; iter < iterations; iter++) {
+    // Phase 1: Signal-based barrier (barrier buffers not available via
+    // get_device_transport(), so use signal ADD/GE on signal_id 0).
+    // Two signals per iteration: one here, one after send/recv.
+    nvl.signal_threadgroup(group, 0, SignalOp::SIGNAL_ADD, 1);
+    nvl.wait_signal_until_threadgroup(
+        group, 0, CmpOp::CMP_GE, static_cast<uint64_t>(2 * iter + 1));
+
+    // Phase 2: Send/recv
+    if (rank == 0) {
+      fillPattern(buf, count, rank, iter);
+      group.sync();
+      nvl.send(group, buf, nbytes);
+    } else {
+      for (size_t i = group.thread_id_in_group; i < count;
+           i += group.group_size) {
+        buf[i] = 0.0f;
+      }
+      group.sync();
+      nvl.recv(group, buf, nbytes);
+    }
+
+    // Phase 3: Signal/wait (confirms both ranks finished send/recv)
+    nvl.signal_threadgroup(group, 0, SignalOp::SIGNAL_ADD, 1);
+    nvl.wait_signal_until_threadgroup(
+        group, 0, CmpOp::CMP_GE, static_cast<uint64_t>(2 * iter + 2));
+
+    // Phase 4: Verify on receiver
+    if (rank == 1) {
+      verifyPattern(buf, count, 0, iter, &results[iter]);
+    } else {
+      if (group.thread_id_in_group == 0) {
+        results[iter] = 1;
+      }
+    }
+    group.sync();
+  }
+}
+
+void launchTransportIteratedCombinedKernel(
+    comms::pipes::MultiPeerDeviceHandle handle,
+    float* buf,
+    size_t count,
+    int peer,
+    int iterations,
+    int num_threads,
+    int* results,
+    cudaStream_t stream) {
+  transportIteratedCombinedKernel<<<1, num_threads, 0, stream>>>(
+      handle, buf, count, peer, iterations, results);
+  TRANSPORT_KERNEL_LAUNCH_CHECK();
+}
+
+// ---------------------------------------------------------------------------
+// LL128 Send/Recv Kernel
+// ---------------------------------------------------------------------------
+// Warp-only LL128 protocol test. Rank 0 sends, rank 1 receives.
+// Fills with byte pattern, verifies on receiver.
+__global__ void transportIteratedLl128Kernel(
+    comms::pipes::MultiPeerDeviceHandle handle,
+    char* buf,
+    size_t nbytes,
+    int peer,
+    int iterations,
+    int* results) {
+  auto group = comms::pipes::make_warp_group();
+  auto& nvl = handle.get_nvl(peer);
+  int rank = handle.myRank;
+
+  // Check if LL128 is configured
+  if (nvl.get_ll128_buffer_num_packets() == 0) {
+    // LL128 not available — mark all iterations as passed (skip)
+    if (threadIdx.x == 0) {
+      for (int i = 0; i < iterations; i++) {
+        results[i] = 1;
+      }
+    }
+    return;
+  }
+
+  for (int iter = 0; iter < iterations; iter++) {
+    char pattern = static_cast<char>((iter + 1) & 0xFF);
+
+    if (rank == 0) {
+      // Fill with byte pattern
+      for (size_t i = threadIdx.x; i < nbytes; i += blockDim.x) {
+        buf[i] = pattern;
+      }
+      __syncthreads();
+      nvl.ll128_send(group, buf, nbytes);
+      if (threadIdx.x == 0) {
+        results[iter] = 1;
+      }
+    } else {
+      // Clear buffer
+      for (size_t i = threadIdx.x; i < nbytes; i += blockDim.x) {
+        buf[i] = 0;
+      }
+      __syncthreads();
+      nvl.ll128_recv(group, buf, nbytes);
+      // Verify
+      __shared__ int any_mismatch;
+      if (threadIdx.x == 0) {
+        any_mismatch = 0;
+      }
+      __syncthreads();
+      for (size_t i = threadIdx.x; i < nbytes; i += blockDim.x) {
+        if (buf[i] != pattern) {
+          atomicExch(&any_mismatch, 1);
+        }
+      }
+      __syncthreads();
+      if (threadIdx.x == 0) {
+        results[iter] = (any_mismatch == 0) ? 1 : 0;
+      }
+    }
+
+    // Signal-based barrier before next iteration (barrier buffers not
+    // available via get_device_transport())
+    nvl.signal_threadgroup(group, 0, SignalOp::SIGNAL_ADD, 1);
+    nvl.wait_signal_until_threadgroup(
+        group, 0, CmpOp::CMP_GE, static_cast<uint64_t>(iter + 1));
+  }
+}
+
+void launchTransportIteratedLl128Kernel(
+    comms::pipes::MultiPeerDeviceHandle handle,
+    char* buf,
+    size_t nbytes,
+    int peer,
+    int iterations,
+    int* results,
+    cudaStream_t stream) {
+  transportIteratedLl128Kernel<<<1, 32, 0, stream>>>(
+      handle, buf, nbytes, peer, iterations, results);
+  TRANSPORT_KERNEL_LAUNCH_CHECK();
+}
+
+} // namespace torchcomms::device::test

--- a/comms/torchcomms/tests/integration/cpp/PipesTransportIteratedTestKernels.cuh
+++ b/comms/torchcomms/tests/integration/cpp/PipesTransportIteratedTestKernels.cuh
@@ -1,0 +1,55 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// CUDA kernel declarations for PipesTransportIteratedTest.
+// Host-safe header — can be included from .cpp files compiled by clang.
+
+// NOLINTNEXTLINE(clang-diagnostic-pragma-once-outside-header)
+#pragma once
+
+#include <cuda_runtime.h>
+#include "comms/pipes/MultiPeerDeviceHandle.cuh"
+
+namespace torchcomms::device::test {
+
+// Iterated send/recv: rank 0 sends, rank 1 receives, with signal-based sync
+// between iterations. Verifies data integrity on receiver.
+void launchTransportIteratedSendRecvKernel(
+    comms::pipes::MultiPeerDeviceHandle handle,
+    float* buf,
+    size_t count,
+    int peer,
+    int iterations,
+    int num_threads,
+    int* results,
+    cudaStream_t stream);
+
+// Iterated signal/wait: ring pattern, monotonic ADD signals with GE waits.
+void launchTransportIteratedSignalKernel(
+    comms::pipes::MultiPeerDeviceHandle handle,
+    int peer,
+    int iterations,
+    int num_threads,
+    cudaStream_t stream);
+
+// Combined: signal-sync + send/recv + signal/wait + verify per iteration.
+void launchTransportIteratedCombinedKernel(
+    comms::pipes::MultiPeerDeviceHandle handle,
+    float* buf,
+    size_t count,
+    int peer,
+    int iterations,
+    int num_threads,
+    int* results,
+    cudaStream_t stream);
+
+// LL128 send/recv: warp-only, small messages.
+void launchTransportIteratedLl128Kernel(
+    comms::pipes::MultiPeerDeviceHandle handle,
+    char* buf,
+    size_t nbytes,
+    int peer,
+    int iterations,
+    int* results,
+    cudaStream_t stream);
+
+} // namespace torchcomms::device::test

--- a/comms/torchcomms/tests/integration/cpp/PipesTransportIteratedTestMain.cpp
+++ b/comms/torchcomms/tests/integration/cpp/PipesTransportIteratedTestMain.cpp
@@ -1,0 +1,8 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Summary:

Adds iterated stress tests for the Pipes transport layer, exercising
P2pNvlTransportDevice send/recv, signal, combined (signal + send/recv),
and LL128 operations under sustained load (100 iterations by default).

These tests complement the existing window-layer iterated tests
(PipesDeviceApiIteratedTest) by testing the lower-level transport APIs
directly through the MultiPeerDeviceHandle obtained via
TorchCommNCCLX::get_device_transport().

**Test matrix (18 tests):**
- SendRecv: {1KB, 1MB, 16MB, 512MB} × {WARP, BLOCK} = 8 tests
- Signal: {WARP, BLOCK} = 2 tests
- Combined (signal + send/recv + verify): {1KB, 1MB, 512MB} × {WARP, BLOCK} = 6 tests
- LL128: {1KB, 64KB} = 2 tests (warp-only, runtime skip if LL128 not configured)

**Key design decisions:**
- Uses signal-based sync (monotonic ADD/GE) instead of barrier_sync_threadgroup
  for inter-iteration synchronization, because barrier buffers (BarrierState)
  are not allocated in the transport handle from get_device_transport().
- Gated by RUN_DEVICE_ITERATED_TEST env var (same as window-layer iterated tests).
- Unidirectional send/recv pattern (rank 0 sends, rank 1 receives) to avoid
  deadlock from simultaneous bidirectional send() calls.
- 512MB message sizes included for heavy pipelining stress.

**Files:**
- PipesTransportIteratedTest.hpp/.cpp — test fixture + parameterized registrations
- PipesTransportIteratedTestKernels.cuh/.cu — CUDA kernel implementations
- PipesTransportIteratedTestMain.cpp — gtest main
- BUCK — library + torchcomm_cpp_distributed_unittest targets

Reviewed By: siyengar

Differential Revision: D98763624
