### PR TITLE
Add tile sendrecv protocol with TiledBuffer abstraction

### DIFF
--- a/comms/pipes/MultiPeerNvlTransport.cc
+++ b/comms/pipes/MultiPeerNvlTransport.cc
@@ -111,6 +111,39 @@ MultiPeerNvlTransport::MultiPeerNvlTransport(
       totalSignalBufferSize,
       cudaMemcpyDefault));
 
+  // Conditionally allocate tile protocol buffers (all internal)
+  if (config_.tileMaxBlocks > 0) {
+    // Step state (local only, not exchanged, per-peer)
+    // Each peer gets 2*maxBlocks int64s: [sender steps | receiver steps]
+    std::size_t perPeerStepStateBytes =
+        2 * config_.tileMaxBlocks * sizeof(int64_t);
+    std::size_t totalStepStateBytes = perPeerStepStateBytes * (nRanks_ - 1);
+    tileStepStateBuffer_ =
+        std::make_unique<meta::comms::DeviceBuffer>(totalStepStateBytes);
+    CUDA_CHECK(cudaMemset(tileStepStateBuffer_->get(), 0, totalStepStateBytes));
+
+    // Tile signal buffer (2*maxBlocks signals per peer, exchanged)
+    std::size_t tileSignalCount = 2 * config_.tileMaxBlocks;
+    perPeerTileSignalSize_ = getSignalBufferSize(tileSignalCount);
+    std::size_t totalTileSignalSize = perPeerTileSignalSize_ * (nRanks_ - 1);
+    tileSignalHandler_ = std::make_unique<GpuMemHandler>(
+        bootstrap_, myRank_, nRanks_, totalTileSignalSize, memSharingMode_);
+    auto* tileSignalPtr = tileSignalHandler_->getLocalDeviceMemPtr();
+    CUDA_CHECK(cudaMemset(tileSignalPtr, 0, totalTileSignalSize));
+  }
+
+  // Conditionally allocate barrier buffer
+  if (config_.p2pBarrierCount > 0) {
+    perPeerBarrierBufferSize_ = getBarrierBufferSize(config_.p2pBarrierCount);
+    std::size_t totalBarrierSize = perPeerBarrierBufferSize_ * (nRanks_ - 1);
+    barrierBufferHandler_ = std::make_unique<GpuMemHandler>(
+        bootstrap_, myRank_, nRanks_, totalBarrierSize, memSharingMode_);
+
+    // Zero-initialize barrier counters
+    auto* barrierPtr = barrierBufferHandler_->getLocalDeviceMemPtr();
+    CUDA_CHECK(cudaMemset(barrierPtr, 0, totalBarrierSize));
+  }
+
   // Conditionally allocate LL128 buffers
   if (config_.ll128BufferSize > 0) {
     perPeerLl128BufferSize_ = config_.ll128BufferSize;
@@ -189,6 +222,12 @@ void MultiPeerNvlTransport::exchange() {
   if (ll128BufferHandler_) {
     ll128BufferHandler_->exchangeMemPtrs();
   }
+  if (barrierBufferHandler_) {
+    barrierBufferHandler_->exchangeMemPtrs();
+  }
+  if (tileSignalHandler_) {
+    tileSignalHandler_->exchangeMemPtrs();
+  }
 }
 
 P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
@@ -251,6 +290,32 @@ P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
           remoteSignalPtr + remoteSignalBufferOffset),
       config_.p2pSignalCount);
 
+  // Barrier buffer spans (empty if p2pBarrierCount == 0)
+  auto makeBarrierSpans =
+      [&]() -> std::pair<DeviceSpan<BarrierState>, DeviceSpan<BarrierState>> {
+    if (!barrierBufferHandler_) {
+      return {DeviceSpan<BarrierState>(), DeviceSpan<BarrierState>()};
+    }
+    auto* localBarrierPtr =
+        static_cast<char*>(barrierBufferHandler_->getLocalDeviceMemPtr());
+    auto* remoteBarrierPtr = static_cast<char*>(
+        barrierBufferHandler_->getPeerDeviceMemPtr(peerRank));
+    const std::size_t localBarrierOffset =
+        localPeerIndex * perPeerBarrierBufferSize_;
+    const std::size_t remoteBarrierOffset =
+        remotePeerIndex * perPeerBarrierBufferSize_;
+    return {
+        DeviceSpan<BarrierState>(
+            reinterpret_cast<BarrierState*>(
+                localBarrierPtr + localBarrierOffset),
+            config_.p2pBarrierCount),
+        DeviceSpan<BarrierState>(
+            reinterpret_cast<BarrierState*>(
+                remoteBarrierPtr + remoteBarrierOffset),
+            config_.p2pBarrierCount)};
+  };
+  auto [localBarrierSpan, remoteBarrierSpan] = makeBarrierSpans();
+
   // When dataBufferSize=0, staging buffers are not allocated.
   // Set data/state to nullptr/empty — send()/recv() will trap.
   if (!dataBufferHandler_ && !externalStagingBuffers_) {
@@ -259,15 +324,33 @@ P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
         .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
         .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
         .signalBuffer = localSignalSpan,
+        .barrierBuffer = localBarrierSpan,
     };
     RemoteState remoteState{
         .dataBuffer = nullptr,
         .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
         .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
         .signalBuffer = remoteSignalSpan,
+        .barrierBuffer = remoteBarrierSpan,
     };
-    return P2pNvlTransportDevice(
+    auto device = P2pNvlTransportDevice(
         myRank_, peerRank, options, localState, remoteState);
+    if (tileStepStateBuffer_) {
+      auto* tileLocalSig = reinterpret_cast<SignalState*>(
+          static_cast<char*>(tileSignalHandler_->getLocalDeviceMemPtr()) +
+          localPeerIndex * perPeerTileSignalSize_);
+      auto* tileRemoteSig = reinterpret_cast<SignalState*>(
+          static_cast<char*>(
+              tileSignalHandler_->getPeerDeviceMemPtr(peerRank)) +
+          remotePeerIndex * perPeerTileSignalSize_);
+      // Each peer gets its own stepState region
+      auto* stepBase = static_cast<int64_t*>(tileStepStateBuffer_->get());
+      auto* peerStepState =
+          stepBase + localPeerIndex * 2 * config_.tileMaxBlocks;
+      device.set_tile_state(
+          peerStepState, config_.tileMaxBlocks, tileLocalSig, tileRemoteSig);
+    }
+    return device;
   }
 
   const std::size_t numChunksPerStep =
@@ -339,6 +422,7 @@ P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
         .senderStateBuffer = DeviceSpan<ChunkState>(
             localChunkStateBase + numChunksPerPeer, numChunksPerPeer),
         .signalBuffer = localSignalSpan,
+        .barrierBuffer = localBarrierSpan,
         .ll128Buffer = localLl128,
     };
 
@@ -349,11 +433,28 @@ P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
         .senderStateBuffer = DeviceSpan<ChunkState>(
             remoteChunkStateBase + numChunksPerPeer, numChunksPerPeer),
         .signalBuffer = remoteSignalSpan,
+        .barrierBuffer = remoteBarrierSpan,
         .ll128Buffer = remoteLl128,
     };
 
-    return P2pNvlTransportDevice(
+    auto device = P2pNvlTransportDevice(
         myRank_, peerRank, options, localState, remoteState);
+    if (tileStepStateBuffer_) {
+      auto* tileLocalSig = reinterpret_cast<SignalState*>(
+          static_cast<char*>(tileSignalHandler_->getLocalDeviceMemPtr()) +
+          localPeerIndex * perPeerTileSignalSize_);
+      auto* tileRemoteSig = reinterpret_cast<SignalState*>(
+          static_cast<char*>(
+              tileSignalHandler_->getPeerDeviceMemPtr(peerRank)) +
+          remotePeerIndex * perPeerTileSignalSize_);
+      // Each peer gets its own stepState region
+      auto* stepBase = static_cast<int64_t*>(tileStepStateBuffer_->get());
+      auto* peerStepState =
+          stepBase + localPeerIndex * 2 * config_.tileMaxBlocks;
+      device.set_tile_state(
+          peerStepState, config_.tileMaxBlocks, tileLocalSig, tileRemoteSig);
+    }
+    return device;
   } else {
     // Single state mode: 1x chunk state per peer (on receiver side only)
     //   Local buffer: only receiverStateBuffer is used (receiver waits here)
@@ -365,6 +466,7 @@ P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
             DeviceSpan<ChunkState>(localChunkStateBase, numChunksPerPeer),
         .senderStateBuffer = DeviceSpan<ChunkState>(), // Not used
         .signalBuffer = localSignalSpan,
+        .barrierBuffer = localBarrierSpan,
         .ll128Buffer = localLl128,
     };
 
@@ -374,11 +476,28 @@ P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
             DeviceSpan<ChunkState>(remoteChunkStateBase, numChunksPerPeer),
         .senderStateBuffer = DeviceSpan<ChunkState>(), // Not used
         .signalBuffer = remoteSignalSpan,
+        .barrierBuffer = remoteBarrierSpan,
         .ll128Buffer = remoteLl128,
     };
 
-    return P2pNvlTransportDevice(
+    auto device = P2pNvlTransportDevice(
         myRank_, peerRank, options, localState, remoteState);
+    if (tileStepStateBuffer_) {
+      auto* tileLocalSig = reinterpret_cast<SignalState*>(
+          static_cast<char*>(tileSignalHandler_->getLocalDeviceMemPtr()) +
+          localPeerIndex * perPeerTileSignalSize_);
+      auto* tileRemoteSig = reinterpret_cast<SignalState*>(
+          static_cast<char*>(
+              tileSignalHandler_->getPeerDeviceMemPtr(peerRank)) +
+          remotePeerIndex * perPeerTileSignalSize_);
+      // Each peer gets its own stepState region
+      auto* stepBase = static_cast<int64_t*>(tileStepStateBuffer_->get());
+      auto* peerStepState =
+          stepBase + localPeerIndex * 2 * config_.tileMaxBlocks;
+      device.set_tile_state(
+          peerStepState, config_.tileMaxBlocks, tileLocalSig, tileRemoteSig);
+    }
+    return device;
   }
 }
 

