### PR TITLE
Bump CXXSTD to c++20 and add --expt-relaxed-constexpr for folly C++20 consteval compatibility

### DIFF
--- a/comms/ncclx/v2_27/makefiles/common.mk
+++ b/comms/ncclx/v2_27/makefiles/common.mk
@@ -73,7 +73,7 @@ else
 endif
 $(info NVCC_GENCODE is ${NVCC_GENCODE})
 
-CXXSTD ?= -std=c++17
+CXXSTD ?= -std=c++20
 
 CXXFLAGS   := -DCUDA_MAJOR=$(CUDA_MAJOR) -DCUDA_MINOR=$(CUDA_MINOR) -fPIC -fvisibility=hidden \
               -Wall -Wno-unused-function -Wno-sign-compare -std=c++2a -Wvla \
@@ -82,7 +82,7 @@ CXXFLAGS   := -DCUDA_MAJOR=$(CUDA_MAJOR) -DCUDA_MINOR=$(CUDA_MINOR) -fPIC -fvisi
 # Maxrregcount needs to be set accordingly to NCCL_MAX_NTHREADS (otherwise it will cause kernel launch errors)
 # 512 : 120, 640 : 96, 768 : 80, 1024 : 60
 # We would not have to set this if we used __launch_bounds__, but this only works on kernels, not on functions.
-NVCUFLAGS  := -ccbin $(CXX) $(NVCC_GENCODE) $(CXXSTD) --expt-extended-lambda -Xptxas -maxrregcount=96 -Xfatbin -compress-all
+NVCUFLAGS  := -ccbin $(CXX) $(NVCC_GENCODE) $(CXXSTD) --expt-extended-lambda --expt-relaxed-constexpr -Xptxas -maxrregcount=96 -Xfatbin -compress-all
 # Use addprefix so that we can specify more than one path
 NVLDFLAGS  := -L${CUDA_LIB} -lcudart -lrt -lstdc++fs
 

--- a/comms/ncclx/v2_27/src/device/Makefile
+++ b/comms/ncclx/v2_27/src/device/Makefile
@@ -29,7 +29,7 @@ INCFLAGS  += -I$(CONDA_INCLUDE_DIR)
 NVCUFLAGS += $(INCFLAGS) --compiler-options "-fPIC -fvisibility=hidden"
 CXXFLAGS  += $(INCFLAGS)
 
-NVCUFLAGS_SYM := -ccbin $(CXX) $(CXXSTD) --expt-extended-lambda -Xptxas -maxrregcount=128 -Xfatbin -compress-all
+NVCUFLAGS_SYM := -ccbin $(CXX) $(CXXSTD) --expt-extended-lambda --expt-relaxed-constexpr -Xptxas -maxrregcount=128 -Xfatbin -compress-all
 NVCUFLAGS_SYM += $(INCFLAGS) --compiler-options "-fPIC -fvisibility=hidden"
 
 ifneq ($(ENABLE_TCPDM),1)

--- a/comms/ncclx/v2_28/CMakeLists.txt
+++ b/comms/ncclx/v2_28/CMakeLists.txt
@@ -91,7 +91,7 @@ endif()
 message(STATUS "Using CUDA_ARCHITECTURES: ${CMAKE_CUDA_ARCHITECTURES}")
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -fvisibility=hidden -Wall -Wno-unused-function -Wno-sign-compare -Wvla -g")
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-extended-lambda -Xptxas -maxrregcount=96 -Xfatbin -compress-all -fPIC")
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-extended-lambda --expt-relaxed-constexpr -Xptxas -maxrregcount=96 -Xfatbin -compress-all -fPIC")
 
 # Sanitizer options
 if(ASAN)

--- a/comms/ncclx/v2_28/makefiles/common.mk
+++ b/comms/ncclx/v2_28/makefiles/common.mk
@@ -68,7 +68,7 @@ else
 endif
 $(info NVCC_GENCODE is ${NVCC_GENCODE})
 
-CXXSTD ?= -std=c++17
+CXXSTD ?= -std=c++20
 
 CXXFLAGS   := -DCUDA_MAJOR=$(CUDA_MAJOR) -DCUDA_MINOR=$(CUDA_MINOR) -fPIC -fvisibility=hidden \
               -Wall -Wno-unused-function -Wno-sign-compare -std=c++2a -Wvla \
