### PR TITLE
Add IB pipelined sendrecv kernel with TiledBuffer (#2058)

### DIFF
--- a/comms/pipes/collectives/benchmarks/IbSendRecvBenchmark.cc
+++ b/comms/pipes/collectives/benchmarks/IbSendRecvBenchmark.cc
@@ -1,0 +1,1031 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// IB SendRecv benchmark: measures RDMA put and pipelined send/recv bandwidth
+// using the TorchComm device API (NCCLx/GIN backend).
+//
+// Tests:
+//   PutSingleBlock   — one block puts the full buffer, sweep over sizes.
+//   PutMultiBlock    — N blocks each put total/N bytes, sweep over block
+//   counts. SendRecvMultiBlock — pipelined sendrecv with section=total
+//   (steps=1, PD=1). SendRecvTileSweep  — 128 blocks, tile size sweep (steps=1,
+//   PD=1). SendRecvParamSweep — blocks x section x PD sweep for Pareto
+//   analysis. SendRecvLargeTileSweep — large total (1-4GB), tile sweep, PD
+//   sweep.
+
+#include <gtest/gtest.h>
+#include <nccl.h> // @manual
+
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/MemPool.h>
+#include <c10/cuda/CUDACachingAllocator.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAStream.h>
+#include <torch/csrc/distributed/c10d/PrefixStore.hpp> // @manual=//caffe2:torch-cpp-cpu
+#include <torch/csrc/distributed/c10d/TCPStore.hpp> // @manual=//caffe2:torch-cpp-cpu
+
+#include "comms/pipes/collectives/benchmarks/IbSendRecvBenchmarkKernels.cuh"
+#include "comms/pipes/collectives/ib/SendRecv.cuh"
+#include "comms/torchcomms/TorchComm.hpp"
+#include "comms/torchcomms/device/TorchCommDeviceWindow.hpp"
+#include "comms/torchcomms/ncclx/TorchCommWindowNCCLX.hpp"
+#include "comms/torchcomms/tests/integration/cpp/TorchCommTestHelpers.h"
+
+using namespace torchcomms::device;
+
+#define NCCL_CHECK(cmd)                                                       \
+  do {                                                                        \
+    ncclResult_t res = cmd;                                                   \
+    ASSERT_EQ(res, ncclSuccess) << "NCCL error: " << ncclGetErrorString(res); \
+  } while (0)
+
+namespace {
+
+constexpr int kWarmupIters = 20;
+constexpr int kMeasureIters = 100;
+constexpr size_t KB = 1024;
+constexpr size_t MB = 1024 * 1024;
+constexpr size_t GB = 1024UL * 1024 * 1024;
+
+std::string format_size(size_t bytes) {
+  if (bytes >= GB) {
+    return std::to_string(bytes / GB) + "GB";
+  }
+  if (bytes >= MB) {
+    return std::to_string(bytes / MB) + "MB";
+  }
+  if (bytes >= KB) {
+    return std::to_string(bytes / KB) + "KB";
+  }
+  return std::to_string(bytes) + "B";
+}
+
+struct WindowSetup {
+  std::unique_ptr<at::cuda::MemPool> mem_pool;
+  at::Tensor win_tensor;
+  at::Tensor src_tensor;
+  std::shared_ptr<torch::comms::TorchCommWindow> win;
+  DeviceWindowNCCL* dev_win{nullptr};
+  RegisteredBufferNCCL src_buf{};
+};
+
+WindowSetup create_window_setup(
+    std::shared_ptr<torch::comms::TorchComm>& torchcomm,
+    std::shared_ptr<c10::Allocator>& allocator,
+    int device_index,
+    size_t total_bytes,
+    int signal_count) {
+  WindowSetup s;
+  size_t count = total_bytes / sizeof(float);
+
+  s.mem_pool = std::make_unique<at::cuda::MemPool>(
+      std::static_pointer_cast<c10::cuda::CUDACachingAllocator::CUDAAllocator>(
+          allocator));
+  c10::cuda::CUDACachingAllocator::beginAllocateToPool(
+      s.mem_pool->device(), s.mem_pool->id(), [](cudaStream_t) {
+        return true;
+      });
+
+  auto options =
+      at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, device_index);
+  s.win_tensor = at::zeros({static_cast<int64_t>(count)}, options);
+
+  c10::cuda::CUDACachingAllocator::endAllocateToPool(
+      s.mem_pool->device(), s.mem_pool->id());
+
+  // Allocate src outside pool for proper alignment.
+  s.src_tensor = at::zeros({static_cast<int64_t>(count)}, options);
+
+  torchcomm->barrier(false);
+  s.win = torchcomm->new_window();
+  s.win->tensor_register(s.win_tensor);
+  torchcomm->barrier(false);
+
+  s.dev_win = static_cast<DeviceWindowNCCL*>(
+      s.win->get_device_window(signal_count, -1, 2));
+  s.src_buf = s.win->register_local_buffer(s.src_tensor);
+
+  torchcomm->barrier(false);
+  cudaDeviceSynchronize();
+
+  return s;
+}
+
+void teardown_window(
+    WindowSetup& s,
+    std::shared_ptr<torch::comms::TorchComm>& torchcomm) {
+  s.win->deregister_local_buffer(s.src_buf);
+  s.win->tensor_deregister();
+  s.win.reset();
+  s.mem_pool.reset();
+  torchcomm->barrier(false);
+}
+
+} // namespace
+
+class IbSendRecvBenchmark : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const char* env = std::getenv("RUN_PUT_BW_BENCHMARK");
+    if (!env || (std::string(env) != "1" && std::string(env) != "true")) {
+      GTEST_SKIP() << "Set RUN_PUT_BW_BENCHMARK=true to run";
+    }
+
+    wrapper_ = std::make_unique<TorchCommTestWrapper>();
+    torchcomm_ = wrapper_->getTorchComm();
+    rank_ = torchcomm_->getRank();
+    num_ranks_ = torchcomm_->getSize();
+    device_index_ = rank_ % at::cuda::device_count();
+    allocator_ = torch::comms::get_mem_allocator(torchcomm_->getBackend());
+
+    // Create a standalone NCCL communicator for baseline comparison.
+    // Bootstrap ncclUniqueId via TCPStore (same MASTER_ADDR/PORT as TorchComm).
+    const char* host = std::getenv("MASTER_ADDR");
+    const char* port_str = std::getenv("MASTER_PORT");
+    if (host && port_str) {
+      c10d::TCPStoreOptions opts;
+      opts.port = std::stoi(port_str);
+      opts.isServer = (rank_ == 0);
+      opts.waitWorkers = false;
+      opts.useLibUV = true;
+      auto store = c10::make_intrusive<c10d::TCPStore>(std::string{host}, opts);
+      auto prefixed =
+          c10::make_intrusive<c10d::PrefixStore>("nccl_baseline", store);
+
+      ncclUniqueId nccl_id;
+      if (rank_ == 0) {
+        ncclGetUniqueId(&nccl_id);
+        auto id_vec = std::vector<uint8_t>(
+            reinterpret_cast<uint8_t*>(&nccl_id),
+            reinterpret_cast<uint8_t*>(&nccl_id) + sizeof(nccl_id));
+        prefixed->set("nccl_id", id_vec);
+      }
+      prefixed->wait({"nccl_id"});
+      auto id_vec = prefixed->get("nccl_id");
+      memcpy(&nccl_id, id_vec.data(), sizeof(nccl_id));
+
+      ncclCommInitRank(&nccl_comm_, num_ranks_, nccl_id, rank_);
+    }
+  }
+
+  void TearDown() override {
+    if (nccl_comm_) {
+      ncclCommDestroy(nccl_comm_);
+      nccl_comm_ = nullptr;
+    }
+    torchcomm_.reset();
+    wrapper_.reset();
+  }
+
+  struct BenchResult {
+    size_t total_bytes;
+    int num_blocks;
+    int iterations;
+    float elapsed_ms;
+    double bw_gbps;
+  };
+
+  BenchResult run_put_benchmark(size_t total_bytes, int num_blocks) {
+    int signal_count = 2 * num_blocks;
+    auto s = create_window_setup(
+        torchcomm_, allocator_, device_index_, total_bytes, signal_count);
+
+    int dst_rank = (rank_ + 1) % num_ranks_;
+    int src_rank = (rank_ - 1 + num_ranks_) % num_ranks_;
+
+    auto stream = at::cuda::getStreamFromPool(false, device_index_);
+
+    // Warmup
+    {
+      c10::cuda::CUDAStreamGuard guard(stream);
+      comms::pipes::ib::benchmark::launch_put_bw_kernel(
+          s.dev_win,
+          s.src_buf,
+          total_bytes,
+          dst_rank,
+          src_rank,
+          num_blocks,
+          0,
+          kWarmupIters,
+          stream.stream());
+    }
+    stream.synchronize();
+    torchcomm_->barrier(false);
+
+    // Timed run
+    cudaEvent_t start, stop;
+    cudaEventCreate(&start);
+    cudaEventCreate(&stop);
+
+    {
+      c10::cuda::CUDAStreamGuard guard(stream);
+      cudaEventRecord(start, stream.stream());
+      comms::pipes::ib::benchmark::launch_put_bw_kernel(
+          s.dev_win,
+          s.src_buf,
+          total_bytes,
+          dst_rank,
+          src_rank,
+          num_blocks,
+          kWarmupIters,
+          kMeasureIters,
+          stream.stream());
+      cudaEventRecord(stop, stream.stream());
+    }
+    cudaEventSynchronize(stop);
+
+    float elapsed_ms = 0;
+    cudaEventElapsedTime(&elapsed_ms, start, stop);
+
+    double total_data = static_cast<double>(total_bytes) * kMeasureIters;
+    double bw = total_data / (elapsed_ms / 1000.0) / 1e9;
+
+    cudaEventDestroy(start);
+    cudaEventDestroy(stop);
+    teardown_window(s, torchcomm_);
+
+    return {total_bytes, num_blocks, kMeasureIters, elapsed_ms, bw};
+  }
+
+  BenchResult run_send_recv_benchmark(
+      size_t total_bytes,
+      size_t section_bytes,
+      int pipeline_depth,
+      int num_blocks) {
+    int signal_count = 2 * num_blocks;
+    int counter_count = num_blocks;
+
+    // Staging and window are ring buffers: pipeline_depth * section_bytes
+    size_t ring_bytes = pipeline_depth * section_bytes;
+    size_t ring_count = ring_bytes / sizeof(float);
+    size_t total_count = total_bytes / sizeof(float);
+
+    // MemPool for window tensor (recv staging ring buffer)
+    auto mem_pool = std::make_unique<at::cuda::MemPool>(
+        std::static_pointer_cast<
+            c10::cuda::CUDACachingAllocator::CUDAAllocator>(allocator_));
+    c10::cuda::CUDACachingAllocator::beginAllocateToPool(
+        mem_pool->device(), mem_pool->id(), [](cudaStream_t) { return true; });
+
+    auto options =
+        at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, device_index_);
+    auto win_tensor = at::zeros({static_cast<int64_t>(ring_count)}, options);
+
+    c10::cuda::CUDACachingAllocator::endAllocateToPool(
+        mem_pool->device(), mem_pool->id());
+
+    // Allocate src, staging, dst outside pool
+    auto src_tensor = at::zeros({static_cast<int64_t>(total_count)}, options);
+    auto staging_tensor =
+        at::zeros({static_cast<int64_t>(ring_count)}, options);
+    auto dst_tensor = at::zeros({static_cast<int64_t>(total_count)}, options);
+
+    torchcomm_->barrier(false);
+    auto win = torchcomm_->new_window();
+    win->tensor_register(win_tensor);
+    torchcomm_->barrier(false);
+
+    auto dev_win = static_cast<DeviceWindowNCCL*>(
+        win->get_device_window(signal_count, counter_count, 2));
+    auto staging_buf = win->register_local_buffer(staging_tensor);
+
+    torchcomm_->barrier(false);
+    cudaDeviceSynchronize();
+
+    int dst_rank = (rank_ + 1) % num_ranks_;
+    int src_rank = (rank_ - 1 + num_ranks_) % num_ranks_;
+
+    auto stream = at::cuda::getStreamFromPool(false, device_index_);
+
+    float* src_ptr = src_tensor.data_ptr<float>();
+    float* staging_ptr = staging_tensor.data_ptr<float>();
+    float* win_ptr = win_tensor.data_ptr<float>();
+    float* dst_ptr = dst_tensor.data_ptr<float>();
+
+    // Persistent step state: 2 * num_blocks (senders + receivers).
+    int64_t* step_state = nullptr;
+    cudaMalloc(&step_state, 2 * num_blocks * sizeof(int64_t));
+    cudaMemset(step_state, 0, 2 * num_blocks * sizeof(int64_t));
+
+    // Warmup
+    {
+      c10::cuda::CUDAStreamGuard guard(stream);
+      for (int i = 0; i < kWarmupIters; i++) {
+        comms::pipes::ib::launch_send_recv_kernel(
+            dev_win,
+            staging_buf,
+            src_ptr,
+            staging_ptr,
+            win_ptr,
+            dst_ptr,
+            total_bytes,
+            section_bytes,
+            pipeline_depth,
+            dst_rank,
+            src_rank,
+            num_blocks,
+            step_state,
+            stream.stream());
+      }
+    }
+    stream.synchronize();
+    torchcomm_->barrier(false);
+
+    // Timed run
+    cudaEvent_t start, stop;
+    cudaEventCreate(&start);
+    cudaEventCreate(&stop);
+
+    {
+      c10::cuda::CUDAStreamGuard guard(stream);
+      cudaEventRecord(start, stream.stream());
+      for (int i = 0; i < kMeasureIters; i++) {
+        comms::pipes::ib::launch_send_recv_kernel(
+            dev_win,
+            staging_buf,
+            src_ptr,
+            staging_ptr,
+            win_ptr,
+            dst_ptr,
+            total_bytes,
+            section_bytes,
+            pipeline_depth,
+            dst_rank,
+            src_rank,
+            num_blocks,
+            step_state,
+            stream.stream());
+      }
+      cudaEventRecord(stop, stream.stream());
+    }
+    cudaEventSynchronize(stop);
+
+    float elapsed_ms = 0;
+    cudaEventElapsedTime(&elapsed_ms, start, stop);
+
+    double total_data = static_cast<double>(total_bytes) * kMeasureIters;
+    double bw = total_data / (elapsed_ms / 1000.0) / 1e9;
+
+    cudaEventDestroy(start);
+    cudaEventDestroy(stop);
+    cudaFree(step_state);
+
+    // Teardown
+    win->deregister_local_buffer(staging_buf);
+    win->tensor_deregister();
+    win.reset();
+    mem_pool.reset();
+    torchcomm_->barrier(false);
+
+    return {total_bytes, num_blocks, kMeasureIters, elapsed_ms, bw};
+  }
+
+  BenchResult run_nccl_baseline(size_t total_bytes) {
+    EXPECT_NE(nccl_comm_, nullptr) << "NCCL comm not initialized";
+    int peer_rank = (rank_ + 1) % num_ranks_;
+
+    auto options =
+        at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, device_index_);
+    size_t total_count = total_bytes / sizeof(float);
+    auto send_tensor = at::zeros({static_cast<int64_t>(total_count)}, options);
+    auto recv_tensor = at::zeros({static_cast<int64_t>(total_count)}, options);
+
+    auto stream = at::cuda::getStreamFromPool(false, device_index_);
+
+    // Warmup
+    for (int i = 0; i < kWarmupIters; i++) {
+      ncclGroupStart();
+      ncclSend(
+          send_tensor.data_ptr(),
+          total_bytes,
+          ncclChar,
+          peer_rank,
+          nccl_comm_,
+          stream.stream());
+      ncclRecv(
+          recv_tensor.data_ptr(),
+          total_bytes,
+          ncclChar,
+          peer_rank,
+          nccl_comm_,
+          stream.stream());
+      ncclGroupEnd();
+    }
+    stream.synchronize();
+    torchcomm_->barrier(false);
+
+    // Timed run
+    cudaEvent_t start, stop;
+    cudaEventCreate(&start);
+    cudaEventCreate(&stop);
+
+    cudaEventRecord(start, stream.stream());
+    for (int i = 0; i < kMeasureIters; i++) {
+      ncclGroupStart();
+      ncclSend(
+          send_tensor.data_ptr(),
+          total_bytes,
+          ncclChar,
+          peer_rank,
+          nccl_comm_,
+          stream.stream());
+      ncclRecv(
+          recv_tensor.data_ptr(),
+          total_bytes,
+          ncclChar,
+          peer_rank,
+          nccl_comm_,
+          stream.stream());
+      ncclGroupEnd();
+    }
+    cudaEventRecord(stop, stream.stream());
+    cudaEventSynchronize(stop);
+
+    float elapsed_ms = 0;
+    cudaEventElapsedTime(&elapsed_ms, start, stop);
+
+    double total_data = static_cast<double>(total_bytes) * kMeasureIters;
+    double bw = total_data / (elapsed_ms / 1000.0) / 1e9;
+
+    cudaEventDestroy(start);
+    cudaEventDestroy(stop);
+
+    return {total_bytes, 0, kMeasureIters, elapsed_ms, bw};
+  }
+
+  std::unique_ptr<TorchCommTestWrapper> wrapper_;
+  std::shared_ptr<torch::comms::TorchComm> torchcomm_;
+  std::shared_ptr<c10::Allocator> allocator_;
+  ncclComm_t nccl_comm_{nullptr};
+  int rank_{0};
+  int num_ranks_{0};
+  int device_index_{0};
+};
+
+TEST_F(IbSendRecvBenchmark, PutSingleBlock) {
+  std::vector<size_t> sizes = {
+      256 * KB, 1 * MB, 4 * MB, 16 * MB, 64 * MB, 128 * MB, 512 * MB};
+
+  if (rank_ == 0) {
+    printf("\n=== Put BW: Single Block (BLOCK scope, zero-copy) ===\n");
+    printf(
+        "%-12s  %5s  %10s  %10s\n", "PutSize", "Iters", "Lat(us)", "BW(GB/s)");
+    printf(
+        "%-12s  %5s  %10s  %10s\n", "-------", "-----", "-------", "--------");
+  }
+
+  for (size_t sz : sizes) {
+    auto r = run_put_benchmark(sz, 1);
+    if (rank_ == 0) {
+      double lat_us = r.elapsed_ms * 1000.0 / r.iterations;
+      printf(
+          "%-12s  %5d  %10.1f  %10.2f\n",
+          format_size(r.total_bytes).c_str(),
+          r.iterations,
+          lat_us,
+          r.bw_gbps);
+    }
+  }
+}
+
+TEST_F(IbSendRecvBenchmark, PutMultiBlock) {
+  size_t total = 512 * MB;
+  std::vector<int> block_counts = {1, 2, 4, 8, 16, 32, 64, 128};
+
+  if (rank_ == 0) {
+    printf(
+        "\n=== Put BW: Multi Block (512MB total, BLOCK scope, zero-copy) ===\n");
+    printf(
+        "%-8s  %-12s  %5s  %10s  %10s\n",
+        "Blocks",
+        "TileSize",
+        "Iters",
+        "Lat(us)",
+        "BW(GB/s)");
+    printf(
+        "%-8s  %-12s  %5s  %10s  %10s\n",
+        "------",
+        "--------",
+        "-----",
+        "-------",
+        "--------");
+  }
+
+  for (int nblk : block_counts) {
+    auto r = run_put_benchmark(total, nblk);
+    if (rank_ == 0) {
+      double lat_us = r.elapsed_ms * 1000.0 / r.iterations;
+      printf(
+          "%-8d  %-12s  %5d  %10.1f  %10.2f\n",
+          nblk,
+          format_size(total / nblk).c_str(),
+          r.iterations,
+          lat_us,
+          r.bw_gbps);
+    }
+  }
+}
+
+TEST_F(IbSendRecvBenchmark, SendRecvMultiBlock) {
+  // Uses pipelined kernel with section=total (steps=1, PD=1) — equivalent
+  // to the old non-pipelined sendRecvBwKernel.
+  size_t total = 512 * MB;
+  std::vector<int> block_counts = {1, 2, 4, 8, 16, 32, 64, 128};
+
+  if (rank_ == 0) {
+    printf(
+        "\n=== SendRecv BW: Multi Block (512MB total, BLOCK scope, copy-based) ===\n");
+    printf(
+        "%-8s  %-12s  %5s  %10s  %10s\n",
+        "Blocks",
+        "TileSize",
+        "Iters",
+        "Lat(us)",
+        "BW(GB/s)");
+    printf(
+        "%-8s  %-12s  %5s  %10s  %10s\n",
+        "------",
+        "--------",
+        "-----",
+        "-------",
+        "--------");
+  }
+
+  for (int nblk : block_counts) {
+    auto r = run_send_recv_benchmark(total, total, 1, nblk);
+    if (rank_ == 0) {
+      double lat_us = r.elapsed_ms * 1000.0 / r.iterations;
+      printf(
+          "%-8d  %-12s  %5d  %10.1f  %10.2f\n",
+          nblk,
+          format_size(total / nblk).c_str(),
+          r.iterations,
+          lat_us,
+          r.bw_gbps);
+    }
+  }
+}
+
+TEST_F(IbSendRecvBenchmark, SendRecvTileSweep) {
+  // 128 blocks, sweep tile sizes by varying total (steps=1, PD=1).
+  // Tile = total / 128. Larger tile -> less per-tile overhead.
+  int nblk = 128;
+  std::vector<size_t> totals = {512 * MB, 1024 * MB, 2048 * MB, 4096UL * MB};
+
+  if (rank_ == 0) {
+    printf(
+        "\n=== SendRecv BW: 128 Blocks, Tile Size Sweep (steps=1, PD=1) ===\n");
+    printf("%-12s  %-10s  %10s\n", "Total", "Tile", "BW(GB/s)");
+    printf("%-12s  %-10s  %10s\n", "-----", "----", "--------");
+  }
+
+  for (size_t total : totals) {
+    size_t section = total; // steps=1
+    int pd = 1;
+    size_t tile = section / nblk;
+
+    auto r = run_send_recv_benchmark(total, section, pd, nblk);
+    if (rank_ == 0) {
+      printf(
+          "%-12s  %-10s  %10.2f\n",
+          format_size(total).c_str(),
+          format_size(tile).c_str(),
+          r.bw_gbps);
+    }
+  }
+}
+
+TEST_F(IbSendRecvBenchmark, SendRecvParamSweep) {
+  // Full parameter sweep: blocks x section x pd for Pareto analysis.
+  size_t total = 512 * MB;
+  std::vector<int> block_counts = {16, 32, 64, 128};
+  std::vector<size_t> section_sizes = {
+      32 * MB, 64 * MB, 128 * MB, 256 * MB, 512 * MB};
+  std::vector<int> pd_values = {1, 2, 4};
+
+  if (rank_ == 0) {
+    printf(
+        "\n=== SendRecv Pipelined: Full Parameter Sweep (512MB total) ===\n");
+    printf(
+        "%-22s | %-6s | %-10s | %-4s | %-10s | %-6s | %-10s | %-12s\n",
+        "Name",
+        "Blocks",
+        "Section",
+        "PD",
+        "Tile",
+        "Steps",
+        "Staging",
+        "BW(GB/s)");
+    printf(
+        "----------------------------------------------------------------------"
+        "------------------------------------------------------\n");
+  }
+
+  for (int nblk : block_counts) {
+    for (size_t sec : section_sizes) {
+      if (sec > total)
+        continue;
+      int total_steps = total / sec;
+      for (int pd : pd_values) {
+        if (pd > total_steps)
+          continue;
+        size_t tile = sec / nblk;
+        size_t staging = static_cast<size_t>(pd) * sec * 2; // send + recv
+
+        char name[64];
+        snprintf(
+            name,
+            sizeof(name),
+            "b%d_s%s_p%d",
+            nblk,
+            format_size(sec).c_str(),
+            pd);
+
+        auto r = run_send_recv_benchmark(total, sec, pd, nblk);
+        if (rank_ == 0) {
+          printf(
+              "%-22s | %-6d | %-10s | %-4d | %-10s | %-6d | %-10s | %-12.2f\n",
+              name,
+              nblk,
+              format_size(sec).c_str(),
+              pd,
+              format_size(tile).c_str(),
+              total_steps,
+              format_size(staging).c_str(),
+              r.bw_gbps);
+        }
+      }
+    }
+  }
+}
+
+TEST_F(IbSendRecvBenchmark, SendRecvSizeSweep) {
+  // Full size sweep from 32KB to 4GB. 128 blocks, section=total (1 step),
+  // PD=1. Tile = total/128. Shows bandwidth across the full size range.
+  int nblk = 128;
+  int pd = 1;
+  std::vector<size_t> sizes = {
+      32 * KB,
+      64 * KB,
+      128 * KB,
+      256 * KB,
+      512 * KB,
+      1 * MB,
+      2 * MB,
+      4 * MB,
+      8 * MB,
+      16 * MB,
+      32 * MB,
+      64 * MB,
+      128 * MB,
+      256 * MB,
+      512 * MB,
+      1 * GB,
+      2 * GB,
+      4 * GB};
+
+  if (rank_ == 0) {
+    printf("\n=== SendRecv Size Sweep (128 blocks, section=total, PD=1) ===\n");
+    printf("%-12s  %-10s  %10s\n", "Total", "Tile", "BW(GB/s)");
+    printf("%-12s  %-10s  %10s\n", "-----", "----", "--------");
+  }
+
+  for (size_t total : sizes) {
+    size_t section = total;
+    auto r = run_send_recv_benchmark(total, section, pd, nblk);
+    if (rank_ == 0) {
+      printf(
+          "%-12s  %-10s  %10.2f\n",
+          format_size(total).c_str(),
+          format_size(total / nblk).c_str(),
+          r.bw_gbps);
+    }
+  }
+}
+
+TEST_F(IbSendRecvBenchmark, SendRecvLargeTileSweep) {
+  // Large-buffer sweep: total={1GB,2GB,4GB}, tile={8MB,16MB}, PD={1,2,4},
+  // 128 blocks. OOM guard at 4GB per direction.
+  int nblk = 128;
+  std::vector<size_t> totals = {1 * GB, 2 * GB, 4 * GB};
+  std::vector<size_t> tile_sizes = {8 * MB, 16 * MB};
+  std::vector<int> pd_values = {1, 2, 4};
+
+  if (rank_ == 0) {
+    printf("\n=== SendRecv Large Tile Sweep (128 blocks) ===\n");
+    printf(
+        "%-12s | %-10s | %-10s | %-4s | %-6s | %-10s | %-12s\n",
+        "Total",
+        "Section",
+        "Tile",
+        "PD",
+        "Steps",
+        "Staging",
+        "BW(GB/s)");
+    printf(
+        "----------------------------------------------------------------------"
+        "----------------------------------\n");
+  }
+
+  for (size_t total : totals) {
+    for (size_t tile : tile_sizes) {
+      size_t section = tile * nblk;
+      if (section > total)
+        continue;
+      int total_steps = total / section;
+      for (int pd : pd_values) {
+        if (pd > total_steps)
+          continue;
+        // OOM guard: staging + window = 2 * pd * section, src + dst = 2 * total
+        size_t ring_bytes = static_cast<size_t>(pd) * section;
+        size_t mem_per_dir = total + ring_bytes * 2; // src/dst + staging + win
+        if (mem_per_dir > 16 * GB) {
+          if (rank_ == 0) {
+            printf(
+                "%-12s | %-10s | %-10s | %-4d | SKIP (OOM: %s/dir)\n",
+                format_size(total).c_str(),
+                format_size(section).c_str(),
+                format_size(tile).c_str(),
+                pd,
+                format_size(mem_per_dir).c_str());
+          }
+          continue;
+        }
+
+        auto r = run_send_recv_benchmark(total, section, pd, nblk);
+        if (rank_ == 0) {
+          size_t staging = static_cast<size_t>(pd) * section * 2;
+          printf(
+              "%-12s | %-10s | %-10s | %-4d | %-6d | %-10s | %-12.2f\n",
+              format_size(total).c_str(),
+              format_size(section).c_str(),
+              format_size(tile).c_str(),
+              pd,
+              total_steps,
+              format_size(staging).c_str(),
+              r.bw_gbps);
+        }
+      }
+    }
+  }
+}
+
+TEST_F(IbSendRecvBenchmark, SendRecvCorrectness) {
+  // Verify data correctness: fill src with rank-specific pattern, run
+  // sendrecv, check dst has peer's pattern. Tests multiple configs
+  // including PD > 1 to exercise the ring buffer offset logic.
+  struct Config {
+    size_t total;
+    size_t section;
+    int pd;
+    int nblk;
+  };
+  std::vector<Config> configs = {
+      // PD=1: single slot, no ring offset
+      {64 * KB, 64 * KB, 1, 128},
+      {1 * MB, 1 * MB, 1, 128},
+      {16 * MB, 16 * MB, 1, 128},
+      // PD=2: exercises ring buffer slot offsets
+      {2 * MB, 1 * MB, 2, 128},
+      {16 * MB, 8 * MB, 2, 128},
+      // PD=4: deeper pipeline
+      {16 * MB, 4 * MB, 4, 128},
+      // Fewer blocks
+      {4 * MB, 4 * MB, 1, 32},
+      {4 * MB, 2 * MB, 2, 64},
+  };
+
+  int dst_rank = (rank_ + 1) % num_ranks_;
+  int src_rank = (rank_ - 1 + num_ranks_) % num_ranks_;
+
+  for (const auto& cfg : configs) {
+    int signal_count = 2 * cfg.nblk;
+    int counter_count = cfg.nblk;
+    size_t ring_bytes = cfg.pd * cfg.section;
+    size_t ring_count = ring_bytes / sizeof(float);
+    size_t total_count = cfg.total / sizeof(float);
+
+    auto mem_pool = std::make_unique<at::cuda::MemPool>(
+        std::static_pointer_cast<
+            c10::cuda::CUDACachingAllocator::CUDAAllocator>(allocator_));
+    c10::cuda::CUDACachingAllocator::beginAllocateToPool(
+        mem_pool->device(), mem_pool->id(), [](cudaStream_t) { return true; });
+
+    auto options =
+        at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, device_index_);
+    auto win_tensor = at::zeros({static_cast<int64_t>(ring_count)}, options);
+
+    c10::cuda::CUDACachingAllocator::endAllocateToPool(
+        mem_pool->device(), mem_pool->id());
+
+    // Fill src with rank-specific pattern: src[i] = rank * 1000000 + i
+    auto src_tensor =
+        at::arange(
+            static_cast<int64_t>(total_count), options.dtype(at::kFloat)) +
+        static_cast<float>(rank_) * 1000000.0f;
+    auto staging_tensor =
+        at::zeros({static_cast<int64_t>(ring_count)}, options);
+    auto dst_tensor = at::zeros({static_cast<int64_t>(total_count)}, options);
+
+    torchcomm_->barrier(false);
+    auto win = torchcomm_->new_window();
+    win->tensor_register(win_tensor);
+    torchcomm_->barrier(false);
+
+    auto dev_win = static_cast<DeviceWindowNCCL*>(
+        win->get_device_window(signal_count, counter_count, 2));
+    auto staging_buf = win->register_local_buffer(staging_tensor);
+
+    torchcomm_->barrier(false);
+    cudaDeviceSynchronize();
+
+    auto stream = at::cuda::getStreamFromPool(false, device_index_);
+
+    // Persistent step state for correctness test (single launch).
+    int64_t* step_state = nullptr;
+    cudaMalloc(&step_state, 2 * cfg.nblk * sizeof(int64_t));
+    cudaMemset(step_state, 0, 2 * cfg.nblk * sizeof(int64_t));
+
+    {
+      c10::cuda::CUDAStreamGuard guard(stream);
+      comms::pipes::ib::launch_send_recv_kernel(
+          dev_win,
+          staging_buf,
+          src_tensor.data_ptr<float>(),
+          staging_tensor.data_ptr<float>(),
+          win_tensor.data_ptr<float>(),
+          dst_tensor.data_ptr<float>(),
+          cfg.total,
+          cfg.section,
+          cfg.pd,
+          dst_rank,
+          src_rank,
+          cfg.nblk,
+          step_state,
+          stream.stream());
+    }
+    stream.synchronize();
+    torchcomm_->barrier(false);
+    cudaFree(step_state);
+
+    // Verify: dst should contain src_rank's pattern
+    auto expected =
+        at::arange(
+            static_cast<int64_t>(total_count), options.dtype(at::kFloat)) +
+        static_cast<float>(src_rank) * 1000000.0f;
+    auto dst_cpu = dst_tensor.cpu();
+    auto exp_cpu = expected.cpu();
+
+    bool match = at::allclose(dst_cpu, exp_cpu);
+    EXPECT_TRUE(match) << "Correctness FAILED for total="
+                       << format_size(cfg.total)
+                       << " section=" << format_size(cfg.section)
+                       << " pd=" << cfg.pd << " nblk=" << cfg.nblk;
+    if (rank_ == 0) {
+      printf(
+          "Correctness: total=%-8s section=%-8s pd=%d nblk=%-4d %s\n",
+          format_size(cfg.total).c_str(),
+          format_size(cfg.section).c_str(),
+          cfg.pd,
+          cfg.nblk,
+          match ? "PASS" : "FAIL");
+    }
+    if (!match) {
+      auto diff = (dst_cpu - exp_cpu).abs();
+      auto max_diff = diff.max().item<float>();
+      auto mismatch_idx = diff.argmax().item<int64_t>();
+      if (rank_ == 0) {
+        printf(
+            "  max_diff=%.1f at idx=%ld got=%.1f expected=%.1f\n",
+            max_diff,
+            mismatch_idx,
+            dst_cpu[mismatch_idx].item<float>(),
+            exp_cpu[mismatch_idx].item<float>());
+      }
+    }
+
+    win->deregister_local_buffer(staging_buf);
+    win->tensor_deregister();
+    win.reset();
+    mem_pool.reset();
+    torchcomm_->barrier(false);
+  }
+}
+
+TEST_F(IbSendRecvBenchmark, SendRecvVsNccl) {
+  // Side-by-side comparison: our sendrecv kernel vs NCCL baseline.
+  // Both use the same sizes, warmup, and measurement iterations.
+  int nblk = 128;
+  int pd = 1;
+  std::vector<size_t> sizes = {
+      32 * KB,
+      64 * KB,
+      128 * KB,
+      256 * KB,
+      512 * KB,
+      1 * MB,
+      2 * MB,
+      4 * MB,
+      8 * MB,
+      16 * MB,
+      32 * MB,
+      64 * MB,
+      128 * MB,
+      256 * MB,
+      512 * MB,
+      1 * GB,
+      2 * GB,
+      4 * GB};
+
+  if (rank_ == 0) {
+    printf(
+        "\n=== SendRecv vs NCCL Baseline (128 blocks, section=total, PD=1) ===\n");
+    printf(
+        "%-12s  %12s  %12s  %10s\n",
+        "Total",
+        "Kernel(GB/s)",
+        "NCCL(GB/s)",
+        "Speedup");
+    printf(
+        "%-12s  %12s  %12s  %10s\n",
+        "-----",
+        "------------",
+        "----------",
+        "-------");
+  }
+
+  for (size_t total : sizes) {
+    auto kernel_r = run_send_recv_benchmark(total, total, pd, nblk);
+    auto nccl_r = run_nccl_baseline(total);
+
+    if (rank_ == 0) {
+      double speedup =
+          nccl_r.bw_gbps > 0 ? kernel_r.bw_gbps / nccl_r.bw_gbps : 0;
+      printf(
+          "%-12s  %12.2f  %12.2f  %9.2fx\n",
+          format_size(total).c_str(),
+          kernel_r.bw_gbps,
+          nccl_r.bw_gbps,
+          speedup);
+    }
+  }
+}
+
+TEST_F(IbSendRecvBenchmark, SendRecvFewBlocks) {
+  // Compare kernel with 1 and 2 blocks vs NCCL baseline.
+  // Uses section=total (1 step), PD=1. Large sizes only.
+  int pd = 1;
+  std::vector<int> block_counts = {1, 2};
+  std::vector<size_t> sizes = {
+      1 * MB,
+      4 * MB,
+      16 * MB,
+      64 * MB,
+      256 * MB,
+      512 * MB,
+      1 * GB,
+      2 * GB,
+      4 * GB};
+
+  for (int nblk : block_counts) {
+    if (rank_ == 0) {
+      printf(
+          "\n=== SendRecv vs NCCL (%d block%s, section=total, PD=1) ===\n",
+          nblk,
+          nblk > 1 ? "s" : "");
+      printf(
+          "%-12s  %12s  %12s  %10s\n",
+          "Total",
+          "Kernel(GB/s)",
+          "NCCL(GB/s)",
+          "Speedup");
+      printf(
+          "%-12s  %12s  %12s  %10s\n",
+          "-----",
+          "------------",
+          "----------",
+          "-------");
+    }
+
+    for (size_t total : sizes) {
+      auto kernel_r = run_send_recv_benchmark(total, total, pd, nblk);
+      auto nccl_r = run_nccl_baseline(total);
+
+      if (rank_ == 0) {
+        double speedup =
+            nccl_r.bw_gbps > 0 ? kernel_r.bw_gbps / nccl_r.bw_gbps : 0;
+        printf(
+            "%-12s  %12.2f  %12.2f  %9.2fx\n",
+            format_size(total).c_str(),
+            kernel_r.bw_gbps,
+            nccl_r.bw_gbps,
+            speedup);
+      }
+    }
+  }
+}

