### PR TITLE
Fix [[nodiscard]] hipError_t build errors in colltrace

### DIFF
--- a/comms/utils/colltrace/CollTrace.cc
+++ b/comms/utils/colltrace/CollTrace.cc
@@ -201,6 +201,8 @@ std::shared_ptr<GraphCollTraceState> CollTrace::getOrCreateGraphState(
         cudaUserObjectRelease(userObject, 1),
         cudaErrorCudartUnloading,
         cudaErrorContextIsDestroyed);
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    (void)cudaUserObjectRelease(userObject, 1);
     XLOG_FIRST_N(WARN, 1) << "Failed to retain graph user object: "
                           << cudaGetErrorString(retainRes);
     return nullptr;

--- a/comms/utils/colltrace/GraphCudaWaitEvent.cc
+++ b/comms/utils/colltrace/GraphCudaWaitEvent.cc
@@ -32,12 +32,16 @@ GraphCudaWaitEvent::~GraphCudaWaitEvent() {
         cudaStreamDestroy(timestampStream_),
         cudaErrorCudartUnloading,
         cudaErrorContextIsDestroyed);
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    (void)cudaStreamDestroy(timestampStream_);
   }
   if (depEvent_) {
     CUDA_CHECK_WITH_IGNORE(
         cudaEventDestroy(depEvent_),
         cudaErrorCudartUnloading,
         cudaErrorContextIsDestroyed);
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    (void)cudaEventDestroy(depEvent_);
   }
 }
 


### PR DESCRIPTION
Summary:
What: Cast return values to (void) to suppress the warnings, matching the existing NOLINTNEXTLINE pattern that already acknowledges these are intentionally unchecked cleanup calls in destructors/error paths.

Why: The hipified versions of cudaStreamDestroy, cudaEventDestroy, and cudaUserObjectRelease have [[nodiscard]] on their return type (hipError_t), causing -Werror,-Wunused-value failures under mode/amd-gpu + rocm70.

Differential Revision: D101673392


