### PR TITLE
Call ncclCommRevoke on timeout when abort_process_on_timeout_or_error=False (#2203)

### DIFF
--- a/comms/torchcomms/nccl/NcclApi.cpp
+++ b/comms/torchcomms/nccl/NcclApi.cpp
@@ -52,6 +52,18 @@ ncclResult_t DefaultNcclApi::commAbort(ncclComm_t comm) {
   return ncclCommAbort(comm);
 }
 
+ncclResult_t DefaultNcclApi::commRevoke(ncclComm_t comm) {
+  std::lock_guard<std::mutex> lock(api_mutex_);
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 28, 0)
+  return ncclCommRevoke(comm, 0);
+#else
+  (void)comm;
+  TC_LOG(ERROR) << "NCCL version " << NCCL_VERSION_CODE
+                << " does not support ncclCommRevoke API";
+  return ncclInvalidUsage;
+#endif
+}
+
 ncclResult_t DefaultNcclApi::commGetAsyncError(
     ncclComm_t comm,
     ncclResult_t* asyncError) {

--- a/comms/torchcomms/nccl/NcclApi.hpp
+++ b/comms/torchcomms/nccl/NcclApi.hpp
@@ -36,6 +36,8 @@ class NcclApi {
 
   [[nodiscard]] virtual ncclResult_t commAbort(ncclComm_t comm) = 0;
 
+  [[nodiscard]] virtual ncclResult_t commRevoke(ncclComm_t comm) = 0;
+
   [[nodiscard]] virtual ncclResult_t commGetAsyncError(
       ncclComm_t comm,
       ncclResult_t* asyncError) = 0;
@@ -204,6 +206,8 @@ class DefaultNcclApi : public NcclApi {
   [[nodiscard]] ncclResult_t commDestroy(ncclComm_t comm) override;
 
   [[nodiscard]] ncclResult_t commAbort(ncclComm_t comm) override;
+
+  [[nodiscard]] ncclResult_t commRevoke(ncclComm_t comm) override;
 
   [[nodiscard]] ncclResult_t commGetAsyncError(
       ncclComm_t comm,

--- a/comms/torchcomms/nccl/TorchCommNCCL.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCL.cpp
@@ -520,6 +520,19 @@ void TorchCommNCCL::abortNcclComm() {
   }
 }
 
+void TorchCommNCCL::revokeNcclComm() {
+  TC_LOG(INFO, this) << "Calling abort hooks before commRevoke.";
+  runAbortHooks();
+  detachMemoryHook();
+  if (nccl_comm_) {
+    NCCL_CHECK(
+        nccl_api_,
+        nccl_comm_,
+        nccl_api_->commRevoke(nccl_comm_),
+        "NCCL Revoke failed");
+  }
+}
+
 int TorchCommNCCL::getRank() const {
   checkInitialized();
 

--- a/comms/torchcomms/nccl/TorchCommNCCL.hpp
+++ b/comms/torchcomms/nccl/TorchCommNCCL.hpp
@@ -248,6 +248,7 @@ class TorchCommNCCL : public TorchCommBackend,
   [[nodiscard]] cudaEvent_t getEvent();
   void returnEvent(cudaEvent_t event);
   void abortNcclComm();
+  void revokeNcclComm();
 
   enum class CommState {
     NORMAL,

--- a/comms/torchcomms/nccl/TorchCommNCCLUtils.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCLUtils.cpp
@@ -237,10 +237,8 @@ void TorchCommNCCL::timeoutWatchdog() noexcept {
       break;
     }
     if (comm_state_ != CommState::NORMAL &&
-        options_.abort_process_on_timeout_or_error) {
-      // Log the error and abort the process.  We cannot abort the NCCL
-      // communicator as it is not safe to call NCCL operations from
-      // multiple threads at the same time.
+        options_.abort_process_on_timeout_or_error &&
+        !options_.enable_reconfigure) {
       if (comm_state_ == CommState::TIMEOUT) {
         TC_LOG(ERROR, this)
             << "Aborting process due to timeout on rank " << rank_
@@ -249,7 +247,7 @@ void TorchCommNCCL::timeoutWatchdog() noexcept {
         TC_LOG(ERROR, this) << "Aborting process due to error on rank " << rank_
                             << " - timeout watchdog detected operation error. ";
       }
-      abort();
+      ::abort();
     }
 
     // Check communicator for async error
@@ -289,12 +287,17 @@ void TorchCommNCCL::checkAndAbortIfTimedOutOrError() {
   checkWorkQueue();
 
   if (comm_state_ == CommState::TIMEOUT) {
-    abortNcclComm();
-    if (options_.abort_process_on_timeout_or_error) {
-      TC_LOG(ERROR, this) << "Aborting process due to timeout";
-      abort();
-    } else {
+    if (options_.enable_reconfigure) {
+      revokeNcclComm();
       throw std::runtime_error("NCCL operation timed out");
+    } else {
+      abortNcclComm();
+      if (options_.abort_process_on_timeout_or_error) {
+        TC_LOG(ERROR, this) << "Aborting process due to timeout";
+        abort();
+      } else {
+        throw std::runtime_error("NCCL operation timed out");
+      }
     }
   } else if (comm_state_ == CommState::ERROR) {
     ncclResult_t asyncErr;

--- a/comms/torchcomms/ncclx/NcclxApi.cpp
+++ b/comms/torchcomms/ncclx/NcclxApi.cpp
@@ -71,6 +71,11 @@ ncclResult_t DefaultNcclxApi::commAbort(ncclComm_t comm) {
   return ncclCommAbort(comm);
 }
 
+ncclResult_t DefaultNcclxApi::commRevoke(ncclComm_t comm) {
+  std::lock_guard<std::mutex> lock(api_mutex_);
+  return ncclCommRevoke(comm, 0);
+}
+
 ncclResult_t DefaultNcclxApi::commGetAsyncError(
     ncclComm_t comm,
     ncclResult_t* asyncError) {

--- a/comms/torchcomms/ncclx/NcclxApi.hpp
+++ b/comms/torchcomms/ncclx/NcclxApi.hpp
@@ -100,6 +100,8 @@ class NcclxApi {
 
   [[nodiscard]] virtual ncclResult_t commAbort(ncclComm_t comm) = 0;
 
+  [[nodiscard]] virtual ncclResult_t commRevoke(ncclComm_t comm) = 0;
+
   [[nodiscard]] virtual ncclResult_t commGetAsyncError(
       ncclComm_t comm,
       ncclResult_t* asyncError) = 0;
@@ -494,6 +496,8 @@ class DefaultNcclxApi : public NcclxApi {
   [[nodiscard]] ncclResult_t commDestroy(ncclComm_t comm) override;
 
   [[nodiscard]] ncclResult_t commAbort(ncclComm_t comm) override;
+
+  [[nodiscard]] ncclResult_t commRevoke(ncclComm_t comm) override;
 
   [[nodiscard]] ncclResult_t commGetAsyncError(
       ncclComm_t comm,

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -595,6 +595,18 @@ void TorchCommNCCLX::abortNcclComm() {
   }
 }
 
+void TorchCommNCCLX::revokeNcclComm() {
+  TC_LOG(INFO, this) << "Calling abort hooks before commRevoke.";
+  runAbortHooks();
+  if (nccl_comm_) {
+    NCCLX_CHECK(
+        nccl_api_,
+        nccl_comm_,
+        nccl_api_->commRevoke(nccl_comm_),
+        "NCCLX Revoke failed");
+  }
+}
+
 int TorchCommNCCLX::getRank() const {
   checkInitialized();
 

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
@@ -340,6 +340,7 @@ class TorchCommNCCLX : public TorchCommBackend,
   [[nodiscard]] cudaEvent_t getEvent();
   void returnEvent(cudaEvent_t event);
   void abortNcclComm();
+  void revokeNcclComm();
 
   enum class CommState {
     NORMAL,

--- a/comms/torchcomms/ncclx/TorchCommNCCLXUtils.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXUtils.cpp
@@ -274,10 +274,8 @@ void TorchCommNCCLX::timeoutWatchdog() noexcept {
     }
 
     if (comm_state_ != CommState::NORMAL &&
-        options_.abort_process_on_timeout_or_error) {
-      // Log the error and abort the process.  We cannot abort the NCCL
-      // communicator as it is not safe to call NCCL operations from
-      // multiple threads at the same time.
+        options_.abort_process_on_timeout_or_error &&
+        !options_.enable_reconfigure) {
       if (comm_state_ == CommState::TIMEOUT) {
         TC_LOG(ERROR, this)
             << "Aborting process due to timeout on rank " << rank_
@@ -286,7 +284,7 @@ void TorchCommNCCLX::timeoutWatchdog() noexcept {
         TC_LOG(ERROR, this) << "Aborting process due to error on rank " << rank_
                             << " - timeout watchdog detected operation error. ";
       }
-      abort();
+      ::abort();
     }
 
     // Check communicator for async error
@@ -329,12 +327,17 @@ void TorchCommNCCLX::checkAndAbortIfTimedOutOrError() {
   // graph_timeout_check_interval_ms, so no synchronous check is needed here.
 
   if (comm_state_ == CommState::TIMEOUT) {
-    abortNcclComm();
-    if (options_.abort_process_on_timeout_or_error) {
-      TC_LOG(ERROR, this) << "Aborting process due to timeout";
-      abort();
-    } else {
+    if (options_.enable_reconfigure) {
+      revokeNcclComm();
       throw std::runtime_error("NCCLX operation timed out");
+    } else {
+      abortNcclComm();
+      if (options_.abort_process_on_timeout_or_error) {
+        TC_LOG(ERROR, this) << "Aborting process due to timeout";
+        abort();
+      } else {
+        throw std::runtime_error("NCCLX operation timed out");
+      }
     }
   } else if (comm_state_ == CommState::ERROR) {
     ncclResult_t asyncErr;

--- a/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.cpp
@@ -33,6 +33,8 @@ void NcclxMock::setupDefaultBehaviors() {
 
   ON_CALL(*this, commAbort(_)).WillByDefault(Return(ncclSuccess));
 
+  ON_CALL(*this, commRevoke(_)).WillByDefault(Return(ncclSuccess));
+
   ON_CALL(*this, commGetAsyncError(_, _))
       .WillByDefault(DoAll(SetArgPointee<1>(ncclSuccess), Return(ncclSuccess)));
 

--- a/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.hpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.hpp
@@ -49,6 +49,8 @@ class NcclxMock : public NcclxApi {
 
   MOCK_METHOD(ncclResult_t, commAbort, (ncclComm_t comm), (override));
 
+  MOCK_METHOD(ncclResult_t, commRevoke, (ncclComm_t comm), (override));
+
   MOCK_METHOD(
       ncclResult_t,
       commGetAsyncError,


### PR DESCRIPTION
Summary:

When `abort_process_on_timeout_or_error` is set to `false`, call `ncclCommRevoke` instead of `ncclCommAbort` on timeout. This provides a more graceful handling path: `ncclCommRevoke` stops in-flight operations but keeps the communicator valid for later cleanup via `commDestroy`, whereas `ncclCommAbort` immediately destroys the communicator.

Changes:
- Added `commRevoke(ncclComm_t comm)` to `NcclApi` and `NcclxApi` interfaces and their default implementations, delegating to `ncclCommRevoke(comm, 0)`.
- Added `revokeNcclComm()` method to both `TorchCommNCCL` and `TorchCommNCCLX`, which runs abort hooks and calls `commRevoke` without nulling the communicator pointer (unlike `abortNcclComm` which calls `commAbort` and nulls it).
- Modified `checkAndAbortIfTimedOutOrError()` in both classes: on timeout with `abort_process_on_timeout_or_error=false`, calls `revokeNcclComm()` and throws `RuntimeError` instead of calling `abortNcclComm()`.
- Updated `NcclxMock` with `commRevoke` mock method and default behavior.
- Added integration test `test_eager_timeout_revoke` to verify that with `abort_process_on_timeout_or_error=False`, a timeout raises `RuntimeError` (via revoke) instead of killing the process with SIGABRT.

Reviewed By: kapilsh

Differential Revision: D101894309


