### PR TITLE
Migrate analyzer test from MCCL to ForkBasedTestDriver (#2011)

### DIFF
--- a/comms/ncclx/meta/analyzer/tests/NCCLXCommsTracingServiceHandlerTest.cc
+++ b/comms/ncclx/meta/analyzer/tests/NCCLXCommsTracingServiceHandlerTest.cc
@@ -17,11 +17,9 @@
 #include "comms/analyzer/CommDumpPuller.h"
 #include "comms/analyzer/if/gen-cpp2/CommsTracingService.h"
 #include "comms/analyzer/if/gen-cpp2/CommsTracingService_types_custom_protocol.h"
-#include "comms/mccl/integration_tests/CollectiveIntegrationTestMixin.h"
-#include "comms/mccl/integration_tests/McclIntegrationTestUtil.h"
-#include "comms/mccl/tests/CudaStream.h"
-#include "comms/mccl/tests/CudaTestUtil.h"
+#include "comms/ncclx/meta/tests/ForkBasedTestDriver.h"
 #include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/CudaRAII.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/trainer/TrainerContext.h"
 #include "ftar/DynMemGpuBuffer.h"
@@ -53,6 +51,54 @@ namespace {
 
 using namespace ::testing;
 
+// Fill GPU buffer with a value
+template <typename T>
+void modifyGPUBuffer(
+    size_t numElements,
+    void* data,
+    T value = 1,
+    cudaStream_t stream = nullptr) {
+  std::vector<T> hostData(numElements, value);
+  CUDACHECK(cudaMemcpyAsync(
+      data,
+      hostData.data(),
+      numElements * sizeof(T),
+      cudaMemcpyHostToDevice,
+      stream));
+}
+
+// Validate GPU buffer contains expected value
+template <typename T>
+void validateGPUBuffer(
+    size_t numElements,
+    void* data,
+    T value,
+    cudaStream_t stream = nullptr) {
+  std::vector<T> hostData(numElements, 0);
+  CUDACHECK(cudaMemcpyAsync(
+      hostData.data(),
+      data,
+      numElements * sizeof(T),
+      cudaMemcpyDeviceToHost,
+      stream));
+  for (size_t i = 0; i < numElements; i++) {
+    auto diff = hostData[i] > value ? hostData[i] - value : value - hostData[i];
+    if constexpr (std::is_floating_point_v<T>) {
+      EXPECT_LT(diff, T(1e-5)) << fmt::format(
+          "Validation FAILED expected:{} got:{} position:{}",
+          value,
+          hostData[i],
+          i);
+    } else {
+      EXPECT_EQ(hostData[i], value) << fmt::format(
+          "Validation FAILED expected:{} got:{} position:{}",
+          value,
+          hostData[i],
+          i);
+    }
+  }
+}
+
 // RAII for NCCL Communicator
 class NcclComm {
  public:
@@ -78,7 +124,7 @@ class NcclComm {
   ncclComm_t comm_;
 };
 
-class NcclCommsTest : public mccl::CollectiveIntegrationTestMixin, public Test {
+class NcclCommsTest : public ncclx::test::ForkBasedTestDriver, public Test {
  public:
   void SetUp() override {
     int numRanks = 4;
@@ -95,8 +141,8 @@ class NcclCommsTest : public mccl::CollectiveIntegrationTestMixin, public Test {
     }
     auto portStr = folly::join(",", commsTracingServicePorts);
 
-    mccl::CollectiveIntegrationTestMixin::SetUp(
-        mccl::CollectiveIntegrationTestMixin::Config{
+    ncclx::test::ForkBasedTestDriver::SetUp(
+        ncclx::test::ForkBasedTestDriver::Config{
             .numRanks = numRanks,
             .env =
                 {
@@ -313,9 +359,9 @@ TEST_F(NcclCommsTest, AnalyzerSuccess) {
   int worldSize = getWorldSize();
 
   // Initialize CUDA state
-  auto deviceId = mccl::CudaTestUtil::getCudaDeviceId(rank);
+  auto deviceId = ncclx::test::ForkBasedTestDriver::getCudaDeviceId(rank);
   XLOG(INFO) << "CUDA device id: " << deviceId;
-  mccl::cuda::CudaStream stream;
+  meta::comms::CudaStream stream;
 
   // NCCL unique ID must be generated on one node and shared to all
   // others
@@ -324,11 +370,11 @@ TEST_F(NcclCommsTest, AnalyzerSuccess) {
   if (rank == 0) {
     // Rank 0 creates the unique id
     NCCLCHECK(ncclGetUniqueId(&ncclUniqueID));
-    mccl::McclIntegrationTestUtil::setKey(
+    ncclx::test::ForkBasedTestDriver::setKey(
         uniqueIDKey, std::string(ncclUniqueID.internal, NCCL_UNIQUE_ID_BYTES));
   } else {
     // Everyone else waits for it
-    auto value = mccl::McclIntegrationTestUtil::waitForKey(uniqueIDKey);
+    auto value = ncclx::test::ForkBasedTestDriver::waitForKey(uniqueIDKey);
     std::memcpy(ncclUniqueID.internal, value.data(), NCCL_UNIQUE_ID_BYTES);
   }
 
@@ -341,7 +387,7 @@ TEST_F(NcclCommsTest, AnalyzerSuccess) {
   facebook::ftar::DynMemGpuBuffer recvBuff(size * sizeof(float));
 
   // Modify GPU memory
-  mccl::McclIntegrationTestUtil::modifyGPUBuffer<float>(size, sendBuff.raw());
+  modifyGPUBuffer<float>(size, sendBuff.raw());
 
   // Perform all-reduce operation
   NCCLCHECK(ncclAllReduce(
@@ -351,14 +397,13 @@ TEST_F(NcclCommsTest, AnalyzerSuccess) {
       ncclFloat,
       ncclSum,
       comm.raw(),
-      stream.raw()));
-  CUDACHECK(cudaStreamSynchronize(stream.raw()));
+      stream.get()));
+  CUDACHECK(cudaStreamSynchronize(stream.get()));
 
   // Validate the results of the all reduce
-  mccl::McclIntegrationTestUtil::validateGPUBuffer<float>(
-      size, recvBuff.raw(), worldSize);
+  validateGPUBuffer<float>(size, recvBuff.raw(), worldSize);
 
-  mccl::McclIntegrationTestUtil::setKey(
+  ncclx::test::ForkBasedTestDriver::setKey(
       fmt::format("done_with_collective_rank_{}", rank), "1");
 
   // Rank 0 checks state of collectives
@@ -366,7 +411,7 @@ TEST_F(NcclCommsTest, AnalyzerSuccess) {
     // Get comm dump state from all ranks
     for (int i = 0; i < worldSize; ++i) {
       // Wait for the rank to be done with collectives
-      mccl::McclIntegrationTestUtil::waitForKey(
+      ncclx::test::ForkBasedTestDriver::waitForKey(
           fmt::format("done_with_collective_rank_{}", rank));
 
       // Get the comm dump state for each rank
@@ -408,11 +453,11 @@ TEST_F(NcclCommsTest, AnalyzerSuccess) {
         analyzerExpectedResult, std::chrono::milliseconds(10000)));
 
     // Notify other ranks to finish
-    mccl::McclIntegrationTestUtil::setKey("analyzer_check_0", "1");
+    ncclx::test::ForkBasedTestDriver::setKey("analyzer_check_0", "1");
   }
 
   // All ranks wait for the collectives check to complete
-  mccl::McclIntegrationTestUtil::waitForKey("analyzer_check_0");
+  ncclx::test::ForkBasedTestDriver::waitForKey("analyzer_check_0");
 }
 
 // Rank 0 doesn't join the second
@@ -425,9 +470,9 @@ TEST_F(NcclCommsTest, OneRankHangs) {
   int worldSize = getWorldSize();
 
   // Initialize CUDA state
-  auto deviceId = mccl::CudaTestUtil::getCudaDeviceId(rank);
+  auto deviceId = ncclx::test::ForkBasedTestDriver::getCudaDeviceId(rank);
   XLOG(INFO) << "CUDA device id: " << deviceId;
-  mccl::cuda::CudaStream stream;
+  meta::comms::CudaStream stream;
 
   // NCCL unique ID must be generated on one node and shared to all
   // others
@@ -436,11 +481,11 @@ TEST_F(NcclCommsTest, OneRankHangs) {
   if (rank == 0) {
     // Rank 0 creates the unique id
     NCCLCHECK(ncclGetUniqueId(&ncclUniqueID));
-    mccl::McclIntegrationTestUtil::setKey(
+    ncclx::test::ForkBasedTestDriver::setKey(
         uniqueIDKey, std::string(ncclUniqueID.internal, NCCL_UNIQUE_ID_BYTES));
   } else {
     // Everyone else waits for it
-    auto value = mccl::McclIntegrationTestUtil::waitForKey(uniqueIDKey);
+    auto value = ncclx::test::ForkBasedTestDriver::waitForKey(uniqueIDKey);
     std::memcpy(ncclUniqueID.internal, value.data(), NCCL_UNIQUE_ID_BYTES);
   }
 
@@ -457,7 +502,7 @@ TEST_F(NcclCommsTest, OneRankHangs) {
 
     ncclxSetIteration(c);
     // Modify GPU memory
-    mccl::McclIntegrationTestUtil::modifyGPUBuffer<float>(size, sendBuff.raw());
+    modifyGPUBuffer<float>(size, sendBuff.raw());
 
     // Rank 0 does not join the last collective
     if (c == 3 && rank == 0) {
@@ -470,12 +515,11 @@ TEST_F(NcclCommsTest, OneRankHangs) {
         ncclFloat,
         ncclSum,
         comm.raw(),
-        stream.raw()));
-    CUDACHECK(cudaStreamSynchronize(stream.raw()));
+        stream.get()));
+    CUDACHECK(cudaStreamSynchronize(stream.get()));
 
     // Validate the results of the all reduce
-    mccl::McclIntegrationTestUtil::validateGPUBuffer<float>(
-        size, recvBuff.raw(), worldSize);
+    validateGPUBuffer<float>(size, recvBuff.raw(), worldSize);
   }
 
   // Rank 0 checks state of collectives
@@ -523,12 +567,11 @@ TEST_F(NcclCommsTest, OneRankHangs) {
         ncclFloat,
         ncclSum,
         comm.raw(),
-        stream.raw()));
-    CUDACHECK(cudaStreamSynchronize(stream.raw()));
+        stream.get()));
+    CUDACHECK(cudaStreamSynchronize(stream.get()));
 
     // Validate the results of the all reduce
-    mccl::McclIntegrationTestUtil::validateGPUBuffer<float>(
-        size, recvBuff.raw(), worldSize);
+    validateGPUBuffer<float>(size, recvBuff.raw(), worldSize);
   }
 }
 
@@ -544,9 +587,9 @@ TEST_F(NcclCommsTest, DISABLED_OneRankHangsCudaGraph) {
   int worldSize = getWorldSize();
 
   // Initialize CUDA state
-  auto deviceId = mccl::CudaTestUtil::getCudaDeviceId(rank);
+  auto deviceId = ncclx::test::ForkBasedTestDriver::getCudaDeviceId(rank);
   XLOG(INFO) << "CUDA device id: " << deviceId;
-  mccl::cuda::CudaStream stream;
+  meta::comms::CudaStream stream;
 
   // NCCL unique ID must be generated on one node and shared to all
   // others
@@ -555,11 +598,11 @@ TEST_F(NcclCommsTest, DISABLED_OneRankHangsCudaGraph) {
   if (rank == 0) {
     // Rank 0 creates the unique id
     NCCLCHECK(ncclGetUniqueId(&ncclUniqueID));
-    mccl::McclIntegrationTestUtil::setKey(
+    ncclx::test::ForkBasedTestDriver::setKey(
         uniqueIDKey, std::string(ncclUniqueID.internal, NCCL_UNIQUE_ID_BYTES));
   } else {
     // Everyone else waits for it
-    auto value = mccl::McclIntegrationTestUtil::waitForKey(uniqueIDKey);
+    auto value = ncclx::test::ForkBasedTestDriver::waitForKey(uniqueIDKey);
     std::memcpy(ncclUniqueID.internal, value.data(), NCCL_UNIQUE_ID_BYTES);
   }
 
@@ -573,7 +616,7 @@ TEST_F(NcclCommsTest, DISABLED_OneRankHangsCudaGraph) {
 
   cudaGraph_t graph;
   cudaGraphExec_t instance;
-  CUDACHECK(cudaStreamBeginCapture(stream.raw(), cudaStreamCaptureModeGlobal));
+  CUDACHECK(cudaStreamBeginCapture(stream.get(), cudaStreamCaptureModeGlobal));
   NCCLCHECK(ncclAllReduce(
       (const void*)sendBuff.raw(),
       (void*)recvBuff.raw(),
@@ -581,8 +624,8 @@ TEST_F(NcclCommsTest, DISABLED_OneRankHangsCudaGraph) {
       ncclFloat,
       ncclSum,
       comm.raw(),
-      stream.raw()));
-  CUDACHECK(cudaStreamEndCapture(stream.raw(), &graph));
+      stream.get()));
+  CUDACHECK(cudaStreamEndCapture(stream.get(), &graph));
   CUDACHECK(cudaGraphInstantiate(&instance, graph, NULL, NULL, 0));
 
   for (int c = 0; c < 4; ++c) {
@@ -590,18 +633,17 @@ TEST_F(NcclCommsTest, DISABLED_OneRankHangsCudaGraph) {
 
     ncclxSetIteration(c);
     // Modify GPU memory
-    mccl::McclIntegrationTestUtil::modifyGPUBuffer<float>(size, sendBuff.raw());
+    modifyGPUBuffer<float>(size, sendBuff.raw());
 
     // Rank 0 does not join the last collective
     if (c == 3 && rank == 0) {
       continue;
     }
-    CUDACHECK(cudaGraphLaunch(instance, stream.raw()));
-    CUDACHECK(cudaStreamSynchronize(stream.raw()));
+    CUDACHECK(cudaGraphLaunch(instance, stream.get()));
+    CUDACHECK(cudaStreamSynchronize(stream.get()));
 
     // Validate the results of the all reduce
-    mccl::McclIntegrationTestUtil::validateGPUBuffer<float>(
-        size, recvBuff.raw(), worldSize);
+    validateGPUBuffer<float>(size, recvBuff.raw(), worldSize);
   }
 
   // Rank 0 checks state of collectives
@@ -642,12 +684,11 @@ TEST_F(NcclCommsTest, DISABLED_OneRankHangsCudaGraph) {
         analyzerExpectedResult, std::chrono::milliseconds(20000)));
 
     // Make rank 0 join the collective to unblock the other ranks
-    CUDACHECK(cudaGraphLaunch(instance, stream.raw()));
-    CUDACHECK(cudaStreamSynchronize(stream.raw()));
+    CUDACHECK(cudaGraphLaunch(instance, stream.get()));
+    CUDACHECK(cudaStreamSynchronize(stream.get()));
 
     // Validate the results of the all reduce
-    mccl::McclIntegrationTestUtil::validateGPUBuffer<float>(
-        size, recvBuff.raw(), worldSize);
+    validateGPUBuffer<float>(size, recvBuff.raw(), worldSize);
   }
   CUDACHECK(cudaGraphExecDestroy(instance));
   CUDACHECK(cudaGraphDestroy(graph));
@@ -727,7 +768,7 @@ TEST_F(NcclCommsTest, CollectiveMetadataMismatch) {
   int worldSize = getWorldSize();
 
   // Initialize CUDA state
-  auto deviceId = mccl::CudaTestUtil::getCudaDeviceId(rank);
+  auto deviceId = ncclx::test::ForkBasedTestDriver::getCudaDeviceId(rank);
   XLOG(INFO) << "CUDA device id: " << deviceId;
   cudaStream_t stream;
   CUDACHECK_TEST(cudaStreamCreate(&stream));
@@ -739,11 +780,11 @@ TEST_F(NcclCommsTest, CollectiveMetadataMismatch) {
   if (rank == 0) {
     // Rank 0 creates the unique id
     NCCLCHECK(ncclGetUniqueId(&ncclUniqueID));
-    mccl::McclIntegrationTestUtil::setKey(
+    ncclx::test::ForkBasedTestDriver::setKey(
         uniqueIDKey, std::string(ncclUniqueID.internal, NCCL_UNIQUE_ID_BYTES));
   } else {
     // Everyone else waits for it
-    auto value = mccl::McclIntegrationTestUtil::waitForKey(uniqueIDKey);
+    auto value = ncclx::test::ForkBasedTestDriver::waitForKey(uniqueIDKey);
     std::memcpy(ncclUniqueID.internal, value.data(), NCCL_UNIQUE_ID_BYTES);
   }
 
@@ -780,7 +821,7 @@ TEST_F(NcclCommsTest, CollectiveMetadataMismatch) {
   if (rank == 0) {
     // Always make sure notify other ranks before exiting
     auto finishGuard = folly::makeGuard([&comm]() {
-      mccl::McclIntegrationTestUtil::setKey("test_return_baton", "Finished");
+      ncclx::test::ForkBasedTestDriver::setKey("test_return_baton", "Finished");
     });
     // Wait for analyzer to report rank 0 is missing
     PullOneJobResult analyzerExpectedResult{
@@ -792,7 +833,7 @@ TEST_F(NcclCommsTest, CollectiveMetadataMismatch) {
 
   } else {
     // Wait for analyzer from rank 0 from returning
-    mccl::McclIntegrationTestUtil::waitForKey("test_return_baton");
+    ncclx::test::ForkBasedTestDriver::waitForKey("test_return_baton");
   }
   XLOG(INFO) << "Test finished, start to abort NCCL comm";
 }
@@ -809,7 +850,7 @@ TEST_F(NcclCommsTest, CollectiveCircularDependency) {
   int worldSize = getWorldSize();
 
   // Initialize CUDA state
-  auto deviceId = mccl::CudaTestUtil::getCudaDeviceId(rank);
+  auto deviceId = ncclx::test::ForkBasedTestDriver::getCudaDeviceId(rank);
   XLOG(INFO) << "CUDA device id: " << deviceId;
 
   // cudaGraph_t graph;
@@ -826,18 +867,18 @@ TEST_F(NcclCommsTest, CollectiveCircularDependency) {
   if (rank == 0) {
     // Rank 0 creates the unique id
     NCCLCHECK(ncclGetUniqueId(&ncclUniqueID1));
-    mccl::McclIntegrationTestUtil::setKey(
+    ncclx::test::ForkBasedTestDriver::setKey(
         uniqueIDKey1,
         std::string(ncclUniqueID1.internal, NCCL_UNIQUE_ID_BYTES));
     NCCLCHECK(ncclGetUniqueId(&ncclUniqueID2));
-    mccl::McclIntegrationTestUtil::setKey(
+    ncclx::test::ForkBasedTestDriver::setKey(
         uniqueIDKey2,
         std::string(ncclUniqueID2.internal, NCCL_UNIQUE_ID_BYTES));
   } else {
     // Everyone else waits for it
-    auto value1 = mccl::McclIntegrationTestUtil::waitForKey(uniqueIDKey1);
+    auto value1 = ncclx::test::ForkBasedTestDriver::waitForKey(uniqueIDKey1);
     std::memcpy(ncclUniqueID1.internal, value1.data(), NCCL_UNIQUE_ID_BYTES);
-    auto value2 = mccl::McclIntegrationTestUtil::waitForKey(uniqueIDKey2);
+    auto value2 = ncclx::test::ForkBasedTestDriver::waitForKey(uniqueIDKey2);
     std::memcpy(ncclUniqueID2.internal, value2.data(), NCCL_UNIQUE_ID_BYTES);
     ASSERT_NE(
         strncmp(
@@ -931,7 +972,7 @@ TEST_F(NcclCommsTest, CollectiveCircularDependency) {
   if (rank == 0) {
     // Always make sure notify other ranks before exiting
     auto finishGuard = folly::makeGuard([]() {
-      mccl::McclIntegrationTestUtil::setKey("test_return_baton", "Finished");
+      ncclx::test::ForkBasedTestDriver::setKey("test_return_baton", "Finished");
     });
     // Wait for analyzer to report rank 0 is missing
     PullOneJobResult analyzerExpectedResult{
@@ -943,7 +984,7 @@ TEST_F(NcclCommsTest, CollectiveCircularDependency) {
 
   } else {
     // Wait for analyzer from rank 0 from returning
-    mccl::McclIntegrationTestUtil::waitForKey("test_return_baton");
+    ncclx::test::ForkBasedTestDriver::waitForKey("test_return_baton");
   }
   XLOG(INFO) << "Test finished, start to abort NCCL comm";
 }

--- a/comms/ncclx/meta/colltrace/tests/CollTraceWatchdogIbMockTest.cc
+++ b/comms/ncclx/meta/colltrace/tests/CollTraceWatchdogIbMockTest.cc
@@ -7,11 +7,9 @@
 #include "comm.h" // @manual
 #include "nccl.h" // @manual
 
-#include "comms/mccl/integration_tests/CollectiveIntegrationTestMixin.h"
-#include "comms/mccl/integration_tests/McclIntegrationTestUtil.h"
-#include "comms/mccl/tests/CudaStream.h"
-#include "comms/mccl/tests/CudaTestUtil.h"
+#include "comms/ncclx/meta/tests/ForkBasedTestDriver.h"
 #include "comms/testinfra/IbverbMockTestUtils.h"
+#include "comms/utils/CudaRAII.h"
 #include "ftar/DynMemGpuBuffer.h"
 
 #define NCCLCHECK_FATAL(cmd)                                            \
@@ -41,12 +39,12 @@ class NcclComm {
     if (globalRank == 0) {
       // Rank 0 creates the unique id
       NCCLCHECK_FATAL(ncclGetUniqueId(&ncclUniqueID));
-      mccl::McclIntegrationTestUtil::setKey(
+      ncclx::test::ForkBasedTestDriver::setKey(
           uniqueIDKey,
           std::string(ncclUniqueID.internal, NCCL_UNIQUE_ID_BYTES));
     } else {
       // Everyone else waits for it
-      auto value = mccl::McclIntegrationTestUtil::waitForKey(uniqueIDKey);
+      auto value = ncclx::test::ForkBasedTestDriver::waitForKey(uniqueIDKey);
       std::memcpy(ncclUniqueID.internal, value.data(), NCCL_UNIQUE_ID_BYTES);
     }
     NCCLCHECK_FATAL(
@@ -71,7 +69,7 @@ class NcclComm {
   ncclComm_t comm_{};
 };
 
-class CollTraceWatchdogTest : public mccl::CollectiveIntegrationTestMixin,
+class CollTraceWatchdogTest : public ncclx::test::ForkBasedTestDriver,
                               public ::testing::Test {
  public:
   void SetUp() override {
@@ -102,8 +100,8 @@ class CollTraceWatchdogTest : public mccl::CollectiveIntegrationTestMixin,
       envList.emplace_back(fmt::format("NCCL_IBVERBS_PATH={}", hookIbVerbs));
     }
 
-    mccl::CollectiveIntegrationTestMixin::SetUp(
-        mccl::CollectiveIntegrationTestMixin::Config{
+    ncclx::test::ForkBasedTestDriver::SetUp(
+        ncclx::test::ForkBasedTestDriver::Config{
             .numRanks = numRanks,
             .shouldExitOnFailure = false,
             .env = envList});
@@ -115,10 +113,9 @@ class CollTraceWatchdogTest : public mccl::CollectiveIntegrationTestMixin,
   void testDriverCheckCrashedWithWatchdog() {
     ASSERT_TRUE(
         std::holds_alternative<
-            mccl::CollectiveIntegrationTestMixin::TestDriverState>(
-            this->state_));
+            ncclx::test::ForkBasedTestDriver::TestDriverState>(this->state_));
     auto& testDriverState =
-        std::get<mccl::CollectiveIntegrationTestMixin::TestDriverState>(
+        std::get<ncclx::test::ForkBasedTestDriver::TestDriverState>(
             this->state_);
     // Check that all ranks exited with non-zero exit code
     EXPECT_THAT(
@@ -149,9 +146,9 @@ TEST_F(CollTraceWatchdogTest, TestAsyncErrorWithIbVerbMock) {
           "ncclx.colltrace.crashOnAsyncError", folly::to<std::string>(true)));
 
   // Initialize CUDA state
-  auto deviceId = mccl::CudaTestUtil::getCudaDeviceId(rank);
+  auto deviceId = ncclx::test::ForkBasedTestDriver::getCudaDeviceId(rank);
   XLOG(INFO) << "CUDA device id: " << deviceId;
-  mccl::cuda::CudaStream stream;
+  meta::comms::CudaStream stream;
 
   // Initialize NCCL communicator
   NcclComm comm(worldSize, rank);
@@ -175,7 +172,7 @@ TEST_F(CollTraceWatchdogTest, TestAsyncErrorWithIbVerbMock) {
       ncclFloat,
       ncclSum,
       comm.raw(),
-      stream.raw()));
+      stream.get()));
 
-  CUDACHECK_FATAL(cudaStreamSynchronize(stream.raw()));
+  CUDACHECK_FATAL(cudaStreamSynchronize(stream.get()));
 }

--- a/comms/ncclx/meta/colltrace/tests/CollTraceWatchdogTest.cc
+++ b/comms/ncclx/meta/colltrace/tests/CollTraceWatchdogTest.cc
@@ -8,10 +8,8 @@
 #include "comm.h" // @manual
 #include "nccl.h" // @manual
 
-#include "comms/mccl/integration_tests/CollectiveIntegrationTestMixin.h"
-#include "comms/mccl/integration_tests/McclIntegrationTestUtil.h"
-#include "comms/mccl/tests/CudaStream.h"
-#include "comms/mccl/tests/CudaTestUtil.h"
+#include "comms/ncclx/meta/tests/ForkBasedTestDriver.h"
+#include "comms/utils/CudaRAII.h"
 #include "comms/utils/colltrace/tests/nvidia-only/CPUControlledKernel.h"
 #include "ftar/DynMemGpuBuffer.h"
 
@@ -42,12 +40,12 @@ class NcclComm {
     if (globalRank == 0) {
       // Rank 0 creates the unique id
       NCCLCHECK_FATAL(ncclGetUniqueId(&ncclUniqueID));
-      mccl::McclIntegrationTestUtil::setKey(
+      ncclx::test::ForkBasedTestDriver::setKey(
           uniqueIDKey,
           std::string(ncclUniqueID.internal, NCCL_UNIQUE_ID_BYTES));
     } else {
       // Everyone else waits for it
-      auto value = mccl::McclIntegrationTestUtil::waitForKey(uniqueIDKey);
+      auto value = ncclx::test::ForkBasedTestDriver::waitForKey(uniqueIDKey);
       std::memcpy(ncclUniqueID.internal, value.data(), NCCL_UNIQUE_ID_BYTES);
     }
     NCCLCHECK_FATAL(
@@ -90,14 +88,14 @@ void waitStreamWithTimeout(
   FAIL() << "Wait Stream did not complete within timeout";
 }
 
-class CollTraceWatchdogTest : public mccl::CollectiveIntegrationTestMixin,
+class CollTraceWatchdogTest : public ncclx::test::ForkBasedTestDriver,
                               public ::testing::Test {
  public:
   void SetUp() override {
     int numRanks = 4;
 
-    mccl::CollectiveIntegrationTestMixin::SetUp(
-        mccl::CollectiveIntegrationTestMixin::Config{
+    ncclx::test::ForkBasedTestDriver::SetUp(
+        ncclx::test::ForkBasedTestDriver::Config{
             .numRanks = numRanks,
             .shouldExitOnFailure = false,
             .env =
@@ -131,12 +129,11 @@ class CollTraceWatchdogTest : public mccl::CollectiveIntegrationTestMixin,
   void testDriverCheckSucceed() {
     ASSERT_TRUE(
         std::holds_alternative<
-            mccl::CollectiveIntegrationTestMixin::TestDriverState>(
-            this->state_));
+            ncclx::test::ForkBasedTestDriver::TestDriverState>(this->state_));
     auto& testDriverState =
-        std::get<mccl::CollectiveIntegrationTestMixin::TestDriverState>(
+        std::get<ncclx::test::ForkBasedTestDriver::TestDriverState>(
             this->state_);
-    // Check that all ranks exited with non-zero exit code
+    // Check that all ranks exited with zero exit code
     EXPECT_THAT(
         testDriverState.workerExitCodes, ::testing::Each(::testing::Eq(0)));
   }
@@ -144,10 +141,9 @@ class CollTraceWatchdogTest : public mccl::CollectiveIntegrationTestMixin,
   void testDriverCheckCrashedWithWatchdog() {
     ASSERT_TRUE(
         std::holds_alternative<
-            mccl::CollectiveIntegrationTestMixin::TestDriverState>(
-            this->state_));
+            ncclx::test::ForkBasedTestDriver::TestDriverState>(this->state_));
     auto& testDriverState =
-        std::get<mccl::CollectiveIntegrationTestMixin::TestDriverState>(
+        std::get<ncclx::test::ForkBasedTestDriver::TestDriverState>(
             this->state_);
     // Check that all ranks exited with non-zero exit code
     EXPECT_THAT(
@@ -166,7 +162,7 @@ class CollTraceWatchdogTest : public mccl::CollectiveIntegrationTestMixin,
 
 class NcclAllReduce {
  public:
-  NcclAllReduce(ncclComm_t comm, mccl::cuda::CudaStream& stream, int64_t size)
+  NcclAllReduce(ncclComm_t comm, meta::comms::CudaStream& stream, int64_t size)
       : sendBuff_(size * sizeof(float)), recvBuff_(size * sizeof(float)) {
     NCCLCHECK_FATAL(ncclAllReduce(
         (const void*)sendBuff_.raw(),
@@ -175,7 +171,7 @@ class NcclAllReduce {
         ncclFloat,
         ncclSum,
         comm,
-        stream.raw()));
+        stream.get()));
   }
 
  private:
@@ -197,9 +193,9 @@ TEST_F(CollTraceWatchdogTest, TestAsyncErrorFromGPE) {
           "ncclx.colltrace.crashOnAsyncError", folly::to<std::string>(true)));
 
   // Initialize CUDA state
-  auto deviceId = mccl::CudaTestUtil::getCudaDeviceId(rank);
+  auto deviceId = ncclx::test::ForkBasedTestDriver::getCudaDeviceId(rank);
   XLOG(INFO) << "CUDA device id: " << deviceId;
-  mccl::cuda::CudaStream stream;
+  meta::comms::CudaStream stream;
 
   // Initialize NCCL communicator
   NcclComm comm(worldSize, rank);
@@ -228,13 +224,13 @@ TEST_F(CollTraceWatchdogTest, TestAsyncErrorFromGPE) {
   NCCLCHECK_FATAL(
 #if NCCL_MINOR >= 29
       ncclx::ncclPutSignal(
-          sendBuff, 32, ncclFloat, dstRank, 0, win, stream.raw()));
-  NCCLCHECK_FATAL(ncclx::ncclWaitSignal(srcRank, win, stream.raw()));
+          sendBuff, 32, ncclFloat, dstRank, 0, win, stream.get()));
+  NCCLCHECK_FATAL(ncclx::ncclWaitSignal(srcRank, win, stream.get()));
 #else
-      ncclPutSignal(sendBuff, 32, ncclFloat, dstRank, 0, win, stream.raw()));
-  NCCLCHECK_FATAL(ncclWaitSignal(srcRank, win, stream.raw()));
+      ncclPutSignal(sendBuff, 32, ncclFloat, dstRank, 0, win, stream.get()));
+  NCCLCHECK_FATAL(ncclWaitSignal(srcRank, win, stream.get()));
 #endif
-  waitStreamWithTimeout(stream.raw(), std::chrono::seconds{80});
+  waitStreamWithTimeout(stream.get(), std::chrono::seconds{80});
 }
 
 TEST_F(CollTraceWatchdogTest, TestAsyncErrorWithGenericAsyncError) {
@@ -251,12 +247,12 @@ TEST_F(CollTraceWatchdogTest, TestAsyncErrorWithGenericAsyncError) {
           "ncclx.colltrace.crashOnAsyncError", folly::to<std::string>(true)));
 
   // Initialize CUDA state
-  auto deviceId = mccl::CudaTestUtil::getCudaDeviceId(rank);
+  auto deviceId = ncclx::test::ForkBasedTestDriver::getCudaDeviceId(rank);
   XLOG(INFO) << "CUDA device id: " << deviceId;
 
   // Initialize NCCL communicator
   NcclComm comm(worldSize, rank);
-  mccl::cuda::CudaStream stream;
+  meta::comms::CudaStream stream;
 
   // Ensure we are using new colltrace
   ASSERT_EQ(comm.raw()->ctranComm_->collTrace_, nullptr);
@@ -266,7 +262,7 @@ TEST_F(CollTraceWatchdogTest, TestAsyncErrorWithGenericAsyncError) {
 
   ncclCommSetAsyncError(comm.raw(), ncclInternalError);
 
-  waitStreamWithTimeout(stream.raw(), std::chrono::seconds{20});
+  waitStreamWithTimeout(stream.get(), std::chrono::seconds{20});
 
   // Wait for sufficiently long for watchdog to stop waiting and exit
   sleep(70);
@@ -293,12 +289,12 @@ TEST_F(CollTraceWatchdogTest, TestTimeoutBeforeColl) {
           folly::to<std::string>(timeoutSec.count() * 1000)));
 
   // Initialize CUDA state
-  auto deviceId = mccl::CudaTestUtil::getCudaDeviceId(rank);
+  auto deviceId = ncclx::test::ForkBasedTestDriver::getCudaDeviceId(rank);
   XLOG(INFO) << "CUDA device id: " << deviceId;
 
   // Initialize NCCL communicator
   NcclComm comm(worldSize, rank);
-  mccl::cuda::CudaStream stream;
+  meta::comms::CudaStream stream;
 
   // Ensure we are using new colltrace
   ASSERT_EQ(comm.raw()->ctranComm_->collTrace_, nullptr);
@@ -307,9 +303,9 @@ TEST_F(CollTraceWatchdogTest, TestTimeoutBeforeColl) {
   // Need a have an allReduce here to trigger pre-connect
   NcclAllReduce initAllReduce(comm.raw(), stream, 32);
 
-  waitStreamWithTimeout(stream.raw(), std::chrono::seconds{20});
+  waitStreamWithTimeout(stream.get(), std::chrono::seconds{20});
 
-  meta::comms::colltrace::CPUControlledKernel kernel(stream.raw());
+  meta::comms::colltrace::CPUControlledKernel kernel(stream.get());
   // Insert a kernel before the collective kernel in the stream;
   kernel.launch();
 
@@ -345,12 +341,12 @@ TEST_F(CollTraceWatchdogTest, TestTimeoutInColl) {
           folly::to<std::string>(timeoutSec.count() * 1000)));
 
   // Initialize CUDA state
-  auto deviceId = mccl::CudaTestUtil::getCudaDeviceId(rank);
+  auto deviceId = ncclx::test::ForkBasedTestDriver::getCudaDeviceId(rank);
   XLOG(INFO) << "CUDA device id: " << deviceId;
 
   // Initialize NCCL communicator
   NcclComm comm(worldSize, rank);
-  mccl::cuda::CudaStream stream;
+  meta::comms::CudaStream stream;
 
   // Ensure we are using new colltrace
   ASSERT_EQ(comm.raw()->ctranComm_->collTrace_, nullptr);
@@ -359,7 +355,7 @@ TEST_F(CollTraceWatchdogTest, TestTimeoutInColl) {
   // Need a have an allReduce here to trigger pre-connect
   NcclAllReduce initAllReduce(comm.raw(), stream, 32);
 
-  waitStreamWithTimeout(stream.raw(), std::chrono::seconds{20});
+  waitStreamWithTimeout(stream.get(), std::chrono::seconds{20});
 
   if (rank != 0) {
     // Sleep long enough to make other ranks timeout
@@ -395,12 +391,12 @@ TEST_F(CollTraceWatchdogTest, TestBelowTimeoutInColl) {
           folly::to<std::string>(timeoutSec.count() * 1000)));
 
   // Initialize CUDA state
-  auto deviceId = mccl::CudaTestUtil::getCudaDeviceId(rank);
+  auto deviceId = ncclx::test::ForkBasedTestDriver::getCudaDeviceId(rank);
   XLOG(INFO) << "CUDA device id: " << deviceId;
 
   // Initialize NCCL communicator
   NcclComm comm(worldSize, rank);
-  mccl::cuda::CudaStream stream;
+  meta::comms::CudaStream stream;
 
   // Ensure we are using new colltrace
   ASSERT_EQ(comm.raw()->ctranComm_->collTrace_, nullptr);
@@ -409,7 +405,7 @@ TEST_F(CollTraceWatchdogTest, TestBelowTimeoutInColl) {
   // Need a have an allReduce here to trigger pre-connect
   NcclAllReduce initAllReduce(comm.raw(), stream, 32);
 
-  waitStreamWithTimeout(stream.raw(), std::chrono::seconds{20});
+  waitStreamWithTimeout(stream.get(), std::chrono::seconds{20});
 
   if (rank != 0) {
     // Sleep shortly, but longer than how long we slept for small timeout case
@@ -420,7 +416,7 @@ TEST_F(CollTraceWatchdogTest, TestBelowTimeoutInColl) {
     std::this_thread::sleep_for(std::chrono::seconds{10});
   }
 
-  waitStreamWithTimeout(stream.raw(), std::chrono::seconds{20});
+  waitStreamWithTimeout(stream.get(), std::chrono::seconds{20});
 }
 
 TEST_F(CollTraceWatchdogTest, TestBelowTimeoutBeforeColl) {
@@ -444,12 +440,12 @@ TEST_F(CollTraceWatchdogTest, TestBelowTimeoutBeforeColl) {
           folly::to<std::string>(timeoutSec.count() * 1000)));
 
   // Initialize CUDA state
-  auto deviceId = mccl::CudaTestUtil::getCudaDeviceId(rank);
+  auto deviceId = ncclx::test::ForkBasedTestDriver::getCudaDeviceId(rank);
   XLOG(INFO) << "CUDA device id: " << deviceId;
 
   // Initialize NCCL communicator
   NcclComm comm(worldSize, rank);
-  mccl::cuda::CudaStream stream;
+  meta::comms::CudaStream stream;
 
   // Ensure we are using new colltrace
   ASSERT_EQ(comm.raw()->ctranComm_->collTrace_, nullptr);
@@ -458,9 +454,9 @@ TEST_F(CollTraceWatchdogTest, TestBelowTimeoutBeforeColl) {
   // Need a have an allReduce here to trigger pre-connect
   NcclAllReduce initAllReduce(comm.raw(), stream, 32);
 
-  waitStreamWithTimeout(stream.raw(), std::chrono::seconds{20});
+  waitStreamWithTimeout(stream.get(), std::chrono::seconds{20});
 
-  meta::comms::colltrace::CPUControlledKernel kernel(stream.raw());
+  meta::comms::colltrace::CPUControlledKernel kernel(stream.get());
   // Insert a kernel before the collective kernel in the stream;
   kernel.launch();
 
@@ -469,5 +465,5 @@ TEST_F(CollTraceWatchdogTest, TestBelowTimeoutBeforeColl) {
   std::this_thread::sleep_for(std::chrono::seconds{10});
   kernel.endKernel();
 
-  waitStreamWithTimeout(stream.raw(), std::chrono::seconds{20});
+  waitStreamWithTimeout(stream.get(), std::chrono::seconds{20});
 }

--- a/comms/ncclx/meta/tests/ForkBasedTestDriver.cpp
+++ b/comms/ncclx/meta/tests/ForkBasedTestDriver.cpp
@@ -1,0 +1,398 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/ncclx/meta/tests/ForkBasedTestDriver.h"
+
+#include <signal.h>
+#include <sys/prctl.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <fcntl.h>
+#include <cstdlib>
+#include <cstring>
+
+#include <c10/util/Exception.h>
+
+#include <fmt/format.h>
+#include <folly/FileUtil.h>
+#include <folly/String.h>
+#include <folly/logging/xlog.h>
+#include <gtest/gtest.h>
+
+#include <cuda_runtime.h>
+
+namespace ncclx::test {
+
+namespace {
+
+constexpr std::string_view kWorkerProcessEnvVar{
+    "NCCLX_FORK_TEST_WORKER_PROCESS"};
+constexpr std::string_view kRankEnvVar{"RANK"};
+constexpr std::string_view kLocalRankEnvVar{"LOCAL_RANK"};
+constexpr std::string_view kWorldSizeEnvVar{"WORLD_SIZE"};
+constexpr std::string_view kStorePortEnvVar{"FORK_TEST_STORE_PORT"};
+constexpr std::string_view kStoreHostEnvVar{"FORK_TEST_STORE_HOST"};
+
+// LLVM coverage env vars to propagate to workers
+const std::vector<std::string_view> kCoverageEnvVars{
+    "LLVM_PROFILE_FILE",
+    "LLVM_COV",
+    "LLVM_COVERAGE_ADDITIONAL_OBJECT_PATHS",
+};
+
+int32_t getIntFromEnvVar(std::string_view envVar) {
+  auto* valueStr = std::getenv(envVar.data());
+  XLOG_IF(FATAL, valueStr == nullptr) << envVar << " env var not set";
+  auto valueTry = folly::tryTo<int32_t>(valueStr);
+  XLOG_IF(FATAL, !valueTry.hasValue())
+      << "Invalid " << envVar << " env var value: " << valueStr;
+  return valueTry.value();
+}
+
+struct Cmdline {
+  std::string binaryPath;
+  std::vector<std::string> args;
+};
+
+Cmdline getCurrentProcessCmdline() {
+  // Get binary path from /proc/self/exe (symlink to actual binary)
+  char binaryPath[PATH_MAX];
+  ssize_t len = readlink("/proc/self/exe", binaryPath, sizeof(binaryPath) - 1);
+  XLOG_IF(FATAL, len < 0) << "Failed to read /proc/self/exe";
+  binaryPath[len] = '\0';
+
+  // Get command line args from /proc/self/cmdline
+  std::string cmdline;
+  bool ret = folly::readFile("/proc/self/cmdline", cmdline);
+  XLOG_IF(FATAL, !ret) << "Failed to read /proc/self/cmdline";
+
+  std::vector<std::string_view> parts;
+  // Note: arguments are stored as null-byte-delimited sequence.
+  folly::split(std::string("\x00", 1), cmdline, parts);
+
+  Cmdline result;
+  result.binaryPath = binaryPath;
+  for (size_t i = 1; i < parts.size(); ++i) {
+    if (!parts[i].empty()) {
+      result.args.emplace_back(parts[i]);
+    }
+  }
+  return result;
+}
+
+// Singleton state for test driver to ensure workers spawn only once per
+// process. Uses Meyer's Singleton pattern.
+struct TestDriverSingletonState {
+  bool workersSpawned = false;
+  // Raw pointer to avoid static destruction order issues.
+  // Intentionally leaked - lives for process lifetime.
+  ForkBasedTestDriver::TestDriverState* state = nullptr;
+  std::shared_ptr<c10d::TCPStore> store;
+};
+
+TestDriverSingletonState& getTestDriverSingleton() {
+  static TestDriverSingletonState instance;
+  return instance;
+}
+
+// Singleton state for worker processes
+struct WorkerSingletonState {
+  std::shared_ptr<c10d::TCPStore> store;
+  bool initialized = false;
+};
+
+WorkerSingletonState& getWorkerSingleton() {
+  static WorkerSingletonState instance;
+  return instance;
+}
+
+ForkBasedTestDriver::TestDriverState testDriverMain(
+    const ForkBasedTestDriver::Config& config,
+    std::shared_ptr<c10d::TCPStore>& storeOut) {
+  XLOG(INFO) << "ForkBasedTestDriver: I am the test driver";
+
+  // Create TCPStore server with OS-assigned port
+  auto store = std::make_shared<c10d::TCPStore>(
+      "127.0.0.1",
+      c10d::TCPStoreOptions{
+          .port = 0,
+          .isServer = true,
+          .numWorkers = config.numRanks + 1, // workers + driver
+          .waitWorkers = false, // Workers haven't been forked yet
+      });
+  storeOut = store;
+
+  auto storePort = store->getPort();
+  XLOG(INFO) << "ForkBasedTestDriver: TCPStore running on port " << storePort;
+
+  // Get current process command line and prepare for re-exec
+  auto cmdline = getCurrentProcessCmdline();
+
+  // Override --gtest_filter so workers only run the current test case
+  auto* testInfo = ::testing::UnitTest::GetInstance()->current_test_info();
+  XLOG_IF(FATAL, testInfo == nullptr) << "No current test info available";
+
+  std::vector<std::string> filteredArgs;
+  filteredArgs.reserve(cmdline.args.size());
+  for (auto& arg : cmdline.args) {
+    if (arg.find("--gtest_filter=") != 0) {
+      filteredArgs.push_back(std::move(arg));
+    }
+  }
+  filteredArgs.push_back(
+      fmt::format(
+          "--gtest_filter={}.{}",
+          testInfo->test_suite_name(),
+          testInfo->name()));
+  cmdline.args = std::move(filteredArgs);
+  XLOG(INFO) << "ForkBasedTestDriver: Worker gtest filter: "
+             << cmdline.args.back();
+
+  // Fork worker processes
+  std::vector<pid_t> workerPids;
+  workerPids.reserve(config.numRanks);
+
+  for (int rank = 0; rank < config.numRanks; ++rank) {
+    pid_t pid = fork();
+    PCHECK(pid >= 0) << "fork() failed";
+
+    if (pid == 0) {
+      // Child process: set up env and exec
+
+      // Auto-terminate if parent dies
+      prctl(PR_SET_PDEATHSIG, SIGTERM);
+
+      // Set required env vars
+      setenv(kWorkerProcessEnvVar.data(), "1", 1);
+      setenv(kRankEnvVar.data(), std::to_string(rank).c_str(), 1);
+      setenv(kLocalRankEnvVar.data(), std::to_string(rank).c_str(), 1);
+      setenv(
+          kWorldSizeEnvVar.data(), std::to_string(config.numRanks).c_str(), 1);
+      setenv(kStorePortEnvVar.data(), std::to_string(storePort).c_str(), 1);
+      setenv(kStoreHostEnvVar.data(), "127.0.0.1", 1);
+
+      // Unset vars that cause duplicate test result files
+      unsetenv("TEST_RESULTS_OUTPUT_FILE");
+      unsetenv("GTEST_OUTPUT");
+
+      // Set user-provided env vars
+      for (const auto& envVar : config.env) {
+        auto pos = envVar.find('=');
+        if (pos != std::string::npos) {
+          auto key = envVar.substr(0, pos);
+          auto value = envVar.substr(pos + 1);
+          setenv(key.c_str(), value.c_str(), 1);
+        }
+      }
+
+      // Propagate LLVM coverage env vars
+      for (const auto& coverageEnvVar : kCoverageEnvVars) {
+        if (auto* value = std::getenv(coverageEnvVar.data())) {
+          setenv(coverageEnvVar.data(), value, 1);
+        }
+      }
+
+      int devnull = ::open("/dev/null", O_WRONLY);
+      if (devnull >= 0) {
+        ::dup2(devnull, STDOUT_FILENO);
+        ::close(devnull);
+      }
+
+      if (auto* existing = std::getenv("ASAN_OPTIONS")) {
+        std::string opts(existing);
+        if (opts.find("protect_shadow_gap=") == std::string::npos) {
+          if (!opts.empty()) {
+            opts += ":";
+          }
+          opts += "protect_shadow_gap=0";
+          setenv("ASAN_OPTIONS", opts.c_str(), 1);
+        }
+      } else {
+        setenv("ASAN_OPTIONS", "protect_shadow_gap=0", 1);
+      }
+
+      // Build argv for execv
+      std::vector<char*> argv;
+      argv.push_back(const_cast<char*>(cmdline.binaryPath.c_str()));
+      for (auto& arg : cmdline.args) {
+        argv.push_back(const_cast<char*>(arg.c_str()));
+      }
+      argv.push_back(nullptr);
+
+      execv(cmdline.binaryPath.c_str(), argv.data());
+      // If execv returns, it failed
+      XLOG(FATAL) << "execv failed: " << strerror(errno);
+      _exit(1);
+    }
+
+    // Parent: record child PID
+    workerPids.push_back(pid);
+    XLOG(INFO) << "ForkBasedTestDriver: Launched worker rank " << rank
+               << " with pid " << pid;
+  }
+
+  // Collect exit codes from all workers
+  std::vector<int> workerExitCodes(config.numRanks, -1);
+
+  for (int rank = 0; rank < config.numRanks; ++rank) {
+    int status = 0;
+    pid_t result = waitpid(workerPids[rank], &status, 0);
+
+    if (result < 0) {
+      XLOG(ERR) << "ForkBasedTestDriver: waitpid failed for rank " << rank
+                << ": " << strerror(errno);
+      workerExitCodes[rank] = -1;
+      continue;
+    }
+
+    if (WIFEXITED(status)) {
+      workerExitCodes[rank] = WEXITSTATUS(status);
+    } else if (WIFSIGNALED(status)) {
+      workerExitCodes[rank] = 128 + WTERMSIG(status);
+    } else {
+      workerExitCodes[rank] = -1;
+    }
+
+    if (workerExitCodes[rank] != 0) {
+      if (config.shouldExitOnFailure) {
+        XLOG(FATAL) << "ForkBasedTestDriver: Rank " << rank
+                    << " exited with code: " << workerExitCodes[rank];
+      } else {
+        XLOG(INFO) << "ForkBasedTestDriver: Rank " << rank
+                   << " exited with code: " << workerExitCodes[rank];
+      }
+    }
+  }
+
+  return ForkBasedTestDriver::TestDriverState{
+      .workerExitCodes = std::move(workerExitCodes),
+  };
+}
+
+ForkBasedTestDriver::WorkerState workerMain() {
+  auto& singleton = getWorkerSingleton();
+  if (!singleton.initialized) {
+    auto port = getIntFromEnvVar(kStorePortEnvVar);
+    auto* host = std::getenv(kStoreHostEnvVar.data());
+    XLOG_IF(FATAL, host == nullptr) << "FORK_TEST_STORE_HOST not set";
+
+    singleton.store = std::make_shared<c10d::TCPStore>(
+        host,
+        c10d::TCPStoreOptions{
+            .port = static_cast<uint16_t>(port),
+            .isServer = false,
+        });
+    singleton.initialized = true;
+  }
+
+  XLOG(INFO) << "ForkBasedTestDriver: I am worker rank "
+             << ForkBasedTestDriver::getRank();
+
+  return ForkBasedTestDriver::WorkerState{
+      .store = singleton.store,
+  };
+}
+
+} // namespace
+
+void ForkBasedTestDriver::SetUp(const Config& config) {
+  if (!isTestDriverProcess()) {
+    state_ = workerMain();
+    return;
+  }
+
+  // For the test driver: only spawn workers once, not per-test.
+  auto& singleton = getTestDriverSingleton();
+  if (!singleton.workersSpawned) {
+    singleton.workersSpawned = true;
+    singleton.state =
+        new TestDriverState(testDriverMain(config, singleton.store));
+  }
+  state_ = *singleton.state;
+}
+
+void ForkBasedTestDriver::TearDown() {
+  // No-op: workers are reaped in SetUp, store is cleaned up via shared_ptr
+}
+
+const ForkBasedTestDriver::TestDriverState&
+ForkBasedTestDriver::getTestDriverState() {
+  return std::get<TestDriverState>(state_);
+}
+
+/* static */
+bool ForkBasedTestDriver::isTestDriverProcess() {
+  if (auto* valueStr = std::getenv(kWorkerProcessEnvVar.data())) {
+    return std::string(valueStr) != "1";
+  }
+  return true;
+}
+
+/* static */
+int ForkBasedTestDriver::getRank() {
+  return getIntFromEnvVar(kRankEnvVar);
+}
+
+/* static */
+int ForkBasedTestDriver::getWorldSize() {
+  return getIntFromEnvVar(kWorldSizeEnvVar);
+}
+
+/* static */
+std::shared_ptr<c10d::TCPStore> ForkBasedTestDriver::getStore() {
+  if (isTestDriverProcess()) {
+    return getTestDriverSingleton().store;
+  }
+  return getWorkerSingleton().store;
+}
+
+/* static */
+void ForkBasedTestDriver::setKey(
+    const std::string& key,
+    const std::string& value) {
+  auto store = getStore();
+  store->set(key, std::vector<uint8_t>(value.begin(), value.end()));
+}
+
+/* static */
+std::string ForkBasedTestDriver::waitForKey(const std::string& key) {
+  auto store = getStore();
+  auto value = store->get(key);
+  return std::string(value.begin(), value.end());
+}
+
+/* static */
+std::optional<std::string> ForkBasedTestDriver::waitForKey(
+    const std::string& key,
+    std::chrono::milliseconds timeout) {
+  auto store = getStore();
+  try {
+    store->wait({key}, timeout);
+  } catch (const c10::DistStoreError&) {
+    return std::nullopt;
+  }
+  // Keys are write-once in test usage, so get() after wait() is safe.
+  auto value = store->get(key);
+  return std::string(value.begin(), value.end());
+}
+
+/* static */
+int ForkBasedTestDriver::getCudaDeviceId(int rank) {
+  int numDevices{0};
+  cudaGetDeviceCount(&numDevices);
+  auto err = cudaGetDeviceCount(&numDevices);
+  XLOG_IF(FATAL, err != cudaSuccess)
+      << "cudaGetDeviceCount failed: " << cudaGetErrorString(err);
+
+  XLOG_IF(FATAL, numDevices <= 0) << "No CUDA devices available";
+  int deviceId = rank % numDevices;
+  XLOG(INFO) << "Using CUDA device id: " << deviceId << " for rank: " << rank;
+  cudaSetDevice(deviceId);
+  err = cudaSetDevice(deviceId);
+  XLOG_IF(FATAL, err != cudaSuccess)
+      << "cudaSetDevice failed: " << cudaGetErrorString(err);
+
+  return deviceId;
+}
+
+} // namespace ncclx::test

--- a/comms/ncclx/meta/tests/ForkBasedTestDriver.h
+++ b/comms/ncclx/meta/tests/ForkBasedTestDriver.h
@@ -1,0 +1,79 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <chrono>
+#include <memory>
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+
+#include <torch/csrc/distributed/c10d/TCPStore.hpp> // @manual=//caffe2:libtorch
+
+namespace ncclx::test {
+
+// Fork-based test driver for multi-process NCCLX tests that need to inspect
+// worker exit codes (e.g., watchdog crash tests). The test driver process
+// re-execs the test binary as worker subprocesses, each scoped to the current
+// test case via --gtest_filter.
+//
+// Usage:
+//   class MyTest : public ForkBasedTestDriver, public ::testing::Test {
+//    public:
+//     void SetUp() override {
+//       ForkBasedTestDriver::SetUp(Config{.numRanks = 4});
+//     }
+//   };
+//
+//   TEST_F(MyTest, Foo) {
+//     if (isTestDriverProcess()) {
+//       // Inspect exit codes via state_
+//       return;
+//     }
+//     // Worker logic
+//     auto rank = getRank();
+//   }
+class ForkBasedTestDriver {
+ public:
+  struct Config {
+    int numRanks{1};
+    bool shouldExitOnFailure{true};
+    std::vector<std::string> env; // "KEY=VALUE" format
+  };
+
+  struct WorkerState {
+    std::shared_ptr<c10d::TCPStore> store;
+  };
+
+  struct TestDriverState {
+    // Exit codes for each worker process.
+    // Signal-terminated workers are reported as 128 + signal number.
+    std::vector<int> workerExitCodes;
+  };
+
+  void SetUp(const Config& config);
+  void TearDown();
+
+  static bool isTestDriverProcess();
+  static int getRank();
+  static int getWorldSize();
+  static std::shared_ptr<c10d::TCPStore> getStore();
+
+  // KV convenience helpers (wrapping TCPStore set/get)
+  static void setKey(const std::string& key, const std::string& value);
+  static std::string waitForKey(const std::string& key);
+  static std::optional<std::string> waitForKey(
+      const std::string& key,
+      std::chrono::milliseconds timeout);
+
+  const TestDriverState& getTestDriverState();
+
+  // Sets CUDA device for the given rank and returns the device ID
+  static int getCudaDeviceId(int rank);
+
+  using State = std::variant<WorkerState, TestDriverState>;
+  State state_; // Default-constructed as WorkerState.
+};
+
+} // namespace ncclx::test

--- a/comms/ncclx/meta/tests/ForkBasedTestDriverTest.cc
+++ b/comms/ncclx/meta/tests/ForkBasedTestDriverTest.cc
@@ -1,0 +1,104 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <chrono>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <signal.h>
+
+#include "comms/ncclx/meta/tests/ForkBasedTestDriver.h"
+
+using namespace ncclx::test;
+using namespace ::testing;
+
+// --- Static method tests (no fixture needed) ---
+
+TEST(ForkBasedTestDriverStaticTest, IsTestDriverByDefault) {
+  EXPECT_TRUE(ForkBasedTestDriver::isTestDriverProcess());
+}
+
+// --- Fixture 1: Basic multi-rank success ---
+// Workers exit normally; verifies rank/worldSize accessors and KV round-trip.
+// KV test is included here (not a separate TEST_F) because the singleton only
+// exec's workers for the first test in the fixture.
+
+class ForkBasedTestDriverBasicTest : public ForkBasedTestDriver,
+                                     public ::testing::Test {
+ public:
+  void SetUp() override {
+    ForkBasedTestDriver::SetUp(Config{.numRanks = 2});
+  }
+};
+
+TEST_F(ForkBasedTestDriverBasicTest, WorkersExitSuccessfully) {
+  if (isTestDriverProcess()) {
+    auto& state = getTestDriverState();
+    EXPECT_EQ(state.workerExitCodes.size(), 2);
+    EXPECT_THAT(state.workerExitCodes, Each(Eq(0)));
+    return;
+  }
+  EXPECT_GE(getRank(), 0);
+  EXPECT_LT(getRank(), 2);
+  EXPECT_EQ(getWorldSize(), 2);
+
+  // KV round-trip
+  setKey("test_key", "test_value");
+  EXPECT_EQ(waitForKey("test_key"), "test_value");
+
+  // Timeout overload: success path
+  setKey("timeout_test_key", "timeout_test_value");
+  auto result = waitForKey("timeout_test_key", std::chrono::milliseconds(5000));
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(*result, "timeout_test_value");
+
+  // Timeout overload: timeout path
+  auto missing =
+      waitForKey("nonexistent_key_xyz", std::chrono::milliseconds(100));
+  EXPECT_FALSE(missing.has_value());
+}
+
+// --- Fixture 2: Worker exit code capture ---
+// Worker calls _exit(42). Must be its own fixture so the singleton captures
+// exit code 42, not stale exit codes from another fixture's workers.
+
+class ForkBasedTestDriverExitCodeTest : public ForkBasedTestDriver,
+                                        public ::testing::Test {
+ public:
+  void SetUp() override {
+    ForkBasedTestDriver::SetUp(
+        Config{.numRanks = 1, .shouldExitOnFailure = false});
+  }
+};
+
+TEST_F(ForkBasedTestDriverExitCodeTest, ExactExitCodeCaptured) {
+  if (isTestDriverProcess()) {
+    auto& state = getTestDriverState();
+    EXPECT_EQ(state.workerExitCodes.size(), 1);
+    EXPECT_EQ(state.workerExitCodes[0], 42);
+    return;
+  }
+  _exit(42);
+}
+
+// --- Fixture 3: Signal-terminated worker ---
+// Worker calls raise(SIGTERM). Must be its own fixture so the singleton
+// captures 128+SIGTERM, not stale exit codes from another fixture.
+
+class ForkBasedTestDriverSignalTest : public ForkBasedTestDriver,
+                                      public ::testing::Test {
+ public:
+  void SetUp() override {
+    ForkBasedTestDriver::SetUp(
+        Config{.numRanks = 1, .shouldExitOnFailure = false});
+  }
+};
+
+TEST_F(ForkBasedTestDriverSignalTest, SignalReportsAs128PlusSignal) {
+  if (isTestDriverProcess()) {
+    auto& state = getTestDriverState();
+    EXPECT_EQ(state.workerExitCodes.size(), 1);
+    EXPECT_EQ(state.workerExitCodes[0], 128 + SIGTERM);
+    return;
+  }
+  raise(SIGTERM);
+}


### PR DESCRIPTION
Summary:

Replace `CollectiveIntegrationTestMixin` with `ForkBasedTestDriver` in the analyzer test. Use `meta::comms::CudaStream`. Include inline `modifyGPUBuffer`/`validateGPUBuffer` helpers (duplicated from MCCL's `McclIntegrationTestUtil`).

Differential Revision: D100079406
