### PR TITLE
Add StagedRdmaTransport implementation (#2030)

### DIFF
--- a/comms/torchcomms/transport/StagedRdmaTransport.cpp
+++ b/comms/torchcomms/transport/StagedRdmaTransport.cpp
@@ -6,12 +6,19 @@
 
 #include <cuda_runtime.h>
 
+#include <folly/dynamic.h>
+#include <folly/json.h>
 #include <folly/synchronization/CallOnce.h>
 
+#include <climits>
+
+#include <comms/ctran/ibverbx/IbvPd.h>
+#include <comms/ctran/ibverbx/Ibverbx.h>
 #include <comms/ctran/utils/CudaWrap.h>
 #include <comms/utils/cvars/nccl_cvars.h>
 
 #include <fmt/core.h>
+#include <folly/logging/xlog.h>
 
 // ibverbx wraps all libibverbs types in its own namespace
 using namespace ibverbx; // NOLINT(google-build-using-namespace)
@@ -39,53 +46,185 @@ void initEnvironment() {
     }                                       \
   } while (0)
 
+// ---------------------------------------------------------------------------
+// QP configuration constants — matches production values in IbvQpUtils.cc
+// and nccl_cvars.yaml defaults.
+// ---------------------------------------------------------------------------
+
+// RDMA port and addressing
+constexpr uint8_t kPortNum = 1; // Standard IB port number
+constexpr int kGidIndex = 3; // RoCEv2 GID index (Ethernet)
+
+// QP capacity
+constexpr int kTotalQps = 1; // 1 for H100; increase for GB200
+constexpr int kMaxMsgCntPerQp = 4; // Single-buffer protocol headroom
+constexpr int kMaxSge = 1; // One scatter-gather entry per WR
+
+// QP transport — aligned with NCCL_IB_* cvar defaults
+constexpr uint8_t kTimeout = 20; // ACK timeout (~4.2 s)
+constexpr uint8_t kRetryCnt = 7; // Transport retries (7 = infinite)
+constexpr uint8_t kRnrRetryCnt = 7; // RNR retries (7 = infinite)
+constexpr uint8_t kMinRnrTimer = 12; // RNR NAK timer
+constexpr uint8_t kMaxRdAtomic = 1; // Outstanding RDMA read/atomic
+constexpr uint8_t kHopLimit = 255; // GRH hop limit
+
+// Value the client writes to the server's readyToSendFlag_ via RDMA_WRITE
+// to signal that it has finished copying data out of its staging buffer.
+static uint64_t kRecvReadyValue = 1;
+
+// Serialize local connection info (business card + GID + port + MTU + staging)
+// to JSON. Staging info allows the peer to populate peerStaging_ during
+// connectQp() for subsequent one-sided RDMA operations.
+std::string serializeConnectionInfo(
+    const ibverbx::IbvVirtualQpBusinessCard& busCard,
+    uint64_t subnetPrefix,
+    uint64_t interfaceId,
+    uint8_t port,
+    ibv_mtu mtu,
+    const torch::comms::StagingRendezvousInfo& staging) {
+  folly::dynamic obj = folly::dynamic::object;
+  obj["busCard"] = busCard.serialize();
+  obj["subnetPrefix"] = static_cast<int64_t>(subnetPrefix);
+  obj["interfaceId"] = static_cast<int64_t>(interfaceId);
+  obj["port"] = port;
+  obj["mtu"] = static_cast<int>(mtu);
+
+  // Staging buffer info
+  folly::dynamic stagingObj = folly::dynamic::object;
+  stagingObj["addr"] = static_cast<int64_t>(staging.stagingBuf.addr);
+  stagingObj["rkey"] = static_cast<int64_t>(staging.stagingBuf.rkey);
+  stagingObj["size"] = static_cast<int64_t>(staging.stagingBuf.size);
+  obj["stagingBuf"] = std::move(stagingObj);
+
+  // recvReady info (only present on server side)
+  if (staging.recvReady) {
+    folly::dynamic flagObj = folly::dynamic::object;
+    flagObj["addr"] = static_cast<int64_t>(staging.recvReady->addr);
+    flagObj["rkey"] = static_cast<int64_t>(staging.recvReady->rkey);
+    flagObj["size"] = static_cast<int64_t>(staging.recvReady->size);
+    obj["recvReady"] = std::move(flagObj);
+  }
+
+  return folly::toJson(obj);
+}
+
+struct ConnectionInfo {
+  ibverbx::IbvVirtualQpBusinessCard busCard;
+  uint64_t subnetPrefix;
+  uint64_t interfaceId;
+  uint8_t port;
+  ibv_mtu mtu;
+  torch::comms::StagingRendezvousInfo staging;
+};
+
+ConnectionInfo deserializeConnectionInfo(const std::string& json) {
+  auto obj = folly::parseJson(json);
+  auto busCard =
+      ibverbx::IbvVirtualQpBusinessCard::deserialize(obj["busCard"].asString());
+  if (!busCard) {
+    throw std::runtime_error(
+        "Failed to deserialize IbvVirtualQpBusinessCard: " +
+        busCard.error().errStr);
+  }
+
+  torch::comms::StagingRendezvousInfo staging;
+  if (obj.count("stagingBuf")) {
+    auto& sb = obj["stagingBuf"];
+    staging.stagingBuf.addr = static_cast<uintptr_t>(sb["addr"].asInt());
+    staging.stagingBuf.rkey = static_cast<uint32_t>(sb["rkey"].asInt());
+    staging.stagingBuf.size = static_cast<size_t>(sb["size"].asInt());
+  }
+  if (obj.count("recvReady")) {
+    auto& rr = obj["recvReady"];
+    torch::comms::StagingRendezvousInfo::BufferInfo readyInfo;
+    readyInfo.addr = static_cast<uintptr_t>(rr["addr"].asInt());
+    readyInfo.rkey = static_cast<uint32_t>(rr["rkey"].asInt());
+    readyInfo.size = static_cast<size_t>(rr["size"].asInt());
+    staging.recvReady = readyInfo;
+  }
+
+  return ConnectionInfo{
+      .busCard = std::move(*busCard),
+      .subnetPrefix = static_cast<uint64_t>(obj["subnetPrefix"].asInt()),
+      .interfaceId = static_cast<uint64_t>(obj["interfaceId"].asInt()),
+      .port = static_cast<uint8_t>(obj["port"].asInt()),
+      .mtu = static_cast<ibv_mtu>(obj["mtu"].asInt()),
+      .staging = std::move(staging),
+  };
+}
+
 } // namespace
 
 namespace torch::comms {
 
 // --- StagedBuffer ---
 
-StagedBuffer::StagedBuffer(size_t size, int cudaDev, ibverbx::IbvPd& pd)
-    : size_(size), cudaDev_(cudaDev) {
-  CUDA_CHECK(cudaSetDevice(cudaDev));
-  CUDA_CHECK(cudaMalloc(&buf_, size));
+StagedBuffer::StagedBuffer(
+    size_t size,
+    int cudaDev,
+    ibverbx::IbvPd& pd,
+    StagedTransferConfig::StagingMode mode)
+    : size_(size),
+      cudaDev_(cudaDev),
+      isGpu_(mode == StagedTransferConfig::StagingMode::GPU) {
+  if (isGpu_) {
+    CUDA_CHECK(cudaSetDevice(cudaDev));
+    CUDA_CHECK(cudaMalloc(&buf_, size));
 
-  // Export dmabuf fd for GDR registration
-  dmabufFd_ = ctran::utils::getCuMemDmaBufFd(buf_, size);
-  if (dmabufFd_ < 0) {
-    // Error path cleanup — cudaFree failure is non-actionable here.
-    cudaFree(buf_);
-    throw std::runtime_error("Failed to get dmabuf fd for GPU buffer");
-  }
+    dmabufFd_ = ctran::utils::getCuMemDmaBufFd(buf_, size);
+    if (dmabufFd_ < 0) {
+      cudaFree(buf_);
+      throw std::runtime_error("Failed to get dmabuf fd for GPU buffer");
+    }
 
-  // Register with IB for RDMA access via GPUDirect
-  auto maybeMr = pd.regDmabufMr(
-      /*offset=*/0,
-      size,
-      reinterpret_cast<uintptr_t>(buf_),
-      dmabufFd_,
-      static_cast<ibv_access_flags>(
-          IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE |
-          IBV_ACCESS_REMOTE_READ));
-  if (!maybeMr) {
-    close(dmabufFd_);
-    // Error path cleanup — cudaFree failure is non-actionable here.
-    cudaFree(buf_);
-    throw std::runtime_error(
-        "Failed to register dmabuf MR: " + maybeMr.error().errStr);
+    auto maybeMr = pd.regDmabufMr(
+        /*offset=*/0,
+        size,
+        reinterpret_cast<uintptr_t>(buf_),
+        dmabufFd_,
+        static_cast<ibv_access_flags>(
+            IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE |
+            IBV_ACCESS_REMOTE_READ));
+    if (!maybeMr) {
+      close(dmabufFd_);
+      cudaFree(buf_);
+      throw std::runtime_error(
+          "Failed to register dmabuf MR: " + maybeMr.error().errStr);
+    }
+    mr_.emplace(std::move(*maybeMr));
+  } else {
+    int ret = posix_memalign(&buf_, 4096, size);
+    if (ret != 0) {
+      throw std::runtime_error(
+          fmt::format("posix_memalign failed: {}", strerror(ret)));
+    }
+
+    auto maybeMr = pd.regMr(
+        buf_,
+        size,
+        static_cast<ibv_access_flags>(
+            IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE |
+            IBV_ACCESS_REMOTE_READ));
+    if (!maybeMr) {
+      free(buf_);
+      throw std::runtime_error(
+          "Failed to register CPU staging MR: " + maybeMr.error().errStr);
+    }
+    mr_.emplace(std::move(*maybeMr));
   }
-  mr_.emplace(std::move(*maybeMr));
 }
 
 StagedBuffer::~StagedBuffer() {
-  // Destruction order: MR → dmabuf fd → GPU memory
   mr_.reset();
   if (dmabufFd_ >= 0) {
     close(dmabufFd_);
   }
   if (buf_) {
-    // Destructor must not throw — cudaFree failure is non-actionable.
-    cudaFree(buf_);
+    if (isGpu_) {
+      cudaFree(buf_);
+    } else {
+      free(buf_);
+    }
   }
 }
 
@@ -93,6 +232,7 @@ StagedBuffer::StagedBuffer(StagedBuffer&& other) noexcept
     : buf_(other.buf_),
       size_(other.size_),
       cudaDev_(other.cudaDev_),
+      isGpu_(other.isGpu_),
       dmabufFd_(other.dmabufFd_),
       mr_(std::move(other.mr_)) {
   other.buf_ = nullptr;
@@ -106,13 +246,17 @@ StagedBuffer& StagedBuffer::operator=(StagedBuffer&& other) noexcept {
       close(dmabufFd_);
     }
     if (buf_) {
-      // noexcept move — cudaFree failure is non-actionable.
-      cudaFree(buf_);
+      if (isGpu_) {
+        cudaFree(buf_);
+      } else {
+        free(buf_);
+      }
     }
 
     buf_ = other.buf_;
     size_ = other.size_;
     cudaDev_ = other.cudaDev_;
+    isGpu_ = other.isGpu_;
     dmabufFd_ = other.dmabufFd_;
     mr_ = std::move(other.mr_);
 
@@ -148,16 +292,203 @@ int32_t StagedRdmaTransportBase::getDeviceId() const {
 }
 
 void StagedRdmaTransportBase::initIbResources() {
-  throw std::runtime_error("initIbResources() not yet implemented");
+  // Initialize CUDA driver PFN symbols (only needed for GPU staging mode
+  // which uses getCuMemDmaBufFd for dmabuf export)
+  if (config_.stagingMode == StagedTransferConfig::StagingMode::GPU) {
+    auto cudaInitResult = ctran::utils::commCudaLibraryInit();
+    if (cudaInitResult != commSuccess) {
+      throw std::runtime_error("Failed to initialize CUDA library for PFN");
+    }
+  }
+
+  // Initialize ibverbx (loads libibverbs symbols)
+  auto ibvInitResult = ibverbx::ibvInit();
+  if (!ibvInitResult) {
+    throw std::runtime_error(
+        "Failed to initialize ibverbx: " + ibvInitResult.error().errStr);
+  }
+
+  // 1. Get IB device list and pick the one matching our CUDA device.
+  auto maybeDevices =
+      ibverbx::IbvDevice::ibvGetDeviceList(NCCL_IB_HCA, NCCL_IB_HCA_PREFIX);
+  if (!maybeDevices) {
+    throw std::runtime_error(
+        "Failed to get IB device list: " + maybeDevices.error().errStr);
+  }
+  auto& devices = *maybeDevices;
+  size_t devIdx =
+      static_cast<size_t>(cudaDev_) * NCCL_CTRAN_IB_DEVICES_PER_RANK;
+  if (devIdx >= devices.size()) {
+    throw std::runtime_error(
+        fmt::format(
+            "CUDA device {} maps to IB device index {} "
+            "(NCCL_CTRAN_IB_DEVICES_PER_RANK={}), but only {} IB devices available",
+            cudaDev_,
+            devIdx,
+            NCCL_CTRAN_IB_DEVICES_PER_RANK,
+            devices.size()));
+  }
+  device_.emplace(std::move(devices.at(devIdx)));
+
+  // 2. Allocate protection domain
+  auto maybePd = device_->allocPd();
+  if (!maybePd) {
+    throw std::runtime_error(
+        "Failed to allocate PD: " + maybePd.error().errStr);
+  }
+  pd_.emplace(std::move(*maybePd));
+
+  // 3. Create virtual CQ
+  int cqe = 2 * kTotalQps * kMaxMsgCntPerQp;
+  auto maybeVcq = device_->createVirtualCq(cqe, nullptr, nullptr, 0);
+  if (!maybeVcq) {
+    throw std::runtime_error(
+        "Failed to create virtual CQ: " + maybeVcq.error().errStr);
+  }
+  vcq_.emplace(std::move(*maybeVcq));
+
+  // 4. Create virtual QP with DQPLB load balancing
+  ibv_qp_init_attr initAttr = {};
+  initAttr.qp_type = IBV_QPT_RC;
+  initAttr.sq_sig_all = 0;
+  auto& physCqs = vcq_->getPhysicalCqsRef();
+  initAttr.send_cq = physCqs.at(0).cq();
+  initAttr.recv_cq = physCqs.at(0).cq();
+  initAttr.cap.max_send_wr = kMaxMsgCntPerQp;
+  initAttr.cap.max_recv_wr = kMaxMsgCntPerQp;
+  initAttr.cap.max_send_sge = kMaxSge;
+  initAttr.cap.max_recv_sge = kMaxSge;
+
+  if (config_.stagingBufSize > static_cast<size_t>(INT_MAX)) {
+    throw std::runtime_error(
+        fmt::format(
+            "stagingBufSize {} exceeds INT_MAX for VirtualQP maxMsgSize",
+            config_.stagingBufSize));
+  }
+
+  auto maybeVqp = pd_->createVirtualQp(
+      kTotalQps,
+      &initAttr,
+      &*vcq_,
+      kMaxMsgCntPerQp,
+      static_cast<int>(config_.stagingBufSize),
+      ibverbx::LoadBalancingScheme::DQPLB);
+  if (!maybeVqp) {
+    throw std::runtime_error(
+        "Failed to create virtual QP: " + maybeVqp.error().errStr);
+  }
+  vqp_.emplace(std::move(*maybeVqp));
+
+  // 5. Transition QP to INIT
+  ibv_qp_attr initQpAttr = {};
+  initQpAttr.qp_state = IBV_QPS_INIT;
+  initQpAttr.qp_access_flags = static_cast<ibv_access_flags>(
+      IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ |
+      IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_ATOMIC);
+  initQpAttr.pkey_index = 0;
+  initQpAttr.port_num = kPortNum;
+
+  auto initResult = vqp_->modifyVirtualQp(
+      &initQpAttr,
+      IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_ACCESS_FLAGS);
+  if (!initResult) {
+    throw std::runtime_error(
+        "Failed to transition QP to INIT: " + initResult.error().errStr);
+  }
+
+  // 6. Create staging buffer (CPU or GPU depending on config)
+  stagingBuf_.emplace(
+      config_.stagingBufSize, cudaDev_, *pd_, config_.stagingMode);
+
+  // CUDA stream is created lazily by ensureCudaStream() on first use in
+  // send()/recv(). This avoids GPU memory allocation at setup time, which
+  // is critical for CPU staging mode where CUDA may not be needed at all.
 }
 
-void StagedRdmaTransportBase::connectQp(const std::string& /*peerConnInfo*/) {
-  throw std::runtime_error("connectQp() not yet implemented");
+void StagedRdmaTransportBase::ensureCudaStream() {
+  if (!stream_) {
+    CUDA_CHECK(cudaSetDevice(cudaDev_));
+    CUDA_CHECK(cudaStreamCreateWithFlags(&stream_, cudaStreamNonBlocking));
+  }
+}
+
+void StagedRdmaTransportBase::connectQp(const std::string& peerConnInfo) {
+  auto peer = deserializeConnectionInfo(peerConnInfo);
+
+  // Store peer's staging info for use in send/recv
+  peerStaging_ = std::move(peer.staging);
+
+  // Transition QP: INIT → RTR
+  ibv_qp_attr rtrAttr = {};
+  rtrAttr.qp_state = IBV_QPS_RTR;
+  rtrAttr.path_mtu = peer.mtu;
+  rtrAttr.dest_qp_num = 0; // overridden per-QP by business card
+  rtrAttr.rq_psn = 0;
+  rtrAttr.max_dest_rd_atomic = kMaxRdAtomic;
+  rtrAttr.min_rnr_timer = kMinRnrTimer;
+  rtrAttr.ah_attr.is_global = 1;
+  rtrAttr.ah_attr.grh.dgid.global.subnet_prefix = peer.subnetPrefix;
+  rtrAttr.ah_attr.grh.dgid.global.interface_id = peer.interfaceId;
+  rtrAttr.ah_attr.grh.flow_label = 0;
+  rtrAttr.ah_attr.grh.sgid_index = kGidIndex;
+  rtrAttr.ah_attr.grh.hop_limit = kHopLimit;
+  rtrAttr.ah_attr.grh.traffic_class = 0;
+  rtrAttr.ah_attr.sl = 0;
+  rtrAttr.ah_attr.src_path_bits = 0;
+  rtrAttr.ah_attr.port_num = peer.port;
+
+  auto rtrResult = vqp_->modifyVirtualQp(
+      &rtrAttr,
+      IBV_QP_STATE | IBV_QP_AV | IBV_QP_PATH_MTU | IBV_QP_DEST_QPN |
+          IBV_QP_RQ_PSN | IBV_QP_MAX_DEST_RD_ATOMIC | IBV_QP_MIN_RNR_TIMER,
+      peer.busCard);
+  if (!rtrResult) {
+    throw std::runtime_error(
+        "Failed to transition QP to RTR: " + rtrResult.error().errStr);
+  }
+
+  // Transition QP: RTR → RTS
+  ibv_qp_attr rtsAttr = {};
+  rtsAttr.qp_state = IBV_QPS_RTS;
+  rtsAttr.timeout = kTimeout;
+  rtsAttr.retry_cnt = kRetryCnt;
+  rtsAttr.rnr_retry = kRnrRetryCnt;
+  rtsAttr.sq_psn = 0;
+  rtsAttr.max_rd_atomic = kMaxRdAtomic;
+
+  auto rtsResult = vqp_->modifyVirtualQp(
+      &rtsAttr,
+      IBV_QP_STATE | IBV_QP_TIMEOUT | IBV_QP_RETRY_CNT | IBV_QP_RNR_RETRY |
+          IBV_QP_SQ_PSN | IBV_QP_MAX_QP_RD_ATOMIC);
+  if (!rtsResult) {
+    throw std::runtime_error(
+        "Failed to transition QP to RTS: " + rtsResult.error().errStr);
+  }
 }
 
 std::string StagedRdmaTransportBase::serializeConnInfo(
-    const StagingRendezvousInfo& /*localStaging*/) {
-  throw std::runtime_error("serializeConnInfo() not yet implemented");
+    const StagingRendezvousInfo& localStaging) {
+  auto busCard = vqp_->getVirtualQpBusinessCard();
+
+  auto maybeGid = device_->queryGid(kPortNum, kGidIndex);
+  if (!maybeGid) {
+    throw std::runtime_error("Failed to query GID: " + maybeGid.error().errStr);
+  }
+  auto& gid = *maybeGid;
+
+  auto maybeMtu = device_->queryPort(kPortNum);
+  if (!maybeMtu) {
+    throw std::runtime_error(
+        "Failed to query port: " + maybeMtu.error().errStr);
+  }
+
+  return serializeConnectionInfo(
+      busCard,
+      gid.global.subnet_prefix,
+      gid.global.interface_id,
+      kPortNum,
+      maybeMtu->active_mtu,
+      localStaging);
 }
 
 // --- StagedRdmaServerTransport ---
@@ -165,35 +496,351 @@ std::string StagedRdmaTransportBase::serializeConnInfo(
 StagedRdmaServerTransport::~StagedRdmaServerTransport() = default;
 
 std::string StagedRdmaServerTransport::setupLocalTransport() {
-  throw std::runtime_error("setupLocalTransport() not yet implemented");
+  initIbResources();
+
+  // Allocate recvReady flag (CPU-pinned, cache-line aligned).
+  // Pre-initialized to kRecvReadyValue so the first send() proceeds
+  // immediately without waiting for a client signal.
+  readyToSendFlag_.reset(new (std::align_val_t{64})
+                             std::atomic<uint64_t>{kRecvReadyValue});
+
+  // Register recvReady flag for RDMA access (client writes to it)
+  auto maybeFlagMr = pd_->regMr(
+      readyToSendFlag_.get(),
+      sizeof(std::atomic<uint64_t>),
+      static_cast<ibv_access_flags>(
+          IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE));
+  if (!maybeFlagMr) {
+    throw std::runtime_error(
+        "Failed to register recvReady flag MR: " + maybeFlagMr.error().errStr);
+  }
+  recvReadyServerMr_.emplace(std::move(*maybeFlagMr));
+
+  // Build staging info with recvReady for the peer
+  StagingRendezvousInfo localStaging;
+  localStaging.stagingBuf = {
+      .addr = reinterpret_cast<uintptr_t>(stagingBuf_->data()),
+      .rkey = stagingBuf_->rkey(),
+      .size = stagingBuf_->size(),
+  };
+  localStaging.recvReady = StagingRendezvousInfo::BufferInfo{
+      .addr = reinterpret_cast<uintptr_t>(readyToSendFlag_.get()),
+      .rkey = recvReadyServerMr_->mr()->rkey,
+      .size = sizeof(uint64_t),
+  };
+
+  return serializeConnInfo(localStaging);
 }
 
 void StagedRdmaServerTransport::connectRemoteTransport(
-    const std::string& /*peerConnInfo*/) {
-  throw std::runtime_error("connectRemoteTransport() not yet implemented");
+    const std::string& peerConnInfo) {
+  connectQp(peerConnInfo);
 }
 
 folly::SemiFuture<commResult_t> StagedRdmaServerTransport::send(
-    const ScatterGatherDescriptor& /*src*/) {
-  throw std::runtime_error("send() not yet implemented");
+    const ScatterGatherDescriptor& src) {
+  CHECK_THROW(evb_, std::runtime_error);
+
+  size_t totalBytes = src.totalBytes();
+  size_t numChunks =
+      (totalBytes + config_.stagingBufSize - 1) / config_.stagingBufSize;
+
+  auto [promise, sf] = folly::makePromiseContract<commResult_t>();
+  evb_->runInEventBaseThread(
+      [this, src, numChunks, totalBytes, p = std::move(promise)]() mutable {
+        try {
+          ensureCudaStream();
+          int32_t deviceId = getDeviceId();
+          auto deadline =
+              std::chrono::steady_clock::now() + config_.chunkTimeout;
+
+          // SGCursor for scatter/gather — tracks position across entries
+          size_t sgEntryIdx = 0;
+          size_t sgEntryOffset = 0;
+
+          for (size_t chunk = 0; chunk < numChunks; chunk++) {
+            // 1. Wait for client recvReady signal
+            while (readyToSendFlag_->load(std::memory_order_acquire) == 0) {
+              if (std::chrono::steady_clock::now() >= deadline) {
+                p.setValue(commTimeout);
+                return;
+              }
+            }
+            readyToSendFlag_->store(0, std::memory_order_release);
+
+            // 2. D2D copy src→staging
+            size_t offset = chunk * config_.stagingBufSize;
+            size_t chunkSize =
+                std::min(config_.stagingBufSize, totalBytes - offset);
+
+            if (src.entries.size() == 1) {
+              // Contiguous path
+              CUDA_CHECK(cudaMemcpyAsync(
+                  stagingBuf_->data(),
+                  static_cast<const uint8_t*>(src.entries[0].ptr) + offset,
+                  chunkSize,
+                  cudaMemcpyDefault,
+                  stream_));
+            } else {
+              // Gather path: copy from non-contiguous GPU regions into staging
+              size_t stagingOffset = 0;
+              while (stagingOffset < chunkSize) {
+                auto& entry = src.entries[sgEntryIdx];
+                size_t remainInEntry = entry.size - sgEntryOffset;
+                size_t remainInChunk = chunkSize - stagingOffset;
+                size_t copySize = std::min(remainInEntry, remainInChunk);
+                CUDA_CHECK(cudaMemcpyAsync(
+                    static_cast<uint8_t*>(stagingBuf_->data()) + stagingOffset,
+                    static_cast<const uint8_t*>(entry.ptr) + sgEntryOffset,
+                    copySize,
+                    cudaMemcpyDefault,
+                    stream_));
+                stagingOffset += copySize;
+                sgEntryOffset += copySize;
+                if (sgEntryOffset >= entry.size) {
+                  sgEntryIdx++;
+                  sgEntryOffset = 0;
+                }
+              }
+            }
+            CUDA_CHECK(cudaStreamSynchronize(stream_));
+
+            // 3. Post RDMA_WRITE_WITH_IMM
+            ibverbx::IbvVirtualSendWr sendWr = {};
+            sendWr.wrId = chunk;
+            sendWr.localAddr = stagingBuf_->data();
+            sendWr.length = static_cast<uint32_t>(chunkSize);
+            sendWr.remoteAddr = peerStaging_.stagingBuf.addr;
+            sendWr.opcode = IBV_WR_RDMA_WRITE_WITH_IMM;
+            sendWr.sendFlags = IBV_SEND_SIGNALED;
+            sendWr.immData = static_cast<uint32_t>(chunk);
+            sendWr.deviceKeys[deviceId] = ibverbx::MemoryRegionKeys{
+                stagingBuf_->lkey(), peerStaging_.stagingBuf.rkey};
+
+            auto postResult = vqp_->postSend(sendWr);
+            if (!postResult) {
+              p.setValue(commInternalError);
+              return;
+            }
+
+            // Drain send completion to free QP slot
+            while (true) {
+              auto maybeWcs = vcq_->pollCq();
+              if (!maybeWcs) {
+                p.setValue(commInternalError);
+                return;
+              }
+              for (auto& wc : *maybeWcs) {
+                if (wc.status != IBV_WC_SUCCESS) {
+                  p.setValue(commInternalError);
+                  return;
+                }
+              }
+              if (!maybeWcs->empty()) {
+                break;
+              }
+            }
+
+            deadline = std::chrono::steady_clock::now() + config_.chunkTimeout;
+          }
+          p.setValue(commSuccess);
+        } catch (const std::exception& e) {
+          XLOGF(ERR, "StagedRdmaServerTransport::send() failed: {}", e.what());
+          p.setValue(commInternalError);
+        }
+      });
+  return std::move(sf); // NOLINT(performance-move-const-arg)
 }
 
 // --- StagedRdmaClientTransport ---
 
 StagedRdmaClientTransport::~StagedRdmaClientTransport() = default;
 
+void StagedRdmaClientTransport::cancelPendingRecv() {
+  recvCancelled_.store(true, std::memory_order_release);
+}
+
 std::string StagedRdmaClientTransport::setupLocalTransport() {
-  throw std::runtime_error("setupLocalTransport() not yet implemented");
+  initIbResources();
+
+  // Build staging info without recvReady (only server has it)
+  StagingRendezvousInfo localStaging;
+  localStaging.stagingBuf = {
+      .addr = reinterpret_cast<uintptr_t>(stagingBuf_->data()),
+      .rkey = stagingBuf_->rkey(),
+      .size = stagingBuf_->size(),
+  };
+
+  return serializeConnInfo(localStaging);
 }
 
 void StagedRdmaClientTransport::connectRemoteTransport(
-    const std::string& /*peerConnInfo*/) {
-  throw std::runtime_error("connectRemoteTransport() not yet implemented");
+    const std::string& peerConnInfo) {
+  connectQp(peerConnInfo);
+
+  // Register source MR for &kRecvReadyValue — used to RDMA_WRITE the
+  // recvReady acknowledgement back to the server's readyToSendFlag_.
+  auto maybeSrcMr = pd_->regMr(
+      const_cast<uint64_t*>(&kRecvReadyValue),
+      sizeof(uint64_t),
+      static_cast<ibv_access_flags>(IBV_ACCESS_LOCAL_WRITE));
+  if (!maybeSrcMr) {
+    throw std::runtime_error(
+        "Failed to register recvReady client MR: " + maybeSrcMr.error().errStr);
+  }
+  recvReadyClientMr_.emplace(std::move(*maybeSrcMr));
+
+  // Post initial dummy recv to trigger initializeDqplbReceiver on multi-QP
+  int32_t deviceId = getDeviceId();
+  ibverbx::IbvVirtualRecvWr recvWr = {};
+  recvWr.wrId = 0;
+  recvWr.localAddr = nullptr;
+  recvWr.length = 0;
+  recvWr.deviceKeys[deviceId] = ibverbx::MemoryRegionKeys{0, 0};
+
+  auto postResult = vqp_->postRecv(recvWr);
+  if (!postResult) {
+    throw std::runtime_error(
+        "Failed to post initial recv: " + postResult.error().errStr);
+  }
 }
 
 folly::SemiFuture<commResult_t> StagedRdmaClientTransport::recv(
-    const ScatterGatherDescriptor& /*dst*/) {
-  throw std::runtime_error("recv() not yet implemented");
+    const ScatterGatherDescriptor& dst) {
+  CHECK_THROW(evb_, std::runtime_error);
+  recvCancelled_.store(false, std::memory_order_release);
+
+  size_t totalBytes = dst.totalBytes();
+  // Use peer's staging buffer size (server's) to compute chunk count
+  size_t numChunks = (totalBytes + peerStaging_.stagingBuf.size - 1) /
+      peerStaging_.stagingBuf.size;
+
+  auto [promise, sf] = folly::makePromiseContract<commResult_t>();
+  evb_->runInEventBaseThread(
+      [this, dst, numChunks, totalBytes, p = std::move(promise)]() mutable {
+        try {
+          ensureCudaStream();
+          int32_t deviceId = getDeviceId();
+          auto deadline =
+              std::chrono::steady_clock::now() + config_.chunkTimeout;
+
+          // SGCursor for scatter/gather — tracks position across entries
+          size_t sgEntryIdx = 0;
+          size_t sgEntryOffset = 0;
+
+          for (size_t chunk = 0; chunk < numChunks; chunk++) {
+            // 1. Poll CQ for RECV_RDMA_WITH_IMM (data arrived)
+            bool readyToRecv = false;
+            while (!readyToRecv) {
+              auto maybeWcs = vcq_->pollCq();
+              if (!maybeWcs) {
+                p.setValue(commInternalError);
+                return;
+              }
+              for (auto& wc : *maybeWcs) {
+                if (wc.status != IBV_WC_SUCCESS) {
+                  p.setValue(commInternalError);
+                  return;
+                }
+                if (wc.opcode == IBV_WC_RECV_RDMA_WITH_IMM) {
+                  readyToRecv = true;
+                  break;
+                }
+              }
+              if (!readyToRecv &&
+                  recvCancelled_.load(std::memory_order_acquire)) {
+                p.setValue(commUserAbort);
+                return;
+              }
+              if (!readyToRecv &&
+                  std::chrono::steady_clock::now() >= deadline) {
+                p.setValue(commTimeout);
+                return;
+              }
+            }
+
+            // 2. Replenish recv WR for next chunk
+            {
+              ibverbx::IbvVirtualRecvWr recvWr = {};
+              recvWr.wrId = chunk + 1;
+              recvWr.localAddr = nullptr;
+              recvWr.length = 0;
+              recvWr.deviceKeys[deviceId] = ibverbx::MemoryRegionKeys{0, 0};
+
+              auto postResult = vqp_->postRecv(recvWr);
+              if (!postResult) {
+                p.setValue(commInternalError);
+                return;
+              }
+            }
+
+            // 3. D2D copy staging→dst
+            size_t offset = chunk * peerStaging_.stagingBuf.size;
+            size_t chunkSize =
+                std::min(peerStaging_.stagingBuf.size, totalBytes - offset);
+
+            if (dst.entries.size() == 1) {
+              // Contiguous path
+              CUDA_CHECK(cudaMemcpyAsync(
+                  static_cast<uint8_t*>(dst.entries[0].ptr) + offset,
+                  stagingBuf_->data(),
+                  chunkSize,
+                  cudaMemcpyDefault,
+                  stream_));
+            } else {
+              // Scatter path: copy from staging to non-contiguous GPU regions
+              size_t stagingOffset = 0;
+              while (stagingOffset < chunkSize) {
+                auto& entry = dst.entries[sgEntryIdx];
+                size_t remainInEntry = entry.size - sgEntryOffset;
+                size_t remainInChunk = chunkSize - stagingOffset;
+                size_t copySize = std::min(remainInEntry, remainInChunk);
+                CUDA_CHECK(cudaMemcpyAsync(
+                    static_cast<uint8_t*>(entry.ptr) + sgEntryOffset,
+                    static_cast<const uint8_t*>(stagingBuf_->data()) +
+                        stagingOffset,
+                    copySize,
+                    cudaMemcpyDefault,
+                    stream_));
+                stagingOffset += copySize;
+                sgEntryOffset += copySize;
+                if (sgEntryOffset >= entry.size) {
+                  sgEntryIdx++;
+                  sgEntryOffset = 0;
+                }
+              }
+            }
+            CUDA_CHECK(cudaStreamSynchronize(stream_));
+
+            // 4. Signal server: staging buffer consumed (always, including last
+            // chunk, to ensure next transfer can start safely)
+            {
+              ibverbx::IbvVirtualSendWr flagWr = {};
+              flagWr.wrId = numChunks + chunk;
+              flagWr.localAddr = const_cast<uint64_t*>(&kRecvReadyValue);
+              flagWr.length = sizeof(uint64_t);
+              flagWr.remoteAddr = peerStaging_.recvReady->addr;
+              flagWr.opcode = IBV_WR_RDMA_WRITE;
+              flagWr.sendFlags = IBV_SEND_SIGNALED;
+              flagWr.deviceKeys[deviceId] = ibverbx::MemoryRegionKeys{
+                  recvReadyClientMr_->mr()->lkey, peerStaging_.recvReady->rkey};
+
+              auto postResult = vqp_->postSend(flagWr);
+              if (!postResult) {
+                p.setValue(commInternalError);
+                return;
+              }
+            }
+
+            deadline = std::chrono::steady_clock::now() + config_.chunkTimeout;
+          }
+          p.setValue(commSuccess);
+        } catch (const std::exception& e) {
+          XLOGF(ERR, "StagedRdmaClientTransport::recv() failed: {}", e.what());
+          p.setValue(commInternalError);
+        }
+      });
+  return std::move(sf); // NOLINT(performance-move-const-arg)
 }
 
 } // namespace torch::comms

--- a/comms/torchcomms/transport/StagedRdmaTransport.h
+++ b/comms/torchcomms/transport/StagedRdmaTransport.h
@@ -26,9 +26,15 @@ namespace torch::comms {
 
 // Configuration for staged RDMA transfers.
 struct StagedTransferConfig {
-  // Size of the GPU staging buffer on each side. Each chunk transfer moves
+  // Where to allocate the staging buffer.
+  // CPU: posix_memalign + ibv_reg_mr (no GPU memory, default)
+  // GPU: cudaMalloc + dmabuf + regDmabufMr (GPUDirect RDMA)
+  enum class StagingMode { CPU, GPU };
+  StagingMode stagingMode = StagingMode::CPU;
+
+  // Size of the staging buffer on each side. Each chunk transfer moves
   // at most this many bytes via a single RDMA_WRITE_WITH_IMM.
-  size_t stagingBufSize = 64 * 1024 * 1024; // 64 MB
+  size_t stagingBufSize = 4 * 1024 * 1024; // 4 MB
 
   // Timeout for waiting on the recvReady flag or CQ poll between chunks.
   std::chrono::milliseconds chunkTimeout{30000};
@@ -52,14 +58,17 @@ struct StagingRendezvousInfo {
   std::optional<BufferInfo> recvReady;
 };
 
-// RAII wrapper for a GPU staging buffer registered for GPUDirect RDMA via
-// dmabuf. Allocates GPU memory with cudaMalloc, exports a dmabuf fd, and
-// registers it with the IB protection domain for zero-copy RDMA access.
-//
-// Destruction order: deregister MR → close dmabuf fd → cudaFree.
+// RAII wrapper for a staging buffer registered for RDMA.
+// CPU mode: posix_memalign + ibv_reg_mr (no GPU memory).
+// GPU mode: cudaMalloc + dmabuf + regDmabufMr (GPUDirect RDMA).
 class StagedBuffer {
  public:
-  StagedBuffer(size_t size, int cudaDev, ibverbx::IbvPd& pd);
+  StagedBuffer(
+      size_t size,
+      int cudaDev,
+      ibverbx::IbvPd& pd,
+      StagedTransferConfig::StagingMode mode =
+          StagedTransferConfig::StagingMode::CPU);
   ~StagedBuffer();
 
   // Move-only
@@ -77,6 +86,9 @@ class StagedBuffer {
   int cudaDev() const {
     return cudaDev_;
   }
+  bool isGpu() const {
+    return isGpu_;
+  }
   uint32_t lkey() const {
     return mr_->mr()->lkey;
   }
@@ -88,13 +100,14 @@ class StagedBuffer {
   void* buf_{nullptr};
   size_t size_{0};
   int cudaDev_{-1};
-  int dmabufFd_{-1};
+  bool isGpu_{false};
+  int dmabufFd_{-1}; // GPU mode only
   std::optional<ibverbx::IbvMr> mr_;
 };
 
-// Describes GPU memory regions for staged RDMA transfers. A single entry
+// Describes memory regions for staged RDMA transfers. A single entry
 // represents a contiguous buffer; multiple entries describe non-contiguous
-// regions for scatter/gather transfers.
+// regions for scatter/gather transfers. Pointers may be GPU or CPU memory.
 struct ScatterGatherDescriptor {
   struct Entry {
     void* ptr;
@@ -172,8 +185,12 @@ class StagedRdmaTransportBase {
 
   // Protected helpers — called explicitly by subclasses, no virtual dispatch.
 
-  // Initialize IB resources: device, PD, CQ, VirtualQP, staging buffer,
-  // CUDA stream. Must be called before connectQp().
+  // Lazily create CUDA stream on first use. Called by send()/recv() when
+  // GPU memory is involved. No-op if stream already exists.
+  void ensureCudaStream();
+
+  // Initialize IB resources: device, PD, CQ, VirtualQP, staging buffer.
+  // Must be called before connectQp().
   void initIbResources();
 
   // Connect to the peer using their serialized connection info. Deserializes
@@ -199,13 +216,13 @@ class StagedRdmaServerTransport : public StagedRdmaTransportBase {
   // Connect to the client using their serialized connection info.
   void connectRemoteTransport(const std::string& peerConnInfo);
 
-  // Transfer GPU memory regions described by src to the client's staging
-  // buffer, pipelining in stagingBufSize chunks. All entry pointers must be
-  // on cudaDev_. Requires evb_ (CHECK_THROW if nullptr).
+  // Transfer memory regions described by src to the client's staging
+  // buffer, pipelining in stagingBufSize chunks. Entry pointers may be
+  // GPU (on cudaDev_) or CPU memory. Requires evb_ (CHECK_THROW if nullptr).
   folly::SemiFuture<commResult_t> send(const ScatterGatherDescriptor& src);
 
  private:
-  // recvReady flag — CPU-pinned, cache-line aligned, RDMA-registered.
+  // readyToSend flag — CPU-pinned, cache-line aligned, RDMA-registered.
   // The client writes kRecvReadyValue here via RDMA_WRITE to signal that it
   // has finished copying data out of its staging buffer.
   // Pre-initialized to kRecvReadyValue so the first send() proceeds
@@ -215,7 +232,7 @@ class StagedRdmaServerTransport : public StagedRdmaTransportBase {
       ::operator delete(p, std::align_val_t{64});
     }
   };
-  std::unique_ptr<std::atomic<uint64_t>, AlignedDelete> recvReadyFlag_;
+  std::unique_ptr<std::atomic<uint64_t>, AlignedDelete> readyToSendFlag_;
   std::optional<ibverbx::IbvMr> recvReadyServerMr_;
 };
 
@@ -234,18 +251,27 @@ class StagedRdmaClientTransport : public StagedRdmaTransportBase {
   // recvReady source MR and posts initial recv WR.
   void connectRemoteTransport(const std::string& peerConnInfo);
 
-  // Receive into GPU memory regions described by dst from the server's
-  // staging buffer, pipelining in stagingBufSize chunks. All entry pointers
-  // must be on cudaDev_ (CPU buffers are not supported). numChunks is
-  // computed internally from totalBytes and the server's staging buffer
-  // size (exchanged during connectRemoteTransport()).
+  // Receive into memory regions described by dst from the server's
+  // staging buffer, pipelining in stagingBufSize chunks. Entry pointers
+  // may be GPU (on cudaDev_) or CPU memory. numChunks is computed
+  // internally from totalBytes and the server's staging buffer size
+  // (exchanged during connectRemoteTransport()).
   // Requires evb_ (CHECK_THROW if nullptr).
   folly::SemiFuture<commResult_t> recv(const ScatterGatherDescriptor& dst);
+
+  // Cancel a pending recv operation. The recv lambda will exit its CQ poll
+  // loop and return commUserAbort. Call this when the corresponding RPC
+  // fails so the caller can wait for the recv future to complete without
+  // blocking for the full chunkTimeout.
+  void cancelPendingRecv();
 
  private:
   // MR for &kRecvReadyValue — used as source for RDMA_WRITE to server's
   // recvReadyFlag_.
   std::optional<ibverbx::IbvMr> recvReadyClientMr_;
+
+  // Set by cancelPendingRecv() to interrupt the recv CQ poll loop.
+  std::atomic<bool> recvCancelled_{false};
 };
 
 } // namespace torch::comms


### PR DESCRIPTION
Summary:

Add a staged RDMA transport for chunked GPU-to-GPU tensor transfer over InfiniBand, eliminating O(model_size) per-tensor ibv_reg_mr registration overhead.

Architecture:
  - Server (StagedRdmaServerTransport): copies source GPU tensor into a fixed staging buffer via cudaMemcpyAsync, then RDMA_WRITE_WITH_IMM to the client's staging buffer. Flow-controlled by a client-written readyToSendFlag between chunks.
  - Client (StagedRdmaClientTransport): polls CQ for incoming RDMA writes, copies from staging buffer to destination via cudaMemcpyAsync, signals server via RDMA_WRITE of recvReady flag.
  - Base class (StagedRdmaTransportBase): IB resource management (device, PD, CQ, VirtualQP with DQPLB), QP state machine (INIT→RTR→RTS), connection info serialization/deserialization via JSON.

Staging buffer modes:
  - CPU (default): posix_memalign + ibv_reg_mr. No GPU memory overhead. Data path: GPU→cudaMemcpy→CPU staging→RDMA→CPU staging→cudaMemcpy→GPU.
  - GPU: cudaMalloc + dmabuf + regDmabufMr for GPUDirect RDMA. Data path: GPU→D2D copy→GPU staging→RDMA→GPU staging→D2D copy→GPU.

Key design decisions:
  - 4MB staging buffer per transport (configurable via StagedTransferConfig::stagingBufSize). Large tensors are transferred in multiple chunks automatically.
  - One-sided flow control: server busy-waits on readyToSendFlag (CPU-pinned, cache-line aligned), client writes it back via RDMA_WRITE after consuming each chunk.
  - send()/recv() return SemiFuture<commResult_t> and run on a caller-provided EventBase thread.
  - cancelPendingRecv() for safe teardown when the corresponding RPC fails mid-transfer.
  - QP config matches NCCL production defaults (RoCEv2, GID index 3, timeout 20, retry 7).

Reviewed By: cenzhaometa

Differential Revision: D99749004


