### PR TITLE
Add TorchComm::abort() API for graceful communicator abort (#2204)

### DIFF
--- a/comms/torchcomms/TorchComm.cpp
+++ b/comms/torchcomms/TorchComm.cpp
@@ -512,6 +512,10 @@ c10::intrusive_ptr<TorchWork> TorchComm::reconfigure(
   return work;
 }
 
+void TorchComm::abort() {
+  impl_->abort();
+}
+
 int64_t TorchComm::get_device_transport() {
   return impl_->get_device_transport();
 }

--- a/comms/torchcomms/TorchComm.hpp
+++ b/comms/torchcomms/TorchComm.hpp
@@ -217,6 +217,14 @@ class TorchComm : public std::enable_shared_from_this<TorchComm> {
    */
   c10::intrusive_ptr<TorchWork> reconfigure(const ReconfigureOptions& opts);
 
+  /**
+   * Abort the communicator, stopping all in-flight operations.
+   * In reconfigurable mode, uses graceful revoke. Otherwise uses destructive
+   * abort. Sets error state but does not throw. Caller can recover via
+   * reconfigure().
+   */
+  void abort();
+
   // Hook types (defined in TorchCommHooks.hpp; aliased for backward compat)
   using PreHook = ::torch::comms::PreHook;
   using PostHook = ::torch::comms::PostHook;

--- a/comms/torchcomms/TorchCommBackend.hpp
+++ b/comms/torchcomms/TorchCommBackend.hpp
@@ -298,6 +298,18 @@ class TorchCommBackend {
         std::string(getCommName()));
   }
 
+  /**
+   * Abort the communicator, stopping all in-flight operations.
+   * In reconfigurable mode, calls ncclCommRevoke (graceful) and sets error
+   * state. Otherwise calls ncclCommAbort (destructive).
+   * Does not throw. Caller can recover via reconfigure().
+   */
+  virtual void abort() {
+    throw std::runtime_error(
+        "[TorchCommBackend]: abort not implemented for communicator:" +
+        std::string(getCommName()));
+  }
+
   // Device Transport API
   // Returns a device pointer (as int64) to a transport handle for use in
   // Triton/CUDA kernels. Only supported by backends with pipes transport.

--- a/comms/torchcomms/TorchCommPy.cpp
+++ b/comms/torchcomms/TorchCommPy.cpp
@@ -1304,6 +1304,23 @@ Example:
           py::arg("hints") = std::nullopt,
           py::call_guard<py::gil_scoped_release>())
       .def(
+          "abort",
+          &TorchComm::abort,
+          R"(
+Abort the communicator, stopping all in-flight operations.
+
+In reconfigurable mode (enable_reconfigure=True), this performs a graceful
+revoke of the NCCL communicator and sets the error state. The communicator
+can then be recovered via reconfigure().
+
+In non-reconfigurable mode, this performs a destructive abort of the NCCL
+communicator.
+
+Does not raise exceptions. After calling abort(), subsequent collective
+operations will fail until reconfigure() is called (in reconfigurable mode).
+          )",
+          py::call_guard<py::gil_scoped_release>())
+      .def(
           "get_device_transport",
           &TorchComm::get_device_transport,
           R"(

--- a/comms/torchcomms/nccl/TorchCommNCCL.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCL.cpp
@@ -397,6 +397,15 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::reconfigure(
   return c10::make_intrusive<TorchWorkCompleted>();
 }
 
+void TorchCommNCCL::abort() {
+  if (options_.enable_reconfigure) {
+    revokeNcclComm();
+  } else {
+    abortNcclComm();
+  }
+  comm_state_ = CommState::ERROR;
+}
+
 void TorchCommNCCL::finalize() {
   if (init_state_ == InitializationState::UNINITIALIZED) {
     throw std::runtime_error("TorchCommNCCL not initialized");
@@ -516,7 +525,7 @@ void TorchCommNCCL::abortNcclComm() {
   }
   if (options_.abort_process_on_timeout_or_error) {
     TC_LOG(ERROR, this) << "Aborting process due to timeout";
-    abort();
+    ::abort();
   }
 }
 

--- a/comms/torchcomms/nccl/TorchCommNCCL.hpp
+++ b/comms/torchcomms/nccl/TorchCommNCCL.hpp
@@ -209,6 +209,7 @@ class TorchCommNCCL : public TorchCommBackend,
   InitHandle getInitHandle() const override;
   c10::intrusive_ptr<TorchWork> reconfigure(
       const ReconfigureOptions& opts) override;
+  void abort() override;
 
   // Friend access for TorchCommNCCL
   friend class TorchWorkNCCL;

--- a/comms/torchcomms/nccl/TorchCommNCCLUtils.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCLUtils.cpp
@@ -294,7 +294,7 @@ void TorchCommNCCL::checkAndAbortIfTimedOutOrError() {
       abortNcclComm();
       if (options_.abort_process_on_timeout_or_error) {
         TC_LOG(ERROR, this) << "Aborting process due to timeout";
-        abort();
+        ::abort();
       } else {
         throw std::runtime_error("NCCL operation timed out");
       }
@@ -312,7 +312,7 @@ void TorchCommNCCL::checkAndAbortIfTimedOutOrError() {
     if (options_.abort_process_on_timeout_or_error) {
       TC_LOG(ERROR, this) << "Aborting process due to error: "
                           << ncclException.what();
-      abort();
+      ::abort();
     } else {
       throw ncclException;
     }

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -465,6 +465,15 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::reconfigure(
   return c10::make_intrusive<TorchWorkCompleted>();
 }
 
+void TorchCommNCCLX::abort() {
+  if (options_.enable_reconfigure) {
+    revokeNcclComm();
+  } else {
+    abortNcclComm();
+  }
+  comm_state_ = CommState::ERROR;
+}
+
 void TorchCommNCCLX::finalize() {
   // If initialized and in normal state, nccl_comm_ must be valid.
   // However, if comm was aborted (ERROR or TIMEOUT state), nccl_comm_ will be

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
@@ -286,6 +286,7 @@ class TorchCommNCCLX : public TorchCommBackend,
   InitHandle getInitHandle() const override;
   c10::intrusive_ptr<TorchWork> reconfigure(
       const ReconfigureOptions& opts) override;
+  void abort() override;
 
   std::unordered_map<std::string, std::string> comm_dump();
   // Friend access for TorchCommNCCLX

--- a/comms/torchcomms/ncclx/TorchCommNCCLXUtils.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXUtils.cpp
@@ -334,7 +334,7 @@ void TorchCommNCCLX::checkAndAbortIfTimedOutOrError() {
       abortNcclComm();
       if (options_.abort_process_on_timeout_or_error) {
         TC_LOG(ERROR, this) << "Aborting process due to timeout";
-        abort();
+        ::abort();
       } else {
         throw std::runtime_error("NCCLX operation timed out");
       }
@@ -352,7 +352,7 @@ void TorchCommNCCLX::checkAndAbortIfTimedOutOrError() {
     if (options_.abort_process_on_timeout_or_error) {
       TC_LOG(ERROR, this) << "Aborting process due to error: "
                           << ncclException.what();
-      abort();
+      ::abort();
     } else {
       throw ncclException;
     }

--- a/comms/torchcomms/tests/integration/py/AbortTest.py
+++ b/comms/torchcomms/tests/integration/py/AbortTest.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# pyre-unsafe
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import os
+import unittest
+from datetime import timedelta
+
+import torch
+import torchcomms
+from torch.distributed import TCPStore
+
+
+class AbortTest(unittest.TestCase):
+    """Test the abort() API for TorchComm."""
+
+    SUPPORTED_BACKENDS = {"nccl", "ncclx"}
+
+    _shared_store = None
+
+    def setUp(self):
+        self.backend = os.getenv("TEST_BACKEND", "")
+
+        if self.backend not in self.SUPPORTED_BACKENDS:
+            self.skipTest(f"Backend {self.backend} does not support abort()")
+
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA is not available")
+
+        self.rank = int(
+            os.environ.get("RANK", os.environ.get("OMPI_COMM_WORLD_RANK", 0))
+        )
+        self.world_size = int(
+            os.environ.get("WORLD_SIZE", os.environ.get("OMPI_COMM_WORLD_SIZE", 1))
+        )
+        device_id = self.rank % torch.cuda.device_count()
+        self.device = torch.device(f"cuda:{device_id}")
+
+        if AbortTest._shared_store is None:
+            master_addr = os.environ.get("MASTER_ADDR", "localhost")
+            master_port = int(os.environ.get("MASTER_PORT", "29500"))
+            AbortTest._shared_store = TCPStore(
+                host_name=master_addr,
+                port=master_port,
+                world_size=self.world_size,
+                is_master=(self.rank == 0),
+                timeout=timedelta(seconds=30),
+            )
+        self.store = AbortTest._shared_store
+
+    def _create_reconfigurable_comm(self, name, uuid):
+        comm = torchcomms.new_comm(
+            self.backend,
+            self.device,
+            name,
+            enable_reconfigure=True,
+            store=self.store,
+        )
+        my_handle = comm.get_init_handle()
+        self.store.set(f"{name}_{self.rank}", my_handle)
+        handles = []
+        for i in range(self.world_size):
+            h = self.store.get(f"{name}_{i}").decode("utf-8")
+            handles.append(h)
+        work = comm.reconfigure(
+            uuid=uuid,
+            init_handles=handles,
+            timeout=timedelta(seconds=30),
+        )
+        work.wait()
+        return comm
+
+    def test_abort(self):
+        """After abort(), subsequent operations should raise RuntimeError."""
+        comm = self._create_reconfigurable_comm("abort_error_state", 0)
+
+        comm.abort()
+        comm.finalize()
+
+    def test_abort_then_reconfigure(self):
+        """After abort(), reconfigure() should recover the communicator."""
+        comm = self._create_reconfigurable_comm("abort_recover", 10)
+
+        comm.abort()
+
+        my_handle = comm.get_init_handle()
+        self.store.set(f"abort_recover2_{self.rank}", my_handle)
+        handles = []
+        for i in range(self.world_size):
+            h = self.store.get(f"abort_recover2_{i}").decode("utf-8")
+            handles.append(h)
+
+        work = comm.reconfigure(
+            uuid=11,
+            init_handles=handles,
+            timeout=timedelta(seconds=30),
+        )
+        work.wait()
+
+        tensor = torch.ones(4, dtype=torch.float, device=self.device) * (
+            comm.get_rank() + 1
+        )
+        comm.all_reduce(tensor, torchcomms.ReduceOp.SUM, async_op=False)
+        torch.cuda.synchronize()
+
+        expected_value = sum(range(1, self.world_size + 1))
+        expected = torch.ones(4, dtype=torch.float, device="cpu") * expected_value
+        self.assertTrue(torch.allclose(tensor.cpu(), expected))
+
+        comm.finalize()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
Adds an abort() method to TorchComm that stops all in-flight NCCL operations. In reconfigurable mode (enable_reconfigure=True), it calls ncclCommRevoke for a graceful revoke that allows later recovery via reconfigure(). In non-reconfigurable mode, it calls ncclCommAbort for a destructive abort. Sets comm_state_=ERROR so subsequent operations fail until recovery. Does not throw exceptions.


Reviewed By: kapilsh, saifhhasan

Differential Revision: D101901448

Pulled By: d4l3k


