### PR TITLE
move GpuClockCalibration from colltrace/ to utils/ and add a device handle (#2048)

### DIFF
--- a/comms/ctran/colltrace/CollTraceWrapper.cc
+++ b/comms/ctran/colltrace/CollTraceWrapper.cc
@@ -9,6 +9,7 @@
 #include "comms/utils/colltrace/CollMetadataImpl.h"
 #include "comms/utils/colltrace/CudaWaitEvent.h"
 #include "comms/utils/colltrace/DummyCollTraceHandle.h"
+#include "comms/utils/colltrace/GraphCudaWaitEvent.h"
 #include "comms/utils/colltrace/plugins/CommDumpPlugin.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
@@ -410,6 +411,9 @@ std::unique_ptr<ICollMetadata> getMetadata(
 std::unique_ptr<ICollWaitEvent> getWaitEvent(
     const std::vector<std::unique_ptr<struct OpElem>>& opGroup,
     cudaStream_t stream) {
+  if (isCapturingStream(stream)) {
+    return std::make_unique<GraphCudaWaitEvent>(stream);
+  }
   if (opGroup.size() > 0) {
     return std::make_unique<CPUWaitEvent>();
   }
@@ -427,18 +431,9 @@ std::shared_ptr<ICollTraceHandle> getNewCollTraceHandle(
     return std::make_unique<DummyCollTraceHandle>();
   }
 
-  if (isCapturingStream(kernelConfig.stream)) {
-    if (RankUtils::getGlobalRank().value_or(0) == 0) {
-      XLOG_FIRST_N(
-          WARN, 1, "CollTrace currently doesn't support capturing streams");
-    }
-    return std::make_unique<DummyCollTraceHandle>();
-  }
-
   auto metadata = getMetadata(comm, opGroup, kernelConfig);
-
   if (metadata == nullptr) {
-    return std::make_unique<meta::comms::colltrace::DummyCollTraceHandle>();
+    return std::make_unique<DummyCollTraceHandle>();
   }
 
   auto res = colltrace->recordCollective(
@@ -447,7 +442,7 @@ std::shared_ptr<ICollTraceHandle> getNewCollTraceHandle(
   if (res.hasError()) {
     XLOG_FIRST_N(
         ERR, 5, "Failed to get colltrace handle due to: ", res.error().message);
-    return std::make_unique<meta::comms::colltrace::DummyCollTraceHandle>();
+    return std::make_unique<DummyCollTraceHandle>();
   }
   return res.value();
 }

--- a/comms/ncclx/meta/colltrace/CollTraceWrapper.cc
+++ b/comms/ncclx/meta/colltrace/CollTraceWrapper.cc
@@ -12,6 +12,7 @@
 #include "comms/utils/colltrace/CudaWaitEvent.h"
 #include "comms/utils/colltrace/DummyCollTraceHandle.h"
 #include "comms/utils/colltrace/GenericMetadata.h"
+#include "comms/utils/colltrace/GraphCudaWaitEvent.h"
 #include "comms/utils/colltrace/plugins/CommDumpPlugin.h"
 #include "comms/utils/colltrace/plugins/WatchdogPlugin.h"
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -450,21 +451,21 @@ getHandleFromNcclKernelPlan(ncclKernelPlan& plan, cudaStream_t stream) {
     return std::make_unique<meta::comms::colltrace::DummyCollTraceHandle>();
   }
 
-  if (isCapturingStream(stream)) {
-    if (RankUtils::getGlobalRank().value_or(0) == 0) {
-      XLOG_FIRST_N(
-          WARN, 1, "CollTrace currently doesn't support capturing streams");
-    }
-    return std::make_unique<meta::comms::colltrace::DummyCollTraceHandle>();
-  }
-
   auto metadata = getMetadataFromNcclKernelPlan(plan, stream);
   if (metadata == nullptr) {
     return std::make_unique<meta::comms::colltrace::DummyCollTraceHandle>();
   }
-  auto res = colltrace->recordCollective(
-      std::move(metadata),
-      std::make_unique<meta::comms::colltrace::CudaWaitEvent>(stream));
+
+  auto makeWaitEvent =
+      [&]() -> std::unique_ptr<meta::comms::colltrace::ICollWaitEvent> {
+    if (isCapturingStream(stream)) {
+      return std::make_unique<meta::comms::colltrace::GraphCudaWaitEvent>(
+          stream);
+    }
+    return std::make_unique<meta::comms::colltrace::CudaWaitEvent>(stream);
+  };
+
+  auto res = colltrace->recordCollective(std::move(metadata), makeWaitEvent());
 
   if (res.hasError()) {
     XLOG_FIRST_N(

--- a/comms/ncclx/v2_27/src/Makefile
+++ b/comms/ncclx/v2_27/src/Makefile
@@ -68,7 +68,7 @@ LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/*.cc)
 ## CollTrace source files
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/colltrace/*.cc)
 ## CollTrace CUDA source files (host-side kernel launchers)
-LIBSRCFILES += ${BASE_DIR}/comms/utils/colltrace/GpuClockCalibration.cu
+LIBSRCFILES += ${BASE_DIR}/comms/utils/GpuClockCalibration.cu
 LIBSRCFILES += ${BASE_DIR}/comms/utils/colltrace/HRDWRingBufferInstantiations.cu
 ## CollTrace plugin source files
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/colltrace/plugins/*.cc)
@@ -225,7 +225,7 @@ LIBSRCFILES_CU  := $(filter %.cu,$(LIBSRCFILES))
 LIBOBJ_CC       := $(LIBSRCFILES_CC:%.cc=$(OBJDIR)/%.o)
 LIBOBJ_CPP      := $(LIBSRCFILES_CPP:%.cpp=$(OBJDIR)/%.o)
 LIBOBJ_C        := $(LIBSRCFILES_C:%.c=$(OBJDIR)/%.o)
-LIBOBJ_CU       := $(LIBSRCFILES_CU:%.cu=$(OBJDIR)/%.o)
+LIBOBJ_CU       := $(LIBSRCFILES_CU:%.cu=$(OBJDIR)/%.cu.o)
 LIBOBJ          := $(LIBOBJ_CC) $(LIBOBJ_CPP) $(LIBOBJ_C) $(LIBOBJ_CU)
 BINOBJ     := $(BINSRCFILES:%.cc=$(OBJDIR)/%.o)
 DEPFILES   := $(LIBOBJ:%.o=%.d) $(BINOBJ:%.o=%.d)
@@ -355,7 +355,7 @@ $(OBJDIR)/%.o : %.c $(INCTARGETS)
                 sed -e 's/^ *//' -e 's/$$/:/' >> $(@:%.o=%.d)
 	@rm -f $(@:%.o=%.d.tmp)
 
-$(OBJDIR)/%.o : %.cu $(INCTARGETS)
+$(OBJDIR)/%.cu.o : %.cu $(INCTARGETS)
 	@printf "Compiling  %-35s > %s\n" $< $@
 	mkdir -p `dirname $@`
 	$(NVCC) $(NVCC_GENCODE) $(CXXSTD) -Xcompiler -fPIC -Xcompiler -fvisibility=hidden -I. -I$(INCDIR) $(INCLUDES) -c $< -o $@

--- a/comms/ncclx/v2_28/src/Makefile
+++ b/comms/ncclx/v2_28/src/Makefile
@@ -75,7 +75,7 @@ LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/*.cc)
 ## CollTrace source files
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/colltrace/*.cc)
 ## CollTrace CUDA source files (host-side kernel launchers)
-LIBSRCFILES += ${BASE_DIR}/comms/utils/colltrace/GpuClockCalibration.cu
+LIBSRCFILES += ${BASE_DIR}/comms/utils/GpuClockCalibration.cu
 LIBSRCFILES += ${BASE_DIR}/comms/utils/colltrace/HRDWRingBufferInstantiations.cu
 ## CollTrace plugin source files
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/colltrace/plugins/*.cc)
@@ -199,7 +199,7 @@ LIBSRCFILES_CU  := $(filter %.cu,$(LIBSRCFILES))
 LIBOBJ_CC       := $(LIBSRCFILES_CC:%.cc=$(OBJDIR)/%.o)
 LIBOBJ_CPP      := $(LIBSRCFILES_CPP:%.cpp=$(OBJDIR)/%.o)
 LIBOBJ_C        := $(LIBSRCFILES_C:%.c=$(OBJDIR)/%.o)
-LIBOBJ_CU       := $(LIBSRCFILES_CU:%.cu=$(OBJDIR)/%.o)
+LIBOBJ_CU       := $(LIBSRCFILES_CU:%.cu=$(OBJDIR)/%.cu.o)
 LIBOBJ          := $(LIBOBJ_CC) $(LIBOBJ_CPP) $(LIBOBJ_C) $(LIBOBJ_CU)
 BINOBJ     := $(BINSRCFILES:%.cc=$(OBJDIR)/%.o)
 DEPFILES   := $(LIBOBJ:%.o=%.d) $(BINOBJ:%.o=%.d)
@@ -380,7 +380,7 @@ $(OBJDIR)/%.o : %.c $(INCTARGETS)
                 sed -e 's/^ *//' -e 's/$$/:/' >> $(@:%.o=%.d)
 	@rm -f $(@:%.o=%.d.tmp)
 
-$(OBJDIR)/%.o : %.cu $(INCTARGETS)
+$(OBJDIR)/%.cu.o : %.cu $(INCTARGETS)
 	@printf "Compiling  %-35s > %s\n" $< $@
 	mkdir -p `dirname $@`
 	$(NVCC) $(NVCC_GENCODE) $(CXXSTD) -Xcompiler -fPIC -Xcompiler -fvisibility=hidden -I. -I$(INCDIR) $(INCLUDES) -I$(INCPLUGIN) -I$(DOCA_HOME)/include -c $< -o $@

--- a/comms/ncclx/v2_29/src/Makefile
+++ b/comms/ncclx/v2_29/src/Makefile
@@ -80,7 +80,7 @@ LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/*.cc)
 ## CollTrace source files
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/colltrace/*.cc)
 ## CollTrace CUDA source files (host-side kernel launchers)
-LIBSRCFILES += ${BASE_DIR}/comms/utils/colltrace/GpuClockCalibration.cu
+LIBSRCFILES += ${BASE_DIR}/comms/utils/GpuClockCalibration.cu
 LIBSRCFILES += ${BASE_DIR}/comms/utils/colltrace/HRDWRingBufferInstantiations.cu
 ## CollTrace plugin source files
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/colltrace/plugins/*.cc)
@@ -248,7 +248,7 @@ LIBSRCFILES_CU  := $(filter %.cu,$(LIBSRCFILES))
 LIBOBJ_CC       := $(LIBSRCFILES_CC:%.cc=$(OBJDIR)/%.o)
 LIBOBJ_CPP      := $(LIBSRCFILES_CPP:%.cpp=$(OBJDIR)/%.o)
 LIBOBJ_C        := $(LIBSRCFILES_C:%.c=$(OBJDIR)/%.o)
-LIBOBJ_CU       := $(LIBSRCFILES_CU:%.cu=$(OBJDIR)/%.o)
+LIBOBJ_CU       := $(LIBSRCFILES_CU:%.cu=$(OBJDIR)/%.cu.o)
 LIBOBJ          := $(LIBOBJ_CC) $(LIBOBJ_CPP) $(LIBOBJ_C) $(LIBOBJ_CU)
 BINOBJ     := $(BINSRCFILES:%.cc=$(OBJDIR)/%.o)
 DEPFILES   := $(LIBOBJ:%.o=%.d) $(BINOBJ:%.o=%.d)
@@ -435,7 +435,7 @@ $(OBJDIR)/%.o : %.c $(INCTARGETS)
                 sed -e 's/^ *//' -e 's/$$/:/' >> $(@:%.o=%.d)
 	@rm -f $(@:%.o=%.d.tmp)
 
-$(OBJDIR)/%.o : %.cu $(INCTARGETS)
+$(OBJDIR)/%.cu.o : %.cu $(INCTARGETS)
 	@printf "Compiling  %-35s > %s\n" $< $@
 	mkdir -p `dirname $@`
 	$(NVCC) $(NVCC_GENCODE) $(CXXSTD) -Xcompiler -fPIC -Xcompiler -fvisibility=hidden -I. -I$(INCDIR) -I$(OBJDIR)/include $(INCLUDES) -I$(INCPLUGIN) -I$(DOCA_HOME)/include -c $< -o $@

--- a/comms/utils/CMakeLists.txt
+++ b/comms/utils/CMakeLists.txt
@@ -4,6 +4,7 @@ find_package(CUDA REQUIRED)
 
 file(GLOB_RECURSE UTILS_SOURCES
     "*.cc"
+    "*.cu"
 )
 file(GLOB_RECURSE UTILS_CU_SOURCES
     "*.cu"
@@ -21,6 +22,11 @@ add_library(utils OBJECT
 target_compile_features(utils PRIVATE cxx_std_20)
 target_compile_options(utils PRIVATE
     -fPIC
+)
+set_target_properties(utils PROPERTIES
+    CUDA_SEPARABLE_COMPILATION ON
+    CUDA_RESOLVE_DEVICE_SYMBOLS ON
+    POSITION_INDEPENDENT_CODE ON
 )
 target_include_directories(utils PUBLIC
     ${ROOT}

--- a/comms/utils/GpuClockCalibration.cc
+++ b/comms/utils/GpuClockCalibration.cc
@@ -1,15 +1,16 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
-#include <cuda_runtime.h>
+#include "comms/utils/GpuClockCalibration.h"
+
+#include <cuda_runtime.h> // @manual=third-party//cuda:cuda-lazy
 
 #include <chrono>
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
 
-#include "comms/utils/colltrace/GpuClockCalibration.h"
-
-// simple fprintf-based check for this .cu file.
-#define CUDA_CHECK_CU(cmd)             \
+// simple fprintf-based check for host code.
+#define CUDA_CHECK_CC(cmd)             \
   do {                                 \
     auto _err = (cmd);                 \
     if (_err != cudaSuccess) {         \
@@ -26,23 +27,8 @@
 
 namespace meta::comms::colltrace {
 
-namespace {
-
-__global__ void readGlobaltimerKernel(uint64_t* out) {
-  *out = readGlobaltimer();
-}
-
-} // namespace
-
-cudaError_t launchReadGlobaltimer(cudaStream_t stream, uint64_t* out) {
-  readGlobaltimerKernel<<<1, 1, 0, stream>>>(out);
-  return cudaGetLastError();
-}
-
 std::chrono::system_clock::time_point GlobaltimerCalibration::toWallClock(
     uint64_t gpu_ns) const {
-  // globaltimer values are in nanoseconds. Compute signed delta to handle
-  // timestamps both before and after the calibration point.
   auto delta_ns =
       static_cast<int64_t>(gpu_ns) - static_cast<int64_t>(device_ns);
   return host_time + std::chrono::nanoseconds(delta_ns);
@@ -52,28 +38,25 @@ std::chrono::system_clock::time_point GlobaltimerCalibration::toWallClock(
   static const GlobaltimerCalibration instance = [] {
     GlobaltimerCalibration cal{};
 
-    // Allocate a single uint64_t in mapped pinned memory for the kernel to
-    // write the globaltimer value.
     uint64_t* mapped_ptr = nullptr;
-    CUDA_CHECK_CU(cudaHostAlloc(
+    CUDA_CHECK_CC(cudaHostAlloc(
         reinterpret_cast<void**>(&mapped_ptr),
         sizeof(uint64_t),
         cudaHostAllocDefault));
     *mapped_ptr = 0;
 
-    // Launch a calibration kernel on the default stream and synchronize.
     launchReadGlobaltimer(nullptr, mapped_ptr);
-    CUDA_CHECK_CU(cudaDeviceSynchronize());
+    CUDA_CHECK_CC(cudaDeviceSynchronize());
 
     cal.device_ns = *mapped_ptr;
     cal.host_time = std::chrono::system_clock::now();
 
-    CUDA_CHECK_CU(cudaFreeHost(mapped_ptr));
+    CUDA_CHECK_CC(cudaFreeHost(mapped_ptr));
     return cal;
   }();
   return instance;
 }
 
-#undef CUDA_CHECK_CU
+#undef CUDA_CHECK_CC
 
 } // namespace meta::comms::colltrace

--- a/comms/utils/GpuClockCalibration.cu
+++ b/comms/utils/GpuClockCalibration.cu
@@ -1,0 +1,24 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+
+#include <cstdint>
+
+#include "comms/utils/GpuClockCalibration.h"
+
+namespace meta::comms::colltrace {
+
+namespace {
+
+__global__ void readGlobaltimerKernel(uint64_t* out) {
+  *out = readGlobaltimer();
+}
+
+} // namespace
+
+cudaError_t launchReadGlobaltimer(cudaStream_t stream, uint64_t* out) {
+  readGlobaltimerKernel<<<1, 1, 0, stream>>>(out);
+  return cudaGetLastError();
+}
+
+} // namespace meta::comms::colltrace

--- a/comms/utils/GpuClockCalibration.h
+++ b/comms/utils/GpuClockCalibration.h
@@ -4,13 +4,17 @@
 
 #include <cuda_runtime.h>
 
-#include <chrono>
 #include <cstdint>
+
+#if not defined(__CUDACC__) and not defined(__HIPCC__)
+#include <chrono>
+#endif // not defined(__CUDACC__) and not defined(__HIPCC__)
 
 namespace meta::comms::colltrace {
 
 // One-time calibration point mapping globaltimer nanoseconds to system_clock.
 // Thread-safe; lazily initialized on first call.
+#if not defined(__CUDACC__) and not defined(__HIPCC__)
 struct GlobaltimerCalibration {
   uint64_t device_ns{};
   std::chrono::system_clock::time_point host_time;
@@ -24,6 +28,7 @@ struct GlobaltimerCalibration {
 
 // Launch a single-thread kernel that writes globaltimer() to *out.
 cudaError_t launchReadGlobaltimer(cudaStream_t stream, uint64_t* out);
+#endif // not defined(__CUDACC__) and not defined(__HIPCC__)
 
 #if defined(__CUDACC__) || defined(__HIPCC__)
 // Device-side globaltimer read. Returns nanoseconds since device boot.

--- a/comms/utils/HRDWRingBuffer.h
+++ b/comms/utils/HRDWRingBuffer.h
@@ -5,7 +5,7 @@
 #include <cuda_runtime.h> // @manual
 
 #if defined(__CUDACC__) || defined(__HIPCC__)
-#include "comms/utils/colltrace/GpuClockCalibration.h"
+#include "comms/utils/GpuClockCalibration.h"
 #endif
 
 #include <algorithm>

--- a/comms/utils/colltrace/CollTrace.cc
+++ b/comms/utils/colltrace/CollTrace.cc
@@ -12,8 +12,8 @@
 #include <cuda_runtime.h> // @manual=third-party//cuda:cuda-lazy
 
 #include "comms/utils/CommsMaybeChecks.h"
+#include "comms/utils/GpuClockCalibration.h"
 #include "comms/utils/checks.h"
-#include "comms/utils/colltrace/GpuClockCalibration.h"
 #include "comms/utils/colltrace/GraphCollTraceHandle.h"
 #include "comms/utils/colltrace/GraphCollTraceState.h"
 #include "comms/utils/colltrace/GraphCudaWaitEvent.h"

--- a/comms/utils/colltrace/CollTrace.cc
+++ b/comms/utils/colltrace/CollTrace.cc
@@ -73,6 +73,11 @@ CollTrace::CollTrace(
               config_.maxPendingQueueSize}),
       plugins_(std::move(plugins)) {
   if (NCCL_COLLTRACE_TRACE_CUDA_GRAPH) {
+    // Eagerly initialize the globaltimer calibration singleton now (outside
+    // graph capture) so it is ready when GraphCudaWaitEvent is constructed
+    // during capture.
+    GlobaltimerCalibration::get();
+
     // 2x the max plugin retention ensures the ring holds at least the last
     // max_retention collective entries (each collective has 1x start + 1x end
     // event). The ring ctor rounds up to the next power of 2.

--- a/comms/utils/colltrace/GraphCudaWaitEvent.cc
+++ b/comms/utils/colltrace/GraphCudaWaitEvent.cc
@@ -5,7 +5,6 @@
 #include <cstring>
 
 #include <cuda_runtime.h> // @manual=third-party//cuda:cuda-lazy
-#include "comms/utils/colltrace/GpuClockCalibration.h"
 
 #include <folly/Unit.h>
 #include <folly/logging/xlog.h>
@@ -20,10 +19,6 @@ GraphCudaWaitEvent::GraphCudaWaitEvent(cudaStream_t stream, uint32_t collId)
     : stream_(stream),
       collId_(collId),
       enqueueTime_(std::chrono::system_clock::now()) {
-  // Eagerly initialize the globaltimer calibration singleton so that the
-  // calibration kernel doesn't fire during graph capture.
-  GlobaltimerCalibration::get();
-
   // Create per-collective CUDA resources using relaxed capture mode so
   // they don't interfere with the graph capture in progress.
   StreamCaptureModeGuard guard{cudaStreamCaptureModeRelaxed};

--- a/comms/utils/colltrace/tests/GraphCollTraceUT.cc
+++ b/comms/utils/colltrace/tests/GraphCollTraceUT.cc
@@ -1,0 +1,499 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Validates per-collective start detection for graph collectives.
+//
+// Uses a host sleep node as the "work" between the start and end timestamp
+// kernels. While the host callback sleeps, only the start entry has been
+// written to the ring buffer and the poll thread should fire
+// collEventProgressing for that specific collective.
+
+#include <cuda_runtime.h> // @manual=third-party//cuda:cuda-lazy
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <optional>
+#include <set>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/colltrace/CollTrace.h"
+#include "comms/utils/colltrace/CollTraceHandle.h"
+#include "comms/utils/colltrace/CudaWaitEvent.h"
+#include "comms/utils/colltrace/GpuClockCalibration.h"
+#include "comms/utils/colltrace/GraphCudaWaitEvent.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+
+using meta::comms::colltrace::CollTrace;
+using meta::comms::colltrace::CollTraceConfig;
+using meta::comms::colltrace::CollTraceEvent;
+using meta::comms::colltrace::CollTraceHandleTriggerState;
+using meta::comms::colltrace::GraphCudaWaitEvent;
+using meta::comms::colltrace::ICollMetadata;
+using meta::comms::colltrace::ICollTracePlugin;
+
+namespace {
+
+class SimpleMetadata : public ICollMetadata {
+ public:
+  std::size_t hash() const override {
+    return 0;
+  }
+  bool equals(const ICollMetadata&) const noexcept override {
+    return true;
+  }
+  std::string_view getMetadataType() const noexcept override {
+    return "test";
+  }
+  folly::dynamic toDynamic() const noexcept override {
+    return folly::dynamic::object("type", "test");
+  }
+  void fromDynamic(const folly::dynamic&) noexcept override {}
+};
+
+// Plugin that tracks which collIds had collEventProgressing fired.
+class ProgressTrackingPlugin : public ICollTracePlugin {
+ public:
+  std::string_view getName() const noexcept override {
+    return "ProgressTrackingPlugin";
+  }
+
+  meta::comms::CommsMaybeVoid beforeCollKernelScheduled(
+      CollTraceEvent&) noexcept override {
+    return folly::unit;
+  }
+
+  meta::comms::CommsMaybeVoid afterCollKernelScheduled(
+      CollTraceEvent&) noexcept override {
+    return folly::unit;
+  }
+
+  meta::comms::CommsMaybeVoid afterCollKernelStart(
+      CollTraceEvent& event) noexcept override {
+    if (event.collRecord) {
+      std::lock_guard<std::mutex> lock(mu_);
+      startedCollIds_.insert(event.collRecord->getCollId());
+    }
+    return folly::unit;
+  }
+
+  meta::comms::CommsMaybeVoid collEventProgressing(
+      CollTraceEvent& event) noexcept override {
+    if (event.collRecord) {
+      std::lock_guard<std::mutex> lock(mu_);
+      progressedCollIds_.insert(event.collRecord->getCollId());
+    }
+    progressCount_.fetch_add(1);
+    return folly::unit;
+  }
+
+  meta::comms::CommsMaybeVoid afterCollKernelEnd(
+      CollTraceEvent& event) noexcept override {
+    if (event.collRecord) {
+      std::lock_guard<std::mutex> lock(mu_);
+      completedCollIds_.insert(event.collRecord->getCollId());
+    }
+    return folly::unit;
+  }
+
+  std::set<int64_t> getProgressedCollIds() const {
+    std::lock_guard<std::mutex> lock(mu_);
+    return progressedCollIds_;
+  }
+
+  std::set<int64_t> getStartedCollIds() const {
+    std::lock_guard<std::mutex> lock(mu_);
+    return startedCollIds_;
+  }
+
+  std::set<int64_t> getCompletedCollIds() const {
+    std::lock_guard<std::mutex> lock(mu_);
+    return completedCollIds_;
+  }
+
+  int progressCount() const {
+    return progressCount_.load();
+  }
+
+  void reset() {
+    std::lock_guard<std::mutex> lock(mu_);
+    progressedCollIds_.clear();
+    startedCollIds_.clear();
+    completedCollIds_.clear();
+    progressCount_.store(0);
+  }
+
+ private:
+  mutable std::mutex mu_;
+  std::set<int64_t> progressedCollIds_;
+  std::set<int64_t> startedCollIds_;
+  std::set<int64_t> completedCollIds_;
+  std::atomic<int> progressCount_{0};
+};
+
+// Host callback that sleeps for a fixed duration.
+void CUDART_CB hostSleepCallback(void* userData) {
+  auto durationMs = reinterpret_cast<uintptr_t>(userData);
+  // NOLINTNEXTLINE(facebook-hte-BadCall-sleep_for)
+  std::this_thread::sleep_for(std::chrono::milliseconds(durationMs));
+}
+
+} // namespace
+
+class GraphColltraceProgressingTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    int deviceCount = 0;
+    auto err = cudaGetDeviceCount(&deviceCount);
+    if (err != cudaSuccess || deviceCount == 0) {
+      GTEST_SKIP() << "No CUDA device available";
+    }
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaSetDevice(0);
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaStreamCreate(&stream_);
+
+    // Enable cudagraph tracing for these tests.
+    cvarGuard_.emplace(NCCL_COLLTRACE_TRACE_CUDA_GRAPH, true);
+
+    meta::comms::colltrace::GlobaltimerCalibration::get();
+
+    auto progressPlugin = std::make_unique<ProgressTrackingPlugin>();
+    progressPlugin_ = progressPlugin.get();
+
+    auto plugins = std::vector<std::unique_ptr<ICollTracePlugin>>{};
+    plugins.push_back(std::move(progressPlugin));
+    CommLogData logData{};
+    colltrace_ = std::make_shared<CollTrace>(
+        CollTraceConfig{.maxCheckCancelInterval = std::chrono::milliseconds{1}},
+        logData,
+        [this]() -> meta::comms::CommsMaybeVoid {
+          // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+          cudaSetDevice(0);
+          auto mode = cudaStreamCaptureModeThreadLocal;
+          // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+          cudaThreadExchangeStreamCaptureMode(&mode);
+          return folly::unit;
+        },
+        std::move(plugins));
+  }
+
+  void TearDown() override {
+    colltrace_.reset();
+    if (stream_) {
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      cudaStreamDestroy(stream_);
+    }
+  }
+
+  // Launch a host callback that sleeps for sleepMs on the capture stream.
+  void launchHostSleep(uint64_t sleepMs) {
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaLaunchHostFunc(
+        stream_,
+        hostSleepCallback,
+        // NOLINTNEXTLINE(performance-no-int-to-ptr)
+        reinterpret_cast<void*>(static_cast<uintptr_t>(sleepMs)));
+  }
+
+  struct CapturedGraph {
+    cudaGraph_t graph{nullptr};
+    cudaGraphExec_t instance{nullptr};
+    std::vector<int64_t> collIds;
+
+    ~CapturedGraph() {
+      if (instance) {
+        // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+        cudaGraphExecDestroy(instance);
+      }
+      if (graph) {
+        // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+        cudaGraphDestroy(graph);
+      }
+    }
+    CapturedGraph() = default;
+    CapturedGraph(CapturedGraph&& o) noexcept
+        : graph(std::exchange(o.graph, nullptr)),
+          instance(std::exchange(o.instance, nullptr)),
+          collIds(std::move(o.collIds)) {}
+    CapturedGraph& operator=(CapturedGraph&&) = delete;
+    CapturedGraph(const CapturedGraph&) = delete;
+    CapturedGraph& operator=(const CapturedGraph&) = delete;
+  };
+
+  // Capture N serial collectives, each doing a host sleep as "work".
+  CapturedGraph captureSerial(uint32_t numColls, uint64_t sleepMs) {
+    CapturedGraph cg;
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaStreamBeginCapture(stream_, cudaStreamCaptureModeGlobal);
+    for (uint32_t c = 0; c < numColls; ++c) {
+      auto metadata = std::make_unique<SimpleMetadata>();
+      auto waitEvent = std::make_unique<GraphCudaWaitEvent>(stream_);
+      auto handle =
+          colltrace_
+              ->recordCollective(std::move(metadata), std::move(waitEvent))
+              .value();
+      auto collRecord = handle->getCollRecord();
+      if (collRecord.hasValue() && collRecord.value() != nullptr) {
+        cg.collIds.push_back(collRecord.value()->getCollId());
+      }
+      handle->trigger(CollTraceHandleTriggerState::BeforeEnqueueKernel);
+      launchHostSleep(sleepMs);
+      handle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel);
+    }
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaStreamEndCapture(stream_, &cg.graph);
+    EXPECT_NE(cg.graph, nullptr);
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaGraphInstantiate(&cg.instance, cg.graph, nullptr, nullptr, 0);
+    return cg;
+  }
+
+  cudaStream_t stream_{nullptr};
+  std::optional<EnvRAII<bool>> cvarGuard_;
+  std::shared_ptr<CollTrace> colltrace_;
+  ProgressTrackingPlugin* progressPlugin_{nullptr};
+};
+
+// Each collective sleeps 50ms. With a 1ms poll interval, the poll thread
+// has many chances to observe the start entry (before the end entry is
+// written) and fire collEventProgressing for the specific in-flight
+// collective.
+TEST_F(GraphColltraceProgressingTest, DetectsInFlightCollective) {
+  constexpr uint32_t kNumColls = 3;
+  constexpr uint64_t kSleepMs = 50;
+  auto cg = captureSerial(kNumColls, kSleepMs);
+  ASSERT_NE(cg.instance, nullptr);
+  ASSERT_EQ(cg.collIds.size(), kNumColls);
+
+  std::set<int64_t> validCollIds(cg.collIds.begin(), cg.collIds.end());
+
+  // Replay once — 150ms total (3 × 50ms), giving the poll thread plenty
+  // of time to observe in-flight entries.
+  ASSERT_EQ(cudaGraphLaunch(cg.instance, stream_), cudaSuccess);
+  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+
+  // Give the poll thread a moment to process remaining entries.
+  // NOLINTNEXTLINE(facebook-hte-BadCall-sleep_for)
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+
+  auto progressedIds = progressPlugin_->getProgressedCollIds();
+
+  // With 50ms per collective and 1ms poll interval, the poll thread
+  // should observe at least one in-flight collective.
+  EXPECT_FALSE(progressedIds.empty())
+      << "Expected collEventProgressing to fire for at least one collective";
+
+  // Every reported collId must be from our captured set.
+  for (auto id : progressedIds) {
+    EXPECT_TRUE(validCollIds.count(id) > 0)
+        << "collEventProgressing reported unknown collId " << id;
+  }
+
+  EXPECT_GT(progressPlugin_->progressCount(), 0);
+
+  // After sync, all collectives should have completed.
+  auto completedIds = progressPlugin_->getCompletedCollIds();
+  EXPECT_EQ(completedIds, validCollIds)
+      << "All collectives should be marked completed after stream sync";
+}
+
+// Capture concurrent collectives on separate streams so multiple start
+// kernels fire before any end kernel. The poll thread should observe
+// multiple start entries (without corresponding end entries) simultaneously
+// and fire collEventProgressing for each one individually.
+TEST_F(GraphColltraceProgressingTest, DetectsMultipleInFlightCollectives) {
+  constexpr uint32_t kNumColls = 3;
+  constexpr uint64_t kSleepMs = 100;
+
+  // Create per-collective streams forked from the main capture stream.
+  std::vector<cudaStream_t> collStreams(kNumColls);
+  for (auto& s : collStreams) {
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaStreamCreate(&s);
+  }
+  cudaEvent_t forkEvent;
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaEventCreateWithFlags(&forkEvent, cudaEventDisableTiming);
+
+  CapturedGraph cg;
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaStreamBeginCapture(stream_, cudaStreamCaptureModeGlobal);
+
+  // Fork: main stream → each collective stream.
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaEventRecord(forkEvent, stream_);
+  for (uint32_t c = 0; c < kNumColls; ++c) {
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaStreamWaitEvent(collStreams[c], forkEvent);
+  }
+
+  // Launch each collective on its own stream with a host sleep.
+  // All start kernels fire concurrently before any end kernel runs.
+  std::vector<std::shared_ptr<meta::comms::colltrace::ICollTraceHandle>>
+      handles;
+  for (uint32_t c = 0; c < kNumColls; ++c) {
+    auto metadata = std::make_unique<SimpleMetadata>();
+    auto waitEvent = std::make_unique<GraphCudaWaitEvent>(collStreams[c]);
+    auto handle =
+        colltrace_->recordCollective(std::move(metadata), std::move(waitEvent))
+            .value();
+    auto collRecord = handle->getCollRecord();
+    if (collRecord.hasValue() && collRecord.value() != nullptr) {
+      cg.collIds.push_back(collRecord.value()->getCollId());
+    }
+    handle->trigger(CollTraceHandleTriggerState::BeforeEnqueueKernel);
+    // Host sleep on the collective's stream — all sleeps run concurrently.
+    cudaLaunchHostFunc(
+        collStreams[c],
+        hostSleepCallback,
+        // NOLINTNEXTLINE(performance-no-int-to-ptr)
+        reinterpret_cast<void*>(static_cast<uintptr_t>(kSleepMs)));
+    handle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel);
+    handles.push_back(std::move(handle));
+  }
+
+  // Join: all collective streams → main stream.
+  for (uint32_t c = 0; c < kNumColls; ++c) {
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaEventRecord(forkEvent, collStreams[c]);
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaStreamWaitEvent(stream_, forkEvent);
+  }
+
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaStreamEndCapture(stream_, &cg.graph);
+  ASSERT_NE(cg.graph, nullptr);
+  ASSERT_EQ(
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      cudaGraphInstantiate(&cg.instance, cg.graph, nullptr, nullptr, 0),
+      cudaSuccess);
+  ASSERT_EQ(cg.collIds.size(), kNumColls);
+
+  std::set<int64_t> validCollIds(cg.collIds.begin(), cg.collIds.end());
+
+  // Replay — all 3 collectives run concurrently with 100ms sleeps.
+  // The poll thread (1ms interval) has ~100ms to observe all 3 as
+  // simultaneously in-flight.
+  ASSERT_EQ(cudaGraphLaunch(cg.instance, stream_), cudaSuccess);
+  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+
+  // NOLINTNEXTLINE(facebook-hte-BadCall-sleep_for)
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+
+  auto progressedIds = progressPlugin_->getProgressedCollIds();
+
+  // All 3 collectives should have been observed as in-flight since
+  // they run concurrently for 100ms.
+  EXPECT_EQ(progressedIds.size(), kNumColls)
+      << "Expected all " << kNumColls
+      << " concurrent collectives to be detected as in-flight";
+
+  for (auto id : progressedIds) {
+    EXPECT_TRUE(validCollIds.count(id) > 0)
+        << "collEventProgressing reported unknown collId " << id;
+  }
+
+  EXPECT_GT(progressPlugin_->progressCount(), 0);
+
+  // After sync, all collectives should have completed.
+  auto completedIds = progressPlugin_->getCompletedCollIds();
+  EXPECT_EQ(completedIds, validCollIds)
+      << "All concurrent collectives should be marked completed after stream sync";
+
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaEventDestroy(forkEvent);
+  for (auto& s : collStreams) {
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaStreamDestroy(s);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Integration test: verify that eager and graph events are merged by
+// timestamp in processCompletedEvents. Records one graph collective and
+// one eager collective, lets both complete, and verifies the plugin sees
+// events in timestamp order.
+// ---------------------------------------------------------------------------
+
+TEST_F(GraphColltraceProgressingTest, EagerAndGraphMergedByTimestamp) {
+  // Record a graph collective (captured with a host sleep so it takes time).
+  cudaGraph_t graph = nullptr;
+  cudaGraphExec_t instance = nullptr;
+
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaStreamBeginCapture(stream_, cudaStreamCaptureModeGlobal);
+  auto graphMetadata = std::make_unique<SimpleMetadata>();
+  auto graphWaitEvent = std::make_unique<GraphCudaWaitEvent>(stream_);
+  auto graphHandle =
+      colltrace_
+          ->recordCollective(
+              std::move(graphMetadata), std::move(graphWaitEvent))
+          .value();
+  graphHandle->trigger(CollTraceHandleTriggerState::BeforeEnqueueKernel);
+  // Short host sleep as the "work".
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaLaunchHostFunc(
+      stream_,
+      hostSleepCallback,
+      // NOLINTNEXTLINE(performance-no-int-to-ptr)
+      reinterpret_cast<void*>(static_cast<uintptr_t>(10)));
+  graphHandle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel);
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaStreamEndCapture(stream_, &graph);
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaGraphInstantiate(&instance, graph, nullptr, nullptr, 0);
+
+  // Launch the graph — this fires the start+end ring buffer writes.
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaGraphLaunch(instance, stream_);
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaStreamSynchronize(stream_);
+
+  // Now record an eager collective on the same stream.
+  auto eagerMetadata = std::make_unique<SimpleMetadata>();
+  auto eagerWaitEvent =
+      std::make_unique<meta::comms::colltrace::CudaWaitEvent>(stream_);
+  auto eagerHandle =
+      colltrace_
+          ->recordCollective(
+              std::move(eagerMetadata), std::move(eagerWaitEvent))
+          .value();
+  eagerHandle->trigger(CollTraceHandleTriggerState::BeforeEnqueueKernel);
+  // Minimal work — just a host func.
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaLaunchHostFunc(
+      stream_,
+      hostSleepCallback,
+      // NOLINTNEXTLINE(performance-no-int-to-ptr)
+      reinterpret_cast<void*>(static_cast<uintptr_t>(10)));
+  eagerHandle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel);
+  eagerHandle->trigger(CollTraceHandleTriggerState::KernelStarted);
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaStreamSynchronize(stream_);
+  eagerHandle->trigger(CollTraceHandleTriggerState::KernelFinished);
+
+  // Wait for the poll thread to process everything.
+  // NOLINTNEXTLINE(facebook-hte-BadCall-sleep_for)
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  // Verify both collectives completed.
+  auto completedIds = progressPlugin_->getCompletedCollIds();
+  EXPECT_EQ(completedIds.size(), 2u)
+      << "Both graph and eager collectives should complete";
+
+  // The graph collective ran first (lower timestamps), so its events
+  // should appear before the eager collective's events in the merged
+  // timeline. The exact ordering depends on timestamp comparison, but
+  // both should be present.
+  auto startedIds = progressPlugin_->getStartedCollIds();
+  EXPECT_EQ(startedIds.size(), 2u) << "Both collectives should have started";
+
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaGraphExecDestroy(instance);
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaGraphDestroy(graph);
+}

--- a/comms/utils/colltrace/tests/GraphCollTraceUT.cc
+++ b/comms/utils/colltrace/tests/GraphCollTraceUT.cc
@@ -20,10 +20,10 @@
 #include <gtest/gtest.h>
 
 #include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/GpuClockCalibration.h"
 #include "comms/utils/colltrace/CollTrace.h"
 #include "comms/utils/colltrace/CollTraceHandle.h"
 #include "comms/utils/colltrace/CudaWaitEvent.h"
-#include "comms/utils/colltrace/GpuClockCalibration.h"
 #include "comms/utils/colltrace/GraphCudaWaitEvent.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 

--- a/comms/utils/colltrace/tests/GraphColltraceTopologyTest.cc
+++ b/comms/utils/colltrace/tests/GraphColltraceTopologyTest.cc
@@ -1,0 +1,686 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Validates the CUDA graph DAG topology produced by graph colltrace capture.
+
+#include <cuda_runtime.h> // @manual=third-party//cuda:cuda-lazy
+
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/colltrace/CollTrace.h"
+#include "comms/utils/colltrace/CollTraceHandle.h"
+#include "comms/utils/colltrace/GpuClockCalibration.h"
+#include "comms/utils/colltrace/GraphCudaWaitEvent.h"
+#include "comms/utils/colltrace/plugins/CommDumpPlugin.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/test_utils/CudaGraphTestUtils.h"
+
+using meta::comms::colltrace::CollTrace;
+using meta::comms::colltrace::CollTraceConfig;
+using meta::comms::colltrace::CollTraceHandleTriggerState;
+using meta::comms::colltrace::CommDumpPlugin;
+using meta::comms::colltrace::GraphCudaWaitEvent;
+using meta::comms::colltrace::ICollMetadata;
+using meta::comms::colltrace::ICollTracePlugin;
+
+namespace {
+
+class BenchMetadata : public ICollMetadata {
+ public:
+  std::size_t hash() const override {
+    return 0;
+  }
+  bool equals(const ICollMetadata&) const noexcept override {
+    return true;
+  }
+  std::string_view getMetadataType() const noexcept override {
+    return "bench";
+  }
+  folly::dynamic toDynamic() const noexcept override {
+    return folly::dynamic::object("type", "bench");
+  }
+  void fromDynamic(const folly::dynamic&) noexcept override {}
+};
+
+} // namespace
+
+class GraphColltraceTopologyTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    int deviceCount = 0;
+    auto err = cudaGetDeviceCount(&deviceCount);
+    if (err != cudaSuccess || deviceCount == 0) {
+      GTEST_SKIP() << "No CUDA device available";
+    }
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaSetDevice(0);
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaStreamCreate(&stream_);
+
+    // Enable cudagraph tracing for these tests.
+    cvarGuard_.emplace(NCCL_COLLTRACE_TRACE_CUDA_GRAPH, true);
+
+    meta::comms::colltrace::GlobaltimerCalibration::get();
+
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaMalloc(&buf1_, kWorkBytes);
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaMalloc(&buf2_, kWorkBytes);
+
+    auto plugins = std::vector<std::unique_ptr<ICollTracePlugin>>{};
+    plugins.push_back(std::make_unique<CommDumpPlugin>());
+    CommLogData logData{};
+    colltrace_ = std::make_shared<CollTrace>(
+        CollTraceConfig{
+            .maxCheckCancelInterval = std::chrono::milliseconds{10}},
+        logData,
+        [this]() -> meta::comms::CommsMaybeVoid {
+          // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+          cudaSetDevice(0);
+          auto mode = cudaStreamCaptureModeThreadLocal;
+          // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+          cudaThreadExchangeStreamCaptureMode(&mode);
+          return folly::unit;
+        },
+        std::move(plugins));
+  }
+
+  void TearDown() override {
+    colltrace_.reset();
+    if (buf2_) {
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      cudaFree(buf2_);
+    }
+    if (buf1_) {
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      cudaFree(buf1_);
+    }
+    if (stream_) {
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      cudaStreamDestroy(stream_);
+    }
+  }
+
+  void launchWork() {
+    cudaMemcpyAsync(
+        buf2_, buf1_, kWorkBytes, cudaMemcpyDeviceToDevice, stream_);
+  }
+
+  // If COLLTRACE_GRAPH_DUMP_DIR is set, dump the graph as a DOT file.
+  // Filename includes the current test name and a suffix for context.
+  void maybeDumpGraph(cudaGraph_t graph, const std::string& suffix) {
+    const char* dir = std::getenv("COLLTRACE_GRAPH_DUMP_DIR");
+    if (dir != nullptr) {
+      auto testName = std::string(
+          ::testing::UnitTest::GetInstance()->current_test_info()->name());
+      auto path = std::string(dir) + "/" + testName + "_" + suffix + ".dot";
+      cudaGraphDebugDotPrint(graph, path.c_str(), 0);
+    }
+  }
+
+  // Capture N serial collectives with colltrace instrumentation.
+  cudaGraph_t captureSerial(uint32_t numColls) {
+    cudaGraph_t graph;
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaStreamBeginCapture(stream_, cudaStreamCaptureModeGlobal);
+    for (uint32_t c = 0; c < numColls; ++c) {
+      auto metadata = std::make_unique<BenchMetadata>();
+      auto waitEvent = std::make_unique<GraphCudaWaitEvent>(stream_);
+      auto handle =
+          colltrace_
+              ->recordCollective(std::move(metadata), std::move(waitEvent))
+              .value();
+      handle->trigger(CollTraceHandleTriggerState::BeforeEnqueueKernel);
+      launchWork();
+      handle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel);
+    }
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaStreamEndCapture(stream_, &graph);
+    maybeDumpGraph(graph, std::to_string(numColls));
+    return graph;
+  }
+
+  // Capture N concurrent collectives on separate streams, simulating
+  // the signal/wait RMA pattern where canConcurrent=true.
+  cudaGraph_t captureConcurrent(uint32_t numColls) {
+    cudaGraph_t graph;
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaStreamBeginCapture(stream_, cudaStreamCaptureModeGlobal);
+
+    // Create per-collective streams forked from the main capture stream.
+    std::vector<cudaStream_t> collStreams(numColls);
+    cudaEvent_t forkEvent;
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaEventCreateWithFlags(&forkEvent, cudaEventDisableTiming);
+
+    // Fork: main stream → each collective stream.
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaEventRecord(forkEvent, stream_);
+    for (uint32_t c = 0; c < numColls; ++c) {
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      cudaStreamCreate(&collStreams[c]);
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      cudaStreamWaitEvent(collStreams[c], forkEvent);
+    }
+
+    // Launch work + colltrace on each concurrent stream.
+    for (uint32_t c = 0; c < numColls; ++c) {
+      auto metadata = std::make_unique<BenchMetadata>();
+      auto waitEvent = std::make_unique<GraphCudaWaitEvent>(collStreams[c]);
+      auto handle =
+          colltrace_
+              ->recordCollective(std::move(metadata), std::move(waitEvent))
+              .value();
+      handle->trigger(CollTraceHandleTriggerState::BeforeEnqueueKernel);
+      // Work on the collective's own stream.
+      cudaMemcpyAsync(
+          buf2_, buf1_, kWorkBytes, cudaMemcpyDeviceToDevice, collStreams[c]);
+      handle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel);
+    }
+
+    // Join: all collective streams → main stream.
+    for (uint32_t c = 0; c < numColls; ++c) {
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      cudaEventRecord(forkEvent, collStreams[c]);
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      cudaStreamWaitEvent(stream_, forkEvent);
+    }
+
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaStreamEndCapture(stream_, &graph);
+    maybeDumpGraph(graph, std::to_string(numColls));
+
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaEventDestroy(forkEvent);
+    for (auto& s : collStreams) {
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      cudaStreamDestroy(s);
+    }
+
+    return graph;
+  }
+
+  // Capture a mixed pattern: serial → concurrent → serial.
+  // Models a realistic workload like: allreduce, then concurrent
+  // signal/wait RMA ops, then another allreduce.
+  cudaGraph_t captureMixed(uint32_t numConcurrent) {
+    cudaGraph_t graph;
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaStreamBeginCapture(stream_, cudaStreamCaptureModeGlobal);
+
+    // Serial collective 1 (e.g., allreduce)
+    {
+      auto metadata = std::make_unique<BenchMetadata>();
+      auto waitEvent = std::make_unique<GraphCudaWaitEvent>(stream_);
+      auto handle =
+          colltrace_
+              ->recordCollective(std::move(metadata), std::move(waitEvent))
+              .value();
+      handle->trigger(CollTraceHandleTriggerState::BeforeEnqueueKernel);
+      launchWork();
+      handle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel);
+    }
+
+    // Concurrent collectives (e.g., signal/wait RMA ops)
+    {
+      std::vector<cudaStream_t> concStreams(numConcurrent);
+      cudaEvent_t forkEvent;
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      cudaEventCreateWithFlags(&forkEvent, cudaEventDisableTiming);
+
+      // Fork main → concurrent streams
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      cudaEventRecord(forkEvent, stream_);
+      for (uint32_t c = 0; c < numConcurrent; ++c) {
+        // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+        cudaStreamCreate(&concStreams[c]);
+        // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+        cudaStreamWaitEvent(concStreams[c], forkEvent);
+      }
+
+      // Launch concurrent work + colltrace
+      for (uint32_t c = 0; c < numConcurrent; ++c) {
+        auto metadata = std::make_unique<BenchMetadata>();
+        auto waitEvent = std::make_unique<GraphCudaWaitEvent>(concStreams[c]);
+        auto handle =
+            colltrace_
+                ->recordCollective(std::move(metadata), std::move(waitEvent))
+                .value();
+        handle->trigger(CollTraceHandleTriggerState::BeforeEnqueueKernel);
+        cudaMemcpyAsync(
+            buf2_, buf1_, kWorkBytes, cudaMemcpyDeviceToDevice, concStreams[c]);
+        handle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel);
+      }
+
+      // Join concurrent streams → main
+      for (uint32_t c = 0; c < numConcurrent; ++c) {
+        // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+        cudaEventRecord(forkEvent, concStreams[c]);
+        // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+        cudaStreamWaitEvent(stream_, forkEvent);
+      }
+
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      cudaEventDestroy(forkEvent);
+      for (auto& s : concStreams) {
+        // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+        cudaStreamDestroy(s);
+      }
+    }
+
+    // Serial collective 2 (e.g., another allreduce)
+    {
+      auto metadata = std::make_unique<BenchMetadata>();
+      auto waitEvent = std::make_unique<GraphCudaWaitEvent>(stream_);
+      auto handle =
+          colltrace_
+              ->recordCollective(std::move(metadata), std::move(waitEvent))
+              .value();
+      handle->trigger(CollTraceHandleTriggerState::BeforeEnqueueKernel);
+      launchWork();
+      handle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel);
+    }
+
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaStreamEndCapture(stream_, &graph);
+    maybeDumpGraph(graph, std::to_string(numConcurrent));
+    return graph;
+  }
+
+  // Capture with non-traced ops interleaved between traced collectives.
+  // This tests that the deferred rejoin doesn't drop dependencies from
+  // non-traced operations.
+  cudaGraph_t captureWithInterleavedOps(uint32_t numColls) {
+    cudaGraph_t graph;
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaStreamBeginCapture(stream_, cudaStreamCaptureModeGlobal);
+    for (uint32_t c = 0; c < numColls; ++c) {
+      auto metadata = std::make_unique<BenchMetadata>();
+      auto waitEvent = std::make_unique<GraphCudaWaitEvent>(stream_);
+      auto handle =
+          colltrace_
+              ->recordCollective(std::move(metadata), std::move(waitEvent))
+              .value();
+      handle->trigger(CollTraceHandleTriggerState::BeforeEnqueueKernel);
+      launchWork();
+      handle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel);
+
+      // Non-traced op between collectives (e.g., a memset).
+      if (c < numColls - 1) {
+        // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+        cudaMemsetAsync(buf1_, 0, kWorkBytes, stream_);
+      }
+    }
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaStreamEndCapture(stream_, &graph);
+    maybeDumpGraph(graph, "interleaved_" + std::to_string(numColls));
+    return graph;
+  }
+
+  static constexpr size_t kWorkBytes = 64 * 1024;
+  cudaStream_t stream_{nullptr};
+  float* buf1_{nullptr};
+  float* buf2_{nullptr};
+  std::optional<EnvRAII<bool>> cvarGuard_;
+  std::shared_ptr<CollTrace> colltrace_;
+};
+
+// Graph capture succeeds for various configurations.
+TEST_F(GraphColltraceTopologyTest, CaptureSucceeds) {
+  for (uint32_t n : {1u, 3u, 10u}) {
+    auto graph = captureSerial(n);
+    ASSERT_NE(graph, nullptr) << "Serial capture failed for N=" << n;
+    auto topo = getGraphTopology(graph);
+    EXPECT_GT(topo.allNodes.size(), 0u);
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaGraphDestroy(graph);
+  }
+}
+
+// Serial collectives have the expected node types.
+TEST_F(GraphColltraceTopologyTest, SerialNodeTypes) {
+  constexpr uint32_t kNumColls = 3;
+  auto graph = captureSerial(kNumColls);
+  auto topo = getGraphTopology(graph);
+
+  auto& memcpyNodes = topo.nodesOfType(cudaGraphNodeTypeMemcpy);
+  auto& kernelNodes = topo.nodesOfType(cudaGraphNodeTypeKernel);
+
+  EXPECT_EQ(memcpyNodes.size(), kNumColls);
+  EXPECT_GE(kernelNodes.size(), kNumColls)
+      << "Expected at least " << kNumColls << " kernel nodes";
+
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaGraphDestroy(graph);
+}
+
+// Each collective has at least one kernel reachable from it (end kernel).
+TEST_F(GraphColltraceTopologyTest, EndKernelsDependOnCollectives) {
+  constexpr uint32_t kNumColls = 3;
+  auto graph = captureSerial(kNumColls);
+  auto topo = getGraphTopology(graph);
+
+  auto& memcpyNodes = topo.nodesOfType(cudaGraphNodeTypeMemcpy);
+  auto& kernelNodes = topo.nodesOfType(cudaGraphNodeTypeKernel);
+
+  for (size_t i = 0; i < memcpyNodes.size(); ++i) {
+    bool hasReachableKernel = false;
+    for (auto& kn : kernelNodes) {
+      if (topo.hasEdge(memcpyNodes[i], kn) ||
+          topo.hasPath(memcpyNodes[i], kn)) {
+        hasReachableKernel = true;
+        break;
+      }
+    }
+    EXPECT_TRUE(hasReachableKernel)
+        << "Collective " << i << " has no reachable end kernel";
+  }
+
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaGraphDestroy(graph);
+}
+
+// Verify deferred rejoin: for serial collectives, no kernel node (start or
+// end timestamp kernel) should be a direct predecessor of any memcpy node
+// (collective). This proves that intermediate rejoins have been undone —
+// the next collective doesn't wait for the previous end kernel.
+TEST_F(GraphColltraceTopologyTest, DeferredRejoinRemovesIntermediateEdges) {
+  constexpr uint32_t kNumColls = 3;
+  auto graph = captureSerial(kNumColls);
+  auto topo = getGraphTopology(graph);
+
+  auto& memcpyNodes = topo.nodesOfType(cudaGraphNodeTypeMemcpy);
+  auto& kernelNodes = topo.nodesOfType(cudaGraphNodeTypeKernel);
+
+  ASSERT_EQ(memcpyNodes.size(), kNumColls);
+
+  // For each memcpy (collective), check that no kernel node has a direct
+  // edge to it. If the deferred rejoin is working, the main stream's
+  // capture dependencies were restored to exclude the end kernel before
+  // the next collective was captured.
+  for (size_t i = 0; i < memcpyNodes.size(); ++i) {
+    for (auto& kn : kernelNodes) {
+      // Direct edge means the end kernel's rejoin was NOT undone.
+      // hasPath would also catch indirect edges through event nodes,
+      // which is too strict — we only care about direct edges that
+      // indicate a pending rejoin.
+
+      // Check: is there a direct edge from any kernel to this memcpy?
+      // We look for edges kernel → X → memcpy where X is an event wait
+      // node (which is how rejoins manifest in the graph). A direct
+      // kernel → memcpy edge or kernel → eventWait → memcpy means the
+      // rejoin was not undone.
+
+      // Simpler: just check no kernel is a direct predecessor.
+      EXPECT_FALSE(topo.hasEdge(kn, memcpyNodes[i]))
+          << "Kernel node has a direct edge to collective " << i
+          << " — deferred rejoin not working (intermediate end kernel "
+             "is blocking the next collective)";
+    }
+  }
+
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaGraphDestroy(graph);
+}
+
+// Concurrent capture succeeds and produces a valid graph.
+TEST_F(GraphColltraceTopologyTest, ConcurrentCaptureSucceeds) {
+  for (uint32_t n : {2u, 3u, 5u}) {
+    auto graph = captureConcurrent(n);
+    ASSERT_NE(graph, nullptr) << "Concurrent capture failed for N=" << n;
+    auto topo = getGraphTopology(graph);
+    EXPECT_GT(topo.allNodes.size(), 0u);
+
+    // Should have N memcpy nodes (one per concurrent collective).
+    auto& memcpyNodes = topo.nodesOfType(cudaGraphNodeTypeMemcpy);
+    EXPECT_EQ(memcpyNodes.size(), n);
+
+    // Should have kernel nodes (start + end per collective).
+    auto& kernelNodes = topo.nodesOfType(cudaGraphNodeTypeKernel);
+    EXPECT_GE(kernelNodes.size(), n);
+
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaGraphDestroy(graph);
+  }
+}
+
+// Concurrent collectives: verify that the graph can be instantiated and
+// replayed, producing correct timestamps for each collective.
+TEST_F(GraphColltraceTopologyTest, ConcurrentReplayProducesTimestamps) {
+  constexpr uint32_t kNumColls = 3;
+  auto graph = captureConcurrent(kNumColls);
+  ASSERT_NE(graph, nullptr);
+
+  cudaGraphExec_t instance;
+  ASSERT_EQ(
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      cudaGraphInstantiate(&instance, graph, nullptr, nullptr, 0),
+      cudaSuccess);
+
+  // Replay a few times.
+  for (int i = 0; i < 5; ++i) {
+    ASSERT_EQ(cudaGraphLaunch(instance, stream_), cudaSuccess);
+  }
+  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaGraphExecDestroy(instance);
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaGraphDestroy(graph);
+}
+
+// Mixed pattern: serial → concurrent → serial. Models a realistic workload.
+TEST_F(GraphColltraceTopologyTest, MixedSerialConcurrentSerial) {
+  constexpr uint32_t kNumConcurrent = 2;
+  auto graph = captureMixed(kNumConcurrent);
+  ASSERT_NE(graph, nullptr);
+
+  auto topo = getGraphTopology(graph);
+
+  // Total: 1 serial + 2 concurrent + 1 serial = 4 memcpy nodes.
+  auto& memcpyNodes = topo.nodesOfType(cudaGraphNodeTypeMemcpy);
+  EXPECT_EQ(memcpyNodes.size(), 2 + kNumConcurrent);
+
+  // Should have kernel nodes for all collectives.
+  auto& kernelNodes = topo.nodesOfType(cudaGraphNodeTypeKernel);
+  EXPECT_GE(kernelNodes.size(), 2 + kNumConcurrent);
+
+  // Verify the graph can be instantiated and replayed.
+  cudaGraphExec_t instance;
+  ASSERT_EQ(
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      cudaGraphInstantiate(&instance, graph, nullptr, nullptr, 0),
+      cudaSuccess);
+  for (int i = 0; i < 5; ++i) {
+    ASSERT_EQ(cudaGraphLaunch(instance, stream_), cudaSuccess);
+  }
+  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaGraphExecDestroy(instance);
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaGraphDestroy(graph);
+}
+
+// Concurrent collectives: verify no kernel node serialization.
+// With per-collective timestamp streams, concurrent collectives' memcpy
+// nodes should NOT have a path between them (they're on parallel streams).
+TEST_F(GraphColltraceTopologyTest, ConcurrentCollectivesAreParallel) {
+  constexpr uint32_t kNumColls = 3;
+  auto graph = captureConcurrent(kNumColls);
+  auto topo = getGraphTopology(graph);
+
+  auto& memcpyNodes = topo.nodesOfType(cudaGraphNodeTypeMemcpy);
+  ASSERT_EQ(memcpyNodes.size(), kNumColls);
+
+  // For concurrent collectives, no memcpy should be reachable from another
+  // memcpy (they're on independent streams).
+  for (size_t i = 0; i < memcpyNodes.size(); ++i) {
+    for (size_t j = 0; j < memcpyNodes.size(); ++j) {
+      if (i == j) {
+        continue;
+      }
+      EXPECT_FALSE(topo.hasPath(memcpyNodes[i], memcpyNodes[j]))
+          << "Concurrent collective " << i << " should not be reachable from "
+          << j << " — they should be parallel";
+    }
+  }
+
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaGraphDestroy(graph);
+}
+
+// Verify that non-traced operations between traced collectives preserve
+// their ordering. The deferred rejoin restores capture deps, which must
+// include any non-traced ops that were added after the previous rejoin.
+TEST_F(GraphColltraceTopologyTest, InterleavedNonTracedOpsPreserveOrder) {
+  constexpr uint32_t kNumColls = 3;
+  auto graph = captureWithInterleavedOps(kNumColls);
+  ASSERT_NE(graph, nullptr);
+
+  auto topo = getGraphTopology(graph);
+
+  // With 3 collectives and memsets between them:
+  // 3 memcpy nodes (collectives) + 2 memset nodes.
+  auto& memcpyNodes = topo.nodesOfType(cudaGraphNodeTypeMemcpy);
+  auto& memsetNodes = topo.nodesOfType(cudaGraphNodeTypeMemset);
+
+  EXPECT_EQ(memcpyNodes.size(), kNumColls);
+  EXPECT_EQ(memsetNodes.size(), kNumColls - 1);
+
+  // Each memset should be reachable from at least one memcpy (the
+  // collective before it) and should have at least one memcpy reachable
+  // from it (the collective after it). If the deferred rejoin broke the
+  // dependency chain, a memset would be disconnected.
+  for (size_t i = 0; i < memsetNodes.size(); ++i) {
+    bool hasPredMemcpy = false;
+    bool hasSuccMemcpy = false;
+    for (auto& mc : memcpyNodes) {
+      if (topo.hasPath(mc, memsetNodes[i])) {
+        hasPredMemcpy = true;
+      }
+      if (topo.hasPath(memsetNodes[i], mc)) {
+        hasSuccMemcpy = true;
+      }
+    }
+    EXPECT_TRUE(hasPredMemcpy)
+        << "Memset " << i
+        << " has no predecessor collective — "
+           "deferred rejoin may have dropped dependencies";
+    EXPECT_TRUE(hasSuccMemcpy)
+        << "Memset " << i
+        << " has no successor collective — "
+           "deferred rejoin may have dropped dependencies";
+  }
+
+  // Verify it can instantiate and replay correctly.
+  cudaGraphExec_t instance;
+  ASSERT_EQ(
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      cudaGraphInstantiate(&instance, graph, nullptr, nullptr, 0),
+      cudaSuccess);
+  for (int i = 0; i < 5; ++i) {
+    ASSERT_EQ(cudaGraphLaunch(instance, stream_), cudaSuccess);
+  }
+  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaGraphExecDestroy(instance);
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaGraphDestroy(graph);
+}
+
+// When NCCL_COLLTRACE_TRACE_CUDA_GRAPH is disabled, recordCollective should
+// fail for graph-captured collectives and the resulting graph should contain
+// no telemetry kernel nodes.
+TEST(GraphColltraceTopologyDisabledTest, NoTelemetryNodesWhenDisabled) {
+  int deviceCount = 0;
+  auto err = cudaGetDeviceCount(&deviceCount);
+  if (err != cudaSuccess || deviceCount == 0) {
+    GTEST_SKIP() << "No CUDA device available";
+  }
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaSetDevice(0);
+
+  // Disable the cvar.
+  EnvRAII<bool> cvarGuard(NCCL_COLLTRACE_TRACE_CUDA_GRAPH, false);
+
+  // Create CollTrace with the cvar disabled — ring buffer should not
+  // be allocated.
+  auto plugins = std::vector<std::unique_ptr<ICollTracePlugin>>{};
+  plugins.push_back(std::make_unique<CommDumpPlugin>());
+  CommLogData logData{};
+  auto colltrace = std::make_shared<CollTrace>(
+      CollTraceConfig{.maxCheckCancelInterval = std::chrono::milliseconds{10}},
+      logData,
+      []() -> meta::comms::CommsMaybeVoid {
+        // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+        cudaSetDevice(0);
+        auto mode = cudaStreamCaptureModeThreadLocal;
+        // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+        cudaThreadExchangeStreamCaptureMode(&mode);
+        return folly::unit;
+      },
+      std::move(plugins));
+
+  cudaStream_t stream;
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaStreamCreate(&stream);
+
+  constexpr size_t kWorkBytes = 64 * 1024;
+  float* buf1 = nullptr;
+  float* buf2 = nullptr;
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaMalloc(&buf1, kWorkBytes);
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaMalloc(&buf2, kWorkBytes);
+
+  // Eagerly initialize globaltimer calibration before capture starts —
+  // it does cudaHostAlloc which is illegal during stream capture.
+  meta::comms::colltrace::GlobaltimerCalibration::get();
+
+  // Capture a graph — recordCollective should fail for graph-captured
+  // collectives when the ring buffer is not allocated.
+  cudaGraph_t graph;
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaStreamBeginCapture(stream, cudaStreamCaptureModeGlobal);
+
+  for (int i = 0; i < 3; ++i) {
+    auto metadata = std::make_unique<BenchMetadata>();
+    auto waitEvent = std::make_unique<GraphCudaWaitEvent>(stream);
+    auto result =
+        colltrace->recordCollective(std::move(metadata), std::move(waitEvent));
+    EXPECT_TRUE(result.hasError())
+        << "recordCollective should fail when cudagraph tracing is disabled";
+
+    cudaMemcpyAsync(buf2, buf1, kWorkBytes, cudaMemcpyDeviceToDevice, stream);
+  }
+
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaStreamEndCapture(stream, &graph);
+  ASSERT_NE(graph, nullptr);
+
+  auto topo = getGraphTopology(graph);
+
+  // Only memcpy (work) nodes should exist — no kernel (telemetry) nodes.
+  auto& memcpyNodes = topo.nodesOfType(cudaGraphNodeTypeMemcpy);
+  auto& kernelNodes = topo.nodesOfType(cudaGraphNodeTypeKernel);
+  EXPECT_EQ(memcpyNodes.size(), 3u);
+  EXPECT_EQ(kernelNodes.size(), 0u)
+      << "Expected no telemetry kernel nodes when "
+         "NCCL_COLLTRACE_TRACE_CUDA_GRAPH is disabled";
+
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaGraphDestroy(graph);
+  colltrace.reset();
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaFree(buf2);
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaFree(buf1);
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaStreamDestroy(stream);
+}

--- a/comms/utils/colltrace/tests/GraphColltraceTopologyTest.cc
+++ b/comms/utils/colltrace/tests/GraphColltraceTopologyTest.cc
@@ -11,9 +11,9 @@
 #include <gtest/gtest.h>
 
 #include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/GpuClockCalibration.h"
 #include "comms/utils/colltrace/CollTrace.h"
 #include "comms/utils/colltrace/CollTraceHandle.h"
-#include "comms/utils/colltrace/GpuClockCalibration.h"
 #include "comms/utils/colltrace/GraphCudaWaitEvent.h"
 #include "comms/utils/colltrace/plugins/CommDumpPlugin.h"
 #include "comms/utils/cvars/nccl_cvars.h"


### PR DESCRIPTION
Summary:

just moving around some files since they aren't specific to colltrace, and adding __CUDACC__ friendly bindings for our ring buffer apis

Reviewed By: siyengar

Differential Revision: D99166508
