### PR TITLE
Add expandable-segment cudagraph AllGather test

### DIFF
--- a/comms/ctran/algos/AllGather/AllGatherCudagraphAware.cc
+++ b/comms/ctran/algos/AllGather/AllGatherCudagraphAware.cc
@@ -10,7 +10,7 @@
 //      captured into the graph.
 //   2. allGatherWinInit() — create persistent AGP state from window metadata.
 //      Synchronous, no async handle exchange needed. Uses
-//      cudaThreadExchangeStreamCaptureMode to temporarily allow cudaHostAlloc
+//      StreamCaptureModeGuard to temporarily allow cudaHostAlloc
 //      (blocked under cudaStreamCaptureModeGlobal used by PyTorch).
 //   3. allGatherWinExec() — dry-run exec that IS captured into the graph.
 //      CE copies (NVL intra-node) and GPE host-node callbacks (IB inter-node)
@@ -33,6 +33,7 @@
 #include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/ctran/utils/CudaGraphUtils.h"
 #include "comms/ctran/window/CtranWin.h"
+#include "comms/utils/CudaRAII.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
 commResult_t ctranAllGatherCudagraphAware(
@@ -66,16 +67,12 @@ commResult_t ctranAllGatherCudagraphAware(
   //    Single-threaded-per-comm assumption (standard for NCCL).
   auto winGuard = folly::makeGuard([win]() { delete win; });
 
-  cudaStreamCaptureMode prevMode = cudaStreamCaptureModeRelaxed;
-  FB_CUDACHECK(cudaThreadExchangeStreamCaptureMode(&prevMode));
-
   CtranPersistentRequest* request = nullptr;
-  // Store result instead of FB_COMMCHECK — must restore capture mode before
-  // any early return.
-  auto initResult = ctran::allGatherWinInit(win, comm, stream, request);
-
-  FB_CUDACHECK(cudaThreadExchangeStreamCaptureMode(&prevMode));
-  FB_COMMCHECK(initResult);
+  {
+    meta::comms::StreamCaptureModeGuard captureGuard{
+        cudaStreamCaptureModeRelaxed};
+    FB_COMMCHECK(ctran::allGatherWinInit(win, comm, stream, request));
+  }
 
   // 3. Dry-run exec — CE copies and GPE host-node callbacks are captured.
   FB_COMMCHECK(ctran::allGatherWinExec(sendbuff, sendcount, datatype, request));

--- a/comms/ctran/tests/CtranNcclTestUtils.h
+++ b/comms/ctran/tests/CtranNcclTestUtils.h
@@ -83,6 +83,8 @@ class CtranNcclTestHelpers : public CtranTestHelpers {
 // Defaults to kMemNcclMemAlloc for NVL-registered buffers.
 class TestDeviceBuffer {
  public:
+  TestDeviceBuffer() = default;
+
   explicit TestDeviceBuffer(
       size_t size,
       MemAllocType memType = kMemNcclMemAlloc,
@@ -126,6 +128,8 @@ class TestDeviceBuffer {
       ptr_ = other.ptr_;
       size_ = other.size_;
       memType_ = other.memType_;
+      numSegments_ = other.numSegments_;
+      refCheck_ = other.refCheck_;
       segments_ = std::move(other.segments_);
       other.ptr_ = nullptr;
       other.size_ = 0;

--- a/comms/ctran/tests/cudagraph/CtranCudaGraphAllGatherCtgraphTest.cc
+++ b/comms/ctran/tests/cudagraph/CtranCudaGraphAllGatherCtgraphTest.cc
@@ -6,6 +6,8 @@
 // ctranAllGather transparently converts to the persistent window-based AGP
 // algorithm.
 
+#include <random>
+
 #include "comms/ctran/algos/AllGather/AllGatherImpl.h"
 #include "comms/ctran/tests/cudagraph/CtranCudaGraphParamTest.h"
 
@@ -61,6 +63,87 @@ static AlgoDescriptor makeAllGatherCtgraph() {
 }
 
 DEFINE_CUDAGRAPH_PARAM_TEST(CudaGraphAllGatherCtgraph, makeAllGatherCtgraph());
+
+// Expandable segment test: verifies cudagraph-aware AllGather with
+// kCuMemAllocDisjoint memory (multiple disjoint physical segments per buffer,
+// 20MB each) and a random offset from the allocation base.
+class CudaGraphAllGatherCtgraphExpandable
+    : public CtranCudaGraphTestBase,
+      public ::testing::WithParamInterface<size_t> {};
+
+static constexpr size_t kSegmentSize = 20UL * 1024 * 1024;
+
+static size_t segmentsNeeded(size_t bytes) {
+  return (bytes + kSegmentSize - 1) / kSegmentSize;
+}
+
+TEST_P(CudaGraphAllGatherCtgraphExpandable, CaptureReplayVerify) {
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+
+  if (!ctran::allGatherPSupport(comm.get())) {
+    GTEST_SKIP() << "allGatherP not supported";
+  }
+
+  const size_t count = GetParam();
+  const int nRanks = numRanks;
+
+  std::mt19937 rng(globalRank);
+  const size_t offsetElems = rng() % 4096 + 1;
+  const size_t offsetBytes = offsetElems * sizeof(int32_t);
+
+  const size_t sendDataBytes = count * sizeof(int32_t);
+  const size_t recvDataBytes = count * nRanks * sizeof(int32_t);
+
+  const size_t sendNumSeg = segmentsNeeded(sendDataBytes + offsetBytes);
+  const size_t recvNumSeg = segmentsNeeded(recvDataBytes + offsetBytes);
+
+  ctran::TestDeviceBuffer send(
+      sendNumSeg * kSegmentSize, kCuMemAllocDisjoint, sendNumSeg);
+  ctran::TestDeviceBuffer recv(
+      recvNumSeg * kSegmentSize, kCuMemAllocDisjoint, recvNumSeg);
+
+  auto* sendbuf = static_cast<char*>(send.get()) + offsetBytes;
+  auto* recvbuf = static_cast<char*>(recv.get()) + offsetBytes;
+
+  fillSendBuf(sendbuf, count, globalRank);
+
+  meta::comms::CudaStream stream(cudaStreamNonBlocking);
+
+  // Capture
+  cudaGraph_t graph;
+  cudaGraphExec_t exec;
+  ASSERT_EQ(
+      cudaStreamBeginCapture(stream.get(), cudaStreamCaptureModeGlobal),
+      cudaSuccess);
+  ASSERT_EQ(
+      ctranAllGather(
+          sendbuf,
+          recvbuf,
+          count,
+          commInt32,
+          comm.get(),
+          stream.get(),
+          NCCL_ALLGATHER_ALGO::ctgraph),
+      commSuccess);
+  ASSERT_EQ(cudaStreamEndCapture(stream.get(), &graph), cudaSuccess);
+  ASSERT_EQ(cudaGraphInstantiate(&exec, graph, 0), cudaSuccess);
+
+  // Replay
+  ASSERT_EQ(cudaGraphLaunch(exec, stream.get()), cudaSuccess);
+  ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
+
+  // Verify
+  verifyAllGather(recvbuf, count, nRanks);
+
+  ASSERT_EQ(cudaGraphExecDestroy(exec), cudaSuccess);
+  ASSERT_EQ(cudaGraphDestroy(graph), cudaSuccess);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CudaGraphAllGatherCtgraphExpandableTests,
+    CudaGraphAllGatherCtgraphExpandable,
+    ::testing::Values(2097152UL, 10485760UL));
 
 // Verifies that graph destruction cleans up without CUDA API errors.
 // The retainUserObject destructor callback defers cleanup to comm destruction


### PR DESCRIPTION
Summary:
- Add `CudaGraphAllGatherCtgraphExpandable` parameterized test that verifies cudagraph-aware AllGather with `kCuMemAllocDisjoint` memory (multiple disjoint 20MB physical segments per buffer) and a random element-wise offset from the allocation base
- Parameterized with counts 2M and 10M int32 elements, exercising 1-16 recv segments across 8 ranks
- Fix pre-existing bug in `TestDeviceBuffer` move assignment operator: `numSegments_` and `refCheck_` were not transferred, causing wrong parameters in `releaseBuf` for non-default segment counts
- Add `TestDeviceBuffer() = default` constructor to support default-construction + move-assignment pattern

Differential Revision: D102286890


