### PR TITLE
Add ringDb option to put() for doorbell batching

### DIFF
--- a/comms/pipes/P2pIbgdaTransportDevice.cuh
+++ b/comms/pipes/P2pIbgdaTransportDevice.cuh
@@ -96,16 +96,23 @@ class P2pIbgdaTransportDevice {
    * Performs an RDMA Write from local buffer to remote buffer.
    * Returns immediately with a work handle for optional completion tracking.
    *
+   * By default, rings the NIC doorbell after posting the WQE. Set
+   * ringDb=false to skip the doorbell for batching multiple puts.
+   * The caller must ensure the doorbell is rung afterward (e.g.,
+   * via a subsequent put(ringDb=true) or ring_doorbell()).
+   *
    * @param localBuf Source buffer in local GPU memory
    * @param remoteBuf Destination buffer in remote GPU memory
    * @param nbytes Number of bytes to transfer
+   * @param ringDb Whether to ring the NIC doorbell (default: true)
    *
    * @return IbgdaWork for tracking local completion via wait_local()
    */
   __device__ IbgdaWork
   put(const IbgdaLocalBuffer& localBuf,
       const IbgdaRemoteBuffer& remoteBuf,
-      std::size_t nbytes) {
+      std::size_t nbytes,
+      bool ringDb = true) {
     doca_gpu_dev_verbs_ticket_t ticket;
 
     doca_gpu_dev_verbs_addr localAddr = {
@@ -115,11 +122,14 @@ class P2pIbgdaTransportDevice {
         .addr = reinterpret_cast<uint64_t>(remoteBuf.ptr),
         .key = remoteBuf.rkey.value};
 
+    uint32_t code_opt = ringDb
+        ? DOCA_GPUNETIO_VERBS_GPU_CODE_OPT_DEFAULT
+        : DOCA_GPUNETIO_VERBS_GPU_CODE_OPT_SKIP_DB_RINGING;
     doca_gpu_dev_verbs_put<
         DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
         DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO,
         DOCA_GPUNETIO_VERBS_EXEC_SCOPE_THREAD>(
-        qp_, remoteAddr, localAddr, nbytes, &ticket);
+        qp_, remoteAddr, localAddr, nbytes, &ticket, code_opt);
 
     return IbgdaWork(ticket);
   }
@@ -142,6 +152,10 @@ class P2pIbgdaTransportDevice {
    * @param remoteBuf Destination buffer in remote GPU memory (this group's
    * chunk)
    * @param nbytes Number of bytes to transfer (partitioned across lanes)
+   * @param ringDb Whether to ring the NIC doorbell (default: true). Set to
+   *   false to batch with subsequent puts; caller must ensure the doorbell is
+   *   eventually rung via a later put(ringDb=true), signal_peer(), or
+   *   ring_doorbell().
    *
    * @return IbgdaWork for tracking local completion via wait_local() (per-lane)
    */
@@ -149,7 +163,8 @@ class P2pIbgdaTransportDevice {
       ThreadGroup& group,
       const IbgdaLocalBuffer& localBuf,
       const IbgdaRemoteBuffer& remoteBuf,
-      std::size_t nbytes) {
+      std::size_t nbytes,
+      bool ringDb = true) {
     std::size_t chunkSize = nbytes / group.group_size;
     std::size_t offset = group.thread_id_in_group * chunkSize;
     // Last thread picks up any remainder bytes
@@ -161,9 +176,9 @@ class P2pIbgdaTransportDevice {
     IbgdaRemoteBuffer laneRemoteBuf = remoteBuf.subBuffer(offset);
 
     if (group.group_size == 1) {
-      return put(laneBuf, laneRemoteBuf, laneBytes);
+      return put(laneBuf, laneRemoteBuf, laneBytes, ringDb);
     }
-    return put_group_impl(group, laneBuf, laneRemoteBuf, laneBytes);
+    return put_group_impl(group, laneBuf, laneRemoteBuf, laneBytes, ringDb);
   }
 
   /**
@@ -183,6 +198,10 @@ class P2pIbgdaTransportDevice {
    *   by all groups)
    * @param nbytes Total number of bytes to transfer (partitioned across groups,
    *   then across lanes within each group)
+   * @param ringDb Whether to ring the NIC doorbell (default: true). Set to
+   *   false to batch with subsequent puts; caller must ensure the doorbell is
+   *   eventually rung via a later put(ringDb=true), signal_peer(), or
+   *   ring_doorbell().
    *
    * @return IbgdaWork for tracking local completion via wait_local() (per-lane)
    */
@@ -190,7 +209,8 @@ class P2pIbgdaTransportDevice {
       ThreadGroup& group,
       const IbgdaLocalBuffer& localBuf,
       const IbgdaRemoteBuffer& remoteBuf,
-      std::size_t nbytes) {
+      std::size_t nbytes,
+      bool ringDb = true) {
     // Partition across groups; last group picks up remainder
     std::size_t chunkPerGroup = nbytes / group.total_groups;
     std::size_t groupOffset = group.group_id * chunkPerGroup;
@@ -201,7 +221,8 @@ class P2pIbgdaTransportDevice {
     IbgdaLocalBuffer groupLocalBuf = localBuf.subBuffer(groupOffset);
     IbgdaRemoteBuffer groupRemoteBuf = remoteBuf.subBuffer(groupOffset);
 
-    return put_group_local(group, groupLocalBuf, groupRemoteBuf, groupBytes);
+    return put_group_local(
+        group, groupLocalBuf, groupRemoteBuf, groupBytes, ringDb);
   }
 
   // ===========================================================================
@@ -754,6 +775,23 @@ class P2pIbgdaTransportDevice {
     return qp_;
   }
 
+  /**
+   * ring_doorbell - Ring doorbell for all pending WQEs up to lastWork
+   *
+   * Call after one or more put(..., ringDb=false) to notify the NIC of
+   * all pending WQEs in a single doorbell ring. Pass the IbgdaWork returned
+   * by the most recent put — the doorbell will cover that WQE and any
+   * earlier ones still pending.
+   *
+   * @param lastWork IbgdaWork returned by the last put(ringDb=false)
+   */
+  __device__ void ring_doorbell(IbgdaWork lastWork) {
+    doca_gpu_dev_verbs_submit<
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+        DOCA_GPUNETIO_VERBS_SYNC_SCOPE_GPU,
+        DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(qp_, lastWork.value + 1);
+  }
+
  private:
   /**
    * put_group_impl - Generic group-collaborative RDMA Write
@@ -772,6 +810,8 @@ class P2pIbgdaTransportDevice {
    * @param laneBuf Source buffer for this thread's chunk
    * @param laneRemoteBuf Destination buffer for this thread's chunk
    * @param laneBytes Number of bytes for this thread's chunk
+   * @param ringDb Whether to ring the NIC doorbell after submit (default:
+   * true)
    *
    * @return IbgdaWork for tracking local completion via wait_local()
    */
@@ -779,7 +819,8 @@ class P2pIbgdaTransportDevice {
       ThreadGroup& group,
       const IbgdaLocalBuffer& laneBuf,
       const IbgdaRemoteBuffer& laneRemoteBuf,
-      std::size_t laneBytes) {
+      std::size_t laneBytes,
+      bool ringDb = true) {
     // Guard: group_size must fit within the QP send queue depth.
     // The leader reserves group_size WQE slots atomically. If group_size
     // exceeds the QP ring buffer depth (sq_wqe_num), the DOCA backpressure
@@ -830,16 +871,19 @@ class P2pIbgdaTransportDevice {
     // 4. Sync — all WQEs prepared
     group.sync();
 
-    // 5. Leader marks ready and rings doorbell
+    // 5. Leader marks ready and rings doorbell (skipped if ringDb=false)
     if (group.is_leader()) {
       doca_gpu_dev_verbs_mark_wqes_ready<
           DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(
           qp_, base_wqe_idx, base_wqe_idx + group.group_size - 1);
+      uint32_t code_opt = ringDb
+          ? DOCA_GPUNETIO_VERBS_GPU_CODE_OPT_DEFAULT
+          : DOCA_GPUNETIO_VERBS_GPU_CODE_OPT_SKIP_DB_RINGING;
       doca_gpu_dev_verbs_submit<
           DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
           DOCA_GPUNETIO_VERBS_SYNC_SCOPE_GPU,
           DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(
-          qp_, base_wqe_idx + group.group_size);
+          qp_, base_wqe_idx + group.group_size, code_opt);
     }
 
     // 6. Sync — ensure submit done before threads proceed

--- a/comms/pipes/tests/MultipeerIbgdaTransportTest.cc
+++ b/comms/pipes/tests/MultipeerIbgdaTransportTest.cc
@@ -225,6 +225,102 @@ TEST_F(MultipeerIbgdaTransportTestFixture, PutSignalBasic) {
 }
 
 // =============================================================================
+// Put with ringDb=false + Signal — Verifies doorbell batching codepath
+//
+// Sender posts put(ringDb=false) to hold the WQE back, then signal_remote()
+// to ring the doorbell. Receiver waits for the signal and verifies the
+// data arrived — proving the held-back put was successfully batched into the
+// signal's doorbell ring on the same QP.
+// =============================================================================
+
+TEST_F(MultipeerIbgdaTransportTestFixture, PutNoDbBatching) {
+  if (numRanks != 2) {
+    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    return;
+  }
+
+  const std::size_t nbytes = 64 * 1024;
+  const int numBlocks = 1;
+  const int blockSize = 1;
+  const int peerRank = (globalRank == 0) ? 1 : 0;
+  const uint8_t testPattern = 0x55;
+
+  try {
+    auto transport = createTransport();
+
+    DeviceBuffer dataBuffer(nbytes);
+    auto localDataBuf = transport->registerBuffer(dataBuffer.get(), nbytes);
+    auto remoteDataBufs = transport->exchangeBuffer(localDataBuf);
+    int peerIndex = (peerRank < globalRank) ? peerRank : (peerRank - 1);
+    auto remoteDataBuf = remoteDataBufs[peerIndex];
+
+    const std::size_t signalBufSize = sizeof(uint64_t);
+    DeviceBuffer signalBuffer(signalBufSize);
+    CUDACHECK_TEST(cudaMemset(signalBuffer.get(), 0, signalBufSize));
+    auto localSignalBuf =
+        transport->registerBuffer(signalBuffer.get(), signalBufSize);
+    auto remoteSignalBufs = transport->exchangeBuffer(localSignalBuf);
+    auto remoteSignalBuf = remoteSignalBufs[peerIndex];
+
+    P2pIbgdaTransportDevice* peerTransportPtr =
+        transport->getP2pTransportDevice(peerRank);
+
+    if (globalRank == 0) {
+      test::fillBufferWithPattern(
+          localDataBuf.ptr, nbytes, testPattern, numBlocks, blockSize);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+      test::testPutNoDbAndSignal(
+          peerTransportPtr,
+          localDataBuf,
+          remoteDataBuf,
+          nbytes,
+          remoteSignalBuf,
+          0,
+          1,
+          numBlocks,
+          blockSize);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    } else {
+      CUDACHECK_TEST(cudaMemset(localDataBuf.ptr, 0, nbytes));
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+      test::testWaitSignal(
+          static_cast<uint64_t*>(signalBuffer.get()),
+          0,
+          1,
+          numBlocks,
+          blockSize);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+      DeviceBuffer errorCountBuf(sizeof(int));
+      auto* d_errorCount = static_cast<int*>(errorCountBuf.get());
+      CUDACHECK_TEST(cudaMemset(d_errorCount, 0, sizeof(int)));
+      test::verifyBufferPattern(
+          localDataBuf.ptr,
+          nbytes,
+          testPattern,
+          d_errorCount,
+          numBlocks,
+          blockSize);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+
+      int h_errorCount = 0;
+      CUDACHECK_TEST(cudaMemcpy(
+          &h_errorCount, d_errorCount, sizeof(int), cudaMemcpyDeviceToHost));
+      EXPECT_EQ(h_errorCount, 0) << "put(ringDb=false): " << h_errorCount
+                                 << " byte mismatches out of " << nbytes;
+    }
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+}
+
+// =============================================================================
 // Group-Level Put/Signal Basic Test - Verifies group-collaborative RDMA
 // =============================================================================
 

--- a/comms/pipes/tests/MultipeerIbgdaTransportTest.cu
+++ b/comms/pipes/tests/MultipeerIbgdaTransportTest.cu
@@ -55,6 +55,55 @@ void testPutAndSignal(
 }
 
 // =============================================================================
+// Kernel: Put with ringDb=false + signal_remote (doorbell batching)
+//
+// put(ringDb=false) prepares and marks the WQE ready in the QP ring buffer,
+// but skips the submit step entirely — the local sq_wqe_pi is not advanced
+// and the NIC is never notified. The subsequent signal_remote() submits its
+// own WQE, which atomic_max's sq_wqe_pi past both WQEs and rings a single
+// doorbell — covering the held-back put and the signal in one ring.
+// =============================================================================
+
+__global__ void putNoDbAndSignalKernel(
+    P2pIbgdaTransportDevice* transport,
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    std::size_t nbytes,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    int signalId,
+    uint64_t signalVal) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    transport->put(localBuf, remoteBuf, nbytes, /*ringDb=*/false);
+    transport->signal_remote(remoteSignalBuf, signalId, signalVal);
+  }
+}
+
+void testPutNoDbAndSignal(
+    P2pIbgdaTransportDevice* deviceTransportPtr,
+    const IbgdaLocalBuffer& localBuf,
+    const IbgdaRemoteBuffer& remoteBuf,
+    std::size_t nbytes,
+    const IbgdaRemoteBuffer& remoteSignalBuf,
+    int signalId,
+    uint64_t signalVal,
+    int numBlocks,
+    int blockSize) {
+  putNoDbAndSignalKernel<<<numBlocks, blockSize>>>(
+      deviceTransportPtr,
+      localBuf,
+      remoteBuf,
+      nbytes,
+      remoteSignalBuf,
+      signalId,
+      signalVal);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("Kernel launch failed: ") + cudaGetErrorString(err));
+  }
+}
+
+// =============================================================================
 // Kernel: Group-collaborative put + signal (warp group)
 // =============================================================================
 

--- a/comms/pipes/tests/MultipeerIbgdaTransportTest.h
+++ b/comms/pipes/tests/MultipeerIbgdaTransportTest.h
@@ -362,6 +362,23 @@ void testPutSignalCounter(
     int blockSize);
 
 /**
+ * Test kernel: Put with ringDb=false + signal_remote (doorbell batching)
+ *
+ * put(ringDb=false) posts the WQE without ringing; the subsequent
+ * signal_remote() rings the doorbell and submits both WQEs in one batch.
+ */
+void testPutNoDbAndSignal(
+    P2pIbgdaTransportDevice* deviceTransportPtr,
+    const IbgdaLocalBuffer& localBuf,
+    const IbgdaRemoteBuffer& remoteBuf,
+    std::size_t nbytes,
+    const IbgdaRemoteBuffer& remoteSignalBuf,
+    int signalId,
+    uint64_t signalVal,
+    int numBlocks,
+    int blockSize);
+
+/**
  * Test kernel: Wait for local counter to reach expected value
  *
  * GPU thread spins on volatile counter until it reaches expectedVal.

--- a/comms/pipes/window/DeviceWindow.cuh
+++ b/comms/pipes/window/DeviceWindow.cuh
@@ -956,12 +956,18 @@ class DeviceWindow {
    * constructor). Source is a registered buffer (from
    * HostWindow::registerLocalBuffer).
    *
+   * By default, rings the NIC doorbell after posting the WQE. Set
+   * ringDb=false to skip the doorbell for batching multiple puts.
+   * The caller must ensure the doorbell is rung afterward (e.g.,
+   * via a subsequent put(ringDb=true) or signal_peer()).
+   *
    * @param group        ThreadGroup for group coordination.
    * @param target_rank  Rank to put to (must not be self).
    * @param dst_offset   Byte offset into the target peer's window buffer.
    * @param src_buf      Registered source buffer.
    * @param src_offset   Byte offset into the source buffer.
    * @param nbytes       Number of bytes to transfer.
+   * @param ringDb      Whether to ring the NIC doorbell (default: true).
    */
   __device__ __forceinline__ void put(
       ThreadGroup& group,
@@ -969,7 +975,8 @@ class DeviceWindow {
       std::size_t dst_offset,
       const LocalBufferRegistration& src_buf,
       std::size_t src_offset,
-      std::size_t nbytes) {
+      std::size_t nbytes,
+      bool ringDb = true) {
     DEVICE_WINDOW_CHECK_RANK(target_rank, handle_.nRanks);
     DEVICE_WINDOW_CHECK_NOT_SELF(target_rank, handle_.myRank);
     const auto* localSrc = static_cast<const char*>(src_buf.base) + src_offset;
@@ -987,7 +994,7 @@ class DeviceWindow {
           remoteBufferRegistry_[ibgdaPeerIdx].rkey);
       handle_.get_ibgda(target_rank)
           .put_group_global(
-              group, localBuf, remoteBuf.subBuffer(dst_offset), nbytes);
+              group, localBuf, remoteBuf.subBuffer(dst_offset), nbytes, ringDb);
     }
   }
 


### PR DESCRIPTION
Summary:
When sending multiple small WQEs on the same QP (e.g., 4+ chunks per peer in AFD scatter), ringing the NIC doorbell after every put causes a doorbell storm — each doorbell is an MMIO write that contends for PCIe bandwidth and NIC doorbell processing. This adds significant latency at scale.

Add bool ringDb=true parameter to put() to allow callers to skip the doorbell and batch multiple puts on the same QP. The caller rings the doorbell once via a subsequent put(ringDb=true), signal_peer(), or the new ring_doorbell(IbgdaWork) API. This uses DOCA's existing SKIP_DB_RINGING flag internally.

The ringDb parameter is wired through put, put_group_local, put_group_global, put_group_impl, and DeviceWindow::put.

Adds PutNoDbBatching test that verifies put(ringDb=false) followed by signal_remote() correctly delivers data — exercising the batching codepath end-to-end with real IBGDA QPs.

Differential Revision: D101080964


