### PR TITLE
Add scuba algo profiling to AllReduceRing (#1401)

### DIFF
--- a/comms/ctran/algos/AllReduce/AllReduceRing.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceRing.cc
@@ -23,6 +23,7 @@
 #include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/ctran/algos/CtranAlgoConsts.h"
 #include "comms/ctran/mapper/CtranMapper.h"
+#include "comms/ctran/profiler/Profiler.h"
 #include "comms/ctran/utils/CudaUtils.h"
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -1009,6 +1010,45 @@ inline commResult_t completeHostResourceSetup(
         std::string(desc));                                                  \
   }
 
+// Dedicated ctrl exchange for straggler detection, separate from the data
+// credit flow. Each rank signals "I'm ready" to both ring neighbors and waits
+// for both to signal back. The measured duration captures pure setup latency
+// (how long until the slowest neighbor is ready) with no data transfer noise.
+static void neighborReadinessBarrier(
+    CtranComm* comm,
+    const ctran::allreduce::ring::HostArgs& args) {
+  CtranMapperRequest recvFromRight;
+  CtranMapperRequest recvFromLeft;
+  CtranMapperRequest sendToLeft;
+  CtranMapperRequest sendToRight;
+
+  // Post receives first to avoid missed signals
+  FB_COMMCHECKTHROW_EX(
+      comm->ctran_->mapper->irecvCtrl(args.rightRank, &recvFromRight),
+      comm->logMetaData_);
+  FB_COMMCHECKTHROW_EX(
+      comm->ctran_->mapper->irecvCtrl(args.leftRank, &recvFromLeft),
+      comm->logMetaData_);
+
+  // Signal both neighbors
+  FB_COMMCHECKTHROW_EX(
+      comm->ctran_->mapper->isendCtrl(args.leftRank, &sendToLeft),
+      comm->logMetaData_);
+  FB_COMMCHECKTHROW_EX(
+      comm->ctran_->mapper->isendCtrl(args.rightRank, &sendToRight),
+      comm->logMetaData_);
+
+  // Wait for peer readiness
+  FB_COMMCHECKTHROW_EX(
+      comm->ctran_->mapper->waitRequest(&recvFromRight), comm->logMetaData_);
+  FB_COMMCHECKTHROW_EX(
+      comm->ctran_->mapper->waitRequest(&recvFromLeft), comm->logMetaData_);
+  FB_COMMCHECKTHROW_EX(
+      comm->ctran_->mapper->waitRequest(&sendToLeft), comm->logMetaData_);
+  FB_COMMCHECKTHROW_EX(
+      comm->ctran_->mapper->waitRequest(&sendToRight), comm->logMetaData_);
+}
+
 static commResult_t impl(
     const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
   FB_CHECKTHROW_EX_NOCOMM(
@@ -1017,16 +1057,27 @@ static commResult_t impl(
   CtranComm* comm = opGroup.front()->comm_;
   CtranAlgoLogger logger(allReduceAlgoName(myAlgo), op->opCount, comm);
 
+  ctran::Profiler* profiler = comm->ctran_->profiler.get();
+  if (profiler) {
+    profiler->initForEachColl(
+        op->opCount, NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT);
+  }
+
   // hostArgs/hostResource are direct members of OpElem — owned by OpElem,
   // destroyed when OpElem is destroyed (after single impl() in eager mode,
   // when graph is destroyed in CUDA graph persistent mode).
   auto& args = op->allreduce.hostArgs;
   auto& resource = op->allreduce.hostResource;
 
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_CTRL));
   if (!resource.setupComplete) {
     FB_COMMCHECK(completeHostResourceSetup(comm, args, resource));
     resource.setupComplete = true;
   }
+  neighborReadinessBarrier(comm, args);
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_CTRL));
 
   // setup algoCtx
   AlgoContext algoCtx = {
@@ -1040,6 +1091,17 @@ static commResult_t impl(
   };
   setupAlgoCtxImpl(algoCtx);
 
+  const size_t messageSize =
+      op->allreduce.count * commTypeSize(op->allreduce.datatype);
+  CTRAN_PROFILER_IF(profiler, {
+    auto& algoContext = profiler->algoContext;
+    algoContext.algorithmName = allReduceAlgoName(myAlgo);
+    algoContext.sendContext.totalBytes = messageSize;
+    algoContext.sendContext.messageSizes = std::to_string(messageSize);
+    algoContext.recvContext.totalBytes = messageSize;
+    algoContext.recvContext.messageSizes = std::to_string(messageSize);
+  });
+
   // Forward direction request vectors
   std::vector<std::unique_ptr<CtranMapperRequest>> dataSResps;
   std::vector<std::unique_ptr<CtranMapperRequest>> bufSyncSResps;
@@ -1052,6 +1114,8 @@ static commResult_t impl(
   std::vector<std::unique_ptr<CtranMapperRequest>> revBufSyncRResps;
   std::vector<std::unique_ptr<CtranMapperRequest>> revFlushResps;
 
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_DATA));
   while (algoCtx.partitionOffset < algoCtx.numElements) {
     updatePartitionCtxHost(args, resource, algoCtx);
     CLOGF_TRACE(
@@ -1140,6 +1204,10 @@ static commResult_t impl(
     updatePartitionDone(algoCtx);
     HOST_ABORT(fmt::format("ctring after partition {}", algoCtx.partition));
   } // end of partition loop
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_DATA));
+
+  CTRAN_PROFILER_IF(profiler, { profiler->reportToScuba(); });
 
   // Reset flags for next allreduce to reuse. Only clear sync status (post/
   // complete flags); do not release to pool (inuse stays true). Pool release

