### PR TITLE
Fix AlltoallvOp teardown race condition causing hang at ≥32 GPUs (#2043)

### DIFF
--- a/comms/pipes/collectives/triton/alltoallv_op.py
+++ b/comms/pipes/collectives/triton/alltoallv_op.py
@@ -551,6 +551,14 @@ class AlltoallvOp:
 
     def teardown(self) -> None:
         """Release comms resources and all buffers.  Safe to call multiple times."""
+        # Barrier ensures all ranks have completed their kernel launches
+        # before any rank deregisters buffers. Without this, fast ranks
+        # can deregister recv_buf (RDMA-unmap) while slow ranks' kernels
+        # are still writing to it via one-sided put operations, corrupting
+        # NCCL state and causing subsequent window lifecycles to hang.
+        if self._window is not None:
+            torch.cuda.synchronize()
+            self.comm.barrier(False)
         # First deregister comms buffers
         if self._src_info is not None:
             self._window.deregister_local_buffer(self._src_info)

--- a/comms/pipes/collectives/triton/tests/test_alltoallv_op_e2e.py
+++ b/comms/pipes/collectives/triton/tests/test_alltoallv_op_e2e.py
@@ -78,6 +78,7 @@ class _OpTestBase(unittest.TestCase):
         AlltoallvOp.clear_cache()
         if cls.torchcomm is not None:
             cls.torchcomm.barrier(False)
+            cls.torchcomm.finalize()
         cls.torchcomm = None
         cls.wrapper = None
         gc.collect()


### PR DESCRIPTION
Summary:

AlltoallvOp.teardown() deregistered recv_buf (RDMA-unmapped memory) without synchronizing across ranks. At ≥32 GPUs with IB, fast ranks could deregister while slow ranks' kernels were still writing via one-sided RDMA puts, corrupting NCCL state. Subsequent AlltoallvOp window lifecycles would hang because the communicator's internal state was damaged.

Root cause: missing barrier + cuda sync before deregistering buffers in teardown(). The alltoallv_raw tests avoided this because their tearDownClass had a barrier before cleanup; AlltoallvOp.teardown() did not.

Fix:
- Add torch.cuda.synchronize() + comm.barrier(False) at the start of teardown() before deregistering any buffers, ensuring all ranks' kernels complete before any rank RDMA-unmaps its recv buffer
- Add explicit torchcomm.finalize() in test tearDownClass for deterministic communicator cleanup

Investigation:
- Crash always on test_packed_output_uniform (10th test class) at H100 4x8/8x8
- Passed when run in isolation (TEST_FILTER=TestOpPackedOutputUniform)
- Window lifecycle stress test: crashed at cycle 2 without fix, passed all 20 with fix
- Root cause confirmed: racy teardown corrupts NCCL state for subsequent window lifecycles

Reviewed By: siyengar

Differential Revision: D100553097
