### PR TITLE
Add reset_signal_threadgroup and put_tile to P2pNvlTransportDevice (#2160)

### DIFF
--- a/comms/pipes/MultiPeerNvlTransport.cc
+++ b/comms/pipes/MultiPeerNvlTransport.cc
@@ -112,18 +112,25 @@ MultiPeerNvlTransport::MultiPeerNvlTransport(
       cudaMemcpyDefault));
 
   // Conditionally allocate tile protocol buffers (all internal)
-  if (config_.tileMaxBlocks > 0) {
+  if (config_.tile_max_groups > 0) {
+    if (config_.pipelineDepth < 1) {
+      throw std::runtime_error("tile send/recv requires pipelineDepth >= 1");
+    }
+    if (config_.dataBufferSize / config_.tile_max_groups < 16) {
+      throw std::runtime_error(
+          "tile send/recv requires (dataBufferSize / tile_max_groups) >= 16");
+    }
     // Step state (local only, not exchanged, per-peer)
     // Each peer gets 2*maxBlocks int64s: [sender steps | receiver steps]
     std::size_t perPeerStepStateBytes =
-        2 * config_.tileMaxBlocks * sizeof(int64_t);
+        2 * config_.tile_max_groups * sizeof(int64_t);
     std::size_t totalStepStateBytes = perPeerStepStateBytes * (nRanks_ - 1);
     tileStepStateBuffer_ =
         std::make_unique<meta::comms::DeviceBuffer>(totalStepStateBytes);
     CUDA_CHECK(cudaMemset(tileStepStateBuffer_->get(), 0, totalStepStateBytes));
 
     // Tile signal buffer (2*maxBlocks signals per peer, exchanged)
-    std::size_t tileSignalCount = 2 * config_.tileMaxBlocks;
+    std::size_t tileSignalCount = 2 * config_.tile_max_groups;
     perPeerTileSignalSize_ = getSignalBufferSize(tileSignalCount);
     std::size_t totalTileSignalSize = perPeerTileSignalSize_ * (nRanks_ - 1);
     tileSignalHandler_ = std::make_unique<GpuMemHandler>(
@@ -333,9 +340,10 @@ P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
         .signalBuffer = remoteSignalSpan,
         .barrierBuffer = remoteBarrierSpan,
     };
-    auto device = P2pNvlTransportDevice(
-        myRank_, peerRank, options, localState, remoteState);
-    if (tileStepStateBuffer_) {
+    auto buildTileState = [&]() -> NvlinkTransportTileState {
+      if (!tileStepStateBuffer_) {
+        return {};
+      }
       auto* tileLocalSig = reinterpret_cast<SignalState*>(
           static_cast<char*>(tileSignalHandler_->getLocalDeviceMemPtr()) +
           localPeerIndex * perPeerTileSignalSize_);
@@ -343,13 +351,21 @@ P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
           static_cast<char*>(
               tileSignalHandler_->getPeerDeviceMemPtr(peerRank)) +
           remotePeerIndex * perPeerTileSignalSize_);
-      // Each peer gets its own stepState region
       auto* stepBase = static_cast<int64_t*>(tileStepStateBuffer_->get());
       auto* peerStepState =
-          stepBase + localPeerIndex * 2 * config_.tileMaxBlocks;
-      device.set_tile_state(
-          peerStepState, config_.tileMaxBlocks, tileLocalSig, tileRemoteSig);
-    }
+          stepBase + localPeerIndex * 2 * config_.tile_max_groups;
+      const int max_groups = config_.tile_max_groups;
+      return {
+          .step_state = {peerStepState, static_cast<uint32_t>(2 * max_groups)},
+          .tile_max_groups = max_groups,
+          .local_signals =
+              {tileLocalSig, static_cast<uint32_t>(2 * max_groups)},
+          .remote_signals =
+              {tileRemoteSig, static_cast<uint32_t>(2 * max_groups)},
+      };
+    };
+    auto device = P2pNvlTransportDevice(
+        myRank_, peerRank, options, localState, remoteState, buildTileState());
     return device;
   }
 
@@ -437,9 +453,10 @@ P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
         .ll128Buffer = remoteLl128,
     };
 
-    auto device = P2pNvlTransportDevice(
-        myRank_, peerRank, options, localState, remoteState);
-    if (tileStepStateBuffer_) {
+    auto buildTileState = [&]() -> NvlinkTransportTileState {
+      if (!tileStepStateBuffer_) {
+        return {};
+      }
       auto* tileLocalSig = reinterpret_cast<SignalState*>(
           static_cast<char*>(tileSignalHandler_->getLocalDeviceMemPtr()) +
           localPeerIndex * perPeerTileSignalSize_);
@@ -447,13 +464,21 @@ P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
           static_cast<char*>(
               tileSignalHandler_->getPeerDeviceMemPtr(peerRank)) +
           remotePeerIndex * perPeerTileSignalSize_);
-      // Each peer gets its own stepState region
       auto* stepBase = static_cast<int64_t*>(tileStepStateBuffer_->get());
       auto* peerStepState =
-          stepBase + localPeerIndex * 2 * config_.tileMaxBlocks;
-      device.set_tile_state(
-          peerStepState, config_.tileMaxBlocks, tileLocalSig, tileRemoteSig);
-    }
+          stepBase + localPeerIndex * 2 * config_.tile_max_groups;
+      const int max_groups = config_.tile_max_groups;
+      return {
+          .step_state = {peerStepState, static_cast<uint32_t>(2 * max_groups)},
+          .tile_max_groups = max_groups,
+          .local_signals =
+              {tileLocalSig, static_cast<uint32_t>(2 * max_groups)},
+          .remote_signals =
+              {tileRemoteSig, static_cast<uint32_t>(2 * max_groups)},
+      };
+    };
+    auto device = P2pNvlTransportDevice(
+        myRank_, peerRank, options, localState, remoteState, buildTileState());
     return device;
   } else {
     // Single state mode: 1x chunk state per peer (on receiver side only)
@@ -480,9 +505,10 @@ P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
         .ll128Buffer = remoteLl128,
     };
 
-    auto device = P2pNvlTransportDevice(
-        myRank_, peerRank, options, localState, remoteState);
-    if (tileStepStateBuffer_) {
+    auto buildTileState = [&]() -> NvlinkTransportTileState {
+      if (!tileStepStateBuffer_) {
+        return {};
+      }
       auto* tileLocalSig = reinterpret_cast<SignalState*>(
           static_cast<char*>(tileSignalHandler_->getLocalDeviceMemPtr()) +
           localPeerIndex * perPeerTileSignalSize_);
@@ -490,13 +516,21 @@ P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
           static_cast<char*>(
               tileSignalHandler_->getPeerDeviceMemPtr(peerRank)) +
           remotePeerIndex * perPeerTileSignalSize_);
-      // Each peer gets its own stepState region
       auto* stepBase = static_cast<int64_t*>(tileStepStateBuffer_->get());
       auto* peerStepState =
-          stepBase + localPeerIndex * 2 * config_.tileMaxBlocks;
-      device.set_tile_state(
-          peerStepState, config_.tileMaxBlocks, tileLocalSig, tileRemoteSig);
-    }
+          stepBase + localPeerIndex * 2 * config_.tile_max_groups;
+      const int max_groups = config_.tile_max_groups;
+      return {
+          .step_state = {peerStepState, static_cast<uint32_t>(2 * max_groups)},
+          .tile_max_groups = max_groups,
+          .local_signals =
+              {tileLocalSig, static_cast<uint32_t>(2 * max_groups)},
+          .remote_signals =
+              {tileRemoteSig, static_cast<uint32_t>(2 * max_groups)},
+      };
+    };
+    auto device = P2pNvlTransportDevice(
+        myRank_, peerRank, options, localState, remoteState, buildTileState());
     return device;
   }
 }

