### PR TITLE
Fix MR leak in deregisterBuffer when CUDA memory already freed

### DIFF
--- a/comms/pipes/MultipeerIbgdaTransport.cc
+++ b/comms/pipes/MultipeerIbgdaTransport.cc
@@ -932,7 +932,6 @@ IbgdaLocalBuffer MultipeerIbgdaTransport::registerBuffer(
 
   // Try DMABUF registration first, fall back to regular reg_mr.
   // export_gpu_dmabuf_aligned handles page alignment + doca_gpu_dmabuf_fd.
-  // allocBase/allocSize already come from cuMemGetAddressRange above.
   ibv_mr* mr = nullptr;
   auto dmabuf = export_gpu_dmabuf_aligned(
       docaGpu_, reinterpret_cast<void*>(allocBase), allocSize);
@@ -970,30 +969,27 @@ IbgdaLocalBuffer MultipeerIbgdaTransport::registerBuffer(
 }
 
 void MultipeerIbgdaTransport::deregisterBuffer(void* ptr) {
-  CUdeviceptr allocBase = 0;
-  size_t allocSize = 0;
-  CUresult cuRes =
-      pfn_cuMemGetAddressRange(&allocBase, &allocSize, (CUdeviceptr)ptr);
-  if (cuRes != CUDA_SUCCESS || allocBase == 0) {
-    LOG(WARNING) << "MultipeerIbgdaTransport: cuMemGetAddressRange failed for "
-                 << ptr;
-    return;
+  // Containment lookup on the ordered map: find the allocation whose base
+  // address is <= ptr and whose range covers ptr.  This avoids calling
+  // cuMemGetAddressRange, which fails when CUDA has already freed the
+  // underlying memory (e.g. PyTorch caching allocator teardown).
+  auto addr = reinterpret_cast<uintptr_t>(ptr);
+  auto it = registeredBuffers_.upper_bound(addr);
+  if (it != registeredBuffers_.begin()) {
+    --it;
+    if (addr < it->first + it->second.allocSize) {
+      it->second.refs--;
+      VLOG(1) << "MultipeerIbgdaTransport: deregister ptr=" << ptr
+              << " allocBase=0x" << std::hex << it->first << std::dec
+              << " refs=" << it->second.refs;
+      if (it->second.refs <= 0) {
+        doca_verbs_wrapper_ibv_dereg_mr(it->second.mr);
+        registeredBuffers_.erase(it);
+      }
+      return;
+    }
   }
-
-  auto it = registeredBuffers_.find(static_cast<uintptr_t>(allocBase));
-  if (it == registeredBuffers_.end()) {
-    LOG(WARNING) << "MultipeerIbgdaTransport: buffer not registered: " << ptr;
-    return;
-  }
-
-  it->second.refs--;
-  VLOG(1) << "MultipeerIbgdaTransport: deregister ptr=" << ptr
-          << " allocBase=0x" << std::hex << allocBase << std::dec
-          << " refs=" << it->second.refs;
-  if (it->second.refs <= 0) {
-    doca_verbs_wrapper_ibv_dereg_mr(it->second.mr);
-    registeredBuffers_.erase(it);
-  }
+  LOG(WARNING) << "MultipeerIbgdaTransport: buffer not registered: " << ptr;
 }
 
 std::vector<IbgdaRemoteBuffer> MultipeerIbgdaTransport::exchangeBuffer(

--- a/comms/pipes/MultipeerIbgdaTransport.h
+++ b/comms/pipes/MultipeerIbgdaTransport.h
@@ -411,8 +411,11 @@ class MultipeerIbgdaTransport {
 
   // Maps CUDA allocation base address -> cached MR covering the full
   // allocation. Keyed by allocBase from cuMemGetAddressRange, not by user
-  // pointer.
-  std::unordered_map<uintptr_t, CachedMr> registeredBuffers_;
+  // pointer. Ordered map enables O(log n) containment lookup via
+  // upper_bound — used by deregisterBuffer to find the owning allocation
+  // without calling cuMemGetAddressRange (which fails if CUDA already freed
+  // the memory).
+  std::map<uintptr_t, CachedMr> registeredBuffers_;
 
   // GPU PCIe bus ID and NIC device name
   std::string gpuPciBusId_;


### PR DESCRIPTION
Summary:
deregisterBuffer() called cuMemGetAddressRange to find the allocation
base, which fails after PyTorch's caching allocator frees the GPU
memory. This caused:
1. Warning spam: "cuMemGetAddressRange failed for 0x..."
2. MR leak: ibv_dereg_mr skipped (early return on failure)

Fix: replace cuMemGetAddressRange in deregisterBuffer with a
containment lookup on an ordered map (std::map + upper_bound).
The map is keyed by allocation base address, so we find the owning
allocation via pure address arithmetic — no CUDA driver call needed.

Changes:
- MultipeerIbgdaTransport.h: unordered_map → std::map for
  registeredBuffers_ (enables ordered upper_bound lookup)
- MultipeerIbgdaTransport.cc: deregisterBuffer uses upper_bound
  containment instead of cuMemGetAddressRange

registerBuffer is unchanged — it still uses cuMemGetAddressRange
(which is correct since memory must exist when you register it).

Differential Revision: D98986426


