### PR TITLE
Fix commHash overwrite for fast-init mode

### DIFF
--- a/comms/ncclx/meta/tests/FastInitTest.cc
+++ b/comms/ncclx/meta/tests/FastInitTest.cc
@@ -482,9 +482,7 @@ TEST_P(FastInitTestFixture, NcclCommSplitNoColor) {
   NCCLCHECK_TEST(ncclCommDestroy(rootComm));
 }
 
-// FIXME: v2.29 regression — getHash(commId) overwrites generateCommHash,
-// causing identical commHash for different commDesc. v2.27/v2.28 pass.
-TEST_P(FastInitTestFixture, DISABLED_NcclCommInitWithDifferentCommDesc) {
+TEST_P(FastInitTestFixture, NcclCommInitWithDifferentCommDesc) {
   ncclComm_t comm1 = nullptr, comm2 = nullptr;
   ncclUniqueId commId1, commId2;
 

--- a/comms/ncclx/v2_29/src/init.cc
+++ b/comms/ncclx/v2_29/src/init.cc
@@ -1836,17 +1836,16 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
     commIdHash = 0;
   } else {
     // GROW or NORMAL INIT: use bootstrapInit
-    // [Meta] Fast-init mode won't get unique commId for different communicators
-    // use ctran helper function to generate unique hash
-    if (isFastInitRingMode(NCCLX_CONFIG_FIELD(comm->config, fastInitMode))) {
-      comm->commHash = commIdHash = ctran::utils::generateCommHash(job->nranks);
-    }
     if (job->isGrow) {
       struct ncclBootstrapHandle* growHandle = (struct ncclBootstrapHandle*)job->commId;
       uint64_t baseMagic = growHandle ? growHandle->magic : hashCombine(job->parent->magic, job->parent->childCount);
       comm->commHash = commIdHash = hashCombine(baseMagic, job->nranks);
       INFO(NCCL_INIT, "Rank %d: Generated commHash 0x%lx from baseMagic 0x%lx and newNRanks %d",
            job->myrank, comm->commHash, baseMagic, job->nranks);
+    } else if (isFastInitRingMode(NCCLX_CONFIG_FIELD(comm->config, fastInitMode))) {
+      // [Meta] Fast-init mode won't get unique commId for different communicators
+      // use ctran helper function to generate unique hash
+      comm->commHash = commIdHash = ctran::utils::generateCommHash(job->nranks);
     } else {
       // obtain a unique hash using the first commId
       comm->commHash = commIdHash = getHash(job->commId->internal, NCCL_UNIQUE_ID_BYTES);


### PR DESCRIPTION
Summary:
Fix v2.29 regression where generateCommHash (for fast-init) was unconditionally overwritten by getHash(commId) in the normal-init else branch:
- The isGrow branch added in v2.29 restructured commHash assignment, but the standalone fast-init if block ran before the isGrow/else chain, so the else branch always overwrote it with getHash on uninitialized commId
- Make the three commHash cases (isGrow, fast-init, normal getHash) mutually exclusive via if/else-if/else
- Re-enable NcclCommInitWithDifferentCommDesc test that validates different commDesc produce different commHash

Reviewed By: max7255

Differential Revision: D98841211


