### PR TITLE
Extract MockAlgoProfilerReporter into reusable header (#1400)

### DIFF
--- a/comms/ctran/profiler/tests/MockProfilerReporter.h
+++ b/comms/ctran/profiler/tests/MockProfilerReporter.h
@@ -1,0 +1,18 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include "comms/ctran/profiler/AlgoProfilerReport.h"
+#include "comms/ctran/profiler/IProfilerReporter.h"
+
+namespace ctran {
+
+// GMock reporter for verifying profiler report calls in tests.
+class MockProfilerReporter : public IProfilerReporter {
+ public:
+  MOCK_METHOD(void, report, (const AlgoProfilerReport& report), (override));
+};
+
+} // namespace ctran

--- a/comms/ctran/profiler/tests/ProfilerTest.cc
+++ b/comms/ctran/profiler/tests/ProfilerTest.cc
@@ -1,20 +1,12 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include "comms/ctran/profiler/Profiler.h"
-#include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include "comms/ctran/profiler/AlgoProfilerReport.h"
-#include "comms/ctran/profiler/IProfilerReporter.h"
+#include "comms/ctran/profiler/tests/MockProfilerReporter.h"
 
 using namespace ::testing;
 
 namespace ctran {
-
-// Mock reporter using GMock for call verification
-class MockAlgoProfilerReporter : public IProfilerReporter {
- public:
-  MOCK_METHOD(void, report, (const AlgoProfilerReport& report), (override));
-};
 
 class ProfilerTest : public ::testing::Test {
  public:
@@ -79,7 +71,7 @@ TEST_F(ProfilerTest, testDefaultReporterType) {
 }
 
 TEST_F(ProfilerTest, testReportToScubaCallsReporter) {
-  auto mockReporter = std::make_unique<StrictMock<MockAlgoProfilerReporter>>();
+  auto mockReporter = std::make_unique<StrictMock<MockProfilerReporter>>();
   auto* mockPtr = mockReporter.get();
   profiler_ = std::make_unique<ctran::Profiler>(comm_, std::move(mockReporter));
 
@@ -128,7 +120,7 @@ TEST_F(ProfilerTest, testReportToScubaCallsReporter) {
 }
 
 TEST_F(ProfilerTest, testReportToScubaNotCalledWhenNotTracing) {
-  auto mockReporter = std::make_unique<StrictMock<MockAlgoProfilerReporter>>();
+  auto mockReporter = std::make_unique<StrictMock<MockProfilerReporter>>();
   profiler_ = std::make_unique<ctran::Profiler>(comm_, std::move(mockReporter));
 
   // Don't init tracing — StrictMock will fail if report() is called


### PR DESCRIPTION
Summary:

Extract MockAlgoProfilerReporter from ProfilerTest.cc into its own header
for reuse across test files. Add setReporter() to Profiler for test
injection.

Differential Revision: D98946148
