### PR TITLE
Add TEST_FULL_SWEEP to reduce CI test iterations

### DIFF
--- a/comms/torchcomms/tests/integration/cpp/AllGatherSingleTestMain.cpp
+++ b/comms/torchcomms/tests/integration/cpp/AllGatherSingleTestMain.cpp
@@ -91,8 +91,12 @@ TEST_P(MultiGraph, InputDeleted) {
 
 auto allGatherSingleParamValues() {
   return ::testing::Combine(
+#if TEST_FULL_SWEEP
       ::testing::Values(0, 4, 1024, 1024 * 1024),
       ::testing::Values(at::kFloat, at::kInt, at::kChar));
+#else
+      ::testing::Values(4, 1024 * 1024), ::testing::Values(at::kFloat));
+#endif
 }
 
 auto allGatherSingleGraphParamValues() {

--- a/comms/torchcomms/tests/integration/cpp/AllGatherTestMain.cpp
+++ b/comms/torchcomms/tests/integration/cpp/AllGatherTestMain.cpp
@@ -89,8 +89,12 @@ TEST_P(MultiGraph, InputDeleted) {
 
 auto allGatherParamValues() {
   return ::testing::Combine(
+#if TEST_FULL_SWEEP
       ::testing::Values(0, 4, 1024, 1024 * 1024),
       ::testing::Values(at::kFloat, at::kInt, at::kChar));
+#else
+      ::testing::Values(4, 1024 * 1024), ::testing::Values(at::kFloat));
+#endif
 }
 
 auto allGatherGraphParamValues() {

--- a/comms/torchcomms/tests/integration/cpp/AllGatherVTestMain.cpp
+++ b/comms/torchcomms/tests/integration/cpp/AllGatherVTestMain.cpp
@@ -90,8 +90,12 @@ TEST_P(MultiGraph, InputDeleted) {
 
 auto allGatherVParamValues() {
   return ::testing::Combine(
+#if TEST_FULL_SWEEP
       ::testing::Values(0, 4, 1024, 1024 * 1024),
       ::testing::Values(at::kFloat, at::kInt, at::kChar));
+#else
+      ::testing::Values(4, 1024 * 1024), ::testing::Values(at::kFloat));
+#endif
 }
 
 auto allGatherVGraphParamValues() {

--- a/comms/torchcomms/tests/integration/cpp/AllReducePreMulSumTestMain.cpp
+++ b/comms/torchcomms/tests/integration/cpp/AllReducePreMulSumTestMain.cpp
@@ -110,14 +110,23 @@ TEST_P(MultiGraph, InputDeleted) {
 
 auto allReducePreMulSumScalarParams() {
   return ::testing::Combine(
+#if TEST_FULL_SWEEP
       ::testing::Values(0, 4, 1024, 1024 * 1024),
       ::testing::Values(at::kHalf, at::kFloat, at::kDouble),
+#else
+      ::testing::Values(4, 1024 * 1024),
+      ::testing::Values(at::kFloat),
+#endif
       ::testing::Values(PreMulSumOpType::kScalar));
 }
 
 auto allReducePreMulSumBf16TensorParams() {
   return ::testing::Combine(
+#if TEST_FULL_SWEEP
       ::testing::Values(0, 4, 1024, 1024 * 1024),
+#else
+      ::testing::Values(4, 1024 * 1024),
+#endif
       ::testing::Values(at::kBFloat16),
       ::testing::Values(PreMulSumOpType::kTensor));
 }

--- a/comms/torchcomms/tests/integration/cpp/AllReduceTestMain.cpp
+++ b/comms/torchcomms/tests/integration/cpp/AllReduceTestMain.cpp
@@ -102,12 +102,18 @@ TEST_P(MultiGraph, InputDeleted) {
 
 auto allReduceParamValues() {
   return ::testing::Combine(
+#if TEST_FULL_SWEEP
       ::testing::Values(0, 4, 1024, 1024 * 1024),
       ::testing::Values(at::kFloat, at::kInt, at::kChar),
       ::testing::Values(
           torch::comms::ReduceOp::SUM,
           torch::comms::ReduceOp::MAX,
           torch::comms::ReduceOp::AVG));
+#else
+      ::testing::Values(4, 1024 * 1024),
+      ::testing::Values(at::kFloat),
+      ::testing::Values(torch::comms::ReduceOp::SUM));
+#endif
 }
 
 auto allReduceGraphParamValues() {

--- a/comms/torchcomms/tests/integration/cpp/AllToAllSingleTestMain.cpp
+++ b/comms/torchcomms/tests/integration/cpp/AllToAllSingleTestMain.cpp
@@ -91,8 +91,12 @@ TEST_P(MultiGraph, InputDeleted) {
 
 auto allToAllSingleParamValues() {
   return ::testing::Combine(
+#if TEST_FULL_SWEEP
       ::testing::Values(0, 4, 1024, 1024 * 1024),
       ::testing::Values(at::kFloat, at::kInt, at::kChar));
+#else
+      ::testing::Values(4, 1024 * 1024), ::testing::Values(at::kFloat));
+#endif
 }
 
 auto allToAllSingleGraphParamValues() {

--- a/comms/torchcomms/tests/integration/cpp/AllToAllTestMain.cpp
+++ b/comms/torchcomms/tests/integration/cpp/AllToAllTestMain.cpp
@@ -89,8 +89,12 @@ TEST_P(MultiGraph, InputDeleted) {
 
 auto allToAllParamValues() {
   return ::testing::Combine(
+#if TEST_FULL_SWEEP
       ::testing::Values(0, 4, 1024, 1024 * 1024),
       ::testing::Values(at::kFloat, at::kInt, at::kChar));
+#else
+      ::testing::Values(4, 1024 * 1024), ::testing::Values(at::kFloat));
+#endif
 }
 
 auto allToAllGraphParamValues() {

--- a/comms/torchcomms/tests/integration/cpp/AllToAllvSingleTestMain.cpp
+++ b/comms/torchcomms/tests/integration/cpp/AllToAllvSingleTestMain.cpp
@@ -114,6 +114,7 @@ TEST_P(MultiGraph, InputDeleted) {
 auto allToAllvSingleParamValues() {
   static std::vector<AllToAllvSingleParams> params = []() {
     std::vector<AllToAllvSingleParams> p;
+#if TEST_FULL_SWEEP
     std::vector<at::ScalarType> dtypes = {at::kFloat, at::kInt, at::kChar};
 
     // Uniform pattern: full dtype coverage with two counts
@@ -127,6 +128,10 @@ auto allToAllvSingleParamValues() {
     p.emplace_back(AllToAllvSizePattern::ZeroSizes, 4, at::kFloat);
     p.emplace_back(AllToAllvSizePattern::AllZero, 0, at::kFloat);
     p.emplace_back(AllToAllvSizePattern::Asymmetric, 4, at::kFloat);
+#else
+    p.emplace_back(AllToAllvSizePattern::Uniform, 4, at::kFloat);
+    p.emplace_back(AllToAllvSizePattern::Uniform, 1024, at::kFloat);
+#endif
     return p;
   }();
   return ::testing::ValuesIn(params);

--- a/comms/torchcomms/tests/integration/cpp/BatchSendRecvTestMain.cpp
+++ b/comms/torchcomms/tests/integration/cpp/BatchSendRecvTestMain.cpp
@@ -89,7 +89,12 @@ TEST_P(MultiGraph, InputDeleted) {
 
 auto batchSendRecvParamValues() {
   return ::testing::Combine(
-      ::testing::Values(4), ::testing::Values(at::kFloat, at::kInt, at::kChar));
+      ::testing::Values(4),
+#if TEST_FULL_SWEEP
+      ::testing::Values(at::kFloat, at::kInt, at::kChar));
+#else
+      ::testing::Values(at::kFloat));
+#endif
 }
 
 auto batchSendRecvGraphParamValues() {

--- a/comms/torchcomms/tests/integration/cpp/BroadcastTestMain.cpp
+++ b/comms/torchcomms/tests/integration/cpp/BroadcastTestMain.cpp
@@ -89,8 +89,12 @@ TEST_P(MultiGraph, InputDeleted) {
 
 auto broadcastParamValues() {
   return ::testing::Combine(
+#if TEST_FULL_SWEEP
       ::testing::Values(0, 4, 1024, 1024 * 1024),
       ::testing::Values(at::kFloat, at::kInt, at::kChar));
+#else
+      ::testing::Values(4, 1024 * 1024), ::testing::Values(at::kFloat));
+#endif
 }
 
 auto broadcastGraphParamValues() {

--- a/comms/torchcomms/tests/integration/cpp/GatherTestMain.cpp
+++ b/comms/torchcomms/tests/integration/cpp/GatherTestMain.cpp
@@ -89,8 +89,12 @@ TEST_P(MultiGraph, InputDeleted) {
 
 auto gatherParamValues() {
   return ::testing::Combine(
+#if TEST_FULL_SWEEP
       ::testing::Values(0, 4, 1024, 1024 * 1024),
       ::testing::Values(at::kFloat, at::kInt, at::kChar));
+#else
+      ::testing::Values(4, 1024 * 1024), ::testing::Values(at::kFloat));
+#endif
 }
 
 auto gatherGraphParamValues() {

--- a/comms/torchcomms/tests/integration/cpp/ReduceScatterSingleTestMain.cpp
+++ b/comms/torchcomms/tests/integration/cpp/ReduceScatterSingleTestMain.cpp
@@ -105,12 +105,18 @@ TEST_P(MultiGraph, InputDeleted) {
 
 auto reduceScatterSingleParamValues() {
   return ::testing::Combine(
+#if TEST_FULL_SWEEP
       ::testing::Values(0, 4, 1024, 1024 * 1024),
       ::testing::Values(at::kFloat, at::kInt, at::kChar),
       ::testing::Values(
           torch::comms::ReduceOp::SUM,
           torch::comms::ReduceOp::MAX,
           torch::comms::ReduceOp::AVG));
+#else
+      ::testing::Values(4, 1024 * 1024),
+      ::testing::Values(at::kFloat),
+      ::testing::Values(torch::comms::ReduceOp::SUM));
+#endif
 }
 
 auto reduceScatterSingleGraphParamValues() {

--- a/comms/torchcomms/tests/integration/cpp/ReduceScatterTestMain.cpp
+++ b/comms/torchcomms/tests/integration/cpp/ReduceScatterTestMain.cpp
@@ -102,12 +102,18 @@ TEST_P(MultiGraph, InputDeleted) {
 
 auto reduceScatterParamValues() {
   return ::testing::Combine(
+#if TEST_FULL_SWEEP
       ::testing::Values(0, 4, 1024, 1024 * 1024),
       ::testing::Values(at::kFloat, at::kInt, at::kChar),
       ::testing::Values(
           torch::comms::ReduceOp::SUM,
           torch::comms::ReduceOp::MAX,
           torch::comms::ReduceOp::AVG));
+#else
+      ::testing::Values(4, 1024 * 1024),
+      ::testing::Values(at::kFloat),
+      ::testing::Values(torch::comms::ReduceOp::SUM));
+#endif
 }
 
 auto reduceScatterGraphParamValues() {

--- a/comms/torchcomms/tests/integration/cpp/ReduceScatterVTestMain.cpp
+++ b/comms/torchcomms/tests/integration/cpp/ReduceScatterVTestMain.cpp
@@ -104,12 +104,18 @@ TEST_P(MultiGraph, InputDeleted) {
 
 auto reduceScatterVParamValues() {
   return ::testing::Combine(
+#if TEST_FULL_SWEEP
       ::testing::Values(0, 4, 1024, 1024 * 1024),
       ::testing::Values(at::kFloat, at::kInt, at::kChar),
       ::testing::Values(
           torch::comms::ReduceOp::SUM,
           torch::comms::ReduceOp::MAX,
           torch::comms::ReduceOp::AVG));
+#else
+      ::testing::Values(4, 1024 * 1024),
+      ::testing::Values(at::kFloat),
+      ::testing::Values(torch::comms::ReduceOp::SUM));
+#endif
 }
 
 auto reduceScatterVGraphParamValues() {

--- a/comms/torchcomms/tests/integration/cpp/ReduceTestMain.cpp
+++ b/comms/torchcomms/tests/integration/cpp/ReduceTestMain.cpp
@@ -102,12 +102,18 @@ TEST_P(MultiGraph, InputDeleted) {
 
 auto reduceParamValues() {
   return ::testing::Combine(
+#if TEST_FULL_SWEEP
       ::testing::Values(0, 4, 1024, 1024 * 1024),
       ::testing::Values(at::kFloat, at::kInt, at::kChar),
       ::testing::Values(
           torch::comms::ReduceOp::SUM,
           torch::comms::ReduceOp::MAX,
           torch::comms::ReduceOp::AVG));
+#else
+      ::testing::Values(4, 1024 * 1024),
+      ::testing::Values(at::kFloat),
+      ::testing::Values(torch::comms::ReduceOp::SUM));
+#endif
 }
 
 auto reduceGraphParamValues() {

--- a/comms/torchcomms/tests/integration/cpp/ScatterTestMain.cpp
+++ b/comms/torchcomms/tests/integration/cpp/ScatterTestMain.cpp
@@ -89,8 +89,12 @@ TEST_P(MultiGraph, InputDeleted) {
 
 auto scatterParamValues() {
   return ::testing::Combine(
+#if TEST_FULL_SWEEP
       ::testing::Values(0, 4, 1024, 1024 * 1024),
       ::testing::Values(at::kFloat, at::kInt, at::kChar));
+#else
+      ::testing::Values(4, 1024 * 1024), ::testing::Values(at::kFloat));
+#endif
 }
 
 auto scatterGraphParamValues() {

--- a/comms/torchcomms/tests/integration/cpp/SendRecvTestMain.cpp
+++ b/comms/torchcomms/tests/integration/cpp/SendRecvTestMain.cpp
@@ -89,7 +89,12 @@ TEST_P(MultiGraph, InputDeleted) {
 
 auto sendRecvParamValues() {
   return ::testing::Combine(
-      ::testing::Values(4), ::testing::Values(at::kFloat, at::kInt, at::kChar));
+      ::testing::Values(4),
+#if TEST_FULL_SWEEP
+      ::testing::Values(at::kFloat, at::kInt, at::kChar));
+#else
+      ::testing::Values(at::kFloat));
+#endif
 }
 
 auto sendRecvGraphParamValues() {

--- a/comms/torchcomms/tests/integration/cpp/TorchCommTestHelpers.h
+++ b/comms/torchcomms/tests/integration/cpp/TorchCommTestHelpers.h
@@ -7,6 +7,12 @@
 #include <string>
 #include <tuple>
 
+// Default to full parameter sweep if not specified via compiler flag.
+// Build with -DTEST_FULL_SWEEP=0 for a reduced smoke test.
+#ifndef TEST_FULL_SWEEP
+#define TEST_FULL_SWEEP 1
+#endif
+
 #include <ATen/ATen.h>
 #include <c10/core/Device.h>
 #include <c10/util/intrusive_ptr.h>

--- a/comms/torchcomms/tests/integration/py/AllGatherSingleTest.py
+++ b/comms/torchcomms/tests/integration/py/AllGatherSingleTest.py
@@ -9,6 +9,7 @@ import unittest
 import torch
 from torchcomms.tests.integration.py.TorchCommTestHelpers import (
     get_dtype_name,
+    is_full_sweep,
     TorchCommTestWrapper,
 )
 
@@ -17,8 +18,8 @@ class AllGatherSingleTest(unittest.TestCase):
     """Test class for all_gather_single operations in TorchComm."""
 
     # Class variables for test parameters
-    counts = [0, 4, 1024, 1024 * 1024]
-    dtypes = [torch.float, torch.int, torch.int8]
+    counts = [0, 4, 1024, 1024 * 1024] if is_full_sweep() else [4, 1024 * 1024]
+    dtypes = [torch.float, torch.int, torch.int8] if is_full_sweep() else [torch.float]
     num_replays = 4
 
     def get_wrapper(self):

--- a/comms/torchcomms/tests/integration/py/AllGatherTest.py
+++ b/comms/torchcomms/tests/integration/py/AllGatherTest.py
@@ -9,6 +9,7 @@ import unittest
 import torch
 from torchcomms.tests.integration.py.TorchCommTestHelpers import (
     get_dtype_name,
+    is_full_sweep,
     TorchCommTestWrapper,
 )
 
@@ -17,8 +18,8 @@ class AllGatherTest(unittest.TestCase):
     """Test class for all_gather operations in TorchComm."""
 
     # Class variables for test parameters
-    counts = [0, 4, 1024, 1024 * 1024]
-    dtypes = [torch.float, torch.int, torch.int8]
+    counts = [0, 4, 1024, 1024 * 1024] if is_full_sweep() else [4, 1024 * 1024]
+    dtypes = [torch.float, torch.int, torch.int8] if is_full_sweep() else [torch.float]
     num_replays = 4
 
     def get_wrapper(self):

--- a/comms/torchcomms/tests/integration/py/AllGatherVTest.py
+++ b/comms/torchcomms/tests/integration/py/AllGatherVTest.py
@@ -9,6 +9,7 @@ import unittest
 import torch
 from torchcomms.tests.integration.py.TorchCommTestHelpers import (
     get_dtype_name,
+    is_full_sweep,
     TorchCommTestWrapper,
 )
 
@@ -17,8 +18,8 @@ class AllGatherVTest(unittest.TestCase):
     """Test class for all_gather_v operations in TorchComm."""
 
     # Class variables for test parameters
-    counts = [0, 4, 1024, 1024 * 1024]
-    dtypes = [torch.float, torch.int, torch.int8]
+    counts = [0, 4, 1024, 1024 * 1024] if is_full_sweep() else [4, 1024 * 1024]
+    dtypes = [torch.float, torch.int, torch.int8] if is_full_sweep() else [torch.float]
     num_replays = 4
 
     def get_wrapper(self):

--- a/comms/torchcomms/tests/integration/py/AllReduceTest.py
+++ b/comms/torchcomms/tests/integration/py/AllReduceTest.py
@@ -12,6 +12,7 @@ from torchcomms.tests.integration.py.TorchCommTestHelpers import (
     filter_int8_overflow_cases,
     get_dtype_name,
     get_op_name,
+    is_full_sweep,
     TorchCommTestWrapper,
 )
 
@@ -20,9 +21,13 @@ class AllReduceTest(unittest.TestCase):
     """Test class for all_reduce operations in TorchComm."""
 
     # Class variables for test parameters
-    counts = [0, 4, 1024, 1024 * 1024]
-    dtypes = [torch.float, torch.int, torch.int8]
-    ops = [ReduceOp.SUM, ReduceOp.MAX, ReduceOp.AVG]
+    counts = [0, 4, 1024, 1024 * 1024] if is_full_sweep() else [4, 1024 * 1024]
+    dtypes = [torch.float, torch.int, torch.int8] if is_full_sweep() else [torch.float]
+    ops = (
+        [ReduceOp.SUM, ReduceOp.MAX, ReduceOp.AVG]
+        if is_full_sweep()
+        else [ReduceOp.SUM]
+    )
     num_replays = 4
 
     def get_test_cases(self):

--- a/comms/torchcomms/tests/integration/py/AllToAllSingleTest.py
+++ b/comms/torchcomms/tests/integration/py/AllToAllSingleTest.py
@@ -9,6 +9,7 @@ import unittest
 import torch
 from torchcomms.tests.integration.py.TorchCommTestHelpers import (
     get_dtype_name,
+    is_full_sweep,
     TorchCommTestWrapper,
 )
 
@@ -17,8 +18,8 @@ class AllToAllSingleTest(unittest.TestCase):
     """Test class for all_to_all_single operations in TorchComm."""
 
     # Class variables for test parameters
-    counts = [0, 4, 1024, 1024 * 1024]
-    dtypes = [torch.float, torch.int, torch.int8]
+    counts = [0, 4, 1024, 1024 * 1024] if is_full_sweep() else [4, 1024 * 1024]
+    dtypes = [torch.float, torch.int, torch.int8] if is_full_sweep() else [torch.float]
     num_replays = 4
 
     def get_wrapper(self):

--- a/comms/torchcomms/tests/integration/py/AllToAllTest.py
+++ b/comms/torchcomms/tests/integration/py/AllToAllTest.py
@@ -9,6 +9,7 @@ import unittest
 import torch
 from torchcomms.tests.integration.py.TorchCommTestHelpers import (
     get_dtype_name,
+    is_full_sweep,
     TorchCommTestWrapper,
 )
 
@@ -17,8 +18,8 @@ class AllToAllTest(unittest.TestCase):
     """Test class for all_to_all operations in TorchComm."""
 
     # Class variables for test parameters
-    counts = [0, 4, 1024, 1024 * 1024]
-    dtypes = [torch.float, torch.int, torch.int8]
+    counts = [0, 4, 1024, 1024 * 1024] if is_full_sweep() else [4, 1024 * 1024]
+    dtypes = [torch.float, torch.int, torch.int8] if is_full_sweep() else [torch.float]
     num_replays = 4
 
     def get_wrapper(self):

--- a/comms/torchcomms/tests/integration/py/AllToAllvSingleTest.py
+++ b/comms/torchcomms/tests/integration/py/AllToAllvSingleTest.py
@@ -10,6 +10,7 @@ from enum import Enum
 import torch
 from torchcomms.tests.integration.py.TorchCommTestHelpers import (
     get_dtype_name,
+    is_full_sweep,
     TorchCommTestWrapper,
 )
 
@@ -18,8 +19,8 @@ class AllToAllvSingleTest(unittest.TestCase):
     """Test class for all_to_all_v_single operations in TorchComm."""
 
     # Class variables for test parameters
-    counts = [4, 1024, 1024 * 1024]
-    dtypes = [torch.float, torch.int, torch.int8]
+    counts = [4, 1024, 1024 * 1024] if is_full_sweep() else [4, 1024 * 1024]
+    dtypes = [torch.float, torch.int, torch.int8] if is_full_sweep() else [torch.float]
     num_replays = 4
 
     def get_wrapper(self):

--- a/comms/torchcomms/tests/integration/py/BroadcastTest.py
+++ b/comms/torchcomms/tests/integration/py/BroadcastTest.py
@@ -9,6 +9,7 @@ import unittest
 import torch
 from torchcomms.tests.integration.py.TorchCommTestHelpers import (
     get_dtype_name,
+    is_full_sweep,
     TorchCommTestWrapper,
 )
 
@@ -17,8 +18,8 @@ class BroadcastTest(unittest.TestCase):
     """Test class for broadcast operations in TorchComm."""
 
     # Class variables for test parameters
-    counts = [0, 4, 1024, 1024 * 1024]
-    dtypes = [torch.float, torch.int, torch.int8]
+    counts = [0, 4, 1024, 1024 * 1024] if is_full_sweep() else [4, 1024 * 1024]
+    dtypes = [torch.float, torch.int, torch.int8] if is_full_sweep() else [torch.float]
     num_replays = 4
 
     def get_wrapper(self):

--- a/comms/torchcomms/tests/integration/py/FullgraphCompileTest.py
+++ b/comms/torchcomms/tests/integration/py/FullgraphCompileTest.py
@@ -21,9 +21,12 @@ if is_torch_compile_supported_and_enabled():
     from torchcomms.tests.integration.py.TorchCommTestHelpers import (  # noqa: E402
         get_dtype_name,
         get_op_name,
+        is_full_sweep,
         TorchCommTestWrapper,
     )
 else:
+    from torchcomms.tests.integration.py.TorchCommTestHelpers import is_full_sweep
+
     ReduceOp = None
 
 logger = logging.getLogger(__name__)
@@ -36,8 +39,12 @@ class FullgraphCompileTest(unittest.TestCase):
 
     # Class variables for test parameters
     counts = [4, 1024]
-    dtypes = [torch.float, torch.int]
-    ops = [ReduceOp.SUM, ReduceOp.MAX] if ReduceOp is not None else []
+    dtypes = [torch.float, torch.int] if is_full_sweep() else [torch.float]
+    ops = (
+        ([ReduceOp.SUM, ReduceOp.MAX] if is_full_sweep() else [ReduceOp.SUM])
+        if ReduceOp is not None
+        else []
+    )
 
     def get_wrapper(self):
         return TorchCommTestWrapper()

--- a/comms/torchcomms/tests/integration/py/GatherSingleTest.py
+++ b/comms/torchcomms/tests/integration/py/GatherSingleTest.py
@@ -9,6 +9,7 @@ import unittest
 import torch
 from torchcomms.tests.integration.py.TorchCommTestHelpers import (
     get_dtype_name,
+    is_full_sweep,
     TorchCommTestWrapper,
 )
 
@@ -17,8 +18,8 @@ class GatherSingleTest(unittest.TestCase):
     """Test class for gather_single operations in TorchComm."""
 
     # Class variables for test parameters
-    counts = [0, 4, 1024, 1024 * 1024]
-    dtypes = [torch.float, torch.int, torch.int8]
+    counts = [0, 4, 1024, 1024 * 1024] if is_full_sweep() else [4, 1024 * 1024]
+    dtypes = [torch.float, torch.int, torch.int8] if is_full_sweep() else [torch.float]
     num_replays = 4
 
     def get_wrapper(self):

--- a/comms/torchcomms/tests/integration/py/GatherTest.py
+++ b/comms/torchcomms/tests/integration/py/GatherTest.py
@@ -9,6 +9,7 @@ import unittest
 import torch
 from torchcomms.tests.integration.py.TorchCommTestHelpers import (
     get_dtype_name,
+    is_full_sweep,
     TorchCommTestWrapper,
 )
 
@@ -17,8 +18,8 @@ class GatherTest(unittest.TestCase):
     """Test class for gather operations in TorchComm."""
 
     # Class variables for test parameters
-    counts = [0, 4, 1024, 1024 * 1024]
-    dtypes = [torch.float, torch.int, torch.int8]
+    counts = [0, 4, 1024, 1024 * 1024] if is_full_sweep() else [4, 1024 * 1024]
+    dtypes = [torch.float, torch.int, torch.int8] if is_full_sweep() else [torch.float]
     num_replays = 4
 
     def get_wrapper(self):

--- a/comms/torchcomms/tests/integration/py/ObjColTest.py
+++ b/comms/torchcomms/tests/integration/py/ObjColTest.py
@@ -8,7 +8,10 @@ from datetime import timedelta
 
 import torch
 from torchcomms import objcol
-from torchcomms.tests.integration.py.TorchCommTestHelpers import TorchCommTestWrapper
+from torchcomms.tests.integration.py.TorchCommTestHelpers import (
+    is_full_sweep,
+    TorchCommTestWrapper,
+)
 
 
 @contextmanager
@@ -29,8 +32,8 @@ class ObjColTest(unittest.TestCase):
     """Test class for broadcast operations in TorchComm."""
 
     # Class variables for test parameters
-    counts = [0, 4, 1024, 1024 * 1024]
-    dtypes = [torch.float, torch.int, torch.int8]
+    counts = [0, 4, 1024, 1024 * 1024] if is_full_sweep() else [4, 1024 * 1024]
+    dtypes = [torch.float, torch.int, torch.int8] if is_full_sweep() else [torch.float]
     num_replays = 4
 
     def get_wrapper(self):

--- a/comms/torchcomms/tests/integration/py/ReduceScatterSingleTest.py
+++ b/comms/torchcomms/tests/integration/py/ReduceScatterSingleTest.py
@@ -12,6 +12,7 @@ from torchcomms.tests.integration.py.TorchCommTestHelpers import (
     filter_int8_overflow_cases,
     get_dtype_name,
     get_op_name,
+    is_full_sweep,
     TorchCommTestWrapper,
 )
 
@@ -20,9 +21,13 @@ class ReduceScatterSingleTest(unittest.TestCase):
     """Test class for reduce_scatter_single operations in TorchComm."""
 
     # Class variables for test parameters
-    counts = [0, 4, 1024, 1024 * 1024]
-    dtypes = [torch.float, torch.int, torch.int8]
-    ops = [ReduceOp.SUM, ReduceOp.MAX, ReduceOp.AVG]
+    counts = [0, 4, 1024, 1024 * 1024] if is_full_sweep() else [4, 1024 * 1024]
+    dtypes = [torch.float, torch.int, torch.int8] if is_full_sweep() else [torch.float]
+    ops = (
+        [ReduceOp.SUM, ReduceOp.MAX, ReduceOp.AVG]
+        if is_full_sweep()
+        else [ReduceOp.SUM]
+    )
     num_replays = 4
 
     def get_test_cases(self):

--- a/comms/torchcomms/tests/integration/py/ReduceScatterTest.py
+++ b/comms/torchcomms/tests/integration/py/ReduceScatterTest.py
@@ -12,6 +12,7 @@ from torchcomms.tests.integration.py.TorchCommTestHelpers import (
     filter_int8_overflow_cases,
     get_dtype_name,
     get_op_name,
+    is_full_sweep,
     TorchCommTestWrapper,
 )
 
@@ -20,9 +21,13 @@ class ReduceScatterTest(unittest.TestCase):
     """Test class for reduce_scatter operations in TorchComm."""
 
     # Class variables for test parameters
-    counts = [0, 4, 1024, 1024 * 1024]
-    dtypes = [torch.float, torch.int, torch.int8]
-    ops = [ReduceOp.SUM, ReduceOp.MAX, ReduceOp.AVG]
+    counts = [0, 4, 1024, 1024 * 1024] if is_full_sweep() else [4, 1024 * 1024]
+    dtypes = [torch.float, torch.int, torch.int8] if is_full_sweep() else [torch.float]
+    ops = (
+        [ReduceOp.SUM, ReduceOp.MAX, ReduceOp.AVG]
+        if is_full_sweep()
+        else [ReduceOp.SUM]
+    )
     num_replays = 4
 
     def get_test_cases(self):

--- a/comms/torchcomms/tests/integration/py/ReduceScatterVTest.py
+++ b/comms/torchcomms/tests/integration/py/ReduceScatterVTest.py
@@ -12,6 +12,7 @@ from torchcomms.tests.integration.py.TorchCommTestHelpers import (
     filter_int8_overflow_cases,
     get_dtype_name,
     get_op_name,
+    is_full_sweep,
     TorchCommTestWrapper,
 )
 
@@ -20,9 +21,13 @@ class ReduceScatterVTest(unittest.TestCase):
     """Test class for reduce_scatter_v operations in TorchComm."""
 
     # Class variables for test parameters
-    counts = [0, 4, 1024, 1024 * 1024]
-    dtypes = [torch.float, torch.int, torch.int8]
-    ops = [ReduceOp.SUM, ReduceOp.MAX, ReduceOp.AVG]
+    counts = [0, 4, 1024, 1024 * 1024] if is_full_sweep() else [4, 1024 * 1024]
+    dtypes = [torch.float, torch.int, torch.int8] if is_full_sweep() else [torch.float]
+    ops = (
+        [ReduceOp.SUM, ReduceOp.MAX, ReduceOp.AVG]
+        if is_full_sweep()
+        else [ReduceOp.SUM]
+    )
     num_replays = 4
 
     def get_test_cases(self):

--- a/comms/torchcomms/tests/integration/py/ReduceTest.py
+++ b/comms/torchcomms/tests/integration/py/ReduceTest.py
@@ -12,6 +12,7 @@ from torchcomms.tests.integration.py.TorchCommTestHelpers import (
     filter_int8_overflow_cases,
     get_dtype_name,
     get_op_name,
+    is_full_sweep,
     TorchCommTestWrapper,
 )
 
@@ -20,9 +21,13 @@ class ReduceTest(unittest.TestCase):
     """Test class for reduce operations in TorchComm."""
 
     # Class variables for test parameters
-    counts = [0, 4, 1024, 1024 * 1024]
-    dtypes = [torch.float, torch.int, torch.int8]
-    ops = [ReduceOp.SUM, ReduceOp.MAX, ReduceOp.AVG]
+    counts = [0, 4, 1024, 1024 * 1024] if is_full_sweep() else [4, 1024 * 1024]
+    dtypes = [torch.float, torch.int, torch.int8] if is_full_sweep() else [torch.float]
+    ops = (
+        [ReduceOp.SUM, ReduceOp.MAX, ReduceOp.AVG]
+        if is_full_sweep()
+        else [ReduceOp.SUM]
+    )
     num_replays = 4
 
     def get_test_cases(self):

--- a/comms/torchcomms/tests/integration/py/ScatterTest.py
+++ b/comms/torchcomms/tests/integration/py/ScatterTest.py
@@ -9,6 +9,7 @@ import unittest
 import torch
 from torchcomms.tests.integration.py.TorchCommTestHelpers import (
     get_dtype_name,
+    is_full_sweep,
     TorchCommTestWrapper,
 )
 
@@ -17,8 +18,8 @@ class ScatterTest(unittest.TestCase):
     """Test class for scatter operations in TorchComm."""
 
     # Class variables for test parameters
-    counts = [0, 4, 1024, 1024 * 1024]
-    dtypes = [torch.float, torch.int, torch.int8]
+    counts = [0, 4, 1024, 1024 * 1024] if is_full_sweep() else [4, 1024 * 1024]
+    dtypes = [torch.float, torch.int, torch.int8] if is_full_sweep() else [torch.float]
     num_replays = 4
 
     def get_wrapper(self):

--- a/comms/torchcomms/tests/integration/py/TorchCommTestHelpers.py
+++ b/comms/torchcomms/tests/integration/py/TorchCommTestHelpers.py
@@ -12,6 +12,16 @@ from torch.distributed import PrefixStore, TCPStore
 from torchcomms import new_comm, RedOpType, ReduceOp
 
 
+def is_full_sweep():
+    """Check if the test should run the full parameter sweep.
+
+    When TEST_FULL_SWEEP=0, tests use a reduced set of parameters
+    (fewer counts, dtypes, ops) for a faster smoke test. The full
+    sweep runs all parameter combinations.
+    """
+    return os.environ.get("TEST_FULL_SWEEP", "1") == "1"
+
+
 def get_dtype_name(dtype):
     """Helper function to get a string representation of the datatype."""
     if dtype == torch.half:


### PR DESCRIPTION
Summary:
Add a TEST_FULL_SWEEP control that reduces parameter sweep in
CI for non-default ncclx configs.

For Python tests, TEST_FULL_SWEEP is an env var checked at
runtime via is_full_sweep(). Only the first ncclx cross-product
combo runs the full sweep; the remaining 7 combos run reduced
parameters. All other backends (nccl, gloo, rccl, mccl, dummy)
always run the full sweep.

For C++ tests, TEST_FULL_SWEEP is a compiler macro passed via
-DTEST_FULL_SWEEP=<0|1> in compiler_flags. By default, only
the first ncclx config is generated in CI (configs are dropped).
When -c comms.full_sweep is passed, all ncclx configs are kept
and the macro controls parameter reduction at compile time.

When TEST_FULL_SWEEP=0, tests reduce:
- counts: [4, 1024*1024] instead of [0, 4, 1024, 1024*1024]
- dtypes: [float] instead of [float, int, int8]
- ops: [SUM] instead of [SUM, MAX, AVG]

Override via buck config:
  buck test -c comms.full_sweep=1 ...  # force full sweep
  buck test -c comms.full_sweep=0 ...  # force reduced

Differential Revision: D101729560
