### PR TITLE
refactor searchIbRegElem behavior and RdmaMemory constructor with caching (#1425)

### DIFF
--- a/comms/ctran/regcache/RegCache.cc
+++ b/comms/ctran/regcache/RegCache.cc
@@ -582,12 +582,41 @@ bool ctran::RegCache::isRegistered(const void* ptr, const size_t len) {
   return regHdl != nullptr;
 }
 
-void* ctran::RegCache::searchIbRegElem(const void* ptr, const size_t len) {
-  auto* regElem = searchRegElem(ptr, len);
-  if (regElem == nullptr || regElem->ibRegElem == nullptr) {
+void* ctran::RegCache::searchIbRegHandle(
+    const void* ptr,
+    const size_t len,
+    int deviceId) {
+  int cudaDev = 0;
+  if (deviceId != -1) {
+    cudaDev = deviceId;
+  } else {
+    // Same as globalRegister, auto-detect cudaDev from buffer pointer.
+    commResult_t devResult = getCudaDevFromPtr(ptr, cudaDev);
+    if (devResult != commSuccess) {
+      // Fall back to current CUDA device for CPU memory
+      FB_CUDACHECK_RETURN(cudaGetDevice(&cudaDev), nullptr);
+    }
+  }
+
+  ctran::regcache::RegElem* regHdl = nullptr;
+  bool didRegister = false;
+  CommLogData logMetaData{};
+  logMetaData.commDesc = "global";
+
+  auto res = regRange(
+      ptr,
+      len,
+      cudaDev,
+      "searchIbRegHandle",
+      logMetaData,
+      globalBackends_,
+      didRegister,
+      &regHdl);
+
+  if (res != commSuccess || regHdl == nullptr || regHdl->ibRegElem == nullptr) {
     return nullptr;
   }
-  return regElem->ibRegElem;
+  return regHdl->ibRegElem;
 }
 
 std::vector<void*> ctran::RegCache::getSegments() const {

--- a/comms/ctran/regcache/RegCache.h
+++ b/comms/ctran/regcache/RegCache.h
@@ -430,8 +430,9 @@ class RegCache {
   bool isRegistered(const void* ptr, const size_t len);
 
   // Thread-safe function to search for a RegElem containing [ptr, ptr+len)
-  // and return its ibRegElem. Returns nullptr if not found.
-  void* searchIbRegElem(const void* ptr, size_t len);
+  // and return its ibRegElem. If the buffer is cached but not yet registered,
+  // it will perform registration via regRange(). Returns nullptr if not cached.
+  void* searchIbRegHandle(const void* ptr, size_t len, int deviceId = -1);
 
   // Thread-safe function to wait on all async registration requests to finish.
   // Used by test only.

--- a/comms/ctran/regcache/tests/GlobalRegistrationUT.cc
+++ b/comms/ctran/regcache/tests/GlobalRegistrationUT.cc
@@ -243,20 +243,22 @@ TEST_F(GlobalRegistrationTest, CpuTensorRegistration) {
   // CtranMapper behavior. IB backend handles CPU memory gracefully via
   // exception catching in doRegister.
   commResult_t result =
-      ctran::globalRegisterWithPtr(cpuBuf, cpuBufSize, /*forceReg=*/true);
+      ctran::globalRegisterWithPtr(cpuBuf, cpuBufSize, /*forceReg=*/false);
   EXPECT_EQ(result, commSuccess) << "CPU memory registration should succeed";
-
-  // Verify that searchRegElem finds the registered element (via isRegistered)
   auto regCache = ctran::RegCache::getInstance();
   ASSERT_NE(regCache, nullptr);
-  EXPECT_TRUE(regCache->isRegistered(cpuBuf, cpuBufSize))
-      << "CPU buffer should be found by searchRegElem after registration";
-  auto* ibRegHdl = regCache->searchIbRegElem(cpuBuf, cpuBufSize);
-  EXPECT_NE(ibRegHdl, nullptr);
-
+  // Verify that searchIbRegHandle registers and finds the IB handle
+  auto* ibRegHdl = regCache->searchIbRegHandle(cpuBuf, cpuBufSize, cudaDev);
+  EXPECT_NE(ibRegHdl, nullptr)
+      << "Found IB handle by searchIbRegHandle after registration";
   // Deregistration of CPU memory should also succeed gracefully
   result = ctran::globalDeregisterWithPtr(cpuBuf, cpuBufSize);
   EXPECT_EQ(result, commSuccess) << "CPU memory deregistration should succeed";
+  // Verify that searchIbRegHandle cannot find the IB handle after
+  // deregistration
+  ibRegHdl = regCache->searchIbRegHandle(cpuBuf, cpuBufSize, cudaDev);
+  EXPECT_EQ(ibRegHdl, nullptr)
+      << "Cannot found IB handle by searchIbRegHandle after deregistration";
 
   free(cpuBuf);
 }

--- a/comms/torchcomms/transport/RdmaTransport.cpp
+++ b/comms/torchcomms/transport/RdmaTransport.cpp
@@ -39,11 +39,10 @@ RdmaMemory::RdmaMemory(const void* buf, size_t len, int cudaDev, bool cacheReg)
     // Hold a shared_ptr to ensure RegCache lifetime while RdmaMemory is in
     // scope
     regCache_ = ctran::RegCache::getInstance();
-    FB_COMMCHECKTHROW(
-        regCache_->globalRegister(buf_, len_, true /* forceReg */, cudaDev_));
-    regHdl_ = regCache_->searchIbRegElem(buf_, len_);
+    regHdl_ = regCache_->searchIbRegHandle(buf_, len_, cudaDev_);
     if (regHdl_ == nullptr) {
-      throw std::runtime_error("Failed to fetch the IB regHdl from regCache");
+      throw std::runtime_error(
+          "Failed to fetch the IB handle from regCache. The buffer may not be registered");
     }
   } else {
     FB_COMMCHECKTHROW(CtranIb::regMem(buf_, len_, cudaDev_, &regHdl_));
@@ -71,9 +70,7 @@ RdmaMemory::RdmaMemory(RdmaMemory&& other) noexcept
 
 RdmaMemory::~RdmaMemory() noexcept {
   if (cacheReg_) {
-    // RegCache destructor handles deregistration; regCache_ shared_ptr
-    // release ensures RegCache outlives this RdmaMemory.
-    FB_COMMCHECKTHROW(regCache_->globalDeregister(buf_, len_));
+    // cacheReg path only queried the handle; caller owns registration lifetime
     return;
   }
   if (remoteKey_.size() > 0 && regHdl_) {

--- a/comms/torchcomms/transport/tests/cpp/RdmaTransportTest.cc
+++ b/comms/torchcomms/transport/tests/cpp/RdmaTransportTest.cc
@@ -10,6 +10,7 @@
 #include <folly/io/async/EventBase.h>
 #include <folly/io/async/ScopedEventBaseThread.h>
 
+#include "comms/ctran/regcache/RegCache.h"
 #include "comms/torchcomms/transport/RdmaTransport.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
@@ -445,17 +446,27 @@ TEST_F(RdmaMemoryTest, MoveOnlySemantics) {
 }
 
 TEST_F(RdmaMemoryTest, CacheRegConstruction) {
-  RdmaMemory memory(buffer_, bufferSize_, cudaDev_, true /* cacheReg */);
+  // Without globalRegister, RdmaMemory should throw because the buffer
+  // is not cached and searchIbRegHandle returns nullptr
+  EXPECT_THROW(
+      RdmaMemory(buffer_, bufferSize_, cudaDev_, true /* cacheReg */),
+      std::runtime_error);
 
+  // After globalRegister, RdmaMemory should succeed
+  auto regCache = ctran::RegCache::getInstance();
+  EXPECT_EQ(
+      regCache->globalRegister(buffer_, bufferSize_, false, cudaDev_),
+      commSuccess);
+  RdmaMemory memory(buffer_, bufferSize_, cudaDev_, true /* cacheReg */);
   EXPECT_EQ(memory.getDevice(), cudaDev_);
   EXPECT_NE(memory.localKey(), nullptr);
   EXPECT_FALSE(memory.remoteKey().empty());
   EXPECT_TRUE(memory.contains(buffer_, bufferSize_));
-
   // Views should work the same as non-cached
   auto view = memory.createView();
   EXPECT_EQ(view.data(), buffer_);
   EXPECT_EQ(view.size(), bufferSize_);
+  EXPECT_EQ(regCache->globalDeregister(buffer_, bufferSize_), commSuccess);
 }
 
 TEST_F(RdmaTransportTest, ServerClientDataTransferWrite) {


### PR DESCRIPTION
Summary:

### refactor of searchIbRegHandle
Renames searchIbRegElem() to searchIbRegHandle() and changes its behavior — instead of just looking up a cached IB registration element, it now performs IB registration via regRange() if the buffer has been cached (via cacheSegment()) but not yet registered.

### refactor of RdmaMemory
As discussed, if `regCache=True`, the RdmaMemory constructor will lazily register the IB through regCache's API `searchIbRegHandle`. If the buffer has not been registered with `cacheSegment`, no IB register handle can be found and throw runtime errors.

Reviewed By: minsii

Differential Revision: D99010912
