### PR TITLE
Rename MCCL_SCUBA_ENABLED CVAR to MCCL_TRACE_LOGGING_ENABLED

### DIFF
--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2939,13 +2939,13 @@ cvars:
      Usage: If the NCCL_CTRAN_BACKENS is set with certain values,
      this config will allow MCCL to override backends.
 
- - name        : MCCL_SCUBA_ENABLED
+ - name        : MCCL_TRACE_LOGGING_ENABLED
    type        : bool
    default     : false
    description : |-
-     Enable MCCL Scuba structured logging. When enabled, MCCL will log
-     events to dedicated MCCL Scuba tables for observability and debugging.
-     This is separate from NCCLX logging to minimize risk.
+     Enable MCCL structured trace logging. When enabled, MCCL will log
+     events to a dedicated structured logging backend for observability
+     and debugging. This is separate from NCCLX logging to minimize risk.
 
  - name        : MCCL_SCUBA_LOG_LEVEL
    type        : enum


### PR DESCRIPTION
Summary:
Rename the MCCL_SCUBA_ENABLED CVAR to MCCL_TRACE_LOGGING_ENABLED to
remove Meta-internal "Scuba" branding from the OSS-facing CVAR name.
"Scuba" is Meta's internal analytics platform and is meaningless to
OSS users. The new name uses generic "trace logging" terminology.

Updated all references in MCCL source code, tests, and integration
tests. The YAML description is also rewritten to remove Scuba references.

Differential Revision: D99335783


