### PR TITLE
Upgrade NCCLX to C++20

### DIFF
--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -32,11 +32,6 @@
 #include "comms/ctran/backends/tcpdevmem/CtranTcpDm.h"
 #endif
 
-// Forward declaration for MapperTrace due to NVCC's lack of concepts support
-namespace ncclx::colltrace {
-class MapperTrace;
-}
-
 class CtranMapperImpl;
 
 const std::string getReqTypeStr(CtranMapperRequest::ReqType type);

--- a/comms/ncclx/v2_27/makefiles/common.mk
+++ b/comms/ncclx/v2_27/makefiles/common.mk
@@ -73,10 +73,10 @@ else
 endif
 $(info NVCC_GENCODE is ${NVCC_GENCODE})
 
-CXXSTD ?= -std=c++17
+CXXSTD ?= -std=c++20
 
 CXXFLAGS   := -DCUDA_MAJOR=$(CUDA_MAJOR) -DCUDA_MINOR=$(CUDA_MINOR) -fPIC -fvisibility=hidden \
-              -Wall -Wno-unused-function -Wno-sign-compare -std=c++2a -Wvla \
+              -Wall -Wno-unused-function -Wno-sign-compare -std=c++20 -Wvla \
               -I $(CUDA_INC) -I $(CUDA_INC)/cccl \
               $(CXXFLAGS)
 # Maxrregcount needs to be set accordingly to NCCL_MAX_NTHREADS (otherwise it will cause kernel launch errors)

--- a/comms/ncclx/v2_29/makefiles/common.mk
+++ b/comms/ncclx/v2_29/makefiles/common.mk
@@ -70,10 +70,10 @@ else
 endif
 $(info NVCC_GENCODE is ${NVCC_GENCODE})
 
-CXXSTD ?= -std=c++17
+CXXSTD ?= -std=c++20
 
 CXXFLAGS   := -DCUDA_MAJOR=$(CUDA_MAJOR) -DCUDA_MINOR=$(CUDA_MINOR) -fPIC -fvisibility=hidden \
-              -Wall -Wno-unused-function -Wno-sign-compare -std=c++2a -Wvla \
+              -Wall -Wno-unused-function -Wno-sign-compare -std=c++20 -Wvla \
               -isystem $(CUDA_INC) -isystem $(CUDA_INC)/cccl \
               $(CXXFLAGS)
 # Maxrregcount needs to be set accordingly to NCCL_MAX_NTHREADS (otherwise it will cause kernel launch errors)


### PR DESCRIPTION
Summary:
- Upgrade NVCC C++ standard from C++17 to C++20 in v2_27 and v2_29 makefiles
- Remove redundant forward declaration of `MapperTrace` from CtranMapper.h that was added as a workaround for NVCC's lack of concepts support (the header is already included)

Differential Revision: D100901276