--- a/comms/pipes/collectives/benchmarks/IbSendRecvBenchmarkKernels.cu
+++ b/comms/pipes/collectives/benchmarks/IbSendRecvBenchmarkKernels.cu
@@ -1,0 +1,78 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Benchmark-only CUDA kernel: zero-copy RDMA put with BLOCK-scope ops.
+// Not part of the library — used only by IbSendRecvBenchmark.
+
+#include "comms/pipes/collectives/benchmarks/IbSendRecvBenchmarkKernels.cuh"
+
+#include "comms/torchcomms/device/ncclx/TorchCommDeviceNCCLX.cuh"
+
+namespace comms::pipes::ib::benchmark {
+
+using torchcomms::device::CmpOp;
+using torchcomms::device::CoopScope;
+using torchcomms::device::DeviceWindowNCCL;
+using torchcomms::device::RegisteredBufferNCCL;
+using torchcomms::device::SignalOp;
+
+__global__ void put_bw_kernel(
+    DeviceWindowNCCL* win,
+    RegisteredBufferNCCL src_buf,
+    size_t total_bytes,
+    int dst_rank,
+    int src_rank,
+    int signal_base,
+    int iterations) {
+  auto pid = blockIdx.x;
+  auto num_blks = gridDim.x;
+  size_t tile_bytes = total_bytes / num_blks;
+  size_t tile_offset = pid * tile_bytes;
+
+  int data_signal = pid;
+  int ack_signal = num_blks + pid;
+
+  for (int iter = 0; iter < iterations; iter++) {
+    uint64_t expected = static_cast<uint64_t>(signal_base + iter + 1);
+
+    // Put tile to remote, piggyback DATA_READY signal
+    win->put(
+        tile_offset,
+        src_buf,
+        tile_offset,
+        dst_rank,
+        tile_bytes,
+        data_signal,
+        -1,
+        CoopScope::BLOCK);
+    win->flush(CoopScope::BLOCK);
+
+    // Wait for remote's data to arrive (their put to us)
+    win->wait_signal_from(
+        src_rank, data_signal, CmpOp::GE, expected, CoopScope::BLOCK);
+
+    // ACK to remote sender: we received their data
+    win->signal(src_rank, ack_signal, SignalOp::ADD, 1, CoopScope::BLOCK);
+
+    // Wait for ACK from our receiver: they received our data
+    win->wait_signal_from(
+        dst_rank, ack_signal, CmpOp::GE, expected, CoopScope::BLOCK);
+  }
+}
+
+void launch_put_bw_kernel(
+    DeviceWindowNCCL* win,
+    RegisteredBufferNCCL src_buf,
+    size_t total_bytes,
+    int dst_rank,
+    int src_rank,
+    int num_blocks,
+    int signal_base,
+    int iterations,
+    cudaStream_t stream) {
+  put_bw_kernel<<<num_blocks, 256, 0, stream>>>(
+      win, src_buf, total_bytes, dst_rank, src_rank, signal_base, iterations);
+  cudaError_t err = cudaGetLastError();
+  assert(err == cudaSuccess && "put_bw_kernel launch failed");
+}
+
+} // namespace comms::pipes::ib::benchmark

