### PR TITLE
Fix NVL domain tag collision in CtranTestBootstrap by creating isolated bootstrap for nvl domain

### DIFF
--- a/comms/common/bootstrap/IBootstrap.h
+++ b/comms/common/bootstrap/IBootstrap.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <memory>
 #include <stdexcept>
 #include <vector>
 
@@ -91,6 +92,23 @@ class IBootstrap {
       }
     }
     return folly::makeSemiFuture(0);
+  }
+
+  /**
+   * Create a new bootstrap instance whose send/recv operations are isolated
+   * from this one.
+   *
+   * For store-backed bootstraps (e.g. TcpStoreBootstrap), this creates a
+   * PrefixStore wrapper so that keys never collide with the original.
+   * For MPI bootstraps, this duplicates the communicator via MPI_Comm_dup
+   * so that tags on the new communicator are independent.
+   *
+   * Returns nullptr if isolation is not needed or not supported.
+   * Callers should fall back to the original bootstrap when nullptr is
+   * returned.
+   */
+  virtual std::unique_ptr<IBootstrap> duplicate() {
+    return nullptr;
   }
 };
 

--- a/comms/common/bootstrap/tests/MockBootstrap.h
+++ b/comms/common/bootstrap/tests/MockBootstrap.h
@@ -52,6 +52,7 @@ class MockBootstrap : public meta::comms::IBootstrap {
       broadcast,
       (void* buf, int len, int root, int rank, int nranks),
       (override));
+  MOCK_METHOD(std::unique_ptr<IBootstrap>, duplicate, (), (override));
 };
 
 } // namespace meta::comms::testing

--- a/comms/ctran/tests/bootstrap/CtranTestBootstrap.h
+++ b/comms/ctran/tests/bootstrap/CtranTestBootstrap.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <cassert>
 #include <cstdint>
 #include <memory>
 #include <unordered_map>
