### PR TITLE
Add StagedBuffer for GPU-resident RDMA staging

### DIFF
--- a/comms/torchcomms/transport/StagedRdmaTransport.cpp
+++ b/comms/torchcomms/transport/StagedRdmaTransport.cpp
@@ -1,0 +1,115 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "StagedRdmaTransport.h"
+
+#include <unistd.h>
+
+#include <cuda_runtime.h>
+
+#include <comms/ctran/utils/CudaWrap.h>
+
+#include <fmt/core.h>
+
+// ibverbx wraps all libibverbs types in its own namespace
+using namespace ibverbx; // NOLINT(google-build-using-namespace)
+
+namespace {
+
+#define CUDA_CHECK(cmd)                     \
+  do {                                      \
+    auto err = (cmd);                       \
+    if (err != cudaSuccess) {               \
+      throw std::runtime_error(             \
+          fmt::format(                      \
+              "CUDA error {} at {}:{}: {}", \
+              static_cast<int>(err),        \
+              __FILE__,                     \
+              __LINE__,                     \
+              cudaGetErrorString(err)));    \
+    }                                       \
+  } while (0)
+
+} // namespace
+
+namespace torch::comms {
+
+// --- StagedBuffer ---
+
+StagedBuffer::StagedBuffer(size_t size, int cudaDev, ibverbx::IbvPd& pd)
+    : size_(size), cudaDev_(cudaDev) {
+  CUDA_CHECK(cudaSetDevice(cudaDev));
+  CUDA_CHECK(cudaMalloc(&buf_, size));
+
+  // Export dmabuf fd for GDR registration
+  dmabufFd_ = ctran::utils::getCuMemDmaBufFd(buf_, size);
+  if (dmabufFd_ < 0) {
+    // Error path cleanup — cudaFree failure is non-actionable here.
+    cudaFree(buf_);
+    throw std::runtime_error("Failed to get dmabuf fd for GPU buffer");
+  }
+
+  // Register with IB for RDMA access via GPUDirect
+  auto maybeMr = pd.regDmabufMr(
+      /*offset=*/0,
+      size,
+      reinterpret_cast<uintptr_t>(buf_),
+      dmabufFd_,
+      static_cast<ibv_access_flags>(
+          IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE |
+          IBV_ACCESS_REMOTE_READ));
+  if (!maybeMr) {
+    close(dmabufFd_);
+    // Error path cleanup — cudaFree failure is non-actionable here.
+    cudaFree(buf_);
+    throw std::runtime_error(
+        "Failed to register dmabuf MR: " + maybeMr.error().errStr);
+  }
+  mr_.emplace(std::move(*maybeMr));
+}
+
+StagedBuffer::~StagedBuffer() {
+  // Destruction order: MR → dmabuf fd → GPU memory
+  mr_.reset();
+  if (dmabufFd_ >= 0) {
+    close(dmabufFd_);
+  }
+  if (buf_) {
+    // Destructor must not throw — cudaFree failure is non-actionable.
+    cudaFree(buf_);
+  }
+}
+
+StagedBuffer::StagedBuffer(StagedBuffer&& other) noexcept
+    : buf_(other.buf_),
+      size_(other.size_),
+      cudaDev_(other.cudaDev_),
+      dmabufFd_(other.dmabufFd_),
+      mr_(std::move(other.mr_)) {
+  other.buf_ = nullptr;
+  other.dmabufFd_ = -1;
+}
+
+StagedBuffer& StagedBuffer::operator=(StagedBuffer&& other) noexcept {
+  if (this != &other) {
+    mr_.reset();
+    if (dmabufFd_ >= 0) {
+      close(dmabufFd_);
+    }
+    if (buf_) {
+      // noexcept move — cudaFree failure is non-actionable.
+      cudaFree(buf_);
+    }
+
+    buf_ = other.buf_;
+    size_ = other.size_;
+    cudaDev_ = other.cudaDev_;
+    dmabufFd_ = other.dmabufFd_;
+    mr_ = std::move(other.mr_);
+
+    other.buf_ = nullptr;
+    other.dmabufFd_ = -1;
+  }
+  return *this;
+}
+
+} // namespace torch::comms

