### PR TITLE
Revert gPid rank suffix and fix nolocal/vnode topology host assignment

### DIFF
--- a/comms/ctran/bootstrap/AsyncSocket.cc
+++ b/comms/ctran/bootstrap/AsyncSocket.cc
@@ -325,7 +325,7 @@ void AsyncServerSocket::OneShotRecv::computeTotalSize() {
     // Grow the IOBuf to accommodate the full message if needed
     size_t needed = totalSize_ - got_;
     if (buf_->tailroom() < needed) {
-      buf_->reserve(0, needed - buf_->tailroom());
+      buf_->reserve(0, needed);
     }
   }
 }

--- a/comms/ctran/commstate/CommStateX.cc
+++ b/comms/ctran/commstate/CommStateX.cc
@@ -80,6 +80,7 @@ void CommStateX::initRankTopologyNolocal() {
     rankState.nLocalRanks = 1;
     rankState.localRankToRanks.assign(1, r);
     const std::string nolocalHost("nolocal_node_" + std::to_string(r));
+    rankState.host = nolocalHost;
     hostToRanks_[nolocalHost].emplace_back(r);
     nodeRanks_[rankState.nodeId].emplace_back(rankState.rank);
   }
@@ -101,6 +102,7 @@ void CommStateX::initRankTopologyVnode(const int nLocalRanks) {
     }
     const std::string vNodeHost(
         "vnode_node_" + std::to_string(rankState.nodeId));
+    rankState.host = vNodeHost;
     hostToRanks_[vNodeHost].emplace_back(r);
     nodeRanks_[rankState.nodeId].emplace_back(r);
   }