--- a/comms/pipes/collectives/benchmarks/IbSendRecvBenchmarkKernels.cuh
+++ b/comms/pipes/collectives/benchmarks/IbSendRecvBenchmarkKernels.cuh
@@ -1,0 +1,45 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Benchmark-only CUDA kernel declarations for IB put BW measurement.
+// Host-safe header — can be included from .cc files compiled by clang.
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include "comms/torchcomms/device/ncclx/TorchCommDeviceNCCLXTypes.hpp"
+
+namespace comms::pipes::ib::benchmark {
+
+using torchcomms::device::DeviceWindowNCCL;
+using torchcomms::device::RegisteredBufferNCCL;
+
+/**
+ * Launch a zero-copy put BW kernel (benchmark only).
+ *
+ * Each block puts total_bytes/num_blocks per iteration.
+ * Signal layout: 2*num_blocks signals.
+ *   [0, num_blocks)            — DATA_READY (piggybacked on put)
+ *   [num_blocks, 2*num_blocks) — ACK (receiver signals sender)
+ *
+ * @param win          Device window handle.
+ * @param src_buf      Registered source buffer.
+ * @param total_bytes  Total transfer size per iteration.
+ * @param dst_rank     Rank to put to.
+ * @param src_rank     Rank to receive from.
+ * @param num_blocks   Number of blocks in the grid.
+ * @param signal_base  Base offset for signal values.
+ * @param iterations   Number of iterations.
+ * @param stream       CUDA stream.
+ */
+void launch_put_bw_kernel(
+    DeviceWindowNCCL* win,
+    RegisteredBufferNCCL src_buf,
+    size_t total_bytes,
+    int dst_rank,
+    int src_rank,
+    int num_blocks,
+    int signal_base,
+    int iterations,
+    cudaStream_t stream);
+
+} // namespace comms::pipes::ib::benchmark

