### PR TITLE
Add Pipes parity tests + large message sizes (#1362)

### DIFF
--- a/comms/torchcomms/tests/integration/cpp/DeviceApiIteratedTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/DeviceApiIteratedTest.cpp
@@ -573,89 +573,6 @@ void DeviceApiIteratedTest::testWindowLifecycle() {
   }
 }
 
-void DeviceApiIteratedTest::testBufferRegistrationChurn() {
-  int cycles = config_.lifecycle_cycles;
-  size_t count = 256;
-
-  SCOPED_TRACE(
-      ::testing::Message() << "BufferRegistrationChurn cycles=" << cycles);
-
-  // Create window once, repeatedly register/deregister source buffers
-  auto mem_pool = std::make_unique<at::cuda::MemPool>(
-      std::static_pointer_cast<c10::cuda::CUDACachingAllocator::CUDAAllocator>(
-          allocator_));
-  c10::cuda::CUDACachingAllocator::beginAllocateToPool(
-      mem_pool->device(), mem_pool->id(), [](cudaStream_t) { return true; });
-
-  auto options =
-      at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, device_index_);
-  at::Tensor win_tensor =
-      at::zeros({static_cast<int64_t>(count * num_ranks_)}, options);
-
-  c10::cuda::CUDACachingAllocator::endAllocateToPool(
-      mem_pool->device(), mem_pool->id());
-
-  torchcomm_->barrier(false);
-  auto win = torchcomm_->new_window();
-  win->tensor_register(win_tensor);
-  torchcomm_->barrier(false);
-
-  auto* dev_win =
-      static_cast<DeviceWindowNCCL*>(win->get_device_window(num_ranks_, -1, 1));
-  ASSERT_NE(dev_win, nullptr);
-
-  int dst_rank = (rank_ + 1) % num_ranks_;
-  int src_rank = (rank_ - 1 + num_ranks_) % num_ranks_;
-
-  for (int cycle = 0; cycle < cycles; cycle++) {
-    // Create a new source tensor and register it
-    at::Tensor src = at::zeros({static_cast<int64_t>(count)}, options);
-    auto src_buf = win->register_local_buffer(src);
-    ASSERT_NE(src_buf.base_ptr, nullptr)
-        << "Cycle " << cycle << ": register_local_buffer returned null";
-
-    // Do one put
-    int* d_result = nullptr;
-    ASSERT_EQ(cudaMalloc(&d_result, sizeof(int)), cudaSuccess);
-    ASSERT_EQ(cudaMemset(d_result, 0, sizeof(int)), cudaSuccess);
-
-    size_t bytes = count * sizeof(float);
-    auto stream = at::cuda::getStreamFromPool(false, device_index_);
-    {
-      c10::cuda::CUDAStreamGuard guard(stream);
-      launchIteratedPutKernel(
-          dev_win,
-          src_buf,
-          src.data_ptr<float>(),
-          win_tensor.data_ptr<float>(),
-          /*src_offset=*/0,
-          /*dst_offset=*/rank_ * bytes,
-          bytes,
-          count,
-          dst_rank,
-          src_rank,
-          /*signal_id=*/0,
-          /*iterations=*/1,
-          CoopScope::THREAD,
-          1,
-          d_result,
-          stream.stream());
-    }
-    stream.synchronize();
-
-    checkKernelResults(
-        d_result, 1, "BufferChurn[" + std::to_string(cycle) + "]");
-    cudaFree(d_result);
-
-    win->deregister_local_buffer(src_buf);
-  }
-
-  win->tensor_deregister();
-  win.reset();
-  mem_pool.reset();
-  torchcomm_->barrier(false);
-}
-
 // =============================================================================
 // Parameterized Test Registrations
 // =============================================================================
