### PR TITLE
Add AMD IBGDA transport tests (#2192)

### DIFF
--- a/comms/common/DeviceConstants.cuh
+++ b/comms/common/DeviceConstants.cuh
@@ -7,7 +7,13 @@
 namespace comms::device {
 
 // Statically define the warp size (unlike warpSize, this can be used in
-// constexpr expressions)
-constexpr uint32_t kWarpSize = 32;
+// constexpr expressions).
+// Note: Uses __HIP_PLATFORM_AMD__ (not __HIP_DEVICE_COMPILE__) because this
+// constant is needed in both host and device code (e.g., buffer allocation).
+#if defined(__HIP_PLATFORM_AMD__)
+constexpr uint32_t kWarpSize = 64; // AMD wavefront size
+#else
+constexpr uint32_t kWarpSize = 32; // NVIDIA warp size
+#endif
 
 } // namespace comms::device

--- a/comms/pipes/CopyUtils.cuh
+++ b/comms/pipes/CopyUtils.cuh
@@ -3,11 +3,56 @@
 #pragma once
 
 #include <cuda_runtime.h>
+
 #include <cstddef>
+#include "comms/pipes/HipCompat.cuh"
 
 #include "comms/pipes/ThreadGroup.cuh"
 
 namespace comms::pipes {
+
+// =============================================================================
+// AMD system-coherent store for P2P writes over XGMI
+// =============================================================================
+// On AMD GPUs, regular stores to remote GPU memory go through L1/L2 cache
+// and may not be visible to the remote GPU until a cache flush. For P2P
+// transfers, we need system-coherent stores that bypass/flush caches.
+#if defined(__HIP_DEVICE_COMPILE__) && !defined(__CUDA_ARCH__)
+
+/**
+ * Requires: dst and src must be 8-byte aligned (guaranteed when called via
+ * uint4* from memcpy_vectorized_aligned_sys). Misaligned pointers cause
+ * undefined behavior on AMD flat_store_dwordx2.
+ */
+__device__ __forceinline__ void store_sys_u128(uint4* dst, const uint4* src) {
+  // Note: 128-bit store is split into two 64-bit stores. Atomicity is not
+  // required — callers synchronize the full transfer via signal/barrier
+  // primitives before the consumer reads.
+#if defined(__gfx942__) || defined(__gfx950__)
+  // 16-byte system-coherent store via 2x dwordx2 with sc0 sc1
+  const uint64_t* s = reinterpret_cast<const uint64_t*>(src);
+  uint64_t* d = reinterpret_cast<uint64_t*>(dst);
+  uint64_t v0 = s[0];
+  uint64_t v1 = s[1];
+  asm volatile("flat_store_dwordx2 %0, %1 sc0 sc1" : : "v"(d), "v"(v0));
+  asm volatile("flat_store_dwordx2 %0, %1 sc0 sc1" : : "v"(d + 1), "v"(v1));
+#elif defined(__gfx90a__)
+  const uint64_t* s = reinterpret_cast<const uint64_t*>(src);
+  uint64_t* d = reinterpret_cast<uint64_t*>(dst);
+  uint64_t v0 = s[0];
+  uint64_t v1 = s[1];
+  asm volatile("flat_store_dwordx2 %0, %1 glc slc" : : "v"(d), "v"(v0));
+  asm volatile("flat_store_dwordx2 %0, %1 glc slc" : : "v"(d + 1), "v"(v1));
+#else
+  // Unsupported AMD architecture — plain store lacks system coherence and
+  // would silently break P2P correctness. Fail at compile time so new
+  // architectures get an explicit implementation.
+#error \
+    "store_sys_u128: no system-coherent store implementation for this AMD GPU architecture"
+#endif
+}
+
+#endif // __HIP_DEVICE_COMPILE__
 
 /**
  * memcpy_vectorized_aligned - High-performance vectorized memory copy
@@ -50,7 +95,7 @@ __device__ __forceinline__ void memcpy_vectorized_aligned(
     const VecType* src_p,
     std::size_t nelems,
     const ThreadGroup& group) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   // Loop stride: group_size threads × kUnroll elements each
   const std::size_t kLoopStride = group.group_size * kUnroll;
   const std::size_t numVecsAligned = (nelems / kLoopStride) * kLoopStride;
@@ -77,8 +122,43 @@ __device__ __forceinline__ void memcpy_vectorized_aligned(
        i += group.group_size) {
     dst[i] = src[i];
   }
-#endif // __CUDA_ARCH__
+#endif // defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 }
+
+// AMD-optimized uint4 copy with system-coherent stores for P2P over XGMI.
+// NVIDIA NVLink provides hardware cache coherence for P2P writes, so the
+// standard memcpy_vectorized_aligned() is sufficient. AMD XGMI does not
+// guarantee coherence — remote stores may remain in local L1/L2 caches —
+// so this variant uses explicit cache-bypassing stores (sc0 sc1 / glc slc).
+#if defined(__HIP_DEVICE_COMPILE__) && !defined(__CUDA_ARCH__)
+template <int kUnroll = 8>
+__device__ __forceinline__ void memcpy_vectorized_aligned_sys(
+    uint4* dst,
+    const uint4* src,
+    std::size_t nelems,
+    const ThreadGroup& group) {
+  const std::size_t kLoopStride = group.group_size * kUnroll;
+  const std::size_t numVecsAligned = (nelems / kLoopStride) * kLoopStride;
+
+  for (std::size_t i = group.thread_id_in_group; i < numVecsAligned;
+       i += kLoopStride) {
+    uint4 v[kUnroll];
+#pragma unroll
+    for (int j = 0; j < kUnroll; ++j) {
+      v[j] = src[i + j * group.group_size];
+    }
+#pragma unroll
+    for (int j = 0; j < kUnroll; ++j) {
+      store_sys_u128(&dst[i + j * group.group_size], &v[j]);
+    }
+  }
+
+  for (std::size_t i = numVecsAligned + group.thread_id_in_group; i < nelems;
+       i += group.group_size) {
+    store_sys_u128(&dst[i], &src[i]);
+  }
+}
+#endif
 
 template <int kUnroll = 8>
 __device__ __forceinline__ void memcpy_vectorized(
@@ -86,7 +166,7 @@ __device__ __forceinline__ void memcpy_vectorized(
     const char* src,
     std::size_t len,
     const ThreadGroup& group) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   constexpr std::size_t kAlignment = sizeof(uint4);
   if ((uintptr_t)dst % kAlignment == 0 && (uintptr_t)src % kAlignment == 0) {
     const std::size_t nelems = len / kAlignment;
@@ -102,7 +182,7 @@ __device__ __forceinline__ void memcpy_vectorized(
   }
 
   memcpy_vectorized_aligned<char, kUnroll>(dst, src, len, group);
-#endif // __CUDA_ARCH__
+#endif // defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 }
 
 /**
@@ -121,15 +201,16 @@ __device__ __forceinline__ void memcpy_vectorized(
  * @param src_d Source buffer pointer
  * @param nbytes Size of both buffers in bytes
  *
- * Note: Only active on device (__CUDA_ARCH__). No-op on host.
+ * Note: Only active on device (__CUDA_ARCH__ / __HIP_DEVICE_COMPILE__). No-op
+ * on host.
  */
 __device__ __forceinline__ void
 assert_buffer_non_overlap(char* dst_d, const char* src_d, std::size_t nbytes) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   if (!(src_d + nbytes <= dst_d || dst_d + nbytes <= src_d)) {
     __trap(); // Abort kernel if buffers overlap
   }
-#endif // __CUDA_ARCH__
+#endif // defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 }
 
 } // namespace comms::pipes

--- a/comms/pipes/DeviceCheck.cuh
+++ b/comms/pipes/DeviceCheck.cuh
@@ -4,6 +4,8 @@
 
 #include <cstdio>
 
+#include "comms/pipes/HipCompat.cuh"
+
 namespace comms::pipes {
 
 /**
@@ -23,7 +25,7 @@ namespace comms::pipes {
  * Note: __trap() puts the CUDA device into an unrecoverable error state. After
  * a trap, cudaDeviceReset() is required to recover the device context.
  */
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 #define PIPES_DEVICE_CHECK(expr)                                    \
   do {                                                              \
     if (!(expr)) {                                                  \
@@ -55,7 +57,7 @@ namespace comms::pipes {
  * Usage:
  *   PIPES_DEVICE_CHECK_MSG(idx < size, "Index out of bounds");
  */
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 #define PIPES_DEVICE_CHECK_MSG(expr, msg)                                \
   do {                                                                   \
     if (!(expr)) {                                                       \

--- a/comms/pipes/DeviceSpan.cuh
+++ b/comms/pipes/DeviceSpan.cuh
@@ -9,10 +9,12 @@
 #include <cassert>
 #include <cstdint>
 
+#include "comms/pipes/HipCompat.cuh"
+
 namespace comms::pipes {
 
 // Device-side bounds check helper
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 #define DEVICE_SPAN_CHECK_LT(val, bound)                          \
   do {                                                            \
     if (!((val) < (bound))) {                                     \

--- a/comms/pipes/HipCompat.cuh
+++ b/comms/pipes/HipCompat.cuh
@@ -1,0 +1,9 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+// On HIP, __trap() is not available; use abort() instead.
+// Include this header in any device code that calls __trap().
+#if defined(__HIP_DEVICE_COMPILE__) && !defined(__CUDA_ARCH__)
+#define __trap() abort()
+#endif

--- a/comms/pipes/IbgdaBuffer.h
+++ b/comms/pipes/IbgdaBuffer.h
@@ -7,14 +7,26 @@
 
 #include <endian.h>
 
-// Allow compilation in both host (C++) and device (CUDA) contexts
-#ifdef __CUDACC__
+// Allow compilation in both host (C++) and device (CUDA/HIP) contexts
+#if defined(__CUDACC__) || defined(__HIPCC__)
 #define IBGDA_HOST_DEVICE __host__ __device__
 #else
 #define IBGDA_HOST_DEVICE
 #endif
 
 namespace comms::pipes {
+
+// NIC-aware byte order conversion for RDMA memory keys.
+// mlx5 requires big-endian keys; bnxt/ionic use native byte order.
+namespace detail {
+inline uint32_t ibgdaNetworkByteOrderKey(uint32_t hostValue) {
+#if defined(NIC_BNXT) || defined(NIC_IONIC)
+  return hostValue; // Native byte order for non-mlx5 NICs
+#else
+  return htobe32(hostValue); // mlx5: big-endian
+#endif
+}
+} // namespace detail
 
 // =============================================================================
 // Strong Types for RDMA Memory Keys
@@ -63,10 +75,10 @@ struct NetworkLKey {
   NetworkLKey() = default;
   IBGDA_HOST_DEVICE explicit NetworkLKey(uint32_t v) : value(v) {}
 
-  // Implicit conversion from HostLKey (performs htobe32)
+  // Implicit conversion from HostLKey (performs byte order conversion)
   // NOLINTNEXTLINE(google-explicit-constructor)
   /* implicit */ NetworkLKey(HostLKey hostKey)
-      : value(htobe32(hostKey.value)) {}
+      : value(detail::ibgdaNetworkByteOrderKey(hostKey.value)) {}
 
   IBGDA_HOST_DEVICE bool operator==(const NetworkLKey& other) const {
     return value == other.value;
@@ -110,14 +122,14 @@ struct NetworkRKey {
   NetworkRKey() = default;
   IBGDA_HOST_DEVICE explicit NetworkRKey(uint32_t v) : value(v) {}
 
-  // Implicit conversion from HostRKey (performs htobe32)
+  // Implicit conversion from HostRKey (performs byte order conversion)
   // Note: This constructor is intentionally NOT explicit - implicit conversion
   // is the desired behavior. It is also intentionally host-only (no
-  // IBGDA_HOST_DEVICE) because htobe32() is not available on GPU. The
-  // conversion happens on the host before passing to device code.
+  // IBGDA_HOST_DEVICE) because the conversion happens on the host before
+  // passing to device code.
   // NOLINTNEXTLINE(google-explicit-constructor)
   /* implicit */ NetworkRKey(HostRKey hostKey)
-      : value(htobe32(hostKey.value)) {}
+      : value(detail::ibgdaNetworkByteOrderKey(hostKey.value)) {}
 
   IBGDA_HOST_DEVICE bool operator==(const NetworkRKey& other) const {
     return value == other.value;

--- a/comms/pipes/MultiPeerTransport.cc
+++ b/comms/pipes/MultiPeerTransport.cc
@@ -725,6 +725,11 @@ void MultiPeerTransport::build_device_handle() {
         new (&transportsHost[r]) Transport(devPtr);
         break;
       }
+
+      case TransportType::P2P_IBGDA_AMD:
+        throw std::runtime_error(
+            "P2P_IBGDA_AMD transport not supported in MultiPeerTransport "
+            "(use MultipeerIbgdaTransportAmd instead)");
     }
   }
 

--- a/comms/pipes/P2pIbgdaTransportDeviceAmd.h
+++ b/comms/pipes/P2pIbgdaTransportDeviceAmd.h
@@ -1,0 +1,502 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// =============================================================================
+// AMD GPU (HIP/ROCm) P2pIbgdaTransportDevice
+// =============================================================================
+//
+// AMD/HIP port of comms::pipes::P2pIbgdaTransportDevice.
+//
+// Provides the same device-side per-peer RDMA transport API as the NVIDIA
+// version, but uses AMD GCN/CDNA intrinsics and direct WQE construction
+// instead of DOCA GPUNetIO high-level APIs.
+//
+// TEMPLATE ARCHITECTURE:
+// P2pIbgdaTransportDeviceImpl<NicBackend> is parameterized on a NIC backend
+// that provides all NIC-specific WQE format, doorbell, and CQ polling logic.
+// See nic/Mlx5NicBackend.h, nic/BnxtNicBackend.h, nic/IonicNicBackend.h.
+//
+// nic/NicSelector.h provides the compile-time type alias:
+//   using P2pIbgdaTransportDevice =
+//   P2pIbgdaTransportDeviceImpl<ActiveNicBackend>;
+//
+// IMPLEMENTATION STYLE:
+// Methods use pipes_gda_gpu_dev_verbs_* helper functions from verbs/VerbsOps.h
+// (equivalent to DOCA GPUNetIO doca_gpu_dev_verbs_* APIs) so that the code
+// reads similarly to comms::pipes::P2pIbgdaTransportDevice.
+//
+// The public API is identical to comms::pipes::P2pIbgdaTransportDevice.
+// =============================================================================
+
+#pragma once
+
+#include <cerrno>
+#include <cstddef>
+#include <cstdint>
+
+#include <hip/hip_runtime.h>
+
+#include "PipesGdaShared.h" // @manual
+#include "nic/NicSelector.h" // @manual
+#include "verbs/VerbsDev.h" // @manual
+#include "verbs/VerbsOps.h" // @manual
+
+namespace pipes_gda {
+
+// Default timeout for internal synchronous waits (e.g., reset_signal).
+// 10 billion cycles ≈ 5-7 seconds on typical GPU clocks (~1.5-1.8 GHz).
+inline constexpr uint64_t kDefaultDeviceTimeoutCycles = 10'000'000'000ULL;
+
+// =============================================================================
+// IbgdaWork - Operation handle for tracking RDMA completion
+// =============================================================================
+
+struct IbgdaWork {
+  uint64_t value{0};
+
+  IbgdaWork() = default;
+
+  __device__ explicit IbgdaWork(uint64_t ticket) : value(ticket) {}
+};
+
+// =============================================================================
+// P2pIbgdaTransportDeviceImpl - Device-side per-peer RDMA transport handle
+// =============================================================================
+
+template <typename NicBackend>
+class P2pIbgdaTransportDeviceImpl {
+ public:
+  P2pIbgdaTransportDeviceImpl() = default;
+
+  __host__ __device__ P2pIbgdaTransportDeviceImpl(
+      pipes_gda_gpu_dev_verbs_qp* qp,
+      pipes_gda_gpu_dev_verbs_qp* companionQp = nullptr,
+      NetworkLKey sinkLkey = NetworkLKey{},
+      void* sinkBufPtr = nullptr)
+      : qp_(qp),
+        companionQp_(companionQp),
+        sinkLkey_(sinkLkey),
+        sinkBufPtr_(sinkBufPtr) {}
+
+  // ===========================================================================
+  // put - RDMA Write without signal (non-blocking)
+  // ===========================================================================
+  __device__ IbgdaWork
+  put(const IbgdaLocalBuffer& localBuf,
+      const IbgdaRemoteBuffer& remoteBuf,
+      std::size_t nbytes) {
+    uint64_t ticket;
+
+    pipes_gda_gpu_dev_verbs_addr localAddr = {
+        .addr = reinterpret_cast<uint64_t>(localBuf.ptr),
+        .key = localBuf.lkey.value};
+    pipes_gda_gpu_dev_verbs_addr remoteAddr = {
+        .addr = reinterpret_cast<uint64_t>(remoteBuf.ptr),
+        .key = remoteBuf.rkey.value};
+
+    pipes_gda_gpu_dev_verbs_put(
+        nic_, qp_, remoteAddr, localAddr, nbytes, &ticket);
+
+    return IbgdaWork(ticket);
+  }
+
+  // ===========================================================================
+  // put_group_local - Group-collaborative RDMA Write (group-local data)
+  // ===========================================================================
+  __device__ IbgdaWork put_group_local(
+      ThreadGroup& group,
+      const IbgdaLocalBuffer& localBuf,
+      const IbgdaRemoteBuffer& remoteBuf,
+      std::size_t nbytes) {
+    std::size_t chunkSize = nbytes / group.group_size;
+    std::size_t offset = group.thread_id_in_group * chunkSize;
+    std::size_t laneBytes = (group.thread_id_in_group == group.group_size - 1)
+        ? (nbytes - offset)
+        : chunkSize;
+
+    IbgdaLocalBuffer laneBuf = localBuf.subBuffer(offset);
+    IbgdaRemoteBuffer laneRemoteBuf = remoteBuf.subBuffer(offset);
+
+    if (group.group_size == 1) {
+      return put(laneBuf, laneRemoteBuf, laneBytes);
+    }
+    return put_group_impl(group, laneBuf, laneRemoteBuf, laneBytes);
+  }
+
+  // ===========================================================================
+  // put_group_global - Group-collaborative RDMA Write (global data)
+  // ===========================================================================
+  __device__ IbgdaWork put_group_global(
+      ThreadGroup& group,
+      const IbgdaLocalBuffer& localBuf,
+      const IbgdaRemoteBuffer& remoteBuf,
+      std::size_t nbytes) {
+    std::size_t chunkPerGroup = nbytes / group.total_groups;
+    std::size_t groupOffset = group.group_id * chunkPerGroup;
+    std::size_t groupBytes = (group.group_id == group.total_groups - 1)
+        ? (nbytes - groupOffset)
+        : chunkPerGroup;
+
+    IbgdaLocalBuffer groupLocalBuf = localBuf.subBuffer(groupOffset);
+    IbgdaRemoteBuffer groupRemoteBuf = remoteBuf.subBuffer(groupOffset);
+
+    return put_group_local(group, groupLocalBuf, groupRemoteBuf, groupBytes);
+  }
+
+  // ===========================================================================
+  // Compound Put + Signal APIs (caller-provided signal buffers)
+  // ===========================================================================
+
+  __device__ IbgdaWork put_signal(
+      const IbgdaLocalBuffer& localBuf,
+      const IbgdaRemoteBuffer& remoteBuf,
+      std::size_t nbytes,
+      const IbgdaRemoteBuffer& remoteSignalBuf,
+      int signalId,
+      uint64_t signalVal) {
+    put(localBuf, remoteBuf, nbytes);
+    return signal_remote_with_fence(remoteSignalBuf, signalId, signalVal);
+  }
+
+  __device__ IbgdaWork put_signal_group_local(
+      ThreadGroup& group,
+      const IbgdaLocalBuffer& localBuf,
+      const IbgdaRemoteBuffer& remoteBuf,
+      std::size_t nbytes,
+      const IbgdaRemoteBuffer& remoteSignalBuf,
+      int signalId,
+      uint64_t signalVal) {
+    std::size_t chunkSize = nbytes / group.group_size;
+    std::size_t offset = group.thread_id_in_group * chunkSize;
+    std::size_t laneBytes = (group.thread_id_in_group == group.group_size - 1)
+        ? (nbytes - offset)
+        : chunkSize;
+
+    IbgdaLocalBuffer laneBuf = localBuf.subBuffer(offset);
+    IbgdaRemoteBuffer laneRemoteBuf = remoteBuf.subBuffer(offset);
+
+    if (group.group_size == 1) {
+      put(laneBuf, laneRemoteBuf, laneBytes);
+      return signal_remote_with_fence(remoteSignalBuf, signalId, signalVal);
+    }
+
+    put_group_impl(group, laneBuf, laneRemoteBuf, laneBytes);
+
+    uint64_t signalTicket = 0;
+    if (group.is_leader()) {
+      IbgdaWork signalWork =
+          signal_remote_with_fence(remoteSignalBuf, signalId, signalVal);
+      signalTicket = signalWork.value;
+    }
+    signalTicket = group.broadcast<uint64_t>(signalTicket);
+    return IbgdaWork(signalTicket);
+  }
+
+  __device__ IbgdaWork put_signal_group_global(
+      ThreadGroup& group,
+      const IbgdaLocalBuffer& localBuf,
+      const IbgdaRemoteBuffer& remoteBuf,
+      std::size_t nbytes,
+      const IbgdaRemoteBuffer& remoteSignalBuf,
+      int signalId,
+      uint64_t signalVal) {
+    std::size_t chunkPerGroup = nbytes / group.total_groups;
+    std::size_t groupOffset = group.group_id * chunkPerGroup;
+    std::size_t groupBytes = (group.group_id == group.total_groups - 1)
+        ? (nbytes - groupOffset)
+        : chunkPerGroup;
+
+    IbgdaLocalBuffer groupLocalBuf = localBuf.subBuffer(groupOffset);
+    IbgdaRemoteBuffer groupRemoteBuf = remoteBuf.subBuffer(groupOffset);
+
+    return put_signal_group_local(
+        group,
+        groupLocalBuf,
+        groupRemoteBuf,
+        groupBytes,
+        remoteSignalBuf,
+        signalId,
+        signalVal);
+  }
+
+  // ===========================================================================
+  // Local Signal Operations (caller-provided local signal buffer)
+  // ===========================================================================
+
+  __device__ void wait_signal(
+      const IbgdaLocalBuffer& localSignalBuf,
+      int signalId,
+      uint64_t expected,
+      const Timeout& timeout = Timeout()) {
+    volatile uint64_t* sig =
+        static_cast<volatile uint64_t*>(localSignalBuf.ptr) + signalId;
+    while (*sig < expected) {
+      TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+          timeout,
+          "wait_signal(GE): signalId=%d, expected>=%llu, current=%llu",
+          signalId,
+          static_cast<unsigned long long>(expected),
+          static_cast<unsigned long long>(*sig));
+    }
+    __threadfence_system();
+  }
+
+  __device__ uint64_t
+  read_signal(const IbgdaLocalBuffer& localSignalBuf, int signalId) const {
+    volatile uint64_t* sig =
+        static_cast<volatile uint64_t*>(localSignalBuf.ptr) + signalId;
+    return *sig;
+  }
+
+  __device__ void reset_signal(
+      const IbgdaRemoteBuffer& remoteSignalBuf,
+      int signalId) {
+    fence();
+
+    uint64_t ticket;
+    pipes_gda_gpu_dev_verbs_addr remoteAddr = {
+        .addr = reinterpret_cast<uint64_t>(
+            static_cast<uint64_t*>(remoteSignalBuf.ptr) + signalId),
+        .key = remoteSignalBuf.rkey.value};
+
+    pipes_gda_gpu_dev_verbs_p<uint64_t>(
+        nic_, qp_, remoteAddr, static_cast<uint64_t>(0), &ticket);
+
+    Timeout timeout(kDefaultDeviceTimeoutCycles);
+    timeout.start();
+    wait_local(IbgdaWork(ticket), timeout);
+  }
+
+  // ===========================================================================
+  // Remote Signal / Counter Operations (for window-owned buffers)
+  // ===========================================================================
+
+  __device__ IbgdaWork signal_remote(
+      const IbgdaRemoteBuffer& remoteBuf,
+      int signalId,
+      uint64_t value) {
+    uint64_t ticket;
+
+    pipes_gda_gpu_dev_verbs_addr remoteAddr = {
+        .addr = reinterpret_cast<uint64_t>(
+            static_cast<uint64_t*>(remoteBuf.ptr) + signalId),
+        .key = remoteBuf.rkey.value};
+    pipes_gda_gpu_dev_verbs_addr sinkAddr = {
+        .addr = reinterpret_cast<uint64_t>(sinkBufPtr_),
+        .key = sinkLkey_.value};
+
+    pipes_gda_gpu_dev_verbs_signal(
+        nic_, qp_, remoteAddr, sinkAddr, value, &ticket);
+
+    return IbgdaWork(ticket);
+  }
+
+  __device__ IbgdaWork signal_remote_with_fence(
+      const IbgdaRemoteBuffer& remoteBuf,
+      int signalId,
+      uint64_t value) {
+    pipes_gda_gpu_dev_verbs_addr remoteAddr = {
+        .addr = reinterpret_cast<uint64_t>(
+            static_cast<uint64_t*>(remoteBuf.ptr) + signalId),
+        .key = remoteBuf.rkey.value};
+    pipes_gda_gpu_dev_verbs_addr sinkAddr = {
+        .addr = reinterpret_cast<uint64_t>(sinkBufPtr_),
+        .key = sinkLkey_.value};
+
+    uint64_t wqeIdx = pipes_gda_gpu_dev_verbs_reserve_wq_slots(nic_, qp_, 1);
+    auto* wqe = pipes_gda_gpu_dev_verbs_get_wqe_ptr(nic_, qp_, wqeIdx);
+
+    pipes_gda_gpu_dev_verbs_wqe_prepare_atomic(
+        nic_,
+        qp_,
+        wqe,
+        wqeIdx,
+        static_cast<uint8_t>(
+            PIPES_GDA_IB_MLX5_WQE_CTRL_CQ_UPDATE |
+            PIPES_GDA_IB_MLX5_WQE_CTRL_FENCE),
+        remoteAddr.addr,
+        remoteAddr.key,
+        sinkAddr.addr,
+        sinkAddr.key,
+        sizeof(uint64_t),
+        value,
+        0);
+
+    pipes_gda_gpu_dev_verbs_mark_wqes_ready(nic_, qp_, wqeIdx, wqeIdx);
+    pipes_gda_gpu_dev_verbs_submit(nic_, qp_, wqeIdx + 1);
+
+    return IbgdaWork(wqeIdx);
+  }
+
+  __device__ void put_signal_counter_remote(
+      const IbgdaLocalBuffer& localDataBuf,
+      const IbgdaRemoteBuffer& remoteDataBuf,
+      std::size_t nbytes,
+      const IbgdaRemoteBuffer& remoteSignalBuf,
+      int signalId,
+      uint64_t signalVal,
+      const IbgdaLocalBuffer& localCounterBuf,
+      int counterId,
+      uint64_t counterVal) {
+    pipes_gda_gpu_dev_verbs_addr laddr = {
+        .addr = reinterpret_cast<uint64_t>(localDataBuf.ptr),
+        .key = localDataBuf.lkey.value};
+    pipes_gda_gpu_dev_verbs_addr raddr = {
+        .addr = reinterpret_cast<uint64_t>(remoteDataBuf.ptr),
+        .key = remoteDataBuf.rkey.value};
+
+    pipes_gda_gpu_dev_verbs_addr sigRemoteAddr = {
+        .addr = reinterpret_cast<uint64_t>(
+            static_cast<uint64_t*>(remoteSignalBuf.ptr) + signalId),
+        .key = remoteSignalBuf.rkey.value};
+    pipes_gda_gpu_dev_verbs_addr sigSinkAddr = {
+        .addr = 0, .key = sinkLkey_.value};
+
+    pipes_gda_gpu_dev_verbs_addr counterRemoteAddr = {
+        .addr = reinterpret_cast<uint64_t>(
+            static_cast<uint64_t*>(localCounterBuf.ptr) + counterId),
+        .key = localCounterBuf.lkey.value};
+    pipes_gda_gpu_dev_verbs_addr counterSinkAddr = {
+        .addr = 0, .key = sinkLkey_.value};
+
+    pipes_gda_gpu_dev_verbs_put_signal_counter(
+        nic_,
+        qp_,
+        raddr,
+        laddr,
+        nbytes,
+        sigRemoteAddr,
+        sigSinkAddr,
+        signalVal,
+        companionQp_,
+        counterRemoteAddr,
+        counterSinkAddr,
+        counterVal);
+  }
+
+  __device__ void signal_counter_remote(
+      const IbgdaRemoteBuffer& remoteSignalBuf,
+      int signalId,
+      uint64_t signalVal,
+      const IbgdaLocalBuffer& localCounterBuf,
+      int counterId,
+      uint64_t counterVal) {
+    pipes_gda_gpu_dev_verbs_addr sigRemoteAddr = {
+        .addr = reinterpret_cast<uint64_t>(
+            static_cast<uint64_t*>(remoteSignalBuf.ptr) + signalId),
+        .key = remoteSignalBuf.rkey.value};
+    pipes_gda_gpu_dev_verbs_addr sigSinkAddr = {
+        .addr = 0, .key = sinkLkey_.value};
+
+    pipes_gda_gpu_dev_verbs_addr counterRemoteAddr = {
+        .addr = reinterpret_cast<uint64_t>(
+            static_cast<uint64_t*>(localCounterBuf.ptr) + counterId),
+        .key = localCounterBuf.lkey.value};
+    pipes_gda_gpu_dev_verbs_addr counterSinkAddr = {
+        .addr = 0, .key = sinkLkey_.value};
+
+    pipes_gda_gpu_dev_verbs_signal_counter(
+        nic_,
+        qp_,
+        sigRemoteAddr,
+        sigSinkAddr,
+        signalVal,
+        companionQp_,
+        counterRemoteAddr,
+        counterSinkAddr,
+        counterVal);
+  }
+
+  // ===========================================================================
+  // wait_local - Wait for local completion of an RDMA operation
+  // ===========================================================================
+  __device__ void wait_local(
+      const IbgdaWork& work,
+      Timeout timeout = Timeout()) {
+    if (!timeout.isEnabled()) {
+      pipes_gda_gpu_dev_verbs_wait(nic_, qp_, work.value);
+    } else {
+      int status;
+      do {
+        status = pipes_gda_gpu_dev_verbs_poll_one_cq_at(
+            nic_, pipes_gda_gpu_dev_verbs_qp_get_cq_sq(qp_), work.value);
+        if (status == EBUSY) {
+          TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+              timeout,
+              "P2pIbgdaTransportDevice::wait_local timed out "
+              "(ticket=%llu)",
+              static_cast<unsigned long long>(work.value));
+        }
+      } while (status == EBUSY);
+    }
+  }
+
+  // ===========================================================================
+  // fence - Wait for all pending RDMA operations to complete at the NIC
+  // ===========================================================================
+  __device__ void fence() {
+    pipes_gda_fence(nic_, qp_);
+  }
+
+  __host__ __device__ pipes_gda_gpu_dev_verbs_qp* getQp() const {
+    return qp_;
+  }
+
+ private:
+  // ===========================================================================
+  // put_group_impl - Group-collaborative RDMA Write (private helper)
+  // ===========================================================================
+  __device__ IbgdaWork put_group_impl(
+      ThreadGroup& group,
+      const IbgdaLocalBuffer& laneBuf,
+      const IbgdaRemoteBuffer& laneRemoteBuf,
+      std::size_t laneBytes) {
+    uint64_t baseWqeIdx = 0;
+    if (group.is_leader()) {
+      baseWqeIdx =
+          pipes_gda_gpu_dev_verbs_reserve_wq_slots(nic_, qp_, group.group_size);
+    }
+
+    baseWqeIdx = group.broadcast<uint64_t>(baseWqeIdx);
+
+    uint64_t wqeIdx = baseWqeIdx + group.thread_id_in_group;
+    auto* wqe = pipes_gda_gpu_dev_verbs_get_wqe_ptr(nic_, qp_, wqeIdx);
+
+    pipes_gda_gpu_dev_verbs_wqe_prepare_write(
+        nic_,
+        qp_,
+        wqe,
+        wqeIdx,
+        PIPES_GDA_IB_MLX5_WQE_CTRL_CQ_UPDATE,
+        reinterpret_cast<uint64_t>(laneRemoteBuf.ptr),
+        laneRemoteBuf.rkey.value,
+        reinterpret_cast<uint64_t>(laneBuf.ptr),
+        laneBuf.lkey.value,
+        static_cast<uint32_t>(laneBytes));
+
+    group.sync();
+
+    if (group.is_leader()) {
+      pipes_gda_gpu_dev_verbs_mark_wqes_ready(
+          nic_, qp_, baseWqeIdx, baseWqeIdx + group.group_size - 1);
+      pipes_gda_gpu_dev_verbs_submit(nic_, qp_, baseWqeIdx + group.group_size);
+    }
+
+    group.sync();
+
+    return IbgdaWork(wqeIdx);
+  }
+
+  NicBackend nic_;
+  pipes_gda_gpu_dev_verbs_qp* qp_{nullptr};
+  pipes_gda_gpu_dev_verbs_qp* companionQp_{nullptr};
+  NetworkLKey sinkLkey_{};
+  void* sinkBufPtr_{nullptr};
+};
+
+// =============================================================================
+// Convenience type alias: P2pIbgdaTransportDevice
+// =============================================================================
+
+using P2pIbgdaTransportDevice = P2pIbgdaTransportDeviceImpl<ActiveNicBackend>;
+
+} // namespace pipes_gda

--- a/comms/pipes/P2pNvlTransportDevice.cuh
+++ b/comms/pipes/P2pNvlTransportDevice.cuh
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <cuda.h>
+
 #include <cuda_runtime.h>
 #include <cstddef>
 #include <cstring>
@@ -10,6 +11,7 @@
 #include "comms/pipes/CopyUtils.cuh"
 #include "comms/pipes/DeviceCheck.cuh"
 #include "comms/pipes/DeviceSpan.cuh"
+#include "comms/pipes/HipCompat.cuh"
 #include "comms/pipes/SignalState.cuh"
 #include "comms/pipes/ThreadGroup.cuh"
 #include "comms/pipes/Timeout.cuh"
@@ -421,7 +423,7 @@ class P2pNvlTransportDevice {
       void* srcbuff,
       std::size_t nbytes,
       const Timeout& timeout = Timeout()) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     if (options_.dataBufferSize == 0) {
       printf(
           "P2pNvlTransportDevice::send_group() requires staging buffer"
@@ -688,7 +690,7 @@ class P2pNvlTransportDevice {
       void* dstbuff,
       std::size_t nbytes,
       const Timeout& timeout = Timeout()) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     if (options_.dataBufferSize == 0) {
       printf(
           "P2pNvlTransportDevice::recv_group() requires staging buffer"
@@ -885,7 +887,7 @@ class P2pNvlTransportDevice {
       [[maybe_unused]] char* dst_d,
       [[maybe_unused]] const char* src_d,
       [[maybe_unused]] std::size_t nbytes) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     if (nbytes == 0) {
       return 0;
     }

--- a/comms/pipes/P2pSelfTransportDevice.cuh
+++ b/comms/pipes/P2pSelfTransportDevice.cuh
@@ -3,7 +3,9 @@
 #pragma once
 
 #include <cuda_runtime.h>
+
 #include <cstddef>
+#include "comms/pipes/HipCompat.cuh"
 
 #include "comms/pipes/CopyUtils.cuh"
 #include "comms/pipes/ThreadGroup.cuh"
@@ -45,7 +47,7 @@ class P2pSelfTransportDevice {
    * Calling this method will trap and abort the kernel.
    */
   __device__ void send(ThreadGroup& group, void* srcbuff, std::size_t nbytes) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     __trap(); // Abort kernel if send is called on SelfTransportDevice
 #endif
   }
@@ -57,7 +59,7 @@ class P2pSelfTransportDevice {
    * Calling this method will trap and abort the kernel.
    */
   __device__ void recv(ThreadGroup& group, void* dstbuff, std::size_t nbytes) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     __trap(); // Abort kernel if recv is called on SelfTransportDevice
 #endif
   }
@@ -86,7 +88,7 @@ class P2pSelfTransportDevice {
       [[maybe_unused]] char* dst_d,
       [[maybe_unused]] const char* src_d,
       [[maybe_unused]] std::size_t nbytes) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     // Early return for no-op cases (check before overlap to handle dst == src)
     if (nbytes == 0 || dst_d == src_d) {
       return;

--- a/comms/pipes/SignalState.cuh
+++ b/comms/pipes/SignalState.cuh
@@ -3,8 +3,10 @@
 #pragma once
 
 #include <cstdint>
+
 #include "comms/common/AtomicUtils.cuh"
 #include "comms/common/BitOps.cuh"
+#include "comms/pipes/HipCompat.cuh"
 #include "comms/pipes/ThreadGroup.cuh"
 #include "comms/pipes/Timeout.cuh"
 

--- a/comms/pipes/ThreadGroup.cuh
+++ b/comms/pipes/ThreadGroup.cuh
@@ -9,6 +9,7 @@
 #include "comms/common/AtomicUtils.cuh"
 #include "comms/common/DeviceConstants.cuh"
 #include "comms/pipes/DeviceSpan.cuh"
+#include "comms/pipes/HipCompat.cuh"
 
 namespace comms::pipes {
 
@@ -95,7 +96,7 @@ struct ThreadGroup {
   SyncScope scope;
 
   __device__ inline void sync() {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     switch (scope) {
       case SyncScope::THREAD:
         // Single-thread group: emit a compiler barrier to prevent reordering
@@ -107,17 +108,27 @@ struct ThreadGroup {
         asm volatile("" ::: "memory");
         break;
       case SyncScope::WARP:
+#if defined(__CUDA_ARCH__)
         __syncwarp();
+#else
+        // AMD wavefronts are implicitly lockstep; agent-scope fence suffices
+        __builtin_amdgcn_fence(__ATOMIC_SEQ_CST, "agent");
+#endif
         break;
       case SyncScope::MULTIWARP: {
         // Multiwarp = 4 warps = 128 threads
-        // Uses named barriers for synchronization within a multiwarp
+#if defined(__CUDA_ARCH__)
+        // Uses CUDA named barriers for synchronization within a multiwarp
         uint32_t tid = threadIdx.x + threadIdx.y * blockDim.x +
             threadIdx.z * blockDim.x * blockDim.y;
         uint32_t barrierId = tid / kMultiwarpSize;
         asm volatile("bar.sync %0, %1;"
                      :
                      : "r"(barrierId), "r"(kMultiwarpSize));
+#else
+        // AMD: no named barriers, fall back to block-level sync
+        __syncthreads();
+#endif
         break;
       }
       case SyncScope::BLOCK:
@@ -185,7 +196,7 @@ struct ThreadGroup {
    * @return Warp-scoped ThreadGroup with renumbered group_id/total_groups
    */
   __device__ inline ThreadGroup to_warp_group() const {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     if (scope == SyncScope::WARP && group_size == kWarpSize) {
       return *this;
     }
@@ -240,8 +251,10 @@ struct ThreadGroup {
    */
   template <typename T>
   __device__ inline T broadcast(T val) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     switch (scope) {
+      case SyncScope::THREAD:
+        return val; // Single thread, nothing to broadcast
       case SyncScope::WARP:
         return shfl(val, 0);
       case SyncScope::MULTIWARP: {
@@ -342,7 +355,7 @@ struct ThreadGroup {
   __device__ inline void for_each_item_contiguous(
       uint32_t total_items,
       Func&& func) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     const uint32_t items_per_group =
         (total_items + total_groups - 1) / total_groups;
     const uint32_t start_item = group_id * items_per_group;
@@ -406,7 +419,7 @@ struct ThreadGroup {
   __device__ inline void for_each_item_strided(
       uint32_t total_items,
       Func&& func) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     for (uint32_t item_id = group_id; item_id < total_items;
          item_id += total_groups) {
       func(item_id);
@@ -493,7 +506,7 @@ struct PartitionResult {
  */
 __device__ inline PartitionResult ThreadGroup::partition(
     uint32_t num_partitions) const {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   // More partitions than groups is invalid - some partitions would be empty
   // and group assignment would skip partitions non-deterministically.
   // Use __trap() instead of assert() to ensure this check is active in both
@@ -604,7 +617,7 @@ __device__ inline PartitionResult ThreadGroup::partition(
  */
 __device__ inline PartitionResult ThreadGroup::partition(
     DeviceSpan<const uint32_t> weights) const {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   const uint32_t num_partitions = static_cast<uint32_t>(weights.size());
 
   // Count non-zero weights and calculate total weight
@@ -712,7 +725,7 @@ __device__ inline PartitionResult ThreadGroup::partition(
  */
 __device__ inline PartitionResult ThreadGroup::partition_interleaved(
     uint32_t num_partitions) const {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   if (num_partitions > total_groups) {
     printf(
         "partition_interleaved: num_partitions (%u) must be <= total_groups (%u)\n",
@@ -756,7 +769,7 @@ __device__ inline PartitionResult ThreadGroup::partition_interleaved(
  * thread index and count respectively.
  */
 __device__ inline ThreadGroup make_thread_solo() {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   uint32_t tid = threadIdx.x + threadIdx.y * blockDim.x +
       threadIdx.z * blockDim.x * blockDim.y;
   uint32_t threads_per_block = blockDim.x * blockDim.y * blockDim.z;
@@ -791,7 +804,7 @@ __device__ inline ThreadGroup make_thread_solo() {
  * ThreadGroup into warp subgroups, preserving group context.
  */
 __device__ inline ThreadGroup make_warp_group() {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   uint32_t warps_per_block = blockDim.x / comms::device::kWarpSize;
   uint32_t warp_id_in_block = threadIdx.x / comms::device::kWarpSize;
   uint32_t global_warp_id = blockIdx.x * warps_per_block + warp_id_in_block;
@@ -836,11 +849,12 @@ __device__ inline ThreadGroup make_warp_group() {
  * - ~16 SMs per GPC, 8 GPCs total -> 132 SMs
  * - Maximum cluster size: 16 blocks (limited by GPC)
  *
- * NOTE: On architectures before SM90, falls back to single-block behavior
- * where cluster_size is effectively 1.
+ * NOTE: On architectures before SM90 (and on HIP/AMD where clusters are not
+ * supported), falls back to single-block behavior where cluster_size is
+ * effectively 1.
  */
 __device__ inline ThreadGroup make_cluster_group() {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 #if __CUDA_ARCH__ >= 900
   // Get cluster grid dimensions using PTX instructions
   uint32_t num_clusters_x, cluster_rank;
@@ -868,7 +882,8 @@ __device__ inline ThreadGroup make_cluster_group() {
       .total_groups = num_clusters_x,
       .scope = SyncScope::CLUSTER};
 #else
-  // Fallback for non-Hopper: treat each block as its own cluster
+  // Fallback for non-Hopper (and HIP — clusters not supported on AMD):
+  // treat each block as its own cluster
   return ThreadGroup{
       .thread_id_in_group = threadIdx.x,
       .group_size = blockDim.x,
@@ -894,7 +909,7 @@ __device__ inline ThreadGroup make_cluster_group() {
  *   - Each block processes work items cooperatively
  */
 __device__ inline ThreadGroup make_block_group() {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   return ThreadGroup{
       .thread_id_in_group = threadIdx.x,
       .group_size = blockDim.x,
@@ -932,7 +947,7 @@ __device__ inline ThreadGroup make_block_group() {
 // TODO: Add support for configurable multiwarp size, 4/8/16.. warps as a
 // multiwarp.
 __device__ inline ThreadGroup make_multiwarp_group() {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   uint32_t threads_per_block = blockDim.x * blockDim.y * blockDim.z;
   uint32_t tid = threadIdx.x + threadIdx.y * blockDim.x +
       threadIdx.z * blockDim.x * blockDim.y;
@@ -979,7 +994,7 @@ __device__ inline ThreadGroup make_multiwarp_group() {
  *   }
  */
 __device__ inline ThreadGroup make_thread_group(SyncScope scope) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   switch (scope) {
     case SyncScope::THREAD:
       return make_thread_solo();

--- a/comms/pipes/Timeout.cuh
+++ b/comms/pipes/Timeout.cuh
@@ -7,6 +7,18 @@
 
 namespace comms::pipes {
 
+// GPU clock abstraction: NVIDIA uses clock64() (shader clock),
+// AMD uses wall_clock64() (fixed 100 MHz wall clock) for accurate timing.
+__device__ __forceinline__ uint64_t gpu_clock64() {
+#if defined(__HIP_DEVICE_COMPILE__) && !defined(__CUDA_ARCH__)
+  return wall_clock64();
+#elif defined(__CUDA_ARCH__)
+  return clock64();
+#else
+  return 0; // Host fallback (never called at runtime)
+#endif
+}
+
 // Forward declaration - full definition in ThreadGroup.cuh
 struct ThreadGroup;
 
@@ -78,7 +90,7 @@ struct Timeout {
    * deadline_cycles already being non-zero.
    */
   __device__ __forceinline__ void start() {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     if (timeout_cycles > 0) {
       if (deadline_cycles != 0) {
         printf(
@@ -87,7 +99,7 @@ struct Timeout {
             static_cast<unsigned long long>(deadline_cycles));
         __trap(); // Double-start is a programming error
       }
-      deadline_cycles = clock64() + timeout_cycles;
+      deadline_cycles = gpu_clock64() + timeout_cycles;
     }
 #endif
   }
@@ -107,9 +119,9 @@ struct Timeout {
    * @return true if timeout has expired, false otherwise (or if disabled)
    */
   __device__ __forceinline__ bool checkExpired() const {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     if (timeout_cycles > 0) {
-      return clock64() > deadline_cycles;
+      return gpu_clock64() > deadline_cycles;
     }
 #endif
     return false;
@@ -141,9 +153,9 @@ namespace comms::pipes {
 
 __device__ __forceinline__ bool Timeout::checkExpired(
     const ThreadGroup& group) const {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   if (timeout_cycles > 0 && group.is_leader()) {
-    return clock64() > deadline_cycles;
+    return gpu_clock64() > deadline_cycles;
   }
 #else
   (void)group;
@@ -169,7 +181,7 @@ __device__ __forceinline__ bool Timeout::checkExpired(
  * @param fmt Printf-style format string (without newline)
  * @param ... Format arguments
  */
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 #define TIMEOUT_TRAP_IF_EXPIRED(timeout, group, fmt, ...)     \
   do {                                                        \
     if ((timeout).checkExpired(group)) {                      \
@@ -194,7 +206,7 @@ __device__ __forceinline__ bool Timeout::checkExpired(
  * @param fmt Printf-style format string (without newline)
  * @param ... Format arguments
  */
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 #define TIMEOUT_TRAP_IF_EXPIRED_SINGLE(timeout, fmt, ...)     \
   do {                                                        \
     if ((timeout).checkExpired()) {                           \

--- a/comms/pipes/Transport.cuh
+++ b/comms/pipes/Transport.cuh
@@ -35,6 +35,7 @@ enum class TransportType : uint8_t {
   SELF,
   P2P_NVL,
   P2P_IBGDA,
+  P2P_IBGDA_AMD,
 };
 
 /// Human-readable name for TransportType (host-only).
@@ -46,6 +47,8 @@ inline const char* transport_type_name(TransportType t) {
       return "P2P_NVL";
     case TransportType::P2P_IBGDA:
       return "P2P_IBGDA";
+    case TransportType::P2P_IBGDA_AMD:
+      return "P2P_IBGDA_AMD";
   }
   return "UNKNOWN";
 }
@@ -79,6 +82,10 @@ struct Transport {
     // etc.) that cannot compile in .cc translation units. A forward declaration
     // + non-owning pointer avoids pulling those headers into Transport.cuh.
     P2pIbgdaTransportDevice* p2p_ibgda;
+    // AMD IBGDA transport (pipes_gda::P2pIbgdaTransportDevice).
+    // Stored as void* to avoid including AMD device headers (HIP intrinsics)
+    // in CUDA compilation units. Cast to the correct type in kernel dispatch.
+    void* p2p_ibgda_amd;
   };
 
   /** Constructor for SelfTransportDevice */
@@ -92,6 +99,12 @@ struct Transport {
   /** Constructor for P2pIbgdaTransportDevice (non-owning pointer) */
   __host__ __device__ explicit Transport(P2pIbgdaTransportDevice* p)
       : type(TransportType::P2P_IBGDA), p2p_ibgda(p) {}
+
+  /** Constructor for AMD IBGDA transport (non-owning void pointer) */
+  struct IbgdaAmdTag {};
+  __host__ __device__ Transport(void* p, IbgdaAmdTag)
+      : type(TransportType::P2P_IBGDA_AMD), p2p_ibgda_amd(p) {}
+
   /**
    * Delete copy constructor and copy assignment.
    * Transport objects contain device pointers and IPC handles that should not
@@ -109,8 +122,10 @@ struct Transport {
       new (&self) P2pSelfTransportDevice(std::move(other.self));
     } else if (type == TransportType::P2P_NVL) {
       new (&p2p_nvl) P2pNvlTransportDevice(std::move(other.p2p_nvl));
-    } else {
+    } else if (type == TransportType::P2P_IBGDA) {
       p2p_ibgda = other.p2p_ibgda;
+    } else {
+      p2p_ibgda_amd = other.p2p_ibgda_amd;
     }
   }
 
@@ -134,8 +149,10 @@ struct Transport {
         new (&self) P2pSelfTransportDevice(std::move(other.self));
       } else if (type == TransportType::P2P_NVL) {
         new (&p2p_nvl) P2pNvlTransportDevice(std::move(other.p2p_nvl));
-      } else {
+      } else if (type == TransportType::P2P_IBGDA) {
         p2p_ibgda = other.p2p_ibgda;
+      } else {
+        p2p_ibgda_amd = other.p2p_ibgda_amd;
       }
     }
     return *this;

--- a/comms/pipes/amd/HipDeviceBuffer.h
+++ b/comms/pipes/amd/HipDeviceBuffer.h
@@ -1,0 +1,50 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// RAII wrapper for HIP device memory allocation.
+// Consolidates the HipDeviceBuffer class previously duplicated across
+// multiple AMD benchmark and test files.
+
+#pragma once
+
+#include <cstddef>
+
+#include <hip/hip_runtime.h>
+
+namespace pipes_gda {
+
+class HipDeviceBuffer {
+ public:
+  explicit HipDeviceBuffer(size_t size) : size_(size) {
+    hipError_t err = hipMalloc(&ptr_, size);
+    if (err != hipSuccess) {
+      ptr_ = nullptr;
+    }
+  }
+
+  ~HipDeviceBuffer() {
+    if (ptr_) {
+      (void)hipFree(ptr_);
+    }
+  }
+
+  HipDeviceBuffer(const HipDeviceBuffer&) = delete;
+  HipDeviceBuffer& operator=(const HipDeviceBuffer&) = delete;
+
+  void* get() const {
+    return ptr_;
+  }
+
+  size_t size() const {
+    return size_;
+  }
+
+  explicit operator bool() const {
+    return ptr_ != nullptr;
+  }
+
+ private:
+  void* ptr_{nullptr};
+  size_t size_{0};
+};
+
+} // namespace pipes_gda

--- a/comms/pipes/amd/HipMemHandler.cu
+++ b/comms/pipes/amd/HipMemHandler.cu
@@ -1,0 +1,168 @@
+#if defined(__HIPCC__) || !defined(__CUDACC__)
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "HipMemHandler.h"
+
+#include <glog/logging.h>
+#include <stdexcept>
+#include <string>
+
+namespace comms::pipes {
+
+namespace {
+
+#define HIP_CHECK(call)                                               \
+  do {                                                                \
+    hipError_t err = (call);                                          \
+    if (err != hipSuccess) {                                          \
+      throw std::runtime_error(                                       \
+          std::string(#call) + " failed: " + hipGetErrorString(err)); \
+    }                                                                 \
+  } while (0)
+
+// IPC handle exchange info (fixed-size for allGather)
+struct IpcExchangeInfo {
+  hipIpcMemHandle_t handle;
+  size_t allocatedSize;
+};
+
+} // namespace
+
+HipMemHandler::HipMemHandler(
+    std::shared_ptr<meta::comms::IBootstrap> bootstrap,
+    int32_t selfRank,
+    int32_t nRanks,
+    size_t size)
+    : bootstrap_(std::move(bootstrap)), selfRank_(selfRank), nRanks_(nRanks) {
+  // Align to 256 bytes (HIP IPC requirement)
+  allocatedSize_ = (size + 255) & ~255ULL;
+
+  HIP_CHECK(hipMalloc(&localPtr_, allocatedSize_));
+  HIP_CHECK(hipMemset(localPtr_, 0, allocatedSize_));
+  HIP_CHECK(hipIpcGetMemHandle(&localHandle_, localPtr_));
+
+  VLOG(1) << "HipMemHandler: rank " << selfRank_ << " allocated "
+          << allocatedSize_ << " bytes at " << localPtr_;
+
+  // Auto-exchange on construction (matches GpuMemHandler behavior)
+  exchangeMemPtrs();
+}
+
+HipMemHandler::HipMemHandler(
+    std::shared_ptr<meta::comms::IBootstrap> bootstrap,
+    int32_t selfRank,
+    int32_t nRanks,
+    size_t size,
+    const std::vector<int32_t>& localPeerRanks)
+    : bootstrap_(std::move(bootstrap)),
+      selfRank_(selfRank),
+      nRanks_(nRanks),
+      filtered_(true),
+      localPeerRanks_(localPeerRanks) {
+  allocatedSize_ = (size + 255) & ~255ULL;
+
+  HIP_CHECK(hipMalloc(&localPtr_, allocatedSize_));
+  HIP_CHECK(hipMemset(localPtr_, 0, allocatedSize_));
+  HIP_CHECK(hipIpcGetMemHandle(&localHandle_, localPtr_));
+
+  VLOG(1) << "HipMemHandler(filtered): rank " << selfRank_ << " allocated "
+          << allocatedSize_ << " bytes, " << localPeerRanks_.size()
+          << " local peers";
+
+  exchangeMemPtrs();
+}
+
+HipMemHandler::~HipMemHandler() {
+  // Close peer IPC handles
+  for (int i = 0; i < nRanks_; i++) {
+    if (i == selfRank_)
+      continue;
+    int idx = (i < selfRank_) ? i : (i - 1);
+    if (idx < static_cast<int>(peerPtrs_.size()) && peerPtrs_[idx]) {
+      hipError_t err = hipIpcCloseMemHandle(peerPtrs_[idx]);
+      if (err != hipSuccess) {
+        LOG(WARNING) << "HipMemHandler: hipIpcCloseMemHandle failed for peer "
+                     << i << " (error=" << hipGetErrorString(err) << ")";
+      }
+    }
+  }
+  peerPtrs_.clear();
+
+  // Free local allocation
+  if (localPtr_) {
+    hipFree(localPtr_);
+    localPtr_ = nullptr;
+  }
+}
+
+void HipMemHandler::exchangeMemPtrs() {
+  if (exchanged_)
+    return;
+
+  // Exchange IPC handles via allGather
+  std::vector<IpcExchangeInfo> allInfo(nRanks_);
+  allInfo[selfRank_].handle = localHandle_;
+  allInfo[selfRank_].allocatedSize = allocatedSize_;
+
+  auto result =
+      bootstrap_
+          ->allGather(
+              allInfo.data(), sizeof(IpcExchangeInfo), selfRank_, nRanks_)
+          .get();
+  if (result != 0) {
+    throw std::runtime_error("HipMemHandler: allGather failed");
+  }
+
+  // Open peer IPC handles
+  const int numPeers = nRanks_ - 1;
+  peerPtrs_.resize(numPeers, nullptr);
+
+  for (int rank = 0; rank < nRanks_; rank++) {
+    if (rank == selfRank_)
+      continue;
+
+    int peerIdx = (rank < selfRank_) ? rank : (rank - 1);
+
+    // In filtered mode, only IPC-open handles for local peers
+    if (filtered_) {
+      bool isLocal = false;
+      for (int32_t lr : localPeerRanks_) {
+        if (lr == rank) {
+          isLocal = true;
+          break;
+        }
+      }
+      if (!isLocal) {
+        continue; // peerPtrs_[peerIdx] stays nullptr
+      }
+    }
+
+    HIP_CHECK(hipIpcOpenMemHandle(
+        &peerPtrs_[peerIdx],
+        allInfo[rank].handle,
+        hipIpcMemLazyEnablePeerAccess));
+
+    VLOG(1) << "HipMemHandler: rank " << selfRank_ << " opened peer " << rank
+            << " at " << peerPtrs_[peerIdx];
+  }
+
+  exchanged_ = true;
+}
+
+void* HipMemHandler::getLocalDeviceMemPtr() const {
+  return localPtr_;
+}
+
+void* HipMemHandler::getPeerDeviceMemPtr(int32_t rank) const {
+  if (!exchanged_) {
+    throw std::runtime_error("HipMemHandler: exchangeMemPtrs() not called");
+  }
+  if (rank == selfRank_) {
+    return localPtr_;
+  }
+  int peerIdx = (rank < selfRank_) ? rank : (rank - 1);
+  return peerPtrs_[peerIdx];
+}
+
+} // namespace comms::pipes
+#endif

--- a/comms/pipes/amd/HipMemHandler.h
+++ b/comms/pipes/amd/HipMemHandler.h
@@ -1,0 +1,75 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// =============================================================================
+// HipMemHandler — AMD GPU memory sharing via HIP IPC
+// =============================================================================
+//
+// AMD equivalent of GpuMemHandler. Provides GPU memory allocation and
+// cross-process sharing using hipIpcGetMemHandle / hipIpcOpenMemHandle.
+//
+// Same public API as GpuMemHandler:
+//   - Constructor allocates GPU memory
+//   - exchangeMemPtrs() collectively exchanges IPC handles
+//   - getLocalDeviceMemPtr() / getPeerDeviceMemPtr() for access
+
+#pragma once
+
+#include <hip/hip_runtime.h>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "comms/common/bootstrap/IBootstrap.h"
+
+namespace comms::pipes {
+
+class HipMemHandler {
+ public:
+  HipMemHandler(
+      std::shared_ptr<meta::comms::IBootstrap> bootstrap,
+      int32_t selfRank,
+      int32_t nRanks,
+      size_t size);
+
+  // Filtered mode: only open IPC handles for localPeerRanks.
+  // AllGather still involves all nRanks for coordination, but
+  // hipIpcOpenMemHandle is skipped for non-local peers.
+  // getPeerDeviceMemPtr() returns nullptr for non-local peers.
+  HipMemHandler(
+      std::shared_ptr<meta::comms::IBootstrap> bootstrap,
+      int32_t selfRank,
+      int32_t nRanks,
+      size_t size,
+      const std::vector<int32_t>& localPeerRanks);
+
+  ~HipMemHandler();
+
+  HipMemHandler(const HipMemHandler&) = delete;
+  HipMemHandler& operator=(const HipMemHandler&) = delete;
+
+  // Collective: all ranks must call
+  void exchangeMemPtrs();
+
+  void* getLocalDeviceMemPtr() const;
+  void* getPeerDeviceMemPtr(int32_t rank) const;
+
+  size_t getAllocatedSize() const {
+    return allocatedSize_;
+  }
+
+ private:
+  std::shared_ptr<meta::comms::IBootstrap> bootstrap_;
+  const int32_t selfRank_;
+  const int32_t nRanks_;
+
+  size_t allocatedSize_{0};
+  bool exchanged_{false};
+  bool filtered_{false};
+  std::vector<int32_t> localPeerRanks_;
+
+  void* localPtr_{nullptr};
+  hipIpcMemHandle_t localHandle_{};
+  std::vector<void*> peerPtrs_;
+};
+
+} // namespace comms::pipes

--- a/comms/pipes/amd/MultiPeerNvlTransportAmd.cu
+++ b/comms/pipes/amd/MultiPeerNvlTransportAmd.cu
@@ -1,0 +1,410 @@
+#if defined(__HIPCC__) || !defined(__CUDACC__)
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "MultiPeerNvlTransportAmd.h"
+#include "comms/pipes/amd/HipMemHandler.h"
+
+#include <hip/hip_runtime.h>
+#include <vector>
+
+#define HIP_CHECK(call)                                               \
+  do {                                                                \
+    hipError_t err = (call);                                          \
+    if (err != hipSuccess) {                                          \
+      throw std::runtime_error(                                       \
+          std::string(#call) + " failed: " + hipGetErrorString(err)); \
+    }                                                                 \
+  } while (0)
+
+namespace comms::pipes {
+
+MultiPeerNvlTransportAmd::MultiPeerNvlTransportAmd(
+    int myRank,
+    int nRanks,
+    std::shared_ptr<meta::comms::IBootstrap> bootstrap,
+    const MultiPeerNvlTransportAmdConfig& config)
+    : myRank_(myRank),
+      nRanks_(nRanks),
+      bootstrap_(std::move(bootstrap)),
+      config_(config) {
+  // Enable P2P access to all peer GPUs for direct XGMI transfers.
+  // Without this, IPC memory access goes through system memory (slow).
+  int deviceCount = 0;
+  HIP_CHECK(hipGetDeviceCount(&deviceCount));
+  int myDevice = 0;
+  HIP_CHECK(hipGetDevice(&myDevice));
+  for (int d = 0; d < deviceCount; d++) {
+    if (d == myDevice)
+      continue;
+    int canAccess = 0;
+    HIP_CHECK(hipDeviceCanAccessPeer(&canAccess, myDevice, d));
+    if (canAccess) {
+      hipError_t peerErr = hipDeviceEnablePeerAccess(d, 0);
+      // Ignore if already enabled
+      if (peerErr != hipSuccess &&
+          peerErr != hipErrorPeerAccessAlreadyEnabled) {
+        HIP_CHECK(peerErr);
+      }
+    }
+  }
+  // Clear any sticky "peer access already enabled" error left by
+  // hipDeviceEnablePeerAccess, so it doesn't poison later
+  // hipGetLastError() checks (e.g., PIPES_KERNEL_LAUNCH_CHECK).
+  (void)hipGetLastError();
+
+  perPeerDataBufferSize_ = config_.pipelineDepth * config_.dataBufferSize;
+  perPeerSignalBufferSize_ = getSignalBufferSize(config_.p2pSignalCount);
+
+  // Allocate signal buffer
+  const std::size_t totalSignalBufferSize =
+      perPeerSignalBufferSize_ * (nRanks_ - 1);
+  signalBufferHandler_ = std::make_unique<HipMemHandler>(
+      bootstrap_, myRank_, nRanks_, totalSignalBufferSize);
+
+  // Staging data + state buffers (only when dataBufferSize > 0)
+  if (config_.dataBufferSize > 0) {
+    const std::size_t numChunksPerStep =
+        (config_.dataBufferSize + config_.chunkSize - 1) / config_.chunkSize;
+    const std::size_t numChunksPerPeer =
+        config_.pipelineDepth * numChunksPerStep;
+    const std::size_t chunkStateMultiplier = config_.useDualStateBuffer ? 2 : 1;
+    perPeerChunkStateBufferSize_ =
+        chunkStateMultiplier * numChunksPerPeer * sizeof(ChunkState);
+
+    const std::size_t totalDataBufferSize =
+        perPeerDataBufferSize_ * (nRanks_ - 1);
+    const std::size_t totalChunkStateBufferSize =
+        perPeerChunkStateBufferSize_ * (nRanks_ - 1);
+
+    dataBufferHandler_ = std::make_unique<HipMemHandler>(
+        bootstrap_, myRank_, nRanks_, totalDataBufferSize);
+    stateBufferHandler_ = std::make_unique<HipMemHandler>(
+        bootstrap_, myRank_, nRanks_, totalChunkStateBufferSize);
+
+    // Initialize state buffer to READY_TO_SEND for all pipeline slots.
+    // ChunkState default constructor sets value_ = READY_TO_SEND (-1).
+    // Without this, HipMemHandler zeroes the buffer, leaving value_ = 0,
+    // which causes deadlocks on multi-step transfers (stepId > 0).
+    const std::size_t totalNumChunks =
+        totalChunkStateBufferSize / sizeof(ChunkState);
+    std::vector<ChunkState> initStates(totalNumChunks);
+    auto* statePtr =
+        static_cast<ChunkState*>(stateBufferHandler_->getLocalDeviceMemPtr());
+    HIP_CHECK(hipMemcpy(
+        statePtr,
+        initStates.data(),
+        totalChunkStateBufferSize,
+        hipMemcpyHostToDevice));
+  }
+
+  // Initialize signal buffer to 0
+  auto signalPtr =
+      static_cast<SignalState*>(signalBufferHandler_->getLocalDeviceMemPtr());
+  HIP_CHECK(hipMemset(signalPtr, 0, totalSignalBufferSize));
+}
+
+MultiPeerNvlTransportAmd::~MultiPeerNvlTransportAmd() {
+  // Close any IPC handles not yet freed by freeDirectCopyPtrs
+  for (void* ptr : ipcPeerPtrs_) {
+    if (ptr) {
+      hipIpcCloseMemHandle(ptr);
+    }
+  }
+  ipcPeerPtrs_.clear();
+
+  if (transportsDevice_) {
+    hipFree(transportsDevice_);
+    transportsDevice_ = nullptr;
+  }
+}
+
+MultiPeerNvlTransportAmd::MultiPeerNvlTransportAmd(
+    int myRank,
+    int nRanks,
+    std::shared_ptr<meta::comms::IBootstrap> bootstrap,
+    const MultiPeerNvlTransportAmdConfig& config,
+    const std::vector<int>& localPeerRanks)
+    : myRank_(myRank),
+      nRanks_(nRanks),
+      bootstrap_(std::move(bootstrap)),
+      config_(config) {
+  // Enable P2P access to all local peer GPUs for direct XGMI transfers.
+  int deviceCount = 0;
+  HIP_CHECK(hipGetDeviceCount(&deviceCount));
+  int myDevice = 0;
+  HIP_CHECK(hipGetDevice(&myDevice));
+  for (int d = 0; d < deviceCount; d++) {
+    if (d == myDevice)
+      continue;
+    int canAccess = 0;
+    HIP_CHECK(hipDeviceCanAccessPeer(&canAccess, myDevice, d));
+    if (canAccess) {
+      hipError_t peerErr = hipDeviceEnablePeerAccess(d, 0);
+      if (peerErr != hipSuccess &&
+          peerErr != hipErrorPeerAccessAlreadyEnabled) {
+        HIP_CHECK(peerErr);
+      }
+    }
+  }
+  (void)hipGetLastError();
+
+  // Convert localPeerRanks to int32_t for HipMemHandler
+  std::vector<int32_t> localPeers32(
+      localPeerRanks.begin(), localPeerRanks.end());
+
+  perPeerDataBufferSize_ = config_.pipelineDepth * config_.dataBufferSize;
+  perPeerSignalBufferSize_ = getSignalBufferSize(config_.p2pSignalCount);
+
+  const std::size_t totalSignalBufferSize =
+      perPeerSignalBufferSize_ * (nRanks_ - 1);
+  signalBufferHandler_ = std::make_unique<HipMemHandler>(
+      bootstrap_, myRank_, nRanks_, totalSignalBufferSize, localPeers32);
+
+  if (config_.dataBufferSize > 0) {
+    const std::size_t numChunksPerStep =
+        (config_.dataBufferSize + config_.chunkSize - 1) / config_.chunkSize;
+    const std::size_t numChunksPerPeer =
+        config_.pipelineDepth * numChunksPerStep;
+    const std::size_t chunkStateMultiplier = config_.useDualStateBuffer ? 2 : 1;
+    perPeerChunkStateBufferSize_ =
+        chunkStateMultiplier * numChunksPerPeer * sizeof(ChunkState);
+
+    const std::size_t totalDataBufferSize =
+        perPeerDataBufferSize_ * (nRanks_ - 1);
+    const std::size_t totalChunkStateBufferSize =
+        perPeerChunkStateBufferSize_ * (nRanks_ - 1);
+
+    dataBufferHandler_ = std::make_unique<HipMemHandler>(
+        bootstrap_, myRank_, nRanks_, totalDataBufferSize, localPeers32);
+    stateBufferHandler_ = std::make_unique<HipMemHandler>(
+        bootstrap_, myRank_, nRanks_, totalChunkStateBufferSize, localPeers32);
+
+    const std::size_t totalNumChunks =
+        totalChunkStateBufferSize / sizeof(ChunkState);
+    std::vector<ChunkState> initStates(totalNumChunks);
+    auto* statePtr =
+        static_cast<ChunkState*>(stateBufferHandler_->getLocalDeviceMemPtr());
+    HIP_CHECK(hipMemcpy(
+        statePtr,
+        initStates.data(),
+        totalChunkStateBufferSize,
+        hipMemcpyHostToDevice));
+  }
+
+  auto signalPtr =
+      static_cast<SignalState*>(signalBufferHandler_->getLocalDeviceMemPtr());
+  HIP_CHECK(hipMemset(signalPtr, 0, totalSignalBufferSize));
+}
+
+void MultiPeerNvlTransportAmd::exchange() {
+  // HipMemHandler auto-exchanges in constructor, so this is a no-op.
+  // Kept for API compatibility with MultiPeerNvlTransport.
+}
+
+P2pNvlTransportDevice MultiPeerNvlTransportAmd::getP2pTransportDevice(
+    int peerRank) {
+  const int localPeerIndex = (peerRank < myRank_) ? peerRank : (peerRank - 1);
+  const std::size_t localSignalBufferOffset =
+      localPeerIndex * perPeerSignalBufferSize_;
+
+  const int remotePeerIndex = (myRank_ < peerRank) ? myRank_ : (myRank_ - 1);
+  const std::size_t remoteSignalBufferOffset =
+      remotePeerIndex * perPeerSignalBufferSize_;
+
+  P2pNvlTransportOptions options{
+      .dataBufferSize = config_.dataBufferSize,
+      .chunkSize = config_.chunkSize,
+      .pipelineDepth = config_.pipelineDepth,
+      .useDualStateBuffer = config_.useDualStateBuffer};
+
+  auto* localSignalPtr =
+      static_cast<char*>(signalBufferHandler_->getLocalDeviceMemPtr());
+  auto* remoteSignalPtr =
+      static_cast<char*>(signalBufferHandler_->getPeerDeviceMemPtr(peerRank));
+
+  DeviceSpan<SignalState> localSignalSpan(
+      reinterpret_cast<SignalState*>(localSignalPtr + localSignalBufferOffset),
+      config_.p2pSignalCount);
+  DeviceSpan<SignalState> remoteSignalSpan(
+      reinterpret_cast<SignalState*>(
+          remoteSignalPtr + remoteSignalBufferOffset),
+      config_.p2pSignalCount);
+
+  if (!dataBufferHandler_ || !stateBufferHandler_) {
+    LocalState localState{
+        .dataBuffer = nullptr,
+        .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+        .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+        .signalBuffer = localSignalSpan,
+    };
+    RemoteState remoteState{
+        .dataBuffer = nullptr,
+        .receiverStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+        .senderStateBuffer = DeviceSpan<ChunkState>(nullptr, 0),
+        .signalBuffer = remoteSignalSpan,
+    };
+    return P2pNvlTransportDevice(
+        myRank_, peerRank, options, localState, remoteState);
+  }
+
+  const std::size_t localDataBufferOffset =
+      localPeerIndex * perPeerDataBufferSize_;
+  const std::size_t localChunkStateBufferOffset =
+      localPeerIndex * perPeerChunkStateBufferSize_;
+  const std::size_t remoteDataBufferOffset =
+      remotePeerIndex * perPeerDataBufferSize_;
+  const std::size_t remoteChunkStateBufferOffset =
+      remotePeerIndex * perPeerChunkStateBufferSize_;
+
+  const std::size_t numChunksPerStep =
+      (config_.dataBufferSize + config_.chunkSize - 1) / config_.chunkSize;
+  const auto numChunksPerPeer =
+      static_cast<uint32_t>(config_.pipelineDepth * numChunksPerStep);
+
+  auto* localDataPtr =
+      static_cast<char*>(dataBufferHandler_->getLocalDeviceMemPtr());
+  auto* localStatePtr =
+      static_cast<char*>(stateBufferHandler_->getLocalDeviceMemPtr());
+  auto* localChunkStateBase = reinterpret_cast<ChunkState*>(
+      localStatePtr + localChunkStateBufferOffset);
+
+  auto* remoteDataPtr =
+      static_cast<char*>(dataBufferHandler_->getPeerDeviceMemPtr(peerRank));
+  auto* remoteChunkStatePtr =
+      static_cast<char*>(stateBufferHandler_->getPeerDeviceMemPtr(peerRank));
+  auto* remoteChunkStateBase = reinterpret_cast<ChunkState*>(
+      remoteChunkStatePtr + remoteChunkStateBufferOffset);
+
+  if (config_.useDualStateBuffer) {
+    LocalState localState{
+        .dataBuffer = localDataPtr + localDataBufferOffset,
+        .receiverStateBuffer =
+            DeviceSpan<ChunkState>(localChunkStateBase, numChunksPerPeer),
+        .senderStateBuffer = DeviceSpan<ChunkState>(
+            localChunkStateBase + numChunksPerPeer, numChunksPerPeer),
+        .signalBuffer = localSignalSpan,
+    };
+    RemoteState remoteState{
+        .dataBuffer = remoteDataPtr + remoteDataBufferOffset,
+        .receiverStateBuffer =
+            DeviceSpan<ChunkState>(remoteChunkStateBase, numChunksPerPeer),
+        .senderStateBuffer = DeviceSpan<ChunkState>(
+            remoteChunkStateBase + numChunksPerPeer, numChunksPerPeer),
+        .signalBuffer = remoteSignalSpan,
+    };
+    return P2pNvlTransportDevice(
+        myRank_, peerRank, options, localState, remoteState);
+  } else {
+    LocalState localState{
+        .dataBuffer = localDataPtr + localDataBufferOffset,
+        .receiverStateBuffer =
+            DeviceSpan<ChunkState>(localChunkStateBase, numChunksPerPeer),
+        .senderStateBuffer = DeviceSpan<ChunkState>(),
+        .signalBuffer = localSignalSpan,
+    };
+    RemoteState remoteState{
+        .dataBuffer = remoteDataPtr + remoteDataBufferOffset,
+        .receiverStateBuffer =
+            DeviceSpan<ChunkState>(remoteChunkStateBase, numChunksPerPeer),
+        .senderStateBuffer = DeviceSpan<ChunkState>(),
+        .signalBuffer = remoteSignalSpan,
+    };
+    return P2pNvlTransportDevice(
+        myRank_, peerRank, options, localState, remoteState);
+  }
+}
+
+DeviceSpan<Transport> MultiPeerNvlTransportAmd::getDeviceTransports() {
+  if (!multiPeerInitialized_) {
+    initializeTransportsArray();
+    multiPeerInitialized_ = true;
+  }
+  return DeviceSpan<Transport>(
+      static_cast<Transport*>(transportsDevice_), nRanks_);
+}
+
+void MultiPeerNvlTransportAmd::initializeTransportsArray() {
+  HIP_CHECK(hipMalloc(&transportsDevice_, nRanks_ * sizeof(Transport)));
+
+  std::vector<Transport> hostTransports;
+  hostTransports.reserve(nRanks_);
+  for (int rank = 0; rank < nRanks_; ++rank) {
+    if (rank == myRank_) {
+      hostTransports.emplace_back(P2pSelfTransportDevice());
+    } else {
+      hostTransports.emplace_back(getP2pTransportDevice(rank));
+    }
+  }
+
+  HIP_CHECK(hipMemcpy(
+      transportsDevice_,
+      hostTransports.data(),
+      nRanks_ * sizeof(Transport),
+      hipMemcpyDefault));
+}
+
+void* MultiPeerNvlTransportAmd::exchangeDirectCopyPtrs(
+    void* recvBuf,
+    std::size_t size) {
+  // Get IPC handle for local recv buffer
+  hipIpcMemHandle_t myHandle;
+  HIP_CHECK(hipIpcGetMemHandle(&myHandle, recvBuf));
+
+  // Exchange handles
+  struct HandleInfo {
+    hipIpcMemHandle_t handle;
+  };
+  std::vector<HandleInfo> allHandles(nRanks_);
+  allHandles[myRank_].handle = myHandle;
+
+  auto result =
+      bootstrap_
+          ->allGather(allHandles.data(), sizeof(HandleInfo), myRank_, nRanks_)
+          .get();
+  if (result != 0)
+    throw std::runtime_error("exchangeDirectCopyPtrs allGather failed");
+
+  // Open peer handles and track IPC pointers for cleanup
+  std::vector<char*> peerPtrs(nRanks_, nullptr);
+  ipcPeerPtrs_.clear();
+  ipcPeerPtrs_.reserve(nRanks_);
+  for (int r = 0; r < nRanks_; r++) {
+    if (r == myRank_) {
+      peerPtrs[r] = static_cast<char*>(recvBuf);
+      ipcPeerPtrs_.push_back(nullptr); // no IPC handle for self
+    } else {
+      void* ptr = nullptr;
+      HIP_CHECK(hipIpcOpenMemHandle(
+          &ptr, allHandles[r].handle, hipIpcMemLazyEnablePeerAccess));
+      peerPtrs[r] = static_cast<char*>(ptr);
+      ipcPeerPtrs_.push_back(ptr);
+    }
+  }
+
+  // Copy pointer array to device memory
+  void* d_peerPtrs = nullptr;
+  HIP_CHECK(hipMalloc(&d_peerPtrs, nRanks_ * sizeof(char*)));
+  HIP_CHECK(hipMemcpy(
+      d_peerPtrs,
+      peerPtrs.data(),
+      nRanks_ * sizeof(char*),
+      hipMemcpyHostToDevice));
+
+  return d_peerPtrs;
+}
+
+void MultiPeerNvlTransportAmd::freeDirectCopyPtrs(void* d_peerPtrs) {
+  // Close IPC handles before freeing device pointer array
+  for (void* ptr : ipcPeerPtrs_) {
+    if (ptr) {
+      hipIpcCloseMemHandle(ptr);
+    }
+  }
+  ipcPeerPtrs_.clear();
+  if (d_peerPtrs) {
+    hipFree(d_peerPtrs);
+  }
+}
+
+} // namespace comms::pipes
+#endif

--- a/comms/pipes/amd/MultiPeerNvlTransportAmd.h
+++ b/comms/pipes/amd/MultiPeerNvlTransportAmd.h
@@ -1,0 +1,107 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// AMD equivalent of MultiPeerNvlTransport.
+// Same API but uses HipMemHandler (HIP IPC) instead of GpuMemHandler (CUDA
+// IPC). Device-side code (P2pNvlTransportDevice, Transport) is hipified
+// automatically.
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "comms/common/bootstrap/IBootstrap.h"
+#include "comms/pipes/P2pNvlTransportDevice.cuh"
+#include "comms/pipes/P2pSelfTransportDevice.cuh"
+#include "comms/pipes/Transport.cuh"
+
+namespace comms::pipes {
+
+class HipMemHandler;
+
+struct MultiPeerNvlTransportAmdConfig {
+  std::size_t dataBufferSize{0};
+  std::size_t chunkSize{0};
+  std::size_t pipelineDepth{0};
+  std::size_t p2pSignalCount{1};
+  bool useDualStateBuffer{false};
+};
+
+class MultiPeerNvlTransportAmd {
+ public:
+  MultiPeerNvlTransportAmd(
+      int myRank,
+      int nRanks,
+      std::shared_ptr<meta::comms::IBootstrap> bootstrap,
+      const MultiPeerNvlTransportAmdConfig& config);
+
+  // Filtered mode: only set up NVL IPC for localPeerRanks.
+  // AllGather coordinates with all nRanks, but hipIpcOpenMemHandle
+  // is only called for specified local peers. Used by MultiPeerTransportAmd
+  // for hybrid NVL+IBGDA topology.
+  MultiPeerNvlTransportAmd(
+      int myRank,
+      int nRanks,
+      std::shared_ptr<meta::comms::IBootstrap> bootstrap,
+      const MultiPeerNvlTransportAmdConfig& config,
+      const std::vector<int>& localPeerRanks);
+
+  ~MultiPeerNvlTransportAmd();
+
+  MultiPeerNvlTransportAmd(const MultiPeerNvlTransportAmd&) = delete;
+  MultiPeerNvlTransportAmd& operator=(const MultiPeerNvlTransportAmd&) = delete;
+
+  // Collective: all ranks must call
+  void exchange();
+
+  // Get device-accessible Transport array for pipelined AllToAllv
+  DeviceSpan<Transport> getDeviceTransports();
+
+  // Register a user buffer and exchange IPC pointers for direct-copy AllToAllv.
+  // Returns device-accessible array of nRanks char* pointers (peer recv bufs).
+  // peerPtrs[myRank] = local recvBuf, peerPtrs[other] = IPC-mapped peer buf.
+  void* exchangeDirectCopyPtrs(void* recvBuf, std::size_t size);
+
+  // Free direct-copy pointers
+  void freeDirectCopyPtrs(void* d_peerPtrs);
+
+  int getMyRank() const {
+    return myRank_;
+  }
+  int getNRanks() const {
+    return nRanks_;
+  }
+
+  friend class MultiPeerTransportAmd;
+
+ private:
+  P2pNvlTransportDevice getP2pTransportDevice(int peerRank);
+  void initializeTransportsArray();
+
+  static std::size_t getSignalBufferSize(std::size_t signalCount) {
+    return signalCount * sizeof(SignalState);
+  }
+
+  const int myRank_;
+  const int nRanks_;
+  std::shared_ptr<meta::comms::IBootstrap> bootstrap_;
+  MultiPeerNvlTransportAmdConfig config_;
+
+  std::unique_ptr<HipMemHandler> signalBufferHandler_;
+  std::unique_ptr<HipMemHandler> dataBufferHandler_;
+  std::unique_ptr<HipMemHandler> stateBufferHandler_;
+
+  std::size_t perPeerDataBufferSize_{0};
+  std::size_t perPeerChunkStateBufferSize_{0};
+  std::size_t perPeerSignalBufferSize_{0};
+
+  // Device transport array
+  void* transportsDevice_{nullptr};
+  bool multiPeerInitialized_{false};
+
+  // IPC peer pointers opened via hipIpcOpenMemHandle (for direct-copy).
+  // Must be closed with hipIpcCloseMemHandle in freeDirectCopyPtrs.
+  std::vector<void*> ipcPeerPtrs_;
+};
+
+} // namespace comms::pipes

--- a/comms/pipes/amd/MultiPeerTransportAmd.cu
+++ b/comms/pipes/amd/MultiPeerTransportAmd.cu
@@ -1,0 +1,177 @@
+#if defined(__HIPCC__) || !defined(__CUDACC__)
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "MultiPeerTransportAmd.h"
+#include "MultipeerIbgdaTransportAmd.h" // @manual
+
+#include <hip/hip_runtime.h>
+#include <unistd.h>
+#include <cstring>
+#include <stdexcept>
+#include <vector>
+
+#include <folly/logging/xlog.h>
+
+namespace comms::pipes {
+
+namespace {
+
+#define HIP_CHECK(call)                                               \
+  do {                                                                \
+    hipError_t err = (call);                                          \
+    if (err != hipSuccess) {                                          \
+      throw std::runtime_error(                                       \
+          std::string(#call) + " failed: " + hipGetErrorString(err)); \
+    }                                                                 \
+  } while (0)
+
+} // namespace
+
+MultiPeerTransportAmd::MultiPeerTransportAmd(
+    int myRank,
+    int nRanks,
+    int localRank,
+    int localSize,
+    std::shared_ptr<meta::comms::IBootstrap> bootstrap,
+    const MultiPeerTransportAmdConfig& config)
+    : myRank_(myRank),
+      nRanks_(nRanks),
+      localRank_(localRank),
+      localSize_(localSize),
+      bootstrap_(std::move(bootstrap)),
+      config_(config) {
+  detectTopology();
+
+  // Create NVL transport for local peers (filtered: only IPC-open local peers)
+  if (!localPeerRanks_.empty()) {
+    nvlTransport_ = std::make_unique<MultiPeerNvlTransportAmd>(
+        myRank_, nRanks_, bootstrap_, config_.nvlConfig, localPeerRanks_);
+  }
+
+  // Create IBGDA transport for remote peers (filtered: only RDMA to remotes)
+  if (!remotePeerRanks_.empty()) {
+    pipes_gda::MultipeerIbgdaTransportAmdConfig ibgdaCfg{
+        .hipDevice = config_.hipDevice,
+        .qpDepth = config_.ibgdaQpDepth,
+    };
+    ibgdaTransport_ = std::make_unique<pipes_gda::MultipeerIbgdaTransportAmd>(
+        myRank_, nRanks_, bootstrap_, ibgdaCfg, remotePeerRanks_);
+  }
+}
+
+MultiPeerTransportAmd::~MultiPeerTransportAmd() {
+  if (transportsDevice_) {
+    hipFree(transportsDevice_);
+    transportsDevice_ = nullptr;
+  }
+}
+
+void MultiPeerTransportAmd::detectTopology() {
+  // Exchange hostnames to determine which peers are on the same node.
+  // Same approach as NVIDIA's TopologyDiscovery Tier 2 (hostname match).
+  constexpr int kMaxHostnameLen = 256;
+
+  struct RankHostInfo {
+    char hostname[kMaxHostnameLen];
+  };
+
+  std::vector<RankHostInfo> allHostInfo(nRanks_);
+  gethostname(allHostInfo[myRank_].hostname, kMaxHostnameLen);
+  allHostInfo[myRank_].hostname[kMaxHostnameLen - 1] = '\0';
+
+  auto result =
+      bootstrap_
+          ->allGather(
+              allHostInfo.data(), sizeof(RankHostInfo), myRank_, nRanks_)
+          .get();
+  if (result != 0) {
+    throw std::runtime_error(
+        "MultiPeerTransportAmd: hostname allGather failed");
+  }
+
+  const char* myHostname = allHostInfo[myRank_].hostname;
+  for (int r = 0; r < nRanks_; ++r) {
+    if (r == myRank_) {
+      continue;
+    }
+    if (strncmp(myHostname, allHostInfo[r].hostname, kMaxHostnameLen) == 0) {
+      localPeerRanks_.push_back(r);
+    } else {
+      remotePeerRanks_.push_back(r);
+    }
+  }
+
+  if (myRank_ == 0) {
+    XLOGF(
+        INFO,
+        "MultiPeerTransportAmd: rank {} topology: {} local NVL peers, "
+        "{} remote IBGDA peers",
+        myRank_,
+        localPeerRanks_.size(),
+        remotePeerRanks_.size());
+  }
+}
+
+void MultiPeerTransportAmd::exchange() {
+  // NVL transport auto-exchanges in constructor (via HipMemHandler)
+  // IBGDA transport requires explicit exchange
+  if (ibgdaTransport_) {
+    ibgdaTransport_->exchange();
+  }
+}
+
+DeviceSpan<Transport> MultiPeerTransportAmd::getDeviceTransports() {
+  if (!initialized_) {
+    initializeTransportsArray();
+    initialized_ = true;
+  }
+  return DeviceSpan<Transport>(
+      static_cast<Transport*>(transportsDevice_), nRanks_);
+}
+
+void MultiPeerTransportAmd::initializeTransportsArray() {
+  HIP_CHECK(hipMalloc(&transportsDevice_, nRanks_ * sizeof(Transport)));
+
+  std::vector<Transport> hostTransports;
+  hostTransports.reserve(nRanks_);
+
+  for (int rank = 0; rank < nRanks_; ++rank) {
+    if (rank == myRank_) {
+      // Self transport
+      hostTransports.emplace_back(P2pSelfTransportDevice());
+    } else {
+      // Check if this rank is a local NVL peer
+      bool isLocal = false;
+      for (int lr : localPeerRanks_) {
+        if (lr == rank) {
+          isLocal = true;
+          break;
+        }
+      }
+
+      if (isLocal && nvlTransport_) {
+        // NVL transport for same-node peer
+        hostTransports.emplace_back(nvlTransport_->getP2pTransportDevice(rank));
+      } else if (ibgdaTransport_) {
+        // IBGDA transport for cross-node peer (stored as void*)
+        void* devTransport =
+            static_cast<void*>(ibgdaTransport_->getP2pTransportDevice(rank));
+        hostTransports.emplace_back(
+            Transport(devTransport, Transport::IbgdaAmdTag{}));
+      } else {
+        throw std::runtime_error(
+            "MultiPeerTransportAmd: no transport available for rank " +
+            std::to_string(rank));
+      }
+    }
+  }
+
+  HIP_CHECK(hipMemcpy(
+      transportsDevice_,
+      hostTransports.data(),
+      nRanks_ * sizeof(Transport),
+      hipMemcpyDefault));
+}
+
+} // namespace comms::pipes
+#endif

--- a/comms/pipes/amd/MultiPeerTransportAmd.h
+++ b/comms/pipes/amd/MultiPeerTransportAmd.h
@@ -1,0 +1,107 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// =============================================================================
+// MultiPeerTransportAmd — Unified NVL + IBGDA transport for AMD GPUs
+// =============================================================================
+//
+// AMD equivalent of comms::pipes::MultiPeerTransport.
+// Auto-detects topology and creates:
+//   - P2P_NVL (IPC/XGMI) transport for same-node peers
+//   - P2P_IBGDA_AMD (RDMA) transport for cross-node peers
+//   - SELF transport for self-rank
+//
+// Single-node: all peers use NVL (no IBGDA needed)
+// Multi-node:  local peers use NVL, remote peers use IBGDA
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "comms/common/bootstrap/IBootstrap.h"
+#include "comms/pipes/DeviceSpan.cuh"
+#include "comms/pipes/Transport.cuh"
+#include "comms/pipes/amd/MultiPeerNvlTransportAmd.h"
+
+// Forward declaration to avoid including IBGDA headers
+namespace pipes_gda {
+class MultipeerIbgdaTransportAmd;
+struct MultipeerIbgdaTransportAmdConfig;
+} // namespace pipes_gda
+
+namespace comms::pipes {
+
+struct MultiPeerTransportAmdConfig {
+  // NVL transport config
+  MultiPeerNvlTransportAmdConfig nvlConfig;
+
+  // IBGDA transport config (only used for multi-node)
+  int hipDevice{0};
+  uint32_t ibgdaQpDepth{128};
+};
+
+class MultiPeerTransportAmd {
+ public:
+  MultiPeerTransportAmd(
+      int myRank,
+      int nRanks,
+      int localRank,
+      int localSize,
+      std::shared_ptr<meta::comms::IBootstrap> bootstrap,
+      const MultiPeerTransportAmdConfig& config);
+
+  ~MultiPeerTransportAmd();
+
+  MultiPeerTransportAmd(const MultiPeerTransportAmd&) = delete;
+  MultiPeerTransportAmd& operator=(const MultiPeerTransportAmd&) = delete;
+
+  // Collective: all ranks must call
+  void exchange();
+
+  // Get unified device-accessible Transport array (one per rank)
+  DeviceSpan<Transport> getDeviceTransports();
+
+  int getMyRank() const {
+    return myRank_;
+  }
+  int getNRanks() const {
+    return nRanks_;
+  }
+  bool isHybrid() const {
+    return !remotePeerRanks_.empty();
+  }
+  const std::vector<int>& getLocalPeerRanks() const {
+    return localPeerRanks_;
+  }
+  const std::vector<int>& getRemotePeerRanks() const {
+    return remotePeerRanks_;
+  }
+  pipes_gda::MultipeerIbgdaTransportAmd* getIbgdaTransport() const {
+    return ibgdaTransport_.get();
+  }
+
+ private:
+  void detectTopology();
+  void initializeTransportsArray();
+
+  const int myRank_;
+  const int nRanks_;
+  const int localRank_;
+  const int localSize_;
+  std::shared_ptr<meta::comms::IBootstrap> bootstrap_;
+  MultiPeerTransportAmdConfig config_;
+
+  // Topology
+  std::vector<int> localPeerRanks_; // same-node peers (NVL)
+  std::vector<int> remotePeerRanks_; // cross-node peers (IBGDA)
+
+  // Sub-transports
+  std::unique_ptr<MultiPeerNvlTransportAmd> nvlTransport_;
+  std::unique_ptr<pipes_gda::MultipeerIbgdaTransportAmd> ibgdaTransport_;
+
+  // Unified device Transport array
+  void* transportsDevice_{nullptr};
+  bool initialized_{false};
+};
+
+} // namespace comms::pipes

--- a/comms/pipes/amd/MultipeerIbgdaTransportAmd.cu
+++ b/comms/pipes/amd/MultipeerIbgdaTransportAmd.cu
@@ -1,0 +1,826 @@
+#if defined(__HIPCC__) || !defined(__CUDACC__)
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "MultipeerIbgdaTransportAmd.h"
+
+#include <hip/hip_runtime.h>
+#include <hsa/hsa.h>
+#include <hsa/hsa_ext_amd.h>
+#include <infiniband/mlx5dv.h>
+
+#include <dlfcn.h>
+#include <algorithm>
+#include <cstring>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include <fmt/core.h>
+#include <glog/logging.h>
+#include <unistd.h>
+
+#include "MultipeerIbgdaTransportAmdHip.h"
+#include "verbs/VerbsUtils.h"
+
+namespace pipes_gda {
+
+namespace {
+
+// =============================================================================
+// HSA Runtime Helpers (UAR-to-GPU mapping)
+// =============================================================================
+
+struct HsaAgentInfo {
+  hsa_agent_t agent;
+  hsa_amd_memory_pool_t pool;
+};
+
+static std::vector<HsaAgentInfo> g_hsaGpuAgents;
+static std::vector<HsaAgentInfo> g_hsaCpuAgents;
+static std::once_flag g_hsaInitFlag;
+static bool g_hsaInitSuccess = false;
+
+static hsa_status_t hsaPoolCallback(hsa_amd_memory_pool_t pool, void* data) {
+  hsa_amd_memory_pool_global_flag_t flag{};
+  hsa_status_t st = hsa_amd_memory_pool_get_info(
+      pool, HSA_AMD_MEMORY_POOL_INFO_GLOBAL_FLAGS, &flag);
+  if (st != HSA_STATUS_SUCCESS)
+    return st;
+  if (flag ==
+      (HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_KERNARG_INIT |
+       HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_FINE_GRAINED)) {
+    *static_cast<hsa_amd_memory_pool_t*>(data) = pool;
+  }
+  return HSA_STATUS_SUCCESS;
+}
+
+static hsa_status_t hsaAgentCallback(hsa_agent_t agent, void*) {
+  hsa_device_type_t devType{};
+  hsa_status_t st = hsa_agent_get_info(agent, HSA_AGENT_INFO_DEVICE, &devType);
+  if (st != HSA_STATUS_SUCCESS)
+    return st;
+  if (devType == HSA_DEVICE_TYPE_GPU) {
+    g_hsaGpuAgents.emplace_back();
+    g_hsaGpuAgents.back().agent = agent;
+    st = hsa_amd_agent_iterate_memory_pools(
+        agent, hsaPoolCallback, &g_hsaGpuAgents.back().pool);
+  } else if (devType == HSA_DEVICE_TYPE_CPU) {
+    g_hsaCpuAgents.emplace_back();
+    g_hsaCpuAgents.back().agent = agent;
+    st = hsa_amd_agent_iterate_memory_pools(
+        agent, hsaPoolCallback, &g_hsaCpuAgents.back().pool);
+  }
+  return st;
+}
+
+static bool ensureHsaInitialized() {
+  std::call_once(g_hsaInitFlag, []() {
+    hsa_status_t st = hsa_init();
+    if (st != HSA_STATUS_SUCCESS)
+      return;
+    st = hsa_iterate_agents(hsaAgentCallback, nullptr);
+    if (st != HSA_STATUS_SUCCESS && st != HSA_STATUS_INFO_BREAK)
+      return;
+    g_hsaInitSuccess = true;
+  });
+  return g_hsaInitSuccess;
+}
+
+static bool
+hsaMemoryLockToGpu(void* hostPtr, size_t size, void** gpuPtr, int gpuId) {
+  if (!ensureHsaInitialized())
+    return false;
+  if (gpuId < 0 || static_cast<size_t>(gpuId) >= g_hsaGpuAgents.size())
+    return false;
+  if (g_hsaCpuAgents.empty())
+    return false;
+  hsa_status_t st = hsa_amd_memory_lock_to_pool(
+      hostPtr,
+      size,
+      &g_hsaGpuAgents[gpuId].agent,
+      1,
+      g_hsaCpuAgents[0].pool,
+      0,
+      gpuPtr);
+  return st == HSA_STATUS_SUCCESS;
+}
+
+// Check if a pointer is device (GPU VRAM) memory.
+// Uses hipPointerGetAttributes which distinguishes:
+//   hipMemoryTypeDevice = GPU VRAM (allocated via hipMalloc)
+//   hipMemoryTypeHost   = host pinned memory (allocated via hipHostMalloc)
+// Note: hipMemoryTypeHost is returned for all host-side allocations including
+// pinned memory. This is the correct classification for RDMA registration
+// purposes: only hipMemoryTypeDevice pointers should use DMA-buf export.
+static bool isDevicePointer(void* ptr) {
+  hipPointerAttribute_t attrs = {};
+  hipError_t err = hipPointerGetAttributes(&attrs, ptr);
+  if (err != hipSuccess)
+    return false;
+  return attrs.type == hipMemoryTypeDevice;
+}
+
+// Register a buffer with RDMA.
+// For GPU memory: tries DMA-buf first (no peer_mem needed), then ibv_reg_mr.
+// For host memory: uses ibv_reg_mr directly (dmabuf is for GPU memory only).
+static ibv_mr*
+registerRdmaBuffer(ibv_pd* pd, void* ptr, size_t size, int accessFlags) {
+  ibv_mr* mr = nullptr;
+
+  // For host memory (hipHostMalloc), use ibv_reg_mr directly.
+  // DMA-buf export is only valid for GPU VRAM (hipMemoryTypeDevice) —
+  // using it on host-pinned memory would export wrong physical pages,
+  // causing silent RDMA corruption. The isDevicePointer check above
+  // relies on hipPointerGetAttributes returning hipMemoryTypeHost for
+  // all host-side allocations.
+  if (!isDevicePointer(ptr)) {
+    mr = ibv_reg_mr(pd, ptr, size, accessFlags);
+    if (mr) {
+      VLOG(1) << "Registered host buffer via ibv_reg_mr";
+    } else {
+      LOG(WARNING) << "ibv_reg_mr failed for host buffer (errno=" << errno
+                   << ": " << strerror(errno) << ")";
+    }
+    return mr;
+  }
+
+  // GPU memory: try DMA-buf first (preferred, no peer_mem module needed)
+  using ExportDmabufFn = int (*)(const void*, size_t, int*, uint64_t*);
+  static ExportDmabufFn exportDmabuf = nullptr;
+  static bool triedLoad = false;
+  if (!triedLoad) {
+    triedLoad = true;
+    void* hsaLib = dlopen("libhsa-runtime64.so", RTLD_LAZY | RTLD_NOLOAD);
+    if (!hsaLib)
+      hsaLib = dlopen("libhsa-runtime64.so.1", RTLD_LAZY | RTLD_NOLOAD);
+    if (hsaLib) {
+      exportDmabuf = reinterpret_cast<ExportDmabufFn>(
+          dlsym(hsaLib, "hsa_amd_portable_export_dmabuf"));
+    }
+  }
+
+  if (exportDmabuf) {
+    int dmabufFd = -1;
+    uint64_t dmabufOffset = 0;
+    int hsaStatus = exportDmabuf(ptr, size, &dmabufFd, &dmabufOffset);
+    if (hsaStatus == 0 && dmabufFd >= 0) {
+      if (dmabufOffset % sysconf(_SC_PAGESIZE) != 0) {
+        LOG(WARNING) << "dmabuf offset " << dmabufOffset
+                     << " is not page-aligned, skipping ibv_reg_dmabuf_mr"
+                     << " to avoid RDMA corruption";
+        close(dmabufFd);
+      } else {
+        mr = ibv_reg_dmabuf_mr(
+            pd,
+            dmabufOffset,
+            size,
+            reinterpret_cast<uint64_t>(ptr),
+            dmabufFd,
+            accessFlags);
+        if (mr) {
+          VLOG(1) << "Registered GPU buffer via dmabuf (fd=" << dmabufFd << ")";
+          close(dmabufFd);
+          return mr;
+        }
+        LOG(WARNING) << "ibv_reg_dmabuf_mr failed (errno=" << errno
+                     << "), falling back to ibv_reg_mr";
+        close(dmabufFd);
+      }
+    }
+  }
+
+  // Fallback: ibv_reg_mr (requires amd-peer-mem kernel module for GPU memory)
+  mr = ibv_reg_mr(pd, ptr, size, accessFlags);
+  if (mr) {
+    VLOG(1) << "Registered GPU buffer via legacy ibv_reg_mr (peer_mem)";
+  } else {
+    LOG(WARNING) << "ibv_reg_mr failed for GPU buffer (errno=" << errno << ": "
+                 << strerror(errno) << ")";
+  }
+  return mr;
+}
+
+} // namespace
+
+// =============================================================================
+// MultipeerIbgdaTransportAmd Implementation
+// =============================================================================
+
+MultipeerIbgdaTransportAmd::MultipeerIbgdaTransportAmd(
+    int myRank,
+    int nRanks,
+    std::shared_ptr<meta::comms::IBootstrap> bootstrap,
+    const MultipeerIbgdaTransportAmdConfig& config)
+    : myRank_(myRank),
+      nRanks_(nRanks),
+      bootstrap_(std::move(bootstrap)),
+      config_(config) {
+  initCommon();
+}
+
+MultipeerIbgdaTransportAmd::MultipeerIbgdaTransportAmd(
+    int myRank,
+    int nRanks,
+    std::shared_ptr<meta::comms::IBootstrap> bootstrap,
+    const MultipeerIbgdaTransportAmdConfig& config,
+    const std::vector<int>& targetRanks)
+    : myRank_(myRank),
+      nRanks_(nRanks),
+      targetRanks_(targetRanks),
+      bootstrap_(std::move(bootstrap)),
+      config_(config) {
+  initCommon();
+}
+
+void MultipeerIbgdaTransportAmd::initCommon() {
+  if (myRank_ < 0 || myRank_ >= nRanks_)
+    throw std::invalid_argument("Invalid rank");
+  if (nRanks_ < 2)
+    throw std::invalid_argument("Need at least 2 ranks");
+
+  // Validate targetRanks if provided (filtered mode)
+  if (!targetRanks_.empty()) {
+    std::unordered_set<int> seen;
+    for (int rank : targetRanks_) {
+      if (rank < 0 || rank >= nRanks_)
+        throw std::invalid_argument(
+            "targetRanks contains out-of-range rank: " + std::to_string(rank));
+      if (rank == myRank_)
+        throw std::invalid_argument(
+            "targetRanks must not contain myRank (" + std::to_string(myRank_) +
+            ")");
+      if (!seen.insert(rank).second)
+        throw std::invalid_argument(
+            "targetRanks contains duplicate rank: " + std::to_string(rank));
+    }
+  }
+
+  hipError_t err = hipSetDevice(config_.hipDevice);
+  if (err != hipSuccess)
+    throw std::runtime_error(
+        "Failed to set HIP device: " + std::string(hipGetErrorString(err)));
+  // Force HIP context init
+  hipFree(0);
+
+  const int nPeers = numPeers();
+
+  try {
+    openIbDevice();
+
+    peerResources_.resize(nPeers);
+    for (int i = 0; i < nPeers; i++) {
+      if (!createQpAndCq(i))
+        throw std::runtime_error(
+            "Failed to create QP for peer " + std::to_string(i));
+    }
+
+    // Allocate sink buffer for atomic return values (discarded).
+    // Use host-pinned memory so ibv_reg_mr works without amd-peer-mem module.
+    hipError_t hipErr =
+        hipHostMalloc(&sinkBuffer_, sizeof(uint64_t), hipHostMallocDefault);
+    if (hipErr != hipSuccess)
+      throw std::runtime_error("Failed to allocate sink buffer");
+    memset(sinkBuffer_, 0, sizeof(uint64_t));
+
+    int accessFlags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE |
+        IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_ATOMIC;
+    sinkMr_ = ibv_reg_mr(ibvPd_, sinkBuffer_, sizeof(uint64_t), accessFlags);
+    if (!sinkMr_)
+      throw std::runtime_error("Failed to register sink MR");
+  } catch (...) {
+    cleanup();
+    throw;
+  }
+
+  VLOG(1) << "MultipeerIbgdaTransportAmd: rank " << myRank_ << "/" << nRanks_
+          << " initialized with " << nPeers << " peers on HIP device "
+          << config_.hipDevice;
+}
+
+MultipeerIbgdaTransportAmd::~MultipeerIbgdaTransportAmd() {
+  cleanup();
+}
+
+void MultipeerIbgdaTransportAmd::openIbDevice() {
+  char pciBusId[32] = {};
+  if (hipDeviceGetPCIBusId(pciBusId, sizeof(pciBusId), config_.hipDevice) !=
+      hipSuccess)
+    throw std::runtime_error("Failed to get GPU PCI bus ID");
+  gpuPciBusId_ = pciBusId;
+
+  std::string nicName = tests::findClosestNic(gpuPciBusId_);
+  if (nicName.empty())
+    nicName = tests::findFirstNicDevice();
+  if (nicName.empty())
+    throw std::runtime_error("No suitable NIC found");
+
+  VLOG(1) << "MultipeerIbgdaTransportAmd: GPU " << gpuPciBusId_ << " -> NIC "
+          << nicName;
+
+  int numDevices = 0;
+  ibv_device** deviceList = ibv_get_device_list(&numDevices);
+  if (!deviceList)
+    throw std::runtime_error("No IB devices found");
+
+  ibv_device* target = nullptr;
+  for (int i = 0; i < numDevices; i++) {
+    if (nicName == deviceList[i]->name) {
+      target = deviceList[i];
+      break;
+    }
+  }
+  if (!target) {
+    ibv_free_device_list(deviceList);
+    throw std::runtime_error("NIC not found: " + nicName);
+  }
+
+  ibvCtx_ = ibv_open_device(target);
+  ibv_free_device_list(deviceList);
+  if (!ibvCtx_)
+    throw std::runtime_error("Failed to open IB device");
+
+  ibvPd_ = ibv_alloc_pd(ibvCtx_);
+  if (!ibvPd_)
+    throw std::runtime_error("Failed to allocate PD");
+
+  if (ibv_query_gid(ibvCtx_, 1, config_.gidIndex, &localGid_) != 0)
+    throw std::runtime_error("Failed to query GID");
+
+  ibv_port_attr portAttr{};
+  if (ibv_query_port(ibvCtx_, 1, &portAttr) != 0)
+    throw std::runtime_error("Failed to query port");
+  if (portAttr.state != IBV_PORT_ACTIVE)
+    throw std::runtime_error("Port not active");
+  localMtu_ = portAttr.active_mtu;
+}
+
+bool MultipeerIbgdaTransportAmd::createQpAndCq(int peerIndex) {
+  auto& res = peerResources_[peerIndex];
+
+  res.cq = ibv_create_cq(ibvCtx_, config_.qpDepth, nullptr, nullptr, 0);
+  if (!res.cq)
+    return false;
+
+  ibv_qp_init_attr qpInitAttr = {};
+  qpInitAttr.send_cq = res.cq;
+  qpInitAttr.recv_cq = res.cq;
+  qpInitAttr.cap.max_send_wr = config_.qpDepth;
+  qpInitAttr.cap.max_recv_wr = 1;
+  qpInitAttr.cap.max_send_sge = 1;
+  qpInitAttr.cap.max_recv_sge = 1;
+  qpInitAttr.qp_type = IBV_QPT_RC;
+  qpInitAttr.sq_sig_all = 0;
+
+  res.qp = ibv_create_qp(ibvPd_, &qpInitAttr);
+  if (!res.qp)
+    return false;
+
+  res.qpNum = res.qp->qp_num;
+  return true;
+}
+
+bool MultipeerIbgdaTransportAmd::connectQp(
+    int peerIndex,
+    const IbgdaTransportExchInfoAmd& peerInfo) {
+  auto& res = peerResources_[peerIndex];
+  ibv_qp_attr attr = {};
+  int flags;
+
+  // RESET -> INIT
+  attr.qp_state = IBV_QPS_INIT;
+  attr.port_num = 1;
+  attr.pkey_index = 0;
+  attr.qp_access_flags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE |
+      IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_ATOMIC;
+  flags = IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_ACCESS_FLAGS;
+  if (ibv_modify_qp(res.qp, &attr, flags) != 0)
+    return false;
+
+  // INIT -> RTR
+  memset(&attr, 0, sizeof(attr));
+  attr.qp_state = IBV_QPS_RTR;
+  attr.path_mtu = IBV_MTU_1024;
+  attr.dest_qp_num = peerInfo.qpn;
+  attr.rq_psn = 0;
+  attr.max_dest_rd_atomic = 16;
+  attr.min_rnr_timer = config_.minRnrTimer;
+  attr.ah_attr.dlid = 0;
+  attr.ah_attr.sl = 0;
+  attr.ah_attr.src_path_bits = 0;
+  attr.ah_attr.port_num = 1;
+  attr.ah_attr.is_global = 1;
+  memcpy(&attr.ah_attr.grh.dgid, peerInfo.gid, 16);
+  attr.ah_attr.grh.sgid_index = config_.gidIndex;
+  attr.ah_attr.grh.hop_limit = 255;
+  flags = IBV_QP_STATE | IBV_QP_AV | IBV_QP_PATH_MTU | IBV_QP_DEST_QPN |
+      IBV_QP_RQ_PSN | IBV_QP_MAX_DEST_RD_ATOMIC | IBV_QP_MIN_RNR_TIMER;
+  if (ibv_modify_qp(res.qp, &attr, flags) != 0)
+    return false;
+
+  // RTR -> RTS
+  memset(&attr, 0, sizeof(attr));
+  attr.qp_state = IBV_QPS_RTS;
+  attr.sq_psn = 0;
+  attr.timeout = config_.timeout;
+  attr.retry_cnt = config_.retryCount;
+  attr.rnr_retry = config_.rnrRetry;
+  attr.max_rd_atomic = 16;
+  flags = IBV_QP_STATE | IBV_QP_SQ_PSN | IBV_QP_TIMEOUT | IBV_QP_RETRY_CNT |
+      IBV_QP_RNR_RETRY | IBV_QP_MAX_QP_RD_ATOMIC;
+  if (ibv_modify_qp(res.qp, &attr, flags) != 0)
+    return false;
+
+  return true;
+}
+
+bool MultipeerIbgdaTransportAmd::exportQpToGpu(int peerIndex) {
+  auto& res = peerResources_[peerIndex];
+
+  // Query mlx5dv QP/CQ layout
+  mlx5dv_obj dvObj = {};
+  mlx5dv_qp dvQp = {};
+  mlx5dv_cq dvCq = {};
+  dvObj.qp.in = res.qp;
+  dvObj.qp.out = &dvQp;
+  dvObj.cq.in = res.cq;
+  dvObj.cq.out = &dvCq;
+  if (mlx5dv_init_obj(&dvObj, MLX5DV_OBJ_QP | MLX5DV_OBJ_CQ) != 0)
+    return false;
+
+  // Map BlueFlame UAR to GPU via HSA
+  int hipDevId = -1;
+  if (hipGetDevice(&hipDevId) != hipSuccess)
+    return false;
+
+  if (!dvQp.bf.reg || dvQp.bf.size == 0)
+    return false;
+
+  res.uarBfHostPtr = dvQp.bf.reg;
+  res.uarBfSize = static_cast<size_t>(dvQp.bf.size) * 2;
+  void* gpuUarBf = nullptr;
+  if (!hsaMemoryLockToGpu(res.uarBfHostPtr, res.uarBfSize, &gpuUarBf, hipDevId))
+    return false;
+  res.gpuUarBf = gpuUarBf;
+
+  // Initialize CQ owner bits
+  {
+    uint8_t* cqBuf = reinterpret_cast<uint8_t*>(dvCq.buf);
+    for (uint32_t i = 0; i < dvCq.cqe_cnt; i++) {
+      cqBuf[i * dvCq.cqe_size + dvCq.cqe_size - 1] = 0x01;
+    }
+  }
+
+  size_t pageSize = sysconf(_SC_PAGESIZE);
+  size_t sqSize = static_cast<size_t>(dvQp.sq.wqe_cnt) * dvQp.sq.stride;
+
+  // Register SQ, CQ, and DBREC buffers with HIP
+  void* gpuSqBuf = nullptr;
+  void* gpuCqBuf = nullptr;
+  void* gpuSqDbrec = nullptr;
+  void* gpuCqDbrec = nullptr;
+
+  hipHostRegister(dvQp.sq.buf, sqSize, hipHostRegisterDefault);
+  res.registeredSqBuf = dvQp.sq.buf;
+  hipHostGetDevicePointer(&gpuSqBuf, dvQp.sq.buf, 0);
+
+  size_t cqSize = static_cast<size_t>(dvCq.cqe_cnt) * dvCq.cqe_size;
+  hipHostRegister(dvCq.buf, cqSize, hipHostRegisterDefault);
+  res.registeredCqBuf = dvCq.buf;
+  hipHostGetDevicePointer(&gpuCqBuf, dvCq.buf, 0);
+
+  // SQ DBREC
+  void* sqDbrecPage = reinterpret_cast<void*>(
+      reinterpret_cast<uintptr_t>(dvQp.dbrec) & ~(pageSize - 1));
+  hipHostRegister(sqDbrecPage, pageSize, hipHostRegisterDefault);
+  res.registeredSqDbrecPage = sqDbrecPage;
+  void* gpuSqDbrecPage = nullptr;
+  hipHostGetDevicePointer(&gpuSqDbrecPage, sqDbrecPage, 0);
+  size_t sqDbrecOffset = reinterpret_cast<uintptr_t>(dvQp.dbrec) -
+      reinterpret_cast<uintptr_t>(sqDbrecPage);
+  gpuSqDbrec = reinterpret_cast<void*>(
+      reinterpret_cast<uintptr_t>(gpuSqDbrecPage) + sqDbrecOffset);
+
+  // CQ DBREC
+  void* cqDbrecPage = reinterpret_cast<void*>(
+      reinterpret_cast<uintptr_t>(dvCq.dbrec) & ~(pageSize - 1));
+  if (cqDbrecPage != sqDbrecPage) {
+    hipHostRegister(cqDbrecPage, pageSize, hipHostRegisterDefault);
+    res.registeredCqDbrecPage = cqDbrecPage;
+  }
+  void* gpuCqDbrecPage = nullptr;
+  hipHostGetDevicePointer(&gpuCqDbrecPage, cqDbrecPage, 0);
+  size_t cqDbrecOffset = reinterpret_cast<uintptr_t>(dvCq.dbrec) -
+      reinterpret_cast<uintptr_t>(cqDbrecPage);
+  gpuCqDbrec = reinterpret_cast<void*>(
+      reinterpret_cast<uintptr_t>(gpuCqDbrecPage) + cqDbrecOffset);
+
+  // Build QP struct on host then copy to GPU
+  pipes_gda_gpu_dev_verbs_qp hostQp = {};
+  hostQp.sq_wqe_daddr = reinterpret_cast<uint8_t*>(gpuSqBuf);
+  hostQp.sq_dbrec = reinterpret_cast<__be32*>(gpuSqDbrec);
+  hostQp.sq_db = reinterpret_cast<uint64_t*>(gpuUarBf);
+  hostQp.sq_wqe_num = static_cast<uint16_t>(dvQp.sq.wqe_cnt);
+  hostQp.sq_wqe_mask = hostQp.sq_wqe_num - 1;
+  hostQp.sq_num = res.qp->qp_num;
+  hostQp.sq_num_shift8 = res.qp->qp_num << 8;
+  hostQp.sq_num_shift8_be = __builtin_bswap32(hostQp.sq_num_shift8 | 3);
+  hostQp.sq_rsvd_index = 0;
+  hostQp.sq_ready_index = 0;
+  hostQp.nic_handler = PIPES_GDA_VERBS_NIC_HANDLER_GPU_SM_BF;
+  hostQp.mem_type = PIPES_GDA_VERBS_MEM_TYPE_GPU;
+
+  hostQp.cq_sq.cqe_daddr = reinterpret_cast<uint8_t*>(gpuCqBuf);
+  hostQp.cq_sq.cq_num = dvCq.cqn;
+  hostQp.cq_sq.cqe_num = dvCq.cqe_cnt;
+  hostQp.cq_sq.dbrec = reinterpret_cast<__be32*>(gpuCqDbrec);
+  hostQp.cq_sq.cqe_ci = 0;
+  hostQp.cq_sq.cqe_mask = dvCq.cqe_cnt - 1;
+  hostQp.cq_sq.cqe_size = dvCq.cqe_size;
+  hostQp.cq_sq.cqe_rsvd = 0;
+  hostQp.cq_sq.mem_type = PIPES_GDA_VERBS_MEM_TYPE_GPU;
+
+  hipError_t err = hipMalloc(&res.gpuQp, sizeof(pipes_gda_gpu_dev_verbs_qp));
+  if (err != hipSuccess)
+    return false;
+
+  err = hipMemcpy(
+      res.gpuQp,
+      &hostQp,
+      sizeof(pipes_gda_gpu_dev_verbs_qp),
+      hipMemcpyHostToDevice);
+  if (err != hipSuccess) {
+    hipFree(res.gpuQp);
+    res.gpuQp = nullptr;
+    return false;
+  }
+
+  VLOG(1) << "MultipeerIbgdaTransportAmd: exported QP " << peerIndex
+          << " to GPU (SQ wqe_cnt=" << dvQp.sq.wqe_cnt
+          << ", CQ cqe_cnt=" << dvCq.cqe_cnt << ")";
+  return true;
+}
+
+void MultipeerIbgdaTransportAmd::exchange() {
+  const int nPeers = numPeers();
+
+  if (nRanks_ > kMaxRanksAmd)
+    throw std::runtime_error("Too many ranks for allGather exchange");
+
+  // Build local exchange info.
+  // Even in filtered mode, we allGather with ALL ranks so each rank can
+  // find the QPN that its peer created for it.
+  std::vector<IbgdaTransportExchInfoAllAmd> allInfo(nRanks_);
+  auto& myInfo = allInfo[myRank_];
+  memcpy(myInfo.gid, localGid_.raw, sizeof(myInfo.gid));
+  myInfo.gidIndex = config_.gidIndex;
+  myInfo.mtu = localMtu_;
+
+  ibv_port_attr portAttr{};
+  if (ibv_query_port(ibvCtx_, 1, &portAttr) == 0) {
+    myInfo.lid = portAttr.lid;
+  }
+
+  // Fill in the QPN that each peer should use to reach us
+  for (int pi = 0; pi < nPeers; pi++) {
+    int peerRank = peerIndexToRank(pi);
+    myInfo.qpnForRank[peerRank] = peerResources_[pi].qpNum;
+  }
+  myInfo.qpnForRank[myRank_] = 0;
+
+  // AllGather exchange (all ranks participate)
+  auto result = bootstrap_
+                    ->allGather(
+                        allInfo.data(),
+                        sizeof(IbgdaTransportExchInfoAllAmd),
+                        myRank_,
+                        nRanks_)
+                    .get();
+  if (result != 0)
+    throw std::runtime_error("allGather failed");
+
+  // Connect QPs to peers (only target peers in filtered mode)
+  for (int pi = 0; pi < nPeers; pi++) {
+    int peerRank = peerIndexToRank(pi);
+    const auto& peerInfo = allInfo[peerRank];
+
+    IbgdaTransportExchInfoAmd exchInfo{};
+    exchInfo.qpn = peerInfo.qpnForRank[myRank_];
+    memcpy(exchInfo.gid, peerInfo.gid, sizeof(exchInfo.gid));
+    exchInfo.gidIndex = peerInfo.gidIndex;
+    exchInfo.lid = peerInfo.lid;
+    exchInfo.mtu = peerInfo.mtu;
+
+    if (!connectQp(pi, exchInfo))
+      throw std::runtime_error(
+          "Failed to connect QP to peer " + std::to_string(peerRank));
+  }
+
+  // Export QPs to GPU
+  for (int pi = 0; pi < nPeers; pi++) {
+    if (!exportQpToGpu(pi))
+      throw std::runtime_error(
+          "Failed to export QP to GPU for peer " + std::to_string(pi));
+  }
+
+  // Build P2pIbgdaTransportDevice array on GPU via HIP helper
+  peerTransportSize_ = getP2pIbgdaTransportDeviceSizeAmd();
+
+  std::vector<P2pIbgdaTransportBuildParamsAmd> buildParams(nPeers);
+  NetworkLKey sinkLkey(HostLKey(sinkMr_->lkey));
+  for (int pi = 0; pi < nPeers; pi++) {
+    buildParams[pi] = {peerResources_[pi].gpuQp, sinkLkey, sinkBuffer_};
+  }
+
+  peerTransportsGpu_ = static_cast<P2pIbgdaTransportDevice*>(
+      buildDeviceTransportsOnGpuAmd(buildParams.data(), nPeers));
+  if (!peerTransportsGpu_)
+    throw std::runtime_error("Failed to build device transports on GPU");
+
+  VLOG(1) << "MultipeerIbgdaTransportAmd: rank " << myRank_
+          << " exchange complete, connected to " << nPeers << " peers"
+          << (targetRanks_.empty() ? " (all)" : " (filtered)");
+}
+
+P2pIbgdaTransportDevice* MultipeerIbgdaTransportAmd::getP2pTransportDevice(
+    int peerRank) const {
+  int pi = rankToPeerIndex(peerRank);
+  return reinterpret_cast<P2pIbgdaTransportDevice*>(
+      reinterpret_cast<char*>(peerTransportsGpu_) + pi * peerTransportSize_);
+}
+
+P2pIbgdaTransportDevice* MultipeerIbgdaTransportAmd::getDeviceTransportPtr()
+    const {
+  return peerTransportsGpu_;
+}
+
+int MultipeerIbgdaTransportAmd::numPeers() const {
+  return targetRanks_.empty() ? (nRanks_ - 1)
+                              : static_cast<int>(targetRanks_.size());
+}
+
+int MultipeerIbgdaTransportAmd::myRank() const {
+  return myRank_;
+}
+
+int MultipeerIbgdaTransportAmd::nRanks() const {
+  return nRanks_;
+}
+
+IbgdaLocalBuffer MultipeerIbgdaTransportAmd::registerBuffer(
+    void* ptr,
+    std::size_t size) {
+  if (!ptr || size == 0)
+    throw std::invalid_argument("Invalid buffer");
+
+  auto it = registeredBuffers_.find(ptr);
+  if (it != registeredBuffers_.end())
+    return IbgdaLocalBuffer(ptr, HostLKey(it->second->lkey));
+
+  int accessFlags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE |
+      IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_ATOMIC;
+
+  ibv_mr* mr = registerRdmaBuffer(ibvPd_, ptr, size, accessFlags);
+  if (!mr)
+    throw std::runtime_error(
+        "Failed to register buffer with RDMA. "
+        "Tried dmabuf (hsa_amd_portable_export_dmabuf) and "
+        "legacy ibv_reg_mr. Check kernel/driver support.");
+
+  registeredBuffers_.emplace(ptr, mr);
+
+  VLOG(1) << "MultipeerIbgdaTransportAmd: registered buffer ptr=" << ptr
+          << " size=" << size << " lkey=" << mr->lkey;
+
+  return IbgdaLocalBuffer(ptr, HostLKey(mr->lkey));
+}
+
+void MultipeerIbgdaTransportAmd::deregisterBuffer(void* ptr) {
+  auto it = registeredBuffers_.find(ptr);
+  if (it == registeredBuffers_.end())
+    return;
+  ibv_dereg_mr(it->second);
+  registeredBuffers_.erase(it);
+}
+
+std::vector<IbgdaRemoteBuffer> MultipeerIbgdaTransportAmd::exchangeBuffer(
+    const IbgdaLocalBuffer& localBuf) {
+  const int nPeers = numPeers();
+
+  auto it = registeredBuffers_.find(localBuf.ptr);
+  if (it == registeredBuffers_.end())
+    throw std::runtime_error("Buffer not registered");
+
+  // AllGather with ALL ranks (even in filtered mode)
+  std::vector<IbgdaBufferExchInfo> allInfo(nRanks_);
+  allInfo[myRank_] = IbgdaBufferExchInfo{
+      reinterpret_cast<uint64_t>(localBuf.ptr),
+      HostRKey(it->second->rkey),
+  };
+
+  auto result =
+      bootstrap_
+          ->allGather(
+              allInfo.data(), sizeof(IbgdaBufferExchInfo), myRank_, nRanks_)
+          .get();
+  if (result != 0)
+    throw std::runtime_error("exchangeBuffer allGather failed");
+
+  // Return only buffers for our target peers
+  std::vector<IbgdaRemoteBuffer> peerBuffers(nPeers);
+  for (int pi = 0; pi < nPeers; pi++) {
+    int peerRank = peerIndexToRank(pi);
+    peerBuffers[pi] = allInfo[peerRank].toRemoteBuffer();
+  }
+
+  return peerBuffers;
+}
+
+int MultipeerIbgdaTransportAmd::rankToPeerIndex(int rank) const {
+  if (targetRanks_.empty()) {
+    // Unfiltered: dense mapping skipping self
+    return (rank < myRank_) ? rank : (rank - 1);
+  }
+  // Filtered: find rank in targetRanks_
+  for (int i = 0; i < static_cast<int>(targetRanks_.size()); i++) {
+    if (targetRanks_[i] == rank)
+      return i;
+  }
+  return -1; // rank not in target list
+}
+
+int MultipeerIbgdaTransportAmd::peerIndexToRank(int peerIndex) const {
+  if (targetRanks_.empty()) {
+    return (peerIndex < myRank_) ? peerIndex : (peerIndex + 1);
+  }
+  return targetRanks_[peerIndex];
+}
+
+void MultipeerIbgdaTransportAmd::cleanup() {
+  if (peerTransportsGpu_) {
+    freeDeviceTransportsOnGpuAmd(peerTransportsGpu_);
+    peerTransportsGpu_ = nullptr;
+  }
+
+  for (auto& res : peerResources_) {
+    if (res.gpuQp) {
+      hipFree(res.gpuQp);
+      res.gpuQp = nullptr;
+    }
+    if (res.gpuUarBf) {
+      hsa_amd_memory_unlock(res.uarBfHostPtr);
+      res.gpuUarBf = nullptr;
+    }
+    // Unregister hipHostRegister'd buffers (reverse order of registration)
+    if (res.registeredCqDbrecPage) {
+      hipHostUnregister(res.registeredCqDbrecPage);
+      res.registeredCqDbrecPage = nullptr;
+    }
+    if (res.registeredSqDbrecPage) {
+      hipHostUnregister(res.registeredSqDbrecPage);
+      res.registeredSqDbrecPage = nullptr;
+    }
+    if (res.registeredCqBuf) {
+      hipHostUnregister(res.registeredCqBuf);
+      res.registeredCqBuf = nullptr;
+    }
+    if (res.registeredSqBuf) {
+      hipHostUnregister(res.registeredSqBuf);
+      res.registeredSqBuf = nullptr;
+    }
+    if (res.qp) {
+      ibv_destroy_qp(res.qp);
+      res.qp = nullptr;
+    }
+    if (res.cq) {
+      ibv_destroy_cq(res.cq);
+      res.cq = nullptr;
+    }
+  }
+  peerResources_.clear();
+
+  for (auto& [_, mr] : registeredBuffers_)
+    ibv_dereg_mr(mr);
+  registeredBuffers_.clear();
+
+  if (sinkMr_) {
+    ibv_dereg_mr(sinkMr_);
+    sinkMr_ = nullptr;
+  }
+  if (sinkBuffer_) {
+    hipHostFree(sinkBuffer_);
+    sinkBuffer_ = nullptr;
+  }
+  if (ibvPd_) {
+    ibv_dealloc_pd(ibvPd_);
+    ibvPd_ = nullptr;
+  }
+  if (ibvCtx_) {
+    ibv_close_device(ibvCtx_);
+    ibvCtx_ = nullptr;
+  }
+}
+
+} // namespace pipes_gda
+#endif

--- a/comms/pipes/amd/MultipeerIbgdaTransportAmd.h
+++ b/comms/pipes/amd/MultipeerIbgdaTransportAmd.h
@@ -1,0 +1,187 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// =============================================================================
+// AMD GPU (HIP/ROCm) MultipeerIbgdaTransport
+// =============================================================================
+//
+// AMD equivalent of comms::pipes::MultipeerIbgdaTransport.
+// Provides the same public API but uses:
+//   - HIP runtime for GPU memory management (instead of CUDA)
+//   - HSA runtime for mapping NIC UAR BlueFlame register to GPU
+//   - Raw ibverbs + mlx5dv for QP/CQ creation and export
+//   - Manual construction of pipes_gda_gpu_dev_verbs_qp in GPU memory
+//
+// Modeled after IbgdaTestFixture.h but refactored into a reusable transport
+// class that supports N peers.
+// =============================================================================
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <infiniband/verbs.h>
+
+#include "PipesGdaShared.h"
+#include "comms/common/bootstrap/IBootstrap.h"
+#include "verbs/VerbsDev.h"
+
+// Forward declaration
+namespace pipes_gda {
+template <typename NicBackend>
+class P2pIbgdaTransportDeviceImpl;
+struct Mlx5NicBackend;
+using P2pIbgdaTransportDevice = P2pIbgdaTransportDeviceImpl<Mlx5NicBackend>;
+} // namespace pipes_gda
+
+namespace pipes_gda {
+
+struct MultipeerIbgdaTransportAmdConfig {
+  // HIP device index for GPU operations
+  int hipDevice{0};
+
+  // GID index for RoCE. Default = 3 (RoCEv2).
+  int gidIndex{3};
+
+  // Queue pair depth (number of outstanding WQEs per peer).
+  uint32_t qpDepth{128};
+
+  // InfiniBand timeout, retry, traffic class settings
+  uint8_t timeout{20};
+  uint8_t retryCount{7};
+  uint8_t trafficClass{224};
+  uint8_t serviceLevel{0};
+  uint8_t minRnrTimer{12};
+  uint8_t rnrRetry{7};
+};
+
+struct IbgdaTransportExchInfoAmd {
+  uint32_t qpn{0};
+  uint8_t gid[16]{};
+  int gidIndex{0};
+  uint16_t lid{0};
+  enum ibv_mtu mtu { IBV_MTU_4096 };
+};
+
+constexpr int kMaxRanksAmd = 128;
+
+struct IbgdaTransportExchInfoAllAmd {
+  uint8_t gid[16]{};
+  int gidIndex{0};
+  uint16_t lid{0};
+  enum ibv_mtu mtu { IBV_MTU_4096 };
+  uint32_t qpnForRank[kMaxRanksAmd]{};
+};
+
+class MultipeerIbgdaTransportAmd {
+ public:
+  // Connect to ALL peers (nRanks - 1 QPs)
+  MultipeerIbgdaTransportAmd(
+      int myRank,
+      int nRanks,
+      std::shared_ptr<meta::comms::IBootstrap> bootstrap,
+      const MultipeerIbgdaTransportAmdConfig& config);
+
+  // Connect only to specified target ranks (filtered QPs).
+  // Used for multi-node: only create QPs to remote peers, skip same-host.
+  MultipeerIbgdaTransportAmd(
+      int myRank,
+      int nRanks,
+      std::shared_ptr<meta::comms::IBootstrap> bootstrap,
+      const MultipeerIbgdaTransportAmdConfig& config,
+      const std::vector<int>& targetRanks);
+
+  ~MultipeerIbgdaTransportAmd();
+
+  MultipeerIbgdaTransportAmd(const MultipeerIbgdaTransportAmd&) = delete;
+  MultipeerIbgdaTransportAmd& operator=(const MultipeerIbgdaTransportAmd&) =
+      delete;
+
+  // Collective: all ranks must call
+  void exchange();
+
+  // Get device transport for a specific peer
+  P2pIbgdaTransportDevice* getP2pTransportDevice(int peerRank) const;
+
+  // Get base pointer to device transport array
+  P2pIbgdaTransportDevice* getDeviceTransportPtr() const;
+
+  int numPeers() const;
+  int myRank() const;
+  int nRanks() const;
+
+  // Register a GPU buffer for RDMA access
+  IbgdaLocalBuffer registerBuffer(void* ptr, std::size_t size);
+
+  // Deregister a buffer
+  void deregisterBuffer(void* ptr);
+
+  // Collective: exchange buffer info with all peers
+  std::vector<IbgdaRemoteBuffer> exchangeBuffer(
+      const IbgdaLocalBuffer& localBuf);
+
+ private:
+  // Initialization helpers
+  void openIbDevice();
+  bool createQpAndCq(int peerIndex);
+  bool connectQp(int peerIndex, const IbgdaTransportExchInfoAmd& peerInfo);
+  bool exportQpToGpu(int peerIndex);
+  void cleanup();
+
+  int rankToPeerIndex(int rank) const;
+  int peerIndexToRank(int peerIndex) const;
+  void initCommon();
+
+  // Rank info
+  const int myRank_;
+  const int nRanks_;
+  std::vector<int> targetRanks_; // Ranks to connect to (empty = all)
+  std::shared_ptr<meta::comms::IBootstrap> bootstrap_;
+  MultipeerIbgdaTransportAmdConfig config_;
+
+  // IB verbs resources
+  ibv_context* ibvCtx_{nullptr};
+  ibv_pd* ibvPd_{nullptr};
+  union ibv_gid localGid_{};
+  enum ibv_mtu localMtu_ { IBV_MTU_4096 };
+  std::string gpuPciBusId_;
+
+  // Per-peer QP/CQ resources
+  struct PeerQpResources {
+    ibv_cq* cq{nullptr};
+    ibv_qp* qp{nullptr};
+    uint32_t qpNum{0};
+    pipes_gda_gpu_dev_verbs_qp* gpuQp{nullptr};
+    void* gpuUarBf{nullptr};
+    void* uarBfHostPtr{nullptr};
+    size_t uarBfSize{0};
+    struct mlx5dv_devx_uar* devxUar{
+        nullptr}; // Per-QP UAR to avoid BF contention
+    // Host pointers registered via hipHostRegister (must be unregistered)
+    void* registeredSqBuf{nullptr};
+    void* registeredCqBuf{nullptr};
+    void* registeredSqDbrecPage{nullptr};
+    void* registeredCqDbrecPage{nullptr}; // nullptr if same page as SQ
+  };
+  std::vector<PeerQpResources> peerResources_;
+
+  // Sink buffer for atomic return values
+  void* sinkBuffer_{nullptr};
+  ibv_mr* sinkMr_{nullptr};
+
+  // User-registered buffers
+  std::unordered_map<void*, ibv_mr*> registeredBuffers_;
+
+  // Device transports array (GPU memory)
+  P2pIbgdaTransportDevice* peerTransportsGpu_{nullptr};
+  std::size_t peerTransportSize_{0};
+
+  // mlx5 UAR (allocated for the connection)
+  void* uar_{nullptr};
+};
+
+} // namespace pipes_gda

--- a/comms/pipes/amd/MultipeerIbgdaTransportAmdHip.cu
+++ b/comms/pipes/amd/MultipeerIbgdaTransportAmdHip.cu
@@ -1,0 +1,48 @@
+#if defined(__HIPCC__) || !defined(__CUDACC__)
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <hip/hip_runtime.h>
+
+#include "MultipeerIbgdaTransportAmdHip.h"
+#include "P2pIbgdaTransportDeviceAmd.h"
+
+namespace pipes_gda {
+
+void* buildDeviceTransportsOnGpuAmd(
+    const P2pIbgdaTransportBuildParamsAmd* params,
+    int numPeers) {
+  std::size_t elemSize = sizeof(P2pIbgdaTransportDevice);
+  void* gpuPtr = nullptr;
+
+  hipError_t err = hipMalloc(&gpuPtr, numPeers * elemSize);
+  if (err != hipSuccess)
+    return nullptr;
+
+  for (int i = 0; i < numPeers; i++) {
+    P2pIbgdaTransportDevice hostTransport(
+        params[i].gpuQp, nullptr, params[i].sinkLkey, params[i].sinkBufPtr);
+    err = hipMemcpy(
+        reinterpret_cast<char*>(gpuPtr) + i * elemSize,
+        &hostTransport,
+        elemSize,
+        hipMemcpyHostToDevice);
+    if (err != hipSuccess) {
+      hipFree(gpuPtr);
+      return nullptr;
+    }
+  }
+
+  return gpuPtr;
+}
+
+void freeDeviceTransportsOnGpuAmd(void* ptr) {
+  if (ptr)
+    hipFree(ptr);
+}
+
+std::size_t getP2pIbgdaTransportDeviceSizeAmd() {
+  return sizeof(P2pIbgdaTransportDevice);
+}
+
+} // namespace pipes_gda
+#endif

--- a/comms/pipes/amd/MultipeerIbgdaTransportAmdHip.h
+++ b/comms/pipes/amd/MultipeerIbgdaTransportAmdHip.h
@@ -1,0 +1,31 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "PipesGdaShared.h"
+#include "verbs/VerbsDev.h"
+
+namespace pipes_gda {
+
+struct P2pIbgdaTransportBuildParamsAmd {
+  pipes_gda_gpu_dev_verbs_qp* gpuQp{nullptr};
+  NetworkLKey sinkLkey{};
+  void* sinkBufPtr{nullptr};
+};
+
+// Build array of P2pIbgdaTransportDevice on GPU memory.
+// Returns opaque pointer (cast to P2pIbgdaTransportDevice* in device code).
+void* buildDeviceTransportsOnGpuAmd(
+    const P2pIbgdaTransportBuildParamsAmd* params,
+    int numPeers);
+
+// Free GPU transport memory
+void freeDeviceTransportsOnGpuAmd(void* ptr);
+
+// Get sizeof(P2pIbgdaTransportDevice)
+std::size_t getP2pIbgdaTransportDeviceSizeAmd();
+
+} // namespace pipes_gda

--- a/comms/pipes/amd/PipesGdaShared.h
+++ b/comms/pipes/amd/PipesGdaShared.h
@@ -1,0 +1,73 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// =============================================================================
+// PipesGdaShared — Re-exports shared comms::pipes types into pipes_gda
+// =============================================================================
+//
+// The shared comms::pipes headers (ThreadGroup.cuh, Timeout.cuh, IbgdaBuffer.h)
+// support both CUDA and HIP. This header re-exports all their types into the
+// pipes_gda namespace so AMD code can use a consistent namespace.
+
+#pragma once
+
+#include "comms/pipes/IbgdaBuffer.h"
+#include "comms/pipes/ThreadGroup.cuh"
+#include "comms/pipes/Timeout.cuh"
+
+namespace pipes_gda {
+
+// ---------------------------------------------------------------------------
+// IbgdaBuffer types
+// ---------------------------------------------------------------------------
+using comms::pipes::HostLKey;
+using comms::pipes::HostRKey;
+using comms::pipes::IbgdaBufferExchInfo;
+using comms::pipes::IbgdaCmpOp;
+using comms::pipes::IbgdaLocalBuffer;
+using comms::pipes::IbgdaRemoteBuffer;
+using comms::pipes::IbgdaSignalOp;
+using comms::pipes::NetworkLKey;
+using comms::pipes::NetworkRKey;
+
+// ---------------------------------------------------------------------------
+// ThreadGroup types and factory functions
+// ---------------------------------------------------------------------------
+using comms::pipes::PartitionResult;
+using comms::pipes::SyncScope;
+using comms::pipes::ThreadGroup;
+
+using comms::pipes::make_block_group;
+using comms::pipes::make_multiwarp_group;
+using comms::pipes::make_thread_group;
+using comms::pipes::make_thread_solo;
+using comms::pipes::make_warp_group;
+
+// AMD alias: make_wavefront_group() = make_warp_group()
+// (kWarpSize is already 64 on AMD via DeviceConstants.cuh)
+__device__ inline ThreadGroup make_wavefront_group() {
+  return comms::pipes::make_warp_group();
+}
+
+using comms::device::kWarpSize;
+constexpr uint32_t kWavefrontSize = comms::device::kWarpSize;
+constexpr uint32_t kMultiwarpWavefrontCount = 4;
+using comms::pipes::kMaxMultiwarpsPerBlock;
+using comms::pipes::kMultiwarpSize;
+
+// ---------------------------------------------------------------------------
+// Timeout types and helpers
+// ---------------------------------------------------------------------------
+using comms::pipes::gpu_clock64;
+using comms::pipes::Timeout;
+
+// AMD wall_clock64() clock rate: 100 MHz = 100 ticks per microsecond
+constexpr uint64_t kAmdWallClockTicksPerUs = 100;
+
+// Convenience: create a Timeout from microseconds (AMD wall_clock64 @ 100 MHz)
+inline Timeout make_timeout_us(uint64_t timeoutUs) {
+  return Timeout(timeoutUs * kAmdWallClockTicksPerUs);
+}
+
+} // namespace pipes_gda
+
+// TIMEOUT_TRAP_IF_EXPIRED_SINGLE is already defined in comms/pipes/Timeout.cuh

--- a/comms/pipes/amd/nic/Mlx5Hsi.h
+++ b/comms/pipes/amd/nic/Mlx5Hsi.h
@@ -1,0 +1,270 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved. SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Modifications: (c) Meta Platforms, Inc. and affiliates.
+
+// =============================================================================
+// MLX5 (Mellanox/NVIDIA ConnectX) Hardware-Software Interface for pipes-gda
+// =============================================================================
+//
+// MLX5 NIC WQE, CQE, and doorbell structures for GPU-initiated RDMA.
+// MLX5 hardware interface definitions for GPU-initiated RDMA.
+//
+// This file is the MLX5 equivalent of BnxtHsi.h:
+//   - WQE segment structs (data, control, raddr, atomic, inline)
+//   - CQE structs (cqe64, error CQE)
+//   - MLX5 opcodes, control flags, CQE status codes
+//   - MLX5-specific constants (SQ shift, doorbell record indices)
+// =============================================================================
+
+#pragma once
+
+#include <linux/types.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// =============================================================================
+// MLX5 WQE Constants
+// =============================================================================
+
+#define PIPES_GDA_IB_MLX5_WQE_SQ_SHIFT 6
+
+// =============================================================================
+// MLX5 WQE Opcodes
+// =============================================================================
+
+enum {
+  PIPES_GDA_IB_MLX5_OPCODE_NOP = 0x00,
+  PIPES_GDA_IB_MLX5_OPCODE_SEND_INVAL = 0x01,
+  PIPES_GDA_IB_MLX5_OPCODE_RDMA_WRITE = 0x08,
+  PIPES_GDA_IB_MLX5_OPCODE_RDMA_WRITE_IMM = 0x09,
+  PIPES_GDA_IB_MLX5_OPCODE_SEND = 0x0a,
+  PIPES_GDA_IB_MLX5_OPCODE_SEND_IMM = 0x0b,
+  PIPES_GDA_IB_MLX5_OPCODE_TSO = 0x0e,
+  PIPES_GDA_IB_MLX5_OPCODE_RDMA_READ = 0x10,
+  PIPES_GDA_IB_MLX5_OPCODE_ATOMIC_CS = 0x11,
+  PIPES_GDA_IB_MLX5_OPCODE_ATOMIC_FA = 0x12,
+  PIPES_GDA_IB_MLX5_OPCODE_ATOMIC_MASKED_CS = 0x14,
+  PIPES_GDA_IB_MLX5_OPCODE_ATOMIC_MASKED_FA = 0x15,
+  PIPES_GDA_IB_MLX5_OPCODE_FMR = 0x19,
+  PIPES_GDA_IB_MLX5_OPCODE_LOCAL_INVAL = 0x1b,
+  PIPES_GDA_IB_MLX5_OPCODE_WAIT = 0x0f,
+  PIPES_GDA_IB_MLX5_OPCODE_CONFIG_CMD = 0x1f,
+  PIPES_GDA_IB_MLX5_OPCODE_SET_PSV = 0x20,
+  PIPES_GDA_IB_MLX5_OPCODE_DUMP = 0x23,
+  PIPES_GDA_IB_MLX5_OPCODE_UMR = 0x25,
+  PIPES_GDA_IB_MLX5_OPCODE_TAG_MATCHING = 0x28,
+  PIPES_GDA_IB_MLX5_OPCODE_FLOW_TBL_ACCESS = 0x2c,
+  PIPES_GDA_IB_MLX5_OPCODE_MMO = 0x2F,
+};
+
+// =============================================================================
+// MLX5 WQE Control Flags
+// =============================================================================
+
+enum {
+  PIPES_GDA_IB_MLX5_WQE_CTRL_CE_CQE_ON_CQE_ERROR = 0x0,
+  PIPES_GDA_IB_MLX5_WQE_CTRL_CE_CQE_ON_FIRST_CQE_ERROR = 0x1,
+  PIPES_GDA_IB_MLX5_WQE_CTRL_CE_CQE_ALWAYS = 0x2,
+  PIPES_GDA_IB_MLX5_WQE_CTRL_CE_CQE_AND_EQE = 0x3,
+};
+
+enum {
+  PIPES_GDA_IB_MLX5_WQE_CTRL_FM_NO_FENCE = 0x0,
+  PIPES_GDA_IB_MLX5_WQE_CTRL_FM_INITIATOR_SMALL_FENCE = 0x1,
+  PIPES_GDA_IB_MLX5_WQE_CTRL_FM_FENCE = 0x2,
+  PIPES_GDA_IB_MLX5_WQE_CTRL_FM_STRONG_ORDERING = 0x3,
+  PIPES_GDA_IB_MLX5_WQE_CTRL_FM_FENCE_AND_INITIATOR_SMALL_FENCE = 0x4,
+  PIPES_GDA_IB_MLX5_WQE_CTRL_FM_CUSTOM = 0x100,
+};
+
+enum pipes_gda_gpu_dev_verbs_wqe_ctrl_flags {
+  PIPES_GDA_IB_MLX5_WQE_CTRL_CQ_UPDATE =
+      PIPES_GDA_IB_MLX5_WQE_CTRL_CE_CQE_ALWAYS << 2,
+  PIPES_GDA_IB_MLX5_WQE_CTRL_CQ_ERROR_UPDATE =
+      PIPES_GDA_IB_MLX5_WQE_CTRL_CE_CQE_ON_CQE_ERROR << 2,
+  PIPES_GDA_IB_MLX5_WQE_CTRL_CQ_FIRST_CQE_ERROR =
+      PIPES_GDA_IB_MLX5_WQE_CTRL_CE_CQE_ON_FIRST_CQE_ERROR << 2,
+  PIPES_GDA_IB_MLX5_WQE_CTRL_SOLICITED = 1 << 1,
+  PIPES_GDA_IB_MLX5_WQE_CTRL_FENCE =
+      PIPES_GDA_IB_MLX5_WQE_CTRL_FM_FENCE_AND_INITIATOR_SMALL_FENCE << 5,
+  PIPES_GDA_IB_MLX5_WQE_CTRL_INITIATOR_SMALL_FENCE =
+      PIPES_GDA_IB_MLX5_WQE_CTRL_FM_INITIATOR_SMALL_FENCE << 5,
+  PIPES_GDA_IB_MLX5_WQE_CTRL_STRONG_ORDERING =
+      PIPES_GDA_IB_MLX5_WQE_CTRL_FM_STRONG_ORDERING << 5
+};
+
+// =============================================================================
+// MLX5 Doorbell Record Indices
+// =============================================================================
+
+enum {
+  PIPES_GDA_IB_MLX5_RCV_DBR = 0,
+  PIPES_GDA_IB_MLX5_SND_DBR = 1,
+};
+
+// =============================================================================
+// MLX5 WQE Segment Count Constants
+// =============================================================================
+
+enum {
+  PIPES_GDA_VERBS_WQE_SEG_CNT_RDMA_WRITE_INL_MIN = 3,
+  PIPES_GDA_VERBS_WQE_SEG_CNT_RDMA_WRITE_INL_MAX = 4,
+  PIPES_GDA_VERBS_WQE_SEG_CNT_ATOMIC_FA_CAS = 4,
+  PIPES_GDA_VERBS_WQE_SEG_CNT_WAIT = 2
+};
+
+enum {
+  PIPES_GDA_IB_MLX5_INLINE_SEG = 0x80000000,
+};
+
+// =============================================================================
+// MLX5 CQE Status Codes
+// =============================================================================
+
+#define PIPES_GDA_VERBS_MLX5_CQE_OPCODE_SHIFT 4
+
+enum {
+  PIPES_GDA_IB_MLX5_CQE_OWNER_MASK = 1,
+  PIPES_GDA_IB_MLX5_CQE_REQ = 0,
+  PIPES_GDA_IB_MLX5_CQE_RESP_WR_IMM = 1,
+  PIPES_GDA_IB_MLX5_CQE_RESP_SEND = 2,
+  PIPES_GDA_IB_MLX5_CQE_RESP_SEND_IMM = 3,
+  PIPES_GDA_IB_MLX5_CQE_RESP_SEND_INV = 4,
+  PIPES_GDA_IB_MLX5_CQE_RESIZE_CQ = 5,
+  PIPES_GDA_IB_MLX5_CQE_NO_PACKET = 6,
+  PIPES_GDA_IB_MLX5_CQE_SIG_ERR = 12,
+  PIPES_GDA_IB_MLX5_CQE_REQ_ERR = 13,
+  PIPES_GDA_IB_MLX5_CQE_RESP_ERR = 14,
+  PIPES_GDA_IB_MLX5_CQE_INVALID = 15,
+};
+
+// =============================================================================
+// MLX5 WQE Segment Structures
+// =============================================================================
+
+struct pipes_gda_ib_mlx5_wqe_data_seg {
+  __be32 byte_count;
+  __be32 lkey;
+  __be64 addr;
+};
+
+struct pipes_gda_ib_mlx5_wqe_ctrl_seg {
+  __be32 opmod_idx_opcode;
+  __be32 qpn_ds;
+  uint8_t signature;
+  __be16 dci_stream_channel_id;
+  uint8_t fm_ce_se;
+  __be32 imm;
+} __attribute__((__packed__)) __attribute__((__aligned__(4)));
+
+struct pipes_gda_ib_mlx5_wqe_raddr_seg {
+  __be64 raddr;
+  __be32 rkey;
+  __be32 reserved;
+};
+
+struct pipes_gda_ib_mlx5_wqe_atomic_seg {
+  __be64 swap_add;
+  __be64 compare;
+};
+
+struct pipes_gda_ib_mlx5_wqe_inl_data_seg {
+  uint32_t byte_count;
+};
+
+// =============================================================================
+// MLX5 CQE Structures
+// =============================================================================
+
+struct pipes_gda_ib_mlx5_tm_cqe {
+  __be32 success;
+  __be16 hw_phase_cnt;
+  uint8_t rsvd0[12];
+};
+
+struct pipes_gda_ib_ibv_tmh {
+  uint8_t opcode;
+  uint8_t reserved[3];
+  __be32 app_ctx;
+  __be64 tag;
+};
+
+struct pipes_gda_ib_mlx5_cqe64 {
+  union {
+    struct {
+      uint8_t rsvd0[2];
+      __be16 wqe_id;
+      uint8_t rsvd4[13];
+      uint8_t ml_path;
+      uint8_t rsvd20[4];
+      __be16 slid;
+      __be32 flags_rqpn;
+      uint8_t hds_ip_ext;
+      uint8_t l4_hdr_type_etc;
+      __be16 vlan_info;
+    };
+    struct pipes_gda_ib_mlx5_tm_cqe tm_cqe;
+    struct pipes_gda_ib_ibv_tmh tmh;
+  };
+  __be32 srqn_uidx;
+  __be32 imm_inval_pkey;
+  uint8_t app;
+  uint8_t app_op;
+  __be16 app_info;
+  __be32 byte_cnt;
+  __be64 timestamp;
+  __be32 sop_drop_qpn;
+  __be16 wqe_counter;
+  uint8_t signature;
+  uint8_t op_own;
+};
+
+struct pipes_gda_ib_mlx5_err_cqe_ex {
+  uint8_t rsvd0[32];
+  __be32 srqn;
+  uint8_t rsvd1[16];
+  uint8_t hw_err_synd;
+  uint8_t hw_synd_type;
+  uint8_t vendor_err_synd;
+  uint8_t syndrome;
+  __be32 s_wqe_opcode_qpn;
+  __be16 wqe_counter;
+  uint8_t signature;
+  uint8_t op_own;
+};
+
+#ifdef __cplusplus
+}
+#endif

--- a/comms/pipes/amd/nic/Mlx5NicBackend.h
+++ b/comms/pipes/amd/nic/Mlx5NicBackend.h
@@ -1,0 +1,405 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved. SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Modifications: (c) Meta Platforms, Inc. and affiliates.
+
+// =============================================================================
+// MLX5 (Mellanox/NVIDIA ConnectX) NIC Backend for pipes-gda
+// =============================================================================
+//
+// Device-side WQE construction, doorbell, and CQ polling for mlx5 NICs.
+// Uses mlx5-specific WQE format (4 x 16-byte segments = 64 bytes),
+// DBREC + BlueFlame doorbell mechanism, and owner-bit CQE polling.
+//
+// This backend is used by P2pIbgdaTransportDevice<Mlx5NicBackend>.
+// =============================================================================
+
+#pragma once
+
+#include <cerrno>
+#include <cstddef>
+#include <cstdint>
+
+#include "nic/Mlx5Hsi.h" // @manual
+#include "verbs/AmdVerbsCompat.h" // @manual
+#include "verbs/VerbsDev.h" // @manual
+
+namespace pipes_gda {
+
+struct Mlx5NicBackend {
+  static constexpr const char* vendorPrefix() {
+    return "mlx5";
+  }
+  static constexpr uint16_t vendorId() {
+    return 0x02c9;
+  }
+  static inline uint32_t swapMkey(uint32_t key) {
+    return __builtin_bswap32(key);
+  }
+  static inline uint32_t networkByteOrderKey(uint32_t hostKey) {
+    return htobe32(hostKey);
+  }
+
+  __device__ pipes_gda_gpu_dev_verbs_wqe* getWqePtr(
+      pipes_gda_gpu_dev_verbs_qp* qp,
+      uint64_t wqeIdx) const {
+    uint16_t maskedIdx = static_cast<uint16_t>(wqeIdx) & qp->sq_wqe_mask;
+    return reinterpret_cast<pipes_gda_gpu_dev_verbs_wqe*>(qp->sq_wqe_daddr) +
+        maskedIdx;
+  }
+
+  __device__ uint64_t
+  reserveWqSlots(pipes_gda_gpu_dev_verbs_qp* qp, uint32_t numSlots) {
+    return amd_atomic_add_device(
+        &qp->sq_rsvd_index, static_cast<uint64_t>(numSlots));
+  }
+
+  __device__ void markWqesReady(
+      pipes_gda_gpu_dev_verbs_qp* qp,
+      uint64_t firstIdx,
+      uint64_t lastIdx) {
+    while (amd_load_relaxed_device(&qp->sq_ready_index) < firstIdx) {
+    }
+    // System-scope release fence: WQE data is in host memory (SQ buffer via
+    // hipHostRegister). Must be visible to the NIC (a PCIe device) before the
+    // doorbell ring. Agent-scope is insufficient — it only orders within the
+    // GPU's L2 cache domain.
+    amd_fence_release_system();
+    amd_atomic_max_device(&qp->sq_ready_index, lastIdx + 1);
+  }
+
+  __device__ void ringDoorbell(
+      pipes_gda_gpu_dev_verbs_qp* qp,
+      uint64_t nextWqeIdx) {
+    uint32_t pi =
+        static_cast<uint32_t>(nextWqeIdx) & PIPES_GDA_VERBS_WQE_PI_MASK;
+
+    *reinterpret_cast<volatile uint32_t*>(
+        qp->sq_dbrec + PIPES_GDA_IB_MLX5_SND_DBR) = amd_bswap32(pi);
+    __atomic_signal_fence(__ATOMIC_SEQ_CST);
+
+    uint64_t lastWqeIdx = nextWqeIdx - 1;
+    pipes_gda_gpu_dev_verbs_wqe* lastWqe = getWqePtr(qp, lastWqeIdx);
+    uint64_t dbVal = *reinterpret_cast<volatile uint64_t*>(lastWqe);
+
+    amd_store_doorbell_sys_u64(qp->sq_db, dbVal);
+
+    uint64_t dbAddr = __hip_atomic_load(
+        reinterpret_cast<uint64_t*>(&qp->sq_db),
+        __ATOMIC_RELAXED,
+        __HIP_MEMORY_SCOPE_AGENT);
+    dbAddr ^= 0x100;
+    __hip_atomic_store(
+        reinterpret_cast<uint64_t*>(&qp->sq_db),
+        dbAddr,
+        __ATOMIC_RELAXED,
+        __HIP_MEMORY_SCOPE_AGENT);
+  }
+
+  __device__ void prepareRdmaWriteWqe(
+      pipes_gda_gpu_dev_verbs_qp* qp,
+      pipes_gda_gpu_dev_verbs_wqe* wqe,
+      uint64_t wqeIdx,
+      uint8_t ctrlFlags,
+      uint64_t remoteAddr,
+      uint32_t remoteKey,
+      uint64_t localAddr,
+      uint32_t localKey,
+      std::size_t size) {
+    pipes_gda_gpu_dev_verbs_wqe_ctrl_seg cseg = {};
+    cseg.opmod_idx_opcode = amd_bswap32(
+        (static_cast<uint32_t>(wqeIdx) << PIPES_GDA_VERBS_WQE_IDX_SHIFT) |
+        PIPES_GDA_IB_MLX5_OPCODE_RDMA_WRITE);
+    cseg.qpn_ds = amd_bswap32(qp->sq_num_shift8 | 3);
+    cseg.fm_ce_se = ctrlFlags;
+
+    pipes_gda_ib_mlx5_wqe_raddr_seg rseg = {};
+    rseg.raddr = amd_bswap64(remoteAddr);
+    rseg.rkey = remoteKey;
+
+    pipes_gda_ib_mlx5_wqe_data_seg dseg = {};
+    dseg.byte_count = amd_bswap32(static_cast<uint32_t>(size));
+    dseg.lkey = localKey;
+    dseg.addr = amd_bswap64(localAddr);
+
+    amd_store_wqe_seg(
+        reinterpret_cast<uint64_t*>(&wqe->dseg0),
+        reinterpret_cast<uint64_t*>(&cseg));
+    amd_store_wqe_seg(
+        reinterpret_cast<uint64_t*>(&wqe->dseg1),
+        reinterpret_cast<uint64_t*>(&rseg));
+    amd_store_wqe_seg(
+        reinterpret_cast<uint64_t*>(&wqe->dseg2),
+        reinterpret_cast<uint64_t*>(&dseg));
+  }
+
+  __device__ void prepareAtomicFaWqe(
+      pipes_gda_gpu_dev_verbs_qp* qp,
+      pipes_gda_gpu_dev_verbs_wqe* wqe,
+      uint64_t wqeIdx,
+      uint8_t ctrlFlags,
+      uint64_t remoteAddr,
+      uint32_t remoteKey,
+      uint64_t localAddr,
+      uint32_t localKey,
+      uint64_t addVal) {
+    pipes_gda_gpu_dev_verbs_wqe_ctrl_seg cseg = {};
+    cseg.opmod_idx_opcode = amd_bswap32(
+        (static_cast<uint32_t>(wqeIdx) << PIPES_GDA_VERBS_WQE_IDX_SHIFT) |
+        PIPES_GDA_IB_MLX5_OPCODE_ATOMIC_FA);
+    cseg.qpn_ds = amd_bswap32(
+        qp->sq_num_shift8 | PIPES_GDA_VERBS_WQE_SEG_CNT_ATOMIC_FA_CAS);
+    cseg.fm_ce_se = ctrlFlags;
+
+    pipes_gda_ib_mlx5_wqe_raddr_seg rseg = {};
+    rseg.raddr = amd_bswap64(remoteAddr);
+    rseg.rkey = remoteKey;
+
+    pipes_gda_ib_mlx5_wqe_atomic_seg aseg = {};
+    aseg.swap_add = amd_bswap64(addVal);
+    aseg.compare = 0;
+
+    pipes_gda_ib_mlx5_wqe_data_seg dseg = {};
+    dseg.byte_count = amd_bswap32(sizeof(uint64_t));
+    dseg.lkey = localKey;
+    dseg.addr = amd_bswap64(localAddr);
+
+    amd_store_wqe_seg(
+        reinterpret_cast<uint64_t*>(&wqe->dseg0),
+        reinterpret_cast<uint64_t*>(&cseg));
+    amd_store_wqe_seg(
+        reinterpret_cast<uint64_t*>(&wqe->dseg1),
+        reinterpret_cast<uint64_t*>(&rseg));
+    amd_store_wqe_seg(
+        reinterpret_cast<uint64_t*>(&wqe->dseg2),
+        reinterpret_cast<uint64_t*>(&aseg));
+    amd_store_wqe_seg(
+        reinterpret_cast<uint64_t*>(&wqe->dseg3),
+        reinterpret_cast<uint64_t*>(&dseg));
+  }
+
+  __device__ void prepareNopWqe(
+      pipes_gda_gpu_dev_verbs_qp* qp,
+      pipes_gda_gpu_dev_verbs_wqe* wqe,
+      uint64_t wqeIdx) {
+    pipes_gda_gpu_dev_verbs_wqe_ctrl_seg cseg = {};
+    cseg.opmod_idx_opcode = amd_bswap32(
+        (static_cast<uint32_t>(wqeIdx) << PIPES_GDA_VERBS_WQE_IDX_SHIFT) |
+        PIPES_GDA_IB_MLX5_OPCODE_NOP);
+    cseg.qpn_ds = amd_bswap32(qp->sq_num_shift8 | 1);
+    cseg.fm_ce_se = PIPES_GDA_IB_MLX5_WQE_CTRL_CQ_UPDATE;
+
+    amd_store_wqe_seg(
+        reinterpret_cast<uint64_t*>(&wqe->dseg0),
+        reinterpret_cast<uint64_t*>(&cseg));
+  }
+
+  // ===========================================================================
+  // prepareInlineWriteWqe - Construct inline RDMA Write WQE
+  // ===========================================================================
+  //
+  // Builds a 3-segment WQE: ctrl + raddr + inline data.
+  // Used by reset_signal() to write a zero to the remote signal buffer
+  // without needing a local memory region (data is embedded in the WQE).
+  template <typename T>
+  __device__ void prepareInlineWriteWqe(
+      pipes_gda_gpu_dev_verbs_qp* qp,
+      pipes_gda_gpu_dev_verbs_wqe* wqe,
+      uint64_t wqeIdx,
+      uint8_t ctrlFlags,
+      uint64_t remoteAddr,
+      uint32_t remoteKey,
+      T value) {
+    static_assert(
+        sizeof(T) <= PIPES_GDA_VERBS_MAX_INLINE_SIZE, "inline too large");
+
+    uint32_t dsCount = (sizeof(T) <= 16)
+        ? PIPES_GDA_VERBS_WQE_SEG_CNT_RDMA_WRITE_INL_MIN
+        : PIPES_GDA_VERBS_WQE_SEG_CNT_RDMA_WRITE_INL_MAX;
+
+    pipes_gda_gpu_dev_verbs_wqe_ctrl_seg cseg = {};
+    cseg.opmod_idx_opcode = amd_bswap32(
+        (static_cast<uint32_t>(wqeIdx) << PIPES_GDA_VERBS_WQE_IDX_SHIFT) |
+        PIPES_GDA_IB_MLX5_OPCODE_RDMA_WRITE);
+    cseg.qpn_ds = amd_bswap32(qp->sq_num_shift8 | dsCount);
+    cseg.fm_ce_se = ctrlFlags;
+
+    pipes_gda_ib_mlx5_wqe_raddr_seg rseg = {};
+    rseg.raddr = amd_bswap64(remoteAddr);
+    rseg.rkey = remoteKey;
+
+    // Inline data segment: header (4 bytes) + payload
+    struct {
+      pipes_gda_ib_mlx5_wqe_inl_data_seg hdr;
+      T payload;
+    } __attribute__((__packed__)) inlSeg = {};
+
+    inlSeg.hdr.byte_count = amd_bswap32(
+        static_cast<uint32_t>(sizeof(T)) | PIPES_GDA_IB_MLX5_INLINE_SEG);
+    inlSeg.payload = value;
+
+    amd_store_wqe_seg(
+        reinterpret_cast<uint64_t*>(&wqe->dseg0),
+        reinterpret_cast<uint64_t*>(&cseg));
+    amd_store_wqe_seg(
+        reinterpret_cast<uint64_t*>(&wqe->dseg1),
+        reinterpret_cast<uint64_t*>(&rseg));
+    amd_store_wqe_seg(
+        reinterpret_cast<uint64_t*>(&wqe->dseg2),
+        reinterpret_cast<uint64_t*>(&inlSeg));
+  }
+
+  // ===========================================================================
+  // prepareWaitWqe - Construct WAIT WQE for cross-QP synchronization
+  // ===========================================================================
+  //
+  // Builds a 2-segment WQE: ctrl + wait. The WAIT WQE tells the NIC to stall
+  // processing on this QP until the referenced CQ has completed the target WQE.
+  // Used by companion QP to wait on main QP completion before posting counter.
+  __device__ void prepareWaitWqe(
+      pipes_gda_gpu_dev_verbs_qp* qp,
+      pipes_gda_gpu_dev_verbs_wqe* wqe,
+      uint64_t wqeIdx,
+      uint8_t ctrlFlags,
+      uint32_t targetCqNum,
+      uint64_t targetWqeIdx) {
+    pipes_gda_gpu_dev_verbs_wqe_ctrl_seg cseg = {};
+    cseg.opmod_idx_opcode = amd_bswap32(
+        (static_cast<uint32_t>(wqeIdx) << PIPES_GDA_VERBS_WQE_IDX_SHIFT) |
+        PIPES_GDA_IB_MLX5_OPCODE_WAIT);
+    cseg.qpn_ds =
+        amd_bswap32(qp->sq_num_shift8 | PIPES_GDA_VERBS_WQE_SEG_CNT_WAIT);
+    cseg.fm_ce_se = ctrlFlags;
+
+    pipes_gda_gpu_dev_verbs_wqe_wait_seg wseg = {};
+    wseg.max_index = amd_bswap32(
+        static_cast<uint32_t>(targetWqeIdx) & PIPES_GDA_VERBS_WQE_PI_MASK);
+    wseg.qpn_cqn = amd_bswap32(targetCqNum);
+
+    amd_store_wqe_seg(
+        reinterpret_cast<uint64_t*>(&wqe->dseg0),
+        reinterpret_cast<uint64_t*>(&cseg));
+    amd_store_wqe_seg(
+        reinterpret_cast<uint64_t*>(&wqe->dseg1),
+        reinterpret_cast<uint64_t*>(&wseg));
+  }
+
+  // ===========================================================================
+  // pollOneCqAt - Non-blocking CQ poll at a specific index
+  // ===========================================================================
+  //
+  // Returns 0 on success, EBUSY if not yet complete.
+  // Unlike pollCqAt() which spins until completion, this returns immediately
+  // so the caller can implement timeout logic.
+  __device__ int pollOneCqAt(
+      pipes_gda_gpu_dev_verbs_cq* cq,
+      uint64_t consIndex) {
+    pipes_gda_ib_mlx5_cqe64* cqeBase =
+        reinterpret_cast<pipes_gda_ib_mlx5_cqe64*>(cq->cqe_daddr);
+    const uint32_t cqeNum = cq->cqe_num;
+    uint32_t idx = static_cast<uint32_t>(consIndex) & (cqeNum - 1);
+    pipes_gda_ib_mlx5_cqe64* cqe64 = &cqeBase[idx];
+
+    uint64_t cqeCi = amd_load_relaxed_device(&cq->cqe_ci);
+    if (consIndex < cqeCi)
+      return 0;
+
+    if (consIndex >= cqeCi + cqeNum)
+      return EBUSY;
+
+    uint32_t cqeChunk =
+        amd_load_relaxed_sys(reinterpret_cast<uint32_t*>(&cqe64->wqe_counter));
+    cqeChunk = amd_bswap32(cqeChunk);
+    uint16_t wqeCounter = cqeChunk >> 16;
+    uint8_t opown = cqeChunk & 0xff;
+
+    if ((opown & PIPES_GDA_IB_MLX5_CQE_OWNER_MASK) ^ !!(consIndex & cqeNum))
+      return EBUSY;
+    if (wqeCounter != (static_cast<uint32_t>(consIndex) & 0xffff))
+      return EBUSY;
+
+    uint8_t opcode = opown >> PIPES_GDA_VERBS_MLX5_CQE_OPCODE_SHIFT;
+
+    amd_fence_acquire_system();
+    amd_atomic_max_device(&cq->cqe_ci, consIndex + 1);
+
+    uint32_t ci =
+        static_cast<uint32_t>(consIndex + 1) & PIPES_GDA_VERBS_CQE_CI_MASK;
+    amd_store_release_sys_u32(
+        reinterpret_cast<uint32_t*>(cq->dbrec), amd_bswap32(ci));
+
+    return (opcode == PIPES_GDA_IB_MLX5_CQE_REQ_ERR) ? -5 : 0;
+  }
+
+  __device__ int pollCqAt(
+      pipes_gda_gpu_dev_verbs_qp* qp,
+      pipes_gda_gpu_dev_verbs_cq* cq,
+      uint64_t consIndex) {
+    pipes_gda_ib_mlx5_cqe64* cqeBase =
+        reinterpret_cast<pipes_gda_ib_mlx5_cqe64*>(cq->cqe_daddr);
+    const uint32_t cqeNum = cq->cqe_num;
+    uint32_t idx = static_cast<uint32_t>(consIndex) & (cqeNum - 1);
+    pipes_gda_ib_mlx5_cqe64* cqe64 = &cqeBase[idx];
+
+    uint8_t opown;
+    uint32_t cqeChunk;
+    uint16_t wqeCounter;
+
+    do {
+      uint64_t cqeCi = amd_load_relaxed_device(&cq->cqe_ci);
+      if (consIndex < cqeCi)
+        return 0;
+
+      cqeChunk = amd_load_relaxed_sys(
+          reinterpret_cast<uint32_t*>(&cqe64->wqe_counter));
+      cqeChunk = amd_bswap32(cqeChunk);
+      wqeCounter = cqeChunk >> 16;
+      opown = cqeChunk & 0xff;
+    } while (
+        (consIndex >= amd_load_relaxed_device(&cq->cqe_ci) + cqeNum) ||
+        ((opown & PIPES_GDA_IB_MLX5_CQE_OWNER_MASK) ^ !!(consIndex & cqeNum)) ||
+        (wqeCounter != (static_cast<uint32_t>(consIndex) & 0xffff)));
+
+    uint8_t opcode = opown >> PIPES_GDA_VERBS_MLX5_CQE_OPCODE_SHIFT;
+
+    amd_fence_acquire_system();
+    amd_atomic_max_device(&cq->cqe_ci, consIndex + 1);
+
+    uint32_t ci =
+        static_cast<uint32_t>(consIndex + 1) & PIPES_GDA_VERBS_CQE_CI_MASK;
+    amd_store_release_sys_u32(
+        reinterpret_cast<uint32_t*>(cq->dbrec), amd_bswap32(ci));
+
+    return (opcode == PIPES_GDA_IB_MLX5_CQE_REQ_ERR) ? -5 : 0;
+  }
+};
+
+} // namespace pipes_gda

--- a/comms/pipes/amd/nic/NicConfig.h
+++ b/comms/pipes/amd/nic/NicConfig.h
@@ -1,0 +1,28 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// =============================================================================
+// NIC Selection Configuration
+// =============================================================================
+//
+// Compile-time NIC selection for pipes-gda. Exactly one NIC type must be
+// defined via BUCK compiler_flags (e.g., -DNIC_MLX5 or -DNIC_BNXT).
+//
+// If no NIC is specified, NIC_MLX5 is used as the default for backward
+// compatibility.
+//
+// NIC-specific vendor prefix, vendor ID, byte order, and WQE/CQ logic are
+// provided by the NIC backend classes (Mlx5NicBackend, BnxtNicBackend, etc.)
+// selected at compile time via NicSelector.h.
+// =============================================================================
+
+#pragma once
+
+// Default to mlx5 if no NIC is specified
+#if !defined(NIC_MLX5) && !defined(NIC_BNXT) && !defined(NIC_IONIC)
+#define NIC_MLX5
+#endif
+
+// Validate: exactly one NIC must be selected
+#if (defined(NIC_MLX5) + defined(NIC_BNXT) + defined(NIC_IONIC)) > 1
+#error "Only one NIC type may be selected (NIC_MLX5, NIC_BNXT, NIC_IONIC)"
+#endif

--- a/comms/pipes/amd/nic/NicSelector.h
+++ b/comms/pipes/amd/nic/NicSelector.h
@@ -1,0 +1,39 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// =============================================================================
+// NIC Backend Selector for pipes-gda
+// =============================================================================
+//
+// This is the ONLY file in the project that uses #ifdef NIC_* to select the
+// active NIC backend. All other files use the ActiveNicBackend type alias.
+//
+// To add a new NIC:
+//   1. Create a new backend header (e.g., IonicNicBackend.h)
+//   2. Add a new #elif branch below
+//   3. Add the NIC_* define to NicConfig.h validation
+//   4. Add a new BUCK target with the appropriate compiler_flags
+// =============================================================================
+
+#pragma once
+
+#include "nic/NicConfig.h" // @manual
+
+#if defined(NIC_BNXT)
+#include "nic/BnxtNicBackend.h" // @manual
+#elif defined(NIC_IONIC)
+#include "nic/IonicNicBackend.h" // @manual
+#else
+#include "nic/Mlx5NicBackend.h" // @manual
+#endif
+
+namespace pipes_gda {
+
+#if defined(NIC_BNXT)
+using ActiveNicBackend = BnxtNicBackend;
+#elif defined(NIC_IONIC)
+using ActiveNicBackend = IonicNicBackend;
+#else
+using ActiveNicBackend = Mlx5NicBackend;
+#endif
+
+} // namespace pipes_gda

--- a/comms/pipes/amd/tests/MultipeerIbgdaTransportAmdTest.cu
+++ b/comms/pipes/amd/tests/MultipeerIbgdaTransportAmdTest.cu
@@ -1,0 +1,647 @@
+#if defined(__HIPCC__) || !defined(__CUDACC__)
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// =============================================================================
+// MultipeerIbgdaTransportTest — Real NIC Integration Tests
+// =============================================================================
+//
+// AMD/HIP port of comms/pipes/tests/MultipeerIbgdaTransportTest.cc.
+// Exercises P2pIbgdaTransportDevice methods over actual RDMA QPs.
+//
+// Requires 2 MPI ranks with AMD GPUs and RDMA NICs.
+// Uses MultipeerIbgdaTransportAmd for transport setup (matching NVIDIA
+// pattern).
+// =============================================================================
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <memory>
+#include <vector>
+
+#include <folly/init/Init.h>
+#include <folly/logging/xlog.h>
+
+#include <hip/hip_runtime.h>
+
+#include "HipDeviceBuffer.h"
+#include "MultipeerIbgdaTransportAmd.h"
+#include "MultipeerIbgdaTransportAmdTestKernels.h"
+#include "PipesGdaShared.h"
+
+#include "comms/testinfra/mpi/MpiBootstrap.h"
+#include "comms/testinfra/mpi/MpiTestUtils.h"
+
+using namespace meta::comms;
+using pipes_gda::HipDeviceBuffer;
+using pipes_gda::MultipeerIbgdaTransportAmd;
+using pipes_gda::MultipeerIbgdaTransportAmdConfig;
+
+namespace pipes_gda::tests {
+
+#define HIPCHECK_TEST(cmd)                                                    \
+  do {                                                                        \
+    hipError_t err = (cmd);                                                   \
+    if (err != hipSuccess) {                                                  \
+      FAIL() << "HIP error: " << hipGetErrorString(err) << " at " << __FILE__ \
+             << ":" << __LINE__;                                              \
+    }                                                                         \
+  } while (0)
+
+#define HIP_EXPECT(cmd)                                             \
+  do {                                                              \
+    hipError_t _hip_err = (cmd);                                    \
+    EXPECT_EQ(_hip_err, hipSuccess) << hipGetErrorString(_hip_err); \
+  } while (0)
+
+// Maximum number of signal slots used across all tests.
+static constexpr size_t kMaxSignalSlots = 16;
+static constexpr size_t kSignalBufferSize = kMaxSignalSlots * sizeof(uint64_t);
+
+// =============================================================================
+// Test Fixture — uses MultipeerIbgdaTransportAmd (matching NVIDIA pattern)
+// =============================================================================
+
+class MultipeerIbgdaTransportTestFixture : public MpiBaseTestFixture {
+ protected:
+  void SetUp() override {
+    MpiBaseTestFixture::SetUp();
+    HIPCHECK_TEST(hipSetDevice(localRank));
+  }
+
+  // Helper to create transport, buffers, and exchange with peer
+  void initTransport(size_t dataSize) {
+    if (numRanks != 2) {
+      GTEST_SKIP() << "Requires exactly 2 MPI ranks";
+    }
+
+    peerRank_ = (globalRank == 0) ? 1 : 0;
+
+    try {
+      MultipeerIbgdaTransportAmdConfig config{.hipDevice = localRank};
+      auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+      transport_ = std::make_unique<MultipeerIbgdaTransportAmd>(
+          globalRank, numRanks, bootstrap, config);
+      transport_->exchange();
+
+      // Allocate and register data buffer
+      dataBuffer_ = std::make_unique<HipDeviceBuffer>(dataSize);
+      localDataBuf_ = transport_->registerBuffer(dataBuffer_->get(), dataSize);
+      auto remoteDataBufs = transport_->exchangeBuffer(localDataBuf_);
+      int peerIndex = (peerRank_ < globalRank) ? peerRank_ : (peerRank_ - 1);
+      remoteDataBuf_ = remoteDataBufs[peerIndex];
+
+      // Allocate and register signal buffer
+      signalBuffer_ = std::make_unique<HipDeviceBuffer>(kSignalBufferSize);
+      HIPCHECK_TEST(hipMemset(signalBuffer_->get(), 0, kSignalBufferSize));
+      localSignalBuf_ =
+          transport_->registerBuffer(signalBuffer_->get(), kSignalBufferSize);
+      auto remoteSignalBufs = transport_->exchangeBuffer(localSignalBuf_);
+      remoteSignalBuf_ = remoteSignalBufs[peerIndex];
+
+      deviceTransport_ = transport_->getP2pTransportDevice(peerRank_);
+
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    } catch (const std::exception& e) {
+      GTEST_SKIP() << "AMD IBGDA transport not available: " << e.what();
+    }
+  }
+
+  // --- Verification helpers ---
+
+  void zeroDataBuffer(size_t nbytes) {
+    HIPCHECK_TEST(hipMemset(dataBuffer_->get(), 0, nbytes));
+    HIPCHECK_TEST(hipDeviceSynchronize());
+  }
+
+  uint64_t readSignalFromHost(int signalId = 0) {
+    uint64_t val = 0;
+    HIP_EXPECT(hipMemcpy(
+        &val,
+        static_cast<uint64_t*>(signalBuffer_->get()) + signalId,
+        sizeof(uint64_t),
+        hipMemcpyDeviceToHost));
+    return val;
+  }
+
+  bool verifyDataFromHost(size_t nbytes, uint8_t seed) {
+    bool* d_success = nullptr;
+    HIP_EXPECT(hipMalloc(&d_success, sizeof(bool)));
+    verifyBufferPattern(dataBuffer_->get(), nbytes, seed, d_success);
+    bool h_success = false;
+    HIP_EXPECT(
+        hipMemcpy(&h_success, d_success, sizeof(bool), hipMemcpyDeviceToHost));
+    HIP_EXPECT(hipFree(d_success));
+    return h_success;
+  }
+
+  bool* allocDeviceBool(bool initVal = false) {
+    bool* d_ptr = nullptr;
+    HIP_EXPECT(hipMalloc(&d_ptr, sizeof(bool)));
+    HIP_EXPECT(hipMemcpy(d_ptr, &initVal, sizeof(bool), hipMemcpyHostToDevice));
+    return d_ptr;
+  }
+
+  bool readDeviceBool(bool* d_ptr) {
+    bool val = false;
+    HIP_EXPECT(hipMemcpy(&val, d_ptr, sizeof(bool), hipMemcpyDeviceToHost));
+    return val;
+  }
+
+  void freeDeviceBool(bool* d_ptr) {
+    if (d_ptr)
+      HIPCHECK_TEST(hipFree(d_ptr));
+  }
+
+  int peerRank_{0};
+  std::unique_ptr<MultipeerIbgdaTransportAmd> transport_;
+  std::unique_ptr<HipDeviceBuffer> dataBuffer_;
+  std::unique_ptr<HipDeviceBuffer> signalBuffer_;
+  IbgdaLocalBuffer localDataBuf_;
+  IbgdaRemoteBuffer remoteDataBuf_;
+  IbgdaLocalBuffer localSignalBuf_;
+  IbgdaRemoteBuffer remoteSignalBuf_;
+  P2pIbgdaTransportDevice* deviceTransport_{nullptr};
+};
+
+// =============================================================================
+// 1. PutSignalBasic — put_signal() + wait_local(), verify data
+// =============================================================================
+
+TEST_F(MultipeerIbgdaTransportTestFixture, PutSignalBasic) {
+  constexpr size_t kDataSize = 4096;
+  constexpr uint8_t kSeed = 0x42;
+  initTransport(kDataSize);
+
+  if (globalRank == 0) {
+    fillBufferWithPattern(dataBuffer_->get(), kDataSize, kSeed);
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    runTestPutAndSignal(
+        deviceTransport_,
+        localDataBuf_,
+        remoteDataBuf_,
+        kDataSize,
+        remoteSignalBuf_,
+        0,
+        1, );
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  } else {
+    zeroDataBuffer(kDataSize);
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    bool* d_success = allocDeviceBool();
+    runTestWaitSignal(localSignalBuf_, 0, 1, d_success);
+    EXPECT_TRUE(readDeviceBool(d_success));
+    freeDeviceBool(d_success);
+
+    EXPECT_TRUE(verifyDataFromHost(kDataSize, kSeed))
+        << "Data verification failed on rank 1";
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  }
+}
+
+// =============================================================================
+// 2. PutSignalGroupBasic — put_signal_group_local() (wavefront group)
+// =============================================================================
+
+TEST_F(MultipeerIbgdaTransportTestFixture, PutSignalGroupBasic) {
+  constexpr size_t kDataSize = 64 * 1024;
+  constexpr uint8_t kSeed = 0xAB;
+  initTransport(kDataSize);
+
+  if (globalRank == 0) {
+    fillBufferWithPattern(dataBuffer_->get(), kDataSize, kSeed);
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    runTestPutAndSignalGroup(
+        deviceTransport_,
+        localDataBuf_,
+        remoteDataBuf_,
+        kDataSize,
+        remoteSignalBuf_,
+        0,
+        1, );
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  } else {
+    zeroDataBuffer(kDataSize);
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    bool* d_success = allocDeviceBool();
+    runTestWaitSignal(localSignalBuf_, 0, 1, d_success);
+    EXPECT_TRUE(readDeviceBool(d_success));
+    freeDeviceBool(d_success);
+
+    EXPECT_TRUE(verifyDataFromHost(kDataSize, kSeed));
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  }
+}
+
+// =============================================================================
+// 3. PutSignalGroupMultiWavefront — put_signal_group_global() multi-wavefront
+// =============================================================================
+
+TEST_F(MultipeerIbgdaTransportTestFixture, PutSignalGroupMultiWavefront) {
+  constexpr size_t kDataSize = 256 * 1024;
+  constexpr uint8_t kSeed = 0xCD;
+  initTransport(kDataSize);
+
+  if (globalRank == 0) {
+    fillBufferWithPattern(dataBuffer_->get(), kDataSize, kSeed);
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    runTestPutAndSignalGroupMultiWarp(
+        deviceTransport_,
+        localDataBuf_,
+        remoteDataBuf_,
+        kDataSize,
+        remoteSignalBuf_,
+        0,
+        1, );
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  } else {
+    zeroDataBuffer(kDataSize);
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    bool* d_success = allocDeviceBool();
+    runTestWaitSignal(localSignalBuf_, 0, 1, d_success);
+    EXPECT_TRUE(readDeviceBool(d_success));
+    freeDeviceBool(d_success);
+
+    EXPECT_TRUE(verifyDataFromHost(kDataSize, kSeed));
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  }
+}
+
+// =============================================================================
+// 4. PutSignalGroupBlock — put_signal_group_global() block-scope
+// =============================================================================
+
+TEST_F(MultipeerIbgdaTransportTestFixture, PutSignalGroupBlock) {
+  constexpr size_t kDataSize = 256 * 1024;
+  constexpr uint8_t kSeed = 0xEF;
+  initTransport(kDataSize);
+
+  if (globalRank == 0) {
+    fillBufferWithPattern(dataBuffer_->get(), kDataSize, kSeed);
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    runTestPutAndSignalGroupBlock(
+        deviceTransport_,
+        localDataBuf_,
+        remoteDataBuf_,
+        kDataSize,
+        remoteSignalBuf_,
+        0,
+        1, );
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  } else {
+    zeroDataBuffer(kDataSize);
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    bool* d_success = allocDeviceBool();
+    runTestWaitSignal(localSignalBuf_, 0, 1, d_success);
+    EXPECT_TRUE(readDeviceBool(d_success));
+    freeDeviceBool(d_success);
+
+    EXPECT_TRUE(verifyDataFromHost(kDataSize, kSeed));
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  }
+}
+
+// =============================================================================
+// 5. TransferSizeVariations — parameterized sizes
+// =============================================================================
+
+class TransferSizeTest
+    : public MultipeerIbgdaTransportTestFixture,
+      public ::testing::WithParamInterface<std::pair<size_t, const char*>> {};
+
+TEST_P(TransferSizeTest, PutSignal) {
+  auto [dataSize, label] = GetParam();
+  constexpr uint8_t kSeed = 0x77;
+
+  initTransport(dataSize);
+
+  if (globalRank == 0) {
+    fillBufferWithPattern(dataBuffer_->get(), dataSize, kSeed);
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    runTestPutAndSignal(
+        deviceTransport_,
+        localDataBuf_,
+        remoteDataBuf_,
+        dataSize,
+        remoteSignalBuf_,
+        0,
+        1, );
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  } else {
+    zeroDataBuffer(dataSize);
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    bool* d_success = allocDeviceBool();
+    runTestWaitSignal(localSignalBuf_, 0, 1, d_success);
+    EXPECT_TRUE(readDeviceBool(d_success));
+    freeDeviceBool(d_success);
+
+    EXPECT_TRUE(verifyDataFromHost(dataSize, kSeed))
+        << "Data verification failed for size " << label;
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    TransferSizeVariations,
+    TransferSizeTest,
+    ::testing::Values(
+        std::make_pair(size_t{1024}, "1KB"),
+        std::make_pair(size_t{4 * 1024}, "4KB"),
+        std::make_pair(size_t{64 * 1024}, "64KB"),
+        std::make_pair(size_t{256 * 1024}, "256KB"),
+        std::make_pair(size_t{1024 * 1024}, "1MB"),
+        std::make_pair(size_t{4 * 1024 * 1024}, "4MB"),
+        std::make_pair(size_t{16 * 1024 * 1024}, "16MB")));
+
+// =============================================================================
+// 6. Bidirectional — both ranks send and receive
+// =============================================================================
+
+TEST_F(MultipeerIbgdaTransportTestFixture, Bidirectional) {
+  constexpr size_t kDataSize = 4096;
+  constexpr uint8_t kSeedRank0 = 0x11;
+  constexpr uint8_t kSeedRank1 = 0x22;
+  // Allocate 2x: first half for send, second half for receive.
+  initTransport(2 * kDataSize);
+
+  // Send region: [0, kDataSize), Receive region: [kDataSize, 2*kDataSize)
+  auto remoteRecvBuf = remoteDataBuf_.subBuffer(kDataSize);
+
+  // Zero the receive region
+  HIPCHECK_TEST(hipMemset(
+      static_cast<char*>(dataBuffer_->get()) + kDataSize, 0, kDataSize));
+  HIPCHECK_TEST(hipDeviceSynchronize());
+
+  uint8_t mySeed = (globalRank == 0) ? kSeedRank0 : kSeedRank1;
+  fillBufferWithPattern(dataBuffer_->get(), kDataSize, mySeed);
+
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  // Both ranks: send data + signal to peer's receive region, wait for signal
+  bool* d_success = allocDeviceBool();
+  runTestBidirectionalPutAndWait(
+      deviceTransport_,
+      localDataBuf_,
+      remoteRecvBuf,
+      kDataSize,
+      remoteSignalBuf_,
+      0,
+      1,
+      localSignalBuf_,
+      0,
+      1,
+      d_success);
+  EXPECT_TRUE(readDeviceBool(d_success));
+  freeDeviceBool(d_success);
+
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  // Verify received data in the receive region (offset kDataSize)
+  uint8_t peerSeed = (globalRank == 0) ? kSeedRank1 : kSeedRank0;
+  bool* d_verify = allocDeviceBool();
+  verifyBufferPattern(
+      static_cast<char*>(dataBuffer_->get()) + kDataSize,
+      kDataSize,
+      peerSeed,
+      d_verify);
+  EXPECT_TRUE(readDeviceBool(d_verify))
+      << "Bidirectional data verification failed on rank " << globalRank;
+  freeDeviceBool(d_verify);
+
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+}
+
+// =============================================================================
+// 7. StressTest — 100 iterations of put+signal+verify
+// =============================================================================
+
+TEST_F(MultipeerIbgdaTransportTestFixture, StressTest) {
+  constexpr size_t kDataSize = 4096;
+  constexpr uint32_t kNumIters = 100;
+  initTransport(kDataSize);
+
+  int totalErrors = 0;
+
+  for (uint32_t iter = 0; iter < kNumIters; ++iter) {
+    const uint8_t testPattern = static_cast<uint8_t>(iter % 256);
+
+    if (globalRank == 0) {
+      fillBufferWithPattern(dataBuffer_->get(), kDataSize, testPattern);
+
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+      runTestPutAndSignal(
+          deviceTransport_,
+          localDataBuf_,
+          remoteDataBuf_,
+          kDataSize,
+          remoteSignalBuf_,
+          0,
+          iter + 1, );
+
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    } else {
+      zeroDataBuffer(kDataSize);
+
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+      bool* d_success = allocDeviceBool();
+      runTestWaitSignal(
+          localSignalBuf_, 0, static_cast<uint64_t>(iter + 1), d_success);
+      EXPECT_TRUE(readDeviceBool(d_success));
+      freeDeviceBool(d_success);
+
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+      if (!verifyDataFromHost(kDataSize, testPattern)) {
+        totalErrors++;
+      }
+    }
+  }
+
+  if (globalRank == 1) {
+    EXPECT_EQ(totalErrors, 0)
+        << "Stress test found " << totalErrors << " errors across " << kNumIters
+        << " iterations";
+  }
+}
+
+// =============================================================================
+// 8. SignalOnly — signal_remote() without data
+// =============================================================================
+
+TEST_F(MultipeerIbgdaTransportTestFixture, SignalOnly) {
+  constexpr size_t kDataSize = 64;
+  initTransport(kDataSize);
+
+  if (globalRank == 0) {
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    runTestSignalOnly(deviceTransport_, remoteSignalBuf_, 0, 42, );
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  } else {
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    bool* d_success = allocDeviceBool();
+    runTestWaitSignal(localSignalBuf_, 0, 42, d_success);
+    EXPECT_TRUE(readDeviceBool(d_success));
+    freeDeviceBool(d_success);
+
+    EXPECT_EQ(readSignalFromHost(0), 42u);
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  }
+}
+
+// =============================================================================
+// 9. ResetSignal — signal + reset cycle
+// =============================================================================
+
+TEST_F(MultipeerIbgdaTransportTestFixture, ResetSignal) {
+  constexpr size_t kDataSize = 64;
+  initTransport(kDataSize);
+
+  for (int iter = 0; iter < 3; ++iter) {
+    if (globalRank == 0) {
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+      runTestSignalOnly(deviceTransport_, remoteSignalBuf_, 0, 1, );
+
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+      runTestResetSignal(deviceTransport_, remoteSignalBuf_, 0);
+
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    } else {
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+      bool* d_success = allocDeviceBool();
+      runTestWaitSignal(localSignalBuf_, 0, 1, d_success);
+      EXPECT_TRUE(readDeviceBool(d_success))
+          << "Signal wait failed at iteration " << iter;
+      freeDeviceBool(d_success);
+
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+      // Wait for reset to complete
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+      EXPECT_EQ(readSignalFromHost(0), 0u)
+          << "Signal not reset at iteration " << iter;
+    }
+  }
+}
+
+// =============================================================================
+// 10. MultipleSignalSlots — multiple signal IDs
+// =============================================================================
+
+TEST_F(MultipeerIbgdaTransportTestFixture, MultipleSignalSlots) {
+  constexpr size_t kDataSize = 64;
+  constexpr int kNumSlots = 4;
+  initTransport(kDataSize);
+
+  if (globalRank == 0) {
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    for (int slot = 0; slot < kNumSlots; ++slot) {
+      runTestSignalOnly(
+          deviceTransport_,
+          remoteSignalBuf_,
+          slot,
+          static_cast<uint64_t>(slot + 1) * 100, );
+    }
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  } else {
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    for (int slot = 0; slot < kNumSlots; ++slot) {
+      uint64_t expected = static_cast<uint64_t>(slot + 1) * 100;
+      bool* d_success = allocDeviceBool();
+      runTestWaitSignal(localSignalBuf_, slot, expected, d_success);
+      EXPECT_TRUE(readDeviceBool(d_success))
+          << "Signal slot " << slot << " wait failed";
+      freeDeviceBool(d_success);
+
+      EXPECT_EQ(readSignalFromHost(slot), expected)
+          << "Signal slot " << slot << " value mismatch";
+    }
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  }
+}
+
+// =============================================================================
+// 11. PutSignalWaitForReady — ready/data handshake
+// =============================================================================
+
+TEST_F(MultipeerIbgdaTransportTestFixture, PutSignalWaitForReady) {
+  constexpr size_t kDataSize = 4096;
+  constexpr uint8_t kSeed = 0x99;
+  initTransport(kDataSize);
+
+  if (globalRank == 0) {
+    fillBufferWithPattern(dataBuffer_->get(), kDataSize, kSeed);
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    runTestWaitReadyThenPutAndSignal(
+        deviceTransport_,
+        localDataBuf_,
+        remoteDataBuf_,
+        kDataSize,
+        localSignalBuf_,
+        0, // readySignalId
+        1, // readyExpected
+        remoteSignalBuf_,
+        1, // dataSignalId
+        1, // dataSignalVal
+    );
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  } else {
+    zeroDataBuffer(kDataSize);
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    runTestSignalOnly(deviceTransport_, remoteSignalBuf_, 0, 1, );
+
+    bool* d_success = allocDeviceBool();
+    runTestWaitSignal(localSignalBuf_, 1, 1, d_success);
+    EXPECT_TRUE(readDeviceBool(d_success));
+    freeDeviceBool(d_success);
+
+    EXPECT_TRUE(verifyDataFromHost(kDataSize, kSeed));
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  }
+}
+
+} // namespace pipes_gda::tests
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  auto mpiEnv = std::make_unique<meta::comms::MPIEnvironmentBase>();
+  ::testing::AddGlobalTestEnvironment(mpiEnv.release());
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}
+#endif

--- a/comms/pipes/amd/tests/MultipeerIbgdaTransportAmdTestKernels.cu
+++ b/comms/pipes/amd/tests/MultipeerIbgdaTransportAmdTestKernels.cu
@@ -1,0 +1,622 @@
+#if defined(__HIPCC__) || !defined(__CUDACC__)
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// AMD/HIP port of comms/pipes/tests/MultipeerIbgdaTransportTest.cu
+// Kernel implementations for the multipeer IBGDA integration tests.
+
+#include "MultipeerIbgdaTransportAmdTestKernels.h"
+#include "P2pIbgdaTransportDeviceAmd.h"
+#include "PipesGdaShared.h"
+
+#include <hip/hip_runtime.h>
+
+namespace pipes_gda::tests {
+
+// =============================================================================
+// Data verification kernels
+// =============================================================================
+
+__global__ void
+fillBufferWithPatternKernel(uint8_t* buf, std::size_t nbytes, uint8_t seed) {
+  std::size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  std::size_t stride = gridDim.x * blockDim.x;
+  for (std::size_t i = idx; i < nbytes; i += stride) {
+    buf[i] = static_cast<uint8_t>((i % 251) ^ seed);
+  }
+}
+
+__global__ void verifyBufferPatternKernel(
+    const uint8_t* buf,
+    std::size_t nbytes,
+    uint8_t seed,
+    bool* success) {
+  std::size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  std::size_t stride = gridDim.x * blockDim.x;
+  for (std::size_t i = idx; i < nbytes; i += stride) {
+    uint8_t expected = static_cast<uint8_t>((i % 251) ^ seed);
+    if (buf[i] != expected) {
+      *success = false;
+      return;
+    }
+  }
+}
+
+void fillBufferWithPattern(void* d_buf, std::size_t nbytes, uint8_t seed) {
+  uint32_t threads = 256;
+  uint32_t blocks = (nbytes + threads - 1) / threads;
+  if (blocks > 1024)
+    blocks = 1024;
+  fillBufferWithPatternKernel<<<blocks, threads>>>(
+      static_cast<uint8_t*>(d_buf), nbytes, seed);
+  (void)hipDeviceSynchronize();
+}
+
+void verifyBufferPattern(
+    const void* d_buf,
+    std::size_t nbytes,
+    uint8_t seed,
+    bool* d_success) {
+  bool initVal = true;
+  (void)hipMemcpy(d_success, &initVal, sizeof(bool), hipMemcpyHostToDevice);
+  uint32_t threads = 256;
+  uint32_t blocks = (nbytes + threads - 1) / threads;
+  if (blocks > 1024)
+    blocks = 1024;
+  verifyBufferPatternKernel<<<blocks, threads>>>(
+      static_cast<const uint8_t*>(d_buf), nbytes, seed, d_success);
+  (void)hipDeviceSynchronize();
+}
+
+// =============================================================================
+// Sender-side kernels
+// =============================================================================
+
+__global__ void putAndSignalKernel(
+    P2pIbgdaTransportDevice* transportPtr,
+    IbgdaLocalBuffer localDataBuf,
+    IbgdaRemoteBuffer remoteDataBuf,
+    std::size_t nbytes,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    int signalId,
+    uint64_t signalVal) {
+  if (threadIdx.x != 0 || blockIdx.x != 0)
+    return;
+
+  auto& transport = *transportPtr;
+  IbgdaWork work = transport.put_signal(
+      localDataBuf,
+      remoteDataBuf,
+      nbytes,
+      remoteSignalBuf,
+      signalId,
+      signalVal);
+  transport.wait_local(work);
+}
+
+void runTestPutAndSignal(
+    P2pIbgdaTransportDevice* transportPtr,
+    IbgdaLocalBuffer localDataBuf,
+    IbgdaRemoteBuffer remoteDataBuf,
+    std::size_t nbytes,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    int signalId,
+    uint64_t signalVal) {
+  putAndSignalKernel<<<1, 1>>>(
+      transportPtr,
+      localDataBuf,
+      remoteDataBuf,
+      nbytes,
+      remoteSignalBuf,
+      signalId,
+      signalVal, );
+  (void)hipDeviceSynchronize();
+}
+
+// ---------------------------------------------------------------------------
+
+__global__ void putAndSignalGroupKernel(
+    P2pIbgdaTransportDevice* transportPtr,
+    IbgdaLocalBuffer localDataBuf,
+    IbgdaRemoteBuffer remoteDataBuf,
+    std::size_t nbytes,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    int signalId,
+    uint64_t signalVal) {
+  pipes_gda::ThreadGroup group = pipes_gda::make_wavefront_group();
+  auto& transport = *transportPtr;
+
+  IbgdaWork work = transport.put_signal_group_local(
+      group,
+      localDataBuf,
+      remoteDataBuf,
+      nbytes,
+      remoteSignalBuf,
+      signalId,
+      signalVal);
+
+  if (group.is_leader()) {
+    transport.wait_local(work);
+  }
+  group.sync();
+}
+
+void runTestPutAndSignalGroup(
+    P2pIbgdaTransportDevice* transportPtr,
+    IbgdaLocalBuffer localDataBuf,
+    IbgdaRemoteBuffer remoteDataBuf,
+    std::size_t nbytes,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    int signalId,
+    uint64_t signalVal) {
+  putAndSignalGroupKernel<<<1, pipes_gda::kWavefrontSize>>>(
+      transportPtr,
+      localDataBuf,
+      remoteDataBuf,
+      nbytes,
+      remoteSignalBuf,
+      signalId,
+      signalVal, );
+  (void)hipDeviceSynchronize();
+}
+
+// ---------------------------------------------------------------------------
+
+__global__ void putAndSignalGroupMultiWarpKernel(
+    P2pIbgdaTransportDevice* transportPtr,
+    IbgdaLocalBuffer localDataBuf,
+    IbgdaRemoteBuffer remoteDataBuf,
+    std::size_t nbytes,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    int signalId,
+    uint64_t signalVal) {
+  pipes_gda::ThreadGroup group = pipes_gda::make_wavefront_group();
+  auto& transport = *transportPtr;
+
+  IbgdaWork work = transport.put_signal_group_global(
+      group,
+      localDataBuf,
+      remoteDataBuf,
+      nbytes,
+      remoteSignalBuf,
+      signalId,
+      signalVal);
+
+  if (group.is_leader()) {
+    transport.wait_local(work);
+  }
+  group.sync();
+}
+
+void runTestPutAndSignalGroupMultiWarp(
+    P2pIbgdaTransportDevice* transportPtr,
+    IbgdaLocalBuffer localDataBuf,
+    IbgdaRemoteBuffer remoteDataBuf,
+    std::size_t nbytes,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    int signalId,
+    uint64_t signalVal) {
+  // 4 wavefronts = 256 threads, using wavefront groups for global partitioning
+  putAndSignalGroupMultiWarpKernel<<<1, 4 * pipes_gda::kWavefrontSize>>>(
+      transportPtr,
+      localDataBuf,
+      remoteDataBuf,
+      nbytes,
+      remoteSignalBuf,
+      signalId,
+      signalVal, );
+  (void)hipDeviceSynchronize();
+}
+
+// ---------------------------------------------------------------------------
+
+__global__ void putAndSignalGroupBlockKernel(
+    P2pIbgdaTransportDevice* transportPtr,
+    IbgdaLocalBuffer localDataBuf,
+    IbgdaRemoteBuffer remoteDataBuf,
+    std::size_t nbytes,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    int signalId,
+    uint64_t signalVal) {
+  pipes_gda::ThreadGroup group = pipes_gda::make_block_group();
+  auto& transport = *transportPtr;
+
+  IbgdaWork work = transport.put_signal_group_global(
+      group,
+      localDataBuf,
+      remoteDataBuf,
+      nbytes,
+      remoteSignalBuf,
+      signalId,
+      signalVal);
+
+  if (group.is_leader()) {
+    transport.wait_local(work);
+  }
+  group.sync();
+}
+
+void runTestPutAndSignalGroupBlock(
+    P2pIbgdaTransportDevice* transportPtr,
+    IbgdaLocalBuffer localDataBuf,
+    IbgdaRemoteBuffer remoteDataBuf,
+    std::size_t nbytes,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    int signalId,
+    uint64_t signalVal) {
+  // 2 blocks × 256 threads each, block-scope groups
+  putAndSignalGroupBlockKernel<<<2, 256>>>(
+      transportPtr,
+      localDataBuf,
+      remoteDataBuf,
+      nbytes,
+      remoteSignalBuf,
+      signalId,
+      signalVal, );
+  (void)hipDeviceSynchronize();
+}
+
+// ---------------------------------------------------------------------------
+
+__global__ void multiplePutAndSignalKernel(
+    P2pIbgdaTransportDevice* transportPtr,
+    IbgdaLocalBuffer localDataBuf,
+    IbgdaRemoteBuffer remoteDataBuf,
+    std::size_t nbytes,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    int signalId,
+    uint64_t signalValPerIter,
+    uint32_t numIters) {
+  if (threadIdx.x != 0 || blockIdx.x != 0)
+    return;
+
+  auto& transport = *transportPtr;
+
+  for (uint32_t i = 0; i < numIters; ++i) {
+    IbgdaWork work = transport.put_signal(
+        localDataBuf,
+        remoteDataBuf,
+        nbytes,
+        remoteSignalBuf,
+        signalId,
+        signalValPerIter);
+    transport.wait_local(work);
+  }
+}
+
+void runTestMultiplePutAndSignal(
+    P2pIbgdaTransportDevice* transportPtr,
+    IbgdaLocalBuffer localDataBuf,
+    IbgdaRemoteBuffer remoteDataBuf,
+    std::size_t nbytes,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    int signalId,
+    uint64_t signalValPerIter,
+    uint32_t numIters) {
+  multiplePutAndSignalKernel<<<1, 1>>>(
+      transportPtr,
+      localDataBuf,
+      remoteDataBuf,
+      nbytes,
+      remoteSignalBuf,
+      signalId,
+      signalValPerIter,
+      numIters);
+  (void)hipDeviceSynchronize();
+}
+
+// ---------------------------------------------------------------------------
+
+__global__ void signalOnlyKernel(
+    P2pIbgdaTransportDevice* transportPtr,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    int signalId,
+    uint64_t signalVal) {
+  if (threadIdx.x != 0 || blockIdx.x != 0)
+    return;
+
+  auto& transport = *transportPtr;
+  IbgdaWork work =
+      transport.signal_remote(remoteSignalBuf, signalId, signalVal);
+  transport.wait_local(work);
+}
+
+void runTestSignalOnly(
+    P2pIbgdaTransportDevice* transportPtr,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    int signalId,
+    uint64_t signalVal) {
+  signalOnlyKernel<<<1, 1>>>(
+      transportPtr, remoteSignalBuf, signalId, signalVal);
+  (void)hipDeviceSynchronize();
+}
+
+// ---------------------------------------------------------------------------
+
+__global__ void putOnlyKernel(
+    P2pIbgdaTransportDevice* transportPtr,
+    IbgdaLocalBuffer localDataBuf,
+    IbgdaRemoteBuffer remoteDataBuf,
+    std::size_t nbytes) {
+  if (threadIdx.x != 0 || blockIdx.x != 0)
+    return;
+
+  auto& transport = *transportPtr;
+  IbgdaWork work = transport.put(localDataBuf, remoteDataBuf, nbytes);
+  transport.wait_local(work);
+}
+
+void runTestPutOnly(
+    P2pIbgdaTransportDevice* transportPtr,
+    IbgdaLocalBuffer localDataBuf,
+    IbgdaRemoteBuffer remoteDataBuf,
+    std::size_t nbytes) {
+  putOnlyKernel<<<1, 1>>>(transportPtr, localDataBuf, remoteDataBuf, nbytes);
+  (void)hipDeviceSynchronize();
+}
+
+// ---------------------------------------------------------------------------
+
+__global__ void resetSignalKernel(
+    P2pIbgdaTransportDevice* transportPtr,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    int signalId) {
+  if (threadIdx.x != 0 || blockIdx.x != 0)
+    return;
+
+  auto& transport = *transportPtr;
+  transport.reset_signal(remoteSignalBuf, signalId);
+}
+
+void runTestResetSignal(
+    P2pIbgdaTransportDevice* transportPtr,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    int signalId) {
+  resetSignalKernel<<<1, 1>>>(transportPtr, remoteSignalBuf, signalId);
+  (void)hipDeviceSynchronize();
+}
+
+// =============================================================================
+// Receiver-side kernels
+// =============================================================================
+
+__global__ void waitSignalKernel(
+    IbgdaLocalBuffer localSignalBuf,
+    int signalId,
+    uint64_t expectedVal,
+    bool* success) {
+  if (threadIdx.x != 0 || blockIdx.x != 0)
+    return;
+
+  volatile uint64_t* sig =
+      static_cast<volatile uint64_t*>(localSignalBuf.ptr) + signalId;
+  while (*sig < expectedVal) {
+    // spin
+  }
+  __threadfence_system();
+  *success = true;
+}
+
+void runTestWaitSignal(
+    IbgdaLocalBuffer localSignalBuf,
+    int signalId,
+    uint64_t expectedVal,
+    bool* d_success) {
+  bool initVal = false;
+  (void)hipMemcpy(d_success, &initVal, sizeof(bool), hipMemcpyHostToDevice);
+  waitSignalKernel<<<1, 1>>>(localSignalBuf, signalId, expectedVal, d_success);
+  (void)hipDeviceSynchronize();
+}
+
+// ---------------------------------------------------------------------------
+
+__global__ void waitCounterKernel(
+    IbgdaLocalBuffer localCounterBuf,
+    int counterId,
+    uint64_t expectedVal,
+    bool* success) {
+  if (threadIdx.x != 0 || blockIdx.x != 0)
+    return;
+
+  volatile uint64_t* counter =
+      static_cast<volatile uint64_t*>(localCounterBuf.ptr) + counterId;
+  while (*counter < expectedVal) {
+    // spin
+  }
+  __threadfence_system();
+  *success = true;
+}
+
+void runTestWaitCounter(
+    IbgdaLocalBuffer localCounterBuf,
+    int counterId,
+    uint64_t expectedVal,
+    bool* d_success) {
+  bool initVal = false;
+  (void)hipMemcpy(d_success, &initVal, sizeof(bool), hipMemcpyHostToDevice);
+  waitCounterKernel<<<1, 1>>>(
+      localCounterBuf, counterId, expectedVal, d_success);
+  (void)hipDeviceSynchronize();
+}
+
+// =============================================================================
+// Compound kernels
+// =============================================================================
+
+__global__ void waitReadyThenPutAndSignalKernel(
+    P2pIbgdaTransportDevice* transportPtr,
+    IbgdaLocalBuffer localDataBuf,
+    IbgdaRemoteBuffer remoteDataBuf,
+    std::size_t nbytes,
+    IbgdaLocalBuffer localSignalBuf,
+    int readySignalId,
+    uint64_t readyExpected,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    int dataSignalId,
+    uint64_t dataSignalVal) {
+  if (threadIdx.x != 0 || blockIdx.x != 0)
+    return;
+
+  auto& transport = *transportPtr;
+
+  // Wait for ready signal from remote
+  transport.wait_signal(localSignalBuf, readySignalId, readyExpected);
+
+  // Send data + signal
+  IbgdaWork work = transport.put_signal(
+      localDataBuf,
+      remoteDataBuf,
+      nbytes,
+      remoteSignalBuf,
+      dataSignalId,
+      dataSignalVal);
+  transport.wait_local(work);
+}
+
+void runTestWaitReadyThenPutAndSignal(
+    P2pIbgdaTransportDevice* transportPtr,
+    IbgdaLocalBuffer localDataBuf,
+    IbgdaRemoteBuffer remoteDataBuf,
+    std::size_t nbytes,
+    IbgdaLocalBuffer localSignalBuf,
+    int readySignalId,
+    uint64_t readyExpected,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    int dataSignalId,
+    uint64_t dataSignalVal) {
+  waitReadyThenPutAndSignalKernel<<<1, 1>>>(
+      transportPtr,
+      localDataBuf,
+      remoteDataBuf,
+      nbytes,
+      localSignalBuf,
+      readySignalId,
+      readyExpected,
+      remoteSignalBuf,
+      dataSignalId,
+      dataSignalVal, );
+  (void)hipDeviceSynchronize();
+}
+
+// ---------------------------------------------------------------------------
+
+__global__ void bidirectionalPutAndWaitKernel(
+    P2pIbgdaTransportDevice* transportPtr,
+    IbgdaLocalBuffer localDataBuf,
+    IbgdaRemoteBuffer remoteDataBuf,
+    std::size_t nbytes,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    int sendSignalId,
+    uint64_t sendSignalVal,
+    IbgdaLocalBuffer localSignalBuf,
+    int recvSignalId,
+    uint64_t recvExpected,
+    bool* success) {
+  if (threadIdx.x != 0 || blockIdx.x != 0)
+    return;
+
+  auto& transport = *transportPtr;
+
+  // Send data + signal to remote
+  IbgdaWork work = transport.put_signal(
+      localDataBuf,
+      remoteDataBuf,
+      nbytes,
+      remoteSignalBuf,
+      sendSignalId,
+      sendSignalVal);
+  transport.wait_local(work);
+
+  // Wait for incoming signal from remote
+  transport.wait_signal(localSignalBuf, recvSignalId, recvExpected);
+
+  *success = true;
+}
+
+void runTestBidirectionalPutAndWait(
+    P2pIbgdaTransportDevice* transportPtr,
+    IbgdaLocalBuffer localDataBuf,
+    IbgdaRemoteBuffer remoteDataBuf,
+    std::size_t nbytes,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    int sendSignalId,
+    uint64_t sendSignalVal,
+    IbgdaLocalBuffer localSignalBuf,
+    int recvSignalId,
+    uint64_t recvExpected,
+    bool* d_success) {
+  bool initVal = false;
+  (void)hipMemcpy(d_success, &initVal, sizeof(bool), hipMemcpyHostToDevice);
+  bidirectionalPutAndWaitKernel<<<1, 1>>>(
+      transportPtr,
+      localDataBuf,
+      remoteDataBuf,
+      nbytes,
+      remoteSignalBuf,
+      sendSignalId,
+      sendSignalVal,
+      localSignalBuf,
+      recvSignalId,
+      recvExpected,
+      d_success);
+  (void)hipDeviceSynchronize();
+}
+
+// ---------------------------------------------------------------------------
+
+__global__ void putSignalCounterKernel(
+    P2pIbgdaTransportDevice* transportPtr,
+    P2pIbgdaTransportDevice* companionTransportPtr,
+    IbgdaLocalBuffer localDataBuf,
+    IbgdaRemoteBuffer remoteDataBuf,
+    std::size_t nbytes,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    int signalId,
+    uint64_t signalVal,
+    IbgdaLocalBuffer localCounterBuf,
+    int counterId,
+    uint64_t counterVal) {
+  if (threadIdx.x != 0 || blockIdx.x != 0)
+    return;
+
+  auto& transport = *transportPtr;
+  transport.put_signal_counter_remote(
+      localDataBuf,
+      remoteDataBuf,
+      nbytes,
+      remoteSignalBuf,
+      signalId,
+      signalVal,
+      localCounterBuf,
+      counterId,
+      counterVal);
+}
+
+void runTestPutSignalCounter(
+    P2pIbgdaTransportDevice* transportPtr,
+    P2pIbgdaTransportDevice* companionTransportPtr,
+    IbgdaLocalBuffer localDataBuf,
+    IbgdaRemoteBuffer remoteDataBuf,
+    std::size_t nbytes,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    int signalId,
+    uint64_t signalVal,
+    IbgdaLocalBuffer localCounterBuf,
+    int counterId,
+    uint64_t counterVal) {
+  putSignalCounterKernel<<<1, 1>>>(
+      transportPtr,
+      companionTransportPtr,
+      localDataBuf,
+      remoteDataBuf,
+      nbytes,
+      remoteSignalBuf,
+      signalId,
+      signalVal,
+      localCounterBuf,
+      counterId,
+      counterVal);
+  (void)hipDeviceSynchronize();
+}
+
+} // namespace pipes_gda::tests
+#endif

--- a/comms/pipes/amd/tests/MultipeerIbgdaTransportAmdTestKernels.h
+++ b/comms/pipes/amd/tests/MultipeerIbgdaTransportAmdTestKernels.h
@@ -1,0 +1,176 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// AMD/HIP port of comms/pipes/tests/MultipeerIbgdaTransportTest.h
+// Declares kernel wrapper functions for the multipeer IBGDA integration tests.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "comms/pipes/IbgdaBuffer.h"
+
+namespace pipes_gda {
+template <typename NicBackend>
+class P2pIbgdaTransportDeviceImpl;
+struct Mlx5NicBackend;
+using P2pIbgdaTransportDevice = P2pIbgdaTransportDeviceImpl<Mlx5NicBackend>;
+} // namespace pipes_gda
+
+namespace pipes_gda::tests {
+
+using comms::pipes::IbgdaLocalBuffer;
+using comms::pipes::IbgdaRemoteBuffer;
+using comms::pipes::NetworkLKey;
+
+// =============================================================================
+// Data verification utilities
+// =============================================================================
+
+void fillBufferWithPattern(void* d_buf, std::size_t nbytes, uint8_t seed);
+
+void verifyBufferPattern(
+    const void* d_buf,
+    std::size_t nbytes,
+    uint8_t seed,
+    bool* d_success);
+
+// =============================================================================
+// Sender-side kernel wrappers
+// =============================================================================
+
+// put_signal() + wait_local()
+void runTestPutAndSignal(
+    pipes_gda::P2pIbgdaTransportDevice* transport,
+    IbgdaLocalBuffer localDataBuf,
+    IbgdaRemoteBuffer remoteDataBuf,
+    std::size_t nbytes,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    int signalId,
+    uint64_t signalVal);
+
+// put_group_local() + put_signal_group_local() (wavefront group)
+void runTestPutAndSignalGroup(
+    pipes_gda::P2pIbgdaTransportDevice* transport,
+    IbgdaLocalBuffer localDataBuf,
+    IbgdaRemoteBuffer remoteDataBuf,
+    std::size_t nbytes,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    int signalId,
+    uint64_t signalVal);
+
+// put_signal_group_global() with multi-wavefront groups
+void runTestPutAndSignalGroupMultiWarp(
+    pipes_gda::P2pIbgdaTransportDevice* transport,
+    IbgdaLocalBuffer localDataBuf,
+    IbgdaRemoteBuffer remoteDataBuf,
+    std::size_t nbytes,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    int signalId,
+    uint64_t signalVal);
+
+// put_signal_group_global() with block-scope groups
+void runTestPutAndSignalGroupBlock(
+    pipes_gda::P2pIbgdaTransportDevice* transport,
+    IbgdaLocalBuffer localDataBuf,
+    IbgdaRemoteBuffer remoteDataBuf,
+    std::size_t nbytes,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    int signalId,
+    uint64_t signalVal);
+
+// Sequential put_signal() iterations with wait_local() each
+void runTestMultiplePutAndSignal(
+    pipes_gda::P2pIbgdaTransportDevice* transport,
+    IbgdaLocalBuffer localDataBuf,
+    IbgdaRemoteBuffer remoteDataBuf,
+    std::size_t nbytes,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    int signalId,
+    uint64_t signalValPerIter,
+    uint32_t numIters);
+
+// signal_remote() + wait_local() (no data)
+void runTestSignalOnly(
+    pipes_gda::P2pIbgdaTransportDevice* transport,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    int signalId,
+    uint64_t signalVal);
+
+// put() + wait_local() (no signal)
+void runTestPutOnly(
+    pipes_gda::P2pIbgdaTransportDevice* transport,
+    IbgdaLocalBuffer localDataBuf,
+    IbgdaRemoteBuffer remoteDataBuf,
+    std::size_t nbytes);
+
+// reset_signal() — write 0 to remote signal via RDMA inline write
+void runTestResetSignal(
+    pipes_gda::P2pIbgdaTransportDevice* transport,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    int signalId);
+
+// =============================================================================
+// Receiver-side kernel wrappers
+// =============================================================================
+
+// Volatile spin on local signal buffer until value >= expected
+void runTestWaitSignal(
+    IbgdaLocalBuffer localSignalBuf,
+    int signalId,
+    uint64_t expectedVal,
+    bool* d_success);
+
+// Volatile spin on local counter buffer until value >= expected
+void runTestWaitCounter(
+    IbgdaLocalBuffer localCounterBuf,
+    int counterId,
+    uint64_t expectedVal,
+    bool* d_success);
+
+// =============================================================================
+// Compound kernel wrappers
+// =============================================================================
+
+// Wait for ready signal, then put + signal data
+void runTestWaitReadyThenPutAndSignal(
+    pipes_gda::P2pIbgdaTransportDevice* transport,
+    IbgdaLocalBuffer localDataBuf,
+    IbgdaRemoteBuffer remoteDataBuf,
+    std::size_t nbytes,
+    IbgdaLocalBuffer localSignalBuf,
+    int readySignalId,
+    uint64_t readyExpected,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    int dataSignalId,
+    uint64_t dataSignalVal);
+
+// Bidirectional: put + signal to remote AND wait for incoming signal
+void runTestBidirectionalPutAndWait(
+    pipes_gda::P2pIbgdaTransportDevice* transport,
+    IbgdaLocalBuffer localDataBuf,
+    IbgdaRemoteBuffer remoteDataBuf,
+    std::size_t nbytes,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    int sendSignalId,
+    uint64_t sendSignalVal,
+    IbgdaLocalBuffer localSignalBuf,
+    int recvSignalId,
+    uint64_t recvExpected,
+    bool* d_success);
+
+// put_signal_counter_remote() via companion QP
+void runTestPutSignalCounter(
+    pipes_gda::P2pIbgdaTransportDevice* transport,
+    pipes_gda::P2pIbgdaTransportDevice* companionTransport,
+    IbgdaLocalBuffer localDataBuf,
+    IbgdaRemoteBuffer remoteDataBuf,
+    std::size_t nbytes,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    int signalId,
+    uint64_t signalVal,
+    IbgdaLocalBuffer localCounterBuf,
+    int counterId,
+    uint64_t counterVal);
+
+} // namespace pipes_gda::tests

--- a/comms/pipes/amd/tests/P2pIbgdaTransportDeviceAmdTestKernels.cu
+++ b/comms/pipes/amd/tests/P2pIbgdaTransportDeviceAmdTestKernels.cu
@@ -1,0 +1,512 @@
+#if defined(__HIPCC__) || !defined(__CUDACC__)
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// AMD/HIP port of comms/pipes/tests/P2pIbgdaTransportDeviceTest.cu
+// Same kernel logic, adapted for pipes_gda::P2pIbgdaTransportDevice (AMD).
+
+#include "P2pIbgdaTransportDeviceAmd.h"
+#include "P2pIbgdaTransportDeviceAmdTestKernels.h"
+#include "PipesGdaShared.h"
+
+#include <hip/hip_runtime.h>
+
+namespace pipes_gda::tests {
+
+// =============================================================================
+// Device-side test kernels
+// =============================================================================
+
+__global__ void testP2pTransportConstruction(bool* success) {
+  P2pIbgdaTransportDevice transport(nullptr);
+
+  *success = true;
+
+  if (transport.getQp() != nullptr) {
+    *success = false;
+  }
+}
+
+__global__ void testP2pTransportDefaultConstruction(bool* success) {
+  P2pIbgdaTransportDevice transport;
+
+  *success = true;
+
+  if (transport.getQp() != nullptr) {
+    *success = false;
+  }
+}
+
+__global__ void testP2pTransportReadSignal(
+    uint64_t* d_signalBuf,
+    IbgdaLocalBuffer localBuf,
+    int numSignals,
+    bool* success) {
+  P2pIbgdaTransportDevice transport(nullptr);
+
+  *success = true;
+
+  for (int i = 0; i < numSignals; ++i) {
+    uint64_t expected = static_cast<uint64_t>(i + 1) * 100;
+    uint64_t actual = transport.read_signal(localBuf, i);
+    if (actual != expected) {
+      *success = false;
+    }
+  }
+}
+
+__global__ void testIbgdaWork(bool* success) {
+  *success = true;
+
+  IbgdaWork defaultWork;
+  if (defaultWork.value != 0) {
+    *success = false;
+  }
+
+  uint64_t testTicket = 12345;
+  IbgdaWork workWithValue(testTicket);
+  if (workWithValue.value != testTicket) {
+    *success = false;
+  }
+
+  IbgdaWork copiedWork = workWithValue;
+  if (copiedWork.value != testTicket) {
+    *success = false;
+  }
+}
+
+// =============================================================================
+// wait_signal test kernels (GE-only comparison)
+// =============================================================================
+
+__global__ void testWaitSignalGE(
+    uint64_t* d_signalBuf,
+    IbgdaLocalBuffer localBuf,
+    uint64_t targetValue,
+    bool* success) {
+  P2pIbgdaTransportDevice transport(nullptr);
+  transport.wait_signal(localBuf, 0, targetValue);
+  *success = true;
+}
+
+__global__ void testWaitSignalMultipleSlots(
+    uint64_t* d_signalBuf,
+    IbgdaLocalBuffer localBuf,
+    int numSignals,
+    bool* success) {
+  P2pIbgdaTransportDevice transport(nullptr);
+
+  *success = true;
+
+  for (int i = 0; i < numSignals; ++i) {
+    uint64_t expectedValue = static_cast<uint64_t>(i + 1) * 100;
+    transport.wait_signal(localBuf, i, expectedValue);
+
+    uint64_t readValue = transport.read_signal(localBuf, i);
+    if (readValue != expectedValue) {
+      *success = false;
+    }
+  }
+}
+
+// =============================================================================
+// wait_signal timeout test kernels
+// =============================================================================
+
+__global__ void testWaitSignalTimeout(
+    uint64_t* d_signalBuf,
+    IbgdaLocalBuffer localBuf,
+    Timeout timeout) {
+  timeout.start();
+  P2pIbgdaTransportDevice transport(nullptr);
+  transport.wait_signal(localBuf, 0, 999, timeout);
+}
+
+__global__ void testWaitSignalNoTimeout(
+    uint64_t* d_signalBuf,
+    IbgdaLocalBuffer localBuf,
+    Timeout timeout,
+    bool* success) {
+  timeout.start();
+  P2pIbgdaTransportDevice transport(nullptr);
+  transport.wait_signal(localBuf, 0, 42, timeout);
+  *success = true;
+}
+
+// =============================================================================
+// Wrapper functions (called from TestMain)
+// =============================================================================
+
+void runTestP2pTransportConstruction(bool* d_success) {
+  testP2pTransportConstruction<<<1, 1>>>(d_success);
+}
+
+void runTestP2pTransportDefaultConstruction(bool* d_success) {
+  testP2pTransportDefaultConstruction<<<1, 1>>>(d_success);
+}
+
+void runTestP2pTransportReadSignal(
+    uint64_t* d_signalBuf,
+    IbgdaLocalBuffer localBuf,
+    int numSignals,
+    bool* d_success) {
+  testP2pTransportReadSignal<<<1, 1>>>(
+      d_signalBuf, localBuf, numSignals, d_success);
+}
+
+void runTestIbgdaWork(bool* d_success) {
+  testIbgdaWork<<<1, 1>>>(d_success);
+}
+
+void runTestWaitSignalGE(
+    uint64_t* d_signalBuf,
+    IbgdaLocalBuffer localBuf,
+    uint64_t targetValue,
+    bool* d_success) {
+  testWaitSignalGE<<<1, 1>>>(d_signalBuf, localBuf, targetValue, d_success);
+}
+
+void runTestWaitSignalMultipleSlots(
+    uint64_t* d_signalBuf,
+    IbgdaLocalBuffer localBuf,
+    int numSignals,
+    bool* d_success) {
+  testWaitSignalMultipleSlots<<<1, 1>>>(
+      d_signalBuf, localBuf, numSignals, d_success);
+}
+
+void runTestWaitSignalTimeout(
+    uint64_t* d_signalBuf,
+    IbgdaLocalBuffer localBuf,
+    int device,
+    uint32_t timeout_ms) {
+  (void)hipSetDevice(device);
+  Timeout timeout =
+      pipes_gda::make_timeout_us(static_cast<uint64_t>(timeout_ms) * 1000);
+  testWaitSignalTimeout<<<1, 1>>>(d_signalBuf, localBuf, timeout);
+  (void)hipDeviceSynchronize();
+}
+
+void runTestWaitSignalNoTimeout(
+    uint64_t* d_signalBuf,
+    IbgdaLocalBuffer localBuf,
+    int device,
+    uint32_t timeout_ms,
+    bool* d_success) {
+  (void)hipSetDevice(device);
+  Timeout timeout =
+      pipes_gda::make_timeout_us(static_cast<uint64_t>(timeout_ms) * 1000);
+  testWaitSignalNoTimeout<<<1, 1>>>(d_signalBuf, localBuf, timeout, d_success);
+}
+
+// =============================================================================
+// put() latency benchmark kernel (mock QP, no real NIC)
+// =============================================================================
+
+static constexpr uint16_t kMockSqSize = 4096;
+
+struct MockQpDevice {
+  pipes_gda_gpu_dev_verbs_qp qp;
+  pipes_gda_gpu_dev_verbs_wqe wqeBuf[kMockSqSize];
+  __be32 dbrec[2];
+  uint64_t dbReg;
+  uint64_t signalBuf;
+};
+
+__device__ void initMockQp(MockQpDevice* mock) {
+  memset(mock, 0, sizeof(MockQpDevice));
+
+  mock->qp.sq_wqe_daddr = reinterpret_cast<uint8_t*>(mock->wqeBuf);
+  mock->qp.sq_wqe_num = kMockSqSize;
+  mock->qp.sq_wqe_mask = kMockSqSize - 1;
+  mock->qp.sq_num = 1;
+  mock->qp.sq_num_shift8 = 1 << 8;
+  mock->qp.sq_dbrec = mock->dbrec;
+  mock->qp.sq_db = &mock->dbReg;
+  mock->qp.sq_rsvd_index = 0;
+  mock->qp.sq_ready_index = 0;
+}
+
+__global__ void testPutLatency(
+    MockQpDevice* mock,
+    std::size_t nbytes,
+    uint32_t numWarmup,
+    uint32_t numIters,
+    uint64_t* latencies) {
+  if (threadIdx.x != 0 || blockIdx.x != 0)
+    return;
+
+  initMockQp(mock);
+
+  IbgdaLocalBuffer localDataBuf(mock->wqeBuf, NetworkLKey(0x3333));
+  IbgdaRemoteBuffer remoteDataBuf(mock->wqeBuf, NetworkRKey(0x4444));
+
+  P2pIbgdaTransportDevice transport(&mock->qp);
+
+  uint32_t totalIters = numWarmup + numIters;
+  for (uint32_t iter = 0; iter < totalIters; iter++) {
+    mock->qp.sq_rsvd_index = 0;
+    mock->qp.sq_ready_index = 0;
+
+    uint64_t t0 = wall_clock64();
+    transport.put(localDataBuf, remoteDataBuf, nbytes);
+    uint64_t t1 = wall_clock64();
+
+    if (iter >= numWarmup) {
+      latencies[iter - numWarmup] = t1 - t0;
+    }
+  }
+}
+
+void runTestPutLatency(
+    std::size_t nbytes,
+    uint32_t numWarmup,
+    uint32_t numIters,
+    uint64_t* d_latencies) {
+  MockQpDevice* d_mock = nullptr;
+  (void)hipMalloc(&d_mock, sizeof(MockQpDevice));
+
+  testPutLatency<<<1, 1>>>(d_mock, nbytes, numWarmup, numIters, d_latencies);
+  (void)hipDeviceSynchronize();
+
+  (void)hipFree(d_mock);
+}
+
+// =============================================================================
+// put() latency benchmark kernel (REAL QP + NIC)
+// =============================================================================
+
+__global__ void testPutLatencyReal(
+    pipes_gda_gpu_dev_verbs_qp* qp,
+    IbgdaLocalBuffer localDataBuf,
+    IbgdaRemoteBuffer remoteDataBuf,
+    std::size_t nbytes,
+    uint32_t numWarmup,
+    uint32_t numIters,
+    uint64_t* latencies) {
+  if (threadIdx.x != 0 || blockIdx.x != 0)
+    return;
+
+  P2pIbgdaTransportDevice transport(qp);
+
+  uint32_t totalIters = numWarmup + numIters;
+  for (uint32_t iter = 0; iter < totalIters; iter++) {
+    uint64_t t0 = wall_clock64();
+    IbgdaWork work = transport.put(localDataBuf, remoteDataBuf, nbytes);
+    transport.wait_local(work);
+    uint64_t t1 = wall_clock64();
+
+    if (iter >= numWarmup) {
+      latencies[iter - numWarmup] = t1 - t0;
+    }
+  }
+}
+
+void runTestPutLatencyReal(
+    pipes_gda_gpu_dev_verbs_qp* qp,
+    IbgdaLocalBuffer localDataBuf,
+    IbgdaRemoteBuffer remoteDataBuf,
+    std::size_t nbytes,
+    uint32_t numWarmup,
+    uint32_t numIters,
+    uint64_t* d_latencies) {
+  testPutLatencyReal<<<1, 1>>>(
+      qp,
+      localDataBuf,
+      remoteDataBuf,
+      nbytes,
+      numWarmup,
+      numIters,
+      d_latencies);
+  (void)hipDeviceSynchronize();
+}
+
+} // namespace pipes_gda::tests
+
+// =============================================================================
+// ThreadGroup / group-level API test kernels
+// =============================================================================
+
+namespace pipes_gda::tests {
+
+__global__ void testPutGroupPartitioning(bool* success) {
+  pipes_gda::ThreadGroup group = pipes_gda::make_wavefront_group();
+
+  *success = true;
+
+  const std::size_t totalBytes = 1024;
+  char dummyLocal[8];
+  char dummyRemote[8];
+  pipes_gda::IbgdaLocalBuffer localBuf(
+      dummyLocal, pipes_gda::NetworkLKey(0x1111));
+  pipes_gda::IbgdaRemoteBuffer remoteBuf(
+      dummyRemote, pipes_gda::NetworkRKey(0x2222));
+
+  std::size_t chunkSize = totalBytes / group.group_size;
+  std::size_t expectedOffset = group.thread_id_in_group * chunkSize;
+  std::size_t expectedBytes = (group.thread_id_in_group == group.group_size - 1)
+      ? (totalBytes - expectedOffset)
+      : chunkSize;
+  (void)expectedBytes;
+
+  pipes_gda::IbgdaLocalBuffer laneBuf = localBuf.subBuffer(expectedOffset);
+  pipes_gda::IbgdaRemoteBuffer laneRemoteBuf =
+      remoteBuf.subBuffer(expectedOffset);
+
+  char* expectedLocalPtr = static_cast<char*>(localBuf.ptr) + expectedOffset;
+  char* expectedRemotePtr = static_cast<char*>(remoteBuf.ptr) + expectedOffset;
+
+  if (laneBuf.ptr != expectedLocalPtr) {
+    *success = false;
+  }
+  if (laneRemoteBuf.ptr != expectedRemotePtr) {
+    *success = false;
+  }
+  if (laneBuf.lkey != localBuf.lkey) {
+    *success = false;
+  }
+  if (laneRemoteBuf.rkey != remoteBuf.rkey) {
+    *success = false;
+  }
+}
+
+void runTestPutGroupPartitioning(bool* d_success) {
+  testPutGroupPartitioning<<<1, pipes_gda::kWavefrontSize>>>(d_success);
+}
+
+__global__ void testPutSignalGroupBroadcast(bool* success) {
+  pipes_gda::ThreadGroup group = pipes_gda::make_wavefront_group();
+
+  *success = true;
+
+  const uint64_t leaderTicket = 0xDEADBEEF42ULL;
+  uint64_t ticket = 0;
+
+  if (group.is_leader()) {
+    ticket = leaderTicket;
+  }
+
+  ticket = group.broadcast<uint64_t>(ticket);
+
+  if (ticket != leaderTicket) {
+    *success = false;
+  }
+}
+
+void runTestPutSignalGroupBroadcast(bool* d_success) {
+  testPutSignalGroupBroadcast<<<1, pipes_gda::kWavefrontSize>>>(d_success);
+}
+
+__global__ void testBroadcast64Block(bool* success) {
+  pipes_gda::ThreadGroup group = pipes_gda::make_block_group();
+
+  const uint64_t leaderVal = 0xCAFEBABE12345678ULL;
+  uint64_t val = 0;
+
+  if (group.is_leader()) {
+    val = leaderVal;
+  }
+
+  val = group.broadcast<uint64_t>(val);
+
+  if (val != leaderVal) {
+    atomicExch(reinterpret_cast<int*>(success), 0);
+  }
+}
+
+void runTestBroadcast64Block(bool* d_success) {
+  bool initVal = true;
+  (void)hipMemcpy(d_success, &initVal, sizeof(bool), hipMemcpyHostToDevice);
+  testBroadcast64Block<<<4, 256>>>(d_success);
+}
+
+// ---------------------------------------------------------------------------
+// Broadcast64Multiwarp: verify multiwarp-level broadcast (4 wavefronts)
+// AMD equivalent of NVIDIA's Broadcast64Multiwarp (4 warps = 128 threads).
+// On AMD CDNA, kMultiwarpSize = 4 × 64 = 256 threads.
+// ---------------------------------------------------------------------------
+__global__ void testBroadcast64Multiwarp(bool* success) {
+  pipes_gda::ThreadGroup group = pipes_gda::make_multiwarp_group();
+
+  // Each multiwarp leader produces a unique value based on group_id
+  uint64_t val = 0;
+  if (group.is_leader()) {
+    val = 0xAAAABBBB00000000ULL + group.group_id;
+  }
+
+  val = group.broadcast<uint64_t>(val);
+
+  // All threads in the multiwarp should see their leader's value
+  uint64_t expected = 0xAAAABBBB00000000ULL + group.group_id;
+  if (val != expected) {
+    atomicExch(reinterpret_cast<int*>(success), 0);
+  }
+}
+
+void runTestBroadcast64Multiwarp(bool* d_success) {
+  bool initVal = true;
+  (void)hipMemcpy(d_success, &initVal, sizeof(bool), hipMemcpyHostToDevice);
+  // 2 blocks × 512 threads = 4 multiwarps (each 256 threads)
+  testBroadcast64Multiwarp<<<2, 512>>>(d_success);
+}
+
+__global__ void testBroadcast64DoubleSafety(bool* success) {
+  pipes_gda::ThreadGroup group = pipes_gda::make_block_group();
+
+  const uint64_t firstVal = 111ULL;
+  const uint64_t secondVal = 222ULL;
+
+  uint64_t v1 = 0, v2 = 0;
+  if (group.is_leader()) {
+    v1 = firstVal;
+  }
+  v1 = group.broadcast<uint64_t>(v1);
+
+  if (group.is_leader()) {
+    v2 = secondVal;
+  }
+  v2 = group.broadcast<uint64_t>(v2);
+
+  if (v1 != firstVal || v2 != secondVal) {
+    atomicExch(reinterpret_cast<int*>(success), 0);
+  }
+}
+
+void runTestBroadcast64DoubleSafety(bool* d_success) {
+  bool initVal = true;
+  (void)hipMemcpy(d_success, &initVal, sizeof(bool), hipMemcpyHostToDevice);
+  testBroadcast64DoubleSafety<<<4, 256>>>(d_success);
+}
+
+__global__ void testPutGroupPartitioningBlock(bool* success) {
+  pipes_gda::ThreadGroup group = pipes_gda::make_block_group();
+
+  const std::size_t totalBytes = 4096;
+  char dummyLocal[8];
+  char dummyRemote[8];
+  pipes_gda::IbgdaLocalBuffer localBuf(
+      dummyLocal, pipes_gda::NetworkLKey(0x1111));
+  pipes_gda::IbgdaRemoteBuffer remoteBuf(
+      dummyRemote, pipes_gda::NetworkRKey(0x2222));
+
+  std::size_t chunkSize = totalBytes / group.group_size;
+  std::size_t expectedOffset = group.thread_id_in_group * chunkSize;
+
+  pipes_gda::IbgdaLocalBuffer laneBuf = localBuf.subBuffer(expectedOffset);
+
+  char* expectedPtr = static_cast<char*>(localBuf.ptr) + expectedOffset;
+  if (laneBuf.ptr != expectedPtr) {
+    atomicExch(reinterpret_cast<int*>(success), 0);
+  }
+  if (laneBuf.lkey != localBuf.lkey) {
+    atomicExch(reinterpret_cast<int*>(success), 0);
+  }
+}
+
+void runTestPutGroupPartitioningBlock(bool* d_success) {
+  bool initVal = true;
+  (void)hipMemcpy(d_success, &initVal, sizeof(bool), hipMemcpyHostToDevice);
+  testPutGroupPartitioningBlock<<<4, 256>>>(d_success);
+}
+
+} // namespace pipes_gda::tests
+#endif

--- a/comms/pipes/amd/tests/P2pIbgdaTransportDeviceAmdTestKernels.h
+++ b/comms/pipes/amd/tests/P2pIbgdaTransportDeviceAmdTestKernels.h
@@ -1,0 +1,91 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// AMD/HIP port of comms/pipes/tests/P2pIbgdaTransportDeviceTest.cuh
+// Same test wrapper function declarations, adapted for pipes_gda types.
+
+#pragma once
+
+#include <cstdint>
+
+#include "PipesGdaShared.h"
+
+// Forward declaration
+struct pipes_gda_gpu_dev_verbs_qp;
+
+namespace pipes_gda::tests {
+
+using pipes_gda::IbgdaLocalBuffer;
+using pipes_gda::IbgdaRemoteBuffer;
+
+void runTestP2pTransportConstruction(bool* d_success);
+
+void runTestP2pTransportDefaultConstruction(bool* d_success);
+
+void runTestP2pTransportReadSignal(
+    uint64_t* d_signalBuf,
+    IbgdaLocalBuffer localBuf,
+    int numSignals,
+    bool* d_success);
+
+void runTestIbgdaWork(bool* d_success);
+
+// wait_signal tests (GE-only comparison)
+void runTestWaitSignalGE(
+    uint64_t* d_signalBuf,
+    IbgdaLocalBuffer localBuf,
+    uint64_t targetValue,
+    bool* d_success);
+
+void runTestWaitSignalMultipleSlots(
+    uint64_t* d_signalBuf,
+    IbgdaLocalBuffer localBuf,
+    int numSignals,
+    bool* d_success);
+
+// wait_signal timeout tests
+void runTestWaitSignalTimeout(
+    uint64_t* d_signalBuf,
+    IbgdaLocalBuffer localBuf,
+    int device,
+    uint32_t timeout_ms);
+
+void runTestWaitSignalNoTimeout(
+    uint64_t* d_signalBuf,
+    IbgdaLocalBuffer localBuf,
+    int device,
+    uint32_t timeout_ms,
+    bool* d_success);
+
+// ThreadGroup / group-level API tests
+void runTestPutGroupPartitioning(bool* d_success);
+
+void runTestPutSignalGroupBroadcast(bool* d_success);
+
+void runTestBroadcast64Block(bool* d_success);
+
+void runTestBroadcast64Multiwarp(bool* d_success);
+
+void runTestBroadcast64DoubleSafety(bool* d_success);
+
+void runTestPutGroupPartitioningBlock(bool* d_success);
+
+// =============================================================================
+// put() latency benchmark
+// =============================================================================
+
+void runTestPutLatency(
+    std::size_t nbytes,
+    uint32_t numWarmup,
+    uint32_t numIters,
+    uint64_t* d_latencies);
+
+void runTestPutLatencyReal(
+    pipes_gda_gpu_dev_verbs_qp* qp,
+    IbgdaLocalBuffer localDataBuf,
+    IbgdaRemoteBuffer remoteDataBuf,
+    std::size_t nbytes,
+    uint32_t numWarmup,
+    uint32_t numIters,
+    uint64_t* d_latencies);
+
+} // namespace pipes_gda::tests

--- a/comms/pipes/amd/tests/P2pIbgdaTransportDeviceAmdTestMain.cu
+++ b/comms/pipes/amd/tests/P2pIbgdaTransportDeviceAmdTestMain.cu
@@ -1,0 +1,318 @@
+#if defined(__HIPCC__) || !defined(__CUDACC__)
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// AMD/HIP port of comms/pipes/tests/P2pIbgdaTransportDeviceTestMain.cc
+// Same test logic, adapted for HIP runtime APIs.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <functional>
+#include <vector>
+
+#include <hip/hip_runtime.h>
+
+#include "HipDeviceBuffer.h"
+#include "P2pIbgdaTransportDeviceAmdTestKernels.h"
+#include "PipesGdaShared.h"
+
+using namespace pipes_gda;
+
+namespace pipes_gda::tests {
+
+// =============================================================================
+// HIP helpers (matching CUDA DeviceBuffer / CUDACHECK_TEST pattern)
+// =============================================================================
+
+#define HIPCHECK_TEST(cmd)                                                    \
+  do {                                                                        \
+    hipError_t err = (cmd);                                                   \
+    if (err != hipSuccess) {                                                  \
+      FAIL() << "HIP error: " << hipGetErrorString(err) << " at " << __FILE__ \
+             << ":" << __LINE__;                                              \
+    }                                                                         \
+  } while (0)
+
+using ::pipes_gda::HipDeviceBuffer;
+
+// =============================================================================
+// Test Fixture
+// =============================================================================
+
+class P2pIbgdaTransportDeviceTestFixture : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    int deviceCount = 0;
+    hipError_t err = hipGetDeviceCount(&deviceCount);
+    if (err != hipSuccess || deviceCount == 0) {
+      GTEST_SKIP() << "No HIP GPU available";
+    }
+    HIPCHECK_TEST(hipSetDevice(0));
+  }
+
+  void runAndVerify(const std::function<void(bool*)>& runKernel) {
+    HipDeviceBuffer successBuf(sizeof(bool));
+    auto* d_success = static_cast<bool*>(successBuf.get());
+
+    bool initSuccess = true;
+    HIPCHECK_TEST(hipMemcpy(
+        d_success, &initSuccess, sizeof(bool), hipMemcpyHostToDevice));
+
+    runKernel(d_success);
+    HIPCHECK_TEST(hipDeviceSynchronize());
+
+    bool success = false;
+    HIPCHECK_TEST(
+        hipMemcpy(&success, d_success, sizeof(bool), hipMemcpyDeviceToHost));
+
+    EXPECT_TRUE(success);
+  }
+};
+
+// =============================================================================
+// Construction and accessor tests
+// =============================================================================
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, DeviceConstruction) {
+  runAndVerify(
+      [&](bool* d_success) { runTestP2pTransportConstruction(d_success); });
+}
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, DefaultConstruction) {
+  runAndVerify([](bool* d_success) {
+    runTestP2pTransportDefaultConstruction(d_success);
+  });
+}
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, ReadSignal) {
+  const int numSignals = 4;
+
+  HipDeviceBuffer signalBuf(numSignals * sizeof(uint64_t));
+  auto* d_signalBuf = static_cast<uint64_t*>(signalBuf.get());
+
+  std::vector<uint64_t> h_signals(numSignals);
+  for (int i = 0; i < numSignals; ++i) {
+    h_signals[i] = static_cast<uint64_t>(i + 1) * 100;
+  }
+  HIPCHECK_TEST(hipMemcpy(
+      d_signalBuf,
+      h_signals.data(),
+      numSignals * sizeof(uint64_t),
+      hipMemcpyHostToDevice));
+
+  IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKey(0x5555));
+
+  runAndVerify([&](bool* d_success) {
+    runTestP2pTransportReadSignal(d_signalBuf, localBuf, numSignals, d_success);
+  });
+}
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, IbgdaWorkConstruction) {
+  runAndVerify([](bool* d_success) { runTestIbgdaWork(d_success); });
+}
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, BufferSubBufferWithTransport) {
+  const size_t offset = 32;
+  char localSignalData[128];
+  char remoteSignalData[128];
+
+  IbgdaLocalBuffer baseLBuf(localSignalData, NetworkLKey(0x7777));
+  IbgdaRemoteBuffer baseRBuf(remoteSignalData, NetworkRKey(0x8888));
+
+  IbgdaLocalBuffer subLBuf = baseLBuf.subBuffer(offset);
+  IbgdaRemoteBuffer subRBuf = baseRBuf.subBuffer(offset);
+
+  EXPECT_EQ(subLBuf.ptr, localSignalData + offset);
+  EXPECT_EQ(subRBuf.ptr, remoteSignalData + offset);
+  EXPECT_EQ(subLBuf.lkey, baseLBuf.lkey);
+  EXPECT_EQ(subRBuf.rkey, baseRBuf.rkey);
+}
+
+// =============================================================================
+// wait_signal Tests (GE-only comparison)
+// =============================================================================
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalGE_Equal) {
+  const uint64_t targetValue = 50;
+
+  HipDeviceBuffer signalBuf(sizeof(uint64_t));
+  auto* d_signalBuf = static_cast<uint64_t*>(signalBuf.get());
+
+  HIPCHECK_TEST(hipMemcpy(
+      d_signalBuf, &targetValue, sizeof(uint64_t), hipMemcpyHostToDevice));
+
+  IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKey(0x1111));
+
+  runAndVerify([&](bool* d_success) {
+    runTestWaitSignalGE(d_signalBuf, localBuf, targetValue, d_success);
+  });
+}
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalGE_Greater) {
+  const uint64_t signalValue = 100;
+  const uint64_t targetValue = 50;
+
+  HipDeviceBuffer signalBuf(sizeof(uint64_t));
+  auto* d_signalBuf = static_cast<uint64_t*>(signalBuf.get());
+
+  HIPCHECK_TEST(hipMemcpy(
+      d_signalBuf, &signalValue, sizeof(uint64_t), hipMemcpyHostToDevice));
+
+  IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKey(0x1111));
+
+  runAndVerify([&](bool* d_success) {
+    runTestWaitSignalGE(d_signalBuf, localBuf, targetValue, d_success);
+  });
+}
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalMultipleSlots) {
+  const int numSignals = 4;
+
+  HipDeviceBuffer signalBuf(numSignals * sizeof(uint64_t));
+  auto* d_signalBuf = static_cast<uint64_t*>(signalBuf.get());
+
+  std::vector<uint64_t> h_signals(numSignals);
+  for (int i = 0; i < numSignals; ++i) {
+    h_signals[i] = static_cast<uint64_t>(i + 1) * 100;
+  }
+  HIPCHECK_TEST(hipMemcpy(
+      d_signalBuf,
+      h_signals.data(),
+      numSignals * sizeof(uint64_t),
+      hipMemcpyHostToDevice));
+
+  IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKey(0x3333));
+
+  runAndVerify([&](bool* d_success) {
+    runTestWaitSignalMultipleSlots(
+        d_signalBuf, localBuf, numSignals, d_success);
+  });
+}
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalZeroValue) {
+  const uint64_t targetValue = 0;
+
+  HipDeviceBuffer signalBuf(sizeof(uint64_t));
+  auto* d_signalBuf = static_cast<uint64_t*>(signalBuf.get());
+
+  HIPCHECK_TEST(hipMemset(d_signalBuf, 0, sizeof(uint64_t)));
+
+  IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKey(0x1111));
+
+  runAndVerify([&](bool* d_success) {
+    runTestWaitSignalGE(d_signalBuf, localBuf, targetValue, d_success);
+  });
+}
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalMaxValue) {
+  const uint64_t targetValue = UINT64_MAX;
+
+  HipDeviceBuffer signalBuf(sizeof(uint64_t));
+  auto* d_signalBuf = static_cast<uint64_t*>(signalBuf.get());
+
+  HIPCHECK_TEST(hipMemcpy(
+      d_signalBuf, &targetValue, sizeof(uint64_t), hipMemcpyHostToDevice));
+
+  IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKey(0x1111));
+
+  runAndVerify([&](bool* d_success) {
+    runTestWaitSignalGE(d_signalBuf, localBuf, targetValue, d_success);
+  });
+}
+
+// =============================================================================
+// ThreadGroup / Group-Level API Tests
+// =============================================================================
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, PutGroupPartitioning) {
+  runAndVerify([](bool* d_success) { runTestPutGroupPartitioning(d_success); });
+}
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, PutSignalGroupBroadcast) {
+  runAndVerify(
+      [](bool* d_success) { runTestPutSignalGroupBroadcast(d_success); });
+}
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, Broadcast64Block) {
+  runAndVerify([](bool* d_success) { runTestBroadcast64Block(d_success); });
+}
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, Broadcast64Multiwarp) {
+  runAndVerify([](bool* d_success) { runTestBroadcast64Multiwarp(d_success); });
+}
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, Broadcast64DoubleSafety) {
+  runAndVerify(
+      [](bool* d_success) { runTestBroadcast64DoubleSafety(d_success); });
+}
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, PutGroupPartitioningBlock) {
+  runAndVerify(
+      [](bool* d_success) { runTestPutGroupPartitioningBlock(d_success); });
+}
+
+// =============================================================================
+// wait_signal Timeout Tests
+// =============================================================================
+
+class P2pIbgdaWaitSignalTimeoutTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    int deviceCount = 0;
+    hipError_t err = hipGetDeviceCount(&deviceCount);
+    if (err != hipSuccess || deviceCount == 0) {
+      GTEST_SKIP() << "No HIP GPU available";
+    }
+    HIPCHECK_TEST(hipSetDevice(0));
+  }
+
+  void TearDown() override {
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    (void)hipDeviceReset();
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    (void)hipSetDevice(0);
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    (void)hipGetLastError();
+  }
+
+  bool isExpectedTrapError(hipError_t err) {
+    return err == hipErrorAssert || err == hipErrorLaunchFailure ||
+        err == hipErrorNotReady;
+  }
+};
+
+// Note: WaitSignalTimeoutTraps is intentionally omitted on AMD. On HIP,
+// abort() in device code terminates the process entirely, unlike CUDA's
+// __trap() which generates a recoverable cudaErrorIllegalInstruction.
+
+TEST_F(P2pIbgdaWaitSignalTimeoutTest, WaitSignalNoTimeoutWhenSatisfied) {
+  HipDeviceBuffer signalBuf(sizeof(uint64_t));
+  auto* d_signalBuf = static_cast<uint64_t*>(signalBuf.get());
+  const uint64_t signalValue = 42;
+  HIPCHECK_TEST(hipMemcpy(
+      d_signalBuf, &signalValue, sizeof(uint64_t), hipMemcpyHostToDevice));
+
+  IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKey(0x1111));
+
+  HipDeviceBuffer successBuf(sizeof(bool));
+  auto* d_success = static_cast<bool*>(successBuf.get());
+  bool initSuccess = false;
+  HIPCHECK_TEST(
+      hipMemcpy(d_success, &initSuccess, sizeof(bool), hipMemcpyHostToDevice));
+
+  runTestWaitSignalNoTimeout(d_signalBuf, localBuf, 0, 1000, d_success);
+  HIPCHECK_TEST(hipDeviceSynchronize());
+
+  bool success = false;
+  HIPCHECK_TEST(
+      hipMemcpy(&success, d_success, sizeof(bool), hipMemcpyDeviceToHost));
+  EXPECT_TRUE(success);
+}
+
+} // namespace pipes_gda::tests
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+#endif

--- a/comms/pipes/amd/verbs/AmdVerbsCompat.h
+++ b/comms/pipes/amd/verbs/AmdVerbsCompat.h
@@ -1,0 +1,328 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// =============================================================================
+// AMD GPU (HIP/ROCm) Compatibility Layer for IBGDA Verbs
+// =============================================================================
+//
+// This header provides AMD GPU equivalents of the CUDA-specific intrinsics and
+// device functions used by IBGDA verbs device-side code.
+//
+// The original NVIDIA implementation in AmdVerbsCompat.h uses:
+// - CUDA PTX inline assembly for memory ordering (ld.relaxed, st.release,
+// fence)
+// - cuda::atomic_ref for lock-free atomic operations with scope control
+// - __ldg() for read-only cache loads
+// - __syncwarp() and __reduce_max_sync() for warp-level primitives
+//
+// This file maps those to AMD GCN/CDNA equivalents using:
+// - __builtin_amdgcn_fence() for memory ordering
+// - __hip_atomic_* builtins for scoped atomics
+// - __builtin_nontemporal_load/store for non-cached I/O
+// - AMD wavefront intrinsics for warp-level operations
+// =============================================================================
+
+#pragma once
+
+#include <hip/hip_runtime.h>
+#include <cstdint>
+
+// =============================================================================
+// Platform Detection
+// =============================================================================
+
+#if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
+#error \
+    "This header requires AMD HIP (ROCm). For NVIDIA GPUs, use the original CUDA headers."
+#endif
+
+// AMD wavefront size: 64 on GCN/CDNA, 32 on RDNA (default to 64 for datacenter
+// GPUs)
+#ifndef AMD_WAVEFRONT_SIZE
+#if defined(__gfx90a__) || defined(__gfx940__) || defined(__gfx941__) || \
+    defined(__gfx942__)
+#define AMD_WAVEFRONT_SIZE 64
+#else
+#define AMD_WAVEFRONT_SIZE 64
+#endif
+#endif
+
+// =============================================================================
+// Memory Ordering / Fence Operations
+// =============================================================================
+
+// AMD equivalent of CUDA PTX: fence.acquire.gpu / fence.acquire.sys
+// Uses __builtin_amdgcn_fence with appropriate scope.
+// "" = system scope (GPU + CPU + PCIe devices like NICs)
+// "agent" = GPU scope (all CUs within the GPU)
+// "workgroup" = workgroup scope
+__device__ __forceinline__ void amd_fence_acquire_system() {
+  __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "");
+}
+
+__device__ __forceinline__ void amd_fence_acquire_device() {
+  __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "agent");
+}
+
+__device__ __forceinline__ void amd_fence_acquire_workgroup() {
+  __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "workgroup");
+}
+
+__device__ __forceinline__ void amd_fence_release_system() {
+  __builtin_amdgcn_fence(__ATOMIC_RELEASE, "");
+}
+
+__device__ __forceinline__ void amd_fence_release_device() {
+  __builtin_amdgcn_fence(__ATOMIC_RELEASE, "agent");
+}
+
+__device__ __forceinline__ void amd_fence_release_workgroup() {
+  __builtin_amdgcn_fence(__ATOMIC_RELEASE, "workgroup");
+}
+
+// Full system-scope memory fence (equivalent to __threadfence_system)
+__device__ __forceinline__ void amd_fence_system() {
+  __builtin_amdgcn_fence(__ATOMIC_SEQ_CST, "");
+}
+
+// =============================================================================
+// Relaxed / Non-temporal Loads (replace CUDA PTX ld.relaxed.sys.global)
+// =============================================================================
+
+// System-scope relaxed loads for memory shared with PCIe devices (NICs).
+// Must use __hip_atomic_load with __HIP_MEMORY_SCOPE_SYSTEM to generate
+// loads with system coherence modifiers (sc0 sc1 on CDNA3), ensuring the
+// GPU sees the latest values written by the NIC (e.g., CQE entries).
+// Plain __atomic_load_n generates loads without coherence modifiers, which
+// may return stale cached values.
+
+__device__ __forceinline__ uint8_t amd_load_relaxed_sys(uint8_t* ptr) {
+  return __hip_atomic_load(ptr, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_SYSTEM);
+}
+
+__device__ __forceinline__ uint32_t amd_load_relaxed_sys(uint32_t* ptr) {
+  return __hip_atomic_load(ptr, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_SYSTEM);
+}
+
+__device__ __forceinline__ uint64_t amd_load_relaxed_sys(uint64_t* ptr) {
+  return __hip_atomic_load(ptr, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_SYSTEM);
+}
+
+// Device-scope relaxed loads (for QP metadata shared among GPU threads)
+__device__ __forceinline__ uint64_t amd_load_relaxed_device(uint64_t* ptr) {
+  return __atomic_load_n(ptr, __ATOMIC_RELAXED);
+}
+
+// =============================================================================
+// MMIO Stores (replace CUDA PTX st.mmio.relaxed.sys.global)
+// =============================================================================
+
+// For writing to NIC doorbell registers mapped into GPU address space.
+// On AMD, we use a volatile store + system fence to ensure visibility to the
+// NIC.
+__device__ __forceinline__ void amd_store_relaxed_mmio_u64(
+    uint64_t* ptr,
+    uint64_t val) {
+  __hip_atomic_store(ptr, val, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_SYSTEM);
+}
+
+__device__ __forceinline__ void amd_store_relaxed_mmio_u32(
+    uint32_t* ptr,
+    uint32_t val) {
+  __hip_atomic_store(ptr, val, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_SYSTEM);
+}
+
+// =============================================================================
+// Byte-swap (replace CUDA PTX prmt.b32 byte permute instructions)
+// ============================================================================
+
+__device__ __forceinline__ uint64_t amd_bswap64(uint64_t x) {
+  return __builtin_bswap64(x);
+}
+
+__device__ __forceinline__ uint32_t amd_bswap32(uint32_t x) {
+  return __builtin_bswap32(x);
+}
+
+__device__ __forceinline__ uint16_t amd_bswap16(uint16_t x) {
+  return __builtin_bswap16(x);
+}
+
+// =============================================================================
+// Lane ID (replace CUDA PTX: mov.u32 %0, %%laneid)
+// =============================================================================
+
+__device__ __forceinline__ unsigned int amd_get_lane_id() {
+  return __lane_id();
+}
+
+// =============================================================================
+// Global Timer (replace CUDA PTX: mov.u64 %0, %%globaltimer)
+// =============================================================================
+
+// AMD uses s_memtime for GPU clock counter (returns 64-bit cycle count)
+__device__ __forceinline__ uint64_t amd_query_global_timer() {
+  return wall_clock64();
+}
+
+// =============================================================================
+// Read-only Cache Load (replace CUDA __ldg())
+// =============================================================================
+
+// On AMD, __ldg equivalent is a const-qualified load.
+// The compiler + hardware will route through the scalar cache or texture cache.
+template <typename T>
+__device__ __forceinline__ T amd_ldg(const T* ptr) {
+  return *ptr; // AMD GCN/CDNA handles caching at HW level
+}
+
+// Specialization for pointer-width loads (uintptr_t)
+__device__ __forceinline__ uintptr_t amd_ldg(const uintptr_t* ptr) {
+  return *ptr;
+}
+
+// =============================================================================
+// Scoped Atomics (replace cuda::atomic_ref<T, cuda::thread_scope_*>)
+// =============================================================================
+
+// fetch_add with device scope
+__device__ __forceinline__ uint64_t
+amd_atomic_add_device(uint64_t* ptr, uint64_t val) {
+  return __hip_atomic_fetch_add(
+      ptr, val, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+}
+
+__device__ __forceinline__ int amd_atomic_add_device(int* ptr, int val) {
+  return __hip_atomic_fetch_add(
+      ptr, val, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+}
+
+// fetch_max with device scope
+__device__ __forceinline__ uint64_t
+amd_atomic_max_device(uint64_t* ptr, uint64_t val) {
+  return __hip_atomic_fetch_max(
+      ptr, val, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+}
+
+// fetch_max with device scope + acquire ordering
+__device__ __forceinline__ uint64_t
+amd_atomic_max_device_acquire(uint64_t* ptr, uint64_t val) {
+  return __hip_atomic_fetch_max(
+      ptr, val, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_AGENT);
+}
+
+// fetch_add with workgroup scope
+__device__ __forceinline__ uint64_t
+amd_atomic_add_workgroup(uint64_t* ptr, uint64_t val) {
+  return __hip_atomic_fetch_add(
+      ptr, val, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_WORKGROUP);
+}
+
+// fetch_max with workgroup scope
+__device__ __forceinline__ uint64_t
+amd_atomic_max_workgroup(uint64_t* ptr, uint64_t val) {
+  return __hip_atomic_fetch_max(
+      ptr, val, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_WORKGROUP);
+}
+
+// compare-exchange with device scope (replace atomicCAS)
+__device__ __forceinline__ int
+amd_atomic_cas_device(int* ptr, int expected, int desired) {
+  __hip_atomic_compare_exchange_strong(
+      ptr,
+      &expected,
+      desired,
+      __ATOMIC_RELAXED,
+      __ATOMIC_RELAXED,
+      __HIP_MEMORY_SCOPE_AGENT);
+  return expected;
+}
+
+// compare-exchange with workgroup scope (replace atomicCAS_block)
+__device__ __forceinline__ int
+amd_atomic_cas_workgroup(int* ptr, int expected, int desired) {
+  __hip_atomic_compare_exchange_strong(
+      ptr,
+      &expected,
+      desired,
+      __ATOMIC_RELAXED,
+      __ATOMIC_RELAXED,
+      __HIP_MEMORY_SCOPE_WORKGROUP);
+  return expected;
+}
+
+// release store with device scope (for unlock operations)
+__device__ __forceinline__ void amd_store_release_device(int* ptr, int val) {
+  __hip_atomic_store(ptr, val, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_AGENT);
+}
+
+__device__ __forceinline__ void amd_store_release_workgroup(int* ptr, int val) {
+  __hip_atomic_store(ptr, val, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_WORKGROUP);
+}
+
+// release store for doorbell record (32-bit, system/agent scope)
+__device__ __forceinline__ void amd_store_release_sys_u32(
+    uint32_t* ptr,
+    uint32_t val) {
+  __hip_atomic_store(ptr, val, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_SYSTEM);
+}
+
+// Direct doorbell store to NIC UAR BlueFlame register (64-bit, system scope).
+// Uses SEQ_CST ordering with system scope to ensure the PCIe posted write
+// reaches the NIC's PCI BAR.
+__device__ __forceinline__ void amd_store_doorbell_sys_u64(
+    uint64_t* ptr,
+    uint64_t val) {
+  __hip_atomic_store(ptr, val, __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_SYSTEM);
+}
+
+// =============================================================================
+// Warp-level Reduction (replace __reduce_max_sync)
+// =============================================================================
+
+// AMD uses DPP (Data Parallel Primitives) or cross-lane shuffle for reductions.
+// For CDNA (MI200/MI300), wavefront is 64 lanes.
+__device__ __forceinline__ uint32_t amd_warp_reduce_max(uint32_t val) {
+  // Butterfly reduction across wavefront using __shfl_xor
+  for (int offset = AMD_WAVEFRONT_SIZE / 2; offset > 0; offset >>= 1) {
+    uint32_t other = __shfl_xor(val, offset);
+    val = val > other ? val : other;
+  }
+  return val;
+}
+
+// =============================================================================
+// Funnel Shift (replace CUDA __funnelshift_r)
+// =============================================================================
+
+// __funnelshift_r(lo, hi, shift) = (lo, hi) >> shift, taking low 32 bits
+// This is used for the div_ceil_aligned_pow2_32bits fast path.
+__device__ __forceinline__ uint32_t
+amd_funnelshift_r(uint32_t lo, uint32_t hi, int shift) {
+  uint64_t combined = (static_cast<uint64_t>(hi) << 32) | lo;
+  return static_cast<uint32_t>(combined >> (shift & 31));
+}
+
+// =============================================================================
+// Utility: ceil division by power-of-2 (replacing CUDA version that uses
+// __funnelshift_r)
+// =============================================================================
+
+__device__ __forceinline__ uint32_t
+amd_div_ceil_aligned_pow2_32bits(uint64_t x, int denominator_shift) {
+  return static_cast<uint32_t>(x >> denominator_shift) +
+      (amd_funnelshift_r(0, static_cast<uint32_t>(x), denominator_shift) != 0
+           ? 1
+           : 0);
+}
+
+// =============================================================================
+// WQE Segment Store (64-byte aligned store for WQE writes)
+// =============================================================================
+
+// Copy a 16-byte WQE segment using 64-bit stores for atomicity
+__device__ __forceinline__ void amd_store_wqe_seg(
+    uint64_t* dst,
+    const uint64_t* src) {
+  dst[0] = src[0];
+  dst[1] = src[1];
+}

--- a/comms/pipes/amd/verbs/VerbsDef.h
+++ b/comms/pipes/amd/verbs/VerbsDef.h
@@ -1,0 +1,159 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved. SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Modifications: (c) Meta Platforms, Inc. and affiliates.
+
+// =============================================================================
+// Common Verbs Definitions (NIC-agnostic)
+// =============================================================================
+//
+// NIC-agnostic constants, enums, and macros shared by all NIC backends.
+// NIC-specific hardware structs are in separate files:
+//   - nic/Mlx5Hsi.h: MLX5 WQE/CQE structs, opcodes, control flags
+//   - nic/BnxtHsi.h: BNXT WQE/CQE structs, opcodes, doorbell
+//
+// Shared constants and enums for GPU-initiated RDMA verbs.
+// =============================================================================
+
+#pragma once
+
+#include <limits.h>
+#include <linux/types.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// =============================================================================
+// Common Macros
+// =============================================================================
+
+#define PIPES_GDA_VOLATILE(x) (*(volatile typeof(x)*)&(x))
+
+#define PIPES_GDA_VERBS_WARP_SIZE 32
+#define PIPES_GDA_VERBS_WARP_FULL_MASK 0xffffffff
+#define PIPES_GDA_VERBS_PAGE_SIZE 65536
+
+#define PIPES_GDA_VERBS_CQE_CI_MASK 0xFFFFFF
+#define PIPES_GDA_VERBS_WQE_PI_MASK 0xFFFF
+
+#define PIPES_GDA_VERBS_MKEY_SWAPPED 1
+
+#ifndef PIPES_GDA_VERBS_ENABLE_DEBUG
+#define PIPES_GDA_VERBS_ENABLE_DEBUG 0
+#endif
+
+#if PIPES_GDA_VERBS_ENABLE_DEBUG == 1
+#include <assert.h>
+#define PIPES_GDA_VERBS_ASSERT(x) assert(x)
+#else
+#define PIPES_GDA_VERBS_ASSERT(x) \
+  do {                            \
+  } while (0)
+#endif
+
+#define PIPES_GDA_VERBS_MAX_INLINE_SIZE 28
+#define PIPES_GDA_VERBS_CQE_SIZE 64
+#define PIPES_GDA_VERBS_WQE_IDX_SHIFT 8
+
+#define PIPES_GDA_VERBS_MAX_TRANSFER_SIZE_SHIFT 30
+#define PIPES_GDA_VERBS_MAX_TRANSFER_SIZE \
+  (1ULL << PIPES_GDA_VERBS_MAX_TRANSFER_SIZE_SHIFT) // 1GiB
+
+#ifndef ACCESS_ONCE
+#define ACCESS_ONCE(x) (*(volatile typeof(x)*)&(x))
+#endif
+
+#ifndef READ_ONCE
+#define READ_ONCE(x) ACCESS_ONCE(x)
+#endif
+
+#ifndef WRITE_ONCE
+#define WRITE_ONCE(x, v) (ACCESS_ONCE(x) = (v))
+#endif
+
+// =============================================================================
+// Common Enums (NIC-agnostic)
+// =============================================================================
+
+enum pipes_gda_gpu_dev_verbs_mem_type {
+  PIPES_GDA_VERBS_MEM_TYPE_AUTO = 0,
+  PIPES_GDA_VERBS_MEM_TYPE_HOST = 1,
+  PIPES_GDA_VERBS_MEM_TYPE_GPU = 2,
+  PIPES_GDA_VERBS_MEM_TYPE_MAX = INT_MAX
+};
+
+enum pipes_gda_gpu_dev_verbs_qp_type {
+  PIPES_GDA_VERBS_QP_SQ = 0,
+};
+
+enum pipes_gda_gpu_dev_verbs_exec_scope {
+  PIPES_GDA_VERBS_EXEC_SCOPE_THREAD = 0,
+  PIPES_GDA_VERBS_EXEC_SCOPE_WARP
+};
+
+enum pipes_gda_gpu_dev_verbs_sync_scope {
+  PIPES_GDA_VERBS_SYNC_SCOPE_SYS = 0,
+  PIPES_GDA_VERBS_SYNC_SCOPE_GPU = 1,
+  PIPES_GDA_VERBS_SYNC_SCOPE_CTA = 2,
+  PIPES_GDA_VERBS_SYNC_SCOPE_MAX = INT_MAX
+};
+
+enum pipes_gda_gpu_dev_verbs_resource_sharing_mode {
+  PIPES_GDA_VERBS_RESOURCE_SHARING_MODE_EXCLUSIVE = 0,
+  PIPES_GDA_VERBS_RESOURCE_SHARING_MODE_CTA = 1,
+  PIPES_GDA_VERBS_RESOURCE_SHARING_MODE_GPU = 2,
+  PIPES_GDA_VERBS_RESOURCE_SHARING_MODE_MAX = INT_MAX
+};
+
+enum pipes_gda_gpu_dev_verbs_nic_handler {
+  PIPES_GDA_VERBS_NIC_HANDLER_AUTO = 0,
+  PIPES_GDA_VERBS_NIC_HANDLER_CPU_PROXY = 1,
+  PIPES_GDA_VERBS_NIC_HANDLER_GPU_SM_DB = 2,
+  PIPES_GDA_VERBS_NIC_HANDLER_GPU_SM_BF = 3,
+  PIPES_GDA_VERBS_NIC_HANDLER_TYPE_MAX,
+};
+
+enum pipes_gda_gpu_dev_verbs_gpu_code_opt {
+  PIPES_GDA_VERBS_GPU_CODE_OPT_DEFAULT = 0,
+  PIPES_GDA_VERBS_GPU_CODE_OPT_ASYNC_STORE_RELEASE = (1 << 0),
+  PIPES_GDA_VERBS_GPU_CODE_OPT_MAX = INT_MAX
+};
+
+enum pipes_gda_gpu_dev_verbs_signal_op {
+  PIPES_GDA_VERBS_SIGNAL_OP_ADD = 0,
+};
+
+#ifdef __cplusplus
+}
+#endif

--- a/comms/pipes/amd/verbs/VerbsDev.h
+++ b/comms/pipes/amd/verbs/VerbsDev.h
@@ -1,0 +1,293 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved. SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file VerbsDev.h
+ * @brief GDAKI common definitions
+ *
+ * @{
+ */
+#ifndef PIPES_GDA_VERBS_DEV_H
+#define PIPES_GDA_VERBS_DEV_H
+
+#include "nic/Mlx5Hsi.h" // @manual
+#include "verbs/VerbsDef.h" // @manual
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @typedef pipes_gda_gpu_dev_verbs_ticket_t
+ * @brief Ticket type used in one-sided APIs.
+ */
+typedef uint64_t pipes_gda_gpu_dev_verbs_ticket_t;
+
+/**
+ * Describes IBGDA dev WQE crtl segment.
+ */
+struct pipes_gda_gpu_dev_verbs_wqe_ctrl_seg {
+  __be32 opmod_idx_opcode; /**< opcode + wqe idx */
+  __be32 qpn_ds; /**< qp number */
+  union {
+    struct {
+      uint8_t signature; /**< signature */
+      uint8_t rsvd[2]; /**< reserved */
+      uint8_t fm_ce_se; /**< fm_ce_se */
+    };
+    struct {
+      __be32 signature_fm_ce_se; /**< all flags in or */
+    };
+  };
+
+  __be32 imm; /**< immediate */
+} __attribute__((__aligned__(8)));
+
+/**
+ * Describes IBGDA dev WQE crtl segment.
+ */
+struct pipes_gda_gpu_dev_verbs_wqe_wait_seg {
+  uint32_t resv[2];
+  __be32 max_index;
+  __be32 qpn_cqn;
+} __attribute__((__packed__)) __attribute__((__aligned__(8)));
+
+/**
+ * @struct pipes_gda_gpu_dev_verbs_addr
+ * @brief This structure holds the address and key of a memory region.
+ */
+struct pipes_gda_gpu_dev_verbs_addr {
+  uint64_t addr;
+  __be32 key;
+};
+
+/**
+ * Describes IBGDA dev general WQE.
+ */
+struct pipes_gda_gpu_dev_verbs_wqe {
+  union {
+    /* Generic inline Data */
+    struct {
+      uint8_t inl_data[64];
+    };
+
+    /* Generic Data */
+    struct {
+      struct pipes_gda_ib_mlx5_wqe_data_seg dseg0;
+      struct pipes_gda_ib_mlx5_wqe_data_seg dseg1;
+      struct pipes_gda_ib_mlx5_wqe_data_seg dseg2;
+      struct pipes_gda_ib_mlx5_wqe_data_seg dseg3;
+    };
+
+    /* Read/Write */
+    struct {
+      struct pipes_gda_gpu_dev_verbs_wqe_ctrl_seg rw_cseg;
+      struct pipes_gda_ib_mlx5_wqe_raddr_seg rw_rseg;
+      struct pipes_gda_ib_mlx5_wqe_data_seg rw_dseg0;
+      struct pipes_gda_ib_mlx5_wqe_data_seg rw_dseg1;
+    };
+
+    /* Atomic */
+    struct {
+      struct pipes_gda_gpu_dev_verbs_wqe_ctrl_seg at_cseg;
+      struct pipes_gda_ib_mlx5_wqe_raddr_seg at_rseg;
+      struct pipes_gda_ib_mlx5_wqe_atomic_seg at_seg;
+      struct pipes_gda_ib_mlx5_wqe_data_seg at_dseg;
+    };
+
+    /* Send */
+    struct {
+      struct pipes_gda_gpu_dev_verbs_wqe_ctrl_seg snd_cseg;
+      struct pipes_gda_ib_mlx5_wqe_data_seg snd_dseg0;
+      struct pipes_gda_ib_mlx5_wqe_data_seg snd_dseg1;
+      struct pipes_gda_ib_mlx5_wqe_data_seg snd_dseg2;
+    };
+
+    /* Wait */
+    struct {
+      struct pipes_gda_gpu_dev_verbs_wqe_ctrl_seg wait_cseg;
+      struct pipes_gda_gpu_dev_verbs_wqe_wait_seg wait_dseg;
+      struct pipes_gda_ib_mlx5_wqe_data_seg padding0;
+      struct pipes_gda_ib_mlx5_wqe_data_seg padding1;
+    };
+  };
+} __attribute__((__aligned__(8)));
+
+/**
+ * Describes IBGDA dev CQ
+ */
+struct pipes_gda_gpu_dev_verbs_cq {
+  uint8_t* cqe_daddr; /**< CQE address */
+  uint32_t cq_num; /**< CQ number */
+  uint32_t cqe_num; /**< Total number of CQEs in CQ */
+  __be32* dbrec; /**< CQE Doorbell Record */
+  uint64_t cqe_ci; /**< CQE Consumer Index */
+  uint32_t cqe_mask; /**< Mask of total number of CQEs in CQ */
+  uint8_t cqe_size; /**< Single CQE size (64B default) */
+  uint64_t cqe_rsvd; /**< All previous CQEs are polled */
+  enum pipes_gda_gpu_dev_verbs_mem_type
+      mem_type; ///< Memory type of the completion queue
+};
+
+// =============================================================================
+// NIC-specific QP extension structures
+// =============================================================================
+// Each NIC backend can store its private state here. The QP struct uses a
+// union so that only one NIC's fields are active at a time. This avoids
+// #ifdef in this header and allows all NIC backends to compile cleanly.
+
+/**
+ * BNXT-specific QP extension fields.
+ */
+struct pipes_gda_gpu_dev_verbs_qp_bnxt {
+  uint32_t sq_depth; ///< SQ depth in slots (not WQEs)
+  uint32_t sq_head; ///< Consumer head pointer (in slots)
+  uint32_t sq_tail; ///< Producer tail pointer (in slots)
+  uint32_t sq_flags; ///< Epoch flags for wrap-around detection
+  uint32_t sq_id; ///< QP ID used in doorbell value
+
+  void* msntbl; ///< MSN table pointer (GPU memory)
+  uint32_t msn; ///< Current MSN index
+  uint32_t msn_tbl_sz; ///< MSN table size (number of entries)
+  uint32_t psn; ///< Current Packet Sequence Number
+  uint32_t psn_sz_log2; ///< log2(PSN entry size)
+  uint64_t mtu; ///< MTU for packet counting
+
+  volatile uint64_t* dbr; ///< GPU-accessible doorbell register pointer
+
+  void* cq_buf; ///< CQ buffer pointer (GPU memory)
+  uint32_t cq_depth; ///< CQ depth (typically 1 for CQE compression)
+
+  int sq_lock; ///< GPU-side spinlock for SQ serialization
+};
+
+/**
+ * MLX5-specific QP extension fields (placeholder for future use).
+ * Currently mlx5 uses the common QP fields directly.
+ */
+struct pipes_gda_gpu_dev_verbs_qp_mlx5 {
+  uint8_t reserved; ///< Placeholder (mlx5 uses common QP fields)
+};
+
+/**
+ * Ionic-specific QP extension fields.
+ * Ionic uses color-bit CQ polling and MSN-based completion tracking.
+ * Doorbell is a 64-bit write to a memory-mapped register.
+ */
+struct pipes_gda_gpu_dev_verbs_qp_ionic {
+  // SQ doorbell register (GPU-mapped via HSA)
+  volatile uint64_t* sq_dbreg; ///< SQ doorbell register pointer
+  uint64_t sq_dbval; ///< SQ base doorbell value (OR'd with masked position)
+  uint16_t sq_mask; ///< SQ index mask (depth - 1)
+
+  // SQ buffer (ionic_v1_wqe entries)
+  void* sq_buf; ///< SQ WQE buffer pointer (GPU-accessible)
+
+  // SQ producer tracking
+  uint32_t sq_prod; ///< Next SQ producer index (atomic)
+  uint32_t sq_dbprod; ///< Last doorbell'd producer index
+  int sq_lock; ///< Spinlock for doorbell serialization
+
+  // CQ doorbell register (GPU-mapped via HSA)
+  volatile uint64_t* cq_dbreg; ///< CQ doorbell register pointer
+  uint64_t cq_dbval; ///< CQ base doorbell value
+  uint16_t cq_mask; ///< CQ index mask (depth - 1, 0 for CCQE mode)
+
+  // CQ buffer (ionic_v1_cqe entries)
+  void* cq_buf; ///< CQ buffer pointer (GPU-accessible)
+
+  // CQ consumer tracking
+  uint32_t cq_pos; ///< Current CQ consumer position
+  uint32_t cq_dbpos; ///< Last doorbell'd CQ consumer position
+  int cq_lock; ///< Spinlock for CQ polling serialization
+
+  // MSN (Message Sequence Number) tracking
+  uint32_t sq_msn; ///< Last completed MSN from CQ
+};
+
+/**
+ * Describes IBGDA dev QP
+ */
+struct pipes_gda_gpu_dev_verbs_qp {
+  uint64_t sq_rsvd_index; ///< All WQE slots prior to this index are reserved
+  uint64_t sq_ready_index; ///< All WQE slots prior to this index are ready
+  uint64_t sq_wqe_pi; /**< SQ WQE producer index */
+  uint32_t sq_num; /**< SQ num */
+  uint32_t sq_num_shift8; /**< SQ num << 8 */
+  uint32_t sq_num_shift8_be; /**< SQ num << 8 big endian */
+  uint32_t sq_num_shift8_be_1ds; /**< SQ num << 8 big endian */
+  uint32_t sq_num_shift8_be_2ds; /**< SQ num << 8 big endian */
+  uint32_t sq_num_shift8_be_3ds; /**< SQ num << 8 big endian */
+  uint32_t sq_num_shift8_be_4ds; /**< SQ num << 8 big endian */
+  int sq_lock; /**< SQ lock */
+  uint16_t sq_wqe_num; /**< Number of SQ WQE slots */
+  uint16_t sq_wqe_mask; /**< SQ WQE index mask (sq_wqe_num - 1) */
+  uint8_t* sq_wqe_daddr; /**< SQ WQE buffer device address */
+  __be32* sq_dbrec; /**< SQ doorbell record address */
+  uint64_t* sq_db; /**< SQ doorbell (BlueFlame UAR) address */
+
+  /* Unused fields (reserved for compatibility) */
+  uint32_t rq_num; /**< RQ number (unused) */
+  uint64_t rq_wqe_pi; /**< RQ WQE producer index (unused) */
+  uint32_t rq_wqe_num; /**< Number of RQ WQE slots (unused) */
+  uint32_t rq_wqe_mask; /**< RQ WQE index mask (unused) */
+  uint8_t* rq_wqe_daddr; /**< RQ WQE buffer device address (unused) */
+  __be32* rq_dbrec; /**< RQ doorbell record address (unused) */
+  uint32_t rcv_wqe_size; /**< Receive WQE size (unused) */
+  uint64_t rq_rsvd_index; /**< All previous WQEs are reserved */
+  uint64_t rq_ready_index; /**< All previous WQEs are ready */
+  int rq_lock; /**< RQ lock */
+
+  struct pipes_gda_gpu_dev_verbs_cq cq_sq; /**< SQ CQ connected to QP */
+  struct pipes_gda_gpu_dev_verbs_cq cq_rq; /**< RQ CQ connected to QP */
+
+  enum pipes_gda_gpu_dev_verbs_nic_handler nic_handler; ///< NIC handler
+  enum pipes_gda_gpu_dev_verbs_mem_type
+      mem_type; ///< Memory type of the completion
+
+  /**
+   * NIC-specific extension fields (union: only one active at a time).
+   * Access via qp->nic.bnxt, qp->nic.mlx5, etc.
+   */
+  union {
+    struct pipes_gda_gpu_dev_verbs_qp_bnxt bnxt;
+    struct pipes_gda_gpu_dev_verbs_qp_mlx5 mlx5;
+    struct pipes_gda_gpu_dev_verbs_qp_ionic ionic;
+  } nic;
+} __attribute__((__aligned__(8)));
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PIPES_GDA_VERBS_DEV_H */
+
+/** @} */

--- a/comms/pipes/amd/verbs/VerbsOps.h
+++ b/comms/pipes/amd/verbs/VerbsOps.h
@@ -1,0 +1,609 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved. SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Modifications: (c) Meta Platforms, Inc. and affiliates.
+
+// =============================================================================
+// VerbsOps - GPU-initiated RDMA one-sided verbs operations for AMD/HIP
+// =============================================================================
+//
+// Provides template helper functions that wrap NIC backend calls into a
+// higher-level API for GPU-initiated RDMA operations (put, signal, fence).
+//
+// All functions are templated on NicBackend for compile-time NIC selection.
+// =============================================================================
+
+#pragma once
+
+#include <cerrno>
+#include <cstddef>
+#include <cstdint>
+
+#include "verbs/VerbsDev.h" // @manual
+
+namespace pipes_gda {
+
+// =============================================================================
+// Low-level WQE operations
+// =============================================================================
+
+template <typename NicBackend>
+__device__ __forceinline__ uint64_t pipes_gda_gpu_dev_verbs_reserve_wq_slots(
+    NicBackend& nic,
+    pipes_gda_gpu_dev_verbs_qp* qp,
+    uint32_t numSlots) {
+  return nic.reserveWqSlots(qp, numSlots);
+}
+
+template <typename NicBackend>
+__device__ __forceinline__ pipes_gda_gpu_dev_verbs_wqe*
+pipes_gda_gpu_dev_verbs_get_wqe_ptr(
+    NicBackend& nic,
+    pipes_gda_gpu_dev_verbs_qp* qp,
+    uint64_t wqeIdx) {
+  return nic.getWqePtr(qp, wqeIdx);
+}
+
+template <typename NicBackend>
+__device__ __forceinline__ void pipes_gda_gpu_dev_verbs_wqe_prepare_write(
+    NicBackend& nic,
+    pipes_gda_gpu_dev_verbs_qp* qp,
+    pipes_gda_gpu_dev_verbs_wqe* wqe,
+    uint64_t wqeIdx,
+    uint8_t ctrlFlags,
+    uint64_t remoteAddr,
+    uint32_t remoteKey,
+    uint64_t localAddr,
+    uint32_t localKey,
+    uint32_t size) {
+  nic.prepareRdmaWriteWqe(
+      qp,
+      wqe,
+      wqeIdx,
+      ctrlFlags,
+      remoteAddr,
+      remoteKey,
+      localAddr,
+      localKey,
+      size);
+}
+
+template <typename NicBackend>
+__device__ __forceinline__ void pipes_gda_gpu_dev_verbs_wqe_prepare_atomic(
+    NicBackend& nic,
+    pipes_gda_gpu_dev_verbs_qp* qp,
+    pipes_gda_gpu_dev_verbs_wqe* wqe,
+    uint64_t wqeIdx,
+    uint8_t ctrlFlags,
+    uint64_t remoteAddr,
+    uint32_t remoteKey,
+    uint64_t localAddr,
+    uint32_t localKey,
+    uint32_t size,
+    uint64_t addVal,
+    uint64_t compareVal) {
+  (void)size;
+  (void)compareVal;
+  nic.prepareAtomicFaWqe(
+      qp,
+      wqe,
+      wqeIdx,
+      ctrlFlags,
+      remoteAddr,
+      remoteKey,
+      localAddr,
+      localKey,
+      addVal);
+}
+
+template <typename NicBackend>
+__device__ __forceinline__ void pipes_gda_gpu_dev_verbs_wqe_prepare_nop(
+    NicBackend& nic,
+    pipes_gda_gpu_dev_verbs_qp* qp,
+    pipes_gda_gpu_dev_verbs_wqe* wqe,
+    uint64_t wqeIdx) {
+  nic.prepareNopWqe(qp, wqe, wqeIdx);
+}
+
+template <typename NicBackend>
+__device__ __forceinline__ void pipes_gda_gpu_dev_verbs_mark_wqes_ready(
+    NicBackend& nic,
+    pipes_gda_gpu_dev_verbs_qp* qp,
+    uint64_t firstIdx,
+    uint64_t lastIdx) {
+  nic.markWqesReady(qp, firstIdx, lastIdx);
+}
+
+template <typename NicBackend>
+__device__ __forceinline__ void pipes_gda_gpu_dev_verbs_submit(
+    NicBackend& nic,
+    pipes_gda_gpu_dev_verbs_qp* qp,
+    uint64_t nextWqeIdx) {
+  nic.ringDoorbell(qp, nextWqeIdx);
+}
+
+template <typename NicBackend>
+__device__ __forceinline__ void pipes_gda_gpu_dev_verbs_wait(
+    NicBackend& nic,
+    pipes_gda_gpu_dev_verbs_qp* qp,
+    uint64_t ticket) {
+  nic.pollCqAt(qp, &qp->cq_sq, ticket);
+}
+
+// =============================================================================
+// High-level composite operations
+// =============================================================================
+
+/**
+ * pipes_gda_gpu_dev_verbs_put - RDMA Write (handles multi-chunk transfers)
+ *
+ * Reserves WQE slots, prepares RDMA WRITE WQEs (splitting into chunks
+ * if size > MAX_TRANSFER_SIZE), marks ready, and submits.
+ */
+template <typename NicBackend>
+__device__ __forceinline__ void pipes_gda_gpu_dev_verbs_put(
+    NicBackend& nic,
+    pipes_gda_gpu_dev_verbs_qp* qp,
+    pipes_gda_gpu_dev_verbs_addr raddr,
+    pipes_gda_gpu_dev_verbs_addr laddr,
+    std::size_t size,
+    uint64_t* out_ticket) {
+  uint32_t numChunks = static_cast<uint32_t>(
+      (size + PIPES_GDA_VERBS_MAX_TRANSFER_SIZE - 1) >>
+      PIPES_GDA_VERBS_MAX_TRANSFER_SIZE_SHIFT);
+  if (numChunks == 0)
+    numChunks = 1;
+
+  uint64_t baseIdx =
+      pipes_gda_gpu_dev_verbs_reserve_wq_slots(nic, qp, numChunks);
+  std::size_t remaining = size;
+
+  for (uint32_t i = 0; i < numChunks; i++) {
+    uint64_t wqeIdx = baseIdx + i;
+    std::size_t chunkSize = remaining > PIPES_GDA_VERBS_MAX_TRANSFER_SIZE
+        ? PIPES_GDA_VERBS_MAX_TRANSFER_SIZE
+        : remaining;
+
+    auto* wqe = pipes_gda_gpu_dev_verbs_get_wqe_ptr(nic, qp, wqeIdx);
+    pipes_gda_gpu_dev_verbs_wqe_prepare_write(
+        nic,
+        qp,
+        wqe,
+        wqeIdx,
+        PIPES_GDA_IB_MLX5_WQE_CTRL_CQ_UPDATE,
+        raddr.addr + i * PIPES_GDA_VERBS_MAX_TRANSFER_SIZE,
+        raddr.key,
+        laddr.addr + i * PIPES_GDA_VERBS_MAX_TRANSFER_SIZE,
+        laddr.key,
+        static_cast<uint32_t>(chunkSize));
+    remaining -= chunkSize;
+  }
+
+  uint64_t lastIdx = baseIdx + numChunks - 1;
+  pipes_gda_gpu_dev_verbs_mark_wqes_ready(nic, qp, baseIdx, lastIdx);
+  pipes_gda_gpu_dev_verbs_submit(nic, qp, lastIdx + 1);
+
+  *out_ticket = lastIdx;
+}
+
+/**
+ * pipes_gda_gpu_dev_verbs_signal - Atomic fetch-add signal
+ *
+ * Posts an atomic fetch-add WQE to the remote signal buffer.
+ */
+template <typename NicBackend>
+__device__ __forceinline__ void pipes_gda_gpu_dev_verbs_signal(
+    NicBackend& nic,
+    pipes_gda_gpu_dev_verbs_qp* qp,
+    pipes_gda_gpu_dev_verbs_addr sig_raddr,
+    pipes_gda_gpu_dev_verbs_addr sig_laddr,
+    uint64_t sig_val,
+    uint64_t* out_ticket) {
+  uint64_t wqeIdx = pipes_gda_gpu_dev_verbs_reserve_wq_slots(nic, qp, 1);
+  auto* wqe = pipes_gda_gpu_dev_verbs_get_wqe_ptr(nic, qp, wqeIdx);
+
+  pipes_gda_gpu_dev_verbs_wqe_prepare_atomic(
+      nic,
+      qp,
+      wqe,
+      wqeIdx,
+      PIPES_GDA_IB_MLX5_WQE_CTRL_CQ_UPDATE,
+      sig_raddr.addr,
+      sig_raddr.key,
+      sig_laddr.addr,
+      sig_laddr.key,
+      sizeof(uint64_t),
+      sig_val,
+      0);
+
+  pipes_gda_gpu_dev_verbs_mark_wqes_ready(nic, qp, wqeIdx, wqeIdx);
+  pipes_gda_gpu_dev_verbs_submit(nic, qp, wqeIdx + 1);
+
+  *out_ticket = wqeIdx;
+}
+
+/**
+ * pipes_gda_gpu_dev_verbs_put_signal - RDMA Write + atomic signal
+ * (non-adaptive)
+ *
+ * Posts data WQEs followed by an atomic signal WQE without NIC fence.
+ */
+template <typename NicBackend>
+__device__ __forceinline__ void pipes_gda_gpu_dev_verbs_put_signal(
+    NicBackend& nic,
+    pipes_gda_gpu_dev_verbs_qp* qp,
+    pipes_gda_gpu_dev_verbs_addr raddr,
+    pipes_gda_gpu_dev_verbs_addr laddr,
+    std::size_t size,
+    pipes_gda_gpu_dev_verbs_addr sig_raddr,
+    pipes_gda_gpu_dev_verbs_addr sig_laddr,
+    uint64_t sig_val,
+    uint64_t* out_ticket) {
+  uint32_t numChunks = static_cast<uint32_t>(
+      (size + PIPES_GDA_VERBS_MAX_TRANSFER_SIZE - 1) >>
+      PIPES_GDA_VERBS_MAX_TRANSFER_SIZE_SHIFT);
+  if (numChunks == 0)
+    numChunks = 1;
+
+  uint64_t baseIdx =
+      pipes_gda_gpu_dev_verbs_reserve_wq_slots(nic, qp, numChunks + 1);
+  std::size_t remaining = size;
+
+  for (uint32_t i = 0; i < numChunks; i++) {
+    uint64_t wqeIdx = baseIdx + i;
+    std::size_t chunkSize = remaining > PIPES_GDA_VERBS_MAX_TRANSFER_SIZE
+        ? PIPES_GDA_VERBS_MAX_TRANSFER_SIZE
+        : remaining;
+
+    auto* wqe = pipes_gda_gpu_dev_verbs_get_wqe_ptr(nic, qp, wqeIdx);
+    pipes_gda_gpu_dev_verbs_wqe_prepare_write(
+        nic,
+        qp,
+        wqe,
+        wqeIdx,
+        PIPES_GDA_IB_MLX5_WQE_CTRL_CQ_UPDATE,
+        raddr.addr + i * PIPES_GDA_VERBS_MAX_TRANSFER_SIZE,
+        raddr.key,
+        laddr.addr + i * PIPES_GDA_VERBS_MAX_TRANSFER_SIZE,
+        laddr.key,
+        static_cast<uint32_t>(chunkSize));
+    remaining -= chunkSize;
+  }
+
+  uint64_t sigIdx = baseIdx + numChunks;
+  auto* sigWqe = pipes_gda_gpu_dev_verbs_get_wqe_ptr(nic, qp, sigIdx);
+  pipes_gda_gpu_dev_verbs_wqe_prepare_atomic(
+      nic,
+      qp,
+      sigWqe,
+      sigIdx,
+      PIPES_GDA_IB_MLX5_WQE_CTRL_CQ_UPDATE,
+      sig_raddr.addr,
+      sig_raddr.key,
+      sig_laddr.addr,
+      sig_laddr.key,
+      sizeof(uint64_t),
+      sig_val,
+      0);
+
+  pipes_gda_gpu_dev_verbs_mark_wqes_ready(nic, qp, baseIdx, sigIdx);
+  pipes_gda_gpu_dev_verbs_submit(nic, qp, sigIdx + 1);
+
+  *out_ticket = sigIdx;
+}
+
+// =============================================================================
+// Utility functions
+// =============================================================================
+
+/**
+ * pipes_gda_fence - Wait for all pending RDMA operations to complete
+ *
+ * Issues a NOP WQE and waits for it to complete. Since WQEs are processed
+ * in order, when the NOP completes, all prior WQEs have been processed.
+ */
+template <typename NicBackend>
+__device__ __forceinline__ void pipes_gda_fence(
+    NicBackend& nic,
+    pipes_gda_gpu_dev_verbs_qp* qp) {
+  uint64_t wqeIdx = pipes_gda_gpu_dev_verbs_reserve_wq_slots(nic, qp, 1);
+  auto* wqe = pipes_gda_gpu_dev_verbs_get_wqe_ptr(nic, qp, wqeIdx);
+
+  pipes_gda_gpu_dev_verbs_wqe_prepare_nop(nic, qp, wqe, wqeIdx);
+  pipes_gda_gpu_dev_verbs_mark_wqes_ready(nic, qp, wqeIdx, wqeIdx);
+  pipes_gda_gpu_dev_verbs_submit(nic, qp, wqeIdx + 1);
+  pipes_gda_gpu_dev_verbs_wait(nic, qp, wqeIdx);
+}
+
+/**
+ * pipes_gda_put_fenced - Fenced RDMA Write with completion
+ *
+ * Issues a fence, then performs an RDMA Write and waits for completion,
+ * then issues another fence.
+ */
+template <typename NicBackend>
+__device__ __forceinline__ void pipes_gda_put_fenced(
+    NicBackend& nic,
+    pipes_gda_gpu_dev_verbs_qp* qp,
+    pipes_gda_gpu_dev_verbs_addr raddr,
+    pipes_gda_gpu_dev_verbs_addr laddr,
+    std::size_t size) {
+  pipes_gda_fence(nic, qp);
+
+  uint64_t ticket;
+  pipes_gda_gpu_dev_verbs_put(nic, qp, raddr, laddr, size, &ticket);
+  pipes_gda_gpu_dev_verbs_wait(nic, qp, ticket);
+
+  pipes_gda_fence(nic, qp);
+}
+
+// =============================================================================
+// Additional primitives
+// =============================================================================
+
+/**
+ * pipes_gda_gpu_dev_verbs_p<T> - Inline RDMA write of a scalar value
+ *
+ * Writes a scalar value to a remote address using an inline RDMA Write WQE.
+ * No local memory region needed — data is embedded in the WQE.
+ * Used by reset_signal() to write zero to remote signal buffer.
+ */
+template <typename T, typename NicBackend>
+__device__ __forceinline__ void pipes_gda_gpu_dev_verbs_p(
+    NicBackend& nic,
+    pipes_gda_gpu_dev_verbs_qp* qp,
+    pipes_gda_gpu_dev_verbs_addr raddr,
+    T value,
+    uint64_t* out_ticket) {
+  uint64_t wqeIdx = pipes_gda_gpu_dev_verbs_reserve_wq_slots(nic, qp, 1);
+  auto* wqe = pipes_gda_gpu_dev_verbs_get_wqe_ptr(nic, qp, wqeIdx);
+
+  nic.prepareInlineWriteWqe(
+      qp,
+      wqe,
+      wqeIdx,
+      PIPES_GDA_IB_MLX5_WQE_CTRL_CQ_UPDATE,
+      raddr.addr,
+      raddr.key,
+      value);
+
+  pipes_gda_gpu_dev_verbs_mark_wqes_ready(nic, qp, wqeIdx, wqeIdx);
+  pipes_gda_gpu_dev_verbs_submit(nic, qp, wqeIdx + 1);
+
+  *out_ticket = wqeIdx;
+}
+
+/**
+ * pipes_gda_gpu_dev_verbs_poll_one_cq_at - Non-blocking CQ poll wrapper
+ *
+ * Returns EBUSY if not yet complete, 0 on success.
+ * Used by wait_local() with timeout.
+ */
+template <typename NicBackend>
+__device__ __forceinline__ int pipes_gda_gpu_dev_verbs_poll_one_cq_at(
+    NicBackend& nic,
+    pipes_gda_gpu_dev_verbs_cq* cq,
+    uint64_t consIndex) {
+  return nic.pollOneCqAt(cq, consIndex);
+}
+
+/**
+ * pipes_gda_gpu_dev_verbs_qp_get_cq_sq - Get pointer to QP's SQ CQ
+ */
+__device__ __forceinline__ pipes_gda_gpu_dev_verbs_cq*
+pipes_gda_gpu_dev_verbs_qp_get_cq_sq(pipes_gda_gpu_dev_verbs_qp* qp) {
+  return &qp->cq_sq;
+}
+
+/**
+ * pipes_gda_gpu_dev_verbs_put_signal_counter - Data write + remote signal +
+ * local counter via companion QP
+ *
+ * Compound operation:
+ * 1. Main QP: RDMA Write data
+ * 2. Main QP: Fenced atomic fetch-add to remote signal buffer
+ * 3. Companion QP: WAIT on main QP signal completion
+ * 4. Companion QP: Atomic fetch-add to local counter buffer
+ */
+template <typename NicBackend>
+__device__ __forceinline__ void pipes_gda_gpu_dev_verbs_put_signal_counter(
+    NicBackend& nic,
+    pipes_gda_gpu_dev_verbs_qp* mainQp,
+    pipes_gda_gpu_dev_verbs_addr raddr,
+    pipes_gda_gpu_dev_verbs_addr laddr,
+    std::size_t size,
+    pipes_gda_gpu_dev_verbs_addr sigRemoteAddr,
+    pipes_gda_gpu_dev_verbs_addr sigSinkAddr,
+    uint64_t sigVal,
+    pipes_gda_gpu_dev_verbs_qp* companionQp,
+    pipes_gda_gpu_dev_verbs_addr counterRemoteAddr,
+    pipes_gda_gpu_dev_verbs_addr counterSinkAddr,
+    uint64_t counterVal) {
+  uint32_t numChunks = static_cast<uint32_t>(
+      (size + PIPES_GDA_VERBS_MAX_TRANSFER_SIZE - 1) >>
+      PIPES_GDA_VERBS_MAX_TRANSFER_SIZE_SHIFT);
+  if (numChunks == 0)
+    numChunks = 1;
+
+  uint64_t mainBase =
+      pipes_gda_gpu_dev_verbs_reserve_wq_slots(nic, mainQp, numChunks + 1);
+  std::size_t remaining = size;
+
+  for (uint32_t i = 0; i < numChunks; i++) {
+    uint64_t wqeIdx = mainBase + i;
+    std::size_t chunkSize = remaining > PIPES_GDA_VERBS_MAX_TRANSFER_SIZE
+        ? PIPES_GDA_VERBS_MAX_TRANSFER_SIZE
+        : remaining;
+
+    auto* wqe = pipes_gda_gpu_dev_verbs_get_wqe_ptr(nic, mainQp, wqeIdx);
+    pipes_gda_gpu_dev_verbs_wqe_prepare_write(
+        nic,
+        mainQp,
+        wqe,
+        wqeIdx,
+        PIPES_GDA_IB_MLX5_WQE_CTRL_CQ_UPDATE,
+        raddr.addr + i * PIPES_GDA_VERBS_MAX_TRANSFER_SIZE,
+        raddr.key,
+        laddr.addr + i * PIPES_GDA_VERBS_MAX_TRANSFER_SIZE,
+        laddr.key,
+        static_cast<uint32_t>(chunkSize));
+    remaining -= chunkSize;
+  }
+
+  uint64_t sigIdx = mainBase + numChunks;
+  auto* sigWqe = pipes_gda_gpu_dev_verbs_get_wqe_ptr(nic, mainQp, sigIdx);
+  pipes_gda_gpu_dev_verbs_wqe_prepare_atomic(
+      nic,
+      mainQp,
+      sigWqe,
+      sigIdx,
+      static_cast<uint8_t>(
+          PIPES_GDA_IB_MLX5_WQE_CTRL_CQ_UPDATE |
+          PIPES_GDA_IB_MLX5_WQE_CTRL_FENCE),
+      sigRemoteAddr.addr,
+      sigRemoteAddr.key,
+      sigSinkAddr.addr,
+      sigSinkAddr.key,
+      sizeof(uint64_t),
+      sigVal,
+      0);
+
+  pipes_gda_gpu_dev_verbs_mark_wqes_ready(nic, mainQp, mainBase, sigIdx);
+  pipes_gda_gpu_dev_verbs_submit(nic, mainQp, sigIdx + 1);
+
+  // Companion QP: WAIT + counter atomic
+  uint64_t compBase =
+      pipes_gda_gpu_dev_verbs_reserve_wq_slots(nic, companionQp, 2);
+
+  uint64_t waitIdx = compBase;
+  auto* waitWqe =
+      pipes_gda_gpu_dev_verbs_get_wqe_ptr(nic, companionQp, waitIdx);
+  nic.prepareWaitWqe(
+      companionQp,
+      waitWqe,
+      waitIdx,
+      PIPES_GDA_IB_MLX5_WQE_CTRL_CQ_UPDATE,
+      mainQp->cq_sq.cq_num,
+      sigIdx);
+
+  uint64_t cntIdx = compBase + 1;
+  auto* cntWqe = pipes_gda_gpu_dev_verbs_get_wqe_ptr(nic, companionQp, cntIdx);
+  pipes_gda_gpu_dev_verbs_wqe_prepare_atomic(
+      nic,
+      companionQp,
+      cntWqe,
+      cntIdx,
+      PIPES_GDA_IB_MLX5_WQE_CTRL_CQ_UPDATE,
+      counterRemoteAddr.addr,
+      counterRemoteAddr.key,
+      counterSinkAddr.addr,
+      counterSinkAddr.key,
+      sizeof(uint64_t),
+      counterVal,
+      0);
+
+  pipes_gda_gpu_dev_verbs_mark_wqes_ready(nic, companionQp, compBase, cntIdx);
+  pipes_gda_gpu_dev_verbs_submit(nic, companionQp, cntIdx + 1);
+}
+
+/**
+ * pipes_gda_gpu_dev_verbs_signal_counter - Remote signal + local counter
+ * (no data write)
+ *
+ * Same as put_signal_counter but without the data write.
+ */
+template <typename NicBackend>
+__device__ __forceinline__ void pipes_gda_gpu_dev_verbs_signal_counter(
+    NicBackend& nic,
+    pipes_gda_gpu_dev_verbs_qp* mainQp,
+    pipes_gda_gpu_dev_verbs_addr sigRemoteAddr,
+    pipes_gda_gpu_dev_verbs_addr sigSinkAddr,
+    uint64_t sigVal,
+    pipes_gda_gpu_dev_verbs_qp* companionQp,
+    pipes_gda_gpu_dev_verbs_addr counterRemoteAddr,
+    pipes_gda_gpu_dev_verbs_addr counterSinkAddr,
+    uint64_t counterVal) {
+  // Main QP: signal atomic
+  uint64_t sigIdx = pipes_gda_gpu_dev_verbs_reserve_wq_slots(nic, mainQp, 1);
+  auto* sigWqe = pipes_gda_gpu_dev_verbs_get_wqe_ptr(nic, mainQp, sigIdx);
+  pipes_gda_gpu_dev_verbs_wqe_prepare_atomic(
+      nic,
+      mainQp,
+      sigWqe,
+      sigIdx,
+      PIPES_GDA_IB_MLX5_WQE_CTRL_CQ_UPDATE,
+      sigRemoteAddr.addr,
+      sigRemoteAddr.key,
+      sigSinkAddr.addr,
+      sigSinkAddr.key,
+      sizeof(uint64_t),
+      sigVal,
+      0);
+
+  pipes_gda_gpu_dev_verbs_mark_wqes_ready(nic, mainQp, sigIdx, sigIdx);
+  pipes_gda_gpu_dev_verbs_submit(nic, mainQp, sigIdx + 1);
+
+  // Companion QP: WAIT + counter atomic
+  uint64_t compBase =
+      pipes_gda_gpu_dev_verbs_reserve_wq_slots(nic, companionQp, 2);
+
+  uint64_t waitIdx = compBase;
+  auto* waitWqe =
+      pipes_gda_gpu_dev_verbs_get_wqe_ptr(nic, companionQp, waitIdx);
+  nic.prepareWaitWqe(
+      companionQp,
+      waitWqe,
+      waitIdx,
+      PIPES_GDA_IB_MLX5_WQE_CTRL_CQ_UPDATE,
+      mainQp->cq_sq.cq_num,
+      sigIdx);
+
+  uint64_t cntIdx = compBase + 1;
+  auto* cntWqe = pipes_gda_gpu_dev_verbs_get_wqe_ptr(nic, companionQp, cntIdx);
+  pipes_gda_gpu_dev_verbs_wqe_prepare_atomic(
+      nic,
+      companionQp,
+      cntWqe,
+      cntIdx,
+      PIPES_GDA_IB_MLX5_WQE_CTRL_CQ_UPDATE,
+      counterRemoteAddr.addr,
+      counterRemoteAddr.key,
+      counterSinkAddr.addr,
+      counterSinkAddr.key,
+      sizeof(uint64_t),
+      counterVal,
+      0);
+
+  pipes_gda_gpu_dev_verbs_mark_wqes_ready(nic, companionQp, compBase, cntIdx);
+  pipes_gda_gpu_dev_verbs_submit(nic, companionQp, cntIdx + 1);
+}
+
+} // namespace pipes_gda

--- a/comms/pipes/amd/verbs/VerbsUtils.h
+++ b/comms/pipes/amd/verbs/VerbsUtils.h
@@ -1,0 +1,271 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <climits>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <string>
+
+#include <fmt/format.h>
+#include <folly/logging/xlog.h>
+
+#include <infiniband/verbs.h>
+
+#include "nic/NicSelector.h" // @manual
+
+namespace pipes_gda::tests {
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+constexpr uint16_t kDefaultQueueSize = 2048;
+constexpr uint8_t kDefaultHopLimit = 255;
+constexpr uint8_t kDefaultPortNum = 1;
+
+// GID index: use 3 for standard mlx5, 1 for FE NIC
+#if defined(USE_FE_NIC)
+constexpr int kDefaultGidIndex = 1;
+#else
+constexpr int kDefaultGidIndex = 3;
+#endif
+
+// =============================================================================
+// IB Device Utilities
+// =============================================================================
+
+/**
+ * Read a sysfs file and return its content as a string.
+ */
+inline std::string readSysfs(const std::string& path) {
+  FILE* f = fopen(path.c_str(), "r");
+  if (!f) {
+    return "";
+  }
+  char buf[256] = {};
+  size_t n = fread(buf, 1, sizeof(buf) - 1, f);
+  fclose(f);
+  // Trim trailing newline
+  while (n > 0 && (buf[n - 1] == '\n' || buf[n - 1] == '\r')) {
+    buf[--n] = '\0';
+  }
+  return std::string(buf);
+}
+
+/**
+ * Get the NUMA node for a PCIe device.
+ * @param pciAddr PCIe address in format "0000:1B:00.0" or "1B:00.0"
+ * @return NUMA node ID, or -1 if not found
+ */
+inline int getNumaNode(const std::string& pciAddr) {
+  // Normalize address to include domain if missing
+  std::string addr = pciAddr;
+  if (addr.length() < 12) { // "0000:XX:XX.X" is 12 chars
+    addr = "0000:" + addr;
+  }
+  // Convert to lowercase for consistency
+  for (char& c : addr) {
+    c = static_cast<char>(tolower(static_cast<unsigned char>(c)));
+  }
+
+  std::string path = "/sys/bus/pci/devices/" + addr + "/numa_node";
+  std::string content = readSysfs(path);
+  if (content.empty()) {
+    return -1;
+  }
+  return std::stoi(content);
+}
+
+/**
+ * Get the PCIe address for an InfiniBand device.
+ * @param ibDevName IB device name (e.g., "mlx5_0")
+ * @return PCIe address or empty string if not found
+ */
+inline std::string getIbDevicePciAddr(const std::string& ibDevName) {
+  std::string symlinkPath = "/sys/class/infiniband/" + ibDevName + "/device";
+  char resolvedPath[PATH_MAX] = {};
+  if (realpath(symlinkPath.c_str(), resolvedPath) == nullptr) {
+    return "";
+  }
+  // resolvedPath is like "/sys/devices/pci0000:00/.../0000:1b:00.0"
+  // Extract the last component which is the PCIe address
+  std::string path(resolvedPath);
+  size_t lastSlash = path.rfind('/');
+  if (lastSlash == std::string::npos) {
+    return "";
+  }
+  return path.substr(lastSlash + 1);
+}
+
+/**
+ * Parse PCIe address and extract bus number.
+ * @param pciAddr PCIe address in format "0000:1B:00.0" or "1B:00.0"
+ * @return Bus number (0-255), or -1 on parse error
+ */
+inline int parsePciBus(const std::string& pciAddr) {
+  // Format: [domain:]bus:device.function
+  // Examples: "0000:1B:00.0" or "1B:00.0"
+  size_t colonPos = pciAddr.find(':');
+  if (colonPos == std::string::npos) {
+    return -1;
+  }
+
+  std::string busStr;
+  size_t secondColon = pciAddr.find(':', colonPos + 1);
+  if (secondColon != std::string::npos) {
+    // Has domain: "0000:1B:00.0"
+    busStr = pciAddr.substr(colonPos + 1, secondColon - colonPos - 1);
+  } else {
+    // No domain: "1B:00.0"
+    busStr = pciAddr.substr(0, colonPos);
+  }
+
+  try {
+    return std::stoi(busStr, nullptr, 16);
+  } catch (...) {
+    return -1;
+  }
+}
+
+/**
+ * Find the closest NIC to a GPU based on PCIe topology.
+ *
+ * Selection criteria (in order of priority):
+ * 1. Same NUMA node as the GPU
+ * 2. Closest PCIe bus number (proxy for physical proximity)
+ *
+ * @param gpuPciAddr GPU's PCIe address (e.g., "0000:1B:00.0")
+ * @return Best NIC device name, or empty string if none found
+ */
+inline std::string findClosestNic(const std::string& gpuPciAddr) {
+  int numDevs = 0;
+  struct ibv_device** devList = ibv_get_device_list(&numDevs);
+  if (!devList || numDevs == 0) {
+    return "";
+  }
+
+  const char* vendorPrefix = pipes_gda::ActiveNicBackend::vendorPrefix();
+  int gpuNuma = getNumaNode(gpuPciAddr);
+  int gpuBus = parsePciBus(gpuPciAddr);
+
+  std::string bestNic;
+  int bestScore = INT_MIN; // Higher is better
+
+  for (int i = 0; i < numDevs; i++) {
+    const char* devName = ibv_get_device_name(devList[i]);
+    if (strncmp(devName, vendorPrefix, strlen(vendorPrefix)) != 0) {
+      continue;
+    }
+
+    std::string nicPciAddr = getIbDevicePciAddr(devName);
+    if (nicPciAddr.empty()) {
+      continue;
+    }
+
+    int nicNuma = getNumaNode(nicPciAddr);
+    int nicBus = parsePciBus(nicPciAddr);
+
+    // Score: NUMA match is worth 1000 points, bus proximity adds 0-255 points
+    int score = 0;
+    if (gpuNuma >= 0 && nicNuma >= 0 && gpuNuma == nicNuma) {
+      score += 1000; // NUMA match is most important
+    }
+    if (gpuBus >= 0 && nicBus >= 0) {
+      // Closer bus numbers suggest closer physical proximity
+      // Max bus difference is 255, so invert to make closer = higher score
+      score += 255 - std::abs(gpuBus - nicBus);
+    }
+
+    XLOGF(
+        DBG,
+        "NIC {} (pci={}, numa={}, bus={}) score={} for GPU (pci={}, numa={}, bus={})",
+        devName,
+        nicPciAddr,
+        nicNuma,
+        nicBus,
+        score,
+        gpuPciAddr,
+        gpuNuma,
+        gpuBus);
+
+    if (score > bestScore) {
+      bestScore = score;
+      bestNic = devName;
+    }
+  }
+
+  ibv_free_device_list(devList);
+
+  if (!bestNic.empty()) {
+    XLOGF(
+        INFO,
+        "Selected NIC {} for GPU {} (score={})",
+        bestNic,
+        gpuPciAddr,
+        bestScore);
+  }
+
+  return bestNic;
+}
+
+/**
+ * Open an IB device by name.
+ * @param name Device name (e.g., "mlx5_0")
+ * @return IB context or nullptr on failure
+ */
+inline struct ibv_context* openIbDevice(const std::string& name) {
+  int numDevs = 0;
+  struct ibv_device** devList = ibv_get_device_list(&numDevs);
+  if (!devList || numDevs == 0) {
+    return nullptr;
+  }
+
+  struct ibv_context* ctx = nullptr;
+  for (int i = 0; i < numDevs; i++) {
+    if (name == ibv_get_device_name(devList[i])) {
+      ctx = ibv_open_device(devList[i]);
+      break;
+    }
+  }
+  ibv_free_device_list(devList);
+  return ctx;
+}
+
+/**
+ * Find the first device matching the selected NIC vendor.
+ * @return Device name or empty string if not found
+ */
+inline std::string findFirstNicDevice() {
+  int numDevs = 0;
+  struct ibv_device** devList = ibv_get_device_list(&numDevs);
+  if (!devList || numDevs == 0) {
+    return "";
+  }
+
+  const char* vendorPrefix = pipes_gda::ActiveNicBackend::vendorPrefix();
+  std::string name;
+  for (int i = 0; i < numDevs; i++) {
+    const char* devName = ibv_get_device_name(devList[i]);
+    if (strncmp(devName, vendorPrefix, strlen(vendorPrefix)) == 0) {
+      name = devName;
+      break;
+    }
+  }
+  ibv_free_device_list(devList);
+  return name;
+}
+
+// Backward-compatible alias for mlx5 builds
+inline std::string findFirstMlx5Device() {
+  return findFirstNicDevice();
+}
+
+// Swap bytes for GPU mkey (required by PIPES_GDA_VERBS_MKEY_SWAPPED).
+// Delegates to the active NIC backend.
+inline uint32_t swapMkey(uint32_t key) {
+  return pipes_gda::ActiveNicBackend::swapMkey(key);
+}
+
+} // namespace pipes_gda::tests

--- a/comms/pipes/collectives/AllToAllv.cuh
+++ b/comms/pipes/collectives/AllToAllv.cuh
@@ -112,7 +112,7 @@ __device__ __forceinline__ void all_to_allv(
     Timeout timeout
     // all arguments below will eventually come from communicator
 ) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   auto group = make_warp_group();
   const auto nranks = transports_per_rank.size();
   PIPES_DEVICE_CHECK(nranks == send_chunk_infos.size());


### PR DESCRIPTION
Summary:

AMD ports of the NVIDIA IBGDA transport tests, following the
`{NvidiaBaseName}Amd{Suffix}` naming convention.

**Tests:**
- `P2pIbgdaTransportDeviceAmdTestMain`: single-GPU unit tests
  (construction, `read_signal`, `wait_signal`, group put / broadcast).
  `WaitSignalTimeoutTraps` is omitted on AMD because HIP `abort()`
  terminates the process (unlike CUDA `__trap()`).
- `MultipeerIbgdaTransportAmdTest`: 12-test 2-rank MPI integration
  suite (basic put+signal, group / multi-warp / block puts,
  parameterized transfer sizes, bidirectional, 100-iter stress,
  signal-only, reset, multiple slots, ready/data handshake).

All `.cu` files guarded by `#if defined(__HIPCC__) || !defined(__CUDACC__)`
so they compile as empty under nvcc.

**Macro infra (def_test.bzl):**
- New `disable_nvidia_ci` flag on `comms_gpu_cpp_distributed_unittest`
  and `comms_gpu_cpp_distributed_unittest_suite`. When True, sets
  `cuda_compatible = False` on the inner `gpu_cpp_binary`, applies
  `amd_only` to `comms_launch_distributed_binary`, and removes Linux
  dev/opt CI labels.

**BUCK:**
- `multipeer_ibgda_transport_test` uses `disable_nvidia_ci = True`.
- `multipeer_ibgda_transport_test_mlx5_binary` adds
  `cuda_compatible = False` + `mpi_bootstrap` dep (the missing dep was
  causing `MpiBootstrap.h` not-found build errors).

Reviewed By: dmwu

Differential Revision: D98509720
