### PR TITLE
Add Triton IB sendrecv and put_bw kernels

### DIFF
--- a/comms/pipes/collectives/benchmarks/IbSendRecvBenchmark.cc
+++ b/comms/pipes/collectives/benchmarks/IbSendRecvBenchmark.cc
@@ -1,0 +1,1020 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// IB SendRecv benchmark: measures RDMA put and pipelined send/recv bandwidth
+// using the TorchComm device API (NCCLx/GIN backend).
+//
+// Tests:
+//   PutSingleBlock   — one block puts the full buffer, sweep over sizes.
+//   PutMultiBlock    — N blocks each put total/N bytes, sweep over block
+//   counts. SendRecvMultiBlock — pipelined sendrecv with section=total
+//   (steps=1, PD=1). SendRecvTileSweep  — 128 blocks, tile size sweep (steps=1,
+//   PD=1). SendRecvParamSweep — blocks x section x PD sweep for Pareto
+//   analysis. SendRecvLargeTileSweep — large total (1-4GB), tile sweep, PD
+//   sweep.
+
+#include <gtest/gtest.h>
+#include <nccl.h> // @manual
+
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/MemPool.h>
+#include <c10/cuda/CUDACachingAllocator.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAStream.h>
+#include <torch/csrc/distributed/c10d/PrefixStore.hpp> // @manual=//caffe2:torch-cpp-cpu
+#include <torch/csrc/distributed/c10d/TCPStore.hpp> // @manual=//caffe2:torch-cpp-cpu
+
+#include "comms/pipes/collectives/benchmarks/IbSendRecvBenchmarkKernels.cuh"
+#include "comms/pipes/collectives/ib/SendRecv.cuh"
+#include "comms/torchcomms/TorchComm.hpp"
+#include "comms/torchcomms/device/TorchCommDeviceWindow.hpp"
+#include "comms/torchcomms/ncclx/TorchCommWindowNCCLX.hpp"
+#include "comms/torchcomms/tests/integration/cpp/TorchCommTestHelpers.h"
+
+using namespace torchcomms::device;
+
+#define NCCL_CHECK(cmd)                                                       \
+  do {                                                                        \
+    ncclResult_t res = cmd;                                                   \
+    ASSERT_EQ(res, ncclSuccess) << "NCCL error: " << ncclGetErrorString(res); \
+  } while (0)
+
+namespace {
+
+constexpr int kWarmupIters = 20;
+constexpr int kMeasureIters = 100;
+constexpr size_t KB = 1024;
+constexpr size_t MB = 1024 * 1024;
+constexpr size_t GB = 1024UL * 1024 * 1024;
+
+std::string format_size(size_t bytes) {
+  if (bytes >= GB) {
+    return std::to_string(bytes / GB) + "GB";
+  }
+  if (bytes >= MB) {
+    return std::to_string(bytes / MB) + "MB";
+  }
+  if (bytes >= KB) {
+    return std::to_string(bytes / KB) + "KB";
+  }
+  return std::to_string(bytes) + "B";
+}
+
+struct WindowSetup {
+  std::unique_ptr<at::cuda::MemPool> mem_pool;
+  at::Tensor win_tensor;
+  at::Tensor src_tensor;
+  std::shared_ptr<torch::comms::TorchCommWindow> win;
+  DeviceWindowNCCL* dev_win{nullptr};
+  RegisteredBufferNCCL src_buf{};
+};
+
+WindowSetup create_window_setup(
+    std::shared_ptr<torch::comms::TorchComm>& torchcomm,
+    std::shared_ptr<c10::Allocator>& allocator,
+    int device_index,
+    size_t total_bytes,
+    int signal_count) {
+  WindowSetup s;
+  size_t count = total_bytes / sizeof(float);
+
+  s.mem_pool = std::make_unique<at::cuda::MemPool>(
+      std::static_pointer_cast<c10::cuda::CUDACachingAllocator::CUDAAllocator>(
+          allocator));
+  c10::cuda::CUDACachingAllocator::beginAllocateToPool(
+      s.mem_pool->device(), s.mem_pool->id(), [](cudaStream_t) {
+        return true;
+      });
+
+  auto options =
+      at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, device_index);
+  s.win_tensor = at::zeros({static_cast<int64_t>(count)}, options);
+
+  c10::cuda::CUDACachingAllocator::endAllocateToPool(
+      s.mem_pool->device(), s.mem_pool->id());
+
+  // Allocate src outside pool for proper alignment.
+  s.src_tensor = at::zeros({static_cast<int64_t>(count)}, options);
+
+  torchcomm->barrier(false);
+  s.win = torchcomm->new_window();
+  s.win->tensor_register(s.win_tensor);
+  torchcomm->barrier(false);
+
+  s.dev_win = static_cast<DeviceWindowNCCL*>(
+      s.win->get_device_window(signal_count, -1, 2));
+  s.src_buf = s.win->register_local_buffer(s.src_tensor);
+
+  torchcomm->barrier(false);
+  cudaDeviceSynchronize();
+
+  return s;
+}
+
+void teardown_window(
+    WindowSetup& s,
+    std::shared_ptr<torch::comms::TorchComm>& torchcomm) {
+  s.win->deregister_local_buffer(s.src_buf);
+  s.win->tensor_deregister();
+  s.win.reset();
+  s.mem_pool.reset();
+  torchcomm->barrier(false);
+}
+
+} // namespace
+
+class IbSendRecvBenchmark : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const char* env = std::getenv("RUN_PUT_BW_BENCHMARK");
+    if (!env || (std::string(env) != "1" && std::string(env) != "true")) {
+      GTEST_SKIP() << "Set RUN_PUT_BW_BENCHMARK=true to run";
+    }
+
+    wrapper_ = std::make_unique<TorchCommTestWrapper>();
+    torchcomm_ = wrapper_->getTorchComm();
+    rank_ = torchcomm_->getRank();
+    num_ranks_ = torchcomm_->getSize();
+    device_index_ = rank_ % at::cuda::device_count();
+    allocator_ = torch::comms::get_mem_allocator(torchcomm_->getBackend());
+
+    // Create a standalone NCCL communicator for baseline comparison.
+    // Bootstrap ncclUniqueId via TCPStore (same MASTER_ADDR/PORT as TorchComm).
+    const char* host = std::getenv("MASTER_ADDR");
+    const char* port_str = std::getenv("MASTER_PORT");
+    if (host && port_str) {
+      c10d::TCPStoreOptions opts;
+      opts.port = std::stoi(port_str);
+      opts.isServer = (rank_ == 0);
+      opts.waitWorkers = false;
+      opts.useLibUV = true;
+      auto store = c10::make_intrusive<c10d::TCPStore>(std::string{host}, opts);
+      auto prefixed =
+          c10::make_intrusive<c10d::PrefixStore>("nccl_baseline", store);
+
+      ncclUniqueId nccl_id;
+      if (rank_ == 0) {
+        ncclGetUniqueId(&nccl_id);
+        auto id_vec = std::vector<uint8_t>(
+            reinterpret_cast<uint8_t*>(&nccl_id),
+            reinterpret_cast<uint8_t*>(&nccl_id) + sizeof(nccl_id));
+        prefixed->set("nccl_id", id_vec);
+      }
+      prefixed->wait({"nccl_id"});
+      auto id_vec = prefixed->get("nccl_id");
+      memcpy(&nccl_id, id_vec.data(), sizeof(nccl_id));
+
+      ncclCommInitRank(&nccl_comm_, num_ranks_, nccl_id, rank_);
+    }
+  }
+
+  void TearDown() override {
+    if (nccl_comm_) {
+      ncclCommDestroy(nccl_comm_);
+      nccl_comm_ = nullptr;
+    }
+    torchcomm_.reset();
+    wrapper_.reset();
+  }
+
+  struct BenchResult {
+    size_t total_bytes;
+    int num_blocks;
+    int iterations;
+    float elapsed_ms;
+    double bw_gbps;
+  };
+
+  BenchResult run_put_benchmark(size_t total_bytes, int num_blocks) {
+    int signal_count = 2 * num_blocks;
+    auto s = create_window_setup(
+        torchcomm_, allocator_, device_index_, total_bytes, signal_count);
+
+    int dst_rank = (rank_ + 1) % num_ranks_;
+    int src_rank = (rank_ - 1 + num_ranks_) % num_ranks_;
+
+    auto stream = at::cuda::getStreamFromPool(false, device_index_);
+
+    // Warmup
+    {
+      c10::cuda::CUDAStreamGuard guard(stream);
+      comms::pipes::ib::benchmark::launch_put_bw_kernel(
+          s.dev_win,
+          s.src_buf,
+          total_bytes,
+          dst_rank,
+          src_rank,
+          num_blocks,
+          0,
+          kWarmupIters,
+          stream.stream());
+    }
+    stream.synchronize();
+    torchcomm_->barrier(false);
+
+    // Timed run
+    cudaEvent_t start, stop;
+    cudaEventCreate(&start);
+    cudaEventCreate(&stop);
+
+    {
+      c10::cuda::CUDAStreamGuard guard(stream);
+      cudaEventRecord(start, stream.stream());
+      comms::pipes::ib::benchmark::launch_put_bw_kernel(
+          s.dev_win,
+          s.src_buf,
+          total_bytes,
+          dst_rank,
+          src_rank,
+          num_blocks,
+          kWarmupIters,
+          kMeasureIters,
+          stream.stream());
+      cudaEventRecord(stop, stream.stream());
+    }
+    cudaEventSynchronize(stop);
+
+    float elapsed_ms = 0;
+    cudaEventElapsedTime(&elapsed_ms, start, stop);
+
+    double total_data = static_cast<double>(total_bytes) * kMeasureIters;
+    double bw = total_data / (elapsed_ms / 1000.0) / 1e9;
+
+    cudaEventDestroy(start);
+    cudaEventDestroy(stop);
+    teardown_window(s, torchcomm_);
+
+    return {total_bytes, num_blocks, kMeasureIters, elapsed_ms, bw};
+  }
+
+  BenchResult run_send_recv_benchmark(
+      size_t total_bytes,
+      size_t section_bytes,
+      int pipeline_depth,
+      int num_blocks) {
+    int signal_count = 2 * num_blocks;
+    int counter_count = num_blocks;
+    int total_steps = total_bytes / section_bytes;
+
+    // Staging and window are ring buffers: pipeline_depth * section_bytes
+    size_t ring_bytes = pipeline_depth * section_bytes;
+    size_t ring_count = ring_bytes / sizeof(float);
+    size_t total_count = total_bytes / sizeof(float);
+
+    // MemPool for window tensor (recv staging ring buffer)
+    auto mem_pool = std::make_unique<at::cuda::MemPool>(
+        std::static_pointer_cast<
+            c10::cuda::CUDACachingAllocator::CUDAAllocator>(allocator_));
+    c10::cuda::CUDACachingAllocator::beginAllocateToPool(
+        mem_pool->device(), mem_pool->id(), [](cudaStream_t) { return true; });
+
+    auto options =
+        at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, device_index_);
+    auto win_tensor = at::zeros({static_cast<int64_t>(ring_count)}, options);
+
+    c10::cuda::CUDACachingAllocator::endAllocateToPool(
+        mem_pool->device(), mem_pool->id());
+
+    // Allocate src, staging, dst outside pool
+    auto src_tensor = at::zeros({static_cast<int64_t>(total_count)}, options);
+    auto staging_tensor =
+        at::zeros({static_cast<int64_t>(ring_count)}, options);
+    auto dst_tensor = at::zeros({static_cast<int64_t>(total_count)}, options);
+
+    torchcomm_->barrier(false);
+    auto win = torchcomm_->new_window();
+    win->tensor_register(win_tensor);
+    torchcomm_->barrier(false);
+
+    auto dev_win = static_cast<DeviceWindowNCCL*>(
+        win->get_device_window(signal_count, counter_count, 2));
+    auto staging_buf = win->register_local_buffer(staging_tensor);
+
+    torchcomm_->barrier(false);
+    cudaDeviceSynchronize();
+
+    int dst_rank = (rank_ + 1) % num_ranks_;
+    int src_rank = (rank_ - 1 + num_ranks_) % num_ranks_;
+
+    auto stream = at::cuda::getStreamFromPool(false, device_index_);
+
+    float* src_ptr = src_tensor.data_ptr<float>();
+    float* staging_ptr = staging_tensor.data_ptr<float>();
+    float* win_ptr = win_tensor.data_ptr<float>();
+    float* dst_ptr = dst_tensor.data_ptr<float>();
+
+    // Warmup
+    {
+      c10::cuda::CUDAStreamGuard guard(stream);
+      comms::pipes::ib::launch_send_recv_kernel(
+          dev_win,
+          staging_buf,
+          src_ptr,
+          staging_ptr,
+          win_ptr,
+          dst_ptr,
+          total_bytes,
+          section_bytes,
+          pipeline_depth,
+          dst_rank,
+          src_rank,
+          num_blocks,
+          0,
+          kWarmupIters,
+          stream.stream());
+    }
+    stream.synchronize();
+    torchcomm_->barrier(false);
+
+    // Timed run
+    int measure_signal_base = kWarmupIters * total_steps;
+    cudaEvent_t start, stop;
+    cudaEventCreate(&start);
+    cudaEventCreate(&stop);
+
+    {
+      c10::cuda::CUDAStreamGuard guard(stream);
+      cudaEventRecord(start, stream.stream());
+      comms::pipes::ib::launch_send_recv_kernel(
+          dev_win,
+          staging_buf,
+          src_ptr,
+          staging_ptr,
+          win_ptr,
+          dst_ptr,
+          total_bytes,
+          section_bytes,
+          pipeline_depth,
+          dst_rank,
+          src_rank,
+          num_blocks,
+          measure_signal_base,
+          kMeasureIters,
+          stream.stream());
+      cudaEventRecord(stop, stream.stream());
+    }
+    cudaEventSynchronize(stop);
+
+    float elapsed_ms = 0;
+    cudaEventElapsedTime(&elapsed_ms, start, stop);
+
+    double total_data = static_cast<double>(total_bytes) * kMeasureIters;
+    double bw = total_data / (elapsed_ms / 1000.0) / 1e9;
+
+    cudaEventDestroy(start);
+    cudaEventDestroy(stop);
+
+    // Teardown
+    win->deregister_local_buffer(staging_buf);
+    win->tensor_deregister();
+    win.reset();
+    mem_pool.reset();
+    torchcomm_->barrier(false);
+
+    return {total_bytes, num_blocks, kMeasureIters, elapsed_ms, bw};
+  }
+
+  BenchResult run_nccl_baseline(size_t total_bytes) {
+    EXPECT_NE(nccl_comm_, nullptr) << "NCCL comm not initialized";
+    int peer_rank = (rank_ + 1) % num_ranks_;
+
+    auto options =
+        at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, device_index_);
+    size_t total_count = total_bytes / sizeof(float);
+    auto send_tensor = at::zeros({static_cast<int64_t>(total_count)}, options);
+    auto recv_tensor = at::zeros({static_cast<int64_t>(total_count)}, options);
+
+    auto stream = at::cuda::getStreamFromPool(false, device_index_);
+
+    // Warmup
+    for (int i = 0; i < kWarmupIters; i++) {
+      ncclGroupStart();
+      ncclSend(
+          send_tensor.data_ptr(),
+          total_bytes,
+          ncclChar,
+          peer_rank,
+          nccl_comm_,
+          stream.stream());
+      ncclRecv(
+          recv_tensor.data_ptr(),
+          total_bytes,
+          ncclChar,
+          peer_rank,
+          nccl_comm_,
+          stream.stream());
+      ncclGroupEnd();
+    }
+    stream.synchronize();
+    torchcomm_->barrier(false);
+
+    // Timed run
+    cudaEvent_t start, stop;
+    cudaEventCreate(&start);
+    cudaEventCreate(&stop);
+
+    cudaEventRecord(start, stream.stream());
+    for (int i = 0; i < kMeasureIters; i++) {
+      ncclGroupStart();
+      ncclSend(
+          send_tensor.data_ptr(),
+          total_bytes,
+          ncclChar,
+          peer_rank,
+          nccl_comm_,
+          stream.stream());
+      ncclRecv(
+          recv_tensor.data_ptr(),
+          total_bytes,
+          ncclChar,
+          peer_rank,
+          nccl_comm_,
+          stream.stream());
+      ncclGroupEnd();
+    }
+    cudaEventRecord(stop, stream.stream());
+    cudaEventSynchronize(stop);
+
+    float elapsed_ms = 0;
+    cudaEventElapsedTime(&elapsed_ms, start, stop);
+
+    double total_data = static_cast<double>(total_bytes) * kMeasureIters;
+    double bw = total_data / (elapsed_ms / 1000.0) / 1e9;
+
+    cudaEventDestroy(start);
+    cudaEventDestroy(stop);
+
+    return {total_bytes, 0, kMeasureIters, elapsed_ms, bw};
+  }
+
+  std::unique_ptr<TorchCommTestWrapper> wrapper_;
+  std::shared_ptr<torch::comms::TorchComm> torchcomm_;
+  std::shared_ptr<c10::Allocator> allocator_;
+  ncclComm_t nccl_comm_{nullptr};
+  int rank_{0};
+  int num_ranks_{0};
+  int device_index_{0};
+};
+
+TEST_F(IbSendRecvBenchmark, PutSingleBlock) {
+  std::vector<size_t> sizes = {
+      256 * KB, 1 * MB, 4 * MB, 16 * MB, 64 * MB, 128 * MB, 512 * MB};
+
+  if (rank_ == 0) {
+    printf("\n=== Put BW: Single Block (BLOCK scope, zero-copy) ===\n");
+    printf(
+        "%-12s  %5s  %10s  %10s\n", "PutSize", "Iters", "Lat(us)", "BW(GB/s)");
+    printf(
+        "%-12s  %5s  %10s  %10s\n", "-------", "-----", "-------", "--------");
+  }
+
+  for (size_t sz : sizes) {
+    auto r = run_put_benchmark(sz, 1);
+    if (rank_ == 0) {
+      double lat_us = r.elapsed_ms * 1000.0 / r.iterations;
+      printf(
+          "%-12s  %5d  %10.1f  %10.2f\n",
+          format_size(r.total_bytes).c_str(),
+          r.iterations,
+          lat_us,
+          r.bw_gbps);
+    }
+  }
+}
+
+TEST_F(IbSendRecvBenchmark, PutMultiBlock) {
+  size_t total = 512 * MB;
+  std::vector<int> block_counts = {1, 2, 4, 8, 16, 32, 64, 128};
+
+  if (rank_ == 0) {
+    printf(
+        "\n=== Put BW: Multi Block (512MB total, BLOCK scope, zero-copy) ===\n");
+    printf(
+        "%-8s  %-12s  %5s  %10s  %10s\n",
+        "Blocks",
+        "TileSize",
+        "Iters",
+        "Lat(us)",
+        "BW(GB/s)");
+    printf(
+        "%-8s  %-12s  %5s  %10s  %10s\n",
+        "------",
+        "--------",
+        "-----",
+        "-------",
+        "--------");
+  }
+
+  for (int nblk : block_counts) {
+    auto r = run_put_benchmark(total, nblk);
+    if (rank_ == 0) {
+      double lat_us = r.elapsed_ms * 1000.0 / r.iterations;
+      printf(
+          "%-8d  %-12s  %5d  %10.1f  %10.2f\n",
+          nblk,
+          format_size(total / nblk).c_str(),
+          r.iterations,
+          lat_us,
+          r.bw_gbps);
+    }
+  }
+}
+
+TEST_F(IbSendRecvBenchmark, SendRecvMultiBlock) {
+  // Uses pipelined kernel with section=total (steps=1, PD=1) — equivalent
+  // to the old non-pipelined sendRecvBwKernel.
+  size_t total = 512 * MB;
+  std::vector<int> block_counts = {1, 2, 4, 8, 16, 32, 64, 128};
+
+  if (rank_ == 0) {
+    printf(
+        "\n=== SendRecv BW: Multi Block (512MB total, BLOCK scope, copy-based) ===\n");
+    printf(
+        "%-8s  %-12s  %5s  %10s  %10s\n",
+        "Blocks",
+        "TileSize",
+        "Iters",
+        "Lat(us)",
+        "BW(GB/s)");
+    printf(
+        "%-8s  %-12s  %5s  %10s  %10s\n",
+        "------",
+        "--------",
+        "-----",
+        "-------",
+        "--------");
+  }
+
+  for (int nblk : block_counts) {
+    auto r = run_send_recv_benchmark(total, total, 1, nblk);
+    if (rank_ == 0) {
+      double lat_us = r.elapsed_ms * 1000.0 / r.iterations;
+      printf(
+          "%-8d  %-12s  %5d  %10.1f  %10.2f\n",
+          nblk,
+          format_size(total / nblk).c_str(),
+          r.iterations,
+          lat_us,
+          r.bw_gbps);
+    }
+  }
+}
+
+TEST_F(IbSendRecvBenchmark, SendRecvTileSweep) {
+  // 128 blocks, sweep tile sizes by varying total (steps=1, PD=1).
+  // Tile = total / 128. Larger tile -> less per-tile overhead.
+  int nblk = 128;
+  std::vector<size_t> totals = {512 * MB, 1024 * MB, 2048 * MB, 4096UL * MB};
+
+  if (rank_ == 0) {
+    printf(
+        "\n=== SendRecv BW: 128 Blocks, Tile Size Sweep (steps=1, PD=1) ===\n");
+    printf("%-12s  %-10s  %10s\n", "Total", "Tile", "BW(GB/s)");
+    printf("%-12s  %-10s  %10s\n", "-----", "----", "--------");
+  }
+
+  for (size_t total : totals) {
+    size_t section = total; // steps=1
+    int pd = 1;
+    size_t tile = section / nblk;
+
+    auto r = run_send_recv_benchmark(total, section, pd, nblk);
+    if (rank_ == 0) {
+      printf(
+          "%-12s  %-10s  %10.2f\n",
+          format_size(total).c_str(),
+          format_size(tile).c_str(),
+          r.bw_gbps);
+    }
+  }
+}
+
+TEST_F(IbSendRecvBenchmark, SendRecvParamSweep) {
+  // Full parameter sweep: blocks x section x pd for Pareto analysis.
+  size_t total = 512 * MB;
+  std::vector<int> block_counts = {16, 32, 64, 128};
+  std::vector<size_t> section_sizes = {
+      32 * MB, 64 * MB, 128 * MB, 256 * MB, 512 * MB};
+  std::vector<int> pd_values = {1, 2, 4};
+
+  if (rank_ == 0) {
+    printf(
+        "\n=== SendRecv Pipelined: Full Parameter Sweep (512MB total) ===\n");
+    printf(
+        "%-22s | %-6s | %-10s | %-4s | %-10s | %-6s | %-10s | %-12s\n",
+        "Name",
+        "Blocks",
+        "Section",
+        "PD",
+        "Tile",
+        "Steps",
+        "Staging",
+        "BW(GB/s)");
+    printf(
+        "----------------------------------------------------------------------"
+        "------------------------------------------------------\n");
+  }
+
+  for (int nblk : block_counts) {
+    for (size_t sec : section_sizes) {
+      if (sec > total)
+        continue;
+      int total_steps = total / sec;
+      for (int pd : pd_values) {
+        if (pd > total_steps)
+          continue;
+        size_t tile = sec / nblk;
+        size_t staging = static_cast<size_t>(pd) * sec * 2; // send + recv
+
+        char name[64];
+        snprintf(
+            name,
+            sizeof(name),
+            "b%d_s%s_p%d",
+            nblk,
+            format_size(sec).c_str(),
+            pd);
+
+        auto r = run_send_recv_benchmark(total, sec, pd, nblk);
+        if (rank_ == 0) {
+          printf(
+              "%-22s | %-6d | %-10s | %-4d | %-10s | %-6d | %-10s | %-12.2f\n",
+              name,
+              nblk,
+              format_size(sec).c_str(),
+              pd,
+              format_size(tile).c_str(),
+              total_steps,
+              format_size(staging).c_str(),
+              r.bw_gbps);
+        }
+      }
+    }
+  }
+}
+
+TEST_F(IbSendRecvBenchmark, SendRecvSizeSweep) {
+  // Full size sweep from 32KB to 4GB. 128 blocks, section=total (1 step),
+  // PD=1. Tile = total/128. Shows bandwidth across the full size range.
+  int nblk = 128;
+  int pd = 1;
+  std::vector<size_t> sizes = {
+      32 * KB,
+      64 * KB,
+      128 * KB,
+      256 * KB,
+      512 * KB,
+      1 * MB,
+      2 * MB,
+      4 * MB,
+      8 * MB,
+      16 * MB,
+      32 * MB,
+      64 * MB,
+      128 * MB,
+      256 * MB,
+      512 * MB,
+      1 * GB,
+      2 * GB,
+      4 * GB};
+
+  if (rank_ == 0) {
+    printf("\n=== SendRecv Size Sweep (128 blocks, section=total, PD=1) ===\n");
+    printf("%-12s  %-10s  %10s\n", "Total", "Tile", "BW(GB/s)");
+    printf("%-12s  %-10s  %10s\n", "-----", "----", "--------");
+  }
+
+  for (size_t total : sizes) {
+    size_t section = total;
+    auto r = run_send_recv_benchmark(total, section, pd, nblk);
+    if (rank_ == 0) {
+      printf(
+          "%-12s  %-10s  %10.2f\n",
+          format_size(total).c_str(),
+          format_size(total / nblk).c_str(),
+          r.bw_gbps);
+    }
+  }
+}
+
+TEST_F(IbSendRecvBenchmark, SendRecvLargeTileSweep) {
+  // Large-buffer sweep: total={1GB,2GB,4GB}, tile={8MB,16MB}, PD={1,2,4},
+  // 128 blocks. OOM guard at 4GB per direction.
+  int nblk = 128;
+  std::vector<size_t> totals = {1 * GB, 2 * GB, 4 * GB};
+  std::vector<size_t> tile_sizes = {8 * MB, 16 * MB};
+  std::vector<int> pd_values = {1, 2, 4};
+
+  if (rank_ == 0) {
+    printf("\n=== SendRecv Large Tile Sweep (128 blocks) ===\n");
+    printf(
+        "%-12s | %-10s | %-10s | %-4s | %-6s | %-10s | %-12s\n",
+        "Total",
+        "Section",
+        "Tile",
+        "PD",
+        "Steps",
+        "Staging",
+        "BW(GB/s)");
+    printf(
+        "----------------------------------------------------------------------"
+        "----------------------------------\n");
+  }
+
+  for (size_t total : totals) {
+    for (size_t tile : tile_sizes) {
+      size_t section = tile * nblk;
+      if (section > total)
+        continue;
+      int total_steps = total / section;
+      for (int pd : pd_values) {
+        if (pd > total_steps)
+          continue;
+        // OOM guard: staging + window = 2 * pd * section, src + dst = 2 * total
+        size_t ring_bytes = static_cast<size_t>(pd) * section;
+        size_t mem_per_dir = total + ring_bytes * 2; // src/dst + staging + win
+        if (mem_per_dir > 16 * GB) {
+          if (rank_ == 0) {
+            printf(
+                "%-12s | %-10s | %-10s | %-4d | SKIP (OOM: %s/dir)\n",
+                format_size(total).c_str(),
+                format_size(section).c_str(),
+                format_size(tile).c_str(),
+                pd,
+                format_size(mem_per_dir).c_str());
+          }
+          continue;
+        }
+
+        auto r = run_send_recv_benchmark(total, section, pd, nblk);
+        if (rank_ == 0) {
+          size_t staging = static_cast<size_t>(pd) * section * 2;
+          printf(
+              "%-12s | %-10s | %-10s | %-4d | %-6d | %-10s | %-12.2f\n",
+              format_size(total).c_str(),
+              format_size(section).c_str(),
+              format_size(tile).c_str(),
+              pd,
+              total_steps,
+              format_size(staging).c_str(),
+              r.bw_gbps);
+        }
+      }
+    }
+  }
+}
+
+TEST_F(IbSendRecvBenchmark, SendRecvCorrectness) {
+  // Verify data correctness: fill src with rank-specific pattern, run
+  // sendrecv, check dst has peer's pattern. Tests multiple configs
+  // including PD > 1 to exercise the ring buffer offset logic.
+  struct Config {
+    size_t total;
+    size_t section;
+    int pd;
+    int nblk;
+  };
+  std::vector<Config> configs = {
+      // PD=1: single slot, no ring offset
+      {64 * KB, 64 * KB, 1, 128},
+      {1 * MB, 1 * MB, 1, 128},
+      {16 * MB, 16 * MB, 1, 128},
+      // PD=2: exercises ring buffer slot offsets
+      {2 * MB, 1 * MB, 2, 128},
+      {16 * MB, 8 * MB, 2, 128},
+      // PD=4: deeper pipeline
+      {16 * MB, 4 * MB, 4, 128},
+      // Fewer blocks
+      {4 * MB, 4 * MB, 1, 32},
+      {4 * MB, 2 * MB, 2, 64},
+  };
+
+  int dst_rank = (rank_ + 1) % num_ranks_;
+  int src_rank = (rank_ - 1 + num_ranks_) % num_ranks_;
+
+  for (const auto& cfg : configs) {
+    int signal_count = 2 * cfg.nblk;
+    int counter_count = cfg.nblk;
+    size_t ring_bytes = cfg.pd * cfg.section;
+    size_t ring_count = ring_bytes / sizeof(float);
+    size_t total_count = cfg.total / sizeof(float);
+
+    auto mem_pool = std::make_unique<at::cuda::MemPool>(
+        std::static_pointer_cast<
+            c10::cuda::CUDACachingAllocator::CUDAAllocator>(allocator_));
+    c10::cuda::CUDACachingAllocator::beginAllocateToPool(
+        mem_pool->device(), mem_pool->id(), [](cudaStream_t) { return true; });
+
+    auto options =
+        at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, device_index_);
+    auto win_tensor = at::zeros({static_cast<int64_t>(ring_count)}, options);
+
+    c10::cuda::CUDACachingAllocator::endAllocateToPool(
+        mem_pool->device(), mem_pool->id());
+
+    // Fill src with rank-specific pattern: src[i] = rank * 1000000 + i
+    auto src_tensor =
+        at::arange(
+            static_cast<int64_t>(total_count), options.dtype(at::kFloat)) +
+        static_cast<float>(rank_) * 1000000.0f;
+    auto staging_tensor =
+        at::zeros({static_cast<int64_t>(ring_count)}, options);
+    auto dst_tensor = at::zeros({static_cast<int64_t>(total_count)}, options);
+
+    torchcomm_->barrier(false);
+    auto win = torchcomm_->new_window();
+    win->tensor_register(win_tensor);
+    torchcomm_->barrier(false);
+
+    auto dev_win = static_cast<DeviceWindowNCCL*>(
+        win->get_device_window(signal_count, counter_count, 2));
+    auto staging_buf = win->register_local_buffer(staging_tensor);
+
+    torchcomm_->barrier(false);
+    cudaDeviceSynchronize();
+
+    auto stream = at::cuda::getStreamFromPool(false, device_index_);
+
+    {
+      c10::cuda::CUDAStreamGuard guard(stream);
+      comms::pipes::ib::launch_send_recv_kernel(
+          dev_win,
+          staging_buf,
+          src_tensor.data_ptr<float>(),
+          staging_tensor.data_ptr<float>(),
+          win_tensor.data_ptr<float>(),
+          dst_tensor.data_ptr<float>(),
+          cfg.total,
+          cfg.section,
+          cfg.pd,
+          dst_rank,
+          src_rank,
+          cfg.nblk,
+          0,
+          1,
+          stream.stream());
+    }
+    stream.synchronize();
+    torchcomm_->barrier(false);
+
+    // Verify: dst should contain src_rank's pattern
+    auto expected =
+        at::arange(
+            static_cast<int64_t>(total_count), options.dtype(at::kFloat)) +
+        static_cast<float>(src_rank) * 1000000.0f;
+    auto dst_cpu = dst_tensor.cpu();
+    auto exp_cpu = expected.cpu();
+
+    bool match = at::allclose(dst_cpu, exp_cpu);
+    EXPECT_TRUE(match) << "Correctness FAILED for total="
+                       << format_size(cfg.total)
+                       << " section=" << format_size(cfg.section)
+                       << " pd=" << cfg.pd << " nblk=" << cfg.nblk;
+    if (rank_ == 0) {
+      printf(
+          "Correctness: total=%-8s section=%-8s pd=%d nblk=%-4d %s\n",
+          format_size(cfg.total).c_str(),
+          format_size(cfg.section).c_str(),
+          cfg.pd,
+          cfg.nblk,
+          match ? "PASS" : "FAIL");
+    }
+    if (!match) {
+      auto diff = (dst_cpu - exp_cpu).abs();
+      auto max_diff = diff.max().item<float>();
+      auto mismatch_idx = diff.argmax().item<int64_t>();
+      if (rank_ == 0) {
+        printf(
+            "  max_diff=%.1f at idx=%ld got=%.1f expected=%.1f\n",
+            max_diff,
+            mismatch_idx,
+            dst_cpu[mismatch_idx].item<float>(),
+            exp_cpu[mismatch_idx].item<float>());
+      }
+    }
+
+    win->deregister_local_buffer(staging_buf);
+    win->tensor_deregister();
+    win.reset();
+    mem_pool.reset();
+    torchcomm_->barrier(false);
+  }
+}
+
+TEST_F(IbSendRecvBenchmark, SendRecvVsNccl) {
+  // Side-by-side comparison: our sendrecv kernel vs NCCL baseline.
+  // Both use the same sizes, warmup, and measurement iterations.
+  int nblk = 128;
+  int pd = 1;
+  std::vector<size_t> sizes = {
+      32 * KB,
+      64 * KB,
+      128 * KB,
+      256 * KB,
+      512 * KB,
+      1 * MB,
+      2 * MB,
+      4 * MB,
+      8 * MB,
+      16 * MB,
+      32 * MB,
+      64 * MB,
+      128 * MB,
+      256 * MB,
+      512 * MB,
+      1 * GB,
+      2 * GB,
+      4 * GB};
+
+  if (rank_ == 0) {
+    printf(
+        "\n=== SendRecv vs NCCL Baseline (128 blocks, section=total, PD=1) ===\n");
+    printf(
+        "%-12s  %12s  %12s  %10s\n",
+        "Total",
+        "Kernel(GB/s)",
+        "NCCL(GB/s)",
+        "Speedup");
+    printf(
+        "%-12s  %12s  %12s  %10s\n",
+        "-----",
+        "------------",
+        "----------",
+        "-------");
+  }
+
+  for (size_t total : sizes) {
+    auto kernel_r = run_send_recv_benchmark(total, total, pd, nblk);
+    auto nccl_r = run_nccl_baseline(total);
+
+    if (rank_ == 0) {
+      double speedup =
+          nccl_r.bw_gbps > 0 ? kernel_r.bw_gbps / nccl_r.bw_gbps : 0;
+      printf(
+          "%-12s  %12.2f  %12.2f  %9.2fx\n",
+          format_size(total).c_str(),
+          kernel_r.bw_gbps,
+          nccl_r.bw_gbps,
+          speedup);
+    }
+  }
+}
+
+TEST_F(IbSendRecvBenchmark, SendRecvFewBlocks) {
+  // Compare kernel with 1 and 2 blocks vs NCCL baseline.
+  // Uses section=total (1 step), PD=1. Large sizes only.
+  int pd = 1;
+  std::vector<int> block_counts = {1, 2};
+  std::vector<size_t> sizes = {
+      1 * MB,
+      4 * MB,
+      16 * MB,
+      64 * MB,
+      256 * MB,
+      512 * MB,
+      1 * GB,
+      2 * GB,
+      4 * GB};
+
+  for (int nblk : block_counts) {
+    if (rank_ == 0) {
+      printf(
+          "\n=== SendRecv vs NCCL (%d block%s, section=total, PD=1) ===\n",
+          nblk,
+          nblk > 1 ? "s" : "");
+      printf(
+          "%-12s  %12s  %12s  %10s\n",
+          "Total",
+          "Kernel(GB/s)",
+          "NCCL(GB/s)",
+          "Speedup");
+      printf(
+          "%-12s  %12s  %12s  %10s\n",
+          "-----",
+          "------------",
+          "----------",
+          "-------");
+    }
+
+    for (size_t total : sizes) {
+      auto kernel_r = run_send_recv_benchmark(total, total, pd, nblk);
+      auto nccl_r = run_nccl_baseline(total);
+
+      if (rank_ == 0) {
+        double speedup =
+            nccl_r.bw_gbps > 0 ? kernel_r.bw_gbps / nccl_r.bw_gbps : 0;
+        printf(
+            "%-12s  %12.2f  %12.2f  %9.2fx\n",
+            format_size(total).c_str(),
+            kernel_r.bw_gbps,
+            nccl_r.bw_gbps,
+            speedup);
+      }
+    }
+  }
+}

