### PR TITLE
Fix MultiCommTest port conflict by destroying _root_store between tests

### DIFF
--- a/comms/torchcomms/tests/integration/py/MultiCommTest.py
+++ b/comms/torchcomms/tests/integration/py/MultiCommTest.py
@@ -8,6 +8,7 @@ import torch
 from torchcomms import ReduceOp
 from torchcomms.tests.integration.py.TorchCommTestHelpers import (
     create_store,
+    destroy_root_store,
     TorchCommTestWrapper,
     verify_tensor_equality,
     wrap_prefix_store,
@@ -128,9 +129,10 @@ class MultiCommTest(unittest.TestCase):
         # Test simultaneous communication across all communicators
         self._verify_simultaneous_communication(wrappers)
 
-        # Clean up
+        # Clean up store and free MASTER_PORT for subsequent no-store tests
         store = None
         store_deletion_barrier(comms[-1])
+        destroy_root_store()
 
     def test_three_comms_separate_stores(self):
         """Test with three communicators with separate stores."""
@@ -170,9 +172,10 @@ class MultiCommTest(unittest.TestCase):
         # Test simultaneous communication across all communicators
         self._verify_simultaneous_communication(wrappers)
 
-        # Clean up
+        # Clean up store and free MASTER_PORT for subsequent no-store tests
         store = None
         store_deletion_barrier(comms[-1])
+        destroy_root_store()
 
     def test_mixed_ops_separate_stores(self):
         """Test mixed operations across multiple communicators with separate stores."""
@@ -224,27 +227,22 @@ class MultiCommTest(unittest.TestCase):
         verify_tensor_equality(input1.cpu(), expected1, "comm_0 all_reduce result")
         verify_tensor_equality(input2.cpu(), broadcast_value, "comm_1 broadcast result")
 
-        # Clean up
+        # Clean up store and free MASTER_PORT for subsequent no-store tests
         store = None
         store_deletion_barrier(comms[-1])
+        destroy_root_store()
 
     def test_two_comms_no_store(self):
         """Test with two communicators with no store."""
-        # Create two communicators
         wrappers = []
         comms = []
 
-        # Create first communicator with a store
-        store = create_store()
-        wrappers.append(TorchCommTestWrapper(store=store))
+        # Create first communicator with no store (internal bootstrap)
+        wrappers.append(TorchCommTestWrapper())
         comms.append(wrappers[-1].get_torchcomm())
 
-        store = None
-        store_deletion_barrier(comms[-1])
-
-        # Create second communicator with a store
-        store = create_store()
-        wrappers.append(TorchCommTestWrapper(store=store))
+        # Create second communicator with no store (internal bootstrap)
+        wrappers.append(TorchCommTestWrapper())
         comms.append(wrappers[-1].get_torchcomm())
 
         # Test communication on each communicator individually
@@ -253,35 +251,22 @@ class MultiCommTest(unittest.TestCase):
 
         # Test simultaneous communication across all communicators
         self._verify_simultaneous_communication(wrappers)
-
-        store = None
-        store_deletion_barrier(comms[-1])
 
     def test_three_comms_no_store(self):
         """Test with three communicators with no store."""
-        # Create three communicators
         wrappers = []
         comms = []
 
-        # Create first communicator with a store
-        store = create_store()
-        wrappers.append(TorchCommTestWrapper(store=store))
+        # Create first communicator with no store (internal bootstrap)
+        wrappers.append(TorchCommTestWrapper())
         comms.append(wrappers[-1].get_torchcomm())
 
-        store = None
-        store_deletion_barrier(comms[-1])
-
-        # Create second communicator with a store
-        store = create_store()
-        wrappers.append(TorchCommTestWrapper(store=store))
+        # Create second communicator with no store (internal bootstrap)
+        wrappers.append(TorchCommTestWrapper())
         comms.append(wrappers[-1].get_torchcomm())
 
-        store = None
-        store_deletion_barrier(comms[-1])
-
-        # Create third communicator with a store
-        store = create_store()
-        wrappers.append(TorchCommTestWrapper(store=store))
+        # Create third communicator with no store (internal bootstrap)
+        wrappers.append(TorchCommTestWrapper())
         comms.append(wrappers[-1].get_torchcomm())
 
         # Test communication on each communicator individually
@@ -291,30 +276,20 @@ class MultiCommTest(unittest.TestCase):
         # Test simultaneous communication across all communicators
         self._verify_simultaneous_communication(wrappers)
 
-        store = None
-        store_deletion_barrier(comms[-1])
-
     def test_mixed_ops_no_store(self):
         """Test mixed operations across multiple communicators with no store."""
-        # Create two communicators
         wrappers = []
         comms = []
 
-        # Create first communicator with a store
-        store = create_store()
-        wrappers.append(TorchCommTestWrapper(store=store))
+        # Create first communicator with no store (internal bootstrap)
+        wrappers.append(TorchCommTestWrapper())
         comms.append(wrappers[-1].get_torchcomm())
 
-        store = None
-        store_deletion_barrier(comms[-1])
-
-        # Create second communicator with a store
-        store = create_store()
-        wrappers.append(TorchCommTestWrapper(store=store))
+        # Create second communicator with no store (internal bootstrap)
+        wrappers.append(TorchCommTestWrapper())
         comms.append(wrappers[-1].get_torchcomm())
 
         # Prepare tensors for different operations
-        # Calculate device indices as rank % num_devices
         device0 = comms[0].get_device()
         device1 = comms[1].get_device()
         options0 = {"dtype": torch.float, "device": device0}
@@ -341,29 +316,23 @@ class MultiCommTest(unittest.TestCase):
         verify_tensor_equality(input1.cpu(), expected1, "comm_0 all_reduce result")
         verify_tensor_equality(input2.cpu(), broadcast_value, "comm_1 broadcast result")
 
-        store = None
-        store_deletion_barrier(comms[-1])
-
     def test_two_comms_mixed_store(self):
-        """Test with two communicators with mixed store (one explicit, one None)."""
-        # Create two communicators
+        """Test with two communicators with mixed store (one explicit, one no-store)."""
         wrappers = []
         comms = []
 
-        # Create a store for the first communicator
-        store = create_store()
-
         # Create first communicator using explicit store
+        store = create_store()
         wrappers.append(TorchCommTestWrapper(store=store))
         comms.append(wrappers[-1].get_torchcomm())
 
-        # Cleanup our store
+        # Destroy all store references and free MASTER_PORT
         store = None
         store_deletion_barrier(comms[0])
+        destroy_root_store()
 
-        # Create second communicator with a new store
-        store = create_store()
-        wrappers.append(TorchCommTestWrapper(store=store))
+        # Create second communicator with no store (internal bootstrap)
+        wrappers.append(TorchCommTestWrapper())
         comms.append(wrappers[-1].get_torchcomm())
 
         # Test communication on each communicator individually
@@ -373,38 +342,31 @@ class MultiCommTest(unittest.TestCase):
         # Test simultaneous communication across all communicators
         self._verify_simultaneous_communication(wrappers)
 
-        store = None
-        store_deletion_barrier(comms[-1])
-
     def test_three_comms_mixed_store(self):
-        """Test with three communicators with mixed store (two explicit, one None)."""
-        # Create three communicators
+        """Test with three communicators with mixed store (two explicit, one no-store)."""
         wrappers = []
         comms = []
 
-        # Create a single store and wrap with prefixes to avoid port conflicts
+        # Create first two communicators using PrefixStore wrappers
         store = create_store()
         store1 = wrap_prefix_store("comm1", store)
         store2 = wrap_prefix_store("comm2", store)
 
-        # Create first communicator using the store
         wrappers.append(TorchCommTestWrapper(store=store1))
         comms.append(wrappers[-1].get_torchcomm())
 
-        # Create second communicator using the same store
         wrappers.append(TorchCommTestWrapper(store=store2))
         comms.append(wrappers[-1].get_torchcomm())
 
-        # Cleanup stores
+        # Destroy all store references and free MASTER_PORT
         store1 = None
         store2 = None
-        store_deletion_barrier(comms[0])
         store = None
         store_deletion_barrier(comms[0])
+        destroy_root_store()
 
-        # Create third communicator with a new store
-        store = create_store()
-        wrappers.append(TorchCommTestWrapper(store=store))
+        # Create third communicator with no store (internal bootstrap)
+        wrappers.append(TorchCommTestWrapper())
         comms.append(wrappers[-1].get_torchcomm())
 
         # Test communication on each communicator individually
@@ -414,29 +376,23 @@ class MultiCommTest(unittest.TestCase):
         # Test simultaneous communication across all communicators
         self._verify_simultaneous_communication(wrappers)
 
-        store = None
-        store_deletion_barrier(comms[-1])
-
     def test_mixed_ops_mixed_store(self):
         """Test mixed operations across multiple communicators with mixed store."""
-        # Create two communicators
         wrappers = []
         comms = []
 
-        # Create a store for the first communicator
-        store = create_store()
-
         # Create first communicator using explicit store
+        store = create_store()
         wrappers.append(TorchCommTestWrapper(store=store))
         comms.append(wrappers[-1].get_torchcomm())
 
-        # Cleanup our store
+        # Destroy all store references and free MASTER_PORT
         store = None
         store_deletion_barrier(comms[0])
+        destroy_root_store()
 
-        # Create second communicator with a new store
-        store = create_store()
-        wrappers.append(TorchCommTestWrapper(store=store))
+        # Create second communicator with no store (internal bootstrap)
+        wrappers.append(TorchCommTestWrapper())
         comms.append(wrappers[-1].get_torchcomm())
 
         device0 = comms[0].get_device()
@@ -464,9 +420,6 @@ class MultiCommTest(unittest.TestCase):
         # Verify results
         verify_tensor_equality(input1.cpu(), expected1, "comm_0 all_reduce result")
         verify_tensor_equality(input2.cpu(), broadcast_value, "comm_1 broadcast result")
-
-        store = None
-        store_deletion_barrier(comms[-1])
 
 
 if __name__ == "__main__":

--- a/comms/torchcomms/tests/integration/py/TorchCommTestHelpers.py
+++ b/comms/torchcomms/tests/integration/py/TorchCommTestHelpers.py
@@ -181,6 +181,17 @@ def wrap_prefix_store(name, store):
     return PrefixStore(name, store)
 
 
+def destroy_root_store():
+    """Destroy the global _root_store so the MASTER_PORT can be reused.
+
+    Call this in tearDown() of test classes that mix store-based and no-store
+    tests. Without this, the persistent _root_store holds MASTER_PORT and
+    prevents the no-store bootstrap path from creating its own TCPStore.
+    """
+    global _root_store
+    _root_store = None
+
+
 def verify_tensor_equality(
     output: torch.Tensor,
     expected: Union[torch.Tensor, int, float],


### PR DESCRIPTION
Summary:
## Impact

| Category | Issues | Root Cause | Fixed by this change? |
|----------|--------|------------|----------------------|
| Python 1x8 | 40 | `_root_store` persistence | **YES** — verified with `buck test` |
| Python 2x8 (real failures) | ~4 | Same `_root_store` persistence | **YES** — same bug, same fix (if GPU available) |
| Python 2x8 (infra) | ~4 | CI cancelled/quota | No — needs GPU capacity |
| C++ 2x8 | 19 | CI `RESOURCE_EXHAUSTED` | No — needs GPU capacity |
| C++ 1x8 | 0 | No failures exist | N/A |

**This change addresses ~44 of the 67 open MultiCommTest test issues.** The remaining 19 C++ issues and ~4 Python 2x8 issues are CI GPU quota problems — no code fix needed.

## Investigation

Investigated 67 open MultiCommTest test issues (48 Python, 19 C++) across the ncclx oncall.

**C++ (19 issues, all 2x8):** All recent CI runs show `RESOURCE_EXHAUSTED` or `cancelled` — pure infrastructure failures due to GPU quota exhaustion. The tests never actually executed. C++ 1x8 tests all pass, confirming no code bug exists on the C++ side.

**Python (48 issues, 40 1x8 + 8 2x8):** Real test failures. CI logs show the test binary hangs during the second communicator bootstrap (SIGTERM after 180s timeout). The first communicator (`comms_test_1`) initializes successfully, but the second one hangs during `TorchCommNCCLXBootstrap` unique ID exchange.

## Root Cause

The Python test helper `TorchCommTestHelpers.py` maintains a module-level `_root_store` (a `TCPStore` bound to `MASTER_PORT`) that persists across test methods:

```python
_root_store = None  # module-level global

def create_store():
    global _root_store
    if _root_store is None:
        _root_store = TCPStore(host, port=MASTER_PORT, ...)  # binds port
    return PrefixStore(f"test_comm_{N}", _root_store)
```

Python unittest runs test methods alphabetically within the `MultiCommTest` class. Store-based tests (e.g., `test_mixed_ops_separate_stores`) call `create_store()`, initializing `_root_store` on `MASTER_PORT`. This store is never destroyed.

When a subsequent no-store test (e.g., `test_two_comms_no_store`) creates `TorchCommTestWrapper()` without a store, the NCCLx bootstrap internally calls `createPrefixStore()` which tries to create a new `TCPStore` on the same `MASTER_PORT` — but it is already held by the persistent `_root_store`, causing a hang.

## Options Considered

1. **Workaround (D99444078):** Replace all `TorchCommTestWrapper()` (no-store) calls with `TorchCommTestWrapper(store=create_store())`. Makes tests pass but eliminates no-store path test coverage and does not fix the underlying bug. New tests using the no-store path would hit the same issue.

2. **Destroy `_root_store` in `tearDown`:** Clean up after every test. Rejected because `tearDown` runs on each rank independently without synchronization — rank 0 could destroy the TCPStore server while other ranks still hold stale client references, causing `DistNetworkError` on the next test.

3. **Destroy `_root_store` after barrier in store-based tests (chosen):** Each store-based test already ends with `store_deletion_barrier()` which synchronizes all ranks via NCCL barrier. Adding `destroy_root_store()` after the barrier ensures all ranks have released their PrefixStore references before the TCPStore is destroyed. This is safe because the barrier guarantees synchronization.

## Fix Details

**`TorchCommTestHelpers.py`:** Added `destroy_root_store()` helper that sets the global `_root_store` to `None`, destroying the `TCPStore` and freeing `MASTER_PORT`.

**`MultiCommTest.py`:**
- **Store-based tests (3 tests):** Added `destroy_root_store()` after the existing `store_deletion_barrier()` at the end of each test, freeing `MASTER_PORT` for subsequent no-store tests.
- **No-store tests (3 tests):** Reverted from D99444078 workaround back to original `TorchCommTestWrapper()` without stores, restoring actual no-store bootstrap path coverage.
- **Mixed-store tests (3 tests):** Call `store_deletion_barrier()` then `destroy_root_store()` before creating the no-store communicator, freeing `MASTER_PORT` for the internal bootstrap.

## Verification

Tested with `buck test` across 7 variants:
- `ranksize={none,auto,manual}` x ncclx baseline: **all PASS**
- `ranksize=none` x gloo: **PASS**
- `ranksize=mpi` x ncclx fast init: **PASS**
- `ranksize=auto` x ncclx expseg+ctran: **PASS**
- C++ 1x8 ncclx: **PASS** (unaffected by Python-only change)

Without fix: FAIL (`test_two_comms_no_store` hangs, killed by SIGTERM)
With fix: PASS (all 9 test methods pass)

Reviewed By: lilyjanjigian

Differential Revision: D100866929


