### PR TITLE
Fix stale CT_currentColl log messages in CommDumpTest (#2108)

### DIFF
--- a/comms/ncclx/meta/tests/CommDumpTest.cc
+++ b/comms/ncclx/meta/tests/CommDumpTest.cc
@@ -979,7 +979,7 @@ TEST_F(CommDumpTest, DumpAfterCollNewCollTrace) {
   }
 
   if (dump.count("CT_currentColls")) {
-    XLOG(DBG1) << "Entered CT_currentColl if statement";
+    XLOG(DBG1) << "Entered CT_currentColls if statement";
     EXPECT_EQ(dump["CT_currentColls"], "[]");
   }
 
@@ -1083,7 +1083,7 @@ TEST_F(CommDumpTest, DumpAfterCollNewCollTraceWithCommsMonitor) {
   }
 
   if (dump.count("CT_currentColls")) {
-    XLOG(DBG1) << "Entered CT_currentColl if statement";
+    XLOG(DBG1) << "Entered CT_currentColls if statement";
     EXPECT_EQ(dump["CT_currentColls"], "[]");
   }
 


### PR DESCRIPTION
Summary:

After the colltrace rename from CT_currentColl to CT_currentColls
(a3b9b18fb1b4), two XLOG debug messages still referenced the old name.
The actual assertions correctly use CT_currentColls. This is cosmetic
but prevents confusion during debugging.

Reviewed By: dolpm

Differential Revision: D101199021
