### PR TITLE
Fix pybind11 3.0 call_guard on def_property family (#2038)

### DIFF
--- a/comms/torchcomms/TorchCommPy.cpp
+++ b/comms/torchcomms/TorchCommPy.cpp
@@ -918,11 +918,7 @@ Args:
           py::arg("async_op"),
           py::arg("options") = BatchP2POptions(),
           py::call_guard<py::gil_scoped_release>())
-      .def_readwrite(
-          "ops",
-          &BatchSendRecv::ops,
-          "List of P2P operations",
-          py::call_guard<py::gil_scoped_release>());
+      .def_readwrite("ops", &BatchSendRecv::ops, "List of P2P operations");
 
   m.def(
       "new_comm",
@@ -2180,9 +2176,10 @@ Note:
       .def("name", &BackendWrapper::getBackendName)
       .def_property_readonly(
           "options",
-          &BackendWrapper::getOptions,
-          R"(Return the options used to create the torchComm under the hood.)",
-          py::call_guard<py::gil_scoped_release>())
+          py::cpp_function(
+              &BackendWrapper::getOptions,
+              py::call_guard<py::gil_scoped_release>()),
+          R"(Return the options used to create the torchComm under the hood.)")
       .def(
           "_verify_work_timeout",
           &BackendWrapper::verifyWorkTimeoutForTest,


### PR DESCRIPTION
Summary:

pybind11 3.0 added a static_assert preventing call_guard from being passed directly to def_property family functions (def_property_readonly, def_readwrite, etc.).

For def_property_readonly("options"), wrap the getter in py::cpp_function with call_guard passed there.

For def_readwrite("ops"), simply remove the call_guard — it has no effect on member variable accessors (they don't release the GIL since they're trivial pointer dereferences).

Both fixes are compatible with pybind11 2.13 and 3.0.

Differential Revision: D100445567
