### PR TITLE
Add CMake build files for common, adapter, tests, and C++ version script (#1353)

### DIFF
--- a/comms/common/CMakeLists.txt
+++ b/comms/common/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+find_package(CUDA REQUIRED)
+
+file(GLOB COMMON_ROOT_SOURCES "*.cc" "*.cu")
+file(GLOB_RECURSE COMMON_ALGO_SOURCES "algorithms/*.cu" "algorithms/*.cc")
+list(FILTER COMMON_ALGO_SOURCES EXCLUDE REGEX ".*/tests/.*")
+list(FILTER COMMON_ALGO_SOURCES EXCLUDE REGEX ".*/fb/.*")
+
+add_library(common OBJECT
+    ${COMMON_ROOT_SOURCES}
+    ${COMMON_ALGO_SOURCES}
+)
+
+target_compile_features(common PRIVATE cxx_std_20)
+target_compile_options(common PRIVATE -fPIC)
+target_compile_options(common PRIVATE
+    $<$<COMPILE_LANGUAGE:CUDA>:--expt-extended-lambda>
+)
+set_target_properties(common PROPERTIES
+    CUDA_SEPARABLE_COMPILATION ON
+    CUDA_RESOLVE_DEVICE_SYMBOLS ON
+    POSITION_INDEPENDENT_CODE ON
+)
+target_include_directories(common PRIVATE
+    ${ROOT}
+    ${CONDA_INCLUDE}
+    ${CUDA_INCLUDE_DIRS}
+)


### PR DESCRIPTION
Summary:

**TL;DR:** Add new CMake build files required by the MCCL OSS build: an OBJECT library for `comms/common/`, an OBJECT library for the MCCL NCCL adapter, a test CMakeLists for MCCL unit tests, and a C++ linker version script.

 ---

**Why?** MCCL is being open-sourced in the torchcomms GitHub repo. These new files are consumed by the top-level `fb/mccl/CMakeLists.txt` via `add_subdirectory()`.

**New files:**

1. `comms/common/CMakeLists.txt`: Builds the algorithms library (AllReduce, AllGather, ReduceScatter, AllToAll) and IPC utilities as a CUDA OBJECT library. Excludes `tests/` and `fb/` subdirectories.

2. `comms/mccl/adapter/CMakeLists.txt`: Builds the NCCL adapter (mccl_adapter only, not pnccl) as an OBJECT library. Defines `MCCL_OSS_BUILD` to activate the compile guards from the previous diff.

3. `comms/mccl/tests/CMakeLists.txt`: Builds `McclWorkUT`, `McclCommUT`, and `McclRmaUT` using googletest (fetched via `FetchContent`). All tests require a GPU. Test utility libraries (`CudaTestUtil`, `CudaStream`, `GpuBuffer`) are built as static libraries.

4. `comms/mccl/build/version_script_cpp.txt`: Linker version script for the optional C++ shared library target (`libmccl.so`). Exports `*mccl*` symbols, hides everything else. Separate from the existing `version_script.txt` which includes `PyInit_*` for the Python extension.

Reviewed By: arttianezhu

Differential Revision: D98142069
