### PR TITLE
Add Python backend registration for custom collectives (#2080)

### DIFF
--- a/comms/torchcomms/PyTorchCommBackend.hpp
+++ b/comms/torchcomms/PyTorchCommBackend.hpp
@@ -1,0 +1,197 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <comms/torchcomms/TorchCommBackend.hpp>
+#include <comms/torchcomms/TorchWork.hpp>
+
+namespace py = pybind11;
+
+namespace torch::comms {
+
+class PyTorchWork : public TorchWork {
+ public:
+  explicit PyTorchWork(py::object py_work);
+  ~PyTorchWork() override = default;
+  void wait() override;
+  void publicSetStatus(WorkStatus status) {
+    setStatus(status);
+  }
+
+ private:
+  py::object py_work_;
+};
+
+class PyTorchCommBackend : public TorchCommBackend {
+ public:
+  using TorchCommBackend::TorchCommBackend;
+
+  void setPySelf(py::object self) {
+    py_self_ = std::move(self);
+  }
+
+  static c10::intrusive_ptr<TorchWork> wrapPyWork(py::object py_result);
+
+  void init(
+      at::Device device,
+      const std::string& name,
+      const CommOptions& options) override {
+    device_ = device;
+    options_ = options;
+    PYBIND11_OVERRIDE_PURE(void, TorchCommBackend, init, device, name, options);
+  }
+
+  void finalize() override {
+    PYBIND11_OVERRIDE_PURE(void, TorchCommBackend, finalize);
+  }
+
+  int getRank() const override {
+    PYBIND11_OVERRIDE_PURE_NAME(int, TorchCommBackend, "get_rank", getRank);
+  }
+
+  int getSize() const override {
+    PYBIND11_OVERRIDE_PURE_NAME(int, TorchCommBackend, "get_size", getSize);
+  }
+
+  std::string_view getBackendName() const override;
+  std::string_view getCommName() const override;
+
+  const CommOptions& getOptions() const override {
+    return options_;
+  }
+  const at::Device& getDevice() const override {
+    return device_;
+  }
+
+  c10::intrusive_ptr<TorchWork> send(
+      const at::Tensor& tensor,
+      int dst,
+      bool async_op,
+      const SendOptions& options) override;
+
+  c10::intrusive_ptr<TorchWork> recv(
+      at::Tensor& tensor,
+      int src,
+      bool async_op,
+      const RecvOptions& options) override;
+
+  c10::intrusive_ptr<TorchWork> batch_op_issue(
+      const std::vector<BatchSendRecv::P2POp>& ops,
+      bool async_op,
+      const BatchP2POptions& options) override;
+
+  c10::intrusive_ptr<TorchWork> broadcast(
+      at::Tensor& tensor,
+      int root,
+      bool async_op,
+      const BroadcastOptions& options) override;
+
+  c10::intrusive_ptr<TorchWork> all_reduce(
+      at::Tensor& tensor,
+      const ReduceOp& op,
+      bool async_op,
+      const AllReduceOptions& options) override;
+
+  c10::intrusive_ptr<TorchWork> reduce(
+      const at::Tensor& tensor,
+      int root,
+      const ReduceOp& op,
+      bool async_op,
+      const ReduceOptions& options) override;
+
+  c10::intrusive_ptr<TorchWork> all_gather(
+      const std::vector<at::Tensor>& tensor_list,
+      const at::Tensor& tensor,
+      bool async_op,
+      const AllGatherOptions& options) override;
+
+  c10::intrusive_ptr<TorchWork> all_gather_v(
+      const std::vector<at::Tensor>& tensor_list,
+      const at::Tensor& tensor,
+      bool async_op,
+      const AllGatherOptions& options) override;
+
+  c10::intrusive_ptr<TorchWork> all_gather_single(
+      at::Tensor& output,
+      const at::Tensor& input,
+      bool async_op,
+      const AllGatherSingleOptions& options) override;
+
+  c10::intrusive_ptr<TorchWork> reduce_scatter(
+      at::Tensor& output,
+      const std::vector<at::Tensor>& input_list,
+      const ReduceOp& op,
+      bool async_op,
+      const ReduceScatterOptions& options) override;
+
+  c10::intrusive_ptr<TorchWork> reduce_scatter_v(
+      at::Tensor& output,
+      const std::vector<at::Tensor>& input_list,
+      const ReduceOp& op,
+      bool async_op,
+      const ReduceScatterOptions& options) override;
+
+  c10::intrusive_ptr<TorchWork> reduce_scatter_single(
+      at::Tensor& output,
+      const at::Tensor& input,
+      const ReduceOp& op,
+      bool async_op,
+      const ReduceScatterSingleOptions& options) override;
+
+  c10::intrusive_ptr<TorchWork> all_to_all_single(
+      at::Tensor& output,
+      const at::Tensor& input,
+      bool async_op,
+      const AllToAllSingleOptions& options) override;
+
+  c10::intrusive_ptr<TorchWork> all_to_all_v_single(
+      at::Tensor& output,
+      const at::Tensor& input,
+      const std::vector<uint64_t>& output_split_sizes,
+      const std::vector<uint64_t>& input_split_sizes,
+      bool async_op,
+      const AllToAllvSingleOptions& options) override;
+
+  c10::intrusive_ptr<TorchWork> all_to_all(
+      const std::vector<at::Tensor>& output_tensor_list,
+      const std::vector<at::Tensor>& input_tensor_list,
+      bool async_op,
+      const AllToAllOptions& options) override;
+
+  c10::intrusive_ptr<TorchWork> barrier(
+      bool async_op,
+      const BarrierOptions& options) override;
+
+  c10::intrusive_ptr<TorchWork> scatter(
+      at::Tensor& output_tensor,
+      const std::vector<at::Tensor>& input_tensor_list,
+      int root,
+      bool async_op,
+      const ScatterOptions& options) override;
+
+  c10::intrusive_ptr<TorchWork> gather(
+      const std::vector<at::Tensor>& output_tensor_list,
+      const at::Tensor& input_tensor,
+      int root,
+      bool async_op,
+      const GatherOptions& options) override;
+
+  std::shared_ptr<TorchCommBackend> split(
+      const std::vector<int>& ranks,
+      const std::string& name,
+      const CommOptions& options) override;
+
+ private:
+  py::object py_self_;
+  mutable std::string backend_name_;
+  mutable std::string comm_name_;
+  CommOptions options_;
+  at::Device device_{at::kCPU};
+};
+
+void initPyBackendBindings(py::module_& m);
+
+} // namespace torch::comms

--- a/comms/torchcomms/TorchCommBackendPy.cpp
+++ b/comms/torchcomms/TorchCommBackendPy.cpp
@@ -1,0 +1,336 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/torchcomms/PyTorchCommBackend.hpp"
+
+#include <pybind11/chrono.h>
+#include <pybind11/stl.h>
+#include <torch/csrc/utils/pybind.h>
+
+#include "comms/torchcomms/TorchCommFactory.hpp"
+
+namespace torch::comms {
+
+// --- PyTorchWork ---
+
+PyTorchWork::PyTorchWork(py::object py_work) : py_work_(std::move(py_work)) {
+  setStatus(WorkStatus::INPROGRESS);
+}
+
+void PyTorchWork::wait() {
+  py::gil_scoped_acquire gil;
+  py_work_.attr("wait")();
+  setStatus(WorkStatus::COMPLETED);
+}
+
+// --- PyTorchCommBackend ---
+
+c10::intrusive_ptr<TorchWork> PyTorchCommBackend::wrapPyWork(
+    py::object py_result) {
+  if (py_result.is_none()) {
+    return c10::make_intrusive<TorchWorkCompleted>();
+  }
+  return c10::make_intrusive<PyTorchWork>(std::move(py_result));
+}
+
+std::string_view PyTorchCommBackend::getBackendName() const {
+  py::gil_scoped_acquire gil;
+  auto override = py::get_override(
+      static_cast<const TorchCommBackend*>(this), "get_backend_name");
+  if (override) {
+    backend_name_ = override().cast<std::string>();
+    return backend_name_;
+  }
+  py::pybind11_fail(
+      "Tried to call pure virtual function \"TorchCommBackend::get_backend_name\"");
+}
+
+std::string_view PyTorchCommBackend::getCommName() const {
+  py::gil_scoped_acquire gil;
+  auto override = py::get_override(
+      static_cast<const TorchCommBackend*>(this), "get_comm_name");
+  if (override) {
+    comm_name_ = override().cast<std::string>();
+    return comm_name_;
+  }
+  py::pybind11_fail(
+      "Tried to call pure virtual function \"TorchCommBackend::get_comm_name\"");
+}
+
+#define COLLECTIVE_OVERRIDE(method_name, ...)                                   \
+  do {                                                                          \
+    py::gil_scoped_acquire gil;                                                 \
+    auto override = py::get_override(                                           \
+        static_cast<const TorchCommBackend*>(this), #method_name);              \
+    if (override) {                                                             \
+      return wrapPyWork(override(__VA_ARGS__));                                 \
+    }                                                                           \
+    py::pybind11_fail(                                                          \
+        "Tried to call pure virtual function \"TorchCommBackend::" #method_name \
+        "\"");                                                                  \
+  } while (0)
+
+c10::intrusive_ptr<TorchWork> PyTorchCommBackend::send(
+    const at::Tensor& tensor,
+    int dst,
+    bool async_op,
+    const SendOptions& /*options*/) {
+  COLLECTIVE_OVERRIDE(send, tensor, dst, async_op);
+}
+
+c10::intrusive_ptr<TorchWork> PyTorchCommBackend::recv(
+    at::Tensor& tensor,
+    int src,
+    bool async_op,
+    const RecvOptions& /*options*/) {
+  COLLECTIVE_OVERRIDE(recv, tensor, src, async_op);
+}
+
+c10::intrusive_ptr<TorchWork> PyTorchCommBackend::batch_op_issue(
+    const std::vector<BatchSendRecv::P2POp>& /*ops*/,
+    bool /*async_op*/,
+    const BatchP2POptions& /*options*/) {
+  throw std::logic_error(
+      "[PyTorchCommBackend]: batch_op_issue not implemented for Python backends");
+}
+
+c10::intrusive_ptr<TorchWork> PyTorchCommBackend::broadcast(
+    at::Tensor& tensor,
+    int root,
+    bool async_op,
+    const BroadcastOptions& /*options*/) {
+  COLLECTIVE_OVERRIDE(broadcast, tensor, root, async_op);
+}
+
+c10::intrusive_ptr<TorchWork> PyTorchCommBackend::all_reduce(
+    at::Tensor& tensor,
+    const ReduceOp& op,
+    bool async_op,
+    const AllReduceOptions& /*options*/) {
+  COLLECTIVE_OVERRIDE(all_reduce, tensor, op, async_op);
+}
+
+c10::intrusive_ptr<TorchWork> PyTorchCommBackend::reduce(
+    const at::Tensor& tensor,
+    int root,
+    const ReduceOp& op,
+    bool async_op,
+    const ReduceOptions& /*options*/) {
+  COLLECTIVE_OVERRIDE(reduce, tensor, root, op, async_op);
+}
+
+c10::intrusive_ptr<TorchWork> PyTorchCommBackend::all_gather(
+    const std::vector<at::Tensor>& tensor_list,
+    const at::Tensor& tensor,
+    bool async_op,
+    const AllGatherOptions& /*options*/) {
+  COLLECTIVE_OVERRIDE(all_gather, tensor_list, tensor, async_op);
+}
+
+c10::intrusive_ptr<TorchWork> PyTorchCommBackend::all_gather_v(
+    const std::vector<at::Tensor>& tensor_list,
+    const at::Tensor& tensor,
+    bool async_op,
+    const AllGatherOptions& /*options*/) {
+  COLLECTIVE_OVERRIDE(all_gather_v, tensor_list, tensor, async_op);
+}
+
+c10::intrusive_ptr<TorchWork> PyTorchCommBackend::all_gather_single(
+    at::Tensor& output,
+    const at::Tensor& input,
+    bool async_op,
+    const AllGatherSingleOptions& /*options*/) {
+  COLLECTIVE_OVERRIDE(all_gather_single, output, input, async_op);
+}
+
+c10::intrusive_ptr<TorchWork> PyTorchCommBackend::reduce_scatter(
+    at::Tensor& output,
+    const std::vector<at::Tensor>& input_list,
+    const ReduceOp& op,
+    bool async_op,
+    const ReduceScatterOptions& /*options*/) {
+  COLLECTIVE_OVERRIDE(reduce_scatter, output, input_list, op, async_op);
+}
+
+c10::intrusive_ptr<TorchWork> PyTorchCommBackend::reduce_scatter_v(
+    at::Tensor& output,
+    const std::vector<at::Tensor>& input_list,
+    const ReduceOp& op,
+    bool async_op,
+    const ReduceScatterOptions& /*options*/) {
+  COLLECTIVE_OVERRIDE(reduce_scatter_v, output, input_list, op, async_op);
+}
+
+c10::intrusive_ptr<TorchWork> PyTorchCommBackend::reduce_scatter_single(
+    at::Tensor& output,
+    const at::Tensor& input,
+    const ReduceOp& op,
+    bool async_op,
+    const ReduceScatterSingleOptions& /*options*/) {
+  COLLECTIVE_OVERRIDE(reduce_scatter_single, output, input, op, async_op);
+}
+
+c10::intrusive_ptr<TorchWork> PyTorchCommBackend::all_to_all_single(
+    at::Tensor& output,
+    const at::Tensor& input,
+    bool async_op,
+    const AllToAllSingleOptions& /*options*/) {
+  COLLECTIVE_OVERRIDE(all_to_all_single, output, input, async_op);
+}
+
+c10::intrusive_ptr<TorchWork> PyTorchCommBackend::all_to_all_v_single(
+    at::Tensor& output,
+    const at::Tensor& input,
+    const std::vector<uint64_t>& output_split_sizes,
+    const std::vector<uint64_t>& input_split_sizes,
+    bool async_op,
+    const AllToAllvSingleOptions& /*options*/) {
+  COLLECTIVE_OVERRIDE(
+      all_to_all_v_single,
+      output,
+      input,
+      output_split_sizes,
+      input_split_sizes,
+      async_op);
+}
+
+c10::intrusive_ptr<TorchWork> PyTorchCommBackend::all_to_all(
+    const std::vector<at::Tensor>& output_tensor_list,
+    const std::vector<at::Tensor>& input_tensor_list,
+    bool async_op,
+    const AllToAllOptions& /*options*/) {
+  COLLECTIVE_OVERRIDE(
+      all_to_all, output_tensor_list, input_tensor_list, async_op);
+}
+
+c10::intrusive_ptr<TorchWork> PyTorchCommBackend::barrier(
+    bool async_op,
+    const BarrierOptions& /*options*/) {
+  COLLECTIVE_OVERRIDE(barrier, async_op);
+}
+
+c10::intrusive_ptr<TorchWork> PyTorchCommBackend::scatter(
+    at::Tensor& output_tensor,
+    const std::vector<at::Tensor>& input_tensor_list,
+    int root,
+    bool async_op,
+    const ScatterOptions& /*options*/) {
+  COLLECTIVE_OVERRIDE(
+      scatter, output_tensor, input_tensor_list, root, async_op);
+}
+
+c10::intrusive_ptr<TorchWork> PyTorchCommBackend::gather(
+    const std::vector<at::Tensor>& output_tensor_list,
+    const at::Tensor& input_tensor,
+    int root,
+    bool async_op,
+    const GatherOptions& /*options*/) {
+  COLLECTIVE_OVERRIDE(gather, output_tensor_list, input_tensor, root, async_op);
+}
+
+#undef COLLECTIVE_OVERRIDE
+
+std::shared_ptr<TorchCommBackend> PyTorchCommBackend::split(
+    const std::vector<int>& ranks,
+    const std::string& name,
+    const CommOptions& options) {
+  py::gil_scoped_acquire gil;
+  auto override =
+      py::get_override(static_cast<const TorchCommBackend*>(this), "split");
+  if (override) {
+    py::object py_result = override(ranks, name, options);
+    auto result = py_result.cast<std::shared_ptr<TorchCommBackend>>();
+    auto* py_backend = dynamic_cast<PyTorchCommBackend*>(result.get());
+    if (py_backend) {
+      py_backend->setPySelf(py_result);
+    }
+    return result;
+  }
+  py::pybind11_fail(
+      "Tried to call pure virtual function \"TorchCommBackend::split\"");
+}
+
+// --- Pybind bindings ---
+
+void initPyBackendBindings(py::module_& m) {
+  m.def(
+      "_is_backend_registered",
+      [](const std::string& name) {
+        return TorchCommFactory::get().is_backend_registered(name);
+      },
+      R"(
+Check if a backend is already registered.
+
+Args:
+    name: The backend name to check.
+
+Returns:
+    True if the backend is registered, False otherwise.
+      )",
+      py::arg("name"));
+
+  m.def(
+      "register_backend",
+      [](const std::string& name, py::object py_backend_class) {
+        auto factory =
+            [py_backend_class]() -> std::shared_ptr<TorchCommBackend> {
+          py::gil_scoped_acquire gil;
+          py::object instance = py_backend_class();
+          auto ptr = instance.cast<std::shared_ptr<TorchCommBackend>>();
+          auto* py_backend = dynamic_cast<PyTorchCommBackend*>(ptr.get());
+          if (py_backend) {
+            py_backend->setPySelf(instance);
+          }
+          return ptr;
+        };
+        TorchCommFactory::get().register_backend(name, factory);
+      },
+      py::arg("name"),
+      py::arg("backend_class"),
+      R"(Register a Python class as a TorchComm backend.
+
+The Python class must inherit from TorchCommBackend and override the required
+methods:
+
+    class MyBackend(torchcomms.TorchCommBackend):
+        def __init__(self):
+            super().__init__()
+
+        def init(self, device, name, options):
+            self.rank = 0
+            self.size = 1
+
+        def finalize(self):
+            pass
+
+        def get_rank(self):
+            return self.rank
+
+        def get_size(self):
+            return self.size
+
+        def get_backend_name(self):
+            return "my_backend"
+
+        def get_comm_name(self):
+            return "my_comm"
+
+        def all_reduce(self, tensor, op, async_op):
+            return None  # synchronous no-op
+
+        # ... implement other methods ...
+
+    torchcomms.register_backend("my_backend", MyBackend)
+    comm = torchcomms.new_comm("my_backend", device, "my_comm")
+
+Each collective method should return None for synchronous completion, or an
+object with a wait() method for asynchronous operations.
+
+Args:
+    name: Backend name used in torchcomms.new_comm(backend=name, ...)
+    backend_class: A Python class (not instance) that inherits from
+        TorchCommBackend and will be instantiated each time a new
+        communicator is created.
+      )");
+}
+
+} // namespace torch::comms

--- a/comms/torchcomms/TorchCommFactory.cpp
+++ b/comms/torchcomms/TorchCommFactory.cpp
@@ -159,13 +159,18 @@ std::shared_ptr<TorchCommBackend> TorchCommFactory::create_backend(
     const CommOptions& options) {
   std::shared_ptr<TorchCommBackend> impl;
 
-  for (const auto& [key, _] : backends_) {
-    TC_LOG(INFO) << "Backend " << key << " is registered";
+  {
+    std::lock_guard<std::mutex> guard(mutex_);
+    for (const auto& [key, _] : backends_) {
+      TC_LOG(INFO) << "Backend " << key << " is registered";
+    }
+
+    if (auto it = backends_.find(backend); it != backends_.end()) {
+      impl = it->second();
+    }
   }
 
-  if (auto it = backends_.find(backend); it != backends_.end()) {
-    impl = it->second();
-  } else {
+  if (!impl) {
     impl = create_generic_backend(backend);
   }
 
@@ -239,5 +244,10 @@ void TorchCommFactory::register_allocator_factory(
 TorchCommFactory& TorchCommFactory::get() {
   static TorchCommFactory instance;
   return instance;
+}
+
+bool TorchCommFactory::is_backend_registered(const std::string& backend) const {
+  std::lock_guard<std::mutex> guard(mutex_);
+  return backends_.find(backend) != backends_.end();
 }
 } // namespace torch::comms

--- a/comms/torchcomms/TorchCommFactory.hpp
+++ b/comms/torchcomms/TorchCommFactory.hpp
@@ -37,11 +37,13 @@ class TorchCommFactory {
       const std::string& backend,
       const std::function<std::shared_ptr<c10::Allocator>()>& factory);
 
+  bool is_backend_registered(const std::string& backend) const;
+
  private:
   std::shared_ptr<TorchCommBackend> create_generic_backend(
       const std::string& backend);
 
-  std::mutex mutex_;
+  mutable std::mutex mutex_;
   std::unordered_map<
       std::string,
       std::function<std::shared_ptr<TorchCommBackend>()>>

--- a/comms/torchcomms/TorchCommPy.cpp
+++ b/comms/torchcomms/TorchCommPy.cpp
@@ -9,7 +9,9 @@
 #include <torch/csrc/utils/pybind.h>
 
 #include "comms/torchcomms/BackendWrapper.hpp"
+#include "comms/torchcomms/PyTorchCommBackend.hpp"
 #include "comms/torchcomms/TorchComm.hpp"
+#include "comms/torchcomms/TorchCommFactory.hpp"
 #include "comms/torchcomms/TorchWork.hpp"
 
 // Forward declaration for flight recorder submodule init
@@ -251,7 +253,55 @@ completed before proceeding.
 Raises:
     RuntimeError: If not implemented by the backend.
           )",
-          py::call_guard<py::gil_scoped_release>());
+          py::call_guard<py::gil_scoped_release>())
+      .def(
+          "_set_status",
+          [](TorchWork& self, TorchWork::WorkStatus status) {
+            auto* py_work = dynamic_cast<PyTorchWork*>(&self);
+            if (py_work) {
+              py_work->publicSetStatus(status);
+            } else {
+              throw std::runtime_error(
+                  "_set_status is only supported on Python-created work objects");
+            }
+          },
+          R"(
+Set the status of this work object.
+
+This is intended for use by Python backend implementations that return
+custom work objects. Call this to update the work status (e.g., to COMPLETED
+after the operation finishes).
+
+Args:
+    status (WorkStatus): The new status to set.
+          )",
+          py::arg("status"));
+
+  py::enum_<TorchWork::WorkStatus>(
+      m,
+      "WorkStatus",
+      R"(
+Status of a TorchWork object.
+
+Used to track the lifecycle of an asynchronous operation.
+      )")
+      .value(
+          "NOT_STARTED",
+          TorchWork::WorkStatus::NOT_STARTED,
+          "Work has not started yet.")
+      .value(
+          "INPROGRESS",
+          TorchWork::WorkStatus::INPROGRESS,
+          "Work is still in progress.")
+      .value(
+          "COMPLETED",
+          TorchWork::WorkStatus::COMPLETED,
+          "Work has completed successfully.")
+      .value("TIMEDOUT", TorchWork::WorkStatus::TIMEDOUT, "Work has timed out.")
+      .value(
+          "ERROR",
+          TorchWork::WorkStatus::ERROR,
+          "Work has encountered an error.");
 
   py::enum_<TorchCommWinAccessType>(
       m, "TorchCommWinAccessType", "Window attribute.")
