### PR TITLE
Fix colltrace for SENDRECV_P2P and drain timing in tests (#2124)

### DIFF
--- a/comms/ctran/colltrace/CollTraceWrapper.cc
+++ b/comms/ctran/colltrace/CollTraceWrapper.cc
@@ -368,6 +368,7 @@ bool isP2PKernel(KernelConfig::KernelType kernelType) {
       KernelConfig::KernelType::SEND,
       KernelConfig::KernelType::RECV,
       KernelConfig::KernelType::SENDRECV,
+      KernelConfig::KernelType::SENDRECV_P2P,
       KernelConfig::KernelType::RECV_UNPACK,
       KernelConfig::KernelType::SENDRECV_UNPACK,
       KernelConfig::KernelType::SENDRECV_P2P,

--- a/comms/ctran/tests/CtranDistAlltoAllTest.cc
+++ b/comms/ctran/tests/CtranDistAlltoAllTest.cc
@@ -205,11 +205,9 @@ class CtranAllToAllTest : public ctran::CtranDistTestFixture,
     }
 
     CUDACHECK_TEST(cudaDeviceSynchronize());
-    // Sleep for a while to make sure all the colls are finished
-    std::this_thread::sleep_for(std::chrono::seconds(2));
 
     ASSERT_NE(ctranComm->colltraceNew_, nullptr);
-    auto dumpMap = ctran::dumpCollTrace(ctranComm.get());
+    auto dumpMap = ctran::waitForCollTraceDrain(ctranComm.get());
 
     EXPECT_EQ(dumpMap["CT_pendingColls"], "[]");
     EXPECT_EQ(dumpMap["CT_currentColls"], "[]");

--- a/comms/ctran/tests/CtranDistSendRecvUT.cc
+++ b/comms/ctran/tests/CtranDistSendRecvUT.cc
@@ -276,13 +276,10 @@ class CtranTestFixture : public ctran::CtranDistTestFixture,
     verifyGpeLeak(ctranComm->ctran_.get());
 
     if (!useGraph) {
-      // Brief wait for GPE thread to flush colltrace entries after stream sync
-      std::this_thread::sleep_for(std::chrono::seconds(2));
-
       // Check the coll trace only for participating ranks
       bool participated = (globalRank == sendRank) || isReceiver;
       if (participated) {
-        auto dumpMap = ctran::dumpCollTrace(ctranComm.get());
+        auto dumpMap = ctran::waitForCollTraceDrain(ctranComm.get());
         ASSERT_FALSE(dumpMap.empty()) << "Colltrace should be initialized";
 
         int numSendPeers = oneToOne ? 1 : (numRanks - 1);

--- a/comms/ctran/tests/CtranDistTestUtils.cc
+++ b/comms/ctran/tests/CtranDistTestUtils.cc
@@ -174,6 +174,28 @@ std::unordered_map<std::string, std::string> dumpCollTrace(CtranComm* comm) {
   return commDumpToMap(dump.value());
 }
 
+std::unordered_map<std::string, std::string> waitForCollTraceDrain(
+    CtranComm* comm,
+    int timeoutMs) {
+  if (comm->colltraceNew_ == nullptr) {
+    return {};
+  }
+  constexpr int kPollIntervalMs = 50;
+  auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::milliseconds(timeoutMs);
+  std::unordered_map<std::string, std::string> dumpMap;
+  while (std::chrono::steady_clock::now() < deadline) {
+    dumpMap = dumpCollTrace(comm);
+    auto it = dumpMap.find("CT_currentColls");
+    if (it != dumpMap.end() && it->second == "[]") {
+      return dumpMap;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(kPollIntervalMs));
+  }
+  // Return whatever we have after timeout
+  return dumpMap.empty() ? dumpCollTrace(comm) : dumpMap;
+}
+
 void CtranDistTestFixture::barrierNvlDomain(CtranComm* comm) {
   auto resFuture = comm->bootstrap_->barrierNvlDomain(
       comm->statex_->localRank(),

--- a/comms/ctran/tests/CtranDistTestUtils.h
+++ b/comms/ctran/tests/CtranDistTestUtils.h
@@ -59,4 +59,11 @@ class CtranDistTestFixture : public CtranTestFixtureBase,
 // "CT_currentColls". Returns empty map if colltrace is not initialized.
 std::unordered_map<std::string, std::string> dumpCollTrace(CtranComm* comm);
 
+// Poll until CT_currentColls drains to "[]", then return the final dump.
+// On single-node configs, CudaWaitEvent may delay colltrace transitions,
+// so a fixed sleep is insufficient. Polls every 50ms up to timeoutMs.
+std::unordered_map<std::string, std::string> waitForCollTraceDrain(
+    CtranComm* comm,
+    int timeoutMs = 5000);
+
 } // namespace ctran


### PR DESCRIPTION
Summary:

Fix two colltrace issues causing test failures:
- Add SENDRECV_P2P to isP2PKernel() in CollTraceWrapper.cc — this kernel type was missing, causing P2P copy kernel metadata to be routed through the collective path (wrong) instead of the P2P path (correct). This produced error log "P2P kernel types being handled by collective path" and opName="Unknown" metadata.
- Add waitForCollTraceDrain() utility in CtranDistTestUtils that polls until CT_currentColls drains to empty, replacing fixed 100ms sleeps. On single-node configs, CudaWaitEvent may delay colltrace transitions, so a fixed sleep is insufficient for fast-completing kernels (e.g., AllToAll with lowlatency+fastput, SendRecv with ctp2p).
- Apply waitForCollTraceDrain in CtranDistSendRecvUT.cc and CtranDistAlltoAllTest.cc.

Reviewed By: YulunW

Differential Revision: D101216456