@@ -77,7 +77,7 @@ CXXFLAGS   := -DCUDA_MAJOR=$(CUDA_MAJOR) -DCUDA_MINOR=$(CUDA_MINOR) -fPIC -fvisi
 # Maxrregcount needs to be set accordingly to NCCL_MAX_NTHREADS (otherwise it will cause kernel launch errors)
 # 512 : 120, 640 : 96, 768 : 80, 1024 : 60
 # We would not have to set this if we used __launch_bounds__, but this only works on kernels, not on functions.
-NVCUFLAGS  := -ccbin $(CXX) $(NVCC_GENCODE) $(CXXSTD) --expt-extended-lambda -Xptxas -maxrregcount=96 -Xfatbin -compress-all
+NVCUFLAGS  := -ccbin $(CXX) $(NVCC_GENCODE) $(CXXSTD) --expt-extended-lambda --expt-relaxed-constexpr -Xptxas -maxrregcount=96 -Xfatbin -compress-all
 # Use addprefix so that we can specify more than one path
 NVLDFLAGS  := -L${CUDA_LIB} -lcudart -lrt -lstdc++fs
 

--- a/comms/ncclx/v2_28/src/device/Makefile
+++ b/comms/ncclx/v2_28/src/device/Makefile
@@ -29,7 +29,7 @@ INCFLAGS  += -I$(CONDA_INCLUDE_DIR)
 NVCUFLAGS += $(INCFLAGS) --compiler-options "-fPIC -fvisibility=hidden"
 CXXFLAGS  += $(INCFLAGS)
 
-NVCUFLAGS_SYM += -ccbin $(CXX) $(CXXSTD) --expt-extended-lambda -Xptxas -maxrregcount=128 -Xfatbin -compress-all
+NVCUFLAGS_SYM += -ccbin $(CXX) $(CXXSTD) --expt-extended-lambda --expt-relaxed-constexpr -Xptxas -maxrregcount=128 -Xfatbin -compress-all
 NVCUFLAGS_SYM += $(INCFLAGS) --compiler-options "-fPIC -fvisibility=hidden"
 
 ifneq ($(ENABLE_TCPDM),1)

--- a/comms/ncclx/v2_29/CMakeLists.txt
+++ b/comms/ncclx/v2_29/CMakeLists.txt
@@ -142,7 +142,7 @@ message(STATUS "Using CUDA_ARCHITECTURES: ${CMAKE_CUDA_ARCHITECTURES}")
 if(NCCL_COMPILER_GCC)
     # GCC/Clang-specific flags
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -fvisibility=hidden -Wall -Wno-unused-function -Wno-sign-compare -Wvla -g")
-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-extended-lambda -Xptxas -maxrregcount=96 -Xfatbin -compress-all -fPIC")
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-extended-lambda --expt-relaxed-constexpr -Xptxas -maxrregcount=96 -Xfatbin -compress-all -fPIC")
 elseif(NCCL_COMPILER_MSVC)
     # MSVC-specific flags
     # /Zc:preprocessor enables conformant preprocessor for proper variadic macro handling (needed for NVTX)
@@ -152,7 +152,7 @@ elseif(NCCL_COMPILER_MSVC)
     # /wd4805 disables "unsafe mix of type 'bool' and type 'int'" - intentional bool/int mixing for flags
     # /wd4018 disables "signed/unsigned mismatch" - safe comparisons where signed value is always positive
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W3 /wd4267 /wd4244 /wd4996 /wd4146 /wd4197 /wd5105 /wd4805 /wd4018 /FS /Zc:preprocessor")
-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-extended-lambda -Xptxas -maxrregcount=96 --compress-mode=balance")
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-extended-lambda --expt-relaxed-constexpr -Xptxas -maxrregcount=96 --compress-mode=balance")
 endif()
 
 # Sanitizer options (GCC/Clang only)

--- a/comms/ncclx/v2_29/makefiles/common.mk
+++ b/comms/ncclx/v2_29/makefiles/common.mk
@@ -70,7 +70,7 @@ else
 endif
 $(info NVCC_GENCODE is ${NVCC_GENCODE})
 
