### PR TITLE
Topology-aware auto-tuning for Triton alltoallv kernel (#2008)

### DIFF
--- a/comms/pipes/collectives/triton/alltoallv_op.py
+++ b/comms/pipes/collectives/triton/alltoallv_op.py
@@ -366,7 +366,7 @@ class AlltoallvOp:
         # Internal comms state (populated by setup()).
         self._window: Any = None
         self._dev_win_ptr: Optional[int] = None
-        self._src_info: Optional[tuple[int, int, int]] = None
+        self._src_info: Optional[int] = None
         self._remote_write_offsets: Optional[torch.Tensor] = None
 
     # ------------------------------------------------------------------
@@ -525,7 +525,7 @@ class AlltoallvOp:
         """Release comms resources and all buffers.  Safe to call multiple times."""
         # First deregister comms buffers
         if self._src_info is not None:
-            self._window.deregister_local_buffer(*self._src_info)
+            self._window.deregister_local_buffer(self._src_info)
             self._src_info = None
         if self._window is not None:
             self._window.tensor_deregister()

--- a/comms/pipes/collectives/triton/alltoallv_op.py
+++ b/comms/pipes/collectives/triton/alltoallv_op.py
@@ -95,6 +95,7 @@ call. If the caller needs the data to persist beyond that point it must
 ``.clone()`` the output.
 """
 
+import os
 from typing import Any, Optional, TYPE_CHECKING, Union
 
 import torch
@@ -368,6 +369,8 @@ class AlltoallvOp:
         self._dev_win_ptr: Optional[int] = None
         self._src_info: Optional[int] = None
         self._remote_write_offsets: Optional[torch.Tensor] = None
+        self._per_peer_blocks: Optional[torch.Tensor] = None
+        self._peer_is_nvl: list[bool] = []
 
     # ------------------------------------------------------------------
     # Factory / caching
@@ -503,6 +506,31 @@ class AlltoallvOp:
         self._window.tensor_register(self.recv_buf)
         self.comm.barrier(False)
 
+        # Detect topology: classify peers as NVL or IB.
+        # Gated behind TRITON_ALLTOALLV_ENABLE_IB=1 — when disabled (default),
+        # all peers are treated as NVL and the kernel uses NVLink-only tuning.
+        self._peer_is_nvl = [True] * self.world_size  # default: all NVL
+        ib_enabled = os.environ.get("TRITON_ALLTOALLV_ENABLE_IB", "0") == "1"
+        if ib_enabled and hasattr(self._window, "get_nvlink_address"):
+            for peer in range(self.world_size):
+                if peer != self.rank:
+                    self._peer_is_nvl[peer] = self._window.get_nvlink_address(peer) != 0
+
+        # Re-tune with topology info for per-peer block counts.
+        worst_case_msg_bytes = self.max_input_tokens * self._bytes_per_token
+        params = auto_tune_alltoallv_params(worst_case_msg_bytes, self._peer_is_nvl)
+        self._blocks_per_peer = params["blocks_per_peer"]
+        self._num_warps = params["num_warps"]
+        self._chunk_size = params["chunk_size"]
+
+        # Build per_peer_blocks tensor if topology is mixed.
+        if params["per_peer_blocks"] is not None:
+            self._per_peer_blocks = torch.tensor(
+                params["per_peer_blocks"], dtype=torch.int32, device=self.device
+            )
+        else:
+            self._per_peer_blocks = None
+
         # get_device_window triggers ncclDevCommCreate (enables GIN).
         # When sync_buffer is enabled, allocate 2x signal slots:
         # signal_id=0 for DATA_COMPLETE, signal_id=1 for BUFFER_READY
@@ -531,6 +559,8 @@ class AlltoallvOp:
             self._window.tensor_deregister()
             self._window = None
         self._dev_win_ptr = None
+        self._per_peer_blocks = None
+        self._peer_is_nvl = []
 
         # Release all GPU buffers to free memory immediately.
         # Without this, Python GC may defer collection and cause OOM.
@@ -912,6 +942,7 @@ class AlltoallvOp:
             num_warps=self._num_warps,
             chunk_size=self._chunk_size,
             sync_buffer=self.sync_buffer,
+            per_peer_blocks=self._per_peer_blocks,
         )
 
         # NOTE: Iteration counter is now managed internally by

--- a/comms/pipes/collectives/triton/device_alltoallv_dynamic.py
+++ b/comms/pipes/collectives/triton/device_alltoallv_dynamic.py
@@ -284,9 +284,7 @@ def prewarm_completion_counters(world_size: int, device: torch.device) -> None:
 def _device_alltoallv_dynamic_kernel(
     # Window handles
     dst_win_ptr,
-    src_base_ptr,
-    src_size,
-    src_nccl_win,
+    src_registered_buf,  # device ptr to RegisteredBuffer (from register_local_buffer)
     # Buffer pointers for self-copy (typed by Triton from tensors)
     send_buf_ptr,
     recv_buf_ptr,
@@ -366,9 +364,10 @@ def _device_alltoallv_dynamic_kernel(
 
     Args:
         dst_win_ptr: TorchComms device window handle for destination
-        src_base_ptr: Base pointer of registered source buffer
-        src_size: Size of source buffer in bytes
-        src_nccl_win: NCCL window handle for source buffer
+        src_registered_buf: Device pointer to RegisteredBuffer struct
+                           (from register_local_buffer()). Passed directly to
+                           put_block_direct / put_warp_chunked_direct which
+                           read base_ptr from the struct internally.
         send_offsets_ptr: GPU tensor [world_size] - byte offsets into src
         send_sizes_ptr: GPU tensor [world_size] - bytes to send per peer
         recv_offsets_ptr: GPU tensor [world_size] - byte offsets into local dst
@@ -533,7 +532,7 @@ def _device_alltoallv_dynamic_kernel(
                 put_block_direct(
                     dst_win_ptr,
                     dst_offset + block_start,
-                    src_nccl_win,
+                    src_registered_buf,
                     send_offset + block_start,
                     peer,
                     block_portion,
@@ -542,7 +541,7 @@ def _device_alltoallv_dynamic_kernel(
                 put_warp_chunked_direct(
                     dst_win_ptr,
                     dst_offset + block_start,
-                    src_nccl_win,
+                    src_registered_buf,
                     send_offset + block_start,
                     peer,
                     block_portion,
@@ -658,7 +657,7 @@ def device_alltoallv_dynamic(
     local_recv_slot_offsets: torch.Tensor,
     remote_write_offsets: torch.Tensor,
     dev_win_ptr: int,
-    src_info: tuple,
+    src_info: int,
     my_rank: int,
     world_size: int,
     num_warps: int = 16,
@@ -738,7 +737,7 @@ def device_alltoallv_dynamic(
         >>> # Cleanup
         >>> deregister_local_buffer(src_info, window)
     """
-    src_base_ptr, src_size, src_nccl_win = src_info
+    src_registered_buf = src_info
 
     # Get internal iteration tensor (cached per device/world_size).
     # This is managed internally - users don't need to create or track it.
@@ -781,9 +780,7 @@ def device_alltoallv_dynamic(
 
     _device_alltoallv_dynamic_kernel[grid](
         dev_win_ptr,
-        src_base_ptr,
-        src_size,
-        src_nccl_win,
+        src_registered_buf,
         send_buf,
         recv_buf,
         send_offsets,

--- a/comms/pipes/collectives/triton/device_alltoallv_dynamic.py
+++ b/comms/pipes/collectives/triton/device_alltoallv_dynamic.py
@@ -182,16 +182,24 @@ def _fill_completion_counters_from_iteration_kernel(
     iteration_ptr,
     BLOCKS_PER_PEER: tl.constexpr,
     N: tl.constexpr,
+    per_peer_blocks_ptr,
+    HAS_PER_PEER_BLOCKS: tl.constexpr,
 ):
     """GIN-safe kernel to reset completion counters based on iteration.
 
-    Reads iteration from GPU memory and computes expected_base = BLOCKS_PER_PEER * iteration.
-    This is CUDA graph compatible since iteration is read from GPU, not host.
+    Reads iteration from GPU memory and computes the expected base counter
+    value for each peer. When HAS_PER_PEER_BLOCKS is True, uses per-peer
+    block counts instead of the uniform BLOCKS_PER_PEER constexpr.
+    This is CUDA graph compatible since all values are read from GPU.
     """
     idx = tl.program_id(0)
     if idx < N:
         iteration = tl.load(iteration_ptr)
-        expected_base = BLOCKS_PER_PEER * iteration
+        if HAS_PER_PEER_BLOCKS:
+            bpp = tl.load(per_peer_blocks_ptr + idx)
+        else:
+            bpp = BLOCKS_PER_PEER
+        expected_base = bpp * iteration
         tl.store(counters_ptr + idx, expected_base)
 
 
@@ -212,23 +220,32 @@ def _fill_completion_counters_from_iteration(
     iteration_tensor: torch.Tensor,
     blocks_per_peer: int,
     world_size: int,
+    per_peer_blocks: "torch.Tensor | None" = None,
 ) -> None:
     """Reset completion counters based on iteration value from GPU tensor.
 
     This is CUDA graph compatible - reads iteration from GPU memory and
-    computes expected_base = blocks_per_peer * iteration entirely on GPU.
+    computes expected_base entirely on GPU.
+
+    When per_peer_blocks is provided, each counter is reset to
+    per_peer_blocks[i] * iteration (per-peer rate). Otherwise, all
+    counters are reset uniformly to blocks_per_peer * iteration.
 
     Args:
         counters: GPU tensor [world_size] of int32 counters.
         iteration_tensor: GPU scalar tensor containing iteration count.
-        blocks_per_peer: Number of blocks per peer.
+        blocks_per_peer: Number of blocks per peer (constexpr upper bound).
         world_size: Number of ranks.
+        per_peer_blocks: Optional GPU tensor [world_size] of int32 per-peer
+            block counts. When provided, counters are reset per-peer.
     """
     _fill_completion_counters_from_iteration_kernel[(world_size,)](
         counters,
         iteration_tensor,
         BLOCKS_PER_PEER=blocks_per_peer,
         N=world_size,
+        per_peer_blocks_ptr=per_peer_blocks,
+        HAS_PER_PEER_BLOCKS=per_peer_blocks is not None,
     )
 
 
@@ -308,6 +325,9 @@ def _device_alltoallv_dynamic_kernel(
     # Sync buffer mode for buffer-ready synchronization
     SYNC_BUFFER: tl.constexpr,
     BUFFER_READY_SIGNAL_ID: tl.constexpr,
+    # Per-peer block counts for topology-aware scheduling (optional)
+    per_peer_blocks_ptr,
+    HAS_PER_PEER_BLOCKS: tl.constexpr,
 ):
     """
     Device-initiated AlltoAllv Dynamic kernel.
@@ -446,8 +466,14 @@ def _device_alltoallv_dynamic_kernel(
                 peer_recv_size = tl.load(recv_sizes_ptr + recv_peer)
                 if peer_recv_size > 0:
                     # Wait for monotonically increasing signal value.
-                    # Each iteration signals BLOCKS_PER_PEER * (iteration + 1).
-                    expected_signal = BLOCKS_PER_PEER * (iteration + 1)
+                    # The sender signals actual_bpp * (iteration + 1).
+                    # In symmetric topology, per_peer_blocks[recv_peer] equals
+                    # the sender's bpp for this rank.
+                    if HAS_PER_PEER_BLOCKS:
+                        sender_bpp = tl.load(per_peer_blocks_ptr + recv_peer)
+                    else:
+                        sender_bpp = BLOCKS_PER_PEER
+                    expected_signal = sender_bpp * (iteration + 1)
                     wait_signal_from(dst_win_ptr, recv_peer, signal_id, expected_signal)
 
         return
@@ -460,6 +486,16 @@ def _device_alltoallv_dynamic_kernel(
     # Skip if peer is out of range (grid may be larger than world_size)
     if peer >= world_size:
         return
+
+    # Per-peer block masking: IB peers may use fewer blocks than NVL peers.
+    # BLOCKS_PER_PEER is the constexpr upper bound; actual_bpp is the real
+    # count for this peer. Excess blocks early-return.
+    if HAS_PER_PEER_BLOCKS:
+        actual_bpp = tl.load(per_peer_blocks_ptr + peer)
+        if block_idx >= actual_bpp:
+            return
+    else:
+        actual_bpp = BLOCKS_PER_PEER
 
     # NOTE: No counter reset here. Counters grow monotonically with each
     # iteration to avoid race conditions from non-deterministic CUDA block
@@ -496,9 +532,9 @@ def _device_alltoallv_dynamic_kernel(
     # pressure on the hot memcpy path.
     if peer == my_rank and send_size > 0:
         dst_offset = tl.load(recv_offsets_ptr + my_rank)
-        block_bytes = send_size // BLOCKS_PER_PEER
+        block_bytes = send_size // actual_bpp
         block_start_bytes = block_bytes * block_idx
-        if block_idx == BLOCKS_PER_PEER - 1:
+        if block_idx == actual_bpp - 1:
             block_bytes = send_size - block_start_bytes
         if block_bytes > 0:
             self_copy_block(
@@ -512,11 +548,11 @@ def _device_alltoallv_dynamic_kernel(
     # Phase 1: Send data to peer (skip self and zero-length messages).
     # Send blocks NEVER call wait_signal_from — they run uninterrupted.
     if peer != my_rank and send_size > 0:
-        # Split send_size across BLOCKS_PER_PEER blocks.
-        block_portion = send_size // BLOCKS_PER_PEER
+        # Split send_size across actual_bpp blocks for this peer.
+        block_portion = send_size // actual_bpp
         block_start = block_portion * block_idx
         # Last block absorbs any remainder bytes from integer division
-        if block_idx == BLOCKS_PER_PEER - 1:
+        if block_idx == actual_bpp - 1:
             block_portion = send_size - block_start
 
         if block_portion > 0:
@@ -555,18 +591,18 @@ def _device_alltoallv_dynamic_kernel(
             # expected value of BLOCKS_PER_PEER * (iteration + 1).
             flush_block(dst_win_ptr)
             if SYNC_BUFFER:
-                if BLOCKS_PER_PEER == 1:
-                    # Add BLOCKS_PER_PEER to signal, making cumulative value = BLOCKS_PER_PEER * (iteration + 1)
-                    signal_block(dst_win_ptr, peer, signal_id, BLOCKS_PER_PEER)
+                if actual_bpp == 1:
+                    # Add actual_bpp to signal, making cumulative value = actual_bpp * (iteration + 1)
+                    signal_block(dst_win_ptr, peer, signal_id, actual_bpp)
                 else:
                     # Atomically increment counter. Last block to complete signals.
-                    # Counter grows monotonically: iteration 0 ends at BLOCKS_PER_PEER,
-                    # iteration 1 ends at 2*BLOCKS_PER_PEER, etc.
+                    # Counter grows monotonically: iteration 0 ends at actual_bpp,
+                    # iteration 1 ends at 2*actual_bpp, etc.
                     old = tl.atomic_add(completion_counters_ptr + peer, 1)
-                    expected_count = BLOCKS_PER_PEER * (iteration + 1)
+                    expected_count = actual_bpp * (iteration + 1)
                     if old + 1 == expected_count:
-                        # Add BLOCKS_PER_PEER to signal, making cumulative value = BLOCKS_PER_PEER * (iteration + 1)
-                        signal_block(dst_win_ptr, peer, signal_id, BLOCKS_PER_PEER)
+                        # Add actual_bpp to signal, making cumulative value = actual_bpp * (iteration + 1)
+                        signal_block(dst_win_ptr, peer, signal_id, actual_bpp)
 
 
 def exchange_offsets(
@@ -597,34 +633,11 @@ def exchange_offsets(
     return remote_write_offsets
 
 
-def auto_tune_alltoallv_params(
-    max_msg_size_bytes: int,
-) -> dict:
-    """
-    Select optimal kernel parameters based on maximum per-peer message size.
+def _tune_for_nvl(max_msg_size_bytes: int) -> dict:
+    """NVLink-optimized tuning parameters.
 
-    Based on benchmark data across message sizes, the optimal configuration is:
-    - ≤1KB: 1 block/peer, 4 warps (Gw4)
-    - >1KB, ≤4KB: 1 block/peer, 8 warps (Gw8)
-    - >4KB, ≤8KB: 1 block/peer, 16 warps (Gw16)
-    - >8KB, ≤16KB: 1 block/peer, 32 warps (Gw32)
-    - >16KB, ≤256KB: 8 blocks/peer, 16 warps (GB8)
-    - >256KB: 16 blocks/peer, 16 warps, 64KB chunks (GB16c64)
-
-    Benchmark sweep (1MB-16MB) confirmed GB16c64 is consistently the best
-    config across all large message sizes.
-
-    Thread count (num_warps) rationale:
-    - Small messages (<4KB): fewer warps (4-8) reduce launch overhead
-    - Medium messages (4KB-64KB): moderate warps (16) balance occupancy
-    - Large messages (>64KB): more warps (32) maximize memory bandwidth
-    - Multi-block (>128KB): 16 warps/block with multiple blocks for parallelism
-
-    Args:
-        max_msg_size_bytes: Maximum per-peer message size in bytes.
-
-    Returns:
-        dict with keys: blocks_per_peer, num_warps, chunk_size
+    NVLink scales with block parallelism (each block independently
+    saturates a portion of the NVLink bandwidth via cooperative memcpy).
     """
     if max_msg_size_bytes <= 1 * 1024:
         return {"blocks_per_peer": 1, "num_warps": 4, "chunk_size": 64 * 1024}
@@ -648,6 +661,85 @@ def auto_tune_alltoallv_params(
         return {"blocks_per_peer": 16, "num_warps": 16, "chunk_size": 64 * 1024}
 
 
+def _tune_for_ib(max_msg_size_bytes: int) -> dict:
+    """IB/RDMA-optimized tuning parameters.
+
+    Empirical data from exhaustive sweep on 2x8 H100 (64 param combos
+    per message size, CUDA graph mode). Key findings:
+    - 1 bpp optimal up to 1MB (RDMA NIC pipelines internally)
+    - 4 bpp for 2-4MB (some block parallelism helps)
+    - 8 bpp for >=8MB (more blocks to saturate bandwidth)
+    - 512KB chunks dominate for medium/large messages
+    """
+    if max_msg_size_bytes <= 1 * 1024:  # 1KB: 2.35x vs NCCL
+        return {"blocks_per_peer": 1, "num_warps": 4, "chunk_size": 256 * 1024}
+    elif max_msg_size_bytes <= 4 * 1024:  # 4KB: 2.05x
+        return {"blocks_per_peer": 1, "num_warps": 16, "chunk_size": 128 * 1024}
+    elif max_msg_size_bytes <= 16 * 1024:  # 16KB: 2.35x
+        return {"blocks_per_peer": 1, "num_warps": 8, "chunk_size": 256 * 1024}
+    elif max_msg_size_bytes <= 64 * 1024:  # 64KB: 2.76x
+        return {"blocks_per_peer": 1, "num_warps": 4, "chunk_size": 64 * 1024}
+    elif max_msg_size_bytes <= 256 * 1024:  # 256KB: 1.91x
+        return {"blocks_per_peer": 1, "num_warps": 8, "chunk_size": 512 * 1024}
+    elif max_msg_size_bytes <= 512 * 1024:  # 512KB: 1.92x
+        return {"blocks_per_peer": 1, "num_warps": 4, "chunk_size": 512 * 1024}
+    elif max_msg_size_bytes <= 1 * 1024 * 1024:  # 1MB: 1.76x
+        return {"blocks_per_peer": 1, "num_warps": 16, "chunk_size": 256 * 1024}
+    elif max_msg_size_bytes <= 4 * 1024 * 1024:  # 2-4MB: 1.51-1.60x
+        return {"blocks_per_peer": 4, "num_warps": 16, "chunk_size": 512 * 1024}
+    else:  # >=8MB: 1.42-1.47x
+        return {"blocks_per_peer": 8, "num_warps": 16, "chunk_size": 512 * 1024}
+
+
+def auto_tune_alltoallv_params(
+    max_msg_size_bytes: int,
+    peer_is_nvl: "list[bool] | None" = None,
+) -> dict:
+    """
+    Select optimal kernel parameters based on maximum per-peer message size.
+
+    When peer_is_nvl is provided, returns topology-aware config with
+    per-peer block counts. NVL peers get NVLink-optimized parameters,
+    IB peers get RDMA-optimized parameters. The kernel launches with
+    the max blocks_per_peer as a constexpr upper bound and masks excess
+    blocks at runtime.
+
+    Args:
+        max_msg_size_bytes: Maximum per-peer message size in bytes.
+        peer_is_nvl: Optional list of booleans per peer. True = NVLink,
+            False = IB. None = all NVLink (backward compatible).
+
+    Returns:
+        dict with keys: blocks_per_peer, num_warps, chunk_size,
+            per_peer_blocks (list[int] or None)
+    """
+    nvl_config = _tune_for_nvl(max_msg_size_bytes)
+
+    if peer_is_nvl is None or all(peer_is_nvl):
+        return {
+            "blocks_per_peer": nvl_config["blocks_per_peer"],
+            "num_warps": nvl_config["num_warps"],
+            "chunk_size": nvl_config["chunk_size"],
+            "per_peer_blocks": None,
+        }
+
+    ib_config = _tune_for_ib(max_msg_size_bytes)
+
+    max_bpp = max(nvl_config["blocks_per_peer"], ib_config["blocks_per_peer"])
+
+    per_peer_blocks = [
+        nvl_config["blocks_per_peer"] if is_nvl else ib_config["blocks_per_peer"]
+        for is_nvl in peer_is_nvl
+    ]
+
+    return {
+        "blocks_per_peer": max_bpp,
+        "num_warps": max(nvl_config["num_warps"], ib_config["num_warps"]),
+        "chunk_size": nvl_config["chunk_size"],
+        "per_peer_blocks": per_peer_blocks,
+    }
+
+
 def device_alltoallv_dynamic(
     send_buf: torch.Tensor,
     recv_buf: torch.Tensor,
@@ -665,6 +757,7 @@ def device_alltoallv_dynamic(
     chunk_size: int = 64 * 1024,
     auto_tune: bool = False,
     sync_buffer: bool = True,
+    per_peer_blocks: "torch.Tensor | None" = None,
 ) -> None:
     """
     Perform device-initiated AlltoAllv with dynamic per-rank counts.
@@ -772,8 +865,14 @@ def device_alltoallv_dynamic(
     if blocks_per_peer > 1:
         # Reset each peer's counter using a GIN-safe Triton kernel that
         # reads iteration from GPU memory.  This is CUDA graph compatible.
+        # When per_peer_blocks is provided, each counter is reset to its
+        # own per_peer_blocks[i] * iteration (not the uniform max).
         _fill_completion_counters_from_iteration(
-            completion_counters, iteration_tensor, blocks_per_peer, world_size
+            completion_counters,
+            iteration_tensor,
+            blocks_per_peer,
+            world_size,
+            per_peer_blocks=per_peer_blocks,
         )
 
     grid = (world_size * blocks_per_peer + world_size,)
@@ -804,6 +903,9 @@ def device_alltoallv_dynamic(
         # Sync buffer mode for buffer-ready synchronization
         SYNC_BUFFER=sync_buffer,
         BUFFER_READY_SIGNAL_ID=1,  # Use signal_id=1 for BUFFER_READY (signal_id=0 is DATA_COMPLETE)
+        # Per-peer block counts for topology-aware scheduling
+        per_peer_blocks_ptr=per_peer_blocks,
+        HAS_PER_PEER_BLOCKS=per_peer_blocks is not None,
     )
 
     # Auto-increment iteration counter on GPU.

--- a/comms/pipes/collectives/triton/tests/benchmark_device_alltoallv_dynamic.py
+++ b/comms/pipes/collectives/triton/tests/benchmark_device_alltoallv_dynamic.py
@@ -160,7 +160,7 @@ class AlltoallvDynamicBenchmark:
     def _deregister_src(self) -> None:
         """Deregister send buffer so it can be modified."""
         if self.src_info is not None:
-            self.window.deregister_local_buffer(*self.src_info)
+            self.window.deregister_local_buffer(self.src_info)
             self.src_info = None
 
     def _register_src(self) -> None:
@@ -185,7 +185,7 @@ class AlltoallvDynamicBenchmark:
         # 2. Clean up class-level window and pools
         self.comm.barrier(False)
         if self.src_info is not None:
-            self.window.deregister_local_buffer(*self.src_info)
+            self.window.deregister_local_buffer(self.src_info)
             self.src_info = None
         if self.window is not None:
             self.window.tensor_deregister()

--- a/comms/pipes/collectives/triton/tests/test_device_alltoallv_dynamic_e2e.py
+++ b/comms/pipes/collectives/triton/tests/test_device_alltoallv_dynamic_e2e.py
@@ -119,7 +119,7 @@ class _SingleTestBase(unittest.TestCase):
     def _deregister_send_buf(self) -> None:
         """Deregister send_buf after collective, before next data fill."""
         if self.src_info is not None:
-            self.window.deregister_local_buffer(*self.src_info)
+            self.window.deregister_local_buffer(self.src_info)
             self.src_info = None
 
     def tearDown(self) -> None:
@@ -131,7 +131,7 @@ class _SingleTestBase(unittest.TestCase):
         if cls.torchcomm is not None:
             cls.torchcomm.barrier(False)
         if hasattr(cls, "src_info") and cls.src_info is not None:
-            cls.window.deregister_local_buffer(*cls.src_info)
+            cls.window.deregister_local_buffer(cls.src_info)
             cls.src_info = None
         if hasattr(cls, "window") and cls.window is not None:
             cls.window.tensor_deregister()

--- a/comms/torchcomms/triton/device_window.h
+++ b/comms/torchcomms/triton/device_window.h
@@ -106,7 +106,7 @@ __device__ int torchcomms_self_copy_block(
 __device__ int torchcomms_put_block_direct(
     TorchCommsWindowHandle win,
     unsigned long long dst_offset,
-    void* src_nccl_win,
+    TorchCommsBufferHandle src_registered_buf,
     unsigned long long src_offset,
     int dst_rank,
     unsigned long long bytes);
@@ -118,7 +118,7 @@ __device__ int torchcomms_put_block_direct(
 __device__ int torchcomms_put_warp_chunked_direct(
     TorchCommsWindowHandle win,
     unsigned long long dst_offset,
-    void* src_nccl_win,
+    TorchCommsBufferHandle src_registered_buf,
     unsigned long long src_offset,
     int dst_rank,
     unsigned long long total_bytes,

--- a/comms/torchcomms/triton/device_window_nvl_opt.cu
+++ b/comms/torchcomms/triton/device_window_nvl_opt.cu
@@ -108,16 +108,10 @@ __device__ __forceinline__ void nvl_memcpy_ptx(
 __device__ __noinline__ int gin_put_fallback(
     DeviceWindow* win,
     size_t dst_offset,
-    void* src_base_ptr,
-    size_t src_size,
-    void* src_nccl_win,
+    const RegisteredBuffer& src_buf,
     size_t src_offset,
     int dst_rank,
     size_t bytes) {
-  RegisteredBuffer src_buf;
-  src_buf.base_ptr = src_base_ptr;
-  src_buf.size = src_size;
-  src_buf.backend_window = src_nccl_win;
   return win->put(
       dst_offset,
       src_buf,
@@ -132,16 +126,10 @@ __device__ __noinline__ int gin_put_fallback(
 __device__ __noinline__ int gin_put_warp_fallback(
     DeviceWindow* win,
     size_t dst_offset,
-    void* src_base_ptr,
-    size_t src_size,
-    void* src_nccl_win,
+    const RegisteredBuffer& src_buf,
     size_t src_offset,
     int dst_rank,
     size_t bytes) {
-  RegisteredBuffer src_buf;
-  src_buf.base_ptr = src_base_ptr;
-  src_buf.size = src_size;
-  src_buf.backend_window = src_nccl_win;
   return win->put(
       dst_offset,
       src_buf,
@@ -168,21 +156,24 @@ __device__ __noinline__ int gin_put_warp_fallback(
 __device__ int torchcomms_put_block_direct(
     void* win_ptr,
     unsigned long long dst_offset,
-    void* src_nccl_win,
+    void* src_registered_buf_ptr,
     unsigned long long src_offset,
     int dst_rank,
     unsigned long long bytes) {
   auto* win = reinterpret_cast<DeviceWindow*>(win_ptr);
+  auto* src_buf =
+      reinterpret_cast<const RegisteredBuffer*>(src_registered_buf_ptr);
   const ncclDevComm& dev_comm = win->comm();
 
   if (ncclTeamRankIsMember(
           ncclTeamLsa(dev_comm), ncclTeamWorld(dev_comm), dst_rank)) {
-    // NVLink path: inline PTX memcpy, zero allocas, zero spills.
+    // NVLink path: use base_ptr directly from RegisteredBuffer.
+    // base_ptr == ncclGetLocalPointer(backend_window, 0), avoiding the
+    // indirection through ncclWindow_t.
     ncclWindow_t dst_win = win->window();
-    ncclWindow_t src_win = static_cast<ncclWindow_t>(src_nccl_win);
     char* dst_base =
         static_cast<char*>(ncclGetPeerPointer(dst_win, 0, dst_rank));
-    char* src_base = static_cast<char*>(ncclGetLocalPointer(src_win, 0));
+    char* src_base = static_cast<char*>(src_buf->base_ptr);
 
     nvl_memcpy_ptx(
         dst_base + static_cast<size_t>(dst_offset),
@@ -191,13 +182,11 @@ __device__ int torchcomms_put_block_direct(
         threadIdx.x,
         blockDim.x);
   } else {
-    // GIN (RDMA) fallback: __noinline__ to isolate register pressure.
+    // GIN (RDMA) fallback: pass the full RegisteredBuffer.
     gin_put_fallback(
         win,
         static_cast<size_t>(dst_offset),
-        nullptr,
-        0,
-        src_nccl_win,
+        *src_buf,
         static_cast<size_t>(src_offset),
         dst_rank,
         static_cast<size_t>(bytes));
@@ -210,12 +199,14 @@ __device__ int torchcomms_put_block_direct(
 __device__ int torchcomms_put_warp_chunked_direct(
     void* win_ptr,
     unsigned long long dst_offset,
-    void* src_nccl_win,
+    void* src_registered_buf_ptr,
     unsigned long long src_offset,
     int dst_rank,
     unsigned long long total_bytes,
     unsigned long long chunk_size) {
   auto* win = reinterpret_cast<DeviceWindow*>(win_ptr);
+  auto* src_buf =
+      reinterpret_cast<const RegisteredBuffer*>(src_registered_buf_ptr);
   const ncclDevComm& dev_comm = win->comm();
 
   auto total = static_cast<size_t>(total_bytes);
@@ -224,12 +215,11 @@ __device__ int torchcomms_put_warp_chunked_direct(
 
   if (ncclTeamRankIsMember(
           ncclTeamLsa(dev_comm), ncclTeamWorld(dev_comm), dst_rank)) {
-    // NVLink path: inline PTX memcpy, zero allocas, zero spills.
+    // NVLink path: use base_ptr directly from RegisteredBuffer.
     ncclWindow_t dst_win = win->window();
-    ncclWindow_t src_win = static_cast<ncclWindow_t>(src_nccl_win);
     char* dst_base =
         static_cast<char*>(ncclGetPeerPointer(dst_win, 0, dst_rank));
-    char* src_base = static_cast<char*>(ncclGetLocalPointer(src_win, 0));
+    char* src_base = static_cast<char*>(src_buf->base_ptr);
 
     auto warp_id = threadIdx.x / 32;
     auto num_warps = blockDim.x / 32;
@@ -245,7 +235,7 @@ __device__ int torchcomms_put_warp_chunked_direct(
           32);
     }
   } else {
-    // GIN (RDMA) fallback: __noinline__ to isolate register pressure.
+    // GIN (RDMA) fallback: pass the full RegisteredBuffer.
     auto warp_id = threadIdx.x / 32;
     auto num_warps = blockDim.x / 32;
 
@@ -255,9 +245,7 @@ __device__ int torchcomms_put_warp_chunked_direct(
       gin_put_warp_fallback(
           win,
           static_cast<size_t>(dst_offset) + off,
-          nullptr,
-          0,
-          src_nccl_win,
+          *src_buf,
           static_cast<size_t>(src_offset) + off,
           dst_rank,
           len);


### PR DESCRIPTION
Summary:

Add topology-aware auto-tuning that assigns different kernel parameters to NVLink vs IB peers for the Triton AlltoAllv kernel.

Gated behind TRITON_ALLTOALLV_ENABLE_IB=1 (disabled by default). When disabled, behavior is identical to pre-change (NVLink-only tuning, kernel binary-identical).

Motivation
==========
On multi-node H100, intra-node peers communicate via NVLink (~900 GB/s) while inter-node peers use InfiniBand via GIN RDMA (~50 GB/s per NIC). The existing auto-tuner applies the same parameters (16 blocks/peer, 64KB chunks) to all peers regardless of transport. NVLink benefits from high block parallelism (each block independently saturates NVLink via cooperative memcpy), while IB benefits from fewer blocks (the NIC handles pipelining; extra blocks just add WQE contention).

Design
======
1. **Host-side topology detection** (alltoallv_op.py): AlltoallvOp.setup() calls window.get_nvlink_address(peer) after tensor_register to classify each peer as NVL (non-zero) or IB (zero). Gated behind TRITON_ALLTOALLV_ENABLE_IB=1 env var.

2. **Split auto-tuning** (device_alltoallv_dynamic.py): auto_tune_alltoallv_params() now accepts peer_is_nvl and returns per-peer block counts. _tune_for_nvl() gives 8-16 blocks/peer; _tune_for_ib() gives 1-4 blocks/peer with larger chunks.

3. **Per-peer block masking** (kernel): The kernel launches with BLOCKS_PER_PEER = max(nvl_bpp, ib_bpp) as a constexpr upper bound. A runtime per_peer_blocks_ptr tensor holds the actual block count per peer. Excess blocks early-return. Completion counters and recv signal waits use actual_bpp instead of the uniform BLOCKS_PER_PEER.

4. **Backward compatible**: On single-node (all NVL), per_peer_blocks is None, so HAS_PER_PEER_BLOCKS=False (constexpr) and all masking code is compiled away by Triton. Zero performance impact on the existing single-node path.

Files changed
=============
- device_alltoallv_dynamic.py: _tune_for_nvl(), _tune_for_ib(), per_peer_blocks kernel parameter, block masking, signal updates, per-peer counter reset
- alltoallv_op.py: topology detection in setup(), per_peer_blocks tensor creation, IB env var gate
- tests/test_auto_tune.py: 19 unit tests for tuning logic
- tests/BUCK: test_auto_tune target

Reviewed By: siyengar

Differential Revision: D99965741
