### PR TITLE
Fixes for build_rcclx.sh

### DIFF
--- a/build_rcclx.sh
+++ b/build_rcclx.sh
@@ -138,6 +138,7 @@ function build_third_party {
     rm -f "${CONDA_PREFIX}"/*.cmake 2>/dev/null || true
   fi
   local third_party_tag="v2026.01.19.00"
+  local folly_tag="v2026.02.23.00"
 
   mkdir -p /tmp/third-party
   pushd /tmp/third-party
@@ -159,9 +160,14 @@ function build_third_party {
     build_fb_oss_library "https://github.com/facebook/zstd.git" "v1.5.6" zstd
     build_automake_library "https://github.com/jedisct1/libsodium.git" "1.0.20-RELEASE" sodium
     build_fb_oss_library "https://github.com/fastfloat/fast_float.git" "v8.0.2" fast_float "-DFASTFLOAT_INSTALL=ON"
-    build_fb_oss_library "https://github.com/libevent/libevent.git" "release-2.1.12-stable" event
+    # Build libevent as both static and shared (thrift needs .a, others may need .so)
+    build_fb_oss_library "https://github.com/libevent/libevent.git" "release-2.1.12-stable" event "-DEVENT__LIBRARY_TYPE=BOTH"
     build_fb_oss_library "https://github.com/google/double-conversion.git" "v3.3.1" double-conversion
-    build_fb_oss_library "https://github.com/facebook/folly.git" "$third_party_tag" folly "-DUSE_STATIC_DEPS_ON_UNIX=ON -DOPENSSL_USE_STATIC_LIBS=ON"
+    # Build folly with SSE4.2 to match RCCL's F14 intrinsics mode, and define SO_INCOMING_NAPI_ID
+    CXXFLAGS_SAVED="${CXXFLAGS:-}"
+    export CXXFLAGS="${CXXFLAGS_SAVED} -DSO_INCOMING_NAPI_ID=56 -msse4.2"
+    build_fb_oss_library "https://github.com/facebook/folly.git" "$folly_tag" folly "-DUSE_STATIC_DEPS_ON_UNIX=ON -DOPENSSL_USE_STATIC_LIBS=ON -DLIBEVENT_INCLUDE_DIR=${CONDA_PREFIX}/include -DLIBEVENT_LIB=${CONDA_PREFIX}/lib/libevent.a"
+    export CXXFLAGS="${CXXFLAGS_SAVED}"
   else
     if [[ -z "${NCCL_SKIP_CONDA_INSTALL}" ]]; then
       DEPS=(
@@ -194,10 +200,16 @@ function build_third_party {
   # TODO: migrate out all dependencies for feedstock
   if [[ -z "${NCCL_FEEDSTOCK_BUILD}" ]]; then
     build_fb_oss_library "https://github.com/facebookincubator/fizz.git" "$third_party_tag" fizz "-DBUILD_TESTS=OFF -DBUILD_EXAMPLES=OFF"
+    # Clone mvfst and disable the xsk subdirectory (requires linux/if_xdp.h not available on all systems)
+    if [ ! -e "quic" ]; then
+      git clone --depth 1 -b "$third_party_tag" "https://github.com/facebook/mvfst" quic
+    fi
+    sed -i 's|^add_subdirectory(xsk)|# add_subdirectory(xsk) # disabled: requires linux/if_xdp.h|' quic/quic/CMakeLists.txt
     build_fb_oss_library "https://github.com/facebook/mvfst" "$third_party_tag" quic
     build_fb_oss_library "https://github.com/facebook/wangle.git" "$third_party_tag" wangle "-DBUILD_TESTS=OFF"
   fi
   build_fb_oss_library "https://github.com/facebook/fbthrift.git" "$third_party_tag" thrift
+
   popd
 }
 
@@ -206,6 +218,7 @@ function build_comms_tracing_service {
   local base_dir="${PWD}"
   local build_dir=/tmp/build/comms_tracing_service
 
+  rm -rf "$build_dir"
   mkdir -p "$build_dir"
   pushd "$build_dir"
   # set up the directory structure
@@ -283,7 +296,7 @@ THRIFT_SERVICE_LDFLAGS=(
 THIRD_PARTY_LDFLAGS+="${THRIFT_SERVICE_LDFLAGS[*]} "
 THIRD_PARTY_LDFLAGS+="$(pkg-config --libs --static libfolly) "
 if [[ -z "${USE_SYSTEM_LIBS}" ]]; then
-  THIRD_PARTY_LDFLAGS+="-l:libglog.a -l:libgflags.a -l:libboost_context.a -l:libfmt.a -l:libssl.a -l:libcrypto.a"
+  THIRD_PARTY_LDFLAGS+="-lglog -lgflags -l:libboost_context.a -l:libfmt.a -l:libssl.a -l:libcrypto.a"
 else
   THIRD_PARTY_LDFLAGS+="-lglog -lgflags -lboost_context -lfmt -lssl -lcrypto"
 fi
@@ -335,6 +348,25 @@ echo "Successfully generated nccl_cvars files in $CVARS_DIR"
 if [ "$CLEAN_BUILD" == 1 ]; then
     rm -rf "$BUILDDIR"
 fi
+
+export CXXFLAGS="-DSO_INCOMING_NAPI_ID=56"
+
+# Create linker version script to hide gflags/glog symbols from librccl.so.
+# These get pulled in via static libs (libfolly.a, libthriftcpp2.a) but conflict
+# at runtime with libgflags.so/libglog.so loaded by PyTorch.
+cat > /tmp/rccl_hide_gflags.lds << 'LDSEOF'
+{
+  global: *;
+  local:
+    *gflags*;
+    *google*CommandLine*;
+    *google*FlagRegisterer*;
+    *google*GetAllFlags*;
+    *FLAGS_flagfile*;
+    *fLS*FLAGS_*;
+};
+LDSEOF
+export LDFLAGS="${LDFLAGS:-} -Wl,--version-script=/tmp/rccl_hide_gflags.lds"
 
 mkdir -p "$BUILDDIR"
 pushd "${NCCL_HOME}"


### PR DESCRIPTION
Summary:
- New folly version has SO_INCOMING_NAPI_ID used and it wasn't defined anywhere.

- Some symbol conflict resolutions

- Explicitly specify ROCM_PATH

Reviewed By: JinghanHuang, t2h-fb

Differential Revision: D97246200


