### PR TITLE
Replace Thrift KV store + Tupperware with TCPStore in integration tests

### DIFF
--- a/comms/ncclx/meta/analyzer/tests/NCCLXCommsTracingServiceHandlerTest.cc
+++ b/comms/ncclx/meta/analyzer/tests/NCCLXCommsTracingServiceHandlerTest.cc
@@ -325,17 +325,11 @@ TEST_F(NcclCommsTest, AnalyzerSuccess) {
     // Rank 0 creates the unique id
     NCCLCHECK(ncclGetUniqueId(&ncclUniqueID));
     mccl::McclIntegrationTestUtil::setKey(
-        uniqueIDKey,
-        std::string(ncclUniqueID.internal, NCCL_UNIQUE_ID_BYTES),
-        std::nullopt);
+        uniqueIDKey, std::string(ncclUniqueID.internal, NCCL_UNIQUE_ID_BYTES));
   } else {
     // Everyone else waits for it
-    auto value = mccl::McclIntegrationTestUtil::waitForKey(
-        uniqueIDKey, [](const auto& versionAndValue) {
-          return versionAndValue.has_value();
-        });
-    std::memcpy(
-        ncclUniqueID.internal, value.value.data(), NCCL_UNIQUE_ID_BYTES);
+    auto value = mccl::McclIntegrationTestUtil::waitForKey(uniqueIDKey);
+    std::memcpy(ncclUniqueID.internal, value.data(), NCCL_UNIQUE_ID_BYTES);
   }
 
   // Initialize NCCL communicator
@@ -365,7 +359,7 @@ TEST_F(NcclCommsTest, AnalyzerSuccess) {
       size, recvBuff.raw(), worldSize);
 
   mccl::McclIntegrationTestUtil::setKey(
-      fmt::format("done_with_collective_rank_{}", rank), "1", std::nullopt);
+      fmt::format("done_with_collective_rank_{}", rank), "1");
 
   // Rank 0 checks state of collectives
   if (rank == 0) {
@@ -373,10 +367,7 @@ TEST_F(NcclCommsTest, AnalyzerSuccess) {
     for (int i = 0; i < worldSize; ++i) {
       // Wait for the rank to be done with collectives
       mccl::McclIntegrationTestUtil::waitForKey(
-          fmt::format("done_with_collective_rank_{}", rank),
-          [](const auto& versionAndValue) {
-            return versionAndValue.has_value();
-          });
+          fmt::format("done_with_collective_rank_{}", rank));
 
       // Get the comm dump state for each rank
       auto analyzerPortForRank = getCommServicePortNumberForRank(i);
@@ -417,14 +408,11 @@ TEST_F(NcclCommsTest, AnalyzerSuccess) {
         analyzerExpectedResult, std::chrono::milliseconds(10000)));
 
     // Notify other ranks to finish
-    mccl::McclIntegrationTestUtil::setKey(
-        "analyzer_check_0", "1", std::nullopt);
+    mccl::McclIntegrationTestUtil::setKey("analyzer_check_0", "1");
   }
 
   // All ranks wait for the collectives check to complete
-  mccl::McclIntegrationTestUtil::waitForKey(
-      "analyzer_check_0",
-      [](const auto& versionAndValue) { return versionAndValue.has_value(); });
+  mccl::McclIntegrationTestUtil::waitForKey("analyzer_check_0");
 }
 
 // Rank 0 doesn't join the second
@@ -449,17 +437,11 @@ TEST_F(NcclCommsTest, OneRankHangs) {
     // Rank 0 creates the unique id
     NCCLCHECK(ncclGetUniqueId(&ncclUniqueID));
     mccl::McclIntegrationTestUtil::setKey(
-        uniqueIDKey,
-        std::string(ncclUniqueID.internal, NCCL_UNIQUE_ID_BYTES),
-        std::nullopt);
+        uniqueIDKey, std::string(ncclUniqueID.internal, NCCL_UNIQUE_ID_BYTES));
   } else {
     // Everyone else waits for it
-    auto value = mccl::McclIntegrationTestUtil::waitForKey(
-        uniqueIDKey, [](const auto& versionAndValue) {
-          return versionAndValue.has_value();
-        });
-    std::memcpy(
-        ncclUniqueID.internal, value.value.data(), NCCL_UNIQUE_ID_BYTES);
+    auto value = mccl::McclIntegrationTestUtil::waitForKey(uniqueIDKey);
+    std::memcpy(ncclUniqueID.internal, value.data(), NCCL_UNIQUE_ID_BYTES);
   }
 
   // Initialize NCCL communicator
