### PR TITLE
Use regCache's globalRegister to register IB, so we can support tensor from expandable segment CCA (#2064)

### DIFF
--- a/comms/torchcomms/transport/RdmaTransport.cpp
+++ b/comms/torchcomms/transport/RdmaTransport.cpp
@@ -35,17 +35,29 @@ namespace torch::comms {
 RdmaMemory::RdmaMemory(const void* buf, size_t len, int cudaDev, bool cacheReg)
     : buf_(buf), len_(len), cudaDev_(cudaDev), cacheReg_(cacheReg) {
   initEnvironment();
-  if (cacheReg_) {
-    // Hold a shared_ptr to ensure RegCache lifetime while RdmaMemory is in
-    // scope
-    regCache_ = ctran::RegCache::getInstance();
+  // Hold a shared_ptr to ensure RegCache lifetime while RdmaMemory is in
+  // scope
+  regCache_ = ctran::RegCache::getInstance();
+
+  // Try to find an existing registration first.
+  regHdl_ = regCache_->searchIbRegHandle(buf_, len_, cudaDev_);
+
+  if (regHdl_ != nullptr) {
+    // Buffer is already registered. If caller didn't expect that, upgrade to
+    // cache-managed so the destructor won't deregister a handle it doesn't own.
+    cacheReg_ = true;
+  } else if (cacheReg_) {
+    // Caller asserted the buffer is pre-registered, but it wasn't found.
+    throw std::runtime_error(
+        "Failed to fetch the IB handle from regCache. The buffer may not be registered");
+  } else {
+    // Not registered yet; do it now.
+    FB_COMMCHECKTHROW(regCache_->globalRegister(buf_, len_, true, cudaDev_));
     regHdl_ = regCache_->searchIbRegHandle(buf_, len_, cudaDev_);
     if (regHdl_ == nullptr) {
-      throw std::runtime_error(
-          "Failed to fetch the IB handle from regCache. The buffer may not be registered");
+      FB_COMMCHECKIGNORE(regCache_->globalDeregister(buf_, len_, cudaDev_));
+      throw std::runtime_error("Failed to fetch the IB handle from regCache.");
     }
-  } else {
-    FB_COMMCHECKTHROW(CtranIb::regMem(buf_, len_, cudaDev_, &regHdl_));
   }
   remoteKey_ = CtranIb::getRemoteAccessKey(regHdl_).toString();
 }
@@ -74,7 +86,8 @@ RdmaMemory::~RdmaMemory() noexcept {
     return;
   }
   if (remoteKey_.size() > 0 && regHdl_) {
-    FB_COMMCHECKIGNORE(CtranIb::deregMem(regHdl_));
+    FB_COMMCHECKIGNORE(regCache_->globalDeregister(buf_, len_, cudaDev_));
+    regHdl_ = nullptr;
   }
 }
 

--- a/comms/torchcomms/transport/RdmaTransport.h
+++ b/comms/torchcomms/transport/RdmaTransport.h
@@ -138,9 +138,11 @@ class RdmaMemory : folly::MoveOnly {
    * @param buf Pointer to the memory buffer to register
    * @param len Length of the memory buffer in bytes
    * @param cudaDev CUDA device ID associated with this memory buffer
-   * @param cacheReg Whether to cache the IB registration of the memory buffer.
-   *        When true, the registration is cached in regCache. Useful if the
-   *        same buffer is used to construct RdmaMemory for multiple times
+   * @param cacheReg Whether the buffer is already registered in regCache.
+   *        When true, the constructor expects the buffer to be pre-registered
+   *        and will throw if the handle is not found. When false, the
+   *        constructor will register the buffer itself and deregister it on
+   *        destruction
    */
   RdmaMemory(const void* buf, size_t len, int cudaDev, bool cacheReg = false);
   RdmaMemory(RdmaMemory&& other) noexcept;


### PR DESCRIPTION
Summary:

Instead of using `CtranIb::regMem`, we should use `regCache_->globalRegister` for external GPU tensor's IB registration, which supports expandable segments.

When we use regcache's API to register a tensor, it discovers all physical memory segments of this virtual address range with pinRange(), and later register all segments with IB.

Reviewed By: tianfengfrank, dsjohns2

Differential Revision: D99870431
