### PR TITLE
Add cudaMemcpyBatchAsync support for NVLink transport (#2195)

### DIFF
--- a/comms/uniflow/benchmarks/bench/NVLinkBandwidthBenchmark.cpp
+++ b/comms/uniflow/benchmarks/bench/NVLinkBandwidthBenchmark.cpp
@@ -115,23 +115,23 @@ struct TransportSession {
   std::shared_ptr<CudaDriverApi> driverApi;
   std::unique_ptr<ScopedEventBaseThread> evbThread;
   std::unique_ptr<NVLinkTransportFactory> factory;
-  VmmAllocation srcAlloc;
-  VmmAllocation dstAlloc;
+  std::unique_ptr<VmmAllocation> srcAlloc;
+  std::unique_ptr<VmmAllocation> dstAlloc;
   std::unique_ptr<Transport> transport;
   std::unique_ptr<RegisteredSegment> localReg;
   std::unique_ptr<RemoteRegisteredSegment> remoteReg;
+  CUmemAllocationHandleType handleType{};
 };
 
-/// Create factory, allocate VMM buffers, create transport, connect,
-/// register segments, and exchange handles with peer.
-/// Returns nullptr on failure.
-std::unique_ptr<TransportSession> setupTransport(
-    const BenchmarkConfig& config,
+/// Create factory, create transport, and connect to peer.
+/// Buffer allocation and segment registration happen per-size via
+/// setupBuffersForSize() to avoid large VMM mappings inflating
+/// small-message latency through TLB pressure.
+std::unique_ptr<TransportSession> setupConnection(
     std::vector<PeerConnection>& peers,
     const BootstrapConfig& bootstrap) {
   auto session = std::make_unique<TransportSession>();
 
-  // --- Device & buffer init ---
   CudaApi cudaApi;
   auto setDevStatus = cudaApi.setDevice(bootstrap.localRank);
   if (!setDevStatus) {
@@ -145,53 +145,8 @@ std::unique_ptr<TransportSession> setupTransport(
   session->evbThread = std::make_unique<ScopedEventBaseThread>("bench-evb");
   session->factory = std::make_unique<NVLinkTransportFactory>(
       bootstrap.localRank, session->evbThread->getEventBase());
+  session->handleType = session->factory->handleType();
 
-  const auto handleType = session->factory->handleType();
-
-  auto srcStatus = session->srcAlloc.init(
-      *session->driverApi, bootstrap.localRank, config.maxSize, handleType);
-  if (srcStatus.hasError()) {
-    UNIFLOW_LOG_ERROR(
-        "NVLinkBandwidthBenchmark: src VmmAllocation failed: {}",
-        srcStatus.error().message());
-    return nullptr;
-  }
-
-  auto dstStatus = session->dstAlloc.init(
-      *session->driverApi, bootstrap.localRank, config.maxSize, handleType);
-  if (dstStatus.hasError()) {
-    UNIFLOW_LOG_ERROR(
-        "NVLinkBandwidthBenchmark: dst VmmAllocation failed: {}",
-        dstStatus.error().message());
-    return nullptr;
-  }
-
-  // Fill source with pattern, zero destination.
-  auto srcMemsetErr =
-      cudaMemset(session->srcAlloc.ptr(), 0xAB, session->srcAlloc.size());
-  if (srcMemsetErr != cudaSuccess) {
-    UNIFLOW_LOG_ERROR(
-        "NVLinkBandwidthBenchmark: cudaMemset(src) failed: {}",
-        cudaGetErrorString(srcMemsetErr));
-    return nullptr;
-  }
-  auto dstMemsetErr =
-      cudaMemset(session->dstAlloc.ptr(), 0, session->dstAlloc.size());
-  if (dstMemsetErr != cudaSuccess) {
-    UNIFLOW_LOG_ERROR(
-        "NVLinkBandwidthBenchmark: cudaMemset(dst) failed: {}",
-        cudaGetErrorString(dstMemsetErr));
-    return nullptr;
-  }
-  auto syncErr = cudaDeviceSynchronize();
-  if (syncErr != cudaSuccess) {
-    UNIFLOW_LOG_ERROR(
-        "NVLinkBandwidthBenchmark: cudaDeviceSynchronize failed: {}",
-        cudaGetErrorString(syncErr));
-    return nullptr;
-  }
-
-  // --- Transport connect ---
   auto localTopology = session->factory->getTopology();
   auto remoteTopologyResult =
       exchangeMetadata(*peers[0].ctrl, localTopology, bootstrap.isRank0());
@@ -231,31 +186,90 @@ std::unique_ptr<TransportSession> setupTransport(
     return nullptr;
   }
 
-  // --- Segment registration ---
+  return session;
+}
+
+/// Allocate VMM buffers of the given size, register segments, and
+/// exchange handles with the peer. Called per message size to ensure
+/// the VMM mapping size matches the transfer size.
+bool setupBuffersForSize(
+    TransportSession& session,
+    size_t bufferSize,
+    std::vector<PeerConnection>& peers,
+    const BootstrapConfig& bootstrap) {
+  session.localReg.reset();
+  session.remoteReg.reset();
+  session.srcAlloc.reset();
+  session.dstAlloc.reset();
+
+  session.srcAlloc = std::make_unique<VmmAllocation>();
+  auto srcStatus = session.srcAlloc->init(
+      *session.driverApi, bootstrap.localRank, bufferSize, session.handleType);
+  if (srcStatus.hasError()) {
+    UNIFLOW_LOG_ERROR(
+        "NVLinkBandwidthBenchmark: src VmmAllocation failed: {}",
+        srcStatus.error().message());
+    return false;
+  }
+
+  session.dstAlloc = std::make_unique<VmmAllocation>();
+  auto dstStatus = session.dstAlloc->init(
+      *session.driverApi, bootstrap.localRank, bufferSize, session.handleType);
+  if (dstStatus.hasError()) {
+    UNIFLOW_LOG_ERROR(
+        "NVLinkBandwidthBenchmark: dst VmmAllocation failed: {}",
+        dstStatus.error().message());
+    return false;
+  }
+
+  auto srcMemsetErr =
+      cudaMemset(session.srcAlloc->ptr(), 0xAB, session.srcAlloc->size());
+  if (srcMemsetErr != cudaSuccess) {
+    UNIFLOW_LOG_ERROR(
+        "NVLinkBandwidthBenchmark: cudaMemset(src) failed: {}",
+        cudaGetErrorString(srcMemsetErr));
+    return false;
+  }
+  auto dstMemsetErr =
+      cudaMemset(session.dstAlloc->ptr(), 0, session.dstAlloc->size());
+  if (dstMemsetErr != cudaSuccess) {
+    UNIFLOW_LOG_ERROR(
+        "NVLinkBandwidthBenchmark: cudaMemset(dst) failed: {}",
+        cudaGetErrorString(dstMemsetErr));
+    return false;
+  }
+  auto syncErr = cudaDeviceSynchronize();
+  if (syncErr != cudaSuccess) {
+    UNIFLOW_LOG_ERROR(
+        "NVLinkBandwidthBenchmark: cudaDeviceSynchronize failed: {}",
+        cudaGetErrorString(syncErr));
+    return false;
+  }
+
   Segment srcSeg(
-      session->srcAlloc.ptr(),
-      session->srcAlloc.size(),
+      session.srcAlloc->ptr(),
+      session.srcAlloc->size(),
       MemoryType::VRAM,
       bootstrap.localRank);
-  auto srcRegResult = session->factory->registerSegment(srcSeg);
+  auto srcRegResult = session.factory->registerSegment(srcSeg);
   if (!srcRegResult) {
     UNIFLOW_LOG_ERROR(
         "NVLinkBandwidthBenchmark: registerSegment(src) failed: {}",
         srcRegResult.error().toString());
-    return nullptr;
+    return false;
   }
 
   Segment dstSeg(
-      session->dstAlloc.ptr(),
-      session->dstAlloc.size(),
+      session.dstAlloc->ptr(),
+      session.dstAlloc->size(),
       MemoryType::VRAM,
       bootstrap.localRank);
-  auto dstRegResult = session->factory->registerSegment(dstSeg);
+  auto dstRegResult = session.factory->registerSegment(dstSeg);
   if (!dstRegResult) {
     UNIFLOW_LOG_ERROR(
         "NVLinkBandwidthBenchmark: registerSegment(dst) failed: {}",
         dstRegResult.error().toString());
-    return nullptr;
+    return false;
   }
 
   auto dstPayload = dstRegResult.value()->serialize();
@@ -265,35 +279,35 @@ std::unique_ptr<TransportSession> setupTransport(
     UNIFLOW_LOG_ERROR(
         "NVLinkBandwidthBenchmark: handle exchange failed: {}",
         remotePayloadResult.error().toString());
-    return nullptr;
+    return false;
   }
 
-  auto remoteHandleResult = session->factory->importSegment(
-      session->dstAlloc.size(), std::move(remotePayloadResult).value());
+  auto remoteHandleResult = session.factory->importSegment(
+      session.dstAlloc->size(), std::move(remotePayloadResult).value());
   if (!remoteHandleResult) {
     UNIFLOW_LOG_ERROR(
         "NVLinkBandwidthBenchmark: importSegment failed: {}",
         remoteHandleResult.error().toString());
-    return nullptr;
+    return false;
   }
 
-  session->localReg = std::make_unique<RegisteredSegment>(
+  session.localReg = std::make_unique<RegisteredSegment>(
       SegmentTest::makeRegistered(srcSeg, std::move(srcRegResult.value())));
 
   auto* nvlinkRemote = dynamic_cast<NVLinkRemoteRegistrationHandle*>(
       remoteHandleResult.value().get());
   if (!nvlinkRemote) {
     UNIFLOW_LOG_ERROR("NVLinkBandwidthBenchmark: failed to cast remote handle");
-    return nullptr;
+    return false;
   }
 
-  session->remoteReg =
+  session.remoteReg =
       std::make_unique<RemoteRegisteredSegment>(SegmentTest::makeRemote(
           nvlinkRemote->mappedPtr(),
           nvlinkRemote->mappedSize(),
           std::move(remoteHandleResult.value())));
 
-  return session;
+  return true;
 }
 
 /// Pre-fault VMM memory paths with a full-size put+get to populate page tables,
@@ -314,7 +328,7 @@ bool prefaultAndVerify(TransportSession& session, size_t maxSize) {
   }
 
   // 2. Zero srcAlloc so we can verify the get overwrites it.
-  auto memsetErr = cudaMemset(session.srcAlloc.ptr(), 0, maxSize);
+  auto memsetErr = cudaMemset(session.srcAlloc->ptr(), 0, maxSize);
   if (memsetErr != cudaSuccess) {
     UNIFLOW_LOG_ERROR(
         "NVLinkBandwidthBenchmark: verification cudaMemset failed: {}",
@@ -337,7 +351,7 @@ bool prefaultAndVerify(TransportSession& session, size_t maxSize) {
   uint8_t hostBuf[kCheckSize] = {};
   auto copyErr = cudaMemcpy(
       hostBuf,
-      session.srcAlloc.ptr(),
+      session.srcAlloc->ptr(),
       std::min(maxSize, kCheckSize),
       cudaMemcpyDeviceToHost);
   if (copyErr != cudaSuccess) {
@@ -360,7 +374,7 @@ bool prefaultAndVerify(TransportSession& session, size_t maxSize) {
 
   // Refill srcAlloc with 0xAB for the benchmark loop.
   auto refillErr =
-      cudaMemset(session.srcAlloc.ptr(), 0xAB, session.srcAlloc.size());
+      cudaMemset(session.srcAlloc->ptr(), 0xAB, session.srcAlloc->size());
   if (refillErr != cudaSuccess) {
     UNIFLOW_LOG_ERROR(
         "NVLinkBandwidthBenchmark: refill cudaMemset failed: {}",
@@ -407,22 +421,31 @@ std::vector<BenchmarkResult> runBenchmarkLoop(
 
   auto runDirection = [&](const std::string& dir) {
     for (auto size : sizes) {
+      if (!setupBuffersForSize(session, size, peers, bootstrap)) {
+        UNIFLOW_LOG_ERROR(
+            "NVLinkBandwidthBenchmark: setupBuffersForSize failed for size {}",
+            size);
+        return;
+      }
+
+      if (isActiveRank) {
+        if (!prefaultAndVerify(session, size)) {
+          UNIFLOW_LOG_ERROR(
+              "NVLinkBandwidthBenchmark: prefault failed for size {}", size);
+          return;
+        }
+      }
+
       const int totalIterations = config.warmupIterations + config.iterations;
       std::vector<double> latenciesUs;
       latenciesUs.reserve(config.iterations);
 
-      // Prepare transfer requests outside the timed region.
-      // Build loopCount identical requests so they can be batched into a
-      // single transport call, pipelining memcpys with one event — matching
-      // nvbandwidth's methodology.
       TransferRequest singleReq{
           .local = session.localReg->span(size_t{0}, size),
           .remote = session.remoteReg->span(size_t{0}, size),
       };
       std::vector<TransferRequest> batchReqs(config.loopCount, singleReq);
 
-      // Per-size barrier keeps rank 1 (passive in unidirectional mode)
-      // in sync with rank 0, preventing early exit and TCP disconnect.
       auto barrierStatus = barrier(peers, bootstrap);
       if (!barrierStatus) {
         UNIFLOW_LOG_ERROR(
@@ -527,13 +550,11 @@ std::vector<BenchmarkResult> NVLinkBandwidthBenchmark::run(
     return {};
   }
 
-  auto session = setupTransport(config, peers, bootstrap);
+  auto session = setupConnection(peers, bootstrap);
   if (!session) {
     return {};
   }
 
-  // In unidirectional mode only rank 0 issues transfers while rank 1 just
-  // participates in barriers (matching nvbandwidth methodology).
   const bool isActiveRank = config.bidirectional || bootstrap.isRank0();
 
   UNIFLOW_LOG_INFO(
@@ -545,12 +566,6 @@ std::vector<BenchmarkResult> NVLinkBandwidthBenchmark::run(
       config.loopCount,
       config.bidirectional ? "bi" : "uni",
       isActiveRank);
-
-  if (isActiveRank) {
-    if (!prefaultAndVerify(*session, config.maxSize)) {
-      return {};
-    }
-  }
 
   auto results = runBenchmarkLoop(
       config, peers, bootstrap, *session, name(), isActiveRank);

--- a/comms/uniflow/benchmarks/scripts/run_nvlink_benchmark.sh
+++ b/comms/uniflow/benchmarks/scripts/run_nvlink_benchmark.sh
@@ -120,6 +120,7 @@ if [[ -n "${HOSTS}" ]]; then
   elif [[ "${GPU_LOWER}" == "h100" ]]; then
     echo "Building uniflow_bench for x86_64 (H100)..."
     BENCH_BIN=$(buck2 build @fbcode//mode/opt \
+      -c fbcode.platform010_cuda_version=12.8 \
       fbcode//comms/uniflow/benchmarks:uniflow_bench \
       --show-full-output 2>/dev/null | awk '{print $2}')
   else

--- a/comms/uniflow/drivers/cuda/CudaApi.cpp
+++ b/comms/uniflow/drivers/cuda/CudaApi.cpp
@@ -80,6 +80,25 @@ Status CudaApi::memcpyAsync(
   return Ok();
 }
 
+#if CUDART_VERSION >= 12080
+Status CudaApi::memcpyBatchAsync(
+    void** dsts,
+    void** srcs,
+    size_t* sizes,
+    size_t count,
+    cudaStream_t stream) {
+  cudaMemcpyAttributes attr{};
+  attr.srcAccessOrder = cudaMemcpySrcAccessOrderStream;
+  size_t attrsIdx = 0;
+  size_t failIdx = SIZE_MAX;
+  CUDA_CHECK(
+      cudaMemcpyBatchAsync(
+          dsts, srcs, sizes, count, &attr, &attrsIdx, 1, &failIdx, stream),
+      ErrCode::DriverError);
+  return Ok();
+}
+#endif
+
 Status CudaApi::memcpyPeerAsync(
     void* dst,
     int dstDevice,

--- a/comms/uniflow/drivers/cuda/CudaApi.cpp
+++ b/comms/uniflow/drivers/cuda/CudaApi.cpp
@@ -80,6 +80,42 @@ Status CudaApi::memcpyAsync(
   return Ok();
 }
 
+#if CUDART_VERSION >= 12080
+Status CudaApi::memcpyBatchAsync(
+    void* const* dsts,
+    const void* const* srcs,
+    const size_t* sizes,
+    size_t count,
+    cudaStream_t stream) {
+  cudaMemcpyAttributes attr{};
+  attr.srcAccessOrder = cudaMemcpySrcAccessOrderStream;
+  size_t attrsIdx = 0;
+#if CUDART_VERSION < 13000
+  // CUDA 12.8 takes non-const dsts/srcs/sizes and a trailing failIdx.
+  size_t failIdx = SIZE_MAX;
+  CUDA_CHECK(
+      cudaMemcpyBatchAsync(
+          const_cast<void**>(dsts),
+          const_cast<void**>(srcs),
+          const_cast<size_t*>(sizes),
+          count,
+          &attr,
+          &attrsIdx,
+          1,
+          &failIdx,
+          stream),
+      ErrCode::DriverError);
+#else
+  // CUDA 13.0+ took const qualifiers and removed failIdx.
+  CUDA_CHECK(
+      cudaMemcpyBatchAsync(
+          dsts, srcs, sizes, count, &attr, &attrsIdx, 1, stream),
+      ErrCode::DriverError);
+#endif
+  return Ok();
+}
+#endif
+
 Status CudaApi::memcpyPeerAsync(
     void* dst,
     int dstDevice,

--- a/comms/uniflow/drivers/cuda/CudaApi.h
+++ b/comms/uniflow/drivers/cuda/CudaApi.h
@@ -38,6 +38,15 @@ class CudaApi {
       cudaMemcpyKind kind,
       cudaStream_t stream);
 
+#if CUDART_VERSION >= 12080
+  virtual Status memcpyBatchAsync(
+      void** dsts,
+      void** srcs,
+      size_t* sizes,
+      size_t count,
+      cudaStream_t stream);
+#endif
+
   virtual Status memcpyPeerAsync(
       void* dst,
       int dstDevice,

--- a/comms/uniflow/drivers/cuda/CudaApi.h
+++ b/comms/uniflow/drivers/cuda/CudaApi.h
@@ -38,6 +38,18 @@ class CudaApi {
       cudaMemcpyKind kind,
       cudaStream_t stream);
 
+#if CUDART_VERSION >= 12080
+  // Batch DMA submission. Available on CUDA 12.8+; the underlying CUDA
+  // signature changed in CUDA 13.0 (failIdx removed), but the wrapper
+  // surface stays stable.
+  virtual Status memcpyBatchAsync(
+      void* const* dsts,
+      const void* const* srcs,
+      const size_t* sizes,
+      size_t count,
+      cudaStream_t stream);
+#endif
+
   virtual Status memcpyPeerAsync(
       void* dst,
       int dstDevice,

--- a/comms/uniflow/drivers/cuda/mock/MockCudaApi.h
+++ b/comms/uniflow/drivers/cuda/mock/MockCudaApi.h
@@ -38,6 +38,17 @@ class MockCudaApi : public CudaApi {
        cudaMemcpyKind kind,
        cudaStream_t stream),
       (override));
+#if CUDART_VERSION >= 12080
+  MOCK_METHOD(
+      Status,
+      memcpyBatchAsync,
+      (void** dsts,
+       void** srcs,
+       size_t* sizes,
+       size_t count,
+       cudaStream_t stream),
+      (override));
+#endif
   MOCK_METHOD(
       Status,
       memcpyPeerAsync,

--- a/comms/uniflow/drivers/cuda/mock/MockCudaApi.h
+++ b/comms/uniflow/drivers/cuda/mock/MockCudaApi.h
@@ -38,6 +38,17 @@ class MockCudaApi : public CudaApi {
        cudaMemcpyKind kind,
        cudaStream_t stream),
       (override));
+#if CUDART_VERSION >= 12080
+  MOCK_METHOD(
+      Status,
+      memcpyBatchAsync,
+      (void* const* dsts,
+       const void* const* srcs,
+       const size_t* sizes,
+       size_t count,
+       cudaStream_t stream),
+      (override));
+#endif
   MOCK_METHOD(
       Status,
       memcpyPeerAsync,

--- a/comms/uniflow/transport/nvlink/NVLinkTransport.cpp
+++ b/comms/uniflow/transport/nvlink/NVLinkTransport.cpp
@@ -84,11 +84,47 @@ std::future<Status> NVLinkTransport::transfer(
                   cudaStream]() mutable noexcept {
     CudaDeviceGuard deviceGuard(*cudaApi, deviceId);
 
-    for (auto& op : ops) {
+#if CUDART_VERSION >= 12080
+    if (ops.size() > 1) {
+      static bool logged = false;
+      if (!logged) {
+        fprintf(
+            stderr,
+            "[uniflow] using cudaMemcpyBatchAsync (CUDART_VERSION=%d, ops=%zu)\n",
+            CUDART_VERSION,
+            ops.size());
+        logged = true;
+      }
+      std::vector<void*> dsts(ops.size());
+      std::vector<void*> srcs(ops.size());
+      std::vector<size_t> sizes(ops.size());
+      for (size_t i = 0; i < ops.size(); ++i) {
+        dsts[i] = ops[i].dst;
+        srcs[i] = const_cast<void*>(ops[i].src);
+        sizes[i] = ops[i].size;
+      }
       CHECK_SET_PROMISE(
           promise,
-          cudaApi->memcpyAsync(
-              op.dst, op.src, op.size, cudaMemcpyDeviceToDevice, cudaStream));
+          cudaApi->memcpyBatchAsync(
+              dsts.data(), srcs.data(), sizes.data(), ops.size(), cudaStream));
+    } else
+#endif
+    {
+      static bool logged = false;
+      if (!logged && ops.size() > 1) {
+        fprintf(
+            stderr,
+            "[uniflow] using cudaMemcpyAsync loop (CUDART_VERSION=%d, ops=%zu)\n",
+            CUDART_VERSION,
+            ops.size());
+        logged = true;
+      }
+      for (auto& op : ops) {
+        CHECK_SET_PROMISE(
+            promise,
+            cudaApi->memcpyAsync(
+                op.dst, op.src, op.size, cudaMemcpyDeviceToDevice, cudaStream));
+      }
     }
 
     // Record a CUDA event after the last memcpy.

--- a/comms/uniflow/transport/nvlink/NVLinkTransport.cpp
+++ b/comms/uniflow/transport/nvlink/NVLinkTransport.cpp
@@ -18,6 +18,7 @@
 #define SYS_pidfd_getfd 438
 #endif
 
+#include <array>
 #include <cerrno>
 #include <cstring>
 
@@ -92,11 +93,45 @@ std::future<Status> NVLinkTransport::transfer(
                   cudaStream]() mutable noexcept {
     CudaDeviceGuard deviceGuard(*cudaApi, deviceId);
 
-    for (auto& op : ops) {
+#if CUDART_VERSION >= 12080
+    if (ops.size() > 1) {
+      // Small inline buffer avoids heap allocation for typical batch sizes.
+      // Falls back to vector for larger batches.
+      constexpr size_t kInlineCap = 16;
+      std::array<void*, kInlineCap> dstsInline;
+      std::array<const void*, kInlineCap> srcsInline;
+      std::array<size_t, kInlineCap> sizesInline;
+      std::vector<void*> dstsHeap;
+      std::vector<const void*> srcsHeap;
+      std::vector<size_t> sizesHeap;
+      void** dsts = dstsInline.data();
+      const void** srcs = srcsInline.data();
+      size_t* sizes = sizesInline.data();
+      if (ops.size() > kInlineCap) {
+        dstsHeap.resize(ops.size());
+        srcsHeap.resize(ops.size());
+        sizesHeap.resize(ops.size());
+        dsts = dstsHeap.data();
+        srcs = srcsHeap.data();
+        sizes = sizesHeap.data();
+      }
+      for (size_t i = 0; i < ops.size(); ++i) {
+        dsts[i] = ops[i].dst;
+        srcs[i] = ops[i].src;
+        sizes[i] = ops[i].size;
+      }
       CHECK_SET_PROMISE(
           promise,
-          cudaApi->memcpyAsync(
-              op.dst, op.src, op.size, cudaMemcpyDeviceToDevice, cudaStream));
+          cudaApi->memcpyBatchAsync(dsts, srcs, sizes, ops.size(), cudaStream));
+    } else
+#endif
+    {
+      for (auto& op : ops) {
+        CHECK_SET_PROMISE(
+            promise,
+            cudaApi->memcpyAsync(
+                op.dst, op.src, op.size, cudaMemcpyDeviceToDevice, cudaStream));
+      }
     }
 
     // Record a CUDA event after the last memcpy.

--- a/comms/uniflow/transport/nvlink/tests/unit/NVLinkTransportTest.cpp
+++ b/comms/uniflow/transport/nvlink/tests/unit/NVLinkTransportTest.cpp
@@ -1895,7 +1895,22 @@ TEST_F(NVLinkTransportPutGetTest, PutMultipleRequestsCopiesAllData) {
 
   cudaEvent_t fakeEvent = reinterpret_cast<cudaEvent_t>(0x70);
 
-  // Expect 3 memcpyAsync calls in order, put: dst=remote, src=local.
+  // Expect a single batched call on CUDA 12.8+, otherwise 3 individual
+  // memcpyAsync calls. put: dst=remote, src=local.
+#if CUDART_VERSION >= 12080
+  EXPECT_CALL(*cudaApiMock_, memcpyBatchAsync(_, _, _, 3, nullptr))
+      .WillOnce(Invoke(
+          [](void** dsts,
+             const void* const* srcs,
+             const size_t* sizes,
+             size_t count,
+             cudaStream_t) -> Status {
+            for (size_t i = 0; i < count; ++i) {
+              std::memcpy(dsts[i], srcs[i], sizes[i]);
+            }
+            return Ok();
+          }));
+#else
   {
     ::testing::InSequence seq;
     EXPECT_CALL(
@@ -1946,6 +1961,7 @@ TEST_F(NVLinkTransportPutGetTest, PutMultipleRequestsCopiesAllData) {
               return Ok();
             }));
   }
+#endif
 
   EXPECT_CALL(*cudaApiMock_, eventCreate(_))
       .WillOnce(DoAll(::testing::SetArgPointee<0>(fakeEvent), Return(Ok())));
@@ -2025,6 +2041,20 @@ TEST_F(NVLinkTransportPutGetTest, PutSubSpanTransfersPartialData) {
   cudaEvent_t fakeEvent = reinterpret_cast<cudaEvent_t>(0x72);
 
   // Sub-spans: only transfer the first half of each region.
+#if CUDART_VERSION >= 12080
+  EXPECT_CALL(*cudaApiMock_, memcpyBatchAsync(_, _, _, 3, nullptr))
+      .WillOnce(Invoke(
+          [](void** dsts,
+             const void* const* srcs,
+             const size_t* sizes,
+             size_t count,
+             cudaStream_t) -> Status {
+            for (size_t i = 0; i < count; ++i) {
+              std::memcpy(dsts[i], srcs[i], sizes[i]);
+            }
+            return Ok();
+          }));
+#else
   {
     ::testing::InSequence seq;
     EXPECT_CALL(
@@ -2079,6 +2109,7 @@ TEST_F(NVLinkTransportPutGetTest, PutSubSpanTransfersPartialData) {
               return Ok();
             }));
   }
+#endif
 
   EXPECT_CALL(*cudaApiMock_, eventCreate(_))
       .WillOnce(DoAll(::testing::SetArgPointee<0>(fakeEvent), Return(Ok())));
@@ -2166,7 +2197,22 @@ TEST_F(NVLinkTransportPutGetTest, GetMultipleRequestsCopiesAllData) {
 
   cudaEvent_t fakeEvent = reinterpret_cast<cudaEvent_t>(0x71);
 
-  // Expect 3 memcpyAsync calls in order, get: dst=local, src=remote.
+  // Expect a single batched call on CUDA 12.8+, otherwise 3 individual
+  // memcpyAsync calls. get: dst=local, src=remote.
+#if CUDART_VERSION >= 12080
+  EXPECT_CALL(*cudaApiMock_, memcpyBatchAsync(_, _, _, 3, nullptr))
+      .WillOnce(Invoke(
+          [](void** dsts,
+             const void* const* srcs,
+             const size_t* sizes,
+             size_t count,
+             cudaStream_t) -> Status {
+            for (size_t i = 0; i < count; ++i) {
+              std::memcpy(dsts[i], srcs[i], sizes[i]);
+            }
+            return Ok();
+          }));
+#else
   {
     ::testing::InSequence seq;
     EXPECT_CALL(
@@ -2217,6 +2263,7 @@ TEST_F(NVLinkTransportPutGetTest, GetMultipleRequestsCopiesAllData) {
               return Ok();
             }));
   }
+#endif
 
   EXPECT_CALL(*cudaApiMock_, eventCreate(_))
       .WillOnce(DoAll(::testing::SetArgPointee<0>(fakeEvent), Return(Ok())));


### PR DESCRIPTION
Summary:

When a `put()`/`get()` call has multiple TransferRequests, use `cudaMemcpyBatchAsync` (CUDA 12.8+) instead of looping over individual `cudaMemcpyAsync` calls. This amortizes CUDA runtime per-call overhead across the batch. Guarded by `#if CUDART_VERSION >= 12080` with fallback to the existing loop on older CUDA.

Also updates the benchmark script to build with CUDA 12.8 for both H100 and GB200 so the batch path is compiled in.

Benchmark results (loop_count=16, 20 iterations, 10 warmup):

H100 (x86, NVLink4):
- 1B: 3.55us -> 2.30us (35% improvement)
- 128B: 3.45us -> 2.23us (35% improvement)
- 1KB: 3.73us -> 2.36us (37% improvement)
- 64KB: 3.98us -> 2.53us (36% improvement)

GB200 (ARM, NVLink5):
- 1B: 3.36us -> 3.15us (6% improvement)
- Minimal improvement on ARM; cudaMemcpyBatchAsync appears less optimized on the Grace CPU than x86.

Reviewed By: rmahidhar, tanquer

Differential Revision: D101876182


