### PR TITLE
Extract auto-tune config to separate module and add unit tests (#2132)

### DIFF
--- a/comms/pipes/collectives/triton/auto_tune_config.py
+++ b/comms/pipes/collectives/triton/auto_tune_config.py
@@ -1,0 +1,118 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# pyre-unsafe
+
+"""Pure-Python auto-tuning configuration for the Triton AlltoAllv kernel.
+
+This module contains topology-aware parameter selection logic with zero
+torch/triton dependencies. Separated from device_alltoallv_dynamic.py
+so that unit tests can import without pulling in the GPU runtime.
+"""
+
+from __future__ import annotations
+
+
+def _tune_for_nvl(max_msg_size_bytes: int) -> dict:
+    """NVLink-optimized tuning parameters.
+
+    NVLink scales with block parallelism (each block independently
+    saturates a portion of the NVLink bandwidth via cooperative memcpy).
+    """
+    if max_msg_size_bytes <= 1 * 1024:
+        return {"blocks_per_peer": 1, "num_warps": 4, "chunk_size": 64 * 1024}
+    if max_msg_size_bytes <= 2 * 1024:
+        return {"blocks_per_peer": 1, "num_warps": 8, "chunk_size": 64 * 1024}
+    elif max_msg_size_bytes <= 4 * 1024:
+        return {"blocks_per_peer": 1, "num_warps": 8, "chunk_size": 64 * 1024}
+    elif max_msg_size_bytes <= 8 * 1024:
+        return {"blocks_per_peer": 1, "num_warps": 16, "chunk_size": 64 * 1024}
+    elif max_msg_size_bytes <= 16 * 1024:
+        return {"blocks_per_peer": 1, "num_warps": 16, "chunk_size": 64 * 1024}
+    elif max_msg_size_bytes <= 32 * 1024:
+        return {"blocks_per_peer": 1, "num_warps": 16, "chunk_size": 64 * 1024}
+    elif max_msg_size_bytes <= 64 * 1024:
+        return {"blocks_per_peer": 1, "num_warps": 32, "chunk_size": 64 * 1024}
+    elif max_msg_size_bytes <= 128 * 1024:
+        return {"blocks_per_peer": 8, "num_warps": 16, "chunk_size": 64 * 1024}
+    elif max_msg_size_bytes <= 256 * 1024:
+        return {"blocks_per_peer": 8, "num_warps": 16, "chunk_size": 64 * 1024}
+    else:
+        return {"blocks_per_peer": 16, "num_warps": 16, "chunk_size": 64 * 1024}
+
+
+def _tune_for_ib(max_msg_size_bytes: int) -> dict:
+    """IB/RDMA-optimized tuning parameters.
+
+    Empirical data from exhaustive sweep on 2x8 H100 (64 param combos
+    per message size, CUDA graph mode). Key findings:
+    - 1 bpp optimal up to 1MB (RDMA NIC pipelines internally)
+    - 4 bpp for 2-4MB (some block parallelism helps)
+    - 8 bpp for >=8MB (more blocks to saturate bandwidth)
+    - 512KB chunks dominate for medium/large messages
+    """
+    if max_msg_size_bytes <= 1 * 1024:  # 1KB: 2.35x vs NCCL
+        return {"blocks_per_peer": 1, "num_warps": 4, "chunk_size": 256 * 1024}
+    elif max_msg_size_bytes <= 4 * 1024:  # 4KB: 2.05x
+        return {"blocks_per_peer": 1, "num_warps": 16, "chunk_size": 128 * 1024}
+    elif max_msg_size_bytes <= 16 * 1024:  # 16KB: 2.35x
+        return {"blocks_per_peer": 1, "num_warps": 8, "chunk_size": 256 * 1024}
+    elif max_msg_size_bytes <= 64 * 1024:  # 64KB: 2.76x
+        return {"blocks_per_peer": 1, "num_warps": 4, "chunk_size": 64 * 1024}
+    elif max_msg_size_bytes <= 256 * 1024:  # 256KB: 1.91x
+        return {"blocks_per_peer": 1, "num_warps": 8, "chunk_size": 512 * 1024}
+    elif max_msg_size_bytes <= 512 * 1024:  # 512KB: 1.92x
+        return {"blocks_per_peer": 1, "num_warps": 4, "chunk_size": 512 * 1024}
+    elif max_msg_size_bytes <= 1 * 1024 * 1024:  # 1MB: 1.76x
+        return {"blocks_per_peer": 1, "num_warps": 16, "chunk_size": 256 * 1024}
+    elif max_msg_size_bytes <= 4 * 1024 * 1024:  # 2-4MB: 1.51-1.60x
+        return {"blocks_per_peer": 4, "num_warps": 16, "chunk_size": 512 * 1024}
+    else:  # >=8MB: 1.42-1.47x
+        return {"blocks_per_peer": 8, "num_warps": 16, "chunk_size": 512 * 1024}
+
+
+def auto_tune_alltoallv_params(
+    max_msg_size_bytes: int,
+    peer_is_nvl: list[bool] | None = None,
+) -> dict:
+    """
+    Select optimal kernel parameters based on maximum per-peer message size.
+
+    When peer_is_nvl is provided, returns topology-aware config with
+    per-peer block counts. NVL peers get NVLink-optimized parameters,
+    IB peers get RDMA-optimized parameters. The kernel launches with
+    the max blocks_per_peer as a constexpr upper bound and masks excess
+    blocks at runtime.
+
+    Args:
+        max_msg_size_bytes: Maximum per-peer message size in bytes.
+        peer_is_nvl: Optional list of booleans per peer. True = NVLink,
+            False = IB. None = all NVLink (backward compatible).
+
+    Returns:
+        dict with keys: blocks_per_peer, num_warps, chunk_size,
+            per_peer_blocks (list[int] or None)
+    """
+    nvl_config = _tune_for_nvl(max_msg_size_bytes)
+
+    if peer_is_nvl is None or all(peer_is_nvl):
+        return {
+            "blocks_per_peer": nvl_config["blocks_per_peer"],
+            "num_warps": nvl_config["num_warps"],
+            "chunk_size": nvl_config["chunk_size"],
+            "per_peer_blocks": None,
+        }
+
+    ib_config = _tune_for_ib(max_msg_size_bytes)
+
+    max_bpp = max(nvl_config["blocks_per_peer"], ib_config["blocks_per_peer"])
+
+    per_peer_blocks = [
+        nvl_config["blocks_per_peer"] if is_nvl else ib_config["blocks_per_peer"]
+        for is_nvl in peer_is_nvl
+    ]
+
+    return {
+        "blocks_per_peer": max_bpp,
+        "num_warps": max(nvl_config["num_warps"], ib_config["num_warps"]),
+        "chunk_size": nvl_config["chunk_size"],
+        "per_peer_blocks": per_peer_blocks,
+    }

--- a/comms/pipes/collectives/triton/device_alltoallv_dynamic.py
+++ b/comms/pipes/collectives/triton/device_alltoallv_dynamic.py
@@ -633,111 +633,14 @@ def exchange_offsets(
     return remote_write_offsets
 
 
-def _tune_for_nvl(max_msg_size_bytes: int) -> dict:
-    """NVLink-optimized tuning parameters.
-
-    NVLink scales with block parallelism (each block independently
-    saturates a portion of the NVLink bandwidth via cooperative memcpy).
-    """
-    if max_msg_size_bytes <= 1 * 1024:
-        return {"blocks_per_peer": 1, "num_warps": 4, "chunk_size": 64 * 1024}
-    if max_msg_size_bytes <= 2 * 1024:
-        return {"blocks_per_peer": 1, "num_warps": 8, "chunk_size": 64 * 1024}
-    elif max_msg_size_bytes <= 4 * 1024:
-        return {"blocks_per_peer": 1, "num_warps": 8, "chunk_size": 64 * 1024}
-    elif max_msg_size_bytes <= 8 * 1024:
-        return {"blocks_per_peer": 1, "num_warps": 16, "chunk_size": 64 * 1024}
-    elif max_msg_size_bytes <= 16 * 1024:
-        return {"blocks_per_peer": 1, "num_warps": 16, "chunk_size": 64 * 1024}
-    elif max_msg_size_bytes <= 32 * 1024:
-        return {"blocks_per_peer": 1, "num_warps": 16, "chunk_size": 64 * 1024}
-    elif max_msg_size_bytes <= 64 * 1024:
-        return {"blocks_per_peer": 1, "num_warps": 32, "chunk_size": 64 * 1024}
-    elif max_msg_size_bytes <= 128 * 1024:
-        return {"blocks_per_peer": 8, "num_warps": 16, "chunk_size": 64 * 1024}
-    elif max_msg_size_bytes <= 256 * 1024:
-        return {"blocks_per_peer": 8, "num_warps": 16, "chunk_size": 64 * 1024}
-    else:
-        return {"blocks_per_peer": 16, "num_warps": 16, "chunk_size": 64 * 1024}
-
-
-def _tune_for_ib(max_msg_size_bytes: int) -> dict:
-    """IB/RDMA-optimized tuning parameters.
-
-    Empirical data from exhaustive sweep on 2x8 H100 (64 param combos
-    per message size, CUDA graph mode). Key findings:
-    - 1 bpp optimal up to 1MB (RDMA NIC pipelines internally)
-    - 4 bpp for 2-4MB (some block parallelism helps)
-    - 8 bpp for >=8MB (more blocks to saturate bandwidth)
-    - 512KB chunks dominate for medium/large messages
-    """
-    if max_msg_size_bytes <= 1 * 1024:  # 1KB: 2.35x vs NCCL
-        return {"blocks_per_peer": 1, "num_warps": 4, "chunk_size": 256 * 1024}
-    elif max_msg_size_bytes <= 4 * 1024:  # 4KB: 2.05x
-        return {"blocks_per_peer": 1, "num_warps": 16, "chunk_size": 128 * 1024}
-    elif max_msg_size_bytes <= 16 * 1024:  # 16KB: 2.35x
-        return {"blocks_per_peer": 1, "num_warps": 8, "chunk_size": 256 * 1024}
-    elif max_msg_size_bytes <= 64 * 1024:  # 64KB: 2.76x
-        return {"blocks_per_peer": 1, "num_warps": 4, "chunk_size": 64 * 1024}
-    elif max_msg_size_bytes <= 256 * 1024:  # 256KB: 1.91x
-        return {"blocks_per_peer": 1, "num_warps": 8, "chunk_size": 512 * 1024}
-    elif max_msg_size_bytes <= 512 * 1024:  # 512KB: 1.92x
-        return {"blocks_per_peer": 1, "num_warps": 4, "chunk_size": 512 * 1024}
-    elif max_msg_size_bytes <= 1 * 1024 * 1024:  # 1MB: 1.76x
-        return {"blocks_per_peer": 1, "num_warps": 16, "chunk_size": 256 * 1024}
-    elif max_msg_size_bytes <= 4 * 1024 * 1024:  # 2-4MB: 1.51-1.60x
-        return {"blocks_per_peer": 4, "num_warps": 16, "chunk_size": 512 * 1024}
-    else:  # >=8MB: 1.42-1.47x
-        return {"blocks_per_peer": 8, "num_warps": 16, "chunk_size": 512 * 1024}
-
-
-def auto_tune_alltoallv_params(
-    max_msg_size_bytes: int,
-    peer_is_nvl: "list[bool] | None" = None,
-) -> dict:
-    """
-    Select optimal kernel parameters based on maximum per-peer message size.
-
-    When peer_is_nvl is provided, returns topology-aware config with
-    per-peer block counts. NVL peers get NVLink-optimized parameters,
-    IB peers get RDMA-optimized parameters. The kernel launches with
-    the max blocks_per_peer as a constexpr upper bound and masks excess
-    blocks at runtime.
-
-    Args:
-        max_msg_size_bytes: Maximum per-peer message size in bytes.
-        peer_is_nvl: Optional list of booleans per peer. True = NVLink,
-            False = IB. None = all NVLink (backward compatible).
-
-    Returns:
-        dict with keys: blocks_per_peer, num_warps, chunk_size,
-            per_peer_blocks (list[int] or None)
-    """
-    nvl_config = _tune_for_nvl(max_msg_size_bytes)
-
-    if peer_is_nvl is None or all(peer_is_nvl):
-        return {
-            "blocks_per_peer": nvl_config["blocks_per_peer"],
-            "num_warps": nvl_config["num_warps"],
-            "chunk_size": nvl_config["chunk_size"],
-            "per_peer_blocks": None,
-        }
-
-    ib_config = _tune_for_ib(max_msg_size_bytes)
-
-    max_bpp = max(nvl_config["blocks_per_peer"], ib_config["blocks_per_peer"])
-
-    per_peer_blocks = [
-        nvl_config["blocks_per_peer"] if is_nvl else ib_config["blocks_per_peer"]
-        for is_nvl in peer_is_nvl
-    ]
-
-    return {
-        "blocks_per_peer": max_bpp,
-        "num_warps": max(nvl_config["num_warps"], ib_config["num_warps"]),
-        "chunk_size": nvl_config["chunk_size"],
-        "per_peer_blocks": per_peer_blocks,
-    }
+# Re-export tuning functions from auto_tune_config (pure Python, no torch/triton deps).
+# This preserves all existing import paths while keeping the tuning logic in a
+# lightweight module that unit tests can import without GPU runtime side effects.
+from comms.pipes.collectives.triton.auto_tune_config import (  # noqa: F401
+    _tune_for_ib,
+    _tune_for_nvl,
+    auto_tune_alltoallv_params,
+)
 
 
 def device_alltoallv_dynamic(

--- a/comms/pipes/collectives/triton/tests/test_auto_tune.py
+++ b/comms/pipes/collectives/triton/tests/test_auto_tune.py
@@ -1,0 +1,194 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# pyre-strict
+
+"""Unit tests for topology-aware auto-tuning in device_alltoallv_dynamic.py.
+
+Tests the pure-function tuning logic (no GPU required):
+- _tune_for_nvl(): NVLink-optimized parameter selection
+- _tune_for_ib(): IB/RDMA-optimized parameter selection
+- auto_tune_alltoallv_params(): topology-aware dispatch with per-peer blocks
+"""
+
+import unittest
+
+from comms.pipes.collectives.triton.auto_tune_config import (
+    _tune_for_ib,
+    _tune_for_nvl,
+    auto_tune_alltoallv_params,
+)
+
+KB: int = 1024
+MB: int = 1024 * 1024
+
+
+class TestTuneForNvl(unittest.TestCase):
+    """Test NVLink tuning parameter selection at each message size tier."""
+
+    def test_small_messages_single_block(self) -> None:
+        """Messages ≤64KB should use 1 block/peer."""
+        for size in [1 * KB, 2 * KB, 4 * KB, 8 * KB, 16 * KB, 32 * KB, 64 * KB]:
+            result = _tune_for_nvl(size)
+            self.assertEqual(result["blocks_per_peer"], 1, f"Failed at {size}")
+
+    def test_medium_messages_multi_block(self) -> None:
+        """Messages 128KB-256KB should use 8 blocks/peer."""
+        for size in [128 * KB, 256 * KB]:
+            result = _tune_for_nvl(size)
+            self.assertEqual(result["blocks_per_peer"], 8, f"Failed at {size}")
+
+    def test_large_messages_max_blocks(self) -> None:
+        """Messages >256KB should use 16 blocks/peer."""
+        for size in [512 * KB, 1 * MB, 16 * MB]:
+            result = _tune_for_nvl(size)
+            self.assertEqual(result["blocks_per_peer"], 16, f"Failed at {size}")
+
+    def test_chunk_size_always_64kb(self) -> None:
+        """NVLink chunk size is always 64KB."""
+        for size in [1 * KB, 64 * KB, 1 * MB, 16 * MB]:
+            result = _tune_for_nvl(size)
+            self.assertEqual(result["chunk_size"], 64 * KB, f"Failed at {size}")
+
+    def test_warps_scaling(self) -> None:
+        """Warps should increase with message size."""
+        self.assertEqual(_tune_for_nvl(1 * KB)["num_warps"], 4)
+        self.assertEqual(_tune_for_nvl(4 * KB)["num_warps"], 8)
+        self.assertEqual(_tune_for_nvl(16 * KB)["num_warps"], 16)
+        self.assertEqual(_tune_for_nvl(64 * KB)["num_warps"], 32)
+        self.assertEqual(_tune_for_nvl(256 * KB)["num_warps"], 16)
+
+    def test_returns_required_keys(self) -> None:
+        """Result must contain blocks_per_peer, num_warps, chunk_size."""
+        result = _tune_for_nvl(1 * MB)
+        self.assertIn("blocks_per_peer", result)
+        self.assertIn("num_warps", result)
+        self.assertIn("chunk_size", result)
+
+
+class TestTuneForIb(unittest.TestCase):
+    """Test IB/RDMA tuning parameter selection at each message size tier."""
+
+    def test_small_messages_single_block(self) -> None:
+        """IB messages ≤1MB should use 1 block/peer."""
+        for size in [1 * KB, 64 * KB, 256 * KB, 512 * KB, 1 * MB]:
+            result = _tune_for_ib(size)
+            self.assertEqual(result["blocks_per_peer"], 1, f"Failed at {size}")
+
+    def test_medium_messages_4_blocks(self) -> None:
+        """IB messages 2-4MB should use 4 blocks/peer."""
+        for size in [2 * MB, 4 * MB]:
+            result = _tune_for_ib(size)
+            self.assertEqual(result["blocks_per_peer"], 4, f"Failed at {size}")
+
+    def test_large_messages_8_blocks(self) -> None:
+        """IB messages ≥8MB should use 8 blocks/peer."""
+        for size in [8 * MB, 16 * MB]:
+            result = _tune_for_ib(size)
+            self.assertEqual(result["blocks_per_peer"], 8, f"Failed at {size}")
+
+    def test_chunk_size_varies(self) -> None:
+        """IB chunk size varies by message size (not fixed like NVL)."""
+        self.assertEqual(_tune_for_ib(1 * KB)["chunk_size"], 256 * KB)
+        self.assertEqual(_tune_for_ib(4 * KB)["chunk_size"], 128 * KB)
+        self.assertEqual(_tune_for_ib(256 * KB)["chunk_size"], 512 * KB)
+        self.assertEqual(_tune_for_ib(4 * MB)["chunk_size"], 512 * KB)
+
+    def test_returns_required_keys(self) -> None:
+        """Result must contain blocks_per_peer, num_warps, chunk_size."""
+        result = _tune_for_ib(1 * MB)
+        self.assertIn("blocks_per_peer", result)
+        self.assertIn("num_warps", result)
+        self.assertIn("chunk_size", result)
+
+
+class TestAutoTuneAlltoallvParams(unittest.TestCase):
+    """Test the top-level auto_tune_alltoallv_params() dispatch logic."""
+
+    def test_peer_is_nvl_none_returns_nvl_config(self) -> None:
+        """peer_is_nvl=None (default) should return NVL config with no per-peer blocks."""
+        result = auto_tune_alltoallv_params(1 * MB, peer_is_nvl=None)
+        nvl = _tune_for_nvl(1 * MB)
+        self.assertEqual(result["blocks_per_peer"], nvl["blocks_per_peer"])
+        self.assertEqual(result["num_warps"], nvl["num_warps"])
+        self.assertEqual(result["chunk_size"], nvl["chunk_size"])
+        self.assertIsNone(result["per_peer_blocks"])
+
+    def test_all_nvl_peers_returns_nvl_config(self) -> None:
+        """All-NVL peers should behave identically to peer_is_nvl=None."""
+        result = auto_tune_alltoallv_params(1 * MB, peer_is_nvl=[True] * 8)
+        self.assertIsNone(result["per_peer_blocks"])
+        nvl = _tune_for_nvl(1 * MB)
+        self.assertEqual(result["blocks_per_peer"], nvl["blocks_per_peer"])
+
+    def test_mixed_peers_returns_per_peer_blocks(self) -> None:
+        """Mixed NVL/IB peers should return per-peer block counts."""
+        peer_is_nvl = [True, True, True, True, False, False, False, False]
+        result = auto_tune_alltoallv_params(1 * MB, peer_is_nvl=peer_is_nvl)
+
+        self.assertIsNotNone(result["per_peer_blocks"])
+        per_peer = result["per_peer_blocks"]
+        assert per_peer is not None
+        self.assertEqual(len(per_peer), 8)
+
+        nvl = _tune_for_nvl(1 * MB)
+        ib = _tune_for_ib(1 * MB)
+
+        # NVL peers get NVL block count
+        for i in range(4):
+            self.assertEqual(per_peer[i], nvl["blocks_per_peer"])
+        # IB peers get IB block count
+        for i in range(4, 8):
+            self.assertEqual(per_peer[i], ib["blocks_per_peer"])
+
+    def test_mixed_peers_blocks_per_peer_is_max(self) -> None:
+        """blocks_per_peer (constexpr upper bound) should be max of NVL and IB."""
+        peer_is_nvl = [True, False]
+        result = auto_tune_alltoallv_params(1 * MB, peer_is_nvl=peer_is_nvl)
+        nvl = _tune_for_nvl(1 * MB)
+        ib = _tune_for_ib(1 * MB)
+        self.assertEqual(
+            result["blocks_per_peer"],
+            max(nvl["blocks_per_peer"], ib["blocks_per_peer"]),
+        )
+
+    def test_mixed_peers_num_warps_is_max(self) -> None:
+        """num_warps should be max of NVL and IB warps."""
+        peer_is_nvl = [True, False]
+        result = auto_tune_alltoallv_params(1 * MB, peer_is_nvl=peer_is_nvl)
+        nvl = _tune_for_nvl(1 * MB)
+        ib = _tune_for_ib(1 * MB)
+        self.assertEqual(
+            result["num_warps"],
+            max(nvl["num_warps"], ib["num_warps"]),
+        )
+
+    def test_all_ib_peers_returns_per_peer_blocks(self) -> None:
+        """All-IB peers should still return per-peer blocks (not None)."""
+        result = auto_tune_alltoallv_params(1 * MB, peer_is_nvl=[False] * 8)
+        self.assertIsNotNone(result["per_peer_blocks"])
+        per_peer = result["per_peer_blocks"]
+        assert per_peer is not None
+        ib = _tune_for_ib(1 * MB)
+        for bpp in per_peer:
+            self.assertEqual(bpp, ib["blocks_per_peer"])
+
+    def test_result_has_all_required_keys(self) -> None:
+        """Result must always contain blocks_per_peer, num_warps, chunk_size, per_peer_blocks."""
+        for peer_is_nvl in [None, [True] * 4, [False] * 4, [True, False, True, False]]:
+            result = auto_tune_alltoallv_params(1 * MB, peer_is_nvl=peer_is_nvl)
+            self.assertIn("blocks_per_peer", result)
+            self.assertIn("num_warps", result)
+            self.assertIn("chunk_size", result)
+            self.assertIn("per_peer_blocks", result)
+
+    def test_various_message_sizes_with_mixed_peers(self) -> None:
+        """Mixed topology should work across all message size tiers."""
+        peer_is_nvl = [True, True, False, False]
+        for size in [1 * KB, 16 * KB, 256 * KB, 1 * MB, 4 * MB, 16 * MB]:
+            result = auto_tune_alltoallv_params(size, peer_is_nvl=peer_is_nvl)
+            self.assertIsNotNone(result["per_peer_blocks"])
+            per_peer = result["per_peer_blocks"]
+            assert per_peer is not None
+            self.assertEqual(len(per_peer), 4)
+            # blocks_per_peer should be >= any individual per_peer value
+            for bpp in per_peer:
+                self.assertLessEqual(bpp, result["blocks_per_peer"])


### PR DESCRIPTION
Summary:

Extract _tune_for_nvl(), _tune_for_ib(), and auto_tune_alltoallv_params() from device_alltoallv_dynamic.py into a new auto_tune_config.py module with zero torch/triton dependencies, and add 19 unit tests.

Motivation: The tuning functions are pure Python (dict-returning, no GPU types). However, device_alltoallv_dynamic.py imports torch and triton at module level. When a python_unittest target depends on triton_collectives, the PAR binary includes torch/triton, whose native CUDA/triton cleanup crashes during Python interpreter shutdown — causing non-zero exit codes that CI treats as test failures ("Test appears to have passed but the binary exited with a non-zero exit code").

Solution: Extract the 3 pure functions into auto_tune_config.py (a standalone python_library with zero deps). The test target depends on auto_tune_config instead of triton_collectives, keeping torch/triton out of the test binary entirely. device_alltoallv_dynamic.py re-exports from auto_tune_config to preserve all existing import paths.

Changes:
- auto_tune_config.py (new): pure Python tuning logic — _tune_for_nvl(), _tune_for_ib(), auto_tune_alltoallv_params()
- device_alltoallv_dynamic.py: replace inline definitions with re-exports from auto_tune_config (# noqa: F401)
- BUCK: add standalone auto_tune_config python_library target (no torch/triton deps); add :auto_tune_config as dep of triton_collectives
- tests/test_auto_tune.py (new): 19 unit tests covering NVL tuning tiers, IB tuning tiers, topology-aware dispatch (None, all-NVL, mixed, all-IB), invariants (max bpp, max warps, required keys)
- tests/BUCK: add test_auto_tune target depending on :auto_tune_config (not :triton_collectives)

Differential Revision: D101125928
