### PR TITLE
Add profilingSampleCount to decouple profiler sampling source from opCount (#2067)

### DIFF
--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -164,6 +164,12 @@ class CtranComm {
   // algorithms are used.
   uint64_t* opCount_{nullptr};
 
+  // Sample count source for profiler sampling decisions.
+  // - nullptr (default): profiler uses opCount for sampling
+  // - When set: points to an external counter (e.g., collectiveCount)
+  //   allowing the caller to control sampling independently of opCount.
+  uint64_t* profilingSampleCount_{nullptr};
+
   // TODO: confirm with Ctran stakeholders if we need to keep this field
   // TODO: move to stateX?
   // Depending on this flag CtranAlgo initialized resources differently

--- a/comms/ctran/algos/AllGather/AllGatherBrucksFF.cc
+++ b/comms/ctran/algos/AllGather/AllGatherBrucksFF.cc
@@ -78,8 +78,7 @@ static commResult_t impl(
 
   ctran::Profiler* profiler = comm->ctran_->profiler.get();
   if (profiler) {
-    profiler->initForEachColl(
-        op->opCount, NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT);
+    profiler->initForEachColl(op->opCount);
   }
 
   void* memHdl;

--- a/comms/ctran/algos/AllGather/AllGatherDirect.cc
+++ b/comms/ctran/algos/AllGather/AllGatherDirect.cc
@@ -28,8 +28,7 @@ static commResult_t impl(
 
   ctran::Profiler* profiler = comm->ctran_->profiler.get();
   if (profiler) {
-    profiler->initForEachColl(
-        op->opCount, NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT);
+    profiler->initForEachColl(op->opCount);
   }
 
   const auto statex = comm->statex_.get();

--- a/comms/ctran/algos/AllGather/AllGatherRecDbl.cc
+++ b/comms/ctran/algos/AllGather/AllGatherRecDbl.cc
@@ -25,8 +25,7 @@ static commResult_t impl(
 
   ctran::Profiler* profiler = comm->ctran_->profiler.get();
   if (profiler) {
-    profiler->initForEachColl(
-        op->opCount, NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT);
+    profiler->initForEachColl(op->opCount);
   }
 
   void* memHdl;

--- a/comms/ctran/algos/AllGather/AllGatherRing.cc
+++ b/comms/ctran/algos/AllGather/AllGatherRing.cc
@@ -36,8 +36,7 @@ static commResult_t impl(
 
   ctran::Profiler* profiler = comm->ctran_->profiler.get();
   if (profiler) {
-    profiler->initForEachColl(
-        op->opCount, NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT);
+    profiler->initForEachColl(op->opCount);
   }
 
   CtranMapperContext context(

--- a/comms/ctran/algos/AllReduce/AllReduceRing.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceRing.cc
@@ -1059,8 +1059,7 @@ static commResult_t impl(
 
   ctran::Profiler* profiler = comm->ctran_->profiler.get();
   if (profiler) {
-    profiler->initForEachColl(
-        op->opCount, NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT);
+    profiler->initForEachColl(op->opCount);
   }
 
   // hostArgs/hostResource are direct members of OpElem — owned by OpElem,

--- a/comms/ctran/algos/AllToAll/AllToAllvImpl.h
+++ b/comms/ctran/algos/AllToAll/AllToAllvImpl.h
@@ -87,8 +87,7 @@ commResult_t ctranAllToAllvIbImpl(
 
   ctran::Profiler* profiler = comm->ctran_->profiler.get();
   if (profiler) {
-    profiler->initForEachColl(
-        opCount, NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT);
+    profiler->initForEachColl(opCount);
   }
 
   if (sendCounts.size() > 0) {

--- a/comms/ctran/algos/SendRecv/SendRecvImpl.h
+++ b/comms/ctran/algos/SendRecv/SendRecvImpl.h
@@ -127,8 +127,7 @@ inline commResult_t sendRecvImpl(
   std::vector<void*> tmpRegHdls;
   ctran::Profiler* profiler = comm->ctran_->profiler.get();
   if (profiler) {
-    profiler->initForEachColl(
-        opCount, NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT);
+    profiler->initForEachColl(opCount);
   }
 
   if (sendOpGroup.size() > 0 || recvOpGroup.size() > 0) {

--- a/comms/ctran/profiler/Profiler.cc
+++ b/comms/ctran/profiler/Profiler.cc
@@ -1,6 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 #include "comms/ctran/profiler/Profiler.h"
 #include "comms/ctran/profiler/DefaultAlgoProfilerReporter.h"
+#include "comms/utils/cvars/nccl_cvars.h"
 
 namespace {
 
@@ -28,14 +29,16 @@ namespace ctran {
 
 Profiler::Profiler(CtranComm* comm, std::unique_ptr<IProfilerReporter> reporter)
     : comm_(comm),
+      samplingRegistry_(NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT),
       reporter_(
           reporter ? std::move(reporter)
                    : std::make_unique<DefaultAlgoProfilerReporter>()) {}
 
 Profiler::~Profiler() = default;
 
-void Profiler::initForEachColl(int opCount, int samplingWeight) {
-  shouldTrace_ = samplingWeight > 0 && (opCount % samplingWeight) == 0;
+void Profiler::initForEachColl(int opCount) {
+  samplingRegistry_.setSampleCount(opCount);
+  shouldTrace_ = samplingRegistry_.shouldTrace();
   if (shouldTrace_) {
     opCount_ = opCount;
     durations_.fill(0);

--- a/comms/ctran/profiler/Profiler.cc
+++ b/comms/ctran/profiler/Profiler.cc
@@ -37,7 +37,10 @@ Profiler::Profiler(CtranComm* comm, std::unique_ptr<IProfilerReporter> reporter)
 Profiler::~Profiler() = default;
 
 void Profiler::initForEachColl(int opCount) {
-  samplingRegistry_.setSampleCount(opCount);
+  int sampleCount = comm_->profilingSampleCount_
+      ? static_cast<int>(*comm_->profilingSampleCount_)
+      : opCount;
+  samplingRegistry_.setSampleCount(sampleCount);
   shouldTrace_ = samplingRegistry_.shouldTrace();
   if (shouldTrace_) {
     opCount_ = opCount;

--- a/comms/ctran/profiler/Profiler.h
+++ b/comms/ctran/profiler/Profiler.h
@@ -7,6 +7,7 @@
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/profiler/AlgoProfilerReport.h"
 #include "comms/ctran/profiler/IProfilerReporter.h"
+#include "comms/ctran/profiler/SamplingRegistry.h"
 #include "comms/ctran/utils/StopWatch.h"
 
 namespace ctran {
@@ -47,7 +48,7 @@ class Profiler {
   ~Profiler();
 
   // This should be called at the beginning of the collective
-  void initForEachColl(int opCount, int samplingWeight);
+  void initForEachColl(int opCount);
 
   bool shouldTrace() const {
     return shouldTrace_;
@@ -85,6 +86,7 @@ class Profiler {
  private:
   AlgoProfilerReport buildReport() const;
   CtranComm* comm_{nullptr};
+  SamplingRegistry samplingRegistry_;
   bool shouldTrace_{false};
   uint64_t opCount_{std::numeric_limits<uint64_t>::max()};
   EventDurationArray durations_{};

--- a/comms/ctran/profiler/SamplingRegistry.cc
+++ b/comms/ctran/profiler/SamplingRegistry.cc
@@ -1,0 +1,19 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/ctran/profiler/SamplingRegistry.h"
+
+namespace ctran {
+
+SamplingRegistry::SamplingRegistry(int samplingWeight)
+    : samplingWeight_(samplingWeight) {}
+
+void SamplingRegistry::setSampleCount(int sampleCount) {
+  sampleCount_ = sampleCount;
+}
+
+bool SamplingRegistry::shouldTrace() const {
+  return samplingWeight_ > 0 && sampleCount_ >= 0 &&
+      (sampleCount_ % samplingWeight_) == 0;
+}
+
+} // namespace ctran

--- a/comms/ctran/profiler/SamplingRegistry.h
+++ b/comms/ctran/profiler/SamplingRegistry.h
@@ -1,0 +1,23 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+namespace ctran {
+
+// Encapsulates the sampling decision for algo profiling.
+// Traces operations where sampleCount is a multiple of samplingWeight.
+// (1 = every op, N = every Nth op, 0 or negative = never trace)
+class SamplingRegistry {
+ public:
+  explicit SamplingRegistry(int samplingWeight);
+
+  void setSampleCount(int sampleCount);
+
+  bool shouldTrace() const;
+
+ private:
+  int samplingWeight_;
+  int sampleCount_{-1};
+};
+
+} // namespace ctran

--- a/comms/ctran/profiler/tests/ProfilerTest.cc
+++ b/comms/ctran/profiler/tests/ProfilerTest.cc
@@ -70,6 +70,45 @@ TEST_F(ProfilerTest, testInitForEachColl) {
   EXPECT_NE(p5->getOpCount(), opCount);
 }
 
+TEST_F(ProfilerTest, testProfilingSampleCountOverridesOpCount) {
+  // When profilingSampleCount_ is set, profiler samples on that counter
+  // instead of opCount
+  uint64_t collectiveCount = 0;
+  comm_->profilingSampleCount_ = &collectiveCount;
+
+  auto p = makeProfiler(10); // trace every 10th
+
+  // opCount=10 would normally trace, but collectiveCount=0 traces (0 % 10 == 0)
+  collectiveCount = 0;
+  p->initForEachColl(10);
+  EXPECT_TRUE(p->shouldTrace());
+
+  // collectiveCount=5 should not trace (5 % 10 != 0)
+  collectiveCount = 5;
+  p->initForEachColl(10);
+  EXPECT_FALSE(p->shouldTrace());
+
+  // collectiveCount=20 should trace (20 % 10 == 0), even though opCount=7
+  collectiveCount = 20;
+  p->initForEachColl(7);
+  EXPECT_TRUE(p->shouldTrace());
+}
+
+TEST_F(ProfilerTest, testNullProfilingSampleCountFallsBackToOpCount) {
+  // When profilingSampleCount_ is nullptr (default), profiler uses opCount
+  EXPECT_EQ(comm_->profilingSampleCount_, nullptr);
+
+  auto p = makeProfiler(10);
+
+  // opCount=10 should trace
+  p->initForEachColl(10);
+  EXPECT_TRUE(p->shouldTrace());
+
+  // opCount=7 should not trace
+  p->initForEachColl(7);
+  EXPECT_FALSE(p->shouldTrace());
+}
+
 TEST_F(ProfilerTest, testDefaultReporterType) {
   // Default constructor should use default reporter (no crash on reportToScuba)
   profiler_->initForEachColl(100);

--- a/comms/ctran/profiler/tests/ProfilerTest.cc
+++ b/comms/ctran/profiler/tests/ProfilerTest.cc
@@ -3,6 +3,7 @@
 #include "comms/ctran/profiler/Profiler.h"
 #include <gtest/gtest.h>
 #include "comms/ctran/profiler/tests/MockProfilerReporter.h"
+#include "comms/utils/cvars/nccl_cvars.h"
 
 using namespace ::testing;
 
@@ -16,14 +17,18 @@ class ProfilerTest : public ::testing::Test {
     // comm_->logMetaData_ which is a trivial POD struct, so zero-init is safe.
     commBuf_.resize(sizeof(CtranComm), 0);
     comm_ = reinterpret_cast<CtranComm*>(commBuf_.data());
+    // Default: sample every op
+    NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT = 1;
     profiler_ = std::make_unique<ctran::Profiler>(comm_);
   }
   void TearDown() override {
     comm_ = nullptr;
   }
 
-  uint64_t getOpCount() {
-    return profiler_->getOpCount();
+  // Create a Profiler with a specific sampling weight
+  std::unique_ptr<ctran::Profiler> makeProfiler(int samplingWeight) {
+    NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT = samplingWeight;
+    return std::make_unique<ctran::Profiler>(comm_);
   }
 
  protected:
@@ -34,44 +39,47 @@ class ProfilerTest : public ::testing::Test {
 
 TEST_F(ProfilerTest, testInitForEachColl) {
   uint64_t opCount = 100;
+
   // test negative sampling weight
-  profiler_->initForEachColl(opCount, -1);
-  EXPECT_FALSE(profiler_->shouldTrace());
-  EXPECT_NE(profiler_->getOpCount(), opCount);
+  auto p1 = makeProfiler(-1);
+  p1->initForEachColl(opCount);
+  EXPECT_FALSE(p1->shouldTrace());
 
   // test zero sampling weight
-  profiler_->initForEachColl(opCount, 0);
-  EXPECT_FALSE(profiler_->shouldTrace());
-  EXPECT_NE(profiler_->getOpCount(), opCount);
+  auto p2 = makeProfiler(0);
+  p2->initForEachColl(opCount);
+  EXPECT_FALSE(p2->shouldTrace());
 
   // test sampling weight = 1
-  profiler_->initForEachColl(opCount, 1);
-  EXPECT_TRUE(profiler_->shouldTrace());
-  EXPECT_EQ(profiler_->getOpCount(), opCount);
+  auto p3 = makeProfiler(1);
+  p3->initForEachColl(opCount);
+  EXPECT_TRUE(p3->shouldTrace());
+  EXPECT_EQ(p3->getOpCount(), opCount);
 
   // test opCount is the multiple of sampling weight
-  profiler_->initForEachColl(opCount, 20);
-  EXPECT_TRUE(profiler_->shouldTrace());
-  EXPECT_EQ(profiler_->getOpCount(), opCount);
+  auto p4 = makeProfiler(20);
+  p4->initForEachColl(opCount);
+  EXPECT_TRUE(p4->shouldTrace());
+  EXPECT_EQ(p4->getOpCount(), opCount);
 
   // test opCount is not the multiple of sampling weight
   ++opCount;
-  profiler_->initForEachColl(opCount, 20);
-  EXPECT_FALSE(profiler_->shouldTrace());
-  EXPECT_NE(profiler_->getOpCount(), opCount);
+  auto p5 = makeProfiler(20);
+  p5->initForEachColl(opCount);
+  EXPECT_FALSE(p5->shouldTrace());
+  EXPECT_NE(p5->getOpCount(), opCount);
 }
 
 TEST_F(ProfilerTest, testDefaultReporterType) {
   // Default constructor should use default reporter (no crash on reportToScuba)
-  auto profiler = std::make_unique<ctran::Profiler>(comm_);
-  profiler->initForEachColl(100, 1);
-  profiler->startEvent(ctran::ProfilerEvent::BUF_REG);
-  profiler->endEvent(ctran::ProfilerEvent::BUF_REG);
-  profiler->startEvent(ctran::ProfilerEvent::ALGO_CTRL);
-  profiler->endEvent(ctran::ProfilerEvent::ALGO_CTRL);
-  profiler->startEvent(ctran::ProfilerEvent::ALGO_DATA);
-  profiler->endEvent(ctran::ProfilerEvent::ALGO_DATA);
-  EXPECT_NO_THROW(profiler->reportToScuba());
+  profiler_->initForEachColl(100);
+  profiler_->startEvent(ctran::ProfilerEvent::BUF_REG);
+  profiler_->endEvent(ctran::ProfilerEvent::BUF_REG);
+  profiler_->startEvent(ctran::ProfilerEvent::ALGO_CTRL);
+  profiler_->endEvent(ctran::ProfilerEvent::ALGO_CTRL);
+  profiler_->startEvent(ctran::ProfilerEvent::ALGO_DATA);
+  profiler_->endEvent(ctran::ProfilerEvent::ALGO_DATA);
+  EXPECT_NO_THROW(profiler_->reportToScuba());
 }
 
 TEST_F(ProfilerTest, testReportToScubaCallsReporter) {
@@ -80,7 +88,7 @@ TEST_F(ProfilerTest, testReportToScubaCallsReporter) {
   profiler_ = std::make_unique<ctran::Profiler>(comm_, std::move(mockReporter));
 
   // Set up profiler state
-  profiler_->initForEachColl(100, 1);
+  profiler_->initForEachColl(100);
   ASSERT_TRUE(profiler_->shouldTrace());
 
   // Set algo context

--- a/comms/ctran/profiler/tests/SamplingRegistryTest.cc
+++ b/comms/ctran/profiler/tests/SamplingRegistryTest.cc
@@ -1,0 +1,67 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/ctran/profiler/SamplingRegistry.h"
+#include <gtest/gtest.h>
+
+namespace ctran {
+
+TEST(SamplingRegistryTest, NegativeWeightNeverTraces) {
+  SamplingRegistry reg(-1);
+  reg.setSampleCount(0);
+  EXPECT_FALSE(reg.shouldTrace());
+  reg.setSampleCount(1);
+  EXPECT_FALSE(reg.shouldTrace());
+  reg.setSampleCount(100);
+  EXPECT_FALSE(reg.shouldTrace());
+}
+
+TEST(SamplingRegistryTest, ZeroWeightNeverTraces) {
+  SamplingRegistry reg(0);
+  reg.setSampleCount(0);
+  EXPECT_FALSE(reg.shouldTrace());
+  reg.setSampleCount(1);
+  EXPECT_FALSE(reg.shouldTrace());
+}
+
+TEST(SamplingRegistryTest, WeightOneAlwaysTraces) {
+  SamplingRegistry reg(1);
+  reg.setSampleCount(0);
+  EXPECT_TRUE(reg.shouldTrace());
+  reg.setSampleCount(1);
+  EXPECT_TRUE(reg.shouldTrace());
+  reg.setSampleCount(999);
+  EXPECT_TRUE(reg.shouldTrace());
+}
+
+TEST(SamplingRegistryTest, WeightNTracesMultiples) {
+  SamplingRegistry reg(20);
+  reg.setSampleCount(0);
+  EXPECT_TRUE(reg.shouldTrace());
+  reg.setSampleCount(20);
+  EXPECT_TRUE(reg.shouldTrace());
+  reg.setSampleCount(100);
+  EXPECT_TRUE(reg.shouldTrace());
+  reg.setSampleCount(1);
+  EXPECT_FALSE(reg.shouldTrace());
+  reg.setSampleCount(19);
+  EXPECT_FALSE(reg.shouldTrace());
+  reg.setSampleCount(101);
+  EXPECT_FALSE(reg.shouldTrace());
+}
+
+TEST(SamplingRegistryTest, InitialStateFalse) {
+  SamplingRegistry reg(1);
+  // Before any setSampleCount call, shouldTrace is false
+  EXPECT_FALSE(reg.shouldTrace());
+}
+
+TEST(SamplingRegistryTest, ShouldTraceReflectsCurrentSampleCount) {
+  SamplingRegistry reg(10);
+  reg.setSampleCount(10);
+  EXPECT_TRUE(reg.shouldTrace());
+  EXPECT_TRUE(reg.shouldTrace()); // idempotent
+  reg.setSampleCount(11);
+  EXPECT_FALSE(reg.shouldTrace());
+}
+
+} // namespace ctran


### PR DESCRIPTION
Summary:

Add a `profilingSampleCount_` pointer on `CtranComm` that allows callers to control which counter the profiler uses for sampling decisions. When set, the profiler samples based on the pointed-to counter instead of opCount. When null (default), existing behavior is preserved — opCount is used.

MCCL uses this to sample based on a new `collectiveCount_` counter (incremented per allReduce call) rather than opCount, enabling independent sampling control.

Changes:
- Add `uint64_t* profilingSampleCount_` to CtranComm (nullptr = use opCount)
- Add `uint64_t collectiveCount_` to McclComm, incremented in allReduce
- Wire `profilingSampleCount_` to `collectiveCount_` in McclComm::finishInit
- Profiler::initForEachColl uses profilingSampleCount when set, else opCount
- Add AUTODEPS fix for profiler_test BUCK (ncclx-cvars dep)
- Add 2 test cases: override via profilingSampleCount, nullptr fallback to opCount

Differential Revision: D100730174
