### PR TITLE
Add per-group send/recv on P2pIbgdaTransportDevice (#2106)

### DIFF
--- a/comms/pipes/IbgdaBuffer.h
+++ b/comms/pipes/IbgdaBuffer.h
@@ -253,4 +253,52 @@ struct IbgdaBufferExchInfo {
   }
 };
 
+/**
+ * IbSendRecvState — device-side state for pipelined RDMA send/recv.
+ *
+ * Holds all buffer handles and config needed by send/recv.
+ * All physical memory is allocated by MultipeerIbgdaTransport on the host;
+ * this struct contains only pointers/handles into those allocations.
+ *
+ * Buffer layout:
+ *   sendStaging / recvStaging: pipelineDepth * dataBufferSize bytes each.
+ *     Logically divided into pipelineDepth slots of dataBufferSize bytes.
+ *     For one send()/recv() call, a caller chooses active_blocks
+ *     (1 <= active_blocks <= maxGroups). Each slot is then partitioned into
+ *     active_blocks per-block regions:
+ *       perBlockSlot = (dataBufferSize / active_blocks) & ~15ULL
+ *     If max_signal_bytes is smaller than perBlockSlot, each per-block region
+ *     is further subdivided into signaled sub-chunks:
+ *       chunkSize = floor16(min(perBlockSlot, max_signal_bytes))
+ *       chunksPerSlot = perBlockSlot / chunkSize
+ *     stepState counts these sub-chunks, not whole slots.
+ *
+ *   signalBuf: 2 * maxGroups * sizeof(uint64_t).
+ *     [0, maxGroups)             — DATA_READY (sender -> receiver)
+ *     [maxGroups, 2*maxGroups)   — SLOT_FREE (receiver -> sender)
+ *
+ *   counterBuf: maxGroups * sizeof(uint64_t).
+ *     [0, maxGroups)             — NIC_DONE counters (loopback atomic)
+ *
+ *   stepState: 2 * maxGroups * sizeof(int64_t).
+ *     [0, maxGroups)             — sender step counters
+ *     [maxGroups, 2*maxGroups)   — receiver step counters
+ */
+struct IbSendRecvState {
+  IbgdaLocalBuffer
+      sendStagingBuf; ///< Registered sendStaging (lkey for put src)
+  IbgdaRemoteBuffer recvStagingBuf; ///< Peer's recvStaging (rkey for put dst)
+  char* sendStagingPtr{
+      nullptr}; ///< Raw sendStaging pointer (memcpy addressing)
+  char* recvStagingPtr{
+      nullptr}; ///< Raw local recvStaging pointer (recv memcpy)
+  IbgdaLocalBuffer localSignalBuf; ///< Signal inbox (DATA_READY + SLOT_FREE)
+  IbgdaRemoteBuffer remoteSignalBuf; ///< Peer's signal inbox
+  IbgdaLocalBuffer localCounterBuf; ///< NIC_DONE counter inbox
+  int64_t* stepState{nullptr}; ///< Per-group step counters
+  int maxGroups{0}; ///< Layout size for signals/step arrays
+  int pipelineDepth{0}; ///< Number of pipeline slots in the ring
+  std::size_t dataBufferSize{0}; ///< Size of one pipeline slot in bytes
+};
+
 } // namespace comms::pipes

--- a/comms/pipes/MultipeerIbgdaTransport.cc
+++ b/comms/pipes/MultipeerIbgdaTransport.cc
@@ -663,6 +663,9 @@ MultipeerIbgdaTransport::MultipeerIbgdaTransport(
     // Allocate and register sink buffer for atomic return values
     allocateResources();
     registerMemory();
+
+    // Allocate tile sendrecv buffers (if configured)
+    allocate_send_recv_buffers();
   } catch (const std::exception&) {
     // Destructor won't run for a partially-constructed object, so clean up
     // all resources allocated by the init methods above.
@@ -691,6 +694,9 @@ void MultipeerIbgdaTransport::cleanup() {
   }
   gpuAllocations_.clear();
   peerTransportsGpu_ = nullptr;
+
+  // Free tile sendrecv buffers
+  cleanup_send_recv_buffers();
 
   // Destroy QP groups (main + companion)
   for (auto* qpGroup : qpGroupHlList_) {
@@ -1038,8 +1044,8 @@ void MultipeerIbgdaTransport::exchange() {
             << totalDiscardBytes << " bytes (" << numPeers << " peers)";
   }
 
-  // Build device transports on GPU. Collect host-side QP handles,
-  // then let buildDeviceTransportsOnGpu handle all GPU allocation + memcpy.
+  exchange_send_recv_buffers();
+
   const NetworkLKey sinkLkey(HostLKey(sinkMr_->lkey));
   std::vector<P2pIbgdaTransportBuildParams> buildParams(numPeers);
 
@@ -1070,6 +1076,22 @@ void MultipeerIbgdaTransport::exchange() {
       buildParams[peer].counterBuf = counterViews_[peer];
       buildParams[peer].discardSignalSlot = discardSignalRemoteViews_[peer];
       buildParams[peer].numCounterSlots = config_.numCounterSlots;
+    }
+    if (!sendRecvPeerBuffers_.empty()) {
+      const auto& pb = sendRecvPeerBuffers_[peer];
+      buildParams[peer].sendRecvState = IbSendRecvState{
+          .sendStagingBuf = pb.sendStaging,
+          .recvStagingBuf = pb.remoteRecvStaging,
+          .sendStagingPtr = static_cast<char*>(pb.sendStaging.ptr),
+          .recvStagingPtr = static_cast<char*>(pb.recvStaging.ptr),
+          .localSignalBuf = pb.signal,
+          .remoteSignalBuf = pb.remoteSignal,
+          .localCounterBuf = pb.counter,
+          .stepState = pb.stepState,
+          .maxGroups = config_.sendRecv->maxGroups,
+          .pipelineDepth = config_.sendRecv->pipelineDepth,
+          .dataBufferSize = config_.dataBufferSize,
+      };
     }
   }
 
@@ -1272,6 +1294,140 @@ std::vector<IbgdaRemoteBuffer> MultipeerIbgdaTransport::exchangeBuffer(
 }
 int MultipeerIbgdaTransport::nRanks() const {
   return nRanks_;
+}
+
+// =============================================================================
+// Send/recv buffer lifecycle
+// =============================================================================
+
+void MultipeerIbgdaTransport::allocate_send_recv_buffers() {
+  if (!config_.sendRecv.has_value()) {
+    return;
+  }
+  const auto& sr = *config_.sendRecv;
+  if (sr.pipelineDepth < 1) {
+    throw std::invalid_argument("sendRecv.pipelineDepth must be >= 1");
+  }
+  if (sr.maxGroups < 1) {
+    throw std::invalid_argument("sendRecv.maxGroups must be >= 1");
+  }
+  if (config_.dataBufferSize == 0) {
+    throw std::invalid_argument(
+        "dataBufferSize must be > 0 when sendRecv is enabled");
+  }
+  if ((config_.dataBufferSize / sr.maxGroups) < 16) {
+    throw std::invalid_argument(
+        fmt::format(
+            "dataBufferSize / maxGroups must be >= 16, got {} / {} = {}",
+            config_.dataBufferSize,
+            sr.maxGroups,
+            config_.dataBufferSize / sr.maxGroups));
+  }
+
+  const int numPeers = nRanks_ - 1;
+  const std::size_t stagingPerPeer = sr.pipelineDepth * config_.dataBufferSize;
+  const std::size_t signalPerPeer = 2 * sr.maxGroups * sizeof(uint64_t);
+  const std::size_t counterPerPeer = sr.maxGroups * sizeof(uint64_t);
+  const std::size_t stepStatePerPeer = 2 * sr.maxGroups * sizeof(int64_t);
+
+  auto allocateBulk = [&](std::size_t perPeer) {
+    auto buf = std::make_unique<meta::comms::DeviceBuffer>(perPeer * numPeers);
+    auto err = cudaMemset(buf->get(), 0, perPeer * numPeers);
+    if (err != cudaSuccess) {
+      throw std::runtime_error(
+          fmt::format(
+              "Failed to zero send/recv buffer: {}", cudaGetErrorString(err)));
+    }
+    return buf;
+  };
+
+  sendStagingBulk_ = allocateBulk(stagingPerPeer);
+  recvStagingBulk_ = allocateBulk(stagingPerPeer);
+  signalBulk_ = allocateBulk(signalPerPeer);
+  counterBulk_ = allocateBulk(counterPerPeer);
+  stepStateBulk_ = allocateBulk(stepStatePerPeer);
+
+  auto sendStagingBulkReg =
+      registerBuffer(sendStagingBulk_->get(), stagingPerPeer * numPeers);
+  recvStagingBulkReg_ =
+      registerBuffer(recvStagingBulk_->get(), stagingPerPeer * numPeers);
+  signalBulkReg_ = registerBuffer(signalBulk_->get(), signalPerPeer * numPeers);
+  auto counterBulkReg =
+      registerBuffer(counterBulk_->get(), counterPerPeer * numPeers);
+
+  sendRecvPeerBuffers_.resize(numPeers);
+  for (int i = 0; i < numPeers; ++i) {
+    auto& pb = sendRecvPeerBuffers_[i];
+    pb.sendStaging = IbgdaLocalBuffer{
+        static_cast<char*>(sendStagingBulk_->get()) + i * stagingPerPeer,
+        sendStagingBulkReg.lkey};
+    pb.recvStaging = IbgdaLocalBuffer{
+        static_cast<char*>(recvStagingBulk_->get()) + i * stagingPerPeer,
+        recvStagingBulkReg_.lkey};
+    pb.signal = IbgdaLocalBuffer{
+        static_cast<char*>(signalBulk_->get()) + i * signalPerPeer,
+        signalBulkReg_.lkey};
+    pb.counter = IbgdaLocalBuffer{
+        static_cast<char*>(counterBulk_->get()) + i * counterPerPeer,
+        counterBulkReg.lkey};
+    pb.stepState = reinterpret_cast<int64_t*>(
+        static_cast<char*>(stepStateBulk_->get()) + i * stepStatePerPeer);
+  }
+
+  VLOG(1) << "MultipeerIbgdaTransport: allocated tile buffers for " << numPeers
+          << " peers (staging=" << stagingPerPeer << "B per peer)";
+}
+
+void MultipeerIbgdaTransport::exchange_send_recv_buffers() {
+  if (!config_.sendRecv.has_value() || sendRecvPeerBuffers_.empty()) {
+    return;
+  }
+
+  const int numPeers = nRanks_ - 1;
+  const std::size_t stagingPerPeer =
+      config_.sendRecv->pipelineDepth * config_.dataBufferSize;
+
+  const std::size_t signalPerPeer =
+      2 * config_.sendRecv->maxGroups * sizeof(uint64_t);
+
+  auto recvStagingRemotes = exchangeBuffer(recvStagingBulkReg_);
+  auto signalRemotes = exchangeBuffer(signalBulkReg_);
+
+  for (int i = 0; i < numPeers; ++i) {
+    int peerRank = peerIndexToRank(i);
+    int remotePeerIndex = (myRank_ < peerRank) ? myRank_ : (myRank_ - 1);
+
+    sendRecvPeerBuffers_[i].remoteRecvStaging =
+        recvStagingRemotes[i].subBuffer(remotePeerIndex * stagingPerPeer);
+    sendRecvPeerBuffers_[i].remoteSignal =
+        signalRemotes[i].subBuffer(remotePeerIndex * signalPerPeer);
+  }
+
+  VLOG(1) << "MultipeerIbgdaTransport: exchanged tile buffers with " << numPeers
+          << " peers";
+}
+
+void MultipeerIbgdaTransport::cleanup_send_recv_buffers() {
+  sendRecvPeerBuffers_.clear();
+
+  if (sendStagingBulk_) {
+    deregisterBuffer(sendStagingBulk_->get());
+  }
+  if (recvStagingBulk_) {
+    deregisterBuffer(recvStagingBulk_->get());
+  }
+  if (signalBulk_) {
+    deregisterBuffer(signalBulk_->get());
+  }
+  if (counterBulk_) {
+    deregisterBuffer(counterBulk_->get());
+  }
+
+  sendStagingBulk_.reset();
+  recvStagingBulk_.reset();
+  signalBulk_.reset();
+  counterBulk_.reset();
+  stepStateBulk_.reset();
 }
 
 } // namespace comms::pipes

