### PR TITLE
Fix alltoall_base and alltoall dispatch in BackendWrapper

### DIFF
--- a/.github/scripts/xpu_test.sh
+++ b/.github/scripts/xpu_test.sh
@@ -35,7 +35,7 @@ export USE_GLOO=OFF
 export USE_TRANSPORT=OFF
 export USE_SYSTEM_LIBS=1
 
-python3 -m pip install typing-extensions numpy sympy
+python3 -m pip install typing-extensions numpy sympy expecttest
 python3 -m pip install --no-deps --pre torch pytorch-triton-xpu --index-url https://download.pytorch.org/whl/nightly/xpu --force-reinstall --no-cache-dir 
 cd torchcomms && pip install . --no-deps --no-build-isolation && cd ..
 

--- a/comms/torchcomms/BackendWrapper.cpp
+++ b/comms/torchcomms/BackendWrapper.cpp
@@ -39,6 +39,8 @@ ReduceOp toReduceOp(const c10d::ReduceOp& op) {
       return ReduceOp::MIN;
     case c10d::ReduceOp::MAX:
       return ReduceOp::MAX;
+    case c10d::ReduceOp::PRODUCT:
+      return ReduceOp::PRODUCT;
     case c10d::ReduceOp::BAND:
       return ReduceOp::BAND;
     case c10d::ReduceOp::BOR:

--- a/comms/torchcomms/BackendWrapper.cpp
+++ b/comms/torchcomms/BackendWrapper.cpp
@@ -466,35 +466,40 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::alltoall_base(
     std::vector<int64_t>& outputSplitSizes,
     std::vector<int64_t>& inputSplitSizes,
     const c10d::AllToAllOptions& opts) {
-  AllToAllvSingleOptions bopts;
-  if (opts.timeout != kUnsetTimeout) {
-    bopts.timeout = opts.timeout;
+  if (outputSplitSizes.empty() && inputSplitSizes.empty()) {
+    AllToAllSingleOptions bopts;
+    if (opts.timeout != kUnsetTimeout) {
+      bopts.timeout = opts.timeout;
+    } else {
+      bopts.timeout = options_->timeout;
+    }
+    return c10::make_intrusive<WorkWrapper>(
+        backend_->all_to_all_single(
+            outputTensor, inputTensor, opts.asyncOp, bopts),
+        std::vector<at::Tensor>{outputTensor});
   } else {
-    bopts.timeout = options_->timeout;
+    AllToAllvSingleOptions bopts;
+    if (opts.timeout != kUnsetTimeout) {
+      bopts.timeout = opts.timeout;
+    } else {
+      bopts.timeout = options_->timeout;
+    }
+    return c10::make_intrusive<WorkWrapper>(
+        backend_->all_to_all_v_single(
+            outputTensor,
+            inputTensor,
+            toVecUint64(outputSplitSizes),
+            toVecUint64(inputSplitSizes),
+            opts.asyncOp,
+            bopts),
+        std::vector<at::Tensor>{outputTensor});
   }
-  return c10::make_intrusive<WorkWrapper>(
-      backend_->all_to_all_v_single(
-          outputTensor,
-          inputTensor,
-          toVecUint64(outputSplitSizes),
-          toVecUint64(inputSplitSizes),
-          opts.asyncOp,
-          bopts),
-      std::vector<at::Tensor>{outputTensor});
 }
 
 c10::intrusive_ptr<c10d::Work> BackendWrapper::alltoall(
     std::vector<at::Tensor>& outputTensors,
     std::vector<at::Tensor>& inputTensors,
     const c10d::AllToAllOptions& opts) {
-  TORCH_CHECK(
-      outputTensors.size() == 1,
-      "Only single output tensor supported, but got ",
-      outputTensors.size());
-  TORCH_CHECK(
-      inputTensors.size() == 1,
-      "Only single input tensor supported, but got ",
-      inputTensors.size());
   AllToAllOptions bopts;
   if (opts.timeout != kUnsetTimeout) {
     bopts.timeout = opts.timeout;

--- a/comms/torchcomms/scripts/run_tests_integration_xccl_py.sh
+++ b/comms/torchcomms/scripts/run_tests_integration_xccl_py.sh
@@ -40,6 +40,7 @@ run_tests () {
         ScatterTest.py
         SplitTest.py
         TPCommTest.py
+        C10dTorchCommTest.py
     )
 
     for test_file in "${tests[@]}"; do

--- a/comms/torchcomms/scripts/run_tests_integration_xccl_py.sh
+++ b/comms/torchcomms/scripts/run_tests_integration_xccl_py.sh
@@ -23,6 +23,7 @@ run_tests () {
         BarrierTest.py
         BatchSendRecvTest.py
         BroadcastTest.py
+        C10dTorchCommTest.py
         DDPCommTest.py
         DeviceMeshTest.py
         DPTPCommTest.py
@@ -40,7 +41,6 @@ run_tests () {
         ScatterTest.py
         SplitTest.py
         TPCommTest.py
-        C10dTorchCommTest.py
     )
 
     for test_file in "${tests[@]}"; do

--- a/comms/torchcomms/tests/helpers/py/test_helpers.py
+++ b/comms/torchcomms/tests/helpers/py/test_helpers.py
@@ -1,9 +1,15 @@
 #!/usr/bin/env python3
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
+import os
 import unittest
 
 from torchcomms.functional import is_torch_compile_supported_and_enabled
+
+# pyre-fixme[5]: Global annotation for skip decorator.
+skip_if_ncclx = unittest.skipIf(
+    os.getenv("TEST_BACKEND") == "ncclx", "Skipping tests for NCCLX backend."
+)
 
 
 def skip_if_torch_compile_not_supported_or_enabled(

--- a/comms/torchcomms/tests/integration/py/C10dTorchCommTest.py
+++ b/comms/torchcomms/tests/integration/py/C10dTorchCommTest.py
@@ -1,0 +1,178 @@
+import os
+import unittest
+
+import torch
+import torch.distributed as dist
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    subtest,
+)
+from torchcomms.tests.integration.py.TorchCommTestHelpers import (
+    get_device,
+    get_rank_and_size,
+)
+
+
+class TestC10dTorchCommsBasic(unittest.TestCase):
+    REDUCE_OPS = [
+        subtest(dist.ReduceOp.SUM, name="SUM"),
+        subtest(dist.ReduceOp.AVG, name="AVG"),
+        subtest(dist.ReduceOp.MIN, name="MIN"),
+        subtest(dist.ReduceOp.MAX, name="MAX"),
+    ]
+
+    @classmethod
+    def setUpClass(cls):
+        dist.config.use_torchcomms = True
+        rank, world_size = get_rank_and_size()
+        dist.init_process_group(
+            backend=os.environ["TEST_BACKEND"], rank=rank, world_size=world_size
+        )
+        device = get_device(os.environ["TEST_BACKEND"], dist.get_rank())
+        torch.set_default_device(device)
+
+    @classmethod
+    def tearDownClass(cls):
+        dist.destroy_process_group()
+
+    def _expected_reduce_result(self, op):
+        """Return the expected scalar result for a rank+1 input reduced across all ranks."""
+        total = sum(range(1, dist.get_world_size() + 1))
+        if op == dist.ReduceOp.SUM:
+            return total
+        elif op == dist.ReduceOp.AVG:
+            return total / dist.get_world_size()
+        elif op == dist.ReduceOp.MIN:
+            return 1
+        elif op == dist.ReduceOp.MAX:
+            return dist.get_world_size()
+        raise ValueError(f"Unsupported op: {op}")
+
+    @parametrize("op", REDUCE_OPS)
+    def test_allreduce(self, op):
+        tensor = torch.tensor([dist.get_rank() + 1], dtype=torch.float32)
+        dist.all_reduce(tensor, op=op)
+        self.assertEqual(tensor.item(), self._expected_reduce_result(op))
+
+    def test_all_gather(self):
+        input_tensor = torch.tensor([dist.get_rank()], dtype=torch.float32)
+        gather_list = [
+            torch.empty_like(input_tensor) for _ in range(dist.get_world_size())
+        ]
+        dist.all_gather(gather_list, input_tensor)
+        expected = list(range(dist.get_world_size()))
+        self.assertEqual([t.item() for t in gather_list], expected)
+
+    def test_all_gather_into_tensor(self):
+        input_tensor = torch.tensor([dist.get_rank()], dtype=torch.float32)
+        output_tensor = torch.empty(dist.get_world_size(), dtype=torch.float32)
+        dist.all_gather_into_tensor(output_tensor, input_tensor)
+        expected = list(range(dist.get_world_size()))
+        self.assertEqual([t.item() for t in output_tensor], expected)
+
+    def test_broadcast(self):
+        tensor = torch.tensor([dist.get_rank() + 1], dtype=torch.float32)
+        dist.broadcast(tensor, src=0)
+        self.assertEqual(tensor.item(), 1)
+
+    def test_gather(self):
+        tensor = torch.tensor([dist.get_rank()], dtype=torch.float32)
+        gather_list = None
+        if dist.get_rank() == 0:
+            gather_list = [
+                torch.empty_like(tensor) for _ in range(dist.get_world_size())
+            ]
+        dist.gather(tensor, gather_list=gather_list, dst=0)
+        if dist.get_rank() == 0:
+            expected = list(range(dist.get_world_size()))
+            self.assertEqual([t.item() for t in gather_list], expected)
+
+    def test_scatter(self):
+        if dist.get_rank() == 0:
+            scatter_list = [
+                torch.tensor([i], dtype=torch.float32)
+                for i in range(dist.get_world_size())
+            ]
+        else:
+            scatter_list = None
+        tensor = torch.empty(1, dtype=torch.float32)
+        dist.scatter(tensor, scatter_list=scatter_list, src=0)
+        self.assertEqual(tensor.item(), dist.get_rank())
+
+    @parametrize("op", REDUCE_OPS)
+    def test_reduce(self, op):
+        input_tensor = torch.tensor([dist.get_rank() + 1], dtype=torch.float32)
+        dist.reduce(input_tensor, dst=0, op=op)
+        if dist.get_rank() == 0:
+            self.assertEqual(input_tensor.item(), self._expected_reduce_result(op))
+
+    @parametrize("op", REDUCE_OPS)
+    def test_reduce_scatter(self, op):
+        input_tensor = [
+            torch.tensor([dist.get_rank() + 1], dtype=torch.float32)
+            for _ in range(dist.get_world_size())
+        ]
+        output_tensor = torch.empty(1, dtype=torch.float32)
+        dist.reduce_scatter(output_tensor, input_tensor, op=op)
+        self.assertEqual(output_tensor.item(), self._expected_reduce_result(op))
+
+    @parametrize("op", REDUCE_OPS)
+    def test_reduce_scatter_tensor(self, op):
+        input_tensor = torch.full(
+            (dist.get_world_size(),), dist.get_rank() + 1, dtype=torch.float32
+        )
+        output_tensor = torch.empty(1, dtype=torch.float32)
+        dist.reduce_scatter_tensor(output_tensor, input_tensor, op=op)
+        self.assertEqual(output_tensor.item(), self._expected_reduce_result(op))
+
+    def test_all_to_all(self):
+        input_tensor = [
+            torch.tensor([dist.get_rank() + 1], dtype=torch.float32)
+            for _ in range(dist.get_world_size())
+        ]
+        output_tensor = [
+            torch.empty(1, dtype=torch.float32) for _ in range(dist.get_world_size())
+        ]
+        dist.all_to_all(output_tensor, input_tensor)
+        expected = list(range(1, dist.get_world_size() + 1))
+        self.assertEqual([t.item() for t in output_tensor], expected)
+
+    def test_all_to_all_single(self):
+        input_tensor = torch.full(
+            (dist.get_world_size(),), dist.get_rank() + 1, dtype=torch.float32
+        )
+        output_tensor = torch.empty([dist.get_world_size()], dtype=torch.float32)
+        dist.all_to_all_single(output_tensor, input_tensor)
+        expected = list(range(1, dist.get_world_size() + 1))
+        self.assertEqual([t.item() for t in output_tensor], expected)
+
+    def test_send_recv(self):
+        send_rank = (dist.get_rank() + 1) % dist.get_world_size()
+        recv_rank = (
+            dist.get_rank() + dist.get_world_size() - 1
+        ) % dist.get_world_size()
+        send_tensor = torch.tensor([dist.get_rank()], dtype=torch.float32)
+        recv_tensor = torch.empty(1, dtype=torch.float32)
+        if dist.get_rank() % 2 == 0:
+            # Even ranks: send first, then receive
+            dist.send(send_tensor, dst=send_rank)
+            dist.recv(recv_tensor, src=recv_rank)
+        else:
+            # Odd ranks: receive first, then send
+            dist.recv(recv_tensor, src=recv_rank)
+            dist.send(send_tensor, dst=send_rank)
+        # Each rank receives the rank number of the sender
+        self.assertEqual(recv_tensor.item(), recv_rank)
+
+    def test_barrier(self):
+        dist.barrier()
+        # If we reach this point, the barrier succeeded without deadlock
+        self.assertTrue(True)
+
+
+instantiate_parametrized_tests(TestC10dTorchCommsBasic)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/comms/torchcomms/tests/integration/py/C10dTorchCommTest.py
+++ b/comms/torchcomms/tests/integration/py/C10dTorchCommTest.py
@@ -9,12 +9,14 @@ from torch.testing._internal.common_utils import (
     parametrize,
     subtest,
 )
+from torchcomms.tests.helpers.py.test_helpers import skip_if_ncclx
 from torchcomms.tests.integration.py.TorchCommTestHelpers import (
     get_device,
     get_rank_and_size,
 )
 
 
+@skip_if_ncclx
 class TestC10dTorchCommsBasic(unittest.TestCase):
     REDUCE_OPS = [
         subtest(dist.ReduceOp.SUM, name="SUM"),

--- a/comms/torchcomms/tests/integration/py/C10dTorchCommTest.py
+++ b/comms/torchcomms/tests/integration/py/C10dTorchCommTest.py
@@ -23,6 +23,7 @@ class TestC10dTorchCommsBasic(unittest.TestCase):
         subtest(dist.ReduceOp.AVG, name="AVG"),
         subtest(dist.ReduceOp.MIN, name="MIN"),
         subtest(dist.ReduceOp.MAX, name="MAX"),
+        subtest(dist.ReduceOp.PRODUCT, name="PRODUCT"),
     ]
 
     @classmethod
@@ -50,6 +51,11 @@ class TestC10dTorchCommsBasic(unittest.TestCase):
             return 1
         elif op == dist.ReduceOp.MAX:
             return dist.get_world_size()
+        elif op == dist.ReduceOp.PRODUCT:
+            product = 1
+            for i in range(1, dist.get_world_size() + 1):
+                product *= i
+            return product
         raise ValueError(f"Unsupported op: {op}")
 
     @parametrize("op", REDUCE_OPS)

--- a/comms/torchcomms/tests/integration/py/C10dTorchCommTest.py
+++ b/comms/torchcomms/tests/integration/py/C10dTorchCommTest.py
@@ -149,6 +149,42 @@ class TestC10dTorchCommsBasic(unittest.TestCase):
         expected = list(range(1, dist.get_world_size() + 1))
         self.assertEqual([t.item() for t in output_tensor], expected)
 
+    def test_all_to_all_single_with_split_sizes(self):
+        rank = dist.get_rank()
+        world_size = dist.get_world_size()
+
+        # Each rank sends (rank + 1) elements to every other rank,
+        # so rank r's input_split_sizes are all (rank + 1).
+        input_split_sizes = [rank + 1] * world_size
+        # Rank r receives (sender_rank + 1) elements from each sender,
+        # so output_split_sizes[i] = i + 1.
+        output_split_sizes = [i + 1 for i in range(world_size)]
+
+        input_tensor = torch.empty(sum(input_split_sizes), dtype=torch.float32)
+        offset = 0
+        for dst in range(world_size):
+            input_tensor[offset : offset + input_split_sizes[dst]].fill_(rank + dst)
+            offset += input_split_sizes[dst]
+
+        output_tensor = torch.empty(sum(output_split_sizes), dtype=torch.float32)
+        dist.all_to_all_single(
+            output_tensor,
+            input_tensor,
+            output_split_sizes=output_split_sizes,
+            input_split_sizes=input_split_sizes,
+        )
+
+        # Verify: section from sender i should contain value (i + rank)
+        offset = 0
+        for src in range(world_size):
+            section = output_tensor[offset : offset + output_split_sizes[src]]
+            expected = torch.full_like(section, src + rank)
+            self.assertTrue(
+                torch.equal(section, expected),
+                f"Mismatch in section from rank {src}: got {section}, expected {expected}",
+            )
+            offset += output_split_sizes[src]
+
     def test_send_recv(self):
         send_rank = (dist.get_rank() + 1) % dist.get_world_size()
         recv_rank = (

--- a/comms/torchcomms/tests/integration/py/C10dTorchCommTest.py
+++ b/comms/torchcomms/tests/integration/py/C10dTorchCommTest.py
@@ -40,6 +40,13 @@ class TestC10dTorchCommsBasic(unittest.TestCase):
     def tearDownClass(cls):
         dist.destroy_process_group()
 
+    def _rank_value(self):
+        return dist.get_rank() + 1
+
+    def _skip_if_product_overflows(self, op):
+        if op == dist.ReduceOp.PRODUCT and dist.get_world_size() > 34:
+            self.skipTest("PRODUCT reduction overflows float32 for world_size > 34")
+
     def _expected_reduce_result(self, op):
         """Return the expected scalar result for a rank+1 input reduced across all ranks."""
         total = sum(range(1, dist.get_world_size() + 1))
@@ -60,28 +67,29 @@ class TestC10dTorchCommsBasic(unittest.TestCase):
 
     @parametrize("op", REDUCE_OPS)
     def test_allreduce(self, op):
-        tensor = torch.tensor([dist.get_rank() + 1], dtype=torch.float32)
+        self._skip_if_product_overflows(op)
+        tensor = torch.tensor([self._rank_value()], dtype=torch.float32)
         dist.all_reduce(tensor, op=op)
         self.assertEqual(tensor.item(), self._expected_reduce_result(op))
 
     def test_all_gather(self):
-        input_tensor = torch.tensor([dist.get_rank()], dtype=torch.float32)
+        input_tensor = torch.tensor([self._rank_value()], dtype=torch.float32)
         gather_list = [
             torch.empty_like(input_tensor) for _ in range(dist.get_world_size())
         ]
         dist.all_gather(gather_list, input_tensor)
-        expected = list(range(dist.get_world_size()))
+        expected = list(range(1, dist.get_world_size() + 1))
         self.assertEqual([t.item() for t in gather_list], expected)
 
     def test_all_gather_into_tensor(self):
-        input_tensor = torch.tensor([dist.get_rank()], dtype=torch.float32)
+        input_tensor = torch.tensor([self._rank_value()], dtype=torch.float32)
         output_tensor = torch.empty(dist.get_world_size(), dtype=torch.float32)
         dist.all_gather_into_tensor(output_tensor, input_tensor)
-        expected = list(range(dist.get_world_size()))
+        expected = list(range(1, dist.get_world_size() + 1))
         self.assertEqual([t.item() for t in output_tensor], expected)
 
     def test_broadcast(self):
-        tensor = torch.tensor([dist.get_rank() + 1], dtype=torch.float32)
+        tensor = torch.tensor([self._rank_value()], dtype=torch.float32)
         dist.broadcast(tensor, src=0)
         self.assertEqual(tensor.item(), 1)
 
@@ -112,15 +120,17 @@ class TestC10dTorchCommsBasic(unittest.TestCase):
 
     @parametrize("op", REDUCE_OPS)
     def test_reduce(self, op):
-        input_tensor = torch.tensor([dist.get_rank() + 1], dtype=torch.float32)
+        self._skip_if_product_overflows(op)
+        input_tensor = torch.tensor([self._rank_value()], dtype=torch.float32)
         dist.reduce(input_tensor, dst=0, op=op)
         if dist.get_rank() == 0:
             self.assertEqual(input_tensor.item(), self._expected_reduce_result(op))
 
     @parametrize("op", REDUCE_OPS)
     def test_reduce_scatter(self, op):
+        self._skip_if_product_overflows(op)
         input_tensor = [
-            torch.tensor([dist.get_rank() + 1], dtype=torch.float32)
+            torch.tensor([self._rank_value()], dtype=torch.float32)
             for _ in range(dist.get_world_size())
         ]
         output_tensor = torch.empty(1, dtype=torch.float32)
@@ -129,8 +139,9 @@ class TestC10dTorchCommsBasic(unittest.TestCase):
 
     @parametrize("op", REDUCE_OPS)
     def test_reduce_scatter_tensor(self, op):
+        self._skip_if_product_overflows(op)
         input_tensor = torch.full(
-            (dist.get_world_size(),), dist.get_rank() + 1, dtype=torch.float32
+            (dist.get_world_size(),), self._rank_value(), dtype=torch.float32
         )
         output_tensor = torch.empty(1, dtype=torch.float32)
         dist.reduce_scatter_tensor(output_tensor, input_tensor, op=op)
@@ -138,7 +149,7 @@ class TestC10dTorchCommsBasic(unittest.TestCase):
 
     def test_all_to_all(self):
         input_tensor = [
-            torch.tensor([dist.get_rank() + 1], dtype=torch.float32)
+            torch.tensor([self._rank_value()], dtype=torch.float32)
             for _ in range(dist.get_world_size())
         ]
         output_tensor = [
@@ -150,7 +161,7 @@ class TestC10dTorchCommsBasic(unittest.TestCase):
 
     def test_all_to_all_single(self):
         input_tensor = torch.full(
-            (dist.get_world_size(),), dist.get_rank() + 1, dtype=torch.float32
+            (dist.get_world_size(),), self._rank_value(), dtype=torch.float32
         )
         output_tensor = torch.empty([dist.get_world_size()], dtype=torch.float32)
         dist.all_to_all_single(output_tensor, input_tensor)

--- a/comms/torchcomms/tests/integration/py/C10dTorchCommTest.py
+++ b/comms/torchcomms/tests/integration/py/C10dTorchCommTest.py
@@ -77,17 +77,18 @@ class TestC10dTorchCommsBasic(unittest.TestCase):
         dist.broadcast(tensor, src=0)
         self.assertEqual(tensor.item(), 1)
 
-    def test_gather(self):
-        tensor = torch.tensor([dist.get_rank()], dtype=torch.float32)
-        gather_list = None
-        if dist.get_rank() == 0:
-            gather_list = [
-                torch.empty_like(tensor) for _ in range(dist.get_world_size())
-            ]
-        dist.gather(tensor, gather_list=gather_list, dst=0)
-        if dist.get_rank() == 0:
-            expected = list(range(dist.get_world_size()))
-            self.assertEqual([t.item() for t in gather_list], expected)
+    # TODO:Enable when PR https://github.com/pytorch/pytorch/pull/178533 is merged
+    # def test_gather(self):
+    #    tensor = torch.tensor([dist.get_rank()], dtype=torch.float32)
+    #    gather_list = None
+    #    if dist.get_rank() == 0:
+    #        gather_list = [
+    #            torch.empty_like(tensor) for _ in range(dist.get_world_size())
+    #        ]
+    #    dist.gather(tensor, gather_list=gather_list, dst=0)
+    #    if dist.get_rank() == 0:
+    #        expected = list(range(dist.get_world_size()))
+    #        self.assertEqual([t.item() for t in gather_list], expected)
 
     def test_scatter(self):
         if dist.get_rank() == 0:

--- a/comms/torchcomms/tests/integration/py/TorchCommTestHelpers.py
+++ b/comms/torchcomms/tests/integration/py/TorchCommTestHelpers.py
@@ -273,25 +273,29 @@ def verify_tensor_equality(
                 )
 
 
+def get_device(backend, rank) -> torch.device:
+    if device_str := os.environ.get("TEST_DEVICE"):
+        return torch.device(device_str)
+
+    if torch.accelerator.is_available():
+        device_count = torch.accelerator.device_count()
+        if device_count > 0:
+            device_id = rank % device_count
+            accelerator = torch.accelerator.current_accelerator()
+            assert accelerator is not None
+            device_type = accelerator.type
+            return torch.device(f"{device_type}:{device_id}")
+    # Fallback to CPU if an accelerator is not found or device_count is 0
+    return torch.device("cpu")
+
+
 class TorchCommTestWrapper:
     """Wrapper class for TorchComm tests, similar to the C++ TorchCommTestWrapper."""
 
     NEXT_COMM_ID = 0
 
     def get_device(self, backend, rank) -> torch.device:
-        if device_str := os.environ.get("TEST_DEVICE"):
-            return torch.device(device_str)
-
-        if torch.accelerator.is_available():
-            device_count = torch.accelerator.device_count()
-            if device_count > 0:
-                device_id = rank % device_count
-                accelerator = torch.accelerator.current_accelerator()
-                assert accelerator is not None
-                device_type = accelerator.type
-                return torch.device(f"{device_type}:{device_id}")
-        # Fallback to CPU if an accelerator is not found or device_count is 0
-        return torch.device("cpu")
+        return get_device(backend, rank)
 
     def get_hints_from_env(self):
         hints = {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 torch
 pyyaml
 packaging
+expecttest


### PR DESCRIPTION
`alltoall_base`: dispatch to `all_to_all_single` when split sizes are empty and otherwise to `all_to_all_v_single`.

`alltoall`: remove incorrect `TORCH_CHECK` guards that required exactly one input/output tensor, allowing the standard multi-tensor list interface to work correctly.