### PR TITLE
Add StagedRdmaTransport for chunked GPU-to-GPU RDMA transfers

### DIFF
--- a/comms/torchcomms/transport/StagedRdmaTransport.cpp
+++ b/comms/torchcomms/transport/StagedRdmaTransport.cpp
@@ -1,0 +1,115 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "StagedRdmaTransport.h"
+
+#include <unistd.h>
+
+#include <cuda_runtime.h>
+
+#include <comms/ctran/utils/CudaWrap.h>
+
+#include <fmt/core.h>
+
+// ibverbx wraps all libibverbs types in its own namespace
+using namespace ibverbx; // NOLINT(google-build-using-namespace)
+
+namespace {
+
+#define CUDA_CHECK(cmd)                     \
+  do {                                      \
+    auto err = (cmd);                       \
+    if (err != cudaSuccess) {               \
+      throw std::runtime_error(             \
+          fmt::format(                      \
+              "CUDA error {} at {}:{}: {}", \
+              static_cast<int>(err),        \
+              __FILE__,                     \
+              __LINE__,                     \
+              cudaGetErrorString(err)));    \
+    }                                       \
+  } while (0)
+
+} // namespace
+
+namespace torch::comms {
+
+// --- StagedBuffer ---
+
+StagedBuffer::StagedBuffer(size_t size, int cudaDev, ibverbx::IbvPd& pd)
+    : size_(size), cudaDev_(cudaDev) {
+  CUDA_CHECK(cudaSetDevice(cudaDev));
+  CUDA_CHECK(cudaMalloc(&buf_, size));
+
+  // Export dmabuf fd for GDR registration
+  dmabufFd_ = ctran::utils::getCuMemDmaBufFd(buf_, size);
+  if (dmabufFd_ < 0) {
+    // Error path cleanup — cudaFree failure is non-actionable here.
+    cudaFree(buf_);
+    throw std::runtime_error("Failed to get dmabuf fd for GPU buffer");
+  }
+
+  // Register with IB for RDMA access via GPUDirect
+  auto maybeMr = pd.regDmabufMr(
+      /*offset=*/0,
+      size,
+      reinterpret_cast<uintptr_t>(buf_),
+      dmabufFd_,
+      static_cast<ibv_access_flags>(
+          IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE |
+          IBV_ACCESS_REMOTE_READ));
+  if (!maybeMr) {
+    close(dmabufFd_);
+    // Error path cleanup — cudaFree failure is non-actionable here.
+    cudaFree(buf_);
+    throw std::runtime_error(
+        "Failed to register dmabuf MR: " + maybeMr.error().errStr);
+  }
+  mr_.emplace(std::move(*maybeMr));
+}
+
+StagedBuffer::~StagedBuffer() {
+  // Destruction order: MR → dmabuf fd → GPU memory
+  mr_.reset();
+  if (dmabufFd_ >= 0) {
+    close(dmabufFd_);
+  }
+  if (buf_) {
+    // Destructor must not throw — cudaFree failure is non-actionable.
+    cudaFree(buf_);
+  }
+}
+
+StagedBuffer::StagedBuffer(StagedBuffer&& other) noexcept
+    : buf_(other.buf_),
+      size_(other.size_),
+      cudaDev_(other.cudaDev_),
+      dmabufFd_(other.dmabufFd_),
+      mr_(std::move(other.mr_)) {
+  other.buf_ = nullptr;
+  other.dmabufFd_ = -1;
+}
+
+StagedBuffer& StagedBuffer::operator=(StagedBuffer&& other) noexcept {
+  if (this != &other) {
+    mr_.reset();
+    if (dmabufFd_ >= 0) {
+      close(dmabufFd_);
+    }
+    if (buf_) {
+      // noexcept move — cudaFree failure is non-actionable.
+      cudaFree(buf_);
+    }
+
+    buf_ = other.buf_;
+    size_ = other.size_;
+    cudaDev_ = other.cudaDev_;
+    dmabufFd_ = other.dmabufFd_;
+    mr_ = std::move(other.mr_);
+
+    other.buf_ = nullptr;
+    other.dmabufFd_ = -1;
+  }
+  return *this;
+}
+
+} // namespace torch::comms