--- a/comms/pipes/MultiPeerNvlTransport.h
+++ b/comms/pipes/MultiPeerNvlTransport.h
@@ -55,7 +55,7 @@ struct MultiPeerNvlTransportConfig {
   // Maximum block count for the tile sendrecv protocol.
   // Allocates persistent step state and dedicated tile signals internally.
   // send_tile/recv_tile use these without user-managed state.
-  int tileMaxBlocks{128};
+  int tile_max_groups{128};
 
   // If true, use dual chunk state buffers (one on each side) for local polling
   // on both sender and receiver. If false (default), use single chunk state
@@ -384,7 +384,7 @@ class MultiPeerNvlTransport {
   std::size_t perPeerLl128BufferSize_{0};
   std::size_t perPeerBarrierBufferSize_{0};
 
-  // Tile protocol state (allocated when tileMaxBlocks > 0)
+  // Tile protocol state (allocated when tile_max_groups > 0)
   std::unique_ptr<meta::comms::DeviceBuffer>
       tileStepStateBuffer_; // not exchanged
   std::unique_ptr<GpuMemHandler>

--- a/comms/pipes/P2pNvlTransportDevice.cuh
+++ b/comms/pipes/P2pNvlTransportDevice.cuh
@@ -362,11 +362,16 @@ class P2pNvlTransportDevice {
   __host__ __device__ ~P2pNvlTransportDevice() = default;
 
   /**
-   * send - Transfer data to peer GPU over NVLink
+   * send - Cooperative transfer to peer GPU over NVLink
    *
    * Sends 'nbytes' bytes from srcbuff to the peer GPU using pipelined staged
-   * transfer with fine-grained chunk-level synchronization. All threads in the
-   * group cooperate to transfer the data in parallel.
+   * transfer with fine-grained chunk-level synchronization. Multiple groups
+   * collaborate to transfer the data in parallel — work is distributed across
+   * all calling groups via for_each_item_contiguous/strided.
+   *
+   * All calling groups must pass the same src/nbytes. Unlike send_tile(),
+   * which has each group independently send its own partition of data, this
+   * version has all groups cooperate on the entire buffer.
    *
    * ALGORITHM:
    * ==========
@@ -852,23 +857,25 @@ class P2pNvlTransportDevice {
   }
 
   /**
-   * put - Direct local memory copy using vectorized operations
+   * put - Cooperative local memory copy using vectorized operations
    *
-   * Performs a high-performance vectorized copy from src_d to dst_d using
-   * memcpy_vectorized. The work is distributed across ALL thread groups
-   * using for_each_item_contiguous, so each group processes only its portion
-   * of the data.
+   * Performs a high-performance vectorized copy from src_d to dst_d.
+   * Multiple groups collaborate on the same src/dst/nbytes — work is
+   * distributed across all calling groups via for_each_item_contiguous
+   * by global group_id.
    *
-   * The chunk size is computed dynamically as (nbytes / total_groups) to
-   * ensure good parallelism, with a minimum of 16 bytes per chunk for
-   * vectorized access efficiency.
+   * All calling groups must pass the same src/dst/nbytes. Unlike put_tile(),
+   * which has each group independently copy its own partition of data, this
+   * version has all groups cooperate on the entire buffer.
    *
-   * NOTE: only support no overlap copy for now
+   * Contrast with send(): send() writes to the peer GPU's staging buffer
+   * via NVLink with pipelined flow control. put() copies within local memory
+   * without any signaling or flow control.
    *
    * @param group ThreadGroup for cooperative processing
    * @param dst_d Destination pointer (device memory)
    * @param src_d Source pointer (device memory)
-   * @param nbytes Number of bytes to write
+   * @param nbytes Number of bytes to copy
    *
    * @return Number of bytes written by the current thread group
    */
@@ -914,6 +921,39 @@ class P2pNvlTransportDevice {
     return totalBytesWritten;
 #endif
     return 0;
+  }
+
+  /**
+   * put_tile - Independent per-group local memory copy
+   *
+   * Performs a vectorized copy from src_d to dst_d using only threads within
+   * the calling group. Each group operates independently on its own data,
+   * so different groups can call put_tile() with different src/dst/nbytes.
+   *
+   * Unlike put(), which has all groups cooperate on the same buffer,
+   * put_tile() has each group work on its own partition independently.
+   *
+   * Contrast with send_tile(): send_tile() writes to the peer GPU's staging
+   * buffer via NVLink with pipelined flow control and signaling. put_tile()
+   * copies within local memory without any signaling or flow control.
+   *
+   * @param group ThreadGroup for cooperative processing (group-local)
+   * @param dst_d Destination pointer (device memory)
+   * @param src_d Source pointer (device memory)
+   * @param nbytes Number of bytes to copy
+   */
+  __device__ __forceinline__ void put_tile(
+      ThreadGroup& group,
+      char* __restrict__ dst_d,
+      const char* __restrict__ src_d,
+      std::size_t nbytes) {
+#ifdef __CUDA_ARCH__
+    if (nbytes == 0) {
+      return;
+    }
+    assert_buffer_non_overlap(dst_d, src_d, nbytes);
+    memcpy_vectorized(dst_d, src_d, nbytes, group);
+#endif
   }
 
   /**
@@ -963,6 +1003,28 @@ class P2pNvlTransportDevice {
       uint64_t value,
       const Timeout& timeout = Timeout()) {
     localState_.signalBuffer[signal_id].wait_until(group, op, value, timeout);
+  }
+
+  /**
+   * reset_signal_threadgroup - Reset a local signal slot to zero
+   *
+   * Resets the local signal counter at the specified index to zero.
+   * This is safe to call from the receiver side after processing the signal,
+   * since the receiver owns the local inbox buffer.
+   *
+   * The caller must ensure the signal has already been consumed (waited on)
+   * before resetting, and that no peer is concurrently signaling the same slot.
+   *
+   * @param group ThreadGroup for cooperative thread synchronization
+   * @param signal_id Index into the signalBuffer array
+   */
+  __device__ __forceinline__ void reset_signal_threadgroup(
+      ThreadGroup& group,
+      uint64_t signal_id) {
+    if (group.is_leader()) {
+      localState_.signalBuffer[signal_id].store(0);
+    }
+    group.sync();
   }
 
   /**
@@ -1128,6 +1190,16 @@ class P2pNvlTransportDevice {
   }
 
   /**
+   * send_tile - Independent per-group transfer to peer GPU over NVLink
+   *
+   * Each group independently sends its own tile of data to the peer GPU's
+   * staging buffer via NVLink, with per-group pipelined flow control and
+   * signaling. Different groups can call send_tile() with different
+   * src/nbytes.
+   *
+   * Unlike send(), which has all groups cooperate on the same buffer,
+   * send_tile() has each group work on its own partition independently.
+   *
    * @param active_blocks Number of blocks calling send_tile concurrently.
    *   0 means use tile_max_groups from transport config.
    * @param max_signal_bytes Hint for max bytes between DATA_READY signals.

--- a/comms/pipes/P2pNvlTransportDevice.cuh
+++ b/comms/pipes/P2pNvlTransportDevice.cuh
@@ -85,6 +85,19 @@ struct RemoteState {
 };
 
 /**
+ * NvlinkTransportTileState — Per-peer tile protocol state.
+ *
+ * Bundled by the host transport at construction and passed to
+ * P2pNvlTransportDevice via set_tile_state(). Invisible to users.
+ */
+struct NvlinkTransportTileState {
+  DeviceSpan<int64_t> step_state;
+  int tile_max_groups{0};
+  DeviceSpan<SignalState> local_signals;
+  DeviceSpan<SignalState> remote_signals;
+};
+
+/**
  * P2pNvlTransportOptions - Configuration for P2P NVLink transport
  *
  * Defines the buffer sizes and chunking parameters for staged transfers.
@@ -337,12 +350,14 @@ class P2pNvlTransportDevice {
       int peerRank,
       const P2pNvlTransportOptions& options,
       const LocalState& localState,
-      const RemoteState& remoteState)
+      const RemoteState& remoteState,
+      const NvlinkTransportTileState& tileState = {})
       : myRank_(myRank),
         peerRank_(peerRank),
         options_(options),
         localState_(localState),
-        remoteState_(remoteState) {}
+        remoteState_(remoteState),
+        tile_state_(tileState) {}
 
   __host__ __device__ ~P2pNvlTransportDevice() = default;
 
@@ -1113,69 +1128,79 @@ class P2pNvlTransportDevice {
   }
 
   /**
-   * send_tile (maxBlocks overload) — For dynamic block count support.
-   *
-   * Uses maxBlocks for signal/stepState layout (fixed) and numBlocks
-   * for the staging buffer partition (variable). This allows changing
-   * numBlocks between calls without corrupting the signal mapping,
-   * provided the caller performs an epoch drain (see TileSendRecvContext).
-   *
-   * @param maxBlocks Layout size for signals/stepState (fixed at setup)
-   * @param numBlocks Active block count (controls perBlockSlotSize)
-   */
-  /**
-   * @param chunksPerSlot Number of sub-chunks per pipeline slot (default 1).
-   *   When > 1, the per-block staging slot is subdivided and signaled
-   *   at finer granularity. The receiver can start reading the first
-   *   sub-chunk while the sender is still writing subsequent ones.
-   *   Increases signal traffic but reduces pipeline latency.
+   * @param active_blocks Number of blocks calling send_tile concurrently.
+   *   0 means use tile_max_groups from transport config.
+   * @param max_signal_bytes Hint for max bytes between DATA_READY signals.
+   *   0 means one signal per slot fill. Capped at per_block_slot_size.
    */
   __device__ __forceinline__ void send_tile(
       ThreadGroup& group,
-      void* __restrict__ src,
+      const void* __restrict__ src,
       std::size_t nbytes,
-      int maxBlocks,
-      int numBlocks,
-      int64_t* __restrict__ stepState,
-      SignalState* __restrict__ localSignals,
-      SignalState* __restrict__ remoteSignals,
-      const Timeout& timeout = Timeout(),
-      int chunksPerSlot = 1) {
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout()) {
 #ifdef __CUDA_ARCH__
-    const int blockId = group.group_id;
-    char* __restrict__ srcPtr = reinterpret_cast<char*>(src);
+    if (nbytes == 0) {
+      return;
+    }
+
+    const int max_groups = tile_state_.tile_max_groups;
+    const int groupId = group.group_id;
+    const int effActive = active_blocks > 0 ? active_blocks : max_groups;
+
+    if (effActive > max_groups) {
+      printf(
+          "send_tile: active_blocks=%d > tile_max_groups=%d. "
+          "Signal and step_state arrays would be accessed out of bounds.\n",
+          effActive,
+          max_groups);
+      __trap();
+    }
+
+    if (groupId >= effActive) {
+      printf(
+          "send_tile: groupId=%d >= active_blocks=%d. "
+          "Too many groups calling send_tile.\n",
+          groupId,
+          effActive);
+      __trap();
+    }
+
+    const char* __restrict__ srcPtr = reinterpret_cast<const char*>(src);
     char* __restrict__ stagBuf = remoteState_.dataBuffer;
 
     const std::size_t slotSize = options_.dataBufferSize;
-    const std::size_t perBlockSlotSize = (slotSize / numBlocks) & ~15ULL;
+    const std::size_t perBlockSlotSize = (slotSize / effActive) & ~15ULL;
     if (perBlockSlotSize == 0) {
       printf(
           "send_tile/recv_tile: perBlockSlotSize is 0 "
-          "(slotSize=%llu, numBlocks=%d). "
-          "Increase dataBufferSize or decrease numBlocks.\n",
+          "(dataBufferSize=%llu, active_blocks=%d). "
+          "Increase dataBufferSize or decrease active_blocks.\n",
           (unsigned long long)slotSize,
-          numBlocks);
+          effActive);
       __trap();
     }
-    const std::size_t stagingOff = blockId * perBlockSlotSize;
-    const std::size_t chunkSize = (perBlockSlotSize / chunksPerSlot) & ~15ULL;
+    const std::size_t stagingOff = groupId * perBlockSlotSize;
+
+    const std::size_t chunkSize =
+        max_signal_bytes > 0 && max_signal_bytes < perBlockSlotSize
+        ? (max_signal_bytes & ~15ULL)
+        : perBlockSlotSize;
     const std::size_t effectiveChunk =
         chunkSize > 0 ? chunkSize : perBlockSlotSize;
 
-    // Total steps = total data / chunk size
     const std::size_t totalSteps =
         (nbytes + effectiveChunk - 1) / effectiveChunk;
-    // Steps per pipeline slot = chunks per slot
     const std::size_t stepsPerSlot =
         (perBlockSlotSize + effectiveChunk - 1) / effectiveChunk;
 
-    const uint64_t tailSignalId = blockId;
-    const uint64_t headSignalId = maxBlocks + blockId;
+    const uint64_t tailSignalId = groupId;
+    const uint64_t headSignalId = max_groups + groupId;
 
-    int64_t step = stepState[blockId];
+    int64_t step = tile_state_.step_state[groupId];
 
     for (std::size_t s = 0; s < totalSteps; ++s) {
-      // Slot and offset within slot
       const std::size_t slotStep = s / stepsPerSlot;
       const std::size_t subStep = s % stepsPerSlot;
       const std::size_t slot = slotStep % options_.pipelineDepth;
@@ -1187,11 +1212,9 @@ class P2pNvlTransportDevice {
           ? effectiveChunk
           : (dataOff < nbytes ? nbytes - dataOff : 0);
 
-      // Backpressure: wait for receiver to free this slot
-      // Only wait at the start of each slot (first sub-step)
       if (subStep == 0 &&
           step >= static_cast<int64_t>(stepsPerSlot * options_.pipelineDepth)) {
-        localSignals[headSignalId].wait_until(
+        tile_state_.local_signals[headSignalId].wait_until(
             group,
             CmpOp::CMP_GE,
             static_cast<uint64_t>(
@@ -1209,7 +1232,7 @@ class P2pNvlTransportDevice {
 
       group.sync();
       if (group.is_leader()) {
-        remoteSignals[tailSignalId].signal(
+        tile_state_.remote_signals[tailSignalId].signal(
             SignalOp::SIGNAL_SET, static_cast<uint64_t>(step + 1));
       }
 
@@ -1217,44 +1240,66 @@ class P2pNvlTransportDevice {
     }
 
     if (group.is_leader()) {
-      stepState[blockId] = step;
+      tile_state_.step_state[groupId] = step;
     }
     group.sync();
 #endif
   }
 
-  /**
-   * recv_tile (maxBlocks overload) — For dynamic block count support.
-   */
   __device__ __forceinline__ void recv_tile(
       ThreadGroup& group,
       void* __restrict__ dst,
       std::size_t nbytes,
-      int maxBlocks,
-      int numBlocks,
-      int64_t* __restrict__ stepState,
-      SignalState* __restrict__ localSignals,
-      SignalState* __restrict__ remoteSignals,
-      const Timeout& timeout = Timeout(),
-      int chunksPerSlot = 1) {
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout()) {
 #ifdef __CUDA_ARCH__
-    const int blockId = group.group_id;
+    if (nbytes == 0) {
+      return;
+    }
+
+    const int max_groups = tile_state_.tile_max_groups;
+    const int groupId = group.group_id;
+    const int effActive = active_blocks > 0 ? active_blocks : max_groups;
+
+    if (effActive > max_groups) {
+      printf(
+          "recv_tile: active_blocks=%d > tile_max_groups=%d. "
+          "Signal and step_state arrays would be accessed out of bounds.\n",
+          effActive,
+          max_groups);
+      __trap();
+    }
+
+    if (groupId >= effActive) {
+      printf(
+          "recv_tile: groupId=%d >= active_blocks=%d. "
+          "Too many groups calling recv_tile.\n",
+          groupId,
+          effActive);
+      __trap();
+    }
+
     char* __restrict__ dstPtr = reinterpret_cast<char*>(dst);
     char* __restrict__ stagBuf = localState_.dataBuffer;
 
     const std::size_t slotSize = options_.dataBufferSize;
-    const std::size_t perBlockSlotSize = (slotSize / numBlocks) & ~15ULL;
+    const std::size_t perBlockSlotSize = (slotSize / effActive) & ~15ULL;
     if (perBlockSlotSize == 0) {
       printf(
           "send_tile/recv_tile: perBlockSlotSize is 0 "
-          "(slotSize=%llu, numBlocks=%d). "
-          "Increase dataBufferSize or decrease numBlocks.\n",
+          "(dataBufferSize=%llu, active_blocks=%d). "
+          "Increase dataBufferSize or decrease active_blocks.\n",
           (unsigned long long)slotSize,
-          numBlocks);
+          effActive);
       __trap();
     }
-    const std::size_t stagingOff = blockId * perBlockSlotSize;
-    const std::size_t chunkSize = (perBlockSlotSize / chunksPerSlot) & ~15ULL;
+    const std::size_t stagingOff = groupId * perBlockSlotSize;
+
+    const std::size_t chunkSize =
+        max_signal_bytes > 0 && max_signal_bytes < perBlockSlotSize
+        ? (max_signal_bytes & ~15ULL)
+        : perBlockSlotSize;
     const std::size_t effectiveChunk =
         chunkSize > 0 ? chunkSize : perBlockSlotSize;
 
@@ -1263,10 +1308,10 @@ class P2pNvlTransportDevice {
     const std::size_t stepsPerSlot =
         (perBlockSlotSize + effectiveChunk - 1) / effectiveChunk;
 
-    const uint64_t tailSignalId = blockId;
-    const uint64_t headSignalId = maxBlocks + blockId;
+    const uint64_t tailSignalId = groupId;
+    const uint64_t headSignalId = max_groups + groupId;
 
-    int64_t step = stepState[maxBlocks + blockId];
+    int64_t step = tile_state_.step_state[max_groups + groupId];
 
     for (std::size_t s = 0; s < totalSteps; ++s) {
       const std::size_t slotStep = s / stepsPerSlot;
@@ -1280,8 +1325,7 @@ class P2pNvlTransportDevice {
           ? effectiveChunk
           : (dataOff < nbytes ? nbytes - dataOff : 0);
 
-      // Wait for sender to fill this sub-chunk
-      localSignals[tailSignalId].wait_until(
+      tile_state_.local_signals[tailSignalId].wait_until(
           group, CmpOp::CMP_GE, static_cast<uint64_t>(step + 1), timeout);
 
       if (copyBytes > 0) {
@@ -1294,10 +1338,8 @@ class P2pNvlTransportDevice {
 
       group.sync();
       if (group.is_leader()) {
-        // Signal head only at the end of each slot (last sub-step)
-        // to release the slot for sender reuse
         if (subStep == stepsPerSlot - 1 || s == totalSteps - 1) {
-          remoteSignals[headSignalId].signal(
+          tile_state_.remote_signals[headSignalId].signal(
               SignalOp::SIGNAL_SET, static_cast<uint64_t>(step + 1));
         }
       }
@@ -1306,73 +1348,14 @@ class P2pNvlTransportDevice {
     }
 
     if (group.is_leader()) {
-      stepState[maxBlocks + blockId] = step;
+      tile_state_.step_state[max_groups + groupId] = step;
     }
     group.sync();
 #endif
   }
 
-  /**
-   * send_tile (internal state) — Uses transport-managed stepState.
-   *
-   * Requires tileMaxBlocks > 0 in transport config.
-   * numBlocks controls staging partition, tileMaxBlocks_ controls layout.
-   */
-  __device__ __forceinline__ void send_tile(
-      ThreadGroup& group,
-      void* __restrict__ src,
-      std::size_t nbytes,
-      int numBlocks,
-      const Timeout& timeout = Timeout(),
-      int chunksPerSlot = 1) {
-    send_tile(
-        group,
-        src,
-        nbytes,
-        tileMaxBlocks_,
-        numBlocks,
-        tileStepState_,
-        tileLocalSignals_,
-        tileRemoteSignals_,
-        timeout,
-        chunksPerSlot);
-  }
-
-  /**
-   * recv_tile (internal state) — Uses transport-managed stepState.
-   */
-  __device__ __forceinline__ void recv_tile(
-      ThreadGroup& group,
-      void* __restrict__ dst,
-      std::size_t nbytes,
-      int numBlocks,
-      const Timeout& timeout = Timeout(),
-      int chunksPerSlot = 1) {
-    recv_tile(
-        group,
-        dst,
-        nbytes,
-        tileMaxBlocks_,
-        numBlocks,
-        tileStepState_,
-        tileLocalSignals_,
-        tileRemoteSignals_,
-        timeout,
-        chunksPerSlot);
-  }
-
-  // Getters for tile protocol internal state
-  __host__ __device__ int64_t* tile_step_state() const {
-    return tileStepState_;
-  }
-  __host__ __device__ int tile_max_blocks() const {
-    return tileMaxBlocks_;
-  }
-  __device__ SignalState* tile_local_signals() const {
-    return tileLocalSignals_;
-  }
-  __device__ SignalState* tile_remote_signals() const {
-    return tileRemoteSignals_;
+  __host__ __device__ const NvlinkTransportTileState& tile_state() const {
+    return tile_state_;
   }
 
   // Device accessors for 2D tile kernel (inlined pipeline)
@@ -1386,31 +1369,13 @@ class P2pNvlTransportDevice {
     return remoteState_;
   }
 
-  // Set tile state (called by MultiPeerNvlTransport during construction)
-  __host__ void set_tile_state(
-      int64_t* stepState,
-      int maxBlocks,
-      SignalState* localSignals,
-      SignalState* remoteSignals) {
-    tileStepState_ = stepState;
-    tileMaxBlocks_ = maxBlocks;
-    tileLocalSignals_ = localSignals;
-    tileRemoteSignals_ = remoteSignals;
-  }
-
  private:
   const int myRank_{-1};
   const int peerRank_{-1};
   const P2pNvlTransportOptions options_;
   LocalState localState_;
   RemoteState remoteState_;
-  // Tile protocol state (set by MultiPeerNvlTransport when tileMaxBlocks > 0)
-  int64_t* tileStepState_{nullptr};
-  int tileMaxBlocks_{0};
-  // Dedicated signal buffer for tile tail/head signals
-  // Layout: [0..maxBlocks-1] = tail, [maxBlocks..2*maxBlocks-1] = head
-  SignalState* tileLocalSignals_{nullptr};
-  SignalState* tileRemoteSignals_{nullptr};
+  NvlinkTransportTileState tile_state_;
 };
 
 } // namespace comms::pipes

--- a/comms/pipes/P2pSelfTransportDevice.cuh
+++ b/comms/pipes/P2pSelfTransportDevice.cuh
@@ -123,6 +123,34 @@ class P2pSelfTransportDevice {
     });
 #endif
   }
+  /**
+   * put_tile - Per-group local memory copy using vectorized operations
+   *
+   * Performs a vectorized copy from src_d to dst_d using only threads within
+   * the calling group. Each group operates independently on its own data,
+   * so different groups can call put_tile() with different src/dst/nbytes.
+   *
+   * Contrast with put(): put() is a grid-collective where all groups must
+   * cooperate on the same data. put_tile() is per-group.
+   *
+   * @param group ThreadGroup for cooperative processing (group-local)
+   * @param dst_d Destination pointer (device memory)
+   * @param src_d Source pointer (device memory)
+   * @param nbytes Number of bytes to copy
+   */
+  __device__ __forceinline__ void put_tile(
+      ThreadGroup& group,
+      char* __restrict__ dst_d,
+      const char* __restrict__ src_d,
+      std::size_t nbytes) {
+#ifdef __CUDA_ARCH__
+    if (nbytes == 0 || dst_d == src_d) {
+      return;
+    }
+    assert_buffer_non_overlap(dst_d, src_d, nbytes);
+    memcpy_vectorized(dst_d, src_d, nbytes, group);
+#endif
+  }
 };
 
 } // namespace comms::pipes

--- a/comms/pipes/benchmarks/P2pNvlSendRecvBenchmark.cc
+++ b/comms/pipes/benchmarks/P2pNvlSendRecvBenchmark.cc
@@ -298,14 +298,18 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     comms::pipes::TiledBuffer<char> recvTiles(
         static_cast<char*>(recvBuff.get()), config.nBytes, numSendBlocks);
 
-    int chunksPerSlot = config.chunksPerSlot;
+    std::size_t maxSignalBytes = config.chunksPerSlot > 1
+        ? static_cast<std::size_t>(
+              config.nBytes / config.numBlocks / config.chunksPerSlot) &
+            ~15ULL
+        : 0;
     void* kernelFunc = (void*)comms::pipes::benchmark::p2pTileSendRecv;
     void* args[] = {
         p2pDevicePtr,
         &sendTiles,
         &recvTiles,
         &numSendBlocks,
-        &chunksPerSlot,
+        &maxSignalBytes,
         &timeout};
 
     dim3 defaultClusterDim(comms::common::kDefaultClusterSize, 1, 1);

--- a/comms/pipes/benchmarks/SelfTransportBench.cc
+++ b/comms/pipes/benchmarks/SelfTransportBench.cc
@@ -91,6 +91,71 @@ static void selfTransportPut(
 }
 
 /**
+ * Benchmark P2pSelfTransportDevice::put_tile() for per-group local copies.
+ * Each block independently copies its own tile (totalBytes / nBlocks).
+ */
+static void selfTransportPutTile(
+    uint32_t iters,
+    size_t nBytes,
+    int nBlocks,
+    folly::UserCounters& counters) {
+  const int nRunsPerIter = 50;
+  const int nThreads = 256;
+
+  CHECK_EQ(cudaSetDevice(0), cudaSuccess);
+  CudaBenchBase bench;
+
+  DeviceBuffer srcBuffer(nBytes);
+  DeviceBuffer dstBuffer(nBytes);
+
+  char* srcPtr = static_cast<char*>(srcBuffer.get());
+  char* dstPtr = static_cast<char*>(dstBuffer.get());
+
+  size_t tileSize = nBytes / nBlocks;
+
+  dim3 grid{static_cast<unsigned int>(nBlocks), 1, 1};
+  dim3 blocks{static_cast<unsigned int>(nThreads), 1, 1};
+  void* kernArgs[4] = {
+      (void*)&dstPtr, (void*)&srcPtr, (void*)&tileSize, (void*)&nRunsPerIter};
+
+  for (int w = 0; w < kWarmupIters; ++w) {
+    CHECK_EQ(
+        cudaLaunchKernel(
+            (const void*)selfTransportPutTileKernel,
+            grid,
+            blocks,
+            kernArgs,
+            0,
+            bench.stream),
+        cudaSuccess);
+  }
+  CHECK_EQ(cudaStreamSynchronize(bench.stream), cudaSuccess);
+
+  bench.startTiming();
+  for (uint32_t i = 0; i < iters; ++i) {
+    CHECK_EQ(
+        cudaLaunchKernel(
+            (const void*)selfTransportPutTileKernel,
+            grid,
+            blocks,
+            kernArgs,
+            0,
+            bench.stream),
+        cudaSuccess);
+  }
+  bench.stopTiming();
+  float totalTimeMs = bench.measureTime();
+
+  float avgTimeUs = (totalTimeMs / iters / nRunsPerIter) * 1000.0f;
+  float busBwGBps = (nBytes / 1e9f) / (avgTimeUs / 1e6f);
+
+  counters["latency (us)"] =
+      folly::UserMetric(avgTimeUs, folly::UserMetric::Type::METRIC);
+  counters["bandwidth (GB/s)"] =
+      folly::UserMetric(busBwGBps, folly::UserMetric::Type::METRIC);
+}
+
+/**
  * Benchmark cudaMemcpyAsync as a baseline for comparison
  */
 static void cudaMemcpyBaseline(
@@ -272,6 +337,150 @@ BENCHMARK_MULTI_PARAM_COUNTERS(
     size_512MB_64blocks,
     512 * 1024 * 1024,
     64);
+
+// Self transport benchmarks - 1GB with 32 blocks
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportPut,
+    size_1GB_32blocks,
+    1024UL * 1024 * 1024,
+    32);
+
+BENCHMARK_DRAW_LINE();
+
+// Self transport put_tile benchmarks - 8MB with different block counts
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportPutTile,
+    size_8MB_2blocks,
+    8 * 1024 * 1024,
+    2);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportPutTile,
+    size_8MB_4blocks,
+    8 * 1024 * 1024,
+    4);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportPutTile,
+    size_8MB_8blocks,
+    8 * 1024 * 1024,
+    8);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportPutTile,
+    size_8MB_16blocks,
+    8 * 1024 * 1024,
+    16);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportPutTile,
+    size_8MB_32blocks,
+    8 * 1024 * 1024,
+    32);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportPutTile,
+    size_8MB_64blocks,
+    8 * 1024 * 1024,
+    64);
+
+// Self transport put_tile benchmarks - 64MB with different block counts
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportPutTile,
+    size_64MB_2blocks,
+    64 * 1024 * 1024,
+    2);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportPutTile,
+    size_64MB_4blocks,
+    64 * 1024 * 1024,
+    4);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportPutTile,
+    size_64MB_8blocks,
+    64 * 1024 * 1024,
+    8);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportPutTile,
+    size_64MB_16blocks,
+    64 * 1024 * 1024,
+    16);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportPutTile,
+    size_64MB_32blocks,
+    64 * 1024 * 1024,
+    32);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportPutTile,
+    size_64MB_64blocks,
+    64 * 1024 * 1024,
+    64);
+
+// Self transport put_tile benchmarks - 256MB with different block counts
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportPutTile,
+    size_256MB_2blocks,
+    256 * 1024 * 1024,
+    2);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportPutTile,
+    size_256MB_4blocks,
+    256 * 1024 * 1024,
+    4);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportPutTile,
+    size_256MB_8blocks,
+    256 * 1024 * 1024,
+    8);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportPutTile,
+    size_256MB_16blocks,
+    256 * 1024 * 1024,
+    16);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportPutTile,
+    size_256MB_32blocks,
+    256 * 1024 * 1024,
+    32);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportPutTile,
+    size_256MB_64blocks,
+    256 * 1024 * 1024,
+    64);
+
+// Self transport put_tile benchmarks - 512MB with different block counts
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportPutTile,
+    size_512MB_2blocks,
+    512 * 1024 * 1024,
+    2);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportPutTile,
+    size_512MB_4blocks,
+    512 * 1024 * 1024,
+    4);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportPutTile,
+    size_512MB_8blocks,
+    512 * 1024 * 1024,
+    8);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportPutTile,
+    size_512MB_16blocks,
+    512 * 1024 * 1024,
+    16);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportPutTile,
+    size_512MB_32blocks,
+    512 * 1024 * 1024,
+    32);
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportPutTile,
+    size_512MB_64blocks,
+    512 * 1024 * 1024,
+    64);
+
+// Self transport put_tile benchmarks - 1GB with 32 blocks
+BENCHMARK_MULTI_PARAM_COUNTERS(
+    selfTransportPutTile,
+    size_1GB_32blocks,
+    1024UL * 1024 * 1024,
+    32);
 
 BENCHMARK_DRAW_LINE();
 

