### PR TITLE
Fix AMD/ROCm HIPify build errors for [[nodiscard]] hipError_t (#2107)

### DIFF
--- a/comms/utils/colltrace/CollTrace.cc
+++ b/comms/utils/colltrace/CollTrace.cc
@@ -192,7 +192,7 @@ std::shared_ptr<GraphCollTraceState> CollTrace::getOrCreateGraphState(
       cudaGraphRetainUserObject(graph, userObject, 1, cudaGraphUserObjectMove);
   if (retainRes != cudaSuccess) {
     // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-    cudaUserObjectRelease(userObject, 1);
+    (void)cudaUserObjectRelease(userObject, 1);
     XLOG_FIRST_N(WARN, 1) << "Failed to retain graph user object: "
                           << cudaGetErrorString(retainRes);
     return nullptr;

--- a/comms/utils/colltrace/GraphCudaWaitEvent.cc
+++ b/comms/utils/colltrace/GraphCudaWaitEvent.cc
@@ -34,11 +34,11 @@ GraphCudaWaitEvent::GraphCudaWaitEvent(cudaStream_t stream, uint32_t collId)
 GraphCudaWaitEvent::~GraphCudaWaitEvent() {
   if (timestampStream_) {
     // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-    cudaStreamDestroy(timestampStream_);
+    (void)cudaStreamDestroy(timestampStream_);
   }
   if (depEvent_) {
     // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-    cudaEventDestroy(depEvent_);
+    (void)cudaEventDestroy(depEvent_);
   }
 }
 


### PR DESCRIPTION
Summary:

Fix 3 compile errors when building `comms/utils/colltrace` for AMD/ROCm.

#### Problem

ROCm 7.0+ annotates `hipError_t` with `[[nodiscard]]`, while NVIDIA's `cudaError_t` does not have this attribute. When CUDA source code is HIPified for AMD builds, the return values of cleanup calls become `hipError_t` (with `[[nodiscard]]`), and discarding them triggers `-Werror,-Wunused-value`.

This is **AMD-only** — NVIDIA builds are unaffected because `cudaError_t` has no `[[nodiscard]]`:

| | NVIDIA (CUDA) | AMD (ROCm/HIP) |
|---|---|---|
| Return type | `cudaError_t` (no `[[nodiscard]]`) | `hipError_t` (has `[[nodiscard]]`) |
| Ignoring return value | Compiles fine | `-Werror,-Wunused-value` compile error |
| After `(void)` cast | No-op | Compiles fine |

The compile chain:
```
CUDA source (trunk)              HIPify auto-conversion           AMD compiler
cudaStreamDestroy(stream);  →   hipStreamDestroy(stream);   →   ERROR: [[nodiscard]] return value discarded
```

This blocks AMD fbpkg builds for any PyPredictor binary that transitively depends on `colltrace` (via PyTorch → libtorch_hip → rcclx → hetero_ctran_lib → colltrace).

#### Changes

- `GraphCudaWaitEvent.cc:37,41`: Add `(void)` cast to `cudaStreamDestroy` and `cudaEventDestroy` in destructor.
- `CollTrace.cc:195`: Add `(void)` cast to `cudaUserObjectRelease` in error cleanup path.
- `BUCK:138`: Remove stale `:hrdw_ring_buffer_instantiations` dep.

#### Why ignoring the return value is correct here

All 3 call sites are in **cleanup/destructor paths** where the return value is intentionally discarded:

**Destructor (GraphCudaWaitEvent.cc:34-43):**
```cpp
GraphCudaWaitEvent::~GraphCudaWaitEvent() {
    (void)cudaStreamDestroy(timestampStream_);  // Destructor cannot propagate errors
    (void)cudaEventDestroy(depEvent_);          // Nothing useful to do if cleanup fails
}
```
Destructors cannot throw or return errors. If `cudaStreamDestroy` fails in a destructor, there is no recovery path. Ignoring the return value is the only correct option.

**Error cleanup (CollTrace.cc:193-198):**
```cpp
if (retainRes != cudaSuccess) {
    (void)cudaUserObjectRelease(userObject, 1);  // Previous operation already failed
    return nullptr;                               // We're already in an error path
}
```
`cudaGraphRetainUserObject` already failed. This is a best-effort cleanup before returning an error. If the cleanup itself also fails, there's nothing additional to do.

#### Safety

- **No behavioral change** — `(void)` cast only suppresses the compiler warning, it does not change runtime behavior.
- **No impact on NVIDIA builds** — `cudaError_t` has no `[[nodiscard]]`, so `(void)` is a no-op.
- **Standard C++ idiom** — `(void)` is the established way to explicitly discard `[[nodiscard]]` return values.
- **Follows precedent** — D94371570 fixed identical issues in `comms/tcp_devmem/unpack/internal_unpack.cc` using the same pattern.

Reviewed By: SuhitK

Differential Revision: D101188535
