### PR TITLE
Back out "Fix broken fbcode//comms/torchcomms/tests/integration/py:MultiCommTest_1x8_ranksize_manual_backend_n"

### DIFF
--- a/comms/torchcomms/tests/integration/py/MultiCommTest.py
+++ b/comms/torchcomms/tests/integration/py/MultiCommTest.py
@@ -234,17 +234,12 @@ class MultiCommTest(unittest.TestCase):
         wrappers = []
         comms = []
 
-        # Create first communicator with a store
-        store = create_store()
-        wrappers.append(TorchCommTestWrapper(store=store))
+        # Create first communicator with no store
+        wrappers.append(TorchCommTestWrapper())
         comms.append(wrappers[-1].get_torchcomm())
 
-        store = None
-        store_deletion_barrier(comms[-1])
-
-        # Create second communicator with a store
-        store = create_store()
-        wrappers.append(TorchCommTestWrapper(store=store))
+        # Create second communicator with no store
+        wrappers.append(TorchCommTestWrapper())
         comms.append(wrappers[-1].get_torchcomm())
 
         # Test communication on each communicator individually
@@ -253,9 +248,6 @@ class MultiCommTest(unittest.TestCase):
 
         # Test simultaneous communication across all communicators
         self._verify_simultaneous_communication(wrappers)
-
-        store = None
-        store_deletion_barrier(comms[-1])
 
     def test_three_comms_no_store(self):
         """Test with three communicators with no store."""
@@ -263,25 +255,16 @@ class MultiCommTest(unittest.TestCase):
         wrappers = []
         comms = []
 
-        # Create first communicator with a store
-        store = create_store()
-        wrappers.append(TorchCommTestWrapper(store=store))
+        # Create first communicator with no store
+        wrappers.append(TorchCommTestWrapper())
         comms.append(wrappers[-1].get_torchcomm())
 
-        store = None
-        store_deletion_barrier(comms[-1])
-
-        # Create second communicator with a store
-        store = create_store()
-        wrappers.append(TorchCommTestWrapper(store=store))
+        # Create second communicator with no store
+        wrappers.append(TorchCommTestWrapper())
         comms.append(wrappers[-1].get_torchcomm())
 
-        store = None
-        store_deletion_barrier(comms[-1])
-
-        # Create third communicator with a store
-        store = create_store()
-        wrappers.append(TorchCommTestWrapper(store=store))
+        # Create third communicator with no store
+        wrappers.append(TorchCommTestWrapper())
         comms.append(wrappers[-1].get_torchcomm())
 
         # Test communication on each communicator individually
@@ -291,26 +274,18 @@ class MultiCommTest(unittest.TestCase):
         # Test simultaneous communication across all communicators
         self._verify_simultaneous_communication(wrappers)
 
-        store = None
-        store_deletion_barrier(comms[-1])
-
     def test_mixed_ops_no_store(self):
         """Test mixed operations across multiple communicators with no store."""
         # Create two communicators
         wrappers = []
         comms = []
 
-        # Create first communicator with a store
-        store = create_store()
-        wrappers.append(TorchCommTestWrapper(store=store))
+        # Create first communicator with no store
+        wrappers.append(TorchCommTestWrapper())
         comms.append(wrappers[-1].get_torchcomm())
 
-        store = None
-        store_deletion_barrier(comms[-1])
-
-        # Create second communicator with a store
-        store = create_store()
-        wrappers.append(TorchCommTestWrapper(store=store))
+        # Create second communicator with no store
+        wrappers.append(TorchCommTestWrapper())
         comms.append(wrappers[-1].get_torchcomm())
 
         # Prepare tensors for different operations
@@ -341,9 +316,6 @@ class MultiCommTest(unittest.TestCase):
         verify_tensor_equality(input1.cpu(), expected1, "comm_0 all_reduce result")
         verify_tensor_equality(input2.cpu(), broadcast_value, "comm_1 broadcast result")
 
-        store = None
-        store_deletion_barrier(comms[-1])
-
     def test_two_comms_mixed_store(self):
         """Test with two communicators with mixed store (one explicit, one None)."""
         # Create two communicators
@@ -361,9 +333,8 @@ class MultiCommTest(unittest.TestCase):
         store = None
         store_deletion_barrier(comms[0])
 
-        # Create second communicator with a new store
-        store = create_store()
-        wrappers.append(TorchCommTestWrapper(store=store))
+        # Create second communicator with no store
+        wrappers.append(TorchCommTestWrapper())
         comms.append(wrappers[-1].get_torchcomm())
 
         # Test communication on each communicator individually
@@ -372,9 +343,6 @@ class MultiCommTest(unittest.TestCase):
 
         # Test simultaneous communication across all communicators
         self._verify_simultaneous_communication(wrappers)
-
-        store = None
-        store_deletion_barrier(comms[-1])
 
     def test_three_comms_mixed_store(self):
         """Test with three communicators with mixed store (two explicit, one None)."""
@@ -402,9 +370,8 @@ class MultiCommTest(unittest.TestCase):
         store = None
         store_deletion_barrier(comms[0])
 
-        # Create third communicator with a new store
-        store = create_store()
-        wrappers.append(TorchCommTestWrapper(store=store))
+        # Create third communicator with no store
+        wrappers.append(TorchCommTestWrapper())
         comms.append(wrappers[-1].get_torchcomm())
 
         # Test communication on each communicator individually
@@ -413,9 +380,6 @@ class MultiCommTest(unittest.TestCase):
 
         # Test simultaneous communication across all communicators
         self._verify_simultaneous_communication(wrappers)
-
-        store = None
-        store_deletion_barrier(comms[-1])
 
     def test_mixed_ops_mixed_store(self):
         """Test mixed operations across multiple communicators with mixed store."""
@@ -434,9 +398,8 @@ class MultiCommTest(unittest.TestCase):
         store = None
         store_deletion_barrier(comms[0])
 
-        # Create second communicator with a new store
-        store = create_store()
-        wrappers.append(TorchCommTestWrapper(store=store))
+        # Create second communicator with no store
+        wrappers.append(TorchCommTestWrapper())
         comms.append(wrappers[-1].get_torchcomm())
 
         device0 = comms[0].get_device()
@@ -464,9 +427,6 @@ class MultiCommTest(unittest.TestCase):
         # Verify results
         verify_tensor_equality(input1.cpu(), expected1, "comm_0 all_reduce result")
         verify_tensor_equality(input2.cpu(), broadcast_value, "comm_1 broadcast result")
-
-        store = None
-        store_deletion_barrier(comms[-1])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
Original commit changeset: 109dac592993

Original Phabricator Diff: D99444078

___

overriding_review_checks_triggers_an_audit_and_retroactive_review
Oncall Short Name: ncclx

Differential Revision: D100864915