--- a/comms/torchcomms/transport/StagedRdmaTransport.cpp
+++ b/comms/torchcomms/transport/StagedRdmaTransport.cpp
@@ -6,7 +6,10 @@
 
 #include <cuda_runtime.h>
 
+#include <folly/synchronization/CallOnce.h>
+
 #include <comms/ctran/utils/CudaWrap.h>
+#include <comms/utils/cvars/nccl_cvars.h>
 
 #include <fmt/core.h>
 
@@ -14,6 +17,13 @@
 using namespace ibverbx; // NOLINT(google-build-using-namespace)
 
 namespace {
+
+// NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
+folly::once_flag initOnceFlag;
+
+void initEnvironment() {
+  folly::call_once(initOnceFlag, [] { ncclCvarInit(); });
+}
 
 #define CUDA_CHECK(cmd)                     \
   do {                                      \
@@ -110,6 +120,80 @@ StagedBuffer& StagedBuffer::operator=(StagedBuffer&& other) noexcept {
     other.dmabufFd_ = -1;
   }
   return *this;
+}
+
+// --- StagedRdmaTransportBase ---
+
+StagedRdmaTransportBase::StagedRdmaTransportBase(
+    int cudaDev,
+    folly::EventBase* evb,
+    StagedTransferConfig config)
+    : cudaDev_(cudaDev), config_(config), evb_(evb) {
+  initEnvironment();
+}
+
+StagedRdmaTransportBase::~StagedRdmaTransportBase() {
+  if (stream_) {
+    cudaStreamSynchronize(stream_);
+    cudaStreamDestroy(stream_);
+  }
+}
+
+int32_t StagedRdmaTransportBase::getDeviceId() const {
+  if (!pd_.has_value()) {
+    throw std::runtime_error(
+        "getDeviceId() called before setupLocalTransport()");
+  }
+  return pd_->getDeviceId();
+}
+
+void StagedRdmaTransportBase::initIbResources() {
+  throw std::runtime_error("initIbResources() not yet implemented");
+}
+
+void StagedRdmaTransportBase::connectQp(const std::string& /*peerConnInfo*/) {
+  throw std::runtime_error("connectQp() not yet implemented");
+}
+
+std::string StagedRdmaTransportBase::serializeConnInfo(
+    const StagingRendezvousInfo& /*localStaging*/) {
+  throw std::runtime_error("serializeConnInfo() not yet implemented");
+}
+
+// --- StagedRdmaServerTransport ---
+
+StagedRdmaServerTransport::~StagedRdmaServerTransport() = default;
+
+std::string StagedRdmaServerTransport::setupLocalTransport() {
+  throw std::runtime_error("setupLocalTransport() not yet implemented");
+}
+
+void StagedRdmaServerTransport::connectRemoteTransport(
+    const std::string& /*peerConnInfo*/) {
+  throw std::runtime_error("connectRemoteTransport() not yet implemented");
+}
+
+folly::SemiFuture<commResult_t> StagedRdmaServerTransport::send(
+    const ScatterGatherDescriptor& /*src*/) {
+  throw std::runtime_error("send() not yet implemented");
+}
+
+// --- StagedRdmaClientTransport ---
+
+StagedRdmaClientTransport::~StagedRdmaClientTransport() = default;
+
+std::string StagedRdmaClientTransport::setupLocalTransport() {
+  throw std::runtime_error("setupLocalTransport() not yet implemented");
+}
+
+void StagedRdmaClientTransport::connectRemoteTransport(
+    const std::string& /*peerConnInfo*/) {
+  throw std::runtime_error("connectRemoteTransport() not yet implemented");
+}
+
+folly::SemiFuture<commResult_t> StagedRdmaClientTransport::recv(
+    const ScatterGatherDescriptor& /*dst*/) {
+  throw std::runtime_error("recv() not yet implemented");
 }
 
 } // namespace torch::comms

--- a/comms/torchcomms/transport/StagedRdmaTransport.h
+++ b/comms/torchcomms/transport/StagedRdmaTransport.h
@@ -2,13 +2,55 @@
 
 #pragma once
 
+#include <atomic>
+#include <chrono>
 #include <memory>
 #include <optional>
