### PR TITLE
Suppress -Wshadow and -Wunused-result warnings in ZBatcher and GpuClockCalibration

### DIFF
--- a/comms/utils/GpuClockCalibration.cc
+++ b/comms/utils/GpuClockCalibration.cc
@@ -45,7 +45,7 @@ std::chrono::system_clock::time_point GlobaltimerCalibration::toWallClock(
         cudaHostAllocDefault));
     *mapped_ptr = 0;
 
-    launchReadGlobaltimer(nullptr, mapped_ptr);
+    (void)launchReadGlobaltimer(nullptr, mapped_ptr);
     CUDA_CHECK_CC(cudaDeviceSynchronize());
 
     cal.device_ns = *mapped_ptr;


### PR DESCRIPTION
Summary:
Fix compiler warnings in ZBatcher and GpuClockCalibration

  Fix variable shadowing in ZBatcher::reGroupAndPushBatch: the lambda inside the range-based for loop `for (auto& [loc, subOps] : grouped)` captured `subOps =
  std::move(subOps)` and `loc = loc`, which shadow the structured bindings from the enclosing scope. Renamed the captures to `ops` and `shardLoc` to eliminate
  -Wshadow warnings.

  Cast unused return value of launchReadGlobaltimer() to void in GpuClockCalibration to suppress -Wunused-result warning.

___

overriding_review_checks_triggers_an_audit_and_retroactive_review
Oncall Short Name: triton

Differential Revision: D102155768


