### PR TITLE
use side-stream for submit guard (#2179)

### DIFF
--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -68,6 +68,7 @@ void OrderedWorkStreamGuard::init(const CommLogData& logMetaData) {
   FB_CUDACHECKTHROW_EX(
       cudaEventCreateWithFlags(&execModeSyncEvent_, cudaEventDisableTiming),
       logMetaData);
+  sideStream_ = std::make_unique<meta::comms::GraphSideStream>();
 }
 
 OrderedWorkStreamGuard::~OrderedWorkStreamGuard() {
@@ -239,9 +240,22 @@ commResult_t OrderedWorkStreamGuard::doRelease(
   if (!isCapturing) {
     FB_CUDACHECK(cudaEventRecord(execModeSyncEvent_, userStream));
   } else {
-    FB_COMMCHECK(
-        utils::cudagraph::addEventRecordNodeToCapture(
-            userStream, captureInfo.g, execModeSyncEvent_, &lastRecordNode_));
+    // Route the external EVENT_RECORD node onto a side stream so its
+    // release fence doesn't stall unrelated work on userStream between
+    // ctran submissions. The next doAcquire on userStream still sees
+    // lastRecordNode_ via cudaStreamUpdateCaptureDependencies, which
+    // reinstates the explicit DAG edge ordering the next ctran op after
+    // this record. Non-ctran work on userStream is not serialized
+    // behind the record.
+    commResult_t innerRes = commSuccess;
+    FB_CUDACHECK(
+        sideStream_->fork_from(userStream, [&](cudaStream_t sideStream) {
+          innerRes = utils::cudagraph::addEventRecordNodeToCapture(
+              sideStream, captureInfo.g, execModeSyncEvent_, &lastRecordNode_);
+        }));
+    if (innerRes != commSuccess) {
+      return innerRes;
+    }
   }
 
   lastUserStream_ = userStream;

--- a/comms/ctran/gpe/CtranGpeImpl.h
+++ b/comms/ctran/gpe/CtranGpeImpl.h
@@ -20,6 +20,7 @@
 #include "comms/ctran/utils/CudaGraphUtils.h"
 #include "comms/ctran/utils/ExtUtils.h"
 #include "comms/ctran/utils/PinnedHostPool.h"
+#include "comms/utils/GraphCaptureSideStream.h"
 
 struct CommLogData;
 
@@ -262,6 +263,13 @@ class OrderedWorkStreamGuard {
   bool everCaptured_{false};
   cudaStream_t lastUserStream_{nullptr};
   cudaGraphNode_t lastRecordNode_{};
+
+  // Side stream used during capture to host the external cudaEventRecord
+  // node for execModeSyncEvent_ off the user stream's critical path, so
+  // its release fence doesn't stall compute between ctran submissions.
+  // The next doAcquire still adds lastRecordNode_ (now on the side) as
+  // an explicit capture dependency of userStream, preserving ordering.
+  std::unique_ptr<meta::comms::GraphSideStream> sideStream_;
 
   const CommLogData* logMetaData_{nullptr};
 };

--- a/comms/torchcomms/ncclx/CMakeLists.txt
+++ b/comms/torchcomms/ncclx/CMakeLists.txt
@@ -96,6 +96,7 @@ add_library(torchcomms_comms_ncclx MODULE
     ${TORCHCOMMS_DEVICE_NCCLX_SOURCE}
     ${TORCHCOMMS_DEVICE_PIPES_SOURCE}
     comms/utils/CudaRAII.cc
+    comms/utils/GraphCaptureSideStream.cc
 )
 set_target_properties(torchcomms_comms_ncclx PROPERTIES
     PREFIX ""

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -229,6 +229,14 @@ void TorchCommNCCLX::initNcclxResources() {
             "Failed to create dependency event on device {}", device_.index()));
   }
 
+  // Side stream used by recordStart/recordEnd to host external EVENT_RECORD
+  // nodes off the main stream's critical path during CUDA graph capture.
+  // Only allocated when monitoring is enabled — nothing else uses it.
+  if (isGraphTimeoutMonitoringEnabled()) {
+    graph_monitor_side_stream_ =
+        std::make_unique<meta::comms::GraphSideStream>(stream_priority);
+  }
+
   if (!barrier_buffer_) {
     CUDA_CHECK(
         cuda_api_,
@@ -555,6 +563,9 @@ void TorchCommNCCLX::finalize() {
         "Failed to destroy dependency event");
     dependency_event_ = nullptr;
   }
+
+  // Destroy graph-monitor side stream (RAII in unique_ptr).
+  graph_monitor_side_stream_.reset();
 
   // Destroy internal stream
   if (internal_stream_) {

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
@@ -24,6 +24,7 @@
 #include "comms/torchcomms/ncclx/TorchCommNCCLXPersistentRequest.hpp"
 #include "comms/torchcomms/ncclx/TorchCommWindowNCCLX.hpp"
 #include "comms/torchcomms/ncclx/TorchWorkNCCLX.hpp"
+#include "comms/utils/GraphCaptureSideStream.h"
 
 #if defined(ENABLE_PIPES)
 #include "comms/torchcomms/device/pipes/PipesDeviceBackend.hpp"
@@ -353,7 +354,18 @@ class TorchCommNCCLX : public TorchCommBackend,
   cudaEvent_t
       dependency_event_{}; // Pre-allocated event for stream dependencies
 
+  // Side stream used to host the graph timeout monitoring's external
+  // cudaEventRecord nodes off the main collective stream's critical path
+  // during CUDA graph capture. See TorchWorkNCCLX::recordStart/recordEnd.
+  // Owns its own dep event internally. Lazily instantiated only when
+  // ``isGraphTimeoutMonitoringEnabled()``.
+  std::unique_ptr<meta::comms::GraphSideStream> graph_monitor_side_stream_;
+
  public:
+  meta::comms::GraphSideStream* getGraphMonitorSideStream() {
+    return graph_monitor_side_stream_.get();
+  }
+
   struct Address {
     void* addr;
   };

--- a/comms/torchcomms/ncclx/TorchWorkNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchWorkNCCLX.cpp
@@ -3,9 +3,11 @@
 #include "comms/torchcomms/ncclx/TorchWorkNCCLX.hpp"
 #include <ATen/ThreadLocalState.h>
 #include <ATen/cuda/CUDAContext.h>
+#include <fmt/format.h>
 #include "TorchCommNCCLX.hpp"
 #include "comms/torchcomms/utils/Logging.hpp"
 #include "comms/torchcomms/utils/TracingGuard.hpp"
+#include "comms/utils/GraphCaptureSideStream.h"
 
 namespace torch::comms {
 
@@ -123,19 +125,49 @@ void TorchWorkNCCLX::recordFunctionStart(std::string_view coll_name) {
   }
 }
 
+void TorchWorkNCCLX::recordExternalEventViaSideStream(
+    cudaEvent_t event,
+    const char* event_label) {
+  auto* side = comm_->getGraphMonitorSideStream();
+  if (side && side->get()) {
+    // Capture the eventRecordWithFlags error instead of throwing inside
+    // the lambda so fork_from can complete its cleanup (rejoin + dep
+    // restore) even on failure.
+    cudaError_t record_err = cudaSuccess;
+    cudaError_t fork_err = side->fork_from(stream_, [&](cudaStream_t s) {
+      record_err = comm_->getCudaApi()->eventRecordWithFlags(
+          event, s, cudaEventRecordExternal);
+    });
+    CUDA_CHECK(
+        comm_->getCudaApi(),
+        fork_err,
+        fmt::format(
+            "Failed to fork graph-monitor side stream for event {}",
+            event_label));
+    CUDA_CHECK(
+        comm_->getCudaApi(),
+        record_err,
+        fmt::format("Failed to record event {} on side stream", event_label));
+  } else {
+    CUDA_CHECK(
+        comm_->getCudaApi(),
+        comm_->getCudaApi()->eventRecordWithFlags(
+            event, stream_, cudaEventRecordExternal),
+        fmt::format("Failed to record {}", event_label));
+  }
+}
+
 void TorchWorkNCCLX::recordStart(std::string_view coll_name) {
   recordFunctionStart(coll_name);
 
   if (comm_->getGraphCaptureMode()) {
     // Use cudaEventRecordExternal so start_event_ remains host-queryable
-    // during graph replay (for watchdog timeout detection).
-    // start_event_ is not used as a graph join point, so this is safe.
+    // during graph replay (for watchdog timeout detection). Route the
+    // external record onto the graph-monitor side stream so its release
+    // fence does NOT serialize the main collective stream at replay time.
+    // See comms/utils/GraphCaptureSideStream.h for the pattern.
     if (start_event_) {
-      CUDA_CHECK(
-          comm_->getCudaApi(),
-          comm_->getCudaApi()->eventRecordWithFlags(
-              start_event_, stream_, cudaEventRecordExternal),
-          "Failed to record start event");
+      recordExternalEventViaSideStream(start_event_, "START");
     }
   } else {
     CUDA_CHECK(
@@ -156,12 +188,11 @@ void TorchWorkNCCLX::recordEnd() {
   // sync_event_ is nullptr.
   if (graph_capture_mode_) {
     if (end_event_) {
-      CUDA_CHECK(
-          comm_->getCudaApi(),
-          comm_->getCudaApi()->eventRecordWithFlags(
-              end_event_, stream_, cudaEventRecordExternal),
-          "Failed to record end event");
+      recordExternalEventViaSideStream(end_event_, "END");
     }
+    // sync_event_ stays on the main stream — it's the join point that
+    // work.wait() uses via cudaStreamWaitEvent to make downstream ops wait
+    // for the collective to complete.
     CUDA_CHECK(
         comm_->getCudaApi(),
         comm_->getCudaApi()->eventRecord(sync_event_, stream_),

--- a/comms/torchcomms/ncclx/TorchWorkNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchWorkNCCLX.hpp
@@ -108,6 +108,14 @@ class TorchWorkNCCLX : public TorchWork {
   void initEvents();
   void releaseEvents();
 
+  // Record a cudaEventRecordExternal on the graph-monitor side stream
+  // (fork/rejoin pattern) if available, falling back to recording directly
+  // on stream_. Used by both recordStart() and recordEnd() to keep the
+  // external event's release fence off the main stream's critical path.
+  void recordExternalEventViaSideStream(
+      cudaEvent_t event,
+      const char* event_label);
+
   std::shared_ptr<TorchCommNCCLX> comm_;
   cudaEvent_t start_event_{};
   // Completion detection event. In both eager and graph modes, this event is

--- a/comms/utils/GraphCaptureSideStream.cc
+++ b/comms/utils/GraphCaptureSideStream.cc
@@ -32,8 +32,30 @@ cudaError_t GraphSideStream::fork_from(
     return cudaErrorInvalidResourceHandle;
   }
 
-  // 1. Fork main → side.
-  cudaError_t err = cudaEventRecord(dep_event_, stream);
+  // 1. Check whether the stream is being captured. If not, run the user
+  // fn directly on main — no fork/rejoin overhead needed.
+  cudaStreamCaptureStatus status = cudaStreamCaptureStatusNone;
+  const cudaGraphNode_t* deps = nullptr;
+  size_t num_deps = 0;
+#if CUDART_VERSION >= 13000
+  const cudaGraphEdgeData* edge_data = nullptr;
+  cudaError_t err = cudaStreamGetCaptureInfo(
+      stream, &status, nullptr, nullptr, &deps, &edge_data, &num_deps);
+#else
+  cudaError_t err = cudaStreamGetCaptureInfo_v2(
+      stream, &status, nullptr, nullptr, &deps, &num_deps);
+#endif
+  if (err != cudaSuccess) {
+    return err;
+  }
+
+  if (status != cudaStreamCaptureStatusActive) {
+    fn(stream);
+    return cudaSuccess;
+  }
+
+  // 2. Fork main → side.
+  err = cudaEventRecord(dep_event_, stream);
   if (err != cudaSuccess) {
     return err;
   }
@@ -42,14 +64,14 @@ cudaError_t GraphSideStream::fork_from(
     return err;
   }
 
-  // 2. Capture main's current dependency set — used in step 5 to rewind
-  // main past the rejoin so subsequent main-stream ops aren't bound to
-  // the side stream.
-  cudaStreamCaptureStatus status = cudaStreamCaptureStatusNone;
-  const cudaGraphNode_t* deps = nullptr;
-  size_t num_deps = 0;
+  // Re-query capture info after the fork. The pointers returned by
+  // cudaStreamGetCaptureInfo are only valid until the next API call on
+  // the stream, so the earlier query's pointers were invalidated by
+  // cudaEventRecord above.
+  deps = nullptr;
+  num_deps = 0;
 #if CUDART_VERSION >= 13000
-  const cudaGraphEdgeData* edge_data = nullptr;
+  edge_data = nullptr;
   err = cudaStreamGetCaptureInfo(
       stream, &status, nullptr, nullptr, &deps, &edge_data, &num_deps);
 #else
@@ -58,14 +80,6 @@ cudaError_t GraphSideStream::fork_from(
 #endif
   if (err != cudaSuccess) {
     return err;
-  }
-
-  if (status != cudaStreamCaptureStatusActive) {
-    // Not capturing — run the user fn directly on main. The upstream
-    // eventRecord/streamWaitEvent calls above were no-ops for capture but
-    // are still valid stream ops; they just added a side-stream sync point.
-    fn(stream);
-    return cudaSuccess;
   }
 
   // Snapshot the captured deps; cudaStreamUpdateCaptureDependencies

--- a/comms/utils/tests/GraphCaptureSideStreamTest.cu
+++ b/comms/utils/tests/GraphCaptureSideStreamTest.cu
@@ -5,6 +5,7 @@
 #include <cuda_runtime.h>
 #include <gtest/gtest.h>
 
+#include <set>
 #include <vector>
 
 using meta::comms::GraphSideStream;
@@ -195,6 +196,265 @@ TEST_F(GraphSideStreamTest, ForkFromRoutesWorkOffMainCriticalPath) {
   EXPECT_EQ(cudaEventDestroy(ext_event), cudaSuccess);
   EXPECT_EQ(cudaStreamDestroy(main), cudaSuccess);
   EXPECT_EQ(cudaFree(dev_counter), cudaSuccess);
+}
+
+// Simulates two back-to-back async collectives inside a single graph capture,
+// mirroring the TorchWorkNCCLX lifecycle:
+//
+//   Per collective:
+//     recordStart    → fork(start_event external) onto side stream
+//     NCCL kernel    → main stream
+//     recordEnd      → fork(end_event external) onto side stream
+//                    → eventRecord(sync_event) on main stream
+//     overlap compute → main stream (runs BEFORE work.wait — this is the
+//                       compute that should overlap with the collective and
+//                       must NOT be blocked by the external event records)
+//     work.wait()    → cudaStreamWaitEvent(main, sync_event)
+//   post-wait compute → main stream
+//
+// Verifies:
+//   - Overlap compute is NOT serialized by side-stream event records
+//   - NCCL kernels ARE ancestors of post-wait compute
+//   - Dep event and side stream are reused correctly across fork_from calls
+//   - The graph instantiates and replays cleanly
+TEST_F(GraphSideStreamTest, AsyncCollectiveLifecycleDoesNotBlockCompute) {
+  GraphSideStream side;
+
+  cudaStream_t main = nullptr;
+  ASSERT_EQ(cudaStreamCreate(&main), cudaSuccess);
+
+  int* dev_buf = nullptr;
+  ASSERT_EQ(cudaMalloc(&dev_buf, sizeof(int)), cudaSuccess);
+  ASSERT_EQ(cudaMemset(dev_buf, 0, sizeof(int)), cudaSuccess);
+
+  // Separate buffer for overlap compute so memset nodes are distinguishable
+  // by address if needed.
+  int* overlap_buf = nullptr;
+  ASSERT_EQ(cudaMalloc(&overlap_buf, sizeof(int)), cudaSuccess);
+  ASSERT_EQ(cudaMemset(overlap_buf, 0, sizeof(int)), cudaSuccess);
+
+  // Two collectives, each with start + end external events and a sync event.
+  constexpr int kNumCollectives = 2;
+  cudaEvent_t start_events[kNumCollectives];
+  cudaEvent_t end_events[kNumCollectives];
+  cudaEvent_t sync_events[kNumCollectives];
+  for (int i = 0; i < kNumCollectives; ++i) {
+    ASSERT_EQ(
+        cudaEventCreateWithFlags(&start_events[i], cudaEventDisableTiming),
+        cudaSuccess);
+    ASSERT_EQ(
+        cudaEventCreateWithFlags(&end_events[i], cudaEventDisableTiming),
+        cudaSuccess);
+    ASSERT_EQ(
+        cudaEventCreateWithFlags(&sync_events[i], cudaEventDisableTiming),
+        cudaSuccess);
+  }
+
+  ASSERT_EQ(
+      cudaStreamBeginCapture(main, cudaStreamCaptureModeThreadLocal),
+      cudaSuccess);
+
+  for (int c = 0; c < kNumCollectives; ++c) {
+    // recordStart: fork start_event onto side stream
+    ASSERT_EQ(
+        side.fork_from(
+            main,
+            [&, c](cudaStream_t s) {
+              (void)cudaEventRecordWithFlags(
+                  start_events[c], s, cudaEventRecordExternal);
+            }),
+        cudaSuccess);
+
+    // NCCL collective kernel (memset as stand-in)
+    ASSERT_EQ(cudaMemsetAsync(dev_buf, 0, sizeof(int), main), cudaSuccess);
+
+    // recordEnd: fork end_event onto side stream
+    ASSERT_EQ(
+        side.fork_from(
+            main,
+            [&, c](cudaStream_t s) {
+              (void)cudaEventRecordWithFlags(
+                  end_events[c], s, cudaEventRecordExternal);
+            }),
+        cudaSuccess);
+
+    // recordEnd: sync_event stays on main stream (the join point)
+    ASSERT_EQ(cudaEventRecord(sync_events[c], main), cudaSuccess);
+
+    // Overlap compute: runs AFTER the collective launches but BEFORE
+    // work.wait(). This is the compute that benefits from the side-stream
+    // optimization — if the external event records were on the main stream,
+    // their release fences would block this compute at replay time.
+    ASSERT_EQ(cudaMemsetAsync(overlap_buf, 0, sizeof(int), main), cudaSuccess);
+
+    // work.wait(): downstream ops wait on sync_event
+    ASSERT_EQ(cudaStreamWaitEvent(main, sync_events[c], 0), cudaSuccess);
+  }
+
+  // Post-wait compute after both collectives complete
+  ASSERT_EQ(cudaMemsetAsync(dev_buf, 0, sizeof(int), main), cudaSuccess);
+
+  cudaGraph_t graph = nullptr;
+  ASSERT_EQ(cudaStreamEndCapture(main, &graph), cudaSuccess);
+  ASSERT_NE(graph, nullptr);
+
+  // Classify nodes.
+  auto nodes = getNodes(graph);
+  std::vector<cudaGraphNode_t> memset_nodes;
+  for (auto n : nodes) {
+    if (nodeType(n) == cudaGraphNodeTypeMemset) {
+      memset_nodes.push_back(n);
+    }
+  }
+
+  // 2 NCCL kernels + 2 overlap computes + 1 post-wait compute = 5 memsets
+  ASSERT_EQ(memset_nodes.size(), 5u);
+
+  // Sort memsets topologically (fewer ancestors = earlier).
+  std::sort(memset_nodes.begin(), memset_nodes.end(), [&](auto a, auto b) {
+    return getPreds(a).size() < getPreds(b).size();
+  });
+
+  // For each overlap compute node, verify no EVENT_RECORD ancestor exists.
+  // The overlap compute nodes are the ones that would be stalled if the
+  // external event records were on the main stream instead of the side stream.
+  for (auto& memset_node : memset_nodes) {
+    // BFS ancestors of this memset node.
+    std::vector<cudaGraphNode_t> bfs = {memset_node};
+    std::set<cudaGraphNode_t> ancestors;
+    while (!bfs.empty()) {
+      auto cur = bfs.back();
+      bfs.pop_back();
+      if (!ancestors.insert(cur).second) {
+        continue;
+      }
+      for (auto p : getPreds(cur)) {
+        bfs.push_back(p);
+      }
+    }
+
+    // No memset node should have an EVENT_RECORD ancestor. The side-stream
+    // external records and fork/rejoin dep-event records must all be off
+    // the critical path.
+    for (auto a : ancestors) {
+      EXPECT_NE(nodeType(a), cudaGraphNodeTypeEventRecord)
+          << "memset node must not have any event record node as ancestor "
+             "(side-stream external records should be off the critical path)";
+    }
+  }
+
+  // The NCCL kernel memsets must be ancestors of the post-wait compute
+  // (the last memset in topological order).
+  auto& post_wait_compute = memset_nodes.back();
+  std::vector<cudaGraphNode_t> bfs = {post_wait_compute};
+  std::set<cudaGraphNode_t> post_wait_ancestors;
+  while (!bfs.empty()) {
+    auto cur = bfs.back();
+    bfs.pop_back();
+    if (!post_wait_ancestors.insert(cur).second) {
+      continue;
+    }
+    for (auto p : getPreds(cur)) {
+      bfs.push_back(p);
+    }
+  }
+  for (size_t i = 0; i < memset_nodes.size() - 1; ++i) {
+    EXPECT_TRUE(post_wait_ancestors.count(memset_nodes[i]))
+        << "memset " << i << " must be an ancestor of post-wait compute";
+  }
+
+  // Verify that the side-stream event record nodes form a totally ordered
+  // chain (they're all on the same captured side stream).
+  //
+  // Identify side-stream event records as EVENT_RECORD nodes that are NOT
+  // ancestors of any memset node (main-stream ops).  The main-stream
+  // dep_event records ARE ancestors of memsets; the side-stream external
+  // records and rejoin dep_event records are not.
+  std::set<cudaGraphNode_t> main_stream_ancestors;
+  for (auto& mn : memset_nodes) {
+    std::vector<cudaGraphNode_t> bfs_m = {mn};
+    while (!bfs_m.empty()) {
+      auto cur = bfs_m.back();
+      bfs_m.pop_back();
+      if (!main_stream_ancestors.insert(cur).second) {
+        continue;
+      }
+      for (auto p : getPreds(cur)) {
+        bfs_m.push_back(p);
+      }
+    }
+  }
+
+  std::vector<cudaGraphNode_t> side_event_records;
+  for (auto n : nodes) {
+    if (nodeType(n) == cudaGraphNodeTypeEventRecord &&
+        main_stream_ancestors.find(n) == main_stream_ancestors.end()) {
+      side_event_records.push_back(n);
+    }
+  }
+
+  // All side-stream event records must form a total order (single chain).
+  // Verify by checking that every pair has an ancestor relationship.
+  // Helper: compute the full ancestor set of a node.
+  auto getAncestors = [&](cudaGraphNode_t node) {
+    std::set<cudaGraphNode_t> ancestors;
+    std::vector<cudaGraphNode_t> q = {node};
+    while (!q.empty()) {
+      auto cur = q.back();
+      q.pop_back();
+      if (!ancestors.insert(cur).second) {
+        continue;
+      }
+      for (auto p : getPreds(cur)) {
+        q.push_back(p);
+      }
+    }
+    return ancestors;
+  };
+
+  for (size_t i = 0; i < side_event_records.size(); ++i) {
+    for (size_t j = i + 1; j < side_event_records.size(); ++j) {
+      auto ancestors_j = getAncestors(side_event_records[j]);
+      auto ancestors_i = getAncestors(side_event_records[i]);
+      bool i_before_j = ancestors_j.count(side_event_records[i]) > 0;
+      bool j_before_i = ancestors_i.count(side_event_records[j]) > 0;
+      EXPECT_TRUE(i_before_j || j_before_i)
+          << "side-stream event records " << i << " and " << j
+          << " must be ordered (one must be an ancestor of the other)";
+    }
+  }
+
+  // Verify the graph is valid by instantiating and replaying, and that
+  // the external events are signaled after replay (watchdog can query them).
+  cudaGraphExec_t exec = nullptr;
+  ASSERT_EQ(
+      cudaGraphInstantiate(&exec, graph, nullptr, nullptr, 0), cudaSuccess);
+  ASSERT_EQ(cudaGraphLaunch(exec, main), cudaSuccess);
+
+  // Wait on each external event directly. If the external records fired
+  // during graph replay, cudaEventSynchronize returns immediately.
+  // If they didn't, the test hangs (timeout).
+  for (int i = 0; i < kNumCollectives; ++i) {
+    EXPECT_EQ(cudaEventSynchronize(start_events[i]), cudaSuccess)
+        << "start_event[" << i
+        << "] must be signaled after graph replay (wait should not block)";
+    EXPECT_EQ(cudaEventSynchronize(end_events[i]), cudaSuccess)
+        << "end_event[" << i
+        << "] must be signaled after graph replay (wait should not block)";
+  }
+
+  ASSERT_EQ(cudaStreamSynchronize(main), cudaSuccess);
+
+  EXPECT_EQ(cudaGraphExecDestroy(exec), cudaSuccess);
+  EXPECT_EQ(cudaGraphDestroy(graph), cudaSuccess);
+  for (int i = 0; i < kNumCollectives; ++i) {
+    EXPECT_EQ(cudaEventDestroy(start_events[i]), cudaSuccess);
+    EXPECT_EQ(cudaEventDestroy(end_events[i]), cudaSuccess);
+    EXPECT_EQ(cudaEventDestroy(sync_events[i]), cudaSuccess);
+  }
+  EXPECT_EQ(cudaStreamDestroy(main), cudaSuccess);
+  EXPECT_EQ(cudaFree(dev_buf), cudaSuccess);
+  EXPECT_EQ(cudaFree(overlap_buf), cudaSuccess);
 }
 
 // Instantiating and replaying the captured graph after fork_from must also


### PR DESCRIPTION
Summary:

the OrderedWorkStreamGuard release mechanism has the same problem that plagued the start/end events that we fixed in the diff below. as such, we need to ensure that the execModeSyncEvent_ record node (baton release) is done on a side stream. this is fine, as the wait nodes will wait until the signal is received.

Reviewed By: ngimel

Differential Revision: D101657267


