### PR TITLE
Add basic reduceCopy kernel (without SR) (#1363)

### DIFF
--- a/comms/ncclx/meta/collectives/benchmarks/SimpleCopyBench.cu
+++ b/comms/ncclx/meta/collectives/benchmarks/SimpleCopyBench.cu
@@ -1,0 +1,516 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+#include "meta/collectives/kernels/reduce_copy.cuh"
+
+// Wrapper kernel for the vectorized copy __device__ function.
+template <int Unroll, typename T>
+__global__ __launch_bounds__(
+    256,
+    1) void copy_kernel(T* dst, const T* src, ssize_t nElts) {
+  auto thread = threadIdx.x + blockIdx.x * blockDim.x;
+  auto nThreads = blockDim.x * gridDim.x;
+  meta::comms::ncclx::kernels::simplecopy::copy<Unroll, T>(
+      thread, nThreads, (void*)src, (void*)dst, nElts);
+}
+
+// Wrapper kernel for reduceCopy with 2 sources.
+template <int Unroll, typename T>
+__global__ __launch_bounds__(256, 1) void reduce_copy_2src_kernel(
+    T* dst,
+    const T* src0,
+    const T* src1,
+    ssize_t nElts) {
+  auto thread = threadIdx.x + blockIdx.x * blockDim.x;
+  auto nThreads = blockDim.x * gridDim.x;
+  meta::comms::ncclx::kernels::simplecopy::reduceCopy<Unroll, T>(
+      thread, nThreads, (void*)dst, nElts, src0, src1);
+}
+
+// Wrapper kernel for reduceCopy with 3 sources.
+template <int Unroll, typename T>
+__global__ __launch_bounds__(256, 1) void reduce_copy_3src_kernel(
+    T* dst,
+    const T* src0,
+    const T* src1,
+    const T* src2,
+    ssize_t nElts) {
+  auto thread = threadIdx.x + blockIdx.x * blockDim.x;
+  auto nThreads = blockDim.x * gridDim.x;
+  meta::comms::ncclx::kernels::simplecopy::reduceCopy<Unroll, T>(
+      thread, nThreads, (void*)dst, nElts, src0, src1, src2);
+}
+
+// Wrapper kernel for reduceCopy with 1 source (degenerates to plain copy).
+template <int Unroll, typename T>
+__global__ __launch_bounds__(
+    256,
+    1) void reduce_copy_1src_kernel(T* dst, const T* src, ssize_t nElts) {
+  auto thread = threadIdx.x + blockIdx.x * blockDim.x;
+  auto nThreads = blockDim.x * gridDim.x;
+  meta::comms::ncclx::kernels::simplecopy::reduceCopy<Unroll, T>(
+      thread, nThreads, (void*)dst, nElts, src);
+}
+
+// Wrapper kernel for reduceCopyPacks with 2 sources.
+template <int Unroll, int EltPerPack, typename T>
+__global__ __launch_bounds__(256, 1) void reduce_copy_packs_2src_kernel(
+    T* dst,
+    const T* src0,
+    const T* src1,
+    ssize_t nElts) {
+  auto thread = threadIdx.x + blockIdx.x * blockDim.x;
+  auto nThreads = blockDim.x * gridDim.x;
+  ssize_t nEltsBehind = 0;
+  ssize_t nEltsAhead = nElts;
+  meta::comms::ncclx::kernels::simplecopy::
+      reduceCopyPacks<Unroll, EltPerPack, T, 1>(
+          nThreads, thread, nEltsBehind, nEltsAhead, src0, src1, dst);
+
+  if (nEltsBehind < nElts) {
+    __trap();
+  }
+
+  if (nEltsAhead > 0) {
+    __trap();
+  }
+}
+
+#define CUDACHECK(cmd)                                                    \
+  do {                                                                    \
+    cudaError_t e = cmd;                                                  \
+    ASSERT_EQ(e, cudaSuccess) << "CUDA error: " << cudaGetErrorString(e); \
+  } while (0)
+
+// =============================================================================
+// Benchmark Fixture
+// =============================================================================
+
+class SimpleCopyBench : public ::testing::Test {
+ protected:
+  using T = float;
+  static constexpr int64_t kN = 4L * 1024L * 1024L; // 4M elements
+  static constexpr int kBlockSize = 256;
+  static constexpr int kDefaultBlocks = 32;
+  static constexpr int kWarmupIters = 10;
+  static constexpr int kBenchIters = 100;
+
+  T* d_input = nullptr;
+  T* d_output = nullptr;
+  T* d_input2 = nullptr;
+  T* d_input3 = nullptr;
+  cudaEvent_t startEvent, stopEvent;
+
+  void SetUp() override {
+    CUDACHECK(cudaMalloc(&d_input, kN * sizeof(T)));
+    CUDACHECK(cudaMalloc(&d_output, kN * sizeof(T)));
+    CUDACHECK(cudaMalloc(&d_input2, kN * sizeof(T)));
+    CUDACHECK(cudaMalloc(&d_input3, kN * sizeof(T)));
+    CUDACHECK(cudaMemset(d_input, 1, kN * sizeof(T)));
+    CUDACHECK(cudaMemset(d_input2, 2, kN * sizeof(T)));
+    CUDACHECK(cudaMemset(d_input3, 3, kN * sizeof(T)));
+    CUDACHECK(cudaEventCreate(&startEvent));
+    CUDACHECK(cudaEventCreate(&stopEvent));
+  }
+
+  void TearDown() override {
+    CUDACHECK(cudaEventDestroy(startEvent));
+    CUDACHECK(cudaEventDestroy(stopEvent));
+    CUDACHECK(cudaFree(d_input));
+    CUDACHECK(cudaFree(d_output));
+    CUDACHECK(cudaFree(d_input2));
+    CUDACHECK(cudaFree(d_input3));
+  }
+
+  // Generate power-of-2 block count sweep up to maxBlk
+  static std::vector<int> blockCountSweep(int maxBlk) {
+    std::vector<int> counts;
+    for (int b = 1; b <= maxBlk; b *= 2) {
+      counts.push_back(b);
+    }
+    if (counts.empty() || counts.back() != maxBlk) {
+      counts.push_back(maxBlk);
+    }
+    return counts;
+  }
+
+  template <typename LaunchFn>
+  void runBenchCore(
+      int64_t nElts,
+      int nBlocks,
+      LaunchFn launchFn,
+      const char* label,
+      int nMemAccesses = 2) {
+    // Warmup
+    for (int i = 0; i < kWarmupIters; i++) {
+      launchFn(nBlocks, kBlockSize, nElts);
+    }
+    CUDACHECK(cudaDeviceSynchronize());
+
+    // Timed iterations
+    CUDACHECK(cudaEventRecord(startEvent));
+    for (int i = 0; i < kBenchIters; i++) {
+      launchFn(nBlocks, kBlockSize, nElts);
+    }
+    CUDACHECK(cudaEventRecord(stopEvent));
+    CUDACHECK(cudaDeviceSynchronize());
+
+    float elapsedMs = 0.0f;
+    CUDACHECK(cudaEventElapsedTime(&elapsedMs, startEvent, stopEvent));
+    float avgMs = elapsedMs / kBenchIters;
+
+    // Bandwidth: nMemAccesses * size bytes transferred
+    // (e.g. 2 for plain copy: 1 read + 1 write,
+    //        3 for 2-src reduce: 2 reads + 1 write)
+    size_t totalBytes = (size_t)nMemAccesses * nElts * sizeof(T);
+    double gbPerSec = (double)totalBytes / (avgMs * 1e6);
+    printf(
+        "  %-55s  nBlocks=%4d  nElts=%10ld  avg=%.3f ms  BW=%.2f GB/s\n",
+        label,
+        nBlocks,
+        (long)nElts,
+        avgMs,
+        gbPerSec);
+  }
+};
+
+// =============================================================================
+// Benchmark: Vectorized copy with different Unroll values (32 blocks, 4M elts)
+// =============================================================================
+
+TEST_F(SimpleCopyBench, CopyUnrollComparison) {
+  printf(
+      "\n--- Vectorized Copy: Unroll comparison (32 blocks, 4M elements) ---\n");
+
+  auto runUnroll = [&](auto unrollTag) {
+    constexpr int U = decltype(unrollTag)::value;
+
+    char label[128];
+    snprintf(label, sizeof(label), "Vectorized copy (Unroll=%d)", U);
+
+    runBenchCore(
+        kN,
+        kDefaultBlocks,
+        [&](int nBlk, int blockSize, int64_t nElts) {
+          copy_kernel<U, T>
+              <<<nBlk, blockSize>>>(d_output, d_input, (ssize_t)nElts);
+          CUDACHECK(cudaGetLastError());
+        },
+        label);
+  };
+
+  runUnroll(std::integral_constant<int, 1>{});
+  runUnroll(std::integral_constant<int, 2>{});
+  runUnroll(std::integral_constant<int, 4>{});
+  runUnroll(std::integral_constant<int, 8>{});
+}
+
+// =============================================================================
+// Benchmark: Block count sweep for vectorized copy (4M elts)
+// =============================================================================
+
+TEST_F(SimpleCopyBench, CopyBlockSweep) {
+  printf("\n--- Vectorized Copy: Block count sweep (4M elements) ---\n");
+
+  constexpr int kUnroll = 4;
+  constexpr int kMaxBlocks = 1024;
+
+  for (int nBlocks : blockCountSweep(kMaxBlocks)) {
+    char label[128];
+    snprintf(label, sizeof(label), "Vectorized copy (Unroll=%d)", kUnroll);
+
+    runBenchCore(
+        kN,
+        nBlocks,
+        [&](int nBlk, int blockSize, int64_t nElts) {
+          copy_kernel<kUnroll, T>
+              <<<nBlk, blockSize>>>(d_output, d_input, (ssize_t)nElts);
+          CUDACHECK(cudaGetLastError());
+        },
+        label);
+  }
+}
+
+// =============================================================================
+// Benchmark: Misaligned buffers + non-power-of-2 element counts
+// =============================================================================
+
+TEST_F(SimpleCopyBench, CopyMisaligned) {
+  printf(
+      "\n--- Vectorized Copy: Misaligned buffers + non-power-of-2 sizes ---\n");
+
+  struct Config {
+    int srcOffset;
+    int dstOffset;
+    int64_t nElts;
+  };
+
+  constexpr Config configs[] = {
+      {1, 1, 4000000}, // both 4B-misaligned
+      {3, 3, 3000007}, // both 12B-misaligned, prime-ish count
+      {1, 3, 4100000}, // different misalignment
+      {0, 1, 3999999}, // only dst misaligned
+  };
+
+  constexpr int kBlocks[] = {16, 32};
+
+  for (int nBlocks : kBlocks) {
+    for (const auto& cfg : configs) {
+      auto runUnroll = [&](auto unrollTag) {
+        constexpr int U = decltype(unrollTag)::value;
+        T* src = d_input + cfg.srcOffset;
+        T* dst = d_output + cfg.dstOffset;
+
+        char label[128];
+        snprintf(
+            label,
+            sizeof(label),
+            "Misaligned copy (srcOff=%d, dstOff=%d, Unroll=%d)",
+            cfg.srcOffset,
+            cfg.dstOffset,
+            U);
+
+        runBenchCore(
+            cfg.nElts,
+            nBlocks,
+            [&](int nBlk, int blockSize, int64_t nElts) {
+              copy_kernel<U, T><<<nBlk, blockSize>>>(dst, src, (ssize_t)nElts);
+              CUDACHECK(cudaGetLastError());
+            },
+            label);
+      };
+
+      runUnroll(std::integral_constant<int, 4>{});
+      runUnroll(std::integral_constant<int, 8>{});
+    }
+  }
+}
+
+// =============================================================================
+// Benchmark: reduceCopy with different Unroll values (2-src, 32 blocks, 4M)
+// =============================================================================
+
+TEST_F(SimpleCopyBench, ReduceCopyUnrollComparison) {
+  printf(
+      "\n--- ReduceCopy 2-src: Unroll comparison (32 blocks, 4M elements) ---\n");
+
+  auto runUnroll = [&](auto unrollTag) {
+    constexpr int U = decltype(unrollTag)::value;
+
+    char label[128];
+    snprintf(label, sizeof(label), "reduceCopy 2-src (Unroll=%d)", U);
+
+    runBenchCore(
+        kN,
+        kDefaultBlocks,
+        [&](int nBlk, int blockSize, int64_t nElts) {
+          reduce_copy_2src_kernel<U, T><<<nBlk, blockSize>>>(
+              d_output, d_input, d_input2, (ssize_t)nElts);
+          CUDACHECK(cudaGetLastError());
+        },
+        label,
+        3); // 2 reads + 1 write
+  };
+
+  runUnroll(std::integral_constant<int, 1>{});
+  runUnroll(std::integral_constant<int, 2>{});
+  runUnroll(std::integral_constant<int, 4>{});
+  runUnroll(std::integral_constant<int, 8>{});
+}
+
+// =============================================================================
+// Benchmark: reduceCopy with different source counts (32 blocks, 4M elts)
+// =============================================================================
+
+TEST_F(SimpleCopyBench, ReduceCopySourceCountComparison) {
+  printf(
+      "\n--- ReduceCopy: Source count comparison (Unroll=4, 32 blocks, 4M elements) ---\n");
+
+  {
+    char label[] = "reduceCopy 1-src (Unroll=4)";
+    runBenchCore(
+        kN,
+        kDefaultBlocks,
+        [&](int nBlk, int blockSize, int64_t nElts) {
+          reduce_copy_1src_kernel<4, T>
+              <<<nBlk, blockSize>>>(d_output, d_input, (ssize_t)nElts);
+          CUDACHECK(cudaGetLastError());
+        },
+        label,
+        2); // 1 read + 1 write
+  }
+  {
+    char label[] = "reduceCopy 2-src (Unroll=4)";
+    runBenchCore(
+        kN,
+        kDefaultBlocks,
+        [&](int nBlk, int blockSize, int64_t nElts) {
+          reduce_copy_2src_kernel<4, T><<<nBlk, blockSize>>>(
+              d_output, d_input, d_input2, (ssize_t)nElts);
+          CUDACHECK(cudaGetLastError());
+        },
+        label,
+        3); // 2 reads + 1 write
+  }
+  {
+    char label[] = "reduceCopy 3-src (Unroll=4)";
+    runBenchCore(
+        kN,
+        kDefaultBlocks,
+        [&](int nBlk, int blockSize, int64_t nElts) {
+          reduce_copy_3src_kernel<4, T><<<nBlk, blockSize>>>(
+              d_output, d_input, d_input2, d_input3, (ssize_t)nElts);
+          CUDACHECK(cudaGetLastError());
+        },
+        label,
+        4); // 3 reads + 1 write
+  }
+}
+
+// =============================================================================
+// Benchmark: reduceCopy block count sweep (2-src, Unroll=4, 4M elts)
+// =============================================================================
+
+TEST_F(SimpleCopyBench, ReduceCopyBlockSweep) {
+  printf(
+      "\n--- ReduceCopy 2-src: Block count sweep (Unroll=4, 4M elements) ---\n");
+
+  constexpr int kUnroll = 4;
+  constexpr int kMaxBlocks = 1024;
+
+  for (int nBlocks : blockCountSweep(kMaxBlocks)) {
+    char label[128];
+    snprintf(label, sizeof(label), "reduceCopy 2-src (Unroll=%d)", kUnroll);
+
+    runBenchCore(
+        kN,
+        nBlocks,
+        [&](int nBlk, int blockSize, int64_t nElts) {
+          reduce_copy_2src_kernel<kUnroll, T><<<nBlk, blockSize>>>(
+              d_output, d_input, d_input2, (ssize_t)nElts);
+          CUDACHECK(cudaGetLastError());
+        },
+        label,
+        3);
+  }
+}
+
+// =============================================================================
+// Benchmark: reduceCopy 2-src with misaligned buffers + non-power-of-2 sizes
+// =============================================================================
+
+TEST_F(SimpleCopyBench, ReduceCopyMisaligned) {
+  printf(
+      "\n--- ReduceCopy 2-src: Misaligned buffers + non-power-of-2 sizes ---\n");
+
+  struct Config {
+    int src0Offset;
+    int src1Offset;
+    int dstOffset;
+    int64_t nElts;
+  };
+
+  constexpr Config configs[] = {
+      {1, 1, 1, 4000000}, // all 4B-misaligned
+      {3, 3, 3, 3000007}, // all 12B-misaligned, prime-ish count
+      {1, 3, 0, 4100000}, // mixed misalignment, dst aligned
+      {0, 1, 3, 3999999}, // src0 aligned, others misaligned
+  };
+
+  constexpr int kBlocks[] = {16, 32};
+
+  for (int nBlocks : kBlocks) {
+    for (const auto& cfg : configs) {
+      auto runUnroll = [&](auto unrollTag) {
+        constexpr int U = decltype(unrollTag)::value;
+        T* src0 = d_input + cfg.src0Offset;
+        T* src1 = d_input2 + cfg.src1Offset;
+        T* dst = d_output + cfg.dstOffset;
+
+        char label[128];
+        snprintf(
+            label,
+            sizeof(label),
+            "Misaligned reduceCopy 2-src (s0Off=%d, s1Off=%d, dOff=%d, U=%d)",
+            cfg.src0Offset,
+            cfg.src1Offset,
+            cfg.dstOffset,
+            U);
+
+        runBenchCore(
+            cfg.nElts,
+            nBlocks,
+            [&](int nBlk, int blockSize, int64_t nElts) {
+              reduce_copy_2src_kernel<U, T>
+                  <<<nBlk, blockSize>>>(dst, src0, src1, (ssize_t)nElts);
+              CUDACHECK(cudaGetLastError());
+            },
+            label,
+            3);
+      };
+
+      runUnroll(std::integral_constant<int, 4>{});
+      runUnroll(std::integral_constant<int, 8>{});
+    }
+  }
+}
+
+// =============================================================================
+// Benchmark: reduceCopyPacks with different Unroll/EltPerPack (2-src, 32 blks)
+// =============================================================================
+
+TEST_F(SimpleCopyBench, ReduceCopyPacksGrid) {
+  printf(
+      "\n--- reduceCopyPacks 2-src: Unroll x EltPerPack grid (32 blocks, 4M elements) ---\n");
+
+  auto runConfig = [&](auto unrollTag, auto bppTag) {
+    constexpr int U = decltype(unrollTag)::value;
+    constexpr int B = decltype(bppTag)::value / sizeof(T);
+
+    char label[128];
+    snprintf(
+        label,
+        sizeof(label),
+        "reduceCopyPacks 2-src (Unroll=%d, EltPerPack=%d)",
+        U,
+        B);
+
+    runBenchCore(
+        kN,
+        kDefaultBlocks,
+        [&](int nBlk, int blockSize, int64_t nElts) {
+          reduce_copy_packs_2src_kernel<U, B, T><<<nBlk, blockSize>>>(
+              d_output, d_input, d_input2, (ssize_t)nElts);
+          CUDACHECK(cudaGetLastError());
+        },
+        label,
+        3);
+  };
+
+  // EltPerPack=1 (sizeof(float) bytes per pack), varying Unroll
+  runConfig(std::integral_constant<int, 1>{}, std::integral_constant<int, 4>{});
+  runConfig(std::integral_constant<int, 2>{}, std::integral_constant<int, 4>{});
+  runConfig(std::integral_constant<int, 4>{}, std::integral_constant<int, 4>{});
+  runConfig(std::integral_constant<int, 8>{}, std::integral_constant<int, 4>{});
+
+  // EltPerPack=2 (8 bytes per pack), varying Unroll
+  runConfig(std::integral_constant<int, 1>{}, std::integral_constant<int, 8>{});
+  runConfig(std::integral_constant<int, 2>{}, std::integral_constant<int, 8>{});
+  runConfig(std::integral_constant<int, 4>{}, std::integral_constant<int, 8>{});
+  runConfig(std::integral_constant<int, 8>{}, std::integral_constant<int, 8>{});
+
+  // EltPerPack=4 (16 bytes per pack), varying Unroll
+  runConfig(
+      std::integral_constant<int, 1>{}, std::integral_constant<int, 16>{});
+  runConfig(
+      std::integral_constant<int, 2>{}, std::integral_constant<int, 16>{});
+  runConfig(
+      std::integral_constant<int, 4>{}, std::integral_constant<int, 16>{});
+  runConfig(
+      std::integral_constant<int, 8>{}, std::integral_constant<int, 16>{});
+}

--- a/comms/ncclx/meta/collectives/benchmarks/SimpleCopyMixedBench.cu
+++ b/comms/ncclx/meta/collectives/benchmarks/SimpleCopyMixedBench.cu
@@ -1,0 +1,399 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+#include "meta/collectives/kernels/reduce_copy.cuh"
+
+// =============================================================================
+// Wrapper Kernels
+// =============================================================================
+
+template <int Unroll, typename AccType, typename DstType, typename Src0Type>
+__global__ __launch_bounds__(256, 1) void reduce_copy_mixed_1src_kernel(
+    DstType* dst,
+    const Src0Type* src0,
+    ssize_t nElts) {
+  auto thread = threadIdx.x + blockIdx.x * blockDim.x;
+  auto nThreads = blockDim.x * gridDim.x;
+  meta::comms::ncclx::kernels::simplecopy::reduceCopyMixed<Unroll, AccType>(
+      thread, nThreads, dst, nElts, src0);
+}
+
+template <
+    int Unroll,
+    typename AccType,
+    typename DstType,
+    typename Src0Type,
+    typename Src1Type>
+__global__ __launch_bounds__(256, 1) void reduce_copy_mixed_2src_kernel(
+    DstType* dst,
+    const Src0Type* src0,
+    const Src1Type* src1,
+    ssize_t nElts) {
+  auto thread = threadIdx.x + blockIdx.x * blockDim.x;
+  auto nThreads = blockDim.x * gridDim.x;
+  meta::comms::ncclx::kernels::simplecopy::reduceCopyMixed<Unroll, AccType>(
+      thread, nThreads, dst, nElts, src0, src1);
+}
+
+#define CUDACHECK(cmd)                                                    \
+  do {                                                                    \
+    cudaError_t e = cmd;                                                  \
+    ASSERT_EQ(e, cudaSuccess) << "CUDA error: " << cudaGetErrorString(e); \
+  } while (0)
+
+// =============================================================================
+// Benchmark Fixture
+// =============================================================================
+
+class SimpleCopyMixedBench : public ::testing::Test {
+ protected:
+  static constexpr int64_t kN = 4L * 1024L * 1024L; // 4M elements
+  static constexpr int kBlockSize = 256;
+  static constexpr int kDefaultBlocks = 32;
+  static constexpr int kWarmupIters = 10;
+  static constexpr int kBenchIters = 100;
+
+  float* d_srcFloat0 = nullptr;
+  float* d_srcFloat1 = nullptr;
+  float* d_dstFloat = nullptr;
+  __nv_bfloat16* d_srcBf16_0 = nullptr;
+  __nv_bfloat16* d_srcBf16_1 = nullptr;
+  __nv_bfloat16* d_dstBf16 = nullptr;
+
+  cudaEvent_t startEvent, stopEvent;
+
+  void SetUp() override {
+    CUDACHECK(cudaMalloc(&d_srcFloat0, kN * sizeof(float)));
+    CUDACHECK(cudaMalloc(&d_srcFloat1, kN * sizeof(float)));
+    CUDACHECK(cudaMalloc(&d_dstFloat, kN * sizeof(float)));
+    CUDACHECK(cudaMalloc(&d_srcBf16_0, kN * sizeof(__nv_bfloat16)));
+    CUDACHECK(cudaMalloc(&d_srcBf16_1, kN * sizeof(__nv_bfloat16)));
+    CUDACHECK(cudaMalloc(&d_dstBf16, kN * sizeof(__nv_bfloat16)));
+
+    // Initialize with simple pattern
+    std::vector<float> h_init(kN);
+    for (int64_t i = 0; i < kN; i++) {
+      h_init[i] = 1.0f + static_cast<float>(i % 1000) * 1e-4f;
+    }
+    CUDACHECK(cudaMemcpy(
+        d_srcFloat0,
+        h_init.data(),
+        kN * sizeof(float),
+        cudaMemcpyHostToDevice));
+    CUDACHECK(cudaMemcpy(
+        d_srcFloat1,
+        h_init.data(),
+        kN * sizeof(float),
+        cudaMemcpyHostToDevice));
+
+    std::vector<__nv_bfloat16> h_bf16(kN);
+    for (int64_t i = 0; i < kN; i++) {
+      h_bf16[i] = __float2bfloat16(h_init[i]);
+    }
+    CUDACHECK(cudaMemcpy(
+        d_srcBf16_0,
+        h_bf16.data(),
+        kN * sizeof(__nv_bfloat16),
+        cudaMemcpyHostToDevice));
+    CUDACHECK(cudaMemcpy(
+        d_srcBf16_1,
+        h_bf16.data(),
+        kN * sizeof(__nv_bfloat16),
+        cudaMemcpyHostToDevice));
+
+    CUDACHECK(cudaEventCreate(&startEvent));
+    CUDACHECK(cudaEventCreate(&stopEvent));
+  }
+
+  void TearDown() override {
+    CUDACHECK(cudaEventDestroy(startEvent));
+    CUDACHECK(cudaEventDestroy(stopEvent));
+    CUDACHECK(cudaFree(d_srcFloat0));
+    CUDACHECK(cudaFree(d_srcFloat1));
+    CUDACHECK(cudaFree(d_dstFloat));
+    CUDACHECK(cudaFree(d_srcBf16_0));
+    CUDACHECK(cudaFree(d_srcBf16_1));
+    CUDACHECK(cudaFree(d_dstBf16));
+  }
+
+  template <typename LaunchFn>
+  void runBenchCore(
+      int64_t nElts,
+      int nBlocks,
+      LaunchFn launchFn,
+      const char* label,
+      size_t totalBytes) {
+    // Warmup
+    for (int i = 0; i < kWarmupIters; i++) {
+      launchFn(nBlocks, kBlockSize, nElts);
+    }
+    CUDACHECK(cudaDeviceSynchronize());
+
+    // Timed iterations
+    CUDACHECK(cudaEventRecord(startEvent));
+    for (int i = 0; i < kBenchIters; i++) {
+      launchFn(nBlocks, kBlockSize, nElts);
+    }
+    CUDACHECK(cudaEventRecord(stopEvent));
+    CUDACHECK(cudaDeviceSynchronize());
+
+    float elapsedMs = 0.0f;
+    CUDACHECK(cudaEventElapsedTime(&elapsedMs, startEvent, stopEvent));
+    float avgMs = elapsedMs / kBenchIters;
+
+    double gbPerSec = (double)totalBytes / (avgMs * 1e6);
+    printf(
+        "  %-55s  nBlocks=%4d  nElts=%10ld  avg=%.3f ms  BW=%.2f GB/s\n",
+        label,
+        nBlocks,
+        (long)nElts,
+        avgMs,
+        gbPerSec);
+  }
+};
+
+// =============================================================================
+// 1-src benchmarks (32 blocks, 4M elements)
+// =============================================================================
+
+// FP32 -> FP32 (1 src): 1 read + 1 write = 2 * 4M * 4 bytes
+TEST_F(SimpleCopyMixedBench, OneSrc_FloatToFloat) {
+  printf(
+      "\n--- reduceCopyMixed 1-src: FP32 -> FP32 (32 blocks, 4M elts) ---\n");
+  size_t totalBytes = kN * sizeof(float) + kN * sizeof(float);
+  runBenchCore(
+      kN,
+      kDefaultBlocks,
+      [&](int nBlk, int blockSize, int64_t nElts) {
+        reduce_copy_mixed_1src_kernel<4, float, float, float>
+            <<<nBlk, blockSize>>>(d_dstFloat, d_srcFloat0, (ssize_t)nElts);
+        CUDACHECK(cudaGetLastError());
+      },
+      "1-src f32 -> f32",
+      totalBytes);
+}
+
+// BF16 -> FP32 (1 src): 1 read of BF16 + 1 write of FP32
+TEST_F(SimpleCopyMixedBench, OneSrc_Bf16ToFloat) {
+  printf(
+      "\n--- reduceCopyMixed 1-src: BF16 -> FP32 (32 blocks, 4M elts) ---\n");
+  size_t totalBytes = kN * sizeof(__nv_bfloat16) + kN * sizeof(float);
+  runBenchCore(
+      kN,
+      kDefaultBlocks,
+      [&](int nBlk, int blockSize, int64_t nElts) {
+        reduce_copy_mixed_1src_kernel<4, float, float, __nv_bfloat16>
+            <<<nBlk, blockSize>>>(d_dstFloat, d_srcBf16_0, (ssize_t)nElts);
+        CUDACHECK(cudaGetLastError());
+      },
+      "1-src bf16 -> f32",
+      totalBytes);
+}
+
+// FP32 -> BF16 (1 src): 1 read of FP32 + 1 write of BF16
+TEST_F(SimpleCopyMixedBench, OneSrc_FloatToBf16) {
+  printf(
+      "\n--- reduceCopyMixed 1-src: FP32 -> BF16 (32 blocks, 4M elts) ---\n");
+  size_t totalBytes = kN * sizeof(float) + kN * sizeof(__nv_bfloat16);
+  runBenchCore(
+      kN,
+      kDefaultBlocks,
+      [&](int nBlk, int blockSize, int64_t nElts) {
+        reduce_copy_mixed_1src_kernel<4, float, __nv_bfloat16, float>
+            <<<nBlk, blockSize>>>(d_dstBf16, d_srcFloat0, (ssize_t)nElts);
+        CUDACHECK(cudaGetLastError());
+      },
+      "1-src f32 -> bf16",
+      totalBytes);
+}
+
+// BF16 -> BF16 (1 src): 1 read of BF16 + 1 write of BF16
+TEST_F(SimpleCopyMixedBench, OneSrc_Bf16ToBf16) {
+  printf(
+      "\n--- reduceCopyMixed 1-src: BF16 -> BF16 (32 blocks, 4M elts) ---\n");
+  size_t totalBytes = kN * sizeof(__nv_bfloat16) + kN * sizeof(__nv_bfloat16);
+  runBenchCore(
+      kN,
+      kDefaultBlocks,
+      [&](int nBlk, int blockSize, int64_t nElts) {
+        reduce_copy_mixed_1src_kernel<4, float, __nv_bfloat16, __nv_bfloat16>
+            <<<nBlk, blockSize>>>(d_dstBf16, d_srcBf16_0, (ssize_t)nElts);
+        CUDACHECK(cudaGetLastError());
+      },
+      "1-src bf16 -> bf16",
+      totalBytes);
+}
+
+// =============================================================================
+// 2-src benchmarks (32 blocks, 4M elements)
+// =============================================================================
+
+// FP32 + FP32 -> FP32: 2 reads of FP32 + 1 write of FP32
+TEST_F(SimpleCopyMixedBench, TwoSrc_FloatFloat_FloatDst) {
+  printf(
+      "\n--- reduceCopyMixed 2-src: FP32+FP32 -> FP32 (32 blocks, 4M elts) ---\n");
+  size_t totalBytes = 2 * kN * sizeof(float) + kN * sizeof(float);
+  runBenchCore(
+      kN,
+      kDefaultBlocks,
+      [&](int nBlk, int blockSize, int64_t nElts) {
+        reduce_copy_mixed_2src_kernel<4, float, float, float, float>
+            <<<nBlk, blockSize>>>(
+                d_dstFloat, d_srcFloat0, d_srcFloat1, (ssize_t)nElts);
+        CUDACHECK(cudaGetLastError());
+      },
+      "2-src f32+f32 -> f32",
+      totalBytes);
+}
+
+// FP32 + FP32 -> BF16: 2 reads of FP32 + 1 write of BF16
+TEST_F(SimpleCopyMixedBench, TwoSrc_FloatFloat_Bf16Dst) {
+  printf(
+      "\n--- reduceCopyMixed 2-src: FP32+FP32 -> BF16 (32 blocks, 4M elts) ---\n");
+  size_t totalBytes = 2 * kN * sizeof(float) + kN * sizeof(__nv_bfloat16);
+  runBenchCore(
+      kN,
+      kDefaultBlocks,
+      [&](int nBlk, int blockSize, int64_t nElts) {
+        reduce_copy_mixed_2src_kernel<4, float, __nv_bfloat16, float, float>
+            <<<nBlk, blockSize>>>(
+                d_dstBf16, d_srcFloat0, d_srcFloat1, (ssize_t)nElts);
+        CUDACHECK(cudaGetLastError());
+      },
+      "2-src f32+f32 -> bf16",
+      totalBytes);
+}
+
+// BF16 + BF16 -> FP32: 2 reads of BF16 + 1 write of FP32
+TEST_F(SimpleCopyMixedBench, TwoSrc_Bf16Bf16_FloatDst) {
+  printf(
+      "\n--- reduceCopyMixed 2-src: BF16+BF16 -> FP32 (32 blocks, 4M elts) ---\n");
+  size_t totalBytes = 2 * kN * sizeof(__nv_bfloat16) + kN * sizeof(float);
+  runBenchCore(
+      kN,
+      kDefaultBlocks,
+      [&](int nBlk, int blockSize, int64_t nElts) {
+        reduce_copy_mixed_2src_kernel<
+            4,
+            float,
+            float,
+            __nv_bfloat16,
+            __nv_bfloat16><<<nBlk, blockSize>>>(
+            d_dstFloat, d_srcBf16_0, d_srcBf16_1, (ssize_t)nElts);
+        CUDACHECK(cudaGetLastError());
+      },
+      "2-src bf16+bf16 -> f32",
+      totalBytes);
+}
+
+// BF16 + BF16 -> BF16: 2 reads of BF16 + 1 write of BF16
+TEST_F(SimpleCopyMixedBench, TwoSrc_Bf16Bf16_Bf16Dst) {
+  printf(
+      "\n--- reduceCopyMixed 2-src: BF16+BF16 -> BF16 (32 blocks, 4M elts) ---\n");
+  size_t totalBytes = 3 * kN * sizeof(__nv_bfloat16);
+  runBenchCore(
+      kN,
+      kDefaultBlocks,
+      [&](int nBlk, int blockSize, int64_t nElts) {
+        reduce_copy_mixed_2src_kernel<
+            4,
+            float,
+            __nv_bfloat16,
+            __nv_bfloat16,
+            __nv_bfloat16><<<nBlk, blockSize>>>(
+            d_dstBf16, d_srcBf16_0, d_srcBf16_1, (ssize_t)nElts);
+        CUDACHECK(cudaGetLastError());
+      },
+      "2-src bf16+bf16 -> bf16",
+      totalBytes);
+}
+
+// BF16 + FP32 -> FP32: 1 read of BF16 + 1 read of FP32 + 1 write of FP32
+TEST_F(SimpleCopyMixedBench, TwoSrc_Bf16Float_FloatDst) {
+  printf(
+      "\n--- reduceCopyMixed 2-src: BF16+FP32 -> FP32 (32 blocks, 4M elts) ---\n");
+  size_t totalBytes =
+      kN * sizeof(__nv_bfloat16) + kN * sizeof(float) + kN * sizeof(float);
+  runBenchCore(
+      kN,
+      kDefaultBlocks,
+      [&](int nBlk, int blockSize, int64_t nElts) {
+        reduce_copy_mixed_2src_kernel<4, float, float, __nv_bfloat16, float>
+            <<<nBlk, blockSize>>>(
+                d_dstFloat, d_srcBf16_0, d_srcFloat1, (ssize_t)nElts);
+        CUDACHECK(cudaGetLastError());
+      },
+      "2-src bf16+f32 -> f32",
+      totalBytes);
+}
+
+// BF16 + FP32 -> BF16: 1 read of BF16 + 1 read of FP32 + 1 write of BF16
+TEST_F(SimpleCopyMixedBench, TwoSrc_Bf16Float_Bf16Dst) {
+  printf(
+      "\n--- reduceCopyMixed 2-src: BF16+FP32 -> BF16 (32 blocks, 4M elts) ---\n");
+  size_t totalBytes = kN * sizeof(__nv_bfloat16) + kN * sizeof(float) +
+      kN * sizeof(__nv_bfloat16);
+  runBenchCore(
+      kN,
+      kDefaultBlocks,
+      [&](int nBlk, int blockSize, int64_t nElts) {
+        reduce_copy_mixed_2src_kernel<
+            4,
+            float,
+            __nv_bfloat16,
+            __nv_bfloat16,
+            float><<<nBlk, blockSize>>>(
+            d_dstBf16, d_srcBf16_0, d_srcFloat1, (ssize_t)nElts);
+        CUDACHECK(cudaGetLastError());
+      },
+      "2-src bf16+f32 -> bf16",
+      totalBytes);
+}
+
+// FP32 + BF16 -> FP32: 1 read of FP32 + 1 read of BF16 + 1 write of FP32
+TEST_F(SimpleCopyMixedBench, TwoSrc_FloatBf16_FloatDst) {
+  printf(
+      "\n--- reduceCopyMixed 2-src: FP32+BF16 -> FP32 (32 blocks, 4M elts) ---\n");
+  size_t totalBytes =
+      kN * sizeof(float) + kN * sizeof(__nv_bfloat16) + kN * sizeof(float);
+  runBenchCore(
+      kN,
+      kDefaultBlocks,
+      [&](int nBlk, int blockSize, int64_t nElts) {
+        reduce_copy_mixed_2src_kernel<4, float, float, float, __nv_bfloat16>
+            <<<nBlk, blockSize>>>(
+                d_dstFloat, d_srcFloat0, d_srcBf16_1, (ssize_t)nElts);
+        CUDACHECK(cudaGetLastError());
+      },
+      "2-src f32+bf16 -> f32",
+      totalBytes);
+}
+
+// FP32 + BF16 -> BF16: 1 read of FP32 + 1 read of BF16 + 1 write of BF16
+TEST_F(SimpleCopyMixedBench, TwoSrc_FloatBf16_Bf16Dst) {
+  printf(
+      "\n--- reduceCopyMixed 2-src: FP32+BF16 -> BF16 (32 blocks, 4M elts) ---\n");
+  size_t totalBytes = kN * sizeof(float) + kN * sizeof(__nv_bfloat16) +
+      kN * sizeof(__nv_bfloat16);
+  runBenchCore(
+      kN,
+      kDefaultBlocks,
+      [&](int nBlk, int blockSize, int64_t nElts) {
+        reduce_copy_mixed_2src_kernel<
+            4,
+            float,
+            __nv_bfloat16,
+            float,
+            __nv_bfloat16><<<nBlk, blockSize>>>(
+            d_dstBf16, d_srcFloat0, d_srcBf16_1, (ssize_t)nElts);
+        CUDACHECK(cudaGetLastError());
+      },
+      "2-src f32+bf16 -> bf16",
+      totalBytes);
+}

--- a/comms/ncclx/meta/collectives/kernels/copy_iterator.cuh
+++ b/comms/ncclx/meta/collectives/kernels/copy_iterator.cuh
@@ -1,0 +1,155 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#ifndef NCCL_COPY_ITERATOR_CUH_
+#define NCCL_COPY_ITERATOR_CUH_
+
+#include "device.h" // WARP_SIZE
+#include "op128.h" // BytePack, cvta_to_global, ld_volatile_global, st_global
+
+#include <type_traits>
+#include <utility>
+
+namespace meta::comms::ncclx::kernels {
+
+// Extract the I-th type from a parameter pack (avoids <tuple> dependency).
+template <size_t I, typename... Pack>
+struct NthType;
+template <typename T, typename... Rest>
+struct NthType<0, T, Rest...> {
+  using type = T;
+};
+template <size_t I, typename T, typename... Rest>
+struct NthType<I, T, Rest...> {
+  using type = typename NthType<I - 1, Rest...>::type;
+};
+template <size_t I, typename... Pack>
+using NthType_t = typename NthType<I, Pack...>::type;
+
+// Encapsulates iteration bookkeeping for copyPacks: hunk counting, per-thread
+// byte offsets, pointer advancement, and warp rotation.  Supports an arbitrary
+// number of pointers, each with its own element type (Ts...).
+//
+// All methods are __forceinline__ so the struct is a source-level abstraction
+// only — it compiles to identical register usage as the original inline code.
+template <
+    int Unroll,
+    int EltPerPack,
+    typename IntBytes,
+    typename IntThread,
+    typename... Ts>
+struct CopyIterator {
+  static constexpr size_t N = sizeof...(Ts);
+  static_assert(N > 0, "CopyIterator requires at least one pointer type");
+
+  uintptr_t ptrs[N];
+  IntBytes threadEltsAhead;
+  IntBytes nHunksAhead;
+  IntThread nThreads;
+
+  static constexpr int kEltPerHunk = Unroll * WARP_SIZE * EltPerPack;
+  static constexpr bool kDoPartialIter = Unroll == 1;
+
+  // The element type associated with the I-th pointer.
+  // std::remove_cv strips const/volatile so that downstream applyCast/fromPack
+  // operate on unqualified types (e.g. __nv_bfloat16 rather than
+  // const __nv_bfloat16), avoiding deleted-default-constructor errors in the
+  // fromPack union.
+  template <size_t I>
+  using PtrType = std::remove_cv_t<NthType_t<I, Ts...>>;
+
+  // Get the element offset for the current thread from the beginning of the
+  // overall element offset
+  __device__ __forceinline__ int getThreadEltOffset(int warp, int lane) {
+    // warp * kEltPerHunk -> Warp offset in elements from the beginning of the
+    // overall offset
+    // lane * EltPerPack -> Offset for this specific thread
+    return warp * kEltPerHunk + lane * EltPerPack;
+  }
+
+  __device__ __forceinline__ CopyIterator(
+      IntThread nThreads_,
+      IntThread thread,
+      IntBytes& nEltsBehind,
+      IntBytes& nEltsAhead,
+      Ts*... ptrArgs)
+      : nThreads{nThreads_} {
+    int warp = thread / WARP_SIZE;
+    int lane = thread % WARP_SIZE;
+
+    IntBytes threadEltsBehind = nEltsBehind + getThreadEltOffset(warp, lane);
+    threadEltsAhead = nEltsAhead - getThreadEltOffset(warp, lane);
+
+    nHunksAhead = nEltsAhead / kEltPerHunk;
+
+    nEltsBehind += nHunksAhead * kEltPerHunk;
+    nEltsAhead -= nHunksAhead * kEltPerHunk;
+
+    if (kDoPartialIter && EltPerPack <= nEltsAhead) {
+      nHunksAhead += 1;
+      nEltsBehind += nEltsAhead - (nEltsAhead % EltPerPack);
+      nEltsAhead = nEltsAhead % EltPerPack;
+    }
+
+    // Put nHunksAhead in regard to the current warp
+    nHunksAhead -= warp;
+
+    // Initialize each pointer with its type-specific byte stride.
+    size_t i = 0;
+    ((ptrs[i++] = cvta_to_global(ptrArgs) + threadEltsBehind * sizeof(Ts)),
+     ...);
+  }
+
+  // Access the I-th pointer.
+  template <size_t I>
+  __device__ __forceinline__ uintptr_t& get() {
+    static_assert(I < N, "Pointer index out of range");
+    return ptrs[I];
+  }
+
+  template <size_t I>
+  __device__ __forceinline__ const uintptr_t& get() const {
+    static_assert(I < N, "Pointer index out of range");
+    return ptrs[I];
+  }
+
+  __device__ __forceinline__ bool hasWork() const {
+    if constexpr (kDoPartialIter)
+      return EltPerPack <= threadEltsAhead;
+    else
+      return 0 < nHunksAhead;
+  }
+
+  // Advance the I-th pointer by one unrolled warp-stride, using the I-th
+  // pointer's type for the byte calculation automatically.
+  template <size_t I>
+  __device__ __forceinline__ void advanceUnroll() {
+    ptrs[I] += WARP_SIZE * EltPerPack * sizeof(PtrType<I>);
+  }
+
+  // Advance an arbitrary uintptr_t by one unrolled warp-stride with an
+  // explicitly specified element type.
+  template <typename PtrT>
+  __device__ __forceinline__ void advanceUnroll(uintptr_t& ptr) {
+    ptr += WARP_SIZE * EltPerPack * sizeof(PtrT);
+  }
+
+  // Advance all pointers past the current set of warps (warp rotation).
+  __device__ __forceinline__ void advance() {
+    int nWarps = nThreads / WARP_SIZE;
+    advanceAll(nWarps, std::index_sequence_for<Ts...>{});
+    threadEltsAhead -= nWarps * kEltPerHunk;
+    nHunksAhead -= nWarps;
+  }
+
+ private:
+  template <size_t... Is>
+  __device__ __forceinline__ void advanceAll(
+      int nWarps,
+      std::index_sequence<Is...>) {
+    ((ptrs[Is] += (nWarps - 1) * kEltPerHunk * sizeof(PtrType<Is>)), ...);
+  }
+};
+
+} // namespace meta::comms::ncclx::kernels
+
+#endif // NCCL_COPY_ITERATOR_CUH_

--- a/comms/ncclx/meta/collectives/kernels/reduce_copy.cuh
+++ b/comms/ncclx/meta/collectives/kernels/reduce_copy.cuh
@@ -1,0 +1,249 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include "meta/collectives/kernels/copy_iterator.cuh"
+#include "meta/collectives/kernels/reduce_copy_common.cuh"
+
+namespace meta::comms::ncclx::kernels::simplecopy {
+
+template <
+    int Unroll,
+    int EltPerPack,
+    typename AccType,
+    int FirstDstIdx,
+    typename IterType>
+static __device__ __forceinline__ void storeFirstDestination(
+    BytePack<EltPerPack * sizeof(AccType)>* acc,
+    IterType& iter) {
+  using DstType = typename IterType::template PtrType<FirstDstIdx>;
+  // Enforce that we only store to equal-or-lower precision destinations from
+  // the accumulator type (e.g., fp32 -> bf16, fp32 -> fp32).
+  static_assert(
+      sizeof(DstType) <= sizeof(AccType),
+      "DstType must be of lower or same precision as AccType (by size).");
+
+  if constexpr (std::is_same_v<AccType, DstType>) {
+    // If the accumulator and dst types are the same, we can just store
+#pragma unroll Unroll
+    for (int u = 0; u < Unroll; u++) {
+      st_global<EltPerPack * sizeof(DstType)>(
+          iter.template get<FirstDstIdx>(), acc[u]);
+      iter.template advanceUnroll<FirstDstIdx>();
+    }
+  } else {
+#pragma unroll Unroll
+    for (int u = 0; u < Unroll; u++) {
+      auto destPack = applyCast<AccType, DstType>(acc[u]);
+      st_global<EltPerPack * sizeof(DstType)>(
+          iter.template get<FirstDstIdx>(), destPack);
+      iter.template advanceUnroll<FirstDstIdx>();
+    }
+  }
+}
+
+// Inner reduce-copy using packs of EltPerPack elements.
+// Ts... are ordered as {Src0Type, [Src1Type, [Src2Type,]] DstType}.
+// The last DstPtrCount pointers are destinations, the rest are sources.
+template <
+    int Unroll,
+    int EltPerPack,
+    typename AccType, // What type to use for the accumulator
+    size_t DstPtrCount, // The last N pointers are dsts, others are srcs
+    typename IntThread,
+    typename IntBytes,
+    typename... Ts>
+__device__ __forceinline__ void reduceCopyPacks(
+    IntThread nThreads,
+    IntThread& thread,
+    IntBytes& nEltsBehind,
+    IntBytes& nEltsAhead,
+    Ts*... ptrs) {
+  static_assert(
+      std::is_signed<IntBytes>::value,
+      "IntBytes must be a signed integral type.");
+  static_assert(EltPerPack > 0, "EltPerPack must be greater than 0");
+  static_assert(DstPtrCount > 0, "DstPtrCount must be greater than 0");
+  static_assert(DstPtrCount == 1, "Currently only support 1 dst pointer");
+
+  constexpr auto kSrcPtrCount = sizeof...(Ts) - DstPtrCount;
+  static_assert(kSrcPtrCount > 0, "There must be at least one src pointer");
+  static_assert(kSrcPtrCount <= 3, "We only support up to 3 src pointers");
+
+  constexpr size_t kDstStartIdx = sizeof...(Ts) - DstPtrCount;
+
+  CopyIterator<Unroll, EltPerPack, IntBytes, IntThread, Ts...> iter(
+      nThreads, thread, nEltsBehind, nEltsAhead, ptrs...);
+
+  using Iter = decltype(iter);
+  using Src0Type = typename Iter::template PtrType<0>;
+  using DstType = typename Iter::template PtrType<kDstStartIdx>;
+
+  while (iter.hasWork()) {
+    BytePack<EltPerPack * sizeof(AccType)> acc[Unroll];
+
+    loadFirstSource<Unroll, EltPerPack, AccType>(acc, iter);
+
+    ReduceSources<1, kSrcPtrCount>::template apply<Unroll, EltPerPack, AccType>(
+        acc, iter);
+
+    storeFirstDestination<Unroll, EltPerPack, AccType, kDstStartIdx>(acc, iter);
+
+    iter.advance();
+  }
+}
+
+// Reduce-sum nElts elements from multiple sources into a single destination.
+// Destination pointer comes first, followed by variadic source pointers.
+// Uses the same multi-pass vectorized packing strategy as copy():
+//   1. Try 16-byte packs if all pointers are aligned (bulk + tail).
+//   2. Fall back to sizeof(AccType)-byte packs (bulk + tail).
+template <int Unroll, typename AccType, typename IntBytes, typename... SrcTs>
+__device__ __forceinline__ void reduceCopy(
+    int thread,
+    int nThreads,
+    void* dstPtr,
+    IntBytes nElts,
+    SrcTs*... srcPtrs) {
+  int lane = thread % WARP_SIZE;
+  constexpr int BigPackSize = 16;
+  constexpr size_t kNSrcs = sizeof...(SrcTs);
+  static_assert(kNSrcs > 0, "reduceCopy requires at least one source");
+
+  IntBytes nEltsBehind = 0;
+  IntBytes nEltsAhead = nElts;
+
+  AccType* dst = static_cast<AccType*>(dstPtr);
+
+  if constexpr (BigPackSize > sizeof(AccType)) {
+    bool aligned = true;
+    if (lane == 0) {
+      aligned &= 0 == cvta_to_global(dstPtr) % BigPackSize;
+      // Check alignment of all source pointers.
+      ((aligned &= 0 == cvta_to_global(srcPtrs) % BigPackSize), ...);
+    }
+    aligned = __all_sync(~0u, aligned);
+    if (aligned) {
+      reduceCopyPacks<Unroll, BigPackSize / sizeof(AccType), AccType, 1>(
+          nThreads, thread, nEltsBehind, nEltsAhead, srcPtrs..., dst);
+      if (nEltsAhead == 0)
+        return;
+
+      reduceCopyPacks<1, BigPackSize / sizeof(AccType), AccType, 1>(
+          nThreads, thread, nEltsBehind, nEltsAhead, srcPtrs..., dst);
+      if (nEltsAhead == 0)
+        return;
+    }
+  }
+
+  reduceCopyPacks<Unroll * (16 / sizeof(AccType)) / 2, 1, AccType, 1>(
+      nThreads, thread, nEltsBehind, nEltsAhead, srcPtrs..., dst);
+  if (nEltsAhead == 0)
+    return;
+
+  reduceCopyPacks<1, 1, AccType, 1>(
+      nThreads, thread, nEltsBehind, nEltsAhead, srcPtrs..., dst);
+}
+
+// Copy nElts elements of type T from srcPtr to dstPtr.
+// Uses a multi-pass vectorized packing strategy:
+//   1. Try 16-byte packs if pointers are aligned (bulk + tail).
+//   2. Fall back to sizeof(T)-byte packs (bulk + tail).
+template <int Unroll, typename T, typename IntBytes>
+__device__ __forceinline__ void
+copy(int thread, int nThreads, void* srcPtr, void* dstPtr, IntBytes nElts) {
+  int lane = thread % WARP_SIZE;
+  constexpr int BigPackSize = 16;
+
+  IntBytes nEltsBehind = 0;
+  IntBytes nEltsAhead = nElts;
+
+  T* src = static_cast<T*>(srcPtr);
+  T* dst = static_cast<T*>(dstPtr);
+
+  if constexpr (BigPackSize > sizeof(T)) {
+    // Check that both pointers are BigPackSize-aligned.
+    bool aligned = true;
+    if (lane == 0) {
+      aligned &= 0 == cvta_to_global(srcPtr) % BigPackSize;
+      aligned &= 0 == cvta_to_global(dstPtr) % BigPackSize;
+    }
+    aligned = __all_sync(~0u, aligned);
+    if (aligned) {
+      reduceCopyPacks<Unroll, BigPackSize / sizeof(T), T, 1>(
+          nThreads, thread, nEltsBehind, nEltsAhead, src, dst);
+      if (nEltsAhead == 0)
+        return;
+
+      reduceCopyPacks<1, BigPackSize / sizeof(T), T, 1>(
+          nThreads, thread, nEltsBehind, nEltsAhead, src, dst);
+      if (nEltsAhead == 0)
+        return;
+    }
+  }
+
+  reduceCopyPacks<Unroll * (16 / sizeof(T)) / 2, 1, T, 1>(
+      nThreads, thread, nEltsBehind, nEltsAhead, src, dst);
+  if (nEltsAhead == 0)
+    return;
+
+  reduceCopyPacks<1, 1, T, 1>(
+      nThreads, thread, nEltsBehind, nEltsAhead, src, dst);
+}
+
+// Reduce-sum nElts elements from multiple sources into a single destination.
+// Destination pointer comes first, followed by variadic source pointers.
+// Uses the same multi-pass vectorized packing strategy as copy():
+//   1. Try 16-byte packs if all pointers are aligned (bulk + tail).
+//   2. Fall back to sizeof(AccType)-byte packs (bulk + tail).
+template <
+    int Unroll,
+    typename AccType,
+    typename DstType,
+    typename IntBytes,
+    typename... SrcTs>
+__device__ __forceinline__ void reduceCopyMixed(
+    int thread,
+    int nThreads,
+    DstType* dstPtr,
+    IntBytes nElts,
+    SrcTs*... srcPtrs) {
+  int lane = thread % WARP_SIZE;
+  constexpr int BigPackSize = 16;
+  constexpr size_t kNSrcs = sizeof...(SrcTs);
+  static_assert(kNSrcs > 0, "reduceCopy requires at least one source");
+
+  IntBytes nEltsBehind = 0;
+  IntBytes nEltsAhead = nElts;
+
+  if constexpr (BigPackSize > sizeof(AccType)) {
+    bool aligned = true;
+    if (lane == 0) {
+      aligned &= 0 == cvta_to_global(dstPtr) % BigPackSize;
+      // Check alignment of all source pointers.
+      ((aligned &= 0 == cvta_to_global(srcPtrs) % BigPackSize), ...);
+    }
+    aligned = __all_sync(~0u, aligned);
+    if (aligned) {
+      reduceCopyPacks<Unroll, BigPackSize / sizeof(AccType), AccType, 1>(
+          nThreads, thread, nEltsBehind, nEltsAhead, srcPtrs..., dstPtr);
+      if (nEltsAhead == 0)
+        return;
+
+      reduceCopyPacks<1, BigPackSize / sizeof(AccType), AccType, 1>(
+          nThreads, thread, nEltsBehind, nEltsAhead, srcPtrs..., dstPtr);
+      if (nEltsAhead == 0)
+        return;
+    }
+  }
+
+  reduceCopyPacks<Unroll * (16 / sizeof(AccType)) / 2, 1, AccType, 1>(
+      nThreads, thread, nEltsBehind, nEltsAhead, srcPtrs..., dstPtr);
+  if (nEltsAhead == 0)
+    return;
+
+  reduceCopyPacks<1, 1, AccType, 1>(
+      nThreads, thread, nEltsBehind, nEltsAhead, srcPtrs..., dstPtr);
+}
+
+} // namespace meta::comms::ncclx::kernels::simplecopy

--- a/comms/ncclx/meta/collectives/kernels/reduce_copy_common.cuh
+++ b/comms/ncclx/meta/collectives/kernels/reduce_copy_common.cuh
@@ -1,0 +1,97 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#ifndef NCCL_REDUCE_COPY_COMMON_CUH_
+#define NCCL_REDUCE_COPY_COMMON_CUH_
+
+#include "meta/collectives/kernels/copy_iterator.cuh"
+#include "reduce_kernel.h" // FuncSum, applyReduce, applyCast
+
+namespace meta::comms::ncclx::kernels {
+
+// Compile-time iteration over source pointer indices [Begin, End).
+// Loads each source and reduces into the accumulator.
+template <size_t Begin, size_t End>
+struct ReduceSources {
+  template <int Unroll, int EltPerPack, typename AccType, typename IterType>
+  static __device__ __forceinline__ void apply(
+      BytePack<EltPerPack * sizeof(AccType)>* acc,
+      IterType& iter) {
+    using SrcType = typename IterType::template PtrType<Begin>;
+    // Enforce that we only accumulate from equal-or-lower precision sources
+    // into the accumulator type (e.g., fp16/bf16 -> fp32, fp32 -> fp32).
+    static_assert(
+        sizeof(SrcType) <= sizeof(AccType),
+        "SrcType must be of lower or same precision as AccType (by size).");
+
+    BytePack<EltPerPack * sizeof(SrcType)> tmp[Unroll];
+
+    auto redFn = FuncSum<AccType>{};
+
+    // Load from the current source pointer
+#pragma unroll Unroll
+    for (int u = 0; u < Unroll; u++) {
+      tmp[u] = ld_volatile_global<EltPerPack * sizeof(SrcType)>(
+          iter.template get<Begin>());
+      iter.template advanceUnroll<Begin>();
+    }
+
+    // Reduce into the accumulation buffer
+#pragma unroll Unroll
+    for (int u = 0; u < Unroll; u++) {
+      acc[u] = applyReduce(redFn, acc[u], applyCast<SrcType, AccType>(tmp[u]));
+    }
+
+    // Recurse to the next source pointer.
+    ReduceSources<Begin + 1, End>::template apply<Unroll, EltPerPack, AccType>(
+        acc, iter);
+  }
+};
+
+template <size_t End>
+struct ReduceSources<End, End> {
+  template <int Unroll, int EltPerPack, typename AccType, typename IterType>
+  static __device__ __forceinline__ void apply(
+      BytePack<EltPerPack * sizeof(AccType)>*,
+      IterType&) {}
+};
+
+template <int Unroll, int EltPerPack, typename AccType, typename IterType>
+static __device__ __forceinline__ void loadFirstSource(
+    BytePack<EltPerPack * sizeof(AccType)>* acc,
+    IterType& iter) {
+  using SrcType = typename IterType::template PtrType<0>;
+  // Enforce that we only accumulate from equal-or-lower precision sources into
+  // the accumulator type (e.g., fp16/bf16 -> fp32, fp32 -> fp32).
+  static_assert(
+      sizeof(SrcType) <= sizeof(AccType),
+      "SrcType must be of lower or same precision as AccType (by size).");
+
+  if constexpr (std::is_same_v<AccType, SrcType>) {
+    // If the accumulator and source types are the same, we can just load
+#pragma unroll Unroll
+    for (int u = 0; u < Unroll; u++) {
+      acc[u] = ld_volatile_global<EltPerPack * sizeof(SrcType)>(
+          iter.template get<0>());
+      iter.template advanceUnroll<0>();
+    }
+  } else {
+    // Otherwise, we need to use extra registers to cast the source to the
+    // accumulator type.
+    BytePack<EltPerPack * sizeof(SrcType)> tmp[Unroll];
+#pragma unroll Unroll
+    for (int u = 0; u < Unroll; u++) {
+      tmp[u] = ld_volatile_global<EltPerPack * sizeof(SrcType)>(
+          iter.template get<0>());
+      iter.template advanceUnroll<0>();
+    }
+
+#pragma unroll Unroll
+    for (int u = 0; u < Unroll; u++) {
+      acc[u] = applyCast<SrcType, AccType>(tmp[u]);
+    }
+  }
+}
+
+} // namespace meta::comms::ncclx::kernels
+
+#endif // NCCL_REDUCE_COPY_COMMON_CUH_

--- a/comms/ncclx/meta/collectives/tests/SimpleCopyMixedTest.cu
+++ b/comms/ncclx/meta/collectives/tests/SimpleCopyMixedTest.cu
@@ -1,0 +1,763 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+#include <cmath>
+#include <cstdint>
+#include <numeric>
+#include <vector>
+
+#include "meta/collectives/kernels/reduce_copy.cuh"
+
+// =============================================================================
+// Wrapper Kernels
+// =============================================================================
+
+// 1-src reduceCopyMixed: AccType accumulation, DstType output.
+template <int Unroll, typename AccType, typename DstType, typename Src0Type>
+__global__ __launch_bounds__(256, 1) void reduce_copy_mixed_1src_kernel(
+    DstType* dst,
+    const Src0Type* src0,
+    ssize_t nElts) {
+  auto thread = threadIdx.x + blockIdx.x * blockDim.x;
+  auto nThreads = blockDim.x * gridDim.x;
+  meta::comms::ncclx::kernels::simplecopy::reduceCopyMixed<Unroll, AccType>(
+      thread, nThreads, dst, nElts, src0);
+}
+
+// 2-src reduceCopyMixed: AccType accumulation, DstType output.
+template <
+    int Unroll,
+    typename AccType,
+    typename DstType,
+    typename Src0Type,
+    typename Src1Type>
+__global__ __launch_bounds__(256, 1) void reduce_copy_mixed_2src_kernel(
+    DstType* dst,
+    const Src0Type* src0,
+    const Src1Type* src1,
+    ssize_t nElts) {
+  auto thread = threadIdx.x + blockIdx.x * blockDim.x;
+  auto nThreads = blockDim.x * gridDim.x;
+  meta::comms::ncclx::kernels::simplecopy::reduceCopyMixed<Unroll, AccType>(
+      thread, nThreads, dst, nElts, src0, src1);
+}
+
+#define CUDACHECK(cmd)                                                    \
+  do {                                                                    \
+    cudaError_t e = cmd;                                                  \
+    ASSERT_EQ(e, cudaSuccess) << "CUDA error: " << cudaGetErrorString(e); \
+  } while (0)
+
+// =============================================================================
+// Test Fixture
+// =============================================================================
+
+class SimpleCopyMixedTest : public ::testing::Test {
+ protected:
+  static constexpr int64_t kMaxN = 4L * 1024L * 1024L + 16;
+  static constexpr int kBlockSize = 256;
+  static constexpr int kDefaultBlocks = 32;
+
+  float* d_srcFloat0 = nullptr;
+  float* d_srcFloat1 = nullptr;
+  float* d_dstFloat = nullptr;
+  __nv_bfloat16* d_srcBf16_0 = nullptr;
+  __nv_bfloat16* d_srcBf16_1 = nullptr;
+  __nv_bfloat16* d_dstBf16 = nullptr;
+
+  void SetUp() override {
+    CUDACHECK(cudaMalloc(&d_srcFloat0, kMaxN * sizeof(float)));
+    CUDACHECK(cudaMalloc(&d_srcFloat1, kMaxN * sizeof(float)));
+    CUDACHECK(cudaMalloc(&d_dstFloat, kMaxN * sizeof(float)));
+    CUDACHECK(cudaMalloc(&d_srcBf16_0, kMaxN * sizeof(__nv_bfloat16)));
+    CUDACHECK(cudaMalloc(&d_srcBf16_1, kMaxN * sizeof(__nv_bfloat16)));
+    CUDACHECK(cudaMalloc(&d_dstBf16, kMaxN * sizeof(__nv_bfloat16)));
+  }
+
+  void TearDown() override {
+    CUDACHECK(cudaFree(d_srcFloat0));
+    CUDACHECK(cudaFree(d_srcFloat1));
+    CUDACHECK(cudaFree(d_dstFloat));
+    CUDACHECK(cudaFree(d_srcBf16_0));
+    CUDACHECK(cudaFree(d_srcBf16_1));
+    CUDACHECK(cudaFree(d_dstBf16));
+  }
+};
+
+// =============================================================================
+// 1-src tests: FP32 -> FP32 (AccType=FP32, DstType=FP32, Src=FP32)
+// Degenerates to plain copy; verifies no cross-index contamination.
+// =============================================================================
+
+TEST_F(SimpleCopyMixedTest, Float_Float_1src_Aligned) {
+  constexpr int64_t sizes[] = {
+      32, 1024, 4L * 1024L * 1024L, 1000, 3000007, 4100000};
+
+  for (int64_t nElts : sizes) {
+    SCOPED_TRACE("nElts=" + std::to_string(nElts));
+
+    std::vector<float> h_src(nElts);
+    for (int64_t i = 0; i < nElts; i++) {
+      h_src[i] = static_cast<float>(i) * 0.5f + 1.0f;
+    }
+    CUDACHECK(cudaMemcpy(
+        d_srcFloat0,
+        h_src.data(),
+        nElts * sizeof(float),
+        cudaMemcpyHostToDevice));
+    CUDACHECK(cudaMemset(d_dstFloat, 0, nElts * sizeof(float)));
+
+    reduce_copy_mixed_1src_kernel<4, float, float, float>
+        <<<kDefaultBlocks, kBlockSize>>>(d_dstFloat, d_srcFloat0, nElts);
+    CUDACHECK(cudaGetLastError());
+    CUDACHECK(cudaDeviceSynchronize());
+
+    std::vector<float> h_dst(nElts);
+    CUDACHECK(cudaMemcpy(
+        h_dst.data(),
+        d_dstFloat,
+        nElts * sizeof(float),
+        cudaMemcpyDeviceToHost));
+    EXPECT_EQ(h_src, h_dst);
+  }
+}
+
+// =============================================================================
+// 1-src tests: BF16 -> FP32 (AccType=FP32, DstType=FP32, Src=BF16)
+// =============================================================================
+
+TEST_F(SimpleCopyMixedTest, Bf16Src_FloatDst_1src) {
+  constexpr int64_t nElts = 4L * 1024L * 1024L;
+
+  std::vector<float> h_srcFloat(nElts);
+  std::vector<__nv_bfloat16> h_srcBf16(nElts);
+  for (int64_t i = 0; i < nElts; i++) {
+    h_srcFloat[i] = static_cast<float>(i % 1000) * 0.25f;
+    h_srcBf16[i] = __float2bfloat16(h_srcFloat[i]);
+  }
+  CUDACHECK(cudaMemcpy(
+      d_srcBf16_0,
+      h_srcBf16.data(),
+      nElts * sizeof(__nv_bfloat16),
+      cudaMemcpyHostToDevice));
+  CUDACHECK(cudaMemset(d_dstFloat, 0, nElts * sizeof(float)));
+
+  reduce_copy_mixed_1src_kernel<4, float, float, __nv_bfloat16>
+      <<<kDefaultBlocks, kBlockSize>>>(d_dstFloat, d_srcBf16_0, nElts);
+  CUDACHECK(cudaGetLastError());
+  CUDACHECK(cudaDeviceSynchronize());
+
+  std::vector<float> h_dst(nElts);
+  CUDACHECK(cudaMemcpy(
+      h_dst.data(), d_dstFloat, nElts * sizeof(float), cudaMemcpyDeviceToHost));
+
+  // Each output should be the float representation of the bf16 value.
+  for (int64_t i = 0; i < nElts; i++) {
+    float expected = __bfloat162float(h_srcBf16[i]);
+    EXPECT_FLOAT_EQ(h_dst[i], expected) << "Mismatch at index " << i;
+  }
+}
+
+// =============================================================================
+// 1-src tests: FP32 -> BF16 (AccType=FP32, DstType=BF16, Src=FP32)
+// =============================================================================
+
+TEST_F(SimpleCopyMixedTest, FloatSrc_Bf16Dst_1src) {
+  constexpr int64_t nElts = 4L * 1024L * 1024L;
+
+  std::vector<float> h_src(nElts);
+  for (int64_t i = 0; i < nElts; i++) {
+    h_src[i] = static_cast<float>(i % 1000) * 0.25f;
+  }
+  CUDACHECK(cudaMemcpy(
+      d_srcFloat0,
+      h_src.data(),
+      nElts * sizeof(float),
+      cudaMemcpyHostToDevice));
+  CUDACHECK(cudaMemset(d_dstBf16, 0, nElts * sizeof(__nv_bfloat16)));
+
+  reduce_copy_mixed_1src_kernel<4, float, __nv_bfloat16, float>
+      <<<kDefaultBlocks, kBlockSize>>>(d_dstBf16, d_srcFloat0, nElts);
+  CUDACHECK(cudaGetLastError());
+  CUDACHECK(cudaDeviceSynchronize());
+
+  std::vector<__nv_bfloat16> h_dstBf16(nElts);
+  CUDACHECK(cudaMemcpy(
+      h_dstBf16.data(),
+      d_dstBf16,
+      nElts * sizeof(__nv_bfloat16),
+      cudaMemcpyDeviceToHost));
+
+  for (int64_t i = 0; i < nElts; i++) {
+    float result = __bfloat162float(h_dstBf16[i]);
+    // applyCast truncates FP32 -> BF16, so the result should be the truncated
+    // bf16 representation of the source.
+    float expected = __bfloat162float(__float2bfloat16(h_src[i]));
+    EXPECT_FLOAT_EQ(result, expected) << "Mismatch at index " << i;
+  }
+}
+
+// =============================================================================
+// 1-src tests: BF16 -> BF16 (AccType=FP32, DstType=BF16, Src=BF16)
+// =============================================================================
+
+TEST_F(SimpleCopyMixedTest, Bf16Src_Bf16Dst_1src) {
+  constexpr int64_t nElts = 4L * 1024L * 1024L;
+
+  std::vector<__nv_bfloat16> h_src(nElts);
+  for (int64_t i = 0; i < nElts; i++) {
+    h_src[i] = __float2bfloat16(static_cast<float>(i % 1000) * 0.25f);
+  }
+  CUDACHECK(cudaMemcpy(
+      d_srcBf16_0,
+      h_src.data(),
+      nElts * sizeof(__nv_bfloat16),
+      cudaMemcpyHostToDevice));
+  CUDACHECK(cudaMemset(d_dstBf16, 0, nElts * sizeof(__nv_bfloat16)));
+
+  reduce_copy_mixed_1src_kernel<4, float, __nv_bfloat16, __nv_bfloat16>
+      <<<kDefaultBlocks, kBlockSize>>>(d_dstBf16, d_srcBf16_0, nElts);
+  CUDACHECK(cudaGetLastError());
+  CUDACHECK(cudaDeviceSynchronize());
+
+  std::vector<__nv_bfloat16> h_dst(nElts);
+  CUDACHECK(cudaMemcpy(
+      h_dst.data(),
+      d_dstBf16,
+      nElts * sizeof(__nv_bfloat16),
+      cudaMemcpyDeviceToHost));
+
+  for (int64_t i = 0; i < nElts; i++) {
+    float result = __bfloat162float(h_dst[i]);
+    float expected = __bfloat162float(h_src[i]);
+    EXPECT_FLOAT_EQ(result, expected) << "Mismatch at index " << i;
+  }
+}
+
+// =============================================================================
+// 2-src tests: FP32 + FP32 -> FP32 (AccType=FP32)
+// Verifies sum and no cross-index contamination.
+// =============================================================================
+
+TEST_F(SimpleCopyMixedTest, FloatFloat_FloatDst_2src) {
+  constexpr int64_t sizes[] = {32, 1024, 4L * 1024L * 1024L, 1000, 3000007};
+
+  for (int64_t nElts : sizes) {
+    SCOPED_TRACE("nElts=" + std::to_string(nElts));
+
+    std::vector<float> h_src0(nElts), h_src1(nElts);
+    for (int64_t i = 0; i < nElts; i++) {
+      h_src0[i] = static_cast<float>(i);
+      h_src1[i] = static_cast<float>(i * 2 + 1);
+    }
+    CUDACHECK(cudaMemcpy(
+        d_srcFloat0,
+        h_src0.data(),
+        nElts * sizeof(float),
+        cudaMemcpyHostToDevice));
+    CUDACHECK(cudaMemcpy(
+        d_srcFloat1,
+        h_src1.data(),
+        nElts * sizeof(float),
+        cudaMemcpyHostToDevice));
+    CUDACHECK(cudaMemset(d_dstFloat, 0, nElts * sizeof(float)));
+
+    reduce_copy_mixed_2src_kernel<4, float, float, float, float>
+        <<<kDefaultBlocks, kBlockSize>>>(
+            d_dstFloat, d_srcFloat0, d_srcFloat1, nElts);
+    CUDACHECK(cudaGetLastError());
+    CUDACHECK(cudaDeviceSynchronize());
+
+    std::vector<float> h_dst(nElts);
+    CUDACHECK(cudaMemcpy(
+        h_dst.data(),
+        d_dstFloat,
+        nElts * sizeof(float),
+        cudaMemcpyDeviceToHost));
+
+    std::vector<float> expected(nElts);
+    for (int64_t i = 0; i < nElts; i++) {
+      expected[i] = h_src0[i] + h_src1[i];
+    }
+    EXPECT_EQ(h_dst, expected);
+  }
+}
+
+// =============================================================================
+// 2-src tests: BF16 + BF16 -> FP32 (AccType=FP32, DstType=FP32)
+// =============================================================================
+
+TEST_F(SimpleCopyMixedTest, Bf16Bf16_FloatDst_2src) {
+  constexpr int64_t nElts = 4L * 1024L * 1024L;
+
+  std::vector<float> h_src0Float(nElts), h_src1Float(nElts);
+  std::vector<__nv_bfloat16> h_src0(nElts), h_src1(nElts);
+  for (int64_t i = 0; i < nElts; i++) {
+    h_src0Float[i] = static_cast<float>(i % 500) * 0.1f;
+    h_src1Float[i] = static_cast<float>(i % 700) * 0.2f;
+    h_src0[i] = __float2bfloat16(h_src0Float[i]);
+    h_src1[i] = __float2bfloat16(h_src1Float[i]);
+  }
+  CUDACHECK(cudaMemcpy(
+      d_srcBf16_0,
+      h_src0.data(),
+      nElts * sizeof(__nv_bfloat16),
+      cudaMemcpyHostToDevice));
+  CUDACHECK(cudaMemcpy(
+      d_srcBf16_1,
+      h_src1.data(),
+      nElts * sizeof(__nv_bfloat16),
+      cudaMemcpyHostToDevice));
+  CUDACHECK(cudaMemset(d_dstFloat, 0, nElts * sizeof(float)));
+
+  reduce_copy_mixed_2src_kernel<4, float, float, __nv_bfloat16, __nv_bfloat16>
+      <<<kDefaultBlocks, kBlockSize>>>(
+          d_dstFloat, d_srcBf16_0, d_srcBf16_1, nElts);
+  CUDACHECK(cudaGetLastError());
+  CUDACHECK(cudaDeviceSynchronize());
+
+  std::vector<float> h_dst(nElts);
+  CUDACHECK(cudaMemcpy(
+      h_dst.data(), d_dstFloat, nElts * sizeof(float), cudaMemcpyDeviceToHost));
+
+  for (int64_t i = 0; i < nElts; i++) {
+    // Accumulation happens in FP32 after upcast from BF16
+    float expected = __bfloat162float(h_src0[i]) + __bfloat162float(h_src1[i]);
+    EXPECT_FLOAT_EQ(h_dst[i], expected) << "Mismatch at index " << i;
+  }
+}
+
+// =============================================================================
+// 2-src tests: BF16 + FP32 -> FP32 (AccType=FP32, mixed source types)
+// =============================================================================
+
+TEST_F(SimpleCopyMixedTest, Bf16Float_FloatDst_2src) {
+  constexpr int64_t nElts = 4L * 1024L * 1024L;
+
+  std::vector<__nv_bfloat16> h_srcBf16(nElts);
+  std::vector<float> h_srcFloat(nElts);
+  for (int64_t i = 0; i < nElts; i++) {
+    h_srcBf16[i] = __float2bfloat16(static_cast<float>(i % 500) * 0.1f);
+    h_srcFloat[i] = static_cast<float>(i % 700) * 0.2f;
+  }
+  CUDACHECK(cudaMemcpy(
+      d_srcBf16_0,
+      h_srcBf16.data(),
+      nElts * sizeof(__nv_bfloat16),
+      cudaMemcpyHostToDevice));
+  CUDACHECK(cudaMemcpy(
+      d_srcFloat1,
+      h_srcFloat.data(),
+      nElts * sizeof(float),
+      cudaMemcpyHostToDevice));
+  CUDACHECK(cudaMemset(d_dstFloat, 0, nElts * sizeof(float)));
+
+  reduce_copy_mixed_2src_kernel<4, float, float, __nv_bfloat16, float>
+      <<<kDefaultBlocks, kBlockSize>>>(
+          d_dstFloat, d_srcBf16_0, d_srcFloat1, nElts);
+  CUDACHECK(cudaGetLastError());
+  CUDACHECK(cudaDeviceSynchronize());
+
+  std::vector<float> h_dst(nElts);
+  CUDACHECK(cudaMemcpy(
+      h_dst.data(), d_dstFloat, nElts * sizeof(float), cudaMemcpyDeviceToHost));
+
+  for (int64_t i = 0; i < nElts; i++) {
+    float expected = __bfloat162float(h_srcBf16[i]) + h_srcFloat[i];
+    EXPECT_FLOAT_EQ(h_dst[i], expected) << "Mismatch at index " << i;
+  }
+}
+
+// =============================================================================
+// 2-src tests: FP32 + FP32 -> BF16 (AccType=FP32, DstType=BF16)
+// =============================================================================
+
+TEST_F(SimpleCopyMixedTest, FloatFloat_Bf16Dst_2src) {
+  constexpr int64_t nElts = 4L * 1024L * 1024L;
+
+  std::vector<float> h_src0(nElts), h_src1(nElts);
+  for (int64_t i = 0; i < nElts; i++) {
+    h_src0[i] = static_cast<float>(i % 500) * 0.1f;
+    h_src1[i] = static_cast<float>(i % 700) * 0.2f;
+  }
+  CUDACHECK(cudaMemcpy(
+      d_srcFloat0,
+      h_src0.data(),
+      nElts * sizeof(float),
+      cudaMemcpyHostToDevice));
+  CUDACHECK(cudaMemcpy(
+      d_srcFloat1,
+      h_src1.data(),
+      nElts * sizeof(float),
+      cudaMemcpyHostToDevice));
+  CUDACHECK(cudaMemset(d_dstBf16, 0, nElts * sizeof(__nv_bfloat16)));
+
+  reduce_copy_mixed_2src_kernel<4, float, __nv_bfloat16, float, float>
+      <<<kDefaultBlocks, kBlockSize>>>(
+          d_dstBf16, d_srcFloat0, d_srcFloat1, nElts);
+  CUDACHECK(cudaGetLastError());
+  CUDACHECK(cudaDeviceSynchronize());
+
+  std::vector<__nv_bfloat16> h_dstBf16(nElts);
+  CUDACHECK(cudaMemcpy(
+      h_dstBf16.data(),
+      d_dstBf16,
+      nElts * sizeof(__nv_bfloat16),
+      cudaMemcpyDeviceToHost));
+
+  for (int64_t i = 0; i < nElts; i++) {
+    float result = __bfloat162float(h_dstBf16[i]);
+    float sum = h_src0[i] + h_src1[i];
+    // applyCast truncates FP32->BF16
+    float expected = __bfloat162float(__float2bfloat16(sum));
+    EXPECT_FLOAT_EQ(result, expected) << "Mismatch at index " << i;
+  }
+}
+
+// =============================================================================
+// 2-src tests: BF16 + BF16 -> BF16 (AccType=FP32, all BF16 I/O)
+// =============================================================================
+
+TEST_F(SimpleCopyMixedTest, Bf16Bf16_Bf16Dst_2src) {
+  constexpr int64_t nElts = 4L * 1024L * 1024L;
+
+  std::vector<__nv_bfloat16> h_src0(nElts), h_src1(nElts);
+  for (int64_t i = 0; i < nElts; i++) {
+    h_src0[i] = __float2bfloat16(static_cast<float>(i % 500) * 0.1f);
+    h_src1[i] = __float2bfloat16(static_cast<float>(i % 700) * 0.2f);
+  }
+  CUDACHECK(cudaMemcpy(
+      d_srcBf16_0,
+      h_src0.data(),
+      nElts * sizeof(__nv_bfloat16),
+      cudaMemcpyHostToDevice));
+  CUDACHECK(cudaMemcpy(
+      d_srcBf16_1,
+      h_src1.data(),
+      nElts * sizeof(__nv_bfloat16),
+      cudaMemcpyHostToDevice));
+  CUDACHECK(cudaMemset(d_dstBf16, 0, nElts * sizeof(__nv_bfloat16)));
+
+  reduce_copy_mixed_2src_kernel<
+      4,
+      float,
+      __nv_bfloat16,
+      __nv_bfloat16,
+      __nv_bfloat16><<<kDefaultBlocks, kBlockSize>>>(
+      d_dstBf16, d_srcBf16_0, d_srcBf16_1, nElts);
+  CUDACHECK(cudaGetLastError());
+  CUDACHECK(cudaDeviceSynchronize());
+
+  std::vector<__nv_bfloat16> h_dst(nElts);
+  CUDACHECK(cudaMemcpy(
+      h_dst.data(),
+      d_dstBf16,
+      nElts * sizeof(__nv_bfloat16),
+      cudaMemcpyDeviceToHost));
+
+  for (int64_t i = 0; i < nElts; i++) {
+    float result = __bfloat162float(h_dst[i]);
+    // Accumulate in FP32, then truncate to BF16
+    float sum = __bfloat162float(h_src0[i]) + __bfloat162float(h_src1[i]);
+    float expected = __bfloat162float(__float2bfloat16(sum));
+    EXPECT_FLOAT_EQ(result, expected) << "Mismatch at index " << i;
+  }
+}
+
+// =============================================================================
+// 2-src tests: BF16 + FP32 -> BF16 (AccType=FP32, mixed src, BF16 dst)
+// =============================================================================
+
+TEST_F(SimpleCopyMixedTest, Bf16Float_Bf16Dst_2src) {
+  constexpr int64_t nElts = 4L * 1024L * 1024L;
+
+  std::vector<__nv_bfloat16> h_srcBf16(nElts);
+  std::vector<float> h_srcFloat(nElts);
+  for (int64_t i = 0; i < nElts; i++) {
+    h_srcBf16[i] = __float2bfloat16(static_cast<float>(i % 500) * 0.1f);
+    h_srcFloat[i] = static_cast<float>(i % 700) * 0.2f;
+  }
+  CUDACHECK(cudaMemcpy(
+      d_srcBf16_0,
+      h_srcBf16.data(),
+      nElts * sizeof(__nv_bfloat16),
+      cudaMemcpyHostToDevice));
+  CUDACHECK(cudaMemcpy(
+      d_srcFloat1,
+      h_srcFloat.data(),
+      nElts * sizeof(float),
+      cudaMemcpyHostToDevice));
+  CUDACHECK(cudaMemset(d_dstBf16, 0, nElts * sizeof(__nv_bfloat16)));
+
+  reduce_copy_mixed_2src_kernel<4, float, __nv_bfloat16, __nv_bfloat16, float>
+      <<<kDefaultBlocks, kBlockSize>>>(
+          d_dstBf16, d_srcBf16_0, d_srcFloat1, nElts);
+  CUDACHECK(cudaGetLastError());
+  CUDACHECK(cudaDeviceSynchronize());
+
+  std::vector<__nv_bfloat16> h_dstBf16(nElts);
+  CUDACHECK(cudaMemcpy(
+      h_dstBf16.data(),
+      d_dstBf16,
+      nElts * sizeof(__nv_bfloat16),
+      cudaMemcpyDeviceToHost));
+
+  for (int64_t i = 0; i < nElts; i++) {
+    float result = __bfloat162float(h_dstBf16[i]);
+    float sum = __bfloat162float(h_srcBf16[i]) + h_srcFloat[i];
+    float expected = __bfloat162float(__float2bfloat16(sum));
+    EXPECT_FLOAT_EQ(result, expected) << "Mismatch at index " << i;
+  }
+}
+
+// =============================================================================
+// 2-src tests: FP32 + BF16 -> FP32 (AccType=FP32, reversed order from above)
+// =============================================================================
+
+TEST_F(SimpleCopyMixedTest, FloatBf16_FloatDst_2src) {
+  constexpr int64_t nElts = 4L * 1024L * 1024L;
+
+  std::vector<float> h_srcFloat(nElts);
+  std::vector<__nv_bfloat16> h_srcBf16(nElts);
+  for (int64_t i = 0; i < nElts; i++) {
+    h_srcFloat[i] = static_cast<float>(i % 500) * 0.1f;
+    h_srcBf16[i] = __float2bfloat16(static_cast<float>(i % 700) * 0.2f);
+  }
+  CUDACHECK(cudaMemcpy(
+      d_srcFloat0,
+      h_srcFloat.data(),
+      nElts * sizeof(float),
+      cudaMemcpyHostToDevice));
+  CUDACHECK(cudaMemcpy(
+      d_srcBf16_1,
+      h_srcBf16.data(),
+      nElts * sizeof(__nv_bfloat16),
+      cudaMemcpyHostToDevice));
+  CUDACHECK(cudaMemset(d_dstFloat, 0, nElts * sizeof(float)));
+
+  reduce_copy_mixed_2src_kernel<4, float, float, float, __nv_bfloat16>
+      <<<kDefaultBlocks, kBlockSize>>>(
+          d_dstFloat, d_srcFloat0, d_srcBf16_1, nElts);
+  CUDACHECK(cudaGetLastError());
+  CUDACHECK(cudaDeviceSynchronize());
+
+  std::vector<float> h_dst(nElts);
+  CUDACHECK(cudaMemcpy(
+      h_dst.data(), d_dstFloat, nElts * sizeof(float), cudaMemcpyDeviceToHost));
+
+  for (int64_t i = 0; i < nElts; i++) {
+    float expected = h_srcFloat[i] + __bfloat162float(h_srcBf16[i]);
+    EXPECT_FLOAT_EQ(h_dst[i], expected) << "Mismatch at index " << i;
+  }
+}
+
+// =============================================================================
+// Cross-index contamination test: Use unique per-element values to verify
+// that element i is never mixed with element j.
+// =============================================================================
+
+TEST_F(SimpleCopyMixedTest, NoIndexCrossContamination_2src) {
+  // Use small non-power-of-2 sizes to stress tail paths.
+  constexpr int64_t sizes[] = {1, 2, 31, 33, 127, 129, 1000, 4100000};
+
+  for (int64_t nElts : sizes) {
+    SCOPED_TRACE("nElts=" + std::to_string(nElts));
+
+    // Use primes to make collisions between indices extremely unlikely.
+    std::vector<float> h_src0(nElts), h_src1(nElts);
+    for (int64_t i = 0; i < nElts; i++) {
+      h_src0[i] = static_cast<float>(i * 7 + 3);
+      h_src1[i] = static_cast<float>(i * 13 + 5);
+    }
+    CUDACHECK(cudaMemcpy(
+        d_srcFloat0,
+        h_src0.data(),
+        nElts * sizeof(float),
+        cudaMemcpyHostToDevice));
+    CUDACHECK(cudaMemcpy(
+        d_srcFloat1,
+        h_src1.data(),
+        nElts * sizeof(float),
+        cudaMemcpyHostToDevice));
+    CUDACHECK(cudaMemset(d_dstFloat, 0, nElts * sizeof(float)));
+
+    reduce_copy_mixed_2src_kernel<4, float, float, float, float>
+        <<<kDefaultBlocks, kBlockSize>>>(
+            d_dstFloat, d_srcFloat0, d_srcFloat1, nElts);
+    CUDACHECK(cudaGetLastError());
+    CUDACHECK(cudaDeviceSynchronize());
+
+    std::vector<float> h_dst(nElts);
+    CUDACHECK(cudaMemcpy(
+        h_dst.data(),
+        d_dstFloat,
+        nElts * sizeof(float),
+        cudaMemcpyDeviceToHost));
+
+    std::vector<float> expected(nElts);
+    for (int64_t i = 0; i < nElts; i++) {
+      expected[i] = h_src0[i] + h_src1[i];
+    }
+    EXPECT_EQ(h_dst, expected);
+  }
+}
+
+// =============================================================================
+// Cross-index contamination test with mixed BF16+FP32 sources.
+// =============================================================================
+
+TEST_F(SimpleCopyMixedTest, NoIndexCrossContamination_Bf16Float_2src) {
+  constexpr int64_t sizes[] = {1, 33, 127, 1000, 4100000};
+
+  for (int64_t nElts : sizes) {
+    SCOPED_TRACE("nElts=" + std::to_string(nElts));
+
+    std::vector<__nv_bfloat16> h_src0(nElts);
+    std::vector<float> h_src1(nElts);
+    for (int64_t i = 0; i < nElts; i++) {
+      h_src0[i] = __float2bfloat16(static_cast<float>(i * 7 + 3));
+      h_src1[i] = static_cast<float>(i * 13 + 5);
+    }
+    CUDACHECK(cudaMemcpy(
+        d_srcBf16_0,
+        h_src0.data(),
+        nElts * sizeof(__nv_bfloat16),
+        cudaMemcpyHostToDevice));
+    CUDACHECK(cudaMemcpy(
+        d_srcFloat1,
+        h_src1.data(),
+        nElts * sizeof(float),
+        cudaMemcpyHostToDevice));
+    CUDACHECK(cudaMemset(d_dstFloat, 0, nElts * sizeof(float)));
+
+    reduce_copy_mixed_2src_kernel<4, float, float, __nv_bfloat16, float>
+        <<<kDefaultBlocks, kBlockSize>>>(
+            d_dstFloat, d_srcBf16_0, d_srcFloat1, nElts);
+    CUDACHECK(cudaGetLastError());
+    CUDACHECK(cudaDeviceSynchronize());
+
+    std::vector<float> h_dst(nElts);
+    CUDACHECK(cudaMemcpy(
+        h_dst.data(),
+        d_dstFloat,
+        nElts * sizeof(float),
+        cudaMemcpyDeviceToHost));
+
+    for (int64_t i = 0; i < nElts; i++) {
+      float expected = __bfloat162float(h_src0[i]) + h_src1[i];
+      EXPECT_FLOAT_EQ(h_dst[i], expected) << "Mismatch at index " << i;
+    }
+  }
+}
+
+// =============================================================================
+// Small sizes: edge cases for tail logic
+// =============================================================================
+
+TEST_F(SimpleCopyMixedTest, SmallSizes_MixedTypes) {
+  constexpr int64_t sizes[] = {0, 1, 2, 31, 32, 33, 127, 128, 129};
+
+  for (int64_t nElts : sizes) {
+    SCOPED_TRACE("nElts=" + std::to_string(nElts));
+    if (nElts == 0) {
+      reduce_copy_mixed_2src_kernel<4, float, float, __nv_bfloat16, float>
+          <<<kDefaultBlocks, kBlockSize>>>(
+              d_dstFloat, d_srcBf16_0, d_srcFloat1, 0);
+      CUDACHECK(cudaGetLastError());
+      CUDACHECK(cudaDeviceSynchronize());
+      continue;
+    }
+
+    std::vector<__nv_bfloat16> h_src0(nElts);
+    std::vector<float> h_src1(nElts);
+    for (int64_t i = 0; i < nElts; i++) {
+      h_src0[i] = __float2bfloat16(static_cast<float>(i + 1));
+      h_src1[i] = static_cast<float>(i * 3);
+    }
+    CUDACHECK(cudaMemcpy(
+        d_srcBf16_0,
+        h_src0.data(),
+        nElts * sizeof(__nv_bfloat16),
+        cudaMemcpyHostToDevice));
+    CUDACHECK(cudaMemcpy(
+        d_srcFloat1,
+        h_src1.data(),
+        nElts * sizeof(float),
+        cudaMemcpyHostToDevice));
+    CUDACHECK(cudaMemset(d_dstFloat, 0, nElts * sizeof(float)));
+
+    reduce_copy_mixed_2src_kernel<4, float, float, __nv_bfloat16, float>
+        <<<kDefaultBlocks, kBlockSize>>>(
+            d_dstFloat, d_srcBf16_0, d_srcFloat1, nElts);
+    CUDACHECK(cudaGetLastError());
+    CUDACHECK(cudaDeviceSynchronize());
+
+    std::vector<float> h_dst(nElts);
+    CUDACHECK(cudaMemcpy(
+        h_dst.data(),
+        d_dstFloat,
+        nElts * sizeof(float),
+        cudaMemcpyDeviceToHost));
+
+    for (int64_t i = 0; i < nElts; i++) {
+      float expected = __bfloat162float(h_src0[i]) + h_src1[i];
+      EXPECT_FLOAT_EQ(h_dst[i], expected) << "Mismatch at index " << i;
+    }
+  }
+}
+
+// =============================================================================
+// Unroll variants: verify all Unroll values work.
+// =============================================================================
+
+TEST_F(SimpleCopyMixedTest, UnrollVariants_Bf16Float_FloatDst) {
+  constexpr int64_t nElts = 4L * 1024L * 1024L;
+
+  std::vector<__nv_bfloat16> h_src0(nElts);
+  std::vector<float> h_src1(nElts);
+  for (int64_t i = 0; i < nElts; i++) {
+    h_src0[i] = __float2bfloat16(static_cast<float>(i % 500));
+    h_src1[i] = static_cast<float>(i % 700);
+  }
+  CUDACHECK(cudaMemcpy(
+      d_srcBf16_0,
+      h_src0.data(),
+      nElts * sizeof(__nv_bfloat16),
+      cudaMemcpyHostToDevice));
+  CUDACHECK(cudaMemcpy(
+      d_srcFloat1,
+      h_src1.data(),
+      nElts * sizeof(float),
+      cudaMemcpyHostToDevice));
+
+  auto test = [&](auto unrollTag) {
+    constexpr int U = decltype(unrollTag)::value;
+    SCOPED_TRACE("Unroll=" + std::to_string(U));
+    CUDACHECK(cudaMemset(d_dstFloat, 0, nElts * sizeof(float)));
+
+    reduce_copy_mixed_2src_kernel<U, float, float, __nv_bfloat16, float>
+        <<<kDefaultBlocks, kBlockSize>>>(
+            d_dstFloat, d_srcBf16_0, d_srcFloat1, nElts);
+    CUDACHECK(cudaGetLastError());
+    CUDACHECK(cudaDeviceSynchronize());
+
+    std::vector<float> h_dst(nElts);
+    CUDACHECK(cudaMemcpy(
+        h_dst.data(),
+        d_dstFloat,
+        nElts * sizeof(float),
+        cudaMemcpyDeviceToHost));
+
+    for (int64_t i = 0; i < nElts; i++) {
+      float expected = __bfloat162float(h_src0[i]) + h_src1[i];
+      EXPECT_FLOAT_EQ(h_dst[i], expected) << "Mismatch at index " << i;
+    }
+  };
+
+  test(std::integral_constant<int, 1>{});
+  test(std::integral_constant<int, 2>{});
+  test(std::integral_constant<int, 4>{});
+  test(std::integral_constant<int, 8>{});
+}

--- a/comms/ncclx/meta/collectives/tests/SimpleCopyTest.cu
+++ b/comms/ncclx/meta/collectives/tests/SimpleCopyTest.cu
@@ -1,0 +1,425 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <numeric>
+#include <vector>
+
+#include "meta/collectives/kernels/reduce_copy.cuh"
+
+// Wrapper kernel for the vectorized copy __device__ function.
+template <int Unroll, typename T>
+__global__ void copy_kernel(T* dst, const T* src, ssize_t nElts) {
+  auto thread = threadIdx.x + blockIdx.x * blockDim.x;
+  auto nThreads = blockDim.x * gridDim.x;
+  meta::comms::ncclx::kernels::simplecopy::copy<Unroll, T>(
+      thread, nThreads, (void*)src, (void*)dst, nElts);
+}
+
+// Wrapper kernel for reduceCopy with 2 sources.
+template <int Unroll, typename T>
+__global__ void
+reduce_copy_2src_kernel(T* dst, const T* src0, const T* src1, ssize_t nElts) {
+  auto thread = threadIdx.x + blockIdx.x * blockDim.x;
+  auto nThreads = blockDim.x * gridDim.x;
+  meta::comms::ncclx::kernels::simplecopy::reduceCopy<Unroll, T>(
+      thread, nThreads, (void*)dst, nElts, src0, src1);
+}
+
+// Wrapper kernel for reduceCopy with 3 sources.
+template <int Unroll, typename T>
+__global__ void reduce_copy_3src_kernel(
+    T* dst,
+    const T* src0,
+    const T* src1,
+    const T* src2,
+    ssize_t nElts) {
+  auto thread = threadIdx.x + blockIdx.x * blockDim.x;
+  auto nThreads = blockDim.x * gridDim.x;
+  meta::comms::ncclx::kernels::simplecopy::reduceCopy<Unroll, T>(
+      thread, nThreads, (void*)dst, nElts, src0, src1, src2);
+}
+
+// Wrapper kernel for reduceCopy with 1 source (degenerates to plain copy).
+template <int Unroll, typename T>
+__global__ void reduce_copy_1src_kernel(T* dst, const T* src, ssize_t nElts) {
+  auto thread = threadIdx.x + blockIdx.x * blockDim.x;
+  auto nThreads = blockDim.x * gridDim.x;
+  meta::comms::ncclx::kernels::simplecopy::reduceCopy<Unroll, T>(
+      thread, nThreads, (void*)dst, nElts, src);
+}
+
+#define CUDACHECK(cmd)                                                    \
+  do {                                                                    \
+    cudaError_t e = cmd;                                                  \
+    ASSERT_EQ(e, cudaSuccess) << "CUDA error: " << cudaGetErrorString(e); \
+  } while (0)
+
+class SimpleCopyTest : public ::testing::Test {
+ protected:
+  static constexpr int64_t kMaxN = 4L * 1024L * 1024L + 16;
+  static constexpr int kBlockSize = 256;
+  static constexpr int kDefaultBlocks = 32;
+
+  int* d_src = nullptr;
+  int* d_dst = nullptr;
+  // Additional source buffers for reduce-copy tests.
+  int* d_src1 = nullptr;
+  int* d_src2 = nullptr;
+
+  void SetUp() override {
+    CUDACHECK(cudaMalloc(&d_src, kMaxN * sizeof(int)));
+    CUDACHECK(cudaMalloc(&d_dst, kMaxN * sizeof(int)));
+    CUDACHECK(cudaMalloc(&d_src1, kMaxN * sizeof(int)));
+    CUDACHECK(cudaMalloc(&d_src2, kMaxN * sizeof(int)));
+  }
+
+  void TearDown() override {
+    CUDACHECK(cudaFree(d_src));
+    CUDACHECK(cudaFree(d_dst));
+    CUDACHECK(cudaFree(d_src1));
+    CUDACHECK(cudaFree(d_src2));
+  }
+
+  // Fill src with sequential ints, zero dst, launch kernel, verify dst == src.
+  template <typename LaunchFn>
+  void verifyCopy(int* src, int* dst, int64_t nElts, LaunchFn launchFn) {
+    if (nElts == 0) {
+      launchFn(dst, src, 0);
+      CUDACHECK(cudaGetLastError());
+      CUDACHECK(cudaDeviceSynchronize());
+      return;
+    }
+
+    std::vector<int> h_src(nElts);
+    std::iota(h_src.begin(), h_src.end(), 0);
+    CUDACHECK(cudaMemcpy(
+        src, h_src.data(), nElts * sizeof(int), cudaMemcpyHostToDevice));
+    CUDACHECK(cudaMemset(dst, 0, nElts * sizeof(int)));
+
+    launchFn(dst, src, nElts);
+    CUDACHECK(cudaGetLastError());
+    CUDACHECK(cudaDeviceSynchronize());
+
+    std::vector<int> h_dst(nElts);
+    CUDACHECK(cudaMemcpy(
+        h_dst.data(), dst, nElts * sizeof(int), cudaMemcpyDeviceToHost));
+
+    EXPECT_EQ(h_src, h_dst);
+  }
+};
+
+// Aligned pointers, various sizes (exercises 16-byte aligned fast path).
+TEST_F(SimpleCopyTest, CopyAligned) {
+  constexpr int64_t sizes[] = {
+      32, 1024, 4L * 1024L * 1024L, 1000, 3000007, 4100000};
+
+  for (int64_t nElts : sizes) {
+    SCOPED_TRACE("nElts=" + std::to_string(nElts));
+    verifyCopy(d_src, d_dst, nElts, [&](int* dst, int* src, ssize_t n) {
+      copy_kernel<4, int><<<kDefaultBlocks, kBlockSize>>>(dst, src, n);
+      CUDACHECK(cudaGetLastError());
+    });
+  }
+}
+
+// Misaligned pointers (exercises fallback path without 16-byte vectorization).
+TEST_F(SimpleCopyTest, CopyMisaligned) {
+  struct Config {
+    int srcOff;
+    int dstOff;
+    int64_t nElts;
+  };
+
+  constexpr Config configs[] = {
+      {1, 1, 4000000},
+      {3, 3, 3000007},
+      {1, 3, 4100000},
+      {0, 1, 3999999},
+  };
+
+  for (const auto& cfg : configs) {
+    SCOPED_TRACE(
+        "srcOff=" + std::to_string(cfg.srcOff) + " dstOff=" +
+        std::to_string(cfg.dstOff) + " nElts=" + std::to_string(cfg.nElts));
+    verifyCopy(
+        d_src + cfg.srcOff,
+        d_dst + cfg.dstOff,
+        cfg.nElts,
+        [&](int* dst, int* src, ssize_t n) {
+          copy_kernel<4, int><<<kDefaultBlocks, kBlockSize>>>(dst, src, n);
+          CUDACHECK(cudaGetLastError());
+        });
+  }
+}
+
+// Edge cases with small element counts (stresses tail/partial logic).
+TEST_F(SimpleCopyTest, CopySmallSizes) {
+  constexpr int64_t sizes[] = {0, 1, 2, 31, 32, 33, 127, 128, 129};
+
+  for (int64_t nElts : sizes) {
+    SCOPED_TRACE("nElts=" + std::to_string(nElts));
+    verifyCopy(d_src, d_dst, nElts, [&](int* dst, int* src, ssize_t n) {
+      copy_kernel<4, int><<<kDefaultBlocks, kBlockSize>>>(dst, src, n);
+      CUDACHECK(cudaGetLastError());
+    });
+  }
+}
+
+// All Unroll values with a fixed size.
+TEST_F(SimpleCopyTest, CopyUnrollVariants) {
+  constexpr int64_t nElts = 4L * 1024L * 1024L;
+
+  auto test = [&](auto unrollTag) {
+    constexpr int U = decltype(unrollTag)::value;
+    SCOPED_TRACE("Unroll=" + std::to_string(U));
+    verifyCopy(d_src, d_dst, nElts, [&](int* dst, int* src, ssize_t n) {
+      copy_kernel<U, int><<<kDefaultBlocks, kBlockSize>>>(dst, src, n);
+      CUDACHECK(cudaGetLastError());
+    });
+  };
+
+  test(std::integral_constant<int, 1>{});
+  test(std::integral_constant<int, 2>{});
+  test(std::integral_constant<int, 4>{});
+  test(std::integral_constant<int, 8>{});
+}
+
+// =============================================================================
+// Reduce-copy tests
+// =============================================================================
+
+// 2-source reduce-copy: verify dst[i] == src0[i] + src1[i].
+TEST_F(SimpleCopyTest, ReduceCopy2Sources) {
+  constexpr int64_t sizes[] = {
+      32, 1024, 4L * 1024L * 1024L, 1000, 3000007, 4100000};
+
+  for (int64_t nElts : sizes) {
+    SCOPED_TRACE("nElts=" + std::to_string(nElts));
+
+    std::vector<int> h_src0(nElts);
+    std::vector<int> h_src1(nElts);
+    for (int64_t i = 0; i < nElts; i++) {
+      h_src0[i] = static_cast<int>(i);
+      h_src1[i] = static_cast<int>(i * 2 + 1);
+    }
+    CUDACHECK(cudaMemcpy(
+        d_src, h_src0.data(), nElts * sizeof(int), cudaMemcpyHostToDevice));
+    CUDACHECK(cudaMemcpy(
+        d_src1, h_src1.data(), nElts * sizeof(int), cudaMemcpyHostToDevice));
+    CUDACHECK(cudaMemset(d_dst, 0, nElts * sizeof(int)));
+
+    reduce_copy_2src_kernel<4, int>
+        <<<kDefaultBlocks, kBlockSize>>>(d_dst, d_src, d_src1, nElts);
+    CUDACHECK(cudaGetLastError());
+    CUDACHECK(cudaDeviceSynchronize());
+
+    std::vector<int> h_dst(nElts);
+    CUDACHECK(cudaMemcpy(
+        h_dst.data(), d_dst, nElts * sizeof(int), cudaMemcpyDeviceToHost));
+
+    std::vector<int> expected(nElts);
+    for (int64_t i = 0; i < nElts; i++) {
+      expected[i] = h_src0[i] + h_src1[i];
+    }
+    EXPECT_EQ(h_dst, expected);
+  }
+}
+
+// 3-source reduce-copy: verify dst[i] == src0[i] + src1[i] + src2[i].
+TEST_F(SimpleCopyTest, ReduceCopy3Sources) {
+  constexpr int64_t nElts = 4L * 1024L * 1024L;
+
+  std::vector<int> h_src0(nElts);
+  std::vector<int> h_src1(nElts);
+  std::vector<int> h_src2(nElts);
+  for (int64_t i = 0; i < nElts; i++) {
+    h_src0[i] = static_cast<int>(i);
+    h_src1[i] = static_cast<int>(i * 2 + 1);
+    h_src2[i] = static_cast<int>(i * 3 + 7);
+  }
+  CUDACHECK(cudaMemcpy(
+      d_src, h_src0.data(), nElts * sizeof(int), cudaMemcpyHostToDevice));
+  CUDACHECK(cudaMemcpy(
+      d_src1, h_src1.data(), nElts * sizeof(int), cudaMemcpyHostToDevice));
+  CUDACHECK(cudaMemcpy(
+      d_src2, h_src2.data(), nElts * sizeof(int), cudaMemcpyHostToDevice));
+  CUDACHECK(cudaMemset(d_dst, 0, nElts * sizeof(int)));
+
+  reduce_copy_3src_kernel<4, int>
+      <<<kDefaultBlocks, kBlockSize>>>(d_dst, d_src, d_src1, d_src2, nElts);
+  CUDACHECK(cudaGetLastError());
+  CUDACHECK(cudaDeviceSynchronize());
+
+  std::vector<int> h_dst(nElts);
+  CUDACHECK(cudaMemcpy(
+      h_dst.data(), d_dst, nElts * sizeof(int), cudaMemcpyDeviceToHost));
+
+  std::vector<int> expected(nElts);
+  for (int64_t i = 0; i < nElts; i++) {
+    expected[i] = h_src0[i] + h_src1[i] + h_src2[i];
+  }
+  EXPECT_EQ(h_dst, expected);
+}
+
+// 1-source reduce-copy: degenerates to plain copy.
+TEST_F(SimpleCopyTest, ReduceCopy1Source) {
+  constexpr int64_t nElts = 4L * 1024L * 1024L;
+
+  std::vector<int> h_src(nElts);
+  std::iota(h_src.begin(), h_src.end(), 0);
+  CUDACHECK(cudaMemcpy(
+      d_src, h_src.data(), nElts * sizeof(int), cudaMemcpyHostToDevice));
+  CUDACHECK(cudaMemset(d_dst, 0, nElts * sizeof(int)));
+
+  reduce_copy_1src_kernel<4, int>
+      <<<kDefaultBlocks, kBlockSize>>>(d_dst, d_src, nElts);
+  CUDACHECK(cudaGetLastError());
+  CUDACHECK(cudaDeviceSynchronize());
+
+  std::vector<int> h_dst(nElts);
+  CUDACHECK(cudaMemcpy(
+      h_dst.data(), d_dst, nElts * sizeof(int), cudaMemcpyDeviceToHost));
+  EXPECT_EQ(h_src, h_dst);
+}
+
+// Reduce-copy with small sizes.
+TEST_F(SimpleCopyTest, ReduceCopySmallSizes) {
+  constexpr int64_t sizes[] = {0, 1, 2, 31, 32, 33, 127, 128, 129};
+
+  for (int64_t nElts : sizes) {
+    SCOPED_TRACE("nElts=" + std::to_string(nElts));
+    if (nElts == 0) {
+      reduce_copy_2src_kernel<4, int>
+          <<<kDefaultBlocks, kBlockSize>>>(d_dst, d_src, d_src1, 0);
+      CUDACHECK(cudaGetLastError());
+      CUDACHECK(cudaDeviceSynchronize());
+      continue;
+    }
+
+    std::vector<int> h_src0(nElts);
+    std::vector<int> h_src1(nElts);
+    for (int64_t i = 0; i < nElts; i++) {
+      h_src0[i] = static_cast<int>(i + 1);
+      h_src1[i] = static_cast<int>(i * 3);
+    }
+    CUDACHECK(cudaMemcpy(
+        d_src, h_src0.data(), nElts * sizeof(int), cudaMemcpyHostToDevice));
+    CUDACHECK(cudaMemcpy(
+        d_src1, h_src1.data(), nElts * sizeof(int), cudaMemcpyHostToDevice));
+    CUDACHECK(cudaMemset(d_dst, 0, nElts * sizeof(int)));
+
+    reduce_copy_2src_kernel<4, int>
+        <<<kDefaultBlocks, kBlockSize>>>(d_dst, d_src, d_src1, nElts);
+    CUDACHECK(cudaGetLastError());
+    CUDACHECK(cudaDeviceSynchronize());
+
+    std::vector<int> h_dst(nElts);
+    CUDACHECK(cudaMemcpy(
+        h_dst.data(), d_dst, nElts * sizeof(int), cudaMemcpyDeviceToHost));
+
+    std::vector<int> expected(nElts);
+    for (int64_t i = 0; i < nElts; i++) {
+      expected[i] = h_src0[i] + h_src1[i];
+    }
+    EXPECT_EQ(h_dst, expected);
+  }
+}
+
+// Reduce-copy with misaligned pointers.
+TEST_F(SimpleCopyTest, ReduceCopyMisaligned) {
+  struct Config {
+    int src0Off;
+    int src1Off;
+    int dstOff;
+    int64_t nElts;
+  };
+
+  constexpr Config configs[] = {
+      {1, 1, 1, 4000000},
+      {3, 3, 3, 3000007},
+      {1, 3, 0, 4100000},
+      {0, 1, 3, 3999999},
+  };
+
+  for (const auto& cfg : configs) {
+    SCOPED_TRACE(
+        "src0Off=" + std::to_string(cfg.src0Off) + " src1Off=" +
+        std::to_string(cfg.src1Off) + " dstOff=" + std::to_string(cfg.dstOff) +
+        " nElts=" + std::to_string(cfg.nElts));
+
+    int* src0 = d_src + cfg.src0Off;
+    int* src1 = d_src1 + cfg.src1Off;
+    int* dst = d_dst + cfg.dstOff;
+
+    std::vector<int> h_src0(cfg.nElts);
+    std::vector<int> h_src1(cfg.nElts);
+    for (int64_t i = 0; i < cfg.nElts; i++) {
+      h_src0[i] = static_cast<int>(i);
+      h_src1[i] = static_cast<int>(i * 2 + 1);
+    }
+    CUDACHECK(cudaMemcpy(
+        src0, h_src0.data(), cfg.nElts * sizeof(int), cudaMemcpyHostToDevice));
+    CUDACHECK(cudaMemcpy(
+        src1, h_src1.data(), cfg.nElts * sizeof(int), cudaMemcpyHostToDevice));
+    CUDACHECK(cudaMemset(dst, 0, cfg.nElts * sizeof(int)));
+
+    reduce_copy_2src_kernel<4, int>
+        <<<kDefaultBlocks, kBlockSize>>>(dst, src0, src1, cfg.nElts);
+    CUDACHECK(cudaGetLastError());
+    CUDACHECK(cudaDeviceSynchronize());
+
+    std::vector<int> h_dst(cfg.nElts);
+    CUDACHECK(cudaMemcpy(
+        h_dst.data(), dst, cfg.nElts * sizeof(int), cudaMemcpyDeviceToHost));
+
+    std::vector<int> expected(cfg.nElts);
+    for (int64_t i = 0; i < cfg.nElts; i++) {
+      expected[i] = h_src0[i] + h_src1[i];
+    }
+    EXPECT_EQ(h_dst, expected);
+  }
+}
+
+// Reduce-copy with different Unroll values.
+TEST_F(SimpleCopyTest, ReduceCopyUnrollVariants) {
+  constexpr int64_t nElts = 4L * 1024L * 1024L;
+
+  std::vector<int> h_src0(nElts);
+  std::vector<int> h_src1(nElts);
+  for (int64_t i = 0; i < nElts; i++) {
+    h_src0[i] = static_cast<int>(i);
+    h_src1[i] = static_cast<int>(i * 2 + 1);
+  }
+  CUDACHECK(cudaMemcpy(
+      d_src, h_src0.data(), nElts * sizeof(int), cudaMemcpyHostToDevice));
+  CUDACHECK(cudaMemcpy(
+      d_src1, h_src1.data(), nElts * sizeof(int), cudaMemcpyHostToDevice));
+
+  std::vector<int> expected(nElts);
+  for (int64_t i = 0; i < nElts; i++) {
+    expected[i] = h_src0[i] + h_src1[i];
+  }
+
+  auto test = [&](auto unrollTag) {
+    constexpr int U = decltype(unrollTag)::value;
+    SCOPED_TRACE("Unroll=" + std::to_string(U));
+    CUDACHECK(cudaMemset(d_dst, 0, nElts * sizeof(int)));
+
+    reduce_copy_2src_kernel<U, int>
+        <<<kDefaultBlocks, kBlockSize>>>(d_dst, d_src, d_src1, nElts);
+    CUDACHECK(cudaGetLastError());
+    CUDACHECK(cudaDeviceSynchronize());
+
+    std::vector<int> h_dst(nElts);
+    CUDACHECK(cudaMemcpy(
+        h_dst.data(), d_dst, nElts * sizeof(int), cudaMemcpyDeviceToHost));
+    EXPECT_EQ(h_dst, expected);
+  };
+
+  test(std::integral_constant<int, 1>{});
+  test(std::integral_constant<int, 2>{});
+  test(std::integral_constant<int, 4>{});
+  test(std::integral_constant<int, 8>{});
+}


### PR DESCRIPTION
Summary:

Adds a basic reduceCopy kernel for NCCLX that performs vectorized copy and reduce-copy operations without stochastic rounding. **This kernel is for experimentation and won't be used in production.**

Includes:
- Copy iterator utilities (`copy_iterator.cuh`) for vectorized memory access
- Core `reduceCopy` and `reduceCopyPacks` kernels supporting variable number of sources with templated unrolling (`reduce_copy.cuh`)
- Mixed-precision variants (`reduceCopyMixed`) for BF16/FP32 conversions (`reduce_copy_common.cuh`)
- Benchmarks for copy, reduce-copy, and mixed-precision operations with block/unroll sweeps
- Correctness tests for same-type and mixed-type copy/reduce operations

Reviewed By: SuhitK

Differential Revision: D99002592


