### PR TITLE
Fix pastColls ordering by using min-heap keyed on collId

### DIFF
--- a/comms/utils/colltrace/plugins/CommDumpPlugin.cc
+++ b/comms/utils/colltrace/plugins/CommDumpPlugin.cc
@@ -155,11 +155,12 @@ CommsMaybeVoid CommDumpPlugin::afterCollKernelEnd(
         commInternalError));
   }
 
+  lockedCollTraceDump->pastCollsHeap.push(std::move(*it));
   while (config_.pastCollSize >= 0 &&
-         lockedCollTraceDump->pastColls.size() >= config_.pastCollSize) {
-    lockedCollTraceDump->pastColls.pop_front();
+         static_cast<int64_t>(lockedCollTraceDump->pastCollsHeap.size()) >
+             config_.pastCollSize) {
+    lockedCollTraceDump->pastCollsHeap.pop();
   }
-  lockedCollTraceDump->pastColls.emplace_back(std::move(*it));
   lockedCollTraceDump->currentColls.erase(it);
 
   return folly::unit;
@@ -203,6 +204,12 @@ CommsMaybe<CollTraceDump> CommDumpPlugin::dump() noexcept {
 
   // Create a copy of the current state of collTraceDump_
   CollTraceDump dumpCopy = *readLockedCollTraceDump;
+
+  // Drain the min-heap into pastColls deque in ascending collId order
+  while (!dumpCopy.pastCollsHeap.empty()) {
+    dumpCopy.pastColls.push_back(dumpCopy.pastCollsHeap.top());
+    dumpCopy.pastCollsHeap.pop();
+  }
 
   // Temporary fix: Currently we use currentColls to also track the next
   // pending collective, this logic is being used in Analyzer to detect

--- a/comms/utils/colltrace/plugins/CommDumpPlugin.h
+++ b/comms/utils/colltrace/plugins/CommDumpPlugin.h
@@ -4,6 +4,7 @@
 
 #include <deque>
 #include <memory>
+#include <queue>
 #include <vector>
 
 #include <folly/MPMCQueue.h>
@@ -37,7 +38,21 @@ struct CommDumpConfig {
   std::chrono::milliseconds dumpLockAcquireTimeout{kDumpLockAcquireTimeout};
 };
 
+struct CollRecordGreaterCollId {
+  bool operator()(
+      const std::shared_ptr<CollRecord>& a,
+      const std::shared_ptr<CollRecord>& b) const {
+    return a->getCollId() > b->getCollId();
+  }
+};
+
+using PastCollsHeap = std::priority_queue<
+    std::shared_ptr<CollRecord>,
+    std::vector<std::shared_ptr<CollRecord>>,
+    CollRecordGreaterCollId>;
+
 struct CollTraceDump {
+  PastCollsHeap pastCollsHeap;
   std::deque<std::shared_ptr<CollRecord>> pastColls;
   std::deque<std::shared_ptr<CollRecord>> currentColls;
   std::deque<std::shared_ptr<CollRecord>> pendingColls;

--- a/comms/utils/colltrace/plugins/tests/CommDumpPluginUT.cc
+++ b/comms/utils/colltrace/plugins/tests/CommDumpPluginUT.cc
@@ -340,12 +340,12 @@ TEST_F(CommDumpPluginTest, OutOfOrderScheduling) {
   EXPECT_VALUE(plugin->afterCollKernelStart(event3));
   EXPECT_VALUE(plugin->afterCollKernelEnd(event3));
 
-  // Final dump: all three in pastColls in completion order (2, 1, 3)
+  // Final dump: all three in pastColls in collId order (1, 2, 3)
   auto dump3 = plugin->dump();
   EXPECT_VALUE(dump3);
   EXPECT_EQ(dump3.value().pastColls.size(), 3);
-  EXPECT_EQ(dump3.value().pastColls[0]->getCollId(), 2);
-  EXPECT_EQ(dump3.value().pastColls[1]->getCollId(), 1);
+  EXPECT_EQ(dump3.value().pastColls[0]->getCollId(), 1);
+  EXPECT_EQ(dump3.value().pastColls[1]->getCollId(), 2);
   EXPECT_EQ(dump3.value().pastColls[2]->getCollId(), 3);
   EXPECT_TRUE(dump3.value().currentColls.empty());
   EXPECT_TRUE(dump3.value().pendingColls.empty());


### PR DESCRIPTION
Summary:
Due to the recent change in colltrace D97960551, now CommDumpPlugin::pastColls was not longer ordered by collId. so the
completion order diverges from enqueue/collId order.

Fix: use a std::priority_queue (min-heap by collId) internally in
CommDumpPlugin to store completed collectives. On dump(), drain the
heap into the pastColls deque in ascending collId order. Eviction
pops the smallest collId (oldest entry) when the heap exceeds
pastCollSize.

Reviewed By: dolpm, minsii

Differential Revision: D101925930