--- a/comms/pipes/collectives/benchmarks/IbSendRecvBenchmarkMain.cpp
+++ b/comms/pipes/collectives/benchmarks/IbSendRecvBenchmarkMain.cpp
@@ -1,0 +1,8 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/pipes/collectives/ib/SendRecv.cu
+++ b/comms/pipes/collectives/ib/SendRecv.cu
@@ -1,0 +1,322 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// TileChannel-based pipelined send/recv for IB (RDMA).
+//
+// send_tile/recv_tile are user-facing primitives. Each call handles one
+// tile of data, internally chunking through the staging ring buffer if
+// the tile is larger than the per-block staging capacity.
+//
+// The step counter tracks chunks (not tiles) — each chunk consumes one
+// pipeline slot. The caller must ensure that the tile fits within
+// pipeline_depth slots: nbytes <= per_block_chunk_bytes * pipeline_depth.
+
+#include "comms/pipes/collectives/ib/SendRecv.cuh"
+
+#include <stdexcept>
+
+#include "comms/pipes/CopyUtils.cuh"
+#include "comms/pipes/TiledBuffer.cuh"
+#include "comms/torchcomms/device/ncclx/TorchCommDeviceNCCLX.cuh"
+
+namespace comms::pipes::ib {
+
+using torchcomms::device::CmpOp;
+using torchcomms::device::CoopScope;
+using torchcomms::device::DeviceWindowNCCL;
+using torchcomms::device::RegisteredBufferNCCL;
+using torchcomms::device::SignalOp;
+
+// ---- helpers ---------------------------------------------------------------
+
+/**
+ * Cooperative element-wise copy across all threads in a block.
+ *
+ * @param dst   Destination pointer (device global memory).
+ * @param src   Source pointer (device global memory).
+ * @param count Number of float elements to copy.
+ */
+__device__ __forceinline__ void
+local_copy(float* dst, const float* src, size_t count) {
+  for (size_t i = threadIdx.x; i < count; i += blockDim.x) {
+    dst[i] = src[i];
+  }
+}
+
+// ---- TileChannel -----------------------------------------------------------
+
+__device__ TileChannel make_tile_channel(
+    DeviceWindowNCCL* win,
+    RegisteredBufferNCCL staging_buf,
+    float* ring_buf_ptr,
+    int peer_rank,
+    int pid,
+    int num_blocks,
+    int pipeline_depth,
+    size_t staging_slot_bytes,
+    int64_t* step_state_ptr) {
+  int64_t initial_step = step_state_ptr ? *step_state_ptr : 0;
+  return TileChannel{
+      .win = win,
+      .staging_buf = staging_buf,
+      .ring_buf_ptr = ring_buf_ptr,
+      .peer_rank = peer_rank,
+      .pid = pid,
+      .num_blocks = num_blocks,
+      .pipeline_depth = pipeline_depth,
+      .staging_slot_bytes = staging_slot_bytes,
+      .data_signal = pid,
+      .slot_free_signal = num_blocks + pid,
+      .nic_counter = pid,
+      .step = initial_step,
+      .step_state_ptr = step_state_ptr,
+  };
+}
+
+// ---- send_tile -------------------------------------------------------------
+
+__device__ void
+send_tile(TileChannel& ch, const float* src_ptr, size_t nbytes) {
+  size_t per_block_chunk_bytes =
+      (ch.staging_slot_bytes / ch.num_blocks) & ~15ULL;
+  size_t total_chunks =
+      (nbytes + per_block_chunk_bytes - 1) / per_block_chunk_bytes;
+
+  // Pre-compute loop-invariant values.
+  size_t staging_slot_floats = ch.staging_slot_bytes / sizeof(float);
+  size_t per_block_slot_floats = per_block_chunk_bytes / sizeof(float);
+
+  for (size_t c = 0; c < total_chunks; c++) {
+    int slot = ch.step % ch.pipeline_depth;
+
+    size_t data_off_floats = c * per_block_slot_floats;
+    size_t chunk_bytes = (c + 1) * per_block_chunk_bytes <= nbytes
+        ? per_block_chunk_bytes
+        : (nbytes - c * per_block_chunk_bytes);
+
+    // Staging destination: slot within ring + block within slot.
+    float* staging_dst = ch.ring_buf_ptr + slot * staging_slot_floats +
+        ch.pid * per_block_slot_floats;
+
+    // 1. Wait NIC_DONE — staging slot safe to overwrite
+    if (ch.step >= ch.pipeline_depth) {
+      uint64_t nic_expected =
+          static_cast<uint64_t>(ch.step - ch.pipeline_depth + 1);
+      ch.win->wait_counter(
+          ch.nic_counter, CmpOp::GE, nic_expected, CoopScope::BLOCK);
+    }
+
+    // 2. Local copy: src chunk → staging (vectorized uint4 loads)
+    {
+      auto group = comms::pipes::make_block_group();
+      comms::pipes::memcpy_vectorized(
+          reinterpret_cast<char*>(staging_dst),
+          reinterpret_cast<const char*>(src_ptr + data_off_floats),
+          chunk_bytes,
+          group);
+    }
+    __syncthreads();
+    __threadfence_system();
+
+    // 3. Wait SLOT_FREE — remote window slot safe for new put
+    if (ch.step >= ch.pipeline_depth) {
+      uint64_t slot_expected =
+          static_cast<uint64_t>(ch.step - ch.pipeline_depth + 1);
+      ch.win->wait_signal_from(
+          ch.peer_rank,
+          ch.slot_free_signal,
+          CmpOp::GE,
+          slot_expected,
+          CoopScope::BLOCK);
+    }
+
+    // 4. Put: staging → remote window (offset is symmetric: local staging
+    //    layout matches remote window layout).
+    size_t byte_off =
+        static_cast<size_t>(staging_dst - ch.ring_buf_ptr) * sizeof(float);
+    ch.win->put(
+        byte_off,
+        ch.staging_buf,
+        byte_off,
+        ch.peer_rank,
+        chunk_bytes,
+        ch.data_signal,
+        ch.nic_counter,
+        CoopScope::BLOCK);
+
+    ch.step++;
+  }
+}
+
+// ---- recv_tile -------------------------------------------------------------
+
+__device__ void recv_tile(TileChannel& ch, float* dst_ptr, size_t nbytes) {
+  size_t per_block_chunk_bytes =
+      (ch.staging_slot_bytes / ch.num_blocks) & ~15ULL;
+  size_t total_chunks =
+      (nbytes + per_block_chunk_bytes - 1) / per_block_chunk_bytes;
+
+  // Pre-compute loop-invariant values.
+  size_t staging_slot_floats = ch.staging_slot_bytes / sizeof(float);
+  size_t per_block_slot_floats = per_block_chunk_bytes / sizeof(float);
+
+  for (size_t c = 0; c < total_chunks; c++) {
+    int slot = ch.step % ch.pipeline_depth;
+
+    size_t data_off_floats = c * per_block_slot_floats;
+    size_t chunk_bytes = (c + 1) * per_block_chunk_bytes <= nbytes
+        ? per_block_chunk_bytes
+        : (nbytes - c * per_block_chunk_bytes);
+
+    // Window source: slot within ring + block within slot.
+    float* window_src = ch.ring_buf_ptr + slot * staging_slot_floats +
+        ch.pid * per_block_slot_floats;
+
+    // 1. Wait DATA_READY
+    uint64_t expected = static_cast<uint64_t>(ch.step + 1);
+    ch.win->wait_signal_from(
+        ch.peer_rank, ch.data_signal, CmpOp::GE, expected, CoopScope::BLOCK);
+
+    // 2. Local copy: window → dst (vectorized uint4 loads)
+    {
+      auto group = comms::pipes::make_block_group();
+      comms::pipes::memcpy_vectorized(
+          reinterpret_cast<char*>(dst_ptr + data_off_floats),
+          reinterpret_cast<const char*>(window_src),
+          chunk_bytes,
+          group);
+    }
+
+    // 3. Signal SLOT_FREE
+    ch.win->signal(
+        ch.peer_rank, ch.slot_free_signal, SignalOp::ADD, 1, CoopScope::BLOCK);
+
+    ch.step++;
+  }
+}
+
+// ---- drain -----------------------------------------------------------------
+
+__device__ void drain(TileChannel& ch) {
+  // Wait for all outstanding SLOT_FREE signals.
+  // NIC_DONE drain is unnecessary — send_tile waits lazily before reusing
+  // each staging slot.
+  uint64_t drain_val = static_cast<uint64_t>(ch.step);
+  ch.win->wait_signal_from(
+      ch.peer_rank,
+      ch.slot_free_signal,
+      CmpOp::GE,
+      drain_val,
+      CoopScope::BLOCK);
+}
+
+// ---- kernel ----------------------------------------------------------------
+
+__global__ void send_recv_kernel(
+    DeviceWindowNCCL* win,
+    RegisteredBufferNCCL staging_buf,
+    float* src_ptr,
+    float* staging_ptr,
+    float* win_ptr,
+    float* dst_ptr,
+    size_t total_bytes,
+    size_t section_bytes,
+    int pipeline_depth,
+    int dst_rank,
+    int src_rank,
+    int num_blocks,
+    int64_t* step_state) {
+  auto bid = blockIdx.x;
+  bool is_sender = bid < num_blocks;
+  int pid = is_sender ? bid : bid - num_blocks;
+  int peer = is_sender ? dst_rank : src_rank;
+
+  // step_state layout: [0, num_blocks) for senders,
+  //                     [num_blocks, 2*num_blocks) for receivers.
+  int64_t* my_step_state = step_state + (is_sender ? pid : num_blocks + pid);
+
+  // Sender's ring buffer is the staging buffer; receiver's is the window.
+  TileChannel ch = make_tile_channel(
+      win,
+      staging_buf,
+      is_sender ? staging_ptr : win_ptr,
+      peer,
+      pid,
+      num_blocks,
+      pipeline_depth,
+      section_bytes,
+      my_step_state);
+
+  size_t section_floats = section_bytes / sizeof(float);
+  int total_steps = total_bytes / section_bytes;
+
+  for (int step = 0; step < total_steps; step++) {
+    TiledBuffer<float> tiles(
+        (is_sender ? src_ptr : dst_ptr) + step * section_floats,
+        section_floats,
+        num_blocks);
+
+    if (is_sender) {
+      send_tile(ch, tiles.tile_data(pid), tiles.tile_bytes(pid));
+    } else {
+      recv_tile(ch, tiles.tile_data(pid), tiles.tile_bytes(pid));
+    }
+  }
+
+  if (is_sender) {
+    drain(ch);
+  }
+
+  // Persist step counter for next kernel launch.
+  if (threadIdx.x == 0) {
+    *my_step_state = ch.step;
+  }
+}
+
+// ---- host launch -----------------------------------------------------------
+
+void launch_send_recv_kernel(
+    DeviceWindowNCCL* win,
+    RegisteredBufferNCCL staging_buf,
+    float* src_ptr,
+    float* staging_ptr,
+    float* win_ptr,
+    float* dst_ptr,
+    size_t total_bytes,
+    size_t section_bytes,
+    int pipeline_depth,
+    int dst_rank,
+    int src_rank,
+    int num_blocks,
+    int64_t* step_state,
+    cudaStream_t stream) {
+  if (section_bytes == 0 || total_bytes % section_bytes != 0) {
+    throw std::runtime_error(
+        "launch_send_recv_kernel: total_bytes must be a positive multiple of section_bytes");
+  }
+  if (pipeline_depth > static_cast<int>(total_bytes / section_bytes)) {
+    throw std::runtime_error(
+        "launch_send_recv_kernel: pipeline_depth must not exceed total_steps");
+  }
+  send_recv_kernel<<<2 * num_blocks, 256, 0, stream>>>(
+      win,
+      staging_buf,
+      src_ptr,
+      staging_ptr,
+      win_ptr,
+      dst_ptr,
+      total_bytes,
+      section_bytes,
+      pipeline_depth,
+      dst_rank,
+      src_rank,
+      num_blocks,
+      step_state);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("send_recv_kernel launch failed: ") +
+        cudaGetErrorString(err));
+  }
+}
+
+} // namespace comms::pipes::ib

