### PR TITLE
Update tile_sendrecv.md to reflect send/recv rename

### DIFF
--- a/comms/pipes/MultiPeerNvlTransport.h
+++ b/comms/pipes/MultiPeerNvlTransport.h
@@ -47,7 +47,7 @@ struct MultiPeerNvlTransportConfig {
   std::size_t p2pSignalCount{1};
 
   // Number of barrier slots per peer for cross-GPU synchronization.
-  // Used by barrier_sync_threadgroup() for device-side barriers.
+  // Used by barrier_sync() for device-side barriers.
   // Set to 0 (default) to skip barrier buffer allocation.
   // Typical: 1 for tile sendrecv dynamic block count support.
   std::size_t p2pBarrierCount{0};

--- a/comms/pipes/P2pNvlTransportDevice.cuh
+++ b/comms/pipes/P2pNvlTransportDevice.cuh
@@ -960,7 +960,7 @@ class P2pNvlTransportDevice {
   }
 
   /**
-   * signal_threadgroup - Signal peer GPU via NVLink
+   * signal - Signal peer GPU via NVLink
    *
    * Sends a signal to the peer's Signal object at the specified index.
    * Only the group leader performs the signal after synchronizing all threads.
@@ -975,16 +975,13 @@ class P2pNvlTransportDevice {
    * @param op SIGNAL_SET to store value, SIGNAL_ADD to atomically add value
    * @param value The value to set or add to peer's signal counter
    */
-  __device__ __forceinline__ void signal_threadgroup(
-      ThreadGroup& group,
-      uint64_t signal_id,
-      SignalOp op,
-      uint64_t value) {
+  __device__ __forceinline__ void
+  signal(ThreadGroup& group, uint64_t signal_id, SignalOp op, uint64_t value) {
     remoteState_.signalBuffer[signal_id].signal(group, op, value);
   }
 
   /**
-   * wait_signal_until_threadgroup - Wait for signal from peer GPU
+   * wait_signal_until - Wait for signal from peer GPU
    *
    * Waits until the local Signal object at the specified index satisfies
    * the given condition. All threads in the group poll the signal.
@@ -999,7 +996,7 @@ class P2pNvlTransportDevice {
    * @param op The comparison operation (CMP_EQ, CMP_GE, etc.)
    * @param value The value to compare against
    */
-  __device__ __forceinline__ void wait_signal_until_threadgroup(
+  __device__ __forceinline__ void wait_signal_until(
       ThreadGroup& group,
       uint64_t signal_id,
       CmpOp op,
@@ -1009,7 +1006,7 @@ class P2pNvlTransportDevice {
   }
 
   /**
-   * reset_signal_threadgroup - Reset a local signal slot to zero
+   * reset_signal - Reset a local signal slot to zero
    *
    * Resets the local signal counter at the specified index to zero.
    * This is safe to call from the receiver side after processing the signal,
@@ -1021,7 +1018,7 @@ class P2pNvlTransportDevice {
    * @param group ThreadGroup for cooperative thread synchronization
    * @param signal_id Index into the signalBuffer array
    */
-  __device__ __forceinline__ void reset_signal_threadgroup(
+  __device__ __forceinline__ void reset_signal(
       ThreadGroup& group,
       uint64_t signal_id) {
     if (group.is_leader()) {
@@ -1031,7 +1028,7 @@ class P2pNvlTransportDevice {
   }
 
   /**
-   * barrier_sync_threadgroup - Two-sided barrier synchronization with peer GPU
+   * barrier_sync - Two-sided barrier synchronization with peer GPU
    *
    * Performs a full barrier synchronization between this GPU and the peer GPU
    * over NVLink. Both sides must call this function to complete the barrier.
@@ -1051,7 +1048,7 @@ class P2pNvlTransportDevice {
    * All threads in the group must call this function (collective operation).
    * Both GPUs must call with the same barrier_id to synchronize.
    */
-  __device__ __forceinline__ void barrier_sync_threadgroup(
+  __device__ __forceinline__ void barrier_sync(
       ThreadGroup& group,
       uint64_t barrier_id,
       const Timeout& timeout = Timeout()) {

--- a/comms/pipes/benchmarks/BarrierBench.cc
+++ b/comms/pipes/benchmarks/BarrierBench.cc
@@ -25,12 +25,12 @@ namespace comms::pipes::benchmark {
 /**
  * Benchmark P2P barrier synchronization using P2pNvlTransportDevice
  *
- * GPU 0 and GPU 1 perform barrier_sync_threadgroup operations concurrently.
- * Each call to barrier_sync_threadgroup:
+ * GPU 0 and GPU 1 perform barrier_sync operations concurrently.
+ * Each call to barrier_sync:
  *   - Arrives at peer's barrier via NVLink remote write
  *   - Waits on local barrier until peer arrives
  *
- * This measures the latency of the barrier_sync_threadgroup API over NVLink.
+ * This measures the latency of the barrier_sync API over NVLink.
  */
 static void barrierBench(
     uint32_t iters,

--- a/comms/pipes/benchmarks/BarrierBench.cu
+++ b/comms/pipes/benchmarks/BarrierBench.cu
@@ -10,14 +10,14 @@ namespace comms::pipes::benchmark {
 /**
  * barrierBenchKernel - Benchmark kernel for P2P barrier synchronization
  *
- * Uses P2pNvlTransportDevice::barrier_sync_threadgroup() for cross-GPU
+ * Uses P2pNvlTransportDevice::barrier_sync() for cross-GPU
  * synchronization over NVLink.
  */
 __global__ void
 barrierBenchKernel(P2pNvlTransportDevice p2p, int nSteps, bool useBlockGroups) {
   auto group = useBlockGroups ? make_block_group() : make_warp_group();
   for (int step = 0; step < nSteps; ++step) {
-    p2p.barrier_sync_threadgroup(group, group.group_id);
+    p2p.barrier_sync(group, group.group_id);
   }
 }
 

--- a/comms/pipes/benchmarks/BenchmarkKernel.cu
+++ b/comms/pipes/benchmarks/BenchmarkKernel.cu
@@ -112,8 +112,8 @@ __global__ void p2pSignalBenchKernel(
   // - Wait on local signal buffer (local read)
   // multiple times before the other reads.
   for (int step = 1; step <= nSteps; ++step) {
-    p2p.signal_threadgroup(group, signal_id, SignalOp::SIGNAL_ADD, 1);
-    p2p.wait_signal_until_threadgroup(
+    p2p.signal(group, signal_id, SignalOp::SIGNAL_ADD, 1);
+    p2p.wait_signal_until(
         group, signal_id, CmpOp::CMP_EQ, static_cast<uint64_t>(step));
   }
 }

--- a/comms/pipes/benchmarks/TileSendRecv.cu
+++ b/comms/pipes/benchmarks/TileSendRecv.cu
@@ -54,7 +54,7 @@ __global__ __launch_bounds__(512, 1) void p2pTileSendRecv(
 // creates a cross-GPU race: the new sender on GPU A may overwrite
 // staging positions that the old receiver on GPU B is still reading.
 //
-// The per-block barrier_sync_threadgroup prevents this race:
+// The per-block barrier_sync prevents this race:
 //
 //   Stream ordering guarantee:
 //     Both kernels execute on the same CUDA stream per GPU. So on each
@@ -105,7 +105,7 @@ __global__ __launch_bounds__(512, 1) void p2pTileSendRecvDynamic(
   const int blockId = sub.group_id;
 
   if (needsBarrier) {
-    p2p.barrier_sync_threadgroup(sub, blockId, timeout);
+    p2p.barrier_sync(sub, blockId, timeout);
   }
 
   if (role == 0) {

--- a/comms/pipes/benchmarks/TileSendRecv.cuh
+++ b/comms/pipes/benchmarks/TileSendRecv.cuh
@@ -161,7 +161,7 @@ __global__ void p2pTileSendRecv(
  * partition uses numBlocks (variable) for efficient use of staging memory.
  *
  * When numBlocks changes, the caller must set needsBarrier=true. Each block
- * does barrier_sync_threadgroup with its peer to ensure the remote GPU's
+ * does barrier_sync with its peer to ensure the remote GPU's
  * previous kernel completed all staging reads before the new layout takes
  * effect. See TileSendRecv.cu for the full correctness analysis.
  *

--- a/comms/pipes/docs/tile_sendrecv.md
+++ b/comms/pipes/docs/tile_sendrecv.md
@@ -2,7 +2,7 @@
 
 A **tile** is the smallest unit of work that all threads in a block process concurrently at one time. A user is free to choose how big or small a tile is. Smaller tiles allow more pipelining but incur more signaling overhead; larger tiles amortize signaling costs. Data is divided amongst blocks by creating tiles of data — each block may handle multiple tiles sequentially, and different blocks may handle different tiles in parallel.
 
-A unified `send_tile` / `recv_tile` API for pipelined point-to-point transfers
+A unified `send` / `recv` API for pipelined point-to-point transfers
 on `P2pNvlTransportDevice` and `P2pIbgdaTransportDevice`, callable from CUDA
 and Triton kernels. Composable building blocks for collectives (allgather,
 alltoall, sendrecv) without users needing to manage staging, signals, slot
@@ -11,8 +11,7 @@ rotation, or pipeline depth.
 **Target backends (all 4 share this contract):** NVLink cpp, NVLink Triton, IB
 cpp, IB Triton.
 
-**In scope:** per-block tile send/recv with cooperative memcpy + pipelined
-staging.
+**In scope:** per-block tile send/recv with cooperative memcpy + pipelined staging.
 **Out of scope:** explicit user-visible drain (handled internally), multi-stream
 concurrency on the same transport, buffer registration (transport-owned), and
 cross-rank rendezvous (separate barrier primitive).
@@ -34,7 +33,7 @@ The existing config already carries all three knobs:
 |---|---|
 | `data_buffer_size` | Bytes per pipeline slot, per peer, per direction. Tile staging is allocated from this. |
 | `pipeline_depth` | Number of slots in the pipeline ring. |
-| `tile_max_blocks` (renamed → `tile_max_groups`) | Upper bound on the number of groups that may call `send_tile`/`recv_tile`. Sizes signal pad and step state arrays. |
+| `tile_max_blocks` (renamed → `tile_max_groups`) | Upper bound on the number of groups that may call `send`/`recv`. Sizes signal pad and step state arrays. |
 
 No new fields are needed on the NVL side.
 
@@ -51,7 +50,7 @@ struct MultipeerIbgdaTransportConfig {
   // Default 2 (double-buffered). Must be >= 1.
   std::size_t tile_pipeline_depth{2};
 
-  // Upper bound on the number of groups calling send_tile/recv_tile.
+  // Upper bound on the number of groups calling send/recv.
   // Sizes signal pad and step state arrays. Must be >= 1.
   int tile_max_groups{128};
 };
@@ -83,7 +82,7 @@ send staging that NVLink does not need.
 
 ```cpp
 struct NvlinkTransportTileState {
-  // Per-block step counters. Persistent across send_tile/recv_tile calls.
+  // Per-block step counters. Persistent across send/recv calls.
   // Required for monotonic signal values and slot-rotation continuity.
   DeviceSpan<int64_t> step_state;   // [2 * max_groups]
                                     //   [0..max_groups)         = sender step per block
@@ -103,7 +102,7 @@ struct NvlinkTransportTileState {
 
 ```cpp
 struct IbTransportTileState {
-  // Per-block step counters. Persistent across send_tile/recv_tile calls.
+  // Per-block step counters. Persistent across send/recv calls.
   DeviceSpan<int64_t> step_state;   // [2 * max_groups]
                                     //   [0..max_groups)         = sender step per block
                                     //   [max_groups..2*max_groups) = receiver step per block
@@ -159,7 +158,7 @@ caller's responsibility (kernel must finish before the host destructor runs).
 ```cpp
 class P2pIbgdaTransportDevice {
  public:
-  __device__ void send_tile(
+  __device__ void send(
       ThreadGroup& group,
       const void* src,
       size_t nbytes,
@@ -167,7 +166,7 @@ class P2pIbgdaTransportDevice {
       size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout());
 
-  __device__ void recv_tile(
+  __device__ void recv(
       ThreadGroup& group,
       void* dst,
       size_t nbytes,
@@ -182,7 +181,7 @@ class P2pIbgdaTransportDevice {
 
 ```python
 @core.extern
-def send_tile(
+def send(
     src_ptr, nbytes,
     block_id, active_blocks,
     max_signal_bytes,
@@ -195,7 +194,7 @@ def send_tile(
     ...
 
 @core.extern
-def recv_tile(dst_ptr, nbytes, block_id, active_blocks, max_signal_bytes, timeout_ns,
+def recv(dst_ptr, nbytes, block_id, active_blocks, max_signal_bytes, timeout_ns,
               transport_handle: tl.constexpr):
     ...
 ```
@@ -207,7 +206,7 @@ def recv_tile(dst_ptr, nbytes, block_id, active_blocks, max_signal_bytes, timeou
 | `group` (cpp) / `block_id` (Triton) | yes | — | Identifies this calling block. Slot routing uses `group.group_id` (cpp) or the `block_id` arg (Triton). |
 | `src` / `dst` | yes | — | This block's pre-sliced data pointer. Caller computes per-block offset (see `TiledBuffer`). |
 | `nbytes` | yes | — | This block's data size. May exceed `per_block_slot_size` — chunked internally over pipeline slots. |
-| `active_blocks` | no | `0` → `tile_max_groups` | Number of blocks calling `send_tile`/`recv_tile` concurrently. Determines `per_block_slot_size = data_buffer_size / active_blocks`. |
+| `active_blocks` | no | `0` → `tile_max_groups` | Number of blocks calling `send`/`recv` concurrently. Determines `per_block_slot_size = data_buffer_size / active_blocks`. |
 | `max_signal_bytes` | no | `0` → `per_block_slot_size` | Hint for the maximum number of bytes between consecutive DATA_READY signals. The transport may signal more frequently if too many blocks share the data buffer. Capped at `per_block_slot_size` if larger (sub-slot signaling only). |
 | `timeout` | no | `Timeout()` (no limit) | Per-wait timeout. Reuses `comms::pipes::Timeout`. On expiry: `__trap()`. |
 
@@ -229,13 +228,13 @@ def recv_tile(dst_ptr, nbytes, block_id, active_blocks, max_signal_bytes, timeou
 
 ### Per-call contract
 
-1. **CTA-cooperative.** All threads in `group` MUST call `send_tile` /
-   `recv_tile` convergently. Cooperative memcpy across the block; leader thread
+1. **CTA-cooperative.** All threads in `group` MUST call `send` /
+   `recv` convergently. Cooperative memcpy across the block; leader thread
    issues signals and RDMA puts.
 2. **Slot routing index = `group.group_id`** (cpp) / `block_id` extern arg
    (Triton). The *logical index within the calling group*, not raw `blockIdx.x`.
    So a kernel that does `auto [role, sub] = group.partition(2)` passes `sub`
-   to `send_tile` / `recv_tile`, and `sub.group_id` (range `[0, sub.total_groups)`)
+   to `send` / `recv`, and `sub.group_id` (range `[0, sub.total_groups)`)
    is the slot row index.
 3. **Trap precondition (debug-mode `__trap`):**
    `group.group_id < (active_blocks > 0 ? active_blocks : tile_max_groups)`.
@@ -253,7 +252,7 @@ def recv_tile(dst_ptr, nbytes, block_id, active_blocks, max_signal_bytes, timeou
 
 ### Changing `active_blocks` between calls
 
-If `active_blocks` changes between consecutive `send_tile`/`recv_tile` calls on the same transport, a **cross-rank barrier** is required between the two calls. Changing `active_blocks` alters `per_block_slot_size` and therefore the slot row layout; without a barrier, the receiver may still be draining the old layout while the sender begins writing the new one, corrupting staging data.
+If `active_blocks` changes between consecutive `send`/`recv` calls on the same transport, a **cross-rank barrier** is required between the two calls. Changing `active_blocks` alters `per_block_slot_size` and therefore the slot row layout; without a barrier, the receiver may still be draining the old layout while the sender begins writing the new one, corrupting staging data.
 
 ### Concurrency
 
@@ -298,7 +297,7 @@ tail_signal_id  = block_id                         // DATA_READY (sender → rec
 head_signal_id  = tile_max_groups + block_id         // SLOT_FREE  (receiver → sender)
 ```
 
-### `send_tile` (NVL)
+### `send` (NVL)
 
 ```text
 if nbytes == 0: return
@@ -348,7 +347,7 @@ completes, all threads have finished their stores, so the data is visible on the
 remote side and local `src` is immediately safe. No outstanding async operations
 remain.
 
-### `recv_tile` (NVL)
+### `recv` (NVL)
 
 ```text
 if nbytes == 0: return
@@ -390,7 +389,7 @@ step_state.receiver[block_id] = step
 group.sync()
 ```
 
-### `send_tile` (IB)
+### `send` (IB)
 
 ```text
 if nbytes == 0: return
@@ -448,7 +447,7 @@ wait_counter(group, nic_done_counter[block_id], step, timeout)
 group.sync()
 ```
 
-### `recv_tile` (IB)
+### `recv` (IB)
 
 ```text
 if nbytes == 0: return
@@ -494,12 +493,12 @@ group.sync()
 
 | Step | Backend | Why it is needed |
 |---|---|---|
-| `send_tile (1)` backpressure | NVL | Receiver may still be reading its local staging. Writing new data via NVLink would corrupt the receiver's in-progress memcpy. Slot-boundary only — sub-steps within a slot share the same slot. |
-| `send_tile (1)` NIC drain | IB | NIC may still be reading local staging from a prior put. Memcpying new data would corrupt the in-flight RDMA. |
-| `send_tile (3)` backpressure | IB | Receiver may still be reading remote staging. Putting new data would corrupt the receiver's read. Slot-boundary only. |
-| `send_tile (5)` drain | IB | Without the drain, returning from `send_tile` would leave outstanding RDMA puts in flight. Internal drain makes the postcondition crisp: on return, all RDMA is delivered. |
-| `recv_tile (1)` | Both | Receiver cannot consume staging until the sender has signaled DATA_READY. |
-| `recv_tile (3)` | Both | Sender's backpressure relies on this signal. Slot-boundary only, matching sender's wait granularity. |
+| `send (1)` backpressure | NVL | Receiver may still be reading its local staging. Writing new data via NVLink would corrupt the receiver's in-progress memcpy. Slot-boundary only — sub-steps within a slot share the same slot. |
+| `send (1)` NIC drain | IB | NIC may still be reading local staging from a prior put. Memcpying new data would corrupt the in-flight RDMA. |
+| `send (3)` backpressure | IB | Receiver may still be reading remote staging. Putting new data would corrupt the receiver's read. Slot-boundary only. |
+| `send (5)` drain | IB | Without the drain, returning from `send` would leave outstanding RDMA puts in flight. Internal drain makes the postcondition crisp: on return, all RDMA is delivered. |
+| `recv (1)` | Both | Receiver cannot consume staging until the sender has signaled DATA_READY. |
+| `recv (3)` | Both | Sender's backpressure relies on this signal. Slot-boundary only, matching sender's wait granularity. |
 
 ---
 
@@ -530,7 +529,7 @@ __global__ void bidirectional_send_recv_kernel(
   TiledBuffer<char> tiles(is_sender ? src : dst, total_bytes, sub);
 
   if (is_sender) {
-    transport->send_tile(
+    transport->send(
         sub,
         tiles.data(),
         tiles.bytes(),
@@ -538,7 +537,7 @@ __global__ void bidirectional_send_recv_kernel(
         /*max_signal_bytes=*/  0,                   // default = one signal per slot fill
         timeout);
   } else {
-    transport->recv_tile(
+    transport->recv(
         sub,
         tiles.data(),
         tiles.bytes(),
@@ -579,15 +578,15 @@ Notes on the example:
 
 ## 7. Out of Scope / Future Work
 
-- **Explicit `drain_tile` API.** Drain is currently internal to `send_tile`
+- **Explicit `drain_tile` API.** Drain is currently internal to `send`
   (step 5). May be exposed if users want to overlap NIC drain with other
-  device-side work between consecutive `send_tile` calls.
+  device-side work between consecutive `send` calls.
 - **Multi-stream concurrency on the same transport.** Currently undefined.
   Would require per-stream `step_state` and `signal_pad` arenas.
 - **Per-call config overrides.** `pipeline_depth` and `data_buffer_size` are
   construction-time only. Per-call overrides would require dynamic staging
   re-allocation.
 - **Cross-rank rendezvous.** Use a separate barrier primitive; not coupled to
-  send/recv_tile.
+  send/recv.
 - **Error reporting on timeout.** Currently traps. Future: device flag +
   host-readable error code for graceful recovery in long-running services.

--- a/comms/pipes/tests/BarrierTest.cu
+++ b/comms/pipes/tests/BarrierTest.cu
@@ -113,7 +113,7 @@ __global__ void testDeviceBarrierSyncKernel(
     uint64_t barrierId,
     GroupType groupType) {
   auto group = make_group(groupType);
-  p2p->barrier_sync_threadgroup(group, barrierId);
+  p2p->barrier_sync(group, barrierId);
 }
 
 __global__ void testDeviceBarrierSyncMultipleKernel(
@@ -123,7 +123,7 @@ __global__ void testDeviceBarrierSyncMultipleKernel(
     GroupType groupType) {
   auto group = make_group(groupType);
   for (int i = 0; i < numSyncs; ++i) {
-    p2p->barrier_sync_threadgroup(group, barrierId);
+    p2p->barrier_sync(group, barrierId);
   }
 }
 
@@ -170,7 +170,7 @@ __global__ void testBarrierWriteDataKernel(
   p2p->put(group, remoteDataBuffer, localSrcBuffer, dataSize);
 
   // Each thread group uses its own barrier id
-  p2p->barrier_sync_threadgroup(group, barrierId);
+  p2p->barrier_sync(group, barrierId);
 }
 
 __global__ void testBarrierVerifyDataKernel(
@@ -187,7 +187,7 @@ __global__ void testBarrierVerifyDataKernel(
 
   // Barrier sync - arrive on remote, wait on local
   // This ensures writer's data is visible before we read
-  p2p->barrier_sync_threadgroup(group, barrierId);
+  p2p->barrier_sync(group, barrierId);
 
   // Calculate the portion of data this thread group handles
   size_t bytesPerGroup = dataSize / group.total_groups;

--- a/comms/pipes/tests/BarrierTest.cuh
+++ b/comms/pipes/tests/BarrierTest.cuh
@@ -51,7 +51,7 @@ void testReadBarrierExpectedCounter(
 
 // =============================================================================
 // P2pNvlTransportDevice barrier API test helpers
-// These test barrier_sync_threadgroup() with 2-GPU P2P communication
+// These test barrier_sync() with 2-GPU P2P communication
 // =============================================================================
 
 // Barrier sync operation using P2pNvlTransportDevice

--- a/comms/pipes/tests/P2pNvlTransportDeviceTest.cu
+++ b/comms/pipes/tests/P2pNvlTransportDeviceTest.cu
@@ -29,7 +29,7 @@ __global__ void testDeviceSignalKernel(
     uint64_t value,
     GroupType groupType) {
   auto group = make_group(groupType);
-  p2p->signal_threadgroup(group, signalId, op, value);
+  p2p->signal(group, signalId, op, value);
 }
 
 __global__ void testDeviceWaitSignalKernel(
@@ -39,7 +39,7 @@ __global__ void testDeviceWaitSignalKernel(
     uint64_t value,
     GroupType groupType) {
   auto group = make_group(groupType);
-  p2p->wait_signal_until_threadgroup(group, signalId, op, value);
+  p2p->wait_signal_until(group, signalId, op, value);
 }
 
 __global__ void testDeviceSignalThenWaitKernel(
@@ -51,8 +51,8 @@ __global__ void testDeviceSignalThenWaitKernel(
     uint64_t waitValue,
     GroupType groupType) {
   auto group = make_group(groupType);
-  p2p->signal_threadgroup(group, signalId, signalOp, signalValue);
-  p2p->wait_signal_until_threadgroup(group, signalId, waitOp, waitValue);
+  p2p->signal(group, signalId, signalOp, signalValue);
+  p2p->wait_signal_until(group, signalId, waitOp, waitValue);
 }
 
 void testDeviceSignal(
@@ -125,7 +125,7 @@ __global__ void testDeviceResetSignalKernel(
     uint64_t signalId,
     GroupType groupType) {
   auto group = make_group(groupType);
-  p2p->reset_signal_threadgroup(group, signalId);
+  p2p->reset_signal(group, signalId);
 }
 
 void testDeviceResetSignal(

--- a/comms/pipes/tests/P2pNvlTransportTest.cu
+++ b/comms/pipes/tests/P2pNvlTransportTest.cu
@@ -258,7 +258,7 @@ __global__ void testPutWithSignalKernel(
     GroupType groupType) {
   auto group = make_group(groupType);
   auto writtenBytes = p2p->put_group(group, dst_d, src_d, nbytes);
-  p2p->signal_threadgroup(group, signal_id, SignalOp::SIGNAL_ADD, writtenBytes);
+  p2p->signal(group, signal_id, SignalOp::SIGNAL_ADD, writtenBytes);
 }
 
 void testPutWithSignal(
@@ -286,7 +286,7 @@ __global__ void testWaitKernel(
     uint64_t expected,
     GroupType groupType) {
   auto group = make_group(groupType);
-  p2p->wait_signal_until_threadgroup(group, signal_id, op, expected);
+  p2p->wait_signal_until(group, signal_id, op, expected);
 }
 
 void testWait(

--- a/comms/torchcomms/tests/integration/cpp/PipesTransportApiTestKernels.cu
+++ b/comms/torchcomms/tests/integration/cpp/PipesTransportApiTestKernels.cu
@@ -77,8 +77,8 @@ __global__ void transportStressSendRecvKernel(
     // Signal-based barrier: both ranks signal and wait before next iteration.
     // Barrier buffers are not available via get_device_transport(), so we use
     // monotonic signal ADD/GE on signal_id 0 as a barrier replacement.
-    nvl.signal_threadgroup(group, 0, SignalOp::SIGNAL_ADD, 1);
-    nvl.wait_signal_until_threadgroup(
+    nvl.signal(group, 0, SignalOp::SIGNAL_ADD, 1);
+    nvl.wait_signal_until(
         group, 0, CmpOp::CMP_GE, static_cast<uint64_t>(iter + 1));
   }
 }
@@ -111,9 +111,9 @@ __global__ void transportStressSignalKernel(
 
   for (int iter = 0; iter < iterations; iter++) {
     // Signal peer: add 1 to signal_id 0
-    nvl.signal_threadgroup(group, 0, SignalOp::SIGNAL_ADD, 1);
+    nvl.signal(group, 0, SignalOp::SIGNAL_ADD, 1);
     // Wait for peer's signal: expect monotonically increasing value
-    nvl.wait_signal_until_threadgroup(
+    nvl.wait_signal_until(
         group, 0, CmpOp::CMP_GE, static_cast<uint64_t>(iter + 1));
   }
 }
@@ -149,8 +149,8 @@ __global__ void transportStressCombinedKernel(
     // Phase 1: Signal-based barrier (barrier buffers not available via
     // get_device_transport(), so use signal ADD/GE on signal_id 0).
     // Two signals per iteration: one here, one after send/recv.
-    nvl.signal_threadgroup(group, 0, SignalOp::SIGNAL_ADD, 1);
-    nvl.wait_signal_until_threadgroup(
+    nvl.signal(group, 0, SignalOp::SIGNAL_ADD, 1);
+    nvl.wait_signal_until(
         group, 0, CmpOp::CMP_GE, static_cast<uint64_t>(2 * iter + 1));
 
     // Phase 2: Send/recv
@@ -168,8 +168,8 @@ __global__ void transportStressCombinedKernel(
     }
 
     // Phase 3: Signal/wait (confirms both ranks finished send/recv)
-    nvl.signal_threadgroup(group, 0, SignalOp::SIGNAL_ADD, 1);
-    nvl.wait_signal_until_threadgroup(
+    nvl.signal(group, 0, SignalOp::SIGNAL_ADD, 1);
+    nvl.wait_signal_until(
         group, 0, CmpOp::CMP_GE, static_cast<uint64_t>(2 * iter + 2));
 
     // Phase 4: Verify on receiver
@@ -264,8 +264,8 @@ __global__ void transportStressLl128Kernel(
 
     // Signal-based barrier before next iteration (barrier buffers not
     // available via get_device_transport())
-    nvl.signal_threadgroup(group, 0, SignalOp::SIGNAL_ADD, 1);
-    nvl.wait_signal_until_threadgroup(
+    nvl.signal(group, 0, SignalOp::SIGNAL_ADD, 1);
+    nvl.wait_signal_until(
         group, 0, CmpOp::CMP_GE, static_cast<uint64_t>(iter + 1));
   }
 }

--- a/comms/torchcomms/triton/device_transport.cu
+++ b/comms/torchcomms/triton/device_transport.cu
@@ -47,7 +47,7 @@ __device__ int torchcomms_transport_signal(
     unsigned long long value) {
   auto* handle = reinterpret_cast<MultiPeerDeviceHandle*>(handle_ptr);
   auto group = make_block_group();
-  handle->get_nvl(peer).signal_threadgroup(
+  handle->get_nvl(peer).signal(
       group,
       static_cast<uint64_t>(signal_id),
       static_cast<SignalOp>(op),
@@ -63,7 +63,7 @@ __device__ int torchcomms_transport_wait_signal(
     unsigned long long value) {
   auto* handle = reinterpret_cast<MultiPeerDeviceHandle*>(handle_ptr);
   auto group = make_block_group();
-  handle->get_nvl(peer).wait_signal_until_threadgroup(
+  handle->get_nvl(peer).wait_signal_until(
       group,
       static_cast<uint64_t>(signal_id),
       static_cast<CmpOp>(op),
@@ -115,8 +115,7 @@ __device__ int
 torchcomms_transport_barrier(void* handle_ptr, int peer, int barrier_id) {
   auto* handle = reinterpret_cast<MultiPeerDeviceHandle*>(handle_ptr);
   auto group = make_block_group();
-  handle->get_nvl(peer).barrier_sync_threadgroup(
-      group, static_cast<uint64_t>(barrier_id));
+  handle->get_nvl(peer).barrier_sync(group, static_cast<uint64_t>(barrier_id));
   return 0;
 }
 


### PR DESCRIPTION
Summary:
Update the design document to use the new method names: send_tile/recv_tile
are now send/recv. Updated all code examples, API declarations, algorithm
pseudocode, parameter tables, and prose references throughout the document.

Reviewed By: goelayu

Differential Revision: D101751637


