### PR TITLE
Decouple ProxyTraceFunc from ctranComm/statex and refactor ProxyTraceDistTest (#2201)

### DIFF
--- a/comms/ncclx/meta/colltrace/ProxyTraceFunc.cc
+++ b/comms/ncclx/meta/colltrace/ProxyTraceFunc.cc
@@ -7,10 +7,10 @@
 #include "meta/colltrace/ProxyTrace.h"
 
 namespace ncclx::colltrace {
-void proxyTraceInfoCopy(ncclProxyOp& proxyOp, CtranComm* comm) {
-  proxyOp.traceArgs.collInfo.commHash = comm->statex_->commHash();
-  proxyOp.traceArgs.collInfo.opCount = *comm->opCount_;
-  proxyOp.traceArgs.rank = comm->statex_->rank();
+void proxyTraceInfoCopy(ncclProxyOp& proxyOp, ncclComm* comm) {
+  proxyOp.traceArgs.collInfo.commHash = comm->commHash;
+  proxyOp.traceArgs.collInfo.opCount = comm->opCount;
+  proxyOp.traceArgs.rank = comm->rank;
 
   proxyOp.traceArgs.remoteRank = proxyOp.root;
 }
@@ -23,7 +23,7 @@ void proxyTraceAddBasicInfo(
   proxyOp.traceArgs.collInfo.coll = coll;
 }
 
-ncclResult_t proxyTraceInit(struct ncclProxyState* state, CtranComm* comm) {
+ncclResult_t proxyTraceInit(struct ncclProxyState* state, ncclComm* comm) {
   if (NCCL_PROXYTRACE.empty()) {
     return ncclSuccess;
   }
@@ -31,7 +31,7 @@ ncclResult_t proxyTraceInit(struct ncclProxyState* state, CtranComm* comm) {
       ncclx::colltrace::NetworkPerfMonitor::getInstance();
   if (networkPerfMonitorPtr != nullptr && comm != nullptr) {
     networkPerfMonitorPtr->storeCommInfo(
-        comm->logMetaData_, comm->statex_->cudaDev(), comm->statex_->busId());
+        comm->logMetaData, comm->cudaDev, comm->busId);
   }
   try {
     state->trace = std::make_unique<ProxyTrace>();
@@ -39,7 +39,7 @@ ncclResult_t proxyTraceInit(struct ncclProxyState* state, CtranComm* comm) {
     WARN(
         "PROXYTRACE: failed to initialize ProxyTrace, comm %p commDesc %s: %s",
         comm,
-        comm->config_.commDesc.c_str(),
+        comm->config.commDesc ? comm->config.commDesc : "",
         e.what());
     return ncclInternalError;
   }

--- a/comms/ncclx/meta/colltrace/ProxyTraceFunc.h
+++ b/comms/ncclx/meta/colltrace/ProxyTraceFunc.h
@@ -5,32 +5,17 @@
 #include "comm.h"
 #include "proxy.h"
 
-#include "comms/ctran/CtranComm.h"
 #include "meta/colltrace/ProxyTrace.h"
 
 namespace ncclx::colltrace {
-void proxyTraceInfoCopy(ncclProxyOp& proxyOp, CtranComm* comm);
-
-// TODO: remove this function after refactoring done
-// !!! DO NOT USE THIS FUNCTION !!!
-inline void proxyTraceInfoCopy(ncclProxyOp& proxyOp, ncclComm* comm) {
-  proxyTraceInfoCopy(proxyOp, comm->ctranComm_.get());
-}
+void proxyTraceInfoCopy(ncclProxyOp& proxyOp, ncclComm* comm);
 
 void proxyTraceAddBasicInfo(
     ncclProxyOp& proxyOp,
     int nChannels,
     ncclFunc_t coll);
 
-ncclResult_t proxyTraceInit(struct ncclProxyState* state, CtranComm* comm);
-
-// TODO: remove this once ctran refactoring is done
-// !!! DO NOT USE THIS FUNCTION !!!
-inline ncclResult_t proxyTraceInit(
-    struct ncclProxyState* state,
-    ncclComm* comm) {
-  return proxyTraceInit(state, comm->ctranComm_.get());
-}
+ncclResult_t proxyTraceInit(struct ncclProxyState* state, ncclComm* comm);
 
 ncclResult_t proxyTraceDestroy(struct ncclProxyState* state);
 } // namespace ncclx::colltrace

--- a/comms/ncclx/meta/colltrace/tests/ProxyTraceDistTest.cc
+++ b/comms/ncclx/meta/colltrace/tests/ProxyTraceDistTest.cc
@@ -11,7 +11,6 @@
 #include <set>
 #include <unordered_map>
 
-#include "comms/ctran/Ctran.h"
 #include "comms/ncclx/meta/tests/NcclCommUtils.h"
 #include "comms/ncclx/meta/tests/NcclxBaseTest.h"
 #include "comms/testinfra/TestUtils.h"
@@ -33,11 +32,14 @@ class ProxyTraceTest : public NcclxBaseTestFixture {
     // calls initEnv() (call_once) + ncclCvarInit(). Per-test EnvRAII overrides
     // won't take effect for cvars read during init.
     NcclxBaseTestFixture::SetUp({
-        {"NCCL_CTRAN_ENABLE", "1"},
         {"NCCL_PROXYTRACE", "trace"},
         {"NCCL_COLLTRACE", "trace"},
         {"NCCL_DEBUG", "INFO"},
         {"NCCL_DEBUG_SUBSYS", "INIT,COLL"},
+        // Simulate 2 nodes on single physical node: ranks 0-1 on node_0,
+        // ranks 2-3 on node_1. NCCL uses NCCL_HOSTID to determine node
+        // membership, so different hostids produce different comm->node values.
+        {"NCCL_HOSTID", "node_" + std::to_string(globalRank / 2)},
     });
     CUDACHECK_TEST(cudaStreamCreate(&stream));
   }
@@ -270,19 +272,9 @@ class ProxyTraceTest : public NcclxBaseTestFixture {
   };
 
   bool checkTestRequirement(ncclComm_t comm) {
-    // FIXME: this check seems flaky on RE when using with socket transport
-    // Disable it for now to unblock other DIFF landing. More investigation is
-    // needed.
-    //
-    // We don't have a good way to detect whether baseline IB transport is
-    // turned on. Thus, use ctran IB backend to valid for now.
-    if (comm->nNodes < 2 || !ctranInitialized(comm->ctranComm_.get()) ||
-        !comm->ctranComm_->ctran_->mapper->hasBackend()) {
+    if (comm->nNodes < 2) {
       std::cout
-          << "This test requires 2+ nodes and valid IB transport, but nNodes="
-          << comm->nNodes << ", ctranInitialized(comm)="
-          << ctranInitialized(comm->ctranComm_.get())
-          << ", hasBackend()=" << comm->ctranComm_->ctran_->mapper->hasBackend()
+          << "This test requires 2+ nodes, but nNodes=" << comm->nNodes
           << ". Skip test "
           << ::testing::UnitTest::GetInstance()->current_test_info()->name()
           << std::endl;
@@ -702,7 +694,7 @@ TEST_F(ProxyTraceTest, CTAndPTOpCountsMatch) {
   ASSERT_TRUE(ctDumpResult.hasValue()) << "CommDumpPlugin dump failed";
   const auto& ctDump = ctDumpResult.value();
 
-  // Build sets of collIds (opCounts) from CT and PT pastColls
+  // Build sets of collIds (opCounts) (collId) from CT and PT pastColls
   std::set<uint64_t> ctOpCounts;
   for (const auto& coll : ctDump.pastColls) {
     ctOpCounts.insert(coll->getCollId());


### PR DESCRIPTION
Summary:

ProxyTrace is baseline-only (ctran uses MapperTrace), so ProxyTraceFunc should never access ctranComm internals:
- Change `proxyTraceInfoCopy` and `proxyTraceInit` to take `ncclComm*` directly instead of `CtranComm*`
- Read commHash, rank, opCount, cudaDev, busId from ncclComm fields instead of `ctranComm->statex_`, which is nullptr when ctran is disabled
- Remove CtranComm.h include from ProxyTraceFunc.h and the deprecated inline wrappers
- Fixes SIGSEGV in proxyTraceInfoCopy when ctran is disabled (statex_ is null)

Refactor ProxyTraceDistTest to decouple from ctran:
- Remove NCCL_CTRAN_ENABLE from SetUp

Schedule test on single RE node as workaround for multi-host RE issue:
- Use NCCL_HOSTID per rank to simulate 2 nodes on single physical node (ranks 0-1 on node_0, ranks 2-3 on node_1)
- Change config from 2x2 to 1x4 (avoids multi-node RE scheduling issues)

Reviewed By: SuhitK

Differential Revision: D101856933
