### PR TITLE
fix silent data corruption for unsupported BAND/BOR/BXOR reduce ops

### DIFF
--- a/comms/torchcomms/nccl/TorchCommNCCLUtils.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCLUtils.cpp
@@ -167,11 +167,11 @@ TorchCommNCCL::RedOpRAII TorchCommNCCL::getNcclReduceOp(
     case ReduceOp::RedOpType::MAX:
       return ncclMax;
     case ReduceOp::RedOpType::BAND:
-      return ncclSum; // NCCL doesn't have bitwise AND, using SUM as fallback
+      throw std::runtime_error("Cannot use ReduceOp.BAND with NCCL");
     case ReduceOp::RedOpType::BOR:
-      return ncclSum; // NCCL doesn't have bitwise OR, using SUM as fallback
+      throw std::runtime_error("Cannot use ReduceOp.BOR with NCCL");
     case ReduceOp::RedOpType::BXOR:
-      return ncclSum; // NCCL doesn't have bitwise XOR, using SUM as fallback
+      throw std::runtime_error("Cannot use ReduceOp.BXOR with NCCL");
     case ReduceOp::RedOpType::PREMUL_SUM:
       return RedOpRAII(op, comm, dataType, nccl_api_);
     case ReduceOp::RedOpType::AVG:

--- a/comms/torchcomms/ncclx/TorchCommNCCLXUtils.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXUtils.cpp
@@ -150,11 +150,11 @@ TorchCommNCCLX::RedOpRAII TorchCommNCCLX::getNcclReduceOp(
     case ReduceOp::RedOpType::MAX:
       return ncclMax;
     case ReduceOp::RedOpType::BAND:
-      return ncclSum; // NCCL doesn't have bitwise AND, using SUM as fallback
+      throw std::runtime_error("Cannot use ReduceOp.BAND with NCCLX");
     case ReduceOp::RedOpType::BOR:
-      return ncclSum; // NCCL doesn't have bitwise OR, using SUM as fallback
+      throw std::runtime_error("Cannot use ReduceOp.BOR with NCCLX");
     case ReduceOp::RedOpType::BXOR:
-      return ncclSum; // NCCL doesn't have bitwise XOR, using SUM as fallback
+      throw std::runtime_error("Cannot use ReduceOp.BXOR with NCCLX");
     case ReduceOp::RedOpType::PREMUL_SUM:
       return RedOpRAII(op, comm, dataType, nccl_api_);
     case ReduceOp::RedOpType::AVG:

--- a/comms/torchcomms/rccl/TorchCommRCCLUtils.cpp
+++ b/comms/torchcomms/rccl/TorchCommRCCLUtils.cpp
@@ -133,11 +133,11 @@ TorchCommRCCL::RedOpRAII TorchCommRCCL::getNcclReduceOp(
     case ReduceOp::RedOpType::MAX:
       return ncclMax;
     case ReduceOp::RedOpType::BAND:
-      return ncclSum; // RCCL doesn't have bitwise AND, using SUM as fallback
+      throw std::runtime_error("Cannot use ReduceOp.BAND with RCCL");
     case ReduceOp::RedOpType::BOR:
-      return ncclSum; // RCCL doesn't have bitwise OR, using SUM as fallback
+      throw std::runtime_error("Cannot use ReduceOp.BOR with RCCL");
     case ReduceOp::RedOpType::BXOR:
-      return ncclSum; // RCCL doesn't have bitwise XOR, using SUM as fallback
+      throw std::runtime_error("Cannot use ReduceOp.BXOR with RCCL");
     case ReduceOp::RedOpType::PREMUL_SUM:
       return RedOpRAII(op, comm, dataType, rccl_api_);
     case ReduceOp::RedOpType::AVG:

--- a/comms/torchcomms/rcclx/TorchCommRCCLXUtils.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLXUtils.cpp
@@ -133,11 +133,11 @@ TorchCommRCCLX::RedOpRAII TorchCommRCCLX::getNcclReduceOp(
     case ReduceOp::RedOpType::MAX:
       return ncclMax;
     case ReduceOp::RedOpType::BAND:
-      return ncclSum; // RCCLX doesn't have bitwise AND, using SUM as fallback
+      throw std::runtime_error("Cannot use ReduceOp.BAND with RCCLX");
     case ReduceOp::RedOpType::BOR:
-      return ncclSum; // RCCLX doesn't have bitwise OR, using SUM as fallback
+      throw std::runtime_error("Cannot use ReduceOp.BOR with RCCLX");
     case ReduceOp::RedOpType::BXOR:
-      return ncclSum; // RCCLX doesn't have bitwise XOR, using SUM as fallback
+      throw std::runtime_error("Cannot use ReduceOp.BXOR with RCCLX");
     case ReduceOp::RedOpType::PREMUL_SUM:
       return RedOpRAII(op, comm, dataType, rcclx_api_);
     case ReduceOp::RedOpType::AVG:


### PR DESCRIPTION
`BAND`, `BOR`, and `BXOR` reduce operations were silently mapped to `ncclSum` across all four backends. Only correctly threw error in xccl. 
Raised same error as PyTorch `ProcessGroupNCCL`. 