--- a/comms/pipes/benchmarks/SelfTransportBench.cu
+++ b/comms/pipes/benchmarks/SelfTransportBench.cu
@@ -18,4 +18,18 @@ __global__ void selfTransportPutKernel(
   }
 }
 
+__global__ void selfTransportPutTileKernel(
+    char* dst,
+    const char* src,
+    std::size_t tileSize,
+    int nRuns) {
+  P2pSelfTransportDevice transport;
+  auto group = make_block_group();
+  std::size_t offset = group.group_id * tileSize;
+
+  for (int run = 0; run < nRuns; ++run) {
+    transport.put_tile(group, dst + offset, src + offset, tileSize);
+  }
+}
+
 } // namespace comms::pipes::benchmark

--- a/comms/pipes/benchmarks/SelfTransportBench.cuh
+++ b/comms/pipes/benchmarks/SelfTransportBench.cuh
@@ -8,12 +8,22 @@
 namespace comms::pipes::benchmark {
 
 /**
- * Kernel that uses P2pSelfTransportDevice to copy data
+ * Kernel that uses P2pSelfTransportDevice to copy data (grid-collective)
  */
 __global__ void selfTransportPutKernel(
     char* dst,
     const char* src,
     std::size_t nBytes,
+    int nRuns);
+
+/**
+ * Kernel that uses P2pSelfTransportDevice to copy per-group tiles.
+ * Each block copies one tile of tileSize bytes at group.group_id offset.
+ */
+__global__ void selfTransportPutTileKernel(
+    char* dst,
+    const char* src,
+    std::size_t tileSize,
     int nRuns);
 
 } // namespace comms::pipes::benchmark

