### PR TITLE
post-kernel cleanup cb (#1344)

### DIFF
--- a/comms/ctran/gpe/CtranGpe.h
+++ b/comms/ctran/gpe/CtranGpe.h
@@ -331,6 +331,12 @@ struct KernelConfig {
   void* algoArgs{nullptr};
   void* unpackPool{nullptr};
 
+  // Post-kernel cleanup callback. Populated by algorithm setup (e.g.,
+  // SendRecv P2P useList path); transferred to CtranGpeCmd on submit,
+  // invoked by GPE thread after the kernel signals completion via
+  // kernelFlag.
+  std::function<void()> postKernelCleanup{nullptr};
+
   const std::string algoName;
   // Copied after collective called ctran->updateOpCount()
   // Upon collective submission, we should always use the copied opCount since

--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -135,6 +135,14 @@ CtranGpeCmd::~CtranGpeCmd() {
     kernelFlag->clearPersistent();
     kernelFlag->reset();
   }
+
+  // For persistent (graph) cmds, postKernelCleanup is deliberately skipped
+  // during replay (the resources must persist across replays). Run it here
+  // on destruction so resources like device-allocated sendsList/recvsList
+  // are freed when the graph is destroyed.
+  if (postKernelCleanup) {
+    postKernelCleanup();
+  }
 }
 
 void CUDART_CB CtranGpe::Impl::cmdDestroy(void* data) {
@@ -247,8 +255,21 @@ commResult_t CtranGpe::Impl::submit(
 
   bool ifchecksum = checksumIsSampled(kernelConfig.type, kernelConfig.opCount);
 
-  // Get kernelFlag from the pool
-  auto kernelFlag = opGroup.size() ? this->kernelFlagPool->pop() : nullptr;
+  utils::cudagraph::StreamCaptureInfo streamCaptureInfo;
+  FB_CUDACHECK(
+      utils::cudagraph::getStreamCaptureInfo(
+          kernelConfig.stream, streamCaptureInfo));
+  bool isCapturing = streamCaptureInfo.status == cudaStreamCaptureStatusActive;
+
+  // For eager (non-capture) submits with empty opGroup but a
+  // postKernelCleanup, we still need a cmd + kernelFlag so the GPE thread
+  // can synchronize with the kernel before running cleanup. During graph
+  // capture the cleanup is retained directly on the graph via
+  // retainUserObject, avoiding host-node overhead.
+  bool needsKernelFlag =
+      !opGroup.empty() || (kernelConfig.postKernelCleanup && !isCapturing);
+
+  auto kernelFlag = needsKernelFlag ? this->kernelFlagPool->pop() : nullptr;
   volatile int* flag = nullptr;
   if (kernelFlag != nullptr) {
     // TODO: remove this allowlist once the per-block flag is enabled in all
@@ -289,17 +310,13 @@ commResult_t CtranGpe::Impl::submit(
   auto colltraceHandle = meta::comms::colltrace::getCollTraceHandle(
       comm, opGroup, kernelConfig, ifchecksum);
 
-  utils::cudagraph::StreamCaptureInfo streamCaptureInfo;
-  FB_CUDACHECK(
-      utils::cudagraph::getStreamCaptureInfo(
-          kernelConfig.stream, streamCaptureInfo));
-
   cudaStream_t launchStream = kernelConfig.stream;
   std::optional<OrderedWorkStreamGuard::Scope> wsScope;
 
   size_t opGroupSize = 0;
-  // Enqueue op to gpeThread if any op is appended
-  if (!opGroup.empty()) {
+  // Enqueue op to gpeThread if any op is appended, or if there is a
+  // postKernelCleanup that needs to run after the kernel completes.
+  if (needsKernelFlag) {
     // record opGroup size before moving the object
     opGroupSize = opGroup.size();
     class CtranGpeCmd* cmd = new class CtranGpeCmd;
@@ -307,6 +324,7 @@ commResult_t CtranGpe::Impl::submit(
     cmd->kernelFlag = kernelFlag;
     cmd->timeout = timeout;
     cmd->unpackPool = kernelConfig.unpackPool;
+    cmd->postKernelCleanup = std::move(kernelConfig.postKernelCleanup);
 
     if (type == CtranGpeCmd::TypeEnum::GRAPH_ENQUEUE) {
       cmd->coll.opGroup = std::move(opGroup);
@@ -316,7 +334,7 @@ commResult_t CtranGpe::Impl::submit(
       }
       cmd->coll.comm = comm;
     }
-    if (streamCaptureInfo.status == cudaStreamCaptureStatusActive) {
+    if (isCapturing) {
       FB_COMMCHECK(preLaunchGraphPrepare(cmd, graphPrepareFn));
       cmd->persistent = true;
       // Mark the flag as persistent so reclaim() won't steal it between
@@ -328,12 +346,34 @@ commResult_t CtranGpe::Impl::submit(
 
       FB_COMMCHECKGOTO(
           utils::cudagraph::addHostNode(
-              cmd, cmdCb, cmdDestroy, kernelConfig.stream, streamCaptureInfo),
+              /*data=*/cmd,
+              /*execCallback=*/cmdCb,
+              /*destroyCallback=*/cmdDestroy,
+              kernelConfig.stream,
+              streamCaptureInfo),
           res,
           fail);
     } else {
       cmdEnqueue(cmd);
     }
+  } else if (kernelConfig.postKernelCleanup && isCapturing) {
+    // During graph capture with empty opGroup (e.g., ctp2p NVL-only ops),
+    // postKernelCleanup wasn't moved into a cmd. Retain it as a user object
+    // on the graph so it runs on graph destruction
+    FB_COMMCHECKGOTO(
+        utils::cudagraph::retainUserObject(
+            /*obj=*/
+            new std::function<void()>(
+                std::move(kernelConfig.postKernelCleanup)),
+            /*destroyCallback=*/
+            [](void* p) {
+              auto* fn = static_cast<std::function<void()>*>(p);
+              (*fn)();
+              delete fn;
+            },
+            streamCaptureInfo),
+        res,
+        fail);
   }
 
   if (!kernelConfig.canConcurrent) {
@@ -492,6 +532,9 @@ commResult_t CtranGpe::Impl::submitHost(
     opFunc func,
     KernelConfig& kernelConfig,
     std::shared_ptr<std::atomic_flag> cpuFlag) {
+  // postKernelCleanup is not supported for host submits (no kernel launched).
+  DCHECK(!kernelConfig.postKernelCleanup);
+
   // Enqueue op to gpeThread if any op is appended
   if (!opGroup.empty()) {
     class CtranGpeCmd* cmd = new class CtranGpeCmd;
@@ -650,9 +693,6 @@ void CtranGpe::Impl::gpeThreadFn() {
         };
 
         /* run collective */
-        // TODO: lost peerRank info which would be useful for some errors (e.g.,
-        // commRemoteError). We may want to enrich commResult_t to contain such
-        // info at failure or throw exception from bottom.
         if (comm->testAbort()) {
           // Comm already aborted — skip collective to prevent
           // progressInternal() from accessing stale VC queue entries
@@ -676,7 +716,7 @@ void CtranGpe::Impl::gpeThreadFn() {
                     "collective skipped: communicator aborted",
                     commRemoteError));
           }
-        } else {
+        } else if (!cmd->coll.opGroup.empty() /* skip when opGroup is empty, i.e,. we are only here for post-kernel cmd destruction/cleanup */) {
           CTRAN_ASYNC_ERR_GUARD_FAULT_TOLERANCE(comm, {
             FB_COMMCHECKTHROW_EX(
                 cmd->coll.func(cmd->coll.opGroup), comm->logMetaData_);

--- a/comms/ctran/gpe/CtranGpeImpl.h
+++ b/comms/ctran/gpe/CtranGpeImpl.h
@@ -153,6 +153,9 @@ class CtranGpeCmd {
 
   // Unpack queue to teardown after kernel completes (for TcpDM backend)
   void* unpackPool{nullptr};
+
+  // Post-kernel cleanup callback. Called by GPE thread after kernel finishes.
+  std::function<void()> postKernelCleanup{nullptr};
 };
 
 /**

--- a/comms/ctran/gpe/tests/CtranGpeUT.cc
+++ b/comms/ctran/gpe/tests/CtranGpeUT.cc
@@ -1641,7 +1641,9 @@ TEST_F(CtranGpeTest, GraphCaptureDestroyFreesResources) {
   CUDACHECK_TEST(cudaGraphExecDestroy(graphExec));
   CUDACHECK_TEST(cudaGraphDestroy(graph));
 
-  EXPECT_EQ(gpe->numInUseKernelFlags(), 0);
+  while (gpe->numInUseKernelFlags() > 0) {
+    std::this_thread::yield();
+  }
 
   CUDACHECK_TEST(cudaFree(buf));
   CUDACHECK_TEST(cudaFreeHost(valPtr));
@@ -1949,3 +1951,215 @@ TEST_F(CtranGpeTest, ThrowAsyncException) {
   EXPECT_EQ(e.commHash(), statex->commHash());
   EXPECT_EQ(e.rank(), statex->rank());
 }
+
+// Verify postKernelCleanup is called after kernel completion for eager
+// submit with empty opGroup.
+TEST_F(CtranGpeTest, PostKernelCleanupEagerEmptyOpGroup) {
+  auto gpe = std::make_unique<CtranGpe>(cudaDev, dummyComm);
+  cudaStream_t stream;
+  CUDACHECK_TEST(cudaStreamCreate(&stream));
+
+  int* a = nullptr;
+  int* expectedValPtr = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&a, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMemset(a, 0, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMallocHost(&expectedValPtr, sizeof(int)));
+  *expectedValPtr = kKernelpdatedVal;
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  constexpr uint64_t dummyOpCount = 100;
+  auto config = KernelConfig(
+      KernelConfig::KernelType::ALLGATHER, stream, "dummyAlgo", dummyOpCount);
+  ctranKernelSetAllGatherArgs(
+      a, expectedValPtr, commInt8, count, dummyDevState_d, &config.args);
+
+  std::atomic<bool> cleanupRan{false};
+  config.postKernelCleanup = [&cleanupRan]() { cleanupRan.store(true); };
+
+  std::vector<std::unique_ptr<OpElem>> emptyOps;
+  auto res = gpe->submit(
+      std::move(emptyOps),
+      nullptr,
+      config,
+      reinterpret_cast<void*>(CtranGpeTestKernel));
+  EXPECT_EQ(res, commSuccess);
+
+  // postKernelCleanup should have been moved out of config
+  EXPECT_EQ(config.postKernelCleanup, nullptr);
+
+  // Wait for kernel + GPE thread to finish
+  CUDACHECK_TEST(cudaStreamSynchronize(stream));
+  // Give GPE thread time to process the cmd
+  while (!cleanupRan.load()) {
+    std::this_thread::yield();
+  }
+  EXPECT_TRUE(cleanupRan.load());
+
+  CUDACHECK_TEST(cudaFreeHost(expectedValPtr));
+  CUDACHECK_TEST(cudaFree(a));
+  CUDACHECK_TEST(cudaStreamDestroy(stream));
+}
+
+// Verify postKernelCleanup is called after kernel completion for eager
+// submit with non-empty opGroup.
+TEST_F(CtranGpeTest, PostKernelCleanupEagerWithOpGroup) {
+  auto gpe = std::make_unique<CtranGpe>(cudaDev, dummyComm);
+  cudaStream_t stream;
+  CUDACHECK_TEST(cudaStreamCreate(&stream));
+
+  int* a = nullptr;
+  int* expectedValPtr = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&a, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMemset(a, 0, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMallocHost(&expectedValPtr, sizeof(int)));
+  *expectedValPtr = kKernelpdatedVal;
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  constexpr uint64_t dummyOpCount = 100;
+  auto config = KernelConfig(
+      KernelConfig::KernelType::ALLGATHER, stream, "dummyAlgo", dummyOpCount);
+  ctranKernelSetAllGatherArgs(
+      a, expectedValPtr, commInt8, count, dummyDevState_d, &config.args);
+
+  std::atomic<bool> cleanupRan{false};
+  config.postKernelCleanup = [&cleanupRan]() { cleanupRan.store(true); };
+
+  std::vector<std::unique_ptr<OpElem>> ops;
+  auto* op = new OpElem(OpElem::opType::RECV, dummyComm, dummyOpCount);
+  op->recv.recvbuff = nullptr;
+  op->recv.count = 0;
+  op->recv.datatype = commInt8;
+  op->recv.peerRank = 0;
+  ops.push_back(std::unique_ptr<OpElem>(op));
+
+  auto res = gpe->submit(
+      std::move(ops),
+      &CtranGpeTestAlgoFunc,
+      config,
+      reinterpret_cast<void*>(CtranGpeTestKernel));
+  EXPECT_EQ(res, commSuccess);
+  EXPECT_EQ(config.postKernelCleanup, nullptr);
+
+  CUDACHECK_TEST(cudaStreamSynchronize(stream));
+  while (!cleanupRan.load()) {
+    std::this_thread::yield();
+  }
+  EXPECT_TRUE(cleanupRan.load());
+
+  CUDACHECK_TEST(cudaFreeHost(expectedValPtr));
+  CUDACHECK_TEST(cudaFree(a));
+  CUDACHECK_TEST(cudaStreamDestroy(stream));
+}
+
+#if not defined(__HIP_PLATFORM_AMD__) and not defined(__HIP_PLATFORM_HCC__)
+// Verify postKernelCleanup is called on graph destruction for graph capture
+// with empty opGroup.
+TEST_F(CtranGpeTest, PostKernelCleanupGraphEmptyOpGroup) {
+  auto gpe = std::make_unique<CtranGpe>(cudaDev, dummyComm);
+  cudaStream_t stream;
+  CUDACHECK_TEST(cudaStreamCreate(&stream));
+
+  int* a = nullptr;
+  int* expectedValPtr = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&a, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMemset(a, 0, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMallocHost(&expectedValPtr, sizeof(int)));
+  *expectedValPtr = kKernelpdatedVal;
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  constexpr uint64_t dummyOpCount = 100;
+
+  std::atomic<bool> cleanupRan{false};
+
+  CUDACHECK_TEST(cudaStreamBeginCapture(stream, cudaStreamCaptureModeRelaxed));
+
+  auto config = KernelConfig(
+      KernelConfig::KernelType::ALLGATHER, stream, "dummyAlgo", dummyOpCount);
+  ctranKernelSetAllGatherArgs(
+      a, expectedValPtr, commInt8, count, dummyDevState_d, &config.args);
+  config.postKernelCleanup = [&cleanupRan]() { cleanupRan.store(true); };
+
+  std::vector<std::unique_ptr<OpElem>> emptyOps;
+  auto res = gpe->submit(
+      std::move(emptyOps),
+      nullptr,
+      config,
+      reinterpret_cast<void*>(CtranGpeTestKernel));
+  EXPECT_EQ(res, commSuccess);
+  EXPECT_EQ(config.postKernelCleanup, nullptr);
+
+  cudaGraph_t graph;
+  CUDACHECK_TEST(cudaStreamEndCapture(stream, &graph));
+  ASSERT_NE(graph, nullptr);
+
+  // Cleanup should not have run yet
+  EXPECT_FALSE(cleanupRan.load());
+
+  // Destroying the graph should trigger cleanup via retained user object
+  CUDACHECK_TEST(cudaGraphDestroy(graph));
+  EXPECT_TRUE(cleanupRan.load())
+      << "postKernelCleanup was not called on graph destruction";
+
+  CUDACHECK_TEST(cudaFreeHost(expectedValPtr));
+  CUDACHECK_TEST(cudaFree(a));
+  CUDACHECK_TEST(cudaStreamDestroy(stream));
+}
+
+// Verify postKernelCleanup is called on graph destruction for graph capture
+// with non-empty opGroup.
+TEST_F(CtranGpeTest, PostKernelCleanupGraphWithOpGroup) {
+  auto gpe = std::make_unique<CtranGpe>(cudaDev, dummyComm);
+  cudaStream_t stream;
+  CUDACHECK_TEST(cudaStreamCreate(&stream));
+
+  int* a = nullptr;
+  int* expectedValPtr = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&a, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMemset(a, 0, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMallocHost(&expectedValPtr, sizeof(int)));
+  *expectedValPtr = kKernelpdatedVal;
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  constexpr uint64_t dummyOpCount = 100;
+
+  std::atomic<bool> cleanupRan{false};
+
+  CUDACHECK_TEST(cudaStreamBeginCapture(stream, cudaStreamCaptureModeRelaxed));
+
+  auto config = KernelConfig(
+      KernelConfig::KernelType::ALLGATHER, stream, "dummyAlgo", dummyOpCount);
+  ctranKernelSetAllGatherArgs(
+      a, expectedValPtr, commInt8, count, dummyDevState_d, &config.args);
+  config.postKernelCleanup = [&cleanupRan]() { cleanupRan.store(true); };
+
+  std::vector<std::unique_ptr<OpElem>> ops;
+  auto* op = new OpElem(OpElem::opType::RECV, dummyComm, dummyOpCount);
+  op->recv.recvbuff = nullptr;
+  op->recv.count = 0;
+  op->recv.datatype = commInt8;
+  op->recv.peerRank = 0;
+  ops.push_back(std::unique_ptr<OpElem>(op));
+
+  auto res = gpe->submit(
+      std::move(ops),
+      &CtranGpeTestAlgoFunc,
+      config,
+      reinterpret_cast<void*>(CtranGpeTestKernel));
+  EXPECT_EQ(res, commSuccess);
+  EXPECT_EQ(config.postKernelCleanup, nullptr);
+
+  cudaGraph_t graph;
+  CUDACHECK_TEST(cudaStreamEndCapture(stream, &graph));
+  ASSERT_NE(graph, nullptr);
+
+  EXPECT_FALSE(cleanupRan.load());
+
+  CUDACHECK_TEST(cudaGraphDestroy(graph));
+  EXPECT_TRUE(cleanupRan.load())
+      << "postKernelCleanup was not called on graph destruction";
+
+  CUDACHECK_TEST(cudaFreeHost(expectedValPtr));
+  CUDACHECK_TEST(cudaFree(a));
+  CUDACHECK_TEST(cudaStreamDestroy(stream));
+}
+#endif

--- a/comms/ctran/gpe/tests/KernelFlagCmdOwnershipUT.cc
+++ b/comms/ctran/gpe/tests/KernelFlagCmdOwnershipUT.cc
@@ -53,6 +53,43 @@ TEST_F(KernelFlagCmdOwnershipTest, CmdDestructorReleasesFlag) {
   EXPECT_EQ(pool->size(), poolSize);
 }
 
+// Verify that ~CtranGpeCmd invokes postKernelCleanup for persistent (graph)
+// cmds. During graph replay, postKernelCleanup is deliberately skipped so
+// resources persist across replays. On graph destruction, cmdDestroy deletes
+// the cmd, and the destructor must run the cleanup to free those resources.
+TEST_F(KernelFlagCmdOwnershipTest, CmdDestructorRunsPostKernelCleanup) {
+  bool cleanupCalled = false;
+
+  auto* cmd = new CtranGpeCmd;
+  cmd->persistent = true;
+  cmd->postKernelCleanup = [&cleanupCalled]() { cleanupCalled = true; };
+
+  EXPECT_FALSE(cleanupCalled);
+  delete cmd;
+  EXPECT_TRUE(cleanupCalled);
+}
+
+// Verify that ~CtranGpeCmd also invokes postKernelCleanup for non-persistent
+// cmds (e.g., if cleanup wasn't already called by the GPE thread).
+TEST_F(KernelFlagCmdOwnershipTest, NonPersistentCmdDestructorRunsCleanup) {
+  bool cleanupCalled = false;
+
+  auto* cmd = new CtranGpeCmd;
+  cmd->persistent = false;
+  cmd->postKernelCleanup = [&cleanupCalled]() { cleanupCalled = true; };
+
+  delete cmd;
+  EXPECT_TRUE(cleanupCalled);
+}
+
+// Verify that ~CtranGpeCmd handles null postKernelCleanup (already consumed).
+TEST_F(KernelFlagCmdOwnershipTest, CmdDestructorNullCleanupNoOp) {
+  auto* cmd = new CtranGpeCmd;
+  cmd->persistent = true;
+  cmd->postKernelCleanup = nullptr;
+  delete cmd;
+}
+
 // Demonstrates the bug scenario: without setPersistent(), the kernel writes
 // KERNEL_UNSET after each replay, making the flag reclaimable while
 // the graph still holds a baked-in pointer to it.

--- a/comms/ctran/utils/CudaGraphUtils.h
+++ b/comms/ctran/utils/CudaGraphUtils.h
@@ -26,21 +26,31 @@ inline cudaError_t getStreamCaptureInfo(
 #endif
 }
 
+// Retain a user object on the graph so its destroy callback runs when the
+// graph is destroyed. Use this to tie resource lifetime to graph lifetime
+// (e.g., pinned memory that must outlive graph replays).
+inline commResult_t retainUserObject(
+    void* obj,
+    cudaHostFn_t destroyCallback,
+    StreamCaptureInfo& info) {
+  cudaUserObject_t object;
+  FB_CUDACHECK(cudaUserObjectCreate(
+      &object, obj, destroyCallback, 1, cudaUserObjectNoDestructorSync));
+  FB_CUDACHECK(
+      cudaGraphRetainUserObject(info.g, object, 1, cudaGraphUserObjectMove));
+  return commSuccess;
+}
+
+// Add a host node to the captured graph and retain the user object so its
+// destroy callback runs on graph destruction.
 inline commResult_t addHostNode(
-    void* cmd,
+    void* data,
     cudaHostFn_t execCallback,
     cudaHostFn_t destroyCallback,
     cudaStream_t stream,
     StreamCaptureInfo& info) {
-  FB_CUDACHECK(cudaLaunchHostFunc(stream, execCallback, cmd));
-  cudaUserObject_t object;
-  FB_CUDACHECK(cudaUserObjectCreate(
-      &object, cmd, destroyCallback, 1, cudaUserObjectNoDestructorSync));
-
-  // Handover ownership to CUDA graph
-  FB_CUDACHECK(
-      cudaGraphRetainUserObject(info.g, object, 1, cudaGraphUserObjectMove));
-  return commSuccess;
+  FB_CUDACHECK(cudaLaunchHostFunc(stream, execCallback, data));
+  return retainUserObject(data, destroyCallback, info);
 }
 // Add an event record node to a graph being captured on `capturedStream`.
 //


### PR DESCRIPTION
Summary:

we might have some state that we want tied to the cmd lifetime. in the p2p case, we could have per-cmd buffers that we don't want to just leak after the cmd has completed (it isn't always feasible for pool alloc).

this just implements a cb that the user can attach to the kernelconfig. it will transfer the cb to the cmd, which will call it on its destrution. if there isn't a gpe cmd (empty op group), we will create a destruction-only cmd that will call the fn which prevents blocking the user thread. this is also graph safe.

Reviewed By: Regina8023

Differential Revision: D98558451


