### PR TITLE
Add ctran::utils::BackendAllocException subclass of std::bad_alloc with messages on backend creation failures.

### DIFF
--- a/comms/ctran/backends/ib/CtranIb.cc
+++ b/comms/ctran/backends/ib/CtranIb.cc
@@ -74,12 +74,12 @@ CtranIbSingleton::CtranIbSingleton() {
   ibvDevices = std::move(*maybeDeviceList);
 
   if (ibvDevices.size() < NCCL_CTRAN_IB_DEVICES_PER_RANK) {
-    CLOGF(
-        WARN,
+    auto msg = fmt::format(
         "CTRAN-IB : active device found {} is less than requested device count {}",
         ibvDevices.size(),
         NCCL_CTRAN_IB_DEVICES_PER_RANK);
-    throw std::bad_alloc();
+    CLOGF(WARN, "{}", msg);
+    throw ctran::utils::BackendAllocException(std::move(msg));
   }
 
   for (auto i = 0; i < this->ibvDevices.size(); i++) {

--- a/comms/ctran/utils/Exception.h
+++ b/comms/ctran/utils/Exception.h
@@ -69,4 +69,16 @@ class Exception : public std::exception {
   std::optional<uint64_t> commHash_;
   std::optional<std::string> desc_;
 };
+
+class BackendAllocException : public std::bad_alloc {
+ public:
+  explicit BackendAllocException(std::string msg) : msg_(std::move(msg)) {}
+  const char* what() const noexcept override {
+    return msg_.c_str();
+  }
+
+ private:
+  std::string msg_;
+};
+
 } // namespace ctran::utils


### PR DESCRIPTION
Summary:
Replace bare `std::bad_alloc()` in CtranIbSingleton constructor with
`ctran::utils::BackendAllocException` that carries the diagnostic message
(e.g. "active device found 0 is less than requested device count 1").

Previously, callers catching this exception saw only "std::bad_alloc" with
no context about what failed. Now the exception's `what()` contains the
same diagnostic info as the CLOGF warning.

BackendAllocException inherits from std::bad_alloc, so all existing
catch(const std::bad_alloc&) blocks (in CtranMapper and RegCache) continue
to work unchanged.

In the long term, BackendAllocException should be refactored to be a
subclass of ctran::utils::Exception to align with the ctran exception
hierarchy.

Differential Revision: D99483268


