### PR TITLE
Gate lsaMultimem on LSA team size and add NCCL_NVLS_ENABLE to test_e2e BUCK

### DIFF
--- a/comms/torchcomms/device/ncclx/NCCLDeviceBackend.cpp
+++ b/comms/torchcomms/device/ncclx/NCCLDeviceBackend.cpp
@@ -88,7 +88,12 @@ NCCLDeviceBackend::Ptr NCCLDeviceBackend::create_device_window(
   reqs.resourceRequirementsList =
       (signal_buffer_size > 0) ? &signal_resource_reqs : nullptr;
   reqs.teamRequirementsList = nullptr;
-  reqs.lsaMultimem = true;
+
+  // Mirror NCCL's internal gating (sym_kernels.cc): only request NVLS
+  // multicast when the LSA team has more than 2 members.  Without this
+  // check ncclDevCommCreate returns ncclInvalidArgument on topologies
+  // where multicast is unavailable (e.g. 1x2 configurations).
+  reqs.lsaMultimem = nccl_api->teamLsa(nccl_comm).nRanks > 2;
   reqs.barrierCount = config.barrier_count;
   reqs.lsaBarrierCount = config.barrier_count;
   reqs.railGinBarrierCount = config.barrier_count;

--- a/comms/torchcomms/device/ncclx/TorchCommDeviceNCCLX.cuh
+++ b/comms/torchcomms/device/ncclx/TorchCommDeviceNCCLX.cuh
@@ -509,6 +509,9 @@ TorchCommDeviceWindow<NCCLDeviceBackend>::get_nvlink_address(int peer) {
 template <>
 __device__ inline void*
 TorchCommDeviceWindow<NCCLDeviceBackend>::get_multimem_address(size_t offset) {
+  if (comm_.lsaMultimem.mcBasePtr == nullptr) {
+    return nullptr;
+  }
   return ncclGetLsaMultimemPointer(window_, offset, comm_);
 }
 

--- a/comms/torchcomms/ncclx/NcclxApi.cpp
+++ b/comms/torchcomms/ncclx/NcclxApi.cpp
@@ -664,6 +664,10 @@ ncclResult_t DefaultNcclxApi::winGetLsaMultimemDevicePointer(
   return ncclGetLsaMultimemDevicePointer(win, offset, outPtr);
 }
 #endif
+
+ncclTeam_t DefaultNcclxApi::teamLsa(ncclComm_t comm) {
+  return ncclTeamLsa(comm);
+}
 #endif // TORCHCOMMS_HAS_NCCL_DEVICE_API
 
 } // namespace torch::comms

--- a/comms/torchcomms/ncclx/NcclxApi.hpp
+++ b/comms/torchcomms/ncclx/NcclxApi.hpp
@@ -374,6 +374,9 @@ class NcclxApi {
       size_t offset,
       void** outPtr) = 0;
 #endif
+
+  // Get the LSA team info (rank count, local rank) for a communicator.
+  [[nodiscard]] virtual ncclTeam_t teamLsa(ncclComm_t comm) = 0;
 #endif
 
 #if defined(ENABLE_PIPES)
@@ -738,6 +741,8 @@ class DefaultNcclxApi : public NcclxApi {
       size_t offset,
       void** outPtr) override;
 #endif
+
+  [[nodiscard]] ncclTeam_t teamLsa(ncclComm_t comm) override;
 #endif
 
 #if defined(ENABLE_PIPES)

--- a/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.hpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.hpp
@@ -390,6 +390,8 @@ class NcclxMock : public NcclxApi {
       devCommDestroy,
       (ncclComm_t comm, const ncclDevComm_t* devComm),
       (override));
+
+  MOCK_METHOD(ncclTeam_t, teamLsa, (ncclComm_t comm), (override));
 #endif
 
 #if defined(ENABLE_PIPES)


### PR DESCRIPTION
Summary:
D99884969 set lsaMultimem=true unconditionally in NCCLDeviceBackend,
which fails on topologies where NVLS multicast is unavailable (1x2
configs, P2P disabled without NVLS).

This diff fixes the root cause and the test gap:

1. **Runtime gating** — `NCCLDeviceBackend::create_device_window` now
   mirrors NCCL's internal check (`sym_kernels.cc`): only request
   `lsaMultimem` when `ncclTeamLsa(comm).nRanks > 2`. This prevents
   `ncclDevCommCreate` from returning `ncclInvalidArgument` on
   configurations where multicast is unavailable.

2. **NcclxApi** — exposes `teamLsa(ncclComm_t)` so the check goes
   through the abstraction layer (mockable in unit tests). Mock added
   to `NcclxMock.hpp`.

3. **Device-side safety** — `get_multimem_address()` in
   `TorchCommDeviceNCCLX.cuh` now returns `nullptr` when
   `comm_.lsaMultimem.mcBasePtr` is null, avoiding undefined behavior
   from pointer arithmetic on nullptr in `ncclGetMultimemPointer`.

4. **Test BUCK fix** — adds `NCCL_NVLS_ENABLE=1` to the `test_e2e`
   BUCK target configuration. The MAST launcher already had this env
   var, but CI runs use the BUCK config directly.

Reviewed By: siyengar

Differential Revision: D100347840


