### PR TITLE
Add conda integration test infrastructure for MAST (#1393)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ option(USE_XCCL "Whether to build XCCL or not" OFF)
 option(USE_TRANSPORT "Whether to build TRANSPORT or not" ON)
 option(USE_TRITON "Whether to build Triton device bitcode or not" OFF)
 option(BUILD_TESTS "Whether to build tests or not" OFF)
+option(BUILD_INTEGRATION_TESTS "Whether to build integration tests or not" OFF)
 message(STATUS "  USE_NCCL : ${USE_NCCL}")
 message(STATUS "  USE_NCCLX : ${USE_NCCLX}")
 message(STATUS "  USE_GLOO  : ${USE_GLOO}")
@@ -24,6 +25,7 @@ message(STATUS "  USE_XCCL  : ${USE_XCCL}")
 message(STATUS "  USE_TRANSPORT  : ${USE_TRANSPORT}")
 message(STATUS "  USE_TRITON     : ${USE_TRITON}")
 message(STATUS "  BUILD_TESTS    : ${BUILD_TESTS}")
+message(STATUS "  BUILD_INTEGRATION_TESTS : ${BUILD_INTEGRATION_TESTS}")
 
 if(DEFINED ENV{TORCH_CUDA_ARCH_LIST})
     set(TORCH_CUDA_ARCH_LIST $ENV{TORCH_CUDA_ARCH_LIST})
@@ -220,4 +222,12 @@ install(TARGETS torchcomms_comms
 if (BUILD_TESTS)
     enable_testing()
     add_subdirectory(comms/torchcomms/tests/unit/cpp)
+endif()
+
+# Build integration tests (requires GPU, NCCL device API headers).
+# MUST come after ncclx include() above, which sets NCCLX_INCLUDE,
+# NCCLX_SHARED_LIB, FOLLY_LDFLAGS, TORCHCOMMS_HAS_NCCL_DEVICE_API.
+if (BUILD_INTEGRATION_TESTS)
+    enable_testing()
+    add_subdirectory(comms/torchcomms/tests/integration/cpp)
 endif()

--- a/comms/torchcomms/tests/integration/cpp/CMakeLists.txt
+++ b/comms/torchcomms/tests/integration/cpp/CMakeLists.txt
@@ -1,0 +1,111 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# Integration tests for torchcomms — built against conda environment.
+#
+# Builds ncclx_iterated_test binary. All sources are compiled directly into
+# the executable because torchcomms_comms_ncclx is a MODULE target (Python
+# extension loaded via dlopen) and cmake cannot link executables against
+# MODULE libraries.
+#
+# ORDERING DEPENDENCY: This add_subdirectory() must appear after the ncclx
+# include() in the top-level CMakeLists.txt, which sets NCCLX_INCLUDE,
+# NCCLX_SHARED_LIB, FOLLY_LDFLAGS, TORCHCOMMS_HAS_NCCL_DEVICE_API,
+# FMT_INCLUDE, and CONDA_LIB in parent scope.
+#
+# If linker errors for meta::comms::logger::* symbols appear, add:
+#   ${ROOT}/comms/utils/logger/LogUtils.cc
+#   ${ROOT}/comms/utils/logger/LoggingFormat.cc
+# to NCCLX_BACKEND_SOURCES below.
+
+# Verify NCCL device API headers exist before doing anything expensive.
+# Gracefully skip when headers are missing (e.g., feedstock CI with standard NCCL).
+if(NOT EXISTS "${NCCLX_INCLUDE}/nccl_device/core.h")
+    message(WARNING
+        "NCCL Device API headers not found at ${NCCLX_INCLUDE}/nccl_device/core.h. "
+        "Skipping integration tests (requires NCCLX 2.28+ with device API headers).")
+    return()
+endif()
+
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG v1.14.0
+)
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+enable_language(CUDA)
+find_package(CUDAToolkit REQUIRED)
+
+# Test sources (relative to this directory)
+set(INTEGRATION_TEST_DIR ${ROOT}/comms/torchcomms/tests/integration/cpp)
+set(NCCLX_ITERATED_TEST_SOURCES
+    ${INTEGRATION_TEST_DIR}/DeviceApiIteratedTest.cpp
+    ${INTEGRATION_TEST_DIR}/DeviceApiIteratedTestMain.cpp
+    ${INTEGRATION_TEST_DIR}/DeviceApiIteratedTestKernels.cu
+    ${INTEGRATION_TEST_DIR}/IteratedTestHelpers.cpp
+    ${INTEGRATION_TEST_DIR}/TorchCommTestHelpers.cpp
+)
+
+# Backend sources compiled directly — torchcomms_comms_ncclx is MODULE, cannot link
+set(NCCLX_BACKEND_SOURCES
+    ${ROOT}/comms/torchcomms/device/ncclx/NCCLDeviceBackend.cpp
+    ${ROOT}/comms/torchcomms/device/cuda/CudaApi.cpp
+    ${ROOT}/comms/torchcomms/device/cuda/AtomicAddKernel.cu
+    ${ROOT}/comms/torchcomms/device/cuda/DeviceCounter.cpp
+    ${ROOT}/comms/utils/CudaRAII.cc
+)
+
+add_executable(ncclx_iterated_test
+    ${NCCLX_ITERATED_TEST_SOURCES}
+    ${NCCLX_BACKEND_SOURCES}
+)
+
+target_include_directories(ncclx_iterated_test PRIVATE
+    ${ROOT}
+    ${NCCLX_INCLUDE}
+    ${CONDA_INCLUDE}
+    ${FMT_INCLUDE}
+)
+
+target_compile_features(ncclx_iterated_test PRIVATE cxx_std_20)
+
+if(TORCHCOMMS_HAS_NCCL_DEVICE_API)
+    target_compile_definitions(ncclx_iterated_test
+        PRIVATE TORCHCOMMS_HAS_NCCL_DEVICE_API=1)
+endif()
+
+target_link_directories(ncclx_iterated_test PRIVATE ${CONDA_LIB})
+target_link_libraries(ncclx_iterated_test PRIVATE
+    torchcomms
+    ${TORCH_LIBRARIES}
+    ${NCCLX_SHARED_LIB}
+    ${FOLLY_LDFLAGS}
+    GTest::gtest
+)
+if(USE_SYSTEM_LIBS)
+    target_link_libraries(ncclx_iterated_test PRIVATE
+        "-lglog"
+        "-lfmt"
+        "-lboost_program_options"
+        "-lboost_filesystem"
+    )
+else()
+    target_link_libraries(ncclx_iterated_test PRIVATE
+        "-l:libglog.a"
+        "-l:libfmt.a"
+    )
+endif()
+target_link_libraries(ncclx_iterated_test PRIVATE CUDA::cudart)
+
+target_link_options(ncclx_iterated_test PRIVATE
+    "LINKER:--allow-shlib-undefined"
+)
+
+# Install to libexec/torchcomms-tests/ relative to CMAKE_INSTALL_PREFIX.
+# Note: CMAKE_INSTALL_PREFIX is set by setup.py to extdir.parent (pip's build
+# temp), not $PREFIX. The feedstock build.sh handles copying the binary from
+# the build tree to $PREFIX/libexec/torchcomms-tests/ post-install.
+install(TARGETS ncclx_iterated_test
+    RUNTIME DESTINATION libexec/torchcomms-tests
+)

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ IS_ROCM = hasattr(torch.version, "hip") and torch.version.hip is not None
 # Transport is CUDA-only; disable by default on ROCm but allow explicit opt-in.
 USE_TRANSPORT = flag_enabled("USE_TRANSPORT", not IS_ROCM)
 USE_TRITON = flag_enabled("USE_TRITON", False)
+BUILD_INTEGRATION_TESTS = flag_enabled("BUILD_INTEGRATION_TESTS", False)
 
 requirement_path = os.path.join(ROOT, "requirements.txt")
 try:
@@ -132,6 +133,7 @@ class build_ext(build_ext_orig):
             f"-DUSE_XCCL={flag_str(USE_XCCL)}",
             f"-DUSE_TRANSPORT={flag_str(USE_TRANSPORT)}",
             f"-DUSE_TRITON={flag_str(USE_TRITON)}",
+            f"-DBUILD_INTEGRATION_TESTS={flag_str(BUILD_INTEGRATION_TESTS)}",
         ]
         build_args = ["--", "-j"]
 


