### PR TITLE
Add RDMA benchmark scripts

### DIFF
--- a/comms/uniflow/MultiTransport.cpp
+++ b/comms/uniflow/MultiTransport.cpp
@@ -15,67 +15,6 @@ bool isCpu(int deviceId) {
   return deviceId == -1;
 }
 
-/// Return names of all NICs matching the filter.
-std::vector<std::string> selectCpuNics(
-    const Topology& topo,
-    const NicFilter& filter) {
-  int nicCount = static_cast<int>(topo.nicCount());
-  std::vector<std::string> nics;
-  nics.reserve(nicCount);
-  PathType bestType = PathType::DIS;
-  uint32_t maxBw = 0;
-  for (int nic = 0; nic < nicCount; ++nic) {
-    if (!topo.filterNic(nic, filter)) {
-      continue;
-    }
-    const auto& nicNode = topo.getNicNode(nic);
-    const auto& numaNode =
-        topo.getCpuNode(std::get<TopoNode::NicData>(nicNode.data).numaNode);
-    const auto& path =
-        topo.getPath(numaNode.id, nicNode.id, {.allowC2C = true});
-    if (path.type < bestType || (path.type == bestType && path.bw > maxBw)) {
-      nics.clear();
-      nics.push_back(nicNode.name);
-      bestType = path.type;
-      maxBw = path.bw;
-    } else if (path.type == bestType && path.bw == maxBw) {
-      nics.push_back(nicNode.name);
-    }
-  }
-  return nics;
-}
-
-/// Return names of filtered NICs closest to the given GPU.
-std::vector<std::string>
-selectGpuNics(const Topology& topo, int deviceId, const NicFilter& filter) {
-  int nicCount = static_cast<int>(topo.nicCount());
-  const auto& gpuNode = topo.getGpuNode(deviceId);
-
-  std::vector<std::string> nics;
-  nics.reserve(nicCount);
-  PathType bestType = PathType::DIS;
-  uint32_t maxBw = 0;
-  for (int i = 0; i < nicCount; ++i) {
-    if (!topo.filterNic(i, filter)) {
-      continue;
-    }
-    const auto& nicNode = topo.getNicNode(i);
-    // Enable C2C paths so GPU→CPU bandwidth reflects the real interconnect
-    // (e.g. 447 GB/s C2C on GB200) rather than the PCIe stub. Without this,
-    // the GPU's low PCIe bandwidth masks NIC speed differences.
-    const auto& path = topo.getPath(gpuNode.id, nicNode.id, {.allowC2C = true});
-    if (path.type < bestType || (path.type == bestType && path.bw > maxBw)) {
-      nics.clear();
-      nics.push_back(nicNode.name);
-      bestType = path.type;
-      maxBw = path.bw;
-    } else if (path.type == bestType && path.bw == maxBw) {
-      nics.push_back(nicNode.name);
-    }
-  }
-  return nics;
-}
-
 } // namespace
 
 // ============================================================================