--- a/comms/pipes/collectives/benchmarks/IbSendRecvBenchmarkKernels.cu
+++ b/comms/pipes/collectives/benchmarks/IbSendRecvBenchmarkKernels.cu
@@ -1,0 +1,78 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Benchmark-only CUDA kernel: zero-copy RDMA put with BLOCK-scope ops.
+// Not part of the library — used only by IbSendRecvBenchmark.
+
+#include "comms/pipes/collectives/benchmarks/IbSendRecvBenchmarkKernels.cuh"
+
+#include "comms/torchcomms/device/ncclx/TorchCommDeviceNCCLX.cuh"
+
+namespace comms::pipes::ib::benchmark {
+
+using torchcomms::device::CmpOp;
+using torchcomms::device::CoopScope;
+using torchcomms::device::DeviceWindowNCCL;
+using torchcomms::device::RegisteredBufferNCCL;
+using torchcomms::device::SignalOp;
+
+__global__ void put_bw_kernel(
+    DeviceWindowNCCL* win,
+    RegisteredBufferNCCL src_buf,
+    size_t total_bytes,
+    int dst_rank,
+    int src_rank,
+    int signal_base,
+    int iterations) {
+  auto pid = blockIdx.x;
+  auto num_blks = gridDim.x;
+  size_t tile_bytes = total_bytes / num_blks;
+  size_t tile_offset = pid * tile_bytes;
+
+  int data_signal = pid;
+  int ack_signal = num_blks + pid;
+
+  for (int iter = 0; iter < iterations; iter++) {
+    uint64_t expected = static_cast<uint64_t>(signal_base + iter + 1);
+
+    // Put tile to remote, piggyback DATA_READY signal
+    win->put(
+        tile_offset,
+        src_buf,
+        tile_offset,
+        dst_rank,
+        tile_bytes,
+        data_signal,
+        -1,
+        CoopScope::BLOCK);
+    win->flush(CoopScope::BLOCK);
+
+    // Wait for remote's data to arrive (their put to us)
+    win->wait_signal_from(
+        src_rank, data_signal, CmpOp::GE, expected, CoopScope::BLOCK);
+
+    // ACK to remote sender: we received their data
+    win->signal(src_rank, ack_signal, SignalOp::ADD, 1, CoopScope::BLOCK);
+
+    // Wait for ACK from our receiver: they received our data
+    win->wait_signal_from(
+        dst_rank, ack_signal, CmpOp::GE, expected, CoopScope::BLOCK);
+  }
+}
+
+void launch_put_bw_kernel(
+    DeviceWindowNCCL* win,
+    RegisteredBufferNCCL src_buf,
+    size_t total_bytes,
+    int dst_rank,
+    int src_rank,
+    int num_blocks,
+    int signal_base,
+    int iterations,
+    cudaStream_t stream) {
+  put_bw_kernel<<<num_blocks, 256, 0, stream>>>(
+      win, src_buf, total_bytes, dst_rank, src_rank, signal_base, iterations);
+  cudaError_t err = cudaGetLastError();
+  assert(err == cudaSuccess && "put_bw_kernel launch failed");
+}
+
+} // namespace comms::pipes::ib::benchmark