--- a/comms/pipes/MultiPeerNvlTransport.h
+++ b/comms/pipes/MultiPeerNvlTransport.h
@@ -46,6 +46,17 @@ struct MultiPeerNvlTransportConfig {
   // Typical: 1-num of blocks for most workloads.
   std::size_t p2pSignalCount{1};
 
+  // Number of barrier slots per peer for cross-GPU synchronization.
+  // Used by barrier_sync_threadgroup() for device-side barriers.
+  // Set to 0 (default) to skip barrier buffer allocation.
+  // Typical: 1 for tile sendrecv dynamic block count support.
+  std::size_t p2pBarrierCount{0};
+
+  // Maximum block count for the tile sendrecv protocol.
+  // Allocates persistent step state and dedicated tile signals internally.
+  // send_tile/recv_tile use these without user-managed state.
+  int tileMaxBlocks{128};
+
   // If true, use dual chunk state buffers (one on each side) for local polling
   // on both sender and receiver. If false (default), use single chunk state
   // buffer on receiver side only.
@@ -354,6 +365,8 @@ class MultiPeerNvlTransport {
   std::unique_ptr<GpuMemHandler> signalBufferHandler_;
   std::unique_ptr<GpuMemHandler>
       ll128BufferHandler_; // nullptr when ll128BufferSize == 0
+  std::unique_ptr<GpuMemHandler>
+      barrierBufferHandler_; // nullptr when p2pBarrierCount == 0
 
   // External data buffer pointers (set via setExternalDataBuffers()).
   // When set, exchange() skips data buffer allocation/exchange.
@@ -369,6 +382,14 @@ class MultiPeerNvlTransport {
   std::size_t perPeerChunkStateBufferSize_{0};
   std::size_t perPeerSignalBufferSize_{0};
   std::size_t perPeerLl128BufferSize_{0};
+  std::size_t perPeerBarrierBufferSize_{0};
+
+  // Tile protocol state (allocated when tileMaxBlocks > 0)
+  std::unique_ptr<meta::comms::DeviceBuffer>
+      tileStepStateBuffer_; // not exchanged
+  std::unique_ptr<GpuMemHandler>
+      tileSignalHandler_; // 2*maxBlocks signals, exchanged
+  std::size_t perPeerTileSignalSize_{0};
 
   // Flag to track if multi-peer device arrays have been initialized
   bool multiPeerInitialized_{false};

--- a/comms/pipes/P2pNvlTransportDevice.cuh
+++ b/comms/pipes/P2pNvlTransportDevice.cuh
@@ -1112,12 +1112,305 @@ class P2pNvlTransportDevice {
 #endif
   }
 
+  /**
+   * send_tile (maxBlocks overload) — For dynamic block count support.
+   *
+   * Uses maxBlocks for signal/stepState layout (fixed) and numBlocks
+   * for the staging buffer partition (variable). This allows changing
+   * numBlocks between calls without corrupting the signal mapping,
+   * provided the caller performs an epoch drain (see TileSendRecvContext).
+   *
+   * @param maxBlocks Layout size for signals/stepState (fixed at setup)
+   * @param numBlocks Active block count (controls perBlockSlotSize)
+   */
+  /**
+   * @param chunksPerSlot Number of sub-chunks per pipeline slot (default 1).
+   *   When > 1, the per-block staging slot is subdivided and signaled
+   *   at finer granularity. The receiver can start reading the first
+   *   sub-chunk while the sender is still writing subsequent ones.
+   *   Increases signal traffic but reduces pipeline latency.
+   */
+  __device__ __forceinline__ void send_tile(
+      ThreadGroup& group,
+      void* __restrict__ src,
+      std::size_t nbytes,
+      int maxBlocks,
+      int numBlocks,
+      int64_t* __restrict__ stepState,
+      SignalState* __restrict__ localSignals,
+      SignalState* __restrict__ remoteSignals,
+      const Timeout& timeout = Timeout(),
+      int chunksPerSlot = 1) {
+#ifdef __CUDA_ARCH__
+    const int blockId = group.group_id;
+    char* __restrict__ srcPtr = reinterpret_cast<char*>(src);
+    char* __restrict__ stagBuf = remoteState_.dataBuffer;
+
+    const std::size_t slotSize = options_.dataBufferSize;
+    const std::size_t perBlockSlotSize = (slotSize / numBlocks) & ~15ULL;
+    if (perBlockSlotSize == 0) {
+      printf(
+          "send_tile/recv_tile: perBlockSlotSize is 0 "
+          "(slotSize=%llu, numBlocks=%d). "
+          "Increase dataBufferSize or decrease numBlocks.\n",
+          (unsigned long long)slotSize,
+          numBlocks);
+      __trap();
+    }
+    const std::size_t stagingOff = blockId * perBlockSlotSize;
+    const std::size_t chunkSize = (perBlockSlotSize / chunksPerSlot) & ~15ULL;
+    const std::size_t effectiveChunk =
+        chunkSize > 0 ? chunkSize : perBlockSlotSize;
+
+    // Total steps = total data / chunk size
+    const std::size_t totalSteps =
+        (nbytes + effectiveChunk - 1) / effectiveChunk;
+    // Steps per pipeline slot = chunks per slot
+    const std::size_t stepsPerSlot =
+        (perBlockSlotSize + effectiveChunk - 1) / effectiveChunk;
+
+    const uint64_t tailSignalId = blockId;
+    const uint64_t headSignalId = maxBlocks + blockId;
+
+    int64_t step = stepState[blockId];
+
+    for (std::size_t s = 0; s < totalSteps; ++s) {
+      // Slot and offset within slot
+      const std::size_t slotStep = s / stepsPerSlot;
+      const std::size_t subStep = s % stepsPerSlot;
+      const std::size_t slot = slotStep % options_.pipelineDepth;
+      const std::size_t slotOff = slot * slotSize;
+      const std::size_t chunkOff = subStep * effectiveChunk;
+
+      const std::size_t dataOff = s * effectiveChunk;
+      const std::size_t copyBytes = (dataOff + effectiveChunk <= nbytes)
+          ? effectiveChunk
+          : (dataOff < nbytes ? nbytes - dataOff : 0);
+
+      // Backpressure: wait for receiver to free this slot
+      // Only wait at the start of each slot (first sub-step)
+      if (subStep == 0 &&
+          step >= static_cast<int64_t>(stepsPerSlot * options_.pipelineDepth)) {
+        localSignals[headSignalId].wait_until(
+            group,
+            CmpOp::CMP_GE,
+            static_cast<uint64_t>(
+                step - stepsPerSlot * options_.pipelineDepth + 1),
+            timeout);
+      }
+
+      if (copyBytes > 0) {
+        memcpy_vectorized(
+            stagBuf + slotOff + stagingOff + chunkOff,
+            srcPtr + dataOff,
+            copyBytes,
+            group);
+      }
+
+      group.sync();
+      if (group.is_leader()) {
+        remoteSignals[tailSignalId].signal(
+            SignalOp::SIGNAL_SET, static_cast<uint64_t>(step + 1));
+      }
+
+      step++;
+    }
+
+    if (group.is_leader()) {
+      stepState[blockId] = step;
+    }
+    group.sync();
+#endif
+  }
+
+  /**
+   * recv_tile (maxBlocks overload) — For dynamic block count support.
+   */
+  __device__ __forceinline__ void recv_tile(
+      ThreadGroup& group,
+      void* __restrict__ dst,
+      std::size_t nbytes,
+      int maxBlocks,
+      int numBlocks,
+      int64_t* __restrict__ stepState,
+      SignalState* __restrict__ localSignals,
+      SignalState* __restrict__ remoteSignals,
+      const Timeout& timeout = Timeout(),
+      int chunksPerSlot = 1) {
+#ifdef __CUDA_ARCH__
+    const int blockId = group.group_id;
+    char* __restrict__ dstPtr = reinterpret_cast<char*>(dst);
+    char* __restrict__ stagBuf = localState_.dataBuffer;
+
+    const std::size_t slotSize = options_.dataBufferSize;
+    const std::size_t perBlockSlotSize = (slotSize / numBlocks) & ~15ULL;
+    if (perBlockSlotSize == 0) {
+      printf(
+          "send_tile/recv_tile: perBlockSlotSize is 0 "
+          "(slotSize=%llu, numBlocks=%d). "
+          "Increase dataBufferSize or decrease numBlocks.\n",
+          (unsigned long long)slotSize,
+          numBlocks);
+      __trap();
+    }
+    const std::size_t stagingOff = blockId * perBlockSlotSize;
+    const std::size_t chunkSize = (perBlockSlotSize / chunksPerSlot) & ~15ULL;
+    const std::size_t effectiveChunk =
+        chunkSize > 0 ? chunkSize : perBlockSlotSize;
+
+    const std::size_t totalSteps =
+        (nbytes + effectiveChunk - 1) / effectiveChunk;
+    const std::size_t stepsPerSlot =
+        (perBlockSlotSize + effectiveChunk - 1) / effectiveChunk;
+
+    const uint64_t tailSignalId = blockId;
+    const uint64_t headSignalId = maxBlocks + blockId;
+
+    int64_t step = stepState[maxBlocks + blockId];
+
+    for (std::size_t s = 0; s < totalSteps; ++s) {
+      const std::size_t slotStep = s / stepsPerSlot;
+      const std::size_t subStep = s % stepsPerSlot;
+      const std::size_t slot = slotStep % options_.pipelineDepth;
+      const std::size_t slotOff = slot * slotSize;
+      const std::size_t chunkOff = subStep * effectiveChunk;
+
+      const std::size_t dataOff = s * effectiveChunk;
+      const std::size_t copyBytes = (dataOff + effectiveChunk <= nbytes)
+          ? effectiveChunk
+          : (dataOff < nbytes ? nbytes - dataOff : 0);
+
+      // Wait for sender to fill this sub-chunk
+      localSignals[tailSignalId].wait_until(
+          group, CmpOp::CMP_GE, static_cast<uint64_t>(step + 1), timeout);
+
+      if (copyBytes > 0) {
+        memcpy_vectorized(
+            dstPtr + dataOff,
+            stagBuf + slotOff + stagingOff + chunkOff,
+            copyBytes,
+            group);
+      }
+
+      group.sync();
+      if (group.is_leader()) {
+        // Signal head only at the end of each slot (last sub-step)
+        // to release the slot for sender reuse
+        if (subStep == stepsPerSlot - 1 || s == totalSteps - 1) {
+          remoteSignals[headSignalId].signal(
+              SignalOp::SIGNAL_SET, static_cast<uint64_t>(step + 1));
+        }
+      }
+
+      step++;
+    }
+
+    if (group.is_leader()) {
+      stepState[maxBlocks + blockId] = step;
+    }
+    group.sync();
+#endif
+  }
+
+  /**
+   * send_tile (internal state) — Uses transport-managed stepState.
+   *
+   * Requires tileMaxBlocks > 0 in transport config.
+   * numBlocks controls staging partition, tileMaxBlocks_ controls layout.
+   */
+  __device__ __forceinline__ void send_tile(
+      ThreadGroup& group,
+      void* __restrict__ src,
+      std::size_t nbytes,
+      int numBlocks,
+      const Timeout& timeout = Timeout(),
+      int chunksPerSlot = 1) {
+    send_tile(
+        group,
+        src,
+        nbytes,
+        tileMaxBlocks_,
+        numBlocks,
+        tileStepState_,
+        tileLocalSignals_,
+        tileRemoteSignals_,
+        timeout,
+        chunksPerSlot);
+  }
+
+  /**
+   * recv_tile (internal state) — Uses transport-managed stepState.
+   */
+  __device__ __forceinline__ void recv_tile(
+      ThreadGroup& group,
+      void* __restrict__ dst,
+      std::size_t nbytes,
+      int numBlocks,
+      const Timeout& timeout = Timeout(),
+      int chunksPerSlot = 1) {
+    recv_tile(
+        group,
+        dst,
+        nbytes,
+        tileMaxBlocks_,
+        numBlocks,
+        tileStepState_,
+        tileLocalSignals_,
+        tileRemoteSignals_,
+        timeout,
+        chunksPerSlot);
+  }
+
+  // Getters for tile protocol internal state
+  __host__ __device__ int64_t* tile_step_state() const {
+    return tileStepState_;
+  }
+  __host__ __device__ int tile_max_blocks() const {
+    return tileMaxBlocks_;
+  }
+  __device__ SignalState* tile_local_signals() const {
+    return tileLocalSignals_;
+  }
+  __device__ SignalState* tile_remote_signals() const {
+    return tileRemoteSignals_;
+  }
+
+  // Device accessors for 2D tile kernel (inlined pipeline)
+  __host__ __device__ const P2pNvlTransportOptions& options() const {
+    return options_;
+  }
+  __device__ LocalState& local_state() {
+    return localState_;
+  }
+  __device__ RemoteState& remote_state() {
+    return remoteState_;
+  }
+
+  // Set tile state (called by MultiPeerNvlTransport during construction)
+  __host__ void set_tile_state(
+      int64_t* stepState,
+      int maxBlocks,
+      SignalState* localSignals,
+      SignalState* remoteSignals) {
+    tileStepState_ = stepState;
+    tileMaxBlocks_ = maxBlocks;
+    tileLocalSignals_ = localSignals;
+    tileRemoteSignals_ = remoteSignals;
+  }
+
  private:
   const int myRank_{-1};
   const int peerRank_{-1};
   const P2pNvlTransportOptions options_;
   LocalState localState_;
   RemoteState remoteState_;
+  // Tile protocol state (set by MultiPeerNvlTransport when tileMaxBlocks > 0)
+  int64_t* tileStepState_{nullptr};
+  int tileMaxBlocks_{0};
+  // Dedicated signal buffer for tile tail/head signals
+  // Layout: [0..maxBlocks-1] = tail, [maxBlocks..2*maxBlocks-1] = head
+  SignalState* tileLocalSignals_{nullptr};
+  SignalState* tileRemoteSignals_{nullptr};
 };
 
 } // namespace comms::pipes

--- a/comms/pipes/TiledBuffer.cuh
+++ b/comms/pipes/TiledBuffer.cuh
@@ -1,0 +1,120 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace comms::pipes {
+
+// Forward declaration — full definition in ThreadGroup.cuh
+struct ThreadGroup;
+
+/**
+ * TiledBuffer - Typed view that partitions a buffer into aligned tiles.
+ *
+ * Divides a contiguous buffer into aligned tiles, one per group in a
+ * ThreadGroup partition. Each tile is aligned to 16 bytes. The last tile
+ * may be smaller than the rest.
+ *
+ * Two construction modes:
+ *
+ *   // Mode 1: explicit tile count (host or device)
+ *   TiledBuffer<char> tiles(ptr, nbytes, numBlocks);
+ *   p2p.send_tile(sub, tiles.tile_data(blockId), tiles.tile_bytes(blockId),
+ * ...);
+ *
+ *   // Mode 2: bind to ThreadGroup (device only, preferred)
+ *   TiledBuffer<char> tile(ptr, nbytes, sub);
+ *   p2p.send_tile(sub, tile.data(), tile.bytes(), ...);
+ *
+ * Mode 2 derives num_tiles from group.total_groups and indexes by
+ * group.group_id, eliminating manual blockId bookkeeping.
+ *
+ * @tparam T Element type (e.g., float, __nv_bfloat16, char)
+ */
+template <typename T>
+struct TiledBuffer {
+  T* __restrict__ buf;
+  std::size_t num_elements;
+  int num_tiles;
+  std::size_t tile_elements; // elements per tile (aligned, computed)
+  int my_tile; // this group's tile index (-1 if unbound)
+
+  /// Construct with explicit tile count (host or device).
+  __host__ __device__
+  TiledBuffer(T* __restrict__ data, std::size_t num_elements, int num_tiles)
+      : buf(data),
+        num_elements(num_elements),
+        num_tiles(num_tiles),
+        my_tile(-1) {
+    compute_tile_elements();
+  }
+
+  /// Construct bound to a ThreadGroup (device only).
+  /// Derives num_tiles from group.total_groups, indexes by group.group_id.
+  __device__ TiledBuffer(
+      T* __restrict__ data,
+      std::size_t num_elements,
+      const ThreadGroup& group);
+
+  /// This group's tile data pointer (requires group-bound construction)
+  __device__ __forceinline__ T* __restrict__ data() const {
+    return buf + my_tile * tile_elements;
+  }
+
+  /// This group's tile byte count (requires group-bound construction)
+  __device__ __forceinline__ std::size_t bytes() const {
+    return tile_bytes(my_tile);
+  }
+
+  /// Pointer to tile i's data (explicit indexing)
+  __device__ __forceinline__ T* __restrict__ tile_data(int tile_id) const {
+    return buf + tile_id * tile_elements;
+  }
+
+  /// Number of elements in tile i (last tile may be smaller)
+  __device__ __forceinline__ std::size_t tile_size(int tile_id) const {
+    std::size_t offset = tile_id * tile_elements;
+    if (offset >= num_elements) {
+      return 0;
+    }
+    std::size_t remaining = num_elements - offset;
+    return remaining < tile_elements ? remaining : tile_elements;
+  }
+
+  /// Bytes in tile i
+  __device__ __forceinline__ std::size_t tile_bytes(int tile_id) const {
+    return tile_size(tile_id) * sizeof(T);
+  }
+
+ private:
+  __host__ __device__ void compute_tile_elements() {
+    constexpr std::size_t kAlignElems = 16 / sizeof(T) > 0 ? 16 / sizeof(T) : 1;
+    tile_elements =
+        (((num_elements + num_tiles - 1) / num_tiles) + kAlignElems - 1) &
+        ~(kAlignElems - 1);
+  }
+};
+
+} // namespace comms::pipes
+
+// Include ThreadGroup for the group-bound constructor implementation.
+// Placed after the struct to break the circular dependency.
+#include "comms/pipes/ThreadGroup.cuh"
+
+namespace comms::pipes {
+
+template <typename T>
+__device__ TiledBuffer<T>::TiledBuffer(
+    T* __restrict__ data,
+    std::size_t num_elements,
+    const ThreadGroup& group)
+    : buf(data),
+      num_elements(num_elements),
+      num_tiles(group.total_groups),
+      my_tile(group.group_id) {
+  compute_tile_elements();
+}
+
+} // namespace comms::pipes

--- a/comms/pipes/benchmarks/P2pNvlBenchmarkUtils.h
+++ b/comms/pipes/benchmarks/P2pNvlBenchmarkUtils.h
@@ -21,6 +21,8 @@ struct BenchmarkConfig {
   SyncScope groupScope = SyncScope::WARP; // Thread group scope for parallelism
   bool spreadClusterLaunch = false; // Use spread cluster kernel launch
   bool useDualStateBuffer = false; // Use dual chunk state buffers
+  bool useTiled = false; // Use tiled protocol (Triton-style head/tail)
+  int chunksPerSlot = 1; // Sub-chunks per pipeline slot for finer signaling
   std::string name;
 };
 

--- a/comms/pipes/benchmarks/P2pNvlSendRecvBenchmark.cc
+++ b/comms/pipes/benchmarks/P2pNvlSendRecvBenchmark.cc
@@ -6,9 +6,11 @@
 
 #include "comms/common/CudaWrap.h"
 #include "comms/pipes/MultiPeerNvlTransport.h"
+#include "comms/pipes/TiledBuffer.cuh"
 #include "comms/pipes/benchmarks/BenchmarkKernel.cuh"
 #include "comms/pipes/benchmarks/BenchmarkMacros.h"
 #include "comms/pipes/benchmarks/P2pNvlBenchmarkUtils.h"
+#include "comms/pipes/benchmarks/TileSendRecv.cuh"
 #include "comms/testinfra/BenchmarkTestFixture.h"
 #include "comms/utils/CudaRAII.h"
 
@@ -128,6 +130,65 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     return bandwidth_GBps;
   }
 
