### PR TITLE
Add AMD support to Timeout.cuh and IbgdaBuffer.h (#2188)

### DIFF
--- a/comms/common/DeviceConstants.cuh
+++ b/comms/common/DeviceConstants.cuh
@@ -7,7 +7,13 @@
 namespace comms::device {
 
 // Statically define the warp size (unlike warpSize, this can be used in
-// constexpr expressions)
-constexpr uint32_t kWarpSize = 32;
+// constexpr expressions).
+// Note: Uses __HIP_PLATFORM_AMD__ (not __HIP_DEVICE_COMPILE__) because this
+// constant is needed in both host and device code (e.g., buffer allocation).
+#if defined(__HIP_PLATFORM_AMD__)
+constexpr uint32_t kWarpSize = 64; // AMD wavefront size
+#else
+constexpr uint32_t kWarpSize = 32; // NVIDIA warp size
+#endif
 
 } // namespace comms::device

--- a/comms/pipes/CopyUtils.cuh
+++ b/comms/pipes/CopyUtils.cuh
@@ -3,11 +3,56 @@
 #pragma once
 
 #include <cuda_runtime.h>
+
 #include <cstddef>
+#include "comms/pipes/HipCompat.cuh"
 
 #include "comms/pipes/ThreadGroup.cuh"
 
 namespace comms::pipes {
+
+// =============================================================================
+// AMD system-coherent store for P2P writes over XGMI
+// =============================================================================
+// On AMD GPUs, regular stores to remote GPU memory go through L1/L2 cache
+// and may not be visible to the remote GPU until a cache flush. For P2P
+// transfers, we need system-coherent stores that bypass/flush caches.
+#if defined(__HIP_DEVICE_COMPILE__) && !defined(__CUDA_ARCH__)
+
+/**
+ * Requires: dst and src must be 8-byte aligned (guaranteed when called via
+ * uint4* from memcpy_vectorized_aligned_sys). Misaligned pointers cause
+ * undefined behavior on AMD flat_store_dwordx2.
+ */
+__device__ __forceinline__ void store_sys_u128(uint4* dst, const uint4* src) {
+  // Note: 128-bit store is split into two 64-bit stores. Atomicity is not
+  // required — callers synchronize the full transfer via signal/barrier
+  // primitives before the consumer reads.
+#if defined(__gfx942__) || defined(__gfx950__)
+  // 16-byte system-coherent store via 2x dwordx2 with sc0 sc1
+  const uint64_t* s = reinterpret_cast<const uint64_t*>(src);
+  uint64_t* d = reinterpret_cast<uint64_t*>(dst);
+  uint64_t v0 = s[0];
+  uint64_t v1 = s[1];
+  asm volatile("flat_store_dwordx2 %0, %1 sc0 sc1" : : "v"(d), "v"(v0));
+  asm volatile("flat_store_dwordx2 %0, %1 sc0 sc1" : : "v"(d + 1), "v"(v1));
+#elif defined(__gfx90a__)
+  const uint64_t* s = reinterpret_cast<const uint64_t*>(src);
+  uint64_t* d = reinterpret_cast<uint64_t*>(dst);
+  uint64_t v0 = s[0];
+  uint64_t v1 = s[1];
+  asm volatile("flat_store_dwordx2 %0, %1 glc slc" : : "v"(d), "v"(v0));
+  asm volatile("flat_store_dwordx2 %0, %1 glc slc" : : "v"(d + 1), "v"(v1));
+#else
+  // Unsupported AMD architecture — plain store lacks system coherence and
+  // would silently break P2P correctness. Fail at compile time so new
+  // architectures get an explicit implementation.
+#error \
+    "store_sys_u128: no system-coherent store implementation for this AMD GPU architecture"
+#endif
+}
+
+#endif // __HIP_DEVICE_COMPILE__
 
 /**
  * memcpy_vectorized_aligned - High-performance vectorized memory copy
@@ -50,7 +95,7 @@ __device__ __forceinline__ void memcpy_vectorized_aligned(
     const VecType* src_p,
     std::size_t nelems,
     const ThreadGroup& group) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   // Loop stride: group_size threads × kUnroll elements each
   const std::size_t kLoopStride = group.group_size * kUnroll;
   const std::size_t numVecsAligned = (nelems / kLoopStride) * kLoopStride;
@@ -77,8 +122,43 @@ __device__ __forceinline__ void memcpy_vectorized_aligned(
        i += group.group_size) {
     dst[i] = src[i];
   }
-#endif // __CUDA_ARCH__
+#endif // defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 }
+
+// AMD-optimized uint4 copy with system-coherent stores for P2P over XGMI.
+// NVIDIA NVLink provides hardware cache coherence for P2P writes, so the
+// standard memcpy_vectorized_aligned() is sufficient. AMD XGMI does not
+// guarantee coherence — remote stores may remain in local L1/L2 caches —
+// so this variant uses explicit cache-bypassing stores (sc0 sc1 / glc slc).
+#if defined(__HIP_DEVICE_COMPILE__) && !defined(__CUDA_ARCH__)
+template <int kUnroll = 8>
+__device__ __forceinline__ void memcpy_vectorized_aligned_sys(
+    uint4* dst,
+    const uint4* src,
+    std::size_t nelems,
+    const ThreadGroup& group) {
+  const std::size_t kLoopStride = group.group_size * kUnroll;
+  const std::size_t numVecsAligned = (nelems / kLoopStride) * kLoopStride;
+
+  for (std::size_t i = group.thread_id_in_group; i < numVecsAligned;
+       i += kLoopStride) {
+    uint4 v[kUnroll];
+#pragma unroll
+    for (int j = 0; j < kUnroll; ++j) {
+      v[j] = src[i + j * group.group_size];
+    }
+#pragma unroll
+    for (int j = 0; j < kUnroll; ++j) {
+      store_sys_u128(&dst[i + j * group.group_size], &v[j]);
+    }
+  }
+
+  for (std::size_t i = numVecsAligned + group.thread_id_in_group; i < nelems;
+       i += group.group_size) {
+    store_sys_u128(&dst[i], &src[i]);
+  }
+}
+#endif
 
 template <int kUnroll = 8>
 __device__ __forceinline__ void memcpy_vectorized(
@@ -86,7 +166,7 @@ __device__ __forceinline__ void memcpy_vectorized(
     const char* src,
     std::size_t len,
     const ThreadGroup& group) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   constexpr std::size_t kAlignment = sizeof(uint4);
   if ((uintptr_t)dst % kAlignment == 0 && (uintptr_t)src % kAlignment == 0) {
     const std::size_t nelems = len / kAlignment;
@@ -102,7 +182,7 @@ __device__ __forceinline__ void memcpy_vectorized(
   }
 
   memcpy_vectorized_aligned<char, kUnroll>(dst, src, len, group);
-#endif // __CUDA_ARCH__
+#endif // defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 }
 
 /**
@@ -121,15 +201,16 @@ __device__ __forceinline__ void memcpy_vectorized(
  * @param src_d Source buffer pointer
  * @param nbytes Size of both buffers in bytes
  *
- * Note: Only active on device (__CUDA_ARCH__). No-op on host.
+ * Note: Only active on device (__CUDA_ARCH__ / __HIP_DEVICE_COMPILE__). No-op
+ * on host.
  */
 __device__ __forceinline__ void
 assert_buffer_non_overlap(char* dst_d, const char* src_d, std::size_t nbytes) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   if (!(src_d + nbytes <= dst_d || dst_d + nbytes <= src_d)) {
     __trap(); // Abort kernel if buffers overlap
   }
-#endif // __CUDA_ARCH__
+#endif // defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 }
 
 } // namespace comms::pipes

--- a/comms/pipes/DeviceCheck.cuh
+++ b/comms/pipes/DeviceCheck.cuh
@@ -4,6 +4,8 @@
 
 #include <cstdio>
 
+#include "comms/pipes/HipCompat.cuh"
+
 namespace comms::pipes {
 
 /**
@@ -23,7 +25,7 @@ namespace comms::pipes {
  * Note: __trap() puts the CUDA device into an unrecoverable error state. After
  * a trap, cudaDeviceReset() is required to recover the device context.
  */
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 #define PIPES_DEVICE_CHECK(expr)                                    \
   do {                                                              \
     if (!(expr)) {                                                  \
@@ -55,7 +57,7 @@ namespace comms::pipes {
  * Usage:
  *   PIPES_DEVICE_CHECK_MSG(idx < size, "Index out of bounds");
  */
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 #define PIPES_DEVICE_CHECK_MSG(expr, msg)                                \
   do {                                                                   \
     if (!(expr)) {                                                       \

--- a/comms/pipes/DeviceSpan.cuh
+++ b/comms/pipes/DeviceSpan.cuh
@@ -9,10 +9,12 @@
 #include <cassert>
 #include <cstdint>
 
+#include "comms/pipes/HipCompat.cuh"
+
 namespace comms::pipes {
 
 // Device-side bounds check helper
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 #define DEVICE_SPAN_CHECK_LT(val, bound)                          \
   do {                                                            \
     if (!((val) < (bound))) {                                     \

--- a/comms/pipes/HipCompat.cuh
+++ b/comms/pipes/HipCompat.cuh
@@ -1,0 +1,9 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+// On HIP, __trap() is not available; use abort() instead.
+// Include this header in any device code that calls __trap().
+#if defined(__HIP_DEVICE_COMPILE__) && !defined(__CUDA_ARCH__)
+#define __trap() abort()
+#endif

--- a/comms/pipes/IbgdaBuffer.h
+++ b/comms/pipes/IbgdaBuffer.h
@@ -7,14 +7,26 @@
 
 #include <endian.h>
 
-// Allow compilation in both host (C++) and device (CUDA) contexts
-#ifdef __CUDACC__
+// Allow compilation in both host (C++) and device (CUDA/HIP) contexts
+#if defined(__CUDACC__) || defined(__HIPCC__)
 #define IBGDA_HOST_DEVICE __host__ __device__
 #else
 #define IBGDA_HOST_DEVICE
 #endif
 
 namespace comms::pipes {
+
+// NIC-aware byte order conversion for RDMA memory keys.
+// mlx5 requires big-endian keys; bnxt/ionic use native byte order.
+namespace detail {
+inline uint32_t ibgdaNetworkByteOrderKey(uint32_t hostValue) {
+#if defined(NIC_BNXT) || defined(NIC_IONIC)
+  return hostValue; // Native byte order for non-mlx5 NICs
+#else
+  return htobe32(hostValue); // mlx5: big-endian
+#endif
+}
+} // namespace detail
 
 // =============================================================================
 // Strong Types for RDMA Memory Keys
@@ -63,10 +75,10 @@ struct NetworkLKey {
   NetworkLKey() = default;
   IBGDA_HOST_DEVICE explicit NetworkLKey(uint32_t v) : value(v) {}
 
-  // Implicit conversion from HostLKey (performs htobe32)
+  // Implicit conversion from HostLKey (performs byte order conversion)
   // NOLINTNEXTLINE(google-explicit-constructor)
   /* implicit */ NetworkLKey(HostLKey hostKey)
-      : value(htobe32(hostKey.value)) {}
+      : value(detail::ibgdaNetworkByteOrderKey(hostKey.value)) {}
 
   IBGDA_HOST_DEVICE bool operator==(const NetworkLKey& other) const {
     return value == other.value;
@@ -110,14 +122,14 @@ struct NetworkRKey {
   NetworkRKey() = default;
   IBGDA_HOST_DEVICE explicit NetworkRKey(uint32_t v) : value(v) {}
 
-  // Implicit conversion from HostRKey (performs htobe32)
+  // Implicit conversion from HostRKey (performs byte order conversion)
   // Note: This constructor is intentionally NOT explicit - implicit conversion
   // is the desired behavior. It is also intentionally host-only (no
-  // IBGDA_HOST_DEVICE) because htobe32() is not available on GPU. The
-  // conversion happens on the host before passing to device code.
+  // IBGDA_HOST_DEVICE) because the conversion happens on the host before
+  // passing to device code.
   // NOLINTNEXTLINE(google-explicit-constructor)
   /* implicit */ NetworkRKey(HostRKey hostKey)
-      : value(htobe32(hostKey.value)) {}
+      : value(detail::ibgdaNetworkByteOrderKey(hostKey.value)) {}
 
   IBGDA_HOST_DEVICE bool operator==(const NetworkRKey& other) const {
     return value == other.value;

--- a/comms/pipes/P2pNvlTransportDevice.cuh
+++ b/comms/pipes/P2pNvlTransportDevice.cuh
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <cuda.h>
+
 #include <cuda_runtime.h>
 #include <cstddef>
 #include <cstring>
@@ -10,6 +11,7 @@
 #include "comms/pipes/CopyUtils.cuh"
 #include "comms/pipes/DeviceCheck.cuh"
 #include "comms/pipes/DeviceSpan.cuh"
+#include "comms/pipes/HipCompat.cuh"
 #include "comms/pipes/SignalState.cuh"
 #include "comms/pipes/ThreadGroup.cuh"
 #include "comms/pipes/Timeout.cuh"
@@ -421,7 +423,7 @@ class P2pNvlTransportDevice {
       void* srcbuff,
       std::size_t nbytes,
       const Timeout& timeout = Timeout()) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     if (options_.dataBufferSize == 0) {
       printf(
           "P2pNvlTransportDevice::send() requires staging buffer"
@@ -687,7 +689,7 @@ class P2pNvlTransportDevice {
       void* dstbuff,
       std::size_t nbytes,
       const Timeout& timeout = Timeout()) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     if (options_.dataBufferSize == 0) {
       printf(
           "P2pNvlTransportDevice::recv() requires staging buffer"
@@ -881,7 +883,7 @@ class P2pNvlTransportDevice {
    */
   __device__ __forceinline__ std::size_t
   put(ThreadGroup& group, char* dst_d, const char* src_d, std::size_t nbytes) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     // Early return for no-op cases
     if (nbytes == 0) {
       return 0;

--- a/comms/pipes/P2pSelfTransportDevice.cuh
+++ b/comms/pipes/P2pSelfTransportDevice.cuh
@@ -3,7 +3,9 @@
 #pragma once
 
 #include <cuda_runtime.h>
+
 #include <cstddef>
+#include "comms/pipes/HipCompat.cuh"
 
 #include "comms/pipes/CopyUtils.cuh"
 #include "comms/pipes/ThreadGroup.cuh"
@@ -45,7 +47,7 @@ class P2pSelfTransportDevice {
    * Calling this method will trap and abort the kernel.
    */
   __device__ void send(ThreadGroup& group, void* srcbuff, std::size_t nbytes) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     __trap(); // Abort kernel if send is called on SelfTransportDevice
 #endif
   }
@@ -57,7 +59,7 @@ class P2pSelfTransportDevice {
    * Calling this method will trap and abort the kernel.
    */
   __device__ void recv(ThreadGroup& group, void* dstbuff, std::size_t nbytes) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     __trap(); // Abort kernel if recv is called on SelfTransportDevice
 #endif
   }
@@ -83,7 +85,7 @@ class P2pSelfTransportDevice {
    */
   __device__ __forceinline__ void
   put(ThreadGroup& group, char* dst_d, const char* src_d, std::size_t nbytes) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     // Early return for no-op cases (check before overlap to handle dst == src)
     if (nbytes == 0 || dst_d == src_d) {
       return;

--- a/comms/pipes/SignalState.cuh
+++ b/comms/pipes/SignalState.cuh
@@ -3,8 +3,10 @@
 #pragma once
 
 #include <cstdint>
+
 #include "comms/common/AtomicUtils.cuh"
 #include "comms/common/BitOps.cuh"
+#include "comms/pipes/HipCompat.cuh"
 #include "comms/pipes/ThreadGroup.cuh"
 #include "comms/pipes/Timeout.cuh"
 

--- a/comms/pipes/ThreadGroup.cuh
+++ b/comms/pipes/ThreadGroup.cuh
@@ -9,6 +9,7 @@
 #include "comms/common/AtomicUtils.cuh"
 #include "comms/common/DeviceConstants.cuh"
 #include "comms/pipes/DeviceSpan.cuh"
+#include "comms/pipes/HipCompat.cuh"
 
 namespace comms::pipes {
 
@@ -95,7 +96,7 @@ struct ThreadGroup {
   SyncScope scope;
 
   __device__ inline void sync() {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     switch (scope) {
       case SyncScope::THREAD:
         // Single-thread group: emit a compiler barrier to prevent reordering
@@ -107,17 +108,27 @@ struct ThreadGroup {
         asm volatile("" ::: "memory");
         break;
       case SyncScope::WARP:
+#if defined(__CUDA_ARCH__)
         __syncwarp();
+#else
+        // AMD wavefronts are implicitly lockstep; agent-scope fence suffices
+        __builtin_amdgcn_fence(__ATOMIC_SEQ_CST, "agent");
+#endif
         break;
       case SyncScope::MULTIWARP: {
         // Multiwarp = 4 warps = 128 threads
-        // Uses named barriers for synchronization within a multiwarp
+#if defined(__CUDA_ARCH__)
+        // Uses CUDA named barriers for synchronization within a multiwarp
         uint32_t tid = threadIdx.x + threadIdx.y * blockDim.x +
             threadIdx.z * blockDim.x * blockDim.y;
         uint32_t barrierId = tid / kMultiwarpSize;
         asm volatile("bar.sync %0, %1;"
                      :
                      : "r"(barrierId), "r"(kMultiwarpSize));
+#else
+        // AMD: no named barriers, fall back to block-level sync
+        __syncthreads();
+#endif
         break;
       }
       case SyncScope::BLOCK:
@@ -185,7 +196,7 @@ struct ThreadGroup {
    * @return Warp-scoped ThreadGroup with renumbered group_id/total_groups
    */
   __device__ inline ThreadGroup to_warp_group() const {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     if (scope == SyncScope::WARP && group_size == kWarpSize) {
       return *this;
     }
@@ -240,8 +251,10 @@ struct ThreadGroup {
    */
   template <typename T>
   __device__ inline T broadcast(T val) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     switch (scope) {
+      case SyncScope::THREAD:
+        return val; // Single thread, nothing to broadcast
       case SyncScope::WARP:
         return shfl(val, 0);
       case SyncScope::MULTIWARP: {
@@ -342,7 +355,7 @@ struct ThreadGroup {
   __device__ inline void for_each_item_contiguous(
       uint32_t total_items,
       Func&& func) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     const uint32_t items_per_group =
         (total_items + total_groups - 1) / total_groups;
     const uint32_t start_item = group_id * items_per_group;
@@ -406,7 +419,7 @@ struct ThreadGroup {
   __device__ inline void for_each_item_strided(
       uint32_t total_items,
       Func&& func) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     for (uint32_t item_id = group_id; item_id < total_items;
          item_id += total_groups) {
       func(item_id);
@@ -493,7 +506,7 @@ struct PartitionResult {
  */
 __device__ inline PartitionResult ThreadGroup::partition(
     uint32_t num_partitions) const {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   // More partitions than groups is invalid - some partitions would be empty
   // and group assignment would skip partitions non-deterministically.
   // Use __trap() instead of assert() to ensure this check is active in both
@@ -604,7 +617,7 @@ __device__ inline PartitionResult ThreadGroup::partition(
  */
 __device__ inline PartitionResult ThreadGroup::partition(
     DeviceSpan<const uint32_t> weights) const {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   const uint32_t num_partitions = static_cast<uint32_t>(weights.size());
 
   // Count non-zero weights and calculate total weight
@@ -712,7 +725,7 @@ __device__ inline PartitionResult ThreadGroup::partition(
  */
 __device__ inline PartitionResult ThreadGroup::partition_interleaved(
     uint32_t num_partitions) const {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   if (num_partitions > total_groups) {
     printf(
         "partition_interleaved: num_partitions (%u) must be <= total_groups (%u)\n",
@@ -756,7 +769,7 @@ __device__ inline PartitionResult ThreadGroup::partition_interleaved(
  * thread index and count respectively.
  */
 __device__ inline ThreadGroup make_thread_solo() {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   uint32_t tid = threadIdx.x + threadIdx.y * blockDim.x +
       threadIdx.z * blockDim.x * blockDim.y;
   uint32_t threads_per_block = blockDim.x * blockDim.y * blockDim.z;
@@ -791,7 +804,7 @@ __device__ inline ThreadGroup make_thread_solo() {
  * ThreadGroup into warp subgroups, preserving group context.
  */
 __device__ inline ThreadGroup make_warp_group() {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   uint32_t warps_per_block = blockDim.x / comms::device::kWarpSize;
   uint32_t warp_id_in_block = threadIdx.x / comms::device::kWarpSize;
   uint32_t global_warp_id = blockIdx.x * warps_per_block + warp_id_in_block;
@@ -836,11 +849,12 @@ __device__ inline ThreadGroup make_warp_group() {
  * - ~16 SMs per GPC, 8 GPCs total -> 132 SMs
  * - Maximum cluster size: 16 blocks (limited by GPC)
  *
- * NOTE: On architectures before SM90, falls back to single-block behavior
- * where cluster_size is effectively 1.
+ * NOTE: On architectures before SM90 (and on HIP/AMD where clusters are not
+ * supported), falls back to single-block behavior where cluster_size is
+ * effectively 1.
  */
 __device__ inline ThreadGroup make_cluster_group() {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 #if __CUDA_ARCH__ >= 900
   // Get cluster grid dimensions using PTX instructions
   uint32_t num_clusters_x, cluster_rank;
@@ -868,7 +882,8 @@ __device__ inline ThreadGroup make_cluster_group() {
       .total_groups = num_clusters_x,
       .scope = SyncScope::CLUSTER};
 #else
-  // Fallback for non-Hopper: treat each block as its own cluster
+  // Fallback for non-Hopper (and HIP — clusters not supported on AMD):
+  // treat each block as its own cluster
   return ThreadGroup{
       .thread_id_in_group = threadIdx.x,
       .group_size = blockDim.x,
@@ -894,7 +909,7 @@ __device__ inline ThreadGroup make_cluster_group() {
  *   - Each block processes work items cooperatively
  */
 __device__ inline ThreadGroup make_block_group() {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   return ThreadGroup{
       .thread_id_in_group = threadIdx.x,
       .group_size = blockDim.x,
@@ -932,7 +947,7 @@ __device__ inline ThreadGroup make_block_group() {
 // TODO: Add support for configurable multiwarp size, 4/8/16.. warps as a
 // multiwarp.
 __device__ inline ThreadGroup make_multiwarp_group() {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   uint32_t threads_per_block = blockDim.x * blockDim.y * blockDim.z;
   uint32_t tid = threadIdx.x + threadIdx.y * blockDim.x +
       threadIdx.z * blockDim.x * blockDim.y;
@@ -979,7 +994,7 @@ __device__ inline ThreadGroup make_multiwarp_group() {
  *   }
  */
 __device__ inline ThreadGroup make_thread_group(SyncScope scope) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   switch (scope) {
     case SyncScope::THREAD:
       return make_thread_solo();

--- a/comms/pipes/Timeout.cuh
+++ b/comms/pipes/Timeout.cuh
@@ -7,6 +7,18 @@
 
 namespace comms::pipes {
 
+// GPU clock abstraction: NVIDIA uses clock64() (shader clock),
+// AMD uses wall_clock64() (fixed 100 MHz wall clock) for accurate timing.
+__device__ __forceinline__ uint64_t gpu_clock64() {
+#if defined(__HIP_DEVICE_COMPILE__) && !defined(__CUDA_ARCH__)
+  return wall_clock64();
+#elif defined(__CUDA_ARCH__)
+  return clock64();
+#else
+  return 0; // Host fallback (never called at runtime)
+#endif
+}
+
 // Forward declaration - full definition in ThreadGroup.cuh
 struct ThreadGroup;
 
@@ -78,7 +90,7 @@ struct Timeout {
    * deadline_cycles already being non-zero.
    */
   __device__ __forceinline__ void start() {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     if (timeout_cycles > 0) {
       if (deadline_cycles != 0) {
         printf(
@@ -87,7 +99,7 @@ struct Timeout {
             static_cast<unsigned long long>(deadline_cycles));
         __trap(); // Double-start is a programming error
       }
-      deadline_cycles = clock64() + timeout_cycles;
+      deadline_cycles = gpu_clock64() + timeout_cycles;
     }
 #endif
   }
@@ -107,9 +119,9 @@ struct Timeout {
    * @return true if timeout has expired, false otherwise (or if disabled)
    */
   __device__ __forceinline__ bool checkExpired() const {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     if (timeout_cycles > 0) {
-      return clock64() > deadline_cycles;
+      return gpu_clock64() > deadline_cycles;
     }
 #endif
     return false;
@@ -141,9 +153,9 @@ namespace comms::pipes {
 
 __device__ __forceinline__ bool Timeout::checkExpired(
     const ThreadGroup& group) const {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   if (timeout_cycles > 0 && group.is_leader()) {
-    return clock64() > deadline_cycles;
+    return gpu_clock64() > deadline_cycles;
   }
 #else
   (void)group;
@@ -169,7 +181,7 @@ __device__ __forceinline__ bool Timeout::checkExpired(
  * @param fmt Printf-style format string (without newline)
  * @param ... Format arguments
  */
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 #define TIMEOUT_TRAP_IF_EXPIRED(timeout, group, fmt, ...)     \
   do {                                                        \
     if ((timeout).checkExpired(group)) {                      \
@@ -194,7 +206,7 @@ __device__ __forceinline__ bool Timeout::checkExpired(
  * @param fmt Printf-style format string (without newline)
  * @param ... Format arguments
  */
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 #define TIMEOUT_TRAP_IF_EXPIRED_SINGLE(timeout, fmt, ...)     \
   do {                                                        \
     if ((timeout).checkExpired()) {                           \

--- a/comms/pipes/collectives/AllToAllv.cuh
+++ b/comms/pipes/collectives/AllToAllv.cuh
@@ -112,7 +112,7 @@ __device__ __forceinline__ void all_to_allv(
     Timeout timeout
     // all arguments below will eventually come from communicator
 ) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   auto group = make_warp_group();
   const auto nranks = transports_per_rank.size();
   PIPES_DEVICE_CHECK(nranks == send_chunk_infos.size());


### PR DESCRIPTION
Summary:

Modify two shared NVIDIA headers with minimal `#ifdef` additions to support
AMD GPUs:

**Timeout.cuh:**
- Add `gpu_clock64()` helper function that dispatches to the platform-appropriate
  GPU clock: `wall_clock64()` on AMD (fixed 100 MHz), `clock64()` on NVIDIA
- Replace all `clock64()` calls with `gpu_clock64()` in `start()`, `checkExpired()`,
  and `checkExpired(ThreadGroup)`
- Host fallback returns 0 (never called at runtime)

**IbgdaBuffer.h:**
- Fix `IBGDA_HOST_DEVICE` macro to include `__HIPCC__` alongside `__CUDACC__`
- Add `detail::ibgdaNetworkByteOrderKey()` helper for NIC-aware byte order
  conversion: `htobe32()` for mlx5 (default), native byte order for bnxt/ionic
- Replace hardcoded `htobe32()` in `NetworkLKey` and `NetworkRKey` implicit
  constructors with the new helper

No behavioral changes on NVIDIA — mlx5 path still uses `htobe32()`.

Reviewed By: dmwu

Differential Revision: D98522970


