### PR TITLE
Migrate ReduceScatter v2_27 test from legacy TestsDistUtils to NcclxBaseTestFixture

### DIFF
--- a/comms/ncclx/meta/collectives/tests/ReduceScatterQuantizeTestUtils.h
+++ b/comms/ncclx/meta/collectives/tests/ReduceScatterQuantizeTestUtils.h
@@ -6,10 +6,12 @@
 #include <stdlib.h>
 #include <cmath>
 #include <cstddef>
+#include <optional>
 
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
+#include "comms/ncclx/meta/tests/NcclxBaseTest.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsCuUtils.h"
-#include "comms/testinfra/TestsDistUtils.h"
 
 // Compute the number of PAT reduction steps = log2(numRanks).
 static int patSteps(int numRanks) {
@@ -34,26 +36,26 @@ static float bf16Ulp(float value) {
 // Test fixture for ReduceScatterQuantize tests.
 // Sets NCCL_PAT_ENABLE=1 and NCCL_ALGO=PAT, creates an NCCL communicator
 // and a CUDA stream.
-class ReduceScatterQuantizeTest : public NcclxBaseTest {
+class ReduceScatterQuantizeTest : public NcclxBaseTestFixture {
  public:
   ReduceScatterQuantizeTest() = default;
   void SetUp() override {
-    setenv("NCCL_PAT_ENABLE", "1", 1);
-    setenv("NCCL_ALGO", "PAT", 1);
-
-    NcclxBaseTest::SetUp();
-    comm = createNcclComm(
-        globalRank, numRanks, localRank, false, nullptr, server.get());
+    NcclxBaseTestFixture::SetUp({
+        {"NCCL_PAT_ENABLE", "1"},
+        {"NCCL_ALGO", "PAT"},
+    });
+    commRAII_.emplace(globalRank, numRanks, localRank, bootstrap_.get());
+    comm = commRAII_->get();
     CUDACHECK_TEST(cudaStreamCreate(&stream));
   }
 
   void TearDown() override {
-    NCCLCHECK_TEST(ncclCommDestroy(comm));
     CUDACHECK_TEST(cudaStreamDestroy(stream));
-    NcclxBaseTest::TearDown();
+    commRAII_.reset();
+    NcclxBaseTestFixture::TearDown();
   }
 
  protected:
-  ncclComm_t comm;
+  std::optional<ncclx::test::NcclCommRAII> commRAII_;
   cudaStream_t stream;
 };

--- a/comms/ncclx/meta/colltrace/tests/CollTraceDistTest.cc
+++ b/comms/ncclx/meta/colltrace/tests/CollTraceDistTest.cc
@@ -19,8 +19,9 @@
 
 #include "comms/ctran/Ctran.h"
 #include "comms/ctran/CtranEx.h"
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
+#include "comms/ncclx/meta/tests/NcclxBaseTest.h"
 #include "comms/testinfra/TestUtils.h"
-#include "comms/testinfra/TestsDistUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/trainer/TrainerContext.h"
 #include "meta/colltrace/CollTrace.h"
@@ -35,24 +36,22 @@
     std::cout << "Test failed with stdout being: " << output << std::endl; \
   };
 
-class CollTraceTest : public NcclxBaseTest {
+class CollTraceTest : public NcclxBaseTestFixture {
  public:
   CollTraceTest() = default;
   void SetUp() override {
-    // Set up dummy values for environment variables for Scuba test
-    setenv("WORLD_SIZE", "4", 0);
-    setenv("HPC_JOB_NAME", "CollTraceUT", 0);
-    setenv("HPC_JOB_VERSION", "1", 0);
-    setenv("HPC_JOB_ATTEMPT_INDEX", "2", 0);
-    setenv(
-        "NCCL_HPC_JOB_IDS",
-        "HPC_JOB_NAME,HPC_JOB_VERSION,HPC_JOB_ATTEMPT_INDEX",
-        0);
-    setenv("NCCL_CTRAN_ENABLE", "1", 0);
+    // FIXME(colltrace): migrate these tests to new colltrace
+    NcclxBaseTestFixture::SetUp({
+        {"WORLD_SIZE", "4"},
+        {"HPC_JOB_NAME", "CollTraceUT"},
+        {"HPC_JOB_VERSION", "1"},
+        {"HPC_JOB_ATTEMPT_INDEX", "2"},
+        {"NCCL_HPC_JOB_IDS",
+         "HPC_JOB_NAME,HPC_JOB_VERSION,HPC_JOB_ATTEMPT_INDEX"},
+        {"NCCL_CTRAN_ENABLE", "1"},
+        {"NCCL_COLLTRACE_USE_NEW_COLLTRACE", "0"},
+    });
 
-    NcclxBaseTest::SetUp();
-
-    CUDACHECK_TEST(cudaSetDevice(this->localRank));
     CUDACHECK_TEST(cudaStreamCreate(&this->stream));
   }
 
@@ -65,6 +64,7 @@ class CollTraceTest : public NcclxBaseTest {
     if (recvBuf) {
       CUDACHECK_TEST(cudaFree(recvBuf));
     }
+    NcclxBaseTestFixture::TearDown();
   }
 
   void prepareAllreduce(const int count) {
@@ -171,7 +171,8 @@ TEST_F(CollTraceTest, TraceFeatureEnableCollTrace) {
   auto traceGuard = EnvRAII(NCCL_COLLTRACE, {"trace"});
   startVerboseLogging();
   CAPTURE_STDOUT_WITH_FAIL_SAFE()
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_EQ(comm->newCollTrace, nullptr);
   const int count = 1048576;
   const int nColl = 10;
@@ -195,7 +196,8 @@ TEST_F(CollTraceTest, TraceFeatureEnableCollTrace) {
 
 TEST_F(CollTraceTest, VerboseAllReduce) {
   auto traceGuard = EnvRAII(NCCL_COLLTRACE, {"verbose"});
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_EQ(comm->newCollTrace, nullptr);
   const int count = 1048576;
   const int nColl = 10;
@@ -228,7 +230,8 @@ TEST_F(CollTraceTest, VerboseAllReduce) {
 
 TEST_F(CollTraceTest, VerboseAllToAll) {
   auto traceGuard = EnvRAII(NCCL_COLLTRACE, {"verbose"});
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_EQ(comm->newCollTrace, nullptr);
   const int count = 1048576;
   const int nColl = 10;
@@ -257,7 +260,8 @@ TEST_F(CollTraceTest, VerboseAllToAll) {
 
 TEST_F(CollTraceTest, VerboseSendRecv) {
   auto traceGuard = EnvRAII(NCCL_COLLTRACE, {"verbose"});
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_EQ(comm->newCollTrace, nullptr);
   const int count = 1048576;
   const int nColl = 10;
@@ -294,7 +298,8 @@ TEST_F(CollTraceTest, VerboseSendOrRecv) {
   }
 
   auto traceGuard = EnvRAII(NCCL_COLLTRACE, {"verbose"});
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_EQ(comm->newCollTrace, nullptr);
   const int count = 1048576;
   const int nColl = 10;
@@ -336,7 +341,8 @@ TEST_F(CollTraceTest, DumpSendRecv) {
   }
 
   auto traceGuard = EnvRAII(NCCL_COLLTRACE, {"verbose"});
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_EQ(comm->newCollTrace, nullptr);
   const int count = 1048576;
   const int nColl = 10;
@@ -371,7 +377,8 @@ TEST_F(CollTraceTest, DumpSendRecv) {
 
 TEST_F(CollTraceTest, DumpAllFinished) {
   auto traceGuard = EnvRAII(NCCL_COLLTRACE, {"trace"});
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_EQ(comm->newCollTrace, nullptr);
   const int count = 1048576;
   const int nColl = 10;
@@ -391,7 +398,8 @@ TEST_F(CollTraceTest, DumpAllFinished) {
 
 TEST_F(CollTraceTest, DumpWithUnfinished) {
   auto traceGuard = EnvRAII(NCCL_COLLTRACE, {"trace"});
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_EQ(comm->newCollTrace, nullptr);
   const int count = 1048576;
   const int nColl = 10;
@@ -436,7 +444,8 @@ TEST_F(CollTraceTest, DumpWithUnfinished) {
 
 TEST_F(CollTraceTest, TestSerializedDump) {
   auto traceGuard = EnvRAII(NCCL_COLLTRACE, {"trace"});
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_EQ(comm->newCollTrace, nullptr);
   const int count = 1048576;
   const int nColl = 10;
@@ -488,7 +497,8 @@ TEST_F(CollTraceTest, TestScubaEntry) {
   // overwrite CollTrace features before creating comm
   auto traceGuard = EnvRAII(NCCL_COLLTRACE, {"trace"});
 
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_EQ(comm->newCollTrace, nullptr);
   const int count = 1048576;
   const int nColl = 10;
@@ -560,7 +570,8 @@ TEST_F(CollTraceTest, TestRecordNoDropBelowLimit) {
   auto recordGuard = EnvRAII(
       NCCL_COLLTRACE_RECORD_MAX, NCCL_COLLTRACE_RECORD_MAX_DEFAULTCVARVALUE);
 
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_EQ(comm->newCollTrace, nullptr);
   const int count = 1048576;
   if (NCCL_COLLTRACE_RECORD_MAX_DEFAULTCVARVALUE <= 1) {
@@ -586,7 +597,8 @@ TEST_F(CollTraceTest, TestRecordNoDropByEnv) {
   auto traceGuard = EnvRAII(NCCL_COLLTRACE, {"trace"});
   auto recordGuard = EnvRAII(NCCL_COLLTRACE_RECORD_MAX, -1);
 
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_EQ(comm->newCollTrace, nullptr);
   const int count = 1048576;
   const int nColl =
@@ -610,7 +622,8 @@ TEST_F(CollTraceTest, TestRecordDropOverLIMIT) {
   auto traceGuard = EnvRAII(NCCL_COLLTRACE, {"trace"});
   auto recordGuard = EnvRAII(NCCL_COLLTRACE_RECORD_MAX, 100);
 
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_EQ(comm->newCollTrace, nullptr);
   const int count = 1048576;
   const int nColl = NCCL_COLLTRACE_RECORD_MAX * 5;
@@ -635,7 +648,8 @@ TEST_F(CollTraceTest, TestCtranScubaEntry) {
   auto traceGuard = EnvRAII(NCCL_COLLTRACE, {"trace"});
   auto ctranGuard = EnvRAII(NCCL_CTRAN_ENABLE, true);
 
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_EQ(comm->newCollTrace, nullptr);
 
   constexpr int count = 1048576;
@@ -709,7 +723,8 @@ TEST_F(CollTraceTest, VerboseAllToAllCtran) {
   auto ctranAlgoGuard = EnvRAII(NCCL_ALLTOALL_ALGO, NCCL_ALLTOALL_ALGO::ctran);
   auto ctranGuard = EnvRAII(NCCL_CTRAN_ENABLE, true);
   auto traceGuard = EnvRAII(NCCL_COLLTRACE, {"verbose"});
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_EQ(comm->newCollTrace, nullptr);
 
   constexpr int count = 1048576;
@@ -753,7 +768,8 @@ TEST_F(CollTraceTest, VerboseAllToAllCtran) {
 TEST_F(CollTraceTest, TestBcastCtranEx) {
   auto ctranGuard = EnvRAII(NCCL_CTRAN_ENABLE, true);
   auto traceGuard = EnvRAII(NCCL_COLLTRACE, {"trace"});
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_EQ(comm->newCollTrace, nullptr);
 
   constexpr int count = 1048576;
@@ -825,7 +841,8 @@ TEST_F(CollTraceTest, MixedCtranBaseline) {
   auto checksumSampleRateGuard =
       EnvRAII(NCCL_CTRAN_ALLGATHER_CHECKSUM_SAMPLE_RATE, 1);
   auto gx = EnvRAII(NCCL_COLLTRACE_RECORD_MAX, -1);
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_EQ(comm->newCollTrace, nullptr);
 
   constexpr int count = 1048576;
@@ -869,7 +886,8 @@ TEST_F(CollTraceTest, GroupedSendRecv) {
   auto traceGuard = EnvRAII(NCCL_COLLTRACE, {"trace"});
   auto gx = EnvRAII(NCCL_COLLTRACE_RECORD_MAX, -1);
 
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_EQ(comm->newCollTrace, nullptr);
 
   const int count = 1048576;
@@ -917,7 +935,8 @@ TEST_F(CollTraceTest, SimulatePPSendRecv) {
   auto traceGuard = EnvRAII(NCCL_COLLTRACE, {"trace"});
   auto gx = EnvRAII(NCCL_COLLTRACE_RECORD_MAX, -1);
 
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_EQ(comm->newCollTrace, nullptr);
 
   const int count = 1048576;
@@ -982,7 +1001,8 @@ TEST_F(CollTraceTest, GroupedSendRecvCtran) {
   auto nolocalGuard =
       EnvRAII(NCCL_COMM_STATE_DEBUG_TOPO, NCCL_COMM_STATE_DEBUG_TOPO::nolocal);
 
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_EQ(comm->newCollTrace, nullptr);
 
   const int count = 1048576;
@@ -1043,7 +1063,8 @@ TEST_F(CollTraceTest, SimulatePPSendRecvCtran) {
       EnvRAII(NCCL_CTRAN_SENDRECV_CHECKSUM_SAMPLE_RATE, 1);
   auto gx = EnvRAII(NCCL_COLLTRACE_RECORD_MAX, -1);
 
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
 
   const int count = 1048576;
   const int nColl = 10;
@@ -1109,7 +1130,8 @@ TEST_F(CollTraceTest, SimulatePPSendRecvCtran) {
 TEST_F(CollTraceTest, TestIterLimit) {
   auto traceGuard = EnvRAII(NCCL_COLLTRACE, {"trace"});
   auto iterGuard = EnvRAII(NCCL_COLLTRACE_RECORD_MAX_ITERATIONS, 4);
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_EQ(comm->newCollTrace, nullptr);
 
   constexpr int count = 1048576;
@@ -1141,7 +1163,8 @@ TEST_F(CollTraceTest, winPutWait) {
   auto cpuGuard = EnvRAII(NCCL_COLLTRACE_CTRAN_USE_CPU_RECORD, true);
   auto recordGuard = EnvRAII(NCCL_COLLTRACE_RECORD_MAX, kNumIters * 3);
 
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_EQ(comm->newCollTrace, nullptr);
 
   auto statex = comm->ctranComm_->statex_.get();
@@ -1269,7 +1292,8 @@ TEST_F(CollTraceTest, TestCudaGraphAllReduce) {
   auto graphGuard = EnvRAII{NCCL_COLLTRACE_TRACE_CUDA_GRAPH, true};
   // Set a big enough number to get all the colls
   auto recordGuard = EnvRAII{NCCL_COLLTRACE_RECORD_MAX, 1000};
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_EQ(comm->newCollTrace, nullptr);
   const int count = 1024;
   const int nColl = 3;
@@ -1322,7 +1346,8 @@ TEST_F(CollTraceTest, TestCudaGraphDisabledByEnvVar) {
   auto graphGuard = EnvRAII{NCCL_COLLTRACE_TRACE_CUDA_GRAPH, false};
   // Set a big enough number to get all the colls
   auto recordGuard = EnvRAII{NCCL_COLLTRACE_RECORD_MAX, 1000};
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_EQ(comm->newCollTrace, nullptr);
   const int count = 1024;
   const int nColl = 3;

--- a/comms/ncclx/meta/colltrace/tests/MapperTraceDistTest.cc
+++ b/comms/ncclx/meta/colltrace/tests/MapperTraceDistTest.cc
@@ -14,8 +14,9 @@
 
 #include "comms/ctran/Ctran.h"
 #include "comms/ctran/colltrace/MapperTrace.h"
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
+#include "comms/ncclx/meta/tests/NcclxBaseTest.h"
 #include "comms/testinfra/TestUtils.h"
-#include "comms/testinfra/TestsDistUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "meta/colltrace/CollTrace.h"
 
@@ -27,27 +28,23 @@
     std::cout << "Test failed with stdout being: " << output << std::endl; \
   };
 
-class MapperTraceTest : public NcclxBaseTest {
+class MapperTraceTest : public NcclxBaseTestFixture {
  public:
   MapperTraceTest() = default;
   void SetUp() override {
-    // Allow user to change via command line
+    // Allow user to change via command line (don't overwrite)
     setenv("NCCL_DEBUG_SUBSYS", "INIT,COLL", 0);
 
-    // Set up dummy values for environment variables for Scuba test
-    setenv("WORLD_SIZE", "4", 0);
-    setenv("HPC_JOB_NAME", "CollTraceUT", 0);
-    setenv("HPC_JOB_VERSION", "1", 0);
-    setenv("HPC_JOB_ATTEMPT_INDEX", "2", 0);
-    setenv(
-        "NCCL_HPC_JOB_IDS",
-        "HPC_JOB_NAME,HPC_JOB_VERSION,HPC_JOB_ATTEMPT_INDEX",
-        0);
-    setenv("NCCL_CTRAN_ENABLE", "1", 0);
+    NcclxBaseTestFixture::SetUp({
+        {"WORLD_SIZE", "4"},
+        {"HPC_JOB_NAME", "CollTraceUT"},
+        {"HPC_JOB_VERSION", "1"},
+        {"HPC_JOB_ATTEMPT_INDEX", "2"},
+        {"NCCL_HPC_JOB_IDS",
+         "HPC_JOB_NAME,HPC_JOB_VERSION,HPC_JOB_ATTEMPT_INDEX"},
+        {"NCCL_CTRAN_ENABLE", "1"},
+    });
 
-    NcclxBaseTest::SetUp();
-
-    CUDACHECK_TEST(cudaSetDevice(this->localRank));
     CUDACHECK_TEST(cudaStreamCreate(&this->stream));
   }
 
@@ -55,6 +52,7 @@ class MapperTraceTest : public NcclxBaseTest {
     CUDACHECK_TEST(cudaStreamDestroy(this->stream));
     CUDACHECK_TEST(cudaFree(sendBuf));
     CUDACHECK_TEST(cudaFree(recvBuf));
+    NcclxBaseTestFixture::TearDown();
   }
 
   void prepareCtranAllToAll(ncclComm* comm, const int count) {
@@ -79,7 +77,8 @@ TEST_F(MapperTraceTest, CtranAllToAll) {
   auto traceGuard = EnvRAII(NCCL_COLLTRACE, {"trace"});
   auto ctranOnGuard = EnvRAII(NCCL_CTRAN_ENABLE, true);
 
-  NcclCommRAII comm{this->globalRank, this->numRanks, this->localRank};
+  ncclx::test::NcclCommRAII comm{
+      this->globalRank, this->numRanks, this->localRank, bootstrap_.get()};
   const int count = 1048576;
   const int nColl = 10;
 

--- a/comms/ncclx/meta/colltrace/tests/NewCollTraceDistTestLocal.cc
+++ b/comms/ncclx/meta/colltrace/tests/NewCollTraceDistTestLocal.cc
@@ -15,34 +15,29 @@
 #include "nccl.h" // @manual
 
 #include "comms/ctran/Ctran.h"
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
+#include "comms/ncclx/meta/tests/NcclxBaseTest.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestXPlatUtils.h"
-#include "comms/testinfra/TestsDistUtils.h"
 #include "meta/commDump.h"
 
-class CollTraceTestLocal : public NcclxBaseTest {
+class CollTraceTestLocal : public NcclxBaseTestFixture {
  public:
   CollTraceTestLocal() = default;
   void SetUp() override {
-    // Set up dummy values for environment variables for Scuba test
-    setenv("WORLD_SIZE", "4", 0);
-    setenv("HPC_JOB_NAME", "CollTraceUT", 0);
-    setenv("HPC_JOB_VERSION", "1", 0);
-    setenv("HPC_JOB_ATTEMPT_INDEX", "2", 0);
-    setenv(
-        "NCCL_HPC_JOB_IDS",
-        "HPC_JOB_NAME,HPC_JOB_VERSION,HPC_JOB_ATTEMPT_INDEX",
-        0);
-    setenv("NCCL_COLLTRACE", "trace", 0);
-    setenv("NCCL_COLLTRACE_USE_NEW_COLLTRACE", "1", 0);
+    NcclxBaseTestFixture::SetUp({
+        {"WORLD_SIZE", "4"},
+        {"HPC_JOB_NAME", "CollTraceUT"},
+        {"HPC_JOB_VERSION", "1"},
+        {"HPC_JOB_ATTEMPT_INDEX", "2"},
+        {"NCCL_HPC_JOB_IDS",
+         "HPC_JOB_NAME,HPC_JOB_VERSION,HPC_JOB_ATTEMPT_INDEX"},
+        {"NCCL_COLLTRACE", "trace"},
+        {"NCCL_COLLTRACE_USE_NEW_COLLTRACE", "1"},
+        {"NCCL_CTRAN_ENABLE", "1"},
+        {"NCCL_CTRAN_IB_EPOCH_LOCK_ENFORCE_CHECK", "true"},
+    });
 
-    // Enable Ctran
-    setenv("NCCL_CTRAN_ENABLE", "1", 0);
-    setenv("NCCL_CTRAN_IB_EPOCH_LOCK_ENFORCE_CHECK", "true", 0);
-
-    NcclxBaseTest::SetUp();
-
-    CUDACHECK_TEST(cudaSetDevice(this->localRank));
     CUDACHECK_TEST(cudaStreamCreate(&this->stream));
   }
 
@@ -55,6 +50,7 @@ class CollTraceTestLocal : public NcclxBaseTest {
     if (recvBuf) {
       CUDACHECK_TEST(cudaFree(recvBuf));
     }
+    NcclxBaseTestFixture::TearDown();
   }
 
   // Use MPI to ensure that we don't see additional all reduce for that nccl
@@ -75,7 +71,8 @@ class CollTraceTestLocal : public NcclxBaseTest {
 TEST_F(CollTraceTestLocal, winSignal) {
   const int kNumIters = 16;
 
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
 
   auto statex = comm->ctranComm_->statex_.get();
   ASSERT_NE(statex, nullptr);
@@ -167,7 +164,8 @@ TEST_F(CollTraceTestLocal, winPutOnly) {
   const int kNumElements = 8192;
   const int kNumIters = 500;
 
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
 
   EXPECT_GE(kNumElements, 8192);
   EXPECT_GE(kNumIters, 1);

--- a/comms/ncclx/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
+++ b/comms/ncclx/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
@@ -19,8 +19,10 @@
 
 #include "comms/ctran/Ctran.h"
 #include "comms/ctran/CtranEx.h"
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
+#include "comms/ncclx/meta/tests/NcclxBaseTest.h"
+#include "comms/testinfra/AlgoTestUtils.h"
 #include "comms/testinfra/TestUtils.h"
-#include "comms/testinfra/TestsDistUtils.h"
 #include "comms/utils/colltrace/CollTrace.h"
 #include "comms/utils/colltrace/tests/nvidia-only/CPUControlledKernel.h"
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -29,26 +31,22 @@
 
 using ::meta::comms::colltrace::CollTraceConfig;
 
-class CollTraceTest : public NcclxBaseTest {
+class CollTraceTest : public NcclxBaseTestFixture {
  public:
   CollTraceTest() = default;
   void SetUp() override {
-    // Set up dummy values for environment variables for Scuba test
-    setenv("WORLD_SIZE", "4", 0);
-    setenv("HPC_JOB_NAME", "CollTraceUT", 0);
-    setenv("HPC_JOB_VERSION", "1", 0);
-    setenv("HPC_JOB_ATTEMPT_INDEX", "2", 0);
-    setenv(
-        "NCCL_HPC_JOB_IDS",
-        "HPC_JOB_NAME,HPC_JOB_VERSION,HPC_JOB_ATTEMPT_INDEX",
-        0);
-    setenv("NCCL_CTRAN_ENABLE", "1", 0);
-    setenv("NCCL_COLLTRACE", "trace", 0);
-    setenv("NCCL_COLLTRACE_USE_NEW_COLLTRACE", "1", 0);
+    NcclxBaseTestFixture::SetUp({
+        {"WORLD_SIZE", "4"},
+        {"HPC_JOB_NAME", "CollTraceUT"},
+        {"HPC_JOB_VERSION", "1"},
+        {"HPC_JOB_ATTEMPT_INDEX", "2"},
+        {"NCCL_HPC_JOB_IDS",
+         "HPC_JOB_NAME,HPC_JOB_VERSION,HPC_JOB_ATTEMPT_INDEX"},
+        {"NCCL_CTRAN_ENABLE", "1"},
+        {"NCCL_COLLTRACE", "trace"},
+        {"NCCL_COLLTRACE_USE_NEW_COLLTRACE", "1"},
+    });
 
-    NcclxBaseTest::SetUp();
-
-    CUDACHECK_TEST(cudaSetDevice(this->localRank));
     CUDACHECK_TEST(cudaStreamCreate(&this->stream));
   }
 
@@ -61,6 +59,7 @@ class CollTraceTest : public NcclxBaseTest {
     if (recvBuf) {
       CUDACHECK_TEST(cudaFree(recvBuf));
     }
+    NcclxBaseTestFixture::TearDown();
   }
 
   void prepareAllreduce(const int count) {
@@ -164,7 +163,8 @@ class CollTraceTest : public NcclxBaseTest {
 };
 
 TEST_F(CollTraceTest, NewCollTraceAllReduce) {
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_EQ(comm->collTrace, nullptr);
   ASSERT_EQ(comm->ctranComm_->collTrace_, nullptr);
   const int count = 1048576;
@@ -192,7 +192,7 @@ TEST_F(CollTraceTest, NewCollTraceAllReduce) {
 
 TEST_F(CollTraceTest, MixedCtranBaseline) {
   auto ctranAlgoGuard =
-      EnvRAII(NCCL_ALLGATHER_ALGO, NCCL_ALLGATHER_ALGO::ctring);
+      testinfra::AlgoRAII(NCCL_ALLGATHER_ALGO, NCCL_ALLGATHER_ALGO::ctring);
   auto ctranGuard = EnvRAII(NCCL_CTRAN_ENABLE, true);
   // CTran has temporarily disabled NVL backend support. Set to nolocal to
   // enable test
@@ -200,7 +200,8 @@ TEST_F(CollTraceTest, MixedCtranBaseline) {
       EnvRAII(NCCL_COMM_STATE_DEBUG_TOPO, NCCL_COMM_STATE_DEBUG_TOPO::nolocal);
   auto checksumSampleRateGuard =
       EnvRAII(NCCL_CTRAN_ALLGATHER_CHECKSUM_SAMPLE_RATE, 1);
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_EQ(comm->collTrace, nullptr);
   ASSERT_EQ(comm->ctranComm_->collTrace_, nullptr);
 
@@ -247,7 +248,8 @@ TEST_F(CollTraceTest, MixedCtranBaseline) {
 
 TEST_F(CollTraceTest, TestBcastCtranEx) {
   auto ctranGuard = EnvRAII(NCCL_CTRAN_ENABLE, true);
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_EQ(comm->collTrace, nullptr);
   ASSERT_EQ(comm->ctranComm_->collTrace_, nullptr);
 
@@ -317,7 +319,8 @@ TEST_F(CollTraceTest, TestBcastCtranEx) {
 TEST_F(CollTraceTest, GroupedSendRecv) {
   auto ctranGuard = EnvRAII{NCCL_SENDRECV_ALGO, NCCL_SENDRECV_ALGO::orig};
 
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_EQ(comm->collTrace, nullptr);
   ASSERT_EQ(comm->ctranComm_->collTrace_, nullptr);
 
@@ -367,7 +370,8 @@ TEST_F(CollTraceTest, GroupedSendRecvCtran) {
   auto ctranGuard = EnvRAII(NCCL_CTRAN_ENABLE, true);
   auto ctranSRGuard = EnvRAII{NCCL_SENDRECV_ALGO, NCCL_SENDRECV_ALGO::ctran};
 
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_EQ(comm->collTrace, nullptr);
   ASSERT_EQ(comm->ctranComm_->collTrace_, nullptr);
 
@@ -424,7 +428,8 @@ TEST_F(CollTraceTest, GroupedSendRecvCtran) {
 TEST_F(CollTraceTest, SimulatePPSendRecv) {
   auto ctranGuard = EnvRAII{NCCL_SENDRECV_ALGO, NCCL_SENDRECV_ALGO::orig};
 
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_EQ(comm->collTrace, nullptr);
   ASSERT_EQ(comm->ctranComm_->collTrace_, nullptr);
 
@@ -487,7 +492,8 @@ TEST_F(CollTraceTest, SimulateCtranPPSendRecv) {
   auto ctranGuard = EnvRAII(NCCL_CTRAN_ENABLE, true);
   auto ctranSRGuard = EnvRAII{NCCL_SENDRECV_ALGO, NCCL_SENDRECV_ALGO::ctran};
 
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_EQ(comm->collTrace, nullptr);
   ASSERT_EQ(comm->ctranComm_->collTrace_, nullptr);
 
@@ -561,7 +567,8 @@ TEST_F(CollTraceTest, winPutWait) {
   auto ctranGuard = EnvRAII(NCCL_CTRAN_ENABLE, true);
   auto recordGuard = EnvRAII{NCCL_COLLTRACE_RECORD_MAX, 1000};
 
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_EQ(comm->collTrace, nullptr);
   ASSERT_EQ(comm->ctranComm_->collTrace_, nullptr);
 
@@ -690,7 +697,8 @@ TEST_F(CollTraceTest, winPutWait) {
 TEST_F(CollTraceTest, DumpWithUnfinished) {
   auto wakeUpGuard = EnvRAII(NCCL_COLLTRACE_WAKEUP_INTERVAL_MS, 10L);
 
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_EQ(comm->collTrace, nullptr);
   ASSERT_EQ(comm->ctranComm_->collTrace_, nullptr);
   const int count = 1048576;
@@ -745,7 +753,8 @@ TEST_F(CollTraceTest, DumpWithUnfinishedCtran) {
   auto envGuard = EnvRAII(NCCL_ALLREDUCE_ALGO, NCCL_ALLREDUCE_ALGO::ctdirect);
   auto ctranGuard = EnvRAII(NCCL_CTRAN_ENABLE, true);
 
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_EQ(comm->collTrace, nullptr);
   ASSERT_EQ(comm->ctranComm_->collTrace_, nullptr);
   const int count = 1048576;
@@ -797,7 +806,8 @@ TEST_F(CollTraceTest, DumpWithUnfinishedCtran) {
 
 TEST_F(CollTraceTest, GroupedAllReduce) {
   auto envGuard = EnvRAII(NCCL_ALLREDUCE_ALGO, NCCL_ALLREDUCE_ALGO::orig);
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_EQ(comm->collTrace, nullptr);
   ASSERT_EQ(comm->ctranComm_->collTrace_, nullptr);
 
@@ -834,7 +844,8 @@ TEST_F(CollTraceTest, GroupedSendRecvAllReduce) {
   auto ctranGuard = EnvRAII{NCCL_SENDRECV_ALGO, NCCL_SENDRECV_ALGO::orig};
   auto envGuard = EnvRAII(NCCL_ALLREDUCE_ALGO, NCCL_ALLREDUCE_ALGO::orig);
 
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_EQ(comm->collTrace, nullptr);
   ASSERT_EQ(comm->ctranComm_->collTrace_, nullptr);
 
@@ -874,7 +885,8 @@ TEST_F(CollTraceTest, GroupedSendRecvAllReduce) {
 }
 
 TEST_F(CollTraceTest, CollTraceQueryInCapture) {
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_EQ(comm->collTrace, nullptr);
   ASSERT_EQ(comm->ctranComm_->collTrace_, nullptr);
   const int count = 1048576;
@@ -911,7 +923,8 @@ TEST_F(CollTraceTest, CollTraceTestEnqueueMoreThanPendingQueue) {
   auto wakeUpGuard = EnvRAII(NCCL_COLLTRACE_WAKEUP_INTERVAL_MS, 10L);
   auto ctranGuard = EnvRAII(NCCL_CTRAN_ENABLE, true);
 
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_EQ(comm->collTrace, nullptr);
   ASSERT_EQ(comm->ctranComm_->collTrace_, nullptr);
 

--- a/comms/ncclx/meta/colltrace/tests/ProxyTraceDistTest.cc
+++ b/comms/ncclx/meta/colltrace/tests/ProxyTraceDistTest.cc
@@ -12,8 +12,9 @@
 #include <unordered_map>
 
 #include "comms/ctran/Ctran.h"
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
+#include "comms/ncclx/meta/tests/NcclxBaseTest.h"
 #include "comms/testinfra/TestUtils.h"
-#include "comms/testinfra/TestsDistUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "meta/colltrace/CollTrace.h"
 #include "meta/colltrace/ProxyMock.h"
@@ -23,14 +24,13 @@
 
 static bool VERBOSE = true;
 
-class ProxyTraceTest : public NcclxBaseTest {
+class ProxyTraceTest : public NcclxBaseTestFixture {
  public:
   ProxyTraceTest() = default;
   void SetUp() override {
-    setenv("NCCL_CTRAN_ENABLE", "1", 0); // enable ctran
-    // Initialize CVAR so that we can overwrite global variable in each test
-    initEnv();
-    NcclxBaseTest::SetUp();
+    NcclxBaseTestFixture::SetUp({
+        {"NCCL_CTRAN_ENABLE", "1"},
+    });
     CUDACHECK_TEST(cudaStreamCreate(&stream));
   }
 
@@ -38,7 +38,7 @@ class ProxyTraceTest : public NcclxBaseTest {
     CUDACHECK_TEST(cudaStreamDestroy(stream));
     CUDACHECK_TEST(cudaFree(sendBuf));
     CUDACHECK_TEST(cudaFree(recvBuf));
-    NcclxBaseTest::TearDown();
+    NcclxBaseTestFixture::TearDown();
   }
 
   void runAllReduce(const int count, const int nColl, ncclComm_t comm) {
@@ -301,7 +301,8 @@ TEST_F(ProxyTraceTest, PastCollNoDropUnderLimit) {
   auto recordGuard = EnvRAII(
       NCCL_PROXYTRACE_RECORD_MAX, std::max(NCCL_PROXYTRACE_RECORD_MAX, 100));
 
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   if (!checkTestRequirement(comm)) {
     GTEST_SKIP();
   }
@@ -327,7 +328,8 @@ TEST_F(ProxyTraceTest, TestRecordNoDropByEnv) {
   auto traceGuard = EnvRAII(NCCL_PROXYTRACE, {"trace"});
   auto recordGuard = EnvRAII(NCCL_PROXYTRACE_RECORD_MAX, -1);
 
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   if (!checkTestRequirement(comm)) {
     GTEST_SKIP();
   }
@@ -356,7 +358,8 @@ TEST_F(ProxyTraceTest, TestRecordDropExceedLimit) {
       NCCL_PROXYTRACE_RECORD_MAX,
       std::max(NCCL_PROXYTRACE_RECORD_MAX_DEFAULTCVARVALUE, 100));
 
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   if (!checkTestRequirement(comm)) {
     GTEST_SKIP();
   }
@@ -380,7 +383,8 @@ TEST_F(ProxyTraceTest, TestRecordDropExceedLimit) {
 
 TEST_F(ProxyTraceTest, QueryFinishedAllReduce) {
   auto traceGuard = EnvRAII(NCCL_PROXYTRACE, {"trace"});
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   if (!checkTestRequirement(comm)) {
     GTEST_SKIP();
   }
@@ -420,7 +424,8 @@ TEST_F(ProxyTraceTest, QueryFinishedAllToAll) {
   // ensure we use default proxy path
   NCCL_ALLTOALL_ALGO = NCCL_ALLTOALL_ALGO::orig;
 
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   if (!checkTestRequirement(comm)) {
     GTEST_SKIP();
   }
@@ -471,7 +476,8 @@ TEST_F(ProxyTraceTest, QueryFinishedSendRecv) {
   // ensure we use default proxy path
   NCCL_SENDRECV_ALGO = NCCL_SENDRECV_ALGO::orig;
 
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   if (!checkTestRequirement(comm)) {
     GTEST_SKIP();
   }
@@ -521,7 +527,8 @@ TEST_F(ProxyTraceTest, QueryFinishedSendRecv) {
 TEST_F(ProxyTraceTest, QueryHangAllReduce) {
   auto traceGuard = EnvRAII(NCCL_PROXYTRACE, {"trace"});
 
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   if (!checkTestRequirement(comm)) {
     GTEST_SKIP();
   }
@@ -581,7 +588,8 @@ TEST_F(ProxyTraceTest, QueryHangSendRecv) {
   // ensure we use default proxy path
   NCCL_SENDRECV_ALGO = NCCL_SENDRECV_ALGO::orig;
 
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   if (!checkTestRequirement(comm)) {
     GTEST_SKIP();
   }
@@ -650,7 +658,8 @@ TEST_F(ProxyTraceTest, CTAndPTOpCountsMatch) {
   auto recordGuard = EnvRAII(
       NCCL_PROXYTRACE_RECORD_MAX, std::max(NCCL_PROXYTRACE_RECORD_MAX, 100));
 
-  NcclCommRAII comm{globalRank, numRanks, localRank, bootstrap_.get()};
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
   if (!checkTestRequirement(comm)) {
     GTEST_SKIP();
   }

--- a/comms/ncclx/v2_27/meta/tests/ReduceScatterTest.cc
+++ b/comms/ncclx/v2_27/meta/tests/ReduceScatterTest.cc
@@ -8,33 +8,34 @@
 #include <nccl.h>
 #include <stdlib.h>
 #include <cstddef>
+#include <optional>
 #include "comms/ctran/Ctran.h"
 #include "comms/ncclx/meta/tests/NcclCommUtils.h"
+#include "comms/ncclx/meta/tests/NcclxBaseTest.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsCuUtils.h"
-#include "comms/testinfra/TestsDistUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
 #include "comms/ctran/algos/ReduceScatter/ReduceScatterImpl.h"
 
-class ReduceScatterTest : public NcclxBaseTest {
+class ReduceScatterTest : public NcclxBaseTestFixture {
  public:
   ReduceScatterTest() = default;
   void SetUp() override {
-    NcclxBaseTest::SetUp();
-    comm = ncclx::test::createNcclComm(
-        globalRank, numRanks, localRank, bootstrap_.get());
+    NcclxBaseTestFixture::SetUp();
+    commRAII_.emplace(globalRank, numRanks, localRank, bootstrap_.get());
+    comm = commRAII_->get();
     CUDACHECK_TEST(cudaStreamCreate(&stream));
   }
 
   void TearDown() override {
-    NCCLCHECK_TEST(ncclCommDestroy(comm));
     CUDACHECK_TEST(cudaStreamDestroy(stream));
-    NcclxBaseTest::TearDown();
+    commRAII_.reset();
+    NcclxBaseTestFixture::TearDown();
   }
 
  protected:
-  ncclComm_t comm;
+  std::optional<ncclx::test::NcclCommRAII> commRAII_;
   cudaStream_t stream;
 };
 


### PR DESCRIPTION
Summary:
Migrate ReduceScatterTest.cc from the legacy NcclxBaseTest (TestsDistUtils.h) to NcclxBaseTestFixture (comms/ncclx/meta/tests/NcclxBaseTest.h):
- Replace base class NcclxBaseTest with NcclxBaseTestFixture
- Replace ncclx::test::createNcclComm with ncclx::test::NcclCommRAII (RAII comm lifecycle, removes manual ncclCommDestroy in TearDown)
- Remove redundant ncclComm_t comm member (inherited from NcclxBaseTestFixture)
- BUCK: add ncclx_base_test_v2_27 dep

Differential Revision: D100733044