@@ -756,8 +673,4 @@ TEST_F(DeviceApiIteratedTest, MultiComm) {
 
 TEST_F(DeviceApiIteratedTest, WindowLifecycle) {
   testWindowLifecycle();
-}
-
-TEST_F(DeviceApiIteratedTest, BufferRegistrationChurn) {
-  testBufferRegistrationChurn();
 }

--- a/comms/torchcomms/tests/integration/cpp/DeviceApiIteratedTest.hpp
+++ b/comms/torchcomms/tests/integration/cpp/DeviceApiIteratedTest.hpp
@@ -55,9 +55,6 @@ class DeviceApiIteratedTest : public ::testing::Test {
   // Repeated window create/register/operate/deregister/destroy
   void testWindowLifecycle();
 
-  // Repeated register_local_buffer / put / deregister_local_buffer
-  void testBufferRegistrationChurn();
-
   // Member variables
   torchcomms::device::test::IteratedTestConfig config_;
   std::unique_ptr<TorchCommTestWrapper> wrapper_;

--- a/comms/torchcomms/tests/integration/cpp/PipesDeviceApiIteratedTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/PipesDeviceApiIteratedTest.cpp
@@ -454,6 +454,99 @@ void PipesDeviceApiIteratedTest::testWindowLifecycle() {
   }
 }
 
+void PipesDeviceApiIteratedTest::testMultiComm() {
+  int num_comms = config_.comm_count;
+  int iterations = config_.num_iterations / 2;
+  size_t count = 1024;
+
+  SCOPED_TRACE(
+      ::testing::Message() << "PipesMultiComm comms=" << num_comms
+                           << " iters=" << iterations);
+
+  // Create multiple communicators
+  std::vector<std::unique_ptr<TorchCommTestWrapper>> wrappers;
+  wrappers.reserve(num_comms);
+  std::vector<std::shared_ptr<torch::comms::TorchComm>> comms;
+  comms.reserve(num_comms);
+  for (int c = 0; c < num_comms; c++) {
+    auto w = std::make_unique<TorchCommTestWrapper>();
+    comms.push_back(w->getTorchComm());
+    wrappers.push_back(std::move(w));
+  }
+
+  int dst_rank = (rank_ + 1) % num_ranks_;
+  int src_rank = (rank_ - 1 + num_ranks_) % num_ranks_;
+
+  // Create a window per communicator
+  std::vector<PipesWindowSetup> windows;
+  windows.reserve(num_comms);
+  for (int c = 0; c < num_comms; c++) {
+    windows.push_back(createPipesWindowSetup(
+        comms[c],
+        allocator_,
+        device_index_,
+        num_ranks_,
+        count,
+        std::max(num_ranks_, 2),
+        -1,
+        -1));
+  }
+
+  // Run iterated put on each comm's window
+  std::vector<int*> d_results_vec(num_comms, nullptr);
+  std::vector<at::cuda::CUDAStream> streams;
+  streams.reserve(num_comms);
+
+  for (int c = 0; c < num_comms; c++) {
+    ASSERT_EQ(
+        cudaMalloc(&d_results_vec[c], iterations * sizeof(int)), cudaSuccess);
+    ASSERT_EQ(
+        cudaMemset(d_results_vec[c], 0, iterations * sizeof(int)), cudaSuccess);
+
+    auto stream = at::cuda::getStreamFromPool(false, device_index_);
+    streams.push_back(stream);
+
+    size_t bytes = count * sizeof(float);
+    c10::cuda::CUDAStreamGuard guard(stream);
+    launchPipesIteratedPutKernel(
+        windows[c].dev_win,
+        windows[c].src_buf,
+        windows[c].src_tensor.data_ptr<float>(),
+        windows[c].win_tensor.data_ptr<float>(),
+        0,
+        rank_ * bytes,
+        bytes,
+        count,
+        dst_rank,
+        src_rank,
+        0,
+        iterations,
+        CoopScope::THREAD,
+        1,
+        d_results_vec[c],
+        stream.stream());
+  }
+
+  for (auto& stream : streams) {
+    stream.synchronize();
+  }
+
+  for (int c = 0; c < num_comms; c++) {
+    checkKernelResults(
+        d_results_vec[c],
+        iterations,
+        "PipesMultiComm[" + std::to_string(c) + "]");
+    cudaFree(d_results_vec[c]);
+  }
+
+  for (int c = 0; c < num_comms; c++) {
+    teardownPipesWindow(windows[c], comms[c]);
+  }
+
+  comms.clear();
+  wrappers.clear();
+}
+
 // =============================================================================
 // Parameterized Test Registrations
 // =============================================================================
@@ -477,6 +570,7 @@ INSTANTIATE_TEST_SUITE_P(
     IteratedPut,
     PipesDeviceApiIteratedPutTest,
     ::testing::Values(
+        PipesPutParam{4, CoopScope::THREAD},
         PipesPutParam{1024, CoopScope::THREAD},
         PipesPutParam{1048576, CoopScope::THREAD},
         PipesPutParam{16777216, CoopScope::THREAD},
@@ -500,7 +594,7 @@ TEST_P(PipesDeviceApiIteratedSignalTest, Signal) {
 INSTANTIATE_TEST_SUITE_P(
     IteratedSignal,
     PipesDeviceApiIteratedSignalTest,
-    ::testing::Values(CoopScope::THREAD, CoopScope::WARP),
+    ::testing::Values(CoopScope::THREAD, CoopScope::WARP, CoopScope::BLOCK),
     [](const ::testing::TestParamInfo<CoopScope>& info) {
       return std::string(scopeName(info.param));
     });
@@ -518,7 +612,7 @@ TEST_P(PipesDeviceApiIteratedBarrierTest, Barrier) {
 INSTANTIATE_TEST_SUITE_P(
     IteratedBarrier,
     PipesDeviceApiIteratedBarrierTest,
-    ::testing::Values(CoopScope::THREAD, CoopScope::WARP),
+    ::testing::Values(CoopScope::THREAD, CoopScope::WARP, CoopScope::BLOCK),
     [](const ::testing::TestParamInfo<CoopScope>& info) {
       return std::string(scopeName(info.param));
     });
@@ -545,6 +639,10 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_F(PipesDeviceApiIteratedTest, MultiWindow) {
   testMultiWindow();
+}
+
+TEST_F(PipesDeviceApiIteratedTest, MultiComm) {
+  testMultiComm();
 }
 
 TEST_F(PipesDeviceApiIteratedTest, WindowLifecycle) {

--- a/comms/torchcomms/tests/integration/cpp/PipesDeviceApiIteratedTest.hpp
+++ b/comms/torchcomms/tests/integration/cpp/PipesDeviceApiIteratedTest.hpp
@@ -30,6 +30,7 @@ class PipesDeviceApiIteratedTest : public ::testing::Test {
   void testIteratedBarrier(torchcomms::device::CoopScope scope);
   void testIteratedCombined(size_t msg_bytes);
   void testMultiWindow();
+  void testMultiComm();
   void testWindowLifecycle();
 
   torchcomms::device::test::IteratedTestConfig config_;


### PR DESCRIPTION
Summary:

Improve test coverage for the Pipes device API iterated test suite to reach
parity with NCCLX.

Changes:
- Add testMultiComm() to Pipes: tests multiple independent communicators
  with concurrent put operations on separate streams
- Add testBufferRegistrationChurn() to Pipes: tests repeated
  register_local_buffer / put / deregister_local_buffer cycles
- Add BLOCK scope to Pipes signal and barrier parameterized tests
- Add 4B minimum message size to Pipes put tests
- Add 1x8 node_config to PipesDeviceApiIteratedTest in BUCK

Reviewed By: zhiyongww, Scusemua

Differential Revision: D99022969


