### PR TITLE
Torchcomms Python test for cudagraph-aware AllGather auto-conversion

### DIFF
--- a/comms/ctran/Ctran.cc
+++ b/comms/ctran/Ctran.cc
@@ -155,6 +155,8 @@ CtranComm::CtranComm(std::shared_ptr<Abort> abort, ctranConfig commConfig)
 }
 
 void CtranComm::destroy() {
+  cudagraphDeferredCleanup.runAll();
+
   // All smart pointers are automatically de-initialized, but we want to
   // ensure they do so in a specific order. Therefore, we manually handle
   // their de-initialization here.

--- a/comms/ctran/Ctran.h
+++ b/comms/ctran/Ctran.h
@@ -75,7 +75,10 @@ commResult_t ctranGroupEndHook(
     enum NCCL_SENDRECV_ALGO algo,
     std::optional<std::chrono::milliseconds> timeout = std::nullopt);
 
-bool ctranAllGatherSupport(CtranComm* comm, enum NCCL_ALLGATHER_ALGO algo);
+bool ctranAllGatherSupport(
+    CtranComm* comm,
+    enum NCCL_ALLGATHER_ALGO algo,
+    cudaStream_t stream = nullptr);
 commResult_t ctranAllGather(
     const void* sendbuff,
     void* recvbuff,

--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -5,6 +5,8 @@
 #include <atomic>
 #include <chrono>
 #include <cstdint>
+#include <functional>
+#include <vector>
 
 #include <folly/Synchronized.h>
 #include "comms/ctran/bootstrap/ICtranBootstrap.h"
@@ -180,6 +182,27 @@ class CtranComm {
 #if defined(ENABLE_PIPES)
   std::unique_ptr<comms::pipes::MultiPeerTransport> multiPeerTransport_;
 #endif // defined(ENABLE_PIPES)
+
+  // Deferred cleanup for CUDA graph resources. CUDA user-object destructor
+  // callbacks cannot call CUDA APIs, so cleanup is enqueued here and
+  // executed at comm destruction where CUDA APIs are safe.
+  class CudagraphDeferredCleanup {
+   public:
+    void add(std::function<void()> fn) {
+      fns_.wlock()->push_back(std::move(fn));
+    }
+    void runAll() {
+      auto fns = fns_.wlock();
+      for (auto& fn : *fns) {
+        fn();
+      }
+      fns->clear();
+    }
+
+   private:
+    folly::Synchronized<std::vector<std::function<void()>>> fns_;
+  };
+  CudagraphDeferredCleanup cudagraphDeferredCleanup;
 
  private:
   // TODO: define proper constructor to make CtranComm be independent of

--- a/comms/ctran/algos/AllGather/AllGather.cc
+++ b/comms/ctran/algos/AllGather/AllGather.cc
@@ -1,15 +1,20 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 // #include <mutex>
+#include "comms/ctran/Ctran.h"
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/AllGather/AllGatherImpl.h"
 #include "comms/ctran/mapper/CtranMapper.h"
+#include "comms/ctran/utils/CudaGraphUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
 // Check if CTRAN is supported and if a specific algo is supported by CTRAN.
 // If user sets a specific algo, it should check to avoid unexpected abort in
 // ctranAllGather.
-bool ctranAllGatherSupport(CtranComm* comm, enum NCCL_ALLGATHER_ALGO algo) {
+bool ctranAllGatherSupport(
+    CtranComm* comm,
+    enum NCCL_ALLGATHER_ALGO algo,
+    cudaStream_t stream) {
   if (!ctranInitialized(comm) || !comm->ctran_->mapper->hasBackend()) {
     return false;
   }
@@ -33,6 +38,26 @@ bool ctranAllGatherSupport(CtranComm* comm, enum NCCL_ALLGATHER_ALGO algo) {
     case NCCL_ALLGATHER_ALGO::ctran:
       supported = true;
       break;
+    case NCCL_ALLGATHER_ALGO::ctgraph: {
+      if (stream == nullptr) {
+        supported = false;
+        break;
+      }
+      ctran::utils::cudagraph::StreamCaptureInfo captureInfo;
+      auto err =
+          ctran::utils::cudagraph::getStreamCaptureInfo(stream, captureInfo);
+      supported = (err == cudaSuccess) &&
+          (captureInfo.status == cudaStreamCaptureStatusActive) &&
+          ctran::allGatherPSupport(comm);
+      if (!supported) {
+        CLOGF_SUBSYS(
+            INFO,
+            COLL,
+            "AllGather ctgraph: not in capture mode or AGP not supported. "
+            "Falling back to baseline");
+      }
+      break;
+    }
     case NCCL_ALLGATHER_ALGO::orig: // invalid query
       supported = false;
       break;
@@ -49,11 +74,25 @@ commResult_t ctranAllGather(
     CtranComm* comm,
     cudaStream_t stream,
     enum NCCL_ALLGATHER_ALGO algo) {
+  // Cudagraph-aware optimization: when capturing and AGP is supported,
+  // transparently convert to the persistent window-based AGP algorithm.
+  if (algo == NCCL_ALLGATHER_ALGO::ctgraph) {
+    ctran::utils::cudagraph::StreamCaptureInfo captureInfo;
+    FB_CUDACHECK(
+        ctran::utils::cudagraph::getStreamCaptureInfo(stream, captureInfo));
+    if (captureInfo.status == cudaStreamCaptureStatusActive &&
+        ctran::allGatherPSupport(comm)) {
+      return ctranAllGatherCudagraphAware(
+          sendbuff, recvbuff, sendcount, datatype, comm, stream);
+    }
+  }
+
   const auto statex = comm->statex_.get();
 
   // Only ctdirect supports nLocalRanks>1 case.
   // Force to use ctdirect if nLocalRanks>1.
-  if (algo == NCCL_ALLGATHER_ALGO::ctran) {
+  if (algo == NCCL_ALLGATHER_ALGO::ctran ||
+      algo == NCCL_ALLGATHER_ALGO::ctgraph) {
     if (statex->nLocalRanks() > 1) {
       algo = NCCL_ALLGATHER_ALGO::ctdirect;
       CLOGF_SUBSYS(

--- a/comms/ctran/algos/AllGather/AllGatherCudagraphAware.cc
+++ b/comms/ctran/algos/AllGather/AllGatherCudagraphAware.cc
@@ -1,0 +1,100 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// Cudagraph-aware AllGather: when a regular ctranAllGather() is called during
+// CUDA graph capture and this path is enabled, the collective is transparently
+// converted to the persistent AllGatherP (window-based) algorithm.
+//
+// Flow:
+//   1. ctranWinRegister() — register recvbuff as a window, exchange handles
+//      with all peers. This is a collective CPU-side operation and is NOT
+//      captured into the graph.
+//   2. allGatherWinInit() — create persistent AGP state from window metadata.
+//      Synchronous, no async handle exchange needed. Uses
+//      cudaThreadExchangeStreamCaptureMode to temporarily allow cudaHostAlloc
+//      (blocked under cudaStreamCaptureModeGlobal used by PyTorch).
+//   3. allGatherWinExec() — dry-run exec that IS captured into the graph.
+//      CE copies (NVL intra-node) and GPE host-node callbacks (IB inter-node)
+//      are recorded as graph nodes.
+//   4. Register cleanup on comm's cudagraphDeferredCleanup.
+//
+// On graph replay, only the captured CE + host-node operations re-execute.
+// The result is SM-free replay (no GPU kernels for NVL copies).
+//
+// Cleanup: Resources are registered for deferred cleanup at capture time
+// (not at graph destruction). This ensures cleanup runs during comm
+// destruction on the main thread, regardless of when or whether the graph
+// is destroyed. Graph replay is guaranteed to finish before comm destroy.
+
+#include <folly/ScopeGuard.h>
+
+#include "comms/ctran/Ctran.h"
+#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/algos/AllGather/AllGatherImpl.h"
+#include "comms/ctran/algos/CtranAlgo.h"
+#include "comms/ctran/utils/CudaGraphUtils.h"
+#include "comms/ctran/window/CtranWin.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+
+commResult_t ctranAllGatherCudagraphAware(
+    const void* sendbuff,
+    void* recvbuff,
+    size_t sendcount,
+    commDataType_t datatype,
+    CtranComm* comm,
+    cudaStream_t stream) {
+  const auto statex = comm->statex_.get();
+  const int nRanks = statex->nRanks();
+  const size_t recvBytes = sendcount * commTypeSize(datatype) * nRanks;
+
+  CLOGF_SUBSYS(
+      INFO,
+      COLL,
+      "AllGather cudagraph-aware: converting to window-based AGP "
+      "(sendcount={}, nRanks={}, recvBytes={})",
+      sendcount,
+      nRanks,
+      recvBytes);
+
+  // 1. Register recvbuff as a window and exchange handles with all peers.
+  //    Collective and CPU-side — NOT captured into the graph.
+  ctran::CtranWin* win = nullptr;
+  FB_COMMCHECK(ctran::ctranWinRegister(recvbuff, recvBytes, comm, &win));
+
+  // 2. Init persistent AGP from window metadata.
+  //    Switch to relaxed capture mode so initResources() can cudaHostAlloc
+  //    (blocked under cudaStreamCaptureModeGlobal used by PyTorch).
+  //    Single-threaded-per-comm assumption (standard for NCCL).
+  auto winGuard = folly::makeGuard([win]() { delete win; });
+
+  cudaStreamCaptureMode prevMode = cudaStreamCaptureModeRelaxed;
+  FB_CUDACHECK(cudaThreadExchangeStreamCaptureMode(&prevMode));
+
+  CtranPersistentRequest* request = nullptr;
+  // Store result instead of FB_COMMCHECK — must restore capture mode before
+  // any early return.
+  auto initResult = ctran::allGatherWinInit(win, comm, stream, request);
+
+  FB_CUDACHECK(cudaThreadExchangeStreamCaptureMode(&prevMode));
+  FB_COMMCHECK(initResult);
+
+  // 3. Dry-run exec — CE copies and GPE host-node callbacks are captured.
+  FB_COMMCHECK(ctran::allGatherWinExec(sendbuff, sendcount, datatype, request));
+
+  // 4. Register cleanup on comm at capture time. Resources live for the
+  //    comm's lifetime and are cleaned up during CtranComm::destroy() on
+  //    the main thread. This avoids depending on retainUserObject callbacks
+  //    which run on CUDA's internal thread where CUDA APIs are forbidden.
+  winGuard.dismiss();
+  comm->cudagraphDeferredCleanup.add([request, win]() {
+    if (request) {
+      ctran::allGatherWinDestroy(request);
+      delete request;
+    }
+    if (win) {
+      win->free(true /* skipBarrier */);
+      delete win;
+    }
+  });
+
+  return commSuccess;
+}

--- a/comms/ctran/algos/AllGather/AllGatherImpl.h
+++ b/comms/ctran/algos/AllGather/AllGatherImpl.h
@@ -53,12 +53,24 @@ static inline const std::string allGatherAlgoName(
       return "CtranBrucksFF";
     case NCCL_ALLGATHER_ALGO::ctran:
       return "CtranAuto";
+    case NCCL_ALLGATHER_ALGO::ctgraph:
+      return "CtranCudagraphAware";
     case NCCL_ALLGATHER_ALGO::orig:
       return "Baseline";
     default:
       return "Unknown";
   }
 }
+
+// Cudagraph-aware path: transparently converts a regular allgather to the
+// persistent window-based AGP algorithm during CUDA graph capture.
+commResult_t ctranAllGatherCudagraphAware(
+    const void* sendbuff,
+    void* recvbuff,
+    size_t sendcount,
+    commDataType_t datatype,
+    CtranComm* comm,
+    cudaStream_t stream);
 
 commResult_t prepareAllGatherArgs(
     std::vector<std::unique_ptr<struct OpElem>>& opGroup,

--- a/comms/ctran/algos/CtranAlgo.cc
+++ b/comms/ctran/algos/CtranAlgo.cc
@@ -630,7 +630,8 @@ static const std::unordered_map<std::string, enum NCCL_ALLGATHER_ALGO>
         {"ctdirect", NCCL_ALLGATHER_ALGO::ctdirect},
         {"ctring", NCCL_ALLGATHER_ALGO::ctring},
         {"ctrd", NCCL_ALLGATHER_ALGO::ctrd},
-        {"ctbrucks", NCCL_ALLGATHER_ALGO::ctbrucks}};
+        {"ctbrucks", NCCL_ALLGATHER_ALGO::ctbrucks},
+        {"ctgraph", NCCL_ALLGATHER_ALGO::ctgraph}};
 
 commResult_t ctranConfigCommAlgoOverride(CtranComm* comm) {
   if (!ctranInitialized(comm)) {

--- a/comms/ctran/tests/cudagraph/CtranCudaGraphAllGatherCtgraphTest.cc
+++ b/comms/ctran/tests/cudagraph/CtranCudaGraphAllGatherCtgraphTest.cc
@@ -1,0 +1,120 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// Tests for the ctgraph AllGather algorithm.
+// When algo=ctgraph, ctranAllGatherSupport returns true only during CUDA graph
+// capture (and falls back to baseline otherwise). During capture,
+// ctranAllGather transparently converts to the persistent window-based AGP
+// algorithm.
+
+#include "comms/ctran/algos/AllGather/AllGatherImpl.h"
+#include "comms/ctran/tests/cudagraph/CtranCudaGraphParamTest.h"
+
+static AlgoDescriptor makeAllGatherCtgraph() {
+  struct B : AlgoDescriptor::Buffers {
+    ctran::TestDeviceBuffer send, recv;
+    size_t bytes;
+    B(size_t c, int rank, int nR)
+        : send(c * sizeof(int32_t)),
+          recv(c * nR * sizeof(int32_t)),
+          bytes(c * nR * sizeof(int32_t)) {
+      CtranCudaGraphTestBase::fillSendBuf(send.get(), c, rank);
+    }
+    void* sendbuf() override {
+      return send.get();
+    }
+    void* recvbuf() override {
+      return recv.get();
+    }
+    size_t recvBytes() override {
+      return bytes;
+    }
+  };
+
+  AlgoDescriptor desc;
+  desc.name = "AllGatherCtgraph";
+  desc.isSupported = [](CtranComm* comm, size_t, int) {
+    return ctran::allGatherPSupport(comm);
+  };
+  desc.expectsHostNodes = [](CtranComm* comm, size_t) {
+    auto statex = comm->statex_.get();
+    return statex->nLocalRanks() < statex->nRanks();
+  };
+  desc.makeBuffers = [](size_t c, int rank, int nR) {
+    return std::make_shared<B>(c, rank, nR);
+  };
+  desc.capture = [](AlgoDescriptor::Buffers* base,
+                    size_t count,
+                    ctran::testing::CaptureContext& ctx) {
+    auto* b = static_cast<B*>(base);
+    ASSERT_EQ(
+        ctranAllGather(
+            b->send.get(),
+            b->recv.get(),
+            count,
+            commInt32,
+            ctx.comm,
+            ctx.stream,
+            NCCL_ALLGATHER_ALGO::ctgraph),
+        commSuccess);
+  };
+  return desc;
+}
+
+DEFINE_CUDAGRAPH_PARAM_TEST(CudaGraphAllGatherCtgraph, makeAllGatherCtgraph());
+
+// Verifies that graph destruction cleans up without CUDA API errors.
+// The retainUserObject destructor callback defers cleanup to comm destruction
+// since CUDA APIs are forbidden in the callback context.
+class CudaGraphAllGatherCtgraphDestroy : public CtranCudaGraphTestBase {};
+
+TEST_F(CudaGraphAllGatherCtgraphDestroy, DestroyGraphCleanly) {
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+
+  if (!ctran::allGatherPSupport(comm.get())) {
+    GTEST_SKIP() << "allGatherP not supported";
+  }
+
+  const size_t count = 1024;
+  const int nRanks = numRanks;
+  ctran::TestDeviceBuffer send(count * sizeof(int32_t));
+  ctran::TestDeviceBuffer recv(count * nRanks * sizeof(int32_t));
+  fillSendBuf(send.get(), count, globalRank);
+
+  meta::comms::CudaStream stream(cudaStreamNonBlocking);
+
+  // Capture
+  cudaGraph_t graph;
+  cudaGraphExec_t exec;
+  ASSERT_EQ(
+      cudaStreamBeginCapture(stream.get(), cudaStreamCaptureModeGlobal),
+      cudaSuccess);
+  ASSERT_EQ(
+      ctranAllGather(
+          send.get(),
+          recv.get(),
+          count,
+          commInt32,
+          comm.get(),
+          stream.get(),
+          NCCL_ALLGATHER_ALGO::ctgraph),
+      commSuccess);
+  ASSERT_EQ(cudaStreamEndCapture(stream.get(), &graph), cudaSuccess);
+  ASSERT_EQ(cudaGraphInstantiate(&exec, graph, 0), cudaSuccess);
+
+  // Replay
+  ASSERT_EQ(cudaGraphLaunch(exec, stream.get()), cudaSuccess);
+  ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
+
+  // Destroy — triggers retainUserObject destructor callback.
+  ASSERT_EQ(cudaGraphExecDestroy(exec), cudaSuccess);
+  ASSERT_EQ(cudaGraphDestroy(graph), cudaSuccess);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+}
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new CtranCudaGraphEnvironment);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ctran/window/CtranWin.h
+++ b/comms/ctran/window/CtranWin.h
@@ -129,7 +129,7 @@ struct CtranWin {
   }
 #endif
 
-  commResult_t free();
+  commResult_t free(bool skipBarrier = false);
 
   bool nvlEnabled(int rank) const;
 

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -221,7 +221,7 @@ commResult_t CtranWin::allocate(void* userBufPtr) {
   return commSuccess;
 }
 
-commResult_t CtranWin::free() {
+commResult_t CtranWin::free(bool skipBarrier) {
   auto statex = comm->statex_.get();
   if (statex == nullptr) {
     FB_ERRORRETURN(commInternalError, "Empty communicator statex.");
@@ -239,11 +239,14 @@ commResult_t CtranWin::free() {
       statex->commHash());
 
   // A barrier among ranks before freeing window to prevent peer ranks accessing
-  // the window after it is freed.
+  // the window after it is freed. Skipped when called from deferred cleanup at
+  // comm destruction (all communication is already finalized).
   // NOTE: the window object is not aware of CUDA streams, users need to
   // ensure the host process waits for CUDA streams where put/wait operations
   // are launched.
-  FB_COMMCHECK(mapper->barrier());
+  if (!skipBarrier) {
+    FB_COMMCHECK(mapper->barrier());
+  }
 
   auto nRanks = statex->nRanks();
 

--- a/comms/ncclx/meta/algoconf/AlgoConfig.cc
+++ b/comms/ncclx/meta/algoconf/AlgoConfig.cc
@@ -48,6 +48,8 @@ inline const std::string algoValToStr(enum NCCL_ALLGATHER_ALGO val) {
       return "ctrd";
     case NCCL_ALLGATHER_ALGO::ctbrucks:
       return "ctbrucks";
+    case NCCL_ALLGATHER_ALGO::ctgraph:
+      return "ctgraph";
       break;
   }
 }
@@ -65,6 +67,8 @@ inline void algoStrToVal(
     val = NCCL_ALLGATHER_ALGO::ctrd;
   } else if (str == "ctbrucks") {
     val = NCCL_ALLGATHER_ALGO::ctbrucks;
+  } else if (str == "ctgraph") {
+    val = NCCL_ALLGATHER_ALGO::ctgraph;
   } else {
     val = NCCL_ALLGATHER_ALGO::orig;
   }

--- a/comms/ncclx/v2_27/src/collectives.cc
+++ b/comms/ncclx/v2_27/src/collectives.cc
@@ -95,7 +95,7 @@ ncclResult_t ncclAllGather(const void* sendbuff, void* recvbuff, size_t sendcoun
 
   auto algo = ncclx::algoconf::getAllGatherAlgo();
 
-  if (algo != NCCL_ALLGATHER_ALGO::orig && ctranAllGatherSupport(comm->ctranComm_.get(), algo)) {
+  if (algo != NCCL_ALLGATHER_ALGO::orig && ctranAllGatherSupport(comm->ctranComm_.get(), algo, stream)) {
     return metaCommToNccl(ctranAllGather(
         sendbuff, recvbuff, sendcount, ncclToMetaComm(datatype), comm->ctranComm_.get(), stream, algo));
   }

--- a/comms/ncclx/v2_28/src/collectives.cc
+++ b/comms/ncclx/v2_28/src/collectives.cc
@@ -98,7 +98,7 @@ ncclResult_t ncclAllGather(const void* sendbuff, void* recvbuff, size_t sendcoun
 
   auto algo = ncclx::algoconf::getAllGatherAlgo();
 
-  if (algo != NCCL_ALLGATHER_ALGO::orig && ctranAllGatherSupport(comm->ctranComm_.get(), algo)) {
+  if (algo != NCCL_ALLGATHER_ALGO::orig && ctranAllGatherSupport(comm->ctranComm_.get(), algo, stream)) {
     return metaCommToNccl(ctranAllGather(
         sendbuff, recvbuff, sendcount, ncclToMetaComm(datatype), comm->ctranComm_.get(), stream, algo));
   }

--- a/comms/ncclx/v2_29/src/collectives.cc
+++ b/comms/ncclx/v2_29/src/collectives.cc
@@ -102,7 +102,7 @@ ncclResult_t ncclAllGather(const void* sendbuff, void* recvbuff, size_t sendcoun
 
   auto algo = ncclx::algoconf::getAllGatherAlgo();
 
-  if (algo != NCCL_ALLGATHER_ALGO::orig && ctranAllGatherSupport(comm->ctranComm_.get(), algo)) {
+  if (algo != NCCL_ALLGATHER_ALGO::orig && ctranAllGatherSupport(comm->ctranComm_.get(), algo, stream)) {
     return metaCommToNccl(ctranAllGather(
         sendbuff, recvbuff, sendcount, ncclToMetaComm(datatype), comm->ctranComm_.get(), stream, algo));
   }

--- a/comms/torchcomms/tests/integration/py/CudaGraphsAllGatherAwareTest.py
+++ b/comms/torchcomms/tests/integration/py/CudaGraphsAllGatherAwareTest.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+# pyre-unsafe
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Tests for cudagraph-aware AllGather auto-conversion to AGP.
+
+When NCCL_ALLGATHER_ALGO=ctgraph, a regular all_gather_single() call during
+CUDA graph capture is transparently converted to the persistent window-based
+AGP algorithm (SM-free CE+IB). These tests verify correct data after graph
+replay.
+
+To collect Kineto traces, set TORCH_PROFILE_DIR to an output directory:
+  TORCH_PROFILE_DIR=/tmp/traces buck2 run ...
+Traces are written as <test_name>_rank<N>.json per rank.
+"""
+
+import contextlib
+import os
+import unittest
+
+import torch
+import torchcomms  # noqa: F401 — side-effect import registers ncclx backend
+
+# pyre-fixme[21]: Could not find name `ProfilerActivity` in `torch.profiler`.
+from torch.profiler import profile, ProfilerActivity
+from torchcomms.tests.helpers.py.cuda_graph_test_helpers import (
+    _wait,
+    CudaGraphTestBase,
+    GraphTestBuilder,
+    skip_unless_ncclx,
+)
+from torchcomms.tests.integration.py.TorchCommTestHelpers import get_rank_and_size
+
+
+class TestAllGatherCudaGraphAware(CudaGraphTestBase):
+    """Tests that regular all_gather_single auto-converts to AGP under
+    CUDA graph capture when NCCL_ALLGATHER_ALGO=ctgraph."""
+
+    NUM_REPLAYS = 3
+    ELEM_COUNT = 1024
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        os.environ["NCCL_CTRAN_ALLOW_CUDA_GRAPH"] = "1"
+        os.environ["NCCL_ALLGATHER_ALGO"] = "ctgraph"
+        os.environ.setdefault("NCCL_DEBUG", "INFO")
+        os.environ.setdefault("NCCL_DEBUG_SUBSYS", "COLL")
+        super().setUpClass()
+
+    @skip_unless_ncclx
+    def test_allgather_cudagraph_aware(self) -> None:
+        """Capture a regular all_gather_single into a CUDA graph and verify
+        correct results on replay. The ctgraph algo transparently converts
+        it to window-based AGP.
+
+        Set TORCH_PROFILE_DIR to collect Kineto traces (handled by
+        GraphTestBuilder internally).
+        """
+
+        def make_inputs(b: GraphTestBuilder) -> list[torch.Tensor]:
+            rank = b.comms[0].get_rank()
+            size = b.comms[0].get_size()
+            sendbuf = (
+                torch.ones(self.ELEM_COUNT, dtype=torch.float32, device=self.device)
+                * rank
+            )
+            recvbuf = torch.zeros(
+                self.ELEM_COUNT * size, dtype=torch.float32, device=self.device
+            )
+            return [sendbuf, recvbuf]
+
+        def capture(b: GraphTestBuilder) -> None:
+            _wait(b.comms[0].all_gather_single(b.inputs[1], b.inputs[0], async_op=True))
+
+        def make_expected(b: GraphTestBuilder) -> list[torch.Tensor]:
+            size = b.comms[0].get_size()
+            sendbuf = b.inputs[0].clone()
+            recvbuf = torch.cat(
+                [
+                    torch.ones(self.ELEM_COUNT, dtype=torch.float32, device=self.device)
+                    * r
+                    for r in range(size)
+                ]
+            )
+            return [sendbuf, recvbuf]
+
+        GraphTestBuilder(self).add_capture(capture).run_serial(
+            inputs=make_inputs,
+            expected=make_expected,
+        )
+
+    @skip_unless_ncclx
+    def test_allgather_cudagraph_aware_changing_data(self) -> None:
+        """Verify graph replay picks up modified sendbuf data each iteration,
+        confirming the auto-converted AGP re-reads from the same address.
+
+        Set TORCH_PROFILE_DIR to collect Kineto traces.
+        """
+        rank, _ = get_rank_and_size()
+        profile_dir = os.environ.get("TORCH_PROFILE_DIR")
+
+        with self.create_comms(1) as comms:
+            comm = comms[0]
+            size = comm.get_size()
+            count = self.ELEM_COUNT
+
+            sendbuf = torch.zeros(count, dtype=torch.float32, device=self.device)
+            recvbuf = torch.zeros(count * size, dtype=torch.float32, device=self.device)
+
+            # Wrap everything in the profiler so the trace shows:
+            #   1. Eager warmup allgathers (regular NCCL kernel path)
+            #   2. Graph capture (auto-converts to AGP)
+            #   3. Graph replays (SM-free CE+host-node replay)
+            profile_ctx = (
+                # pyre-fixme[16]: Module `torch.profiler` has no attribute `ProfilerActivity`.
+                profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA])
+                if profile_dir
+                else contextlib.nullcontext()
+            )
+            with profile_ctx as prof:
+                # Eager warmup: run a few regular allgathers before capture
+                # so the profile shows the contrast with AGP graph replay.
+                NUM_WARMUP = 3
+                for _ in range(NUM_WARMUP):
+                    sendbuf.fill_(float(rank))
+                    _wait(comm.all_gather_single(recvbuf, sendbuf, async_op=True))
+                torch.cuda.synchronize()
+
+                # Graph capture: allgather auto-converts to AGP here
+                graph = torch.cuda.CUDAGraph()
+                with torch.cuda.graph(graph):
+                    _wait(comm.all_gather_single(recvbuf, sendbuf, async_op=True))
+
+                comm.barrier(False)
+
+                # Graph replay
+                for replay in range(self.NUM_REPLAYS):
+                    val = float(rank * 100 + replay)
+                    sendbuf.fill_(val)
+                    recvbuf.zero_()
+                    torch.cuda.synchronize()
+                    comm.barrier(False)
+
+                    graph.replay()
+                    torch.cuda.synchronize()
+                    comm.barrier(False)
+
+                    for r in range(size):
+                        expected_val = float(r * 100 + replay)
+                        chunk = recvbuf[r * count : (r + 1) * count]
+                        expected = torch.full(
+                            (count,),
+                            expected_val,
+                            dtype=torch.float32,
+                            device=self.device,
+                        )
+                        torch.testing.assert_close(
+                            chunk,
+                            expected,
+                            rtol=1e-5,
+                            atol=1e-5,
+                            msg=(
+                                f"Replay {replay}: rank {rank} expected {expected_val} "
+                                f"from rank {r}, got {chunk[:4].tolist()}"
+                            ),
+                        )
+
+            if profile_dir and prof:
+                os.makedirs(profile_dir, exist_ok=True)
+                trace_path = os.path.join(
+                    profile_dir,
+                    f"test_allgather_cudagraph_aware_changing_data_rank{rank}.json",
+                )
+                prof.export_chrome_trace(trace_path)
+
+            graph.reset()
+            torch.cuda.synchronize()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2014,7 +2014,7 @@ cvars:
  - name        : NCCL_ALLGATHER_ALGO
    type        : enum
    default     : orig
-   choices     : orig, ctran, ctdirect, ctring, ctrd, ctbrucks
+   choices     : orig, ctran, ctdirect, ctring, ctrd, ctbrucks, ctgraph
    description : |-
      The algorithm to use for Allgather communication
      orig - Copy-based ring algorithm
@@ -2022,6 +2022,7 @@ cvars:
      ctdirect - Ctran-based direct point-to-point algorithm
      ctring - Ctran-based ring algorithm
      ctrd - Ctran-based recursive doubling algorithm
+     ctgraph - Cudagraph-aware: uses ctran persistent AGP during graph capture, falls back to baseline otherwise
 
  - name        : NCCL_REDUCESCATTER_ALGO
    type        : enum


### PR DESCRIPTION
Summary:
Adds CudaGraphsAllGatherAwareTest with two test cases:
- test_allgather_cudagraph_aware: captures a regular all_gather_single() into a CUDA graph via GraphTestBuilder and verifies correct results on replay. The CVAR transparently converts the allgather to window-based AGP.
- test_allgather_cudagraph_aware_changing_data: runs eager warmup allgathers before graph capture, then captures and replays with changing data. The Kineto trace (when TORCH_PROFILE_DIR is set) shows the ctdirect path in warmup followed by SM-free AGP graph replay.

Requires NCCL_CTRAN_ALLGATHER_CUDAGRAPH_AWARE_ENABLE=1, NCCL_ALLGATHER_ALGO=ctran, and NCCL_CTRAN_ALLOW_CUDA_GRAPH=1 (all set in setUpClass).

Verified with NCCL_DEBUG=INFO that the conversion log appears on all 8 ranks:
AllGatherCudagraphAware.cc:72: AllGather cudagraph-aware: converting to window-based AGP (sendcount=1024, nRanks=8, recvBytes=32768)

Reviewed By: minsii

Differential Revision: D101000942


