### PR TITLE
Fix segfault in PinnedHostPool::allocChunk() from uninitialized GpeKernelSync::nworkers

### DIFF
--- a/comms/ctran/gpe/tests/GpeKernelSyncPoolUT.cc
+++ b/comms/ctran/gpe/tests/GpeKernelSyncPoolUT.cc
@@ -77,6 +77,54 @@ TEST_F(GpeKernelSyncPoolTest, ReclaimTest) {
   EXPECT_EQ(pool->capacity(), poolSize);
 }
 
+// Regression test for PinnedHostPool::allocChunk() calling reset() on raw
+// cudaHostAlloc memory without running the C++ constructor. reset() calls
+// resetStatus() which loops `for (i = 0; i < nworkers; i++)` — if nworkers
+// is non-zero garbage, this writes past postFlag[CTRAN_ALGO_MAX_THREAD_BLOCKS]
+// and causes SIGSEGV. The fix (memset in allocChunk) ensures nworkers=0.
+TEST_F(GpeKernelSyncPoolTest, InitNworkersZero) {
+  constexpr int poolSize = 16;
+  auto pool = std::make_unique<GpeKernelSyncPool>(poolSize);
+
+  // All freshly allocated elements must have nworkers=0 so that
+  // resetStatus() is a safe no-op during pool construction.
+  for (int i = 0; i < poolSize; ++i) {
+    auto* g = pool->pop();
+    ASSERT_NE(g, nullptr);
+    EXPECT_EQ(g->nworkers, 0u) << "element " << i;
+  }
+}
+
+// Exercises the recycled-memory scenario that caused the production SIGSEGV:
+// destroy a pool whose elements had non-zero nworkers, then construct a new
+// pool of the same size. CUDA's allocator frequently returns the same pages,
+// so without memset the new pool's allocChunk() would see non-zero nworkers
+// and crash in resetStatus(). With the fix, nworkers is always 0 on init.
+TEST_F(GpeKernelSyncPoolTest, NworkersZeroAfterPoolRecycle) {
+  constexpr int poolSize = 16;
+  constexpr int nworkers = 32; // non-zero value to leave in recycled memory
+
+  // Round 1: allocate pool, set nworkers on all elements, then destroy.
+  {
+    auto pool = std::make_unique<GpeKernelSyncPool>(poolSize);
+    std::vector<ctran::algos::GpeKernelSync*> syncs;
+    ::allocGpeKernelSyncs(pool.get(), poolSize, nworkers, syncs);
+    ASSERT_EQ(static_cast<int>(syncs.size()), poolSize);
+    // pool destructs here, cudaFreeHost called with nworkers=32 in memory
+  }
+
+  // Round 2: new pool of same size — CUDA often returns the same pages.
+  // With the fix, nworkers must be 0 regardless of what pages CUDA returns.
+  auto pool2 = std::make_unique<GpeKernelSyncPool>(poolSize);
+  for (int i = 0; i < poolSize; ++i) {
+    auto* g = pool2->pop();
+    ASSERT_NE(g, nullptr);
+    EXPECT_EQ(g->nworkers, 0u)
+        << "element " << i
+        << ": nworkers must be 0 after pool init (memset), not recycled garbage";
+  }
+}
+
 TEST_F(GpeKernelSyncPoolTest, allocGpeKernelSyncs) {
   constexpr int poolSize = 10;
   constexpr int popSize = 3;

--- a/comms/ctran/utils/PinnedHostPool.h
+++ b/comms/ctran/utils/PinnedHostPool.h
@@ -127,6 +127,12 @@ class PinnedHostPool {
     void* mem = nullptr;
     FB_CUDACHECKTHROW_EX_NOCOMM(
         cudaHostAlloc(&mem, chunkSize_ * sizeof(T), cudaHostAllocDefault));
+    // Zero-initialize before reset(): cudaHostAlloc does not guarantee zeroed
+    // memory when recycling pages from its internal pool. reset() calls
+    // resetStatus() which loops `nworkers` times — if nworkers is non-zero
+    // garbage (e.g. from recycled pages of a differently-typed pool), writes
+    // go past the postFlag[CTRAN_ALGO_MAX_THREAD_BLOCKS] array bounds.
+    memset(mem, 0, chunkSize_ * sizeof(T));
     chunks_.push_back(mem);
 
     for (size_t i = 0; i < chunkSize_; ++i) {


### PR DESCRIPTION
Summary:
Zero-initialize pinned host memory in PinnedHostPool::allocChunk() before
calling reset() on pool elements.

PinnedHostPool::allocChunk() uses reinterpret_cast to place elements into
raw cudaHostAlloc memory, bypassing the C++ constructor. GpeKernelSync's
default member initializer (nworkers{0}) therefore never runs. reset() then
calls resetStatus() which loops `for (i = 0; i < nworkers; i++)` on
uninitialized memory. cudaHostAlloc does not guarantee zeroed memory when
recycling pages from its internal pool — on fresh OS pages (first allocation)
the kernel always zeros them, but on reuse the bytes at offset 0 of each
528-byte slot can contain arbitrary data from a previous, differently-typed
pool (kernelElemPool or kernelFlagPool have different element sizes). If
nworkers is large enough to write past postFlag[64] or beyond the end of the
540KB allocation, this causes SIGSEGV.


cuda_graph_v9_tpp_600_TIER1_90M_PAFT-f9nnh6x7

Observed in PAFT CUDA graph jobs: training survives the first several
reconfigures (which get fresh or same-typed recycled pages) but crashes on a
later reconfigure when CUDA's allocator returns memory from a different pool.
The faulthandler stack trace confirms the crash site:

  GpeKernelSync::resetStatus()
  GpeKernelSync::reset()
  PinnedHostPool<GpeKernelSync>::allocChunk()
  PinnedHostPool<GpeKernelSync>::PinnedHostPool(unsigned long)
  CtranGpe::Impl::Impl()
  ...
  McclComm::reconfigure()
  torch::autograd::PyNode::apply()   <- paft_hook from autograd thread
  torch::autograd::Engine::thread_main()

The fix adds memset(mem, 0, chunkSize_ * sizeof(T)) immediately after
cudaHostAlloc succeeds, ensuring nworkers=0 for all elements before reset()
is called. This is equivalent to what the C++ default member initializer
would have done had the constructor been invoked.

Reviewed By: dolpm

Differential Revision: D98924255


