### PR TITLE
Resolving rsmi mutex issue by reading firmware version from sysfs (#2181)

### DIFF
--- a/comms/rcclx/develop/src/rccl_wrap.cc
+++ b/comms/rcclx/develop/src/rccl_wrap.cc
@@ -24,8 +24,9 @@ THE SOFTWARE.
 #include "comm.h"
 #include "graph/topo.h"
 #include "enqueue.h"
-#include "rocm_smi/rocm_smi.h"
 #include <algorithm>
+#include <cstdio>
+#include <cstdlib>
 // Use this param to experiment pipelining new data types besides bfloat16
 // Make sure you generate the device code with the new data type (i.e. in generate.py)
 RCCL_PARAM(PipelineAllDTypes, "PIPELINE_ALL_DATA_TYPES", 0);
@@ -480,17 +481,22 @@ std::vector<std::string> splitString(const std::string& s, char delimiter) {
 }
 
 int parseFirmwareVersionImpl() {
-  uint64_t fw_version = -1;
-
-  // using rocm-smi APIs for now to query MEC FW version
-  // will switch to amd-smi APIs soon
-  rsmi_status_t ret;
-  ret = rsmi_init(0);
-  if (ret != RSMI_STATUS_SUCCESS) return -1;
-  ret = rsmi_dev_firmware_version_get(0, RSMI_FW_BLOCK_MEC, &fw_version);
-  if (ret != RSMI_STATUS_SUCCESS) return -1;
-
-  return fw_version;
+  // Read MEC firmware version directly from sysfs to avoid the rsmi global
+  // mutex (which has been observed to deadlock / serialize callers on MI350).
+  // Sysfs file is world-readable; no rsmi/amd-smi linkage required.
+  for (int card = 0; card < 128; ++card) {
+    char path[128];
+    snprintf(path, sizeof(path),
+             "/sys/class/drm/card%d/device/fw_version/mec_fw_version", card);
+    FILE* fp = fopen(path, "r");
+    if (!fp) continue;
+    char line[64] = {0};
+    char* got = fgets(line, sizeof(line), fp);
+    fclose(fp);
+    if (!got) continue;
+    return static_cast<int>(strtoull(line, nullptr, 16));
+  }
+  return 0;
 }
 
 int parseFirmwareVersion() {


### PR DESCRIPTION
Summary:

`parseFirmwareVersionImpl()` previously called `rsmi_init` +
`rsmi_dev_firmware_version_get(..., RSMI_FW_BLOCK_MEC, ...)`. That path takes a
global mutex inside `librocm_smi64.so` which has been observed to
deadlock / serialize callers on MI350.

Replace the rsmi-based firmware query with a direct read from the
world-readable sysfs file:
  `/sys/class/drm/card<N>/device/fw_version/mec_fw_version`
parsed as a hex value. This eliminates rsmi linkage and locking entirely.

Changes:
- Replace `parseFirmwareVersionImpl()` body with a loop over card indices
  0..127 that reads `mec_fw_version` from sysfs via `fopen`/`fgets`/`strtoull`.
- Drop `#include "rocm_smi/rocm_smi.h"` (no other rsmi symbol used in this TU);
  add `<cstdio>` / `<cstdlib>`.
- Add `patches/sysfs_fw_version.patch` so the change survives `fb_upgrade.sh`
  re-imports.
- Return value semantics preserved: `parseFirmwareVersion()` still wraps the
  call in a try/catch.

Corresponds to commits 30+31 of upstream ROCm/rocm-systems#4150; we
intentionally skip the rest of that PR (amdsmi_wrap rework, fabric/UALoE shims,
USE_AMDSMI cmake plumbing) and PR3496 per AMD recommendation.

Reviewed By: ganesank-git

Differential Revision: D101650051


