### PR TITLE
Disable perf measurement in AllToAll correctness tests (#1347)

### DIFF
--- a/comms/ctran/tests/CtranDistAlltoAllTest.cc
+++ b/comms/ctran/tests/CtranDistAlltoAllTest.cc
@@ -83,6 +83,7 @@ class CtranAllToAllTest : public ctran::CtranDistTestFixture,
       const size_t count,
       const size_t bufCount,
       bool registerFlag = true,
+      // TODO: Move perf measurement to a separate benchmark file
       bool reportPerf = false) {
     using DT = typename CommTypeTraits<DataType>::T;
     size_t dataTypeSize = sizeof(DT);
@@ -292,7 +293,7 @@ TEST_P(CtranAllToAllTestParam, SmallAllToAll) {
       enable_put_fast_path_for_small_msgs);
   // Even for small data transfer size, need buffer size >= pagesize for IB
   // registration
-  run(2, 8192 * ctranComm->statex_->nRanks(), true, true);
+  run(2, 8192 * ctranComm->statex_->nRanks());
 }
 
 TEST_P(CtranAllToAllTestParam, LargeAllToAll) {
@@ -303,10 +304,7 @@ TEST_P(CtranAllToAllTestParam, LargeAllToAll) {
   EnvRAII env3(
       NCCL_CTRAN_ENABLE_PUT_FAST_PATH_FOR_SMALL_MSGS,
       enable_put_fast_path_for_small_msgs);
-  run(1024 * 1024 * 128UL,
-      1024 * 1024 * 128UL * ctranComm->statex_->nRanks(),
-      true,
-      true);
+  run(1024 * 1024 * 128UL, 1024 * 1024 * 128UL * ctranComm->statex_->nRanks());
 }
 
 TEST_P(CtranAllToAllTestParam, ZeroByteAllToAll) {


### PR DESCRIPTION
Summary:

- Remove reportPerf=true from SmallAllToAll and LargeAllToAll test cases so correctness tests only verify data correctness, not performance
- Add TODO to move perf measurement to a separate benchmark file
- Total test time reduced from ~281s to ~41s (-85%), mainly from LargeAllToAll dropping from ~66s to ~6.5s per param combo
- Follow-up: T261863484

Reviewed By: Regina8023

Differential Revision: D98581546
