### PR TITLE
Remove CtranCtrlManager from IB backend (#2234)

### DIFF
--- a/comms/ctran/CtranEx.cc
+++ b/comms/ctran/CtranEx.cc
@@ -73,7 +73,6 @@ void CtranExImpl::initialize(
               cudaDev,
               0,
               desc,
-              ctrlMgr.get(),
               true, /* enableLocalFlush */
               bootstrapMode,
               serverAddrOpt);

--- a/comms/ctran/backends/ib/CtranIb.cc
+++ b/comms/ctran/backends/ib/CtranIb.cc
@@ -312,7 +312,6 @@ void CtranIbSingleton::ibAsyncEventHandler(const int cudaDev) {
 
 CtranIb::CtranIb(
     CtranComm* comm,
-    CtranCtrlManager* ctrlMgr,
     std::optional<bool> enableLocalFlush,
     std::shared_ptr<ctran::bootstrap::ISocketFactory> socketFactory,
     std::optional<int> maxNumCqe)
@@ -339,7 +338,6 @@ CtranIb::CtranIb(
       comm->statex_->cudaDev(),
       comm->statex_->commHash(),
       comm->statex_->commDesc(),
-      ctrlMgr,
       enableLocalFlush_,
       BootstrapMode::kDefaultServer,
       std::nullopt,
@@ -359,7 +357,6 @@ CtranIb::CtranIb(
     int cudaDev,
     uint64_t commHash,
     const std::string& commDesc,
-    CtranCtrlManager* ctrlMgr,
     // FIXME: Unlike IB with comm, we require user to always specify
     // enableLocalFlush because we don't have access to statex->cudaArch() for
     // default config detection
@@ -375,7 +372,6 @@ CtranIb::CtranIb(
       cudaDev,
       commHash,
       commDesc,
-      ctrlMgr,
       enableLocalFlush,
       bootstrapMode,
       qpServerAddr,
@@ -400,7 +396,6 @@ void CtranIb::init(
     int cudaDev,
     uint64_t commHash,
     const std::string& commDesc,
-    CtranCtrlManager* ctrlMgr,
     bool enableLocalFlush,
     const BootstrapMode bootstrapMode,
     std::optional<const SocketServerAddr*> qpServerAddr,
@@ -414,7 +409,6 @@ void CtranIb::init(
   this->cudaDev = cudaDev;
   this->commHash = commHash;
   this->commDesc = commDesc;
-  this->ctrlMgr = ctrlMgr;
   this->ncclLogData = CommLogData{
       .commId = comm ? comm->logMetaData_.commId : 0,
       .commHash = commHash,
@@ -730,10 +724,6 @@ void CtranIb::bootstrapStart(
   }
 
   this->listenThread = std::thread{bootstrapAccept, this};
-}
-
-void CtranIb::regCtrlCb(std::unique_ptr<CtranCtrlManager>& ctrlMgr) {
-  // no control message callback to register; no-op.
 }
 
 std::string CtranIb::getIbDevName(int device) const {
@@ -1432,7 +1422,7 @@ std::shared_ptr<CtranIbVirtualConn> CtranIb::createVc(int peerRank) {
   }
   // Create a new VC and assign
   it.first->second = std::make_shared<CtranIbVirtualConn>(
-      devices, peerRank, comm, ctrlMgr, getPgToTrafficClassValue(), cudaDev);
+      devices, peerRank, comm, getPgToTrafficClassValue(), cudaDev);
   return it.first->second;
 }
 

--- a/comms/ctran/backends/ib/CtranIb.h
+++ b/comms/ctran/backends/ib/CtranIb.h
@@ -42,14 +42,10 @@ class CtranIb {
   // to the local rank.
   // Input arguments:
   //   - comm: the Ctran communicator
-  //   - ctrlMgr: the ctranCtrlManager that manages control message callback
-  //              functions registered by other modules. Passed to VC for
-  //              calling callback when receiving control message.
   //   - enableLocalFlush: whether to support local flush. If not specified, use
   //              default config based on cuda arch.
   CtranIb(
       CtranComm* comm,
-      CtranCtrlManager* ctrlMgr,
       std::optional<bool> enableLocalFlush = std::nullopt,
       std::shared_ptr<ctran::bootstrap::ISocketFactory> socketFactory = nullptr,
       std::optional<int> maxNumCqe = std::nullopt);
@@ -64,7 +60,6 @@ class CtranIb {
   //              mapping NIC
   //   - commHash: for logging only.
   //   - commDesc: for logging only.
-  //   - ctrlMgr: same as in comm-based CtranIb constructor.
   //   - enableLocalFlush: whether to support local flush.
   //   - bootstrapMode: defines the needed bootstrap mode. If kDefaultServer,
   //                    it launches internal listen thread which binds and
@@ -80,7 +75,6 @@ class CtranIb {
       int cudaDev,
       uint64_t commHash,
       const std::string& commDesc,
-      CtranCtrlManager* ctrlMgr,
       bool enableLocalFlush,
       const BootstrapMode bootstrapMode = BootstrapMode::kDefaultServer,
       std::optional<const SocketServerAddr*> qpServerAddr = std::nullopt,
@@ -113,11 +107,6 @@ class CtranIb {
 
   // Unlock the entire CtranIb instance.
   commResult_t epochUnlock();
-
-  // Register control message callback function if have any.
-  // Input arguments:
-  //   - ctrlMgr: the ctranCtrlManager to manage the control message
-  void regCtrlCb(std::unique_ptr<CtranCtrlManager>& ctrlMgr);
 
   // Register memory to be used for IB operations.
   // Input arguments:
@@ -508,7 +497,6 @@ class CtranIb {
       int cudaDev,
       uint64_t commHash,
       const std::string& commDesc,
-      CtranCtrlManager* ctrlMgr,
       bool enableLocalFlush,
       const BootstrapMode bootstrapMode = BootstrapMode::kDefaultServer,
       std::optional<const SocketServerAddr*> qpServerAddr = std::nullopt,
@@ -1140,8 +1128,6 @@ class CtranIb {
 
   folly::F14FastMap<int, PendingOpQueue> rankToPendingOpsMap;
   std::mutex pendingOpsMutex;
-
-  CtranCtrlManager* ctrlMgr{nullptr};
 
   std::unordered_map<std::string, uint32_t> pgToTrafficClassMap_;
 

--- a/comms/ctran/backends/ib/CtranIbVc.cc
+++ b/comms/ctran/backends/ib/CtranIbVc.cc
@@ -316,14 +316,12 @@ CtranIbVirtualConn::CtranIbVirtualConn(
     std::vector<CtranIbDevice>& devices,
     int peerRank,
     CtranComm* comm,
-    CtranCtrlManager* ctrlMgr,
     uint32_t pgTrafficClass,
     int cudaDev)
     : peerRank(peerRank),
       devices_(devices),
       maxNumQps_(NCCL_CTRAN_IB_MAX_QPS),
       comm_(comm),
-      ctrlMgr_(ctrlMgr),
       pgTrafficClass_(pgTrafficClass),
       cudaDev_(cudaDev) {
   // set default QP configs based on topology and user-specified CVARs, if

--- a/comms/ctran/backends/ib/CtranIbVc.h
+++ b/comms/ctran/backends/ib/CtranIbVc.h
@@ -191,7 +191,6 @@ class CtranIbVirtualConn {
       std::vector<CtranIbDevice>& devices,
       int peerRank,
       CtranComm* comm,
-      CtranCtrlManager* ctrlMgr,
       uint32_t pgTrafficClass,
       int cudaDev);
   ~CtranIbVirtualConn();
@@ -1085,17 +1084,7 @@ class CtranIbVirtualConn {
 
       case ibverbx::IBV_WC_RECV: {
         auto& packet = dequeFront(this->recvCtrl_.postedPkts_).get();
-        if (this->ctrlMgr_ && this->ctrlMgr_->hasCb(packet.type)) {
-          // This is a control message with registered callback.
-          // Handle it in callback without matching recv
-          CLOGF_TRACE(
-              COLL,
-              "CTRAN-IB-VC: received and invoke callback for packet [{}] peer {}",
-              packet.toString(),
-              this->peerRank);
-          FB_COMMCHECK(this->ctrlMgr_->runCb(
-              this->peerRank, packet.type, packet.payload));
-        } else if (this->recvCtrl_.enqueuedWrs_.empty()) {
+        if (this->recvCtrl_.enqueuedWrs_.empty()) {
           // No queued receive msg. This is an unexpected message.
           // Copy received ctrl msg to unexp buffer
           FB_COMMCHECK(enqueueUnexpWr(packet));
@@ -1807,7 +1796,6 @@ class CtranIbVirtualConn {
   std::unordered_map<uint32_t, bool> rcvdSeqNums_;
 
   CtranComm* comm_{nullptr};
-  CtranCtrlManager* ctrlMgr_{nullptr};
 
   // State for notifyQP notifications
   int32_t notifyCount_{0};

--- a/comms/ctran/backends/ib/benchmarks/CtranIbBench.cc
+++ b/comms/ctran/backends/ib/benchmarks/CtranIbBench.cc
@@ -89,7 +89,6 @@ static BenchmarkContext setupBenchmarkContext(size_t bufferSize) {
       cudaDev0,
       -1 /* commHash */,
       "RDMA-Transport",
-      nullptr /* ctrlManager */,
       true /* enableLocalFlush */,
       CtranIb::BootstrapMode::kExternal);
   auto receiverIb = std::make_unique<CtranIb>(
@@ -97,7 +96,6 @@ static BenchmarkContext setupBenchmarkContext(size_t bufferSize) {
       cudaDev1,
       -1 /* commHash */,
       "RDMA-Transport",
-      nullptr /* ctrlManager */,
       true /* enableLocalFlush */,
       CtranIb::BootstrapMode::kExternal);
 

--- a/comms/ctran/backends/ib/tests/CtranIbBootstrapTest.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbBootstrapTest.cc
@@ -140,7 +140,6 @@ std::unique_ptr<CtranIb> createCtranIb(
       rank, // Use rank as CUDA device identifier
       commHash,
       commDesc,
-      nullptr, // ctrlMgr
       false, // enableLocalFlush
       mode,
       qpServerAddr,
@@ -261,7 +260,6 @@ class CtranIbBootstrapTestBase : public ::testing::Test {
         rank, // Use rank as CUDA device identifier
         commHash,
         commDesc,
-        nullptr, // ctrlMgr
         false, // enableLocalFlush
         mode,
         qpServerAddr,

--- a/comms/ctran/backends/ib/tests/CtranIbConnectionTest.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbConnectionTest.cc
@@ -68,7 +68,6 @@ class CtranIbConnectionTest : public ::testing::Test {
         rank, // Use rank as CUDA device identifier
         commHash,
         commDesc,
-        nullptr, // ctrlMgr
         false, // enableLocalFlush
         CtranIb::BootstrapMode::kExternal,
         /*qpServerAddr=*/std::nullopt,
@@ -284,7 +283,6 @@ TEST_F(CtranIbConnectionTest, ConnectVcDirectWithoutLocalVcIdentifierFails) {
       rank,
       commHash,
       commDesc,
-      nullptr, // ctrlMgr
       false, // enableLocalFlush
       CtranIb::BootstrapMode::kExternal,
       /*qpServerAddr=*/std::nullopt,

--- a/comms/ctran/backends/ib/tests/CtranIbCtrlMsgDistUT.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbCtrlMsgDistUT.cc
@@ -7,7 +7,6 @@
 #include <folly/init/Init.h>
 #include <folly/logging/xlog.h>
 
-#include "comms/ctran/backends/CtranCtrl.h"
 #include "comms/ctran/backends/ib/CtranIb.h"
 #include "comms/ctran/backends/ib/CtranIbBase.h"
 #include "comms/ctran/tests/CtranDistTestUtils.h"
@@ -30,11 +29,9 @@ class CtranIbCtrlMsgTest : public ctran::CtranDistTestFixture {
     CtranDistTestFixture::SetUp();
     this->comm_ = makeCtranComm();
     this->comm = this->comm_.get();
-    this->ctrlMgr = std::make_unique<CtranCtrlManager>();
   }
 
   void TearDown() override {
-    this->ctrlMgr.reset();
     this->comm_.reset();
     CtranDistTestFixture::TearDown();
   }
@@ -48,7 +45,6 @@ class CtranIbCtrlMsgTest : public ctran::CtranDistTestFixture {
  protected:
   std::unique_ptr<CtranComm> comm_{nullptr};
   CtranComm* comm{nullptr};
-  std::unique_ptr<CtranCtrlManager> ctrlMgr{nullptr};
 };
 
 TEST_F(CtranIbCtrlMsgTest, CtrlMsg) {
@@ -57,7 +53,7 @@ TEST_F(CtranIbCtrlMsgTest, CtrlMsg) {
       "Expect rank 2 can issue multiple send control msgs to ranks 0 and 1, and match to the corresponding recvs");
 
   try {
-    auto ctranIb = std::make_unique<CtranIb>(this->comm, this->ctrlMgr.get());
+    auto ctranIb = std::make_unique<CtranIb>(this->comm);
     std::vector<CtranIbRequest> reqs;
     std::vector<ControlMsg> smsgs;
     ControlMsg rmsg0(ControlMsgType::IB_EXPORT_MEM);

--- a/comms/ctran/backends/ib/tests/CtranIbDistUT.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbDistUT.cc
@@ -15,7 +15,6 @@
 
 #include <gmock/gmock.h>
 #include "comms/ctran/algos/common/GpeKernelSync.h"
-#include "comms/ctran/backends/CtranCtrl.h"
 #include "comms/ctran/backends/ib/CtranIb.h"
 #include "comms/ctran/backends/ib/CtranIbBase.h"
 #include "comms/ctran/bootstrap/Socket.h"
@@ -45,12 +44,10 @@ class CtranIbTest : public ctran::CtranDistTestFixture {
     CtranDistTestFixture::SetUp();
     this->comm_ = makeCtranComm();
     this->comm = this->comm_.get();
-    this->ctrlMgr = std::make_unique<CtranCtrlManager>();
     this->commIbRegCount = getIbRegCount();
   }
 
   void TearDown() override {
-    this->ctrlMgr.reset();
     this->comm_.reset();
     CtranDistTestFixture::TearDown();
     ASSERT_EQ(getIbRegCount(), 0);
@@ -99,7 +96,7 @@ class CtranIbTest : public ctran::CtranDistTestFixture {
       bool issueFastPut = false) {
     if (!ctranIb) {
       try {
-        ctranIb = std::make_unique<CtranIb>(comm, ctrlMgr.get());
+        ctranIb = std::make_unique<CtranIb>(comm);
       } catch (const std::bad_alloc&) {
         GTEST_SKIP() << "IB backend not enabled. Skip test";
       }
@@ -290,7 +287,7 @@ class CtranIbTest : public ctran::CtranDistTestFixture {
       bool issueFastGet = false) {
     if (!ctranIb) {
       try {
-        ctranIb = std::make_unique<CtranIb>(comm, ctrlMgr.get());
+        ctranIb = std::make_unique<CtranIb>(comm);
       } catch (const std::bad_alloc&) {
         GTEST_SKIP() << "IB backend not enabled. Skip test";
       }
@@ -425,7 +422,7 @@ class CtranIbTest : public ctran::CtranDistTestFixture {
 
   void runNotify(const int numNotifies, bool localSignal) {
     try {
-      ctranIb = std::make_unique<CtranIb>(this->comm, this->ctrlMgr.get());
+      ctranIb = std::make_unique<CtranIb>(this->comm);
     } catch (const std::bad_alloc&) {
       GTEST_SKIP() << "IB backend not enabled. Skip test";
     }
@@ -488,7 +485,7 @@ class CtranIbTest : public ctran::CtranDistTestFixture {
       bool fallbackPut = false) {
     if (!ctranIb) {
       try {
-        ctranIb = std::make_unique<CtranIb>(comm, ctrlMgr.get());
+        ctranIb = std::make_unique<CtranIb>(comm);
       } catch (const std::bad_alloc&) {
         GTEST_SKIP() << "IB backend not enabled. Skip test";
       }
@@ -731,7 +728,7 @@ class CtranIbTest : public ctran::CtranDistTestFixture {
       bool isGpuMem = false,
       bool isFetchAdd = true) {
     try {
-      ctranIb = std::make_unique<CtranIb>(this->comm, this->ctrlMgr.get());
+      ctranIb = std::make_unique<CtranIb>(this->comm);
     } catch (const std::bad_alloc&) {
       GTEST_SKIP() << "IB backend not enabled. Skip test";
     }
@@ -923,7 +920,6 @@ class CtranIbTest : public ctran::CtranDistTestFixture {
   std::unique_ptr<CtranComm> comm_{nullptr};
   CtranComm* comm{nullptr};
   std::unique_ptr<CtranIb> ctranIb{nullptr};
-  std::unique_ptr<CtranCtrlManager> ctrlMgr{nullptr};
   size_t commIbRegCount{0};
   const int sendRank{0}, recvRank{1};
 };
@@ -934,7 +930,7 @@ TEST_F(CtranIbTest, NormalInitialize) {
       "Expect CtranIb to be initialized without internal error.");
 
   try {
-    auto ctranIb = std::make_unique<CtranIb>(this->comm, this->ctrlMgr.get());
+    auto ctranIb = std::make_unique<CtranIb>(this->comm);
   } catch (const std::bad_alloc&) {
     GTEST_SKIP() << "IB backend not enabled. Skip test";
   }
@@ -976,7 +972,6 @@ TEST_F(CtranIbTest, InitializeWithoutComm) {
         cudaDev,
         commHash,
         commDesc,
-        this->ctrlMgr.get(),
         true /*enableLocalFlush*/,
         CtranIb::BootstrapMode::kSpecifiedServer,
         &qpServerAddr);
@@ -1059,7 +1054,6 @@ TEST_F(CtranIbTest, InitializeWithoutCommAndExternalBootstrap) {
         cudaDev,
         commHash,
         commDesc,
-        this->ctrlMgr.get(),
         false /*enableLocalFlush*/,
         CtranIb::BootstrapMode::kExternal);
   } catch (const std::bad_alloc&) {
@@ -1075,7 +1069,7 @@ TEST_F(CtranIbTest, RegMem) {
       "Expect RegMem and deregMem can be finished without internal error.");
 
   try {
-    auto ctranIb = std::make_unique<CtranIb>(this->comm, this->ctrlMgr.get());
+    auto ctranIb = std::make_unique<CtranIb>(this->comm);
     size_t len = 2048576;
     constexpr int numThreads = 10;
     std::vector<void*> bufs(numThreads, nullptr);
@@ -1118,7 +1112,7 @@ TEST_F(CtranIbTest, ExportMem) {
       "Expect ExportMem generates control message with the correct content.");
 
   try {
-    auto ctranIb = std::make_unique<CtranIb>(this->comm, this->ctrlMgr.get());
+    auto ctranIb = std::make_unique<CtranIb>(this->comm);
     void* buf = nullptr;
     size_t len = 2048576;
     void* handle = nullptr;
@@ -1154,7 +1148,7 @@ TEST_F(CtranIbTest, SmallRegMem) {
 
   // Expect registration fails due to small size <= pageSize
   try {
-    auto ctranIb = std::make_unique<CtranIb>(this->comm, this->ctrlMgr.get());
+    auto ctranIb = std::make_unique<CtranIb>(this->comm);
 
     for (size_t len : {4096, 512}) {
       void* handle = nullptr;
@@ -1180,7 +1174,7 @@ TEST_F(CtranIbTest, MatchAnyCtrlMsg) {
       "Expect rank 0 can issue a send control msg to rank 1 and matches to the UNSPECIFIED recv on rank1");
 
   try {
-    auto ctranIb = std::make_unique<CtranIb>(this->comm, this->ctrlMgr.get());
+    auto ctranIb = std::make_unique<CtranIb>(this->comm);
     const int nCtrl = 300; // exceed MAX_CONTROL_MSGS
     std::vector<CtranIbRequest> reqs(nCtrl);
     std::vector<ControlMsg> smsgs(nCtrl);
@@ -1228,63 +1222,6 @@ TEST_F(CtranIbTest, MatchAnyCtrlMsg) {
   }
 }
 
-namespace {
-constexpr int testRkey = 9;
-constexpr uint64_t testRemoteAddr = 100;
-bool testCbFlag = false;
-commResult_t testCtrlMsgCb(int peer, void* msgPtr, void* ctx) {
-  bool* testCbFlagPtr = reinterpret_cast<bool*>(ctx);
-  *testCbFlagPtr = true;
-  EXPECT_EQ(peer, 0);
-
-  auto msg = reinterpret_cast<ControlMsg*>(msgPtr);
-  EXPECT_EQ(msg->type, ControlMsgType::IB_EXPORT_MEM);
-  EXPECT_EQ(msg->ibDesc.rkeys[0], testRkey);
-  EXPECT_EQ(msg->ibDesc.remoteAddr, testRemoteAddr);
-  return commSuccess;
-}
-} // namespace
-
-TEST_F(CtranIbTest, CbCtrlMsg) {
-  this->printTestDesc(
-      "CbCtrlMsg",
-      "Expect rank 0 can issue a send control msg that triggers corresponding callback on rank 1");
-
-  try {
-    // Register callback
-    this->ctrlMgr->regCb(
-        ControlMsgType::IB_EXPORT_MEM, testCtrlMsgCb, &testCbFlag);
-
-    auto ctranIb = std::make_unique<CtranIb>(this->comm, this->ctrlMgr.get());
-    CtranIbRequest req;
-    ControlMsg smsg(ControlMsgType::IB_EXPORT_MEM);
-
-    CtranIbEpochRAII epochRAII(ctranIb.get());
-
-    smsg.ibDesc.remoteAddr = testRemoteAddr;
-    smsg.ibDesc.rkeys[0] = testRkey;
-    smsg.ibDesc.nKeys = 1;
-    if (this->globalRank == 0) {
-      COMMCHECK_TEST(
-          ctranIb->isendCtrlMsg(smsg.type, &smsg, sizeof(smsg), 1, req));
-
-      // Wait until send finishes
-      waitIbReq(req, ctranIb);
-    } else if (this->globalRank == 1) {
-      // Wait until callback is triggered
-      do {
-        COMMCHECK_TEST(ctranIb->progress());
-      } while (!testCbFlag);
-    } else {
-      // no-op for non-communicating ranks
-      COMMCHECK_TEST(req.complete());
-    }
-
-  } catch (const std::bad_alloc&) {
-    GTEST_SKIP() << "IB backend not enabled. Skip test";
-  }
-}
-
 TEST_F(CtranIbTest, LocalFlush) {
   this->printTestDesc("LocalFlush", "Expect rank 0 can issue a local flush");
 
@@ -1294,7 +1231,6 @@ TEST_F(CtranIbTest, LocalFlush) {
         localRank,
         0,
         "ib_dist_test",
-        this->ctrlMgr.get(),
         true /*enableLocalFlush*/,
         CtranIb::BootstrapMode::kDefaultServer);
 
@@ -1604,8 +1540,8 @@ TEST_F(CtranIbTest, MultiPutTrafficProfiler) {
 #undef BUF_COUNT
 #define BUF_COUNT 8192
   try {
-    auto ctranIb = std::make_unique<CtranIb>(
-        this->comm, this->ctrlMgr.get(), true /* enableLocalFlush */);
+    auto ctranIb =
+        std::make_unique<CtranIb>(this->comm, true /* enableLocalFlush */);
     int* buf;
     void* handle = nullptr;
     ControlMsg sendMsg;
@@ -1721,7 +1657,7 @@ TEST_F(CtranIbTest, MultiPutTrafficProfiler) {
 
 TEST_F(CtranIbTest, InvalidPeer) {
   try {
-    auto ctranIb = std::make_unique<CtranIb>(this->comm, this->ctrlMgr.get());
+    auto ctranIb = std::make_unique<CtranIb>(this->comm);
     auto invalidPeer = this->comm->statex_->nRanks();
 
     CtranIbEpochRAII epochRAII(ctranIb.get());
@@ -1762,7 +1698,7 @@ TEST_F(CtranIbTest, InvalidPeer) {
 
 TEST_F(CtranIbTest, NotReadyPeer) {
   try {
-    auto ctranIb = std::make_unique<CtranIb>(this->comm, this->ctrlMgr.get());
+    auto ctranIb = std::make_unique<CtranIb>(this->comm);
     constexpr int peerRank = 0;
 
     CtranIbEpochRAII epochRAII(ctranIb.get());
@@ -1794,7 +1730,7 @@ TEST_F(CtranIbTest, InvalidMemoryWaitNotify) {
   this->printTestDesc(
       "InvalidMemoryWaitNotify",
       "Expect waitNotify to return error when called after put with invalid remote memory (wrong rkey or remote address)");
-  ctranIb = std::make_unique<CtranIb>(comm, ctrlMgr.get());
+  ctranIb = std::make_unique<CtranIb>(comm);
   CtranIbEpochRAII epochRAII(ctranIb.get());
 
   if (this->globalRank == recvRank) {
@@ -1911,7 +1847,7 @@ TEST_F(CtranIbTest, envQpConfig) {
 
   std::unique_ptr<CtranIb> ctranIb = nullptr;
   try {
-    ctranIb = std::make_unique<CtranIb>(comm, ctrlMgr.get());
+    ctranIb = std::make_unique<CtranIb>(comm);
   } catch (const std::bad_alloc&) {
     GTEST_SKIP() << "IB backend not enabled. Skip test";
   }
@@ -1998,7 +1934,7 @@ TEST_F(CtranIbTest, ValidBeTopology) {
 
   std::unique_ptr<CtranIb> ctranIb = nullptr;
   try {
-    ctranIb = std::make_unique<CtranIb>(comm, ctrlMgr.get());
+    ctranIb = std::make_unique<CtranIb>(comm);
   } catch (const std::bad_alloc&) {
     GTEST_SKIP() << "IB backend not enabled. Skip test";
   }
@@ -2048,7 +1984,7 @@ TEST_F(CtranIbTest, InvalidBeTopology) {
 
   std::unique_ptr<CtranIb> ctranIb = nullptr;
   try {
-    ctranIb = std::make_unique<CtranIb>(comm, ctrlMgr.get());
+    ctranIb = std::make_unique<CtranIb>(comm);
   } catch (const std::bad_alloc&) {
     GTEST_SKIP() << "IB backend not enabled. Skip test";
   } catch (const ctran::utils::Exception& e) {
@@ -2062,7 +1998,7 @@ TEST_F(CtranIbTest, pgTrafficClassConfig) {
   std::vector<std::string> pgTrafficClass = {"PP_P2P_0:200", "PP_P2P_1:208"};
   EnvRAII env1(NCCL_CTRAN_IB_PG_TRAFFIC_CLASS, pgTrafficClass);
   try {
-    auto ctranIb = std::make_unique<CtranIb>(this->comm, this->ctrlMgr.get());
+    auto ctranIb = std::make_unique<CtranIb>(this->comm);
     constexpr int peerRank = 0;
 
     CtranIbEpochRAII epochRAII(ctranIb.get());
@@ -2119,7 +2055,6 @@ TEST_F(CtranIbTest, pgTrafficClassConfigWithoutComm) {
         cudaDev,
         commHash,
         commDesc,
-        this->ctrlMgr.get(),
         true /*enableLocalFlush*/,
         CtranIb::BootstrapMode::kSpecifiedServer,
         &qpServerAddr);
@@ -2152,7 +2087,7 @@ TEST_F(CtranIbTest, AccessWithoutEpochLock) {
   try {
     EnvRAII env1(NCCL_CTRAN_IB_EPOCH_LOCK_ENFORCE_CHECK, true);
 
-    auto ctranIb = std::make_unique<CtranIb>(comm, this->ctrlMgr.get());
+    auto ctranIb = std::make_unique<CtranIb>(comm);
     int peerRank = (globalRank + 1) % numRanks;
     CtranIbRequest ctrlReq;
     ControlMsg msg;
@@ -2168,7 +2103,7 @@ TEST_F(CtranIbTest, AccessWithoutEpochLock) {
 
 TEST_F(CtranIbTest, EpochUnlockWithoutLock) {
   try {
-    auto ctranIb = std::make_unique<CtranIb>(comm, this->ctrlMgr.get());
+    auto ctranIb = std::make_unique<CtranIb>(comm);
     EXPECT_EQ(ctranIb->epochUnlock(), commInternalError);
 
   } catch (const std::bad_alloc& e) {
@@ -2178,7 +2113,7 @@ TEST_F(CtranIbTest, EpochUnlockWithoutLock) {
 
 TEST_F(CtranIbTest, DoubleEpochLock) {
   try {
-    auto ctranIb = std::make_unique<CtranIb>(comm, this->ctrlMgr.get());
+    auto ctranIb = std::make_unique<CtranIb>(comm);
     EXPECT_EQ(ctranIb->epochLock(), commSuccess);
 
     // Expect inProgress is returned if epochLock is called by another thread
@@ -2201,7 +2136,7 @@ TEST_F(CtranIbTest, CtrlMsgAndPreConnect) {
       "the preConnect is expected to be a no-op");
 
   try {
-    auto ctranIb = std::make_unique<CtranIb>(this->comm, this->ctrlMgr.get());
+    auto ctranIb = std::make_unique<CtranIb>(this->comm);
     CtranIbRequest req;
     ControlMsg smsg(ControlMsgType::IB_EXPORT_MEM);
     ControlMsg rmsg(ControlMsgType::IB_EXPORT_MEM);
@@ -2253,7 +2188,7 @@ TEST_P(CtranIbTestParam, InvalidIputFastNotify) {
       "2. the number of outstanding fast iput is equal to NCCL_CTRAN_IB_QP_MAX_MSGS;"
       "3. issuing fast iput without waiting on regular put completion;"
       "In any of the case, expect fast iput to return systemError");
-  ctranIb = std::make_unique<CtranIb>(comm, ctrlMgr.get());
+  ctranIb = std::make_unique<CtranIb>(comm);
 
   auto bufCount = NCCL_CTRAN_IB_QP_SCALING_THRESHOLD / sizeof(int);
   // NCCL_CTRAN_IB_QP_SCALING_THRESHOLD can be overridden internally in Ctran.
@@ -2441,7 +2376,7 @@ TEST_P(CtranIbTestParam, GpuMemPutNoSignalMixedFastRegular) {
       "GpuMemPutNoSignalMixedFastRegular",
       "Expect rank 0 issue iputFast (w/ notify w/o signal) followed by iput (w/o notify w/o signal).");
 
-  ctranIb = std::make_unique<CtranIb>(comm, ctrlMgr.get());
+  ctranIb = std::make_unique<CtranIb>(comm);
 
   auto bufCount = NCCL_CTRAN_IB_QP_SCALING_THRESHOLD / sizeof(int);
 
@@ -2542,7 +2477,7 @@ TEST_P(CtranIbTestParam, GpuMemPutNotifyLastMixedFastRegular) {
       "GpuMemPutNotifyLastMixedFastRegular",
       "Expect rank 0 issue iputFast (w/o notify w/o signal) followed by iput (notifyLast w/o signal).");
 
-  ctranIb = std::make_unique<CtranIb>(comm, ctrlMgr.get());
+  ctranIb = std::make_unique<CtranIb>(comm);
 
   auto bufCount = NCCL_CTRAN_IB_QP_SCALING_THRESHOLD / sizeof(int);
 
@@ -2665,7 +2600,7 @@ TEST_F(CtranIbTestWithQueuePairProfiler, GpuMemPutNotifyMixedFastRegular) {
   comm->ctran_->mapper->setContext(std::move(context));
 
   // create ib + register profiler
-  ctranIb = std::make_unique<CtranIb>(comm, ctrlMgr.get());
+  ctranIb = std::make_unique<CtranIb>(comm);
 
   // Sanity check default VC Mode == spray
   // A dummy control message exchange to ensure QP connection

--- a/comms/ctran/backends/ib/tests/CtranIbExactMatchHcaDistUT.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbExactMatchHcaDistUT.cc
@@ -72,9 +72,6 @@ TEST_F(CtranIbHcaTest, IbHcaExactMatchDev) {
   // devices match the condition
   nDevices = std::min(nDevices, (int)ibHcaExactDevs.size());
   for (int devId = 0; devId < nDevices; devId++) {
-    auto ctrlMgr = std::make_unique<CtranCtrlManager>();
-    // CtranComm* comm = this->commRAII->ctranComm;
-
     std::unique_ptr<ctran::TestCtranCommRAII> commRAII_ =
         ctran::createDummyCtranComm(devId);
     CtranComm* comm = commRAII_->ctranComm.get();
@@ -82,7 +79,7 @@ TEST_F(CtranIbHcaTest, IbHcaExactMatchDev) {
     EXPECT_EQ(NCCL_IB_HCA_PREFIX, "=");
 
     try {
-      auto ctranIb = std::make_unique<CtranIb>(comm, ctrlMgr.get());
+      auto ctranIb = std::make_unique<CtranIb>(comm);
       EXPECT_EQ(ctranIb->getIbDevName(), ibHcaExactDevs[devId]);
       printf(
           "CtranIbTest.IbHcaExactMatchDev: Rank %d devId %d uses devName %s devPort %d\n",

--- a/comms/ctran/backends/ib/tests/CtranIbExcludeHcaDistUT.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbExcludeHcaDistUT.cc
@@ -62,13 +62,12 @@ TEST_F(CtranIbHcaTest, IbHcaExcludeDev) {
   // Rank 0 creates comm with differen local GPU, to check whether all used
   // devices match the condition
   for (int devId = 0; devId < nDevices; devId++) {
-    auto ctrlMgr = std::make_unique<CtranCtrlManager>();
     CtranComm* comm = this->comm_.get();
 
     EXPECT_EQ(NCCL_IB_HCA_PREFIX, "^");
 
     try {
-      auto ctranIb = std::make_unique<CtranIb>(comm, ctrlMgr.get());
+      auto ctranIb = std::make_unique<CtranIb>(comm);
       for (auto& dev : ibHcaExcludeDevs) {
         EXPECT_NE(ctranIb->getIbDevName(), dev);
       }

--- a/comms/ctran/backends/ib/tests/CtranIbPrefixMatchHcaDistUT.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbPrefixMatchHcaDistUT.cc
@@ -60,13 +60,12 @@ TEST_F(CtranIbHcaTest, IbHcaPrefixMatchDev) {
   // Rank 0 creates comm with differen local GPU, to check whether all used
   // devices match the condition
   for (int devId = 0; devId < nDevices; devId++) {
-    auto ctrlMgr = std::make_unique<CtranCtrlManager>();
     CtranComm* comm = this->comm_.get();
 
     EXPECT_EQ(NCCL_IB_HCA_PREFIX, "");
 
     try {
-      auto ctranIb = std::make_unique<CtranIb>(comm, ctrlMgr.get());
+      auto ctranIb = std::make_unique<CtranIb>(comm);
       EXPECT_EQ(
           ctranIb->getIbDevName().compare(0, ibHcaStr.size(), ibHcaStr), 0);
       printf(

--- a/comms/ctran/backends/ib/tests/CtranIbTransportErrorsUT.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbTransportErrorsUT.cc
@@ -13,7 +13,6 @@
 #include <folly/init/Init.h>
 
 #include "comm.h"
-#include "comms/ctran/backends/CtranCtrl.h"
 #include "comms/ctran/backends/ib/CtranIb.h"
 #include "comms/ctran/backends/ib/ibutils.h"
 #include "comms/ctran/ibverbx/Ibverbx.h"
@@ -81,7 +80,6 @@ class CtranIbTest : public ctran::CtranDistTestFixture {
     ctran::CtranDistTestFixture::SetUp();
     ctranComm_ = makeCtranComm();
     this->comm = ctranComm_.get();
-    this->ctrlMgr = std::make_unique<CtranCtrlManager>();
     auto s = CtranIbSingleton::getInstance();
     CHECK_VALID_IB_SINGLETON(s);
     installedVerbs = s->verbsUtils->setVerbs<MockIbVerbsWrapper>();
@@ -91,7 +89,6 @@ class CtranIbTest : public ctran::CtranDistTestFixture {
     auto s = CtranIbSingleton::getInstance();
     CHECK_VALID_IB_SINGLETON(s);
     s->verbsUtils->setVerbs<VerbsWrapper>();
-    this->ctrlMgr.reset();
     ctranComm_.reset();
     ctran::CtranDistTestFixture::TearDown();
   }
@@ -109,7 +106,6 @@ class CtranIbTest : public ctran::CtranDistTestFixture {
  protected:
   std::unique_ptr<CtranComm> ctranComm_;
   CtranComm* comm{nullptr};
-  std::unique_ptr<CtranCtrlManager> ctrlMgr{nullptr};
 };
 
 /* function extracts the difference in timestamps between
@@ -168,8 +164,8 @@ TEST_F(CtranIbTest, Baseline) {
 
   s->startIbAsyncEventHandler(this->comm->statex_->cudaDev());
   try {
-    auto ctranIb1 = std::make_unique<CtranIb>(this->comm, this->ctrlMgr.get());
-    auto ctranIb2 = std::make_unique<CtranIb>(this->comm, this->ctrlMgr.get());
+    auto ctranIb1 = std::make_unique<CtranIb>(this->comm);
+    auto ctranIb2 = std::make_unique<CtranIb>(this->comm);
     // ensures ibv_poll_async_fd runs at least waitCount times
     for (int i = 0; i < 10; i++) {
       if (asyncFdCounter >= waitCount) {
@@ -211,7 +207,7 @@ TEST_F(CtranIbTest, PollError) {
 
   s->startIbAsyncEventHandler(this->comm->statex_->cudaDev());
   try {
-    auto ctranIb = std::make_unique<CtranIb>(this->comm, this->ctrlMgr.get());
+    auto ctranIb = std::make_unique<CtranIb>(this->comm);
     // ensures ibv_poll_async_fd runs at least once
     for (int i = 0; i < 10; i++) {
       if (asyncFdCounter >= 1) {
@@ -261,7 +257,7 @@ TEST_F(CtranIbTest, AsyncEventFound) {
 
   s->startIbAsyncEventHandler(this->comm->statex_->cudaDev());
   try {
-    auto ctranIb = std::make_unique<CtranIb>(this->comm, this->ctrlMgr.get());
+    auto ctranIb = std::make_unique<CtranIb>(this->comm);
     // Wait for ibv_poll_async_fd to run at least once and for the handler
     // to process the event
     for (int i = 0; i < 10; i++) {
@@ -365,7 +361,7 @@ TEST_F(CtranIbTest, AsyncEventLinkFlap) {
 
   s->startIbAsyncEventHandler(this->comm->statex_->cudaDev());
   try {
-    auto ctranIb = std::make_unique<CtranIb>(this->comm, this->ctrlMgr.get());
+    auto ctranIb = std::make_unique<CtranIb>(this->comm);
     // need to wait for timeout; total time > down + up + down + timeout (2s in
     // this test)
     for (int i = 0; i < 10; i++) {
@@ -469,7 +465,7 @@ TEST_F(CtranIbTest, LinkFlapZeroTimeout) {
   s->startIbAsyncEventHandler(this->comm->statex_->cudaDev());
 
   try {
-    auto ctranIb = std::make_unique<CtranIb>(this->comm, this->ctrlMgr.get());
+    auto ctranIb = std::make_unique<CtranIb>(this->comm);
     // need to wait for timeout; total time > down + up + timeout (2s in this
     // test)
     for (int i = 0; i < 10; i++) {

--- a/comms/ctran/mapper/CtranMapper.cc
+++ b/comms/ctran/mapper/CtranMapper.cc
@@ -159,9 +159,7 @@ CtranMapper::CtranMapper(CtranComm* comm) {
   /* enable available backends */
   if (enableBackends_[CtranMapperBackend::IB]) {
     try {
-      this->ctranIb =
-          std::make_unique<class CtranIb>(comm, this->ctrlMgr.get());
-      this->ctranIb->regCtrlCb(this->ctrlMgr);
+      this->ctranIb = std::make_unique<class CtranIb>(comm);
     } catch ([[maybe_unused]] const std::bad_alloc& e) {
       ctranIb = nullptr;
       enableBackends_[CtranMapperBackend::IB] = false;

--- a/comms/torchcomms/transport/RdmaTransport.cpp
+++ b/comms/torchcomms/transport/RdmaTransport.cpp
@@ -125,7 +125,6 @@ RdmaTransport::RdmaTransport(
       cudaDev,
       -1 /* commHash */,
       "RDMA-Transport",
-      nullptr /* ctrlManager */,
       true /* enableLocalFlush */,
       CtranIb::BootstrapMode::kExternal,
       std::nullopt /* qpServerAddr */,
@@ -179,7 +178,6 @@ bool queryRdmaSupport() {
           kDummyDevice,
           -1 /* commHash */,
           "Query-RDMA-Support",
-          nullptr /* ctrlManager */,
           true /* enableLocalFlush */,
           CtranIb::BootstrapMode::kExternal);
     } catch (const std::exception& e) {


### PR DESCRIPTION
Summary:

Remove all CtranCtrlManager callsites from backends/ib/. The callback mechanism was unused (regCtrlCb was a no-op), making the CtranCtrlManager parameter dead code in the IB backend.

Changes:
- Remove ctrlMgr parameter from CtranIb constructors, init(), and member variable
- Remove regCtrlCb method entirely
- Remove ctrlMgr_ parameter and member from CtranIbVirtualConn
- Remove callback dispatch code path in CtranIbVc processCqe
- Update all callers: CtranMapper.cc, CtranEx.cc, benchmarks, and 8 test files
- Remove CbCtrlMsg test case that tested the now-removed callback mechanism

Reviewed By: Regina8023

Differential Revision: D102042628


