### PR TITLE
fix the bug in dist_mapper_ut such that the same NVL handle is sent to a peer 10 times

### DIFF
--- a/comms/ctran/mapper/tests/CtranDistMapperBackendUT.cc
+++ b/comms/ctran/mapper/tests/CtranDistMapperBackendUT.cc
@@ -7,8 +7,8 @@
 #include "comms/ctran/algos/common/GpeKernelSync.h"
 #include "comms/ctran/mapper/CtranMapper.h"
 #include "comms/ctran/mapper/CtranMapperTypes.h"
+#include "comms/ctran/tests/CtranDistTestUtils.h"
 #include "comms/testinfra/TestUtils.h"
-#include "comms/testinfra/TestsDistUtils.h"
 #include "nccl.h"
 
 // Note that The bufSize should be less than NCCL_CTRAN_IB_QP_SCALING_THRESHOLD
@@ -23,16 +23,15 @@ using ctran::algos::GpeKernelSync;
 extern __global__ void
 waitSigTestKernel(GpeKernelSync* sync, uint64_t* data, int cmpVal);
 
-class CtranDistMapperBackendTest : public NcclxBaseTest {
+class CtranDistMapperBackendTest : public ctran::CtranDistTestFixture {
  public:
   void SetUp() override {
     setenv("NCCL_CTRAN_ENABLE", "1", 0);
-    NcclxBaseTest::SetUp();
-    commDeprecated_ = createNcclComm(
-        globalRank, numRanks, localRank, false, nullptr, server.get());
-    comm_ = commDeprecated_->ctranComm_.get();
+    ctran::CtranDistTestFixture::SetUp();
+    comm_ = makeCtranComm();
 
-    if (!ctranInitialized(comm_) || !comm_->ctran_->mapper->hasBackend()) {
+    if (!ctranInitialized(comm_.get()) ||
+        !comm_->ctran_->mapper->hasBackend()) {
       GTEST_SKIP()
           << "Ctran is not initialized or backend is not available.  Skip test.";
     }
@@ -47,9 +46,8 @@ class CtranDistMapperBackendTest : public NcclxBaseTest {
   }
 
   void TearDown() override {
-    finalizeNcclComm(globalRank, server.get());
-    NCCLCHECK_TEST(ncclCommDestroy(commDeprecated_));
-    NcclxBaseTest::TearDown();
+    comm_.reset();
+    ctran::CtranDistTestFixture::TearDown();
   }
 
   void PreConnectAllPeers() {
@@ -199,8 +197,7 @@ class CtranDistMapperBackendTest : public NcclxBaseTest {
   void* sendHdl{nullptr};
 
  protected:
-  ncclComm_t commDeprecated_{nullptr};
-  CtranComm* comm_{nullptr};
+  std::unique_ptr<CtranComm> comm_;
 };
 
 class CtranDistMapperBackendPerfConfigTestParam
@@ -244,7 +241,7 @@ TEST_P(CtranDistMapperBackendPerfConfigTestParam, IntraNodeUseIb) {
             CtranMapperBackend::IB),
         commSuccess);
 
-    intraNodeBarrier(commDeprecated_);
+    barrierNvlDomain(comm_.get());
 
     ASSERT_EQ(mapper->iPutCount[CtranMapperBackend::IB], 0);
     ASSERT_EQ(mapper->iPutCount[CtranMapperBackend::NVL], 0);
@@ -319,7 +316,7 @@ TEST_P(CtranDistMapperBackendPerfConfigTestParam, IntraNodeUseNvl) {
             CtranMapperBackend::NVL),
         commSuccess);
 
-    intraNodeBarrier(commDeprecated_);
+    barrierNvlDomain(comm_.get());
 
     ASSERT_EQ(mapper->iPutCount[CtranMapperBackend::IB], 0);
     ASSERT_EQ(mapper->iPutCount[CtranMapperBackend::NVL], 0);
@@ -375,10 +372,12 @@ TEST_P(
             buf, sendHdl, ranks, remoteBufs, remoteAccessKeys),
         commSuccess);
 
-    intraNodeBarrier(commDeprecated_);
+    barrierNvlDomain(comm_.get());
 
     ASSERT_EQ(mapper->iPutCount[CtranMapperBackend::IB], 0);
     ASSERT_EQ(mapper->iPutCount[CtranMapperBackend::NVL], 0);
+
+    // issue puts to all ranks
 
     // issue puts to all ranks, they should use NVL for intra-node and IB for
     // inter-node
@@ -428,7 +427,7 @@ TEST_P(CtranDistMapperBackendPerfConfigTestParam, InteNodeUseIbFastPut) {
             buf, sendHdl, ranks, remoteBufs, remoteAccessKeys),
         commSuccess);
 
-    intraNodeBarrier(commDeprecated_);
+    barrierNvlDomain(comm_.get());
 
     ASSERT_EQ(mapper->iPutCount[CtranMapperBackend::IB], 0);
     // Remove local ranks from the list of peers
@@ -558,7 +557,7 @@ TEST_F(CtranDistMapperBackendTest, InterNodeIbSignal) {
 
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
-  ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);
+  ::testing::AddGlobalTestEnvironment(new ctran::CtranDistEnvironment);
   folly::Init init(&argc, &argv);
   return RUN_ALL_TESTS();
 }

