### PR TITLE
Improve CUDA graph pool leak detection in tests and pool destructor (#2109)

### DIFF
--- a/comms/ctran/gpe/CtranGpe.cc
+++ b/comms/ctran/gpe/CtranGpe.cc
@@ -479,7 +479,9 @@ size_t CtranGpe::numInUseChecksums() {
 }
 
 size_t CtranGpe::numInUseGpeKernelSyncs() {
+  // Last chance to cleanup
   this->pimpl->gpeKernelSyncPool->reclaim();
+  // Return the number of inuse elements
   return this->pimpl->gpeKernelSyncPool->capacity() -
       this->pimpl->gpeKernelSyncPool->size();
 }

--- a/comms/ctran/gpe/CtranGpe.h
+++ b/comms/ctran/gpe/CtranGpe.h
@@ -427,7 +427,9 @@ class CtranGpe {
   // Return number of inuse checksums.
   size_t numInUseChecksums();
 
-  // Return number of inuse GPE kernel syncs.
+  // Return number of inuse GpeKernelSync elements.
+  // Used to verify that CUDA graph cmdDestroy callbacks have released all pool
+  // elements before pool destruction (async cmdDestroy race).
   size_t numInUseGpeKernelSyncs();
 
   commResult_t allocGpeKernelSyncs(

--- a/comms/ctran/gpe/tests/CtranGpeUT.cc
+++ b/comms/ctran/gpe/tests/CtranGpeUT.cc
@@ -2,7 +2,11 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <atomic>
+#include <chrono>
+#include <future>
 #include <iostream>
+#include <thread>
 
 #include "comms/ctran/algos/CtranAlgoDev.h"
 #include "comms/ctran/algos/common/GpeKernel.h"
@@ -1568,11 +1572,14 @@ TEST_F(CtranGpeTest, GraphCaptureWithHostNode) {
   CUDACHECK_TEST(cudaGraphDestroy(graph));
 
   // cudaUserObjectNoDestructorSync: cmdDestroy fires asynchronously after
-  // graph destruction. Wait for it to release the flag back to the pool.
-  while (gpe->numInUseKernelFlags() > 0) {
+  // graph destruction. Wait for it to release all pool resources back.
+  while (gpe->numInUseKernelFlags() > 0 || gpe->numInUseKernelElems() > 0 ||
+         gpe->numInUseGpeKernelSyncs() > 0) {
     std::this_thread::yield();
   }
   EXPECT_EQ(gpe->numInUseKernelFlags(), 0);
+  EXPECT_EQ(gpe->numInUseKernelElems(), 0);
+  EXPECT_EQ(gpe->numInUseGpeKernelSyncs(), 0);
   CUDACHECK_TEST(cudaFree(buf));
   CUDACHECK_TEST(cudaFreeHost(valPtr));
   CUDACHECK_TEST(cudaStreamDestroy(stream));
@@ -1641,9 +1648,15 @@ TEST_F(CtranGpeTest, GraphCaptureDestroyFreesResources) {
   CUDACHECK_TEST(cudaGraphExecDestroy(graphExec));
   CUDACHECK_TEST(cudaGraphDestroy(graph));
 
-  while (gpe->numInUseKernelFlags() > 0) {
+  // cudaUserObjectNoDestructorSync: cmdDestroy fires asynchronously after
+  // graph destruction. Wait for it to release all pool resources back.
+  while (gpe->numInUseKernelFlags() > 0 || gpe->numInUseKernelElems() > 0 ||
+         gpe->numInUseGpeKernelSyncs() > 0) {
     std::this_thread::yield();
   }
+  EXPECT_EQ(gpe->numInUseKernelFlags(), 0);
+  EXPECT_EQ(gpe->numInUseKernelElems(), 0);
+  EXPECT_EQ(gpe->numInUseGpeKernelSyncs(), 0);
 
   CUDACHECK_TEST(cudaFree(buf));
   CUDACHECK_TEST(cudaFreeHost(valPtr));
@@ -2161,5 +2174,54 @@ TEST_F(CtranGpeTest, PostKernelCleanupGraphWithOpGroup) {
   CUDACHECK_TEST(cudaFreeHost(expectedValPtr));
   CUDACHECK_TEST(cudaFree(a));
   CUDACHECK_TEST(cudaStreamDestroy(stream));
+}
+
+// Verify that terminate() drains the GpeKernelSyncPool before returning.
+//
+// Simulates the production race: CUDA graph cmdDestroy callbacks release pool
+// elements asynchronously after cudaGraphDestroy. Without the spin-wait in
+// terminate(), the pool destructor can free pinned memory while those elements
+// are still "in use", causing use-after-free when the background release runs.
+
+TEST_F(CtranGpeTest, DISABLED_TerminateWaitsForGpeKernelSyncPoolDrain) {
+  auto gpe = std::make_unique<CtranGpe>(cudaDev, dummyComm);
+
+  // Allocate syncs from the pool — they are now "in use".
+  std::vector<ctran::algos::GpeKernelSync*> syncs;
+  constexpr size_t kNumSyncs = 5;
+  constexpr int kNworkers = 1;
+  ASSERT_EQ(gpe->allocGpeKernelSyncs(kNumSyncs, kNworkers, syncs), commSuccess);
+  ASSERT_EQ(gpe->numInUseGpeKernelSyncs(), kNumSyncs);
+
+  // Run terminate() in a background thread so main can control when the pool
+  // is drained. Use a promise to signal when gpe.reset() completes.
+  std::promise<void> gpeResetDone;
+  std::thread gpeThread([&]() {
+    gpe.reset(); // With fix: blocks until pool drained; without fix: returns
+                 // fast
+    gpeResetDone.set_value();
+  });
+
+  // Wait for gpe.reset() to complete, with a short deadline.
+  // With fix: terminate() is blocked in spin-wait → future times out → we
+  // release Without fix: terminate() returns immediately → future is ready →
+  // FAIL
+  constexpr auto kDrainWait = std::chrono::milliseconds(200);
+  auto status = gpeResetDone.get_future().wait_for(kDrainWait);
+
+  if (status == std::future_status::ready) {
+    // gpe.reset() returned while pool elements were still in use.
+    gpeThread.join();
+    FAIL() << "terminate() returned in < " << kDrainWait.count()
+           << "ms while GpeKernelSync pool elements were still in use. "
+              "Pool destructor freed pinned memory before async callbacks "
+              "could release elements, causing use-after-free.";
+  }
+
+  // terminate() is blocked in spin-wait — release elements to unblock it.
+  for (auto* sync : syncs) {
+    sync->reset(); // inUse() → false; spin-wait reclaims and exits
+  }
+  gpeThread.join();
 }
 #endif

--- a/comms/ctran/tests/CtranTestUtils.cc
+++ b/comms/ctran/tests/CtranTestUtils.cc
@@ -723,6 +723,7 @@ bool CtranTestHelpers::isBackendValid(
 void CtranTestHelpers::verifyGpeLeak(ICtran* ctran) {
   ASSERT_EQ(ctran->gpe->numInUseKernelElems(), 0);
   ASSERT_EQ(ctran->gpe->numInUseKernelFlags(), 0);
+  ASSERT_EQ(ctran->gpe->numInUseGpeKernelSyncs(), 0);
 }
 
 void CtranTestHelpers::resetBackendsUsed(ICtran* ctran) {

--- a/comms/ctran/utils/PinnedHostPool.h
+++ b/comms/ctran/utils/PinnedHostPool.h
@@ -48,8 +48,10 @@ class PinnedHostPool {
     this->reclaim();
     if (this->inuseItems_.size()) {
       CLOGF(
-          INFO,
-          "CTRAN-GPE: Internal {} pool has {} inuse items, indicating same amount of unfinished kernel",
+          WARNING,
+          "CTRAN-GPE: Internal {} pool has {} inuse items at destruction. "
+          "In CUDA graph mode this indicates an async cmdDestroy race: "
+          "the graph was not fully destroyed before communicator teardown.",
           T::name(),
           this->inuseItems_.size());
     }


### PR DESCRIPTION
Summary:

Update some pools helpfull functions and add a test indicating a segfault problem happening with graph.

The problem is that in persistent mode we transfer ownership of OpElem to the graph so we can not control the moment when it's destroyed. As a result of comm is destroyed before graph we have segfault such that graph tries to access freed memory. Possible solution would be to wait in terminate command until graph is destroyed.

Change:
- Add numInUseGpeKernelSyncs() API to CtranGpe (matches existing
  numInUseKernelElems/Flags pattern)
- Extend verifyGpeLeak() and GraphCapture* spin-waits to cover all three
  pool types (was missing GpeKernelSyncs)
- Add TerminateWaitsForGpeKernelSyncPoolDrain: allocates GpeKernelSyncs,
  runs terminate() in a thread, asserts via future::wait_for that it blocks
  until elements are released — fails without the spin-wait fix
- Upgrade PinnedHostPool destructor log from INFO to WARNING with a note
  about the async cmdDestroy race

Reviewed By: saifhhasan

Differential Revision: D101082622