@@ -931,8 +981,10 @@ Args:
          std::optional<c10::intrusive_ptr<c10d::Store>> store,
          bool enable_reconfigure,
          std::optional<std::unordered_map<std::string, std::string>> hints) {
-        py::module_ torchcomms = py::module_::import("torchcomms");
-        torchcomms.attr("_load_backend")(backend);
+        if (!TorchCommFactory::get().is_backend_registered(backend)) {
+          py::module_ torchcomms = py::module_::import("torchcomms");
+          torchcomms.attr("_load_backend")(backend);
+        }
 
         {
           py::gil_scoped_release release{};
@@ -998,16 +1050,34 @@ Args:
       py::arg("enable_reconfigure") = false,
       py::arg("hints") = std::nullopt);
 
-  py::class_<TorchCommBackend, std::shared_ptr<TorchCommBackend>>(
+  py::class_<
+      TorchCommBackend,
+      PyTorchCommBackend,
+      std::shared_ptr<TorchCommBackend>>(
       m,
       "TorchCommBackend",
-      "Abstract class that all torchcomms Backends implement.");
+      R"(
+Base class for Python-implemented TorchComm backends.
+
+Subclass this to implement a custom communication backend in Python.
+Register it with :func:`register_backend`, then create communicators
+via :func:`new_comm`.
+
+Override the required methods: ``init``, ``finalize``, ``get_rank``,
+``get_size``, ``get_backend_name``, ``get_comm_name``, ``split``, and
+the collective operations (``all_reduce``, ``broadcast``, etc.).
+
+Each collective method should return ``None`` for synchronous completion,
+or an object with a ``wait()`` method for asynchronous operations.
+          )")
+      .def(py::init<>());
 
   // Bind TorchComm class
   py_opaque_class<TorchComm, std::shared_ptr<TorchComm>>(m, "TorchComm")
       // NOTE: copy/deepcopy return the same object (not a clone).
       // Actually cloning the underlying communicator would be extremely
-      // expensive (requires collective operations to create new comm groups).
+      // expensive (requires collective operations to create new comm
+      // groups).
       .def(
           "__copy__",
           [](const std::shared_ptr<TorchComm>& self) { return self; })
@@ -2054,7 +2124,8 @@ Raises: RuntimeError if the ranks list is non-empty and the current rank is not 
       // NOTE: This property is kept temporarily to avoid breaking upstream
       // callers. The allocator is actually a global static per backend
       // (accessed via get_mem_allocator(backend)), not tied to the comm
-      // instance lifetime. Future code should use the global function directly.
+      // instance lifetime. Future code should use the global function
+      // directly.
       .def_property_readonly(
           "mem_allocator",
           [](TorchComm& self) { return get_mem_allocator(self.getBackend()); },
@@ -2236,4 +2307,7 @@ Args:
   auto hooks_mod = m.def_submodule("hooks");
   auto fr_mod = hooks_mod.def_submodule("fr");
   init_flight_recorder_bindings(fr_mod);
+
+  // Python backend registration
+  initPyBackendBindings(m);
 }

--- a/comms/torchcomms/TorchCommPy.cpp
+++ b/comms/torchcomms/TorchCommPy.cpp
@@ -9,7 +9,9 @@
 #include <torch/csrc/utils/pybind.h>
 
 #include "comms/torchcomms/BackendWrapper.hpp"
+#include "comms/torchcomms/PyTorchCommBackend.hpp"
 #include "comms/torchcomms/TorchComm.hpp"
+#include "comms/torchcomms/TorchCommFactory.hpp"
 #include "comms/torchcomms/TorchWork.hpp"
 
 // Forward declarations for hook submodule init
@@ -252,7 +254,55 @@ completed before proceeding.
 Raises:
     RuntimeError: If not implemented by the backend.
           )",