@@ -14,14 +15,24 @@ namespace ctran::testing {
 
 /**
  * Test-only ICtranBootstrap that wraps a single IBootstrap instance.
- * Global operations delegate directly; NVL-domain operations are implemented
- * via pairwise send/recv through the global bootstrap.
+ *
+ * Global collective operations (allGather, barrier, broadcast) and direct
+ * send/recv delegate to the wrapped bootstrap. NVL-domain operations are
+ * implemented via pairwise send/recv through a dedicated isolated bootstrap
+ * created via IBootstrap::duplicate(), ensuring complete send/recv
+ * key-space / communicator isolation from global operations.
  */
 class CtranTestBootstrap : public meta::comms::ICtranBootstrap {
  public:
   explicit CtranTestBootstrap(
       std::unique_ptr<meta::comms::IBootstrap> bootstrap)
-      : bootstrap_(std::move(bootstrap)) {}
+      : bootstrap_(std::move(bootstrap)),
+        nvlDomainBootstrap_(bootstrap_->duplicate()) {
+    assert(
+        nvlDomainBootstrap_ != nullptr &&
+        "IBootstrap::duplicate() must return a non-null bootstrap; "
+        "every bootstrap type in tests must implement duplicate()");
+  }
 
   // -- Global operations (delegated to bootstrap_) --
 
@@ -47,7 +58,7 @@ class CtranTestBootstrap : public meta::comms::ICtranBootstrap {
     return bootstrap_->broadcast(buf, len, root, rank, nranks);
   }
 
-  // -- NvlDomain operations (pairwise sendrecv via bootstrap_) --
+  // -- NvlDomain operations (pairwise send/recv via nvlDomainBootstrap_) --
 
   folly::SemiFuture<int> allGatherNvlDomain(
       void* buf,
@@ -66,20 +77,20 @@ class CtranTestBootstrap : public meta::comms::ICtranBootstrap {
           static_cast<char*>(buf) + static_cast<size_t>(nvlLocalRank) * len;
       auto* peerChunk = static_cast<char*>(buf) + static_cast<size_t>(nr) * len;
       if (myGlobalRank < peer) {
-        auto rc = bootstrap_->send(myChunk, len, peer, tag).get();
+        auto rc = nvlDomainBootstrap_->send(myChunk, len, peer, tag).get();
         if (rc != 0) {
           return folly::makeSemiFuture(rc);
         }
-        rc = bootstrap_->recv(peerChunk, len, peer, tag).get();
+        rc = nvlDomainBootstrap_->recv(peerChunk, len, peer, tag).get();
         if (rc != 0) {
           return folly::makeSemiFuture(rc);
         }
       } else {
-        auto rc = bootstrap_->recv(peerChunk, len, peer, tag).get();
+        auto rc = nvlDomainBootstrap_->recv(peerChunk, len, peer, tag).get();
         if (rc != 0) {
           return folly::makeSemiFuture(rc);
         }
-        rc = bootstrap_->send(myChunk, len, peer, tag).get();
+        rc = nvlDomainBootstrap_->send(myChunk, len, peer, tag).get();
         if (rc != 0) {
           return folly::makeSemiFuture(rc);
         }
@@ -101,20 +112,22 @@ class CtranTestBootstrap : public meta::comms::ICtranBootstrap {
       int peer = nvlRankToCommRank[nr];
       int tag = nextTag(peer);
       if (myGlobalRank < peer) {
-        auto rc = bootstrap_->send(&dummy, sizeof(dummy), peer, tag).get();
+        auto rc =
+            nvlDomainBootstrap_->send(&dummy, sizeof(dummy), peer, tag).get();
         if (rc != 0) {
           return folly::makeSemiFuture(rc);
         }
-        rc = bootstrap_->recv(&dummy, sizeof(dummy), peer, tag).get();
+        rc = nvlDomainBootstrap_->recv(&dummy, sizeof(dummy), peer, tag).get();
         if (rc != 0) {
           return folly::makeSemiFuture(rc);
         }
       } else {
-        auto rc = bootstrap_->recv(&dummy, sizeof(dummy), peer, tag).get();
+        auto rc =
+            nvlDomainBootstrap_->recv(&dummy, sizeof(dummy), peer, tag).get();
         if (rc != 0) {
           return folly::makeSemiFuture(rc);
         }
-        rc = bootstrap_->send(&dummy, sizeof(dummy), peer, tag).get();
+        rc = nvlDomainBootstrap_->send(&dummy, sizeof(dummy), peer, tag).get();
         if (rc != 0) {
           return folly::makeSemiFuture(rc);
         }
@@ -124,15 +137,14 @@ class CtranTestBootstrap : public meta::comms::ICtranBootstrap {
   }
 
  private:
-  // IBootstrap internally uses (peer, tag) as the key to match send/recv
-  // pairs. By maintaining a per-peer monotonically increasing tag, concurrent
-  // communications across different subgroups (intra-node, NVL-domain) are
-  // guaranteed not to mismatch, since each peer pair always gets a unique tag.
+  // Per-peer monotonically increasing tag for unique send/recv keys used in
+  // nvldomain functions.
   int nextTag(int peer) {
     return peerTags_[peer]++;
   }
 
   std::unique_ptr<meta::comms::IBootstrap> bootstrap_;
+  std::unique_ptr<meta::comms::IBootstrap> nvlDomainBootstrap_;
   std::unordered_map<int, int> peerTags_;
 };
 

--- a/comms/ctran/tests/bootstrap/CtranTestBootstrapTest.cpp
+++ b/comms/ctran/tests/bootstrap/CtranTestBootstrapTest.cpp
@@ -71,6 +71,10 @@ class InProcessSendRecvBootstrap : public meta::comms::IBootstrap {
     return folly::makeSemiFuture(0);
   }
 
+  std::unique_ptr<meta::comms::IBootstrap> duplicate() override {
+    return std::make_unique<InProcessSendRecvBootstrap>(rank_, store_);
+  }
+
  private:
   int rank_;
   std::shared_ptr<SharedStore> store_;
@@ -84,12 +88,15 @@ class InProcessSendRecvBootstrap : public meta::comms::IBootstrap {
 
 using meta::comms::testing::MockBootstrap;
 using ::testing::_;
+using ::testing::ByMove;
 using ::testing::Return;
 
 TEST(CtranTestBootstrapDelegation, AllGatherDelegates) {
   auto mock = std::make_unique<MockBootstrap>();
   auto* mockPtr = mock.get();
 
+  EXPECT_CALL(*mockPtr, duplicate())
+      .WillOnce(Return(ByMove(std::make_unique<MockBootstrap>())));
   EXPECT_CALL(*mockPtr, allGather(_, 10, 0, 2))
       .WillOnce(Return(folly::makeSemiFuture(0)));
 
@@ -103,6 +110,8 @@ TEST(CtranTestBootstrapDelegation, BarrierDelegates) {
   auto mock = std::make_unique<MockBootstrap>();
   auto* mockPtr = mock.get();
 
+  EXPECT_CALL(*mockPtr, duplicate())
+      .WillOnce(Return(ByMove(std::make_unique<MockBootstrap>())));
   EXPECT_CALL(*mockPtr, barrier(1, 3))
       .WillOnce(Return(folly::makeSemiFuture(0)));
 
@@ -114,6 +123,9 @@ TEST(CtranTestBootstrapDelegation, BarrierDelegates) {
 TEST(CtranTestBootstrapDelegation, SendDelegates) {
   auto mock = std::make_unique<MockBootstrap>();
   auto* mockPtr = mock.get();
+
+  EXPECT_CALL(*mockPtr, duplicate())
+      .WillOnce(Return(ByMove(std::make_unique<MockBootstrap>())));
 
   char data[] = "hello";
   EXPECT_CALL(*mockPtr, send(data, 5, 2, 99))
@@ -128,6 +140,9 @@ TEST(CtranTestBootstrapDelegation, RecvDelegates) {
   auto mock = std::make_unique<MockBootstrap>();
   auto* mockPtr = mock.get();
 
+  EXPECT_CALL(*mockPtr, duplicate())
+      .WillOnce(Return(ByMove(std::make_unique<MockBootstrap>())));
+
   char buf[8] = {};
   EXPECT_CALL(*mockPtr, recv(buf, 8, 3, 42))
       .WillOnce(Return(folly::makeSemiFuture(0)));
@@ -140,6 +155,9 @@ TEST(CtranTestBootstrapDelegation, RecvDelegates) {
 TEST(CtranTestBootstrapDelegation, BroadcastDelegates) {
   auto mock = std::make_unique<MockBootstrap>();
   auto* mockPtr = mock.get();
+
+  EXPECT_CALL(*mockPtr, duplicate())
+      .WillOnce(Return(ByMove(std::make_unique<MockBootstrap>())));
 
   char buf[4] = {};
   EXPECT_CALL(*mockPtr, broadcast(buf, 4, 0, 1, 3))
@@ -155,10 +173,13 @@ TEST(CtranTestBootstrapDelegation, BroadcastDelegates) {
 // ============================================================================
 
 TEST(CtranTestBootstrapErrors, SendErrorPropagatesInAllGatherNvlDomain) {
-  auto mock = std::make_unique<MockBootstrap>();
-  auto* mockPtr = mock.get();
+  auto nvlMock = std::make_unique<MockBootstrap>();
+  auto* nvlMockPtr = nvlMock.get();
 
-  EXPECT_CALL(*mockPtr, send(_, _, _, _))
+  auto mock = std::make_unique<MockBootstrap>();
+  EXPECT_CALL(*mock, duplicate()).WillOnce(Return(ByMove(std::move(nvlMock))));
+
+  EXPECT_CALL(*nvlMockPtr, send(_, _, _, _))
       .WillOnce(Return(folly::makeSemiFuture(42)));
 
   ctran::testing::CtranTestBootstrap uut(std::move(mock));
@@ -169,11 +190,14 @@ TEST(CtranTestBootstrapErrors, SendErrorPropagatesInAllGatherNvlDomain) {
 }
 
 TEST(CtranTestBootstrapErrors, RecvErrorPropagatesInAllGatherNvlDomain) {
+  auto nvlMock = std::make_unique<MockBootstrap>();
+  auto* nvlMockPtr = nvlMock.get();
+
   auto mock = std::make_unique<MockBootstrap>();
-  auto* mockPtr = mock.get();
+  EXPECT_CALL(*mock, duplicate()).WillOnce(Return(ByMove(std::move(nvlMock))));
 
   // rank 1 (global 1) receives first from rank 0 (global 0) since 1 > 0
-  EXPECT_CALL(*mockPtr, recv(_, _, _, _))
+  EXPECT_CALL(*nvlMockPtr, recv(_, _, _, _))
       .WillOnce(Return(folly::makeSemiFuture(77)));
 
   ctran::testing::CtranTestBootstrap uut(std::move(mock));
@@ -225,7 +249,153 @@ void runAllGatherNvlDomainTest(
   for (int r = 0; r < nRanks; ++r) {
     for (int s = 0; s < nRanks; ++s) {
       EXPECT_EQ(results[r][s], globalRanks[s] + 1000)
-          << "rank " << r << " slot " << s;
+          << "rank " << r << " expected globalRank[" << s << "]+1000";
+    }
+  }
+}
+
+// ============================================================================
+// Send/recv and NVL domain isolation — both use tag 0, must not collide
+// ============================================================================
+
+TEST(
+    CtranTestBootstrapIsolation,
+    DirectSendRecvAndNvlDomainWithSameTagAreIndependent) {
+  // This test reproduces the original bug: NVL domain operations and direct
+  // send/recv both use tag=0. Without isolation, the second operation would
+  // see stale data from the first. With duplicate(), each goes through
+  // a different bootstrap so their keys/messages never collide.
+  constexpr int kNRanks = 2;
+  const std::vector<int> globalRanks = {0, 1};
+  const int len = static_cast<int>(sizeof(int));
+
+  auto store = std::make_shared<SharedStore>();
+
+  std::vector<std::unique_ptr<ctran::testing::CtranTestBootstrap>> bootstraps(
+      kNRanks);
+  for (int r = 0; r < kNRanks; ++r) {
+    bootstraps[r] = std::make_unique<ctran::testing::CtranTestBootstrap>(
+        std::make_unique<InProcessSendRecvBootstrap>(globalRanks[r], store));
+  }
+
+  // Round 1: NVL domain allGather (internally uses tag=0 on the isolated
+  // bootstrap).
+  std::vector<std::vector<int>> nvlResults(
+      kNRanks, std::vector<int>(kNRanks, -1));
+  {
+    std::vector<std::thread> threads;
+    for (int r = 0; r < kNRanks; ++r) {
+      threads.emplace_back([&, r] {
+        nvlResults[r][r] = r + 100;
+        auto rc = bootstraps[r]
+                      ->allGatherNvlDomain(
+                          nvlResults[r].data(), len, r, kNRanks, globalRanks)
+                      .get();
+        EXPECT_EQ(rc, 0) << "NVL allGather rank " << r;
+      });
+    }
+    for (auto& t : threads) {
+      t.join();
+    }
+  }
+
+  // Round 2: Direct send/recv with tag=0 — the same tag that NVL domain
+  // used internally. Without isolation this would collide.
+  constexpr int kDirectTag = 0;
+  int sendVal = 42;
+  int recvVal = -1;
+  {
+    std::vector<std::thread> threads;
+    // rank 0 sends to rank 1
+    threads.emplace_back([&] {
+      auto rc = bootstraps[0]->send(&sendVal, len, 1, kDirectTag).get();
+      EXPECT_EQ(rc, 0) << "direct send failed";
+    });
+    // rank 1 receives from rank 0
+    threads.emplace_back([&] {
+      auto rc = bootstraps[1]->recv(&recvVal, len, 0, kDirectTag).get();
+      EXPECT_EQ(rc, 0) << "direct recv failed";
+    });
+    for (auto& t : threads) {
+      t.join();
+    }
+  }
+
+  // Verify NVL domain results are correct
+  for (int r = 0; r < kNRanks; ++r) {
+    for (int s = 0; s < kNRanks; ++s) {
+      EXPECT_EQ(nvlResults[r][s], s + 100)
+          << "NVL result rank " << r << " slot " << s;
+    }
+  }
+
+  // Verify direct send/recv got the right value (not stale NVL data)
+  EXPECT_EQ(recvVal, 42);
+}
+
+TEST(
+    CtranTestBootstrapIsolation,
+    InterleavedDirectSendRecvAndNvlDomainAreIndependent) {
+  // Interleave direct send/recv and NVL domain operations multiple times
+  // to confirm they never interfere, even when both use tag=0 repeatedly.
+  constexpr int kNRanks = 2;
+  const std::vector<int> globalRanks = {0, 1};
+  const int len = static_cast<int>(sizeof(int));
+
+  auto store = std::make_shared<SharedStore>();
+
+  std::vector<std::unique_ptr<ctran::testing::CtranTestBootstrap>> bootstraps(
+      kNRanks);
+  for (int r = 0; r < kNRanks; ++r) {
+    bootstraps[r] = std::make_unique<ctran::testing::CtranTestBootstrap>(
+        std::make_unique<InProcessSendRecvBootstrap>(globalRanks[r], store));
+  }
+
+  constexpr int kRounds = 3;
+  for (int round = 0; round < kRounds; ++round) {
+    // Direct send/recv with tag=0
+    int sendVal = round * 10;
+    int recvVal = -1;
+    {
+      std::vector<std::thread> threads;
+      threads.emplace_back([&] {
+        auto rc = bootstraps[0]->send(&sendVal, len, 1, 0).get();
+        EXPECT_EQ(rc, 0);
+      });
+      threads.emplace_back([&] {
+        auto rc = bootstraps[1]->recv(&recvVal, len, 0, 0).get();
+        EXPECT_EQ(rc, 0);
+      });
+      for (auto& t : threads) {
+        t.join();
+      }
+    }
+    EXPECT_EQ(recvVal, round * 10) << "direct send/recv round " << round;
+
+    // NVL domain allGather (internally uses tag=0 on isolated bootstrap)
+    std::vector<std::vector<int>> nvlResults(
+        kNRanks, std::vector<int>(kNRanks, -1));
+    {
+      std::vector<std::thread> threads;
+      for (int r = 0; r < kNRanks; ++r) {
+        threads.emplace_back([&, r] {
+          nvlResults[r][r] = round * 100 + r;
+          auto rc = bootstraps[r]
+                        ->allGatherNvlDomain(
+                            nvlResults[r].data(), len, r, kNRanks, globalRanks)
+                        .get();
+          EXPECT_EQ(rc, 0);
+        });
+      }
+      for (auto& t : threads) {
+        t.join();
+      }
+    }
+    for (int r = 0; r < kNRanks; ++r) {
+      for (int s = 0; s < kNRanks; ++s) {
+        EXPECT_EQ(nvlResults[r][s], round * 100 + s)
+            << "NVL round " << round << " rank " << r << " slot " << s;
+      }
     }
   }
 }


### PR DESCRIPTION
Summary:
D98025086 introduced CtranTestBootstrap which implements NVL domain
operations (allGatherNvlDomain, barrierNvlDomain) via pairwise send/recv
with auto-incrementing tags starting from tag=0.

During ctranInit(), CtranAlgo::SharedResource calls these NVL domain
operations, which write data to TcpStoreBootstrap under a fixed key
keyed by (sender, receiver, tag). Later, test code calling
bootstrap_->send()/recv() with tag=0 directly (e.g. sockSend/sockRecv
in CtranIbDistUT) collides with these NVL domain keys.

Since TcpStoreBootstrap::recv does store_->wait(key) followed by
store_->get(key), and the key already exists from the NVL domain
operation, wait() returns immediately with stale NVL data (wrong size),
causing a data size mismatch and test failure.

**Fix**: add IBootstrap::duplicate() — a virtual method that each bootstrap type implements to create a new instance with isolated send/recv namespace:

- TcpStoreBootstrap: wraps the underlying store in c10d::PrefixStore so all keys are prefixed and never collide with the original bootstrap.
- MpiBootstrap: duplicates the communicator via MPI_Comm_dup so tags on the new communicator are independent.
- Default: returns nullptr (callers must override).

CtranTestBootstrap calls `duplicate()` in its constructor and asserts the result is non-null. NVL-domain operations use the isolated bootstrap for pairwise send/recv, while global operations (allGather, barrier, send, recv, broadcast) delegate to the primary bootstrap. No tag restrictions remain.

**New tests added**:

- DirectSendRecvAndNvlDomainWithSameTagAreIndependent: NVL-domain allGather followed by direct send/recv with tag=0 — confirms no collision.
- InterleavedDirectSendRecvAndNvlDomainAreIndependent: 3 rounds of interleaved direct send/recv and NVL-domain allGather, both using tag=0 — confirms repeated operations never interfere.

Reviewed By: minsii

Differential Revision: D98649856


