### PR TITLE
Fix pre-existing build failures in TimeoutTrapTest and dispatch targets

### DIFF
--- a/comms/pipes/tests/TimeoutTrapTest.cu
+++ b/comms/pipes/tests/TimeoutTrapTest.cu
@@ -33,7 +33,7 @@ __global__ void chunkStateTimeoutKernel(ChunkState* state, Timeout timeout) {
 
   // State is initialized to READY_TO_SEND (-1), so waiting for stepId=0
   // will spin forever unless timeout triggers
-  state->wait_ready_to_recv(group, 0, 0, timeout);
+  state->wait_ready_to_recv(group, 0, timeout);
 }
 
 // Kernel that waits on SignalState that will never be signaled
@@ -135,7 +135,7 @@ __global__ void chunkStateThreadGroupTimeoutKernel(
   // State is initialized to READY_TO_SEND (-1), so waiting for stepId=0
   // will spin forever unless timeout triggers
   // Uses ThreadGroup-based wait which calls timeout.check(group)
-  state->wait_ready_to_recv(group, 0, 0, timeout);
+  state->wait_ready_to_recv(group, 0, timeout);
 }
 
 // Kernel that uses ThreadGroup-based timeout checking for SignalState


### PR DESCRIPTION
Summary:
Fix two pre-existing master breakages:

1. **TimeoutTrapTest.cu**: `wait_ready_to_recv` signature was changed to remove the `chunkId` parameter (now takes `group, stepId, timeout` instead of `group, stepId, chunkId, timeout`), but the test wasn't updated. The extra `0` argument caused a compile error: "no suitable constructor exists to convert from int to Timeout".

2. **dispatch BUCK targets**: The Dispatch collective source files (Dispatchv.cu/cuh/h, DispatchBenchmark.cc) were removed in a prior diff ("[Pipes] Remove send_one, send_multiple, recv_one, recv_multiple, and Dispatch collective") but the BUCK target entries for `dispatch` library and `dispatch_benchmark` were left behind, causing build failures.

Differential Revision: D100481377


