### PR TITLE
support graph captured kernel elems w/o gpeFn (#1975)

### DIFF
--- a/comms/ctran/algos/AllToAll/AllToAllv.cc
+++ b/comms/ctran/algos/AllToAll/AllToAllv.cc
@@ -111,6 +111,17 @@ static inline commResult_t setupKernelConfig(
       ngroups,
       &config.args.collective.alltoallv.recvElemsList);
 
+  KernelElem* sendElem = config.args.collective.alltoallv.sendElemsList;
+  KernelElem* recvElem = config.args.collective.alltoallv.recvElemsList;
+
+  // Collect persistent elems for graph cleanup in the no-cmd path.
+  for (auto* e = sendElem; e != nullptr; e = e->next) {
+    config.persistentKernelElems.push_back(e);
+  }
+  for (auto* e = recvElem; e != nullptr; e = e->next) {
+    config.persistentKernelElems.push_back(e);
+  }
+
   // Ensure each rank sends to different peer at a time to avoid alltoone P2P
   // write congestion. For example, with localRanks = 4, the following
   // schedule is used:
@@ -120,8 +131,6 @@ static inline commResult_t setupKernelConfig(
   // rank0: s(2)r(2); rank1: s(3)r(3); rank2: s(0)r(0); rank3: s(1)r(1)
   // - Round2:
   // rank0: s(3)r(1); rank1: s(0)r(2); rank2: s(1)r(3); rank3: s(2)r(0)
-  KernelElem* sendElem = config.args.collective.alltoallv.sendElemsList;
-  KernelElem* recvElem = config.args.collective.alltoallv.recvElemsList;
   for (int r = 0; r < statex->nLocalRanks() - 1; r++) {
     int sendPeer = (statex->localRank() + r + 1) % statex->nLocalRanks();
     int recvPeer = (statex->localRank() + statex->nLocalRanks() - r - 1) %

--- a/comms/ctran/gpe/CtranGpe.cc
+++ b/comms/ctran/gpe/CtranGpe.cc
@@ -425,10 +425,6 @@ commResult_t CtranGpe::allocKernelElems(
   if (numElems > this->pimpl->kernelElemPool->size()) {
     this->pimpl->kernelElemPool->reclaim();
 
-    // We do not expect such high amount of inuse elements, return error here to
-    // avoid hang. If there can be really such a high usage case, either
-    // increase the pool size or set a timeout here to reclaim multiple times.
-    // Avoid timeout logic for now to avoid complexity.
     if (numElems > this->pimpl->kernelElemPool->size()) {
       CLOGF(
           WARN,
@@ -456,6 +452,7 @@ commResult_t CtranGpe::allocKernelElems(
     }
     elem = elem->next;
   }
+
   return commSuccess;
 }
 

--- a/comms/ctran/gpe/CtranGpe.h
+++ b/comms/ctran/gpe/CtranGpe.h
@@ -333,6 +333,11 @@ struct KernelConfig {
   // kernelFlag.
   std::function<void()> postKernelCleanup{nullptr};
 
+  // KernelElems marked persistent during graph capture by allocKernelElems().
+  // submit() retains cleanup on the graph for the no-cmd (empty opGroup) path.
+  // For the cmd path, ~OpElem handles free() and this vector is ignored.
+  std::vector<KernelElem*> persistentKernelElems;
+
   const std::string algoName;
   // Copied after collective called ctran->updateOpCount()
   // Upon collective submission, we should always use the copied opCount since
@@ -407,14 +412,6 @@ class CtranGpe {
       std::shared_ptr<std::atomic_flag> cpuFlag);
 
   // Allocate numElems number of p2pElem objects from internal pool.
-  // When free objects are not enough, it will be in blocking wait and reclaim
-  // inuse p2pElems till enough objects are available. Return commSuccess if all
-  // elements are allocated, otherwise return commInternalError. Input
-  // arguments:
-  //   - numElems: number of p2pElem objects to be allocated
-  //   - ngroups: number of thread block groups to use each p2pElem object
-  // Output arguments:
-  //   - elemsList: a C-style list of p2pElem objects being accessed in kernel
   commResult_t
   allocKernelElems(size_t numElems, int ngroups, KernelElem** elemsList);
 

--- a/comms/ctran/gpe/CtranGpeDev.h
+++ b/comms/ctran/gpe/CtranGpeDev.h
@@ -104,6 +104,21 @@ struct alignas(16) KernelElem {
   volatile int stepDone{0};
   // allow kernel to access next element in the list
   KernelElem* next{nullptr};
+  // If true, isFree() always returns false — prevents reclaim() from stealing
+  // the elem while a persistent cmd (graph capture) still owns it.
+  // Not cleared by free()/unuse() — only cleared by clearPersistent().
+  std::atomic<bool> persistent_{false};
+
+  // Prevent pool reclaim between graph replays. The kernel resets status
+  // after each replay, but persistent keeps isFree() returning false.
+  void setPersistent() {
+    persistent_ = true;
+  }
+
+  // Allow pool reclaim. Called at graph destruction to release the elem.
+  void clearPersistent() {
+    persistent_ = false;
+  }
 
   // CPU side calls to manage the lifetime of the element and coordinate with
   // kernel. Check if the element is free and ready to be reclaimed.

--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -350,24 +350,51 @@ commResult_t CtranGpe::Impl::submit(
     } else {
       cmdEnqueue(cmd);
     }
-  } else if (kernelConfig.postKernelCleanup && isCapturing) {
-    // During graph capture with empty opGroup (e.g., ctp2p NVL-only ops),
-    // postKernelCleanup wasn't moved into a cmd. Retain it as a user object
-    // on the graph so it runs on graph destruction
-    FB_COMMCHECKGOTO(
-        utils::cudagraph::retainUserObject(
-            /*obj=*/
-            new std::function<void()>(
-                std::move(kernelConfig.postKernelCleanup)),
-            /*destroyCallback=*/
-            [](void* p) {
-              auto* fn = static_cast<std::function<void()>*>(p);
-              (*fn)();
-              delete fn;
-            },
-            streamCaptureInfo),
-        res,
-        fail);
+  }
+
+  // For the no-cmd path during graph capture, retain cleanup on the graph.
+  if (isCapturing && !needsKernelFlag) {
+    if (kernelConfig.postKernelCleanup) {
+      FB_COMMCHECKGOTO(
+          utils::cudagraph::retainUserObject(
+              /*obj=*/
+              new std::function<void()>(
+                  std::move(kernelConfig.postKernelCleanup)),
+              /*destroyCallback=*/
+              [](void* p) {
+                auto* fn = static_cast<std::function<void()>*>(p);
+                (*fn)();
+                delete fn;
+              },
+              streamCaptureInfo),
+          res,
+          fail);
+    }
+
+    // Mark KernelElems as persistent and release on graph destruction.
+    // In the cmd path, ~OpElem handles free() (which also clears persistent).
+    if (!kernelConfig.persistentKernelElems.empty()) {
+      for (auto* elem : kernelConfig.persistentKernelElems) {
+        elem->setPersistent();
+      }
+      auto* elems = new std::vector<KernelElem*>(
+          std::move(kernelConfig.persistentKernelElems));
+      FB_COMMCHECKGOTO(
+          utils::cudagraph::retainUserObject(
+              /*obj=*/elems,
+              /*destroyCallback=*/
+              [](void* p) {
+                auto* v = static_cast<std::vector<KernelElem*>*>(p);
+                for (auto* elem : *v) {
+                  elem->clearPersistent();
+                  elem->free();
+                }
+                delete v;
+              },
+              streamCaptureInfo),
+          res,
+          fail);
+    }
   }
 
   if (!kernelConfig.canConcurrent) {
@@ -818,6 +845,8 @@ void KernelElem::setStatus(KernelElem::ElemStatus s) {
 }
 
 void KernelElem::free() {
+  // Clear persistence so reclaim() can pick up this elem after free.
+  persistent_ = false;
   CHECK_KELEM_NGROUPS(this);
 
   bool canFree = true;
@@ -853,6 +882,9 @@ void KernelElem::free() {
 }
 
 bool KernelElem::isFree() {
+  if (persistent_) {
+    return false;
+  }
   CHECK_KELEM_NGROUPS(this);
   bool allFree = true;
   for (int i = 0; i < this->ngroups && allFree; i++) {


### PR DESCRIPTION
Summary:

AllToAllv on single-node (all-NVL, nLocalRanks == nRanks) uses a kernel-only path (empty opGroup, no GPE host callback).
The kernel reads per-peer send/recv metadata (count, displacement, peer rank) from KernelElem objects whose addresses
are baked into the graph as kernel args when captured. After the capture, the kernel resets status[*] = RESET on those elems.
The pool's reclaim() sees them as free and recycles them. If something else pops the same elems from the pool (e.g., another
eager AllToAllv call) and overwrites staged.count/staged.displ/staged.peerRank with new values, subsequent replays will be corupted.

to fix this, we can have allocKernelElems(stream) make the objects persistent. This prevents reclaim() from recycling them, and
on graph destruction, the retained callback calls clearPersistent() + free() to return them to the pool.

Reviewed By: kapilsh

Differential Revision: D99361274