### PR DESCRIPTION
Summary:

Enable building and running torchcomms NCCLX device API integration tests
inside conda environments on MAST, so tests exercise the same torchcomms
library that end users deploy with.

**Build system changes:**
- Add `BUILD_INTEGRATION_TESTS` cmake option (OFF by default) and new
  `comms/torchcomms/tests/integration/cpp/CMakeLists.txt` that builds
  `ncclx_iterated_test`. Backend sources (NCCLDeviceBackend, CudaApi,
  AtomicAddKernel, DeviceCounter, CudaRAII) are compiled directly into
  the executable because `torchcomms_comms_ncclx` is a MODULE target
  (Python extension) and cmake cannot link executables against MODULE
  libraries.
- Wire `BUILD_INTEGRATION_TESTS` through `setup.py` → cmake via the
  existing `flag_enabled()` pattern.
- The integration tests `add_subdirectory()` is placed after the ncclx
  `include()` in the top-level CMakeLists.txt, which sets `NCCLX_INCLUDE`,
  `NCCLX_SHARED_LIB`, `FOLLY_LDFLAGS`, `TORCHCOMMS_HAS_NCCL_DEVICE_API`.

**Feedstock changes:**
- Update `conda/feedstock/torchcomms/tests/torchcomms.toml` to pass
  `BUILD_INTEGRATION_TESTS=1` so the test conda env builds the binary.
- Add post-install step in `conda/feedstock/torchcomms/build.sh` to copy
  the test binary from cmake's build tree to
  `$PREFIX/libexec/torchcomms-tests/`. This is needed because `setup.py`
  sets `CMAKE_INSTALL_PREFIX` to pip's build temp (not `$PREFIX`).

**MAST launcher changes:**
- Add `--conda-fbpkg` argument (mutually exclusive with `--img`) for
  launching tests from a conda fbpkg instead of buck-built XAR/PAR.
- Add `--conda-test-dir` argument (default: `libexec/torchcomms-tests`).
- In conda mode, set `CONDA_DIR` env var so `local_launcher()` can find
  test binaries, and set `LD_LIBRARY_PATH` to include site-packages
  (where `libtorchcomms.so` lives).
- Add `_find_site_packages()` helper that globs for the Python version
  directory to handle different Python versions.
- Job names include `conda`/`buck` mode suffix for disambiguation.

Differential Revision: D99014725