@@ -84,8 +23,8 @@ selectGpuNics(const Topology& topo, int deviceId, const NicFilter& filter) {
 
 std::vector<std::string> MultiTransportFactory::selectNics() {
   auto& topo = Topology::get();
-  return isCpu(deviceId_) ? selectCpuNics(topo, nicFilter_)
-                          : selectGpuNics(topo, deviceId_, nicFilter_);
+  return isCpu(deviceId_) ? topo.selectCpuNics(nicFilter_)
+                          : topo.selectGpuNics(deviceId_, nicFilter_);
 }
 
 Status MultiTransport::validateRequests(

--- a/comms/uniflow/Segment.h
+++ b/comms/uniflow/Segment.h
@@ -201,6 +201,15 @@ class RegisteredSegment : public SegmentBase<RegisteredSegment> {
 
   Result<std::vector<uint8_t>> exportId() const;
 
+  /// Construct from a Segment and a single backend registration handle.
+  static RegisteredSegment fromHandle(
+      Segment& segment,
+      std::unique_ptr<RegistrationHandle> handle) {
+    RegisteredSegment reg(segment);
+    reg.handles_.push_back(std::move(handle));
+    return reg;
+  }
+
   friend class SegmentTest;
   friend class MultiTransportFactory;
 
@@ -248,6 +257,16 @@ class RemoteRegisteredSegment : public SegmentBase<RemoteRegisteredSegment> {
     size_t nvlinkOffset_;
   };
 
+  /// Construct from a remote buffer address and a single backend handle.
+  static RemoteRegisteredSegment fromHandle(
+      void* buf,
+      size_t len,
+      std::unique_ptr<RemoteRegistrationHandle> handle) {
+    RemoteRegisteredSegment remote(buf, len);
+    remote.handles_.push_back(std::move(handle));
+    return remote;
+  }
+
   friend class SegmentTest;
   friend class MultiTransportFactory;
   friend class MultiTransportFactoryTest;
@@ -260,9 +279,6 @@ class RemoteRegisteredSegment : public SegmentBase<RemoteRegisteredSegment> {
           remoteHandleT(TransportType, size_t, std::span<const uint8_t>)>&
           getHandle);
 
-  friend class SegmentTest;
-
- private:
   explicit RemoteRegisteredSegment(Segment& segment)
       : SegmentBase(
             segment.mutable_data(),

--- a/comms/uniflow/benchmarks/BenchmarkResult.h
+++ b/comms/uniflow/benchmarks/BenchmarkResult.h
@@ -15,6 +15,7 @@ struct BenchmarkResult {
   size_t messageSize{0};
   int iterations{0};
   int batchSize{0};
+  int txDepth{0};
   size_t chunkSize{0};
   double bandwidthGBs{0};
   Stats latency{}; // in microseconds

--- a/comms/uniflow/benchmarks/BenchmarkRunner.h
+++ b/comms/uniflow/benchmarks/BenchmarkRunner.h
@@ -19,6 +19,8 @@ struct BenchmarkConfig {
   int warmupIterations{10};
   int loopCount{1};
   int batchSize{1};
+  int txDepth{1};
+  int numNics{0}; // 0 = use all topology-selected NICs
   size_t chunkSize{512 * 1024};
   int cudaDevice{-1};
   bool bidirectional{false};

--- a/comms/uniflow/benchmarks/Reporter.cpp
+++ b/comms/uniflow/benchmarks/Reporter.cpp
@@ -117,17 +117,18 @@ void Reporter::printCSV(
     const std::vector<BenchmarkResult>& results,
     std::ostream& os) {
   os << "benchmark,transport,direction,size_bytes,iterations,"
-        "batch_size,chunk_size,"
+        "batch_size,tx_depth,chunk_size,"
         "bw_gbps,lat_avg_us,lat_p50_us,lat_p99_us,"
         "lat_min_us,lat_max_us,msg_rate_mops,num_streams\n";
 
   for (const auto& r : results) {
     os << r.benchmarkName << "," << r.transport << "," << r.direction << ","
        << r.messageSize << "," << r.iterations << "," << r.batchSize << ","
-       << r.chunkSize << "," << std::fixed << std::setprecision(4)
-       << r.bandwidthGBs << "," << r.latency.avg << "," << r.latency.p50 << ","
-       << r.latency.p99 << "," << r.latency.min << "," << r.latency.max << ","
-       << r.messageRateMops << "," << r.numStreams << "\n";
+       << r.txDepth << "," << r.chunkSize << "," << std::fixed
+       << std::setprecision(4) << r.bandwidthGBs << "," << r.latency.avg << ","
+       << r.latency.p50 << "," << r.latency.p99 << "," << r.latency.min << ","
+       << r.latency.max << "," << r.messageRateMops << "," << r.numStreams
+       << "\n";
   }
 }
 

--- a/comms/uniflow/benchmarks/bench/NVLinkBandwidthBenchmark.cpp
+++ b/comms/uniflow/benchmarks/bench/NVLinkBandwidthBenchmark.cpp
@@ -9,7 +9,6 @@
 
 #include "comms/uniflow/Segment.h"
 #include "comms/uniflow/benchmarks/Rendezvous.h"
-#include "comms/uniflow/benchmarks/SegmentHelper.h"
 #include "comms/uniflow/benchmarks/Stats.h"
 #include "comms/uniflow/drivers/cuda/CudaApi.h"
 #include "comms/uniflow/drivers/cuda/CudaDriverApi.h"
@@ -278,7 +277,7 @@ std::unique_ptr<TransportSession> setupTransport(
   }
 
   session->localReg = std::make_unique<RegisteredSegment>(
-      SegmentTest::makeRegistered(srcSeg, std::move(srcRegResult.value())));
+      RegisteredSegment::fromHandle(srcSeg, std::move(srcRegResult.value())));
 
   auto* nvlinkRemote = dynamic_cast<NVLinkRemoteRegistrationHandle*>(
       remoteHandleResult.value().get());
@@ -287,8 +286,8 @@ std::unique_ptr<TransportSession> setupTransport(
     return nullptr;
   }
 
-  session->remoteReg =
-      std::make_unique<RemoteRegisteredSegment>(SegmentTest::makeRemote(
+  session->remoteReg = std::make_unique<RemoteRegisteredSegment>(
+      RemoteRegisteredSegment::fromHandle(
           nvlinkRemote->mappedPtr(),
           nvlinkRemote->mappedSize(),
           std::move(remoteHandleResult.value())));

--- a/comms/uniflow/benchmarks/bench/RdmaBandwidthBenchmark.cpp
+++ b/comms/uniflow/benchmarks/bench/RdmaBandwidthBenchmark.cpp
@@ -3,6 +3,7 @@
 #include "comms/uniflow/benchmarks/bench/RdmaBandwidthBenchmark.h"
 
 #include <algorithm>
+#include <cassert>
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
@@ -15,12 +16,12 @@
 
 #include "comms/uniflow/Segment.h"
 #include "comms/uniflow/benchmarks/Rendezvous.h"
-#include "comms/uniflow/benchmarks/SegmentHelper.h"
 #include "comms/uniflow/benchmarks/Stats.h"
 #include "comms/uniflow/drivers/cuda/CudaDriverApi.h"
 #include "comms/uniflow/drivers/ibverbs/IbvApi.h"
 #include "comms/uniflow/executor/ScopedEventBaseThread.h"
 #include "comms/uniflow/logging/Logger.h"
+#include "comms/uniflow/transport/Topology.h"
 #include "comms/uniflow/transport/rdma/RdmaTransport.h"
 
 namespace uniflow::benchmark {
@@ -47,8 +48,10 @@ std::vector<std::string> discoverRdmaDevices(
 }
 
 struct BenchmarkBuffers {
-  void* src{nullptr};
-  void* dst{nullptr};
+  // Per-NIC separate allocations to avoid PCIe DMA contention when
+  // multiple NICs read from the same GPU memory region simultaneously.
+  std::vector<void*> srcs;
+  std::vector<void*> dsts;
   bool useGpu{false}; // Controls deallocation path (cudaFree vs std::free).
   MemoryType memType{MemoryType::DRAM};
   int gpuDevice{0};
@@ -59,8 +62,8 @@ struct BenchmarkBuffers {
   }
 
   BenchmarkBuffers(BenchmarkBuffers&& o) noexcept
-      : src(std::exchange(o.src, nullptr)),
-        dst(std::exchange(o.dst, nullptr)),
+      : srcs(std::move(o.srcs)),
+        dsts(std::move(o.dsts)),
         useGpu(o.useGpu),
         memType(o.memType),
         gpuDevice(o.gpuDevice) {}
@@ -71,27 +74,59 @@ struct BenchmarkBuffers {
 
  private:
   void release() noexcept {
-    if (useGpu) {
-      if (src) {
-        cudaFree(src);
+    auto freeOne = [this](void* p) {
+      if (p) {
+        if (useGpu) {
+          cudaFree(p);
+        } else {
+          std::free(p);
+        }
       }
-      if (dst) {
-        cudaFree(dst);
-      }
-    } else {
-      std::free(src);
-      std::free(dst);
+    };
+    for (auto* p : srcs) {
+      freeOne(p);
     }
-    src = dst = nullptr;
+    for (auto* p : dsts) {
+      freeOne(p);
+    }
+    srcs.clear();
+    dsts.clear();
   }
 };
 
 std::optional<BenchmarkBuffers>
-allocateBuffers(size_t maxSize, int cudaDevice, int rank) {
+allocateBuffers(size_t maxSize, int cudaDevice, int rank, int numBuffers) {
   BenchmarkBuffers bufs;
   bufs.useGpu = cudaDevice >= 0;
   bufs.memType = bufs.useGpu ? MemoryType::VRAM : MemoryType::DRAM;
   bufs.gpuDevice = bufs.useGpu ? cudaDevice : 0;
+
+  auto allocOne = [&](void** out, uint8_t fill) -> bool {
+    if (bufs.useGpu) {
+      auto ret = cudaMalloc(out, maxSize);
+      if (ret != cudaSuccess || *out == nullptr) {
+        UNIFLOW_LOG_ERROR("RdmaBandwidthBenchmark: cudaMalloc failed");
+        return false;
+      }
+      ret = cudaMemset(*out, fill, maxSize);
+      if (ret != cudaSuccess) {
+        UNIFLOW_LOG_ERROR(
+            "RdmaBandwidthBenchmark: cudaMemset failed: {}",
+            cudaGetErrorString(ret));
+        cudaFree(*out);
+        *out = nullptr;
+        return false;
+      }
+    } else {
+      *out = std::malloc(maxSize);
+      if (*out == nullptr) {
+        UNIFLOW_LOG_ERROR("RdmaBandwidthBenchmark: malloc failed");
+        return false;
+      }
+      std::memset(*out, fill, maxSize);
+    }
+    return true;
+  };
 
   if (bufs.useGpu) {
     auto cudaRet = cudaSetDevice(bufs.gpuDevice);
@@ -102,54 +137,36 @@ allocateBuffers(size_t maxSize, int cudaDevice, int rank) {
           cudaGetErrorString(cudaRet));
       return std::nullopt;
     }
-    cudaRet = cudaMalloc(&bufs.src, maxSize);
-    if (cudaRet != cudaSuccess || bufs.src == nullptr) {
-      UNIFLOW_LOG_ERROR("RdmaBandwidthBenchmark: cudaMalloc(src) failed");
+  }
+
+  for (int i = 0; i < numBuffers; ++i) {
+    void* src = nullptr;
+    if (!allocOne(&src, 0xAB)) {
       return std::nullopt;
     }
-    cudaRet = cudaMalloc(&bufs.dst, maxSize);
-    if (cudaRet != cudaSuccess || bufs.dst == nullptr) {
-      UNIFLOW_LOG_ERROR("RdmaBandwidthBenchmark: cudaMalloc(dst) failed");
+    bufs.srcs.push_back(src);
+    void* dst = nullptr;
+    if (!allocOne(&dst, 0x00)) {
       return std::nullopt;
     }
-    cudaRet = cudaMemset(bufs.src, 0xAB, maxSize);
-    if (cudaRet != cudaSuccess) {
-      UNIFLOW_LOG_ERROR(
-          "RdmaBandwidthBenchmark: cudaMemset(src) failed: {}",
-          cudaGetErrorString(cudaRet));
-      return std::nullopt;
-    }
-    cudaRet = cudaMemset(bufs.dst, 0, maxSize);
-    if (cudaRet != cudaSuccess) {
-      UNIFLOW_LOG_ERROR(
-          "RdmaBandwidthBenchmark: cudaMemset(dst) failed: {}",
-          cudaGetErrorString(cudaRet));
-      return std::nullopt;
-    }
-    cudaRet = cudaDeviceSynchronize();
+    bufs.dsts.push_back(dst);
+  }
+
+  if (bufs.useGpu) {
+    auto cudaRet = cudaDeviceSynchronize();
     if (cudaRet != cudaSuccess) {
       UNIFLOW_LOG_ERROR(
           "RdmaBandwidthBenchmark: cudaDeviceSynchronize failed: {}",
           cudaGetErrorString(cudaRet));
       return std::nullopt;
     }
-    UNIFLOW_LOG_INFO(
-        "RdmaBandwidthBenchmark: rank {} using GPU {} memory",
-        rank,
-        bufs.gpuDevice);
-  } else {
-    bufs.src = std::malloc(maxSize);
-    bufs.dst = std::malloc(maxSize);
-    if (bufs.src == nullptr || bufs.dst == nullptr) {
-      UNIFLOW_LOG_ERROR("RdmaBandwidthBenchmark: malloc failed");
-      return std::nullopt;
-    }
-    std::memset(bufs.src, 0xAB, maxSize);
-    std::memset(bufs.dst, 0, maxSize);
-    UNIFLOW_LOG_INFO(
-        "RdmaBandwidthBenchmark: rank {} using CPU (DRAM) memory", rank);
   }
 
+  UNIFLOW_LOG_INFO(
+      "RdmaBandwidthBenchmark: rank {} allocated {} buffer pairs ({} memory)",
+      rank,
+      numBuffers,
+      bufs.useGpu ? "GPU" : "CPU");
   return bufs;
 }
 
@@ -161,16 +178,153 @@ struct TransportSession {
   // associated QPs/MRs/CQs).
   std::unique_ptr<RdmaTransportFactory> factory;
   std::unique_ptr<Transport> transport;
-  RegisteredSegment localReg;
-  RemoteRegisteredSegment remoteReg;
-  // The local destination MR must stay alive so the remote side's rkey
-  // remains valid for RDMA writes.  Without this, ibv_dereg_mr fires
-  // when setupTransport returns and the remote gets R_Key violation.
-  std::unique_ptr<RegistrationHandle> localDstReg;
+  std::vector<RegisteredSegment> localRegs;
+  std::vector<RemoteRegisteredSegment> remoteRegs;
+  std::vector<std::unique_ptr<RegistrationHandle>> localDstRegs;
 };
 
+// Wire format for registration payload exchange between ranks.
+// Layout: [uint64_t dstAddr | registration payload bytes]
+struct RegistrationExchange {
+  static std::vector<uint8_t> serialize(
+      uint64_t dstAddr,
+      const std::vector<uint8_t>& regPayload) {
+    std::vector<uint8_t> buf(sizeof(dstAddr) + regPayload.size());
+    std::memcpy(buf.data(), &dstAddr, sizeof(dstAddr));
+    std::memcpy(
+        buf.data() + sizeof(dstAddr), regPayload.data(), regPayload.size());
+    return buf;
+  }
+
+  static std::optional<std::pair<uint64_t, std::vector<uint8_t>>> deserialize(
+      const std::vector<uint8_t>& data) {
+    if (data.size() < sizeof(uint64_t)) {
+      return std::nullopt;
+    }
+    uint64_t addr = 0;
+    std::memcpy(&addr, data.data(), sizeof(addr));
+    return std::make_pair(
+        addr, std::vector<uint8_t>(data.begin() + sizeof(addr), data.end()));
+  }
+};
+
+// Register per-NIC buffer pairs and exchange registration payloads with the
+// remote peer.
+bool registerBuffers(
+    RdmaTransportFactory& factory,
+    const BenchmarkBuffers& bufs,
+    size_t maxSize,
+    controller::Conn& ctrl,
+    const BootstrapConfig& bootstrap,
+    TransportSession& session) {
+  int numBufs = static_cast<int>(bufs.srcs.size());
+  if (numBufs == 0) {
+    return true;
+  }
+
+  // Validate both ranks selected the same number of NICs. The loop below
+  // calls exchangeMetadata once per NIC — a mismatch would deadlock.
+  int32_t localCount = numBufs;
+  std::vector<uint8_t> countPayload(sizeof(localCount));
+  std::memcpy(countPayload.data(), &localCount, sizeof(localCount));
+  auto remoteCountResult =
+      exchangeMetadata(ctrl, countPayload, bootstrap.isRank0());
+  if (!remoteCountResult ||
+      remoteCountResult.value().size() < sizeof(int32_t)) {
+    UNIFLOW_LOG_ERROR("registerBuffers: NIC count exchange failed");
+    return false;
+  }
+  int32_t remoteCount = 0;
+  std::memcpy(
+      &remoteCount, remoteCountResult.value().data(), sizeof(remoteCount));
+  if (localCount != remoteCount) {
+    UNIFLOW_LOG_ERROR(
+        "registerBuffers: NIC count mismatch (local={}, remote={})",
+        localCount,
+        remoteCount);
+    return false;
+  }
+
+  for (int b = 0; b < numBufs; ++b) {
+    Segment srcSeg(bufs.srcs[b], maxSize, bufs.memType, bufs.gpuDevice);
+    Segment dstSeg(bufs.dsts[b], maxSize, bufs.memType, bufs.gpuDevice);
+
+    auto srcRegResult = factory.registerSegment(srcSeg);
+    if (!srcRegResult) {
+      UNIFLOW_LOG_ERROR(
+          "registerSegment(src[{}]) failed: {}",
+          b,
+          srcRegResult.error().toString());
+      return false;
+    }
+
+    auto dstRegResult = factory.registerSegment(dstSeg);
+    if (!dstRegResult) {
+      UNIFLOW_LOG_ERROR(
+          "registerSegment(dst[{}]) failed: {}",
+          b,
+          dstRegResult.error().toString());
+      return false;
+    }
+
+    auto localPayload = RegistrationExchange::serialize(
+        reinterpret_cast<uint64_t>(bufs.dsts[b]),
+        dstRegResult.value()->serialize());
+
+    auto remotePayloadResult =
+        exchangeMetadata(ctrl, localPayload, bootstrap.isRank0());
+    if (!remotePayloadResult) {
+      UNIFLOW_LOG_ERROR(
+          "registration exchange[{}] failed: {}",
+          b,
+          remotePayloadResult.error().toString());
+      return false;
+    }
+
+    auto parsed =
+        RegistrationExchange::deserialize(remotePayloadResult.value());
+    if (!parsed) {
+      UNIFLOW_LOG_ERROR(
+          "remote payload[{}] too small: {}",
+          b,
+          remotePayloadResult.value().size());
+      return false;
+    }
+    auto& [remoteDstAddr, remoteRegPayload] = *parsed;
+
+    auto remoteHandleResult =
+        factory.importSegment(maxSize, std::move(remoteRegPayload));
+    if (!remoteHandleResult) {
+      UNIFLOW_LOG_ERROR(
+          "importSegment[{}] failed: {}",
+          b,
+          remoteHandleResult.error().toString());
+      return false;
+    }
+
+    session.localRegs.push_back(
+        RegisteredSegment::fromHandle(srcSeg, std::move(srcRegResult.value())));
+    session.remoteRegs.push_back(
+        RemoteRegisteredSegment::fromHandle(
+            // NOLINTNEXTLINE(performance-no-int-to-ptr)
+            reinterpret_cast<void*>(remoteDstAddr),
+            maxSize,
+            std::move(remoteHandleResult.value())));
+    session.localDstRegs.push_back(std::move(dstRegResult.value()));
+
+    UNIFLOW_LOG_INFO(
+        "registerBuffers: buf[{}] src={:#x} dst={:#x} remoteDst={:#x}",
+        b,
+        reinterpret_cast<uintptr_t>(bufs.srcs[b]),
+        reinterpret_cast<uintptr_t>(bufs.dsts[b]),
+        remoteDstAddr);
+  }
+
+  return true;
+}
+
 std::optional<TransportSession> setupTransport(
-    const std::string& device,
+    const std::vector<std::string>& devices,
     const BenchmarkBuffers& bufs,
     size_t maxSize,
     ScopedEventBaseThread& evbThread,
@@ -180,14 +334,11 @@ std::optional<TransportSession> setupTransport(
     size_t chunkSize) {
   RdmaTransportConfig rdmaConfig{};
   rdmaConfig.chunkSize = chunkSize;
+  rdmaConfig.numQps = static_cast<uint32_t>(devices.size());
 
   auto cudaDriverApi = std::make_shared<CudaDriverApi>();
   auto factory = std::make_unique<RdmaTransportFactory>(
-      std::vector<std::string>{device},
-      evbThread.getEventBase(),
-      rdmaConfig,
-      ibvApi,
-      cudaDriverApi);
+      devices, evbThread.getEventBase(), rdmaConfig, ibvApi, cudaDriverApi);
 
   auto localTopology = factory->getTopology();
   auto remoteTopologyResult =
@@ -229,102 +380,24 @@ std::optional<TransportSession> setupTransport(
     return std::nullopt;
   }
 
-  Segment srcSeg(bufs.src, maxSize, bufs.memType, bufs.gpuDevice);
-  Segment dstSeg(bufs.dst, maxSize, bufs.memType, bufs.gpuDevice);
-
-  auto srcRegResult = factory->registerSegment(srcSeg);
-  if (!srcRegResult) {
-    UNIFLOW_LOG_ERROR(
-        "RdmaBandwidthBenchmark: registerSegment(src) failed: {}",
-        srcRegResult.error().toString());
+  TransportSession session;
+  if (!registerBuffers(
+          *factory, bufs, maxSize, *peer.ctrl, bootstrap, session)) {
     transport->shutdown();
     return std::nullopt;
   }
 
-  auto dstRegResult = factory->registerSegment(dstSeg);
-  if (!dstRegResult) {
-    UNIFLOW_LOG_ERROR(
-        "RdmaBandwidthBenchmark: registerSegment(dst) failed: {}",
-        dstRegResult.error().toString());
-    transport->shutdown();
-    return std::nullopt;
-  }
-
-  UNIFLOW_LOG_INFO(
-      "setupTransport: src={:#x} dst={:#x} maxSize={} memType={}",
-      reinterpret_cast<uintptr_t>(bufs.src),
-      reinterpret_cast<uintptr_t>(bufs.dst),
-      maxSize,
-      static_cast<int>(bufs.memType));
-  auto dstPayload = dstRegResult.value()->serialize();
-  uint64_t dstAddr = reinterpret_cast<uint64_t>(bufs.dst);
-  std::vector<uint8_t> dstPayloadWithAddr(sizeof(dstAddr) + dstPayload.size());
-  std::memcpy(dstPayloadWithAddr.data(), &dstAddr, sizeof(dstAddr));
-  std::memcpy(
-      dstPayloadWithAddr.data() + sizeof(dstAddr),
-      dstPayload.data(),
-      dstPayload.size());
-
-  auto remotePayloadResult =
-      exchangeMetadata(*peer.ctrl, dstPayloadWithAddr, bootstrap.isRank0());
-  if (!remotePayloadResult) {
-    UNIFLOW_LOG_ERROR(
-        "RdmaBandwidthBenchmark: registration exchange failed: {}",
-        remotePayloadResult.error().toString());
-    transport->shutdown();
-    return std::nullopt;
-  }
-
-  auto& remotePayload = remotePayloadResult.value();
-  if (remotePayload.size() < sizeof(uint64_t)) {
-    UNIFLOW_LOG_ERROR(
-        "RdmaBandwidthBenchmark: remote payload too small: {}",
-        remotePayload.size());
-    transport->shutdown();
-    return std::nullopt;
-  }
-  uint64_t remoteDstAddr = 0;
-  std::memcpy(&remoteDstAddr, remotePayload.data(), sizeof(remoteDstAddr));
-  UNIFLOW_LOG_INFO(
-      "setupTransport: remoteDstAddr={:#x} payloadSize={}",
-      remoteDstAddr,
-      remotePayload.size());
-  std::vector<uint8_t> remoteRegPayload(
-      remotePayload.begin() + sizeof(remoteDstAddr), remotePayload.end());
-
-  auto remoteHandleResult =
-      factory->importSegment(maxSize, std::move(remoteRegPayload));
-  if (!remoteHandleResult) {
-    UNIFLOW_LOG_ERROR(
-        "RdmaBandwidthBenchmark: importSegment failed: {}",
-        remoteHandleResult.error().toString());
-    transport->shutdown();
-    return std::nullopt;
-  }
-
-  auto localReg =
-      SegmentTest::makeRegistered(srcSeg, std::move(srcRegResult.value()));
-  auto remoteReg = SegmentTest::makeRemote(
-      // NOLINTNEXTLINE(performance-no-int-to-ptr)
-      reinterpret_cast<void*>(remoteDstAddr),
-      maxSize,
-      std::move(remoteHandleResult.value()));
-
-  return TransportSession{
-      std::move(factory),
-      std::move(transport),
-      std::move(localReg),
-      std::move(remoteReg),
-      std::move(dstRegResult.value()),
-  };
+  session.factory = std::move(factory);
+  session.transport = std::move(transport);
+  return session;
 }
 
 /// Batched put/get: pass batchSize requests per put() call, measure the
 /// latency of the whole batch, divide by batchSize for per-op latency.
 std::vector<BenchmarkResult> runBenchmarkLoop(
     Transport& transport,
-    RegisteredSegment& localReg,
-    RemoteRegisteredSegment& remoteReg,
+    std::vector<RegisteredSegment>& localRegs,
+    std::vector<RemoteRegisteredSegment>& remoteRegs,
     const BenchmarkConfig& config,
     std::vector<PeerConnection>& peers,
     const BootstrapConfig& bootstrap,
@@ -332,6 +405,7 @@ std::vector<BenchmarkResult> runBenchmarkLoop(
   auto sizes = generateSizes(config.minSize, config.maxSize);
   std::vector<BenchmarkResult> results;
   const int batchSize = std::max(1, config.batchSize);
+  const int numBufs = static_cast<int>(localRegs.size());
 
   const bool isActiveRank = config.bidirectional || bootstrap.isRank0();
 
@@ -349,12 +423,21 @@ std::vector<BenchmarkResult> runBenchmarkLoop(
         continue;
       }
 
-      std::vector<TransferRequest> batch(
-          batchSize,
-          TransferRequest{
-              .local = localReg.span(size_t{0}, size),
-              .remote = remoteReg.span(size_t{0}, size),
-          });
+      // Map each request to its NIC's buffer. Must match spray()'s
+      // contiguous chunk-to-QP assignment in the transport layer.
+      auto nicForRequest = [&](int requestIdx) {
+        return requestIdx * numBufs / batchSize;
+      };
+      std::vector<TransferRequest> batch;
+      batch.reserve(batchSize);
+      for (int i = 0; i < batchSize; ++i) {
+        int bufIdx = nicForRequest(i);
+        batch.push_back(
+            TransferRequest{
+                .local = localRegs[bufIdx].span(size_t{0}, size),
+                .remote = remoteRegs[bufIdx].span(size_t{0}, size),
+            });
+      }
 
       int numBatches =
           std::max(1, (config.iterations + batchSize - 1) / batchSize);
@@ -428,12 +511,11 @@ std::vector<BenchmarkResult> runBenchmarkLoop(
           .messageRateMops = msgRateMops,
       });
 
-      fprintf(
-          stderr,
-          "[rank %d] %s size=%-10zu batch=%-3d iters=%-6d "
-          "bw=%.2f GB/s  avg=%.1f us  %s\n",
+      UNIFLOW_LOG_WARN(
+          "[rank {}] {} size={:<10} batch={:<3} iters={:<6} "
+          "bw={:.2f} GB/s  avg={:.1f} us  {}",
           bootstrap.rank,
-          dir.c_str(),
+          dir,
           size,
           batchSize,
           totalOps,
@@ -482,27 +564,51 @@ std::vector<BenchmarkResult> RdmaBandwidthBenchmark::run(
     return {};
   }
 
-  std::string myDevice;
-  if (static_cast<size_t>(bootstrap.localRank) < deviceNames.size()) {
-    myDevice = deviceNames[bootstrap.localRank];
+  std::vector<std::string> myDevices;
+  if (!rdmaDevices_.empty()) {
+    myDevices = rdmaDevices_;
   } else {
-    myDevice = deviceNames[0];
+    auto& topo = Topology::get();
+    if (topo.available()) {
+      myDevices = (config.cudaDevice < 0)
+          ? topo.selectCpuNics()
+          : topo.selectGpuNics(config.cudaDevice);
+    }
+    if (myDevices.empty()) {
+      myDevices = deviceNames;
+    }
   }
-  UNIFLOW_LOG_INFO(
-      "RdmaBandwidthBenchmark: rank {} using RDMA device {}",
-      bootstrap.rank,
-      myDevice);
+  {
+    std::string devList;
+    for (const auto& d : myDevices) {
+      if (!devList.empty()) {
+        devList += ", ";
+      }
+      devList += d;
+    }
+    UNIFLOW_LOG_WARN(
+        "RdmaBandwidthBenchmark: rank {} RDMA device(s): {}",
+        bootstrap.rank,
+        devList);
+  }
 
-  auto bufs =
-      allocateBuffers(config.maxSize, config.cudaDevice, bootstrap.rank);
+  int numNics = static_cast<int>(myDevices.size());
+  auto bufs = allocateBuffers(
+      config.maxSize, config.cudaDevice, bootstrap.rank, numNics);
   if (!bufs) {
     return {};
   }
 
+  // Sanity check: we allocate one buffer pair per NIC and create one QP per
+  // NIC.  A mismatch would cause out-of-bounds accesses in runBenchmarkLoop.
+  assert(
+      bufs->srcs.size() == myDevices.size() &&
+      "Buffer count must equal NIC/QP count");
+
   // evbThread must outlive the transport (transport posts async work to it).
   ScopedEventBaseThread evbThread("bench-evb");
   auto session = setupTransport(
-      myDevice,
+      myDevices,
       *bufs,
       config.maxSize,
       evbThread,
@@ -516,8 +622,8 @@ std::vector<BenchmarkResult> RdmaBandwidthBenchmark::run(
 
   auto results = runBenchmarkLoop(
       *session->transport,
-      session->localReg,
-      session->remoteReg,
+      session->localRegs,
+      session->remoteRegs,
       config,
       peers,
       bootstrap,

--- a/comms/uniflow/benchmarks/bench/RdmaBandwidthBenchmark.cpp
+++ b/comms/uniflow/benchmarks/bench/RdmaBandwidthBenchmark.cpp
@@ -8,6 +8,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <deque>
 #include <future>
 #include <optional>
 #include <utility>
@@ -52,7 +53,7 @@ struct BenchmarkBuffers {
   // multiple NICs read from the same GPU memory region simultaneously.
   std::vector<void*> srcs;
   std::vector<void*> dsts;
-  bool useGpu{false}; // Controls deallocation path (cudaFree vs std::free).
+  bool useGpu{false};
   MemoryType memType{MemoryType::DRAM};
   int gpuDevice{0};
 
@@ -392,8 +393,7 @@ std::optional<TransportSession> setupTransport(
   return session;
 }
 
-/// Batched put/get: pass batchSize requests per put() call, measure the
-/// latency of the whole batch, divide by batchSize for per-op latency.
+/// Run batched put/get with pipelined submission (txDepth in-flight batches).
 std::vector<BenchmarkResult> runBenchmarkLoop(
     Transport& transport,
     std::vector<RegisteredSegment>& localRegs,
@@ -402,9 +402,13 @@ std::vector<BenchmarkResult> runBenchmarkLoop(
     std::vector<PeerConnection>& peers,
     const BootstrapConfig& bootstrap,
     const std::string& benchmarkName) {
+  using Clock = std::chrono::steady_clock;
+  using TimePoint = Clock::time_point;
+
   auto sizes = generateSizes(config.minSize, config.maxSize);
   std::vector<BenchmarkResult> results;
   const int batchSize = std::max(1, config.batchSize);
+  const int txDepth = std::max(1, config.txDepth);
   const int numBufs = static_cast<int>(localRegs.size());
 
   const bool isActiveRank = config.bidirectional || bootstrap.isRank0();
@@ -441,18 +445,15 @@ std::vector<BenchmarkResult> runBenchmarkLoop(
 
       int numBatches =
           std::max(1, (config.iterations + batchSize - 1) / batchSize);
-      // totalOps may exceed config.iterations when iterations is not evenly
-      // divisible by batchSize (we round up to complete batches).
       int totalOps = numBatches * batchSize;
 
-      auto submitBatch = [&]() -> Status {
-        auto fut = (dir == "put") ? transport.put(batch, {})
-                                  : transport.get(batch, {});
-        return fut.get();
+      auto submitBatchAsync = [&]() -> std::future<Status> {
+        return (dir == "put") ? transport.put(batch, {})
+                              : transport.get(batch, {});
       };
 
       for (int iter = 0; iter < config.warmupIterations; ++iter) {
-        auto status = submitBatch();
+        auto status = submitBatchAsync().get();
         if (status.hasError()) {
           UNIFLOW_LOG_ERROR(
               "RdmaBandwidthBenchmark: warmup {} failed at size {}: {}",
@@ -463,29 +464,56 @@ std::vector<BenchmarkResult> runBenchmarkLoop(
         }
       }
 
+      // Sliding window: keep up to txDepth batches in-flight.
+      // txDepth=1 degenerates to synchronous behavior.
+      std::deque<std::pair<std::future<Status>, TimePoint>> inflight;
       std::vector<double> latenciesUs;
       latenciesUs.reserve(numBatches);
 
-      auto overallStart = std::chrono::steady_clock::now();
-
-      for (int b = 0; b < numBatches; ++b) {
-        auto t0 = std::chrono::steady_clock::now();
-        auto status = submitBatch();
-        auto t1 = std::chrono::steady_clock::now();
+      // Complete the oldest in-flight batch: get result, record latency.
+      // Returns false on error after draining all remaining futures.
+      auto completeOne = [&]() -> bool {
+        auto& [fut, submitTime] = inflight.front();
+        auto status = fut.get();
+        auto completeTime = Clock::now();
         if (status.hasError()) {
+          inflight.pop_front();
           UNIFLOW_LOG_ERROR(
               "RdmaBandwidthBenchmark: {} failed at size {}: {}",
               dir,
               size,
               status.error().message());
-          return;
+          for (auto& [f, _] : inflight) {
+            f.wait();
+          }
+          return false;
         }
         double batchUs =
-            std::chrono::duration<double, std::micro>(t1 - t0).count();
+            std::chrono::duration<double, std::micro>(completeTime - submitTime)
+                .count();
         latenciesUs.push_back(batchUs / batchSize);
+        inflight.pop_front();
+        return true;
+      };
+
+      auto overallStart = Clock::now();
+
+      for (int b = 0; b < numBatches; ++b) {
+        if (static_cast<int>(inflight.size()) >= txDepth) {
+          if (!completeOne()) {
+            return;
+          }
+        }
+        inflight.emplace_back(submitBatchAsync(), Clock::now());
       }
 
-      auto overallEnd = std::chrono::steady_clock::now();
+      while (!inflight.empty()) {
+        if (!completeOne()) {
+          return;
+        }
+      }
+
+      auto overallEnd = Clock::now();
 
       double totalTimeSec =
           std::chrono::duration<double>(overallEnd - overallStart).count();
@@ -505,6 +533,7 @@ std::vector<BenchmarkResult> runBenchmarkLoop(
           .messageSize = size,
           .iterations = totalOps,
           .batchSize = batchSize,
+          .txDepth = txDepth,
           .chunkSize = config.chunkSize,
           .bandwidthGBs = bandwidthGBs,
           .latency = stats,
@@ -512,12 +541,13 @@ std::vector<BenchmarkResult> runBenchmarkLoop(
       });
 
       UNIFLOW_LOG_WARN(
-          "[rank {}] {} size={:<10} batch={:<3} iters={:<6} "
+          "[rank {}] {} size={:<10} batch={:<3} txdepth={:<3} iters={:<6} "
           "bw={:.2f} GB/s  avg={:.1f} us  {}",
           bootstrap.rank,
           dir,
           size,
           batchSize,
+          txDepth,
           totalOps,
           bandwidthGBs,
           stats.avg,
@@ -577,6 +607,10 @@ std::vector<BenchmarkResult> RdmaBandwidthBenchmark::run(
     if (myDevices.empty()) {
       myDevices = deviceNames;
     }
+    if (config.numNics > 0 &&
+        config.numNics < static_cast<int>(myDevices.size())) {
+      myDevices.resize(config.numNics);
+    }
   }
   {
     std::string devList;
@@ -599,13 +633,10 @@ std::vector<BenchmarkResult> RdmaBandwidthBenchmark::run(
     return {};
   }
 
-  // Sanity check: we allocate one buffer pair per NIC and create one QP per
-  // NIC.  A mismatch would cause out-of-bounds accesses in runBenchmarkLoop.
   assert(
       bufs->srcs.size() == myDevices.size() &&
       "Buffer count must equal NIC/QP count");
 
-  // evbThread must outlive the transport (transport posts async work to it).
   ScopedEventBaseThread evbThread("bench-evb");
   auto session = setupTransport(
       myDevices,

--- a/comms/uniflow/benchmarks/main.cpp
+++ b/comms/uniflow/benchmarks/main.cpp
@@ -31,6 +31,8 @@ struct CliOptions {
   int warmup{10};
   int loopCount{1};
   int batchSize{1};
+  int txDepth{1};
+  int numNics{0};
   size_t chunkSize{512 * 1024};
   int cudaDevice{-1};
   bool bidirectional{false};
@@ -84,6 +86,8 @@ void printUsage(const char* prog) {
       << "  --format <fmt>         table|csv|both (default: table)\n"
       << "  --rdma-devices <list>  Comma-separated RDMA device names (default: auto-discover)\n"
       << "  --batch-size <n>       Number of requests per transport call (default: 1)\n"
+      << "  --tx-depth <n>         Outstanding transport calls before waiting (default: 1)\n"
+      << "  --num-nics <n>         Cap number of NICs to use (default: 0 = all)\n"
       << "  --chunk-size <bytes>   RDMA transfer chunk size in bytes (default: 524288)\n"
       << "  --cuda-device <id>     GPU device index for buffer allocation (default: CPU memory)\n"
       << "  --list                 List available benchmarks\n"
@@ -116,6 +120,8 @@ CliOptions parseArgs(int argc, char** argv) {
       {"format", required_argument, nullptr, 'f'},
       {"rdma-devices", required_argument, nullptr, 'r'},
       {"batch-size", required_argument, nullptr, 'T'},
+      {"tx-depth", required_argument, nullptr, 257},
+      {"num-nics", required_argument, nullptr, 258},
       {"chunk-size", required_argument, nullptr, 256},
       {"cuda-device", required_argument, nullptr, 'c'},
       {"list", no_argument, nullptr, 'l'},
@@ -205,6 +211,30 @@ CliOptions parseArgs(int argc, char** argv) {
           std::exit(1);
         }
         break;
+      case 257:
+        try {
+          opts.txDepth = std::stoi(optarg);
+          if (opts.txDepth < 1) {
+            std::cerr << "Invalid value for --tx-depth: must be >= 1\n";
+            std::exit(1);
+          }
+        } catch (const std::exception&) {
+          std::cerr << "Invalid value for --tx-depth: '" << optarg << "'\n";
+          std::exit(1);
+        }
+        break;
+      case 258:
+        try {
+          opts.numNics = std::stoi(optarg);
+          if (opts.numNics < 0) {
+            std::cerr << "Invalid value for --num-nics: must be >= 0\n";
+            std::exit(1);
+          }
+        } catch (const std::exception&) {
+          std::cerr << "Invalid value for --num-nics: '" << optarg << "'\n";
+          std::exit(1);
+        }
+        break;
       case 256:
         try {
           opts.chunkSize = std::stoull(optarg);
@@ -287,6 +317,8 @@ int main(int argc, char** argv) {
   config.bidirectional = opts.bidirectional;
   config.direction = opts.direction;
   config.batchSize = opts.batchSize;
+  config.txDepth = opts.txDepth;
+  config.numNics = opts.numNics;
   config.chunkSize = opts.chunkSize;
   config.cudaDevice = opts.cudaDevice;
   config.numStreams = opts.numStreams;

--- a/comms/uniflow/benchmarks/main.cpp
+++ b/comms/uniflow/benchmarks/main.cpp
@@ -245,10 +245,11 @@ CliOptions parseArgs(int argc, char** argv) {
 } // namespace
 
 int main(int argc, char** argv) {
-  // Default to error-only. Override with SPDLOG_LEVEL="uniflow=info".
-  // getLogger() lazy-init calls spdlog::cfg::load_env_levels(), so env
-  // overrides take effect automatically; set_level just sets the default.
-  uniflow::logging::getLogger()->set_level(spdlog::level::err);
+  // Default to error-only unless SPDLOG_LEVEL env var is set.
+  auto* logger = uniflow::logging::getLogger();
+  if (std::getenv("SPDLOG_LEVEL") == nullptr) {
+    logger->set_level(spdlog::level::err);
+  }
 
   auto opts = parseArgs(argc, argv);
 

--- a/comms/uniflow/benchmarks/scripts/compare_rdma_bandwidth.py
+++ b/comms/uniflow/benchmarks/scripts/compare_rdma_bandwidth.py
@@ -1,0 +1,1052 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# @noautodeps — standalone script, runs with system python3 (no buck target)
+#
+# Compare uniflow RDMA bandwidth against ib_write_bw (perftest).
+# stdlib-only — runs with system python3, no buck build for the script itself.
+# Binaries are cached in ~/.cache/uniflow_compare/<gpu>/ after first build.
+#
+# Usage: python3 compare_rdma_bandwidth.py [OPTIONS]
+
+import argparse
+import atexit
+import base64
+import csv
+import os
+import random
+import re
+import shlex
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+
+_verbose = False
+
+REMOTE_DIR = "/tmp/uniflow_compare"
+
+# SSH throttling mitigation: remote hosts enforce MaxStartups limits on
+# concurrent SSH connections. These delays prevent back-to-back sush2/suscp
+# calls from being rejected.
+SSH_THROTTLE_DELAY = 3  # seconds between SSH retries on throttle errors
+IB_SERVER_INIT_DELAY_LOCAL = 3  # seconds for ib_write_bw server startup (local)
+IB_SERVER_INIT_DELAY_REMOTE = 10  # seconds for ib_write_bw server startup (remote)
+IB_PER_SIZE_DELAY = 3  # seconds between sizes in ib_write_bw loop
+
+GPU_PATTERNS = [
+    ("H100", "h100"),
+    ("H200", "h200"),
+    ("GB200", "b200"),
+    ("B200", "b200"),
+    ("A100", "a100"),
+]
+
+BUILD_SPECS = {
+    "uniflow_bench": {
+        "target": "fbcode//comms/uniflow/benchmarks:uniflow_bench",
+        "b200_flags": (
+            " -c fbcode.arch=aarch64"
+            " -c fbcode.enable_gpu_sections=true"
+            " -c fbcode.nvcc_arch=b200"
+            " -c fbcode.platform010_cuda_version=12.8"
+        ),
+        "supported_gpus": ("h100", "b200"),
+    },
+    "ib_write_bw": {
+        "target": "fbsource//third-party/perftest/25.07.0-0.104:ib_write_bw",
+        "b200_flags": " -c fbcode.arch=aarch64",
+        "supported_gpus": None,
+    },
+}
+
+# Setup scripts: plain bash with __PLACEHOLDER__ substitution, base64-encoded
+# before execution to avoid sush2 quoting issues entirely.
+
+SETUP_SCRIPT_HOST0 = """\
+set +e
+GPU=$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | head -1)
+echo "GPU:$GPU"
+NIC=$(ibstat -l 2>/dev/null | head -1 || ls /sys/class/infiniband/ 2>/dev/null | head -1)
+echo "NIC:$NIC"
+IP=$(ip -4 addr show eth1 2>/dev/null | awk '/inet /{split($2,a,"/"); print a[1]; exit}')
+[ -z "$IP" ] && IP=$(ip -4 addr show eth0 2>/dev/null | awk '/inet /{split($2,a,"/"); print a[1]; exit}')
+[ -z "$IP" ] && IP=$(hostname -i 2>/dev/null | awk '{print $1}')
+echo "IP:$IP"
+GID_NIC=${__NIC_OVERRIDE__:-$NIC}
+GID=$(show_gids 2>/dev/null | awk "/$GID_NIC/ && /v2/ && !/fe80/ {print \\$3; exit}")
+echo "GID:${GID:-3}"
+test -x __REMOTE_DIR__/uniflow_bench && echo "HAS:uniflow_bench"
+test -x __REMOTE_DIR__/ib_write_bw && echo "HAS:ib_write_bw"
+pkill -9 -f uniflow_bench 2>/dev/null
+pkill -9 -f ib_write_bw 2>/dev/null
+mkdir -p __REMOTE_DIR__
+echo "SETUP_OK"
+"""
+
+SETUP_SCRIPT_EXTRA_HOST = """\
+set +e
+GID=$(show_gids 2>/dev/null | awk "/__NIC__/ && /v2/ && !/fe80/ {print \\$3; exit}")
+echo "GID:${GID:-3}"
+test -x __REMOTE_DIR__/uniflow_bench && echo "HAS:uniflow_bench"
+test -x __REMOTE_DIR__/ib_write_bw && echo "HAS:ib_write_bw"
+pkill -9 -f uniflow_bench 2>/dev/null
+pkill -9 -f ib_write_bw 2>/dev/null
+mkdir -p __REMOTE_DIR__
+echo "SETUP_OK"
+"""
+
+
+def _log(msg):
+    if _verbose:
+        print(f"  [debug] {msg}", file=sys.stderr)
+
+
+def format_size(nbytes):
+    if nbytes >= 1 << 30:
+        return f"{nbytes >> 30} GB"
+    if nbytes >= 1 << 20:
+        return f"{nbytes >> 20} MB"
+    if nbytes >= 1 << 10:
+        return f"{nbytes >> 10} KB"
+    return f"{nbytes} B"
+
+
+def generate_sizes(min_size, max_size):
+    for val, label in [(min_size, "--min-size"), (max_size, "--max-size")]:
+        if val <= 0 or (val & (val - 1)) != 0:
+            sys.exit(f"ERROR: {label} must be a power of 2, got {val}")
+    if min_size > max_size:
+        sys.exit(f"ERROR: --min-size ({min_size}) must be <= --max-size ({max_size})")
+    sizes = []
+    s = min_size
+    while s <= max_size:
+        sizes.append(s)
+        s *= 2
+    return sizes
+
+
+def match_gpu(raw):
+    """Match nvidia-smi output string to a canonical GPU type."""
+    for pattern, name in GPU_PATTERNS:
+        if pattern in raw:
+            return name
+    return ""
+
+
+def _run_script_on_host(host, script):
+    """Base64-encode a bash script and run it via sush2, avoiding quoting issues."""
+    encoded = base64.b64encode(script.encode()).decode()
+    return host.run(f"echo {encoded} | base64 -d | bash", timeout=30)
+
+
+_SUSH2_BANNER = (
+    "Meta authorized users only. Usage is subject to monitoring and recording."
+)
+
+
+class RemoteHost:
+    """Manages all sush2 interactions with a single remote host."""
+
+    def __init__(self, hostname):
+        self.hostname = hostname
+        self._bg_procs = []
+
+    @property
+    def is_local(self):
+        return self.hostname == "localhost"
+
+    def _wrap(self, cmd):
+        if self.is_local:
+            return cmd
+        remote = f"{{ {cmd} ; }} 2>&1"
+        return (
+            f"sush2 --reason 'RDMA bandwidth comparison'"
+            f" root@{self.hostname} {shlex.quote(remote)}"
+        )
+
+    @staticmethod
+    def _strip_banner(output):
+        lines = output.splitlines()
+        return "\n".join(ln for ln in lines if _SUSH2_BANNER not in ln).strip()
+
+    def run(self, cmd, capture=True, timeout=None):
+        _log(f"[{self.hostname}] {cmd}")
+        full = self._wrap(cmd)
+        if not capture:
+            subprocess.run(full, shell=True, timeout=timeout)
+            return ""
+        # Retry on SSH throttling (empty stdout + non-zero rc).
+        # Commands that legitimately return empty output have rc=0.
+        out = ""
+        for attempt in range(3):
+            if attempt > 0:
+                _log(f"sush2 retry {attempt + 1}/3 after SSH throttle delay")
+                time.sleep(SSH_THROTTLE_DELAY)
+            r = subprocess.run(
+                full, shell=True, capture_output=True, text=True, timeout=timeout
+            )
+            if _verbose and r.stderr and r.stderr.strip():
+                _log(f"stderr: {r.stderr.strip()[:500]}")
+            out = r.stdout.strip()
+            if not self.is_local and out:
+                out = self._strip_banner(out)
+            if out or r.returncode == 0:
+                return out
+        return out
+
+    def run_bg(self, cmd, quiet=False):
+        _log(f"[{self.hostname} bg] {cmd}")
+        full = self._wrap(cmd)
+        fd, log_path = tempfile.mkstemp(suffix=".log", prefix="uniflow_bg_", dir="/tmp")
+        log_file = os.fdopen(fd, "w")
+        p = subprocess.Popen(
+            full,
+            shell=True,
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+            stdin=subprocess.DEVNULL,
+        )
+        p.log_file = log_file
+        p.log_path = log_path
+        self._bg_procs.append(p)
+        if not quiet:
+            print(f"  bg log: {log_path}")
+        return p
+
+    def collect_bg(self, proc):
+        proc.log_file.close()
+        output = ""
+        if os.path.exists(proc.log_path):
+            with open(proc.log_path) as f:
+                output = f.read()
+            os.unlink(proc.log_path)
+        return self._strip_banner(output).strip() if output else ""
+
+    def _suscp(self, src, dst, reason, timeout=120):
+        # Retry on transient SSH kex errors (MaxStartups throttling).
+        cmd = f"suscp --reason {shlex.quote(reason)} {src} {dst}"
+        for attempt in range(3):
+            if attempt > 0:
+                _log(f"suscp retry {attempt + 1}/3 after SSH throttle delay")
+                time.sleep(SSH_THROTTLE_DELAY)
+            rc = subprocess.run(cmd, shell=True, timeout=timeout).returncode
+            if rc == 0:
+                return
+        # suscp may also return non-zero despite successful transfer when SSH
+        # hits transient kex errors. Callers verify the file arrived.
+        _log(f"suscp exited {rc}, caller will verify file")
+
+    def copy_to(self, local_path, remote_name):
+        self._suscp(
+            local_path,
+            f"root@{self.hostname}:{REMOTE_DIR}/{remote_name}",
+            "copy benchmark binary",
+        )
+
+    def copy_from(self, remote_name, local_path):
+        self._suscp(
+            f"root@{self.hostname}:{REMOTE_DIR}/{remote_name}",
+            local_path,
+            "retrieve results",
+            timeout=60,
+        )
+
+    def verify_and_chmod(self, names):
+        checks = " && ".join(
+            f"test -f {REMOTE_DIR}/{n} && chmod +x {REMOTE_DIR}/{n}" for n in names
+        )
+        out = self.run(f"{checks} && echo OK", timeout=15)
+        if "OK" not in (out or ""):
+            sys.exit(
+                f"ERROR: Binaries not found on {self.hostname} after copy."
+                f" Expected: {', '.join(names)}"
+            )
+
+    def setup_primary(self, nic_override=""):
+        script = SETUP_SCRIPT_HOST0.replace("__REMOTE_DIR__", REMOTE_DIR).replace(
+            "__NIC_OVERRIDE__", nic_override or ""
+        )
+        return self._parse_setup(_run_script_on_host(self, script))
+
+    def setup_secondary(self, nic):
+        script = SETUP_SCRIPT_EXTRA_HOST.replace("__REMOTE_DIR__", REMOTE_DIR).replace(
+            "__NIC__", nic
+        )
+        return self._parse_setup(_run_script_on_host(self, script))
+
+    @staticmethod
+    def _parse_setup(output):
+        if "SETUP_OK" not in (output or ""):
+            sys.exit(f"ERROR: Remote setup failed.\n  Output: {output!r}")
+
+        info = {}
+        has_bins = set()
+        for line in output.splitlines():
+            if line.startswith("HAS:"):
+                has_bins.add(line[4:].strip())
+            elif ":" in line and not line.startswith(" "):
+                key, _, val = line.partition(":")
+                info[key.strip()] = val.strip()
+
+        info["has_bins"] = has_bins
+        return info
+
+    def cleanup(self):
+        """Gracefully terminate bg sush2 processes.
+
+        SIGTERM lets sush2 close the SSH channel, which sends SIGHUP to the
+        remote process group. SIGKILL is a fallback if it doesn't exit in time.
+        """
+        for proc in self._bg_procs:
+            try:
+                proc.terminate()  # SIGTERM → sush2 propagates to remote
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()  # fallback
+            except OSError:
+                pass
+        self._bg_procs.clear()
+
+    def format_cmd(self, cmd):
+        return cmd if self.is_local else self._wrap(cmd)
+
+
+CACHE_DIR = os.path.expanduser("~/.cache/uniflow_compare")
+
+
+def get_cached_binary(name, gpu):
+    path = os.path.join(CACHE_DIR, gpu, name)
+    return path if os.path.isfile(path) and os.access(path, os.X_OK) else None
+
+
+def build_binary(name, gpu, rebuild=False):
+    cached = get_cached_binary(name, gpu)
+    if cached and not rebuild:
+        print(f"  {name}: {cached} (cached)")
+        return cached
+
+    spec = BUILD_SPECS[name]
+    if spec["supported_gpus"] and gpu not in spec["supported_gpus"]:
+        sys.exit(f"ERROR: Unsupported GPU for {name}: {gpu}")
+
+    print(f"  Building {name}...")
+    extra = spec["b200_flags"] if gpu == "b200" else ""
+    cmd = f"buck2 build @fbcode//mode/opt{extra} {spec['target']} --show-full-output"
+    try:
+        r = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=600)
+    except subprocess.TimeoutExpired:
+        sys.exit(f"ERROR: Build of {name} timed out after 10 minutes")
+    if r.returncode != 0:
+        tail = "\n".join(r.stderr.splitlines()[-20:]) if r.stderr else "(no stderr)"
+        sys.exit(f"ERROR: Build of {name} failed (exit {r.returncode}):\n{tail}")
+
+    parts = r.stdout.strip().split()
+    built = parts[1] if len(parts) >= 2 else ""
+    if not built or not os.path.isfile(built):
+        sys.exit(f"ERROR: Build of {name} produced no output binary")
+
+    dest_dir = os.path.join(CACHE_DIR, gpu)
+    os.makedirs(dest_dir, exist_ok=True)
+    dest = os.path.join(dest_dir, name)
+    shutil.copy2(built, dest)
+    os.chmod(dest, 0o755)
+    print(f"  {name}: {dest}")
+    return dest
+
+
+class UniflowBenchmark:
+    name = "uniflow"
+    binary_name = "uniflow_bench"
+
+    def __init__(self, args, sizes, host0, rank1_host):
+        self.args = args
+        self.sizes = sizes
+        self.host0 = host0
+        self.rank1_host = rank1_host
+        self.binary_path = f"{REMOTE_DIR}/{self.binary_name}"
+
+    def run(self, dry_run=False):
+        print("--- Running uniflow ---")
+        a = self.args
+
+        bench_flags = (
+            f"--benchmark rdma_bandwidth --transport rdma"
+            f" --iterations {a.iterations} --warmup {a.warmup}"
+            f" --min-size {a.min_size} --max-size {a.max_size}"
+            f" --direction put --batch-size {a.batch_size}"
+            f" --tx-depth {a.tx_depth}"
+            f" --chunk-size {a.chunk_size}"
+            f" --format csv --output {REMOTE_DIR}/results.csv"
+        )
+        if a.num_nics > 0:
+            bench_flags += f" --num-nics {a.num_nics}"
+        if a.use_cuda:
+            bench_flags += " --cuda-device 0"
+        if a.nics:
+            bench_flags += f" --rdma-devices {a.nics}"
+
+        env = f"MASTER_ADDR={a.master_ip} MASTER_PORT=29500 WORLD_SIZE=2"
+        if _verbose:
+            env = f'SPDLOG_LEVEL="uniflow=info" {env}'
+        r0_cmd = f"{env} RANK=0 LOCAL_RANK=0 {self.binary_path} {bench_flags}"
+        r1_cmd = (
+            f"{env} RANK=1 LOCAL_RANK={a.rank1_local_rank}"
+            f" {self.binary_path} {bench_flags}"
+        )
+
+        if dry_run:
+            print(f"  rank 0: {self.host0.format_cmd(r0_cmd)}")
+            print(f"  rank 1: {self.rank1_host.format_cmd(r1_cmd)}")
+            print()
+            return {}
+
+        print(f"  rank 0: {r0_cmd}")
+        print(f"  rank 1: {r1_cmd}")
+        print()
+
+        # Prepend rm to the rank0 command to clear stale results within
+        # the same sush2 session (zero extra SSH calls).
+        r0_cmd_full = f"rm -f {REMOTE_DIR}/results.csv; {r0_cmd}"
+        p1 = self.rank1_host.run_bg(r1_cmd)
+        time.sleep(1)
+        self.host0.run(r0_cmd_full, capture=False)
+        p1.wait()
+
+        rank1_log = self.rank1_host.collect_bg(p1)
+        if rank1_log:
+            print("  [rank 1 log]")
+            for line in rank1_log.splitlines():
+                print(f"    {line}")
+            print()
+
+        results = self._collect_results()
+        if results:
+            print(f"  Parsed {len(results)} sizes")
+        else:
+            print("  WARNING: No results parsed from CSV")
+        print()
+        return results
+
+    def _collect_results(self):
+        a = self.args
+        fd, csv_path = tempfile.mkstemp(suffix=".csv", prefix="uniflow_")
+        os.close(fd)
+        try:
+            if self.host0.is_local:
+                shutil.copy2(f"{REMOTE_DIR}/results.csv", csv_path)
+            else:
+                self.host0.copy_from("results.csv", csv_path)
+            if not os.path.exists(csv_path) or os.path.getsize(csv_path) == 0:
+                remote_check = ""
+                if not self.host0.is_local:
+                    remote_check = self.host0.run(
+                        f"ls -la {REMOTE_DIR}/results.csv 2>&1", timeout=10
+                    )
+                sys.exit(
+                    f"ERROR: uniflow CSV results not retrieved."
+                    f"\n  Remote: {remote_check or '(local mode)'}"
+                )
+            # Validate the CSV is from this run, not a stale file from a
+            # previous chunk-size sweep.
+            with open(csv_path) as f:
+                reader = csv.DictReader(f)
+                first_row = next(reader, None)
+                if first_row and "chunk_size" in first_row:
+                    csv_chunk = int(first_row["chunk_size"])
+                    if csv_chunk != a.chunk_size:
+                        sys.exit(
+                            f"ERROR: Stale results.csv detected"
+                            f" (chunk_size={csv_chunk}, expected {a.chunk_size})."
+                            f" The uniflow benchmark may have failed silently."
+                        )
+            if getattr(a, "save_csv", ""):
+                os.makedirs(os.path.dirname(a.save_csv) or ".", exist_ok=True)
+                shutil.copy2(csv_path, a.save_csv)
+                print(f"  Raw CSV saved to {a.save_csv}")
+            return self._parse_csv(csv_path)
+        finally:
+            if os.path.exists(csv_path):
+                os.unlink(csv_path)
+
+    @staticmethod
+    def _parse_csv(csv_path):
+        results = {}
+        with open(csv_path) as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                try:
+                    size = int(row["size_bytes"])
+                    entry = {"bw": float(row["bw_gbps"])}
+                    for csv_key, dict_key in [
+                        ("lat_avg_us", "avg_us"),
+                        ("lat_p50_us", "p50_us"),
+                        ("lat_p99_us", "p99_us"),
+                        ("lat_min_us", "min_us"),
+                        ("lat_max_us", "max_us"),
+                        ("msg_rate_mops", "msg_rate_mops"),
+                        ("batch_size", "batch_size"),
+                        ("chunk_size", "chunk_size"),
+                    ]:
+                        if csv_key in row:
+                            entry[dict_key] = float(row[csv_key])
+                    results[size] = entry
+                except (ValueError, KeyError):
+                    continue
+        return results
+
+
+class IbWriteBwBenchmark:
+    name = "ib_write_bw"
+    binary_name = "ib_write_bw"
+
+    def __init__(self, args, sizes, host0, rank1_host):
+        self.args = args
+        self.sizes = sizes
+        self.host0 = host0
+        self.rank1_host = rank1_host
+        self.binary_path = f"{REMOTE_DIR}/{self.binary_name}"
+
+    def run(self, dry_run=False):
+        print("--- Running ib_write_bw ---")
+        a = self.args
+        base_port = random.randint(18000, 29999)
+        cuda_flag = "--use_cuda=0 --use_cuda_dmabuf" if a.use_cuda else ""
+
+        server_loop, client_loop = self._build_loop(base_port, cuda_flag)
+
+        if dry_run:
+            print(f"  server: {self.host0.format_cmd(server_loop)}")
+            print(f"  client: {self.rank1_host.format_cmd(client_loop)}")
+            print()
+            return {}
+
+        srv_proc = self.host0.run_bg(server_loop)
+        delay = (
+            IB_SERVER_INIT_DELAY_LOCAL
+            if self.host0.is_local
+            else IB_SERVER_INIT_DELAY_REMOTE
+        )
+        time.sleep(delay)
+        self.rank1_host.run(client_loop, capture=False, timeout=1800)
+        srv_proc.wait()
+        srv_log = self.host0.collect_bg(srv_proc)
+
+        ib_out = self.rank1_host.run(f"cat {REMOTE_DIR}/ib_results.txt 2>/dev/null")
+
+        results = {}
+        for size in self.sizes:
+            bw = self._parse_bw(ib_out, size)
+            if bw is not None:
+                results[size] = bw
+
+        missing = [s for s in self.sizes if s not in results]
+        if missing:
+            labels = ", ".join(format_size(s) for s in missing)
+            print(f"  Missing results for: {labels}")
+            if srv_log:
+                print(f"  Server log (last 500 chars):\n    {srv_log[-500:]}")
+
+        print(f"  Completed {len(results)}/{len(self.sizes)} sizes")
+        print()
+        return results
+
+    def _build_loop(self, base_port, cuda_flag):
+        a = self.args
+        sizes_str = " ".join(str(s) for s in self.sizes)
+        target = "127.0.0.1" if self.host0.is_local else a.master_ip
+        total = len(self.sizes)
+
+        common = f"--report_gbits --CPU-freq -n {a.iterations}"
+        srv_flags = f"-x {a.gid0} {common} -d {a.nic0}"
+        cli_flags = f"-x {a.gid1} {common} -d {a.nic1}"
+        for flag in [a.ipv6_flag, cuda_flag]:
+            if flag:
+                srv_flags += f" {flag}"
+                cli_flags += f" {flag}"
+
+        results_file = f"{REMOTE_DIR}/ib_results.txt"
+
+        # Server: suppress all output (it's only useful for debugging via bg log).
+        server_loop = (
+            f"P={base_port}; for S in {sizes_str}; do"
+            f" {self.binary_path} {srv_flags} -p $P -s $S 2>&1;"
+            f" P=$((P+1)); done"
+        )
+        # Client: tee raw output to results file for parsing, but only display
+        # the data line (starts with whitespace+digits) to keep console clean.
+        # Retries each size up to 5 times to handle server-not-ready.
+        ib_cmd = f"{self.binary_path} {cli_flags}"
+        # rm at the start clears stale results within the same sush2 session.
+        client_loop = (
+            f"rm -f {results_file};"
+            f" set -o pipefail; P={base_port}; I=0; for S in {sizes_str}; do"
+            f" I=$((I+1));"
+            f' echo "  [$I/{total}] size=$S ...";'
+            f" for RETRY in 1 2 3 4 5; do"
+            f" sleep {IB_PER_SIZE_DELAY};"
+            f" {ib_cmd} -p $P -s $S {target} 2>&1"
+            f" | tee -a {results_file}"
+            f" | grep -E '^\\s+[0-9]';"
+            f" RC=${{PIPESTATUS[0]}}; [ $RC -eq 0 ] && break;"
+            f' echo "    retry $RETRY/5 ...";'
+            f" done;"
+            f" [ $RC -eq 0 ] && echo '    ok' || echo \"    FAILED (rc=$RC)\";"
+            f" P=$((P+1)); done"
+        )
+        return server_loop, client_loop
+
+    @staticmethod
+    def _parse_bw(output, size):
+        if not output:
+            return None
+        unit_is_mb = "BW average[MB/sec]" in output
+        for line in output.splitlines():
+            m = re.match(r"\s*(\d+)\s+", line)
+            if m and int(m.group(1)) == size:
+                cols = line.split()
+                if len(cols) >= 4:
+                    try:
+                        raw = float(cols[3])
+                        return raw / 1024.0 if unit_is_mb else raw / 8.0
+                    except ValueError:
+                        pass
+        return None
+
+
+def _fmt(val, decimals=2):
+    return f"{val:.{decimals}f}" if val is not None else "N/A"
+
+
+def print_table(tool, sizes, uniflow_results, ib_results):
+    print()
+    print("=" * 60)
+    print("  Results")
+    print("=" * 60)
+
+    if tool == "uniflow":
+        print(
+            f"| {'Size':<11} | {'BW (GB/s)':>9}"
+            f" | {'Avg (us)':>10} | {'P50 (us)':>10} | {'P99 (us)':>10} |"
+        )
+        print(f"|{'-' * 13}|{'-' * 11}|{'-' * 12}|{'-' * 12}|{'-' * 12}|")
+        for size in sizes:
+            r = uniflow_results.get(size, {})
+            print(
+                f"| {format_size(size):<11} | {_fmt(r.get('bw')):>9}"
+                f" | {_fmt(r.get('avg_us'), 1):>10}"
+                f" | {_fmt(r.get('p50_us'), 1):>10}"
+                f" | {_fmt(r.get('p99_us'), 1):>10} |"
+            )
+
+    elif tool == "ib":
+        print(f"| {'Size':<11} | {'BW (GB/s)':>9} |")
+        print(f"|{'-' * 13}|{'-' * 11}|")
+        for size in sizes:
+            print(f"| {format_size(size):<11} | {_fmt(ib_results.get(size)):>9} |")
+
+    elif tool == "both":
+        print(
+            f"| {'Size':<11} | {'uniflow':>9}"
+            f" | {'ib_write_bw':>11} | {'Gap':>6}"
+            f" | {'Avg (us)':>10} | {'P99 (us)':>10} |"
+        )
+        print(f"|{'-' * 13}|{'-' * 11}|{'-' * 13}|{'-' * 8}|{'-' * 12}|{'-' * 12}|")
+        for size in sizes:
+            ur = uniflow_results.get(size, {})
+            uf = ur.get("bw")
+            ib = ib_results.get(size)
+
+            if uf is not None and ib is not None and ib > 0:
+                gap_pct = (ib - uf) / ib * 100
+                gap_s = "*" if gap_pct > 50 else f"{gap_pct:.1f}%"
+            else:
+                gap_s = "N/A"
+
+            print(
+                f"| {format_size(size):<11} | {_fmt(uf):>9}"
+                f" | {_fmt(ib):>11} | {gap_s:>6}"
+                f" | {_fmt(ur.get('avg_us'), 1):>10}"
+                f" | {_fmt(ur.get('p99_us'), 1):>10} |"
+            )
+
+        print()
+        print("  Gap = (ib - uniflow) / ib. (*) = gap > 50% (small-message overhead).")
+        print("  BW in GB/s. Latency from uniflow.")
+
+    print()
+
+
+def _parse_nics(nics_str):
+    parts = [n.strip() for n in nics_str.split(",") if n.strip()]
+    if not parts:
+        return "", ""
+    nic0 = parts[0]
+    nic1 = parts[1] if len(parts) > 1 else nic0
+    for n in (nic0, nic1):
+        if not re.match(r"^[a-zA-Z0-9_-]+$", n):
+            sys.exit(f"ERROR: Invalid NIC name: {n!r}")
+    return nic0, nic1
+
+
+def _setup_hosts(args):
+    """Batched remote setup: 1 SSH call per host to avoid MaxStartups throttling."""
+    hosts = {}
+
+    h0 = RemoteHost(args.host0)
+    print(f"Setting up {h0.hostname}...")
+    nic_override = args.nic0 if args.nics else ""
+    info0 = h0.setup_primary(nic_override=nic_override)
+
+    if not args.gpu:
+        args.gpu = match_gpu(info0.get("GPU", ""))
+        if not args.gpu:
+            sys.exit(
+                f"ERROR: Could not auto-detect GPU on {h0.hostname}"
+                f" (nvidia-smi returned: {info0.get('GPU', '')!r}). Specify --gpu"
+            )
+
+    if not args.nics:
+        nic_raw = info0.get("NIC", "")
+        args.nic0 = nic_raw.split()[0] if nic_raw.split() else ""
+        if not args.nic0:
+            sys.exit(f"ERROR: No RDMA NIC found on {h0.hostname}. Specify --nics")
+        args.nic1 = args.nic0
+
+    args.master_ip = info0.get("IP", "")
+    if not args.master_ip:
+        sys.exit(f"ERROR: Could not resolve IP for {h0.hostname}")
+    args.gid0 = info0.get("GID", "3")
+    args.ipv6_flag = "--ipv6-addr" if ":" in args.master_ip else ""
+
+    print(f"  GPU: {args.gpu}, NIC: {args.nic0}, IP: {args.master_ip}")
+
+    hosts[args.host0] = h0
+    has_bins_all = dict.fromkeys(info0["has_bins"], True)
+
+    if args.host1 != args.host0:
+        h1 = RemoteHost(args.host1)
+        print(f"Setting up {h1.hostname}...")
+        info1 = h1.setup_secondary(nic=args.nic1)
+        args.gid1 = info1.get("GID", "3")
+        hosts[args.host1] = h1
+        for name in ("uniflow_bench", "ib_write_bw"):
+            if name not in info1["has_bins"]:
+                has_bins_all.pop(name, None)
+    else:
+        args.gid1 = args.gid0
+
+    print(
+        f"  GID: {args.host0}/{args.nic0}={args.gid0},"
+        f" {args.host1}/{args.nic1}={args.gid1}"
+    )
+
+    args._hosts = hosts
+    args._has_remote_bins = has_bins_all
+
+
+def _copy_binaries(args, benchmarks):
+    force = args.force_copy or ""
+    has = args._has_remote_bins
+    hosts = list(args._hosts.values())
+
+    to_copy = []
+    for b in benchmarks:
+        need = b.binary_name not in has
+        if force in ("both", b.name):
+            need = True
+        if need:
+            to_copy.append(b)
+        else:
+            print(f"  {b.binary_name}: already on remote (--force-copy to re-copy)")
+
+    if not to_copy:
+        return
+
+    print("  Copying binaries to remote hosts...")
+    for host in hosts:
+        for i, b in enumerate(to_copy):
+            if i > 0:
+                _log(f"sleeping {SSH_THROTTLE_DELAY}s to avoid SSH throttling")
+                time.sleep(SSH_THROTTLE_DELAY)
+            host.copy_to(b.local_binary_path, b.binary_name)
+        _log(f"sleeping {SSH_THROTTLE_DELAY}s to avoid SSH throttling")
+        time.sleep(SSH_THROTTLE_DELAY)
+        host.verify_and_chmod([b.binary_name for b in to_copy])
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(
+        description="Compare uniflow RDMA bandwidth against ib_write_bw (perftest)",
+    )
+    parser.add_argument(
+        "--hosts",
+        default="",
+        help="Comma-separated hostnames (1 = intra-host remote, 2 = inter-host)",
+    )
+    parser.add_argument(
+        "--gpu",
+        default="",
+        help="GPU type: h100 or b200 (default: auto-detect)",
+    )
+    parser.add_argument(
+        "--nics",
+        default="",
+        help="RDMA device(s), comma-separated if different per rank"
+        " (default: auto-detect)",
+    )
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=10000,
+        help="Iterations per size (default: 10000)",
+    )
+    parser.add_argument(
+        "--min-size",
+        type=int,
+        default=1,
+        help="Min message size, must be power of 2 (default: 1)",
+    )
+    parser.add_argument(
+        "--max-size",
+        type=int,
+        default=1073741824,
+        help="Max message size, must be power of 2 (default: 1 GiB)",
+    )
+    parser.add_argument(
+        "--warmup", type=int, default=10, help="Warmup iterations (default: 10)"
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=1,
+        help="Number of requests per transport call (default: 1)",
+    )
+    parser.add_argument(
+        "--tx-depth",
+        type=int,
+        default=128,
+        help="Outstanding transport calls before waiting (default: 128)",
+    )
+    parser.add_argument(
+        "--num-nics",
+        type=int,
+        default=0,
+        help="Cap number of NICs to use, 0 = all (default: 0)",
+    )
+    parser.add_argument(
+        "--chunk-size",
+        type=int,
+        default=524288,
+        help="RDMA transfer chunk size in bytes (default: 524288)",
+    )
+    parser.add_argument(
+        "--no-cuda",
+        action="store_true",
+        help="Use CPU memory instead of GPU Direct RDMA (default: GPU Direct)",
+    )
+    parser.add_argument(
+        "--tool",
+        default="uniflow",
+        choices=["uniflow", "ib", "both"],
+        help="Which tool(s) to run (default: uniflow)",
+    )
+    parser.add_argument(
+        "--rebuild",
+        action="store_true",
+        help="Force rebuild of binaries even if cached",
+    )
+    parser.add_argument(
+        "--force-copy",
+        default="",
+        nargs="?",
+        const="both",
+        choices=["uniflow", "ib", "both"],
+        help="Force re-copy binaries: uniflow | ib | both (default: both)",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Log every command to stderr for debugging",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print benchmark commands without executing them",
+    )
+    parser.add_argument(
+        "--save-csv",
+        default="",
+        help="Save raw uniflow CSV results to this path",
+    )
+    args = parser.parse_args()
+
+    global _verbose
+    _verbose = args.verbose
+    args.use_cuda = not args.no_cuda
+
+    if args.hosts:
+        parts = [h.strip() for h in args.hosts.split(",") if h.strip()]
+        if not parts:
+            sys.exit("ERROR: --hosts value is empty")
+        for h in parts:
+            if not re.match(r"^[a-zA-Z0-9._-]+$", h):
+                sys.exit(f"ERROR: Invalid hostname: {h!r}")
+        args.host0 = parts[0]
+        args.host1 = parts[1] if len(parts) > 1 else parts[0]
+        args.mode = "inter-host" if len(parts) > 1 else "intra-host-remote"
+    else:
+        args.host0 = args.host1 = "localhost"
+        args.mode = "intra-host-local"
+
+    if args.nics:
+        args.nic0, args.nic1 = _parse_nics(args.nics)
+
+    return args
+
+
+def _setup_local(args):
+    local = RemoteHost("localhost")
+    if not args.gpu:
+        raw = local.run(
+            "nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | head -1"
+        )
+        args.gpu = match_gpu(raw)
+        if not args.gpu:
+            sys.exit("ERROR: Could not auto-detect GPU. Specify --gpu")
+    if not args.nics:
+        raw = local.run(
+            "ibstat -l 2>/dev/null | head -1"
+            " || ls /sys/class/infiniband/ 2>/dev/null | head -1"
+        )
+        args.nic0 = raw.split()[0] if raw.split() else ""
+        if not args.nic0:
+            sys.exit("ERROR: No RDMA NIC found. Specify --nics")
+        args.nic1 = args.nic0
+    args.master_ip = "127.0.0.1"
+    args.gid0 = args.gid1 = "0"
+    args.ipv6_flag = ""
+    args._hosts = {"localhost": local}
+    args._has_remote_bins = {}
+
+
+def _create_benchmarks(args, sizes, host0, rank1_host):
+    binary_names = []
+    if args.tool in ("uniflow", "both"):
+        binary_names.append("uniflow_bench")
+    if args.tool in ("ib", "both"):
+        binary_names.append("ib_write_bw")
+
+    print()
+    local_bins = {}
+    for name in binary_names:
+        local_bins[name] = build_binary(name, args.gpu, rebuild=args.rebuild)
+
+    benchmarks = []
+    if args.tool in ("uniflow", "both"):
+        benchmarks.append(UniflowBenchmark(args, sizes, host0, rank1_host))
+    if args.tool in ("ib", "both"):
+        benchmarks.append(IbWriteBwBenchmark(args, sizes, host0, rank1_host))
+
+    for b in benchmarks:
+        b.local_binary_path = local_bins[b.binary_name]
+
+    if args.mode == "intra-host-local":
+        os.makedirs(REMOTE_DIR, exist_ok=True)
+        for b in benchmarks:
+            b.binary_path = b.local_binary_path
+    else:
+        _copy_binaries(args, benchmarks)
+
+    return benchmarks
+
+
+def _print_config(args, sizes):
+    print()
+    print("=" * 60)
+    print(f"  RDMA Bandwidth Benchmark (tool: {args.tool})")
+    print("=" * 60)
+    print(f"  Mode:       {args.mode}")
+    if args.mode == "intra-host-local":
+        print("  Host:       localhost")
+    else:
+        print(f"  Rank 0:     {args.host0} ({args.master_ip})")
+        print(f"  Rank 1:     {args.rank1_host}")
+    print(f"  GPU:        {args.gpu}")
+    nic_str = args.nic0
+    if args.nic1 != args.nic0:
+        nic_str += f", {args.nic1}"
+    print(f"  NICs:       {nic_str}")
+    print(
+        f"  Sizes:      {format_size(sizes[0])} - {format_size(sizes[-1])}"
+        f" ({len(sizes)} steps)"
+    )
+    print(f"  Iterations: {args.iterations}")
+    print(f"  Batch size: {args.batch_size}")
+    print(f"  TX depth:   {args.tx_depth}")
+    if args.num_nics > 0:
+        print(f"  Num NICs:   {args.num_nics}")
+    if args.use_cuda:
+        print("  Memory:     GPU 0 (GPU Direct)")
+    else:
+        print("  Memory:     CPU (DRAM)")
+    print("=" * 60)
+    print()
+
+
+def _run_benchmarks(args, benchmarks):
+    all_results = {}
+    for b in benchmarks:
+        all_results[b.name] = b.run(dry_run=args.dry_run)
+    return all_results
+
+
+def main():
+    args = _parse_args()
+
+    if args.mode == "intra-host-local":
+        _setup_local(args)
+    else:
+        _setup_hosts(args)
+
+    if args.mode == "inter-host":
+        args.rank1_host = args.host1
+        args.rank1_local_rank = 0
+    else:
+        args.rank1_host = args.host0
+        args.rank1_local_rank = 1
+
+    host0 = args._hosts[args.host0]
+    rank1_host = args._hosts[args.rank1_host]
+
+    def _cleanup():
+        for h in args._hosts.values():
+            h.cleanup()
+
+    atexit.register(_cleanup)
+    signal.signal(signal.SIGINT, lambda s, f: (_cleanup(), sys.exit(130)))
+    signal.signal(signal.SIGTERM, lambda s, f: (_cleanup(), sys.exit(143)))
+
+    sizes = generate_sizes(args.min_size, args.max_size)
+    benchmarks = _create_benchmarks(args, sizes, host0, rank1_host)
+    _print_config(args, sizes)
+    all_results = _run_benchmarks(args, benchmarks)
+
+    if args.dry_run:
+        print("(dry run — no commands were executed)")
+        return
+
+    print_table(
+        args.tool,
+        sizes,
+        all_results.get("uniflow", {}),
+        all_results.get("ib_write_bw", {}),
+    )
+
+    _cleanup()
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/comms/uniflow/benchmarks/scripts/generate_comparison.py
+++ b/comms/uniflow/benchmarks/scripts/generate_comparison.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+#
+# Generate comparison tables from uniflow CSV results and ib_write_bw baseline.
+#
+# Usage:
+#   python3 generate_comparison.py <results_dir> [--ib-baseline <path>]
+#
+# Examples:
+#   # Use ib_write_bw baseline from a results.log in the same directory
+#   python3 generate_comparison.py ~/me/benchmarks/rdma/gb200/inter-host-per-nic-buf
+#
+#   # Use ib_write_bw baseline from a different directory
+#   python3 generate_comparison.py ~/me/benchmarks/rdma/gb200/inter-host-per-nic-buf \
+#       --ib-baseline ~/me/benchmarks/rdma/gb200/inter-host/chunk_512KB/results.log
+#
+# Expects directory structure:
+#   <results_dir>/
+#     chunk_512KB/results.csv
+#     chunk_1MB/results.csv
+#     chunk_2MB/results.csv
+#     chunk_4MB/results.csv
+#
+# Outputs results.log (comparison table) next to each results.csv.
+
+import argparse
+import csv
+import os
+import re
+import sys
+
+
+def format_size(n):
+    if n >= 1 << 30:
+        return f"{n >> 30} GB"
+    if n >= 1 << 20:
+        return f"{n >> 20} MB"
+    if n >= 1 << 10:
+        return f"{n >> 10} KB"
+    return f"{n} B"
+
+
+def fmt(v, d=2):
+    return f"{v:.{d}f}" if v is not None else "N/A"
+
+
+def parse_uniflow_csv(path):
+    results = {}
+    with open(path) as f:
+        for row in csv.DictReader(f):
+            try:
+                size = int(row["size_bytes"])
+                results[size] = {
+                    "bw": float(row["bw_gbps"]),
+                    "avg_us": float(row.get("lat_avg_us", 0)),
+                    "p50_us": float(row.get("lat_p50_us", 0)),
+                    "p99_us": float(row.get("lat_p99_us", 0)),
+                }
+            except (ValueError, KeyError):
+                continue
+    return results
+
+
+_SIZE_MULT = {"B": 1, "KB": 1024, "MB": 1 << 20, "GB": 1 << 30}
+
+
+def _parse_comparison_table(content):
+    """Parse ib_write_bw column from a '| Size | uniflow | ib_write_bw |' table."""
+    results = {}
+    in_table = False
+    for line in content.splitlines():
+        if line.startswith("| Size"):
+            in_table = True
+            continue
+        if not in_table:
+            continue
+        if line.startswith("|---"):
+            continue
+        if not line.startswith("|"):
+            break
+        cols = [c.strip() for c in line.strip().strip("|").split("|")]
+        if len(cols) < 3:
+            continue
+        parts = cols[0].strip().split()
+        if len(parts) != 2:
+            continue
+        try:
+            size = int(float(parts[0]) * _SIZE_MULT.get(parts[1], 1))
+            results[size] = float(cols[2])
+        except ValueError:
+            pass
+    return results
+
+
+def _parse_perftest_output(content):
+    """Parse raw ib_write_bw output (size in col 0, BW average in col 3)."""
+    results = {}
+    unit_is_mb = "BW average[MB/sec]" in content
+    for line in content.splitlines():
+        if not re.match(r"\s*\d+\s+", line):
+            continue
+        cols = line.split()
+        if len(cols) < 4:
+            continue
+        try:
+            size = int(cols[0])
+            raw = float(cols[3])
+            results[size] = raw / 1024.0 if unit_is_mb else raw / 8.0
+        except ValueError:
+            pass
+    return results
+
+
+def parse_ib_from_log(path):
+    """Extract ib_write_bw bandwidth from a log file.
+
+    Tries comparison table format first, falls back to raw perftest output.
+    """
+    with open(path) as f:
+        content = f.read()
+    return _parse_comparison_table(content) or _parse_perftest_output(content)
+
+
+def generate_table(uniflow, ib_results, sizes):
+    lines = []
+    lines.append(
+        f"| {'Size':<11} | {'uniflow':>9}"
+        f" | {'ib_write_bw':>11} | {'Gap':>6}"
+        f" | {'Avg (us)':>10} | {'P99 (us)':>10} |"
+    )
+    lines.append(f"|{'-' * 13}|{'-' * 11}|{'-' * 13}|{'-' * 8}|{'-' * 12}|{'-' * 12}|")
+
+    for size in sizes:
+        ur = uniflow.get(size, {})
+        uf = ur.get("bw")
+        ib = ib_results.get(size)
+
+        if uf is not None and ib is not None and ib > 0:
+            gap_pct = (ib - uf) / ib * 100
+            gap_s = "*" if gap_pct > 50 else f"{gap_pct:.1f}%"
+        else:
+            gap_s = "N/A"
+
+        lines.append(
+            f"| {format_size(size):<11} | {fmt(uf):>9}"
+            f" | {fmt(ib):>11} | {gap_s:>6}"
+            f" | {fmt(ur.get('avg_us'), 1):>10}"
+            f" | {fmt(ur.get('p99_us'), 1):>10} |"
+        )
+
+    lines.append("")
+    lines.append("  Gap = (ib - uniflow) / ib. Negative = uniflow faster (dual-NIC).")
+    lines.append("  BW in GB/s. Latency from uniflow.")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def find_ib_baseline(results_dir):
+    """Search for an existing results.log with ib_write_bw data."""
+    for chunk in ["chunk_512KB", "chunk_1MB", "chunk_2MB", "chunk_4MB"]:
+        path = os.path.join(results_dir, chunk, "results.log")
+        if os.path.exists(path):
+            ib = parse_ib_from_log(path)
+            if ib:
+                return path, ib
+    # Try parent directory (e.g., inter-host/ has single-NIC baselines)
+    parent = os.path.dirname(results_dir.rstrip("/"))
+    for chunk in ["chunk_512KB", "chunk_1MB", "chunk_2MB", "chunk_4MB"]:
+        path = os.path.join(parent, chunk, "results.log")
+        if os.path.exists(path):
+            ib = parse_ib_from_log(path)
+            if ib:
+                return path, ib
+    return None, {}
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate comparison tables from uniflow CSV results"
+    )
+    parser.add_argument(
+        "results_dir",
+        help="Directory containing chunk_*/results.csv files",
+    )
+    parser.add_argument(
+        "--ib-baseline",
+        default="",
+        help="Path to results.log with ib_write_bw baseline"
+        " (default: auto-detect from results_dir or parent)",
+    )
+    args = parser.parse_args()
+
+    if args.ib_baseline:
+        ib_path = args.ib_baseline
+        ib_results = parse_ib_from_log(ib_path)
+    else:
+        ib_path, ib_results = find_ib_baseline(args.results_dir)
+
+    if ib_results:
+        print(f"Using ib_write_bw baseline from: {ib_path}")
+    else:
+        print("WARNING: No ib_write_bw baseline found. Gap column will show N/A.")
+
+    chunk_dirs = sorted(
+        d
+        for d in os.listdir(args.results_dir)
+        if d.startswith("chunk_")
+        and os.path.isfile(os.path.join(args.results_dir, d, "results.csv"))
+    )
+
+    if not chunk_dirs:
+        sys.exit(f"ERROR: No chunk_*/results.csv found in {args.results_dir}")
+
+    for chunk_dir in chunk_dirs:
+        csv_path = os.path.join(args.results_dir, chunk_dir, "results.csv")
+        out_path = os.path.join(args.results_dir, chunk_dir, "results.log")
+
+        uniflow = parse_uniflow_csv(csv_path)
+        if not uniflow:
+            print(f"  {chunk_dir}: empty CSV, skipping")
+            continue
+
+        sizes = sorted(uniflow.keys())
+        table = generate_table(uniflow, ib_results, sizes)
+
+        with open(out_path, "w") as f:
+            f.write(table + "\n")
+
+        peak_bw = max(r["bw"] for r in uniflow.values())
+        print(
+            f"  {chunk_dir}: {len(sizes)} sizes, peak {peak_bw:.1f} GB/s → {out_path}"
+        )
+
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/comms/uniflow/benchmarks/scripts/rdma_benchmark.sh
+++ b/comms/uniflow/benchmarks/scripts/rdma_benchmark.sh
@@ -1,0 +1,285 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+#
+# End-to-end RDMA benchmark: runs uniflow + ib_write_bw across multiple
+# chunk sizes and generates comparison tables.
+#
+# Usage:
+#   bash rdma_benchmark.sh --host0 <host> --host1 <host> [OPTIONS]
+#
+# Options:
+#   --host0 <host>       Rank 0 host (required)
+#   --host1 <host>       Rank 1 host (required)
+#   --output-dir <dir>   Results directory (default: ~/me/benchmarks/rdma/<gpu>/<mode>)
+#   --iterations <n>     Iterations per size (default: 500)
+#   --warmup <n>         Warmup iterations (default: 10)
+#   --min-size <n>       Min message size (default: 1)
+#   --max-size <n>       Max message size (default: 1073741824)
+#   --chunks <list>      Comma-separated chunk sizes in bytes (default: 524288,1048576,2097152,4194304)
+#   --batch-size <n>     Requests per transport call (default: 1)
+#   --tx-depth <n>       Outstanding transport calls before waiting (default: 128)
+#   --num-nics <n>       Cap number of NICs to use, 0 = all (default: 0)
+#   --rebuild            Force rebuild of binaries
+#   --force-copy         Force re-copy binaries to remote hosts
+#   --skip-ib            Skip ib_write_bw (uniflow only)
+#   --skip-uniflow       Skip uniflow (ib_write_bw only)
+#
+# Example:
+#   bash rdma_benchmark.sh --host0 rtptest2356.nha6 --host1 rtptest2357.nha6
+#   bash rdma_benchmark.sh --host0 rtptest2356.nha6 --host1 rtptest2357.nha6 --skip-ib
+#   bash rdma_benchmark.sh --host0 rtptest2356.nha6 --host1 rtptest2357.nha6 --rebuild --force-copy
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPARE_SCRIPT="${SCRIPT_DIR}/compare_rdma_bandwidth.py"
+COMPARISON_SCRIPT="${SCRIPT_DIR}/generate_comparison.py"
+
+HOST0=""
+HOST1=""
+OUTPUT_DIR=""
+ITERATIONS=500
+WARMUP=10
+MIN_SIZE=1
+MAX_SIZE=1073741824
+CHUNKS="524288,1048576,2097152,4194304"
+BATCH_SIZE=1
+TX_DEPTH=128
+NUM_NICS=0
+REBUILD=0
+FORCE_COPY=0
+SKIP_IB=0
+SKIP_UNIFLOW=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --host0)        HOST0="$2"; shift 2 ;;
+    --host1)        HOST1="$2"; shift 2 ;;
+    --output-dir)   OUTPUT_DIR="$2"; shift 2 ;;
+    --iterations)   ITERATIONS="$2"; shift 2 ;;
+    --warmup)       WARMUP="$2"; shift 2 ;;
+    --min-size)     MIN_SIZE="$2"; shift 2 ;;
+    --max-size)     MAX_SIZE="$2"; shift 2 ;;
+    --chunks)       CHUNKS="$2"; shift 2 ;;
+    --batch-size)   BATCH_SIZE="$2"; shift 2 ;;
+    --tx-depth)     TX_DEPTH="$2"; shift 2 ;;
+    --num-nics)     NUM_NICS="$2"; shift 2 ;;
+    --rebuild)      REBUILD=1; shift ;;
+    --force-copy)   FORCE_COPY=1; shift ;;
+    --skip-ib)      SKIP_IB=1; shift ;;
+    --skip-uniflow) SKIP_UNIFLOW=1; shift ;;
+    *)              echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+if [[ -z "${HOST0}" || -z "${HOST1}" ]]; then
+  echo "Usage: $0 --host0 <host> --host1 <host> [OPTIONS]"
+  exit 1
+fi
+
+# Parse chunk sizes
+IFS=',' read -ra CHUNK_SIZES <<< "${CHUNKS}"
+CHUNK_LABELS=()
+for cs in "${CHUNK_SIZES[@]}"; do
+  if [[ ${cs} -ge 1048576 ]]; then
+    CHUNK_LABELS+=("$((cs / 1048576))MB")
+  else
+    CHUNK_LABELS+=("$((cs / 1024))KB")
+  fi
+done
+
+# Determine mode
+if [[ "${HOST0}" == "${HOST1}" ]]; then
+  MODE="intra-host"
+else
+  MODE="inter-host"
+fi
+
+# Default output directory
+if [[ -z "${OUTPUT_DIR}" ]]; then
+  OUTPUT_DIR="${HOME}/me/benchmarks/rdma/${MODE}"
+fi
+
+ts() { date "+%H:%M:%S"; }
+
+echo "============================================================"
+echo "  RDMA Benchmark Suite"
+echo "============================================================"
+echo "  Host 0:     ${HOST0}"
+echo "  Host 1:     ${HOST1}"
+echo "  Mode:       ${MODE}"
+echo "  Chunks:     ${CHUNK_LABELS[*]}"
+echo "  Iterations: ${ITERATIONS}"
+echo "  Batch size: ${BATCH_SIZE}"
+echo "  TX depth:   ${TX_DEPTH}"
+[[ ${NUM_NICS} -gt 0 ]] && echo "  Num NICs:   ${NUM_NICS}"
+echo "  Sizes:      ${MIN_SIZE} - ${MAX_SIZE}"
+echo "  Output:     ${OUTPUT_DIR}"
+echo "============================================================"
+echo
+
+COMMON_ARGS=(
+  --hosts "${HOST0},${HOST1}"
+  --iterations "${ITERATIONS}"
+  --warmup "${WARMUP}"
+  --min-size "${MIN_SIZE}"
+  --max-size "${MAX_SIZE}"
+  --batch-size "${BATCH_SIZE}"
+  --tx-depth "${TX_DEPTH}"
+  --num-nics "${NUM_NICS}"
+)
+
+TOTAL=${#CHUNK_SIZES[@]}
+SWEEP_START=$(date +%s)
+
+# ── Phase 1: Uniflow ────────────────────────────────────────
+
+if [[ ${SKIP_UNIFLOW} -eq 0 ]]; then
+  echo "[$(ts)] Phase 1: Uniflow benchmarks"
+  echo
+
+  for i in "${!CHUNK_SIZES[@]}"; do
+    cs="${CHUNK_SIZES[$i]}"
+    label="${CHUNK_LABELS[$i]}"
+    chunk_dir="${OUTPUT_DIR}/chunk_${label}"
+    mkdir -p "${chunk_dir}"
+
+    echo "[$(ts)] [$(( i + 1 ))/${TOTAL}] uniflow chunk_${label}..."
+
+    # --rebuild and --force-copy only on first chunk
+    EXTRA=()
+    if [[ ${i} -eq 0 ]]; then
+      [[ ${REBUILD} -eq 1 ]] && EXTRA+=(--rebuild)
+      [[ ${FORCE_COPY} -eq 1 ]] && EXTRA+=(--force-copy)
+    fi
+
+    # Retry up to 3 times per chunk
+    for attempt in 1 2 3; do
+      python3 "${COMPARE_SCRIPT}" \
+        --chunk-size "${cs}" \
+        --tool uniflow \
+        --save-csv "${chunk_dir}/results.csv" \
+        "${COMMON_ARGS[@]}" \
+        ${EXTRA[@]+"${EXTRA[@]}"} \
+        2>&1 | tee "${chunk_dir}/uniflow.log"
+      rc=${PIPESTATUS[0]}
+
+      if [[ ${rc} -eq 0 ]]; then
+        echo "[$(ts)] uniflow chunk_${label}: OK"
+        break
+      fi
+
+      if [[ ${attempt} -lt 3 ]]; then
+        echo "[$(ts)] uniflow chunk_${label}: FAILED (attempt ${attempt}/3), retrying in 30s..."
+        sleep 30
+      else
+        echo "[$(ts)] uniflow chunk_${label}: FAILED after 3 attempts"
+      fi
+    done
+    echo
+  done
+fi
+
+# ── Phase 2: ib_write_bw ───────────────────────────────────
+
+if [[ ${SKIP_IB} -eq 0 ]]; then
+  echo "[$(ts)] Phase 2: ib_write_bw baseline (single run, chunk-size independent)"
+  echo "[$(ts)] Waiting 30s for SSH cooldown..."
+  sleep 30
+  echo
+
+  ib_log="${OUTPUT_DIR}/ib_baseline.log"
+
+  for attempt in 1 2 3; do
+    python3 "${COMPARE_SCRIPT}" \
+      --chunk-size "${CHUNK_SIZES[0]}" \
+      --tool ib \
+      "${COMMON_ARGS[@]}" \
+      2>&1 | tee "${ib_log}"
+    rc=${PIPESTATUS[0]}
+
+    if [[ ${rc} -eq 0 ]]; then
+      echo "[$(ts)] ib_write_bw: OK"
+      break
+    fi
+
+    if [[ ${attempt} -lt 3 ]]; then
+      echo "[$(ts)] ib_write_bw: FAILED (attempt ${attempt}/3), retrying in 30s..."
+      sleep 30
+    else
+      echo "[$(ts)] ib_write_bw: FAILED after 3 attempts"
+    fi
+  done
+  echo
+fi
+
+# ── Phase 3: Comparison tables ──────────────────────────────
+
+echo "[$(ts)] Phase 3: Generating comparison tables..."
+
+# Find the ib_write_bw baseline
+IB_BASELINE="${OUTPUT_DIR}/ib_baseline.log"
+if [[ ! -f "${IB_BASELINE}" ]]; then
+  # Fall back to results.log from previous runs
+  IB_BASELINE=""
+  for label in "${CHUNK_LABELS[@]}"; do
+    candidate="${OUTPUT_DIR}/chunk_${label}/results.log"
+    if [[ -f "${candidate}" ]] && grep -q "ib_write_bw" "${candidate}" 2>/dev/null; then
+      IB_BASELINE="${candidate}"
+      break
+    fi
+  done
+fi
+
+if [[ -n "${IB_BASELINE}" ]]; then
+  python3 "${COMPARISON_SCRIPT}" "${OUTPUT_DIR}" --ib-baseline "${IB_BASELINE}"
+else
+  python3 "${COMPARISON_SCRIPT}" "${OUTPUT_DIR}"
+fi
+
+# ── Summary ─────────────────────────────────────────────────
+
+SWEEP_END=$(date +%s)
+ELAPSED=$(( SWEEP_END - SWEEP_START ))
+
+echo
+echo "============================================================"
+echo "  Benchmark Complete"
+echo "============================================================"
+printf "  Total time: %dh %dm %ds\n" $((ELAPSED/3600)) $(((ELAPSED%3600)/60)) $((ELAPSED%60))
+echo "  Results:     ${OUTPUT_DIR}"
+echo
+[[ -f "${OUTPUT_DIR}/ib_baseline.log" ]] && echo "  ib baseline: ib_baseline.log"
+echo "  Files per chunk:"
+for label in "${CHUNK_LABELS[@]}"; do
+  dir="${OUTPUT_DIR}/chunk_${label}"
+  echo -n "    chunk_${label}: "
+  files=()
+  [[ -f "${dir}/results.csv" ]] && files+=("results.csv")
+  [[ -f "${dir}/results.log" ]] && files+=("results.log")
+  [[ -f "${dir}/uniflow.log" ]] && files+=("uniflow.log")
+  echo "${files[*]}"
+done
+
+# Print the best chunk's comparison table
+BEST_CHUNK=""
+BEST_BW=0
+for label in "${CHUNK_LABELS[@]}"; do
+  csv="${OUTPUT_DIR}/chunk_${label}/results.csv"
+  if [[ -f "${csv}" ]]; then
+    bw=$(tail -1 "${csv}" | cut -d, -f9)
+    if [[ -n "${bw}" ]] && python3 -c "exit(0 if float('${bw}') > float('${BEST_BW}') else 1)" 2>/dev/null; then
+      BEST_BW="${bw}"
+      BEST_CHUNK="${label}"
+    fi
+  fi
+done
+
+if [[ -n "${BEST_CHUNK}" && -f "${OUTPUT_DIR}/chunk_${BEST_CHUNK}/results.log" ]]; then
+  echo
+  echo "  Best chunk: ${BEST_CHUNK} (peak ${BEST_BW} GB/s)"
+  echo
+  cat "${OUTPUT_DIR}/chunk_${BEST_CHUNK}/results.log"
+fi
+
+echo "============================================================"

--- a/comms/uniflow/transport/Topology.cpp
+++ b/comms/uniflow/transport/Topology.cpp
@@ -1230,6 +1230,58 @@ bool Topology::filterNic(int nicIndex, const NicFilter& filter) const {
   return filter.matches(nodes_[nicNodeIds_[nicIndex]].name);
 }
 
+std::vector<std::string> Topology::selectCpuNics(
+    const NicFilter& filter) const {
+  int count = static_cast<int>(nicCount());
+  std::vector<std::string> nics;
+  PathType bestType = PathType::DIS;
+  uint32_t maxBw = 0;
+  for (int i = 0; i < count; ++i) {
+    if (!filterNic(i, filter)) {
+      continue;
+    }
+    const auto& nicNode = getNicNode(i);
+    const auto& numaNode =
+        getCpuNode(std::get<TopoNode::NicData>(nicNode.data).numaNode);
+    const auto& path = getPath(numaNode.id, nicNode.id, {.allowC2C = true});
+    if (path.type < bestType || (path.type == bestType && path.bw > maxBw)) {
+      nics.clear();
+      nics.push_back(nicNode.name);
+      bestType = path.type;
+      maxBw = path.bw;
+    } else if (path.type == bestType && path.bw == maxBw) {
+      nics.push_back(nicNode.name);
+    }
+  }
+  return nics;
+}
+
+std::vector<std::string> Topology::selectGpuNics(
+    int cudaDeviceId,
+    const NicFilter& filter) const {
+  const auto& gpuNode = getGpuNode(cudaDeviceId);
+  int count = static_cast<int>(nicCount());
+  std::vector<std::string> nics;
+  PathType bestType = PathType::DIS;
+  uint32_t maxBw = 0;
+  for (int i = 0; i < count; ++i) {
+    if (!filterNic(i, filter)) {
+      continue;
+    }
+    const auto& nicNode = getNicNode(i);
+    const auto& path = getPath(gpuNode.id, nicNode.id, {.allowC2C = true});
+    if (path.type < bestType || (path.type == bestType && path.bw > maxBw)) {
+      nics.clear();
+      nics.push_back(nicNode.name);
+      bestType = path.type;
+      maxBw = path.bw;
+    } else if (path.type == bestType && path.bw == maxBw) {
+      nics.push_back(nicNode.name);
+    }
+  }
+  return nics;
+}
+
 // --- NicFilter ---
 
 NicFilter::NicFilter(std::string_view filterStr) {

--- a/comms/uniflow/transport/Topology.h
+++ b/comms/uniflow/transport/Topology.h
@@ -200,6 +200,20 @@ class Topology {
   /// Check if a NIC passes the given filter.
   bool filterNic(int nicIndex, const NicFilter& filter) const;
 
+  // --- NIC selection ---
+
+  /// Select NICs with the best path from their own NUMA node, filtered by
+  /// NicFilter. Returns multiple NICs when they share the same best path
+  /// type and bandwidth.
+  std::vector<std::string> selectCpuNics(const NicFilter& filter = {}) const;
+
+  /// Select NICs closest to the given GPU, filtered by NicFilter.
+  /// Returns multiple NICs when they share the same best path (e.g. GB200:
+  /// 2 NICs per GPU).
+  std::vector<std::string> selectGpuNics(
+      int cudaDeviceId,
+      const NicFilter& filter = {}) const;
+
   friend class TopologyTest;
 
  private:


### PR DESCRIPTION
Summary:
Three scripts for running, comparing, and reporting uniflow RDMA bandwidth benchmarks against ib_write_bw (perftest). Updated with `--tx-depth`, `--num-nics`, and `--batch-size` defaults from D100917507.

## Scripts

**`compare_rdma_bandwidth.py`** — Core benchmark runner. Sets up remote hosts, builds/copies binaries, runs uniflow and/or ib_write_bw, collects results, and prints a comparison table. Designed to minimize SSH calls (6 per run) to avoid MaxStartups throttling.

Key features:
- `RemoteHost` class encapsulates all sush2 interactions with retry logic
- Batched setup: GPU/NIC/IP/GID detection + stale process cleanup in a single base64-encoded bash script per host (avoids quoting issues)
- Binary caching: stable remote dir (`/tmp/uniflow_compare/`), skips copy when binaries already present (`--force-copy` to override)
- Random MASTER_PORT to prevent stale port conflicts between runs
- Stale CSV validation: checks chunk_size in retrieved CSV matches expected value
- Graceful cleanup: SIGTERM → 5s grace → SIGKILL on background processes

**`rdma_benchmark.sh`** — End-to-end orchestrator. Runs uniflow for all chunk sizes (phase 1), then ib_write_bw baseline (phase 2, single run since ib_write_bw is chunk-size independent), then generates comparison tables (phase 3). Per-chunk retry with 30s SSH cooldown between phases.

**`generate_comparison.py`** — Offline comparison table generator. Reads uniflow CSV results and ib_write_bw baseline, produces a formatted comparison table per chunk size.

## Changes for tx-depth and num-nics (from D100917507)

**`compare_rdma_bandwidth.py`**
- Add `--tx-depth` arg (default 128) — passed to uniflow binary as `--tx-depth`
- Add `--num-nics` arg (default 0) — passed to uniflow binary as `--num-nics` when > 0
- Change `--batch-size` default from 128 to 1 (tx-depth replaces batching as the primary pipelining knob)
- Add batch_size, tx_depth, num_nics to config printout

**`rdma_benchmark.sh`**
- Add `--batch-size`, `--tx-depth`, `--num-nics` passthrough args (defaults: 1, 128, 0)
- Pass all three to `compare_rdma_bandwidth.py` via COMMON_ARGS
- Add to usage header and config display

## Usage

```bash
# End-to-end benchmark (recommended)
bash comms/uniflow/benchmarks/scripts/rdma_benchmark.sh \
    --host0 rtptest2356.nha6 --host1 rtptest2357.nha6

# Single chunk, single NIC, tx-depth 128
python3 comms/uniflow/benchmarks/scripts/compare_rdma_bandwidth.py \
    --hosts rtptest2356.nha6,rtptest2357.nha6 \
    --iterations 3000 --warmup 10 --min-size 1 --max-size 1073741824 \
    --chunk-size 524288 --batch-size 1 --tx-depth 128 --num-nics 1 \
    --tool uniflow --rebuild --force-copy
```

## SSH Call Budget

Per `compare_rdma_bandwidth.py` invocation (cached binaries):

| Phase | Calls |
|-------|-------|
| Setup host0 (base64 script) | 1 sush2 |
| Setup host1 (base64 script) | 1 sush2 |
| Uniflow rank1 bg | 1 sush2 |
| Uniflow rank0 (rm + benchmark) | 1 sush2 |
| CSV retrieval | 1 sush2 (cat) |
| ib_write_bw server bg | 1 sush2 |
| ib_write_bw client (rm + loop) | 1 sush2 |
| ib_write_bw results (cat) | 1 sush2 |
| **Total** | **8** (uniflow only: 5) |

Investigation doc: https://docs.google.com/document/d/1fGwwnVXsvbBCSHenjgpBZoFKVeT2_mTPWqy191K3epM/edit
Benchmark spreadsheet: https://docs.google.com/spreadsheets/d/1jjxHUXHPRaug83BOybyDhjZ0eYi-weK1Gz6g4HSUwxo/edit

## Quality Scorecard

| Dimension | Score | Assessment |
|-----------|-------|------------|
| Design | 8/10 | Clean OOP (RemoteHost, UniflowBenchmark, IbWriteBwBenchmark), SSH call budget minimized |
| Implementation | 8/10 | CSV field index fixed, base64 setup, retry logic, stale CSV validation |
| Test Coverage | 3/10 | No automated tests — manual remote testing only |
| Simplicity | 7/10 | compare script ~1050 lines but well-structured |
| Design Patterns | 8/10 | Strategy pattern for benchmarks, RAII cleanup, builder for CLI flags |
| Understandability | 8/10 | Clear class names, SSH budget documented |
| Maintainability | 8/10 | New benchmark tool = new class with run() method |
| Debuggability | 8/10 | BG process logs, verbose mode, SSH retry logging |
| **Overall** | **7.5/10** | Test coverage and script size are gaps |

Reviewed By: tanquer

Differential Revision: D99169756


