### PR TITLE
Remove CtranCtrlManager member from CtranMapper and CtranExImpl (#2237)

### DIFF
--- a/comms/ctran/CtranEx.cc
+++ b/comms/ctran/CtranEx.cc
@@ -37,9 +37,7 @@ void initEnvCtranEx() {
 }
 
 CtranExImpl::CtranExImpl(int rank, int cudaDev, const std::string& desc)
-    : rank(rank), cudaDev(cudaDev), desc(desc) {
-  ctrlMgr = std::make_unique<CtranCtrlManager>();
-};
+    : rank(rank), cudaDev(cudaDev), desc(desc) {};
 
 void CtranExImpl::initialize(
     std::optional<const CtranExHostInfo*> hostInfo,

--- a/comms/ctran/CtranExImpl.h
+++ b/comms/ctran/CtranExImpl.h
@@ -8,7 +8,6 @@
 #include <string>
 
 #include "comms/ctran/CtranEx.h"
-#include "comms/ctran/backends/CtranCtrl.h"
 #include "comms/ctran/backends/ib/CtranIb.h"
 #include "comms/ctran/utils/AsyncError.h"
 
@@ -25,7 +24,6 @@ class CtranExImpl {
   int rank{-1};
   int cudaDev{-1};
   std::string desc{"undefined"};
-  std::unique_ptr<CtranCtrlManager> ctrlMgr{nullptr};
   std::unique_ptr<CtranIb> ctranIb{nullptr};
 
   std::string describe() const {

--- a/comms/ctran/backends/mock/CtranTcpDmMock.h
+++ b/comms/ctran/backends/mock/CtranTcpDmMock.h
@@ -3,14 +3,13 @@
 #pragma once
 
 #include "comms/ctran/CtranComm.h"
-#include "comms/ctran/backends/CtranCtrl.h"
 #include "comms/ctran/backends/mock/CtranTcpDmBaseMock.h"
 
 namespace ctran {
 
 class CtranTcpDm {
  public:
-  CtranTcpDm(CtranComm* comm, CtranCtrlManager* ctrlMgr) {}
+  explicit CtranTcpDm(CtranComm* comm) {}
   ~CtranTcpDm() {}
 
   commResult_t preConnect(const std::unordered_set<int>& peerRanks) {

--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
@@ -182,9 +182,7 @@ commResult_t CtranTcpDm::bootstrapConnect(
   return res;
 }
 
-CtranTcpDm::CtranTcpDm(
-    [[maybe_unused]] CtranComm* comm,
-    [[maybe_unused]] CtranCtrlManager* ctrlMgr) {
+CtranTcpDm::CtranTcpDm([[maybe_unused]] CtranComm* comm) {
   transport_ = CtranTcpDmSingleton::getTransport();
 
   cudaDev_ = comm->statex_->cudaDev();

--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.h
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.h
@@ -16,7 +16,7 @@ namespace ctran {
 
 class CtranTcpDm {
  public:
-  CtranTcpDm(CtranComm* comm, CtranCtrlManager* ctrlMgr);
+  explicit CtranTcpDm(CtranComm* comm);
   ~CtranTcpDm();
 
   commResult_t preConnect(const std::unordered_set<int>& peerRanks);

--- a/comms/ctran/backends/tcpdevmem/tests/CtranTcpDmDistUT.cc
+++ b/comms/ctran/backends/tcpdevmem/tests/CtranTcpDmDistUT.cc
@@ -12,7 +12,6 @@
 #include <folly/logging/xlog.h>
 
 #include "comms/ctran/Ctran.h"
-#include "comms/ctran/backends/CtranCtrl.h"
 #include "comms/ctran/backends/tcpdevmem/CtranTcpDm.h"
 #include "comms/ctran/backends/tcpdevmem/CtranTcpDmSingleton.h"
 #include "comms/ctran/tests/CtranDistTestUtils.h"
@@ -47,11 +46,8 @@ class CtranTcpTest : public ctran::CtranDistTestFixture {
     ncclCvarInit(); // initialize cvars explicitly to take effect
     comm_ = makeCtranComm();
 
-    this->ctrlMgr = std::make_unique<CtranCtrlManager>();
-
     try {
-      this->ctranTcpDm =
-          std::make_unique<CtranTcpDm>(comm_.get(), this->ctrlMgr.get());
+      this->ctranTcpDm = std::make_unique<CtranTcpDm>(comm_.get());
     } catch (const ctran::utils::Exception&) {
       GTEST_SKIP() << "TCPDM backend not enabled. Skip test";
     } catch (const std::runtime_error&) {
@@ -61,7 +57,6 @@ class CtranTcpTest : public ctran::CtranDistTestFixture {
 
   void TearDown() override {
     this->ctranTcpDm.reset();
-    this->ctrlMgr.reset();
     comm_.reset();
     ctran::CtranDistTestFixture::TearDown();
   }
@@ -81,7 +76,6 @@ class CtranTcpTest : public ctran::CtranDistTestFixture {
  protected:
   std::unique_ptr<CtranComm> comm_{nullptr};
   std::unique_ptr<CtranTcpDm> ctranTcpDm{nullptr};
-  std::unique_ptr<CtranCtrlManager> ctrlMgr{nullptr};
   const int sendRank{0}, recvRank{1};
 };
 

--- a/comms/ctran/mapper/CtranMapper.cc
+++ b/comms/ctran/mapper/CtranMapper.cc
@@ -178,8 +178,7 @@ CtranMapper::CtranMapper(CtranComm* comm) {
     }
   }
   if (enableBackends_[CtranMapperBackend::TCPDM]) {
-    this->ctranTcpDm =
-        std::make_unique<class ctran::CtranTcpDm>(comm, this->ctrlMgr.get());
+    this->ctranTcpDm = std::make_unique<class ctran::CtranTcpDm>(comm);
     CLOGF(WARN, "CTRAN-MAPPER: TCPDM backend is enabled");
   }
 

--- a/comms/ctran/mapper/CtranMapper.cc
+++ b/comms/ctran/mapper/CtranMapper.cc
@@ -10,7 +10,6 @@
 #include <sstream>
 #include <string>
 
-#include "comms/ctran/backends/CtranCtrl.h"
 #include "comms/ctran/colltrace/MapperTrace.h"
 #include "comms/ctran/mapper/CtranMapper.h"
 #include "comms/ctran/mapper/CtranMapperTypes.h"
@@ -153,8 +152,6 @@ CtranMapper::CtranMapper(CtranComm* comm) {
         comm->logMetaData_,
         "CTRAN-MAPPER: TCPDM can not be enabled with IB, NVL or Socket backends");
   }
-
-  this->ctrlMgr = std::make_unique<CtranCtrlManager>();
 
   /* enable available backends */
   if (enableBackends_[CtranMapperBackend::IB]) {

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -2011,7 +2011,6 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
   std::unique_ptr<class CtranNvl> ctranNvl{nullptr};
   std::unique_ptr<class CtranSocket> ctranSock{nullptr};
   std::unique_ptr<class ctran::CtranTcpDm> ctranTcpDm{nullptr};
-  std::unique_ptr<class CtranCtrlManager> ctrlMgr{nullptr};
 
   // holds enabled backends when the mapper is created.
   // A unified struct for holding all available backends.


### PR DESCRIPTION
Summary:

With all backends no longer requiring CtranCtrlManager, remove the member variable and its creation from CtranMapper. The CtranCtrl.h include in the header is kept since CtranMapper still uses ControlMsg and ControlMsgType types defined there.

Changes:
- Remove ctrlMgr member from CtranMapper.h
- Remove ctrlMgr creation in CtranMapper constructor
- Remove redundant CtranCtrl.h include from CtranMapper.cc

Reviewed By: Regina8023

Differential Revision: D102042626
