### PR TITLE
graceful fallback when IB backend is unavailable

### DIFF
--- a/comms/ctran/backends/ib/CtranIb.cc
+++ b/comms/ctran/backends/ib/CtranIb.cc
@@ -62,32 +62,32 @@ commResult_t checkEpochLock(CtranIb* ctranIb) {
 static folly::Singleton<CtranIbSingleton> ctranIbSingleton;
 
 std::shared_ptr<CtranIbSingleton> CtranIbSingleton::getInstance() {
-  try {
-    return ctranIbSingleton.try_get();
-  } catch ([[maybe_unused]] const ctran::utils::Exception& e) {
-    return nullptr;
-  }
+  return ctranIbSingleton.try_get();
 }
 
 CtranIbSingleton::CtranIbSingleton() {
   auto ibvInitResult = ibverbx::ibvInit();
-  if (!ibvInitResult.hasValue()) {
-    std::string msg =
-        "CTRAN-IB: Failed to initialize ibverbs (libibverbs.so). "
-        "InfiniBand backend is not available. "
-        "Set NCCL_CTRAN_BACKENDS=nvl,socket to use alternative backends.";
-    CLOGF(ERR, msg);
-    throw ctran::utils::Exception(msg, commSystemError);
+  try {
+    FOLLY_EXPECTED_CHECKTHROW_EX_NOCOMM(ibvInitResult);
+  } catch (const ctran::utils::Exception& e) {
+    CLOGF(
+        ERR,
+        "CTRAN-IB: Failed to initialize ibverbs (libibverbs.so): {}. "
+        "Set NCCL_CTRAN_BACKENDS=nvl,socket to use alternative backends.",
+        e.what());
+    throw;
   }
   auto maybeDeviceList = ibverbx::IbvDevice::ibvGetDeviceList(
       NCCL_IB_HCA, NCCL_IB_HCA_PREFIX, CTRAN_IB_ANY_PORT, NCCL_IB_DATA_DIRECT);
-  if (!maybeDeviceList.hasValue()) {
-    std::string msg =
-        "CTRAN-IB: Failed to get InfiniBand device list. "
-        "No HCA devices found on this system. "
-        "Set NCCL_CTRAN_BACKENDS=nvl,socket to use alternative backends.";
-    CLOGF(ERR, msg);
-    throw ctran::utils::Exception(msg, commSystemError);
+  try {
+    FOLLY_EXPECTED_CHECKTHROW_EX_NOCOMM(maybeDeviceList);
+  } catch (const ctran::utils::Exception& e) {
+    CLOGF(
+        ERR,
+        "CTRAN-IB: Failed to get InfiniBand device list: {}. "
+        "Set NCCL_CTRAN_BACKENDS=nvl,socket to use alternative backends.",
+        e.what());
+    throw;
   }
   ibvDevices = std::move(*maybeDeviceList);
 

--- a/comms/ctran/backends/ib/CtranIb.cc
+++ b/comms/ctran/backends/ib/CtranIb.cc
@@ -62,24 +62,44 @@ commResult_t checkEpochLock(CtranIb* ctranIb) {
 static folly::Singleton<CtranIbSingleton> ctranIbSingleton;
 
 std::shared_ptr<CtranIbSingleton> CtranIbSingleton::getInstance() {
-  return ctranIbSingleton.try_get();
+  try {
+    return ctranIbSingleton.try_get();
+  } catch ([[maybe_unused]] const ctran::utils::Exception& e) {
+    return nullptr;
+  }
 }
 
 CtranIbSingleton::CtranIbSingleton() {
   auto ibvInitResult = ibverbx::ibvInit();
-  FOLLY_EXPECTED_CHECKTHROW_EX_NOCOMM(ibvInitResult);
+  if (!ibvInitResult.hasValue()) {
+    std::string msg =
+        "CTRAN-IB: Failed to initialize ibverbs (libibverbs.so). "
+        "InfiniBand backend is not available. "
+        "Set NCCL_CTRAN_BACKENDS=nvl,socket to use alternative backends.";
+    CLOGF(ERR, msg);
+    throw ctran::utils::Exception(msg, commSystemError);
+  }
   auto maybeDeviceList = ibverbx::IbvDevice::ibvGetDeviceList(
       NCCL_IB_HCA, NCCL_IB_HCA_PREFIX, CTRAN_IB_ANY_PORT, NCCL_IB_DATA_DIRECT);
-  FOLLY_EXPECTED_CHECKTHROW_EX_NOCOMM(maybeDeviceList);
+  if (!maybeDeviceList.hasValue()) {
+    std::string msg =
+        "CTRAN-IB: Failed to get InfiniBand device list. "
+        "No HCA devices found on this system. "
+        "Set NCCL_CTRAN_BACKENDS=nvl,socket to use alternative backends.";
+    CLOGF(ERR, msg);
+    throw ctran::utils::Exception(msg, commSystemError);
+  }
   ibvDevices = std::move(*maybeDeviceList);
 
   if (ibvDevices.size() < NCCL_CTRAN_IB_DEVICES_PER_RANK) {
-    CLOGF(
-        WARN,
-        "CTRAN-IB : active device found {} is less than requested device count {}",
+    std::string msg = fmt::format(
+        "CTRAN-IB: Found {} InfiniBand device(s) but {} required "
+        "(NCCL_CTRAN_IB_DEVICES_PER_RANK). "
+        "Set NCCL_CTRAN_BACKENDS=nvl,socket to use alternative backends.",
         ibvDevices.size(),
         NCCL_CTRAN_IB_DEVICES_PER_RANK);
-    throw std::bad_alloc();
+    CLOGF(ERR, msg);
+    throw ctran::utils::Exception(msg, commSystemError);
   }
 
   for (auto i = 0; i < this->ibvDevices.size(); i++) {
@@ -98,8 +118,6 @@ CtranIbSingleton::CtranIbSingleton() {
   for (auto& p : this->devBytes_) {
     p = std::make_unique<std::atomic<size_t>>(0);
   }
-
-  return;
 }
 
 commResult_t CtranIbSingleton::destroy() {

--- a/comms/ctran/ibverbx/IbverbxSymbols.cc
+++ b/comms/ctran/ibverbx/IbverbxSymbols.cc
@@ -563,7 +563,7 @@ int buildIbvSymbols(IbvSymbols& symbols, const std::string& ibv_path) {
     cast = (void**)&funcptr;                                 \
     tmp = dlvsym(handle, symbol, version);                   \
     if (tmp == nullptr) {                                    \
-      XLOG(WARN) << fmt::format(                             \
+      XLOG(DBG) << fmt::format(                              \
           "dlvsym failed on {} - {} version {}, set null",   \
           symbol,                                            \
           dlerror(),                                         \

--- a/comms/ctran/ibverbx/IbverbxSymbols.cc
+++ b/comms/ctran/ibverbx/IbverbxSymbols.cc
@@ -563,7 +563,7 @@ int buildIbvSymbols(IbvSymbols& symbols, const std::string& ibv_path) {
     cast = (void**)&funcptr;                                 \
     tmp = dlvsym(handle, symbol, version);                   \
     if (tmp == nullptr) {                                    \
-      XLOG(DBG) << fmt::format(                              \
+      XLOG(WARN) << fmt::format(                             \
           "dlvsym failed on {} - {} version {}, set null",   \
           symbol,                                            \
           dlerror(),                                         \

--- a/comms/ctran/regcache/RegCache.cc
+++ b/comms/ctran/regcache/RegCache.cc
@@ -219,7 +219,13 @@ void ctran::RegCache::init() {
   // exist, so the lifetime dependency is not needed.
   if (globalBackends_[CommBackend::IB]) {
     ibSingleton_ = CtranIbSingleton::getInstance();
-    CHECK_VALID_IB_SINGLETON(ibSingleton_);
+    if (!ibSingleton_) {
+      CLOGF_SUBSYS(
+          WARN,
+          INIT,
+          "CTRAN-REGCACHE: IB backend not available, disabling.");
+      globalBackends_[CommBackend::IB] = false;
+    }
   }
 
   if (NCCL_CTRAN_REGISTER == NCCL_CTRAN_REGISTER::async &&

--- a/comms/ctran/regcache/RegCache.cc
+++ b/comms/ctran/regcache/RegCache.cc
@@ -218,12 +218,14 @@ void ctran::RegCache::init() {
   // CtranIb::deregMem(). When IB is not configured, no IB registrations will
   // exist, so the lifetime dependency is not needed.
   if (globalBackends_[CommBackend::IB]) {
-    ibSingleton_ = CtranIbSingleton::getInstance();
-    if (!ibSingleton_) {
+    try {
+      ibSingleton_ = CtranIbSingleton::getInstance();
+    } catch (const ctran::utils::Exception& e) {
       CLOGF_SUBSYS(
           WARN,
           INIT,
-          "CTRAN-REGCACHE: IB backend not available, disabling.");
+          "CTRAN-REGCACHE: IB backend not available, disabling. {}",
+          e.what());
       globalBackends_[CommBackend::IB] = false;
     }
   }


### PR DESCRIPTION
My system has `libibverbs.so` installed but no actual `IB HCAs`. This caused `CtranIbSingleton` to throw `std::bad_alloc` and crash the process instead of falling back to NVLink/socket as per the documented behavior.

Made changes so the issue is clearly stated in a readable error message.


Before: process crashes with `SIGABRT` and opaque `commInternalError`

After:
```

E0331 CtranIb.cc:101] CTRAN-IB: Found 0 InfiniBand device(s) but 1 required (NCCL_CTRAN_IB_DEVICES_PER_RANK). Set NCCL_CTRAN_BACKENDS=nvl,socket to use alternative backends.
W0331 RegCache.cc:223] CTRAN-REGCACHE: IB backend not available, disabling.
[Rank 0/2] After AllReduce: 3.0 (expected 3.0) [PASS]
[Rank 1/2] After AllReduce: 3.0 (expected 3.0) [PASS]
```

`torchrun --nproc_per_node=2 repro.py`
_**repro.py**_
```
import os
import torch
from torchcomms import new_comm, ReduceOp

def main():
    device = torch.device("cuda")
    torchcomm = new_comm("ncclx", device, name="repro_comm")
    
    rank = torchcomm.get_rank()
    world_size = torchcomm.get_size()
    device_id = rank % torch.cuda.device_count()
    target_device = torch.device(f"cuda:{device_id}")
    
    tensor = torch.full((1024,), float(rank + 1), dtype=torch.float32, device=target_device)
    print(f"[Rank {rank}/{world_size}] Before AllReduce: {tensor[0].item()}")
    
    torchcomm.all_reduce(tensor, ReduceOp.SUM, async_op=False)
    torch.cuda.current_stream().synchronize()
    
    expected = world_size * (world_size + 1) / 2.0
    actual = tensor[0].item()
    status = "PASS" if actual == expected else "FAIL"
    print(f"[Rank {rank}/{world_size}] After AllReduce: {actual} (expected {expected}) [{status}]")
    
    torchcomm.finalize()
    
if __name__ == "__main__":
    main()
```