### PR TITLE
IbgdaBuffer multi-key arrays via union with legacy aliases (#2175)

### DIFF
--- a/comms/pipes/IbgdaBuffer.h
+++ b/comms/pipes/IbgdaBuffer.h
@@ -7,6 +7,8 @@
 
 #include <endian.h>
 
+#include "comms/pipes/IbgdaNicConfig.h"
+
 // Allow compilation in both host (C++) and device (CUDA) contexts
 #ifdef __CUDACC__
 #define IBGDA_HOST_DEVICE __host__ __device__
@@ -136,24 +138,57 @@ struct NetworkRKey {
  *
  * Represents a buffer in the local GPU's memory that can be used
  * as a source for RDMA writes or destination for RDMA reads.
- * Uses lkey (local key) in network byte order for memory registration.
+ * Carries one local key per NIC (lkeys[kMaxIbgdaNics]) for multi-NIC
+ * IBGDA support — each NIC has its own ibv_pd with a distinct lkey for
+ * the same physical buffer. The kernel-side P2pIbgdaTransportDevice
+ * selects lkeys[transportIdx_] based on the rail it dispatches to.
+ *
+ * Backward compatibility:
+ *   - lkey aliases lkeys[0] via anonymous union — existing call sites
+ *     using `.lkey.value` continue to work unchanged.
+ *   - The single-key constructor is [[deprecated]] (sets lkeys[0]=key,
+ *     lkeys[1..N-1]=zero) — safe at numNics=1 (transportIdx_ always 0)
+ *     but unsafe at numNics>1. Migrate to multi-key constructor.
  *
  * This struct is usable from both host and device code.
  */
 struct IbgdaLocalBuffer {
   void* ptr{nullptr};
-  NetworkLKey lkey{};
+  union {
+    NetworkLKey lkey; // legacy alias for lkeys[0] (zero-init via lkeys{})
+    NetworkLKey lkeys[kMaxIbgdaNics];
+  };
 
-  IbgdaLocalBuffer() = default;
+  IBGDA_HOST_DEVICE IbgdaLocalBuffer() : ptr(nullptr), lkeys{} {}
 
+  // Single-key constructor — DEPRECATED. Sets lkeys[0]=key; lkeys[1..N-1]=0.
+  // Safe only when consumed by a P2p with transportIdx_=0 (single-NIC). For
+  // multi-NIC transports, use the multi-key constructor below.
+  [[deprecated("Use multi-key constructor (ptr, keys) for multi-NIC support")]]
   IBGDA_HOST_DEVICE IbgdaLocalBuffer(void* p, NetworkLKey key)
-      : ptr(p), lkey(key) {}
+      : ptr(p), lkeys{key} {}
+
+  // Multi-key constructor — preferred. Caller passes the per-NIC lkeys
+  // array by reference (type-checked, fixed size = kMaxIbgdaNics).
+  // Single-NIC callers may zero-initialize the unused slots (NetworkLKey{}):
+  //   NetworkLKey keys[kMaxIbgdaNics]{lkey};  // {lkey, NetworkLKey{}}
+  //   IbgdaLocalBuffer buf(ptr, keys);
+  // since lkeys[1..N-1] are never read when numNics=1 (transportIdx_=0).
+  IBGDA_HOST_DEVICE IbgdaLocalBuffer(
+      void* p,
+      const NetworkLKey (&keys)[kMaxIbgdaNics])
+      : ptr(p) {
+    for (int n = 0; n < kMaxIbgdaNics; n++) {
+      lkeys[n] = keys[n];
+    }
+  }
 
   /**
-   * Create a sub-buffer at the given byte offset
+   * Create a sub-buffer at the given byte offset.
+   * Propagates all NICs' lkeys via the array-ref constructor.
    */
   IBGDA_HOST_DEVICE IbgdaLocalBuffer subBuffer(std::size_t offset) const {
-    return IbgdaLocalBuffer(static_cast<char*>(ptr) + offset, lkey);
+    return IbgdaLocalBuffer(static_cast<char*>(ptr) + offset, lkeys);
   }
 };
 
@@ -161,25 +196,48 @@ struct IbgdaLocalBuffer {
  * IbgdaRemoteBuffer - Remote buffer descriptor for RDMA operations
  *
  * Represents a buffer in a remote GPU's memory that can be accessed
- * via RDMA operations. Uses rkey (remote key) in network byte order
- * for memory registration.
+ * via RDMA operations. Carries one remote key per NIC
+ * (rkeys[kMaxIbgdaNics]) for multi-NIC IBGDA support — each NIC has
+ * its own ibv_pd with a distinct rkey for the same physical remote
+ * buffer. The kernel-side P2pIbgdaTransportDevice selects
+ * rkeys[transportIdx_] based on the rail it dispatches to.
+ *
+ * Backward compatibility: same pattern as IbgdaLocalBuffer (rkey aliases
+ * rkeys[0] via union; single-key constructor is [[deprecated]]).
  *
  * This struct is usable from both host and device code.
  */
 struct IbgdaRemoteBuffer {
   void* ptr{nullptr};
-  NetworkRKey rkey{};
+  union {
+    NetworkRKey rkey; // legacy alias for rkeys[0]
+    NetworkRKey rkeys[kMaxIbgdaNics];
+  };
 
-  IbgdaRemoteBuffer() = default;
+  IBGDA_HOST_DEVICE IbgdaRemoteBuffer() : ptr(nullptr), rkeys{} {}
 
+  // Single-key constructor — DEPRECATED. Sets rkeys[0]=key; rkeys[1..N-1]=0.
+  [[deprecated("Use multi-key constructor (ptr, keys) for multi-NIC support")]]
   IBGDA_HOST_DEVICE IbgdaRemoteBuffer(void* p, NetworkRKey key)
-      : ptr(p), rkey(key) {}
+      : ptr(p), rkeys{key} {}
+
+  // Multi-key constructor — preferred. Caller passes the per-NIC rkeys
+  // array by reference (type-checked, fixed size = kMaxIbgdaNics).
+  IBGDA_HOST_DEVICE IbgdaRemoteBuffer(
+      void* p,
+      const NetworkRKey (&keys)[kMaxIbgdaNics])
+      : ptr(p) {
+    for (int n = 0; n < kMaxIbgdaNics; n++) {
+      rkeys[n] = keys[n];
+    }
+  }
 
   /**
-   * Create a sub-buffer at the given byte offset
+   * Create a sub-buffer at the given byte offset.
+   * Propagates all NICs' rkeys via the array-ref constructor.
    */
   IBGDA_HOST_DEVICE IbgdaRemoteBuffer subBuffer(std::size_t offset) const {
-    return IbgdaRemoteBuffer(static_cast<char*>(ptr) + offset, rkey);
+    return IbgdaRemoteBuffer(static_cast<char*>(ptr) + offset, rkeys);
   }
 };
 
@@ -240,9 +298,15 @@ struct IbgdaBufferExchInfo {
   /**
    * Convert to IbgdaRemoteBuffer for RDMA operations.
    * The HostRKey is implicitly converted to NetworkRKey.
+   *
+   * Single-NIC path: populates rkeys[0] with the exchanged rkey;
+   * rkeys[1..N-1] left zero (never read at numNics=1 because
+   * transportIdx_=0). Multi-NIC code uses IbgdaBufferExchInfoMultiNic
+   * (added in Group 1) instead of this struct.
    */
   IbgdaRemoteBuffer toRemoteBuffer() const {
-    return IbgdaRemoteBuffer(reinterpret_cast<void*>(addr), rkey);
+    NetworkRKey keys[kMaxIbgdaNics]{NetworkRKey(rkey)};
+    return IbgdaRemoteBuffer(reinterpret_cast<void*>(addr), keys);
   }
 
   /**

--- a/comms/pipes/IbgdaNicConfig.h
+++ b/comms/pipes/IbgdaNicConfig.h
@@ -1,0 +1,30 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+namespace comms::pipes {
+
+// Maximum number of IBGDA NICs per GPU supported by the multi-NIC transport.
+// One "NIC" corresponds to one ibverbs path: a mlx5_X device + ibv_pd + QPs.
+//
+// Hardware mapping (per comms/tcp_devmem/HW.md):
+//   - H100 (Grand Teton): 1 NIC per GPU → numNics=1
+//   - GB200 (Catalina):   2 NICs per GPU (2 ConnectX-7 chips) → numNics=2
+//   - GB300 (Clemente):   2 NICs per GPU (1 dual-port ConnectX-8 exposed as
+//                         2 mlx5_X) → numNics=2
+//
+// kMaxIbgdaNics caps the static array sizes used in:
+//   - IbgdaLocalBuffer.lkeys[kMaxIbgdaNics]
+//   - IbgdaRemoteBuffer.rkeys[kMaxIbgdaNics]
+//   - LocalBufferRegistration.lkeys[kMaxIbgdaNics]
+//   - RemoteBufferRegistration.rkeys[kMaxIbgdaNics]
+//   - P2pIbgdaTransportDevice.sinkLkeys_[kMaxIbgdaNics]
+//   - IbgdaTransportExchInfoAll.nicInfo[kMaxIbgdaNics]
+//   - CachedMr.mrs[kMaxIbgdaNics]
+//
+// Increase this constant only if a future platform supports > 2 NICs per GPU.
+// At that point, also audit the wire format (IbgdaTransportExchInfoAll size
+// scales with kMaxIbgdaNics × kMaxQpsPerPeer × kMaxRanksForAllGather).
+constexpr int kMaxIbgdaNics = 2;
+
+} // namespace comms::pipes

--- a/comms/pipes/tests/IbgdaBufferTest.cc
+++ b/comms/pipes/tests/IbgdaBufferTest.cc
@@ -77,4 +77,72 @@ TEST(IbgdaBufferTest, RemoteBufferOperations) {
   EXPECT_EQ(sub.rkey, rkey);
 }
 
+// =============================================================================
+// Multi-NIC Buffer Tests
+// =============================================================================
+
+TEST(IbgdaBufferTest, LocalBufferMultiKeyConstruction) {
+  // Multi-key constructor takes the per-NIC lkeys array by reference.
+  char data[64];
+  NetworkLKey keys[kMaxIbgdaNics]{NetworkLKey(0x1111), NetworkLKey(0x2222)};
+  IbgdaLocalBuffer buf(data, keys);
+
+  EXPECT_EQ(buf.ptr, data);
+  EXPECT_EQ(buf.lkeys[0].value, 0x1111u);
+  EXPECT_EQ(buf.lkeys[1].value, 0x2222u);
+
+  // Union aliasing: legacy `.lkey` member reads the same memory as `.lkeys[0]`,
+  // so existing call sites using `.lkey.value` continue to work unchanged.
+  EXPECT_EQ(buf.lkey.value, 0x1111u);
+}
+
+TEST(IbgdaBufferTest, RemoteBufferMultiKeyConstruction) {
+  char data[64];
+  NetworkRKey keys[kMaxIbgdaNics]{NetworkRKey(0x3333), NetworkRKey(0x4444)};
+  IbgdaRemoteBuffer buf(data, keys);
+
+  EXPECT_EQ(buf.ptr, data);
+  EXPECT_EQ(buf.rkeys[0].value, 0x3333u);
+  EXPECT_EQ(buf.rkeys[1].value, 0x4444u);
+  EXPECT_EQ(buf.rkey.value, 0x3333u); // union alias
+}
+
+TEST(IbgdaBufferTest, LocalBufferSubBufferPropagatesAllKeys) {
+  // subBuffer must preserve BOTH lkeys[0] AND lkeys[1] (loop in ctor).
+  char data[64];
+  NetworkLKey keys[kMaxIbgdaNics]{NetworkLKey(0xAAAA), NetworkLKey(0xBBBB)};
+  IbgdaLocalBuffer buf(data, keys);
+
+  auto sub = buf.subBuffer(16);
+  EXPECT_EQ(sub.ptr, data + 16);
+  EXPECT_EQ(sub.lkeys[0].value, 0xAAAAu);
+  EXPECT_EQ(sub.lkeys[1].value, 0xBBBBu);
+}
+
+TEST(IbgdaBufferTest, RemoteBufferSubBufferPropagatesAllKeys) {
+  char data[64];
+  NetworkRKey keys[kMaxIbgdaNics]{NetworkRKey(0xCCCC), NetworkRKey(0xDDDD)};
+  IbgdaRemoteBuffer buf(data, keys);
+
+  auto sub = buf.subBuffer(32);
+  EXPECT_EQ(sub.ptr, data + 32);
+  EXPECT_EQ(sub.rkeys[0].value, 0xCCCCu);
+  EXPECT_EQ(sub.rkeys[1].value, 0xDDDDu);
+}
+
+TEST(IbgdaBufferTest, DefaultConstructorZeroInitsAllKeys) {
+  // Default-constructed buffers must have all per-NIC keys zeroed.
+  IbgdaLocalBuffer localBuf;
+  EXPECT_EQ(localBuf.ptr, nullptr);
+  for (int n = 0; n < kMaxIbgdaNics; n++) {
+    EXPECT_EQ(localBuf.lkeys[n].value, 0u);
+  }
+
+  IbgdaRemoteBuffer remoteBuf;
+  EXPECT_EQ(remoteBuf.ptr, nullptr);
+  for (int n = 0; n < kMaxIbgdaNics; n++) {
+    EXPECT_EQ(remoteBuf.rkeys[n].value, 0u);
+  }
+}
+
 } // namespace comms::pipes::tests


### PR DESCRIPTION
Summary:

Add per-NIC lkeys[kMaxIbgdaNics] / rkeys[kMaxIbgdaNics] arrays to IbgdaLocalBuffer and IbgdaRemoteBuffer, with full backward compatibility for existing call sites:

1. Anonymous union — legacy .lkey / .rkey member aliases lkeys[0] / rkeys[0]
   so existing call sites doing buf.lkey.value continue to work unchanged.
   Zero overhead, type-safe.

2. Array-reference multi-key constructor — IbgdaLocalBuffer(ptr, keys) where
   keys is NetworkLKey (&)[kMaxIbgdaNics]. Type-checked at compile time, fixed
   size matches the array dimension. Clean call sites:
     IbgdaLocalBuffer buf(localSrc, src_buf.lkeys);  // pass array directly
     IbgdaRemoteBuffer rbuf(base, registry[idx].rkeys);

3. [[deprecated]] single-key constructor — kept temporarily so the migration
   to multi-key can land in stages (P1.5 DeviceWindow, P1.6 HostWindow,
   P1.8 tests/benchmarks, P1.9 final delete). Lint warnings flag remaining
   call sites during transition.

4. Loop-based subBuffer() — propagates all NICs' keys via the array-ref
   constructor (forward-compat with kMaxIbgdaNics > 2).

5. IbgdaBufferExchInfo::toRemoteBuffer() switched to the multi-key ctor
   (single-NIC path: rkeys[1..N-1] zero-init, never read at numNics=1
   because transportIdx_=0 always).

Behavior at numNics=1 is bit-identical: lkeys[0] = today's lkey, lkeys[1] = 0
(never read since P2pIbgdaTransportDevice's transportIdx_ is always 0 in the
single-NIC config). Existing tests pass unchanged.

Differential Revision: D101700972


