### PR TITLE
Rename P2pNvlTransportDevice: per-group methods become the default (#2180)

### DIFF
--- a/comms/ctran/algos/AllToAll/DeviceAllToAllvPipes.cu
+++ b/comms/ctran/algos/AllToAll/DeviceAllToAllvPipes.cu
@@ -37,13 +37,14 @@ __device__ __forceinline__ void send_peer(
     bool use_ll128 = (bytes <= ll128ThresholdBytes) &&
         comms::pipes::can_use_ll128(src, bytes);
     if (use_ll128) {
-      transport.p2p_nvl.ll128_send(
+      transport.p2p_nvl.ll128_send_group(
           group, const_cast<char*>(src), bytes, timeout);
     } else {
-      transport.p2p_nvl.send(group, const_cast<char*>(src), bytes, timeout);
+      transport.p2p_nvl.send_group(
+          group, const_cast<char*>(src), bytes, timeout);
     }
   } else {
-    transport.p2p_nvl.send(group, const_cast<char*>(src), bytes, timeout);
+    transport.p2p_nvl.send_group(group, const_cast<char*>(src), bytes, timeout);
   }
 }
 
@@ -60,12 +61,12 @@ __device__ __forceinline__ void recv_peer(
     bool use_ll128 = (bytes <= ll128ThresholdBytes) &&
         comms::pipes::can_use_ll128(dst, bytes);
     if (use_ll128) {
-      transport.p2p_nvl.ll128_recv(group, dst, bytes, timeout);
+      transport.p2p_nvl.ll128_recv_group(group, dst, bytes, timeout);
     } else {
-      transport.p2p_nvl.recv(group, dst, bytes, timeout);
+      transport.p2p_nvl.recv_group(group, dst, bytes, timeout);
     }
   } else {
-    transport.p2p_nvl.recv(group, dst, bytes, timeout);
+    transport.p2p_nvl.recv_group(group, dst, bytes, timeout);
   }
 }
 
