### PR TITLE
adjust per-event poll timeout (#2115)

### DIFF
--- a/comms/ctran/colltrace/CollTraceWrapper.cc
+++ b/comms/ctran/colltrace/CollTraceWrapper.cc
@@ -370,6 +370,7 @@ bool isP2PKernel(KernelConfig::KernelType kernelType) {
       KernelConfig::KernelType::SENDRECV,
       KernelConfig::KernelType::RECV_UNPACK,
       KernelConfig::KernelType::SENDRECV_UNPACK,
+      KernelConfig::KernelType::SENDRECV_P2P,
   };
 
   return p2pKernels.contains(kernelType);

--- a/comms/ctran/tests/CtranDistAllReduceTest.cc
+++ b/comms/ctran/tests/CtranDistAllReduceTest.cc
@@ -199,7 +199,7 @@ class CtranAllReduceTest : public ctran::CtranDistTestFixture,
 
     CUDACHECK_TEST(cudaDeviceSynchronize());
     // Sleep for a while to make sure all the colls are finished
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    std::this_thread::sleep_for(std::chrono::seconds(2));
 
     ASSERT_NE(ctranComm->colltraceNew_, nullptr);
     auto dumpMap = ctran::dumpCollTrace(ctranComm.get());

--- a/comms/ctran/tests/CtranDistAllgatherTests.cc
+++ b/comms/ctran/tests/CtranDistAllgatherTests.cc
@@ -228,7 +228,7 @@ TEST_P(CtranAllgatherTestParam, AllgatherAlgo) {
 
   CUDACHECK_TEST(cudaDeviceSynchronize());
   // Sleep for a while to make sure all the colls are finished
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  std::this_thread::sleep_for(std::chrono::seconds(2));
 
   ASSERT_NE(ctranComm->colltraceNew_, nullptr);
   auto dumpMap = ctran::dumpCollTrace(ctranComm.get());
@@ -466,7 +466,7 @@ TEST_P(CtranSocketAllgatherTestParam, AllgatherAlgo) {
 
   CUDACHECK_TEST(cudaDeviceSynchronize());
   // Sleep for a while to make sure all the colls are finished
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  std::this_thread::sleep_for(std::chrono::seconds(2));
 
   ASSERT_NE(ctranComm->colltraceNew_, nullptr);
   auto dumpMap = ctran::dumpCollTrace(ctranComm.get());

--- a/comms/ctran/tests/CtranDistAlltoAllDedupTest.cc
+++ b/comms/ctran/tests/CtranDistAlltoAllDedupTest.cc
@@ -194,7 +194,7 @@ class ctranAllToAllDedupTest : public ctran::CtranDistTestFixture,
 
     CUDACHECK_TEST(cudaDeviceSynchronize());
     // Sleep for a while to make sure all the colls are finished
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    std::this_thread::sleep_for(std::chrono::seconds(2));
 
     ASSERT_NE(ctranComm->colltraceNew_, nullptr);
     auto dumpMap = ctran::dumpCollTrace(ctranComm.get());

--- a/comms/ctran/tests/CtranDistAlltoAllPTest.cc
+++ b/comms/ctran/tests/CtranDistAlltoAllPTest.cc
@@ -135,7 +135,7 @@ class ctranAllToAllPTest : public ctran::CtranDistTestFixture,
     CUDACHECK_TEST(cudaDeviceSynchronize());
 
     // Verify colltrace records the AllToAllP operations
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    std::this_thread::sleep_for(std::chrono::seconds(2));
     ASSERT_NE(ctranComm->colltraceNew_, nullptr);
     auto dumpMap = ctran::dumpCollTrace(ctranComm.get());
     EXPECT_NE(dumpMap["CT_pastColls"], "[]");

--- a/comms/ctran/tests/CtranDistAlltoAllTest.cc
+++ b/comms/ctran/tests/CtranDistAlltoAllTest.cc
@@ -206,7 +206,7 @@ class CtranAllToAllTest : public ctran::CtranDistTestFixture,
 
     CUDACHECK_TEST(cudaDeviceSynchronize());
     // Sleep for a while to make sure all the colls are finished
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    std::this_thread::sleep_for(std::chrono::seconds(2));
 
     ASSERT_NE(ctranComm->colltraceNew_, nullptr);
     auto dumpMap = ctran::dumpCollTrace(ctranComm.get());

--- a/comms/ctran/tests/CtranDistAlltoAllvTest.cc
+++ b/comms/ctran/tests/CtranDistAlltoAllvTest.cc
@@ -146,7 +146,7 @@ class ctranAllToAllvTest : public ctran::CtranDistTestFixture,
     CUDACHECK_TEST(cudaDeviceSynchronize());
 
     // Verify colltrace records the AllToAllv operation
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    std::this_thread::sleep_for(std::chrono::seconds(2));
     ASSERT_NE(ctranComm->colltraceNew_, nullptr);
     auto dumpMap = ctran::dumpCollTrace(ctranComm.get());
     EXPECT_NE(dumpMap["CT_pastColls"], "[]");

--- a/comms/ctran/tests/CtranDistBroadcastTests.cc
+++ b/comms/ctran/tests/CtranDistBroadcastTests.cc
@@ -149,7 +149,7 @@ TEST_P(CtranTestBroadcastFixture, Broadcast) {
 
   CUDACHECK_TEST(cudaDeviceSynchronize());
   // Sleep for a while to make sure all the colls are finished
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  std::this_thread::sleep_for(std::chrono::seconds(2));
 
   ASSERT_NE(ctranComm->colltraceNew_, nullptr);
   auto dumpMap = ctran::dumpCollTrace(ctranComm.get());

--- a/comms/ctran/tests/CtranDistReduceScatterTest.cc
+++ b/comms/ctran/tests/CtranDistReduceScatterTest.cc
@@ -212,7 +212,7 @@ class CtranReduceScatterTest : public ctran::CtranDistTestFixture,
 
     CUDACHECK_TEST(cudaDeviceSynchronize());
     // Sleep for a while to make sure all the colls are finished
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    std::this_thread::sleep_for(std::chrono::seconds(2));
 
     ASSERT_NE(ctranComm->colltraceNew_, nullptr);
     auto dumpMap = ctran::dumpCollTrace(ctranComm.get());

--- a/comms/ctran/tests/CtranDistSendRecvUT.cc
+++ b/comms/ctran/tests/CtranDistSendRecvUT.cc
@@ -277,7 +277,7 @@ class CtranTestFixture : public ctran::CtranDistTestFixture,
 
     if (!useGraph) {
       // Brief wait for GPE thread to flush colltrace entries after stream sync
-      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      std::this_thread::sleep_for(std::chrono::seconds(2));
 
       // Check the coll trace only for participating ranks
       bool participated = (globalRank == sendRank) || isReceiver;

--- a/comms/ncclx/meta/colltrace/tests/DumpNewColltraceUT.cc
+++ b/comms/ncclx/meta/colltrace/tests/DumpNewColltraceUT.cc
@@ -85,7 +85,7 @@ TEST(DumpNewCollTraceUT, dumpNewCollTraceWithCollectives) {
                   .hasValue());
 
   // Sleep briefly to allow the CollTrace thread to process the events
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  std::this_thread::sleep_for(std::chrono::seconds(2));
 
   // At this point, the collective should be in the pending state. However,
   // since currently we will treat the first pending collective as the current
@@ -106,7 +106,7 @@ TEST(DumpNewCollTraceUT, dumpNewCollTraceWithCollectives) {
       handle->trigger(CollTraceHandleTriggerState::KernelStarted).hasValue());
 
   // Sleep briefly to allow the CollTrace thread to process the events
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  std::this_thread::sleep_for(std::chrono::seconds(2));
 
   // Now the collective should be in the current state
   auto dumpMapCurrent = dumpNewCollTrace(*collTrace);
@@ -122,7 +122,7 @@ TEST(DumpNewCollTraceUT, dumpNewCollTraceWithCollectives) {
       handle->trigger(CollTraceHandleTriggerState::KernelFinished).hasValue());
 
   // Sleep briefly to allow the CollTrace thread to process the events
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  std::this_thread::sleep_for(std::chrono::seconds(2));
 
   // Now the collective should be in the past state
   auto dumpMapPast = dumpNewCollTrace(*collTrace);
@@ -167,7 +167,7 @@ TEST(DumpNewCollTraceUT, dumpNewCollTraceMultipleCollectives) {
                     .hasValue());
 
     // Sleep briefly to allow the CollTrace thread to process the events
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    std::this_thread::sleep_for(std::chrono::seconds(2));
   }
 
   // Start second collective but don't finish it
@@ -189,7 +189,7 @@ TEST(DumpNewCollTraceUT, dumpNewCollTraceMultipleCollectives) {
     // Don't trigger KernelFinished
 
     // Sleep briefly to allow the CollTrace thread to process the events
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    std::this_thread::sleep_for(std::chrono::seconds(2));
   }
 
   // Enqueue third collective but don't start it
@@ -209,7 +209,7 @@ TEST(DumpNewCollTraceUT, dumpNewCollTraceMultipleCollectives) {
     // Don't trigger KernelStarted
 
     // Sleep briefly to allow the CollTrace thread to process the events
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    std::this_thread::sleep_for(std::chrono::seconds(2));
   }
 
   // Dump the state and verify

--- a/comms/ncclx/meta/colltrace/tests/NewCollTraceDistTestLocal.cc
+++ b/comms/ncclx/meta/colltrace/tests/NewCollTraceDistTestLocal.cc
@@ -149,7 +149,7 @@ TEST_F(CollTraceTestLocal, winSignal) {
   EXPECT_EQ(res, ncclSuccess);
 
   CUDACHECK_TEST(cudaDeviceSynchronize());
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  std::this_thread::sleep_for(std::chrono::seconds(2));
   auto dumpMap =
       meta::comms::ncclx::dumpNewCollTrace(*comm->ctranComm_->colltraceNew_);
   EXPECT_NE(dumpMap["CT_pastColls"], "[]");
@@ -240,7 +240,7 @@ TEST_F(CollTraceTestLocal, winPutOnly) {
   ASSERT_EQ(ncclMemFree(localBuf), ncclSuccess);
 
   cudaDeviceSynchronize();
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  std::this_thread::sleep_for(std::chrono::seconds(2));
   auto dumpMap =
       meta::comms::ncclx::dumpNewCollTrace(*comm->ctranComm_->colltraceNew_);
   EXPECT_NE(dumpMap["CT_pastColls"], "[]");

--- a/comms/ncclx/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
+++ b/comms/ncclx/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
@@ -177,7 +177,7 @@ TEST_F(CollTraceTest, NewCollTraceAllReduce) {
   }
   CUDACHECK_TEST(cudaStreamSynchronize(stream));
   // Sleep for a while to make sure all the colls are finished
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  std::this_thread::sleep_for(std::chrono::seconds(2));
 
   ASSERT_TRUE(comm->newCollTrace != nullptr);
   auto dumpMap = meta::comms::ncclx::dumpNewCollTrace(*comm->newCollTrace);
@@ -223,7 +223,7 @@ TEST_F(CollTraceTest, MixedCtranBaseline) {
   }
   CUDACHECK_TEST(cudaStreamSynchronize(stream));
   // Sleep for a while to make sure all the colls are finished
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  std::this_thread::sleep_for(std::chrono::seconds(2));
 
   ASSERT_TRUE(comm->newCollTrace != nullptr);
   auto dumpMap = meta::comms::ncclx::dumpNewCollTrace(*comm->newCollTrace);
@@ -288,7 +288,7 @@ TEST_F(CollTraceTest, TestBcastCtranEx) {
   }
 
   // Sleep for a while to make sure all the colls are finished
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  std::this_thread::sleep_for(std::chrono::seconds(2));
 
   auto startOpCount = 0;
   auto dumpMap =
@@ -342,7 +342,7 @@ TEST_F(CollTraceTest, GroupedSendRecv) {
     NCCLCHECK_TEST(ncclGroupEnd());
   }
   CUDACHECK_TEST(cudaStreamSynchronize(stream));
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  std::this_thread::sleep_for(std::chrono::seconds(2));
 
   auto dumpMap = meta::comms::ncclx::dumpNewCollTrace(*comm->newCollTrace);
   EXPECT_EQ(folly::parseJson(dumpMap["CT_pendingColls"]).size(), 0);
@@ -401,7 +401,7 @@ TEST_F(CollTraceTest, GroupedSendRecvCtran) {
     NCCLCHECK_TEST(ncclGroupEnd());
   }
   CUDACHECK_TEST(cudaStreamSynchronize(stream));
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  std::this_thread::sleep_for(std::chrono::seconds(2));
 
   auto dumpMap = meta::comms::ncclx::dumpNewCollTrace(*comm->newCollTrace);
   EXPECT_EQ(folly::parseJson(dumpMap["CT_pendingColls"]).size(), 0);
@@ -454,7 +454,7 @@ TEST_F(CollTraceTest, SimulatePPSendRecv) {
     }
   }
   CUDACHECK_TEST(cudaStreamSynchronize(stream));
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  std::this_thread::sleep_for(std::chrono::seconds(2));
 
   auto dumpMap = meta::comms::ncclx::dumpNewCollTrace(*comm->newCollTrace);
   EXPECT_EQ(folly::parseJson(dumpMap["CT_pendingColls"]).size(), 0);
@@ -525,7 +525,7 @@ TEST_F(CollTraceTest, SimulateCtranPPSendRecv) {
   }
   CUDACHECK_TEST(cudaStreamSynchronize(stream));
   CUDACHECK_TEST(cudaStreamSynchronize(stream));
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  std::this_thread::sleep_for(std::chrono::seconds(2));
 
   auto dumpMap = meta::comms::ncclx::dumpNewCollTrace(*comm->newCollTrace);
   EXPECT_EQ(folly::parseJson(dumpMap["CT_pendingColls"]).size(), 0);
@@ -657,7 +657,7 @@ TEST_F(CollTraceTest, winPutWait) {
   // Barrier to ensure all peers have finished put
   this->barrier();
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  std::this_thread::sleep_for(std::chrono::seconds(2));
 
   auto dumpMap = meta::comms::ncclx::dumpNewCollTrace(*comm->newCollTrace);
 
@@ -711,7 +711,7 @@ TEST_F(CollTraceTest, DumpWithUnfinished) {
   }
 
   CUDACHECK_TEST(cudaStreamSynchronize(stream));
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  std::this_thread::sleep_for(std::chrono::seconds(2));
 
   // Create a kernel that will block the stream, so that all the following
   // scheduled collective will be pending
@@ -725,7 +725,7 @@ TEST_F(CollTraceTest, DumpWithUnfinished) {
   }
 
   // Give CollTrace some time to start tracking next coll
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  std::this_thread::sleep_for(std::chrono::seconds(2));
 
   auto dumpMap = meta::comms::ncclx::dumpNewCollTrace(*comm->newCollTrace);
 
@@ -767,7 +767,7 @@ TEST_F(CollTraceTest, DumpWithUnfinishedCtran) {
   }
 
   CUDACHECK_TEST(cudaStreamSynchronize(stream));
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  std::this_thread::sleep_for(std::chrono::seconds(2));
 
   // Create a kernel that will block the stream, so that all the following
   // scheduled collective will be pending
@@ -781,7 +781,7 @@ TEST_F(CollTraceTest, DumpWithUnfinishedCtran) {
   }
 
   // Give CollTrace some time to start tracking next coll and exited wait once
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  std::this_thread::sleep_for(std::chrono::seconds(2));
 
   auto dumpMap = meta::comms::ncclx::dumpNewCollTrace(*comm->newCollTrace);
 
@@ -827,7 +827,7 @@ TEST_F(CollTraceTest, GroupedAllReduce) {
   }
   CUDACHECK_TEST(cudaStreamSynchronize(stream));
   // Sleep for a while to make sure all the colls are finished
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  std::this_thread::sleep_for(std::chrono::seconds(2));
 
   ASSERT_TRUE(comm->newCollTrace != nullptr);
   auto dumpMap = meta::comms::ncclx::dumpNewCollTrace(*comm->newCollTrace);
@@ -871,7 +871,7 @@ TEST_F(CollTraceTest, GroupedSendRecvAllReduce) {
     NCCLCHECK_TEST(ncclGroupEnd());
   }
   CUDACHECK_TEST(cudaStreamSynchronize(stream));
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  std::this_thread::sleep_for(std::chrono::seconds(2));
 
   ASSERT_TRUE(comm->newCollTrace != nullptr);
   auto dumpMap = meta::comms::ncclx::dumpNewCollTrace(*comm->newCollTrace);
@@ -901,7 +901,7 @@ TEST_F(CollTraceTest, CollTraceQueryInCapture) {
   CUDACHECK_TEST(cudaStreamBeginCapture(
       stream, cudaStreamCaptureMode::cudaStreamCaptureModeGlobal));
   // Sleep for a while to make sure all the colls are finished
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  std::this_thread::sleep_for(std::chrono::seconds(2));
   cudaGraph_t graph;
   CUDACHECK_TEST(cudaStreamEndCapture(stream, &graph));
 

--- a/comms/ncclx/meta/colltrace/tests/NewCollTraceUT.cc
+++ b/comms/ncclx/meta/colltrace/tests/NewCollTraceUT.cc
@@ -95,7 +95,7 @@ TEST_F(NewCollTraceUT, dumpNewCollTraceWithCollectives) {
                   .hasValue());
 
   // Sleep briefly to allow the CollTrace thread to process the events
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  std::this_thread::sleep_for(std::chrono::seconds(2));
 
   // At this point, the collective should be in the pending state. However,
   // since currently we will treat the first pending collective as the current
@@ -113,7 +113,7 @@ TEST_F(NewCollTraceUT, dumpNewCollTraceWithCollectives) {
       handle->trigger(CollTraceHandleTriggerState::KernelStarted).hasValue());
 
   // Sleep briefly to allow the CollTrace thread to process the events
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  std::this_thread::sleep_for(std::chrono::seconds(2));
 
   // Now the collective should be in the current state
   auto dumpMapCurrent = dumpNewCollTrace(*collTrace);
@@ -129,7 +129,7 @@ TEST_F(NewCollTraceUT, dumpNewCollTraceWithCollectives) {
       handle->trigger(CollTraceHandleTriggerState::KernelFinished).hasValue());
 
   // Sleep briefly to allow the CollTrace thread to process the events
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  std::this_thread::sleep_for(std::chrono::seconds(2));
 
   // Now the collective should be in the past state
   auto dumpMapPast = dumpNewCollTrace(*collTrace);

--- a/comms/utils/colltrace/CollTrace.cc
+++ b/comms/utils/colltrace/CollTrace.cc
@@ -504,6 +504,7 @@ void CollTrace::pollEagerEvents(
   }
 
   static constexpr auto kEpoch = ICollWaitEvent::system_clock_time_point{};
+  static constexpr auto kPollTimeout = std::chrono::milliseconds(10);
 
   for (auto& event : eagerEvents_) {
     if (event == nullptr) {
@@ -515,8 +516,7 @@ void CollTrace::pollEagerEvents(
     bool ended = timing.getCollEndTs() != kEpoch;
 
     if (!started) {
-      if (event->waitEvent->waitCollStart(config_.maxCheckCancelInterval)
-              .value_or(false)) {
+      if (event->waitEvent->waitCollStart(kPollTimeout).value_or(false)) {
         auto now = std::chrono::system_clock::now();
         auto startTimeRes = event->waitEvent->getCollStartTime();
         auto startTs = startTimeRes.hasValue() ? startTimeRes.value() : now;
@@ -534,8 +534,7 @@ void CollTrace::pollEagerEvents(
     }
 
     if (started && !ended) {
-      if (event->waitEvent->waitCollEnd(config_.maxCheckCancelInterval)
-              .value_or(false)) {
+      if (event->waitEvent->waitCollEnd(kPollTimeout).value_or(false)) {
         auto now = std::chrono::system_clock::now();
         auto endTimeRes = event->waitEvent->getCollEndTime();
         auto endTs = endTimeRes.hasValue() ? endTimeRes.value() : now;

--- a/comms/utils/colltrace/CollTrace.cc
+++ b/comms/utils/colltrace/CollTrace.cc
@@ -12,6 +12,7 @@
 #include <cuda_runtime.h> // @manual=third-party//cuda:cuda-lazy
 
 #include "comms/utils/CommsMaybeChecks.h"
+#include "comms/utils/checks.h"
 #include "comms/utils/colltrace/GpuClockCalibration.h"
 #include "comms/utils/colltrace/GraphCollTraceHandle.h"
 #include "comms/utils/colltrace/GraphCollTraceState.h"
@@ -191,8 +192,10 @@ std::shared_ptr<GraphCollTraceState> CollTrace::getOrCreateGraphState(
   auto retainRes =
       cudaGraphRetainUserObject(graph, userObject, 1, cudaGraphUserObjectMove);
   if (retainRes != cudaSuccess) {
-    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-    cudaUserObjectRelease(userObject, 1);
+    CUDA_CHECK_WITH_IGNORE(
+        cudaUserObjectRelease(userObject, 1),
+        cudaErrorCudartUnloading,
+        cudaErrorContextIsDestroyed);
     XLOG_FIRST_N(WARN, 1) << "Failed to retain graph user object: "
                           << cudaGetErrorString(retainRes);
     return nullptr;

--- a/comms/utils/colltrace/GraphCudaWaitEvent.cc
+++ b/comms/utils/colltrace/GraphCudaWaitEvent.cc
@@ -33,12 +33,16 @@ GraphCudaWaitEvent::GraphCudaWaitEvent(cudaStream_t stream, uint32_t collId)
 
 GraphCudaWaitEvent::~GraphCudaWaitEvent() {
   if (timestampStream_) {
-    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-    cudaStreamDestroy(timestampStream_);
+    CUDA_CHECK_WITH_IGNORE(
+        cudaStreamDestroy(timestampStream_),
+        cudaErrorCudartUnloading,
+        cudaErrorContextIsDestroyed);
   }
   if (depEvent_) {
-    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-    cudaEventDestroy(depEvent_);
+    CUDA_CHECK_WITH_IGNORE(
+        cudaEventDestroy(depEvent_),
+        cudaErrorCudartUnloading,
+        cudaErrorContextIsDestroyed);
   }
 }
 


### PR DESCRIPTION
Summary:

it's possible that our first polling iteration, which is followed by a 1s sleep, doesn't flush out all of the events. we must account for this in the tests, which only wait 100ms.

alternatively, we could reduce the inter-poll timeout, but i think this is fine for now, although i think sleeping in generally bad practice.

a separate but necessary change which i've done here is modif the inter-event query timeout to be separate from inter-poll one. if we have N in-flight collectives, each of them (i think only if they are cpu) could wait for 1s until they are considered to "not have any updates" , which isn't great. let's just do a small static timeout instead...

Reviewed By: lilyjanjigian

Differential Revision: D101193983


