### PR TITLE
stop resetting KernelElem in cmdDestroy (#1405)

### DIFF
--- a/comms/ctran/gpe/CtranGpe.cc
+++ b/comms/ctran/gpe/CtranGpe.cc
@@ -243,6 +243,12 @@ OpElem::~OpElem() {
       }
       break;
     }
+    case ALLTOALLV_DYNAMIC_SPLIT_NON_CONTIG_P: {
+      if (this->alltoallv_dynamic.kElem) {
+        this->alltoallv_dynamic.kElem->free();
+      }
+      break;
+    }
     default:
       break;
   }
@@ -316,6 +322,14 @@ void OpElem::setStatus(KernelElem::ElemStatus status) {
     case ALLTOALLV_DYNAMIC_SPLIT_NON_CONTIG_P: {
       if (this->alltoallv_dynamic.kElem) {
         this->alltoallv_dynamic.kElem->setStatus(status);
+      }
+      break;
+    }
+    case ALLTOALL_DEDUP: {
+      for (auto& pair : this->alltoall_dedup.bcastElemMap) {
+        if (pair.second != nullptr) {
+          pair.second->setStatus(status);
+        }
       }
       break;
     }

--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -150,12 +150,6 @@ void CUDART_CB CtranGpe::Impl::cmdDestroy(void* data) {
   if (!cmd->persistent) {
     CLOGF(WARN, "CTranGPE: cmd desctructor called for non-persistent cmd");
   }
-  // We actually don't need to do anything here, sicne
-  // ~OpElem::free() would also handle this
-  // TODO: remove in subsequent diff
-  for (const auto& x : cmd->coll.opGroup) {
-    x->setStatus(KernelElem::ElemStatus::RESET);
-  }
   delete cmd;
 }
 


### PR DESCRIPTION
Summary:

just actioning the TODO here... will cause KernelElem::free's CHECK_KELEM_NGROUPS to fail when:

1. cmdDestroy sets status to RESET
2. main thrad calls pop() -> reclaim() -> isFree() --> reset() --> ngroups = 0
3. cmdDestroy calls delete cmd --> ~OpElem --> kElem->free() --> CHECK_KELEM_NGROUPS(0)

Reviewed By: Regina8023

Differential Revision: D98780631
