### PR TITLE
side stream util

### DIFF
--- a/comms/utils/GraphCaptureSideStream.cc
+++ b/comms/utils/GraphCaptureSideStream.cc
@@ -1,0 +1,104 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/utils/GraphCaptureSideStream.h"
+
+#include <vector>
+
+namespace meta::comms {
+
+GraphSideStream::GraphSideStream(int priority) {
+  // Non-blocking so the side stream can run concurrently with the main
+  // stream when both are on the GPU.
+  (void)cudaStreamCreateWithPriority(
+      &side_stream_, cudaStreamNonBlocking, priority);
+  (void)cudaEventCreateWithFlags(&dep_event_, cudaEventDisableTiming);
+}
+
+GraphSideStream::~GraphSideStream() {
+  if (dep_event_ != nullptr) {
+    (void)cudaEventDestroy(dep_event_);
+    dep_event_ = nullptr;
+  }
+  if (side_stream_ != nullptr) {
+    (void)cudaStreamDestroy(side_stream_);
+    side_stream_ = nullptr;
+  }
+}
+
+cudaError_t GraphSideStream::fork_from(
+    cudaStream_t stream,
+    std::function<void(cudaStream_t)> fn) {
+  if (side_stream_ == nullptr || dep_event_ == nullptr) {
+    return cudaErrorInvalidResourceHandle;
+  }
+
+  // 1. Fork main → side.
+  cudaError_t err = cudaEventRecord(dep_event_, stream);
+  if (err != cudaSuccess) {
+    return err;
+  }
+  err = cudaStreamWaitEvent(side_stream_, dep_event_);
+  if (err != cudaSuccess) {
+    return err;
+  }
+
+  // 2. Capture main's current dependency set — used in step 5 to rewind
+  // main past the rejoin so subsequent main-stream ops aren't bound to
+  // the side stream.
+  cudaStreamCaptureStatus status = cudaStreamCaptureStatusNone;
+  const cudaGraphNode_t* deps = nullptr;
+  size_t num_deps = 0;
+#if CUDART_VERSION >= 13000
+  const cudaGraphEdgeData* edge_data = nullptr;
+  err = cudaStreamGetCaptureInfo(
+      stream, &status, nullptr, nullptr, &deps, &edge_data, &num_deps);
+#else
+  err = cudaStreamGetCaptureInfo_v2(
+      stream, &status, nullptr, nullptr, &deps, &num_deps);
+#endif
+  if (err != cudaSuccess) {
+    return err;
+  }
+
+  if (status != cudaStreamCaptureStatusActive) {
+    // Not capturing — run the user fn directly on main. The upstream
+    // eventRecord/streamWaitEvent calls above were no-ops for capture but
+    // are still valid stream ops; they just added a side-stream sync point.
+    fn(stream);
+    return cudaSuccess;
+  }
+
+  // Snapshot the captured deps; cudaStreamUpdateCaptureDependencies
+  // consumes them via a caller-owned buffer, so we need our own copy.
+  std::vector<cudaGraphNode_t> saved_deps(deps, deps + num_deps);
+#if CUDART_VERSION >= 13000
+  std::vector<cudaGraphEdgeData> saved_edge_data;
+  if (edge_data != nullptr) {
+    saved_edge_data.assign(edge_data, edge_data + num_deps);
+  }
+#endif
+
+  // 3. Invoke user work on the side stream.
+  fn(side_stream_);
+
+  // 4. Rejoin side → main. Required so cudaStreamEndCapture accepts the
+  // capture (every forked stream must have a rejoin path).
+  (void)cudaEventRecord(dep_event_, side_stream_);
+  (void)cudaStreamWaitEvent(stream, dep_event_);
+
+  // 5. Restore main's pre-rejoin deps so the rejoin node, while present
+  // in the graph DAG, is NOT a predecessor of any subsequent main-stream
+  // op. Implicit "clean up" of the just-added join: we never need to
+  // track a "prev event" manually because the dep is removed from main's
+  // active set here.
+  return cudaStreamUpdateCaptureDependencies(
+      stream,
+      saved_deps.data(),
+#if CUDART_VERSION >= 13000
+      saved_edge_data.empty() ? nullptr : saved_edge_data.data(),
+#endif
+      saved_deps.size(),
+      cudaStreamSetCaptureDependencies);
+}
+
+} // namespace meta::comms

