### PR TITLE
Add version guards for v2_27 build compatibility (#2061)

### DIFF
--- a/comms/pipes/collectives/triton/device_alltoallv_dynamic.py
+++ b/comms/pipes/collectives/triton/device_alltoallv_dynamic.py
@@ -69,7 +69,6 @@ from torchcomms.triton.fb import (
     wait_signal_from,
 )
 
-
 if TYPE_CHECKING:
     from torchcomms import TorchComm
 

--- a/comms/torchcomms/device/DeviceBackendTraits.hpp
+++ b/comms/torchcomms/device/DeviceBackendTraits.hpp
@@ -56,7 +56,11 @@ class TorchCommDeviceWindow;
 
 struct NCCLDeviceBackend {
   using Comm = ncclDevComm;
+#ifdef NCCL_RMA_SUPPORTED
   using Window = ncclWindow_t;
+#else
+  using Window = void*;
+#endif
 
   // =========================================================================
   // DeviceWindowDeleter - Custom deleter for device window cleanup
@@ -135,7 +139,7 @@ struct NCCLDeviceBackend {
   static void register_extra_window(
       torch::comms::NcclxApi* nccl_api,
       ncclComm_t nccl_comm,
-      ncclWindow_t* out_win,
+      Window* out_win,
       void* ptr,
       size_t size);
 
@@ -143,16 +147,14 @@ struct NCCLDeviceBackend {
   static void deregister_extra_window(
       torch::comms::NcclxApi* nccl_api,
       ncclComm_t nccl_comm,
-      ncclWindow_t* win);
+      Window* win);
 
   // Destroy backend-specific device communicator (GIN ncclDevComm).
   static void destroy_device_comm(Ptr& device_window);
 
   // Select which window handle to use for device window creation.
   // GIN uses nccl_orig_win_ (device API flag).
-  static ncclWindow_t select_device_win(
-      ncclWindow_t /* win */,
-      ncclWindow_t nccl_orig_win) {
+  static Window select_device_win(Window /* win */, Window nccl_orig_win) {
     return nccl_orig_win;
   }
 

--- a/comms/torchcomms/device/pipes/PipesDeviceBackend.cpp
+++ b/comms/torchcomms/device/pipes/PipesDeviceBackend.cpp
@@ -53,7 +53,7 @@ PipesDeviceBackend::Ptr PipesDeviceBackend::create_device_window(
     torch::comms::NcclxApi* nccl_api,
     torch::comms::CudaApi* cuda_api,
     const DeviceBackendConfig& config,
-    ncclWindow_t nccl_win,
+    NcclWin nccl_win,
     void* base,
     size_t size) {
   if (nccl_api == nullptr) {

--- a/comms/torchcomms/device/pipes/PipesDeviceBackend.hpp
+++ b/comms/torchcomms/device/pipes/PipesDeviceBackend.hpp
@@ -114,12 +114,21 @@ struct PipesDeviceBackend {
   //   - nccl_win:   NCCL window handle (ncclWindow_t from tensor_register)
   //   - base:       Window base pointer (local data buffer)
   //   - size:       Window size in bytes
+  // NcclWin is the NCCL host-side window handle type.
+  // When NCCL_RMA_SUPPORTED is defined, this is ncclWindow_t (ncclWindow*).
+  // Otherwise, it falls back to void* to match the NcclxWindow alias.
+#ifdef NCCL_RMA_SUPPORTED
+  using NcclWin = ncclWindow_t;
+#else
+  using NcclWin = void*;
+#endif
+
   static Ptr create_device_window(
       ncclComm_t nccl_comm,
       torch::comms::NcclxApi* nccl_api,
       torch::comms::CudaApi* cuda_api,
       const DeviceBackendConfig& config,
-      ncclWindow_t nccl_win,
+      NcclWin nccl_win,
       void* base,
       size_t size);
 
@@ -131,21 +140,19 @@ struct PipesDeviceBackend {
   static void register_extra_window(
       torch::comms::NcclxApi*,
       ncclComm_t,
-      ncclWindow_t*,
+      NcclWin*,
       void*,
       size_t) {}
 
   // No additional window to deregister for Pipes.
   static void
-  deregister_extra_window(torch::comms::NcclxApi*, ncclComm_t, ncclWindow_t*) {}
+  deregister_extra_window(torch::comms::NcclxApi*, ncclComm_t, NcclWin*) {}
 
   // Pipes deleter handles all cleanup via winDestroyDeviceWin.
   static void destroy_device_comm(Ptr&) {}
 
   // Pipes uses the regular ctran window for device window creation.
-  static ncclWindow_t select_device_win(
-      ncclWindow_t win,
-      ncclWindow_t /* nccl_orig_win */) {
+  static NcclWin select_device_win(NcclWin win, NcclWin /* nccl_orig_win */) {
     return win;
   }
 

--- a/comms/torchcomms/ncclx/NcclxApi.hpp
+++ b/comms/torchcomms/ncclx/NcclxApi.hpp
@@ -67,7 +67,9 @@ using NcclxWindowAttr = ncclWinAttr_t;
 using NcclxWindow = void*;
 using NcclxWindowAccessType = int;
 using NcclxWindowAttr = void*;
-constexpr int NCCL_WIN_DEFAULT = 0;
+#ifndef NCCL_WIN_DEFAULT
+#define NCCL_WIN_DEFAULT 0x00
+#endif
 #endif
 
 /**

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -2382,6 +2382,7 @@ std::shared_ptr<TorchCommBackend> TorchCommNCCLX::split(
       "{}::split::{}_{}_{}", name_, color, split_name, split_counter_++);
 
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+#ifdef NCCLX_CONFIG_SUPPORTED
   ncclx::Hints hints;
   config.hints = &hints;
   populateNcclConfig(config, options, commDesc);
@@ -2398,6 +2399,9 @@ std::shared_ptr<TorchCommBackend> TorchCommNCCLX::split(
     }
     hints.set("ncclx::splitGroupRanks", rankStr);
   }
+#else
+  populateNcclConfig(config, options, commDesc);
+#endif
 
   // Verify the correct CUDA device is set before calling ncclCommSplit.
   // NCCL expects the caller to have set the device matching the communicator.

--- a/comms/torchcomms/ncclx/TorchCommNCCLXBootstrap.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXBootstrap.cpp
@@ -25,6 +25,7 @@ const std::string kUniqueidXchgMethodAuto = "auto";
 const std::string kUniqueidXchgMethodTCPStore = "tcpstore";
 const std::string kUniqueidXchgMethodDefault = kUniqueidXchgMethodAuto;
 
+#ifdef NCCLX_CONFIG_SUPPORTED
 bool isFastInitEnable(const ncclx::Hints& hints) {
   std::string fastInitVal;
   if (hints.get("ncclx::fastInitMode", fastInitVal) == ncclSuccess &&
@@ -37,6 +38,7 @@ bool isFastInitEnable(const ncclx::Hints& hints) {
   }
   return std::string(env) == "ring_hybrid";
 }
+#endif
 
 } // namespace
 
@@ -219,7 +221,9 @@ void populateNcclConfig(
     ncclConfig_t& config,
     const CommOptions& options,
     const std::string& name) {
+#ifdef NCCLX_CONFIG_SUPPORTED
   auto* hints = static_cast<ncclx::Hints*>(config.hints);
+#endif
   constexpr std::string_view kNcclxPrefix = "ncclx::";
 
   // Iterate over the hints and set the corresponding fields.  Keys with
@@ -232,6 +236,7 @@ void populateNcclConfig(
   for (const auto& [key, val] : options.hints) {
     // NCCLx-specific fields -- pass via ncclx::Hints
     if (key.compare(0, kNcclxPrefix.size(), kNcclxPrefix) == 0) {
+#ifdef NCCLX_CONFIG_SUPPORTED
       if (key == "ncclx::commDesc") {
         throw std::invalid_argument(
             "ncclx::commDesc must not be set in hints; "
@@ -245,6 +250,11 @@ void populateNcclConfig(
       hints->set(key, val);
       TC_LOG(INFO, nullptr)
           << "[comm=" << name << "] Setting hint " << key << "=" << val;
+#else
+      TC_LOG(WARNING)
+          << "NCCLx hints are not supported in this NCCL version, ignoring '"
+          << key << "' for comm '" << name << "'";
+#endif
     }
     // Upstream NCCL config fields -- set directly on the config struct
     else if (kTorchCommLayerHints.count(key)) {
@@ -312,6 +322,7 @@ void populateNcclConfig(
   }
 }
 
+#ifdef NCCLX_CONFIG_SUPPORTED
 bool TorchCommNCCLXBootstrap::useFastInit(const ncclx::Hints& hints) {
   if (isFastInitEnable(hints)) {
     // Use raw dynamic_cast instead of c10::dynamic_intrusive_pointer_cast
@@ -336,6 +347,7 @@ bool TorchCommNCCLXBootstrap::useFastInit(const ncclx::Hints& hints) {
   }
   return false;
 }
+#endif
 
 ncclComm_t TorchCommNCCLXBootstrap::createNcclComm(
     const std::string& name,
@@ -349,9 +361,12 @@ ncclComm_t TorchCommNCCLXBootstrap::createNcclComm(
   createStore(name);
 
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+#ifdef NCCLX_CONFIG_SUPPORTED
   ncclx::Hints hints;
   config.hints = &hints;
+#endif
   populateNcclConfig(config, options, name);
+#ifdef NCCLX_CONFIG_SUPPORTED
   hints.set("ncclx::commDesc", name);
 
   if (useFastInit(hints)) {
@@ -359,6 +374,9 @@ ncclComm_t TorchCommNCCLXBootstrap::createNcclComm(
   } else {
     uniqueId = exchangeUniqueId();
   }
+#else
+  uniqueId = exchangeUniqueId();
+#endif
 
   ncclResult_t ncclErr = nccl_api_->commInitRankConfig(
       &nccl_comm, comm_size_, uniqueId, rank_, &config);

--- a/comms/torchcomms/ncclx/TorchCommNCCLXBootstrap.hpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXBootstrap.hpp
@@ -54,7 +54,9 @@ class TorchCommNCCLXBootstrap {
  private:
   ncclUniqueId exchangeUniqueId();
   void createStore(std::string_view name);
+#ifdef NCCLX_CONFIG_SUPPORTED
   bool useFastInit(const ncclx::Hints& hints);
+#endif
   void cleanupTCPStore(ncclComm_t nccl_comm);
 
  private:

--- a/comms/torchcomms/ncclx/TorchCommWindowNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommWindowNCCLX.cpp
@@ -320,6 +320,7 @@ c10::intrusive_ptr<TorchWork> TorchCommWindowNCCLX<Backend>::wait_signal(
 template <typename Backend>
 std::shared_ptr<TorchCommWindowAttr> TorchCommWindowNCCLX<Backend>::get_attr(
     int peerRank) {
+#ifdef NCCL_RMA_SUPPORTED
   checkWindowAndThrow();
   NcclxWindowAttr nccl_attr_raw = nullptr;
   CHECK_EQ(
@@ -343,6 +344,10 @@ std::shared_ptr<TorchCommWindowAttr> TorchCommWindowNCCLX<Backend>::get_attr(
       throw std::runtime_error("Unsupported NCCL window access type");
   }
   return attr;
+#else
+  throw std::runtime_error(
+      "Window attributes are not supported without NCCL_RMA_SUPPORTED");
+#endif
 }
 
 // =============================================================================

--- a/comms/torchcomms/triton/ir_include/nccl.h
+++ b/comms/torchcomms/triton/ir_include/nccl.h
@@ -29,7 +29,8 @@ typedef enum {
 /* Opaque handle to communicator */
 typedef struct ncclComm* ncclComm_t;
 
-/* Window type - pointer to ncclWindow_vidmem struct defined in core__types.h */
+/* Window/RMA types */
+#define NCCL_RMA_SUPPORTED
 struct ncclWindow_vidmem;
 typedef struct ncclWindow_vidmem* ncclWindow_t;
 

--- a/comms/uniflow/MultiTransport.cpp
+++ b/comms/uniflow/MultiTransport.cpp
@@ -1,6 +1,7 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 #include "comms/uniflow/MultiTransport.h"
+#include "comms/uniflow/Result.h"
 #include "comms/uniflow/logging/Logger.h"
 #include "comms/uniflow/transport/nvlink/NVLinkTransport.h"
 #include "comms/uniflow/transport/rdma/RdmaTransport.h"


### PR DESCRIPTION
Summary:

Several diffs landed over the past few months that introduced ncclx-only types (ncclWindow_t, ncclx::Hints, NCCL_FAST_INIT_MODE_RING) into torchcomms code without version guards. This broke the build when using hpc_comms.use_nccl=stable (upstream NCCL v2_27), which doesn't define these types. The ~15-20 backend_nccl and backend_gloo tests in TestX that build with this config were all failing at compile time.

Fixes:
  - NcclxApi.hpp: Replace constexpr NCCL_WIN_DEFAULT with #ifndef/#define guard to avoid collision with the macro in nccl.h
  - TorchCommNCCLXBootstrap.hpp/.cpp: Wrap ncclx::Hints and NCCL_FAST_INIT_MODE_RING usage with #ifdef NCCLX_CONFIG_SUPPORTED, with fallback paths for upstream NCCL
  - TorchCommNCCLX.cpp: Same ncclx::Hints guard in the split function
  - TorchCommWindowNCCLX.cpp: Wrap get_attr() body with #ifdef NCCL_RMA_SUPPORTED
  - DeviceBackendTraits.hpp: Conditional Window type alias (ncclWindow_t vs void*) based on NCCL_RMA_SUPPORTED
  - PipesDeviceBackend.hpp: Added NcclWin type alias with same conditional
  - ir_include/nccl.h: Added missing NCCL_RMA_SUPPORTED define to the IR stub header used by the device_window_bitcode genrule

Reviewed By: goelayu

Differential Revision: D100670686