--- a/comms/pipes/collectives/benchmarks/IbSendRecvBenchmarkKernels.cuh
+++ b/comms/pipes/collectives/benchmarks/IbSendRecvBenchmarkKernels.cuh
@@ -1,0 +1,45 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Benchmark-only CUDA kernel declarations for IB put BW measurement.
+// Host-safe header — can be included from .cc files compiled by clang.
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include "comms/torchcomms/device/ncclx/TorchCommDeviceNCCLXTypes.hpp"
+
+namespace comms::pipes::ib::benchmark {
+
+using torchcomms::device::DeviceWindowNCCL;
+using torchcomms::device::RegisteredBufferNCCL;
+
+/**
+ * Launch a zero-copy put BW kernel (benchmark only).
+ *
+ * Each block puts total_bytes/num_blocks per iteration.
+ * Signal layout: 2*num_blocks signals.
+ *   [0, num_blocks)            — DATA_READY (piggybacked on put)
+ *   [num_blocks, 2*num_blocks) — ACK (receiver signals sender)
+ *
+ * @param win          Device window handle.
+ * @param src_buf      Registered source buffer.
+ * @param total_bytes  Total transfer size per iteration.
+ * @param dst_rank     Rank to put to.
+ * @param src_rank     Rank to receive from.
+ * @param num_blocks   Number of blocks in the grid.
+ * @param signal_base  Base offset for signal values.
+ * @param iterations   Number of iterations.
+ * @param stream       CUDA stream.
+ */
+void launch_put_bw_kernel(
+    DeviceWindowNCCL* win,
+    RegisteredBufferNCCL src_buf,
+    size_t total_bytes,
+    int dst_rank,
+    int src_rank,
+    int num_blocks,
+    int signal_base,
+    int iterations,
+    cudaStream_t stream);
+
+} // namespace comms::pipes::ib::benchmark

--- a/comms/pipes/collectives/benchmarks/IbSendRecvBenchmarkMain.cpp
+++ b/comms/pipes/collectives/benchmarks/IbSendRecvBenchmarkMain.cpp
@@ -1,0 +1,8 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/pipes/collectives/ib/SendRecv.cu
+++ b/comms/pipes/collectives/ib/SendRecv.cu
@@ -1,0 +1,316 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// TileChannel-based pipelined send/recv for IB (RDMA).
+//
+// send_tile/recv_tile are user-facing primitives. Each call handles one
+// tile of data, internally chunking through the staging ring buffer if
+// the tile is larger than the per-block staging capacity.
+//
+// The step counter tracks chunks (not tiles) — each chunk consumes one
+// pipeline slot. The caller must ensure that the tile fits within
+// pipeline_depth slots: nbytes <= per_block_chunk_bytes * pipeline_depth.
+
+#include "comms/pipes/collectives/ib/SendRecv.cuh"
+
+#include <stdexcept>
+
+#include "comms/pipes/CopyUtils.cuh"
+#include "comms/pipes/TiledBuffer.cuh"
+#include "comms/torchcomms/device/ncclx/TorchCommDeviceNCCLX.cuh"
+
+namespace comms::pipes::ib {
+
+using torchcomms::device::CmpOp;
+using torchcomms::device::CoopScope;
+using torchcomms::device::DeviceWindowNCCL;
+using torchcomms::device::RegisteredBufferNCCL;
+using torchcomms::device::SignalOp;
+
+// ---- helpers ---------------------------------------------------------------
+
+/**
+ * Cooperative element-wise copy across all threads in a block.
+ *
+ * @param dst   Destination pointer (device global memory).
+ * @param src   Source pointer (device global memory).
+ * @param count Number of float elements to copy.
+ */
+__device__ __forceinline__ void
+local_copy(float* dst, const float* src, size_t count) {
+  for (size_t i = threadIdx.x; i < count; i += blockDim.x) {
+    dst[i] = src[i];
+  }
+}
+
+// ---- TileChannel -----------------------------------------------------------
+
+__device__ TileChannel make_tile_channel(
+    DeviceWindowNCCL* win,
+    RegisteredBufferNCCL staging_buf,
+    float* ring_buf_ptr,
+    int peer_rank,
+    int pid,
+    int num_blocks,
+    int pipeline_depth,
+    size_t staging_slot_bytes,
+    int signal_base) {
+  return TileChannel{
+      .win = win,
+      .staging_buf = staging_buf,
+      .ring_buf_ptr = ring_buf_ptr,
+      .peer_rank = peer_rank,
+      .pid = pid,
+      .num_blocks = num_blocks,
+      .pipeline_depth = pipeline_depth,
+      .staging_slot_bytes = staging_slot_bytes,
+      .data_signal = pid,
+      .slot_free_signal = num_blocks + pid,
+      .nic_counter = pid,
+      .step = signal_base,
+  };
+}
+
+// ---- send_tile -------------------------------------------------------------
+
+__device__ void
+send_tile(TileChannel& ch, const float* src_ptr, size_t nbytes) {
+  size_t per_block_chunk_bytes =
+      (ch.staging_slot_bytes / ch.num_blocks) & ~15ULL;
+  size_t total_chunks =
+      (nbytes + per_block_chunk_bytes - 1) / per_block_chunk_bytes;
+
+  // Pre-compute loop-invariant values.
+  size_t staging_slot_floats = ch.staging_slot_bytes / sizeof(float);
+  size_t per_block_slot_floats = per_block_chunk_bytes / sizeof(float);
+
+  for (size_t c = 0; c < total_chunks; c++) {
+    int slot = ch.step % ch.pipeline_depth;
+
+    size_t data_off_floats = c * per_block_slot_floats;
+    size_t chunk_bytes = (c + 1) * per_block_chunk_bytes <= nbytes
+        ? per_block_chunk_bytes
+        : (nbytes - c * per_block_chunk_bytes);
+
+    // Staging destination: slot within ring + block within slot.
+    float* staging_dst = ch.ring_buf_ptr + slot * staging_slot_floats +
+        ch.pid * per_block_slot_floats;
+
+    // 1. Wait NIC_DONE — staging slot safe to overwrite
+    if (ch.step >= ch.pipeline_depth) {
+      uint64_t nic_expected =
+          static_cast<uint64_t>(ch.step - ch.pipeline_depth + 1);
+      ch.win->wait_counter(
+          ch.nic_counter, CmpOp::GE, nic_expected, CoopScope::BLOCK);
+    }
+
+    // 2. Local copy: src chunk → staging (vectorized uint4 loads)
+    {
+      auto group = comms::pipes::make_block_group();
+      comms::pipes::memcpy_vectorized(
+          reinterpret_cast<char*>(staging_dst),
+          reinterpret_cast<const char*>(src_ptr + data_off_floats),
+          chunk_bytes,
+          group);
+    }
+    __syncthreads();
+    __threadfence_system();
+
+    // 3. Wait SLOT_FREE — remote window slot safe for new put
+    if (ch.step >= ch.pipeline_depth) {
+      uint64_t slot_expected =
+          static_cast<uint64_t>(ch.step - ch.pipeline_depth + 1);
+      ch.win->wait_signal_from(
+          ch.peer_rank,
+          ch.slot_free_signal,
+          CmpOp::GE,
+          slot_expected,
+          CoopScope::BLOCK);
+    }
+
+    // 4. Put: staging → remote window (offset is symmetric: local staging
+    //    layout matches remote window layout).
+    size_t byte_off =
+        static_cast<size_t>(staging_dst - ch.ring_buf_ptr) * sizeof(float);
+    ch.win->put(
+        byte_off,
+        ch.staging_buf,
+        byte_off,
+        ch.peer_rank,
+        chunk_bytes,
+        ch.data_signal,
+        ch.nic_counter,
+        CoopScope::BLOCK);
+
+    ch.step++;
+  }
+}
+
+// ---- recv_tile -------------------------------------------------------------
+
+__device__ void recv_tile(TileChannel& ch, float* dst_ptr, size_t nbytes) {
+  size_t per_block_chunk_bytes =
+      (ch.staging_slot_bytes / ch.num_blocks) & ~15ULL;
+  size_t total_chunks =
+      (nbytes + per_block_chunk_bytes - 1) / per_block_chunk_bytes;
+
+  // Pre-compute loop-invariant values.
+  size_t staging_slot_floats = ch.staging_slot_bytes / sizeof(float);
+  size_t per_block_slot_floats = per_block_chunk_bytes / sizeof(float);
+
+  for (size_t c = 0; c < total_chunks; c++) {
+    int slot = ch.step % ch.pipeline_depth;
+
+    size_t data_off_floats = c * per_block_slot_floats;
+    size_t chunk_bytes = (c + 1) * per_block_chunk_bytes <= nbytes
+        ? per_block_chunk_bytes
+        : (nbytes - c * per_block_chunk_bytes);
+
+    // Window source: slot within ring + block within slot.
+    float* window_src = ch.ring_buf_ptr + slot * staging_slot_floats +
+        ch.pid * per_block_slot_floats;
+
+    // 1. Wait DATA_READY
+    uint64_t expected = static_cast<uint64_t>(ch.step + 1);
+    ch.win->wait_signal_from(
+        ch.peer_rank, ch.data_signal, CmpOp::GE, expected, CoopScope::BLOCK);
+
+    // 2. Local copy: window → dst (vectorized uint4 loads)
+    {
+      auto group = comms::pipes::make_block_group();
+      comms::pipes::memcpy_vectorized(
+          reinterpret_cast<char*>(dst_ptr + data_off_floats),
+          reinterpret_cast<const char*>(window_src),
+          chunk_bytes,
+          group);
+    }
+
+    // 3. Signal SLOT_FREE
+    ch.win->signal(
+        ch.peer_rank, ch.slot_free_signal, SignalOp::ADD, 1, CoopScope::BLOCK);
+
+    ch.step++;
+  }
+}
+
+// ---- drain -----------------------------------------------------------------
+
+__device__ void drain(TileChannel& ch) {
+  // Wait for all outstanding SLOT_FREE signals.
+  // NIC_DONE drain is unnecessary — send_tile waits lazily before reusing
+  // each staging slot.
+  uint64_t drain_val = static_cast<uint64_t>(ch.step);
+  ch.win->wait_signal_from(
+      ch.peer_rank,
+      ch.slot_free_signal,
+      CmpOp::GE,
+      drain_val,
+      CoopScope::BLOCK);
+}
+
+// ---- kernel ----------------------------------------------------------------
+
+__global__ void send_recv_kernel(
+    DeviceWindowNCCL* win,
+    RegisteredBufferNCCL staging_buf,
+    float* src_ptr,
+    float* staging_ptr,
+    float* win_ptr,
+    float* dst_ptr,
+    size_t total_bytes,
+    size_t section_bytes,
+    int pipeline_depth,
+    int dst_rank,
+    int src_rank,
+    int num_blocks,
+    int signal_base,
+    int iterations) {
+  auto bid = blockIdx.x;
+  bool is_sender = bid < num_blocks;
+  int pid = is_sender ? bid : bid - num_blocks;
+  int peer = is_sender ? dst_rank : src_rank;
+
+  // Sender's ring buffer is the staging buffer; receiver's is the window.
+  TileChannel ch = make_tile_channel(
+      win,
+      staging_buf,
+      is_sender ? staging_ptr : win_ptr,
+      peer,
+      pid,
+      num_blocks,
+      pipeline_depth,
+      section_bytes,
+      signal_base);
+
+  size_t section_floats = section_bytes / sizeof(float);
+  int total_steps = total_bytes / section_bytes;
+
+  for (int iter = 0; iter < iterations; iter++) {
+    for (int step = 0; step < total_steps; step++) {
+      TiledBuffer<float> tiles(
+          (is_sender ? src_ptr : dst_ptr) + step * section_floats,
+          section_floats,
+          num_blocks);
+
+      if (is_sender) {
+        send_tile(ch, tiles.tile_data(pid), tiles.tile_bytes(pid));
+      } else {
+        recv_tile(ch, tiles.tile_data(pid), tiles.tile_bytes(pid));
+      }
+    }
+
+    if (is_sender) {
+      drain(ch);
+    }
+  }
+}
+
+// ---- host launch -----------------------------------------------------------
+
+void launch_send_recv_kernel(
+    DeviceWindowNCCL* win,
+    RegisteredBufferNCCL staging_buf,
+    float* src_ptr,
+    float* staging_ptr,
+    float* win_ptr,
+    float* dst_ptr,
+    size_t total_bytes,
+    size_t section_bytes,
+    int pipeline_depth,
+    int dst_rank,
+    int src_rank,
+    int num_blocks,
+    int signal_base,
+    int iterations,
+    cudaStream_t stream) {
+  if (section_bytes == 0 || total_bytes % section_bytes != 0) {
+    throw std::runtime_error(
+        "launch_send_recv_kernel: total_bytes must be a positive multiple of section_bytes");
+  }
+  if (pipeline_depth > static_cast<int>(total_bytes / section_bytes)) {
+    throw std::runtime_error(
+        "launch_send_recv_kernel: pipeline_depth must not exceed total_steps");
+  }
+  send_recv_kernel<<<2 * num_blocks, 256, 0, stream>>>(
+      win,
+      staging_buf,
+      src_ptr,
+      staging_ptr,
+      win_ptr,
+      dst_ptr,
+      total_bytes,
+      section_bytes,
+      pipeline_depth,
+      dst_rank,
+      src_rank,
+      num_blocks,
+      signal_base,
+      iterations);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("send_recv_kernel launch failed: ") +
+        cudaGetErrorString(err));
+  }
+}
+
+} // namespace comms::pipes::ib

--- a/comms/pipes/collectives/ib/SendRecv.cuh
+++ b/comms/pipes/collectives/ib/SendRecv.cuh
@@ -1,0 +1,157 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// User-facing TileChannel API for IB (RDMA) pipelined send/recv.
+//
+// TileChannel encapsulates the signal/counter management and staging buffer
+// layout for GPU-initiated RDMA. Users call send_tile()/recv_tile() as
+// single-step primitives — internal chunking handles tiles larger than
+// the staging slot.
+//
+// Host-safe header for the launch function. Device-side APIs require
+// including SendRecv.cu (compiled by nvcc).
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include "comms/torchcomms/device/ncclx/TorchCommDeviceNCCLXTypes.hpp"
+
+namespace comms::pipes::ib {
+
+using torchcomms::device::DeviceWindowNCCL;
+using torchcomms::device::RegisteredBufferNCCL;
+
+/**
+ * TileChannel — lightweight device-side handle for pipelined RDMA send/recv.
+ *
+ * Encapsulates the window, staging buffer, and signal/counter IDs for one
+ * block's tile communication with a peer. Created once per block, used
+ * across multiple send_tile()/recv_tile() calls.
+ *
+ * The user provides their own staging and window buffers (BYOB). The channel
+ * derives per-block signal/counter IDs from the block's tile index (pid).
+ *
+ * Internal chunking: if the user's tile is larger than what fits in one
+ * staging slot (staging_slot_bytes / num_blocks), send_tile/recv_tile
+ * internally pipeline the tile through the staging ring buffer in multiple
+ * chunks. This decouples staging memory from data size.
+ *
+ * Signal layout: 2 * num_blocks signals.
+ *   [0, num_blocks)             — DATA_READY (piggybacked on put)
+ *   [num_blocks, 2*num_blocks)  — SLOT_FREE  (receiver → sender)
+ * Counter layout: num_blocks counters.
+ *   [0, num_blocks)             — NIC_DONE   (staging reuse)
+ */
+struct TileChannel {
+  DeviceWindowNCCL* win;
+  RegisteredBufferNCCL
+      staging_buf; ///< Registered buffer (sender uses for put).
+  float* ring_buf_ptr; ///< Ring buffer base. Sender: staging. Receiver: window.
+  int peer_rank;
+  int pid; ///< This block's tile index.
+  int num_blocks;
+  int pipeline_depth;
+  size_t
+      staging_slot_bytes; ///< Size of one pipeline slot (full, not per-block).
+
+  // Per-block signal/counter IDs (derived from pid).
+  int data_signal;
+  int slot_free_signal;
+  int nic_counter;
+
+  /// Step counter — monotonically increasing across calls. Tracks signal
+  /// values for backpressure and CUDA graph replay safety.
+  int step;
+};
+
+/**
+ * Initialize a TileChannel for a sender or receiver block.
+ *
+ * @param win              Device window handle.
+ * @param staging_buf      Registered staging buffer (sender uses for put).
+ * @param ring_buf_ptr     Ring buffer base pointer. For senders this is the
+ *                         staging buffer; for receivers this is the window
+ *                         buffer. Both share the same ring layout.
+ * @param peer_rank        Rank to communicate with.
+ * @param pid              This block's tile index (0..num_blocks-1).
+ * @param num_blocks       Total sender (= receiver) blocks.
+ * @param pipeline_depth   Number of ring-buffer slots.
+ * @param staging_slot_bytes Size of one pipeline slot in bytes
+ *                           (staging ring = pipeline_depth *
+ * staging_slot_bytes).
+ * @param signal_base      Initial step counter value (for CUDA graph replay).
+ */
+__device__ TileChannel make_tile_channel(
+    DeviceWindowNCCL* win,
+    RegisteredBufferNCCL staging_buf,
+    float* ring_buf_ptr,
+    int peer_rank,
+    int pid,
+    int num_blocks,
+    int pipeline_depth,
+    size_t staging_slot_bytes,
+    int signal_base);
+
+/**
+ * Send a tile of data to the peer via pipelined RDMA.
+ *
+ * Copies src_ptr → staging, then RDMA puts staging → peer's window.
+ * If nbytes > per-block staging capacity, internally pipelines through
+ * the staging ring buffer in multiple chunks.
+ *
+ * @param ch      TileChannel (step counter is advanced).
+ * @param src_ptr Source data for this block's tile.
+ * @param nbytes  Bytes to send.
+ */
+__device__ void send_tile(TileChannel& ch, const float* src_ptr, size_t nbytes);
+
+/**
+ * Receive a tile of data from the peer.
+ *
+ * Waits for RDMA data to arrive in window, then copies window → dst_ptr.
+ * If nbytes > per-block staging capacity, internally receives in multiple
+ * chunks.
+ *
+ * @param ch      TileChannel (step counter is advanced).
+ * @param dst_ptr Destination for this block's tile.
+ * @param nbytes  Bytes to receive.
+ */
+__device__ void recv_tile(TileChannel& ch, float* dst_ptr, size_t nbytes);
+
+/**
+ * Drain outstanding SLOT_FREE signals.
+ *
+ * Call after all send_tile() calls in an iteration to ensure the peer
+ * has consumed all data before starting the next iteration.
+ *
+ * @param ch TileChannel.
+ */
+__device__ void drain(TileChannel& ch);
+
+/**
+ * Launch a pipelined send/recv kernel over IB (RDMA).
+ *
+ * Convenience launcher that creates TileChannels and calls send_tile/recv_tile
+ * in a loop. For custom kernels, create TileChannels directly and call
+ * send_tile/recv_tile as needed.
+ *
+ * Grid: 2 * num_blocks (first half sends, second half receives).
+ * Block: 256 threads.
+ */
+void launch_send_recv_kernel(
+    DeviceWindowNCCL* win,
+    RegisteredBufferNCCL staging_buf,
+    float* src_ptr,
+    float* staging_ptr,
+    float* win_ptr,
+    float* dst_ptr,
+    size_t total_bytes,
+    size_t section_bytes,
+    int pipeline_depth,
+    int dst_rank,
+    int src_rank,
+    int num_blocks,
+    int signal_base,
+    int iterations,
+    cudaStream_t stream);
+
+} // namespace comms::pipes::ib

--- a/comms/pipes/triton/__init__.py
+++ b/comms/pipes/triton/__init__.py
@@ -1,0 +1,1 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.

--- a/comms/pipes/triton/collectives/__init__.py
+++ b/comms/pipes/triton/collectives/__init__.py
@@ -1,0 +1,1 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.

--- a/comms/pipes/triton/collectives/ib/__init__.py
+++ b/comms/pipes/triton/collectives/ib/__init__.py
@@ -1,0 +1,1 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.

