### PR TITLE
Instrument GPE execution with OperationTraceLogger

### DIFF
--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -25,6 +25,7 @@
 #include "comms/utils/colltrace/CollRecord.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/LogUtils.h"
+#include "comms/utils/logger/OperationTraceWriter.h"
 
 using namespace ctran;
 using namespace ncclx::colltrace;
@@ -307,6 +308,12 @@ commResult_t CtranGpe::Impl::submit(
     cmd->kernelFlag = kernelFlag;
     cmd->timeout = timeout;
     cmd->unpackPool = kernelConfig.unpackPool;
+
+    // Capture enqueue timing for GPE execution tracing
+    cmd->timing.tEnqueueUs = comms::logger::getTraceTimestampUs();
+    cmd->timing.kernelTypeName = kernelTypeToName[kernelConfig.type];
+    cmd->timing.numBlocks = kernelConfig.numBlocks;
+    cmd->timing.numThreads = kernelConfig.numThreads;
 
     if (type == CtranGpeCmd::TypeEnum::GRAPH_ENQUEUE) {
       cmd->coll.opGroup = std::move(opGroup);
@@ -602,18 +609,49 @@ void CtranGpe::Impl::gpeThreadFn() {
         return;
       }
 
-      // If kernelFlag is set, indicates it is a device memory communication
-      // thus, wait for the kernel to launch
+      // --- GPE execution tracing ---
+      comms::logger::OperationTraceLogger traceLogger(
+          "GPE_EXECUTION",
+          this->comm->logMetaData_.rank,
+          static_cast<int64_t>(this->comm->logMetaData_.commHash),
+          static_cast<int64_t>(this->comm->logMetaData_.commId),
+          this->comm->logMetaData_.nRanks,
+          !cmd->coll.opGroup.empty()
+              ? static_cast<int64_t>(cmd->coll.opGroup.front()->opCount)
+              : -1);
+      if (traceLogger.isActive()) {
+        traceLogger.setGpeContext(
+            cmd->timing.kernelTypeName,
+            cmd->timing.numBlocks,
+            cmd->timing.numThreads,
+            cmd->persistent);
+        traceLogger.logEvent("GPE_EXECUTION_START", cmd->timing.tEnqueueUs);
+      }
+
+      // Queue wait phase: enqueue (submit thread) → dequeue (this thread)
+      auto tDequeue = comms::logger::getTraceTimestampUs();
+      traceLogger.logEvent(
+          "GPE_QUEUE_WAIT_END", tDequeue, tDequeue - cmd->timing.tEnqueueUs);
+
+      // Kernel wait phase: wait for GPU kernel to signal KERNEL_STARTED
       KernelFlagItem* kernelFlag = cmd->kernelFlag;
-      if (kernelFlag) {
-        volatile int* flag_d = kernelFlag->flag_;
-        // Here we check just flag_d[0]. This is ok because Kernel Start signal
-        // is only used for tracing purposes. Before the flags are freed below
-        // with reset, all block flags are checked.
-        while (flag_d[0] != KERNEL_STARTED &&
-               flag_d[0] != KERNEL_STARTED_AND_EXIT) {
-          std::this_thread::yield();
+      {
+        auto tKernelWaitStart = comms::logger::getTraceTimestampUs();
+        if (kernelFlag) {
+          volatile int* flag_d = kernelFlag->flag_;
+          // Here we check just flag_d[0]. This is ok because Kernel Start
+          // signal is only used for tracing purposes. Before the flags are
+          // freed below with reset, all block flags are checked.
+          while (flag_d[0] != KERNEL_STARTED &&
+                 flag_d[0] != KERNEL_STARTED_AND_EXIT) {
+            std::this_thread::yield();
+          }
         }
+        auto tKernelWaitEnd = comms::logger::getTraceTimestampUs();
+        traceLogger.logEvent(
+            "GPE_KERNEL_WAIT_END",
+            tKernelWaitEnd,
+            tKernelWaitEnd - tKernelWaitStart);
       }
 
       if (cmd->coll.collHandle != nullptr) {
@@ -634,7 +672,9 @@ void CtranGpe::Impl::gpeThreadFn() {
             });
       }
 
+      // CPU execution phase: run collective function
       {
+        auto tCpuStart = comms::logger::getTraceTimestampUs();
         // comm may be dummy in GPE UT, although never happens in real.
         // Pass in nullptr mapper to skip lock.
         auto mapper =
@@ -690,38 +730,55 @@ void CtranGpe::Impl::gpeThreadFn() {
         } else {
           cmd->coll.opGroup.clear();
         }
+        auto tCpuEnd = comms::logger::getTraceTimestampUs();
+        traceLogger.logEvent(
+            "GPE_CPU_EXECUTION_END", tCpuEnd, tCpuEnd - tCpuStart);
       }
 
-      if (kernelFlag) {
-        volatile int* flag_d = kernelFlag->flag_;
-        if (flag_d[0] == KERNEL_STARTED_AND_EXIT) {
-          // Indicate kernel would exit without the terminate signal, thus free
-          // the flag now
-          while (!kernelFlag->testFlagAllGroups(KERNEL_STARTED_AND_EXIT)) {
-            std::this_thread::yield();
+      // GPU terminate phase: signal kernel to stop and wait
+      {
+        auto tTermStart = comms::logger::getTraceTimestampUs();
+        if (kernelFlag) {
+          volatile int* flag_d = kernelFlag->flag_;
+          if (flag_d[0] == KERNEL_STARTED_AND_EXIT) {
+            // Indicate kernel would exit without the terminate signal, thus
+            // free the flag now
+            while (!kernelFlag->testFlagAllGroups(KERNEL_STARTED_AND_EXIT)) {
+              std::this_thread::yield();
+            }
+            // After all blocks exited, we can safely reset.
+            kernelFlag->reset();
+          } else {
+            // In case of aborted comm, wait for kernel to start
+            while (comm->testAbort() &&
+                   !kernelFlag->testFlagAllGroups(KERNEL_STARTED)) {
+              std::this_thread::yield();
+            }
+            // Stop kernel and kernel will free up the flag after confirmed the
+            // termination
+            kernelFlag->setFlagPerGroup(
+                comm->testAbort() ? KERNEL_HOST_ABORT : KERNEL_TERMINATE);
           }
-          // After all blocks exited, we can safely reset.
-          kernelFlag->reset();
-        } else {
-          // In case of aborted comm, wait for kernel to start
-          while (comm->testAbort() &&
-                 !kernelFlag->testFlagAllGroups(KERNEL_STARTED)) {
-            std::this_thread::yield();
+          // Teardown unpack queue if it was allocated for this operation (TcpDM
+          // backend). Don't wait for kernel to finish, the pool manages
+          // the allocations in the round robin fashion to avoid immediate
+          // reuse.
+          if (cmd->unpackPool != nullptr) {
+            FB_COMMCHECKTHROW_EX(
+                comm->ctran_->mapper->teardownUnpackConsumer(cmd->unpackPool),
+                comm->logMetaData_);
           }
-          // Stop kernel and kernel will free up the flag after confirmed the
-          // termination
-          kernelFlag->setFlagPerGroup(
-              comm->testAbort() ? KERNEL_HOST_ABORT : KERNEL_TERMINATE);
         }
-        // Teardown unpack queue if it was allocated for this operation (TcpDM
-        // backend). Don't wait for kernel to finish, the pool manages
-        // the allocations in the round robin fashion to avoid immediate
-        // reuse.
-        if (cmd->unpackPool != nullptr) {
-          FB_COMMCHECKTHROW_EX(
-              comm->ctran_->mapper->teardownUnpackConsumer(cmd->unpackPool),
-              comm->logMetaData_);
-        }
+        auto tTermEnd = comms::logger::getTraceTimestampUs();
+        traceLogger.logEvent(
+            "GPE_GPU_TERMINATE_END", tTermEnd, tTermEnd - tTermStart);
+      }
+
+      // Log overall GPE execution end with total duration
+      {
+        auto tEnd = comms::logger::getTraceTimestampUs();
+        traceLogger.logEvent(
+            "GPE_EXECUTION_END", tEnd, tEnd - cmd->timing.tEnqueueUs);
       }
 
       if (cmd->coll.collHandle != nullptr) {

--- a/comms/ctran/gpe/CtranGpeImpl.h
+++ b/comms/ctran/gpe/CtranGpeImpl.h
@@ -153,6 +153,15 @@ class CtranGpeCmd {
 
   // Unpack queue to teardown after kernel completes (for TcpDM backend)
   void* unpackPool{nullptr};
+
+  // GPE execution tracing (mccl_operation_trace).
+  // Captured in submit() for use by the GPE thread.
+  struct {
+    int64_t tEnqueueUs{0};
+    std::string kernelTypeName;
+    int numBlocks{0};
+    int numThreads{0};
+  } timing;
 };
 
 /**

--- a/comms/utils/logger/OperationTraceWriter.cc
+++ b/comms/utils/logger/OperationTraceWriter.cc
@@ -2,6 +2,8 @@
 
 #include "comms/utils/logger/OperationTraceWriter.h"
 
+#include "comms/utils/logger/ScubaFileUtils.h"
+
 namespace comms::logger {
 
 namespace {
@@ -18,6 +20,87 @@ void OperationTraceWriterRegistry::set(
 
 IOperationTraceWriter* OperationTraceWriterRegistry::get() {
   return writerInstance().get();
+}
+
+int64_t getTraceTimestampUs() {
+  return getTimestampUs();
+}
+
+// --- OperationTraceLogger ---
+
+OperationTraceLogger::OperationTraceLogger(
+    std::string mcclop,
+    int rank,
+    int64_t commHash,
+    int64_t commId,
+    int worldSize,
+    int64_t opCount)
+    : mcclop_(std::move(mcclop)),
+      rank_(rank),
+      commHash_(commHash),
+      commId_(commId),
+      worldSize_(worldSize),
+      opCount_(opCount) {
+  writer_ = OperationTraceWriterRegistry::get();
+  active_ = writer_ != nullptr && writer_->isEnabled();
+}
+
+void OperationTraceLogger::setGpeContext(
+    std::string kernelType,
+    int numBlocks,
+    int numThreads,
+    bool persistent) {
+  gpeKernelType_ = std::move(kernelType);
+  gpeNumBlocks_ = numBlocks;
+  gpeNumThreads_ = numThreads;
+  gpePersistent_ = persistent;
+}
+
+void OperationTraceLogger::logEvent(const std::string& event) {
+  if (!active_) {
+    return;
+  }
+  writer_->addSample(buildSample(event, getTimestampUs(), std::nullopt));
+}
+
+void OperationTraceLogger::logEvent(
+    const std::string& event,
+    int64_t timestampUs) {
+  if (!active_) {
+    return;
+  }
+  writer_->addSample(buildSample(event, timestampUs, std::nullopt));
+}
+
+void OperationTraceLogger::logEvent(
+    const std::string& event,
+    int64_t timestampUs,
+    int64_t durationUs) {
+  if (!active_) {
+    return;
+  }
+  writer_->addSample(buildSample(event, timestampUs, durationUs));
+}
+
+OperationTraceSample OperationTraceLogger::buildSample(
+    const std::string& event,
+    int64_t timestampUs,
+    std::optional<int64_t> durationUs) const {
+  OperationTraceSample s;
+  s.mcclop = mcclop_;
+  s.event = event;
+  s.timestampUs = timestampUs;
+  s.rank = rank_;
+  s.commHash = commHash_;
+  s.commId = commId_;
+  s.worldSize = worldSize_;
+  s.opCount = opCount_;
+  s.durationUs = durationUs;
+  s.gpeKernelType = gpeKernelType_;
+  s.gpeNumBlocks = gpeNumBlocks_;
+  s.gpeNumThreads = gpeNumThreads_;
+  s.gpePersistent = gpePersistent_;
+  return s;
 }
 
 } // namespace comms::logger

--- a/comms/utils/logger/OperationTraceWriter.cc
+++ b/comms/utils/logger/OperationTraceWriter.cc
@@ -1,0 +1,23 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/utils/logger/OperationTraceWriter.h"
+
+namespace comms::logger {
+
+namespace {
+std::shared_ptr<IOperationTraceWriter>& writerInstance() {
+  static std::shared_ptr<IOperationTraceWriter> instance;
+  return instance;
+}
+} // namespace
+
+void OperationTraceWriterRegistry::set(
+    std::shared_ptr<IOperationTraceWriter> writer) {
+  writerInstance() = std::move(writer);
+}
+
+IOperationTraceWriter* OperationTraceWriterRegistry::get() {
+  return writerInstance().get();
+}
+
+} // namespace comms::logger

--- a/comms/utils/logger/OperationTraceWriter.h
+++ b/comms/utils/logger/OperationTraceWriter.h
@@ -1,0 +1,49 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+
+namespace comms::logger {
+
+// Sample for operation trace logging to mccl_operation_trace scuba table.
+// Defines the schema for all columns that ctran (and other lower-level
+// components) can log through the DI writer, without depending on MCCL.
+struct OperationTraceSample {
+  std::string mcclop; // Operation type (e.g., "GPE_EXECUTION")
+  std::string event; // Event name (e.g., "GPE_EXECUTION_END")
+  int64_t timestampUs{0}; // Timestamp in microseconds
+  int rank{-1};
+  int64_t commHash{0};
+  int64_t commId{0};
+  int worldSize{-1};
+  int64_t opCount{-1};
+  std::optional<int64_t> durationUs;
+};
+
+// Interface for operation trace writers.
+// Implementations route samples to their respective scuba tables
+// (e.g., mccl_operation_trace, ncclx_operation_trace).
+class IOperationTraceWriter {
+ public:
+  virtual ~IOperationTraceWriter() = default;
+  virtual bool isEnabled() const = 0;
+  virtual void addSample(OperationTraceSample sample) = 0;
+};
+
+// Global registry for the operation trace writer.
+// Set by the communication library (MCCL or NCCLX) during initialization;
+// queried by lower-level components (e.g., ctran) at runtime.
+class OperationTraceWriterRegistry {
+ public:
+  static void set(std::shared_ptr<IOperationTraceWriter> writer);
+  static IOperationTraceWriter* get();
+
+ private:
+  OperationTraceWriterRegistry() = delete;
+};
+
+} // namespace comms::logger

--- a/comms/utils/logger/OperationTraceWriter.h
+++ b/comms/utils/logger/OperationTraceWriter.h
@@ -52,4 +52,73 @@ class OperationTraceWriterRegistry {
   OperationTraceWriterRegistry() = delete;
 };
 
+// Get current timestamp in microseconds (re-declared to avoid pulling in
+// ScubaFileUtils.h — definition lives in OperationTraceWriter.cc).
+int64_t getTraceTimestampUs();
+
+// Lightweight logger that captures shared identity fields once and provides
+// simple logEvent() calls. No RAII, no automatic START/END — the caller
+// explicitly logs each event at the point they want.
+//
+// Usage:
+//   OperationTraceLogger logger("GPE_EXECUTION", rank, commHash, commId,
+//                               worldSize, opCount);
+//   if (!logger.isActive()) return;  // writer not registered or disabled
+//   logger.setGpeContext("AllGather", 4, 256, false);
+//   logger.logEvent("GPE_EXECUTION_START");
+//   // ... do work ...
+//   logger.logEvent("GPE_EXECUTION_END", startUs, endUs - startUs);
+class OperationTraceLogger {
+ public:
+  OperationTraceLogger(
+      std::string mcclop,
+      int rank,
+      int64_t commHash,
+      int64_t commId,
+      int worldSize,
+      int64_t opCount);
+
+  bool isActive() const {
+    return active_;
+  }
+
+  // Set GPE context fields on all subsequent logEvent() calls.
+  void setGpeContext(
+      std::string kernelType,
+      int numBlocks,
+      int numThreads,
+      bool persistent);
+
+  // Log an event with auto-generated timestamp, no duration.
+  void logEvent(const std::string& event);
+
+  // Log an event with explicit timestamp, no duration.
+  void logEvent(const std::string& event, int64_t timestampUs);
+
+  // Log an event with explicit timestamp and duration.
+  void
+  logEvent(const std::string& event, int64_t timestampUs, int64_t durationUs);
+
+ private:
+  OperationTraceSample buildSample(
+      const std::string& event,
+      int64_t timestampUs,
+      std::optional<int64_t> durationUs) const;
+
+  IOperationTraceWriter* writer_{nullptr};
+  std::string mcclop_;
+  int rank_;
+  int64_t commHash_;
+  int64_t commId_;
+  int worldSize_;
+  int64_t opCount_;
+  bool active_{false};
+
+  // GPE context (set once, applied to all samples)
+  std::optional<std::string> gpeKernelType_;
+  std::optional<int> gpeNumBlocks_;
+  std::optional<int> gpeNumThreads_;
+  std::optional<bool> gpePersistent_;
+};
+
 } // namespace comms::logger

--- a/comms/utils/logger/OperationTraceWriter.h
+++ b/comms/utils/logger/OperationTraceWriter.h
@@ -22,6 +22,12 @@ struct OperationTraceSample {
   int worldSize{-1};
   int64_t opCount{-1};
   std::optional<int64_t> durationUs;
+
+  // === GPE Execution context (Optional) ===
+  std::optional<std::string> gpeKernelType;
+  std::optional<int> gpeNumBlocks;
+  std::optional<int> gpeNumThreads;
+  std::optional<bool> gpePersistent;
 };
 
 // Interface for operation trace writers.

--- a/comms/utils/logger/tests/OperationTraceWriterTest.cc
+++ b/comms/utils/logger/tests/OperationTraceWriterTest.cc
@@ -1,0 +1,88 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include "comms/utils/logger/OperationTraceWriter.h"
+
+using comms::logger::IOperationTraceWriter;
+using comms::logger::OperationTraceSample;
+using comms::logger::OperationTraceWriterRegistry;
+
+namespace {
+
+class MockOperationTraceWriter : public IOperationTraceWriter {
+ public:
+  bool isEnabled() const override {
+    return enabled;
+  }
+
+  void addSample(OperationTraceSample sample) override {
+    samples.push_back(std::move(sample));
+  }
+
+  bool enabled{true};
+  std::vector<OperationTraceSample> samples;
+};
+
+class OperationTraceWriterTest : public ::testing::Test {
+ protected:
+  void TearDown() override {
+    OperationTraceWriterRegistry::set(nullptr);
+  }
+};
+
+} // namespace
+
+TEST_F(OperationTraceWriterTest, RegistryReturnsNullByDefault) {
+  EXPECT_EQ(OperationTraceWriterRegistry::get(), nullptr);
+}
+
+TEST_F(OperationTraceWriterTest, RegisteredWriterReceivesSamples) {
+  auto mock = std::make_shared<MockOperationTraceWriter>();
+  OperationTraceWriterRegistry::set(mock);
+
+  auto* writer = OperationTraceWriterRegistry::get();
+  ASSERT_NE(writer, nullptr);
+  EXPECT_TRUE(writer->isEnabled());
+
+  OperationTraceSample sample;
+  sample.mcclop = "TEST_OP";
+  sample.event = "TEST_OP_END";
+  sample.timestampUs = 1000000;
+  sample.rank = 3;
+  sample.commHash = 12345;
+  sample.commId = 99;
+  sample.worldSize = 8;
+  sample.opCount = 42;
+  sample.durationUs = 500;
+  writer->addSample(std::move(sample));
+
+  ASSERT_EQ(mock->samples.size(), 1);
+  const auto& s = mock->samples[0];
+  EXPECT_EQ(s.mcclop, "TEST_OP");
+  EXPECT_EQ(s.event, "TEST_OP_END");
+  EXPECT_EQ(s.timestampUs, 1000000);
+  EXPECT_EQ(s.rank, 3);
+  EXPECT_EQ(s.commHash, 12345);
+  EXPECT_EQ(s.commId, 99);
+  EXPECT_EQ(s.worldSize, 8);
+  EXPECT_EQ(s.opCount, 42);
+  ASSERT_TRUE(s.durationUs.has_value());
+  EXPECT_EQ(s.durationUs.value(), 500);
+}
+
+TEST_F(OperationTraceWriterTest, DisabledWriterSkipsSamples) {
+  auto mock = std::make_shared<MockOperationTraceWriter>();
+  mock->enabled = false;
+  OperationTraceWriterRegistry::set(mock);
+
+  auto* writer = OperationTraceWriterRegistry::get();
+  ASSERT_NE(writer, nullptr);
+  EXPECT_FALSE(writer->isEnabled());
+
+  if (writer->isEnabled()) {
+    OperationTraceSample sample;
+    writer->addSample(std::move(sample));
+  }
+  EXPECT_EQ(mock->samples.size(), 0);
+}

--- a/comms/utils/logger/tests/OperationTraceWriterTest.cc
+++ b/comms/utils/logger/tests/OperationTraceWriterTest.cc
@@ -5,6 +5,7 @@
 #include "comms/utils/logger/OperationTraceWriter.h"
 
 using comms::logger::IOperationTraceWriter;
+using comms::logger::OperationTraceLogger;
 using comms::logger::OperationTraceSample;
 using comms::logger::OperationTraceWriterRegistry;
 
@@ -85,4 +86,84 @@ TEST_F(OperationTraceWriterTest, DisabledWriterSkipsSamples) {
     writer->addSample(std::move(sample));
   }
   EXPECT_EQ(mock->samples.size(), 0);
+}
+
+// --- OperationTraceLogger tests ---
+
+TEST_F(OperationTraceWriterTest, LoggerIsInactiveWithNoWriter) {
+  OperationTraceLogger logger("GPE_EXECUTION", 0, 111, 222, 8, 1);
+  EXPECT_FALSE(logger.isActive());
+  // Should be a no-op, not crash
+  logger.logEvent("GPE_EXECUTION_START");
+}
+
+TEST_F(OperationTraceWriterTest, LoggerIsInactiveWhenDisabled) {
+  auto mock = std::make_shared<MockOperationTraceWriter>();
+  mock->enabled = false;
+  OperationTraceWriterRegistry::set(mock);
+
+  OperationTraceLogger logger("GPE_EXECUTION", 0, 111, 222, 8, 1);
+  EXPECT_FALSE(logger.isActive());
+  logger.logEvent("GPE_EXECUTION_START");
+  EXPECT_EQ(mock->samples.size(), 0);
+}
+
+TEST_F(OperationTraceWriterTest, LoggerLogEventAutoTimestamp) {
+  auto mock = std::make_shared<MockOperationTraceWriter>();
+  OperationTraceWriterRegistry::set(mock);
+
+  OperationTraceLogger logger("GPE_EXECUTION", 3, 111, 222, 8, 42);
+  ASSERT_TRUE(logger.isActive());
+
+  logger.logEvent("GPE_EXECUTION_START");
+
+  ASSERT_EQ(mock->samples.size(), 1);
+  const auto& s = mock->samples[0];
+  EXPECT_EQ(s.mcclop, "GPE_EXECUTION");
+  EXPECT_EQ(s.event, "GPE_EXECUTION_START");
+  EXPECT_GT(s.timestampUs, 0);
+  EXPECT_EQ(s.rank, 3);
+  EXPECT_EQ(s.commHash, 111);
+  EXPECT_EQ(s.commId, 222);
+  EXPECT_EQ(s.worldSize, 8);
+  EXPECT_EQ(s.opCount, 42);
+  EXPECT_FALSE(s.durationUs.has_value());
+}
+
+TEST_F(OperationTraceWriterTest, LoggerLogEventWithTimestampAndDuration) {
+  auto mock = std::make_shared<MockOperationTraceWriter>();
+  OperationTraceWriterRegistry::set(mock);
+
+  OperationTraceLogger logger("GPE_EXECUTION", 0, 111, 222, 8, 1);
+  logger.logEvent("GPE_EXECUTION_END", 5000, 3000);
+
+  ASSERT_EQ(mock->samples.size(), 1);
+  const auto& s = mock->samples[0];
+  EXPECT_EQ(s.event, "GPE_EXECUTION_END");
+  EXPECT_EQ(s.timestampUs, 5000);
+  ASSERT_TRUE(s.durationUs.has_value());
+  EXPECT_EQ(s.durationUs.value(), 3000);
+}
+
+TEST_F(OperationTraceWriterTest, LoggerGpeContextAppliedToAllEvents) {
+  auto mock = std::make_shared<MockOperationTraceWriter>();
+  OperationTraceWriterRegistry::set(mock);
+
+  OperationTraceLogger logger("GPE_EXECUTION", 0, 111, 222, 8, 1);
+  logger.setGpeContext("AllGather", 4, 256, false);
+
+  logger.logEvent("GPE_EXECUTION_START");
+  logger.logEvent("GPE_EXECUTION_END", 5000, 3000);
+
+  ASSERT_EQ(mock->samples.size(), 2);
+  for (const auto& s : mock->samples) {
+    ASSERT_TRUE(s.gpeKernelType.has_value());
+    EXPECT_EQ(s.gpeKernelType.value(), "AllGather");
+    ASSERT_TRUE(s.gpeNumBlocks.has_value());
+    EXPECT_EQ(s.gpeNumBlocks.value(), 4);
+    ASSERT_TRUE(s.gpeNumThreads.has_value());
+    EXPECT_EQ(s.gpeNumThreads.value(), 256);
+    ASSERT_TRUE(s.gpePersistent.has_value());
+    EXPECT_FALSE(s.gpePersistent.value());
+  }
 }

--- a/comms/utils/logger/tests/OperationTraceWriterTest.cc
+++ b/comms/utils/logger/tests/OperationTraceWriterTest.cc
@@ -167,3 +167,99 @@ TEST_F(OperationTraceWriterTest, LoggerGpeContextAppliedToAllEvents) {
     EXPECT_FALSE(s.gpePersistent.value());
   }
 }
+
+// Simulate the exact 6-event GPE tracing pattern from CtranGpeImpl.cc
+// gpeThreadFn() to verify correctness of the instrumentation sequence.
+TEST_F(OperationTraceWriterTest, GpeThreadTracingPattern) {
+  auto mock = std::make_shared<MockOperationTraceWriter>();
+  OperationTraceWriterRegistry::set(mock);
+
+  // Simulated timestamps (microseconds)
+  const int64_t tEnqueue = 1000;
+  const int64_t tDequeue = 1050;
+  const int64_t tKernelWaitStart = 1055;
+  const int64_t tKernelWaitEnd = 1100;
+  const int64_t tCpuStart = 1105;
+  const int64_t tCpuEnd = 1400;
+  const int64_t tTermStart = 1405;
+  const int64_t tTermEnd = 1500;
+  const int64_t tEnd = 1505;
+
+  // Mirror gpeThreadFn() instrumentation
+  OperationTraceLogger traceLogger("GPE_EXECUTION", 2, 0xABCD, 42, 16, 7);
+  ASSERT_TRUE(traceLogger.isActive());
+  traceLogger.setGpeContext("AllReduce", 8, 512, false);
+
+  // 1. GPE_EXECUTION_START (at enqueue time, no duration)
+  traceLogger.logEvent("GPE_EXECUTION_START", tEnqueue);
+
+  // 2. GPE_QUEUE_WAIT_END (dequeue time, duration = dequeue - enqueue)
+  traceLogger.logEvent("GPE_QUEUE_WAIT_END", tDequeue, tDequeue - tEnqueue);
+
+  // 3. GPE_KERNEL_WAIT_END (kernel started, duration = wait time)
+  traceLogger.logEvent(
+      "GPE_KERNEL_WAIT_END", tKernelWaitEnd, tKernelWaitEnd - tKernelWaitStart);
+
+  // 4. GPE_CPU_EXECUTION_END (collective done, duration = cpu time)
+  traceLogger.logEvent("GPE_CPU_EXECUTION_END", tCpuEnd, tCpuEnd - tCpuStart);
+
+  // 5. GPE_GPU_TERMINATE_END (kernel stopped, duration = term time)
+  traceLogger.logEvent(
+      "GPE_GPU_TERMINATE_END", tTermEnd, tTermEnd - tTermStart);
+
+  // 6. GPE_EXECUTION_END (total, duration = end - enqueue)
+  traceLogger.logEvent("GPE_EXECUTION_END", tEnd, tEnd - tEnqueue);
+
+  // Verify all 6 events were logged
+  ASSERT_EQ(mock->samples.size(), 6);
+
+  // Verify event names in order
+  EXPECT_EQ(mock->samples[0].event, "GPE_EXECUTION_START");
+  EXPECT_EQ(mock->samples[1].event, "GPE_QUEUE_WAIT_END");
+  EXPECT_EQ(mock->samples[2].event, "GPE_KERNEL_WAIT_END");
+  EXPECT_EQ(mock->samples[3].event, "GPE_CPU_EXECUTION_END");
+  EXPECT_EQ(mock->samples[4].event, "GPE_GPU_TERMINATE_END");
+  EXPECT_EQ(mock->samples[5].event, "GPE_EXECUTION_END");
+
+  // Verify timestamps
+  EXPECT_EQ(mock->samples[0].timestampUs, tEnqueue);
+  EXPECT_EQ(mock->samples[5].timestampUs, tEnd);
+
+  // Verify durations
+  EXPECT_FALSE(
+      mock->samples[0].durationUs.has_value()); // START has no duration
+  EXPECT_EQ(mock->samples[1].durationUs.value(), 50); // queue wait
+  EXPECT_EQ(mock->samples[2].durationUs.value(), 45); // kernel wait
+  EXPECT_EQ(mock->samples[3].durationUs.value(), 295); // cpu execution
+  EXPECT_EQ(mock->samples[4].durationUs.value(), 95); // gpu terminate
+  EXPECT_EQ(mock->samples[5].durationUs.value(), 505); // total
+
+  // Verify identity fields consistent across all events
+  for (const auto& s : mock->samples) {
+    EXPECT_EQ(s.mcclop, "GPE_EXECUTION");
+    EXPECT_EQ(s.rank, 2);
+    EXPECT_EQ(s.commHash, 0xABCD);
+    EXPECT_EQ(s.commId, 42);
+    EXPECT_EQ(s.worldSize, 16);
+    EXPECT_EQ(s.opCount, 7);
+    ASSERT_TRUE(s.gpeKernelType.has_value());
+    EXPECT_EQ(s.gpeKernelType.value(), "AllReduce");
+    EXPECT_EQ(s.gpeNumBlocks.value(), 8);
+    EXPECT_EQ(s.gpeNumThreads.value(), 512);
+    EXPECT_FALSE(s.gpePersistent.value());
+  }
+}
+
+// Verify GPE tracing is completely skipped when no writer is registered
+TEST_F(OperationTraceWriterTest, GpeTracingNoOpWithoutWriter) {
+  // No writer registered
+  OperationTraceLogger traceLogger("GPE_EXECUTION", 0, 111, 222, 8, 1);
+  EXPECT_FALSE(traceLogger.isActive());
+
+  // All these should be no-ops
+  traceLogger.setGpeContext("AllReduce", 4, 256, false);
+  traceLogger.logEvent("GPE_EXECUTION_START", 1000);
+  traceLogger.logEvent("GPE_QUEUE_WAIT_END", 1050, 50);
+  traceLogger.logEvent("GPE_EXECUTION_END", 1100, 100);
+  // No crash, no samples — verified by mock not existing
+}


### PR DESCRIPTION
Summary:
Add execution tracing to the GPE thread using the `OperationTraceLogger`
API, logging phase timings to the `mccl_operation_trace` scuba table.

Instrumentation points:
- `submit()`: captures enqueue timestamp and kernel context
  (type, numBlocks, numThreads) on `CtranGpeCmd::timing`
- `gpeThreadFn()`: logs 5 events per GPE operation:
  - `GPE_EXECUTION_START`: overall operation start (at enqueue time)
  - `GPE_QUEUE_WAIT_END`: enqueue → dequeue duration
  - `GPE_KERNEL_WAIT_END`: GPU kernel start wait duration
  - `GPE_CPU_EXECUTION_END`: collective function execution duration
  - `GPE_GPU_TERMINATE_END`: kernel termination wait duration
  - `GPE_EXECUTION_END`: total enqueue-to-completion duration

All tracing is no-op when the writer is not registered or disabled.

Differential Revision: D98770695


