### PR TITLE
Fix physical NICs leaking into topology when vNICs are cached across communicators

### DIFF
--- a/comms/ncclx/v2_29/src/graph/topo.cc
+++ b/comms/ncclx/v2_29/src/graph/topo.cc
@@ -1042,13 +1042,6 @@ ncclResult_t ncclTopoMakeVnic(struct ncclXml* xml, struct ncclTopoNetInfo* netIn
     return ret;
   }
 
-  // Mark original NICs as keep="0" in the topology
-  for (int i = 0; i < vProps->ndevs; i++) {
-    int dev = vProps->devs[i];
-    struct ncclXmlNode* netNode = physNetNodes[dev];
-    NCCLCHECK(xmlSetAttrInt(netNode, "keep", 0));
-  }
-
   INFO(NCCL_GRAPH, "TOPO/NET : Made vNic %d", vDevIndex);
   return ncclSuccess;
 }
@@ -1410,7 +1403,7 @@ ncclResult_t ncclTopoProcessNet(ncclXml* xml, const char* dumpXmlFile, struct nc
   bool usePhysicalDevices = (dumpXmlFile || net->makeVDevice == NULL);
   int nPhysicalNics, nVirtualNics;
   NCCLCHECK(net->getDevCount(net->netPluginIndex, &nPhysicalNics, &nVirtualNics));
-  // List the physical devices in the topo
+  // List the physical devices in the topo and set keep = 1
   NCCLCHECK(ncclTopoPopulateNics(xml, 0, nPhysicalNics, net, /*virtual=*/false));
   if (!usePhysicalDevices) {
     // Virtual devices are only created once per network
@@ -1425,8 +1418,32 @@ ncclResult_t ncclTopoProcessNet(ncclXml* xml, const char* dumpXmlFile, struct nc
     }
     // populate the virtual devices if any
     if (nVirtualNics > 0) {
+      INFO(NCCL_GRAPH, "TOPO/NET : Processing %d vNICs (phys=%d), marking fused phys NICs as keep=0", nVirtualNics, nPhysicalNics);
+      // All fused devices are marked as keep = 0.
+      // Note: ncclTopoMakeVnic doesn't create a vNic if ndevs = 1; no special case needed
+      for (int n = nPhysicalNics; n < nPhysicalNics + nVirtualNics; n++) {
+        ncclNetProperties_t vProps;
+        NCCLCHECK(net->getProperties(n, &vProps));
+        for (int i = 0; i < vProps.vProps.ndevs; i++) {
+          ncclNetProperties_t physProps;
+          NCCLCHECK(net->getProperties(vProps.vProps.devs[i], &physProps));
+          struct ncclXmlNode* physNetNode = NULL;
+          NCCLCHECK(xmlFindTagKv(xml, "net", &physNetNode, "name", physProps.name));
+          if (physNetNode) {
+            NCCLCHECK(xmlSetAttrInt(physNetNode, "keep", 0));
+            INFO(NCCL_GRAPH, "TOPO/NET : Marking fused phys NIC %s as keep=0 (vNic %d)", physProps.name, n);
+          } else {
+            WARN("TOPO/NET : Could not find XML node for fused phys NIC %s (vNic %d) — keep=0 NOT set", physProps.name, n);
+          }
+        }
+      }
+      // Populate the virtual devices and set keep = 1
       NCCLCHECK(ncclTopoPopulateNics(xml, nPhysicalNics, nPhysicalNics + nVirtualNics, net, /*virtual=*/true));
+    } else {
+      INFO(NCCL_GRAPH, "TOPO/NET : No vNICs present (nVirtualNics=%d), skipping keep=0 marking", nVirtualNics);
     }
+  } else {
+    INFO(NCCL_GRAPH, "TOPO/NET : Using physical devices only (dumpXml=%d, makeVDevice=%p), skipping vNIC processing", dumpXmlFile != NULL, net->makeVDevice);
   }
 
   return ncclSuccess;


### PR DESCRIPTION
Summary:
Backport of 3 upstream NCCL commits to NCCLx v2.29:
- b82e2b5e: enforce consistent channel to NET assignment (already present)
- 3975b25f: fix physical NICs leaking when vNICs cached (superseded by below)
- 6e440369: always mark fused physical NICs as keep=0 in ncclTopoProcessNet

When multiple NCCL communicators are created in the same process, the
first communicator creates virtual NICs (vNICs) via ncclTopoMakeVNics
and caches the vNIC count. Subsequent communicators skip vNIC creation
but previously failed to mark the merged physical NICs as keep=0.

This caused the second communicator's topology to contain both physical
and virtual NICs, giving the ring search extra NIC paths. When two
sub-communicators (e.g., DP groups in a TP+DP setup) are created after
a TP communicator, they can end up with different ring topologies due to
the extra NICs, leading to cross-rail connections on GCP GB300 and
bitwise non-deterministic results in reduce_scatter.

The fix moves the keep=0 marking from ncclTopoMakeVnic (which only runs
on first communicator creation) to ncclTopoProcessNet (which runs for
every communicator). It queries each existing vNIC's constituent
physical devices and marks them keep=0 unconditionally.

Upstream commits:
https://github.com/NVIDIA/nccl/commit/6e4403691f84b5be43700e4ca8cbc1a814efc432
https://github.com/NVIDIA/nccl/commit/3975b25f29d17a8b262b7f82022667883d658895
https://github.com/NVIDIA/nccl/commit/b82e2b5e935cd8b24bdea3e646775971d2ce8a36

Differential Revision: D101701306