--- a/comms/ctran/profiler/tests/MockAlgoProfilerReporter.h
+++ b/comms/ctran/profiler/tests/MockAlgoProfilerReporter.h
@@ -1,0 +1,18 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <gmock/gmock.h>
+#include "comms/ctran/profiler/AlgoProfilerReport.h"
+#include "comms/ctran/profiler/IProfilerReporter.h"
+
+namespace ctran {
+
+// Mock reporter using GMock for call verification.
+// Extracted from ProfilerTest.cc for reuse across test files.
+class MockAlgoProfilerReporter : public IProfilerReporter {
+ public:
+  MOCK_METHOD(void, report, (const AlgoProfilerReport& report), (override));
+};
+
+} // namespace ctran

--- a/comms/ctran/tests/CtranAllReduceTest.cc
+++ b/comms/ctran/tests/CtranAllReduceTest.cc
@@ -11,6 +11,8 @@
 #include <folly/synchronization/Baton.h>
 
 #include "comms/ctran/Ctran.h"
+#include "comms/ctran/profiler/Profiler.h"
+#include "comms/ctran/profiler/tests/MockAlgoProfilerReporter.h"
 #include "comms/ctran/tests/CtranTestUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
@@ -268,6 +270,66 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Values(
         std::make_tuple("ctring", NCCL_ALLREDUCE_ALGO::ctring),
         std::make_tuple("ctdirect", NCCL_ALLREDUCE_ALGO::ctdirect)),
+    [](const ::testing::TestParamInfo<AllReduceTestParam>& info) {
+      return std::get<0>(info.param);
+    });
+
+// Profiler test subclass: enables profiler in SetUp so ctran::Profiler is
+// created during ctranInit, then injects MockAlgoProfilerReporter.
+class CtranAllReduceProfilerTest : public CtranAllReduceTest {
+ protected:
+  void SetUp() override {
+    setenv("NCCL_CTRAN_TRANSPORT_PROFILER", "1", 1);
+    setenv("NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT", "1", 1);
+    CtranAllReduceTest::SetUp();
+  }
+};
+
+TEST_P(CtranAllReduceProfilerTest, ProfilerReportsValidData) {
+  auto [algoName, algo] = GetParam();
+
+  startWorkers(/*abortEnabled=*/false);
+  for (int rank = 0; rank < kNRanks; ++rank) {
+    run(rank, [this, algo](PerRankState& state) {
+      auto mockReporter = std::make_unique<
+          ::testing::NiceMock<ctran::MockAlgoProfilerReporter>>();
+      auto* mockPtr = mockReporter.get();
+      ASSERT_NE(state.ctranComm->ctran_->profiler, nullptr);
+
+      ctran::AlgoProfilerReport capturedReport{};
+      ctran::AlgoContext capturedAlgoContext{};
+      int reportCount = 0;
+
+      EXPECT_CALL(*mockPtr, report(::testing::_))
+          .WillRepeatedly([&](const ctran::AlgoProfilerReport& report) {
+            reportCount++;
+            capturedReport = report;
+            if (report.algoContext) {
+              capturedAlgoContext = *report.algoContext;
+            }
+          });
+
+      // Replace profiler with one using our mock reporter (ctor injection)
+      state.ctranComm->ctran_->profiler = std::make_unique<ctran::Profiler>(
+          state.ctranComm.get(), std::move(mockReporter));
+
+      runAllReduce(kBufferNElem, state, algo);
+
+      EXPECT_GE(reportCount, 1);
+      EXPECT_EQ(capturedAlgoContext.algorithmName, "CtranAllReduceRing");
+      EXPECT_GT(capturedAlgoContext.sendContext.totalBytes, 0);
+      EXPECT_GT(capturedAlgoContext.recvContext.totalBytes, 0);
+      EXPECT_GT(capturedReport.collectiveDurationUs, 0);
+      EXPECT_GE(capturedReport.controlSyncTimeUs, 0);
+      EXPECT_GE(capturedReport.dataTransferTimeUs, 0);
+    });
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ProfilerCombinations,
+    CtranAllReduceProfilerTest,
+    ::testing::Values(std::make_tuple("ctring", NCCL_ALLREDUCE_ALGO::ctring)),
     [](const ::testing::TestParamInfo<AllReduceTestParam>& info) {
       return std::get<0>(info.param);
     });


### PR DESCRIPTION
Summary:

Add ctran::Profiler instrumentation to AllReduceRing. Traces ALGO_DATA (entire partition loop) phases so that
AllReduceRing timing breakdowns appear in nccl_profiler_algo scuba. 

AllReduceRing doesn't wait for ALGO_CTRL before starting ALGO_DATA. In order to really do that, we need to have a barrier as in D98946151, else ALGO_CTRL is just empty. (even if we put ALGO_CTRL on prePostRemRecvBuf, it's still fire-and-forget, the part posting the credit i.e. sendCtrl is blended in the pipeline itself). The new barrier would be correctly measuring algoCtrl, but adding this barrier causes lost opportunity for the pipeline on startup. So without the barrier, ALGO_DATA itself is the proper straggler measurement, algo performance is illustrated with the shortest ALGO_DATA, which is also the straggler.

Reviewed By: arttianezhu

Differential Revision: D98835445


