### PR TITLE
Add scuba algo profiling to AllGatherP algos (#2210)

### DIFF
--- a/comms/ctran/algos/AllGatherP/DirectImpl.cc
+++ b/comms/ctran/algos/AllGatherP/DirectImpl.cc
@@ -6,6 +6,7 @@
 #include "comms/ctran/algos/AllGatherP/AlgoImpl.h"
 #include "comms/ctran/algos/AllGatherP/CommUtils.h"
 #include "comms/ctran/algos/CtranAlgo.h"
+#include "comms/ctran/profiler/Profiler.h"
 #include "comms/ctran/utils/ExtUtils.h"
 #include "comms/utils/checks.h"
 
@@ -29,6 +30,19 @@ commResult_t gpnFn(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
 
   CtranAlgoLogger logger(AlgoImpl::algoName(myAlgo), op->opCount, comm);
 
+  ctran::Profiler* profiler = comm->ctran_->profiler.get();
+  if (profiler) {
+    profiler->initForEachColl(
+        op->opCount, NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT);
+  }
+
+  CTRAN_PROFILER_IF(profiler, {
+    auto& algoContext = profiler->algoContext;
+    algoContext.algorithmName = AlgoImpl::algoName(myAlgo);
+    algoContext.sendContext.messageSizes = std::to_string(sendSize);
+    algoContext.recvContext.messageSizes = std::to_string(sendSize * nRanks);
+  });
+
   std::vector<std::unique_ptr<CtranMapperRequest>> pReqs;
   std::vector<std::unique_ptr<CtranMapperRequest>> sReqs;
   std::vector<std::unique_ptr<CtranMapperRequest>> rReqs;
@@ -41,14 +55,20 @@ commResult_t gpnFn(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
 
   void* sendHdl = nullptr;
   bool localReg = false;
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::BUF_REG));
   FB_COMMCHECK(
       mapper->searchRegHandle(sendBuff, sendSize, &sendHdl, &localReg));
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::BUF_REG));
   auto guard = folly::makeGuard([sendHdl, localReg, mapper]() {
     if (localReg) {
       FB_COMMCHECKIGNORE(mapper->deregDynamic(sendHdl));
     }
   });
 
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_CTRL));
   // Sync to make sure ib peers are ready to receive
   for (int p = 1; p < nRanks; p++) {
     CtranMapperRequest* req = nullptr;
@@ -66,7 +86,11 @@ commResult_t gpnFn(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
   for (auto& req : sReqs) {
     FB_COMMCHECK(mapper->waitRequest(req.get()));
   }
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_CTRL));
 
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_DATA));
   // Issue PUT operations
   for (auto p = 1; p < nRanks; p++) {
     CtranMapperRequest* req = nullptr;
@@ -101,8 +125,13 @@ commResult_t gpnFn(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
   for (auto& req : pReqs) {
     FB_COMMCHECK(mapper->waitRequest(req.get()));
   }
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_DATA));
+
   mapper->timestamps.emplace_back(std::move(timestamp));
   mapper->reportProfiling();
+
+  CTRAN_PROFILER_IF(profiler, { profiler->reportToScuba(); });
 
   return commSuccess;
 }

--- a/comms/ctran/algos/AllGatherP/PipelineImpl.cc
+++ b/comms/ctran/algos/AllGatherP/PipelineImpl.cc
@@ -7,6 +7,7 @@
 #include "comms/ctran/algos/AllGatherP/Types.h"
 #include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/ctran/mapper/CtranMapper.h"
+#include "comms/ctran/profiler/Profiler.h"
 #include "comms/ctran/utils/ExtUtils.h"
 
 using ctran::allgatherp::AlgoImpl;
@@ -41,6 +42,19 @@ commResult_t gpeFn(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
 
   CtranAlgoLogger logger(AlgoImpl::algoName(myAlgo), op->opCount, comm);
 
+  ctran::Profiler* profiler = comm->ctran_->profiler.get();
+  if (profiler) {
+    profiler->initForEachColl(
+        op->opCount, NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT);
+  }
+
+  CTRAN_PROFILER_IF(profiler, {
+    auto& algoContext = profiler->algoContext;
+    algoContext.algorithmName = AlgoImpl::algoName(myAlgo);
+    algoContext.sendContext.messageSizes = std::to_string(sendSize);
+    algoContext.recvContext.messageSizes = std::to_string(sendSize * nRanks);
+  });
+
   // Receive data from upPeer, and put to downPeer
   const int downPeer = (nRanks + rank + nLocalRanks) % nRanks;
   const int upPeer = (nRanks + rank - nLocalRanks) % nRanks;
@@ -49,8 +63,12 @@ commResult_t gpeFn(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
 
   void* sendHdl = nullptr;
   bool localReg;
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::BUF_REG));
   FB_COMMCHECK(
       mapper->searchRegHandle(sendBuff, sendSize, &sendHdl, &localReg));
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::BUF_REG));
   auto guard = folly::makeGuard([sendHdl, localReg, mapper]() {
     if (localReg) {
       FB_COMMCHECKIGNORE(mapper->deregDynamic(sendHdl));
@@ -59,16 +77,22 @@ commResult_t gpeFn(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
 
   CtranMapperRequest syncSreq, syncRreq;
 
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_CTRL));
   // Sync to notify upPeer that I am ready to receive data
   FB_COMMCHECK(mapper->isendCtrl(upPeer, &syncSreq));
   FB_COMMCHECK(mapper->irecvCtrl(downPeer, &syncRreq));
 
   FB_COMMCHECK(mapper->waitRequest(&syncRreq));
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_CTRL));
 
   // Initialize notify flag to receive from upstream peer
   auto notify = std::make_unique<CtranMapperNotify>();
   FB_COMMCHECK(mapper->initNotify(upPeer, pArgs->recvHdl, notify.get()));
 
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_DATA));
   std::vector<CtranMapperRequest> putReqs(nNodes - 1);
   for (auto step = 0; step < nNodes - 1; step++) {
     const auto offset =
@@ -104,9 +128,13 @@ commResult_t gpeFn(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
   for (auto& putReq : putReqs) {
     FB_COMMCHECK(mapper->waitRequest(&putReq));
   }
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_DATA));
 
   // Wait till the isendCtrl has completed so we don't have leak
   FB_COMMCHECK(mapper->waitRequest(&syncSreq));
