### PR TITLE
Fix AsyncSocket variable-length message receive bug and ExportMultiSegmentMem test

### DIFF
--- a/comms/ctran/bootstrap/AsyncSocket.cc
+++ b/comms/ctran/bootstrap/AsyncSocket.cc
@@ -325,7 +325,7 @@ void AsyncServerSocket::OneShotRecv::computeTotalSize() {
     // Grow the IOBuf to accommodate the full message if needed
     size_t needed = totalSize_ - got_;
     if (buf_->tailroom() < needed) {
-      buf_->reserve(0, needed - buf_->tailroom());
+      buf_->reserve(0, needed);
     }
   }
 }

--- a/comms/ctran/regcache/tests/DistRegCacheUT.cc
+++ b/comms/ctran/regcache/tests/DistRegCacheUT.cc
@@ -408,13 +408,13 @@ TEST_F(DistRegCacheTest, ExportMultiMem) {
 
 TEST_F(DistRegCacheTest, ExportMultiSegmentMem) {
   // E2E test: rank 0 allocates disjoint memory with more segments than
-  // CTRAN_IPC_INLINE_SEGMENTS, exports via notifyRemoteIpcExport(), and
+  // CTRAN_IPC_INLINE_SEGMENTS, registers via globalRegister (mapper->regMem
+  // doesn't support multi-segment), exports via notifyRemoteIpcExport(), and
   // rank 1 verifies the imported registration matches what rank 0 sent.
   auto& mapper = comm_->ctran_->mapper;
   ASSERT_NE(mapper, nullptr);
 
   constexpr size_t numSegments = CTRAN_IPC_INLINE_SEGMENTS + 1;
-  // Each segment is 2MB; total = numSegments * 2MB
   const size_t segSize = 1UL << 21;
   const size_t bufSize = segSize * numSegments;
 
@@ -428,18 +428,23 @@ TEST_F(DistRegCacheTest, ExportMultiSegmentMem) {
     auto myId = comm_->statex_->gPid();
     const int peer = 1;
 
-    // Allocate disjoint buffer with numSegments physical segments
     std::vector<TestMemSegment> segments;
     void* data = ctran::CtranNcclTestHelpers::prepareBuf(
         bufSize, kCuMemAllocDisjoint, segments, numSegments);
     ASSERT_NE(data, nullptr);
 
-    // Register memory
-    void* segHdl;
-    ctran::regcache::RegElem* regHdl = nullptr;
-    COMMCHECK_TEST(
-        mapper->regMem(data, bufSize, &segHdl, true, true, (void**)&regHdl));
+    // Use globalRegister which supports multi-segment buffers
+    COMMCHECK_TEST(regCache->globalRegister(data, bufSize, true));
+
+    // Retrieve the RegElem to access ipcRegElem for export
+    std::vector<void*> segHdls;
+    std::vector<ctran::regcache::RegElem*> regElems;
+    COMMCHECK_TEST(regCache->lookupSegmentsForBuffer(
+        data, bufSize, localRank, segHdls, regElems));
+    ASSERT_FALSE(regElems.empty());
+    auto* regHdl = regElems[0];
     ASSERT_NE(regHdl, nullptr);
+    ASSERT_NE(regHdl->ipcRegElem, nullptr);
 
     // Export memory — should produce extraSegments
     ctran::regcache::IpcDesc ipcDesc;
@@ -448,6 +453,10 @@ TEST_F(DistRegCacheTest, ExportMultiSegmentMem) {
         data, regHdl->ipcRegElem, ipcDesc, extraSegments));
 
     // Verify export produced the expected segment layout
+    ctran::regcache::IpcRegElem* ipcRegElem =
+        reinterpret_cast<ctran::regcache::IpcRegElem*>(regHdl->ipcRegElem);
+    auto ipcMem = ipcRegElem->ipcMem.rlock();
+    EXPECT_EQ(ipcDesc.desc.range, ipcMem->getRange());
     EXPECT_EQ(ipcDesc.desc.totalSegments, static_cast<int>(numSegments));
     EXPECT_EQ(ipcDesc.desc.numInlineSegments(), CTRAN_IPC_INLINE_SEGMENTS);
     ASSERT_EQ(extraSegments.size(), numSegments - CTRAN_IPC_INLINE_SEGMENTS);
@@ -468,10 +477,10 @@ TEST_F(DistRegCacheTest, ExportMultiSegmentMem) {
     while (!exportReqCb.completed.load()) {
     }
 
-    mapper->barrier();
+    oobBarrier();
 
     // Cleanup
-    COMMCHECK_TEST(mapper->deregMem(segHdl, true));
+    COMMCHECK_TEST(regCache->globalDeregister(data, bufSize));
     ctran::CtranNcclTestHelpers::releaseBuf(
         data, bufSize, kCuMemAllocDisjoint, numSegments);
 
@@ -485,14 +494,13 @@ TEST_F(DistRegCacheTest, ExportMultiSegmentMem) {
     }
     EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 1);
 
-    mapper->barrier();
-
+    oobBarrier();
     // Cleanup remote registrations
     ipcRegCache->clearAllRemReg();
     EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 0);
 
   } else {
-    mapper->barrier();
+    oobBarrier();
   }
 }
 


### PR DESCRIPTION
Summary:
**Summary:**

Fix `ExportMultiSegmentMem` test and `AsyncSocket` variable-length message receive bug.

1. `CtranMapper::regMem` has a `FB_CHECKABORT(segments.size() == 1)` that fatally aborts when called with a buffer backed by multiple physical segments (e.g., `kCuMemAllocDisjoint`). This test allocates disjoint memory with `CTRAN_IPC_INLINE_SEGMENTS + 1` physical segments, which always triggers the abort. The fix replaces `mapper->regMem`/`deregMem` with `RegCache::globalRegister`/`globalDeregister`, which natively support multi-segment buffers. 
2. `AsyncSocket.cc`: Fix IOBuf under-reservation in computeTotalSize(). `IOBuf::reserve(minHeadroom, minTailroom)` sets an absolute minimum tailroom, not a delta. When `IOBuf::create(sizeof(IpcReq))` rounds capacity up (e.g., jemalloc gives 512 for a 500-byte request), partial tailroom remains after reading the header. The old code reserve(0, needed - tailroom) requested too few bytes — after the next read consumed the available tailroom, 0 bytes remained for subsequent reads, causing folly to error with getReadBuffer() returned empty buffer. Fix: `reserve(0, needed)` to guarantee enough tailroom for the full remaining payload.
3. Also renames the BUCK target from `regcache_init_none` to `regcache_dist_ut_init_none` to match the intended target name.

Reviewed By: dsjohns2

Differential Revision: D100862851


