### PR TITLE
Move pool drain spin-wait from terminate() into pool destructors (#2232)

### DIFF
--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -639,47 +639,7 @@ void CtranGpe::Impl::terminate() {
   cmdEnqueue(cmd);
   thread_.join();
 
-  // Pool elements are released by CUDA's async cmdDestroy callback
-  // (cudaUserObjectNoDestructorSync). Spin until all pools drain before
-  // returning, to avoid freeing pinned memory from under an in-flight callback.
   const auto& statex = comm->statex_;
-  const auto start = std::chrono::steady_clock::now();
-  auto nextLog = start + std::chrono::seconds(5);
-  while (true) {
-    this->kernelFlagPool->reclaim();
-    this->kernelElemPool->reclaim();
-    this->gpeKernelSyncPool->reclaim();
-    if (this->kernelFlagPool->capacity() == this->kernelFlagPool->size() &&
-        this->kernelElemPool->capacity() == this->kernelElemPool->size() &&
-        this->gpeKernelSyncPool->capacity() ==
-            this->gpeKernelSyncPool->size()) {
-      break;
-    }
-    const auto now = std::chrono::steady_clock::now();
-    if (now >= nextLog) {
-      const auto elapsedSec =
-          std::chrono::duration_cast<std::chrono::seconds>(now - start).count();
-      CLOGF_SUBSYS(
-          WARNING,
-          INIT,
-          "terminate() spin-wait: pools still draining after {}s on rank {} commHash {:x}"
-          " -- kernelFlag {}/{} kernelElem {}/{} gpeKernelSync {}/{}."
-          " Most likely cudaGraphDestroy() was not called on all CUDA graphs"
-          " that captured CTranGPE operations.",
-          elapsedSec,
-          statex->rank(),
-          statex->commHash(),
-          this->kernelFlagPool->size(),
-          this->kernelFlagPool->capacity(),
-          this->kernelElemPool->size(),
-          this->kernelElemPool->capacity(),
-          this->gpeKernelSyncPool->size(),
-          this->gpeKernelSyncPool->capacity());
-      nextLog = now + std::chrono::seconds(5);
-    }
-    std::this_thread::yield();
-  }
-
   CLOGF_SUBSYS(
       INFO,
       INIT,
@@ -1081,18 +1041,38 @@ KernelElemPool::KernelElemPool(size_t capacity) : capacity_(capacity) {
 }
 
 KernelElemPool::~KernelElemPool() {
-  this->reclaim();
-  if (this->inuseWorkElems_.size()) {
-    CLOGF(
-        WARN,
-        "CTRAN-GPE: Internal KernelElem pool has {} inuse elements",
-        this->inuseWorkElems_.size());
-  }
+  drainUntilEmpty();
   FB_CUDACHECKIGNORE(cudaFreeHost(this->memPtr_));
 
-  // Dot not throw exception in destructor to avoid early termination in stack
+  // Do not throw exception in destructor to avoid early termination in stack
   // unwind. See discussion in
   // https://stackoverflow.com/questions/130117/if-you-shouldnt-throw-exceptions-in-a-destructor-how-do-you-handle-errors-in-i
+}
+
+void KernelElemPool::drainUntilEmpty() {
+  const auto start = std::chrono::steady_clock::now();
+  auto nextLog = start + std::chrono::seconds(5);
+  while (true) {
+    this->reclaim();
+    if (this->inuseWorkElems_.empty()) {
+      break;
+    }
+    const auto now = std::chrono::steady_clock::now();
+    if (now >= nextLog) {
+      const auto elapsedSec =
+          std::chrono::duration_cast<std::chrono::seconds>(now - start).count();
+      CLOGF(
+          WARN,
+          "CTRAN-GPE: KernelElem pool drain spin-wait: {} inuse / {} total after {}s."
+          " Most likely cudaGraphDestroy() was not called on all CUDA graphs"
+          " that captured CTranGPE operations.",
+          this->inuseWorkElems_.size(),
+          capacity_,
+          elapsedSec);
+      nextLog = now + std::chrono::seconds(5);
+    }
+    std::this_thread::yield();
+  }
 }
 
 void KernelElemPool::resetWorkElem(KernelElem* workElem) {

--- a/comms/ctran/gpe/CtranGpeImpl.h
+++ b/comms/ctran/gpe/CtranGpeImpl.h
@@ -183,6 +183,9 @@ class KernelElemPool {
   // Reclaim any unused KernelElem objects back to the free pool.
   void reclaim();
 
+  // Spin until all in-use elements are returned, logging every 5s.
+  void drainUntilEmpty();
+
   // Return the number of KernelElem objects in the free pool.
   size_t size();
 

--- a/comms/ctran/gpe/tests/CtranGpeUT.cc
+++ b/comms/ctran/gpe/tests/CtranGpeUT.cc
@@ -2176,12 +2176,13 @@ TEST_F(CtranGpeTest, PostKernelCleanupGraphWithOpGroup) {
   CUDACHECK_TEST(cudaStreamDestroy(stream));
 }
 
-// Verify that terminate() drains the GpeKernelSyncPool before returning.
+// Verify that CtranGpe destruction drains the GpeKernelSyncPool before freeing
+// pinned memory.
 //
 // Simulates the production race: CUDA graph cmdDestroy callbacks release pool
-// elements asynchronously after cudaGraphDestroy. Without the spin-wait in
-// terminate(), the pool destructor can free pinned memory while those elements
-// are still "in use", causing use-after-free when the background release runs.
+// elements asynchronously after cudaGraphDestroy. Without drainUntilEmpty() in
+// the pool destructor, cudaFreeHost runs while elements are still "in use",
+// causing use-after-free when the background release runs.
 
 TEST_F(CtranGpeTest, TerminateWaitsForGpeKernelSyncPoolDrain) {
   auto gpe = std::make_unique<CtranGpe>(cudaDev, dummyComm);
@@ -2193,34 +2194,35 @@ TEST_F(CtranGpeTest, TerminateWaitsForGpeKernelSyncPoolDrain) {
   ASSERT_EQ(gpe->allocGpeKernelSyncs(kNumSyncs, kNworkers, syncs), commSuccess);
   ASSERT_EQ(gpe->numInUseGpeKernelSyncs(), kNumSyncs);
 
-  // Run terminate() in a background thread so main can control when the pool
+  // Run gpe.reset() in a background thread so main can control when the pool
   // is drained. Use a promise to signal when gpe.reset() completes.
   std::promise<void> gpeResetDone;
   std::thread gpeThread([&]() {
-    gpe.reset(); // With fix: blocks until pool drained; without fix: returns
-                 // fast
+    gpe.reset(); // With fix: blocks in pool destructor until drained;
+                 // without fix: cudaFreeHost runs immediately → use-after-free
     gpeResetDone.set_value();
   });
 
   // Wait for gpe.reset() to complete, with a short deadline.
-  // With fix: terminate() is blocked in spin-wait → future times out → we
-  // release Without fix: terminate() returns immediately → future is ready →
-  // FAIL
+  // With fix: pool destructor is blocked in drainUntilEmpty() → future times
+  // out → we release. Without fix: destructor returns immediately → future is
+  // ready → FAIL.
   constexpr auto kDrainWait = std::chrono::milliseconds(200);
   auto status = gpeResetDone.get_future().wait_for(kDrainWait);
 
   if (status == std::future_status::ready) {
     // gpe.reset() returned while pool elements were still in use.
     gpeThread.join();
-    FAIL() << "terminate() returned in < " << kDrainWait.count()
+    FAIL() << "CtranGpe destruction returned in < " << kDrainWait.count()
            << "ms while GpeKernelSync pool elements were still in use. "
               "Pool destructor freed pinned memory before async callbacks "
               "could release elements, causing use-after-free.";
   }
 
-  // terminate() is blocked in spin-wait — release elements to unblock it.
+  // Pool destructor is blocked in drainUntilEmpty() — release elements to
+  // unblock it.
   for (auto* sync : syncs) {
-    sync->reset(); // inUse() → false; spin-wait reclaims and exits
+    sync->reset(); // inUse() → false; drainUntilEmpty() reclaims and exits
   }
   gpeThread.join();
 }

--- a/comms/ctran/utils/PinnedHostPool.h
+++ b/comms/ctran/utils/PinnedHostPool.h
@@ -7,8 +7,10 @@ using cudaHostAlloc. It is NOT thread-safe.
 
 #pragma once
 
+#include <chrono>
 #include <list>
 #include <stack>
+#include <thread>
 #include <vector>
 
 #include "comms/ctran/utils/Checks.h"
@@ -45,16 +47,7 @@ class PinnedHostPool {
   }
 
   ~PinnedHostPool() {
-    this->reclaim();
-    if (this->inuseItems_.size()) {
-      CLOGF(
-          WARNING,
-          "CTRAN-GPE: Internal {} pool has {} inuse items at destruction. "
-          "In CUDA graph mode this indicates an async cmdDestroy race: "
-          "the graph was not fully destroyed before communicator teardown.",
-          T::name(),
-          this->inuseItems_.size());
-    }
+    drainUntilEmpty();
     for (void* chunk : chunks_) {
       FB_CUDACHECKIGNORE(cudaFreeHost(chunk));
     }
@@ -62,6 +55,38 @@ class PinnedHostPool {
     // Do not throw exception in destructor to avoid early termination in stack
     // unwind. See discussion in
     // https://stackoverflow.com/questions/130117/if-you-shouldnt-throw-exceptions-in-a-destructor-how-do-you-handle-errors-in-i
+  }
+
+  // Spin until all in-use items are returned to the pool, logging a warning
+  // every 5s. Needed before freeing pinned memory to avoid use-after-free when
+  // CUDA async cmdDestroy callbacks (cudaUserObjectNoDestructorSync) are still
+  // in flight.
+  void drainUntilEmpty() {
+    const auto start = std::chrono::steady_clock::now();
+    auto nextLog = start + std::chrono::seconds(5);
+    while (true) {
+      this->reclaim();
+      if (this->inuseItems_.empty()) {
+        break;
+      }
+      const auto now = std::chrono::steady_clock::now();
+      if (now >= nextLog) {
+        const auto elapsedSec =
+            std::chrono::duration_cast<std::chrono::seconds>(now - start)
+                .count();
+        CLOGF(
+            WARNING,
+            "CTRAN-GPE: {} pool drain spin-wait: {} inuse / {} total after {}s."
+            " Most likely cudaGraphDestroy() was not called on all CUDA graphs"
+            " that captured CTranGPE operations.",
+            T::name(),
+            this->inuseItems_.size(),
+            capacity_,
+            elapsedSec);
+        nextLog = now + std::chrono::seconds(5);
+      }
+      std::this_thread::yield();
+    }
   }
 
   T* pop() {


### PR DESCRIPTION
Summary:

The spin-wait that prevents use-after-free from async CUDA cmdDestroy
callbacks was in CtranGpe::Impl::terminate(). Moving it into the
pool destructors (PinnedHostPool::drainUntilEmpty and
KernelElemPool::drainUntilEmpty) is cleaner: the invariant that pinned
memory must not be freed while items are in-use is now enforced
automatically at destruction, regardless of how the pool is torn down.

Both pool classes now expose drainUntilEmpty() which spins calling
reclaim() and logs a WARNING every 5s if the drain takes longer than
expected, with a hint that cudaGraphDestroy() may not have been called.

The corresponding spin-wait in terminate() and its comments are removed.
Test comments updated to reflect the new drain site.

Reviewed By: dolpm, saifhhasan

Differential Revision: D102064402
