### PR TITLE
P2 stage 8 — auto-detect numNics_, flip the multi-NIC switch (#2255)

### DIFF
--- a/comms/ncclx/meta/rma/window.cc
+++ b/comms/ncclx/meta/rma/window.cc
@@ -344,7 +344,7 @@ ncclResult_t ncclWinLocalRegisterBuffer(
 
   try {
     auto ibgdaBuf = mpt->localRegisterIbgdaBuffer(ptr, size);
-    *outLkey = ibgdaBuf.lkey.value;
+    *outLkey = ibgdaBuf.lkey_per_device[0].value;
     return ncclSuccess;
   } catch (const std::exception& e) {
     WARN("ncclWinLocalRegisterBuffer: %s", e.what());

--- a/comms/pipes/HipCompat.cuh
+++ b/comms/pipes/HipCompat.cuh
@@ -2,8 +2,10 @@
 
 #pragma once
 
-// On HIP, __trap() is not available; use abort() instead.
-// Include this header in any device code that calls __trap().
+// HIP device shim: provide __trap() (mapped to abort()) and pull in
+// hip_runtime.h so device-side blockIdx/threadIdx are visible to any header
+// that uses them (e.g. printf-before-trap diagnostics in IbgdaBuffer.h).
 #if defined(__HIP_DEVICE_COMPILE__) && !defined(__CUDA_ARCH__)
+#include <hip/hip_runtime.h>
 #define __trap() abort()
 #endif

--- a/comms/pipes/IbgdaBuffer.h
+++ b/comms/pipes/IbgdaBuffer.h
@@ -385,24 +385,32 @@ enum class IbgdaCmpOp {
  */
 struct IbgdaBufferExchInfo {
   uint64_t addr{0};
-  HostRKey rkey{};
+  // Number of valid entries in rkey_per_device. All peers exchange the
+  // same numNics (uniform topology assumption).
+  int numNics{0};
+  HostRKey rkey_per_device[kMaxNicsPerGpu]{};
 
   IbgdaBufferExchInfo() = default;
-  IbgdaBufferExchInfo(uint64_t a, HostRKey r) : addr(a), rkey(r) {}
 
   /**
    * Convert to IbgdaRemoteBuffer for RDMA operations.
-   * Single-NIC: rkey_per_device.size = 1, values[0] = rkey.
+   * The result's NetworkRKeys.size matches this->numNics.
    */
   IbgdaRemoteBuffer toRemoteBuffer() const {
-    return IbgdaRemoteBuffer(reinterpret_cast<void*>(addr), NetworkRKeys{rkey});
+    NetworkRKeys keys(numNics);
+    for (int n = 0; n < numNics; ++n) {
+      keys[n] = NetworkRKey(rkey_per_device[n]);
+    }
+    return IbgdaRemoteBuffer(reinterpret_cast<void*>(addr), keys);
   }
 
   /**
    * Create a sub-buffer at the given byte offset.
    */
   IbgdaBufferExchInfo subBuffer(std::size_t offset) const {
-    return IbgdaBufferExchInfo(addr + offset, rkey);
+    IbgdaBufferExchInfo sub = *this;
+    sub.addr += offset;
+    return sub;
   }
 };
 

--- a/comms/pipes/IbgdaBuffer.h
+++ b/comms/pipes/IbgdaBuffer.h
@@ -2,16 +2,44 @@
 
 #pragma once
 
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
 
 #include <endian.h>
+
+#include "comms/pipes/HipCompat.cuh"
+#include "comms/pipes/rdma/NicConstants.h"
 
 // Allow compilation in both host (C++) and device (CUDA/HIP) contexts
 #if defined(__CUDACC__) || defined(__HIPCC__)
 #define IBGDA_HOST_DEVICE __host__ __device__
 #else
 #define IBGDA_HOST_DEVICE
+#endif
+
+// Bounds-check trap for NetworkLKeys / NetworkRKeys operator[].
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#define IBGDA_KEYS_OOB_TRAP(kind, n, sz)              \
+  do {                                                \
+    printf(                                           \
+        "Network" kind                                \
+        "Keys: index %d out of range [0, %d) at "     \
+        "%s:%d block=(%u,%u,%u) thread=(%u,%u,%u)\n", \
+        (int)(n),                                     \
+        (int)(sz),                                    \
+        __FILE__,                                     \
+        __LINE__,                                     \
+        blockIdx.x,                                   \
+        blockIdx.y,                                   \
+        blockIdx.z,                                   \
+        threadIdx.x,                                  \
+        threadIdx.y,                                  \
+        threadIdx.z);                                 \
+    __trap();                                         \
+  } while (0)
+#else
+#define IBGDA_KEYS_OOB_TRAP(kind, n, sz) assert((n) >= 0 && (n) < (sz))
 #endif
 
 namespace comms::pipes {
@@ -140,58 +168,171 @@ struct NetworkRKey {
 };
 
 // =============================================================================
+// Per-NIC Key Arrays
+// =============================================================================
+//
+// Named wrappers around fixed-size arrays of per-NIC keys with explicit
+// `size` (count of populated NIC slots) and bounds-checked indexing.
+//
+// Construction:
+//   NetworkLKeys keys{};               // size=0, no NICs
+//   NetworkLKeys keys(numNics);        // pre-size for loop fill via op[]
+//
+// Indexed access:
+//   auto v = keys[nic].value;          // traps if nic >= keys.size
+
+/**
+ * NetworkLKeys - Fixed-capacity array of per-NIC local keys with explicit
+ * `size` and bounds-checked indexing.
+ */
+struct NetworkLKeys {
+  NetworkLKey values[kMaxNicsPerGpu]{};
+  int size{0};
+
+  NetworkLKeys() = default;
+
+  // Pre-size for progressive fill via operator[]:
+  //   NetworkLKeys k(numNics);
+  //   for (int n = 0; n < numNics; ++n) k[n] = ...;
+  IBGDA_HOST_DEVICE explicit NetworkLKeys(int n) : size(n) {
+    assert(n >= 0 && n <= kMaxNicsPerGpu);
+  }
+
+  // Variadic per-NIC ctor: size = number of keys.
+  //   Single-NIC: NetworkLKeys{lkey}            (size=1)
+  //   Multi-NIC:  NetworkLKeys{lkey0, lkey1}    (size=2)
+  // explicit: NetworkLKey does NOT implicitly convert to NetworkLKeys —
+  // every single-NIC site must spell the wrap, making it visible in code
+  // review when refactoring for multi-NIC.
+  template <typename... Rest>
+  IBGDA_HOST_DEVICE explicit NetworkLKeys(NetworkLKey k0, Rest... rest)
+      : size(static_cast<int>(1 + sizeof...(Rest))) {
+    static_assert(
+        1 + sizeof...(Rest) <= kMaxNicsPerGpu,
+        "NetworkLKeys: too many keys for kMaxNicsPerGpu");
+    const NetworkLKey arr[] = {k0, rest...};
+    for (int i = 0; i < size; ++i) {
+      values[i] = arr[i];
+    }
+  }
+
+  IBGDA_HOST_DEVICE NetworkLKey& operator[](int n) {
+    if (n < 0 || n >= size) {
+      IBGDA_KEYS_OOB_TRAP("L", n, size);
+    }
+    return values[n];
+  }
+  IBGDA_HOST_DEVICE const NetworkLKey& operator[](int n) const {
+    if (n < 0 || n >= size) {
+      IBGDA_KEYS_OOB_TRAP("L", n, size);
+    }
+    return values[n];
+  }
+};
+
+/**
+ * NetworkRKeys - Mirror of NetworkLKeys for remote keys.
+ */
+struct NetworkRKeys {
+  NetworkRKey values[kMaxNicsPerGpu]{};
+  int size{0};
+
+  NetworkRKeys() = default;
+
+  IBGDA_HOST_DEVICE explicit NetworkRKeys(int n) : size(n) {
+    assert(n >= 0 && n <= kMaxNicsPerGpu);
+  }
+
+  // Variadic per-NIC ctor: size = number of keys.
+  //   Single-NIC: NetworkRKeys{rkey}            (size=1)
+  //   Multi-NIC:  NetworkRKeys{rkey0, rkey1}    (size=2)
+  // explicit — see NetworkLKeys for rationale.
+  template <typename... Rest>
+  IBGDA_HOST_DEVICE explicit NetworkRKeys(NetworkRKey k0, Rest... rest)
+      : size(static_cast<int>(1 + sizeof...(Rest))) {
+    static_assert(
+        1 + sizeof...(Rest) <= kMaxNicsPerGpu,
+        "NetworkRKeys: too many keys for kMaxNicsPerGpu");
+    const NetworkRKey arr[] = {k0, rest...};
+    for (int i = 0; i < size; ++i) {
+      values[i] = arr[i];
+    }
+  }
+
+  IBGDA_HOST_DEVICE NetworkRKey& operator[](int n) {
+    if (n < 0 || n >= size) {
+      IBGDA_KEYS_OOB_TRAP("R", n, size);
+    }
+    return values[n];
+  }
+  IBGDA_HOST_DEVICE const NetworkRKey& operator[](int n) const {
+    if (n < 0 || n >= size) {
+      IBGDA_KEYS_OOB_TRAP("R", n, size);
+    }
+    return values[n];
+  }
+};
+
+// =============================================================================
 // Buffer Descriptors
 // =============================================================================
 
 /**
  * IbgdaLocalBuffer - Local buffer descriptor for RDMA operations
  *
- * Represents a buffer in the local GPU's memory that can be used
- * as a source for RDMA writes or destination for RDMA reads.
- * Uses lkey (local key) in network byte order for memory registration.
+ * Represents a buffer in the local GPU's memory that can be used as a
+ * source for RDMA writes or destination for RDMA reads. Carries one local
+ * key per NIC (`lkey_per_device`) for multi-NIC IBGDA support — each NIC
+ * has its own ibv_pd with a distinct lkey for the same physical buffer.
+ * The kernel-side P2pIbgdaTransportDevice selects
+ * `lkey_per_device[nic]` based on the rail it dispatches to.
+ *
+ * Indexing `lkey_per_device[n]` traps if `n >= lkey_per_device.size`.
  *
  * This struct is usable from both host and device code.
  */
 struct IbgdaLocalBuffer {
   void* ptr{nullptr};
-  NetworkLKey lkey{};
+  NetworkLKeys lkey_per_device{};
 
   IbgdaLocalBuffer() = default;
 
-  IBGDA_HOST_DEVICE IbgdaLocalBuffer(void* p, NetworkLKey key)
-      : ptr(p), lkey(key) {}
+  IBGDA_HOST_DEVICE IbgdaLocalBuffer(void* p, const NetworkLKeys& keys)
+      : ptr(p), lkey_per_device(keys) {}
 
   /**
-   * Create a sub-buffer at the given byte offset
+   * Create a sub-buffer at the given byte offset.
+   * Propagates all NICs' lkeys.
    */
   IBGDA_HOST_DEVICE IbgdaLocalBuffer subBuffer(std::size_t offset) const {
-    return IbgdaLocalBuffer(static_cast<char*>(ptr) + offset, lkey);
+    return IbgdaLocalBuffer(static_cast<char*>(ptr) + offset, lkey_per_device);
   }
 };
 
 /**
  * IbgdaRemoteBuffer - Remote buffer descriptor for RDMA operations
  *
- * Represents a buffer in a remote GPU's memory that can be accessed
- * via RDMA operations. Uses rkey (remote key) in network byte order
- * for memory registration.
+ * Mirror of IbgdaLocalBuffer for remote buffers. Carries one remote key
+ * per NIC (`rkey_per_device`) for multi-NIC IBGDA support. Indexing
+ * `rkey_per_device[n]` traps if `n >= rkey_per_device.size`.
  *
  * This struct is usable from both host and device code.
  */
 struct IbgdaRemoteBuffer {
   void* ptr{nullptr};
-  NetworkRKey rkey{};
+  NetworkRKeys rkey_per_device{};
 
   IbgdaRemoteBuffer() = default;
 
-  IBGDA_HOST_DEVICE IbgdaRemoteBuffer(void* p, NetworkRKey key)
-      : ptr(p), rkey(key) {}
+  IBGDA_HOST_DEVICE IbgdaRemoteBuffer(void* p, const NetworkRKeys& keys)
+      : ptr(p), rkey_per_device(keys) {}
 
   /**
-   * Create a sub-buffer at the given byte offset
+   * Create a sub-buffer at the given byte offset.
+   * Propagates all NICs' rkeys.
    */
   IBGDA_HOST_DEVICE IbgdaRemoteBuffer subBuffer(std::size_t offset) const {
-    return IbgdaRemoteBuffer(static_cast<char*>(ptr) + offset, rkey);
+    return IbgdaRemoteBuffer(static_cast<char*>(ptr) + offset, rkey_per_device);
   }
 };
 
@@ -251,10 +392,10 @@ struct IbgdaBufferExchInfo {
 
   /**
    * Convert to IbgdaRemoteBuffer for RDMA operations.
-   * The HostRKey is implicitly converted to NetworkRKey.
+   * Single-NIC: rkey_per_device.size = 1, values[0] = rkey.
    */
   IbgdaRemoteBuffer toRemoteBuffer() const {
-    return IbgdaRemoteBuffer(reinterpret_cast<void*>(addr), rkey);
+    return IbgdaRemoteBuffer(reinterpret_cast<void*>(addr), NetworkRKeys{rkey});
   }
 
   /**

--- a/comms/pipes/MultipeerIbgdaTransport.cc
+++ b/comms/pipes/MultipeerIbgdaTransport.cc
@@ -719,6 +719,53 @@ MultipeerIbgdaTransport::MultipeerIbgdaTransport(
                  << " peers * 3 = " << config.numQpsPerPeer * (nRanks - 1) * 3
                  << " total QPs";
   }
+
+  // Resolve numNics_ from the available NIC sources. No numeric knob —
+  // the count is implied by what the caller / topology actually provides:
+  //   1. config.gpuNicMap[cudaDevice] populated → use its NIC list.
+  //   2. Otherwise auto-discover via GpuNicDiscovery — every NIC at the
+  //      best-affinity tier (same pathType + bandwidth + isDataDirect as
+  //      the top candidate).
+  // No silent fallback to 1: if a GPU is wired to N best-affinity NICs,
+  // the transport must use all N. H100 (1 NIC) and GB200/GB300 (2 NICs)
+  // both get the right count automatically; an unexpected count throws
+  // with a clear hint.
+  {
+    auto it = config.gpuNicMap.find(config.cudaDevice);
+    int n = 0;
+    const char* source = nullptr;
+    if (it != config.gpuNicMap.end() && !it->second.empty()) {
+      n = static_cast<int>(it->second.size());
+      source = "config.gpuNicMap";
+    } else {
+      GpuNicDiscovery discovery(config.cudaDevice, config.ibHca);
+      auto bestNics = discovery.getBestAffinityNics();
+      if (bestNics.empty()) {
+        throw std::runtime_error(
+            fmt::format(
+                "MultipeerIbgdaTransport: NIC auto-discovery returned no "
+                "candidates for GPU {}; set config.gpuNicMap or config.ibHca "
+                "to expose at least one NIC",
+                config.cudaDevice));
+      }
+      n = static_cast<int>(bestNics.size());
+      source = "auto-discovery (best-affinity tier)";
+    }
+    if (n > kMaxNicsPerGpu) {
+      throw std::runtime_error(
+          fmt::format(
+              "MultipeerIbgdaTransport: {} found {} NIC(s) for GPU {} but "
+              "kMaxNicsPerGpu={}; raise kMaxNicsPerGpu or trim the source",
+              source,
+              n,
+              config.cudaDevice,
+              kMaxNicsPerGpu));
+    }
+    numNics_ = n;
+    VLOG(1) << "MultipeerIbgdaTransport: numNics_=" << numNics_
+            << " (source=" << source << ")";
+  }
+
   try {
     // Resolve CUDA driver function pointers
     if (cuda_driver_lazy_init() != 0) {

--- a/comms/pipes/MultipeerIbgdaTransport.cc
+++ b/comms/pipes/MultipeerIbgdaTransport.cc
@@ -129,6 +129,8 @@ void MultipeerIbgdaTransport::initDocaGpu() {
 }
 
 void MultipeerIbgdaTransport::openIbDevice() {
+  nicDevices_.resize(numNics_);
+
   // Get all IB devices via DOCA's dlopen wrapper
   int numDevices = 0;
   ibv_device** deviceList = nullptr;
@@ -138,134 +140,182 @@ void MultipeerIbgdaTransport::openIbDevice() {
     throw std::runtime_error("No IB devices found");
   }
 
-  // Priority 1: Explicit GPU-to-NIC mapping from config
+  // Resolve nicDevices_[0..numNics_).deviceName — config override first,
+  // then topology-aware auto-discovery.
+  //
+  // Priority 1: Explicit GPU-to-NIC mapping from config (vector per GPU,
+  // entries [0..numNics_) used in order — first is preferred).
   auto it = config_.gpuNicMap.find(config_.cudaDevice);
   if (it != config_.gpuNicMap.end() && !it->second.empty()) {
-    nicDeviceName_ = it->second[0]; // Use first (preferred) NIC
+    const auto& names = it->second;
+    if (static_cast<int>(names.size()) < numNics_) {
+      throw std::runtime_error(
+          fmt::format(
+              "config.gpuNicMap[{}] supplies {} NIC(s) but numNics_={}; "
+              "provide at least numNics_ NIC names",
+              config_.cudaDevice,
+              names.size(),
+              numNics_));
+    }
+    for (int n = 0; n < numNics_; ++n) {
+      nicDevices_[n].deviceName = names[n];
+    }
     VLOG(1) << "MultipeerIbgdaTransport: using config.gpuNicMap for GPU "
-            << config_.cudaDevice << " -> " << nicDeviceName_;
+            << config_.cudaDevice << " -> " << nicDevices_[0].deviceName
+            << (numNics_ > 1 ? " (+ " + std::to_string(numNics_ - 1) +
+                        " more for multi-NIC)"
+                             : "");
   }
 
-  // Priority 2: Auto-discovery if no config override
-  if (nicDeviceName_.empty()) {
+  // Priority 2: Auto-discovery (top-numNics_ candidates by NUMA affinity).
+  if (nicDevices_[0].deviceName.empty()) {
     auto discovery = GpuNicDiscovery(config_.cudaDevice, config_.ibHca);
     const auto& candidates = discovery.getCandidates();
-    nicDeviceName_ = candidates[0].name;
-    VLOG(1) << "MultipeerIbgdaTransport: using NIC " << nicDeviceName_
-            << " for GPU device " << config_.cudaDevice;
-  }
-
-  // Find the NIC by name
-  int nicIdx = -1;
-  for (int i = 0; i < numDevices; i++) {
-    const char* devName = nullptr;
-    doca_verbs_wrapper_ibv_get_device_name(deviceList[i], &devName);
-    if (devName && nicDeviceName_ == devName) {
-      nicIdx = i;
-      break;
+    if (static_cast<int>(candidates.size()) < numNics_) {
+      throw std::runtime_error(
+          fmt::format(
+              "NIC auto-discovery found {} candidate(s) for GPU {} but "
+              "numNics_={}; set config.gpuNicMap or config.ibHca to expose "
+              "additional NICs",
+              candidates.size(),
+              config_.cudaDevice,
+              numNics_));
     }
+    for (int n = 0; n < numNics_; ++n) {
+      nicDevices_[n].deviceName = candidates[n].name;
+    }
+    VLOG(1) << "MultipeerIbgdaTransport: auto-discovered NIC "
+            << nicDevices_[0].deviceName << " for GPU device "
+            << config_.cudaDevice;
   }
-  if (nicIdx < 0) {
-    doca_verbs_wrapper_ibv_free_device_list(deviceList);
-    throw std::runtime_error("Specified NIC not found: " + nicDeviceName_);
+
+  // Open + setup each NIC: find by name, open ctx, alloc PD, query GID +
+  // port, create AH attributes.
+  doca_verbs_addr_type addrType = DOCA_VERBS_ADDR_TYPE_IB_NO_GRH;
+  for (int n = 0; n < numNics_; ++n) {
+    int nicIdx = -1;
+    for (int i = 0; i < numDevices; i++) {
+      const char* devName = nullptr;
+      doca_verbs_wrapper_ibv_get_device_name(deviceList[i], &devName);
+      if (devName && nicDevices_[n].deviceName == devName) {
+        nicIdx = i;
+        break;
+      }
+    }
+    if (nicIdx < 0) {
+      doca_verbs_wrapper_ibv_free_device_list(deviceList);
+      throw std::runtime_error(
+          "Specified NIC not found: " + nicDevices_[n].deviceName);
+    }
+    VLOG(1) << "MultipeerIbgdaTransport: NIC " << n << " = "
+            << nicDevices_[n].deviceName << " at device-list index " << nicIdx;
+
+    docaRet = doca_verbs_wrapper_ibv_open_device(
+        deviceList[nicIdx], &nicDevices_[n].ibvCtx);
+    if (docaRet != DOCA_SUCCESS || !nicDevices_[n].ibvCtx) {
+      doca_verbs_wrapper_ibv_free_device_list(deviceList);
+      throw std::runtime_error(
+          "Failed to open IB device: " + nicDevices_[n].deviceName);
+    }
+
+    docaRet = doca_verbs_wrapper_ibv_alloc_pd(
+        nicDevices_[n].ibvCtx, &nicDevices_[n].ibvPd);
+    if (docaRet != DOCA_SUCCESS || !nicDevices_[n].ibvPd) {
+      doca_verbs_wrapper_ibv_free_device_list(deviceList);
+      throw std::runtime_error(
+          "Failed to allocate protection domain on NIC " +
+          nicDevices_[n].deviceName);
+    }
+
+    docaRet = doca_verbs_wrapper_ibv_query_gid(
+        nicDevices_[n].ibvCtx, 1, gidIndex_, &nicDevices_[n].localGid);
+    if (docaRet != DOCA_SUCCESS) {
+      doca_verbs_wrapper_ibv_free_device_list(deviceList);
+      throw std::runtime_error(
+          "Failed to query GID at index " + std::to_string(gidIndex_) +
+          " on NIC " + nicDevices_[n].deviceName);
+    }
+
+    auto gidStr = fmt::format(
+        "{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:"
+        "{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}",
+        nicDevices_[n].localGid.raw[0],
+        nicDevices_[n].localGid.raw[1],
+        nicDevices_[n].localGid.raw[2],
+        nicDevices_[n].localGid.raw[3],
+        nicDevices_[n].localGid.raw[4],
+        nicDevices_[n].localGid.raw[5],
+        nicDevices_[n].localGid.raw[6],
+        nicDevices_[n].localGid.raw[7],
+        nicDevices_[n].localGid.raw[8],
+        nicDevices_[n].localGid.raw[9],
+        nicDevices_[n].localGid.raw[10],
+        nicDevices_[n].localGid.raw[11],
+        nicDevices_[n].localGid.raw[12],
+        nicDevices_[n].localGid.raw[13],
+        nicDevices_[n].localGid.raw[14],
+        nicDevices_[n].localGid.raw[15]);
+    VLOG(1) << "MultipeerIbgdaTransport: NIC " << n << " GID[" << gidIndex_
+            << "] = " << gidStr;
+
+    ibv_port_attr portAttr{};
+    docaRet =
+        doca_verbs_wrapper_ibv_query_port(nicDevices_[n].ibvCtx, 1, &portAttr);
+    if (docaRet != DOCA_SUCCESS) {
+      doca_verbs_wrapper_ibv_free_device_list(deviceList);
+      throw std::runtime_error(
+          "Failed to query port attributes on NIC " +
+          nicDevices_[n].deviceName);
+    }
+
+    VLOG(1) << "MultipeerIbgdaTransport: NIC " << n
+            << " port 1 state=" << portAttr.state
+            << " link_layer=" << (int)portAttr.link_layer
+            << " (1=IB, 2=Ethernet) active_mtu=" << portAttr.active_mtu;
+
+    if (portAttr.state != IBV_PORT_ACTIVE) {
+      doca_verbs_wrapper_ibv_free_device_list(deviceList);
+      throw std::runtime_error(
+          "NIC " + nicDevices_[n].deviceName + " port 1 is not active (state=" +
+          std::to_string(portAttr.state) + ")");
+    }
+
+    // MTU + addr type are common across NICs (same fabric/HCA generation
+    // assumed). Capture from NIC 0; cross-check the rest match.
+    if (n == 0) {
+      localMtu_ = portAttr.active_mtu;
+      if (portAttr.link_layer == IBV_LINK_LAYER_INFINIBAND) {
+        addrType = DOCA_VERBS_ADDR_TYPE_IB_NO_GRH;
+      } else {
+        addrType = (config_.addressFamily == AddressFamily::IPV4)
+            ? DOCA_VERBS_ADDR_TYPE_IPv4
+            : DOCA_VERBS_ADDR_TYPE_IPv6;
+      }
+    } else if (portAttr.active_mtu != localMtu_) {
+      LOG(WARNING) << "MultipeerIbgdaTransport: NIC " << n << " ("
+                   << nicDevices_[n].deviceName
+                   << ") active_mtu=" << portAttr.active_mtu
+                   << " differs from NIC 0 active_mtu=" << localMtu_
+                   << "; using NIC 0's MTU for negotiation";
+    }
+
+    doca_error_t err = doca_verbs_ah_attr_create(
+        nicDevices_[n].ibvCtx, &nicDevices_[n].ahAttr);
+    checkDocaError(err, "Failed to create AH attributes");
+    err = doca_verbs_ah_attr_set_addr_type(nicDevices_[n].ahAttr, addrType);
+    checkDocaError(err, "Failed to set address type");
+    err = doca_verbs_ah_attr_set_sgid_index(nicDevices_[n].ahAttr, gidIndex_);
+    checkDocaError(err, "Failed to set SGID index");
+    err = doca_verbs_ah_attr_set_hop_limit(nicDevices_[n].ahAttr, kHopLimit);
+    checkDocaError(err, "Failed to set hop limit");
+    err = doca_verbs_ah_attr_set_traffic_class(
+        nicDevices_[n].ahAttr, config_.trafficClass);
+    checkDocaError(err, "Failed to set traffic class");
+    err =
+        doca_verbs_ah_attr_set_sl(nicDevices_[n].ahAttr, config_.serviceLevel);
+    checkDocaError(err, "Failed to set service level");
   }
-  VLOG(1) << "MultipeerIbgdaTransport: found NIC " << nicDeviceName_
-          << " at index " << nicIdx;
-
-  VLOG(1) << "MultipeerIbgdaTransport: selected NIC " << nicDeviceName_
-          << " for GPU " << gpuPciBusId_;
-
-  // Open the device
-  docaRet = doca_verbs_wrapper_ibv_open_device(deviceList[nicIdx], &ibvCtx_);
   doca_verbs_wrapper_ibv_free_device_list(deviceList);
-  if (docaRet != DOCA_SUCCESS || !ibvCtx_) {
-    throw std::runtime_error("Failed to open IB device: " + nicDeviceName_);
-  }
-
-  // Allocate PD
-  docaRet = doca_verbs_wrapper_ibv_alloc_pd(ibvCtx_, &ibvPd_);
-  if (docaRet != DOCA_SUCCESS || !ibvPd_) {
-    throw std::runtime_error("Failed to allocate protection domain");
-  }
-
-  // Query GID
-  docaRet = doca_verbs_wrapper_ibv_query_gid(ibvCtx_, 1, gidIndex_, &localGid_);
-  if (docaRet != DOCA_SUCCESS) {
-    throw std::runtime_error(
-        "Failed to query GID at index " + std::to_string(gidIndex_));
-  }
-
-  // Print GID value for debugging
-  auto gidStr = fmt::format(
-      "{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:"
-      "{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}",
-      localGid_.raw[0],
-      localGid_.raw[1],
-      localGid_.raw[2],
-      localGid_.raw[3],
-      localGid_.raw[4],
-      localGid_.raw[5],
-      localGid_.raw[6],
-      localGid_.raw[7],
-      localGid_.raw[8],
-      localGid_.raw[9],
-      localGid_.raw[10],
-      localGid_.raw[11],
-      localGid_.raw[12],
-      localGid_.raw[13],
-      localGid_.raw[14],
-      localGid_.raw[15]);
-  VLOG(1) << "MultipeerIbgdaTransport: GID index " << gidIndex_ << " = "
-          << gidStr;
-
-  // Query port to determine link layer (IB vs Ethernet)
-  ibv_port_attr portAttr{};
-  docaRet = doca_verbs_wrapper_ibv_query_port(ibvCtx_, 1, &portAttr);
-  if (docaRet != DOCA_SUCCESS) {
-    throw std::runtime_error("Failed to query port attributes");
-  }
-
-  VLOG(1) << "MultipeerIbgdaTransport: port 1 state=" << portAttr.state
-          << " link_layer=" << (int)portAttr.link_layer << " (1=IB, 2=Ethernet)"
-          << " active_mtu=" << portAttr.active_mtu;
-
-  if (portAttr.state != IBV_PORT_ACTIVE) {
-    throw std::runtime_error(
-        "Port 1 is not active (state=" + std::to_string(portAttr.state) + ")");
-  }
-
-  // Store local port MTU for negotiation during connectQp
-  localMtu_ = portAttr.active_mtu;
-
-  // Determine address type based on link layer
-  // For InfiniBand, always use IB_NO_GRH. For RoCE (Ethernet), use the
-  // configured address family (similar to NCCL_IB_ADDR_FAMILY).
-  doca_verbs_addr_type addrType;
-  if (portAttr.link_layer == IBV_LINK_LAYER_INFINIBAND) {
-    addrType = DOCA_VERBS_ADDR_TYPE_IB_NO_GRH;
-  } else {
-    addrType = (config_.addressFamily == AddressFamily::IPV4)
-        ? DOCA_VERBS_ADDR_TYPE_IPv4
-        : DOCA_VERBS_ADDR_TYPE_IPv6;
-  }
-
-  doca_error_t err = doca_verbs_ah_attr_create(ibvCtx_, &ahAttr_);
-  checkDocaError(err, "Failed to create AH attributes");
-
-  err = doca_verbs_ah_attr_set_addr_type(ahAttr_, addrType);
-  checkDocaError(err, "Failed to set address type");
-
-  err = doca_verbs_ah_attr_set_sgid_index(ahAttr_, gidIndex_);
-  checkDocaError(err, "Failed to set SGID index");
-
-  err = doca_verbs_ah_attr_set_hop_limit(ahAttr_, kHopLimit);
-  checkDocaError(err, "Failed to set hop limit");
-
-  err = doca_verbs_ah_attr_set_traffic_class(ahAttr_, config_.trafficClass);
-  checkDocaError(err, "Failed to set traffic class");
-
-  err = doca_verbs_ah_attr_set_sl(ahAttr_, config_.serviceLevel);
-  checkDocaError(err, "Failed to set service level");
 }
 
 void MultipeerIbgdaTransport::allocateResources() {
@@ -367,7 +417,7 @@ void MultipeerIbgdaTransport::registerMemory() {
   int accessFlags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE |
       IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_ATOMIC;
 
-  // Register sink buffer as a zero-based MR (iova=0).
+  // Register sink buffer as a zero-based MR (iova=0) on each NIC's PD.
   //
   // The sink buffer receives the discarded return value from RDMA atomic
   // fetch-add operations. Device code uses sinkAddr.addr=0 with the sink
@@ -379,38 +429,49 @@ void MultipeerIbgdaTransport::registerMemory() {
   // error → QP error state → hang.
   //
   // ibv_reg_mr_iova2(pd, addr, length, iova=0, access) creates a zero-based
-  // MR where IOVA range [0, length) maps to [addr, addr+length). This
-  // matches GIN's gdakiRegMr() pattern (gin_host_gdaki.cc).
-  auto sinkDmabuf =
-      export_gpu_dmabuf_aligned(docaGpu_, sinkBuffer_, sinkBufferSize_);
-  if (sinkDmabuf) {
-    // ibv_reg_dmabuf_mr: 4th param is iova — set to 0 for zero-based MR
-    sinkMr_ = lazy_ibv_reg_dmabuf_mr(
-        ibvPd_,
-        sinkDmabuf->alignment.dmabufOffset,
-        sinkBufferSize_,
-        0, // iova=0: zero-based MR
-        sinkDmabuf->fd,
-        accessFlags);
-    close(sinkDmabuf->fd);
-  }
-  if (!sinkMr_) {
-    // Fallback: use ibv_reg_mr_iova2 with iova=0 for zero-based MR
-    sinkMr_ = lazy_ibv_reg_mr_iova2(
-        ibvPd_, sinkBuffer_, sinkBufferSize_, 0, accessFlags);
-    if (!sinkMr_) {
-      throw std::runtime_error("Failed to register sink memory region");
+  // MR where IOVA range [0, length) maps to [addr, addr+length). Matches
+  // GIN's gdakiRegMr() pattern (gin_host_gdaki.cc).
+  //
+  // Multi-NIC: the same physical sink buffer is registered once per PD
+  // (one MR per NIC). DMABUF export is shared across NICs (same fd
+  // re-imported per PD); on first dmabuf failure we fall back to plain
+  // ibv_reg_mr_iova2 across the remaining NICs to keep behavior consistent.
+  for (int n = 0; n < numNics_; ++n) {
+    auto sinkDmabuf =
+        export_gpu_dmabuf_aligned(docaGpu_, sinkBuffer_, sinkBufferSize_);
+    if (sinkDmabuf) {
+      nicDevices_[n].sinkMr = lazy_ibv_reg_dmabuf_mr(
+          nicDevices_[n].ibvPd,
+          sinkDmabuf->alignment.dmabufOffset,
+          sinkBufferSize_,
+          0, // iova=0: zero-based MR
+          sinkDmabuf->fd,
+          accessFlags);
+      close(sinkDmabuf->fd);
     }
-  }
+    if (!nicDevices_[n].sinkMr) {
+      nicDevices_[n].sinkMr = lazy_ibv_reg_mr_iova2(
+          nicDevices_[n].ibvPd, sinkBuffer_, sinkBufferSize_, 0, accessFlags);
+      if (!nicDevices_[n].sinkMr) {
+        throw std::runtime_error(
+            "Failed to register sink memory region on NIC " +
+            std::to_string(n));
+      }
+    }
 
-  VLOG(1) << "MultipeerIbgdaTransport: registered sink buffer"
-          << " lkey=" << sinkMr_->lkey << " (zero-based MR, iova=0)";
+    VLOG(1) << "MultipeerIbgdaTransport: NIC " << n
+            << " sink lkey=" << nicDevices_[n].sinkMr->lkey
+            << " (zero-based MR, iova=0)";
+  }
 }
 void MultipeerIbgdaTransport::createQpGroups() {
   const int numPeers = nRanks_ - 1;
   const int numQps = config_.numQpsPerPeer;
-  const int totalQpGroups = numPeers * numQps;
-  qpGroupHlList_.resize(totalQpGroups, nullptr);
+  const int totalQpsPerPeer = numNics_ * numQps;
+  const int totalQpGroups = numPeers * totalQpsPerPeer;
+  for (auto& nic : nicDevices_) {
+    nic.qpGroups.assign(numPeers * numQps, nullptr);
+  }
 
   // Verify CUDA device is still set correctly
   int currentDevice = -1;
@@ -423,45 +484,50 @@ void MultipeerIbgdaTransport::createQpGroups() {
   VLOG(1) << "MultipeerIbgdaTransport::createQpGroups: current CUDA device="
           << currentDevice << " expected=" << config_.cudaDevice;
 
-  // Query IB device capabilities for debugging
+  // Query IB device capabilities for debugging (NIC 0 is representative).
   ibv_device_attr devAttr{};
-  if (doca_verbs_wrapper_ibv_query_device(ibvCtx_, &devAttr) == DOCA_SUCCESS) {
+  if (doca_verbs_wrapper_ibv_query_device(nicDevices_[0].ibvCtx, &devAttr) ==
+      DOCA_SUCCESS) {
     VLOG(1) << "MultipeerIbgdaTransport: IB device - max_qp=" << devAttr.max_qp
             << " max_cq=" << devAttr.max_cq << " max_mr=" << devAttr.max_mr
             << " max_qp_wr=" << devAttr.max_qp_wr;
   }
 
-  doca_gpu_verbs_qp_init_attr_hl initAttr{};
-  initAttr.gpu_dev = docaGpu_;
-  initAttr.ibpd = ibvPd_;
-  initAttr.sq_nwqe = config_.qpDepth;
-  initAttr.nic_handler = DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO;
-  initAttr.mreg_type = DOCA_GPUNETIO_VERBS_MEM_REG_TYPE_DEFAULT;
-
   VLOG(1) << "MultipeerIbgdaTransport: creating " << totalQpGroups
-          << " QP groups (" << numQps << " per peer, " << numPeers
+          << " QP groups (" << totalQpsPerPeer << " slots/peer = " << numNics_
+          << " NICs × " << numQps << " QPs, " << numPeers
           << " peers) gpu_dev=" << (void*)docaGpu_
-          << " ibpd=" << (void*)initAttr.ibpd << " sq_nwqe=" << config_.qpDepth
+          << " sq_nwqe=" << config_.qpDepth
           << " nic_handler=AUTO mreg_type=DEFAULT";
 
-  for (int peer = 0; peer < numPeers; peer++) {
-    for (int q = 0; q < numQps; q++) {
-      int idx = peer * numQps + q;
-      doca_error_t err =
-          doca_gpu_verbs_create_qp_group_hl(&initAttr, &qpGroupHlList_[idx]);
-      if (err != DOCA_SUCCESS) {
-        LOG(ERROR) << "MultipeerIbgdaTransport: QP group " << idx
-                   << " (peer=" << peer << " qp=" << q
-                   << ") creation failed: " << docaErrorToString(err)
-                   << " (code " << (int)err << ")";
-        checkDocaError(err, "Failed to create QP group");
-      }
+  for (int nic = 0; nic < numNics_; nic++) {
+    doca_gpu_verbs_qp_init_attr_hl initAttr{};
+    initAttr.gpu_dev = docaGpu_;
+    initAttr.ibpd = nicDevices_[nic].ibvPd;
+    initAttr.sq_nwqe = config_.qpDepth;
+    initAttr.nic_handler = DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO;
+    initAttr.mreg_type = DOCA_GPUNETIO_VERBS_MEM_REG_TYPE_DEFAULT;
 
-      VLOG(1) << "MultipeerIbgdaTransport: created QP group " << idx
-              << " (peer=" << peer << " qp=" << q << ") main_qpn="
-              << doca_verbs_qp_get_qpn(qpGroupHlList_[idx]->qp_main.qp)
-              << " companion_qpn="
-              << doca_verbs_qp_get_qpn(qpGroupHlList_[idx]->qp_companion.qp);
+    auto& nicQps = nicDevices_[nic].qpGroups;
+    for (int peer = 0; peer < numPeers; peer++) {
+      for (int q = 0; q < numQps; q++) {
+        const int qpIdx = peer * numQps + q;
+        doca_error_t err =
+            doca_gpu_verbs_create_qp_group_hl(&initAttr, &nicQps[qpIdx]);
+        if (err != DOCA_SUCCESS) {
+          LOG(ERROR) << "MultipeerIbgdaTransport: QP group (nic=" << nic
+                     << " peer=" << peer << " q=" << q
+                     << ") creation failed: " << docaErrorToString(err)
+                     << " (code " << (int)err << ")";
+          checkDocaError(err, "Failed to create QP group");
+        }
+
+        VLOG(1) << "MultipeerIbgdaTransport: created QP group (nic=" << nic
+                << " peer=" << peer << " q=" << q << ") main_qpn="
+                << doca_verbs_qp_get_qpn(nicQps[qpIdx]->qp_main.qp)
+                << " companion_qpn="
+                << doca_verbs_qp_get_qpn(nicQps[qpIdx]->qp_companion.qp);
+      }
     }
   }
 }
@@ -469,55 +535,66 @@ void MultipeerIbgdaTransport::createQpGroups() {
 void MultipeerIbgdaTransport::createLoopbackCompanionQps() {
   const int numPeers = nRanks_ - 1;
   const int numQps = config_.numQpsPerPeer;
-  const int totalLoopback = numPeers * numQps;
-  // Create one self-loop responder companion QP per QP group.
-  // These are passive endpoints connected to the active companion QPs
-  // (from the QP groups) to form loopback pairs for counter atomics.
-  loopbackCompanionQpHlList_.resize(totalLoopback, nullptr);
+  // One self-loop responder companion QP per QP group, on the SAME NIC's
+  // PD as the active companion (loopback only works within a single NIC).
+  for (auto& nic : nicDevices_) {
+    nic.loopbackCompanionQps.assign(numPeers * numQps, nullptr);
+  }
 
-  doca_gpu_verbs_qp_init_attr_hl initAttr{};
-  initAttr.gpu_dev = docaGpu_;
-  initAttr.ibpd = ibvPd_;
-  initAttr.sq_nwqe = kCompanionQpDepth;
-  initAttr.nic_handler = DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO;
-  initAttr.mreg_type = DOCA_GPUNETIO_VERBS_MEM_REG_TYPE_DEFAULT;
+  VLOG(1) << "MultipeerIbgdaTransport: creating "
+          << numNics_ * numPeers * numQps
+          << " loopback companion QPs with depth=" << kCompanionQpDepth;
 
-  VLOG(1) << "MultipeerIbgdaTransport: creating " << totalLoopback
-          << " loopback companion QPs (" << numQps
-          << " per peer) with depth=" << kCompanionQpDepth;
+  for (int nic = 0; nic < numNics_; nic++) {
+    doca_gpu_verbs_qp_init_attr_hl initAttr{};
+    initAttr.gpu_dev = docaGpu_;
+    initAttr.ibpd = nicDevices_[nic].ibvPd;
+    initAttr.sq_nwqe = kCompanionQpDepth;
+    initAttr.nic_handler = DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO;
+    initAttr.mreg_type = DOCA_GPUNETIO_VERBS_MEM_REG_TYPE_DEFAULT;
 
-  for (int i = 0; i < totalLoopback; i++) {
-    doca_error_t err =
-        doca_gpu_verbs_create_qp_hl(&initAttr, &loopbackCompanionQpHlList_[i]);
-    if (err != DOCA_SUCCESS) {
-      LOG(ERROR) << "MultipeerIbgdaTransport: loopback companion QP " << i
-                 << " creation failed: " << docaErrorToString(err) << " (code "
-                 << (int)err << ")";
-      checkDocaError(err, "Failed to create loopback companion QP");
+    auto& nicLoopback = nicDevices_[nic].loopbackCompanionQps;
+    for (int peer = 0; peer < numPeers; peer++) {
+      for (int q = 0; q < numQps; q++) {
+        const int qpIdx = peer * numQps + q;
+        doca_error_t err =
+            doca_gpu_verbs_create_qp_hl(&initAttr, &nicLoopback[qpIdx]);
+        if (err != DOCA_SUCCESS) {
+          LOG(ERROR) << "MultipeerIbgdaTransport: loopback companion QP (nic="
+                     << nic << " peer=" << peer << " q=" << q
+                     << ") creation failed: " << docaErrorToString(err)
+                     << " (code " << (int)err << ")";
+          checkDocaError(err, "Failed to create loopback companion QP");
+        }
+
+        VLOG(1) << "MultipeerIbgdaTransport: created loopback companion QP "
+                   "(nic="
+                << nic << " peer=" << peer << " q=" << q
+                << ") qpn=" << doca_verbs_qp_get_qpn(nicLoopback[qpIdx]->qp);
+      }
     }
-
-    VLOG(1) << "MultipeerIbgdaTransport: created loopback companion QP " << i
-            << " qpn="
-            << doca_verbs_qp_get_qpn(loopbackCompanionQpHlList_[i]->qp);
   }
 }
 
 void MultipeerIbgdaTransport::connectQp(
     doca_gpu_verbs_qp_hl* qpHl,
-    const IbgdaTransportExchInfo& peerInfo) {
-  // Set remote GID in AH attributes
+    const IbgdaTransportExchInfo& peerInfo,
+    int nic) {
+  // Set remote GID in AH attributes (per-NIC: each local NIC has its own
+  // AH attr, modified in-place per connection target).
   doca_verbs_gid remoteGid{};
   memcpy(remoteGid.raw, peerInfo.gid, sizeof(remoteGid.raw));
-  doca_error_t err = doca_verbs_ah_attr_set_gid(ahAttr_, remoteGid);
+  doca_error_t err =
+      doca_verbs_ah_attr_set_gid(nicDevices_[nic].ahAttr, remoteGid);
   checkDocaError(err, "Failed to set remote GID");
 
   // Query port for IB-specific parameters
   ibv_port_attr portAttr{};
-  if (doca_verbs_wrapper_ibv_query_port(ibvCtx_, 1, &portAttr) !=
-      DOCA_SUCCESS) {
+  if (doca_verbs_wrapper_ibv_query_port(
+          nicDevices_[nic].ibvCtx, 1, &portAttr) != DOCA_SUCCESS) {
     LOG(WARNING) << "Failed to query port for IB-specific parameters";
   } else if (portAttr.link_layer == IBV_LINK_LAYER_INFINIBAND) {
-    err = doca_verbs_ah_attr_set_dlid(ahAttr_, peerInfo.lid);
+    err = doca_verbs_ah_attr_set_dlid(nicDevices_[nic].ahAttr, peerInfo.lid);
     checkDocaError(err, "Failed to set DLID");
   }
 
@@ -562,7 +639,7 @@ void MultipeerIbgdaTransport::connectQp(
     checkDocaError(err, "Failed to set RQ PSN");
     err = doca_verbs_qp_attr_set_dest_qp_num(qpAttr, peerInfo.qpn);
     checkDocaError(err, "Failed to set dest QP number");
-    err = doca_verbs_qp_attr_set_ah_attr(qpAttr, ahAttr_);
+    err = doca_verbs_qp_attr_set_ah_attr(qpAttr, nicDevices_[nic].ahAttr);
     checkDocaError(err, "Failed to set AH attributes");
     err = doca_verbs_qp_attr_set_min_rnr_timer(qpAttr, config_.minRnrTimer);
     checkDocaError(err, "Failed to set min RNR timer");
@@ -698,21 +775,21 @@ void MultipeerIbgdaTransport::cleanup() {
   // Free tile sendrecv buffers
   cleanup_send_recv_buffers();
 
-  // Destroy QP groups (main + companion)
-  for (auto* qpGroup : qpGroupHlList_) {
-    if (qpGroup != nullptr) {
-      doca_gpu_verbs_destroy_qp_group_hl(qpGroup);
+  // Destroy per-NIC QP groups (main + companion) and loopback responders.
+  for (auto& nic : nicDevices_) {
+    for (auto* qpGroup : nic.qpGroups) {
+      if (qpGroup != nullptr) {
+        doca_gpu_verbs_destroy_qp_group_hl(qpGroup);
+      }
     }
-  }
-  qpGroupHlList_.clear();
-
-  // Destroy loopback companion QPs
-  for (auto* qpHl : loopbackCompanionQpHlList_) {
-    if (qpHl != nullptr) {
-      doca_gpu_verbs_destroy_qp_hl(qpHl);
+    nic.qpGroups.clear();
+    for (auto* qpHl : nic.loopbackCompanionQps) {
+      if (qpHl != nullptr) {
+        doca_gpu_verbs_destroy_qp_hl(qpHl);
+      }
     }
+    nic.loopbackCompanionQps.clear();
   }
-  loopbackCompanionQpHlList_.clear();
 
   // Deregister and free transport-owned signal/counter buffers.
   // MRs must be deregistered BEFORE cudaFree (correct RDMA teardown order).
@@ -740,17 +817,26 @@ void MultipeerIbgdaTransport::cleanup() {
 
   // Destroy user buffer MRs
   for (auto& [_, cached] : registeredBuffers_) {
-    doca_verbs_wrapper_ibv_dereg_mr(cached.mr);
+    // numNics_=1 today; loop is the multi-NIC-ready shape (P2.x fills the
+    // rest of mrs[]).
+    for (int n = 0; n < numNics_; ++n) {
+      doca_verbs_wrapper_ibv_dereg_mr(cached.mrs[n]);
+    }
   }
   registeredBuffers_.clear();
 
-  // Destroy sink MR
-  if (sinkMr_) {
-    doca_verbs_wrapper_ibv_dereg_mr(sinkMr_);
-    sinkMr_ = nullptr;
+  // Destroy per-NIC sink MRs. Iterate over actual nicDevices_ entries
+  // (vector is empty if cleanup runs before openIbDevice; partial init leaves
+  // unset fields as nullptr).
+  for (int n = 0; n < static_cast<int>(nicDevices_.size()); ++n) {
+    if (nicDevices_[n].sinkMr != nullptr) {
+      doca_verbs_wrapper_ibv_dereg_mr(nicDevices_[n].sinkMr);
+      nicDevices_[n].sinkMr = nullptr;
+    }
   }
 
-  // Free sink buffer (cuMem-allocated with gpuDirectRDMACapable)
+  // Free sink buffer (cuMem-allocated with gpuDirectRDMACapable). Shared
+  // across NICs — only one allocation, freed after all per-NIC MRs.
   if (sinkBuffer_ != nullptr) {
     auto devPtr = reinterpret_cast<CUdeviceptr>(sinkBuffer_);
     pfn_cuMemUnmap(devPtr, sinkBufferAllocSize_);
@@ -760,22 +846,28 @@ void MultipeerIbgdaTransport::cleanup() {
     sinkBuffer_ = nullptr;
   }
 
-  // Destroy AH attributes
-  if (ahAttr_ != nullptr) {
-    doca_verbs_ah_attr_destroy(ahAttr_);
-    ahAttr_ = nullptr;
+  // Destroy per-NIC AH attributes
+  for (int n = 0; n < static_cast<int>(nicDevices_.size()); ++n) {
+    if (nicDevices_[n].ahAttr != nullptr) {
+      doca_verbs_ah_attr_destroy(nicDevices_[n].ahAttr);
+      nicDevices_[n].ahAttr = nullptr;
+    }
   }
 
-  // Destroy PD
-  if (ibvPd_) {
-    doca_verbs_wrapper_ibv_dealloc_pd(ibvPd_);
-    ibvPd_ = nullptr;
+  // Destroy per-NIC PDs
+  for (int n = 0; n < static_cast<int>(nicDevices_.size()); ++n) {
+    if (nicDevices_[n].ibvPd != nullptr) {
+      doca_verbs_wrapper_ibv_dealloc_pd(nicDevices_[n].ibvPd);
+      nicDevices_[n].ibvPd = nullptr;
+    }
   }
 
-  // Close device
-  if (ibvCtx_) {
-    doca_verbs_wrapper_ibv_close_device(ibvCtx_);
-    ibvCtx_ = nullptr;
+  // Close per-NIC devices
+  for (int n = 0; n < static_cast<int>(nicDevices_.size()); ++n) {
+    if (nicDevices_[n].ibvCtx != nullptr) {
+      doca_verbs_wrapper_ibv_close_device(nicDevices_[n].ibvCtx);
+      nicDevices_[n].ibvCtx = nullptr;
+    }
   }
 
   // Destroy DOCA GPU context
@@ -801,35 +893,47 @@ void MultipeerIbgdaTransport::exchange() {
   // Build local exchange info for allGather
   std::vector<IbgdaTransportExchInfoAll> allInfo(nRanks_);
 
-  // Fill in my info at my rank's slot
+  // Fill in my info at my rank's slot. Per-NIC GID/LID land in nicInfo[n];
+  // gidIndex + MTU are common across NICs (same fabric/HCA generation in
+  // multi-NIC platforms).
   IbgdaTransportExchInfoAll& myInfo = allInfo[myRank_];
-  memcpy(myInfo.gid, localGid_.raw, sizeof(myInfo.gid));
   myInfo.gidIndex = gidIndex_;
   myInfo.mtu = localMtu_;
-  myInfo.numQpsPerPeer = numQps;
-
-  // Query port for LID (IB only)
-  ibv_port_attr exchPortAttr{};
-  if (doca_verbs_wrapper_ibv_query_port(ibvCtx_, 1, &exchPortAttr) !=
-      DOCA_SUCCESS) {
-    LOG(WARNING) << "Failed to query port for LID";
-  } else {
-    myInfo.lid = exchPortAttr.lid;
+  myInfo.numNics = numNics_;
+  myInfo.numQpsPerNic = numQps;
+  for (int n = 0; n < numNics_; ++n) {
+    memcpy(
+        myInfo.nicInfo[n].gid,
+        nicDevices_[n].localGid.raw,
+        sizeof(myInfo.nicInfo[n].gid));
+    // Query NIC n's port for LID (IB only — RoCE leaves LID as 0).
+    ibv_port_attr exchPortAttr{};
+    if (doca_verbs_wrapper_ibv_query_port(
+            nicDevices_[n].ibvCtx, 1, &exchPortAttr) != DOCA_SUCCESS) {
+      LOG(WARNING) << "Failed to query port for LID on NIC " << n;
+    } else {
+      myInfo.nicInfo[n].lid = exchPortAttr.lid;
+    }
   }
 
-  // Fill in per-target QPNs (N QPNs per peer)
-  // qpnForRank[j][q] = QPN of q-th QP I use to connect to rank j
+  // Fill in per-target QPNs for every (nic, q). NIC-fast interleaving:
+  // slot s = q * numNics_ + nic.
+  const int totalQpsPerPeer = numNics_ * numQps;
   for (int peerIndex = 0; peerIndex < numPeers; peerIndex++) {
-    int peerRank = peerIndexToRank(peerIndex);
-    for (int q = 0; q < numQps; q++) {
-      int idx = peerIndex * numQps + q;
-      myInfo.qpnForRank[peerRank][q] =
-          doca_verbs_qp_get_qpn(qpGroupHlList_[idx]->qp_main.qp);
+    const int peerRank = peerIndexToRank(peerIndex);
+    for (int nic = 0; nic < numNics_; nic++) {
+      const auto& nicQps = nicDevices_[nic].qpGroups;
+      for (int q = 0; q < numQps; q++) {
+        const int qpIdx = peerIndex * numQps + q;
+        myInfo.nicInfo[nic].qpnForRank[peerRank][q] =
+            doca_verbs_qp_get_qpn(nicQps[qpIdx]->qp_main.qp);
+      }
     }
   }
 
   VLOG(1) << "MultipeerIbgdaTransport: rank " << myRank_
-          << " performing allGather exchange (" << numQps << " QPs/peer)";
+          << " performing allGather exchange (" << totalQpsPerPeer
+          << " slots/peer = " << numNics_ << " NICs × " << numQps << " QPs)";
 
   // Use allGather to exchange transport info with all ranks
   auto result = bootstrap_
@@ -844,74 +948,112 @@ void MultipeerIbgdaTransport::exchange() {
         "MultipeerIbgdaTransport::exchange allGather failed");
   }
 
-  // Convert allGather results to per-peer IbgdaTransportExchInfo
-  // For multi-QP, we extract N QPNs per peer
+  // Validate every peer's numNics matches mine — same-rail pairing relies
+  // on the symmetric (myRank+peerRank) % numNics offset, which only makes
+  // sense when both sides agree on numNics.
+  for (int peerIndex = 0; peerIndex < numPeers; peerIndex++) {
+    const int peerRank = peerIndexToRank(peerIndex);
+    const auto& peerInfo = allInfo[peerRank];
+    if (peerInfo.numNics != numNics_) {
+      throw std::runtime_error(
+          fmt::format(
+              "Peer rank {} reports numNics={} but my numNics={}; all ranks "
+              "must agree on numNics for same-rail pairing",
+              peerRank,
+              peerInfo.numNics,
+              numNics_));
+    }
+  }
+
+  // Stash per-peer summary info (slot 0 / NIC 0) for retrospect/debug.
+  // Per-slot connection info is computed inline in the connect loop below.
   peerExchInfo_.resize(numPeers);
   for (int peerIndex = 0; peerIndex < numPeers; peerIndex++) {
     int peerRank = peerIndexToRank(peerIndex);
     const IbgdaTransportExchInfoAll& peerInfo = allInfo[peerRank];
 
-    CHECK_EQ(peerInfo.numQpsPerPeer, numQps)
-        << "Rank " << peerRank
-        << " has numQpsPerPeer=" << peerInfo.numQpsPerPeer << " but local rank "
-        << myRank_ << " has " << numQps
-        << ". All ranks must use the same numQpsPerPeer.";
+    CHECK_EQ(peerInfo.numQpsPerNic, numQps)
+        << "Rank " << peerRank << " has numQpsPerNic=" << peerInfo.numQpsPerNic
+        << " but local rank " << myRank_ << " has " << numQps
+        << ". All ranks must use the same numQpsPerNic.";
 
     // Store common connection info (from QP 0 — same GID/LID for all QPs)
-    peerExchInfo_[peerIndex].qpn = peerInfo.qpnForRank[myRank_][0];
-    memcpy(peerExchInfo_[peerIndex].gid, peerInfo.gid, sizeof(peerInfo.gid));
+    peerExchInfo_[peerIndex].qpn = peerInfo.nicInfo[0].qpnForRank[myRank_][0];
+    memcpy(
+        peerExchInfo_[peerIndex].gid,
+        peerInfo.nicInfo[0].gid,
+        sizeof(peerInfo.nicInfo[0].gid));
     peerExchInfo_[peerIndex].gidIndex = peerInfo.gidIndex;
-    peerExchInfo_[peerIndex].lid = peerInfo.lid;
+    peerExchInfo_[peerIndex].lid = peerInfo.nicInfo[0].lid;
     peerExchInfo_[peerIndex].mtu = peerInfo.mtu;
 
     VLOG(1) << "MultipeerIbgdaTransport: received from peer " << peerRank
-            << " numQps=" << peerInfo.numQpsPerPeer
-            << " qpn[0]=" << peerExchInfo_[peerIndex].qpn;
+            << " numNics=" << peerInfo.numNics
+            << " numQps=" << peerInfo.numQpsPerNic
+            << " slot0_qpn=" << peerExchInfo_[peerIndex].qpn;
   }
 
-  // Connect main QPs to peers (N QPs per peer)
+  // Connect main QPs to peers — same-rail pairing: my (nic, q) for peer P
+  // talks to P's (nic, q) for me. NIC-fast interleaving: slot s = q * numNics_
+  // + nic.
   for (int peerIndex = 0; peerIndex < numPeers; peerIndex++) {
-    int peerRank = peerIndexToRank(peerIndex);
-    const IbgdaTransportExchInfoAll& peerInfo = allInfo[peerRank];
+    const IbgdaTransportExchInfoAll& peerInfo =
+        allInfo[peerIndexToRank(peerIndex)];
 
-    for (int q = 0; q < numQps; q++) {
-      int idx = peerIndex * numQps + q;
-      IbgdaTransportExchInfo qpPeerInfo = peerExchInfo_[peerIndex];
-      qpPeerInfo.qpn = peerInfo.qpnForRank[myRank_][q];
-      connectQp(&qpGroupHlList_[idx]->qp_main, qpPeerInfo);
+    for (int nic = 0; nic < numNics_; nic++) {
+      auto& nicQps = nicDevices_[nic].qpGroups;
+      for (int q = 0; q < numQps; q++) {
+        const int qpIdx = peerIndex * numQps + q;
+        IbgdaTransportExchInfo qpPeerInfo;
+        qpPeerInfo.qpn = peerInfo.nicInfo[nic].qpnForRank[myRank_][q];
+        memcpy(
+            qpPeerInfo.gid, peerInfo.nicInfo[nic].gid, sizeof(qpPeerInfo.gid));
+        qpPeerInfo.gidIndex = peerInfo.gidIndex;
+        qpPeerInfo.lid = peerInfo.nicInfo[nic].lid;
+        qpPeerInfo.mtu = peerInfo.mtu;
+        connectQp(&nicQps[qpIdx]->qp_main, qpPeerInfo, nic);
+      }
     }
   }
 
-  // Connect companion QPs as loopback pairs on the local NIC.
-  // N loopback pairs per peer (one per QP group).
+  // Connect companion QPs as loopback pairs — each slot's companion QP
+  // must loopback within the same NIC's PD (loopback can't cross PDs).
   {
-    IbgdaTransportExchInfo selfInfo{};
-    memcpy(selfInfo.gid, localGid_.raw, sizeof(selfInfo.gid));
-    selfInfo.gidIndex = gidIndex_;
-    selfInfo.mtu = localMtu_;
-
-    ibv_port_attr loopbackPortAttr{};
-    if (doca_verbs_wrapper_ibv_query_port(ibvCtx_, 1, &loopbackPortAttr) ==
-        DOCA_SUCCESS) {
-      selfInfo.lid = loopbackPortAttr.lid;
+    std::vector<IbgdaTransportExchInfo> selfInfoPerNic(numNics_);
+    for (int n = 0; n < numNics_; ++n) {
+      memcpy(
+          selfInfoPerNic[n].gid,
+          nicDevices_[n].localGid.raw,
+          sizeof(selfInfoPerNic[n].gid));
+      selfInfoPerNic[n].gidIndex = gidIndex_;
+      selfInfoPerNic[n].mtu = localMtu_;
+      ibv_port_attr loopbackPortAttr{};
+      if (doca_verbs_wrapper_ibv_query_port(
+              nicDevices_[n].ibvCtx, 1, &loopbackPortAttr) == DOCA_SUCCESS) {
+        selfInfoPerNic[n].lid = loopbackPortAttr.lid;
+      }
     }
 
-    for (int peer = 0; peer < numPeers; peer++) {
-      for (int q = 0; q < numQps; q++) {
-        int idx = peer * numQps + q;
-        // Connect active companion → loopback responder
-        selfInfo.qpn =
-            doca_verbs_qp_get_qpn(loopbackCompanionQpHlList_[idx]->qp);
-        connectQp(&qpGroupHlList_[idx]->qp_companion, selfInfo);
+    for (int nic = 0; nic < numNics_; nic++) {
+      auto& nicQps = nicDevices_[nic].qpGroups;
+      auto& nicLoopback = nicDevices_[nic].loopbackCompanionQps;
+      for (int peer = 0; peer < numPeers; peer++) {
+        for (int q = 0; q < numQps; q++) {
+          const int qpIdx = peer * numQps + q;
+          IbgdaTransportExchInfo selfInfo = selfInfoPerNic[nic];
 
-        // Connect loopback responder → active companion
-        selfInfo.qpn =
-            doca_verbs_qp_get_qpn(qpGroupHlList_[idx]->qp_companion.qp);
-        connectQp(loopbackCompanionQpHlList_[idx], selfInfo);
+          // Connect active companion → loopback responder
+          selfInfo.qpn = doca_verbs_qp_get_qpn(nicLoopback[qpIdx]->qp);
+          connectQp(&nicQps[qpIdx]->qp_companion, selfInfo, nic);
 
-        VLOG(1)
-            << "MultipeerIbgdaTransport: connected companion QP loopback pair "
-            << idx << " (peer=" << peer << " qp=" << q << ")";
+          // Connect loopback responder → active companion
+          selfInfo.qpn = doca_verbs_qp_get_qpn(nicQps[qpIdx]->qp_companion.qp);
+          connectQp(nicLoopback[qpIdx], selfInfo, nic);
+
+          VLOG(1) << "MultipeerIbgdaTransport: connected companion QP loopback "
+                     "pair (nic="
+                  << nic << " peer=" << peer << " q=" << q << ")";
+        }
       }
     }
   }
@@ -1046,33 +1188,36 @@ void MultipeerIbgdaTransport::exchange() {
 
   exchange_send_recv_buffers();
 
-  // Build device transports on GPU. Collect host-side QP handles,
-  // then let buildDeviceTransportsOnGpu handle all GPU allocation + memcpy.
-  // Single-NIC: numNics=1 (default), sinkLkeys[0] = sink lkey, sinkLkeys[1]
-  // unused (never read since active_nic() returns 0 at numNics=1).
-  // Multi-NIC plumbing (numNics > 1, nicSlotMap, nicToSlot, per-NIC sinkLkeys)
-  // lands in Group 1's MultipeerIbgdaTransport.cc rewrite.
-  const NetworkLKey sinkLkey(HostLKey(sinkMr_->lkey));
+  // Build device transports on GPU. One NicDeviceIbgdaResourcesBuildSpec
+  // per (peer, NIC) carries that NIC's QP pointers and sink lkey.
   std::vector<P2pIbgdaTransportBuildParams> buildParams(numPeers);
 
   for (int peer = 0; peer < numPeers; peer++) {
-    buildParams[peer].h_nicDeviceIbgdaResources.resize(1);
-    auto& nicSpec = buildParams[peer].h_nicDeviceIbgdaResources[0];
-    nicSpec.qps.resize(numQps);
-    nicSpec.companionQps.resize(numQps);
-    nicSpec.sinkLkey = sinkLkey;
-    nicSpec.deviceId = 0;
+    // One NicDeviceIbgdaResourcesBuildSpec per physical NIC. NIC-fast
+    // interleaving: slot s = q * numNics_ + nic.
+    auto& bp = buildParams[peer];
+    bp.h_nicDeviceIbgdaResources.resize(numNics_);
+    for (int n = 0; n < numNics_; ++n) {
+      auto& nicSpec = bp.h_nicDeviceIbgdaResources[n];
+      nicSpec.qps.resize(numQps);
+      nicSpec.companionQps.resize(numQps);
+      nicSpec.sinkLkey = NetworkLKey(HostLKey(nicDevices_[n].sinkMr->lkey));
+      nicSpec.deviceId = n;
+    }
 
-    for (int q = 0; q < numQps; q++) {
-      int idx = peer * numQps + q;
-      doca_error_t err = doca_gpu_verbs_get_qp_dev(
-          qpGroupHlList_[idx]->qp_main.qp_gverbs, &nicSpec.qps[q]);
-      checkDocaError(err, "Failed to get GPU QP handle");
+    for (int nic = 0; nic < numNics_; nic++) {
+      auto& nicQps = nicDevices_[nic].qpGroups;
+      auto& nicSpec = bp.h_nicDeviceIbgdaResources[nic];
+      for (int q = 0; q < numQps; q++) {
+        const int qpIdx = peer * numQps + q;
+        doca_error_t err = doca_gpu_verbs_get_qp_dev(
+            nicQps[qpIdx]->qp_main.qp_gverbs, &nicSpec.qps[q]);
+        checkDocaError(err, "Failed to get GPU QP handle");
 
-      err = doca_gpu_verbs_get_qp_dev(
-          qpGroupHlList_[idx]->qp_companion.qp_gverbs,
-          &nicSpec.companionQps[q]);
-      checkDocaError(err, "Failed to get companion GPU QP handle");
+        err = doca_gpu_verbs_get_qp_dev(
+            nicQps[qpIdx]->qp_companion.qp_gverbs, &nicSpec.companionQps[q]);
+        checkDocaError(err, "Failed to get companion GPU QP handle");
+      }
     }
 
     if (config_.numSignalSlots > 0) {
@@ -1123,7 +1268,8 @@ MultipeerIbgdaDeviceTransport MultipeerIbgdaTransport::getDeviceTransport()
 P2pIbgdaTransportDevice* MultipeerIbgdaTransport::getP2pTransportDevice(
     int peerRank) const {
   int peerIndex = rankToPeerIndex(peerRank);
-  // Use byte-level arithmetic since P2pIbgdaTransportDevice is incomplete here
+  // Use byte-level arithmetic since P2pIbgdaTransportDevice is incomplete
+  // here
   return reinterpret_cast<P2pIbgdaTransportDevice*>(
       reinterpret_cast<char*>(peerTransportsGpu_) +
       peerIndex * peerTransportSize_);
@@ -1158,8 +1304,8 @@ IbgdaLocalBuffer MultipeerIbgdaTransport::registerBuffer(
   }
 
   // Fast path: containment lookup — if [ptr, ptr+size) falls entirely
-  // within an existing registration, return the cached lkey without any
-  // CUDA driver call.
+  // within an existing registration, return the cached per-NIC lkeys
+  // without any CUDA driver call.
   auto addr = reinterpret_cast<uintptr_t>(ptr);
   auto it = registeredBuffers_.upper_bound(addr);
   if (it != registeredBuffers_.begin()) {
@@ -1169,11 +1315,17 @@ IbgdaLocalBuffer MultipeerIbgdaTransport::registerBuffer(
       VLOG(1) << "MultipeerIbgdaTransport: cache hit for ptr=" << ptr
               << " allocBase=0x" << std::hex << it->first << std::dec
               << " refs=" << it->second.refs;
-      return IbgdaLocalBuffer(ptr, NetworkLKeys{HostLKey(it->second.mr->lkey)});
+      NetworkLKeys keys(numNics_);
+      for (int n = 0; n < numNics_; ++n) {
+        keys[n] = NetworkLKey(HostLKey(it->second.mrs[n]->lkey));
+      }
+      return IbgdaLocalBuffer(ptr, keys);
     }
   }
 
-  // Cache miss — find the CUDA allocation base and register it.
+  // Cache miss — find the CUDA allocation base and register it on every
+  // NIC's PD. Each NIC gets an independent MR over the same physical
+  // memory; lkey/rkey differ per NIC.
   CUdeviceptr allocBase = 0;
   size_t allocSize = 0;
   CUresult cuRes =
@@ -1185,42 +1337,60 @@ IbgdaLocalBuffer MultipeerIbgdaTransport::registerBuffer(
   int accessFlags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE |
       IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_ATOMIC;
 
-  // Try DMABUF registration first, fall back to regular reg_mr.
-  // export_gpu_dmabuf_aligned handles page alignment + doca_gpu_dmabuf_fd.
-  ibv_mr* mr = nullptr;
-  auto dmabuf = export_gpu_dmabuf_aligned(
-      docaGpu_, reinterpret_cast<void*>(allocBase), allocSize);
-  if (dmabuf) {
-    mr = lazy_ibv_reg_dmabuf_mr(
-        ibvPd_,
-        dmabuf->alignment.dmabufOffset,
-        allocSize,
-        static_cast<uint64_t>(allocBase),
-        dmabuf->fd,
-        accessFlags);
-    close(dmabuf->fd);
-  }
-  if (!mr) {
-    doca_error_t regErr = doca_verbs_wrapper_ibv_reg_mr(
-        ibvPd_,
-        reinterpret_cast<void*>(allocBase),
-        allocSize,
-        accessFlags,
-        &mr);
-    if (regErr != DOCA_SUCCESS || !mr) {
-      throw std::runtime_error("Failed to register buffer with RDMA");
-    }
-  }
+  CachedMr cached;
+  cached.allocSize = allocSize;
+  cached.refs = 1;
 
-  registeredBuffers_.emplace(
-      static_cast<uintptr_t>(allocBase), CachedMr{mr, allocSize, /*refs=*/1});
+  // Try DMABUF first per NIC, fall back to plain reg_mr per NIC. If any
+  // NIC's registration fails, deregister everything we already registered
+  // and propagate the error.
+  for (int n = 0; n < numNics_; ++n) {
+    ibv_mr* mr = nullptr;
+    auto dmabuf = export_gpu_dmabuf_aligned(
+        docaGpu_, reinterpret_cast<void*>(allocBase), allocSize);
+    if (dmabuf) {
+      mr = lazy_ibv_reg_dmabuf_mr(
+          nicDevices_[n].ibvPd,
+          dmabuf->alignment.dmabufOffset,
+          allocSize,
+          static_cast<uint64_t>(allocBase),
+          dmabuf->fd,
+          accessFlags);
+      close(dmabuf->fd);
+    }
+    if (!mr) {
+      doca_error_t regErr = doca_verbs_wrapper_ibv_reg_mr(
+          nicDevices_[n].ibvPd,
+          reinterpret_cast<void*>(allocBase),
+          allocSize,
+          accessFlags,
+          &mr);
+      if (regErr != DOCA_SUCCESS || !mr) {
+        // Roll back partial registration before throwing.
+        for (int j = 0; j < n; ++j) {
+          doca_verbs_wrapper_ibv_dereg_mr(cached.mrs[j]);
+        }
+        throw std::runtime_error(
+            "Failed to register buffer with RDMA on NIC " + std::to_string(n));
+      }
+    }
+    cached.mrs[n] = mr;
+  }
 
   VLOG(1) << "MultipeerIbgdaTransport: registered allocation allocBase=0x"
           << std::hex << allocBase << std::dec << " allocSize=" << allocSize
-          << " lkey=" << mr->lkey << " rkey=" << mr->rkey
-          << " (requested ptr=" << ptr << " size=" << size << ")";
+          << " across " << numNics_
+          << " NIC(s) (NIC0 lkey=" << cached.mrs[0]->lkey
+          << " rkey=" << cached.mrs[0]->rkey << ", requested ptr=" << ptr
+          << " size=" << size << ")";
 
-  return IbgdaLocalBuffer(ptr, NetworkLKeys{HostLKey(mr->lkey)});
+  registeredBuffers_.emplace(static_cast<uintptr_t>(allocBase), cached);
+
+  NetworkLKeys keys(numNics_);
+  for (int n = 0; n < numNics_; ++n) {
+    keys[n] = NetworkLKey(HostLKey(cached.mrs[n]->lkey));
+  }
+  return IbgdaLocalBuffer(ptr, keys);
 }
 
 void MultipeerIbgdaTransport::deregisterBuffer(void* ptr) {
@@ -1238,7 +1408,9 @@ void MultipeerIbgdaTransport::deregisterBuffer(void* ptr) {
               << " allocBase=0x" << std::hex << it->first << std::dec
               << " refs=" << it->second.refs;
       if (it->second.refs <= 0) {
-        doca_verbs_wrapper_ibv_dereg_mr(it->second.mr);
+        for (int n = 0; n < numNics_; ++n) {
+          doca_verbs_wrapper_ibv_dereg_mr(it->second.mrs[n]);
+        }
         registeredBuffers_.erase(it);
       }
       return;
@@ -1266,14 +1438,16 @@ std::vector<IbgdaRemoteBuffer> MultipeerIbgdaTransport::exchangeBuffer(
         "Buffer not registered - call registerBuffer() first");
   }
 
-  // Allocate buffer for allGather: one entry per rank
+  // Allocate buffer for allGather: one entry per rank.
   std::vector<IbgdaBufferExchInfo> allInfo(nRanks_);
 
-  // Write my info at my rank's slot
-  allInfo[myRank_] = IbgdaBufferExchInfo{
-      reinterpret_cast<uint64_t>(localBuf.ptr),
-      HostRKey(it->second.mr->rkey),
-  };
+  // Write my info at my rank's slot — populate per-NIC rkeys (each PD
+  // gave us its own MR for the same physical buffer).
+  allInfo[myRank_].addr = reinterpret_cast<uint64_t>(localBuf.ptr);
+  allInfo[myRank_].numNics = numNics_;
+  for (int n = 0; n < numNics_; ++n) {
+    allInfo[myRank_].rkey_per_device[n] = HostRKey(it->second.mrs[n]->rkey);
+  }
 
   // Use allGather to exchange buffer info with all ranks
   auto result =
@@ -1288,7 +1462,8 @@ std::vector<IbgdaRemoteBuffer> MultipeerIbgdaTransport::exchangeBuffer(
 
   // Convert to IbgdaRemoteBuffer vector, extracting peer entries
   // peerIndex maps to ranks: 0..myRank_-1 -> ranks 0..myRank_-1
-  //                          myRank_..numPeers-1 -> ranks myRank_+1..nRanks_-1
+  //                          myRank_..numPeers-1 -> ranks
+  //                          myRank_+1..nRanks_-1
   std::vector<IbgdaRemoteBuffer> peerBuffers(numPeers);
   for (int peerIndex = 0; peerIndex < numPeers; peerIndex++) {
     int peerRank = peerIndexToRank(peerIndex);

--- a/comms/pipes/MultipeerIbgdaTransport.cc
+++ b/comms/pipes/MultipeerIbgdaTransport.cc
@@ -1046,24 +1046,32 @@ void MultipeerIbgdaTransport::exchange() {
 
   exchange_send_recv_buffers();
 
+  // Build device transports on GPU. Collect host-side QP handles,
+  // then let buildDeviceTransportsOnGpu handle all GPU allocation + memcpy.
+  // Single-NIC: numNics=1 (default), sinkLkeys[0] = sink lkey, sinkLkeys[1]
+  // unused (never read since active_nic() returns 0 at numNics=1).
+  // Multi-NIC plumbing (numNics > 1, nicSlotMap, nicToSlot, per-NIC sinkLkeys)
+  // lands in Group 1's MultipeerIbgdaTransport.cc rewrite.
   const NetworkLKey sinkLkey(HostLKey(sinkMr_->lkey));
   std::vector<P2pIbgdaTransportBuildParams> buildParams(numPeers);
 
   for (int peer = 0; peer < numPeers; peer++) {
-    buildParams[peer].mainQps.resize(numQps);
-    buildParams[peer].companionQps.resize(numQps);
-    buildParams[peer].sinkLkey = sinkLkey;
+    buildParams[peer].h_nicDeviceIbgdaResources.resize(1);
+    auto& nicSpec = buildParams[peer].h_nicDeviceIbgdaResources[0];
+    nicSpec.qps.resize(numQps);
+    nicSpec.companionQps.resize(numQps);
+    nicSpec.sinkLkey = sinkLkey;
+    nicSpec.deviceId = 0;
 
     for (int q = 0; q < numQps; q++) {
       int idx = peer * numQps + q;
       doca_error_t err = doca_gpu_verbs_get_qp_dev(
-          qpGroupHlList_[idx]->qp_main.qp_gverbs,
-          &buildParams[peer].mainQps[q]);
+          qpGroupHlList_[idx]->qp_main.qp_gverbs, &nicSpec.qps[q]);
       checkDocaError(err, "Failed to get GPU QP handle");
 
       err = doca_gpu_verbs_get_qp_dev(
           qpGroupHlList_[idx]->qp_companion.qp_gverbs,
-          &buildParams[peer].companionQps[q]);
+          &nicSpec.companionQps[q]);
       checkDocaError(err, "Failed to get companion GPU QP handle");
     }
 

--- a/comms/pipes/MultipeerIbgdaTransport.cc
+++ b/comms/pipes/MultipeerIbgdaTransport.cc
@@ -1161,7 +1161,7 @@ IbgdaLocalBuffer MultipeerIbgdaTransport::registerBuffer(
       VLOG(1) << "MultipeerIbgdaTransport: cache hit for ptr=" << ptr
               << " allocBase=0x" << std::hex << it->first << std::dec
               << " refs=" << it->second.refs;
-      return IbgdaLocalBuffer(ptr, HostLKey(it->second.mr->lkey));
+      return IbgdaLocalBuffer(ptr, NetworkLKeys{HostLKey(it->second.mr->lkey)});
     }
   }
 
@@ -1212,7 +1212,7 @@ IbgdaLocalBuffer MultipeerIbgdaTransport::registerBuffer(
           << " lkey=" << mr->lkey << " rkey=" << mr->rkey
           << " (requested ptr=" << ptr << " size=" << size << ")";
 
-  return IbgdaLocalBuffer(ptr, HostLKey(mr->lkey));
+  return IbgdaLocalBuffer(ptr, NetworkLKeys{HostLKey(mr->lkey)});
 }
 
 void MultipeerIbgdaTransport::deregisterBuffer(void* ptr) {
@@ -1360,16 +1360,16 @@ void MultipeerIbgdaTransport::allocate_send_recv_buffers() {
     auto& pb = sendRecvPeerBuffers_[i];
     pb.sendStaging = IbgdaLocalBuffer{
         static_cast<char*>(sendStagingBulk_->get()) + i * stagingPerPeer,
-        sendStagingBulkReg.lkey};
+        sendStagingBulkReg.lkey_per_device};
     pb.recvStaging = IbgdaLocalBuffer{
         static_cast<char*>(recvStagingBulk_->get()) + i * stagingPerPeer,
-        recvStagingBulkReg_.lkey};
+        recvStagingBulkReg_.lkey_per_device};
     pb.signal = IbgdaLocalBuffer{
         static_cast<char*>(signalBulk_->get()) + i * signalPerPeer,
-        signalBulkReg_.lkey};
+        signalBulkReg_.lkey_per_device};
     pb.counter = IbgdaLocalBuffer{
         static_cast<char*>(counterBulk_->get()) + i * counterPerPeer,
-        counterBulkReg.lkey};
+        counterBulkReg.lkey_per_device};
     pb.stepState = reinterpret_cast<int64_t*>(
         static_cast<char*>(stepStateBulk_->get()) + i * stepStatePerPeer);
   }

--- a/comms/pipes/MultipeerIbgdaTransport.h
+++ b/comms/pipes/MultipeerIbgdaTransport.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <map>
 #include <memory>
@@ -196,26 +197,34 @@ constexpr int kMaxQpsPerPeer = 128;
 /**
  * Transport exchange info for allGather-based exchange.
  *
- * Each rank contributes this structure containing:
- * - Common connection info (GID, lid) shared with all peers
- * - Per-target QPNs: qpnForRank[j] = QPN this rank uses to connect to rank j
+ * Each rank contributes this structure containing per-NIC GID/LID and the
+ * per-(target_rank, q) QPN this rank uses on that NIC.
  */
 struct IbgdaTransportExchInfoAll {
-  // Common info (same for all connections from this rank)
-  uint8_t gid[16]{};
-  int gidIndex{0};
-  uint16_t lid{0};
+  // Per-NIC public info shared with peers (wire format). nicInfo[n] holds
+  // this rank's NIC n's GID, LID, and the QPNs it uses to connect to each
+  // (target_rank, q). Indices [numNics .. kMaxNicsPerGpu) are zero-init and
+  // never read by peers (both ranks must agree on numNics — validated at
+  // exchange time).
+  struct NicWireInfo {
+    uint8_t gid[16]{};
+    uint16_t lid{0};
+    // QPN this rank uses on this NIC to connect to (target_rank, q).
+    // qpnForRank[myRank][*] is unused (set to 0).
+    uint32_t qpnForRank[kMaxRanksForAllGather][kMaxQpsPerPeer]{};
+  };
+  NicWireInfo nicInfo[kMaxNicsPerGpu]{};
 
-  // Port active MTU.
+  // Common (shared across NICs on this rank).
+  int gidIndex{0};
   enum ibv_mtu mtu { IBV_MTU_4096 };
 
-  // Number of QPs per peer used by this rank
-  int numQpsPerPeer{1};
+  // Number of NICs (rails) used by this rank.
+  // Must match across all ranks (validated at exchange time).
+  int numNics{1};
 
-  // Per-target-rank QPNs
-  // qpnForRank[j][q] = QPN of q-th QP that this rank uses to connect to rank j
-  // qpnForRank[myRank][*] is unused (set to 0)
-  uint32_t qpnForRank[kMaxRanksForAllGather][kMaxQpsPerPeer]{};
+  // Number of QPs per (peer, NIC) used by this rank.
+  int numQpsPerNic{1};
 };
 
 /**
@@ -418,9 +427,13 @@ class MultipeerIbgdaTransport {
   void exchange_send_recv_buffers();
   void cleanup_send_recv_buffers();
   void cleanup();
+  // Connect a QP to a peer (or self for loopback). The nic argument selects
+  // which local NIC's AH attrs / port to use; the peerInfo carries the
+  // remote-side GID / LID / qpn. At numNics_=1 nic is always 0.
   void connectQp(
       doca_gpu_verbs_qp_hl* qpHl,
-      const IbgdaTransportExchInfo& peerInfo);
+      const IbgdaTransportExchInfo& peerInfo,
+      int nic);
   int rankToPeerIndex(int rank) const;
   int peerIndexToRank(int peerIndex) const;
 
@@ -434,23 +447,26 @@ class MultipeerIbgdaTransport {
   // Configuration
   MultipeerIbgdaTransportConfig config_;
 
-  // DOCA GPU context
+  // DOCA GPU context (shared across NICs).
   doca_gpu* docaGpu_{nullptr};
 
-  // IB verbs resources (raw rdma-core)
-  ibv_context* ibvCtx_{nullptr};
-  ibv_pd* ibvPd_{nullptr};
-  doca_verbs_ah_attr* ahAttr_{nullptr};
-  union ibv_gid localGid_{};
+  // Number of NICs (rails) actually in use. <= kMaxNicsPerGpu.
+  // nicDevices_.size() == numNics_ after openIbDevice().
+  int numNics_{1};
 
-  // QP groups (one per peer): main QP + companion QP with shared UAR.
-  // The companion QP is created with core_direct=true (required for WAIT WQE).
-  std::vector<doca_gpu_verbs_qp_group_hl*> qpGroupHlList_;
-
-  // Self-loop responder companion QPs (one per peer, passive endpoints)
-  // These are connected to the active companion QPs in each group,
-  // forming loopback pairs for counter-based completion tracking.
-  std::vector<doca_gpu_verbs_qp_hl*> loopbackCompanionQpHlList_;
+  // Per-NIC host-side IB verbs resources. qpGroups and loopbackCompanionQps
+  // are indexed [peer * numQpsPerPeer + q].
+  struct NicHostIbgdaResources {
+    std::string deviceName;
+    ibv_context* ibvCtx{nullptr};
+    ibv_pd* ibvPd{nullptr};
+    doca_verbs_ah_attr* ahAttr{nullptr};
+    union ibv_gid localGid{};
+    ibv_mr* sinkMr{nullptr};
+    std::vector<doca_gpu_verbs_qp_group_hl*> qpGroups;
+    std::vector<doca_gpu_verbs_qp_hl*> loopbackCompanionQps;
+  };
+  std::vector<NicHostIbgdaResources> nicDevices_;
 
   // Sink buffer for RDMA atomic return values (discarded).
   // DOCA's OPCODE_ATOMIC_FA requires a local address for the fetch-add
@@ -461,14 +477,14 @@ class MultipeerIbgdaTransport {
   std::size_t sinkBufferSize_{0};
   std::size_t sinkBufferAllocSize_{0};
   std::uint64_t sinkBufferHandle_{0};
-  ibv_mr* sinkMr_{nullptr};
 
-  // Cached MR entry: one MR per CUDA allocation, refcounted.
-  // Multiple user buffers within the same cudaMalloc allocation share one MR.
+  // Cached MR entry: one MR per (CUDA allocation, NIC), refcounted.
+  // Multiple user buffers within the same cudaMalloc allocation share one
+  // MR per NIC; the MR set covers all NICs for the same physical buffer.
   struct CachedMr {
-    ibv_mr* mr;
-    size_t allocSize;
-    int refs;
+    std::array<ibv_mr*, kMaxNicsPerGpu> mrs{};
+    size_t allocSize{0};
+    int refs{0};
   };
 
   // Maps CUDA allocation base address -> cached MR covering the full
@@ -479,10 +495,11 @@ class MultipeerIbgdaTransport {
   // the memory).
   std::map<uintptr_t, CachedMr> registeredBuffers_;
 
-  // GPU PCIe bus ID and NIC device name
+  // GPU PCIe bus ID.
   std::string gpuPciBusId_;
-  std::string nicDeviceName_;
-  int gidIndex_{3}; // Default GID index
+  // GID index + active MTU are common across NICs (same config knob, same
+  // fabric/HCA generation in multi-NIC platforms like GB200/GB300).
+  int gidIndex_{3};
   enum ibv_mtu localMtu_ { IBV_MTU_4096 };
 
   // Per-peer device transports (GPU accessible)

--- a/comms/pipes/MultipeerIbgdaTransportCuda.cu
+++ b/comms/pipes/MultipeerIbgdaTransportCuda.cu
@@ -5,6 +5,8 @@
 #include <cuda_runtime.h>
 #include <glog/logging.h>
 
+#include <cstring>
+
 #include "comms/pipes/P2pIbgdaTransportDevice.cuh"
 
 namespace comms::pipes {
@@ -13,50 +15,111 @@ P2pIbgdaTransportDevice* buildDeviceTransportsOnGpu(
     const std::vector<P2pIbgdaTransportBuildParams>& params,
     int numPeers,
     std::vector<void*>& outGpuAllocations) {
-  // All peers must have the same numQps
-  int numQps = static_cast<int>(params[0].mainQps.size());
-  std::size_t arraySize = numQps * sizeof(doca_gpu_dev_verbs_qp*);
-
-  // 1. Allocate one contiguous GPU buffer for all QP pointer arrays:
-  //    [peer0_main][peer0_comp][peer1_main][peer1_comp]...
-  std::size_t totalArraySize = numPeers * 2 * arraySize;
-  char* d_allArrays = nullptr;
-  cudaError_t err = cudaMalloc(&d_allArrays, totalArraySize);
-  CHECK(err == cudaSuccess)
-      << "Failed to allocate GPU QP arrays: " << cudaGetErrorString(err);
-  outGpuAllocations.push_back(d_allArrays);
-
-  // Build contiguous host buffer with all QP pointer arrays
-  std::vector<doca_gpu_dev_verbs_qp*> hostArrays;
-  hostArrays.reserve(numPeers * 2 * numQps);
+  // All peers must have the same shape: same numNics, and same per-NIC QP
+  // counts. Take peer 0's layout as canonical and validate the rest.
+  CHECK(!params.empty() && !params[0].h_nicDeviceIbgdaResources.empty())
+      << "buildDeviceTransportsOnGpu: empty params or zero NICs";
+  int numNics = static_cast<int>(params[0].h_nicDeviceIbgdaResources.size());
+  int qpsPerNic =
+      static_cast<int>(params[0].h_nicDeviceIbgdaResources[0].qps.size());
   for (int i = 0; i < numPeers; ++i) {
-    hostArrays.insert(
-        hostArrays.end(), params[i].mainQps.begin(), params[i].mainQps.end());
-    hostArrays.insert(
-        hostArrays.end(),
-        params[i].companionQps.begin(),
-        params[i].companionQps.end());
+    CHECK_EQ(
+        static_cast<int>(params[i].h_nicDeviceIbgdaResources.size()), numNics)
+        << "All peers must have the same numNics";
+    for (int n = 0; n < numNics; ++n) {
+      CHECK_EQ(
+          static_cast<int>(params[i].h_nicDeviceIbgdaResources[n].qps.size()),
+          qpsPerNic)
+          << "All peers' NICs must have the same QP count";
+      CHECK_EQ(
+          static_cast<int>(
+              params[i].h_nicDeviceIbgdaResources[n].companionQps.size()),
+          qpsPerNic)
+          << "qps and companionQps must match per NIC";
+    }
   }
 
-  // One memcpy for all QP pointer arrays
-  err = cudaMemcpy(
-      d_allArrays, hostArrays.data(), totalArraySize, cudaMemcpyHostToDevice);
+  // Each NIC has two QP kinds packed back-to-back: primary + companion.
+  constexpr int kQpKindsPerNic = 2;
+
+  // 1. Allocate one contiguous GPU buffer for all QP pointer arrays.
+  //    Layout per peer: [nic0_main][nic0_comp][nic1_main][nic1_comp]...
+  //    Total: numPeers * numNics * kQpKindsPerNic * qpsPerNic pointers.
+  std::size_t qpsPerPeer =
+      static_cast<std::size_t>(kQpKindsPerNic) * numNics * qpsPerNic;
+  std::size_t totalQpBytes =
+      numPeers * qpsPerPeer * sizeof(doca_gpu_dev_verbs_qp*);
+  doca_gpu_dev_verbs_qp** d_allQps = nullptr;
+  cudaError_t err = cudaMalloc(&d_allQps, totalQpBytes);
+  CHECK(err == cudaSuccess)
+      << "Failed to allocate GPU QP arrays: " << cudaGetErrorString(err);
+  outGpuAllocations.push_back(d_allQps);
+
+  std::vector<doca_gpu_dev_verbs_qp*> h_qps;
+  h_qps.reserve(numPeers * qpsPerPeer);
+  for (int i = 0; i < numPeers; ++i) {
+    for (int n = 0; n < numNics; ++n) {
+      const auto& nicSpec = params[i].h_nicDeviceIbgdaResources[n];
+      h_qps.insert(h_qps.end(), nicSpec.qps.begin(), nicSpec.qps.end());
+      h_qps.insert(
+          h_qps.end(),
+          nicSpec.companionQps.begin(),
+          nicSpec.companionQps.end());
+    }
+  }
+  err =
+      cudaMemcpy(d_allQps, h_qps.data(), totalQpBytes, cudaMemcpyHostToDevice);
   CHECK(err == cudaSuccess)
       << "Failed to copy QP arrays to GPU: " << cudaGetErrorString(err);
 
-  // 2. Build transport objects pointing into the contiguous GPU buffer
-  //    Each peer gets 2 * numQps entries: [main QPs][companion QPs]
-  auto* basePtr = reinterpret_cast<doca_gpu_dev_verbs_qp**>(d_allArrays);
-  std::vector<P2pIbgdaTransportDevice> hostTransports;
-  hostTransports.reserve(numPeers);
+  // 2. Allocate one contiguous GPU buffer for all NicDeviceIbgdaResources
+  // structs:
+  //    [peer0_nic0..nicN-1][peer1_nic0..nicN-1]...
+  std::size_t totalNicBytes =
+      numPeers * numNics * sizeof(NicDeviceIbgdaResources);
+  NicDeviceIbgdaResources* d_allNicResources = nullptr;
+  err = cudaMalloc(&d_allNicResources, totalNicBytes);
+  CHECK(err == cudaSuccess)
+      << "Failed to allocate GPU NicDeviceIbgdaResources array: "
+      << cudaGetErrorString(err);
+  outGpuAllocations.push_back(d_allNicResources);
 
+  std::vector<NicDeviceIbgdaResources> h_nicResources;
+  h_nicResources.reserve(numPeers * numNics);
   for (int i = 0; i < numPeers; ++i) {
-    auto* d_mainQps = basePtr + (i * 2 * numQps);
-    auto* d_companionQps = basePtr + (i * 2 * numQps + numQps);
-    hostTransports.emplace_back(
-        DeviceSpan<doca_gpu_dev_verbs_qp*>(d_mainQps, numQps),
-        DeviceSpan<doca_gpu_dev_verbs_qp*>(d_companionQps, numQps),
-        params[i].sinkLkey,
+    for (int n = 0; n < numNics; ++n) {
+      // QP pointers for this peer/NIC start at offset:
+      //   (i * qpsPerPeer) + (n * kQpKindsPerNic * qpsPerNic) within d_allQps.
+      auto* d_mainQps =
+          d_allQps + (i * qpsPerPeer) + (n * kQpKindsPerNic * qpsPerNic);
+      auto* d_companionQps = d_mainQps + qpsPerNic;
+      h_nicResources.push_back(
+          NicDeviceIbgdaResources{
+              DeviceSpan<doca_gpu_dev_verbs_qp*>(d_mainQps, qpsPerNic),
+              DeviceSpan<doca_gpu_dev_verbs_qp*>(d_companionQps, qpsPerNic),
+              params[i].h_nicDeviceIbgdaResources[n].sinkLkey,
+              params[i].h_nicDeviceIbgdaResources[n].deviceId,
+          });
+    }
+  }
+  err = cudaMemcpy(
+      d_allNicResources,
+      h_nicResources.data(),
+      totalNicBytes,
+      cudaMemcpyHostToDevice);
+  CHECK(err == cudaSuccess)
+      << "Failed to copy NicDeviceIbgdaResources array to GPU: "
+      << cudaGetErrorString(err);
+
+  // 3. Build transport objects pointing into the contiguous
+  // NicDeviceIbgdaResources array.
+  std::vector<P2pIbgdaTransportDevice> h_transports;
+  h_transports.reserve(numPeers);
+  for (int i = 0; i < numPeers; ++i) {
+    NicDeviceIbgdaResources* d_peerNicResources =
+        d_allNicResources + i * numNics;
+    h_transports.emplace_back(
+        DeviceSpan<NicDeviceIbgdaResources>(d_peerNicResources, numNics),
         params[i].remoteSignalBuf,
         params[i].localSignalBuf,
         params[i].counterBuf,
@@ -66,7 +129,7 @@ P2pIbgdaTransportDevice* buildDeviceTransportsOnGpu(
         params[i].sendRecvState);
   }
 
-  // 3. Allocate and copy transport objects to GPU
+  // 4. Allocate and copy transport objects to GPU.
   P2pIbgdaTransportDevice* gpuPtr = nullptr;
   std::size_t transportSize = numPeers * sizeof(P2pIbgdaTransportDevice);
   err = cudaMalloc(&gpuPtr, transportSize);
@@ -74,7 +137,7 @@ P2pIbgdaTransportDevice* buildDeviceTransportsOnGpu(
                             << cudaGetErrorString(err);
   outGpuAllocations.push_back(gpuPtr); // track before memcpy for leak safety
   err = cudaMemcpy(
-      gpuPtr, hostTransports.data(), transportSize, cudaMemcpyHostToDevice);
+      gpuPtr, h_transports.data(), transportSize, cudaMemcpyHostToDevice);
   CHECK(err == cudaSuccess)
       << "Failed to copy device transports to GPU: " << cudaGetErrorString(err);
 

--- a/comms/pipes/MultipeerIbgdaTransportCuda.cuh
+++ b/comms/pipes/MultipeerIbgdaTransportCuda.cuh
@@ -3,9 +3,11 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <vector>
 
 #include "comms/pipes/IbgdaBuffer.h"
+#include "comms/pipes/rdma/NicConstants.h"
 
 // Forward declarations
 struct doca_gpu_dev_verbs_qp;
@@ -16,15 +18,34 @@ namespace comms::pipes {
 class P2pIbgdaTransportDevice;
 
 /**
+ * Per-NIC build spec for one peer's transport.
+ *
+ * Each entry corresponds to a physical NIC. The build function packs
+ * these into a GPU-resident DeviceSpan<NicDeviceIbgdaResources> for the device
+ * transport. Host callers are responsible for ordering the vector with
+ * peer-specific NIC rotation so device-side `nic_for_group(g) = g % numNics`
+ * produces balanced thread-per-peer scatter.
+ */
+struct NicDeviceIbgdaResourcesBuildSpec {
+  std::vector<doca_gpu_dev_verbs_qp*> qps; // primary QPs on this NIC
+  std::vector<doca_gpu_dev_verbs_qp*> companionQps; // companion QPs on this NIC
+  NetworkLKey sinkLkey{}; // sink lkey for this NIC's PD
+  int deviceId{0}; // physical NIC device id (informational)
+};
+
+/**
  * Parameters for building a single P2pIbgdaTransportDevice.
  *
- * Contains host-side vectors of QP pointers (one per QP set).
- * The build function handles copying these to GPU memory.
+ * The build function reads `nicResources` (one entry per NIC), copies QP
+ * pointers to GPU memory, and constructs a DeviceSpan<NicDeviceIbgdaResources>
+ * for the device transport.
+ *
+ * Single-NIC callers populate `nicResources` with one element.
+ * Multi-NIC callers populate `nicResources` with one element per NIC; qps and
+ * companionQps within a NicDeviceIbgdaResourcesBuildSpec must be the same size.
  */
 struct P2pIbgdaTransportBuildParams {
-  std::vector<doca_gpu_dev_verbs_qp*> mainQps;
-  std::vector<doca_gpu_dev_verbs_qp*> companionQps;
-  NetworkLKey sinkLkey{};
+  std::vector<NicDeviceIbgdaResourcesBuildSpec> h_nicDeviceIbgdaResources;
   IbgdaRemoteBuffer remoteSignalBuf{};
   IbgdaLocalBuffer localSignalBuf{};
   IbgdaLocalBuffer counterBuf{};

--- a/comms/pipes/P2pIbgdaTransportDevice.cuh
+++ b/comms/pipes/P2pIbgdaTransportDevice.cuh
@@ -49,6 +49,26 @@ inline constexpr uint64_t kDefaultDeviceTimeoutCycles = 10'000'000'000ULL;
 #endif
 
 /**
+ * NicDeviceIbgdaResources - Per-NIC bundle of QPs and sink lkey
+ *
+ * Owns the QPs (primary + companion for compound put+signal+counter ops)
+ * and the sink lkey for atomic FA responses on a single NIC. The
+ * P2pIbgdaTransportDevice holds a `DeviceSpan<NicDeviceIbgdaResources>` indexed
+ * by NIC slot (peer-rotated on the host side so that `nic_qp_for_group(g)`'s
+ * nic_id (= g % numNics) yields balanced per-peer scatter).
+ */
+struct NicDeviceIbgdaResources {
+  DeviceSpan<doca_gpu_dev_verbs_qp*> qps{};
+  DeviceSpan<doca_gpu_dev_verbs_qp*> companion_qps{};
+  NetworkLKey sink_lkey{};
+  int device_id{0};
+
+  __host__ __device__ int get_nic_id() const {
+    return device_id;
+  }
+};
+
+/**
  * P2pIbgdaTransportDevice - Device-side per-peer RDMA transport handle
  *
  * Every method has two overloads:
@@ -79,49 +99,51 @@ class P2pIbgdaTransportDevice {
  public:
   // Default ctor required so an array of these can be cudaMemcpy'd from host
   // (see MultipeerIbgdaTransportCuda.cu::buildDeviceTransportsOnGpu). Do not
-  // call methods on a default-constructed instance — qpArray_ is null.
+  // call methods on a default-constructed instance — nicDevices_ is empty.
   P2pIbgdaTransportDevice() = default;
 
   /**
    * Construct a per-peer device transport handle.
    *
-   * @param qpArray               GPU array of N primary QP pointers. WQEs for
-   *                              a block/group are posted to
-   *                              qpArray[group_id % numQps].
-   * @param companionArray        GPU array of N companion QP pointers for
-   *                              compound put+signal+counter ops. May be
-   *                              nullptr if counters are not used.
-   * @param numQps                Number of QPs in qpArray/companionArray.
-   * @param sinkLkey              LKey of a scratch buffer used as the atomic
-   *                              fetch-add response sink (value is discarded).
+   * Each P2p instance owns one peer's NICs. Each NicDeviceIbgdaResources
+   * carries its own primary and companion QPs and a sink lkey. The host-side
+   * builder is responsible for peer-rotating the NicDeviceIbgdaResources[]
+   * order so that `nic_qp_for_group(g)`'s nic_id (= g % nicDevices.size())
+   * produces balanced thread-per-peer scatter when nicDevices.size() > 1.
+   *
+   * Single-NIC usage: pass a 1-element nicDevices span. All ops fall through
+   * to NIC 0.
+   *
+   * @param nicDevices          GPU span of per-NIC bundles (length =
+   *                              numNics). Each NicDeviceIbgdaResources owns
+   *                              numQpsPerPeer primary + companion QP
+   *                              pointers and the per-NIC sink lkey.
    * @param ownedRemoteSignalBuf  Remote-side signal outbox: writing here
-   *                              targets the peer's local signal inbox. Used
-   *                              by the slot-index signal API.
+   *                              targets the peer's local signal inbox.
+   *                              Used by the slot-index signal API.
    * @param ownedLocalSignalBuf   Local signal inbox: receives signals from
    *                              the peer. Used by the slot-index
    *                              wait_signal/reset_signal/read_signal APIs.
    * @param ownedCounterBuf       Local counter buffer for compound
    *                              put+signal+counter and the slot-index
    *                              counter APIs. May be empty if not used.
+   * @param numSignalSlots        Number of uint64_t slots in the owned
+   *                              signal buffers. Used to bounds-check
+   *                              signalId. Zero disables the slot-index
+   *                              signal API.
+   * @param numCounterSlots       Number of uint64_t slots in the owned
+   *                              counter buffer. Zero disables the
+   *                              slot-index counter API.
    * @param discardSignalSlot     Remote uint64_t slot used as a "throwaway"
    *                              signal target for counter-only puts (see
    *                              put_impl for rationale). The peer never
    *                              reads this slot. Required when counter is
    *                              used; ignored otherwise.
-   * @param numSignalSlots        Number of uint64_t slots in the owned signal
-   *                              buffers. Used to bounds-check signalId
-   *                              args. Zero disables the slot-index signal
-   *                              API.
-   * @param numCounterSlots       Number of uint64_t slots in the owned
-   *                              counter buffer. Zero disables the
-   *                              slot-index counter API.
    * @param sendRecvState         Optional pipelined send/recv protocol state.
    *                              When empty, send()/recv() are unavailable.
    */
   __host__ __device__ P2pIbgdaTransportDevice(
-      DeviceSpan<doca_gpu_dev_verbs_qp*> qpArray,
-      DeviceSpan<doca_gpu_dev_verbs_qp*> companionArray,
-      NetworkLKey sinkLkey = NetworkLKey{},
+      DeviceSpan<NicDeviceIbgdaResources> nicDevices,
       IbgdaRemoteBuffer ownedRemoteSignalBuf = {},
       IbgdaLocalBuffer ownedLocalSignalBuf = {},
       IbgdaLocalBuffer ownedCounterBuf = {},
@@ -129,9 +151,7 @@ class P2pIbgdaTransportDevice {
       int numCounterSlots = 0,
       IbgdaRemoteBuffer discardSignalSlot = {},
       IbSendRecvState sendRecvState = {})
-      : qpArray_(qpArray),
-        companionArray_(companionArray),
-        sinkLkey_(sinkLkey),
+      : nicDevices_(nicDevices),
         ownedRemoteSignalBuf_(ownedRemoteSignalBuf),
         ownedLocalSignalBuf_(ownedLocalSignalBuf),
         ownedCounterBuf_(ownedCounterBuf),
@@ -760,9 +780,13 @@ class P2pIbgdaTransportDevice {
       return;
     }
 
+    auto idx = nic_qp_for_group(group.group_id);
+    const NicDeviceIbgdaResources& nic = nicDevices_[idx.nic_id];
+    auto* qp = nic.qps[idx.qp_id];
+
     // Guard: group_size must fit within QP send queue depth
     if (group.is_leader()) {
-      const uint16_t qp_depth = __ldg(&active_qp(group.group_id)->sq_wqe_num);
+      const uint16_t qp_depth = __ldg(&qp->sq_wqe_num);
       if (group.group_size > qp_depth) {
         printf(
             "[PIPES] FATAL: put group_size (%u) > QP depth (%u). "
@@ -778,27 +802,26 @@ class P2pIbgdaTransportDevice {
     uint64_t base_wqe_idx = 0;
     if (group.is_leader()) {
       base_wqe_idx = doca_gpu_dev_verbs_reserve_wq_slots<
-          DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(
-          active_qp(group.group_id), group.group_size);
+          DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(qp, group.group_size);
     }
     base_wqe_idx = group.broadcast<uint64_t>(base_wqe_idx);
 
     // Each thread prepares its WQE
     uint64_t wqe_idx = base_wqe_idx + group.thread_id_in_group;
     struct doca_gpu_dev_verbs_wqe* wqe_ptr =
-        doca_gpu_dev_verbs_get_wqe_ptr(active_qp(group.group_id), wqe_idx);
+        doca_gpu_dev_verbs_get_wqe_ptr(qp, wqe_idx);
 
     doca_gpu_dev_verbs_wqe_prepare_write(
-        active_qp(group.group_id),
+        qp,
         wqe_ptr,
         static_cast<uint16_t>(wqe_idx),
         DOCA_GPUNETIO_IB_MLX5_OPCODE_RDMA_WRITE,
         DOCA_GPUNETIO_IB_MLX5_WQE_CTRL_CQ_UPDATE,
         0,
         reinterpret_cast<uint64_t>(laneRemoteBuf.ptr),
-        laneRemoteBuf.rkey_per_device[0].value,
+        laneRemoteBuf.rkey_per_device[idx.nic_id].value,
         reinterpret_cast<uint64_t>(laneBuf.ptr),
-        laneBuf.lkey_per_device[0].value,
+        laneBuf.lkey_per_device[idx.nic_id].value,
         static_cast<uint32_t>(laneBytes));
 
     group.sync();
@@ -807,14 +830,12 @@ class P2pIbgdaTransportDevice {
     if (group.is_leader()) {
       doca_gpu_dev_verbs_mark_wqes_ready<
           DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(
-          active_qp(group.group_id),
-          base_wqe_idx,
-          base_wqe_idx + group.group_size - 1);
+          qp, base_wqe_idx, base_wqe_idx + group.group_size - 1);
       doca_gpu_dev_verbs_submit<
           DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
           DOCA_GPUNETIO_VERBS_SYNC_SCOPE_GPU,
           DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(
-          active_qp(group.group_id), base_wqe_idx + group.group_size);
+          qp, base_wqe_idx + group.group_size);
     }
 
     group.sync();
@@ -827,19 +848,21 @@ class P2pIbgdaTransportDevice {
       const IbgdaLocalBuffer& localBuf,
       const IbgdaRemoteBuffer& remoteBuf,
       std::size_t nbytes) {
+    auto idx = nic_qp_for_group(group_id);
+    const NicDeviceIbgdaResources& nic = nicDevices_[idx.nic_id];
     doca_gpu_dev_verbs_ticket_t ticket;
     doca_gpu_dev_verbs_addr localAddr = {
         .addr = reinterpret_cast<uint64_t>(localBuf.ptr),
-        .key = localBuf.lkey_per_device[0].value};
+        .key = localBuf.lkey_per_device[idx.nic_id].value};
     doca_gpu_dev_verbs_addr remoteAddr = {
         .addr = reinterpret_cast<uint64_t>(remoteBuf.ptr),
-        .key = remoteBuf.rkey_per_device[0].value};
+        .key = remoteBuf.rkey_per_device[idx.nic_id].value};
 
     doca_gpu_dev_verbs_put<
         DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
         DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO,
         DOCA_GPUNETIO_VERBS_EXEC_SCOPE_THREAD>(
-        active_qp(group_id), remoteAddr, localAddr, nbytes, &ticket);
+        nic.qps[idx.qp_id], remoteAddr, localAddr, nbytes, &ticket);
   }
 
   // --- signal_fenced: atomic fetch-add with NIC FENCE (always fenced) ---
@@ -848,11 +871,13 @@ class P2pIbgdaTransportDevice {
       uint32_t group_id,
       const IbgdaRemoteBuffer& signalBuf,
       uint64_t signalVal) {
-    doca_gpu_dev_verbs_qp* qp = active_qp(group_id);
+    auto idx = nic_qp_for_group(group_id);
+    const NicDeviceIbgdaResources& nic = nicDevices_[idx.nic_id];
+    doca_gpu_dev_verbs_qp* qp = nic.qps[idx.qp_id];
     doca_gpu_dev_verbs_addr remoteAddr = {
         .addr = reinterpret_cast<uint64_t>(signalBuf.ptr),
-        .key = signalBuf.rkey_per_device[0].value};
-    doca_gpu_dev_verbs_addr sinkAddr = {.addr = 0, .key = sinkLkey_.value};
+        .key = signalBuf.rkey_per_device[idx.nic_id].value};
+    doca_gpu_dev_verbs_addr sinkAddr = {.addr = 0, .key = nic.sink_lkey.value};
 
     uint64_t wqe_idx = doca_gpu_dev_verbs_reserve_wq_slots<
         DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(qp, 1);
@@ -893,26 +918,29 @@ class P2pIbgdaTransportDevice {
       uint64_t signalVal,
       const IbgdaLocalBuffer& counterBuf,
       uint64_t counterVal) {
+    auto idx = nic_qp_for_group(group_id);
+    const NicDeviceIbgdaResources& nic = nicDevices_[idx.nic_id];
     doca_gpu_dev_verbs_addr sigRemoteAddr = {
         .addr = reinterpret_cast<uint64_t>(signalBuf.ptr),
-        .key = signalBuf.rkey_per_device[0].value};
-    doca_gpu_dev_verbs_addr sigSinkAddr = {.addr = 0, .key = sinkLkey_.value};
+        .key = signalBuf.rkey_per_device[idx.nic_id].value};
+    doca_gpu_dev_verbs_addr sigSinkAddr = {
+        .addr = 0, .key = nic.sink_lkey.value};
 
     doca_gpu_dev_verbs_addr counterRemoteAddr = {
         .addr = reinterpret_cast<uint64_t>(counterBuf.ptr),
-        .key = counterBuf.lkey_per_device[0].value};
+        .key = counterBuf.lkey_per_device[idx.nic_id].value};
     doca_gpu_dev_verbs_addr counterSinkAddr = {
-        .addr = 0, .key = sinkLkey_.value};
+        .addr = 0, .key = nic.sink_lkey.value};
 
     doca_gpu_dev_verbs_signal_counter<
         DOCA_GPUNETIO_VERBS_SIGNAL_OP_ADD,
         DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
         DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(
-        active_qp(group_id),
+        nic.qps[idx.qp_id],
         sigRemoteAddr,
         sigSinkAddr,
         signalVal,
-        active_companion_qp(group_id),
+        nic.companion_qps[idx.qp_id],
         counterRemoteAddr,
         counterSinkAddr,
         counterVal);
@@ -1374,34 +1402,76 @@ class P2pIbgdaTransportDevice {
   }
 
  private:
+  struct NicQpIndex {
+    int nic_id;
+    int qp_id;
+  };
+
   /**
-   * active_qp - Select the QP for the calling group
+   * nic_qp_for_group - Single lookup: returns {nic_id, qp_id} for a group.
    *
-   * Maps group_id → QP via group_id % numQps_. Every leaf helper takes a
-   * group_id argument so that all WQEs belonging to one logical operation
-   * (e.g. put + signal_fenced inside put_impl) land on the same QP — this
-   * is required for the FENCE bit to actually order them. Thread-scope
-   * public methods pass 0.
+   * Round-robin over nicDevices_, then within the chosen NIC round-robin
+   * over its qps. All WQEs for one logical operation share the same
+   * group_id and therefore land on the same NIC + QP — required for the
+   * FENCE bit to order them. Host-side population is responsible for
+   * peer-rotating the NicDeviceIbgdaResources[] order so adjacent peers
+   * land on different NICs. Traps if nicDevices_ is empty or the chosen
+   * NIC has no qps (programming error: device op on a default-constructed
+   * transport).
    */
-  __device__ doca_gpu_dev_verbs_qp* active_qp(uint32_t group_id) const {
-    if (qpArray_.empty()) {
-      return nullptr;
+  __device__ NicQpIndex nic_qp_for_group(uint32_t group_id) const {
+    if (nicDevices_.empty()) {
+      printf(
+          "P2pIbgdaTransportDevice: nicDevices_ is empty at "
+          "%s:%d block=(%u,%u,%u) thread=(%u,%u,%u)\n",
+          __FILE__,
+          __LINE__,
+          blockIdx.x,
+          blockIdx.y,
+          blockIdx.z,
+          threadIdx.x,
+          threadIdx.y,
+          threadIdx.z);
+      __trap();
     }
-    return qpArray_[group_id % qpArray_.size()];
+    int nic_id = group_id % nicDevices_.size();
+    const auto& qps = nicDevices_[nic_id].qps;
+    if (qps.empty()) {
+      printf(
+          "P2pIbgdaTransportDevice: NIC %d has no qps at "
+          "%s:%d block=(%u,%u,%u) thread=(%u,%u,%u)\n",
+          nic_id,
+          __FILE__,
+          __LINE__,
+          blockIdx.x,
+          blockIdx.y,
+          blockIdx.z,
+          threadIdx.x,
+          threadIdx.y,
+          threadIdx.z);
+      __trap();
+    }
+    int qp_id = (group_id / nicDevices_.size()) % qps.size();
+    return {nic_id, qp_id};
+  }
+
+  __device__ doca_gpu_dev_verbs_qp* active_qp(uint32_t group_id) const {
+    auto idx = nic_qp_for_group(group_id);
+    return nicDevices_[idx.nic_id].qps[idx.qp_id];
   }
 
   __device__ doca_gpu_dev_verbs_qp* active_companion_qp(
       uint32_t group_id) const {
-    if (companionArray_.empty()) {
-      return nullptr;
-    }
-    return companionArray_[group_id % companionArray_.size()];
+    auto idx = nic_qp_for_group(group_id);
+    return nicDevices_[idx.nic_id].companion_qps[idx.qp_id];
   }
 
   // --- Members ---
-  DeviceSpan<doca_gpu_dev_verbs_qp*> qpArray_{};
-  DeviceSpan<doca_gpu_dev_verbs_qp*> companionArray_{};
-  NetworkLKey sinkLkey_{};
+  // Per-NIC bundles (qps + companion_qps + sink_lkey + device_id). Host-side
+  // builder peer-rotates the order so nic_qp_for_group(g)'s nic_id (= g %
+  // nicDevices_.size()) produces balanced scatter. At single-NIC:
+  // nicDevices_.size() == 1.
+  DeviceSpan<NicDeviceIbgdaResources> nicDevices_{};
 
   // Owned signal/counter buffers (set by transport during construction)
   IbgdaRemoteBuffer ownedRemoteSignalBuf_{}; // outbox: signal peer's inbox

--- a/comms/pipes/P2pIbgdaTransportDevice.cuh
+++ b/comms/pipes/P2pIbgdaTransportDevice.cuh
@@ -796,9 +796,9 @@ class P2pIbgdaTransportDevice {
         DOCA_GPUNETIO_IB_MLX5_WQE_CTRL_CQ_UPDATE,
         0,
         reinterpret_cast<uint64_t>(laneRemoteBuf.ptr),
-        laneRemoteBuf.rkey.value,
+        laneRemoteBuf.rkey_per_device[0].value,
         reinterpret_cast<uint64_t>(laneBuf.ptr),
-        laneBuf.lkey.value,
+        laneBuf.lkey_per_device[0].value,
         static_cast<uint32_t>(laneBytes));
 
     group.sync();
@@ -830,10 +830,10 @@ class P2pIbgdaTransportDevice {
     doca_gpu_dev_verbs_ticket_t ticket;
     doca_gpu_dev_verbs_addr localAddr = {
         .addr = reinterpret_cast<uint64_t>(localBuf.ptr),
-        .key = localBuf.lkey.value};
+        .key = localBuf.lkey_per_device[0].value};
     doca_gpu_dev_verbs_addr remoteAddr = {
         .addr = reinterpret_cast<uint64_t>(remoteBuf.ptr),
-        .key = remoteBuf.rkey.value};
+        .key = remoteBuf.rkey_per_device[0].value};
 
     doca_gpu_dev_verbs_put<
         DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
@@ -851,7 +851,7 @@ class P2pIbgdaTransportDevice {
     doca_gpu_dev_verbs_qp* qp = active_qp(group_id);
     doca_gpu_dev_verbs_addr remoteAddr = {
         .addr = reinterpret_cast<uint64_t>(signalBuf.ptr),
-        .key = signalBuf.rkey.value};
+        .key = signalBuf.rkey_per_device[0].value};
     doca_gpu_dev_verbs_addr sinkAddr = {.addr = 0, .key = sinkLkey_.value};
 
     uint64_t wqe_idx = doca_gpu_dev_verbs_reserve_wq_slots<
@@ -895,12 +895,12 @@ class P2pIbgdaTransportDevice {
       uint64_t counterVal) {
     doca_gpu_dev_verbs_addr sigRemoteAddr = {
         .addr = reinterpret_cast<uint64_t>(signalBuf.ptr),
-        .key = signalBuf.rkey.value};
+        .key = signalBuf.rkey_per_device[0].value};
     doca_gpu_dev_verbs_addr sigSinkAddr = {.addr = 0, .key = sinkLkey_.value};
 
     doca_gpu_dev_verbs_addr counterRemoteAddr = {
         .addr = reinterpret_cast<uint64_t>(counterBuf.ptr),
-        .key = counterBuf.lkey.value};
+        .key = counterBuf.lkey_per_device[0].value};
     doca_gpu_dev_verbs_addr counterSinkAddr = {
         .addr = 0, .key = sinkLkey_.value};
 
@@ -962,21 +962,21 @@ class P2pIbgdaTransportDevice {
     IBGDA_CHECK_SLOT_ID(id, numSignalSlots_, "signal");
     return IbgdaRemoteBuffer(
         static_cast<uint64_t*>(ownedRemoteSignalBuf_.ptr) + id,
-        ownedRemoteSignalBuf_.rkey);
+        ownedRemoteSignalBuf_.rkey_per_device);
   }
 
   __device__ IbgdaLocalBuffer local_signal_slot(int id) const {
     IBGDA_CHECK_SLOT_ID(id, numSignalSlots_, "signal");
     return IbgdaLocalBuffer(
         static_cast<uint64_t*>(ownedLocalSignalBuf_.ptr) + id,
-        ownedLocalSignalBuf_.lkey);
+        ownedLocalSignalBuf_.lkey_per_device);
   }
 
   __device__ IbgdaLocalBuffer counter_slot(int id) const {
     IBGDA_CHECK_SLOT_ID(id, numCounterSlots_, "counter");
     return IbgdaLocalBuffer(
         static_cast<uint64_t*>(ownedCounterBuf_.ptr) + id,
-        ownedCounterBuf_.lkey);
+        ownedCounterBuf_.lkey_per_device);
   }
 
  public:

--- a/comms/pipes/P2pIbgdaTransportDeviceAmd.h
+++ b/comms/pipes/P2pIbgdaTransportDeviceAmd.h
@@ -88,10 +88,10 @@ class P2pIbgdaTransportDeviceImpl {
 
     pipes_gda_gpu_dev_verbs_addr localAddr = {
         .addr = reinterpret_cast<uint64_t>(localBuf.ptr),
-        .key = localBuf.lkey.value};
+        .key = localBuf.lkey_per_device[0].value};
     pipes_gda_gpu_dev_verbs_addr remoteAddr = {
         .addr = reinterpret_cast<uint64_t>(remoteBuf.ptr),
-        .key = remoteBuf.rkey.value};
+        .key = remoteBuf.rkey_per_device[0].value};
 
     pipes_gda_gpu_dev_verbs_put(
         nic_, qp_, remoteAddr, localAddr, nbytes, &ticket);
@@ -256,7 +256,7 @@ class P2pIbgdaTransportDeviceImpl {
     pipes_gda_gpu_dev_verbs_addr remoteAddr = {
         .addr = reinterpret_cast<uint64_t>(
             static_cast<uint64_t*>(remoteSignalBuf.ptr) + signalId),
-        .key = remoteSignalBuf.rkey.value};
+        .key = remoteSignalBuf.rkey_per_device[0].value};
 
     pipes_gda_gpu_dev_verbs_p<uint64_t>(
         nic_, qp_, remoteAddr, static_cast<uint64_t>(0), &ticket);
