### PR TITLE
Decouple CommsMonitor from CommStateX with lightweight CommStateInfo

### DIFF
--- a/comms/ncclx/meta/commDump.cc
+++ b/comms/ncclx/meta/commDump.cc
@@ -101,7 +101,7 @@ static void dumpCommInfo(
 
 static void dumpCommInfo(
     const CommLogData* logMetaData,
-    const ncclx::CommStateX* statex,
+    const ncclx::comms_monitor::CommStateInfo& stateInfo,
     std::unordered_map<std::string, std::string>& map) {
   if (logMetaData != nullptr) {
     map["commHash"] = toQuotedString(hashToHexStr(logMetaData->commHash));
@@ -113,14 +113,10 @@ static void dumpCommInfo(
     return;
   }
 
-  if (statex != nullptr) {
-    map["localRank"] = std::to_string(statex->localRank());
-    map["node"] = std::to_string(statex->node());
-    map["localRanks"] = std::to_string(statex->nLocalRanks());
-    map["nNodes"] = std::to_string(statex->nNodes());
-  } else {
-    XLOGF(DBG2, "CommDump: statex is disabled. No trace to dump");
-  }
+  map["localRank"] = std::to_string(stateInfo.localRank);
+  map["node"] = std::to_string(stateInfo.node);
+  map["localRanks"] = std::to_string(stateInfo.nLocalRanks);
+  map["nNodes"] = std::to_string(stateInfo.nNodes);
 }
 
 static void dumpMapperTrace(
@@ -196,7 +192,7 @@ static void dumpProxyTrace(
 std::unordered_map<std::string, std::string> commDumpByMonitorInfo(
     const ncclx::comms_monitor::NcclCommMonitorInfo& info) {
   std::unordered_map<std::string, std::string> map;
-  dumpCommInfo(&info.logMetaData, &info.commState, map);
+  dumpCommInfo(&info.logMetaData, info.stateInfo, map);
   if (info.newCollTrace != nullptr) {
     map.merge(dumpNewCollTrace(*info.newCollTrace));
     XLOGF(DBG2, "commDumpByMonitorInfo: Dumped from new colltrace");

--- a/comms/ncclx/meta/comms-monitor/CommsMonitor.cc
+++ b/comms/ncclx/meta/comms-monitor/CommsMonitor.cc
@@ -78,7 +78,12 @@ folly::Singleton<CommsMonitor, CommsMonitorSingletonTag>
   }
   return NcclCommMonitorInfo{
       .logMetaData = comm->logMetaData,
-      .commState = ncclx::CommStateX{*comm->ctranComm_->statex_},
+      .stateInfo =
+          CommStateInfo{
+              .localRank = comm->localRank,
+              .node = comm->rankToNode ? comm->rankToNode[comm->rank] : 0,
+              .nLocalRanks = comm->localRanks,
+              .nNodes = comm->nNodes},
       .topoInfo = getTopoInfoFromNcclComm(comm),
       .collTrace = comm->collTrace,
       .mapperTrace = mapperTrace,

--- a/comms/ncclx/meta/comms-monitor/CommsMonitor.h
+++ b/comms/ncclx/meta/comms-monitor/CommsMonitor.h
@@ -16,9 +16,16 @@
 namespace ncclx::comms_monitor {
 ::comms::CommsTopologyInfo getTopoInfoFromNcclComm(ncclComm_t comm);
 
+struct CommStateInfo {
+  int localRank{0};
+  int node{0};
+  int nLocalRanks{1};
+  int nNodes{1};
+};
+
 struct NcclCommMonitorInfo {
   CommLogData logMetaData;
-  ncclx::CommStateX commState;
+  CommStateInfo stateInfo;
   ::comms::CommsTopologyInfo topoInfo;
   // This one will be deprecated soon.
   std::shared_ptr<CollTrace> collTrace;


### PR DESCRIPTION
Summary:
Replace `ncclx::CommStateX` dependency in CommsMonitor with a lightweight `CommStateInfo` struct containing only the 4 fields used by commDump (localRank, node, nLocalRanks, nNodes):
- CommsMonitor::registerComm is called unconditionally after comm init, but CommStateX is only initialized when ctran is enabled. When ctran is disabled, `statex_` is nullptr, causing a SIGSEGV when CommsMonitor tries to copy-construct CommStateX.
- CommStateInfo is populated directly from ncclComm fields (comm->localRank, comm->rankToNode, comm->localRanks, comm->nNodes), removing the dependency on ctranComm_->statex_.
- Updated commDump.cc to use CommStateInfo instead of CommStateX pointer.
- Delete per-version comms-monitor/ files (v2_27, v2_28, v2_29) — use shared ncclx/meta/comms-monitor/ for all versions. The per-version copies had stale CommStateX-based code that caused GitHub CI build failures.
- This fix is a prerequisite for the refactoring diff that moves createCommStateXFromNcclComm inside `if (useCtran_)`, making statex_ null when ctran is disabled.

Reviewed By: YulunW

Differential Revision: D101683300
