### PR TITLE
Fix ValueError crash in TorchComm::reconfigure() on failure (#2041)

### DIFF
--- a/comms/torchcomms/TorchComm.cpp
+++ b/comms/torchcomms/TorchComm.cpp
@@ -55,6 +55,10 @@ TorchComm::TorchComm(
 }
 
 void TorchComm::initRanks() {
+  if (!impl_->isInitialized()) {
+    return;
+  }
+
   int size = impl_->getSize();
   ranks_.clear();
   ranks_.reserve(size);
@@ -481,7 +485,14 @@ InitHandle TorchComm::getInitHandle() const {
 c10::intrusive_ptr<TorchWork> TorchComm::reconfigure(
     const ReconfigureOptions& opts) {
   auto work = impl_->reconfigure(opts);
-  initRanks();
+  work->waitBlocking();
+
+  if (work->isCompleted()) {
+    initRanks();
+  } else {
+    ranks_.clear();
+  }
+
   return work;
 }
 

--- a/comms/torchcomms/TorchCommBackend.hpp
+++ b/comms/torchcomms/TorchCommBackend.hpp
@@ -289,6 +289,19 @@ class TorchCommBackend {
   }
 
   /**
+   * Check if the backend is fully initialized and ready for collective
+   * operations. In dynamic regime, the backend transitions to initialized
+   * state after a successful reconfigure().
+   *
+   * This method is non-throwing and safe to call regardless of backend state.
+   *
+   * @return True if the backend is initialized, false otherwise.
+   */
+  virtual bool isInitialized() const {
+    return true;
+  }
+
+  /**
    * Get the initialization handle for this backend.
    * In dynamic regime, this URL encodes information required by the backend
    * to complete the initialization process via reconfigure().

--- a/comms/torchcomms/TorchWork.cpp
+++ b/comms/torchcomms/TorchWork.cpp
@@ -28,6 +28,12 @@ void TorchWorkCompleted::wait() {
   runWaitPostHooks();
 }
 
+void TorchWorkCompleted::waitBlocking() {
+  // Note: required for TorchComm::reconfigure to work with the dummy backend.
+  // No need to checkStatus as the constructor sets the status to COMPLETED.
+  return;
+}
+
 TorchWorkThread::TorchWorkThread(std::function<void()> fn)
     : future_(std::async(std::launch::async, [this, fn = std::move(fn)]() {
         try {

--- a/comms/torchcomms/TorchWork.hpp
+++ b/comms/torchcomms/TorchWork.hpp
@@ -194,6 +194,8 @@ class TorchWorkCompleted : public TorchWork {
 
   // Override virtual functions from TorchWork
   void wait() override;
+
+  void waitBlocking() override;
 };
 
 class TorchWorkThread : public TorchWork {

--- a/comms/torchcomms/fake/TorchCommFake.cpp
+++ b/comms/torchcomms/fake/TorchCommFake.cpp
@@ -251,6 +251,11 @@ std::shared_ptr<TorchCommWindow> TorchCommFake::new_window(
   return win;
 }
 
+c10::intrusive_ptr<TorchWork> TorchCommFake::reconfigure(
+    const ReconfigureOptions& /* opts */) {
+  return c10::make_intrusive<TorchWorkCompleted>();
+}
+
 std::shared_ptr<TorchCommBackend> TorchCommFake::split(
     const std::vector<int>& ranks,
     const std::string& name,

--- a/comms/torchcomms/fake/TorchCommFake.hpp
+++ b/comms/torchcomms/fake/TorchCommFake.hpp
@@ -132,6 +132,18 @@ class TorchCommFake : public TorchCommBackend {
   std::shared_ptr<TorchCommWindow> new_window(
       const std::optional<at::Tensor>& tensor = std::nullopt) override;
 
+  // Fault Tolerance
+  bool supportsReconfigure() const override {
+    return true;
+  }
+  c10::intrusive_ptr<TorchWork> reconfigure(
+      const ReconfigureOptions& opts) override;
+
+  // Test helpers
+  void setSize(int size) {
+    size_ = size;
+  }
+
   // Communicator Management
   std::shared_ptr<TorchCommBackend> split(
       const std::vector<int>& ranks,

--- a/comms/torchcomms/tests/unit/cpp/TorchCommReconfigureTest.cpp
+++ b/comms/torchcomms/tests/unit/cpp/TorchCommReconfigureTest.cpp
@@ -1,0 +1,94 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <comms/torchcomms/TorchComm.hpp>
+#include <comms/torchcomms/TorchCommFactory.hpp>
+#include <comms/torchcomms/fake/TorchCommFake.hpp>
+#include <gtest/gtest.h>
+#include <cstdlib>
+
+namespace torch::comms {
+
+namespace {
+constexpr const char* kBackendName = "fake_test";
+constexpr const char* kBackendEnvKey = "TORCHCOMMS_BACKEND_LIB_PATH_FAKE_TEST";
+} // namespace
+
+class TorchCommReconfigureTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const char* lib_path = std::getenv("FAKE_TEST_BACKEND_LIB_PATH");
+    ASSERT_NE(lib_path, nullptr) << "FAKE_TEST_BACKEND_LIB_PATH not set";
+    setenv(kBackendEnvKey, lib_path, 1);
+  }
+
+  void TearDown() override {
+    unsetenv(kBackendEnvKey);
+  }
+
+  std::shared_ptr<TorchComm> createComm(bool enable_reconfigure = false) {
+    at::Device device(at::kCPU);
+    CommOptions options;
+    options.enable_reconfigure = enable_reconfigure;
+    return new_comm(kBackendName, device, "test_comm", options);
+  }
+
+  ReconfigureOptions makeOpts() {
+    ReconfigureOptions opts;
+    opts.uuid = 42;
+    opts.handles = std::vector<InitHandle>{"url0"};
+    opts.timeout = std::chrono::milliseconds(1000);
+    return opts;
+  }
+};
+
+TEST_F(TorchCommReconfigureTest, ReconfigureSuccess) {
+  auto comm = createComm(/*enable_reconfigure=*/true);
+  ASSERT_NE(comm, nullptr);
+
+  // In dynamic regime, ranks_ starts empty
+  EXPECT_TRUE(comm->getRanks().empty());
+
+  // Reconfigure with fake backend (size=1) should populate ranks
+  comm->reconfigure(makeOpts());
+
+  auto ranks = comm->getRanks();
+  ASSERT_EQ(ranks.size(), 1);
+  EXPECT_EQ(ranks[0], 0);
+}
+
+TEST_F(TorchCommReconfigureTest, ReconfigureWithZeroSizeClearsRanks) {
+  auto comm = createComm(/*enable_reconfigure=*/true);
+  ASSERT_NE(comm, nullptr);
+
+  // First reconfigure succeeds — populates ranks
+  comm->reconfigure(makeOpts());
+  ASSERT_EQ(comm->getRanks().size(), 1);
+
+  // Simulate failure by setting backend size to 0
+  auto backend =
+      std::dynamic_pointer_cast<TorchCommFake>(comm->getBackendImpl());
+  ASSERT_NE(backend, nullptr);
+  backend->setSize(0);
+
+  // Second reconfigure with size=0 should clear ranks, not crash
+  comm->reconfigure(makeOpts());
+  EXPECT_TRUE(comm->getRanks().empty());
+}
+
+TEST_F(TorchCommReconfigureTest, ReconfigureFailureOnFirstCall) {
+  auto comm = createComm(/*enable_reconfigure=*/true);
+  ASSERT_NE(comm, nullptr);
+
+  // Set backend size to 0 before first reconfigure
+  auto backend =
+      std::dynamic_pointer_cast<TorchCommFake>(comm->getBackendImpl());
+  ASSERT_NE(backend, nullptr);
+  backend->setSize(0);
+
+  // First reconfigure with size=0 — this is the original SEV scenario.
+  // Without the fix, this would crash with reserve(SIZE_MAX).
+  comm->reconfigure(makeOpts());
+  EXPECT_TRUE(comm->getRanks().empty());
+}
+
+} // namespace torch::comms

--- a/comms/torchcomms/utils/TracingGuard.cpp
+++ b/comms/torchcomms/utils/TracingGuard.cpp
@@ -19,6 +19,7 @@ namespace torch::comms {
 // analyze distributed communication patterns.
 std::shared_ptr<torch::ParamCommsDebugInfo> TracingGuard::getDebugInfo(
     std::string_view comm_name,
+    std::string_view comm_id,
     int comm_size,
     std::string_view collective_name,
     int collective_rank,
@@ -44,7 +45,7 @@ std::shared_ptr<torch::ParamCommsDebugInfo> TracingGuard::getDebugInfo(
   }
 
   return std::make_shared<torch::ParamCommsDebugInfo>(
-      std::make_tuple(std::string(comm_name), std::string("")),
+      std::make_tuple(std::string(comm_name), std::string(comm_id)),
       collective_rank,
       std::string(collective_name).c_str(),
       input_total_numel,
@@ -59,6 +60,7 @@ std::shared_ptr<torch::ParamCommsDebugInfo> TracingGuard::getDebugInfo(
 
 void TracingGuard::initializeTracingCommon(
     std::string_view comm_name,
+    std::string_view comm_id,
     int comm_size,
     std::string_view collective_name,
     int collective_rank,
@@ -77,6 +79,7 @@ void TracingGuard::initializeTracingCommon(
       c10::DebugInfoKind::PARAM_COMMS_INFO,
       getDebugInfo(
           comm_name,
+          comm_id,
           comm_size,
           collective_name,
           collective_rank,
@@ -89,7 +92,7 @@ void TracingGuard::initializeTracingCommon(
     std::initializer_list<const c10::IValue> paramList = {
         c10::IValue(input_tensor_list),
         std::make_tuple(++sequence_number_, false),
-        std::make_tuple(std::string(comm_name), std::string("")),
+        std::make_tuple(std::string(comm_name), std::string(comm_id)),
         collective_rank,
         std::string(collective_name),
         in_split_sizes,
@@ -122,6 +125,7 @@ TracingGuard::TracingGuard(
   }
   initializeTracingCommon(
       comm_name,
+      "",
       comm_size,
       collective_name,
       collective_rank,
@@ -142,11 +146,50 @@ TracingGuard::TracingGuard(
   }
   initializeTracingCommon(
       comm_name,
+      "",
       comm_size,
       collective_name,
       collective_rank,
       input_tensor_list,
       output_tensor_list);
+}
+
+TracingGuard::TracingGuard(
+    const TracingGuardInfo& info,
+    std::string_view collective_name,
+    const std::vector<at::Tensor>& input_tensor_list,
+    const std::vector<at::Tensor>& output_tensor_list) {
+  record_function_guard_.emplace(at::RecordScope::FUNCTION);
+  if (!record_function_guard_->isActive()) {
+    return;
+  }
+  initializeTracingCommon(
+      info.commName,
+      info.commId,
+      info.commSize,
+      collective_name,
+      info.rank,
+      input_tensor_list,
+      output_tensor_list);
+}
+
+TracingGuard::TracingGuard(
+    const TracingGuardInfo& info,
+    std::string_view collective_name,
+    const at::Tensor& input_tensor,
+    const at::Tensor& output_tensor) {
+  record_function_guard_.emplace(at::RecordScope::FUNCTION);
+  if (!record_function_guard_->isActive()) {
+    return;
+  }
+  initializeTracingCommon(
+      info.commName,
+      info.commId,
+      info.commSize,
+      collective_name,
+      info.rank,
+      {input_tensor},
+      {output_tensor});
 }
 
 } // namespace torch::comms

--- a/comms/torchcomms/utils/TracingGuard.hpp
+++ b/comms/torchcomms/utils/TracingGuard.hpp
@@ -11,6 +11,16 @@
 
 namespace torch::comms {
 
+// Snapshot of communicator metadata captured at construction time.
+// Stored by work handles to avoid calling checked comm accessors that
+// may throw after the communicator transitions to UNINITIALIZED or FINALIZED.
+struct TracingGuardInfo {
+  std::string commName;
+  std::string commId;
+  int commSize{0};
+  int rank{-1};
+};
+
 class TracingGuard {
  public:
   TracingGuard(
@@ -29,8 +39,21 @@ class TracingGuard {
       const at::Tensor& input_tensor,
       const at::Tensor& output_tensor);
 
+  TracingGuard(
+      const TracingGuardInfo& info,
+      std::string_view collective_name,
+      const std::vector<at::Tensor>& input_tensor_list = {},
+      const std::vector<at::Tensor>& output_tensor_list = {});
+
+  TracingGuard(
+      const TracingGuardInfo& info,
+      std::string_view collective_name,
+      const at::Tensor& input_tensor,
+      const at::Tensor& output_tensor);
+
   void initializeTracingCommon(
       std::string_view comm_name,
+      std::string_view comm_id,
       int comm_size,
       std::string_view collective_name,
       int collective_rank,
@@ -39,6 +62,7 @@ class TracingGuard {
 
   std::shared_ptr<torch::ParamCommsDebugInfo> getDebugInfo(
       std::string_view comm_name,
+      std::string_view comm_id,
       int comm_size,
       std::string_view collective_name,
       int collective_rank,


### PR DESCRIPTION
Summary:

The public TC path calls `initRanks()` unconditionally after `impl_->reconfigure()`, but on failure `commSize_` is `-1`, causing `ranks_.reserve(SIZE_MAX)` which throws `std::length_error("vector::reserve")` surfaced as Python `ValueError`.

**Fix 1 (TorchComm.cpp):** Call `work->waitBlocking()` after `impl_->reconfigure()`, then guard `initRanks()` behind `work->isCompleted()`. On success, `initRanks()` populates `ranks_` normally. On failure, `initRanks()` is skipped entirely, avoiding the `reserve(SIZE_MAX)` crash.

**Fix 2 from D100673963 (TorchCommMCCL.cpp):** Set `initState_ = UNINITIALIZED` before calling `mccl_comm_->reconfigure()`, then only promote to `INITIALIZED` inside the existing success block (where `result->code == commSuccess`) alongside `rank_` and `commSize_` updates. Previously `initState_ = INITIALIZED` was set unconditionally after `createWork()`, which allowed subsequent operations to proceed on a broken communicator after a failed reconfigure.

**Fix 3**: Add `isInitialized` check to `TorchComm::initRanks`; return if not initialized. This alleviates the incompatibility between fixes 1 and 2 (in that `work->waitBlocking` will throw if the backend/comm is not initialized).

**Fix 4**: Clear `TorchComm::ranks_` if `reconfigure` fails. Otherwise, `comm->getRanks()` would return stale data from the previous successful reconfigure / initialization.

---

**Tests:** Add unit tests for both `TorchComm::reconfigure()` (via the dummy backend) and `TorchCommMCCL::reconfigure()` (via mocks) covering success, failure, exception, and recovery (success→failure→success) paths. Add `reconfigure()` and `supportsReconfigure()` overrides plus a `setSize()` test helper to `TorchCommDummy`.

---

NOTE: D100643058 provides a small suite of tests reproducing the error.

Reviewed By: dboyda

Differential Revision: D100521352


