### PR TITLE
make allGatherPSupported a static func and check before window register in test (#2085)

### DIFF
--- a/comms/ctran/tests/CtranWinAllGatherTest.cc
+++ b/comms/ctran/tests/CtranWinAllGatherTest.cc
@@ -65,6 +65,11 @@ class CtranWinAllGatherTest : public ctran::CtranDistTestFixture {
     const size_t sendBytes = sendCount * commTypeSize(dt);
     const size_t recvBytes = sendBytes * nRanks;
 
+    // Check support before allocating resources
+    if (!CtranWin::allGatherPSupported(comm.get())) {
+      GTEST_SKIP() << "allGatherP not supported on this topology";
+    }
+
     cudaStream_t stream;
     CUDACHECK_TEST(cudaStreamCreate(&stream));
 
@@ -74,13 +79,6 @@ class CtranWinAllGatherTest : public ctran::CtranDistTestFixture {
     CtranWin* win = nullptr;
     auto res = ctranWinRegister(winBase, recvBytes, comm.get(), &win);
     ASSERT_EQ(res, commSuccess);
-
-    if (!win->allGatherPSupported()) {
-      CUDACHECK_TEST(cudaFree(winBase));
-      ASSERT_EQ(ctranWinFree(win), commSuccess);
-      CUDACHECK_TEST(cudaStreamDestroy(stream));
-      GTEST_SKIP() << "allGatherP not supported on this topology";
-    }
 
     // Allocate separate send buffer
     void* sendbuf = nullptr;

--- a/comms/ctran/window/CtranWin.h
+++ b/comms/ctran/window/CtranWin.h
@@ -146,10 +146,13 @@ struct CtranWin {
         bufType_ == DevMemType::kCumem;
   }
 
-  // Check whether this window supports persistent allgather (allgatherP).
+  // Check whether persistent allgather (allgatherP) is supported.
   // Returns true if ctran is initialized and all peers have configured
-  // backends.
-  bool allGatherPSupported() const;
+  // backends. Static variant allows checking before a window is created.
+  static bool allGatherPSupported(CtranComm* comm);
+  bool allGatherPSupported() const {
+    return allGatherPSupported(comm);
+  }
 
  private:
   DevMemType bufType_{DevMemType::kCumem};

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -140,7 +140,7 @@ commResult_t CtranWin::exchange() {
   return commSuccess;
 }
 
-bool CtranWin::allGatherPSupported() const {
+bool CtranWin::allGatherPSupported(CtranComm* comm) {
   if (!ctranInitialized(comm)) {
     return false;
   }


### PR DESCRIPTION
Summary:

- Make make allGatherPSupported a static func.
- Move the allGatherPSupported() check before cudaMalloc/cudaStreamCreate/ctranWinRegister so we skip early without unnecessary resource allocation and cleanup when allGatherP is not supported.

Reviewed By: dsjohns2

Differential Revision: D101008294