+  // Verify correctness of a P2P transfer by filling src with a pattern,
+  // running one send/recv, and checking the received data matches.
+  bool verifyP2pCorrectness(
+      comms::pipes::P2pNvlTransportDevice* p2pDevicePtr,
+      const BenchmarkConfig& config) {
+    DeviceBuffer sendBuff(config.nBytes);
+    DeviceBuffer recvBuff(config.nBytes);
+
+    bool isSend = (globalRank == 0);
+    const int testValue = 0xAB;
+
+    if (isSend) {
+      CUDA_CHECK_BOOL(cudaMemset(sendBuff.get(), testValue, config.nBytes));
+    } else {
+      CUDA_CHECK_BOOL(cudaMemset(recvBuff.get(), 0, config.nBytes));
+    }
+
+    dim3 gridDim(config.numBlocks);
+    dim3 blockDim(config.numThreads);
+    SyncScope groupScope = config.groupScope;
+    void* devicePtr = isSend ? sendBuff.get() : recvBuff.get();
+    std::size_t nBytes = config.nBytes;
+    Timeout timeout;
+    void* args[] = {p2pDevicePtr, &devicePtr, &nBytes, &groupScope, &timeout};
+
+    void* kernelFunc = isSend ? (void*)comms::pipes::benchmark::p2pSend
+                              : (void*)comms::pipes::benchmark::p2pRecv;
+
+    bootstrap->barrierAll();
+    CUDA_CHECK_BOOL(
+        cudaLaunchKernel(kernelFunc, gridDim, blockDim, args, 0, nullptr));
+    CUDA_CHECK_BOOL(cudaDeviceSynchronize());
+    bootstrap->barrierAll();
+
+    if (!isSend) {
+      // Verify received data
+      std::vector<char> hostBuf(config.nBytes);
+      CUDA_CHECK_BOOL(cudaMemcpy(
+          hostBuf.data(),
+          recvBuff.get(),
+          config.nBytes,
+          cudaMemcpyDeviceToHost));
+      for (size_t i = 0; i < config.nBytes; i++) {
+        if (static_cast<unsigned char>(hostBuf[i]) != testValue) {
+          XLOGF(
+              ERR,
+              "VERIFY FAILED {}: byte {} expected 0x{:02X} got 0x{:02X}",
+              config.name,
+              i,
+              testValue,
+              static_cast<unsigned int>(
+                  static_cast<unsigned char>(hostBuf[i])));
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
   // Helper function to run P2P NVL benchmark - returns bandwidth
   // p2pDevicePtr must point to a P2pNvlTransportDevice in host memory
   // (e.g. obtained from buildP2pTransportDevice()).
@@ -166,6 +227,7 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     // cudaLaunchKernel reads the struct by value from host memory for the
     // kernel parameter.
     void* args[] = {p2pDevicePtr, &devicePtr, &nBytes, &groupScope, &timeout};
+
     void* kernelFunc = isSend ? (void*)comms::pipes::benchmark::p2pSend
                               : (void*)comms::pipes::benchmark::p2pRecv;
     cudaStream_t stream = isSend ? sendStream : recvStream;
@@ -202,6 +264,121 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
 
     bootstrap->barrierAll();
 
+    return bandwidth_GBps;
+  }
+
+  // Tile sendrecv — Triton-style head/tail counter protocol.
+  // Uses 16MB slots with per-slot signaling (not per-chunk).
+  float runTileBenchmark(
+      comms::pipes::P2pNvlTransportDevice* p2pDevicePtr,
+      const BenchmarkConfig& config,
+      float& timeUs) {
+    XLOGF(DBG1, "=== Running Tile benchmark: {} ===", config.name);
+
+    DeviceBuffer sendBuff(config.nBytes);
+    DeviceBuffer recvBuff(config.nBytes);
+
+    // Fill send with rank-specific pattern, clear recv
+    const int sendPattern = 0xA0 + globalRank;
+    const int peerPattern = 0xA0 + (1 - globalRank);
+    CUDA_CHECK(cudaMemset(sendBuff.get(), sendPattern, config.nBytes));
+    CUDA_CHECK(cudaMemset(recvBuff.get(), 0, config.nBytes));
+
+    int numSendBlocks = config.numBlocks;
+    int totalBlocks = numSendBlocks * 2;
+    dim3 gridDim(totalBlocks);
+    dim3 blockDim(config.numThreads);
+
+    CudaEvent start, stop;
+    Timeout timeout;
+
+    // Create TiledBuffer views for send and recv
+    comms::pipes::TiledBuffer<char> sendTiles(
+        static_cast<char*>(sendBuff.get()), config.nBytes, numSendBlocks);
+    comms::pipes::TiledBuffer<char> recvTiles(
+        static_cast<char*>(recvBuff.get()), config.nBytes, numSendBlocks);
+
+    int chunksPerSlot = config.chunksPerSlot;
+    void* kernelFunc = (void*)comms::pipes::benchmark::p2pTileSendRecv;
+    void* args[] = {
+        p2pDevicePtr,
+        &sendTiles,
+        &recvTiles,
+        &numSendBlocks,
+        &chunksPerSlot,
+        &timeout};
+
+    dim3 defaultClusterDim(comms::common::kDefaultClusterSize, 1, 1);
+    std::optional<dim3> clusterDimOpt = config.spreadClusterLaunch
+        ? std::optional{defaultClusterDim}
+        : std::nullopt;
+
+    // Correctness verification: run one exchange and check received data
+    bootstrap->barrierAll();
+    CUDA_CHECK(
+        comms::common::launchKernel(
+            kernelFunc, gridDim, blockDim, args, nullptr, clusterDimOpt));
+    CUDA_CHECK(cudaDeviceSynchronize());
+    bootstrap->barrierAll();
+
+    // Verify recv buffer has peer's pattern
+    {
+      std::vector<char> hostBuf(config.nBytes);
+      CUDA_CHECK(cudaMemcpy(
+          hostBuf.data(),
+          recvBuff.get(),
+          config.nBytes,
+          cudaMemcpyDeviceToHost));
+      for (size_t i = 0; i < config.nBytes; i++) {
+        if (static_cast<unsigned char>(hostBuf[i]) !=
+            static_cast<unsigned char>(peerPattern)) {
+          XLOGF(
+              ERR,
+              "TILE VERIFY FAILED {}: byte {} expected 0x{:02X} got 0x{:02X}",
+              config.name,
+              i,
+              peerPattern,
+              static_cast<unsigned int>(
+                  static_cast<unsigned char>(hostBuf[i])));
+          bootstrap->barrierAll();
+          timeUs = 0;
+          return 0;
+        }
+      }
+    }
+
+    // Re-init buffers for benchmark
+    CUDA_CHECK(cudaMemset(sendBuff.get(), sendPattern, config.nBytes));
+    CUDA_CHECK(cudaMemset(recvBuff.get(), 0, config.nBytes));
+
+    // Warmup
+    bootstrap->barrierAll();
+    for (int i = 0; i < kWarmupIters; i++) {
+      CUDA_CHECK(
+          comms::common::launchKernel(
+              kernelFunc, gridDim, blockDim, args, nullptr, clusterDimOpt));
+      CUDA_CHECK(cudaDeviceSynchronize());
+    }
+    bootstrap->barrierAll();
+
+    // Benchmark
+    CUDA_CHECK(cudaEventRecord(start.get()));
+    for (int i = 0; i < kBenchmarkIters; i++) {
+      CUDA_CHECK(
+          comms::common::launchKernel(
+              kernelFunc, gridDim, blockDim, args, nullptr, clusterDimOpt));
+    }
+    CUDA_CHECK(cudaEventRecord(stop.get()));
+    CUDA_CHECK(cudaDeviceSynchronize());
+
+    float totalTime_ms = 0.0f;
+    CUDA_CHECK(cudaEventElapsedTime(&totalTime_ms, start.get(), stop.get()));
+    float avgTime_ms = totalTime_ms / kBenchmarkIters;
+    timeUs = avgTime_ms * 1000.0f;
+    float bandwidth_GBps =
+        (2.0f * config.nBytes / 1e9f) / (avgTime_ms / 1000.0f);
+
+    bootstrap->barrierAll();
     return bandwidth_GBps;
   }
 
@@ -322,12 +499,12 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     // kernel parameter.
     void* args[] = {
         p2pDevicePtr, &sendPtr, &recvPtr, &nBytes, &groupScope, &timeout};
+
     void* kernelFunc = (void*)comms::pipes::benchmark::p2pBidirectional;
 
     // Warmup - no reset needed, recv() signals -1 after each transfer
     bootstrap->barrierAll();
 
-    // Use pointer to cluster dimension for clustered launch
     dim3 defaultClusterDim(comms::common::kDefaultClusterSize, 1, 1);
     std::optional<dim3> clusterDimOpt = config.spreadClusterLaunch
         ? std::optional{defaultClusterDim}
@@ -341,8 +518,7 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     }
     bootstrap->barrierAll();
 
-    // Benchmark - measure time across all iterations
-    // No barrier between iterations - ChunkState provides synchronization
+    // Benchmark
     CUDA_CHECK(cudaEventRecord(start.get()));
     for (int i = 0; i < kBenchmarkIters; i++) {
       CUDA_CHECK(
@@ -553,12 +729,20 @@ TEST_F(P2pSendRecvBenchmarkFixture, UnidirectionalBenchmark) {
     result.numBlocks = config.numBlocks;
     result.numThreads = config.numThreads;
 
+    // Verify correctness before benchmarking
+    if (!verifyP2pCorrectness(&p2pHost, config)) {
+      XLOGF(ERR, "CORRECTNESS CHECK FAILED for config: {}", config.name);
+      if (globalRank == 0) {
+        std::cout << "*** VERIFY FAILED: " << config.name << " ***\n";
+      }
+      continue;
+    }
+
     // Run NCCL benchmark
     result.ncclBandwidth = runNcclBenchmark(config, result.ncclTime);
 
     // Run P2P NVL benchmark
-    result.p2pBandwidth =
-        runP2pNvlBenchmark(&p2pHost, config, result.p2pTime);
+    result.p2pBandwidth = runP2pNvlBenchmark(&p2pHost, config, result.p2pTime);
 
     // Calculate speedup
     result.p2pSpeedup = (result.ncclBandwidth > 0)
@@ -581,77 +765,171 @@ TEST_F(P2pSendRecvBenchmarkFixture, BidirectionalBenchmark) {
 
   int peerRank = (globalRank == 0) ? 1 : 0;
 
-  // Bidirectional test configurations using NCCL-like parameters
+  // Bidirectional test configurations
   std::vector<BenchmarkConfig> configs;
 
-  // 2MB: 256 warps, 128 chunks (16KB each) - matches optimal unidirectional
-  configs.push_back({
-      .nBytes = 2 * 1024 * 1024,
-      .stagedBufferSize = 2 * 1024 * 1024,
-      .numBlocks = 64,
-      .numThreads = 128,
-      .pipelineDepth = 2,
-      .chunkSize = 16 * 1024,
-      .name = "Bidir_2MB",
-  });
+  // NCCL-like bidirectional configs at all message sizes
+  std::vector<std::pair<std::size_t, std::string>> bidiSizes = {
+      {8 * 1024, "8K"},
+      {16 * 1024, "16K"},
+      {64 * 1024, "64K"},
+      {128 * 1024, "128K"},
+      {256 * 1024, "256K"},
+      {512 * 1024, "512K"},
+      {1024 * 1024, "1M"},
+      {2 * 1024 * 1024, "2M"},
+      {4 * 1024 * 1024, "4M"},
+      {8 * 1024 * 1024, "8M"},
+      {16 * 1024 * 1024, "16M"},
+      {32 * 1024 * 1024, "32M"},
+      {64 * 1024 * 1024, "64M"},
+      {128 * 1024 * 1024, "128M"},
+      {256 * 1024 * 1024, "256M"},
+      {512 * 1024 * 1024, "512M"},
+      {1024 * 1024 * 1024, "1G"},
+  };
+  for (const auto& [sz, nm] : bidiSizes) {
+    configs.push_back({
+        .nBytes = sz,
+        .stagedBufferSize = 8 * 1024 * 1024,
+        .numBlocks = 32,
+        .numThreads = 512,
+        .pipelineDepth = 2,
+        .chunkSize = 512 * 1024,
+        .groupScope = SyncScope::BLOCK,
+        .name = "Bidir_" + nm,
+    });
+  }
 
-  // 64MB: 512 warps, 256 chunks (128KB each)
-  configs.push_back({
-      .nBytes = 64 * 1024 * 1024,
-      .stagedBufferSize = 8 * 1024 * 1024,
-      .numBlocks = 32,
-      .numThreads = 512,
-      .pipelineDepth = 2,
-      .chunkSize = 512 * 1024,
-      .groupScope = SyncScope::BLOCK,
-      .name = "Bidir_64MB",
-  });
+  // === TILE CONFIGS (Triton-style: 8MB slots, head/tail counters) ===
+  auto addTileConfig = [&](std::size_t sizeBytes, const std::string& name) {
+    constexpr std::size_t kSlot = 8 * 1024 * 1024; // 8MB per slot
+    configs.push_back({
+        .nBytes = sizeBytes,
+        .stagedBufferSize = kSlot,
+        .numBlocks = 16,
+        .numThreads = 512,
+        .pipelineDepth = 2, // 2 slots = 16MB total
+        .chunkSize = kSlot,
+        .groupScope = SyncScope::BLOCK,
+        .useTiled = true,
+        .name = name,
+    });
+  };
 
-  configs.push_back({
-      .nBytes = 128 * 1024 * 1024,
-      .stagedBufferSize = 8 * 1024 * 1024,
-      .numBlocks = 32,
-      .numThreads = 512,
-      .pipelineDepth = 2,
-      .chunkSize = 512 * 1024,
-      .groupScope = SyncScope::BLOCK,
-      .name = "Bidir_128MB",
-  });
+  std::vector<std::pair<std::size_t, std::string>> tileSizes = {
+      {8 * 1024, "8K"},
+      {16 * 1024, "16K"},
+      {64 * 1024, "64K"},
+      {128 * 1024, "128K"},
+      {256 * 1024, "256K"},
+      {512 * 1024, "512K"},
+      {1 * 1024 * 1024, "1M"},
+      {2 * 1024 * 1024, "2M"},
+      {4 * 1024 * 1024, "4M"},
+      {8 * 1024 * 1024, "8M"},
+      {16 * 1024 * 1024, "16M"},
+      {32 * 1024 * 1024, "32M"},
+      {64 * 1024 * 1024, "64M"},
+      {128 * 1024 * 1024, "128M"},
+      {256 * 1024 * 1024, "256M"},
+      {512 * 1024 * 1024, "512M"},
+      {1024 * 1024 * 1024, "1G"},
+  };
+  for (const auto& [sz, nm] : tileSizes) {
+    addTileConfig(sz, "Tile_" + nm);
+  }
 
-  // 256MB: 512 warps, 256 chunks (256KB each)
-  configs.push_back({
-      .nBytes = 256 * 1024 * 1024,
-      .stagedBufferSize = 8 * 1024 * 1024,
-      .numBlocks = 32,
-      .numThreads = 512,
-      .pipelineDepth = 2,
-      .chunkSize = 512 * 1024,
-      .groupScope = SyncScope::BLOCK,
-      .name = "Bidir_256MB",
-  });
+  // === CLUSTERED TILE CONFIGS ===
+  for (const auto& [sz, nm] : tileSizes) {
+    constexpr std::size_t kSlot = 8 * 1024 * 1024;
+    configs.push_back({
+        .nBytes = sz,
+        .stagedBufferSize = kSlot,
+        .numBlocks = 16,
+        .numThreads = 512,
+        .pipelineDepth = 2,
+        .chunkSize = kSlot,
+        .groupScope = SyncScope::BLOCK,
+        .spreadClusterLaunch = true,
+        .useTiled = true,
+        .name = "TileClus_" + nm,
+    });
+  }
 
-  configs.push_back({
-      .nBytes = 512 * 1024 * 1024,
-      .stagedBufferSize = 8 * 1024 * 1024,
-      .numBlocks = 32,
-      .numThreads = 512,
-      .pipelineDepth = 2,
-      .chunkSize = 512 * 1024,
-      .groupScope = SyncScope::BLOCK,
-      .name = "Bidir_512MB",
-  });
+  // === CHUNKS PER SLOT SWEEP (clustered, 8MB staging, pd=2) ===
+  for (int cps : {2, 4, 8}) {
+    for (const auto& [sz, nm] : tileSizes) {
+      if (sz < 1 * 1024 * 1024)
+        continue; // only test >= 1MB
+      constexpr std::size_t kSlot2 = 8 * 1024 * 1024;
+      configs.push_back({
+          .nBytes = sz,
+          .stagedBufferSize = kSlot2,
+          .numBlocks = 16,
+          .numThreads = 512,
+          .pipelineDepth = 2,
+          .chunkSize = kSlot2,
+          .groupScope = SyncScope::BLOCK,
+          .spreadClusterLaunch = true,
+          .useTiled = true,
+          .chunksPerSlot = cps,
+          .name = "CPS" + std::to_string(cps) + "_" + nm,
+      });
+    }
+  }
 
-  // 1GB with 256MB staging
-  configs.push_back({
-      .nBytes = 1024 * 1024 * 1024,
-      .stagedBufferSize = 8 * 1024 * 1024,
-      .numBlocks = 32,
-      .numThreads = 512,
-      .pipelineDepth = 2,
-      .chunkSize = 512 * 1024,
-      .groupScope = SyncScope::BLOCK,
-      .name = "Bidir_1GB",
-  });
+  // Sweep staging buffer configurations with 128KB signal granularity (best
+  // from signal sweep) Baseline: 8MB slot × pd=2 = 16MB total (already covered
+  // by Tile_*) Variant A: 16MB slot × pd=2 = 32MB total (larger slots, fewer
+  // round-trips) Variant B: 8MB slot × pd=4 = 32MB total (deeper pipeline, same
+  // slot size)
+  struct StagingConfig {
+    std::size_t slotSize;
+    std::size_t pipelineDepth;
+    std::string prefix;
+  };
+  std::vector<StagingConfig> stagingConfigs = {
+      {16 * 1024 * 1024, 2, "Stg32M_"}, // 16MB×2 = 32MB total
+      {8 * 1024 * 1024, 4, "Pd4_"}, // 8MB×4 = 32MB total
+  };
+
+  for (const auto& sc : stagingConfigs) {
+    for (const auto& [sz, nm] : tileSizes) {
+      if (sz < 4 * 1024 * 1024)
+        continue; // only test >= 4MB
+
+      configs.push_back({
+          .nBytes = sz,
+          .stagedBufferSize = sc.slotSize,
+          .numBlocks = 16,
+          .numThreads = 512,
+          .pipelineDepth = sc.pipelineDepth,
+          .chunkSize = 128 * 1024, // best signal granularity
+          .groupScope = SyncScope::BLOCK,
+          .useTiled = true,
+          .name = sc.prefix + nm,
+      });
+    }
+  }
+
+  // Also test best signal granularity (128KB) with baseline staging for
+  // comparison
+  for (const auto& [sz, nm] : tileSizes) {
+    if (sz < 4 * 1024 * 1024)
+      continue;
+    configs.push_back({
+        .nBytes = sz,
+        .stagedBufferSize = 8 * 1024 * 1024,
+        .numBlocks = 16,
+        .numThreads = 512,
+        .pipelineDepth = 2,
+        .chunkSize = 128 * 1024,
+        .groupScope = SyncScope::BLOCK,
+        .useTiled = true,
+        .name = "Sig128K_" + nm,
+    });
+  }
 
   std::vector<BenchmarkResult> results;
 
@@ -668,7 +946,6 @@ TEST_F(P2pSendRecvBenchmarkFixture, BidirectionalBenchmark) {
         globalRank, worldSize, bootstrap, p2pConfig);
     transport.exchange();
 
-    // Build host-side P2pNvlTransportDevice (passed by value to kernel)
     auto p2pHost = transport.buildP2pTransportDevice(peerRank);
 
     BenchmarkResult result;
@@ -684,9 +961,13 @@ TEST_F(P2pSendRecvBenchmarkFixture, BidirectionalBenchmark) {
     result.ncclBandwidth =
         runNcclBidirectionalBenchmark(config, result.ncclTime);
 
-    // Run P2P NVL bidirectional benchmark
-    result.p2pBandwidth =
-        runP2pNvlBidirectionalBenchmark(&p2pHost, config, result.p2pTime);
+    // Run P2P benchmark
+    if (config.useTiled) {
+      result.p2pBandwidth = runTileBenchmark(&p2pHost, config, result.p2pTime);
+    } else {
+      result.p2pBandwidth =
+          runP2pNvlBidirectionalBenchmark(&p2pHost, config, result.p2pTime);
+    }
 
     // Calculate speedup
     result.p2pSpeedup = (result.ncclBandwidth > 0)

--- a/comms/pipes/benchmarks/P2pNvlSendRecvBenchmark.cc
+++ b/comms/pipes/benchmarks/P2pNvlSendRecvBenchmark.cc
@@ -10,7 +10,6 @@
 #include "comms/pipes/benchmarks/BenchmarkMacros.h"
 #include "comms/pipes/benchmarks/P2pNvlBenchmarkUtils.h"
 #include "comms/testinfra/BenchmarkTestFixture.h"
-#include "comms/testinfra/mpi/MpiTestUtils.h"
 #include "comms/utils/CudaRAII.h"
 
 #include <iomanip>
@@ -130,8 +129,8 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
   }
 
   // Helper function to run P2P NVL benchmark - returns bandwidth
-  // p2pDevicePtr must point to a P2pNvlTransportDevice in device memory
-  // (e.g. obtained from getDeviceTransports()).
+  // p2pDevicePtr must point to a P2pNvlTransportDevice in host memory
+  // (e.g. obtained from buildP2pTransportDevice()).
   float runP2pNvlBenchmark(
       comms::pipes::P2pNvlTransportDevice* p2pDevicePtr,
       const BenchmarkConfig& config,
@@ -163,7 +162,10 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     SyncScope groupScope = config.groupScope;
     void* devicePtr = (isSend ? sendBuff.get() : recvBuff.get());
     Timeout timeout; // Default timeout (disabled)
-    void* args[] = {&p2pDevicePtr, &devicePtr, &nBytes, &groupScope, &timeout};
+    // p2pDevicePtr points to a host-side P2pNvlTransportDevice;
+    // cudaLaunchKernel reads the struct by value from host memory for the
+    // kernel parameter.
+    void* args[] = {p2pDevicePtr, &devicePtr, &nBytes, &groupScope, &timeout};
     void* kernelFunc = isSend ? (void*)comms::pipes::benchmark::p2pSend
                               : (void*)comms::pipes::benchmark::p2pRecv;
     cudaStream_t stream = isSend ? sendStream : recvStream;
@@ -286,8 +288,8 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
   }
 
   // Helper function to run P2P NVL bidirectional benchmark - returns algorithm
-  // BW. p2pDevicePtr must point to a P2pNvlTransportDevice in device memory
-  // (e.g. obtained from getDeviceTransports()).
+  // BW. p2pDevicePtr must point to a P2pNvlTransportDevice in host memory
+  // (e.g. obtained from buildP2pTransportDevice()).
   float runP2pNvlBidirectionalBenchmark(
       comms::pipes::P2pNvlTransportDevice* p2pDevicePtr,
       const BenchmarkConfig& config,
@@ -315,8 +317,11 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     void* recvPtr = recvBuff.get();
     SyncScope groupScope = config.groupScope;
     Timeout timeout; // Default timeout (disabled)
+    // p2pDevicePtr points to a host-side P2pNvlTransportDevice;
+    // cudaLaunchKernel reads the struct by value from host memory for the
+    // kernel parameter.
     void* args[] = {
-        &p2pDevicePtr, &sendPtr, &recvPtr, &nBytes, &groupScope, &timeout};
+        p2pDevicePtr, &sendPtr, &recvPtr, &nBytes, &groupScope, &timeout};
     void* kernelFunc = (void*)comms::pipes::benchmark::p2pBidirectional;
 
     // Warmup - no reset needed, recv() signals -1 after each transfer
@@ -536,10 +541,8 @@ TEST_F(P2pSendRecvBenchmarkFixture, UnidirectionalBenchmark) {
         globalRank, worldSize, bootstrap, p2pConfig);
     transport.exchange();
 
-    // Get device pointer to the pre-allocated P2pNvlTransportDevice
-    // from the device-side Transport array (indexed by global rank).
-    auto deviceTransports = transport.getDeviceTransports();
-    auto* p2pDevicePtr = &deviceTransports.data()[peerRank].p2p_nvl;
+    // Build host-side P2pNvlTransportDevice (passed by value to kernel)
+    auto p2pHost = transport.buildP2pTransportDevice(peerRank);
 
     BenchmarkResult result;
     result.testName = config.name;
@@ -555,7 +558,7 @@ TEST_F(P2pSendRecvBenchmarkFixture, UnidirectionalBenchmark) {
 
     // Run P2P NVL benchmark
     result.p2pBandwidth =
-        runP2pNvlBenchmark(p2pDevicePtr, config, result.p2pTime);
+        runP2pNvlBenchmark(&p2pHost, config, result.p2pTime);
 
     // Calculate speedup
     result.p2pSpeedup = (result.ncclBandwidth > 0)
@@ -665,10 +668,8 @@ TEST_F(P2pSendRecvBenchmarkFixture, BidirectionalBenchmark) {
         globalRank, worldSize, bootstrap, p2pConfig);
     transport.exchange();
 
-    // Get device pointer to the pre-allocated P2pNvlTransportDevice
-    // from the device-side Transport array (indexed by global rank).
-    auto deviceTransports = transport.getDeviceTransports();
-    auto* p2pDevicePtr = &deviceTransports.data()[peerRank].p2p_nvl;
+    // Build host-side P2pNvlTransportDevice (passed by value to kernel)
+    auto p2pHost = transport.buildP2pTransportDevice(peerRank);
 
     BenchmarkResult result;
     result.testName = config.name;
@@ -685,7 +686,7 @@ TEST_F(P2pSendRecvBenchmarkFixture, BidirectionalBenchmark) {
 
     // Run P2P NVL bidirectional benchmark
     result.p2pBandwidth =
-        runP2pNvlBidirectionalBenchmark(p2pDevicePtr, config, result.p2pTime);
+        runP2pNvlBidirectionalBenchmark(&p2pHost, config, result.p2pTime);
 
     // Calculate speedup
     result.p2pSpeedup = (result.ncclBandwidth > 0)

--- a/comms/pipes/benchmarks/TileSendRecv.cu
+++ b/comms/pipes/benchmarks/TileSendRecv.cu
@@ -1,0 +1,135 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Tile send/recv kernels — caller partitions data across blocks,
+// each block calls P2pNvlTransportDevice::send_tile/recv_tile.
+
+#include "comms/pipes/benchmarks/TileSendRecv.cuh"
+
+namespace comms::pipes::benchmark {
+
+__global__ __launch_bounds__(512, 1) void p2pTileSendRecv(
+    P2pNvlTransportDevice p2p,
+    TiledBuffer<char> sendTiles,
+    TiledBuffer<char> recvTiles,
+    int numBlocks,
+    int chunksPerSlot,
+    Timeout timeout) {
+  timeout.start();
+
+  auto group = make_block_group();
+  auto [role, sub] = group.partition(2);
+
+  const int blockId = sub.group_id;
+
+  if (role == 0) {
+    p2p.send_tile(
+        sub,
+        sendTiles.tile_data(blockId),
+        sendTiles.tile_bytes(blockId),
+        numBlocks,
+        timeout,
+        chunksPerSlot);
+  } else {
+    p2p.recv_tile(
+        sub,
+        recvTiles.tile_data(blockId),
+        recvTiles.tile_bytes(blockId),
+        numBlocks,
+        timeout,
+        chunksPerSlot);
+  }
+}
+
+// =============================================================================
+// Dynamic block count variant — uses transport-internal tile state
+// =============================================================================
+//
+// Requires tileMaxBlocks > 0 and p2pBarrierCount >= tileMaxBlocks in
+// transport config.
+//
+// DYNAMIC BLOCK COUNT: BARRIER CORRECTNESS
+// =========================================
+// When numBlocks changes between kernel launches, the staging buffer
+// layout shifts (perBlockSlotSize = dataBufferSize / numBlocks). This
+// creates a cross-GPU race: the new sender on GPU A may overwrite
+// staging positions that the old receiver on GPU B is still reading.
+//
+// The per-block barrier_sync_threadgroup prevents this race:
+//
+//   Stream ordering guarantee:
+//     Both kernels execute on the same CUDA stream per GPU. So on each
+//     GPU individually, kernel N completes before kernel N+1 starts.
+//     But GPU A's kernel N+1 can start while GPU B's kernel N is still
+//     running (no cross-GPU stream ordering).
+//
+//   What the barrier provides:
+//     Each block in the NEW kernel barriers with its same-numbered peer
+//     block on the remote GPU. Since the peer block can only reach the
+//     barrier AFTER its kernel N+1 starts, and kernel N+1 can only start
+//     after kernel N completed (stream ordering), the barrier guarantees
+//     that ALL of the peer's kernel N work is done — including reads
+//     from the staging buffer.
+//
+//   Higher → Lower (e.g., 16 → 8 blocks):
+//     Only blocks 0-7 are launched. Blocks 8-15 don't barrier, but
+//     that's safe: stream ordering on the peer ensures kernel N (which
+//     used blocks 8-15) completed before kernel N+1 started on that GPU.
+//     Barrier counters for blocks 8-15 remain consistent because BOTH
+//     GPUs skip them (same kernel launch parameters on both sides).
+//
+//   Lower → Higher (e.g., 8 → 16 blocks):
+//     Blocks 8-15 are new on both GPUs. Both sides launch them, so both
+//     call barrier(8..15). The barrier counters may have stale values
+//     from earlier kernels, but they're symmetric (both sides did the
+//     same number of arrive/wait cycles), so the monotonic arrive/wait
+//     succeeds correctly.
+//
+//   Why the receiver doesn't need protection:
+//     The new receiver waits for TAIL signals from the new sender before
+//     reading. The old sender on the remote GPU completed (stream
+//     ordering). So the receiver never reads stale data.
+//
+// CUDA graph compatible: all device-side (no host synchronization).
+
+__global__ __launch_bounds__(512, 1) void p2pTileSendRecvDynamic(
+    P2pNvlTransportDevice p2p,
+    TiledBuffer<char> sendTiles,
+    TiledBuffer<char> recvTiles,
+    int numBlocks,
+    bool needsBarrier,
+    Timeout timeout) {
+  timeout.start();
+
+  auto group = make_block_group();
+  auto [role, sub] = group.partition(2);
+  const int blockId = sub.group_id;
+
+  // If block count changed, each block barriers with its peer.
+  // Since kernels are on the same stream, the peer's current kernel can't
+  // start until its previous kernel finished. So when any peer block
+  // reaches the barrier, ALL of the peer's old-round work is done.
+  // Each block uses its own barrier slot — all barriers complete in parallel.
+  // Requires p2pBarrierCount >= tileMaxBlocks.
+  if (needsBarrier) {
+    p2p.barrier_sync_threadgroup(sub, blockId, timeout);
+  }
+
+  // Uses transport-internal tile signals, stepState, and maxBlocks
+  if (role == 0) {
+    p2p.send_tile(
+        sub,
+        sendTiles.tile_data(blockId),
+        sendTiles.tile_bytes(blockId),
+        numBlocks,
+        timeout);
+  } else {
+    p2p.recv_tile(
+        sub,
+        recvTiles.tile_data(blockId),
+        recvTiles.tile_bytes(blockId),
+        numBlocks,
+        timeout);
+  }
+}
+
+} // namespace comms::pipes::benchmark

--- a/comms/pipes/benchmarks/TileSendRecv.cuh
+++ b/comms/pipes/benchmarks/TileSendRecv.cuh
@@ -1,0 +1,182 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Tile send/recv — bidirectional pipelined data transfer over NVLink.
+//
+// OVERVIEW
+// ========
+// Each GPU simultaneously sends AND receives by partitioning the kernel's
+// thread blocks into two roles (sender blocks and receiver blocks) and
+// giving each block an independent tile of data. The transport pipelines
+// tiles through a staging buffer using monotonic head/tail signal counters
+// for backpressure.
+//
+// KERNEL LAUNCH
+// =============
+// The kernel is launched with 2 * numSendBlocks total blocks:
+//   - Blocks [0, numSendBlocks)              → sender role
+//   - Blocks [numSendBlocks, 2*numSendBlocks) → receiver role
+//
+// Partitioning is done via ThreadGroup::partition(2):
+//   auto [role, sub] = group.partition(2);
+//   role == 0 → sender,  sub.group_id ∈ [0, numSendBlocks)
+//   role == 1 → receiver, sub.group_id ∈ [0, numSendBlocks)
+//
+// DATA PARTITIONING (caller-side)
+// ===============================
+// The caller divides the message into numSendBlocks contiguous tiles:
+//
+//   tileSize = ceil(nBytes / numSendBlocks) aligned to 16B
+//   tile i   = [i * tileSize, min((i+1) * tileSize, nBytes))
+//
+// Each sender block i sends tile i; each receiver block i receives tile i.
+// Sender block i is paired with receiver block i on the remote GPU.
+//
+// PIPELINING (inside send_tile / recv_tile)
+// =========================================
+// Each block's tile may be larger than the per-block staging area. The tile
+// is therefore pipelined through the staging buffer in multiple steps:
+//
+//   perBlockSlotSize = floor(dataBufferSize / numBlocks) & ~15
+//   totalSlotSteps   = ceil(tileBytes / perBlockSlotSize)
+//
+// Each step uses one of `pipelineDepth` slots (step % pipelineDepth) to
+// allow sender and receiver to overlap:
+//
+//   Step 0: sender writes to slot 0, signals tail=1
+//   Step 1: sender writes to slot 1, signals tail=2
+//           receiver reads slot 0, signals head=1
+//   Step 2: sender waits for head >= 1 (slot 0 freed), writes slot 0
+//           receiver reads slot 1, signals head=2
+//   ...
+//
+// SIGNAL PROTOCOL
+// ===============
+// Uses 2 * numSendBlocks SignalState entries (128-byte aligned, sys scope):
+//
+//   signal[i]                = tail counter for block pair i
+//                              (sender → receiver: "data is ready")
+//   signal[numBlocks + i]   = head counter for block pair i
+//                              (receiver → sender: "slot is freed")
+//
+// Both counters are monotonically increasing. The sender waits for
+//   head >= step - pipelineDepth + 1
+// before reusing a slot (backpressure). The receiver waits for
+//   tail >= step + 1
+// before reading (data availability).
+//
+// Memory ordering:
+//   - signal() uses st.release.sys.global → all prior writes (memcpy data)
+//     are visible to the peer before the signal is observed.
+//   - wait_until() uses ld.acquire.sys.global → all subsequent reads see
+//     the data the peer wrote before signaling.
+//
+// MULTI-CALL CORRECTNESS
+// ======================
+// The step counters are persisted in device memory (`stepState`):
+//   stepState[0..numBlocks-1]           = sender step per block
+//   stepState[numBlocks..2*numBlocks-1] = receiver step per block
+//
+// On first call (stepState zeroed), sender starts at step=0, receiver at
+// step=0. On subsequent calls, they resume from where they left off.
+// Because signals are monotonically increasing, old signal values from
+// previous calls are always < current expected values, so no ABA issue.
+//
+// PRECONDITION: stepState must be zeroed before the first kernel launch.
+// The transport's exchange() zeroes the signal buffers. For repeated
+// launches with the same transport, the persistent step counters handle
+// correctness automatically.
+//
+//
+// CORRECTNESS ANALYSIS
+// ====================
+// 1. No data race on staging buffer:
+//    - Sender writes to slot S, then signals tail.
+//    - Receiver waits for tail (acquire), reads slot S, then signals head.
+//    - Sender waits for head (acquire) before reusing slot S.
+//    → Slot S is never written and read simultaneously.
+//
+// 2. No signal race:
+//    - Each (tail, head) pair is used by exactly one sender block and one
+//      receiver block. No two blocks share a signal slot.
+//
+// 3. No ABA on signals:
+//    - Monotonically increasing step values + CMP_GE comparisons ensure
+//      stale values from prior steps are always < expected.
+//
+// 4. group.sync() before signal:
+//    - Ensures all threads in the block complete their memcpy_vectorized
+//      before the leader signals. Without this, the peer could observe
+//      the signal before all data is written.
+
+#pragma once
+
+#include "comms/pipes/P2pNvlTransportDevice.cuh"
+#include "comms/pipes/TiledBuffer.cuh"
+
+namespace comms::pipes::benchmark {
+
+constexpr int kNumSlots = 2;
+constexpr std::size_t kSlotSize = 16 * 1024 * 1024; // 16MB per slot
+
+// Step state: persistent per-block step counters for multi-call correctness.
+// Array of int64: [0..numSendBlocks-1] = sender steps,
+//                 [numSendBlocks..2*numSendBlocks-1] = receiver steps.
+// Initialize to 0 before first use. The kernel loads at start, stores at end.
+
+/**
+ * p2pTileSendRecv — Bidirectional tiled send/recv kernel.
+ *
+ * Launches with 2 * numSendBlocks blocks. The first half are senders,
+ * the second half are receivers. Each sender/receiver pair transfers
+ * an independent tile of data through the pipelined staging buffer.
+ *
+ * Uses TiledBuffer<char> to partition data across blocks, eliminating
+ * manual offset math. Each block queries its tile pointer and size from
+ * the TiledBuffer.
+ *
+ * @param p2p           Transport device (passed by value from host memory)
+ * @param sendTiles     Tiled view of the send buffer
+ * @param recvTiles     Tiled view of the recv buffer
+ * @param stepState     Persistent step counters [2 * numSendBlocks int64s],
+ *                      zeroed before first use
+ * @param timeout       Optional timeout for signal waits
+ */
+__global__ void p2pTileSendRecv(
+    P2pNvlTransportDevice p2p,
+    TiledBuffer<char> sendTiles,
+    TiledBuffer<char> recvTiles,
+    int numBlocks,
+    int chunksPerSlot = 1,
+    Timeout timeout = Timeout());
+
+/**
+ * p2pTileSendRecvDynamic — Variant using transport-internal tile state
+ * with support for dynamic block count changes.
+ *
+ * Requires tileMaxBlocks > 0 and p2pBarrierCount >= tileMaxBlocks.
+ * StepState, signals, and maxBlocks are managed internally by the transport.
+ *
+ * Signal layout uses maxBlocks (constant across launches) so that block k
+ * always maps to signal slot k regardless of numBlocks. The staging buffer
+ * partition uses numBlocks (variable) for efficient use of staging memory.
+ *
+ * When numBlocks changes, the caller must set needsBarrier=true. Each block
+ * does barrier_sync_threadgroup with its peer to ensure the remote GPU's
+ * previous kernel completed all staging reads before the new layout takes
+ * effect. See TileSendRecv.cu for the full correctness analysis.
+ *
+ * CUDA graph compatible: all synchronization is device-side.
+ *
+ * @param numBlocks    Active block count (controls staging partition).
+ *                     Launch with 2 * numBlocks total blocks.
+ * @param needsBarrier Set true when numBlocks changed since last call.
+ */
+__global__ void p2pTileSendRecvDynamic(
+    P2pNvlTransportDevice p2p,
+    TiledBuffer<char> sendTiles,
+    TiledBuffer<char> recvTiles,
+    int numBlocks,
+    bool needsBarrier,
+    Timeout timeout = Timeout());
+
+} // namespace comms::pipes::benchmark

--- a/comms/pipes/tests/P2pNvlTransportTest.cc
+++ b/comms/pipes/tests/P2pNvlTransportTest.cc
@@ -11,6 +11,8 @@
 
 #include "comms/pipes/MultiPeerNvlTransport.h"
 #include "comms/pipes/P2pNvlTransportDevice.cuh"
+#include "comms/pipes/TiledBuffer.cuh"
+#include "comms/pipes/benchmarks/TileSendRecv.cuh"
 #include "comms/pipes/tests/P2pNvlTransportTest.cuh"
 #include "comms/pipes/tests/Utils.cuh"
 #include "comms/testinfra/TestXPlatUtils.h"
@@ -371,6 +373,582 @@ void runBasicSendRecvTest(
     CUDACHECK_TEST(cudaGraphDestroy(graph));
     CUDACHECK_TEST(cudaStreamDestroy(stream));
   }
+}
+
+// =============================================================================
+// Tile sendrecv multi-call correctness test
+// =============================================================================
+
+TEST_F(P2pNvlTransportTestFixture, TileSendRecvMultiCall) {
+  if (numRanks != 2) {
+    XLOGF(WARNING, "Skipping: requires 2 ranks, got {}", numRanks);
+    return;
+  }
+
+  int peerRank = (globalRank == 0) ? 1 : 0;
+  const size_t nBytes = 8 * 1024 * 1024; // 8MB
+  const int numSendBlocks = 4;
+  const int nIters = 5; // call sendrecv 5 times with different data
+
+  MultiPeerNvlTransportConfig config{
+      .dataBufferSize = 8 * 1024 * 1024, // 8MB slot
+      .chunkSize = 8 * 1024 * 1024,
+      .pipelineDepth = 2,
+  };
+
+  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
+  transport.exchange();
+  auto p2pHost = transport.buildP2pTransportDevice(peerRank);
+
+  DeviceBuffer sendBuf(nBytes);
+  DeviceBuffer recvBuf(nBytes);
+
+  dim3 grid(numSendBlocks * 2);
+  dim3 block(256);
+
+  Timeout timeout;
+
+  for (int iter = 0; iter < nIters; iter++) {
+    const int pattern = 0x10 + globalRank + iter * 0x20;
+    const int peerPattern = 0x10 + peerRank + iter * 0x20;
+
+    CUDACHECK_TEST(cudaMemset(sendBuf.get(), pattern, nBytes));
+    CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, nBytes));
+
+    comms::pipes::TiledBuffer<char> sendTiles(
+        static_cast<char*>(sendBuf.get()), nBytes, numSendBlocks);
+    comms::pipes::TiledBuffer<char> recvTiles(
+        static_cast<char*>(recvBuf.get()), nBytes, numSendBlocks);
+    int numBlocksArg = numSendBlocks;
+    int chunksPerSlot = 1;
+    void* args[] = {
+        &p2pHost,
+        &sendTiles,
+        &recvTiles,
+        &numBlocksArg,
+        &chunksPerSlot,
+        &timeout};
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    CUDACHECK_TEST(cudaLaunchKernel(
+        (void*)comms::pipes::benchmark::p2pTileSendRecv,
+        grid,
+        block,
+        args,
+        0,
+        nullptr));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    // Verify received data
+    std::vector<char> hostBuf(nBytes);
+    CUDACHECK_TEST(cudaMemcpy(
+        hostBuf.data(), recvBuf.get(), nBytes, cudaMemcpyDeviceToHost));
+
+    for (size_t i = 0; i < nBytes; i++) {
+      EXPECT_EQ(
+          static_cast<unsigned char>(hostBuf[i]),
+          static_cast<unsigned char>(peerPattern))
+          << "Iter " << iter << ": Mismatch at byte " << i;
+      if (static_cast<unsigned char>(hostBuf[i]) !=
+          static_cast<unsigned char>(peerPattern)) {
+        break;
+      }
+    }
+  }
+}
+
+// =============================================================================
+// send_tile / recv_tile Tests
+// =============================================================================
+
+// Helper: run tile sendrecv with given params and verify correctness
+static void runTileTest(
+    int globalRank,
+    int numRanks,
+    std::shared_ptr<meta::comms::MpiBootstrap> bootstrap,
+    size_t nBytes,
+    size_t dataBufferSize,
+    size_t chunkSize,
+    size_t pipelineDepth,
+    int numSendBlocks,
+    int nIters,
+    int threadCount = 256) {
+  int peerRank = (globalRank == 0) ? 1 : 0;
+
+  MultiPeerNvlTransportConfig config{
+      .dataBufferSize = dataBufferSize,
+      .chunkSize = chunkSize,
+      .pipelineDepth = pipelineDepth,
+  };
+
+  MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
+  transport.exchange();
+  auto p2pHost = transport.buildP2pTransportDevice(peerRank);
+
+  DeviceBuffer sendBuf(nBytes);
+  DeviceBuffer recvBuf(nBytes);
+
+  dim3 grid(numSendBlocks * 2);
+  dim3 block(threadCount);
+
+  Timeout timeout;
+
+  for (int iter = 0; iter < nIters; iter++) {
+    const int pattern = 0x10 + globalRank + iter * 0x20;
+    const int peerPattern = 0x10 + peerRank + iter * 0x20;
+
+    CUDACHECK_TEST(cudaMemset(sendBuf.get(), pattern, nBytes));
+    CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, nBytes));
+
+    comms::pipes::TiledBuffer<char> sendTiles(
+        static_cast<char*>(sendBuf.get()), nBytes, numSendBlocks);
+    comms::pipes::TiledBuffer<char> recvTiles(
+        static_cast<char*>(recvBuf.get()), nBytes, numSendBlocks);
+    int numBlocksArg = numSendBlocks;
+    int chunksPerSlot = 1;
+    void* args[] = {
+        &p2pHost,
+        &sendTiles,
+        &recvTiles,
+        &numBlocksArg,
+        &chunksPerSlot,
+        &timeout};
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    CUDACHECK_TEST(cudaLaunchKernel(
+        (void*)comms::pipes::benchmark::p2pTileSendRecv,
+        grid,
+        block,
+        args,
+        0,
+        nullptr));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    std::vector<char> hostBuf(nBytes);
+    CUDACHECK_TEST(cudaMemcpy(
+        hostBuf.data(), recvBuf.get(), nBytes, cudaMemcpyDeviceToHost));
+
+    for (size_t i = 0; i < nBytes; i++) {
+      EXPECT_EQ(
+          static_cast<unsigned char>(hostBuf[i]),
+          static_cast<unsigned char>(peerPattern))
+          << "Iter " << iter << ": Mismatch at byte " << i
+          << " (nBytes=" << nBytes << ", blocks=" << numSendBlocks
+          << ", slot=" << dataBufferSize << ", chunk=" << chunkSize
+          << ", pd=" << pipelineDepth << ")";
+      if (static_cast<unsigned char>(hostBuf[i]) !=
+          static_cast<unsigned char>(peerPattern)) {
+        return; // stop on first failure
+      }
+    }
+  }
+}
+
+// Test various message sizes with default config
+TEST_F(P2pNvlTransportTestFixture, TileSendRecvMessageSizes) {
+  if (numRanks != 2) {
+    return;
+  }
+  auto bs = std::make_shared<meta::comms::MpiBootstrap>();
+
+  // Small sizes
+  runTileTest(
+      globalRank,
+      numRanks,
+      bs,
+      4096,
+      8 * 1024 * 1024,
+      8 * 1024 * 1024,
+      2,
+      4,
+      1);
+  runTileTest(
+      globalRank,
+      numRanks,
+      bs,
+      16384,
+      8 * 1024 * 1024,
+      8 * 1024 * 1024,
+      2,
+      4,
+      1);
+  runTileTest(
+      globalRank,
+      numRanks,
+      bs,
+      65536,
+      8 * 1024 * 1024,
+      8 * 1024 * 1024,
+      2,
+      4,
+      1);
+
+  // Medium sizes
+  runTileTest(
+      globalRank,
+      numRanks,
+      bs,
+      1 * 1024 * 1024,
+      8 * 1024 * 1024,
+      8 * 1024 * 1024,
+      2,
+      8,
+      1);
+  runTileTest(
+      globalRank,
+      numRanks,
+      bs,
+      8 * 1024 * 1024,
+      8 * 1024 * 1024,
+      8 * 1024 * 1024,
+      2,
+      16,
+      1);
+
+  // Large sizes
+  runTileTest(
+      globalRank,
+      numRanks,
+      bs,
+      64 * 1024 * 1024,
+      8 * 1024 * 1024,
+      8 * 1024 * 1024,
+      2,
+      16,
+      1);
+  runTileTest(
+      globalRank,
+      numRanks,
+      bs,
+      256 * 1024 * 1024,
+      8 * 1024 * 1024,
+      8 * 1024 * 1024,
+      2,
+      16,
+      1);
+}
+
+// Test signal granularity (chunkSize < slotSize)
+TEST_F(P2pNvlTransportTestFixture, TileSendRecvSignalGranularity) {
+  if (numRanks != 2) {
+    return;
+  }
+  auto bs = std::make_shared<meta::comms::MpiBootstrap>();
+  const size_t nBytes = 32 * 1024 * 1024; // 32MB
+
+  // Per-slot signaling (chunkSize == slotSize)
+  runTileTest(
+      globalRank,
+      numRanks,
+      bs,
+      nBytes,
+      8 * 1024 * 1024,
+      8 * 1024 * 1024,
+      2,
+      16,
+      1);
+
+  // 128KB signal granularity
+  runTileTest(
+      globalRank, numRanks, bs, nBytes, 8 * 1024 * 1024, 128 * 1024, 2, 16, 1);
+
+  // 512KB signal granularity
+  runTileTest(
+      globalRank, numRanks, bs, nBytes, 8 * 1024 * 1024, 512 * 1024, 2, 16, 1);
+
+  // 1MB signal granularity
+  runTileTest(
+      globalRank, numRanks, bs, nBytes, 8 * 1024 * 1024, 1024 * 1024, 2, 16, 1);
+}
+
+// Test different block counts
+TEST_F(P2pNvlTransportTestFixture, TileSendRecvBlockCounts) {
+  if (numRanks != 2) {
+    return;
+  }
+  auto bs = std::make_shared<meta::comms::MpiBootstrap>();
+  const size_t nBytes = 16 * 1024 * 1024; // 16MB
+
+  runTileTest(
+      globalRank,
+      numRanks,
+      bs,
+      nBytes,
+      8 * 1024 * 1024,
+      8 * 1024 * 1024,
+      2,
+      1,
+      1);
+  runTileTest(
+      globalRank,
+      numRanks,
+      bs,
+      nBytes,
+      8 * 1024 * 1024,
+      8 * 1024 * 1024,
+      2,
+      2,
+      1);
+  runTileTest(
+      globalRank,
+      numRanks,
+      bs,
+      nBytes,
+      8 * 1024 * 1024,
+      8 * 1024 * 1024,
+      2,
+      4,
+      1);
+  runTileTest(
+      globalRank,
+      numRanks,
+      bs,
+      nBytes,
+      8 * 1024 * 1024,
+      8 * 1024 * 1024,
+      2,
+      8,
+      1);
+  runTileTest(
+      globalRank,
+      numRanks,
+      bs,
+      nBytes,
+      8 * 1024 * 1024,
+      8 * 1024 * 1024,
+      2,
+      16,
+      1);
+  runTileTest(
+      globalRank,
+      numRanks,
+      bs,
+      nBytes,
+      8 * 1024 * 1024,
+      8 * 1024 * 1024,
+      2,
+      32,
+      1);
+}
+
+// Test pipeline depth variations
+TEST_F(P2pNvlTransportTestFixture, TileSendRecvPipelineDepth) {
+  if (numRanks != 2) {
+    return;
+  }
+  auto bs = std::make_shared<meta::comms::MpiBootstrap>();
+  const size_t nBytes = 32 * 1024 * 1024;
+
+  runTileTest(
+      globalRank, numRanks, bs, nBytes, 8 * 1024 * 1024, 128 * 1024, 2, 16, 1);
+  runTileTest(
+      globalRank, numRanks, bs, nBytes, 8 * 1024 * 1024, 128 * 1024, 4, 16, 1);
+}
+
+// Test multi-call with persistent step state
+TEST_F(P2pNvlTransportTestFixture, TileSendRecvMultiCallPersistentStep) {
+  if (numRanks != 2) {
+    return;
+  }
+  auto bs = std::make_shared<meta::comms::MpiBootstrap>();
+
+  // 5 iterations with same size — tests step counter persistence
+  runTileTest(
+      globalRank,
+      numRanks,
+      bs,
+      8 * 1024 * 1024,
+      8 * 1024 * 1024,
+      8 * 1024 * 1024,
+      2,
+      4,
+      5);
+
+  // 5 iterations with 128KB signal — more steps per call
+  runTileTest(
+      globalRank,
+      numRanks,
+      bs,
+      8 * 1024 * 1024,
+      8 * 1024 * 1024,
+      128 * 1024,
+      2,
+      4,
+      5);
+}
+
+// Test multi-call with different message sizes per call
+TEST_F(P2pNvlTransportTestFixture, TileSendRecvMultiCallDifferentSizes) {
+  if (numRanks != 2) {
+    return;
+  }
+  int peerRank = (globalRank == 0) ? 1 : 0;
+
+  const int numSendBlocks = 4;
+  MultiPeerNvlTransportConfig config{
+      .dataBufferSize = 8 * 1024 * 1024,
+      .chunkSize = 8 * 1024 * 1024,
+      .pipelineDepth = 2,
+  };
+
+  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
+  transport.exchange();
+  auto p2pHost = transport.buildP2pTransportDevice(peerRank);
+
+  // Different sizes for each call
+  std::vector<size_t> sizes = {
+      2 * 1024 * 1024, // 2MB
+      8 * 1024 * 1024, // 8MB
+      1 * 1024 * 1024, // 1MB (smaller than first)
+      16 * 1024 * 1024, // 16MB
+  };
+
+  dim3 grid(numSendBlocks * 2);
+  dim3 block(256);
+  Timeout timeout;
+
+  for (size_t callIdx = 0; callIdx < sizes.size(); callIdx++) {
+    size_t nBytes = sizes[callIdx];
+    const int pattern = 0x30 + globalRank + static_cast<int>(callIdx) * 0x10;
+    const int peerPattern = 0x30 + peerRank + static_cast<int>(callIdx) * 0x10;
+
+    DeviceBuffer sendBuf(nBytes);
+    DeviceBuffer recvBuf(nBytes);
+    CUDACHECK_TEST(cudaMemset(sendBuf.get(), pattern, nBytes));
+    CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, nBytes));
+
+    comms::pipes::TiledBuffer<char> sendTiles(
+        static_cast<char*>(sendBuf.get()), nBytes, numSendBlocks);
+    comms::pipes::TiledBuffer<char> recvTiles(
+        static_cast<char*>(recvBuf.get()), nBytes, numSendBlocks);
+    int numBlocksArg = numSendBlocks;
+    int chunksPerSlot = 1;
+    void* args[] = {
+        &p2pHost,
+        &sendTiles,
+        &recvTiles,
+        &numBlocksArg,
+        &chunksPerSlot,
+        &timeout};
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    CUDACHECK_TEST(cudaLaunchKernel(
+        (void*)comms::pipes::benchmark::p2pTileSendRecv,
+        grid,
+        block,
+        args,
+        0,
+        nullptr));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    std::vector<char> hostBuf(nBytes);
+    CUDACHECK_TEST(cudaMemcpy(
+        hostBuf.data(), recvBuf.get(), nBytes, cudaMemcpyDeviceToHost));
+
+    for (size_t i = 0; i < nBytes; i++) {
+      EXPECT_EQ(
+          static_cast<unsigned char>(hostBuf[i]),
+          static_cast<unsigned char>(peerPattern))
+          << "Call " << callIdx << " (size=" << nBytes << "): Mismatch at byte "
+          << i;
+      if (static_cast<unsigned char>(hostBuf[i]) !=
+          static_cast<unsigned char>(peerPattern)) {
+        break;
+      }
+    }
+  }
+}
+
+// Test partial tiles (nbytes not evenly divisible by numBlocks)
+TEST_F(P2pNvlTransportTestFixture, TileSendRecvPartialTiles) {
+  if (numRanks != 2) {
+    return;
+  }
+  auto bs = std::make_shared<meta::comms::MpiBootstrap>();
+
+  // nBytes not divisible by numBlocks — last block gets fewer bytes
+  runTileTest(
+      globalRank,
+      numRanks,
+      bs,
+      1000000,
+      8 * 1024 * 1024,
+      8 * 1024 * 1024,
+      2,
+      4,
+      1);
+  runTileTest(
+      globalRank,
+      numRanks,
+      bs,
+      3000000,
+      8 * 1024 * 1024,
+      8 * 1024 * 1024,
+      2,
+      8,
+      1);
+
+  // Odd sizes
+  runTileTest(
+      globalRank,
+      numRanks,
+      bs,
+      7 * 1024 * 1024 + 12345,
+      8 * 1024 * 1024,
+      8 * 1024 * 1024,
+      2,
+      4,
+      1);
+}
+
+// Test with different staging buffer sizes
+TEST_F(P2pNvlTransportTestFixture, TileSendRecvStagingSizes) {
+  if (numRanks != 2) {
+    return;
+  }
+  auto bs = std::make_shared<meta::comms::MpiBootstrap>();
+  const size_t nBytes = 16 * 1024 * 1024;
+
+  // 4MB staging
+  runTileTest(
+      globalRank,
+      numRanks,
+      bs,
+      nBytes,
+      4 * 1024 * 1024,
+      4 * 1024 * 1024,
+      2,
+      8,
+      1);
+
+  // 8MB staging
+  runTileTest(
+      globalRank,
+      numRanks,
+      bs,
+      nBytes,
+      8 * 1024 * 1024,
+      8 * 1024 * 1024,
+      2,
+      8,
+      1);
+
+  // 16MB staging
+  runTileTest(
+      globalRank,
+      numRanks,
+      bs,
+      nBytes,
+      16 * 1024 * 1024,
+      16 * 1024 * 1024,
+      2,
+      8,
+      1);
 }
 
 // =============================================================================
@@ -2889,6 +3467,113 @@ TEST_F(P2pNvlTransportTestFixture, Ll128BufferWiring_Disabled) {
       << ": remoteState.ll128Buffer should be null when ll128BufferSize == 0";
 
   XLOGF(INFO, "Rank {}: Ll128BufferWiring_Disabled test completed", globalRank);
+}
+
+// =============================================================================
+// Dynamic block count tests
+// =============================================================================
+// Verify that changing numBlocks between send_tile/recv_tile rounds works
+// correctly with the maxBlocks layout and host-side barrier.
+
+TEST_F(P2pNvlTransportTestFixture, TileSendRecvDynamicBlockCount) {
+  if (numRanks != 2) {
+    XLOGF(WARNING, "Skipping: requires 2 ranks, got {}", numRanks);
+    return;
+  }
+
+  int peerRank = (globalRank == 0) ? 1 : 0;
+  constexpr int maxBlocks = 32;
+
+  MultiPeerNvlTransportConfig config{
+      .dataBufferSize = 8 * 1024 * 1024, // 8MB slot
+      .chunkSize = 8 * 1024 * 1024,
+      .pipelineDepth = 2,
+      .p2pBarrierCount = static_cast<std::size_t>(maxBlocks),
+      .tileMaxBlocks = maxBlocks,
+  };
+
+  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
+  transport.exchange();
+  auto p2pHost = transport.buildP2pTransportDevice(peerRank);
+
+  // Sequence of rounds with different block counts and message sizes
+  struct Round {
+    int numBlocks;
+    size_t nBytes;
+  };
+  std::vector<Round> rounds = {
+      {16, 8 * 1024 * 1024}, // 16 blocks, 8MB
+      {32, 16 * 1024 * 1024}, // 32 blocks, 16MB (increase blocks)
+      {8, 4 * 1024 * 1024}, // 8 blocks, 4MB (decrease blocks)
+      {16, 8 * 1024 * 1024}, // 16 blocks again, 8MB
+      {32, 32 * 1024 * 1024}, // 32 blocks, 32MB
+      {4, 1 * 1024 * 1024}, // 4 blocks, 1MB (small)
+      {16, 64 * 1024 * 1024}, // 16 blocks, 64MB (large)
+  };
+
+  Timeout timeout;
+  int prevBlocks = 0;
+
+  for (size_t roundIdx = 0; roundIdx < rounds.size(); roundIdx++) {
+    int numBlocks = rounds[roundIdx].numBlocks;
+    size_t nBytes = rounds[roundIdx].nBytes;
+    int totalBlocks = numBlocks * 2;
+
+    // Unique pattern per round
+    const int pattern = 0x10 + globalRank + static_cast<int>(roundIdx) * 0x20;
+    const int peerPattern = 0x10 + peerRank + static_cast<int>(roundIdx) * 0x20;
+
+    DeviceBuffer sendBuf(nBytes);
+    DeviceBuffer recvBuf(nBytes);
+    CUDACHECK_TEST(cudaMemset(sendBuf.get(), pattern, nBytes));
+    CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, nBytes));
+
+    comms::pipes::TiledBuffer<char> sendTiles(
+        static_cast<char*>(sendBuf.get()), nBytes, numBlocks);
+    comms::pipes::TiledBuffer<char> recvTiles(
+        static_cast<char*>(recvBuf.get()), nBytes, numBlocks);
+
+    bool needsBarrier = (prevBlocks != 0 && prevBlocks != numBlocks);
+    int numBlocksArg = numBlocks;
+    void* args[] = {
+        &p2pHost,
+        &sendTiles,
+        &recvTiles,
+        &numBlocksArg,
+        &needsBarrier,
+        &timeout};
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    CUDACHECK_TEST(cudaLaunchKernel(
+        (void*)comms::pipes::benchmark::p2pTileSendRecvDynamic,
+        dim3(totalBlocks),
+        dim3(256),
+        args,
+        0,
+        nullptr));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    // Verify received data
+    std::vector<char> hostBuf(nBytes);
+    CUDACHECK_TEST(cudaMemcpy(
+        hostBuf.data(), recvBuf.get(), nBytes, cudaMemcpyDeviceToHost));
+
+    for (size_t i = 0; i < nBytes; i++) {
+      EXPECT_EQ(
+          static_cast<unsigned char>(hostBuf[i]),
+          static_cast<unsigned char>(peerPattern))
+          << "Round " << roundIdx << " (blocks=" << numBlocks
+          << ", size=" << nBytes << "): Mismatch at byte " << i;
+      if (static_cast<unsigned char>(hostBuf[i]) !=
+          static_cast<unsigned char>(peerPattern)) {
+        break;
+      }
+    }
+
+    prevBlocks = numBlocks;
+  }
 }
 
 } // namespace comms::pipes::tests


