### PR TITLE
Use globalRegisterWithPtr for user-provided window buffers (#2156)

### DIFF
--- a/comms/ctran/Ctran.cc
+++ b/comms/ctran/Ctran.cc
@@ -155,6 +155,8 @@ CtranComm::CtranComm(std::shared_ptr<Abort> abort, ctranConfig commConfig)
 }
 
 void CtranComm::destroy() {
+  cudagraphDeferredCleanup.runAll();
+
   // All smart pointers are automatically de-initialized, but we want to
   // ensure they do so in a specific order. Therefore, we manually handle
   // their de-initialization here.

--- a/comms/ctran/Ctran.cc
+++ b/comms/ctran/Ctran.cc
@@ -195,7 +195,11 @@ commResult_t ctranFinalize(CtranComm* comm) {
 
 namespace ctran {
 
-commResult_t globalRegisterWithPtr(void* buff, size_t size, bool forceReg) {
+commResult_t globalRegisterWithPtr(
+    void* buff,
+    size_t size,
+    bool forceReg,
+    bool ncclManaged) {
   if (NCCL_CTRAN_REGISTER == NCCL_CTRAN_REGISTER::none) {
     // ctran registration is disabled, no-op
     return commSuccess;
@@ -207,10 +211,11 @@ commResult_t globalRegisterWithPtr(void* buff, size_t size, bool forceReg) {
     return commInternalError;
   }
 
-  return regCache->globalRegister(buff, size, forceReg);
+  return regCache->globalRegister(buff, size, forceReg, ncclManaged);
 }
 
-commResult_t globalDeregisterWithPtr(void* buff, size_t size) {
+commResult_t
+globalDeregisterWithPtr(void* buff, size_t size, bool skipRemRelease) {
   if (NCCL_CTRAN_REGISTER == NCCL_CTRAN_REGISTER::none) {
     // ctran registration is disabled, no-op
     return commSuccess;
@@ -222,7 +227,7 @@ commResult_t globalDeregisterWithPtr(void* buff, size_t size) {
     return commInternalError;
   }
 
-  return regCache->globalDeregister(buff, size);
+  return regCache->globalDeregister(buff, size, skipRemRelease);
 }
 
 commResult_t registerAll() {

--- a/comms/ctran/Ctran.h
+++ b/comms/ctran/Ctran.h
@@ -462,11 +462,18 @@ commResult_t AllToAllPDestroy(CtranPersistentRequest* request);
 
 // Global pointer-based memory registration (does not require a comm).
 // If forceReg is true, registration happens even in async/lazy mode.
-commResult_t
-globalRegisterWithPtr(void* buff, size_t size, bool forceReg = false);
+commResult_t globalRegisterWithPtr(
+    void* buff,
+    size_t size,
+    bool forceReg = false,
+    bool ncclManaged = false);
 
 // Global pointer-based memory deregistration (does not require a comm).
-commResult_t globalDeregisterWithPtr(void* buff, size_t size);
+// If skipRemRelease is true, skip remote IPC release notifications and
+// just remove from exportRegCache. Use this during shutdown when remote
+// peers may have already exited.
+commResult_t
+globalDeregisterWithPtr(void* buff, size_t size, bool skipRemRelease = false);
 
 // Global APIs for bulk registration/deregistration of cached segments.
 // These are global operations that work on the singleton RegCache.

--- a/comms/ctran/Ctran.h
+++ b/comms/ctran/Ctran.h
@@ -75,7 +75,10 @@ commResult_t ctranGroupEndHook(
     enum NCCL_SENDRECV_ALGO algo,
     std::optional<std::chrono::milliseconds> timeout = std::nullopt);
 
-bool ctranAllGatherSupport(CtranComm* comm, enum NCCL_ALLGATHER_ALGO algo);
+bool ctranAllGatherSupport(
+    CtranComm* comm,
+    enum NCCL_ALLGATHER_ALGO algo,
+    cudaStream_t stream = nullptr);
 commResult_t ctranAllGather(
     const void* sendbuff,
     void* recvbuff,

--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -5,6 +5,8 @@
 #include <atomic>
 #include <chrono>
 #include <cstdint>
+#include <functional>
+#include <vector>
 
 #include <folly/Synchronized.h>
 #include "comms/ctran/bootstrap/ICtranBootstrap.h"
@@ -180,6 +182,27 @@ class CtranComm {
 #if defined(ENABLE_PIPES)
   std::unique_ptr<comms::pipes::MultiPeerTransport> multiPeerTransport_;
 #endif // defined(ENABLE_PIPES)
+
+  // Deferred cleanup for CUDA graph resources. CUDA user-object destructor
+  // callbacks cannot call CUDA APIs, so cleanup is enqueued here and
+  // executed at comm destruction where CUDA APIs are safe.
+  class CudagraphDeferredCleanup {
+   public:
+    void add(std::function<void()> fn) {
+      fns_.wlock()->push_back(std::move(fn));
+    }
+    void runAll() {
+      auto fns = fns_.wlock();
+      for (auto& fn : *fns) {
+        fn();
+      }
+      fns->clear();
+    }
+
+   private:
+    folly::Synchronized<std::vector<std::function<void()>>> fns_;
+  };
+  CudagraphDeferredCleanup cudagraphDeferredCleanup;
 
  private:
   // TODO: define proper constructor to make CtranComm be independent of

--- a/comms/ctran/algos/AllGather/AllGather.cc
+++ b/comms/ctran/algos/AllGather/AllGather.cc
@@ -1,15 +1,20 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 // #include <mutex>
+#include "comms/ctran/Ctran.h"
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/AllGather/AllGatherImpl.h"
 #include "comms/ctran/mapper/CtranMapper.h"
+#include "comms/ctran/utils/CudaGraphUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
 // Check if CTRAN is supported and if a specific algo is supported by CTRAN.
 // If user sets a specific algo, it should check to avoid unexpected abort in
 // ctranAllGather.
-bool ctranAllGatherSupport(CtranComm* comm, enum NCCL_ALLGATHER_ALGO algo) {
+bool ctranAllGatherSupport(
+    CtranComm* comm,
+    enum NCCL_ALLGATHER_ALGO algo,
+    cudaStream_t stream) {
   if (!ctranInitialized(comm) || !comm->ctran_->mapper->hasBackend()) {
     return false;
   }
@@ -33,6 +38,26 @@ bool ctranAllGatherSupport(CtranComm* comm, enum NCCL_ALLGATHER_ALGO algo) {
     case NCCL_ALLGATHER_ALGO::ctran:
       supported = true;
       break;
+    case NCCL_ALLGATHER_ALGO::ctgraph: {
+      if (stream == nullptr) {
+        supported = false;
+        break;
+      }
+      ctran::utils::cudagraph::StreamCaptureInfo captureInfo;
+      auto err =
+          ctran::utils::cudagraph::getStreamCaptureInfo(stream, captureInfo);
+      supported = (err == cudaSuccess) &&
+          (captureInfo.status == cudaStreamCaptureStatusActive) &&
+          ctran::allGatherPSupport(comm);
+      if (!supported) {
+        CLOGF_SUBSYS(
+            INFO,
+            COLL,
+            "AllGather ctgraph: not in capture mode or AGP not supported. "
+            "Falling back to baseline");
+      }
+      break;
+    }
     case NCCL_ALLGATHER_ALGO::orig: // invalid query
       supported = false;
       break;
@@ -49,11 +74,25 @@ commResult_t ctranAllGather(
     CtranComm* comm,
     cudaStream_t stream,
     enum NCCL_ALLGATHER_ALGO algo) {
+  // Cudagraph-aware optimization: when capturing and AGP is supported,
+  // transparently convert to the persistent window-based AGP algorithm.
+  if (algo == NCCL_ALLGATHER_ALGO::ctgraph) {
+    ctran::utils::cudagraph::StreamCaptureInfo captureInfo;
+    FB_CUDACHECK(
+        ctran::utils::cudagraph::getStreamCaptureInfo(stream, captureInfo));
+    if (captureInfo.status == cudaStreamCaptureStatusActive &&
+        ctran::allGatherPSupport(comm)) {
+      return ctranAllGatherCudagraphAware(
+          sendbuff, recvbuff, sendcount, datatype, comm, stream);
+    }
+  }
+
   const auto statex = comm->statex_.get();
 
   // Only ctdirect supports nLocalRanks>1 case.
   // Force to use ctdirect if nLocalRanks>1.
-  if (algo == NCCL_ALLGATHER_ALGO::ctran) {
+  if (algo == NCCL_ALLGATHER_ALGO::ctran ||
+      algo == NCCL_ALLGATHER_ALGO::ctgraph) {
     if (statex->nLocalRanks() > 1) {
       algo = NCCL_ALLGATHER_ALGO::ctdirect;
       CLOGF_SUBSYS(

--- a/comms/ctran/algos/AllGather/AllGatherCudagraphAware.cc
+++ b/comms/ctran/algos/AllGather/AllGatherCudagraphAware.cc
@@ -1,0 +1,100 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// Cudagraph-aware AllGather: when a regular ctranAllGather() is called during
+// CUDA graph capture and this path is enabled, the collective is transparently
+// converted to the persistent AllGatherP (window-based) algorithm.
+//
+// Flow:
+//   1. ctranWinRegister() — register recvbuff as a window, exchange handles
+//      with all peers. This is a collective CPU-side operation and is NOT
+//      captured into the graph.
+//   2. allGatherWinInit() — create persistent AGP state from window metadata.
+//      Synchronous, no async handle exchange needed. Uses
+//      cudaThreadExchangeStreamCaptureMode to temporarily allow cudaHostAlloc
+//      (blocked under cudaStreamCaptureModeGlobal used by PyTorch).
+//   3. allGatherWinExec() — dry-run exec that IS captured into the graph.
+//      CE copies (NVL intra-node) and GPE host-node callbacks (IB inter-node)
+//      are recorded as graph nodes.
+//   4. Register cleanup on comm's cudagraphDeferredCleanup.
+//
+// On graph replay, only the captured CE + host-node operations re-execute.
+// The result is SM-free replay (no GPU kernels for NVL copies).
+//
+// Cleanup: Resources are registered for deferred cleanup at capture time
+// (not at graph destruction). This ensures cleanup runs during comm
+// destruction on the main thread, regardless of when or whether the graph
+// is destroyed. Graph replay is guaranteed to finish before comm destroy.
+
+#include <folly/ScopeGuard.h>
+
+#include "comms/ctran/Ctran.h"
+#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/algos/AllGather/AllGatherImpl.h"
+#include "comms/ctran/algos/CtranAlgo.h"
+#include "comms/ctran/utils/CudaGraphUtils.h"
+#include "comms/ctran/window/CtranWin.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+
+commResult_t ctranAllGatherCudagraphAware(
+    const void* sendbuff,
+    void* recvbuff,
+    size_t sendcount,
+    commDataType_t datatype,
+    CtranComm* comm,
+    cudaStream_t stream) {
+  const auto statex = comm->statex_.get();
+  const int nRanks = statex->nRanks();
+  const size_t recvBytes = sendcount * commTypeSize(datatype) * nRanks;
+
+  CLOGF_SUBSYS(
+      INFO,
+      COLL,
+      "AllGather cudagraph-aware: converting to window-based AGP "
+      "(sendcount={}, nRanks={}, recvBytes={})",
+      sendcount,
+      nRanks,
+      recvBytes);
+
+  // 1. Register recvbuff as a window and exchange handles with all peers.
+  //    Collective and CPU-side — NOT captured into the graph.
+  ctran::CtranWin* win = nullptr;
+  FB_COMMCHECK(ctran::ctranWinRegister(recvbuff, recvBytes, comm, &win));
+
+  // 2. Init persistent AGP from window metadata.
+  //    Switch to relaxed capture mode so initResources() can cudaHostAlloc
+  //    (blocked under cudaStreamCaptureModeGlobal used by PyTorch).
+  //    Single-threaded-per-comm assumption (standard for NCCL).
+  auto winGuard = folly::makeGuard([win]() { delete win; });
+
+  cudaStreamCaptureMode prevMode = cudaStreamCaptureModeRelaxed;
+  FB_CUDACHECK(cudaThreadExchangeStreamCaptureMode(&prevMode));
+
+  CtranPersistentRequest* request = nullptr;
+  // Store result instead of FB_COMMCHECK — must restore capture mode before
+  // any early return.
+  auto initResult = ctran::allGatherWinInit(win, comm, stream, request);
+
+  FB_CUDACHECK(cudaThreadExchangeStreamCaptureMode(&prevMode));
+  FB_COMMCHECK(initResult);
+
+  // 3. Dry-run exec — CE copies and GPE host-node callbacks are captured.
+  FB_COMMCHECK(ctran::allGatherWinExec(sendbuff, sendcount, datatype, request));
+
+  // 4. Register cleanup on comm at capture time. Resources live for the
+  //    comm's lifetime and are cleaned up during CtranComm::destroy() on
+  //    the main thread. This avoids depending on retainUserObject callbacks
+  //    which run on CUDA's internal thread where CUDA APIs are forbidden.
+  winGuard.dismiss();
+  comm->cudagraphDeferredCleanup.add([request, win]() {
+    if (request) {
+      ctran::allGatherWinDestroy(request);
+      delete request;
+    }
+    if (win) {
+      win->free(true /* skipBarrier */);
+      delete win;
+    }
+  });
+
+  return commSuccess;
+}

--- a/comms/ctran/algos/AllGather/AllGatherImpl.h
+++ b/comms/ctran/algos/AllGather/AllGatherImpl.h
@@ -53,12 +53,24 @@ static inline const std::string allGatherAlgoName(
       return "CtranBrucksFF";
     case NCCL_ALLGATHER_ALGO::ctran:
       return "CtranAuto";
+    case NCCL_ALLGATHER_ALGO::ctgraph:
+      return "CtranCudagraphAware";
     case NCCL_ALLGATHER_ALGO::orig:
       return "Baseline";
     default:
       return "Unknown";
   }
 }
+
+// Cudagraph-aware path: transparently converts a regular allgather to the
+// persistent window-based AGP algorithm during CUDA graph capture.
+commResult_t ctranAllGatherCudagraphAware(
+    const void* sendbuff,
+    void* recvbuff,
+    size_t sendcount,
+    commDataType_t datatype,
+    CtranComm* comm,
+    cudaStream_t stream);
 
 commResult_t prepareAllGatherArgs(
     std::vector<std::unique_ptr<struct OpElem>>& opGroup,

--- a/comms/ctran/algos/CtranAlgo.cc
+++ b/comms/ctran/algos/CtranAlgo.cc
@@ -630,7 +630,8 @@ static const std::unordered_map<std::string, enum NCCL_ALLGATHER_ALGO>
         {"ctdirect", NCCL_ALLGATHER_ALGO::ctdirect},
         {"ctring", NCCL_ALLGATHER_ALGO::ctring},
         {"ctrd", NCCL_ALLGATHER_ALGO::ctrd},
-        {"ctbrucks", NCCL_ALLGATHER_ALGO::ctbrucks}};
+        {"ctbrucks", NCCL_ALLGATHER_ALGO::ctbrucks},
+        {"ctgraph", NCCL_ALLGATHER_ALGO::ctgraph}};
 
 commResult_t ctranConfigCommAlgoOverride(CtranComm* comm) {
   if (!ctranInitialized(comm)) {

--- a/comms/ctran/mapper/CtranMapper.cc
+++ b/comms/ctran/mapper/CtranMapper.cc
@@ -722,6 +722,11 @@ commResult_t CtranMapper::deregDynamic(void* regHdl) {
   return commSuccess;
 }
 
+void CtranMapper::removeFromExportCache(void* regHdl) {
+  auto* regElem = reinterpret_cast<ctran::regcache::RegElem*>(regHdl);
+  exportRegCache_.wlock()->remove(regElem);
+}
+
 commResult_t CtranMapper::deregRemReg(struct CtranMapperRemoteAccessKey* rkey) {
   switch (rkey->backend) {
     case CtranMapperBackend::NVL: {

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -118,6 +118,13 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
    */
   commResult_t deregDynamic(void* regHdl);
 
+  /* Remove a registration handle from the export tracking cache.
+   * Used when the caller handles deregistration separately (e.g., via
+   * globalDeregisterWithPtr) and needs to prevent the mapper destructor
+   * from accessing a freed RegElem.
+   */
+  void removeFromExportCache(void* regHdl);
+
   /* Deregister an imported buffer registration from remote peer.
    * Input arguments:
    *  - rkey: the remoteAccessKey of the imported remote buffer received in

--- a/comms/ctran/regcache/RegCache.cc
+++ b/comms/ctran/regcache/RegCache.cc
@@ -311,6 +311,7 @@ commResult_t ctran::RegCache::globalRegister(
     const void* buf,
     size_t len,
     bool forceReg,
+    bool ncclManaged,
     int deviceId) {
   if (buf == nullptr || len == 0) {
     return commSuccess;
@@ -337,7 +338,7 @@ commResult_t ctran::RegCache::globalRegister(
       buf,
       len,
       cudaDev,
-      false /* ncclManaged */,
+      ncclManaged,
       0 /* commHash - not used for global registration */,
       segments,
       segHdls));
@@ -357,14 +358,17 @@ commResult_t ctran::RegCache::globalRegister(
         globalBackends_,
         didRegister,
         &regHdl,
-        false /* ncclManaged */));
+        ncclManaged));
   }
 
   return commSuccess;
 }
 
-commResult_t
-ctran::RegCache::globalDeregister(const void* buf, size_t len, int deviceId) {
+commResult_t ctran::RegCache::globalDeregister(
+    const void* buf,
+    size_t len,
+    bool skipRemRelease,
+    int deviceId) {
   if (buf == nullptr || len == 0) {
     return commSuccess;
   }
@@ -390,13 +394,13 @@ ctran::RegCache::globalDeregister(const void* buf, size_t len, int deviceId) {
   std::vector<ctran::regcache::RegElem*> regElems;
   FB_COMMCHECK(lookupSegmentsForBuffer(buf, len, cudaDev, segHdls, regElems));
 
-  // Call releaseFromAllClients on regElems before freeing segments.
-  // This iterates all registered IpcExportClients (mappers) and notifies
-  // remote peers to release their imported NVL memory.
-  auto ipcRegCache = ctran::IpcRegCache::getInstance();
-  for (auto& regElem : regElems) {
-    if (regElem->ipcRegElem != nullptr) {
-      FB_COMMCHECK(ipcRegCache->releaseFromAllClients(regElem));
+  if (!skipRemRelease) {
+    // Notify remote peers to release their imported NVL memory.
+    auto ipcRegCache = ctran::IpcRegCache::getInstance();
+    for (auto& regElem : regElems) {
+      if (regElem->ipcRegElem != nullptr) {
+        FB_COMMCHECK(ipcRegCache->releaseFromAllClients(regElem));
+      }
     }
   }
 

--- a/comms/ctran/regcache/RegCache.h
+++ b/comms/ctran/regcache/RegCache.h
@@ -280,11 +280,16 @@ class RegCache {
       const void* buf,
       size_t len,
       bool forceReg = false,
+      bool ncclManaged = false,
       int deviceId = -1);
 
   // Global deregistration using pointer lookup.
   // Frees cached segments and their associated registrations.
-  commResult_t globalDeregister(const void* buf, size_t len, int deviceId = -1);
+  commResult_t globalDeregister(
+      const void* buf,
+      size_t len,
+      bool skipRemRelease = false,
+      int deviceId = -1);
 
   // Thread-safe functions to cache a buffer range into the global cache.
   // This function uses pinRange to discover all physical segments underlying

--- a/comms/ctran/tests/CtranDistRMATest.cc
+++ b/comms/ctran/tests/CtranDistRMATest.cc
@@ -77,13 +77,18 @@ class CtranRMATest : public ctran::CtranDistTestFixture, public CtranBaseTest {
   freeWinBuf(bool isUserBuf, void* ptr, size_t size, MemAllocType bufType) {
     if (isUserBuf) {
       commMemFree(ptr, size, bufType);
-      // Remove the segment from the tracking vector
-      segments.erase(
-          std::remove_if(
-              segments.begin(),
-              segments.end(),
-              [ptr](const TestMemSegment& seg) { return seg.ptr == ptr; }),
-          segments.end());
+      if (bufType == MemAllocType::kCuMemAllocDisjoint) {
+        // Disjoint allocations create multiple sub-segment entries in the
+        // tracking vector. Clear all since commMemFree handles the actual free.
+        segments.clear();
+      } else {
+        segments.erase(
+            std::remove_if(
+                segments.begin(),
+                segments.end(),
+                [ptr](const TestMemSegment& seg) { return seg.ptr == ptr; }),
+            segments.end());
+      }
     }
   }
   std::vector<TestMemSegment> segments;
@@ -664,6 +669,7 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::Values(true, false),
         ::testing::Values(
             MemAllocType::kMemCuMemAlloc,
+            MemAllocType::kCuMemAllocDisjoint,
             MemAllocType::kMemCudaMalloc,
             MemAllocType::kMemHostManaged,
             MemAllocType::kMemHostUnregistered),

--- a/comms/ctran/tests/CtranWinAllGatherTest.cc
+++ b/comms/ctran/tests/CtranWinAllGatherTest.cc
@@ -147,6 +147,83 @@ INSTANTIATE_TEST_SUITE_P(
           std::get<1>(info.param);
     });
 
+// Test window allgather with disjoint (multi-segment) memory allocation,
+// simulating expandable segments. Verifies that ctranWinRegister works with
+// globalRegisterWithPtr for buffers backed by multiple physical segments.
+TEST_F(CtranWinAllGatherTest, DisjointMemory) {
+  SysEnvRAII algoEnv("NCCL_ALLGATHER_P_ALGO", "ctdirect");
+
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+
+  auto statex = comm->statex_.get();
+  ASSERT_NE(statex, nullptr);
+
+  const auto nRanks = statex->nRanks();
+  const auto myRank = statex->rank();
+  const commDataType_t dt = commFloat;
+  // sendCount must be large enough that recvBytes (sendCount * 4 * nRanks)
+  // spans multiple 2MB-aligned cuMem segments to trigger the multi-segment
+  // path in pinRange. With 8 ranks: 1M * 4 * 8 = 32MB > 2MB.
+  const size_t sendCount = 1024 * 1024;
+  const size_t sendBytes = sendCount * commTypeSize(dt);
+  const size_t recvBytes = sendBytes * nRanks;
+
+  if (!CtranWin::allGatherPSupported(comm.get())) {
+    GTEST_SKIP() << "allGatherP not supported on this topology";
+  }
+
+  cudaStream_t stream;
+  CUDACHECK_TEST(cudaStreamCreate(&stream));
+
+  // Allocate recv buffer as disjoint segments (simulates expandable segments)
+  constexpr int kNumSegments = 4;
+  size_t segSize = recvBytes / kNumSegments;
+  std::vector<size_t> segSizes(kNumSegments, segSize);
+  std::vector<TestMemSegment> segments;
+  void* winBase = nullptr;
+  ASSERT_EQ(commMemAllocDisjoint(&winBase, segSizes, segments), commSuccess);
+
+  CtranWin* win = nullptr;
+  auto res = ctranWinRegister(winBase, recvBytes, comm.get(), &win);
+  ASSERT_EQ(res, commSuccess);
+
+  void* sendbuf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&sendbuf, sendBytes));
+
+  CtranPersistentRequest* request = nullptr;
+  ASSERT_EQ(
+      ctran::allGatherWinInit(win, comm.get(), stream, request), commSuccess);
+  ASSERT_NE(request, nullptr);
+  CUDACHECK_TEST(cudaStreamSynchronize(stream));
+
+  constexpr int nIter = 3;
+  for (int iter = 0; iter < nIter; iter++) {
+    const float sendVal = static_cast<float>(myRank * 100 + iter);
+    std::vector<float> sendVals(sendCount, sendVal);
+    CUDACHECK_TEST(cudaMemcpyAsync(
+        sendbuf, sendVals.data(), sendBytes, cudaMemcpyHostToDevice, stream));
+    CUDACHECK_TEST(cudaMemsetAsync(winBase, 0, recvBytes, stream));
+
+    ASSERT_EQ(
+        ctran::allGatherWinExec(sendbuf, sendCount, dt, request), commSuccess);
+    CUDACHECK_TEST(cudaStreamSynchronize(stream));
+
+    verifyAllGather(winBase, sendCount, sendBytes, nRanks, myRank, iter);
+  }
+
+  ASSERT_EQ(comm->ctran_->gpe->numInUseKernelElems(), 0);
+  ASSERT_EQ(comm->ctran_->gpe->numInUseKernelFlags(), 0);
+
+  ASSERT_EQ(ctran::allGatherWinDestroy(request), commSuccess);
+  delete request;
+
+  CUDACHECK_TEST(cudaFree(sendbuf));
+  ASSERT_EQ(ctranWinFree(win), commSuccess);
+  ASSERT_EQ(commMemFreeDisjoint(winBase, segSizes), commSuccess);
+  CUDACHECK_TEST(cudaStreamDestroy(stream));
+}
+
 class CtranWinAllGatherTestEnv : public ctran::CtranEnvironmentBase {
  public:
   void SetUp() override {

--- a/comms/ctran/tests/cudagraph/CtranCudaGraphAllGatherCtgraphTest.cc
+++ b/comms/ctran/tests/cudagraph/CtranCudaGraphAllGatherCtgraphTest.cc
@@ -1,0 +1,120 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// Tests for the ctgraph AllGather algorithm.
+// When algo=ctgraph, ctranAllGatherSupport returns true only during CUDA graph
+// capture (and falls back to baseline otherwise). During capture,
+// ctranAllGather transparently converts to the persistent window-based AGP
+// algorithm.
+
+#include "comms/ctran/algos/AllGather/AllGatherImpl.h"
+#include "comms/ctran/tests/cudagraph/CtranCudaGraphParamTest.h"
+
+static AlgoDescriptor makeAllGatherCtgraph() {
+  struct B : AlgoDescriptor::Buffers {
+    ctran::TestDeviceBuffer send, recv;
+    size_t bytes;
+    B(size_t c, int rank, int nR)
+        : send(c * sizeof(int32_t)),
+          recv(c * nR * sizeof(int32_t)),
+          bytes(c * nR * sizeof(int32_t)) {
+      CtranCudaGraphTestBase::fillSendBuf(send.get(), c, rank);
+    }
+    void* sendbuf() override {
+      return send.get();
+    }
+    void* recvbuf() override {
+      return recv.get();
+    }
+    size_t recvBytes() override {
+      return bytes;
+    }
+  };
+
+  AlgoDescriptor desc;
+  desc.name = "AllGatherCtgraph";
+  desc.isSupported = [](CtranComm* comm, size_t, int) {
+    return ctran::allGatherPSupport(comm);
+  };
+  desc.expectsHostNodes = [](CtranComm* comm, size_t) {
+    auto statex = comm->statex_.get();
+    return statex->nLocalRanks() < statex->nRanks();
+  };
+  desc.makeBuffers = [](size_t c, int rank, int nR) {
+    return std::make_shared<B>(c, rank, nR);
+  };
+  desc.capture = [](AlgoDescriptor::Buffers* base,
+                    size_t count,
+                    ctran::testing::CaptureContext& ctx) {
+    auto* b = static_cast<B*>(base);
+    ASSERT_EQ(
+        ctranAllGather(
+            b->send.get(),
+            b->recv.get(),
+            count,
+            commInt32,
+            ctx.comm,
+            ctx.stream,
+            NCCL_ALLGATHER_ALGO::ctgraph),
+        commSuccess);
+  };
+  return desc;
+}
+
+DEFINE_CUDAGRAPH_PARAM_TEST(CudaGraphAllGatherCtgraph, makeAllGatherCtgraph());
+
+// Verifies that graph destruction cleans up without CUDA API errors.
+// The retainUserObject destructor callback defers cleanup to comm destruction
+// since CUDA APIs are forbidden in the callback context.
+class CudaGraphAllGatherCtgraphDestroy : public CtranCudaGraphTestBase {};
+
+TEST_F(CudaGraphAllGatherCtgraphDestroy, DestroyGraphCleanly) {
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+
+  if (!ctran::allGatherPSupport(comm.get())) {
+    GTEST_SKIP() << "allGatherP not supported";
+  }
+
+  const size_t count = 1024;
+  const int nRanks = numRanks;
+  ctran::TestDeviceBuffer send(count * sizeof(int32_t));
+  ctran::TestDeviceBuffer recv(count * nRanks * sizeof(int32_t));
+  fillSendBuf(send.get(), count, globalRank);
+
+  meta::comms::CudaStream stream(cudaStreamNonBlocking);
+
+  // Capture
+  cudaGraph_t graph;
+  cudaGraphExec_t exec;
+  ASSERT_EQ(
+      cudaStreamBeginCapture(stream.get(), cudaStreamCaptureModeGlobal),
+      cudaSuccess);
+  ASSERT_EQ(
+      ctranAllGather(
+          send.get(),
+          recv.get(),
+          count,
+          commInt32,
+          comm.get(),
+          stream.get(),
+          NCCL_ALLGATHER_ALGO::ctgraph),
+      commSuccess);
+  ASSERT_EQ(cudaStreamEndCapture(stream.get(), &graph), cudaSuccess);
+  ASSERT_EQ(cudaGraphInstantiate(&exec, graph, 0), cudaSuccess);
+
+  // Replay
+  ASSERT_EQ(cudaGraphLaunch(exec, stream.get()), cudaSuccess);
+  ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
+
+  // Destroy — triggers retainUserObject destructor callback.
+  ASSERT_EQ(cudaGraphExecDestroy(exec), cudaSuccess);
+  ASSERT_EQ(cudaGraphDestroy(graph), cudaSuccess);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+}
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new CtranCudaGraphEnvironment);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ctran/window/CtranWin.h
+++ b/comms/ctran/window/CtranWin.h
@@ -129,7 +129,7 @@ struct CtranWin {
   }
 #endif
 
-  commResult_t free();
+  commResult_t free(bool skipBarrier = false);
 
   bool nvlEnabled(int rank) const;
 

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -221,7 +221,7 @@ commResult_t CtranWin::allocate(void* userBufPtr) {
   return commSuccess;
 }
 
-commResult_t CtranWin::free() {
+commResult_t CtranWin::free(bool skipBarrier) {
   auto statex = comm->statex_.get();
   if (statex == nullptr) {
     FB_ERRORRETURN(commInternalError, "Empty communicator statex.");
@@ -239,11 +239,14 @@ commResult_t CtranWin::free() {
       statex->commHash());
 
   // A barrier among ranks before freeing window to prevent peer ranks accessing
-  // the window after it is freed.
+  // the window after it is freed. Skipped when called from deferred cleanup at
+  // comm destruction (all communication is already finalized).
   // NOTE: the window object is not aware of CUDA streams, users need to
   // ensure the host process waits for CUDA streams where put/wait operations
   // are launched.
-  FB_COMMCHECK(mapper->barrier());
+  if (!skipBarrier) {
+    FB_COMMCHECK(mapper->barrier());
+  }
 
   auto nRanks = statex->nRanks();
 

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include "comms/ctran/Ctran.h"
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/mapper/CtranMapper.h"
 #include "comms/ctran/utils/Alloc.h"
@@ -62,14 +63,29 @@ commResult_t CtranWin::exchange() {
     dataSegHdl = baseSegHdl;
     dataRegHdl = baseRegHdl;
   } else {
-    // if data buffer is provided by user, we need to register it
-    FB_COMMCHECK(mapper->regMem(
+    // User-provided buffer: use globalRegisterWithPtr to cache and register
+    // multi-segment buffers (e.g., expandable segments) that mapper->regMem
+    // cannot handle (it asserts single-segment). forceReg=true ensures
+    // registration happens immediately; ncclManaged=true enables NVL IPC
+    // handle creation for cudaMalloc buffers. searchRegHandle then finds the
+    // RegElem via fast path for use in allGatherCtrl handle exchange.
+    FB_COMMCHECK(
+        ctran::globalRegisterWithPtr(
+            winDataPtr,
+            dataBytes,
+            true /* forceReg */,
+            true /* ncclManaged */));
+    bool dynamicRegist = false;
+    FB_COMMCHECK(mapper->searchRegHandle(
+        winDataPtr, dataBytes, &dataRegHdl, &dynamicRegist));
+    // globalRegisterWithPtr with forceReg=true guarantees the RegElem is
+    // already created, so searchRegHandle should find it via fast path
+    // (not dynamic registration).
+    FB_CHECKABORT(
+        !dynamicRegist,
+        "Unexpected dynamic registration for window data buffer {} len {}",
         winDataPtr,
-        dataBytes,
-        &(dataSegHdl),
-        true,
-        true, /* NCCL managed buffer */
-        &dataRegHdl));
+        dataBytes);
   }
 
   // Exchange each rank's data buffer size via bootstrap allGather
@@ -273,15 +289,19 @@ commResult_t CtranWin::free(bool skipBarrier) {
   // deregister remote buf
   for (auto i = 0; i < nRanks; ++i) {
     if (i != statex->rank()) {
-      // the signal buffer is always allocated by window internally, so we only
-      // need to dereg using the signalRkey
       FB_COMMCHECK(mapper->deregRemReg(&remWinInfo[i].signalRkey));
     }
   }
 
-  // if data buffer is provided by user, we need to dereg the data buffer
+  // User-provided data buffer: deregister locally without remote IPC
+  // notifications. Remove from export cache first (so mapper destructor
+  // won't access the freed RegElem), then free segments locally, then
+  // release locally-imported remote handles.
   if (!allocDataBuf_) {
-    deregMemIfNotNull(dataSegHdl);
+    mapper->removeFromExportCache(dataRegHdl);
+    FB_COMMCHECK(
+        ctran::globalDeregisterWithPtr(
+            winDataPtr, dataBytes, true /* skipRemRelease */));
     for (auto i = 0; i < nRanks; ++i) {
       if (i != statex->rank()) {
         FB_COMMCHECK(mapper->deregRemReg(&remWinInfo[i].dataRkey));

--- a/comms/ncclx/meta/algoconf/AlgoConfig.cc
+++ b/comms/ncclx/meta/algoconf/AlgoConfig.cc
@@ -48,6 +48,8 @@ inline const std::string algoValToStr(enum NCCL_ALLGATHER_ALGO val) {
       return "ctrd";
     case NCCL_ALLGATHER_ALGO::ctbrucks:
       return "ctbrucks";
+    case NCCL_ALLGATHER_ALGO::ctgraph:
+      return "ctgraph";
       break;
   }
 }
@@ -65,6 +67,8 @@ inline void algoStrToVal(
     val = NCCL_ALLGATHER_ALGO::ctrd;
   } else if (str == "ctbrucks") {
     val = NCCL_ALLGATHER_ALGO::ctbrucks;
+  } else if (str == "ctgraph") {
+    val = NCCL_ALLGATHER_ALGO::ctgraph;
   } else {
     val = NCCL_ALLGATHER_ALGO::orig;
   }

--- a/comms/ncclx/v2_27/src/collectives.cc
+++ b/comms/ncclx/v2_27/src/collectives.cc
@@ -95,7 +95,7 @@ ncclResult_t ncclAllGather(const void* sendbuff, void* recvbuff, size_t sendcoun
 
   auto algo = ncclx::algoconf::getAllGatherAlgo();
 
-  if (algo != NCCL_ALLGATHER_ALGO::orig && ctranAllGatherSupport(comm->ctranComm_.get(), algo)) {
+  if (algo != NCCL_ALLGATHER_ALGO::orig && ctranAllGatherSupport(comm->ctranComm_.get(), algo, stream)) {
     return metaCommToNccl(ctranAllGather(
         sendbuff, recvbuff, sendcount, ncclToMetaComm(datatype), comm->ctranComm_.get(), stream, algo));
   }

--- a/comms/ncclx/v2_28/src/collectives.cc
+++ b/comms/ncclx/v2_28/src/collectives.cc
@@ -98,7 +98,7 @@ ncclResult_t ncclAllGather(const void* sendbuff, void* recvbuff, size_t sendcoun
 
   auto algo = ncclx::algoconf::getAllGatherAlgo();
 
-  if (algo != NCCL_ALLGATHER_ALGO::orig && ctranAllGatherSupport(comm->ctranComm_.get(), algo)) {
+  if (algo != NCCL_ALLGATHER_ALGO::orig && ctranAllGatherSupport(comm->ctranComm_.get(), algo, stream)) {
     return metaCommToNccl(ctranAllGather(
         sendbuff, recvbuff, sendcount, ncclToMetaComm(datatype), comm->ctranComm_.get(), stream, algo));
   }

--- a/comms/ncclx/v2_29/src/collectives.cc
+++ b/comms/ncclx/v2_29/src/collectives.cc
@@ -102,7 +102,7 @@ ncclResult_t ncclAllGather(const void* sendbuff, void* recvbuff, size_t sendcoun
 
   auto algo = ncclx::algoconf::getAllGatherAlgo();
 
-  if (algo != NCCL_ALLGATHER_ALGO::orig && ctranAllGatherSupport(comm->ctranComm_.get(), algo)) {
+  if (algo != NCCL_ALLGATHER_ALGO::orig && ctranAllGatherSupport(comm->ctranComm_.get(), algo, stream)) {
     return metaCommToNccl(ctranAllGather(
         sendbuff, recvbuff, sendcount, ncclToMetaComm(datatype), comm->ctranComm_.get(), stream, algo));
   }

--- a/comms/torchcomms/tests/integration/py/CudaGraphsAllGatherAwareTest.py
+++ b/comms/torchcomms/tests/integration/py/CudaGraphsAllGatherAwareTest.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+# pyre-unsafe
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Tests for cudagraph-aware AllGather auto-conversion to AGP.
+
+When NCCL_ALLGATHER_ALGO=ctgraph, a regular all_gather_single() call during
+CUDA graph capture is transparently converted to the persistent window-based
+AGP algorithm (SM-free CE+IB). These tests verify correct data after graph
+replay.
+
+To collect Kineto traces, set TORCH_PROFILE_DIR to an output directory:
+  TORCH_PROFILE_DIR=/tmp/traces buck2 run ...
+Traces are written as <test_name>_rank<N>.json per rank.
+"""
+
+import contextlib
+import os
+import unittest
+
+import torch
+import torchcomms  # noqa: F401 — side-effect import registers ncclx backend
+
+# pyre-fixme[21]: Could not find name `ProfilerActivity` in `torch.profiler`.
+from torch.profiler import profile, ProfilerActivity
+from torchcomms.tests.helpers.py.cuda_graph_test_helpers import (
+    _wait,
+    CudaGraphTestBase,
+    GraphTestBuilder,
+    skip_unless_ncclx,
+)
+from torchcomms.tests.integration.py.TorchCommTestHelpers import get_rank_and_size
+
+
+class TestAllGatherCudaGraphAware(CudaGraphTestBase):
+    """Tests that regular all_gather_single auto-converts to AGP under
+    CUDA graph capture when NCCL_ALLGATHER_ALGO=ctgraph."""
+
+    NUM_REPLAYS = 3
+    ELEM_COUNT = 1024
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        os.environ["NCCL_CTRAN_ALLOW_CUDA_GRAPH"] = "1"
+        os.environ["NCCL_ALLGATHER_ALGO"] = "ctgraph"
+        os.environ.setdefault("NCCL_DEBUG", "INFO")
+        os.environ.setdefault("NCCL_DEBUG_SUBSYS", "COLL")
+        super().setUpClass()
+
+    @skip_unless_ncclx
+    def test_allgather_cudagraph_aware(self) -> None:
+        """Capture a regular all_gather_single into a CUDA graph and verify
+        correct results on replay. The ctgraph algo transparently converts
+        it to window-based AGP.
+
+        Set TORCH_PROFILE_DIR to collect Kineto traces (handled by
+        GraphTestBuilder internally).
+        """
+
+        def make_inputs(b: GraphTestBuilder) -> list[torch.Tensor]:
+            rank = b.comms[0].get_rank()
+            size = b.comms[0].get_size()
+            sendbuf = (
+                torch.ones(self.ELEM_COUNT, dtype=torch.float32, device=self.device)
+                * rank
+            )
+            recvbuf = torch.zeros(
+                self.ELEM_COUNT * size, dtype=torch.float32, device=self.device
+            )
+            return [sendbuf, recvbuf]
+
+        def capture(b: GraphTestBuilder) -> None:
+            _wait(b.comms[0].all_gather_single(b.inputs[1], b.inputs[0], async_op=True))
+
+        def make_expected(b: GraphTestBuilder) -> list[torch.Tensor]:
+            size = b.comms[0].get_size()
+            sendbuf = b.inputs[0].clone()
+            recvbuf = torch.cat(
+                [
+                    torch.ones(self.ELEM_COUNT, dtype=torch.float32, device=self.device)
+                    * r
+                    for r in range(size)
+                ]
+            )
+            return [sendbuf, recvbuf]
+
+        GraphTestBuilder(self).add_capture(capture).run_serial(
+            inputs=make_inputs,
+            expected=make_expected,
+        )
+
+    @skip_unless_ncclx
+    def test_allgather_cudagraph_aware_changing_data(self) -> None:
+        """Verify graph replay picks up modified sendbuf data each iteration,
+        confirming the auto-converted AGP re-reads from the same address.
+
+        Set TORCH_PROFILE_DIR to collect Kineto traces.
+        """
+        rank, _ = get_rank_and_size()
+        profile_dir = os.environ.get("TORCH_PROFILE_DIR")
+
+        with self.create_comms(1) as comms:
+            comm = comms[0]
+            size = comm.get_size()
+            count = self.ELEM_COUNT
+
+            sendbuf = torch.zeros(count, dtype=torch.float32, device=self.device)
+            recvbuf = torch.zeros(count * size, dtype=torch.float32, device=self.device)
+
+            # Wrap everything in the profiler so the trace shows:
+            #   1. Eager warmup allgathers (regular NCCL kernel path)
+            #   2. Graph capture (auto-converts to AGP)
+            #   3. Graph replays (SM-free CE+host-node replay)
+            profile_ctx = (
+                # pyre-fixme[16]: Module `torch.profiler` has no attribute `ProfilerActivity`.
+                profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA])
+                if profile_dir
+                else contextlib.nullcontext()
+            )
+            with profile_ctx as prof:
+                # Eager warmup: run a few regular allgathers before capture
+                # so the profile shows the contrast with AGP graph replay.
+                NUM_WARMUP = 3
+                for _ in range(NUM_WARMUP):
+                    sendbuf.fill_(float(rank))
+                    _wait(comm.all_gather_single(recvbuf, sendbuf, async_op=True))
+                torch.cuda.synchronize()
+
+                # Graph capture: allgather auto-converts to AGP here
+                graph = torch.cuda.CUDAGraph()
+                with torch.cuda.graph(graph):
+                    _wait(comm.all_gather_single(recvbuf, sendbuf, async_op=True))
+
+                comm.barrier(False)
+
+                # Graph replay
+                for replay in range(self.NUM_REPLAYS):
+                    val = float(rank * 100 + replay)
+                    sendbuf.fill_(val)
+                    recvbuf.zero_()
+                    torch.cuda.synchronize()
+                    comm.barrier(False)
+
+                    graph.replay()
+                    torch.cuda.synchronize()
+                    comm.barrier(False)
+
+                    for r in range(size):
+                        expected_val = float(r * 100 + replay)
+                        chunk = recvbuf[r * count : (r + 1) * count]
+                        expected = torch.full(
+                            (count,),
+                            expected_val,
+                            dtype=torch.float32,
+                            device=self.device,
+                        )
+                        torch.testing.assert_close(
+                            chunk,
+                            expected,
+                            rtol=1e-5,
+                            atol=1e-5,
+                            msg=(
+                                f"Replay {replay}: rank {rank} expected {expected_val} "
+                                f"from rank {r}, got {chunk[:4].tolist()}"
+                            ),
+                        )
+
+            if profile_dir and prof:
+                os.makedirs(profile_dir, exist_ok=True)
+                trace_path = os.path.join(
+                    profile_dir,
+                    f"test_allgather_cudagraph_aware_changing_data_rank{rank}.json",
+                )
+                prof.export_chrome_trace(trace_path)
+
+            graph.reset()
+            torch.cuda.synchronize()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2014,7 +2014,7 @@ cvars:
  - name        : NCCL_ALLGATHER_ALGO
    type        : enum
    default     : orig
-   choices     : orig, ctran, ctdirect, ctring, ctrd, ctbrucks
+   choices     : orig, ctran, ctdirect, ctring, ctrd, ctbrucks, ctgraph
    description : |-
      The algorithm to use for Allgather communication
      orig - Copy-based ring algorithm
@@ -2022,6 +2022,7 @@ cvars:
      ctdirect - Ctran-based direct point-to-point algorithm
      ctring - Ctran-based ring algorithm
      ctrd - Ctran-based recursive doubling algorithm
+     ctgraph - Cudagraph-aware: uses ctran persistent AGP during graph capture, falls back to baseline otherwise
 
  - name        : NCCL_REDUCESCATTER_ALGO
    type        : enum


### PR DESCRIPTION
Summary:

Switch CtranWin::exchange() to use globalRegisterWithPtr + searchRegHandle instead of mapper->regMem for user-provided data buffers. This handles multi-segment buffers (e.g., expandable segments) which regMem rejects with a single-segment assertion.

globalRegisterWithPtr is called with forceReg=true and ncclManaged=true. The ncclManaged flag is critical — it enables cudaMalloc IPC support in IpcRegCache::regMem, which is required for NVL peer access. A new ncclManaged parameter was added to globalRegisterWithPtr and RegCache::globalRegister to support this.

In free(), globalDeregisterWithPtr handles both local deregistration and remote IPC release notifications, replacing the separate deregMem + deregRemReg calls for user data buffers.

A DisjointMemory test is added to CtranWinAllGatherTest to verify window allgather with multi-segment (expandable) memory.

Reviewed By: tianfengfrank

Differential Revision: D101551580