@@ -279,7 +279,7 @@ class P2pIbgdaTransportDeviceImpl {
     pipes_gda_gpu_dev_verbs_addr remoteAddr = {
         .addr = reinterpret_cast<uint64_t>(
             static_cast<uint64_t*>(remoteBuf.ptr) + signalId),
-        .key = remoteBuf.rkey.value};
+        .key = remoteBuf.rkey_per_device[0].value};
     pipes_gda_gpu_dev_verbs_addr sinkAddr = {
         .addr = reinterpret_cast<uint64_t>(sinkBufPtr_),
         .key = sinkLkey_.value};
@@ -297,7 +297,7 @@ class P2pIbgdaTransportDeviceImpl {
     pipes_gda_gpu_dev_verbs_addr remoteAddr = {
         .addr = reinterpret_cast<uint64_t>(
             static_cast<uint64_t*>(remoteBuf.ptr) + signalId),
-        .key = remoteBuf.rkey.value};
+        .key = remoteBuf.rkey_per_device[0].value};
     pipes_gda_gpu_dev_verbs_addr sinkAddr = {
         .addr = reinterpret_cast<uint64_t>(sinkBufPtr_),
         .key = sinkLkey_.value};
@@ -339,22 +339,22 @@ class P2pIbgdaTransportDeviceImpl {
       uint64_t counterVal) {
     pipes_gda_gpu_dev_verbs_addr laddr = {
         .addr = reinterpret_cast<uint64_t>(localDataBuf.ptr),
-        .key = localDataBuf.lkey.value};
+        .key = localDataBuf.lkey_per_device[0].value};
     pipes_gda_gpu_dev_verbs_addr raddr = {
         .addr = reinterpret_cast<uint64_t>(remoteDataBuf.ptr),
-        .key = remoteDataBuf.rkey.value};
+        .key = remoteDataBuf.rkey_per_device[0].value};
 
     pipes_gda_gpu_dev_verbs_addr sigRemoteAddr = {
         .addr = reinterpret_cast<uint64_t>(
             static_cast<uint64_t*>(remoteSignalBuf.ptr) + signalId),
-        .key = remoteSignalBuf.rkey.value};
+        .key = remoteSignalBuf.rkey_per_device[0].value};
     pipes_gda_gpu_dev_verbs_addr sigSinkAddr = {
         .addr = 0, .key = sinkLkey_.value};
 
     pipes_gda_gpu_dev_verbs_addr counterRemoteAddr = {
         .addr = reinterpret_cast<uint64_t>(
             static_cast<uint64_t*>(localCounterBuf.ptr) + counterId),
-        .key = localCounterBuf.lkey.value};
+        .key = localCounterBuf.lkey_per_device[0].value};
     pipes_gda_gpu_dev_verbs_addr counterSinkAddr = {
         .addr = 0, .key = sinkLkey_.value};
 