+
+  CTRAN_PROFILER_IF(profiler, { profiler->reportToScuba(); });
 
   return commSuccess;
 }

--- a/comms/ctran/tests/CtranDistAllgatherPTests.cc
+++ b/comms/ctran/tests/CtranDistAllgatherPTests.cc
@@ -15,6 +15,7 @@
 #include <nccl.h>
 #include "comms/ctran/Ctran.h"
 #include "comms/ctran/algos/AllGatherP/AlgoImpl.h"
+#include "comms/ctran/profiler/Profiler.h"
 #include "comms/ctran/tests/CtranDistTestUtils.h"
 #include "comms/ctran/tests/CtranTestUtils.h"
 #include "comms/testinfra/TestXPlatUtils.h"
@@ -58,6 +59,8 @@ class CtranAllgatherPTest : public ctran::CtranDistTestFixture {
 
   void SetUp() override {
     setenv("NCCL_CTRAN_ENABLE", "1", 0);
+    setenv("NCCL_CTRAN_TRANSPORT_PROFILER", "1", 0);
+    setenv("NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT", "1", 0);
     CtranDistTestFixture::SetUp();
 
     CUDACHECK_TEST(cudaStreamCreate(&stream));
@@ -75,6 +78,29 @@ class CtranAllgatherPTest : public ctran::CtranDistTestFixture {
   void verifyGpeLeak(ICtran* ctran) {
     ASSERT_EQ(ctran->gpe->numInUseKernelElems(), 0);
     ASSERT_EQ(ctran->gpe->numInUseKernelFlags(), 0);
+  }
+
+  static void checkProfiler(ctran::Profiler* profiler) {
+    if (!profiler) {
+      return;
+    }
+    uint64_t algoTotal =
+        profiler->getEventDurationUs(ctran::ProfilerEvent::ALGO_TOTAL);
+    uint64_t algoCtrl =
+        profiler->getEventDurationUs(ctran::ProfilerEvent::ALGO_CTRL);
+    uint64_t algoData =
+        profiler->getEventDurationUs(ctran::ProfilerEvent::ALGO_DATA);
+    uint64_t bufReg =
+        profiler->getEventDurationUs(ctran::ProfilerEvent::BUF_REG);
+    uint64_t oneMinUs = 1000 * 1000 * 60;
+    EXPECT_GE(algoTotal, 0);
+    EXPECT_LE(algoTotal, oneMinUs);
+    EXPECT_GE(algoCtrl, 0);
+    EXPECT_LE(algoCtrl, oneMinUs);
+    EXPECT_GE(algoData, 0);
+    EXPECT_LE(algoData, oneMinUs);
+    EXPECT_GE(bufReg, 0);
+    EXPECT_LE(bufReg, oneMinUs);
   }
 
   char* prepareBuf(size_t bufSize, MemAllocType memType) {
@@ -226,6 +252,9 @@ class CtranAllgatherPTest : public ctran::CtranDistTestFixture {
             << " at chunk received from peer " << i;
       }
     }
+
+    // Verify profiler event durations are populated
+    checkProfiler(testComm->ctran_->profiler.get());
 
     verifyGpeLeak(testComm->ctran_.get());
 


### PR DESCRIPTION
Summary:

Both ctran AllGatherP algorithms (Direct and Pipeline) were missing the ctran::Profiler integration that D98528576 recently added to the AllGather family. This adds the same profiling instrumentation so that AllGatherP collectives are logged to the nccl_profiler_algo scuba table with timing breakdowns for buffer registration, control sync, and data transfer phases.

After this change, rows with algorithmName in {CtranAllGatherPDirect, CtranAllGatherPPipeline} will appear in the nccl_profiler_algo scuba table.

Also wires the profiler env vars and a `checkProfiler` helper into CtranDistAllgatherPTests.cc (mirroring the pattern added for AllGather in D98528576) so tests exercise the new instrumentation.

Reviewed By: minsii

Differential Revision: D101926795
