### PR TITLE
torchcomms: switch non-ncclx builds to cmake only

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -24,6 +24,11 @@ jobs:
             gpu-arch-type: "cuda"
             gpu-arch-version: "12.8"
             torch-version: "nightly"
+          - runs-on: "linux.g5.12xlarge.nvidia.gpu"
+            gpu-arch-type: "cuda"
+            gpu-arch-version: "12.8"
+            torch-version: "nightly"
+            build-flags: "USE_NCCLX=0 USE_TRANSPORT=0"
 
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     permissions:
@@ -34,10 +39,12 @@ jobs:
       runner: ${{ matrix.runs-on }}
       gpu-arch-type: ${{ matrix.gpu-arch-type }}
       gpu-arch-version: ${{ matrix.gpu-arch-version }}
-      upload-artifact: build-artifacts-${{ matrix.torch-version }}-${{ matrix.gpu-arch-type }}-${{ matrix.gpu-arch-version }}
+      upload-artifact: build-artifacts-${{ matrix.torch-version }}-${{ matrix.gpu-arch-type }}-${{ matrix.gpu-arch-version }}-${{ matrix.build-flags }}
       script: |
         set -ex
         source .github/scripts/setup_env.sh --with-cmake --cuda-version "${{ matrix.gpu-arch-version }}" "${{ matrix.torch-version }}"
+
+        export ${{ matrix.build-flags }}
 
         # Build wheel
         pip install build
@@ -94,6 +101,11 @@ jobs:
             gpu-arch-type: "cuda"
             gpu-arch-version: "12.8"
             torch-version: "nightly"
+          - runs-on: "linux.g5.12xlarge.nvidia.gpu"
+            gpu-arch-type: "cuda"
+            gpu-arch-version: "12.8"
+            torch-version: "nightly"
+            build-flags: "USE_NCCLX=0 USE_TRANSPORT=0"
 
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     permissions:
@@ -104,16 +116,18 @@ jobs:
       runner: ${{ matrix.runs-on }}
       gpu-arch-type: ${{ matrix.gpu-arch-type }}
       gpu-arch-version: ${{ matrix.gpu-arch-version }}
-      download-artifact: build-artifacts-${{ matrix.torch-version }}-${{ matrix.gpu-arch-type }}-${{ matrix.gpu-arch-version }}
+      download-artifact: build-artifacts-${{ matrix.torch-version }}-${{ matrix.gpu-arch-type }}-${{ matrix.gpu-arch-version }}-${{ matrix.build-flags }}
       script: |
         set -ex
         TORCH_VERSION=$(cat "${RUNNER_ARTIFACT_DIR}/torch_version.txt")
         source .github/scripts/setup_env.sh --cuda-version "${{ matrix.gpu-arch-version }}" --torch-version "$TORCH_VERSION" "${{ matrix.torch-version }}"
 