--- a/comms/torchcomms/transport/StagedRdmaTransport.h
+++ b/comms/torchcomms/transport/StagedRdmaTransport.h
@@ -1,0 +1,53 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <memory>
+#include <optional>
+
+#include <comms/ctran/ibverbx/IbvMr.h>
+#include <comms/ctran/ibverbx/IbvPd.h>
+
+namespace torch::comms {
+
+// RAII wrapper for a GPU staging buffer registered for GPUDirect RDMA via
+// dmabuf. Allocates GPU memory with cudaMalloc, exports a dmabuf fd, and
+// registers it with the IB protection domain for zero-copy RDMA access.
+//
+// Destruction order: deregister MR → close dmabuf fd → cudaFree.
+class StagedBuffer {
+ public:
+  StagedBuffer(size_t size, int cudaDev, ibverbx::IbvPd& pd);
+  ~StagedBuffer();
+
+  // Move-only
+  StagedBuffer(StagedBuffer&& other) noexcept;
+  StagedBuffer& operator=(StagedBuffer&& other) noexcept;
+  StagedBuffer(const StagedBuffer&) = delete;
+  StagedBuffer& operator=(const StagedBuffer&) = delete;
+
+  void* data() const {
+    return buf_;
+  }
+  size_t size() const {
+    return size_;
+  }
+  int cudaDev() const {
+    return cudaDev_;
+  }
+  uint32_t lkey() const {
+    return mr_->mr()->lkey;
+  }
+  uint32_t rkey() const {
+    return mr_->mr()->rkey;
+  }
+
+ private:
+  void* buf_{nullptr};
+  size_t size_{0};
+  int cudaDev_{-1};
+  int dmabufFd_{-1};
+  std::optional<ibverbx::IbvMr> mr_;
+};
+
+} // namespace torch::comms