-CXXSTD ?= -std=c++17
+CXXSTD ?= -std=c++20
 
 CXXFLAGS   := -DCUDA_MAJOR=$(CUDA_MAJOR) -DCUDA_MINOR=$(CUDA_MINOR) -fPIC -fvisibility=hidden \
               -Wall -Wno-unused-function -Wno-sign-compare -std=c++2a -Wvla \
@@ -79,7 +79,7 @@ CXXFLAGS   := -DCUDA_MAJOR=$(CUDA_MAJOR) -DCUDA_MINOR=$(CUDA_MINOR) -fPIC -fvisi
 # Maxrregcount needs to be set accordingly to NCCL_MAX_NTHREADS (otherwise it will cause kernel launch errors)
 # 512 : 120, 640 : 96, 768 : 80, 1024 : 60
 # We would not have to set this if we used __launch_bounds__, but this only works on kernels, not on functions.
-NVCUFLAGS  := -ccbin $(CXX) $(NVCC_GENCODE) $(CXXSTD) --expt-extended-lambda -Xptxas -maxrregcount=96 -Xfatbin -compress-all
+NVCUFLAGS  := -ccbin $(CXX) $(NVCC_GENCODE) $(CXXSTD) --expt-extended-lambda --expt-relaxed-constexpr -Xptxas -maxrregcount=96 -Xfatbin -compress-all
 # Use addprefix so that we can specify more than one path
 NVLDFLAGS  := -L${CUDA_LIB} -lcudart -lrt -lstdc++fs
 

--- a/comms/ncclx/v2_29/src/device/Makefile
+++ b/comms/ncclx/v2_29/src/device/Makefile
@@ -30,7 +30,7 @@ INCFLAGS  += -I$(CONDA_INCLUDE_DIR)
 NVCUFLAGS += $(INCFLAGS) --compiler-options "-fPIC -fvisibility=hidden"
 CXXFLAGS  += $(INCFLAGS)
 
-NVCUFLAGS_SYM += -ccbin $(CXX) $(CXXSTD) --expt-extended-lambda -Xptxas -maxrregcount=128 -Xfatbin -compress-all
+NVCUFLAGS_SYM += -ccbin $(CXX) $(CXXSTD) --expt-extended-lambda --expt-relaxed-constexpr -Xptxas -maxrregcount=128 -Xfatbin -compress-all
 NVCUFLAGS_SYM += $(INCFLAGS) --compiler-options "-fPIC -fvisibility=hidden"
 #NVCUFLAGS_SYM += --ptx
 


### PR DESCRIPTION
Summary:
The conda-feedstock-ci-torchcomms_test CI job fails because newer folly headers from conda-forge use C++20 features (`consteval` in folly/lang/Builtin.h, FOLLY_CONSTEVAL helpers, stricter constexpr rules) while the NCCLX nvcc compilation was stuck on -std=c++17. Without the C++20 standard, nvcc reports `identifier "consteval" is undefined` and downstream constructor/conversion errors when folly headers are included in CUDA translation units.

This change:

1. Bumps CXXSTD from -std=c++17 to -std=c++20 in v2_27/v2_28/v2_29 makefiles/common.mk so nvcc matches the host C++ flags (which already use -std=c++2a). Note nvcc requires the literal `c++20` identifier — the gcc alias `c++2a` is not accepted by nvcc.

2. Exports CXXSTD=-std=c++20 in fbcode/conda/feedstock/nccl/build.sh so the conda build path explicitly propagates the new standard down through build_ncclx.sh and submakes.

3. Adds --expt-relaxed-constexpr to nvcc flags across all NCCLX version directories (v2_27, v2_28, v2_29) in both Makefile (NVCUFLAGS, NVCUFLAGS_SYM) and CMake (CMAKE_CUDA_FLAGS) build paths, plus the Buck nccl_build_config.bzl. This makes nvcc treat consteval as constexpr, matching folly's pre-C++20 fallback behavior. Already used in other CUDA projects in the codebase (e.g., HugeCTR).

4. Removes the redundant -DFMT_USE_CONSTEXPR=0 from the Makefile NVCUFLAGS / NVCUFLAGS_SYM lines for v2_27/v2_28/v2_29. fmt 9.x already sets FMT_USE_CONSTEXPR=0 internally when it detects __NVCC__ (see fmt/core.h), so the explicit -D was a no-op. Kept in the bzl and CMake paths to preserve current behavior there.

Reviewed By: vickyuec

Differential Revision: D101089614


