### PR TITLE
Fixing Transport plugin leaks

### DIFF
--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
@@ -31,13 +31,13 @@ void CtranTcpDm::bootstrapPrepare(meta::comms::IBootstrap* bootstrap) {
   sin6.sin6_addr = dev->addr;
   ifAddrSockAddr.setFromSockaddr(&sin6);
   FB_SYSCHECKTHROW_EX(
-      listenSocket_.bindAndListen(ifAddrSockAddr, *dev->name),
+      listenSocket_.bindAndListen(ifAddrSockAddr, dev->name.c_str()),
       rank_,
       commHash_,
       commDesc_);
 
   std::string line =
-      ::comms::tcp_devmem::addrToString(&dev->addr, 0, *dev->name);
+      ::comms::tcp_devmem::addrToString(&dev->addr, 0, dev->name.c_str());
   CLOGF_SUBSYS(
       INFO,
       INIT,


### PR DESCRIPTION
Summary:
Fix multiple resource leaks in the transport plugin (file descriptors, memory, object ownership).

| # | Severity | Leak | Fix |
|---|----------|------|-----|
| 1 | **High** | `NetDev::name`/`pciPath` use `unique_ptr<char*>` wrapping `strdup`/`realpath` — `delete` frees the outer pointer but the inner `malloc`'d string leaks | Replaced `unique_ptr<char*>` with `std::string`; `devPciPath` now returns `std::string` and frees `realpath` result |
| 2 | **High** | `CommunicatorListener` destructor only closes `fd_`, never `ctrlFd_` — control socket fd leaks | Added `close(ctrlFd_)` guarded by `ctrlFd_ >= 0` in destructor |
| 3 | **High** | `deregMr` returns early without `delete` when `Dmabuf` is false — `MemHandle` from `regMr` leaks | Delete `MemHandle` unconditionally; only close `fd` when `>= 0` |
| 4 | **Medium** | `fakeTxBuf_` (64 MB) allocated in `init()` but never freed; also uninitialized | Initialize to `nullptr`; `delete[]` in `shutdown()` |
| 5 | **Medium** | `comms_` uninitialized — indeterminate value can cause `shutdown()` to skip cleanup | Initialize to `0` in header |
| 6 | **Medium** | `newSocket`: if `IPV6_TCLASS` setsockopt fails, socket fd leaks (assigned but not closed) | Close fd and set to `-1` before returning error |
| 7 | **Medium** | `connect()`: raw `new Communicator` and socket fds leak on error paths | Use `unique_ptr<Communicator>`; close fd on each error path |
| 8 | **Medium** | `accept()`: same pattern — raw `new Communicator` and accepted fds leak on error | Use `unique_ptr<Communicator>`; close fd on each error path |
| 9 | **Medium** | `listen()`: `ctrlFd` and `fd` leak if any step between `newSocket` and `CommunicatorListener` creation fails | Close both fds via cleanup lambdas on all error paths |
| 10 | **Medium** | `NetDev::dmabufFd` uninitialized (could be garbage value) | Initialize to `-1` in struct definition |
| 11 | **Low** | `retiredComm_` entries leak if destructor calls `shutdown(false)` while `comms_ > 0` | Move `releaseComms()` before the early-return check |

Reviewed By: fomichev

Differential Revision: D98506217


