### PR TITLE
Add ncclShrink/ncclGrow support for reconfiguration (#2202)

### DIFF
--- a/comms/torchcomms/nccl/NcclApi.cpp
+++ b/comms/torchcomms/nccl/NcclApi.cpp
@@ -69,6 +69,68 @@ ncclResult_t DefaultNcclApi::commSplit(
   return ncclCommSplit(comm, color, key, newcomm, config);
 }
 
+ncclResult_t DefaultNcclApi::commShrink(
+    ncclComm_t comm,
+    int* excludeRanksList,
+    int excludeRanksCount,
+    ncclComm_t* newcomm,
+    ncclConfig_t* config,
+    int shrinkFlags) {
+  std::lock_guard<std::mutex> lock(api_mutex_);
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 27, 0)
+  return ncclCommShrink(
+      comm, excludeRanksList, excludeRanksCount, newcomm, config, shrinkFlags);
+#else
+  (void)comm;
+  (void)excludeRanksList;
+  (void)excludeRanksCount;
+  (void)newcomm;
+  (void)config;
+  (void)shrinkFlags;
+  TC_LOG(ERROR) << "NCCL version " << NCCL_VERSION_CODE
+                << " does not support ncclCommShrink API";
+  return ncclInvalidUsage;
+#endif
+}
+
+ncclResult_t DefaultNcclApi::commGetUniqueId(
+    ncclComm_t comm,
+    ncclUniqueId* uniqueId) {
+  std::lock_guard<std::mutex> lock(api_mutex_);
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)
+  return ncclCommGetUniqueId(comm, uniqueId);
+#else
+  (void)comm;
+  (void)uniqueId;
+  TC_LOG(ERROR) << "NCCL version " << NCCL_VERSION_CODE
+                << " does not support ncclCommGetUniqueId API";
+  return ncclInvalidUsage;
+#endif
+}
+
+ncclResult_t DefaultNcclApi::commGrow(
+    ncclComm_t comm,
+    int nRanks,
+    const ncclUniqueId* uniqueId,
+    int rank,
+    ncclComm_t* newcomm,
+    ncclConfig_t* config) {
+  std::lock_guard<std::mutex> lock(api_mutex_);
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)
+  return ncclCommGrow(comm, nRanks, uniqueId, rank, newcomm, config);
+#else
+  (void)comm;
+  (void)nRanks;
+  (void)uniqueId;
+  (void)rank;
+  (void)newcomm;
+  (void)config;
+  TC_LOG(ERROR) << "NCCL version " << NCCL_VERSION_CODE
+                << " does not support ncclCommGrow API";
+  return ncclInvalidUsage;
+#endif
+}
+
 ncclResult_t DefaultNcclApi::commRegister(
     ncclComm_t comm,
     void* buffer,

--- a/comms/torchcomms/nccl/NcclApi.hpp
+++ b/comms/torchcomms/nccl/NcclApi.hpp
@@ -47,6 +47,26 @@ class NcclApi {
       ncclComm_t* newcomm,
       ncclConfig_t* config) = 0;
 
+  [[nodiscard]] virtual ncclResult_t commShrink(
+      ncclComm_t comm,
+      int* excludeRanksList,
+      int excludeRanksCount,
+      ncclComm_t* newcomm,
+      ncclConfig_t* config,
+      int shrinkFlags) = 0;
+
+  [[nodiscard]] virtual ncclResult_t commGetUniqueId(
+      ncclComm_t comm,
+      ncclUniqueId* uniqueId) = 0;
+
+  [[nodiscard]] virtual ncclResult_t commGrow(
+      ncclComm_t comm,
+      int nRanks,
+      const ncclUniqueId* uniqueId,
+      int rank,
+      ncclComm_t* newcomm,
+      ncclConfig_t* config) = 0;
+
   // Memory registration
   [[nodiscard]] virtual ncclResult_t
   commRegister(ncclComm_t comm, void* buffer, size_t size, void** handle) = 0;
@@ -193,6 +213,26 @@ class DefaultNcclApi : public NcclApi {
       ncclComm_t comm,
       int color,
       int key,
+      ncclComm_t* newcomm,
+      ncclConfig_t* config) override;
+
+  [[nodiscard]] ncclResult_t commShrink(
+      ncclComm_t comm,
+      int* excludeRanksList,
+      int excludeRanksCount,
+      ncclComm_t* newcomm,
+      ncclConfig_t* config,
+      int shrinkFlags) override;
+
+  [[nodiscard]] ncclResult_t commGetUniqueId(
+      ncclComm_t comm,
+      ncclUniqueId* uniqueId) override;
+
+  [[nodiscard]] ncclResult_t commGrow(
+      ncclComm_t comm,
+      int nRanks,
+      const ncclUniqueId* uniqueId,
+      int rank,
       ncclComm_t* newcomm,
       ncclConfig_t* config) override;
 

--- a/comms/torchcomms/nccl/TorchCommNCCL.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCL.cpp
@@ -3,6 +3,7 @@
 #include "comms/torchcomms/nccl/TorchCommNCCL.hpp"
 
 #include <cstdlib>
+#include <cstring>
 #include <stdexcept>
 #include <string>
 
@@ -15,6 +16,7 @@
 #include "comms/torchcomms/TorchCommFactory.hpp"
 #include "comms/torchcomms/nccl/TorchCommNCCLBootstrap.hpp"
 #include "comms/torchcomms/utils/Logging.hpp"
+#include "comms/torchcomms/utils/StoreManager.hpp"
 #include "comms/torchcomms/utils/TracingGuard.hpp"
 #include "comms/torchcomms/utils/Utils.hpp"
 
@@ -87,27 +89,31 @@ void TorchCommNCCL::init(
     at::Device device,
     const std::string& name,
     const CommOptions& options) {
-  // Initialize private members
+  TC_LOG(INFO, this) << "Initializing TorchCommNCCL for device: " << device;
   device_ = device;
   name_ = name;
   options_ = options;
 
-  // Only initialize once
   if (init_state_ == InitializationState::INITIALIZED) {
     throw std::runtime_error("TorchCommNCCL already initialized");
   } else if (init_state_ == InitializationState::FINALIZED) {
     throw std::runtime_error("TorchCommNCCL already finalized");
   }
-  init_state_ = InitializationState::INITIALIZED;
 
-  // Initialize default NCCL API implementation if not already set
   if (!nccl_api_) {
     nccl_api_ = std::make_unique<DefaultNcclApi>();
   }
 
-  // Initialize default CUDA API implementation if not already set
   if (!cuda_api_) {
     cuda_api_ = std::make_unique<DefaultCudaApi>();
+  }
+
+  if (options.enable_reconfigure) {
+    options_.enable_reconfigure = true;
+    reconfigure_store_ = options_.store;
+    TC_LOG(INFO, this)
+        << "TorchCommNCCL dynamic regime enabled, deferring initialization";
+    return;
   }
 
   if (device_.index() == -1 || nccl_comm_ == nullptr) {
@@ -120,13 +126,20 @@ void TorchCommNCCL::init(
     }
   }
 
-  // Set CUDA device and verify it's accessible
+  initNcclResources();
+
+  init_state_ = InitializationState::INITIALIZED;
+  TracingGuard tracingGuard(name_, comm_size_, "init", rank_);
+
+  TC_LOG(INFO, this) << "TorchCommNCCL initialized for rank: " << rank_;
+}
+
+void TorchCommNCCL::initNcclResources() {
   CUDA_CHECK(
       cuda_api_,
       cuda_api_->setDevice(device_.index()),
       fmt::format("Failed to set CUDA device to {}", device_.index()));
 
-  // Verify device properties and memory availability
   cudaDeviceProp device_prop = {};
   CUDA_CHECK(
       cuda_api_,
@@ -134,23 +147,17 @@ void TorchCommNCCL::init(
       fmt::format(
           "Failed to get device properties for device {}", device_.index()));
 
-  // Check available memory
   size_t free_memory, total_memory;
   CUDA_CHECK(
       cuda_api_,
       cuda_api_->memGetInfo(&free_memory, &total_memory),
       fmt::format("Failed to get memory info for device {}", device_.index()));
 
-  // Read hints and store them
   high_priority_stream_ =
       options_.getHint<bool>(kHintHighPriorityStream, false);
 
-  // Create internal stream
-  //
-  // Default priority is 0 as per NVIDIA docs (https://fburl.com/2xb0iqwl).
   int stream_priority = 0;
 
-  // Check for high priority stream hint
   if (high_priority_stream_) {
     int leastPriority, greatestPriority;
     CUDA_CHECK(
@@ -160,35 +167,35 @@ void TorchCommNCCL::init(
     stream_priority = greatestPriority;
   }
 
-  CUDA_CHECK(
-      cuda_api_,
-      cuda_api_->streamCreateWithPriority(
-          &internal_stream_, cudaStreamNonBlocking, stream_priority),
-      fmt::format(
-          "Failed to create internal CUDA stream on device {}",
-          device_.index()));
+  if (!internal_stream_) {
+    CUDA_CHECK(
+        cuda_api_,
+        cuda_api_->streamCreateWithPriority(
+            &internal_stream_, cudaStreamNonBlocking, stream_priority),
+        fmt::format(
+            "Failed to create internal CUDA stream on device {}",
+            device_.index()));
+  }
 
-  // Create dependency event for stream synchronization
-  CUDA_CHECK(
-      cuda_api_,
-      cuda_api_->eventCreateWithFlags(
-          &dependency_event_, cudaEventDisableTiming),
-      fmt::format(
-          "Failed to create dependency event on device {}", device_.index()));
+  if (!dependency_event_) {
+    CUDA_CHECK(
+        cuda_api_,
+        cuda_api_->eventCreateWithFlags(
+            &dependency_event_, cudaEventDisableTiming),
+        fmt::format(
+            "Failed to create dependency event on device {}", device_.index()));
+  }
 
-  // Allocate CUDA buffer for barrier operations
-  CUDA_CHECK(
-      cuda_api_,
-      cuda_api_->malloc(&barrier_buffer_, sizeof(float)),
-      "Failed to allocate barrier buffer");
+  if (!barrier_buffer_) {
+    CUDA_CHECK(
+        cuda_api_,
+        cuda_api_->malloc(&barrier_buffer_, sizeof(float)),
+        "Failed to allocate barrier buffer");
+  }
 
   max_event_pool_size_ =
       options_.getHint<size_t>(kHintMaxEventPoolSize, kDefaultMaxEventPoolSize);
 
-  // Give up our internal reference to the store object here.  The caller
-  // would still need to keep a reference to the store object till the init
-  // call returns, at which point the NCCL communicator would already be
-  // created.
   if (options_.store) {
     options_.store.reset();
   }
@@ -207,13 +214,187 @@ void TorchCommNCCL::init(
       nccl_api_->commCount(nccl_comm_, &comm_size_),
       "NCCL Count failed");
 
-  TracingGuard tracingGuard(name_, comm_size_, "init", rank_);
+  if (!shutdown_) {
+    timeout_thread_ = std::thread(&TorchCommNCCL::timeoutWatchdog, this);
+  }
 
-  // Start timeout watchdog thread
-  timeout_thread_ = std::thread(&TorchCommNCCL::timeoutWatchdog, this);
-
-  // Register comm with CachingAllocator
   attachMemoryHook();
+}
+
+InitHandle TorchCommNCCL::getInitHandle() const {
+  return fmt::format("nccl:{}", rank_);
+}
+
+namespace {
+
+std::unordered_set<int> parseRanksFromHandles(
+    const std::variant<std::unordered_set<InitHandle>, std::vector<InitHandle>>&
+        handles) {
+  std::unordered_set<int> ranks;
+  auto extractRank = [&](const InitHandle& handle) {
+    auto pos = handle.find(':');
+    if (pos != std::string::npos) {
+      ranks.insert(std::stoi(handle.substr(pos + 1)));
+    }
+  };
+  std::visit(
+      [&](const auto& h) {
+        for (const auto& handle : h) {
+          extractRank(handle);
+        }
+      },
+      handles);
+  return ranks;
+}
+
+} // namespace
+
+c10::intrusive_ptr<TorchWork> TorchCommNCCL::reconfigure(
+    const ReconfigureOptions& opts) {
+  TC_LOG(INFO, this) << "TorchCommNCCL reconfigure starting";
+
+  int new_size = static_cast<int>(
+      std::visit([](const auto& h) { return h.size(); }, opts.handles));
+
+  auto reconfigureTimeout = opts.timeout.value_or(options_.timeout);
+
+  if (comm_state_ == CommState::ERROR && nccl_comm_) {
+    detachMemoryHook();
+    if (timeout_thread_.joinable()) {
+      shutdown_ = true;
+      {
+        std::lock_guard<std::mutex> lock(timeout_mutex_);
+        timeout_cv_.notify_all();
+      }
+      timeout_thread_.join();
+    }
+    workq_.finalize();
+    NCCL_CHECK_IGNORE(
+        nccl_api_,
+        nccl_api_->commAbort(nccl_comm_),
+        "NCCL commAbort failed during error recovery");
+    nccl_comm_ = nullptr;
+  }
+
+  auto growRankIt = opts.hints.find("grow_rank");
+  bool isNewRankJoining = !nccl_comm_ && growRankIt != opts.hints.end();
+
+  if (!nccl_comm_ && !isNewRankJoining) {
+    comm_state_ = CommState::NORMAL;
+    shutdown_ = false;
+
+    comm_size_ = new_size;
+
+    auto bootstrap = std::make_unique<TorchCommNCCLBootstrap>(
+        reconfigure_store_, device_, nccl_api_, cuda_api_, reconfigureTimeout);
+    device_ = bootstrap->getDevice();
+    nccl_comm_ = bootstrap->createNcclComm(
+        fmt::format("{}/reconfigure/{}", name_, opts.uuid), options_);
+
+    initNcclResources();
+  } else if (isNewRankJoining) {
+    comm_state_ = CommState::NORMAL;
+    shutdown_ = false;
+
+    int growRank = std::stoi(growRankIt->second);
+    auto store = createPrefixStore(
+        fmt::format("{}/grow/{}", name_, opts.uuid), reconfigureTimeout);
+
+    store->wait({"unique_id"}, reconfigureTimeout);
+    auto vec = store->get("unique_id");
+    ncclUniqueId uniqueId{};
+    std::memcpy(&uniqueId, vec.data(), sizeof(ncclUniqueId));
+
+    ncclComm_t new_comm = nullptr;
+    NCCL_CHECK(
+        nccl_api_,
+        nccl_comm_,
+        nccl_api_->commGrow(
+            nullptr, new_size, &uniqueId, growRank, &new_comm, nullptr),
+        "NCCL commGrow failed for new rank during reconfigure");
+
+    nccl_comm_ = new_comm;
+    initNcclResources();
+  } else {
+    detachMemoryHook();
+
+    if (timeout_thread_.joinable()) {
+      shutdown_ = true;
+      {
+        std::lock_guard<std::mutex> lock(timeout_mutex_);
+        timeout_cv_.notify_all();
+      }
+      timeout_thread_.join();
+    }
+
+    workq_.finalize();
+
+    ncclComm_t new_comm = nullptr;
+
+    if (new_size <= comm_size_) {
+      auto newRanks = parseRanksFromHandles(opts.handles);
+      std::vector<int> excludeRanks;
+      for (int r = 0; r < comm_size_; ++r) {
+        if (newRanks.find(r) == newRanks.end()) {
+          excludeRanks.push_back(r);
+        }
+      }
+
+      NCCL_CHECK(
+          nccl_api_,
+          nccl_comm_,
+          nccl_api_->commShrink(
+              nccl_comm_,
+              excludeRanks.data(),
+              static_cast<int>(excludeRanks.size()),
+              &new_comm,
+              nullptr,
+              NCCL_SHRINK_ABORT),
+          "NCCL commShrink failed during reconfigure");
+    } else {
+      const ncclUniqueId* uniqueIdPtr = nullptr;
+      ncclUniqueId uniqueId{};
+
+      if (rank_ == 0) {
+        NCCL_CHECK(
+            nccl_api_,
+            nccl_comm_,
+            nccl_api_->commGetUniqueId(nccl_comm_, &uniqueId),
+            "NCCL commGetUniqueId failed during grow");
+
+        auto store = createPrefixStore(
+            fmt::format("{}/grow/{}", name_, opts.uuid), reconfigureTimeout);
+        std::vector<uint8_t> vec(
+            reinterpret_cast<uint8_t*>(&uniqueId),
+            reinterpret_cast<uint8_t*>(&uniqueId) + sizeof(uniqueId));
+        store->set("unique_id", vec);
+
+        uniqueIdPtr = &uniqueId;
+      }
+
+      NCCL_CHECK(
+          nccl_api_,
+          nccl_comm_,
+          nccl_api_->commGrow(
+              nccl_comm_, new_size, uniqueIdPtr, -1, &new_comm, nullptr),
+          "NCCL commGrow failed during reconfigure");
+    }
+
+    nccl_comm_ = new_comm;
+    comm_state_ = CommState::NORMAL;
+    shutdown_ = false;
+
+    initNcclResources();
+  }
+
+  init_state_ = InitializationState::INITIALIZED;
+
+  TracingGuard tracingGuard(name_, comm_size_, "reconfigure", rank_);
+
+  TC_LOG(INFO, this) << "TorchCommNCCL reconfigure completed for rank: "
+                     << rank_;
+
+  return c10::make_intrusive<TorchWorkCompleted>();
 }
 
 void TorchCommNCCL::finalize() {

--- a/comms/torchcomms/nccl/TorchCommNCCL.hpp
+++ b/comms/torchcomms/nccl/TorchCommNCCL.hpp
@@ -202,6 +202,14 @@ class TorchCommNCCL : public TorchCommBackend,
       const std::string& name,
       const CommOptions& options = {}) override;
 
+  // Fault Tolerance API
+  bool supportsReconfigure() const override {
+    return true;
+  }
+  InitHandle getInitHandle() const override;
+  c10::intrusive_ptr<TorchWork> reconfigure(
+      const ReconfigureOptions& opts) override;
+
   // Friend access for TorchCommNCCL
   friend class TorchWorkNCCL;
   friend class CachingAllocatorHookImpl;
@@ -368,6 +376,7 @@ class TorchCommNCCL : public TorchCommBackend,
 
   void attachMemoryHook();
   void detachMemoryHook();
+  void initNcclResources();
 
   // Member variables
   ncclComm_t nccl_comm_{};
@@ -389,6 +398,9 @@ class TorchCommNCCL : public TorchCommBackend,
   // List of [comm, regHandlesMap] pairs.  Each regHandlesMap is a map from the
   // buffer address to the registeration handle
   std::map<void*, RegistrationHandle> memoryRegistrationHandles_;
+
+  // Store held for reconfigure bootstrap (kept alive across reconfigure calls)
+  c10::intrusive_ptr<c10d::Store> reconfigure_store_;
 
   // NCCL API abstraction
   std::shared_ptr<NcclApi> nccl_api_;

--- a/comms/torchcomms/ncclx/NcclxApi.cpp
+++ b/comms/torchcomms/ncclx/NcclxApi.cpp
@@ -88,6 +88,52 @@ ncclResult_t DefaultNcclxApi::commSplit(
   return ncclCommSplit(comm, color, key, newcomm, config);
 }
 
+ncclResult_t DefaultNcclxApi::commShrink(
+    ncclComm_t comm,
+    int* excludeRanksList,
+    int excludeRanksCount,
+    ncclComm_t* newcomm,
+    ncclConfig_t* config,
+    int shrinkFlags) {
+  std::lock_guard<std::mutex> lock(api_mutex_);
+  return ncclCommShrink(
+      comm, excludeRanksList, excludeRanksCount, newcomm, config, shrinkFlags);
+}
+
+ncclResult_t DefaultNcclxApi::commGetUniqueId(
+    ncclComm_t comm,
+    ncclUniqueId* uniqueId) {
+  std::lock_guard<std::mutex> lock(api_mutex_);
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)
+  return ncclCommGetUniqueId(comm, uniqueId);
+#else
+  (void)comm;
+  (void)uniqueId;
+  return ncclInvalidUsage;
+#endif
+}
+
+ncclResult_t DefaultNcclxApi::commGrow(
+    ncclComm_t comm,
+    int nRanks,
+    const ncclUniqueId* uniqueId,
+    int rank,
+    ncclComm_t* newcomm,
+    ncclConfig_t* config) {
+  std::lock_guard<std::mutex> lock(api_mutex_);
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)
+  return ncclCommGrow(comm, nRanks, uniqueId, rank, newcomm, config);
+#else
+  (void)comm;
+  (void)nRanks;
+  (void)uniqueId;
+  (void)rank;
+  (void)newcomm;
+  (void)config;
+  return ncclInvalidUsage;
+#endif
+}
+
 ncclResult_t DefaultNcclxApi::commRegister(
     ncclComm_t comm,
     void* buffer,

--- a/comms/torchcomms/ncclx/NcclxApi.hpp
+++ b/comms/torchcomms/ncclx/NcclxApi.hpp
@@ -111,6 +111,26 @@ class NcclxApi {
       ncclComm_t* newcomm,
       ncclConfig_t* config) = 0;
 
+  [[nodiscard]] virtual ncclResult_t commShrink(
+      ncclComm_t comm,
+      int* excludeRanksList,
+      int excludeRanksCount,
+      ncclComm_t* newcomm,
+      ncclConfig_t* config,
+      int shrinkFlags) = 0;
+
+  [[nodiscard]] virtual ncclResult_t commGetUniqueId(
+      ncclComm_t comm,
+      ncclUniqueId* uniqueId) = 0;
+
+  [[nodiscard]] virtual ncclResult_t commGrow(
+      ncclComm_t comm,
+      int nRanks,
+      const ncclUniqueId* uniqueId,
+      int rank,
+      ncclComm_t* newcomm,
+      ncclConfig_t* config) = 0;
+
   // Memory registration
   [[nodiscard]] virtual ncclResult_t
   commRegister(ncclComm_t comm, void* buffer, size_t size, void** handle) = 0;
@@ -483,6 +503,26 @@ class DefaultNcclxApi : public NcclxApi {
       ncclComm_t comm,
       int color,
       int key,
+      ncclComm_t* newcomm,
+      ncclConfig_t* config) override;
+
+  [[nodiscard]] ncclResult_t commShrink(
+      ncclComm_t comm,
+      int* excludeRanksList,
+      int excludeRanksCount,
+      ncclComm_t* newcomm,
+      ncclConfig_t* config,
+      int shrinkFlags) override;
+
+  [[nodiscard]] ncclResult_t commGetUniqueId(
+      ncclComm_t comm,
+      ncclUniqueId* uniqueId) override;
+
+  [[nodiscard]] ncclResult_t commGrow(
+      ncclComm_t comm,
+      int nRanks,
+      const ncclUniqueId* uniqueId,
+      int rank,
       ncclComm_t* newcomm,
       ncclConfig_t* config) override;
 

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -18,6 +18,7 @@
 #include "comms/torchcomms/TorchCommFactory.hpp"
 #include "comms/torchcomms/ncclx/TorchCommNCCLXBootstrap.hpp"
 #include "comms/torchcomms/utils/Logging.hpp"
+#include "comms/torchcomms/utils/StoreManager.hpp"
 #include "comms/torchcomms/utils/TracingGuard.hpp"
 #include "comms/torchcomms/utils/Utils.hpp"
 #include "comms/utils/CudaRAII.h"
@@ -137,26 +138,30 @@ void TorchCommNCCLX::init(
     at::Device device,
     const std::string& name,
     const CommOptions& options) {
-  // Initialize private members
   device_ = device;
   name_ = name;
   options_ = options;
 
-  // Only initialize once
   if (init_state_ == InitializationState::INITIALIZED) {
     throw std::runtime_error("TorchCommNCCLX already initialized");
   } else if (init_state_ == InitializationState::FINALIZED) {
     throw std::runtime_error("TorchCommNCCLX already finalized");
   }
 
-  // Initialize default NCCL API implementation if not already set
   if (!nccl_api_) {
     nccl_api_ = std::make_unique<DefaultNcclxApi>();
   }
 
-  // Initialize default CUDA API implementation if not already set
   if (!cuda_api_) {
     cuda_api_ = std::make_unique<DefaultCudaApi>();
+  }
+
+  if (options.enable_reconfigure) {
+    options_.enable_reconfigure = true;
+    reconfigure_store_ = options_.store;
+    TC_LOG(INFO, this)
+        << "TorchCommNCCLX dynamic regime enabled, deferring initialization";
+    return;
   }
 
   if (device_.index() == -1 || nccl_comm_ == nullptr) {
@@ -169,13 +174,15 @@ void TorchCommNCCLX::init(
     }
   }
 
-  // Set CUDA device and verify it's accessible
+  initNcclxResources();
+}
+
+void TorchCommNCCLX::initNcclxResources() {
   CUDA_CHECK(
       cuda_api_,
       cuda_api_->setDevice(device_.index()),
       fmt::format("Failed to set CUDA device to {}", device_.index()));
 
-  // Verify device properties and memory availability
   cudaDeviceProp device_prop = {};
   CUDA_CHECK(
       cuda_api_,
@@ -183,23 +190,17 @@ void TorchCommNCCLX::init(
       fmt::format(
           "Failed to get device properties for device {}", device_.index()));
 
-  // Check available memory
   size_t free_memory, total_memory;
   CUDA_CHECK(
       cuda_api_,
       cuda_api_->memGetInfo(&free_memory, &total_memory),
       fmt::format("Failed to get memory info for device {}", device_.index()));
 
-  // Read hints and store them
   high_priority_stream_ =
       options_.getHint<bool>(kHintHighPriorityStream, false);
 
-  // Create internal stream
-  //
-  // Default priority is 0 as per NVIDIA docs (https://fburl.com/2xb0iqwl).
   int stream_priority = 0;
 
-  // Check for high priority stream hint
   if (high_priority_stream_) {
     int leastPriority, greatestPriority;
     CUDA_CHECK(
@@ -209,27 +210,31 @@ void TorchCommNCCLX::init(
     stream_priority = greatestPriority;
   }
 
-  CUDA_CHECK(
-      cuda_api_,
-      cuda_api_->streamCreateWithPriority(
-          &internal_stream_, cudaStreamNonBlocking, stream_priority),
-      fmt::format(
-          "Failed to create internal CUDA stream on device {}",
-          device_.index()));
+  if (!internal_stream_) {
+    CUDA_CHECK(
+        cuda_api_,
+        cuda_api_->streamCreateWithPriority(
+            &internal_stream_, cudaStreamNonBlocking, stream_priority),
+        fmt::format(
+            "Failed to create internal CUDA stream on device {}",
+            device_.index()));
+  }
 
-  // Create dependency event for stream synchronization
-  CUDA_CHECK(
-      cuda_api_,
-      cuda_api_->eventCreateWithFlags(
-          &dependency_event_, cudaEventDisableTiming),
-      fmt::format(
-          "Failed to create dependency event on device {}", device_.index()));
+  if (!dependency_event_) {
+    CUDA_CHECK(
+        cuda_api_,
+        cuda_api_->eventCreateWithFlags(
+            &dependency_event_, cudaEventDisableTiming),
+        fmt::format(
+            "Failed to create dependency event on device {}", device_.index()));
+  }
 
-  // Allocate CUDA buffer for barrier operations
-  CUDA_CHECK(
-      cuda_api_,
-      cuda_api_->malloc(&barrier_buffer_, sizeof(float)),
-      "Failed to allocate barrier buffer");
+  if (!barrier_buffer_) {
+    CUDA_CHECK(
+        cuda_api_,
+        cuda_api_->malloc(&barrier_buffer_, sizeof(float)),
+        "Failed to allocate barrier buffer");
+  }
 
   configs_.max_event_pool_size_ =
       options_.getHint<size_t>(kHintMaxEventPoolSize, kDefaultMaxEventPoolSize);
@@ -240,10 +245,6 @@ void TorchCommNCCLX::init(
   configs_.graph_timeout_check_interval_ms_ = options_.getHint<size_t>(
       kHintGraphTimeoutCheckIntervalMs, kDefaultGraphTimeoutCheckIntervalMs);
 
-  // Give up our internal reference to the store object here.  The caller
-  // would still need to keep a reference to the store object till the init
-  // call returns, at which point the NCCL communicator would already be
-  // created.
   if (options_.store) {
     options_.store.reset();
   }
@@ -262,17 +263,198 @@ void TorchCommNCCLX::init(
       nccl_api_->commCount(nccl_comm_, &comm_size_),
       "NCCLX Count failed");
 
-  TracingGuard tracingGuard(name_, comm_size_, "init", rank_);
+  if (!shutdown_) {
+    timeout_thread_ = std::thread(&TorchCommNCCLX::timeoutWatchdog, this);
+  }
 
-  // Start timeout watchdog thread
-  timeout_thread_ = std::thread(&TorchCommNCCLX::timeoutWatchdog, this);
-
-  // Attach memory hook to register pre-existing allocations and capture future
-  // ones
   attachMemoryHook();
 
-  // Mark initialization as complete only after all steps succeed
   init_state_ = InitializationState::INITIALIZED;
+}
+
+InitHandle TorchCommNCCLX::getInitHandle() const {
+  return fmt::format("ncclx:{}", rank_);
+}
+
+namespace {
+
+std::unordered_set<int> parseRanksFromHandles(
+    const std::variant<std::unordered_set<InitHandle>, std::vector<InitHandle>>&
+        handles) {
+  std::unordered_set<int> ranks;
+  auto extractRank = [&](const InitHandle& handle) {
+    auto pos = handle.find(':');
+    if (pos != std::string::npos) {
+      ranks.insert(std::stoi(handle.substr(pos + 1)));
+    }
+  };
+  std::visit(
+      [&](const auto& h) {
+        for (const auto& handle : h) {
+          extractRank(handle);
+        }
+      },
+      handles);
+  return ranks;
+}
+
+} // namespace
+
+c10::intrusive_ptr<TorchWork> TorchCommNCCLX::reconfigure(
+    const ReconfigureOptions& opts) {
+  TC_LOG(INFO, this) << "TorchCommNCCLX reconfigure starting";
+
+  int new_size = static_cast<int>(
+      std::visit([](const auto& h) { return h.size(); }, opts.handles));
+
+  auto reconfigureTimeout = opts.timeout.value_or(options_.timeout);
+
+  if (comm_state_ == CommState::ERROR && nccl_comm_) {
+    if (timeout_thread_.joinable()) {
+      shutdown_ = true;
+      {
+        std::lock_guard<std::mutex> lock(timeout_mutex_);
+        timeout_cv_.notify_all();
+      }
+      timeout_thread_.join();
+    }
+    workq_.finalize();
+    NCCLX_CHECK_IGNORE(
+        nccl_api_,
+        nccl_api_->commAbort(nccl_comm_),
+        "NCCLX commAbort failed during error recovery");
+    nccl_comm_ = nullptr;
+  }
+
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)
+  auto growRankIt = opts.hints.find("grow_rank");
+  bool isNewRankJoining = !nccl_comm_ && growRankIt != opts.hints.end();
+#else
+  bool isNewRankJoining = false;
+#endif
+
+  if (!nccl_comm_ && !isNewRankJoining) {
+    comm_state_ = CommState::NORMAL;
+    shutdown_ = false;
+
+    comm_size_ = new_size;
+
+    auto bootstrap = std::make_unique<TorchCommNCCLXBootstrap>(
+        reconfigure_store_, device_, nccl_api_, cuda_api_, reconfigureTimeout);
+    device_ = bootstrap->getDevice();
+    nccl_comm_ = bootstrap->createNcclComm(
+        fmt::format("{}/reconfigure/{}", name_, opts.uuid), options_);
+
+    initNcclxResources();
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)
+  } else if (isNewRankJoining) {
+    comm_state_ = CommState::NORMAL;
+    shutdown_ = false;
+
+    int growRank = std::stoi(growRankIt->second);
+    auto store = createPrefixStore(
+        fmt::format("{}/grow/{}", name_, opts.uuid), reconfigureTimeout);
+
+    store->wait({"unique_id"}, reconfigureTimeout);
+    auto vec = store->get("unique_id");
+    ncclUniqueId uniqueId{};
+    std::memcpy(&uniqueId, vec.data(), sizeof(ncclUniqueId));
+
+    ncclComm_t new_comm = nullptr;
+    NCCLX_CHECK(
+        nccl_api_,
+        nccl_comm_,
+        nccl_api_->commGrow(
+            nullptr, new_size, &uniqueId, growRank, &new_comm, nullptr),
+        "NCCLX commGrow failed for new rank during reconfigure");
+
+    nccl_comm_ = new_comm;
+    initNcclxResources();
+#endif
+  } else {
+    if (timeout_thread_.joinable()) {
+      shutdown_ = true;
+      {
+        std::lock_guard<std::mutex> lock(timeout_mutex_);
+        timeout_cv_.notify_all();
+      }
+      timeout_thread_.join();
+    }
+
+    workq_.finalize();
+
+    ncclComm_t new_comm = nullptr;
+
+    if (new_size <= comm_size_) {
+      auto newRanks = parseRanksFromHandles(opts.handles);
+      std::vector<int> excludeRanks;
+      for (int r = 0; r < comm_size_; ++r) {
+        if (newRanks.find(r) == newRanks.end()) {
+          excludeRanks.push_back(r);
+        }
+      }
+
+      NCCLX_CHECK(
+          nccl_api_,
+          nccl_comm_,
+          nccl_api_->commShrink(
+              nccl_comm_,
+              excludeRanks.data(),
+              static_cast<int>(excludeRanks.size()),
+              &new_comm,
+              nullptr,
+              NCCL_SHRINK_ABORT),
+          "NCCLX commShrink failed during reconfigure");
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)
+    } else {
+      const ncclUniqueId* uniqueIdPtr = nullptr;
+      ncclUniqueId uniqueId{};
+
+      if (rank_ == 0) {
+        NCCLX_CHECK(
+            nccl_api_,
+            nccl_comm_,
+            nccl_api_->commGetUniqueId(nccl_comm_, &uniqueId),
+            "NCCLX commGetUniqueId failed during grow");
+
+        auto store = createPrefixStore(
+            fmt::format("{}/grow/{}", name_, opts.uuid), reconfigureTimeout);
+        std::vector<uint8_t> vec(
+            reinterpret_cast<uint8_t*>(&uniqueId),
+            reinterpret_cast<uint8_t*>(&uniqueId) + sizeof(uniqueId));
+        store->set("unique_id", vec);
+
+        uniqueIdPtr = &uniqueId;
+      }
+
+      NCCLX_CHECK(
+          nccl_api_,
+          nccl_comm_,
+          nccl_api_->commGrow(
+              nccl_comm_, new_size, uniqueIdPtr, -1, &new_comm, nullptr),
+          "NCCLX commGrow failed during reconfigure");
+#else
+    } else {
+      throw std::runtime_error(
+          "TorchCommNCCLX reconfigure: grow requires NCCLx >= 2.29");
+#endif
+    }
+
+    nccl_comm_ = new_comm;
+    comm_state_ = CommState::NORMAL;
+    shutdown_ = false;
+
+    initNcclxResources();
+  }
+
+  init_state_ = InitializationState::INITIALIZED;
+
+  TracingGuard tracingGuard(name_, comm_size_, "reconfigure", rank_);
+
+  TC_LOG(INFO, this) << "TorchCommNCCLX reconfigure completed for rank: "
+                     << rank_;
+
+  return c10::make_intrusive<TorchWorkCompleted>();
 }
 
 void TorchCommNCCLX::finalize() {

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
@@ -278,6 +278,14 @@ class TorchCommNCCLX : public TorchCommBackend,
       const std::string& name,
       const CommOptions& options = {}) override;
 
+  // Fault Tolerance API
+  bool supportsReconfigure() const override {
+    return true;
+  }
+  InitHandle getInitHandle() const override;
+  c10::intrusive_ptr<TorchWork> reconfigure(
+      const ReconfigureOptions& opts) override;
+
   std::unordered_map<std::string, std::string> comm_dump();
   // Friend access for TorchCommNCCLX
   friend class TorchWorkNCCLX;
@@ -487,6 +495,7 @@ class TorchCommNCCLX : public TorchCommBackend,
       const ncclDataType_t dataType);
   void timeoutWatchdog() noexcept;
   void checkInitialized() const;
+  void initNcclxResources();
   void checkAndAbortIfTimedOutOrError();
   void checkWorkQueue();
   bool getGraphCaptureMode();
@@ -507,6 +516,9 @@ class TorchCommNCCLX : public TorchCommBackend,
   int rank_{};
   size_t split_counter_{};
   CommOptions options_;
+
+  // Store held for reconfigure bootstrap (kept alive across reconfigure calls)
+  c10::intrusive_ptr<c10d::Store> reconfigure_store_;
 
   cudaStream_t internal_stream_{};
   void* barrier_buffer_{}; // Pre-allocated CUDA buffer for barrier operations

--- a/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.cpp
@@ -41,6 +41,20 @@ void NcclxMock::setupDefaultBehaviors() {
           SetArgPointee<3>(reinterpret_cast<ncclComm_t>(0x4000)),
           Return(ncclSuccess)));
 
+  ON_CALL(*this, commShrink(_, _, _, _, _, _))
+      .WillByDefault(DoAll(
+          SetArgPointee<3>(reinterpret_cast<ncclComm_t>(0x6000)),
+          Return(ncclSuccess)));
+
+  ON_CALL(*this, commGetUniqueId(_, _))
+      .WillByDefault(
+          DoAll(SetArgPointee<1>(ncclUniqueId{}), Return(ncclSuccess)));
+
+  ON_CALL(*this, commGrow(_, _, _, _, _, _))
+      .WillByDefault(DoAll(
+          SetArgPointee<4>(reinterpret_cast<ncclComm_t>(0x7000)),
+          Return(ncclSuccess)));
+
   // Memory registration - return success by default
   ON_CALL(*this, commRegister(_, _, _, _))
       .WillByDefault(DoAll(

--- a/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.hpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.hpp
@@ -65,6 +65,34 @@ class NcclxMock : public NcclxApi {
        ncclConfig_t* config),
       (override));
 
+  MOCK_METHOD(
+      ncclResult_t,
+      commShrink,
+      (ncclComm_t comm,
+       int* excludeRanksList,
+       int excludeRanksCount,
+       ncclComm_t* newcomm,
+       ncclConfig_t* config,
+       int shrinkFlags),
+      (override));
+
+  MOCK_METHOD(
+      ncclResult_t,
+      commGetUniqueId,
+      (ncclComm_t comm, ncclUniqueId* uniqueId),
+      (override));
+
+  MOCK_METHOD(
+      ncclResult_t,
+      commGrow,
+      (ncclComm_t comm,
+       int nRanks,
+       const ncclUniqueId* uniqueId,
+       int rank,
+       ncclComm_t* newcomm,
+       ncclConfig_t* config),
+      (override));
+
   // Memory registration
   MOCK_METHOD(
       ncclResult_t,

--- a/comms/torchcomms/tests/integration/py/GetInitHandleTest.py
+++ b/comms/torchcomms/tests/integration/py/GetInitHandleTest.py
@@ -20,7 +20,7 @@ class GetInitHandleTest(unittest.TestCase):
     """Test class for get_init_handle() fault tolerance API."""
 
     # Backends that implement get_init_handle()
-    SUPPORTED_BACKENDS = {"mccl", "gloo"}
+    SUPPORTED_BACKENDS = {"mccl", "gloo", "nccl", "ncclx"}
 
     def get_wrapper(self):
         return TorchCommTestWrapper()

--- a/comms/torchcomms/tests/integration/py/ReconfigureTest.py
+++ b/comms/torchcomms/tests/integration/py/ReconfigureTest.py
@@ -24,7 +24,7 @@ from torchcomms.tests.integration.py.TorchCommTestHelpers import TorchCommTestWr
 class ReconfigureTest(unittest.TestCase):
     """Test class for reconfigure() fault tolerance API."""
 
-    SUPPORTED_BACKENDS = {"mccl", "gloo"}
+    SUPPORTED_BACKENDS = {"mccl", "gloo", "nccl", "ncclx"}
 
     _shared_store = None
 
@@ -80,6 +80,10 @@ class ReconfigureTest(unittest.TestCase):
     def _is_supported_backend(self):
         """Check if current backend supports reconfigure()."""
         return self.backend in self.SUPPORTED_BACKENDS
+
+    def _get_store_for_comm(self):
+        """Get the store to pass to new_comm for NCCL/NCCLx bootstrap."""
+        return getattr(self, "store", None)
 
     def _collect_handles(self, comm, key_prefix):
         """Collect init handles from all ranks."""
@@ -141,7 +145,11 @@ class ReconfigureTest(unittest.TestCase):
         import torchcomms
 
         comm = torchcomms.new_comm(
-            self.backend, self.device, "reconfigure_basic", enable_reconfigure=True
+            self.backend,
+            self.device,
+            "reconfigure_basic",
+            enable_reconfigure=True,
+            store=self._get_store_for_comm(),
         )
 
         all_handles = self._collect_handles(comm, "test_reconfigure_basic")
@@ -181,6 +189,7 @@ class ReconfigureTest(unittest.TestCase):
             self.device,
             "reconfigure_unordered",
             enable_reconfigure=True,
+            store=self._get_store_for_comm(),
         )
 
         all_handles = set(self._collect_handles(comm, "test_reconfigure_unordered"))
@@ -217,6 +226,7 @@ class ReconfigureTest(unittest.TestCase):
             self.device,
             "reconfigure_collective",
             enable_reconfigure=True,
+            store=self._get_store_for_comm(),
         )
 
         all_handles = self._collect_handles(comm, "test_reconfigure_collective")
@@ -276,6 +286,7 @@ class ReconfigureTest(unittest.TestCase):
             self.device,
             "reconfigure_allreduce",
             enable_reconfigure=True,
+            store=self._get_store_for_comm(),
         )
 
         all_handles = self._collect_handles(comm, "test_reconfigure_allreduce")


### PR DESCRIPTION
Summary:

Implements reconfiguration support for NCCL backend by adding `ncclCommShrink` and `ncclCommGrow` API wrappers and updating `TorchCommNCCL::reconfigure()` to handle dynamic membership changes.

Updates `getInitHandle()` to return rank-encoded handles (`"nccl:<rank>"`) which enables the shrink path to compute excluded ranks by diffing old membership against new handles, eliminating the need for explicit `exclude_ranks` hints. The implementation defers NCCL resource initialization when reconfiguration is enabled, then initializes on-demand during the first reconfigure call or normal init.

---
AI generated Summary & Test Plan from DEV197792793

Reviewed By: kapilsh

Differential Revision: D101746890