@@ -383,14 +383,14 @@ class P2pIbgdaTransportDeviceImpl {
     pipes_gda_gpu_dev_verbs_addr sigRemoteAddr = {
         .addr = reinterpret_cast<uint64_t>(
             static_cast<uint64_t*>(remoteSignalBuf.ptr) + signalId),
-        .key = remoteSignalBuf.rkey.value};
+        .key = remoteSignalBuf.rkey_per_device[0].value};
     pipes_gda_gpu_dev_verbs_addr sigSinkAddr = {
         .addr = 0, .key = sinkLkey_.value};
 
     pipes_gda_gpu_dev_verbs_addr counterRemoteAddr = {
         .addr = reinterpret_cast<uint64_t>(
             static_cast<uint64_t*>(localCounterBuf.ptr) + counterId),
-        .key = localCounterBuf.lkey.value};
+        .key = localCounterBuf.lkey_per_device[0].value};
     pipes_gda_gpu_dev_verbs_addr counterSinkAddr = {
         .addr = 0, .key = sinkLkey_.value};
 
@@ -468,9 +468,9 @@ class P2pIbgdaTransportDeviceImpl {
         wqeIdx,
         PIPES_GDA_IB_MLX5_WQE_CTRL_CQ_UPDATE,
         reinterpret_cast<uint64_t>(laneRemoteBuf.ptr),
-        laneRemoteBuf.rkey.value,
+        laneRemoteBuf.rkey_per_device[0].value,
         reinterpret_cast<uint64_t>(laneBuf.ptr),
-        laneBuf.lkey.value,
+        laneBuf.lkey_per_device[0].value,
         static_cast<uint32_t>(laneBytes));
 
     group.sync();

