### PR TITLE
Fix use-after-free in GpeKernelSyncPool during MCCL reconfigure (#2183)

### DIFF
--- a/comms/ctran/gpe/CtranGpe.cc
+++ b/comms/ctran/gpe/CtranGpe.cc
@@ -479,7 +479,9 @@ size_t CtranGpe::numInUseChecksums() {
 }
 
 size_t CtranGpe::numInUseGpeKernelSyncs() {
+  // Last chance to cleanup
   this->pimpl->gpeKernelSyncPool->reclaim();
+  // Return the number of inuse elements
   return this->pimpl->gpeKernelSyncPool->capacity() -
       this->pimpl->gpeKernelSyncPool->size();
 }

--- a/comms/ctran/gpe/CtranGpe.h
+++ b/comms/ctran/gpe/CtranGpe.h
@@ -427,7 +427,9 @@ class CtranGpe {
   // Return number of inuse checksums.
   size_t numInUseChecksums();
 
-  // Return number of inuse GPE kernel syncs.
+  // Return number of inuse GpeKernelSync elements.
+  // Used to verify that CUDA graph cmdDestroy callbacks have released all pool
+  // elements before pool destruction (async cmdDestroy race).
   size_t numInUseGpeKernelSyncs();
 
   commResult_t allocGpeKernelSyncs(

--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -639,7 +639,47 @@ void CtranGpe::Impl::terminate() {
   cmdEnqueue(cmd);
   thread_.join();
 
+  // Pool elements are released by CUDA's async cmdDestroy callback
+  // (cudaUserObjectNoDestructorSync). Spin until all pools drain before
+  // returning, to avoid freeing pinned memory from under an in-flight callback.
   const auto& statex = comm->statex_;
+  const auto start = std::chrono::steady_clock::now();
+  auto nextLog = start + std::chrono::seconds(5);
+  while (true) {
+    this->kernelFlagPool->reclaim();
+    this->kernelElemPool->reclaim();
+    this->gpeKernelSyncPool->reclaim();
+    if (this->kernelFlagPool->capacity() == this->kernelFlagPool->size() &&
+        this->kernelElemPool->capacity() == this->kernelElemPool->size() &&
+        this->gpeKernelSyncPool->capacity() ==
+            this->gpeKernelSyncPool->size()) {
+      break;
+    }
+    const auto now = std::chrono::steady_clock::now();
+    if (now >= nextLog) {
+      const auto elapsedSec =
+          std::chrono::duration_cast<std::chrono::seconds>(now - start).count();
+      CLOGF_SUBSYS(
+          WARNING,
+          INIT,
+          "terminate() spin-wait: pools still draining after {}s on rank {} commHash {:x}"
+          " -- kernelFlag {}/{} kernelElem {}/{} gpeKernelSync {}/{}."
+          " Most likely cudaGraphDestroy() was not called on all CUDA graphs"
+          " that captured CTranGPE operations.",
+          elapsedSec,
+          statex->rank(),
+          statex->commHash(),
+          this->kernelFlagPool->size(),
+          this->kernelFlagPool->capacity(),
+          this->kernelElemPool->size(),
+          this->kernelElemPool->capacity(),
+          this->gpeKernelSyncPool->size(),
+          this->gpeKernelSyncPool->capacity());
+      nextLog = now + std::chrono::seconds(5);
+    }
+    std::this_thread::yield();
+  }
+
   CLOGF_SUBSYS(
       INFO,
       INIT,

--- a/comms/ctran/gpe/tests/CtranGpeUT.cc
+++ b/comms/ctran/gpe/tests/CtranGpeUT.cc
@@ -2,7 +2,11 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <atomic>
+#include <chrono>
+#include <future>
 #include <iostream>
+#include <thread>
 
 #include "comms/ctran/algos/CtranAlgoDev.h"
 #include "comms/ctran/algos/common/GpeKernel.h"
@@ -1568,11 +1572,14 @@ TEST_F(CtranGpeTest, GraphCaptureWithHostNode) {
   CUDACHECK_TEST(cudaGraphDestroy(graph));
 
   // cudaUserObjectNoDestructorSync: cmdDestroy fires asynchronously after
-  // graph destruction. Wait for it to release the flag back to the pool.
-  while (gpe->numInUseKernelFlags() > 0) {
+  // graph destruction. Wait for it to release all pool resources back.
+  while (gpe->numInUseKernelFlags() > 0 || gpe->numInUseKernelElems() > 0 ||
+         gpe->numInUseGpeKernelSyncs() > 0) {
     std::this_thread::yield();
   }
   EXPECT_EQ(gpe->numInUseKernelFlags(), 0);
+  EXPECT_EQ(gpe->numInUseKernelElems(), 0);
+  EXPECT_EQ(gpe->numInUseGpeKernelSyncs(), 0);
   CUDACHECK_TEST(cudaFree(buf));
   CUDACHECK_TEST(cudaFreeHost(valPtr));
   CUDACHECK_TEST(cudaStreamDestroy(stream));
@@ -1641,9 +1648,15 @@ TEST_F(CtranGpeTest, GraphCaptureDestroyFreesResources) {
   CUDACHECK_TEST(cudaGraphExecDestroy(graphExec));
   CUDACHECK_TEST(cudaGraphDestroy(graph));
 
-  while (gpe->numInUseKernelFlags() > 0) {
+  // cudaUserObjectNoDestructorSync: cmdDestroy fires asynchronously after
+  // graph destruction. Wait for it to release all pool resources back.
+  while (gpe->numInUseKernelFlags() > 0 || gpe->numInUseKernelElems() > 0 ||
+         gpe->numInUseGpeKernelSyncs() > 0) {
     std::this_thread::yield();
   }
+  EXPECT_EQ(gpe->numInUseKernelFlags(), 0);
+  EXPECT_EQ(gpe->numInUseKernelElems(), 0);
+  EXPECT_EQ(gpe->numInUseGpeKernelSyncs(), 0);
 
   CUDACHECK_TEST(cudaFree(buf));
   CUDACHECK_TEST(cudaFreeHost(valPtr));
@@ -2161,5 +2174,54 @@ TEST_F(CtranGpeTest, PostKernelCleanupGraphWithOpGroup) {
   CUDACHECK_TEST(cudaFreeHost(expectedValPtr));
   CUDACHECK_TEST(cudaFree(a));
   CUDACHECK_TEST(cudaStreamDestroy(stream));
+}
+
+// Verify that terminate() drains the GpeKernelSyncPool before returning.
+//
+// Simulates the production race: CUDA graph cmdDestroy callbacks release pool
+// elements asynchronously after cudaGraphDestroy. Without the spin-wait in
+// terminate(), the pool destructor can free pinned memory while those elements
+// are still "in use", causing use-after-free when the background release runs.
+
+TEST_F(CtranGpeTest, DISABLED_TerminateWaitsForGpeKernelSyncPoolDrain) {
+  auto gpe = std::make_unique<CtranGpe>(cudaDev, dummyComm);
+
+  // Allocate syncs from the pool — they are now "in use".
+  std::vector<ctran::algos::GpeKernelSync*> syncs;
+  constexpr size_t kNumSyncs = 5;
+  constexpr int kNworkers = 1;
+  ASSERT_EQ(gpe->allocGpeKernelSyncs(kNumSyncs, kNworkers, syncs), commSuccess);
+  ASSERT_EQ(gpe->numInUseGpeKernelSyncs(), kNumSyncs);
+
+  // Run terminate() in a background thread so main can control when the pool
+  // is drained. Use a promise to signal when gpe.reset() completes.
+  std::promise<void> gpeResetDone;
+  std::thread gpeThread([&]() {
+    gpe.reset(); // With fix: blocks until pool drained; without fix: returns
+                 // fast
+    gpeResetDone.set_value();
+  });
+
+  // Wait for gpe.reset() to complete, with a short deadline.
+  // With fix: terminate() is blocked in spin-wait → future times out → we
+  // release Without fix: terminate() returns immediately → future is ready →
+  // FAIL
+  constexpr auto kDrainWait = std::chrono::milliseconds(200);
+  auto status = gpeResetDone.get_future().wait_for(kDrainWait);
+
+  if (status == std::future_status::ready) {
+    // gpe.reset() returned while pool elements were still in use.
+    gpeThread.join();
+    FAIL() << "terminate() returned in < " << kDrainWait.count()
+           << "ms while GpeKernelSync pool elements were still in use. "
+              "Pool destructor freed pinned memory before async callbacks "
+              "could release elements, causing use-after-free.";
+  }
+
+  // terminate() is blocked in spin-wait — release elements to unblock it.
+  for (auto* sync : syncs) {
+    sync->reset(); // inUse() → false; spin-wait reclaims and exits
+  }
+  gpeThread.join();
 }
 #endif

--- a/comms/ctran/gpe/tests/CtranGpeUT.cc
+++ b/comms/ctran/gpe/tests/CtranGpeUT.cc
@@ -2183,7 +2183,7 @@ TEST_F(CtranGpeTest, PostKernelCleanupGraphWithOpGroup) {
 // terminate(), the pool destructor can free pinned memory while those elements
 // are still "in use", causing use-after-free when the background release runs.
 
-TEST_F(CtranGpeTest, DISABLED_TerminateWaitsForGpeKernelSyncPoolDrain) {
+TEST_F(CtranGpeTest, TerminateWaitsForGpeKernelSyncPoolDrain) {
   auto gpe = std::make_unique<CtranGpe>(cudaDev, dummyComm);
 
   // Allocate syncs from the pool — they are now "in use".

--- a/comms/ctran/tests/CtranTestUtils.cc
+++ b/comms/ctran/tests/CtranTestUtils.cc
@@ -723,6 +723,7 @@ bool CtranTestHelpers::isBackendValid(
 void CtranTestHelpers::verifyGpeLeak(ICtran* ctran) {
   ASSERT_EQ(ctran->gpe->numInUseKernelElems(), 0);
   ASSERT_EQ(ctran->gpe->numInUseKernelFlags(), 0);
+  ASSERT_EQ(ctran->gpe->numInUseGpeKernelSyncs(), 0);
 }
 
 void CtranTestHelpers::resetBackendsUsed(ICtran* ctran) {

--- a/comms/ctran/utils/PinnedHostPool.h
+++ b/comms/ctran/utils/PinnedHostPool.h
@@ -48,8 +48,10 @@ class PinnedHostPool {
     this->reclaim();
     if (this->inuseItems_.size()) {
       CLOGF(
-          INFO,
-          "CTRAN-GPE: Internal {} pool has {} inuse items, indicating same amount of unfinished kernel",
+          WARNING,
+          "CTRAN-GPE: Internal {} pool has {} inuse items at destruction. "
+          "In CUDA graph mode this indicates an async cmdDestroy race: "
+          "the graph was not fully destroyed before communicator teardown.",
           T::name(),
           this->inuseItems_.size());
     }


### PR DESCRIPTION
Summary:

When a CUDA graph capturing ctran allreduces is destroyed, pool elements
(GpeKernelSyncs, KernelFlags, KernelElems) held for the graph's lifetime
are released via the cmdDestroy callback, registered with
cudaUserObjectNoDestructorSync. This means CUDA fires cmdDestroy
asynchronously on an internal thread — it may not have completed by the
time bwd_graph.reset() returns to the caller.

The bug: terminate() joined the GPE thread and returned immediately,
allowing pool destructors to free pinned memory unconditionally. If
cmdDestroy fired after cudaFreeHost, it called reset()/resetStatus() on
freed memory. When CUDA recycled those pages for a new pool allocation,
this caused a use-after-free crash in resetStatus() during new communicator
construction.

Fix: add a spin-wait in terminate() after thread_.join() that drains all
three pools before returning. CUDA fires cmdDestroy within sub-milliseconds
of cudaGraphDestroy dropping the user object refcount to zero, so in
practice the spin-wait exits immediately.

Reviewed By: saifhhasan

Differential Revision: D101229209
