### PR TITLE
Fix ctran memory tests to build with both ncclx v2_28 and v2_29 (#2214)

### DIFF
--- a/comms/ctran/memory/tests/SlabAllocatorTest.cc
+++ b/comms/ctran/memory/tests/SlabAllocatorTest.cc
@@ -10,6 +10,16 @@
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "strongstream.h"
 
+namespace {
+inline struct ncclCudaGraph ncclCudaGraphNoneCompat() {
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)
+  return ncclCudaGraphNone(0);
+#else
+  return ncclCudaGraphNone();
+#endif
+}
+} // namespace
+
 class SlabAllocatorTest : public ::testing::Test {
  public:
   int cudaDev = 0;
@@ -88,7 +98,7 @@ TEST_F(SlabAllocatorTest, ReuseSlabIfPossible) {
   NCCLCHECK_TEST(ncclCalloc(&ss, 1));
   NCCLCHECK_TEST(ncclStrongStreamConstruct(ss));
   NCCLCHECK_TEST(ncclStrongStreamAcquire(
-      ncclCudaGraphNone(), ss, /*concurrent=*/false, &stream));
+      ncclCudaGraphNoneCompat(), ss, /*concurrent=*/false, &stream));
   size_t before_free, total;
   CUDACHECK_TEST(cudaMemGetInfo(&before_free, &total));
   // allocation calls: 1 byte, (2097152 - 16) bytes, 2097152 * 2, 2097152 /2
@@ -104,8 +114,8 @@ TEST_F(SlabAllocatorTest, ReuseSlabIfPossible) {
   size_t after_free;
   CUDACHECK_TEST(cudaMemGetInfo(&after_free, &total));
   EXPECT_EQ(before_free - after_free, allocator->getUsedMem());
-  NCCLCHECK_TEST(
-      ncclStrongStreamRelease(ncclCudaGraphNone(), ss, /*concurrent=*/false));
+  NCCLCHECK_TEST(ncclStrongStreamRelease(
+      ncclCudaGraphNoneCompat(), ss, /*concurrent=*/false));
   free(ss);
 }
 
@@ -115,7 +125,7 @@ TEST_F(SlabAllocatorTest, FreeMemoryUponDestruction) {
   NCCLCHECK_TEST(ncclCalloc(&ss, 1));
   NCCLCHECK_TEST(ncclStrongStreamConstruct(ss));
   NCCLCHECK_TEST(ncclStrongStreamAcquire(
-      ncclCudaGraphNone(), ss, /*concurrent=*/false, &stream));
+      ncclCudaGraphNoneCompat(), ss, /*concurrent=*/false, &stream));
   size_t before_free, total;
   CUDACHECK_TEST(cudaMemGetInfo(&before_free, &total));
   auto allocator = std::make_unique<ncclx::memory::SlabAllocator>();
@@ -126,8 +136,8 @@ TEST_F(SlabAllocatorTest, FreeMemoryUponDestruction) {
   EXPECT_EQ(actualUsedMem(allocator.get(), 2097152, ss), 2097152);
   EXPECT_EQ(actualUsedMem(allocator.get(), 2097152 * 2, ss), 2097152 * 2);
   NCCLCHECK_TEST(ncclStrongStreamSynchronize(ss));
-  NCCLCHECK_TEST(
-      ncclStrongStreamRelease(ncclCudaGraphNone(), ss, /*concurrent=*/false));
+  NCCLCHECK_TEST(ncclStrongStreamRelease(
+      ncclCudaGraphNoneCompat(), ss, /*concurrent=*/false));
   free(ss);
   allocator.reset();
   size_t after_free;
@@ -143,13 +153,13 @@ TEST_F(SlabAllocatorTest, CudaMemCpyAsync) {
   NCCLCHECK_TEST(ncclCalloc(&ss, 1));
   NCCLCHECK_TEST(ncclStrongStreamConstruct(ss));
   NCCLCHECK_TEST(ncclStrongStreamAcquire(
-      ncclCudaGraphNone(), ss, /*concurrent=*/false, &stream));
+      ncclCudaGraphNoneCompat(), ss, /*concurrent=*/false, &stream));
   allocAndCheckMemCpy(allocator.get(), 4, ss);
   allocAndCheckMemCpy(allocator.get(), 2097152, ss);
   allocAndCheckMemCpy(allocator.get(), 2097152 * 2, ss);
   NCCLCHECK_TEST(ncclStrongStreamSynchronize(ss));
-  NCCLCHECK_TEST(
-      ncclStrongStreamRelease(ncclCudaGraphNone(), ss, /*concurrent=*/false));
+  NCCLCHECK_TEST(ncclStrongStreamRelease(
+      ncclCudaGraphNoneCompat(), ss, /*concurrent=*/false));
   allocator.reset();
   free(ss);
 }

--- a/comms/ctran/memory/tests/memoryUtilsTests.cc
+++ b/comms/ctran/memory/tests/memoryUtilsTests.cc
@@ -60,7 +60,11 @@ TEST_F(memoryUtilsTest, cudaCallocAsync) {
   CUDACHECK_TEST(cudaStreamSynchronize(stream));
 
   // can be freed by ncclCudaFree
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)
+  EXPECT_EQ(ncclCudaFree(ptr, nullptr), commSuccess);
+#else
   EXPECT_EQ(ncclCudaFree(ptr), commSuccess);
+#endif
 
   CUDACHECK_TEST(cudaMemGetInfo(&after, &total));
   EXPECT_EQ(before, after);

--- a/comms/torchcomms/triton/ir_include/device_new.h
+++ b/comms/torchcomms/triton/ir_include/device_new.h
@@ -1,0 +1,15 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// Device-compatible placement new/delete for CUDA device-only bitcode
+// compilation. The standard <new> header does not provide __device__
+// qualified versions, which ncclx device headers require (gin__funcs.h).
+
+#ifndef TORCHCOMMS_IR_DEVICE_NEW_H_
+#define TORCHCOMMS_IR_DEVICE_NEW_H_
+
+inline __device__ void* operator new(decltype(sizeof(0)), void* p) noexcept {
+  return p;
+}
+inline __device__ void operator delete(void*, void*) noexcept {}
+
+#endif // TORCHCOMMS_IR_DEVICE_NEW_H_


### PR DESCRIPTION
Summary:

Add version guards for API changes in ncclx v2_29:

- ncclCudaFree now requires a ncclMemManager* parameter. Use
  NCCL_VERSION_CODE guard to pass nullptr on v2_29 and omit it on
  v2_28.

- ncclCudaGraphNone now requires an int graphUsageMode parameter. Add
  a ncclCudaGraphNoneCompat() wrapper that passes 0 on v2_29 and
  calls the no-arg version on v2_28.

___

overriding_review_checks_triggers_an_audit_and_retroactive_review
Oncall Short Name: networkai_host

Differential Revision: D102000709


