### PR TITLE
Add isInitialized() API to TorchCommBackend and update TorchCommMCCL::reconfigure initialization state (#2071)

### DIFF
--- a/comms/torchcomms/TorchCommBackend.hpp
+++ b/comms/torchcomms/TorchCommBackend.hpp
@@ -254,6 +254,19 @@ class TorchCommBackend {
   }
 
   /**
+   * Check if the backend is fully initialized and ready for collective
+   * operations. In dynamic regime, the backend transitions to initialized
+   * state after a successful reconfigure().
+   *
+   * This method is non-throwing and safe to call regardless of backend state.
+   *
+   * @return True if the backend is initialized, false otherwise.
+   */
+  virtual bool isInitialized() const {
+    return true;
+  }
+
+  /**
    * Get the initialization handle for this backend.
    * In dynamic regime, this URL encodes information required by the backend
    * to complete the initialization process via reconfigure().

--- a/comms/torchcomms/TorchCommBackend.hpp
+++ b/comms/torchcomms/TorchCommBackend.hpp
@@ -289,6 +289,19 @@ class TorchCommBackend {
   }
 
   /**
+   * Check if the backend is fully initialized and ready for collective
+   * operations. In dynamic regime, the backend transitions to initialized
+   * state after a successful reconfigure().
+   *
+   * This method is non-throwing and safe to call regardless of backend state.
+   *
+   * @return True if the backend is initialized, false otherwise.
+   */
+  virtual bool isInitialized() const {
+    return true;
+  }
+
+  /**
    * Get the initialization handle for this backend.
    * In dynamic regime, this URL encodes information required by the backend
    * to complete the initialization process via reconfigure().


### PR DESCRIPTION
Summary:

Add `isInitialized()` virtual method to `TorchCommBackend` so callers can check whether a backend is ready for collective operations before issuing them. The MCCL implementation now correctly ties initialization state to a successful `reconfigure()` result rather than unconditionally marking itself initialized, preventing use of a backend whose reconfigure failed.

Specifically, we now set `initState_ = UNINITIALIZED` before calling `mccl_comm_->reconfigure()`, then only promote to `INITIALIZED` inside the existing success block (where `result->code == commSuccess`) alongside `rank_` and `commSize_` updates. Previously `initState_ = INITIALIZED` was set unconditionally after `createWork()`, which allowed subsequent operations to proceed on a broken communicator after a failed reconfigure.

**We also** reset `commSize_` to 0 instead of -1, and we move the reset of `commSize_` and `rank_` to be with the `initState_ = UNITIALIZED`. For one thing, -1 (as an int) silently becomes `SIZE_MAX` when cast to `size_t`, which caused a SEV once already. And if `commSize_` ever leaks beyond these guards, then 0 is harmless, while -1 is catastrophic (can crash the workload/application).

**Concession:** 0 is more of a soft sentinel insofar as it is a valid communicator size, and so you cannot distinguish "uninitialized" from "genuinely zero participants" by looking at `commSize_` alone. But you can just look at `initState_` for this.

Reviewed By: dboyda

Differential Revision: D100673963