--- a/comms/pipes/triton/collectives/ib/put_bw_kernel.py
+++ b/comms/pipes/triton/collectives/ib/put_bw_kernel.py
@@ -1,0 +1,334 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""
+Triton kernels for microbenchmarking raw ``put_block`` RDMA throughput.
+
+These kernels isolate put_block performance from local-copy overhead by
+operating directly on pre-filled staging buffers. Three experiments are
+provided, each adding a different dimension of overhead:
+
+Kernel 1 — ``put_bw_fireforget_kernel``
+    Fire-and-forget: no flow control, no ring-buffer wrapping. Each step
+    puts from a unique staging offset. Measures the absolute ceiling of
+    put_block throughput.
+
+Kernel 2 — ``put_bw_pipelined_kernel``
+    Pipelined with flow control: ring-buffer staging with SLOT_FREE
+    signaling from the receiver. Measures put_block throughput under
+    realistic back-pressure.
+
+Kernel 3 — ``put_bw_multiblock_kernel``
+    Multi-block pipelined: N send blocks each put their own tile of each
+    section, sharing a single QP. Measures throughput scaling and QP
+    contention effects.
+
+All kernels are bidirectional (each rank sends and receives simultaneously)
+and use monotonic signal/counter tracking identical to sendrecv.
+"""
+
+from torch.utils._triton import has_triton
+
+if has_triton():
+    import triton
+    import triton.language as tl
+    from torchcomms.triton.fb import (
+        fence,
+        put_block,
+        requires_torchcomms,
+        signal_block,
+        wait_counter,
+        wait_signal_from,
+    )
+
+    from .sendrecv_cooperative_kernel import _increment_iteration_kernel  # noqa: F401
+
+    # ------------------------------------------------------------------
+    # Kernel 1: Fire-and-forget put_block throughput
+    # ------------------------------------------------------------------
+
+    @requires_torchcomms
+    @triton.jit
+    def put_bw_fireforget_kernel(
+        # torchcomms handles
+        win,
+        send_buf,
+        # staging pointer (pre-filled, >= total message size)
+        send_staging_ptr,
+        # iteration tracking (monotonic, GPU-resident)
+        iteration_ptr,
+        # sizes
+        total_elements,
+        section_elements,
+        elem_size_bytes,
+        # peer
+        peer_rank: tl.constexpr,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        """
+        Fire-and-forget put_block bandwidth kernel.
+
+        Measures the absolute ceiling of put_block throughput with zero flow
+        control overhead. The staging buffer is sized to hold the entire
+        message, so each step writes to a unique offset — no ring-buffer
+        wrapping and no SLOT_FREE signaling from the receiver.
+
+        Grid: 2 blocks (pid=0 send, pid=1 recv). Bidirectional.
+
+        Signal / counter layout
+        ~~~~~~~~~~~~~~~~~~~~~~~
+        - signal_id=0 (DATA_READY): put_block increments by 1 each step.
+        - signal_id=1 (ALL_DONE): receiver signals sender after all data
+          arrived, ensuring end-to-end delivery is measured.
+        - counter_id=0 (NIC_DONE): put_block increments by 1 each step.
+        """
+        pid = tl.program_id(axis=0)
+        iteration = tl.load(iteration_ptr)
+        total_steps = tl.cdiv(total_elements, section_elements)
+        base = iteration * total_steps
+
+        if pid == 0:
+            # -- Send block --
+            # Post all puts without waiting — true fire-and-forget.
+            # No per-step wait_counter: each step uses a unique staging
+            # offset (no data hazard), and QP depth (1024) >> max steps.
+            # This keeps multiple WQEs in flight to saturate the NIC.
+            for step in range(total_steps):
+                staging_byte_offset = step * section_elements * elem_size_bytes
+
+                # Handle last section which may be smaller.
+                remaining_elements = total_elements - step * section_elements
+                actual_section_elements = tl.where(
+                    section_elements < remaining_elements,
+                    section_elements,
+                    remaining_elements,
+                )
+                section_bytes = actual_section_elements * elem_size_bytes
+
+                put_block(
+                    win,
+                    staging_byte_offset,  # dst_offset in peer's recv buffer
+                    send_buf,
+                    staging_byte_offset,  # src_offset in our staging
+                    peer_rank,
+                    section_bytes,
+                    0,  # signal_id = DATA_READY
+                    0,  # counter_id = NIC_DONE
+                )
+
+            # Wait for receiver to confirm all data arrived (end-to-end).
+            # wait_counter only means NIC finished reading from staging —
+            # NOT that data was delivered to the remote.
+            # ALL_DONE increments by 1 per iteration (not per step), so
+            # use iteration+1, NOT base+1 (base = iteration * total_steps
+            # would grow too fast and deadlock on iteration >= 1).
+            wait_signal_from(win, peer_rank, 1, iteration + 1)
+        else:
+            # -- Recv block --
+            # Wait for all data to arrive.
+            wait_signal_from(win, peer_rank, 0, base + total_steps)
+            # Signal sender that all data was delivered.
+            fence(win)
+            signal_block(win, peer_rank, 1, 1)  # ALL_DONE
+
+    # ------------------------------------------------------------------
+    # Kernel 2: Pipelined put_block with flow control
+    # ------------------------------------------------------------------
+
+    @requires_torchcomms
+    @triton.jit
+    def put_bw_pipelined_kernel(
+        # torchcomms handles
+        win,
+        send_buf,
+        # staging pointer (pipeline_depth * section_size)
+        send_staging_ptr,
+        # iteration tracking (monotonic, GPU-resident)
+        iteration_ptr,
+        # sizes
+        total_elements,
+        section_elements,
+        elem_size_bytes,
+        # pipeline config
+        pipeline_depth,
+        # peer
+        peer_rank: tl.constexpr,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        """
+        Pipelined put_block bandwidth kernel with flow control.
+
+        Measures put_block throughput under realistic ring-buffer back-pressure.
+        The staging buffer holds ``pipeline_depth`` sections, and the receiver
+        signals SLOT_FREE after consuming each section.
+
+        Grid: 2 blocks (pid=0 send, pid=1 recv). Bidirectional.
+
+        Signal / counter layout
+        ~~~~~~~~~~~~~~~~~~~~~~~
+        - signal_id=0 (DATA_READY): put_block increments by 1 each step.
+        - signal_id=1 (SLOT_FREE): receiver's signal_block increments by 1
+          each step after draining.
+        - counter_id=0 (NIC_DONE): put_block increments by 1 each step.
+        """
+        pid = tl.program_id(axis=0)
+        iteration = tl.load(iteration_ptr)
+        total_steps = tl.cdiv(total_elements, section_elements)
+        base = iteration * total_steps
+
+        if pid == 0:
+            # -- Send block --
+            for step in range(total_steps):
+                slot = step % pipeline_depth
+
+                # Wait for NIC + receiver to free the slot before reuse.
+                if step >= pipeline_depth:
+                    wait_counter(win, 0, base + step - pipeline_depth + 1)
+                    wait_signal_from(
+                        win, peer_rank, 1, base + step - pipeline_depth + 1
+                    )
+
+                staging_byte_offset = slot * section_elements * elem_size_bytes
+
+                # Handle last section which may be smaller.
+                remaining_elements = total_elements - step * section_elements
+                actual_section_elements = tl.where(
+                    section_elements < remaining_elements,
+                    section_elements,
+                    remaining_elements,
+                )
+                section_bytes = actual_section_elements * elem_size_bytes
+
+                put_block(
+                    win,
+                    staging_byte_offset,  # dst_offset in peer's recv staging
+                    send_buf,
+                    staging_byte_offset,  # src_offset in our staging
+                    peer_rank,
+                    section_bytes,
+                    0,  # signal_id = DATA_READY
+                    0,  # counter_id = NIC_DONE
+                )
+        else:
+            # -- Recv block --
+            for step in range(total_steps):
+                # Wait for data to arrive for this step.
+                wait_signal_from(win, peer_rank, 0, base + step + 1)
+                fence(win)
+                # Signal sender that the slot is free for reuse.
+                signal_block(win, peer_rank, 1, 1)  # SLOT_FREE += 1
+
+    # ------------------------------------------------------------------
+    # Kernel 3: Multi-block pipelined put_block (QP contention)
+    # ------------------------------------------------------------------
+
+    @requires_torchcomms
+    @triton.jit
+    def put_bw_multiblock_kernel(
+        # torchcomms handles
+        win,
+        send_buf,
+        # staging pointer (pipeline_depth * section_size)
+        send_staging_ptr,
+        # iteration tracking (monotonic, GPU-resident)
+        iteration_ptr,
+        # sizes
+        total_elements,
+        section_elements,
+        elem_size_bytes,
+        # pipeline config
+        pipeline_depth,
+        num_blocks,  # send blocks = recv blocks
+        # peer
+        peer_rank: tl.constexpr,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        """
+        Multi-block pipelined put_block bandwidth kernel.
+
+        Measures put_block throughput with N send blocks sharing a single QP,
+        exposing contention effects. Each send block puts its own tile of each
+        section independently — no inter-block coordination.
+
+        Grid: ``2 * num_blocks`` (pids ``[0, num_blocks)`` send,
+        pids ``[num_blocks, 2*num_blocks)`` recv). Bidirectional.
+
+        Signal / counter layout (per block)
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        - signal_id=pid (DATA_READY): put_block increments by 1 each step.
+        - signal_id=num_blocks+pid (SLOT_FREE): receiver's signal_block
+          increments by 1 each step.
+        - counter_id=pid (NIC_DONE): put_block increments by 1 each step.
+        """
+        pid = tl.program_id(axis=0)
+        iteration = tl.load(iteration_ptr)
+        total_steps = tl.cdiv(total_elements, section_elements)
+        base = iteration * total_steps
+
+        if pid < num_blocks:
+            # -- Send block --
+            tile_elements = section_elements // num_blocks
+            my_element_offset = pid * tile_elements
+            # Last block absorbs remainder.
+            if pid == num_blocks - 1:
+                tile_elements = section_elements - my_element_offset
+
+            for step in range(total_steps):
+                slot = step % pipeline_depth
+
+                # Wait for NIC + receiver to free the slot before reuse.
+                if step >= pipeline_depth:
+                    wait_counter(win, pid, base + step - pipeline_depth + 1)
+                    wait_signal_from(
+                        win,
+                        peer_rank,
+                        num_blocks + pid,
+                        base + step - pipeline_depth + 1,
+                    )
+
+                staging_byte_offset = (
+                    slot * section_elements + my_element_offset
+                ) * elem_size_bytes
+
+                # Handle last section which may be smaller.
+                remaining_elements = total_elements - step * section_elements
+                actual_section_elements = tl.where(
+                    section_elements < remaining_elements,
+                    section_elements,
+                    remaining_elements,
+                )
+                # My tile within this (possibly smaller) section.
+                actual_tile_elements = actual_section_elements - my_element_offset
+                if actual_tile_elements > tile_elements:
+                    actual_tile_elements = tile_elements
+                if actual_tile_elements < 0:
+                    actual_tile_elements = 0
+
+                tile_bytes = actual_tile_elements * elem_size_bytes
+
+                if tile_bytes > 0:
+                    put_block(
+                        win,
+                        staging_byte_offset,  # dst_offset in peer's recv staging
+                        send_buf,
+                        staging_byte_offset,  # src_offset in our staging
+                        peer_rank,
+                        tile_bytes,
+                        pid,  # signal_id = DATA_READY for my tile
+                        pid,  # counter_id = NIC_DONE for my tile
+                    )
+                else:
+                    # No data for this tile in the last (partial) section.
+                    # Still signal DATA_READY so the receiver doesn't deadlock.
+                    signal_block(win, peer_rank, pid, 1)
+        else:
+            # -- Recv block --
+            recv_pid = pid - num_blocks
+
+            for step in range(total_steps):
+                # Wait for my tile's data to arrive.
+                wait_signal_from(win, peer_rank, recv_pid, base + step + 1)
+                fence(win)
+                # Signal sender that my tile's slot is free.
+                signal_block(win, peer_rank, num_blocks + recv_pid, 1)

--- a/comms/pipes/triton/collectives/ib/put_bw_op.py
+++ b/comms/pipes/triton/collectives/ib/put_bw_op.py
@@ -1,0 +1,210 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+"""
+Host-side wrapper for put_block bandwidth microbenchmark kernels.
+
+Measures raw RDMA put throughput (no src/dst copy overhead) using three
+modes:
+  - fireforget:  One block sends, one block receives. No flow control —
+                 all steps are posted without waiting for completion.
+  - pipelined:   Same grid but with a ring-buffer flow-control protocol
+                 (DATA_READY / SLOT_FREE signals) to cap in-flight data.
+  - multiblock:  Multiple independent send/recv block pairs, each running
+                 its own pipelined stream.
+"""
+
+import torch
+import torchcomms
+
+from .put_bw_kernel import (
+    put_bw_fireforget_kernel,
+    put_bw_multiblock_kernel,
+    put_bw_pipelined_kernel,
+)
+from .sendrecv_cooperative_kernel import _increment_iteration_kernel
+
+
+class PutBwOp:
+    """
+    GPU-to-GPU put bandwidth microbenchmark using torchcomms window.put.
+
+    Usage:
+        op = PutBwOp(comm, "pipelined", pipeline_depth=8,
+                     section_size=4*1024*1024)
+        op(total_bytes=256*1024*1024, peer_rank=1)
+        # ... repeat as needed ...
+        op.teardown()
+
+    Args:
+        comm: TorchComm communicator instance.
+        mode: "fireforget" | "pipelined" | "multiblock".
+        pipeline_depth: Number of pipeline slots.
+        section_size: Size of each put in bytes.
+        num_blocks: Number of send (=recv) block pairs (multiblock only).
+        total_bytes: Total transfer size in bytes. Required for fireforget
+                     mode (determines staging buffer size).
+    """
+
+    VALID_MODES = ("fireforget", "pipelined", "multiblock")
+
+    def __init__(
+        self,
+        comm,
+        mode,
+        pipeline_depth,
+        section_size,
+        num_blocks=1,
+        total_bytes=None,
+    ):
+        assert mode in self.VALID_MODES, f"Unknown mode {mode!r}"
+        self.comm = comm
+        self.mode = mode
+        self.pipeline_depth = pipeline_depth
+        self.section_size = section_size  # bytes
+        self.num_blocks = num_blocks
+        self.rank = comm.get_rank()
+        self.device = comm.get_device()
+        self.backend = comm.get_backend()
+
+        # ── Staging buffer size depends on mode ──
+        if mode == "fireforget":
+            assert total_bytes is not None, "total_bytes required for fireforget mode"
+            staging_bytes = total_bytes
+        else:
+            staging_bytes = pipeline_depth * section_size
+
+        staging_elements = staging_bytes // 4  # float32
+
+        # ── Iteration counter (created BEFORE GIN activation) ──
+        self._iteration = torch.zeros(1, dtype=torch.int32, device=self.device)
+
+        # ── Allocate RDMA-compatible staging buffers ──
+        allocator = torchcomms.get_mem_allocator(self.backend)
+        self._pool = torch.cuda.MemPool(allocator)
+        with torch.cuda.use_mem_pool(self._pool):
+            self.recv_staging = torch.zeros(
+                staging_elements, dtype=torch.float32, device=self.device
+            )
+            self.send_staging = torch.ones(
+                staging_elements, dtype=torch.float32, device=self.device
+            )
+
+        # ── Window setup (COLLECTIVE — all ranks must participate) ──
+        self.comm.barrier(False)
+        self.window = self.comm.new_window()
+        self.window.tensor_register(self.recv_staging)
+        self.comm.barrier(False)
+
+        # ── Signal / counter budget depends on mode ──
+        if mode == "fireforget":
+            signal_count = 2  # DATA_READY + ALL_DONE
+            counter_count = 1  # NIC_DONE
+        elif mode == "pipelined":
+            signal_count = 2  # DATA_READY + SLOT_FREE
+            counter_count = 1  # NIC_DONE
+        else:  # multiblock
+            signal_count = 2 * num_blocks
+            counter_count = num_blocks
+
+        self.dev_win = self.window.get_device_window(
+            signal_count=signal_count,
+            counter_count=counter_count,
+            barrier_count=0,
+        )
+
+        # ── Register send staging for RDMA source (NON-COLLECTIVE) ──
+        self.send_buf_info = self.window.register_local_buffer(self.send_staging)
+
+        self._torn_down = False
+
+    def __call__(self, total_bytes, peer_rank):
+        """
+        Execute put bandwidth test.
+
+        Both ranks must call this simultaneously. Each rank puts data to
+        the peer's recv_staging via RDMA. Returns nothing — just moves bytes.
+        """
+        assert not self._torn_down, "PutBwOp has been torn down"
+
+        total_elements = total_bytes // 4  # float32
+        elem_size_bytes = 4
+        section_elements = self.section_size // elem_size_bytes
+
+        if self.mode == "fireforget":
+            self._call_fireforget(
+                total_elements, section_elements, elem_size_bytes, peer_rank
+            )
+        elif self.mode == "pipelined":
+            self._call_pipelined(
+                total_elements, section_elements, elem_size_bytes, peer_rank
+            )
+        else:
+            self._call_multiblock(
+                total_elements, section_elements, elem_size_bytes, peer_rank
+            )
+
+        # Increment iteration counter for monotonic signal tracking
+        _increment_iteration_kernel[(1,)](self._iteration, num_warps=1)
+
+    def _call_fireforget(
+        self, total_elements, section_elements, elem_size_bytes, peer_rank
+    ):
+        put_bw_fireforget_kernel[(2,)](
+            self.dev_win,
+            self.send_buf_info,
+            self.send_staging,
+            self._iteration,
+            total_elements,
+            section_elements,
+            elem_size_bytes,
+            peer_rank=peer_rank,
+            BLOCK_SIZE=1024,
+            num_warps=32,
+        )
+
+    def _call_pipelined(
+        self, total_elements, section_elements, elem_size_bytes, peer_rank
+    ):
+        put_bw_pipelined_kernel[(2,)](
+            self.dev_win,
+            self.send_buf_info,
+            self.send_staging,
+            self._iteration,
+            total_elements,
+            section_elements,
+            elem_size_bytes,
+            self.pipeline_depth,
+            peer_rank=peer_rank,
+            BLOCK_SIZE=1024,
+            num_warps=32,
+        )
+
+    def _call_multiblock(
+        self, total_elements, section_elements, elem_size_bytes, peer_rank
+    ):
+        put_bw_multiblock_kernel[(2 * self.num_blocks,)](
+            self.dev_win,
+            self.send_buf_info,
+            self.send_staging,
+            self._iteration,
+            total_elements,
+            section_elements,
+            elem_size_bytes,
+            self.pipeline_depth,
+            self.num_blocks,
+            peer_rank=peer_rank,
+            BLOCK_SIZE=1024,
+            num_warps=32,
+        )
+
+    def teardown(self):
+        """Release resources. Must be called by all ranks (tensor_deregister is collective)."""
+        if self._torn_down:
+            return
+        self.window.deregister_local_buffer(self.send_buf_info)
+        self.window.tensor_deregister()
+        self._torn_down = True
+
+    def __del__(self):
+        # Best-effort cleanup, but user should call teardown() explicitly
+        # because tensor_deregister is collective
+        pass

--- a/comms/pipes/triton/collectives/ib/sendrecv.py
+++ b/comms/pipes/triton/collectives/ib/sendrecv.py
@@ -1,0 +1,332 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""
+Block-scope pipelined send/recv kernel for GPU-to-GPU communication.
+
+Each block independently RDMA-puts its own tile using block-scope APIs,
+eliminating inter-block coordination overhead.
+
+Architecture
+------------
+- Block i owns tile i of each section (section_elements // num_blocks).
+- Block i copies its tile from src to send_staging, then calls put_block
+  for its tile alone — no atomic coordination, no "last block" logic.
+- Block i on the receiver waits for its tile's DATA_READY signal,
+  copies its tile from recv_staging to dst, then signals SLOT_FREE.
+
+This design posts N WQEs per pipeline step (one per block) instead of 1,
+keeping the NIC pipeline full and enabling NIC-level parallelism.
+
+Signal layout (per direction, per pipeline slot)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Let N = num_blocks, P = pipeline_depth.
+
+Each (block, slot) pair has independent signals/counters, enabling true
+pipeline parallelism — the sender can have P puts in-flight per block.
+
+- signal_id ``pid * P + slot``             : DATA_READY (sender → receiver)
+- signal_id ``N * P + pid * P + slot``     : SLOT_FREE  (receiver → sender)
+- counter_id ``pid * P + slot``            : NIC_DONE   (local NIC completion)
+
+Total signals: ``2 * N * P``.
+Total counters: ``N * P``.
+
+Monotonic signals across iterations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Each per-slot signal is incremented once per use of that slot. Slot s is
+used at steps s, s+P, s+2P, ..., giving ``steps_per_slot = ceil(total_steps/P)``
+uses per iteration. The monotonic base is ``iteration * steps_per_slot``.
+"""
+
+from torch.utils._triton import has_triton
+
+if has_triton():
+    import triton
+    import triton.language as tl
+    from torchcomms.triton.fb import (
+        fence,
+        put_block,
+        requires_torchcomms,
+        signal_block,
+        wait_counter_block,
+        wait_signal_from_block,
+    )
+
+    @triton.jit
+    def _threadfence_system():
+        """Emit fence.acq_rel.sys — ensures all prior stores are visible to
+        all devices (including NIC DMA readers) before subsequent operations."""
+        tl.inline_asm_elementwise(
+            "fence.acq_rel.sys;",
+            "=r",
+            [],
+            dtype=tl.int32,
+            is_pure=False,
+            pack=1,
+        )
+
+    @triton.jit
+    def _send_block_fn(
+        win,
+        send_buf,
+        src_ptr,
+        send_staging_ptr,
+        iteration_ptr,
+        total_elements,
+        section_elements,
+        elem_size_bytes,
+        pipeline_depth,
+        num_blocks,
+        pid,
+        peer_rank: tl.constexpr,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        """
+        Block-scope send: each block copies and RDMA-puts its own tile.
+
+        Per-block signal/counter IDs (monotonically increasing values):
+        - DATA_READY signal ``pid``: data arrived at receiver
+        - SLOT_FREE signal ``N + pid``: receiver freed window slot
+        - NIC_DONE counter ``pid``: NIC finished reading staging
+        """
+        iteration = tl.load(iteration_ptr)
+        total_steps = tl.cdiv(total_elements, section_elements)
+        iter_base = iteration * total_steps
+
+        # Per-block signal/counter IDs
+        data_signal = pid
+        slot_free_signal = num_blocks + pid
+        nic_counter = pid
+
+        # Each block owns a fixed tile within the section.
+        tile_elements = section_elements // num_blocks
+        my_element_offset = pid * tile_elements
+        # Last block absorbs remainder.
+        if pid == num_blocks - 1:
+            tile_elements = section_elements - my_element_offset
+
+        for step in range(total_steps):
+            slot = step % pipeline_depth
+
+            # -- Wait for NIC to finish reading staging[slot] --
+            if step >= pipeline_depth:
+                nic_expected = iter_base + step - pipeline_depth + 1
+                wait_counter_block(win, nic_counter, nic_expected)
+
+            # -- Copy my tile: src → send_staging --
+            src_start = step * section_elements + my_element_offset
+            staging_start = slot * section_elements + my_element_offset
+
+            remaining = total_elements - step * section_elements - my_element_offset
+            copy_elements = tl.where(
+                tile_elements < remaining,
+                tile_elements,
+                remaining,
+            )
+
+            if copy_elements > 0:
+                for i in range(0, copy_elements, BLOCK_SIZE):
+                    offs = i + tl.arange(0, BLOCK_SIZE)
+                    mask = offs < copy_elements
+                    data = tl.load(src_ptr + src_start + offs, mask=mask)
+                    tl.store(
+                        send_staging_ptr + staging_start + offs,
+                        data,
+                        mask=mask,
+                    )
+
+            # Ensure staging writes are visible to the NIC (PCIe DMA reader).
+            _threadfence_system()
+
+            # -- Wait for receiver to free window[slot] --
+            if step >= pipeline_depth:
+                slot_expected = iter_base + step - pipeline_depth + 1
+                wait_signal_from_block(
+                    win,
+                    peer_rank,
+                    slot_free_signal,
+                    slot_expected,
+                )
+
+            # -- RDMA put my tile --
+            remaining_elements = total_elements - step * section_elements
+            actual_section_elements = tl.where(
+                section_elements < remaining_elements,
+                section_elements,
+                remaining_elements,
+            )
+            actual_tile_elements = actual_section_elements - my_element_offset
+            if actual_tile_elements > tile_elements:
+                actual_tile_elements = tile_elements
+            if actual_tile_elements < 0:
+                actual_tile_elements = 0
+
+            actual_tile_bytes = actual_tile_elements.to(tl.int64) * elem_size_bytes
+            staging_byte_offset = (
+                tl.cast(slot * section_elements + my_element_offset, tl.int64)
+                * elem_size_bytes
+            )
+
+            if actual_tile_bytes > 0:
+                put_block(
+                    win,
+                    staging_byte_offset,
+                    send_buf,
+                    staging_byte_offset,
+                    peer_rank,
+                    actual_tile_bytes,
+                    data_signal,
+                    nic_counter,
+                )
+            else:
+                signal_block(win, peer_rank, data_signal, 1)
+
+        # -- Drain: SLOT_FREE only (implies NIC_DONE) --
+        drain_val = iter_base + total_steps
+        wait_signal_from_block(win, peer_rank, slot_free_signal, drain_val)
+
+        # Increment iteration counter (only sender block 0, thread 0).
+        # Device-side update keeps this CUDA graph replayable.
+        if pid == 0:
+            old_val = tl.load(iteration_ptr)
+            tl.store(iteration_ptr, old_val + 1)
+
+    @triton.jit
+    def _recv_block_fn(
+        win,
+        dst_ptr,
+        recv_staging_ptr,
+        iteration_ptr,
+        total_elements,
+        section_elements,
+        elem_size_bytes,
+        pipeline_depth,
+        num_blocks,
+        pid,
+        peer_rank: tl.constexpr,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        """
+        Block-scope recv: each block waits for and drains its own tile.
+
+        Per-block signal IDs (monotonically increasing values):
+        - DATA_READY signal ``pid``: data arrived from sender
+        - SLOT_FREE signal ``N + pid``: window slot freed for sender
+        """
+        iteration = tl.load(iteration_ptr)
+        total_steps = tl.cdiv(total_elements, section_elements)
+        iter_base = iteration * total_steps
+
+        # Per-block signal IDs
+        data_signal = pid
+        slot_free_signal = num_blocks + pid
+
+        tile_elements = section_elements // num_blocks
+        my_element_offset = pid * tile_elements
+        if pid == num_blocks - 1:
+            tile_elements = section_elements - my_element_offset
+
+        for step in range(total_steps):
+            slot = step % pipeline_depth
+            expected = iter_base + step + 1
+
+            # -- Wait for data to arrive --
+            wait_signal_from_block(win, peer_rank, data_signal, expected)
+            # Ensure RDMA-written data in recv_staging is visible to GPU.
+            _threadfence_system()
+
+            # -- Copy my tile: recv_staging → dst --
+            staging_start = slot * section_elements + my_element_offset
+            dst_start = step * section_elements + my_element_offset
+
+            remaining = total_elements - step * section_elements - my_element_offset
+            copy_elements = tl.where(
+                tile_elements < remaining,
+                tile_elements,
+                remaining,
+            )
+
+            if copy_elements > 0:
+                for i in range(0, copy_elements, BLOCK_SIZE):
+                    offs = i + tl.arange(0, BLOCK_SIZE)
+                    mask = offs < copy_elements
+                    data = tl.load(
+                        recv_staging_ptr + staging_start + offs,
+                        mask=mask,
+                    )
+                    tl.store(dst_ptr + dst_start + offs, data, mask=mask)
+
+            # -- Signal sender: this slot is free --
+            signal_block(win, peer_rank, slot_free_signal, 1)
+
+    @requires_torchcomms
+    @triton.jit
+    def sendrecv_kernel(
+        # torchcomms handles
+        win,
+        send_buf,
+        # data pointers
+        src_ptr,
+        dst_ptr,
+        send_staging_ptr,
+        recv_staging_ptr,
+        # iteration tracking (monotonic, GPU-resident)
+        iteration_ptr,
+        # sizes (in elements, not bytes)
+        total_elements,
+        section_elements,
+        elem_size_bytes,
+        # config
+        pipeline_depth,
+        num_blocks,  # must be equal for send and recv
+        peer_rank: tl.constexpr,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        """
+        Block-scope pipelined sendrecv kernel.
+
+        Launched with ``2 * num_blocks`` program instances.
+        PIDs ``[0, num_blocks)`` execute the send path.
+        PIDs ``[num_blocks, 2 * num_blocks)`` execute the recv path.
+
+        The kernel loops ``iterations`` times internally, avoiding
+        per-iteration kernel launch overhead. CUDA graph replayable:
+        iteration_ptr is device-resident and updated by a separate
+        increment kernel after this kernel completes.
+        """
+        pid = tl.program_id(axis=0)
+
+        if pid < num_blocks:
+            _send_block_fn(
+                win,
+                send_buf,
+                src_ptr,
+                send_staging_ptr,
+                iteration_ptr,
+                total_elements,
+                section_elements,
+                elem_size_bytes,
+                pipeline_depth,
+                num_blocks,
+                pid,
+                peer_rank,
+                BLOCK_SIZE,
+            )
+        else:
+            recv_pid = pid - num_blocks
+            _recv_block_fn(
+                win,
+                dst_ptr,
+                recv_staging_ptr,
+                iteration_ptr,
+                total_elements,
+                section_elements,
+                elem_size_bytes,
+                pipeline_depth,
+                num_blocks,
+                recv_pid,
+                peer_rank,
+                BLOCK_SIZE,
+            )

--- a/comms/pipes/triton/collectives/ib/sendrecv_cooperative_kernel.py
+++ b/comms/pipes/triton/collectives/ib/sendrecv_cooperative_kernel.py
@@ -1,0 +1,314 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""
+Triton-based pipelined send/recv kernel for GPU-to-GPU communication.
+
+This module implements a copy-based sendrecv protocol using the torchcomms
+window API (NCCLX GIN backend). The kernel is designed for InfiniBand RDMA
+and uses a pipelined ring-buffer staging approach to overlap local copies
+with network transfers.
+
+Architecture
+------------
+The total message (src tensor) is divided into **sections**, the unit of
+pipelining. A staging buffer acts as a ring buffer with ``pipeline_depth``
+slots, each holding one section. Step ``s`` uses slot ``s % pipeline_depth``.
+
+Data flow (IB path)::
+
+    src -> send_staging[slot] -> (RDMA put via put_block) -> recv_staging[slot] -> dst
+            local copy (GPU)      NIC DMA transfer            local copy (GPU)
+
+Multi-block coordination
+~~~~~~~~~~~~~~~~~~~~~~~~
+- N send blocks cooperatively copy src -> send_staging. After all send blocks
+  finish, the **last** block (detected via ``tl.atomic_add`` on a coordination
+  counter) calls ``put_block`` for the entire section.
+- M recv blocks cooperatively copy recv_staging -> dst. After all recv blocks
+  finish, the **last** block calls ``signal_block`` to notify the sender that
+  the staging slot is free for reuse.
+
+Signal design (cumulative values, monotonic across iterations)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Let ``I`` = iteration index, ``S`` = total_steps per iteration.
+``base = I * S``.
+
+- ``signal_id=0`` (DATA_READY): ``put_block`` increments by 1 each step.
+  Receiver waits for ``>= base + step + 1``.
+- ``signal_id=1`` (SLOT_FREE): receiver's ``signal_block`` increments by 1
+  each step after draining. Sender waits for ``>= base + step - P + 1``.
+- ``counter_id=0`` (NIC_DONE): local counter incremented by 1 each step when
+  the NIC finishes reading send_staging.
+  Sender waits for ``>= base + step - P + 1``.
+
+Coordination counters (per-slot, reset to 0 each iteration)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``send_coord[slot]`` / ``recv_coord[slot]`` are reset to 0 before each call
+via a GIN-safe Triton fill kernel. At step ``s`` (slot ``s % P``), this slot
+has been used ``s // P + 1`` times in the current call.
+Expected value = ``num_blocks * (s // P + 1)``.
+"""
+
+from torch.utils._triton import has_triton
+
+if has_triton():
+    import triton
+    import triton.language as tl
+    from torchcomms.triton.fb import (
+        fence,
+        put_block,
+        requires_torchcomms,
+        signal_block,
+        wait_counter,
+        wait_signal_from,
+    )
+
+    @triton.jit
+    def _fill_kernel(ptr, value, N, BLOCK_SIZE: tl.constexpr):
+        """Fill the first N elements of ptr with value (GIN-safe)."""
+        offs = tl.arange(0, BLOCK_SIZE)
+        mask = offs < N
+        tl.store(ptr + offs, value, mask=mask)
+
+    @triton.jit
+    def _increment_iteration_kernel(iteration_ptr):
+        """Increment the iteration counter by 1 (GIN-safe)."""
+        old_val = tl.load(iteration_ptr)
+        tl.store(iteration_ptr, old_val + 1)
+
+    @triton.jit
+    def _send_fn(
+        win,
+        send_buf,
+        src_ptr,
+        send_staging_ptr,
+        send_coord_ptr,
+        iteration_ptr,
+        total_elements,
+        section_elements,
+        elem_size_bytes,
+        pipeline_depth,
+        num_send_blocks,
+        pid,
+        peer_rank: tl.constexpr,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        """
+        Send-side logic executed by each send block.
+
+        Each send block copies its assigned portion of the current section from
+        ``src_ptr`` into ``send_staging_ptr``. The last block to finish (detected
+        via atomic increment on ``send_coord_ptr``) issues the RDMA put to the
+        peer's recv staging buffer.
+        """
+        iteration = tl.load(iteration_ptr)
+        total_steps = tl.cdiv(total_elements, section_elements)
+        base = iteration * total_steps
+
+        # Each block handles a contiguous portion of the section.
+        block_elements = section_elements // num_send_blocks
+        my_element_offset = pid * block_elements
+        # Last block absorbs any remainder elements.
+        if pid == num_send_blocks - 1:
+            block_elements = section_elements - my_element_offset
+
+        for step in range(total_steps):
+            slot = step % pipeline_depth
+
+            # -- Wait for slot reuse (NIC must have finished reading this slot) --
+            if step >= pipeline_depth:
+                wait_counter(win, 0, base + step - pipeline_depth + 1)
+
+            # -- Phase 1: Local copy src -> send_staging (all send blocks) --
+            src_start = step * section_elements + my_element_offset
+            staging_start = slot * section_elements + my_element_offset
+
+            # Handle the last section which may be smaller than section_elements.
+            remaining = total_elements - step * section_elements - my_element_offset
+            copy_elements = tl.where(
+                block_elements < remaining, block_elements, remaining
+            )
+
+            if copy_elements > 0:
+                for i in range(0, copy_elements, BLOCK_SIZE):
+                    offs = i + tl.arange(0, BLOCK_SIZE)
+                    mask = offs < copy_elements
+                    data = tl.load(src_ptr + src_start + offs, mask=mask)
+                    tl.store(send_staging_ptr + staging_start + offs, data, mask=mask)
+
+            # -- Phase 2: Coordinate; last block issues RDMA put --
+            # fence(win)
+            old_count = tl.atomic_add(send_coord_ptr + slot, 1)
+            expected = num_send_blocks * (step // pipeline_depth + 1)
+
+            if old_count + 1 == expected:
+                # Last block: wait for receiver to free recv_staging[slot].
+                if step >= pipeline_depth:
+                    wait_signal_from(
+                        win, peer_rank, 1, base + step - pipeline_depth + 1
+                    )
+
+                # Compute actual bytes for this section (last section may be
+                # smaller).
+                remaining_elements = total_elements - step * section_elements
+                actual_section_elements = tl.where(
+                    section_elements < remaining_elements,
+                    section_elements,
+                    remaining_elements,
+                )
+                actual_section_bytes = actual_section_elements * elem_size_bytes
+
+                staging_byte_offset = slot * section_elements * elem_size_bytes
+
+                # RDMA put: send_staging[slot] -> peer's recv_staging[slot].
+                put_block(
+                    win,
+                    staging_byte_offset,  # dst_offset (bytes)
+                    send_buf,
+                    staging_byte_offset,  # src_offset (bytes)
+                    peer_rank,
+                    actual_section_bytes,
+                    0,  # signal_id = DATA_READY
+                    0,  # counter_id = NIC_DONE
+                )
+
+    @triton.jit
+    def _recv_fn(
+        win,
+        dst_ptr,
+        recv_staging_ptr,
+        recv_coord_ptr,
+        iteration_ptr,
+        total_elements,
+        section_elements,
+        elem_size_bytes,
+        pipeline_depth,
+        num_recv_blocks,
+        pid,
+        peer_rank: tl.constexpr,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        """
+        Recv-side logic executed by each recv block.
+
+        Each recv block copies its assigned portion of the current section from
+        ``recv_staging_ptr`` into ``dst_ptr``. The last block to finish (detected
+        via atomic increment on ``recv_coord_ptr``) signals the sender that the
+        staging slot is free for reuse.
+        """
+        iteration = tl.load(iteration_ptr)
+        total_steps = tl.cdiv(total_elements, section_elements)
+        base = iteration * total_steps
+
+        block_elements = section_elements // num_recv_blocks
+        my_element_offset = pid * block_elements
+        if pid == num_recv_blocks - 1:
+            block_elements = section_elements - my_element_offset
+
+        for step in range(total_steps):
+            slot = step % pipeline_depth
+
+            # -- Wait for data to arrive from sender --
+            wait_signal_from(win, peer_rank, 0, base + step + 1)
+
+            # -- Local copy: recv_staging[slot] -> dst (all recv blocks) --
+            staging_start = slot * section_elements + my_element_offset
+            dst_start = step * section_elements + my_element_offset
+
+            remaining = total_elements - step * section_elements - my_element_offset
+            copy_elements = tl.where(
+                block_elements < remaining, block_elements, remaining
+            )
+
+            if copy_elements > 0:
+                for i in range(0, copy_elements, BLOCK_SIZE):
+                    offs = i + tl.arange(0, BLOCK_SIZE)
+                    mask = offs < copy_elements
+                    data = tl.load(recv_staging_ptr + staging_start + offs, mask=mask)
+                    tl.store(dst_ptr + dst_start + offs, data, mask=mask)
+
+            # -- Coordinate; last block signals SLOT_FREE --
+            fence(win)
+            old_count = tl.atomic_add(recv_coord_ptr + slot, 1)
+            expected = num_recv_blocks * (step // pipeline_depth + 1)
+
+            if old_count + 1 == expected:
+                signal_block(win, peer_rank, 1, 1)  # SLOT_FREE += 1
+
+    @requires_torchcomms
+    @triton.jit
+    def sendrecv_cooperative_kernel(
+        # torchcomms handles
+        win,
+        send_buf,
+        # data pointers
+        src_ptr,
+        dst_ptr,
+        send_staging_ptr,
+        recv_staging_ptr,
+        # coordination counters
+        send_coord_ptr,
+        recv_coord_ptr,
+        # iteration tracking (monotonic, GPU-resident)
+        iteration_ptr,
+        # sizes (in elements, not bytes)
+        total_elements,
+        section_elements,
+        elem_size_bytes,
+        # config
+        pipeline_depth,
+        num_send_blocks,
+        num_recv_blocks,
+        peer_rank: tl.constexpr,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        """
+        Pipelined send/recv kernel for GPU-to-GPU communication via RDMA.
+
+        Launched with ``num_send_blocks + num_recv_blocks`` program instances.
+        Program IDs ``[0, num_send_blocks)`` execute the send path; program IDs
+        ``[num_send_blocks, num_send_blocks + num_recv_blocks)`` execute the
+        recv path.
+
+        Signals and counters are monotonic across iterations. The iteration
+        counter (``iteration_ptr``) tracks how many times the kernel has been
+        invoked, and wait thresholds are offset by ``iteration * total_steps``.
+        """
+        pid = tl.program_id(axis=0)
+
+        if pid < num_send_blocks:
+            _send_fn(
+                win,
+                send_buf,
+                src_ptr,
+                send_staging_ptr,
+                send_coord_ptr,
+                iteration_ptr,
+                total_elements,
+                section_elements,
+                elem_size_bytes,
+                pipeline_depth,
+                num_send_blocks,
+                pid,
+                peer_rank,
+                BLOCK_SIZE,
+            )
+        else:
+            recv_pid = pid - num_send_blocks
+            _recv_fn(
+                win,
+                dst_ptr,
+                recv_staging_ptr,
+                recv_coord_ptr,
+                iteration_ptr,
+                total_elements,
+                section_elements,
+                elem_size_bytes,
+                pipeline_depth,
+                num_recv_blocks,
+                recv_pid,
+                peer_rank,
+                BLOCK_SIZE,
+            )

--- a/comms/pipes/triton/collectives/ib/sendrecv_op.py
+++ b/comms/pipes/triton/collectives/ib/sendrecv_op.py
@@ -1,0 +1,320 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+"""
+Host-side wrapper for the Triton pipelined sendrecv operation.
+
+Handles window creation, buffer registration, and kernel launch for
+copy-based send/recv over InfiniBand using the torchcomms window API.
+
+Two kernel implementations:
+  - Block-scope (default): Each block independently copies and RDMA-puts
+    its own tile. Posts N WQEs per step — no inter-block coordination.
+  - Cooperative: N blocks cooperatively copy, then the last block issues
+    a single RDMA put per step. Lower WQE count but requires atomics.
+
+Public API:
+  - ``SendRecvOp``: Stateful op for repeated calls (CUDA graph compatible).
+  - ``sendrecv()``: One-shot convenience function.
+"""
+
+import torch
+import torchcomms
+
+from .sendrecv import sendrecv_kernel
+from .sendrecv_cooperative_kernel import (
+    _fill_kernel,
+    _increment_iteration_kernel,
+    sendrecv_cooperative_kernel,
+)
+
+
+def _default_num_blocks(msg_bytes: int) -> int:
+    """Pick a default block count based on message size.
+
+    Heuristic mirrors NCCL's SM allocation: more blocks for larger
+    messages to keep the NIC pipeline full without over-subscribing SMs.
+    """
+    if msg_bytes >= 512 * 1024 * 1024:
+        return 32
+    if msg_bytes >= 64 * 1024 * 1024:
+        return 16
+    if msg_bytes >= 1024 * 1024:
+        return 8
+    return 4
+
+
+def sendrecv(
+    comm,
+    src: torch.Tensor,
+    dst: torch.Tensor,
+    peer_rank: int,
+    *,
+    pipeline_depth: int = 4,
+    section_size: int = 4 * 1024 * 1024,
+    num_blocks: int | None = None,
+    parallel: bool = True,
+) -> None:
+    """One-shot bidirectional sendrecv over IB.
+
+    Creates a ``SendRecvOp``, executes it once, and tears down. For repeated
+    calls (e.g. inside a training loop), prefer creating a ``SendRecvOp``
+    directly to amortize setup cost.
+
+    Args:
+        comm: TorchComm communicator instance.
+        src: Source tensor to send (float32, CUDA).
+        dst: Destination tensor to receive into (float32, CUDA).
+        peer_rank: Rank of the peer to exchange with.
+        pipeline_depth: Number of pipeline slots (ring buffer depth).
+        section_size: Size of each pipeline section in bytes.
+        num_blocks: Thread blocks per direction. ``None`` = auto-select.
+        parallel: If True (default), use block-scope kernel.
+    """
+    if num_blocks is None:
+        num_blocks = _default_num_blocks(src.nbytes)
+    op = SendRecvOp(comm, pipeline_depth, section_size, num_blocks, parallel=parallel)
+    try:
+        op(src, dst, peer_rank)
+    finally:
+        op.teardown()
+
+
+class SendRecvOp:
+    """
+    Pipelined GPU-to-GPU sendrecv using torchcomms window.put.
+
+    Usage::
+
+        op = SendRecvOp(comm, pipeline_depth=4, section_size=4*1024*1024)
+        op(src_tensor, dst_tensor, peer_rank=1)
+        # ... repeat as needed ...
+        op.teardown()
+
+    Or as a context manager::
+
+        with SendRecvOp(comm, pipeline_depth=4, section_size=4*MB) as op:
+            op(src, dst, peer_rank)
+
+    Args:
+        comm: TorchComm communicator instance.
+        pipeline_depth: Number of pipeline slots (ring buffer depth).
+        section_size: Size of each pipeline section in bytes.
+        num_blocks_per_dir: Number of thread blocks per direction (send/recv).
+        parallel: If True (default), use block-scope kernel (per-block RDMA puts).
+    """
+
+    def __init__(
+        self,
+        comm,
+        pipeline_depth,
+        section_size,
+        num_blocks_per_dir,
+        parallel=True,
+    ):
+        self.comm = comm
+        self.pipeline_depth = pipeline_depth
+        self.section_size = section_size  # bytes
+        self.parallel = parallel
+        # Cap blocks to avoid GPU deadlock: total blocks (send + recv) must
+        # fit within SM concurrency. H100 = 132 SMs, 2 blocks/SM @ 32 warps.
+        max_blocks_per_dir = 128
+        self.num_blocks = min(num_blocks_per_dir, max_blocks_per_dir)
+        self.rank = comm.get_rank()
+        self.device = comm.get_device()
+        self.backend = comm.get_backend()
+
+        staging_bytes = pipeline_depth * section_size
+        staging_elements = staging_bytes // 4  # float32 for now
+
+        # ── Iteration counter (created BEFORE GIN activation) ──
+        self._iteration = torch.zeros(1, dtype=torch.int32, device=self.device)
+
+        # ── Allocate RDMA-compatible staging buffers ──
+        allocator = torchcomms.get_mem_allocator(self.backend)
+        self._pool = torch.cuda.MemPool(allocator)
+        with torch.cuda.use_mem_pool(self._pool):
+            self.recv_staging = torch.zeros(
+                staging_elements, dtype=torch.float32, device=self.device
+            )
+            self.send_staging = torch.zeros(
+                staging_elements, dtype=torch.float32, device=self.device
+            )
+
+        # ── Coordination buffers (only needed for non-parallel mode) ──
+        if not parallel:
+            self.send_coord = torch.zeros(
+                pipeline_depth, dtype=torch.int32, device=self.device
+            )
+            self.recv_coord = torch.zeros(
+                pipeline_depth, dtype=torch.int32, device=self.device
+            )
+
+        # ── Window setup (COLLECTIVE — all ranks must participate) ──
+        # Matches C++ createWindowSetup: barrier → new_window → tensor_register
+        # → barrier → cudaDeviceSynchronize.
+        self.comm.barrier(False)
+        self.window = self.comm.new_window()
+        self.window.tensor_register(self.recv_staging)
+        self.comm.barrier(False)
+        torch.cuda.synchronize()
+
+        # Signal/counter budget depends on mode.
+        if parallel:
+            # Per-block signals with monotonically increasing values.
+            # 2*N signals: N DATA_READY + N SLOT_FREE
+            # N counters: per-block NIC_DONE
+            signal_count = 2 * self.num_blocks
+            counter_count = self.num_blocks
+        else:
+            # 2 signals: DATA_READY + SLOT_FREE, 1 counter: NIC_DONE
+            signal_count = 2
+            counter_count = 1
+
+        self.dev_win = self.window.get_device_window(
+            signal_count=signal_count,
+            counter_count=counter_count,
+            barrier_count=0,
+        )
+
+        # ── Register send staging for RDMA source (NON-COLLECTIVE) ──
+        self.send_buf_info = self.window.register_local_buffer(self.send_staging)
+
+        self._torn_down = False
+
+    def __call__(self, src, dst, peer_rank):
+        """
+        Execute pipelined sendrecv.
+
+        Both ranks must call this simultaneously. Each rank sends src to peer
+        and receives into dst from peer.
+        """
+        assert src.numel() == dst.numel(), (
+            "src and dst must have same number of elements"
+        )
+        assert src.dtype == torch.float32, "Only float32 supported currently"
+        assert not self._torn_down, "SendRecvOp has been torn down"
+
+        total_elements = src.numel()
+        elem_size_bytes = src.element_size()  # 4 for float32
+        section_elements = self.section_size // elem_size_bytes
+
+        if self.parallel:
+            self._call_parallel(
+                src,
+                dst,
+                peer_rank,
+                total_elements,
+                section_elements,
+                elem_size_bytes,
+            )
+        else:
+            self._call_original(
+                src,
+                dst,
+                peer_rank,
+                total_elements,
+                section_elements,
+                elem_size_bytes,
+            )
+
+        # Iteration counter is incremented inside the kernel (sender block 0)
+        # after drain. No separate kernel needed.
+
+    def _call_original(
+        self, src, dst, peer_rank, total_elements, section_elements, elem_size_bytes
+    ):
+        """Launch the original cooperative sendrecv kernel."""
+        grid = (self.num_blocks + self.num_blocks,)
+
+        # Reset coordination counters.
+        _fill_kernel[(1,)](
+            self.send_coord, 0, self.pipeline_depth, BLOCK_SIZE=64, num_warps=1
+        )
+        _fill_kernel[(1,)](
+            self.recv_coord, 0, self.pipeline_depth, BLOCK_SIZE=64, num_warps=1
+        )
+
+        sendrecv_cooperative_kernel[grid](
+            self.dev_win,
+            self.send_buf_info,
+            src,
+            dst,
+            self.send_staging,
+            self.recv_staging,
+            self.send_coord,
+            self.recv_coord,
+            self._iteration,
+            total_elements,
+            section_elements,
+            elem_size_bytes,
+            self.pipeline_depth,
+            self.num_blocks,
+            self.num_blocks,
+            peer_rank=peer_rank,
+            BLOCK_SIZE=1024,
+            num_warps=32,
+        )
+
+    def _call_parallel(
+        self, src, dst, peer_rank, total_elements, section_elements, elem_size_bytes
+    ):
+        """Launch the tile-parallel sendrecv kernel."""
+        grid = (self.num_blocks + self.num_blocks,)
+
+        sendrecv_kernel[grid](
+            self.dev_win,
+            self.send_buf_info,
+            src,
+            dst,
+            self.send_staging,
+            self.recv_staging,
+            self._iteration,
+            total_elements,
+            section_elements,
+            elem_size_bytes,
+            self.pipeline_depth,
+            self.num_blocks,
+            peer_rank=peer_rank,
+            BLOCK_SIZE=8192,
+            num_warps=8,
+        )
+
+    def teardown(self):
+        """Release resources. Must be called by all ranks (tensor_deregister is collective).
+
+        Mirrors the C++ teardownWindow pattern:
+          1. deregister_local_buffer (non-collective)
+          2. tensor_deregister (collective, has internal barriers)
+          3. Destroy window object (triggers ncclDevCommDestroy)
+          4. Release staging buffers and memory pool
+          5. Barrier after full cleanup
+        """
+        if self._torn_down:
+            return
+        # 1-2: Deregister from window
+        self.window.deregister_local_buffer(self.send_buf_info)
+        self.window.tensor_deregister()
+        # 3: Destroy window and device window (ncclDevCommDestroy, cudaFree)
+        self.dev_win = None
+        self.window = None
+        # 4: Release staging buffers and memory pool
+        self.send_staging = None
+        self.recv_staging = None
+        self._pool = None
+        if not self.parallel:
+            self.send_coord = None
+            self.recv_coord = None
+        # 5: Barrier after full cleanup
+        self.comm.barrier(False)
+        self._torn_down = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.teardown()
+        return False
+
+    def __del__(self):
+        # Best-effort cleanup, but user should call teardown() explicitly
+        # because tensor_deregister is collective
+        pass

--- a/comms/pipes/triton/collectives/ib/tests/__init__.py
+++ b/comms/pipes/triton/collectives/ib/tests/__init__.py
@@ -1,0 +1,1 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.

--- a/comms/pipes/triton/collectives/ib/tests/benchmark_put_bw.py
+++ b/comms/pipes/triton/collectives/ib/tests/benchmark_put_bw.py
@@ -1,0 +1,373 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+"""
+Benchmark for put_block bandwidth microbenchmark.
+
+Sweeps three modes — fire-and-forget, pipelined, and multi-block — to
+characterize raw RDMA put throughput without copy overhead.
+
+Usage:
+    buck2 run ... :benchmark_put_bw                    # all experiments
+    buck2 run ... :benchmark_put_bw -- fireforget       # fire-and-forget only
+    buck2 run ... :benchmark_put_bw -- pipelined        # pipelined only
+    buck2 run ... :benchmark_put_bw -- multiblock       # multi-block only
+"""
+
+import os
+import socket
+
+# Enable GIN (GPU-Initiated Networking) for device-side window operations
+os.environ.setdefault("NCCL_GIN_ENABLE", "1")
+os.environ.setdefault("NCCL_GIN_TYPE", "-1")
+# Disable P2P to force IB transport even on single-node
+os.environ.setdefault("NCCL_P2P_DISABLE", "1")
+# Large QP depth for multi-block kernel (many WQEs per step)
+os.environ.setdefault("NCCL_GIN_GDAKI_QP_DEPTH", "1024")
+os.environ.setdefault("NCCL_DEBUG", "INFO")
+
+import sys
+
+import torch
+import torch.multiprocessing as mp
+import torchcomms
+from comms.pipes.triton.collectives.ib.put_bw_op import PutBwOp
+
+
+def find_free_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def format_size(nbytes):
+    if nbytes >= 1024 * 1024:
+        return f"{nbytes / (1024**2):.0f}MB"
+    if nbytes >= 1024:
+        return f"{nbytes / 1024:.0f}KB"
+    return f"{nbytes}B"
+
+
+M = 1024 * 1024
+
+# ── Experiment 1: Fire-and-forget put sweep (no flow control) ──
+# (name, total_bytes, section_bytes)
+FIREFORGET_CONFIGS = [
+    ("256KB", 256 * 1024, 256 * 1024),  # 1 step
+    ("1MB", 64 * M, 1 * M),  # 64 steps
+    ("4MB", 256 * M, 4 * M),  # 64 steps
+    ("16MB", 256 * M, 16 * M),  # 16 steps
+    ("64MB", 512 * M, 64 * M),  # 8 steps
+    ("128MB", 1024 * M, 128 * M),  # 8 steps
+]
+
+# ── Experiment 2: Pipelined put sweep (with flow control) ──
+# (name, total_bytes, section_bytes, pipeline_depth)
+PIPELINED_CONFIGS = [
+    ("256KB", 256 * M, 256 * 1024, 8),
+    ("1MB", 512 * M, 1 * M, 8),
+    ("4MB", 512 * M, 4 * M, 8),
+    ("16MB", 1024 * M, 16 * M, 4),
+    ("64MB", 1024 * M, 64 * M, 4),
+    ("128MB", 1024 * M, 128 * M, 4),
+]
+
+# ── Experiment 3: Multi-block put sweep (fixed section, sweep blocks) ──
+# (name, total_bytes, section_bytes, pipeline_depth, num_blocks)
+MULTIBLOCK_CONFIGS = [
+    ("1blk", 1024 * M, 64 * M, 4, 1),
+    ("2blk", 1024 * M, 64 * M, 4, 2),
+    ("4blk", 1024 * M, 64 * M, 4, 4),
+    ("8blk", 1024 * M, 64 * M, 4, 8),
+    ("16blk", 1024 * M, 64 * M, 4, 16),
+    ("32blk", 1024 * M, 64 * M, 4, 32),
+    ("64blk", 1024 * M, 64 * M, 4, 64),
+    ("128blk", 1024 * M, 64 * M, 4, 128),
+]
+
+# ── Diagnostic configs for debugging 16-block deadlock ──
+# Each tests a specific hypothesis about the root cause.
+# (name, total_bytes, section_bytes, pipeline_depth, num_blocks)
+DIAGNOSTIC_CONFIGS = {
+    # --- Step count sweep (16 blocks, PD=total_steps, no flow control) ---
+    "D1": ("D1_16blk_1step", 64 * M, 64 * M, 1, 16),
+    "D2": ("D2_16blk_2step", 128 * M, 64 * M, 2, 16),
+    "D3": ("D3_16blk_4step", 256 * M, 64 * M, 4, 16),
+    "D4": ("D4_16blk_8step", 512 * M, 64 * M, 8, 16),
+    "D5": ("D5_16blk_16step", 1024 * M, 64 * M, 16, 16),
+    # --- Block count threshold (PD=4, total_steps=16, with flow control) ---
+    "D6": ("D6_9blk_fc", 1024 * M, 64 * M, 4, 9),
+    "D7": ("D7_10blk_fc", 1024 * M, 64 * M, 4, 10),
+    "D8": ("D8_12blk_fc", 1024 * M, 64 * M, 4, 12),
+    "D9": ("D9_14blk_fc", 1024 * M, 64 * M, 4, 14),
+    "D10": ("D10_15blk_fc", 1024 * M, 64 * M, 4, 15),
+    "D11": ("D11_16blk_fc", 1024 * M, 64 * M, 4, 16),
+}
+
+
+def run_fireforget(comm, local_rank, configs):
+    peer_rank = 1 - local_rank
+    if local_rank == 0:
+        print("\n=== Experiment 1: Fire-and-Forget Put (no flow control) ===")
+        print(
+            f"{'PutSize':<12} | {'Total':<10} | {'Steps':<8} | "
+            f"{'Lat (us)':<12} | {'BW (GB/s)':<12}"
+        )
+        print("-" * 65)
+
+    for name, total_bytes, section_bytes in configs:
+        total_steps = total_bytes // section_bytes
+        # For fireforget: pipeline_depth = total_steps (unique slot per step)
+        op = PutBwOp(
+            comm,
+            "fireforget",
+            total_steps,
+            section_bytes,
+            total_bytes=total_bytes,
+        )
+
+        # Warmup
+        for _ in range(3):
+            op(total_bytes, peer_rank)
+        torch.cuda.synchronize()
+        comm.barrier(False)
+
+        # Timed runs
+        iters = 50 if total_bytes >= 256 * M else 200
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+
+        comm.barrier(False)
+        start.record()
+        for _ in range(iters):
+            op(total_bytes, peer_rank)
+        end.record()
+        torch.cuda.synchronize()
+
+        elapsed_ms = start.elapsed_time(end)
+        avg_us = (elapsed_ms * 1000.0) / iters
+        bw = (total_bytes / (1024**3)) / (avg_us / 1e6)
+
+        if local_rank == 0:
+            print(
+                f"{name:<12} | {format_size(total_bytes):<10} | "
+                f"{total_steps:<8} | {avg_us:<12.2f} | {bw:<12.2f}"
+            )
+
+        op.teardown()
+        torch.cuda.empty_cache()
+        comm.barrier(False)
+
+
+def run_pipelined(comm, local_rank, configs):
+    peer_rank = 1 - local_rank
+    if local_rank == 0:
+        print("\n=== Experiment 2: Pipelined Put (with flow control) ===")
+        print(
+            f"{'PutSize':<12} | {'Total':<10} | {'PD':<4} | {'Steps':<8} | "
+            f"{'Lat (us)':<12} | {'BW (GB/s)':<12}"
+        )
+        print("-" * 70)
+
+    for name, total_bytes, section_bytes, pipeline_depth in configs:
+        total_steps = total_bytes // section_bytes
+        op = PutBwOp(comm, "pipelined", pipeline_depth, section_bytes)
+
+        # Warmup
+        for _ in range(3):
+            op(total_bytes, peer_rank)
+        torch.cuda.synchronize()
+        comm.barrier(False)
+
+        # Timed runs
+        iters = 50 if total_bytes >= 256 * M else 200
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+
+        comm.barrier(False)
+        start.record()
+        for _ in range(iters):
+            op(total_bytes, peer_rank)
+        end.record()
+        torch.cuda.synchronize()
+
+        elapsed_ms = start.elapsed_time(end)
+        avg_us = (elapsed_ms * 1000.0) / iters
+        bw = (total_bytes / (1024**3)) / (avg_us / 1e6)
+
+        if local_rank == 0:
+            print(
+                f"{name:<12} | {format_size(total_bytes):<10} | "
+                f"{pipeline_depth:<4} | {total_steps:<8} | "
+                f"{avg_us:<12.2f} | {bw:<12.2f}"
+            )
+
+        op.teardown()
+        torch.cuda.empty_cache()
+        comm.barrier(False)
+
+
+def run_multiblock(comm, local_rank, configs):
+    peer_rank = 1 - local_rank
+    if local_rank == 0:
+        print("\n=== Experiment 3: Multi-Block Put (sweep block count) ===")
+        print(
+            f"{'Blocks':<12} | {'Total':<10} | {'PD':<4} | {'Steps':<8} | "
+            f"{'Lat (us)':<12} | {'BW (GB/s)':<12}"
+        )
+        print("-" * 70)
+
+    for name, total_bytes, section_bytes, pipeline_depth, num_blocks in configs:
+        total_steps = total_bytes // section_bytes
+        op = PutBwOp(
+            comm,
+            "multiblock",
+            pipeline_depth,
+            section_bytes,
+            num_blocks=num_blocks,
+        )
+
+        # Warmup
+        for _ in range(3):
+            op(total_bytes, peer_rank)
+        torch.cuda.synchronize()
+        comm.barrier(False)
+
+        # Timed runs
+        iters = 50 if total_bytes >= 256 * M else 200
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+
+        comm.barrier(False)
+        start.record()
+        for _ in range(iters):
+            op(total_bytes, peer_rank)
+        end.record()
+        torch.cuda.synchronize()
+
+        elapsed_ms = start.elapsed_time(end)
+        avg_us = (elapsed_ms * 1000.0) / iters
+        bw = (total_bytes / (1024**3)) / (avg_us / 1e6)
+
+        if local_rank == 0:
+            print(
+                f"{name:<12} | {format_size(total_bytes):<10} | "
+                f"{pipeline_depth:<4} | {total_steps:<8} | "
+                f"{avg_us:<12.2f} | {bw:<12.2f}"
+            )
+
+        op.teardown()
+        torch.cuda.empty_cache()
+        comm.barrier(False)
+
+
+def run_diagnostic(comm, local_rank, config_id):
+    """Run a single diagnostic config by ID (e.g. 'D1')."""
+    if config_id not in DIAGNOSTIC_CONFIGS:
+        if local_rank == 0:
+            print(f"Unknown diag config: {config_id}")
+            print(f"Available: {', '.join(sorted(DIAGNOSTIC_CONFIGS.keys()))}")
+        return
+
+    name, total_bytes, section_bytes, pipeline_depth, num_blocks = DIAGNOSTIC_CONFIGS[
+        config_id
+    ]
+    total_steps = total_bytes // section_bytes
+    peer_rank = 1 - local_rank
+
+    if local_rank == 0:
+        print(
+            f"DIAG {name}: total={format_size(total_bytes)} "
+            f"section={format_size(section_bytes)} PD={pipeline_depth} "
+            f"steps={total_steps} blocks={num_blocks}"
+        )
+        sys.stdout.flush()
+
+    op = PutBwOp(
+        comm,
+        "multiblock",
+        pipeline_depth,
+        section_bytes,
+        num_blocks=num_blocks,
+    )
+
+    # Warmup
+    for i in range(3):
+        if local_rank == 0:
+            print(f"  warmup {i + 1}/3...", end="", flush=True)
+        op(total_bytes, peer_rank)
+        if local_rank == 0:
+            print(" done", flush=True)
+    torch.cuda.synchronize()
+    comm.barrier(False)
+
+    # Timed runs
+    iters = 10
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    comm.barrier(False)
+    start.record()
+    for _ in range(iters):
+        op(total_bytes, peer_rank)
+    end.record()
+    torch.cuda.synchronize()
+
+    elapsed_ms = start.elapsed_time(end)
+    avg_us = (elapsed_ms * 1000.0) / iters
+    bw = (total_bytes / (1024**3)) / (avg_us / 1e6)
+
+    if local_rank == 0:
+        print(f"  RESULT: OK  {bw:.2f} GB/s  (lat={avg_us:.2f} us)")
+
+    op.teardown()
+    torch.cuda.empty_cache()
+    comm.barrier(False)
+
+
+def run_benchmark_worker(local_rank, master_port, experiment):
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(master_port)
+    os.environ["RANK"] = str(local_rank)
+    os.environ["LOCAL_RANK"] = str(local_rank)
+    os.environ["WORLD_SIZE"] = "2"
+
+    torch.cuda.set_device(local_rank)
+
+    comm = torchcomms.new_comm(
+        "ncclx",
+        torch.device(f"cuda:{local_rank}"),
+        name="put_bw_bench",
+    )
+
+    if local_rank == 0:
+        print("Put-Block Bandwidth Microbenchmark (2 GPUs)")
+        print(f"GPU {local_rank} <-> GPU {1 - local_rank}")
+
+    if experiment in ("fireforget", "all"):
+        run_fireforget(comm, local_rank, FIREFORGET_CONFIGS)
+
+    if experiment in ("pipelined", "all"):
+        run_pipelined(comm, local_rank, PIPELINED_CONFIGS)
+
+    if experiment in ("multiblock", "all"):
+        run_multiblock(comm, local_rank, MULTIBLOCK_CONFIGS)
+
+    if experiment.startswith("D") and experiment in DIAGNOSTIC_CONFIGS:
+        run_diagnostic(comm, local_rank, experiment)
+
+    comm.finalize()
+
+
+if __name__ == "__main__":
+    experiment = "all"
+    for arg in sys.argv[1:]:
+        if arg in ("fireforget", "pipelined", "multiblock", "all"):
+            experiment = arg
+        elif arg.startswith("D") and arg in DIAGNOSTIC_CONFIGS:
+            experiment = arg
+
+    port = find_free_port()
+    mp.spawn(
+        run_benchmark_worker,
+        args=(port, experiment),
+        nprocs=2,
+        join=True,
+    )

--- a/comms/pipes/triton/collectives/ib/tests/benchmark_sendrecv.py
+++ b/comms/pipes/triton/collectives/ib/tests/benchmark_sendrecv.py
@@ -1,0 +1,200 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+"""
+Benchmark for Triton pipelined sendrecv.
+
+Sweeps through message sizes, pipeline depths, chunk sizes, and block counts
+to characterize bandwidth and latency.
+
+Usage:
+    buck2 run ... :benchmark_sendrecv                # original kernel
+    buck2 run ... :benchmark_sendrecv -- --parallel   # tile-parallel kernel
+"""
+
+import os
+import socket
+
+# Enable GIN (GPU-Initiated Networking) for device-side window operations
+os.environ.setdefault("NCCL_GIN_ENABLE", "1")
+os.environ.setdefault("NCCL_GIN_TYPE", "-1")
+# Disable P2P to force IB transport even on single-node
+os.environ.setdefault("NCCL_P2P_DISABLE", "1")
+# Large QP depth for parallel kernel (many WQEs per step)
+os.environ.setdefault("NCCL_GIN_GDAKI_QP_DEPTH", "1024")
+os.environ.setdefault("NCCL_DEBUG", "INFO")
+
+import sys
+
+import torch
+import torch.multiprocessing as mp
+import torchcomms
+from comms.pipes.triton.collectives.ib.sendrecv_op import SendRecvOp
+
+
+def find_free_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def format_size(nbytes):
+    if nbytes >= 1024 * 1024:
+        return f"{nbytes / (1024**2):.0f}MB"
+    if nbytes >= 1024:
+        return f"{nbytes / 1024:.0f}KB"
+    return f"{nbytes}B"
+
+
+M = 1024 * 1024
+TOTAL = 512 * M  # Default message size for sweep (overridable via --total)
+
+
+def generate_sweep_configs(block_filter=None):
+    """
+    Generate comprehensive parameter sweep for Pareto analysis.
+
+    Sweep dimensions:
+      - num_blocks: [16, 32, 64, 128] (or filtered via --blocks N)
+      - section_size: powers of 2 from 32MB up to total
+      - pipeline_depth: [1, 2, 4] capped at total_steps
+
+    For each config, compute:
+      - tile_per_put = section / blocks  (NIC efficiency driver)
+      - staging_memory = pd * section * 2  (send + recv staging)
+    """
+    configs = []
+    block_counts = [block_filter] if block_filter else [16, 32, 64, 128]
+    # Section sizes from 32MB to 2GB (powers of 2)
+    section_sizes = [32 * M, 64 * M, 128 * M, 256 * M, 512 * M, 1024 * M, 2048 * M]
+    pd_values = [1, 2, 4, 8, 16]
+
+    for nblocks in block_counts:
+        for sec in section_sizes:
+            if sec > TOTAL:
+                continue
+            total_steps = TOTAL // sec
+            for pd in pd_values:
+                if pd > total_steps:
+                    continue
+                name = f"b{nblocks}_s{format_size(sec)}_p{pd}"
+                configs.append((name, TOTAL, sec, pd, nblocks))
+
+    return configs
+
+
+# Parse CLI filters: --blocks N --section S --pd P --total T (all in MB) --gpu-offset G
+_block_filter = None
+_section_filter = None
+_pd_filter = None
+_gpu_offset = 0
+for i, a in enumerate(sys.argv):
+    if a == "--blocks" and i + 1 < len(sys.argv):
+        _block_filter = int(sys.argv[i + 1])
+    elif a == "--section" and i + 1 < len(sys.argv):
+        _section_filter = int(sys.argv[i + 1]) * M
+    elif a == "--pd" and i + 1 < len(sys.argv):
+        _pd_filter = int(sys.argv[i + 1])
+    elif a == "--total" and i + 1 < len(sys.argv):
+        TOTAL = int(sys.argv[i + 1]) * M
+    elif a == "--gpu-offset" and i + 1 < len(sys.argv):
+        _gpu_offset = int(sys.argv[i + 1])
+
+if _section_filter and _pd_filter and _block_filter:
+    # Single config mode
+    _name = f"b{_block_filter}_s{format_size(_section_filter)}_p{_pd_filter}"
+    CONFIGS = [(_name, TOTAL, _section_filter, _pd_filter, _block_filter)]
+else:
+    CONFIGS = generate_sweep_configs(_block_filter)
+
+
+def run_benchmark_worker(local_rank, master_port, use_parallel, gpu_offset):
+    gpu_id = local_rank + gpu_offset
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(master_port)
+    os.environ["RANK"] = str(local_rank)
+    os.environ["LOCAL_RANK"] = str(gpu_id)
+    os.environ["WORLD_SIZE"] = "2"
+
+    peer_rank = 1 - local_rank
+    torch.cuda.set_device(gpu_id)
+
+    comm = torchcomms.new_comm(
+        "ncclx",
+        torch.device(f"cuda:{gpu_id}"),
+        name="sendrecv_bench",
+    )
+
+    if local_rank == 0:
+        mode = "PARALLEL (per-block RDMA)" if use_parallel else "ORIGINAL (cooperative)"
+        print(f"Bidirectional Triton SendRecv Benchmark (2 GPUs) — {mode}")
+        print(f"GPU {gpu_id} <-> GPU {gpu_id + 1 - 2 * local_rank}")
+        print(f"Total message: {format_size(TOTAL)}")
+        print()
+        # CSV-friendly header for easy parsing
+        print(
+            f"{'Name':<22} | {'Blocks':<6} | {'Section':<10} | "
+            f"{'PD':<4} | {'Tile':<10} | {'Steps':<6} | "
+            f"{'Staging':<10} | "
+            f"{'Lat (us)':<12} | {'BW (GB/s)':<12}"
+        )
+        print("-" * 120)
+
+    for name, msg_bytes, sec_bytes, pd, nblocks in CONFIGS:
+        total_elements = msg_bytes // 4
+
+        src = torch.randn(total_elements, dtype=torch.float32, device=f"cuda:{gpu_id}")
+        dst = torch.zeros(total_elements, dtype=torch.float32, device=f"cuda:{gpu_id}")
+
+        op = SendRecvOp(comm, pd, sec_bytes, nblocks, parallel=use_parallel)
+
+        # Warmup
+        for _ in range(20):
+            op(src, dst, peer_rank)
+        torch.cuda.synchronize()
+        comm.barrier(False)
+
+        # Timed runs
+        iters = 200 if msg_bytes < 64 * M else 100
+
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
+
+        comm.barrier(False)
+        start_event.record()
+        for _ in range(iters):
+            op(src, dst, peer_rank)
+        end_event.record()
+        torch.cuda.synchronize()
+
+        elapsed_ms = start_event.elapsed_time(end_event)
+        avg_us = (elapsed_ms * 1000.0) / iters
+
+        bw_unidir = (msg_bytes / (1024**3)) / (avg_us / 1_000_000.0)
+        bw_bidir = 2.0 * bw_unidir
+
+        if local_rank == 0:
+            tile_bytes = sec_bytes // nblocks
+            total_steps = msg_bytes // sec_bytes
+            staging_bytes = pd * sec_bytes * 2  # send + recv
+            print(
+                f"{name:<22} | {nblocks:<6} | {format_size(sec_bytes):<10} | "
+                f"{pd:<4} | {format_size(tile_bytes):<10} | {total_steps:<6} | "
+                f"{format_size(staging_bytes):<10} | "
+                f"{avg_us:<12.2f} | {bw_unidir:<12.2f}"
+            )
+
+        op.teardown()
+        del op, src, dst
+        torch.cuda.empty_cache()
+
+    comm.finalize()
+
+
+if __name__ == "__main__":
+    use_parallel = "--parallel" in sys.argv
+    port = find_free_port()
+    mp.spawn(
+        run_benchmark_worker,
+        args=(port, use_parallel, _gpu_offset),
+        nprocs=2,
+        join=True,
+    )

--- a/comms/pipes/triton/collectives/ib/tests/test_sendrecv.py
+++ b/comms/pipes/triton/collectives/ib/tests/test_sendrecv.py
@@ -1,0 +1,129 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+"""
+Correctness tests for Triton pipelined sendrecv.
+
+Tests bidirectional sendrecv between 2 GPUs using torchcomms window API.
+"""
+
+import os
+import socket
+
+# Enable GIN (GPU-Initiated Networking) for device-side window operations
+os.environ.setdefault("NCCL_GIN_ENABLE", "1")
+os.environ.setdefault("NCCL_GIN_TYPE", "-1")
+# Disable P2P to force IB transport even on single-node
+os.environ.setdefault("NCCL_P2P_DISABLE", "1")
+# Large QP depth for parallel kernel (many WQEs per step)
+os.environ.setdefault("NCCL_GIN_GDAKI_QP_DEPTH", "1024")
+
+import torch
+import torch.multiprocessing as mp
+import torchcomms
+from comms.pipes.triton.collectives.ib.sendrecv_op import SendRecvOp
+
+
+def find_free_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+# Test configurations: (name, msg_bytes, section_bytes, pipeline_depth, num_blocks)
+TEST_CONFIGS = [
+    ("medium_64KB", 64 * 1024, 32 * 1024, 2, 2),
+    ("medium_256KB", 256 * 1024, 64 * 1024, 4, 4),
+    ("large_1MB", 1024 * 1024, 256 * 1024, 4, 8),
+    ("large_4MB", 4 * 1024 * 1024, 1024 * 1024, 4, 16),
+    ("large_16MB", 16 * 1024 * 1024, 4 * 1024 * 1024, 4, 32),
+]
+
+
+def run_test_worker(local_rank, master_port):
+    """Worker function for each GPU process."""
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(master_port)
+    os.environ["RANK"] = str(local_rank)
+    os.environ["LOCAL_RANK"] = str(local_rank)
+    os.environ["WORLD_SIZE"] = "2"
+
+    peer_rank = 1 - local_rank
+    torch.cuda.set_device(local_rank)
+
+    comm = torchcomms.new_comm(
+        "ncclx",
+        torch.device(f"cuda:{local_rank}"),
+        name="sendrecv_test",
+    )
+
+    passed = 0
+    failed = 0
+
+    for name, msg_bytes, section_bytes, pd, nblocks in TEST_CONFIGS:
+        try:
+            total_elements = msg_bytes // 4  # float32
+
+            # Create known data pattern: rank-specific values
+            src = torch.full(
+                (total_elements,),
+                float(local_rank + 1),
+                dtype=torch.float32,
+                device=f"cuda:{local_rank}",
+            )
+            dst = torch.zeros(
+                total_elements,
+                dtype=torch.float32,
+                device=f"cuda:{local_rank}",
+            )
+
+            # Create SendRecvOp
+            op = SendRecvOp(comm, pd, section_bytes, nblocks)
+
+            # Execute sendrecv
+            op(src, dst, peer_rank)
+            torch.cuda.synchronize()
+            comm.barrier(False)
+
+            # Verify: dst should contain peer's data
+            expected_value = float(peer_rank + 1)
+            expected = torch.full_like(dst, expected_value)
+
+            if torch.allclose(dst, expected):
+                if local_rank == 0:
+                    print(f"  PASS: {name} ({msg_bytes} bytes)")
+                passed += 1
+            else:
+                mismatch = (dst != expected).sum().item()
+                if local_rank == 0:
+                    print(
+                        f"  FAIL: {name} — {mismatch}/{total_elements} elements wrong"
+                    )
+                    print(
+                        f"    Expected: {expected_value}, "
+                        f"Got first 10: {dst[:10].tolist()}"
+                    )
+                failed += 1
+
+            op.teardown()
+            del op, src, dst
+            torch.cuda.empty_cache()
+
+        except Exception as e:
+            if local_rank == 0:
+                print(f"  ERROR: {name} — {e}")
+            failed += 1
+            comm.barrier(False)
+
+    if local_rank == 0:
+        print(
+            f"\nResults: {passed} passed, {failed} failed "
+            f"out of {len(TEST_CONFIGS)} tests"
+        )
+
+    comm.finalize()
+
+
+if __name__ == "__main__":
+    port = find_free_port()
+    print("Running Triton SendRecv Correctness Tests")
+    print("=" * 50)
+    mp.spawn(run_test_worker, args=(port,), nprocs=2, join=True)

--- a/comms/torchcomms/tests/perf/cpp/PutBwBenchmark.cpp
+++ b/comms/torchcomms/tests/perf/cpp/PutBwBenchmark.cpp
@@ -1,0 +1,652 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Put BW microbenchmark: measures raw RDMA put bandwidth using the
+// TorchComm device API (NCCLx/GIN backend).
+//
+// Two tests:
+//   SingleBlock — one block puts the full buffer, sweep over sizes.
+//   MultiBlock  — N blocks each put total/N bytes, sweep over block counts.
+//
+// Zero-copy (no staging buffer). BLOCK-scope cooperative ops.
+// Receiver ACKs each iteration so sender knows the put landed.
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/MemPool.h>
+#include <c10/cuda/CUDACachingAllocator.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAStream.h>
+
+#include "PutBwBenchmarkKernels.cuh"
+#include "comms/torchcomms/TorchComm.hpp"
+#include "comms/torchcomms/device/TorchCommDeviceWindow.hpp"
+#include "comms/torchcomms/ncclx/TorchCommWindowNCCLX.hpp"
+#include "comms/torchcomms/tests/integration/cpp/TorchCommTestHelpers.h"
+
+using namespace torchcomms::device;
+using namespace torchcomms::device::test;
+
+namespace {
+
+constexpr int kWarmupIters = 20;
+constexpr int kMeasureIters = 100;
+constexpr size_t KB = 1024;
+constexpr size_t MB = 1024 * 1024;
+
+std::string formatSize(size_t bytes) {
+  if (bytes >= MB) {
+    return std::to_string(bytes / MB) + "MB";
+  }
+  if (bytes >= KB) {
+    return std::to_string(bytes / KB) + "KB";
+  }
+  return std::to_string(bytes) + "B";
+}
+
+struct WindowSetup {
+  std::unique_ptr<at::cuda::MemPool> mem_pool;
+  at::Tensor win_tensor;
+  at::Tensor src_tensor;
+  std::shared_ptr<torch::comms::TorchCommWindow> win;
+  DeviceWindowNCCL* dev_win{nullptr};
+  RegisteredBufferNCCL src_buf{};
+};
+
+WindowSetup createWindowSetup(
+    std::shared_ptr<torch::comms::TorchComm>& torchcomm,
+    std::shared_ptr<c10::Allocator>& allocator,
+    int device_index,
+    size_t total_bytes,
+    int signal_count) {
+  WindowSetup s;
+  size_t count = total_bytes / sizeof(float);
+
+  s.mem_pool = std::make_unique<at::cuda::MemPool>(
+      std::static_pointer_cast<c10::cuda::CUDACachingAllocator::CUDAAllocator>(
+          allocator));
+  c10::cuda::CUDACachingAllocator::beginAllocateToPool(
+      s.mem_pool->device(), s.mem_pool->id(), [](cudaStream_t) {
+        return true;
+      });
+
+  auto options =
+      at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, device_index);
+  s.win_tensor = at::zeros({static_cast<int64_t>(count)}, options);
+
+  c10::cuda::CUDACachingAllocator::endAllocateToPool(
+      s.mem_pool->device(), s.mem_pool->id());
+
+  // Allocate src outside pool for proper alignment (see DeviceApiTest comment).
+  s.src_tensor = at::zeros({static_cast<int64_t>(count)}, options);
+
+  torchcomm->barrier(false);
+  s.win = torchcomm->new_window();
+  s.win->tensor_register(s.win_tensor);
+  torchcomm->barrier(false);
+
+  s.dev_win = static_cast<DeviceWindowNCCL*>(
+      s.win->get_device_window(signal_count, -1, 2));
+  s.src_buf = s.win->register_local_buffer(s.src_tensor);
+
+  torchcomm->barrier(false);
+  cudaDeviceSynchronize();
+
+  return s;
+}
+
+void teardownWindow(
+    WindowSetup& s,
+    std::shared_ptr<torch::comms::TorchComm>& torchcomm) {
+  s.win->deregister_local_buffer(s.src_buf);
+  s.win->tensor_deregister();
+  s.win.reset();
+  s.mem_pool.reset();
+  torchcomm->barrier(false);
+}
+
+} // namespace
+
+class PutBwBenchmark : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const char* env = std::getenv("RUN_PUT_BW_BENCHMARK");
+    if (!env || (std::string(env) != "1" && std::string(env) != "true")) {
+      GTEST_SKIP() << "Set RUN_PUT_BW_BENCHMARK=true to run";
+    }
+
+    wrapper_ = std::make_unique<TorchCommTestWrapper>();
+    torchcomm_ = wrapper_->getTorchComm();
+    rank_ = torchcomm_->getRank();
+    num_ranks_ = torchcomm_->getSize();
+    device_index_ = rank_ % at::cuda::device_count();
+    allocator_ = torch::comms::get_mem_allocator(torchcomm_->getBackend());
+  }
+
+  void TearDown() override {
+    torchcomm_.reset();
+    wrapper_.reset();
+  }
+
+  struct BenchResult {
+    size_t total_bytes;
+    int num_blocks;
+    int iterations;
+    float elapsed_ms;
+    double bw_gbps;
+  };
+
+  BenchResult runBenchmark(size_t total_bytes, int num_blocks) {
+    int signal_count = 2 * num_blocks;
+    auto s = createWindowSetup(
+        torchcomm_, allocator_, device_index_, total_bytes, signal_count);
+
+    int dst_rank = (rank_ + 1) % num_ranks_;
+    int src_rank = (rank_ - 1 + num_ranks_) % num_ranks_;
+
+    auto stream = at::cuda::getStreamFromPool(false, device_index_);
+
+    // Warmup
+    {
+      c10::cuda::CUDAStreamGuard guard(stream);
+      launchPutBwKernel(
+          s.dev_win,
+          s.src_buf,
+          total_bytes,
+          dst_rank,
+          src_rank,
+          num_blocks,
+          0,
+          kWarmupIters,
+          stream.stream());
+    }
+    stream.synchronize();
+    torchcomm_->barrier(false);
+
+    // Timed run
+    cudaEvent_t start, stop;
+    cudaEventCreate(&start);
+    cudaEventCreate(&stop);
+
+    {
+      c10::cuda::CUDAStreamGuard guard(stream);
+      cudaEventRecord(start, stream.stream());
+      launchPutBwKernel(
+          s.dev_win,
+          s.src_buf,
+          total_bytes,
+          dst_rank,
+          src_rank,
+          num_blocks,
+          kWarmupIters,
+          kMeasureIters,
+          stream.stream());
+      cudaEventRecord(stop, stream.stream());
+    }
+    cudaEventSynchronize(stop);
+
+    float elapsed_ms = 0;
+    cudaEventElapsedTime(&elapsed_ms, start, stop);
+
+    double total_data = static_cast<double>(total_bytes) * kMeasureIters;
+    double bw = total_data / (elapsed_ms / 1000.0) / 1e9;
+
+    cudaEventDestroy(start);
+    cudaEventDestroy(stop);
+    teardownWindow(s, torchcomm_);
+
+    return {total_bytes, num_blocks, kMeasureIters, elapsed_ms, bw};
+  }
+
+  BenchResult runSendRecvBenchmark(size_t total_bytes, int num_blocks) {
+    int signal_count = 2 * num_blocks;
+    int counter_count = num_blocks;
+    size_t count = total_bytes / sizeof(float);
+
+    // MemPool for window tensor
+    auto mem_pool = std::make_unique<at::cuda::MemPool>(
+        std::static_pointer_cast<
+            c10::cuda::CUDACachingAllocator::CUDAAllocator>(allocator_));
+    c10::cuda::CUDACachingAllocator::beginAllocateToPool(
+        mem_pool->device(), mem_pool->id(), [](cudaStream_t) { return true; });
+
+    auto options =
+        at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, device_index_);
+    auto win_tensor = at::zeros({static_cast<int64_t>(count)}, options);
+
+    c10::cuda::CUDACachingAllocator::endAllocateToPool(
+        mem_pool->device(), mem_pool->id());
+
+    // Allocate src, staging, dst outside pool
+    auto src_tensor = at::zeros({static_cast<int64_t>(count)}, options);
+    auto staging_tensor = at::zeros({static_cast<int64_t>(count)}, options);
+    auto dst_tensor = at::zeros({static_cast<int64_t>(count)}, options);
+
+    torchcomm_->barrier(false);
+    auto win = torchcomm_->new_window();
+    win->tensor_register(win_tensor);
+    torchcomm_->barrier(false);
+
+    auto dev_win = static_cast<DeviceWindowNCCL*>(
+        win->get_device_window(signal_count, counter_count, 2));
+    auto staging_buf = win->register_local_buffer(staging_tensor);
+
+    torchcomm_->barrier(false);
+    cudaDeviceSynchronize();
+
+    int dst_rank = (rank_ + 1) % num_ranks_;
+    int src_rank = (rank_ - 1 + num_ranks_) % num_ranks_;
+
+    auto stream = at::cuda::getStreamFromPool(false, device_index_);
+
+    float* src_ptr = src_tensor.data_ptr<float>();
+    float* staging_ptr = staging_tensor.data_ptr<float>();
+    float* win_ptr = win_tensor.data_ptr<float>();
+    float* dst_ptr = dst_tensor.data_ptr<float>();
+
+    // Warmup
+    {
+      c10::cuda::CUDAStreamGuard guard(stream);
+      launchSendRecvBwKernel(
+          dev_win,
+          staging_buf,
+          src_ptr,
+          staging_ptr,
+          win_ptr,
+          dst_ptr,
+          total_bytes,
+          dst_rank,
+          src_rank,
+          num_blocks,
+          0,
+          kWarmupIters,
+          stream.stream());
+    }
+    stream.synchronize();
+    torchcomm_->barrier(false);
+
+    // Timed run
+    cudaEvent_t start, stop;
+    cudaEventCreate(&start);
+    cudaEventCreate(&stop);
+
+    {
+      c10::cuda::CUDAStreamGuard guard(stream);
+      cudaEventRecord(start, stream.stream());
+      launchSendRecvBwKernel(
+          dev_win,
+          staging_buf,
+          src_ptr,
+          staging_ptr,
+          win_ptr,
+          dst_ptr,
+          total_bytes,
+          dst_rank,
+          src_rank,
+          num_blocks,
+          kWarmupIters,
+          kMeasureIters,
+          stream.stream());
+      cudaEventRecord(stop, stream.stream());
+    }
+    cudaEventSynchronize(stop);
+
+    float elapsed_ms = 0;
+    cudaEventElapsedTime(&elapsed_ms, start, stop);
+
+    double total_data = static_cast<double>(total_bytes) * kMeasureIters;
+    double bw = total_data / (elapsed_ms / 1000.0) / 1e9;
+
+    cudaEventDestroy(start);
+    cudaEventDestroy(stop);
+
+    // Teardown
+    win->deregister_local_buffer(staging_buf);
+    win->tensor_deregister();
+    win.reset();
+    mem_pool.reset();
+    torchcomm_->barrier(false);
+
+    return {total_bytes, num_blocks, kMeasureIters, elapsed_ms, bw};
+  }
+
+  BenchResult runSendRecvPipelinedBenchmark(
+      size_t total_bytes,
+      size_t section_bytes,
+      int pipeline_depth,
+      int num_blocks) {
+    int signal_count = 2 * num_blocks;
+    int counter_count = num_blocks;
+    int total_steps = total_bytes / section_bytes;
+
+    // Staging and window are ring buffers: pipeline_depth * section_bytes
+    size_t ring_bytes = pipeline_depth * section_bytes;
+    size_t ring_count = ring_bytes / sizeof(float);
+    size_t total_count = total_bytes / sizeof(float);
+
+    // MemPool for window tensor (recv staging ring buffer)
+    auto mem_pool = std::make_unique<at::cuda::MemPool>(
+        std::static_pointer_cast<
+            c10::cuda::CUDACachingAllocator::CUDAAllocator>(allocator_));
+    c10::cuda::CUDACachingAllocator::beginAllocateToPool(
+        mem_pool->device(), mem_pool->id(), [](cudaStream_t) { return true; });
+
+    auto options =
+        at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, device_index_);
+    auto win_tensor = at::zeros({static_cast<int64_t>(ring_count)}, options);
+
+    c10::cuda::CUDACachingAllocator::endAllocateToPool(
+        mem_pool->device(), mem_pool->id());
+
+    // Allocate src, staging, dst outside pool
+    auto src_tensor = at::zeros({static_cast<int64_t>(total_count)}, options);
+    auto staging_tensor =
+        at::zeros({static_cast<int64_t>(ring_count)}, options);
+    auto dst_tensor = at::zeros({static_cast<int64_t>(total_count)}, options);
+
+    torchcomm_->barrier(false);
+    auto win = torchcomm_->new_window();
+    win->tensor_register(win_tensor);
+    torchcomm_->barrier(false);
+
+    auto dev_win = static_cast<DeviceWindowNCCL*>(
+        win->get_device_window(signal_count, counter_count, 2));
+    auto staging_buf = win->register_local_buffer(staging_tensor);
+
+    torchcomm_->barrier(false);
+    cudaDeviceSynchronize();
+
+    int dst_rank = (rank_ + 1) % num_ranks_;
+    int src_rank = (rank_ - 1 + num_ranks_) % num_ranks_;
+
+    auto stream = at::cuda::getStreamFromPool(false, device_index_);
+
+    float* src_ptr = src_tensor.data_ptr<float>();
+    float* staging_ptr = staging_tensor.data_ptr<float>();
+    float* win_ptr = win_tensor.data_ptr<float>();
+    float* dst_ptr = dst_tensor.data_ptr<float>();
+
+    // Warmup
+    {
+      c10::cuda::CUDAStreamGuard guard(stream);
+      launchSendRecvPipelinedBwKernel(
+          dev_win,
+          staging_buf,
+          src_ptr,
+          staging_ptr,
+          win_ptr,
+          dst_ptr,
+          total_bytes,
+          section_bytes,
+          pipeline_depth,
+          dst_rank,
+          src_rank,
+          num_blocks,
+          0,
+          kWarmupIters,
+          stream.stream());
+    }
+    stream.synchronize();
+    torchcomm_->barrier(false);
+
+    // Timed run
+    int measure_signal_base = kWarmupIters * total_steps;
+    cudaEvent_t start, stop;
+    cudaEventCreate(&start);
+    cudaEventCreate(&stop);
+
+    {
+      c10::cuda::CUDAStreamGuard guard(stream);
+      cudaEventRecord(start, stream.stream());
+      launchSendRecvPipelinedBwKernel(
+          dev_win,
+          staging_buf,
+          src_ptr,
+          staging_ptr,
+          win_ptr,
+          dst_ptr,
+          total_bytes,
+          section_bytes,
+          pipeline_depth,
+          dst_rank,
+          src_rank,
+          num_blocks,
+          measure_signal_base,
+          kMeasureIters,
+          stream.stream());
+      cudaEventRecord(stop, stream.stream());
+    }
+    cudaEventSynchronize(stop);
+
+    float elapsed_ms = 0;
+    cudaEventElapsedTime(&elapsed_ms, start, stop);
+
+    double total_data = static_cast<double>(total_bytes) * kMeasureIters;
+    double bw = total_data / (elapsed_ms / 1000.0) / 1e9;
+
+    cudaEventDestroy(start);
+    cudaEventDestroy(stop);
+
+    // Teardown
+    win->deregister_local_buffer(staging_buf);
+    win->tensor_deregister();
+    win.reset();
+    mem_pool.reset();
+    torchcomm_->barrier(false);
+
+    return {total_bytes, num_blocks, kMeasureIters, elapsed_ms, bw};
+  }
+
+  std::unique_ptr<TorchCommTestWrapper> wrapper_;
+  std::shared_ptr<torch::comms::TorchComm> torchcomm_;
+  std::shared_ptr<c10::Allocator> allocator_;
+  int rank_{0};
+  int num_ranks_{0};
+  int device_index_{0};
+};
+
+TEST_F(PutBwBenchmark, SingleBlock) {
+  std::vector<size_t> sizes = {
+      256 * KB, 1 * MB, 4 * MB, 16 * MB, 64 * MB, 128 * MB, 512 * MB};
+
+  if (rank_ == 0) {
+    printf("\n=== Put BW: Single Block (BLOCK scope, zero-copy) ===\n");
+    printf(
+        "%-12s  %5s  %10s  %10s\n", "PutSize", "Iters", "Lat(us)", "BW(GB/s)");
+    printf(
+        "%-12s  %5s  %10s  %10s\n", "-------", "-----", "-------", "--------");
+  }
+
+  for (size_t sz : sizes) {
+    auto r = runBenchmark(sz, 1);
+    if (rank_ == 0) {
+      double lat_us = r.elapsed_ms * 1000.0 / r.iterations;
+      printf(
+          "%-12s  %5d  %10.1f  %10.2f\n",
+          formatSize(r.total_bytes).c_str(),
+          r.iterations,
+          lat_us,
+          r.bw_gbps);
+    }
+  }
+}
+
+TEST_F(PutBwBenchmark, MultiBlock) {
+  size_t total = 512 * MB;
+  std::vector<int> block_counts = {1, 2, 4, 8, 16, 32, 64, 128};
+
+  if (rank_ == 0) {
+    printf(
+        "\n=== Put BW: Multi Block (512MB total, BLOCK scope, zero-copy) ===\n");
+    printf(
+        "%-8s  %-12s  %5s  %10s  %10s\n",
+        "Blocks",
+        "TileSize",
+        "Iters",
+        "Lat(us)",
+        "BW(GB/s)");
+    printf(
+        "%-8s  %-12s  %5s  %10s  %10s\n",
+        "------",
+        "--------",
+        "-----",
+        "-------",
+        "--------");
+  }
+
+  for (int nblk : block_counts) {
+    auto r = runBenchmark(total, nblk);
+    if (rank_ == 0) {
+      double lat_us = r.elapsed_ms * 1000.0 / r.iterations;
+      printf(
+          "%-8d  %-12s  %5d  %10.1f  %10.2f\n",
+          nblk,
+          formatSize(total / nblk).c_str(),
+          r.iterations,
+          lat_us,
+          r.bw_gbps);
+    }
+  }
+}
+
+TEST_F(PutBwBenchmark, SendRecvMultiBlock) {
+  size_t total = 512 * MB;
+  std::vector<int> block_counts = {1, 2, 4, 8, 16, 32, 64, 128};
+
+  if (rank_ == 0) {
+    printf(
+        "\n=== SendRecv BW: Multi Block (512MB total, BLOCK scope, copy-based) ===\n");
+    printf(
+        "%-8s  %-12s  %5s  %10s  %10s\n",
+        "Blocks",
+        "TileSize",
+        "Iters",
+        "Lat(us)",
+        "BW(GB/s)");
+    printf(
+        "%-8s  %-12s  %5s  %10s  %10s\n",
+        "------",
+        "--------",
+        "-----",
+        "-------",
+        "--------");
+  }
+
+  for (int nblk : block_counts) {
+    auto r = runSendRecvBenchmark(total, nblk);
+    if (rank_ == 0) {
+      double lat_us = r.elapsed_ms * 1000.0 / r.iterations;
+      printf(
+          "%-8d  %-12s  %5d  %10.1f  %10.2f\n",
+          nblk,
+          formatSize(total / nblk).c_str(),
+          r.iterations,
+          lat_us,
+          r.bw_gbps);
+    }
+  }
+}
+
+TEST_F(PutBwBenchmark, SendRecvPipelinedMultiBlock) {
+  // 128 blocks, sweep tile sizes by varying total (steps=1, PD=1).
+  // Tile = total / 128. Larger tile → less per-tile overhead.
+  int nblk = 128;
+  std::vector<size_t> totals = {512 * MB, 1024 * MB, 2048 * MB, 4096UL * MB};
+
+  if (rank_ == 0) {
+    printf(
+        "\n=== SendRecv BW: 128 Blocks, Tile Size Sweep (steps=1, PD=1) ===\n");
+    printf("%-12s  %-10s  %10s\n", "Total", "Tile", "BW(GB/s)");
+    printf("%-12s  %-10s  %10s\n", "-----", "----", "--------");
+  }
+
+  for (size_t total : totals) {
+    size_t section = total; // steps=1
+    int pd = 1;
+    size_t tile = section / nblk;
+
+    auto r = runSendRecvPipelinedBenchmark(total, section, pd, nblk);
+    if (rank_ == 0) {
+      printf(
+          "%-12s  %-10s  %10.2f\n",
+          formatSize(total).c_str(),
+          formatSize(tile).c_str(),
+          r.bw_gbps);
+    }
+  }
+}
+
+TEST_F(PutBwBenchmark, SendRecvPipelinedParamSweep) {
+  // Comprehensive sweep: 128 blocks, tile sizes 1-16MB, pd sweep.
+  // Matches Triton sweep configs exactly for direct comparison.
+  size_t total = 2048UL * MB;
+  std::vector<int> block_counts = {128};
+  std::vector<size_t> section_sizes = {
+      128 * MB, 256 * MB, 512 * MB, 1024 * MB, 2048 * MB};
+  std::vector<int> pd_values = {1, 2, 4, 8, 16};
+
+  if (rank_ == 0) {
+    printf(
+        "\n=== SendRecv Pipelined: Full Parameter Sweep (2GB total, 128 blocks) ===\n");
+    printf(
+        "%-22s | %-6s | %-10s | %-4s | %-10s | %-6s | %-10s | %-12s\n",
+        "Name",
+        "Blocks",
+        "Section",
+        "PD",
+        "Tile",
+        "Steps",
+        "Staging",
+        "BW(GB/s)");
+    printf(
+        "----------------------------------------------------------------------"
+        "------------------------------------------------------\n");
+  }
+
+  for (int nblk : block_counts) {
+    for (size_t sec : section_sizes) {
+      if (sec > total)
+        continue;
+      int total_steps = total / sec;
+      for (int pd : pd_values) {
+        if (pd > total_steps)
+          continue;
+        // Skip configs that need >2GB staging per dir to avoid OOM
+        size_t staging_per_dir = static_cast<size_t>(pd) * sec;
+        if (staging_per_dir > 1024UL * MB)
+          continue;
+        size_t tile = sec / nblk;
+        size_t staging = static_cast<size_t>(pd) * sec * 2; // send + recv
+
+        char name[64];
+        snprintf(
+            name,
+            sizeof(name),
+            "b%d_s%s_p%d",
+            nblk,
+            formatSize(sec).c_str(),
+            pd);
+
+        auto r = runSendRecvPipelinedBenchmark(total, sec, pd, nblk);
+        if (rank_ == 0) {
+          printf(
+              "%-22s | %-6d | %-10s | %-4d | %-10s | %-6d | %-10s | %-12.2f\n",
+              name,
+              nblk,
+              formatSize(sec).c_str(),
+              pd,
+              formatSize(tile).c_str(),
+              total_steps,
+              formatSize(staging).c_str(),
+              r.bw_gbps);
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Summary:
Add Triton IB sendrecv and put_bw kernels using the torchcomms device window API (NCCLx/GIN backend) for GPU-initiated RDMA over InfiniBand.

## Kernels

**sendrecv** (`sendrecv_kernel.py`): Block-scope pipelined bidirectional sendrecv. Each block independently copies and RDMA-puts its own tile — no inter-block coordination. Per-block signal IDs with monotonically increasing values. CUDA graph replayable via device-resident iteration counter.

**sendrecv cooperative** (`sendrecv_cooperative_kernel.py`): Cooperative variant where N blocks share the copy work and the last block issues a single put per step.

**put_bw** (`put_bw_kernel.py`): Raw put bandwidth microbenchmarks (fire-and-forget, pipelined, multi-block) for measuring NIC throughput ceiling.

## Key optimizations (vs initial implementation)
- `BLOCK_SIZE=8192` with `num_warps=8` (256 threads): enables Triton auto-vectorization to 128-bit loads/stores, 32 elements per thread per loop iteration
- Per-block signal layout (not per-block-per-slot): simpler, matches C++ kernel design
- Simplified drain: SLOT_FREE only (implies NIC_DONE by causal ordering)

## Performance (H100, IB, p2p_disabled, 128 blocks, section=total, PD=1)

| Size | Triton (GB/s) | C++ (GB/s) | Triton/C++ |
|------|--------------|------------|------------|
| 8MB | 6.78 | 6.49 | 104% |
| 32MB | 18.74 | 16.30 | 115% |
| 64MB | 26.75 | 26.86 | 100% |
| 128MB | 33.91 | 33.69 | 101% |
| 256MB | 39.14 | 39.59 | 99% |
| 512MB | 42.45 | 42.25 | 100% |
| 1GB | 44.23 | 42.92 | 103% |
| 2GB | 44.51 | 45.25 | 98% |
| 4GB | 44.80 | 46.34 | 97% |

Triton matches or exceeds C++ across most sizes. Small gap at 4GB (~3%) likely due to per-iteration kernel launch overhead (Triton launches per iteration, C++ loops internally).

Depends on D100357723 for C++ benchmark reference.

Reviewed By: siyengar

Differential Revision: D100059897


