### PR TITLE
fix build (#2105)

### DIFF
--- a/comms/utils/colltrace/CollTrace.cc
+++ b/comms/utils/colltrace/CollTrace.cc
@@ -12,6 +12,7 @@
 #include <cuda_runtime.h> // @manual=third-party//cuda:cuda-lazy
 
 #include "comms/utils/CommsMaybeChecks.h"
+#include "comms/utils/checks.h"
 #include "comms/utils/colltrace/GpuClockCalibration.h"
 #include "comms/utils/colltrace/GraphCollTraceHandle.h"
 #include "comms/utils/colltrace/GraphCollTraceState.h"
@@ -191,8 +192,10 @@ std::shared_ptr<GraphCollTraceState> CollTrace::getOrCreateGraphState(
   auto retainRes =
       cudaGraphRetainUserObject(graph, userObject, 1, cudaGraphUserObjectMove);
   if (retainRes != cudaSuccess) {
-    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-    cudaUserObjectRelease(userObject, 1);
+    CUDA_CHECK_WITH_IGNORE(
+        cudaUserObjectRelease(userObject, 1),
+        cudaErrorCudartUnloading,
+        cudaErrorContextIsDestroyed);
     XLOG_FIRST_N(WARN, 1) << "Failed to retain graph user object: "
                           << cudaGetErrorString(retainRes);
     return nullptr;

--- a/comms/utils/colltrace/GraphCudaWaitEvent.cc
+++ b/comms/utils/colltrace/GraphCudaWaitEvent.cc
@@ -33,12 +33,16 @@ GraphCudaWaitEvent::GraphCudaWaitEvent(cudaStream_t stream, uint32_t collId)
 
 GraphCudaWaitEvent::~GraphCudaWaitEvent() {
   if (timestampStream_) {
-    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-    cudaStreamDestroy(timestampStream_);
+    CUDA_CHECK_WITH_IGNORE(
+        cudaStreamDestroy(timestampStream_),
+        cudaErrorCudartUnloading,
+        cudaErrorContextIsDestroyed);
   }
   if (depEvent_) {
-    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-    cudaEventDestroy(depEvent_);
+    CUDA_CHECK_WITH_IGNORE(
+        cudaEventDestroy(depEvent_),
+        cudaErrorCudartUnloading,
+        cudaErrorContextIsDestroyed);
   }
 }
 


### PR DESCRIPTION
Summary:

```
Action failed: fbcode//comms/utils/colltrace:graph_cuda_wait_event (cfg:opt-linux-x86_64-fbcode-platform010-clang21-no-san-opt-by-default#8277d2b34a33e47b) (cxx_compile GraphCudaWaitEvent.cc (pic))
Remote command returned non-zero exit code 1
Remote action, reproduce with: `frecli cas download-action 1d68a7ecce121d61a65501250b74c6cb69c5841fa0a60d6474339214bed659d0:148`
Stdout: <empty>
Stderr:
buck-out/v2/art/fbcode/8277d2b34a33e47b/comms/utils/colltrace/__graph_cuda_wait_event_hipify_gen__/out/GraphCudaWaitEvent.cc:38:5: error: ignoring return value of type 'hipError_t' declared with 'nodiscard' attribute [-Werror,-Wunused-value]
   38 |     hipStreamDestroy(timestampStream_);
      |     ^~~~~~~~~~~~~~~~ ~~~~~~~~~~~~~~~~
buck-out/v2/art/fbcode/8277d2b34a33e47b/comms/utils/colltrace/__graph_cuda_wait_event_hipify_gen__/out/GraphCudaWaitEvent.cc:42:5: error: ignoring return value of type 'hipError_t' declared with 'nodiscard' attribute [-Werror,-Wunused-value]
   42 |     hipEventDestroy(depEvent_);
      |     ^~~~~~~~~~~~~~~ ~~~~~~~~~
2 errors generated.
```

Reviewed By: lilyjanjigian

Differential Revision: D101187378