--- a/comms/pipes/benchmarks/TileSendRecv.cu
+++ b/comms/pipes/benchmarks/TileSendRecv.cu
@@ -11,8 +11,8 @@ __global__ __launch_bounds__(512, 1) void p2pTileSendRecv(
     P2pNvlTransportDevice p2p,
     TiledBuffer<char> sendTiles,
     TiledBuffer<char> recvTiles,
-    int numBlocks,
-    int chunksPerSlot,
+    int active_blocks,
+    std::size_t max_signal_bytes,
     Timeout timeout) {
   timeout.start();
 
@@ -26,17 +26,17 @@ __global__ __launch_bounds__(512, 1) void p2pTileSendRecv(
         sub,
         sendTiles.tile_data(blockId),
         sendTiles.tile_bytes(blockId),
-        numBlocks,
-        timeout,
-        chunksPerSlot);
+        active_blocks,
+        max_signal_bytes,
+        timeout);
   } else {
     p2p.recv_tile(
         sub,
         recvTiles.tile_data(blockId),
         recvTiles.tile_bytes(blockId),
-        numBlocks,
-        timeout,
-        chunksPerSlot);
+        active_blocks,
+        max_signal_bytes,
+        timeout);
   }
 }
 
@@ -44,7 +44,7 @@ __global__ __launch_bounds__(512, 1) void p2pTileSendRecv(
 // Dynamic block count variant — uses transport-internal tile state
 // =============================================================================
 //
-// Requires tileMaxBlocks > 0 and p2pBarrierCount >= tileMaxBlocks in
+// Requires tile_max_groups > 0 and p2pBarrierCount >= tile_max_groups in
 // transport config.
 //
 // DYNAMIC BLOCK COUNT: BARRIER CORRECTNESS
@@ -95,7 +95,7 @@ __global__ __launch_bounds__(512, 1) void p2pTileSendRecvDynamic(
     P2pNvlTransportDevice p2p,
     TiledBuffer<char> sendTiles,
     TiledBuffer<char> recvTiles,
-    int numBlocks,
+    int active_blocks,
     bool needsBarrier,
     Timeout timeout) {
   timeout.start();
@@ -104,30 +104,25 @@ __global__ __launch_bounds__(512, 1) void p2pTileSendRecvDynamic(
   auto [role, sub] = group.partition(2);
   const int blockId = sub.group_id;
 
-  // If block count changed, each block barriers with its peer.
-  // Since kernels are on the same stream, the peer's current kernel can't
-  // start until its previous kernel finished. So when any peer block
-  // reaches the barrier, ALL of the peer's old-round work is done.
-  // Each block uses its own barrier slot — all barriers complete in parallel.
-  // Requires p2pBarrierCount >= tileMaxBlocks.
   if (needsBarrier) {
     p2p.barrier_sync_threadgroup(sub, blockId, timeout);
   }
 
-  // Uses transport-internal tile signals, stepState, and maxBlocks
   if (role == 0) {
     p2p.send_tile(
         sub,
         sendTiles.tile_data(blockId),
         sendTiles.tile_bytes(blockId),
-        numBlocks,
+        active_blocks,
+        /*max_signal_bytes=*/0,
         timeout);
   } else {
     p2p.recv_tile(
         sub,
         recvTiles.tile_data(blockId),
         recvTiles.tile_bytes(blockId),
-        numBlocks,
+        active_blocks,
+        /*max_signal_bytes=*/0,
         timeout);
   }
 }

--- a/comms/pipes/benchmarks/TileSendRecv.cuh
+++ b/comms/pipes/benchmarks/TileSendRecv.cuh
@@ -145,15 +145,15 @@ __global__ void p2pTileSendRecv(
     P2pNvlTransportDevice p2p,
     TiledBuffer<char> sendTiles,
     TiledBuffer<char> recvTiles,
-    int numBlocks,
-    int chunksPerSlot = 1,
+    int active_blocks,
+    std::size_t max_signal_bytes = 0,
     Timeout timeout = Timeout());
 
 /**
  * p2pTileSendRecvDynamic — Variant using transport-internal tile state
  * with support for dynamic block count changes.
  *
- * Requires tileMaxBlocks > 0 and p2pBarrierCount >= tileMaxBlocks.
+ * Requires tile_max_groups > 0 and p2pBarrierCount >= tile_max_groups.
  * StepState, signals, and maxBlocks are managed internally by the transport.
  *
  * Signal layout uses maxBlocks (constant across launches) so that block k
@@ -175,7 +175,7 @@ __global__ void p2pTileSendRecvDynamic(
     P2pNvlTransportDevice p2p,
     TiledBuffer<char> sendTiles,
     TiledBuffer<char> recvTiles,
-    int numBlocks,
+    int active_blocks,
     bool needsBarrier,
     Timeout timeout = Timeout());
 

--- a/comms/pipes/docs/tile_sendrecv.md
+++ b/comms/pipes/docs/tile_sendrecv.md
@@ -1,0 +1,592 @@
+# Tile Send/Recv Design
+
+A **tile** is the smallest unit of work that all threads in a block process concurrently at one time. A user is free to choose how big or small a tile is. Smaller tiles allow more pipelining but incur more signaling overhead; larger tiles amortize signaling costs. Data is divided amongst blocks by creating tiles of data — each block may handle multiple tiles sequentially, and different blocks may handle different tiles in parallel.
+
+A unified `send_tile` / `recv_tile` API for pipelined point-to-point transfers
+on `P2pNvlTransportDevice` and `P2pIbgdaTransportDevice`, callable from CUDA
+and Triton kernels. Composable building blocks for collectives (allgather,
+alltoall, sendrecv) without users needing to manage staging, signals, slot
+rotation, or pipeline depth.
+
+**Target backends (all 4 share this contract):** NVLink cpp, NVLink Triton, IB
+cpp, IB Triton.
+
+**In scope:** per-block tile send/recv with cooperative memcpy + pipelined
+staging.
+**Out of scope:** explicit user-visible drain (handled internally), multi-stream
+concurrency on the same transport, buffer registration (transport-owned), and
+cross-rank rendezvous (separate barrier primitive).
+
+---
+
+## 1. Transport Setup
+
+The tile API reuses the existing per-peer buffer settings already present in
+each transport's config. No new `TileConfig` sub-struct is introduced — the
+three knobs the tile algorithm needs are drawn from fields that already exist
+(or are added minimally where missing).
+
+### NVL (`MultiPeerNvlTransportConfig`)
+
+The existing config already carries all three knobs:
+
+| Existing field | Role in tile API |
+|---|---|
+| `data_buffer_size` | Bytes per pipeline slot, per peer, per direction. Tile staging is allocated from this. |
+| `pipeline_depth` | Number of slots in the pipeline ring. |
+| `tile_max_blocks` (renamed → `tile_max_groups`) | Upper bound on the number of groups that may call `send_tile`/`recv_tile`. Sizes signal pad and step state arrays. |
+
+No new fields are needed on the NVL side.
+
+### IB (`MultipeerIbgdaTransportConfig`)
+
+The existing config has `data_buffer_size` but lacks explicit pipeline depth and
+tile group count. Two fields are added:
+
+```cpp
+struct MultipeerIbgdaTransportConfig {
+  // ... existing fields (data_buffer_size, qpDepth, etc.) ...
+
+  // Number of pipeline slots for tile send/recv staging.
+  // Default 2 (double-buffered). Must be >= 1.
+  std::size_t tile_pipeline_depth{2};
+
+  // Upper bound on the number of groups calling send_tile/recv_tile.
+  // Sizes signal pad and step state arrays. Must be >= 1.
+  int tile_max_groups{128};
+};
+```
+
+### Validation (throws at construction, both transports)
+
+- `pipeline_depth` (NVL) / `tile_pipeline_depth` (IB) `>= 1`
+- `tile_max_groups >= 1`
+- `(data_buffer_size / tile_max_groups) >= 16` — per-group slot must fit at least
+  one 16-byte vectorized memcpy.
+
+**Defaults rationale:** matches NVL benchmarks and Triton (H100) practice. With
+`tile_max_groups=128`, `per_block_slot_size = data_buffer_size / tile_max_groups = 64 KiB`
+— a non-trivial chunk on which RDMA puts amortize NIC setup cost.
+
+---
+
+## 2. Internal State
+
+Owned by the transport, allocated and registered at construction. **Invisible
+to users** — referenced here only for implementer reference.
+
+The NVLink and IB transports use separate tile state structs because the IB
+transport requires additional fields for NIC completion tracking and local
+send staging that NVLink does not need.
+
+### `NvlinkTransportTileState`
+
+```cpp
+struct NvlinkTransportTileState {
+  // Per-block step counters. Persistent across send_tile/recv_tile calls.
+  // Required for monotonic signal values and slot-rotation continuity.
+  DeviceSpan<int64_t> step_state;   // [2 * max_groups]
+                                    //   [0..max_groups)         = sender step per block
+                                    //   [max_groups..2*max_groups) = receiver step per block
+
+  int tile_max_groups{0};
+
+  // Signal pad (using SignalState). Receiver inbox + sender ack inbox.
+  DeviceSpan<SignalState> local_signals;   // [2 * max_groups]
+  DeviceSpan<SignalState> remote_signals;  // [2 * max_groups]
+                                           //   [0..max_groups)         = DATA_READY (sender→receiver, "tail")
+                                           //   [max_groups..2*max_groups) = SLOT_FREE (receiver→sender, "head")
+};
+```
+
+### `IbTransportTileState`
+
+```cpp
+struct IbTransportTileState {
+  // Per-block step counters. Persistent across send_tile/recv_tile calls.
+  DeviceSpan<int64_t> step_state;   // [2 * max_groups]
+                                    //   [0..max_groups)         = sender step per block
+                                    //   [max_groups..2*max_groups) = receiver step per block
+
+  int tile_max_groups{0};
+
+  // Signal pad. Receiver inbox + sender ack inbox.
+  DeviceSpan<uint64_t> signal_pad;  // [2 * max_groups]
+                                    //   [0..max_groups)         = DATA_READY (sender→receiver, "tail")
+                                    //   [max_groups..2*max_groups) = SLOT_FREE (receiver→sender, "head")
+
+  // NIC completion counters.
+  // Bumped by the companion-QP loopback when an RDMA put is delivered.
+  DeviceSpan<uint64_t> nic_done_counter;  // [max_groups]
+
+  // Local send staging buffer (registered MR for RDMA source).
+  DeviceSpan<std::byte> send_staging;  // [pipeline_depth * data_buffer_size]
+};
+```
+
+**Per-slot layout** (one slot is `data_buffer_size` bytes, partitioned across
+the calling blocks):
+
+```
+slot k  (= step / chunks_per_slot % pipeline_depth):
+┌──────────────┬──────────────┬─────┬────────────────────┐
+│ block 0 row  │ block 1 row  │ ... │ block (N-1) row    │
+└──────────────┴──────────────┴─────┴────────────────────┘
+   N = max_groups (the construction-time upper bound, NOT active_blocks)
+   each row = per_block_slot_size = (data_buffer_size / active_blocks) & ~15ULL
+```
+
+`active_blocks` is per-call; `per_block_slot_size` is internal to the algorithm
+and never exposed to users.
+
+**Construction responsibilities (host):**
+- Allocate `step_state`, `signal_pad`, `nic_done_counter`, `send_staging`,
+  `recv_staging`.
+- IB: register MRs for staging; exchange `recv_staging` rkeys + `signal_pad`
+  rkeys with each peer.
+- NVL: P2P-enable `recv_staging` access; exchange device pointers.
+- Zero-init `step_state`, `signal_pad`, `nic_done_counter`.
+
+**Destruction:** deregister MRs (IB), free buffers. Outstanding ops are the
+caller's responsibility (kernel must finish before the host destructor runs).
+
+---
+
+## 3. API Surface
+
+### Cpp (both transports, identical signature)
+
+```cpp
+class P2pIbgdaTransportDevice {
+ public:
+  __device__ void send_tile(
+      ThreadGroup& group,
+      const void* src,
+      size_t nbytes,
+      int active_blocks = 0,
+      size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout());
+
+  __device__ void recv_tile(
+      ThreadGroup& group,
+      void* dst,
+      size_t nbytes,
+      int active_blocks = 0,
+      size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout());
+};
+// P2pNvlTransportDevice exposes the same two methods with the same signature.
+```
+
+### Triton (both transports, identical signature)
+
+```python
+@core.extern
+def send_tile(
+    src_ptr, nbytes,
+    block_id, active_blocks,
+    max_signal_bytes,
+    timeout_ns,
+    # Constexpr handles plumbed from host transport.
+    # Bundles staging ptrs, signal pad ptrs, step state ptr, transport config values.
+    # Exact constexpr/runtime split is an impl-time decision.
+    transport_handle: tl.constexpr,
+):
+    ...
+
+@core.extern
+def recv_tile(dst_ptr, nbytes, block_id, active_blocks, max_signal_bytes, timeout_ns,
+              transport_handle: tl.constexpr):
+    ...
+```
+
+### Parameter table
+
+| Param | Required | Default | Meaning |
+|---|---|---|---|
+| `group` (cpp) / `block_id` (Triton) | yes | — | Identifies this calling block. Slot routing uses `group.group_id` (cpp) or the `block_id` arg (Triton). |
+| `src` / `dst` | yes | — | This block's pre-sliced data pointer. Caller computes per-block offset (see `TiledBuffer`). |
+| `nbytes` | yes | — | This block's data size. May exceed `per_block_slot_size` — chunked internally over pipeline slots. |
+| `active_blocks` | no | `0` → `tile_max_groups` | Number of blocks calling `send_tile`/`recv_tile` concurrently. Determines `per_block_slot_size = data_buffer_size / active_blocks`. |
+| `max_signal_bytes` | no | `0` → `per_block_slot_size` | Hint for the maximum number of bytes between consecutive DATA_READY signals. The transport may signal more frequently if too many blocks share the data buffer. Capped at `per_block_slot_size` if larger (sub-slot signaling only). |
+| `timeout` | no | `Timeout()` (no limit) | Per-wait timeout. Reuses `comms::pipes::Timeout`. On expiry: `__trap()`. |
+
+### Special values
+
+- **`nbytes == 0`** — block participates in convergent control flow but does no
+  copy and no signal; `step_state` does not advance. Sender and receiver MUST
+  both pass `nbytes==0` for the same `block_id` (per-block matching rule below).
+- **`max_signal_bytes > per_block_slot_size`** — silently capped to `per_block_slot_size`.
+  The protocol never signals less frequently than once per slot fill (sub-slot
+  signaling only).
+- **`active_blocks > tile_max_groups`** — `__trap()`. The precondition check
+  at the top of the algorithm catches this and traps immediately rather than
+  silently aliasing staging rows.
+
+---
+
+## 4. Coordination Contract
+
+### Per-call contract
+
+1. **CTA-cooperative.** All threads in `group` MUST call `send_tile` /
+   `recv_tile` convergently. Cooperative memcpy across the block; leader thread
+   issues signals and RDMA puts.
+2. **Slot routing index = `group.group_id`** (cpp) / `block_id` extern arg
+   (Triton). The *logical index within the calling group*, not raw `blockIdx.x`.
+   So a kernel that does `auto [role, sub] = group.partition(2)` passes `sub`
+   to `send_tile` / `recv_tile`, and `sub.group_id` (range `[0, sub.total_groups)`)
+   is the slot row index.
+3. **Trap precondition (debug-mode `__trap`):**
+   `group.group_id < (active_blocks > 0 ? active_blocks : tile_max_groups)`.
+   Violating this would alias two blocks onto the same staging row and silently
+   corrupt data — trap converts that into an immediate, locatable failure.
+
+### Cross-rank coordination
+
+- For each `group_id k`: sender block_k's `(nbytes, active_blocks, max_signal_bytes)`
+  MUST equal receiver block_k's. The protocol routes data through slot row `k`
+  on both sides; mismatched values cause deadlock (receiver waits for more
+  signals) or silent drop (receiver consumes too few).
+- Across blocks within the same call: `nbytes` may differ per block (uneven tile
+  partitions are supported as long as both sides agree per-block).
+
+### Changing `active_blocks` between calls
+
+If `active_blocks` changes between consecutive `send_tile`/`recv_tile` calls on the same transport, a **cross-rank barrier** is required between the two calls. Changing `active_blocks` alters `per_block_slot_size` and therefore the slot row layout; without a barrier, the receiver may still be draining the old layout while the sender begins writing the new one, corrupting staging data.
+
+### Concurrency
+
+- **Single-stream sequential calls on the same transport are supported** —
+  internal `step_state` and `signal_pad` survive across calls; the next call
+  resumes the protocol monotonically.
+- **Multiple kernels on the same transport via different CUDA streams =
+  undefined behavior** — they would race on `step_state` and `signal_pad`.
+
+---
+
+## 5. Algorithm
+
+Both backends share the same precomputation and slot-rotation logic. The key
+differences are in how data reaches the remote side and what synchronization
+primitives are used.
+
+| Aspect | NVL | IB |
+|---|---|---|
+| Data path | Direct P2P memcpy to **remote** `recv_staging` via NVLink | Cooperative memcpy to **local** `send_staging`, then fused RDMA put to remote `recv_staging` |
+| NIC wait | None — P2P writes complete in-order | `wait_counter(nic_done_counter)` before reusing local staging |
+| Signaling | `SignalState.signal(SIGNAL_SET, step)` via NVLink remote write | Fused RDMA put-with-signal (`put_signal_counter_remote`) |
+| Drain | None — no outstanding async ops after memcpy + sync | Internal drain at end: `wait_counter(nic_done_counter, step)` |
+| `send_staging` | Not used (`nullptr`) | Required (registered MR for RDMA source) |
+
+### Common precomputation (both backends)
+
+```text
+block_id        = group.group_id
+eff_active      = active_blocks > 0 ? active_blocks : tile_max_groups
+trap if block_id >= eff_active
+
+per_block_slot  = (data_buffer_size / eff_active) & ~15ULL
+trap if per_block_slot == 0
+chunk_size      = min(max_signal_bytes > 0 ? max_signal_bytes : per_block_slot,
+                      per_block_slot)
+chunks_per_slot = per_block_slot / chunk_size      // sub-slot signaling factor
+total_chunks    = ceil(nbytes / chunk_size)
+
+tail_signal_id  = block_id                         // DATA_READY (sender → receiver)
+head_signal_id  = tile_max_groups + block_id         // SLOT_FREE  (receiver → sender)
+```
+
+### `send_tile` (NVL)
+
+```text
+if nbytes == 0: return
+
+step = step_state.sender[block_id]
+
+for s in [0, total_chunks):
+    slot_step     = s / chunks_per_slot
+    sub_step      = s % chunks_per_slot
+    slot          = slot_step % pipeline_depth
+    slot_off      = slot * data_buffer_size
+    chunk_off     = sub_step * chunk_size
+    data_off      = s * chunk_size
+    bytes_this    = min(chunk_size, nbytes - data_off)
+
+    // (1) Backpressure: wait for receiver to free this slot.
+    //     Only at slot boundary (first sub-step) and only after the pipeline
+    //     is fully filled.
+    if sub_step == 0 and step >= chunks_per_slot * pipeline_depth:
+        local_signals[head_signal_id].wait_until(
+            group, CMP_GE,
+            step - chunks_per_slot * pipeline_depth + 1,
+            timeout)
+
+    // (2) Cooperative P2P memcpy: src chunk -> remote recv_staging via NVLink.
+    //     No local staging needed — NVLink writes go directly to the peer's
+    //     staging buffer.
+    memcpy_vectorized(
+        remote_recv_staging + slot_off + staging_off + chunk_off,
+        src + data_off,
+        bytes_this, group)
+
+    // (3) Barrier + signal DATA_READY to receiver.
+    group.sync()
+    if group.is_leader():
+        remote_signals[tail_signal_id].signal(SIGNAL_SET, step + 1)
+
+    step++
+
+step_state.sender[block_id] = step
+group.sync()
+```
+
+**Key difference from IB:** no NIC-done wait (step 1 in IB) and no drain (step
+5 in IB). The P2P memcpy writes directly to remote memory — once `group.sync()`
+completes, all threads have finished their stores, so the data is visible on the
+remote side and local `src` is immediately safe. No outstanding async operations
+remain.
+
+### `recv_tile` (NVL)
+
+```text
+if nbytes == 0: return
+
+step = step_state.receiver[block_id]
+
+for s in [0, total_chunks):
+    slot_step     = s / chunks_per_slot
+    sub_step      = s % chunks_per_slot
+    slot          = slot_step % pipeline_depth
+    slot_off      = slot * data_buffer_size
+    chunk_off     = sub_step * chunk_size
+    data_off      = s * chunk_size
+    bytes_this    = min(chunk_size, nbytes - data_off)
+
+    // (1) Wait for sender's DATA_READY signal.
+    local_signals[tail_signal_id].wait_until(
+        group, CMP_GE, step + 1, timeout)
+
+    // (2) Cooperative memcpy: local recv_staging -> dst.
+    //     Sender wrote here via NVLink; we read from local memory (fast).
+    memcpy_vectorized(
+        dst + data_off,
+        local_recv_staging + slot_off + staging_off + chunk_off,
+        bytes_this, group)
+
+    // (3) Barrier + conditional SLOT_FREE signal to sender.
+    //     Signal only at slot boundaries (last sub-step in a slot or the
+    //     very last step) to release the entire slot for reuse.
+    group.sync()
+    bool last_in_slot = (sub_step == chunks_per_slot - 1)
+                        or (s == total_chunks - 1)
+    if last_in_slot and group.is_leader():
+        remote_signals[head_signal_id].signal(SIGNAL_SET, step + 1)
+
+    step++
+
+step_state.receiver[block_id] = step
+group.sync()
+```
+
+### `send_tile` (IB)
+
+```text
+if nbytes == 0: return
+
+step = step_state.sender[block_id]
+
+for s in [0, total_chunks):
+    slot_step     = s / chunks_per_slot
+    sub_step      = s % chunks_per_slot
+    slot          = slot_step % pipeline_depth
+    slot_off      = slot * data_buffer_size
+    chunk_off     = sub_step * chunk_size
+    staging_off   = slot_off + block_id * per_block_slot + chunk_off
+    data_off      = s * chunk_size
+    bytes_this    = min(chunk_size, nbytes - data_off)
+
+    // (1) Wait for prior NIC use of this slot to drain (local staging is safe).
+    if step >= pipeline_depth * chunks_per_slot:
+        wait_counter(group,
+                     nic_done_counter[block_id],
+                     step - pipeline_depth * chunks_per_slot + 1,
+                     timeout)
+
+    // (2) Cooperative memcpy: src chunk -> local send_staging.
+    memcpy_vectorized(send_staging + staging_off,
+                      src + data_off,
+                      bytes_this, group)
+    group.sync()
+
+    // (3) Wait for receiver to free this slot — only at slot boundary.
+    if sub_step == 0 and step >= pipeline_depth * chunks_per_slot:
+        wait_signal(group,
+                    signal_pad[tile_max_groups + block_id],       // SLOT_FREE row
+                    step / chunks_per_slot - pipeline_depth + 1,
+                    timeout)
+
+    // (4) Fused RDMA put + remote DATA_READY signal + local NIC_DONE bump.
+    if group.is_leader():
+        put_signal_counter_remote(
+            local_src     = send_staging        + staging_off,
+            remote_dst    = recv_staging_remote + staging_off,
+            nbytes        = bytes_this,
+            remote_signal = signal_pad_remote[block_id],       // DATA_READY row
+            signal_inc    = 1,
+            local_counter = nic_done_counter[block_id],
+            counter_inc   = 1)
+
+    step++
+
+step_state.sender[block_id] = step
+group.sync()
+
+// (5) Internal drain: wait for all RDMA puts on this block to complete.
+wait_counter(group, nic_done_counter[block_id], step, timeout)
+group.sync()
+```
+
+### `recv_tile` (IB)
+
+```text
+if nbytes == 0: return
+
+step = step_state.receiver[block_id]
+
+for s in [0, total_chunks):
+    slot_step     = s / chunks_per_slot
+    sub_step      = s % chunks_per_slot
+    slot          = slot_step % pipeline_depth
+    slot_off      = slot * data_buffer_size
+    chunk_off     = sub_step * chunk_size
+    staging_off   = slot_off + block_id * per_block_slot + chunk_off
+    data_off      = s * chunk_size
+    bytes_this    = min(chunk_size, nbytes - data_off)
+
+    // (1) Wait for sender's data.
+    wait_signal(group,
+                signal_pad[block_id],                          // DATA_READY row
+                step + 1,
+                timeout)
+
+    // (2) Cooperative memcpy: local recv_staging -> dst.
+    memcpy_vectorized(dst + data_off,
+                      recv_staging + staging_off,
+                      bytes_this, group)
+    group.sync()
+
+    // (3) Tell sender slot is free — only at slot boundary.
+    bool last_in_slot = (sub_step == chunks_per_slot - 1)
+                        or (s == total_chunks - 1)
+    if last_in_slot and group.is_leader():
+        signal_remote(signal_pad_remote[tile_max_groups + block_id],  // SLOT_FREE row
+                      increment = 1)
+
+    step++
+
+step_state.receiver[block_id] = step
+group.sync()
+```
+
+### Why these waits are placed where they are
+
+| Step | Backend | Why it is needed |
+|---|---|---|
+| `send_tile (1)` backpressure | NVL | Receiver may still be reading its local staging. Writing new data via NVLink would corrupt the receiver's in-progress memcpy. Slot-boundary only — sub-steps within a slot share the same slot. |
+| `send_tile (1)` NIC drain | IB | NIC may still be reading local staging from a prior put. Memcpying new data would corrupt the in-flight RDMA. |
+| `send_tile (3)` backpressure | IB | Receiver may still be reading remote staging. Putting new data would corrupt the receiver's read. Slot-boundary only. |
+| `send_tile (5)` drain | IB | Without the drain, returning from `send_tile` would leave outstanding RDMA puts in flight. Internal drain makes the postcondition crisp: on return, all RDMA is delivered. |
+| `recv_tile (1)` | Both | Receiver cannot consume staging until the sender has signaled DATA_READY. |
+| `recv_tile (3)` | Both | Sender's backpressure relies on this signal. Slot-boundary only, matching sender's wait granularity. |
+
+---
+
+## 6. Worked Example
+
+A bidirectional same-rank-pair send/recv kernel using `partition(2)` to split
+blocks into senders and receivers.
+
+```cpp
+#include "comms/pipes/MultipeerIbgdaTransport.h"
+#include "comms/pipes/P2pIbgdaTransportDevice.cuh"
+#include "comms/pipes/ThreadGroup.cuh"
+#include "comms/pipes/TiledBuffer.cuh"
+#include "comms/pipes/Timeout.cuh"
+
+using namespace comms::pipes;
+
+__global__ void bidirectional_send_recv_kernel(
+    P2pIbgdaTransportDevice* transport,
+    char* src, char* dst,
+    size_t total_bytes,
+    Timeout timeout) {
+  auto group = make_block_group();
+  auto [role, sub] = group.partition(2);
+  const bool is_sender = (role == 0);
+
+  // Each side partitions its own data evenly across its half of the blocks.
+  TiledBuffer<char> tiles(is_sender ? src : dst, total_bytes, sub);
+
+  if (is_sender) {
+    transport->send_tile(
+        sub,
+        tiles.data(),
+        tiles.bytes(),
+        /*active_blocks=*/sub.total_groups,   // explicit — matches the partition size
+        /*max_signal_bytes=*/  0,                   // default = one signal per slot fill
+        timeout);
+  } else {
+    transport->recv_tile(
+        sub,
+        tiles.data(),
+        tiles.bytes(),
+        /*active_blocks=*/sub.total_groups,
+        /*max_signal_bytes=*/  0,
+        timeout);
+  }
+}
+
+// Host side:
+MultipeerIbgdaTransportConfig cfg{
+    .cudaDevice = local_rank,
+    // ... existing IB fields (qpDepth, etc.) ...
+    .data_buffer_size    = 8 * 1024 * 1024,
+    .tile_pipeline_depth = 2,
+    .tile_max_groups     = 64,    // we launch 128 blocks total = 64 senders + 64 receivers
+};
+MultipeerIbgdaTransport transport(global_rank, world_size, bootstrap, cfg);
+transport.exchange();
+
+auto* device_xport = transport.get_p2p_transport_device(peer_rank);
+bidirectional_send_recv_kernel<<<128, 256, 0, stream>>>(
+    device_xport, send_buf, recv_buf, total_bytes, Timeout::ms(5000));
+```
+
+Notes on the example:
+- The `partition(2)` renumbers `sub.group_id` to `[0, 64)` for both senders and
+  receivers. The trap precondition is `sub.group_id < active_blocks=64`,
+  which is satisfied.
+- `TiledBuffer` partitions `total_bytes` evenly across the 64 sub-blocks; each
+  block's `tiles.data()` is its own pre-sliced pointer, `tiles.bytes()` is its
+  per-block byte count. Last block may be smaller (handled by `TiledBuffer`).
+- `max_signal_bytes=0` keeps the default of one DATA_READY signal per slot fill —
+  optimal for IB (amortizes RDMA atomic cost). To get sub-slot signaling, pass
+  e.g., `max_signal_bytes = 16384` for finer-grained pipelining.
+
+---
+
+## 7. Out of Scope / Future Work
+
+- **Explicit `drain_tile` API.** Drain is currently internal to `send_tile`
+  (step 5). May be exposed if users want to overlap NIC drain with other
+  device-side work between consecutive `send_tile` calls.
+- **Multi-stream concurrency on the same transport.** Currently undefined.
+  Would require per-stream `step_state` and `signal_pad` arenas.
+- **Per-call config overrides.** `pipeline_depth` and `data_buffer_size` are
+  construction-time only. Per-call overrides would require dynamic staging
+  re-allocation.
+- **Cross-rank rendezvous.** Use a separate barrier primitive; not coupled to
+  send/recv_tile.
+- **Error reporting on timeout.** Currently traps. Future: device flag +
+  host-readable error code for graceful recovery in long-running services.

--- a/comms/pipes/docs/tile_sendrecv.md
+++ b/comms/pipes/docs/tile_sendrecv.md
@@ -284,6 +284,7 @@ primitives are used.
 ```text
 block_id        = group.group_id
 eff_active      = active_blocks > 0 ? active_blocks : tile_max_groups
