### PR TITLE
Fix iterated tests for single-node and multi-binary MAST runs

### DIFF
--- a/comms/torchcomms/tests/integration/cpp/PipesDeviceApiIteratedTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/PipesDeviceApiIteratedTest.cpp
@@ -42,16 +42,6 @@ void PipesDeviceApiIteratedTest::SetUp() {
 }
 
 void PipesDeviceApiIteratedTest::TearDown() {
-  // Barrier + GPU sync before destroy to prevent cross-rank desynchronization.
-  // Without this, fast ranks can start creating the next communicator (which
-  // requires collective bootstrap) while slow ranks are still destroying DOCA
-  // IBGDA resources (QP teardown, cudaFree implicit sync, ibv_close_device).
-  // On GB200 multi-node, this desync causes the next comm's exchangeUniqueId()
-  // to hang because ranks never rendezvous on the same bootstrap operation.
-  if (torchcomm_) {
-    torchcomm_->barrier(false);
-    cudaDeviceSynchronize();
-  }
   torchcomm_.reset();
   wrapper_.reset();
 }

--- a/comms/torchcomms/tests/integration/cpp/PipesTransportIteratedTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/PipesTransportIteratedTest.cpp
@@ -65,8 +65,12 @@ void PipesTransportIteratedTest::SetUp() {
     GTEST_SKIP() << "No NVL peers available — transport tests require NVLink";
   }
 
-  // Ring pattern: peer is the other rank
-  peer_ = (rank_ == 0) ? 1 : 0;
+  // Pair adjacent ranks: 0↔1, 2↔3, 4↔5, ...
+  // Odd-numbered total ranks: last rank has no partner → skip.
+  if (num_ranks_ % 2 != 0 && rank_ == num_ranks_ - 1) {
+    GTEST_SKIP() << "Odd rank count — last rank has no partner";
+  }
+  peer_ = (rank_ % 2 == 0) ? rank_ + 1 : rank_ - 1;
 }
 
 void PipesTransportIteratedTest::TearDown() {

--- a/comms/torchcomms/tests/integration/cpp/PipesTransportIteratedTestKernels.cu
+++ b/comms/torchcomms/tests/integration/cpp/PipesTransportIteratedTestKernels.cu
@@ -52,7 +52,7 @@ __global__ void transportIteratedSendRecvKernel(
   size_t nbytes = count * sizeof(float);
 
   for (int iter = 0; iter < iterations; iter++) {
-    if (rank == 0) {
+    if (rank % 2 == 0) {
       // Fill src with identifiable pattern
       fillPattern(buf, count, rank, iter);
       group.sync();
@@ -70,7 +70,7 @@ __global__ void transportIteratedSendRecvKernel(
       group.sync();
       nvl.recv(group, buf, nbytes);
       // Verify received data matches sender's pattern
-      verifyPattern(buf, count, 0 /* sender rank */, iter, &results[iter]);
+      verifyPattern(buf, count, peer, iter, &results[iter]);
     }
     group.sync();
 
@@ -154,7 +154,7 @@ __global__ void transportIteratedCombinedKernel(
         group, 0, CmpOp::CMP_GE, static_cast<uint64_t>(2 * iter + 1));
 
     // Phase 2: Send/recv
-    if (rank == 0) {
+    if (rank % 2 == 0) {
       fillPattern(buf, count, rank, iter);
       group.sync();
       nvl.send(group, buf, nbytes);
@@ -173,8 +173,8 @@ __global__ void transportIteratedCombinedKernel(
         group, 0, CmpOp::CMP_GE, static_cast<uint64_t>(2 * iter + 2));
 
     // Phase 4: Verify on receiver
-    if (rank == 1) {
-      verifyPattern(buf, count, 0, iter, &results[iter]);
+    if (rank % 2 == 1) {
+      verifyPattern(buf, count, peer, iter, &results[iter]);
     } else {
       if (group.thread_id_in_group == 0) {
         results[iter] = 1;
@@ -228,7 +228,7 @@ __global__ void transportIteratedLl128Kernel(
   for (int iter = 0; iter < iterations; iter++) {
     char pattern = static_cast<char>((iter + 1) & 0xFF);
 
-    if (rank == 0) {
+    if (rank % 2 == 0) {
       // Fill with byte pattern
       for (size_t i = threadIdx.x; i < nbytes; i += blockDim.x) {
         buf[i] = pattern;


### PR DESCRIPTION
Summary:
Three fixes for torchcomm device API iterated tests running on MAST:

1. **Fix transport kernel deadlock on >2 ranks**: The send/recv, combined,
   and LL128 kernels hardcoded `rank == 0` for the send direction. With 8
   ranks paired as 0-1, 2-3, 4-5, 6-7, only rank 0 sent — ranks 2,4,6
   entered recv mode, deadlocking their pairs. Changed to `rank % 2 == 0`
   and fixed verifyPattern to use the actual sender rank instead of
   hardcoded 0.

2. **Fix transport test peer pairing for >2 ranks**: The host-side peer
   assignment used `peer_ = (rank_ == 0) ? 1 : 0` which only works for
   2 ranks. Changed to adjacent pairing `peer_ = (rank_ % 2 == 0) ? rank_ + 1 : rank_ - 1`
   with skip logic for odd rank counts.

3. **Fix multi-binary stale key collision**: When running ncclx then
   pipes_window sequentially, the torchelastic agent store persists keys
   across binary invocations. Both binaries use identical store key names
   (static counters reset per process), causing the second binary to read
   stale NCCL unique IDs and fail with "Connection refused". Fixed by
   offsetting MASTER_PORT per binary in the launcher.

Also removed unnecessary TearDown barrier from PipesDeviceApiIteratedTest
(each test method already has entry/exit barriers).

Reviewed By: srinathb-meta

Differential Revision: D98987763


