### PR TITLE
Add missing trition dep to BUCK target

### DIFF
--- a/comms/pipes/collectives/triton/device_alltoallv_dynamic.py
+++ b/comms/pipes/collectives/triton/device_alltoallv_dynamic.py
@@ -69,7 +69,6 @@ from torchcomms.triton.fb import (
     wait_signal_from,
 )
 
-
 if TYPE_CHECKING:
     from torchcomms import TorchComm
 


### PR DESCRIPTION
Summary:
The test_device_alltoallv_dynamic target was missing the triton dependency in its BUCK file. Without it, CI workers that don't have triton pre-installed hit ImportError at module load time, before any test skip logic could run. This caused all 34 tests to fail with "cannot import name 'flush_block' from 'torchcomms.triton.fb'".

Add the triton dep so the module imports succeed. Individual tests that need CUDA still skip gracefully via unittest.skipUnless(CUDA_AVAILABLE).

Also reverts the try/except import guards and SimpleNamespace stubs that were added as a workaround — they're no longer needed since triton is always available as a build dep.

Differential Revision: D100182678


