### PR TITLE
Allow user to overwrite NCCL_DEBUG=INFO env var

### DIFF
--- a/comms/ctran/tests/CtranTestUtils.cc
+++ b/comms/ctran/tests/CtranTestUtils.cc
@@ -457,7 +457,7 @@ void CtranTestFixtureBase::TearDown() {
 
 void CtranTestFixtureBase::setupEnvironment() {
   setenv("NCCL_CTRAN_ENABLE", "1", 1);
-  setenv("NCCL_DEBUG", "INFO", 1);
+  setenv("NCCL_DEBUG", "INFO", 0);
 
   FB_CUDACHECKIGNORE(cudaSetDevice(cudaDev));
 


### PR DESCRIPTION
Summary: user can set `-c comms.envs='NCCL_DEBUG=WARN'` to avoid log spam

Reviewed By: minsii

Differential Revision: D99200699


