### PR TITLE
Fix default value of NCCL_P2P_PER_CHANNEL_NET_BW

### DIFF
--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3083,7 +3083,7 @@ cvars:
 
  - name        : NCCL_P2P_PER_CHANNEL_NET_BW
    type        : int
-   default     : -1
+   default     : 14
    description : |-
      Specifies the assumed per-channel network bandwidth in GB/s used to calculate
      the number of network channels for P2P (point-to-point) communication with


### PR DESCRIPTION
Summary:
Baseline NCCL_P2P_PER_CHANNEL_NET_BW was incorrectly converted to CVAR with default value "-1". Caused P2P (sendrecv) can leverage only 1 NIC on GB200, result in more than 2x perf regression.

Bug detail:
- NCCL_P2P_PER_CHANNEL_NET_BW is a new v2.29 param (not in v2.27/v2.28) that controls how many p2p channels are allocated per peer: `nNetChannels = max(netCount, divUp(netBw, P2P_PER_CHANNEL_NET_BW))`
- Code default in NCCL_PARAM(P2pPerChannelNetBw, ..., 14) is 14 GB/s (v2_29/src/graph/paths.cc:886)
- nccl_cvars.yaml overrides this to -1 (comms/utils/cvars/nccl_cvars.yaml:3086), which the cvar system passes through directly instead of resolving to the code default
- divUp(netBw, -1) produces a garbage value, max(netCount, garbage) collapses to nNetChannels=1
- This cascades: p2pnChannelsPerPeer=1 → nChannelsMax=1 → only 1 channel used for sendrecv → 1-NIC performance


Workaround before this diff being landed:
set env var `NCCL_P2P_PER_CHANNEL_NET_BW=14` to override the buggy yaml default

Reviewed By: dolpm, mingrany

Differential Revision: D99404588


