### PR TITLE
fix sm_100 -> sm_100a for OSS build (#2217)

### DIFF
--- a/build_ncclx.sh
+++ b/build_ncclx.sh
@@ -364,7 +364,7 @@ if [[ -z "${NVCC_GENCODE-}" ]]; then
             arch_gencode="$arch_gencode -gencode=arch=compute_90,code=sm_90"
         ;;
         "b200")
-            arch_gencode="$arch_gencode -gencode=arch=compute_100,code=sm_100"
+            arch_gencode="$arch_gencode -gencode=arch=compute_100a,code=sm_100a"
         ;;
         "b300")
             arch_gencode="$arch_gencode -gencode=arch=compute_103a,code=sm_103a"


### PR DESCRIPTION
Summary:

CUDA 12.8 NVCC emits `.rs` register-reuse hints in PTX when compiling
for compute_100 with -maxrregcount=96. ptxas only accepts those hints
when targeting sm_100a (architecture-conditional Blackwell variant),
not plain sm_100. The internal Buck build already had this fix via
_upgrade_sm100_to_sm100a in nccl_build_config.bzl, but the open-source
build_ncclx.sh was missed.

All B200/GB200 hardware supports sm_100a.

Differential Revision: D102027977


