### PR TITLE
Fix ENABLE_PIPES vs TORCHCOMMS_HAS_NCCL_DEVICE_API gating mismatch

### DIFF
--- a/comms/torchcomms/device/DeviceBackendTraits.hpp
+++ b/comms/torchcomms/device/DeviceBackendTraits.hpp
@@ -56,7 +56,11 @@ class TorchCommDeviceWindow;
 
 struct NCCLDeviceBackend {
   using Comm = ncclDevComm;
+#ifdef NCCL_RMA_SUPPORTED
   using Window = ncclWindow_t;
+#else
+  using Window = void*;
+#endif
 
   // =========================================================================
   // DeviceWindowDeleter - Custom deleter for device window cleanup
@@ -135,7 +139,7 @@ struct NCCLDeviceBackend {
   static void register_extra_window(
       torch::comms::NcclxApi* nccl_api,
       ncclComm_t nccl_comm,
-      ncclWindow_t* out_win,
+      Window* out_win,
       void* ptr,
       size_t size);
 
@@ -143,16 +147,14 @@ struct NCCLDeviceBackend {
   static void deregister_extra_window(
       torch::comms::NcclxApi* nccl_api,
       ncclComm_t nccl_comm,
-      ncclWindow_t* win);
+      Window* win);
 
   // Destroy backend-specific device communicator (GIN ncclDevComm).
   static void destroy_device_comm(Ptr& device_window);
 
   // Select which window handle to use for device window creation.
   // GIN uses nccl_orig_win_ (device API flag).
-  static ncclWindow_t select_device_win(
-      ncclWindow_t /* win */,
-      ncclWindow_t nccl_orig_win) {
+  static Window select_device_win(Window /* win */, Window nccl_orig_win) {
     return nccl_orig_win;
   }
 

--- a/comms/torchcomms/device/pipes/PipesDeviceBackend.cpp
+++ b/comms/torchcomms/device/pipes/PipesDeviceBackend.cpp
@@ -53,7 +53,7 @@ PipesDeviceBackend::Ptr PipesDeviceBackend::create_device_window(
     torch::comms::NcclxApi* nccl_api,
     torch::comms::CudaApi* cuda_api,
     const DeviceBackendConfig& config,
-    ncclWindow_t nccl_win,
+    NcclWin nccl_win,
     void* base,
     size_t size) {
   if (nccl_api == nullptr) {

--- a/comms/torchcomms/device/pipes/PipesDeviceBackend.hpp
+++ b/comms/torchcomms/device/pipes/PipesDeviceBackend.hpp
@@ -114,12 +114,21 @@ struct PipesDeviceBackend {
   //   - nccl_win:   NCCL window handle (ncclWindow_t from tensor_register)
   //   - base:       Window base pointer (local data buffer)
   //   - size:       Window size in bytes
+  // NcclWin is the NCCL host-side window handle type.
+  // When NCCL_RMA_SUPPORTED is defined, this is ncclWindow_t (ncclWindow*).
+  // Otherwise, it falls back to void* to match the NcclxWindow alias.
+#ifdef NCCL_RMA_SUPPORTED
+  using NcclWin = ncclWindow_t;
+#else
+  using NcclWin = void*;
+#endif
+
   static Ptr create_device_window(
       ncclComm_t nccl_comm,
       torch::comms::NcclxApi* nccl_api,
       torch::comms::CudaApi* cuda_api,
       const DeviceBackendConfig& config,
-      ncclWindow_t nccl_win,
+      NcclWin nccl_win,
       void* base,
       size_t size);
 
@@ -131,21 +140,19 @@ struct PipesDeviceBackend {
   static void register_extra_window(
       torch::comms::NcclxApi*,
       ncclComm_t,
-      ncclWindow_t*,
+      NcclWin*,
       void*,
       size_t) {}
 
   // No additional window to deregister for Pipes.
   static void
-  deregister_extra_window(torch::comms::NcclxApi*, ncclComm_t, ncclWindow_t*) {}
+  deregister_extra_window(torch::comms::NcclxApi*, ncclComm_t, NcclWin*) {}
 
   // Pipes deleter handles all cleanup via winDestroyDeviceWin.
   static void destroy_device_comm(Ptr&) {}
 
   // Pipes uses the regular ctran window for device window creation.
-  static ncclWindow_t select_device_win(
-      ncclWindow_t win,
-      ncclWindow_t /* nccl_orig_win */) {
+  static NcclWin select_device_win(NcclWin win, NcclWin /* nccl_orig_win */) {
     return win;
   }
 

--- a/comms/torchcomms/ncclx/NcclxApi.hpp
+++ b/comms/torchcomms/ncclx/NcclxApi.hpp
@@ -67,7 +67,9 @@ using NcclxWindowAttr = ncclWinAttr_t;
 using NcclxWindow = void*;
 using NcclxWindowAccessType = int;
 using NcclxWindowAttr = void*;
-constexpr int NCCL_WIN_DEFAULT = 0;
+#ifndef NCCL_WIN_DEFAULT
+#define NCCL_WIN_DEFAULT 0x00
+#endif
 #endif
 
 /**

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -2382,6 +2382,7 @@ std::shared_ptr<TorchCommBackend> TorchCommNCCLX::split(
       "{}::split::{}_{}_{}", name_, color, split_name, split_counter_++);
 
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+#ifdef NCCLX_CONFIG_SUPPORTED
   ncclx::Hints hints;
   config.hints = &hints;
   populateNcclConfig(config, options, commDesc);
@@ -2398,6 +2399,9 @@ std::shared_ptr<TorchCommBackend> TorchCommNCCLX::split(
     }
     hints.set("ncclx::splitGroupRanks", rankStr);
   }
+#else
+  populateNcclConfig(config, options, commDesc);
+#endif
 
   // Verify the correct CUDA device is set before calling ncclCommSplit.
   // NCCL expects the caller to have set the device matching the communicator.

--- a/comms/torchcomms/ncclx/TorchCommNCCLXBootstrap.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXBootstrap.cpp
@@ -25,6 +25,7 @@ const std::string kUniqueidXchgMethodAuto = "auto";
 const std::string kUniqueidXchgMethodTCPStore = "tcpstore";
 const std::string kUniqueidXchgMethodDefault = kUniqueidXchgMethodAuto;
 
+#ifdef NCCLX_CONFIG_SUPPORTED
 bool isFastInitEnable(const ncclx::Hints& hints) {
   std::string fastInitVal;
   if (hints.get("ncclx::fastInitMode", fastInitVal) == ncclSuccess &&
@@ -37,6 +38,7 @@ bool isFastInitEnable(const ncclx::Hints& hints) {
   }
   return std::string(env) == "ring_hybrid";
 }
+#endif
 
 } // namespace
 
@@ -219,7 +221,9 @@ void populateNcclConfig(
     ncclConfig_t& config,
     const CommOptions& options,
     const std::string& name) {
+#ifdef NCCLX_CONFIG_SUPPORTED
   auto* hints = static_cast<ncclx::Hints*>(config.hints);
+#endif
   constexpr std::string_view kNcclxPrefix = "ncclx::";
 
   // Iterate over the hints and set the corresponding fields.  Keys with
@@ -232,6 +236,7 @@ void populateNcclConfig(
   for (const auto& [key, val] : options.hints) {
     // NCCLx-specific fields -- pass via ncclx::Hints
     if (key.compare(0, kNcclxPrefix.size(), kNcclxPrefix) == 0) {
+#ifdef NCCLX_CONFIG_SUPPORTED
       if (key == "ncclx::commDesc") {
         throw std::invalid_argument(
             "ncclx::commDesc must not be set in hints; "
@@ -245,6 +250,11 @@ void populateNcclConfig(
       hints->set(key, val);
       TC_LOG(INFO, nullptr)
           << "[comm=" << name << "] Setting hint " << key << "=" << val;
+#else
+      TC_LOG(WARNING)
+          << "NCCLx hints are not supported in this NCCL version, ignoring '"
+          << key << "' for comm '" << name << "'";
+#endif
     }
     // Upstream NCCL config fields -- set directly on the config struct
     else if (kTorchCommLayerHints.count(key)) {
@@ -312,6 +322,7 @@ void populateNcclConfig(
   }
 }
 
+#ifdef NCCLX_CONFIG_SUPPORTED
 bool TorchCommNCCLXBootstrap::useFastInit(const ncclx::Hints& hints) {
   if (isFastInitEnable(hints)) {
     // Use raw dynamic_cast instead of c10::dynamic_intrusive_pointer_cast
@@ -336,6 +347,7 @@ bool TorchCommNCCLXBootstrap::useFastInit(const ncclx::Hints& hints) {
   }
   return false;
 }
+#endif
 
 ncclComm_t TorchCommNCCLXBootstrap::createNcclComm(
     const std::string& name,
@@ -349,9 +361,12 @@ ncclComm_t TorchCommNCCLXBootstrap::createNcclComm(
   createStore(name);
 
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+#ifdef NCCLX_CONFIG_SUPPORTED
   ncclx::Hints hints;
   config.hints = &hints;
+#endif
   populateNcclConfig(config, options, name);
+#ifdef NCCLX_CONFIG_SUPPORTED
   hints.set("ncclx::commDesc", name);
 
   if (useFastInit(hints)) {
@@ -359,6 +374,9 @@ ncclComm_t TorchCommNCCLXBootstrap::createNcclComm(
   } else {
     uniqueId = exchangeUniqueId();
   }
+#else
+  uniqueId = exchangeUniqueId();
+#endif
 
   ncclResult_t ncclErr = nccl_api_->commInitRankConfig(
       &nccl_comm, comm_size_, uniqueId, rank_, &config);

--- a/comms/torchcomms/ncclx/TorchCommNCCLXBootstrap.hpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXBootstrap.hpp
@@ -54,7 +54,9 @@ class TorchCommNCCLXBootstrap {
  private:
   ncclUniqueId exchangeUniqueId();
   void createStore(std::string_view name);
+#ifdef NCCLX_CONFIG_SUPPORTED
   bool useFastInit(const ncclx::Hints& hints);
+#endif
   void cleanupTCPStore(ncclComm_t nccl_comm);
 
  private:

--- a/comms/torchcomms/ncclx/TorchCommWindowNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommWindowNCCLX.cpp
@@ -320,6 +320,7 @@ c10::intrusive_ptr<TorchWork> TorchCommWindowNCCLX<Backend>::wait_signal(
 template <typename Backend>
 std::shared_ptr<TorchCommWindowAttr> TorchCommWindowNCCLX<Backend>::get_attr(
     int peerRank) {
+#ifdef NCCL_RMA_SUPPORTED
   checkWindowAndThrow();
   NcclxWindowAttr nccl_attr_raw = nullptr;
   CHECK_EQ(
@@ -343,6 +344,10 @@ std::shared_ptr<TorchCommWindowAttr> TorchCommWindowNCCLX<Backend>::get_attr(
       throw std::runtime_error("Unsupported NCCL window access type");
   }
   return attr;
+#else
+  throw std::runtime_error(
+      "Window attributes are not supported without NCCL_RMA_SUPPORTED");
+#endif
 }
 
 // =============================================================================

--- a/comms/torchcomms/ncclx/TorchCommWindowNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommWindowNCCLX.cpp
@@ -640,11 +640,18 @@ void TorchCommWindowNCCLX<Backend>::checkWindowAndThrow() const {
 
 #ifdef TORCHCOMMS_HAS_NCCL_DEVICE_API
 template class TorchCommWindowNCCLX<torchcomms::device::NCCLDeviceBackend>;
-#if defined(ENABLE_PIPES)
-template class TorchCommWindowNCCLX<torchcomms::device::PipesDeviceBackend>;
-#endif
 #else
 template class TorchCommWindowNCCLX<HostOnlyBackend>;
+#endif
+
+// Pipes instantiation is independent of the device API flag.
+// ENABLE_PIPES can be set without TORCHCOMMS_HAS_NCCL_DEVICE_API (e.g.,
+// NCCLX 2.27 CMake builds with ENABLE_PIPES=1). In that case, host-side
+// window operations (put, signal, wait_signal) work; device API methods
+// (get_device_window, register_local_buffer) fall back to the base class
+// default that throws "not yet supported".
+#if defined(ENABLE_PIPES)
+template class TorchCommWindowNCCLX<torchcomms::device::PipesDeviceBackend>;
 #endif
 
 } // namespace torch::comms

--- a/comms/torchcomms/triton/ir_include/nccl.h
+++ b/comms/torchcomms/triton/ir_include/nccl.h
@@ -29,7 +29,8 @@ typedef enum {
 /* Opaque handle to communicator */
 typedef struct ncclComm* ncclComm_t;
 
-/* Window type - pointer to ncclWindow_vidmem struct defined in core__types.h */
+/* Window/RMA types */
+#define NCCL_RMA_SUPPORTED
 struct ncclWindow_vidmem;
 typedef struct ncclWindow_vidmem* ncclWindow_t;
 


### PR DESCRIPTION
Summary:
The explicit template instantiation of `TorchCommWindowNCCLX<PipesDeviceBackend>` was nested inside `#ifdef TORCHCOMMS_HAS_NCCL_DEVICE_API`, but the type alias (`TorchCommWindowNCCLXPipes`) and the runtime window creation in `new_window()` are gated by `#if defined(ENABLE_PIPES)` only. This creates a mismatch when `ENABLE_PIPES=1` but `TORCHCOMMS_HAS_NCCL_DEVICE_API` is not set (e.g., NCCLX 2.27): the type exists and `new_window()` tries to instantiate it, but the linker can't find the symbols because the template was never explicitly instantiated.

In internal Buck builds this doesn't currently manifest because both flags are always enabled together — `ENABLE_PIPES` comes from `ctran_lib` via `torchcomm-device-pipes`, which is only a dependency when `has_ncclx_device_api()` returns true (NCCLX >= 2.28). However, in CMakeLists.txt builds (conda feedstock), `ENABLE_PIPES` is controlled independently via an environment variable, so it's possible to set `ENABLE_PIPES=1` with an NCCLX version that doesn't have device API headers.

Fix: Move the Pipes explicit template instantiation out of the `TORCHCOMMS_HAS_NCCL_DEVICE_API` guard so it's gated by `ENABLE_PIPES` only, matching the header and `new_window()` runtime usage. When device API is unavailable, host-side window operations (put, signal, wait_signal) still work; device API methods (get_device_window, register_local_buffer) fall back to the base class default that throws "not yet supported".

Broken MAST run: h100-6b4b53d83792-260408-1412_perception_v5g_tpp_800_TIER4_-wqtnkwmg

Reviewed By: lilyjanjigian

Differential Revision: D100887961


