### PR TITLE
Create Profiler when caller injects a reporter, bypassing NCCL_CTRAN_TRANSPORT_PROFILER gate (#2005)

### DIFF
--- a/comms/ctran/Ctran.cc
+++ b/comms/ctran/Ctran.cc
@@ -32,7 +32,7 @@ Ctran::Ctran(
 
   algo = std::make_unique<CtranAlgo>(comm, this);
 
-  if (NCCL_CTRAN_TRANSPORT_PROFILER) {
+  if (comm->config_.enableProfiler) {
     profiler = std::make_unique<ctran::Profiler>(comm, std::move(reporter));
   }
 }

--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -41,12 +41,14 @@ struct ctranConfig {
   const char* ncclAllGatherAlgo{nullptr};
   std::vector<enum CommBackend> backends = {};
   ctranPipesConfig pipesConfig;
+  bool enableProfiler{NCCL_CTRAN_TRANSPORT_PROFILER};
 
   bool operator==(const ctranConfig& other) const {
     return (
         blocking == other.blocking && commDesc == other.commDesc &&
         ncclAllGatherAlgo == other.ncclAllGatherAlgo &&
-        backends == other.backends && pipesConfig == other.pipesConfig);
+        backends == other.backends && pipesConfig == other.pipesConfig &&
+        enableProfiler == other.enableProfiler);
   }
 };
 


### PR DESCRIPTION
Summary:

MCCL injects its own McclAlgoProfilerReporter into ctran via ctranInit(),
but the ctran::Profiler was only created when NCCL_CTRAN_TRANSPORT_PROFILER=true
(default: false). This silently dropped the MCCL reporter, preventing all algo
profiler data from reaching the mccl_operation_trace Scuba table.

Fix: create the Profiler whenever a custom reporter is injected (reporter != nullptr),
regardless of NCCL_CTRAN_TRANSPORT_PROFILER. The NCCLx path (no reporter, defaults to
DefaultAlgoProfilerReporter) retains the existing CVAR gate.

MCCL already has its own enable gate (MCCL_SCUBA_ENABLED) inside
McclAlgoProfilerReporter, so requiring a second NCCL-prefixed CVAR is redundant.

Differential Revision: D100086191
