### PR TITLE
Fix colltrace ordering in AllGather test with paired collectives

### DIFF
--- a/comms/ctran/colltrace/CollTraceWrapper.cc
+++ b/comms/ctran/colltrace/CollTraceWrapper.cc
@@ -368,6 +368,7 @@ bool isP2PKernel(KernelConfig::KernelType kernelType) {
       KernelConfig::KernelType::SEND,
       KernelConfig::KernelType::RECV,
       KernelConfig::KernelType::SENDRECV,
+      KernelConfig::KernelType::SENDRECV_P2P,
       KernelConfig::KernelType::RECV_UNPACK,
       KernelConfig::KernelType::SENDRECV_UNPACK,
       KernelConfig::KernelType::SENDRECV_P2P,

--- a/comms/ctran/tests/CtranDistAllgatherTests.cc
+++ b/comms/ctran/tests/CtranDistAllgatherTests.cc
@@ -5,6 +5,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <stdlib.h>
+#include <algorithm>
 #include <thread>
 
 #include "CtranUtUtils.h"
@@ -129,6 +130,23 @@ class CtranAllgatherTest : public ctran::CtranDistTestFixture,
     }
   }
 
+  // Drain colltrace, parse pastColls, and sort by collId (submission order).
+  folly::dynamic getPastColls() {
+    EXPECT_NE(ctranComm->colltraceNew_, nullptr);
+    auto dumpMap = ctran::waitForCollTraceDrain(ctranComm.get());
+    EXPECT_NE(dumpMap["CT_pastColls"], "[]");
+    EXPECT_EQ(dumpMap["CT_pendingColls"], "[]");
+    EXPECT_EQ(dumpMap["CT_currentColls"], "[]");
+    auto pastColls = folly::parseJson(dumpMap["CT_pastColls"]);
+    std::sort(
+        pastColls.begin(),
+        pastColls.end(),
+        [](const folly::dynamic& a, const folly::dynamic& b) {
+          return a["collId"].asInt() < b["collId"].asInt();
+        });
+    return pastColls;
+  }
+
  protected:
   cudaStream_t testStream{0};
   std::unique_ptr<CtranComm> ctranComm{nullptr};
