### PR TITLE
Add DeviceWindow IBGDA integration test for ringDb

### DIFF
--- a/comms/pipes/P2pIbgdaTransportDevice.cuh
+++ b/comms/pipes/P2pIbgdaTransportDevice.cuh
@@ -96,16 +96,23 @@ class P2pIbgdaTransportDevice {
    * Performs an RDMA Write from local buffer to remote buffer.
    * Returns immediately with a work handle for optional completion tracking.
    *
+   * By default, rings the NIC doorbell after posting the WQE. Set
+   * ringDb=false to skip the doorbell for batching multiple puts.
+   * The caller must ensure the doorbell is rung afterward (e.g.,
+   * via a subsequent put(ringDb=true) or ring_doorbell()).
+   *
    * @param localBuf Source buffer in local GPU memory
    * @param remoteBuf Destination buffer in remote GPU memory
    * @param nbytes Number of bytes to transfer
+   * @param ringDb Whether to ring the NIC doorbell (default: true)
    *
    * @return IbgdaWork for tracking local completion via wait_local()
    */
   __device__ IbgdaWork
   put(const IbgdaLocalBuffer& localBuf,
       const IbgdaRemoteBuffer& remoteBuf,
-      std::size_t nbytes) {
+      std::size_t nbytes,
+      bool ringDb = true) {
     doca_gpu_dev_verbs_ticket_t ticket;
 
     doca_gpu_dev_verbs_addr localAddr = {
@@ -115,11 +122,14 @@ class P2pIbgdaTransportDevice {
         .addr = reinterpret_cast<uint64_t>(remoteBuf.ptr),
         .key = remoteBuf.rkey.value};
 
+    uint32_t code_opt = ringDb
+        ? DOCA_GPUNETIO_VERBS_GPU_CODE_OPT_DEFAULT
+        : DOCA_GPUNETIO_VERBS_GPU_CODE_OPT_SKIP_DB_RINGING;
     doca_gpu_dev_verbs_put<
         DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
         DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO,
         DOCA_GPUNETIO_VERBS_EXEC_SCOPE_THREAD>(
-        qp_, remoteAddr, localAddr, nbytes, &ticket);
+        qp_, remoteAddr, localAddr, nbytes, &ticket, code_opt);
 
     return IbgdaWork(ticket);
   }
@@ -142,6 +152,10 @@ class P2pIbgdaTransportDevice {
    * @param remoteBuf Destination buffer in remote GPU memory (this group's
    * chunk)
    * @param nbytes Number of bytes to transfer (partitioned across lanes)
+   * @param ringDb Whether to ring the NIC doorbell (default: true). Set to
+   *   false to batch with subsequent puts; caller must ensure the doorbell is
+   *   eventually rung via a later put(ringDb=true), signal_peer(), or
+   *   ring_doorbell().
    *
    * @return IbgdaWork for tracking local completion via wait_local() (per-lane)
    */
@@ -149,7 +163,8 @@ class P2pIbgdaTransportDevice {
       ThreadGroup& group,
       const IbgdaLocalBuffer& localBuf,
       const IbgdaRemoteBuffer& remoteBuf,
-      std::size_t nbytes) {
+      std::size_t nbytes,
+      bool ringDb = true) {
     std::size_t chunkSize = nbytes / group.group_size;
     std::size_t offset = group.thread_id_in_group * chunkSize;
     // Last thread picks up any remainder bytes
@@ -161,9 +176,9 @@ class P2pIbgdaTransportDevice {
     IbgdaRemoteBuffer laneRemoteBuf = remoteBuf.subBuffer(offset);
 
     if (group.group_size == 1) {
-      return put(laneBuf, laneRemoteBuf, laneBytes);
+      return put(laneBuf, laneRemoteBuf, laneBytes, ringDb);
     }
-    return put_group_impl(group, laneBuf, laneRemoteBuf, laneBytes);
+    return put_group_impl(group, laneBuf, laneRemoteBuf, laneBytes, ringDb);
   }
 
   /**
@@ -183,6 +198,10 @@ class P2pIbgdaTransportDevice {
    *   by all groups)
    * @param nbytes Total number of bytes to transfer (partitioned across groups,
    *   then across lanes within each group)
+   * @param ringDb Whether to ring the NIC doorbell (default: true). Set to
+   *   false to batch with subsequent puts; caller must ensure the doorbell is
+   *   eventually rung via a later put(ringDb=true), signal_peer(), or
+   *   ring_doorbell().
    *
    * @return IbgdaWork for tracking local completion via wait_local() (per-lane)
    */
@@ -190,7 +209,8 @@ class P2pIbgdaTransportDevice {
       ThreadGroup& group,
       const IbgdaLocalBuffer& localBuf,
       const IbgdaRemoteBuffer& remoteBuf,
-      std::size_t nbytes) {
+      std::size_t nbytes,
+      bool ringDb = true) {
     // Partition across groups; last group picks up remainder
     std::size_t chunkPerGroup = nbytes / group.total_groups;
     std::size_t groupOffset = group.group_id * chunkPerGroup;
@@ -201,7 +221,8 @@ class P2pIbgdaTransportDevice {
     IbgdaLocalBuffer groupLocalBuf = localBuf.subBuffer(groupOffset);
     IbgdaRemoteBuffer groupRemoteBuf = remoteBuf.subBuffer(groupOffset);
 
-    return put_group_local(group, groupLocalBuf, groupRemoteBuf, groupBytes);
+    return put_group_local(
+        group, groupLocalBuf, groupRemoteBuf, groupBytes, ringDb);
   }
 
   // ===========================================================================
@@ -754,6 +775,23 @@ class P2pIbgdaTransportDevice {
     return qp_;
   }
 
+  /**
+   * ring_doorbell - Ring doorbell for all pending WQEs up to lastWork
+   *
+   * Call after one or more put(..., ringDb=false) to notify the NIC of
+   * all pending WQEs in a single doorbell ring. Pass the IbgdaWork returned
+   * by the most recent put — the doorbell will cover that WQE and any
+   * earlier ones still pending.
+   *
+   * @param lastWork IbgdaWork returned by the last put(ringDb=false)
+   */
+  __device__ void ring_doorbell(IbgdaWork lastWork) {
+    doca_gpu_dev_verbs_submit<
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+        DOCA_GPUNETIO_VERBS_SYNC_SCOPE_GPU,
+        DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(qp_, lastWork.value + 1);
+  }
+
  private:
   /**
    * put_group_impl - Generic group-collaborative RDMA Write
@@ -772,6 +810,8 @@ class P2pIbgdaTransportDevice {
    * @param laneBuf Source buffer for this thread's chunk
    * @param laneRemoteBuf Destination buffer for this thread's chunk
    * @param laneBytes Number of bytes for this thread's chunk
+   * @param ringDb Whether to ring the NIC doorbell after submit (default:
+   * true)
    *
    * @return IbgdaWork for tracking local completion via wait_local()
    */
@@ -779,7 +819,8 @@ class P2pIbgdaTransportDevice {
       ThreadGroup& group,
       const IbgdaLocalBuffer& laneBuf,
       const IbgdaRemoteBuffer& laneRemoteBuf,
-      std::size_t laneBytes) {
+      std::size_t laneBytes,
+      bool ringDb = true) {
     // Guard: group_size must fit within the QP send queue depth.
     // The leader reserves group_size WQE slots atomically. If group_size
     // exceeds the QP ring buffer depth (sq_wqe_num), the DOCA backpressure
@@ -830,16 +871,19 @@ class P2pIbgdaTransportDevice {
     // 4. Sync — all WQEs prepared
     group.sync();
 
-    // 5. Leader marks ready and rings doorbell
+    // 5. Leader marks ready and rings doorbell (skipped if ringDb=false)
     if (group.is_leader()) {
       doca_gpu_dev_verbs_mark_wqes_ready<
           DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(
           qp_, base_wqe_idx, base_wqe_idx + group.group_size - 1);
+      uint32_t code_opt = ringDb
+          ? DOCA_GPUNETIO_VERBS_GPU_CODE_OPT_DEFAULT
+          : DOCA_GPUNETIO_VERBS_GPU_CODE_OPT_SKIP_DB_RINGING;
       doca_gpu_dev_verbs_submit<
           DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
           DOCA_GPUNETIO_VERBS_SYNC_SCOPE_GPU,
           DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(
-          qp_, base_wqe_idx + group.group_size);
+          qp_, base_wqe_idx + group.group_size, code_opt);
     }
 
     // 6. Sync — ensure submit done before threads proceed

--- a/comms/pipes/tests/DeviceWindowIbgdaIntegrationTest.cc
+++ b/comms/pipes/tests/DeviceWindowIbgdaIntegrationTest.cc
@@ -1,0 +1,152 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include <folly/init/Init.h>
+#include <folly/logging/xlog.h>
+
+#include <memory>
+#include <vector>
+
+#include "comms/pipes/MultiPeerTransport.h"
+#include "comms/pipes/TopologyDiscovery.h"
+#include "comms/pipes/tests/DeviceWindowIbgdaIntegrationTest.cuh"
+#include "comms/pipes/window/DeviceWindow.cuh"
+#include "comms/pipes/window/HostWindow.h"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/testinfra/mpi/MpiBootstrap.h"
+#include "comms/testinfra/mpi/MpiTestUtils.h"
+#include "comms/utils/CudaRAII.h"
+
+using meta::comms::DeviceBuffer;
+using meta::comms::MpiBaseTestFixture;
+using meta::comms::MpiBootstrap;
+using meta::comms::MPIEnvironmentBase;
+
+namespace comms::pipes::tests {
+
+// =============================================================================
+// Test Fixture: forces all peers to IBGDA via TopologyConfig{p2pDisable=true}
+// so DeviceWindow::put dispatches to the IBGDA path (and exercises ringDb).
+// =============================================================================
+
+class DeviceWindowIbgdaIntegrationTestFixture : public MpiBaseTestFixture {
+ protected:
+  void SetUp() override {
+    MpiBaseTestFixture::SetUp();
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+  }
+
+  void TearDown() override {
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    MpiBaseTestFixture::TearDown();
+  }
+
+  struct TransportBundle {
+    std::unique_ptr<MultiPeerTransport> transport;
+    std::unique_ptr<HostWindow> window;
+    DeviceWindow dw;
+  };
+
+  TransportBundle createIbgdaTransport(
+      const WindowConfig& wmConfig,
+      void* userBuffer,
+      std::size_t userBufferSize) {
+    MultiPeerTransportConfig config{
+        .topoConfig = TopologyConfig{.p2pDisable = true},
+        .ibgdaConfig = {.cudaDevice = localRank},
+    };
+    auto bootstrap = std::make_shared<MpiBootstrap>();
+    auto transport = std::make_unique<MultiPeerTransport>(
+        globalRank, numRanks, localRank, bootstrap, config);
+    transport->exchange();
+
+    auto window = std::make_unique<HostWindow>(
+        *transport, wmConfig, userBuffer, userBufferSize);
+    window->exchange();
+
+    DeviceWindow dw = window->getDeviceWindow();
+    return {std::move(transport), std::move(window), dw};
+  }
+};
+
+// =============================================================================
+// PutNoDbBatching — DeviceWindow::put(ringDb=false) + signal_peer
+// =============================================================================
+
+TEST_F(DeviceWindowIbgdaIntegrationTestFixture, PutNoDbBatching) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Requires exactly 2 ranks, got " << numRanks;
+  }
+
+  const std::size_t nbytes = 64 * 1024;
+  const int peerRank = (globalRank == 0) ? 1 : 0;
+  const uint8_t testPattern = 0x55;
+  const int signalId = 0;
+
+  try {
+    DeviceBuffer userBuffer(nbytes);
+    CUDACHECK_TEST(cudaMemset(userBuffer.get(), 0, nbytes));
+
+    WindowConfig wmConfig{.peerSignalCount = 1};
+    auto [transport, window, dw] =
+        createIbgdaTransport(wmConfig, userBuffer.get(), nbytes);
+
+    DeviceBuffer srcBuffer(nbytes);
+    auto lkey = window->registerLocalBuffer(srcBuffer.get(), nbytes);
+    ASSERT_TRUE(lkey.has_value())
+        << "registerLocalBuffer should succeed when IBGDA peers exist";
+    LocalBufferRegistration src{
+        .base = srcBuffer.get(),
+        .size = nbytes,
+        .lkey = *lkey,
+    };
+
+    if (globalRank == 0) {
+      std::vector<uint8_t> hostPattern(nbytes, testPattern);
+      CUDACHECK_TEST(cudaMemcpy(
+          srcBuffer.get(), hostPattern.data(), nbytes, cudaMemcpyHostToDevice));
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+      test::testDeviceWindowPutNoDbAndSignal(
+          dw, peerRank, src, nbytes, signalId);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    } else {
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+      test::testDeviceWindowWaitSignal(dw, signalId, /*expectedValue=*/1);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+      std::vector<uint8_t> hostBuf(nbytes);
+      CUDACHECK_TEST(cudaMemcpy(
+          hostBuf.data(), userBuffer.get(), nbytes, cudaMemcpyDeviceToHost));
+      std::size_t mismatches = 0;
+      for (auto b : hostBuf) {
+        if (b != testPattern) {
+          mismatches++;
+        }
+      }
+      EXPECT_EQ(mismatches, 0u)
+          << "DeviceWindow::put(ringDb=false) + signal_peer: " << mismatches
+          << " byte mismatches out of " << nbytes;
+    }
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+
+  XLOGF(
+      INFO, "Rank {}: DeviceWindow PutNoDbBatching test completed", globalRank);
+}
+
+} // namespace comms::pipes::tests
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new MPIEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/pipes/tests/DeviceWindowIbgdaIntegrationTest.cu
+++ b/comms/pipes/tests/DeviceWindowIbgdaIntegrationTest.cu
@@ -1,0 +1,72 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/tests/DeviceWindowIbgdaIntegrationTest.cuh"
+
+#include "comms/pipes/ThreadGroup.cuh"
+#include "comms/pipes/window/DeviceWindow.cuh"
+#include "comms/testinfra/TestXPlatUtils.h"
+
+namespace comms::pipes::test {
+
+// =============================================================================
+// Kernel: DeviceWindow put with ringDb=false + signal_peer
+//
+// dw.put(group, peer, ..., ringDb=false) prepares and marks the WQE ready
+// in the QP ring buffer but skips the submit step entirely (sq_wqe_pi not
+// advanced, NIC not notified). The subsequent dw.signal_peer() submits its
+// own WQE, which atomic_max's sq_wqe_pi past both WQEs and rings a single
+// doorbell — covering the held-back put and the signal in one ring.
+// =============================================================================
+
+__global__ void deviceWindowPutNoDbAndSignalKernel(
+    DeviceWindow dw,
+    int targetRank,
+    LocalBufferRegistration src,
+    std::size_t nbytes,
+    int signalId) {
+  auto group = make_block_group();
+  if (group.is_global_leader()) {
+    dw.put(
+        group,
+        targetRank,
+        /*dst_offset=*/0,
+        src,
+        /*src_offset=*/0,
+        nbytes,
+        /*ringDb=*/false);
+    dw.signal_peer(targetRank, signalId);
+  }
+}
+
+void testDeviceWindowPutNoDbAndSignal(
+    DeviceWindow& dw,
+    int targetRank,
+    LocalBufferRegistration src,
+    std::size_t nbytes,
+    int signalId) {
+  deviceWindowPutNoDbAndSignalKernel<<<1, 1>>>(
+      dw, targetRank, src, nbytes, signalId);
+  CUDACHECK_TEST(cudaGetLastError());
+}
+
+// =============================================================================
+// Kernel: Wait for aggregate signal via DeviceWindow::wait_signal
+// =============================================================================
+
+__global__ void deviceWindowWaitSignalKernel(
+    DeviceWindow dw,
+    int signalId,
+    uint64_t expectedValue) {
+  auto group = make_block_group();
+  dw.wait_signal(group, signalId, CmpOp::CMP_GE, expectedValue);
+}
+
+void testDeviceWindowWaitSignal(
+    DeviceWindow& dw,
+    int signalId,
+    uint64_t expectedValue) {
+  deviceWindowWaitSignalKernel<<<1, 32>>>(dw, signalId, expectedValue);
+  CUDACHECK_TEST(cudaGetLastError());
+}
+
+} // namespace comms::pipes::test

--- a/comms/pipes/tests/DeviceWindowIbgdaIntegrationTest.cuh
+++ b/comms/pipes/tests/DeviceWindowIbgdaIntegrationTest.cuh
@@ -1,0 +1,38 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "comms/pipes/window/DeviceWindow.cuh"
+
+namespace comms::pipes::test {
+
+/**
+ * Test kernel: DeviceWindow put with ringDb=false + signal_peer
+ *
+ * Sender posts dw.put(group, peer, ..., ringDb=false) which holds the WQE
+ * back without ringing the doorbell, then dw.signal_peer() rings the
+ * doorbell and submits both WQEs in a single batch — exercising the
+ * DeviceWindow → IBGDA put_group_global ringDb forwarding.
+ */
+void testDeviceWindowPutNoDbAndSignal(
+    DeviceWindow& dw,
+    int targetRank,
+    LocalBufferRegistration src,
+    std::size_t nbytes,
+    int signalId);
+
+/**
+ * Test kernel: Wait for a peer signal via DeviceWindow::wait_signal
+ *
+ * Receiver waits until the aggregate signal across all peers reaches
+ * expectedValue.
+ */
+void testDeviceWindowWaitSignal(
+    DeviceWindow& dw,
+    int signalId,
+    uint64_t expectedValue);
+
+} // namespace comms::pipes::test

--- a/comms/pipes/tests/MultipeerIbgdaTransportTest.cc
+++ b/comms/pipes/tests/MultipeerIbgdaTransportTest.cc
@@ -225,6 +225,102 @@ TEST_F(MultipeerIbgdaTransportTestFixture, PutSignalBasic) {
 }
 
 // =============================================================================
+// Put with ringDb=false + Signal — Verifies doorbell batching codepath
+//
+// Sender posts put(ringDb=false) to hold the WQE back, then signal_remote()
+// to ring the doorbell. Receiver waits for the signal and verifies the
+// data arrived — proving the held-back put was successfully batched into the
+// signal's doorbell ring on the same QP.
+// =============================================================================
+
+TEST_F(MultipeerIbgdaTransportTestFixture, PutNoDbBatching) {
+  if (numRanks != 2) {
+    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    return;
+  }
+
+  const std::size_t nbytes = 64 * 1024;
+  const int numBlocks = 1;
+  const int blockSize = 1;
+  const int peerRank = (globalRank == 0) ? 1 : 0;
+  const uint8_t testPattern = 0x55;
+
+  try {
+    auto transport = createTransport();
+
+    DeviceBuffer dataBuffer(nbytes);
+    auto localDataBuf = transport->registerBuffer(dataBuffer.get(), nbytes);
+    auto remoteDataBufs = transport->exchangeBuffer(localDataBuf);
+    int peerIndex = (peerRank < globalRank) ? peerRank : (peerRank - 1);
+    auto remoteDataBuf = remoteDataBufs[peerIndex];
+
+    const std::size_t signalBufSize = sizeof(uint64_t);
+    DeviceBuffer signalBuffer(signalBufSize);
+    CUDACHECK_TEST(cudaMemset(signalBuffer.get(), 0, signalBufSize));
+    auto localSignalBuf =
+        transport->registerBuffer(signalBuffer.get(), signalBufSize);
+    auto remoteSignalBufs = transport->exchangeBuffer(localSignalBuf);
+    auto remoteSignalBuf = remoteSignalBufs[peerIndex];
+
+    P2pIbgdaTransportDevice* peerTransportPtr =
+        transport->getP2pTransportDevice(peerRank);
+
+    if (globalRank == 0) {
+      test::fillBufferWithPattern(
+          localDataBuf.ptr, nbytes, testPattern, numBlocks, blockSize);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+      test::testPutNoDbAndSignal(
+          peerTransportPtr,
+          localDataBuf,
+          remoteDataBuf,
+          nbytes,
+          remoteSignalBuf,
+          0,
+          1,
+          numBlocks,
+          blockSize);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    } else {
+      CUDACHECK_TEST(cudaMemset(localDataBuf.ptr, 0, nbytes));
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+      test::testWaitSignal(
+          static_cast<uint64_t*>(signalBuffer.get()),
+          0,
+          1,
+          numBlocks,
+          blockSize);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+      DeviceBuffer errorCountBuf(sizeof(int));
+      auto* d_errorCount = static_cast<int*>(errorCountBuf.get());
+      CUDACHECK_TEST(cudaMemset(d_errorCount, 0, sizeof(int)));
+      test::verifyBufferPattern(
+          localDataBuf.ptr,
+          nbytes,
+          testPattern,
+          d_errorCount,
+          numBlocks,
+          blockSize);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+
+      int h_errorCount = 0;
+      CUDACHECK_TEST(cudaMemcpy(
+          &h_errorCount, d_errorCount, sizeof(int), cudaMemcpyDeviceToHost));
+      EXPECT_EQ(h_errorCount, 0) << "put(ringDb=false): " << h_errorCount
+                                 << " byte mismatches out of " << nbytes;
+    }
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+}
+
+// =============================================================================
 // Group-Level Put/Signal Basic Test - Verifies group-collaborative RDMA
 // =============================================================================
 

--- a/comms/pipes/tests/MultipeerIbgdaTransportTest.cu
+++ b/comms/pipes/tests/MultipeerIbgdaTransportTest.cu
@@ -55,6 +55,55 @@ void testPutAndSignal(
 }
 
 // =============================================================================
+// Kernel: Put with ringDb=false + signal_remote (doorbell batching)
+//
+// put(ringDb=false) prepares and marks the WQE ready in the QP ring buffer,
+// but skips the submit step entirely — the local sq_wqe_pi is not advanced
+// and the NIC is never notified. The subsequent signal_remote() submits its
+// own WQE, which atomic_max's sq_wqe_pi past both WQEs and rings a single
+// doorbell — covering the held-back put and the signal in one ring.
+// =============================================================================
+
+__global__ void putNoDbAndSignalKernel(
+    P2pIbgdaTransportDevice* transport,
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    std::size_t nbytes,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    int signalId,
+    uint64_t signalVal) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    transport->put(localBuf, remoteBuf, nbytes, /*ringDb=*/false);
+    transport->signal_remote(remoteSignalBuf, signalId, signalVal);
+  }
+}
+
+void testPutNoDbAndSignal(
+    P2pIbgdaTransportDevice* deviceTransportPtr,
+    const IbgdaLocalBuffer& localBuf,
+    const IbgdaRemoteBuffer& remoteBuf,
+    std::size_t nbytes,
+    const IbgdaRemoteBuffer& remoteSignalBuf,
+    int signalId,
+    uint64_t signalVal,
+    int numBlocks,
+    int blockSize) {
+  putNoDbAndSignalKernel<<<numBlocks, blockSize>>>(
+      deviceTransportPtr,
+      localBuf,
+      remoteBuf,
+      nbytes,
+      remoteSignalBuf,
+      signalId,
+      signalVal);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("Kernel launch failed: ") + cudaGetErrorString(err));
+  }
+}
+
+// =============================================================================
 // Kernel: Group-collaborative put + signal (warp group)
 // =============================================================================
 

--- a/comms/pipes/tests/MultipeerIbgdaTransportTest.h
+++ b/comms/pipes/tests/MultipeerIbgdaTransportTest.h
@@ -362,6 +362,23 @@ void testPutSignalCounter(
     int blockSize);
 
 /**
+ * Test kernel: Put with ringDb=false + signal_remote (doorbell batching)
+ *
+ * put(ringDb=false) posts the WQE without ringing; the subsequent
+ * signal_remote() rings the doorbell and submits both WQEs in one batch.
+ */
+void testPutNoDbAndSignal(
+    P2pIbgdaTransportDevice* deviceTransportPtr,
+    const IbgdaLocalBuffer& localBuf,
+    const IbgdaRemoteBuffer& remoteBuf,
+    std::size_t nbytes,
+    const IbgdaRemoteBuffer& remoteSignalBuf,
+    int signalId,
+    uint64_t signalVal,
+    int numBlocks,
+    int blockSize);
+
+/**
  * Test kernel: Wait for local counter to reach expected value
  *
  * GPU thread spins on volatile counter until it reaches expectedVal.

--- a/comms/pipes/window/DeviceWindow.cuh
+++ b/comms/pipes/window/DeviceWindow.cuh
@@ -956,12 +956,18 @@ class DeviceWindow {
    * constructor). Source is a registered buffer (from
    * HostWindow::registerLocalBuffer).
    *
+   * By default, rings the NIC doorbell after posting the WQE. Set
+   * ringDb=false to skip the doorbell for batching multiple puts.
+   * The caller must ensure the doorbell is rung afterward (e.g.,
+   * via a subsequent put(ringDb=true) or signal_peer()).
+   *
    * @param group        ThreadGroup for group coordination.
    * @param target_rank  Rank to put to (must not be self).
    * @param dst_offset   Byte offset into the target peer's window buffer.
    * @param src_buf      Registered source buffer.
    * @param src_offset   Byte offset into the source buffer.
    * @param nbytes       Number of bytes to transfer.
+   * @param ringDb      Whether to ring the NIC doorbell (default: true).
    */
   __device__ __forceinline__ void put(
       ThreadGroup& group,
@@ -969,7 +975,8 @@ class DeviceWindow {
       std::size_t dst_offset,
       const LocalBufferRegistration& src_buf,
       std::size_t src_offset,
-      std::size_t nbytes) {
+      std::size_t nbytes,
+      bool ringDb = true) {
     DEVICE_WINDOW_CHECK_RANK(target_rank, handle_.nRanks);
     DEVICE_WINDOW_CHECK_NOT_SELF(target_rank, handle_.myRank);
     const auto* localSrc = static_cast<const char*>(src_buf.base) + src_offset;
@@ -987,7 +994,7 @@ class DeviceWindow {
           remoteBufferRegistry_[ibgdaPeerIdx].rkey);
       handle_.get_ibgda(target_rank)
           .put_group_global(
-              group, localBuf, remoteBuf.subBuffer(dst_offset), nbytes);
+              group, localBuf, remoteBuf.subBuffer(dst_offset), nbytes, ringDb);
     }
   }
 


### PR DESCRIPTION
Summary:
Adds DeviceWindowIbgdaIntegrationTest to cover the DeviceWindow::put(ringDb=false) → put_group_global path on IBGDA. The transport-level test PutNoDbBatching (D101080964) exercises put_group_global directly; this test ensures the DeviceWindow wrapper correctly forwards the ringDb argument when dispatching to IBGDA.

Same-node peers default to NVL transport, which would bypass ringDb entirely. To force the IBGDA path, the test fixture builds the MultiPeerTransport with TopologyConfig{p2pDisable=true} (mirror of NCCL_P2P_DISABLE=1) — this skips both Tier 1 (MNNVL) and Tier 2 (same-host P2P) detection so all peers fall through to IBGDA.

Test flow (2 ranks):
- Sender posts dw.put(group, peer, ..., ringDb=false) holding the WQE in the QP, then dw.signal_peer() rings the doorbell — submitting both put and signal in one batch.
- Receiver waits via dw.wait_signal and verifies the userBuffer contents match the sender's pattern.

Differential Revision: D101237531