+trap if eff_active > tile_max_groups   // signal/step_state arrays are sized to tile_max_groups
 trap if block_id >= eff_active
 
 per_block_slot  = (data_buffer_size / eff_active) & ~15ULL

--- a/comms/pipes/tests/P2pNvlTransportDeviceTest.cc
+++ b/comms/pipes/tests/P2pNvlTransportDeviceTest.cc
@@ -1046,6 +1046,196 @@ TEST_F(P2pNvlTransportDeviceTwoGpuFixture, DeviceSignalTwoGpuPingPong) {
   CUDACHECK_TEST(cudaFree(transport1_d));
 }
 
+TEST_F(P2pNvlTransportDeviceTestFixture, PutTilePerGroup) {
+  const std::size_t tileSize = 4096;
+  const int numGroups = 4;
+
+  // Allocate per-group src and dst buffers
+  char* src_d;
+  char* dst_d;
+  CUDACHECK_TEST(cudaMalloc(&src_d, tileSize * numGroups));
+  CUDACHECK_TEST(cudaMalloc(&dst_d, tileSize * numGroups));
+  CUDACHECK_TEST(cudaMemset(dst_d, 0, tileSize * numGroups));
+
+  // Fill each group's tile with a distinct pattern
+  std::vector<char> srcPattern(tileSize * numGroups);
+  for (int g = 0; g < numGroups; ++g) {
+    for (std::size_t i = 0; i < tileSize; ++i) {
+      srcPattern[g * tileSize + i] = static_cast<char>((g + 1) * 10 + (i % 64));
+    }
+  }
+  CUDACHECK_TEST(cudaMemcpy(
+      src_d, srcPattern.data(), tileSize * numGroups, cudaMemcpyHostToDevice));
+
+  // Minimal transport — put_tile doesn't use any transport buffers
+  P2pNvlTransportOptions options{
+      .dataBufferSize = 1024,
+      .chunkSize = 512,
+      .pipelineDepth = 2,
+  };
+  LocalState localState{
+      .dataBuffer = nullptr,
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .signalBuffer = DeviceSpan<SignalState>(nullptr, 0),
+  };
+  RemoteState remoteState{
+      .dataBuffer = nullptr,
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .signalBuffer = DeviceSpan<SignalState>(nullptr, 0),
+  };
+  P2pNvlTransportDevice transport(0, 0, options, localState, remoteState);
+
+  P2pNvlTransportDevice* transport_d;
+  CUDACHECK_TEST(cudaMalloc(&transport_d, sizeof(P2pNvlTransportDevice)));
+  CUDACHECK_TEST(cudaMemcpy(
+      transport_d,
+      &transport,
+      sizeof(P2pNvlTransportDevice),
+      cudaMemcpyHostToDevice));
+
+  // Launch numGroups blocks, each copying its own tile independently
+  // Each group offsets by group.group_id * tileSize into src/dst
+  test::testDevicePutTile(
+      transport_d,
+      dst_d,
+      src_d,
+      tileSize,
+      numGroups,
+      256,
+      test::GroupType::BLOCK);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  // Verify all data was copied correctly
+  std::vector<char> result(tileSize * numGroups);
+  CUDACHECK_TEST(cudaMemcpy(
+      result.data(), dst_d, tileSize * numGroups, cudaMemcpyDeviceToHost));
+
+  for (std::size_t i = 0; i < tileSize * numGroups; ++i) {
+    ASSERT_EQ(result[i], srcPattern[i]) << "Mismatch at byte " << i;
+  }
+
+  CUDACHECK_TEST(cudaFree(src_d));
+  CUDACHECK_TEST(cudaFree(dst_d));
+  CUDACHECK_TEST(cudaFree(transport_d));
+}
+
+TEST_F(P2pNvlTransportDeviceTwoGpuFixture, DeviceResetSignalTwoGpu) {
+  const int numSignals = 8;
+
+  CUDACHECK_TEST(cudaSetDevice(kGpu0));
+  SignalState* signalBuffer0;
+  CUDACHECK_TEST(cudaMalloc(&signalBuffer0, numSignals * sizeof(SignalState)));
+  CUDACHECK_TEST(
+      cudaMemset(signalBuffer0, 0, numSignals * sizeof(SignalState)));
+
+  CUDACHECK_TEST(cudaSetDevice(kGpu1));
+  SignalState* signalBuffer1;
+  CUDACHECK_TEST(cudaMalloc(&signalBuffer1, numSignals * sizeof(SignalState)));
+  CUDACHECK_TEST(
+      cudaMemset(signalBuffer1, 0, numSignals * sizeof(SignalState)));
+
+  P2pNvlTransportOptions options{
+      .dataBufferSize = 1024,
+      .chunkSize = 512,
+      .pipelineDepth = 2,
+  };
+
+  LocalState localState0{
+      .dataBuffer = nullptr,
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .signalBuffer = DeviceSpan<SignalState>(signalBuffer0, numSignals),
+  };
+  RemoteState remoteState0{
+      .dataBuffer = nullptr,
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .signalBuffer = DeviceSpan<SignalState>(signalBuffer1, numSignals),
+  };
+  P2pNvlTransportDevice transport0(
+      kGpu0, kGpu1, options, localState0, remoteState0);
+
+  P2pNvlTransportDevice* transport0_d;
+  CUDACHECK_TEST(cudaMalloc(&transport0_d, sizeof(P2pNvlTransportDevice)));
+  CUDACHECK_TEST(cudaMemcpy(
+      transport0_d,
+      &transport0,
+      sizeof(P2pNvlTransportDevice),
+      cudaMemcpyHostToDevice));
+
+  LocalState localState1{
+      .dataBuffer = nullptr,
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .signalBuffer = DeviceSpan<SignalState>(signalBuffer1, numSignals),
+  };
+  RemoteState remoteState1{
+      .dataBuffer = nullptr,
+      .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+      .signalBuffer = DeviceSpan<SignalState>(signalBuffer0, numSignals),
+  };
+  P2pNvlTransportDevice transport1(
+      kGpu1, kGpu0, options, localState1, remoteState1);
+
+  CUDACHECK_TEST(cudaSetDevice(kGpu1));
+  P2pNvlTransportDevice* transport1_d;
+  CUDACHECK_TEST(cudaMalloc(&transport1_d, sizeof(P2pNvlTransportDevice)));
+  CUDACHECK_TEST(cudaMemcpy(
+      transport1_d,
+      &transport1,
+      sizeof(P2pNvlTransportDevice),
+      cudaMemcpyHostToDevice));
+
+  const int numBlocks = 1;
+  const int blockSize = 32;
+  const uint64_t signalId = 0;
+
+  // GPU 0 signals value 42 to GPU 1
+  CUDACHECK_TEST(cudaSetDevice(kGpu0));
+  test::testDeviceSignal(
+      transport0_d, signalId, SignalOp::SIGNAL_SET, 42, numBlocks, blockSize);
+
+  // GPU 1 waits for signal, then resets it
+  CUDACHECK_TEST(cudaSetDevice(kGpu1));
+  test::testDeviceWaitSignal(
+      transport1_d, signalId, CmpOp::CMP_EQ, 42, numBlocks, blockSize);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  test::testDeviceResetSignal(transport1_d, signalId, numBlocks, blockSize);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  // Verify signal is back to 0 by reading the raw buffer
+  uint64_t* result_d;
+  CUDACHECK_TEST(cudaMalloc(&result_d, sizeof(uint64_t)));
+  test::testReadSignal(&signalBuffer1[signalId], result_d);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  uint64_t result_h;
+  CUDACHECK_TEST(cudaMemcpy(
+      &result_h, result_d, sizeof(uint64_t), cudaMemcpyDeviceToHost));
+  ASSERT_EQ(result_h, 0) << "Signal should be 0 after reset";
+
+  // GPU 0 signals again with a new value — verifies the slot is reusable
+  CUDACHECK_TEST(cudaSetDevice(kGpu0));
+  test::testDeviceSignal(
+      transport0_d, signalId, SignalOp::SIGNAL_SET, 99, numBlocks, blockSize);
+
+  // GPU 1 waits for the new value
+  CUDACHECK_TEST(cudaSetDevice(kGpu1));
+  test::testDeviceWaitSignal(
+      transport1_d, signalId, CmpOp::CMP_EQ, 99, numBlocks, blockSize);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  CUDACHECK_TEST(cudaFree(result_d));
+  CUDACHECK_TEST(cudaSetDevice(kGpu0));
+  CUDACHECK_TEST(cudaFree(signalBuffer0));
+  CUDACHECK_TEST(cudaFree(transport0_d));
+  CUDACHECK_TEST(cudaSetDevice(kGpu1));
+  CUDACHECK_TEST(cudaFree(signalBuffer1));
+  CUDACHECK_TEST(cudaFree(transport1_d));
+}
+
 // =============================================================================
 // LL128 Transport Send/Recv Tests
 // These test the ll128_send()/ll128_recv() methods on P2pNvlTransportDevice

