### PR TITLE
Port NCCL_HAS_DUMP_ALGO_STAT conditional guard to v2_29

### DIFF
--- a/comms/ncclx/v2_29/src/nccl.h.in
+++ b/comms/ncclx/v2_29/src/nccl.h.in
@@ -1109,7 +1109,16 @@ ncclResult_t ncclCommDumpAll(std::unordered_map<std::string, std::unordered_map<
 #define NCCL_HAS_COMMS_TRACING_SERVICE_PORT
 ncclResult_t ncclCommsTracingServicePort(int& port);
 
+// NCCL_HAS_DUMP_ALGO_STAT controls whether dumpAlgoStat() is available.
+// To disable (e.g., when using a shim with a
+// different ncclComm layout), compile with -DNCCL_HAS_DUMP_ALGO_STAT=0.
+#if !defined(NCCL_HAS_DUMP_ALGO_STAT)
 #define NCCL_HAS_DUMP_ALGO_STAT
+#elif NCCL_HAS_DUMP_ALGO_STAT == 0
+#undef NCCL_HAS_DUMP_ALGO_STAT
+#endif
+
+#ifdef NCCL_HAS_DUMP_ALGO_STAT
 namespace ncclx::colltrace {
 
 // Dump collective algorithm statistics for a communicator.
@@ -1119,6 +1128,7 @@ namespace ncclx::colltrace {
 void dumpAlgoStat(ncclComm_t comm, std::unordered_map<std::string, std::unordered_map<std::string, int64_t>>& map);
 
 } // namespace ncclx::colltrace
+#endif // NCCL_HAS_DUMP_ALGO_STAT
 
 namespace ncclx {
 


### PR DESCRIPTION
Summary:
Port the conditional compilation guard for NCCL_HAS_DUMP_ALGO_STAT
from v2_28 to v2_29. This allows downstream consumers (e.g., shims
with a different ncclComm layout) to disable dumpAlgoStat() by
compiling with -DNCCL_HAS_DUMP_ALGO_STAT=0.

Reviewed By: tianfengfrank, goelayu

Differential Revision: D101930200