+#include <string>
 
+#include <cuda_runtime.h>
+
+#include <folly/futures/Future.h>
+#include <folly/io/async/EventBase.h>
+
+#include <comms/ctran/ibverbx/IbvCommon.h>
+#include <comms/ctran/ibverbx/IbvDevice.h>
 #include <comms/ctran/ibverbx/IbvMr.h>
 #include <comms/ctran/ibverbx/IbvPd.h>
+#include <comms/ctran/ibverbx/IbvVirtualCq.h>
+#include <comms/ctran/ibverbx/IbvVirtualQp.h>
+#include <comms/ctran/ibverbx/IbvVirtualWr.h>
+#include <comms/utils/commSpecs.h>
 
 namespace torch::comms {
+
+// Configuration for staged RDMA transfers.
+struct StagedTransferConfig {
+  // Size of the GPU staging buffer on each side. Each chunk transfer moves
+  // at most this many bytes via a single RDMA_WRITE_WITH_IMM.
+  size_t stagingBufSize = 64 * 1024 * 1024; // 64 MB
+
+  // Timeout for waiting on the recvReady flag or CQ poll between chunks.
+  std::chrono::milliseconds chunkTimeout{30000};
+};
+
+// Information exchanged between server and client during setupLocalTransport()
+// so each side knows the remote staging buffer address and rkey for one-sided
+// RDMA operations. Serialized into the connection info string by
+// setupLocalTransport() and deserialized/stored by connectRemoteTransport().
+struct StagingRendezvousInfo {
+  struct BufferInfo {
+    uintptr_t addr{0};
+    uint32_t rkey{0};
+    size_t size{0};
+  };
+
+  BufferInfo stagingBuf{};
+
+  // Only populated on the server side — the client uses this to RDMA_WRITE
+  // the recvReady acknowledgement back to the server.
+  std::optional<BufferInfo> recvReady;
+};
 
 // RAII wrapper for a GPU staging buffer registered for GPUDirect RDMA via
 // dmabuf. Allocates GPU memory with cudaMalloc, exports a dmabuf fd, and
@@ -48,6 +90,162 @@ class StagedBuffer {
   int cudaDev_{-1};
   int dmabufFd_{-1};
   std::optional<ibverbx::IbvMr> mr_;
+};
+
+// Describes GPU memory regions for staged RDMA transfers. A single entry
+// represents a contiguous buffer; multiple entries describe non-contiguous
+// regions for scatter/gather transfers.
+struct ScatterGatherDescriptor {
+  struct Entry {
+    void* ptr;
+    size_t size;
+  };
+  std::vector<Entry> entries;
+
+  size_t totalBytes() const {
+    size_t total = 0;
+    for (const auto& e : entries) {
+      total += e.size;
+    }
+    return total;
+  }
+};
+
+// Base class for staged RDMA transports. Holds shared IB resources and
+// provides protected helpers for IB setup and QP connection.
+//
+// Not intended to be used directly — use StagedRdmaServerTransport or
+// StagedRdmaClientTransport.
+//
+// Bootstrap workflow:
+//   1. Construct server/client transport(cudaDev, evb)
+//   2. connInfo = setupLocalTransport() — creates IB resources + staging buffer
+//   3. Exchange connInfo out-of-band (e.g. via Thrift RPC)
+//   4. Server: connectRemoteTransport(clientConnInfo)
+//   5. Client: connectRemoteTransport(serverConnInfo)
+//   6. Server: send(src)    — chunked D2D + RDMA pipeline
+//      Client: recv(dst)    — chunked RDMA + D2D pipeline
+class StagedRdmaTransportBase {
+ public:
+  explicit StagedRdmaTransportBase(
+      int cudaDev,
+      folly::EventBase* evb = nullptr,
+      StagedTransferConfig config = {});
+  ~StagedRdmaTransportBase();
+
+  // Non-copyable, non-movable (owns IB resources tied to device state)
+  StagedRdmaTransportBase(const StagedRdmaTransportBase&) = delete;
+  StagedRdmaTransportBase& operator=(const StagedRdmaTransportBase&) = delete;
+  StagedRdmaTransportBase(StagedRdmaTransportBase&&) = delete;
+  StagedRdmaTransportBase& operator=(StagedRdmaTransportBase&&) = delete;
+
+  // Return the staging buffer size from config.
+  size_t stagingBufSize() const {
+    return config_.stagingBufSize;
+  }
+
+ protected:
+  int cudaDev_;
+  StagedTransferConfig config_;
+
+  // EventBase for running transfers. Optional for construction/setup/connect,
+  // but required for send/recv (CHECK_THROW if nullptr).
+  folly::EventBase* evb_{nullptr};
+
+  // Peer's staging info — populated by connectQp() from the peer's serialized
+  // connection info. Used by send (to know remote staging buffer addr)
+  // and recv (to know remote recvReady addr).
+  StagingRendezvousInfo peerStaging_;
+
+  // IB resources (H100: single device/PD; GB200 diff expands to vectors)
+  std::optional<ibverbx::IbvDevice> device_;
+  std::optional<ibverbx::IbvPd> pd_;
+  std::optional<ibverbx::IbvVirtualCq> vcq_;
+  std::optional<StagedBuffer> stagingBuf_;
+  cudaStream_t stream_{nullptr};
+
+  // Virtual QP — declared last so it is destroyed first.
+  std::optional<ibverbx::IbvVirtualQp> vqp_;
+
+  // Get the device ID for building deviceKeys maps.
+  int32_t getDeviceId() const;
+
+  // Protected helpers — called explicitly by subclasses, no virtual dispatch.
+
+  // Initialize IB resources: device, PD, CQ, VirtualQP, staging buffer,
+  // CUDA stream. Must be called before connectQp().
+  void initIbResources();
+
+  // Connect to the peer using their serialized connection info. Deserializes
+  // peer info, stores peerStaging_, transitions QP through INIT → RTR → RTS.
+  void connectQp(const std::string& peerConnInfo);
+
+  // Serialize local connection info (business card + GID/port/MTU + staging)
+  // into a JSON string for exchange with the peer.
+  std::string serializeConnInfo(const StagingRendezvousInfo& localStaging);
+};
+
+// Server-side staged RDMA transport. Sends data to the client via chunked
+// D2D copy → RDMA_WRITE_WITH_IMM pipeline.
+class StagedRdmaServerTransport : public StagedRdmaTransportBase {
+ public:
+  using StagedRdmaTransportBase::StagedRdmaTransportBase;
+  ~StagedRdmaServerTransport();
+
+  // Initialize IB resources, allocate recvReady flag, and return serialized
+  // connection info for the peer.
+  std::string setupLocalTransport();
+
+  // Connect to the client using their serialized connection info.
+  void connectRemoteTransport(const std::string& peerConnInfo);
+
+  // Transfer GPU memory regions described by src to the client's staging
+  // buffer, pipelining in stagingBufSize chunks. All entry pointers must be
+  // on cudaDev_. Requires evb_ (CHECK_THROW if nullptr).
+  folly::SemiFuture<commResult_t> send(const ScatterGatherDescriptor& src);
+
+ private:
+  // recvReady flag — CPU-pinned, cache-line aligned, RDMA-registered.
+  // The client writes kRecvReadyValue here via RDMA_WRITE to signal that it
+  // has finished copying data out of its staging buffer.
+  // Pre-initialized to kRecvReadyValue so the first send() proceeds
+  // immediately.
+  struct AlignedDelete {
+    void operator()(std::atomic<uint64_t>* p) const {
+      ::operator delete(p, std::align_val_t{64});
+    }
+  };
+  std::unique_ptr<std::atomic<uint64_t>, AlignedDelete> recvReadyFlag_;
+  std::optional<ibverbx::IbvMr> recvReadyServerMr_;
+};
+
+// Client-side staged RDMA transport. Receives data from the server via
+// RDMA_WRITE_WITH_IMM → D2D copy pipeline.
+class StagedRdmaClientTransport : public StagedRdmaTransportBase {
+ public:
+  using StagedRdmaTransportBase::StagedRdmaTransportBase;
+  ~StagedRdmaClientTransport();
+
+  // Initialize IB resources and return serialized connection info for the
+  // peer.
+  std::string setupLocalTransport();
+
+  // Connect to the server using their serialized connection info. Registers
+  // recvReady source MR and posts initial recv WR.
+  void connectRemoteTransport(const std::string& peerConnInfo);
+
+  // Receive into GPU memory regions described by dst from the server's
+  // staging buffer, pipelining in stagingBufSize chunks. All entry pointers
+  // must be on cudaDev_ (CPU buffers are not supported). numChunks is
+  // computed internally from totalBytes and the server's staging buffer
+  // size (exchanged during connectRemoteTransport()).
+  // Requires evb_ (CHECK_THROW if nullptr).
+  folly::SemiFuture<commResult_t> recv(const ScatterGatherDescriptor& dst);
+
+ private:
+  // MR for &kRecvReadyValue — used as source for RDMA_WRITE to server's
+  // recvReadyFlag_.
+  std::optional<ibverbx::IbvMr> recvReadyClientMr_;
 };
 
 } // namespace torch::comms

