### PR TITLE
record export-count in mapper, and attach it in notifyRemoteIpcRelease to decrement refCount at import-cache properly (#1953)

### DIFF
--- a/comms/ctran/mapper/CtranMapper.cc
+++ b/comms/ctran/mapper/CtranMapper.cc
@@ -500,7 +500,7 @@ commResult_t CtranMapper::remReleaseMem(ctran::regcache::RegElem* regElem) {
         exportedNvlRanks.size());
   }
 
-  for (auto peerRank : exportedNvlRanks) {
+  for (auto& [peerRank, exportCount] : exportedNvlRanks) {
     // Warning: the remote rank may release the memory after the next import,
     // becase exportMem msgs are transferred over CtranIB&CtranSocket while
     // releaseMem msgs are transferred over AsyncSocket. To prevent the remote
@@ -515,9 +515,14 @@ commResult_t CtranMapper::remReleaseMem(ctran::regcache::RegElem* regElem) {
             comm->statex_->gPid(),
             peerAddr,
             reinterpret_cast<ctran::regcache::IpcRegElem*>(regElem->ipcRegElem),
-            req.get()));
+            req.get(),
+            exportCount));
 
-    CLOGF_TRACE(COLL, "CTRAN-MAPPER: Posted IPC release to rank {}", peerRank);
+    CLOGF_TRACE(
+        COLL,
+        "CTRAN-MAPPER: Posted IPC release to rank {} with exportCount {}",
+        peerRank,
+        exportCount);
 
     // IPC release requests will be checked in progress and erased at
     // completion. Mapper needs to free up all requests at destruction.
@@ -1027,7 +1032,7 @@ commResult_t CtranMapper::intraBarrier() {
   return commSuccess;
 }
 
-std::unordered_map<ctran::regcache::RegElem*, std::unordered_set<int>>
+std::unordered_map<ctran::regcache::RegElem*, std::unordered_map<int, int>>
 CtranMapper::dumpExportRegCache() const {
   return exportRegCache_.rlock()->dump();
 }

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -890,7 +890,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
   }
 
   // Dump exported registration cache, for testing only
-  std::unordered_map<ctran::regcache::RegElem*, std::unordered_set<int>>
+  std::unordered_map<ctran::regcache::RegElem*, std::unordered_map<int, int>>
   dumpExportRegCache() const;
 
  protected:

