### PR TITLE
Fix tests for upstream NCCL_PARAM env var reading (#1999)

### DIFF
--- a/comms/ncclx/meta/colltrace/tests/ProxyTraceDistTest.cc
+++ b/comms/ncclx/meta/colltrace/tests/ProxyTraceDistTest.cc
@@ -521,8 +521,15 @@ TEST_F(ProxyTraceTest, QueryFinishedSendRecv) {
 TEST_F(ProxyTraceTest, QueryHangAllReduce) {
   auto traceGuard = EnvRAII(NCCL_PROXYTRACE, {"trace"});
 
+  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  if (!checkTestRequirement(comm)) {
+    GTEST_SKIP();
+  }
+
+  // Configure mock failure relative to current opCount to account for
+  // init-phase operations (e.g., fast-init) that consume opCounts.
   SendFailureConfig failureConfig = {
-      8 /*opCount*/,
+      static_cast<int>(comm->opCount) + 8 /*opCount*/,
       0 /*rank*/,
       -1 /*remoteRank*/,
       1 /*step*/,
@@ -530,11 +537,6 @@ TEST_F(ProxyTraceTest, QueryHangAllReduce) {
       30 /*delay*/
   };
   setMockConfig(failureConfig);
-
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
-  if (!checkTestRequirement(comm)) {
-    GTEST_SKIP();
-  }
 
   EXPECT_NE(comm->proxyState->trace, nullptr);
 
@@ -584,8 +586,10 @@ TEST_F(ProxyTraceTest, QueryHangSendRecv) {
     GTEST_SKIP();
   }
 
+  // Configure mock failure relative to current opCount to account for
+  // init-phase operations (e.g., fast-init) that consume opCounts.
   SendFailureConfig failureConfig = {
-      8 /*opCount*/,
+      static_cast<int>(comm->opCount) + 8 /*opCount*/,
       0 /*rank*/,
       comm->localRanks /*remoteRank*/,
       1 /*step*/,

--- a/comms/ncclx/meta/tests/CommRegisterTest.cc
+++ b/comms/ncclx/meta/tests/CommRegisterTest.cc
@@ -34,10 +34,12 @@ class CommRegisterTestParam
 
 TEST_P(CommRegisterTestParam, RegularUsage) {
   const auto& [nbytes, memType, ctranRegist] = GetParam();
+  // Set NCCL_LOCAL_REGISTER before comm creation to avoid a race condition
+  // with internal threads spawned during comm init that may call getenv.
+  SysEnvRAII env2("NCCL_LOCAL_REGISTER", "0");
   ncclx::test::NcclCommRAII comm(
       globalRank, numRanks, localRank, bootstrap_.get());
   EnvRAII env(NCCL_CTRAN_REGISTER, ctranRegist);
-  EnvRAII env2(NCCL_LOCAL_REGISTER, (int64_t)0);
 
   if ((memType == kMemNcclMemAlloc || memType == kCuMemAllocDisjoint) &&
       ncclIsCuMemSupported() == false) {
@@ -69,10 +71,12 @@ TEST_P(CommRegisterTestParam, RegularUsage) {
 }
 
 TEST_F(CommRegisterTest, InvalidHybridUsage) {
+  // Set NCCL_LOCAL_REGISTER before comm creation to avoid a race condition
+  // with internal threads spawned during comm init that may call getenv.
+  SysEnvRAII env2("NCCL_LOCAL_REGISTER", "1");
   ncclx::test::NcclCommRAII comm(
       globalRank, numRanks, localRank, bootstrap_.get());
   EnvRAII env1(NCCL_CTRAN_REGISTER, NCCL_CTRAN_REGISTER::lazy);
-  EnvRAII env2(NCCL_LOCAL_REGISTER, (int64_t)1);
   constexpr size_t nbytes = 8192;
 
   std::vector<TestMemSegment> segments;
@@ -138,6 +142,9 @@ INSTANTIATE_TEST_SUITE_P(
     });
 
 int main(int argc, char* argv[]) {
+  // Disable NCCL_PARAM caching for NCCL_LOCAL_REGISTER so tests can
+  // dynamically toggle it between test cases via setenv/unsetenv.
+  setenv("NCCL_NO_CACHE", "NCCL_LOCAL_REGISTER", 0);
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);
   folly::Init init(&argc, &argv);

--- a/comms/ncclx/meta/tests/ReduceScatterPatSelectTest.cc
+++ b/comms/ncclx/meta/tests/ReduceScatterPatSelectTest.cc
@@ -39,13 +39,6 @@ class ReduceScatterPatSelectTest : public NcclxBaseTestFixture {
 
   void SetUp() override {
     NcclxBaseTestFixture::SetUp();
-    // [META:PAT] Enable PAT algorithm for all tests in this suite.
-    // This must be set BEFORE any communicator is created because
-    // ncclParamPatEnable() uses a static cache that is only populated once.
-    // Setting it here ensures the cache is populated with the correct value
-    // regardless of test execution order.
-    patEnableGuard_ =
-        std::make_unique<EnvRAII<int64_t>>(NCCL_PAT_ENABLE, (int64_t)1);
     // Enable AlgoStats for algorithm validation (must be before comm creation)
     algoStats_.enable();
     CUDACHECK_TEST(cudaStreamCreate(&stream));
@@ -53,7 +46,6 @@ class ReduceScatterPatSelectTest : public NcclxBaseTestFixture {
 
   void TearDown() override {
     CUDACHECK_TEST(cudaStreamDestroy(stream));
-    patEnableGuard_.reset();
     // Reset global hint to avoid affecting subsequent tests
     ncclx::resetGlobalHint(
         std::string(ncclx::HintKeys::kCommAlgoReduceScatter));
@@ -130,7 +122,6 @@ class ReduceScatterPatSelectTest : public NcclxBaseTestFixture {
 
   cudaStream_t stream{nullptr};
   ncclx::test::VerifyAlgoStatsHelper algoStats_;
-  std::unique_ptr<EnvRAII<int64_t>> patEnableGuard_;
 };
 
 /**
@@ -300,9 +291,16 @@ TEST_P(ReduceScatterPatAlgoSelectionTest, AlgoSelection) {
 
   // Enforce PAT algorithm selection via env vars for SUM (both NCCL_ALGO,
   // NCCL_PROTO and NCCL_PAT_ENABLE must be set, NCCL_PAT_ENABLE=1 is set in
-  // base fixture SetUp()). AVG requires PAT AVG CVAR or hint.
-  auto algoGuard = EnvRAII<std::string>(NCCL_ALGO, "reducescatter:pat");
-  auto protoGuard = EnvRAII<std::string>(NCCL_PROTO, "Simple");
+  // main()). AVG requires PAT AVG CVAR or hint.
+  // Starting NCCLX 2.29, we started fully relying on the Nvidia PARAM
+  // infrastructure for the Nvidia-provided control variables.
+#if NCCL_VERSION_CODE >= 22900
+  SysEnvRAII algoGuard("NCCL_ALGO", "reducescatter:pat");
+  SysEnvRAII protoGuard("NCCL_PROTO", "Simple");
+#else
+  EnvRAII<std::string> algoGuard(NCCL_ALGO, std::string("reducescatter:pat"));
+  EnvRAII<std::string> protoGuard(NCCL_PROTO, std::string("Simple"));
+#endif
 
   // Enable PAT AVG via CVAR before comm creation
   auto patAvgGuard = EnvRAII(NCCL_REDUCESCATTER_PAT_AVG_ENABLE, patAvgEnable);
@@ -652,6 +650,7 @@ TEST_F(ReduceScatterPatSelectTest, ComputePatAvgChannelsScalesWithMsgSize) {
 }
 
 int main(int argc, char* argv[]) {
+  setenv("NCCL_PAT_ENABLE", "1", 0);
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);
   folly::Init init(&argc, &argv);

--- a/comms/ncclx/meta/tests/ReduceScatterTest.cc
+++ b/comms/ncclx/meta/tests/ReduceScatterTest.cc
@@ -60,7 +60,6 @@ class ReduceScatterTest : public NcclxBaseTestFixture {
     envs.push_back({"NCCL_CTRAN_ENABLE", "1"});
     envs.push_back({"NCCL_CTRAN_IPC_REGCACHE_ENABLE_ASYNC_SOCKET", "1"});
     NcclxBaseTestFixture::SetUp(envs);
-    patEnableGuard_.emplace(NCCL_PAT_ENABLE, (int64_t)1);
     algoStats_.enable();
     CUDACHECK_TEST(cudaStreamCreate(&stream));
   }
@@ -223,7 +222,6 @@ class ReduceScatterTest : public NcclxBaseTestFixture {
  protected:
   ncclComm_t comm{nullptr};
   cudaStream_t stream{nullptr};
-  std::optional<EnvRAII<int64_t>> patEnableGuard_;
   ncclx::test::VerifyAlgoStatsHelper algoStats_;
 };
 
@@ -278,7 +276,13 @@ TEST_P(ReduceScatterOrigTestParam, OrigTest) {
   (void)envs_; // applied in SetUp
   auto rsAlgoGuard =
       EnvRAII(NCCL_REDUCESCATTER_ALGO, NCCL_REDUCESCATTER_ALGO::orig);
-  auto algoGuard = EnvRAII<std::string>(NCCL_ALGO, ncclAlgo);
+  // Starting NCCLX 2.29, we started fully relying on the Nvidia PARAM
+  // infrastructure for the Nvidia-provided control variables.
+#if NCCL_VERSION_CODE >= 22900
+  SysEnvRAII algoGuard("NCCL_ALGO", ncclAlgo);
+#else
+  EnvRAII<std::string> algoGuard(NCCL_ALGO, ncclAlgo);
+#endif
 
   ReduceScatterTestParams param{
       .algo = NCCL_REDUCESCATTER_ALGO::orig,
@@ -455,6 +459,7 @@ INSTANTIATE_TEST_SUITE_P(
     rsPatAvgTestNameGen);
 
 int main(int argc, char* argv[]) {
+  setenv("NCCL_PAT_ENABLE", "1", 0);
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);
   folly::Init init(&argc, &argv);

--- a/comms/ncclx/meta/tests/topoTest.cc
+++ b/comms/ncclx/meta/tests/topoTest.cc
@@ -7,6 +7,7 @@
 #include <gtest/gtest.h>
 
 #include "comms/testinfra/TestUtils.h"
+#include "comms/utils/cvars/nccl_cvars.h"
 #include "graph.h"
 #include "nccl.h"
 
@@ -48,8 +49,14 @@ TEST_F(topoTest, defaultTopoXmlNotFound) {
 }
 
 TEST_F(topoTest, userTopoXmlFileNotFound) {
+  // Starting NCCLX 2.29, we started fully relying on the Nvidia PARAM
+  // infrastructure for the Nvidia-provided control variables.
+#if NCCL_VERSION_CODE >= 22900
+  SysEnvRAII topoFileEnv("NCCL_TOPO_FILE", "/tmp/nccl_topo_not_exist.xml");
+#else
   EnvRAII<std::string> topoFileEnv(
       NCCL_TOPO_FILE, "/tmp/nccl_topo_not_exist.xml");
+#endif
   folly::test::TemporaryFile dumpXmlFile;
 
   testing::internal::CaptureStdout();

--- a/comms/ncclx/v2_29/src/enqueue.cc
+++ b/comms/ncclx/v2_29/src/enqueue.cc
@@ -798,7 +798,6 @@ static ncclResult_t scheduleCollTasksToPlan(
         proxyOp->ringAlgo = NULL;
         if (proxyOp->reg && task->algorithm == NCCL_ALGO_RING && (task->recvNetHandles[c] || task->sendNetHandles[c])) {
           if (task->func == ncclFuncAllGather) {
-        ncclx::colltrace::proxyTraceAddBasicInfo(*proxyOp, nMaxChannels[kind], proxyOp->task.coll->func);
             proxyOp->ringAlgo = new RingAGAlgorithm(task->sendbuff, task->recvbuff, comm->nRanks, comm->channels[c].ring.userRanks, proxyOp->chunkSteps, proxyOp->sliceSteps, proxyOp->chunkSize, proxyOp->sliceSize, proxyOp->loopOffset, proxyOp->channelSize, elementSize, task->count * elementSize, task->sendNetHandles[c], task->recvNetHandles[c], task->srecvNetHandles[c]);
           } else if (task->func == ncclFuncAllReduce) {
             proxyOp->ringAlgo = new RingARAlgorithm(task->sendbuff, task->recvbuff, comm->nRanks, comm->channels[c].ring.index, proxyOp->chunkSteps, proxyOp->sliceSteps, proxyOp->chunkSize, proxyOp->sliceSize, proxyOp->loopOffset, proxyOp->channelSize, elementSize, task->sendNetHandles[c], task->recvNetHandles[c], task->srecvNetHandles[c]);
@@ -811,6 +810,7 @@ static ncclResult_t scheduleCollTasksToPlan(
         proxyOp->incWorkCounter = true;
         proxyOp->nChannels = nChannels;
         ncclAddWorkBatchToPlan(comm, plan, c, workNode->workType, task->devFuncId, plan->workBytes);
+        ncclx::colltrace::proxyTraceAddBasicInfo(*proxyOp, nMaxChannels[kind], proxyOp->task.coll->func);
         // Coverity reports "proxyOp->connection" as being possibly uninitialized.  It's hard to
         // determine if that's actually true but it's also not clear if that would be an issue.
         // coverity[uninit_use_in_call:FALSE]


### PR DESCRIPTION
Summary:

After reverting NCCL_PARAM to the upstream NVIDIA mechanism
(D99871317), ncclParamX() functions and ncclGetEnv() read
process environment variables directly instead of the Meta
CVAR system. Tests using EnvRAII (which modifies CVARs) for
upstream NCCL params no longer work because the code reads
getenv(), not the CVAR globals.

Changes:
- Fix SysEnvRAII to unsetenv when no previous value existed,
  matching its documented "remove the variable" behavior
- CommRegisterTest: use SysEnvRAII for NCCL_LOCAL_REGISTER
  and NCCL_NO_CACHE to allow toggling across tests
- ReduceScatterPatSelectTest: use SysEnvRAII for
  NCCL_PAT_ENABLE, NCCL_ALGO, NCCL_PROTO
- ReduceScatterTest: use SysEnvRAII for NCCL_PAT_ENABLE
  and NCCL_ALGO

Reviewed By: dolpm

Differential Revision: D100030880