--- a/comms/torchcomms/transport/tests/cpp/StagedBufferTest.cc
+++ b/comms/torchcomms/transport/tests/cpp/StagedBufferTest.cc
@@ -1,0 +1,153 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+#include <vector>
+
+#include "comms/ctran/ibverbx/Ibverbx.h"
+#include "comms/ctran/utils/CudaWrap.h"
+#include "comms/torchcomms/transport/StagedRdmaTransport.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+
+// NOLINTNEXTLINE(google-build-using-namespace)
+using namespace torch::comms;
+
+class StagedBufferTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    ncclCvarInit();
+    ASSERT_EQ(ctran::utils::commCudaLibraryInit(), commSuccess);
+    ASSERT_TRUE(ibverbx::ibvInit());
+    ASSERT_EQ(cudaSetDevice(0), cudaSuccess);
+
+    auto maybeDevices = ibverbx::IbvDevice::ibvGetDeviceList();
+    ASSERT_TRUE(maybeDevices.hasValue()) << maybeDevices.error().errStr;
+    ASSERT_GT(maybeDevices->size(), 0);
+    devices_ = std::move(*maybeDevices);
+
+    auto maybePd = devices_[0].allocPd();
+    ASSERT_TRUE(maybePd.hasValue()) << maybePd.error().errStr;
+    pd_.emplace(std::move(*maybePd));
+  }
+
+  void TearDown() override {
+    pd_.reset();
+    devices_.clear();
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaDeviceReset();
+  }
+
+  std::vector<ibverbx::IbvDevice> devices_;
+  std::optional<ibverbx::IbvPd> pd_;
+};
+
+TEST_F(StagedBufferTest, AllocateAndDestroy) {
+  const size_t bufSize = 4 * 1024 * 1024; // 4 MB
+  {
+    StagedBuffer buf(bufSize, 0, *pd_);
+    EXPECT_NE(buf.data(), nullptr);
+    EXPECT_EQ(buf.size(), bufSize);
+    EXPECT_EQ(buf.cudaDev(), 0);
+    EXPECT_NE(buf.lkey(), 0u);
+    EXPECT_NE(buf.rkey(), 0u);
+  }
+  // Destruction should not crash
+}
+
+TEST_F(StagedBufferTest, SmallBuffer) {
+  // Small but page-aligned buffer (cudaMalloc + dmabuf require page alignment)
+  const size_t bufSize = 64 * 1024; // 64 KB
+  StagedBuffer buf(bufSize, 0, *pd_);
+  EXPECT_NE(buf.data(), nullptr);
+  EXPECT_EQ(buf.size(), bufSize);
+}
+
+TEST_F(StagedBufferTest, LargeBuffer) {
+  // 64 MB — the default staging buffer size used in production
+  const size_t bufSize = 64 * 1024 * 1024;
+  StagedBuffer buf(bufSize, 0, *pd_);
+  EXPECT_NE(buf.data(), nullptr);
+  EXPECT_EQ(buf.size(), bufSize);
+  EXPECT_NE(buf.lkey(), 0u);
+  EXPECT_NE(buf.rkey(), 0u);
+}
+
+TEST_F(StagedBufferTest, MoveConstruct) {
+  const size_t bufSize = 1024 * 1024;
+  StagedBuffer buf1(bufSize, 0, *pd_);
+  void* origData = buf1.data();
+  uint32_t origLkey = buf1.lkey();
+
+  StagedBuffer buf2(std::move(buf1));
+  EXPECT_EQ(buf2.data(), origData);
+  EXPECT_EQ(buf2.lkey(), origLkey);
+  EXPECT_EQ(buf2.size(), bufSize);
+
+  // Moved-from object should have null data
+  EXPECT_EQ(buf1.data(), nullptr);
+}
+
+TEST_F(StagedBufferTest, MoveAssign) {
+  const size_t bufSize = 1024 * 1024;
+  StagedBuffer buf1(bufSize, 0, *pd_);
+  StagedBuffer buf2(bufSize * 2, 0, *pd_);
+
+  void* origData1 = buf1.data();
+  uint32_t origLkey1 = buf1.lkey();
+
+  // Move-assign buf1 into buf2 — buf2's original resources should be freed
+  buf2 = std::move(buf1);
+  EXPECT_EQ(buf2.data(), origData1);
+  EXPECT_EQ(buf2.lkey(), origLkey1);
+  EXPECT_EQ(buf2.size(), bufSize);
+  EXPECT_EQ(buf1.data(), nullptr);
+}
+
+TEST_F(StagedBufferTest, GpuDataReadWrite) {
+  // Verify the GPU pointer is usable for cudaMemcpy (the staging use case)
+  const size_t bufSize = 4096;
+  StagedBuffer buf(bufSize, 0, *pd_);
+
+  // Write a pattern to the staging buffer via host
+  std::vector<uint8_t> hostSrc(bufSize, 0xAB);
+  ASSERT_EQ(
+      cudaMemcpy(buf.data(), hostSrc.data(), bufSize, cudaMemcpyHostToDevice),
+      cudaSuccess);
+
+  // Read it back and verify
+  std::vector<uint8_t> hostDst(bufSize, 0);
+  ASSERT_EQ(
+      cudaMemcpy(hostDst.data(), buf.data(), bufSize, cudaMemcpyDeviceToHost),
+      cudaSuccess);
+  EXPECT_EQ(hostSrc, hostDst);
+}
+
+TEST_F(StagedBufferTest, GpuD2DCopy) {
+  // Verify D2D copy works (the core staging operation)
+  const size_t bufSize = 4096;
+  StagedBuffer buf(bufSize, 0, *pd_);
+
+  // Allocate a separate GPU buffer (simulating a model tensor)
+  void* srcGpu = nullptr;
+  ASSERT_EQ(cudaMalloc(&srcGpu, bufSize), cudaSuccess);
+
+  // Fill source with pattern
+  std::vector<uint8_t> hostSrc(bufSize, 0xCD);
+  ASSERT_EQ(
+      cudaMemcpy(srcGpu, hostSrc.data(), bufSize, cudaMemcpyHostToDevice),
+      cudaSuccess);
+
+  // D2D copy: srcGpu → staging buffer
+  ASSERT_EQ(
+      cudaMemcpy(buf.data(), srcGpu, bufSize, cudaMemcpyDeviceToDevice),
+      cudaSuccess);
+
+  // Read staging buffer back to host and verify
+  std::vector<uint8_t> hostDst(bufSize, 0);
+  ASSERT_EQ(
+      cudaMemcpy(hostDst.data(), buf.data(), bufSize, cudaMemcpyDeviceToHost),
+      cudaSuccess);
+  EXPECT_EQ(hostSrc, hostDst);
+
+  ASSERT_EQ(cudaFree(srcGpu), cudaSuccess);
+}


### PR DESCRIPTION
Summary:
Add StagedBuffer, an RAII wrapper for GPU memory registered for GPUDirect
RDMA via dmabuf. Allocates GPU memory with cudaMalloc, exports a dmabuf fd
via cuMemGetHandleForAddressRange, and registers it with the IB protection
domain for zero-copy RDMA access. Destruction tears down in reverse order:
deregister MR, close dmabuf fd, cudaFree. Supports move semantics.

This is the foundational building block for staged RDMA transfers that
eliminate O(model_size) CPU memory during trainer-to-trainer tensor transfer.

Reviewed By: cenzhaometa

Differential Revision: D99563145


