### PR TITLE
Fix int32 overflow deadlock and non-power-of-2 crash in Triton AlltoAllv (#2133)

### DIFF
--- a/comms/pipes/collectives/triton/alltoallv_op.py
+++ b/comms/pipes/collectives/triton/alltoallv_op.py
@@ -124,10 +124,16 @@ def _triton_copy_1d_kernel(src_ptr, dst_ptr, N, BLOCK_SIZE: tl.constexpr):
 
 
 @triton.jit
-def _sum_int64_kernel(input_ptr, output_ptr, N: tl.constexpr):
-    """GIN-safe kernel to compute sum of int64 tensor."""
-    offsets = tl.arange(0, N)
-    vals = tl.load(input_ptr + offsets)
+def _sum_int64_kernel(input_ptr, output_ptr, W, BLOCK_SIZE: tl.constexpr):
+    """GIN-safe kernel to compute sum of int64 tensor.
+
+    Uses BLOCK_SIZE (next power-of-2 of W) with masking to support
+    non-power-of-2 world sizes, matching the pattern used by
+    ``_prepare_alltoallv_kernel``.
+    """
+    offsets = tl.arange(0, BLOCK_SIZE)
+    mask = offsets < W
+    vals = tl.load(input_ptr + offsets, mask=mask, other=0)
     total = tl.sum(vals, axis=0)
     tl.store(output_ptr, total)
 
@@ -982,8 +988,9 @@ class AlltoallvOp:
             _sum_int64_kernel[(1,)](
                 output_split_sizes,
                 self._total_tokens_buf,
+                self.world_size,
                 # pyre-fixme[6]: Triton constexpr accepts int at runtime
-                N=self.world_size,
+                BLOCK_SIZE=self._prep_block_size,
             )
             total_tokens = int(self._total_tokens_buf.item())
 

--- a/comms/pipes/collectives/triton/device_alltoallv_dynamic.py
+++ b/comms/pipes/collectives/triton/device_alltoallv_dynamic.py
@@ -95,10 +95,17 @@ _ITERATION_TENSOR_CACHE: dict = {}
 
 
 def _get_iteration_tensor(world_size: int, device: torch.device) -> torch.Tensor:
-    """Return a cached int32 scalar tensor for iteration counting.
+    """Return a cached int64 scalar tensor for iteration counting.
 
     The tensor is allocated once on first use and reused across all
     subsequent calls. The iteration value grows monotonically.
+
+    Uses int64 to prevent overflow in signal value calculations. The
+    kernel computes ``sender_bpp * (iteration + 1)`` which is passed to
+    ``wait_signal_from`` and compared against uint64 signal memory. With
+    int32, this expression overflows after ~134M iterations (with
+    blocks_per_peer=16), causing the sign-extended value to become a huge
+    uint64 that can never be reached — a silent deadlock.
 
     IMPORTANT: This must be called BEFORE GIN (GPU-Initiated NCCL) is
     activated via get_device_window(). Once GIN is active, regular CUDA
@@ -106,7 +113,7 @@ def _get_iteration_tensor(world_size: int, device: torch.device) -> torch.Tensor
     """
     key = (device, world_size)
     if key not in _ITERATION_TENSOR_CACHE:
-        _ITERATION_TENSOR_CACHE[key] = torch.zeros(1, dtype=torch.int32, device=device)
+        _ITERATION_TENSOR_CACHE[key] = torch.zeros(1, dtype=torch.int64, device=device)
     return _ITERATION_TENSOR_CACHE[key]
 
 
@@ -140,7 +147,7 @@ def _reset_iteration_counter(world_size: int, device: torch.device) -> None:
     key = (device, world_size)
     if key in _ITERATION_TENSOR_CACHE:
         # Use a GIN-safe kernel to reset the counter
-        _fill_int32_kernel[(1,)](_ITERATION_TENSOR_CACHE[key], 0, N=1)
+        _fill_int64_kernel[(1,)](_ITERATION_TENSOR_CACHE[key], 0, N=1)
 
 
 @requires_torchcomms
@@ -162,14 +169,14 @@ def _increment_iteration_kernel(iteration_ptr):
 
 
 # Pre-allocated completion counters cache to avoid per-call CUDA allocator
-# overhead.  Keyed by (device, world_size) → torch.Tensor(int32).
+# overhead.  Keyed by (device, world_size) → torch.Tensor(int64).
 _COMPLETION_COUNTERS_CACHE: dict = {}
 
 
 @requires_torchcomms
 @triton.jit
-def _fill_int32_kernel(ptr, value, N: tl.constexpr):
-    """GIN-safe kernel to fill an int32 tensor with a scalar value."""
+def _fill_int64_kernel(ptr, value, N: tl.constexpr):
+    """GIN-safe kernel to fill an int64 tensor with a scalar value."""
     idx = tl.program_id(0)
     if idx < N:
         tl.store(ptr + idx, value)
@@ -212,7 +219,7 @@ def _fill_completion_counters_gin_safe(
     (cudaErrorHostMemoryAlreadyRegistered).  This function uses a Triton
     kernel which only does device-side stores and is GIN-safe.
     """
-    _fill_int32_kernel[(world_size,)](counters, value, N=world_size)
+    _fill_int64_kernel[(world_size,)](counters, value, N=world_size)
 
 
 def _fill_completion_counters_from_iteration(
@@ -232,7 +239,7 @@ def _fill_completion_counters_from_iteration(
     counters are reset uniformly to blocks_per_peer * iteration.
 
     Args:
-        counters: GPU tensor [world_size] of int32 counters.
+        counters: GPU tensor [world_size] of int64 counters.
         iteration_tensor: GPU scalar tensor containing iteration count.
         blocks_per_peer: Number of blocks per peer (constexpr upper bound).
         world_size: Number of ranks.
@@ -250,12 +257,16 @@ def _fill_completion_counters_from_iteration(
 
 
 def _get_completion_counters(world_size: int, device: torch.device) -> torch.Tensor:
-    """Return a cached int32 tensor of shape [world_size] on device.
+    """Return a cached int64 tensor of shape [world_size] on device.
 
     The tensor is allocated once (via torch.zeros) on first use and reused
     across all subsequent calls.  Counters grow monotonically with each
     iteration (no in-kernel reset) to avoid race conditions with CUDA
     block scheduling.
+
+    Uses int64 to match the iteration tensor dtype and prevent overflow
+    in the multi-block completion coordination logic, where counters
+    accumulate ``blocks_per_peer * iteration`` values.
 
     IMPORTANT: This must be called BEFORE GIN (GPU-Initiated NCCL) is
     activated via get_device_window().  Once GIN is active, regular CUDA
@@ -264,7 +275,7 @@ def _get_completion_counters(world_size: int, device: torch.device) -> torch.Ten
     key = (device, world_size)
     if key not in _COMPLETION_COUNTERS_CACHE:
         _COMPLETION_COUNTERS_CACHE[key] = torch.zeros(
-            world_size, dtype=torch.int32, device=device
+            world_size, dtype=torch.int64, device=device
         )
     return _COMPLETION_COUNTERS_CACHE[key]
 

--- a/comms/pipes/collectives/triton/tests/test_device_alltoallv_dynamic.py
+++ b/comms/pipes/collectives/triton/tests/test_device_alltoallv_dynamic.py
@@ -423,7 +423,7 @@ class TestMonotonicSignalCounter(unittest.TestCase):
         counters = _get_completion_counters(world_size, device)
 
         # Counters should be zeros
-        expected = torch.zeros(world_size, dtype=torch.int32, device=device)
+        expected = torch.zeros(world_size, dtype=torch.int64, device=device)
         torch.testing.assert_close(counters, expected)
 
     @unittest.skipUnless(TRITON_AVAILABLE, "Triton not available")


### PR DESCRIPTION
Summary:

This diff fixes two bugs in the Triton AlltoAllv kernel (`comms/pipes/collectives/triton/`):

**int32 iteration/completion counter overflow causes deadlock**

The iteration counter tensor and completion counters tensor were allocated as `torch.int32`. The kernel computes signal values as `sender_bpp * (iteration + 1)` in int32 arithmetic before passing to `wait_signal_from`, which sign-extends the result to int64 and then reinterprets as uint64 for the C++ comparison. With `blocks_per_peer=16`, int32 overflows after ~134M iterations. The overflowed negative int32 becomes a huge uint64 (~18.4 quintillion) after sign-extension, making the unsigned comparison `actual >= expected` permanently false — causing all recv blocks to spin forever in a **silent deadlock**.

The full overflow chain:
1. `torch.zeros(1, dtype=torch.int32)` — iteration tensor created as int32
2. `tl.load(iteration_ptr)` — loaded as Triton i32 in the kernel
3. `sender_bpp * (iteration + 1)` — i32 × i32 = i32 **OVERFLOW** at ~134M iterations
4. `tl.full([], expected_value, tl.int64)` — sign-extends negative i32 to i64 in `wait_signal_from` wrapper
5. C++ `torchcomms_wait_signal_from(unsigned long long expected_value)` — reinterprets as uint64 = ~18.4 quintillion
6. `cmp_op(CmpOp::GE, actual_uint64, expected_uint64)` — unsigned comparison, permanently false → **DEADLOCK**

Time to failure: ~77 days at 20 iter/s with bpp=16, ~1.5 days at 1000 iter/s (CUDA graph replay).

The sender side is fine — `signal_block` promotes the small value to int64 via `tl.zeros([], dtype=tl.int64) + value` *before* arithmetic, so the cumulative uint64 signal is always correct. The mismatch is only on the receiver side where the expected value computation overflows in int32 before widening.

Fix: Change both `_ITERATION_TENSOR_CACHE` and `_COMPLETION_COUNTERS_CACHE` from `dtype=torch.int32` to `dtype=torch.int64`. This makes all kernel arithmetic (iteration loads, bpp multiplications, counter atomics) operate in int64, matching the uint64 signal infrastructure. Zero performance cost — these are a single scalar tensor and a small per-rank array.

**`_sum_int64_kernel` crashes for non-power-of-2 world sizes**

`_sum_int64_kernel` passes `N=self.world_size` directly to `tl.arange(0, N)`. Triton requires `tl.arange` range to be a power of 2 — verified in `third-party/tp2/triton/2.0.x/triton/python/triton/language/semantic.py:603-614`: `if (range & (range - 1)) != 0: raise ValueError("arange's range must be a power of 2")`. Non-power-of-2 world sizes (3, 5, 6, 7...) cause a compile-time `ValueError` crash.

The sibling kernel `_prepare_alltoallv_kernel` in the same file correctly uses `BLOCK_SIZE=triton.next_power_of_2(self.world_size)` with masking (`mask = offsets < W`), but `_sum_int64_kernel` was not updated to match.

Fix: Apply the same power-of-2 rounding + masking pattern that `_prepare_alltoallv_kernel` already uses. The `_prep_block_size` is already computed and available.

Reviewed By: srinathb-meta

Differential Revision: D101236430