--- a/comms/torchcomms/transport/StagedRdmaTransport.h
+++ b/comms/torchcomms/transport/StagedRdmaTransport.h
@@ -1,0 +1,53 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <memory>
+#include <optional>
+
+#include <comms/ctran/ibverbx/IbvMr.h>
+#include <comms/ctran/ibverbx/IbvPd.h>
+
+namespace torch::comms {
+
+// RAII wrapper for a GPU staging buffer registered for GPUDirect RDMA via
+// dmabuf. Allocates GPU memory with cudaMalloc, exports a dmabuf fd, and
+// registers it with the IB protection domain for zero-copy RDMA access.
+//
+// Destruction order: deregister MR → close dmabuf fd → cudaFree.
+class StagedBuffer {
+ public:
+  StagedBuffer(size_t size, int cudaDev, ibverbx::IbvPd& pd);
+  ~StagedBuffer();
+
+  // Move-only
+  StagedBuffer(StagedBuffer&& other) noexcept;
+  StagedBuffer& operator=(StagedBuffer&& other) noexcept;
+  StagedBuffer(const StagedBuffer&) = delete;
+  StagedBuffer& operator=(const StagedBuffer&) = delete;
+
+  void* data() const {
+    return buf_;
+  }
+  size_t size() const {
+    return size_;
+  }
+  int cudaDev() const {
+    return cudaDev_;
+  }
+  uint32_t lkey() const {
+    return mr_->mr()->lkey;
+  }
+  uint32_t rkey() const {
+    return mr_->mr()->rkey;
+  }
+
+ private:
+  void* buf_{nullptr};
+  size_t size_{0};
+  int cudaDev_{-1};
+  int dmabufFd_{-1};
+  std::optional<ibverbx::IbvMr> mr_;
+};
+
+} // namespace torch::comms