-          py::call_guard<py::gil_scoped_release>());
+          py::call_guard<py::gil_scoped_release>())
+      .def(
+          "_set_status",
+          [](TorchWork& self, TorchWork::WorkStatus status) {
+            auto* py_work = dynamic_cast<PyTorchWork*>(&self);
+            if (py_work) {
+              py_work->publicSetStatus(status);
+            } else {
+              throw std::runtime_error(
+                  "_set_status is only supported on Python-created work objects");
+            }
+          },
+          R"(
+Set the status of this work object.
+
+This is intended for use by Python backend implementations that return
+custom work objects. Call this to update the work status (e.g., to COMPLETED
+after the operation finishes).
+
+Args:
+    status (WorkStatus): The new status to set.
+          )",
+          py::arg("status"));
+
+  py::enum_<TorchWork::WorkStatus>(
+      m,
+      "WorkStatus",
+      R"(
+Status of a TorchWork object.
+
+Used to track the lifecycle of an asynchronous operation.
+      )")
+      .value(
+          "NOT_STARTED",
+          TorchWork::WorkStatus::NOT_STARTED,
+          "Work has not started yet.")
+      .value(
+          "INPROGRESS",
+          TorchWork::WorkStatus::INPROGRESS,
+          "Work is still in progress.")
+      .value(
+          "COMPLETED",
+          TorchWork::WorkStatus::COMPLETED,
+          "Work has completed successfully.")
+      .value("TIMEDOUT", TorchWork::WorkStatus::TIMEDOUT, "Work has timed out.")
+      .value(
+          "ERROR",
+          TorchWork::WorkStatus::ERROR,
+          "Work has encountered an error.");
 
   py::enum_<TorchCommWinAccessType>(
       m, "TorchCommWinAccessType", "Window attribute.")