--- a/comms/pipes/collectives/ib/SendRecv.cuh
+++ b/comms/pipes/collectives/ib/SendRecv.cuh
@@ -1,0 +1,169 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// User-facing TileChannel API for IB (RDMA) pipelined send/recv.
+//
+// TileChannel encapsulates the signal/counter management and staging buffer
+// layout for GPU-initiated RDMA. Users call send_tile()/recv_tile() as
+// single-step primitives — internal chunking handles tiles larger than
+// the staging slot.
+//
+// Host-safe header for the launch function. Device-side APIs require
+// including SendRecv.cu (compiled by nvcc).
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include "comms/torchcomms/device/ncclx/TorchCommDeviceNCCLXTypes.hpp"
+
+namespace comms::pipes::ib {
+
+using torchcomms::device::DeviceWindowNCCL;
+using torchcomms::device::RegisteredBufferNCCL;
+
+/**
+ * TileChannel — lightweight device-side handle for pipelined RDMA send/recv.
+ *
+ * Encapsulates the window, staging buffer, and signal/counter IDs for one
+ * block's tile communication with a peer. Created once per block, used
+ * across multiple send_tile()/recv_tile() calls.
+ *
+ * The user provides their own staging and window buffers (BYOB). The channel
+ * derives per-block signal/counter IDs from the block's tile index (pid).
+ *
+ * Internal chunking: if the user's tile is larger than what fits in one
+ * staging slot (staging_slot_bytes / num_blocks), send_tile/recv_tile
+ * internally pipeline the tile through the staging ring buffer in multiple
+ * chunks. This decouples staging memory from data size.
+ *
+ * Signal layout: 2 * num_blocks signals.
+ *   [0, num_blocks)             — DATA_READY (piggybacked on put)
+ *   [num_blocks, 2*num_blocks)  — SLOT_FREE  (receiver → sender)
+ * Counter layout: num_blocks counters.
+ *   [0, num_blocks)             — NIC_DONE   (staging reuse)
+ */
+struct TileChannel {
+  DeviceWindowNCCL* win;
+  RegisteredBufferNCCL
+      staging_buf; ///< Registered buffer (sender uses for put).
+  float* ring_buf_ptr; ///< Ring buffer base. Sender: staging. Receiver: window.
+  int peer_rank;
+  int pid; ///< This block's tile index.
+  int num_blocks;
+  int pipeline_depth;
+  size_t
+      staging_slot_bytes; ///< Size of one pipeline slot (full, not per-block).
+
+  // Per-block signal/counter IDs (derived from pid).
+  int data_signal;
+  int slot_free_signal;
+  int nic_counter;
+
+  /// Step counter — monotonically increasing across calls. Tracks signal
+  /// values for backpressure and CUDA graph replay safety.
+  int64_t step;
+
+  /// Pointer to persistent step state in device memory. When non-null,
+  /// make_tile_channel reads the initial step from here. The kernel writes
+  /// the final step back (thread 0 only) before exiting. This allows step
+  /// counters to survive across kernel launches, eliminating manual
+  /// signal_base bookkeeping.
+  int64_t* step_state_ptr;
+};
+
+/**
+ * Initialize a TileChannel for a sender or receiver block.
+ *
+ * @param win              Device window handle.
+ * @param staging_buf      Registered staging buffer (sender uses for put).
+ * @param ring_buf_ptr     Ring buffer base pointer. For senders this is the
+ *                         staging buffer; for receivers this is the window
+ *                         buffer. Both share the same ring layout.
+ * @param peer_rank        Rank to communicate with.
+ * @param pid              This block's tile index (0..num_blocks-1).
+ * @param num_blocks       Total sender (= receiver) blocks.
+ * @param pipeline_depth   Number of ring-buffer slots.
+ * @param staging_slot_bytes Size of one pipeline slot in bytes
+ *                           (staging ring = pipeline_depth *
+ * staging_slot_bytes).
+ * @param step_state_ptr   Pointer to persistent step counter in device memory.
+ *                         If non-null, the initial step is read from here.
+ *                         If null, the step starts at 0 (no persistence).
+ */
+__device__ TileChannel make_tile_channel(
+    DeviceWindowNCCL* win,
+    RegisteredBufferNCCL staging_buf,
+    float* ring_buf_ptr,
+    int peer_rank,
+    int pid,
+    int num_blocks,
+    int pipeline_depth,
+    size_t staging_slot_bytes,
+    int64_t* step_state_ptr = nullptr);
+
+/**
+ * Send a tile of data to the peer via pipelined RDMA.
+ *
+ * Copies src_ptr → staging, then RDMA puts staging → peer's window.
+ * If nbytes > per-block staging capacity, internally pipelines through
+ * the staging ring buffer in multiple chunks.
+ *
+ * @param ch      TileChannel (step counter is advanced).
+ * @param src_ptr Source data for this block's tile.
+ * @param nbytes  Bytes to send.
+ */
+__device__ void send_tile(TileChannel& ch, const float* src_ptr, size_t nbytes);
+
+/**
+ * Receive a tile of data from the peer.
+ *
+ * Waits for RDMA data to arrive in window, then copies window → dst_ptr.
+ * If nbytes > per-block staging capacity, internally receives in multiple
+ * chunks.
+ *
+ * @param ch      TileChannel (step counter is advanced).
+ * @param dst_ptr Destination for this block's tile.
+ * @param nbytes  Bytes to receive.
+ */
+__device__ void recv_tile(TileChannel& ch, float* dst_ptr, size_t nbytes);
+
+/**
+ * Drain outstanding SLOT_FREE signals.
+ *
+ * Call after all send_tile() calls in an iteration to ensure the peer
+ * has consumed all data before starting the next iteration.
+ *
+ * @param ch TileChannel.
+ */
+__device__ void drain(TileChannel& ch);
+
+/**
+ * Launch a pipelined send/recv kernel over IB (RDMA).
+ *
+ * Convenience launcher that creates TileChannels and calls send_tile/recv_tile.
+ * Each launch performs one transfer of total_bytes. Step counters are persisted
+ * in step_state across launches — call in a loop for benchmarking.
+ *
+ * Grid: 2 * num_blocks (first half sends, second half receives).
+ * Block: 256 threads.
+ *
+ * @param step_state  Device memory array of 2 * num_blocks int64_t values,
+ *                    zero-initialized before first use. Senders use
+ *                    [0, num_blocks), receivers use [num_blocks, 2*num_blocks).
+ */
+void launch_send_recv_kernel(
+    DeviceWindowNCCL* win,
+    RegisteredBufferNCCL staging_buf,
+    float* src_ptr,
+    float* staging_ptr,
+    float* win_ptr,
+    float* dst_ptr,
+    size_t total_bytes,
+    size_t section_bytes,
+    int pipeline_depth,
+    int dst_rank,
+    int src_rank,
+    int num_blocks,
+    int64_t* step_state,
+    cudaStream_t stream);
+
+} // namespace comms::pipes::ib