--- a/comms/torchcomms/transport/tests/cpp/StagedBufferTest.cc
+++ b/comms/torchcomms/transport/tests/cpp/StagedBufferTest.cc
@@ -1,0 +1,153 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+#include <vector>
+
+#include "comms/ctran/ibverbx/Ibverbx.h"
+#include "comms/ctran/utils/CudaWrap.h"
+#include "comms/torchcomms/transport/StagedRdmaTransport.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+
+// NOLINTNEXTLINE(google-build-using-namespace)
+using namespace torch::comms;
+
+class StagedBufferTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    ncclCvarInit();
+    ASSERT_EQ(ctran::utils::commCudaLibraryInit(), commSuccess);
+    ASSERT_TRUE(ibverbx::ibvInit());
+    ASSERT_EQ(cudaSetDevice(0), cudaSuccess);
+
+    auto maybeDevices = ibverbx::IbvDevice::ibvGetDeviceList();
+    ASSERT_TRUE(maybeDevices.hasValue()) << maybeDevices.error().errStr;
+    ASSERT_GT(maybeDevices->size(), 0);
+    devices_ = std::move(*maybeDevices);
+
+    auto maybePd = devices_[0].allocPd();
+    ASSERT_TRUE(maybePd.hasValue()) << maybePd.error().errStr;
+    pd_.emplace(std::move(*maybePd));
+  }
+
+  void TearDown() override {
+    pd_.reset();
+    devices_.clear();
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaDeviceReset();
+  }
+
+  std::vector<ibverbx::IbvDevice> devices_;
+  std::optional<ibverbx::IbvPd> pd_;
+};
+
+TEST_F(StagedBufferTest, AllocateAndDestroy) {
+  const size_t bufSize = 4 * 1024 * 1024; // 4 MB
+  {
+    StagedBuffer buf(bufSize, 0, *pd_);
+    EXPECT_NE(buf.data(), nullptr);
+    EXPECT_EQ(buf.size(), bufSize);
+    EXPECT_EQ(buf.cudaDev(), 0);
+    EXPECT_NE(buf.lkey(), 0u);
+    EXPECT_NE(buf.rkey(), 0u);
+  }
+  // Destruction should not crash
+}
+
+TEST_F(StagedBufferTest, SmallBuffer) {
+  // Small but page-aligned buffer (cudaMalloc + dmabuf require page alignment)
+  const size_t bufSize = 64 * 1024; // 64 KB
+  StagedBuffer buf(bufSize, 0, *pd_);
+  EXPECT_NE(buf.data(), nullptr);
+  EXPECT_EQ(buf.size(), bufSize);
+}
+
+TEST_F(StagedBufferTest, LargeBuffer) {
+  // 64 MB — the default staging buffer size used in production
+  const size_t bufSize = 64 * 1024 * 1024;
+  StagedBuffer buf(bufSize, 0, *pd_);
+  EXPECT_NE(buf.data(), nullptr);
+  EXPECT_EQ(buf.size(), bufSize);
+  EXPECT_NE(buf.lkey(), 0u);
+  EXPECT_NE(buf.rkey(), 0u);
+}
+
+TEST_F(StagedBufferTest, MoveConstruct) {
+  const size_t bufSize = 1024 * 1024;
+  StagedBuffer buf1(bufSize, 0, *pd_);
+  void* origData = buf1.data();
+  uint32_t origLkey = buf1.lkey();
+
+  StagedBuffer buf2(std::move(buf1));
+  EXPECT_EQ(buf2.data(), origData);
+  EXPECT_EQ(buf2.lkey(), origLkey);
+  EXPECT_EQ(buf2.size(), bufSize);
+
+  // Moved-from object should have null data
+  EXPECT_EQ(buf1.data(), nullptr);
+}
+
+TEST_F(StagedBufferTest, MoveAssign) {
+  const size_t bufSize = 1024 * 1024;
+  StagedBuffer buf1(bufSize, 0, *pd_);
+  StagedBuffer buf2(bufSize * 2, 0, *pd_);
+
+  void* origData1 = buf1.data();
+  uint32_t origLkey1 = buf1.lkey();
+
+  // Move-assign buf1 into buf2 — buf2's original resources should be freed
+  buf2 = std::move(buf1);
+  EXPECT_EQ(buf2.data(), origData1);
+  EXPECT_EQ(buf2.lkey(), origLkey1);
+  EXPECT_EQ(buf2.size(), bufSize);
+  EXPECT_EQ(buf1.data(), nullptr);
+}
+
+TEST_F(StagedBufferTest, GpuDataReadWrite) {
+  // Verify the GPU pointer is usable for cudaMemcpy (the staging use case)
+  const size_t bufSize = 4096;
+  StagedBuffer buf(bufSize, 0, *pd_);
+
+  // Write a pattern to the staging buffer via host
+  std::vector<uint8_t> hostSrc(bufSize, 0xAB);
+  ASSERT_EQ(
+      cudaMemcpy(buf.data(), hostSrc.data(), bufSize, cudaMemcpyHostToDevice),
+      cudaSuccess);
+
+  // Read it back and verify
+  std::vector<uint8_t> hostDst(bufSize, 0);
+  ASSERT_EQ(
+      cudaMemcpy(hostDst.data(), buf.data(), bufSize, cudaMemcpyDeviceToHost),
+      cudaSuccess);
+  EXPECT_EQ(hostSrc, hostDst);
+}
+
+TEST_F(StagedBufferTest, GpuD2DCopy) {
+  // Verify D2D copy works (the core staging operation)
+  const size_t bufSize = 4096;
+  StagedBuffer buf(bufSize, 0, *pd_);
+
+  // Allocate a separate GPU buffer (simulating a model tensor)
+  void* srcGpu = nullptr;
+  ASSERT_EQ(cudaMalloc(&srcGpu, bufSize), cudaSuccess);
+
+  // Fill source with pattern
+  std::vector<uint8_t> hostSrc(bufSize, 0xCD);
+  ASSERT_EQ(
+      cudaMemcpy(srcGpu, hostSrc.data(), bufSize, cudaMemcpyHostToDevice),
+      cudaSuccess);
+
+  // D2D copy: srcGpu → staging buffer
+  ASSERT_EQ(
+      cudaMemcpy(buf.data(), srcGpu, bufSize, cudaMemcpyDeviceToDevice),
+      cudaSuccess);
+
+  // Read staging buffer back to host and verify
+  std::vector<uint8_t> hostDst(bufSize, 0);
+  ASSERT_EQ(
+      cudaMemcpy(hostDst.data(), buf.data(), bufSize, cudaMemcpyDeviceToHost),
+      cudaSuccess);
+  EXPECT_EQ(hostSrc, hostDst);
+
+  ASSERT_EQ(cudaFree(srcGpu), cudaSuccess);
+}

