### PR TITLE
Add TcpSocketConfig for user-configurable socket options and timeouts

### DIFF
--- a/comms/uniflow/Uniflow.cpp
+++ b/comms/uniflow/Uniflow.cpp
@@ -16,9 +16,10 @@ UniflowAgent::UniflowAgent(
       server_(std::move(server)) {
   // Auto-create TcpClient if not provided
   if (!client_) {
-    client_ = std::make_unique<controller::TcpClient>(
-        config.connectRetries,
-        std::chrono::milliseconds(config.connectTimeoutMs));
+    controller::TcpSocketConfig tcpCfg;
+    tcpCfg.connectRetries = config.connectRetries;
+    tcpCfg.retryTimeout = std::chrono::milliseconds(config.connectTimeoutMs);
+    client_ = std::make_unique<controller::TcpClient>(std::move(tcpCfg));
   }
 
   // Auto-create TcpServer if listenAddress is specified

--- a/comms/uniflow/controller/TcpController.cpp
+++ b/comms/uniflow/controller/TcpController.cpp
@@ -7,6 +7,7 @@
 #include <sys/socket.h>
 #include <unistd.h>
 #include <cerrno>
+#include <charconv>
 #include <cstring>
 #include <stdexcept>
 #include <system_error>
@@ -16,24 +17,56 @@
 
 namespace uniflow::controller {
 
+TcpSocketConfig TcpSocketConfig::osDefaults() {
+  TcpSocketConfig cfg;
+  cfg.connTimeout = std::nullopt;
+  cfg.socketBufSize = std::nullopt;
+  cfg.tcpNoDelay = std::nullopt;
+  cfg.enableKeepalive = std::nullopt;
+  cfg.keepaliveIdle = std::nullopt;
+  cfg.keepaliveInterval = std::nullopt;
+  cfg.keepaliveCount = std::nullopt;
+  cfg.userTimeout = std::nullopt;
+  return cfg;
+}
+
+Status TcpSocketConfig::validate() const {
+  if (connTimeout && connTimeout->count() <= 0) {
+    return Err(ErrCode::InvalidArgument, "connTimeout must be positive");
+  }
+  if (socketBufSize && *socketBufSize <= 0) {
+    return Err(ErrCode::InvalidArgument, "socketBufSize must be positive");
+  }
+  if (keepaliveIdle && keepaliveIdle->count() <= 0) {
+    return Err(ErrCode::InvalidArgument, "keepaliveIdle must be positive");
+  }
+  if (keepaliveInterval && keepaliveInterval->count() <= 0) {
+    return Err(ErrCode::InvalidArgument, "keepaliveInterval must be positive");
+  }
+  if (keepaliveCount && *keepaliveCount <= 0) {
+    return Err(ErrCode::InvalidArgument, "keepaliveCount must be positive");
+  }
+  if (userTimeout && userTimeout->count() <= 0) {
+    return Err(ErrCode::InvalidArgument, "userTimeout must be positive");
+  }
+  if (acceptRetryCnt <= 0) {
+    return Err(ErrCode::InvalidArgument, "acceptRetryCnt must be positive");
+  }
+  if (retryTimeout.count() < 0) {
+    return Err(ErrCode::InvalidArgument, "retryTimeout must be non-negative");
+  }
+  return Ok();
+}
+
 namespace {
 
-constexpr int kUserTimeoutMs = 60000;
-constexpr int kKeepaliveIdleSec = 60;
-constexpr int kKeepaliveIntervalSec = 5;
-constexpr int kKeepaliveCount = 3;
-constexpr int kSocketBufSize = 1 << 20; // 1MB send/recv buffer
 constexpr uint32_t kMaxMessageSize = 64 << 20; // 64MB max message size
 constexpr int kAcceptTimeoutSec = 5; // accept() wakeup interval
-constexpr int kConnectedTimeoutSec =
-    30; // send/recv timeout on connected sockets
 
 // Magic value exchanged during connection handshake to validate that both
 // endpoints are uniflow controllers (rejects stray connections).
 constexpr uint32_t kMagic = 0x554E4946; // "UNIF" in ASCII
 
-// Helper for setting socket options with error collection. Accumulates the
-// names of all failed options and produces a single Status at the end.
 class SockOptSetter {
   int sock_;
   std::string failures_;
@@ -41,7 +74,6 @@ class SockOptSetter {
  public:
   explicit SockOptSetter(int sock) : sock_(sock) {}
 
-  // Checked — collects failure name if setsockopt fails.
   template <typename T>
   void set(int level, int optname, const T& value, const char* name) {
     if (::setsockopt(sock_, level, optname, &value, sizeof(value)) < 0) {
@@ -52,7 +84,7 @@ class SockOptSetter {
     }
   }
 
-  // Optional — best-effort, failure is silently ignored.
+  // Best-effort, failure silently ignored.
   template <typename T>
   void trySet(int level, int optname, const T& value) {
     ::setsockopt(sock_, level, optname, &value, sizeof(value));
@@ -66,8 +98,7 @@ class SockOptSetter {
   }
 };
 
-// Returns true if the given errno indicates a transient error that should
-// be retried. Aligned with ctran/bootstrap/Socket.cc::shouldRetry().
+// Aligned with ctran/bootstrap/Socket.cc::shouldRetry().
 bool shouldRetry(int errcode) {
   return (
       errcode == ENETDOWN || errcode == EPROTO || errcode == ENOPROTOOPT ||
@@ -91,9 +122,9 @@ Result<std::pair<std::string, int>> parseHostPort(std::string_view id) {
   }
 
   int port = 0;
-  try {
-    port = std::stoi(std::string(portStr));
-  } catch (const std::exception&) {
+  auto [ptr, ec] =
+      std::from_chars(portStr.data(), portStr.data() + portStr.size(), port);
+  if (ec != std::errc{} || ptr != portStr.data() + portStr.size()) {
     return Err(
         ErrCode::InvalidArgument, "Invalid port: " + std::string(portStr));
   }
@@ -106,22 +137,18 @@ Result<std::pair<std::string, int>> parseHostPort(std::string_view id) {
 }
 
 Result<int> detectAddressFamily(std::string_view host) {
-  // Empty host and "*" are wildcards — use IPv6 dual-stack (AF_INET6 with
-  // in6addr_any accepts both IPv4 and IPv6 when IPV6_V6ONLY is not set,
-  // which is the Linux default)
+  // Wildcard → IPv6 dual-stack (accepts both v4 and v6 on Linux).
   if (host.empty() || host == "*") {
     return AF_INET6;
   }
 
   std::string hostStr(host);
 
-  // Try IPv6 first
   in6_addr addr6{};
   if (::inet_pton(AF_INET6, hostStr.c_str(), &addr6) == 1) {
     return AF_INET6;
   }
 
-  // Try IPv4
   in_addr addr4{};
   if (::inet_pton(AF_INET, hostStr.c_str(), &addr4) == 1) {
     return AF_INET;
@@ -130,8 +157,6 @@ Result<int> detectAddressFamily(std::string_view host) {
   return Err(ErrCode::InvalidArgument, "Invalid host address: " + hostStr);
 }
 
-// Build a sockaddr for the given host/port/domain, handling wildcard addresses
-// for bind. Returns the sockaddr size.
 Result<socklen_t> buildSockAddr(
     std::string_view host,
     int port,
@@ -169,7 +194,6 @@ Result<socklen_t> buildSockAddr(
   return static_cast<socklen_t>(sizeof(sockaddr_in));
 }
 
-// Format a sockaddr as "host:port" for logging.
 std::string formatAddr(const sockaddr_storage& addr) {
   char buf[INET6_ADDRSTRLEN] = {};
   if (addr.ss_family == AF_INET6) {
@@ -184,10 +208,6 @@ std::string formatAddr(const sockaddr_storage& addr) {
 
 } // namespace
 
-// ---------------------------------------------------------------------------
-// TcpConn
-// ---------------------------------------------------------------------------
-
 bool TcpConn::sendAll(const void* buf, size_t len) {
   auto* ptr = static_cast<const uint8_t*>(buf);
   size_t remaining = len;
@@ -197,11 +217,13 @@ bool TcpConn::sendAll(const void* buf, size_t len) {
       if (errno == EINTR) {
         continue;
       }
+      int savedErrno = errno;
       UNIFLOW_LOG_ERROR(
           "sendAll failed: fd={} errno={} ({})",
           sock_,
-          errno,
-          std::system_category().message(errno));
+          savedErrno,
+          std::system_category().message(savedErrno));
+      errno = savedErrno;
       return false;
     }
     ptr += n;
@@ -219,11 +241,13 @@ bool TcpConn::recvAll(void* buf, size_t len) {
       if (errno == EINTR) {
         continue;
       }
+      int savedErrno = errno;
       UNIFLOW_LOG_ERROR(
           "recvAll failed: fd={} errno={} ({})",
           sock_,
-          errno,
-          std::system_category().message(errno));
+          savedErrno,
+          std::system_category().message(savedErrno));
+      errno = savedErrno;
       return false;
     }
     if (n == 0) {
@@ -286,8 +310,6 @@ Result<size_t> TcpConn::send(std::span<const uint8_t> data) {
 
   UNIFLOW_LOG_DEBUG("TcpConn::send: fd={} bytes={}", sock_, data.size());
 
-  // Length-prefixed framing: send 4-byte size header in network byte order
-  // then payload
   uint32_t len = htonl(static_cast<uint32_t>(data.size()));
   if (!sendAll(&len, sizeof(len))) {
     return Err(
@@ -309,8 +331,6 @@ Result<size_t> TcpConn::recv(std::vector<uint8_t>& data) {
     return Err(ErrCode::NotConnected, "Socket is not connected");
   }
 
-  // Length-prefixed framing: read 4-byte size header in network byte order
-  // then payload
   uint32_t rawLen = 0;
   if (!recvAll(&rawLen, sizeof(rawLen))) {
     return Err(
@@ -364,7 +384,7 @@ Result<int> TcpServer::createListenSocket(int domain) {
 
   SockOptSetter opt(sock);
   opt.set(SOL_SOCKET, SO_REUSEADDR, 1, "SO_REUSEADDR");
-  opt.set(SOL_SOCKET, SO_REUSEPORT, 1, "SO_REUSEPORT"); // optional
+  opt.trySet(SOL_SOCKET, SO_REUSEPORT, 1);
 
   // Set accept timeout so accept() wakes up periodically, allowing
   // shutdown checks instead of blocking indefinitely
@@ -384,19 +404,42 @@ Result<int> TcpServer::createListenSocket(int domain) {
 
 Status TcpServer::configureAcceptedSocket(int sock) {
   SockOptSetter opt(sock);
-  opt.set(SOL_SOCKET, SO_SNDBUF, kSocketBufSize, "SO_SNDBUF");
-  opt.set(SOL_SOCKET, SO_RCVBUF, kSocketBufSize, "SO_RCVBUF");
-  opt.set(IPPROTO_TCP, TCP_NODELAY, 1, "TCP_NODELAY");
-  opt.set(SOL_SOCKET, SO_KEEPALIVE, 1, "SO_KEEPALIVE");
-  opt.set(IPPROTO_TCP, TCP_KEEPIDLE, kKeepaliveIdleSec, "TCP_KEEPIDLE");
-  opt.set(IPPROTO_TCP, TCP_KEEPINTVL, kKeepaliveIntervalSec, "TCP_KEEPINTVL");
-  opt.set(IPPROTO_TCP, TCP_KEEPCNT, kKeepaliveCount, "TCP_KEEPCNT");
-  opt.set(IPPROTO_TCP, TCP_USER_TIMEOUT, kUserTimeoutMs, "TCP_USER_TIMEOUT");
 
-  struct timeval tv{};
-  tv.tv_sec = kConnectedTimeoutSec;
-  opt.set(SOL_SOCKET, SO_SNDTIMEO, tv, "SO_SNDTIMEO");
-  opt.set(SOL_SOCKET, SO_RCVTIMEO, tv, "SO_RCVTIMEO");
+  if (config_.socketBufSize) {
+    opt.set(SOL_SOCKET, SO_SNDBUF, *config_.socketBufSize, "SO_SNDBUF");
+    opt.set(SOL_SOCKET, SO_RCVBUF, *config_.socketBufSize, "SO_RCVBUF");
+  }
+  if (config_.tcpNoDelay) {
+    int val = *config_.tcpNoDelay ? 1 : 0;
+    opt.set(IPPROTO_TCP, TCP_NODELAY, val, "TCP_NODELAY");
+  }
+  if (config_.enableKeepalive) {
+    int val = *config_.enableKeepalive ? 1 : 0;
+    opt.set(SOL_SOCKET, SO_KEEPALIVE, val, "SO_KEEPALIVE");
+  }
+  if (config_.enableKeepalive && *config_.enableKeepalive) {
+    if (config_.keepaliveIdle) {
+      int val = static_cast<int>(config_.keepaliveIdle->count());
+      opt.set(IPPROTO_TCP, TCP_KEEPIDLE, val, "TCP_KEEPIDLE");
+    }
+    if (config_.keepaliveInterval) {
+      int val = static_cast<int>(config_.keepaliveInterval->count());
+      opt.set(IPPROTO_TCP, TCP_KEEPINTVL, val, "TCP_KEEPINTVL");
+    }
+    if (config_.keepaliveCount) {
+      opt.set(IPPROTO_TCP, TCP_KEEPCNT, *config_.keepaliveCount, "TCP_KEEPCNT");
+    }
+  }
+  if (config_.userTimeout) {
+    int val = static_cast<int>(config_.userTimeout->count());
+    opt.set(IPPROTO_TCP, TCP_USER_TIMEOUT, val, "TCP_USER_TIMEOUT");
+  }
+  if (config_.connTimeout) {
+    struct timeval tv{};
+    tv.tv_sec = config_.connTimeout->count();
+    opt.set(SOL_SOCKET, SO_SNDTIMEO, tv, "SO_SNDTIMEO");
+    opt.set(SOL_SOCKET, SO_RCVTIMEO, tv, "SO_RCVTIMEO");
+  }
 
   return opt.status();
 }
@@ -420,8 +463,8 @@ Status TcpServer::resolveAndBind(int domain) {
   return Ok();
 }
 
-TcpServer::TcpServer(std::string id, int acceptRetryCnt)
-    : id_(std::move(id)), acceptRetryCnt_(acceptRetryCnt) {
+TcpServer::TcpServer(std::string id, TcpSocketConfig config)
+    : id_(std::move(id)), config_(std::move(config)) {
   auto result = parseHostPort(id_);
   if (!result) {
     throw std::invalid_argument(
@@ -430,6 +473,12 @@ TcpServer::TcpServer(std::string id, int acceptRetryCnt)
   auto [host, port] = result.value();
   host_ = host;
   port_ = port;
+
+  auto status = config_.validate();
+  if (!status) {
+    throw std::invalid_argument(
+        "Invalid socket config: " + status.error().toString());
+  }
 }
 
 TcpServer::~TcpServer() {
@@ -479,7 +528,7 @@ Status TcpServer::init() {
     return bindStatus;
   }
 
-  // Retrieve the actual bound port (needed when binding to port 0)
+  // Retrieve actual bound port (needed when binding to port 0).
   sockaddr_storage boundAddr{};
   socklen_t boundLen = sizeof(boundAddr);
   if (::getsockname(
@@ -493,15 +542,16 @@ Status TcpServer::init() {
   }
 
   if (::listen(listenSock_, SOMAXCONN) < 0) {
+    int savedErrno = errno;
     UNIFLOW_LOG_ERROR(
         "TcpServer: listen failed on {}: {}",
         id_,
-        std::system_category().message(errno));
+        std::system_category().message(savedErrno));
     ::close(listenSock_);
     listenSock_ = -1;
     return Err(
         ErrCode::ConnectionFailed,
-        "listen failed: " + std::system_category().message(errno));
+        "listen failed: " + std::system_category().message(savedErrno));
   }
 
   // Resolve wildcard host to connectable loopback address so that getId()
@@ -525,12 +575,8 @@ std::unique_ptr<Conn> TcpServer::accept() {
   sockaddr_storage clientAddr{};
   socklen_t clientLen = sizeof(clientAddr);
 
-  // Retry accept on transient errors, aligned with ctran
-  // ServerSocket::accept(). EAGAIN/EWOULDBLOCK from SO_RCVTIMEO timeout are
-  // handled separately — they loop back to allow periodic shutdown checks
-  // without counting as a transient failure.
   int retryCnt = 0;
-  while (retryCnt < acceptRetryCnt_) {
+  while (retryCnt < config_.acceptRetryCnt) {
     clientLen = sizeof(clientAddr);
     int clientSock = ::accept4(
         listenSock_,
@@ -542,7 +588,6 @@ std::unique_ptr<Conn> TcpServer::accept() {
           "TcpServer: accepted fd={} from {}",
           clientSock,
           formatAddr(clientAddr));
-      // Sockopt failure is a system-level issue — return immediately
       auto status = configureAcceptedSocket(clientSock);
       if (!status) {
         UNIFLOW_LOG_ERROR(
@@ -556,27 +601,26 @@ std::unique_ptr<Conn> TcpServer::accept() {
       if (conn) {
         return conn;
       }
-      // Magic handshake failed (non-uniflow client) — keep accepting.
-      // Socket was already closed by TcpConn destructor inside create().
+      // Non-uniflow client — socket closed by TcpConn dtor, keep accepting.
       UNIFLOW_LOG_WARN(
           "TcpServer: rejecting non-uniflow client, fd={}", clientSock);
       continue;
     }
 
     if (errno == EAGAIN || errno == EWOULDBLOCK) {
-      // Timeout fired — check if shutdown was called
       if (listenSock_ < 0) {
         UNIFLOW_LOG_INFO("TcpServer: accept interrupted by shutdown");
         return nullptr;
       }
-      continue; // don't count timeouts as retries
+      continue;
     }
 
-    if (!shouldRetry(errno)) {
+    int savedErrno = errno;
+    if (!shouldRetry(savedErrno)) {
       UNIFLOW_LOG_ERROR(
           "TcpServer: accept failed (non-retryable): errno={} ({})",
-          errno,
-          std::system_category().message(errno));
+          savedErrno,
+          std::system_category().message(savedErrno));
       return nullptr;
     }
 
@@ -584,30 +628,64 @@ std::unique_ptr<Conn> TcpServer::accept() {
     UNIFLOW_LOG_WARN(
         "TcpServer: accept retry {}/{}: errno={} ({})",
         retryCnt,
-        acceptRetryCnt_,
-        errno,
-        std::system_category().message(errno));
+        config_.acceptRetryCnt,
+        savedErrno,
+        std::system_category().message(savedErrno));
   }
 
   UNIFLOW_LOG_ERROR(
-      "TcpServer: accept exhausted {} retries on {}", acceptRetryCnt_, id_);
+      "TcpServer: accept exhausted {} retries on {}",
+      config_.acceptRetryCnt,
+      id_);
   return nullptr;
 }
 
-// ---------------------------------------------------------------------------
-// TcpClient
-// ---------------------------------------------------------------------------
+TcpClient::TcpClient(TcpSocketConfig config) : config_(std::move(config)) {
+  auto status = config_.validate();
+  if (!status) {
+    throw std::invalid_argument(
+        "Invalid socket config: " + status.error().toString());
+  }
+}
 
 Status TcpClient::configureClientSocket(int sock) {
   SockOptSetter opt(sock);
-  opt.set(SOL_SOCKET, SO_SNDBUF, kSocketBufSize, "SO_SNDBUF");
-  opt.set(SOL_SOCKET, SO_RCVBUF, kSocketBufSize, "SO_RCVBUF");
-  opt.set(IPPROTO_TCP, TCP_NODELAY, 1, "TCP_NODELAY");
 
-  struct timeval tv{};
-  tv.tv_sec = kConnectedTimeoutSec;
-  opt.set(SOL_SOCKET, SO_SNDTIMEO, tv, "SO_SNDTIMEO");
-  opt.set(SOL_SOCKET, SO_RCVTIMEO, tv, "SO_RCVTIMEO");
+  if (config_.socketBufSize) {
+    opt.set(SOL_SOCKET, SO_SNDBUF, *config_.socketBufSize, "SO_SNDBUF");
+    opt.set(SOL_SOCKET, SO_RCVBUF, *config_.socketBufSize, "SO_RCVBUF");
+  }
+  if (config_.tcpNoDelay) {
+    int val = *config_.tcpNoDelay ? 1 : 0;
+    opt.set(IPPROTO_TCP, TCP_NODELAY, val, "TCP_NODELAY");
+  }
+  if (config_.enableKeepalive) {
+    int val = *config_.enableKeepalive ? 1 : 0;
+    opt.set(SOL_SOCKET, SO_KEEPALIVE, val, "SO_KEEPALIVE");
+  }
+  if (config_.enableKeepalive && *config_.enableKeepalive) {
+    if (config_.keepaliveIdle) {
+      int val = static_cast<int>(config_.keepaliveIdle->count());
+      opt.set(IPPROTO_TCP, TCP_KEEPIDLE, val, "TCP_KEEPIDLE");
+    }
+    if (config_.keepaliveInterval) {
+      int val = static_cast<int>(config_.keepaliveInterval->count());
+      opt.set(IPPROTO_TCP, TCP_KEEPINTVL, val, "TCP_KEEPINTVL");
+    }
+    if (config_.keepaliveCount) {
+      opt.set(IPPROTO_TCP, TCP_KEEPCNT, *config_.keepaliveCount, "TCP_KEEPCNT");
+    }
+  }
+  if (config_.userTimeout) {
+    int val = static_cast<int>(config_.userTimeout->count());
+    opt.set(IPPROTO_TCP, TCP_USER_TIMEOUT, val, "TCP_USER_TIMEOUT");
+  }
+  if (config_.connTimeout) {
+    struct timeval tv{};
+    tv.tv_sec = config_.connTimeout->count();
+    opt.set(SOL_SOCKET, SO_SNDTIMEO, tv, "SO_SNDTIMEO");
+    opt.set(SOL_SOCKET, SO_RCVTIMEO, tv, "SO_RCVTIMEO");
+  }
 
   return opt.status();
 }
@@ -627,7 +705,6 @@ std::unique_ptr<Conn> TcpClient::connect(std::string id) {
   }
   int domain = domainResult.value();
 
-  // Build the destination sockaddr once
   sockaddr_storage serverAddr{};
   auto addrLenResult = buildSockAddr(host, port, domain, serverAddr);
   if (!addrLenResult) {
@@ -637,19 +714,17 @@ std::unique_ptr<Conn> TcpClient::connect(std::string id) {
 
   UNIFLOW_LOG_INFO("TcpClient: connecting to {}", id);
 
-  // Retry connect on transient errors with linear backoff,
-  // aligned with ctran Socket::connect()
-  for (size_t attempt = 0; attempt <= numRetries_; ++attempt) {
+  for (size_t attempt = 0; attempt <= config_.connectRetries; ++attempt) {
     if (attempt > 0) {
       UNIFLOW_LOG_WARN(
           "TcpClient: retry {}/{} to {} (backoff {}ms)",
           attempt,
-          numRetries_,
+          config_.connectRetries,
           id,
-          (attempt * retryTimeout_).count());
+          (attempt * config_.retryTimeout).count());
       // Intentional linear backoff between connect retries
       // NOLINTNEXTLINE(facebook-hte-BadCall-sleep_for)
-      std::this_thread::sleep_for(attempt * retryTimeout_);
+      std::this_thread::sleep_for(attempt * config_.retryTimeout);
     }
 
     // Create a fresh socket for each attempt (connect on a failed socket
@@ -690,7 +765,9 @@ std::unique_ptr<Conn> TcpClient::connect(std::string id) {
   }
 
   UNIFLOW_LOG_ERROR(
-      "TcpClient: connect to {} failed after {} retries", id, numRetries_);
+      "TcpClient: connect to {} failed after {} retries",
+      id,
+      config_.connectRetries);
   return nullptr;
 }
 

--- a/comms/uniflow/controller/TcpController.h
+++ b/comms/uniflow/controller/TcpController.h
@@ -4,15 +4,37 @@
 
 #include <atomic>
 #include <chrono>
+#include <optional>
 
 #include "comms/uniflow/controller/Controller.h"
 
 namespace uniflow::controller {
 
+/// Socket configuration for TcpServer and TcpClient.
+/// Optional fields: valued → setsockopt, nullopt → OS kernel default.
+/// Default-constructed with production-tuned values.
+struct TcpSocketConfig {
+  std::optional<std::chrono::seconds> connTimeout{std::chrono::seconds{30}};
+  std::optional<int> socketBufSize{1 << 20}; // 1MB
+  std::optional<bool> tcpNoDelay{true};
+  std::optional<bool> enableKeepalive{true};
+  std::optional<std::chrono::seconds> keepaliveIdle{std::chrono::seconds{60}};
+  std::optional<std::chrono::seconds> keepaliveInterval{
+      std::chrono::seconds{5}};
+  std::optional<int> keepaliveCount{3};
+  std::optional<std::chrono::milliseconds> userTimeout{
+      std::chrono::milliseconds{60000}};
+
+  int acceptRetryCnt{5};
+  size_t connectRetries{10};
+  std::chrono::milliseconds retryTimeout{std::chrono::milliseconds{1000}};
+
+  static TcpSocketConfig osDefaults();
+  Status validate() const;
+};
+
 class TcpConn : public Conn {
  public:
-  // Factory: creates a TcpConn and validates the peer via magic exchange.
-  // Returns nullptr and closes the socket if the handshake fails.
   static std::unique_ptr<TcpConn> create(int sock);
 
   TcpConn(const TcpConn&) = delete;
@@ -42,7 +64,7 @@ class TcpConn : public Conn {
 
 class TcpServer : public Server {
  public:
-  explicit TcpServer(std::string id, int acceptRetryCnt = 5);
+  explicit TcpServer(std::string id, TcpSocketConfig config = {});
   TcpServer(const TcpServer&) = delete;
   TcpServer& operator=(const TcpServer&) = delete;
   TcpServer(TcpServer&&) = delete;
@@ -56,8 +78,7 @@ class TcpServer : public Server {
   Status init() override;
   std::unique_ptr<Conn> accept() override;
 
-  // Gracefully shut down the listening socket. After this call, accept()
-  // will return nullptr. Safe to call from a different thread than accept().
+  // Thread-safe: can be called from a different thread than accept().
   void shutdown();
 
  private:
@@ -69,28 +90,23 @@ class TcpServer : public Server {
   std::string host_;
   int port_{-1};
   std::atomic<int> listenSock_{-1};
-  int acceptRetryCnt_;
+  TcpSocketConfig config_;
 };
 
 class TcpClient : public Client {
  public:
-  TcpClient() = default;
+  explicit TcpClient(TcpSocketConfig config = {});
   TcpClient(const TcpClient&) = delete;
   TcpClient& operator=(const TcpClient&) = delete;
   TcpClient(TcpClient&&) = delete;
   TcpClient& operator=(TcpClient&&) = delete;
 
-  // Configure retry behavior for connect().
-  TcpClient(size_t numRetries, std::chrono::milliseconds retryTimeout)
-      : numRetries_(numRetries), retryTimeout_(retryTimeout) {}
-
   std::unique_ptr<Conn> connect(std::string id) override;
 
  private:
-  static Status configureClientSocket(int sock);
+  Status configureClientSocket(int sock);
 
-  size_t numRetries_{10};
-  std::chrono::milliseconds retryTimeout_{1000};
+  TcpSocketConfig config_;
 };
 
 } // namespace uniflow::controller

--- a/comms/uniflow/controller/tests/TcpServerClientTest.cpp
+++ b/comms/uniflow/controller/tests/TcpServerClientTest.cpp
@@ -9,14 +9,9 @@
 using namespace uniflow;
 using namespace uniflow::controller;
 
-// ---------------------------------------------------------------------------
-// Parameterized fixture: runs server/client lifecycle tests over both
-// IPv4 (127.0.0.1) and IPv6 (::1). IPv6 tests are skipped if not available.
-// ---------------------------------------------------------------------------
-
 struct AddrFamily {
-  std::string serverAddr; // e.g., "127.0.0.1:0" or ":::0"
-  std::string clientHost; // e.g., "127.0.0.1" or "::1"
+  std::string serverAddr;
+  std::string clientHost;
 };
 
 class TcpServerClientTest : public ::testing::TestWithParam<AddrFamily> {
@@ -98,11 +93,6 @@ INSTANTIATE_TEST_SUITE_P(
       return info.param.clientHost == "127.0.0.1" ? "IPv4" : "IPv6";
     });
 
-// ---------------------------------------------------------------------------
-// Non-parameterized tests: address parsing, wildcards, and edge cases that
-// are not address-family-specific.
-// ---------------------------------------------------------------------------
-
 class TcpServerClientMiscTest : public ::testing::Test {};
 
 TEST_F(TcpServerClientMiscTest, DoubleInitFails) {
@@ -141,8 +131,10 @@ TEST_F(TcpServerClientMiscTest, AddressParsingErrors) {
   EXPECT_THROW(TcpServer("::1:invalid"), std::invalid_argument);
   EXPECT_THROW(TcpServer(":::"), std::invalid_argument);
 
-  // Client parsing
-  TcpClient client(0, std::chrono::milliseconds(0));
+  TcpSocketConfig noRetryCfg = TcpSocketConfig{};
+  noRetryCfg.connectRetries = 0;
+  noRetryCfg.retryTimeout = std::chrono::milliseconds(0);
+  TcpClient client(noRetryCfg);
   EXPECT_EQ(client.connect("127.0.0.1:invalid"), nullptr);
   EXPECT_EQ(client.connect("127.0.0.1"), nullptr);
   EXPECT_EQ(client.connect("localhost:8080"), nullptr);
@@ -168,7 +160,10 @@ TEST_F(TcpServerClientMiscTest, InvalidHostAddress) {
 }
 
 TEST_F(TcpServerClientMiscTest, ConnectFailsWhenNoServerListening) {
-  TcpClient client(0, std::chrono::milliseconds(0));
+  TcpSocketConfig noRetryCfg = TcpSocketConfig{};
+  noRetryCfg.connectRetries = 0;
+  noRetryCfg.retryTimeout = std::chrono::milliseconds(0);
+  TcpClient client(noRetryCfg);
 
   // IPv4
   EXPECT_EQ(client.connect("127.0.0.1:59999"), nullptr);
@@ -200,7 +195,6 @@ TEST_F(TcpServerClientMiscTest, WildcardAddresses) {
         << "init() failed with 0.0.0.0: " << status.error().toString();
   }
 
-  // Asterisk wildcard (maps to IPv6 dual-stack)
   {
     TcpServer server("*:0");
     Status status = server.init();
@@ -226,4 +220,140 @@ TEST_F(TcpServerClientMiscTest, EmptyHostBindsWildcard) {
   Status status = server.init();
   EXPECT_TRUE(status.hasValue())
       << "init() failed with empty host: " << status.error().toString();
+}
+
+class TcpSocketConfigTest : public ::testing::Test {};
+
+TEST_F(TcpSocketConfigTest, DefaultConstructedMatchesProduction) {
+  TcpSocketConfig cfg;
+  EXPECT_EQ(cfg.connTimeout, std::chrono::seconds{30});
+  EXPECT_EQ(cfg.socketBufSize, 1 << 20);
+  EXPECT_EQ(cfg.tcpNoDelay, true);
+  EXPECT_EQ(cfg.enableKeepalive, true);
+  EXPECT_EQ(cfg.keepaliveIdle, std::chrono::seconds{60});
+  EXPECT_EQ(cfg.keepaliveInterval, std::chrono::seconds{5});
+  EXPECT_EQ(cfg.keepaliveCount, 3);
+  EXPECT_EQ(cfg.userTimeout, std::chrono::milliseconds{60000});
+  EXPECT_EQ(cfg.acceptRetryCnt, 5);
+  EXPECT_EQ(cfg.connectRetries, 10u);
+  EXPECT_EQ(cfg.retryTimeout, std::chrono::milliseconds{1000});
+}
+
+TEST_F(TcpSocketConfigTest, OsDefaultsIsAllNullopt) {
+  auto cfg = TcpSocketConfig::osDefaults();
+  EXPECT_FALSE(cfg.connTimeout.has_value());
+  EXPECT_FALSE(cfg.socketBufSize.has_value());
+  EXPECT_FALSE(cfg.tcpNoDelay.has_value());
+  EXPECT_FALSE(cfg.enableKeepalive.has_value());
+  EXPECT_FALSE(cfg.keepaliveIdle.has_value());
+  EXPECT_FALSE(cfg.keepaliveInterval.has_value());
+  EXPECT_FALSE(cfg.keepaliveCount.has_value());
+  EXPECT_FALSE(cfg.userTimeout.has_value());
+}
+
+TEST_F(TcpSocketConfigTest, ValidateAcceptsDefaults) {
+  TcpSocketConfig cfg;
+  EXPECT_TRUE(cfg.validate().hasValue());
+}
+
+TEST_F(TcpSocketConfigTest, ValidateAcceptsOsDefaults) {
+  auto cfg = TcpSocketConfig::osDefaults();
+  EXPECT_TRUE(cfg.validate().hasValue());
+}
+
+TEST_F(TcpSocketConfigTest, OsDefaultConfigConnectionSucceeds) {
+  auto cfg = TcpSocketConfig::osDefaults();
+
+  TcpServer server("127.0.0.1:0", cfg);
+  auto status = server.init();
+  ASSERT_TRUE(status.hasValue()) << status.error().toString();
+
+  std::unique_ptr<Conn> serverConn;
+  std::thread acceptThread([&]() { serverConn = server.accept(); });
+
+  TcpClient client(cfg);
+  auto clientConn =
+      client.connect("127.0.0.1:" + std::to_string(server.getPort()));
+  EXPECT_NE(clientConn, nullptr);
+
+  acceptThread.join();
+  EXPECT_NE(serverConn, nullptr);
+}
+
+TEST_F(TcpSocketConfigTest, ValidateRejectsNegativeTimeout) {
+  auto cfg = TcpSocketConfig{};
+  cfg.connTimeout = std::chrono::seconds{-1};
+  auto status = cfg.validate();
+  EXPECT_TRUE(status.hasError());
+  EXPECT_EQ(status.error().code(), ErrCode::InvalidArgument);
+}
+
+TEST_F(TcpSocketConfigTest, ValidateRejectsZeroBufferSize) {
+  auto cfg = TcpSocketConfig{};
+  cfg.socketBufSize = 0;
+  auto status = cfg.validate();
+  EXPECT_TRUE(status.hasError());
+  EXPECT_EQ(status.error().code(), ErrCode::InvalidArgument);
+}
+
+TEST_F(TcpSocketConfigTest, ValidateRejectsZeroAcceptRetry) {
+  auto cfg = TcpSocketConfig{};
+  cfg.acceptRetryCnt = 0;
+  auto status = cfg.validate();
+  EXPECT_TRUE(status.hasError());
+  EXPECT_EQ(status.error().code(), ErrCode::InvalidArgument);
+}
+
+TEST_F(TcpSocketConfigTest, InvalidConfigThrowsInServerConstructor) {
+  auto cfg = TcpSocketConfig{};
+  cfg.connTimeout = std::chrono::seconds{-1};
+  EXPECT_THROW(TcpServer("127.0.0.1:0", cfg), std::invalid_argument);
+}
+
+TEST_F(TcpSocketConfigTest, InvalidConfigThrowsInClientConstructor) {
+  auto cfg = TcpSocketConfig{};
+  cfg.socketBufSize = -1;
+  EXPECT_THROW(TcpClient{cfg}, std::invalid_argument);
+}
+
+TEST_F(TcpSocketConfigTest, CustomConfigConnectionSucceeds) {
+  auto cfg = TcpSocketConfig{};
+  cfg.connTimeout = std::chrono::seconds{10};
+  cfg.socketBufSize = 256 * 1024;
+
+  TcpServer server("127.0.0.1:0", cfg);
+  auto status = server.init();
+  ASSERT_TRUE(status.hasValue()) << status.error().toString();
+
+  std::unique_ptr<Conn> serverConn;
+  std::thread acceptThread([&]() { serverConn = server.accept(); });
+
+  TcpClient client(cfg);
+  auto clientConn =
+      client.connect("127.0.0.1:" + std::to_string(server.getPort()));
+  EXPECT_NE(clientConn, nullptr);
+
+  acceptThread.join();
+  EXPECT_NE(serverConn, nullptr);
+}
+
+TEST_F(TcpSocketConfigTest, ExplicitKeepaliveDisableIsValid) {
+  auto cfg = TcpSocketConfig{};
+  cfg.enableKeepalive = false;
+  EXPECT_TRUE(cfg.validate().hasValue());
+
+  TcpServer server("127.0.0.1:0", cfg);
+  auto status = server.init();
+  ASSERT_TRUE(status.hasValue()) << status.error().toString();
+
+  std::unique_ptr<Conn> serverConn;
+  std::thread acceptThread([&]() { serverConn = server.accept(); });
+
+  TcpClient client(cfg);
+  auto clientConn =
+      client.connect("127.0.0.1:" + std::to_string(server.getPort()));
+  EXPECT_NE(clientConn, nullptr);
+
+  acceptThread.join();
+  EXPECT_NE(serverConn, nullptr);
 }


### PR DESCRIPTION
Summary:
All TCP socket tuning in TcpController was previously hardcoded as constexpr
constants, making it impossible to adjust socket behavior without code changes.
This diff introduces `TcpSocketConfig`, a configuration struct that gives users
full control over TCP socket options while preserving backward compatibility.

**Design:**
- Socket-option fields use `std::optional` — `nullopt` means "don't call
  setsockopt, use OS kernel default." This lets users opt into OS defaults
  for any individual option.
- `std::chrono` types for all duration fields prevent unit confusion at
  compile time (seconds vs milliseconds).
- `validate()` method catches invalid configuration at construction time
  with clear error messages, rather than failing silently at setsockopt.
- Default-constructed `TcpSocketConfig{}` is production-ready with tuned
  values. Use `TcpSocketConfig::osDefaults()` for OS kernel defaults
  (no setsockopt calls).

**Configurable options:**
- `connTimeout` (SO_SNDTIMEO/SO_RCVTIMEO), `socketBufSize` (SO_SNDBUF/SO_RCVBUF)
- `tcpNoDelay` (TCP_NODELAY), `enableKeepalive` (SO_KEEPALIVE) + tuning params
- `userTimeout` (TCP_USER_TIMEOUT), connect/accept retry behavior
- Keepalive is now available on client sockets too (previously server-only)

**What stays hardcoded:** accept wakeup timeout (5s, internal mechanism),
max message size (64MB, protocol-level), magic handshake value.

**Hardening:**
- `std::from_chars` for strict port parsing (rejects "42abc")
- `errno` saved/restored before logging to prevent clobbering
- `enableKeepalive = false` explicitly disables (three-state `optional<bool>`)
- `SO_REUSEPORT` uses best-effort `trySet` (not all kernels support it)

Reviewed By: GirasoleY

Differential Revision: D99517429


