### PR TITLE
Remove CtranCtrlManager from Socket backend (#2235)

### DIFF
--- a/comms/ctran/backends/socket/CtranSocket.cc
+++ b/comms/ctran/backends/socket/CtranSocket.cc
@@ -14,13 +14,12 @@
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/LogUtils.h"
 
-CtranSocket::CtranSocket(CtranComm* comm, CtranCtrlManager* ctrlMgr)
+CtranSocket::CtranSocket(CtranComm* comm)
     : comm(comm),
       rank_(comm->statex_->rank()),
       cudaDev_(comm->statex_->cudaDev()),
       commHash_(comm->statex_->commHash()),
-      commDesc_(comm->statex_->commDesc()),
-      ctrlMgr_(ctrlMgr) {
+      commDesc_(comm->statex_->commDesc()) {
   init(SocketServerAddr());
   CLOGF_SUBSYS(
       INFO,
@@ -35,14 +34,12 @@ CtranSocket::CtranSocket(
     int cudaDev,
     uint64_t commHash,
     const std::string& commDesc,
-    CtranCtrlManager* ctrlMgr,
     const SocketServerAddr& serverAddr)
     : comm(nullptr),
       rank_(rank),
       cudaDev_(cudaDev),
       commHash_(commHash),
-      commDesc_(commDesc),
-      ctrlMgr_(ctrlMgr) {
+      commDesc_(commDesc) {
   init(serverAddr);
   CLOGF_SUBSYS(
       INFO,
@@ -458,14 +455,7 @@ commResult_t CtranSocket::progressInternal() {
           continueWhileLoop = false;
           continue;
         }
-        if (ctrlMgr_ && ctrlMgr_->hasCb(msg->type)) {
-          CLOGF_TRACE(
-              COLL,
-              "CTRAN-SOCKET: received and invoke callback for msg [{}] peer {}",
-              msg->toString(),
-              peerRanks[fid]);
-          FB_COMMCHECK(ctrlMgr_->runCb(peerRanks[fid], msg->type, msg.get()));
-        } else if (recvQueue.postedOps_.empty()) {
+        if (recvQueue.postedOps_.empty()) {
           // no posted op, let's read it and store as unexpected msg
           CLOGF_TRACE(
               COLL,

--- a/comms/ctran/backends/socket/CtranSocket.h
+++ b/comms/ctran/backends/socket/CtranSocket.h
@@ -24,18 +24,14 @@ class CtranSocket {
    * The remote connection will happen when the remote peer
    * issues the first message to the local rank. Input arguments:
    *    - comm: the NCCL communicator
-   *    - ctrlMgr: the ctranCtrlManager that manages control message callback
-   *               functions registered by other modules. Passed to VC for
-   *               calling callback when receiving control message.
    */
-  CtranSocket(CtranComm* comm, CtranCtrlManager* ctrlMgr);
+  explicit CtranSocket(CtranComm* comm);
 
   CtranSocket(
       int rank,
       int cudaDev,
       uint64_t commHash,
       const std::string& commDesc,
-      CtranCtrlManager* ctrlMgr,
       const SocketServerAddr& serverAddr);
   ~CtranSocket();
 
@@ -184,7 +180,6 @@ class CtranSocket {
   const int cudaDev_;
   const uint64_t commHash_;
   const std::string commDesc_;
-  CtranCtrlManager* ctrlMgr_{nullptr};
   CommLogData ncclLogData_;
   std::vector<bool> preConnectPeerMap_;
 

--- a/comms/ctran/backends/socket/tests/CtranSocketDistUT.cc
+++ b/comms/ctran/backends/socket/tests/CtranSocketDistUT.cc
@@ -6,7 +6,6 @@
 #include <folly/ScopeGuard.h>
 #include <folly/init/Init.h>
 
-#include "comms/ctran/backends/CtranCtrl.h"
 #include "comms/ctran/backends/socket/CtranSocket.h"
 #include "comms/ctran/tests/CtranDistTestUtils.h"
 #include "comms/ctran/tests/CtranTestUtils.h"
@@ -28,7 +27,6 @@ class CtranSocketTest : public ctran::CtranDistTestFixture {
     ctran::CtranDistTestFixture::SetUp();
     comm_ = makeCtranComm();
     comm = comm_.get();
-    ctrlMgr = std::make_unique<CtranCtrlManager>();
   }
 
   void printTestDesc(const std::string& testName, const std::string& testDesc) {
@@ -41,7 +39,6 @@ class CtranSocketTest : public ctran::CtranDistTestFixture {
  protected:
   std::unique_ptr<CtranComm> comm_{nullptr};
   CtranComm* comm{nullptr};
-  std::unique_ptr<CtranCtrlManager> ctrlMgr{nullptr};
 };
 
 TEST_F(CtranSocketTest, NormalInitialize) {
@@ -49,7 +46,7 @@ TEST_F(CtranSocketTest, NormalInitialize) {
       "NormalInitialize",
       "Expect CtranSocket to be initialized without internal error.");
 
-  auto ctranSock = std::make_unique<CtranSocket>(comm, ctrlMgr.get());
+  auto ctranSock = std::make_unique<CtranSocket>(comm);
   EXPECT_NE(ctranSock, nullptr);
 }
 
@@ -79,7 +76,7 @@ TEST_F(CtranSocketTest, InitializeWithoutComm) {
   SocketServerAddr serverAddr{.port = port, .ipv6 = maybeAddr->str()};
 
   auto ctranSock = std::make_unique<CtranSocket>(
-      rank, cudaDev, commHash, commDesc, ctrlMgr.get(), serverAddr);
+      rank, cudaDev, commHash, commDesc, serverAddr);
   EXPECT_NE(ctranSock, nullptr);
 
   // test send/recv control message
@@ -127,60 +124,12 @@ TEST_F(CtranSocketTest, InitializeWithoutComm) {
   }
 }
 
-namespace {
-constexpr int testRkey = 9;
-constexpr uint64_t testRemoteAddr = 100;
-bool testCbFlag = false;
-commResult_t testCtrlMsgCb(int peer, void* msgPtr, void* ctx) {
-  bool* testCbFlagPtr = reinterpret_cast<bool*>(ctx);
-  *testCbFlagPtr = true;
-  EXPECT_EQ(peer, 0);
-  auto msg = reinterpret_cast<ControlMsg*>(msgPtr);
-  EXPECT_EQ(msg->type, ControlMsgType::IB_EXPORT_MEM);
-  EXPECT_EQ(msg->ibDesc.rkeys[0], testRkey);
-  EXPECT_EQ(msg->ibDesc.remoteAddr, testRemoteAddr);
-  return commSuccess;
-}
-} // namespace
-
-TEST_F(CtranSocketTest, CbCtrlMsg) {
-  this->printTestDesc(
-      "CbCtrlMsg",
-      "Expect rank 0 can issue a send control msg that triggers corresponding callback on rank 1");
-
-  // Register callback
-  this->ctrlMgr->regCb(
-      ControlMsgType::IB_EXPORT_MEM, testCtrlMsgCb, &testCbFlag);
-
-  auto ctranSock =
-      std::make_unique<CtranSocket>(this->comm, this->ctrlMgr.get());
-  CtranSocketRequest req;
-  ControlMsg smsg(ControlMsgType::IB_EXPORT_MEM);
-
-  smsg.ibDesc.remoteAddr = testRemoteAddr;
-  smsg.ibDesc.rkeys[0] = testRkey;
-  smsg.ibDesc.nKeys = 1;
-  if (this->globalRank == 0) {
-    COMMCHECK_TEST(ctranSock->isendCtrlMsg(smsg, 1, req));
-
-    // Wait until send finishes
-    waitSocketReq(req, ctranSock);
-  } else if (this->globalRank == 1) {
-    // Wait until callback is triggered
-    do {
-      COMMCHECK_TEST(ctranSock->progress());
-    } while (!testCbFlag);
-  } else {
-    // no-op for non-communicating ranks
-    COMMCHECK_TEST(req.complete());
-  }
-}
 TEST_F(CtranSocketTest, CtrlMsg) {
   printTestDesc(
       "SendRecvCtrlMsg",
       "Expect rank 2 can issue multiple send control msgs to ranks 0 and 1, and match to the corresponding recvs");
 
-  auto ctranSock = std::make_unique<CtranSocket>(comm, ctrlMgr.get());
+  auto ctranSock = std::make_unique<CtranSocket>(comm);
   std::vector<CtranSocketRequest> reqs;
   std::vector<ControlMsg> smsgs;
   ControlMsg rmsg0(ControlMsgType::IB_EXPORT_MEM);
@@ -252,7 +201,7 @@ TEST_F(CtranSocketTest, AllGather) {
   printTestDesc(
       "AllGather",
       "Expect every rank to recv&send a control msg to all other ranks");
-  auto ctranSock = std::make_unique<CtranSocket>(comm, ctrlMgr.get());
+  auto ctranSock = std::make_unique<CtranSocket>(comm);
   std::vector<CtranSocketRequest> sreqs(numRanks);
   std::vector<CtranSocketRequest> rreqs(numRanks);
   std::vector<ControlMsg> smsgs(numRanks);
@@ -301,7 +250,7 @@ TEST_F(CtranSocketTest, MatchAnyCtrlMsg) {
       "MatchAnyCtrlMsg",
       "Expect rank 0 can issue a send control msg to rank 1 and matches to the UNSPECIFIED recv on rank1");
 
-  auto ctranSock = std::make_unique<CtranSocket>(comm, ctrlMgr.get());
+  auto ctranSock = std::make_unique<CtranSocket>(comm);
   const int nCtrl = 300; // exceed MAX_CONTROL_MSGS
   std::vector<CtranSocketRequest> reqs(nCtrl);
   std::vector<ControlMsg> smsgs(nCtrl);
@@ -347,7 +296,7 @@ TEST_F(CtranSocketTest, CtrlMsgAndPreConnect) {
       "Expect rank 0 can issue a send control msg, followed by preConnect"
       "the preConnect is expected to be a no-op");
 
-  auto ctranSock = std::make_unique<CtranSocket>(comm, ctrlMgr.get());
+  auto ctranSock = std::make_unique<CtranSocket>(comm);
   CtranSocketRequest req;
   ControlMsg smsg(ControlMsgType::IB_EXPORT_MEM);
   ControlMsg rmsg(ControlMsgType::IB_EXPORT_MEM);

--- a/comms/ctran/mapper/CtranMapper.cc
+++ b/comms/ctran/mapper/CtranMapper.cc
@@ -168,8 +168,7 @@ CtranMapper::CtranMapper(CtranComm* comm) {
   }
   if (enableBackends_[CtranMapperBackend::SOCKET]) {
     if (!this->ctranIb) {
-      this->ctranSock =
-          std::make_unique<class CtranSocket>(comm, this->ctrlMgr.get());
+      this->ctranSock = std::make_unique<class CtranSocket>(comm);
     } else {
       enableBackends_[CtranMapperBackend::SOCKET] = false;
       CLOGF_SUBSYS(


### PR DESCRIPTION
Summary:

Remove all CtranCtrlManager callsites from backends/socket/. The callback mechanism was unused, making the CtranCtrlManager parameter dead code in the Socket backend.

Changes:
- Remove ctrlMgr parameter from CtranSocket constructors and member variable
- Remove callback dispatch code path in CtranSocket::progressInternal
- Update caller in CtranMapper.cc
- Remove CbCtrlMsg test case and update socket test file

Reviewed By: Regina8023

Differential Revision: D102042630
