### PR TITLE
Introduce TracingGuardInfo struct (#2245)

### DIFF
--- a/comms/torchcomms/TorchCommBackend.hpp
+++ b/comms/torchcomms/TorchCommBackend.hpp
@@ -289,6 +289,19 @@ class TorchCommBackend {
   }
 
   /**
+   * Check if the backend is fully initialized and ready for collective
+   * operations. In dynamic regime, the backend transitions to initialized
+   * state after a successful reconfigure().
+   *
+   * This method is non-throwing and safe to call regardless of backend state.
+   *
+   * @return True if the backend is initialized, false otherwise.
+   */
+  virtual bool isInitialized() const {
+    return true;
+  }
+
+  /**
    * Get the initialization handle for this backend.
    * In dynamic regime, this URL encodes information required by the backend
    * to complete the initialization process via reconfigure().

--- a/comms/torchcomms/utils/TracingGuard.cpp
+++ b/comms/torchcomms/utils/TracingGuard.cpp
@@ -19,6 +19,7 @@ namespace torch::comms {
 // analyze distributed communication patterns.
 std::shared_ptr<torch::ParamCommsDebugInfo> TracingGuard::getDebugInfo(
     std::string_view comm_name,
+    std::string_view comm_id,
     int comm_size,
     std::string_view collective_name,
     int collective_rank,
@@ -44,7 +45,7 @@ std::shared_ptr<torch::ParamCommsDebugInfo> TracingGuard::getDebugInfo(
   }
 
   return std::make_shared<torch::ParamCommsDebugInfo>(
-      std::make_tuple(std::string(comm_name), std::string("")),
+      std::make_tuple(std::string(comm_name), std::string(comm_id)),
       collective_rank,
       std::string(collective_name).c_str(),
       input_total_numel,
@@ -59,6 +60,7 @@ std::shared_ptr<torch::ParamCommsDebugInfo> TracingGuard::getDebugInfo(
 
 void TracingGuard::initializeTracingCommon(
     std::string_view comm_name,
+    std::string_view comm_id,
     int comm_size,
     std::string_view collective_name,
     int collective_rank,
@@ -77,6 +79,7 @@ void TracingGuard::initializeTracingCommon(
       c10::DebugInfoKind::PARAM_COMMS_INFO,
       getDebugInfo(
           comm_name,
+          comm_id,
           comm_size,
           collective_name,
           collective_rank,
@@ -89,7 +92,7 @@ void TracingGuard::initializeTracingCommon(
     std::initializer_list<const c10::IValue> paramList = {
         c10::IValue(input_tensor_list),
         std::make_tuple(++sequence_number_, false),
-        std::make_tuple(std::string(comm_name), std::string("")),
+        std::make_tuple(std::string(comm_name), std::string(comm_id)),
         collective_rank,
         std::string(collective_name),
         in_split_sizes,
@@ -122,6 +125,7 @@ TracingGuard::TracingGuard(
   }
   initializeTracingCommon(
       comm_name,
+      "",
       comm_size,
       collective_name,
       collective_rank,
@@ -142,11 +146,50 @@ TracingGuard::TracingGuard(
   }
   initializeTracingCommon(
       comm_name,
+      "",
       comm_size,
       collective_name,
       collective_rank,
       input_tensor_list,
       output_tensor_list);
+}
+
+TracingGuard::TracingGuard(
+    const TracingGuardInfo& info,
+    std::string_view collective_name,
+    const std::vector<at::Tensor>& input_tensor_list,
+    const std::vector<at::Tensor>& output_tensor_list) {
+  record_function_guard_.emplace(at::RecordScope::FUNCTION);
+  if (!record_function_guard_->isActive()) {
+    return;
+  }
+  initializeTracingCommon(
+      info.commName,
+      info.commId,
+      info.commSize,
+      collective_name,
+      info.rank,
+      input_tensor_list,
+      output_tensor_list);
+}
+
+TracingGuard::TracingGuard(
+    const TracingGuardInfo& info,
+    std::string_view collective_name,
+    const at::Tensor& input_tensor,
+    const at::Tensor& output_tensor) {
+  record_function_guard_.emplace(at::RecordScope::FUNCTION);
+  if (!record_function_guard_->isActive()) {
+    return;
+  }
+  initializeTracingCommon(
+      info.commName,
+      info.commId,
+      info.commSize,
+      collective_name,
+      info.rank,
+      {input_tensor},
+      {output_tensor});
 }
 
 } // namespace torch::comms

--- a/comms/torchcomms/utils/TracingGuard.hpp
+++ b/comms/torchcomms/utils/TracingGuard.hpp
@@ -11,6 +11,16 @@
 
 namespace torch::comms {
 
+// Snapshot of communicator metadata captured at construction time.
+// Stored by work handles to avoid calling checked comm accessors that
+// may throw after the communicator transitions to UNINITIALIZED or FINALIZED.
+struct TracingGuardInfo {
+  std::string commName;
+  std::string commId;
+  int commSize{0};
+  int rank{-1};
+};
+
 class TracingGuard {
  public:
   TracingGuard(
@@ -29,8 +39,21 @@ class TracingGuard {
       const at::Tensor& input_tensor,
       const at::Tensor& output_tensor);
 
+  TracingGuard(
+      const TracingGuardInfo& info,
+      std::string_view collective_name,
+      const std::vector<at::Tensor>& input_tensor_list = {},
+      const std::vector<at::Tensor>& output_tensor_list = {});
+
+  TracingGuard(
+      const TracingGuardInfo& info,
+      std::string_view collective_name,
+      const at::Tensor& input_tensor,
+      const at::Tensor& output_tensor);
+
   void initializeTracingCommon(
       std::string_view comm_name,
+      std::string_view comm_id,
       int comm_size,
       std::string_view collective_name,
       int collective_rank,
@@ -39,6 +62,7 @@ class TracingGuard {
 
   std::shared_ptr<torch::ParamCommsDebugInfo> getDebugInfo(
       std::string_view comm_name,
+      std::string_view comm_id,
       int comm_size,
       std::string_view collective_name,
       int collective_rank,


### PR DESCRIPTION
Summary:

**Context**: For certain sub-classes of `TorchWork`, `wait()` and `waitCPU()` previously called `comm_->getCommName()`, `comm_->getSize()`, and `comm_->getRank()` when constructing a `TracingGuard`. These accessors throw if the communicator is not `INITIALIZED` (e.g., after a failed `reconfigure()` or after `finalize()`), which causes crashes in the wait path.

**TL;DR:** This diff introduces `TracingGuardInfo`, a plain struct that snapshots communicator metadata (name, UUID, size, rank) at `TorchWorkXYZ` construction time. The work handle then passes the cached struct to `TracingGuard` instead of calling checked accessors, making `wait()`/`waitCPU()` safe regardless of communicator state.

Reviewed By: dboyda

Differential Revision: D100866538