--- a/comms/pipes/tests/P2pNvlTransportDeviceTest.cu
+++ b/comms/pipes/tests/P2pNvlTransportDeviceTest.cu
@@ -96,6 +96,49 @@ void testDeviceSignalThenWait(
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 
+__global__ void testDevicePutTileKernel(
+    P2pNvlTransportDevice* p2p,
+    char* dst_d,
+    const char* src_d,
+    std::size_t tileSize,
+    GroupType groupType) {
+  auto group = make_group(groupType);
+  std::size_t offset = group.group_id * tileSize;
+  p2p->put_tile(group, dst_d + offset, src_d + offset, tileSize);
+}
+
+void testDevicePutTile(
+    P2pNvlTransportDevice* p2p,
+    char* dst_d,
+    const char* src_d,
+    std::size_t tileSize,
+    int numBlocks,
+    int blockSize,
+    GroupType groupType) {
+  testDevicePutTileKernel<<<numBlocks, blockSize>>>(
+      p2p, dst_d, src_d, tileSize, groupType);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+__global__ void testDeviceResetSignalKernel(
+    P2pNvlTransportDevice* p2p,
+    uint64_t signalId,
+    GroupType groupType) {
+  auto group = make_group(groupType);
+  p2p->reset_signal_threadgroup(group, signalId);
+}
+
+void testDeviceResetSignal(
+    P2pNvlTransportDevice* p2p,
+    uint64_t signalId,
+    int numBlocks,
+    int blockSize,
+    GroupType groupType) {
+  testDeviceResetSignalKernel<<<numBlocks, blockSize>>>(
+      p2p, signalId, groupType);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
 // =============================================================================
 // Direct Signal struct test kernels
 // =============================================================================

--- a/comms/pipes/tests/P2pNvlTransportDeviceTest.cuh
+++ b/comms/pipes/tests/P2pNvlTransportDeviceTest.cuh
@@ -81,6 +81,24 @@ void testRawWaitSignal(
 // Read the signal value (for verification)
 void testReadSignal(SignalState* signal_d, uint64_t* result_d);
 
+// Per-group put_tile copy (each block copies its own tile at blockIdx.x offset)
+void testDevicePutTile(
+    P2pNvlTransportDevice* p2p,
+    char* dst_d,
+    const char* src_d,
+    std::size_t tileSize,
+    int numBlocks,
+    int blockSize,
+    GroupType groupType = GroupType::BLOCK);
+
+// Reset signal on a transport (resets local signal state)
+void testDeviceResetSignal(
+    P2pNvlTransportDevice* p2p,
+    uint64_t signalId,
+    int numBlocks,
+    int blockSize,
+    GroupType groupType = GroupType::WARP);
+
 // =============================================================================
 // LL128 transport send/recv test helpers
 // These test the ll128_send()/ll128_recv() methods on P2pNvlTransportDevice

--- a/comms/pipes/tests/P2pNvlTransportTest.cc
+++ b/comms/pipes/tests/P2pNvlTransportTest.cc
@@ -421,13 +421,13 @@ TEST_F(P2pNvlTransportTestFixture, TileSendRecvMultiCall) {
     comms::pipes::TiledBuffer<char> recvTiles(
         static_cast<char*>(recvBuf.get()), nBytes, numSendBlocks);
     int numBlocksArg = numSendBlocks;
-    int chunksPerSlot = 1;
+    std::size_t maxSignalBytes = 0;
     void* args[] = {
         &p2pHost,
         &sendTiles,
         &recvTiles,
         &numBlocksArg,
-        &chunksPerSlot,
+        &maxSignalBytes,
         &timeout};
 
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
@@ -507,13 +507,13 @@ static void runTileTest(
     comms::pipes::TiledBuffer<char> recvTiles(
         static_cast<char*>(recvBuf.get()), nBytes, numSendBlocks);
     int numBlocksArg = numSendBlocks;
-    int chunksPerSlot = 1;
+    std::size_t maxSignalBytes = 0;
     void* args[] = {
         &p2pHost,
         &sendTiles,
         &recvTiles,
         &numBlocksArg,
-        &chunksPerSlot,
+        &maxSignalBytes,
         &timeout};
 
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
@@ -826,13 +826,13 @@ TEST_F(P2pNvlTransportTestFixture, TileSendRecvMultiCallDifferentSizes) {
     comms::pipes::TiledBuffer<char> recvTiles(
         static_cast<char*>(recvBuf.get()), nBytes, numSendBlocks);
     int numBlocksArg = numSendBlocks;
-    int chunksPerSlot = 1;
+    std::size_t maxSignalBytes = 0;
     void* args[] = {
         &p2pHost,
         &sendTiles,
         &recvTiles,
         &numBlocksArg,
-        &chunksPerSlot,
+        &maxSignalBytes,
         &timeout};
 
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
@@ -3489,7 +3489,7 @@ TEST_F(P2pNvlTransportTestFixture, TileSendRecvDynamicBlockCount) {
       .chunkSize = 8 * 1024 * 1024,
       .pipelineDepth = 2,
       .p2pBarrierCount = static_cast<std::size_t>(maxBlocks),
-      .tileMaxBlocks = maxBlocks,
+      .tile_max_groups = maxBlocks,
   };
 
   auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();


### PR DESCRIPTION
Summary:

Add two new methods to P2pNvlTransportDevice:

- **reset_signal_threadgroup**: Allows the receiver to reset its local signal slot to zero after processing. Safe because the receiver owns the local inbox buffer (no cross-GPU race).

- **put_tile**: Per-group local memory copy where each group independently copies its own tile. Unlike put() which is a grid-collective requiring all groups to cooperate on the same data, put_tile() lets each group operate on independent src/dst/nbytes.

Also updated docblocks on put, put_tile, send, and send_tile to clarify grid-collective vs per-group semantics and cross-reference each other.

Reviewed By: goelayu

Differential Revision: D101696836