### PR DESCRIPTION
Summary:

Refactor IB sendrecv kernel code from torchcomms test directory into a proper reusable library at `comms/pipes/collectives/ib/`, mirroring the Triton IB sendrecv at `comms/pipes/triton/collectives/ib/`.

## Changes

- **New kernel library** (`collectives/ib/SendRecv.cu/.cuh`): Pipelined bidirectional sendrecv over IB/IBGDA using the torchcomms device API (NCCLx/GIN). Split into clean `send_tile()` and `recv_tile()` device functions. Uses `TiledBuffer<float>` from D100253564 for 16-byte-aligned tile partitioning, replacing manual offset math.
- **Benchmark** (`collectives/benchmarks/IbSendRecvBenchmark.cc`): Full benchmark harness with put BW reference (performance ceiling) and sendrecv sweeps across sizes, tile sizes, block counts, and pipeline depths.
- **Removed** old files from `torchcomms/tests/perf/cpp/` (PutBwBenchmark*).
- **Dropped** non-pipelined sendRecvBwKernel — pipelined version is the default.

## Key Design

- `send_tile()` / `recv_tile()` are separate `__device__` functions for clean composition
- Ring-buffer staging with configurable pipeline depth (PD)
- Signal protocol: DATA_READY (piggybacked on put), SLOT_FREE (receiver → sender), NIC_DONE counter (staging reuse)
- CUDA graph compatible: iteration count and signal_base as kernel args, monotonic counters
- snake_case naming following Pipes conventions

## Performance (H100, IB, p2p_disabled, 128 blocks)

| Size | Tile | BW (GB/s) |
|------|------|-----------|
| 32KB | 256B | 0.03 |
| 1MB | 8KB | 0.98 |
| 16MB | 128KB | 10.45 |
| 128MB | 1MB | 33.69 |
| 512MB | 4MB | 42.25 |
| 1GB | 8MB | 42.92 |
| 2GB | 16MB | 45.25 |
| 4GB | 32MB | 46.34 |

Raw put ceiling: ~47.8 GB/s. Best sendrecv: ~46.3 GB/s at 4GB (97% of ceiling).

Depends on D100253564 for TiledBuffer.

Reviewed By: siyengar

Differential Revision: D100357723