@@ -563,7 +565,7 @@ int CommStateX::gRank(int rank) const {
 std::string CommStateX::gPid(int rank) const {
   CHECK_TOPO_AND_SET_RANK(rank, rank_, rankStates_);
   return rankStates_.at(rank).host + ":" +
-      std::to_string(rankStates_.at(rank).pid) + ":" + std::to_string(rank);
+      std::to_string(rankStates_.at(rank).pid);
 }
 
 std::string CommStateX::dc(int rank) const {

--- a/comms/ctran/regcache/tests/DistRegCacheUT.cc
+++ b/comms/ctran/regcache/tests/DistRegCacheUT.cc
@@ -408,13 +408,13 @@ TEST_F(DistRegCacheTest, ExportMultiMem) {
 
 TEST_F(DistRegCacheTest, ExportMultiSegmentMem) {
   // E2E test: rank 0 allocates disjoint memory with more segments than
-  // CTRAN_IPC_INLINE_SEGMENTS, exports via notifyRemoteIpcExport(), and
+  // CTRAN_IPC_INLINE_SEGMENTS, registers via globalRegister (mapper->regMem
+  // doesn't support multi-segment), exports via notifyRemoteIpcExport(), and
   // rank 1 verifies the imported registration matches what rank 0 sent.
   auto& mapper = comm_->ctran_->mapper;
   ASSERT_NE(mapper, nullptr);
 
   constexpr size_t numSegments = CTRAN_IPC_INLINE_SEGMENTS + 1;
-  // Each segment is 2MB; total = numSegments * 2MB
   const size_t segSize = 1UL << 21;
   const size_t bufSize = segSize * numSegments;
 
@@ -428,18 +428,23 @@ TEST_F(DistRegCacheTest, ExportMultiSegmentMem) {
     auto myId = comm_->statex_->gPid();
     const int peer = 1;
 
-    // Allocate disjoint buffer with numSegments physical segments
     std::vector<TestMemSegment> segments;
     void* data = ctran::CtranNcclTestHelpers::prepareBuf(
         bufSize, kCuMemAllocDisjoint, segments, numSegments);
     ASSERT_NE(data, nullptr);
 
-    // Register memory
-    void* segHdl;
-    ctran::regcache::RegElem* regHdl = nullptr;
-    COMMCHECK_TEST(
-        mapper->regMem(data, bufSize, &segHdl, true, true, (void**)&regHdl));
+    // Use globalRegister which supports multi-segment buffers
+    COMMCHECK_TEST(regCache->globalRegister(data, bufSize, true));
+
+    // Retrieve the RegElem to access ipcRegElem for export
+    std::vector<void*> segHdls;
+    std::vector<ctran::regcache::RegElem*> regElems;
+    COMMCHECK_TEST(regCache->lookupSegmentsForBuffer(
+        data, bufSize, localRank, segHdls, regElems));
+    ASSERT_FALSE(regElems.empty());
+    auto* regHdl = regElems[0];
     ASSERT_NE(regHdl, nullptr);
+    ASSERT_NE(regHdl->ipcRegElem, nullptr);
 
     // Export memory — should produce extraSegments
     ctran::regcache::IpcDesc ipcDesc;
@@ -448,6 +453,10 @@ TEST_F(DistRegCacheTest, ExportMultiSegmentMem) {
         data, regHdl->ipcRegElem, ipcDesc, extraSegments));
 
     // Verify export produced the expected segment layout
+    ctran::regcache::IpcRegElem* ipcRegElem =
+        reinterpret_cast<ctran::regcache::IpcRegElem*>(regHdl->ipcRegElem);
+    auto ipcMem = ipcRegElem->ipcMem.rlock();
+    EXPECT_EQ(ipcDesc.desc.range, ipcMem->getRange());
     EXPECT_EQ(ipcDesc.desc.totalSegments, static_cast<int>(numSegments));
     EXPECT_EQ(ipcDesc.desc.numInlineSegments(), CTRAN_IPC_INLINE_SEGMENTS);
     ASSERT_EQ(extraSegments.size(), numSegments - CTRAN_IPC_INLINE_SEGMENTS);
@@ -468,10 +477,10 @@ TEST_F(DistRegCacheTest, ExportMultiSegmentMem) {
     while (!exportReqCb.completed.load()) {
     }
 
-    mapper->barrier();
+    oobBarrier();
 
     // Cleanup
-    COMMCHECK_TEST(mapper->deregMem(segHdl, true));
+    COMMCHECK_TEST(regCache->globalDeregister(data, bufSize));
     ctran::CtranNcclTestHelpers::releaseBuf(
         data, bufSize, kCuMemAllocDisjoint, numSegments);
 
@@ -485,14 +494,13 @@ TEST_F(DistRegCacheTest, ExportMultiSegmentMem) {
     }
     EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 1);
 
-    mapper->barrier();
-
+    oobBarrier();
     // Cleanup remote registrations
     ipcRegCache->clearAllRemReg();
     EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 0);
 
   } else {
-    mapper->barrier();
+    oobBarrier();
   }
 }
 


### PR DESCRIPTION
Summary:
### Summary

Reverts [D92879823](https://www.internalfb.com/diff/D92879823) which appended `:rank` to `gPid()` format (`hostname:pid:rank`). This contradicts the purpose of the IPC import cache (`ipcRemRegMap_`), which should be keyed by process identity (`hostname:pid`) since CUDA IPC handles are per-process, not per-rank. Using per-rank keys creates duplicate cache entries for ranks in the same process and causes key mismatches between `ipcRemRegMap_` (keyed by `gPid`) and `remImportMap_` (keyed by `localPeerId_` which is `hostname:pid`).

D92879823 was a workaround for MCCL tests using NOLOCAL topology mode, where `initRankTopologyNolocal()` never assigned `rankState.host` (stayed `""`) or `rankState.pid` (stayed `-1`), causing all ranks to have identical `gPid = ":-1"`. The proper fix is to assign the synthetic hostname to `rankState.host` so that `gPid()` naturally returns unique values without needing the rank suffix.

### Changes

**`CommStateX.cc`**:
- `initRankTopologyNolocal()`: Assign `rankState.host = nolocalHost` (`"nolocal_node_<r>"`) so `gPid()` returns `"nolocal_node_0:-1"`, `"nolocal_node_1:-1"`, etc. — unique per rank without the `:rank` suffix.
- `initRankTopologyVnode()`: Same fix — assign `rankState.host = vNodeHost` (`"vnode_node_<nodeId>"`) for consistency.
- `gPid()`: Revert to `hostname:pid` format (remove `:rank` suffix), restoring alignment with `localPeerId_` and IPC cache key semantics.

### Why

- **IPC handles are per-process**: `cudaIpcOpenMemHandle` returns the same mapped base regardless of which rank in the process calls it. `hostname:pid` is the natural process identifier.
- **Deduplication**: With `hostname:pid`, same-process ranks share one cache entry with proper refcounting. With `hostname:pid:rank`, they create duplicate entries.

Reviewed By: elvinlife

Differential Revision: D100055198


