### PR TITLE
Pipes: Device AllToAllv IBGDA integration (5/7) — ncclx integration + CVARs (#1374)

### DIFF
--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -108,9 +108,32 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
           static_cast<uint8_t>(NCCL_CTRAN_IBGDA_RNR_RETRY);
     }
 
+    // IBGDA device alltoallv staging buffer overrides
+    if (NCCL_CTRAN_PIPES_DEVICE_ALLTOALLV_STAGING_BUFFER_SIZE > 0) {
+      config.ibgdaSetupConfig.dataBufferSize =
+          NCCL_CTRAN_PIPES_DEVICE_ALLTOALLV_STAGING_BUFFER_SIZE;
+    }
+    if (NCCL_CTRAN_PIPES_DEVICE_ALLTOALLV_CHUNK_SIZE > 0) {
+      config.ibgdaSetupConfig.chunkSize =
+          NCCL_CTRAN_PIPES_DEVICE_ALLTOALLV_CHUNK_SIZE;
+    }
+    if (NCCL_CTRAN_PIPES_DEVICE_ALLTOALLV_PIPELINE_DEPTH > 0) {
+      config.ibgdaSetupConfig.pipelineDepth =
+          static_cast<int>(NCCL_CTRAN_PIPES_DEVICE_ALLTOALLV_PIPELINE_DEPTH);
+    }
+
     config.disableIb = NCCL_CTRAN_PIPES_DISABLE_IB;
     config.topoConfig.p2pDisable = NCCL_P2P_DISABLE ||
         NCCL_COMM_STATE_DEBUG_TOPO == NCCL_COMM_STATE_DEBUG_TOPO::nolocal;
+
+    // TEST_IBGDA_SINGLE_NODE=1: Force all peers to IBGDA even on single node.
+    // Data travels through real NICs (GPU→PCIe→NIC→IB switch→NIC→PCIe→GPU).
+    // For testing IBGDA alltoallv correctness without multi-node cluster.
+    const char* forceIbgdaEnv = std::getenv("TEST_IBGDA_SINGLE_NODE");
+    if (forceIbgdaEnv && std::string(forceIbgdaEnv) == "1") {
+      config.forceIbgda = true;
+      config.disableIb = false; // Override — can't force IBGDA with IB disabled
+    }
 
     // Topology config: MNNVL mode and overrides
     config.topoConfig.mnnvlMode =

--- a/comms/ctran/algos/AllToAll/AllToAll.cc
+++ b/comms/ctran/algos/AllToAll/AllToAll.cc
@@ -10,8 +10,26 @@
 #include "comms/ctran/algos/AllToAll/AllToAllvImpl.h"
 #if defined(ENABLE_PIPES)
 #include "comms/ctran/algos/AllToAll/DeviceAllToAllvPipesImpl.h"
+#include "comms/pipes/MultiPeerDeviceHandle.cuh"
 #include "comms/pipes/MultiPeerTransport.h"
 #include "comms/pipes/Transport.cuh"
+#include "comms/pipes/collectives/AllToAllv.cuh"
+
+// Pipes-direct bypass defined in DeviceAllToAllvPipes.cu
+extern commResult_t pipesDirectDeviceAllToAllv(
+    const void* sendbuff,
+    void* recvbuff,
+    const int64_t* sendcounts_d,
+    const int64_t* recvcounts_d,
+    size_t elementSize,
+    int myRank,
+    int nRanks,
+    comms::pipes::DeviceSpan<comms::pipes::Transport> transports,
+    int64_t sendMultiplier,
+    int64_t recvMultiplier,
+    comms::pipes::ChunkInfo* d_sendChunks,
+    comms::pipes::ChunkInfo* d_recvChunks,
+    cudaStream_t stream);
 #endif
 #include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/ctran/gpe/CtranGpe.h"
