### PR TITLE
Add divisibility check for AllGatherP pipeline algorithm (#2119)

### DIFF
--- a/comms/ctran/algos/AllGatherP/PipelineImpl.cc
+++ b/comms/ctran/algos/AllGatherP/PipelineImpl.cc
@@ -143,6 +143,19 @@ commResult_t AlgoImpl::execPipeline(
   const auto myRank = statex->rank();
   const auto nNodes = statex->nNodes();
 
+  if (nLocalRanks > 1 && nRanks % nLocalRanks != 0) {
+    FB_ERRORRETURN(
+        commInvalidUsage,
+        "AllGatherP pipeline requires nRanks ({}) to be evenly divisible by "
+        "nLocalRanks ({}), nNodes={}, nvlFabricEnabled={}, "
+        "nvlFabricCliqueEnabled={}",
+        nRanks,
+        nLocalRanks,
+        nNodes,
+        statex->nvlFabricEnabled(),
+        statex->nvlFabricCliqueEnabled());
+  }
+
   CTRAN_COLL_INFO(
       AlgoImpl::algoName(myAlgo),
       sendbuff,


### PR DESCRIPTION
Summary:

The AllGatherP pipeline algorithm requires nRanks to be evenly divisible by nLocalRanks. When this invariant is violated (e.g., when the physical MNNVL domain size is 6 and the communicator has 32 ranks), the ring-based pipeline produces incorrect results and can cause IBV_WC_REM_ACCESS_ERR (status=10) or IBV_WC_LOC_PROT_ERR (status=4) on IB RDMA operations.

This was the root cause of AllGatherP failures reported by NCCLX users on GB200_HP (KCM2 cluster) where the physical NVLink domain had cliqueSize=6. With nRanks=32 and nLocalRanks=6, the pipeline ring step of 6 does not evenly partition 32 ranks, causing:
1. The ring to not visit all nodes in nNodes-1 steps
2. Potential data corruption from misaligned buffer offsets
3. IB RDMA errors from concurrent access violations

The fix adds a validation check at the start of execPipeline that returns commInvalidUsage with an actionable error message. The check only applies to the pipeline algorithm (ctpipeline), not the direct algorithm (ctdirect).

Non-power-of-2 MNNVL domain sizes (6, 10, 52) have been observed on GB200 (KCM2, VCN5) and GB300 (MWG2) clusters where racks have varying numbers of GPU trays per NVLink switch chassis.

Reviewed By: minsii

Differential Revision: D101229005