--- a/comms/torchcomms/transport/tests/cpp/StagedRdmaTransportTest.cc
+++ b/comms/torchcomms/transport/tests/cpp/StagedRdmaTransportTest.cc
@@ -1,0 +1,39 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include <folly/io/async/EventBase.h>
+#include <folly/io/async/ScopedEventBaseThread.h>
+
+#include "comms/torchcomms/transport/StagedRdmaTransport.h"
+
+// NOLINTNEXTLINE(google-build-using-namespace)
+using namespace torch::comms;
+
+TEST(StagedRdmaTransportTest, ConstructAndDestroy) {
+  // Minimal construction — no IB resources, no EventBase.
+  StagedRdmaServerTransport server(0);
+  StagedRdmaClientTransport client(0);
+  EXPECT_EQ(server.stagingBufSize(), 64 * 1024 * 1024);
+  EXPECT_EQ(client.stagingBufSize(), 64 * 1024 * 1024);
+}
+
+TEST(StagedRdmaTransportTest, ConstructWithConfig) {
+  StagedTransferConfig config;
+  config.stagingBufSize = 1024 * 1024;
+  config.chunkTimeout = std::chrono::milliseconds{5000};
+
+  StagedRdmaServerTransport server(0, nullptr, config);
+  StagedRdmaClientTransport client(0, nullptr, config);
+  EXPECT_EQ(server.stagingBufSize(), 1024 * 1024);
+  EXPECT_EQ(client.stagingBufSize(), 1024 * 1024);
+}
+
+TEST(StagedRdmaTransportTest, ConstructWithEventBase) {
+  folly::ScopedEventBaseThread evbThread("test-evb");
+  StagedRdmaServerTransport server(0, evbThread.getEventBase());
+  StagedRdmaClientTransport client(0, evbThread.getEventBase());
+  EXPECT_EQ(server.stagingBufSize(), 64 * 1024 * 1024);
+  EXPECT_EQ(client.stagingBufSize(), 64 * 1024 * 1024);
+}


### PR DESCRIPTION
Summary:
Add StagedRdmaTransport, a transport class that manages IB resources for GPU-to-GPU RDMA transfers using StagedBuffer.

Class declaration with full public API:
  - bind(), connect(), stagedPut(), stagedRecv(), getLocalStagingInfo()
  - All methods are throw-stubs; implementations deferred to later diffs

Supporting types:
  - StagedTransferConfig: staging buffer size + chunk timeout
  - StagingRendezvousInfo: remote buffer addr/rkey/size for rendezvous
  - StagedTransportRole: SENDER vs RECEIVER endpoint role

Constructor/destructor tests (3 tests, 1 GPU, no IB hardware):
  - ConstructAndDestroy: default config, verifies 64MB staging buffer size
  - ConstructWithConfig: custom config (1MB buffer, 5s timeout)
  - ConstructWithEventBase: EventBase injection + clean timeout cancellation

Reviewed By: cenzhaometa

Differential Revision: D99563143


