### PR TITLE
fix agp race + deadlock (#2054)

### DIFF
--- a/comms/ctran/algos/RMA/PutSignal.cc
+++ b/comms/ctran/algos/RMA/PutSignal.cc
@@ -106,45 +106,58 @@ static commResult_t putSignalImpl(
       reinterpret_cast<size_t>(win->remWinInfo[peerRank].dataAddr) +
       targetDispNbytes);
 
-  // Get registration handle for local send buffer
+  // Skip data transfer if count is 0 (signal-only, e.g. ready barrier)
   void* localMemHdl = nullptr;
   bool localReg = false;
-  FB_COMMCHECK(comm->ctran_->mapper->searchRegHandle(
-      op->putsignal.sendbuff, putSize, &localMemHdl, &localReg));
+  if (putSize > 0) {
+    // Get registration handle for local send buffer
+    FB_COMMCHECK(comm->ctran_->mapper->searchRegHandle(
+        op->putsignal.sendbuff, putSize, &localMemHdl, &localReg));
 
-  CLOGF_TRACE(
-      COLL,
-      "putSignalImpl: sbuf {}, rbuf {} (base {} + offset {}), size {}, signalAddr {} signalVal {}",
-      op->putsignal.sendbuff,
-      dstPtr,
-      win->remWinInfo[peerRank].dataAddr,
-      targetDispNbytes,
-      putSize,
-      (void*)op->putsignal.signalAddr,
-      op->putsignal.signalVal);
+    CLOGF_TRACE(
+        COLL,
+        "putSignalImpl: sbuf {}, rbuf {} (base {} + offset {}), size {}, signalAddr {} signalVal {}",
+        op->putsignal.sendbuff,
+        dstPtr,
+        win->remWinInfo[peerRank].dataAddr,
+        targetDispNbytes,
+        putSize,
+        (void*)op->putsignal.signalAddr,
+        op->putsignal.signalVal);
 
-  CtranMapperRequest* req = nullptr;
+    CtranMapperRequest* req = nullptr;
 
-  FB_COMMCHECK(comm->ctran_->mapper->iput(
-      op->putsignal.sendbuff,
-      dstPtr,
-      putSize,
-      peerRank,
-      CtranMapperConfig{
-          .memHdl_ = localMemHdl,
-          .remoteAccessKey_ = win->remWinInfo[peerRank].dataRkey,
-      },
-      &req));
+    FB_COMMCHECK(comm->ctran_->mapper->iput(
+        op->putsignal.sendbuff,
+        dstPtr,
+        putSize,
+        peerRank,
+        CtranMapperConfig{
+            .memHdl_ = localMemHdl,
+            .remoteAccessKey_ = win->remWinInfo[peerRank].dataRkey,
+        },
+        &req));
 
-  auto putReq = std::unique_ptr<CtranMapperRequest>(req);
-  FB_COMMCHECK(comm->ctran_->mapper->waitRequest(putReq.get()));
+    auto putReq = std::unique_ptr<CtranMapperRequest>(req);
+    FB_COMMCHECK(comm->ctran_->mapper->waitRequest(putReq.get()));
+  }
 
   CtranMapperRequest signalReq = CtranMapperRequest();
   if (op->putsignal.signalAddr != nullptr) {
+    // For graph replay, read the replay counter to get a fresh monotonic
+    // signal value. The counter is in mapped pinned host memory, so the
+    // GPE host thread can read it directly. For eager, use the baked value.
+    uint64_t signalVal = op->putsignal.signalVal;
+    if (signalVal == 0 && win->graphReplayCounter != nullptr) {
+      // Read with volatile to ensure we see the GPU kernel's write to
+      // this mapped pinned host memory. Without volatile, the CPU may
+      // read a cached stale value.
+      signalVal = *static_cast<volatile uint64_t*>(win->graphReplayCounter);
+    }
     // flush the iput to make sure the signal is sent after the data
     FB_COMMCHECK(comm->ctran_->mapper->atomicSet(
         op->putsignal.signalAddr,
-        op->putsignal.signalVal,
+        signalVal,
         peerRank,
         CtranMapperConfig{
             .remoteAccessKey_ = win->remWinInfo[peerRank].signalRkey},
@@ -181,10 +194,16 @@ static commResult_t signalImpl(
       (void*)op->signal.signalAddr,
       op->signal.signalVal);
 
+  // For graph replay, read the replay counter for a fresh signal value.
+  uint64_t signalVal = op->signal.signalVal;
+  if (signalVal == 0 && win->graphReplayCounter != nullptr) {
+    signalVal = *static_cast<volatile uint64_t*>(win->graphReplayCounter);
+  }
+
   CtranMapperRequest signalReq = CtranMapperRequest();
   FB_COMMCHECK(comm->ctran_->mapper->atomicSet(
       op->signal.signalAddr,
-      op->signal.signalVal,
+      signalVal,
       peerRank,
       CtranMapperConfig{
           .remoteAccessKey_ = win->remWinInfo[peerRank].signalRkey},
@@ -252,9 +271,20 @@ commResult_t ctranPutSignal(
   size_t countNbytes = count * commTypeSize(datatype);
   uint64_t* signalAddr = nullptr;
   uint64_t signalVal = 0;
+  cudaStreamCaptureStatus captureStatus{};
+  cudaStreamGetCaptureInfo(stream, &captureStatus, nullptr);
+  bool isCapturing = (captureStatus == cudaStreamCaptureStatusActive);
   if (signal) {
-    signalVal = win->ctranNextSignalVal(peer);
-    signalAddr = win->remWinInfo[peer].signalAddr + statex->rank();
+    if (isCapturing) {
+      // During graph capture, use the graph signal buffer. The actual
+      // signal value comes from a device-side replay counter read by the
+      // kernel at runtime (not baked into graph args).
+      signalVal = 0; // unused — kernel reads replayCounter instead
+      signalAddr = win->remWinInfo[peer].graphSignalAddr + statex->rank();
+    } else {
+      signalVal = win->ctranNextSignalVal(peer);
+      signalAddr = win->remWinInfo[peer].signalAddr + statex->rank();
+    }
   }
 
   KernelConfig config = KernelConfig(
@@ -266,8 +296,15 @@ commResult_t ctranPutSignal(
 
   // Use direct copy if peer is on the same host and has NVL enabled.
   // Otherwise, do put & signal via network
-  CtranKernelPutSignalArgs kernArgs = {.signalAddr = nullptr, .signalVal = 0};
-  if (statex->node(peer) == statex->node() && win->nvlEnabled(peer)) {
+  bool isNvl = statex->node(peer) == statex->node() && win->nvlEnabled(peer);
+  CtranKernelPutSignalArgs kernArgs = {
+      .signalAddr = nullptr,
+      .signalVal = 0,
+      .replayCounter = isCapturing ? win->graphReplayCounter : nullptr,
+      // NVL: only same-device kernels read the counter (device scope).
+      // IB: the GPE host thread also reads it (system scope).
+      .replayCounterSystemScope = !isNvl};
+  if (isNvl) {
     // Single-node direct cudaMemcpy
     if (count > 0) {
       void* dstPtr = reinterpret_cast<void*>(
@@ -336,53 +373,25 @@ waitSignalDriverApi(int peer, CtranWin* win, cudaStream_t stream) {
     return commInvalidUsage;
   }
 
-  // Get the signal address
-  const uint64_t* signalAddr = win->winSignalPtr + peer;
-  // Get the expected compare value
-  uint64_t cmpVal = win->ctranNextWaitSignalVal(peer);
-
   cudaStreamCaptureStatus captureStatus{};
   cudaStreamGetCaptureInfo(stream, &captureStatus, nullptr);
 
-  CUresult result;
-
   if (captureStatus == cudaStreamCaptureStatusActive) {
-    if (!ctran::utils::canUseCuStreamBatchMemOp()) {
-      return commInvalidUsage;
-    }
-
-    // During CUDA graph capture, use cuStreamBatchMemOp to atomically
-    // wait for the signal and then reset it to 0.  The reset prepares
-    // the slot for the next graph replay.
-    //
-    // This follows the pattern established by NCCL's CE collective path
-    // in ncclMemOpSync() (comms/ncclx/v2_28/src/ce_coll.cc lines 212-222),
-    // which batches waits + resets in a single cuStreamBatchMemOp during
-    // graph capture.  The batch is atomic on the stream — the wait
-    // completes before the reset runs, and no remote signal for the next
-    // replay can interleave.
-    CUstreamBatchMemOpParams ops[2] = {};
-
-    // wait for signal GEQ cmpVal
-    ops[0].waitValue.operation = CU_STREAM_MEM_OP_WAIT_VALUE_64;
-    ops[0].waitValue.address = (CUdeviceptr)signalAddr;
-    ops[0].waitValue.value64 = cmpVal;
-    ops[0].waitValue.flags = CU_STREAM_WAIT_VALUE_GEQ;
-
-    // reset signal to 0
-    ops[1].writeValue.operation = CU_STREAM_MEM_OP_WRITE_VALUE_64;
-    ops[1].writeValue.address = (CUdeviceptr)signalAddr;
-    ops[1].writeValue.value64 = 0;
-    ops[1].writeValue.flags = CU_STREAM_WRITE_VALUE_DEFAULT;
-
-    result = FB_CUPFN(cuStreamBatchMemOp)((CUstream)stream, 2, ops, 0);
-  } else {
-    result = FB_CUPFN(cuStreamWaitValue64)(
-        (CUstream)stream,
-        (CUdeviceptr)signalAddr,
-        cmpVal,
-        CU_STREAM_WAIT_VALUE_GEQ);
+    // During graph capture, fall back to the spinning kernel which uses
+    // a device-side replay counter for monotonically increasing signal
+    // values. Don't advance the eager counter.
+    return commInvalidUsage;
   }
+
+  // Eager path only below
+  const uint64_t* signalAddr = win->winSignalPtr + peer;
+  uint64_t cmpVal = win->ctranNextWaitSignalVal(peer);
+
+  CUresult result = FB_CUPFN(cuStreamWaitValue64)(
+      (CUstream)stream,
+      (CUdeviceptr)signalAddr,
+      cmpVal,
+      CU_STREAM_WAIT_VALUE_GEQ);
 
   if (result != CUDA_SUCCESS) {
     const char* errStr = nullptr;
@@ -421,9 +430,20 @@ commResult_t waitSignalSpinningKernel(
     cudaStream_t stream,
     uint64_t waitOpCount) {
   CtranComm* comm = win->comm;
-  auto waitSignalVal = win->ctranNextWaitSignalVal(peer);
 
-  const uint64_t* signalAddr = win->winSignalPtr + peer;
+  cudaStreamCaptureStatus spinCaptureCheck{};
+  cudaStreamGetCaptureInfo(stream, &spinCaptureCheck, nullptr);
+  bool isCapturing = (spinCaptureCheck == cudaStreamCaptureStatusActive);
+
+  uint64_t waitSignalVal;
+  const uint64_t* signalAddr;
+  if (isCapturing) {
+    waitSignalVal = 0; // unused — kernel reads replayCounter instead
+    signalAddr = win->winGraphSignalPtr + peer;
+  } else {
+    waitSignalVal = win->ctranNextWaitSignalVal(peer);
+    signalAddr = win->winSignalPtr + peer;
+  }
 
   KernelConfig config = KernelConfig(
       KernelConfig::KernelType::WAITSIGNAL, stream, "WaitSignal", waitOpCount);
@@ -436,6 +456,7 @@ commResult_t waitSignalSpinningKernel(
   CtranKernelWaitSignalArgs kernArgs = {
       .signalAddr = nullptr,
       .cmpVal = waitSignalVal,
+      .replayCounter = isCapturing ? win->graphReplayCounter : nullptr,
   };
   config.algoArgs = reinterpret_cast<void*>(&kernArgs);
   if (win->isGpuMem()) {
@@ -469,7 +490,20 @@ commResult_t ctranSignal(int peer, CtranWin* win, cudaStream_t stream) {
       win->updateOpCount(peer, window::OpCountType::kSignal);
   auto statex = comm->statex_.get();
 
-  auto signalVal = win->ctranNextSignalVal(peer);
+  cudaStreamCaptureStatus sigCaptureStatus{};
+  cudaStreamGetCaptureInfo(stream, &sigCaptureStatus, nullptr);
+  bool isCapturing = (sigCaptureStatus == cudaStreamCaptureStatusActive);
+
+  uint64_t signalVal;
+  uint64_t* signalAddr;
+  if (isCapturing) {
+    signalVal = 0; // unused — kernel reads replayCounter
+    signalAddr = win->remWinInfo[peer].graphSignalAddr + statex->rank();
+  } else {
+    signalVal = win->ctranNextSignalVal(peer);
+    signalAddr = win->remWinInfo[peer].signalAddr + statex->rank();
+  }
+
   CTRAN_RMA_INFO(
       "ctranSignal",
       sigOpCount,
@@ -484,8 +518,6 @@ commResult_t ctranSignal(int peer, CtranWin* win, cudaStream_t stream) {
       comm,
       stream);
 
-  uint64_t* signalAddr = win->remWinInfo[peer].signalAddr + statex->rank();
-
   KernelConfig config = KernelConfig(
       KernelConfig::KernelType::SIGNAL, stream, "Signal", sigOpCount);
   config.args.devState_d = comm->ctran_->algo->getDevState();
@@ -495,9 +527,14 @@ commResult_t ctranSignal(int peer, CtranWin* win, cudaStream_t stream) {
 
   // Use cuda atomic store if peer is on the same host and has NVL enabled.
   // Otherwise, do signal via IB in GPE thread
-  CtranKernelSignalArgs kernArgs = {.signalAddr = nullptr, .signalVal = 0};
+  bool isSigNvl = statex->node(peer) == statex->node() && win->nvlEnabled(peer);
+  CtranKernelSignalArgs kernArgs = {
+      .signalAddr = nullptr,
+      .signalVal = 0,
+      .replayCounter = isCapturing ? win->graphReplayCounter : nullptr,
+      .replayCounterSystemScope = !isSigNvl};
   config.algoArgs = reinterpret_cast<void*>(&kernArgs);
-  if (statex->node(peer) == statex->node() && win->nvlEnabled(peer)) {
+  if (isSigNvl) {
     kernArgs.signalAddr = signalAddr;
     kernArgs.signalVal = signalVal;
   } else {

--- a/comms/ctran/algos/RMA/PutSignal.cu
+++ b/comms/ctran/algos/RMA/PutSignal.cu
@@ -79,19 +79,39 @@ __global__ void ncclKernelPutSignal(
     CtranAlgoDeviceState* devState,
     CtranKernelPutSignalArgs args) {
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
+
+  [[maybe_unused]] uint64_t val = args.signalVal;
+  if (gtIdx == 0 && args.replayCounter) {
+#if defined(__HIP_PLATFORM_AMD__)
+    trap();
+#else
+    if (args.replayCounterSystemScope) /* ib */ {
+      ::cuda::atomic_ref<uint64_t, cuda::thread_scope_system> cref{
+          *args.replayCounter};
+      val = cref.fetch_add(1, cuda::std::memory_order_release) + 1;
+    } else /* nvl */ {
+      ::cuda::atomic_ref<uint64_t, cuda::thread_scope_device> cref{
+          *args.replayCounter};
+      val = cref.fetch_add(1, cuda::std::memory_order_release) + 1;
+    }
+#endif
+  }
+
   if (flag && gtIdx == 0) {
     ctran::device::devLoadAbortFlags(flag, devState);
     ctran::device::KernelStartGpe(flag);
   }
-  // just atomic store
-  if (gtIdx == 0 && args.signalAddr != nullptr) {
+  if (gtIdx == 0) {
 #if defined(__HIP_PLATFORM_AMD__)
     // TODO: implement this atomic operations for AMD GPUs.
-    trap();
+    if (args.signalAddr != nullptr)
+      trap();
 #else
-    ::cuda::atomic_ref<uint64_t, cuda::thread_scope_system> ref{
-        *args.signalAddr};
-    ref.store(args.signalVal, cuda::std::memory_order_release);
+    if (args.signalAddr != nullptr) {
+      ::cuda::atomic_ref<uint64_t, cuda::thread_scope_system> ref{
+          *args.signalAddr};
+      ref.store(val, cuda::std::memory_order_release);
+    }
 #endif
   }
 
@@ -124,9 +144,15 @@ __global__ void ncclKernelWaitSignal(
     // TODO: implement this atomic operations for AMD GPUs.
     trap();
 #else
+    uint64_t val = args.cmpVal;
+    if (args.replayCounter) {
+      ::cuda::atomic_ref<uint64_t, cuda::thread_scope_device> cref{
+          *args.replayCounter};
+      val = cref.load(cuda::std::memory_order_acquire);
+    }
     ::cuda::atomic_ref<uint64_t, cuda::thread_scope_system> ref{
         *args.signalAddr};
-    while (ref.load(cuda::std::memory_order_acquire) < args.cmpVal) {
+    while (ref.load(cuda::std::memory_order_acquire) < val) {
     }
 #endif
   }
@@ -141,6 +167,22 @@ __global__ void ncclKernelSignal(
     CtranAlgoDeviceState* devState,
     CtranKernelSignalArgs args) {
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
+
+  [[maybe_unused]] uint64_t val = args.signalVal;
+  if (gtIdx == 0 && args.replayCounter) {
+#if !defined(__HIP_PLATFORM_AMD__)
+    if (args.replayCounterSystemScope) /* ib */ {
+      ::cuda::atomic_ref<uint64_t, cuda::thread_scope_system> cref{
+          *args.replayCounter};
+      val = cref.fetch_add(1, cuda::std::memory_order_release) + 1;
+    } else /* nvl */ {
+      ::cuda::atomic_ref<uint64_t, cuda::thread_scope_device> cref{
+          *args.replayCounter};
+      val = cref.fetch_add(1, cuda::std::memory_order_release) + 1;
+    }
+#endif
+  }
+
   if (flag && gtIdx == 0) {
     ctran::device::devLoadAbortFlags(flag, devState);
     ctran::device::KernelStartGpe(flag);
@@ -152,7 +194,7 @@ __global__ void ncclKernelSignal(
 #else
     ::cuda::atomic_ref<uint64_t, cuda::thread_scope_system> ref{
         *args.signalAddr};
-    ref.store(args.signalVal, cuda::std::memory_order_release);
+    ref.store(val, cuda::std::memory_order_release);
 #endif
   }
 

--- a/comms/ctran/algos/RMA/Types.h
+++ b/comms/ctran/algos/RMA/Types.h
@@ -25,14 +25,29 @@ struct KernelGetArgs {
 struct CtranKernelPutSignalArgs {
   uint64_t* signalAddr;
   uint64_t signalVal;
+  // Device-side replay counter for CUDA graph mode. When non-null, the
+  // kernel atomically increments this counter and uses the result as the
+  // signal value (ignoring signalVal). This gives each graph replay a
+  // unique monotonic value without modifying frozen graph args.
+  uint64_t* replayCounter;
+  // Whether the counter increment needs system-wide visibility (true for
+  // IB path where the GPE host thread reads the counter, false for NVL
+  // where only same-device kernels read it).
+  bool replayCounterSystemScope;
 };
 
 struct CtranKernelWaitSignalArgs {
   uint64_t* signalAddr;
   uint64_t cmpVal;
+  // Device-side replay counter for CUDA graph mode. When non-null, the
+  // kernel reads this counter (already incremented by PutSignal on the
+  // same stream) and uses it as the compare value (ignoring cmpVal).
+  uint64_t* replayCounter;
 };
 
 struct CtranKernelSignalArgs {
   uint64_t* signalAddr;
   uint64_t signalVal;
+  uint64_t* replayCounter;
+  bool replayCounterSystemScope;
 };

--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -122,6 +122,9 @@ OrderedWorkStreamGuard::Scope OrderedWorkStreamGuard::acquire(
 
 void CUDART_CB CtranGpe::Impl::cmdCb(void* data) {
   CtranGpeCmd* cmd = reinterpret_cast<CtranGpeCmd*>(data);
+  if (cmd->persistent) {
+    cmd->inFlight.fetch_add(1, std::memory_order_release);
+  }
   cmd->gpe->pimpl->cmdEnqueue(cmd);
 }
 
@@ -149,6 +152,13 @@ void CUDART_CB CtranGpe::Impl::cmdDestroy(void* data) {
   CtranGpeCmd* cmd = reinterpret_cast<CtranGpeCmd*>(data);
   if (!cmd->persistent) {
     CLOGF(WARN, "CTranGPE: cmd desctructor called for non-persistent cmd");
+  }
+  // Wait for the GPE thread to finish processing any queued instances of
+  // this cmd before deleting. With KERNEL_STARTED_AND_EXIT persistent cmds,
+  // the GPE processes cmds instantly (stale flag), so cmdCb enqueues from
+  // graph replays may still be in the GPE queue when the graph is destroyed.
+  while (cmd->inFlight.load(std::memory_order_acquire) > 0) {
+    std::this_thread::yield();
   }
   delete cmd;
 }
@@ -789,7 +799,9 @@ void CtranGpe::Impl::gpeThreadFn() {
             std::this_thread::yield();
           }
           // After all blocks exited, we can safely reset.
-          kernelFlag->reset();
+          if (!cmd->persistent) {
+            kernelFlag->reset();
+          }
         } else {
           // In case of aborted comm, wait for kernel to start
           while (comm->testAbort() &&
@@ -822,7 +834,9 @@ void CtranGpe::Impl::gpeThreadFn() {
             cmd->coll.comm, ncclx::colltrace::CollEnd{});
       }
 
-      if (!cmd->persistent) {
+      if (cmd->persistent) {
+        cmd->inFlight.fetch_sub(1, std::memory_order_release);
+      } else {
         delete cmd;
       }
     }

--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -179,13 +179,25 @@ commResult_t OrderedWorkStreamGuard::doAcquire(
     return commSuccess; // first submit ever
   }
 
-  if (userStream == lastUserStream_ && lastWasCaptured_ == isCapturing &&
-      !isCapturing) {
-    return commSuccess; // same stream, same mode, no capture -- ordering
-                        // implicit
+  if (!isCapturing) {
+    if (everCaptured_) {
+      // Graph replays bypass submit(), so we cannot know for certain whether
+      // the previous operation was a graph replay or eager. CPU-side sync
+      // ensures any in-flight graph host node (which enqueues a GPE command)
+      // has fired before the caller can cmdEnqueue. Without this, the eager
+      // command lands in the GPE queue first and the single-threaded GPE
+      // deadlocks.
+      FB_CUDACHECK(cudaEventSynchronize(execModeSyncEvent_));
+    } else if (userStream != lastUserStream_) {
+      // Cross-stream eager, no graphs: GPU-side ordering only.
+      // We don't make any thread-safety guarantees for submit()
+      // so this is sufficient.
+      FB_COMMCHECK(doWait());
+    }
+    return commSuccess;
   }
 
-  if (isCapturing && !isNewCapture && lastWasCaptured_) {
+  if (!isNewCapture) {
     // Intra-capture cross-stream: add the RECORD node from the previous
     // doRelease as a capture dependency of this stream. This creates an
     // explicit graph edge, since cudaStreamWaitEvent cannot see RECORD
@@ -223,7 +235,6 @@ commResult_t OrderedWorkStreamGuard::doRelease(
   }
 
   lastUserStream_ = userStream;
-  lastWasCaptured_ = isCapturing;
 
   return commSuccess;
 }
@@ -308,6 +319,22 @@ commResult_t CtranGpe::Impl::submit(
   cudaStream_t launchStream = kernelConfig.stream;
   std::optional<OrderedWorkStreamGuard::Scope> wsScope;
 
+  // Acquire the work-stream baton before adding the host node so that
+  // during graph replay the host node (which enqueues a GPE command) only
+  // fires after the previous operation's kernel has completed. Without this
+  // ordering, a subsequent eager submit could enqueue its GPE command before
+  // the graph's host node fires, causing the single-threaded GPE to deadlock
+  // (spinning on the eager kernel's KERNEL_STARTED while the graph's command
+  // is stuck behind it in the queue).
+  auto maybeAcquireWorkStreamScope = [&]() {
+    if (!kernelConfig.canConcurrent) {
+      wsScope = ws_.acquire(kernelConfig.stream, streamCaptureInfo);
+      FB_COMMCHECK(wsScope->status());
+      launchStream = wsScope->stream();
+    }
+    return commSuccess;
+  };
+
   size_t opGroupSize = 0;
   // Enqueue op to gpeThread if any op is appended, or if there is a
   // postKernelCleanup that needs to run after the kernel completes.
@@ -329,6 +356,9 @@ commResult_t CtranGpe::Impl::submit(
       }
       cmd->coll.comm = comm;
     }
+
+    maybeAcquireWorkStreamScope();
+
     if (isCapturing) {
       FB_COMMCHECK(preLaunchGraphPrepare(cmd, graphPrepareFn));
       cmd->persistent = true;
@@ -351,6 +381,8 @@ commResult_t CtranGpe::Impl::submit(
     } else {
       cmdEnqueue(cmd);
     }
+  } else {
+    maybeAcquireWorkStreamScope();
   }
 
   // For the no-cmd path during graph capture, retain cleanup on the graph.
@@ -396,12 +428,6 @@ commResult_t CtranGpe::Impl::submit(
           res,
           fail);
     }
-  }
-
-  if (!kernelConfig.canConcurrent) {
-    wsScope = ws_.acquire(kernelConfig.stream, streamCaptureInfo);
-    FB_COMMCHECK(wsScope->status());
-    launchStream = wsScope->stream();
   }
 
   if (NCCL_CTRAN_ENALBE_CLUSTER_KERNEL_LAUNCH) {

--- a/comms/ctran/gpe/CtranGpeImpl.h
+++ b/comms/ctran/gpe/CtranGpeImpl.h
@@ -257,7 +257,6 @@ class OrderedWorkStreamGuard {
   unsigned long long lastCaptureId_{0};
   bool everCaptured_{false};
   cudaStream_t lastUserStream_{nullptr};
-  bool lastWasCaptured_{false};
   cudaGraphNode_t lastRecordNode_{};
 
   const CommLogData* logMetaData_{nullptr};

--- a/comms/ctran/gpe/CtranGpeImpl.h
+++ b/comms/ctran/gpe/CtranGpeImpl.h
@@ -147,6 +147,10 @@ class CtranGpeCmd {
   std::shared_ptr<std::atomic_flag> cpuFlag{nullptr};
 
   bool persistent{false};
+  // Count of queued-but-not-yet-processed instances of this cmd. Used by
+  // cmdDestroy to wait for the GPE to drain stale queue entries before
+  // deleting the cmd.
+  std::atomic_uint32_t inFlight{0};
   CtranGpe* gpe{nullptr};
 
   std::optional<std::chrono::milliseconds> timeout{std::nullopt};

--- a/comms/ctran/window/CtranWin.h
+++ b/comms/ctran/window/CtranWin.h
@@ -57,6 +57,17 @@ struct CtranWin {
   void* winDataPtr{nullptr};
   // The pointer of the signal buffer of this window
   uint64_t* winSignalPtr{nullptr};
+  // Dedicated signal buffer for CUDA graph capture/replay. Isolated from
+  // winSignalPtr so graph signal values don't conflict with eager monotonic
+  // counters.
+  uint64_t* winGraphSignalPtr{nullptr};
+
+  // Device-side replay counter for CUDA graph replay. Incremented by a
+  // small kernel at the start of each graph replay. PutSignal/WaitSignal
+  // kernels read this to get a unique, monotonically increasing signal
+  // value per replay — eliminating the need for signal resets and
+  // preventing inter-replay races.
+  uint64_t* graphReplayCounter{nullptr};
   // Stores signal values for waiting, used to track progress
   std::deque<std::atomic<uint64_t>> waitSignalVal{};
 

--- a/comms/ctran/window/Types.h
+++ b/comms/ctran/window/Types.h
@@ -21,6 +21,10 @@ enum OpCountType {
 struct RemWinInfo {
   void* dataAddr{nullptr};
   uint64_t* signalAddr{nullptr};
+  // Dedicated signal slot for CUDA graph capture/replay. Isolated from the
+  // eager signalAddr so that graph signal values and eager monotonic
+  // counters don't interfere.
+  uint64_t* graphSignalAddr{nullptr};
   CtranMapperRemoteAccessKey dataRkey{CtranMapperBackend::UNSET};
   CtranMapperRemoteAccessKey signalRkey{CtranMapperBackend::UNSET};
   size_t dataBytes{0};

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -15,6 +15,7 @@
 #include "comms/pipes/window/DeviceWindow.cuh"
 #include "comms/pipes/window/HostWindow.h"
 #endif
+#include "comms/utils/CudaRAII.h"
 #include "comms/utils/logger/LogUtils.h"
 
 using ctran::window::RemWinInfo;
@@ -99,6 +100,7 @@ commResult_t CtranWin::exchange() {
         winDataPtr, dataRegHdl, remoteUserBufs, remoteUserBufAccessKeys));
   }
 
+  auto signalBytes = signalSize * sizeof(uint64_t);
   for (auto r = 0; r < nRanks; r++) {
     remWinInfo[r].dataBytes = allRankSizes[r];
     if (allocDataBuf_) {
@@ -106,11 +108,16 @@ commResult_t CtranWin::exchange() {
       remWinInfo[r].dataRkey = remoteBaseBufAccessKeys[r];
       remWinInfo[r].signalAddr = reinterpret_cast<uint64_t*>(
           reinterpret_cast<size_t>(remoteBaseBufs[r]) + allRankSizes[r]);
+      remWinInfo[r].graphSignalAddr = reinterpret_cast<uint64_t*>(
+          reinterpret_cast<size_t>(remoteBaseBufs[r]) + allRankSizes[r] +
+          signalBytes);
       remWinInfo[r].signalRkey = remoteBaseBufAccessKeys[r];
     } else {
       remWinInfo[r].dataAddr = remoteUserBufs[r];
       remWinInfo[r].dataRkey = remoteUserBufAccessKeys[r];
       remWinInfo[r].signalAddr = reinterpret_cast<uint64_t*>(remoteBaseBufs[r]);
+      remWinInfo[r].graphSignalAddr = reinterpret_cast<uint64_t*>(
+          reinterpret_cast<size_t>(remoteBaseBufs[r]) + signalBytes);
       remWinInfo[r].signalRkey = remoteBaseBufAccessKeys[r];
     }
   }
@@ -171,7 +178,9 @@ commResult_t CtranWin::allocate(void* userBufPtr) {
   void* addr = nullptr;
   CUmemGenericAllocationHandle allocHandle;
   auto signalBytes = signalSize * sizeof(uint64_t);
-  size_t allocSize = allocDataBuf_ ? dataBytes + signalBytes : signalBytes;
+  auto graphSignalBytes = signalBytes;
+  size_t allocSize = allocDataBuf_ ? dataBytes + signalBytes + graphSignalBytes
+                                   : signalBytes + graphSignalBytes;
   if (isGpuMem()) {
     FB_COMMCHECK(
         utils::commCuMemAlloc(
@@ -196,9 +205,36 @@ commResult_t CtranWin::allocate(void* userBufPtr) {
     winDataPtr = addr;
     winSignalPtr =
         reinterpret_cast<uint64_t*>(reinterpret_cast<size_t>(addr) + dataBytes);
+    winGraphSignalPtr = reinterpret_cast<uint64_t*>(
+        reinterpret_cast<size_t>(addr) + dataBytes + signalBytes);
   } else {
     winDataPtr = userBufPtr;
     winSignalPtr = reinterpret_cast<uint64_t*>(reinterpret_cast<size_t>(addr));
+    winGraphSignalPtr = reinterpret_cast<uint64_t*>(
+        reinterpret_cast<size_t>(addr) + signalBytes);
+  }
+
+  {
+    meta::comms::StreamCaptureModeGuard captureGuard{
+        cudaStreamCaptureModeRelaxed};
+    // Allocate replay counter in mapped pinned host memory. Accessible from:
+    //   - GPU kernels (NVL: atomicAdd to increment, WaitSignal: load to read)
+    //   - CPU GPE thread (IB: direct pointer read for RDMA atomicSet value)
+    // Initialized to 0; gives each graph replay a unique monotonic signal
+    // value without needing signal resets.
+    FB_CUDACHECK(cudaHostAlloc(
+        &graphReplayCounter, sizeof(uint64_t), cudaHostAllocMapped));
+    *graphReplayCounter = 0;
+
+    // Zero-initialize both signal buffers.
+    // commCuMemAlloc (cuMemCreate/cuMemMap) does NOT zero memory.
+    // The graph signal buffer must start at 0 so the spinning kernel wait
+    // blocks correctly on first replay.
+    if (isGpuMem()) {
+      FB_CUDACHECK(cudaMemset(winSignalPtr, 0, signalBytes + graphSignalBytes));
+    } else {
+      memset(winSignalPtr, 0, signalBytes + graphSignalBytes);
+    }
   }
 
   CLOGF_SUBSYS(
@@ -291,6 +327,10 @@ commResult_t CtranWin::free() {
   hostWindow_.reset();
 #endif
 
+  if (graphReplayCounter) {
+    cudaFreeHost(graphReplayCounter);
+    graphReplayCounter = nullptr;
+  }
   freeMem(winBasePtr);
 
   return commSuccess;

--- a/comms/utils/colltrace/CudaWaitEvent.cc
+++ b/comms/utils/colltrace/CudaWaitEvent.cc
@@ -7,6 +7,7 @@
 #include <folly/Unit.h>
 #include <folly/stop_watch.h>
 
+#include "comms/utils/CudaRAII.h"
 #include "comms/utils/checks.h"
 #include "comms/utils/colltrace/CudaEventPool.h"
 #include "comms/utils/cvars/nccl_cvars.h" // @manual=fbcode//comms/utils/cvars:ncclx-cvars
@@ -17,6 +18,7 @@ namespace {
 CommsMaybe<bool> waitCudaEventFinish(
     const CudaEvent& event,
     std::chrono::milliseconds sleepTimeMs) {
+  StreamCaptureModeGuard guard{cudaStreamCaptureModeRelaxed};
   // async polling case, query cuda whether event is ready every
   // NCCL_COLLTRACE_CHECK_INTERVAL_MS milliseconds
   folly::stop_watch<std::chrono::milliseconds> timer;


### PR DESCRIPTION
Summary:

1. Flag race (skip reset): CPU reset() writes 0, next replay's GPU kernel writes 4, whoever lands last wins -> GPE spins on 0 forever
2. Use-after-free (inFlight counter): cmdDestroy deletes cmd while GPE queue still has references -> segfault

Reviewed By: dsjohns2

Differential Revision: D100045801
