### PR TITLE
Set nolocal topology for MCCL in ReconfigureTest (#2199)

### DIFF
--- a/comms/torchcomms/tests/integration/py/ReconfigureTest.py
+++ b/comms/torchcomms/tests/integration/py/ReconfigureTest.py
@@ -48,6 +48,11 @@ class ReconfigureTest(unittest.TestCase):
             else:
                 if not torch.cuda.is_available():
                     self.skipTest("CUDA is not available")
+
+                if self.backend == "mccl":
+                    os.environ["NCCL_COMM_STATE_DEBUG_TOPO"] = "nolocal"
+                    os.environ["NCCL_IGNORE_TOPO_LOAD_FAILURE"] = "1"
+
                 device_id = self.rank % torch.cuda.device_count()
                 self.device = torch.device(f"cuda:{device_id}")
 


### PR DESCRIPTION
Summary:

Set `NCCL_COMM_STATE_DEBUG_TOPO=nolocal` for the MCCL backend in `ReconfigureTest.setUp()`. This ensures that MCCL reconfigure tests use a topology where `nLocalRanks=1`, which is required for the ctring allreduce algorithm to be supported.

Without this, the `test_reconfigure_then_allreduce` test fails because the default topology has `nLocalRanks > 1`, causing ctring allreduce to be unsupported and silently leaving tensor data unchanged.

Reviewed By: arttianezhu

Differential Revision: D101655614