--- a/comms/pipes/MultipeerIbgdaTransport.h
+++ b/comms/pipes/MultipeerIbgdaTransport.h
@@ -16,6 +16,7 @@
 #include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/pipes/IbgdaBuffer.h"
 #include "comms/pipes/IbverbsLazy.h"
+#include "comms/utils/CudaRAII.h"
 
 // Forward declarations for device types (defined in .cuh files)
 namespace comms::pipes {
@@ -68,18 +69,46 @@ struct MultipeerIbgdaTransportConfig {
   std::string ibHca;
 
   // Per-peer data buffer size in bytes.
-  // This determines the maximum transfer size per put call.
+  //
+  // Raw put()/signal() users interpret this as the exported per-peer RDMA
+  // buffer size. send()/recv() users interpret it as the size of one logical
+  // staging slot. The send/recv ring therefore has:
+  //   pipelineDepth slots
+  //   each slot is dataBufferSize bytes
+  //   each slot is partitioned across active_blocks block-groups at runtime
+  //
+  // For one send()/recv() call:
+  //   perBlockSlot = (dataBufferSize / active_blocks) & ~15ULL
+  //
+  // In the benchmark, one "section" is exactly one dataBufferSize-sized slot.
   std::size_t dataBufferSize{0};
 
   // Number of signal slots managed by the transport (per peer).
-  // If > 0, transport allocates, registers, and exchanges signal buffers
-  // automatically. Slot-index API on P2pIbgdaTransportDevice becomes usable.
+  // Used by the slot-index API (put/signal/wait_signal by slot ID).
+  // Independent of send/recv which uses its own private signal buffers.
   int numSignalSlots{0};
 
   // Number of counter slots managed by the transport (per peer).
-  // If > 0, transport allocates and registers counter buffers (local only,
-  // no exchange). Slot-index API for counters becomes usable.
+  // Used by the slot-index API (wait_counter by slot ID).
+  // Independent of send/recv which uses its own private counter buffers.
   int numCounterSlots{0};
+
+  // Send/recv configuration. When set, the transport allocates a private
+  // pipelined staging ring plus private signal/counter state for send()/recv().
+  // When nullopt (default), send/recv is disabled and only the raw put/signal
+  // APIs are available.
+  struct SendRecvConfig {
+    // Maximum number of block-groups that may participate in one send()/recv()
+    // call. This sizes the private signal/counter/step arrays and defines the
+    // maximum active_blocks accepted at runtime.
+    int maxGroups{128};
+
+    // Number of logical slots in the send/recv staging ring.
+    // Total staging bytes per peer per direction:
+    //   pipelineDepth * dataBufferSize
+    int pipelineDepth{2};
+  };
+  std::optional<SendRecvConfig> sendRecv;
 
   // Queue pair depth (number of outstanding WQEs per peer).
   // Higher values allow more pipelining but use more memory.
@@ -385,6 +414,9 @@ class MultipeerIbgdaTransport {
   void registerMemory();
   void createQpGroups();
   void createLoopbackCompanionQps();
+  void allocate_send_recv_buffers();
+  void exchange_send_recv_buffers();
+  void cleanup_send_recv_buffers();
   void cleanup();
   void connectQp(
       doca_gpu_verbs_qp_hl* qpHl,
@@ -464,48 +496,37 @@ class MultipeerIbgdaTransport {
   std::vector<IbgdaTransportExchInfo> peerExchInfo_;
 
   // Transport-owned signal buffers (allocated if numSignalSlots > 0)
-  void* signalInboxGpu_{nullptr}; // local inbox: peers write here via RDMA
-  std::vector<IbgdaRemoteBuffer> signalRemoteViews_; // per-peer outbox views
-  std::vector<IbgdaLocalBuffer> signalLocalViews_; // per-peer inbox views
+  void* signalInboxGpu_{nullptr};
+  std::vector<IbgdaRemoteBuffer> signalRemoteViews_;
+  std::vector<IbgdaLocalBuffer> signalLocalViews_;
 
   // Transport-owned counter buffers (allocated if numCounterSlots > 0)
   void* counterGpu_{nullptr};
-  std::vector<IbgdaLocalBuffer> counterViews_; // per-peer local views
+  std::vector<IbgdaLocalBuffer> counterViews_;
 
-  // Transport-owned discard-signal buffer.
-  //
-  // Why this exists
-  // ---------------
-  // DOCA verbs exposes two relevant compound WQEs:
-  //   * signal_fenced  - remote atomic FA, FENCEd against the prior put
-  //   * signal_counter - signal_fenced on the primary QP + a companion-QP
-  //                      loopback atomic for the local counter (both ordered
-  //                      against the prior put)
-  // It does NOT expose a "counter-only" primitive (counter atomic without a
-  // remote signal). Counter-only put() callers therefore have two choices:
-  //   (a) fence the QP and then bump the counter from the GPU - synchronous,
-  //       adds a CQ-poll round-trip on the hot path.
-  //   (b) reuse signal_counter with a throwaway remote signal target so the
-  //       counter atomic stays piggy-backed on the same async WQE compound.
-  // We pick (b). The "discard signal" is that throwaway target: a real
-  // remote-addressable uint64_t whose value nobody ever reads.
-  //
-  // Layout
-  // ------
-  // numPeers slots, one uint64_t per peer that may write to us. Each rank
-  // exchanges (addr, rkey) with all peers; per-peer remote view is built
-  // pointing at *our* slot in the peer's discard buffer (offset =
-  // myPeerIndexOnPeer * sizeof(uint64_t)) so our primary QP can post a
-  // throwaway atomic into it. The peer never reads its local slots, so the
-  // accumulated value is garbage by design.
-  //
-  // Lifecycle
-  // ---------
-  // Allocated only when numCounterSlots > 0 (no counters => no counter-only
-  // puts => discard slot is never targeted). See
-  // P2pIbgdaTransportDevice::put_impl for the consumer.
   void* discardSignalGpu_{nullptr};
   std::vector<IbgdaRemoteBuffer> discardSignalRemoteViews_;
+
+  // Send/recv buffers (allocated when maxGroups > 0)
+  struct SendRecvPeerBuffers {
+    IbgdaLocalBuffer sendStaging;
+    IbgdaLocalBuffer recvStaging;
+    IbgdaLocalBuffer signal;
+    IbgdaLocalBuffer counter;
+    int64_t* stepState{nullptr};
+    IbgdaRemoteBuffer remoteRecvStaging;
+    IbgdaRemoteBuffer remoteSignal;
+  };
+  std::vector<SendRecvPeerBuffers> sendRecvPeerBuffers_;
+
+  std::unique_ptr<meta::comms::DeviceBuffer> sendStagingBulk_;
+  std::unique_ptr<meta::comms::DeviceBuffer> recvStagingBulk_;
+  std::unique_ptr<meta::comms::DeviceBuffer> signalBulk_;
+  std::unique_ptr<meta::comms::DeviceBuffer> counterBulk_;
+  std::unique_ptr<meta::comms::DeviceBuffer> stepStateBulk_;
+
+  IbgdaLocalBuffer recvStagingBulkReg_;
+  IbgdaLocalBuffer signalBulkReg_;
 };
 
 } // namespace comms::pipes

--- a/comms/pipes/MultipeerIbgdaTransportCuda.cu
+++ b/comms/pipes/MultipeerIbgdaTransportCuda.cu
@@ -62,7 +62,8 @@ P2pIbgdaTransportDevice* buildDeviceTransportsOnGpu(
         params[i].counterBuf,
         params[i].numSignalSlots,
         params[i].numCounterSlots,
-        params[i].discardSignalSlot);
+        params[i].discardSignalSlot,
+        params[i].sendRecvState);
   }
 
   // 3. Allocate and copy transport objects to GPU

--- a/comms/pipes/MultipeerIbgdaTransportCuda.cuh
+++ b/comms/pipes/MultipeerIbgdaTransportCuda.cuh
@@ -28,12 +28,10 @@ struct P2pIbgdaTransportBuildParams {
   IbgdaRemoteBuffer remoteSignalBuf{};
   IbgdaLocalBuffer localSignalBuf{};
   IbgdaLocalBuffer counterBuf{};
-  // Throwaway remote uint64_t slot used as the signal target for counter-only
-  // puts. Required when counterBuf is set; ignored otherwise. See
-  // P2pIbgdaTransportDevice::put_impl for rationale.
   IbgdaRemoteBuffer discardSignalSlot{};
   int numSignalSlots{0};
   int numCounterSlots{0};
+  IbSendRecvState sendRecvState{};
 };
 
 /**
@@ -42,6 +40,8 @@ struct P2pIbgdaTransportBuildParams {
  * For each peer, allocates GPU arrays for QP pointers, copies them,
  * then constructs P2pIbgdaTransportDevice objects in GPU memory.
  * All GPU allocations are pushed into outGpuAllocations for cleanup.
+ * If sendRecvState is populated in the build params, it is passed through
+ * the transport constructor before copying to GPU.
  *
  * @param params Build parameters (one per peer)
  * @param numPeers Number of peers

--- a/comms/pipes/P2pIbgdaTransportDevice.cuh
+++ b/comms/pipes/P2pIbgdaTransportDevice.cuh
@@ -9,6 +9,7 @@
 #include <device/doca_gpunetio_dev_verbs_counter.cuh>
 #include <device/doca_gpunetio_dev_verbs_onesided.cuh>
 
+#include "comms/pipes/CopyUtils.cuh"
 #include "comms/pipes/DeviceSpan.cuh"
 #include "comms/pipes/DocaVerbsUtils.cuh"
 #include "comms/pipes/IbgdaBuffer.h"
@@ -114,6 +115,8 @@ class P2pIbgdaTransportDevice {
    * @param numCounterSlots       Number of uint64_t slots in the owned
    *                              counter buffer. Zero disables the
    *                              slot-index counter API.
+   * @param sendRecvState         Optional pipelined send/recv protocol state.
+   *                              When empty, send()/recv() are unavailable.
    */
   __host__ __device__ P2pIbgdaTransportDevice(
       DeviceSpan<doca_gpu_dev_verbs_qp*> qpArray,
@@ -124,7 +127,8 @@ class P2pIbgdaTransportDevice {
       IbgdaLocalBuffer ownedCounterBuf = {},
       int numSignalSlots = 0,
       int numCounterSlots = 0,
-      IbgdaRemoteBuffer discardSignalSlot = {})
+      IbgdaRemoteBuffer discardSignalSlot = {},
+      IbSendRecvState sendRecvState = {})
       : qpArray_(qpArray),
         companionArray_(companionArray),
         sinkLkey_(sinkLkey),
@@ -133,7 +137,8 @@ class P2pIbgdaTransportDevice {
         ownedCounterBuf_(ownedCounterBuf),
         discardSignalSlot_(discardSignalSlot),
         numSignalSlots_(numSignalSlots),
-        numCounterSlots_(numCounterSlots) {}
+        numCounterSlots_(numCounterSlots),
+        sendRecvState_(sendRecvState) {}
 
   // =========================================================================
   // Slot-Index API (resolves owned buffers, forwards to explicit-buffer API)
@@ -975,6 +980,401 @@ class P2pIbgdaTransportDevice {
         ownedCounterBuf_.lkey);
   }
 
+ public:
+  // ===========================================================================
+  // Pipelined Send/Recv (using transport-managed staging buffers)
+  // ===========================================================================
+  //
+  // Public composable primitives for pipelined RDMA data transfer. Each block
+  // owns one tile (a partition of the user's data). The transport manages
+  // staging buffers internally — the user only provides src/dst pointers.
+  //
+  // Data flow:
+  //
+  //   SENDER (GPU A)                              RECEIVER (GPU B)
+  //   ┌──────────┐                                ┌──────────┐
+  //   │ user src │                                │ user dst │
+  //   └────┬─────┘                                └────▲─────┘
+  //        │ memcpy                                    │ memcpy
+  //        ▼                                           │
+  //   ┌────────────┐       RDMA put              ┌─────┴──────┐
+  //   │sendStaging │ ─────────────────────────▶  │recvStaging │
+  //   │  (GPU A)   │  + DATA_READY signal        │  (GPU B)   │
+  //   └────────────┘  + NIC_DONE counter         └────────────┘
+  //        ▲                                           │
+  //        └───────────── SLOT_FREE signal ────────────┘
+  //
+  // Signal protocol (per block, 3 primitives):
+  //   DATA_READY  — piggybacked on put (sender → receiver's signalBuf)
+  //   SLOT_FREE   — explicit signal    (receiver → sender's signalBuf)
+  //   NIC_DONE    — loopback counter   (NIC → sender's counterBuf)
+  //
+  // Terminology used below:
+  //   slot             = one logical staging-ring entry of dataBufferSize
+  //                      bytes. There are pipelineDepth slots in the ring.
+  //   active_blocks    = number of participating block-groups in one
+  //                      send()/recv() call. Must be <= maxGroups.
+  //   perBlockSlot     = one block-group's partition within a slot:
+  //                      (dataBufferSize / active_blocks) & ~15ULL
+  //   sub-chunk        = one signaled piece within a perBlockSlot. When
+  //                      max_signal_bytes == 0, a sub-chunk is the whole
+  //                      perBlockSlot. Otherwise:
+  //                        chunkSize = floor16(min(perBlockSlot,
+  //                                             max_signal_bytes))
+  //                        chunksPerSlot = perBlockSlot / chunkSize
+  //   stepState        = persistent sub-chunk cursor. It advances by one per
+  //                      DATA_READY / SLOT_FREE / NIC_DONE event, not one per
+  //                      whole slot.
+  //
+  // Typical usage:
+  //   auto [role, sub] = group.partition(2);
+  //   std::size_t sectionBytes = transport->send_recv_state().dataBufferSize;
+  //   for (std::size_t s = 0; s < totalBytes / sectionBytes; ++s) {
+  //     TiledBuffer<char> tiles(data + s * sectionBytes, sectionBytes, sub);
+  //     if (role == 0)
+  //       transport->send(sub, tiles.data(), tiles.bytes(), active_blocks);
+  //     else
+  //       transport->recv(sub, tiles.data(), tiles.bytes(), active_blocks);
+  //   }
+
+  /**
+   * send — send one block's tile via pipelined RDMA.
+   *
+   * Copies src → sendStaging, then RDMA puts sendStaging → peer's recvStaging.
+   * For this call, each logical slot contributes one perBlockSlot-sized region
+   * for this group. If nbytes > perBlockSlot, send() advances through multiple
+   * ring positions. max_signal_bytes can further subdivide each perBlockSlot
+   * into multiple signaled sub-chunks, enabling finer-grained overlap at the
+   * receiver.
+   *
+   * Signaling protocol (per group):
+   *   NIC_DONE   — loopback counter incremented by NIC after each RDMA put.
+   *                send waits on this before overwriting local sendStaging.
+   *   SLOT_FREE  — receiver increments per sub-chunk (symmetric with
+   *                DATA_READY). send waits before overwriting recvStaging.
+   *   DATA_READY — sender increments per sub-chunk, piggybacked on put.
+   *                recv waits on this before reading recvStaging.
+   *
+   * stepState persists across calls, so send() resumes the staging-ring cursor
+   * and protocol sequence numbers on each invocation. This allows callers to
+   * pipeline across repeated send() calls without a separate drain.
+   *
+   * The caller must keep the staging layout stable while a sequence is in
+   * flight. If active_blocks, max_signal_bytes, or any other parameter that
+   * changes the slot/sub-chunk mapping is modified, both sides must perform a
+   * higher-level barrier/quiescence step before issuing the next send()/recv().
+   *
+   * @param group           ThreadGroup (all threads participate in memcpy,
+   *                        leader does RDMA ops).
+   * @param src             Source data for this block's tile.
+   * @param nbytes          Bytes to send for this group. Internally consumed
+   *                        in perBlockSlot-sized pieces, or smaller sub-chunks
+   *                        when max_signal_bytes is set.
+   * @param active_blocks   Number of block-groups sharing each logical slot in
+   *                        this call. 0 means use maxGroups.
+   * @param max_signal_bytes Max bytes per signaled sub-chunk within one
+   *                        perBlockSlot. 0 means one signal per perBlockSlot.
+   * @param timeout         Optional timeout for wait operations.
+   */
+  __device__ __forceinline__ void send(
+      ThreadGroup& group,
+      void* __restrict__ src,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout()) {
+#ifndef __CUDA_ARCH__
+    (void)group;
+    (void)src;
+    (void)nbytes;
+    (void)active_blocks;
+    (void)max_signal_bytes;
+    (void)timeout;
+#else
+    if (nbytes == 0) {
+      return;
+    }
+
+    const int groupId = group.group_id;
+    const int effActive =
+        active_blocks > 0 ? active_blocks : sendRecvState_.maxGroups;
+
+    if (effActive > sendRecvState_.maxGroups) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: send active_blocks=%d > maxGroups=%d\n",
+            effActive,
+            sendRecvState_.maxGroups);
+      }
+      __trap();
+    }
+    if (groupId >= effActive) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: send group_id=%u >= active_blocks=%d\n",
+            groupId,
+            effActive);
+      }
+      __trap();
+    }
+
+    const std::size_t perBlockSlot =
+        (sendRecvState_.dataBufferSize / effActive) & ~15ULL;
+    if (perBlockSlot == 0) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: send perBlockSlot=0 "
+            "(dataBufferSize=%llu, active_blocks=%d)\n",
+            (unsigned long long)sendRecvState_.dataBufferSize,
+            effActive);
+      }
+      __trap();
+    }
+
+    std::size_t chunkSize =
+        (max_signal_bytes > 0 && max_signal_bytes < perBlockSlot)
+        ? (max_signal_bytes & ~15ULL)
+        : perBlockSlot;
+    if (chunkSize == 0) {
+      chunkSize = perBlockSlot;
+    }
+    const std::size_t chunksPerSlot = perBlockSlot / chunkSize;
+    const std::size_t totalChunks = (nbytes + chunkSize - 1) / chunkSize;
+
+    const int64_t baseStep = sendRecvState_.stepState[groupId];
+    const int pipelineDepth = sendRecvState_.pipelineDepth;
+    const std::size_t dataBufferSize = sendRecvState_.dataBufferSize;
+    const int maxGroups = sendRecvState_.maxGroups;
+    const int64_t chunksPerSlot64 = static_cast<int64_t>(chunksPerSlot);
+    const int64_t pipelineChunks =
+        static_cast<int64_t>(pipelineDepth) * chunksPerSlot64;
+
+    for (std::size_t s = 0; s < totalChunks; ++s) {
+      const int64_t chunkStep = baseStep + static_cast<int64_t>(s);
+      const int64_t slotStep = chunkStep / chunksPerSlot64;
+      const int64_t subStep = chunkStep % chunksPerSlot64;
+      const int slot = static_cast<int>(slotStep % pipelineDepth);
+      const std::size_t slotOff = slot * dataBufferSize;
+      const std::size_t chunkOff =
+          static_cast<std::size_t>(subStep) * chunkSize;
+      const std::size_t stagingOff =
+          slotOff + groupId * perBlockSlot + chunkOff;
+      const std::size_t dataOff = s * chunkSize;
+      const std::size_t bytesThis =
+          (dataOff + chunkSize <= nbytes) ? chunkSize : (nbytes - dataOff);
+
+      // (1) Wait for NIC to finish with this slot's local sendStaging.
+      if (chunkStep >= pipelineChunks) {
+        wait_counter(
+            group,
+            sendRecvState_.localCounterBuf.subBuffer(
+                groupId * sizeof(uint64_t)),
+            static_cast<uint64_t>(chunkStep - pipelineChunks + 1),
+            timeout);
+      }
+
+      // (2) Cooperative memcpy: src → local sendStaging.
+      memcpy_vectorized(
+          sendRecvState_.sendStagingPtr + stagingOff,
+          static_cast<char*>(src) + dataOff,
+          bytesThis,
+          group);
+      group.sync();
+
+      // (3) Backpressure: wait for receiver to free this sub-chunk's
+      //     recvStaging offset. Symmetric with DATA_READY (per sub-chunk).
+      if (chunkStep >= pipelineChunks) {
+        wait_signal(
+            group,
+            sendRecvState_.localSignalBuf.subBuffer(
+                (maxGroups + groupId) * sizeof(uint64_t)),
+            static_cast<uint64_t>(chunkStep - pipelineChunks + 1),
+            timeout);
+      }
+
+      // (4) threadfence_system + leader-only single-WQE RDMA put with
+      //     fused signal+counter. All threads fence to ensure memcpy
+      //     stores are visible to the NIC before the leader posts the WQE.
+      __threadfence_system();
+      group.sync();
+      if (group.is_leader()) {
+        ThreadGroup solo{0, 1, group.group_id, 1, SyncScope::THREAD};
+        put(solo,
+            sendRecvState_.sendStagingBuf.subBuffer(stagingOff),
+            sendRecvState_.recvStagingBuf.subBuffer(stagingOff),
+            bytesThis,
+            sendRecvState_.remoteSignalBuf.subBuffer(
+                groupId * sizeof(uint64_t)),
+            1ULL,
+            sendRecvState_.localCounterBuf.subBuffer(
+                groupId * sizeof(uint64_t)),
+            1ULL);
+      }
+      group.sync();
+    }
+
+    if (group.is_leader()) {
+      sendRecvState_.stepState[groupId] =
+          baseStep + static_cast<int64_t>(totalChunks);
+    }
+    group.sync();
+#endif
+  }
+
+  /**
+   * recv — receive one block's tile from pipelined RDMA.
+   *
+   * Waits for data to arrive in recvStaging, then copies recvStaging → dst.
+   * For this call, each logical slot contributes one perBlockSlot-sized region
+   * for this group. If nbytes > perBlockSlot, recv() advances through multiple
+   * ring positions. max_signal_bytes controls sub-chunk granularity and must
+   * match the sender.
+   *
+   * Signaling protocol (per group, symmetric with send):
+   *   DATA_READY — sender increments per sub-chunk after RDMA put completes.
+   *                recv waits on this before copying from recvStaging.
+   *   SLOT_FREE  — recv increments per sub-chunk (symmetric with DATA_READY)
+   *                to release backpressure on sender.
+   *
+   * @param group           ThreadGroup (all threads participate in memcpy,
+   *                        leader does signal ops).
+   * @param dst             Destination for this block's tile.
+   * @param nbytes          Bytes to receive for this group. Internally
+   *                        consumed in perBlockSlot-sized pieces, or smaller
+   *                        sub-chunks when max_signal_bytes is set.
+   * @param active_blocks   Number of block-groups sharing each logical slot in
+   *                        this call. 0 means use maxGroups.
+   * @param max_signal_bytes Max bytes per signaled sub-chunk within one
+   *                        perBlockSlot. 0 means one signal per perBlockSlot.
+   *                        Must match the sender's value.
+   * @param timeout         Optional timeout for wait operations.
+   */
+  __device__ __forceinline__ void recv(
+      ThreadGroup& group,
+      void* __restrict__ dst,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout()) {
+#ifndef __CUDA_ARCH__
+    (void)group;
+    (void)dst;
+    (void)nbytes;
+    (void)active_blocks;
+    (void)max_signal_bytes;
+    (void)timeout;
+#else
+    if (nbytes == 0) {
+      return;
+    }
+
+    const int groupId = group.group_id;
+    const int effActive =
+        active_blocks > 0 ? active_blocks : sendRecvState_.maxGroups;
+
+    if (effActive > sendRecvState_.maxGroups) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: recv active_blocks=%d > maxGroups=%d\n",
+            effActive,
+            sendRecvState_.maxGroups);
+      }
+      __trap();
+    }
+    if (groupId >= effActive) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: recv group_id=%u >= active_blocks=%d\n",
+            groupId,
+            effActive);
+      }
+      __trap();
+    }
+
+    const std::size_t perBlockSlot =
+        (sendRecvState_.dataBufferSize / effActive) & ~15ULL;
+    if (perBlockSlot == 0) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: recv perBlockSlot=0 "
+            "(dataBufferSize=%llu, active_blocks=%d)\n",
+            (unsigned long long)sendRecvState_.dataBufferSize,
+            effActive);
+      }
+      __trap();
+    }
+
+    std::size_t chunkSize =
+        (max_signal_bytes > 0 && max_signal_bytes < perBlockSlot)
+        ? (max_signal_bytes & ~15ULL)
+        : perBlockSlot;
+    if (chunkSize == 0) {
+      chunkSize = perBlockSlot;
+    }
+    const std::size_t chunksPerSlot = perBlockSlot / chunkSize;
+    const std::size_t totalChunks = (nbytes + chunkSize - 1) / chunkSize;
+
+    const int64_t baseStep =
+        sendRecvState_.stepState[sendRecvState_.maxGroups + groupId];
+    const int pipelineDepth = sendRecvState_.pipelineDepth;
+    const std::size_t dataBufferSize = sendRecvState_.dataBufferSize;
+    const int maxGroups = sendRecvState_.maxGroups;
+    const int64_t chunksPerSlot64 = static_cast<int64_t>(chunksPerSlot);
+
+    for (std::size_t s = 0; s < totalChunks; ++s) {
+      const int64_t chunkStep = baseStep + static_cast<int64_t>(s);
+      const int64_t slotStep = chunkStep / chunksPerSlot64;
+      const int64_t subStep = chunkStep % chunksPerSlot64;
+      const int slot = static_cast<int>(slotStep % pipelineDepth);
+      const std::size_t slotOff = slot * dataBufferSize;
+      const std::size_t chunkOff =
+          static_cast<std::size_t>(subStep) * chunkSize;
+      const std::size_t stagingOff =
+          slotOff + groupId * perBlockSlot + chunkOff;
+      const std::size_t dataOff = s * chunkSize;
+      const std::size_t bytesThis =
+          (dataOff + chunkSize <= nbytes) ? chunkSize : (nbytes - dataOff);
+
+      // (1) Wait for sender's DATA_READY signal.
+      wait_signal(
+          group,
+          sendRecvState_.localSignalBuf.subBuffer(groupId * sizeof(uint64_t)),
+          static_cast<uint64_t>(chunkStep + 1),
+          timeout);
+
+      // (2) Cooperative memcpy: local recvStaging → dst.
+      memcpy_vectorized(
+          static_cast<char*>(dst) + dataOff,
+          sendRecvState_.recvStagingPtr + stagingOff,
+          bytesThis,
+          group);
+      group.sync();
+
+      // (3) Signal SLOT_FREE to sender — per sub-chunk (symmetric with
+      //     DATA_READY). Sender waits per sub-chunk before reusing remote
+      //     recvStaging at the same offset.
+      signal(
+          group,
+          sendRecvState_.remoteSignalBuf.subBuffer(
+              (maxGroups + groupId) * sizeof(uint64_t)),
+          1ULL);
+    }
+
+    if (group.is_leader()) {
+      sendRecvState_.stepState[sendRecvState_.maxGroups + groupId] =
+          baseStep + static_cast<int64_t>(totalChunks);
+    }
+    group.sync();
+#endif
+  }
+
+  // Send/recv state accessors
+
+  __host__ __device__ const IbSendRecvState& send_recv_state() const {
+    return sendRecvState_;
+  }
+
+ private:
   /**
    * active_qp - Select the QP for the calling group
    *
@@ -1009,17 +1409,12 @@ class P2pIbgdaTransportDevice {
   IbgdaLocalBuffer ownedLocalSignalBuf_{}; // inbox: receive signals from peers
   IbgdaLocalBuffer ownedCounterBuf_{}; // local counter for companion QP
 
-  // Throwaway remote slot used as the signal target when put_impl needs to
-  // increment a counter without a real signal. The peer never reads this
-  // slot — we only need somewhere addressable so signal_counter has a place
-  // to land its atomic FA. See put_impl for the rationale.
   IbgdaRemoteBuffer discardSignalSlot_{};
 
-  // Slot counts for bounds-checking the slot-index API. Zero means the
-  // transport was not configured with that buffer; any slot-index call
-  // traps via IBGDA_CHECK_SLOT_ID.
   int numSignalSlots_{0};
   int numCounterSlots_{0};
+
+  IbSendRecvState sendRecvState_{};
 };
 
 } // namespace comms::pipes

--- a/comms/pipes/benchmarks/IbgdaSendRecv.cu
+++ b/comms/pipes/benchmarks/IbgdaSendRecv.cu
@@ -1,0 +1,147 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/benchmarks/IbgdaSendRecv.cuh"
+
+#include <algorithm>
+
+#include "comms/pipes/CopyUtils.cuh"
+#include "comms/pipes/ThreadGroup.cuh"
+#include "comms/pipes/TiledBuffer.cuh"
+#include "comms/pipes/Timeout.cuh"
+
+namespace comms::pipes::benchmark {
+
+__global__ void __launch_bounds__(512, 1) ibgda_send_recv_kernel(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    char* dst,
+    std::size_t totalBytes,
+    int numBlocks,
+    Timeout timeout) {
+  auto group = make_block_group();
+
+  // Partition blocks: first half sends, second half receives.
+  auto [role, sub] = group.partition(2);
+  const bool isSender = (role == 0);
+
+  // Section size = transport's staging slot size (dataBufferSize).
+  // Clamp to totalBytes for small transfers.
+  const std::size_t sectionBytes =
+      min(transport->send_recv_state().dataBufferSize, totalBytes);
+  const std::size_t totalSections = totalBytes / sectionBytes;
+
+  for (std::size_t s = 0; s < totalSections; ++s) {
+    const std::size_t offset = s * sectionBytes;
+
+    if (isSender) {
+      TiledBuffer<char> tiles(src + offset, sectionBytes, sub);
+      transport->send(sub, tiles.data(), tiles.bytes(), numBlocks, 0, timeout);
+    } else {
+      TiledBuffer<char> tiles(dst + offset, sectionBytes, sub);
+      transport->recv(sub, tiles.data(), tiles.bytes(), numBlocks, 0, timeout);
+    }
+  }
+}
+
+void launch_ibgda_send_recv(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    char* dst,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    Timeout timeout) {
+  ibgda_send_recv_kernel<<<2 * numBlocks, 512, 0, stream>>>(
+      transport, src, dst, nbytes, numBlocks, timeout);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf("[PIPES] Kernel launch failed: %s\n", cudaGetErrorString(err));
+  }
+}
+
+__global__ void __launch_bounds__(512, 1) ibgda_send_kernel(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    std::size_t totalBytes,
+    int numBlocks,
+    Timeout timeout) {
+  auto group = make_block_group();
+
+  const std::size_t sectionBytes =
+      min(transport->send_recv_state().dataBufferSize, totalBytes);
+  const std::size_t totalSections = totalBytes / sectionBytes;
+
+  for (std::size_t s = 0; s < totalSections; ++s) {
+    TiledBuffer<char> tiles(src + s * sectionBytes, sectionBytes, group);
+    transport->send(group, tiles.data(), tiles.bytes(), numBlocks, 0, timeout);
+  }
+}
+
+__global__ void __launch_bounds__(512, 1) ibgda_recv_kernel(
+    P2pIbgdaTransportDevice* transport,
+    char* dst,
+    std::size_t totalBytes,
+    int numBlocks,
+    Timeout timeout) {
+  auto group = make_block_group();
+
+  const std::size_t sectionBytes =
+      min(transport->send_recv_state().dataBufferSize, totalBytes);
+  const std::size_t totalSections = totalBytes / sectionBytes;
+
+  for (std::size_t s = 0; s < totalSections; ++s) {
+    TiledBuffer<char> tiles(dst + s * sectionBytes, sectionBytes, group);
+    transport->recv(group, tiles.data(), tiles.bytes(), numBlocks, 0, timeout);
+  }
+}
+
+void launch_ibgda_send(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    Timeout timeout) {
+  ibgda_send_kernel<<<numBlocks, 512, 0, stream>>>(
+      transport, src, nbytes, numBlocks, timeout);
+}
+
+void launch_ibgda_recv(
+    P2pIbgdaTransportDevice* transport,
+    char* dst,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    Timeout timeout) {
+  ibgda_recv_kernel<<<numBlocks, 512, 0, stream>>>(
+      transport, dst, nbytes, numBlocks, timeout);
+}
+
+__global__ void ibgda_snapshot_step_state_kernel(
+    P2pIbgdaTransportDevice* transport,
+    int64_t* dst,
+    int count) {
+  const auto idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx < count) {
+    dst[idx] = transport->send_recv_state().stepState[idx];
+  }
+}
+
+void launch_ibgda_snapshot_step_state(
+    P2pIbgdaTransportDevice* transport,
+    int64_t* dst,
+    int count,
+    cudaStream_t stream) {
+  constexpr int kThreads = 256;
+  const int blocks = (count + kThreads - 1) / kThreads;
+  ibgda_snapshot_step_state_kernel<<<blocks, kThreads, 0, stream>>>(
+      transport, dst, count);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf(
+        "[PIPES] Step-state snapshot launch failed: %s\n",
+        cudaGetErrorString(err));
+  }
+}
+
+} // namespace comms::pipes::benchmark

--- a/comms/pipes/benchmarks/IbgdaSendRecv.cuh
+++ b/comms/pipes/benchmarks/IbgdaSendRecv.cuh
@@ -1,0 +1,53 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include "comms/pipes/P2pIbgdaTransportDevice.cuh"
+#include "comms/pipes/TiledBuffer.cuh"
+#include "comms/pipes/Timeout.cuh"
+
+namespace comms::pipes::benchmark {
+
+/**
+ * Bidirectional tile sendrecv kernel for IBGDA transport.
+ *
+ * Grid: 2 * numBlocks (first half sends, second half receives).
+ * Block: 512 threads.
+ * Each sender block i is paired with receiver block i on the remote GPU.
+ * Uses transport-managed staging buffers via send/recv.
+ *
+ * The kernel loops over sections of totalBytes, each dataBufferSize in size
+ * (read from the transport's tile state). Within each section, TiledBuffer
+ * partitions data into per-block tiles. Each tile fits in one perBlockSlotSize.
+ */
+__global__ void ibgda_send_recv_kernel(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    char* dst,
+    std::size_t totalBytes,
+    int numBlocks,
+    Timeout timeout);
+
+/**
+ * Unidirectional tile send kernel. All blocks send.
+ * Grid: numBlocks. Block: 512 threads.
+ */
+__global__ void ibgda_send_kernel(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    std::size_t totalBytes,
+    int numBlocks,
+    Timeout timeout);
+
+/**
+ * Unidirectional tile recv kernel. All blocks receive.
+ * Grid: numBlocks. Block: 512 threads.
+ */
+__global__ void ibgda_recv_kernel(
+    P2pIbgdaTransportDevice* transport,
+    char* dst,
+    std::size_t totalBytes,
+    int numBlocks,
+    Timeout timeout);
+
+} // namespace comms::pipes::benchmark

