### PR TITLE
Add block-scope wait operations for device window

### DIFF
--- a/comms/torchcomms/device/ncclx/NCCLDeviceBackend.cpp
+++ b/comms/torchcomms/device/ncclx/NCCLDeviceBackend.cpp
@@ -88,7 +88,12 @@ NCCLDeviceBackend::Ptr NCCLDeviceBackend::create_device_window(
   reqs.resourceRequirementsList =
       (signal_buffer_size > 0) ? &signal_resource_reqs : nullptr;
   reqs.teamRequirementsList = nullptr;
-  reqs.lsaMultimem = true;
+
+  // Mirror NCCL's internal gating (sym_kernels.cc): only request NVLS
+  // multicast when the LSA team has more than 2 members.  Without this
+  // check ncclDevCommCreate returns ncclInvalidArgument on topologies
+  // where multicast is unavailable (e.g. 1x2 configurations).
+  reqs.lsaMultimem = nccl_api->teamLsa(nccl_comm).nRanks > 2;
   reqs.barrierCount = config.barrier_count;
   reqs.lsaBarrierCount = config.barrier_count;
   reqs.railGinBarrierCount = config.barrier_count;

--- a/comms/torchcomms/device/ncclx/TorchCommDeviceNCCLX.cuh
+++ b/comms/torchcomms/device/ncclx/TorchCommDeviceNCCLX.cuh
@@ -509,6 +509,9 @@ TorchCommDeviceWindow<NCCLDeviceBackend>::get_nvlink_address(int peer) {
 template <>
 __device__ inline void*
 TorchCommDeviceWindow<NCCLDeviceBackend>::get_multimem_address(size_t offset) {
+  if (comm_.lsaMultimem.mcBasePtr == nullptr) {
+    return nullptr;
+  }
   return ncclGetLsaMultimemPointer(window_, offset, comm_);
 }
 

--- a/comms/torchcomms/ncclx/NcclxApi.cpp
+++ b/comms/torchcomms/ncclx/NcclxApi.cpp
@@ -664,6 +664,10 @@ ncclResult_t DefaultNcclxApi::winGetLsaMultimemDevicePointer(
   return ncclGetLsaMultimemDevicePointer(win, offset, outPtr);
 }
 #endif
+
+ncclTeam_t DefaultNcclxApi::teamLsa(ncclComm_t comm) {
+  return ncclTeamLsa(comm);
+}
 #endif // TORCHCOMMS_HAS_NCCL_DEVICE_API
 
 } // namespace torch::comms

--- a/comms/torchcomms/ncclx/NcclxApi.hpp
+++ b/comms/torchcomms/ncclx/NcclxApi.hpp
@@ -374,6 +374,9 @@ class NcclxApi {
       size_t offset,
       void** outPtr) = 0;
 #endif
+
+  // Get the LSA team info (rank count, local rank) for a communicator.
+  [[nodiscard]] virtual ncclTeam_t teamLsa(ncclComm_t comm) = 0;
 #endif
 
 #if defined(ENABLE_PIPES)
@@ -738,6 +741,8 @@ class DefaultNcclxApi : public NcclxApi {
       size_t offset,
       void** outPtr) override;
 #endif
+
+  [[nodiscard]] ncclTeam_t teamLsa(ncclComm_t comm) override;
 #endif
 
 #if defined(ENABLE_PIPES)

--- a/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.hpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.hpp
@@ -390,6 +390,8 @@ class NcclxMock : public NcclxApi {
       devCommDestroy,
       (ncclComm_t comm, const ncclDevComm_t* devComm),
       (override));
+
+  MOCK_METHOD(ncclTeam_t, teamLsa, (ncclComm_t comm), (override));
 #endif
 
 #if defined(ENABLE_PIPES)

--- a/comms/torchcomms/triton/device_window.cu
+++ b/comms/torchcomms/triton/device_window.cu
@@ -119,6 +119,34 @@ __device__ int torchcomms_barrier_block(void* win_ptr, int barrier_id) {
 }
 
 // =============================================================================
+// Block-scope Wait Operations
+//
+// Thread 0 polls the signal/counter; remaining threads synchronize via
+// __syncthreads__ (CoopScope::BLOCK → make_thread_group → group.sync()).
+// Reduces spin-poll traffic from N acquire loads per poll cycle
+// (thread-scope, N = blockDim.x) to 1 acquire load + 1 __syncthreads__.
+// =============================================================================
+
+__device__ int torchcomms_wait_signal_from_block(
+    void* win_ptr,
+    int peer,
+    int signal_id,
+    unsigned long long expected_value) {
+  auto* win = reinterpret_cast<DeviceWindow*>(win_ptr);
+  return win->wait_signal_from(
+      peer, signal_id, CmpOp::GE, expected_value, CoopScope::BLOCK);
+}
+
+__device__ int torchcomms_wait_counter_block(
+    void* win_ptr,
+    int counter_id,
+    unsigned long long expected_value) {
+  auto* win = reinterpret_cast<DeviceWindow*>(win_ptr);
+  return win->wait_counter(
+      counter_id, CmpOp::GE, expected_value, CoopScope::BLOCK);
+}
+
+// =============================================================================
 // Signal Operations (Remote Notification)
 // Thread-scope (idempotent)
 // =============================================================================

--- a/comms/torchcomms/triton/device_window.h
+++ b/comms/torchcomms/triton/device_window.h
@@ -145,6 +145,30 @@ __device__ int torchcomms_barrier_block(
     int barrier_id);
 
 // =============================================================================
+// Block-scope Wait Operations
+//
+// ALL threads in the calling block must call these together (convergently).
+// Thread 0 polls the signal/counter; remaining threads synchronize via
+// __syncthreads__ (CoopScope::BLOCK). Reduces spin-poll traffic from N
+// independent acquire loads (thread-scope) to 1 poll + __syncthreads__.
+// =============================================================================
+
+// Block-scope wait for signal from a specific peer (>=).
+// Returns: 0 on success, negative on error
+__device__ int torchcomms_wait_signal_from_block(
+    TorchCommsWindowHandle win,
+    int peer,
+    int signal_id,
+    unsigned long long expected_value);
+
+// Block-scope wait for local counter (>=).
+// Returns: 0 on success, negative on error
+__device__ int torchcomms_wait_counter_block(
+    TorchCommsWindowHandle win,
+    int counter_id,
+    unsigned long long expected_value);
+
+// =============================================================================
 // Signal Operations (Remote Notification)
 // Thread-scope (idempotent) — all 128 threads call these; same result from any
 // count.


### PR DESCRIPTION
Summary:
Add block-scope variants of `wait_signal_from` and `wait_counter` to the
TorchComms device window API, exposed to Triton via extern_elementwise.

## Motivation

The existing thread-scope wait operations (`wait_signal_from`, `wait_counter`)
have every thread in the block independently polling the signal/counter with
acquire loads. For a block of 1024 threads, this means 1024 concurrent acquire
loads per poll cycle — wasting memory bandwidth and adding contention.

Block-scope variants (`wait_signal_from_block`, `wait_counter_block`) reduce
this to 1 acquire load (thread 0 polls) + 1 `__syncthreads__`, significantly
reducing spin-poll traffic.

## Changes

- `device_window.cu`: Add `torchcomms_wait_signal_from_block` and
  `torchcomms_wait_counter_block` C device functions
- `device_window.h`: Add declarations
- `fb/__init__.py`: Add Triton `extern_elementwise` wrappers and
  `triton.jit` helper functions (`wait_signal_from_block`,
  `wait_counter_block`), exported in `__all__`

Reviewed By: cenzhaometa, siyengar

Differential Revision: D100357722


