### PR TITLE
Fix allGatherCtrl ignoring caller-specified backend

### DIFF
--- a/comms/ctran/mapper/CtranMapper.cc
+++ b/comms/ctran/mapper/CtranMapper.cc
@@ -1023,14 +1023,22 @@ commResult_t CtranMapper::allGatherCtrl(
 
     if (peerBackends[i] == CtranMapperBackend::NVL) {
       if (nvlSendMsg.type == ControlMsgType::UNSPECIFIED) {
+        // exportMem records in exportRegCache_ for this peer
         FB_COMMCHECK(this->exportMem(
-            peerList[i], buf, hdl, nvlSendMsg, &nvlExtraSegments));
+            peerList[i],
+            buf,
+            hdl,
+            nvlSendMsg,
+            &nvlExtraSegments,
+            peerBackends[i]));
+      } else if (NCCL_CTRAN_IPC_REGCACHE_ENABLE_ASYNC_SOCKET) {
+        // exportMem not called for this peer, record explicitly
+        exportRegCache_.wlock()->record(regElem, peerList[i]);
       }
-      exportRegCache_.wlock()->record(regElem, peerList[i]);
     } else {
       if (ibSendMsg.type == ControlMsgType::UNSPECIFIED) {
-        FB_COMMCHECK(
-            this->exportMem(peerList[i], buf, hdl, ibSendMsg, nullptr));
+        FB_COMMCHECK(this->exportMem(
+            peerList[i], buf, hdl, ibSendMsg, nullptr, peerBackends[i]));
       }
     }
   }

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -369,7 +369,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
    * Input argument:
    *   - buf: the local buffer to be remotely accessed
    *   - hdl: the handle of the local buffer
-   *   - backend: the backend to be used for data transfer. If not specified,
+   *   - backend: the backend to be used for memory export. If not specified,
    *              use internal default based on peer rank and memory type.
    * Output arguments:
    *   - remoteBufs: the allgathered remote buffers from all local ranks
@@ -391,7 +391,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
    *   - buf: the local buffer to be remotely accessed
    *   - hdl: the handle of the local buffer
    *   - ranks: the ranks to be used for the AllGather
-   *   - backend: the backend to be used for data transfer. If not specified,
+   *   - backend: the backend to be used for memory export. If not specified,
    *              use internal default based on peer rank and memory type.
    * Output arguments:
    *   - remoteBufs: the allgathered remote buffers from all local ranks
@@ -414,7 +414,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
    * Input argument:
    *   - buf: the local buffer to be remotely accessed
    *   - hdl: the handle of the local buffer
-   *   - backend: the backend to be used for data transfer. If not specified,
+   *   - backend: the backend to be used for memory export. If not specified,
    *              use internal default based on peer rank and memory type.
    * Output arguments:
    *   - remoteBufs: the allgathered remote buffers from all local ranks


### PR DESCRIPTION
Summary:
D98386092 refactored allGatherCtrl to use pre-built ControlMsg objects
(nvlSendMsg/ibSendMsg) for multi-packet transport. However, the exportMem
calls that populate these messages did not forward the caller's backend
parameter, defaulting to UNSET. Inside exportMem, UNSET triggers
queryPeerBackend() which returns NVL for intra-node peers, even when the
caller explicitly requested IB.

This caused the intraAllGatherCtrl/IB test to fail: rank 3 observed
remoteAccessKeys[i].backend == NVL (2) instead of the expected IB (1).

Fix: pass the resolved peerBackends[i] to both exportMem calls so the
caller-specified backend is respected.

Also updated comment of allgatherCtrl API:  `backend` means for memory export, not transfer; fix double record in exportCache_ for the first peer: mapper->exportMem should already update the exportCache_ for the peer, we only need to explicitly record for the remaining peer

Differential Revision: D100900492