--- a/comms/pipes/amd/MultipeerIbgdaTransportAmd.cu
+++ b/comms/pipes/amd/MultipeerIbgdaTransportAmd.cu
@@ -714,10 +714,9 @@ std::vector<IbgdaRemoteBuffer> MultipeerIbgdaTransportAmd::exchangeBuffer(
 
   // AllGather with ALL ranks (even in filtered mode)
   std::vector<IbgdaBufferExchInfo> allInfo(nRanks_);
-  allInfo[myRank_] = IbgdaBufferExchInfo{
-      reinterpret_cast<uint64_t>(localBuf.ptr),
-      HostRKey(it->second->rkey),
-  };
+  allInfo[myRank_].addr = reinterpret_cast<uint64_t>(localBuf.ptr);
+  allInfo[myRank_].numNics = 1;
+  allInfo[myRank_].rkey_per_device[0] = HostRKey(it->second->rkey);
 
   auto result =
       bootstrap_

--- a/comms/pipes/amd/MultipeerIbgdaTransportAmd.cu
+++ b/comms/pipes/amd/MultipeerIbgdaTransportAmd.cu
@@ -676,7 +676,7 @@ IbgdaLocalBuffer MultipeerIbgdaTransportAmd::registerBuffer(
 
   auto it = registeredBuffers_.find(ptr);
   if (it != registeredBuffers_.end())
-    return IbgdaLocalBuffer(ptr, HostLKey(it->second->lkey));
+    return IbgdaLocalBuffer(ptr, NetworkLKeys{HostLKey(it->second->lkey)});
 
   int accessFlags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE |
       IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_ATOMIC;
@@ -693,7 +693,7 @@ IbgdaLocalBuffer MultipeerIbgdaTransportAmd::registerBuffer(
   VLOG(1) << "MultipeerIbgdaTransportAmd: registered buffer ptr=" << ptr
           << " size=" << size << " lkey=" << mr->lkey;
 
-  return IbgdaLocalBuffer(ptr, HostLKey(mr->lkey));
+  return IbgdaLocalBuffer(ptr, NetworkLKeys{HostLKey(mr->lkey)});
 }
 
 void MultipeerIbgdaTransportAmd::deregisterBuffer(void* ptr) {

--- a/comms/pipes/amd/PipesGdaShared.h
+++ b/comms/pipes/amd/PipesGdaShared.h
@@ -27,7 +27,9 @@ using comms::pipes::IbgdaLocalBuffer;
 using comms::pipes::IbgdaRemoteBuffer;
 using comms::pipes::IbgdaSignalOp;
 using comms::pipes::NetworkLKey;
+using comms::pipes::NetworkLKeys;
 using comms::pipes::NetworkRKey;
+using comms::pipes::NetworkRKeys;
 
 // ---------------------------------------------------------------------------
 // ThreadGroup types and factory functions

--- a/comms/pipes/amd/collectives/AllToAllvAmd.cuh
+++ b/comms/pipes/amd/collectives/AllToAllvAmd.cuh
@@ -65,7 +65,8 @@ __device__ __forceinline__ void all_to_allv_hybrid_amd(
           static_cast<char*>(ibgda_transport_base) +
           i * ibgda_transport_stride);
 
-      IbgdaLocalBuffer src(sendbuf + send_info.offset, ibgda_send_buf.lkey);
+      IbgdaLocalBuffer src(
+          sendbuf + send_info.offset, ibgda_send_buf.lkey_per_device);
 
       // Remote recv buf points to peer's recvbuff base. Add offset for
       // where this rank's data goes (= recv_chunk_infos[my_rank_id] on

--- a/comms/pipes/amd/tests/P2pIbgdaTransportDeviceAmdTestKernels.cu
+++ b/comms/pipes/amd/tests/P2pIbgdaTransportDeviceAmdTestKernels.cu
@@ -237,8 +237,10 @@ __global__ void testPutLatency(
 
   initMockQp(mock);
 
-  IbgdaLocalBuffer localDataBuf(mock->wqeBuf, NetworkLKey(0x3333));
-  IbgdaRemoteBuffer remoteDataBuf(mock->wqeBuf, NetworkRKey(0x4444));
+  IbgdaLocalBuffer localDataBuf(
+      mock->wqeBuf, NetworkLKeys{NetworkLKey(0x3333)});
+  IbgdaRemoteBuffer remoteDataBuf(
+      mock->wqeBuf, NetworkRKeys{NetworkRKey(0x4444)});
 
   P2pIbgdaTransportDevice transport(&mock->qp);
 
@@ -337,9 +339,9 @@ __global__ void testPutGroupPartitioning(bool* success) {
   char dummyLocal[8];
   char dummyRemote[8];
   pipes_gda::IbgdaLocalBuffer localBuf(
-      dummyLocal, pipes_gda::NetworkLKey(0x1111));
+      dummyLocal, pipes_gda::NetworkLKeys{pipes_gda::NetworkLKey(0x1111)});
   pipes_gda::IbgdaRemoteBuffer remoteBuf(
-      dummyRemote, pipes_gda::NetworkRKey(0x2222));
+      dummyRemote, pipes_gda::NetworkRKeys{pipes_gda::NetworkRKey(0x2222)});
 
   std::size_t chunkSize = totalBytes / group.group_size;
   std::size_t expectedOffset = group.thread_id_in_group * chunkSize;
@@ -361,10 +363,10 @@ __global__ void testPutGroupPartitioning(bool* success) {
   if (laneRemoteBuf.ptr != expectedRemotePtr) {
     *success = false;
   }
-  if (laneBuf.lkey != localBuf.lkey) {
+  if (laneBuf.lkey_per_device[0] != localBuf.lkey_per_device[0]) {
     *success = false;
   }
-  if (laneRemoteBuf.rkey != remoteBuf.rkey) {
+  if (laneRemoteBuf.rkey_per_device[0] != remoteBuf.rkey_per_device[0]) {
     *success = false;
   }
 }
@@ -484,9 +486,9 @@ __global__ void testPutGroupPartitioningBlock(bool* success) {
   char dummyLocal[8];
   char dummyRemote[8];
   pipes_gda::IbgdaLocalBuffer localBuf(
-      dummyLocal, pipes_gda::NetworkLKey(0x1111));
+      dummyLocal, pipes_gda::NetworkLKeys{pipes_gda::NetworkLKey(0x1111)});
   pipes_gda::IbgdaRemoteBuffer remoteBuf(
-      dummyRemote, pipes_gda::NetworkRKey(0x2222));
+      dummyRemote, pipes_gda::NetworkRKeys{pipes_gda::NetworkRKey(0x2222)});
 
   std::size_t chunkSize = totalBytes / group.group_size;
   std::size_t expectedOffset = group.thread_id_in_group * chunkSize;
@@ -497,7 +499,7 @@ __global__ void testPutGroupPartitioningBlock(bool* success) {
   if (laneBuf.ptr != expectedPtr) {
     atomicExch(reinterpret_cast<int*>(success), 0);
   }
-  if (laneBuf.lkey != localBuf.lkey) {
+  if (laneBuf.lkey_per_device[0] != localBuf.lkey_per_device[0]) {
     atomicExch(reinterpret_cast<int*>(success), 0);
   }
 }

--- a/comms/pipes/amd/tests/P2pIbgdaTransportDeviceAmdTestMain.cu
+++ b/comms/pipes/amd/tests/P2pIbgdaTransportDeviceAmdTestMain.cu
@@ -100,7 +100,7 @@ TEST_F(P2pIbgdaTransportDeviceTestFixture, ReadSignal) {
       numSignals * sizeof(uint64_t),
       hipMemcpyHostToDevice));
 
-  IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKey(0x5555));
+  IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKeys{NetworkLKey(0x5555)});
 
   runAndVerify([&](bool* d_success) {
     runTestP2pTransportReadSignal(d_signalBuf, localBuf, numSignals, d_success);
@@ -116,16 +116,17 @@ TEST_F(P2pIbgdaTransportDeviceTestFixture, BufferSubBufferWithTransport) {
   char localSignalData[128];
   char remoteSignalData[128];
 
-  IbgdaLocalBuffer baseLBuf(localSignalData, NetworkLKey(0x7777));
-  IbgdaRemoteBuffer baseRBuf(remoteSignalData, NetworkRKey(0x8888));
+  IbgdaLocalBuffer baseLBuf(localSignalData, NetworkLKeys{NetworkLKey(0x7777)});
+  IbgdaRemoteBuffer baseRBuf(
+      remoteSignalData, NetworkRKeys{NetworkRKey(0x8888)});
 
   IbgdaLocalBuffer subLBuf = baseLBuf.subBuffer(offset);
   IbgdaRemoteBuffer subRBuf = baseRBuf.subBuffer(offset);
 
   EXPECT_EQ(subLBuf.ptr, localSignalData + offset);
   EXPECT_EQ(subRBuf.ptr, remoteSignalData + offset);
-  EXPECT_EQ(subLBuf.lkey, baseLBuf.lkey);
-  EXPECT_EQ(subRBuf.rkey, baseRBuf.rkey);
+  EXPECT_EQ(subLBuf.lkey_per_device[0], baseLBuf.lkey_per_device[0]);
+  EXPECT_EQ(subRBuf.rkey_per_device[0], baseRBuf.rkey_per_device[0]);
 }
 
 // =============================================================================
@@ -141,7 +142,7 @@ TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalGE_Equal) {
   HIPCHECK_TEST(hipMemcpy(
       d_signalBuf, &targetValue, sizeof(uint64_t), hipMemcpyHostToDevice));
 
-  IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKey(0x1111));
+  IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKeys{NetworkLKey(0x1111)});
 
   runAndVerify([&](bool* d_success) {
     runTestWaitSignalGE(d_signalBuf, localBuf, targetValue, d_success);
@@ -158,7 +159,7 @@ TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalGE_Greater) {
   HIPCHECK_TEST(hipMemcpy(
       d_signalBuf, &signalValue, sizeof(uint64_t), hipMemcpyHostToDevice));
 
-  IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKey(0x1111));
+  IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKeys{NetworkLKey(0x1111)});
 
   runAndVerify([&](bool* d_success) {
     runTestWaitSignalGE(d_signalBuf, localBuf, targetValue, d_success);
@@ -181,7 +182,7 @@ TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalMultipleSlots) {
       numSignals * sizeof(uint64_t),
       hipMemcpyHostToDevice));
 
-  IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKey(0x3333));
+  IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKeys{NetworkLKey(0x3333)});
 
   runAndVerify([&](bool* d_success) {
     runTestWaitSignalMultipleSlots(
@@ -197,7 +198,7 @@ TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalZeroValue) {
 
   HIPCHECK_TEST(hipMemset(d_signalBuf, 0, sizeof(uint64_t)));
 
-  IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKey(0x1111));
+  IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKeys{NetworkLKey(0x1111)});
 
   runAndVerify([&](bool* d_success) {
     runTestWaitSignalGE(d_signalBuf, localBuf, targetValue, d_success);
@@ -213,7 +214,7 @@ TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalMaxValue) {
   HIPCHECK_TEST(hipMemcpy(
       d_signalBuf, &targetValue, sizeof(uint64_t), hipMemcpyHostToDevice));
 
-  IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKey(0x1111));
+  IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKeys{NetworkLKey(0x1111)});
 
   runAndVerify([&](bool* d_success) {
     runTestWaitSignalGE(d_signalBuf, localBuf, targetValue, d_success);
@@ -292,7 +293,7 @@ TEST_F(P2pIbgdaWaitSignalTimeoutTest, WaitSignalNoTimeoutWhenSatisfied) {
   HIPCHECK_TEST(hipMemcpy(
       d_signalBuf, &signalValue, sizeof(uint64_t), hipMemcpyHostToDevice));
 
-  IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKey(0x1111));
+  IbgdaLocalBuffer localBuf(d_signalBuf, NetworkLKeys{NetworkLKey(0x1111)});
 
   HipDeviceBuffer successBuf(sizeof(bool));
   auto* d_success = static_cast<bool*>(successBuf.get());

--- a/comms/pipes/rdma/NicConstants.h
+++ b/comms/pipes/rdma/NicConstants.h
@@ -1,0 +1,40 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+namespace comms::pipes {
+
+/**
+ * Maximum number of NICs (RDMA rails) per GPU supported by the multi-NIC
+ * transport stack. One "NIC" corresponds to one ibverbs path: a mlx5_X
+ * device + ibv_pd + QPs.
+ *
+ * Hardware mapping (per comms/tcp_devmem/HW.md):
+ *   - H100 (Grand Teton): 1 NIC per GPU → numNics=1
+ *   - GB200 (Catalina):   2 NICs per GPU (2 ConnectX-7 chips) → numNics=2
+ *   - GB300 (Clemente):   2 NICs per GPU (1 dual-port ConnectX-8 exposed
+ *                         as 2 mlx5_X) → numNics=2
+ *
+ * `kMaxNicsPerGpu` caps the static array sizes used in the IBGDA backend:
+ *   - NetworkLKeys / NetworkRKeys (per-NIC key array wrappers)
+ *   - IbgdaLocalBuffer.lkeys / IbgdaRemoteBuffer.rkeys
+ *   - LocalBufferRegistration.lkeys / RemoteBufferRegistration.rkeys
+ *   - P2pIbgdaTransportDevice.sinkLkeys_
+ *   - IbgdaTransportExchInfoAll.nicInfo
+ *   - MultipeerIbgdaTransport per-NIC IB resources (ibvCtxs_, ibvPds_, ...)
+ *   - CachedMr.mrs
+ *
+ * Increase this constant only if a future platform supports > 2 NICs per
+ * GPU. At that point, also audit the IBGDA wire format
+ * (IbgdaTransportExchInfoAll size scales with kMaxNicsPerGpu ×
+ * kMaxQpsPerPeer × kMaxRanksForAllGather).
+ *
+ * Lives in its own minimal header (no doca/ibverbs deps) so lightweight
+ * device-side headers like IbgdaBuffer.h can include it without dragging
+ * in NicDiscovery's heavyweight transitive deps. The C-side mirror for
+ * the NCCLx ABI is `NCCLX_MAX_NICS_PER_GPU` in nccl.h, kept in lockstep
+ * via static_assert at the bridge layer.
+ */
+constexpr int kMaxNicsPerGpu = 2;
+
+} // namespace comms::pipes

--- a/comms/pipes/rdma/NicDiscovery.cc
+++ b/comms/pipes/rdma/NicDiscovery.cc
@@ -291,8 +291,32 @@ void NicDiscovery::sortCandidates() {
         if (a.pathType != b.pathType) {
           return static_cast<int>(a.pathType) < static_cast<int>(b.pathType);
         }
-        return a.bandwidthGbps > b.bandwidthGbps;
+        if (a.bandwidthGbps != b.bandwidthGbps) {
+          return a.bandwidthGbps > b.bandwidthGbps;
+        }
+        // Deterministic tiebreak: device name. Without this, ties fall back
+        // to ibv_get_device_list() enumeration order, which is not guaranteed
+        // consistent across hosts — breaking same-rail pairing in multi-NIC
+        // setups (e.g., GB200 where each GPU has 2 equivalent PIX NICs).
+        return a.name < b.name;
       });
+}
+
+std::vector<NicCandidate> NicDiscovery::getBestAffinityNics() const {
+  std::vector<NicCandidate> result;
+  if (candidates_.empty()) {
+    return result;
+  }
+  const auto& best = candidates_.front();
+  for (const auto& c : candidates_) {
+    if (c.pathType == best.pathType && c.bandwidthGbps == best.bandwidthGbps &&
+        c.isDataDirect == best.isDataDirect) {
+      result.push_back(c);
+    } else {
+      break;
+    }
+  }
+  return result;
 }
 
 void NicDiscovery::logBestCandidate() {

--- a/comms/pipes/rdma/NicDiscovery.h
+++ b/comms/pipes/rdma/NicDiscovery.h
@@ -108,6 +108,20 @@ class NicDiscovery {
   }
 
   /**
+   * Get all NIC candidates at the best-affinity tier — i.e., NICs that
+   * share the same {pathType, bandwidthGbps, isDataDirect} as the top
+   * candidate. Returns an empty vector if no candidates were discovered.
+   *
+   * Used by multi-NIC transports to count how many equally-good NICs the
+   * GPU has access to (e.g., GB200/GB300 typically expose 2 NICs at the
+   * same PIX path tier with identical bandwidth).
+   *
+   * Since `candidates_` is sorted best-to-worst, the iteration stops at
+   * the first divergence — no full scan needed past the best tier.
+   */
+  std::vector<NicCandidate> getBestAffinityNics() const;
+
+  /**
    * Get the anchor's NUMA node.
    * For GPU-anchored: the GPU's NUMA node.
    * For CPU-anchored: the NUMA node passed to the constructor.

--- a/comms/pipes/rdma/tests/NicDiscoveryTest.cc
+++ b/comms/pipes/rdma/tests/NicDiscoveryTest.cc
@@ -191,4 +191,43 @@ TEST(NicDiscoveryTest, DataDirectAncestorChainForTopology) {
   EXPECT_EQ(nicHops, 1);
 }
 
+// =============================================================================
+// getBestAffinityNics Determinism Test
+// =============================================================================
+
+namespace {
+class TestableNicDiscovery : public NicDiscovery {
+ public:
+  TestableNicDiscovery() : NicDiscovery("") {}
+  using NicDiscovery::candidates_;
+  using NicDiscovery::sortCandidates;
+
+ protected:
+  std::pair<PathType, int> computePathType(const std::string&, int)
+      const override {
+    return {PathType::PIX, 0};
+  }
+  std::string anchorDescription() const override {
+    return "test";
+  }
+};
+} // namespace
+
+// NICs at the same affinity tier (same pathType + bandwidth + isDataDirect)
+// must be returned in a deterministic order independent of insertion /
+// ibv_get_device_list() enumeration. Otherwise, multi-NIC pairing across
+// ranks falls apart on GB200/GB300 where each GPU has 2 equivalent PIX NICs.
+TEST(NicDiscoveryTest, GetBestAffinityNicsDeterministic) {
+  TestableNicDiscovery d;
+  d.candidates_ = {
+      {.name = "mlx5_1", .pathType = PathType::PIX, .bandwidthGbps = 400},
+      {.name = "mlx5_0", .pathType = PathType::PIX, .bandwidthGbps = 400}};
+  d.sortCandidates();
+
+  auto best = d.getBestAffinityNics();
+  ASSERT_EQ(best.size(), 2);
+  EXPECT_EQ(best[0].name, "mlx5_0");
+  EXPECT_EQ(best[1].name, "mlx5_1");
+}
+
 } // namespace comms::pipes::tests

--- a/comms/pipes/tests/DeviceWindowTest.cu
+++ b/comms/pipes/tests/DeviceWindowTest.cu
@@ -399,7 +399,7 @@ void testDeviceWindowNvlOffsetPut(
   auto dw = bufs.create_with_offset_put(myRank, nRanks, windowBuf_d);
 
   int targetPeerRank = (myRank == 0) ? 1 : 0;
-  LocalBufferRegistration src_buf{srcBuf_d, srcBufSize, NetworkLKey{}};
+  LocalBufferRegistration src_buf{srcBuf_d, srcBufSize};
   nvlOffsetPutKernel<<<4, 256>>>(
       dw, targetPeerRank, dst_offset, src_buf, src_offset, nbytes);
   CUDACHECK_TEST(cudaGetLastError());
@@ -432,7 +432,7 @@ void testDeviceWindowNvlOffsetPutPerGroup(
   auto dw = bufs.create_with_offset_put(myRank, nRanks, windowBuf_d);
 
   int targetPeerRank = (myRank == 0) ? 1 : 0;
-  LocalBufferRegistration src_buf{srcBuf_d, srcBufSize, NetworkLKey{}};
+  LocalBufferRegistration src_buf{srcBuf_d, srcBufSize, NetworkLKeys{}};
   nvlOffsetPutPerGroupKernel<<<numTiles, 256>>>(
       dw, targetPeerRank, src_buf, tileSize);
   CUDACHECK_TEST(cudaGetLastError());
@@ -470,7 +470,7 @@ void testDeviceWindowNvlOffsetPutSignal(
   auto dw = bufs.create_with_offset_put(myRank, nRanks, windowBuf_d);
 
   int targetPeerRank = (myRank == 0) ? 1 : 0;
-  LocalBufferRegistration src_buf{srcBuf_d, srcBufSize, NetworkLKey{}};
+  LocalBufferRegistration src_buf{srcBuf_d, srcBufSize};
   nvlOffsetPutSignalKernel<<<4, 256>>>(
       dw, targetPeerRank, dst_offset, src_buf, src_offset, nbytes, signalId);
   CUDACHECK_TEST(cudaGetLastError());
@@ -501,8 +501,8 @@ void testDeviceWindowNvlBidirectionalOffsetPutSignal(
   NvlOffsetPutDeviceWindowBuffers bufs1;
   auto dw1 = bufs1.create_with_offset_put(1, nRanks, windowBuf0_d);
 
-  LocalBufferRegistration srcReg0{srcBuf0_d, srcBufSize, NetworkLKey{}};
-  LocalBufferRegistration srcReg1{srcBuf1_d, srcBufSize, NetworkLKey{}};
+  LocalBufferRegistration srcReg0{srcBuf0_d, srcBufSize};
+  LocalBufferRegistration srcReg1{srcBuf1_d, srcBufSize};
 
   // Rank 0 puts to rank 1's window buffer
   nvlOffsetPutSignalKernel<<<4, 256>>>(
@@ -783,7 +783,7 @@ void testDeviceWindowNvlOffsetPutSignalCounter(
   auto dw = bufs.create_with_offset_put(myRank, nRanks, windowBuf_d);
 
   int targetPeerRank = (myRank == 0) ? 1 : 0;
-  LocalBufferRegistration src_buf{srcBuf_d, srcBufSize, NetworkLKey{}};
+  LocalBufferRegistration src_buf{srcBuf_d, srcBufSize};
   nvlOffsetPutSignalCounterKernel<<<4, 256>>>(
       dw,
       targetPeerRank,
@@ -839,7 +839,7 @@ void testDeviceWindowNvlOffsetPutCounter(
   auto dw = bufs.create_with_offset_put(myRank, nRanks, windowBuf_d);
 
   int targetPeerRank = (myRank == 0) ? 1 : 0;
-  LocalBufferRegistration src_buf{srcBuf_d, srcBufSize, NetworkLKey{}};
+  LocalBufferRegistration src_buf{srcBuf_d, srcBufSize};
   nvlOffsetPutCounterKernel<<<4, 256>>>(
       dw,
       targetPeerRank,

--- a/comms/pipes/tests/IbgdaBufferTest.cc
+++ b/comms/pipes/tests/IbgdaBufferTest.cc
@@ -27,20 +27,22 @@ TEST(IbgdaBufferTest, KeyImplicitConversion) {
 }
 
 TEST(IbgdaBufferTest, KeyImplicitConversionInBufferConstructor) {
-  // Test that implicit conversion works when constructing buffer descriptors
+  // HostLKey converts implicitly to NetworkLKey during the slot assignment.
   char data[64];
   HostLKey hostLKey(0x1234);
   HostRKey hostRKey(0x5678);
 
-  // IbgdaLocalBuffer should accept HostLKey via implicit conversion
-  IbgdaLocalBuffer localBuf(data, hostLKey);
+  NetworkLKeys lkeys(1);
+  lkeys[0] = hostLKey;
+  IbgdaLocalBuffer localBuf(data, lkeys);
   EXPECT_EQ(localBuf.ptr, data);
-  EXPECT_EQ(localBuf.lkey.value, htobe32(0x1234));
+  EXPECT_EQ(localBuf.lkey_per_device[0].value, htobe32(0x1234));
 
-  // IbgdaRemoteBuffer should accept HostRKey via implicit conversion
-  IbgdaRemoteBuffer remoteBuf(data, hostRKey);
+  NetworkRKeys rkeys(1);
+  rkeys[0] = hostRKey;
+  IbgdaRemoteBuffer remoteBuf(data, rkeys);
   EXPECT_EQ(remoteBuf.ptr, data);
-  EXPECT_EQ(remoteBuf.rkey.value, htobe32(0x5678));
+  EXPECT_EQ(remoteBuf.rkey_per_device[0].value, htobe32(0x5678));
 }
 
 // =============================================================================
@@ -51,30 +53,106 @@ TEST(IbgdaBufferTest, LocalBufferOperations) {
   char data[64];
   NetworkLKey lkey(0x1234);
 
-  // Construction
-  IbgdaLocalBuffer buf(data, lkey);
+  NetworkLKeys keys(1);
+  keys[0] = lkey;
+  IbgdaLocalBuffer buf(data, keys);
   EXPECT_EQ(buf.ptr, data);
-  EXPECT_EQ(buf.lkey, lkey);
+  EXPECT_EQ(buf.lkey_per_device[0], lkey);
 
   // SubBuffer with offset
   auto sub = buf.subBuffer(16);
   EXPECT_EQ(sub.ptr, data + 16);
-  EXPECT_EQ(sub.lkey, lkey);
+  EXPECT_EQ(sub.lkey_per_device[0], lkey);
 }
 
 TEST(IbgdaBufferTest, RemoteBufferOperations) {
   char data[64];
   NetworkRKey rkey(0x5678);
 
-  // Construction
-  IbgdaRemoteBuffer buf(data, rkey);
+  NetworkRKeys keys(1);
+  keys[0] = rkey;
+  IbgdaRemoteBuffer buf(data, keys);
   EXPECT_EQ(buf.ptr, data);
-  EXPECT_EQ(buf.rkey, rkey);
+  EXPECT_EQ(buf.rkey_per_device[0], rkey);
 
   // SubBuffer with offset
   auto sub = buf.subBuffer(32);
   EXPECT_EQ(sub.ptr, data + 32);
-  EXPECT_EQ(sub.rkey, rkey);
+  EXPECT_EQ(sub.rkey_per_device[0], rkey);
+}
+
+// =============================================================================
+// Multi-NIC Buffer Tests
+// =============================================================================
+
+TEST(IbgdaBufferTest, LocalBufferMultiKeyConstruction) {
+  char data[64];
+  NetworkLKeys keys(2);
+  keys[0] = NetworkLKey(0x1111);
+  keys[1] = NetworkLKey(0x2222);
+  IbgdaLocalBuffer buf(data, keys);
+
+  EXPECT_EQ(buf.ptr, data);
+  EXPECT_EQ(buf.lkey_per_device[0].value, 0x1111u);
+  EXPECT_EQ(buf.lkey_per_device[1].value, 0x2222u);
+  EXPECT_EQ(buf.lkey_per_device.size, 2);
+}
+
+TEST(IbgdaBufferTest, RemoteBufferMultiKeyConstruction) {
+  char data[64];
+  NetworkRKeys keys(2);
+  keys[0] = NetworkRKey(0x3333);
+  keys[1] = NetworkRKey(0x4444);
+  IbgdaRemoteBuffer buf(data, keys);
+
+  EXPECT_EQ(buf.ptr, data);
+  EXPECT_EQ(buf.rkey_per_device[0].value, 0x3333u);
+  EXPECT_EQ(buf.rkey_per_device[1].value, 0x4444u);
+  EXPECT_EQ(buf.rkey_per_device.size, 2);
+}
+
+TEST(IbgdaBufferTest, LocalBufferSubBufferPropagatesAllKeys) {
+  // subBuffer must preserve both lkeys[0] AND lkeys[1].
+  char data[64];
+  NetworkLKeys keys(2);
+  keys[0] = NetworkLKey(0xAAAA);
+  keys[1] = NetworkLKey(0xBBBB);
+  IbgdaLocalBuffer buf(data, keys);
+
+  auto sub = buf.subBuffer(16);
+  EXPECT_EQ(sub.ptr, data + 16);
+  EXPECT_EQ(sub.lkey_per_device[0].value, 0xAAAAu);
+  EXPECT_EQ(sub.lkey_per_device[1].value, 0xBBBBu);
+}
+
+TEST(IbgdaBufferTest, RemoteBufferSubBufferPropagatesAllKeys) {
+  char data[64];
+  NetworkRKeys keys(2);
+  keys[0] = NetworkRKey(0xCCCC);
+  keys[1] = NetworkRKey(0xDDDD);
+  IbgdaRemoteBuffer buf(data, keys);
+
+  auto sub = buf.subBuffer(32);
+  EXPECT_EQ(sub.ptr, data + 32);
+  EXPECT_EQ(sub.rkey_per_device[0].value, 0xCCCCu);
+  EXPECT_EQ(sub.rkey_per_device[1].value, 0xDDDDu);
+}
+
+TEST(IbgdaBufferTest, DefaultConstructorZeroInitsAllKeys) {
+  // Default-constructed buffers must have size=0 and storage zero.
+  IbgdaLocalBuffer localBuf;
+  EXPECT_EQ(localBuf.ptr, nullptr);
+  EXPECT_EQ(localBuf.lkey_per_device.size, 0);
+  for (int n = 0; n < kMaxNicsPerGpu; n++) {
+    EXPECT_EQ(localBuf.lkey_per_device.values[n].value, 0u);
+  }
+
+  IbgdaRemoteBuffer remoteBuf;
+  EXPECT_EQ(remoteBuf.ptr, nullptr);
+  EXPECT_EQ(remoteBuf.rkey_per_device.size, 0);
+  for (int n = 0; n < kMaxNicsPerGpu; n++) {
+    EXPECT_EQ(remoteBuf.rkey_per_device.values[n].value, 0u);
+  }
 }
 
 } // namespace comms::pipes::tests

--- a/comms/pipes/tests/MultiPeerNvlTransportIntegrationTest.cc
+++ b/comms/pipes/tests/MultiPeerNvlTransportIntegrationTest.cc
@@ -1760,7 +1760,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, PutSignalOperation) {
 
   // Build LocalBufferRegistration for the source buffer.
   // For NVL-only, lkey is unused.
-  LocalBufferRegistration srcBuf{localSrc_d, kTransferSize, NetworkLKey{}};
+  LocalBufferRegistration srcBuf{localSrc_d, kTransferSize};
 
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 

--- a/comms/pipes/tests/MultipeerIbgdaTransportTest.cc
+++ b/comms/pipes/tests/MultipeerIbgdaTransportTest.cc
@@ -124,9 +124,9 @@ TEST_F(MultipeerIbgdaTransportTestFixture, PutSignalBasic) {
         "Rank {}: localDataBuf ptr={} lkey={}, remoteDataBuf ptr={} rkey={}",
         globalRank,
         localDataBuf.ptr,
-        localDataBuf.lkey.value,
+        localDataBuf.lkey_per_device[0].value,
         remoteDataBuf.ptr,
-        remoteDataBuf.rkey.value);
+        remoteDataBuf.rkey_per_device[0].value);
 
     // Get peer transport for explicit peer selection
     P2pIbgdaTransportDevice* peerTransportPtr =

--- a/comms/pipes/tests/P2pIbgdaTransportDeviceTest.cu
+++ b/comms/pipes/tests/P2pIbgdaTransportDeviceTest.cu
@@ -33,7 +33,7 @@ __global__ void testP2pTransportReadSignal(
     int numSignals,
     bool* success) {
   // Construct transport with ownedLocalSignalBuf pointing to d_signalBuf
-  IbgdaLocalBuffer localSigBuf(d_signalBuf, NetworkLKeys{NetworkLKey(0)});
+  IbgdaLocalBuffer localSigBuf(d_signalBuf, NetworkLKeys{});
   P2pIbgdaTransportDevice transport(
       DeviceSpan<NicDeviceIbgdaResources>{},
       IbgdaRemoteBuffer{},
@@ -60,7 +60,7 @@ __global__ void testP2pTransportReadSignal(
 __global__ void
 testWaitSignalGE(uint64_t* d_signalBuf, uint64_t targetValue, bool* success) {
   // Construct transport with ownedLocalSignalBuf
-  IbgdaLocalBuffer localSigBuf(d_signalBuf, NetworkLKeys{NetworkLKey(0)});
+  IbgdaLocalBuffer localSigBuf(d_signalBuf, NetworkLKeys{});
   P2pIbgdaTransportDevice transport(
       DeviceSpan<NicDeviceIbgdaResources>{},
       IbgdaRemoteBuffer{},
@@ -81,7 +81,7 @@ __global__ void testWaitSignalMultipleSlots(
     int numSignals,
     bool* success) {
   // Construct transport with ownedLocalSignalBuf
-  IbgdaLocalBuffer localSigBuf(d_signalBuf, NetworkLKeys{NetworkLKey(0)});
+  IbgdaLocalBuffer localSigBuf(d_signalBuf, NetworkLKeys{});
   P2pIbgdaTransportDevice transport(
       DeviceSpan<NicDeviceIbgdaResources>{},
       IbgdaRemoteBuffer{},
@@ -329,7 +329,7 @@ __global__ void testWaitSignalTimeout(uint64_t* d_signalBuf, Timeout timeout) {
   timeout.start();
 
   // Construct transport with ownedLocalSignalBuf
-  IbgdaLocalBuffer localSigBuf(d_signalBuf, NetworkLKeys{NetworkLKey(0)});
+  IbgdaLocalBuffer localSigBuf(d_signalBuf, NetworkLKeys{});
   P2pIbgdaTransportDevice transport(
       DeviceSpan<NicDeviceIbgdaResources>{},
       IbgdaRemoteBuffer{},
@@ -348,7 +348,7 @@ testWaitSignalNoTimeout(uint64_t* d_signalBuf, Timeout timeout, bool* success) {
   timeout.start();
 
   // Construct transport with ownedLocalSignalBuf
-  IbgdaLocalBuffer localSigBuf(d_signalBuf, NetworkLKeys{NetworkLKey(0)});
+  IbgdaLocalBuffer localSigBuf(d_signalBuf, NetworkLKeys{});
   P2pIbgdaTransportDevice transport(
       DeviceSpan<NicDeviceIbgdaResources>{},
       IbgdaRemoteBuffer{},

--- a/comms/pipes/tests/P2pIbgdaTransportDeviceTest.cu
+++ b/comms/pipes/tests/P2pIbgdaTransportDeviceTest.cu
@@ -33,7 +33,7 @@ __global__ void testP2pTransportReadSignal(
     int numSignals,
     bool* success) {
   // Construct transport with ownedLocalSignalBuf pointing to d_signalBuf
-  IbgdaLocalBuffer localSigBuf(d_signalBuf, NetworkLKey(0));
+  IbgdaLocalBuffer localSigBuf(d_signalBuf, NetworkLKeys{NetworkLKey(0)});
   P2pIbgdaTransportDevice transport(
       {},
       {},
@@ -62,7 +62,7 @@ __global__ void testP2pTransportReadSignal(
 __global__ void
 testWaitSignalGE(uint64_t* d_signalBuf, uint64_t targetValue, bool* success) {
   // Construct transport with ownedLocalSignalBuf
-  IbgdaLocalBuffer localSigBuf(d_signalBuf, NetworkLKey(0));
+  IbgdaLocalBuffer localSigBuf(d_signalBuf, NetworkLKeys{NetworkLKey(0)});
   P2pIbgdaTransportDevice transport(
       {},
       {},
@@ -85,7 +85,7 @@ __global__ void testWaitSignalMultipleSlots(
     int numSignals,
     bool* success) {
   // Construct transport with ownedLocalSignalBuf
-  IbgdaLocalBuffer localSigBuf(d_signalBuf, NetworkLKey(0));
+  IbgdaLocalBuffer localSigBuf(d_signalBuf, NetworkLKeys{NetworkLKey(0)});
   P2pIbgdaTransportDevice transport(
       {},
       {},
@@ -167,7 +167,7 @@ __global__ void testPutGroupPartitioning(bool* success) {
   void* basePtr = baseData;
 
   comms::pipes::IbgdaLocalBuffer baseBuf(
-      basePtr, comms::pipes::NetworkLKey(0x1111));
+      basePtr, comms::pipes::NetworkLKeys{comms::pipes::NetworkLKey(0x1111)});
   comms::pipes::IbgdaLocalBuffer laneBuf = baseBuf.subBuffer(expectedOffset);
 
   auto* expectedPtr = static_cast<char*>(basePtr) + expectedOffset;
@@ -175,7 +175,7 @@ __global__ void testPutGroupPartitioning(bool* success) {
     *success = false;
   }
 
-  if (laneBuf.lkey != baseBuf.lkey) {
+  if (laneBuf.lkey_per_device[0] != baseBuf.lkey_per_device[0]) {
     *success = false;
   }
 
@@ -289,7 +289,7 @@ __global__ void testPutGroupPartitioningBlock(bool* success) {
   void* basePtr = baseData;
 
   comms::pipes::IbgdaLocalBuffer baseBuf(
-      basePtr, comms::pipes::NetworkLKey(0x1111));
+      basePtr, comms::pipes::NetworkLKeys{comms::pipes::NetworkLKey(0x1111)});
   comms::pipes::IbgdaLocalBuffer laneBuf = baseBuf.subBuffer(expectedOffset);
 
   auto* expectedPtr = static_cast<char*>(basePtr) + expectedOffset;
@@ -297,7 +297,7 @@ __global__ void testPutGroupPartitioningBlock(bool* success) {
     *success = false;
   }
 
-  if (laneBuf.lkey != baseBuf.lkey) {
+  if (laneBuf.lkey_per_device[0] != baseBuf.lkey_per_device[0]) {
     *success = false;
   }
 }
@@ -335,7 +335,7 @@ __global__ void testWaitSignalTimeout(uint64_t* d_signalBuf, Timeout timeout) {
   timeout.start();
 
   // Construct transport with ownedLocalSignalBuf
-  IbgdaLocalBuffer localSigBuf(d_signalBuf, NetworkLKey(0));
+  IbgdaLocalBuffer localSigBuf(d_signalBuf, NetworkLKeys{NetworkLKey(0)});
   P2pIbgdaTransportDevice transport(
       {},
       {},
@@ -356,7 +356,7 @@ testWaitSignalNoTimeout(uint64_t* d_signalBuf, Timeout timeout, bool* success) {
   timeout.start();
 
   // Construct transport with ownedLocalSignalBuf
-  IbgdaLocalBuffer localSigBuf(d_signalBuf, NetworkLKey(0));
+  IbgdaLocalBuffer localSigBuf(d_signalBuf, NetworkLKeys{NetworkLKey(0)});
   P2pIbgdaTransportDevice transport(
       {},
       {},

--- a/comms/pipes/tests/P2pIbgdaTransportDeviceTest.cu
+++ b/comms/pipes/tests/P2pIbgdaTransportDeviceTest.cu
@@ -13,8 +13,8 @@ namespace comms::pipes::tests {
 // =============================================================================
 
 __global__ void testP2pTransportConstruction(bool* success) {
-  // Create transport on device with null QPs
-  P2pIbgdaTransportDevice transport({}, {});
+  // Create transport on device with empty NIC span
+  P2pIbgdaTransportDevice transport(DeviceSpan<NicDeviceIbgdaResources>{});
 
   // If we get here, construction succeeded
   *success = true;
@@ -35,9 +35,7 @@ __global__ void testP2pTransportReadSignal(
   // Construct transport with ownedLocalSignalBuf pointing to d_signalBuf
   IbgdaLocalBuffer localSigBuf(d_signalBuf, NetworkLKeys{NetworkLKey(0)});
   P2pIbgdaTransportDevice transport(
-      {},
-      {},
-      NetworkLKey{},
+      DeviceSpan<NicDeviceIbgdaResources>{},
       IbgdaRemoteBuffer{},
       localSigBuf,
       IbgdaLocalBuffer{},
@@ -64,9 +62,7 @@ testWaitSignalGE(uint64_t* d_signalBuf, uint64_t targetValue, bool* success) {
   // Construct transport with ownedLocalSignalBuf
   IbgdaLocalBuffer localSigBuf(d_signalBuf, NetworkLKeys{NetworkLKey(0)});
   P2pIbgdaTransportDevice transport(
-      {},
-      {},
-      NetworkLKey{},
+      DeviceSpan<NicDeviceIbgdaResources>{},
       IbgdaRemoteBuffer{},
       localSigBuf,
       IbgdaLocalBuffer{},
@@ -87,9 +83,7 @@ __global__ void testWaitSignalMultipleSlots(
   // Construct transport with ownedLocalSignalBuf
   IbgdaLocalBuffer localSigBuf(d_signalBuf, NetworkLKeys{NetworkLKey(0)});
   P2pIbgdaTransportDevice transport(
-      {},
-      {},
-      NetworkLKey{},
+      DeviceSpan<NicDeviceIbgdaResources>{},
       IbgdaRemoteBuffer{},
       localSigBuf,
       IbgdaLocalBuffer{},
@@ -337,9 +331,7 @@ __global__ void testWaitSignalTimeout(uint64_t* d_signalBuf, Timeout timeout) {
   // Construct transport with ownedLocalSignalBuf
   IbgdaLocalBuffer localSigBuf(d_signalBuf, NetworkLKeys{NetworkLKey(0)});
   P2pIbgdaTransportDevice transport(
-      {},
-      {},
-      NetworkLKey{},
+      DeviceSpan<NicDeviceIbgdaResources>{},
       IbgdaRemoteBuffer{},
       localSigBuf,
       IbgdaLocalBuffer{},
@@ -358,9 +350,7 @@ testWaitSignalNoTimeout(uint64_t* d_signalBuf, Timeout timeout, bool* success) {
   // Construct transport with ownedLocalSignalBuf
   IbgdaLocalBuffer localSigBuf(d_signalBuf, NetworkLKeys{NetworkLKey(0)});
   P2pIbgdaTransportDevice transport(
-      {},
-      {},
-      NetworkLKey{},
+      DeviceSpan<NicDeviceIbgdaResources>{},
       IbgdaRemoteBuffer{},
       localSigBuf,
       IbgdaLocalBuffer{},

--- a/comms/pipes/tests/P2pIbgdaTransportDeviceTestMain.cc
+++ b/comms/pipes/tests/P2pIbgdaTransportDeviceTestMain.cc
@@ -103,8 +103,9 @@ TEST_F(P2pIbgdaTransportDeviceTestFixture, BufferSubBuffer) {
   char remoteSignalData[128];
 
   // Create base buffers
-  IbgdaLocalBuffer baseLBuf(localSignalData, NetworkLKey(0x7777));
-  IbgdaRemoteBuffer baseRBuf(remoteSignalData, NetworkRKey(0x8888));
+  IbgdaLocalBuffer baseLBuf(localSignalData, NetworkLKeys{NetworkLKey(0x7777)});
+  IbgdaRemoteBuffer baseRBuf(
+      remoteSignalData, NetworkRKeys{NetworkRKey(0x8888)});
 
   // Create sub-buffers at offset
   IbgdaLocalBuffer subLBuf = baseLBuf.subBuffer(offset);
@@ -115,8 +116,8 @@ TEST_F(P2pIbgdaTransportDeviceTestFixture, BufferSubBuffer) {
   EXPECT_EQ(subRBuf.ptr, remoteSignalData + offset);
 
   // Verify keys are preserved
-  EXPECT_EQ(subLBuf.lkey, baseLBuf.lkey);
-  EXPECT_EQ(subRBuf.rkey, baseRBuf.rkey);
+  EXPECT_EQ(subLBuf.lkey_per_device[0], baseLBuf.lkey_per_device[0]);
+  EXPECT_EQ(subRBuf.rkey_per_device[0], baseRBuf.rkey_per_device[0]);
 }
 
 // =============================================================================

--- a/comms/pipes/window/DeviceWindow.cuh
+++ b/comms/pipes/window/DeviceWindow.cuh
@@ -33,16 +33,68 @@ struct IbgdaOnlyDeviceWindowBuffers;
 // Buffer Registration Types (for DeviceWindow generic put)
 // ===========================================================================
 
+/**
+ * LocalBufferRegistration - Source buffer + per-NIC local keys
+ *
+ * Carries one local key per NIC (`lkey_per_device`, a NetworkLKeys aggregate)
+ * for multi-NIC IBGDA — each NIC has its own ibv_pd with a distinct lkey
+ * for the same physical buffer. The kernel-side P2pIbgdaTransportDevice
+ * selects `lkey_per_device[nic]` based on the slot it dispatches on.
+ *
+ * Construction:
+ *   - {ptr, size}                  — NVL-only path, lkey_per_device empty
+ *   - {ptr, size, NetworkLKeys{…}} — IBGDA path, full per-NIC keys
+ *
+ * No single-key ctor: at numNics>1 a single-key value would silently leave
+ * NIC[1..N-1] keys zero and trap on first multi-NIC use. Single-NIC IBGDA
+ * callers use `NetworkLKeys{lkey}` to express the intent explicitly.
+ */
 struct LocalBufferRegistration {
   const void* base{nullptr};
   std::size_t size{0};
-  NetworkLKey lkey{};
+  NetworkLKeys lkey_per_device{};
+
+  IBGDA_HOST_DEVICE LocalBufferRegistration() = default;
+
+  // NVL-only — leaves lkey_per_device empty. Will trap if used in IBGDA path.
+  IBGDA_HOST_DEVICE LocalBufferRegistration(const void* b, std::size_t s)
+      : base(b), size(s) {}
+
+  // Multi-key — preferred for IBGDA paths.
+  IBGDA_HOST_DEVICE LocalBufferRegistration(
+      const void* b,
+      std::size_t s,
+      const NetworkLKeys& keys)
+      : base(b), size(s), lkey_per_device(keys) {}
 };
 
+/**
+ * RemoteBufferRegistration - Destination buffer + per-NIC remote keys
+ *
+ * Same multi-NIC pattern as LocalBufferRegistration. The `(ptr, size)` ctor
+ * leaves rkey_per_device empty (NVL-only path); the
+ * `(ptr, size, NetworkRKeys{…})` ctor accepts the per-NIC rkey_per_device
+ * for IBGDA.
+ * No single-key ctor — same silent-misuse rationale as
+ * LocalBufferRegistration.
+ */
 struct RemoteBufferRegistration {
   const void* base{nullptr};
   std::size_t size{0};
-  NetworkRKey rkey{};
+  NetworkRKeys rkey_per_device{};
+
+  IBGDA_HOST_DEVICE RemoteBufferRegistration() = default;
+
+  // NVL-only — leaves rkey_per_device empty. Will trap if used in IBGDA path.
+  IBGDA_HOST_DEVICE RemoteBufferRegistration(const void* b, std::size_t s)
+      : base(b), size(s) {}
+
+  // Multi-key — preferred for IBGDA paths.
+  IBGDA_HOST_DEVICE RemoteBufferRegistration(
+      const void* b,
+      std::size_t s,
+      const NetworkRKeys& keys)
+      : base(b), size(s), rkey_per_device(keys) {}
 };
 
 // Bounds checking macros for device code
@@ -991,10 +1043,10 @@ class DeviceWindow {
       int ibgdaPeerIdx = rank_to_peer_index(target_rank);
       IbgdaLocalBuffer localBuf(
           const_cast<void*>(static_cast<const void*>(localSrc)),
-          NetworkLKeys{src_buf.lkey});
+          src_buf.lkey_per_device);
       IbgdaRemoteBuffer remoteBuf(
           const_cast<void*>(remoteBufferRegistry_[ibgdaPeerIdx].base),
-          NetworkRKeys{remoteBufferRegistry_[ibgdaPeerIdx].rkey});
+          remoteBufferRegistry_[ibgdaPeerIdx].rkey_per_device);
       handle_.get_ibgda(target_rank)
           .put(group, localBuf, remoteBuf.subBuffer(dst_offset), nbytes);
     }
