### PR TITLE
Update torchcomms OSS CI to dynamically discover tests under **/tests/py

### DIFF
--- a/comms/torchcomms/scripts/run_tests_integration_py.sh
+++ b/comms/torchcomms/scripts/run_tests_integration_py.sh
@@ -15,11 +15,16 @@ if [ ! -d /sys/class/infiniband ] || [ -z "$(ls /sys/class/infiniband 2>/dev/nul
     export NCCL_CTRAN_BACKENDS="socket"
 fi
 
-cd "$(dirname "$0")/../tests/integration/py"
+TORCHCOMMS_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+INTEGRATION_TEST_DIRS=$(find "$TORCHCOMMS_ROOT" -path '*/tests/integration/py' -type d | sort -u)
 
 run_tests () {
-    for file in *Test.py; do
-        torchrun --nnodes 1 --nproc_per_node 4 "$file" --verbose
+    for dir in $INTEGRATION_TEST_DIRS; do
+        for file in "$dir"/*Test.py; do
+            [ -f "$file" ] || continue
+            torchrun --nnodes 1 --nproc_per_node 4 "$file" --verbose
+        done
     done
 }
 

--- a/comms/torchcomms/scripts/run_tests_unit_py.sh
+++ b/comms/torchcomms/scripts/run_tests_unit_py.sh
@@ -3,28 +3,43 @@
 
 set -ex
 
-run_test () {
-    pytest -v comms/torchcomms/tests/unit/py
+TORCHCOMMS_ROOT="comms/torchcomms"
+
+collect_unit_test_dirs () {
+    find "$TORCHCOMMS_ROOT" -path '*/tests/py' -type d ! -path '*/tests/integration/*'
+    find "$TORCHCOMMS_ROOT" -path '*/tests/unit/py' -type d
+}
+
+UNIT_TEST_DIRS=$(collect_unit_test_dirs | sort -u)
+
+run_tests () {
+    for dir in $UNIT_TEST_DIRS; do
+        if [[ "$dir" == *transport* ]] && { [ "${USE_TRANSPORT}" = "0" ] || [ "${USE_TRANSPORT}" = "OFF" ]; }; then
+            echo "Skipping $dir (USE_TRANSPORT=${USE_TRANSPORT})"
+            continue
+        fi
+        pytest -v "$dir"
+    done
 }
 
 # NCCL
 export TEST_BACKEND=nccl
-run_test
+run_tests
 
 # NCCLX
 export TEST_BACKEND=ncclx
-run_test
+run_tests
 
 # Gloo with CPU
 export TEST_BACKEND=gloo
 export TEST_DEVICE=cpu
 export CUDA_VISIBLE_DEVICES=""
-run_test
+run_tests
 unset TEST_DEVICE
 unset CUDA_VISIBLE_DEVICES
 
 # Gloo with CUDA
 export TEST_BACKEND=gloo
 export TEST_DEVICE=cuda
-run_test
+run_tests
 unset TEST_DEVICE


### PR DESCRIPTION
Summary:
Update both CI test scripts to use find-based dynamic discovery instead of hardcoded paths:

- run_tests_unit_py.sh: Discovers all **/tests/py (excluding tests/integration/*) and **/tests/unit/py directories. Picks up transport/tests/py, hooks/fr/tests/py, etc. Includes USE_TRANSPORT skip guard.
- run_tests_integration_py.sh: Discovers all **/tests/integration/py directories. Picks up ncclx/tests/integration/py, etc.

Differential Revision: D101703595


