### PR TITLE
Rename get_device_win to getDeviceWin for camelCase consistency (#1349)

### DIFF
--- a/comms/ctran/window/CtranWin.h
+++ b/comms/ctran/window/CtranWin.h
@@ -117,7 +117,7 @@ struct CtranWin {
   //
   // @param devWin  Output: populated device-side window handle.
   // @param config  WindowConfig controlling signal/counter/barrier allocation.
-  commResult_t get_device_win(
+  commResult_t getDeviceWin(
       comms::pipes::DeviceWindow* devWin,
       const comms::pipes::WindowConfig& config);
 

--- a/comms/ctran/window/tests/CtranWinDeviceTest.cc
+++ b/comms/ctran/window/tests/CtranWinDeviceTest.cc
@@ -43,14 +43,14 @@ class CtranWinDeviceTest : public ctran::CtranDistTestFixture {
   }
 };
 
-// Verify get_device_win() returns a correctly populated CtranWinDevice.
+// Verify getDeviceWin() returns a correctly populated CtranWinDevice.
 TEST_F(CtranWinDeviceTest, GetDeviceWin) {
   auto [comm, win] = makeCommAndWindow();
   ASSERT_NE(comm->multiPeerTransport_, nullptr);
 
   WindowConfig config{.peerSignalCount = win->signalSize};
   DeviceWindow devWin{};
-  ASSERT_EQ(win->get_device_win(&devWin, config), commSuccess);
+  ASSERT_EQ(win->getDeviceWin(&devWin, config), commSuccess);
 
   // Verify rank and n_ranks match the communicator's values
   EXPECT_EQ(devWin.rank(), globalRank);
@@ -68,7 +68,7 @@ TEST_F(CtranWinDeviceTest, GetDeviceWin) {
   ctran::ctranWinFree(win);
 }
 
-// Verify get_device_win() returns the same result on repeated calls.
+// Verify getDeviceWin() returns the same result on repeated calls.
 TEST_F(CtranWinDeviceTest, GetDeviceWinIdempotent) {
   auto [comm, win] = makeCommAndWindow();
   ASSERT_NE(comm->multiPeerTransport_, nullptr);
@@ -76,8 +76,8 @@ TEST_F(CtranWinDeviceTest, GetDeviceWinIdempotent) {
   WindowConfig config{.peerSignalCount = win->signalSize};
   DeviceWindow devWin1{};
   DeviceWindow devWin2{};
-  ASSERT_EQ(win->get_device_win(&devWin1, config), commSuccess);
-  ASSERT_EQ(win->get_device_win(&devWin2, config), commSuccess);
+  ASSERT_EQ(win->getDeviceWin(&devWin1, config), commSuccess);
+  ASSERT_EQ(win->getDeviceWin(&devWin2, config), commSuccess);
 
   EXPECT_EQ(devWin1.rank(), devWin2.rank());
   EXPECT_EQ(devWin1.n_ranks(), devWin2.n_ranks());
@@ -87,17 +87,17 @@ TEST_F(CtranWinDeviceTest, GetDeviceWinIdempotent) {
   ctran::ctranWinFree(win);
 }
 
-// Verify get_device_win() fails when MultiPeerTransport is not initialized.
+// Verify getDeviceWin() fails when MultiPeerTransport is not initialized.
 TEST_F(CtranWinDeviceTest, GetDeviceWinNoTransportFails) {
   auto [comm, win] = makeCommAndWindow();
 
   // Simulate no-pipes by nulling out the transport
   comm->multiPeerTransport_.reset();
 
-  // get_device_win should fail since multiPeerTransport_ is null
+  // getDeviceWin should fail since multiPeerTransport_ is null
   WindowConfig config{.peerSignalCount = win->signalSize};
   DeviceWindow devWin{};
-  EXPECT_NE(win->get_device_win(&devWin, config), commSuccess);
+  EXPECT_NE(win->getDeviceWin(&devWin, config), commSuccess);
 
   ctran::ctranWinFree(win);
 }

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -286,13 +286,13 @@ bool CtranWin::nvlEnabled(int rank) const {
 }
 
 #if defined(ENABLE_PIPES)
-commResult_t CtranWin::get_device_win(
+commResult_t CtranWin::getDeviceWin(
     comms::pipes::DeviceWindow* devWin,
     const comms::pipes::WindowConfig& config) {
   auto* transport = comm->multiPeerTransport_.get();
   if (!transport) {
     FB_ERRORRETURN(
-        commInternalError, "get_device_win: multiPeerTransport is null.");
+        commInternalError, "getDeviceWin: multiPeerTransport is null.");
   }
 
   if (!hostWindow_) {

--- a/comms/ncclx/v2_27/meta/rma/window.cc
+++ b/comms/ncclx/v2_27/meta/rma/window.cc
@@ -230,7 +230,7 @@ ncclResult_t ncclWinCreateDeviceWin(
     void** outDevicePtr) {
   // Creates a DeviceWindow in device memory from the ctran window underlying
   // the given ncclWindow_t. This is a COLLECTIVE operation on first call —
-  // all ranks must call together because get_device_win() does an allGather.
+  // all ranks must call together because getDeviceWin() does an allGather.
   //
   // Subsequent calls on the same window return cached results (config ignored).
   //
@@ -252,12 +252,12 @@ ncclResult_t ncclWinCreateDeviceWin(
       .barrierCount = static_cast<std::size_t>(std::max(barrier_count, 0)),
   };
 
-  // Populate DeviceWindow on host stack. get_device_win() fills in transport
+  // Populate DeviceWindow on host stack. getDeviceWin() fills in transport
   // handles, remote buffer descriptors, and signal pointers.
   comms::pipes::DeviceWindow host_dev_win{};
-  auto result = nw->ctranWindow->get_device_win(&host_dev_win, config);
+  auto result = nw->ctranWindow->getDeviceWin(&host_dev_win, config);
   if (result != commSuccess) {
-    WARN("ncclWinCreateDeviceWin: get_device_win failed with error %d", result);
+    WARN("ncclWinCreateDeviceWin: getDeviceWin failed with error %d", result);
     return ncclInternalError;
   }
 

--- a/comms/ncclx/v2_28/meta/rma/window.cc
+++ b/comms/ncclx/v2_28/meta/rma/window.cc
@@ -228,7 +228,7 @@ ncclResult_t ncclWinCreateDeviceWin(
     void** outDevicePtr) {
   // Creates a DeviceWindow in device memory from the ctran window underlying
   // the given ncclWindow_t. This is a COLLECTIVE operation on first call —
-  // all ranks must call together because get_device_win() does an allGather.
+  // all ranks must call together because getDeviceWin() does an allGather.
   //
   // Subsequent calls on the same window return cached results (config ignored).
   //
@@ -250,12 +250,12 @@ ncclResult_t ncclWinCreateDeviceWin(
       .barrierCount = static_cast<std::size_t>(std::max(barrier_count, 0)),
   };
 
-  // Populate DeviceWindow on host stack. get_device_win() fills in transport
+  // Populate DeviceWindow on host stack. getDeviceWin() fills in transport
   // handles, remote buffer descriptors, and signal pointers.
   comms::pipes::DeviceWindow host_dev_win{};
-  auto result = nw->ctranWindow->get_device_win(&host_dev_win, config);
+  auto result = nw->ctranWindow->getDeviceWin(&host_dev_win, config);
   if (result != commSuccess) {
-    WARN("ncclWinCreateDeviceWin: get_device_win failed with error %d", result);
+    WARN("ncclWinCreateDeviceWin: getDeviceWin failed with error %d", result);
     return ncclInternalError;
   }
 

--- a/comms/ncclx/v2_29/meta/rma/window.cc
+++ b/comms/ncclx/v2_29/meta/rma/window.cc
@@ -228,7 +228,7 @@ ncclResult_t ncclWinCreateDeviceWin(
     void** outDevicePtr) {
   // Creates a DeviceWindow in device memory from the ctran window underlying
   // the given ncclWindow_t. This is a COLLECTIVE operation on first call —
-  // all ranks must call together because get_device_win() does an allGather.
+  // all ranks must call together because getDeviceWin() does an allGather.
   //
   // Subsequent calls on the same window return cached results (config ignored).
   //
@@ -250,12 +250,12 @@ ncclResult_t ncclWinCreateDeviceWin(
       .barrierCount = static_cast<std::size_t>(std::max(barrier_count, 0)),
   };
 
-  // Populate DeviceWindow on host stack. get_device_win() fills in transport
+  // Populate DeviceWindow on host stack. getDeviceWin() fills in transport
   // handles, remote buffer descriptors, and signal pointers.
   comms::pipes::DeviceWindow host_dev_win{};
-  auto result = nw->ctranWindow->get_device_win(&host_dev_win, config);
+  auto result = nw->ctranWindow->getDeviceWin(&host_dev_win, config);
   if (result != commSuccess) {
-    WARN("ncclWinCreateDeviceWin: get_device_win failed with error %d", result);
+    WARN("ncclWinCreateDeviceWin: getDeviceWin failed with error %d", result);
     return ncclInternalError;
   }
 

--- a/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTest.cpp
@@ -96,7 +96,7 @@ std::string PipesDeviceApiTest::getDtypeName(at::ScalarType dtype) {
 // Validates the Pipes device window creation flow:
 //   1. All ranks register the same-sized tensor in a symmetric window
 //   2. Barrier ensures all registrations complete before device window creation
-//   3. get_device_window() triggers ctran_win->get_device_win() (allGather):
+//   3. get_device_window() triggers ctran_win->getDeviceWin() (allGather):
 //      - IBGDA path: exchanges remote buffer registration info
 //      - NVLink path: exchanges NVLink-mapped remote pointers
 //   4. Verify the returned device pointer is non-null
@@ -144,7 +144,7 @@ void PipesDeviceApiTest::testPipesDeviceWindowCreation(
                              "Is NCCL_CTRAN_USE_PIPES=1 set?";
 
   // get_device_window() is COLLECTIVE: internally calls
-  // ctran_win->get_device_win() which does an allGather to exchange IBGDA
+  // ctran_win->getDeviceWin() which does an allGather to exchange IBGDA
   // buffer registration info and NVLink-mapped remote buffer pointers.
   // All ranks must call this simultaneously.
   DeviceWindowPipes* dev_win = nullptr;

--- a/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTest.hpp
+++ b/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTest.hpp
@@ -49,7 +49,7 @@ class PipesDeviceApiTest : public ::testing::Test {
 
   // Verify that tensor_register() + get_device_window() succeeds.
   // get_device_window() is COLLECTIVE: all ranks call
-  // ctran_win->get_device_win() which performs an allGather to exchange IBGDA
+  // ctran_win->getDeviceWin() which performs an allGather to exchange IBGDA
   // registration info and NVLink-mapped pointers.
   void testPipesDeviceWindowCreation(int count, at::ScalarType dtype);
 


### PR DESCRIPTION
Summary:

Rename `get_device_win` to `getDeviceWin` across ctran, ncclx, and
torchcomms to follow camelCase naming convention used by the rest of the
ctran codebase.

Differential Revision: D98845854