@@ -1045,10 +1097,10 @@ class DeviceWindow {
       int ibgdaPeerIdx = rank_to_peer_index(target_rank);
       IbgdaLocalBuffer localBuf(
           const_cast<void*>(static_cast<const void*>(localSrc)),
-          NetworkLKeys{src_buf.lkey});
+          src_buf.lkey_per_device);
       IbgdaRemoteBuffer remoteBuf(
           const_cast<void*>(remoteBufferRegistry_[ibgdaPeerIdx].base),
-          NetworkRKeys{remoteBufferRegistry_[ibgdaPeerIdx].rkey});
+          remoteBufferRegistry_[ibgdaPeerIdx].rkey_per_device);
       handle_.get_ibgda(target_rank)
           .put(
               group,
@@ -1112,12 +1164,11 @@ class DeviceWindow {
       int ibgdaPeerIdx = rank_to_peer_index(target_rank);
       IbgdaLocalBuffer localBuf(
           const_cast<void*>(static_cast<const void*>(localSrc)),
-          NetworkLKeys{src_buf.lkey});
+          src_buf.lkey_per_device);
       IbgdaRemoteBuffer remoteBuf(
           const_cast<void*>(remoteBufferRegistry_[ibgdaPeerIdx].base),
-          NetworkRKeys{remoteBufferRegistry_[ibgdaPeerIdx].rkey});
-      IbgdaLocalBuffer counterBuf(
-          ibgdaPeerCounterBuf_, NetworkLKeys{ibgdaPeerCounterLkey_});
+          remoteBufferRegistry_[ibgdaPeerIdx].rkey_per_device);
+      IbgdaLocalBuffer counterBuf(ibgdaPeerCounterBuf_, ibgdaPeerCounterLkeys_);
       int counterSlot = ibgdaPeerIdx * peerCounterCount_ + counterId;
       handle_.get_ibgda(target_rank)
           .put(
@@ -1176,12 +1227,11 @@ class DeviceWindow {
       int ibgdaPeerIdx = rank_to_peer_index(target_rank);
       IbgdaLocalBuffer localBuf(
           const_cast<void*>(static_cast<const void*>(localSrc)),
-          NetworkLKeys{src_buf.lkey});
+          src_buf.lkey_per_device);
       IbgdaRemoteBuffer remoteBuf(
           const_cast<void*>(remoteBufferRegistry_[ibgdaPeerIdx].base),
-          NetworkRKeys{remoteBufferRegistry_[ibgdaPeerIdx].rkey});
-      IbgdaLocalBuffer counterBuf(
-          ibgdaPeerCounterBuf_, NetworkLKeys{ibgdaPeerCounterLkey_});
+          remoteBufferRegistry_[ibgdaPeerIdx].rkey_per_device);
+      IbgdaLocalBuffer counterBuf(ibgdaPeerCounterBuf_, ibgdaPeerCounterLkeys_);
       int counterSlot = ibgdaPeerIdx * peerCounterCount_ + counterId;
       handle_.get_ibgda(target_rank)
           .put(
@@ -1256,7 +1306,7 @@ class DeviceWindow {
   // --- Per-peer counter buffers (IBGDA-only, local) ---
   int peerCounterCount_{0};
   uint64_t* ibgdaPeerCounterBuf_{nullptr};
-  NetworkLKey ibgdaPeerCounterLkey_{};
+  NetworkLKeys ibgdaPeerCounterLkeys_{};
 
   // --- Barrier buffers (flat, per-peer-type) ---
   int barrierCount_{0};

--- a/comms/pipes/window/DeviceWindow.cuh
+++ b/comms/pipes/window/DeviceWindow.cuh
@@ -990,10 +990,11 @@ class DeviceWindow {
     } else {
       int ibgdaPeerIdx = rank_to_peer_index(target_rank);
       IbgdaLocalBuffer localBuf(
-          const_cast<void*>(static_cast<const void*>(localSrc)), src_buf.lkey);
+          const_cast<void*>(static_cast<const void*>(localSrc)),
+          NetworkLKeys{src_buf.lkey});
       IbgdaRemoteBuffer remoteBuf(
           const_cast<void*>(remoteBufferRegistry_[ibgdaPeerIdx].base),
-          remoteBufferRegistry_[ibgdaPeerIdx].rkey);
+          NetworkRKeys{remoteBufferRegistry_[ibgdaPeerIdx].rkey});
       handle_.get_ibgda(target_rank)
           .put(group, localBuf, remoteBuf.subBuffer(dst_offset), nbytes);
     }
