### PR TITLE
Clean up ctran logging for small message allreduce ring (#2053)

### DIFF
--- a/comms/ctran/algos/AllReduce/AllReduce.cc
+++ b/comms/ctran/algos/AllReduce/AllReduce.cc
@@ -49,14 +49,14 @@ commResult_t ctranAllReduce(
         // TODO(T242570177): this is a temp workaround for nRanks == 1. Remove
         // the warning below if fixed.
         CLOGF(
-            WARN,
+            DBG,
             "AllReduce ctring currently requires nRanks > 1, fallback to ctdirect");
         return ctranAllReduceDirect(
             sendbuff, recvbuff, count, datatype, redOp, comm, stream, timeout);
       }
       if (count < comm->statex_->nRanks()) {
         CLOGF(
-            WARN,
+            DBG,
             "AllReduce ctring requires count {} > nRanks {}, fallback to ctdirect",
             count,
             comm->statex_->nRanks());


### PR DESCRIPTION
Summary:

As title.

Moved the logging level to DBG.

Reviewed By: dboyda, Scusemua

Differential Revision: D100648760
