### PR TITLE
Fix ReduceScatterQuantized test crash with ncclx v2_29

### DIFF
--- a/comms/ctran/memory/tests/SlabAllocatorTest.cc
+++ b/comms/ctran/memory/tests/SlabAllocatorTest.cc
@@ -10,6 +10,16 @@
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "strongstream.h"
 
+namespace {
+inline struct ncclCudaGraph ncclCudaGraphNoneCompat() {
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)
+  return ncclCudaGraphNone(0);
+#else
+  return ncclCudaGraphNone();
+#endif
+}
+} // namespace
+
 class SlabAllocatorTest : public ::testing::Test {
  public:
   int cudaDev = 0;
@@ -88,7 +98,7 @@ TEST_F(SlabAllocatorTest, ReuseSlabIfPossible) {
   NCCLCHECK_TEST(ncclCalloc(&ss, 1));
   NCCLCHECK_TEST(ncclStrongStreamConstruct(ss));
   NCCLCHECK_TEST(ncclStrongStreamAcquire(
-      ncclCudaGraphNone(), ss, /*concurrent=*/false, &stream));
+      ncclCudaGraphNoneCompat(), ss, /*concurrent=*/false, &stream));
   size_t before_free, total;
   CUDACHECK_TEST(cudaMemGetInfo(&before_free, &total));
   // allocation calls: 1 byte, (2097152 - 16) bytes, 2097152 * 2, 2097152 /2
@@ -104,8 +114,8 @@ TEST_F(SlabAllocatorTest, ReuseSlabIfPossible) {
   size_t after_free;
   CUDACHECK_TEST(cudaMemGetInfo(&after_free, &total));
   EXPECT_EQ(before_free - after_free, allocator->getUsedMem());
-  NCCLCHECK_TEST(
-      ncclStrongStreamRelease(ncclCudaGraphNone(), ss, /*concurrent=*/false));
+  NCCLCHECK_TEST(ncclStrongStreamRelease(
+      ncclCudaGraphNoneCompat(), ss, /*concurrent=*/false));
   free(ss);
 }
 
@@ -115,7 +125,7 @@ TEST_F(SlabAllocatorTest, FreeMemoryUponDestruction) {
   NCCLCHECK_TEST(ncclCalloc(&ss, 1));
   NCCLCHECK_TEST(ncclStrongStreamConstruct(ss));
   NCCLCHECK_TEST(ncclStrongStreamAcquire(
-      ncclCudaGraphNone(), ss, /*concurrent=*/false, &stream));
+      ncclCudaGraphNoneCompat(), ss, /*concurrent=*/false, &stream));
   size_t before_free, total;
   CUDACHECK_TEST(cudaMemGetInfo(&before_free, &total));
   auto allocator = std::make_unique<ncclx::memory::SlabAllocator>();
@@ -126,8 +136,8 @@ TEST_F(SlabAllocatorTest, FreeMemoryUponDestruction) {
   EXPECT_EQ(actualUsedMem(allocator.get(), 2097152, ss), 2097152);
   EXPECT_EQ(actualUsedMem(allocator.get(), 2097152 * 2, ss), 2097152 * 2);
   NCCLCHECK_TEST(ncclStrongStreamSynchronize(ss));
-  NCCLCHECK_TEST(
-      ncclStrongStreamRelease(ncclCudaGraphNone(), ss, /*concurrent=*/false));
+  NCCLCHECK_TEST(ncclStrongStreamRelease(
+      ncclCudaGraphNoneCompat(), ss, /*concurrent=*/false));
   free(ss);
   allocator.reset();
   size_t after_free;
@@ -143,13 +153,13 @@ TEST_F(SlabAllocatorTest, CudaMemCpyAsync) {
   NCCLCHECK_TEST(ncclCalloc(&ss, 1));
   NCCLCHECK_TEST(ncclStrongStreamConstruct(ss));
   NCCLCHECK_TEST(ncclStrongStreamAcquire(
-      ncclCudaGraphNone(), ss, /*concurrent=*/false, &stream));
+      ncclCudaGraphNoneCompat(), ss, /*concurrent=*/false, &stream));
   allocAndCheckMemCpy(allocator.get(), 4, ss);
   allocAndCheckMemCpy(allocator.get(), 2097152, ss);
   allocAndCheckMemCpy(allocator.get(), 2097152 * 2, ss);
   NCCLCHECK_TEST(ncclStrongStreamSynchronize(ss));
-  NCCLCHECK_TEST(
-      ncclStrongStreamRelease(ncclCudaGraphNone(), ss, /*concurrent=*/false));
+  NCCLCHECK_TEST(ncclStrongStreamRelease(
+      ncclCudaGraphNoneCompat(), ss, /*concurrent=*/false));
   allocator.reset();
   free(ss);
 }