--- a/comms/utils/GraphCaptureSideStream.h
+++ b/comms/utils/GraphCaptureSideStream.h
@@ -1,0 +1,83 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#include <functional>
+
+namespace meta::comms {
+
+// A CUDA "side stream" that lives alongside a main capture stream and
+// offers an ``fork_from(stream, fn)`` API to launch work onto the side
+// stream during CUDA graph capture. The launched work is captured into
+// the graph, but does NOT serialize subsequent operations on the main
+// stream.
+//
+// For each ``fork_from()`` call, the helper internally:
+//   1. Forks ``stream → sideStream`` via
+//      ``cudaEventRecord(depEvent, stream)`` +
+//      ``cudaStreamWaitEvent(sideStream, depEvent)``.
+//   2. Captures ``stream``'s current dependency set via
+//      ``cudaStreamGetCaptureInfo`` (post-fork, pre-rejoin).
+//   3. Invokes ``fn(sideStream)`` so the caller can launch captured ops.
+//   4. Rejoins ``sideStream → stream`` via
+//      ``cudaEventRecord(depEvent, sideStream)`` +
+//      ``cudaStreamWaitEvent(stream, depEvent)``. This rejoin is
+//      required — ``cudaStreamEndCapture`` rejects captures with an
+//      unjoined fork.
+//   5. Restores main's pre-rejoin deps via
+//      ``cudaStreamUpdateCaptureDependencies(stream, savedDeps,
+//      cudaStreamSetCaptureDependencies)``. The rejoin node still lives
+//      in the graph DAG, but ``stream``'s next captured op does
+//      not inherit it as a predecessor — so work you launch on the
+//      side stream stays off main's critical path at replay.
+//
+// Cross-call state: the instance owns a single side stream and single
+// dependency event shared across ``fork_from()`` calls. That's safe because
+// each call consumes the dep event immediately after recording it
+// (``record`` + ``waitEvent`` pair), so there is no lingering unconsumed
+// recording to "clean up" between calls. The side stream accumulates a
+// captured chain of user ops across the same capture, which is fine —
+// it's always off main's critical path.
+//
+// Construction must happen OUTSIDE of an active graph capture (it
+// allocates a stream and event). Typical usage: one instance per
+// communicator, created at ``init()`` time.
+class GraphSideStream {
+ public:
+  // ``priority`` matches ``cudaStreamCreateWithPriority``; ``0`` is default.
+  explicit GraphSideStream(int priority = 0);
+  ~GraphSideStream();
+
+  GraphSideStream(const GraphSideStream&) = delete;
+  GraphSideStream& operator=(const GraphSideStream&) = delete;
+  GraphSideStream(GraphSideStream&&) = delete;
+  GraphSideStream& operator=(GraphSideStream&&) = delete;
+
+  // Run ``fn(sideStream)`` on the side stream with fork/save/rejoin/restore
+  // scaffolding wrapped around it.
+  //
+  // If ``stream`` is not currently under CUDA graph capture, ``fn`` is
+  // invoked directly with ``stream`` (no fork). Useful for callers that
+  // speculatively route through ``fork_from()`` without branching on capture
+  // state.
+  //
+  // Returns the first CUDA error encountered. On error, the user function
+  // may or may not have been invoked — callers that need strict ordering
+  // should check ``cudaStreamGetCaptureInfo`` up front.
+  cudaError_t fork_from(
+      cudaStream_t stream,
+      std::function<void(cudaStream_t)> fn);
+
+  cudaStream_t get() const {
+    return side_stream_;
+  }
+
+ private:
+  cudaStream_t side_stream_{nullptr};
+  cudaEvent_t dep_event_{nullptr};
+};
+
+} // namespace meta::comms

