### PR TITLE
cudagraph colltrace support (#1980)

### DIFF
--- a/comms/ncclx/v2_27/src/Makefile
+++ b/comms/ncclx/v2_27/src/Makefile
@@ -66,6 +66,9 @@ LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/logger/*.cc)
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/*.cc)
 ## CollTrace source files
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/colltrace/*.cc)
+## CollTrace CUDA source files (host-side kernel launchers)
+LIBSRCFILES += ${BASE_DIR}/comms/utils/colltrace/GpuClockCalibration.cu
+LIBSRCFILES += ${BASE_DIR}/comms/utils/colltrace/HRDWRingBufferInstantiations.cu
 ## CollTrace plugin source files
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/colltrace/plugins/*.cc)
 ## Include ibverbx files
@@ -216,10 +219,12 @@ PKGTARGET  := $(PKGCONFIGFILE)
 LIBSRCFILES_CC  := $(filter %.cc,$(LIBSRCFILES))
 LIBSRCFILES_CPP := $(filter %.cpp,$(LIBSRCFILES))
 LIBSRCFILES_C   := $(filter %.c,$(LIBSRCFILES))
+LIBSRCFILES_CU  := $(filter %.cu,$(LIBSRCFILES))
 LIBOBJ_CC       := $(LIBSRCFILES_CC:%.cc=$(OBJDIR)/%.o)
 LIBOBJ_CPP      := $(LIBSRCFILES_CPP:%.cpp=$(OBJDIR)/%.o)
 LIBOBJ_C        := $(LIBSRCFILES_C:%.c=$(OBJDIR)/%.o)
-LIBOBJ          := $(LIBOBJ_CC) $(LIBOBJ_CPP) $(LIBOBJ_C)
+LIBOBJ_CU       := $(LIBSRCFILES_CU:%.cu=$(OBJDIR)/%.o)
+LIBOBJ          := $(LIBOBJ_CC) $(LIBOBJ_CPP) $(LIBOBJ_C) $(LIBOBJ_CU)
 BINOBJ     := $(BINSRCFILES:%.cc=$(OBJDIR)/%.o)
 DEPFILES   := $(LIBOBJ:%.o=%.d) $(BINOBJ:%.o=%.d)
 LDFLAGS    += -Wl,--no-undefined
@@ -347,6 +352,11 @@ $(OBJDIR)/%.o : %.c $(INCTARGETS)
 	@sed -e 's/.*://' -e 's/\\$$//' < $(@:%.o=%.d.tmp) | fmt -1 | \
                 sed -e 's/^ *//' -e 's/$$/:/' >> $(@:%.o=%.d)
 	@rm -f $(@:%.o=%.d.tmp)
+
+$(OBJDIR)/%.o : %.cu $(INCTARGETS)
+	@printf "Compiling  %-35s > %s\n" $< $@
+	mkdir -p `dirname $@`
+	$(NVCC) $(NVCC_GENCODE) $(CXXSTD) -Xcompiler -fPIC -Xcompiler -fvisibility=hidden -I. -I$(INCDIR) $(INCLUDES) -c $< -o $@
 
 clean :
 	$(MAKE) -C device clean

--- a/comms/ncclx/v2_28/src/Makefile
+++ b/comms/ncclx/v2_28/src/Makefile
@@ -73,6 +73,9 @@ LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/logger/*.cc)
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/*.cc)
 ## CollTrace source files
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/colltrace/*.cc)
+## CollTrace CUDA source files (host-side kernel launchers)
+LIBSRCFILES += ${BASE_DIR}/comms/utils/colltrace/GpuClockCalibration.cu
+LIBSRCFILES += ${BASE_DIR}/comms/utils/colltrace/HRDWRingBufferInstantiations.cu
 ## CollTrace plugin source files
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/colltrace/plugins/*.cc)
 ## Include ibverbx files
@@ -190,10 +193,12 @@ PKGTARGET  := $(PKGCONFIGFILE)
 LIBSRCFILES_CC  := $(filter %.cc,$(LIBSRCFILES))
 LIBSRCFILES_CPP := $(filter %.cpp,$(LIBSRCFILES))
 LIBSRCFILES_C   := $(filter %.c,$(LIBSRCFILES))
+LIBSRCFILES_CU  := $(filter %.cu,$(LIBSRCFILES))
 LIBOBJ_CC       := $(LIBSRCFILES_CC:%.cc=$(OBJDIR)/%.o)
 LIBOBJ_CPP      := $(LIBSRCFILES_CPP:%.cpp=$(OBJDIR)/%.o)
 LIBOBJ_C        := $(LIBSRCFILES_C:%.c=$(OBJDIR)/%.o)
-LIBOBJ          := $(LIBOBJ_CC) $(LIBOBJ_CPP) $(LIBOBJ_C)
+LIBOBJ_CU       := $(LIBSRCFILES_CU:%.cu=$(OBJDIR)/%.o)
+LIBOBJ          := $(LIBOBJ_CC) $(LIBOBJ_CPP) $(LIBOBJ_C) $(LIBOBJ_CU)
 BINOBJ     := $(BINSRCFILES:%.cc=$(OBJDIR)/%.o)
 DEPFILES   := $(LIBOBJ:%.o=%.d) $(BINOBJ:%.o=%.d)
 LDFLAGS    += -Wl,--no-undefined
@@ -372,6 +377,11 @@ $(OBJDIR)/%.o : %.c $(INCTARGETS)
 	@sed -e 's/.*://' -e 's/\\$$//' < $(@:%.o=%.d.tmp) | fmt -1 | \
                 sed -e 's/^ *//' -e 's/$$/:/' >> $(@:%.o=%.d)
 	@rm -f $(@:%.o=%.d.tmp)
+
+$(OBJDIR)/%.o : %.cu $(INCTARGETS)
+	@printf "Compiling  %-35s > %s\n" $< $@
+	mkdir -p `dirname $@`
+	$(NVCC) $(NVCC_GENCODE) $(CXXSTD) -Xcompiler -fPIC -Xcompiler -fvisibility=hidden -I. -I$(INCDIR) $(INCLUDES) -I$(INCPLUGIN) -I$(DOCA_HOME)/include -c $< -o $@
 
 $(DOCA_OBJDIR)/%.o : $(DOCA_HOME)/src/%.cpp
 	@printf "Compiling  %-35s > %s\n" $< $@

--- a/comms/ncclx/v2_29/src/Makefile
+++ b/comms/ncclx/v2_29/src/Makefile
@@ -78,6 +78,9 @@ LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/logger/*.cc)
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/*.cc)
 ## CollTrace source files
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/colltrace/*.cc)
+## CollTrace CUDA source files (host-side kernel launchers)
+LIBSRCFILES += ${BASE_DIR}/comms/utils/colltrace/GpuClockCalibration.cu
+LIBSRCFILES += ${BASE_DIR}/comms/utils/colltrace/HRDWRingBufferInstantiations.cu
 ## CollTrace plugin source files
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/colltrace/plugins/*.cc)
 ## Include ibverbx files
@@ -239,10 +242,12 @@ PKGTARGET  := $(PKGCONFIGFILE)
 LIBSRCFILES_CC  := $(filter %.cc,$(LIBSRCFILES))
 LIBSRCFILES_CPP := $(filter %.cpp,$(LIBSRCFILES))
 LIBSRCFILES_C   := $(filter %.c,$(LIBSRCFILES))
+LIBSRCFILES_CU  := $(filter %.cu,$(LIBSRCFILES))
 LIBOBJ_CC       := $(LIBSRCFILES_CC:%.cc=$(OBJDIR)/%.o)
 LIBOBJ_CPP      := $(LIBSRCFILES_CPP:%.cpp=$(OBJDIR)/%.o)
 LIBOBJ_C        := $(LIBSRCFILES_C:%.c=$(OBJDIR)/%.o)
-LIBOBJ          := $(LIBOBJ_CC) $(LIBOBJ_CPP) $(LIBOBJ_C)
+LIBOBJ_CU       := $(LIBSRCFILES_CU:%.cu=$(OBJDIR)/%.o)
+LIBOBJ          := $(LIBOBJ_CC) $(LIBOBJ_CPP) $(LIBOBJ_C) $(LIBOBJ_CU)
 BINOBJ     := $(BINSRCFILES:%.cc=$(OBJDIR)/%.o)
 DEPFILES   := $(LIBOBJ:%.o=%.d) $(BINOBJ:%.o=%.d)
 LDFLAGS    += -Wl,--no-undefined
@@ -427,6 +432,11 @@ $(OBJDIR)/%.o : %.c $(INCTARGETS)
 	@sed -e 's/.*://' -e 's/\\$$//' < $(@:%.o=%.d.tmp) | fmt -1 | \
                 sed -e 's/^ *//' -e 's/$$/:/' >> $(@:%.o=%.d)
 	@rm -f $(@:%.o=%.d.tmp)
+
+$(OBJDIR)/%.o : %.cu $(INCTARGETS)
+	@printf "Compiling  %-35s > %s\n" $< $@
+	mkdir -p `dirname $@`
+	$(NVCC) $(NVCC_GENCODE) $(CXXSTD) -Xcompiler -fPIC -Xcompiler -fvisibility=hidden -I. -I$(INCDIR) -I$(OBJDIR)/include $(INCLUDES) -I$(INCPLUGIN) -I$(DOCA_HOME)/include -c $< -o $@
 
 $(OBJDIR)/misc/git_version.o: $(GIT_VERSION_FILE)
 

--- a/comms/utils/CMakeLists.txt
+++ b/comms/utils/CMakeLists.txt
@@ -5,11 +5,17 @@ find_package(CUDA REQUIRED)
 file(GLOB_RECURSE UTILS_SOURCES
     "*.cc"
 )
+file(GLOB_RECURSE UTILS_CU_SOURCES
+    "*.cu"
+)
 list(FILTER UTILS_SOURCES EXCLUDE REGEX ".*/tests/.*")
 list(FILTER UTILS_SOURCES EXCLUDE REGEX ".*/test_utils/.*")
+list(FILTER UTILS_CU_SOURCES EXCLUDE REGEX ".*/tests/.*")
+list(FILTER UTILS_CU_SOURCES EXCLUDE REGEX ".*/test_utils/.*")
 
 add_library(utils OBJECT
     ${UTILS_SOURCES}
+    ${UTILS_CU_SOURCES}
 )
 
 target_compile_features(utils PRIVATE cxx_std_20)

--- a/comms/utils/HRDWRingBuffer.h
+++ b/comms/utils/HRDWRingBuffer.h
@@ -9,7 +9,9 @@
 #endif
 
 #include <algorithm>
+#if __cplusplus >= 202002L
 #include <bit>
+#endif
 #include <cassert>
 #include <cstdint>
 #include <cstdio>
@@ -182,7 +184,15 @@ class HRDWRingBuffer {
       return; // valid() will return false
     }
     if ((size & (size - 1)) != 0) {
+#if __cplusplus >= 202002L
       uint32_t nextPowerOf2 = 1U << (std::bit_width(size - 1));
+#else
+      // C++17 fallback for std::bit_width
+      uint32_t nextPowerOf2 = 1;
+      while (nextPowerOf2 < size) {
+        nextPowerOf2 <<= 1;
+      }
+#endif
       fprintf(
           stderr,
           "HRDWRingBuffer: size %u is not a power of 2, rounding up to %u\n",

--- a/comms/utils/colltrace/CollTrace.cc
+++ b/comms/utils/colltrace/CollTrace.cc
@@ -2,27 +2,40 @@
 
 #include "comms/utils/colltrace/CollTrace.h"
 
+#include <algorithm>
+
 #include <fmt/core.h>
 #include <folly/json.h>
 #include <folly/logging/xlog.h>
 #include <folly/stop_watch.h>
 
+#include <cuda_runtime.h> // @manual=third-party//cuda:cuda-lazy
+
 #include "comms/utils/CommsMaybeChecks.h"
-
-// Helper macro to return from a function once cancellation is requested
-#define SAFE_RETURN_POINT(shouldCancel) \
-  if (shouldCancel) {                   \
-    return;                             \
-  }
-
-#define SAFE_RETURN_POINT_WITH_VAL(shouldCancel, returnVal) \
-  if (shouldCancel) {                                       \
-    return returnVal;                                       \
-  }
+#include "comms/utils/colltrace/GpuClockCalibration.h"
+#include "comms/utils/colltrace/GraphCollTraceHandle.h"
+#include "comms/utils/colltrace/GraphCollTraceState.h"
+#include "comms/utils/colltrace/GraphCudaWaitEvent.h"
+#include "comms/utils/cvars/nccl_cvars.h"
 
 namespace meta::comms::colltrace {
 
 namespace {
+
+// fires when graph is destroyed to set released flag s.t., the associated
+// GraphCollTraceState will stop being used.
+void
+#if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
+    CUDART_CB
+#endif
+    graphCleanupCallback(void* userData) {
+  auto* sp = static_cast<std::shared_ptr<GraphCollTraceState>*>(userData);
+  (*sp)->graph_destructed.store(true, std::memory_order_relaxed);
+  delete sp;
+}
+
+} // namespace
+
 template <auto Method>
 void triggerPlugins(
     std::vector<std::unique_ptr<ICollTracePlugin>>& plugins,
@@ -40,7 +53,6 @@ void triggerPlugins(
     }
   }
 }
-} // namespace
 
 CollTrace::CollTrace(
     CollTraceConfig config,
@@ -58,23 +70,66 @@ CollTrace::CollTrace(
       pendingTraceColls_(
           folly::MPMCQueue<std::unique_ptr<CollTraceEvent>>{
               config_.maxPendingQueueSize}),
-      plugins_(std::move(plugins)),
-      traceCollThread_(
-          std::thread(&CollTrace::collTraceThread, this, threadSetupFunc)) {
+      plugins_(std::move(plugins)) {
+  if (NCCL_COLLTRACE_TRACE_CUDA_GRAPH) {
+    // 2x the max plugin retention ensures the ring holds at least the last
+    // max_retention collective entries (each collective has 1x start + 1x end
+    // event). The ring ctor rounds up to the next power of 2.
+    int64_t maxRetention = 0;
+    for (const auto& plugin : plugins_) {
+      maxRetention = std::max(maxRetention, plugin->maxEventRetention());
+    }
+    uint32_t ringSize =
+        std::max(kDefaultRingSize, static_cast<uint32_t>(maxRetention) * 2);
+    XLOGF(
+        DBG0,
+        "{}: graph ring buffer sized to {} entries (max plugin retention={}, "
+        "default={})",
+        logPrefix_,
+        ringSize,
+        maxRetention,
+        kDefaultRingSize);
+
+    ringBuffer_.emplace(ringSize);
+    if (ringBuffer_->valid()) {
+      ringReader_.emplace(*ringBuffer_);
+    } else {
+      XLOG_FIRST_N(ERR, 1) << logPrefix_
+                           << ": Failed to allocate shared ring buffer";
+      ringBuffer_.reset();
+    }
+  }
+
   // pluginByName_ is not used in the colltrace thread. It is okay to initialize
   // it after the colltrace thread starts
   for (const auto& plugin : plugins_) {
     XLOG(DBG0) << "Registering plugin " << plugin->getName();
     pluginByName_.emplace(plugin->getName(), *plugin);
   }
+
+  // Start the poll thread after ring buffer initialization to avoid a data
+  // race: the thread reads ringBuffer_.has_value() on its first iteration,
+  // and std::optional is not thread-safe for concurrent read/write.
+  traceCollThread_ =
+      std::thread(&CollTrace::collTraceThread, this, threadSetupFunc);
+
+  threadStarted_.wait();
 }
 
 CollTrace::~CollTrace() {
   // Set the cancellation flag
   threadShouldStop_.test_and_set();
-  // Invalidate all the handles
+  // Invalidate all eager handles.
   for (auto& [_, handle] : eventToHandleMap_) {
     handle->invalidate();
+  }
+  // Invalidate all graph handles.
+  for (auto& [_, state] : graphStateMap_) {
+    for (auto& [_, collEntry] : state->collectives) {
+      if (auto h = collEntry.handle.lock()) {
+        h->invalidate();
+      }
+    }
   }
   // Wait for the thread to finish
   if (traceCollThread_.joinable()) {
@@ -82,7 +137,73 @@ CollTrace::~CollTrace() {
   }
 }
 
-CommsMaybe<std::shared_ptr<CollTraceHandle>> CollTrace::recordCollective(
+std::shared_ptr<GraphCollTraceState> CollTrace::getOrCreateGraphState(
+    cudaStream_t stream) {
+  cudaStreamCaptureStatus captureStatus;
+  unsigned long long graphId = 0;
+  cudaGraph_t graph = nullptr;
+
+#if CUDART_VERSION >= 13000
+  auto res = cudaStreamGetCaptureInfo(
+      stream, &captureStatus, &graphId, &graph, nullptr, nullptr, nullptr);
+#else
+  auto res = cudaStreamGetCaptureInfo_v2(
+      stream, &captureStatus, &graphId, &graph, nullptr, nullptr);
+#endif
+  if (res != cudaSuccess || captureStatus != cudaStreamCaptureStatusActive ||
+      graph == nullptr) {
+    return nullptr;
+  }
+
+  // Hold the lock for the entire create-or-lookup path. This is a capture-time
+  // path so contention is not a concern, and it avoids the race where two
+  // threads both see an empty map and create duplicate state / leak CUDA user
+  // objects.
+  std::lock_guard<std::mutex> lock(graphStateMutex_);
+
+  auto it = graphStateMap_.find(graphId);
+  if (it != graphStateMap_.end()) {
+    return it->second;
+  }
+
+  auto state = std::make_shared<GraphCollTraceState>();
+
+  // heap alloc a copy s.t., the graph will keep the state alive until its
+  // dtor flips the flag. the readers will see this and stop using
+  // the state, which will drop the refcount to 0.
+  auto* prevent_free = new std::shared_ptr<GraphCollTraceState>(state);
+
+  cudaUserObject_t userObject;
+  auto createRes = cudaUserObjectCreate(
+      &userObject,
+      prevent_free,
+      graphCleanupCallback,
+      1,
+      cudaUserObjectNoDestructorSync);
+
+  if (createRes != cudaSuccess) {
+    delete prevent_free;
+    XLOG_FIRST_N(WARN, 1) << "Failed to create graph cleanup user object: "
+                          << cudaGetErrorString(createRes);
+    return nullptr;
+  }
+
+  auto retainRes =
+      cudaGraphRetainUserObject(graph, userObject, 1, cudaGraphUserObjectMove);
+  if (retainRes != cudaSuccess) {
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaUserObjectRelease(userObject, 1);
+    XLOG_FIRST_N(WARN, 1) << "Failed to retain graph user object: "
+                          << cudaGetErrorString(retainRes);
+    return nullptr;
+  }
+
+  graphStateMap_.emplace(graphId, state);
+
+  return state;
+}
+
+CommsMaybe<std::shared_ptr<ICollTraceHandle>> CollTrace::recordCollective(
     std::unique_ptr<ICollMetadata> metadata,
     std::unique_ptr<ICollWaitEvent> waitEvent) noexcept {
   if (metadata == nullptr) {
@@ -95,6 +216,11 @@ CommsMaybe<std::shared_ptr<CollTraceHandle>> CollTrace::recordCollective(
         "Received nullptr for waitEvent during recordCollective",
         commInternalError));
   }
+
+  if (dynamic_cast<GraphCudaWaitEvent*>(waitEvent.get()) != nullptr) {
+    return recordGraphCollectiveImpl(std::move(metadata), std::move(waitEvent));
+  }
+
   if (pendingEnqueueColl_ != nullptr) {
     XLOG_FIRST_N(
         ERR,
@@ -191,53 +317,299 @@ CommsMaybeVoid CollTrace::triggerEventState(
       CommsError("Unexpected return path", commInternalError));
 }
 
+CommsMaybe<std::shared_ptr<ICollTraceHandle>>
+CollTrace::recordGraphCollectiveImpl(
+    std::unique_ptr<ICollMetadata> metadata,
+    std::unique_ptr<ICollWaitEvent> waitEvent) noexcept {
+  // we know this will be non-null because we checked it in the caller
+  auto* rawWaitEvent = dynamic_cast<GraphCudaWaitEvent*>(waitEvent.get());
+
+  // Assign a unique collId for this collective — used to tag entries in
+  // the shared ring buffer so the poll thread can dispatch by collective.
+  auto collIdVal = collId_.fetch_add(1);
+  rawWaitEvent->setCollId(collIdVal);
+
+  if (!ringBuffer_.has_value()) {
+    return folly::makeUnexpected(CommsError(
+        "Ringbuffer not initialized during recordGraphCollective",
+        commInternalError));
+  }
+
+  // Get or create per-graph state (shared ring buffer, cleanup callback).
+  auto graphState = getOrCreateGraphState(rawWaitEvent->getStream());
+
+  if (graphState == nullptr) {
+    return folly::makeUnexpected(CommsError(
+        "Failed to initialize graph state for capturing stream",
+        commInternalError));
+  }
+
+  rawWaitEvent->attachRingBuffer(&*ringBuffer_);
+
+  auto collRecord =
+      std::make_shared<CollRecord>(collIdVal, std::move(metadata));
+  auto recordPtr = std::static_pointer_cast<ICollRecord>(collRecord);
+
+  auto collEvent = std::make_unique<CollTraceEvent>(CollTraceEvent{
+      .collRecord = std::move(collRecord),
+      .waitEvent = std::move(waitEvent),
+  });
+
+  auto handle = std::make_shared<GraphCollTraceHandle>(
+      rawWaitEvent, std::move(recordPtr));
+
+  uint32_t collId = rawWaitEvent->getCollId();
+
+  GraphCollectiveEntry collectiveEntry{
+      .graphWaitEvent = rawWaitEvent,
+      .event = std::move(collEvent),
+      .handle = handle,
+  };
+
+  // afterCollKernelScheduled is fired per replay via kScheduleAndStart on the
+  // poll thread — nothing to schedule at capture time.
+
+  {
+    std::lock_guard<std::mutex> lock(graphStateMutex_);
+    graphState->collectives.emplace(collId, std::move(collectiveEntry));
+  }
+
+  return handle;
+}
+
 bool CollTrace::isThreadCancelled() const noexcept {
   return threadShouldStop_.test(std::memory_order_relaxed);
 }
 
-CommsMaybe<std::unique_ptr<CollTraceEvent>>
-CollTrace::getNextPendingEvent() noexcept {
-  std::unique_ptr<CollTraceEvent> event;
-  auto curTime = std::chrono::steady_clock::now();
-  while (!pendingTraceColls_.tryReadUntil(
-      curTime + config_.maxCheckCancelInterval, event)) {
-    SAFE_RETURN_POINT_WITH_VAL(
-        isThreadCancelled(),
-        folly::makeUnexpected(CommsError("Got cancellation", commInProgress)));
-    curTime = std::chrono::steady_clock::now();
+void CollTrace::pollGraphEvents(
+    std::multiset<PendingAction>& actions) noexcept {
+  if (!ringBuffer_.has_value() || !ringReader_.has_value()) {
+    return;
   }
-  if (event == nullptr) {
-    XLOG_FIRST_N(
-        ERR, 2, logPrefix_, ": Got null event from pendingTrace queue");
-    return folly::makeUnexpected(
-        CommsError("Got null event from queue", commInternalError));
-  }
-  return event;
-}
 
-CommsMaybeVoid CollTrace::waitCollStart(CollTraceEvent& event) noexcept {
-  while (!isThreadCancelled()) {
-    auto res = event.waitEvent->waitCollStart(config_.maxCheckCancelInterval);
-    triggerPlugins<&ICollTracePlugin::collEventProgressing>(plugins_, event);
-    EXPECT_CHECK_RES(res);
-    if (res.value()) {
-      return folly::unit;
+  {
+    std::lock_guard<std::mutex> lock(graphStateMutex_);
+
+    // check to see if any graphs have been destroyed.
+    // if so, remove stop tracking associated state.
+    std::erase_if(graphStateMap_, [this](const auto& entry) {
+      const auto& state = entry.second;
+      if (state->graph_destructed.load(std::memory_order_relaxed)) {
+        for (const auto& [collId, collEntry] : state->collectives) {
+          // Invalidate the handle to prevent use-after-free of the
+          // raw GraphCudaWaitEvent pointer once we destroy the entry.
+          if (auto h = collEntry.handle.lock()) {
+            h->invalidate();
+          }
+          collIdMap_.erase(collId);
+          progressingGraphCollectives_.erase(collId);
+        }
+        return true;
+      }
+      return false;
+    });
+
+    // add new collectives that aren't in collIdMap_ yet.
+    for (auto& [_, state] : graphStateMap_) {
+      for (auto& [collId, collEntry] : state->collectives) {
+        if (collIdMap_.find(collId) == collIdMap_.end()) {
+          collIdMap_[collId] = &collEntry;
+        }
+      }
     }
   }
-  return folly::unit;
-}
 
-CommsMaybeVoid CollTrace::waitCollEnd(CollTraceEvent& event) noexcept {
-  // Check for
-  while (!isThreadCancelled()) {
-    auto res = event.waitEvent->waitCollEnd(config_.maxCheckCancelInterval);
-    triggerPlugins<&ICollTracePlugin::collEventProgressing>(plugins_, event);
-    EXPECT_CHECK_RES(res);
-    if (res.value()) {
-      return folly::unit;
+  if (collIdMap_.empty()) {
+    return;
+  }
+
+  const auto& cal = GlobaltimerCalibration::get();
+
+  auto pollResult = ringReader_->poll(
+      [&](const auto& entry, uint64_t /*slot*/) {
+        auto collId = entry.data.collId;
+        bool isStartEvent = entry.data.phase == GraphCollTracePhase::kStart;
+
+        auto it = collIdMap_.find(collId);
+        if (it == collIdMap_.end()) {
+          return;
+        }
+
+        auto& collEntry = *(it->second);
+        auto timestamp = cal.toWallClock(entry.timestamp_ns);
+
+        if (isStartEvent) {
+          // if we see a new start event before we observed this collectives
+          // last end, the end event was likely overwritten (ring too small).
+          // the watchdog detects this via the changed start timestamp and
+          // resets its timer automatically but we should log it anyway
+          if (auto [_, inserted] = progressingGraphCollectives_.insert(collId);
+              !inserted) {
+            XLOG_EVERY_MS(WARN, 5000)
+                << logPrefix_ << ": graph collective " << collId
+                << " saw a new start event before the previous end event"
+                   " — the end event was likely overwritten (ring too small)";
+          }
+          collEntry.event->collRecord->getTimingInfo().setCollStartTs(
+              timestamp);
+          actions.insert(
+              {collEntry.event.get(),
+               PendingActionType::kScheduleAndStart,
+               timestamp});
+        } else /* isEndEvent */ {
+          collEntry.event->collRecord->getTimingInfo().setCollEndTs(timestamp);
+          progressingGraphCollectives_.erase(collId);
+          actions.insert(
+              {collEntry.event.get(), PendingActionType::kEnd, timestamp});
+        }
+      },
+      /*timeout=*/config_.maxCheckCancelInterval);
+
+  if (pollResult.entriesLost > 0) {
+    XLOG_EVERY_MS(WARN, 5000)
+        << logPrefix_ << ": missed " << pollResult.entriesLost
+        << " graph replay timestamp(s) (overwritten)";
+  }
+
+  // Emit kProgressing for every pending start so the watchdog plugin's
+  // timer accumulates. Without this, graph collectives would never trigger
+  // the watchdog timeout because collEventProgressing is only called on
+  // discrete ring buffer events.
+  auto now = std::chrono::system_clock::now();
+  for (auto collId : progressingGraphCollectives_) {
+    auto it = collIdMap_.find(collId);
+    if (it != collIdMap_.end()) {
+      actions.insert(
+          {it->second->event.get(), PendingActionType::kProgressing, now});
     }
   }
-  return folly::unit;
+}
+
+void CollTrace::pollEagerEvents(
+    std::multiset<PendingAction>& actions) noexcept {
+  {
+    // drain pendingTraceColls_ into eagerEvents_
+    std::unique_ptr<CollTraceEvent> event;
+    while (pendingTraceColls_.read(event)) {
+      if (event == nullptr) {
+        XLOG_FIRST_N(
+            ERR, 2, logPrefix_, ": Got null event from pendingTrace queue");
+        continue;
+      }
+      eagerEvents_.push_back(std::move(event));
+    }
+  }
+
+  static constexpr auto kEpoch = ICollWaitEvent::system_clock_time_point{};
+
+  for (auto& event : eagerEvents_) {
+    if (event == nullptr) {
+      continue;
+    }
+
+    auto& timing = event->collRecord->getTimingInfo();
+    bool started = timing.getCollStartTs() != kEpoch;
+    bool ended = timing.getCollEndTs() != kEpoch;
+
+    if (!started) {
+      if (event->waitEvent->waitCollStart(config_.maxCheckCancelInterval)
+              .value_or(false)) {
+        auto now = std::chrono::system_clock::now();
+        auto startTimeRes = event->waitEvent->getCollStartTime();
+        auto startTs = startTimeRes.hasValue() ? startTimeRes.value() : now;
+        timing.setCollStartTs(startTs);
+        actions.insert({event.get(), PendingActionType::kStart, startTs});
+        started = true;
+      } else {
+        // Fire progressing even before start so the watchdog plugin can
+        // detect pre-start timeouts and async errors.
+        actions.insert(
+            {event.get(),
+             PendingActionType::kProgressing,
+             std::chrono::system_clock::now()});
+      }
+    }
+
+    if (started && !ended) {
+      if (event->waitEvent->waitCollEnd(config_.maxCheckCancelInterval)
+              .value_or(false)) {
+        auto now = std::chrono::system_clock::now();
+        auto endTimeRes = event->waitEvent->getCollEndTime();
+        auto endTs = endTimeRes.hasValue() ? endTimeRes.value() : now;
+        timing.setCollEndTs(endTs);
+        actions.insert({event.get(), PendingActionType::kEnd, endTs});
+      } else {
+        actions.insert(
+            {event.get(),
+             PendingActionType::kProgressing,
+             std::chrono::system_clock::now()});
+      }
+    }
+  }
+}
+
+void CollTrace::processCompletedEvents(
+    std::multiset<PendingAction>& actions) noexcept {
+  for (auto& action : actions) {
+    switch (action.type) {
+      case PendingActionType::kScheduleAndStart: {
+        // for graph collectives, there is no actual scheduling
+        // so we just fire the before/after callbacks here
+        // in-case plugins depend on them
+        triggerPlugins<&ICollTracePlugin::beforeCollKernelScheduled>(
+            plugins_, *action.event);
+        triggerPlugins<&ICollTracePlugin::afterCollKernelScheduled>(
+            plugins_, *action.event);
+        [[fallthrough]];
+      }
+      case PendingActionType::kStart: {
+        if (lastCollEndTime_.has_value()) [[likely]] {
+          action.event->collRecord->getTimingInfo().setPreviousCollEndTs(
+              lastCollEndTime_.value());
+        }
+        triggerPlugins<&ICollTracePlugin::afterCollKernelStart>(
+            plugins_, *action.event);
+        break;
+      }
+      case PendingActionType::kEnd: {
+        // Fire progressing one last time before end so plugins (e.g.
+        // watchdog) can check async errors even for fast-completing
+        // collectives. This matches the old behavior where
+        // collEventProgressing was called unconditionally inside the
+        // waitCollEnd loop.
+        triggerPlugins<&ICollTracePlugin::collEventProgressing>(
+            plugins_, *action.event);
+        triggerPlugins<&ICollTracePlugin::afterCollKernelEnd>(
+            plugins_, *action.event);
+        lastCollEndTime_ =
+            action.event->collRecord->getTimingInfo().getCollEndTs();
+        break;
+      }
+      case PendingActionType::kProgressing: {
+        triggerPlugins<&ICollTracePlugin::collEventProgressing>(
+            plugins_, *action.event);
+        break;
+      }
+    }
+  }
+
+  // clean up completed eager events...
+  static constexpr auto kEpoch = ICollWaitEvent::system_clock_time_point{};
+  std::erase_if(
+      eagerEvents_, [this](const std::unique_ptr<CollTraceEvent>& event) {
+        if (event == nullptr) {
+          return true;
+        }
+        if (event->collRecord->getTimingInfo().getCollEndTs() == kEpoch) {
+          return false;
+        }
+        auto it = eventToHandleMap_.find(event.get());
+        if (it != eventToHandleMap_.end()) {
+          it->second->invalidate();
+          eventToHandleMap_.erase(it);
+        }
+        return true;
+      });
 }
 
 void CollTrace::collTraceThread(
@@ -250,65 +622,40 @@ void CollTrace::collTraceThread(
         "{}: Error in calling colltrace thread setup function: {}",
         logPrefix_,
         res.error().message);
+    // Unblock the constructor so it doesn't hang forever.
+    threadStarted_.count_down();
     return;
   }
 
   XLOGF(INFO, "{}: CollTrace thread STARTED", logPrefix_);
 
+  bool initialized = false;
+
   while (!isThreadCancelled()) {
-    // ----- Get the next pending event from the MPMC Queue -----
-    auto eventMaybe = getNextPendingEvent();
-    SAFE_RETURN_POINT(isThreadCancelled());
+    std::multiset<PendingAction> actions;
 
-    if (eventMaybe.hasError()) {
-      XLOG_FIRST_N(
-          ERR,
-          2,
-          logPrefix_,
-          ": Got error from pendingTrace queue: ",
-          eventMaybe.error().message);
-      continue;
+    pollGraphEvents(actions);
+    pollEagerEvents(actions);
+    processCompletedEvents(actions);
+
+    if (!initialized) {
+      threadStarted_.count_down();
+      initialized = true;
     }
 
-    // ----- Get the event, Setup guard for handle -----
-    auto event = std::move(eventMaybe.value());
-    // Always invalidate the handle to the event to ensure we don't reference
-    // to it after the event is destroyed
-    auto handleReleaseGuard = folly::makeGuard([&event, this]() {
-      auto it = eventToHandleMap_.find(event.get());
-      if (it != eventToHandleMap_.end()) {
-        it->second->invalidate();
-        eventToHandleMap_.erase(it);
+    if (actions.empty()) {
+      // No active events. Block on the MPMC queue so incoming eager events
+      // wake the thread immediately instead of sleeping for the full
+      // interval. Graph events are polled at the top of the next iteration.
+      std::unique_ptr<CollTraceEvent> event;
+      auto deadline =
+          std::chrono::steady_clock::now() + config_.maxCheckCancelInterval;
+      if (pendingTraceColls_.tryReadUntil(deadline, event)) {
+        if (event != nullptr) {
+          eagerEvents_.push_back(std::move(event));
+        }
       }
-    });
-
-    if (lastCollEndTime_.has_value()) [[likely]] {
-      event->collRecord->getTimingInfo().setPreviousCollEndTs(
-          lastCollEndTime_.value());
     }
-
-    XLOGF(DBG2, "Start tracking collId {}", event->collRecord->getCollId());
-
-    // ----- Track the start of the event -----
-    EXPECT_CHECK_CONTINUE_LOG_FIRST_N(waitCollStart(*event), 2);
-    XLOGF(DBG2, "CollId {} started kernel", event->collRecord->getCollId());
-    SAFE_RETURN_POINT(isThreadCancelled());
-
-    event->collRecord->getTimingInfo().setCollStartTs(
-        std::chrono::system_clock::now());
-
-    triggerPlugins<&ICollTracePlugin::afterCollKernelStart>(plugins_, *event);
-
-    // ----- Track the end of the event -----
-    EXPECT_CHECK_CONTINUE_LOG_FIRST_N(waitCollEnd(*event), 2);
-    XLOGF(DBG2, "CollId {} finished kernel", event->collRecord->getCollId());
-    SAFE_RETURN_POINT(isThreadCancelled());
-
-    auto endTs = std::chrono::system_clock::now();
-    event->collRecord->getTimingInfo().setCollEndTs(endTs);
-    lastCollEndTime_ = endTs; // Update the last coll end time
-
-    triggerPlugins<&ICollTracePlugin::afterCollKernelEnd>(plugins_, *event);
   }
 }
 

--- a/comms/utils/colltrace/CollTrace.h
+++ b/comms/utils/colltrace/CollTrace.h
@@ -2,18 +2,34 @@
 
 #pragma once
 
+#include <chrono>
+#include <latch>
+#include <mutex>
+#include <set>
 #include <thread>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 #include <folly/MPMCQueue.h>
 #include <folly/concurrency/ConcurrentHashMap.h>
 
+#include "comms/utils/HRDWRingBuffer.h"
+#include "comms/utils/HRDWRingBufferReader.h"
 #include "comms/utils/colltrace/CollTraceEvent.h"
 #include "comms/utils/colltrace/CollTraceHandle.h"
 #include "comms/utils/colltrace/CollTraceInterface.h"
 #include "comms/utils/colltrace/CollTracePlugin.h"
+#include "comms/utils/colltrace/GraphCollTraceEvent.h"
 #include "comms/utils/commSpecs.h"
 
+struct CUstream_st;
+
 namespace meta::comms::colltrace {
+
+struct GraphCollTraceState;
+struct GraphCollectiveEntry;
+class GraphCudaWaitEvent;
 
 struct CollTraceConfig {
   static constexpr ::size_t kDefaultMaxPendingQueueSize{1024};
@@ -30,6 +46,31 @@ struct CollTraceConfig {
   // If we have too many pending events, we will start dropping events.
   // 1024 should be enough for most of the cases.
   ::size_t maxPendingQueueSize{kDefaultMaxPendingQueueSize};
+};
+
+// Action types for the unified polling pipeline.
+enum class PendingActionType {
+  kScheduleAndStart, // Graph replay started — fire scheduled + start plugins
+  kStart, // Eager collective started — fire start plugin
+  kProgressing, // Heartbeat — fire progressing plugin (watchdog)
+  kEnd, // Collective ended — fire end plugin
+};
+
+struct PendingAction {
+  CollTraceEvent* event{nullptr};
+  PendingActionType type{};
+  std::chrono::system_clock::time_point timestamp{};
+
+  // ordered by timestamp, or by action type if timestamp is the same
+  // which will ensure that for a given collective, we always fire the
+  // the start plugin before the progressing plugin, and the progressing plugin
+  // before the end plugin.
+  bool operator<(const PendingAction& other) const {
+    if (timestamp != other.timestamp) {
+      return timestamp < other.timestamp;
+    }
+    return type < other.type;
+  }
 };
 
 class CollTrace : public ICollTrace {
@@ -56,7 +97,7 @@ class CollTrace : public ICollTrace {
   // Enqueue a collective event to be traced. Note that now this will first in
   // the pending enqueue map. Then it will move the queue for pending execution
   // once the collective is scheduled.
-  CommsMaybe<std::shared_ptr<CollTraceHandle>> recordCollective(
+  CommsMaybe<std::shared_ptr<ICollTraceHandle>> recordCollective(
       std::unique_ptr<ICollMetadata> metadata,
       std::unique_ptr<ICollWaitEvent> waitEvent) noexcept override;
 
@@ -69,6 +110,12 @@ class CollTrace : public ICollTrace {
       CollTraceHandleTriggerState state) noexcept override;
 
  private:
+  // Internal impl for graph-captured collectives, called when
+  // recordCollective detects a GraphCudaWaitEvent.
+  CommsMaybe<std::shared_ptr<ICollTraceHandle>> recordGraphCollectiveImpl(
+      std::unique_ptr<ICollMetadata> metadata,
+      std::unique_ptr<ICollWaitEvent> waitEvent) noexcept;
+
   /****************************************************************************
    * Start of Private Methods for CollTrace thread. All of these methods should
    * be called from the CollTrace thread only. And they should all support
@@ -76,14 +123,25 @@ class CollTrace : public ICollTrace {
    ***************************************************************************/
   bool isThreadCancelled() const noexcept;
 
-  CommsMaybe<std::unique_ptr<CollTraceEvent>> getNextPendingEvent() noexcept;
-
-  CommsMaybeVoid waitCollStart(CollTraceEvent& event) noexcept;
-
-  CommsMaybeVoid waitCollEnd(CollTraceEvent& event) noexcept;
-
   void collTraceThread(
       const std::function<CommsMaybeVoid(void)>& threadSetupFunc);
+
+  // Poll all active graph-captured events (non-blocking), appending completed
+  // or progressing actions to the provided vector.
+  void pollGraphEvents(std::multiset<PendingAction>& actions) noexcept;
+
+  // Get or create the per-graph state for a stream currently in graph capture.
+  // Installs a cleanup user object on first call per graph so we know when the
+  // graph is destroyed.
+  std::shared_ptr<GraphCollTraceState> getOrCreateGraphState(
+      CUstream_st* stream);
+
+  // Non-blocking drain of MPMC queue and poll of in-flight eager events,
+  // appending completed or progressing actions to the provided vector.
+  void pollEagerEvents(std::multiset<PendingAction>& actions) noexcept;
+  // for all temporarly-ordered pending actions fire plugins and clean
+  // up completed eager events.
+  void processCompletedEvents(std::multiset<PendingAction>& actions) noexcept;
 
   // **** Start of Private Member Variables ****
   CollTraceConfig config_;
@@ -114,13 +172,43 @@ class CollTrace : public ICollTrace {
   std::unordered_map<std::string, ICollTracePlugin&> pluginByName_;
   std::vector<std::unique_ptr<ICollTracePlugin>> plugins_;
 
-  // CollTrace internal collective id. Should always increment monotonically
-  std::atomic<int64_t> collId_{0};
+  // CollTrace internal collective id. Should always increment monotonically.
+  // uint32_t to match GraphCollTraceEvent.collId without truncation.
+  std::atomic<uint32_t> collId_{0};
 
   // Should only be accessed from CollTrace thread
   std::optional<ICollWaitEvent::system_clock_time_point> lastCollEndTime_;
 
+  // Per-graph state map — maps CUDA graph IDs to their GraphCollTraceState.
+  // Accessed from capture threads (recordCollective) and the poll thread
+  // (pollGraphEvents). Protected by graphStatesMutex_.
+  std::mutex graphStateMutex_;
+  std::unordered_map<unsigned long long, std::shared_ptr<GraphCollTraceState>>
+      graphStateMap_;
+
+  // Single shared ring buffer for ALL cuda graphs. RAII-managed via
+  // HRDWRingBuffer (mapped pinned memory, GPU-writable, CPU-readable).
+  std::optional<HRDWRingBuffer<GraphCollTraceEvent>> ringBuffer_;
+  // CPU-side reader for the shared ring buffer (poll thread only).
+  std::optional<HRDWRingBufferReader<GraphCollTraceEvent>> ringReader_;
+  // Map from collId to GraphCollectiveEntry* for fast lookup during polling.
+  // Only accessed from the colltrace thread (no mutex needed). Entries are
+  // added under graphStatesMutex_ and then inserted here on first poll.
+  std::unordered_map<uint32_t, GraphCollectiveEntry*> collIdMap_;
+  // CollIds that have seen a start event but not yet a matching end event.
+  // Used to emit periodic kProgressing actions so the watchdog plugin can
+  // detect hung graph collectives.
+  std::unordered_set<uint32_t> progressingGraphCollectives_;
+
+  // Eager events being polled by the colltrace thread. Only accessed from
+  // the colltrace thread — no mutex needed.
+  std::vector<std::unique_ptr<CollTraceEvent>> eagerEvents_;
+
   std::atomic_flag threadShouldStop_;
+  // Signaled by the poll thread after its first loop iteration completes.
+  // The constructor waits on this so the poll thread is actively polling
+  // before any graph replays can fire.
+  std::latch threadStarted_{1};
   // Always keep this thread as the last member variable to ensure that it is
   // initialized after all the other member variables.
   std::thread traceCollThread_;

--- a/comms/utils/colltrace/CollTraceInterface.h
+++ b/comms/utils/colltrace/CollTraceInterface.h
@@ -16,7 +16,10 @@ class ICollTrace {
  public:
   virtual ~ICollTrace() = default;
 
-  virtual CommsMaybe<std::shared_ptr<CollTraceHandle>> recordCollective(
+  // Record a collective event. If the waitEvent is a GraphCudaWaitEvent,
+  // the collective is recorded for graph-mode polling. Otherwise it's
+  // recorded as an eager collective.
+  virtual CommsMaybe<std::shared_ptr<ICollTraceHandle>> recordCollective(
       std::unique_ptr<ICollMetadata> metadata,
       std::unique_ptr<ICollWaitEvent> waitEvent) noexcept = 0;
 

--- a/comms/utils/colltrace/CudaWaitEvent.cc
+++ b/comms/utils/colltrace/CudaWaitEvent.cc
@@ -48,9 +48,13 @@ CudaReferencePoint::CudaReferencePoint() {
 
 CommsMaybe<ICollWaitEvent::system_clock_time_point>
 CudaReferencePoint::getTimeViaEvent(const CudaEvent& event) {
+  return getTimeViaEvent(event.get());
+}
+
+CommsMaybe<ICollWaitEvent::system_clock_time_point>
+CudaReferencePoint::getTimeViaEvent(cudaEvent_t event) {
   float offsetMs;
-  CUDA_CHECK_EXPECTED(
-      cudaEventElapsedTime(&offsetMs, this->event_, event.get()));
+  CUDA_CHECK_EXPECTED(cudaEventElapsedTime(&offsetMs, this->event_, event));
   auto eventTime = this->time_ +
       std::chrono::duration_cast<std::chrono::microseconds>(
                        std::chrono::duration<float, std::milli>{offsetMs});

--- a/comms/utils/colltrace/CudaWaitEvent.h
+++ b/comms/utils/colltrace/CudaWaitEvent.h
@@ -22,6 +22,7 @@ class CudaReferencePoint {
   CudaReferencePoint();
 
   CommsMaybe<system_clock_time_point> getTimeViaEvent(const CudaEvent& event);
+  CommsMaybe<system_clock_time_point> getTimeViaEvent(cudaEvent_t event);
 
  private:
   // We intentionally NOT using the RAII version to avoid segfault when calling

--- a/comms/utils/colltrace/GraphCollTraceEvent.h
+++ b/comms/utils/colltrace/GraphCollTraceEvent.h
@@ -1,0 +1,22 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// Typed event for the graph-initiated colltrace ring buffer.
+// Replaces manual bit-packing into uint64_t.
+
+#pragma once
+
+#include <cstdint>
+
+namespace meta::comms::colltrace {
+
+enum class GraphCollTracePhase : uint8_t {
+  kStart = 0,
+  kEnd = 1,
+};
+
+struct GraphCollTraceEvent {
+  uint32_t collId;
+  GraphCollTracePhase phase;
+};
+
+} // namespace meta::comms::colltrace

--- a/comms/utils/colltrace/GraphCollTraceHandle.h
+++ b/comms/utils/colltrace/GraphCollTraceHandle.h
@@ -1,0 +1,64 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include "comms/utils/colltrace/CollRecord.h"
+#include "comms/utils/colltrace/CollTraceHandle.h"
+#include "comms/utils/colltrace/CollWaitEvent.h"
+#include "comms/utils/commSpecs.h"
+
+namespace meta::comms::colltrace {
+
+// Handle for graph-captured collectives. Unlike CollTraceHandle, this does
+// not interact with the serial queue. It delegates before/after kernel
+// scheduling to the underlying ICollWaitEvent and is otherwise a no-op.
+class GraphCollTraceHandle : public ICollTraceHandle {
+ public:
+  explicit GraphCollTraceHandle(
+      ICollWaitEvent* waitEvent,
+      std::shared_ptr<ICollRecord> record)
+      : waitEvent_(waitEvent), record_(std::move(record)) {}
+
+  ~GraphCollTraceHandle() override = default;
+
+  CommsMaybeVoid trigger(CollTraceHandleTriggerState state) noexcept override {
+    if (waitEvent_ == nullptr) {
+      return folly::Unit{};
+    }
+    switch (state) {
+      case CollTraceHandleTriggerState::BeforeEnqueueKernel:
+        return waitEvent_->beforeCollKernelScheduled();
+      case CollTraceHandleTriggerState::AfterEnqueueKernel:
+        return waitEvent_->afterCollKernelScheduled();
+      case CollTraceHandleTriggerState::KernelStarted:
+        return waitEvent_->signalCollStart();
+      case CollTraceHandleTriggerState::KernelFinished:
+        return waitEvent_->signalCollEnd();
+      case CollTraceHandleTriggerState::NumTriggerStates:
+        return folly::Unit{};
+    }
+    return folly::Unit{};
+  }
+
+  CommsMaybeVoid triggerPlugin(
+      std::string /* pluginName */,
+      folly::dynamic /* params */) noexcept override {
+    return folly::Unit{};
+  }
+
+  CommsMaybe<std::shared_ptr<ICollRecord>> getCollRecord() noexcept override {
+    return record_;
+  }
+
+  CommsMaybeVoid invalidate() noexcept override {
+    waitEvent_ = nullptr;
+    record_ = nullptr;
+    return folly::Unit{};
+  }
+
+ private:
+  ICollWaitEvent* waitEvent_;
+  std::shared_ptr<ICollRecord> record_;
+};
+
+} // namespace meta::comms::colltrace

--- a/comms/utils/colltrace/GraphCollTraceState.h
+++ b/comms/utils/colltrace/GraphCollTraceState.h
@@ -1,0 +1,59 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <atomic>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+#include <cuda_runtime.h>
+
+#include "comms/utils/colltrace/CollTraceEvent.h"
+
+namespace meta::comms::colltrace {
+
+class GraphCudaWaitEvent;
+class ICollTraceHandle;
+
+// Tracking entry for a graph-captured collective.
+struct GraphCollectiveEntry {
+  // Owned by the CollTraceEvent below (unique_ptr), which we also own.
+  GraphCudaWaitEvent* graphWaitEvent;
+  std::unique_ptr<CollTraceEvent> event;
+  // Weak reference to the handle returned to the caller. Used to invalidate
+  // the handle when the CUDA graph is destroyed, preventing use-after-free
+  // of the raw GraphCudaWaitEvent pointer held by the handle.
+  std::weak_ptr<ICollTraceHandle> handle;
+};
+
+// Per-graph coordinator for all graph-captured collectives. Manages CUDA
+// resources for cleanup when the graph is destroyed.
+//
+// Timestamp streams and dependency events are per-collective (owned by
+// GraphCudaWaitEvent) so concurrent collectives don't serialize.
+//
+// The ring buffer and write index are owned by the CollTrace instance and
+// shared across ALL graphs. Each collective atomically claims a slot during
+// replay so events are interleaved but never lost (as long as the poll thread
+// keeps up within ringSize replays).
+//
+// Ref-counted via shared_ptr — the CUDA graph destruction callback holds a
+// copy to keep this alive until it can set the released flag.
+struct GraphCollTraceState {
+  // Set by the CUDA graph destruction callback. The poll thread checks this
+  // to detect when a graph has been destroyed and stop tracking it.
+  std::atomic_bool graph_destructed{false};
+  // All collectives captured in this graph, indexed by collId.
+  // Populated during graph capture, read by the poll thread.
+  std::unordered_map<uint32_t, GraphCollectiveEntry> collectives;
+
+  GraphCollTraceState() = default;
+  ~GraphCollTraceState() = default;
+  GraphCollTraceState(const GraphCollTraceState&) = delete;
+  GraphCollTraceState& operator=(const GraphCollTraceState&) = delete;
+  GraphCollTraceState(GraphCollTraceState&&) = delete;
+  GraphCollTraceState& operator=(GraphCollTraceState&&) = delete;
+};
+
+} // namespace meta::comms::colltrace

--- a/comms/utils/colltrace/GraphCudaWaitEvent.cc
+++ b/comms/utils/colltrace/GraphCudaWaitEvent.cc
@@ -1,0 +1,165 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/utils/colltrace/GraphCudaWaitEvent.h"
+
+#include <cstring>
+
+#include <cuda_runtime.h> // @manual=third-party//cuda:cuda-lazy
+#include "comms/utils/colltrace/GpuClockCalibration.h"
+
+#include <folly/Unit.h>
+#include <folly/logging/xlog.h>
+
+#include "comms/utils/CudaRAII.h"
+#include "comms/utils/HRDWRingBuffer.h"
+#include "comms/utils/checks.h"
+
+namespace meta::comms::colltrace {
+
+GraphCudaWaitEvent::GraphCudaWaitEvent(cudaStream_t stream, uint32_t collId)
+    : stream_(stream),
+      collId_(collId),
+      enqueueTime_(std::chrono::system_clock::now()) {
+  // Eagerly initialize the globaltimer calibration singleton so that the
+  // calibration kernel doesn't fire during graph capture.
+  GlobaltimerCalibration::get();
+
+  // Create per-collective CUDA resources using relaxed capture mode so
+  // they don't interfere with the graph capture in progress.
+  StreamCaptureModeGuard guard{cudaStreamCaptureModeRelaxed};
+  CUDA_CHECK(cudaStreamCreate(&timestampStream_));
+  CUDA_CHECK(cudaEventCreateWithFlags(&depEvent_, cudaEventDisableTiming));
+}
+
+GraphCudaWaitEvent::~GraphCudaWaitEvent() {
+  if (timestampStream_) {
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaStreamDestroy(timestampStream_);
+  }
+  if (depEvent_) {
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaEventDestroy(depEvent_);
+  }
+}
+
+void GraphCudaWaitEvent::attachRingBuffer(
+    HRDWRingBuffer<GraphCollTraceEvent>* ringBuffer) noexcept {
+  ringBuffer_ = ringBuffer;
+}
+
+CommsMaybeVoid GraphCudaWaitEvent::beforeCollKernelScheduled() noexcept {
+  // Fork: collective stream -> timestamp stream so the start kernel is
+  // captured into the graph. We use cudaStreamWaitEvent to bring the
+  // timestamp stream into the capture with a dependency on the main
+  // stream's current position (right before the collective launches).
+  CUDA_CHECK_EXPECTED(cudaEventRecord(depEvent_, stream_));
+  CUDA_CHECK_EXPECTED(cudaStreamWaitEvent(timestampStream_, depEvent_));
+
+  // Launch the start timestamp kernel on this collective's timestamp stream.
+  CUDA_CHECK_EXPECTED(ringBuffer_->write(
+      timestampStream_,
+      GraphCollTraceEvent{collId_, GraphCollTracePhase::kStart}));
+
+  return folly::unit;
+}
+
+CommsMaybeVoid GraphCudaWaitEvent::afterCollKernelScheduled() noexcept {
+  // Fork: collective stream -> timestamp stream. This DAG edge ensures the
+  // end timestamp kernel fires only after the collective completes.
+  CUDA_CHECK_EXPECTED(cudaEventRecord(depEvent_, stream_));
+  CUDA_CHECK_EXPECTED(cudaStreamWaitEvent(timestampStream_, depEvent_));
+
+  // Launch the end timestamp kernel on this collective's timestamp stream.
+  CUDA_CHECK_EXPECTED(ringBuffer_->write(
+      timestampStream_,
+      GraphCollTraceEvent{collId_, GraphCollTracePhase::kEnd}));
+
+  // Save the collective stream's capture deps before the rejoin.
+  cudaStreamCaptureStatus status;
+  const cudaGraphNode_t* preRejoinDeps = nullptr;
+  const cudaGraphEdgeData* preRejoinEdgeData = nullptr;
+  size_t numPreRejoinDeps = 0;
+#if CUDART_VERSION >= 13000
+  CUDA_CHECK_EXPECTED(cudaStreamGetCaptureInfo(
+      stream_,
+      &status,
+      nullptr,
+      nullptr,
+      &preRejoinDeps,
+      &preRejoinEdgeData,
+      &numPreRejoinDeps));
+#else
+  CUDA_CHECK_EXPECTED(cudaStreamGetCaptureInfo_v2(
+      stream_, &status, nullptr, nullptr, &preRejoinDeps, &numPreRejoinDeps));
+#endif
+  std::vector<cudaGraphNode_t> savedDeps(
+      preRejoinDeps, preRejoinDeps + numPreRejoinDeps);
+  std::vector<cudaGraphEdgeData> savedEdgeData(
+      preRejoinEdgeData,
+      preRejoinEdgeData ? preRejoinEdgeData + numPreRejoinDeps
+                        : preRejoinEdgeData);
+
+  // Rejoin: timestamp stream -> collective stream. Required by
+  // cudaStreamEndCapture (all forked streams must rejoin). We immediately
+  // restore the pre-rejoin deps afterward so the rejoin node exists in
+  // the graph DAG but is NOT a dependency of subsequent ops on the
+  // collective stream. This means non-traced ops between collectives
+  // won't be serialized behind the end kernel.
+  CUDA_CHECK_EXPECTED(cudaEventRecord(depEvent_, timestampStream_));
+  CUDA_CHECK_EXPECTED(cudaStreamWaitEvent(stream_, depEvent_));
+
+  // Immediately undo: restore pre-rejoin deps so the main stream
+  // doesn't carry the endK dependency forward.
+  CUDA_CHECK_EXPECTED(cudaStreamUpdateCaptureDependencies(
+      stream_,
+      savedDeps.data(),
+#if CUDART_VERSION >= 13000
+      savedEdgeData.empty() ? nullptr : savedEdgeData.data(),
+#endif
+      savedDeps.size(),
+      cudaStreamSetCaptureDependencies));
+
+  return folly::unit;
+}
+
+CommsMaybe<bool> GraphCudaWaitEvent::waitCollStart(
+    std::chrono::milliseconds /* sleepTimeMs */) noexcept {
+  return false;
+}
+
+CommsMaybe<bool> GraphCudaWaitEvent::waitCollEnd(
+    std::chrono::milliseconds /*sleepTimeMs*/) noexcept {
+  // Graph completion is detected via the ring buffer poll thread, not here.
+  return false;
+}
+
+CommsMaybeVoid GraphCudaWaitEvent::signalCollStart() noexcept {
+  return folly::unit;
+}
+
+CommsMaybeVoid GraphCudaWaitEvent::signalCollEnd() noexcept {
+  return folly::unit;
+}
+
+CommsMaybe<GraphCudaWaitEvent::system_clock_time_point>
+GraphCudaWaitEvent::getCollEnqueueTime() noexcept {
+  return enqueueTime_;
+}
+
+CommsMaybe<GraphCudaWaitEvent::system_clock_time_point>
+GraphCudaWaitEvent::getCollStartTime() noexcept {
+  // Graph timing is read from the ring buffer by the poll thread and set
+  // directly on CollRecord — this method should not be called.
+  return folly::makeUnexpected(CommsError(
+      "GraphCudaWaitEvent: timing is provided by the poll thread, not via getCollStartTime",
+      commInternalError));
+}
+
+CommsMaybe<GraphCudaWaitEvent::system_clock_time_point>
+GraphCudaWaitEvent::getCollEndTime() noexcept {
+  return folly::makeUnexpected(CommsError(
+      "GraphCudaWaitEvent: timing is provided by the poll thread, not via getCollEndTime",
+      commInternalError));
+}
+
+} // namespace meta::comms::colltrace

--- a/comms/utils/colltrace/GraphCudaWaitEvent.h
+++ b/comms/utils/colltrace/GraphCudaWaitEvent.h
@@ -1,0 +1,87 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda_runtime.h>
+
+#include "comms/utils/HRDWRingBuffer.h"
+#include "comms/utils/colltrace/CollWaitEvent.h"
+#include "comms/utils/colltrace/GraphCollTraceEvent.h"
+#include "comms/utils/colltrace/GraphCollTraceState.h"
+
+namespace meta::comms::colltrace {
+
+// Default shared ring buffer size — must be a power of 2.
+// At 24 bytes per entry, 65536 entries = 1.5MB per communicator.
+inline constexpr uint32_t kDefaultRingSize =
+    65536; // NOLINT(misc-unused-using-decls)
+
+// Graph-aware wait event that uses device-side globaltimer reads and a
+// shared ring buffer for precise per-replay timing. All collectives across
+// ALL CUDA graphs share a single ring buffer (owned by CollTrace) and
+// atomically claim slots via a shared write index.
+//
+// Each GraphCudaWaitEvent owns its own timestamp stream and dependency event.
+// Per-collective streams ensure that concurrent collectives (e.g.,
+// signal/wait RMA ops) don't serialize their timestamp kernels.
+//
+// No back-pressure — if the poll thread falls behind by more than ringSize
+// replays across all collectives, data loss is detected and logged.
+class GraphCudaWaitEvent : public ICollWaitEvent {
+ public:
+  explicit GraphCudaWaitEvent(cudaStream_t stream, uint32_t collId = 0);
+
+  ~GraphCudaWaitEvent() override;
+
+  GraphCudaWaitEvent(const GraphCudaWaitEvent&) = delete;
+  GraphCudaWaitEvent& operator=(const GraphCudaWaitEvent&) = delete;
+  GraphCudaWaitEvent(GraphCudaWaitEvent&&) = delete;
+  GraphCudaWaitEvent& operator=(GraphCudaWaitEvent&&) = delete;
+
+  CommsMaybeVoid beforeCollKernelScheduled() noexcept override;
+  CommsMaybeVoid afterCollKernelScheduled() noexcept override;
+
+  CommsMaybe<bool> waitCollStart(
+      std::chrono::milliseconds sleepTimeMs) noexcept override;
+  CommsMaybe<bool> waitCollEnd(
+      std::chrono::milliseconds sleepTimeMs) noexcept override;
+
+  CommsMaybeVoid signalCollStart() noexcept override;
+  CommsMaybeVoid signalCollEnd() noexcept override;
+
+  CommsMaybe<system_clock_time_point> getCollEnqueueTime() noexcept override;
+  CommsMaybe<system_clock_time_point> getCollStartTime() noexcept override;
+  CommsMaybe<system_clock_time_point> getCollEndTime() noexcept override;
+
+  void attachRingBuffer(
+      HRDWRingBuffer<GraphCollTraceEvent>* ringBuffer) noexcept;
+
+  cudaStream_t getStream() const noexcept {
+    return stream_;
+  }
+
+  uint32_t getCollId() const noexcept {
+    return collId_;
+  }
+
+  void setCollId(uint32_t collId) noexcept {
+    collId_ = collId;
+  }
+
+ private:
+  cudaStream_t stream_;
+  uint32_t collId_;
+  system_clock_time_point enqueueTime_;
+
+  // per-collective timestamp stream — runs in parallel with the collective
+  // stream. each collective gets its own stream so concurrent collectives
+  // (e.g., signal/wait) don't serialize their timestamp kernels.
+  cudaStream_t timestampStream_{nullptr};
+  // per-collective dependency event for fork/join edges.
+  cudaEvent_t depEvent_{nullptr};
+
+  // owned by CollTrace, shared across ALL graphs. set via attachRingBuffer().
+  HRDWRingBuffer<GraphCollTraceEvent>* ringBuffer_{nullptr};
+};
+
+} // namespace meta::comms::colltrace

--- a/comms/utils/colltrace/HRDWRingBufferInstantiations.cu
+++ b/comms/utils/colltrace/HRDWRingBufferInstantiations.cu
@@ -1,0 +1,18 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// Explicit template instantiations for HRDWRingBuffer typed kernel launches.
+// The template definition lives in HRDWRingBuffer.h.
+// Add new DataT types here and in HRDWRingBufferInstantiations.cuh.
+
+#include "comms/utils/colltrace/HRDWRingBufferInstantiations.cuh"
+
+namespace meta::comms::colltrace {
+
+template cudaError_t launchRingBufferWrite<GraphCollTraceEvent>(
+    cudaStream_t,
+    HRDWEntry<GraphCollTraceEvent>*,
+    uint64_t*,
+    uint32_t,
+    GraphCollTraceEvent);
+
+} // namespace meta::comms::colltrace

--- a/comms/utils/colltrace/HRDWRingBufferInstantiations.cuh
+++ b/comms/utils/colltrace/HRDWRingBufferInstantiations.cuh
@@ -1,0 +1,23 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// Explicit template instantiation declarations for HRDWRingBuffer.
+// Include this header from host code that uses HRDWRingBuffer::write().
+// Add new DataT types here and in HRDWRingBufferInstantiations.cu.
+
+// NOLINTNEXTLINE(clang-diagnostic-pragma-once-outside-header)
+#pragma once
+
+#include "comms/utils/HRDWRingBuffer.h"
+#include "comms/utils/colltrace/GraphCollTraceEvent.h"
+
+namespace meta::comms::colltrace {
+
+// --- GraphCollTraceEvent (graph-initiated colltrace) ---
+extern template cudaError_t launchRingBufferWrite<GraphCollTraceEvent>(
+    cudaStream_t,
+    HRDWEntry<GraphCollTraceEvent>*,
+    uint64_t*,
+    uint32_t,
+    GraphCollTraceEvent);
+
+} // namespace meta::comms::colltrace

--- a/comms/utils/colltrace/tests/CollTraceUT.cc
+++ b/comms/utils/colltrace/tests/CollTraceUT.cc
@@ -1,5 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#include <set>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -305,10 +307,10 @@ TEST_F(CollTraceTest, PluginCallbacks) {
   EXPECT_VALUE(
       handle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel));
 
-  EXPECT_CALL(*mockPluginPtr, collEventProgressing(_)).Times(AtLeast(1));
-  // Sleep briefly to trigger collEventProgressing
-  std::this_thread::sleep_for(std::chrono::milliseconds(20));
   EXPECT_VALUE(handle->trigger(CollTraceHandleTriggerState::KernelStarted));
+
+  // wait for progressing to fire after started
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
 
   EXPECT_CALL(*mockPluginPtr, collEventProgressing(_)).Times(AtLeast(1));
   // Sleep briefly to trigger collEventProgressing
@@ -456,4 +458,172 @@ TEST_F(CollTraceTest, CheckHandleValidityOverMultipleEnqueues) {
       EXPECT_NE(res.value(), nullptr);
     }
   }
+}
+
+// Test that collEventProgressing fires only for the collective that has
+// started but not finished, verifying per-collective start detection.
+TEST_F(CollTraceTest, PerCollectiveProgressingForInFlightCollective) {
+  // Set up coll1 with controllable start/end signals so we can hold it
+  // in the "started but not finished" state.
+  auto metadata1 = std::make_unique<::testing::StrictMock<MockCollMetadata>>();
+  auto waitEvent1 = std::make_unique<NiceMock<MockCollWaitEvent>>();
+
+  std::atomic_flag coll1Started;
+  std::atomic_flag coll1Ended;
+  {
+    ::testing::InSequence seq;
+    EXPECT_CALL(*waitEvent1, beforeCollKernelScheduled())
+        .WillOnce(Return(folly::unit));
+    EXPECT_CALL(*waitEvent1, afterCollKernelScheduled())
+        .WillOnce(Return(folly::unit));
+    EXPECT_CALL(*waitEvent1, waitCollStart(_)).WillRepeatedly([&]() {
+      return coll1Started.test();
+    });
+    EXPECT_CALL(*waitEvent1, waitCollEnd(_)).WillRepeatedly([&]() {
+      return coll1Ended.test();
+    });
+  }
+  EXPECT_CALL(*waitEvent1, signalCollStart()).WillOnce([&]() {
+    coll1Started.test_and_set();
+    return folly::unit;
+  });
+  EXPECT_CALL(*waitEvent1, signalCollEnd()).WillOnce([&]() {
+    coll1Ended.test_and_set();
+    return folly::unit;
+  });
+
+  // Record and enqueue coll1.
+  auto handle1 =
+      *collTrace->recordCollective(std::move(metadata1), std::move(waitEvent1));
+  EXPECT_VALUE(
+      handle1->trigger(CollTraceHandleTriggerState::BeforeEnqueueKernel));
+  EXPECT_VALUE(
+      handle1->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel));
+
+  // Signal coll1 start but NOT end — it's now "in flight".
+  handle1->trigger(CollTraceHandleTriggerState::KernelStarted);
+
+  // Expect collEventProgressing to be called at least once for coll1.
+  std::atomic<int> coll1ProgressCount{0};
+  auto coll1Id = handle1->getCollRecord().value()->getCollId();
+  EXPECT_CALL(*mockPluginPtr, collEventProgressing(_))
+      .WillRepeatedly([&](CollTraceEvent& event) {
+        if (event.collRecord->getCollId() == coll1Id) {
+          coll1ProgressCount++;
+        }
+        return folly::unit;
+      });
+
+  // Wait for the poll thread to detect the in-flight state.
+  // NOLINTNEXTLINE(facebook-hte-BadCall-sleep_for)
+  while (coll1ProgressCount.load() == 0) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+
+  EXPECT_GT(coll1ProgressCount.load(), 0)
+      << "collEventProgressing should fire for the in-flight collective";
+
+  // Complete coll1.
+  std::atomic<bool> coll1Completed{false};
+  EXPECT_CALL(*mockPluginPtr, afterCollKernelEnd(_))
+      .WillRepeatedly([&](CollTraceEvent& event) {
+        if (event.collRecord->getCollId() == coll1Id) {
+          coll1Completed.store(true);
+        }
+        return folly::unit;
+      });
+
+  handle1->trigger(CollTraceHandleTriggerState::KernelFinished);
+  // NOLINTNEXTLINE(facebook-hte-BadCall-sleep_for)
+  while (!coll1Completed.load()) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+
+  EXPECT_TRUE(coll1Completed.load())
+      << "afterCollKernelEnd should fire after KernelFinished";
+}
+
+// ---------------------------------------------------------------------------
+// PendingAction ordering tests — verify the multiset merge-by-timestamp
+// logic that ensures events from both eager and graph pipelines are
+// processed in chronological order.
+// ---------------------------------------------------------------------------
+
+TEST(PendingActionOrdering, SortsByTimestamp) {
+  auto t1 = std::chrono::system_clock::now();
+  auto t2 = t1 + std::chrono::milliseconds(10);
+  auto t3 = t1 + std::chrono::milliseconds(20);
+
+  std::multiset<PendingAction> actions;
+  // Insert out of order.
+  actions.insert({nullptr, PendingActionType::kEnd, t3});
+  actions.insert({nullptr, PendingActionType::kStart, t1});
+  actions.insert({nullptr, PendingActionType::kProgressing, t2});
+
+  std::vector<PendingActionType> order;
+  for (const auto& a : actions) {
+    order.push_back(a.type);
+  }
+  const std::vector<PendingActionType> expected{
+      PendingActionType::kStart,
+      PendingActionType::kProgressing,
+      PendingActionType::kEnd,
+  };
+  EXPECT_EQ(order, expected);
+}
+
+TEST(PendingActionOrdering, SameTimestampOrderedByType) {
+  auto t = std::chrono::system_clock::now();
+
+  std::multiset<PendingAction> actions;
+  // All same timestamp, insert in reverse type order.
+  actions.insert({nullptr, PendingActionType::kEnd, t});
+  actions.insert({nullptr, PendingActionType::kProgressing, t});
+  actions.insert({nullptr, PendingActionType::kStart, t});
+  actions.insert({nullptr, PendingActionType::kScheduleAndStart, t});
+
+  std::vector<PendingActionType> order;
+  for (const auto& a : actions) {
+    order.push_back(a.type);
+  }
+  // kScheduleAndStart < kStart < kProgressing < kEnd
+  const std::vector<PendingActionType> expected{
+      PendingActionType::kScheduleAndStart,
+      PendingActionType::kStart,
+      PendingActionType::kProgressing,
+      PendingActionType::kEnd,
+  };
+  EXPECT_EQ(order, expected);
+}
+
+TEST(PendingActionOrdering, MixedTimestampsAndTypes) {
+  auto t1 = std::chrono::system_clock::now();
+  auto t2 = t1 + std::chrono::milliseconds(5);
+
+  std::multiset<PendingAction> actions;
+  // Graph start at t1, eager start at t1 (same timestamp — graph first).
+  actions.insert({nullptr, PendingActionType::kStart, t1});
+  actions.insert({nullptr, PendingActionType::kScheduleAndStart, t1});
+  // Eager end at t2, graph end at t2 (same timestamp — same type, either
+  // order).
+  actions.insert({nullptr, PendingActionType::kEnd, t2});
+  actions.insert({nullptr, PendingActionType::kEnd, t2});
+
+  std::vector<PendingActionType> order;
+  std::vector<std::chrono::system_clock::time_point> times;
+  for (const auto& a : actions) {
+    order.push_back(a.type);
+    times.push_back(a.timestamp);
+  }
+
+  // First two should be the t1 actions (schedule+start before start).
+  EXPECT_EQ(order[0], PendingActionType::kScheduleAndStart);
+  EXPECT_EQ(order[1], PendingActionType::kStart);
+  EXPECT_EQ(times[0], t1);
+  EXPECT_EQ(times[1], t1);
+  // Last two should be the t2 end actions.
+  EXPECT_EQ(order[2], PendingActionType::kEnd);
+  EXPECT_EQ(order[3], PendingActionType::kEnd);
+  EXPECT_EQ(times[2], t2);
+  EXPECT_EQ(times[3], t2);
 }

--- a/comms/utils/colltrace/tests/MockTypes.h
+++ b/comms/utils/colltrace/tests/MockTypes.h
@@ -24,7 +24,7 @@ class MockCollTrace : public ICollTrace {
       (noexcept, override));
 
   MOCK_METHOD(
-      CommsMaybe<std::shared_ptr<CollTraceHandle>>,
+      CommsMaybe<std::shared_ptr<ICollTraceHandle>>,
       recordCollective,
       (std::unique_ptr<ICollMetadata> metadata,
        std::unique_ptr<ICollWaitEvent> waitEvent),
@@ -71,6 +71,24 @@ class MockCollTracePlugin : public ICollTracePlugin {
 // Mock CollWaitEvent for testing
 class MockCollWaitEvent : public ICollWaitEvent {
  public:
+  MockCollWaitEvent() {
+    ON_CALL(*this, getCollStartTime())
+        .WillByDefault(
+            ::testing::Return(
+                CommsMaybe<system_clock_time_point>(
+                    std::chrono::system_clock::now())));
+    ON_CALL(*this, getCollEndTime())
+        .WillByDefault(
+            ::testing::Return(
+                CommsMaybe<system_clock_time_point>(
+                    std::chrono::system_clock::now())));
+    ON_CALL(*this, getCollEnqueueTime())
+        .WillByDefault(
+            ::testing::Return(
+                CommsMaybe<system_clock_time_point>(
+                    std::chrono::system_clock::now())));
+  }
+
   MOCK_METHOD(
       CommsMaybeVoid,
       beforeCollKernelScheduled,


### PR DESCRIPTION
Summary:

```                                                                                                                                                                                            
Graph CollTrace overhead (~200us D2D collectives, 500 replays):
  N=1     Baseline:    138.7us  CollTrace:    151.5us  Overhead: +9.2%
  N=10    Baseline:   1365.8us  CollTrace:   1385.4us  Overhead: +1.4%
  N=100   Baseline:  13631.5us  CollTrace:  13736.7us  Overhead: +0.8%
```

Reviewed By: SuhitK

Differential Revision: D97960551


