### PR TITLE
Fix ProxyTrace hang tests for fast-init

### DIFF
--- a/comms/ncclx/meta/colltrace/tests/ProxyTraceDistTest.cc
+++ b/comms/ncclx/meta/colltrace/tests/ProxyTraceDistTest.cc
@@ -521,8 +521,15 @@ TEST_F(ProxyTraceTest, QueryFinishedSendRecv) {
 TEST_F(ProxyTraceTest, QueryHangAllReduce) {
   auto traceGuard = EnvRAII(NCCL_PROXYTRACE, {"trace"});
 
+  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  if (!checkTestRequirement(comm)) {
+    GTEST_SKIP();
+  }
+
+  // Configure mock failure relative to current opCount to account for
+  // init-phase operations (e.g., fast-init) that consume opCounts.
   SendFailureConfig failureConfig = {
-      8 /*opCount*/,
+      static_cast<int>(comm->opCount) + 8 /*opCount*/,
       0 /*rank*/,
       -1 /*remoteRank*/,
       1 /*step*/,
@@ -530,11 +537,6 @@ TEST_F(ProxyTraceTest, QueryHangAllReduce) {
       30 /*delay*/
   };
   setMockConfig(failureConfig);
-
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
-  if (!checkTestRequirement(comm)) {
-    GTEST_SKIP();
-  }
 
   EXPECT_NE(comm->proxyState->trace, nullptr);
 
@@ -584,8 +586,10 @@ TEST_F(ProxyTraceTest, QueryHangSendRecv) {
     GTEST_SKIP();
   }
 
+  // Configure mock failure relative to current opCount to account for
+  // init-phase operations (e.g., fast-init) that consume opCounts.
   SendFailureConfig failureConfig = {
-      8 /*opCount*/,
+      static_cast<int>(comm->opCount) + 8 /*opCount*/,
       0 /*rank*/,
       comm->localRanks /*remoteRank*/,
       1 /*step*/,

--- a/comms/ncclx/v2_29/src/enqueue.cc
+++ b/comms/ncclx/v2_29/src/enqueue.cc
@@ -798,7 +798,6 @@ static ncclResult_t scheduleCollTasksToPlan(
         proxyOp->ringAlgo = NULL;
         if (proxyOp->reg && task->algorithm == NCCL_ALGO_RING && (task->recvNetHandles[c] || task->sendNetHandles[c])) {
           if (task->func == ncclFuncAllGather) {
-        ncclx::colltrace::proxyTraceAddBasicInfo(*proxyOp, nMaxChannels[kind], proxyOp->task.coll->func);
             proxyOp->ringAlgo = new RingAGAlgorithm(task->sendbuff, task->recvbuff, comm->nRanks, comm->channels[c].ring.userRanks, proxyOp->chunkSteps, proxyOp->sliceSteps, proxyOp->chunkSize, proxyOp->sliceSize, proxyOp->loopOffset, proxyOp->channelSize, elementSize, task->count * elementSize, task->sendNetHandles[c], task->recvNetHandles[c], task->srecvNetHandles[c]);
           } else if (task->func == ncclFuncAllReduce) {
             proxyOp->ringAlgo = new RingARAlgorithm(task->sendbuff, task->recvbuff, comm->nRanks, comm->channels[c].ring.index, proxyOp->chunkSteps, proxyOp->sliceSteps, proxyOp->chunkSize, proxyOp->sliceSize, proxyOp->loopOffset, proxyOp->channelSize, elementSize, task->sendNetHandles[c], task->recvNetHandles[c], task->srecvNetHandles[c]);
@@ -811,6 +810,7 @@ static ncclResult_t scheduleCollTasksToPlan(
         proxyOp->incWorkCounter = true;
         proxyOp->nChannels = nChannels;
         ncclAddWorkBatchToPlan(comm, plan, c, workNode->workType, task->devFuncId, plan->workBytes);
+        ncclx::colltrace::proxyTraceAddBasicInfo(*proxyOp, nMaxChannels[kind], proxyOp->task.coll->func);
         // Coverity reports "proxyOp->connection" as being possibly uninitialized.  It's hard to
         // determine if that's actually true but it's also not clear if that would be an issue.
         // coverity[uninit_use_in_call:FALSE]


### PR DESCRIPTION
Summary:
With fast-init (ring_hybrid mode), NCCL runs internal collectives
during communicator initialization that consume opCounts. The
ProxyTrace hang tests (QueryHangAllReduce, QueryHangSendRecv) used
hardcoded opCount values for mock failure injection, which could
target init-phase operations instead of user collectives.

Fix by creating the comm before configuring the mock, and offsetting
the mock's opCount by comm->opCount so the failure targets the correct
user-level collective.

Reviewed By: SuhitK

Differential Revision: D100730040


