### PR TITLE
Add device_new.h include for triton IR with ncclx v2_29 (#2213)

### DIFF
--- a/comms/torchcomms/triton/ir_include/device_new.h
+++ b/comms/torchcomms/triton/ir_include/device_new.h
@@ -1,0 +1,15 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// Device-compatible placement new/delete for CUDA device-only bitcode
+// compilation. The standard <new> header does not provide __device__
+// qualified versions, which ncclx device headers require (gin__funcs.h).
+
+#ifndef TORCHCOMMS_IR_DEVICE_NEW_H_
+#define TORCHCOMMS_IR_DEVICE_NEW_H_
+
+inline __device__ void* operator new(decltype(sizeof(0)), void* p) noexcept {
+  return p;
+}
+inline __device__ void operator delete(void*, void*) noexcept {}
+
+#endif // TORCHCOMMS_IR_DEVICE_NEW_H_


### PR DESCRIPTION
Summary:

Add device_new.h to the triton bitcode build to fix compilation
against ncclx v2_29. The header is added as a source dependency and
force-included via -include so it is available during IR generation.

Reviewed By: goelayu

Differential Revision: D102000708


