### PR TITLE
Fix CT/PT opCount mismatch by moving increment to ncclLaunchPrepare

### DIFF
--- a/comms/ncclx/meta/colltrace/CollTrace.cc
+++ b/comms/ncclx/meta/colltrace/CollTrace.cc
@@ -465,16 +465,10 @@ void CollTrace::addGraphEvent(std::unique_ptr<CollTraceEvent> event) {
 }
 
 void CollTrace::enqueueEvent(std::unique_ptr<CollTraceEvent> event) {
-  event->coll.collId = curCollId_.fetch_add(1);
-  if (event->coll.collId != event->coll.opCount) {
-    XLOG_FIRST_N(
-        WARN,
-        5,
-        fmt::format(
-            "CollId and OpCount is different! Collective info: {}",
-            event->coll.toString()));
-    event->coll.opCount = event->coll.collId;
-  }
+  // collId is kept in sync with opCount. Previously collId was used as a
+  // workaround for opCount being unreliable (D73568360), but opCount is now
+  // incremented at the correct point in ncclLaunchPrepare (D100385134).
+  event->coll.collId = event->coll.opCount;
   eventQueue_.push(std::move(event));
 }
 

--- a/comms/ncclx/meta/colltrace/CollTrace.h
+++ b/comms/ncclx/meta/colltrace/CollTrace.h
@@ -139,8 +139,6 @@ class CollTrace {
   SharedPool cudaEventPool_;
   EventQueue eventQueue_;
 
-  std::atomic<uint64_t> curCollId_{0};
-
   std::unique_ptr<CollTraceEvent> curEvent_;
   std::atomic<CurrentCollState> curCollState_{CurrentCollState::PENDING};
   std::deque<std::unique_ptr<CollTraceColl>> pastColls_;

--- a/comms/ncclx/meta/colltrace/tests/ProxyTraceDistTest.cc
+++ b/comms/ncclx/meta/colltrace/tests/ProxyTraceDistTest.cc
@@ -8,12 +8,14 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <set>
 #include <unordered_map>
 
 #include "comms/ctran/Ctran.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsDistUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
+#include "meta/colltrace/CollTrace.h"
 #include "meta/colltrace/ProxyMock.h"
 #include "meta/colltrace/ProxyTrace.h"
 
@@ -632,6 +634,74 @@ TEST_F(ProxyTraceTest, QueryHangSendRecv) {
 
   // Now let's wait for all communication to finish
   CUDACHECK_TEST(cudaStreamSynchronize(stream));
+}
+
+// Verify that CollTrace (CT) and ProxyTrace (PT) record the same opCount
+// for the same collective. A bug introduced by D83294734 caused opCount to be
+// incremented in doLaunches (after kernel launch) instead of in
+// ncclLaunchPrepare (before proxy ops are created), causing PT to capture a
+// stale value when multiple plans exist in a single group.
+TEST_F(ProxyTraceTest, CTAndPTOpCountsMatch) {
+  auto traceGuard = EnvRAII(NCCL_PROXYTRACE, {"trace"});
+  auto recordGuard = EnvRAII(
+      NCCL_PROXYTRACE_RECORD_MAX, std::max(NCCL_PROXYTRACE_RECORD_MAX, 100));
+
+  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  if (!checkTestRequirement(comm)) {
+    GTEST_SKIP();
+  }
+
+  EXPECT_THAT(comm->proxyState->trace, ::testing::NotNull());
+  EXPECT_THAT(comm->ctranComm_->collTrace_, ::testing::NotNull());
+
+  const int count = 1048500;
+  const int nColl = 20;
+
+  runAllReduce(count, nColl, comm);
+  CUDACHECK_TEST(cudaStreamSynchronize(stream));
+
+  // Wait for proxy ops to finish
+  sleep(3);
+
+  // Dump both CT and PT
+  auto ptDump = comm->proxyState->trace->dump(comm->commHash);
+  comm->ctranComm_->collTrace_->waitForWorkerFinishQueue();
+  auto ctDump = comm->ctranComm_->collTrace_->dump();
+
+  // Build sets of opCounts from CT and PT pastColls
+  std::set<uint64_t> ctOpCounts;
+  for (const auto& coll : ctDump.pastColls) {
+    ctOpCounts.insert(coll.opCount);
+  }
+
+  std::set<uint64_t> ptOpCounts;
+  for (const auto& coll : ptDump.pastColls) {
+    ptOpCounts.insert(coll.collInfo.opCount);
+  }
+
+  // The set of opCounts in CT and PT should be identical — both should have
+  // recorded the same operations under the same opCount values.
+  // A mismatch here means PT captured stale/wrong opCount values.
+  if (comm->rank == 0 && VERBOSE) {
+    printf(
+        "Rank %d: CT pastColls=%zu (opCounts %lu-%lu), "
+        "PT pastColls=%zu (opCounts %lu-%lu)\n",
+        comm->rank,
+        ctDump.pastColls.size(),
+        ctOpCounts.empty() ? 0UL : *ctOpCounts.begin(),
+        ctOpCounts.empty() ? 0UL : *ctOpCounts.rbegin(),
+        ptDump.pastColls.size(),
+        ptOpCounts.empty() ? 0UL : *ptOpCounts.begin(),
+        ptOpCounts.empty() ? 0UL : *ptOpCounts.rbegin());
+  }
+
+  // Verify the opCount sets match
+  EXPECT_EQ(ctOpCounts, ptOpCounts)
+      << "CT and PT pastColls have different opCount sets. "
+      << "CT range: [" << (ctOpCounts.empty() ? 0UL : *ctOpCounts.begin())
+      << ", " << (ctOpCounts.empty() ? 0UL : *ctOpCounts.rbegin()) << "], "
+      << "PT range: [" << (ptOpCounts.empty() ? 0UL : *ptOpCounts.begin())
+      << ", " << (ptOpCounts.empty() ? 0UL : *ptOpCounts.rbegin()) << "]";
 }
 
 int main(int argc, char* argv[]) {

--- a/comms/ncclx/v2_27/src/enqueue.cc
+++ b/comms/ncclx/v2_27/src/enqueue.cc
@@ -1440,6 +1440,13 @@ ncclResult_t ncclLaunchPrepare(struct ncclComm* comm) {
 
   if (planner->nTasksColl + planner->nTasksP2p != 0) {
     do {
+      // Bump opCount before creating proxy ops for this plan, so that
+      // ProxyTrace and CollTrace both capture the same opCount value.
+      // Previously opCount was incremented in doLaunches (group.cc) after
+      // each kernel launch, but proxy ops are created here in Prepare
+      // before any launches, causing PT to capture a stale value.
+      comm->opCount++;
+
       memset(&planner->wipPlan, 0, sizeof(planner->wipPlan));
 
       struct ncclKernelPlan* plan = ncclMemoryPoolAlloc<struct ncclKernelPlan>(&comm->memPool_ncclKernelPlan, &comm->memPermanent);

--- a/comms/ncclx/v2_27/src/group.cc
+++ b/comms/ncclx/v2_27/src/group.cc
@@ -327,11 +327,8 @@ static ncclResult_t doLaunches(struct ncclComm* head) {
             NCCLCHECKGOTO(ncclLaunchKernelBefore_NoUncapturedCuda(comm, plan), result, failure);
             NCCLCHECKGOTO(ncclLaunchKernel(comm, plan), result, failure);
             INFO(NCCL_COLL, "comm %s %p opCount %ld launched kernel for plan %p",  NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str(), comm, comm->opCount, plan);
-            // NOTE: bump up opCount right after launching kernel as this field is dedicated to track number of kernels
-            // including both p2p and collective kernels, no matter proxyOp existance.
-            // Known limitation: It won't be updated properly under cuda graph replay since it is not captured by the graph.
-            // But it is sufficient to unblock log based debugging in eager mode.
-            comm->opCount++;
+            // NOTE: opCount is now incremented in ncclLaunchPrepare (enqueue.cc)
+            // before proxy ops are created, so that PT and CT see the same value.
           }
           // Barrier reduction input indicates if we require further rounds.
           if (useBarrier) ncclCommIntraBarrierIn(comm, comm->planner.unlaunchedPlansHead != nullptr ? 1 : 0);

--- a/comms/ncclx/v2_28/src/enqueue.cc
+++ b/comms/ncclx/v2_28/src/enqueue.cc
@@ -1460,6 +1460,13 @@ ncclResult_t ncclLaunchPrepare(struct ncclComm* comm) {
       !ncclIntruQueueEmpty(&planner->collSymTaskQueue) ||
       !ncclIntruQueueEmpty(&planner->collCeTaskQueue)) {
     do {
+      // Bump opCount before creating proxy ops for this plan, so that
+      // ProxyTrace and CollTrace both capture the same opCount value.
+      // Previously opCount was incremented in doLaunches (group.cc) after
+      // each kernel launch, but proxy ops are created here in Prepare
+      // before any launches, causing PT to capture a stale value.
+      comm->opCount++;
+
       memset(&planner->wipPlan, 0, sizeof(planner->wipPlan));
 
       struct ncclKernelPlan* plan = ncclMemoryPoolAlloc<struct ncclKernelPlan>(&comm->memPool_ncclKernelPlan, &comm->memPermanent);

--- a/comms/ncclx/v2_28/src/group.cc
+++ b/comms/ncclx/v2_28/src/group.cc
@@ -327,11 +327,8 @@ static ncclResult_t doLaunches(struct ncclComm* head) {
               NCCLCHECKGOTO(ncclLaunchKernel(comm, plan), result, failure);
             }
             INFO(NCCL_COLL, "comm %s %p opCount %ld launched kernel for plan %p",  NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str(), comm, comm->opCount, plan);
-            // NOTE: bump up opCount right after launching kernel as this field is dedicated to track number of kernels
-            // including both p2p and collective kernels, no matter proxyOp existance.
-            // Known limitation: It won't be updated properly under cuda graph replay since it is not captured by the graph.
-            // But it is sufficient to unblock log based debugging in eager mode.
-            comm->opCount++;
+            // NOTE: opCount is now incremented in ncclLaunchPrepare (enqueue.cc)
+            // before proxy ops are created, so that PT and CT see the same value.
           }
           // Barrier reduction input indicates if we require further rounds.
           if (useBarrier) ncclCommIntraBarrierIn(comm, comm->planner.unlaunchedPlansHead != nullptr ? 1 : 0);

--- a/comms/ncclx/v2_29/src/enqueue.cc
+++ b/comms/ncclx/v2_29/src/enqueue.cc
@@ -1560,6 +1560,13 @@ ncclResult_t ncclLaunchPrepare(struct ncclComm* comm) {
       !ncclIntruQueueEmpty(&planner->collCeTaskQueue) ||
       planner->nTasksRma != 0) {
     do {
+      // Bump opCount before creating proxy ops for this plan, so that
+      // ProxyTrace and CollTrace both capture the same opCount value.
+      // Previously opCount was incremented in doLaunches (group.cc) after
+      // each kernel launch, but proxy ops are created here in Prepare
+      // before any launches, causing PT to capture a stale value.
+      comm->opCount++;
+
       memset(&planner->wipPlan, 0, sizeof(planner->wipPlan));
 
       struct ncclKernelPlan* plan = ncclMemoryPoolAlloc<struct ncclKernelPlan>(&comm->memPool_ncclKernelPlan, &comm->memPermanent);

--- a/comms/ncclx/v2_29/src/group.cc
+++ b/comms/ncclx/v2_29/src/group.cc
@@ -360,11 +360,8 @@ static ncclResult_t doLaunches(struct ncclComm* head) {
               NCCLCHECKGOTO(ncclLaunchKernel(comm, plan), result, failure);
             }
             INFO(NCCL_COLL, "comm %s %p opCount %ld launched kernel for plan %p",  NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str(), comm, comm->opCount, plan);
-            // NOTE: bump up opCount right after launching kernel as this field is dedicated to track number of kernels
-            // including both p2p and collective kernels, no matter proxyOp existance.
-            // Known limitation: It won't be updated properly under cuda graph replay since it is not captured by the graph.
-            // But it is sufficient to unblock log based debugging in eager mode.
-            comm->opCount++;
+            // NOTE: opCount is now incremented in ncclLaunchPrepare (enqueue.cc)
+            // before proxy ops are created, so that PT and CT see the same value.
           }
           // Barrier reduction input indicates if we require further rounds.
           if (useBarrier) ncclCommIntraBarrierIn(comm, comm->planner.unlaunchedPlansHead != nullptr ? 1 : 0);


### PR DESCRIPTION
Summary:
D83294734 moved `comm->opCount++` from `ncclProxyStart` (proxy.cc) to
`doLaunches` (group.cc) to fix missing increments for collectives without
proxy ops. However, this introduced a mismatch between CollTrace (CT) and
ProxyTrace (PT) opCounts.

The issue: proxy ops are created during `ncclLaunchPrepare` (Phase 1),
but `opCount++` now happens during `doLaunches` (Phase 2). When multiple
plans exist for one communicator, all proxy ops capture the same stale
opCount from Phase 1, while CT sees incrementing values from Phase 2.

This causes the Comms Analyzer's `analyzeProxyTrace()` to look up proxy
ops under the CT opCount, finding data for a different operation (or
nothing at all). In a production incident, this prevented the analyzer
from identifying a stuck rank in a 16384-rank job — it reported
"could not identify bad ranks" for all 64 ranks in the communicator.

The fix moves `comm->opCount++` to the top of the plan creation loop in
`ncclLaunchPrepare`, before proxy ops are created. This ensures:
- PT captures the correct opCount (reads after increment)
- CT captures the same value (plan.comm->opCount unchanged between
  prepare and launch)
- Every plan gets a unique opCount regardless of proxy op existence

Applied to v2_27, v2_28, and v2_29.

Differential Revision: D100385134


