### PR TITLE
Fix RegCache::destroy() not clearing segToRegElemsMap

### DIFF
--- a/comms/ctran/regcache/RegCache.cc
+++ b/comms/ctran/regcache/RegCache.cc
@@ -260,6 +260,10 @@ commResult_t ctran::RegCache::destroy() {
       it = regHdlToElemMap.erase(it);
     }
 
+    // Clear segment-to-regElem correlation map to avoid stale entries
+    // after segments and regElems are destroyed above.
+    regElemsMaps->segToRegElemsMap.clear();
+
     for (auto avlHdl : segmentsAvl->getAllElems()) {
       auto seg = reinterpret_cast<ctran::regcache::Segment*>(
           segmentsAvl->lookup(avlHdl));


### PR DESCRIPTION
Summary:
RegCache::destroy() clears regHdlToElemMap and the segments AVL tree,
but does not clear segToRegElemsMap. This leaves stale entries keyed
by freed Segment* pointers. When subsequent tests allocate new segments
that reuse the same memory addresses, getRegElems() matches on stale
keys and returns dangling RegElem* pointers.

This fixes the CtranMapperTest.getMultiSegRegElems test failure where
getRegElems() returned extra phantom elements from prior test runs.

Reviewed By: minsii

Differential Revision: D98949134


