### PR TITLE
rename CT_currentColl to CT_currentColls (#1956)

### DIFF
--- a/comms/analyzer/if/CommsTracingService.thrift
+++ b/comms/analyzer/if/CommsTracingService.thrift
@@ -208,9 +208,9 @@ struct CudaError {
 // NOTE: Keep in sync with commDump.cc
 // The field names must exactly match the json keys.
 // The values themselves are serialized json.
-@thrift.ReserveIds{ids = [19, 20, 21]}
+@thrift.ReserveIds{ids = [1, 19, 20, 21]}
 struct NCCLCommRawEntry {
-  1: string CT_currentColl;
+  25: string CT_currentColls;
   2: string CT_pastColls;
   3: string CT_pendingColls;
   4: string PT_activeColls;
@@ -267,9 +267,9 @@ struct GetTopologyResponse {
   1: list<CommsTopologyInfo> topologies;
 }
 
-@thrift.ReserveIds{ids = [19, 20, 21]}
+@thrift.ReserveIds{ids = [1, 19, 20, 21]}
 struct NCCLParsedEntry {
-  1: optional CT_Coll_struct CT_currentColl;
+  25: list<CT_Coll_struct> CT_currentColls;
   2: list<CT_Coll_struct> CT_pastColls;
   3: list<CT_Coll_struct> CT_pendingColls;
   4: list<PT_Coll_struct> PT_activeColls;

--- a/comms/ctran/tests/CtranDistAllReduceTest.cc
+++ b/comms/ctran/tests/CtranDistAllReduceTest.cc
@@ -206,7 +206,7 @@ class CtranAllReduceTest : public ctran::CtranDistTestFixture,
 
     EXPECT_NE(dumpMap["CT_pastColls"], "[]");
     EXPECT_EQ(dumpMap["CT_pendingColls"], "[]");
-    EXPECT_EQ(dumpMap["CT_currentColl"], "null");
+    EXPECT_EQ(dumpMap["CT_currentColls"], "[]");
 
     auto pastCollsJson = folly::parseJson(dumpMap["CT_pastColls"]);
     EXPECT_EQ(pastCollsJson.size(), 1);

--- a/comms/ctran/tests/CtranDistAllgatherTests.cc
+++ b/comms/ctran/tests/CtranDistAllgatherTests.cc
@@ -235,7 +235,7 @@ TEST_P(CtranAllgatherTestParam, AllgatherAlgo) {
 
   EXPECT_NE(dumpMap["CT_pastColls"], "[]");
   EXPECT_EQ(dumpMap["CT_pendingColls"], "[]");
-  EXPECT_EQ(dumpMap["CT_currentColl"], "null");
+  EXPECT_EQ(dumpMap["CT_currentColls"], "[]");
 
   auto pastCollsJson = folly::parseJson(dumpMap["CT_pastColls"]);
   EXPECT_EQ(pastCollsJson.size(), expOpNames.size());
@@ -473,7 +473,7 @@ TEST_P(CtranSocketAllgatherTestParam, AllgatherAlgo) {
 
   EXPECT_NE(dumpMap["CT_pastColls"], "[]");
   EXPECT_EQ(dumpMap["CT_pendingColls"], "[]");
-  EXPECT_EQ(dumpMap["CT_currentColl"], "null");
+  EXPECT_EQ(dumpMap["CT_currentColls"], "[]");
 
   auto pastCollsJson = folly::parseJson(dumpMap["CT_pastColls"]);
   EXPECT_EQ(pastCollsJson.size(), expOpNames.size());

--- a/comms/ctran/tests/CtranDistAlltoAllDedupTest.cc
+++ b/comms/ctran/tests/CtranDistAlltoAllDedupTest.cc
@@ -201,7 +201,7 @@ class ctranAllToAllDedupTest : public ctran::CtranDistTestFixture,
 
     EXPECT_NE(dumpMap["CT_pastColls"], "[]");
     EXPECT_EQ(dumpMap["CT_pendingColls"], "[]");
-    EXPECT_EQ(dumpMap["CT_currentColl"], "null");
+    EXPECT_EQ(dumpMap["CT_currentColls"], "[]");
 
     auto pastCollsJson = folly::parseJson(dumpMap["CT_pastColls"]);
     // make sure we are collecting enough records

--- a/comms/ctran/tests/CtranDistAlltoAllPTest.cc
+++ b/comms/ctran/tests/CtranDistAlltoAllPTest.cc
@@ -140,7 +140,7 @@ class ctranAllToAllPTest : public ctran::CtranDistTestFixture,
     auto dumpMap = ctran::dumpCollTrace(ctranComm.get());
     EXPECT_NE(dumpMap["CT_pastColls"], "[]");
     EXPECT_EQ(dumpMap["CT_pendingColls"], "[]");
-    EXPECT_EQ(dumpMap["CT_currentColl"], "null");
+    EXPECT_EQ(dumpMap["CT_currentColls"], "[]");
 
     auto pastCollsJson = folly::parseJson(dumpMap["CT_pastColls"]);
     auto statex = ctranComm->statex_.get();

--- a/comms/ctran/tests/CtranDistAlltoAllTest.cc
+++ b/comms/ctran/tests/CtranDistAlltoAllTest.cc
@@ -212,7 +212,7 @@ class CtranAllToAllTest : public ctran::CtranDistTestFixture,
     auto dumpMap = ctran::dumpCollTrace(ctranComm.get());
 
     EXPECT_EQ(dumpMap["CT_pendingColls"], "[]");
-    EXPECT_EQ(dumpMap["CT_currentColl"], "null");
+    EXPECT_EQ(dumpMap["CT_currentColls"], "[]");
 
     auto pastCollsJson = folly::parseJson(dumpMap["CT_pastColls"]);
     if (count == 0) {

--- a/comms/ctran/tests/CtranDistAlltoAllvTest.cc
+++ b/comms/ctran/tests/CtranDistAlltoAllvTest.cc
@@ -151,7 +151,7 @@ class ctranAllToAllvTest : public ctran::CtranDistTestFixture,
     auto dumpMap = ctran::dumpCollTrace(ctranComm.get());
     EXPECT_NE(dumpMap["CT_pastColls"], "[]");
     EXPECT_EQ(dumpMap["CT_pendingColls"], "[]");
-    EXPECT_EQ(dumpMap["CT_currentColl"], "null");
+    EXPECT_EQ(dumpMap["CT_currentColls"], "[]");
     auto pastCollsJson = folly::parseJson(dumpMap["CT_pastColls"]);
     ASSERT_GE(pastCollsJson.size(), 1);
     for (const auto& coll : pastCollsJson) {

--- a/comms/ctran/tests/CtranDistBroadcastTests.cc
+++ b/comms/ctran/tests/CtranDistBroadcastTests.cc
@@ -156,7 +156,7 @@ TEST_P(CtranTestBroadcastFixture, Broadcast) {
 
   EXPECT_NE(dumpMap["CT_pastColls"], "[]");
   EXPECT_EQ(dumpMap["CT_pendingColls"], "[]");
-  EXPECT_EQ(dumpMap["CT_currentColl"], "null");
+  EXPECT_EQ(dumpMap["CT_currentColls"], "[]");
 
   auto pastCollsJson = folly::parseJson(dumpMap["CT_pastColls"]);
   EXPECT_EQ(pastCollsJson.size(), 1);

--- a/comms/ctran/tests/CtranDistReduceScatterTest.cc
+++ b/comms/ctran/tests/CtranDistReduceScatterTest.cc
@@ -218,7 +218,7 @@ class CtranReduceScatterTest : public ctran::CtranDistTestFixture,
     auto dumpMap = ctran::dumpCollTrace(ctranComm.get());
 
     EXPECT_EQ(dumpMap["CT_pendingColls"], "[]");
-    EXPECT_EQ(dumpMap["CT_currentColl"], "null");
+    EXPECT_EQ(dumpMap["CT_currentColls"], "[]");
 
     // Only verify CollTrace records if count > 0 (operation was executed)
     if (count > 0) {

--- a/comms/ctran/tests/CtranDistTestUtils.h
+++ b/comms/ctran/tests/CtranDistTestUtils.h
@@ -56,7 +56,7 @@ class CtranDistTestFixture : public CtranTestFixtureBase,
 
 // Dump colltrace records from a standalone CtranComm's colltraceNew_.
 // Returns a map with keys like "CT_pastColls", "CT_pendingColls",
-// "CT_currentColl". Returns empty map if colltrace is not initialized.
+// "CT_currentColls". Returns empty map if colltrace is not initialized.
 std::unordered_map<std::string, std::string> dumpCollTrace(CtranComm* comm);
 
 } // namespace ctran

--- a/comms/ncclx/meta/analyzer/tests/NCCLXCommsTracingServiceHandlerTest.cc
+++ b/comms/ncclx/meta/analyzer/tests/NCCLXCommsTracingServiceHandlerTest.cc
@@ -398,7 +398,7 @@ TEST_F(NcclCommsTest, AnalyzerSuccess) {
             }
 
             const auto& ncclParsedEntry = commHashMap.begin()->second;
-            if (ncclParsedEntry.CT_currentColl().has_value()) {
+            if (!ncclParsedEntry.CT_currentColls()->empty()) {
               XLOG(INFO) << "Expecting no ongoing collectives";
               return false;
             }
@@ -512,7 +512,7 @@ TEST_F(NcclCommsTest, OneRankHangs) {
             const auto& ncclParsedEntry = commHashMap.begin()->second;
             // Rank 0 is not in the collective
             if (i != 0) {
-              if (!ncclParsedEntry.CT_currentColl().has_value()) {
+              if (ncclParsedEntry.CT_currentColls()->empty()) {
                 XLOG(INFO) << "Expecting current collective";
                 return false;
               }
@@ -644,7 +644,7 @@ TEST_F(NcclCommsTest, DISABLED_OneRankHangsCudaGraph) {
             const auto& ncclParsedEntry = commHashMap.begin()->second;
             // Rank 0 is not in the collective
             if (i != 0) {
-              if (!ncclParsedEntry.CT_currentColl().has_value()) {
+              if (ncclParsedEntry.CT_currentColls()->empty()) {
                 XLOG(INFO) << "Expecting current collective";
                 return false;
               }

--- a/comms/ncclx/meta/colltrace/tests/DumpNewColltraceUT.cc
+++ b/comms/ncclx/meta/colltrace/tests/DumpNewColltraceUT.cc
@@ -45,12 +45,12 @@ TEST(DumpNewCollTraceUT, dumpNewCollTraceEmptyState) {
   EXPECT_EQ(dumpMap.size(), 3);
   EXPECT_TRUE(dumpMap.find("CT_pastColls") != dumpMap.end());
   EXPECT_TRUE(dumpMap.find("CT_pendingColls") != dumpMap.end());
-  EXPECT_TRUE(dumpMap.find("CT_currentColl") != dumpMap.end());
+  EXPECT_TRUE(dumpMap.find("CT_currentColls") != dumpMap.end());
 
-  // Empty state should have empty arrays and null current collective
+  // Empty state should have empty arrays
   EXPECT_EQ(dumpMap["CT_pastColls"], "[]");
   EXPECT_EQ(dumpMap["CT_pendingColls"], "[]");
-  EXPECT_EQ(dumpMap["CT_currentColl"], "null");
+  EXPECT_EQ(dumpMap["CT_currentColls"], "[]");
 }
 
 TEST(DumpNewCollTraceUT, dumpNewCollTraceWithCollectives) {
@@ -95,7 +95,7 @@ TEST(DumpNewCollTraceUT, dumpNewCollTraceWithCollectives) {
 
   // Verify pastColls is empty and currentColl should have one entry
   EXPECT_EQ(dumpMapPending["CT_pastColls"], "[]");
-  EXPECT_NE(dumpMapPending["CT_currentColl"], "null");
+  EXPECT_NE(dumpMapPending["CT_currentColls"], "[]");
   // Verify pendingColls is empty since the pending collective was moved to
   // current
   auto pendingCollsJson = folly::parseJson(dumpMapPending["CT_pendingColls"]);
@@ -115,7 +115,7 @@ TEST(DumpNewCollTraceUT, dumpNewCollTraceWithCollectives) {
   // Verify currentColl is set and pendingColls is empty
   EXPECT_EQ(dumpMapCurrent["CT_pastColls"], "[]");
   EXPECT_EQ(dumpMapCurrent["CT_pendingColls"], "[]");
-  EXPECT_NE(dumpMapCurrent["CT_currentColl"], "null");
+  EXPECT_NE(dumpMapCurrent["CT_currentColls"], "[]");
 
   // Trigger kernel finish
   ASSERT_TRUE(
@@ -128,8 +128,8 @@ TEST(DumpNewCollTraceUT, dumpNewCollTraceWithCollectives) {
   auto dumpMapPast = dumpNewCollTrace(*collTrace);
   ASSERT_FALSE(dumpMapPast.empty());
 
-  // Verify pastColls has one entry and currentColl is null
-  EXPECT_EQ(dumpMapPast["CT_currentColl"], "null");
+  // Verify pastColls has one entry and currentColls is empty
+  EXPECT_EQ(dumpMapPast["CT_currentColls"], "[]");
   auto pastCollsJson = folly::parseJson(dumpMapPast["CT_pastColls"]);
   EXPECT_EQ(pastCollsJson.size(), 1);
 }
@@ -221,7 +221,7 @@ TEST(DumpNewCollTraceUT, dumpNewCollTraceMultipleCollectives) {
   EXPECT_EQ(pastCollsJson.size(), 1);
 
   // Verify currentColl is the second collective
-  EXPECT_NE(dumpMap["CT_currentColl"], "null");
+  EXPECT_NE(dumpMap["CT_currentColls"], "[]");
 
   // Verify pendingColls has the third collective
   auto pendingCollsJson = folly::parseJson(dumpMap["CT_pendingColls"]);

--- a/comms/ncclx/meta/colltrace/tests/NewCollTraceDistTestLocal.cc
+++ b/comms/ncclx/meta/colltrace/tests/NewCollTraceDistTestLocal.cc
@@ -157,7 +157,7 @@ TEST_F(CollTraceTestLocal, winSignal) {
       meta::comms::ncclx::dumpNewCollTrace(*comm->ctranComm_->colltraceNew_);
   EXPECT_NE(dumpMap["CT_pastColls"], "[]");
   EXPECT_EQ(dumpMap["CT_pendingColls"], "[]");
-  EXPECT_EQ(dumpMap["CT_currentColl"], "null");
+  EXPECT_EQ(dumpMap["CT_currentColls"], "[]");
 
   CUDACHECK_TEST(cudaStreamDestroy(sig_stream));
   CUDACHECK_TEST(cudaStreamDestroy(wait_stream));
@@ -247,7 +247,7 @@ TEST_F(CollTraceTestLocal, winPutOnly) {
       meta::comms::ncclx::dumpNewCollTrace(*comm->ctranComm_->colltraceNew_);
   EXPECT_NE(dumpMap["CT_pastColls"], "[]");
   EXPECT_EQ(dumpMap["CT_pendingColls"], "[]");
-  EXPECT_EQ(dumpMap["CT_currentColl"], "null");
+  EXPECT_EQ(dumpMap["CT_currentColls"], "[]");
 
   CUDACHECK_TEST(cudaStreamDestroy(put_stream));
   EXPECT_EQ(errs, 0);

--- a/comms/ncclx/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
+++ b/comms/ncclx/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
@@ -184,7 +184,7 @@ TEST_F(CollTraceTest, NewCollTraceAllReduce) {
 
   EXPECT_NE(dumpMap["CT_pastColls"], "[]");
   EXPECT_EQ(dumpMap["CT_pendingColls"], "[]");
-  EXPECT_EQ(dumpMap["CT_currentColl"], "null");
+  EXPECT_EQ(dumpMap["CT_currentColls"], "[]");
 
   auto pastCollsJson = folly::parseJson(dumpMap["CT_pastColls"]);
   EXPECT_EQ(pastCollsJson.size(), nColl);
@@ -229,7 +229,7 @@ TEST_F(CollTraceTest, MixedCtranBaseline) {
 
   EXPECT_NE(dumpMap["CT_pastColls"], "[]");
   EXPECT_EQ(dumpMap["CT_pendingColls"], "[]");
-  EXPECT_EQ(dumpMap["CT_currentColl"], "null");
+  EXPECT_EQ(dumpMap["CT_currentColls"], "[]");
 
   auto pastCollsJson = folly::parseJson(dumpMap["CT_pastColls"]);
   EXPECT_EQ(pastCollsJson.size(), nColl * 2);
@@ -293,7 +293,7 @@ TEST_F(CollTraceTest, TestBcastCtranEx) {
       meta::comms::ncclx::dumpNewCollTrace(*actualComm->newCollTrace);
 
   EXPECT_EQ(folly::parseJson(dumpMap["CT_pastColls"]).size(), nColl);
-  EXPECT_EQ(dumpMap["CT_currentColl"], "null");
+  EXPECT_EQ(dumpMap["CT_currentColls"], "[]");
   EXPECT_EQ(folly::parseJson(dumpMap["CT_pendingColls"]).size(), 0);
   auto pastCollsJson = folly::parseJson(dumpMap["CT_pastColls"]);
   for (const auto& coll : pastCollsJson) {
@@ -343,7 +343,7 @@ TEST_F(CollTraceTest, GroupedSendRecv) {
 
   auto dumpMap = meta::comms::ncclx::dumpNewCollTrace(*comm->newCollTrace);
   EXPECT_EQ(folly::parseJson(dumpMap["CT_pendingColls"]).size(), 0);
-  EXPECT_EQ(dumpMap["CT_currentColl"], "null");
+  EXPECT_EQ(dumpMap["CT_currentColls"], "[]");
   EXPECT_EQ(folly::parseJson(dumpMap["CT_pastColls"]).size(), nColl);
   auto curOpCount = 0;
   for (const auto& coll : folly::parseJson(dumpMap["CT_pastColls"])) {
@@ -401,7 +401,7 @@ TEST_F(CollTraceTest, GroupedSendRecvCtran) {
 
   auto dumpMap = meta::comms::ncclx::dumpNewCollTrace(*comm->newCollTrace);
   EXPECT_EQ(folly::parseJson(dumpMap["CT_pendingColls"]).size(), 0);
-  EXPECT_EQ(dumpMap["CT_currentColl"], "null");
+  EXPECT_EQ(dumpMap["CT_currentColls"], "[]");
   EXPECT_EQ(folly::parseJson(dumpMap["CT_pastColls"]).size(), nColl);
   auto curOpCount = 0;
   for (const auto& coll : folly::parseJson(dumpMap["CT_pastColls"])) {
@@ -453,7 +453,7 @@ TEST_F(CollTraceTest, SimulatePPSendRecv) {
 
   auto dumpMap = meta::comms::ncclx::dumpNewCollTrace(*comm->newCollTrace);
   EXPECT_EQ(folly::parseJson(dumpMap["CT_pendingColls"]).size(), 0);
-  EXPECT_EQ(dumpMap["CT_currentColl"], "null");
+  EXPECT_EQ(dumpMap["CT_currentColls"], "[]");
   if (this->globalRank == 0 || this->globalRank == comm->nRanks - 1) {
     EXPECT_EQ(folly::parseJson(dumpMap["CT_pastColls"]).size(), nColl);
   } else {
@@ -523,7 +523,7 @@ TEST_F(CollTraceTest, SimulateCtranPPSendRecv) {
 
   auto dumpMap = meta::comms::ncclx::dumpNewCollTrace(*comm->newCollTrace);
   EXPECT_EQ(folly::parseJson(dumpMap["CT_pendingColls"]).size(), 0);
-  EXPECT_EQ(dumpMap["CT_currentColl"], "null");
+  EXPECT_EQ(dumpMap["CT_currentColls"], "[]");
   if (this->globalRank == 0 || this->globalRank == comm->nRanks - 1) {
     EXPECT_EQ(folly::parseJson(dumpMap["CT_pastColls"]).size(), nColl);
   } else {
@@ -657,10 +657,10 @@ TEST_F(CollTraceTest, winPutWait) {
   // Parse the dumpMap JSON to check values, similar to previous tests
   auto pastCollsJson = folly::parseJson(dumpMap["CT_pastColls"]);
   auto pendingCollsJson = folly::parseJson(dumpMap["CT_pendingColls"]);
-  auto currentCollJson = dumpMap["CT_currentColl"];
+  auto currentCollJson = dumpMap["CT_currentColls"];
 
   EXPECT_EQ(pendingCollsJson.size(), 0);
-  EXPECT_EQ(currentCollJson, "null");
+  EXPECT_EQ(currentCollJson, "[]");
   // 1 put + 1 wait + 1 allreduce per iteration
   EXPECT_EQ(pastCollsJson.size(), 3 * kNumIters);
 
@@ -723,12 +723,12 @@ TEST_F(CollTraceTest, DumpWithUnfinished) {
 
   auto pastCollsJson = folly::parseJson(dumpMap["CT_pastColls"]);
   auto pendingCollsJson = folly::parseJson(dumpMap["CT_pendingColls"]);
-  auto currentCollJson = dumpMap["CT_currentColl"];
+  auto currentCollJson = dumpMap["CT_currentColls"];
 
   EXPECT_EQ(pastCollsJson.size(), nColl);
   // We will have 1 coll as current coll
   EXPECT_EQ(pendingCollsJson.size(), nColl - 1);
-  EXPECT_NE(currentCollJson, "null");
+  EXPECT_NE(currentCollJson, "[]");
 
   for (const auto& coll : pastCollsJson) {
     EXPECT_GT(coll["startTs"].asInt(), 0);
@@ -778,12 +778,12 @@ TEST_F(CollTraceTest, DumpWithUnfinishedCtran) {
 
   auto pastCollsJson = folly::parseJson(dumpMap["CT_pastColls"]);
   auto pendingCollsJson = folly::parseJson(dumpMap["CT_pendingColls"]);
-  auto currentCollJson = dumpMap["CT_currentColl"];
+  auto currentCollJson = dumpMap["CT_currentColls"];
 
   EXPECT_EQ(pastCollsJson.size(), nColl);
   // We will have 1 coll as current coll
   EXPECT_EQ(pendingCollsJson.size(), nColl - 1);
-  EXPECT_NE(currentCollJson, "null");
+  EXPECT_NE(currentCollJson, "[]");
 
   for (const auto& coll : pastCollsJson) {
     EXPECT_GT(coll["startTs"].asInt(), 0);
@@ -824,7 +824,7 @@ TEST_F(CollTraceTest, GroupedAllReduce) {
 
   EXPECT_NE(dumpMap["CT_pastColls"], "[]");
   EXPECT_EQ(dumpMap["CT_pendingColls"], "[]");
-  EXPECT_EQ(dumpMap["CT_currentColl"], "null");
+  EXPECT_EQ(dumpMap["CT_currentColls"], "[]");
 
   auto pastCollsJson = folly::parseJson(dumpMap["CT_pastColls"]);
   EXPECT_EQ(pastCollsJson.size(), nColl);
@@ -867,7 +867,7 @@ TEST_F(CollTraceTest, GroupedSendRecvAllReduce) {
 
   EXPECT_NE(dumpMap["CT_pastColls"], "[]");
   EXPECT_EQ(dumpMap["CT_pendingColls"], "[]");
-  EXPECT_EQ(dumpMap["CT_currentColl"], "null");
+  EXPECT_EQ(dumpMap["CT_currentColls"], "[]");
 
   auto pastCollsJson = folly::parseJson(dumpMap["CT_pastColls"]);
   EXPECT_EQ(pastCollsJson.size(), nColl);
@@ -898,7 +898,7 @@ TEST_F(CollTraceTest, CollTraceQueryInCapture) {
 
   EXPECT_NE(dumpMap["CT_pastColls"], "[]");
   EXPECT_EQ(dumpMap["CT_pendingColls"], "[]");
-  EXPECT_EQ(dumpMap["CT_currentColl"], "null");
+  EXPECT_EQ(dumpMap["CT_currentColls"], "[]");
 
   auto pastCollsJson = folly::parseJson(dumpMap["CT_pastColls"]);
   EXPECT_EQ(pastCollsJson.size(), nColl);

--- a/comms/ncclx/meta/colltrace/tests/NewCollTraceUT.cc
+++ b/comms/ncclx/meta/colltrace/tests/NewCollTraceUT.cc
@@ -105,7 +105,7 @@ TEST_F(NewCollTraceUT, dumpNewCollTraceWithCollectives) {
 
   // Verify pastColls is empty and currentColl should have one entry
   EXPECT_EQ(dumpMapPending["CT_pastColls"], "[]");
-  EXPECT_NE(dumpMapPending["CT_currentColl"], "null");
+  EXPECT_NE(dumpMapPending["CT_currentColls"], "[]");
   EXPECT_EQ(dumpMapPending["CT_pendingColls"], "[]");
 
   // Trigger kernel start
@@ -122,7 +122,7 @@ TEST_F(NewCollTraceUT, dumpNewCollTraceWithCollectives) {
   // Verify currentColl is set and pendingColls is empty
   EXPECT_EQ(dumpMapCurrent["CT_pastColls"], "[]");
   EXPECT_EQ(dumpMapCurrent["CT_pendingColls"], "[]");
-  EXPECT_NE(dumpMapCurrent["CT_currentColl"], "null");
+  EXPECT_NE(dumpMapCurrent["CT_currentColls"], "[]");
 
   // Trigger kernel finish
   ASSERT_TRUE(
@@ -136,7 +136,7 @@ TEST_F(NewCollTraceUT, dumpNewCollTraceWithCollectives) {
   ASSERT_FALSE(dumpMapPast.empty());
 
   // Verify pastColls has one entry and currentColl is null
-  EXPECT_EQ(dumpMapPast["CT_currentColl"], "null");
+  EXPECT_EQ(dumpMapPast["CT_currentColls"], "[]");
   auto pastCollsJson = folly::parseJson(dumpMapPast["CT_pastColls"]);
   EXPECT_EQ(pastCollsJson.size(), 1);
 

--- a/comms/ncclx/meta/commDump.cc
+++ b/comms/ncclx/meta/commDump.cc
@@ -162,11 +162,11 @@ static void dumpCollTrace(
     // old coll trace, we don't care too much about code reuse here.
     map["CT_pastColls"] = folly::toJson(folly::toDynamic(dump.pastColls));
     map["CT_pendingColls"] = folly::toJson(folly::toDynamic(dump.pendingColls));
+    auto currentColls = folly::dynamic::array();
     if (dump.currentColl != nullptr) {
-      map["CT_currentColl"] = folly::toJson(dump.currentColl->toDynamic());
-    } else {
-      map["CT_currentColl"] = "null";
+      currentColls.push_back(dump.currentColl->toDynamic());
     }
+    map["CT_currentColls"] = folly::toJson(currentColls);
   } else {
     XLOGF(DBG2, "CommDump: COLLTRACE is disabled. No trace to dump");
   }

--- a/comms/ncclx/meta/tests/CommDumpTest.cc
+++ b/comms/ncclx/meta/tests/CommDumpTest.cc
@@ -186,7 +186,7 @@ TEST_F(CommDumpTest, SingleComm) {
 
   EXPECT_EQ(dump.count("CT_pastColls"), 1);
   EXPECT_EQ(dump.count("CT_pendingColls"), 1);
-  EXPECT_EQ(dump.count("CT_currentColl"), 1);
+  EXPECT_EQ(dump.count("CT_currentColls"), 1);
 
   EXPECT_EQ(dump.count("PT_pastColls"), 1);
   EXPECT_EQ(dump.count("PT_activeOps"), 1);
@@ -246,7 +246,7 @@ TEST_F(CommDumpTest, DumpAfterSendRecv) {
 
   EXPECT_EQ(dump.count("CT_pastColls"), 1);
   EXPECT_EQ(dump.count("CT_pendingColls"), 1);
-  EXPECT_EQ(dump.count("CT_currentColl"), 1);
+  EXPECT_EQ(dump.count("CT_currentColls"), 1);
   EXPECT_EQ(dump.count("PT_pastColls"), 1);
   EXPECT_EQ(dump.count("PT_activeOps"), 1);
 
@@ -287,8 +287,8 @@ TEST_F(CommDumpTest, DumpAfterSendRecv) {
     EXPECT_EQ(ctPendingCollsObjs.size(), 0);
   }
 
-  if (dump.count("CT_currentColl")) {
-    EXPECT_EQ(dump["CT_currentColl"], "null");
+  if (dump.count("CT_currentColls")) {
+    EXPECT_EQ(dump["CT_currentColls"], "[]");
   }
 
   if (dump.count("PT_activeOps")) {
@@ -354,7 +354,7 @@ TEST_F(CommDumpTest, DumpAfterCtranSendRecv) {
 
   EXPECT_EQ(dump.count("CT_pastColls"), 1);
   EXPECT_EQ(dump.count("CT_pendingColls"), 1);
-  EXPECT_EQ(dump.count("CT_currentColl"), 1);
+  EXPECT_EQ(dump.count("CT_currentColls"), 1);
   EXPECT_EQ(dump.count("PT_pastColls"), 1);
   EXPECT_EQ(dump.count("PT_activeOps"), 1);
 
@@ -397,8 +397,8 @@ TEST_F(CommDumpTest, DumpAfterCtranSendRecv) {
     EXPECT_EQ(ctPendingCollsObjs.size(), 0);
   }
 
-  if (dump.count("CT_currentColl")) {
-    EXPECT_EQ(dump["CT_currentColl"], "null");
+  if (dump.count("CT_currentColls")) {
+    EXPECT_EQ(dump["CT_currentColls"], "[]");
   }
 
   if (dump.count("PT_activeOps")) {
@@ -457,7 +457,7 @@ TEST_F(CommDumpTest, DumpAfterColl) {
 
   EXPECT_EQ(dump.count("CT_pastColls"), 1);
   EXPECT_EQ(dump.count("CT_pendingColls"), 1);
-  EXPECT_EQ(dump.count("CT_currentColl"), 1);
+  EXPECT_EQ(dump.count("CT_currentColls"), 1);
   EXPECT_EQ(dump.count("PT_pastColls"), 1);
   EXPECT_EQ(dump.count("PT_activeOps"), 1);
 
@@ -489,8 +489,8 @@ TEST_F(CommDumpTest, DumpAfterColl) {
     EXPECT_EQ(ctPendingCollsObjs.size(), 0);
   }
 
-  if (dump.count("CT_currentColl")) {
-    EXPECT_EQ(dump["CT_currentColl"], "null");
+  if (dump.count("CT_currentColls")) {
+    EXPECT_EQ(dump["CT_currentColls"], "[]");
   }
 
   if (dump.count("PT_activeOps")) {
@@ -560,7 +560,7 @@ TEST_F(CommDumpTest, DumpAfterCtranColl) {
   }
 
   EXPECT_EQ(dump.count("CT_pendingColls"), 1);
-  EXPECT_EQ(dump.count("CT_currentColl"), 1);
+  EXPECT_EQ(dump.count("CT_currentColls"), 1);
   EXPECT_EQ(dump.count("PT_pastColls"), 1);
   EXPECT_EQ(dump.count("PT_activeOps"), 1);
 
@@ -681,7 +681,7 @@ TEST_F(CommDumpTest, DumpDuringColl) {
 
   EXPECT_EQ(dump.count("CT_pastColls"), 1);
   EXPECT_EQ(dump.count("CT_pendingColls"), 1);
-  EXPECT_EQ(dump.count("CT_currentColl"), 1);
+  EXPECT_EQ(dump.count("CT_currentColls"), 1);
   EXPECT_EQ(dump.count("PT_pastColls"), 1);
   EXPECT_EQ(dump.count("PT_activeOps"), 1);
   EXPECT_EQ(dump.count("PT_activeColls"), 1);
@@ -725,13 +725,14 @@ TEST_F(CommDumpTest, DumpDuringColl) {
     }
   }
 
-  if (dump.count("CT_currentColl")) {
-    EXPECT_NE(dump["CT_currentColl"], "null");
-    auto ctCurrentCollsObj = folly::parseJson(dump["CT_currentColl"]);
+  if (dump.count("CT_currentColls")) {
+    EXPECT_NE(dump["CT_currentColls"], "[]");
+    auto ctCurrentCollsArr = folly::parseJson(dump["CT_currentColls"]);
+    ASSERT_GT(ctCurrentCollsArr.size(), 0);
     if (comm->rank == hangRank) {
-      EXPECT_EQ(ctCurrentCollsObj["collId"].asInt(), hangOpCount);
-      EXPECT_EQ(ctCurrentCollsObj["opCount"].asInt(), hangOpCount);
-      EXPECT_EQ(ctCurrentCollsObj["opName"], "AllReduce");
+      EXPECT_EQ(ctCurrentCollsArr[0]["collId"].asInt(), hangOpCount);
+      EXPECT_EQ(ctCurrentCollsArr[0]["opCount"].asInt(), hangOpCount);
+      EXPECT_EQ(ctCurrentCollsArr[0]["opName"], "AllReduce");
     }
   }
 
@@ -940,7 +941,7 @@ TEST_F(CommDumpTest, DumpAfterCollNewCollTrace) {
 
   EXPECT_EQ(dump.count("CT_pastColls"), 1);
   EXPECT_EQ(dump.count("CT_pendingColls"), 1);
-  EXPECT_EQ(dump.count("CT_currentColl"), 1);
+  EXPECT_EQ(dump.count("CT_currentColls"), 1);
   EXPECT_EQ(dump.count("PT_pastColls"), 1);
   EXPECT_EQ(dump.count("PT_activeOps"), 1);
 
@@ -977,9 +978,9 @@ TEST_F(CommDumpTest, DumpAfterCollNewCollTrace) {
     EXPECT_EQ(ctPendingCollsObjs.size(), 0);
   }
 
-  if (dump.count("CT_currentColl")) {
+  if (dump.count("CT_currentColls")) {
     XLOG(DBG1) << "Entered CT_currentColl if statement";
-    EXPECT_EQ(dump["CT_currentColl"], "null");
+    EXPECT_EQ(dump["CT_currentColls"], "[]");
   }
 
   if (dump.count("PT_activeOps")) {
@@ -1044,7 +1045,7 @@ TEST_F(CommDumpTest, DumpAfterCollNewCollTraceWithCommsMonitor) {
 
   EXPECT_EQ(dump.count("CT_pastColls"), 1);
   EXPECT_EQ(dump.count("CT_pendingColls"), 1);
-  EXPECT_EQ(dump.count("CT_currentColl"), 1);
+  EXPECT_EQ(dump.count("CT_currentColls"), 1);
   EXPECT_EQ(dump.count("PT_pastColls"), 1);
   EXPECT_EQ(dump.count("PT_activeOps"), 1);
 
@@ -1081,9 +1082,9 @@ TEST_F(CommDumpTest, DumpAfterCollNewCollTraceWithCommsMonitor) {
     EXPECT_EQ(ctPendingCollsObjs.size(), 0);
   }
 
-  if (dump.count("CT_currentColl")) {
+  if (dump.count("CT_currentColls")) {
     XLOG(DBG1) << "Entered CT_currentColl if statement";
-    EXPECT_EQ(dump["CT_currentColl"], "null");
+    EXPECT_EQ(dump["CT_currentColls"], "[]");
   }
 
   if (dump.count("PT_activeOps")) {

--- a/comms/utils/colltrace/plugins/CommDumpPlugin.cc
+++ b/comms/utils/colltrace/plugins/CommDumpPlugin.cc
@@ -104,18 +104,9 @@ CommsMaybeVoid CommDumpPlugin::afterCollKernelStart(
         commInternalError));
   }
 
-  // ----- Check whether the current event is not empty -----
-  if (lockedCollTraceDump->currentColl != nullptr) [[unlikely]] {
-    XLOG_FIRST_N(
-        ERR, 2, "Got event with non-empty currentColl in CommDumpPlugin");
-    return folly::makeUnexpected(CommsError(
-        "Got event with non-empty currentColl in CommDumpPlugin",
-        commInternalError));
-  }
-
-  // ----- Set the pending event and current event -----
-  lockedCollTraceDump->currentColl =
-      std::move(lockedCollTraceDump->pendingColls.front());
+  // ----- Move from pending to current -----
+  lockedCollTraceDump->currentColls.push_back(
+      std::move(lockedCollTraceDump->pendingColls.front()));
   lockedCollTraceDump->pendingColls.pop_front();
 
   return folly::unit;
@@ -143,25 +134,30 @@ CommsMaybeVoid CommDumpPlugin::afterCollKernelEnd(
           lockedCollTraceDump->pendingColls,
           config_.pendingCollSize + 1));
 
-  // ----- Ensure CollRecord matches -----
-  if (lockedCollTraceDump->currentColl.get() != curEvent.collRecord.get())
-      [[unlikely]] {
+  // ----- Find and move from currentColls to pastColls -----
+  auto it = std::find_if(
+      lockedCollTraceDump->currentColls.begin(),
+      lockedCollTraceDump->currentColls.end(),
+      [&curEvent](const std::shared_ptr<CollRecord>& record) {
+        return record.get() == curEvent.collRecord.get();
+      });
+
+  if (it == lockedCollTraceDump->currentColls.end()) [[unlikely]] {
     XLOG_FIRST_N(
         ERR,
         2,
-        "Got event with mismatched collRecord in CommDumpPlugin during coll end");
+        "Could not find matching collRecord in currentColls during coll end");
     return folly::makeUnexpected(CommsError(
-        "Got event with mismatched collRecord in CommDumpPlugin during coll end",
+        "Could not find matching collRecord in currentColls during coll end",
         commInternalError));
   }
 
-  // ----- Move the coll to pastColls -----
   while (config_.pastCollSize >= 0 &&
          lockedCollTraceDump->pastColls.size() >= config_.pastCollSize) {
     lockedCollTraceDump->pastColls.pop_front();
   }
-  lockedCollTraceDump->pastColls.emplace_back(
-      std::move(lockedCollTraceDump->currentColl));
+  lockedCollTraceDump->pastColls.emplace_back(std::move(*it));
+  lockedCollTraceDump->currentColls.erase(it);
 
   return folly::unit;
 }
@@ -205,14 +201,14 @@ CommsMaybe<CollTraceDump> CommDumpPlugin::dump() noexcept {
   // Create a copy of the current state of collTraceDump_
   CollTraceDump dumpCopy = *readLockedCollTraceDump;
 
-  // Temporary fix: Currently we use currentColl to also track the next
+  // Temporary fix: Currently we use currentColls to also track the next
   // pending collective, this logic is being used in Analyzer to detect
   // dependencies between collectives. Without making the next pending
   // collective current, Analyzer will not work. For now we temporarily
   // track next pending collective as current, until we fully deprecate
   // old colltrace and change Analyzer logic
-  if (dumpCopy.currentColl == nullptr && !dumpCopy.pendingColls.empty()) {
-    dumpCopy.currentColl = std::move(dumpCopy.pendingColls.front());
+  if (dumpCopy.currentColls.empty() && !dumpCopy.pendingColls.empty()) {
+    dumpCopy.currentColls.push_back(std::move(dumpCopy.pendingColls.front()));
     dumpCopy.pendingColls.pop_front();
   }
 
@@ -235,11 +231,11 @@ std::unordered_map<std::string, std::string> commDumpToMap(
   }
   map["CT_pendingColls"] = folly::toJson(pendingColls);
 
-  if (dump.currentColl != nullptr) {
-    map["CT_currentColl"] = folly::toJson(dump.currentColl->toDynamic());
-  } else {
-    map["CT_currentColl"] = "null";
+  auto currentColls = folly::dynamic::array();
+  for (const auto& coll : dump.currentColls) {
+    currentColls.push_back(coll->toDynamic());
   }
+  map["CT_currentColls"] = folly::toJson(currentColls);
 
   return map;
 }

--- a/comms/utils/colltrace/plugins/CommDumpPlugin.h
+++ b/comms/utils/colltrace/plugins/CommDumpPlugin.h
@@ -4,6 +4,7 @@
 
 #include <deque>
 #include <memory>
+#include <vector>
 
 #include <folly/MPMCQueue.h>
 #include <folly/Synchronized.h>
@@ -38,7 +39,7 @@ struct CommDumpConfig {
 
 struct CollTraceDump {
   std::deque<std::shared_ptr<CollRecord>> pastColls;
-  std::shared_ptr<CollRecord> currentColl;
+  std::vector<std::shared_ptr<CollRecord>> currentColls;
   std::deque<std::shared_ptr<CollRecord>> pendingColls;
 };
 

--- a/comms/utils/colltrace/plugins/tests/CommDumpPluginUT.cc
+++ b/comms/utils/colltrace/plugins/tests/CommDumpPluginUT.cc
@@ -85,8 +85,8 @@ TEST_F(CommDumpPluginTest, AfterCollKernelScheduledWithDump) {
   auto dump = plugin->dump();
   EXPECT_VALUE(dump);
   EXPECT_TRUE(dump.value().pastColls.empty());
-  ASSERT_NE(dump.value().currentColl, nullptr);
-  EXPECT_EQ(dump.value().currentColl.get(), event.collRecord.get());
+  ASSERT_EQ(dump.value().currentColls.size(), 1);
+  EXPECT_EQ(dump.value().currentColls.front().get(), event.collRecord.get());
 }
 
 TEST_F(CommDumpPluginTest, NullAfterCollKernel) {
@@ -115,7 +115,8 @@ TEST_F(CommDumpPluginTest, AfterCollKernelStart) {
   EXPECT_VALUE(dump);
   EXPECT_TRUE(dump.value().pastColls.empty());
   EXPECT_TRUE(dump.value().pendingColls.empty());
-  EXPECT_EQ(dump.value().currentColl.get(), event.collRecord.get());
+  ASSERT_EQ(dump.value().currentColls.size(), 1);
+  EXPECT_EQ(dump.value().currentColls.front().get(), event.collRecord.get());
 }
 
 // Test afterCollKernelEnd
@@ -139,7 +140,7 @@ TEST_F(CommDumpPluginTest, AfterCollKernelEnd) {
   EXPECT_EQ(dump.value().pastColls.size(), 1);
   EXPECT_EQ(dump.value().pastColls.front().get(), event.collRecord.get());
   EXPECT_TRUE(dump.value().pendingColls.empty());
-  EXPECT_EQ(dump.value().currentColl, nullptr);
+  EXPECT_TRUE(dump.value().currentColls.empty());
 }
 
 // Test dump method
@@ -151,7 +152,7 @@ TEST_F(CommDumpPluginTest, Dump) {
   // Verify that the dump is initially empty
   auto& dump = dumpResult.value();
   EXPECT_TRUE(dump.pastColls.empty());
-  EXPECT_EQ(dump.currentColl, nullptr);
+  EXPECT_TRUE(dump.currentColls.empty());
   EXPECT_TRUE(dump.pendingColls.empty());
 
   // Process a complete collective
@@ -166,7 +167,7 @@ TEST_F(CommDumpPluginTest, Dump) {
 
   auto& dump2 = dumpResult2.value();
   EXPECT_EQ(dump2.pastColls.size(), 1);
-  EXPECT_EQ(dump2.currentColl, nullptr);
+  EXPECT_TRUE(dump2.currentColls.empty());
   EXPECT_TRUE(dump2.pendingColls.empty());
   EXPECT_EQ(dump2.pastColls.front()->getCollId(), 1);
 }
@@ -188,8 +189,9 @@ TEST_F(CommDumpPluginTest, MultipleCollectives) {
 
   auto& dump = dumpResult.value();
   EXPECT_TRUE(dump.pastColls.empty());
-  EXPECT_EQ(dump.currentColl.get(), event1.collRecord.get());
-  EXPECT_EQ(dump.currentColl->getCollId(), 1);
+  ASSERT_EQ(dump.currentColls.size(), 1);
+  EXPECT_EQ(dump.currentColls.front().get(), event1.collRecord.get());
+  EXPECT_EQ(dump.currentColls.front()->getCollId(), 1);
   EXPECT_EQ(dump.pendingColls.size(), 1);
   EXPECT_EQ(dump.pendingColls.front()->getCollId(), 2);
   EXPECT_EQ(dump.pendingColls.front().get(), event2.collRecord.get());
@@ -207,8 +209,8 @@ TEST_F(CommDumpPluginTest, MultipleCollectives) {
   auto& dump2 = dumpResult2.value();
   EXPECT_EQ(dump2.pastColls.size(), 1);
   EXPECT_EQ(dump2.pastColls.front()->getCollId(), 1);
-  EXPECT_NE(dump2.currentColl, nullptr);
-  EXPECT_EQ(dump2.currentColl->getCollId(), 2);
+  ASSERT_EQ(dump2.currentColls.size(), 1);
+  EXPECT_EQ(dump2.currentColls.front()->getCollId(), 2);
   EXPECT_TRUE(dump2.pendingColls.empty());
 
   // Complete second collective
@@ -222,7 +224,7 @@ TEST_F(CommDumpPluginTest, MultipleCollectives) {
   EXPECT_EQ(dump3.pastColls.size(), 2);
   EXPECT_EQ(dump3.pastColls.front()->getCollId(), 1);
   EXPECT_EQ(dump3.pastColls.back()->getCollId(), 2);
-  EXPECT_EQ(dump3.currentColl, nullptr);
+  EXPECT_TRUE(dump3.currentColls.empty());
   EXPECT_TRUE(dump3.pendingColls.empty());
 }
 
@@ -279,8 +281,8 @@ TEST_F(CommDumpPluginTest, ConfigurablePendingQueueSize) {
   EXPECT_EQ(
       dump.value().pendingColls.size(),
       kTestPendingQueueSize - 1); // One will be marked as currentColl
-  EXPECT_NE(dump.value().currentColl, nullptr); // First one moved to current
-  EXPECT_EQ(dump.value().currentColl->getCollId(), 0);
+  ASSERT_EQ(dump.value().currentColls.size(), 1); // First one moved to current
+  EXPECT_EQ(dump.value().currentColls.front()->getCollId(), 0);
   if (dump.value().pendingColls.size() == kTestPendingQueueSize - 1) {
     for (int i = 0; i < kTestPendingQueueSize - 1; ++i) {
       EXPECT_EQ(dump.value().pendingColls[i]->getCollId(), i + 1); // IDs 1-3

--- a/comms/utils/colltrace/plugins/tests/CommDumpToMapUT.cc
+++ b/comms/utils/colltrace/plugins/tests/CommDumpToMapUT.cc
@@ -37,12 +37,12 @@ TEST_F(CommDumpToMapTest, EmptyDump) {
   EXPECT_EQ(map.size(), 3);
   EXPECT_TRUE(map.find("CT_pastColls") != map.end());
   EXPECT_TRUE(map.find("CT_pendingColls") != map.end());
-  EXPECT_TRUE(map.find("CT_currentColl") != map.end());
+  EXPECT_TRUE(map.find("CT_currentColls") != map.end());
 
   // Verify the values are as expected for an empty dump
   EXPECT_EQ(map["CT_pastColls"], "[]");
   EXPECT_EQ(map["CT_pendingColls"], "[]");
-  EXPECT_EQ(map["CT_currentColl"], "null");
+  EXPECT_EQ(map["CT_currentColls"], "[]");
 }
 
 // Test commDumpToMap with only pastColls
@@ -66,7 +66,7 @@ TEST_F(CommDumpToMapTest, WithPastColls) {
 
   // Verify other values
   EXPECT_EQ(map["CT_pendingColls"], "[]");
-  EXPECT_EQ(map["CT_currentColl"], "null");
+  EXPECT_EQ(map["CT_currentColls"], "[]");
 }
 
 // Test commDumpToMap with only currentColl
@@ -74,7 +74,7 @@ TEST_F(CommDumpToMapTest, WithCurrentColl) {
   CollTraceDump dump;
 
   // Set current collective
-  dump.currentColl = createCollRecord(3);
+  dump.currentColls = {createCollRecord(3)};
 
   auto map = commDumpToMap(dump);
 
@@ -85,9 +85,10 @@ TEST_F(CommDumpToMapTest, WithCurrentColl) {
   EXPECT_EQ(map["CT_pastColls"], "[]");
   EXPECT_EQ(map["CT_pendingColls"], "[]");
 
-  // Parse the JSON for currentColl and verify it contains the expected data
-  auto currentCollJson = folly::parseJson(map["CT_currentColl"]);
-  EXPECT_EQ(currentCollJson["collId"], 3);
+  // Parse the JSON for currentColls and verify it contains the expected data
+  auto currentCollsJson = folly::parseJson(map["CT_currentColls"]);
+  ASSERT_EQ(currentCollsJson.size(), 1u);
+  EXPECT_EQ(currentCollsJson[0]["collId"], 3);
 }
 
 // Test commDumpToMap with only pendingColls
@@ -106,7 +107,7 @@ TEST_F(CommDumpToMapTest, WithPendingColls) {
 
   // Verify pastColls is empty and currentColl is null
   EXPECT_EQ(map["CT_pastColls"], "[]");
-  EXPECT_EQ(map["CT_currentColl"], "null");
+  EXPECT_EQ(map["CT_currentColls"], "[]");
 
   // Parse the JSON for pendingColls and verify it contains the expected data
   auto pendingCollsJson = folly::parseJson(map["CT_pendingColls"]);
@@ -125,7 +126,7 @@ TEST_F(CommDumpToMapTest, FullDump) {
   dump.pastColls.push_back(createCollRecord(2));
 
   // Set current collective
-  dump.currentColl = createCollRecord(3);
+  dump.currentColls = {createCollRecord(3)};
 
   // Add pending collectives
   dump.pendingColls.push_back(createCollRecord(4));
@@ -142,9 +143,10 @@ TEST_F(CommDumpToMapTest, FullDump) {
   EXPECT_EQ(pastCollsJson[0]["collId"], 1);
   EXPECT_EQ(pastCollsJson[1]["collId"], 2);
 
-  // Parse the JSON for currentColl and verify it contains the expected data
-  auto currentCollJson = folly::parseJson(map["CT_currentColl"]);
-  EXPECT_EQ(currentCollJson["collId"], 3);
+  // Parse the JSON for currentColls and verify it contains the expected data
+  auto currentCollsJson = folly::parseJson(map["CT_currentColls"]);
+  ASSERT_EQ(currentCollsJson.size(), 1u);
+  EXPECT_EQ(currentCollsJson[0]["collId"], 3);
 
   // Parse the JSON for pendingColls and verify it contains the expected data
   auto pendingCollsJson = folly::parseJson(map["CT_pendingColls"]);


### PR DESCRIPTION
Summary:

we should support multiple current collectives - this is possible when multiple collectives are being executed across ctran/nccl-baseline communicators, or we have collectives that require concurrency (e.g., signals)

Reviewed By: SuhitK

Differential Revision: D98955440