@@ -574,17 +556,11 @@ TEST_F(NcclCommsTest, DISABLED_OneRankHangsCudaGraph) {
     // Rank 0 creates the unique id
     NCCLCHECK(ncclGetUniqueId(&ncclUniqueID));
     mccl::McclIntegrationTestUtil::setKey(
-        uniqueIDKey,
-        std::string(ncclUniqueID.internal, NCCL_UNIQUE_ID_BYTES),
-        std::nullopt);
+        uniqueIDKey, std::string(ncclUniqueID.internal, NCCL_UNIQUE_ID_BYTES));
   } else {
     // Everyone else waits for it
-    auto value = mccl::McclIntegrationTestUtil::waitForKey(
-        uniqueIDKey, [](const auto& versionAndValue) {
-          return versionAndValue.has_value();
-        });
-    std::memcpy(
-        ncclUniqueID.internal, value.value.data(), NCCL_UNIQUE_ID_BYTES);
+    auto value = mccl::McclIntegrationTestUtil::waitForKey(uniqueIDKey);
+    std::memcpy(ncclUniqueID.internal, value.data(), NCCL_UNIQUE_ID_BYTES);
   }
 
   // Initialize NCCL communicator
@@ -764,17 +740,11 @@ TEST_F(NcclCommsTest, CollectiveMetadataMismatch) {
     // Rank 0 creates the unique id
     NCCLCHECK(ncclGetUniqueId(&ncclUniqueID));
     mccl::McclIntegrationTestUtil::setKey(
-        uniqueIDKey,
-        std::string(ncclUniqueID.internal, NCCL_UNIQUE_ID_BYTES),
-        std::nullopt);
+        uniqueIDKey, std::string(ncclUniqueID.internal, NCCL_UNIQUE_ID_BYTES));
   } else {
     // Everyone else waits for it
-    auto value = mccl::McclIntegrationTestUtil::waitForKey(
-        uniqueIDKey, [](const auto& versionAndValue) {
-          return versionAndValue.has_value();
-        });
-    std::memcpy(
-        ncclUniqueID.internal, value.value.data(), NCCL_UNIQUE_ID_BYTES);
+    auto value = mccl::McclIntegrationTestUtil::waitForKey(uniqueIDKey);
+    std::memcpy(ncclUniqueID.internal, value.data(), NCCL_UNIQUE_ID_BYTES);
   }
 
   // Initialize NCCL communicator. Could not use RAII because we need to abort
