### PR TITLE
cudagraph test building utils

### DIFF
--- a/comms/ctran/gpe/CtranGpe.cc
+++ b/comms/ctran/gpe/CtranGpe.cc
@@ -472,6 +472,18 @@ size_t CtranGpe::numInUseKernelFlags() {
       this->pimpl->kernelFlagPool->size();
 }
 
+size_t CtranGpe::numInUseChecksums() {
+  this->pimpl->checksumPool->reclaim();
+  return this->pimpl->checksumPool->capacity() -
+      this->pimpl->checksumPool->size();
+}
+
+size_t CtranGpe::numInUseGpeKernelSyncs() {
+  this->pimpl->gpeKernelSyncPool->reclaim();
+  return this->pimpl->gpeKernelSyncPool->capacity() -
+      this->pimpl->gpeKernelSyncPool->size();
+}
+
 commResult_t CtranGpe::allocGpeKernelSyncs(
     size_t count,
     int nworkers,

--- a/comms/ctran/gpe/CtranGpe.h
+++ b/comms/ctran/gpe/CtranGpe.h
@@ -424,6 +424,12 @@ class CtranGpe {
   // Used to check potential flag leak in UT due to inproper usage in ctran
   size_t numInUseKernelFlags();
 
+  // Return number of inuse checksums.
+  size_t numInUseChecksums();
+
+  // Return number of inuse GPE kernel syncs.
+  size_t numInUseGpeKernelSyncs();
+
   commResult_t allocGpeKernelSyncs(
       size_t count,
       int nworkers,

--- a/comms/ctran/tests/CtranNcclTestUtils.cc
+++ b/comms/ctran/tests/CtranNcclTestUtils.cc
@@ -69,12 +69,17 @@ void CtranNcclTestHelpers::releaseBuf(
     void* buf,
     size_t bufSize,
     MemAllocType memType,
-    size_t numSegments) {
+    size_t numSegments,
+    bool refCheck) {
   if (memType == kMemCudaMalloc) {
     CUDACHECK_TEST(cudaFree(buf));
   } else if (memType == kMemNcclMemAlloc) {
 #if !defined(USE_ROCM)
-    NCCLCHECK_TEST(ncclMemFreeWithRefCheck(buf));
+    if (refCheck) {
+      NCCLCHECK_TEST(ncclMemFreeWithRefCheck(buf));
+    } else {
+      ncclMemFree(buf);
+    }
 #else
     XLOG(FATAL) << "kMemNcclMemAlloc is not supported on AMD/HIP";
 #endif

--- a/comms/ctran/tests/CtranNcclTestUtils.h
+++ b/comms/ctran/tests/CtranNcclTestUtils.h
@@ -75,7 +75,79 @@ class CtranNcclTestHelpers : public CtranTestHelpers {
       void* buf,
       size_t bufSize,
       MemAllocType memType,
-      size_t numSegments = 2);
+      size_t numSegments = 2,
+      bool refCheck = true);
+};
+
+// RAII wrapper around prepareBuf/releaseBuf for automatic lifetime management.
+// Defaults to kMemNcclMemAlloc for NVL-registered buffers.
+class TestDeviceBuffer {
+ public:
+  explicit TestDeviceBuffer(
+      size_t size,
+      MemAllocType memType = kMemNcclMemAlloc,
+      size_t numSegments = 2,
+      bool refCheck = false)
+      : size_(size),
+        memType_(memType),
+        numSegments_(numSegments),
+        refCheck_(refCheck) {
+    ptr_ =
+        CtranNcclTestHelpers::prepareBuf(size, memType, segments_, numSegments);
+  }
+
+  ~TestDeviceBuffer() {
+    if (ptr_) {
+      CtranNcclTestHelpers::releaseBuf(
+          ptr_, size_, memType_, numSegments_, refCheck_);
+    }
+  }
+
+  TestDeviceBuffer(const TestDeviceBuffer&) = delete;
+  TestDeviceBuffer& operator=(const TestDeviceBuffer&) = delete;
+
+  TestDeviceBuffer(TestDeviceBuffer&& other) noexcept
+      : ptr_(other.ptr_),
+        size_(other.size_),
+        memType_(other.memType_),
+        numSegments_(other.numSegments_),
+        refCheck_(other.refCheck_),
+        segments_(std::move(other.segments_)) {
+    other.ptr_ = nullptr;
+    other.size_ = 0;
+  }
+
+  TestDeviceBuffer& operator=(TestDeviceBuffer&& other) noexcept {
+    if (this != &other) {
+      if (ptr_) {
+        CtranNcclTestHelpers::releaseBuf(
+            ptr_, size_, memType_, numSegments_, refCheck_);
+      }
+      ptr_ = other.ptr_;
+      size_ = other.size_;
+      memType_ = other.memType_;
+      segments_ = std::move(other.segments_);
+      other.ptr_ = nullptr;
+      other.size_ = 0;
+    }
+    return *this;
+  }
+
+  void* get() const {
+    return ptr_;
+  }
+
+  size_t size() const {
+    return size_;
+  }
+
+ private:
+  void* ptr_{nullptr};
+  size_t size_{0};
+  MemAllocType memType_{};
+  size_t numSegments_{2};
+  bool refCheck_{true};
+  std::vector<TestMemSegment> segments_{};
 };
 
 } // namespace ctran

--- a/comms/ctran/tests/cudagraph/CtranCudaGraphParamTest.h
+++ b/comms/ctran/tests/cudagraph/CtranCudaGraphParamTest.h
@@ -1,0 +1,187 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "comms/ctran/tests/cudagraph/CtranCudaGraphTestBase.h"
+#include "comms/ctran/tests/cudagraph/CudaGraphTestBuilder.h"
+#include "comms/ctran/tests/cudagraph/DeviceVerify.h"
+
+enum class GraphPattern {
+  Basic,
+};
+
+inline const char* patternToString(GraphPattern pattern) {
+  switch (pattern) {
+    case GraphPattern::Basic:
+      return "Basic";
+  }
+  return "Unknown";
+}
+
+// Base replay count per pattern. Multiplied by the replay multiplier parameter.
+inline int baseReplays(GraphPattern pattern) {
+  switch (pattern) {
+    case GraphPattern::Basic:
+      return 5;
+  }
+  return 3;
+}
+
+struct AlgoDescriptor {
+  struct Buffers {
+    virtual ~Buffers() = default;
+    virtual void* sendbuf() = 0;
+    virtual void* recvbuf() = 0;
+    virtual size_t recvBytes() = 0;
+  };
+
+  std::string name;
+
+  std::function<bool(CtranComm*, size_t count)> expectsHostNodes =
+      [](CtranComm*, size_t) { return true; };
+
+  std::function<bool(CtranComm*, size_t count, int numRanks)> isSupported;
+
+  std::function<std::shared_ptr<Buffers>(size_t count, int rank, int nRanks)>
+      makeBuffers;
+
+  std::function<void(Buffers*, size_t count, ctran::testing::CaptureContext&)>
+      capture;
+};
+
+// Run the collective eagerly to compute expected output.
+// Uses the same comm as graph capture — the eager run warms up connections
+// which is needed for some algorithms on certain topologies.
+inline void computeExpected(
+    AlgoDescriptor& desc,
+    AlgoDescriptor::Buffers* bufs,
+    size_t count,
+    CtranComm* comm,
+    int rank,
+    int nRanks) {
+  meta::comms::CudaStream stream(cudaStreamNonBlocking);
+  ctran::testing::CaptureContext ctx{comm, stream.get(), rank, nRanks};
+  desc.capture(bufs, count, ctx);
+  ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
+  cudaDeviceSynchronize();
+}
+
+// Launch device-side buffer comparison kernel. Async on stream, no host sync.
+inline void deviceVerifyAgainstExpected(
+    AlgoDescriptor::Buffers* actual,
+    AlgoDescriptor::Buffers* expected,
+    unsigned int* mismatchCount_d,
+    cudaStream_t stream) {
+  ctran::testing::launchCompareBuffers(
+      actual->recvbuf(),
+      expected->recvbuf(),
+      actual->recvBytes(),
+      mismatchCount_d,
+      stream);
+}
+
+inline void runBasicPattern(
+    CtranComm* comm,
+    int rank,
+    int nRanks,
+    size_t count,
+    int numReplays,
+    AlgoDescriptor& desc) {
+  auto bufs = desc.makeBuffers(count, rank, nRanks);
+  auto expected = desc.makeBuffers(count, rank, nRanks);
+  computeExpected(desc, expected.get(), count, comm, rank, nRanks);
+
+  ctran::testing::CtranGraphTestBuilder(comm, rank, nRanks)
+      .withNumReplays(numReplays)
+      .addCapture([&](ctran::testing::CaptureContext& ctx) {
+        desc.capture(bufs.get(), count, ctx);
+      })
+      .withReset([&](cudaStream_t stream) {
+        cudaMemsetAsync(bufs->recvbuf(), 0, bufs->recvBytes(), stream);
+      })
+      .withDeviceVerify([&](cudaStream_t stream, unsigned int* mc) {
+        deviceVerifyAgainstExpected(bufs.get(), expected.get(), mc, stream);
+      })
+      .withGraphAssertions(
+          CtranCudaGraphTestBase::expectGraphNodes(
+              desc.expectsHostNodes(comm, count) ? 1 : 0))
+      .run();
+}
+
+// GraphTestParam: (algo, pattern, count, replayMultiplier)
+// Actual replays = baseReplays(pattern) * replayMultiplier
+using GraphTestParam = std::tuple<AlgoDescriptor, GraphPattern, size_t, int>;
+
+#ifndef CUDAGRAPH_TEST_PATTERN
+static_assert(false && "CUDAGRAPH_TEST_PATTERN must be defined");
+#endif
+
+inline void runPattern(
+    GraphPattern pattern,
+    CtranComm* comm,
+    int rank,
+    int nRanks,
+    size_t count,
+    int numReplays,
+    AlgoDescriptor& desc) {
+  switch (pattern) {
+    case GraphPattern::Basic:
+      runBasicPattern(comm, rank, nRanks, count, numReplays, desc);
+      break;
+  }
+}
+
+#define DEFINE_CUDAGRAPH_PARAM_TEST(SuiteName, ...)                          \
+  class SuiteName : public CtranCudaGraphTestBase,                           \
+                    public ::testing::WithParamInterface<GraphTestParam> {}; \
+                                                                             \
+  TEST_P(SuiteName, CudaGraphOp) {                                           \
+    auto [desc, pattern, count, replayMult] = GetParam();                    \
+    int numReplays = baseReplays(pattern) * replayMult;                      \
+    auto comm = makeCtranComm();                                             \
+    ASSERT_NE(comm, nullptr);                                                \
+    if (!desc.isSupported(comm.get(), count, numRanks)) {                    \
+      GTEST_SKIP() << desc.name << " not supported";                         \
+    }                                                                        \
+    runPattern(                                                              \
+        pattern, comm.get(), globalRank, numRanks, count, numReplays, desc); \
+  }                                                                          \
+                                                                             \
+  std::string SuiteName##TestName(                                           \
+      const ::testing::TestParamInfo<GraphTestParam>& info) {                \
+    auto& [desc, pattern, count, replayMult] = info.param;                   \
+    return desc.name + "_" + patternToString(pattern) + "_" +                \
+        std::to_string(count) + "_x" + std::to_string(replayMult);           \
+  }                                                                          \
+                                                                             \
+  INSTANTIATE_TEST_SUITE_P(                                                  \
+      SuiteName##Tests,                                                      \
+      SuiteName,                                                             \
+      ::testing::Combine(                                                    \
+          ::testing::Values(__VA_ARGS__),                                    \
+          ::testing::Values(CUDAGRAPH_TEST_PATTERN),                         \
+          ::testing::Values(1024UL, 8192UL),                                 \
+          ::testing::Values(1)),                                             \
+      SuiteName##TestName)
+
+// Stress variant: reuses the same test class from DEFINE_CUDAGRAPH_PARAM_TEST
+// but with a higher replay multiplier. Must be in a separate .cc / BUCK target
+// with a longer re_timeout.
+#define DEFINE_CUDAGRAPH_STRESS_TEST(SuiteName, Multiplier, ...) \
+  INSTANTIATE_TEST_SUITE_P(                                      \
+      SuiteName##StressTests,                                    \
+      SuiteName,                                                 \
+      ::testing::Combine(                                        \
+          ::testing::Values(__VA_ARGS__),                        \
+          ::testing::Values(                                     \
+              GraphPattern::Basic,                               \
+              GraphPattern::MultipleSequential,                  \
+              GraphPattern::MultiStream),                        \
+          ::testing::Values(8192UL),                             \
+          ::testing::Values(Multiplier)),                        \
+      SuiteName##TestName)

--- a/comms/ctran/tests/cudagraph/CtranCudaGraphTestBase.h
+++ b/comms/ctran/tests/cudagraph/CtranCudaGraphTestBase.h
@@ -1,0 +1,175 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#include <thread>
+#include <vector>
+
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+
+#include "comms/ctran/tests/CtranDistTestUtils.h"
+#include "comms/ctran/tests/CtranNcclTestUtils.h"
+#include "comms/ctran/tests/cudagraph/CudaGraphTestBuilder.h"
+#include "comms/utils/test_utils/CudaGraphTestUtils.h"
+
+class CtranCudaGraphEnvironment : public ctran::CtranDistEnvironment {
+ public:
+  void SetUp() override {
+    setenv("NCCL_CTRAN_ALLOW_CUDA_GRAPH", "1", 1);
+    setenv("NCCL_CTRAN_ENABLE", "1", 0);
+#ifdef NCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL
+    setenv("NCCL_COMM_STATE_DEBUG_TOPO", "nolocal", 1);
+#endif
+#ifdef NCCL_COMM_STATE_DEBUG_TOPO_VNODE
+    setenv("NCCL_COMM_STATE_DEBUG_TOPO", "vnode", 1);
+#endif
+#ifdef TEST_FAST_INIT_MODE_NONE
+    setenv("NCCL_FASTINIT_MODE", "none", 1);
+#endif
+    ctran::CtranDistEnvironment::SetUp();
+  }
+};
+
+class CtranCudaGraphTestBase : public ctran::CtranDistTestFixture {
+ public:
+  void SetUp() override {
+    CtranDistTestFixture::SetUp();
+  }
+
+  void TearDown() override {
+    CtranDistTestFixture::TearDown();
+  }
+
+ public:
+  static constexpr size_t kDefaultCount = 1024;
+
+  void waitAndVerifyGpeClean(CtranComm* comm) {
+    ASSERT_NE(comm->ctran_, nullptr);
+    constexpr int kMaxSpinMs = 5000;
+    constexpr int kSpinIntervalMs = 10;
+    int elapsedMs = 0;
+    while (elapsedMs < kMaxSpinMs) {
+      if (comm->ctran_->gpe->numInUseKernelFlags() == 0 &&
+          comm->ctran_->gpe->numInUseKernelElems() == 0 &&
+          comm->ctran_->gpe->numInUseChecksums() == 0 &&
+          comm->ctran_->gpe->numInUseGpeKernelSyncs() == 0) {
+        return;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(kSpinIntervalMs));
+      elapsedMs += kSpinIntervalMs;
+    }
+    EXPECT_EQ(comm->ctran_->gpe->numInUseKernelFlags(), 0)
+        << "KernelFlag leak after graph destroy";
+    EXPECT_EQ(comm->ctran_->gpe->numInUseKernelElems(), 0)
+        << "KernelElem leak after graph destroy";
+    EXPECT_EQ(comm->ctran_->gpe->numInUseChecksums(), 0)
+        << "Checksum leak after graph destroy";
+    EXPECT_EQ(comm->ctran_->gpe->numInUseGpeKernelSyncs(), 0)
+        << "GpeKernelSync leak after graph destroy";
+  }
+
+  static void fillSendBuf(void* buf, size_t count, int32_t val) {
+    std::vector<int32_t> h(count, val);
+    CUDACHECK_TEST(
+        cudaMemcpy(buf, h.data(), count * sizeof(int32_t), cudaMemcpyDefault));
+  }
+
+  void verifyAllGather(const void* recvbuf, size_t sendcount, int nRanks) {
+    size_t totalCount = sendcount * nRanks;
+    std::vector<int32_t> h(totalCount);
+    CUDACHECK_TEST(cudaMemcpy(
+        h.data(), recvbuf, totalCount * sizeof(int32_t), cudaMemcpyDefault));
+    for (int r = 0; r < nRanks; ++r) {
+      for (size_t i = 0; i < sendcount; ++i) {
+        ASSERT_EQ(h[r * sendcount + i], r)
+            << "AllGather mismatch at rank segment " << r << " index " << i;
+      }
+    }
+  }
+
+  void verifyAllReduce(const void* recvbuf, size_t count, int nRanks) {
+    std::vector<int32_t> h(count);
+    CUDACHECK_TEST(cudaMemcpy(
+        h.data(), recvbuf, count * sizeof(int32_t), cudaMemcpyDefault));
+    int32_t expected = nRanks * (nRanks - 1) / 2; // sum of 0..nRanks-1
+    for (size_t i = 0; i < count; ++i) {
+      ASSERT_EQ(h[i], expected) << "AllReduce mismatch at index " << i;
+    }
+  }
+
+  void verifyReduceScatter(
+      const void* recvbuf,
+      size_t recvcount,
+      int rank,
+      int nRanks) {
+    std::vector<int32_t> h(recvcount);
+    CUDACHECK_TEST(cudaMemcpy(
+        h.data(), recvbuf, recvcount * sizeof(int32_t), cudaMemcpyDefault));
+    int32_t expected = nRanks * (nRanks - 1) / 2;
+    for (size_t i = 0; i < recvcount; ++i) {
+      ASSERT_EQ(h[i], expected)
+          << "ReduceScatter mismatch at index " << i << " on rank " << rank;
+    }
+  }
+
+  // AllToAll with uniform counts: same layout as AllGather (each rank's
+  // segment filled with that rank's value).
+  void verifyAllToAll(const void* recvbuf, size_t countPerRank, int nRanks) {
+    verifyAllGather(recvbuf, countPerRank, nRanks);
+  }
+
+  // AllToAllv with variable counts/displacements: recvbuf at
+  // rdispls[p]..rdispls[p]+recvcounts[p]-1 should equal p (the sender's rank).
+  void verifyAllToAllv(
+      const void* recvbuf,
+      const size_t* recvcounts,
+      const size_t* rdispls,
+      int nRanks) {
+    size_t totalRecv = 0;
+    for (int p = 0; p < nRanks; ++p) {
+      totalRecv = std::max(totalRecv, rdispls[p] + recvcounts[p]);
+    }
+    std::vector<int32_t> h(totalRecv);
+    CUDACHECK_TEST(cudaMemcpy(
+        h.data(), recvbuf, totalRecv * sizeof(int32_t), cudaMemcpyDefault));
+    for (int p = 0; p < nRanks; ++p) {
+      for (size_t i = 0; i < recvcounts[p]; ++i) {
+        ASSERT_EQ(h[rdispls[p] + i], p)
+            << "AllToAllv mismatch from peer " << p << " index " << i;
+      }
+    }
+  }
+
+  // Returns a GraphAssertionsFn that verifies each captured graph has at least
+  // the expected number of HOST and KERNEL nodes.
+  static ctran::testing::GraphAssertionsFn expectGraphNodes(
+      size_t minHostNodes = 1,
+      size_t minKernelNodes = 1) {
+    return [=](const std::vector<GraphTopology>& topos) {
+      for (size_t i = 0; i < topos.size(); ++i) {
+        EXPECT_GE(
+            topos[i].nodesOfType(cudaGraphNodeTypeHost).size(), minHostNodes)
+            << "Graph " << i << ": expected at least " << minHostNodes
+            << " HOST node(s)";
+        EXPECT_GE(
+            topos[i].nodesOfType(cudaGraphNodeTypeKernel).size(),
+            minKernelNodes)
+            << "Graph " << i << ": expected at least " << minKernelNodes
+            << " KERNEL node(s)";
+      }
+    };
+  }
+
+  void verifyBroadcast(const void* recvbuf, size_t count, int32_t rootVal) {
+    std::vector<int32_t> h(count);
+    CUDACHECK_TEST(cudaMemcpy(
+        h.data(), recvbuf, count * sizeof(int32_t), cudaMemcpyDefault));
+    for (size_t i = 0; i < count; ++i) {
+      ASSERT_EQ(h[i], rootVal) << "Broadcast mismatch at index " << i;
+    }
+  }
+};

--- a/comms/ctran/tests/cudagraph/CudaGraphTestBuilder.cc
+++ b/comms/ctran/tests/cudagraph/CudaGraphTestBuilder.cc
@@ -1,0 +1,353 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/ctran/tests/cudagraph/CudaGraphTestBuilder.h"
+
+#include <chrono>
+#include <optional>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include "comms/ctran/gpe/CtranGpe.h"
+#include "comms/ctran/interfaces/ICtran.h"
+
+namespace ctran::testing {
+
+GpePoolGuard::GpePoolGuard(CtranGpe* gpe, size_t maxGrowth)
+    : gpe_(gpe),
+      maxGrowth_(maxGrowth),
+      initialFlags_(gpe->numInUseKernelFlags()),
+      initialElems_(gpe->numInUseKernelElems()),
+      initialChecksums_(gpe->numInUseChecksums()),
+      initialSyncs_(gpe->numInUseGpeKernelSyncs()) {}
+
+GpePoolGuard::~GpePoolGuard() {
+  EXPECT_LE(gpe_->numInUseKernelFlags(), initialFlags_ + maxGrowth_)
+      << "KernelFlag pool growing unboundedly";
+  EXPECT_LE(gpe_->numInUseKernelElems(), initialElems_ + maxGrowth_)
+      << "KernelElem pool growing unboundedly";
+  EXPECT_LE(gpe_->numInUseChecksums(), initialChecksums_ + maxGrowth_)
+      << "Checksum pool growing unboundedly";
+  EXPECT_LE(gpe_->numInUseGpeKernelSyncs(), initialSyncs_ + maxGrowth_)
+      << "GpeKernelSync pool growing unboundedly";
+}
+
+CapturedGraph::~CapturedGraph() {
+  if (graphExec) {
+    cudaGraphExecDestroy(graphExec);
+  }
+  if (graph) {
+    cudaGraphDestroy(graph);
+  }
+}
+
+CapturedGraph::CapturedGraph(CapturedGraph&& other) noexcept
+    : graph(other.graph),
+      graphExec(other.graphExec),
+      captureStream(other.captureStream) {
+  other.graph = nullptr;
+  other.graphExec = nullptr;
+  other.captureStream = nullptr;
+}
+
+CapturedGraph& CapturedGraph::operator=(CapturedGraph&& other) noexcept {
+  if (this != &other) {
+    if (graphExec) {
+      cudaGraphExecDestroy(graphExec);
+    }
+    if (graph) {
+      cudaGraphDestroy(graph);
+    }
+    graph = other.graph;
+    graphExec = other.graphExec;
+    captureStream = other.captureStream;
+    other.graph = nullptr;
+    other.graphExec = nullptr;
+    other.captureStream = nullptr;
+  }
+  return *this;
+}
+
+CtranGraphTestBuilder::CtranGraphTestBuilder(
+    CtranComm* comm,
+    int rank,
+    int numRanks)
+    : comm_(comm), rank_(rank), numRanks_(numRanks) {}
+
+CtranGraphTestBuilder& CtranGraphTestBuilder::withNumReplays(int n) {
+  numReplays_ = n;
+  return *this;
+}
+
+CtranGraphTestBuilder& CtranGraphTestBuilder::addCapture(
+    cudaStream_t,
+    CaptureFn captureFn) {
+  // addCapture is sugar for a single-step single-substep Graph schedule entry.
+  // The stream parameter is ignored — scheduleReplay creates its own streams.
+  schedule_.push_back({{ScheduleEntryType::Graph, std::move(captureFn)}});
+  return *this;
+}
+
+CtranGraphTestBuilder& CtranGraphTestBuilder::addCapture(CaptureFn captureFn) {
+  return addCapture(nullptr, std::move(captureFn));
+}
+
+CtranGraphTestBuilder& CtranGraphTestBuilder::addSchedule(Schedule schedule) {
+  EXPECT_TRUE(schedule_.empty())
+      << "addSchedule() cannot be combined with addCapture()";
+  schedule_ = std::move(schedule);
+  return *this;
+}
+
+CtranGraphTestBuilder& CtranGraphTestBuilder::withReset(ResetFn resetFn) {
+  resetFn_ = std::move(resetFn);
+  return *this;
+}
+
+CtranGraphTestBuilder& CtranGraphTestBuilder::withVerify(VerifyFn verifyFn) {
+  verifyFn_ = std::move(verifyFn);
+  return *this;
+}
+
+CtranGraphTestBuilder& CtranGraphTestBuilder::withDeviceVerify(
+    DeviceVerifyFn fn) {
+  deviceVerifyFn_ = std::move(fn);
+  mismatchCounter_.emplace();
+  return *this;
+}
+
+CtranGraphTestBuilder& CtranGraphTestBuilder::withGraphAssertions(
+    GraphAssertionsFn fn) {
+  graphAssertionsFn_ = std::move(fn);
+  return *this;
+}
+
+CtranGraphTestBuilder& CtranGraphTestBuilder::withResourcePoolCheck(
+    bool enable) {
+  checkResourcePools_ = enable;
+  return *this;
+}
+
+void CtranGraphTestBuilder::run() {
+  ASSERT_FALSE(schedule_.empty())
+      << "Must call addCapture() or addSchedule() before run()";
+  scheduleReplay();
+  if (mismatchCounter_) {
+    mismatchCounter_->assertZero();
+  }
+  destroy();
+  verifyGpeLeak();
+}
+
+void CtranGraphTestBuilder::scheduleReplay() {
+  // Allocate per-substep streams and graph holders (initially null).
+  // Graph entries are captured on the first replay iteration.
+  std::vector<std::vector<meta::comms::CudaStream>> stepStreams;
+  scheduleGraphs_.resize(schedule_.size());
+  stepStreams.reserve(schedule_.size());
+  for (size_t s = 0; s < schedule_.size(); ++s) {
+    auto& step = schedule_[s];
+    scheduleGraphs_[s].resize(step.size());
+    stepStreams.emplace_back();
+    stepStreams.back().reserve(step.size());
+    for (size_t j = 0; j < step.size(); ++j) {
+      stepStreams.back().emplace_back(cudaStreamNonBlocking);
+    }
+  }
+
+  size_t numGraphEntries = 0;
+  for (auto& step : schedule_) {
+    for (auto& entry : step) {
+      if (entry.type == ScheduleEntryType::Graph) {
+        ++numGraphEntries;
+      }
+    }
+  }
+
+  // Pool guard is created after the first iteration (when graphs are captured)
+  // so the snapshot reflects the post-capture state.
+  std::optional<GpePoolGuard> poolGuard;
+  cudaEvent_t iterDoneEvent = nullptr;
+
+  for (int iter = 0; iter < numReplays_; ++iter) {
+    // Reset buffers. The first stream from step 0 is used for async reset
+    // so it's ordered before the schedule steps on that stream.
+    cudaStream_t firstStream = stepStreams[0][0].get();
+
+    // Wait for previous iteration's verify to complete before resetting
+    // buffers (verify may run on a different stream in multi-step schedules).
+    if (iterDoneEvent) {
+      ASSERT_EQ(
+          cudaStreamWaitEvent(firstStream, iterDoneEvent, 0), cudaSuccess);
+      cudaEventDestroy(iterDoneEvent);
+      iterDoneEvent = nullptr;
+    }
+
+    if (resetFn_) {
+      resetFn_(firstStream);
+    }
+
+    std::vector<cudaEvent_t> prevEvents;
+
+    for (size_t s = 0; s < schedule_.size(); ++s) {
+      auto& step = schedule_[s];
+      std::vector<cudaEvent_t> stepEvents;
+      stepEvents.reserve(step.size());
+
+      for (size_t j = 0; j < step.size(); ++j) {
+        cudaStream_t stream = stepStreams[s][j].get();
+
+        // Wait on all events from the previous step.
+        for (auto& ev : prevEvents) {
+          ASSERT_EQ(cudaStreamWaitEvent(stream, ev, 0), cudaSuccess);
+        }
+
+        if (step[j].type == ScheduleEntryType::Eager) {
+          // Eager: run lambda directly on the stream.
+          CaptureContext ctx{comm_, stream, rank_, numRanks_};
+          step[j].fn(ctx);
+        } else {
+          // Graph: capture on first iteration, replay on subsequent.
+          auto& cg = scheduleGraphs_[s][j];
+          if (!cg) {
+            cg = std::make_unique<CapturedGraph>();
+            cg->captureStream = stream;
+
+            ASSERT_EQ(
+                cudaStreamBeginCapture(stream, cudaStreamCaptureModeGlobal),
+                cudaSuccess);
+
+            CaptureContext ctx{comm_, stream, rank_, numRanks_};
+            step[j].fn(ctx);
+
+            ASSERT_EQ(cudaStreamEndCapture(stream, &cg->graph), cudaSuccess);
+            ASSERT_NE(cg->graph, nullptr);
+
+            ASSERT_EQ(
+                cudaGraphInstantiate(
+                    &cg->graphExec, cg->graph, nullptr, nullptr, 0),
+                cudaSuccess);
+            ASSERT_NE(cg->graphExec, nullptr);
+          }
+          ASSERT_EQ(cudaGraphLaunch(cg->graphExec, stream), cudaSuccess);
+        }
+
+        // Record an event after this substep completes.
+        cudaEvent_t ev;
+        ASSERT_EQ(cudaEventCreate(&ev), cudaSuccess);
+        ASSERT_EQ(cudaEventRecord(ev, stream), cudaSuccess);
+        stepEvents.push_back(ev);
+      }
+
+      // Destroy previous step events and move current to prev.
+      for (auto& ev : prevEvents) {
+        cudaEventDestroy(ev);
+      }
+      prevEvents = std::move(stepEvents);
+    }
+
+    // Device-side verify: launch comparison kernel on the last step's stream.
+    // No device sync needed — the kernel is ordered after the schedule steps.
+    cudaStream_t lastStream = stepStreams.back().back().get();
+    if (deviceVerifyFn_) {
+      // Ensure all steps complete before verify (join all prevEvents to
+      // lastStream).
+      for (auto& ev : prevEvents) {
+        ASSERT_EQ(cudaStreamWaitEvent(lastStream, ev, 0), cudaSuccess);
+      }
+      deviceVerifyFn_(lastStream, mismatchCounter_->ptr());
+
+      // Record event so the next iteration's reset waits for verify to finish
+      // reading the buffers (verify and reset may be on different streams).
+      ASSERT_EQ(cudaEventCreate(&iterDoneEvent), cudaSuccess);
+      ASSERT_EQ(cudaEventRecord(iterDoneEvent, lastStream), cudaSuccess);
+    }
+
+    // Clean up remaining events.
+    for (auto& ev : prevEvents) {
+      cudaEventDestroy(ev);
+    }
+
+    // After first iteration: sync for graph assertions and pool guard setup.
+    // Subsequent iterations run fully async (no device sync).
+    if (iter == 0) {
+      ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+      if (graphAssertionsFn_) {
+        std::vector<GraphTopology> topos;
+        for (auto& stepGraphs : scheduleGraphs_) {
+          for (auto& cg : stepGraphs) {
+            if (cg) {
+              topos.push_back(getGraphTopology(cg->graph));
+            }
+          }
+        }
+        if (!topos.empty()) {
+          graphAssertionsFn_(topos);
+        }
+      }
+      if (checkResourcePools_ && comm_->ctran_ && numGraphEntries > 0) {
+        poolGuard.emplace(comm_->ctran_->gpe.get(), numGraphEntries);
+      }
+    }
+  }
+
+  if (iterDoneEvent) {
+    cudaEventDestroy(iterDoneEvent);
+  }
+
+  // One final sync after all iterations.
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  // Legacy CPU-side verify (runs after final sync).
+  if (verifyFn_) {
+    verifyFn_();
+  }
+
+  // Move captured graphs into graphs_ so destroy() and verifyGpeLeak() work.
+  for (auto& stepGraphs : scheduleGraphs_) {
+    for (auto& cg : stepGraphs) {
+      if (cg) {
+        graphs_.push_back(std::move(cg));
+      }
+    }
+  }
+  scheduleGraphs_.clear();
+}
+
+void CtranGraphTestBuilder::destroy() {
+  graphs_.clear();
+  cudaDeviceSynchronize();
+}
+
+void CtranGraphTestBuilder::verifyGpeLeak() {
+  if (!comm_->ctran_) {
+    return;
+  }
+  // GPE pools use lazy reclaim — items may not be returned to the free pool
+  // immediately after graph destroy. Spin until all counters reach zero,
+  // with a timeout to catch real leaks.
+  constexpr int kMaxSpinMs = 5000;
+  constexpr int kSpinIntervalMs = 10;
+  int elapsedMs = 0;
+  while (elapsedMs < kMaxSpinMs) {
+    if (comm_->ctran_->gpe->numInUseKernelFlags() == 0 &&
+        comm_->ctran_->gpe->numInUseKernelElems() == 0 &&
+        comm_->ctran_->gpe->numInUseChecksums() == 0 &&
+        comm_->ctran_->gpe->numInUseGpeKernelSyncs() == 0) {
+      return;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(kSpinIntervalMs));
+    elapsedMs += kSpinIntervalMs;
+  }
+  EXPECT_EQ(comm_->ctran_->gpe->numInUseKernelFlags(), 0)
+      << "KernelFlag leak detected after graph destroy";
+  EXPECT_EQ(comm_->ctran_->gpe->numInUseKernelElems(), 0)
+      << "KernelElem leak detected after graph destroy";
+  EXPECT_EQ(comm_->ctran_->gpe->numInUseChecksums(), 0)
+      << "Checksum leak detected after graph destroy";
+  EXPECT_EQ(comm_->ctran_->gpe->numInUseGpeKernelSyncs(), 0)
+      << "GpeKernelSync leak detected after graph destroy";
+}
+
+} // namespace ctran::testing

--- a/comms/ctran/tests/cudagraph/CudaGraphTestBuilder.h
+++ b/comms/ctran/tests/cudagraph/CudaGraphTestBuilder.h
@@ -1,0 +1,156 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <functional>
+#include <memory>
+#include <vector>
+
+#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/tests/cudagraph/DeviceVerify.h"
+#include "comms/utils/CudaRAII.h"
+#include "comms/utils/test_utils/CudaGraphTestUtils.h"
+
+class CtranGpe;
+
+namespace ctran::testing {
+
+struct CaptureContext {
+  CtranComm* comm;
+  cudaStream_t stream;
+  int rank;
+  int numRanks;
+};
+
+struct CapturedGraph {
+  ~CapturedGraph();
+  CapturedGraph() = default;
+
+  CapturedGraph(const CapturedGraph&) = delete;
+  CapturedGraph& operator=(const CapturedGraph&) = delete;
+  CapturedGraph(CapturedGraph&& other) noexcept;
+  CapturedGraph& operator=(CapturedGraph&& other) noexcept;
+
+  cudaGraph_t graph{nullptr};
+  cudaGraphExec_t graphExec{nullptr};
+  cudaStream_t captureStream{nullptr};
+};
+
+using CaptureFn = std::function<void(CaptureContext& ctx)>;
+using ResetFn = std::function<void(cudaStream_t stream)>;
+using VerifyFn = std::function<void()>;
+using DeviceVerifyFn =
+    std::function<void(cudaStream_t stream, unsigned int* mismatchCount_d)>;
+using GraphAssertionsFn =
+    std::function<void(const std::vector<GraphTopology>& topos)>;
+
+// Schedule types for pipeline-style execution (fork-join across steps).
+enum class ScheduleEntryType { Eager, Graph };
+
+struct ScheduleEntry {
+  ScheduleEntryType type;
+  CaptureFn fn;
+};
+
+using ScheduleStep = std::vector<ScheduleEntry>;
+using Schedule = std::vector<ScheduleStep>;
+
+// RAII guard that snapshots GPE pool sizes on construction and asserts
+// they haven't grown unboundedly on destruction.
+class GpePoolGuard {
+ public:
+  GpePoolGuard(CtranGpe* gpe, size_t maxGrowth);
+  ~GpePoolGuard();
+
+  GpePoolGuard(const GpePoolGuard&) = delete;
+  GpePoolGuard& operator=(const GpePoolGuard&) = delete;
+
+ private:
+  CtranGpe* gpe_;
+  size_t maxGrowth_;
+  size_t initialFlags_;
+  size_t initialElems_;
+  size_t initialChecksums_;
+  size_t initialSyncs_;
+};
+
+// Builder for CTRAN CUDA graph tests with schedule-based pipeline execution.
+//
+// Supports two APIs:
+//   addCapture(fn)    — sugar for a single Graph step
+//   addSchedule(sched) — full pipeline with Eager/Graph fork-join steps
+//
+// Usage (simple):
+//   CtranGraphTestBuilder(comm, rank, nRanks)
+//       .addCapture([](CaptureContext& ctx) { ... })
+//       .withReset([]() { ... })
+//       .withVerify([]() { ... })
+//       .run();
+//
+// Usage (pipeline):
+//   CtranGraphTestBuilder(comm, rank, nRanks)
+//       .addSchedule({
+//           {{Graph, captureFn}},                  // step 1: graph only
+//           {{Eager, eagerFn}, {Graph, captureFn}}, // step 2: concurrent
+//           {{Eager, eagerFn}},                    // step 3: eager only
+//       })
+//       .withReset([]() { ... })
+//       .withVerify([]() { ... })
+//       .run();
+class CtranGraphTestBuilder {
+ public:
+  CtranGraphTestBuilder(CtranComm* comm, int rank, int numRanks);
+  CtranGraphTestBuilder(const CtranGraphTestBuilder&) = delete;
+  CtranGraphTestBuilder& operator=(const CtranGraphTestBuilder&) = delete;
+  CtranGraphTestBuilder(CtranGraphTestBuilder&&) = default;
+  CtranGraphTestBuilder& operator=(CtranGraphTestBuilder&&) = default;
+
+  CtranGraphTestBuilder& withNumReplays(int n);
+
+  CtranGraphTestBuilder& addCapture(cudaStream_t stream, CaptureFn captureFn);
+  CtranGraphTestBuilder& addCapture(CaptureFn captureFn);
+
+  CtranGraphTestBuilder& addSchedule(Schedule schedule);
+
+  CtranGraphTestBuilder& withReset(ResetFn resetFn);
+  CtranGraphTestBuilder& withVerify(VerifyFn verifyFn);
+  CtranGraphTestBuilder& withDeviceVerify(DeviceVerifyFn fn);
+  CtranGraphTestBuilder& withGraphAssertions(GraphAssertionsFn fn);
+  CtranGraphTestBuilder& withResourcePoolCheck(bool enable);
+
+  void run();
+
+  const std::vector<std::unique_ptr<CapturedGraph>>& capturedGraphs() const {
+    return graphs_;
+  }
+
+ private:
+  void scheduleReplay();
+  void destroy();
+  void verifyGpeLeak();
+
+  CtranComm* comm_;
+  int rank_;
+  int numRanks_;
+  int numReplays_{3};
+  bool checkResourcePools_{true};
+
+  Schedule schedule_;
+
+  // Captured graphs (populated by scheduleReplay, consumed by
+  // destroy/verifyGpeLeak)
+  std::vector<std::unique_ptr<CapturedGraph>> graphs_;
+
+  // Per-substep graph state for schedule replay (indexed by [step][substep]).
+  // Graph entries get captured on first replay; Eager entries leave these null.
+  std::vector<std::vector<std::unique_ptr<CapturedGraph>>> scheduleGraphs_;
+
+  ResetFn resetFn_;
+  VerifyFn verifyFn_;
+  DeviceVerifyFn deviceVerifyFn_;
+  GraphAssertionsFn graphAssertionsFn_;
+  std::optional<DeviceMismatchCounter> mismatchCounter_;
+};
+
+} // namespace ctran::testing

--- a/comms/ctran/tests/cudagraph/DeviceVerify.cu
+++ b/comms/ctran/tests/cudagraph/DeviceVerify.cu
@@ -1,0 +1,33 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/ctran/tests/cudagraph/DeviceVerify.h"
+
+namespace ctran::testing {
+
+__global__ void compareBuffersKernel(
+    const char* actual,
+    const char* expected,
+    size_t numBytes,
+    unsigned int* mismatchCount) {
+  size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx < numBytes && actual[idx] != expected[idx]) {
+    atomicAdd(mismatchCount, 1);
+  }
+}
+
+void launchCompareBuffers(
+    const void* actual,
+    const void* expected,
+    size_t numBytes,
+    unsigned int* mismatchCount_d,
+    cudaStream_t stream) {
+  constexpr int kBlockSize = 256;
+  int numBlocks = (numBytes + kBlockSize - 1) / kBlockSize;
+  compareBuffersKernel<<<numBlocks, kBlockSize, 0, stream>>>(
+      static_cast<const char*>(actual),
+      static_cast<const char*>(expected),
+      numBytes,
+      mismatchCount_d);
+}
+
+} // namespace ctran::testing

--- a/comms/ctran/tests/cudagraph/DeviceVerify.h
+++ b/comms/ctran/tests/cudagraph/DeviceVerify.h
@@ -1,0 +1,57 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+namespace ctran::testing {
+
+// Launch a kernel that compares two buffers byte-by-byte on the GPU.
+// Mismatches are counted via atomicAdd into mismatchCount_d.
+// Fully async — enqueued on `stream`, no host sync.
+void launchCompareBuffers(
+    const void* actual,
+    const void* expected,
+    size_t numBytes,
+    unsigned int* mismatchCount_d,
+    cudaStream_t stream);
+
+// RAII wrapper for a device-side mismatch counter.
+// Accumulates mismatches across multiple launchCompareBuffers calls.
+// Call assertZero() after final device sync to check results.
+class DeviceMismatchCounter {
+ public:
+  DeviceMismatchCounter() {
+    cudaMalloc(&ptr_, sizeof(unsigned int));
+    cudaMemset(ptr_, 0, sizeof(unsigned int));
+  }
+
+  ~DeviceMismatchCounter() {
+    if (ptr_) {
+      cudaFree(ptr_);
+    }
+  }
+
+  DeviceMismatchCounter(const DeviceMismatchCounter&) = delete;
+  DeviceMismatchCounter& operator=(const DeviceMismatchCounter&) = delete;
+
+  unsigned int* ptr() {
+    return ptr_;
+  }
+
+  unsigned int get() {
+    unsigned int val = 0;
+    cudaMemcpy(&val, ptr_, sizeof(unsigned int), cudaMemcpyDeviceToHost);
+    return val;
+  }
+
+  void assertZero() {
+    EXPECT_EQ(get(), 0u) << "Device-side buffer comparison found mismatches";
+  }
+
+ private:
+  unsigned int* ptr_{nullptr};
+};
+
+} // namespace ctran::testing

--- a/comms/ctran/tests/cudagraph/docs/README.md
+++ b/comms/ctran/tests/cudagraph/docs/README.md
@@ -1,0 +1,224 @@
+# CTRAN CUDA Graph Test Framework
+
+A builder-based framework for testing CTRAN collectives under CUDA graph
+capture, replay, and lifecycle scenarios.
+
+## Architecture
+
+- **Test File (.cc)** — uses `DEFINE_CUDAGRAPH_PARAM_TEST(AllGather, algoDescriptor)`
+  - Defines an `AlgoDescriptor`: `makeBuffers`, `capture`, `isSupported`
+  - Parameterized over (algo, pattern, count, replayMultiplier)
+- **CtranCudaGraphParamTest.h** — test harness that the test file uses
+  - `GraphPattern` enum: Basic, MultipleSequential, MultiStream, ...
+  - `AlgoDescriptor`: algorithm-agnostic interface
+  - `runPattern()`: dispatches to pattern-specific runner
+  - `DEFINE_CUDAGRAPH_PARAM_TEST` / `DEFINE_CUDAGRAPH_STRESS_TEST` macros
+- **CudaGraphTestBuilder** — builder pattern for graph test execution, called by the harness
+  - `.addCapture(fn)` — single graph capture
+  - `.addSchedule(sched)` — multi-step eager/graph pipeline
+  - `.withReset(fn)` — buffer reset between replays
+  - `.withDeviceVerify(fn)` — GPU-side result comparison
+  - `.withGraphAssertions()` — topology checks (host/kernel nodes)
+  - `.withNumReplays(n)` — number of replay iterations
+  - `.run()` — execute capture, replay, verify
+- **CtranCudaGraphTestBase.h** — environment setup
+  - `expectGraphNodes` — graph topology assertions
+  - `GpePoolGuard` — RAII guard for GPE pool state
+- **DeviceVerify (.cu / .h)** — GPU-side verification
+  - `launchCompareBuffers()`: GPU kernel that compares actual vs expected buffers
+  - `DeviceMismatchCounter`: RAII counter for mismatches
+
+## Key Components
+
+### AlgoDescriptor
+
+Algorithm-agnostic interface that each collective test provides:
+
+```cpp
+AlgoDescriptor desc{
+    .name = "AllGather",
+    .isSupported = [](CtranComm* c, size_t count, int nRanks) { return true; },
+    .makeBuffers = [](size_t count, int rank, int nRanks) {
+        // Return shared_ptr<Buffers> with sendbuf/recvbuf/recvBytes
+    },
+    .capture = [](Buffers* bufs, size_t count, CaptureContext& ctx) {
+        // Call the collective on ctx.comm / ctx.stream
+    },
+};
+```
+
+### Graph Patterns
+
+Each pattern tests a different lifecycle or concurrency scenario:
+
+| Pattern              | Edge Case                                                          |
+|----------------------|--------------------------------------------------------------------|
+| `Basic`              | Baseline correctness: GPE host-node callbacks, kernel flag/elem allocation, and pool reclamation work correctly across multiple replays. Catches regressions in the core capture/replay path. |
+| `MultipleSequential` | Multiple collectives in a single graph share the same GPE submission pipeline. Tests that kernel flags, elems, checksums, and sync objects are allocated per-op and don't alias or leak when N ops coexist in one graph. |
+| `MultiStream`        | Fork-join topology inside a captured graph. Tests that CTRAN's stream-ordered resources (GPE submissions, kernel flags) are correctly scoped per-stream and that cross-stream event dependencies survive graph replay. |
+| `DestroyRecreate`    | Repeated graph destroy + re-capture cycles. Tests that GPE pool resources (kernel flags, elems, checksums, syncs) are fully reclaimed on graph destroy and can be re-allocated on the next capture without leaks or stale state. |
+| `MixedEagerGraph`    | Eager → Graph → Eager execution sequence. Tests that graph capture/replay doesn't corrupt CTRAN's internal state (connection state, GPE queues, backend handles) for subsequent eager operations. |
+| `MultiGraph`         | Two independent graphs captured from the same comm. Tests that per-graph resource isolation is correct — each graph gets its own kernel flags/elems and destroying one doesn't invalidate the other's resources. |
+| `InPlace`            | Send and recv buffers alias (same pointer). Tests that CTRAN's buffer registration, NVL copies, and GPE kernel launches handle the in-place case without double-free or incorrect DMA source/dest during replay. |
+| `Abort`              | Replay a graph after `comm->setAbort()`. Tests that the abort signal propagates through GPE host-node callbacks during replay and unblocks the collective promptly without deadlocking on kernel flags or sync objects. |
+
+#### Topologies
+
+Tests run across three simulated topologies (1 node, 8 GPUs each):
+
+| Topology Suffix         | `NCCL_COMM_STATE_DEBUG_TOPO` | Description                                |
+|-------------------------|------------------------------|--------------------------------------------|
+| `1x8_init_none`         | *(default)*                  | Default NVL topology — all GPUs see each other as local |
+| `1x8_nolocal_init_none` | `nolocal`                    | Simulated multi-node — no NVL, forces IB/network paths |
+| `1x8_vnode_init_none`   | `vnode`                      | Virtual node topology (effectively 4x2) — tests hybrid local/remote splits |
+
+All topologies use `NCCL_FASTINIT_MODE=none` to ensure full initialization
+without fast-init shortcuts.
+
+### Algorithm Coverage Matrix
+
+Each algorithm has multiple sub-variants (e.g., different transport paths or
+algorithmic strategies). All variants are parameterized across all patterns
+except `Abort`, which is limited to algorithms with abort-path coverage.
+
+| Algorithm\_Variant          | Topology                    | Basic | MultiSeq | MultiStream | DestroyRecreate | MixedEager | MultiGraph | InPlace | Abort |
+|-----------------------------|-----------------------------|:-----:|:--------:|:-----------:|:---------------:|:----------:|:----------:|:-------:|:-----:|
+| AllGather\_ctran             | 1x8, nolocal, vnode         |   x   |    x     |      x      |        x        |     x      |     x      |    x    |       |
+| AllGather\_ctdirect          | 1x8, nolocal, vnode         |   x   |    x     |      x      |        x        |     x      |     x      |    x    |       |
+| AllGather\_ctring            | 1x8, nolocal, vnode         |   x   |    x     |      x      |        x        |     x      |     x      |    x    |       |
+| AllGather\_ctrd              | 1x8, nolocal, vnode         |   x   |    x     |      x      |        x        |     x      |     x      |    x    |       |
+| AllGather\_ctbrucks          | 1x8, nolocal, vnode         |   x   |    x     |      x      |        x        |     x      |     x      |    x    |       |
+| AllGatherP\_ctdirect         | 1x8, nolocal, vnode         |   x   |    x     |      x      |        x        |     x      |     x      |    x    |       |
+| AllGatherP\_ctpipeline       | 1x8, nolocal, vnode         |   x   |    x     |      x      |        x        |     x      |     x      |    x    |       |
+| AllReduce\_ctran             | 1x8, nolocal, vnode         |   x   |    x     |      x      |        x        |     x      |     x      |    x    |   x   |
+| AllReduce\_ctdirect          | 1x8, nolocal, vnode         |   x   |    x     |      x      |        x        |     x      |     x      |    x    |   x   |
+| AllReduce\_ctring            | 1x8, nolocal, vnode         |   x   |    x     |      x      |        x        |     x      |     x      |    x    |   x   |
+| AllToAll\_ctran              | 1x8, nolocal, vnode         |   x   |    x     |      x      |        x        |     x      |     x      |    x    |       |
+| AllToAll\_alltoallv           | 1x8, nolocal, vnode         |   x   |    x     |      x      |        x        |     x      |     x      |    x    |       |
+| AllToAll\_alltoallv\_dynamic  | 1x8, nolocal, vnode         |   x   |    x     |      x      |        x        |     x      |     x      |    x    |       |
+| AllToAll\_alltoall\_dedup     | 1x8, nolocal, vnode         |   x   |    x     |      x      |        x        |     x      |     x      |    x    |       |
+| Broadcast\_ctran             | 1x8, nolocal, vnode         |   x   |    x     |      x      |        x        |     x      |     x      |    x    |       |
+| Broadcast\_ctdirect          | 1x8, nolocal, vnode         |   x   |    x     |      x      |        x        |     x      |     x      |    x    |       |
+| Broadcast\_ctbtree           | 1x8, nolocal, vnode         |   x   |    x     |      x      |        x        |     x      |     x      |    x    |       |
+| ReduceScatter\_ctran         | 1x8, nolocal, vnode         |   x   |    x     |      x      |        x        |     x      |     x      |    x    |       |
+| ReduceScatter\_ctdirect      | 1x8, nolocal, vnode         |   x   |    x     |      x      |        x        |     x      |     x      |    x    |       |
+| ReduceScatter\_ctring        | 1x8, nolocal, vnode         |   x   |    x     |      x      |        x        |     x      |     x      |    x    |       |
+| RMA\_put\_wait               | 1x8, nolocal, vnode         |   x   |    x     |      x      |        x        |     x      |     x      |    x    |       |
+| SendRecv\_ctp2p              | 1x8, nolocal, vnode         |   x   |    x     |      x      |        x        |     x      |     x      |    x    |   x   |
+
+Each (algo, pattern) pair generates two test targets (one per topology):
+- `<algo>_<pattern>_1x8_init_none`
+- `<algo>_<pattern>_1x8_nolocal_init_none`
+
+Within each target, all sub-variants are parameterized as GTest `Values`, so
+a single target like `allgather_basic_1x8_init_none` runs the Basic pattern
+across all 5 AllGather variants (ctran, ctdirect, ctring, ctrd, ctbrucks) x
+2 message sizes x 1 replay multiplier.
+
+#### Data Sizes
+
+Each test is parameterized over two element counts (int32):
+- **1024** (4 KB) — small message path, exercises control-plane-heavy code
+- **8192** (32 KB) — larger message path, exercises pipelined data transfers
+
+### CudaGraphTestBuilder
+
+Fluent builder that handles the capture/replay/verify lifecycle:
+
+1. **Capture** — wraps user lambda in `cudaStreamBeginCapture`/`EndCapture`
+2. **Replay** — launches `cudaGraphExec` for `numReplays` iterations
+3. **Reset** — calls user-provided reset function between replays
+4. **Verify** — device-side comparison against eagerly-computed expected output
+5. **Assertions** — validates graph topology (host nodes, kernel nodes)
+6. **Cleanup** — destroys graphs, verifies no GPE resource leaks
+
+### Verification Strategy
+
+Tests compare graph replay output against eager execution output using a
+GPU-side comparison kernel (`DeviceVerify.cu`).
+
+**Why device-side verification matters for CUDA graph tests:**
+
+Host-side verification (cudaMemcpy + CPU compare) requires a
+`cudaDeviceSynchronize` or `cudaStreamSynchronize` before reading results. That
+synchronization acts as a full barrier that masks synchronization bugs in the
+algorithm itself — if the collective's internal signaling is broken but the data
+happens to land before the host sync, the test passes despite the bug.
+
+Device-side verification eliminates this blind spot. The comparison kernel is
+enqueued on the same stream immediately after the graph replay, so it reads
+buffers at exactly the point the algorithm considers them ready. If the
+algorithm's synchronization logic has gaps — e.g., a missing stream-ordered
+dependency, a kernel flag that isn't signaled, or a GPE callback that completes
+out of order — the comparison kernel will observe partially-written or stale
+data and report mismatches. No host sync covers up the race.
+
+This is especially important for multi-replay tests: the comparison runs after
+every replay iteration without any device sync between iterations (only the
+first iteration syncs for graph assertions). A synchronization bug that only
+manifests on replay N>1 — when the previous iteration's stale data is still
+resident — will be caught.
+
+```
+Eager run (warmup) → expected buffers
+    ↓
+Graph capture → replay N times (no device sync between iterations)
+    ↓ (each replay, fully async)
+    Reset recvbuf → Replay graph → Device-compare actual vs expected
+    ↓
+Final sync → assert mismatch count == 0
+```
+
+## Adding a New Collective Test
+
+1. Create `CtranCudaGraph<Algo>Test.cc` in `tests/cudagraph/`
+2. Define an `AlgoDescriptor` with `makeBuffers`, `capture`, `isSupported`
+3. Use the `DEFINE_CUDAGRAPH_PARAM_TEST` macro
+4. Add the source file to `CUDAGRAPH_TEST_FILES` in `tests/cudagraph/BUCK`
+
+Example:
+
+```cpp
+#include "comms/ctran/tests/cudagraph/CtranCudaGraphParamTest.h"
+
+static AlgoDescriptor myAlgo() {
+    return {
+        .name = "MyAlgo",
+        .isSupported = [](CtranComm*, size_t, int) { return true; },
+        .makeBuffers = [](size_t count, int rank, int nRanks) {
+            // allocate and initialize buffers
+        },
+        .capture = [](AlgoDescriptor::Buffers* bufs, size_t count,
+                       ctran::testing::CaptureContext& ctx) {
+            // call collective API
+        },
+    };
+}
+
+DEFINE_CUDAGRAPH_PARAM_TEST(MyAlgoTest, myAlgo());
+```
+
+## Adding a New Graph Pattern
+
+1. Add enum value to `GraphPattern` in `CtranCudaGraphParamTest.h`
+2. Add case to `patternToString()` and `baseReplays()`
+3. Implement `run<Pattern>Pattern()` function
+4. Add case to `runPattern()` switch
+5. Add pattern flag to `CUDAGRAPH_PATTERN_FLAGS` in BUCK
+
+## Running Tests
+
+```bash
+# Build the test builder library
+buck2 build @fbcode//mode/opt -c hpc_comms.use_ncclx=stable \
+    //comms/ctran/tests/cudagraph:cudagraph_test_builder
+
+# Run all cudagraph tests
+buck2 test @fbcode//mode/opt -c hpc_comms.use_ncclx=stable \
+    //comms/ctran/tests/cudagraph/...
+
+# Run a specific test target
+# Format: //comms/ctran/tests/cudagraph:<algo>_<pattern>_<topology>_init_none
+buck2 test @fbcode//mode/opt -c hpc_comms.use_ncclx=stable \
+    //comms/ctran/tests/cudagraph:allgather_basic_1x8_init_none
+```


### PR DESCRIPTION
Summary: similar to GraphTestBuilder in cuda_graph_test_helpers.py but more specific to ctran. please look at framework.md for a more in-depth overview. for the sake of simplicity, this commit only has the basic test pattern (run the graph, validate results against eager) -- more complex ones are added in subsequent diffs.

Reviewed By: kapilsh

Differential Revision: D99184216


