### PR TITLE
Move ctranConfigCommAlgoOverride into ctranInit (#2151)

### DIFF
--- a/comms/ctran/Ctran.cc
+++ b/comms/ctran/Ctran.cc
@@ -128,6 +128,11 @@ commResult_t ctranInit(
     return res;
   }
 
+  res = ctranConfigCommAlgoOverride(comm);
+  if (res != commSuccess) {
+    return res;
+  }
+
   initEvent.lapAndRecord("CtranInit COMPLETE");
   return commSuccess;
 }

--- a/comms/ctran/algos/CtranAlgo.cc
+++ b/comms/ctran/algos/CtranAlgo.cc
@@ -633,12 +633,14 @@ static const std::unordered_map<std::string, enum NCCL_ALLGATHER_ALGO>
         {"ctbrucks", NCCL_ALLGATHER_ALGO::ctbrucks},
         {"ctgraph", NCCL_ALLGATHER_ALGO::ctgraph}};
 
+// FIXME: consolidate ctranConfigCommAlgoOverride with the algo config
 commResult_t ctranConfigCommAlgoOverride(CtranComm* comm) {
   if (!ctranInitialized(comm)) {
     return commSuccess;
   }
 
-  if (std::strcmp(comm->config_.ncclAllGatherAlgo, "undefined") == 0) {
+  if (comm->config_.ncclAllGatherAlgo == nullptr ||
+      std::strcmp(comm->config_.ncclAllGatherAlgo, "undefined") == 0) {
     return commSuccess;
   }
 

--- a/comms/ncclx/meta/colltrace/ProxyTraceFunc.cc
+++ b/comms/ncclx/meta/colltrace/ProxyTraceFunc.cc
@@ -7,10 +7,10 @@
 #include "meta/colltrace/ProxyTrace.h"
 
 namespace ncclx::colltrace {
-void proxyTraceInfoCopy(ncclProxyOp& proxyOp, CtranComm* comm) {
-  proxyOp.traceArgs.collInfo.commHash = comm->statex_->commHash();
-  proxyOp.traceArgs.collInfo.opCount = *comm->opCount_;
-  proxyOp.traceArgs.rank = comm->statex_->rank();
+void proxyTraceInfoCopy(ncclProxyOp& proxyOp, ncclComm* comm) {
+  proxyOp.traceArgs.collInfo.commHash = comm->commHash;
+  proxyOp.traceArgs.collInfo.opCount = comm->opCount;
+  proxyOp.traceArgs.rank = comm->rank;
 
   proxyOp.traceArgs.remoteRank = proxyOp.root;
 }
@@ -23,7 +23,7 @@ void proxyTraceAddBasicInfo(
   proxyOp.traceArgs.collInfo.coll = coll;
 }
 
-ncclResult_t proxyTraceInit(struct ncclProxyState* state, CtranComm* comm) {
+ncclResult_t proxyTraceInit(struct ncclProxyState* state, ncclComm* comm) {
   if (NCCL_PROXYTRACE.empty()) {
     return ncclSuccess;
   }
@@ -31,7 +31,7 @@ ncclResult_t proxyTraceInit(struct ncclProxyState* state, CtranComm* comm) {
       ncclx::colltrace::NetworkPerfMonitor::getInstance();
   if (networkPerfMonitorPtr != nullptr && comm != nullptr) {
     networkPerfMonitorPtr->storeCommInfo(
-        comm->logMetaData_, comm->statex_->cudaDev(), comm->statex_->busId());
+        comm->logMetaData, comm->cudaDev, comm->busId);
   }
   try {
     state->trace = std::make_unique<ProxyTrace>();
@@ -39,7 +39,7 @@ ncclResult_t proxyTraceInit(struct ncclProxyState* state, CtranComm* comm) {
     WARN(
         "PROXYTRACE: failed to initialize ProxyTrace, comm %p commDesc %s: %s",
         comm,
-        comm->config_.commDesc.c_str(),
+        comm->config.commDesc ? comm->config.commDesc : "",
         e.what());
     return ncclInternalError;
   }

--- a/comms/ncclx/meta/colltrace/ProxyTraceFunc.h
+++ b/comms/ncclx/meta/colltrace/ProxyTraceFunc.h
@@ -5,32 +5,17 @@
 #include "comm.h"
 #include "proxy.h"
 
-#include "comms/ctran/CtranComm.h"
 #include "meta/colltrace/ProxyTrace.h"
 
 namespace ncclx::colltrace {
-void proxyTraceInfoCopy(ncclProxyOp& proxyOp, CtranComm* comm);
-
-// TODO: remove this function after refactoring done
-// !!! DO NOT USE THIS FUNCTION !!!
-inline void proxyTraceInfoCopy(ncclProxyOp& proxyOp, ncclComm* comm) {
-  proxyTraceInfoCopy(proxyOp, comm->ctranComm_.get());
-}
+void proxyTraceInfoCopy(ncclProxyOp& proxyOp, ncclComm* comm);
 
 void proxyTraceAddBasicInfo(
     ncclProxyOp& proxyOp,
     int nChannels,
     ncclFunc_t coll);
 
-ncclResult_t proxyTraceInit(struct ncclProxyState* state, CtranComm* comm);
-
-// TODO: remove this once ctran refactoring is done
-// !!! DO NOT USE THIS FUNCTION !!!
-inline ncclResult_t proxyTraceInit(
-    struct ncclProxyState* state,
-    ncclComm* comm) {
-  return proxyTraceInit(state, comm->ctranComm_.get());
-}
+ncclResult_t proxyTraceInit(struct ncclProxyState* state, ncclComm* comm);
 
 ncclResult_t proxyTraceDestroy(struct ncclProxyState* state);
 } // namespace ncclx::colltrace

--- a/comms/ncclx/meta/colltrace/tests/ProxyTraceDistTest.cc
+++ b/comms/ncclx/meta/colltrace/tests/ProxyTraceDistTest.cc
@@ -11,7 +11,6 @@
 #include <set>
 #include <unordered_map>
 
-#include "comms/ctran/Ctran.h"
 #include "comms/ncclx/meta/tests/NcclCommUtils.h"
 #include "comms/ncclx/meta/tests/NcclxBaseTest.h"
 #include "comms/testinfra/TestUtils.h"
@@ -33,11 +32,14 @@ class ProxyTraceTest : public NcclxBaseTestFixture {
     // calls initEnv() (call_once) + ncclCvarInit(). Per-test EnvRAII overrides
     // won't take effect for cvars read during init.
     NcclxBaseTestFixture::SetUp({
-        {"NCCL_CTRAN_ENABLE", "1"},
         {"NCCL_PROXYTRACE", "trace"},
         {"NCCL_COLLTRACE", "trace"},
         {"NCCL_DEBUG", "INFO"},
         {"NCCL_DEBUG_SUBSYS", "INIT,COLL"},
+        // Simulate 2 nodes on single physical node: ranks 0-1 on node_0,
+        // ranks 2-3 on node_1. NCCL uses NCCL_HOSTID to determine node
+        // membership, so different hostids produce different comm->node values.
+        {"NCCL_HOSTID", "node_" + std::to_string(globalRank / 2)},
     });
     CUDACHECK_TEST(cudaStreamCreate(&stream));
   }
@@ -270,19 +272,9 @@ class ProxyTraceTest : public NcclxBaseTestFixture {
   };
 
   bool checkTestRequirement(ncclComm_t comm) {
-    // FIXME: this check seems flaky on RE when using with socket transport
-    // Disable it for now to unblock other DIFF landing. More investigation is
-    // needed.
-    //
-    // We don't have a good way to detect whether baseline IB transport is
-    // turned on. Thus, use ctran IB backend to valid for now.
-    if (comm->nNodes < 2 || !ctranInitialized(comm->ctranComm_.get()) ||
-        !comm->ctranComm_->ctran_->mapper->hasBackend()) {
+    if (comm->nNodes < 2) {
       std::cout
-          << "This test requires 2+ nodes and valid IB transport, but nNodes="
-          << comm->nNodes << ", ctranInitialized(comm)="
-          << ctranInitialized(comm->ctranComm_.get())
-          << ", hasBackend()=" << comm->ctranComm_->ctran_->mapper->hasBackend()
+          << "This test requires 2+ nodes, but nNodes=" << comm->nNodes
           << ". Skip test "
           << ::testing::UnitTest::GetInstance()->current_test_info()->name()
           << std::endl;
@@ -702,7 +694,7 @@ TEST_F(ProxyTraceTest, CTAndPTOpCountsMatch) {
   ASSERT_TRUE(ctDumpResult.hasValue()) << "CommDumpPlugin dump failed";
   const auto& ctDump = ctDumpResult.value();
 
-  // Build sets of collIds (opCounts) from CT and PT pastColls
+  // Build sets of collIds (opCounts) (collId) from CT and PT pastColls
   std::set<uint64_t> ctOpCounts;
   for (const auto& coll : ctDump.pastColls) {
     ctOpCounts.insert(coll->getCollId());

--- a/comms/ncclx/v2_27/src/init.cc
+++ b/comms/ncclx/v2_27/src/init.cc
@@ -1671,7 +1671,6 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
     comm->ctranComm_->colltraceNew_ = comm->newCollTrace;
     NCCLCHECKGOTO(metaCommToNccl(ctranInit(comm->ctranComm_.get())), res, fail);
   }
-  NCCLCHECKGOTO(metaCommToNccl(ctranConfigCommAlgoOverride(comm->ctranComm_.get())), res, fail);
   // --------------------- done
 
 

--- a/comms/ncclx/v2_28/src/init.cc
+++ b/comms/ncclx/v2_28/src/init.cc
@@ -1790,7 +1790,6 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
     comm->ctranComm_->colltraceNew_ = comm->newCollTrace;
     NCCLCHECKGOTO(metaCommToNccl(ctranInit(comm->ctranComm_.get())), res, fail);
   }
-  NCCLCHECKGOTO(metaCommToNccl(ctranConfigCommAlgoOverride(comm->ctranComm_.get())), res, fail);
   // --------------------- done
 
   ncclx::comms_monitor::CommsMonitor::registerComm(comm);

--- a/comms/ncclx/v2_29/src/init.cc
+++ b/comms/ncclx/v2_29/src/init.cc
@@ -1915,7 +1915,6 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
     comm->ctranComm_->colltraceNew_ = comm->newCollTrace;
     NCCLCHECKGOTO(metaCommToNccl(ctranInit(comm->ctranComm_.get())), res, fail);
   }
-  NCCLCHECKGOTO(metaCommToNccl(ctranConfigCommAlgoOverride(comm->ctranComm_.get())), res, fail);
   // --------------------- done
 
   ncclx::comms_monitor::CommsMonitor::registerComm(comm);

--- a/comms/rcclx/develop/meta/ctran/MetaFactory.cc
+++ b/comms/rcclx/develop/meta/ctran/MetaFactory.cc
@@ -128,12 +128,10 @@ commResult_t initNcclCommCtran(ncclComm* ncclComm) {
   ctranComm->bootstrap_ = std::make_unique<rcclx::BaselineBootstrap>(ncclComm);
   ctranComm->statex_ =
       createCtranCommStateXFromNcclComm(ncclComm, ctranComm.get());
-  // TODO: init CtranComm newCollTrace
-  FB_COMMCHECK(ctranInit(ctranComm.get()));
-
   // TODO: add RCCL config to configure all gather algo
   ctranComm->config_.ncclAllGatherAlgo = "undefined";
-  FB_COMMCHECK(ctranConfigCommAlgoOverride(ctranComm.get()));
+  // TODO: init CtranComm newCollTrace
+  FB_COMMCHECK(ctranInit(ctranComm.get()));
 
   // Ensure Ctran has been initialized correctly
   FB_CHECKTHROW(ctranInitialized(ctranComm.get()), "Ctran not initialized");


### PR DESCRIPTION
Summary:

Move algo config override from callers (init.cc, McclComm.cpp, rcclx MetaFactory.cc) into ctranInit, consolidating it with the rest of ctran initialization:
- Add null check for `ncclAllGatherAlgo` to prevent SIGSEGV when config is not set (e.g., ctran tests that create CtranComm without going through setCtranCommBase)
- Remove `ctranConfigCommAlgoOverride` calls from ncclx init.cc (all 3 versions), mccl McclComm.cpp, and rcclx MetaFactory.cc
- Call `ctranConfigCommAlgoOverride` inside `ctranInit` (Ctran.cc) after algo is initialized

Reviewed By: dsjohns2

Differential Revision: D101582113
