### PR TITLE
torchcomms/CMakeLists: support building from torch

### DIFF
--- a/comms/torchcomms/TorchCommPy.cpp
+++ b/comms/torchcomms/TorchCommPy.cpp
@@ -48,7 +48,7 @@ auto py_opaque_class(py::module_& m, const char* name, Extra&&... extra) {
   }
 }
 
-PYBIND11_MODULE(_comms, m) {
+PYBIND11_MODULE(_comms, m, py::mod_gil_not_used()) {
   m.doc() = "Python bindings for TorchComm";
 
   // Bind RedOpType enum

--- a/comms/torchcomms/gloo/CMakeLists.txt
+++ b/comms/torchcomms/gloo/CMakeLists.txt
@@ -1,14 +1,20 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # Extension: torchcomms._comms_gloo
 
-include(FetchContent)
-FetchContent_Declare(
-  gloo
-  GIT_REPOSITORY https://github.com/pytorch/gloo.git
-  GIT_TAG        main
-)
-# fetch but don't build
-FetchContent_Populate(gloo)
+if(DEFINED PYTORCH_GLOO_SOURCE_DIR AND EXISTS "${PYTORCH_GLOO_SOURCE_DIR}/gloo")
+  set(gloo_SOURCE_DIR "${PYTORCH_GLOO_SOURCE_DIR}")
+elseif(EXISTS "${ROOT}/../gloo/gloo")
+  set(gloo_SOURCE_DIR "${ROOT}/../gloo")
+else()
+  include(FetchContent)
+  FetchContent_Declare(
+    gloo
+    GIT_REPOSITORY https://github.com/pytorch/gloo.git
+    GIT_TAG        main
+  )
+  # fetch but don't build
+  FetchContent_Populate(gloo)
+endif()
 
 file(GLOB TORCHCOMMS_GLOO_SOURCES "comms/torchcomms/gloo/*.cpp")
 

--- a/comms/torchcomms/gloo/TorchCommGlooPy.cpp
+++ b/comms/torchcomms/gloo/TorchCommGlooPy.cpp
@@ -11,7 +11,7 @@
 namespace py = pybind11;
 using namespace torch::comms;
 
-PYBIND11_MODULE(_comms_gloo, m) {
+PYBIND11_MODULE(_comms_gloo, m, py::mod_gil_not_used()) {
   m.doc() = "Gloo specific python bindings for TorchComm";
 
   py::class_<TorchCommGloo, std::shared_ptr<TorchCommGloo>>(m, "TorchCommGloo");

--- a/comms/torchcomms/nccl/CMakeLists.txt
+++ b/comms/torchcomms/nccl/CMakeLists.txt
@@ -8,6 +8,9 @@ if(USE_SYSTEM_LIBS)
     # Use system installed NCCL
     set(NCCL_INCLUDE "${CONDA_INCLUDE}")
     set(NCCL_SHARED_LIB "${CONDA_LIB}/libnccl.so")
+elseif(DEFINED TORCHCOMMS_NCCL_INCLUDE AND DEFINED TORCHCOMMS_NCCL_LIBRARY)
+    set(NCCL_INCLUDE "${TORCHCOMMS_NCCL_INCLUDE}")
+    set(NCCL_SHARED_LIB "${TORCHCOMMS_NCCL_LIBRARY}")
 elseif(EXISTS "${TORCH_INSTALL_PREFIX}/../build/nccl/include/nccl.h")
     # Use NCCL from PyTorch source build
     set(NCCL_INCLUDE "${TORCH_INSTALL_PREFIX}/../build/nccl/include")
@@ -48,6 +51,10 @@ target_link_libraries(torchcomms_comms_nccl PRIVATE
     ${TORCH_PYTHON_LIB}
 )
 if(USE_SYSTEM_LIBS)
+    target_link_libraries(torchcomms_comms_nccl PRIVATE
+        ${NCCL_SHARED_LIB}
+    )
+elseif(DEFINED TORCHCOMMS_NCCL_INCLUDE AND DEFINED TORCHCOMMS_NCCL_LIBRARY)
     target_link_libraries(torchcomms_comms_nccl PRIVATE
         ${NCCL_SHARED_LIB}
     )

--- a/comms/torchcomms/nccl/TorchCommNCCLPy.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCLPy.cpp
@@ -11,7 +11,7 @@
 namespace py = pybind11;
 using namespace torch::comms;
 
-PYBIND11_MODULE(_comms_nccl, m) {
+PYBIND11_MODULE(_comms_nccl, m, py::mod_gil_not_used()) {
   m.doc() = "NCCL specific python bindings for TorchComm";
 
   py::class_<TorchCommNCCL, std::shared_ptr<TorchCommNCCL>>(m, "TorchCommNCCL");

--- a/comms/torchcomms/ncclx/TorchCommNCCLXPy.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXPy.cpp
@@ -16,7 +16,7 @@ using namespace torch::comms;
 template <typename T, typename... TOptions>
 using intrusive_ptr_class_ = py::class_<T, c10::intrusive_ptr<T>, TOptions...>;
 
-PYBIND11_MODULE(_comms_ncclx, m) {
+PYBIND11_MODULE(_comms_ncclx, m, py::mod_gil_not_used()) {
   m.doc() = "NCCLX specific python bindings for TorchComm";
 
   intrusive_ptr_class_<TorchCommNCCLXPersistentRequest>(

--- a/comms/torchcomms/rccl/TorchCommRCCLPy.cpp
+++ b/comms/torchcomms/rccl/TorchCommRCCLPy.cpp
@@ -11,7 +11,7 @@
 namespace py = pybind11;
 using namespace torch::comms;
 
-PYBIND11_MODULE(_comms_rccl, m) {
+PYBIND11_MODULE(_comms_rccl, m, py::mod_gil_not_used()) {
   m.doc() = "RCCL specific python bindings for TorchComm";
 
   py::class_<TorchCommRCCL, std::shared_ptr<TorchCommRCCL>>(m, "TorchCommRCCL");

--- a/comms/torchcomms/rcclx/TorchCommRCCLXPy.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLXPy.cpp
@@ -11,7 +11,7 @@
 namespace py = pybind11;
 using namespace torch::comms;
 
-PYBIND11_MODULE(_comms_rcclx, m) {
+PYBIND11_MODULE(_comms_rcclx, m, py::mod_gil_not_used()) {
   m.doc() = "RCCLX specific python bindings for TorchComm";
 
   py::class_<TorchCommRCCLX, std::shared_ptr<TorchCommRCCLX>>(

--- a/comms/torchcomms/transport/RdmaTransportPy.cpp
+++ b/comms/torchcomms/transport/RdmaTransportPy.cpp
@@ -23,7 +23,7 @@ folly::ScopedEventBaseThread& getScopedEventBaseThread() {
 }
 } // namespace
 
-PYBIND11_MODULE(_transport, m) {
+PYBIND11_MODULE(_transport, m, py::mod_gil_not_used()) {
   m.doc() = "RdmaTransport python bindings for TorchComm";
 
   py::class_<RdmaRemoteBuffer, std::shared_ptr<RdmaRemoteBuffer>>(

--- a/comms/torchcomms/xccl/TorchCommXCCLPy.cpp
+++ b/comms/torchcomms/xccl/TorchCommXCCLPy.cpp
@@ -9,7 +9,7 @@
 namespace py = pybind11;
 using namespace torch::comms;
 
-PYBIND11_MODULE(_comms_xccl, m) {
+PYBIND11_MODULE(_comms_xccl, m, py::mod_gil_not_used()) {
   m.doc() = "XCCL specific python bindings for TorchComm";
 
   py::class_<TorchCommXCCL, std::shared_ptr<TorchCommXCCL>>(m, "TorchCommXCCL");


### PR DESCRIPTION
This allows overriding paths so we can share the torch copies of gloo/nccl. It also sets nogil to avoid throwing warnings on Python 3.13t/3.14t.

See https://github.com/pytorch/pytorch/pull/181046 for details.