@@ -214,6 +232,28 @@ commResult_t ctranDeviceAllToAllv(
     int64_t sendcountsMultiplier,
     int64_t recvcountsMultiplier,
     const std::unordered_map<std::string, std::string>& hints) {
+  if (NCCL_CTRAN_PIPES_DEVICE_ALLTOALLV_ENABLE) {
+    // Pipes-direct path: unified all_to_allv() handles NVLink + IBGDA.
+    auto* mpt = comm->multiPeerTransport_.get();
+    auto deviceHandle = mpt->get_device_handle();
+    return pipesDirectDeviceAllToAllv(
+        sendbuff,
+        recvbuff,
+        sendcounts_d,
+        recvcounts_d,
+        commTypeSize(datatype),
+        mpt->my_rank(),
+        mpt->n_ranks(),
+        deviceHandle.transports,
+        sendcountsMultiplier,
+        recvcountsMultiplier,
+        mpt->getChunkInfoSendBuf(),
+        mpt->getChunkInfoRecvBuf(),
+        stream);
+  }
+
+  // Ctran kernel path: GPE, block scheduling, tunable hints.
+  // Currently NVLink-only.
   auto opCount = comm->ctran_->getOpCount();
 
   KernelConfig config = KernelConfig(
@@ -278,14 +318,15 @@ bool ctranDeviceAllToAllvSupport(CtranComm* comm) {
     return false;
   }
 
-  // NVLink domain only: verify ALL peers are reachable via NVLink (or self).
-  // Reject communicators with any IB-only peers to prevent silent data loss.
+  // Verify ALL peers are reachable via a supported transport.
+  // Supported: NVLink (P2P_NVL), IBGDA (P2P_IBGDA), or self (SELF).
   // Use host-side API — getMultiPeerTransportsPtr() returns a device pointer
   // that cannot be dereferenced on the host.
   const auto statex = comm->statex_.get();
   for (int rank = 0; rank < statex->nRanks(); rank++) {
     auto type = comm->multiPeerTransport_->get_transport_type(rank);
     if (type != comms::pipes::TransportType::P2P_NVL &&
+        type != comms::pipes::TransportType::P2P_IBGDA &&
         type != comms::pipes::TransportType::SELF) {
       return false;
     }

--- a/comms/ctran/algos/AllToAll/DeviceAllToAllvPipes.cu
+++ b/comms/ctran/algos/AllToAll/DeviceAllToAllvPipes.cu
@@ -3,11 +3,13 @@
 #if defined(ENABLE_PIPES)
 
 #include <cstddef>
+#include <new>
 #include "comms/ctran/algos/AllToAll/Types.h"
 #include "comms/ctran/algos/CtranAlgoDev.h"
 #include "comms/pipes/DeviceSpan.cuh"
 #include "comms/pipes/Timeout.cuh"
 #include "comms/pipes/Transport.cuh"
+#include "comms/pipes/collectives/AllToAllv.h"
 #include "comms/pipes/ll128/Ll128Packet.cuh"
 
 // Compute the exclusive prefix sum of counts[0..rank-1] to get the
@@ -67,6 +69,82 @@ __device__ __forceinline__ void recv_peer(
   } else {
     transport.p2p_nvl.recv(group, dst, bytes, timeout);
   }
+}
+
+// Helper kernel: compute ChunkInfo (offsets via prefix sum) from device counts
+static __global__ void buildChunkInfosKernel(
+    comms::pipes::ChunkInfo* send_chunks,
+    comms::pipes::ChunkInfo* recv_chunks,
+    const int64_t* sendcounts_d,
+    const int64_t* recvcounts_d,
+    int nRanks,
+    size_t elementSize,
+    int64_t sendMultiplier,
+    int64_t recvMultiplier) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    size_t sendOffset = 0;
+    size_t recvOffset = 0;
+    for (int r = 0; r < nRanks; ++r) {
+      size_t sendBytes =
+          static_cast<size_t>(sendcounts_d[r] * sendMultiplier) * elementSize;
+      size_t recvBytes =
+          static_cast<size_t>(recvcounts_d[r] * recvMultiplier) * elementSize;
+      new (&send_chunks[r]) comms::pipes::ChunkInfo(sendOffset, sendBytes);
+      new (&recv_chunks[r]) comms::pipes::ChunkInfo(recvOffset, recvBytes);
+      sendOffset += sendBytes;
+      recvOffset += recvBytes;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pipes-direct bypass: builds ChunkInfo from device counts and calls the
+// unified pipes all_to_allv() which handles both NVLink and IBGDA.
+// Called from ctranDeviceAllToAllv() to avoid the old NVLink-only kernel.
+// ---------------------------------------------------------------------------
+commResult_t pipesDirectDeviceAllToAllv(
+    const void* sendbuff,
+    void* recvbuff,
+    const int64_t* sendcounts_d,
+    const int64_t* recvcounts_d,
+    size_t elementSize,
+    int myRank,
+    int nRanks,
+    comms::pipes::DeviceSpan<comms::pipes::Transport> transports,
+    int64_t sendMultiplier,
+    int64_t recvMultiplier,
+    comms::pipes::ChunkInfo* d_sendChunks,
+    comms::pipes::ChunkInfo* d_recvChunks,
+    cudaStream_t stream) {
+  buildChunkInfosKernel<<<1, 1, 0, stream>>>(
+      d_sendChunks,
+      d_recvChunks,
+      sendcounts_d,
+      recvcounts_d,
+      nRanks,
+      elementSize,
+      sendMultiplier,
+      recvMultiplier);
+
+  comms::pipes::DeviceSpan<comms::pipes::ChunkInfo> sendSpan(
+      d_sendChunks, static_cast<uint32_t>(nRanks));
+  comms::pipes::DeviceSpan<comms::pipes::ChunkInfo> recvSpan(
+      d_recvChunks, static_cast<uint32_t>(nRanks));
+
+  comms::pipes::all_to_allv(
+      recvbuff,
+      sendbuff,
+      myRank,
+      transports,
+      sendSpan,
+      recvSpan,
+      std::chrono::milliseconds{0},
+      stream,
+      4,
+      256,
+      dim3{4, 1, 1});
+
+  return commSuccess;
 }
 
 template <PipeProtocol Proto>

--- a/comms/pipes/MultiPeerIbgdaTransportSetup.cc
+++ b/comms/pipes/MultiPeerIbgdaTransportSetup.cc
@@ -1,0 +1,192 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/MultiPeerIbgdaTransportSetup.h"
+
+#include <stdexcept>
+#include <vector>
+
+#include <cuda_runtime.h>
+#include <glog/logging.h>
+
+#include "comms/pipes/MultipeerIbgdaTransport.h"
+
+namespace comms::pipes {
+
+namespace {
+
+// kP2pSignalCount is now in P2pIbgdaTransportState.h (shared with device code).
+
+#define CUDA_CHECK(cmd)                                                    \
+  do {                                                                     \
+    cudaError_t err = (cmd);                                               \
+    if (err != cudaSuccess) {                                              \
+      throw std::runtime_error(                                            \
+          std::string("CUDA error: ") + cudaGetErrorString(err) + " at " + \
+          __FILE__ + ":" + std::to_string(__LINE__));                      \
+    }                                                                      \
+  } while (0)
+
+} // namespace
+
+MultiPeerIbgdaTransportSetup::MultiPeerIbgdaTransportSetup(
+    MultipeerIbgdaTransport& ibgdaTransport,
+    int myRank,
+    int nRanks,
+    const MultiPeerIbgdaTransportSetupConfig& config,
+    int maxChannelsPerPeer,
+    cudaStream_t stream)
+    : ibgdaTransport_(ibgdaTransport),
+      myRank_(myRank),
+      nRanks_(nRanks),
+      config_(config),
+      maxChannelsPerPeer_(maxChannelsPerPeer),
+      stream_(stream) {
+  CHECK_GT(maxChannelsPerPeer_, 0)
+      << "maxChannelsPerPeer must be >= 1, got " << maxChannelsPerPeer_;
+  CHECK(config_.dataBufferSize % maxChannelsPerPeer_ == 0)
+      << "dataBufferSize (" << config_.dataBufferSize
+      << ") must be divisible by maxChannelsPerPeer (" << maxChannelsPerPeer_
+      << ") for clean staging subdivision";
+
+  // Grouped counter layout: [send_ch0..send_chN-1 | recv_ch0..recv_chN-1]
+  // per peer. Total: nRanks * maxChannelsPerPeer * 2 counters.
+  const size_t counterCount =
+      static_cast<size_t>(nRanks_) * maxChannelsPerPeer_ * 2;
+  CUDA_CHECK(cudaMalloc(&d_iterationCounter_, counterCount * sizeof(uint64_t)));
+  CUDA_CHECK(cudaMemsetAsync(
+      d_iterationCounter_, 0, counterCount * sizeof(uint64_t), stream_));
+}
+
+MultiPeerIbgdaTransportSetup::~MultiPeerIbgdaTransportSetup() {
+  if (stagingBuffer_) {
+    ibgdaTransport_.deregisterBuffer(stagingBuffer_);
+    (void)cudaFree(stagingBuffer_);
+  }
+  if (signalBuffer_) {
+    ibgdaTransport_.deregisterBuffer(signalBuffer_);
+    (void)cudaFree(signalBuffer_);
+  }
+  if (d_iterationCounter_) {
+    (void)cudaFree(d_iterationCounter_);
+  }
+}
+
+void MultiPeerIbgdaTransportSetup::exchangeBuffers() {
+  const int nPeers = nRanks_ - 1;
+  const size_t perPeerStagingSize =
+      static_cast<size_t>(config_.pipelineDepth) * config_.dataBufferSize;
+
+  // 1. Allocate staging data buffers.
+  // Each peer needs TWO staging regions: one for send, one for recv.
+  // Layout: [send_peer0 | send_peer1 | ... | recv_peer0 | recv_peer1 | ...]
+  // This avoids the data race where the sender's memcpy and the remote
+  // RDMA put write to the same memory.
+  const size_t totalStagingSize = perPeerStagingSize * nPeers * 2;
+  CUDA_CHECK(cudaMalloc(&stagingBuffer_, totalStagingSize));
+  CUDA_CHECK(cudaMemsetAsync(stagingBuffer_, 0, totalStagingSize, stream_));
+
+  // 2. Register staging buffers with NIC
+  localStagingBuf_ =
+      ibgdaTransport_.registerBuffer(stagingBuffer_, totalStagingSize);
+
+  // 3. Exchange staging buffers (COLLECTIVE) — get per-peer rkeys
+  remoteStagingBufs_ = ibgdaTransport_.exchangeBuffer(localStagingBuf_);
+
+  // 4. Allocate signal buffers (scaled by maxChannelsPerPeer)
+  const size_t signalBufSize = static_cast<size_t>(nRanks_) *
+      maxChannelsPerPeer_ * kP2pSignalCount * sizeof(uint64_t);
+  CUDA_CHECK(cudaMalloc(&signalBuffer_, signalBufSize));
+  CUDA_CHECK(cudaMemsetAsync(signalBuffer_, 0, signalBufSize, stream_));
+
+  // 5. Register signal buffers with NIC
+  localSignalBuf_ =
+      ibgdaTransport_.registerBuffer(signalBuffer_, signalBufSize);
+
+  // 6. Exchange signal buffers (COLLECTIVE)
+  remoteSignalBufs_ = ibgdaTransport_.exchangeBuffer(localSignalBuf_);
+
+  CUDA_CHECK(cudaStreamSynchronize(stream_));
+
+  // Pre-build host-side peer states for buildP2pTransportDevice() in
+  // build_device_handle().
+  h_peerStates_.resize(nRanks_);
+
+  int peerIdx = 0;
+  for (int peer = 0; peer < nRanks_; peer++) {
+    if (peer == myRank_) {
+      continue;
+    }
+
+    // Send staging: peerIdx-th region in the SEND half of our staging buffer.
+    size_t sendStagingOffset = peerIdx * perPeerStagingSize;
+
+    // Recv staging: peerIdx-th region in the RECV half of our staging buffer.
+    // Recv half starts at nPeers * perPeerStagingSize.
+    const size_t recvHalfOffset =
+        static_cast<size_t>(nRanks_ - 1) * perPeerStagingSize;
+    size_t recvStagingOffset = recvHalfOffset + peerIdx * perPeerStagingSize;
+
+    // Remote staging: our RECV region within the peer's staging buffer.
+    // The peer's recv half starts at nPeers * perPeerStagingSize in their
+    // buffer. Within that half, our data lands at remotePeerIndex.
+    int remotePeerIndex = (myRank_ < peer) ? myRank_ : (myRank_ - 1);
+    size_t remoteStagingOffset =
+        recvHalfOffset + remotePeerIndex * perPeerStagingSize;
+
+    // exchangeBuffer() returns nRanks-1 entries indexed by peer index
+    // (skip-self ordering), NOT by global rank. Convert rank → peer index.
+    int exchIdx = (peer < myRank_) ? peer : (peer - 1);
+
+    // Signal ID bases: channel 0's pair. Device adds channelId *
+    // kP2pSignalCount.
+    int localSignalId = peer * maxChannelsPerPeer_ * kP2pSignalCount;
+    int remoteSignalId = myRank_ * maxChannelsPerPeer_ * kP2pSignalCount;
+
+    CHECK_LT(exchIdx, static_cast<int>(remoteStagingBufs_.size()));
+    CHECK_LT(exchIdx, static_cast<int>(remoteSignalBufs_.size()));
+    const size_t channelDataBufSize =
+        config_.dataBufferSize / maxChannelsPerPeer_;
+    h_peerStates_[peer] = P2pIbgdaTransportState{
+        .localStagingBuf = localStagingBuf_.subBuffer(sendStagingOffset),
+        .remoteStagingBuf =
+            remoteStagingBufs_.at(exchIdx).subBuffer(remoteStagingOffset),
+        .recvStagingBuf = localStagingBuf_.subBuffer(recvStagingOffset),
+        .localSignalBuf = localSignalBuf_,
+        .remoteSignalBuf = remoteSignalBufs_.at(exchIdx),
+        .localSignalId = localSignalId,
+        .remoteSignalId = remoteSignalId,
+        .dataBufferSize = config_.dataBufferSize,
+        .chunkSize = config_.chunkSize,
+        .pipelineDepth = config_.pipelineDepth,
+        .maxChannelsPerPeer = maxChannelsPerPeer_,
+        .channelDataBufferSize = channelDataBufSize,
+        .channelStride =
+            static_cast<size_t>(config_.pipelineDepth) * channelDataBufSize,
+    };
+    peerIdx++;
+  }
+
+  // Cross-rank consistency: maxChannelsPerPeer_ is derived from the same
+  // compile-time autotune table (getMaxIbgdaChannelsPerPeer) on all ranks,
+  // so it is guaranteed consistent. If a future change makes this value
+  // rank-dependent, add a collective allReduce/allGather check here to
+  // assert all ranks agree — a mismatch would cause silent signal/staging
+  // offset corruption.
+  LOG(INFO) << "MultiPeerIbgdaTransportSetup: rank " << myRank_
+            << " exchanged buffers — staging=" << totalStagingSize
+            << "B, signals=" << signalBufSize
+            << ", pipelineDepth=" << config_.pipelineDepth
+            << ", dataBufferSize=" << config_.dataBufferSize
+            << ", maxChannelsPerPeer=" << maxChannelsPerPeer_;
+}
+
+uint64_t* MultiPeerIbgdaTransportSetup::getIterationCounter() const {
+  return d_iterationCounter_;
+}
+
+const std::vector<P2pIbgdaTransportState>&
+MultiPeerIbgdaTransportSetup::getHostPeerStates() const {
+  return h_peerStates_;
+}
+
+} // namespace comms::pipes

--- a/comms/pipes/MultiPeerIbgdaTransportSetup.h
+++ b/comms/pipes/MultiPeerIbgdaTransportSetup.h
@@ -1,0 +1,134 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <cstddef>
+#include <vector>
+
+#include "comms/pipes/IbgdaBuffer.h"
+#include "comms/pipes/P2pIbgdaTransportState.h"
+
+namespace comms::pipes {
+
+// Forward declaration — avoid pulling DOCA headers
+class MultipeerIbgdaTransport;
+
+/**
+ * Configuration for MultiPeerIbgdaTransportSetup.
+ *
+ * Controls staging buffer sizing and pipelining depth.
+ * These mirror the NVLink config in MultiPeerNvlTransportConfig.
+ */
+struct MultiPeerIbgdaTransportSetupConfig {
+  // Per-pipeline-slot staging buffer size in bytes
+  size_t dataBufferSize{2048};
+
+  // Chunk size for sub-pipeline RDMA puts (bytes)
+  size_t chunkSize{512};
+
+  // Number of pipeline slots for latency hiding
+  int pipelineDepth{4};
+};
+
+/**
+ * MultiPeerIbgdaTransportSetup - Host-side IBGDA staging + signal buffer
+ * manager for device-initiated collectives.
+ *
+ * Allocates, registers, and exchanges ALL communication infrastructure
+ * (staging data buffers, signal buffers) for IBGDA-based device collectives.
+ * Fills the gap where MultiPeerNvlTransport handles this internally for
+ * NVLink, but MultipeerIbgdaTransport follows a caller-provides-buffers model.
+ *
+ * Owned by MultiPeerTransport alongside the existing ibgdaTransport_.
+ *
+ * LIFETIME:
+ *   - ibgdaTransport must outlive this object
+ *   - All GPU memory is freed in the destructor
+ *   - NIC registrations are deregistered in the destructor
+ */
+class MultiPeerIbgdaTransportSetup {
+ public:
+  /**
+   * Constructor. Allocates a device-side iteration counter (zeroed).
+   *
+   * @param ibgdaTransport  Existing MultipeerIbgdaTransport (must outlive)
+   * @param myRank          This rank's global ID
+   * @param nRanks          Total number of ranks
+   * @param config          Staging buffer and pipelining configuration
+   * @param maxChannelsPerPeer Maximum channels per IBGDA peer (derived from
+   *                         autotune table; 1 = backward-compatible single
+   *                         channel)
+   * @param stream          CUDA stream for async memset operations
+   */
+  MultiPeerIbgdaTransportSetup(
+      MultipeerIbgdaTransport& ibgdaTransport,
+      int myRank,
+      int nRanks,
+      const MultiPeerIbgdaTransportSetupConfig& config,
+      int maxChannelsPerPeer = 1,
+      cudaStream_t stream = nullptr);
+
+  ~MultiPeerIbgdaTransportSetup();
+
+  // Non-copyable, non-movable (owns GPU memory)
+  MultiPeerIbgdaTransportSetup(const MultiPeerIbgdaTransportSetup&) = delete;
+  MultiPeerIbgdaTransportSetup& operator=(const MultiPeerIbgdaTransportSetup&) =
+      delete;
+  MultiPeerIbgdaTransportSetup(MultiPeerIbgdaTransportSetup&&) = delete;
+  MultiPeerIbgdaTransportSetup& operator=(MultiPeerIbgdaTransportSetup&&) =
+      delete;
+
+  /**
+   * Allocate staging + signal buffers, register with NIC, exchange with peers.
+   *
+   * COLLECTIVE — all ranks must call. Allocates:
+   *   - Per-peer staging data buffers (pipelineDepth * dataBufferSize per peer)
+   *   - Signal buffers (nRanks * 2 uint64_t slots: completion + back-pressure)
+   * Registers all with ibgdaTransport and exchanges to get remote rkeys.
+   */
+  void exchangeBuffers();
+
+  /**
+   * Get the device-side iteration counter pointer.
+   * Allocated and zeroed by the constructor. The kernel reads and increments
+   * this to derive expected signal values. CUDA graph safe.
+   */
+  uint64_t* getIterationCounter() const;
+
+  /**
+   * Get the host-side per-peer state vector.
+   * Used by MultiPeerTransport::build_device_handle() to construct
+   * fully-formed P2pIbgdaTransportDevice objects with embedded staging state.
+   *
+   * @return Reference to host-side vector of per-peer staging state.
+   */
+  const std::vector<P2pIbgdaTransportState>& getHostPeerStates() const;
+
+ private:
+  MultipeerIbgdaTransport& ibgdaTransport_;
+  int myRank_;
+  int nRanks_;
+  MultiPeerIbgdaTransportSetupConfig config_;
+  int maxChannelsPerPeer_;
+  cudaStream_t stream_;
+
+  // Staging data buffers (owned)
+  void* stagingBuffer_{nullptr};
+  IbgdaLocalBuffer localStagingBuf_;
+  std::vector<IbgdaRemoteBuffer> remoteStagingBufs_;
+
+  // Signal buffers (owned)
+  void* signalBuffer_{nullptr};
+  IbgdaLocalBuffer localSignalBuf_;
+  std::vector<IbgdaRemoteBuffer> remoteSignalBufs_;
+
+  // Device-side iteration counter (owned)
+  uint64_t* d_iterationCounter_{nullptr};
+
+  // Host-side peer state vector (saved from exchangeBuffers for
+  // buildP2pTransportDevice)
+  std::vector<P2pIbgdaTransportState> h_peerStates_;
+};
+
+} // namespace comms::pipes

--- a/comms/pipes/MultiPeerTransport.cc
+++ b/comms/pipes/MultiPeerTransport.cc
@@ -15,6 +15,7 @@
 
 #include "comms/pipes/CudaDriverLazy.h"
 #include "comms/pipes/MultiPeerDeviceHandle.cuh"
+#include "comms/pipes/MultiPeerIbgdaTransportSetup.h"
 #include "comms/pipes/MultipeerIbgdaDeviceTransport.cuh"
 #include "comms/pipes/TopologyDiscovery.h"
 #include "comms/pipes/bootstrap/NvlBootstrapAdapter.h"
@@ -63,6 +64,7 @@ MultiPeerTransport::MultiPeerTransport(
     topo = topoDiscovery.discover(
         myRank_, nRanks_, deviceId_, *bootstrap_, config.topoConfig);
   }
+  ibgdaSetupConfig_ = config.ibgdaSetupConfig;
   initFromTopology(std::move(*topo), config);
 }
 
@@ -102,15 +104,21 @@ void MultiPeerTransport::initFromTopology(
     for (int r = 0; r < nRanks_; ++r) {
       if (r == myRank_) {
         typePerRank_.at(r) = TransportType::SELF;
-      } else if (globalToNvlLocal_.count(r)) {
+      } else if (globalToNvlLocal_.count(r) && !config.forceIbgda) {
         typePerRank_.at(r) = TransportType::P2P_NVL;
       } else {
         typePerRank_.at(r) = TransportType::P2P_IBGDA;
       }
     }
 
+    if (config.forceIbgda) {
+      LOG(INFO) << "MultiPeerTransport: rank " << myRank_
+                << " TEST_IBGDA_SINGLE_NODE=1 — forcing all peers to IBGDA"
+                << " (data travels GPU→PCIe→NIC→IB switch→NIC→PCIe→GPU)";
+    }
+
     for (int r = 0; r < nRanks_; ++r) {
-      if (r != myRank_) {
+      if (typePerRank_[r] == TransportType::P2P_IBGDA) {
         ibgdaPeerRanks_.push_back(r);
       }
     }
@@ -153,9 +161,10 @@ void MultiPeerTransport::initFromTopology(
             << " nvlLocalRank=" << nvlLocalRank_;
   }
 
-  // Always create IBGDA transport — it is the universal fallback for all peers.
-  // NVL is preferred when available, but IBGDA covers every non-self rank.
-  if (!config.disableIb && nRanks_ > 1) {
+  // Only create IBGDA transport when peers actually need it. On single-node
+  // where all peers are NVL-reachable, skip IBGDA construction to avoid
+  // DOCA/NIC failures on machines without IBGDA support.
+  if (!ibgdaPeerRanks_.empty()) {
     auto ibgdaConfig = config.ibgdaConfig;
     ibgdaConfig.cudaDevice = deviceId_;
     ibgdaTransport_ = std::make_unique<MultipeerIbgdaTransport>(
@@ -192,6 +201,9 @@ void MultiPeerTransport::exchange() {
   }
   if (ibgdaTransport_) {
     ibgdaTransport_->exchange();
+    ibgdaSetup_ = std::make_unique<MultiPeerIbgdaTransportSetup>(
+        *ibgdaTransport_, myRank_, nRanks_, ibgdaSetupConfig_);
+    ibgdaSetup_->exchangeBuffers();
   }
 
   build_device_handle();
@@ -246,13 +258,15 @@ MultiPeerDeviceHandle MultiPeerTransport::get_device_handle() const {
         "MultiPeerTransport::get_device_handle() called before exchange()");
   }
 
-  return MultiPeerDeviceHandle{
+  MultiPeerDeviceHandle handle{
       myRank_,
       nRanks_,
       {transportsGpu_, static_cast<uint32_t>(nRanks_)},
       static_cast<int>(nvlPeerRanks_.size()),
       static_cast<int>(ibgdaPeerRanks_.size()),
   };
+
+  return handle;
 }
 
 IbgdaLocalBuffer MultiPeerTransport::localRegisterIbgdaBuffer(
@@ -719,9 +733,20 @@ void MultiPeerTransport::build_device_handle() {
       }
 
       case TransportType::P2P_IBGDA: {
-        P2pIbgdaTransportDevice* devPtr = ibgdaTransport_
-            ? ibgdaTransport_->getP2pTransportDevice(r)
-            : nullptr;
+        // Build fully-formed IBGDA device with staging state + counters.
+        // Grouped counter layout: per-peer region has maxChannelsPerPeer
+        // send counters followed by maxChannelsPerPeer recv counters.
+        P2pIbgdaTransportDevice* devPtr = nullptr;
+        if (ibgdaTransport_ && ibgdaSetup_) {
+          const auto& hostStates = ibgdaSetup_->getHostPeerStates();
+          uint64_t* iterCounter = ibgdaSetup_->getIterationCounter();
+          int maxCh = hostStates[r].maxChannelsPerPeer;
+          uint64_t* sendBase = &iterCounter[r * maxCh * 2];
+          uint64_t* recvBase = &iterCounter[r * maxCh * 2 + maxCh];
+          devPtr = ibgdaTransport_->buildP2pTransportDevice(
+              r, hostStates[r], sendBase, recvBase);
+          ibgdaDevicePtrsGpu_.push_back(devPtr);
+        }
         new (&transportsHost[r]) Transport(devPtr);
         break;
       }
@@ -741,13 +766,36 @@ void MultiPeerTransport::build_device_handle() {
   }
   std::free(transportsHost);
 
+  // Pre-allocate scratch buffers for AllToAllv ChunkInfo arrays.
+  // Uses synchronous cudaMalloc so these are ready before any CUDA graph
+  // capture. Sized for nRanks_ and reused across all collective calls.
+  // ChunkInfo is {size_t offset, size_t nbytes} = 2 * sizeof(size_t).
+  constexpr size_t kChunkInfoSize = 2 * sizeof(size_t);
+  const size_t chunkBytes = nRanks_ * kChunkInfoSize;
+  CUDA_CHECK(cudaMalloc(&chunkInfoSendBuf_, chunkBytes));
+  CUDA_CHECK(cudaMalloc(&chunkInfoRecvBuf_, chunkBytes));
+
   deviceHandleBuilt_ = true;
 }
 
 void MultiPeerTransport::free_device_handle() {
   if (transportsGpu_) {
-    cudaFree(transportsGpu_);
+    (void)cudaFree(transportsGpu_);
     transportsGpu_ = nullptr;
+  }
+  for (auto* ptr : ibgdaDevicePtrsGpu_) {
+    if (ptr) {
+      (void)cudaFree(ptr);
+    }
+  }
+  ibgdaDevicePtrsGpu_.clear();
+  if (chunkInfoSendBuf_) {
+    (void)cudaFree(chunkInfoSendBuf_);
+    chunkInfoSendBuf_ = nullptr;
+  }
+  if (chunkInfoRecvBuf_) {
+    (void)cudaFree(chunkInfoRecvBuf_);
+    chunkInfoRecvBuf_ = nullptr;
   }
   deviceHandleBuilt_ = false;
 }

--- a/comms/pipes/MultiPeerTransport.h
+++ b/comms/pipes/MultiPeerTransport.h
@@ -13,6 +13,7 @@
 
 #include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/pipes/GpuMemHandler.h"
+#include "comms/pipes/MultiPeerIbgdaTransportSetup.h"
 #include "comms/pipes/MultiPeerNvlTransport.h"
 #include "comms/pipes/MultipeerIbgdaTransport.h"
 #include "comms/pipes/P2pSelfTransportDevice.cuh"
@@ -25,9 +26,13 @@ namespace comms::pipes {
 // get_device_handle()
 struct MultiPeerDeviceHandle;
 
+// Forward declaration — defined in collectives/AllToAllv.cuh
+struct ChunkInfo;
+
 struct MultiPeerTransportConfig {
   MultiPeerNvlTransportConfig nvlConfig;
   MultipeerIbgdaTransportConfig ibgdaConfig;
+  MultiPeerIbgdaTransportSetupConfig ibgdaSetupConfig;
 
   // MNNVL topology overrides for UUID and clique ID.
   // See TopologyConfig for field-level documentation.
@@ -36,6 +41,12 @@ struct MultiPeerTransportConfig {
   // When true, IBGDA transport is never constructed and all non-self peers
   // are routed over NVLink. Requires all ranks in the same NVL domain.
   bool disableIb{false};
+
+  // When true, force all non-self peers to use IBGDA transport even if
+  // NVLink is available. Used for single-node IBGDA testing where data
+  // travels through real NICs (GPU → PCIe → NIC → IB switch → NIC → PCIe →
+  // GPU). Set via TEST_IBGDA_SINGLE_NODE=1 env var.
+  bool forceIbgda{false};
 };
 
 /**
@@ -192,6 +203,24 @@ class MultiPeerTransport {
    */
   MultiPeerDeviceHandle get_device_handle() const;
 
+  // --- Scratch buffers for collectives ---
+
+  /**
+   * @return Pre-allocated device buffer for send ChunkInfo (nRanks elements).
+   * Allocated during exchange(), safe for CUDA graph capture.
+   */
+  ChunkInfo* getChunkInfoSendBuf() const {
+    return chunkInfoSendBuf_;
+  }
+
+  /**
+   * @return Pre-allocated device buffer for recv ChunkInfo (nRanks elements).
+   * Allocated during exchange(), safe for CUDA graph capture.
+   */
+  ChunkInfo* getChunkInfoRecvBuf() const {
+    return chunkInfoRecvBuf_;
+  }
+
   // --- IBGDA buffer registration (delegates to ibgdaTransport_) ---
 
   /**
@@ -269,10 +298,21 @@ class MultiPeerTransport {
   std::shared_ptr<meta::comms::IBootstrap> nvlBootstrapAdapter_;
   std::unique_ptr<MultiPeerNvlTransport> nvlTransport_;
   std::unique_ptr<MultipeerIbgdaTransport> ibgdaTransport_;
+  std::unique_ptr<MultiPeerIbgdaTransportSetup> ibgdaSetup_;
+  MultiPeerIbgdaTransportSetupConfig ibgdaSetupConfig_;
 
   // --- GPU-allocated transport array for device handle ---
   Transport* transportsGpu_{nullptr};
   bool deviceHandleBuilt_{false};
+
+  // Individually-allocated IBGDA device pointers on GPU (for cleanup)
+  std::vector<P2pIbgdaTransportDevice*> ibgdaDevicePtrsGpu_;
+
+  // Pre-allocated device arrays for AllToAllv ChunkInfo, sized for nRanks_.
+  // Allocated once during build_device_handle() (called from exchange()) so
+  // they are ready before any CUDA graph capture.
+  ChunkInfo* chunkInfoSendBuf_{nullptr};
+  ChunkInfo* chunkInfoRecvBuf_{nullptr};
 
   // --- Private helpers ---
   void initFromTopology(

--- a/comms/pipes/MultipeerIbgdaTransport.cc
+++ b/comms/pipes/MultipeerIbgdaTransport.cc
@@ -835,8 +835,8 @@ void MultipeerIbgdaTransport::exchange() {
     }
   }
 
-  // Build device transports on GPU
-  std::vector<P2pIbgdaTransportBuildParams> buildParams(numPeers);
+  // Build QP params and save host-side for buildP2pTransportDevice()
+  buildParams_.resize(numPeers);
   for (int i = 0; i < numPeers; i++) {
     // Get GPU-accessible QP handle for main QP
     doca_gpu_dev_verbs_qp* gpuQp = nullptr;
@@ -850,14 +850,16 @@ void MultipeerIbgdaTransport::exchange() {
         qpGroupHlList_[i]->qp_companion.qp_gverbs, &companionGpuQp);
     checkDocaError(err, "Failed to get companion GPU QP handle");
 
-    buildParams[i] = P2pIbgdaTransportBuildParams{
+    buildParams_[i] = P2pIbgdaTransportBuildParams{
         gpuQp,
         companionGpuQp,
         NetworkLKey(HostLKey(sinkMr_->lkey)),
         reinterpret_cast<uint64_t>(sinkBuffer_)};
   }
 
-  peerTransportsGpu_ = buildDeviceTransportsOnGpu(buildParams.data(), numPeers);
+  // Upload QP-only devices to GPU for backward compat (getP2pTransportDevice)
+  peerTransportsGpu_ =
+      buildDeviceTransportsOnGpu(buildParams_.data(), numPeers);
   peerTransportSize_ = getP2pIbgdaTransportDeviceSize();
 
   VLOG(1) << "MultipeerIbgdaTransport: rank " << myRank_
@@ -870,6 +872,16 @@ MultipeerIbgdaDeviceTransport MultipeerIbgdaTransport::getDeviceTransport()
       myRank_,
       nRanks_,
       DeviceSpan<P2pIbgdaTransportDevice>(peerTransportsGpu_, nRanks_ - 1));
+}
+
+P2pIbgdaTransportDevice* MultipeerIbgdaTransport::buildP2pTransportDevice(
+    int peerRank,
+    const P2pIbgdaTransportState& stagingState,
+    uint64_t* sendCounter,
+    uint64_t* recvCounter) const {
+  int peerIndex = rankToPeerIndex(peerRank);
+  return buildFullP2pIbgdaTransportDeviceOnGpu(
+      buildParams_[peerIndex], stagingState, sendCounter, recvCounter);
 }
 
 P2pIbgdaTransportDevice* MultipeerIbgdaTransport::getP2pTransportDevice(

--- a/comms/pipes/MultipeerIbgdaTransport.cc
+++ b/comms/pipes/MultipeerIbgdaTransport.cc
@@ -369,44 +369,40 @@ void MultipeerIbgdaTransport::registerMemory() {
   int accessFlags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE |
       IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_ATOMIC;
 
-  // Register sink buffer as a zero-based MR (iova=0).
+  // Register sink buffer with its actual GPU virtual address as IOVA.
   //
   // The sink buffer receives the discarded return value from RDMA atomic
-  // fetch-add operations. Device code uses sinkAddr.addr=0 with the sink
-  // lkey, so the MR must be zero-based: addr=0 maps to offset 0 within the
-  // MR (i.e., the actual sinkBuffer_ GPU address).
+  // fetch-add operations. Device code uses sinkAddr_ (the actual GPU virtual
+  // address) with the sink lkey.
   //
-  // With a standard ibv_reg_mr(), the IOVA equals the virtual address, so
-  // addr=0 would be outside the MR's valid range → NIC local protection
-  // error → QP error state → hang.
-  //
-  // ibv_reg_mr_iova2(pd, addr, length, iova=0, access) creates a zero-based
-  // MR where IOVA range [0, length) maps to [addr, addr+length). This
-  // matches GIN's gdakiRegMr() pattern (gin_host_gdaki.cc).
+  // NOTE: We previously used iova=0 (zero-based MR) here, but
+  // ibv_reg_dmabuf_mr does not support iova=0 on ARM64/GB200 platforms.
+  // Using the actual GPU virtual address as the IOVA works universally
+  // (same pattern as user buffer registration in registerBuffer()).
+  auto sinkIova = reinterpret_cast<uint64_t>(sinkBuffer_);
   auto sinkDmabuf =
       export_gpu_dmabuf_aligned(docaGpu_, sinkBuffer_, sinkBufferSize_);
   if (sinkDmabuf) {
-    // ibv_reg_dmabuf_mr: 4th param is iova — set to 0 for zero-based MR
     sinkMr_ = lazy_ibv_reg_dmabuf_mr(
         ibvPd_,
         sinkDmabuf->alignment.dmabufOffset,
         sinkBufferSize_,
-        0, // iova=0: zero-based MR
+        sinkIova,
         sinkDmabuf->fd,
         accessFlags);
     close(sinkDmabuf->fd);
   }
   if (!sinkMr_) {
-    // Fallback: use ibv_reg_mr_iova2 with iova=0 for zero-based MR
-    sinkMr_ = lazy_ibv_reg_mr_iova2(
-        ibvPd_, sinkBuffer_, sinkBufferSize_, 0, accessFlags);
-    if (!sinkMr_) {
+    doca_error_t regErr = doca_verbs_wrapper_ibv_reg_mr(
+        ibvPd_, sinkBuffer_, sinkBufferSize_, accessFlags, &sinkMr_);
+    if (regErr != DOCA_SUCCESS || !sinkMr_) {
       throw std::runtime_error("Failed to register sink memory region");
     }
   }
 
   VLOG(1) << "MultipeerIbgdaTransport: registered sink buffer"
-          << " lkey=" << sinkMr_->lkey << " (zero-based MR, iova=0)";
+          << " lkey=" << sinkMr_->lkey << " iova=0x" << std::hex << sinkIova
+          << std::dec;
 }
 void MultipeerIbgdaTransport::createQpGroups() {
   const int numPeers = nRanks_ - 1;
@@ -855,7 +851,10 @@ void MultipeerIbgdaTransport::exchange() {
     checkDocaError(err, "Failed to get companion GPU QP handle");
 
     buildParams[i] = P2pIbgdaTransportBuildParams{
-        gpuQp, companionGpuQp, NetworkLKey(HostLKey(sinkMr_->lkey))};
+        gpuQp,
+        companionGpuQp,
+        NetworkLKey(HostLKey(sinkMr_->lkey)),
+        reinterpret_cast<uint64_t>(sinkBuffer_)};
   }
 
   peerTransportsGpu_ = buildDeviceTransportsOnGpu(buildParams.data(), numPeers);

--- a/comms/pipes/MultipeerIbgdaTransport.h
+++ b/comms/pipes/MultipeerIbgdaTransport.h
@@ -16,11 +16,13 @@
 #include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/pipes/IbgdaBuffer.h"
 #include "comms/pipes/IbverbsLazy.h"
+#include "comms/pipes/MultipeerIbgdaTransportCuda.cuh"
 
 // Forward declarations for device types (defined in .cuh files)
 namespace comms::pipes {
 class P2pIbgdaTransportDevice;
 struct MultipeerIbgdaDeviceTransport;
+struct P2pIbgdaTransportState;
 } // namespace comms::pipes
 
 namespace comms::pipes {
@@ -268,6 +270,28 @@ class MultipeerIbgdaTransport {
   MultipeerIbgdaDeviceTransport getDeviceTransport() const;
 
   /**
+   * buildP2pTransportDevice - Build a fully-formed P2pIbgdaTransportDevice
+   *
+   * Constructs a P2pIbgdaTransportDevice on the HOST with both QP handles
+   * AND staging state. Returns by value — NVLink-symmetric with
+   * MultiPeerNvlTransport::buildP2pTransportDevice().
+   *
+   * Called from MultiPeerTransport::build_device_handle() after staging
+   * buffers have been exchanged.
+   *
+   * @param peerRank Global rank of the peer
+   * @param stagingState Pre-built staging state for this peer
+   * @param sendCounter Pointer to per-peer send iteration counter
+   * @param recvCounter Pointer to per-peer recv iteration counter
+   * @return Fully-formed P2pIbgdaTransportDevice, allocated on GPU
+   */
+  P2pIbgdaTransportDevice* buildP2pTransportDevice(
+      int peerRank,
+      const P2pIbgdaTransportState& stagingState,
+      uint64_t* sendCounter,
+      uint64_t* recvCounter) const;
+
+  /**
    * getP2pTransportDevice - Get P2P transport for a specific peer rank
    *
    * Returns a pointer to the P2pIbgdaTransportDevice for the given peer rank.
@@ -426,6 +450,9 @@ class MultipeerIbgdaTransport {
   // Per-peer device transports (GPU accessible)
   P2pIbgdaTransportDevice* peerTransportsGpu_{nullptr};
   std::size_t peerTransportSize_{0};
+
+  // Host-side build params saved from exchange() for buildP2pTransportDevice()
+  std::vector<P2pIbgdaTransportBuildParams> buildParams_;
 
   // Exchange info received from peers
   std::vector<IbgdaTransportExchInfo> peerExchInfo_;

--- a/comms/pipes/MultipeerIbgdaTransportCuda.cu
+++ b/comms/pipes/MultipeerIbgdaTransportCuda.cu
@@ -18,7 +18,10 @@ P2pIbgdaTransportDevice* buildDeviceTransportsOnGpu(
 
   for (int i = 0; i < numPeers; ++i) {
     hostTransports.emplace_back(
-        params[i].gpuQp, params[i].companionGpuQp, params[i].sinkLkey);
+        params[i].gpuQp,
+        params[i].companionGpuQp,
+        params[i].sinkLkey,
+        params[i].sinkAddr);
   }
 
   // Allocate GPU memory

--- a/comms/pipes/MultipeerIbgdaTransportCuda.cu
+++ b/comms/pipes/MultipeerIbgdaTransportCuda.cu
@@ -6,6 +6,7 @@
 #include <glog/logging.h>
 
 #include "comms/pipes/P2pIbgdaTransportDevice.cuh"
+#include "comms/pipes/P2pIbgdaTransportState.h"
 
 namespace comms::pipes {
 
@@ -52,6 +53,49 @@ void freeDeviceTransportsOnGpu(P2pIbgdaTransportDevice* ptr) {
 
 std::size_t getP2pIbgdaTransportDeviceSize() {
   return sizeof(P2pIbgdaTransportDevice);
+}
+
+P2pIbgdaTransportDevice* buildFullP2pIbgdaTransportDeviceOnGpu(
+    const P2pIbgdaTransportBuildParams& params,
+    const P2pIbgdaTransportState& stagingState,
+    uint64_t* sendCounter,
+    uint64_t* recvCounter) {
+  P2pIbgdaTransportDevice hostDev(
+      params.gpuQp,
+      params.companionGpuQp,
+      params.sinkLkey,
+      params.sinkAddr,
+      stagingState.localStagingBuf,
+      stagingState.remoteStagingBuf,
+      stagingState.recvStagingBuf,
+      stagingState.localSignalBuf,
+      stagingState.remoteSignalBuf,
+      stagingState.localSignalId,
+      stagingState.remoteSignalId,
+      stagingState.dataBufferSize,
+      stagingState.pipelineDepth,
+      sendCounter,
+      recvCounter,
+      stagingState.maxChannelsPerPeer,
+      stagingState.channelDataBufferSize,
+      stagingState.channelStride);
+
+  P2pIbgdaTransportDevice* gpuPtr = nullptr;
+  cudaError_t err = cudaMalloc(&gpuPtr, sizeof(P2pIbgdaTransportDevice));
+  CHECK(err == cudaSuccess)
+      << "Failed to allocate GPU memory for fully-formed IBGDA device: "
+      << cudaGetErrorString(err);
+
+  err = cudaMemcpy(
+      gpuPtr,
+      &hostDev,
+      sizeof(P2pIbgdaTransportDevice),
+      cudaMemcpyHostToDevice);
+  CHECK(err == cudaSuccess)
+      << "Failed to copy fully-formed IBGDA device to GPU: "
+      << cudaGetErrorString(err);
+
+  return gpuPtr;
 }
 
 } // namespace comms::pipes

--- a/comms/pipes/MultipeerIbgdaTransportCuda.cuh
+++ b/comms/pipes/MultipeerIbgdaTransportCuda.cuh
@@ -51,4 +51,28 @@ void freeDeviceTransportsOnGpu(P2pIbgdaTransportDevice* ptr);
  */
 std::size_t getP2pIbgdaTransportDeviceSize();
 
+// Forward declaration
+struct P2pIbgdaTransportState;
+
+/**
+ * Build a fully-formed P2pIbgdaTransportDevice on the host with QP handles
+ * AND staging state. Used by
+ * MultipeerIbgdaTransport::buildP2pTransportDevice().
+ *
+ * This free function exists because P2pIbgdaTransportDevice.cuh includes DOCA
+ * device headers with CUDA-only intrinsics that can't compile in .cc files.
+ * The .cu file can include the full definition.
+ *
+ * @param params QP build parameters
+ * @param stagingState Pre-built staging state for this peer
+ * @param sendCounter Pointer to per-peer send iteration counter
+ * @param recvCounter Pointer to per-peer recv iteration counter
+ * @return Fully-formed P2pIbgdaTransportDevice, allocated on GPU (cudaMalloc)
+ */
+P2pIbgdaTransportDevice* buildFullP2pIbgdaTransportDeviceOnGpu(
+    const P2pIbgdaTransportBuildParams& params,
+    const P2pIbgdaTransportState& stagingState,
+    uint64_t* sendCounter,
+    uint64_t* recvCounter);
+
 } // namespace comms::pipes

--- a/comms/pipes/MultipeerIbgdaTransportCuda.cuh
+++ b/comms/pipes/MultipeerIbgdaTransportCuda.cuh
@@ -21,6 +21,7 @@ struct P2pIbgdaTransportBuildParams {
   doca_gpu_dev_verbs_qp* gpuQp{nullptr};
   doca_gpu_dev_verbs_qp* companionGpuQp{nullptr};
   NetworkLKey sinkLkey{};
+  uint64_t sinkAddr{0};
 };
 
 /**

--- a/comms/pipes/P2pIbgdaTransportDevice.cuh
+++ b/comms/pipes/P2pIbgdaTransportDevice.cuh
@@ -87,8 +87,12 @@ class P2pIbgdaTransportDevice {
   __host__ __device__ P2pIbgdaTransportDevice(
       doca_gpu_dev_verbs_qp* qp,
       doca_gpu_dev_verbs_qp* companionQp = nullptr,
-      NetworkLKey sinkLkey = NetworkLKey{})
-      : qp_(qp), companionQp_(companionQp), sinkLkey_(sinkLkey) {}
+      NetworkLKey sinkLkey = NetworkLKey{},
+      uint64_t sinkAddr = 0)
+      : qp_(qp),
+        companionQp_(companionQp),
+        sinkLkey_(sinkLkey),
+        sinkAddr_(sinkAddr) {}
 
   /**
    * put - RDMA Write without signal (non-blocking)
@@ -439,7 +443,8 @@ class P2pIbgdaTransportDevice {
         .addr = reinterpret_cast<uint64_t>(
             static_cast<uint64_t*>(remoteBuf.ptr) + signalId),
         .key = remoteBuf.rkey.value};
-    doca_gpu_dev_verbs_addr sinkAddr = {.addr = 0, .key = sinkLkey_.value};
+    doca_gpu_dev_verbs_addr sinkAddr = {
+        .addr = sinkAddr_, .key = sinkLkey_.value};
 
     doca_gpu_dev_verbs_signal<
         DOCA_GPUNETIO_VERBS_SIGNAL_OP_ADD,
@@ -470,7 +475,8 @@ class P2pIbgdaTransportDevice {
         .addr = reinterpret_cast<uint64_t>(
             static_cast<uint64_t*>(remoteBuf.ptr) + signalId),
         .key = remoteBuf.rkey.value};
-    doca_gpu_dev_verbs_addr sinkAddr = {.addr = 0, .key = sinkLkey_.value};
+    doca_gpu_dev_verbs_addr sinkAddr = {
+        .addr = sinkAddr_, .key = sinkLkey_.value};
 
     uint64_t wqe_idx = doca_gpu_dev_verbs_reserve_wq_slots<
         DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(qp_, 1);
@@ -571,14 +577,15 @@ class P2pIbgdaTransportDevice {
         .addr = reinterpret_cast<uint64_t>(
             static_cast<uint64_t*>(remoteSignalBuf.ptr) + signalId),
         .key = remoteSignalBuf.rkey.value};
-    doca_gpu_dev_verbs_addr sigSinkAddr = {.addr = 0, .key = sinkLkey_.value};
+    doca_gpu_dev_verbs_addr sigSinkAddr = {
+        .addr = sinkAddr_, .key = sinkLkey_.value};
 
     doca_gpu_dev_verbs_addr counterRemoteAddr = {
         .addr = reinterpret_cast<uint64_t>(
             static_cast<uint64_t*>(localCounterBuf.ptr) + counterId),
         .key = localCounterBuf.lkey.value};
     doca_gpu_dev_verbs_addr counterSinkAddr = {
-        .addr = 0, .key = sinkLkey_.value};
+        .addr = sinkAddr_, .key = sinkLkey_.value};
 
     doca_gpu_dev_verbs_put_signal_counter<
         DOCA_GPUNETIO_VERBS_SIGNAL_OP_ADD,
@@ -621,14 +628,15 @@ class P2pIbgdaTransportDevice {
         .addr = reinterpret_cast<uint64_t>(
             static_cast<uint64_t*>(remoteSignalBuf.ptr) + signalId),
         .key = remoteSignalBuf.rkey.value};
-    doca_gpu_dev_verbs_addr sigSinkAddr = {.addr = 0, .key = sinkLkey_.value};
+    doca_gpu_dev_verbs_addr sigSinkAddr = {
+        .addr = sinkAddr_, .key = sinkLkey_.value};
 
     doca_gpu_dev_verbs_addr counterRemoteAddr = {
         .addr = reinterpret_cast<uint64_t>(
             static_cast<uint64_t*>(localCounterBuf.ptr) + counterId),
         .key = localCounterBuf.lkey.value};
     doca_gpu_dev_verbs_addr counterSinkAddr = {
-        .addr = 0, .key = sinkLkey_.value};
+        .addr = sinkAddr_, .key = sinkLkey_.value};
 
     doca_gpu_dev_verbs_signal_counter<
         DOCA_GPUNETIO_VERBS_SIGNAL_OP_ADD,
@@ -679,7 +687,7 @@ class P2pIbgdaTransportDevice {
             static_cast<uint64_t*>(localCounterBuf.ptr) + counterId),
         .key = localCounterBuf.lkey.value};
     doca_gpu_dev_verbs_addr counterSinkAddr = {
-        .addr = 0, .key = sinkLkey_.value};
+        .addr = sinkAddr_, .key = sinkLkey_.value};
 
     doca_gpu_dev_verbs_put_counter<
         DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
@@ -851,6 +859,7 @@ class P2pIbgdaTransportDevice {
   doca_gpu_dev_verbs_qp* qp_{nullptr};
   doca_gpu_dev_verbs_qp* companionQp_{nullptr};
   NetworkLKey sinkLkey_{};
+  uint64_t sinkAddr_{0};
 };
 
 } // namespace comms::pipes

--- a/comms/pipes/P2pIbgdaTransportDevice.cuh
+++ b/comms/pipes/P2pIbgdaTransportDevice.cuh
@@ -9,8 +9,10 @@
 #include <device/doca_gpunetio_dev_verbs_counter.cuh>
 #include <device/doca_gpunetio_dev_verbs_onesided.cuh>
 
+#include "comms/pipes/CopyUtils.cuh"
 #include "comms/pipes/DocaVerbsUtils.cuh"
 #include "comms/pipes/IbgdaBuffer.h"
+#include "comms/pipes/P2pIbgdaTransportState.h"
 #include "comms/pipes/ThreadGroup.cuh"
 #include "comms/pipes/Timeout.cuh"
 
@@ -80,7 +82,7 @@ class P2pIbgdaTransportDevice {
   P2pIbgdaTransportDevice() = default;
 
   /**
-   * Constructor
+   * Constructor (QP-only, without staging state)
    *
    * @param qp GPU QP handle for RDMA operations
    */
@@ -93,6 +95,54 @@ class P2pIbgdaTransportDevice {
         companionQp_(companionQp),
         sinkLkey_(sinkLkey),
         sinkAddr_(sinkAddr) {}
+
+  /**
+   * Constructor with staging state (fully-formed device, NVLink-symmetric)
+   *
+   * Constructs a device handle with both QP handles AND staging state,
+   * so that send()/recv() can operate without any external state.
+   */
+  __host__ __device__ P2pIbgdaTransportDevice(
+      doca_gpu_dev_verbs_qp* qp,
+      doca_gpu_dev_verbs_qp* companionQp,
+      NetworkLKey sinkLkey,
+      uint64_t sinkAddr,
+      IbgdaLocalBuffer localStagingBuf,
+      IbgdaRemoteBuffer remoteStagingBuf,
+      IbgdaLocalBuffer recvStagingBuf,
+      IbgdaLocalBuffer localSignalBuf,
+      IbgdaRemoteBuffer remoteSignalBuf,
+      int localSignalId,
+      int remoteSignalId,
+      size_t dataBufferSize,
+      int pipelineDepth,
+      uint64_t* sendIterationCounter,
+      uint64_t* recvIterationCounter,
+      int maxChannelsPerPeer = 1,
+      size_t channelDataBufferSize = 0,
+      size_t channelStride = 0)
+      : qp_(qp),
+        companionQp_(companionQp),
+        sinkLkey_(sinkLkey),
+        sinkAddr_(sinkAddr),
+        localStagingBuf_(localStagingBuf),
+        remoteStagingBuf_(remoteStagingBuf),
+        recvStagingBuf_(recvStagingBuf),
+        localSignalBuf_(localSignalBuf),
+        remoteSignalBuf_(remoteSignalBuf),
+        localSignalId_(localSignalId),
+        remoteSignalId_(remoteSignalId),
+        dataBufferSize_(dataBufferSize),
+        pipelineDepth_(pipelineDepth),
+        sendIterationCounter_(sendIterationCounter),
+        recvIterationCounter_(recvIterationCounter),
+        maxChannelsPerPeer_(maxChannelsPerPeer),
+        channelDataBufferSize_(
+            channelDataBufferSize > 0 ? channelDataBufferSize : dataBufferSize),
+        channelStride_(
+            channelStride > 0
+                ? channelStride
+                : static_cast<size_t>(pipelineDepth) * dataBufferSize) {}
 
   /**
    * put - RDMA Write without signal (non-blocking)
@@ -762,6 +812,160 @@ class P2pIbgdaTransportDevice {
     return qp_;
   }
 
+  __host__ __device__ uint32_t getMaxChannelsPerPeer() const {
+    return static_cast<uint32_t>(maxChannelsPerPeer_);
+  }
+
+  // ===========================================================================
+  // High-level send()/recv() APIs (NVLink-symmetric)
+  // ===========================================================================
+  // Encapsulate the pipelined staging buffer protocol, mirroring
+  // P2pNvlTransportDevice::send()/recv(). Requires the fully-formed
+  // constructor (with staging state + counters).
+
+  /**
+   * send - Pipelined RDMA send to peer via staging buffers
+   *
+   * Copies data from src to local staging buffer, then RDMA puts to
+   * the peer's recv staging buffer with completion signaling. Handles
+   * multi-step pipelining and back-pressure automatically.
+   *
+   * Symmetric with P2pNvlTransportDevice::send().
+   */
+  __device__ __forceinline__ void send(
+      [[maybe_unused]] ThreadGroup& group,
+      [[maybe_unused]] void* src,
+      [[maybe_unused]] size_t nbytes,
+      [[maybe_unused]] const Timeout& timeout = Timeout(),
+      [[maybe_unused]] uint32_t channelId = 0) {
+#ifdef __CUDA_ARCH__
+    if (nbytes == 0) {
+      return;
+    }
+    const char* srcPtr = static_cast<const char*>(src);
+    const uint64_t iteration = *(sendIterationCounter_ + channelId);
+    const size_t stepSize = channelDataBufferSize_;
+    const size_t totalSteps = (nbytes + stepSize - 1) / stepSize;
+
+    const int completionSlot = remoteSignalId_ + channelId * kP2pSignalCount;
+    const int backPressureSlot =
+        localSignalId_ + channelId * kP2pSignalCount + 1;
+
+    for (size_t stepId = 0; stepId < totalSteps; stepId++) {
+      const size_t pipelineIdx = (iteration + stepId) % pipelineDepth_;
+      const size_t stagingOffset =
+          channelId * channelStride_ + pipelineIdx * channelDataBufferSize_;
+      const size_t stepOffset = stepId * stepSize;
+      const size_t stepBytes =
+          (stepOffset + stepSize <= nbytes) ? stepSize : (nbytes - stepOffset);
+
+      if (iteration + stepId >= static_cast<uint64_t>(pipelineDepth_)) {
+        if (group.is_leader()) {
+          wait_signal(
+              localSignalBuf_,
+              backPressureSlot,
+              iteration + stepId - pipelineDepth_ + 1,
+              timeout);
+        }
+        group.sync();
+      }
+
+      memcpy_vectorized(
+          static_cast<char*>(localStagingBuf_.ptr) + stagingOffset,
+          srcPtr + stepOffset,
+          stepBytes,
+          group);
+
+      group.sync();
+      __threadfence_system();
+
+      if (group.is_global_leader()) {
+        put_signal(
+            localStagingBuf_.subBuffer(stagingOffset),
+            remoteStagingBuf_.subBuffer(stagingOffset),
+            stepBytes,
+            remoteSignalBuf_,
+            completionSlot,
+            1);
+      }
+    }
+
+    if (group.is_global_leader()) {
+      atomicAdd(
+          reinterpret_cast<unsigned long long int*>(
+              sendIterationCounter_ + channelId),
+          static_cast<unsigned long long int>(totalSteps));
+    }
+    group.sync();
+#endif
+  }
+
+  /**
+   * recv - Pipelined RDMA recv from peer via staging buffers
+   *
+   * Waits for completion signals from the sender, then copies data from
+   * the local recv staging buffer to dst. Sends back-pressure signals
+   * to the sender to allow pipeline slot reuse.
+   *
+   * Symmetric with P2pNvlTransportDevice::recv().
+   */
+  __device__ __forceinline__ void recv(
+      [[maybe_unused]] ThreadGroup& group,
+      [[maybe_unused]] void* dst,
+      [[maybe_unused]] size_t nbytes,
+      [[maybe_unused]] const Timeout& timeout = Timeout(),
+      [[maybe_unused]] uint32_t channelId = 0) {
+#ifdef __CUDA_ARCH__
+    if (nbytes == 0) {
+      return;
+    }
+    char* dstPtr = static_cast<char*>(dst);
+    const uint64_t iteration = *(recvIterationCounter_ + channelId);
+    const size_t stepSize = channelDataBufferSize_;
+    const size_t totalSteps = (nbytes + stepSize - 1) / stepSize;
+
+    const int completionSlot = localSignalId_ + channelId * kP2pSignalCount;
+    const int backPressureSlot =
+        remoteSignalId_ + channelId * kP2pSignalCount + 1;
+
+    for (size_t stepId = 0; stepId < totalSteps; stepId++) {
+      const size_t pipelineIdx = (iteration + stepId) % pipelineDepth_;
+      const size_t stagingOffset =
+          channelId * channelStride_ + pipelineIdx * channelDataBufferSize_;
+      const size_t stepOffset = stepId * stepSize;
+      const size_t stepBytes =
+          (stepOffset + stepSize <= nbytes) ? stepSize : (nbytes - stepOffset);
+
+      if (group.is_leader()) {
+        wait_signal(
+            localSignalBuf_, completionSlot, iteration + stepId + 1, timeout);
+      }
+      group.sync();
+      __threadfence_system();
+
+      memcpy_vectorized(
+          dstPtr + stepOffset,
+          static_cast<char*>(recvStagingBuf_.ptr) + stagingOffset,
+          stepBytes,
+          group);
+
+      group.sync();
+
+      if (group.is_global_leader()) {
+        signal_remote(remoteSignalBuf_, backPressureSlot, 1);
+      }
+    }
+
+    if (group.is_global_leader()) {
+      atomicAdd(
+          reinterpret_cast<unsigned long long int*>(
+              recvIterationCounter_ + channelId),
+          static_cast<unsigned long long int>(totalSteps));
+    }
+    group.sync();
+#endif
+  }
+
  private:
   /**
    * put_group_impl - Generic group-collaborative RDMA Write
@@ -860,6 +1064,22 @@ class P2pIbgdaTransportDevice {
   doca_gpu_dev_verbs_qp* companionQp_{nullptr};
   NetworkLKey sinkLkey_{};
   uint64_t sinkAddr_{0};
+
+  // Staging state (populated by fully-formed constructor)
+  IbgdaLocalBuffer localStagingBuf_{};
+  IbgdaRemoteBuffer remoteStagingBuf_{};
+  IbgdaLocalBuffer recvStagingBuf_{};
+  IbgdaLocalBuffer localSignalBuf_{};
+  IbgdaRemoteBuffer remoteSignalBuf_{};
+  [[maybe_unused]] int localSignalId_{0};
+  [[maybe_unused]] int remoteSignalId_{0};
+  [[maybe_unused]] size_t dataBufferSize_{0};
+  [[maybe_unused]] int pipelineDepth_{0};
+  [[maybe_unused]] uint64_t* sendIterationCounter_{nullptr};
+  [[maybe_unused]] uint64_t* recvIterationCounter_{nullptr};
+  [[maybe_unused]] int maxChannelsPerPeer_{1};
+  [[maybe_unused]] size_t channelDataBufferSize_{0};
+  [[maybe_unused]] size_t channelStride_{0};
 };
 
 } // namespace comms::pipes

--- a/comms/pipes/P2pIbgdaTransportState.h
+++ b/comms/pipes/P2pIbgdaTransportState.h
@@ -1,0 +1,84 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include "comms/pipes/IbgdaBuffer.h"
+
+namespace comms::pipes {
+
+// Fixed: 2 signal slots per peer per channel (completion + back-pressure).
+// Shared across host setup (MultiPeerIbgdaTransportSetup.cc) and device
+// protocol (P2pIbgdaTransportDevice.cuh) so signal offset computations agree.
+inline constexpr int kP2pSignalCount = 2;
+
+/**
+ * P2pIbgdaTransportState - Per-peer device state for IBGDA collectives
+ *
+ * Contains pre-baked buffer descriptors and configuration for one peer.
+ * The kernel indexes into a DeviceSpan<P2pIbgdaTransportState> by peer rank
+ * to get all the information needed for pipelined RDMA send/recv.
+ *
+ * Symmetric with NVLink's P2pNvlTransportDevice::LocalState/RemoteState,
+ * but uses IBGDA buffer descriptors (lkey/rkey) instead of raw pointers.
+ *
+ * Offsets are pre-baked at host setup time (following the NVLink pattern
+ * in MultiPeerNvlTransport::getP2pTransportDevice()), so the kernel only
+ * applies pipeline-slot and chunk offsets within the staging buffer.
+ */
+struct P2pIbgdaTransportState {
+  // Staging data buffer descriptors (allocated once, registered with NIC)
+  // Send and recv use SEPARATE staging regions to avoid data races:
+  //   - Sender writes own data to localStagingBuf, then RDMA puts to remote
+  //   - RDMA from remote peer writes incoming data to recvStagingBuf
+  //   - Receiver reads from recvStagingBuf
+  IbgdaLocalBuffer localStagingBuf; // send staging (sender writes here)
+  IbgdaRemoteBuffer
+      remoteStagingBuf; // remote peer's recv staging (RDMA target)
+  IbgdaLocalBuffer recvStagingBuf; // recv staging (receiver reads here)
+
+  // Signal buffer descriptors (allocated once, registered with NIC)
+  IbgdaLocalBuffer localSignalBuf;
+  IbgdaRemoteBuffer remoteSignalBuf;
+
+  // Signal slot IDs for the sender and receiver directions.
+  // Each rank's signal buffer has nRanks * 2 slots (completion +
+  // back-pressure). localSignalId:  slot in MY signal buffer where this peer
+  // writes
+  //                 (used by receiver to wait_signal)
+  // remoteSignalId: slot in PEER's signal buffer where I write
+  //                 (used by sender to signal_remote)
+  // Layout per peer: [+0] = completion signal, [+1] = back-pressure signal
+  int localSignalId{};
+  int remoteSignalId{};
+
+  // Per-pipeline-slot staging buffer size in bytes
+  size_t dataBufferSize{};
+
+  // Chunk size for sub-pipeline RDMA puts (bytes).
+  //
+  // CURRENTLY UNUSED by the IBGDA kernel. Each pipeline step
+  // issues a single RDMA put_signal for the full dataBufferSize. Unlike the
+  // NVLink path — where chunkSize subdivides each step into independent
+  // chunks with per-chunk ChunkState signaling for warp-level parallelism —
+  // the IBGDA path uses a single QP per peer, so issuing multiple smaller
+  // WQEs per step would just serialize on the same QP and add WQE-posting
+  // overhead without any parallelism benefit.
+  //
+  // This field is intentionally kept for forward compatibility: with
+  // multi-QP support, chunks can be striped across QPs to achieve
+  // sub-step parallelism analogous to the NVLink chunk distribution.
+  size_t chunkSize{};
+
+  // Number of pipeline slots
+  int pipelineDepth{};
+
+  // Multi-channel fields — subdivide per-peer staging across channels.
+  // When maxChannelsPerPeer == 1 (default), single-channel mode:
+  //   channelDataBufferSize == dataBufferSize
+  //   channelStride == pipelineDepth * dataBufferSize
+  int maxChannelsPerPeer{1};
+  size_t channelDataBufferSize{0}; // dataBufferSize / maxChannelsPerPeer
+  size_t channelStride{0}; // pipelineDepth * channelDataBufferSize
+};
+
+} // namespace comms::pipes

--- a/comms/pipes/ThreadGroup.cuh
+++ b/comms/pipes/ThreadGroup.cuh
@@ -91,8 +91,16 @@ struct ThreadGroup {
 
   // scope - Synchronization scope for sync() calls
   // WARP: uses __syncwarp() (fast). BLOCK: uses __syncthreads() (block-wide).
+  // MULTIWARP: uses named barriers (bar.sync barrierId, groupSize).
   // CLUSTER: uses cluster.sync().
   SyncScope scope;
+
+  // barrier_id - Named barrier ID for MULTIWARP scope [0, 15].
+  // Each MULTIWARP group within a block must have a unique barrier_id.
+  // Hardware supports up to 16 named barriers per block.
+  // Set by make_multiwarp_group() or manually when constructing
+  // per-channel sub-groups for IBGDA multi-channel dispatch.
+  uint32_t barrier_id{0};
 
   __device__ inline void sync() {
 #ifdef __CUDA_ARCH__
@@ -110,14 +118,17 @@ struct ThreadGroup {
         __syncwarp();
         break;
       case SyncScope::MULTIWARP: {
-        // Multiwarp = 4 warps = 128 threads
-        // Uses named barriers for synchronization within a multiwarp
-        uint32_t tid = threadIdx.x + threadIdx.y * blockDim.x +
-            threadIdx.z * blockDim.x * blockDim.y;
-        uint32_t barrierId = tid / kMultiwarpSize;
-        asm volatile("bar.sync %0, %1;"
-                     :
-                     : "r"(barrierId), "r"(kMultiwarpSize));
+        // Uses named barriers (bar.sync) for sub-block synchronization.
+        // barrier_id and group_size are set by the creator
+        // (make_multiwarp_group or manual construction for per-channel IBGDA
+        // groups). Hardware supports up to 16 named barriers per block.
+        if (barrier_id >= 16) {
+          printf(
+              "ThreadGroup::sync MULTIWARP: barrier_id (%u) must be < 16\n",
+              barrier_id);
+          __trap();
+        }
+        asm volatile("bar.sync %0, %1;" : : "r"(barrier_id), "r"(group_size));
         break;
       }
       case SyncScope::BLOCK:
@@ -248,15 +259,13 @@ struct ThreadGroup {
         // Always use uint64_t shared memory so that broadcast<uint32_t> and
         // broadcast<uint64_t> share the same __shared__ allocation (CUDA
         // deduplicates by name).
+        // Uses barrier_id as shared memory index (matches the named barrier).
         __shared__ uint64_t __tg_broadcast_scratch[kMaxMultiwarpsPerBlock];
-        uint32_t tid = threadIdx.x + threadIdx.y * blockDim.x +
-            threadIdx.z * blockDim.x * blockDim.y;
-        uint32_t scratch_idx = tid / kMultiwarpSize;
         if (is_leader()) {
-          __tg_broadcast_scratch[scratch_idx] = static_cast<uint64_t>(val);
+          __tg_broadcast_scratch[barrier_id] = static_cast<uint64_t>(val);
         }
         sync();
-        T result = static_cast<T>(__tg_broadcast_scratch[scratch_idx]);
+        T result = static_cast<T>(__tg_broadcast_scratch[barrier_id]);
         sync(); // Prevent leader overwriting before all threads read
         return result;
       }
@@ -549,7 +558,8 @@ __device__ inline PartitionResult ThreadGroup::partition(
           .group_size = group_size,
           .group_id = group_id - partition_start,
           .total_groups = partition_size,
-          .scope = scope}};
+          .scope = scope,
+          .barrier_id = barrier_id}};
 #endif
   return PartitionResult{};
 }
@@ -638,7 +648,8 @@ __device__ inline PartitionResult ThreadGroup::partition(
             .group_size = group_size,
             .group_id = group_id,
             .total_groups = total_groups,
-            .scope = scope}};
+            .scope = scope,
+            .barrier_id = barrier_id}};
   }
 
   // Calculate distributable groups (after guaranteeing 1 per non-zero
@@ -679,7 +690,8 @@ __device__ inline PartitionResult ThreadGroup::partition(
               .group_size = group_size,
               .group_id = group_id - partition_start,
               .total_groups = partition_end - partition_start,
-              .scope = scope}};
+              .scope = scope,
+              .barrier_id = barrier_id}};
     }
     partition_start = partition_end;
   }