--- a/comms/pipes/benchmarks/IbgdaSendRecv.h
+++ b/comms/pipes/benchmarks/IbgdaSendRecv.h
@@ -1,0 +1,76 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <cstddef>
+#include <cstdint>
+
+#include "comms/pipes/Timeout.cuh"
+
+namespace comms::pipes {
+class P2pIbgdaTransportDevice;
+} // namespace comms::pipes
+
+namespace comms::pipes::benchmark {
+
+/**
+ * Launch bidirectional tile sendrecv kernel for IBGDA transport.
+ *
+ * Grid: 2 * numBlocks (first half sends, second half receives).
+ * Block: 512 threads.
+ *
+ * @param transport  GPU-resident P2pIbgdaTransportDevice pointer
+ * @param src        Source data buffer (device memory)
+ * @param dst        Destination data buffer (device memory)
+ * @param nbytes     Total bytes to transfer
+ * @param numBlocks  Number of send blocks (= number of recv blocks)
+ * @param stream     CUDA stream
+ * @param timeout    Optional timeout for wait operations
+ */
+void launch_ibgda_send_recv(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    char* dst,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    Timeout timeout = Timeout());
+
+/**
+ * Launch unidirectional tile send kernel. All blocks send.
+ */
+void launch_ibgda_send(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    Timeout timeout = Timeout());
+
+/**
+ * Launch unidirectional tile recv kernel. All blocks receive.
+ */
+void launch_ibgda_recv(
+    P2pIbgdaTransportDevice* transport,
+    char* dst,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    Timeout timeout = Timeout());
+
+/**
+ * Snapshot the transport send/recv step-state array into device memory.
+ *
+ * @param transport  GPU-resident P2pIbgdaTransportDevice pointer
+ * @param dst        Device buffer receiving `count` int64_t values
+ * @param count      Number of step-state entries to copy
+ * @param stream     CUDA stream
+ */
+void launch_ibgda_snapshot_step_state(
+    P2pIbgdaTransportDevice* transport,
+    int64_t* dst,
+    int count,
+    cudaStream_t stream);
+
+} // namespace comms::pipes::benchmark

