### PR TITLE
harden cudagraph support for graphed signals (#1976)

### DIFF
--- a/comms/ctran/algos/RMA/PutSignal.cc
+++ b/comms/ctran/algos/RMA/PutSignal.cc
@@ -106,45 +106,58 @@ static commResult_t putSignalImpl(
       reinterpret_cast<size_t>(win->remWinInfo[peerRank].dataAddr) +
       targetDispNbytes);
 
-  // Get registration handle for local send buffer
+  // Skip data transfer if count is 0 (signal-only, e.g. ready barrier)
   void* localMemHdl = nullptr;
   bool localReg = false;
-  FB_COMMCHECK(comm->ctran_->mapper->searchRegHandle(
-      op->putsignal.sendbuff, putSize, &localMemHdl, &localReg));
+  if (putSize > 0) {
+    // Get registration handle for local send buffer
+    FB_COMMCHECK(comm->ctran_->mapper->searchRegHandle(
+        op->putsignal.sendbuff, putSize, &localMemHdl, &localReg));
 
-  CLOGF_TRACE(
-      COLL,
-      "putSignalImpl: sbuf {}, rbuf {} (base {} + offset {}), size {}, signalAddr {} signalVal {}",
-      op->putsignal.sendbuff,
-      dstPtr,
-      win->remWinInfo[peerRank].dataAddr,
-      targetDispNbytes,
-      putSize,
-      (void*)op->putsignal.signalAddr,
-      op->putsignal.signalVal);
+    CLOGF_TRACE(
+        COLL,
+        "putSignalImpl: sbuf {}, rbuf {} (base {} + offset {}), size {}, signalAddr {} signalVal {}",
+        op->putsignal.sendbuff,
+        dstPtr,
+        win->remWinInfo[peerRank].dataAddr,
+        targetDispNbytes,
+        putSize,
+        (void*)op->putsignal.signalAddr,
+        op->putsignal.signalVal);
 
-  CtranMapperRequest* req = nullptr;
+    CtranMapperRequest* req = nullptr;
 
-  FB_COMMCHECK(comm->ctran_->mapper->iput(
-      op->putsignal.sendbuff,
-      dstPtr,
-      putSize,
-      peerRank,
-      CtranMapperConfig{
-          .memHdl_ = localMemHdl,
-          .remoteAccessKey_ = win->remWinInfo[peerRank].dataRkey,
-      },
-      &req));
+    FB_COMMCHECK(comm->ctran_->mapper->iput(
+        op->putsignal.sendbuff,
+        dstPtr,
+        putSize,
+        peerRank,
+        CtranMapperConfig{
+            .memHdl_ = localMemHdl,
+            .remoteAccessKey_ = win->remWinInfo[peerRank].dataRkey,
+        },
+        &req));
 
-  auto putReq = std::unique_ptr<CtranMapperRequest>(req);
-  FB_COMMCHECK(comm->ctran_->mapper->waitRequest(putReq.get()));
+    auto putReq = std::unique_ptr<CtranMapperRequest>(req);
+    FB_COMMCHECK(comm->ctran_->mapper->waitRequest(putReq.get()));
+  }
 
   CtranMapperRequest signalReq = CtranMapperRequest();
   if (op->putsignal.signalAddr != nullptr) {
+    // For graph replay, read the replay counter to get a fresh monotonic
+    // signal value. The counter is in mapped pinned host memory, so the
+    // GPE host thread can read it directly. For eager, use the baked value.
+    uint64_t signalVal = op->putsignal.signalVal;
+    if (signalVal == 0 && win->graphReplayCounter != nullptr) {
+      // Read with volatile to ensure we see the GPU kernel's write to
+      // this mapped pinned host memory. Without volatile, the CPU may
+      // read a cached stale value.
+      signalVal = *static_cast<volatile uint64_t*>(win->graphReplayCounter);
+    }
     // flush the iput to make sure the signal is sent after the data
     FB_COMMCHECK(comm->ctran_->mapper->atomicSet(
         op->putsignal.signalAddr,
-        op->putsignal.signalVal,
+        signalVal,
         peerRank,
         CtranMapperConfig{
             .remoteAccessKey_ = win->remWinInfo[peerRank].signalRkey},
@@ -181,10 +194,16 @@ static commResult_t signalImpl(
       (void*)op->signal.signalAddr,
       op->signal.signalVal);
 
+  // For graph replay, read the replay counter for a fresh signal value.
+  uint64_t signalVal = op->signal.signalVal;
+  if (signalVal == 0 && win->graphReplayCounter != nullptr) {
+    signalVal = *static_cast<volatile uint64_t*>(win->graphReplayCounter);
+  }
+
   CtranMapperRequest signalReq = CtranMapperRequest();
   FB_COMMCHECK(comm->ctran_->mapper->atomicSet(
       op->signal.signalAddr,
-      op->signal.signalVal,
+      signalVal,
       peerRank,
       CtranMapperConfig{
           .remoteAccessKey_ = win->remWinInfo[peerRank].signalRkey},
@@ -252,9 +271,20 @@ commResult_t ctranPutSignal(
   size_t countNbytes = count * commTypeSize(datatype);
   uint64_t* signalAddr = nullptr;
   uint64_t signalVal = 0;
+  cudaStreamCaptureStatus captureStatus{};
+  cudaStreamGetCaptureInfo(stream, &captureStatus, nullptr);
+  bool isCapturing = (captureStatus == cudaStreamCaptureStatusActive);
   if (signal) {
-    signalVal = win->ctranNextSignalVal(peer);
-    signalAddr = win->remWinInfo[peer].signalAddr + statex->rank();
+    if (isCapturing) {
+      // During graph capture, use the graph signal buffer. The actual
+      // signal value comes from a device-side replay counter read by the
+      // kernel at runtime (not baked into graph args).
+      signalVal = 0; // unused — kernel reads replayCounter instead
+      signalAddr = win->remWinInfo[peer].graphSignalAddr + statex->rank();
+    } else {
+      signalVal = win->ctranNextSignalVal(peer);
+      signalAddr = win->remWinInfo[peer].signalAddr + statex->rank();
+    }
   }
 
   KernelConfig config = KernelConfig(
@@ -266,8 +296,15 @@ commResult_t ctranPutSignal(
 
   // Use direct copy if peer is on the same host and has NVL enabled.
   // Otherwise, do put & signal via network
-  CtranKernelPutSignalArgs kernArgs = {.signalAddr = nullptr, .signalVal = 0};
-  if (statex->node(peer) == statex->node() && win->nvlEnabled(peer)) {
+  bool isNvl = statex->node(peer) == statex->node() && win->nvlEnabled(peer);
+  CtranKernelPutSignalArgs kernArgs = {
+      .signalAddr = nullptr,
+      .signalVal = 0,
+      .replayCounter = isCapturing ? win->graphReplayCounter : nullptr,
+      // NVL: only same-device kernels read the counter (device scope).
+      // IB: the GPE host thread also reads it (system scope).
+      .replayCounterSystemScope = !isNvl};
+  if (isNvl) {
     // Single-node direct cudaMemcpy
     if (count > 0) {
       void* dstPtr = reinterpret_cast<void*>(
@@ -336,53 +373,25 @@ waitSignalDriverApi(int peer, CtranWin* win, cudaStream_t stream) {
     return commInvalidUsage;
   }
 
-  // Get the signal address
-  const uint64_t* signalAddr = win->winSignalPtr + peer;
-  // Get the expected compare value
-  uint64_t cmpVal = win->ctranNextWaitSignalVal(peer);
-
   cudaStreamCaptureStatus captureStatus{};
   cudaStreamGetCaptureInfo(stream, &captureStatus, nullptr);
 
-  CUresult result;
-
   if (captureStatus == cudaStreamCaptureStatusActive) {
-    if (!ctran::utils::canUseCuStreamBatchMemOp()) {
-      return commInvalidUsage;
-    }
-
-    // During CUDA graph capture, use cuStreamBatchMemOp to atomically
-    // wait for the signal and then reset it to 0.  The reset prepares
-    // the slot for the next graph replay.
-    //
-    // This follows the pattern established by NCCL's CE collective path
-    // in ncclMemOpSync() (comms/ncclx/v2_28/src/ce_coll.cc lines 212-222),
-    // which batches waits + resets in a single cuStreamBatchMemOp during
-    // graph capture.  The batch is atomic on the stream — the wait
-    // completes before the reset runs, and no remote signal for the next
-    // replay can interleave.
-    CUstreamBatchMemOpParams ops[2] = {};
-
-    // wait for signal GEQ cmpVal
-    ops[0].waitValue.operation = CU_STREAM_MEM_OP_WAIT_VALUE_64;
-    ops[0].waitValue.address = (CUdeviceptr)signalAddr;
-    ops[0].waitValue.value64 = cmpVal;
-    ops[0].waitValue.flags = CU_STREAM_WAIT_VALUE_GEQ;
-
-    // reset signal to 0
-    ops[1].writeValue.operation = CU_STREAM_MEM_OP_WRITE_VALUE_64;
-    ops[1].writeValue.address = (CUdeviceptr)signalAddr;
-    ops[1].writeValue.value64 = 0;
-    ops[1].writeValue.flags = CU_STREAM_WRITE_VALUE_DEFAULT;
-
-    result = FB_CUPFN(cuStreamBatchMemOp)((CUstream)stream, 2, ops, 0);
-  } else {
-    result = FB_CUPFN(cuStreamWaitValue64)(
-        (CUstream)stream,
-        (CUdeviceptr)signalAddr,
-        cmpVal,
-        CU_STREAM_WAIT_VALUE_GEQ);
+    // During graph capture, fall back to the spinning kernel which uses
+    // a device-side replay counter for monotonically increasing signal
+    // values. Don't advance the eager counter.
+    return commInvalidUsage;
   }
+
+  // Eager path only below
+  const uint64_t* signalAddr = win->winSignalPtr + peer;
+  uint64_t cmpVal = win->ctranNextWaitSignalVal(peer);
+
+  CUresult result = FB_CUPFN(cuStreamWaitValue64)(
+      (CUstream)stream,
+      (CUdeviceptr)signalAddr,
+      cmpVal,
+      CU_STREAM_WAIT_VALUE_GEQ);
 
   if (result != CUDA_SUCCESS) {
     const char* errStr = nullptr;
@@ -421,9 +430,20 @@ commResult_t waitSignalSpinningKernel(
     cudaStream_t stream,
     uint64_t waitOpCount) {
   CtranComm* comm = win->comm;
-  auto waitSignalVal = win->ctranNextWaitSignalVal(peer);
 
-  const uint64_t* signalAddr = win->winSignalPtr + peer;
+  cudaStreamCaptureStatus spinCaptureCheck{};
+  cudaStreamGetCaptureInfo(stream, &spinCaptureCheck, nullptr);
+  bool isCapturing = (spinCaptureCheck == cudaStreamCaptureStatusActive);
+
+  uint64_t waitSignalVal;
+  const uint64_t* signalAddr;
+  if (isCapturing) {
+    waitSignalVal = 0; // unused — kernel reads replayCounter instead
+    signalAddr = win->winGraphSignalPtr + peer;
+  } else {
+    waitSignalVal = win->ctranNextWaitSignalVal(peer);
+    signalAddr = win->winSignalPtr + peer;
+  }
 
   KernelConfig config = KernelConfig(
       KernelConfig::KernelType::WAITSIGNAL, stream, "WaitSignal", waitOpCount);
@@ -436,6 +456,7 @@ commResult_t waitSignalSpinningKernel(
   CtranKernelWaitSignalArgs kernArgs = {
       .signalAddr = nullptr,
       .cmpVal = waitSignalVal,
+      .replayCounter = isCapturing ? win->graphReplayCounter : nullptr,
   };
   config.algoArgs = reinterpret_cast<void*>(&kernArgs);
   if (win->isGpuMem()) {
@@ -469,7 +490,20 @@ commResult_t ctranSignal(int peer, CtranWin* win, cudaStream_t stream) {
       win->updateOpCount(peer, window::OpCountType::kSignal);
   auto statex = comm->statex_.get();
 
-  auto signalVal = win->ctranNextSignalVal(peer);
+  cudaStreamCaptureStatus sigCaptureStatus{};
+  cudaStreamGetCaptureInfo(stream, &sigCaptureStatus, nullptr);
+  bool isCapturing = (sigCaptureStatus == cudaStreamCaptureStatusActive);
+
+  uint64_t signalVal;
+  uint64_t* signalAddr;
+  if (isCapturing) {
+    signalVal = 0; // unused — kernel reads replayCounter
+    signalAddr = win->remWinInfo[peer].graphSignalAddr + statex->rank();
+  } else {
+    signalVal = win->ctranNextSignalVal(peer);
+    signalAddr = win->remWinInfo[peer].signalAddr + statex->rank();
+  }
+
   CTRAN_RMA_INFO(
       "ctranSignal",
       sigOpCount,
@@ -484,8 +518,6 @@ commResult_t ctranSignal(int peer, CtranWin* win, cudaStream_t stream) {
       comm,
       stream);
 
-  uint64_t* signalAddr = win->remWinInfo[peer].signalAddr + statex->rank();
-
   KernelConfig config = KernelConfig(
       KernelConfig::KernelType::SIGNAL, stream, "Signal", sigOpCount);
   config.args.devState_d = comm->ctran_->algo->getDevState();
@@ -495,9 +527,14 @@ commResult_t ctranSignal(int peer, CtranWin* win, cudaStream_t stream) {
 
   // Use cuda atomic store if peer is on the same host and has NVL enabled.
   // Otherwise, do signal via IB in GPE thread
-  CtranKernelSignalArgs kernArgs = {.signalAddr = nullptr, .signalVal = 0};
+  bool isSigNvl = statex->node(peer) == statex->node() && win->nvlEnabled(peer);
+  CtranKernelSignalArgs kernArgs = {
+      .signalAddr = nullptr,
+      .signalVal = 0,
+      .replayCounter = isCapturing ? win->graphReplayCounter : nullptr,
+      .replayCounterSystemScope = !isSigNvl};
   config.algoArgs = reinterpret_cast<void*>(&kernArgs);
-  if (statex->node(peer) == statex->node() && win->nvlEnabled(peer)) {
+  if (isSigNvl) {
     kernArgs.signalAddr = signalAddr;
     kernArgs.signalVal = signalVal;
   } else {

--- a/comms/ctran/algos/RMA/PutSignal.cc
+++ b/comms/ctran/algos/RMA/PutSignal.cc
@@ -106,45 +106,52 @@ static commResult_t putSignalImpl(
       reinterpret_cast<size_t>(win->remWinInfo[peerRank].dataAddr) +
       targetDispNbytes);
 
-  // Get registration handle for local send buffer
+  // Skip data transfer if count is 0 (signal-only, e.g. ready barrier)
   void* localMemHdl = nullptr;
   bool localReg = false;
-  FB_COMMCHECK(comm->ctran_->mapper->searchRegHandle(
-      op->putsignal.sendbuff, putSize, &localMemHdl, &localReg));
+  if (putSize > 0) {
+    // Get registration handle for local send buffer
+    FB_COMMCHECK(comm->ctran_->mapper->searchRegHandle(
+        op->putsignal.sendbuff, putSize, &localMemHdl, &localReg));
 
-  CLOGF_TRACE(
-      COLL,
-      "putSignalImpl: sbuf {}, rbuf {} (base {} + offset {}), size {}, signalAddr {} signalVal {}",
-      op->putsignal.sendbuff,
-      dstPtr,
-      win->remWinInfo[peerRank].dataAddr,
-      targetDispNbytes,
-      putSize,
-      (void*)op->putsignal.signalAddr,
-      op->putsignal.signalVal);
+    CLOGF_TRACE(
+        COLL,
+        "putSignalImpl: sbuf {}, rbuf {} (base {} + offset {}), size {}, signalAddr {}",
+        op->putsignal.sendbuff,
+        dstPtr,
+        win->remWinInfo[peerRank].dataAddr,
+        targetDispNbytes,
+        putSize,
+        (void*)op->putsignal.signalAddr);
 
-  CtranMapperRequest* req = nullptr;
+    CtranMapperRequest* req = nullptr;
 
-  FB_COMMCHECK(comm->ctran_->mapper->iput(
-      op->putsignal.sendbuff,
-      dstPtr,
-      putSize,
-      peerRank,
-      CtranMapperConfig{
-          .memHdl_ = localMemHdl,
-          .remoteAccessKey_ = win->remWinInfo[peerRank].dataRkey,
-      },
-      &req));
+    FB_COMMCHECK(comm->ctran_->mapper->iput(
+        op->putsignal.sendbuff,
+        dstPtr,
+        putSize,
+        peerRank,
+        CtranMapperConfig{
+            .memHdl_ = localMemHdl,
+            .remoteAccessKey_ = win->remWinInfo[peerRank].dataRkey,
+        },
+        &req));
 
-  auto putReq = std::unique_ptr<CtranMapperRequest>(req);
-  FB_COMMCHECK(comm->ctran_->mapper->waitRequest(putReq.get()));
+    auto putReq = std::unique_ptr<CtranMapperRequest>(req);
+    FB_COMMCHECK(comm->ctran_->mapper->waitRequest(putReq.get()));
+  }
 
   CtranMapperRequest signalReq = CtranMapperRequest();
   if (op->putsignal.signalAddr != nullptr) {
+    // The kernel has already incremented the per-peer counter
+    // (KernelWaitGpeTerminate serializes kernel and GPE). Acquire pairs
+    // with the kernel's system-scope release.
+    uint64_t signalVal =
+        __atomic_load_n(op->putsignal.signalCounter, __ATOMIC_ACQUIRE);
     // flush the iput to make sure the signal is sent after the data
     FB_COMMCHECK(comm->ctran_->mapper->atomicSet(
         op->putsignal.signalAddr,
-        op->putsignal.signalVal,
+        signalVal,
         peerRank,
         CtranMapperConfig{
             .remoteAccessKey_ = win->remWinInfo[peerRank].signalRkey},
@@ -176,15 +183,17 @@ static commResult_t signalImpl(
 
   CLOGF_TRACE(
       COLL,
-      "signalImpl: peer {} signalAddr {} signalVal {}",
+      "signalImpl: peer {} signalAddr {}",
       op->signal.peerRank,
-      (void*)op->signal.signalAddr,
-      op->signal.signalVal);
+      (void*)op->signal.signalAddr);
+
+  uint64_t signalVal =
+      __atomic_load_n(op->signal.signalCounter, __ATOMIC_ACQUIRE);
 
   CtranMapperRequest signalReq = CtranMapperRequest();
   FB_COMMCHECK(comm->ctran_->mapper->atomicSet(
       op->signal.signalAddr,
-      op->signal.signalVal,
+      signalVal,
       peerRank,
       CtranMapperConfig{
           .remoteAccessKey_ = win->remWinInfo[peerRank].signalRkey},
@@ -202,16 +211,16 @@ static commResult_t waitSignalSpinningKernelImpl(
   const std::atomic<uint64_t>* addr =
       reinterpret_cast<const std::atomic<uint64_t>*>(op->waitsignal.signalAddr);
   CtranAlgoRMALogger logger("ctranWaitSignal", op->opCount, -1, win, comm);
+  // The kernel increments the wait counter before KernelStartGpe,
+  // so this load always observes the post-increment value.
+  uint64_t cmpVal =
+      __atomic_load_n(op->waitsignal.signalCounter, __ATOMIC_ACQUIRE);
   CLOGF_TRACE(
       COLL,
       "waitSignalSpinningKernelImpl: signalAddr {}, cmpVal={}",
       (void*)const_cast<uint64_t*>(op->waitsignal.signalAddr),
-      op->waitsignal.cmpVal);
-  // Spin-wait until the signal is received.
-  // Only a 'greater or equal (GE)' (>=) comparison is required in this design,
-  // because signals are monotonically increasing and we only care about
-  // reaching or passing the target value.
-  while (std::atomic_load(addr) < op->waitsignal.cmpVal) {
+      cmpVal);
+  while (std::atomic_load(addr) < cmpVal) {
     std::this_thread::yield();
   };
 
@@ -251,9 +260,7 @@ commResult_t ctranPutSignal(
   size_t targetDispNbytes = targetDisp * commTypeSize(datatype);
   size_t countNbytes = count * commTypeSize(datatype);
   uint64_t* signalAddr = nullptr;
-  uint64_t signalVal = 0;
   if (signal) {
-    signalVal = win->ctranNextSignalVal(peer);
     signalAddr = win->remWinInfo[peer].signalAddr + statex->rank();
   }
 
@@ -266,17 +273,21 @@ commResult_t ctranPutSignal(
 
   // Use direct copy if peer is on the same host and has NVL enabled.
   // Otherwise, do put & signal via network
-  CtranKernelPutSignalArgs kernArgs = {.signalAddr = nullptr, .signalVal = 0};
-  if (statex->node(peer) == statex->node() && win->nvlEnabled(peer)) {
+  bool isNvl = statex->node(peer) == statex->node() && win->nvlEnabled(peer);
+  // The kernel always increments the per-peer signal counter to get a
+  // monotonically increasing value. KernelWaitGpeTerminate serializes
+  // kernel execution with GPE processing, so the GPE thread always sees
+  // the correct counter value for the current op.
+  CtranKernelPutSignalArgs kernArgs = {
+      .signalAddr = nullptr,
+      .signalCounter = signal ? &win->signalCounters[peer] : nullptr,
+      .signalCounterSystemScope = !isNvl};
+  if (isNvl) {
     // Single-node direct cudaMemcpy
     if (count > 0) {
       void* dstPtr = reinterpret_cast<void*>(
           reinterpret_cast<size_t>(win->remWinInfo[peer].dataAddr) +
           targetDispNbytes);
-      // CollTrace tracing logic for local + no signal case. In this case the
-      // put will not trigger gpe->submit, so we need to record manually in the
-      // algo. In other cases, this handle would be a no-op and the tracing
-      // will take place in the gpe function.
       auto colltraceHandle = meta::comms::colltrace::getCollTraceHandleRMA(
           comm, opGroup, config, !signal);
       colltraceHandle->trigger(
@@ -288,16 +299,12 @@ commResult_t ctranPutSignal(
       colltraceHandle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel);
     }
     if (signal) {
-      // Use atomic_store to signal the remote peer
       kernArgs.signalAddr = signalAddr;
-      kernArgs.signalVal = signalVal;
     } else {
-      // No signal, just return
       return commSuccess;
     }
   } else {
     // X-node put & signal via network
-    // Create an op for GPE thread to complete put and signal
     struct OpElem* op =
         new struct OpElem(OpElem::opType::PUTSIGNAL, comm, putOpCount);
     op->putsignal.sendbuff = originBuff;
@@ -305,7 +312,7 @@ commResult_t ctranPutSignal(
     op->putsignal.count = count;
     op->putsignal.datatype = datatype;
     op->putsignal.signalAddr = signalAddr;
-    op->putsignal.signalVal = signalVal;
+    op->putsignal.signalCounter = &win->signalCounters[peer];
     op->putsignal.peerRank = peer;
     op->putsignal.win = win;
     opGroup.push_back(std::unique_ptr<struct OpElem>(op));
@@ -325,10 +332,10 @@ commResult_t ctranPutSignal(
   return commSuccess;
 }
 
-// Hardware-accelerated wait using CUDA Driver API directly
-// Returns commSuccess if hardware wait was used, otherwise returns error to
-// fallback This avoids GPU spinning kernel overhead by using hardware memory
-// polling
+// Hardware-accelerated wait. Increments the wait counter internally so
+// the counter only advances when we know the HW path will be attempted.
+// Returns commInvalidUsage if HW wait is unavailable (caller can fall
+// back to spinning kernel without double-increment risk).
 static commResult_t
 waitSignalDriverApi(int peer, CtranWin* win, cudaStream_t stream) {
 #if CUDART_VERSION >= 11070
@@ -336,61 +343,23 @@ waitSignalDriverApi(int peer, CtranWin* win, cudaStream_t stream) {
     return commInvalidUsage;
   }
 
-  // Get the signal address
   const uint64_t* signalAddr = win->winSignalPtr + peer;
-  // Get the expected compare value
-  uint64_t cmpVal = win->ctranNextWaitSignalVal(peer);
+  // Peek at the next expected value without incrementing. Only commit the
+  // counter advance after confirming the HW wait was enqueued successfully,
+  // so the spinning-kernel fallback won't double-increment.
+  uint64_t cmpVal =
+      __atomic_load_n(&win->waitCounters[peer], __ATOMIC_RELAXED) + 1;
 
-  cudaStreamCaptureStatus captureStatus{};
-  cudaStreamGetCaptureInfo(stream, &captureStatus, nullptr);
-
-  CUresult result;
-
-  if (captureStatus == cudaStreamCaptureStatusActive) {
-    if (!ctran::utils::canUseCuStreamBatchMemOp()) {
-      return commInvalidUsage;
-    }
-
-    // During CUDA graph capture, use cuStreamBatchMemOp to atomically
-    // wait for the signal and then reset it to 0.  The reset prepares
-    // the slot for the next graph replay.
-    //
-    // This follows the pattern established by NCCL's CE collective path
-    // in ncclMemOpSync() (comms/ncclx/v2_29/src/ce_coll.cc lines 212-222),
-    // which batches waits + resets in a single cuStreamBatchMemOp during
-    // graph capture.  The batch is atomic on the stream — the wait
-    // completes before the reset runs, and no remote signal for the next
-    // replay can interleave.
-    CUstreamBatchMemOpParams ops[2] = {};
-
-    // wait for signal GEQ cmpVal
-    ops[0].waitValue.operation = CU_STREAM_MEM_OP_WAIT_VALUE_64;
-    ops[0].waitValue.address = (CUdeviceptr)signalAddr;
-    ops[0].waitValue.value64 = cmpVal;
-    ops[0].waitValue.flags = CU_STREAM_WAIT_VALUE_GEQ;
-
-    // reset signal to 0
-    ops[1].writeValue.operation = CU_STREAM_MEM_OP_WRITE_VALUE_64;
-    ops[1].writeValue.address = (CUdeviceptr)signalAddr;
-    ops[1].writeValue.value64 = 0;
-    ops[1].writeValue.flags = CU_STREAM_WRITE_VALUE_DEFAULT;
-
-    result = FB_CUPFN(cuStreamBatchMemOp)((CUstream)stream, 2, ops, 0);
-  } else {
-    result = FB_CUPFN(cuStreamWaitValue64)(
-        (CUstream)stream,
-        (CUdeviceptr)signalAddr,
-        cmpVal,
-        CU_STREAM_WAIT_VALUE_GEQ);
-  }
+  CUresult result = FB_CUPFN(cuStreamWaitValue64)(
+      (CUstream)stream,
+      (CUdeviceptr)signalAddr,
+      cmpVal,
+      CU_STREAM_WAIT_VALUE_GEQ);
 
   if (result != CUDA_SUCCESS) {
     const char* errStr = nullptr;
     FB_CUPFN(cuGetErrorString)(result, &errStr);
 
-    // Only fallback on NOT_SUPPORTED - this is safe (hardware doesn't support)
-    // Other errors (e.g., INVALID_VALUE) may indicate prior async failures
-    // that could cause the spinning kernel to hang, so propagate them
     if (result == CUDA_ERROR_NOT_SUPPORTED) {
       CLOGF(
           WARN,
@@ -399,8 +368,6 @@ waitSignalDriverApi(int peer, CtranWin* win, cudaStream_t stream) {
       return commInvalidUsage;
     }
 
-    // Propagate other errors - do not fallback as they may indicate
-    // stream corruption from prior async operations
     CLOGF(
         ERR,
         "CTRAN RMA: Hardware wait failed with error ({}), not falling back",
@@ -408,20 +375,22 @@ waitSignalDriverApi(int peer, CtranWin* win, cudaStream_t stream) {
     return commInternalError;
   }
 
+  // HW wait enqueued — commit the counter increment
+  win->nextWaitCounter(peer);
   return commSuccess;
 #else
-  // CUDA < 11.7 doesn't support cuStreamWaitValue64
   return commInvalidUsage;
 #endif
 }
 
+// Spinning kernel wait. The kernel always increments the per-peer wait
+// counter to derive the compare value — no capture-mode branching needed.
 commResult_t waitSignalSpinningKernel(
     int peer,
     CtranWin* win,
     cudaStream_t stream,
     uint64_t waitOpCount) {
   CtranComm* comm = win->comm;
-  auto waitSignalVal = win->ctranNextWaitSignalVal(peer);
 
   const uint64_t* signalAddr = win->winSignalPtr + peer;
 
@@ -435,22 +404,17 @@ commResult_t waitSignalSpinningKernel(
 
   CtranKernelWaitSignalArgs kernArgs = {
       .signalAddr = nullptr,
-      .cmpVal = waitSignalVal,
+      .signalCounter = &win->waitCounters[peer],
   };
   config.algoArgs = reinterpret_cast<void*>(&kernArgs);
   if (win->isGpuMem()) {
-    // if GPU memory, use kernel to atomic wait on the local signal value update
-    // from remote rank, either from NVL or IB
     kernArgs.signalAddr = const_cast<uint64_t*>(signalAddr);
-    kernArgs.cmpVal = waitSignalVal;
   } else {
-    // if CPU memory, GPE thread to atomic wait for update from remote rank via
-    // IB.
     struct OpElem* op =
         new struct OpElem(OpElem::opType::WAITSIGNAL, comm, waitOpCount);
     op->waitsignal.win = win;
     op->waitsignal.signalAddr = signalAddr;
-    op->waitsignal.cmpVal = waitSignalVal;
+    op->waitsignal.signalCounter = &win->waitCounters[peer];
     opGroup.push_back(std::unique_ptr<struct OpElem>(op));
   }
 
@@ -469,7 +433,8 @@ commResult_t ctranSignal(int peer, CtranWin* win, cudaStream_t stream) {
       win->updateOpCount(peer, window::OpCountType::kSignal);
   auto statex = comm->statex_.get();
 
-  auto signalVal = win->ctranNextSignalVal(peer);
+  uint64_t* signalAddr = win->remWinInfo[peer].signalAddr + statex->rank();
+
   CTRAN_RMA_INFO(
       "ctranSignal",
       sigOpCount,
@@ -484,8 +449,6 @@ commResult_t ctranSignal(int peer, CtranWin* win, cudaStream_t stream) {
       comm,
       stream);
 
-  uint64_t* signalAddr = win->remWinInfo[peer].signalAddr + statex->rank();
-
   KernelConfig config = KernelConfig(
       KernelConfig::KernelType::SIGNAL, stream, "Signal", sigOpCount);
   config.args.devState_d = comm->ctran_->algo->getDevState();
@@ -493,18 +456,19 @@ commResult_t ctranSignal(int peer, CtranWin* win, cudaStream_t stream) {
   std::vector<std::unique_ptr<struct OpElem>> opGroup;
   opGroup.clear();
 
-  // Use cuda atomic store if peer is on the same host and has NVL enabled.
-  // Otherwise, do signal via IB in GPE thread
-  CtranKernelSignalArgs kernArgs = {.signalAddr = nullptr, .signalVal = 0};
+  bool isSigNvl = statex->node(peer) == statex->node() && win->nvlEnabled(peer);
+  CtranKernelSignalArgs kernArgs = {
+      .signalAddr = nullptr,
+      .signalCounter = &win->signalCounters[peer],
+      .signalCounterSystemScope = !isSigNvl};
   config.algoArgs = reinterpret_cast<void*>(&kernArgs);
-  if (statex->node(peer) == statex->node() && win->nvlEnabled(peer)) {
+  if (isSigNvl) {
     kernArgs.signalAddr = signalAddr;
-    kernArgs.signalVal = signalVal;
   } else {
     struct OpElem* op =
         new struct OpElem(OpElem::opType::SIGNAL, comm, sigOpCount);
     op->signal.signalAddr = signalAddr;
-    op->signal.signalVal = signalVal;
+    op->signal.signalCounter = &win->signalCounters[peer];
     op->signal.peerRank = peer;
     op->signal.win = win;
     opGroup.push_back(std::unique_ptr<struct OpElem>(op));
@@ -545,44 +509,42 @@ commResult_t ctranWaitSignal(int peer, CtranWin* win, cudaStream_t stream) {
       comm,
       stream);
 
-  // Only try hardware wait for GPU memory windows
+  // For eager GPU-memory, try hardware-accelerated wait first.
+  // waitSignalDriverApi increments the counter internally, only after
+  // confirming HW support — so commInvalidUsage means the counter
+  // was NOT incremented and we can safely fall back.
   if (win->isGpuMem()) {
-    // Try hardware-accelerated wait first (zero GPU overhead!)
+    cudaStreamCaptureStatus captureStatus{};
+    cudaStreamGetCaptureInfo(stream, &captureStatus, nullptr);
+    if (captureStatus != cudaStreamCaptureStatusActive) {
+      auto colltraceHandle = meta::comms::colltrace::getCollTraceHandleRMA(
+          comm,
+          {},
+          KernelConfig{
+              KernelConfig::KernelType::WAITSIGNAL,
+              stream,
+              "WaitSignal",
+              waitOpCount},
+          true);
+      colltraceHandle->trigger(
+          CollTraceHandleTriggerState::BeforeEnqueueKernel);
 
-    // CollTrace tracing logic for hardware-accelerated case. In this case the
-    // wait will not trigger gpe->submit, so we need to record manually in the
-    // algo. In other cases, this handle would be a no-op and the tracing
-    // will take place in the gpe function.
-    auto colltraceHandle = meta::comms::colltrace::getCollTraceHandleRMA(
-        comm,
-        {},
-        KernelConfig{
-            KernelConfig::KernelType::WAITSIGNAL,
-            stream,
-            "WaitSignal",
-            waitOpCount},
-        true);
-    colltraceHandle->trigger(CollTraceHandleTriggerState::BeforeEnqueueKernel);
+      commResult_t hwResult = waitSignalDriverApi(peer, win, stream);
 
-    commResult_t hwResult = waitSignalDriverApi(peer, win, stream);
+      colltraceHandle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel);
 
-    colltraceHandle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel);
+      if (hwResult == commSuccess) {
+        CLOGF_TRACE(
+            COLL,
+            "CTRAN RMA: WaitSignal successful using hardware acceleration");
+        return commSuccess;
+      }
 
-    if (hwResult == commSuccess) {
-      CLOGF_TRACE(
-          COLL, "CTRAN RMA: WaitSignal successful using hardware acceleration");
-      return commSuccess;
-    }
-
-    // Only fallback on commInvalidUsage (CUDA_ERROR_NOT_SUPPORTED)
-    // Other errors (commInternalError) are propagated to avoid masking
-    // potential stream corruption from prior async operations
-    if (hwResult != commInvalidUsage) {
-      return hwResult;
+      if (hwResult != commInvalidUsage) {
+        return hwResult;
+      }
     }
   }
-
-  // Fallback to spinning kernel implementation
   CLOGF(
       INFO,
       "CTRAN RMA: WaitSignal falling back to spinning kernel (peer={})",

--- a/comms/ctran/algos/RMA/PutSignal.cu
+++ b/comms/ctran/algos/RMA/PutSignal.cu
@@ -79,19 +79,39 @@ __global__ void ncclKernelPutSignal(
     CtranAlgoDeviceState* devState,
     CtranKernelPutSignalArgs args) {
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
+
+  [[maybe_unused]] uint64_t val = args.signalVal;
+  if (gtIdx == 0 && args.replayCounter) {
+#if defined(__HIP_PLATFORM_AMD__)
+    trap();
+#else
+    if (args.replayCounterSystemScope) /* ib */ {
+      ::cuda::atomic_ref<uint64_t, cuda::thread_scope_system> cref{
+          *args.replayCounter};
+      val = cref.fetch_add(1, cuda::std::memory_order_release) + 1;
+    } else /* nvl */ {
+      ::cuda::atomic_ref<uint64_t, cuda::thread_scope_device> cref{
+          *args.replayCounter};
+      val = cref.fetch_add(1, cuda::std::memory_order_release) + 1;
+    }
+#endif
+  }
+
   if (flag && gtIdx == 0) {
     ctran::device::devLoadAbortFlags(flag, devState);
     ctran::device::KernelStartGpe(flag);
   }
-  // just atomic store
-  if (gtIdx == 0 && args.signalAddr != nullptr) {
+  if (gtIdx == 0) {
 #if defined(__HIP_PLATFORM_AMD__)
     // TODO: implement this atomic operations for AMD GPUs.
-    trap();
+    if (args.signalAddr != nullptr)
+      trap();
 #else
-    ::cuda::atomic_ref<uint64_t, cuda::thread_scope_system> ref{
-        *args.signalAddr};
-    ref.store(args.signalVal, cuda::std::memory_order_release);
+    if (args.signalAddr != nullptr) {
+      ::cuda::atomic_ref<uint64_t, cuda::thread_scope_system> ref{
+          *args.signalAddr};
+      ref.store(val, cuda::std::memory_order_release);
+    }
 #endif
   }
 
@@ -124,9 +144,15 @@ __global__ void ncclKernelWaitSignal(
     // TODO: implement this atomic operations for AMD GPUs.
     trap();
 #else
+    uint64_t val = args.cmpVal;
+    if (args.replayCounter) {
+      ::cuda::atomic_ref<uint64_t, cuda::thread_scope_device> cref{
+          *args.replayCounter};
+      val = cref.load(cuda::std::memory_order_acquire);
+    }
     ::cuda::atomic_ref<uint64_t, cuda::thread_scope_system> ref{
         *args.signalAddr};
-    while (ref.load(cuda::std::memory_order_acquire) < args.cmpVal) {
+    while (ref.load(cuda::std::memory_order_acquire) < val) {
     }
 #endif
   }
@@ -141,6 +167,22 @@ __global__ void ncclKernelSignal(
     CtranAlgoDeviceState* devState,
     CtranKernelSignalArgs args) {
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
+
+  [[maybe_unused]] uint64_t val = args.signalVal;
+  if (gtIdx == 0 && args.replayCounter) {
+#if !defined(__HIP_PLATFORM_AMD__)
+    if (args.replayCounterSystemScope) /* ib */ {
+      ::cuda::atomic_ref<uint64_t, cuda::thread_scope_system> cref{
+          *args.replayCounter};
+      val = cref.fetch_add(1, cuda::std::memory_order_release) + 1;
+    } else /* nvl */ {
+      ::cuda::atomic_ref<uint64_t, cuda::thread_scope_device> cref{
+          *args.replayCounter};
+      val = cref.fetch_add(1, cuda::std::memory_order_release) + 1;
+    }
+#endif
+  }
+
   if (flag && gtIdx == 0) {
     ctran::device::devLoadAbortFlags(flag, devState);
     ctran::device::KernelStartGpe(flag);
@@ -152,7 +194,7 @@ __global__ void ncclKernelSignal(
 #else
     ::cuda::atomic_ref<uint64_t, cuda::thread_scope_system> ref{
         *args.signalAddr};
-    ref.store(args.signalVal, cuda::std::memory_order_release);
+    ref.store(val, cuda::std::memory_order_release);
 #endif
   }
 

--- a/comms/ctran/algos/RMA/PutSignal.cu
+++ b/comms/ctran/algos/RMA/PutSignal.cu
@@ -1,5 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#include <assert.h>
 #include <cuda.h>
 #include <cuda_runtime_api.h>
 
@@ -79,20 +80,34 @@ __global__ void ncclKernelPutSignal(
     CtranAlgoDeviceState* devState,
     CtranKernelPutSignalArgs args) {
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
+
+  [[maybe_unused]] uint64_t val = 0;
+  if (gtIdx == 0) {
+#if defined(__HIP_PLATFORM_AMD__)
+    trap();
+#else
+    assert(args.signalCounter);
+    if (args.signalCounterSystemScope) /* ib */ {
+      ::cuda::atomic_ref<uint64_t, cuda::thread_scope_system> cref{
+          *args.signalCounter};
+      val = cref.fetch_add(1, cuda::std::memory_order_release) + 1;
+    } else /* nvl */ {
+      ::cuda::atomic_ref<uint64_t, cuda::thread_scope_device> cref{
+          *args.signalCounter};
+      val = cref.fetch_add(1, cuda::std::memory_order_release) + 1;
+    }
+
+    if (args.signalAddr != nullptr) {
+      ::cuda::atomic_ref<uint64_t, cuda::thread_scope_system> ref{
+          *args.signalAddr};
+      ref.store(val, cuda::std::memory_order_release);
+    }
+#endif
+  }
+
   if (flag && gtIdx == 0) {
     ctran::device::devLoadAbortFlags(flag, devState);
     ctran::device::KernelStartGpe(flag);
-  }
-  // just atomic store
-  if (gtIdx == 0 && args.signalAddr != nullptr) {
-#if defined(__HIP_PLATFORM_AMD__)
-    // TODO: implement this atomic operations for AMD GPUs.
-    trap();
-#else
-    ::cuda::atomic_ref<uint64_t, cuda::thread_scope_system> ref{
-        *args.signalAddr};
-    ref.store(args.signalVal, cuda::std::memory_order_release);
-#endif
   }
 
   if (flag && gtIdx == 0) {
@@ -114,21 +129,30 @@ __global__ void ncclKernelWaitSignal(
     CtranAlgoDeviceState* devState,
     CtranKernelWaitSignalArgs args) {
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
+
+  if (gtIdx == 0) {
+#if defined(__HIP_PLATFORM_AMD__)
+    trap();
+#else
+    // Increment the wait counter BEFORE KernelStartGpe so the GPE host
+    // thread (waitSignalSpinningKernelImpl) sees the updated value when
+    // it wakes. This matches the put/signal kernels.
+    assert(args.signalCounter);
+    ::cuda::atomic_ref<uint64_t, cuda::thread_scope_system> cref{
+        *args.signalCounter};
+    uint64_t val = cref.fetch_add(1, cuda::std::memory_order_release) + 1;
+    if (args.signalAddr != nullptr) {
+      ::cuda::atomic_ref<uint64_t, cuda::thread_scope_system> ref{
+          *args.signalAddr};
+      while (ref.load(cuda::std::memory_order_acquire) < val) {
+      }
+    }
+#endif
+  }
+
   if (flag && gtIdx == 0) {
     ctran::device::devLoadAbortFlags(flag, devState);
     ctran::device::KernelStartGpe(flag);
-  }
-
-  if (args.signalAddr != nullptr && gtIdx == 0) {
-#if defined(__HIP_PLATFORM_AMD__)
-    // TODO: implement this atomic operations for AMD GPUs.
-    trap();
-#else
-    ::cuda::atomic_ref<uint64_t, cuda::thread_scope_system> ref{
-        *args.signalAddr};
-    while (ref.load(cuda::std::memory_order_acquire) < args.cmpVal) {
-    }
-#endif
   }
 
   if (flag && gtIdx == 0) {
@@ -141,6 +165,23 @@ __global__ void ncclKernelSignal(
     CtranAlgoDeviceState* devState,
     CtranKernelSignalArgs args) {
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
+
+  [[maybe_unused]] uint64_t val = 0;
+  if (gtIdx == 0) {
+#if !defined(__HIP_PLATFORM_AMD__)
+    assert(args.signalCounter);
+    if (args.signalCounterSystemScope) /* ib */ {
+      ::cuda::atomic_ref<uint64_t, cuda::thread_scope_system> cref{
+          *args.signalCounter};
+      val = cref.fetch_add(1, cuda::std::memory_order_release) + 1;
+    } else /* nvl */ {
+      ::cuda::atomic_ref<uint64_t, cuda::thread_scope_device> cref{
+          *args.signalCounter};
+      val = cref.fetch_add(1, cuda::std::memory_order_release) + 1;
+    }
+#endif
+  }
+
   if (flag && gtIdx == 0) {
     ctran::device::devLoadAbortFlags(flag, devState);
     ctran::device::KernelStartGpe(flag);
@@ -152,7 +193,7 @@ __global__ void ncclKernelSignal(
 #else
     ::cuda::atomic_ref<uint64_t, cuda::thread_scope_system> ref{
         *args.signalAddr};
-    ref.store(args.signalVal, cuda::std::memory_order_release);
+    ref.store(val, cuda::std::memory_order_release);
 #endif
   }
 

--- a/comms/ctran/algos/RMA/Types.h
+++ b/comms/ctran/algos/RMA/Types.h
@@ -25,14 +25,29 @@ struct KernelGetArgs {
 struct CtranKernelPutSignalArgs {
   uint64_t* signalAddr;
   uint64_t signalVal;
+  // Device-side replay counter for CUDA graph mode. When non-null, the
+  // kernel atomically increments this counter and uses the result as the
+  // signal value (ignoring signalVal). This gives each graph replay a
+  // unique monotonic value without modifying frozen graph args.
+  uint64_t* replayCounter;
+  // Whether the counter increment needs system-wide visibility (true for
+  // IB path where the GPE host thread reads the counter, false for NVL
+  // where only same-device kernels read it).
+  bool replayCounterSystemScope;
 };
 
 struct CtranKernelWaitSignalArgs {
   uint64_t* signalAddr;
   uint64_t cmpVal;
+  // Device-side replay counter for CUDA graph mode. When non-null, the
+  // kernel reads this counter (already incremented by PutSignal on the
+  // same stream) and uses it as the compare value (ignoring cmpVal).
+  uint64_t* replayCounter;
 };
 
 struct CtranKernelSignalArgs {
   uint64_t* signalAddr;
   uint64_t signalVal;
+  uint64_t* replayCounter;
+  bool replayCounterSystemScope;
 };

--- a/comms/ctran/algos/RMA/Types.h
+++ b/comms/ctran/algos/RMA/Types.h
@@ -22,17 +22,24 @@ struct KernelGetArgs {
 
 } // namespace ctran::rma
 
-struct CtranKernelPutSignalArgs {
+struct CtranKernelSignalArgs {
   uint64_t* signalAddr;
-  uint64_t signalVal;
+  // Per-peer signal counter in mapped pinned host memory. The kernel
+  // atomically increments this counter and uses the result as the signal
+  // value to store at signalAddr.
+  uint64_t* signalCounter;
+  // Whether the counter increment needs system-wide visibility (true for
+  // IB path where the GPE host thread reads the counter, false for NVL
+  // where only same-device kernels read it).
+  bool signalCounterSystemScope;
 };
+
+using CtranKernelPutSignalArgs = CtranKernelSignalArgs;
 
 struct CtranKernelWaitSignalArgs {
   uint64_t* signalAddr;
-  uint64_t cmpVal;
-};
-
-struct CtranKernelSignalArgs {
-  uint64_t* signalAddr;
-  uint64_t signalVal;
+  // Per-peer signal counter in mapped pinned host memory. The kernel
+  // atomically increments this counter and spins on signalAddr until
+  // the value reaches the counter result.
+  uint64_t* signalCounter;
 };

--- a/comms/ctran/gpe/CtranGpe.h
+++ b/comms/ctran/gpe/CtranGpe.h
@@ -222,18 +222,19 @@ struct OpElem {
       size_t count;
       commDataType_t datatype;
       uint64_t* signalAddr;
-      uint64_t signalVal;
+      uint64_t* signalCounter;
       int peerRank;
       ctran::CtranWin* win;
     } putsignal;
     struct {
       const uint64_t* signalAddr;
-      uint64_t cmpVal;
+      uint64_t* signalCounter;
       ctran::CtranWin* win;
     } waitsignal;
     struct {
+      // Remote peer's signal buffer slot for RDMA atomicSet (IB path).
       uint64_t* signalAddr;
-      uint64_t signalVal;
+      uint64_t* signalCounter;
       int peerRank;
       ctran::CtranWin* win;
     } signal;

--- a/comms/ctran/tests/cudagraph/CtranCudaGraphSignalRaceTest.cc
+++ b/comms/ctran/tests/cudagraph/CtranCudaGraphSignalRaceTest.cc
@@ -1,0 +1,260 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+
+#include "comms/ctran/Ctran.h"
+#include "comms/ctran/tests/cudagraph/CtranCudaGraphTestBase.h"
+#include "comms/ctran/tests/cudagraph/CudaGraphTestBuilder.h"
+#include "comms/utils/CudaRAII.h"
+
+using namespace ctran;
+
+class CtranCudaGraphSignalRaceTest : public CtranCudaGraphTestBase {
+ protected:
+  void SetUp() override {
+    CtranCudaGraphTestBase::SetUp();
+    CUDACHECK_TEST(cudaSetDevice(this->localRank));
+  }
+};
+
+// ---------------------------------------------------------------------------
+// CounterNotIncrementedDuringCapture
+//
+// Verifies that the per-peer signal/wait counters are NOT advanced during
+// CUDA graph capture. The capture path skips the host-side counter
+// increment; the kernel atomically increments the counter at replay time
+// instead.
+// ---------------------------------------------------------------------------
+TEST_F(CtranCudaGraphSignalRaceTest, CounterNotIncrementedDuringCapture) {
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+
+  const int rank = globalRank;
+  const int nRanks = numRanks;
+  if (nRanks < 2) {
+    GTEST_SKIP() << "Need at least 2 ranks";
+  }
+
+  const int nextPeer = (rank + 1) % nRanks;
+  const int prevPeer = (rank + nRanks - 1) % nRanks;
+
+  constexpr size_t kElements = 64;
+  size_t sizeBytes = kElements * sizeof(int32_t) * nRanks;
+
+  CtranWin* win = nullptr;
+  void* winBase = nullptr;
+  meta::comms::Hints hints;
+  ASSERT_EQ(
+      ctranWinAllocate(sizeBytes, comm.get(), &winBase, &win, hints),
+      commSuccess);
+  ASSERT_NE(win, nullptr);
+
+  int32_t* sendBuf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&sendBuf, kElements * sizeof(int32_t)));
+  std::vector<int32_t> hostBuf(kElements, rank);
+  CUDACHECK_TEST(cudaMemcpy(
+      sendBuf,
+      hostBuf.data(),
+      kElements * sizeof(int32_t),
+      cudaMemcpyHostToDevice));
+  ASSERT_EQ(
+      ctran::globalRegisterWithPtr(sendBuf, kElements * sizeof(int32_t)),
+      commSuccess);
+
+  meta::comms::CudaStream stream(cudaStreamNonBlocking);
+
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  oobBarrier();
+
+  // Phase 1: N eager iterations to establish baseline counter values.
+  constexpr int kEagerIters = 5;
+  for (int i = 0; i < kEagerIters; ++i) {
+    ASSERT_EQ(
+        ctranPutSignal(
+            sendBuf,
+            kElements,
+            commInt32,
+            nextPeer,
+            kElements * rank,
+            win,
+            stream.get(),
+            true),
+        commSuccess);
+    ASSERT_EQ(ctranWaitSignal(prevPeer, win, stream.get()), commSuccess);
+  }
+  CUDACHECK_TEST(cudaStreamSynchronize(stream.get()));
+  oobBarrier();
+
+  // Snapshot counters before capture.
+  const auto signalBefore =
+      __atomic_load_n(&win->signalCounters[nextPeer], __ATOMIC_RELAXED);
+  const auto waitBefore =
+      __atomic_load_n(&win->waitCounters[prevPeer], __ATOMIC_RELAXED);
+
+  // Phase 2: Capture a graph (no replay needed — just capture).
+  meta::comms::CudaStream captureStream(cudaStreamNonBlocking);
+  cudaGraph_t graph = nullptr;
+  ASSERT_EQ(
+      cudaStreamBeginCapture(captureStream.get(), cudaStreamCaptureModeRelaxed),
+      cudaSuccess);
+  ASSERT_EQ(
+      ctranPutSignal(
+          sendBuf,
+          kElements,
+          commInt32,
+          nextPeer,
+          kElements * rank,
+          win,
+          captureStream.get(),
+          true),
+      commSuccess);
+  ASSERT_EQ(ctranWaitSignal(prevPeer, win, captureStream.get()), commSuccess);
+  ASSERT_EQ(cudaStreamEndCapture(captureStream.get(), &graph), cudaSuccess);
+  ASSERT_NE(graph, nullptr);
+
+  // The counters must NOT have been incremented by graph capture.
+  EXPECT_EQ(
+      __atomic_load_n(&win->signalCounters[nextPeer], __ATOMIC_RELAXED),
+      signalBefore)
+      << "signalCounter was polluted during graph capture";
+  EXPECT_EQ(
+      __atomic_load_n(&win->waitCounters[prevPeer], __ATOMIC_RELAXED),
+      waitBefore)
+      << "waitCounter was polluted during graph capture";
+
+  // Cleanup
+  cudaGraphDestroy(graph);
+  ASSERT_EQ(
+      ctran::globalDeregisterWithPtr(sendBuf, kElements * sizeof(int32_t)),
+      commSuccess);
+  CUDACHECK_TEST(cudaFree(sendBuf));
+  ASSERT_EQ(ctranWinFree(win), commSuccess);
+}
+
+// ---------------------------------------------------------------------------
+// MonotonicSignalValues
+//
+// Verifies that signal values are monotonically increasing across eager
+// iterations followed by graph replays. Both paths share a single signal
+// buffer and per-peer counters, so the values must form a continuous
+// ascending sequence (no resets, no gaps).
+// ---------------------------------------------------------------------------
+TEST_F(CtranCudaGraphSignalRaceTest, MonotonicSignalValues) {
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+
+  const int rank = globalRank;
+  const int nRanks = numRanks;
+  if (nRanks < 2) {
+    GTEST_SKIP() << "Need at least 2 ranks";
+  }
+
+  const int nextPeer = (rank + 1) % nRanks;
+  const int prevPeer = (rank + nRanks - 1) % nRanks;
+
+  constexpr size_t kElements = 64;
+  size_t sizeBytes = kElements * sizeof(int32_t) * nRanks;
+
+  CtranWin* win = nullptr;
+  void* winBase = nullptr;
+  meta::comms::Hints hints;
+  ASSERT_EQ(
+      ctranWinAllocate(sizeBytes, comm.get(), &winBase, &win, hints),
+      commSuccess);
+  ASSERT_NE(win, nullptr);
+
+  int32_t* sendBuf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&sendBuf, kElements * sizeof(int32_t)));
+  std::vector<int32_t> hostBuf(kElements, rank);
+  CUDACHECK_TEST(cudaMemcpy(
+      sendBuf,
+      hostBuf.data(),
+      kElements * sizeof(int32_t),
+      cudaMemcpyHostToDevice));
+  ASSERT_EQ(
+      ctran::globalRegisterWithPtr(sendBuf, kElements * sizeof(int32_t)),
+      commSuccess);
+
+  meta::comms::CudaStream stream(cudaStreamNonBlocking);
+
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  oobBarrier();
+
+  // Phase 1: Eager iterations.
+  constexpr int kEagerIters = 5;
+  for (int i = 0; i < kEagerIters; ++i) {
+    ASSERT_EQ(
+        ctranPutSignal(
+            sendBuf,
+            kElements,
+            commInt32,
+            nextPeer,
+            kElements * rank,
+            win,
+            stream.get(),
+            true),
+        commSuccess);
+    ASSERT_EQ(ctranWaitSignal(prevPeer, win, stream.get()), commSuccess);
+  }
+  CUDACHECK_TEST(cudaStreamSynchronize(stream.get()));
+  oobBarrier();
+
+  // Read signal buffer after eager phase.
+  uint64_t signalAfterEager = 0;
+  CUDACHECK_TEST(cudaMemcpy(
+      &signalAfterEager,
+      win->winSignalPtr + prevPeer,
+      sizeof(uint64_t),
+      cudaMemcpyDeviceToHost));
+  ASSERT_EQ(signalAfterEager, static_cast<uint64_t>(kEagerIters))
+      << "Signal value should equal eager iteration count";
+
+  // Phase 2: Graph replays — values should continue from where eager left off.
+  constexpr int kGraphReplays = 3;
+  ctran::testing::CtranGraphTestBuilder(comm.get(), rank, nRanks)
+      .withNumReplays(kGraphReplays)
+      .addCapture([&](ctran::testing::CaptureContext& ctx) {
+        ASSERT_EQ(
+            ctranPutSignal(
+                sendBuf,
+                kElements,
+                commInt32,
+                nextPeer,
+                kElements * rank,
+                win,
+                ctx.stream,
+                true),
+            commSuccess);
+        ASSERT_EQ(ctranWaitSignal(prevPeer, win, ctx.stream), commSuccess);
+      })
+      .withResourcePoolCheck(false)
+      .run();
+
+  oobBarrier();
+
+  uint64_t signalAfterGraph = 0;
+  CUDACHECK_TEST(cudaMemcpy(
+      &signalAfterGraph,
+      win->winSignalPtr + prevPeer,
+      sizeof(uint64_t),
+      cudaMemcpyDeviceToHost));
+  EXPECT_EQ(
+      signalAfterGraph, static_cast<uint64_t>(kEagerIters + kGraphReplays))
+      << "Signal values should be monotonically increasing across "
+         "eager and graph replay";
+
+  // Cleanup
+  ASSERT_EQ(
+      ctran::globalDeregisterWithPtr(sendBuf, kElements * sizeof(int32_t)),
+      commSuccess);
+  CUDACHECK_TEST(cudaFree(sendBuf));
+  ASSERT_EQ(ctranWinFree(win), commSuccess);
+}
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new CtranCudaGraphEnvironment);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ctran/window/CtranWin.h
+++ b/comms/ctran/window/CtranWin.h
@@ -57,6 +57,17 @@ struct CtranWin {
   void* winDataPtr{nullptr};
   // The pointer of the signal buffer of this window
   uint64_t* winSignalPtr{nullptr};
+  // Dedicated signal buffer for CUDA graph capture/replay. Isolated from
+  // winSignalPtr so graph signal values don't conflict with eager monotonic
+  // counters.
+  uint64_t* winGraphSignalPtr{nullptr};
+
+  // Device-side replay counter for CUDA graph replay. Incremented by a
+  // small kernel at the start of each graph replay. PutSignal/WaitSignal
+  // kernels read this to get a unique, monotonically increasing signal
+  // value per replay — eliminating the need for signal resets and
+  // preventing inter-replay races.
+  uint64_t* graphReplayCounter{nullptr};
   // Stores signal values for waiting, used to track progress
   std::deque<std::atomic<uint64_t>> waitSignalVal{};
 

--- a/comms/ctran/window/CtranWin.h
+++ b/comms/ctran/window/CtranWin.h
@@ -57,11 +57,13 @@ struct CtranWin {
   void* winDataPtr{nullptr};
   // The pointer of the signal buffer of this window
   uint64_t* winSignalPtr{nullptr};
-  // Stores signal values for waiting, used to track progress
-  std::deque<std::atomic<uint64_t>> waitSignalVal{};
 
-  // Stores signal values for sent signals, used to track progress
-  std::deque<std::atomic<uint64_t>> signalVal{};
+  // Per-peer signal counters in mapped pinned host memory. Accessible from
+  // both GPU kernels (atomicAdd to get monotonic signal values) and the CPU
+  // GPE thread (volatile read for IB RDMA atomicSet). Initialized to 0;
+  // kernels/host use fetch_add(1)+1 to produce values 1, 2, 3, ...
+  uint64_t* signalCounters{nullptr};
+  uint64_t* waitCounters{nullptr};
 
   CtranWin(
       CtranComm* comm,
@@ -87,22 +89,11 @@ struct CtranWin {
     return opCount;
   }
 
-  inline uint64_t ctranNextWaitSignalVal(int peer) {
-    FB_CHECKTHROW_EX_NOCOMM(
-        peer < signalSize,
-        "peer rank {} exceed window signal buffer size {}",
-        peer,
-        signalSize);
-    return waitSignalVal[peer].fetch_add(1, std::memory_order_relaxed);
-  }
-
-  inline uint64_t ctranNextSignalVal(int peer) {
-    FB_CHECKTHROW_EX_NOCOMM(
-        peer < signalSize,
-        "peer rank {} exceed window signal buffer size {}",
-        peer,
-        signalSize);
-    return signalVal[peer].fetch_add(1, std::memory_order_relaxed);
+  // Atomically increment and return the per-peer wait counter.
+  // Used by the host for cuStreamWaitValue64 (eager path only).
+  // Signal counters are always incremented by the kernel.
+  inline uint64_t nextWaitCounter(int peer) {
+    return __atomic_fetch_add(&waitCounters[peer], 1, __ATOMIC_RELAXED) + 1;
   }
 
   commResult_t allocate(void* userBufPtr = nullptr);

--- a/comms/ctran/window/Types.h
+++ b/comms/ctran/window/Types.h
@@ -21,6 +21,10 @@ enum OpCountType {
 struct RemWinInfo {
   void* dataAddr{nullptr};
   uint64_t* signalAddr{nullptr};
+  // Dedicated signal slot for CUDA graph capture/replay. Isolated from the
+  // eager signalAddr so that graph signal values and eager monotonic
+  // counters don't interfere.
+  uint64_t* graphSignalAddr{nullptr};
   CtranMapperRemoteAccessKey dataRkey{CtranMapperBackend::UNSET};
   CtranMapperRemoteAccessKey signalRkey{CtranMapperBackend::UNSET};
   size_t dataBytes{0};

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -16,6 +16,7 @@
 #include "comms/pipes/window/DeviceWindow.cuh"
 #include "comms/pipes/window/HostWindow.h"
 #endif
+#include "comms/utils/CudaRAII.h"
 #include "comms/utils/logger/LogUtils.h"
 
 using ctran::window::RemWinInfo;
@@ -115,6 +116,7 @@ commResult_t CtranWin::exchange() {
         winDataPtr, dataRegHdl, remoteUserBufs, remoteUserBufAccessKeys));
   }
 
+  auto signalBytes = signalSize * sizeof(uint64_t);
   for (auto r = 0; r < nRanks; r++) {
     remWinInfo[r].dataBytes = allRankSizes[r];
     if (allocDataBuf_) {
@@ -122,11 +124,16 @@ commResult_t CtranWin::exchange() {
       remWinInfo[r].dataRkey = remoteBaseBufAccessKeys[r];
       remWinInfo[r].signalAddr = reinterpret_cast<uint64_t*>(
           reinterpret_cast<size_t>(remoteBaseBufs[r]) + allRankSizes[r]);
+      remWinInfo[r].graphSignalAddr = reinterpret_cast<uint64_t*>(
+          reinterpret_cast<size_t>(remoteBaseBufs[r]) + allRankSizes[r] +
+          signalBytes);
       remWinInfo[r].signalRkey = remoteBaseBufAccessKeys[r];
     } else {
       remWinInfo[r].dataAddr = remoteUserBufs[r];
       remWinInfo[r].dataRkey = remoteUserBufAccessKeys[r];
       remWinInfo[r].signalAddr = reinterpret_cast<uint64_t*>(remoteBaseBufs[r]);
+      remWinInfo[r].graphSignalAddr = reinterpret_cast<uint64_t*>(
+          reinterpret_cast<size_t>(remoteBaseBufs[r]) + signalBytes);
       remWinInfo[r].signalRkey = remoteBaseBufAccessKeys[r];
     }
   }
@@ -187,7 +194,9 @@ commResult_t CtranWin::allocate(void* userBufPtr) {
   void* addr = nullptr;
   CUmemGenericAllocationHandle allocHandle;
   auto signalBytes = signalSize * sizeof(uint64_t);
-  size_t allocSize = allocDataBuf_ ? dataBytes + signalBytes : signalBytes;
+  auto graphSignalBytes = signalBytes;
+  size_t allocSize = allocDataBuf_ ? dataBytes + signalBytes + graphSignalBytes
+                                   : signalBytes + graphSignalBytes;
   if (isGpuMem()) {
     FB_COMMCHECK(
         utils::commCuMemAlloc(
@@ -212,9 +221,36 @@ commResult_t CtranWin::allocate(void* userBufPtr) {
     winDataPtr = addr;
     winSignalPtr =
         reinterpret_cast<uint64_t*>(reinterpret_cast<size_t>(addr) + dataBytes);
+    winGraphSignalPtr = reinterpret_cast<uint64_t*>(
+        reinterpret_cast<size_t>(addr) + dataBytes + signalBytes);
   } else {
     winDataPtr = userBufPtr;
     winSignalPtr = reinterpret_cast<uint64_t*>(reinterpret_cast<size_t>(addr));
+    winGraphSignalPtr = reinterpret_cast<uint64_t*>(
+        reinterpret_cast<size_t>(addr) + signalBytes);
+  }
+
+  {
+    meta::comms::StreamCaptureModeGuard captureGuard{
+        cudaStreamCaptureModeRelaxed};
+    // Allocate replay counter in mapped pinned host memory. Accessible from:
+    //   - GPU kernels (NVL: atomicAdd to increment, WaitSignal: load to read)
+    //   - CPU GPE thread (IB: direct pointer read for RDMA atomicSet value)
+    // Initialized to 0; gives each graph replay a unique monotonic signal
+    // value without needing signal resets.
+    FB_CUDACHECK(cudaHostAlloc(
+        &graphReplayCounter, sizeof(uint64_t), cudaHostAllocMapped));
+    *graphReplayCounter = 0;
+
+    // Zero-initialize both signal buffers.
+    // commCuMemAlloc (cuMemCreate/cuMemMap) does NOT zero memory.
+    // The graph signal buffer must start at 0 so the spinning kernel wait
+    // blocks correctly on first replay.
+    if (isGpuMem()) {
+      FB_CUDACHECK(cudaMemset(winSignalPtr, 0, signalBytes + graphSignalBytes));
+    } else {
+      memset(winSignalPtr, 0, signalBytes + graphSignalBytes);
+    }
   }
 
   CLOGF_SUBSYS(
@@ -314,6 +350,10 @@ commResult_t CtranWin::free(bool skipBarrier) {
   hostWindow_.reset();
 #endif
 
+  if (graphReplayCounter) {
+    cudaFreeHost(graphReplayCounter);
+    graphReplayCounter = nullptr;
+  }
   freeMem(winBasePtr);
 
   return commSuccess;

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -16,6 +16,7 @@
 #include "comms/pipes/window/DeviceWindow.cuh"
 #include "comms/pipes/window/HostWindow.h"
 #endif
+#include "comms/utils/CudaRAII.h"
 #include "comms/utils/logger/LogUtils.h"
 
 using ctran::window::RemWinInfo;
@@ -33,12 +34,6 @@ CtranWin::CtranWin(CtranComm* comm, size_t size, DevMemType bufType)
         commInternalError, "CtranWin: comm is nullptr when creating window.");
   }
   signalSize = comm->statex_.get()->nRanks();
-  signalVal.resize(signalSize);
-  waitSignalVal.resize(signalSize);
-  for (auto& val : signalVal)
-    val.store(1);
-  for (auto& val : waitSignalVal)
-    val.store(1);
 }
 
 commResult_t CtranWin::exchange() {
@@ -217,6 +212,25 @@ commResult_t CtranWin::allocate(void* userBufPtr) {
     winSignalPtr = reinterpret_cast<uint64_t*>(reinterpret_cast<size_t>(addr));
   }
 
+  {
+    meta::comms::StreamCaptureModeGuard captureGuard{
+        cudaStreamCaptureModeRelaxed};
+    auto counterBytes = signalSize * sizeof(uint64_t);
+
+    FB_CUDACHECK(
+        cudaHostAlloc(&signalCounters, counterBytes, cudaHostAllocMapped));
+    FB_CUDACHECK(
+        cudaHostAlloc(&waitCounters, counterBytes, cudaHostAllocMapped));
+    memset(signalCounters, 0, counterBytes);
+    memset(waitCounters, 0, counterBytes);
+
+    if (isGpuMem()) {
+      FB_CUDACHECK(cudaMemset(winSignalPtr, 0, signalBytes));
+    } else {
+      memset(winSignalPtr, 0, signalBytes);
+    }
+  }
+
   CLOGF_SUBSYS(
       INFO,
       INIT,
@@ -313,6 +327,15 @@ commResult_t CtranWin::free(bool skipBarrier) {
   // HostWindow handles cleanup via RAII
   hostWindow_.reset();
 #endif
+
+  if (signalCounters) {
+    cudaFreeHost(signalCounters);
+    signalCounters = nullptr;
+  }
+  if (waitCounters) {
+    cudaFreeHost(waitCounters);
+    waitCounters = nullptr;
+  }
 
   freeMem(winBasePtr);
 


### PR DESCRIPTION
Summary:

the current cuStreamBatchMemOp increment + reset isn't sufficient.

we may have eager executions competing w/ graph executions. the eager path expects monotonically increasing counters, but a graph counter reset can interfere with this; think of the case where our eager reader calls ctranNextWaitSignalVal and gets some value GEQ 2, then some graph shows up and does it's increment-then-reset before this signal arrives. it'd be stuck waiting for some value that is now 1 (but expects GEQ 2).

i suppose there is an asymmetric comms where you have a graph that does A signals B repeatedly. it's possible that A will clobber it's own signals (i.e,. it sets 1->1 before B is able to set 1 back to 0). B will be waiting for a 1 but it'll never come because it's last wait was actually for multiple clobbered puts.

we can solve this by making sure that the put kernel does a device-side increment on the signal value similar to what the host does for the non-graph case. monotonically increasing values don't have the gaps mentioned above, and the eager path remains unchanged.

Differential Revision: D99684144