--- a/comms/ctran/mapper/tests/CtranDistMapperUT.cc
+++ b/comms/ctran/mapper/tests/CtranDistMapperUT.cc
@@ -791,7 +791,8 @@ TEST_P(CtranDistMapperBufExportParam, BufExportCtrl) {
   auto remoteAccessKeys = CtranMapperRemoteAccessKey();
 
   std::vector<std::unique_ptr<CtranMapperRequest>> requests;
-  for (int x = 0; x < 10; x++) {
+
+  {
     CtranMapperRequest* req = nullptr;
 
     CtranMapperEpochRAII epochRAII(mapper);

--- a/comms/ctran/mapper/tests/CtranDistMapperUT.cc
+++ b/comms/ctran/mapper/tests/CtranDistMapperUT.cc
@@ -3,16 +3,15 @@
 #include <folly/init/Init.h>
 #include <gtest/gtest.h>
 #include <stdlib.h>
-#include "comm.h"
 #include "comms/ctran/Ctran.h"
 #include "comms/ctran/mapper/CtranMapper.h"
 #include "comms/ctran/mapper/CtranMapperTypes.h"
+#include "comms/ctran/tests/CtranDistTestUtils.h"
 #include "comms/ctran/utils/Alloc.h"
 #include "comms/testinfra/TestUtils.h"
-#include "comms/testinfra/TestsDistUtils.h"
 #include "nccl.h"
 
-class CtranDistMapperTest : public NcclxBaseTest {
+class CtranDistMapperTest : public ctran::CtranDistTestFixture {
  public:
   void SetUp() override {
     setenv("NCCL_CTRAN_ENABLE", "1", 0);
@@ -20,27 +19,23 @@ class CtranDistMapperTest : public NcclxBaseTest {
 #ifdef CTRAN_TEST_SOCKET_ONLY_BACKEND
     setenv("NCCL_CTRAN_BACKENDS", "socket, nvl", 1);
 #endif
-    NcclxBaseTest::SetUp();
+    ctran::CtranDistTestFixture::SetUp();
 
     // Turn on CTran for the entire test
     NCCL_CTRAN_ENABLE = true;
-    // Check epoch lock for the entire test
-    NCCL_CTRAN_IB_EPOCH_LOCK_ENFORCE_CHECK = true;
 
-    commDeprecated_ = createNcclComm(
-        globalRank, numRanks, localRank, false, nullptr, server.get());
-    comm_ = commDeprecated_->ctranComm_.get();
+    comm_ = makeCtranComm();
 
-    if (!ctranInitialized(comm_) || !comm_->ctran_->mapper->hasBackend()) {
+    if (!ctranInitialized(comm_.get()) ||
+        !comm_->ctran_->mapper->hasBackend()) {
       GTEST_SKIP()
           << "Ctran is not initialized or backend is not available.  Skip test.";
     }
   }
 
   void TearDown() override {
-    finalizeNcclComm(globalRank, server.get());
-    NCCLCHECK_TEST(ncclCommDestroy(commDeprecated_));
-    NcclxBaseTest::TearDown();
+    comm_.reset();
+    ctran::CtranDistTestFixture::TearDown();
   }
 
   void PreConnectAllPeers() {
@@ -54,8 +49,7 @@ class CtranDistMapperTest : public NcclxBaseTest {
   }
 
  protected:
-  ncclComm_t commDeprecated_{nullptr};
-  CtranComm* comm_{nullptr};
+  std::unique_ptr<CtranComm> comm_;
 };
 
 class CtranDistMapperBackendParam
@@ -125,7 +119,7 @@ TEST_P(CtranDistMapperBackendParam, intraAllGatherCtrl) {
 
   // Ensure all local ranks have finished importing remote NVL buffer before
   // deregister
-  intraNodeBarrier(commDeprecated_);
+  barrierNvlDomain(comm_.get());
 
   COMMCHECK_TEST(comm_->ctran_->commDeregister(handle));
   NCCLCHECK_TEST(ncclMemFree(buf));
@@ -210,7 +204,7 @@ TEST_P(CtranDistMapperBackendParam, allGatherCtrl) {
 
   // Ensure all local ranks have finished importing remote NVL buffer before
   // deregister
-  intraNodeBarrier(commDeprecated_);
+  barrierNvlDomain(comm_.get());
 
   COMMCHECK_TEST(comm_->ctran_->commDeregister(handle));
   NCCLCHECK_TEST(ncclMemFree(buf));
@@ -264,7 +258,7 @@ TEST_F(CtranDistMapperTest, allGatherCtrlNRanks) {
 
   // Ensure all local ranks have finished importing remote NVL buffer before
   // deregister
-  intraNodeBarrier(commDeprecated_);
+  barrierNvlDomain(comm_.get());
 
   COMMCHECK_TEST(comm_->ctran_->commDeregister(handle));
   NCCLCHECK_TEST(ncclMemFree(buf));
@@ -359,7 +353,7 @@ TEST_P(CtranDistMapperPerfConfigTestParam, CtrlWithUserAllocatedReq) {
 
   // Ensure all local ranks have finished importing remote NVL buffer before
   // deregister
-  intraNodeBarrier(commDeprecated_);
+  barrierNvlDomain(comm_.get());
 
   COMMCHECK_TEST(comm_->ctran_->commDeregister(handle));
   NCCLCHECK_TEST(ncclMemFree(buf));
@@ -499,7 +493,7 @@ TEST_P(CtranDistMapperPerfConfigTestParam, isendCtrlBatchToAllPeers) {
 
   // Ensure all local ranks have finished importing remote NVL buffer before
   // deregister
-  intraNodeBarrier(commDeprecated_);
+  barrierNvlDomain(comm_.get());
 
   COMMCHECK_TEST(comm_->ctran_->commDeregister(handle));
   NCCLCHECK_TEST(ncclMemFree(buf));
@@ -700,7 +694,7 @@ TEST_F(CtranDistMapperTest, intraNodeDynamicRegistration) {
 
   // Ensure all local ranks have finished importing remote NVL buffer before
   // deregister
-  intraNodeBarrier(commDeprecated_);
+  barrierNvlDomain(comm_.get());
 
   COMMCHECK_TEST(comm_->ctran_->mapper->deregDynamic(sendHdl));
 
@@ -905,7 +899,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
-  ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);
+  ::testing::AddGlobalTestEnvironment(new ctran::CtranDistEnvironment);
   folly::Init init(&argc, &argv);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Summary: After D94555726, the IpcRegCache singleton records how many times a remote NVL memory has been imported. Therefore, a rank should only export his NVL handle to a remote peer once, since `mapper->deregMem()` only sends the release notification once.

Differential Revision: D99209072