@@ -1043,10 +1044,11 @@ class DeviceWindow {
     } else {
       int ibgdaPeerIdx = rank_to_peer_index(target_rank);
       IbgdaLocalBuffer localBuf(
-          const_cast<void*>(static_cast<const void*>(localSrc)), src_buf.lkey);
+          const_cast<void*>(static_cast<const void*>(localSrc)),
+          NetworkLKeys{src_buf.lkey});
       IbgdaRemoteBuffer remoteBuf(
           const_cast<void*>(remoteBufferRegistry_[ibgdaPeerIdx].base),
-          remoteBufferRegistry_[ibgdaPeerIdx].rkey);
+          NetworkRKeys{remoteBufferRegistry_[ibgdaPeerIdx].rkey});
       handle_.get_ibgda(target_rank)
           .put(
               group,
@@ -1109,11 +1111,13 @@ class DeviceWindow {
     } else {
       int ibgdaPeerIdx = rank_to_peer_index(target_rank);
       IbgdaLocalBuffer localBuf(
-          const_cast<void*>(static_cast<const void*>(localSrc)), src_buf.lkey);
+          const_cast<void*>(static_cast<const void*>(localSrc)),
+          NetworkLKeys{src_buf.lkey});
       IbgdaRemoteBuffer remoteBuf(
           const_cast<void*>(remoteBufferRegistry_[ibgdaPeerIdx].base),
-          remoteBufferRegistry_[ibgdaPeerIdx].rkey);
-      IbgdaLocalBuffer counterBuf(ibgdaPeerCounterBuf_, ibgdaPeerCounterLkey_);
+          NetworkRKeys{remoteBufferRegistry_[ibgdaPeerIdx].rkey});
+      IbgdaLocalBuffer counterBuf(
+          ibgdaPeerCounterBuf_, NetworkLKeys{ibgdaPeerCounterLkey_});
       int counterSlot = ibgdaPeerIdx * peerCounterCount_ + counterId;
       handle_.get_ibgda(target_rank)
           .put(
@@ -1171,11 +1175,13 @@ class DeviceWindow {
     } else {
       int ibgdaPeerIdx = rank_to_peer_index(target_rank);
       IbgdaLocalBuffer localBuf(
-          const_cast<void*>(static_cast<const void*>(localSrc)), src_buf.lkey);
+          const_cast<void*>(static_cast<const void*>(localSrc)),
+          NetworkLKeys{src_buf.lkey});
       IbgdaRemoteBuffer remoteBuf(
           const_cast<void*>(remoteBufferRegistry_[ibgdaPeerIdx].base),
-          remoteBufferRegistry_[ibgdaPeerIdx].rkey);
-      IbgdaLocalBuffer counterBuf(ibgdaPeerCounterBuf_, ibgdaPeerCounterLkey_);
+          NetworkRKeys{remoteBufferRegistry_[ibgdaPeerIdx].rkey});
+      IbgdaLocalBuffer counterBuf(
+          ibgdaPeerCounterBuf_, NetworkLKeys{ibgdaPeerCounterLkey_});
       int counterSlot = ibgdaPeerIdx * peerCounterCount_ + counterId;
       handle_.get_ibgda(target_rank)
           .put(

--- a/comms/pipes/window/HostWindow.cc
+++ b/comms/pipes/window/HostWindow.cc
@@ -16,8 +16,8 @@ namespace comms::pipes {
 namespace {
 
 // Allocate zeroed GPU memory via cudaMalloc and wrap in IbgdaLocalBuffer.
-// The .ptr field holds the raw GPU pointer; lkey_per_device is empty
-// (size=0) until registerIbgdaBuffer() is called in exchange().
+// The .ptr field holds the raw GPU pointer; .lkey_per_device are unset until
+// localRegisterIbgdaBuffer() is called in exchange().
 IbgdaLocalBuffer allocateIbgdaBuffer(std::size_t size) {
   void* ptr = nullptr;
   CUDA_CHECK(cudaMalloc(&ptr, size));
@@ -309,7 +309,7 @@ void HostWindow::exchange() {
   exchanged_ = true;
 }
 
-std::optional<NetworkLKey> HostWindow::registerLocalBuffer(
+std::optional<NetworkLKeys> HostWindow::registerLocalBuffer(
     void* ptr,
     std::size_t size) {
   if (ibgdaPeerRanks_.empty()) {
@@ -317,7 +317,7 @@ std::optional<NetworkLKey> HostWindow::registerLocalBuffer(
   }
   auto ibgdaBuf = transport_.localRegisterIbgdaBuffer(ptr, size);
   registeredLocalBuffers_.push_back(ptr);
-  return ibgdaBuf.lkey_per_device[0];
+  return ibgdaBuf.lkey_per_device;
 }
 
 void HostWindow::reset_signals(cudaStream_t stream) const {
@@ -351,10 +351,9 @@ void HostWindow::registerAndExchangeBuffer(void* ptr, std::size_t size) {
     auto ibgdaBuf = transport_.localRegisterIbgdaBuffer(ptr, size);
     registeredLocalBuffers_.push_back(ptr);
     auto remoteBufs = transport_.exchangeIbgdaBuffer(ibgdaBuf);
-    for (int i = 0; i < nIbgdaPeers; ++i) {
-      remoteRegistrations_.push_back(
-          RemoteBufferRegistration{
-              remoteBufs[i].ptr, size, remoteBufs[i].rkey_per_device[0]});
+    for (const auto& remoteBuf : remoteBufs) {
+      remoteRegistrations_.emplace_back(
+          remoteBuf.ptr, size, remoteBuf.rkey_per_device);
     }
   }
 
@@ -448,7 +447,7 @@ DeviceWindow HostWindow::getDeviceWindow() const {
   if (ibgdaPeerCounterLocalBuf_.ptr) {
     dw.ibgdaPeerCounterBuf_ =
         static_cast<uint64_t*>(ibgdaPeerCounterLocalBuf_.ptr);
-    dw.ibgdaPeerCounterLkey_ = ibgdaPeerCounterLocalBuf_.lkey_per_device[0];
+    dw.ibgdaPeerCounterLkeys_ = ibgdaPeerCounterLocalBuf_.lkey_per_device;
   }
 
   // Barrier

--- a/comms/pipes/window/HostWindow.cc
+++ b/comms/pipes/window/HostWindow.cc
@@ -16,13 +16,13 @@ namespace comms::pipes {
 namespace {
 
 // Allocate zeroed GPU memory via cudaMalloc and wrap in IbgdaLocalBuffer.
-// The .ptr field holds the raw GPU pointer; .lkey is unset until
-// registerIbgdaBuffer() is called in exchange().
+// The .ptr field holds the raw GPU pointer; lkey_per_device is empty
+// (size=0) until registerIbgdaBuffer() is called in exchange().
 IbgdaLocalBuffer allocateIbgdaBuffer(std::size_t size) {
   void* ptr = nullptr;
   CUDA_CHECK(cudaMalloc(&ptr, size));
   CUDA_CHECK(cudaMemset(ptr, 0, size));
-  return IbgdaLocalBuffer(ptr, NetworkLKey{});
+  return IbgdaLocalBuffer(ptr, NetworkLKeys{});
 }
 
 } // namespace
@@ -139,19 +139,19 @@ HostWindow::~HostWindow() {
   // lkey is only populated during exchange() via registerIbgdaBuffer(),
   // so check lkey != NetworkLKey{} to avoid deregistering unregistered buffers.
   if (ibgdaBarrierLocalBuf_.ptr) {
-    if (ibgdaBarrierLocalBuf_.lkey != NetworkLKey{}) {
+    if (ibgdaBarrierLocalBuf_.lkey_per_device.size > 0) {
       transport_.localDeregisterIbgdaBuffer(ibgdaBarrierLocalBuf_.ptr);
     }
     cudaFree(ibgdaBarrierLocalBuf_.ptr);
   }
   if (ibgdaPeerSignalLocalBuf_.ptr) {
-    if (ibgdaPeerSignalLocalBuf_.lkey != NetworkLKey{}) {
+    if (ibgdaPeerSignalLocalBuf_.lkey_per_device.size > 0) {
       transport_.localDeregisterIbgdaBuffer(ibgdaPeerSignalLocalBuf_.ptr);
     }
     cudaFree(ibgdaPeerSignalLocalBuf_.ptr);
   }
   if (ibgdaPeerCounterLocalBuf_.ptr) {
-    if (ibgdaPeerCounterLocalBuf_.lkey != NetworkLKey{}) {
+    if (ibgdaPeerCounterLocalBuf_.lkey_per_device.size > 0) {
       transport_.localDeregisterIbgdaBuffer(ibgdaPeerCounterLocalBuf_.ptr);
     }
     cudaFree(ibgdaPeerCounterLocalBuf_.ptr);
@@ -317,7 +317,7 @@ std::optional<NetworkLKey> HostWindow::registerLocalBuffer(
   }
   auto ibgdaBuf = transport_.localRegisterIbgdaBuffer(ptr, size);
   registeredLocalBuffers_.push_back(ptr);
-  return ibgdaBuf.lkey;
+  return ibgdaBuf.lkey_per_device[0];
 }
 
 void HostWindow::reset_signals(cudaStream_t stream) const {
@@ -354,7 +354,7 @@ void HostWindow::registerAndExchangeBuffer(void* ptr, std::size_t size) {
     for (int i = 0; i < nIbgdaPeers; ++i) {
       remoteRegistrations_.push_back(
           RemoteBufferRegistration{
-              remoteBufs[i].ptr, size, remoteBufs[i].rkey});
+              remoteBufs[i].ptr, size, remoteBufs[i].rkey_per_device[0]});
     }
   }
 
@@ -445,9 +445,11 @@ DeviceWindow HostWindow::getDeviceWindow() const {
 
   // Per-peer counters
   dw.peerCounterCount_ = static_cast<int>(config_.peerCounterCount);
-  dw.ibgdaPeerCounterBuf_ =
-      static_cast<uint64_t*>(ibgdaPeerCounterLocalBuf_.ptr);
-  dw.ibgdaPeerCounterLkey_ = ibgdaPeerCounterLocalBuf_.lkey;
+  if (ibgdaPeerCounterLocalBuf_.ptr) {
+    dw.ibgdaPeerCounterBuf_ =
+        static_cast<uint64_t*>(ibgdaPeerCounterLocalBuf_.ptr);
+    dw.ibgdaPeerCounterLkey_ = ibgdaPeerCounterLocalBuf_.lkey_per_device[0];
+  }
 
   // Barrier
   dw.barrierCount_ = static_cast<int>(config_.barrierCount);

--- a/comms/pipes/window/HostWindow.h
+++ b/comms/pipes/window/HostWindow.h
@@ -128,14 +128,19 @@ class HostWindow {
    * Register a local buffer for use as a source in
    * DeviceWindow::put/put_signal.
    *
-   * NOT collective: only registers locally for IBGDA (gets lkey).
+   * NOT collective: only registers locally for IBGDA (gets per-NIC lkeys).
    * Does not exchange with peers. Use for source-only buffers.
    *
    * @param ptr   Local GPU buffer pointer
    * @param size  Buffer size in bytes
-   * @return      lkey for the registered buffer, or nullopt if no IBGDA peers
+   * @return      Per-NIC lkeys for the registered buffer (one entry per NIC,
+   *              up to kMaxNicsPerGpu), or nullopt if no IBGDA peers. The
+   *              kernel-side IBGDA put selects lkeys[nic] based on the slot
+   *              it dispatches on, so passing only NIC0's lkey would corrupt
+   *              WQEs for any slot landing on NIC[1..N-1] on multi-NIC
+   *              hardware (GB200/GB300).
    */
-  std::optional<NetworkLKey> registerLocalBuffer(void* ptr, std::size_t size);
+  std::optional<NetworkLKeys> registerLocalBuffer(void* ptr, std::size_t size);
 
   /**
    * Register and exchange the window data buffer with all peers.

--- a/comms/torchcomms/device/pipes/TorchCommDevicePipes.cuh
+++ b/comms/torchcomms/device/pipes/TorchCommDevicePipes.cuh
@@ -133,7 +133,7 @@ __device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::put(
   ::comms::pipes::LocalBufferRegistration pipes_src{
       src_buf.base_ptr,
       src_buf.size,
-      ::comms::pipes::NetworkLKey{src_buf.lkey}};
+      ::comms::pipes::NetworkLKeys{::comms::pipes::NetworkLKey{src_buf.lkey}}};
 
   bool has_signal = signal_id >= 0;
   bool has_counter = counter_id >= 0;


### PR DESCRIPTION
Summary:

Wires `numNics_` into the `MultipeerIbgdaTransport` ctor so the multi-NIC infrastructure landed in P2 stages 1-7 actually engages on multi-NIC hardware. Two-source resolution, no separate numeric knob:

  1. `config.gpuNicMap[cudaDevice]` populated → use its NIC list (count = `.size()`).
  2. Otherwise auto-discover via `GpuNicDiscovery::getBestAffinityNics()` — every NIC at the best-affinity tier (same `pathType` + `bandwidthGbps` + `isDataDirect` as the top candidate).

Both paths validate against `kMaxNicsPerGpu`. No silent fallback to 1: if auto-discovery returns 0 candidates or finds more than the cap allows, the ctor throws with a clear hint instead of quietly running degraded.

Behavior on real hardware (default `MultipeerIbgdaTransportConfig{}`, `gpuNicMap` empty):
  - H100 (Grand Teton): 1 NIC at PIX tier → numNics_ = 1.
  - GB200 (Catalina):   2 ConnectX-7 NICs at PIX/400Gbps tier → numNics_ = 2.
  - GB300 (Clemente):   2 mlx5_X devices on the dual-port HCA → numNics_ = 2.

The existing `gpuNicMap` field is the operator override for when topology auto-discovery picks the wrong NICs (test environments, manual pinning).

`getBestAffinityNics()` lives on `NicDiscovery` (the base class) so both `GpuNicDiscovery` and `CpuNicDiscovery` expose it consistently.

Files:
  - `comms/pipes/rdma/NicDiscovery.h`: `getBestAffinityNics()` helper method on the base class. Returns the prefix of `candidates_` matching the top entry's `{pathType, bandwidthGbps, isDataDirect}` tier. Iteration stops at the first divergence (`candidates_` is sorted best-to-worst by construction).
  - `comms/pipes/MultipeerIbgdaTransport.cc`: ctor reads gpuNicMap or runs auto-discovery, throws on empty / overflow, sets `numNics_` before any per-NIC resource allocation.

Reviewed By: goelayu

Differential Revision: D101838892