--- a/comms/pipes/benchmarks/IbgdaSendRecvBenchmark.cc
+++ b/comms/pipes/benchmarks/IbgdaSendRecvBenchmark.cc
@@ -1,0 +1,635 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include <cuda_runtime.h>
+#include <folly/init/Init.h>
+#include <folly/logging/xlog.h>
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "comms/pipes/MultipeerIbgdaTransport.h"
+#include "comms/pipes/TimeoutUtils.h"
+#include "comms/pipes/benchmarks/IbgdaSendRecv.h"
+#include "comms/testinfra/BenchmarkTestFixture.h"
+#include "comms/utils/CudaRAII.h"
+
+using meta::comms::BenchmarkEnvironment;
+using meta::comms::BenchmarkTestFixture;
+using meta::comms::DeviceBuffer;
+
+namespace comms::pipes::benchmark {
+
+using SendRecvConfig = MultipeerIbgdaTransportConfig::SendRecvConfig;
+
+namespace {
+
+std::vector<int64_t> snapshotStepState(
+    P2pIbgdaTransportDevice* transport,
+    int maxGroups,
+    cudaStream_t stream) {
+  DeviceBuffer stepBuf(2 * maxGroups * sizeof(int64_t));
+  launch_ibgda_snapshot_step_state(
+      transport, static_cast<int64_t*>(stepBuf.get()), 2 * maxGroups, stream);
+
+  cudaError_t err = cudaStreamSynchronize(stream);
+  EXPECT_EQ(err, cudaSuccess)
+      << "Step-state snapshot failed: " << cudaGetErrorString(err);
+
+  std::vector<int64_t> hostSteps(2 * maxGroups, -1);
+  err = cudaMemcpy(
+      hostSteps.data(),
+      stepBuf.get(),
+      hostSteps.size() * sizeof(int64_t),
+      cudaMemcpyDeviceToHost);
+  EXPECT_EQ(err, cudaSuccess)
+      << "Step-state copy failed: " << cudaGetErrorString(err);
+  return hostSteps;
+}
+
+void expectUniformBuffer(
+    const DeviceBuffer& buf,
+    std::size_t nbytes,
+    uint8_t expected,
+    int rank) {
+  std::vector<uint8_t> hostBuf(nbytes);
+  cudaError_t err =
+      cudaMemcpy(hostBuf.data(), buf.get(), nbytes, cudaMemcpyDeviceToHost);
+  ASSERT_EQ(err, cudaSuccess)
+      << "cudaMemcpy failed: " << cudaGetErrorString(err);
+
+  for (std::size_t i = 0; i < nbytes; ++i) {
+    ASSERT_EQ(hostBuf[i], expected)
+        << "Rank " << rank << ": data mismatch at byte " << i << ", expected "
+        << static_cast<int>(expected) << ", got "
+        << static_cast<int>(hostBuf[i]);
+  }
+}
+
+void expectStepState(
+    const std::vector<int64_t>& steps,
+    int maxGroups,
+    int64_t expected) {
+  ASSERT_EQ(steps.size(), 2 * maxGroups);
+  for (int i = 0; i < 2 * maxGroups; ++i) {
+    EXPECT_EQ(steps[i], expected)
+        << "Unexpected stepState[" << i << "], expected " << expected;
+  }
+}
+
+} // namespace
+
+class IbgdaSendRecvTest : public BenchmarkTestFixture {
+ protected:
+  void SetUp() override {
+    BenchmarkTestFixture::SetUp();
+    cudaSetDevice(localRank);
+    cudaStreamCreate(&stream_);
+  }
+
+  void TearDown() override {
+    cudaStreamDestroy(stream_);
+    BenchmarkTestFixture::TearDown();
+  }
+
+  cudaStream_t stream_{};
+};
+
+TEST_F(IbgdaSendRecvTest, Correctness) {
+  if (worldSize != 2) {
+    XLOGF(INFO, "Skipping: requires exactly 2 ranks, got {}", worldSize);
+    return;
+  }
+
+  constexpr std::size_t kDataBytes = 4 * 1024 * 1024; // 4MB
+  constexpr int kNumBlocks = 4;
+  constexpr std::size_t kSlotSize = kDataBytes; // 1 section = 1 slot
+  constexpr int kPipelineDepth = 2;
+  constexpr int kMaxBlocks = kNumBlocks;
+
+  int peerRank = (globalRank == 0) ? 1 : 0;
+
+  MultipeerIbgdaTransportConfig transportConfig{
+      .cudaDevice = localRank,
+      .dataBufferSize = kSlotSize,
+      .sendRecv =
+          SendRecvConfig{
+              .maxGroups = kMaxBlocks,
+              .pipelineDepth = kPipelineDepth,
+          },
+  };
+
+  MultipeerIbgdaTransport transport(
+      globalRank, worldSize, bootstrap, transportConfig);
+  transport.exchange();
+
+  DeviceBuffer sendBuf(kDataBytes);
+  DeviceBuffer recvBuf(kDataBytes);
+
+  uint8_t fillPattern = 0xA0 + globalRank;
+  cudaMemset(sendBuf.get(), fillPattern, kDataBytes);
+  cudaMemset(recvBuf.get(), 0, kDataBytes);
+  cudaDeviceSynchronize();
+
+  bootstrap->barrierAll();
+
+  auto* deviceTransport = transport.getP2pTransportDevice(peerRank);
+
+  launch_ibgda_send_recv(
+      deviceTransport,
+      static_cast<char*>(sendBuf.get()),
+      static_cast<char*>(recvBuf.get()),
+      kDataBytes,
+      kNumBlocks,
+      stream_);
+
+  cudaError_t err = cudaStreamSynchronize(stream_);
+  ASSERT_EQ(err, cudaSuccess)
+      << "Kernel execution failed: " << cudaGetErrorString(err);
+
+  bootstrap->barrierAll();
+
+  uint8_t expectedPattern = 0xA0 + peerRank;
+  std::vector<uint8_t> hostBuf(kDataBytes);
+  cudaMemcpy(hostBuf.data(), recvBuf.get(), kDataBytes, cudaMemcpyDeviceToHost);
+
+  bool correct = true;
+  for (std::size_t i = 0; i < kDataBytes; i++) {
+    if (hostBuf[i] != expectedPattern) {
+      XLOGF(
+          ERR,
+          "Rank {}: data mismatch at byte {}: expected 0x{:02X}, got 0x{:02X}",
+          globalRank,
+          i,
+          expectedPattern,
+          hostBuf[i]);
+      correct = false;
+      break;
+    }
+  }
+  EXPECT_TRUE(correct) << "Rank " << globalRank
+                       << ": tile sendrecv data correctness failed";
+  if (correct) {
+    XLOGF(
+        INFO,
+        "Rank {}: tile sendrecv correctness OK ({} bytes)",
+        globalRank,
+        kDataBytes);
+  }
+}
+
+TEST_F(IbgdaSendRecvTest, StepStatePersistsAcrossKernelLaunches) {
+  if (worldSize != 2) {
+    XLOGF(INFO, "Skipping: requires exactly 2 ranks, got {}", worldSize);
+    return;
+  }
+
+  constexpr int kNumBlocks = 4;
+  constexpr int kPipelineDepth = 2;
+  constexpr std::size_t kSlotSize = 1 * 1024 * 1024;
+  constexpr std::size_t kSectionsFirst = 3;
+  constexpr std::size_t kSectionsSecond = 2;
+  constexpr std::size_t kBytesFirst = kSectionsFirst * kSlotSize;
+  constexpr std::size_t kBytesSecond = kSectionsSecond * kSlotSize;
+  constexpr std::size_t kMaxBytes = kBytesFirst;
+
+  int peerRank = (globalRank == 0) ? 1 : 0;
+
+  MultipeerIbgdaTransportConfig transportConfig{
+      .cudaDevice = localRank,
+      .dataBufferSize = kSlotSize,
+      .sendRecv =
+          SendRecvConfig{
+              .maxGroups = kNumBlocks,
+              .pipelineDepth = kPipelineDepth,
+          },
+  };
+
+  MultipeerIbgdaTransport transport(
+      globalRank, worldSize, bootstrap, transportConfig);
+  transport.exchange();
+
+  DeviceBuffer sendBuf(kMaxBytes);
+  DeviceBuffer recvBuf(kMaxBytes);
+  auto* deviceTransport = transport.getP2pTransportDevice(peerRank);
+
+  bootstrap->barrierAll();
+
+  const uint8_t firstPattern = static_cast<uint8_t>(0x40 + globalRank);
+  ASSERT_EQ(cudaMemset(sendBuf.get(), firstPattern, kBytesFirst), cudaSuccess);
+  ASSERT_EQ(cudaMemset(recvBuf.get(), 0, kBytesFirst), cudaSuccess);
+
+  launch_ibgda_send_recv(
+      deviceTransport,
+      static_cast<char*>(sendBuf.get()),
+      static_cast<char*>(recvBuf.get()),
+      kBytesFirst,
+      kNumBlocks,
+      stream_);
+  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+  bootstrap->barrierAll();
+
+  expectUniformBuffer(
+      recvBuf, kBytesFirst, static_cast<uint8_t>(0x40 + peerRank), globalRank);
+  expectStepState(
+      snapshotStepState(deviceTransport, kNumBlocks, stream_),
+      kNumBlocks,
+      static_cast<int64_t>(kSectionsFirst));
+
+  const uint8_t secondPattern = static_cast<uint8_t>(0x50 + globalRank);
+  ASSERT_EQ(
+      cudaMemset(sendBuf.get(), secondPattern, kBytesSecond), cudaSuccess);
+  ASSERT_EQ(cudaMemset(recvBuf.get(), 0, kBytesSecond), cudaSuccess);
+
+  launch_ibgda_send_recv(
+      deviceTransport,
+      static_cast<char*>(sendBuf.get()),
+      static_cast<char*>(recvBuf.get()),
+      kBytesSecond,
+      kNumBlocks,
+      stream_);
+  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+  bootstrap->barrierAll();
+
+  expectUniformBuffer(
+      recvBuf, kBytesSecond, static_cast<uint8_t>(0x50 + peerRank), globalRank);
+  expectStepState(
+      snapshotStepState(deviceTransport, kNumBlocks, stream_),
+      kNumBlocks,
+      static_cast<int64_t>(kSectionsFirst + kSectionsSecond));
+}
+
+TEST_F(IbgdaSendRecvTest, StepStatePersistsAcrossCudaGraphReplays) {
+  if (worldSize != 2) {
+    XLOGF(INFO, "Skipping: requires exactly 2 ranks, got {}", worldSize);
+    return;
+  }
+
+  constexpr int kNumBlocks = 4;
+  constexpr int kPipelineDepth = 2;
+  constexpr std::size_t kSlotSize = 1 * 1024 * 1024;
+  constexpr std::size_t kSectionsPerReplay = 2;
+  constexpr std::size_t kBytesPerReplay = kSectionsPerReplay * kSlotSize;
+  constexpr int kReplays = 3;
+
+  int peerRank = (globalRank == 0) ? 1 : 0;
+
+  MultipeerIbgdaTransportConfig transportConfig{
+      .cudaDevice = localRank,
+      .dataBufferSize = kSlotSize,
+      .sendRecv =
+          SendRecvConfig{
+              .maxGroups = kNumBlocks,
+              .pipelineDepth = kPipelineDepth,
+          },
+  };
+
+  MultipeerIbgdaTransport transport(
+      globalRank, worldSize, bootstrap, transportConfig);
+  transport.exchange();
+
+  DeviceBuffer sendBuf(kBytesPerReplay);
+  DeviceBuffer recvBuf(kBytesPerReplay);
+  auto* deviceTransport = transport.getP2pTransportDevice(peerRank);
+
+  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+
+  cudaGraph_t graph{};
+  cudaGraphExec_t graphExec{};
+  ASSERT_EQ(
+      cudaStreamBeginCapture(stream_, cudaStreamCaptureModeGlobal),
+      cudaSuccess);
+  launch_ibgda_send_recv(
+      deviceTransport,
+      static_cast<char*>(sendBuf.get()),
+      static_cast<char*>(recvBuf.get()),
+      kBytesPerReplay,
+      kNumBlocks,
+      stream_);
+  ASSERT_EQ(cudaStreamEndCapture(stream_, &graph), cudaSuccess);
+  ASSERT_NE(graph, nullptr);
+  ASSERT_EQ(
+      cudaGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0),
+      cudaSuccess);
+
+  bootstrap->barrierAll();
+
+  for (int replay = 0; replay < kReplays; ++replay) {
+    const uint8_t sendPattern =
+        static_cast<uint8_t>(0x70 + replay * 8 + globalRank);
+    ASSERT_EQ(
+        cudaMemsetAsync(sendBuf.get(), sendPattern, kBytesPerReplay, stream_),
+        cudaSuccess);
+    ASSERT_EQ(
+        cudaMemsetAsync(recvBuf.get(), 0, kBytesPerReplay, stream_),
+        cudaSuccess);
+    ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+
+    bootstrap->barrierAll();
+    ASSERT_EQ(cudaGraphLaunch(graphExec, stream_), cudaSuccess);
+    ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+    bootstrap->barrierAll();
+
+    expectUniformBuffer(
+        recvBuf,
+        kBytesPerReplay,
+        static_cast<uint8_t>(0x70 + replay * 8 + peerRank),
+        globalRank);
+    expectStepState(
+        snapshotStepState(deviceTransport, kNumBlocks, stream_),
+        kNumBlocks,
+        static_cast<int64_t>((replay + 1) * kSectionsPerReplay));
+  }
+
+  ASSERT_EQ(cudaGraphExecDestroy(graphExec), cudaSuccess);
+  ASSERT_EQ(cudaGraphDestroy(graph), cudaSuccess);
+}
+
+TEST_F(IbgdaSendRecvTest, Bandwidth) {
+  if (worldSize != 2) {
+    XLOGF(INFO, "Skipping: requires exactly 2 ranks, got {}", worldSize);
+    return;
+  }
+
+  constexpr int kNumBlocks = 2;
+  constexpr std::size_t kSlotSize = 8 * 1024 * 1024; // 8MB
+  constexpr int kPipelineDepth = 2;
+  constexpr int kMaxBlocks = kNumBlocks;
+  constexpr int kWarmupIters = 5;
+  constexpr int kBenchIters = 20;
+
+  // Message sizes: 1MB to 4GB
+  std::vector<std::size_t> messageSizes;
+  for (std::size_t sz = 1ULL << 20; sz <= 4ULL << 30; sz <<= 1) {
+    messageSizes.push_back(sz);
+  }
+
+  int peerRank = (globalRank == 0) ? 1 : 0;
+  std::size_t maxBytes = messageSizes.back();
+
+  MultipeerIbgdaTransportConfig transportConfig{
+      .cudaDevice = localRank,
+      .dataBufferSize = kSlotSize,
+      .sendRecv =
+          SendRecvConfig{
+              .maxGroups = kMaxBlocks,
+              .pipelineDepth = kPipelineDepth,
+          },
+  };
+
+  MultipeerIbgdaTransport transport(
+      globalRank, worldSize, bootstrap, transportConfig);
+  transport.exchange();
+
+  DeviceBuffer sendBuf(maxBytes);
+  DeviceBuffer recvBuf(maxBytes);
+  cudaMemset(sendBuf.get(), 0xAA, maxBytes);
+  cudaMemset(recvBuf.get(), 0, maxBytes);
+  cudaDeviceSynchronize();
+
+  auto* deviceTransport = transport.getP2pTransportDevice(peerRank);
+
+  cudaEvent_t start, stop;
+  cudaEventCreate(&start);
+  cudaEventCreate(&stop);
+
+  if (globalRank == 0) {
+    XLOGF(INFO, "");
+    XLOGF(
+        INFO,
+        "================================================================");
+    XLOGF(INFO, "  IBGDA Tile SendRecv Bandwidth");
+    XLOGF(
+        INFO,
+        "  numBlocks={}, slotSize={}MB, pipelineDepth={}",
+        kNumBlocks,
+        kSlotSize / (1024 * 1024),
+        kPipelineDepth);
+    XLOGF(
+        INFO,
+        "================================================================");
+    XLOGF(
+        INFO, "{:>10s}  {:>10s}  {:>12s}", "MsgSize", "Sections", "BW (GB/s)");
+    XLOGF(INFO, "----------------------------------------------");
+  }
+
+  for (auto nBytes : messageSizes) {
+    bootstrap->barrierAll();
+
+    // Warmup
+    for (int i = 0; i < kWarmupIters; ++i) {
+      launch_ibgda_send_recv(
+          deviceTransport,
+          static_cast<char*>(sendBuf.get()),
+          static_cast<char*>(recvBuf.get()),
+          nBytes,
+          kNumBlocks,
+          stream_);
+      cudaStreamSynchronize(stream_);
+      bootstrap->barrierAll();
+    }
+
+    bootstrap->barrierAll();
+
+    // Benchmark
+    cudaEventRecord(start, stream_);
+    for (int i = 0; i < kBenchIters; ++i) {
+      launch_ibgda_send_recv(
+          deviceTransport,
+          static_cast<char*>(sendBuf.get()),
+          static_cast<char*>(recvBuf.get()),
+          nBytes,
+          kNumBlocks,
+          stream_);
+    }
+    cudaEventRecord(stop, stream_);
+    cudaEventSynchronize(stop);
+
+    bootstrap->barrierAll();
+
+    float totalMs = 0;
+    cudaEventElapsedTime(&totalMs, start, stop);
+    float avgMs = totalMs / kBenchIters;
+
+    float bwGBs = (2.0f * nBytes / 1e9f) / (avgMs / 1000.0f);
+    std::size_t numSections = (nBytes + kSlotSize - 1) / kSlotSize;
+
+    if (globalRank == 0) {
+      std::string sizeStr;
+      if (nBytes >= 1ULL << 30) {
+        sizeStr = fmt::format("{}GB", nBytes >> 30);
+      } else {
+        sizeStr = fmt::format("{}MB", nBytes >> 20);
+      }
+      XLOGF(INFO, "{:>10s}  {:>10d}  {:>12.2f}", sizeStr, numSections, bwGBs);
+    }
+  }
+
+  if (globalRank == 0) {
+    XLOGF(
+        INFO,
+        "================================================================");
+  }
+
+  cudaEventDestroy(start);
+  cudaEventDestroy(stop);
+}
+
+TEST_F(IbgdaSendRecvTest, UnidirectionalBandwidth) {
+  if (worldSize != 2) {
+    XLOGF(INFO, "Skipping: requires exactly 2 ranks, got {}", worldSize);
+    return;
+  }
+
+  constexpr int kNumBlocks = 2;
+  constexpr std::size_t kSlotSize = 8 * 1024 * 1024; // 8MB
+  constexpr int kPipelineDepth = 2;
+  constexpr int kMaxBlocks = kNumBlocks;
+  constexpr int kWarmupIters = 5;
+  constexpr int kBenchIters = 20;
+
+  std::vector<std::size_t> messageSizes;
+  for (std::size_t sz = 1ULL << 20; sz <= 4ULL << 30; sz <<= 1) {
+    messageSizes.push_back(sz);
+  }
+
+  int peerRank = (globalRank == 0) ? 1 : 0;
+  std::size_t maxBytes = messageSizes.back();
+
+  MultipeerIbgdaTransportConfig transportConfig{
+      .cudaDevice = localRank,
+      .dataBufferSize = kSlotSize,
+      .sendRecv =
+          SendRecvConfig{
+              .maxGroups = kMaxBlocks,
+              .pipelineDepth = kPipelineDepth,
+          },
+  };
+
+  MultipeerIbgdaTransport transport(
+      globalRank, worldSize, bootstrap, transportConfig);
+  transport.exchange();
+
+  DeviceBuffer sendBuf(maxBytes);
+  DeviceBuffer recvBuf(maxBytes);
+  cudaMemset(sendBuf.get(), 0xAA, maxBytes);
+  cudaMemset(recvBuf.get(), 0, maxBytes);
+  cudaDeviceSynchronize();
+
+  auto* deviceTransport = transport.getP2pTransportDevice(peerRank);
+
+  cudaEvent_t start, stop;
+  cudaEventCreate(&start);
+  cudaEventCreate(&stop);
+
+  if (globalRank == 0) {
+    XLOGF(INFO, "");
+    XLOGF(
+        INFO,
+        "================================================================");
+    XLOGF(INFO, "  IBGDA Tile Unidirectional Bandwidth (rank 0 → rank 1)");
+    XLOGF(
+        INFO,
+        "  numBlocks={}, slotSize={}MB, pipelineDepth={}",
+        kNumBlocks,
+        kSlotSize / (1024 * 1024),
+        kPipelineDepth);
+    XLOGF(
+        INFO,
+        "================================================================");
+    XLOGF(
+        INFO, "{:>10s}  {:>10s}  {:>12s}", "MsgSize", "Sections", "BW (GB/s)");
+    XLOGF(INFO, "----------------------------------------------");
+  }
+
+  for (auto nBytes : messageSizes) {
+    bootstrap->barrierAll();
+
+    // Warmup
+    for (int i = 0; i < kWarmupIters; ++i) {
+      if (globalRank == 0) {
+        launch_ibgda_send(
+            deviceTransport,
+            static_cast<char*>(sendBuf.get()),
+            nBytes,
+            kNumBlocks,
+            stream_);
+      } else {
+        launch_ibgda_recv(
+            deviceTransport,
+            static_cast<char*>(recvBuf.get()),
+            nBytes,
+            kNumBlocks,
+            stream_);
+      }
+      cudaStreamSynchronize(stream_);
+      bootstrap->barrierAll();
+    }
+
+    bootstrap->barrierAll();
+
+    // Benchmark
+    cudaEventRecord(start, stream_);
+    for (int i = 0; i < kBenchIters; ++i) {
+      if (globalRank == 0) {
+        launch_ibgda_send(
+            deviceTransport,
+            static_cast<char*>(sendBuf.get()),
+            nBytes,
+            kNumBlocks,
+            stream_);
+      } else {
+        launch_ibgda_recv(
+            deviceTransport,
+            static_cast<char*>(recvBuf.get()),
+            nBytes,
+            kNumBlocks,
+            stream_);
+      }
+    }
+    cudaEventRecord(stop, stream_);
+    cudaEventSynchronize(stop);
+
+    bootstrap->barrierAll();
+
+    float totalMs = 0;
+    cudaEventElapsedTime(&totalMs, start, stop);
+    float avgMs = totalMs / kBenchIters;
+
+    // Unidirectional: only one direction
+    float bwGBs = (nBytes / 1e9f) / (avgMs / 1000.0f);
+    std::size_t numSections = (nBytes + kSlotSize - 1) / kSlotSize;
+
+    if (globalRank == 0) {
+      std::string sizeStr;
+      if (nBytes >= 1ULL << 30) {
+        sizeStr = fmt::format("{}GB", nBytes >> 30);
+      } else {
+        sizeStr = fmt::format("{}MB", nBytes >> 20);
+      }
+      XLOGF(INFO, "{:>10s}  {:>10d}  {:>12.2f}", sizeStr, numSections, bwGBs);
+    }
+  }
+
+  if (globalRank == 0) {
+    XLOGF(
+        INFO,
+        "================================================================");
+  }
+
+  cudaEventDestroy(start);
+  cudaEventDestroy(stop);
+}
+
+} // namespace comms::pipes::benchmark
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv);
+  if (!meta::comms::isTcpEnvironment()) {
+    ::testing::AddGlobalTestEnvironment(new BenchmarkEnvironment());
+  }
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Summary:

Add public send()/recv()/drain() device APIs to P2pIbgdaTransportDevice for pipelined RDMA data transfer. The transport manages staging buffers internally (sendStaging + recvStaging), so users only provide src/dst pointers — no window API needed.

Signal protocol (per group, 3 primitives):
- DATA_READY: piggybacked on RDMA put (sender → receiver, per sub-chunk)
- SLOT_FREE: explicit signal (receiver → sender, per sub-chunk, symmetric)
- NIC_DONE: loopback counter via companion QP (NIC → sender GPU)

Key design:
- Leader-only single-WQE RDMA put for minimal NIC overhead
- Explicit drain() for pipelining across sections
- Sub-slot signaling via max_signal_bytes for fine-grained overlap
- Private signal/counter buffers separate from transport-owned slots
- SendRecvConfig nested struct with defaults (maxGroups=128, pipelineDepth=2)

Host-side buffer lifecycle:
- allocate_send_recv_buffers(): bulk allocations for sendStaging, recvStaging, signal, counter, stepState
- exchange_send_recv_buffers(): allGather for recvStaging + signal remote addresses
- Cleanup: RDMA deregistration + DeviceBuffer RAII

Reviewed By: siyengar

Differential Revision: D101055842
