### PR TITLE
Move window AGP init to GPE thread (#2166)

### DIFF
--- a/comms/ctran/algos/AllGatherP/WinAllGather.cc
+++ b/comms/ctran/algos/AllGatherP/WinAllGather.cc
@@ -2,12 +2,14 @@
 
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/AllGatherP/AlgoImpl.h"
+#include "comms/ctran/algos/AllGatherP/Types.h"
 #include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/window/CtranWin.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
 using ctran::allgatherp::AlgoImpl;
+using ctran::allgatherp::PersistArgs;
 
 #define CHECK_VALID_PREQ(pReq)                                         \
   do {                                                                 \
@@ -28,6 +30,35 @@ using ctran::allgatherp::AlgoImpl;
 
 namespace ctran {
 
+namespace {
+const std::string algoWinInitName = "CtranAllGatherWinInit";
+
+// GPE callback: populate pArgs remote info from window, then mark initialized.
+// Runs on GPE thread to avoid races between init and exec on the mapper epoch
+// lock (see D76792218).
+commResult_t populateWinPArgs(
+    const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
+  struct OpElem* op = opGroup.front().get();
+  auto* pArgs = reinterpret_cast<PersistArgs*>(op->allgatherp_init.pArgs);
+  auto* win = op->allgatherp_init.win;
+  CtranComm* comm = opGroup.front()->comm_;
+
+  const auto nRanks = comm->statex_->nRanks();
+
+  CtranAlgoLogger logger(algoWinInitName, op->opCount, comm);
+
+  pArgs->remoteRecvBuffs.resize(nRanks);
+  pArgs->remoteAccessKeys.resize(nRanks);
+  for (int r = 0; r < nRanks; r++) {
+    pArgs->remoteRecvBuffs[r] = win->remWinInfo[r].dataAddr;
+    pArgs->remoteAccessKeys[r] = win->remWinInfo[r].dataRkey;
+  }
+
+  pArgs->initialized.store(true);
+  return commSuccess;
+}
+} // namespace
+
 commResult_t allGatherWinInit(
     CtranWin* win,
     CtranComm* comm,
@@ -47,19 +78,34 @@ commResult_t allGatherWinInit(
 
   auto algo = std::make_unique<AlgoImpl>(comm, stream);
 
-  // Populate pArgs from window remote info
   algo->pArgs.recvbuff = win->winDataPtr;
   algo->pArgs.recvHdl = win->dataRegHdl;
-  algo->pArgs.remoteRecvBuffs.resize(nRanks);
-  algo->pArgs.remoteAccessKeys.resize(nRanks);
-  for (int r = 0; r < nRanks; r++) {
-    algo->pArgs.remoteRecvBuffs[r] = win->remWinInfo[r].dataAddr;
-    algo->pArgs.remoteAccessKeys[r] = win->remWinInfo[r].dataRkey;
-  }
-  // Window already exchanged remote info, mark as initialized
-  algo->pArgs.initialized.store(true);
+  algo->pArgs.initialized.store(false);
 
   FB_COMMCHECK(algo->initResources());
+
+  // Submit remote info population to GPE thread via submitHost (no kernel).
+  // submitHost is not captured by cudagraph, so it works correctly during
+  // both graph capture and eager execution. This matches the pattern from
+  // allGatherPInit to avoid races between init and exec on the
+  // mapper epoch lock.
+  auto opCount = comm->ctran_->getOpCount();
+
+  KernelConfig config = KernelConfig(
+      KernelConfig::KernelType::ALLGATHERP_INIT,
+      stream,
+      algoWinInitName,
+      opCount);
+
+  std::vector<std::unique_ptr<struct OpElem>> opGroup;
+  auto op = std::make_unique<OpElem>(
+      OpElem::opType::ALLGATHERP_INIT, stream, comm, opCount);
+  op->allgatherp_init.pArgs = &algo->pArgs;
+  op->allgatherp_init.win = win;
+  opGroup.push_back(std::move(op));
+
+  FB_COMMCHECK(comm->ctran_->gpe->submitHost(
+      std::move(opGroup), populateWinPArgs, config, nullptr /* cpuFlag */));
 
   request = new CtranPersistentRequest(
       CtranPersistentRequest::Type::ALLGATHER_P_WIN, comm, stream);

--- a/comms/ctran/gpe/CtranGpe.h
+++ b/comms/ctran/gpe/CtranGpe.h
@@ -91,6 +91,9 @@ struct OpElem {
     struct {
       // reference to pre-initialized persistent arguments and resource
       void* pArgs;
+      // non-null for window-based init; used by GPE callback to populate
+      // pArgs from window remote info
+      ctran::CtranWin* win;
     } allgatherp_init;
     struct {
       // reference to pre-initialized persistent arguments and resource

--- a/comms/ctran/tests/CtranWinAllGatherTest.cc
+++ b/comms/ctran/tests/CtranWinAllGatherTest.cc
@@ -224,6 +224,135 @@ TEST_F(CtranWinAllGatherTest, DisjointMemory) {
   CUDACHECK_TEST(cudaStreamDestroy(stream));
 }
 
+// Test back-to-back window collective init+exec across multiple communicators.
+// Exercises the GPE-thread init path (D101075857) to verify no races between
+// overlapping init and exec on the mapper epoch lock.
+TEST_F(CtranWinAllGatherTest, BackToBackMultiComm) {
+  const size_t sendCount = 8192;
+  const commDataType_t dt = commFloat;
+  const int kComms = 4;
+
+  auto firstComm = makeCtranComm();
+  ASSERT_NE(firstComm, nullptr);
+
+  const auto nRanks = firstComm->statex_->nRanks();
+  const size_t sendBytes = sendCount * commTypeSize(dt);
+  const size_t recvBytes = sendBytes * nRanks;
+
+  // Check allGatherP support with a temporary window
+  {
+    void* tmpBuf = nullptr;
+    CUDACHECK_TEST(cudaMalloc(&tmpBuf, recvBytes));
+    CtranWin* tmpWin = nullptr;
+    ASSERT_EQ(
+        ctranWinRegister(tmpBuf, recvBytes, firstComm.get(), &tmpWin),
+        commSuccess);
+    if (!tmpWin->allGatherPSupported()) {
+      ASSERT_EQ(ctranWinFree(tmpWin), commSuccess);
+      CUDACHECK_TEST(cudaFree(tmpBuf));
+      GTEST_SKIP() << "allGatherP not supported on this topology";
+    }
+    ASSERT_EQ(ctranWinFree(tmpWin), commSuccess);
+    CUDACHECK_TEST(cudaFree(tmpBuf));
+  }
+  firstComm.reset();
+
+  std::vector<cudaStream_t> streams(kComms);
+  std::vector<std::unique_ptr<CtranComm>> comms(kComms);
+  std::vector<void*> winBases(kComms);
+  std::vector<CtranWin*> wins(kComms);
+  std::vector<void*> sendbufs(kComms);
+  std::vector<CtranPersistentRequest*> requests(kComms);
+
+  for (int c = 0; c < kComms; c++) {
+    CUDACHECK_TEST(cudaStreamCreate(&streams[c]));
+    comms[c] = makeCtranComm();
+    ASSERT_NE(comms[c], nullptr);
+
+    CUDACHECK_TEST(cudaMalloc(&winBases[c], recvBytes));
+    ASSERT_EQ(
+        ctranWinRegister(winBases[c], recvBytes, comms[c].get(), &wins[c]),
+        commSuccess);
+
+    CUDACHECK_TEST(cudaMalloc(&sendbufs[c], sendBytes));
+  }
+
+  const auto myRank = comms[0]->statex_->rank();
+
+  // Init all windows back-to-back without synchronizing between them.
+  // No stream sync here: execs below rely on waitInit() to wait for each
+  // init's GPE callback to populate remote info, which is the mechanism
+  // D101075857 establishes for window-based allGatherP.
+  for (int c = 0; c < kComms; c++) {
+    requests[c] = nullptr;
+    ASSERT_EQ(
+        ctran::allGatherWinInit(
+            wins[c], comms[c].get(), streams[c], requests[c]),
+        commSuccess);
+    ASSERT_NE(requests[c], nullptr);
+  }
+
+  // Execute all back-to-back and verify correctness
+  constexpr int nIter = 3;
+  for (int iter = 0; iter < nIter; iter++) {
+    for (int c = 0; c < kComms; c++) {
+      const float sendVal = static_cast<float>(myRank * 100 + iter + c);
+      std::vector<float> sendVals(sendCount, sendVal);
+      CUDACHECK_TEST(cudaMemcpyAsync(
+          sendbufs[c],
+          sendVals.data(),
+          sendBytes,
+          cudaMemcpyHostToDevice,
+          streams[c]));
+      CUDACHECK_TEST(cudaMemsetAsync(winBases[c], 0, recvBytes, streams[c]));
+
+      ASSERT_EQ(
+          ctran::allGatherWinExec(sendbufs[c], sendCount, dt, requests[c]),
+          commSuccess);
+    }
+
+    for (int c = 0; c < kComms; c++) {
+      CUDACHECK_TEST(cudaStreamSynchronize(streams[c]));
+      for (int r = 0; r < nRanks; r++) {
+        std::vector<float> observed(sendCount);
+        CUDACHECK_TEST(cudaMemcpy(
+            observed.data(),
+            static_cast<char*>(winBases[c]) + r * sendBytes,
+            sendBytes,
+            cudaMemcpyDeviceToHost));
+
+        const float expected = static_cast<float>(r * 100 + iter + c);
+        for (size_t i = 0; i < sendCount; i++) {
+          EXPECT_EQ(observed[i], expected)
+              << "comm " << c << " rank " << myRank << " iter " << iter
+              << " chunk from rank " << r << " element " << i;
+        }
+      }
+    }
+  }
+
+  // Verify no GPE resource leak
+  for (int c = 0; c < kComms; c++) {
+    ASSERT_EQ(comms[c]->ctran_->gpe->numInUseKernelElems(), 0);
+    ASSERT_EQ(comms[c]->ctran_->gpe->numInUseKernelFlags(), 0);
+  }
+
+  // Cleanup
+  for (int c = 0; c < kComms; c++) {
+    ASSERT_EQ(ctran::allGatherWinDestroy(requests[c]), commSuccess);
+    delete requests[c];
+    CUDACHECK_TEST(cudaFree(sendbufs[c]));
+    ASSERT_EQ(ctranWinFree(wins[c]), commSuccess);
+    CUDACHECK_TEST(cudaFree(winBases[c]));
+  }
+
+  comms.clear();
+
+  for (int c = 0; c < kComms; c++) {
+    CUDACHECK_TEST(cudaStreamDestroy(streams[c]));
+  }
+}
+
 class CtranWinAllGatherTestEnv : public ctran::CtranEnvironmentBase {
  public:
   void SetUp() override {


### PR DESCRIPTION
Summary:

Window-based allGatherP init was running entirely on the user thread, which is susceptible to the same init-vs-exec race on the mapper epoch lock that D76792218 fixed for regular allGatherP. This moves the window init's remote info population to the GPE thread, following the same pattern: a GPE callback (`populateWinPArgs`) populates pArgs from the window's already-exchanged remote info and sets the `initialized` flag, while the `ncclKernelAllGatherPInit` stub kernel holds the stream. The existing `waitInit()` in execDirect/execPipeline ensures execution waits for the async init to complete.

Reviewed By: tianfengfrank

Differential Revision: D101075857