@@ -810,8 +780,7 @@ TEST_F(NcclCommsTest, CollectiveMetadataMismatch) {
   if (rank == 0) {
     // Always make sure notify other ranks before exiting
     auto finishGuard = folly::makeGuard([&comm]() {
-      mccl::McclIntegrationTestUtil::setKey(
-          "test_return_baton", "Finished", std::nullopt);
+      mccl::McclIntegrationTestUtil::setKey("test_return_baton", "Finished");
     });
     // Wait for analyzer to report rank 0 is missing
     PullOneJobResult analyzerExpectedResult{
@@ -823,10 +792,7 @@ TEST_F(NcclCommsTest, CollectiveMetadataMismatch) {
 
   } else {
     // Wait for analyzer from rank 0 from returning
-    mccl::McclIntegrationTestUtil::waitForKey(
-        "test_return_baton", [](const auto& versionAndValue) {
-          return versionAndValue.has_value();
-        });
+    mccl::McclIntegrationTestUtil::waitForKey("test_return_baton");
   }
   XLOG(INFO) << "Test finished, start to abort NCCL comm";
 }
@@ -862,27 +828,17 @@ TEST_F(NcclCommsTest, CollectiveCircularDependency) {
     NCCLCHECK(ncclGetUniqueId(&ncclUniqueID1));
     mccl::McclIntegrationTestUtil::setKey(
         uniqueIDKey1,
-        std::string(ncclUniqueID1.internal, NCCL_UNIQUE_ID_BYTES),
-        std::nullopt);
+        std::string(ncclUniqueID1.internal, NCCL_UNIQUE_ID_BYTES));
     NCCLCHECK(ncclGetUniqueId(&ncclUniqueID2));
     mccl::McclIntegrationTestUtil::setKey(
         uniqueIDKey2,
-        std::string(ncclUniqueID2.internal, NCCL_UNIQUE_ID_BYTES),
-        std::nullopt);
+        std::string(ncclUniqueID2.internal, NCCL_UNIQUE_ID_BYTES));
   } else {
     // Everyone else waits for it
-    auto value1 = mccl::McclIntegrationTestUtil::waitForKey(
-        uniqueIDKey1, [](const auto& versionAndValue) {
-          return versionAndValue.has_value();
-        });
-    std::memcpy(
-        ncclUniqueID1.internal, value1.value.data(), NCCL_UNIQUE_ID_BYTES);
-    auto value2 = mccl::McclIntegrationTestUtil::waitForKey(
-        uniqueIDKey2, [](const auto& versionAndValue) {
-          return versionAndValue.has_value();
-        });
-    std::memcpy(
-        ncclUniqueID2.internal, value2.value.data(), NCCL_UNIQUE_ID_BYTES);
+    auto value1 = mccl::McclIntegrationTestUtil::waitForKey(uniqueIDKey1);
+    std::memcpy(ncclUniqueID1.internal, value1.data(), NCCL_UNIQUE_ID_BYTES);
+    auto value2 = mccl::McclIntegrationTestUtil::waitForKey(uniqueIDKey2);
+    std::memcpy(ncclUniqueID2.internal, value2.data(), NCCL_UNIQUE_ID_BYTES);
     ASSERT_NE(
         strncmp(
             ncclUniqueID1.internal,
@@ -975,8 +931,7 @@ TEST_F(NcclCommsTest, CollectiveCircularDependency) {
   if (rank == 0) {
     // Always make sure notify other ranks before exiting
     auto finishGuard = folly::makeGuard([]() {
-      mccl::McclIntegrationTestUtil::setKey(
-          "test_return_baton", "Finished", std::nullopt);
+      mccl::McclIntegrationTestUtil::setKey("test_return_baton", "Finished");
     });
     // Wait for analyzer to report rank 0 is missing
     PullOneJobResult analyzerExpectedResult{
@@ -988,10 +943,7 @@ TEST_F(NcclCommsTest, CollectiveCircularDependency) {
 
   } else {
     // Wait for analyzer from rank 0 from returning
-    mccl::McclIntegrationTestUtil::waitForKey(
-        "test_return_baton", [](const auto& versionAndValue) {
-          return versionAndValue.has_value();
-        });
+    mccl::McclIntegrationTestUtil::waitForKey("test_return_baton");
   }
   XLOG(INFO) << "Test finished, start to abort NCCL comm";
 }

--- a/comms/ncclx/meta/colltrace/tests/CollTraceWatchdogIbMockTest.cc
+++ b/comms/ncclx/meta/colltrace/tests/CollTraceWatchdogIbMockTest.cc
@@ -1,3 +1,4 @@
+#include <folly/FileUtil.h>
 #include <folly/Random.h>
 #include <folly/testing/TestUtil.h>
 #include <gmock/gmock.h>
@@ -42,16 +43,11 @@ class NcclComm {
       NCCLCHECK_FATAL(ncclGetUniqueId(&ncclUniqueID));
       mccl::McclIntegrationTestUtil::setKey(
           uniqueIDKey,
-          std::string(ncclUniqueID.internal, NCCL_UNIQUE_ID_BYTES),
-          std::nullopt);
+          std::string(ncclUniqueID.internal, NCCL_UNIQUE_ID_BYTES));
     } else {
       // Everyone else waits for it
-      auto value = mccl::McclIntegrationTestUtil::waitForKey(
-          uniqueIDKey, [](const auto& versionAndValue) {
-            return versionAndValue.has_value();
-          });
-      std::memcpy(
-          ncclUniqueID.internal, value.value.data(), NCCL_UNIQUE_ID_BYTES);
+      auto value = mccl::McclIntegrationTestUtil::waitForKey(uniqueIDKey);
+      std::memcpy(ncclUniqueID.internal, value.data(), NCCL_UNIQUE_ID_BYTES);
     }
     NCCLCHECK_FATAL(
         ncclCommInitRank(&comm_, worldSize, ncclUniqueID, globalRank));

--- a/comms/ncclx/meta/colltrace/tests/CollTraceWatchdogTest.cc
+++ b/comms/ncclx/meta/colltrace/tests/CollTraceWatchdogTest.cc
@@ -1,3 +1,4 @@
+#include <folly/FileUtil.h>
 #include <folly/Random.h>
 #include <folly/stop_watch.h>
 #include <folly/testing/TestUtil.h>
@@ -43,16 +44,11 @@ class NcclComm {
       NCCLCHECK_FATAL(ncclGetUniqueId(&ncclUniqueID));
       mccl::McclIntegrationTestUtil::setKey(
           uniqueIDKey,
-          std::string(ncclUniqueID.internal, NCCL_UNIQUE_ID_BYTES),
-          std::nullopt);
+          std::string(ncclUniqueID.internal, NCCL_UNIQUE_ID_BYTES));
     } else {
       // Everyone else waits for it
-      auto value = mccl::McclIntegrationTestUtil::waitForKey(
-          uniqueIDKey, [](const auto& versionAndValue) {
-            return versionAndValue.has_value();
-          });
-      std::memcpy(
-          ncclUniqueID.internal, value.value.data(), NCCL_UNIQUE_ID_BYTES);
+      auto value = mccl::McclIntegrationTestUtil::waitForKey(uniqueIDKey);
+      std::memcpy(ncclUniqueID.internal, value.data(), NCCL_UNIQUE_ID_BYTES);
     }
     NCCLCHECK_FATAL(
         ncclCommInitRank(&comm_, worldSize, ncclUniqueID, globalRank));


### PR DESCRIPTION
Summary:
Introduces a rewrite of `CollectiveIntegrationTestMixin` and the associated `IntegrationTestUtil` to use `c10d::TCPStore` instead of the Thrift-based KV store, and `SubProcessHandle` instead of `tupperware::SubProcessClientFactory`. This removes all Meta-internal infrastructure dependencies from the integration test framework.

**Changes:**
- TCPStore with port 0 (OS picks free port) replaces Thrift KV + `ServiceFrameworkLight` + `ServiceRouter`
- `SubProcessHandle` (POSIX `fork`/`exec`/`waitpid`) replaces Tupperware `SubProcessClientFactory`
- **Simplified KV API:** `setKey(key, value)`, `waitForKey(key)` - removed version tracking, predicates
- **Removed dead code:** `getKey()`, `getRankFromRankURLKey()`, `ValueAndVersion` struct
- Fixed transitive include breakage in `CollectiveIntegrationTestMixinTest.cpp`

**Update 4 integration test files to use the simplified TCPStore-based API:**
- `setKey(key, value)` replaces `setKey(key, value, expectedVersion)`
- `waitForKey(key)` replaces `waitForKey(key, predicate)`
- **`AllReduceTest.cpp`:** use local `SysEnvRAII.h` instead of `comms/testinfra/TestXPlatUtils.h`
- **`AllReduceTest.cpp`:** add explicit `folly/synchronization/Baton.h` include (was transitively provided)

NOTE: the new `TCPStore` dependency is causing a relatively significant **build size regression**. As far as I know, there is no way to avoid this, so I am documenting/acknowledging this change explicitly here.

Reviewed By: arttianezhu

Differential Revision: D99727897


