### PR TITLE
Consolidate CommStateX factory and guard ctranComm_ init behind useCtran_ (#2152)

### DIFF
--- a/comms/ctran/commstate/CommStateX.h
+++ b/comms/ctran/commstate/CommStateX.h
@@ -90,7 +90,6 @@ class CommStateX {
 
   void initRankTopologyNolocal();
   void initRankTopologyVnode(const int nLocalRanks);
-  friend void initRankTopologyFrom(CommStateX* _CommStateX, void* _comm);
   void initRankStatesTopology(meta::comms::IBootstrap* bootstrap);
 
   /* Setters */

--- a/comms/ncclx/meta/commHash.cc
+++ b/comms/ncclx/meta/commHash.cc
@@ -4,15 +4,10 @@
 #include "comm.h"
 #include "nccl.h"
 
-#include "comms/ctran/commstate/CommStateX.h"
-
 NCCL_API(ncclResult_t, ncclCommGetUniqueHash, ncclComm_t comm, uint64_t* hash);
 ncclResult_t ncclCommGetUniqueHash(ncclComm_t comm, uint64_t* hash) {
-  NCCLCHECK(PtrCheck(comm, "CommGetUniqueHash", "comm"));
-  NCCLCHECK(PtrCheck(comm->ctranComm_.get(), "CommGetUniqueHash", "ctranComm"));
-  NCCLCHECK(
-      PtrCheck(comm->ctranComm_->statex_.get(), "CommGetUniqueHash", "statex"));
+  NCCLCHECK(CommCheck(comm, "CommGetUniqueHash", "comm"));
 
-  *hash = comm->ctranComm_->statex_->commHash();
+  *hash = comm->commHash;
   return ncclSuccess;
 }

--- a/comms/ncclx/meta/commstate/FactoryCommStateX.cc
+++ b/comms/ncclx/meta/commstate/FactoryCommStateX.cc
@@ -1,83 +1,16 @@
 #include "meta/commstate/FactoryCommStateX.h"
 #include "checks.h"
 #include "comm.h"
+#include "comms/ctran/CtranComm.h"
 #include "comms/ctran/commstate/CommStateX.h"
-#include "comms/ctran/utils/Checks.h"
 #include "meta/NcclxConfig.h" // @manual
 #include "meta/hints/CommHintConfig.h" // @manual
 
-#include "bootstrap.h"
 #include "nvmlwrap.h"
 #include "transport.h"
 
 namespace ncclx {
-
-void initRankTopologyFrom(CommStateX* _CommStateX, void* _comm) {
-  auto comm = reinterpret_cast<ncclComm*>(_comm);
-  _CommStateX->rankStates_.resize(comm->nRanks);
-  _CommStateX->nodeRanks_.resize(comm->nNodes);
-  for (int r = 0; r < comm->nRanks; ++r) {
-    auto& rankState = _CommStateX->rankStates_.at(r);
-    rankState.rank = r;
-    rankState.nodeId = comm->rankToNode[r];
-    rankState.localRank = comm->rankToLocalRank[r];
-    rankState.nLocalRanks = comm->localRanks;
-    rankState.localRankToRanks.assign(
-        comm->localRankToRank, comm->localRankToRank + comm->localRanks);
-
-    // Order of global ranks never changes, thus OK to assume global rank on
-    // each node is already ordered by local rank
-    // NOTE: two GPUs on the same node may be with different nodeId because
-    // they don't have direct NVL access. To keep same nodeId in statex, we
-    // use hostHash+nodeId to make it unique
-    std::string host(
-        std::to_string(comm->peerInfo[r].hostHash) + "_" +
-        std::to_string(rankState.nodeId));
-    _CommStateX->hostToRanks_[host].emplace_back(r);
-
-    _CommStateX->nodeRanks_[rankState.nodeId].emplace_back(rankState.rank);
-  }
-}
-
-std::unique_ptr<CommStateX> createCommStateXFromNcclComm(void* _comm) {
-  auto comm = reinterpret_cast<ncclComm*>(_comm);
-  CHECKABORT(comm->rankToNode, "rankToNode is nullptr");
-  CHECKABORT(comm->localRankToRank, "localRankToRank is nullptr");
-
-  auto _CommStateX = std::make_unique<CommStateX>(
-      comm->rank,
-      comm->nRanks,
-      comm->cudaDev,
-      comm->cudaArch,
-      comm->busId,
-      comm->commHash,
-      std::vector<RankTopology>(), /* rankTopologies */
-      std::vector<int>(), /* commRanksToWorldRanks */
-      NCCLX_CONFIG_FIELD(comm->config, commDesc),
-      comm->noLocal_,
-      commVCliqueSize(NCCLX_CONFIG_FIELD(comm->config, vCliqueSize)));
-
-  if (comm->noLocal_ ||
-      NCCL_COMM_STATE_DEBUG_TOPO == NCCL_COMM_STATE_DEBUG_TOPO::nolocal) {
-    // Fake topology with nLocalRanks=1
-    _CommStateX->initRankTopologyNolocal();
-  } else if (NCCL_COMM_STATE_DEBUG_TOPO == NCCL_COMM_STATE_DEBUG_TOPO::vnode) {
-    // Fake topology with
-    // nLocalRanks=NCCL_COMM_STATE_DEBUG_TOPO_VNODE_NLOCALRANKS
-    _CommStateX->initRankTopologyVnode(
-        NCCL_COMM_STATE_DEBUG_TOPO_VNODE_NLOCALRANKS);
-  } else {
-    initRankTopologyFrom(_CommStateX.get(), _comm);
-  }
-
-  INFO(
-      NCCL_INIT | NCCL_GRAPH,
-      "CommStateX: set rankTopology with %s%s",
-      topoNameMap[NCCL_COMM_STATE_DEBUG_TOPO].c_str(),
-      comm->noLocal_ ? " (noLocal hint)" : "");
-
-  return _CommStateX;
-}
+namespace {
 
 ncclResult_t getLocalGpuFabricInfo(
     ncclComm* ncclComm,
@@ -105,24 +38,34 @@ ncclResult_t getLocalGpuFabricInfo(
   return ncclSuccess;
 }
 
-ncclResult_t initNvlFabricTopologies(ncclComm* ncclComm, CtranComm* ctranComm) {
-  // Get local fabric information
+// TODO: NVL fabric topology init should be handled within ctran/statex
+// (e.g., as part of CommStateX initialization), not passed from ncclx.
+ncclResult_t initNvlFabricTopologies(
+    ncclComm* comm,
+    CommStateX* statex,
+    meta::comms::IBootstrap* bootstrap) {
   nvmlGpuFabricInfoV_t localFabricInfo;
-  NCCLCHECK(getLocalGpuFabricInfo(ncclComm, localFabricInfo));
+  NCCLCHECK(getLocalGpuFabricInfo(comm, localFabricInfo));
 
-  // Gather fabric info from all ranks
-  std::vector<nvmlGpuFabricInfoV_t> allFabricInfos(ncclComm->nRanks);
-  allFabricInfos.at(ncclComm->rank) = localFabricInfo;
+  std::vector<nvmlGpuFabricInfoV_t> allFabricInfos(comm->nRanks);
+  allFabricInfos.at(comm->rank) = localFabricInfo;
 
-  bootstrapAllGather(
-      ncclComm->bootstrap, allFabricInfos.data(), sizeof(nvmlGpuFabricInfoV_t));
+  auto resFuture = bootstrap->allGather(
+      allFabricInfos.data(),
+      sizeof(nvmlGpuFabricInfoV_t),
+      comm->rank,
+      comm->nRanks);
+  const int res = std::move(resFuture).get();
+  if (res != 0) {
+    WARN("initNvlFabricTopologies: bootstrap allGather failed with %d", res);
+    return ncclInternalError;
+  }
 
-  // Create NVL fabric topologies for all ranks
-  std::vector<ncclx::NvlFabricTopology> nvlFabricTopos;
-  nvlFabricTopos.reserve(ncclComm->nRanks);
-  for (int rank = 0; rank < ncclComm->nRanks; rank++) {
+  std::vector<NvlFabricTopology> nvlFabricTopos;
+  nvlFabricTopos.reserve(comm->nRanks);
+  for (int rank = 0; rank < comm->nRanks; rank++) {
     const auto& fabricInfo_ = allFabricInfos.at(rank);
-    ncclx::NvlFabricTopology topo;
+    NvlFabricTopology topo;
     if (fabricInfo_.state != NVML_GPU_FABRIC_STATE_NOT_SUPPORTED) {
       topo.supportNvlFabric = true;
       topo.rank = rank;
@@ -134,37 +77,58 @@ ncclResult_t initNvlFabricTopologies(ncclComm* ncclComm, CtranComm* ctranComm) {
     }
     nvlFabricTopos.emplace_back(std::move(topo));
   }
-  ctranComm->statex_->setNvlFabricTopos(
-      std::move(nvlFabricTopos), std::nullopt);
+  statex->setNvlFabricTopos(std::move(nvlFabricTopos), std::nullopt);
   return ncclSuccess;
 }
 
-/**
- * Initialize CtranComm statex from NCCL communicator.
- * This function performs two main phases:
- * 1. Initialize rank states topology
- * 2. Initialize NVL fabric topologies by gathering fabric info from all ranks
- */
-ncclResult_t initCtranCommStatexFromNcclComm(
-    ncclComm* ncclComm,
-    CtranComm* ctranComm) {
-  if (!ncclComm || !ctranComm) {
-    FB_ERRORRETURN(ncclInvalidArgument, "Invalid arguments provided");
-  }
+} // namespace
+
+ncclResult_t initCommStateXFromNcclComm(void* _comm, CtranComm* ctranComm) {
+  auto comm = reinterpret_cast<ncclComm*>(_comm);
+  CHECKABORT(comm->rankToNode, "rankToNode is nullptr");
+  CHECKABORT(comm->localRankToRank, "localRankToRank is nullptr");
+
+  auto* bootstrap = ctranComm->bootstrap_.get();
+
+  const int vCliqueSize =
+      commVCliqueSize(NCCLX_CONFIG_FIELD(comm->config, vCliqueSize));
+
+  ctranComm->statex_ = std::make_unique<CommStateX>(
+      comm->rank,
+      comm->nRanks,
+      comm->cudaDev,
+      comm->cudaArch,
+      comm->busId,
+      comm->commHash,
+      std::vector<RankTopology>(), /* rankTopologies */
+      std::vector<int>(), /* commRanksToWorldRanks */
+      NCCLX_CONFIG_FIELD(comm->config, commDesc),
+      comm->noLocal_,
+      vCliqueSize);
 
   try {
-    ctranComm->statex_->initRankStatesTopology(ctranComm->bootstrap_.get());
-
-    NCCLCHECK(initNvlFabricTopologies(ncclComm, ctranComm));
-
-    return ncclSuccess;
-
+    ctranComm->statex_->initRankStatesTopology(bootstrap);
   } catch (const std::exception& e) {
-    FB_ERRORRETURN(
-        ncclInternalError,
-        "Failed to initialize CtranComm statex from ncclComm: {}",
+    WARN(
+        "initCommStateXFromNcclComm: initRankStatesTopology failed: %s",
         e.what());
+    return ncclInternalError;
   }
+
+  INFO(
+      NCCL_INIT | NCCL_GRAPH,
+      "CommStateX: set rankTopology with noLocal=%d, vCliqueSize=%d, commDesc=%s, commHash=0x%lx, rank=%d, nRanks=%d, nLocalRanks=%d",
+      comm->noLocal_,
+      vCliqueSize,
+      NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str(),
+      comm->commHash,
+      comm->rank,
+      comm->nRanks,
+      ctranComm->statex_->nLocalRanks());
+
+  NCCLCHECK(initNvlFabricTopologies(comm, ctranComm->statex_.get(), bootstrap));
+
+  return ncclSuccess;
 }
 
 ncclResult_t assignMnnvlCliqueIdBasedOnCliqueSize(int* cliqueId) {

--- a/comms/ncclx/meta/commstate/FactoryCommStateX.h
+++ b/comms/ncclx/meta/commstate/FactoryCommStateX.h
@@ -1,21 +1,17 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 #include <algorithm>
 #include "comm.h"
-#include "comms/ctran/commstate/CommStateX.h"
 #include "meta/RankUtil.h"
 #include "socket.h"
 
+class CtranComm;
+
 namespace ncclx {
 
-// This Factory must be used ONLY in NCCLx code, not in CTRAN code
-// Ctran has it's own StateX factory
-std::unique_ptr<CommStateX> createCommStateXFromNcclComm(void* _comm);
-
-// This init function must be used ONLY in NCCLx code, not in CTRAN code
-// Ctran has it's own StateX factory
-ncclResult_t initCtranCommStatexFromNcclComm(
-    ncclComm* ncclComm,
-    CtranComm* ctranComm);
+// Create CommStateX from ncclComm. Initializes rank topology via bootstrap
+// allgather and sets up NVL fabric topologies. Virtual topology overrides
+// (noLocal, vnode, vClique) are applied internally.
+ncclResult_t initCommStateXFromNcclComm(void* _comm, CtranComm* ctranComm);
 
 ncclResult_t assignMnnvlCliqueIdBasedOnCliqueSize(int* cliqueId);
 } // namespace ncclx

--- a/comms/ncclx/meta/tests/CommWithCtranTest.cc
+++ b/comms/ncclx/meta/tests/CommWithCtranTest.cc
@@ -3,6 +3,7 @@
 #include <fstream>
 #include <memory>
 
+#include <fmt/format.h>
 #include <folly/init/Init.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -58,55 +59,18 @@ TEST_F(CommWithCtranTest, CtranDisable) {
       globalRank, numRanks, localRank, bootstrap_.get()};
 
   ASSERT_NE(nullptr, comm.get());
-  ASSERT_EQ(nullptr, comm->ctranComm_->ctran_);
-  EXPECT_FALSE(ctranInitialized(comm->ctranComm_.get()));
+  EXPECT_EQ(nullptr, comm->ctranComm_);
+  EXPECT_FALSE(ctranInitialized(nullptr));
 
-  ASSERT_NE(nullptr, comm->ctranComm_->opCount_);
-  EXPECT_EQ(comm->ctranComm_->opCount_, &comm->opCount);
-
-  ASSERT_NE(nullptr, comm->ctranComm_->statex_);
-
-  EXPECT_EQ(comm->ctranComm_->config_, makeCtranConfigFrom(comm));
-  EXPECT_EQ(comm->ctranComm_->logMetaData_, comm->logMetaData);
-
-  EXPECT_EQ(comm->ctranComm_->colltraceNew_, nullptr);
-
-  // Expect all CTran collective support to be false
-  EXPECT_FALSE(
-      ctranAllGatherSupport(comm->ctranComm_.get(), NCCL_ALLGATHER_ALGO));
-  EXPECT_FALSE(ctranAllReduceSupport(
-      comm->ctranComm_.get(), NCCL_ALLREDUCE_ALGO::ctran));
-  EXPECT_FALSE(
-      ctranBroadcastSupport(comm->ctranComm_.get(), NCCL_BROADCAST_ALGO));
-  EXPECT_FALSE(ctranReduceScatterSupport(
-      comm->ctranComm_.get(), NCCL_REDUCESCATTER_ALGO));
-  EXPECT_FALSE(ctranSendRecvSupport(0, comm->ctranComm_.get()));
+  // All CTran collective support functions should return false with nullptr
+  EXPECT_FALSE(ctranAllGatherSupport(nullptr, NCCL_ALLGATHER_ALGO));
+  EXPECT_FALSE(ctranAllReduceSupport(nullptr, NCCL_ALLREDUCE_ALGO::ctran));
+  EXPECT_FALSE(ctranBroadcastSupport(nullptr, NCCL_BROADCAST_ALGO));
+  EXPECT_FALSE(ctranReduceScatterSupport(nullptr, NCCL_REDUCESCATTER_ALGO));
+  EXPECT_FALSE(ctranSendRecvSupport(0, nullptr));
   EXPECT_FALSE(ctranAllToAllSupport(
-      1048576, commInt, comm->ctranComm_.get(), NCCL_ALLTOALL_ALGO::ctran));
-  EXPECT_FALSE(ctranAllToAllvSupport(comm->ctranComm_.get()));
-  meta::comms::Hints hints;
-
-  size_t maxSendcounts =
-      dceil(CTRAN_MIN_REGISTRATION_SIZE, commTypeSize(commInt));
-  size_t maxRecvcounts =
-      dceil(CTRAN_MIN_REGISTRATION_SIZE, commTypeSize(commInt));
-
-  auto res = ctranAllToAllvDynamicSupport(
-      comm->ctranComm_.get(), hints, maxSendcounts, maxRecvcounts, commInt);
-  EXPECT_EQ(commInvalidUsage, res);
-
-  hints.set("ncclx_alltoallv_dynamic_sendbuffs_location", "cpu");
-  hints.set("ncclx_alltoallv_dynamic_recvbuffs_location", "cpu");
-  hints.set("ncclx_alltoallv_dynamic_sendcounts_location", "gpu");
-  hints.set("ncclx_alltoallv_dynamic_max_sendcounts_location", "cpu");
-  hints.set("ncclx_alltoallv_dynamic_max_recvcounts_location", "cpu");
-  hints.set("ncclx_alltoallv_dynamic_actual_recvcounts_location", "gpu");
-
-  maxSendcounts = CTRAN_MIN_REGISTRATION_SIZE / commTypeSize(commInt);
-  maxRecvcounts = CTRAN_MIN_REGISTRATION_SIZE / commTypeSize(commInt);
-  res = ctranAllToAllvDynamicSupport(
-      comm->ctranComm_.get(), hints, maxSendcounts, maxRecvcounts, commInt);
-  EXPECT_EQ(commInvalidUsage, res);
+      1048576, commInt, nullptr, NCCL_ALLTOALL_ALGO::ctran));
+  EXPECT_FALSE(ctranAllToAllvSupport(nullptr));
 }
 
 TEST_F(CommWithCtranTest, CtranCommInitialized) {
@@ -394,14 +358,12 @@ TEST_F(CommWithCtranTest, CommFailureWithInvalidTopology) {
         try {
           ncclx::test::createNcclComm(
               globalRank, numRanks, localRank, bootstrap_.get(), true);
-        } catch (const std::runtime_error& e) {
-          EXPECT_THAT(
-              e.what(),
-              testing::HasSubstr("Failed, NCCL error: internal error"));
+        } catch (const std::exception& e) {
+          EXPECT_THAT(e.what(), testing::HasSubstr("NCCL error"));
           throw;
         }
       },
-      std::runtime_error);
+      std::exception);
 
   // Clean up temporary files
   unlink(invalidTopoFilepath.c_str());

--- a/comms/ncclx/meta/wrapper/MetaFactory.cc
+++ b/comms/ncclx/meta/wrapper/MetaFactory.cc
@@ -5,13 +5,19 @@
 #include "comm.h"
 #include "comms/ctran/algos/AllToAll/AllToAllPHintUtils.h"
 #include "comms/ctran/algos/AllToAll/AllToAllvDynamicHintUtils.h"
+#include "comms/ctran/interfaces/ICtran.h"
+#include "comms/ctran/memory/memCacheAllocator.h"
 #include "comms/ctran/window/WinHintUtils.h"
 #include "comms/utils/checks.h"
 #include "comms/utils/commSpecs.h"
 #include "meta/NcclxConfig.h" // @manual
+#include "meta/commstate/FactoryCommStateX.h"
+#include "meta/ctran-integration/BaselineBootstrap.h"
 #include "meta/wrapper/MetaFactory.h"
 
 using namespace ctran;
+
+#define NCCLCHECK_COMM(call) NCCLCHECK(metaCommToNccl(call))
 
 meta::comms::Hints ncclToMetaComm(const ncclx::Hints& hints) {
   meta::comms::Hints ret;
@@ -88,4 +94,39 @@ CtranComm* getCtranCommFromNcclComm(ncclComm* ncclComm) {
     return ncclComm->ctranComm_.get();
   }
   return nullptr;
+}
+
+ncclResult_t createCtranComm(ncclComm* comm) {
+  NCCLCHECK_COMM(setCtranCommBase(comm));
+
+  if (NCCL_USE_MEM_CACHE) {
+    comm->ctranComm_->memCache_ =
+        ncclx::memory::memCacheAllocator::getInstance();
+  }
+
+  comm->ctranComm_->bootstrap_ =
+      std::make_unique<ncclx::BaselineBootstrap>(comm);
+
+  NCCLCHECK(ncclx::initCommStateXFromNcclComm(comm, comm->ctranComm_.get()));
+
+  comm->ctranComm_->colltraceNew_ = comm->newCollTrace;
+
+  NCCLCHECK_COMM(ctranInit(comm->ctranComm_.get()));
+
+  return ncclSuccess;
+}
+
+ncclResult_t destroyCtranComm(ncclComm* comm) {
+  if (!comm || !comm->ctranComm_) {
+    return ncclSuccess;
+  }
+  NCCLCHECK_COMM(ctranFinalize(comm->ctranComm_.get()));
+  try {
+    comm->ctranComm_->destroy();
+    comm->ctranComm_.reset();
+  } catch (const std::exception& e) {
+    CLOGF(ERR, "CtranComm destruction failed: {}", e.what());
+    return ncclInternalError;
+  }
+  return ncclSuccess;
 }

--- a/comms/ncclx/meta/wrapper/MetaFactory.h
+++ b/comms/ncclx/meta/wrapper/MetaFactory.h
@@ -198,6 +198,15 @@ inline commDataType_t ncclToMetaComm(ncclDataType_t dataType) {
 ctranConfig makeCtranConfigFrom(ncclComm* comm);
 commResult_t setCtranCommBase(ncclComm* ncclCommVal);
 
+// Create and fully initialize CtranComm on the given ncclComm.
+// Combines: setCtranCommBase, memCache, bootstrap, CommStateX, colltrace,
+// and ctranInit into a single call.
+ncclResult_t createCtranComm(ncclComm* comm);
+
+// Finalize, destroy, and reset ctranComm_ on the given ncclComm.
+// No-op if ctranComm_ is nullptr.
+ncclResult_t destroyCtranComm(ncclComm* comm);
+
 // Public accessor returning the CtranComm* hanging off an ncclComm, or
 // nullptr if it isn't initialized (e.g. NCCL_CTRAN_ENABLE not set).
 CtranComm* getCtranCommFromNcclComm(ncclComm* ncclComm);

--- a/comms/ncclx/v2_27/src/init.cc
+++ b/comms/ncclx/v2_27/src/init.cc
@@ -39,7 +39,7 @@
 
 #include "comms/ctran/Ctran.h"
 #include "meta/commstate/FactoryCommStateX.h"
-#include "comms/ctran/commstate/CommStateX.h"
+
 #include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/ctran/utils/Utils.h"
 #include "comms/ctran/utils/SkipDestroyUtil.h"
@@ -47,7 +47,7 @@
 #include "meta/colltrace/CollTraceWrapper.h"
 #include "meta/comms-monitor/CommsMonitor.h"
 #include "meta/commstate/FactoryCommStateX.h"
-#include "meta/ctran-integration/BaselineBootstrap.h"
+
 #include "meta/hints/CommHintConfig.h"
 
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -1635,24 +1635,6 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
    */
   NCCLCHECKGOTO(meta::comms::ncclx::newCollTraceInit(comm), res, fail);
 
-  // TODO: remove all ncclx fields and leave only ctranComm_
-  // (we are working on refactoring now, when it's done only ctranComm_ must be used)
-
-  // TODO: replace this dirty init code with CtranComm constructor.
-  // There is an issue with the order of initialization. We need to initialize stateX
-  // before initializing ctran/bootstrap/calltrace. The ctran classes internally start
-  // using CtranComm while still relying on ncclComm_t. This means that when we call
-  // ctranInit/boostrap init/calltrace init/ any internal ctran calss,
-  // both comm->stateX and ctranComm_->stateX must be initialized. Consequently, we have
-  // to split the initialization of CtranComm into several parts. This must be cleaned
-  // when we develop CtranComm constuctor.
-  NCCLCHECKGOTO(metaCommToNccl(setCtranCommBase(comm)), res, fail);
-
-  comm->ctranComm_->bootstrap_ = std::make_unique<ncclx::BaselineBootstrap>(comm);
-
-  comm->ctranComm_->statex_ = ncclx::createCommStateXFromNcclComm(comm);
-
-  comm->ctranComm_->memCache_ = comm->memCache;
 
   NCCLCHECKGOTO(
       metaCommToNccl(ncclx::transport::tranportProxyInit(comm, job->parent)),
@@ -1660,10 +1642,7 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
       fail);
 
   if (comm->useCtran_) {
-    // TODO: move initialization to CtranComm constructor once we finish all ctran refactor
-    NCCLCHECK(ncclx::initCtranCommStatexFromNcclComm(comm, comm->ctranComm_.get()));
-    comm->ctranComm_->colltraceNew_ = comm->newCollTrace;
-    NCCLCHECKGOTO(metaCommToNccl(ctranInit(comm->ctranComm_.get())), res, fail);
+    NCCLCHECKGOTO(createCtranComm(comm), res, fail);
   }
   // --------------------- done
 
@@ -2322,19 +2301,12 @@ static ncclResult_t commDestroySync(struct ncclAsyncJob* job_) {
   /*
    * NCCLX - Resource Cleanup
    */
-  NCCLCHECKGOTO(metaCommToNccl(ctranFinalize(comm->ctranComm_.get())), ret, fail);
   NCCLCHECKGOTO(meta::comms::ncclx::newCollTraceDestroy(comm), ret, fail);
 
   comm->logMetaData.commDesc.clear(); // free up memory associated with commDesc
   comm->logMetaData.commDesc.shrink_to_fit();
 
-  try {
-    comm->ctranComm_->destroy();
-    comm->ctranComm_.reset();
-  } catch (std::exception& e) {
-    CLOGF(ERR, "CtranComm destruction failed: {}", e.what());
-    goto fail;
-  }
+  NCCLCHECKGOTO(destroyCtranComm(comm), ret, fail);
 
 
   TRACE(NCCL_INIT, "Destroying comm %p rank %d abortFlag %d asyncResult %d", comm, comm->rank, *comm->abortFlag, comm->asyncResult);
@@ -2581,7 +2553,9 @@ ncclResult_t ncclCommAbort(ncclComm_t comm) {
     ctran::utils::setSkipDestroyCtran(skipDestroyFlag);
     if (comm->memCache) {
       comm->memCache.reset();
-      comm->ctranComm_->memCache_.reset();
+      if (comm->ctranComm_) {
+        comm->ctranComm_->memCache_.reset();
+      }
     }
   }
   if (NCCL_COMM_ABORT_SCOPE == NCCL_COMM_ABORT_SCOPE::none) {

--- a/comms/ncclx/v2_28/src/init.cc
+++ b/comms/ncclx/v2_28/src/init.cc
@@ -44,7 +44,7 @@
 
 #include "comms/ctran/Ctran.h"
 #include "meta/commstate/FactoryCommStateX.h"
-#include "comms/ctran/commstate/CommStateX.h"
+
 #include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/ctran/utils/Utils.h"
 #include "comms/ctran/utils/SkipDestroyUtil.h"
@@ -52,7 +52,7 @@
 #include "meta/colltrace/CollTraceWrapper.h"
 #include "meta/comms-monitor/CommsMonitor.h"
 #include "meta/commstate/FactoryCommStateX.h"
-#include "meta/ctran-integration/BaselineBootstrap.h"
+
 #include "meta/hints/CommHintConfig.h"
 
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -1736,7 +1736,7 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
     timers[TIMER_INIT_BOOTSTRAP] = clockNano() - timers[TIMER_INIT_BOOTSTRAP];
   }
   comm->cudaArch = cudaArch;
-  
+
   // init this communicator's  Logger fields
   comm->logMetaData.commId = commIdHash;
   comm->logMetaData.commHash = comm->commHash;
@@ -1763,27 +1763,9 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
    */
   NCCLCHECKGOTO(meta::comms::ncclx::newCollTraceInit(comm), res, fail);
 
-  // TODO: remove all ncclx fields and leave only ctranComm_
-  // (we are working on refactoring now, when it's done only ctranComm_ must be used)
-
-  // TODO: replace this dirty init code with CtranComm constructor.
-  // There is an issue with the order of initialization. We need to initialize stateX
-  // before initializing ctran/bootstrap/calltrace. The ctran classes internally start
-  // using CtranComm while still relying on ncclComm_t. This means that when we call
-  // ctranInit/boostrap init/calltrace init/ any internal ctran calss,
-  // both comm->stateX and ctranComm_->stateX must be initialized. Consequently, we have
-  // to split the initialization of CtranComm into several parts. This must be cleaned
-  // when we develop CtranComm constuctor.
-  NCCLCHECKGOTO(metaCommToNccl(setCtranCommBase(comm)), res, fail);
-
-  comm->ctranComm_->bootstrap_ = std::make_unique<ncclx::BaselineBootstrap>(comm);
-  comm->ctranComm_->statex_ = ncclx::createCommStateXFromNcclComm(comm);
 
   if (comm->useCtran_) {
-    // TODO: move initialization to CtranComm constructor once we finish all ctran refactor
-    NCCLCHECK(ncclx::initCtranCommStatexFromNcclComm(comm, comm->ctranComm_.get()));
-    comm->ctranComm_->colltraceNew_ = comm->newCollTrace;
-    NCCLCHECKGOTO(metaCommToNccl(ctranInit(comm->ctranComm_.get())), res, fail);
+    NCCLCHECKGOTO(createCtranComm(comm), res, fail);
   }
   // --------------------- done
 
@@ -2483,16 +2465,9 @@ static ncclResult_t commDestroySync(struct ncclAsyncJob* job_) {
   /*
    * NCCLX - Resource Cleanup
    */
-  NCCLCHECKGOTO(metaCommToNccl(ctranFinalize(comm->ctranComm_.get())), ret, fail);
   NCCLCHECKGOTO(meta::comms::ncclx::newCollTraceDestroy(comm), ret, fail);
 
-  try {
-    comm->ctranComm_->destroy();
-    comm->ctranComm_.reset();
-  } catch (std::exception& e) {
-    CLOGF(ERR, "CtranComm destruction failed: {}", e.what());
-    goto fail;
-  }
+  NCCLCHECKGOTO(destroyCtranComm(comm), ret, fail);
 
   TRACE(NCCL_INIT, "Destroying comm %p rank %d abortFlag %d asyncResult %d", comm, comm->rank, *comm->abortFlag, comm->asyncResult);
 

--- a/comms/ncclx/v2_29/src/init.cc
+++ b/comms/ncclx/v2_29/src/init.cc
@@ -43,7 +43,7 @@
 
 #include "comms/ctran/Ctran.h"
 #include "meta/commstate/FactoryCommStateX.h"
-#include "comms/ctran/commstate/CommStateX.h"
+
 #include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/ctran/utils/Utils.h"
 #include "comms/ctran/utils/SkipDestroyUtil.h"
@@ -51,7 +51,7 @@
 #include "meta/colltrace/CollTraceWrapper.h"
 #include "meta/comms-monitor/CommsMonitor.h"
 #include "meta/commstate/FactoryCommStateX.h"
-#include "meta/ctran-integration/BaselineBootstrap.h"
+
 #include "meta/hints/CommHintConfig.h"
 
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -1933,27 +1933,9 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
    */
   NCCLCHECKGOTO(meta::comms::ncclx::newCollTraceInit(comm), res, fail);
 
-  // TODO: remove all ncclx fields and leave only ctranComm_
-  // (we are working on refactoring now, when it's done only ctranComm_ must be used)
-
-  // TODO: replace this dirty init code with CtranComm constructor.
-  // There is an issue with the order of initialization. We need to initialize stateX
-  // before initializing ctran/bootstrap/calltrace. The ctran classes internally start
-  // using CtranComm while still relying on ncclComm_t. This means that when we call
-  // ctranInit/boostrap init/calltrace init/ any internal ctran calss,
-  // both comm->stateX and ctranComm_->stateX must be initialized. Consequently, we have
-  // to split the initialization of CtranComm into several parts. This must be cleaned
-  // when we develop CtranComm constuctor.
-  NCCLCHECKGOTO(metaCommToNccl(setCtranCommBase(comm)), res, fail);
-
-  comm->ctranComm_->bootstrap_ = std::make_unique<ncclx::BaselineBootstrap>(comm);
-  comm->ctranComm_->statex_ = ncclx::createCommStateXFromNcclComm(comm);
 
   if (comm->useCtran_) {
-    // TODO: move initialization to CtranComm constructor once we finish all ctran refactor
-    NCCLCHECK(ncclx::initCtranCommStatexFromNcclComm(comm, comm->ctranComm_.get()));
-    comm->ctranComm_->colltraceNew_ = comm->newCollTrace;
-    NCCLCHECKGOTO(metaCommToNccl(ctranInit(comm->ctranComm_.get())), res, fail);
+    NCCLCHECKGOTO(createCtranComm(comm), res, fail);
   }
   // --------------------- done
 
@@ -2760,16 +2742,9 @@ static ncclResult_t commDestroySync(struct ncclAsyncJob* job_) {
   /*
    * NCCLX - Resource Cleanup
    */
-  NCCLCHECKGOTO(metaCommToNccl(ctranFinalize(comm->ctranComm_.get())), ret, fail);
   NCCLCHECKGOTO(meta::comms::ncclx::newCollTraceDestroy(comm), ret, fail);
 
-  try {
-    comm->ctranComm_->destroy();
-    comm->ctranComm_.reset();
-  } catch (std::exception& e) {
-    CLOGF(ERR, "CtranComm destruction failed: {}", e.what());
-    goto fail;
-  }
+  NCCLCHECKGOTO(destroyCtranComm(comm), ret, fail);
 
   TRACE(NCCL_INIT, "Destroying comm %p rank %d abortFlag %d asyncResult %d", comm, comm->rank, *comm->abortFlag, comm->asyncResult);
 


### PR DESCRIPTION
Summary:

Consolidate CommStateX creation and NVL fabric topology initialization into a single createCommStateXFromNcclComm entry point, and guard all ctranComm_ usage behind useCtran_:
- Change `createCommStateXFromNcclComm` signature to take `(void* _comm, CtranComm* ctranComm)` and return `ncclResult_t`, creating `statex_` directly on the CtranComm. This merges the old `createCommStateXFromNcclComm` (returning `unique_ptr<CommStateX>`) and `initCtranCommStatexFromNcclComm` into one function.
- Fold `initNvlFabricTopologies` into the factory as file-local helper, switching from NCCL-internal `bootstrapAllGather` to `IBootstrap::allGather`
- Remove `initRankTopologyFrom` (which populated topology from raw ncclComm fields) — topology init now goes through `initRankStatesTopology(bootstrap)`
- Move setCtranCommBase, bootstrap, memCache, and statex initialization into the `if (comm->useCtran_)` block in v2_27/v2_28/v2_29 init.cc. When ctran is disabled, `ctranComm_` is now nullptr (not a partially-initialized object).
- Add null checks for `ctranComm_` in destroy/cleanup paths
- Update CtranDisable test to verify `ctranComm_ == nullptr` when ctran is off
- Remove `friend void initRankTopologyFrom` from CommStateX.h

Reviewed By: dboyda, Scusemua

Differential Revision: D101586421