@@ -106,7 +107,7 @@ __global__ void ncclKernelDeviceAllToAllvPipes(
     size_t recvOffset = computeDisplacement(args.recvcounts_d, globalRank) *
         recvMultiplier * elementSize;
 
-    transports[globalRank].self.put(
+    transports[globalRank].self.put_group(
         group,
         static_cast<char*>(args.recvbuff) + recvOffset,
         static_cast<const char*>(args.sendbuff) + sendOffset,
@@ -136,7 +137,7 @@ __global__ void ncclKernelDeviceAllToAllvPipes(
 
     if (peerGlobalRank == myRank) {
       if (partition_id == 0) {
-        transports[peerGlobalRank].self.put(
+        transports[peerGlobalRank].self.put_group(
             group_per_peer, dst_ptr, src_ptr, sendBytes);
       }
     } else if (partition_id == 0) {

--- a/comms/ctran/algos/SendRecv/SendRecvP2p.cu
+++ b/comms/ctran/algos/SendRecv/SendRecvP2p.cu
@@ -18,7 +18,7 @@ __device__ __forceinline__ void sendImpl(
   for (auto i = 0; i < numSends; i++) {
     const auto nbytes = sends[i].nbytes;
     const auto peerLocalRank = sends[i].peerLocalRank;
-    nvlTransportsBase[peerLocalRank].send(group, sends[i].buff, nbytes);
+    nvlTransportsBase[peerLocalRank].send_group(group, sends[i].buff, nbytes);
   }
 }
 
@@ -30,7 +30,7 @@ __device__ __forceinline__ void recvImpl(
   for (auto i = 0; i < numRecvs; i++) {
     const auto nbytes = recvs[i].nbytes;
     const auto peerLocalRank = recvs[i].peerLocalRank;
-    nvlTransportsBase[peerLocalRank].recv(group, recvs[i].buff, nbytes);
+    nvlTransportsBase[peerLocalRank].recv_group(group, recvs[i].buff, nbytes);
   }
 }
 

--- a/comms/pipes/MultiPeerDeviceHandle.cuh
+++ b/comms/pipes/MultiPeerDeviceHandle.cuh
@@ -39,9 +39,8 @@ namespace comms::pipes {
  *     for (int rank = 0; rank < handle.nRanks; ++rank) {
  *       switch (handle.get_type(rank)) {
  *         case TransportType::SELF: ... break;
- *         case TransportType::P2P_NVL: handle.get_nvl(rank).send(...); break;
- *         case TransportType::P2P_IBGDA: handle.get_ibgda(rank).put(...);
- * break;
+ *         case TransportType::P2P_NVL: handle.get_nvl(rank).send_group(...);
+ * break; case TransportType::P2P_IBGDA: handle.get_ibgda(rank).put(...); break;
  *       }
  *     }
  *   }

--- a/comms/pipes/MultiPeerNvlTransport.h
+++ b/comms/pipes/MultiPeerNvlTransport.h
@@ -54,7 +54,7 @@ struct MultiPeerNvlTransportConfig {
 
   // Maximum block count for the tile sendrecv protocol.
   // Allocates persistent step state and dedicated tile signals internally.
-  // send_tile/recv_tile use these without user-managed state.
+  // send/recv use these without user-managed state.
   int tile_max_groups{128};
 
   // If true, use dual chunk state buffers (one on each side) for local polling
@@ -90,9 +90,10 @@ struct MultiPeerNvlTransportConfig {
   bool useDualStateBuffer{false};
 
   // Size of LL128 packet buffer per peer (bytes).
-  // When > 0, allocates LL128 buffers and enables ll128_send/recv/forward
-  // on P2pNvlTransportDevice. When 0 (default), LL128 is disabled.
-  // Use ll128_buffer_size() from Ll128Packet.cuh to compute from message size.
+  // When > 0, allocates LL128 buffers and enables
+  // ll128_send_group/recv_group/forward_groups on P2pNvlTransportDevice. When
+  // 0 (default), LL128 is disabled. Use ll128_buffer_size() from
+  // Ll128Packet.cuh to compute from message size.
   std::size_t ll128BufferSize{0};
 };
 

--- a/comms/pipes/P2pNvlTransportDevice.cuh
+++ b/comms/pipes/P2pNvlTransportDevice.cuh
@@ -331,14 +331,14 @@ struct P2pNvlTransportOptions {
  *
  *   // Kernel (sender on GPU A)
  *   __global__ void sendKernel(P2pNvlTransportDevice p2p, void* src, size_t n)
- * { auto group = make_warp_group(); p2p.send(group, src, n);  // Writes to GPU
- * B's buffers via NVLink
+ * { auto group = make_warp_group(); p2p.send_group(group, src, n);  // Writes
+ * to GPU B's buffers via NVLink
  *   }
  *
  *   // Kernel (receiver on GPU B)
  *   __global__ void recvKernel(P2pNvlTransportDevice p2p, void* dst, size_t n)
- * { auto group = make_warp_group(); p2p.recv(group, dst, n);  // Reads from own
- * local buffers
+ * { auto group = make_warp_group(); p2p.recv_group(group, dst, n);  // Reads
+ * from own local buffers
  *   }
  */
 class P2pNvlTransportDevice {
@@ -362,14 +362,14 @@ class P2pNvlTransportDevice {
   __host__ __device__ ~P2pNvlTransportDevice() = default;
 
   /**
-   * send - Cooperative transfer to peer GPU over NVLink
+   * send_group - Cooperative transfer to peer GPU over NVLink
    *
    * Sends 'nbytes' bytes from srcbuff to the peer GPU using pipelined staged
    * transfer with fine-grained chunk-level synchronization. Multiple groups
    * collaborate to transfer the data in parallel — work is distributed across
    * all calling groups via for_each_item_contiguous/strided.
    *
-   * All calling groups must pass the same src/nbytes. Unlike send_tile(),
+   * All calling groups must pass the same src/nbytes. Unlike send(),
    * which has each group independently send its own partition of data, this
    * version has all groups cooperate on the entire buffer.
    *
@@ -416,7 +416,7 @@ class P2pNvlTransportDevice {
    *   stateOffset = pipelineIdx × chunksPerStep          (into state buffer)
    *   stepOffset = stepId × dataBufferSize               (into source data)
    **/
-  __device__ __forceinline__ void send(
+  __device__ __forceinline__ void send_group(
       ThreadGroup& group,
       void* srcbuff,
       std::size_t nbytes,
@@ -424,7 +424,7 @@ class P2pNvlTransportDevice {
 #ifdef __CUDA_ARCH__
     if (options_.dataBufferSize == 0) {
       printf(
-          "P2pNvlTransportDevice::send() requires staging buffer"
+          "P2pNvlTransportDevice::send_group() requires staging buffer"
           " (dataBufferSize > 0) at %s:%d\n",
           __FILE__,
           __LINE__);
@@ -644,10 +644,11 @@ class P2pNvlTransportDevice {
   }
 
   /**
-   * recv - Receive data from peer GPU over NVLink
+   * recv_group - Receive data from peer GPU over NVLink
    *
-   * Receives 'nbytes' bytes into dstbuff from the peer GPU's send() call.
-   * Must be called simultaneously with peer's send() for the same byte count.
+   * Receives 'nbytes' bytes into dstbuff from the peer GPU's send_group()
+   * call. Must be called simultaneously with peer's send_group() for the same
+   * byte count.
    *
    * ALGORITHM:
    * ==========
@@ -682,7 +683,7 @@ class P2pNvlTransportDevice {
    *                                   copy data to dst
    *                                   state = -1 ────────▶ [sender unblocks]
    */
-  __device__ __forceinline__ void recv(
+  __device__ __forceinline__ void recv_group(
       ThreadGroup& group,
       void* dstbuff,
       std::size_t nbytes,
@@ -690,7 +691,7 @@ class P2pNvlTransportDevice {
 #ifdef __CUDA_ARCH__
     if (options_.dataBufferSize == 0) {
       printf(
-          "P2pNvlTransportDevice::recv() requires staging buffer"
+          "P2pNvlTransportDevice::recv_group() requires staging buffer"
           " (dataBufferSize > 0) at %s:%d\n",
           __FILE__,
           __LINE__);
@@ -713,7 +714,7 @@ class P2pNvlTransportDevice {
       // =====================================================================
       // DUAL CHUNK STATE MODE (Receiver side)
       // =====================================================================
-      // See send() for detailed state machine, correctness analysis, and
+      // See send_group() for detailed state machine, correctness analysis, and
       // explanation of why two group.sync() calls are required.
       //
       // Receiver steps per chunk:
@@ -771,8 +772,8 @@ class P2pNvlTransportDevice {
               group);
 
           // Sync #1 + plain write: barrier all threads, then leader
-          // writes UNREADY to local receiverState (see send() correctness
-          // note for why two syncs are required)
+          // writes UNREADY to local receiverState (see send_group()
+          // correctness note for why two syncs are required)
           localReceiverState.unready(group);
 
           // Sync #2 + release store: barrier all threads (flushes the
@@ -786,7 +787,7 @@ class P2pNvlTransportDevice {
       // =====================================================================
       // SINGLE CHUNK STATE MODE (Original Design)
       // =====================================================================
-      // See send() for detailed state machine documentation.
+      // See send_group() for detailed state machine documentation.
       //
       // Receiver side:
       // 1. Wait LOCAL receiverStateBuffer for sender's signal (stepId)
@@ -857,20 +858,20 @@ class P2pNvlTransportDevice {
   }
 
   /**
-   * put - Cooperative local memory copy using vectorized operations
+   * put_group - Cooperative local memory copy using vectorized operations
    *
    * Performs a high-performance vectorized copy from src_d to dst_d.
    * Multiple groups collaborate on the same src/dst/nbytes — work is
    * distributed across all calling groups via for_each_item_contiguous
    * by global group_id.
    *
-   * All calling groups must pass the same src/dst/nbytes. Unlike put_tile(),
+   * All calling groups must pass the same src/dst/nbytes. Unlike put(),
    * which has each group independently copy its own partition of data, this
    * version has all groups cooperate on the entire buffer.
    *
-   * Contrast with send(): send() writes to the peer GPU's staging buffer
-   * via NVLink with pipelined flow control. put() copies within local memory
-   * without any signaling or flow control.
+   * Contrast with send_group(): send_group() writes to the peer GPU's staging
+   * buffer via NVLink with pipelined flow control. put_group() copies within
+   * local memory without any signaling or flow control.
    *
    * @param group ThreadGroup for cooperative processing
    * @param dst_d Destination pointer (device memory)
@@ -879,10 +880,12 @@ class P2pNvlTransportDevice {
    *
    * @return Number of bytes written by the current thread group
    */
-  __device__ __forceinline__ std::size_t
-  put(ThreadGroup& group, char* dst_d, const char* src_d, std::size_t nbytes) {
+  __device__ __forceinline__ std::size_t put_group(
+      [[maybe_unused]] ThreadGroup& group,
+      [[maybe_unused]] char* dst_d,
+      [[maybe_unused]] const char* src_d,
+      [[maybe_unused]] std::size_t nbytes) {
 #ifdef __CUDA_ARCH__
-    // Early return for no-op cases
     if (nbytes == 0) {
       return 0;
     }
@@ -924,17 +927,17 @@ class P2pNvlTransportDevice {
   }
 
   /**
-   * put_tile - Independent per-group local memory copy
+   * put - Independent per-group local memory copy
    *
    * Performs a vectorized copy from src_d to dst_d using only threads within
    * the calling group. Each group operates independently on its own data,
-   * so different groups can call put_tile() with different src/dst/nbytes.
+   * so different groups can call put() with different src/dst/nbytes.
    *
-   * Unlike put(), which has all groups cooperate on the same buffer,
-   * put_tile() has each group work on its own partition independently.
+   * Unlike put_group(), which has all groups cooperate on the same buffer,
+   * put() has each group work on its own partition independently.
    *
-   * Contrast with send_tile(): send_tile() writes to the peer GPU's staging
-   * buffer via NVLink with pipelined flow control and signaling. put_tile()
+   * Contrast with send(): send() writes to the peer GPU's staging
+   * buffer via NVLink with pipelined flow control and signaling. put()
    * copies within local memory without any signaling or flow control.
    *
    * @param group ThreadGroup for cooperative processing (group-local)
@@ -942,7 +945,7 @@ class P2pNvlTransportDevice {
    * @param src_d Source pointer (device memory)
    * @param nbytes Number of bytes to copy
    */
-  __device__ __forceinline__ void put_tile(
+  __device__ __forceinline__ void put(
       ThreadGroup& group,
       char* __restrict__ dst_d,
       const char* __restrict__ src_d,
@@ -1074,7 +1077,7 @@ class P2pNvlTransportDevice {
   // ===========================================================================
 
   /**
-   * ll128_send — Send data to peer's LL128 buffer via NVLink.
+   * ll128_send_group — Send data to peer's LL128 buffer via NVLink.
    *
    * Packs user data into LL128 packets and volatile-stores them to the
    * peer's LL128 buffer with inline flag signaling.
@@ -1086,7 +1089,7 @@ class P2pNvlTransportDevice {
    * @param nbytes  Total bytes (must be a multiple of 16)
    * @param timeout Timeout for flag polling
    */
-  __device__ __forceinline__ void ll128_send(
+  __device__ __forceinline__ void ll128_send_group(
       const ThreadGroup& group,
       const char* src,
       size_t nbytes,
@@ -1106,7 +1109,7 @@ class P2pNvlTransportDevice {
   }
 
   /**
-   * ll128_recv — Receive data from local LL128 buffer.
+   * ll128_recv_group — Receive data from local LL128 buffer.
    *
    * Polls the local LL128 buffer (written remotely by peer), reads
    * payload to output buffer, and ACKs with READY_TO_WRITE.
@@ -1118,7 +1121,7 @@ class P2pNvlTransportDevice {
    * @param nbytes  Total bytes (must be a multiple of 16)
    * @param timeout Timeout for flag polling
    */
-  __device__ __forceinline__ void ll128_recv(
+  __device__ __forceinline__ void ll128_recv_group(
       const ThreadGroup& group,
       char* dst,
       size_t nbytes,
@@ -1138,7 +1141,7 @@ class P2pNvlTransportDevice {
   }
 
   /**
-   * ll128_forward — Receive from predecessor and forward to successor.
+   * ll128_forward_group — Receive from predecessor and forward to successor.
    *
    * Reads from this transport's local LL128 buffer (predecessor wrote here),
    * forwards to successor_transport's remote LL128 buffer, copies payload
@@ -1152,7 +1155,7 @@ class P2pNvlTransportDevice {
    * @param successor_transport  Transport for the successor peer
    * @param timeout              Timeout for flag polling
    */
-  __device__ __forceinline__ void ll128_forward(
+  __device__ __forceinline__ void ll128_forward_group(
       const ThreadGroup& group,
       char* dst,
       size_t nbytes,
@@ -1190,22 +1193,22 @@ class P2pNvlTransportDevice {
   }
 
   /**
-   * send_tile - Independent per-group transfer to peer GPU over NVLink
+   * send - Independent per-group transfer to peer GPU over NVLink
    *
    * Each group independently sends its own tile of data to the peer GPU's
    * staging buffer via NVLink, with per-group pipelined flow control and
-   * signaling. Different groups can call send_tile() with different
+   * signaling. Different groups can call send() with different
    * src/nbytes.
    *
-   * Unlike send(), which has all groups cooperate on the same buffer,
-   * send_tile() has each group work on its own partition independently.
+   * Unlike send_group(), which has all groups cooperate on the same buffer,
+   * send() has each group work on its own partition independently.
    *
-   * @param active_blocks Number of blocks calling send_tile concurrently.
+   * @param active_blocks Number of blocks calling send concurrently.
    *   0 means use tile_max_groups from transport config.
    * @param max_signal_bytes Hint for max bytes between DATA_READY signals.
    *   0 means one signal per slot fill. Capped at per_block_slot_size.
    */
-  __device__ __forceinline__ void send_tile(
+  __device__ __forceinline__ void send(
       ThreadGroup& group,
       const void* __restrict__ src,
       std::size_t nbytes,
@@ -1223,7 +1226,7 @@ class P2pNvlTransportDevice {
 
     if (effActive > max_groups) {
       printf(
-          "send_tile: active_blocks=%d > tile_max_groups=%d. "
+          "send: active_blocks=%d > tile_max_groups=%d. "
           "Signal and step_state arrays would be accessed out of bounds.\n",
           effActive,
           max_groups);
@@ -1232,8 +1235,8 @@ class P2pNvlTransportDevice {
 
     if (groupId >= effActive) {
       printf(
-          "send_tile: groupId=%d >= active_blocks=%d. "
-          "Too many groups calling send_tile.\n",
+          "send: groupId=%d >= active_blocks=%d. "
+          "Too many groups calling send.\n",
           groupId,
           effActive);
       __trap();
@@ -1246,7 +1249,7 @@ class P2pNvlTransportDevice {
     const std::size_t perBlockSlotSize = (slotSize / effActive) & ~15ULL;
     if (perBlockSlotSize == 0) {
       printf(
-          "send_tile/recv_tile: perBlockSlotSize is 0 "
+          "send/recv: perBlockSlotSize is 0 "
           "(dataBufferSize=%llu, active_blocks=%d). "
           "Increase dataBufferSize or decrease active_blocks.\n",
           (unsigned long long)slotSize,
@@ -1318,7 +1321,7 @@ class P2pNvlTransportDevice {
 #endif
   }
 
-  __device__ __forceinline__ void recv_tile(
+  __device__ __forceinline__ void recv(
       ThreadGroup& group,
       void* __restrict__ dst,
       std::size_t nbytes,
@@ -1336,7 +1339,7 @@ class P2pNvlTransportDevice {
 
     if (effActive > max_groups) {
       printf(
-          "recv_tile: active_blocks=%d > tile_max_groups=%d. "
+          "recv: active_blocks=%d > tile_max_groups=%d. "
           "Signal and step_state arrays would be accessed out of bounds.\n",
           effActive,
           max_groups);
@@ -1345,8 +1348,8 @@ class P2pNvlTransportDevice {
 
     if (groupId >= effActive) {
       printf(
-          "recv_tile: groupId=%d >= active_blocks=%d. "
-          "Too many groups calling recv_tile.\n",
+          "recv: groupId=%d >= active_blocks=%d. "
+          "Too many groups calling recv.\n",
           groupId,
           effActive);
       __trap();
@@ -1359,7 +1362,7 @@ class P2pNvlTransportDevice {
     const std::size_t perBlockSlotSize = (slotSize / effActive) & ~15ULL;
     if (perBlockSlotSize == 0) {
       printf(
-          "send_tile/recv_tile: perBlockSlotSize is 0 "
+          "send/recv: perBlockSlotSize is 0 "
           "(dataBufferSize=%llu, active_blocks=%d). "
           "Increase dataBufferSize or decrease active_blocks.\n",
           (unsigned long long)slotSize,

--- a/comms/pipes/P2pSelfTransportDevice.cuh
+++ b/comms/pipes/P2pSelfTransportDevice.cuh
@@ -63,7 +63,7 @@ class P2pSelfTransportDevice {
   }
 
   /**
-   * put - Direct local memory copy using vectorized operations
+   * put_group - Direct local memory copy using vectorized operations
    *
    * Performs a high-performance vectorized copy from src_d to dst_d using
    * memcpy_vectorized. The work is distributed across ALL thread groups
@@ -81,8 +81,11 @@ class P2pSelfTransportDevice {
    * @param src_d Source pointer (device memory)
    * @param nbytes Number of bytes to write
    */
-  __device__ __forceinline__ void
-  put(ThreadGroup& group, char* dst_d, const char* src_d, std::size_t nbytes) {
+  __device__ __forceinline__ void put_group(
+      [[maybe_unused]] ThreadGroup& group,
+      [[maybe_unused]] char* dst_d,
+      [[maybe_unused]] const char* src_d,
+      [[maybe_unused]] std::size_t nbytes) {
 #ifdef __CUDA_ARCH__
     // Early return for no-op cases (check before overlap to handle dst == src)
     if (nbytes == 0 || dst_d == src_d) {
@@ -124,21 +127,21 @@ class P2pSelfTransportDevice {
 #endif
   }
   /**
-   * put_tile - Per-group local memory copy using vectorized operations
+   * put - Per-group local memory copy using vectorized operations
    *
    * Performs a vectorized copy from src_d to dst_d using only threads within
    * the calling group. Each group operates independently on its own data,
-   * so different groups can call put_tile() with different src/dst/nbytes.
+   * so different groups can call put() with different src/dst/nbytes.
    *
-   * Contrast with put(): put() is a grid-collective where all groups must
-   * cooperate on the same data. put_tile() is per-group.
+   * Contrast with put_group(): put_group() is a grid-collective where all
+   * groups must cooperate on the same data. put() is per-group.
    *
    * @param group ThreadGroup for cooperative processing (group-local)
    * @param dst_d Destination pointer (device memory)
    * @param src_d Source pointer (device memory)
    * @param nbytes Number of bytes to copy
    */
-  __device__ __forceinline__ void put_tile(
+  __device__ __forceinline__ void put(
       ThreadGroup& group,
       char* __restrict__ dst_d,
       const char* __restrict__ src_d,

--- a/comms/pipes/ThreadGroup.cuh
+++ b/comms/pipes/ThreadGroup.cuh
@@ -482,9 +482,9 @@ struct PartitionResult {
  * ==================================
  *   auto [partition_id, subgroup] = warp.partition(2);
  *   if (partition_id == 0) {
- *     p2p.send(subgroup, sendBuff, nBytes);  // warps 0-15
+ *     p2p.send_group(subgroup, sendBuff, nBytes);  // warps 0-15
  *   } else {
- *     p2p.recv(subgroup, recvBuff, nBytes);  // warps 16-31
+ *     p2p.recv_group(subgroup, recvBuff, nBytes);  // warps 16-31
  *   }
  *
  * @param num_partitions Number of partitions to create (must be <=
@@ -591,11 +591,11 @@ __device__ inline PartitionResult ThreadGroup::partition(
  *   uint32_t weights[] = {3, 0, 1};
  *   auto [partition_id, subgroup] = warp.partition(weights);
  *   if (partition_id == 0) {
- *     p2p.send(subgroup, sendBuff, nBytes);  // 24 warps
+ *     p2p.send_group(subgroup, sendBuff, nBytes);  // 24 warps
  *   } else if (partition_id == 1) {
  *     // No warps assigned (zero weight)
  *   } else {
- *     p2p.recv(subgroup, recvBuff, nBytes);  // 8 warps
+ *     p2p.recv_group(subgroup, recvBuff, nBytes);  // 8 warps
  *   }
  *
  * @param weights Span of relative weights (non-zero count must be <=
@@ -702,9 +702,9 @@ __device__ inline PartitionResult ThreadGroup::partition(
  * =================================
  *   auto [partition_id, subgroup] = group.partition_interleaved(2);
  *   if (partition_id == 0) {
- *     p2p.recv(subgroup, recvBuff, nBytes);  // blocks 0,2,4,...,30
+ *     p2p.recv_group(subgroup, recvBuff, nBytes);  // blocks 0,2,4,...,30
  *   } else {
- *     p2p.send(subgroup, sendBuff, nBytes);  // blocks 1,3,5,...,31
+ *     p2p.send_group(subgroup, sendBuff, nBytes);  // blocks 1,3,5,...,31
  *   }
  *
  * @param num_partitions Number of partitions (typically 2 for send/recv)

--- a/comms/pipes/TiledBuffer.cuh
+++ b/comms/pipes/TiledBuffer.cuh
@@ -21,12 +21,12 @@ struct ThreadGroup;
  *
  *   // Mode 1: explicit tile count (host or device)
  *   TiledBuffer<char> tiles(ptr, nbytes, numBlocks);
- *   p2p.send_tile(sub, tiles.tile_data(blockId), tiles.tile_bytes(blockId),
+ *   p2p.send(sub, tiles.tile_data(blockId), tiles.tile_bytes(blockId),
  * ...);
  *
  *   // Mode 2: bind to ThreadGroup (device only, preferred)
  *   TiledBuffer<char> tile(ptr, nbytes, sub);
- *   p2p.send_tile(sub, tile.data(), tile.bytes(), ...);
+ *   p2p.send(sub, tile.data(), tile.bytes(), ...);
  *
  * Mode 2 derives num_tiles from group.total_groups and indexes by
  * group.group_id, eliminating manual blockId bookkeeping.

--- a/comms/pipes/benchmarks/BenchmarkKernel.cu
+++ b/comms/pipes/benchmarks/BenchmarkKernel.cu
@@ -17,7 +17,7 @@ __global__ void p2pSend(
     Timeout timeout) {
   timeout.start();
   auto group = make_thread_group(groupScope);
-  p2p.send(group, srcBuff, nBytes, timeout);
+  p2p.send_group(group, srcBuff, nBytes, timeout);
 }
 
 __global__ void p2pRecv(
@@ -28,7 +28,7 @@ __global__ void p2pRecv(
     Timeout timeout) {
   timeout.start();
   auto group = make_thread_group(groupScope);
-  p2p.recv(group, dstBuff, nBytes, timeout);
+  p2p.recv_group(group, dstBuff, nBytes, timeout);
 }
 
 __global__ void p2pSendTimed(
@@ -45,7 +45,7 @@ __global__ void p2pSendTimed(
     stats->startCycle = clock64();
   }
 
-  p2p.send(group, srcBuff, nBytes);
+  p2p.send_group(group, srcBuff, nBytes);
 
   // Only first thread globally records end time
   if (globalThreadId == 0) {
@@ -69,7 +69,7 @@ __global__ void p2pRecvTimed(
     stats->startCycle = clock64();
   }
 
-  p2p.recv(group, dstBuff, nBytes);
+  p2p.recv_group(group, dstBuff, nBytes);
 
   // Only first thread globally records end time
   if (globalThreadId == 0) {
@@ -92,9 +92,9 @@ __global__ __launch_bounds__(512, 1) void p2pBidirectional(
   // Partition groups into 2: half for send, half for recv
   auto [partition_id, subgroup] = group.partition_interleaved(2);
   if (partition_id == 0) {
-    p2p.send(subgroup, sendBuff, nBytes, timeout);
+    p2p.send_group(subgroup, sendBuff, nBytes, timeout);
   } else {
-    p2p.recv(subgroup, recvBuff, nBytes, timeout);
+    p2p.recv_group(subgroup, recvBuff, nBytes, timeout);
   }
 }
 
@@ -125,7 +125,8 @@ __global__ void p2pLl128Send(
     Timeout timeout) {
   timeout.start();
   auto group = make_warp_group();
-  p2p.ll128_send(group, static_cast<const char*>(srcBuff), nBytes, timeout);
+  p2p.ll128_send_group(
+      group, static_cast<const char*>(srcBuff), nBytes, timeout);
 }
 
 __global__ void p2pLl128Recv(
@@ -135,7 +136,7 @@ __global__ void p2pLl128Recv(
     Timeout timeout) {
   timeout.start();
   auto group = make_warp_group();
-  p2p.ll128_recv(group, static_cast<char*>(dstBuff), nBytes, timeout);
+  p2p.ll128_recv_group(group, static_cast<char*>(dstBuff), nBytes, timeout);
 }
 
 __global__ void p2pLl128Bidirectional(
@@ -148,10 +149,11 @@ __global__ void p2pLl128Bidirectional(
   auto group = make_warp_group();
   auto [partition_id, subgroup] = group.partition_interleaved(2);
   if (partition_id == 0) {
-    p2p.ll128_send(
+    p2p.ll128_send_group(
         subgroup, static_cast<const char*>(sendBuff), nBytes, timeout);
   } else {
-    p2p.ll128_recv(subgroup, static_cast<char*>(recvBuff), nBytes, timeout);
+    p2p.ll128_recv_group(
+        subgroup, static_cast<char*>(recvBuff), nBytes, timeout);
   }
 }
 

--- a/comms/pipes/benchmarks/SelfTransportBench.cc
+++ b/comms/pipes/benchmarks/SelfTransportBench.cc
@@ -91,7 +91,7 @@ static void selfTransportPut(
 }
 
 /**
- * Benchmark P2pSelfTransportDevice::put_tile() for per-group local copies.
+ * Benchmark P2pSelfTransportDevice::put() for per-group local copies.
  * Each block independently copies its own tile (totalBytes / nBlocks).
  */
 static void selfTransportPutTile(
@@ -347,7 +347,7 @@ BENCHMARK_MULTI_PARAM_COUNTERS(
 
 BENCHMARK_DRAW_LINE();
 
-// Self transport put_tile benchmarks - 8MB with different block counts
+// Self transport put benchmarks (per-group) - 8MB with different block counts
 BENCHMARK_MULTI_PARAM_COUNTERS(
     selfTransportPutTile,
     size_8MB_2blocks,
@@ -379,7 +379,7 @@ BENCHMARK_MULTI_PARAM_COUNTERS(
     8 * 1024 * 1024,
     64);
 
-// Self transport put_tile benchmarks - 64MB with different block counts
+// Self transport put benchmarks (per-group) - 64MB with different block counts
 BENCHMARK_MULTI_PARAM_COUNTERS(
     selfTransportPutTile,
     size_64MB_2blocks,
@@ -411,7 +411,7 @@ BENCHMARK_MULTI_PARAM_COUNTERS(
     64 * 1024 * 1024,
     64);
 
-// Self transport put_tile benchmarks - 256MB with different block counts
+// Self transport put benchmarks (per-group) - 256MB with different block counts
 BENCHMARK_MULTI_PARAM_COUNTERS(
     selfTransportPutTile,
     size_256MB_2blocks,
@@ -443,7 +443,7 @@ BENCHMARK_MULTI_PARAM_COUNTERS(
     256 * 1024 * 1024,
     64);
 
-// Self transport put_tile benchmarks - 512MB with different block counts
+// Self transport put benchmarks (per-group) - 512MB with different block counts
 BENCHMARK_MULTI_PARAM_COUNTERS(
     selfTransportPutTile,
     size_512MB_2blocks,
@@ -475,7 +475,7 @@ BENCHMARK_MULTI_PARAM_COUNTERS(
     512 * 1024 * 1024,
     64);
 
-// Self transport put_tile benchmarks - 1GB with 32 blocks
+// Self transport put benchmarks (per-group) - 1GB with 32 blocks
 BENCHMARK_MULTI_PARAM_COUNTERS(
     selfTransportPutTile,
     size_1GB_32blocks,

--- a/comms/pipes/benchmarks/SelfTransportBench.cu
+++ b/comms/pipes/benchmarks/SelfTransportBench.cu
@@ -14,7 +14,7 @@ __global__ void selfTransportPutKernel(
   auto group = make_warp_group();
 
   for (int run = 0; run < nRuns; ++run) {
-    transport.put(group, dst, src, nBytes);
+    transport.put_group(group, dst, src, nBytes);
   }
 }
 
@@ -28,7 +28,7 @@ __global__ void selfTransportPutTileKernel(
   std::size_t offset = group.group_id * tileSize;
 
   for (int run = 0; run < nRuns; ++run) {
-    transport.put_tile(group, dst + offset, src + offset, tileSize);
+    transport.put(group, dst + offset, src + offset, tileSize);
   }
 }
 

--- a/comms/pipes/benchmarks/TileSendRecv.cu
+++ b/comms/pipes/benchmarks/TileSendRecv.cu
@@ -1,7 +1,7 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 //
 // Tile send/recv kernels — caller partitions data across blocks,
-// each block calls P2pNvlTransportDevice::send_tile/recv_tile.
+// each block calls P2pNvlTransportDevice::send/recv.
 
 #include "comms/pipes/benchmarks/TileSendRecv.cuh"
 
@@ -22,7 +22,7 @@ __global__ __launch_bounds__(512, 1) void p2pTileSendRecv(
   const int blockId = sub.group_id;
 
   if (role == 0) {
-    p2p.send_tile(
+    p2p.send(
         sub,
         sendTiles.tile_data(blockId),
         sendTiles.tile_bytes(blockId),
@@ -30,7 +30,7 @@ __global__ __launch_bounds__(512, 1) void p2pTileSendRecv(
         max_signal_bytes,
         timeout);
   } else {
-    p2p.recv_tile(
+    p2p.recv(
         sub,
         recvTiles.tile_data(blockId),
         recvTiles.tile_bytes(blockId),
@@ -109,7 +109,7 @@ __global__ __launch_bounds__(512, 1) void p2pTileSendRecvDynamic(
   }
 
   if (role == 0) {
-    p2p.send_tile(
+    p2p.send(
         sub,
         sendTiles.tile_data(blockId),
         sendTiles.tile_bytes(blockId),
@@ -117,7 +117,7 @@ __global__ __launch_bounds__(512, 1) void p2pTileSendRecvDynamic(
         /*max_signal_bytes=*/0,
         timeout);
   } else {
-    p2p.recv_tile(
+    p2p.recv(
         sub,
         recvTiles.tile_data(blockId),
         recvTiles.tile_bytes(blockId),

--- a/comms/pipes/benchmarks/TileSendRecv.cuh
+++ b/comms/pipes/benchmarks/TileSendRecv.cuh
@@ -31,7 +31,7 @@
 // Each sender block i sends tile i; each receiver block i receives tile i.
 // Sender block i is paired with receiver block i on the remote GPU.
 //
-// PIPELINING (inside send_tile / recv_tile)
+// PIPELINING (inside send / recv)
 // =========================================
 // Each block's tile may be larger than the per-block staging area. The tile
 // is therefore pipelined through the staging buffer in multiple steps:

--- a/comms/pipes/collectives/AllGather.cuh
+++ b/comms/pipes/collectives/AllGather.cuh
@@ -109,7 +109,7 @@ __device__ __forceinline__ void all_gather(
 
     auto& transport = transports_per_rank[my_rank_id];
     assert(transport.type == TransportType::SELF);
-    transport.self.put(group, dst, src, sendcount);
+    transport.self.put_group(group, dst, src, sendcount);
     return;
   }
 
@@ -145,7 +145,7 @@ __device__ __forceinline__ void all_gather(
     }
 #endif
 
-    transport.self.put(group_per_peer, dst, src, sendcount);
+    transport.self.put_group(group_per_peer, dst, src, sendcount);
     return;
   }
 
@@ -177,14 +177,14 @@ __device__ __forceinline__ void all_gather(
   if (is_send) {
     // Send my local data to peer
     // Note: All sends use the same source buffer (sendbuff_d)
-    transport.p2p_nvl.send(
+    transport.p2p_nvl.send_group(
         group_per_peer,
         static_cast<char*>(const_cast<void*>(sendbuff_d)),
         sendcount,
         timeout);
   } else {
     // Receive peer's data into my recvbuff at appropriate offset
-    transport.p2p_nvl.recv(
+    transport.p2p_nvl.recv_group(
         group_per_peer,
         static_cast<char*>(recvbuff_d) + recv_offset,
         sendcount,

--- a/comms/pipes/collectives/AllToAllv.cuh
+++ b/comms/pipes/collectives/AllToAllv.cuh
@@ -127,7 +127,7 @@ __device__ __forceinline__ void all_to_allv(
 
     auto& transport = transports_per_rank[my_rank_id];
     PIPES_DEVICE_CHECK(transport.type == TransportType::SELF);
-    transport.self.put(group, dst, src, send_info.nbytes);
+    transport.self.put_group(group, dst, src, send_info.nbytes);
     return;
   }
 
@@ -168,7 +168,7 @@ __device__ __forceinline__ void all_to_allv(
 
     // Only one partition is active for self-copy
     if (partition_id == 0) {
-      transport.self.put(group_per_peer, dst, src, send_info.nbytes);
+      transport.self.put_group(group_per_peer, dst, src, send_info.nbytes);
     }
     return;
   }
@@ -201,13 +201,13 @@ __device__ __forceinline__ void all_to_allv(
   // Perform peer send/recv based on partition_id from first partition
   bool is_send = (partition_id == 0);
   if (is_send) {
-    transport.p2p_nvl.send(
+    transport.p2p_nvl.send_group(
         group_per_peer,
         static_cast<char*>(const_cast<void*>(sendbuff_d)) + send_info.offset,
         send_info.nbytes,
         timeout);
   } else {
-    transport.p2p_nvl.recv(
+    transport.p2p_nvl.recv_group(
         group_per_peer,
         static_cast<char*>(recvbuff_d) + recv_info.offset,
         recv_info.nbytes,

--- a/comms/pipes/collectives/AllToAllvLl128.cuh
+++ b/comms/pipes/collectives/AllToAllvLl128.cuh
@@ -20,7 +20,7 @@ namespace comms::pipes {
  * optimized for small/medium messages (<= 256KB per peer).
  *
  * Two differences from all_to_allv() (Simple protocol):
- * 1. Calls transport.p2p_nvl.ll128_send() / ll128_recv()
+ * 1. Calls transport.p2p_nvl.ll128_send_group() / ll128_recv_group()
  * 2. No cluster launch (volatile stores bypass L1 cache)
  *
  * The sender always polls for READY_TO_WRITE before overwriting each buffer
@@ -57,7 +57,7 @@ __device__ __forceinline__ void all_to_allv_ll128(
     PIPES_DEVICE_CHECK(send_info.nbytes == recv_info.nbytes);
     auto& transport = transports_per_rank[my_rank_id];
     PIPES_DEVICE_CHECK(transport.type == TransportType::SELF);
-    transport.self.put(
+    transport.self.put_group(
         group,
         static_cast<char*>(recvbuff_d) + recv_info.offset,
         static_cast<const char*>(sendbuff_d) + send_info.offset,
@@ -82,7 +82,7 @@ __device__ __forceinline__ void all_to_allv_ll128(
     PIPES_DEVICE_CHECK(send_info.nbytes == recv_info.nbytes);
     // Only one partition does the self-copy (match Simple protocol)
     if (partition_id == 0) {
-      transport.self.put(
+      transport.self.put_group(
           group_per_peer,
           static_cast<char*>(recvbuff_d) + recv_info.offset,
           static_cast<const char*>(sendbuff_d) + send_info.offset,
@@ -103,13 +103,13 @@ __device__ __forceinline__ void all_to_allv_ll128(
   PIPES_DEVICE_CHECK(transport.type == TransportType::P2P_NVL);
 
   if (partition_id == 0) {
-    transport.p2p_nvl.ll128_send(
+    transport.p2p_nvl.ll128_send_group(
         group_per_peer,
         static_cast<const char*>(sendbuff_d) + send_info.offset,
         send_info.nbytes,
         timeout);
   } else {
-    transport.p2p_nvl.ll128_recv(
+    transport.p2p_nvl.ll128_recv_group(
         group_per_peer,
         static_cast<char*>(recvbuff_d) + recv_info.offset,
         recv_info.nbytes,

--- a/comms/pipes/tests/DeviceWindowTest.cu
+++ b/comms/pipes/tests/DeviceWindowTest.cu
@@ -165,7 +165,7 @@ __global__ void selfTransportPutKernel(
     const char* src_d,
     std::size_t nbytes) {
   auto group = make_warp_group();
-  transport->self.put(group, dst_d, src_d, nbytes);
+  transport->self.put_group(group, dst_d, src_d, nbytes);
 }
 
 void testSelfTransportPut(

--- a/comms/pipes/tests/MultiPeerNvlTransportIntegrationTest.cu
+++ b/comms/pipes/tests/MultiPeerNvlTransportIntegrationTest.cu
@@ -85,7 +85,7 @@ __global__ void singlePeerSendKernel(
     void* srcBuff,
     std::size_t nbytes) {
   auto group = make_warp_group();
-  dw.get_handle().get_nvl(peerRank).send(group, srcBuff, nbytes);
+  dw.get_handle().get_nvl(peerRank).send_group(group, srcBuff, nbytes);
 }
 
 void testSinglePeerSend(
@@ -105,7 +105,7 @@ __global__ void singlePeerRecvKernel(
     void* dstBuff,
     std::size_t nbytes) {
   auto group = make_warp_group();
-  dw.get_handle().get_nvl(peerRank).recv(group, dstBuff, nbytes);
+  dw.get_handle().get_nvl(peerRank).recv_group(group, dstBuff, nbytes);
 }
 
 void testSinglePeerRecv(
@@ -144,10 +144,10 @@ __global__ void multiPeerSendRecvAllPeersKernel(
   int peer_rank = peer_idx < myRank ? peer_idx : peer_idx + 1;
 
   if (partition_id == 0) {
-    dw.get_handle().get_nvl(peer_rank).send(
+    dw.get_handle().get_nvl(peer_rank).send_group(
         group_per_peer, srcBuffs[peer_idx], nbytesPerPeer);
   } else {
-    dw.get_handle().get_nvl(peer_rank).recv(
+    dw.get_handle().get_nvl(peer_rank).recv_group(
         group_per_peer, dstBuffs[peer_idx], nbytesPerPeer);
   }
 }

--- a/comms/pipes/tests/MultiPeerTransportKernelTest.cu
+++ b/comms/pipes/tests/MultiPeerTransportKernelTest.cu
@@ -25,7 +25,7 @@ __global__ void test_multi_peer_nvl_send_kernel(
     size_t nbytes) {
   auto group = make_warp_group();
   auto& nvl = handle.get_nvl(peerRank);
-  nvl.send(group, src_d, nbytes);
+  nvl.send_group(group, src_d, nbytes);
 }
 
 __global__ void test_multi_peer_nvl_recv_kernel(
@@ -35,7 +35,7 @@ __global__ void test_multi_peer_nvl_recv_kernel(
     size_t nbytes) {
   auto group = make_warp_group();
   auto& nvl = handle.get_nvl(peerRank);
-  nvl.recv(group, dst_d, nbytes);
+  nvl.recv_group(group, dst_d, nbytes);
 }
 
 __global__ void test_multi_peer_self_put_kernel(
@@ -47,10 +47,10 @@ __global__ void test_multi_peer_self_put_kernel(
   if (handle.get_type(handle.myRank) != TransportType::SELF) {
     return;
   }
-  // Use P2pSelfTransportDevice::put() through the device handle
+  // Use P2pSelfTransportDevice::put_group() through the device handle
   auto group = make_warp_group();
   P2pSelfTransportDevice selfTransport;
-  selfTransport.put(
+  selfTransport.put_group(
       group,
       reinterpret_cast<char*>(dst_d),
       reinterpret_cast<const char*>(src_d),

--- a/comms/pipes/tests/P2pNvlTransportDeviceTest.cc
+++ b/comms/pipes/tests/P2pNvlTransportDeviceTest.cc
@@ -87,9 +87,9 @@ class P2pNvlTransportDeviceTwoGpuFixture : public ::testing::Test {
   }
 
   /**
-   * Runs an LL128 loopback test: GPU0 ll128_send → GPU1 ll128_recv, verifies
-   * data. Handles LL128 buffer allocation, transport setup, kernel launch,
-   * verify, cleanup.
+   * Runs an LL128 loopback test: GPU0 ll128_send_group → GPU1
+   * ll128_recv_group, verifies data. Handles LL128 buffer allocation,
+   * transport setup, kernel launch, verify, cleanup.
    */
   void runLl128LoopbackTest(
       std::size_t nbytes,
@@ -1046,7 +1046,7 @@ TEST_F(P2pNvlTransportDeviceTwoGpuFixture, DeviceSignalTwoGpuPingPong) {
   CUDACHECK_TEST(cudaFree(transport1_d));
 }
 
-TEST_F(P2pNvlTransportDeviceTestFixture, PutTilePerGroup) {
+TEST_F(P2pNvlTransportDeviceTestFixture, PutPerGroup) {
   const std::size_t tileSize = 4096;
   const int numGroups = 4;
 
@@ -1067,7 +1067,7 @@ TEST_F(P2pNvlTransportDeviceTestFixture, PutTilePerGroup) {
   CUDACHECK_TEST(cudaMemcpy(
       src_d, srcPattern.data(), tileSize * numGroups, cudaMemcpyHostToDevice));
 
-  // Minimal transport — put_tile doesn't use any transport buffers
+  // Minimal transport — put doesn't use any transport buffers
   P2pNvlTransportOptions options{
       .dataBufferSize = 1024,
       .chunkSize = 512,
@@ -1097,7 +1097,7 @@ TEST_F(P2pNvlTransportDeviceTestFixture, PutTilePerGroup) {
 
   // Launch numGroups blocks, each copying its own tile independently
   // Each group offsets by group.group_id * tileSize into src/dst
-  test::testDevicePutTile(
+  test::testDevicePut(
       transport_d,
       dst_d,
       src_d,
@@ -1238,7 +1238,8 @@ TEST_F(P2pNvlTransportDeviceTwoGpuFixture, DeviceResetSignalTwoGpu) {
 
 // =============================================================================
 // LL128 Transport Send/Recv Tests
-// These test the ll128_send()/ll128_recv() methods on P2pNvlTransportDevice
+// These test the ll128_send_group()/ll128_recv_group() methods on
+// P2pNvlTransportDevice
 // =============================================================================
 
 TEST_F(P2pNvlTransportDeviceTwoGpuFixture, Ll128SendRecv_4KB) {

--- a/comms/pipes/tests/P2pNvlTransportDeviceTest.cu
+++ b/comms/pipes/tests/P2pNvlTransportDeviceTest.cu
@@ -96,7 +96,7 @@ void testDeviceSignalThenWait(
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 
-__global__ void testDevicePutTileKernel(
+__global__ void testDevicePutKernel(
     P2pNvlTransportDevice* p2p,
     char* dst_d,
     const char* src_d,
@@ -104,10 +104,10 @@ __global__ void testDevicePutTileKernel(
     GroupType groupType) {
   auto group = make_group(groupType);
   std::size_t offset = group.group_id * tileSize;
-  p2p->put_tile(group, dst_d + offset, src_d + offset, tileSize);
+  p2p->put(group, dst_d + offset, src_d + offset, tileSize);
 }
 
-void testDevicePutTile(
+void testDevicePut(
     P2pNvlTransportDevice* p2p,
     char* dst_d,
     const char* src_d,
@@ -115,7 +115,7 @@ void testDevicePutTile(
     int numBlocks,
     int blockSize,
     GroupType groupType) {
-  testDevicePutTileKernel<<<numBlocks, blockSize>>>(
+  testDevicePutKernel<<<numBlocks, blockSize>>>(
       p2p, dst_d, src_d, tileSize, groupType);
   PIPES_KERNEL_LAUNCH_CHECK();
 }
@@ -206,7 +206,7 @@ testLl128SendKernel(P2pNvlTransportDevice p2p, const char* src, size_t nbytes) {
   auto group = make_warp_group();
   Timeout timeout;
   timeout.start();
-  p2p.ll128_send(group, src, nbytes, timeout);
+  p2p.ll128_send_group(group, src, nbytes, timeout);
 }
 
 __global__ void
@@ -214,7 +214,7 @@ testLl128RecvKernel(P2pNvlTransportDevice p2p, char* dst, size_t nbytes) {
   auto group = make_warp_group();
   Timeout timeout;
   timeout.start();
-  p2p.ll128_recv(group, dst, nbytes, timeout);
+  p2p.ll128_recv_group(group, dst, nbytes, timeout);
 }
 
 void testLl128SendRecv(

--- a/comms/pipes/tests/P2pNvlTransportDeviceTest.cuh
+++ b/comms/pipes/tests/P2pNvlTransportDeviceTest.cuh
@@ -81,8 +81,8 @@ void testRawWaitSignal(
 // Read the signal value (for verification)
 void testReadSignal(SignalState* signal_d, uint64_t* result_d);
 
-// Per-group put_tile copy (each block copies its own tile at blockIdx.x offset)
-void testDevicePutTile(
+// Per-group put copy (each block copies its own tile at blockIdx.x offset)
+void testDevicePut(
     P2pNvlTransportDevice* p2p,
     char* dst_d,
     const char* src_d,
@@ -101,15 +101,16 @@ void testDeviceResetSignal(
 
 // =============================================================================
 // LL128 transport send/recv test helpers
-// These test the ll128_send()/ll128_recv() methods on P2pNvlTransportDevice
+// These test the ll128_send_group()/ll128_recv_group() methods on
+// P2pNvlTransportDevice
 // =============================================================================
 
 /**
  * Test LL128 send/recv via P2pNvlTransportDevice transport wrappers.
  *
  * Uses two transports in a loopback configuration where transport0 sends
- * to transport1. The sender calls p2p.ll128_send() and the receiver calls
- * p2p.ll128_recv().
+ * to transport1. The sender calls p2p.ll128_send_group() and the receiver
+ * calls p2p.ll128_recv_group().
  *
  * @param sender Sender transport (writes to receiver's LL128 buffer)
  * @param receiver Receiver transport (reads from its local LL128 buffer)

--- a/comms/pipes/tests/P2pNvlTransportTest.cc
+++ b/comms/pipes/tests/P2pNvlTransportTest.cc
@@ -460,7 +460,7 @@ TEST_F(P2pNvlTransportTestFixture, TileSendRecvMultiCall) {
 }
 
 // =============================================================================
-// send_tile / recv_tile Tests
+// send / recv (per-group) Tests
 // =============================================================================
 
 // Helper: run tile sendrecv with given params and verify correctness
@@ -3472,7 +3472,7 @@ TEST_F(P2pNvlTransportTestFixture, Ll128BufferWiring_Disabled) {
 // =============================================================================
 // Dynamic block count tests
 // =============================================================================
-// Verify that changing numBlocks between send_tile/recv_tile rounds works
+// Verify that changing numBlocks between send/recv rounds works
 // correctly with the maxBlocks layout and host-side barrier.
 
 TEST_F(P2pNvlTransportTestFixture, TileSendRecvDynamicBlockCount) {

--- a/comms/pipes/tests/P2pNvlTransportTest.cu
+++ b/comms/pipes/tests/P2pNvlTransportTest.cu
@@ -23,7 +23,7 @@ __global__ void testSendKernel(
     size_t nbytes,
     GroupType groupType) {
   auto group = make_group(groupType);
-  p2p->send(group, src_d, nbytes);
+  p2p->send_group(group, src_d, nbytes);
 }
 
 __global__ void testRecvKernel(
@@ -32,7 +32,7 @@ __global__ void testRecvKernel(
     size_t nbytes,
     GroupType groupType) {
   auto group = make_group(groupType);
-  p2p->recv(group, dst_d, nbytes);
+  p2p->recv_group(group, dst_d, nbytes);
 }
 
 // Kernel that performs multiple sequential sends within a single kernel launch
@@ -45,7 +45,7 @@ __global__ void testMultiSendKernel(
   auto group = make_group(groupType);
   char* src = reinterpret_cast<char*>(src_d);
   for (int i = 0; i < numSends; i++) {
-    p2p->send(group, src + i * nbytes, nbytes);
+    p2p->send_group(group, src + i * nbytes, nbytes);
   }
 }
 
@@ -59,7 +59,7 @@ __global__ void testMultiRecvKernel(
   auto group = make_group(groupType);
   char* dst = reinterpret_cast<char*>(dst_d);
   for (int i = 0; i < numRecvs; i++) {
-    p2p->recv(group, dst + i * nbytes, nbytes);
+    p2p->recv_group(group, dst + i * nbytes, nbytes);
   }
 }
 
@@ -72,8 +72,8 @@ __global__ void testSendRecvKernel(
     size_t nbytes,
     GroupType groupType) {
   auto group = make_group(groupType);
-  p2p->send(group, send_d, nbytes);
-  p2p->recv(group, recv_d, nbytes);
+  p2p->send_group(group, send_d, nbytes);
+  p2p->recv_group(group, recv_d, nbytes);
 }
 
 // Kernel that performs recv then send within a single kernel launch
@@ -85,8 +85,8 @@ __global__ void testRecvSendKernel(
     size_t nbytes,
     GroupType groupType) {
   auto group = make_group(groupType);
-  p2p->recv(group, recv_d, nbytes);
-  p2p->send(group, send_d, nbytes);
+  p2p->recv_group(group, recv_d, nbytes);
+  p2p->send_group(group, send_d, nbytes);
 }
 
 // Kernel that performs weighted partition send/recv
@@ -104,9 +104,9 @@ __global__ void testWeightedSendRecvKernel(
   uint32_t weights[] = {sendWeight, recvWeight};
   auto [partition_id, subgroup] = group.partition(make_device_span(weights, 2));
   if (partition_id == 0) {
-    p2p->send(subgroup, send_d, nbytes);
+    p2p->send_group(subgroup, send_d, nbytes);
   } else {
-    p2p->recv(subgroup, recv_d, nbytes);
+    p2p->recv_group(subgroup, recv_d, nbytes);
   }
 }
 
@@ -125,9 +125,9 @@ __global__ void testWeightedRecvSendKernel(
   uint32_t weights[] = {recvWeight, sendWeight};
   auto [partition_id, subgroup] = group.partition(make_device_span(weights, 2));
   if (partition_id == 0) {
-    p2p->recv(subgroup, recv_d, nbytes);
+    p2p->recv_group(subgroup, recv_d, nbytes);
   } else {
-    p2p->send(subgroup, send_d, nbytes);
+    p2p->send_group(subgroup, send_d, nbytes);
   }
 }
 
@@ -257,7 +257,7 @@ __global__ void testPutWithSignalKernel(
     size_t nbytes,
     GroupType groupType) {
   auto group = make_group(groupType);
-  auto writtenBytes = p2p->put(group, dst_d, src_d, nbytes);
+  auto writtenBytes = p2p->put_group(group, dst_d, src_d, nbytes);
   p2p->signal_threadgroup(group, signal_id, SignalOp::SIGNAL_ADD, writtenBytes);
 }
 

--- a/comms/pipes/window/DeviceWindow.cuh
+++ b/comms/pipes/window/DeviceWindow.cuh
@@ -986,7 +986,8 @@ class DeviceWindow {
       int nvlPeerIdx = rankToNvlPeerIndex_[target_rank];
       auto* remoteDst =
           static_cast<char*>(windowNvlPeerPtrs_[nvlPeerIdx]) + dst_offset;
-      handle_.get_nvl(target_rank).put(group, remoteDst, localSrc, nbytes);
+      handle_.get_nvl(target_rank)
+          .put_group(group, remoteDst, localSrc, nbytes);
     } else {
       int ibgdaPeerIdx = rank_to_peer_index(target_rank);
       IbgdaLocalBuffer localBuf(
@@ -1036,7 +1037,8 @@ class DeviceWindow {
       int nvlPeerIdx = rankToNvlPeerIndex_[target_rank];
       auto* remoteDst =
           static_cast<char*>(windowNvlPeerPtrs_[nvlPeerIdx]) + dst_offset;
-      handle_.get_nvl(target_rank).put(group, remoteDst, localSrc, nbytes);
+      handle_.get_nvl(target_rank)
+          .put_group(group, remoteDst, localSrc, nbytes);
       signal_peer(
           group, target_rank, signalId, SignalOp::SIGNAL_ADD, signalVal);
       group.sync();
@@ -1102,7 +1104,8 @@ class DeviceWindow {
       int nvlPeerIdx = rankToNvlPeerIndex_[target_rank];
       auto* remoteDst =
           static_cast<char*>(windowNvlPeerPtrs_[nvlPeerIdx]) + dst_offset;
-      handle_.get_nvl(target_rank).put(group, remoteDst, localSrc, nbytes);
+      handle_.get_nvl(target_rank)
+          .put_group(group, remoteDst, localSrc, nbytes);
       signal_peer(
           group, target_rank, signalId, SignalOp::SIGNAL_ADD, signalVal);
       group.sync();
@@ -1167,7 +1170,8 @@ class DeviceWindow {
       int nvlPeerIdx = rankToNvlPeerIndex_[target_rank];
       auto* remoteDst =
           static_cast<char*>(windowNvlPeerPtrs_[nvlPeerIdx]) + dst_offset;
-      handle_.get_nvl(target_rank).put(group, remoteDst, localSrc, nbytes);
+      handle_.get_nvl(target_rank)
+          .put_group(group, remoteDst, localSrc, nbytes);
     } else {
       int ibgdaPeerIdx = rank_to_peer_index(target_rank);
       IbgdaLocalBuffer localBuf(

--- a/comms/torchcomms/tests/integration/cpp/PipesTransportApiTestKernels.cu
+++ b/comms/torchcomms/tests/integration/cpp/PipesTransportApiTestKernels.cu
@@ -56,7 +56,7 @@ __global__ void transportStressSendRecvKernel(
       // Fill src with identifiable pattern
       fillPattern(buf, count, rank, iter);
       group.sync();
-      nvl.send(group, buf, nbytes);
+      nvl.send_group(group, buf, nbytes);
       // Sender always passes
       if (group.thread_id_in_group == 0) {
         results[iter] = 1;
@@ -68,7 +68,7 @@ __global__ void transportStressSendRecvKernel(
         buf[i] = 0.0f;
       }
       group.sync();
-      nvl.recv(group, buf, nbytes);
+      nvl.recv_group(group, buf, nbytes);
       // Verify received data matches sender's pattern
       verifyPattern(buf, count, peer, iter, &results[iter]);
     }
@@ -157,14 +157,14 @@ __global__ void transportStressCombinedKernel(
     if (rank % 2 == 0) {
       fillPattern(buf, count, rank, iter);
       group.sync();
-      nvl.send(group, buf, nbytes);
+      nvl.send_group(group, buf, nbytes);
     } else {
       for (size_t i = group.thread_id_in_group; i < count;
            i += group.group_size) {
         buf[i] = 0.0f;
       }
       group.sync();
-      nvl.recv(group, buf, nbytes);
+      nvl.recv_group(group, buf, nbytes);
     }
 
     // Phase 3: Signal/wait (confirms both ranks finished send/recv)
@@ -234,7 +234,7 @@ __global__ void transportStressLl128Kernel(
         buf[i] = pattern;
       }
       __syncthreads();
-      nvl.ll128_send(group, buf, nbytes);
+      nvl.ll128_send_group(group, buf, nbytes);
       if (threadIdx.x == 0) {
         results[iter] = 1;
       }
@@ -244,7 +244,7 @@ __global__ void transportStressLl128Kernel(
         buf[i] = 0;
       }
       __syncthreads();
-      nvl.ll128_recv(group, buf, nbytes);
+      nvl.ll128_recv_group(group, buf, nbytes);
       // Verify
       __shared__ int any_mismatch;
       if (threadIdx.x == 0) {

--- a/comms/torchcomms/triton/device_transport.cu
+++ b/comms/torchcomms/triton/device_transport.cu
@@ -22,7 +22,7 @@ __device__ __noinline__ int torchcomms_transport_send(
     unsigned long long nbytes) {
   auto* handle = reinterpret_cast<MultiPeerDeviceHandle*>(handle_ptr);
   auto group = make_block_group();
-  handle->get_nvl(peer).send(group, src_ptr, static_cast<size_t>(nbytes));
+  handle->get_nvl(peer).send_group(group, src_ptr, static_cast<size_t>(nbytes));
   return 0;
 }
 
@@ -33,7 +33,7 @@ __device__ __noinline__ int torchcomms_transport_recv(
     unsigned long long nbytes) {
   auto* handle = reinterpret_cast<MultiPeerDeviceHandle*>(handle_ptr);
   auto group = make_block_group();
-  handle->get_nvl(peer).recv(group, dst_ptr, static_cast<size_t>(nbytes));
+  handle->get_nvl(peer).recv_group(group, dst_ptr, static_cast<size_t>(nbytes));
   return 0;
 }
 


### PR DESCRIPTION
Summary:

Rename P2pNvlTransportDevice and P2pSelfTransportDevice methods so that
the per-group variants (formerly *_tile) become the default short names,
and the grid-collective variants get a _groups suffix:

- send_tile() -> send(), send() -> send_groups()
- recv_tile() -> recv(), recv() -> recv_groups()
- put_tile() -> put(), put() -> put_groups()

This reflects that per-group is the correct default behavior for these
operations, since callers (Triton put_block, DeviceWindow, collectives)
always use them from per-group contexts with independent data.

Reviewed By: cenzhaometa

Differential Revision: D101740355