@@ -739,7 +751,8 @@ __device__ inline PartitionResult ThreadGroup::partition_interleaved(
           .group_size = group_size,
           .group_id = new_group_id,
           .total_groups = groups_in_partition,
-          .scope = scope}};
+          .scope = scope,
+          .barrier_id = barrier_id}};
 #endif
   return PartitionResult{};
 }
@@ -950,7 +963,8 @@ __device__ inline ThreadGroup make_multiwarp_group() {
       .group_size = kMultiwarpSize,
       .group_id = global_multiwarp_id,
       .total_groups = total_multiwarps,
-      .scope = SyncScope::MULTIWARP};
+      .scope = SyncScope::MULTIWARP,
+      .barrier_id = multiwarp_id_in_block};
 #else
   return ThreadGroup{};
 #endif

--- a/comms/pipes/collectives/AllToAllv.cu
+++ b/comms/pipes/collectives/AllToAllv.cu
@@ -17,8 +17,10 @@
 namespace comms::pipes {
 
 /**
- * AllToAllv kernel.
- * Wrapper kernel that calls the device all_to_allv function.
+ * Unified AllToAllv kernel.
+ * Handles both NVL-only and IBGDA transports — the device-side all_to_allv()
+ * dispatches per-peer based on transport type. IBGDA staging state is now
+ * embedded in each P2pIbgdaTransportDevice (via send()/recv() APIs).
  */
 __global__ void allToAllvKernel(
     void* recvbuff_d,
@@ -38,6 +40,8 @@ __global__ void allToAllvKernel(
       recv_chunk_infos,
       timeout);
 }
+
+// --- Unified host wrappers ---
 
 void all_to_allv(
     void* recvbuff_d,

--- a/comms/pipes/collectives/AllToAllv.cuh
+++ b/comms/pipes/collectives/AllToAllv.cuh
@@ -11,7 +11,29 @@
 #include "comms/pipes/Timeout.cuh"
 #include "comms/pipes/Transport.cuh"
 
+// P2pIbgdaTransportDevice.cuh includes DOCA device headers with CUDA-only
+// intrinsics (atomicCAS, __ldg, etc.) that cannot compile in .cc translation
+// units. Guard with __CUDA_ARCH__ so the header is only included during device
+// compilation. Transport.cuh provides the forward declaration of
+// P2pIbgdaTransportDevice for the pointer type.
+#ifdef __CUDA_ARCH__
+#include "comms/pipes/P2pIbgdaTransportDevice.cuh"
+#endif
+
 namespace comms::pipes {
+
+/**
+ * Chunk metadata for all_to_allv operation.
+ * Describes a contiguous chunk of data to send or receive for a specific peer.
+ */
+struct ChunkInfo {
+  std::size_t offset; // offset in bytes from buffer base address
+  std::size_t nbytes; // number of bytes to send or recv
+
+  __host__ __device__ __forceinline__
+  ChunkInfo(std::size_t offset, std::size_t nbytes)
+      : offset(offset), nbytes(nbytes) {}
+};
 
 namespace {
 /**
@@ -57,17 +79,276 @@ __device__ __forceinline__ void printPerPeerOperation(
 } // namespace
 
 /**
- * Chunk metadata for all_to_allv operation.
- * Describes a contiguous chunk of data to send or receive for a specific peer.
+ * IBGDA send helper with multi-channel dispatch.
+ *
+ * Supports two scheduling modes based on the incoming ThreadGroup's scope:
+ *
+ * BLOCK scope (from make_block_group uniform path):
+ *   - Blocks are partitioned into numActiveBlocks (up to maxChannelsPerPeer /
+ *     channelsPerBlock). Excess blocks per peer early-return.
+ *   - Each active block owns a disjoint channel range [baseChannelId,
+ *     baseChannelId + channelsPerBlock) and a disjoint data slice.
+ *   - Within each block, threads are split into per-channel sub-groups
+ *     with independent named barriers (barrier_id = threadChannelId).
+ *   - Zero redundancy, proper cross-warp sync via named barriers.
+ *   - Backwards compatible: when total_groups==1 behaves identically to today.
+ *
+ * WARP scope (legacy/fallback):
+ *   - Channels are assigned via partition_interleaved across warps
+ *   - Each warp independently handles its channel (redundant if multi-warp)
+ *
+ * @param maxChannelsPerPeer  Max channels (from setup/autotune). 1 = single
+ *                            channel, backward compatible.
  */
-struct ChunkInfo {
-  std::size_t offset; // offset in bytes from buffer base address
-  std::size_t nbytes; // number of bytes to send or recv
+__device__ __forceinline__ void ibgda_send_helper(
+    [[maybe_unused]] ThreadGroup group_per_peer,
+    [[maybe_unused]] Transport& transport,
+    [[maybe_unused]] const void* sendbuff_d,
+    [[maybe_unused]] const ChunkInfo& send_info,
+    [[maybe_unused]] Timeout timeout,
+    [[maybe_unused]] uint32_t maxChannelsPerPeer = 1) {
+#ifdef __CUDA_ARCH__
+  if (group_per_peer.scope == SyncScope::BLOCK) {
+    // Two-level partitioning: each block gets a disjoint channel range and
+    // a disjoint data slice so all active blocks do meaningful work in
+    // parallel.
+    uint32_t warpsPerGroup = group_per_peer.group_size / 32;
+    uint32_t channelsPerBlock = (warpsPerGroup < maxChannelsPerPeer)
+        ? warpsPerGroup
+        : maxChannelsPerPeer;
+    if (channelsPerBlock == 0)
+      channelsPerBlock = 1;
+    uint32_t maxBlocks = maxChannelsPerPeer / channelsPerBlock;
+    uint32_t numActiveBlocks = (group_per_peer.total_groups < maxBlocks)
+        ? group_per_peer.total_groups
+        : maxBlocks;
+    if (numActiveBlocks == 0)
+      numActiveBlocks = 1;
 
-  __host__ __device__ __forceinline__
-  ChunkInfo(std::size_t offset, std::size_t nbytes)
-      : offset(offset), nbytes(nbytes) {}
-};
+    // Excess blocks (can't contribute disjoint channels) early-return.
+    if (group_per_peer.group_id >= numActiveBlocks)
+      return;
+
+    // This block's channel range starts at baseChannelId.
+    // This block's data slice starts at blockOffset.
+    uint32_t baseChannelId = group_per_peer.group_id * channelsPerBlock;
+    size_t blockBytes = send_info.nbytes / numActiveBlocks;
+    size_t blockOffset = group_per_peer.group_id * blockBytes;
+    size_t myBlockBytes = (group_per_peer.group_id == numActiveBlocks - 1)
+        ? (send_info.nbytes - blockOffset)
+        : blockBytes;
+
+    if (channelsPerBlock <= 1) {
+      // Single channel per block: all threads cooperate via named barrier 0.
+      ThreadGroup channel_group = {
+          .thread_id_in_group = group_per_peer.thread_id_in_group,
+          .group_size = group_per_peer.group_size,
+          .group_id = 0,
+          .total_groups = 1,
+          .scope = SyncScope::MULTIWARP,
+          .barrier_id = 0};
+      transport.p2p_ibgda->send(
+          channel_group,
+          static_cast<char*>(const_cast<void*>(sendbuff_d)) + send_info.offset +
+              blockOffset,
+          myBlockBytes,
+          timeout,
+          baseChannelId);
+      return;
+    }
+
+    // Multi-channel within block: split threads into per-channel sub-groups.
+    // barrier_id = threadChannelId (named barriers are block-local, no
+    // collision).
+    uint32_t threadsPerChannel = group_per_peer.group_size / channelsPerBlock;
+    uint32_t threadChannelId =
+        group_per_peer.thread_id_in_group / threadsPerChannel;
+    uint32_t threadInChannel =
+        group_per_peer.thread_id_in_group % threadsPerChannel;
+
+    // Threads beyond the last channel's range are idle (remainder threads).
+    if (threadChannelId >= channelsPerBlock)
+      return;
+
+    ThreadGroup channel_group = {
+        .thread_id_in_group = threadInChannel,
+        .group_size = threadsPerChannel,
+        .group_id = 0,
+        .total_groups = 1,
+        .scope = SyncScope::MULTIWARP,
+        .barrier_id = threadChannelId};
+
+    size_t bytesPerChannel = myBlockBytes / channelsPerBlock;
+    size_t channelOffset = threadChannelId * bytesPerChannel;
+    size_t myBytes = (threadChannelId == channelsPerBlock - 1)
+        ? (myBlockBytes - channelOffset)
+        : bytesPerChannel;
+
+    transport.p2p_ibgda->send(
+        channel_group,
+        static_cast<char*>(const_cast<void*>(sendbuff_d)) + send_info.offset +
+            blockOffset + channelOffset,
+        myBytes,
+        timeout,
+        baseChannelId + threadChannelId);
+    return;
+  }
+
+  // WARP-scope path: existing partition_interleaved behavior.
+  uint32_t numActiveChannels =
+      (group_per_peer.total_groups < maxChannelsPerPeer)
+      ? group_per_peer.total_groups
+      : maxChannelsPerPeer;
+
+  if (numActiveChannels <= 1) {
+    transport.p2p_ibgda->send(
+        group_per_peer,
+        static_cast<char*>(const_cast<void*>(sendbuff_d)) + send_info.offset,
+        send_info.nbytes,
+        timeout,
+        0);
+    return;
+  }
+
+  auto [channelId, channel_group] =
+      group_per_peer.partition_interleaved(numActiveChannels);
+
+  size_t bytesPerChannel = send_info.nbytes / numActiveChannels;
+  size_t channelOffset = channelId * bytesPerChannel;
+  size_t myBytes = (channelId == numActiveChannels - 1)
+      ? (send_info.nbytes - channelOffset)
+      : bytesPerChannel;
+
+  transport.p2p_ibgda->send(
+      channel_group,
+      static_cast<char*>(const_cast<void*>(sendbuff_d)) + send_info.offset +
+          channelOffset,
+      myBytes,
+      timeout,
+      channelId);
+#endif
+}
+
+/**
+ * IBGDA recv helper with multi-channel dispatch (symmetric to send).
+ * Supports both BLOCK scope (cooperative) and WARP scope (legacy).
+ */
+__device__ __forceinline__ void ibgda_recv_helper(
+    [[maybe_unused]] ThreadGroup group_per_peer,
+    [[maybe_unused]] Transport& transport,
+    [[maybe_unused]] void* recvbuff_d,
+    [[maybe_unused]] const ChunkInfo& recv_info,
+    [[maybe_unused]] Timeout timeout,
+    [[maybe_unused]] uint32_t maxChannelsPerPeer = 1) {
+#ifdef __CUDA_ARCH__
+  if (group_per_peer.scope == SyncScope::BLOCK) {
+    // Symmetric to ibgda_send_helper: two-level block+thread partitioning.
+    uint32_t warpsPerGroup = group_per_peer.group_size / 32;
+    uint32_t channelsPerBlock = (warpsPerGroup < maxChannelsPerPeer)
+        ? warpsPerGroup
+        : maxChannelsPerPeer;
+    if (channelsPerBlock == 0)
+      channelsPerBlock = 1;
+    uint32_t maxBlocks = maxChannelsPerPeer / channelsPerBlock;
+    uint32_t numActiveBlocks = (group_per_peer.total_groups < maxBlocks)
+        ? group_per_peer.total_groups
+        : maxBlocks;
+    if (numActiveBlocks == 0)
+      numActiveBlocks = 1;
+
+    if (group_per_peer.group_id >= numActiveBlocks)
+      return;
+
+    uint32_t baseChannelId = group_per_peer.group_id * channelsPerBlock;
+    size_t blockBytes = recv_info.nbytes / numActiveBlocks;
+    size_t blockOffset = group_per_peer.group_id * blockBytes;
+    size_t myBlockBytes = (group_per_peer.group_id == numActiveBlocks - 1)
+        ? (recv_info.nbytes - blockOffset)
+        : blockBytes;
+
+    if (channelsPerBlock <= 1) {
+      ThreadGroup channel_group = {
+          .thread_id_in_group = group_per_peer.thread_id_in_group,
+          .group_size = group_per_peer.group_size,
+          .group_id = 0,
+          .total_groups = 1,
+          .scope = SyncScope::MULTIWARP,
+          .barrier_id = 0};
+      transport.p2p_ibgda->recv(
+          channel_group,
+          static_cast<char*>(recvbuff_d) + recv_info.offset + blockOffset,
+          myBlockBytes,
+          timeout,
+          baseChannelId);
+      return;
+    }
+
+    uint32_t threadsPerChannel = group_per_peer.group_size / channelsPerBlock;
+    uint32_t threadChannelId =
+        group_per_peer.thread_id_in_group / threadsPerChannel;
+    uint32_t threadInChannel =
+        group_per_peer.thread_id_in_group % threadsPerChannel;
+
+    if (threadChannelId >= channelsPerBlock)
+      return;
+
+    ThreadGroup channel_group = {
+        .thread_id_in_group = threadInChannel,
+        .group_size = threadsPerChannel,
+        .group_id = 0,
+        .total_groups = 1,
+        .scope = SyncScope::MULTIWARP,
+        .barrier_id = threadChannelId};
+
+    size_t bytesPerChannel = myBlockBytes / channelsPerBlock;
+    size_t channelOffset = threadChannelId * bytesPerChannel;
+    size_t myBytes = (threadChannelId == channelsPerBlock - 1)
+        ? (myBlockBytes - channelOffset)
+        : bytesPerChannel;
+
+    transport.p2p_ibgda->recv(
+        channel_group,
+        static_cast<char*>(recvbuff_d) + recv_info.offset + blockOffset +
+            channelOffset,
+        myBytes,
+        timeout,
+        baseChannelId + threadChannelId);
+    return;
+  }
+
+  // WARP-scope path: existing partition_interleaved behavior.
+  uint32_t numActiveChannels =
+      (group_per_peer.total_groups < maxChannelsPerPeer)
+      ? group_per_peer.total_groups
+      : maxChannelsPerPeer;
+
+  if (numActiveChannels <= 1) {
+    transport.p2p_ibgda->recv(
+        group_per_peer,
+        static_cast<char*>(recvbuff_d) + recv_info.offset,
+        recv_info.nbytes,
+        timeout,
+        0);
+    return;
+  }
+
+  auto [channelId, channel_group] =
+      group_per_peer.partition_interleaved(numActiveChannels);
+
+  size_t bytesPerChannel = recv_info.nbytes / numActiveChannels;
+  size_t channelOffset = channelId * bytesPerChannel;
+  size_t myBytes = (channelId == numActiveChannels - 1)
+      ? (recv_info.nbytes - channelOffset)
+      : bytesPerChannel;
+
+  transport.p2p_ibgda->recv(
+      channel_group,
+      static_cast<char*>(recvbuff_d) + recv_info.offset + channelOffset,
+      myBytes,
+      timeout,
+      channelId);
+#endif
+}
 
 /**
  * AllToAllv collective communication primitive.
@@ -82,7 +363,7 @@ struct ChunkInfo {
  * 2. For self-rank: Perform local memory copy within the same GPU
  * 3. For peer ranks: Second weighted partition to split warps between send
  *    and recv operations based on their respective data sizes
- * 4. Execute send or recv using P2P NVL transport
+ * 4. Execute send or recv using P2P NVL or P2P IBGDA transport
  *
  * Parameters:
  *   @param recvbuff_d: Device pointer to receive buffer
@@ -93,6 +374,7 @@ struct ChunkInfo {
  *   @param send_chunk_infos: Array of send chunk metadata, one per destination
  * rank
  *   @param recv_chunk_infos: Array of recv chunk metadata, one per source rank
+ *   @param timeout: Timeout configuration
  *
  * Requirements:
  * - Must be called from device code with sufficient threads
@@ -103,20 +385,33 @@ struct ChunkInfo {
  * - Max 8 ranks supported (stack-allocated weights)
  */
 __device__ __forceinline__ void all_to_allv(
-    void* recvbuff_d,
-    const void* sendbuff_d,
-    int my_rank_id,
-    DeviceSpan<Transport> transports_per_rank,
-    DeviceSpan<ChunkInfo> send_chunk_infos,
-    DeviceSpan<ChunkInfo> recv_chunk_infos,
-    Timeout timeout
+    [[maybe_unused]] void* recvbuff_d,
+    [[maybe_unused]] const void* sendbuff_d,
+    [[maybe_unused]] int my_rank_id,
+    [[maybe_unused]] DeviceSpan<Transport> transports_per_rank,
+    [[maybe_unused]] DeviceSpan<ChunkInfo> send_chunk_infos,
+    [[maybe_unused]] DeviceSpan<ChunkInfo> recv_chunk_infos,
+    [[maybe_unused]] Timeout timeout
     // all arguments below will eventually come from communicator
 ) {
 #ifdef __CUDA_ARCH__
-  auto group = make_warp_group();
   const auto nranks = transports_per_rank.size();
   PIPES_DEVICE_CHECK(nranks == send_chunk_infos.size());
   PIPES_DEVICE_CHECK(nranks == recv_chunk_infos.size());
+
+  // Detect whether IBGDA peers are present to choose scheduling mode.
+  // IBGDA transport benefits from block-scope scheduling where all threads
+  // in a block cooperatively memcpy to staging buffers via named barriers.
+  // NVL-only can use warp-scope (each warp handles independent chunks).
+  bool hasIbgdaPeers = false;
+  for (uint32_t r = 0; r < nranks; ++r) {
+    if (transports_per_rank[r].type == TransportType::P2P_IBGDA) {
+      hasIbgdaPeers = true;
+      break;
+    }
+  }
+
+  auto group = hasIbgdaPeers ? make_block_group() : make_warp_group();
 
   // Single rank case - just do self-copy
   if (nranks == 1) {
@@ -135,22 +430,63 @@ __device__ __forceinline__ void all_to_allv(
   // partition_id: 0 = send, 1 = recv
   auto [partition_id, send_recv_group] = group.partition_interleaved(2);
 
-  // 2. Then partition by PEERS using interleaved partitioning
-  // Spreads blocks for same peer across SM space for better load balancing
-  auto [peer_rank_id, group_per_peer] =
-      send_recv_group.partition_interleaved(nranks);
+  // 2. Capped partition by PEERS: cap concurrent peers at available warps
+  // so partition_interleaved never exceeds total_groups. When nranks >
+  // available warps, each warp iterates over multiple peers in batches.
+  uint32_t avail = send_recv_group.total_groups;
+  uint32_t concurrent = (nranks < avail) ? nranks : avail;
+  auto [slot_id, group_per_peer] =
+      send_recv_group.partition_interleaved(concurrent);
 
-  if (peer_rank_id == my_rank_id) {
-    // Self partition - both send and recv groups participate in copying
-    auto& transport = transports_per_rank[my_rank_id];
-    PIPES_DEVICE_CHECK(transport.type == TransportType::SELF);
+  // Extract to local pointer to avoid aliasing (see DeviceSpan.cuh:228).
+  auto transports = transports_per_rank.data();
 
-    const auto& send_info = send_chunk_infos[my_rank_id];
-    const auto& recv_info = recv_chunk_infos[my_rank_id];
-    PIPES_DEVICE_CHECK(send_info.nbytes == recv_info.nbytes);
+  for (uint32_t batch = 0; batch * concurrent < nranks; batch++) {
+    uint32_t peer_rank_id = slot_id + batch * concurrent;
+    if (peer_rank_id >= nranks)
+      break;
 
-    const char* src = static_cast<const char*>(sendbuff_d) + send_info.offset;
-    char* dst = static_cast<char*>(recvbuff_d) + recv_info.offset;
+    const auto& send_info = send_chunk_infos[peer_rank_id];
+    const auto& recv_info = recv_chunk_infos[peer_rank_id];
+    const bool is_send = (partition_id == 0);
+    const size_t nbytes = is_send ? send_info.nbytes : recv_info.nbytes;
+
+    // Nothing to send/recv for this peer
+    if (nbytes == 0) {
+      continue;
+    }
+
+    if (peer_rank_id == static_cast<uint32_t>(my_rank_id)) {
+      // Self partition
+      auto& transport = transports[my_rank_id];
+      PIPES_DEVICE_CHECK(transport.type == TransportType::SELF);
+      PIPES_DEVICE_CHECK(send_info.nbytes == recv_info.nbytes);
+
+      const char* src = static_cast<const char*>(sendbuff_d) + send_info.offset;
+      char* dst = static_cast<char*>(recvbuff_d) + recv_info.offset;
+
+#ifdef DEBUG_ALLTOALLV
+      if (group_per_peer.is_global_leader()) {
+        printPerPeerOperation(
+            my_rank_id,
+            peer_rank_id,
+            partition_id,
+            group_per_peer.total_groups,
+            send_info.offset,
+            recv_info.offset,
+            send_info.nbytes,
+            recv_info.nbytes);
+      }
+#endif
+
+      // Only one partition is active for self-copy
+      if (partition_id == 0) {
+        transport.self.put(group_per_peer, dst, src, send_info.nbytes);
+      }
+      continue;
+    }
+
+    auto& transport = transports[peer_rank_id];
 
 #ifdef DEBUG_ALLTOALLV
     if (group_per_peer.is_global_leader()) {
@@ -166,52 +502,32 @@ __device__ __forceinline__ void all_to_allv(
     }
 #endif
 
-    // Only one partition is active for self-copy
-    if (partition_id == 0) {
-      transport.self.put(group_per_peer, dst, src, send_info.nbytes);
+    // Dispatch based on transport type
+    if (transport.type == TransportType::P2P_NVL) {
+      if (is_send) {
+        transport.p2p_nvl.send(
+            group_per_peer,
+            static_cast<char*>(const_cast<void*>(sendbuff_d)) +
+                send_info.offset,
+            send_info.nbytes,
+            timeout);
+      } else {
+        transport.p2p_nvl.recv(
+            group_per_peer,
+            static_cast<char*>(recvbuff_d) + recv_info.offset,
+            recv_info.nbytes,
+            timeout);
+      }
+    } else if (transport.type == TransportType::P2P_IBGDA) {
+      uint32_t maxCh = transport.p2p_ibgda->getMaxChannelsPerPeer();
+      if (is_send) {
+        ibgda_send_helper(
+            group_per_peer, transport, sendbuff_d, send_info, timeout, maxCh);
+      } else {
+        ibgda_recv_helper(
+            group_per_peer, transport, recvbuff_d, recv_info, timeout, maxCh);
+      }
     }
-    return;
-  }
-
-  // Peer communication
-  const auto& send_info = send_chunk_infos[peer_rank_id];
-  const auto& recv_info = recv_chunk_infos[peer_rank_id];
-
-  // Extract to local pointer to avoid aliasing: compiler can't prove that
-  // operations on transport won't modify transports_per_rank.data_, forcing
-  // reloads. Local variable is provably independent. See DeviceSpan.cuh:228.
-  auto transports = transports_per_rank.data();
-  auto& transport = transports[peer_rank_id];
-  PIPES_DEVICE_CHECK(transport.type == TransportType::P2P_NVL);
-
-#ifdef DEBUG_ALLTOALLV
-  if (group_per_peer.is_global_leader()) {
-    printPerPeerOperation(
-        my_rank_id,
-        peer_rank_id,
-        partition_id,
-        group_per_peer.total_groups,
-        send_info.offset,
-        recv_info.offset,
-        send_info.nbytes,
-        recv_info.nbytes);
-  }
-#endif
-
-  // Perform peer send/recv based on partition_id from first partition
-  bool is_send = (partition_id == 0);
-  if (is_send) {
-    transport.p2p_nvl.send(
-        group_per_peer,
-        static_cast<char*>(const_cast<void*>(sendbuff_d)) + send_info.offset,
-        send_info.nbytes,
-        timeout);
-  } else {
-    transport.p2p_nvl.recv(
-        group_per_peer,
-        static_cast<char*>(recvbuff_d) + recv_info.offset,
-        recv_info.nbytes,
-        timeout);
   }
 
 #endif

--- a/comms/pipes/collectives/AllToAllv.h
+++ b/comms/pipes/collectives/AllToAllv.h
@@ -11,14 +11,16 @@
 namespace comms::pipes {
 
 /**
- * Host wrapper for AllToAllv collective communication.
+ * Unified host wrapper for AllToAllv collective communication.
  *
  * Performs variable-sized all-to-all data exchange among multiple ranks.
  * Each rank sends a potentially different amount of data to every other rank,
  * and receives a potentially different amount of data from every other rank.
  *
- * This is a host function that launches the AllToAllv kernel. All device
- * pointers and DeviceSpans must already be allocated and populated on the GPU.
+ * Supports both NVLink and IBGDA transports via a single entry point.
+ * IBGDA staging state is embedded in each P2pIbgdaTransportDevice — the
+ * kernel dispatches per-peer based on transport type without needing
+ * separate ibgda_peer_states or iteration_counter parameters.
  *
  * This overload creates a Timeout internally per call. For pipelined usage
  * (multiple back-to-back calls), prefer the Timeout overload below to avoid
@@ -36,8 +38,8 @@ namespace comms::pipes {
  * @param num_blocks Number of thread blocks to launch (default: 4)
  * @param num_threads Number of threads per block (default: 256)
  * @param cluster_dim Cluster dimensions for spread cluster launch.
- *                    Default: dim3{4, 1, 1} for better load balancing.
- *                    Set to std::nullopt to use standard kernel launch.
+ *                    Default: dim3{4, 1, 1}. Set to std::nullopt to use
+ *                    standard kernel launch.
  */
 void all_to_allv(
     void* recvbuff_d,
@@ -53,7 +55,7 @@ void all_to_allv(
     std::optional<dim3> cluster_dim = dim3{4, 1, 1});
 
 /**
- * Host wrapper for AllToAllv with pre-built Timeout.
+ * Unified host wrapper for AllToAllv with pre-built Timeout.
  *
  * Use this overload for pipelined/multi-call usage (e.g., benchmarks) where
  * Timeout is created once outside the loop (avoids per-call CUDA API

--- a/comms/pipes/collectives/AllToAllvAuto.cu
+++ b/comms/pipes/collectives/AllToAllvAuto.cu
@@ -17,10 +17,30 @@ void all_to_allv_auto(
     DeviceSpan<ChunkInfo> send_chunk_infos,
     DeviceSpan<ChunkInfo> recv_chunk_infos,
     std::size_t max_bytes_per_peer,
+    bool has_ibgda_peers,
     const AllToAllvAutoConfig& config,
     std::chrono::milliseconds timeout,
     cudaStream_t stream) {
-  if (max_bytes_per_peer <= config.ll128Threshold) {
+  if (has_ibgda_peers) {
+    // IBGDA peers present — use IBGDA-capable path with block-group
+    // scheduling. The kernel detects IBGDA peers and uses make_block_group(),
+    // where each block cooperatively handles one peer. Need at least
+    // 2 * nranks blocks (send + recv × peers).
+    int minBlocks = 2 * nranks;
+    int blocks =
+        (config.ibgdaNumBlocks > minBlocks) ? config.ibgdaNumBlocks : minBlocks;
+    all_to_allv(
+        recvbuff_d,
+        sendbuff_d,
+        my_rank_id,
+        transports_per_rank,
+        send_chunk_infos,
+        recv_chunk_infos,
+        timeout,
+        stream,
+        blocks,
+        config.ibgdaNumThreads);
+  } else if (max_bytes_per_peer <= config.ll128Threshold) {
     int blocks = config.ll128NumBlocks;
     if (blocks <= 0) {
       blocks = ll128_auto_tune_alltoallv(max_bytes_per_peer, nranks).numBlocks;

--- a/comms/pipes/collectives/AllToAllvAuto.h
+++ b/comms/pipes/collectives/AllToAllvAuto.h
@@ -38,6 +38,13 @@ struct AllToAllvAutoConfig {
   /// nranks.
   int ll128NumBlocks{0};
   int ll128NumThreads{512};
+
+  /// IBGDA protocol settings (used when IBGDA peers are present).
+  /// Benchmark data: 1 block is optimal (each doubling of blocks doubles
+  /// latency). Thread count is computed dynamically in all_to_allv_auto()
+  /// as 2 * nranks * 32 (minimum for partition_interleaved chain).
+  int ibgdaNumBlocks{1};
+  int ibgdaNumThreads{128};
 };
 
 /**
@@ -47,6 +54,12 @@ struct AllToAllvAutoConfig {
  * all_to_allv() for large messages (> threshold). The decision is based on
  * max_bytes_per_peer, which the caller must provide (since chunk infos live
  * in device memory).
+ *
+ * When IBGDA peers are present (detected via transport types in the
+ * transports array), automatically selects the IBGDA-capable path with
+ * appropriate block/thread configuration. IBGDA staging state is embedded
+ * in each P2pIbgdaTransportDevice — no separate ibgda_peer_states or
+ * iteration_counter parameters are needed.
  *
  * @param recvbuff_d Device pointer to receive buffer
  * @param sendbuff_d Device pointer to send buffer (const)
@@ -58,6 +71,7 @@ struct AllToAllvAutoConfig {
  * @param max_bytes_per_peer Maximum bytes sent to any single peer (caller
  *                           provides this since chunk infos are in device
  *                           memory)
+ * @param has_ibgda_peers Whether any peer uses IBGDA transport
  * @param config Auto-selector configuration
  * @param timeout Timeout duration (0ms = no timeout, default)
  * @param stream CUDA stream for kernel execution
@@ -71,6 +85,7 @@ void all_to_allv_auto(
     DeviceSpan<ChunkInfo> send_chunk_infos,
     DeviceSpan<ChunkInfo> recv_chunk_infos,
     std::size_t max_bytes_per_peer,
+    bool has_ibgda_peers = false,
     const AllToAllvAutoConfig& config = {},
     std::chrono::milliseconds timeout = std::chrono::milliseconds{0},
     cudaStream_t stream = nullptr);

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1728,6 +1728,42 @@ cvars:
      to be NVL-connected. All data movement and sync operations go over
      NVLink. Requires that all ranks are in the same NVL domain.
 
+ - name        : NCCL_CTRAN_PIPES_DEVICE_ALLTOALLV_ENABLE
+   type        : bool
+   default     : false
+   description : |-
+     Use the pipes all_to_allv kernel for device alltoallv instead of the
+     ctran kernel. The pipes kernel supports both NVLink and IBGDA transports.
+     The ctran kernel currently supports NVLink only. This knob is independent
+     of transport configuration (NCCL_CTRAN_PIPES_DISABLE_IB).
+
+ - name        : NCCL_CTRAN_PIPES_DEVICE_ALLTOALLV_STAGING_BUFFER_SIZE
+   type        : uint64_t
+   default     : 0
+   description : |-
+     Per-pipeline-slot staging buffer size in bytes for IBGDA transport in
+     device alltoallv. Overrides the default (2048 bytes) when set to a
+     non-zero value. Larger values reduce the number of pipeline steps but
+     use more GPU memory.
+
+ - name        : NCCL_CTRAN_PIPES_DEVICE_ALLTOALLV_CHUNK_SIZE
+   type        : uint64_t
+   default     : 0
+   description : |-
+     Chunk size in bytes for sub-pipeline RDMA puts in IBGDA device alltoallv.
+     Overrides the default (512 bytes) when set to a non-zero value. Controls
+     the granularity of individual RDMA write operations within each pipeline
+     step.
+
+ - name        : NCCL_CTRAN_PIPES_DEVICE_ALLTOALLV_PIPELINE_DEPTH
+   type        : int64_t
+   default     : 0
+   description : |-
+     Number of pipeline slots for latency hiding in IBGDA device alltoallv.
+     Overrides the default (4) when set to a non-zero value. Higher values
+     allow more overlap between RDMA transfers and GPU copies but use more
+     staging buffer memory.
+
  - name        : NCCL_CTRAN_IBGDA_QP_DEPTH
    type        : uint64_t
    default     : 1024


### PR DESCRIPTION
Summary:

Wires the pipes-direct alltoallv path into the ncclx production entrypoint
(ncclx::deviceAllToAllv) and adds runtime configuration CVARs.

Direct ncclx-to-pipes routing (AllToAll.cc)
============================================
The production integration in ctranDeviceAllToAllv() now detects IBGDA peers
via MultiPeerDeviceHandle and routes directly to pipesDirectDeviceAllToAllv()
(defined in diff 4/5), bypassing the ctran GPE entirely. This path is gated
by NCCL_CTRAN_PIPES_DEVICE_ALLTOALLV_ENABLE=1.

isPipesEnabled() now accepts P2P_IBGDA as a valid transport type alongside
P2P_NVL and SELF, so communicators with IBGDA peers are not rejected.

CtranPipes.cc configuration
=============================
- Wire NCCL_CTRAN_PIPES_DEVICE_ALLTOALLV_STAGING_BUFFER_SIZE,
  _CHUNK_SIZE, and _PIPELINE_DEPTH CVARs into ibgdaSetupConfig.
- Implement TEST_IBGDA_SINGLE_NODE env var: forces all peers to IBGDA
  transport even on single-node, allowing IBGDA correctness testing
  without a multi-node cluster (data travels GPU->PCIe->NIC->IB->NIC->PCIe->GPU).

New CVARs (nccl_cvars.yaml)
=============================
- NCCL_CTRAN_PIPES_DEVICE_ALLTOALLV_ENABLE: bool, default false.
  Use pipes kernel instead of ctran kernel for device alltoallv.
- NCCL_CTRAN_PIPES_DEVICE_ALLTOALLV_STAGING_BUFFER_SIZE: uint64_t,
  default 0 (uses 2048). Per-pipeline-slot staging buffer size.
- NCCL_CTRAN_PIPES_DEVICE_ALLTOALLV_CHUNK_SIZE: uint64_t,
  default 0 (uses 512). Sub-pipeline RDMA put granularity.
- NCCL_CTRAN_PIPES_DEVICE_ALLTOALLV_PIPELINE_DEPTH: int64_t,
  default 0 (uses 4). Number of pipeline slots for latency hiding.

Differential Revision: D98351461
