### PR TITLE
Fix transport callsites for new globalRegister/globalDeregister signatures

### DIFF
--- a/comms/torchcomms/transport/RdmaTransport.cpp
+++ b/comms/torchcomms/transport/RdmaTransport.cpp
@@ -52,10 +52,12 @@ RdmaMemory::RdmaMemory(const void* buf, size_t len, int cudaDev, bool cacheReg)
         "Failed to fetch the IB handle from regCache. The buffer may not be registered");
   } else {
     // Not registered yet; do it now.
-    FB_COMMCHECKTHROW(regCache_->globalRegister(buf_, len_, true, cudaDev_));
+    FB_COMMCHECKTHROW(regCache_->globalRegister(
+        buf_, len_, true /* forceReg */, false /* ncclManaged */, cudaDev_));
     regHdl_ = regCache_->searchIbRegHandle(buf_, len_, cudaDev_);
     if (regHdl_ == nullptr) {
-      FB_COMMCHECKIGNORE(regCache_->globalDeregister(buf_, len_, cudaDev_));
+      FB_COMMCHECKIGNORE(regCache_->globalDeregister(
+          buf_, len_, false /* skipRemRelease */, cudaDev_));
       throw std::runtime_error("Failed to fetch the IB handle from regCache.");
     }
   }
@@ -86,7 +88,8 @@ RdmaMemory::~RdmaMemory() noexcept {
     return;
   }
   if (remoteKey_.size() > 0 && regHdl_) {
-    FB_COMMCHECKIGNORE(regCache_->globalDeregister(buf_, len_, cudaDev_));
+    FB_COMMCHECKIGNORE(regCache_->globalDeregister(
+        buf_, len_, false /* skipRemRelease */, cudaDev_));
     regHdl_ = nullptr;
   }
 }

--- a/comms/torchcomms/transport/tests/cpp/RdmaTransportTest.cc
+++ b/comms/torchcomms/transport/tests/cpp/RdmaTransportTest.cc
@@ -455,7 +455,12 @@ TEST_F(RdmaMemoryTest, CacheRegConstruction) {
   // After globalRegister, RdmaMemory should succeed
   auto regCache = ctran::RegCache::getInstance();
   EXPECT_EQ(
-      regCache->globalRegister(buffer_, bufferSize_, false, cudaDev_),
+      regCache->globalRegister(
+          buffer_,
+          bufferSize_,
+          false /* forceReg */,
+          false /* ncclManaged */,
+          cudaDev_),
       commSuccess);
   RdmaMemory memory(buffer_, bufferSize_, cudaDev_, true /* cacheReg */);
   EXPECT_EQ(memory.getDevice(), cudaDev_);


### PR DESCRIPTION
Summary:
D101551580 added a `bool ncclManaged` parameter to `RegCache::globalRegister` and a `bool skipRemRelease` parameter to `RegCache::globalDeregister`, inserting them BEFORE the existing `int deviceId` parameter. Three callsites were passing `cudaDev_` (or `*cudaDevice_`) positionally as what used to be `deviceId`, so after the diff landed the int was silently reinterpreted as a bool.

Fix: pass the new bool parameter explicitly (`false /* ncclManaged */` or `false /* skipRemRelease */`) at each callsite so `cudaDev_` / `*cudaDevice_` again lands in the `deviceId` slot. Preserves the prior behavior for all three files and makes the intent of each argument visible at the call — matching the rest of the new-signature callsites (e.g., `window.cc`).

Reviewed By: tianfengfrank, amirafzali

Differential Revision: D101914693