--- a/comms/ctran/memory/tests/memoryUtilsTests.cc
+++ b/comms/ctran/memory/tests/memoryUtilsTests.cc
@@ -60,7 +60,11 @@ TEST_F(memoryUtilsTest, cudaCallocAsync) {
   CUDACHECK_TEST(cudaStreamSynchronize(stream));
 
   // can be freed by ncclCudaFree
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)
+  EXPECT_EQ(ncclCudaFree(ptr, nullptr), commSuccess);
+#else
   EXPECT_EQ(ncclCudaFree(ptr), commSuccess);
+#endif
 
   CUDACHECK_TEST(cudaMemGetInfo(&after, &total));
   EXPECT_EQ(before, after);

--- a/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTest.cpp
@@ -1231,7 +1231,6 @@ TEST_F(TorchCommNCCLXTest, AlltoallvDedupExecCombine) {
 #ifdef NCCL_REDUCE_SCATTER_QUANTIZE_SUPPORTED
 TEST_F(TorchCommNCCLXTest, ReduceScatterQuantized) {
   setupRankAndSize(0, 2);
-  setupCCAExpectations(1, 2, 1);
 
   auto comm = createMockedTorchComm();
 
@@ -1261,7 +1260,6 @@ TEST_F(TorchCommNCCLXTest, ReduceScatterQuantized) {
 
 TEST_F(TorchCommNCCLXTest, ReduceScatterQuantizedInvalidInputType) {
   setupRankAndSize(0, 2);
-  setupCCAExpectations(1, 2, 1);
 
   auto comm = createMockedTorchComm();
 
@@ -1286,7 +1284,6 @@ TEST_F(TorchCommNCCLXTest, ReduceScatterQuantizedInvalidInputType) {
 
 TEST_F(TorchCommNCCLXTest, ReduceScatterQuantizedInvalidOp) {
   setupRankAndSize(0, 2);
-  setupCCAExpectations(1, 2, 1);
 
   auto comm = createMockedTorchComm();
 
@@ -1311,7 +1308,6 @@ TEST_F(TorchCommNCCLXTest, ReduceScatterQuantizedInvalidOp) {
 
 TEST_F(TorchCommNCCLXTest, ReduceScatterQuantizedSizeMismatch) {
   setupRankAndSize(0, 2);
-  setupCCAExpectations(1, 2, 1);
 
   auto comm = createMockedTorchComm();
 

--- a/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTest.cpp
@@ -1247,12 +1247,21 @@ TEST_F(TorchCommNCCLXTest, ReduceScatterQuantized) {
   // Create seed tensor (single-element int64)
   auto seed = createTestTensor({1}, at::kLong);
 
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)
+  // v2_29 added a check that seed must be a CUDA tensor, which cannot
+  // be satisfied in the mocked CPU test environment.
+  EXPECT_THROW(
+      comm->reduce_scatter_quantized(
+          output, input, ReduceOp::SUM, seed, /*async_op=*/true),
+      c10::Error);
+#else
   EXPECT_CALL(*nccl_mock_, reduceScatterQuantize(_, _, _, _, _, _, _, _, _))
       .WillOnce(Return(ncclSuccess));
 
   auto work = comm->reduce_scatter_quantized(
       output, input, ReduceOp::SUM, seed, /*async_op=*/true);
   EXPECT_NE(work, nullptr);
+#endif
 
   setupNormalDestruction(*comm);
   comm->finalize();

--- a/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.hpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.hpp
@@ -392,6 +392,20 @@ class NcclxMock : public NcclxApi {
       (override));
 
   MOCK_METHOD(ncclTeam_t, teamLsa, (ncclComm_t comm), (override));
+
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)
+  MOCK_METHOD(
+      ncclResult_t,
+      winGetPeerDevicePointer,
+      (NcclxWindow win, size_t offset, int peer, void** outPtr),
+      (override));
+
+  MOCK_METHOD(
+      ncclResult_t,
+      winGetLsaMultimemDevicePointer,
+      (NcclxWindow win, size_t offset, void** outPtr),
+      (override));
+#endif
 #endif
 
 #if defined(ENABLE_PIPES)

--- a/comms/torchcomms/triton/ir_include/device_new.h
+++ b/comms/torchcomms/triton/ir_include/device_new.h
@@ -1,0 +1,15 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// Device-compatible placement new/delete for CUDA device-only bitcode
+// compilation. The standard <new> header does not provide __device__
+// qualified versions, which ncclx device headers require (gin__funcs.h).
+
+#ifndef TORCHCOMMS_IR_DEVICE_NEW_H_
+#define TORCHCOMMS_IR_DEVICE_NEW_H_
+
+inline __device__ void* operator new(decltype(sizeof(0)), void* p) noexcept {
+  return p;
+}
+inline __device__ void operator delete(void*, void*) noexcept {}
+
+#endif // TORCHCOMMS_IR_DEVICE_NEW_H_


### PR DESCRIPTION
Summary:
v2_29 added a validation that the seed tensor must be a CUDA tensor.
In the mocked CPU test environment this check cannot be satisfied, so
the test crashes with a c10::Error. Guard the happy path with a
version check: on v2_29+ expect the error, on older versions run the
original happy path.

Differential Revision: D102038093
