### PR TITLE
Rename MCCL_SCUBA_LOG_LEVEL CVAR to MCCL_TRACE_LOG_LEVEL

### DIFF
--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2947,20 +2947,21 @@ cvars:
      events to a dedicated structured logging backend for observability
      and debugging. This is separate from NCCLX logging to minimize risk.
 
- - name        : MCCL_SCUBA_LOG_LEVEL
+ - name        : MCCL_TRACE_LOG_LEVEL
    type        : enum
    default     : HIGH
    choices     : CRITICAL, HIGH, NORMAL, LOW
    description : |-
-     Minimum log priority level for MCCL Scuba logging. Only logs at or above
-     this priority level will be forwarded to Scuba; lower-priority logs are
-     dropped. The priority levels from highest to lowest are:
+     Minimum log priority level for MCCL structured trace logging. Only logs
+     at or above this priority level will be forwarded to the structured
+     logging backend; lower-priority logs are dropped. The priority levels
+     from highest to lowest are:
        CRITICAL - Critical logs only (e.g., errors, failures)
        HIGH     - Critical and high-priority logs (e.g., important events)
        NORMAL   - Critical, high, and normal logs (default operational logs)
        LOW      - All logs including low-priority (verbose/debug)
-     For example, setting MCCL_SCUBA_LOG_LEVEL=HIGH means only HIGH and
-     CRITICAL priority logs will be forwarded to Scuba.
+     For example, setting MCCL_TRACE_LOG_LEVEL=HIGH means only HIGH and
+     CRITICAL priority logs will be forwarded to the logging backend.
 
  - name        : NCCL_GIN_GDAKI_NIC_HANDLER
    type        : int


### PR DESCRIPTION
Summary:
Rename the MCCL_SCUBA_LOG_LEVEL CVAR to MCCL_TRACE_LOG_LEVEL to
remove Meta-internal "Scuba" branding from the OSS-facing CVAR name.
The YAML description is rewritten to use generic "structured logging
backend" language instead of referencing Scuba.

Updated all references in MCCL source code and test files.

Differential Revision: D99335782


