### PR TITLE
Add AMD NIC backend, verbs layer, and PipesGdaShared.h (#2190)

### DIFF
--- a/comms/common/DeviceConstants.cuh
+++ b/comms/common/DeviceConstants.cuh
@@ -7,7 +7,13 @@
 namespace comms::device {
 
 // Statically define the warp size (unlike warpSize, this can be used in
-// constexpr expressions)
-constexpr uint32_t kWarpSize = 32;
+// constexpr expressions).
+// Note: Uses __HIP_PLATFORM_AMD__ (not __HIP_DEVICE_COMPILE__) because this
+// constant is needed in both host and device code (e.g., buffer allocation).
+#if defined(__HIP_PLATFORM_AMD__)
+constexpr uint32_t kWarpSize = 64; // AMD wavefront size
+#else
+constexpr uint32_t kWarpSize = 32; // NVIDIA warp size
+#endif
 
 } // namespace comms::device

--- a/comms/pipes/CopyUtils.cuh
+++ b/comms/pipes/CopyUtils.cuh
@@ -3,11 +3,56 @@
 #pragma once
 
 #include <cuda_runtime.h>
+
 #include <cstddef>
+#include "comms/pipes/HipCompat.cuh"
 
 #include "comms/pipes/ThreadGroup.cuh"
 
 namespace comms::pipes {
+
+// =============================================================================
+// AMD system-coherent store for P2P writes over XGMI
+// =============================================================================
+// On AMD GPUs, regular stores to remote GPU memory go through L1/L2 cache
+// and may not be visible to the remote GPU until a cache flush. For P2P
+// transfers, we need system-coherent stores that bypass/flush caches.
+#if defined(__HIP_DEVICE_COMPILE__) && !defined(__CUDA_ARCH__)
+
+/**
+ * Requires: dst and src must be 8-byte aligned (guaranteed when called via
+ * uint4* from memcpy_vectorized_aligned_sys). Misaligned pointers cause
+ * undefined behavior on AMD flat_store_dwordx2.
+ */
+__device__ __forceinline__ void store_sys_u128(uint4* dst, const uint4* src) {
+  // Note: 128-bit store is split into two 64-bit stores. Atomicity is not
+  // required — callers synchronize the full transfer via signal/barrier
+  // primitives before the consumer reads.
+#if defined(__gfx942__) || defined(__gfx950__)
+  // 16-byte system-coherent store via 2x dwordx2 with sc0 sc1
+  const uint64_t* s = reinterpret_cast<const uint64_t*>(src);
+  uint64_t* d = reinterpret_cast<uint64_t*>(dst);
+  uint64_t v0 = s[0];
+  uint64_t v1 = s[1];
+  asm volatile("flat_store_dwordx2 %0, %1 sc0 sc1" : : "v"(d), "v"(v0));
+  asm volatile("flat_store_dwordx2 %0, %1 sc0 sc1" : : "v"(d + 1), "v"(v1));
+#elif defined(__gfx90a__)
+  const uint64_t* s = reinterpret_cast<const uint64_t*>(src);
+  uint64_t* d = reinterpret_cast<uint64_t*>(dst);
+  uint64_t v0 = s[0];
+  uint64_t v1 = s[1];
+  asm volatile("flat_store_dwordx2 %0, %1 glc slc" : : "v"(d), "v"(v0));
+  asm volatile("flat_store_dwordx2 %0, %1 glc slc" : : "v"(d + 1), "v"(v1));
+#else
+  // Unsupported AMD architecture — plain store lacks system coherence and
+  // would silently break P2P correctness. Fail at compile time so new
+  // architectures get an explicit implementation.
+#error \
+    "store_sys_u128: no system-coherent store implementation for this AMD GPU architecture"
+#endif
+}
+
+#endif // __HIP_DEVICE_COMPILE__
 
 /**
  * memcpy_vectorized_aligned - High-performance vectorized memory copy
@@ -50,7 +95,7 @@ __device__ __forceinline__ void memcpy_vectorized_aligned(
     const VecType* src_p,
     std::size_t nelems,
     const ThreadGroup& group) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   // Loop stride: group_size threads × kUnroll elements each
   const std::size_t kLoopStride = group.group_size * kUnroll;
   const std::size_t numVecsAligned = (nelems / kLoopStride) * kLoopStride;
@@ -77,8 +122,43 @@ __device__ __forceinline__ void memcpy_vectorized_aligned(
        i += group.group_size) {
     dst[i] = src[i];
   }
-#endif // __CUDA_ARCH__
+#endif // defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 }
+
+// AMD-optimized uint4 copy with system-coherent stores for P2P over XGMI.
+// NVIDIA NVLink provides hardware cache coherence for P2P writes, so the
+// standard memcpy_vectorized_aligned() is sufficient. AMD XGMI does not
+// guarantee coherence — remote stores may remain in local L1/L2 caches —
+// so this variant uses explicit cache-bypassing stores (sc0 sc1 / glc slc).
+#if defined(__HIP_DEVICE_COMPILE__) && !defined(__CUDA_ARCH__)
+template <int kUnroll = 8>
+__device__ __forceinline__ void memcpy_vectorized_aligned_sys(
+    uint4* dst,
+    const uint4* src,
+    std::size_t nelems,
+    const ThreadGroup& group) {
+  const std::size_t kLoopStride = group.group_size * kUnroll;
+  const std::size_t numVecsAligned = (nelems / kLoopStride) * kLoopStride;
+
+  for (std::size_t i = group.thread_id_in_group; i < numVecsAligned;
+       i += kLoopStride) {
+    uint4 v[kUnroll];
+#pragma unroll
+    for (int j = 0; j < kUnroll; ++j) {
+      v[j] = src[i + j * group.group_size];
+    }
+#pragma unroll
+    for (int j = 0; j < kUnroll; ++j) {
+      store_sys_u128(&dst[i + j * group.group_size], &v[j]);
+    }
+  }
+
+  for (std::size_t i = numVecsAligned + group.thread_id_in_group; i < nelems;
+       i += group.group_size) {
+    store_sys_u128(&dst[i], &src[i]);
+  }
+}
+#endif
 
 template <int kUnroll = 8>
 __device__ __forceinline__ void memcpy_vectorized(
@@ -86,7 +166,7 @@ __device__ __forceinline__ void memcpy_vectorized(
     const char* src,
     std::size_t len,
     const ThreadGroup& group) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   constexpr std::size_t kAlignment = sizeof(uint4);
   if ((uintptr_t)dst % kAlignment == 0 && (uintptr_t)src % kAlignment == 0) {
     const std::size_t nelems = len / kAlignment;
@@ -102,7 +182,7 @@ __device__ __forceinline__ void memcpy_vectorized(
   }
 
   memcpy_vectorized_aligned<char, kUnroll>(dst, src, len, group);
-#endif // __CUDA_ARCH__
+#endif // defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 }
 
 /**
@@ -121,15 +201,16 @@ __device__ __forceinline__ void memcpy_vectorized(
  * @param src_d Source buffer pointer
  * @param nbytes Size of both buffers in bytes
  *
- * Note: Only active on device (__CUDA_ARCH__). No-op on host.
+ * Note: Only active on device (__CUDA_ARCH__ / __HIP_DEVICE_COMPILE__). No-op
+ * on host.
  */
 __device__ __forceinline__ void
 assert_buffer_non_overlap(char* dst_d, const char* src_d, std::size_t nbytes) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   if (!(src_d + nbytes <= dst_d || dst_d + nbytes <= src_d)) {
     __trap(); // Abort kernel if buffers overlap
   }
-#endif // __CUDA_ARCH__
+#endif // defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 }
 
 } // namespace comms::pipes

--- a/comms/pipes/DeviceCheck.cuh
+++ b/comms/pipes/DeviceCheck.cuh
@@ -4,6 +4,8 @@
 
 #include <cstdio>
 
+#include "comms/pipes/HipCompat.cuh"
+
 namespace comms::pipes {
 
 /**
@@ -23,7 +25,7 @@ namespace comms::pipes {
  * Note: __trap() puts the CUDA device into an unrecoverable error state. After
  * a trap, cudaDeviceReset() is required to recover the device context.
  */
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 #define PIPES_DEVICE_CHECK(expr)                                    \
   do {                                                              \
     if (!(expr)) {                                                  \
@@ -55,7 +57,7 @@ namespace comms::pipes {
  * Usage:
  *   PIPES_DEVICE_CHECK_MSG(idx < size, "Index out of bounds");
  */
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 #define PIPES_DEVICE_CHECK_MSG(expr, msg)                                \
   do {                                                                   \
     if (!(expr)) {                                                       \

--- a/comms/pipes/DeviceSpan.cuh
+++ b/comms/pipes/DeviceSpan.cuh
@@ -9,10 +9,12 @@
 #include <cassert>
 #include <cstdint>
 
+#include "comms/pipes/HipCompat.cuh"
+
 namespace comms::pipes {
 
 // Device-side bounds check helper
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 #define DEVICE_SPAN_CHECK_LT(val, bound)                          \
   do {                                                            \
     if (!((val) < (bound))) {                                     \

--- a/comms/pipes/HipCompat.cuh
+++ b/comms/pipes/HipCompat.cuh
@@ -1,0 +1,9 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+// On HIP, __trap() is not available; use abort() instead.
+// Include this header in any device code that calls __trap().
+#if defined(__HIP_DEVICE_COMPILE__) && !defined(__CUDA_ARCH__)
+#define __trap() abort()
+#endif

--- a/comms/pipes/IbgdaBuffer.h
+++ b/comms/pipes/IbgdaBuffer.h
@@ -7,14 +7,26 @@
 
 #include <endian.h>
 
-// Allow compilation in both host (C++) and device (CUDA) contexts
-#ifdef __CUDACC__
+// Allow compilation in both host (C++) and device (CUDA/HIP) contexts
+#if defined(__CUDACC__) || defined(__HIPCC__)
 #define IBGDA_HOST_DEVICE __host__ __device__
 #else
 #define IBGDA_HOST_DEVICE
 #endif
 
 namespace comms::pipes {
+
+// NIC-aware byte order conversion for RDMA memory keys.
+// mlx5 requires big-endian keys; bnxt/ionic use native byte order.
+namespace detail {
+inline uint32_t ibgdaNetworkByteOrderKey(uint32_t hostValue) {
+#if defined(NIC_BNXT) || defined(NIC_IONIC)
+  return hostValue; // Native byte order for non-mlx5 NICs
+#else
+  return htobe32(hostValue); // mlx5: big-endian
+#endif
+}
+} // namespace detail
 
 // =============================================================================
 // Strong Types for RDMA Memory Keys
@@ -63,10 +75,10 @@ struct NetworkLKey {
   NetworkLKey() = default;
   IBGDA_HOST_DEVICE explicit NetworkLKey(uint32_t v) : value(v) {}
 
-  // Implicit conversion from HostLKey (performs htobe32)
+  // Implicit conversion from HostLKey (performs byte order conversion)
   // NOLINTNEXTLINE(google-explicit-constructor)
   /* implicit */ NetworkLKey(HostLKey hostKey)
-      : value(htobe32(hostKey.value)) {}
+      : value(detail::ibgdaNetworkByteOrderKey(hostKey.value)) {}
 
   IBGDA_HOST_DEVICE bool operator==(const NetworkLKey& other) const {
     return value == other.value;
@@ -110,14 +122,14 @@ struct NetworkRKey {
   NetworkRKey() = default;
   IBGDA_HOST_DEVICE explicit NetworkRKey(uint32_t v) : value(v) {}
 
-  // Implicit conversion from HostRKey (performs htobe32)
+  // Implicit conversion from HostRKey (performs byte order conversion)
   // Note: This constructor is intentionally NOT explicit - implicit conversion
   // is the desired behavior. It is also intentionally host-only (no
-  // IBGDA_HOST_DEVICE) because htobe32() is not available on GPU. The
-  // conversion happens on the host before passing to device code.
+  // IBGDA_HOST_DEVICE) because the conversion happens on the host before
+  // passing to device code.
   // NOLINTNEXTLINE(google-explicit-constructor)
   /* implicit */ NetworkRKey(HostRKey hostKey)
-      : value(htobe32(hostKey.value)) {}
+      : value(detail::ibgdaNetworkByteOrderKey(hostKey.value)) {}
 
   IBGDA_HOST_DEVICE bool operator==(const NetworkRKey& other) const {
     return value == other.value;

--- a/comms/pipes/MultiPeerTransport.cc
+++ b/comms/pipes/MultiPeerTransport.cc
@@ -725,6 +725,11 @@ void MultiPeerTransport::build_device_handle() {
         new (&transportsHost[r]) Transport(devPtr);
         break;
       }
+
+      case TransportType::P2P_IBGDA_AMD:
+        throw std::runtime_error(
+            "P2P_IBGDA_AMD transport not supported in MultiPeerTransport "
+            "(use MultipeerIbgdaTransportAmd instead)");
     }
   }
 

--- a/comms/pipes/P2pNvlTransportDevice.cuh
+++ b/comms/pipes/P2pNvlTransportDevice.cuh
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <cuda.h>
+
 #include <cuda_runtime.h>
 #include <cstddef>
 #include <cstring>
@@ -10,6 +11,7 @@
 #include "comms/pipes/CopyUtils.cuh"
 #include "comms/pipes/DeviceCheck.cuh"
 #include "comms/pipes/DeviceSpan.cuh"
+#include "comms/pipes/HipCompat.cuh"
 #include "comms/pipes/SignalState.cuh"
 #include "comms/pipes/ThreadGroup.cuh"
 #include "comms/pipes/Timeout.cuh"
@@ -421,7 +423,7 @@ class P2pNvlTransportDevice {
       void* srcbuff,
       std::size_t nbytes,
       const Timeout& timeout = Timeout()) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     if (options_.dataBufferSize == 0) {
       printf(
           "P2pNvlTransportDevice::send() requires staging buffer"
@@ -687,7 +689,7 @@ class P2pNvlTransportDevice {
       void* dstbuff,
       std::size_t nbytes,
       const Timeout& timeout = Timeout()) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     if (options_.dataBufferSize == 0) {
       printf(
           "P2pNvlTransportDevice::recv() requires staging buffer"
@@ -881,7 +883,7 @@ class P2pNvlTransportDevice {
    */
   __device__ __forceinline__ std::size_t
   put(ThreadGroup& group, char* dst_d, const char* src_d, std::size_t nbytes) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     // Early return for no-op cases
     if (nbytes == 0) {
       return 0;

--- a/comms/pipes/P2pSelfTransportDevice.cuh
+++ b/comms/pipes/P2pSelfTransportDevice.cuh
@@ -3,7 +3,9 @@
 #pragma once
 
 #include <cuda_runtime.h>
+
 #include <cstddef>
+#include "comms/pipes/HipCompat.cuh"
 
 #include "comms/pipes/CopyUtils.cuh"
 #include "comms/pipes/ThreadGroup.cuh"
@@ -45,7 +47,7 @@ class P2pSelfTransportDevice {
    * Calling this method will trap and abort the kernel.
    */
   __device__ void send(ThreadGroup& group, void* srcbuff, std::size_t nbytes) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     __trap(); // Abort kernel if send is called on SelfTransportDevice
 #endif
   }
@@ -57,7 +59,7 @@ class P2pSelfTransportDevice {
    * Calling this method will trap and abort the kernel.
    */
   __device__ void recv(ThreadGroup& group, void* dstbuff, std::size_t nbytes) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     __trap(); // Abort kernel if recv is called on SelfTransportDevice
 #endif
   }
@@ -83,7 +85,7 @@ class P2pSelfTransportDevice {
    */
   __device__ __forceinline__ void
   put(ThreadGroup& group, char* dst_d, const char* src_d, std::size_t nbytes) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     // Early return for no-op cases (check before overlap to handle dst == src)
     if (nbytes == 0 || dst_d == src_d) {
       return;

--- a/comms/pipes/SignalState.cuh
+++ b/comms/pipes/SignalState.cuh
@@ -3,8 +3,10 @@
 #pragma once
 
 #include <cstdint>
+
 #include "comms/common/AtomicUtils.cuh"
 #include "comms/common/BitOps.cuh"
+#include "comms/pipes/HipCompat.cuh"
 #include "comms/pipes/ThreadGroup.cuh"
 #include "comms/pipes/Timeout.cuh"
 

--- a/comms/pipes/ThreadGroup.cuh
+++ b/comms/pipes/ThreadGroup.cuh
@@ -9,6 +9,7 @@
 #include "comms/common/AtomicUtils.cuh"
 #include "comms/common/DeviceConstants.cuh"
 #include "comms/pipes/DeviceSpan.cuh"
+#include "comms/pipes/HipCompat.cuh"
 
 namespace comms::pipes {
 
@@ -95,7 +96,7 @@ struct ThreadGroup {
   SyncScope scope;
 
   __device__ inline void sync() {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     switch (scope) {
       case SyncScope::THREAD:
         // Single-thread group: emit a compiler barrier to prevent reordering
@@ -107,17 +108,27 @@ struct ThreadGroup {
         asm volatile("" ::: "memory");
         break;
       case SyncScope::WARP:
+#if defined(__CUDA_ARCH__)
         __syncwarp();
+#else
+        // AMD wavefronts are implicitly lockstep; agent-scope fence suffices
+        __builtin_amdgcn_fence(__ATOMIC_SEQ_CST, "agent");
+#endif
         break;
       case SyncScope::MULTIWARP: {
         // Multiwarp = 4 warps = 128 threads
-        // Uses named barriers for synchronization within a multiwarp
+#if defined(__CUDA_ARCH__)
+        // Uses CUDA named barriers for synchronization within a multiwarp
         uint32_t tid = threadIdx.x + threadIdx.y * blockDim.x +
             threadIdx.z * blockDim.x * blockDim.y;
         uint32_t barrierId = tid / kMultiwarpSize;
         asm volatile("bar.sync %0, %1;"
                      :
                      : "r"(barrierId), "r"(kMultiwarpSize));
+#else
+        // AMD: no named barriers, fall back to block-level sync
+        __syncthreads();
+#endif
         break;
       }
       case SyncScope::BLOCK:
@@ -185,7 +196,7 @@ struct ThreadGroup {
    * @return Warp-scoped ThreadGroup with renumbered group_id/total_groups
    */
   __device__ inline ThreadGroup to_warp_group() const {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     if (scope == SyncScope::WARP && group_size == kWarpSize) {
       return *this;
     }
@@ -240,8 +251,10 @@ struct ThreadGroup {
    */
   template <typename T>
   __device__ inline T broadcast(T val) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     switch (scope) {
+      case SyncScope::THREAD:
+        return val; // Single thread, nothing to broadcast
       case SyncScope::WARP:
         return shfl(val, 0);
       case SyncScope::MULTIWARP: {
@@ -342,7 +355,7 @@ struct ThreadGroup {
   __device__ inline void for_each_item_contiguous(
       uint32_t total_items,
       Func&& func) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     const uint32_t items_per_group =
         (total_items + total_groups - 1) / total_groups;
     const uint32_t start_item = group_id * items_per_group;
@@ -406,7 +419,7 @@ struct ThreadGroup {
   __device__ inline void for_each_item_strided(
       uint32_t total_items,
       Func&& func) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     for (uint32_t item_id = group_id; item_id < total_items;
          item_id += total_groups) {
       func(item_id);
@@ -493,7 +506,7 @@ struct PartitionResult {
  */
 __device__ inline PartitionResult ThreadGroup::partition(
     uint32_t num_partitions) const {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   // More partitions than groups is invalid - some partitions would be empty
   // and group assignment would skip partitions non-deterministically.
   // Use __trap() instead of assert() to ensure this check is active in both
@@ -604,7 +617,7 @@ __device__ inline PartitionResult ThreadGroup::partition(
  */
 __device__ inline PartitionResult ThreadGroup::partition(
     DeviceSpan<const uint32_t> weights) const {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   const uint32_t num_partitions = static_cast<uint32_t>(weights.size());
 
   // Count non-zero weights and calculate total weight
@@ -712,7 +725,7 @@ __device__ inline PartitionResult ThreadGroup::partition(
  */
 __device__ inline PartitionResult ThreadGroup::partition_interleaved(
     uint32_t num_partitions) const {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   if (num_partitions > total_groups) {
     printf(
         "partition_interleaved: num_partitions (%u) must be <= total_groups (%u)\n",
@@ -756,7 +769,7 @@ __device__ inline PartitionResult ThreadGroup::partition_interleaved(
  * thread index and count respectively.
  */
 __device__ inline ThreadGroup make_thread_solo() {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   uint32_t tid = threadIdx.x + threadIdx.y * blockDim.x +
       threadIdx.z * blockDim.x * blockDim.y;
   uint32_t threads_per_block = blockDim.x * blockDim.y * blockDim.z;
@@ -791,7 +804,7 @@ __device__ inline ThreadGroup make_thread_solo() {
  * ThreadGroup into warp subgroups, preserving group context.
  */
 __device__ inline ThreadGroup make_warp_group() {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   uint32_t warps_per_block = blockDim.x / comms::device::kWarpSize;
   uint32_t warp_id_in_block = threadIdx.x / comms::device::kWarpSize;
   uint32_t global_warp_id = blockIdx.x * warps_per_block + warp_id_in_block;
@@ -836,11 +849,12 @@ __device__ inline ThreadGroup make_warp_group() {
  * - ~16 SMs per GPC, 8 GPCs total -> 132 SMs
  * - Maximum cluster size: 16 blocks (limited by GPC)
  *
- * NOTE: On architectures before SM90, falls back to single-block behavior
- * where cluster_size is effectively 1.
+ * NOTE: On architectures before SM90 (and on HIP/AMD where clusters are not
+ * supported), falls back to single-block behavior where cluster_size is
+ * effectively 1.
  */
 __device__ inline ThreadGroup make_cluster_group() {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 #if __CUDA_ARCH__ >= 900
   // Get cluster grid dimensions using PTX instructions
   uint32_t num_clusters_x, cluster_rank;
@@ -868,7 +882,8 @@ __device__ inline ThreadGroup make_cluster_group() {
       .total_groups = num_clusters_x,
       .scope = SyncScope::CLUSTER};
 #else
-  // Fallback for non-Hopper: treat each block as its own cluster
+  // Fallback for non-Hopper (and HIP — clusters not supported on AMD):
+  // treat each block as its own cluster
   return ThreadGroup{
       .thread_id_in_group = threadIdx.x,
       .group_size = blockDim.x,
@@ -894,7 +909,7 @@ __device__ inline ThreadGroup make_cluster_group() {
  *   - Each block processes work items cooperatively
  */
 __device__ inline ThreadGroup make_block_group() {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   return ThreadGroup{
       .thread_id_in_group = threadIdx.x,
       .group_size = blockDim.x,
@@ -932,7 +947,7 @@ __device__ inline ThreadGroup make_block_group() {
 // TODO: Add support for configurable multiwarp size, 4/8/16.. warps as a
 // multiwarp.
 __device__ inline ThreadGroup make_multiwarp_group() {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   uint32_t threads_per_block = blockDim.x * blockDim.y * blockDim.z;
   uint32_t tid = threadIdx.x + threadIdx.y * blockDim.x +
       threadIdx.z * blockDim.x * blockDim.y;
@@ -979,7 +994,7 @@ __device__ inline ThreadGroup make_multiwarp_group() {
  *   }
  */
 __device__ inline ThreadGroup make_thread_group(SyncScope scope) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   switch (scope) {
     case SyncScope::THREAD:
       return make_thread_solo();

--- a/comms/pipes/Timeout.cuh
+++ b/comms/pipes/Timeout.cuh
@@ -7,6 +7,18 @@
 
 namespace comms::pipes {
 
+// GPU clock abstraction: NVIDIA uses clock64() (shader clock),
+// AMD uses wall_clock64() (fixed 100 MHz wall clock) for accurate timing.
+__device__ __forceinline__ uint64_t gpu_clock64() {
+#if defined(__HIP_DEVICE_COMPILE__) && !defined(__CUDA_ARCH__)
+  return wall_clock64();
+#elif defined(__CUDA_ARCH__)
+  return clock64();
+#else
+  return 0; // Host fallback (never called at runtime)
+#endif
+}
+
 // Forward declaration - full definition in ThreadGroup.cuh
 struct ThreadGroup;
 
@@ -78,7 +90,7 @@ struct Timeout {
    * deadline_cycles already being non-zero.
    */
   __device__ __forceinline__ void start() {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     if (timeout_cycles > 0) {
       if (deadline_cycles != 0) {
         printf(
@@ -87,7 +99,7 @@ struct Timeout {
             static_cast<unsigned long long>(deadline_cycles));
         __trap(); // Double-start is a programming error
       }
-      deadline_cycles = clock64() + timeout_cycles;
+      deadline_cycles = gpu_clock64() + timeout_cycles;
     }
 #endif
   }
@@ -107,9 +119,9 @@ struct Timeout {
    * @return true if timeout has expired, false otherwise (or if disabled)
    */
   __device__ __forceinline__ bool checkExpired() const {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     if (timeout_cycles > 0) {
-      return clock64() > deadline_cycles;
+      return gpu_clock64() > deadline_cycles;
     }
 #endif
     return false;
@@ -141,9 +153,9 @@ namespace comms::pipes {
 
 __device__ __forceinline__ bool Timeout::checkExpired(
     const ThreadGroup& group) const {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   if (timeout_cycles > 0 && group.is_leader()) {
-    return clock64() > deadline_cycles;
+    return gpu_clock64() > deadline_cycles;
   }
 #else
   (void)group;
@@ -169,7 +181,7 @@ __device__ __forceinline__ bool Timeout::checkExpired(
  * @param fmt Printf-style format string (without newline)
  * @param ... Format arguments
  */
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 #define TIMEOUT_TRAP_IF_EXPIRED(timeout, group, fmt, ...)     \
   do {                                                        \
     if ((timeout).checkExpired(group)) {                      \
@@ -194,7 +206,7 @@ __device__ __forceinline__ bool Timeout::checkExpired(
  * @param fmt Printf-style format string (without newline)
  * @param ... Format arguments
  */
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 #define TIMEOUT_TRAP_IF_EXPIRED_SINGLE(timeout, fmt, ...)     \
   do {                                                        \
     if ((timeout).checkExpired()) {                           \

--- a/comms/pipes/Transport.cuh
+++ b/comms/pipes/Transport.cuh
@@ -35,6 +35,7 @@ enum class TransportType : uint8_t {
   SELF,
   P2P_NVL,
   P2P_IBGDA,
+  P2P_IBGDA_AMD,
 };
 
 /// Human-readable name for TransportType (host-only).
@@ -46,6 +47,8 @@ inline const char* transport_type_name(TransportType t) {
       return "P2P_NVL";
     case TransportType::P2P_IBGDA:
       return "P2P_IBGDA";
+    case TransportType::P2P_IBGDA_AMD:
+      return "P2P_IBGDA_AMD";
   }
   return "UNKNOWN";
 }
@@ -79,6 +82,10 @@ struct Transport {
     // etc.) that cannot compile in .cc translation units. A forward declaration
     // + non-owning pointer avoids pulling those headers into Transport.cuh.
     P2pIbgdaTransportDevice* p2p_ibgda;
+    // AMD IBGDA transport (pipes_gda::P2pIbgdaTransportDevice).
+    // Stored as void* to avoid including AMD device headers (HIP intrinsics)
+    // in CUDA compilation units. Cast to the correct type in kernel dispatch.
+    void* p2p_ibgda_amd;
   };
 
   /** Constructor for SelfTransportDevice */
@@ -92,6 +99,12 @@ struct Transport {
   /** Constructor for P2pIbgdaTransportDevice (non-owning pointer) */
   __host__ __device__ explicit Transport(P2pIbgdaTransportDevice* p)
       : type(TransportType::P2P_IBGDA), p2p_ibgda(p) {}
+
+  /** Constructor for AMD IBGDA transport (non-owning void pointer) */
+  struct IbgdaAmdTag {};
+  __host__ __device__ Transport(void* p, IbgdaAmdTag)
+      : type(TransportType::P2P_IBGDA_AMD), p2p_ibgda_amd(p) {}
+
   /**
    * Delete copy constructor and copy assignment.
    * Transport objects contain device pointers and IPC handles that should not
@@ -109,8 +122,10 @@ struct Transport {
       new (&self) P2pSelfTransportDevice(std::move(other.self));
     } else if (type == TransportType::P2P_NVL) {
       new (&p2p_nvl) P2pNvlTransportDevice(std::move(other.p2p_nvl));
-    } else {
+    } else if (type == TransportType::P2P_IBGDA) {
       p2p_ibgda = other.p2p_ibgda;
+    } else {
+      p2p_ibgda_amd = other.p2p_ibgda_amd;
     }
   }
 
@@ -134,8 +149,10 @@ struct Transport {
         new (&self) P2pSelfTransportDevice(std::move(other.self));
       } else if (type == TransportType::P2P_NVL) {
         new (&p2p_nvl) P2pNvlTransportDevice(std::move(other.p2p_nvl));
-      } else {
+      } else if (type == TransportType::P2P_IBGDA) {
         p2p_ibgda = other.p2p_ibgda;
+      } else {
+        p2p_ibgda_amd = other.p2p_ibgda_amd;
       }
     }
     return *this;

--- a/comms/pipes/amd/PipesGdaShared.h
+++ b/comms/pipes/amd/PipesGdaShared.h
@@ -1,0 +1,73 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// =============================================================================
+// PipesGdaShared — Re-exports shared comms::pipes types into pipes_gda
+// =============================================================================
+//
+// The shared comms::pipes headers (ThreadGroup.cuh, Timeout.cuh, IbgdaBuffer.h)
+// support both CUDA and HIP. This header re-exports all their types into the
+// pipes_gda namespace so AMD code can use a consistent namespace.
+
+#pragma once
+
+#include "comms/pipes/IbgdaBuffer.h"
+#include "comms/pipes/ThreadGroup.cuh"
+#include "comms/pipes/Timeout.cuh"
+
+namespace pipes_gda {
+
+// ---------------------------------------------------------------------------
+// IbgdaBuffer types
+// ---------------------------------------------------------------------------
+using comms::pipes::HostLKey;
+using comms::pipes::HostRKey;
+using comms::pipes::IbgdaBufferExchInfo;
+using comms::pipes::IbgdaCmpOp;
+using comms::pipes::IbgdaLocalBuffer;
+using comms::pipes::IbgdaRemoteBuffer;
+using comms::pipes::IbgdaSignalOp;
+using comms::pipes::NetworkLKey;
+using comms::pipes::NetworkRKey;
+
+// ---------------------------------------------------------------------------
+// ThreadGroup types and factory functions
+// ---------------------------------------------------------------------------
+using comms::pipes::PartitionResult;
+using comms::pipes::SyncScope;
+using comms::pipes::ThreadGroup;
+
+using comms::pipes::make_block_group;
+using comms::pipes::make_multiwarp_group;
+using comms::pipes::make_thread_group;
+using comms::pipes::make_thread_solo;
+using comms::pipes::make_warp_group;
+
+// AMD alias: make_wavefront_group() = make_warp_group()
+// (kWarpSize is already 64 on AMD via DeviceConstants.cuh)
+__device__ inline ThreadGroup make_wavefront_group() {
+  return comms::pipes::make_warp_group();
+}
+
+using comms::device::kWarpSize;
+constexpr uint32_t kWavefrontSize = comms::device::kWarpSize;
+constexpr uint32_t kMultiwarpWavefrontCount = 4;
+using comms::pipes::kMaxMultiwarpsPerBlock;
+using comms::pipes::kMultiwarpSize;
+
+// ---------------------------------------------------------------------------
+// Timeout types and helpers
+// ---------------------------------------------------------------------------
+using comms::pipes::gpu_clock64;
+using comms::pipes::Timeout;
+
+// AMD wall_clock64() clock rate: 100 MHz = 100 ticks per microsecond
+constexpr uint64_t kAmdWallClockTicksPerUs = 100;
+
+// Convenience: create a Timeout from microseconds (AMD wall_clock64 @ 100 MHz)
+inline Timeout make_timeout_us(uint64_t timeoutUs) {
+  return Timeout(timeoutUs * kAmdWallClockTicksPerUs);
+}
+
+} // namespace pipes_gda
+
+// TIMEOUT_TRAP_IF_EXPIRED_SINGLE is already defined in comms/pipes/Timeout.cuh

--- a/comms/pipes/amd/nic/Mlx5Hsi.h
+++ b/comms/pipes/amd/nic/Mlx5Hsi.h
@@ -1,0 +1,270 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved. SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Modifications: (c) Meta Platforms, Inc. and affiliates.
+
+// =============================================================================
+// MLX5 (Mellanox/NVIDIA ConnectX) Hardware-Software Interface for pipes-gda
+// =============================================================================
+//
+// MLX5 NIC WQE, CQE, and doorbell structures for GPU-initiated RDMA.
+// MLX5 hardware interface definitions for GPU-initiated RDMA.
+//
+// This file is the MLX5 equivalent of BnxtHsi.h:
+//   - WQE segment structs (data, control, raddr, atomic, inline)
+//   - CQE structs (cqe64, error CQE)
+//   - MLX5 opcodes, control flags, CQE status codes
+//   - MLX5-specific constants (SQ shift, doorbell record indices)
+// =============================================================================
+
+#pragma once
+
+#include <linux/types.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// =============================================================================
+// MLX5 WQE Constants
+// =============================================================================
+
+#define PIPES_GDA_IB_MLX5_WQE_SQ_SHIFT 6
+
+// =============================================================================
+// MLX5 WQE Opcodes
+// =============================================================================
+
+enum {
+  PIPES_GDA_IB_MLX5_OPCODE_NOP = 0x00,
+  PIPES_GDA_IB_MLX5_OPCODE_SEND_INVAL = 0x01,
+  PIPES_GDA_IB_MLX5_OPCODE_RDMA_WRITE = 0x08,
+  PIPES_GDA_IB_MLX5_OPCODE_RDMA_WRITE_IMM = 0x09,
+  PIPES_GDA_IB_MLX5_OPCODE_SEND = 0x0a,
+  PIPES_GDA_IB_MLX5_OPCODE_SEND_IMM = 0x0b,
+  PIPES_GDA_IB_MLX5_OPCODE_TSO = 0x0e,
+  PIPES_GDA_IB_MLX5_OPCODE_RDMA_READ = 0x10,
+  PIPES_GDA_IB_MLX5_OPCODE_ATOMIC_CS = 0x11,
+  PIPES_GDA_IB_MLX5_OPCODE_ATOMIC_FA = 0x12,
+  PIPES_GDA_IB_MLX5_OPCODE_ATOMIC_MASKED_CS = 0x14,
+  PIPES_GDA_IB_MLX5_OPCODE_ATOMIC_MASKED_FA = 0x15,
+  PIPES_GDA_IB_MLX5_OPCODE_FMR = 0x19,
+  PIPES_GDA_IB_MLX5_OPCODE_LOCAL_INVAL = 0x1b,
+  PIPES_GDA_IB_MLX5_OPCODE_WAIT = 0x0f,
+  PIPES_GDA_IB_MLX5_OPCODE_CONFIG_CMD = 0x1f,
+  PIPES_GDA_IB_MLX5_OPCODE_SET_PSV = 0x20,
+  PIPES_GDA_IB_MLX5_OPCODE_DUMP = 0x23,
+  PIPES_GDA_IB_MLX5_OPCODE_UMR = 0x25,
+  PIPES_GDA_IB_MLX5_OPCODE_TAG_MATCHING = 0x28,
+  PIPES_GDA_IB_MLX5_OPCODE_FLOW_TBL_ACCESS = 0x2c,
+  PIPES_GDA_IB_MLX5_OPCODE_MMO = 0x2F,
+};
+
+// =============================================================================
+// MLX5 WQE Control Flags
+// =============================================================================
+
+enum {
+  PIPES_GDA_IB_MLX5_WQE_CTRL_CE_CQE_ON_CQE_ERROR = 0x0,
+  PIPES_GDA_IB_MLX5_WQE_CTRL_CE_CQE_ON_FIRST_CQE_ERROR = 0x1,
+  PIPES_GDA_IB_MLX5_WQE_CTRL_CE_CQE_ALWAYS = 0x2,
+  PIPES_GDA_IB_MLX5_WQE_CTRL_CE_CQE_AND_EQE = 0x3,
+};
+
+enum {
+  PIPES_GDA_IB_MLX5_WQE_CTRL_FM_NO_FENCE = 0x0,
+  PIPES_GDA_IB_MLX5_WQE_CTRL_FM_INITIATOR_SMALL_FENCE = 0x1,
+  PIPES_GDA_IB_MLX5_WQE_CTRL_FM_FENCE = 0x2,
+  PIPES_GDA_IB_MLX5_WQE_CTRL_FM_STRONG_ORDERING = 0x3,
+  PIPES_GDA_IB_MLX5_WQE_CTRL_FM_FENCE_AND_INITIATOR_SMALL_FENCE = 0x4,
+  PIPES_GDA_IB_MLX5_WQE_CTRL_FM_CUSTOM = 0x100,
+};
+
+enum pipes_gda_gpu_dev_verbs_wqe_ctrl_flags {
+  PIPES_GDA_IB_MLX5_WQE_CTRL_CQ_UPDATE =
+      PIPES_GDA_IB_MLX5_WQE_CTRL_CE_CQE_ALWAYS << 2,
+  PIPES_GDA_IB_MLX5_WQE_CTRL_CQ_ERROR_UPDATE =
+      PIPES_GDA_IB_MLX5_WQE_CTRL_CE_CQE_ON_CQE_ERROR << 2,
+  PIPES_GDA_IB_MLX5_WQE_CTRL_CQ_FIRST_CQE_ERROR =
+      PIPES_GDA_IB_MLX5_WQE_CTRL_CE_CQE_ON_FIRST_CQE_ERROR << 2,
+  PIPES_GDA_IB_MLX5_WQE_CTRL_SOLICITED = 1 << 1,
+  PIPES_GDA_IB_MLX5_WQE_CTRL_FENCE =
+      PIPES_GDA_IB_MLX5_WQE_CTRL_FM_FENCE_AND_INITIATOR_SMALL_FENCE << 5,
+  PIPES_GDA_IB_MLX5_WQE_CTRL_INITIATOR_SMALL_FENCE =
+      PIPES_GDA_IB_MLX5_WQE_CTRL_FM_INITIATOR_SMALL_FENCE << 5,
+  PIPES_GDA_IB_MLX5_WQE_CTRL_STRONG_ORDERING =
+      PIPES_GDA_IB_MLX5_WQE_CTRL_FM_STRONG_ORDERING << 5
+};
+
+// =============================================================================
+// MLX5 Doorbell Record Indices
+// =============================================================================
+
+enum {
+  PIPES_GDA_IB_MLX5_RCV_DBR = 0,
+  PIPES_GDA_IB_MLX5_SND_DBR = 1,
+};
+
+// =============================================================================
+// MLX5 WQE Segment Count Constants
+// =============================================================================
+
+enum {
+  PIPES_GDA_VERBS_WQE_SEG_CNT_RDMA_WRITE_INL_MIN = 3,
+  PIPES_GDA_VERBS_WQE_SEG_CNT_RDMA_WRITE_INL_MAX = 4,
+  PIPES_GDA_VERBS_WQE_SEG_CNT_ATOMIC_FA_CAS = 4,
+  PIPES_GDA_VERBS_WQE_SEG_CNT_WAIT = 2
+};
+
+enum {
+  PIPES_GDA_IB_MLX5_INLINE_SEG = 0x80000000,
+};
+
+// =============================================================================
+// MLX5 CQE Status Codes
+// =============================================================================
+
+#define PIPES_GDA_VERBS_MLX5_CQE_OPCODE_SHIFT 4
+
+enum {
+  PIPES_GDA_IB_MLX5_CQE_OWNER_MASK = 1,
+  PIPES_GDA_IB_MLX5_CQE_REQ = 0,
+  PIPES_GDA_IB_MLX5_CQE_RESP_WR_IMM = 1,
+  PIPES_GDA_IB_MLX5_CQE_RESP_SEND = 2,
+  PIPES_GDA_IB_MLX5_CQE_RESP_SEND_IMM = 3,
+  PIPES_GDA_IB_MLX5_CQE_RESP_SEND_INV = 4,
+  PIPES_GDA_IB_MLX5_CQE_RESIZE_CQ = 5,
+  PIPES_GDA_IB_MLX5_CQE_NO_PACKET = 6,
+  PIPES_GDA_IB_MLX5_CQE_SIG_ERR = 12,
+  PIPES_GDA_IB_MLX5_CQE_REQ_ERR = 13,
+  PIPES_GDA_IB_MLX5_CQE_RESP_ERR = 14,
+  PIPES_GDA_IB_MLX5_CQE_INVALID = 15,
+};
+
+// =============================================================================
+// MLX5 WQE Segment Structures
+// =============================================================================
+
+struct pipes_gda_ib_mlx5_wqe_data_seg {
+  __be32 byte_count;
+  __be32 lkey;
+  __be64 addr;
+};
+
+struct pipes_gda_ib_mlx5_wqe_ctrl_seg {
+  __be32 opmod_idx_opcode;
+  __be32 qpn_ds;
+  uint8_t signature;
+  __be16 dci_stream_channel_id;
+  uint8_t fm_ce_se;
+  __be32 imm;
+} __attribute__((__packed__)) __attribute__((__aligned__(4)));
+
+struct pipes_gda_ib_mlx5_wqe_raddr_seg {
+  __be64 raddr;
+  __be32 rkey;
+  __be32 reserved;
+};
+
+struct pipes_gda_ib_mlx5_wqe_atomic_seg {
+  __be64 swap_add;
+  __be64 compare;
+};
+
+struct pipes_gda_ib_mlx5_wqe_inl_data_seg {
+  uint32_t byte_count;
+};
+
+// =============================================================================
+// MLX5 CQE Structures
+// =============================================================================
+
+struct pipes_gda_ib_mlx5_tm_cqe {
+  __be32 success;
+  __be16 hw_phase_cnt;
+  uint8_t rsvd0[12];
+};
+
+struct pipes_gda_ib_ibv_tmh {
+  uint8_t opcode;
+  uint8_t reserved[3];
+  __be32 app_ctx;
+  __be64 tag;
+};
+
+struct pipes_gda_ib_mlx5_cqe64 {
+  union {
+    struct {
+      uint8_t rsvd0[2];
+      __be16 wqe_id;
+      uint8_t rsvd4[13];
+      uint8_t ml_path;
+      uint8_t rsvd20[4];
+      __be16 slid;
+      __be32 flags_rqpn;
+      uint8_t hds_ip_ext;
+      uint8_t l4_hdr_type_etc;
+      __be16 vlan_info;
+    };
+    struct pipes_gda_ib_mlx5_tm_cqe tm_cqe;
+    struct pipes_gda_ib_ibv_tmh tmh;
+  };
+  __be32 srqn_uidx;
+  __be32 imm_inval_pkey;
+  uint8_t app;
+  uint8_t app_op;
+  __be16 app_info;
+  __be32 byte_cnt;
+  __be64 timestamp;
+  __be32 sop_drop_qpn;
+  __be16 wqe_counter;
+  uint8_t signature;
+  uint8_t op_own;
+};
+
+struct pipes_gda_ib_mlx5_err_cqe_ex {
+  uint8_t rsvd0[32];
+  __be32 srqn;
+  uint8_t rsvd1[16];
+  uint8_t hw_err_synd;
+  uint8_t hw_synd_type;
+  uint8_t vendor_err_synd;
+  uint8_t syndrome;
+  __be32 s_wqe_opcode_qpn;
+  __be16 wqe_counter;
+  uint8_t signature;
+  uint8_t op_own;
+};
+
+#ifdef __cplusplus
+}
+#endif

--- a/comms/pipes/amd/nic/Mlx5NicBackend.h
+++ b/comms/pipes/amd/nic/Mlx5NicBackend.h
@@ -1,0 +1,405 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved. SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Modifications: (c) Meta Platforms, Inc. and affiliates.
+
+// =============================================================================
+// MLX5 (Mellanox/NVIDIA ConnectX) NIC Backend for pipes-gda
+// =============================================================================
+//
+// Device-side WQE construction, doorbell, and CQ polling for mlx5 NICs.
+// Uses mlx5-specific WQE format (4 x 16-byte segments = 64 bytes),
+// DBREC + BlueFlame doorbell mechanism, and owner-bit CQE polling.
+//
+// This backend is used by P2pIbgdaTransportDevice<Mlx5NicBackend>.
+// =============================================================================
+
+#pragma once
+
+#include <cerrno>
+#include <cstddef>
+#include <cstdint>
+
+#include "nic/Mlx5Hsi.h" // @manual
+#include "verbs/AmdVerbsCompat.h" // @manual
+#include "verbs/VerbsDev.h" // @manual
+
+namespace pipes_gda {
+
+struct Mlx5NicBackend {
+  static constexpr const char* vendorPrefix() {
+    return "mlx5";
+  }
+  static constexpr uint16_t vendorId() {
+    return 0x02c9;
+  }
+  static inline uint32_t swapMkey(uint32_t key) {
+    return __builtin_bswap32(key);
+  }
+  static inline uint32_t networkByteOrderKey(uint32_t hostKey) {
+    return htobe32(hostKey);
+  }
+
+  __device__ pipes_gda_gpu_dev_verbs_wqe* getWqePtr(
+      pipes_gda_gpu_dev_verbs_qp* qp,
+      uint64_t wqeIdx) const {
+    uint16_t maskedIdx = static_cast<uint16_t>(wqeIdx) & qp->sq_wqe_mask;
+    return reinterpret_cast<pipes_gda_gpu_dev_verbs_wqe*>(qp->sq_wqe_daddr) +
+        maskedIdx;
+  }
+
+  __device__ uint64_t
+  reserveWqSlots(pipes_gda_gpu_dev_verbs_qp* qp, uint32_t numSlots) {
+    return amd_atomic_add_device(
+        &qp->sq_rsvd_index, static_cast<uint64_t>(numSlots));
+  }
+
+  __device__ void markWqesReady(
+      pipes_gda_gpu_dev_verbs_qp* qp,
+      uint64_t firstIdx,
+      uint64_t lastIdx) {
+    while (amd_load_relaxed_device(&qp->sq_ready_index) < firstIdx) {
+    }
+    // System-scope release fence: WQE data is in host memory (SQ buffer via
+    // hipHostRegister). Must be visible to the NIC (a PCIe device) before the
+    // doorbell ring. Agent-scope is insufficient — it only orders within the
+    // GPU's L2 cache domain.
+    amd_fence_release_system();
+    amd_atomic_max_device(&qp->sq_ready_index, lastIdx + 1);
+  }
+
+  __device__ void ringDoorbell(
+      pipes_gda_gpu_dev_verbs_qp* qp,
+      uint64_t nextWqeIdx) {
+    uint32_t pi =
+        static_cast<uint32_t>(nextWqeIdx) & PIPES_GDA_VERBS_WQE_PI_MASK;
+
+    *reinterpret_cast<volatile uint32_t*>(
+        qp->sq_dbrec + PIPES_GDA_IB_MLX5_SND_DBR) = amd_bswap32(pi);
+    __atomic_signal_fence(__ATOMIC_SEQ_CST);
+
+    uint64_t lastWqeIdx = nextWqeIdx - 1;
+    pipes_gda_gpu_dev_verbs_wqe* lastWqe = getWqePtr(qp, lastWqeIdx);
+    uint64_t dbVal = *reinterpret_cast<volatile uint64_t*>(lastWqe);
+
+    amd_store_doorbell_sys_u64(qp->sq_db, dbVal);
+
+    uint64_t dbAddr = __hip_atomic_load(
+        reinterpret_cast<uint64_t*>(&qp->sq_db),
+        __ATOMIC_RELAXED,
+        __HIP_MEMORY_SCOPE_AGENT);
+    dbAddr ^= 0x100;
+    __hip_atomic_store(
+        reinterpret_cast<uint64_t*>(&qp->sq_db),
+        dbAddr,
+        __ATOMIC_RELAXED,
+        __HIP_MEMORY_SCOPE_AGENT);
+  }
+
+  __device__ void prepareRdmaWriteWqe(
+      pipes_gda_gpu_dev_verbs_qp* qp,
+      pipes_gda_gpu_dev_verbs_wqe* wqe,
+      uint64_t wqeIdx,
+      uint8_t ctrlFlags,
+      uint64_t remoteAddr,
+      uint32_t remoteKey,
+      uint64_t localAddr,
+      uint32_t localKey,
+      std::size_t size) {
+    pipes_gda_gpu_dev_verbs_wqe_ctrl_seg cseg = {};
+    cseg.opmod_idx_opcode = amd_bswap32(
+        (static_cast<uint32_t>(wqeIdx) << PIPES_GDA_VERBS_WQE_IDX_SHIFT) |
+        PIPES_GDA_IB_MLX5_OPCODE_RDMA_WRITE);
+    cseg.qpn_ds = amd_bswap32(qp->sq_num_shift8 | 3);
+    cseg.fm_ce_se = ctrlFlags;
+
+    pipes_gda_ib_mlx5_wqe_raddr_seg rseg = {};
+    rseg.raddr = amd_bswap64(remoteAddr);
+    rseg.rkey = remoteKey;
+
+    pipes_gda_ib_mlx5_wqe_data_seg dseg = {};
+    dseg.byte_count = amd_bswap32(static_cast<uint32_t>(size));
+    dseg.lkey = localKey;
+    dseg.addr = amd_bswap64(localAddr);
+
+    amd_store_wqe_seg(
+        reinterpret_cast<uint64_t*>(&wqe->dseg0),
+        reinterpret_cast<uint64_t*>(&cseg));
+    amd_store_wqe_seg(
+        reinterpret_cast<uint64_t*>(&wqe->dseg1),
+        reinterpret_cast<uint64_t*>(&rseg));
+    amd_store_wqe_seg(
+        reinterpret_cast<uint64_t*>(&wqe->dseg2),
+        reinterpret_cast<uint64_t*>(&dseg));
+  }
+
+  __device__ void prepareAtomicFaWqe(
+      pipes_gda_gpu_dev_verbs_qp* qp,
+      pipes_gda_gpu_dev_verbs_wqe* wqe,
+      uint64_t wqeIdx,
+      uint8_t ctrlFlags,
+      uint64_t remoteAddr,
+      uint32_t remoteKey,
+      uint64_t localAddr,
+      uint32_t localKey,
+      uint64_t addVal) {
+    pipes_gda_gpu_dev_verbs_wqe_ctrl_seg cseg = {};
+    cseg.opmod_idx_opcode = amd_bswap32(
+        (static_cast<uint32_t>(wqeIdx) << PIPES_GDA_VERBS_WQE_IDX_SHIFT) |
+        PIPES_GDA_IB_MLX5_OPCODE_ATOMIC_FA);
+    cseg.qpn_ds = amd_bswap32(
+        qp->sq_num_shift8 | PIPES_GDA_VERBS_WQE_SEG_CNT_ATOMIC_FA_CAS);
+    cseg.fm_ce_se = ctrlFlags;
+
+    pipes_gda_ib_mlx5_wqe_raddr_seg rseg = {};
+    rseg.raddr = amd_bswap64(remoteAddr);
+    rseg.rkey = remoteKey;
+
+    pipes_gda_ib_mlx5_wqe_atomic_seg aseg = {};
+    aseg.swap_add = amd_bswap64(addVal);
+    aseg.compare = 0;
+
+    pipes_gda_ib_mlx5_wqe_data_seg dseg = {};
+    dseg.byte_count = amd_bswap32(sizeof(uint64_t));
+    dseg.lkey = localKey;
+    dseg.addr = amd_bswap64(localAddr);
+
+    amd_store_wqe_seg(
+        reinterpret_cast<uint64_t*>(&wqe->dseg0),
+        reinterpret_cast<uint64_t*>(&cseg));
+    amd_store_wqe_seg(
+        reinterpret_cast<uint64_t*>(&wqe->dseg1),
+        reinterpret_cast<uint64_t*>(&rseg));
+    amd_store_wqe_seg(
+        reinterpret_cast<uint64_t*>(&wqe->dseg2),
+        reinterpret_cast<uint64_t*>(&aseg));
+    amd_store_wqe_seg(
+        reinterpret_cast<uint64_t*>(&wqe->dseg3),
+        reinterpret_cast<uint64_t*>(&dseg));
+  }
+
+  __device__ void prepareNopWqe(
+      pipes_gda_gpu_dev_verbs_qp* qp,
+      pipes_gda_gpu_dev_verbs_wqe* wqe,
+      uint64_t wqeIdx) {
+    pipes_gda_gpu_dev_verbs_wqe_ctrl_seg cseg = {};
+    cseg.opmod_idx_opcode = amd_bswap32(
+        (static_cast<uint32_t>(wqeIdx) << PIPES_GDA_VERBS_WQE_IDX_SHIFT) |
+        PIPES_GDA_IB_MLX5_OPCODE_NOP);
+    cseg.qpn_ds = amd_bswap32(qp->sq_num_shift8 | 1);
+    cseg.fm_ce_se = PIPES_GDA_IB_MLX5_WQE_CTRL_CQ_UPDATE;
+
+    amd_store_wqe_seg(
+        reinterpret_cast<uint64_t*>(&wqe->dseg0),
+        reinterpret_cast<uint64_t*>(&cseg));
+  }
+
+  // ===========================================================================
+  // prepareInlineWriteWqe - Construct inline RDMA Write WQE
+  // ===========================================================================
+  //
+  // Builds a 3-segment WQE: ctrl + raddr + inline data.
+  // Used by reset_signal() to write a zero to the remote signal buffer
+  // without needing a local memory region (data is embedded in the WQE).
+  template <typename T>
+  __device__ void prepareInlineWriteWqe(
+      pipes_gda_gpu_dev_verbs_qp* qp,
+      pipes_gda_gpu_dev_verbs_wqe* wqe,
+      uint64_t wqeIdx,
+      uint8_t ctrlFlags,
+      uint64_t remoteAddr,
+      uint32_t remoteKey,
+      T value) {
+    static_assert(
+        sizeof(T) <= PIPES_GDA_VERBS_MAX_INLINE_SIZE, "inline too large");
+
+    uint32_t dsCount = (sizeof(T) <= 16)
+        ? PIPES_GDA_VERBS_WQE_SEG_CNT_RDMA_WRITE_INL_MIN
+        : PIPES_GDA_VERBS_WQE_SEG_CNT_RDMA_WRITE_INL_MAX;
+
+    pipes_gda_gpu_dev_verbs_wqe_ctrl_seg cseg = {};
+    cseg.opmod_idx_opcode = amd_bswap32(
+        (static_cast<uint32_t>(wqeIdx) << PIPES_GDA_VERBS_WQE_IDX_SHIFT) |
+        PIPES_GDA_IB_MLX5_OPCODE_RDMA_WRITE);
+    cseg.qpn_ds = amd_bswap32(qp->sq_num_shift8 | dsCount);
+    cseg.fm_ce_se = ctrlFlags;
+
+    pipes_gda_ib_mlx5_wqe_raddr_seg rseg = {};
+    rseg.raddr = amd_bswap64(remoteAddr);
+    rseg.rkey = remoteKey;
+
+    // Inline data segment: header (4 bytes) + payload
+    struct {
+      pipes_gda_ib_mlx5_wqe_inl_data_seg hdr;
+      T payload;
+    } __attribute__((__packed__)) inlSeg = {};
+
+    inlSeg.hdr.byte_count = amd_bswap32(
+        static_cast<uint32_t>(sizeof(T)) | PIPES_GDA_IB_MLX5_INLINE_SEG);
+    inlSeg.payload = value;
+
+    amd_store_wqe_seg(
+        reinterpret_cast<uint64_t*>(&wqe->dseg0),
+        reinterpret_cast<uint64_t*>(&cseg));
+    amd_store_wqe_seg(
+        reinterpret_cast<uint64_t*>(&wqe->dseg1),
+        reinterpret_cast<uint64_t*>(&rseg));
+    amd_store_wqe_seg(
+        reinterpret_cast<uint64_t*>(&wqe->dseg2),
+        reinterpret_cast<uint64_t*>(&inlSeg));
+  }
+
+  // ===========================================================================
+  // prepareWaitWqe - Construct WAIT WQE for cross-QP synchronization
+  // ===========================================================================
+  //
+  // Builds a 2-segment WQE: ctrl + wait. The WAIT WQE tells the NIC to stall
+  // processing on this QP until the referenced CQ has completed the target WQE.
+  // Used by companion QP to wait on main QP completion before posting counter.
+  __device__ void prepareWaitWqe(
+      pipes_gda_gpu_dev_verbs_qp* qp,
+      pipes_gda_gpu_dev_verbs_wqe* wqe,
+      uint64_t wqeIdx,
+      uint8_t ctrlFlags,
+      uint32_t targetCqNum,
+      uint64_t targetWqeIdx) {
+    pipes_gda_gpu_dev_verbs_wqe_ctrl_seg cseg = {};
+    cseg.opmod_idx_opcode = amd_bswap32(
+        (static_cast<uint32_t>(wqeIdx) << PIPES_GDA_VERBS_WQE_IDX_SHIFT) |
+        PIPES_GDA_IB_MLX5_OPCODE_WAIT);
+    cseg.qpn_ds =
+        amd_bswap32(qp->sq_num_shift8 | PIPES_GDA_VERBS_WQE_SEG_CNT_WAIT);
+    cseg.fm_ce_se = ctrlFlags;
+
+    pipes_gda_gpu_dev_verbs_wqe_wait_seg wseg = {};
+    wseg.max_index = amd_bswap32(
+        static_cast<uint32_t>(targetWqeIdx) & PIPES_GDA_VERBS_WQE_PI_MASK);
+    wseg.qpn_cqn = amd_bswap32(targetCqNum);
+
+    amd_store_wqe_seg(
+        reinterpret_cast<uint64_t*>(&wqe->dseg0),
+        reinterpret_cast<uint64_t*>(&cseg));
+    amd_store_wqe_seg(
+        reinterpret_cast<uint64_t*>(&wqe->dseg1),
+        reinterpret_cast<uint64_t*>(&wseg));
+  }
+
+  // ===========================================================================
+  // pollOneCqAt - Non-blocking CQ poll at a specific index
+  // ===========================================================================
+  //
+  // Returns 0 on success, EBUSY if not yet complete.
+  // Unlike pollCqAt() which spins until completion, this returns immediately
+  // so the caller can implement timeout logic.
+  __device__ int pollOneCqAt(
+      pipes_gda_gpu_dev_verbs_cq* cq,
+      uint64_t consIndex) {
+    pipes_gda_ib_mlx5_cqe64* cqeBase =
+        reinterpret_cast<pipes_gda_ib_mlx5_cqe64*>(cq->cqe_daddr);
+    const uint32_t cqeNum = cq->cqe_num;
+    uint32_t idx = static_cast<uint32_t>(consIndex) & (cqeNum - 1);
+    pipes_gda_ib_mlx5_cqe64* cqe64 = &cqeBase[idx];
+
+    uint64_t cqeCi = amd_load_relaxed_device(&cq->cqe_ci);
+    if (consIndex < cqeCi)
+      return 0;
+
+    if (consIndex >= cqeCi + cqeNum)
+      return EBUSY;
+
+    uint32_t cqeChunk =
+        amd_load_relaxed_sys(reinterpret_cast<uint32_t*>(&cqe64->wqe_counter));
+    cqeChunk = amd_bswap32(cqeChunk);
+    uint16_t wqeCounter = cqeChunk >> 16;
+    uint8_t opown = cqeChunk & 0xff;
+
+    if ((opown & PIPES_GDA_IB_MLX5_CQE_OWNER_MASK) ^ !!(consIndex & cqeNum))
+      return EBUSY;
+    if (wqeCounter != (static_cast<uint32_t>(consIndex) & 0xffff))
+      return EBUSY;
+
+    uint8_t opcode = opown >> PIPES_GDA_VERBS_MLX5_CQE_OPCODE_SHIFT;
+
+    amd_fence_acquire_system();
+    amd_atomic_max_device(&cq->cqe_ci, consIndex + 1);
+
+    uint32_t ci =
+        static_cast<uint32_t>(consIndex + 1) & PIPES_GDA_VERBS_CQE_CI_MASK;
+    amd_store_release_sys_u32(
+        reinterpret_cast<uint32_t*>(cq->dbrec), amd_bswap32(ci));
+
+    return (opcode == PIPES_GDA_IB_MLX5_CQE_REQ_ERR) ? -5 : 0;
+  }
+
+  __device__ int pollCqAt(
+      pipes_gda_gpu_dev_verbs_qp* qp,
+      pipes_gda_gpu_dev_verbs_cq* cq,
+      uint64_t consIndex) {
+    pipes_gda_ib_mlx5_cqe64* cqeBase =
+        reinterpret_cast<pipes_gda_ib_mlx5_cqe64*>(cq->cqe_daddr);
+    const uint32_t cqeNum = cq->cqe_num;
+    uint32_t idx = static_cast<uint32_t>(consIndex) & (cqeNum - 1);
+    pipes_gda_ib_mlx5_cqe64* cqe64 = &cqeBase[idx];
+
+    uint8_t opown;
+    uint32_t cqeChunk;
+    uint16_t wqeCounter;
+
+    do {
+      uint64_t cqeCi = amd_load_relaxed_device(&cq->cqe_ci);
+      if (consIndex < cqeCi)
+        return 0;
+
+      cqeChunk = amd_load_relaxed_sys(
+          reinterpret_cast<uint32_t*>(&cqe64->wqe_counter));
+      cqeChunk = amd_bswap32(cqeChunk);
+      wqeCounter = cqeChunk >> 16;
+      opown = cqeChunk & 0xff;
+    } while (
+        (consIndex >= amd_load_relaxed_device(&cq->cqe_ci) + cqeNum) ||
+        ((opown & PIPES_GDA_IB_MLX5_CQE_OWNER_MASK) ^ !!(consIndex & cqeNum)) ||
+        (wqeCounter != (static_cast<uint32_t>(consIndex) & 0xffff)));
+
+    uint8_t opcode = opown >> PIPES_GDA_VERBS_MLX5_CQE_OPCODE_SHIFT;
+
+    amd_fence_acquire_system();
+    amd_atomic_max_device(&cq->cqe_ci, consIndex + 1);
+
+    uint32_t ci =
+        static_cast<uint32_t>(consIndex + 1) & PIPES_GDA_VERBS_CQE_CI_MASK;
+    amd_store_release_sys_u32(
+        reinterpret_cast<uint32_t*>(cq->dbrec), amd_bswap32(ci));
+
+    return (opcode == PIPES_GDA_IB_MLX5_CQE_REQ_ERR) ? -5 : 0;
+  }
+};
+
+} // namespace pipes_gda

--- a/comms/pipes/amd/nic/NicConfig.h
+++ b/comms/pipes/amd/nic/NicConfig.h
@@ -1,0 +1,28 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// =============================================================================
+// NIC Selection Configuration
+// =============================================================================
+//
+// Compile-time NIC selection for pipes-gda. Exactly one NIC type must be
+// defined via BUCK compiler_flags (e.g., -DNIC_MLX5 or -DNIC_BNXT).
+//
+// If no NIC is specified, NIC_MLX5 is used as the default for backward
+// compatibility.
+//
+// NIC-specific vendor prefix, vendor ID, byte order, and WQE/CQ logic are
+// provided by the NIC backend classes (Mlx5NicBackend, BnxtNicBackend, etc.)
+// selected at compile time via NicSelector.h.
+// =============================================================================
+
+#pragma once
+
+// Default to mlx5 if no NIC is specified
+#if !defined(NIC_MLX5) && !defined(NIC_BNXT) && !defined(NIC_IONIC)
+#define NIC_MLX5
+#endif
+
+// Validate: exactly one NIC must be selected
+#if (defined(NIC_MLX5) + defined(NIC_BNXT) + defined(NIC_IONIC)) > 1
+#error "Only one NIC type may be selected (NIC_MLX5, NIC_BNXT, NIC_IONIC)"
+#endif

--- a/comms/pipes/amd/nic/NicSelector.h
+++ b/comms/pipes/amd/nic/NicSelector.h
@@ -1,0 +1,39 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// =============================================================================
+// NIC Backend Selector for pipes-gda
+// =============================================================================
+//
+// This is the ONLY file in the project that uses #ifdef NIC_* to select the
+// active NIC backend. All other files use the ActiveNicBackend type alias.
+//
+// To add a new NIC:
+//   1. Create a new backend header (e.g., IonicNicBackend.h)
+//   2. Add a new #elif branch below
+//   3. Add the NIC_* define to NicConfig.h validation
+//   4. Add a new BUCK target with the appropriate compiler_flags
+// =============================================================================
+
+#pragma once
+
+#include "nic/NicConfig.h" // @manual
+
+#if defined(NIC_BNXT)
+#include "nic/BnxtNicBackend.h" // @manual
+#elif defined(NIC_IONIC)
+#include "nic/IonicNicBackend.h" // @manual
+#else
+#include "nic/Mlx5NicBackend.h" // @manual
+#endif
+
+namespace pipes_gda {
+
+#if defined(NIC_BNXT)
+using ActiveNicBackend = BnxtNicBackend;
+#elif defined(NIC_IONIC)
+using ActiveNicBackend = IonicNicBackend;
+#else
+using ActiveNicBackend = Mlx5NicBackend;
+#endif
+
+} // namespace pipes_gda

--- a/comms/pipes/amd/verbs/AmdVerbsCompat.h
+++ b/comms/pipes/amd/verbs/AmdVerbsCompat.h
@@ -1,0 +1,328 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// =============================================================================
+// AMD GPU (HIP/ROCm) Compatibility Layer for IBGDA Verbs
+// =============================================================================
+//
+// This header provides AMD GPU equivalents of the CUDA-specific intrinsics and
+// device functions used by IBGDA verbs device-side code.
+//
+// The original NVIDIA implementation in AmdVerbsCompat.h uses:
+// - CUDA PTX inline assembly for memory ordering (ld.relaxed, st.release,
+// fence)
+// - cuda::atomic_ref for lock-free atomic operations with scope control
+// - __ldg() for read-only cache loads
+// - __syncwarp() and __reduce_max_sync() for warp-level primitives
+//
+// This file maps those to AMD GCN/CDNA equivalents using:
+// - __builtin_amdgcn_fence() for memory ordering
+// - __hip_atomic_* builtins for scoped atomics
+// - __builtin_nontemporal_load/store for non-cached I/O
+// - AMD wavefront intrinsics for warp-level operations
+// =============================================================================
+
+#pragma once
+
+#include <hip/hip_runtime.h>
+#include <cstdint>
+
+// =============================================================================
+// Platform Detection
+// =============================================================================
+
+#if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
+#error \
+    "This header requires AMD HIP (ROCm). For NVIDIA GPUs, use the original CUDA headers."
+#endif
+
+// AMD wavefront size: 64 on GCN/CDNA, 32 on RDNA (default to 64 for datacenter
+// GPUs)
+#ifndef AMD_WAVEFRONT_SIZE
+#if defined(__gfx90a__) || defined(__gfx940__) || defined(__gfx941__) || \
+    defined(__gfx942__)
+#define AMD_WAVEFRONT_SIZE 64
+#else
+#define AMD_WAVEFRONT_SIZE 64
+#endif
+#endif
+
+// =============================================================================
+// Memory Ordering / Fence Operations
+// =============================================================================
+
+// AMD equivalent of CUDA PTX: fence.acquire.gpu / fence.acquire.sys
+// Uses __builtin_amdgcn_fence with appropriate scope.
+// "" = system scope (GPU + CPU + PCIe devices like NICs)
+// "agent" = GPU scope (all CUs within the GPU)
+// "workgroup" = workgroup scope
+__device__ __forceinline__ void amd_fence_acquire_system() {
+  __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "");
+}
+
+__device__ __forceinline__ void amd_fence_acquire_device() {
+  __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "agent");
+}
+
+__device__ __forceinline__ void amd_fence_acquire_workgroup() {
+  __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "workgroup");
+}
+
+__device__ __forceinline__ void amd_fence_release_system() {
+  __builtin_amdgcn_fence(__ATOMIC_RELEASE, "");
+}
+
+__device__ __forceinline__ void amd_fence_release_device() {
+  __builtin_amdgcn_fence(__ATOMIC_RELEASE, "agent");
+}
+
+__device__ __forceinline__ void amd_fence_release_workgroup() {
+  __builtin_amdgcn_fence(__ATOMIC_RELEASE, "workgroup");
+}
+
+// Full system-scope memory fence (equivalent to __threadfence_system)
+__device__ __forceinline__ void amd_fence_system() {
+  __builtin_amdgcn_fence(__ATOMIC_SEQ_CST, "");
+}
+
+// =============================================================================
+// Relaxed / Non-temporal Loads (replace CUDA PTX ld.relaxed.sys.global)
+// =============================================================================
+
+// System-scope relaxed loads for memory shared with PCIe devices (NICs).
+// Must use __hip_atomic_load with __HIP_MEMORY_SCOPE_SYSTEM to generate
+// loads with system coherence modifiers (sc0 sc1 on CDNA3), ensuring the
+// GPU sees the latest values written by the NIC (e.g., CQE entries).
+// Plain __atomic_load_n generates loads without coherence modifiers, which
+// may return stale cached values.
+
+__device__ __forceinline__ uint8_t amd_load_relaxed_sys(uint8_t* ptr) {
+  return __hip_atomic_load(ptr, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_SYSTEM);
+}
+
+__device__ __forceinline__ uint32_t amd_load_relaxed_sys(uint32_t* ptr) {
+  return __hip_atomic_load(ptr, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_SYSTEM);
+}
+
+__device__ __forceinline__ uint64_t amd_load_relaxed_sys(uint64_t* ptr) {
+  return __hip_atomic_load(ptr, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_SYSTEM);
+}
+
+// Device-scope relaxed loads (for QP metadata shared among GPU threads)
+__device__ __forceinline__ uint64_t amd_load_relaxed_device(uint64_t* ptr) {
+  return __atomic_load_n(ptr, __ATOMIC_RELAXED);
+}
+
+// =============================================================================
+// MMIO Stores (replace CUDA PTX st.mmio.relaxed.sys.global)
+// =============================================================================
+
+// For writing to NIC doorbell registers mapped into GPU address space.
+// On AMD, we use a volatile store + system fence to ensure visibility to the
+// NIC.
+__device__ __forceinline__ void amd_store_relaxed_mmio_u64(
+    uint64_t* ptr,
+    uint64_t val) {
+  __hip_atomic_store(ptr, val, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_SYSTEM);
+}
+
+__device__ __forceinline__ void amd_store_relaxed_mmio_u32(
+    uint32_t* ptr,
+    uint32_t val) {
+  __hip_atomic_store(ptr, val, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_SYSTEM);
+}
+
+// =============================================================================
+// Byte-swap (replace CUDA PTX prmt.b32 byte permute instructions)
+// ============================================================================
+
+__device__ __forceinline__ uint64_t amd_bswap64(uint64_t x) {
+  return __builtin_bswap64(x);
+}
+
+__device__ __forceinline__ uint32_t amd_bswap32(uint32_t x) {
+  return __builtin_bswap32(x);
+}
+
+__device__ __forceinline__ uint16_t amd_bswap16(uint16_t x) {
+  return __builtin_bswap16(x);
+}
+
+// =============================================================================
+// Lane ID (replace CUDA PTX: mov.u32 %0, %%laneid)
+// =============================================================================
+
+__device__ __forceinline__ unsigned int amd_get_lane_id() {
+  return __lane_id();
+}
+
+// =============================================================================
+// Global Timer (replace CUDA PTX: mov.u64 %0, %%globaltimer)
+// =============================================================================
+
+// AMD uses s_memtime for GPU clock counter (returns 64-bit cycle count)
+__device__ __forceinline__ uint64_t amd_query_global_timer() {
+  return wall_clock64();
+}
+
+// =============================================================================
+// Read-only Cache Load (replace CUDA __ldg())
+// =============================================================================
+
+// On AMD, __ldg equivalent is a const-qualified load.
+// The compiler + hardware will route through the scalar cache or texture cache.
+template <typename T>
+__device__ __forceinline__ T amd_ldg(const T* ptr) {
+  return *ptr; // AMD GCN/CDNA handles caching at HW level
+}
+
+// Specialization for pointer-width loads (uintptr_t)
+__device__ __forceinline__ uintptr_t amd_ldg(const uintptr_t* ptr) {
+  return *ptr;
+}
+
+// =============================================================================
+// Scoped Atomics (replace cuda::atomic_ref<T, cuda::thread_scope_*>)
+// =============================================================================
+
+// fetch_add with device scope
+__device__ __forceinline__ uint64_t
+amd_atomic_add_device(uint64_t* ptr, uint64_t val) {
+  return __hip_atomic_fetch_add(
+      ptr, val, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+}
+
+__device__ __forceinline__ int amd_atomic_add_device(int* ptr, int val) {
+  return __hip_atomic_fetch_add(
+      ptr, val, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+}
+
+// fetch_max with device scope
+__device__ __forceinline__ uint64_t
+amd_atomic_max_device(uint64_t* ptr, uint64_t val) {
+  return __hip_atomic_fetch_max(
+      ptr, val, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+}
+
+// fetch_max with device scope + acquire ordering
+__device__ __forceinline__ uint64_t
+amd_atomic_max_device_acquire(uint64_t* ptr, uint64_t val) {
+  return __hip_atomic_fetch_max(
+      ptr, val, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_AGENT);
+}
+
+// fetch_add with workgroup scope
+__device__ __forceinline__ uint64_t
+amd_atomic_add_workgroup(uint64_t* ptr, uint64_t val) {
+  return __hip_atomic_fetch_add(
+      ptr, val, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_WORKGROUP);
+}
+
+// fetch_max with workgroup scope
+__device__ __forceinline__ uint64_t
+amd_atomic_max_workgroup(uint64_t* ptr, uint64_t val) {
+  return __hip_atomic_fetch_max(
+      ptr, val, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_WORKGROUP);
+}
+
+// compare-exchange with device scope (replace atomicCAS)
+__device__ __forceinline__ int
+amd_atomic_cas_device(int* ptr, int expected, int desired) {
+  __hip_atomic_compare_exchange_strong(
+      ptr,
+      &expected,
+      desired,
+      __ATOMIC_RELAXED,
+      __ATOMIC_RELAXED,
+      __HIP_MEMORY_SCOPE_AGENT);
+  return expected;
+}
+
+// compare-exchange with workgroup scope (replace atomicCAS_block)
+__device__ __forceinline__ int
+amd_atomic_cas_workgroup(int* ptr, int expected, int desired) {
+  __hip_atomic_compare_exchange_strong(
+      ptr,
+      &expected,
+      desired,
+      __ATOMIC_RELAXED,
+      __ATOMIC_RELAXED,
+      __HIP_MEMORY_SCOPE_WORKGROUP);
+  return expected;
+}
+
+// release store with device scope (for unlock operations)
+__device__ __forceinline__ void amd_store_release_device(int* ptr, int val) {
+  __hip_atomic_store(ptr, val, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_AGENT);
+}
+
+__device__ __forceinline__ void amd_store_release_workgroup(int* ptr, int val) {
+  __hip_atomic_store(ptr, val, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_WORKGROUP);
+}
+
+// release store for doorbell record (32-bit, system/agent scope)
+__device__ __forceinline__ void amd_store_release_sys_u32(
+    uint32_t* ptr,
+    uint32_t val) {
+  __hip_atomic_store(ptr, val, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_SYSTEM);
+}
+
+// Direct doorbell store to NIC UAR BlueFlame register (64-bit, system scope).
+// Uses SEQ_CST ordering with system scope to ensure the PCIe posted write
+// reaches the NIC's PCI BAR.
+__device__ __forceinline__ void amd_store_doorbell_sys_u64(
+    uint64_t* ptr,
+    uint64_t val) {
+  __hip_atomic_store(ptr, val, __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_SYSTEM);
+}
+
+// =============================================================================
+// Warp-level Reduction (replace __reduce_max_sync)
+// =============================================================================
+
+// AMD uses DPP (Data Parallel Primitives) or cross-lane shuffle for reductions.
+// For CDNA (MI200/MI300), wavefront is 64 lanes.
+__device__ __forceinline__ uint32_t amd_warp_reduce_max(uint32_t val) {
+  // Butterfly reduction across wavefront using __shfl_xor
+  for (int offset = AMD_WAVEFRONT_SIZE / 2; offset > 0; offset >>= 1) {
+    uint32_t other = __shfl_xor(val, offset);
+    val = val > other ? val : other;
+  }
+  return val;
+}
+
+// =============================================================================
+// Funnel Shift (replace CUDA __funnelshift_r)
+// =============================================================================
+
+// __funnelshift_r(lo, hi, shift) = (lo, hi) >> shift, taking low 32 bits
+// This is used for the div_ceil_aligned_pow2_32bits fast path.
+__device__ __forceinline__ uint32_t
+amd_funnelshift_r(uint32_t lo, uint32_t hi, int shift) {
+  uint64_t combined = (static_cast<uint64_t>(hi) << 32) | lo;
+  return static_cast<uint32_t>(combined >> (shift & 31));
+}
+
+// =============================================================================
+// Utility: ceil division by power-of-2 (replacing CUDA version that uses
+// __funnelshift_r)
+// =============================================================================
+
+__device__ __forceinline__ uint32_t
+amd_div_ceil_aligned_pow2_32bits(uint64_t x, int denominator_shift) {
+  return static_cast<uint32_t>(x >> denominator_shift) +
+      (amd_funnelshift_r(0, static_cast<uint32_t>(x), denominator_shift) != 0
+           ? 1
+           : 0);
+}
+
+// =============================================================================
+// WQE Segment Store (64-byte aligned store for WQE writes)
+// =============================================================================
+
+// Copy a 16-byte WQE segment using 64-bit stores for atomicity
+__device__ __forceinline__ void amd_store_wqe_seg(
+    uint64_t* dst,
+    const uint64_t* src) {
+  dst[0] = src[0];
+  dst[1] = src[1];
+}

--- a/comms/pipes/amd/verbs/VerbsDef.h
+++ b/comms/pipes/amd/verbs/VerbsDef.h
@@ -1,0 +1,159 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved. SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Modifications: (c) Meta Platforms, Inc. and affiliates.
+
+// =============================================================================
+// Common Verbs Definitions (NIC-agnostic)
+// =============================================================================
+//
+// NIC-agnostic constants, enums, and macros shared by all NIC backends.
+// NIC-specific hardware structs are in separate files:
+//   - nic/Mlx5Hsi.h: MLX5 WQE/CQE structs, opcodes, control flags
+//   - nic/BnxtHsi.h: BNXT WQE/CQE structs, opcodes, doorbell
+//
+// Shared constants and enums for GPU-initiated RDMA verbs.
+// =============================================================================
+
+#pragma once
+
+#include <limits.h>
+#include <linux/types.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// =============================================================================
+// Common Macros
+// =============================================================================
+
+#define PIPES_GDA_VOLATILE(x) (*(volatile typeof(x)*)&(x))
+
+#define PIPES_GDA_VERBS_WARP_SIZE 32
+#define PIPES_GDA_VERBS_WARP_FULL_MASK 0xffffffff
+#define PIPES_GDA_VERBS_PAGE_SIZE 65536
+
+#define PIPES_GDA_VERBS_CQE_CI_MASK 0xFFFFFF
+#define PIPES_GDA_VERBS_WQE_PI_MASK 0xFFFF
+
+#define PIPES_GDA_VERBS_MKEY_SWAPPED 1
+
+#ifndef PIPES_GDA_VERBS_ENABLE_DEBUG
+#define PIPES_GDA_VERBS_ENABLE_DEBUG 0
+#endif
+
+#if PIPES_GDA_VERBS_ENABLE_DEBUG == 1
+#include <assert.h>
+#define PIPES_GDA_VERBS_ASSERT(x) assert(x)
+#else
+#define PIPES_GDA_VERBS_ASSERT(x) \
+  do {                            \
+  } while (0)
+#endif
+
+#define PIPES_GDA_VERBS_MAX_INLINE_SIZE 28
+#define PIPES_GDA_VERBS_CQE_SIZE 64
+#define PIPES_GDA_VERBS_WQE_IDX_SHIFT 8
+
+#define PIPES_GDA_VERBS_MAX_TRANSFER_SIZE_SHIFT 30
+#define PIPES_GDA_VERBS_MAX_TRANSFER_SIZE \
+  (1ULL << PIPES_GDA_VERBS_MAX_TRANSFER_SIZE_SHIFT) // 1GiB
+
+#ifndef ACCESS_ONCE
+#define ACCESS_ONCE(x) (*(volatile typeof(x)*)&(x))
+#endif
+
+#ifndef READ_ONCE
+#define READ_ONCE(x) ACCESS_ONCE(x)
+#endif
+
+#ifndef WRITE_ONCE
+#define WRITE_ONCE(x, v) (ACCESS_ONCE(x) = (v))
+#endif
+
+// =============================================================================
+// Common Enums (NIC-agnostic)
+// =============================================================================
+
+enum pipes_gda_gpu_dev_verbs_mem_type {
+  PIPES_GDA_VERBS_MEM_TYPE_AUTO = 0,
+  PIPES_GDA_VERBS_MEM_TYPE_HOST = 1,
+  PIPES_GDA_VERBS_MEM_TYPE_GPU = 2,
+  PIPES_GDA_VERBS_MEM_TYPE_MAX = INT_MAX
+};
+
+enum pipes_gda_gpu_dev_verbs_qp_type {
+  PIPES_GDA_VERBS_QP_SQ = 0,
+};
+
+enum pipes_gda_gpu_dev_verbs_exec_scope {
+  PIPES_GDA_VERBS_EXEC_SCOPE_THREAD = 0,
+  PIPES_GDA_VERBS_EXEC_SCOPE_WARP
+};
+
+enum pipes_gda_gpu_dev_verbs_sync_scope {
+  PIPES_GDA_VERBS_SYNC_SCOPE_SYS = 0,
+  PIPES_GDA_VERBS_SYNC_SCOPE_GPU = 1,
+  PIPES_GDA_VERBS_SYNC_SCOPE_CTA = 2,
+  PIPES_GDA_VERBS_SYNC_SCOPE_MAX = INT_MAX
+};
+
+enum pipes_gda_gpu_dev_verbs_resource_sharing_mode {
+  PIPES_GDA_VERBS_RESOURCE_SHARING_MODE_EXCLUSIVE = 0,
+  PIPES_GDA_VERBS_RESOURCE_SHARING_MODE_CTA = 1,
+  PIPES_GDA_VERBS_RESOURCE_SHARING_MODE_GPU = 2,
+  PIPES_GDA_VERBS_RESOURCE_SHARING_MODE_MAX = INT_MAX
+};
+
+enum pipes_gda_gpu_dev_verbs_nic_handler {
+  PIPES_GDA_VERBS_NIC_HANDLER_AUTO = 0,
+  PIPES_GDA_VERBS_NIC_HANDLER_CPU_PROXY = 1,
+  PIPES_GDA_VERBS_NIC_HANDLER_GPU_SM_DB = 2,
+  PIPES_GDA_VERBS_NIC_HANDLER_GPU_SM_BF = 3,
+  PIPES_GDA_VERBS_NIC_HANDLER_TYPE_MAX,
+};
+
+enum pipes_gda_gpu_dev_verbs_gpu_code_opt {
+  PIPES_GDA_VERBS_GPU_CODE_OPT_DEFAULT = 0,
+  PIPES_GDA_VERBS_GPU_CODE_OPT_ASYNC_STORE_RELEASE = (1 << 0),
+  PIPES_GDA_VERBS_GPU_CODE_OPT_MAX = INT_MAX
+};
+
+enum pipes_gda_gpu_dev_verbs_signal_op {
+  PIPES_GDA_VERBS_SIGNAL_OP_ADD = 0,
+};
+
+#ifdef __cplusplus
+}
+#endif

--- a/comms/pipes/amd/verbs/VerbsDev.h
+++ b/comms/pipes/amd/verbs/VerbsDev.h
@@ -1,0 +1,293 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved. SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file VerbsDev.h
+ * @brief GDAKI common definitions
+ *
+ * @{
+ */
+#ifndef PIPES_GDA_VERBS_DEV_H
+#define PIPES_GDA_VERBS_DEV_H
+
+#include "nic/Mlx5Hsi.h" // @manual
+#include "verbs/VerbsDef.h" // @manual
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @typedef pipes_gda_gpu_dev_verbs_ticket_t
+ * @brief Ticket type used in one-sided APIs.
+ */
+typedef uint64_t pipes_gda_gpu_dev_verbs_ticket_t;
+
+/**
+ * Describes IBGDA dev WQE crtl segment.
+ */
+struct pipes_gda_gpu_dev_verbs_wqe_ctrl_seg {
+  __be32 opmod_idx_opcode; /**< opcode + wqe idx */
+  __be32 qpn_ds; /**< qp number */
+  union {
+    struct {
+      uint8_t signature; /**< signature */
+      uint8_t rsvd[2]; /**< reserved */
+      uint8_t fm_ce_se; /**< fm_ce_se */
+    };
+    struct {
+      __be32 signature_fm_ce_se; /**< all flags in or */
+    };
+  };
+
+  __be32 imm; /**< immediate */
+} __attribute__((__aligned__(8)));
+
+/**
+ * Describes IBGDA dev WQE crtl segment.
+ */
+struct pipes_gda_gpu_dev_verbs_wqe_wait_seg {
+  uint32_t resv[2];
+  __be32 max_index;
+  __be32 qpn_cqn;
+} __attribute__((__packed__)) __attribute__((__aligned__(8)));
+
+/**
+ * @struct pipes_gda_gpu_dev_verbs_addr
+ * @brief This structure holds the address and key of a memory region.
+ */
+struct pipes_gda_gpu_dev_verbs_addr {
+  uint64_t addr;
+  __be32 key;
+};
+
+/**
+ * Describes IBGDA dev general WQE.
+ */
+struct pipes_gda_gpu_dev_verbs_wqe {
+  union {
+    /* Generic inline Data */
+    struct {
+      uint8_t inl_data[64];
+    };
+
+    /* Generic Data */
+    struct {
+      struct pipes_gda_ib_mlx5_wqe_data_seg dseg0;
+      struct pipes_gda_ib_mlx5_wqe_data_seg dseg1;
+      struct pipes_gda_ib_mlx5_wqe_data_seg dseg2;
+      struct pipes_gda_ib_mlx5_wqe_data_seg dseg3;
+    };
+
+    /* Read/Write */
+    struct {
+      struct pipes_gda_gpu_dev_verbs_wqe_ctrl_seg rw_cseg;
+      struct pipes_gda_ib_mlx5_wqe_raddr_seg rw_rseg;
+      struct pipes_gda_ib_mlx5_wqe_data_seg rw_dseg0;
+      struct pipes_gda_ib_mlx5_wqe_data_seg rw_dseg1;
+    };
+
+    /* Atomic */
+    struct {
+      struct pipes_gda_gpu_dev_verbs_wqe_ctrl_seg at_cseg;
+      struct pipes_gda_ib_mlx5_wqe_raddr_seg at_rseg;
+      struct pipes_gda_ib_mlx5_wqe_atomic_seg at_seg;
+      struct pipes_gda_ib_mlx5_wqe_data_seg at_dseg;
+    };
+
+    /* Send */
+    struct {
+      struct pipes_gda_gpu_dev_verbs_wqe_ctrl_seg snd_cseg;
+      struct pipes_gda_ib_mlx5_wqe_data_seg snd_dseg0;
+      struct pipes_gda_ib_mlx5_wqe_data_seg snd_dseg1;
+      struct pipes_gda_ib_mlx5_wqe_data_seg snd_dseg2;
+    };
+
+    /* Wait */
+    struct {
+      struct pipes_gda_gpu_dev_verbs_wqe_ctrl_seg wait_cseg;
+      struct pipes_gda_gpu_dev_verbs_wqe_wait_seg wait_dseg;
+      struct pipes_gda_ib_mlx5_wqe_data_seg padding0;
+      struct pipes_gda_ib_mlx5_wqe_data_seg padding1;
+    };
+  };
+} __attribute__((__aligned__(8)));
+
+/**
+ * Describes IBGDA dev CQ
+ */
+struct pipes_gda_gpu_dev_verbs_cq {
+  uint8_t* cqe_daddr; /**< CQE address */
+  uint32_t cq_num; /**< CQ number */
+  uint32_t cqe_num; /**< Total number of CQEs in CQ */
+  __be32* dbrec; /**< CQE Doorbell Record */
+  uint64_t cqe_ci; /**< CQE Consumer Index */
+  uint32_t cqe_mask; /**< Mask of total number of CQEs in CQ */
+  uint8_t cqe_size; /**< Single CQE size (64B default) */
+  uint64_t cqe_rsvd; /**< All previous CQEs are polled */
+  enum pipes_gda_gpu_dev_verbs_mem_type
+      mem_type; ///< Memory type of the completion queue
+};
+
+// =============================================================================
+// NIC-specific QP extension structures
+// =============================================================================
+// Each NIC backend can store its private state here. The QP struct uses a
+// union so that only one NIC's fields are active at a time. This avoids
+// #ifdef in this header and allows all NIC backends to compile cleanly.
+
+/**
+ * BNXT-specific QP extension fields.
+ */
+struct pipes_gda_gpu_dev_verbs_qp_bnxt {
+  uint32_t sq_depth; ///< SQ depth in slots (not WQEs)
+  uint32_t sq_head; ///< Consumer head pointer (in slots)
+  uint32_t sq_tail; ///< Producer tail pointer (in slots)
+  uint32_t sq_flags; ///< Epoch flags for wrap-around detection
+  uint32_t sq_id; ///< QP ID used in doorbell value
+
+  void* msntbl; ///< MSN table pointer (GPU memory)
+  uint32_t msn; ///< Current MSN index
+  uint32_t msn_tbl_sz; ///< MSN table size (number of entries)
+  uint32_t psn; ///< Current Packet Sequence Number
+  uint32_t psn_sz_log2; ///< log2(PSN entry size)
+  uint64_t mtu; ///< MTU for packet counting
+
+  volatile uint64_t* dbr; ///< GPU-accessible doorbell register pointer
+
+  void* cq_buf; ///< CQ buffer pointer (GPU memory)
+  uint32_t cq_depth; ///< CQ depth (typically 1 for CQE compression)
+
+  int sq_lock; ///< GPU-side spinlock for SQ serialization
+};
+
+/**
+ * MLX5-specific QP extension fields (placeholder for future use).
+ * Currently mlx5 uses the common QP fields directly.
+ */
+struct pipes_gda_gpu_dev_verbs_qp_mlx5 {
+  uint8_t reserved; ///< Placeholder (mlx5 uses common QP fields)
+};
+
+/**
+ * Ionic-specific QP extension fields.
+ * Ionic uses color-bit CQ polling and MSN-based completion tracking.
+ * Doorbell is a 64-bit write to a memory-mapped register.
+ */
+struct pipes_gda_gpu_dev_verbs_qp_ionic {
+  // SQ doorbell register (GPU-mapped via HSA)
+  volatile uint64_t* sq_dbreg; ///< SQ doorbell register pointer
+  uint64_t sq_dbval; ///< SQ base doorbell value (OR'd with masked position)
+  uint16_t sq_mask; ///< SQ index mask (depth - 1)
+
+  // SQ buffer (ionic_v1_wqe entries)
+  void* sq_buf; ///< SQ WQE buffer pointer (GPU-accessible)
+
+  // SQ producer tracking
+  uint32_t sq_prod; ///< Next SQ producer index (atomic)
+  uint32_t sq_dbprod; ///< Last doorbell'd producer index
+  int sq_lock; ///< Spinlock for doorbell serialization
+
+  // CQ doorbell register (GPU-mapped via HSA)
+  volatile uint64_t* cq_dbreg; ///< CQ doorbell register pointer
+  uint64_t cq_dbval; ///< CQ base doorbell value
+  uint16_t cq_mask; ///< CQ index mask (depth - 1, 0 for CCQE mode)
+
+  // CQ buffer (ionic_v1_cqe entries)
+  void* cq_buf; ///< CQ buffer pointer (GPU-accessible)
+
+  // CQ consumer tracking
+  uint32_t cq_pos; ///< Current CQ consumer position
+  uint32_t cq_dbpos; ///< Last doorbell'd CQ consumer position
+  int cq_lock; ///< Spinlock for CQ polling serialization
+
+  // MSN (Message Sequence Number) tracking
+  uint32_t sq_msn; ///< Last completed MSN from CQ
+};
+
+/**
+ * Describes IBGDA dev QP
+ */
+struct pipes_gda_gpu_dev_verbs_qp {
+  uint64_t sq_rsvd_index; ///< All WQE slots prior to this index are reserved
+  uint64_t sq_ready_index; ///< All WQE slots prior to this index are ready
+  uint64_t sq_wqe_pi; /**< SQ WQE producer index */
+  uint32_t sq_num; /**< SQ num */
+  uint32_t sq_num_shift8; /**< SQ num << 8 */
+  uint32_t sq_num_shift8_be; /**< SQ num << 8 big endian */
+  uint32_t sq_num_shift8_be_1ds; /**< SQ num << 8 big endian */
+  uint32_t sq_num_shift8_be_2ds; /**< SQ num << 8 big endian */
+  uint32_t sq_num_shift8_be_3ds; /**< SQ num << 8 big endian */
+  uint32_t sq_num_shift8_be_4ds; /**< SQ num << 8 big endian */
+  int sq_lock; /**< SQ lock */
+  uint16_t sq_wqe_num; /**< Number of SQ WQE slots */
+  uint16_t sq_wqe_mask; /**< SQ WQE index mask (sq_wqe_num - 1) */
+  uint8_t* sq_wqe_daddr; /**< SQ WQE buffer device address */
+  __be32* sq_dbrec; /**< SQ doorbell record address */
+  uint64_t* sq_db; /**< SQ doorbell (BlueFlame UAR) address */
+
+  /* Unused fields (reserved for compatibility) */
+  uint32_t rq_num; /**< RQ number (unused) */
+  uint64_t rq_wqe_pi; /**< RQ WQE producer index (unused) */
+  uint32_t rq_wqe_num; /**< Number of RQ WQE slots (unused) */
+  uint32_t rq_wqe_mask; /**< RQ WQE index mask (unused) */
+  uint8_t* rq_wqe_daddr; /**< RQ WQE buffer device address (unused) */
+  __be32* rq_dbrec; /**< RQ doorbell record address (unused) */
+  uint32_t rcv_wqe_size; /**< Receive WQE size (unused) */
+  uint64_t rq_rsvd_index; /**< All previous WQEs are reserved */
+  uint64_t rq_ready_index; /**< All previous WQEs are ready */
+  int rq_lock; /**< RQ lock */
+
+  struct pipes_gda_gpu_dev_verbs_cq cq_sq; /**< SQ CQ connected to QP */
+  struct pipes_gda_gpu_dev_verbs_cq cq_rq; /**< RQ CQ connected to QP */
+
+  enum pipes_gda_gpu_dev_verbs_nic_handler nic_handler; ///< NIC handler
+  enum pipes_gda_gpu_dev_verbs_mem_type
+      mem_type; ///< Memory type of the completion
+
+  /**
+   * NIC-specific extension fields (union: only one active at a time).
+   * Access via qp->nic.bnxt, qp->nic.mlx5, etc.
+   */
+  union {
+    struct pipes_gda_gpu_dev_verbs_qp_bnxt bnxt;
+    struct pipes_gda_gpu_dev_verbs_qp_mlx5 mlx5;
+    struct pipes_gda_gpu_dev_verbs_qp_ionic ionic;
+  } nic;
+} __attribute__((__aligned__(8)));
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PIPES_GDA_VERBS_DEV_H */
+
+/** @} */

--- a/comms/pipes/amd/verbs/VerbsOps.h
+++ b/comms/pipes/amd/verbs/VerbsOps.h
@@ -1,0 +1,609 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved. SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Modifications: (c) Meta Platforms, Inc. and affiliates.
+
+// =============================================================================
+// VerbsOps - GPU-initiated RDMA one-sided verbs operations for AMD/HIP
+// =============================================================================
+//
+// Provides template helper functions that wrap NIC backend calls into a
+// higher-level API for GPU-initiated RDMA operations (put, signal, fence).
+//
+// All functions are templated on NicBackend for compile-time NIC selection.
+// =============================================================================
+
+#pragma once
+
+#include <cerrno>
+#include <cstddef>
+#include <cstdint>
+
+#include "verbs/VerbsDev.h" // @manual
+
+namespace pipes_gda {
+
+// =============================================================================
+// Low-level WQE operations
+// =============================================================================
+
+template <typename NicBackend>
+__device__ __forceinline__ uint64_t pipes_gda_gpu_dev_verbs_reserve_wq_slots(
+    NicBackend& nic,
+    pipes_gda_gpu_dev_verbs_qp* qp,
+    uint32_t numSlots) {
+  return nic.reserveWqSlots(qp, numSlots);
+}
+
+template <typename NicBackend>
+__device__ __forceinline__ pipes_gda_gpu_dev_verbs_wqe*
+pipes_gda_gpu_dev_verbs_get_wqe_ptr(
+    NicBackend& nic,
+    pipes_gda_gpu_dev_verbs_qp* qp,
+    uint64_t wqeIdx) {
+  return nic.getWqePtr(qp, wqeIdx);
+}
+
+template <typename NicBackend>
+__device__ __forceinline__ void pipes_gda_gpu_dev_verbs_wqe_prepare_write(
+    NicBackend& nic,
+    pipes_gda_gpu_dev_verbs_qp* qp,
+    pipes_gda_gpu_dev_verbs_wqe* wqe,
+    uint64_t wqeIdx,
+    uint8_t ctrlFlags,
+    uint64_t remoteAddr,
+    uint32_t remoteKey,
+    uint64_t localAddr,
+    uint32_t localKey,
+    uint32_t size) {
+  nic.prepareRdmaWriteWqe(
+      qp,
+      wqe,
+      wqeIdx,
+      ctrlFlags,
+      remoteAddr,
+      remoteKey,
+      localAddr,
+      localKey,
+      size);
+}
+
+template <typename NicBackend>
+__device__ __forceinline__ void pipes_gda_gpu_dev_verbs_wqe_prepare_atomic(
+    NicBackend& nic,
+    pipes_gda_gpu_dev_verbs_qp* qp,
+    pipes_gda_gpu_dev_verbs_wqe* wqe,
+    uint64_t wqeIdx,
+    uint8_t ctrlFlags,
+    uint64_t remoteAddr,
+    uint32_t remoteKey,
+    uint64_t localAddr,
+    uint32_t localKey,
+    uint32_t size,
+    uint64_t addVal,
+    uint64_t compareVal) {
+  (void)size;
+  (void)compareVal;
+  nic.prepareAtomicFaWqe(
+      qp,
+      wqe,
+      wqeIdx,
+      ctrlFlags,
+      remoteAddr,
+      remoteKey,
+      localAddr,
+      localKey,
+      addVal);
+}
+
+template <typename NicBackend>
+__device__ __forceinline__ void pipes_gda_gpu_dev_verbs_wqe_prepare_nop(
+    NicBackend& nic,
+    pipes_gda_gpu_dev_verbs_qp* qp,
+    pipes_gda_gpu_dev_verbs_wqe* wqe,
+    uint64_t wqeIdx) {
+  nic.prepareNopWqe(qp, wqe, wqeIdx);
+}
+
+template <typename NicBackend>
+__device__ __forceinline__ void pipes_gda_gpu_dev_verbs_mark_wqes_ready(
+    NicBackend& nic,
+    pipes_gda_gpu_dev_verbs_qp* qp,
+    uint64_t firstIdx,
+    uint64_t lastIdx) {
+  nic.markWqesReady(qp, firstIdx, lastIdx);
+}
+
+template <typename NicBackend>
+__device__ __forceinline__ void pipes_gda_gpu_dev_verbs_submit(
+    NicBackend& nic,
+    pipes_gda_gpu_dev_verbs_qp* qp,
+    uint64_t nextWqeIdx) {
+  nic.ringDoorbell(qp, nextWqeIdx);
+}
+
+template <typename NicBackend>
+__device__ __forceinline__ void pipes_gda_gpu_dev_verbs_wait(
+    NicBackend& nic,
+    pipes_gda_gpu_dev_verbs_qp* qp,
+    uint64_t ticket) {
+  nic.pollCqAt(qp, &qp->cq_sq, ticket);
+}
+
+// =============================================================================
+// High-level composite operations
+// =============================================================================
+
+/**
+ * pipes_gda_gpu_dev_verbs_put - RDMA Write (handles multi-chunk transfers)
+ *
+ * Reserves WQE slots, prepares RDMA WRITE WQEs (splitting into chunks
+ * if size > MAX_TRANSFER_SIZE), marks ready, and submits.
+ */
+template <typename NicBackend>
+__device__ __forceinline__ void pipes_gda_gpu_dev_verbs_put(
+    NicBackend& nic,
+    pipes_gda_gpu_dev_verbs_qp* qp,
+    pipes_gda_gpu_dev_verbs_addr raddr,
+    pipes_gda_gpu_dev_verbs_addr laddr,
+    std::size_t size,
+    uint64_t* out_ticket) {
+  uint32_t numChunks = static_cast<uint32_t>(
+      (size + PIPES_GDA_VERBS_MAX_TRANSFER_SIZE - 1) >>
+      PIPES_GDA_VERBS_MAX_TRANSFER_SIZE_SHIFT);
+  if (numChunks == 0)
+    numChunks = 1;
+
+  uint64_t baseIdx =
+      pipes_gda_gpu_dev_verbs_reserve_wq_slots(nic, qp, numChunks);
+  std::size_t remaining = size;
+
+  for (uint32_t i = 0; i < numChunks; i++) {
+    uint64_t wqeIdx = baseIdx + i;
+    std::size_t chunkSize = remaining > PIPES_GDA_VERBS_MAX_TRANSFER_SIZE
+        ? PIPES_GDA_VERBS_MAX_TRANSFER_SIZE
+        : remaining;
+
+    auto* wqe = pipes_gda_gpu_dev_verbs_get_wqe_ptr(nic, qp, wqeIdx);
+    pipes_gda_gpu_dev_verbs_wqe_prepare_write(
+        nic,
+        qp,
+        wqe,
+        wqeIdx,
+        PIPES_GDA_IB_MLX5_WQE_CTRL_CQ_UPDATE,
+        raddr.addr + i * PIPES_GDA_VERBS_MAX_TRANSFER_SIZE,
+        raddr.key,
+        laddr.addr + i * PIPES_GDA_VERBS_MAX_TRANSFER_SIZE,
+        laddr.key,
+        static_cast<uint32_t>(chunkSize));
+    remaining -= chunkSize;
+  }
+
+  uint64_t lastIdx = baseIdx + numChunks - 1;
+  pipes_gda_gpu_dev_verbs_mark_wqes_ready(nic, qp, baseIdx, lastIdx);
+  pipes_gda_gpu_dev_verbs_submit(nic, qp, lastIdx + 1);
+
+  *out_ticket = lastIdx;
+}
+
+/**
+ * pipes_gda_gpu_dev_verbs_signal - Atomic fetch-add signal
+ *
+ * Posts an atomic fetch-add WQE to the remote signal buffer.
+ */
+template <typename NicBackend>
+__device__ __forceinline__ void pipes_gda_gpu_dev_verbs_signal(
+    NicBackend& nic,
+    pipes_gda_gpu_dev_verbs_qp* qp,
+    pipes_gda_gpu_dev_verbs_addr sig_raddr,
+    pipes_gda_gpu_dev_verbs_addr sig_laddr,
+    uint64_t sig_val,
+    uint64_t* out_ticket) {
+  uint64_t wqeIdx = pipes_gda_gpu_dev_verbs_reserve_wq_slots(nic, qp, 1);
+  auto* wqe = pipes_gda_gpu_dev_verbs_get_wqe_ptr(nic, qp, wqeIdx);
+
+  pipes_gda_gpu_dev_verbs_wqe_prepare_atomic(
+      nic,
+      qp,
+      wqe,
+      wqeIdx,
+      PIPES_GDA_IB_MLX5_WQE_CTRL_CQ_UPDATE,
+      sig_raddr.addr,
+      sig_raddr.key,
+      sig_laddr.addr,
+      sig_laddr.key,
+      sizeof(uint64_t),
+      sig_val,
+      0);
+
+  pipes_gda_gpu_dev_verbs_mark_wqes_ready(nic, qp, wqeIdx, wqeIdx);
+  pipes_gda_gpu_dev_verbs_submit(nic, qp, wqeIdx + 1);
+
+  *out_ticket = wqeIdx;
+}
+
+/**
+ * pipes_gda_gpu_dev_verbs_put_signal - RDMA Write + atomic signal
+ * (non-adaptive)
+ *
+ * Posts data WQEs followed by an atomic signal WQE without NIC fence.
+ */
+template <typename NicBackend>
+__device__ __forceinline__ void pipes_gda_gpu_dev_verbs_put_signal(
+    NicBackend& nic,
+    pipes_gda_gpu_dev_verbs_qp* qp,
+    pipes_gda_gpu_dev_verbs_addr raddr,
+    pipes_gda_gpu_dev_verbs_addr laddr,
+    std::size_t size,
+    pipes_gda_gpu_dev_verbs_addr sig_raddr,
+    pipes_gda_gpu_dev_verbs_addr sig_laddr,
+    uint64_t sig_val,
+    uint64_t* out_ticket) {
+  uint32_t numChunks = static_cast<uint32_t>(
+      (size + PIPES_GDA_VERBS_MAX_TRANSFER_SIZE - 1) >>
+      PIPES_GDA_VERBS_MAX_TRANSFER_SIZE_SHIFT);
+  if (numChunks == 0)
+    numChunks = 1;
+
+  uint64_t baseIdx =
+      pipes_gda_gpu_dev_verbs_reserve_wq_slots(nic, qp, numChunks + 1);
+  std::size_t remaining = size;
+
+  for (uint32_t i = 0; i < numChunks; i++) {
+    uint64_t wqeIdx = baseIdx + i;
+    std::size_t chunkSize = remaining > PIPES_GDA_VERBS_MAX_TRANSFER_SIZE
+        ? PIPES_GDA_VERBS_MAX_TRANSFER_SIZE
+        : remaining;
+
+    auto* wqe = pipes_gda_gpu_dev_verbs_get_wqe_ptr(nic, qp, wqeIdx);
+    pipes_gda_gpu_dev_verbs_wqe_prepare_write(
+        nic,
+        qp,
+        wqe,
+        wqeIdx,
+        PIPES_GDA_IB_MLX5_WQE_CTRL_CQ_UPDATE,
+        raddr.addr + i * PIPES_GDA_VERBS_MAX_TRANSFER_SIZE,
+        raddr.key,
+        laddr.addr + i * PIPES_GDA_VERBS_MAX_TRANSFER_SIZE,
+        laddr.key,
+        static_cast<uint32_t>(chunkSize));
+    remaining -= chunkSize;
+  }
+
+  uint64_t sigIdx = baseIdx + numChunks;
+  auto* sigWqe = pipes_gda_gpu_dev_verbs_get_wqe_ptr(nic, qp, sigIdx);
+  pipes_gda_gpu_dev_verbs_wqe_prepare_atomic(
+      nic,
+      qp,
+      sigWqe,
+      sigIdx,
+      PIPES_GDA_IB_MLX5_WQE_CTRL_CQ_UPDATE,
+      sig_raddr.addr,
+      sig_raddr.key,
+      sig_laddr.addr,
+      sig_laddr.key,
+      sizeof(uint64_t),
+      sig_val,
+      0);
+
+  pipes_gda_gpu_dev_verbs_mark_wqes_ready(nic, qp, baseIdx, sigIdx);
+  pipes_gda_gpu_dev_verbs_submit(nic, qp, sigIdx + 1);
+
+  *out_ticket = sigIdx;
+}
+
+// =============================================================================
+// Utility functions
+// =============================================================================
+
+/**
+ * pipes_gda_fence - Wait for all pending RDMA operations to complete
+ *
+ * Issues a NOP WQE and waits for it to complete. Since WQEs are processed
+ * in order, when the NOP completes, all prior WQEs have been processed.
+ */
+template <typename NicBackend>
+__device__ __forceinline__ void pipes_gda_fence(
+    NicBackend& nic,
+    pipes_gda_gpu_dev_verbs_qp* qp) {
+  uint64_t wqeIdx = pipes_gda_gpu_dev_verbs_reserve_wq_slots(nic, qp, 1);
+  auto* wqe = pipes_gda_gpu_dev_verbs_get_wqe_ptr(nic, qp, wqeIdx);
+
+  pipes_gda_gpu_dev_verbs_wqe_prepare_nop(nic, qp, wqe, wqeIdx);
+  pipes_gda_gpu_dev_verbs_mark_wqes_ready(nic, qp, wqeIdx, wqeIdx);
+  pipes_gda_gpu_dev_verbs_submit(nic, qp, wqeIdx + 1);
+  pipes_gda_gpu_dev_verbs_wait(nic, qp, wqeIdx);
+}
+
+/**
+ * pipes_gda_put_fenced - Fenced RDMA Write with completion
+ *
+ * Issues a fence, then performs an RDMA Write and waits for completion,
+ * then issues another fence.
+ */
+template <typename NicBackend>
+__device__ __forceinline__ void pipes_gda_put_fenced(
+    NicBackend& nic,
+    pipes_gda_gpu_dev_verbs_qp* qp,
+    pipes_gda_gpu_dev_verbs_addr raddr,
+    pipes_gda_gpu_dev_verbs_addr laddr,
+    std::size_t size) {
+  pipes_gda_fence(nic, qp);
+
+  uint64_t ticket;
+  pipes_gda_gpu_dev_verbs_put(nic, qp, raddr, laddr, size, &ticket);
+  pipes_gda_gpu_dev_verbs_wait(nic, qp, ticket);
+
+  pipes_gda_fence(nic, qp);
+}
+
+// =============================================================================
+// Additional primitives
+// =============================================================================
+
+/**
+ * pipes_gda_gpu_dev_verbs_p<T> - Inline RDMA write of a scalar value
+ *
+ * Writes a scalar value to a remote address using an inline RDMA Write WQE.
+ * No local memory region needed — data is embedded in the WQE.
+ * Used by reset_signal() to write zero to remote signal buffer.
+ */
+template <typename T, typename NicBackend>
+__device__ __forceinline__ void pipes_gda_gpu_dev_verbs_p(
+    NicBackend& nic,
+    pipes_gda_gpu_dev_verbs_qp* qp,
+    pipes_gda_gpu_dev_verbs_addr raddr,
+    T value,
+    uint64_t* out_ticket) {
+  uint64_t wqeIdx = pipes_gda_gpu_dev_verbs_reserve_wq_slots(nic, qp, 1);
+  auto* wqe = pipes_gda_gpu_dev_verbs_get_wqe_ptr(nic, qp, wqeIdx);
+
+  nic.prepareInlineWriteWqe(
+      qp,
+      wqe,
+      wqeIdx,
+      PIPES_GDA_IB_MLX5_WQE_CTRL_CQ_UPDATE,
+      raddr.addr,
+      raddr.key,
+      value);
+
+  pipes_gda_gpu_dev_verbs_mark_wqes_ready(nic, qp, wqeIdx, wqeIdx);
+  pipes_gda_gpu_dev_verbs_submit(nic, qp, wqeIdx + 1);
+
+  *out_ticket = wqeIdx;
+}
+
+/**
+ * pipes_gda_gpu_dev_verbs_poll_one_cq_at - Non-blocking CQ poll wrapper
+ *
+ * Returns EBUSY if not yet complete, 0 on success.
+ * Used by wait_local() with timeout.
+ */
+template <typename NicBackend>
+__device__ __forceinline__ int pipes_gda_gpu_dev_verbs_poll_one_cq_at(
+    NicBackend& nic,
+    pipes_gda_gpu_dev_verbs_cq* cq,
+    uint64_t consIndex) {
+  return nic.pollOneCqAt(cq, consIndex);
+}
+
+/**
+ * pipes_gda_gpu_dev_verbs_qp_get_cq_sq - Get pointer to QP's SQ CQ
+ */
+__device__ __forceinline__ pipes_gda_gpu_dev_verbs_cq*
+pipes_gda_gpu_dev_verbs_qp_get_cq_sq(pipes_gda_gpu_dev_verbs_qp* qp) {
+  return &qp->cq_sq;
+}
+
+/**
+ * pipes_gda_gpu_dev_verbs_put_signal_counter - Data write + remote signal +
+ * local counter via companion QP
+ *
+ * Compound operation:
+ * 1. Main QP: RDMA Write data
+ * 2. Main QP: Fenced atomic fetch-add to remote signal buffer
+ * 3. Companion QP: WAIT on main QP signal completion
+ * 4. Companion QP: Atomic fetch-add to local counter buffer
+ */
+template <typename NicBackend>
+__device__ __forceinline__ void pipes_gda_gpu_dev_verbs_put_signal_counter(
+    NicBackend& nic,
+    pipes_gda_gpu_dev_verbs_qp* mainQp,
+    pipes_gda_gpu_dev_verbs_addr raddr,
+    pipes_gda_gpu_dev_verbs_addr laddr,
+    std::size_t size,
+    pipes_gda_gpu_dev_verbs_addr sigRemoteAddr,
+    pipes_gda_gpu_dev_verbs_addr sigSinkAddr,
+    uint64_t sigVal,
+    pipes_gda_gpu_dev_verbs_qp* companionQp,
+    pipes_gda_gpu_dev_verbs_addr counterRemoteAddr,
+    pipes_gda_gpu_dev_verbs_addr counterSinkAddr,
+    uint64_t counterVal) {
+  uint32_t numChunks = static_cast<uint32_t>(
+      (size + PIPES_GDA_VERBS_MAX_TRANSFER_SIZE - 1) >>
+      PIPES_GDA_VERBS_MAX_TRANSFER_SIZE_SHIFT);
+  if (numChunks == 0)
+    numChunks = 1;
+
+  uint64_t mainBase =
+      pipes_gda_gpu_dev_verbs_reserve_wq_slots(nic, mainQp, numChunks + 1);
+  std::size_t remaining = size;
+
+  for (uint32_t i = 0; i < numChunks; i++) {
+    uint64_t wqeIdx = mainBase + i;
+    std::size_t chunkSize = remaining > PIPES_GDA_VERBS_MAX_TRANSFER_SIZE
+        ? PIPES_GDA_VERBS_MAX_TRANSFER_SIZE
+        : remaining;
+
+    auto* wqe = pipes_gda_gpu_dev_verbs_get_wqe_ptr(nic, mainQp, wqeIdx);
+    pipes_gda_gpu_dev_verbs_wqe_prepare_write(
+        nic,
+        mainQp,
+        wqe,
+        wqeIdx,
+        PIPES_GDA_IB_MLX5_WQE_CTRL_CQ_UPDATE,
+        raddr.addr + i * PIPES_GDA_VERBS_MAX_TRANSFER_SIZE,
+        raddr.key,
+        laddr.addr + i * PIPES_GDA_VERBS_MAX_TRANSFER_SIZE,
+        laddr.key,
+        static_cast<uint32_t>(chunkSize));
+    remaining -= chunkSize;
+  }
+
+  uint64_t sigIdx = mainBase + numChunks;
+  auto* sigWqe = pipes_gda_gpu_dev_verbs_get_wqe_ptr(nic, mainQp, sigIdx);
+  pipes_gda_gpu_dev_verbs_wqe_prepare_atomic(
+      nic,
+      mainQp,
+      sigWqe,
+      sigIdx,
+      static_cast<uint8_t>(
+          PIPES_GDA_IB_MLX5_WQE_CTRL_CQ_UPDATE |
+          PIPES_GDA_IB_MLX5_WQE_CTRL_FENCE),
+      sigRemoteAddr.addr,
+      sigRemoteAddr.key,
+      sigSinkAddr.addr,
+      sigSinkAddr.key,
+      sizeof(uint64_t),
+      sigVal,
+      0);
+
+  pipes_gda_gpu_dev_verbs_mark_wqes_ready(nic, mainQp, mainBase, sigIdx);
+  pipes_gda_gpu_dev_verbs_submit(nic, mainQp, sigIdx + 1);
+
+  // Companion QP: WAIT + counter atomic
+  uint64_t compBase =
+      pipes_gda_gpu_dev_verbs_reserve_wq_slots(nic, companionQp, 2);
+
+  uint64_t waitIdx = compBase;
+  auto* waitWqe =
+      pipes_gda_gpu_dev_verbs_get_wqe_ptr(nic, companionQp, waitIdx);
+  nic.prepareWaitWqe(
+      companionQp,
+      waitWqe,
+      waitIdx,
+      PIPES_GDA_IB_MLX5_WQE_CTRL_CQ_UPDATE,
+      mainQp->cq_sq.cq_num,
+      sigIdx);
+
+  uint64_t cntIdx = compBase + 1;
+  auto* cntWqe = pipes_gda_gpu_dev_verbs_get_wqe_ptr(nic, companionQp, cntIdx);
+  pipes_gda_gpu_dev_verbs_wqe_prepare_atomic(
+      nic,
+      companionQp,
+      cntWqe,
+      cntIdx,
+      PIPES_GDA_IB_MLX5_WQE_CTRL_CQ_UPDATE,
+      counterRemoteAddr.addr,
+      counterRemoteAddr.key,
+      counterSinkAddr.addr,
+      counterSinkAddr.key,
+      sizeof(uint64_t),
+      counterVal,
+      0);
+
+  pipes_gda_gpu_dev_verbs_mark_wqes_ready(nic, companionQp, compBase, cntIdx);
+  pipes_gda_gpu_dev_verbs_submit(nic, companionQp, cntIdx + 1);
+}
+
+/**
+ * pipes_gda_gpu_dev_verbs_signal_counter - Remote signal + local counter
+ * (no data write)
+ *
+ * Same as put_signal_counter but without the data write.
+ */
+template <typename NicBackend>
+__device__ __forceinline__ void pipes_gda_gpu_dev_verbs_signal_counter(
+    NicBackend& nic,
+    pipes_gda_gpu_dev_verbs_qp* mainQp,
+    pipes_gda_gpu_dev_verbs_addr sigRemoteAddr,
+    pipes_gda_gpu_dev_verbs_addr sigSinkAddr,
+    uint64_t sigVal,
+    pipes_gda_gpu_dev_verbs_qp* companionQp,
+    pipes_gda_gpu_dev_verbs_addr counterRemoteAddr,
+    pipes_gda_gpu_dev_verbs_addr counterSinkAddr,
+    uint64_t counterVal) {
+  // Main QP: signal atomic
+  uint64_t sigIdx = pipes_gda_gpu_dev_verbs_reserve_wq_slots(nic, mainQp, 1);
+  auto* sigWqe = pipes_gda_gpu_dev_verbs_get_wqe_ptr(nic, mainQp, sigIdx);
+  pipes_gda_gpu_dev_verbs_wqe_prepare_atomic(
+      nic,
+      mainQp,
+      sigWqe,
+      sigIdx,
+      PIPES_GDA_IB_MLX5_WQE_CTRL_CQ_UPDATE,
+      sigRemoteAddr.addr,
+      sigRemoteAddr.key,
+      sigSinkAddr.addr,
+      sigSinkAddr.key,
+      sizeof(uint64_t),
+      sigVal,
+      0);
+
+  pipes_gda_gpu_dev_verbs_mark_wqes_ready(nic, mainQp, sigIdx, sigIdx);
+  pipes_gda_gpu_dev_verbs_submit(nic, mainQp, sigIdx + 1);
+
+  // Companion QP: WAIT + counter atomic
+  uint64_t compBase =
+      pipes_gda_gpu_dev_verbs_reserve_wq_slots(nic, companionQp, 2);
+
+  uint64_t waitIdx = compBase;
+  auto* waitWqe =
+      pipes_gda_gpu_dev_verbs_get_wqe_ptr(nic, companionQp, waitIdx);
+  nic.prepareWaitWqe(
+      companionQp,
+      waitWqe,
+      waitIdx,
+      PIPES_GDA_IB_MLX5_WQE_CTRL_CQ_UPDATE,
+      mainQp->cq_sq.cq_num,
+      sigIdx);
+
+  uint64_t cntIdx = compBase + 1;
+  auto* cntWqe = pipes_gda_gpu_dev_verbs_get_wqe_ptr(nic, companionQp, cntIdx);
+  pipes_gda_gpu_dev_verbs_wqe_prepare_atomic(
+      nic,
+      companionQp,
+      cntWqe,
+      cntIdx,
+      PIPES_GDA_IB_MLX5_WQE_CTRL_CQ_UPDATE,
+      counterRemoteAddr.addr,
+      counterRemoteAddr.key,
+      counterSinkAddr.addr,
+      counterSinkAddr.key,
+      sizeof(uint64_t),
+      counterVal,
+      0);
+
+  pipes_gda_gpu_dev_verbs_mark_wqes_ready(nic, companionQp, compBase, cntIdx);
+  pipes_gda_gpu_dev_verbs_submit(nic, companionQp, cntIdx + 1);
+}
+
+} // namespace pipes_gda

--- a/comms/pipes/amd/verbs/VerbsUtils.h
+++ b/comms/pipes/amd/verbs/VerbsUtils.h
@@ -1,0 +1,271 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <climits>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <string>
+
+#include <fmt/format.h>
+#include <folly/logging/xlog.h>
+
+#include <infiniband/verbs.h>
+
+#include "nic/NicSelector.h" // @manual
+
+namespace pipes_gda::tests {
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+constexpr uint16_t kDefaultQueueSize = 2048;
+constexpr uint8_t kDefaultHopLimit = 255;
+constexpr uint8_t kDefaultPortNum = 1;
+
+// GID index: use 3 for standard mlx5, 1 for FE NIC
+#if defined(USE_FE_NIC)
+constexpr int kDefaultGidIndex = 1;
+#else
+constexpr int kDefaultGidIndex = 3;
+#endif
+
+// =============================================================================
+// IB Device Utilities
+// =============================================================================
+
+/**
+ * Read a sysfs file and return its content as a string.
+ */
+inline std::string readSysfs(const std::string& path) {
+  FILE* f = fopen(path.c_str(), "r");
+  if (!f) {
+    return "";
+  }
+  char buf[256] = {};
+  size_t n = fread(buf, 1, sizeof(buf) - 1, f);
+  fclose(f);
+  // Trim trailing newline
+  while (n > 0 && (buf[n - 1] == '\n' || buf[n - 1] == '\r')) {
+    buf[--n] = '\0';
+  }
+  return std::string(buf);
+}
+
+/**
+ * Get the NUMA node for a PCIe device.
+ * @param pciAddr PCIe address in format "0000:1B:00.0" or "1B:00.0"
+ * @return NUMA node ID, or -1 if not found
+ */
+inline int getNumaNode(const std::string& pciAddr) {
+  // Normalize address to include domain if missing
+  std::string addr = pciAddr;
+  if (addr.length() < 12) { // "0000:XX:XX.X" is 12 chars
+    addr = "0000:" + addr;
+  }
+  // Convert to lowercase for consistency
+  for (char& c : addr) {
+    c = static_cast<char>(tolower(static_cast<unsigned char>(c)));
+  }
+
+  std::string path = "/sys/bus/pci/devices/" + addr + "/numa_node";
+  std::string content = readSysfs(path);
+  if (content.empty()) {
+    return -1;
+  }
+  return std::stoi(content);
+}
+
+/**
+ * Get the PCIe address for an InfiniBand device.
+ * @param ibDevName IB device name (e.g., "mlx5_0")
+ * @return PCIe address or empty string if not found
+ */
+inline std::string getIbDevicePciAddr(const std::string& ibDevName) {
+  std::string symlinkPath = "/sys/class/infiniband/" + ibDevName + "/device";
+  char resolvedPath[PATH_MAX] = {};
+  if (realpath(symlinkPath.c_str(), resolvedPath) == nullptr) {
+    return "";
+  }
+  // resolvedPath is like "/sys/devices/pci0000:00/.../0000:1b:00.0"
+  // Extract the last component which is the PCIe address
+  std::string path(resolvedPath);
+  size_t lastSlash = path.rfind('/');
+  if (lastSlash == std::string::npos) {
+    return "";
+  }
+  return path.substr(lastSlash + 1);
+}
+
+/**
+ * Parse PCIe address and extract bus number.
+ * @param pciAddr PCIe address in format "0000:1B:00.0" or "1B:00.0"
+ * @return Bus number (0-255), or -1 on parse error
+ */
+inline int parsePciBus(const std::string& pciAddr) {
+  // Format: [domain:]bus:device.function
+  // Examples: "0000:1B:00.0" or "1B:00.0"
+  size_t colonPos = pciAddr.find(':');
+  if (colonPos == std::string::npos) {
+    return -1;
+  }
+
+  std::string busStr;
+  size_t secondColon = pciAddr.find(':', colonPos + 1);
+  if (secondColon != std::string::npos) {
+    // Has domain: "0000:1B:00.0"
+    busStr = pciAddr.substr(colonPos + 1, secondColon - colonPos - 1);
+  } else {
+    // No domain: "1B:00.0"
+    busStr = pciAddr.substr(0, colonPos);
+  }
+
+  try {
+    return std::stoi(busStr, nullptr, 16);
+  } catch (...) {
+    return -1;
+  }
+}
+
+/**
+ * Find the closest NIC to a GPU based on PCIe topology.
+ *
+ * Selection criteria (in order of priority):
+ * 1. Same NUMA node as the GPU
+ * 2. Closest PCIe bus number (proxy for physical proximity)
+ *
+ * @param gpuPciAddr GPU's PCIe address (e.g., "0000:1B:00.0")
+ * @return Best NIC device name, or empty string if none found
+ */
+inline std::string findClosestNic(const std::string& gpuPciAddr) {
+  int numDevs = 0;
+  struct ibv_device** devList = ibv_get_device_list(&numDevs);
+  if (!devList || numDevs == 0) {
+    return "";
+  }
+
+  const char* vendorPrefix = pipes_gda::ActiveNicBackend::vendorPrefix();
+  int gpuNuma = getNumaNode(gpuPciAddr);
+  int gpuBus = parsePciBus(gpuPciAddr);
+
+  std::string bestNic;
+  int bestScore = INT_MIN; // Higher is better
+
+  for (int i = 0; i < numDevs; i++) {
+    const char* devName = ibv_get_device_name(devList[i]);
+    if (strncmp(devName, vendorPrefix, strlen(vendorPrefix)) != 0) {
+      continue;
+    }
+
+    std::string nicPciAddr = getIbDevicePciAddr(devName);
+    if (nicPciAddr.empty()) {
+      continue;
+    }
+
+    int nicNuma = getNumaNode(nicPciAddr);
+    int nicBus = parsePciBus(nicPciAddr);
+
+    // Score: NUMA match is worth 1000 points, bus proximity adds 0-255 points
+    int score = 0;
+    if (gpuNuma >= 0 && nicNuma >= 0 && gpuNuma == nicNuma) {
+      score += 1000; // NUMA match is most important
+    }
+    if (gpuBus >= 0 && nicBus >= 0) {
+      // Closer bus numbers suggest closer physical proximity
+      // Max bus difference is 255, so invert to make closer = higher score
+      score += 255 - std::abs(gpuBus - nicBus);
+    }
+
+    XLOGF(
+        DBG,
+        "NIC {} (pci={}, numa={}, bus={}) score={} for GPU (pci={}, numa={}, bus={})",
+        devName,
+        nicPciAddr,
+        nicNuma,
+        nicBus,
+        score,
+        gpuPciAddr,
+        gpuNuma,
+        gpuBus);
+
+    if (score > bestScore) {
+      bestScore = score;
+      bestNic = devName;
+    }
+  }
+
+  ibv_free_device_list(devList);
+
+  if (!bestNic.empty()) {
+    XLOGF(
+        INFO,
+        "Selected NIC {} for GPU {} (score={})",
+        bestNic,
+        gpuPciAddr,
+        bestScore);
+  }
+
+  return bestNic;
+}
+
+/**
+ * Open an IB device by name.
+ * @param name Device name (e.g., "mlx5_0")
+ * @return IB context or nullptr on failure
+ */
+inline struct ibv_context* openIbDevice(const std::string& name) {
+  int numDevs = 0;
+  struct ibv_device** devList = ibv_get_device_list(&numDevs);
+  if (!devList || numDevs == 0) {
+    return nullptr;
+  }
+
+  struct ibv_context* ctx = nullptr;
+  for (int i = 0; i < numDevs; i++) {
+    if (name == ibv_get_device_name(devList[i])) {
+      ctx = ibv_open_device(devList[i]);
+      break;
+    }
+  }
+  ibv_free_device_list(devList);
+  return ctx;
+}
+
+/**
+ * Find the first device matching the selected NIC vendor.
+ * @return Device name or empty string if not found
+ */
+inline std::string findFirstNicDevice() {
+  int numDevs = 0;
+  struct ibv_device** devList = ibv_get_device_list(&numDevs);
+  if (!devList || numDevs == 0) {
+    return "";
+  }
+
+  const char* vendorPrefix = pipes_gda::ActiveNicBackend::vendorPrefix();
+  std::string name;
+  for (int i = 0; i < numDevs; i++) {
+    const char* devName = ibv_get_device_name(devList[i]);
+    if (strncmp(devName, vendorPrefix, strlen(vendorPrefix)) == 0) {
+      name = devName;
+      break;
+    }
+  }
+  ibv_free_device_list(devList);
+  return name;
+}
+
+// Backward-compatible alias for mlx5 builds
+inline std::string findFirstMlx5Device() {
+  return findFirstNicDevice();
+}
+
+// Swap bytes for GPU mkey (required by PIPES_GDA_VERBS_MKEY_SWAPPED).
+// Delegates to the active NIC backend.
+inline uint32_t swapMkey(uint32_t key) {
+  return pipes_gda::ActiveNicBackend::swapMkey(key);
+}
+
+} // namespace pipes_gda::tests

--- a/comms/pipes/collectives/AllToAllv.cuh
+++ b/comms/pipes/collectives/AllToAllv.cuh
@@ -112,7 +112,7 @@ __device__ __forceinline__ void all_to_allv(
     Timeout timeout
     // all arguments below will eventually come from communicator
 ) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   auto group = make_warp_group();
   const auto nranks = transports_per_rank.size();
   PIPES_DEVICE_CHECK(nranks == send_chunk_infos.size());


### PR DESCRIPTION
Summary:

Open-source AMD GPU-initiated RDMA verbs implementation — equivalent of
NVIDIA's DOCA GPUNetIO. Lets GPU kernels construct and submit InfiniBand
WQEs directly, bypassing the CPU.

**`amd/nic/`** — NIC backend layer:
- `Mlx5Hsi.h`: ConnectX wire format (WQE segments: data/control/raddr/
  atomic/inline; CQE64; opcodes; control flags).
- `Mlx5NicBackend.h`: device-side WQE construction, doorbell ring
  (64-bit system-scope MMIO store to BlueFlame UAR), CQ poll
  (ownership bit + wraparound), `htobe32` byte-order helper. All hot-
  path methods `__device__ __forceinline__`.
- `NicConfig.h`: compile-time validation that exactly one of
  `NIC_MLX5` / `NIC_BNXT` / `NIC_IONIC` is defined (default `NIC_MLX5`).
- `NicSelector.h`: `using ActiveNicBackend = Mlx5NicBackend;` —
  adding a NIC = one backend header + one line here.

**`amd/verbs/`** — NIC-agnostic verbs layer:
- `VerbsDef.h`: shared constants (page size, masks, max inline,
  max transfer).
- `VerbsDev.h`: GPU-accessible QP/CQ structs.
- `VerbsOps.h`: templated RDMA primitives —
  `reserve_wq_slots` / `wqe_prepare_*` / `mark_wqes_ready` / `submit` /
  `wait` / composite `put`/`signal`/`fence`/`put_signal_counter`.
- `VerbsUtils.h`: host-side `findClosestNic()` (NUMA-aware sysfs
  enumeration).
- `AmdVerbsCompat.h`: AMD GPU intrinsic mappings — system-scope atomic
  loads/stores/fences, BlueFlame doorbell store, scoped fetch-add for
  WQE PI reservation, non-temporal load.

**`PipesGdaShared.h`** — namespace bridge re-exporting `comms::pipes`
types into `pipes_gda` plus AMD-specific helpers
(`make_wavefront_group()`, `make_timeout_us()` at 100 MHz wall_clock,
`kWavefrontSize`).

**BUCK:** two header-only `comms_gpu_cpp_library` targets — `pipes_gda`
(full deps) and `pipes_gda_device` (no MPI). Both compiled with
`-DNIC_MLX5`.

Reviewed By: dmwu

Differential Revision: D98509715