@@ -227,17 +245,7 @@ TEST_P(CtranAllgatherTestParam, AllgatherAlgo) {
   verifyGpeLeak(ctranComm->ctran_.get());
 
   CUDACHECK_TEST(cudaDeviceSynchronize());
-  // Sleep for a while to make sure all the colls are finished
-  std::this_thread::sleep_for(std::chrono::seconds(2));
-
-  ASSERT_NE(ctranComm->colltraceNew_, nullptr);
-  auto dumpMap = ctran::dumpCollTrace(ctranComm.get());
-
-  EXPECT_NE(dumpMap["CT_pastColls"], "[]");
-  EXPECT_EQ(dumpMap["CT_pendingColls"], "[]");
-  EXPECT_EQ(dumpMap["CT_currentColls"], "[]");
-
-  auto pastCollsJson = folly::parseJson(dumpMap["CT_pastColls"]);
+  auto pastCollsJson = getPastColls();
   EXPECT_EQ(pastCollsJson.size(), expOpNames.size());
   int idx = 0;
   for (const auto& coll : pastCollsJson) {
@@ -465,17 +473,7 @@ TEST_P(CtranSocketAllgatherTestParam, AllgatherAlgo) {
   verifyGpeLeak(ctranComm->ctran_.get());
 
   CUDACHECK_TEST(cudaDeviceSynchronize());
-  // Sleep for a while to make sure all the colls are finished
-  std::this_thread::sleep_for(std::chrono::seconds(2));
-
-  ASSERT_NE(ctranComm->colltraceNew_, nullptr);
-  auto dumpMap = ctran::dumpCollTrace(ctranComm.get());
-
-  EXPECT_NE(dumpMap["CT_pastColls"], "[]");
-  EXPECT_EQ(dumpMap["CT_pendingColls"], "[]");
-  EXPECT_EQ(dumpMap["CT_currentColls"], "[]");
-
-  auto pastCollsJson = folly::parseJson(dumpMap["CT_pastColls"]);
+  auto pastCollsJson = getPastColls();
   EXPECT_EQ(pastCollsJson.size(), expOpNames.size());
   int idx = 0;
   for (const auto& coll : pastCollsJson) {

--- a/comms/ctran/tests/CtranDistAlltoAllTest.cc
+++ b/comms/ctran/tests/CtranDistAlltoAllTest.cc
@@ -205,11 +205,9 @@ class CtranAllToAllTest : public ctran::CtranDistTestFixture,
     }
 
     CUDACHECK_TEST(cudaDeviceSynchronize());
-    // Sleep for a while to make sure all the colls are finished
-    std::this_thread::sleep_for(std::chrono::seconds(2));
 
     ASSERT_NE(ctranComm->colltraceNew_, nullptr);
-    auto dumpMap = ctran::dumpCollTrace(ctranComm.get());
+    auto dumpMap = ctran::waitForCollTraceDrain(ctranComm.get());
 
     EXPECT_EQ(dumpMap["CT_pendingColls"], "[]");
     EXPECT_EQ(dumpMap["CT_currentColls"], "[]");

--- a/comms/ctran/tests/CtranDistSendRecvUT.cc
+++ b/comms/ctran/tests/CtranDistSendRecvUT.cc
@@ -276,13 +276,10 @@ class CtranTestFixture : public ctran::CtranDistTestFixture,
     verifyGpeLeak(ctranComm->ctran_.get());
 
     if (!useGraph) {
-      // Brief wait for GPE thread to flush colltrace entries after stream sync
-      std::this_thread::sleep_for(std::chrono::seconds(2));
-
       // Check the coll trace only for participating ranks
       bool participated = (globalRank == sendRank) || isReceiver;
       if (participated) {
-        auto dumpMap = ctran::dumpCollTrace(ctranComm.get());
+        auto dumpMap = ctran::waitForCollTraceDrain(ctranComm.get());
         ASSERT_FALSE(dumpMap.empty()) << "Colltrace should be initialized";
 
         int numSendPeers = oneToOne ? 1 : (numRanks - 1);

--- a/comms/ctran/tests/CtranDistTestUtils.cc
+++ b/comms/ctran/tests/CtranDistTestUtils.cc
@@ -174,6 +174,28 @@ std::unordered_map<std::string, std::string> dumpCollTrace(CtranComm* comm) {
   return commDumpToMap(dump.value());
 }
 
+std::unordered_map<std::string, std::string> waitForCollTraceDrain(
+    CtranComm* comm,
+    int timeoutMs) {
+  if (comm->colltraceNew_ == nullptr) {
+    return {};
+  }
+  constexpr int kPollIntervalMs = 50;
+  auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::milliseconds(timeoutMs);
+  std::unordered_map<std::string, std::string> dumpMap;
+  while (std::chrono::steady_clock::now() < deadline) {
+    dumpMap = dumpCollTrace(comm);
+    auto it = dumpMap.find("CT_currentColls");
+    if (it != dumpMap.end() && it->second == "[]") {
+      return dumpMap;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(kPollIntervalMs));
+  }
+  // Return whatever we have after timeout
+  return dumpMap.empty() ? dumpCollTrace(comm) : dumpMap;
+}
+
 void CtranDistTestFixture::barrierNvlDomain(CtranComm* comm) {
   auto resFuture = comm->bootstrap_->barrierNvlDomain(
       comm->statex_->localRank(),

--- a/comms/ctran/tests/CtranDistTestUtils.h
+++ b/comms/ctran/tests/CtranDistTestUtils.h
@@ -59,4 +59,11 @@ class CtranDistTestFixture : public CtranTestFixtureBase,
 // "CT_currentColls". Returns empty map if colltrace is not initialized.
 std::unordered_map<std::string, std::string> dumpCollTrace(CtranComm* comm);
 
+// Poll until CT_currentColls drains to "[]", then return the final dump.
+// On single-node configs, CudaWaitEvent may delay colltrace transitions,
+// so a fixed sleep is insufficient. Polls every 50ms up to timeoutMs.
+std::unordered_map<std::string, std::string> waitForCollTraceDrain(
+    CtranComm* comm,
+    int timeoutMs = 5000);
+
 } // namespace ctran


### PR DESCRIPTION
Summary:
Fix flaky AllGather test failure when paired with AllReduce (testPairAllReduce, count=1). The colltrace pastColls entries are ordered by completion timestamp, not submission order. When operations complete very fast (count=1), the colltrace poll thread may detect them in the same iteration with near-identical timestamps, causing pastColls to have AllReduce before AllGather despite same-stream submission ordering.
- Replace fixed 2s sleep + dumpCollTrace with waitForCollTraceDrain for reliable drain
- Sort pastColls by collId (monotonically increasing submission-order ID) before strict-order verification
- Extract getPastColls() helper to deduplicate drain + parse + sort logic across two test paths

Root cause: colltrace PendingAction multiset sorts by wall-clock timestamp. For same-timestamp entries, multiset insertion order is undefined. Filed for colltrace owner to consider sorting by collId in PendingAction::operator< as a proper fix.

Differential Revision: D101581803


