### PR TITLE
AGP ctdirect: skip nvlCeBcast when local peers are not NVL

### DIFF
--- a/comms/ctran/algos/AllGatherP/DirectImpl.cc
+++ b/comms/ctran/algos/AllGatherP/DirectImpl.cc
@@ -144,9 +144,17 @@ commResult_t AlgoImpl::execDirect(
     FB_COMMCHECK(waitInit());
   }
 
-  // Copy data to other local ranks
-  FB_COMMCHECK(
-      nvlCeBcast(comm_, sendbuff, sendSize, myRank * sendSize, pArgs, stream_));
+  // Copy data to other local ranks via NVL CE broadcast, if NVL is available
+  const auto statex = comm_->statex_.get();
+  const auto actualNLocalRanks = statex->nLocalRanks();
+  if (actualNLocalRanks > 1) {
+    const auto localPeer =
+        statex->localRankToRank((statex->localRank() + 1) % actualNLocalRanks);
+    if (pArgs.remoteAccessKeys[localPeer].backend == CtranMapperBackend::NVL) {
+      FB_COMMCHECK(nvlCeBcast(
+          comm_, sendbuff, sendSize, myRank * sendSize, pArgs, stream_));
+    }
+  }
 
   auto op = std::make_unique<OpElem>(
       OpElem::opType::ALLGATHERP, stream_, comm_, opCount);


### PR DESCRIPTION
Summary:
`AlgoImpl::execDirect` (AllGatherP::ctdirect) unconditionally calls `nvlCeBcast`, which strict-rejects with `commInvalidArgument` if any local-rank peer's `remoteAccessKeys[peer].backend != CtranMapperBackend::NVL` (see `comms/ctran/algos/AllGatherP/CommUtils.h:74`). On hosts where local peers fall back to IB (NVL backend not initialized, or `cudaDeviceCanAccessPeer` returns false between the GPUs), the test fails with `Peer X has non-NVL backend in nvlCeBcast`.

The strict check was introduced by D99001856 (Mar 9), which converted a silent skip into a hard error. Before that, the algorithm silently produced incorrect results on the same configuration; afterwards it errors out at runtime even though `allGatherPSupport()` returned true.

Fix: gate `nvlCeBcast` on whether the next local peer's backend is NVL. When NVL is unavailable for the local domain, skip the broadcast — `gpnFn` already issues IB irecv/isend/iput for every peer including local ones, so the data still arrives. This mirrors how `PipelineImpl.cc` already guards its `nvlCeBcast` call.

Caveat: the guard inspects only `(localRank+1) % nLocalRanks`, assuming peer-backend homogeneity within the local domain. Safe for current Meta GPU SKUs where all local peers share the same fabric topology, but worth revisiting if mixed-topology hosts emerge.

Differential Revision: D101685358