### PR DESCRIPTION
Summary:
## Tile sendrecv protocol

Add a bidirectional pipelined data transfer protocol for NVLink P2P:

- Each GPU simultaneously sends AND receives by partitioning kernel blocks
  into sender/receiver roles (half send, half recv).
- Each sender/receiver block pair transfers an independent tile of data
  through a pipelined staging buffer using monotonic head/tail SignalState
  counters.
- Sender and receiver run on separate GPUs — signals exchanged via NVLink
  remote writes to peer signal buffers.
- Backpressure via `head >= step - pipelineDepth + 1` (CMP_GE).
- Memory ordering: `group.sync()` before `st.release.sys.global` signal;
  `ld.acquire.sys.global` wait forms release-acquire pair with sender.
- Persistent step counters in device memory for multi-call correctness.
- Supports clustered kernel launch for improved NVLink utilization.
- Transport-internal tile signals and stepState (tileMaxBlocks config).
- Dynamic block count via per-block barrier_sync_threadgroup.

## TiledBuffer<T> abstraction

Add `comms::pipes::TiledBuffer<T>` — a typed view that partitions a buffer
into aligned tiles across blocks. Zero-cost abstraction.

## Transport enhancements

- `tileMaxBlocks` config: transport allocates tile signals + stepState
- `p2pBarrierCount` config: allocates barrier buffer for cross-GPU sync
- `send_tile`/`recv_tile` with internal state (no user stepState needed)
- `__restrict__` hints on send_tile/recv_tile parameters
- `options()`, `local_state()`, `remote_state()` device getters

## Benchmark results (H100 NVLink, ncclx 2.29, bidirectional, clustered)

  Size    NCCL    Tile    Speedup
  128K      19      28     1.48x
  1M       128     159     1.24x
  8M       332     395     1.19x
  32M      485     582     1.20x
  64M      527     645     1.22x
  128M     574     679     1.18x
  256M     597     702     1.18x
  512M     706     712     1.01x
  1G       717     718     1.00x

Reviewed By: snarayankh

Differential Revision: D100253564


