### PR TITLE
Fix unit test build with ncclx v2_29 (#2212)

### DIFF
--- a/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTest.cpp
@@ -1231,7 +1231,6 @@ TEST_F(TorchCommNCCLXTest, AlltoallvDedupExecCombine) {
 #ifdef NCCL_REDUCE_SCATTER_QUANTIZE_SUPPORTED
 TEST_F(TorchCommNCCLXTest, ReduceScatterQuantized) {
   setupRankAndSize(0, 2);
-  setupCCAExpectations(1, 2, 1);
 
   auto comm = createMockedTorchComm();
 
@@ -1261,7 +1260,6 @@ TEST_F(TorchCommNCCLXTest, ReduceScatterQuantized) {
 
 TEST_F(TorchCommNCCLXTest, ReduceScatterQuantizedInvalidInputType) {
   setupRankAndSize(0, 2);
-  setupCCAExpectations(1, 2, 1);
 
   auto comm = createMockedTorchComm();
 
@@ -1286,7 +1284,6 @@ TEST_F(TorchCommNCCLXTest, ReduceScatterQuantizedInvalidInputType) {
 
 TEST_F(TorchCommNCCLXTest, ReduceScatterQuantizedInvalidOp) {
   setupRankAndSize(0, 2);
-  setupCCAExpectations(1, 2, 1);
 
   auto comm = createMockedTorchComm();
 
@@ -1311,7 +1308,6 @@ TEST_F(TorchCommNCCLXTest, ReduceScatterQuantizedInvalidOp) {
 
 TEST_F(TorchCommNCCLXTest, ReduceScatterQuantizedSizeMismatch) {
   setupRankAndSize(0, 2);
-  setupCCAExpectations(1, 2, 1);
 
   auto comm = createMockedTorchComm();
 

--- a/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.hpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.hpp
@@ -392,6 +392,20 @@ class NcclxMock : public NcclxApi {
       (override));
 
   MOCK_METHOD(ncclTeam_t, teamLsa, (ncclComm_t comm), (override));
+
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)
+  MOCK_METHOD(
+      ncclResult_t,
+      winGetPeerDevicePointer,
+      (NcclxWindow win, size_t offset, int peer, void** outPtr),
+      (override));
+
+  MOCK_METHOD(
+      ncclResult_t,
+      winGetLsaMultimemDevicePointer,
+      (NcclxWindow win, size_t offset, void** outPtr),
+      (override));
+#endif
 #endif
 
 #if defined(ENABLE_PIPES)


### PR DESCRIPTION
Summary:

Fix TorchCommNCCLXTest build failures when building against ncclx v2_29:

- Remove dead setupCCAExpectations calls from ReduceScatterQuantized
  tests. The helper was removed from TorchCommNCCLXTestBase but 4 call
  sites were not updated. The tests already set up everything they need
  via setupRankAndSize() and setupDefaultBehaviors().

- Add mock methods for winGetPeerDevicePointer and
  winGetLsaMultimemDevicePointer to NcclxMock, guarded by
  NCCL_VERSION_CODE >= 2.29. Without these, NiceMock<NcclxMock> is
  abstract and non-constructible.

___

overriding_review_checks_triggers_an_audit_and_retroactive_review
Oncall Short Name: networkai_host

Differential Revision: D102000707
