### PR TITLE
Fix alltoallv_dynamic_dispatch crash when called with empty output_tensor_list

### DIFF
--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -1663,6 +1663,9 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::alltoallv_dynamic_dispatch(
     bool async_op) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
+  TORCH_CHECK(
+      !output_tensor_list.empty(),
+      "alltoallv_dynamic_dispatch: output_tensor_list must not be empty");
   ensureTensorContiguous(input_tensor);
   ensureTensorContiguous(input_chunk_sizes);
   ensureTensorContiguous(input_chunk_indices);


### PR DESCRIPTION
`output_tensor_list[0].numel()` was accessed with no bounds check. every other collective in the file validates list size upfront.

**Repro**
```
ncclx = comm.get_backend_impl()
ncclx.alltoallv_dynamic_dispatch([], output_sizes, input, chunk_sizes, chunk_indices, chunk_count, D, False)
```
**Before**
```
exitcode: -11 (SIGSEGV)
```
**Now**
```
RuntimeError: alltoallv_dynamic_dispatch: output_tensor_list must not be empty
```