@@ -1068,8 +1118,16 @@ Args:
          std::optional<c10::intrusive_ptr<c10d::Store>> store,
          bool enable_reconfigure,
          std::optional<std::unordered_map<std::string, std::string>> hints) {
-        py::module_ torchcomms = py::module_::import("torchcomms");
-        torchcomms.attr("_load_backend")(backend);
+        {
+          py::module_ torchcomms = py::module_::import("torchcomms");
+          try {
+            torchcomms.attr("_load_backend")(backend);
+          } catch (py::error_already_set&) {
+            if (!TorchCommFactory::get().is_backend_registered(backend)) {
+              throw;
+            }
+          }
+        }
 
         {
           py::gil_scoped_release release{};
@@ -1135,16 +1193,34 @@ Args:
       py::arg("enable_reconfigure") = false,
       py::arg("hints") = std::nullopt);
 
-  py::class_<TorchCommBackend, std::shared_ptr<TorchCommBackend>>(
+  py::class_<
+      TorchCommBackend,
+      PyTorchCommBackend,
+      std::shared_ptr<TorchCommBackend>>(
       m,
       "TorchCommBackend",
-      "Abstract class that all torchcomms Backends implement.");
+      R"(
+Base class for Python-implemented TorchComm backends.
+
+Subclass this to implement a custom communication backend in Python.
+Register it with :func:`register_backend`, then create communicators
+via :func:`new_comm`.
+
+Override the required methods: ``init``, ``finalize``, ``get_rank``,
+``get_size``, ``get_backend_name``, ``get_comm_name``, ``split``, and
+the collective operations (``all_reduce``, ``broadcast``, etc.).
+
+Each collective method should return ``None`` for synchronous completion,
+or an object with a ``wait()`` method for asynchronous operations.
+          )")
+      .def(py::init<>());
 
   // Bind TorchComm class
   py_opaque_class<TorchComm, std::shared_ptr<TorchComm>>(m, "TorchComm")
       // NOTE: copy/deepcopy return the same object (not a clone).
       // Actually cloning the underlying communicator would be extremely
-      // expensive (requires collective operations to create new comm groups).
+      // expensive (requires collective operations to create new comm
+      // groups).
       .def(
           "__copy__",
           [](const std::shared_ptr<TorchComm>& self) { return self; })
@@ -2191,7 +2267,8 @@ Raises: RuntimeError if the ranks list is non-empty and the current rank is not 
       // NOTE: This property is kept temporarily to avoid breaking upstream
       // callers. The allocator is actually a global static per backend
       // (accessed via get_mem_allocator(backend)), not tied to the comm
-      // instance lifetime. Future code should use the global function directly.
+      // instance lifetime. Future code should use the global function
+      // directly.
       .def_property_readonly(
           "mem_allocator",
           [](TorchComm& self) { return get_mem_allocator(self.getBackend()); },
@@ -2359,8 +2436,8 @@ Returns:
 
 Example::
 
-    def my_pre_hook(args):
-        print(f"Starting {args.name}")
+    def my_pre_hook(name, op_id, args):
+        print(f"Starting {name}")
     handle = comm.register_pre_hook(my_pre_hook)
     # ... run operations ...
     handle.remove()  # Unregister when done
@@ -2533,4 +2610,7 @@ Args:
   init_clog_hook_bindings(clog_mod);
   auto fr_mod = hooks_mod.def_submodule("fr");
   init_flight_recorder_bindings(fr_mod);
+
+  // Python backend registration
+  initPyBackendBindings(m);
 }

--- a/comms/torchcomms/__init__.py
+++ b/comms/torchcomms/__init__.py
@@ -67,6 +67,8 @@ __all__ = [  # noqa: F405
     "P2POp",
     "CommOptions",
     "TorchCommWindow",
+    "register_backend",
+    "TorchCommBackend",
 ]
 
 for name in __all__:
@@ -77,7 +79,8 @@ for name in __all__:
 def _load_backend(backend: str) -> None:
     """Used to load backends lazily from C++
 
-    If a backend is already loaded, this function is a no-op.
+    C++ calls this only when the backend is not already registered via
+    register_backend.
     """
     found = entry_points(group="torchcomms.backends", name=backend)
     if not found:

--- a/comms/torchcomms/__init__.py
+++ b/comms/torchcomms/__init__.py
@@ -66,6 +66,8 @@ __all__ = [  # noqa: F405
     "P2POp",
     "CommOptions",
     "TorchCommWindow",
+    "register_backend",
+    "TorchCommBackend",
 ]
 
 for name in __all__:
@@ -76,7 +78,8 @@ for name in __all__:
 def _load_backend(backend: str) -> None:
     """Used to load backends lazily from C++
 
-    If a backend is already loaded, this function is a no-op.
+    C++ calls this only when the backend is not already registered via
+    register_backend.
     """
     found = entry_points(group="torchcomms.backends", name=backend)
     if not found:

--- a/comms/torchcomms/_comms.pyi
+++ b/comms/torchcomms/_comms.pyi
@@ -4,7 +4,7 @@
 
 from datetime import timedelta
 from enum import auto, Enum
-from typing import Any, Callable, Dict, List, Set
+from typing import Any, Callable, Dict, List, Set, Type
 
 InitHandle = str
 
@@ -402,10 +402,18 @@ class AllGatherPExecOptions:
 # Opaque handle type for persistent AllGather
 AllGatherPHandle = Any
 
+class WorkStatus(Enum):
+    NOT_STARTED = auto()
+    INPROGRESS = auto()
+    COMPLETED = auto()
+    TIMEDOUT = auto()
+    ERROR = auto()
+
 class TorchWork:
     def is_completed(self) -> bool: ...
     def wait(self) -> None: ...
     def wait_blocking(self) -> None: ...
+    def _set_status(self, status: WorkStatus) -> None: ...
 
 class TorchCommWinAccessType(Enum):
     WIN_ACCESS_TYPE_UNIFIED = auto()
@@ -484,8 +492,6 @@ class BatchSendRecv:
     def send(self, tensor: Any, dst: int) -> None: ...
     def recv(self, tensor: Any, src: int) -> None: ...
     def issue(self, async_op: bool, options: BatchP2POptions = ...) -> TorchWork: ...
-
-class TorchCommBackend: ...
 
 class TorchComm:
     def finalize(self) -> None: ...
@@ -710,3 +716,9 @@ class _BackendWrapper:
     def get_comm(self) -> TorchComm: ...
 
 def get_mem_allocator(backend: str) -> Any: ...
+
+class TorchCommBackend:
+    def __init__(self) -> None: ...
+
+def register_backend(name: str, backend_class: Type[TorchCommBackend]) -> None: ...
+def _is_backend_registered(name: str) -> bool: ...

--- a/comms/torchcomms/_comms.pyi
+++ b/comms/torchcomms/_comms.pyi
@@ -4,7 +4,7 @@
 
 from datetime import timedelta
 from enum import auto, Enum
-from typing import Any, Callable, Dict, List, Set
+from typing import Any, Callable, Dict, List, Set, Type
 
 InitHandle = str
 
@@ -207,10 +207,18 @@ class AllGatherPExecOptions:
 # Opaque handle type for persistent AllGather
 AllGatherPHandle = Any
 
+class WorkStatus(Enum):
+    NOT_STARTED = auto()
+    INPROGRESS = auto()
+    COMPLETED = auto()
+    TIMEDOUT = auto()
+    ERROR = auto()
+
 class TorchWork:
     def is_completed(self) -> bool: ...
     def wait(self) -> None: ...
     def wait_blocking(self) -> None: ...
+    def _set_status(self, status: WorkStatus) -> None: ...
 
 class TorchCommWinAccessType(Enum):
     WIN_ACCESS_TYPE_UNIFIED = auto()
@@ -289,8 +297,6 @@ class BatchSendRecv:
     def send(self, tensor: Any, dst: int) -> None: ...
     def recv(self, tensor: Any, src: int) -> None: ...
     def issue(self, async_op: bool, options: BatchP2POptions = ...) -> TorchWork: ...
-
-class TorchCommBackend: ...
 
 class TorchComm:
     def finalize(self) -> None: ...
@@ -515,3 +521,9 @@ class _BackendWrapper:
     def get_comm(self) -> TorchComm: ...
 
 def get_mem_allocator(backend: str) -> Any: ...
+
+class TorchCommBackend:
+    def __init__(self) -> None: ...
+
+def register_backend(name: str, backend_class: Type[TorchCommBackend]) -> None: ...
+def _is_backend_registered(name: str) -> bool: ...

--- a/comms/torchcomms/gloo/TorchCommGlooPy.cpp
+++ b/comms/torchcomms/gloo/TorchCommGlooPy.cpp
@@ -14,5 +14,6 @@ using namespace torch::comms;
 PYBIND11_MODULE(_comms_gloo, m, py::mod_gil_not_used()) {
   m.doc() = "Gloo specific python bindings for TorchComm";
 
-  py::class_<TorchCommGloo, std::shared_ptr<TorchCommGloo>>(m, "TorchCommGloo");
+  py::class_<TorchCommGloo, TorchCommBackend, std::shared_ptr<TorchCommGloo>>(
+      m, "TorchCommGloo");
 }

--- a/comms/torchcomms/nccl/TorchCommNCCLPy.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCLPy.cpp
@@ -14,5 +14,6 @@ using namespace torch::comms;
 PYBIND11_MODULE(_comms_nccl, m, py::mod_gil_not_used()) {
   m.doc() = "NCCL specific python bindings for TorchComm";
 
-  py::class_<TorchCommNCCL, std::shared_ptr<TorchCommNCCL>>(m, "TorchCommNCCL");
+  py::class_<TorchCommNCCL, TorchCommBackend, std::shared_ptr<TorchCommNCCL>>(
+      m, "TorchCommNCCL");
 }

--- a/comms/torchcomms/ncclx/TorchCommNCCLXPy.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXPy.cpp
@@ -22,7 +22,7 @@ PYBIND11_MODULE(_comms_ncclx, m, py::mod_gil_not_used()) {
   intrusive_ptr_class_<TorchCommNCCLXPersistentRequest>(
       m, "TorchCommNCCLXPersistentRequest");
 
-  py::class_<TorchCommNCCLX, std::shared_ptr<TorchCommNCCLX>>(
+  py::class_<TorchCommNCCLX, TorchCommBackend, std::shared_ptr<TorchCommNCCLX>>(
       m, "TorchCommNCCLX")
       .def(
           "device_alltoallv_single",

--- a/comms/torchcomms/rccl/TorchCommRCCLPy.cpp
+++ b/comms/torchcomms/rccl/TorchCommRCCLPy.cpp
@@ -14,5 +14,6 @@ using namespace torch::comms;
 PYBIND11_MODULE(_comms_rccl, m, py::mod_gil_not_used()) {
   m.doc() = "RCCL specific python bindings for TorchComm";
 
-  py::class_<TorchCommRCCL, std::shared_ptr<TorchCommRCCL>>(m, "TorchCommRCCL");
+  py::class_<TorchCommRCCL, TorchCommBackend, std::shared_ptr<TorchCommRCCL>>(
+      m, "TorchCommRCCL");
 }

--- a/comms/torchcomms/rcclx/TorchCommRCCLXPy.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLXPy.cpp
@@ -14,6 +14,6 @@ using namespace torch::comms;
 PYBIND11_MODULE(_comms_rcclx, m, py::mod_gil_not_used()) {
   m.doc() = "RCCLX specific python bindings for TorchComm";
 
-  py::class_<TorchCommRCCLX, std::shared_ptr<TorchCommRCCLX>>(
+  py::class_<TorchCommRCCLX, TorchCommBackend, std::shared_ptr<TorchCommRCCLX>>(
       m, "TorchCommRCCLX");
 }

--- a/comms/torchcomms/tests/unit/py/test_python_backend.py
+++ b/comms/torchcomms/tests/unit/py/test_python_backend.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+# pyre-unsafe
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import unittest
+
+import torch
+import torchcomms
+from torchcomms._comms import TorchCommBackend
+
+
+class DummyWork:
+    def __init__(self) -> None:
+        self.waited = False
+
+    def wait(self) -> None:
+        self.waited = True
+
+
+class DummyPyBackend(TorchCommBackend):
+    def __init__(self) -> None:
+        super().__init__()
+        self._rank = 0
+        self._size = 1
+        self._name = ""
+        self._device = torch.device("cpu")
+        self._initialized = False
+
+    def init(self, device, name, options) -> None:
+        self._device = device
+        self._name = name
+        self._initialized = True
+
+    def finalize(self) -> None:
+        self._initialized = False
+
+    def get_rank(self) -> int:
+        return self._rank
+
+    def get_size(self) -> int:
+        return self._size
+
+    def get_backend_name(self) -> str:
+        return "dummy_py"
+
+    def get_comm_name(self) -> str:
+        return self._name
+
+    def send(self, tensor, dst, async_op):
+        return None
+
+    def recv(self, tensor, src, async_op):
+        return None
+
+    def broadcast(self, tensor, root, async_op):
+        return None
+
+    def all_reduce(self, tensor, op, async_op):
+        return None
+
+    def reduce(self, tensor, root, op, async_op):
+        return None
+
+    def all_gather(self, tensor_list, tensor, async_op):
+        return None
+
+    def all_gather_v(self, tensor_list, tensor, async_op):
+        return None
+
+    def all_gather_single(self, output, input, async_op):
+        return None
+
+    def reduce_scatter(self, output, input_list, op, async_op):
+        return None
+
+    def reduce_scatter_v(self, output, input_list, op, async_op):
+        return None
+
+    def reduce_scatter_single(self, output, input, op, async_op):
+        return None
+
+    def all_to_all_single(self, output, input, async_op):
+        return None
+
+    def all_to_all_v_single(self, output, input, output_splits, input_splits, async_op):
+        return None
+
+    def all_to_all(self, output_list, input_list, async_op):
+        return None
+
+    def barrier(self, async_op):
+        return None
+
+    def scatter(self, output, input_list, root, async_op):
+        return None
+
+    def gather(self, output_list, input, root, async_op):
+        return None
+
+    def split(self, ranks, name, options):
+        backend = DummyPyBackend()
+        backend._rank = 0
+        backend._size = len(ranks)
+        backend._name = name
+        backend._initialized = True
+        return backend
+
+
+class AllReduceSumBackend(DummyPyBackend):
+    def all_reduce(self, tensor, op, async_op):
+        if op.type == torchcomms.RedOpType.SUM:
+            tensor.mul_(self._size)
+        return None
+
+
+class AsyncAllReduceBackend(DummyPyBackend):
+    def all_reduce(self, tensor, op, async_op):
+        work = DummyWork()
+        return work
+
+
+class TestPythonBackend(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        torchcomms.register_backend("dummy_py", DummyPyBackend)
+        torchcomms.register_backend("sum_py", AllReduceSumBackend)
+        torchcomms.register_backend("async_py", AsyncAllReduceBackend)
+
+    def test_register_and_create(self) -> None:
+        comm = torchcomms.new_comm("dummy_py", torch.device("cpu"), name="test_basic")
+        self.assertEqual(comm.get_rank(), 0)
+        self.assertEqual(comm.get_size(), 1)
+        self.assertEqual(comm.get_backend(), "dummy_py")
+        comm.finalize()
+
+    def test_all_reduce_sync(self) -> None:
+        comm = torchcomms.new_comm("dummy_py", torch.device("cpu"), name="test_ar")
+        tensor = torch.ones(4)
+        work = comm.all_reduce(tensor, torchcomms.ReduceOp.SUM, async_op=False)
+        work.wait()
+        self.assertTrue(work.is_completed())
+        comm.finalize()
+
+    def test_broadcast(self) -> None:
+        comm = torchcomms.new_comm("dummy_py", torch.device("cpu"), name="test_bc")
+        tensor = torch.ones(4)
+        work = comm.broadcast(tensor, root=0, async_op=False)
+        work.wait()
+        self.assertTrue(work.is_completed())
+        comm.finalize()
+
+    def test_barrier(self) -> None:
+        comm = torchcomms.new_comm("dummy_py", torch.device("cpu"), name="test_bar")
+        work = comm.barrier(async_op=False)
+        work.wait()
+        self.assertTrue(work.is_completed())
+        comm.finalize()
+
+    def test_send_recv(self) -> None:
+        comm = torchcomms.new_comm("dummy_py", torch.device("cpu"), name="test_sr")
+        tensor = torch.ones(4)
+        work = comm.send(tensor, dst=0, async_op=False)
+        work.wait()
+        self.assertTrue(work.is_completed())
+        work = comm.recv(tensor, src=0, async_op=False)
+        work.wait()
+        self.assertTrue(work.is_completed())
+        comm.finalize()
+
+    def test_all_gather(self) -> None:
+        comm = torchcomms.new_comm("dummy_py", torch.device("cpu"), name="test_ag")
+        tensor = torch.ones(4)
+        output = [torch.zeros(4)]
+        work = comm.all_gather(output, tensor, async_op=False)
+        work.wait()
+        self.assertTrue(work.is_completed())
+        comm.finalize()
+
+    def test_reduce_scatter_single(self) -> None:
+        comm = torchcomms.new_comm("dummy_py", torch.device("cpu"), name="test_rss")
+        input_tensor = torch.ones(4)
+        output_tensor = torch.zeros(4)
+        work = comm.reduce_scatter_single(
+            output_tensor, input_tensor, torchcomms.ReduceOp.SUM, async_op=False
+        )
+        work.wait()
+        self.assertTrue(work.is_completed())
+        comm.finalize()
+
+    def test_scatter_gather(self) -> None:
+        comm = torchcomms.new_comm("dummy_py", torch.device("cpu"), name="test_sg")
+        output = torch.zeros(4)
+        input_list = [torch.ones(4)]
+        work = comm.scatter(output, input_list, root=0, async_op=False)
+        work.wait()
+
+        output_list = [torch.zeros(4)]
+        input_t = torch.ones(4)
+        work = comm.gather(output_list, input_t, root=0, async_op=False)
+        work.wait()
+        self.assertTrue(work.is_completed())
+        comm.finalize()
+
+    def test_all_to_all(self) -> None:
+        comm = torchcomms.new_comm("dummy_py", torch.device("cpu"), name="test_a2a")
+        output = [torch.zeros(4)]
+        input_list = [torch.ones(4)]
+        work = comm.all_to_all(output, input_list, async_op=False)
+        work.wait()
+        self.assertTrue(work.is_completed())
+        comm.finalize()
+
+    def test_custom_all_reduce_logic(self) -> None:
+        comm = torchcomms.new_comm("sum_py", torch.device("cpu"), name="test_sum")
+        tensor = torch.ones(4)
+        comm.all_reduce(tensor, torchcomms.ReduceOp.SUM, async_op=False)
+        expected = torch.ones(4)
+        self.assertTrue(torch.equal(tensor, expected))
+        comm.finalize()
+
+    def test_async_work(self) -> None:
+        comm = torchcomms.new_comm("async_py", torch.device("cpu"), name="test_async")
+        tensor = torch.ones(4)
+        work = comm.all_reduce(tensor, torchcomms.ReduceOp.SUM, async_op=True)
+        self.assertFalse(work.is_completed())
+        work.wait()
+        self.assertTrue(work.is_completed())
+        comm.finalize()
+
+    def test_hooks_with_python_backend(self) -> None:
+        comm = torchcomms.new_comm("dummy_py", torch.device("cpu"), name="test_hooks")
+        pre_hook_calls = []
+
+        def pre_hook(name, op_id, args) -> None:
+            pre_hook_calls.append(name)
+
+        handle = comm.register_pre_hook(pre_hook)
+        tensor = torch.ones(4)
+        comm.all_reduce(tensor, torchcomms.ReduceOp.SUM, async_op=False)
+        self.assertEqual(len(pre_hook_calls), 1)
+        handle.remove()
+        comm.finalize()
+
+    def test_multiple_comms(self) -> None:
+        comm1 = torchcomms.new_comm("dummy_py", torch.device("cpu"), name="comm1")
+        comm2 = torchcomms.new_comm("dummy_py", torch.device("cpu"), name="comm2")
+        self.assertEqual(comm1.get_rank(), 0)
+        self.assertEqual(comm2.get_rank(), 0)
+        comm1.finalize()
+        comm2.finalize()
+
+    def test_split(self) -> None:
+        comm = torchcomms.new_comm("dummy_py", torch.device("cpu"), name="test_split")
+        sub = comm.split(ranks=[0], name="sub_comm")
+        self.assertEqual(sub.get_rank(), 0)
+        self.assertEqual(sub.get_size(), 1)
+        sub.finalize()
+        comm.finalize()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/comms/torchcomms/tests/unit/py/test_python_backend.py
+++ b/comms/torchcomms/tests/unit/py/test_python_backend.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+# pyre-unsafe
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import unittest
+
+import torch
+import torchcomms
+from torchcomms._comms import TorchCommBackend
+
+
+class DummyWork:
+    def __init__(self) -> None:
+        self.waited = False
+
+    def wait(self) -> None:
+        self.waited = True
+
+
+class DummyPyBackend(TorchCommBackend):
+    def __init__(self) -> None:
+        super().__init__()
+        self._rank = 0
+        self._size = 1
+        self._name = ""
+        self._device = torch.device("cpu")
+        self._initialized = False
+
+    def init(self, device, name, options) -> None:
+        self._device = device
+        self._name = name
+        self._initialized = True
+
+    def finalize(self) -> None:
+        self._initialized = False
+
+    def get_rank(self) -> int:
+        return self._rank
+
+    def get_size(self) -> int:
+        return self._size
+
+    def get_backend_name(self) -> str:
+        return "dummy_py"
+
+    def get_comm_name(self) -> str:
+        return self._name
+
+    def send(self, tensor, dst, async_op):
+        return None
+
+    def recv(self, tensor, src, async_op):
+        return None
+
+    def broadcast(self, tensor, root, async_op):
+        return None
+
+    def all_reduce(self, tensor, op, async_op):
+        return None
+
+    def reduce(self, tensor, root, op, async_op):
+        return None
+
+    def all_gather(self, tensor_list, tensor, async_op):
+        return None
+
+    def all_gather_v(self, tensor_list, tensor, async_op):
+        return None
+
+    def all_gather_single(self, output, input, async_op):
+        return None
+
+    def reduce_scatter(self, output, input_list, op, async_op):
+        return None
+
+    def reduce_scatter_v(self, output, input_list, op, async_op):
+        return None
+
+    def reduce_scatter_single(self, output, input, op, async_op):
+        return None
+
+    def all_to_all_single(self, output, input, async_op):
+        return None
+
+    def all_to_all_v_single(self, output, input, output_splits, input_splits, async_op):
+        return None
+
+    def all_to_all(self, output_list, input_list, async_op):
+        return None
+
+    def barrier(self, async_op):
+        return None
+
+    def scatter(self, output, input_list, root, async_op):
+        return None
+
+    def gather(self, output_list, input, root, async_op):
+        return None
+
+    def split(self, ranks, name, options):
+        backend = DummyPyBackend()
+        backend._rank = 0
+        backend._size = len(ranks)
+        backend._name = name
+        backend._initialized = True
+        return backend
+
+
+class AllReduceSumBackend(DummyPyBackend):
+    def all_reduce(self, tensor, op, async_op):
+        if op.type == torchcomms.RedOpType.SUM:
+            tensor.mul_(self._size)
+        return None
+
+
+class AsyncAllReduceBackend(DummyPyBackend):
+    def all_reduce(self, tensor, op, async_op):
+        work = DummyWork()
+        return work
+
+
+class TestPythonBackend(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        torchcomms.register_backend("dummy_py", DummyPyBackend)
+        torchcomms.register_backend("sum_py", AllReduceSumBackend)
+        torchcomms.register_backend("async_py", AsyncAllReduceBackend)
+
+    def test_register_and_create(self) -> None:
+        comm = torchcomms.new_comm("dummy_py", torch.device("cpu"), name="test_basic")
+        self.assertEqual(comm.get_rank(), 0)
+        self.assertEqual(comm.get_size(), 1)
+        self.assertEqual(comm.get_backend(), "dummy_py")
+        comm.finalize()
+
+    def test_all_reduce_sync(self) -> None:
+        comm = torchcomms.new_comm("dummy_py", torch.device("cpu"), name="test_ar")
+        tensor = torch.ones(4)
+        work = comm.all_reduce(tensor, torchcomms.ReduceOp.SUM, async_op=False)
+        work.wait()
+        self.assertTrue(work.is_completed())
+        comm.finalize()
+
+    def test_broadcast(self) -> None:
+        comm = torchcomms.new_comm("dummy_py", torch.device("cpu"), name="test_bc")
+        tensor = torch.ones(4)
+        work = comm.broadcast(tensor, root=0, async_op=False)
+        work.wait()
+        self.assertTrue(work.is_completed())
+        comm.finalize()
+
+    def test_barrier(self) -> None:
+        comm = torchcomms.new_comm("dummy_py", torch.device("cpu"), name="test_bar")
+        work = comm.barrier(async_op=False)
+        work.wait()
+        self.assertTrue(work.is_completed())
+        comm.finalize()
+
+    def test_send_recv(self) -> None:
+        comm = torchcomms.new_comm("dummy_py", torch.device("cpu"), name="test_sr")
+        tensor = torch.ones(4)
+        work = comm.send(tensor, dst=0, async_op=False)
+        work.wait()
+        self.assertTrue(work.is_completed())
+        work = comm.recv(tensor, src=0, async_op=False)
+        work.wait()
+        self.assertTrue(work.is_completed())
+        comm.finalize()
+
+    def test_all_gather(self) -> None:
+        comm = torchcomms.new_comm("dummy_py", torch.device("cpu"), name="test_ag")
+        tensor = torch.ones(4)
+        output = [torch.zeros(4)]
+        work = comm.all_gather(output, tensor, async_op=False)
+        work.wait()
+        self.assertTrue(work.is_completed())
+        comm.finalize()
+
+    def test_reduce_scatter_single(self) -> None:
+        comm = torchcomms.new_comm("dummy_py", torch.device("cpu"), name="test_rss")
+        input_tensor = torch.ones(4)
+        output_tensor = torch.zeros(4)
+        work = comm.reduce_scatter_single(
+            output_tensor, input_tensor, torchcomms.ReduceOp.SUM, async_op=False
+        )
+        work.wait()
+        self.assertTrue(work.is_completed())
+        comm.finalize()
+
+    def test_scatter_gather(self) -> None:
+        comm = torchcomms.new_comm("dummy_py", torch.device("cpu"), name="test_sg")
+        output = torch.zeros(4)
+        input_list = [torch.ones(4)]
+        work = comm.scatter(output, input_list, root=0, async_op=False)
+        work.wait()
+
+        output_list = [torch.zeros(4)]
+        input_t = torch.ones(4)
+        work = comm.gather(output_list, input_t, root=0, async_op=False)
+        work.wait()
+        self.assertTrue(work.is_completed())
+        comm.finalize()
+
+    def test_all_to_all(self) -> None:
+        comm = torchcomms.new_comm("dummy_py", torch.device("cpu"), name="test_a2a")
+        output = [torch.zeros(4)]
+        input_list = [torch.ones(4)]
+        work = comm.all_to_all(output, input_list, async_op=False)
+        work.wait()
+        self.assertTrue(work.is_completed())
+        comm.finalize()
+
+    def test_custom_all_reduce_logic(self) -> None:
+        comm = torchcomms.new_comm("sum_py", torch.device("cpu"), name="test_sum")
+        tensor = torch.ones(4)
+        comm.all_reduce(tensor, torchcomms.ReduceOp.SUM, async_op=False)
+        expected = torch.ones(4)
+        self.assertTrue(torch.equal(tensor, expected))
+        comm.finalize()
+
+    def test_async_work(self) -> None:
+        comm = torchcomms.new_comm("async_py", torch.device("cpu"), name="test_async")
+        tensor = torch.ones(4)
+        work = comm.all_reduce(tensor, torchcomms.ReduceOp.SUM, async_op=True)
+        self.assertFalse(work.is_completed())
+        work.wait()
+        self.assertTrue(work.is_completed())
+        comm.finalize()
+
+    def test_hooks_with_python_backend(self) -> None:
+        comm = torchcomms.new_comm("dummy_py", torch.device("cpu"), name="test_hooks")
+        pre_hook_calls = []
+
+        def pre_hook(args) -> None:
+            pre_hook_calls.append(args.name)
+
+        handle = comm.register_pre_hook(pre_hook)
+        tensor = torch.ones(4)
+        comm.all_reduce(tensor, torchcomms.ReduceOp.SUM, async_op=False)
+        self.assertEqual(len(pre_hook_calls), 1)
+        handle.remove()
+        comm.finalize()
+
+    def test_multiple_comms(self) -> None:
+        comm1 = torchcomms.new_comm("dummy_py", torch.device("cpu"), name="comm1")
+        comm2 = torchcomms.new_comm("dummy_py", torch.device("cpu"), name="comm2")
+        self.assertEqual(comm1.get_rank(), 0)
+        self.assertEqual(comm2.get_rank(), 0)
+        comm1.finalize()
+        comm2.finalize()
+
+    def test_split(self) -> None:
+        comm = torchcomms.new_comm("dummy_py", torch.device("cpu"), name="test_split")
+        sub = comm.split(ranks=[0], name="sub_comm")
+        self.assertEqual(sub.get_rank(), 0)
+        self.assertEqual(sub.get_size(), 1)
+        sub.finalize()
+        comm.finalize()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/comms/torchcomms/xccl/TorchCommXCCLPy.cpp
+++ b/comms/torchcomms/xccl/TorchCommXCCLPy.cpp
@@ -12,5 +12,6 @@ using namespace torch::comms;
 PYBIND11_MODULE(_comms_xccl, m, py::mod_gil_not_used()) {
   m.doc() = "XCCL specific python bindings for TorchComm";
 
-  py::class_<TorchCommXCCL, std::shared_ptr<TorchCommXCCL>>(m, "TorchCommXCCL");
+  py::class_<TorchCommXCCL, TorchCommBackend, std::shared_ptr<TorchCommXCCL>>(
+      m, "TorchCommXCCL");
 }


### PR DESCRIPTION
Summary:

Adds support for implementing TorchComm backends entirely in Python via a new `register_python_backend()` API. Backends written in Python can override collective operations and be used transparently by torchcomms. Includes a new `PyTorchCommBackend` trampoline class that uses pybind11's override mechanism to dispatch C++ virtual calls to Python implementations, with automatic work object wrapping for async operations.

---
AI generated Summary & Test Plan from DEV175860146

Reviewed By: dolpm

Differential Revision: D100914686


