### PR TITLE
Remove CtranCtrlManager from TcpDm and mock backends (#2236)

### DIFF
--- a/comms/ctran/backends/mock/CtranTcpDmMock.h
+++ b/comms/ctran/backends/mock/CtranTcpDmMock.h
@@ -3,14 +3,13 @@
 #pragma once
 
 #include "comms/ctran/CtranComm.h"
-#include "comms/ctran/backends/CtranCtrl.h"
 #include "comms/ctran/backends/mock/CtranTcpDmBaseMock.h"
 
 namespace ctran {
 
 class CtranTcpDm {
  public:
-  CtranTcpDm(CtranComm* comm, CtranCtrlManager* ctrlMgr) {}
+  explicit CtranTcpDm(CtranComm* comm) {}
   ~CtranTcpDm() {}
 
   commResult_t preConnect(const std::unordered_set<int>& peerRanks) {

--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
@@ -182,9 +182,7 @@ commResult_t CtranTcpDm::bootstrapConnect(
   return res;
 }
 
-CtranTcpDm::CtranTcpDm(
-    [[maybe_unused]] CtranComm* comm,
-    [[maybe_unused]] CtranCtrlManager* ctrlMgr) {
+CtranTcpDm::CtranTcpDm([[maybe_unused]] CtranComm* comm) {
   transport_ = CtranTcpDmSingleton::getTransport();
 
   cudaDev_ = comm->statex_->cudaDev();

--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.h
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.h
@@ -16,7 +16,7 @@ namespace ctran {
 
 class CtranTcpDm {
  public:
-  CtranTcpDm(CtranComm* comm, CtranCtrlManager* ctrlMgr);
+  explicit CtranTcpDm(CtranComm* comm);
   ~CtranTcpDm();
 
   commResult_t preConnect(const std::unordered_set<int>& peerRanks);

--- a/comms/ctran/backends/tcpdevmem/tests/CtranTcpDmDistUT.cc
+++ b/comms/ctran/backends/tcpdevmem/tests/CtranTcpDmDistUT.cc
@@ -12,7 +12,6 @@
 #include <folly/logging/xlog.h>
 
 #include "comms/ctran/Ctran.h"
-#include "comms/ctran/backends/CtranCtrl.h"
 #include "comms/ctran/backends/tcpdevmem/CtranTcpDm.h"
 #include "comms/ctran/backends/tcpdevmem/CtranTcpDmSingleton.h"
 #include "comms/ctran/tests/CtranDistTestUtils.h"
@@ -47,11 +46,8 @@ class CtranTcpTest : public ctran::CtranDistTestFixture {
     ncclCvarInit(); // initialize cvars explicitly to take effect
     comm_ = makeCtranComm();
 
-    this->ctrlMgr = std::make_unique<CtranCtrlManager>();
-
     try {
-      this->ctranTcpDm =
-          std::make_unique<CtranTcpDm>(comm_.get(), this->ctrlMgr.get());
+      this->ctranTcpDm = std::make_unique<CtranTcpDm>(comm_.get());
     } catch (const ctran::utils::Exception&) {
       GTEST_SKIP() << "TCPDM backend not enabled. Skip test";
     } catch (const std::runtime_error&) {
@@ -61,7 +57,6 @@ class CtranTcpTest : public ctran::CtranDistTestFixture {
 
   void TearDown() override {
     this->ctranTcpDm.reset();
-    this->ctrlMgr.reset();
     comm_.reset();
     ctran::CtranDistTestFixture::TearDown();
   }
@@ -81,7 +76,6 @@ class CtranTcpTest : public ctran::CtranDistTestFixture {
  protected:
   std::unique_ptr<CtranComm> comm_{nullptr};
   std::unique_ptr<CtranTcpDm> ctranTcpDm{nullptr};
-  std::unique_ptr<CtranCtrlManager> ctrlMgr{nullptr};
   const int sendRank{0}, recvRank{1};
 };
 

--- a/comms/ctran/mapper/CtranMapper.cc
+++ b/comms/ctran/mapper/CtranMapper.cc
@@ -178,8 +178,7 @@ CtranMapper::CtranMapper(CtranComm* comm) {
     }
   }
   if (enableBackends_[CtranMapperBackend::TCPDM]) {
-    this->ctranTcpDm =
-        std::make_unique<class ctran::CtranTcpDm>(comm, this->ctrlMgr.get());
+    this->ctranTcpDm = std::make_unique<class ctran::CtranTcpDm>(comm);
     CLOGF(WARN, "CTRAN-MAPPER: TCPDM backend is enabled");
   }
 


### PR DESCRIPTION
Summary:

Remove all CtranCtrlManager callsites from backends/tcpdevmem/ and backends/mock/. The ctrlMgr parameter was unused in both the real and mock TcpDm implementations.

Changes:
- Remove ctrlMgr parameter from CtranTcpDm constructor (real and mock)
- Remove CtranCtrl.h include from mock header
- Update caller in CtranMapper.cc
- Update tcpdevmem test file

Reviewed By: Regina8023

Differential Revision: D102042629