--- a/comms/utils/tests/GraphCaptureSideStreamTest.cu
+++ b/comms/utils/tests/GraphCaptureSideStreamTest.cu
@@ -1,0 +1,245 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/utils/GraphCaptureSideStream.h"
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include <vector>
+
+using meta::comms::GraphSideStream;
+
+namespace {
+
+// Tests inject captured non-event graph nodes via ``cudaMemsetAsync`` rather
+// than a custom __global__ kernel — it's simpler and doesn't depend on which
+// CUDA archs the test target compiles for.
+
+class GraphSideStreamTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    int device_count = 0;
+    if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+      GTEST_SKIP() << "No CUDA device available";
+    }
+    ASSERT_EQ(cudaSetDevice(0), cudaSuccess);
+  }
+
+  static std::vector<cudaGraphNode_t> getNodes(cudaGraph_t graph) {
+    size_t n = 0;
+    EXPECT_EQ(cudaGraphGetNodes(graph, nullptr, &n), cudaSuccess);
+    std::vector<cudaGraphNode_t> nodes(n);
+    if (n > 0) {
+      EXPECT_EQ(cudaGraphGetNodes(graph, nodes.data(), &n), cudaSuccess);
+    }
+    return nodes;
+  }
+
+  static std::vector<cudaGraphNode_t> getSuccs(cudaGraphNode_t node) {
+    size_t n = 0;
+    EXPECT_EQ(cudaGraphNodeGetDependentNodes(node, nullptr, &n), cudaSuccess);
+    std::vector<cudaGraphNode_t> out(n);
+    if (n > 0) {
+      EXPECT_EQ(
+          cudaGraphNodeGetDependentNodes(node, out.data(), &n), cudaSuccess);
+    }
+    return out;
+  }
+
+  static std::vector<cudaGraphNode_t> getPreds(cudaGraphNode_t node) {
+    size_t n = 0;
+    EXPECT_EQ(cudaGraphNodeGetDependencies(node, nullptr, &n), cudaSuccess);
+    std::vector<cudaGraphNode_t> out(n);
+    if (n > 0) {
+      EXPECT_EQ(
+          cudaGraphNodeGetDependencies(node, out.data(), &n), cudaSuccess);
+    }
+    return out;
+  }
+
+  static cudaGraphNodeType nodeType(cudaGraphNode_t node) {
+    cudaGraphNodeType t;
+    EXPECT_EQ(cudaGraphNodeGetType(node, &t), cudaSuccess);
+    return t;
+  }
+};
+
+TEST_F(GraphSideStreamTest, ConstructAndDestruct) {
+  GraphSideStream side;
+  EXPECT_NE(side.get(), nullptr);
+}
+
+// When the caller's stream is NOT currently under graph capture, fork_from
+// should fall back to invoking ``fn`` with the caller's stream directly.
+TEST_F(GraphSideStreamTest, ForkFromFallsBackWhenNotCapturing) {
+  GraphSideStream side;
+  cudaStream_t stream = nullptr;
+  ASSERT_EQ(cudaStreamCreate(&stream), cudaSuccess);
+
+  cudaStream_t invoked_with = nullptr;
+  int invocation_count = 0;
+  EXPECT_EQ(
+      side.fork_from(
+          stream,
+          [&](cudaStream_t passed) {
+            ++invocation_count;
+            invoked_with = passed;
+          }),
+      cudaSuccess);
+  EXPECT_EQ(invocation_count, 1);
+  EXPECT_EQ(invoked_with, stream)
+      << "fallback path must pass the caller's stream, not the side stream";
+
+  EXPECT_EQ(cudaStreamDestroy(stream), cudaSuccess);
+}
+
+// End-to-end: during graph capture, fork_from should:
+//   - Invoke the user fn with the SIDE stream.
+//   - Produce a captured graph where the side-stream work is NOT a
+//     predecessor of the caller's subsequent ops.
+//   - Keep ``cudaStreamEndCapture`` happy (rejoin node present in graph).
+TEST_F(GraphSideStreamTest, ForkFromRoutesWorkOffMainCriticalPath) {
+  GraphSideStream side;
+
+  cudaStream_t main = nullptr;
+  ASSERT_EQ(cudaStreamCreate(&main), cudaSuccess);
+
+  int* dev_counter = nullptr;
+  ASSERT_EQ(cudaMalloc(&dev_counter, sizeof(int)), cudaSuccess);
+  ASSERT_EQ(cudaMemset(dev_counter, 0, sizeof(int)), cudaSuccess);
+
+  cudaEvent_t ext_event = nullptr;
+  ASSERT_EQ(
+      cudaEventCreateWithFlags(&ext_event, cudaEventDisableTiming),
+      cudaSuccess);
+
+  ASSERT_EQ(
+      cudaStreamBeginCapture(main, cudaStreamCaptureModeThreadLocal),
+      cudaSuccess);
+
+  ASSERT_EQ(
+      cudaMemsetAsync(dev_counter, 0, sizeof(int), main),
+      cudaSuccess); // kernel1
+
+  cudaStream_t invoked_with = nullptr;
+  ASSERT_EQ(
+      side.fork_from(
+          main,
+          [&](cudaStream_t s) {
+            invoked_with = s;
+            (void)cudaEventRecordWithFlags(
+                ext_event, s, cudaEventRecordExternal);
+          }),
+      cudaSuccess);
+  EXPECT_EQ(invoked_with, side.get())
+      << "under active capture, fn must run on the side stream";
+
+  ASSERT_EQ(
+      cudaMemsetAsync(dev_counter, 0, sizeof(int), main),
+      cudaSuccess); // kernel2
+
+  cudaGraph_t graph = nullptr;
+  ASSERT_EQ(cudaStreamEndCapture(main, &graph), cudaSuccess);
+  ASSERT_NE(graph, nullptr);
+
+  // Classify nodes. We injected two cudaMemsetAsync ops as "main stream
+  // anchors" (kernel1 / kernel2 in role) and a single external EVENT_RECORD
+  // via the side stream.
+  auto nodes = getNodes(graph);
+  cudaGraphNode_t kernel1 = nullptr;
+  cudaGraphNode_t kernel2 = nullptr;
+  cudaGraphNode_t event_record = nullptr;
+  for (auto n : nodes) {
+    auto t = nodeType(n);
+    if (t == cudaGraphNodeTypeMemset) {
+      if (kernel1 == nullptr) {
+        kernel1 = n;
+      } else {
+        kernel2 = n;
+      }
+    } else if (t == cudaGraphNodeTypeEventRecord) {
+      // Capture the user-issued external record (the first EVENT_RECORD
+      // encountered — fork/rejoin records also exist on side but are not
+      // what the test asserts on structurally).
+      if (event_record == nullptr) {
+        event_record = n;
+      }
+    }
+  }
+  ASSERT_NE(kernel1, nullptr);
+  ASSERT_NE(kernel2, nullptr);
+  ASSERT_NE(event_record, nullptr);
+
+  // kernel2 must depend directly on kernel1 (and NOT transitively via the
+  // event record node).
+  auto k2_preds = getPreds(kernel2);
+  bool kernel2_depends_on_kernel1_directly = false;
+  for (auto p : k2_preds) {
+    EXPECT_NE(p, event_record)
+        << "kernel2 must not depend on the external event record";
+    if (p == kernel1) {
+      kernel2_depends_on_kernel1_directly = true;
+    }
+  }
+  EXPECT_TRUE(kernel2_depends_on_kernel1_directly)
+      << "kernel2 should have a direct kernel1 edge after rewind";
+
+  // And the event record itself must NOT have kernel2 as a descendant.
+  auto er_succs = getSuccs(event_record);
+  for (auto s : er_succs) {
+    EXPECT_NE(s, kernel2)
+        << "event record must not be a predecessor of kernel2";
+  }
+
+  EXPECT_EQ(cudaGraphDestroy(graph), cudaSuccess);
+  EXPECT_EQ(cudaEventDestroy(ext_event), cudaSuccess);
+  EXPECT_EQ(cudaStreamDestroy(main), cudaSuccess);
+  EXPECT_EQ(cudaFree(dev_counter), cudaSuccess);
+}
+
+// Instantiating and replaying the captured graph after fork_from must also
+// execute cleanly — guards against accidentally breaking the DAG structure
+// such that cudaGraphInstantiate fails.
+TEST_F(GraphSideStreamTest, CapturedGraphInstantiatesAndReplays) {
+  GraphSideStream side;
+  cudaStream_t main = nullptr;
+  ASSERT_EQ(cudaStreamCreate(&main), cudaSuccess);
+  int* dev_counter = nullptr;
+  ASSERT_EQ(cudaMalloc(&dev_counter, sizeof(int)), cudaSuccess);
+  ASSERT_EQ(cudaMemset(dev_counter, 0, sizeof(int)), cudaSuccess);
+  cudaEvent_t ext_event = nullptr;
+  ASSERT_EQ(
+      cudaEventCreateWithFlags(&ext_event, cudaEventDisableTiming),
+      cudaSuccess);
+
+  ASSERT_EQ(
+      cudaStreamBeginCapture(main, cudaStreamCaptureModeThreadLocal),
+      cudaSuccess);
+  ASSERT_EQ(cudaMemsetAsync(dev_counter, 0, sizeof(int), main), cudaSuccess);
+  ASSERT_EQ(
+      side.fork_from(
+          main,
+          [&](cudaStream_t s) {
+            (void)cudaEventRecordWithFlags(
+                ext_event, s, cudaEventRecordExternal);
+          }),
+      cudaSuccess);
+  ASSERT_EQ(cudaMemsetAsync(dev_counter, 0, sizeof(int), main), cudaSuccess);
+
+  cudaGraph_t graph = nullptr;
+  ASSERT_EQ(cudaStreamEndCapture(main, &graph), cudaSuccess);
+
+  cudaGraphExec_t exec = nullptr;
+  ASSERT_EQ(
+      cudaGraphInstantiate(&exec, graph, nullptr, nullptr, 0), cudaSuccess);
+  ASSERT_EQ(cudaGraphLaunch(exec, main), cudaSuccess);
+  ASSERT_EQ(cudaStreamSynchronize(main), cudaSuccess);
+
+  EXPECT_EQ(cudaGraphExecDestroy(exec), cudaSuccess);
+  EXPECT_EQ(cudaGraphDestroy(graph), cudaSuccess);
+  EXPECT_EQ(cudaEventDestroy(ext_event), cudaSuccess);
+  EXPECT_EQ(cudaStreamDestroy(main), cudaSuccess);
+  EXPECT_EQ(cudaFree(dev_counter), cudaSuccess);
+}
+
+} // namespace


### PR DESCRIPTION
Summary:
a utility to maintain a dedicated side stream that ensures it is joined into the main stream. we do this by 'undoing' the most-recently-added join when a new item is added to the stream.

this is useful for a lot of things, but most pertinently, keeping external record nodes off of the hot path.

Differential Revision: D101579027