--- a/comms/ctran/mapper/CtranMapperImpl.cc
+++ b/comms/ctran/mapper/CtranMapperImpl.cc
@@ -2,20 +2,20 @@
 #include "comms/ctran/mapper/CtranMapperImpl.h"
 
 namespace ctran {
-std::unordered_set<int> ExportRegCache::remove(
+std::unordered_map<int, int> ExportRegCache::remove(
     const regcache::RegElem* regElem) {
-  std::unordered_set<int> nvlRanks;
+  std::unordered_map<int, int> nvlRanks;
 
   auto it = map_.find(const_cast<regcache::RegElem*>(regElem));
   if (it != map_.end()) {
-    nvlRanks = it->second;
+    nvlRanks = std::move(it->second);
     map_.erase(it);
   }
 
   return nvlRanks;
 }
 
-std::unordered_map<regcache::RegElem*, std::unordered_set<int>>
+std::unordered_map<regcache::RegElem*, std::unordered_map<int, int>>
 ExportRegCache::dump() const {
   return map_;
 }

--- a/comms/ctran/mapper/CtranMapperImpl.h
+++ b/comms/ctran/mapper/CtranMapperImpl.h
@@ -1,27 +1,37 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 #pragma once
 #include <unordered_map>
-#include <unordered_set>
 #include "comms/ctran/regcache/RegCache.h"
 
 namespace ctran {
-// Class to cache exported regElem for each mapper instance
+// Class to cache exported regElem for each mapper instance.
+// Tracks how many times each regElem has been exported to each peer rank,
+// so that release notifications can decrement the import-side refcount by the
+// correct amount.
+// FIXME(alvinyc): after enabling AutoSwitch, we should remove the explicit NVL
+// export API using CtrlMsg, and the exportCount tracking
 class ExportRegCache {
  private:
-  std::unordered_map<regcache::RegElem*, std::unordered_set<int>> map_;
+  // regElem -> (rank -> export count)
+  std::unordered_map<regcache::RegElem*, std::unordered_map<int, int>> map_;
 
  public:
-  // Record the regElem and the rank to export to.
+  // Record an export of regElem to the given rank. Increments the export count
+  // for this (regElem, rank) pair.
   inline void record(const regcache::RegElem* regElem, const int rank) {
-    map_[const_cast<regcache::RegElem*>(regElem)].insert(rank);
+    auto& rankMap = map_[const_cast<regcache::RegElem*>(regElem)];
+    auto [it, inserted] = rankMap.emplace(rank, 0);
+    it->second++;
   }
 
-  // Remove the specified regElem from cache. Return the exported ranks set if
-  // the regElem has been exported. Otherwise, empty set is returned.
-  std::unordered_set<int> remove(const regcache::RegElem* regElem);
+  // Remove the specified regElem from cache. Return the exported ranks map
+  // (rank -> export count) if the regElem has been exported. Otherwise, empty
+  // map is returned.
+  std::unordered_map<int, int> remove(const regcache::RegElem* regElem);
 
   // Dump a full copy of the cache map;
   // used for testing only
-  std::unordered_map<regcache::RegElem*, std::unordered_set<int>> dump() const;
+  std::unordered_map<regcache::RegElem*, std::unordered_map<int, int>> dump()
+      const;
 };
 } // namespace ctran

--- a/comms/ctran/mapper/tests/CtranMapperUT.cc
+++ b/comms/ctran/mapper/tests/CtranMapperUT.cc
@@ -1300,25 +1300,29 @@ TEST_F(CtranMapperTest, ExportRegCache) {
     cache->record(dummyRegElem0, peer);
   }
 
-  // Except dump gives full copy of the cache
+  // Expect dump gives full copy of the cache
   const auto dump = cache->dump();
   EXPECT_EQ(dump.size(), 1);
   auto it = dump.begin();
   EXPECT_EQ(it->first, dummyRegElem0);
   EXPECT_EQ(it->second.size(), peers.size());
+  for (auto peer : peers) {
+    EXPECT_EQ(it->second.at(peer), 1);
+  }
 
   const ctran::regcache::RegElem* dummyRegElem1 =
       reinterpret_cast<ctran::regcache::RegElem*>(0x12346);
 
-  // Expect return empty vector for non-existing regElem
+  // Expect return empty map for non-existing regElem
   auto cachedPeers = cache->remove(dummyRegElem1);
   EXPECT_EQ(cachedPeers.size(), 0);
 
-  // Expect return cached peers for existing regElem
+  // Expect return cached peers with export counts for existing regElem
   cachedPeers = cache->remove(dummyRegElem0);
   EXPECT_EQ(cachedPeers.size(), peers.size());
   for (auto peer : peers) {
     EXPECT_EQ(cachedPeers.count(peer), 1);
+    EXPECT_EQ(cachedPeers.at(peer), 1);
   }
 
   // Expect empty dump after remove
@@ -1346,21 +1350,21 @@ TEST_F(CtranMapperTest, ExportRegCacheMultipleElems) {
 
   EXPECT_EQ(cache.dump().size(), 2);
 
-  // Remove elem0 — should only return elem0's peers
+  // Remove elem0 — should only return elem0's peers with counts
   auto peers0 = cache.remove(elem0);
-  const std::unordered_set<int> expected0 = {0, 1, 2};
+  const std::unordered_map<int, int> expected0 = {{0, 1}, {1, 1}, {2, 1}};
   EXPECT_EQ(peers0, expected0);
   EXPECT_EQ(cache.dump().size(), 1);
 
-  // Remove elem1 — should only return elem1's peers
+  // Remove elem1 — should only return elem1's peers with counts
   auto peers1 = cache.remove(elem1);
-  const std::unordered_set<int> expected1 = {1, 2, 3};
+  const std::unordered_map<int, int> expected1 = {{1, 1}, {2, 1}, {3, 1}};
   EXPECT_EQ(peers1, expected1);
   EXPECT_EQ(cache.dump().size(), 0);
 }
 
-// Test ExportRegCache deduplication: recording the same peer twice for the
-// same regElem should not create duplicate entries.
+// Test ExportRegCache counting: recording the same peer multiple times for the
+// same regElem should increment the export count.
 TEST_F(CtranMapperTest, ExportRegCacheDuplicatePeer) {
   ctran::ExportRegCache cache;
   auto* elem = reinterpret_cast<ctran::regcache::RegElem*>(0x3000);
@@ -1371,7 +1375,27 @@ TEST_F(CtranMapperTest, ExportRegCacheDuplicatePeer) {
 
   auto peers = cache.remove(elem);
   EXPECT_EQ(peers.size(), 1);
-  EXPECT_EQ(peers.count(5), 1);
+  EXPECT_EQ(peers.at(5), 3);
+}
+
+// Test ExportRegCache with varying export counts per rank.
+TEST_F(CtranMapperTest, ExportRegCacheMultiExportCount) {
+  ctran::ExportRegCache cache;
+  auto* elem = reinterpret_cast<ctran::regcache::RegElem*>(0x4000);
+
+  // Export to rank 1 three times, rank 2 twice, rank 3 once
+  cache.record(elem, 1);
+  cache.record(elem, 1);
+  cache.record(elem, 1);
+  cache.record(elem, 2);
+  cache.record(elem, 2);
+  cache.record(elem, 3);
+
+  auto peers = cache.remove(elem);
+  EXPECT_EQ(peers.size(), 3);
+  EXPECT_EQ(peers.at(1), 3);
+  EXPECT_EQ(peers.at(2), 2);
+  EXPECT_EQ(peers.at(3), 1);
 }
 
 class CtranMapperTestDisjoint : public ::testing::Test {

--- a/comms/ctran/regcache/IpcRegCache.cc
+++ b/comms/ctran/regcache/IpcRegCache.cc
@@ -161,7 +161,8 @@ commResult_t ctran::IpcRegCache::importRemMemImpl(
 commResult_t ctran::IpcRegCache::releaseRemReg(
     const std::string& peerId,
     void* basePtr,
-    uint32_t uid) {
+    uint32_t uid,
+    int32_t exportCount) {
   auto lockedMap = ipcRemRegMap_.wlock();
   uint64_t base = reinterpret_cast<uint64_t>(basePtr);
   IpcRemRegKey key{base, uid};
@@ -178,8 +179,21 @@ commResult_t ctran::IpcRegCache::releaseRemReg(
   }
 
   auto& elem = (*lockedMap)[peerId][key];
-  int prevCount = elem->refCount.fetch_sub(1, std::memory_order_acq_rel);
-  if (prevCount > 1) {
+  int prevCount =
+      elem->refCount.fetch_sub(exportCount, std::memory_order_acq_rel);
+
+  if (prevCount < exportCount) {
+    CLOGF(
+        WARN,
+        "CTRAN-REGCACHE: over-release detected for IPC remote registration "
+        "peer:base:uid=<{}:{}:{}>, prevCount {} < exportCount {}",
+        peerId,
+        basePtr,
+        uid,
+        prevCount,
+        exportCount);
+    // Fall through to erase — the entry is invalid regardless
+  } else if (prevCount > exportCount) {
     CLOGF_TRACE(
         COLL,
         "CTRAN-REGCACHE: decremented refCount for IPC remote registration "
@@ -187,7 +201,7 @@ commResult_t ctran::IpcRegCache::releaseRemReg(
         peerId,
         basePtr,
         uid,
-        prevCount - 1);
+        prevCount - exportCount);
     return commSuccess;
   }
 
@@ -244,7 +258,8 @@ commResult_t ctran::IpcRegCache::notifyRemoteIpcRelease(
     const std::string& myId,
     const folly::SocketAddress& peerAddr,
     ctran::regcache::IpcRegElem* ipcRegElem,
-    ctran::regcache::IpcReqCb* reqCb) {
+    ctran::regcache::IpcReqCb* reqCb,
+    int32_t exportCount) {
   // Check if AsyncSocket is initialized
   if (!asyncSocketEvbThread_ || !asyncServerSocket_) {
     CLOGF(
@@ -258,6 +273,7 @@ commResult_t ctran::IpcRegCache::notifyRemoteIpcRelease(
       ctran::regcache::IpcReq(ctran::regcache::IpcReqType::kRelease, myId);
   reqCb->completed.store(false);
   remReleaseMem(ipcRegElem, reqCb->req.release);
+  reqCb->req.release.exportCount = exportCount;
 
   CLOGF_TRACE(
       COLL,
@@ -380,8 +396,11 @@ commResult_t ctran::IpcRegCache::initAsyncSocket() {
                 peerId,
                 ipcReq.release.toString());
 
-            FB_COMMCHECKIGNORE(
-                releaseRemReg(peerId, ipcReq.release.base, ipcReq.release.uid));
+            FB_COMMCHECKIGNORE(releaseRemReg(
+                peerId,
+                ipcReq.release.base,
+                ipcReq.release.uid,
+                ipcReq.release.exportCount));
             break;
           }
           case ctran::regcache::IpcReqType::kDesc: {

--- a/comms/ctran/regcache/IpcRegCache.h
+++ b/comms/ctran/regcache/IpcRegCache.h
@@ -121,8 +121,13 @@ class IpcRegCache {
   }
 
   // Release a specific remote registration for a given peer.
-  commResult_t
-  releaseRemReg(const std::string& peerId, void* basePtr, uint32_t uid);
+  // exportCount specifies how many times the buffer was exported to this peer;
+  // the refcount is decremented by this amount.
+  commResult_t releaseRemReg(
+      const std::string& peerId,
+      void* basePtr,
+      uint32_t uid,
+      int32_t exportCount = 1);
 
   // Get the number of existing remote registrations for a given peer
   size_t getNumRemReg(const std::string& peerId) const;
@@ -142,6 +147,8 @@ class IpcRegCache {
   }
 
   // Notify remote peers to release their imported NVL memory.
+  // exportCount specifies how many times this buffer was exported to the peer,
+  // so the remote side decrements its refcount by the correct amount.
   // Output argument:
   //   - reqCb: IpcReqCb that the caller can track for completion.
   //            Caller must ensure reqCb remains valid until completed.
@@ -149,7 +156,8 @@ class IpcRegCache {
       const std::string& myId,
       const folly::SocketAddress& peerAddr,
       regcache::IpcRegElem* ipcRegElem,
-      regcache::IpcReqCb* reqCb);
+      regcache::IpcReqCb* reqCb,
+      int32_t exportCount = 1);
 
   // Notify remote peer to import our exported NVL memory.
   // The peer will call importMem upon receiving this request.

--- a/comms/ctran/regcache/IpcRegCacheBase.h
+++ b/comms/ctran/regcache/IpcRegCacheBase.h
@@ -52,10 +52,14 @@ struct IpcRelease {
   void* base{nullptr};
   // unique ID for tracking registrations
   uint32_t uid{0};
+  // Number of times this buffer was exported to the peer. The import side
+  // should decrement its refcount by this amount.
+  int32_t exportCount{1};
 
   std::string toString() const {
     std::stringstream ss;
-    ss << "[IPC_RELEASE_MEM] base: " << base << " uid: " << uid;
+    ss << "[IPC_RELEASE_MEM] base: " << base << " uid: " << uid
+       << " exportCount: " << exportCount;
     return ss.str();
   }
 };


### PR DESCRIPTION
Summary:

##  Summary

Fixed a bug where the import-side IpcRemRegElem::refCount was not correctly decremented when a RegElem was exported multiple times to the same peer rank.
Previously, ExportRegCache used std::unordered_set<int> to track exported ranks, which deduplicated entries. When the same buffer was exported N times to the same peer (across multiple collectives), the import side incremented refCount to N, but the release notification only decremented by 1 — leaking N-1 CUDA IPC memory mappings.
The fix changes ExportRegCache to track (RegElem, rank) -> export_count using std::unordered_map<int, int>. The export count is attached to the IpcRelease message and the import-side releaseRemReg() decrements   refCount by the full export count.

 ## Changes:
  - ExportRegCache: set<int> → map<int, int> (rank → export count)
  - IpcRelease: added int32_t exportCount field
  - releaseRemReg() / notifyRemoteIpcRelease(): accept and use exportCount
  - Added over-release safety warning in releaseRemReg()

Reviewed By: Regina8023

Differential Revision: D99366933