+        export ${{ matrix.build-flags }}
+
         # Install from pre-built wheel (skip build step)
         pip install "${RUNNER_ARTIFACT_DIR}"/*.whl pytest numpy psutil parameterized pydot requests urllib3 tabulate
 
-        python -c "import torchcomms; import torchcomms._transport"
+        python -c "import torchcomms"
 
         # Run Python tests
         comms/torchcomms/scripts/run_tests_unit_py.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,14 +54,37 @@ else()
 endif()
 message(STATUS "TORCH_CUDA_ARCH_LIST : ${TORCH_CUDA_ARCH_LIST}")
 
-# Fetch nlohmann/json
-include(FetchContent)
-FetchContent_Declare(
-    nlohmann_json
-    GIT_REPOSITORY https://github.com/nlohmann/json.git
-    GIT_TAG v3.11.3
-)
-FetchContent_MakeAvailable(nlohmann_json)
+# Set ROOT early — needed by build_ncclx.cmake and backend CMakeLists.
+set(ROOT ${CMAKE_CURRENT_SOURCE_DIR})
+
+set(USE_SYSTEM_LIBS $ENV{USE_SYSTEM_LIBS})
+
+# Find CONDA_PREFIX — must be set before third-party includes so find_package
+# can discover libs installed by build_ncclx.sh.
+if(DEFINED ENV{BUILD_PREFIX})
+    set(CONDA_PREFIX $ENV{PREFIX})
+elseif(DEFINED ENV{CONDA_PREFIX})
+    set(CONDA_PREFIX $ENV{CONDA_PREFIX})
+else()
+    set(CONDA_PREFIX "${ROOT}/build/conda")
+    set(ENV{CONDA_PREFIX} "${CONDA_PREFIX}")
+endif()
+set(CONDA_LIB "${CONDA_PREFIX}/lib")
+set(CONDA_INCLUDE "${CONDA_PREFIX}/include")
+
+# Third-party dependencies (find_package with FetchContent fallback)
+# Allow FetchContent_Populate() which we use to patch glog before add_subdirectory.
+if(POLICY CMP0169)
+    cmake_policy(SET CMP0169 OLD)
+endif()
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/comms/torchcomms/cmake/third_party ${CMAKE_MODULE_PATH})
+# When USE_NCCLX=ON, build_ncclx.sh installs gflags/glog/fmt/folly/etc. into
+# CONDA_PREFIX. Run it first so the find_package calls below find them.
+include(build_ncclx)
+include(nlohmann_json)
+include(gflags)
+include(glog)
+include(fmt)
 
 # Find Python and PyTorch
 find_package(Python3 COMPONENTS Interpreter Development.Module REQUIRED)
@@ -101,24 +124,8 @@ list(APPEND TORCHCOMMS_SOURCES ${HOOKS_SOURCES})
 list(APPEND TORCHCOMMS_SOURCES ${UTILS_SOURCES})
 list(APPEND TORCHCOMMS_PYTHON_SOURCES ${HOOKS_PYTHON_SOURCES})
 
-# Set include directories
-set(ROOT ${CMAKE_CURRENT_SOURCE_DIR})
-
-set(USE_SYSTEM_LIBS $ENV{USE_SYSTEM_LIBS})
-
 message(STATUS "Python3_ROOT_DIR : ${Python3_ROOT_DIR}")
 
-# Find CONDA_PREFIX
-if(DEFINED ENV{BUILD_PREFIX})
-    set(CONDA_PREFIX $ENV{PREFIX})
-elseif(DEFINED ENV{CONDA_PREFIX})
-  set(CONDA_PREFIX $ENV{CONDA_PREFIX})
-else()
-  set(CONDA_PREFIX "${ROOT}/build/conda")
-  set(ENV{CONDA_PREFIX} "${CONDA_PREFIX}")
-endif()
-set(CONDA_LIB "${CONDA_PREFIX}/lib")
-set(CONDA_INCLUDE "${CONDA_PREFIX}/include")
 set(TORCH_PYTHON_LIB "${TORCH_INSTALL_PREFIX}/lib/libtorch_python.so")
 
 # Core libtorchcomms
@@ -134,23 +141,13 @@ target_include_directories(torchcomms PRIVATE
 )
 target_compile_features(torchcomms PRIVATE cxx_std_20)
 target_link_directories(torchcomms PRIVATE ${CONDA_LIB})
+# glog/gflags/fmt must come before TORCH_LIBRARIES so our headers are found
+# before PyTorch's bundled (and potentially different-version) fmt headers.
+# PRIVATE: consumer extensions that need these link them explicitly.
+# Extensions that link torchcomms (gloo, nccl, ncclx) resolve glog/gflags
+# symbols from libtorchcomms.so at runtime via the DT_NEEDED chain.
+target_link_libraries(torchcomms PRIVATE glog::glog gflags::gflags fmt::fmt)
 target_link_libraries(torchcomms PRIVATE ${TORCH_LIBRARIES} nlohmann_json::nlohmann_json)
-if(USE_SYSTEM_LIBS)
-    target_link_libraries(torchcomms PRIVATE
-        "-lglog"
-        "-lgflags"
-        "-lfmt"
-    )
-else()
-    target_include_directories(torchcomms PRIVATE
-        ${ROOT}/third-party/fmt/include
-    )
-    target_link_libraries(torchcomms PRIVATE
-        "-l:libglog.a"
-        "-l:libgflags.a"
-        "-l:libfmt.a"
-    )
-endif()
 
 # Flight Recorder sources (compiled into _comms)
 file(GLOB TORCHCOMMS_FR_SOURCES "comms/torchcomms/hooks/fr/FlightRecorder.cpp")
@@ -177,10 +174,10 @@ target_include_directories(torchcomms_comms PRIVATE
 target_compile_features(torchcomms_comms PRIVATE cxx_std_20)
 target_link_directories(torchcomms_comms PRIVATE ${CONDA_LIB})
 target_link_libraries(torchcomms_comms PRIVATE
-    ${TORCH_LIBRARIES}
-    ${TORCH_PYTHON_LIB}
     torchcomms
     nlohmann_json::nlohmann_json
+    ${TORCH_LIBRARIES}
+    ${TORCH_PYTHON_LIB}
 )
 
 if (USE_NCCL)

--- a/comms/torchcomms/cmake/third_party/build_ncclx.cmake
+++ b/comms/torchcomms/cmake/third_party/build_ncclx.cmake
@@ -1,0 +1,26 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+include_guard(GLOBAL)
+
+# When USE_NCCLX is enabled and we're not using system libs, run build_ncclx.sh
+# to build gflags/glog/fmt/folly/fbthrift/NCCLX into CONDA_PREFIX. This must
+# happen before the other third-party includes so find_package() can discover
+# the libraries that build_ncclx.sh installs.
+if(USE_NCCLX AND NOT USE_SYSTEM_LIBS)
+    set(NCCLX_BUILD_DIR $ENV{BUILDDIR})
+    if(NOT NCCLX_BUILD_DIR)
+        set(NCCLX_BUILD_DIR "${ROOT}/build/ncclx")
+    endif()
+    if(NOT EXISTS "${NCCLX_BUILD_DIR}")
+        message(STATUS "NCCLX build dir not found at ${NCCLX_BUILD_DIR}, running build_ncclx.sh...")
+        execute_process(
+            COMMAND ${ROOT}/build_ncclx.sh
+            WORKING_DIRECTORY ${ROOT}
+            RESULT_VARIABLE _ncclx_result
+            ERROR_VARIABLE _ncclx_error
+        )
+        if(_ncclx_result)
+            message(FATAL_ERROR "NCCLX build failed: ${_ncclx_result}\n${_ncclx_error}")
+        endif()
+    endif()
+endif()

--- a/comms/torchcomms/cmake/third_party/fmt.cmake
+++ b/comms/torchcomms/cmake/third_party/fmt.cmake
@@ -1,0 +1,43 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+include_guard(GLOBAL)
+
+# We need static fmt — shared libs can't be shipped in wheels.
+# Check for static library first (e.g., installed by build_ncclx.sh).
+# This avoids find_package creating SHARED IMPORTED targets that can't be
+# rejected without a duplicate-target conflict in the FetchContent fallback.
+if(EXISTS "${CONDA_INCLUDE}/fmt/format.h")
+    # Prefer static, fall back to shared.
+    if(EXISTS "${CONDA_LIB}/libfmt.a")
+        set(_FMT_LIB "${CONDA_LIB}/libfmt.a")
+    elseif(EXISTS "${CONDA_LIB}/libfmt.so")
+        set(_FMT_LIB "${CONDA_LIB}/libfmt.so")
+    else()
+        set(_FMT_LIB "fmt")
+    endif()
+    add_library(fmt::fmt INTERFACE IMPORTED GLOBAL)
+    set_target_properties(fmt::fmt PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${CONDA_INCLUDE}"
+        INTERFACE_LINK_LIBRARIES "${_FMT_LIB}"
+    )
+    message(STATUS "Using fmt: ${_FMT_LIB}")
+else()
+    find_package(fmt 11.2.0 QUIET CONFIG NO_CMAKE_PACKAGE_REGISTRY)
+    if(fmt_FOUND)
+        message(STATUS "Found system fmt: ${fmt_VERSION}")
+    else()
+        message(STATUS "System fmt not found, fetching 11.2.0 header-only via FetchContent")
+        include(FetchContent)
+        FetchContent_Declare(
+            fmt
+            GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+            GIT_TAG 11.2.0
+        )
+        FetchContent_Populate(fmt)
+        add_library(fmt::fmt INTERFACE IMPORTED GLOBAL)
+        set_target_properties(fmt::fmt PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${fmt_SOURCE_DIR}/include"
+            INTERFACE_COMPILE_DEFINITIONS "FMT_HEADER_ONLY=1"
+        )
+    endif()
+endif()

--- a/comms/torchcomms/cmake/third_party/gflags.cmake
+++ b/comms/torchcomms/cmake/third_party/gflags.cmake
@@ -1,0 +1,79 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+include_guard(GLOBAL)
+
+# We need static gflags — shared libs can't be shipped in wheels.
+# Check for static library first (e.g., installed by build_ncclx.sh).
+# This avoids find_package creating SHARED IMPORTED targets that can't be
+# rejected without a duplicate-target conflict in the FetchContent fallback.
+if(EXISTS "${CONDA_INCLUDE}/gflags/gflags.h")
+    # Prefer static, fall back to shared.
+    if(EXISTS "${CONDA_LIB}/libgflags.a")
+        set(_GFLAGS_LIB "${CONDA_LIB}/libgflags.a")
+    elseif(EXISTS "${CONDA_LIB}/libgflags.so")
+        set(_GFLAGS_LIB "${CONDA_LIB}/libgflags.so")
+    else()
+        set(_GFLAGS_LIB "gflags")
+    endif()
+    add_library(gflags::gflags INTERFACE IMPORTED GLOBAL)
+    set_target_properties(gflags::gflags PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${CONDA_INCLUDE}"
+        INTERFACE_LINK_LIBRARIES "${_GFLAGS_LIB}"
+    )
+    message(STATUS "Using gflags: ${_GFLAGS_LIB}")
+else()
+    find_package(gflags 2.2.2 QUIET CONFIG NO_CMAKE_PACKAGE_REGISTRY)
+    if(gflags_FOUND)
+        message(STATUS "Found system gflags: ${gflags_VERSION}")
+    else()
+        message(STATUS "System gflags not found, fetching v2.2.2 via FetchContent")
+        include(FetchContent)
+        FetchContent_Declare(
+            gflags
+            GIT_REPOSITORY https://github.com/gflags/gflags.git
+            GIT_TAG v2.2.2
+        )
+        set(GFLAGS_SHARED OFF CACHE BOOL "" FORCE)
+        set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
+        set(CMAKE_POSITION_INDEPENDENT_CODE ON CACHE BOOL "" FORCE)
+        FetchContent_Populate(gflags)
+        # Patch cmake_minimum_required: gflags v2.2.2 uses VERSION 2.8.12 which is
+        # a fatal error on CMake 3.31+ ("Compatibility with CMake < 3.5 removed").
+        file(READ "${gflags_SOURCE_DIR}/CMakeLists.txt" _gflags_cml)
+        string(REPLACE
+            "cmake_minimum_required (VERSION 2.8.12)"
+            "cmake_minimum_required (VERSION 3.5)"
+            _gflags_cml "${_gflags_cml}")
+        file(WRITE "${gflags_SOURCE_DIR}/CMakeLists.txt" "${_gflags_cml}")
+        # Keep build artifacts in the build tree, not the source/install dir
+        set(_save_archive_dir ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY})
+        set(_save_lib_dir ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
+        set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+        set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+        add_subdirectory(${gflags_SOURCE_DIR} ${gflags_BINARY_DIR} EXCLUDE_FROM_ALL)
+        set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${_save_archive_dir})
+        set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${_save_lib_dir})
+    endif()
+
+    # gflags v2.2.2 doesn't always provide a gflags::gflags target:
+    #   - Installed configs create gflags::gflags_nothreads_shared etc.
+    #   - FetchContent/add_subdirectory creates gflags_nothreads_static etc.
+    # Create gflags::gflags as an alias to the first available target.
+    if(NOT TARGET gflags::gflags)
+        foreach(_tgt
+            gflags::gflags_nothreads_static gflags::gflags_static
+            gflags_nothreads_static gflags_static
+            gflags
+            gflags::gflags_nothreads_shared gflags::gflags_shared
+            gflags_nothreads_shared gflags_shared)
+            if(TARGET ${_tgt})
+                add_library(gflags::gflags ALIAS ${_tgt})
+                message(STATUS "Created gflags::gflags alias -> ${_tgt}")
+                break()
+            endif()
+        endforeach()
+        if(NOT TARGET gflags::gflags)
+            message(FATAL_ERROR "gflags found/built but no usable target exists")
+        endif()
+    endif()
+endif()

--- a/comms/torchcomms/cmake/third_party/glog.cmake
+++ b/comms/torchcomms/cmake/third_party/glog.cmake
@@ -1,0 +1,67 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+include_guard(GLOBAL)
+
+# glog::glog        — links the glog library (static or shared).
+# glog::glog_headers — INTERFACE (header-only), no library linked.
+#
+# libtorchcomms.so links glog::glog (gets symbols). Extensions that only
+# need headers (gloo, nccl) use glog::glog_headers and resolve symbols
+# from libtorchcomms.so at runtime via DT_NEEDED.
+if(EXISTS "${CONDA_INCLUDE}/glog/logging.h")
+    # Prefer static, fall back to shared, fall back to -lglog.
+    if(EXISTS "${CONDA_LIB}/libglog.a")
+        set(_GLOG_LIB "${CONDA_LIB}/libglog.a")
+    elseif(EXISTS "${CONDA_LIB}/libglog.so")
+        set(_GLOG_LIB "${CONDA_LIB}/libglog.so")
+    else()
+        set(_GLOG_LIB "glog")
+    endif()
+    add_library(glog::glog INTERFACE IMPORTED GLOBAL)
+    set_target_properties(glog::glog PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${CONDA_INCLUDE}"
+        INTERFACE_LINK_LIBRARIES "${_GLOG_LIB}"
+    )
+    add_library(glog::glog_headers INTERFACE IMPORTED GLOBAL)
+    set_target_properties(glog::glog_headers PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${CONDA_INCLUDE}"
+    )
+    message(STATUS "Using glog: ${_GLOG_LIB}")
+else()
+    find_package(glog 0.4.0 QUIET CONFIG NO_CMAKE_PACKAGE_REGISTRY)
+    if(glog_FOUND)
+        message(STATUS "Found system glog: ${glog_VERSION}")
+        get_target_property(_glog_inc glog::glog INTERFACE_INCLUDE_DIRECTORIES)
+        add_library(glog::glog_headers INTERFACE IMPORTED GLOBAL)
+        set_target_properties(glog::glog_headers PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${_glog_inc}"
+        )
+    else()
+        message(STATUS "System glog not found, fetching v0.4.0 via FetchContent")
+        include(FetchContent)
+        FetchContent_Declare(
+            glog
+            GIT_REPOSITORY https://github.com/google/glog.git
+            GIT_TAG v0.4.0
+        )
+        set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
+        set(WITH_GFLAGS OFF CACHE BOOL "" FORCE)
+        set(CMAKE_POSITION_INDEPENDENT_CODE ON CACHE BOOL "" FORCE)
+        # Keep build artifacts in the build tree
+        set(_save_archive_dir ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY})
+        set(_save_lib_dir ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
+        set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+        set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+        FetchContent_Populate(glog)
+        add_subdirectory(${glog_SOURCE_DIR} ${glog_BINARY_DIR} EXCLUDE_FROM_ALL)
+        set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${_save_archive_dir})
+        set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${_save_lib_dir})
+        # glog's CMake build creates a glog::glog target.
+        # Create glog_headers from its include directories.
+        get_target_property(_glog_inc glog::glog INTERFACE_INCLUDE_DIRECTORIES)
+        add_library(glog::glog_headers INTERFACE IMPORTED GLOBAL)
+        set_target_properties(glog::glog_headers PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${_glog_inc}"
+        )
+    endif()
+endif()

--- a/comms/torchcomms/cmake/third_party/nlohmann_json.cmake
+++ b/comms/torchcomms/cmake/third_party/nlohmann_json.cmake
@@ -1,0 +1,18 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+include_guard(GLOBAL)
+
+find_package(nlohmann_json 3.11.3 QUIET CONFIG NO_CMAKE_PACKAGE_REGISTRY)
+if(nlohmann_json_FOUND)
+    message(STATUS "Found system nlohmann_json: ${nlohmann_json_VERSION}")
+else()
+    message(STATUS "System nlohmann_json not found, fetching v3.11.3 via FetchContent")
+    include(FetchContent)
+    FetchContent_Declare(
+        nlohmann_json
+        GIT_REPOSITORY https://github.com/nlohmann/json.git
+        GIT_TAG v3.11.3
+    )
+    FetchContent_Populate(nlohmann_json)
+    add_subdirectory(${nlohmann_json_SOURCE_DIR} ${nlohmann_json_BINARY_DIR} EXCLUDE_FROM_ALL)
+endif()

--- a/comms/torchcomms/gloo/CMakeLists.txt
+++ b/comms/torchcomms/gloo/CMakeLists.txt
@@ -21,7 +21,6 @@ set_target_properties(torchcomms_comms_gloo PROPERTIES
 )
 target_include_directories(torchcomms_comms_gloo PRIVATE
     ${ROOT}
-    ${FMT_INCLUDE}
     ${CONDA_INCLUDE}
     ${Python3_INCLUDE_DIRS}
     ${gloo_SOURCE_DIR}
@@ -29,19 +28,12 @@ target_include_directories(torchcomms_comms_gloo PRIVATE
 target_compile_features(torchcomms_comms_gloo PRIVATE cxx_std_20)
 target_link_directories(torchcomms_comms_gloo PRIVATE ${CONDA_LIB})
 target_link_libraries(torchcomms_comms_gloo PRIVATE
+    glog::glog_headers
+    torchcomms
+    fmt::fmt
     ${TORCH_LIBRARIES}
     ${TORCH_PYTHON_LIB}
-    torchcomms
 )
-if(USE_SYSTEM_LIBS)
-    target_link_libraries(torchcomms_comms_gloo PRIVATE
-        "-lfmt"
-    )
-else()
-    target_link_libraries(torchcomms_comms_gloo PRIVATE
-        "-l:libfmt.a"
-    )
-endif()
 
 install(TARGETS torchcomms_comms_gloo
     LIBRARY DESTINATION .

--- a/comms/torchcomms/nccl/CMakeLists.txt
+++ b/comms/torchcomms/nccl/CMakeLists.txt
@@ -22,8 +22,6 @@ else()
     )
 endif()
 
-set(FMT_INCLUDE "${ROOT}/third-party/fmt/include")
-
 add_library(torchcomms_comms_nccl MODULE
     ${TORCHCOMMS_NCCL_SOURCES}
     ${TORCHCOMMS_CUDA_API_SOURCE}
@@ -37,26 +35,25 @@ set_target_properties(torchcomms_comms_nccl PROPERTIES
 target_include_directories(torchcomms_comms_nccl PRIVATE
     ${ROOT}
     ${NCCL_INCLUDE}
-    ${FMT_INCLUDE}
     ${CONDA_INCLUDE}
     ${Python3_INCLUDE_DIRS}
 )
 target_compile_features(torchcomms_comms_nccl PRIVATE cxx_std_20)
 target_link_directories(torchcomms_comms_nccl PRIVATE ${CONDA_LIB})
 target_link_libraries(torchcomms_comms_nccl PRIVATE
+    glog::glog_headers
+    fmt::fmt
+    torchcomms
     ${TORCH_LIBRARIES}
     ${TORCH_PYTHON_LIB}
-    torchcomms
 )
 if(USE_SYSTEM_LIBS)
     target_link_libraries(torchcomms_comms_nccl PRIVATE
         ${NCCL_SHARED_LIB}
-        "-lfmt"
     )
 else()
     target_link_libraries(torchcomms_comms_nccl PRIVATE
         ${NCCL_STATIC_LIB}
-        "-l:libfmt.a"
     )
 endif()
 

--- a/comms/torchcomms/ncclx/CMakeLists.txt
+++ b/comms/torchcomms/ncclx/CMakeLists.txt
@@ -24,19 +24,8 @@ else()
     set(NCCLX_INCLUDE "${NCCLX_BUILD_DIR}/include")
     set(NCCLX_STATIC_LIB "${NCCLX_BUILD_DIR}/lib/libnccl_static.a")
     set(NCCLX_SHARED_LIB "${NCCLX_BUILD_DIR}/lib/libnccl.so")
-    set(FMT_INCLUDE "${ROOT}/third-party/fmt/include")
-
-    if (NOT EXISTS "${NCCLX_BUILD_DIR}")
-        execute_process(
-            COMMAND ${ROOT}/build_ncclx.sh
-            WORKING_DIRECTORY ${ROOT}
-            RESULT_VARIABLE result
-            OUTPUT_VARIABLE output
-        )
-        if(result)
-            message(FATAL_ERROR "NCCLX build failed: ${result}")
-        endif()
-    endif()
+    # build_ncclx.sh is invoked by build_ncclx.cmake (included before other
+    # third-party deps) so NCCLX_BUILD_DIR should already exist at this point.
 endif()
 
 # Get folly LDFLAGS using pkg-config
@@ -52,8 +41,13 @@ if(NOT PKG_RESULT EQUAL 0)
 endif()
 separate_arguments(FOLLY_LDFLAGS NATIVE_COMMAND "${FOLLY_LDFLAGS_RAW}")
 
-# Remove any -l:libglog.a from FOLLY_LDFLAGS
-list(FILTER FOLLY_LDFLAGS EXCLUDE REGEX ".*libglog.*")
+# Remove glog/gflags/fmt from FOLLY_LDFLAGS — they're already linked
+# statically via libtorchcomms.so from the third-party cmake modules.
+# pkg-config may output -lglog, -l:libglog.a, or full paths like
+# /path/to/libglog.a — the simple substring match handles all forms.
+list(FILTER FOLLY_LDFLAGS EXCLUDE REGEX "glog")
+list(FILTER FOLLY_LDFLAGS EXCLUDE REGEX "gflags")
+list(FILTER FOLLY_LDFLAGS EXCLUDE REGEX "libfmt")
 
 # Check NCCLX include exists
 if(NOT EXISTS "${NCCLX_INCLUDE}")
@@ -112,7 +106,6 @@ set_target_properties(torchcomms_comms_ncclx PROPERTIES
 target_include_directories(torchcomms_comms_ncclx PRIVATE
     ${ROOT}
     ${NCCLX_INCLUDE}
-    ${FMT_INCLUDE}
     ${CONDA_INCLUDE}
     ${Python3_INCLUDE_DIRS}
 )
@@ -132,15 +125,15 @@ endif()
 
 target_link_directories(torchcomms_comms_ncclx PRIVATE ${CONDA_LIB})
 target_link_libraries(torchcomms_comms_ncclx PRIVATE
+    fmt::fmt
+    torchcomms
     ${TORCH_LIBRARIES}
     ${TORCH_PYTHON_LIB}
-    torchcomms
 )
 if(USE_SYSTEM_LIBS)
     target_link_libraries(torchcomms_comms_ncclx PRIVATE
         ${NCCLX_SHARED_LIB}
         ${FOLLY_LDFLAGS}
-        "-lfmt"
         "-lboost_program_options"
         "-lboost_filesystem"
     )
@@ -172,7 +165,6 @@ else()
         "-l:libxxhash.a"
         "-l:libboost_filesystem.a"
         "-l:libboost_context.a"
-        "-l:libfmt.a"
         ${FOLLY_LDFLAGS}
     )
     # Rename NCCL symbols to avoid conflicting with OSS nccl* that is bundled

--- a/comms/torchcomms/rccl/CMakeLists.txt
+++ b/comms/torchcomms/rccl/CMakeLists.txt
@@ -11,8 +11,6 @@ set(ROCM_INCLUDE "${ROCM_HOME}/include")
 set(RCCL_INCLUDE $ENV{RCCL_INCLUDE})
 message(STATUS "RCCL_INCLUDE is set to ${RCCL_INCLUDE}")
 set(RCCL_SHARED_LIB ${ROCM_HOME}/lib/librccl.so)
-set(FMT_INCLUDE "${ROOT}/third-party/fmt/include")
-
 add_library(torchcomms_comms_rccl MODULE ${TORCHCOMMS_RCCL_SOURCES})
 set_target_properties(torchcomms_comms_rccl PROPERTIES
     PREFIX ""
@@ -24,7 +22,6 @@ set_target_properties(torchcomms_comms_rccl PROPERTIES
 target_include_directories(torchcomms_comms_rccl PRIVATE
     ${ROOT}
     ${RCCL_INCLUDE}
-    ${FMT_INCLUDE}
     ${CONDA_INCLUDE}
     ${Python3_INCLUDE_DIRS}
     ${ROCM_INCLUDE}
@@ -33,13 +30,10 @@ target_include_directories(torchcomms_comms_rccl PRIVATE
 target_compile_features(torchcomms_comms_rccl PRIVATE cxx_std_20)
 target_link_directories(torchcomms_comms_rccl PRIVATE ${CONDA_LIB})
 target_link_libraries(torchcomms_comms_rccl PRIVATE
+    torchcomms
     ${TORCH_LIBRARIES}
     ${TORCH_PYTHON_LIB}
-    torchcomms
-)
-target_link_libraries(torchcomms_comms_rccl PRIVATE
     ${RCCL_SHARED_LIB}
-    "-lfmt"
 )
 
 set(CMAKE_CXX_COMPILE_OBJECT "${CMAKE_CXX_COMPILE_OBJECT} -std=c++20")

--- a/comms/torchcomms/rcclx/CMakeLists.txt
+++ b/comms/torchcomms/rcclx/CMakeLists.txt
@@ -13,8 +13,6 @@ message(STATUS "RCCLX_INCLUDE is set to ${RCCLX_INCLUDE}")
 set(RCCLX_SHARED_LIB $ENV{RCCLX_LIB}/librccl.so)
 message(STATUS "RCCLX_SHARED_LIB is set to ${RCCLX_SHARED_LIB}")
 
-set(FMT_INCLUDE "${ROOT}/third-party/fmt/include")
-
 add_library(torchcomms_comms_rcclx MODULE ${TORCHCOMMS_RCCLX_SOURCES})
 set_target_properties(torchcomms_comms_rcclx PROPERTIES
     PREFIX ""
@@ -26,7 +24,6 @@ set_target_properties(torchcomms_comms_rcclx PROPERTIES
 target_include_directories(torchcomms_comms_rcclx PRIVATE
     ${ROOT}
     ${RCCLX_INCLUDE}
-    ${FMT_INCLUDE}
     ${CONDA_INCLUDE}
     ${Python3_INCLUDE_DIRS}
     ${ROCM_INCLUDE}
@@ -35,13 +32,10 @@ target_include_directories(torchcomms_comms_rcclx PRIVATE
 target_compile_features(torchcomms_comms_rcclx PRIVATE cxx_std_20)
 target_link_directories(torchcomms_comms_rcclx PRIVATE ${CONDA_LIB})
 target_link_libraries(torchcomms_comms_rcclx PRIVATE
+    torchcomms
     ${TORCH_LIBRARIES}
     ${TORCH_PYTHON_LIB}
-    torchcomms
-)
-target_link_libraries(torchcomms_comms_rcclx PRIVATE
     ${RCCLX_SHARED_LIB}
-    "-lfmt"
 )
 
 set(CMAKE_CXX_COMPILE_OBJECT "${CMAKE_CXX_COMPILE_OBJECT} -std=c++20")

--- a/comms/torchcomms/scripts/run_tests_integration_py.sh
+++ b/comms/torchcomms/scripts/run_tests_integration_py.sh
@@ -27,9 +27,13 @@ run_tests () {
 export TEST_BACKEND=nccl
 run_tests
 
-# NCCLX
-export TEST_BACKEND=ncclx
-run_tests
+# NCCLX (skip if built with USE_NCCLX=0)
+if [ "${USE_NCCLX}" != "0" ] && [ "${USE_NCCLX}" != "OFF" ]; then
+    export TEST_BACKEND=ncclx
+    run_tests
+else
+    echo "Skipping ncclx tests (USE_NCCLX=${USE_NCCLX})"
+fi
 
 # Gloo with CPU
 export TEST_BACKEND=gloo

--- a/comms/torchcomms/transport/CMakeLists.txt
+++ b/comms/torchcomms/transport/CMakeLists.txt
@@ -44,8 +44,13 @@ if(NOT PKG_RESULT EQUAL 0)
     message(FATAL_ERROR "pkg-config for libfolly failed")
 endif()
 separate_arguments(FOLLY_LDFLAGS NATIVE_COMMAND "${FOLLY_LDFLAGS_RAW}")
-# Remove any -l:libglog.a from FOLLY_LDFLAGS
-list(FILTER FOLLY_LDFLAGS EXCLUDE REGEX ".*libglog.*")
+# Remove glog/gflags/fmt from FOLLY_LDFLAGS — they're already linked
+# statically via libtorchcomms.so from the third-party cmake modules.
+# pkg-config may output -lglog, -l:libglog.a, or full paths like
+# /path/to/libglog.a — the simple substring match handles all forms.
+list(FILTER FOLLY_LDFLAGS EXCLUDE REGEX "glog")
+list(FILTER FOLLY_LDFLAGS EXCLUDE REGEX "gflags")
+list(FILTER FOLLY_LDFLAGS EXCLUDE REGEX "libfmt")
 
 add_library(torchcomms_transport MODULE
     ${TORCHCOMMS_TRANSPORT_SOURCES}
@@ -73,28 +78,24 @@ target_link_libraries(torchcomms_transport PRIVATE
     ${TORCH_PYTHON_LIB}
     ctran
     utils
-    ${FOLLY_LDFLAGS}
 )
-
 if(USE_SYSTEM_LIBS)
     target_link_libraries(torchcomms_transport PRIVATE
         "-lfolly"
-        "-lgflags"
-        "-lglog"
+        glog::glog gflags::gflags fmt::fmt
         "-lboost_program_options"
         "-lboost_filesystem"
         "-lboost_context"
-        "-lfmt"
+        ${FOLLY_LDFLAGS}
     )
 else()
     target_link_libraries(torchcomms_transport PRIVATE
         "-l:libfolly.a"
-        "-l:libgflags.a"
-        "-l:libglog.a"
+        glog::glog gflags::gflags fmt::fmt
         "-l:libboost_program_options.a"
         "-l:libboost_filesystem.a"
         "-l:libboost_context.a"
-        "-l:libfmt.a"
+        ${FOLLY_LDFLAGS}
     )
 endif()
 

--- a/comms/utils/test_utils/CMakeLists.txt
+++ b/comms/utils/test_utils/CMakeLists.txt
@@ -17,3 +17,4 @@ target_include_directories(test_utils PUBLIC
     ${CONDA_INCLUDE}
     ${CUDA_INCLUDE_DIRS}
 )
+target_link_libraries(test_utils PUBLIC fmt::fmt)


### PR DESCRIPTION
This makes it so for non-NCCLX builds we are cmake only. This should make it much more simple to integrate in with PyTorch.

Test plan:

```
USE_NCCLX=0 USE_TRANSPORT=0 uv pip install --no-build-isolation -v -e .
```
CI long tail coverage

Added CI build variant that's pure cmake w/ no ncclx