### PR TITLE
Add ctgraph algorithm selection for cudagraph-aware AllGather (#2262)

### DIFF
--- a/comms/ctran/Ctran.cc
+++ b/comms/ctran/Ctran.cc
@@ -1,5 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 #include <memory>
+#include <optional>
 
 #include "comms/ctran/Ctran.h"
 #include "comms/ctran/CtranComm.h"
@@ -111,6 +112,14 @@ comms::pipes::Transport* CtranComm::getMultiPeerTransportsPtr() const {
 }
 #endif // defined(ENABLE_PIPES)
 
+std::optional<meta::comms::colltrace::AlgoStatDump> CtranComm::dumpAlgoStats()
+    const {
+  if (!algoStats_) {
+    return std::nullopt;
+  }
+  return algoStats_->dump();
+}
+
 commResult_t ctranInit(
     CtranComm* comm,
     std::unique_ptr<ctran::IProfilerReporter> reporter) {
@@ -157,6 +166,13 @@ CtranComm::CtranComm(std::shared_ptr<Abort> abort, ctranConfig commConfig)
   }
   // Default points to internal opCount
   opCount_ = &ctranOpCount_;
+
+  for (const auto& opt : NCCL_COLLTRACE) {
+    if (opt == "algostat") {
+      algoStats_ = std::make_unique<meta::comms::colltrace::AlgoStats>();
+      break;
+    }
+  }
 }
 
 void CtranComm::destroy() {

--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -6,6 +6,7 @@
 #include <chrono>
 #include <cstdint>
 #include <functional>
+#include <optional>
 #include <vector>
 
 #include <folly/Synchronized.h>
@@ -15,6 +16,7 @@
 #include "comms/ctran/utils/Abort.h"
 #include "comms/ctran/utils/AsyncError.h"
 #include "comms/ctran/utils/Exception.h"
+#include "comms/utils/colltrace/AlgoStats.h"
 #include "comms/utils/colltrace/CollTraceInterface.h"
 #include "comms/utils/commSpecs.h"
 
@@ -57,6 +59,7 @@ struct ctranConfig {
 // Forward declaration to avoid circular dependency
 class CollTrace;
 struct ncclComm;
+class CtranGpe;
 namespace ncclx::memory {
 class memCacheAllocator;
 }
@@ -154,6 +157,10 @@ class CtranComm {
   // initialized.
   comms::pipes::Transport* getMultiPeerTransportsPtr() const;
 
+  // Returns a snapshot of the algo stats, or std::nullopt if stats are
+  // disabled.
+  std::optional<meta::comms::colltrace::AlgoStatDump> dumpAlgoStats() const;
+
   // fields are public to allow access from external code and tests
   // TODO: remove config_, it's redundant
   ctranConfig config_;
@@ -205,6 +212,8 @@ class CtranComm {
   CudagraphDeferredCleanup cudagraphDeferredCleanup;
 
  private:
+  friend class CtranGpe;
+  std::unique_ptr<meta::comms::colltrace::AlgoStats> algoStats_;
   // TODO: define proper constructor to make CtranComm be independent of
   // ncclComm.
   // While doing refactoring we always create CtranComm from ncclComm and it

--- a/comms/ctran/algos/AllGather/AllGather.cc
+++ b/comms/ctran/algos/AllGather/AllGather.cc
@@ -8,6 +8,24 @@
 #include "comms/ctran/utils/CudaGraphUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
+static bool isGraphAwareAlgo(enum NCCL_ALLGATHER_ALGO algo) {
+  switch (algo) {
+    case NCCL_ALLGATHER_ALGO::ctgraph:
+    case NCCL_ALLGATHER_ALGO::ctgraph_pipeline:
+    case NCCL_ALLGATHER_ALGO::ctgraph_ring:
+    case NCCL_ALLGATHER_ALGO::ctgraph_rd:
+      return true;
+    case NCCL_ALLGATHER_ALGO::ctdirect:
+    case NCCL_ALLGATHER_ALGO::ctrd:
+    case NCCL_ALLGATHER_ALGO::ctring:
+    case NCCL_ALLGATHER_ALGO::ctbrucks:
+    case NCCL_ALLGATHER_ALGO::ctran:
+    case NCCL_ALLGATHER_ALGO::orig:
+      return false;
+  }
+  return false;
+}
+
 // Check if CTRAN is supported and if a specific algo is supported by CTRAN.
 // If user sets a specific algo, it should check to avoid unexpected abort in
 // ctranAllGather.
@@ -38,7 +56,11 @@ bool ctranAllGatherSupport(
     case NCCL_ALLGATHER_ALGO::ctran:
       supported = true;
       break;
-    case NCCL_ALLGATHER_ALGO::ctgraph: {
+    case NCCL_ALLGATHER_ALGO::ctgraph:
+    case NCCL_ALLGATHER_ALGO::ctgraph_pipeline:
+    case NCCL_ALLGATHER_ALGO::ctgraph_ring:
+    case NCCL_ALLGATHER_ALGO::ctgraph_rd: {
+      // Check stream capture status
       if (stream == nullptr) {
         supported = false;
         break;
@@ -47,14 +69,30 @@ bool ctranAllGatherSupport(
       auto err =
           ctran::utils::cudagraph::getStreamCaptureInfo(stream, captureInfo);
       supported = (err == cudaSuccess) &&
-          (captureInfo.status == cudaStreamCaptureStatusActive) &&
-          ctran::allGatherPSupport(comm);
+          (captureInfo.status == cudaStreamCaptureStatusActive);
       if (!supported) {
         CLOGF_SUBSYS(
             INFO,
             COLL,
-            "AllGather ctgraph: not in capture mode or AGP not supported. "
-            "Falling back to baseline");
+            "AllGather {}: not in capture mode. "
+            "Falling back to baseline",
+            allGatherAlgoName(algo));
+        break;
+      }
+
+      // Topology check for explicit algo variants
+      if ((algo == NCCL_ALLGATHER_ALGO::ctgraph_ring ||
+           algo == NCCL_ALLGATHER_ALGO::ctgraph_rd) &&
+          statex->nLocalRanks() > 1) {
+        CLOGF_SUBSYS(
+            WARN,
+            COLL,
+            "AllGather {} requires nLocalRanks==1, got {}. "
+            "Falling back to baseline",
+            allGatherAlgoName(algo),
+            statex->nLocalRanks());
+        supported = false;
+        break;
       }
       break;
     }
@@ -76,23 +114,26 @@ commResult_t ctranAllGather(
     enum NCCL_ALLGATHER_ALGO algo) {
   // Cudagraph-aware optimization: when capturing and AGP is supported,
   // transparently convert to the persistent window-based AGP algorithm.
-  if (algo == NCCL_ALLGATHER_ALGO::ctgraph) {
+  if (isGraphAwareAlgo(algo)) {
     ctran::utils::cudagraph::StreamCaptureInfo captureInfo;
     FB_CUDACHECK(
         ctran::utils::cudagraph::getStreamCaptureInfo(stream, captureInfo));
-    if (captureInfo.status == cudaStreamCaptureStatusActive &&
-        ctran::allGatherPSupport(comm)) {
+    if (captureInfo.status == cudaStreamCaptureStatusActive) {
       return ctranAllGatherCudagraphAware(
-          sendbuff, recvbuff, sendcount, datatype, comm, stream);
+          sendbuff, recvbuff, sendcount, datatype, comm, stream, algo);
     }
+    FB_ERRORRETURN(
+        commInternalError,
+        "AllGather {} called outside CUDA graph capture. "
+        "ctranAllGatherSupport should have returned false.",
+        allGatherAlgoName(algo));
   }
 
   const auto statex = comm->statex_.get();
 
   // Only ctdirect supports nLocalRanks>1 case.
   // Force to use ctdirect if nLocalRanks>1.
-  if (algo == NCCL_ALLGATHER_ALGO::ctran ||
-      algo == NCCL_ALLGATHER_ALGO::ctgraph) {
+  if (algo == NCCL_ALLGATHER_ALGO::ctran) {
     if (statex->nLocalRanks() > 1) {
       algo = NCCL_ALLGATHER_ALGO::ctdirect;
       CLOGF_SUBSYS(

--- a/comms/ctran/algos/AllGather/AllGatherCudagraphAware.cc
+++ b/comms/ctran/algos/AllGather/AllGatherCudagraphAware.cc
@@ -1,24 +1,21 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
-// Cudagraph-aware AllGather: when a regular ctranAllGather() is called during
-// CUDA graph capture and this path is enabled, the collective is transparently
-// converted to the persistent AllGatherP (window-based) algorithm.
+// Cudagraph-aware AllGather: when ctranAllGather() is called during CUDA graph
+// capture with a ctgraph* algorithm, this module handles buffer registration
+// and algorithm dispatch. The algo is either explicitly specified
+// (ctgraph_pipeline, ctgraph_ring, ctgraph_rd) or auto-selected by
+// selectCtgraphAlgo() based on topology and message size.
 //
-// Flow:
-//   1. ctranWinRegister() — register recvbuff as a window, exchange handles
-//      with all peers. This is a collective CPU-side operation and is NOT
-//      captured into the graph.
-//   2. allGatherWinInit() — create persistent AGP state from window metadata.
-//      Synchronous, no async handle exchange needed. Uses
-//      StreamCaptureModeGuard to temporarily allow cudaHostAlloc
-//      (blocked under cudaStreamCaptureModeGlobal used by PyTorch).
-//   3. allGatherWinExec() — dry-run exec that IS captured into the graph.
-//      CE copies (NVL intra-node) and GPE host-node callbacks (IB inter-node)
-//      are recorded as graph nodes.
-//   4. Register cleanup on comm's cudagraphDeferredCleanup.
+// Two registration strategies:
 //
-// On graph replay, only the captured CE + host-node operations re-execute.
-// The result is SM-free replay (no GPU kernels for NVL copies).
+//   winPersistBuffReg (ctgraph_pipeline, nLocalRanks > 1):
+//     Both local and remote addresses must be stable across replays.
+//     Uses window: ctranWinRegister → allGatherWinInit → allGatherWinExec.
+//
+//   localPersistBuffReg (ctgraph_ring/rd, nLocalRanks == 1):
+//     Only local registration persists; remote exchange happens at each replay
+//     via IB isendCtrl/irecvCtrl inside the GPE host node.
+//     Uses globalRegisterWithPtr so searchRegHandle hits the fast path.
 //
 // Cleanup: Resources are registered for deferred cleanup at capture time
 // (not at graph destruction). This ensures cleanup runs during comm
@@ -36,62 +33,160 @@
 #include "comms/utils/CudaRAII.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
+namespace {
+
+// winPersistBuffReg: register recvbuff as a window, exchange handles with
+// all peers. Both local and remote addresses must be stable across replays.
+commResult_t winPersistBuffReg(
+    void* recvbuff,
+    size_t recvBytes,
+    CtranComm* comm,
+    cudaStream_t stream,
+    ctran::CtranWin** winOut,
+    CtranPersistentRequest** requestOut) {
+  FB_COMMCHECK(ctran::ctranWinRegister(recvbuff, recvBytes, comm, winOut));
+
+  auto winGuard = folly::makeGuard([winOut]() { delete *winOut; });
+
+  CtranPersistentRequest* request = nullptr;
+  {
+    meta::comms::StreamCaptureModeGuard captureGuard{
+        cudaStreamCaptureModeRelaxed};
+    FB_COMMCHECK(ctran::allGatherWinInit(*winOut, comm, stream, request));
+  }
+
+  winGuard.dismiss();
+  *requestOut = request;
+  return commSuccess;
+}
+
+// localPersistBuffReg: register recvbuff locally via globalRegisterWithPtr.
+// Only local registration persists; remote exchange happens at each replay.
+commResult_t localPersistBuffReg(void* recvbuff, size_t recvBytes) {
+  meta::comms::StreamCaptureModeGuard captureGuard{
+      cudaStreamCaptureModeRelaxed};
+  FB_COMMCHECK(ctran::globalRegisterWithPtr(recvbuff, recvBytes, true, true));
+  return commSuccess;
+}
+
+enum NCCL_ALLGATHER_ALGO selectCtgraphAlgo(
+    size_t sendBytes,
+    const ncclx::CommStateX* statex) {
+  if (statex->nLocalRanks() > 1) {
+    return NCCL_ALLGATHER_ALGO::ctgraph_pipeline;
+  }
+  return (sendBytes >= NCCL_CTGRAPH_ALLGATHER_RING_THRESHOLD)
+      ? NCCL_ALLGATHER_ALGO::ctgraph_ring
+      : NCCL_ALLGATHER_ALGO::ctgraph_rd;
+}
+
+} // namespace
+
 commResult_t ctranAllGatherCudagraphAware(
     const void* sendbuff,
     void* recvbuff,
     size_t sendcount,
     commDataType_t datatype,
     CtranComm* comm,
-    cudaStream_t stream) {
+    cudaStream_t stream,
+    enum NCCL_ALLGATHER_ALGO algo) {
   const auto statex = comm->statex_.get();
   const int nRanks = statex->nRanks();
   const size_t recvBytes = sendcount * commTypeSize(datatype) * nRanks;
 
+  // auto-select algo if not specified
+  if (algo == NCCL_ALLGATHER_ALGO::ctgraph) {
+    algo = selectCtgraphAlgo(sendcount * commTypeSize(datatype), statex);
+  }
+
   CLOGF_SUBSYS(
       INFO,
       COLL,
-      "AllGather cudagraph-aware: converting to window-based AGP "
-      "(sendcount={}, nRanks={}, recvBytes={})",
+      "AllGather cudagraph-aware: algo={} "
+      "(sendcount={}, nRanks={}, nLocalRanks={}, recvBytes={})",
+      allGatherAlgoName(algo),
       sendcount,
       nRanks,
+      statex->nLocalRanks(),
       recvBytes);
 
-  // 1. Register recvbuff as a window and exchange handles with all peers.
-  //    Collective and CPU-side — NOT captured into the graph.
+  // Buffer registration + cleanup guard
   ctran::CtranWin* win = nullptr;
-  FB_COMMCHECK(ctran::ctranWinRegister(recvbuff, recvBytes, comm, &win));
-
-  // 2. Init persistent AGP from window metadata.
-  //    Switch to relaxed capture mode so initResources() can cudaHostAlloc
-  //    (blocked under cudaStreamCaptureModeGlobal used by PyTorch).
-  //    Single-threaded-per-comm assumption (standard for NCCL).
-  auto winGuard = folly::makeGuard([win]() { delete win; });
-
   CtranPersistentRequest* request = nullptr;
-  {
-    meta::comms::StreamCaptureModeGuard captureGuard{
-        cudaStreamCaptureModeRelaxed};
-    FB_COMMCHECK(ctran::allGatherWinInit(win, comm, stream, request));
+
+  switch (algo) {
+    case NCCL_ALLGATHER_ALGO::ctgraph_pipeline:
+      FB_COMMCHECK(
+          winPersistBuffReg(recvbuff, recvBytes, comm, stream, &win, &request));
+      break;
+    case NCCL_ALLGATHER_ALGO::ctgraph_ring:
+    case NCCL_ALLGATHER_ALGO::ctgraph_rd:
+      FB_COMMCHECK(localPersistBuffReg(recvbuff, recvBytes));
+      break;
+    default:
+      FB_ERRORRETURN(
+          commInvalidArgument,
+          "Unexpected algo {} in ctranAllGatherCudagraphAware",
+          allGatherAlgoName(algo));
   }
 
-  // 3. Dry-run exec — CE copies and GPE host-node callbacks are captured.
-  FB_COMMCHECK(ctran::allGatherWinExec(sendbuff, sendcount, datatype, request));
+  // Cleanup lambda: shared between error guard and deferred cleanup.
+  std::function<void()> cleanup;
+  switch (algo) {
+    case NCCL_ALLGATHER_ALGO::ctgraph_pipeline:
+      cleanup = [request, win]() {
+        if (request) {
+          ctran::allGatherWinDestroy(request);
+          delete request;
+        }
+        if (win) {
+          win->free(true /* skipBarrier */);
+          delete win;
+        }
+      };
+      break;
+    case NCCL_ALLGATHER_ALGO::ctgraph_ring:
+    case NCCL_ALLGATHER_ALGO::ctgraph_rd:
+      cleanup = [recvbuff, recvBytes]() {
+        ctran::globalDeregisterWithPtr(recvbuff, recvBytes);
+      };
+      break;
+    default:
+      break;
+  }
 
-  // 4. Register cleanup on comm at capture time. Resources live for the
-  //    comm's lifetime and are cleaned up during CtranComm::destroy() on
-  //    the main thread. This avoids depending on retainUserObject callbacks
-  //    which run on CUDA's internal thread where CUDA APIs are forbidden.
-  winGuard.dismiss();
-  comm->cudagraphDeferredCleanup.add([request, win]() {
-    if (request) {
-      ctran::allGatherWinDestroy(request);
-      delete request;
-    }
-    if (win) {
-      win->free(true /* skipBarrier */);
-      delete win;
+  auto cleanupGuard = folly::makeGuard([&cleanup]() {
+    if (cleanup) {
+      cleanup();
     }
   });
+
+  // Execute (captured into graph)
+  switch (algo) {
+    case NCCL_ALLGATHER_ALGO::ctgraph_pipeline: {
+      auto savedPAlgo = NCCL_ALLGATHER_P_ALGO;
+      NCCL_ALLGATHER_P_ALGO = NCCL_ALLGATHER_P_ALGO::ctpipeline;
+      auto pAlgoGuard = folly::makeGuard(
+          [savedPAlgo]() { NCCL_ALLGATHER_P_ALGO = savedPAlgo; });
+      FB_COMMCHECK(
+          ctran::allGatherWinExec(sendbuff, sendcount, datatype, request));
+      break;
+    }
+    case NCCL_ALLGATHER_ALGO::ctgraph_ring:
+      FB_COMMCHECK(ctranAllGatherRing(
+          sendbuff, recvbuff, sendcount, datatype, comm, stream));
+      break;
+    case NCCL_ALLGATHER_ALGO::ctgraph_rd:
+      FB_COMMCHECK(ctranAllGatherRd(
+          sendbuff, recvbuff, sendcount, datatype, comm, stream));
+      break;
+    default:
+      break;
+  }
+
+  // Success — transfer ownership to deferred cleanup
+  cleanupGuard.dismiss();
+  comm->cudagraphDeferredCleanup.add(std::move(cleanup));
 
   return commSuccess;
 }

--- a/comms/ctran/algos/AllGather/AllGatherCudagraphAware.cc
+++ b/comms/ctran/algos/AllGather/AllGatherCudagraphAware.cc
@@ -10,7 +10,7 @@
 //      captured into the graph.
 //   2. allGatherWinInit() — create persistent AGP state from window metadata.
 //      Synchronous, no async handle exchange needed. Uses
-//      cudaThreadExchangeStreamCaptureMode to temporarily allow cudaHostAlloc
+//      StreamCaptureModeGuard to temporarily allow cudaHostAlloc
 //      (blocked under cudaStreamCaptureModeGlobal used by PyTorch).
 //   3. allGatherWinExec() — dry-run exec that IS captured into the graph.
 //      CE copies (NVL intra-node) and GPE host-node callbacks (IB inter-node)
@@ -33,6 +33,7 @@
 #include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/ctran/utils/CudaGraphUtils.h"
 #include "comms/ctran/window/CtranWin.h"
+#include "comms/utils/CudaRAII.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
 commResult_t ctranAllGatherCudagraphAware(
@@ -66,16 +67,12 @@ commResult_t ctranAllGatherCudagraphAware(
   //    Single-threaded-per-comm assumption (standard for NCCL).
   auto winGuard = folly::makeGuard([win]() { delete win; });
 
-  cudaStreamCaptureMode prevMode = cudaStreamCaptureModeRelaxed;
-  FB_CUDACHECK(cudaThreadExchangeStreamCaptureMode(&prevMode));
-
   CtranPersistentRequest* request = nullptr;
-  // Store result instead of FB_COMMCHECK — must restore capture mode before
-  // any early return.
-  auto initResult = ctran::allGatherWinInit(win, comm, stream, request);
-
-  FB_CUDACHECK(cudaThreadExchangeStreamCaptureMode(&prevMode));
-  FB_COMMCHECK(initResult);
+  {
+    meta::comms::StreamCaptureModeGuard captureGuard{
+        cudaStreamCaptureModeRelaxed};
+    FB_COMMCHECK(ctran::allGatherWinInit(win, comm, stream, request));
+  }
 
   // 3. Dry-run exec — CE copies and GPE host-node callbacks are captured.
   FB_COMMCHECK(ctran::allGatherWinExec(sendbuff, sendcount, datatype, request));

--- a/comms/ctran/algos/AllGather/AllGatherImpl.h
+++ b/comms/ctran/algos/AllGather/AllGatherImpl.h
@@ -55,6 +55,12 @@ static inline const std::string allGatherAlgoName(
       return "CtranAuto";
     case NCCL_ALLGATHER_ALGO::ctgraph:
       return "CtranCudagraphAware";
+    case NCCL_ALLGATHER_ALGO::ctgraph_pipeline:
+      return "CtranCudagraphPipeline";
+    case NCCL_ALLGATHER_ALGO::ctgraph_ring:
+      return "CtranCudagraphRing";
+    case NCCL_ALLGATHER_ALGO::ctgraph_rd:
+      return "CtranCudagraphRd";
     case NCCL_ALLGATHER_ALGO::orig:
       return "Baseline";
     default:
@@ -70,7 +76,8 @@ commResult_t ctranAllGatherCudagraphAware(
     size_t sendcount,
     commDataType_t datatype,
     CtranComm* comm,
-    cudaStream_t stream);
+    cudaStream_t stream,
+    enum NCCL_ALLGATHER_ALGO algo = NCCL_ALLGATHER_ALGO::ctgraph);
 
 commResult_t prepareAllGatherArgs(
     std::vector<std::unique_ptr<struct OpElem>>& opGroup,

--- a/comms/ctran/algos/AllGather/tests/AllGatherCtgraphSupportTest.cc
+++ b/comms/ctran/algos/AllGather/tests/AllGatherCtgraphSupportTest.cc
@@ -1,0 +1,41 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include "comms/ctran/Ctran.h"
+#include "comms/ctran/algos/AllGather/AllGatherImpl.h"
+#include "comms/ctran/tests/CtranTestUtils.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+
+namespace ctran::testing {
+
+class AllGatherCtgraphSupportTest : public CtranStandaloneFixture {
+ protected:
+  void SetUp() override {
+    CtranStandaloneFixture::SetUp();
+    comm_ = makeCtranComm();
+    ASSERT_NE(comm_, nullptr);
+  }
+
+  std::unique_ptr<CtranComm> comm_;
+};
+
+TEST_F(AllGatherCtgraphSupportTest, NullStream) {
+  EXPECT_FALSE(ctranAllGatherSupport(
+      comm_.get(), NCCL_ALLGATHER_ALGO::ctgraph, nullptr));
+  EXPECT_FALSE(ctranAllGatherSupport(
+      comm_.get(), NCCL_ALLGATHER_ALGO::ctgraph_pipeline, nullptr));
+  EXPECT_FALSE(ctranAllGatherSupport(
+      comm_.get(), NCCL_ALLGATHER_ALGO::ctgraph_ring, nullptr));
+  EXPECT_FALSE(ctranAllGatherSupport(
+      comm_.get(), NCCL_ALLGATHER_ALGO::ctgraph_rd, nullptr));
+}
+
+TEST_F(AllGatherCtgraphSupportTest, EagerAlgosUnaffected) {
+  EXPECT_TRUE(ctranAllGatherSupport(
+      comm_.get(), NCCL_ALLGATHER_ALGO::ctdirect, stream->get()));
+  EXPECT_TRUE(ctranAllGatherSupport(
+      comm_.get(), NCCL_ALLGATHER_ALGO::ctran, stream->get()));
+}
+
+} // namespace ctran::testing

--- a/comms/ctran/algos/CtranAlgo.cc
+++ b/comms/ctran/algos/CtranAlgo.cc
@@ -631,7 +631,10 @@ static const std::unordered_map<std::string, enum NCCL_ALLGATHER_ALGO>
         {"ctring", NCCL_ALLGATHER_ALGO::ctring},
         {"ctrd", NCCL_ALLGATHER_ALGO::ctrd},
         {"ctbrucks", NCCL_ALLGATHER_ALGO::ctbrucks},
-        {"ctgraph", NCCL_ALLGATHER_ALGO::ctgraph}};
+        {"ctgraph", NCCL_ALLGATHER_ALGO::ctgraph},
+        {"ctgraph_pipeline", NCCL_ALLGATHER_ALGO::ctgraph_pipeline},
+        {"ctgraph_ring", NCCL_ALLGATHER_ALGO::ctgraph_ring},
+        {"ctgraph_rd", NCCL_ALLGATHER_ALGO::ctgraph_rd}};
 
 // FIXME: consolidate ctranConfigCommAlgoOverride with the algo config
 commResult_t ctranConfigCommAlgoOverride(CtranComm* comm) {

--- a/comms/ctran/gpe/CtranGpe.cc
+++ b/comms/ctran/gpe/CtranGpe.cc
@@ -13,6 +13,51 @@
 
 using namespace ctran;
 
+namespace {
+std::string kernelTypeToOpName(KernelConfig::KernelType type) {
+  switch (type) {
+    case KernelConfig::ALLGATHER:
+    case KernelConfig::ALLGATHERP:
+    // ALLGATHERP_INIT goes through submitHost(), not submit(), so this
+    // case is currently unreachable. Included for completeness.
+    case KernelConfig::ALLGATHERP_INIT:
+      return "AllGather";
+    case KernelConfig::ALLREDUCE:
+      return "AllReduce";
+    case KernelConfig::SEND:
+    case KernelConfig::RECV:
+    case KernelConfig::SENDRECV:
+    case KernelConfig::SENDRECV_P2P:
+    case KernelConfig::RECV_UNPACK:
+    case KernelConfig::SENDRECV_UNPACK:
+      return "SendRecv";
+    case KernelConfig::ALLTOALL:
+    case KernelConfig::ALLTOALL_DEDUP:
+    case KernelConfig::DEVICE_ALLTOALLV:
+    case KernelConfig::ALLTOALLV:
+    case KernelConfig::ALLTOALLV_DYNAMIC:
+    case KernelConfig::ALLTOALLV_DYNAMIC_SPLIT:
+    case KernelConfig::ALLTOALLV_DYNAMIC_SPLIT_NON_CONTIG:
+    case KernelConfig::ALLTOALLV_DEDUP:
+      return "AllToAll";
+    case KernelConfig::BROADCAST:
+    case KernelConfig::BROADCAST_UNPACK:
+      return "Broadcast";
+    case KernelConfig::REDUCESCATTER:
+      return "ReduceScatter";
+    case KernelConfig::PUTNOTIFY:
+    case KernelConfig::WAITNOTIFY:
+    case KernelConfig::PUTSIGNAL:
+    case KernelConfig::WAITSIGNAL:
+    case KernelConfig::SIGNAL:
+    case KernelConfig::GET:
+      return "RMA";
+    default:
+      return "Unknown";
+  }
+}
+} // namespace
+
 OpElem::OpElem(enum opType type, CtranComm* comm, uint64_t opCount)
     : OpElem(type, nullptr, comm, nullptr, opCount) {};
 
@@ -394,6 +439,10 @@ commResult_t CtranGpe::submit(
     const void* ncclKernel,
     std::optional<std::chrono::milliseconds> timeout,
     PreLaunchGraphPrepareFn graphPrepareFn) {
+  if (this->pimpl->comm->algoStats_) {
+    this->pimpl->comm->algoStats_->record(
+        kernelTypeToOpName(kernelConfig.type), kernelConfig.algoName);
+  }
   return this->pimpl->submit(
       CtranGpeCmd::TypeEnum::GRAPH_ENQUEUE,
       std::move(opGroup),

--- a/comms/ctran/tests/CtranDistAllgatherTests.cc
+++ b/comms/ctran/tests/CtranDistAllgatherTests.cc
@@ -15,6 +15,7 @@
 #include "comms/ctran/colltrace/CollTraceWrapper.h"
 #include "comms/ctran/profiler/Profiler.h"
 #include "comms/ctran/tests/CtranDistTestUtils.h"
+#include "comms/ctran/tests/VerifyAlgoStatsUtil.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsCuUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -32,9 +33,12 @@ class CtranAllgatherTest : public ctran::CtranDistTestFixture,
   void *sCommBuf, *rCommBuf, *pCommBuf;
   std::vector<TestMemSegment> segments;
 
+  ctran::test::VerifyAlgoStatsHelper algoStats_;
+
   void SetUp() override {
     setenv("NCCL_CTRAN_TRANSPORT_PROFILER", "1", 0);
     setenv("NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT", "1", 0);
+    algoStats_.enable();
     ctran::CtranDistTestFixture::SetUp();
     ctranComm = makeCtranComm();
     segments.clear();
@@ -255,6 +259,8 @@ TEST_P(CtranAllgatherTestParam, AllgatherAlgo) {
         coll["algoName"].asString(), testing::HasSubstr(expAlgoNames.at(idx)));
     idx++;
   }
+
+  algoStats_.verify(ctranComm.get(), "AllGather", allGatherAlgoName(algo));
 
   for (auto& segment : segments) {
     COMMCHECK_TEST(ctran::globalDeregisterWithPtr(segment.ptr, segment.size));

--- a/comms/ctran/tests/CtranNcclTestUtils.h
+++ b/comms/ctran/tests/CtranNcclTestUtils.h
@@ -83,6 +83,8 @@ class CtranNcclTestHelpers : public CtranTestHelpers {
 // Defaults to kMemNcclMemAlloc for NVL-registered buffers.
 class TestDeviceBuffer {
  public:
+  TestDeviceBuffer() = default;
+
   explicit TestDeviceBuffer(
       size_t size,
       MemAllocType memType = kMemNcclMemAlloc,
@@ -126,6 +128,8 @@ class TestDeviceBuffer {
       ptr_ = other.ptr_;
       size_ = other.size_;
       memType_ = other.memType_;
+      numSegments_ = other.numSegments_;
+      refCheck_ = other.refCheck_;
       segments_ = std::move(other.segments_);
       other.ptr_ = nullptr;
       other.size_ = 0;

--- a/comms/ctran/tests/VerifyAlgoStatsUtil.cc
+++ b/comms/ctran/tests/VerifyAlgoStatsUtil.cc
@@ -1,0 +1,95 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "VerifyAlgoStatsUtil.h"
+
+#include <fmt/core.h>
+#include <gtest/gtest.h>
+#include "comms/utils/cvars/nccl_cvars.h"
+
+namespace ctran::test {
+
+VerifyAlgoStatsHelper::~VerifyAlgoStatsHelper() {
+  if (enabled_) {
+    NCCL_COLLTRACE = oldColltrace_;
+  }
+}
+
+void VerifyAlgoStatsHelper::enable() {
+  oldColltrace_ = NCCL_COLLTRACE;
+  NCCL_COLLTRACE.push_back("algostat");
+  enabled_ = true;
+}
+
+namespace {
+
+std::string formatStats(const std::unordered_map<std::string, int64_t>& stats) {
+  std::string result;
+  for (const auto& [name, count] : stats) {
+    if (!result.empty()) {
+      result += ", ";
+    }
+    result += fmt::format("{}({})", name, count);
+  }
+  return result;
+}
+
+} // namespace
+
+void VerifyAlgoStatsHelper::verify(
+    CtranComm* comm,
+    const std::string& collective,
+    const std::string& expectedAlgoSubstr) const {
+  auto statDumpOpt = comm->dumpAlgoStats();
+  ASSERT_TRUE(statDumpOpt.has_value());
+  auto statDump = std::move(*statDumpOpt);
+  auto it = statDump.counts.find(collective);
+  ASSERT_NE(it, statDump.counts.end())
+      << collective << " not found in AlgoStats";
+  bool found = false;
+  for (const auto& [algoName, callCount] : it->second) {
+    if (algoName.find(expectedAlgoSubstr) != std::string::npos &&
+        callCount > 0) {
+      found = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(found) << "Expected algorithm containing '" << expectedAlgoSubstr
+                     << "' not found in " << collective
+                     << ". Found: " << formatStats(it->second);
+}
+
+void VerifyAlgoStatsHelper::verifyNot(
+    CtranComm* comm,
+    const std::string& collective,
+    const std::string& unexpectedAlgoSubstr) const {
+  auto statDumpOpt = comm->dumpAlgoStats();
+  ASSERT_TRUE(statDumpOpt.has_value());
+  auto statDump = std::move(*statDumpOpt);
+  auto it = statDump.counts.find(collective);
+  if (it == statDump.counts.end()) {
+    return;
+  }
+  for (const auto& [algoName, callCount] : it->second) {
+    EXPECT_FALSE(
+        algoName.find(unexpectedAlgoSubstr) != std::string::npos &&
+        callCount > 0)
+        << "Unexpected algorithm '" << algoName << "' with count " << callCount
+        << " found in " << collective;
+  }
+}
+
+void VerifyAlgoStatsHelper::dump(CtranComm* comm, const std::string& collective)
+    const {
+  auto statDumpOpt = comm->dumpAlgoStats();
+  if (!statDumpOpt) {
+    return;
+  }
+  auto statDump = std::move(*statDumpOpt);
+  auto it = statDump.counts.find(collective);
+  if (it != statDump.counts.end()) {
+    fmt::print(
+        stderr, "AlgoStats[{}]: [{}]\n", collective, formatStats(it->second));
+  }
+}
+
+} // namespace ctran::test

--- a/comms/ctran/tests/VerifyAlgoStatsUtil.h
+++ b/comms/ctran/tests/VerifyAlgoStatsUtil.h
@@ -1,0 +1,35 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <string>
+#include "comms/ctran/CtranComm.h"
+
+namespace ctran::test {
+
+// TODO: Migrate to colltrace once CUDA graph colltrace support is fixed.
+class VerifyAlgoStatsHelper {
+ public:
+  ~VerifyAlgoStatsHelper();
+
+  // Enable AlgoStats tracing. Must be called before CtranComm creation.
+  void enable();
+
+  void verify(
+      CtranComm* comm,
+      const std::string& collective,
+      const std::string& expectedAlgoSubstr) const;
+
+  void verifyNot(
+      CtranComm* comm,
+      const std::string& collective,
+      const std::string& unexpectedAlgoSubstr) const;
+
+  void dump(CtranComm* comm, const std::string& collective) const;
+
+ private:
+  bool enabled_{false};
+  std::vector<std::string> oldColltrace_;
+};
+
+} // namespace ctran::test

--- a/comms/ctran/tests/cudagraph/CtranCudaGraphAllGatherCtgraphTest.cc
+++ b/comms/ctran/tests/cudagraph/CtranCudaGraphAllGatherCtgraphTest.cc
@@ -6,6 +6,8 @@
 // ctranAllGather transparently converts to the persistent window-based AGP
 // algorithm.
 
+#include <random>
+
 #include "comms/ctran/algos/AllGather/AllGatherImpl.h"
 #include "comms/ctran/tests/cudagraph/CtranCudaGraphParamTest.h"
 
@@ -61,6 +63,87 @@ static AlgoDescriptor makeAllGatherCtgraph() {
 }
 
 DEFINE_CUDAGRAPH_PARAM_TEST(CudaGraphAllGatherCtgraph, makeAllGatherCtgraph());
+
+// Expandable segment test: verifies cudagraph-aware AllGather with
+// kCuMemAllocDisjoint memory (multiple disjoint physical segments per buffer,
+// 20MB each) and a random offset from the allocation base.
+class CudaGraphAllGatherCtgraphExpandable
+    : public CtranCudaGraphTestBase,
+      public ::testing::WithParamInterface<size_t> {};
+
+static constexpr size_t kSegmentSize = 20UL * 1024 * 1024;
+
+static size_t segmentsNeeded(size_t bytes) {
+  return (bytes + kSegmentSize - 1) / kSegmentSize;
+}
+
+TEST_P(CudaGraphAllGatherCtgraphExpandable, CaptureReplayVerify) {
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+
+  if (!ctran::allGatherPSupport(comm.get())) {
+    GTEST_SKIP() << "allGatherP not supported";
+  }
+
+  const size_t count = GetParam();
+  const int nRanks = numRanks;
+
+  std::mt19937 rng(globalRank);
+  const size_t offsetElems = rng() % 4096 + 1;
+  const size_t offsetBytes = offsetElems * sizeof(int32_t);
+
+  const size_t sendDataBytes = count * sizeof(int32_t);
+  const size_t recvDataBytes = count * nRanks * sizeof(int32_t);
+
+  const size_t sendNumSeg = segmentsNeeded(sendDataBytes + offsetBytes);
+  const size_t recvNumSeg = segmentsNeeded(recvDataBytes + offsetBytes);
+
+  ctran::TestDeviceBuffer send(
+      sendNumSeg * kSegmentSize, kCuMemAllocDisjoint, sendNumSeg);
+  ctran::TestDeviceBuffer recv(
+      recvNumSeg * kSegmentSize, kCuMemAllocDisjoint, recvNumSeg);
+
+  auto* sendbuf = static_cast<char*>(send.get()) + offsetBytes;
+  auto* recvbuf = static_cast<char*>(recv.get()) + offsetBytes;
+
+  fillSendBuf(sendbuf, count, globalRank);
+
+  meta::comms::CudaStream stream(cudaStreamNonBlocking);
+
+  // Capture
+  cudaGraph_t graph;
+  cudaGraphExec_t exec;
+  ASSERT_EQ(
+      cudaStreamBeginCapture(stream.get(), cudaStreamCaptureModeGlobal),
+      cudaSuccess);
+  ASSERT_EQ(
+      ctranAllGather(
+          sendbuf,
+          recvbuf,
+          count,
+          commInt32,
+          comm.get(),
+          stream.get(),
+          NCCL_ALLGATHER_ALGO::ctgraph),
+      commSuccess);
+  ASSERT_EQ(cudaStreamEndCapture(stream.get(), &graph), cudaSuccess);
+  ASSERT_EQ(cudaGraphInstantiate(&exec, graph, 0), cudaSuccess);
+
+  // Replay
+  ASSERT_EQ(cudaGraphLaunch(exec, stream.get()), cudaSuccess);
+  ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
+
+  // Verify
+  verifyAllGather(recvbuf, count, nRanks);
+
+  ASSERT_EQ(cudaGraphExecDestroy(exec), cudaSuccess);
+  ASSERT_EQ(cudaGraphDestroy(graph), cudaSuccess);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CudaGraphAllGatherCtgraphExpandableTests,
+    CudaGraphAllGatherCtgraphExpandable,
+    ::testing::Values(2097152UL, 10485760UL));
 
 // Verifies that graph destruction cleans up without CUDA API errors.
 // The retainUserObject destructor callback defers cleanup to comm destruction

--- a/comms/ctran/tests/cudagraph/CtranCudaGraphAllGatherCtgraphTest.cc
+++ b/comms/ctran/tests/cudagraph/CtranCudaGraphAllGatherCtgraphTest.cc
@@ -1,17 +1,18 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
-// Tests for the ctgraph AllGather algorithm.
-// When algo=ctgraph, ctranAllGatherSupport returns true only during CUDA graph
-// capture (and falls back to baseline otherwise). During capture,
-// ctranAllGather transparently converts to the persistent window-based AGP
-// algorithm.
+// Tests for the ctgraph AllGather algorithm variants.
+// ctgraph auto-selects based on topology; ctgraph_pipeline, ctgraph_ring,
+// ctgraph_rd allow explicit selection. All variants are only active during
+// CUDA graph capture and fall back to baseline otherwise.
 
 #include <random>
 
 #include "comms/ctran/algos/AllGather/AllGatherImpl.h"
+#include "comms/ctran/tests/VerifyAlgoStatsUtil.h"
 #include "comms/ctran/tests/cudagraph/CtranCudaGraphParamTest.h"
 
-static AlgoDescriptor makeAllGatherCtgraph() {
+static AlgoDescriptor makeAllGatherCtgraph(
+    enum NCCL_ALLGATHER_ALGO algo = NCCL_ALLGATHER_ALGO::ctgraph) {
   struct B : AlgoDescriptor::Buffers {
     ctran::TestDeviceBuffer send, recv;
     size_t bytes;
@@ -33,9 +34,18 @@ static AlgoDescriptor makeAllGatherCtgraph() {
   };
 
   AlgoDescriptor desc;
-  desc.name = "AllGatherCtgraph";
-  desc.isSupported = [](CtranComm* comm, size_t, int) {
-    return ctran::allGatherPSupport(comm);
+  desc.name = allGatherAlgoName(algo);
+  desc.isSupported = [algo](CtranComm* comm, size_t, int) {
+    if (!ctran::allGatherPSupport(comm)) {
+      return false;
+    }
+    const auto statex = comm->statex_.get();
+    if ((algo == NCCL_ALLGATHER_ALGO::ctgraph_ring ||
+         algo == NCCL_ALLGATHER_ALGO::ctgraph_rd) &&
+        statex->nLocalRanks() > 1) {
+      return false;
+    }
+    return true;
   };
   desc.expectsHostNodes = [](CtranComm* comm, size_t) {
     auto statex = comm->statex_.get();
@@ -44,10 +54,17 @@ static AlgoDescriptor makeAllGatherCtgraph() {
   desc.makeBuffers = [](size_t c, int rank, int nR) {
     return std::make_shared<B>(c, rank, nR);
   };
-  desc.capture = [](AlgoDescriptor::Buffers* base,
-                    size_t count,
-                    ctran::testing::CaptureContext& ctx) {
+  desc.capture = [algo](
+                     AlgoDescriptor::Buffers* base,
+                     size_t count,
+                     ctran::testing::CaptureContext& ctx) {
     auto* b = static_cast<B*>(base);
+    // Use specified algo during capture, ctran for eager warmup
+    cudaStreamCaptureStatus status;
+    ASSERT_EQ(cudaStreamIsCapturing(ctx.stream, &status), cudaSuccess);
+    const auto resolvedAlgo = (status == cudaStreamCaptureStatusActive)
+        ? algo
+        : NCCL_ALLGATHER_ALGO::ctran;
     ASSERT_EQ(
         ctranAllGather(
             b->send.get(),
@@ -56,20 +73,26 @@ static AlgoDescriptor makeAllGatherCtgraph() {
             commInt32,
             ctx.comm,
             ctx.stream,
-            NCCL_ALLGATHER_ALGO::ctgraph),
+            resolvedAlgo),
         commSuccess);
   };
   return desc;
 }
 
-DEFINE_CUDAGRAPH_PARAM_TEST(CudaGraphAllGatherCtgraph, makeAllGatherCtgraph());
+DEFINE_CUDAGRAPH_PARAM_TEST(
+    CudaGraphAllGatherCtgraph,
+    makeAllGatherCtgraph(),
+    makeAllGatherCtgraph(NCCL_ALLGATHER_ALGO::ctgraph_pipeline),
+    makeAllGatherCtgraph(NCCL_ALLGATHER_ALGO::ctgraph_ring),
+    makeAllGatherCtgraph(NCCL_ALLGATHER_ALGO::ctgraph_rd));
 
 // Expandable segment test: verifies cudagraph-aware AllGather with
 // kCuMemAllocDisjoint memory (multiple disjoint physical segments per buffer,
 // 20MB each) and a random offset from the allocation base.
 class CudaGraphAllGatherCtgraphExpandable
     : public CtranCudaGraphTestBase,
-      public ::testing::WithParamInterface<size_t> {};
+      public ::testing::WithParamInterface<
+          std::tuple<enum NCCL_ALLGATHER_ALGO, size_t>> {};
 
 static constexpr size_t kSegmentSize = 20UL * 1024 * 1024;
 
@@ -78,6 +101,7 @@ static size_t segmentsNeeded(size_t bytes) {
 }
 
 TEST_P(CudaGraphAllGatherCtgraphExpandable, CaptureReplayVerify) {
+  const auto [algo, count] = GetParam();
   auto comm = makeCtranComm();
   ASSERT_NE(comm, nullptr);
 
@@ -85,7 +109,13 @@ TEST_P(CudaGraphAllGatherCtgraphExpandable, CaptureReplayVerify) {
     GTEST_SKIP() << "allGatherP not supported";
   }
 
-  const size_t count = GetParam();
+  const auto statex = comm->statex_.get();
+  if ((algo == NCCL_ALLGATHER_ALGO::ctgraph_ring ||
+       algo == NCCL_ALLGATHER_ALGO::ctgraph_rd) &&
+      statex->nLocalRanks() > 1) {
+    GTEST_SKIP() << allGatherAlgoName(algo) << " requires nLocalRanks == 1";
+  }
+
   const int nRanks = numRanks;
 
   std::mt19937 rng(globalRank);
@@ -118,13 +148,7 @@ TEST_P(CudaGraphAllGatherCtgraphExpandable, CaptureReplayVerify) {
       cudaSuccess);
   ASSERT_EQ(
       ctranAllGather(
-          sendbuf,
-          recvbuf,
-          count,
-          commInt32,
-          comm.get(),
-          stream.get(),
-          NCCL_ALLGATHER_ALGO::ctgraph),
+          sendbuf, recvbuf, count, commInt32, comm.get(), stream.get(), algo),
       commSuccess);
   ASSERT_EQ(cudaStreamEndCapture(stream.get(), &graph), cudaSuccess);
   ASSERT_EQ(cudaGraphInstantiate(&exec, graph, 0), cudaSuccess);
@@ -140,10 +164,119 @@ TEST_P(CudaGraphAllGatherCtgraphExpandable, CaptureReplayVerify) {
   ASSERT_EQ(cudaGraphDestroy(graph), cudaSuccess);
 }
 
+std::string expandableTestName(
+    const ::testing::TestParamInfo<
+        std::tuple<enum NCCL_ALLGATHER_ALGO, size_t>>& info) {
+  const auto& [algo, count] = info.param;
+  return allGatherAlgoName(algo) + "_" + std::to_string(count);
+}
+
 INSTANTIATE_TEST_SUITE_P(
     CudaGraphAllGatherCtgraphExpandableTests,
     CudaGraphAllGatherCtgraphExpandable,
-    ::testing::Values(2097152UL, 10485760UL));
+    ::testing::Combine(
+        ::testing::Values(
+            NCCL_ALLGATHER_ALGO::ctgraph,
+            NCCL_ALLGATHER_ALGO::ctgraph_pipeline,
+            NCCL_ALLGATHER_ALGO::ctgraph_ring,
+            NCCL_ALLGATHER_ALGO::ctgraph_rd),
+        ::testing::Values(2097152UL, 10485760UL)),
+    expandableTestName);
+
+// Verifies ctgraph auto-select picks the correct algorithm based on topology
+// and message size. Parameterized by sendcount (element count).
+// nLocalRanks > 1 → pipeline; nLocalRanks == 1 + small msg → rd;
+// nLocalRanks == 1 + large msg (>= threshold) → ring.
+struct AutoSelectParam {
+  std::string name;
+  size_t count;
+  std::string expectedAlgoWhenLocal;
+  std::string expectedAlgoWhenNolocal;
+};
+
+class CudaGraphAllGatherCtgraphAutoSelect
+    : public CtranCudaGraphTestBase,
+      public ::testing::WithParamInterface<AutoSelectParam> {
+ protected:
+  ctran::test::VerifyAlgoStatsHelper algoStats_;
+
+  void SetUp() override {
+    CtranCudaGraphTestBase::SetUp();
+    algoStats_.enable();
+  }
+};
+
+TEST_P(CudaGraphAllGatherCtgraphAutoSelect, CaptureReplayVerify) {
+  const auto& param = GetParam();
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+
+  if (!ctran::allGatherPSupport(comm.get())) {
+    GTEST_SKIP() << "allGatherP not supported";
+  }
+
+  const size_t count = param.count;
+  const int nRanks = numRanks;
+  const auto statex = comm->statex_.get();
+
+  // Large msg test only meaningful with nLocalRanks == 1
+  if (count * sizeof(int32_t) >= NCCL_CTGRAPH_ALLGATHER_RING_THRESHOLD &&
+      statex->nLocalRanks() > 1) {
+    GTEST_SKIP() << "Large message ring test requires nLocalRanks == 1";
+  }
+
+  ctran::TestDeviceBuffer send(count * sizeof(int32_t));
+  ctran::TestDeviceBuffer recv(count * nRanks * sizeof(int32_t));
+  fillSendBuf(send.get(), count, globalRank);
+
+  meta::comms::CudaStream stream(cudaStreamNonBlocking);
+
+  cudaGraph_t graph;
+  cudaGraphExec_t exec;
+  ASSERT_EQ(
+      cudaStreamBeginCapture(stream.get(), cudaStreamCaptureModeGlobal),
+      cudaSuccess);
+  ASSERT_EQ(
+      ctranAllGather(
+          send.get(),
+          recv.get(),
+          count,
+          commInt32,
+          comm.get(),
+          stream.get(),
+          NCCL_ALLGATHER_ALGO::ctgraph),
+      commSuccess);
+  ASSERT_EQ(cudaStreamEndCapture(stream.get(), &graph), cudaSuccess);
+  ASSERT_EQ(cudaGraphInstantiate(&exec, graph, 0), cudaSuccess);
+
+  ASSERT_EQ(cudaGraphLaunch(exec, stream.get()), cudaSuccess);
+  ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
+
+  verifyAllGather(recv.get(), count, nRanks);
+
+  const auto& expectedAlgo = (statex->nLocalRanks() > 1)
+      ? param.expectedAlgoWhenLocal
+      : param.expectedAlgoWhenNolocal;
+  algoStats_.verify(comm.get(), "AllGather", expectedAlgo);
+
+  ASSERT_EQ(cudaGraphExecDestroy(exec), cudaSuccess);
+  ASSERT_EQ(cudaGraphDestroy(graph), cudaSuccess);
+}
+
+// 128MB / sizeof(int32_t) — matches NCCL_CTGRAPH_ALLGATHER_RING_THRESHOLD
+// default. Hardcoded because INSTANTIATE runs at static init before cvars are
+// initialized.
+static constexpr size_t kRingThresholdCount = 134217728UL / sizeof(int32_t);
+
+INSTANTIATE_TEST_SUITE_P(
+    CudaGraphAllGatherCtgraphAutoSelectTests,
+    CudaGraphAllGatherCtgraphAutoSelect,
+    ::testing::Values(
+        AutoSelectParam{"SmallMsg", 1024, "Pipeline", "Rd"},
+        AutoSelectParam{"LargeMsg", kRingThresholdCount, "Pipeline", "Ring"}),
+    [](const ::testing::TestParamInfo<AutoSelectParam>& info) {
+      return info.param.name;
+    });
 
 // Verifies that graph destruction cleans up without CUDA API errors.
 // The retainUserObject destructor callback defers cleanup to comm destruction

--- a/comms/ncclx/meta/algoconf/AlgoConfig.cc
+++ b/comms/ncclx/meta/algoconf/AlgoConfig.cc
@@ -50,8 +50,14 @@ inline const std::string algoValToStr(enum NCCL_ALLGATHER_ALGO val) {
       return "ctbrucks";
     case NCCL_ALLGATHER_ALGO::ctgraph:
       return "ctgraph";
-      break;
+    case NCCL_ALLGATHER_ALGO::ctgraph_pipeline:
+      return "ctgraph_pipeline";
+    case NCCL_ALLGATHER_ALGO::ctgraph_ring:
+      return "ctgraph_ring";
+    case NCCL_ALLGATHER_ALGO::ctgraph_rd:
+      return "ctgraph_rd";
   }
+  return "unknown";
 }
 
 inline void algoStrToVal(
@@ -69,6 +75,12 @@ inline void algoStrToVal(
     val = NCCL_ALLGATHER_ALGO::ctbrucks;
   } else if (str == "ctgraph") {
     val = NCCL_ALLGATHER_ALGO::ctgraph;
+  } else if (str == "ctgraph_pipeline") {
+    val = NCCL_ALLGATHER_ALGO::ctgraph_pipeline;
+  } else if (str == "ctgraph_ring") {
+    val = NCCL_ALLGATHER_ALGO::ctgraph_ring;
+  } else if (str == "ctgraph_rd") {
+    val = NCCL_ALLGATHER_ALGO::ctgraph_rd;
   } else {
     val = NCCL_ALLGATHER_ALGO::orig;
   }

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2014,7 +2014,7 @@ cvars:
  - name        : NCCL_ALLGATHER_ALGO
    type        : enum
    default     : orig
-   choices     : orig, ctran, ctdirect, ctring, ctrd, ctbrucks, ctgraph
+   choices     : orig, ctran, ctdirect, ctring, ctrd, ctbrucks, ctgraph, ctgraph_pipeline, ctgraph_ring, ctgraph_rd
    description : |-
      The algorithm to use for Allgather communication
      orig - Copy-based ring algorithm
@@ -2022,7 +2022,16 @@ cvars:
      ctdirect - Ctran-based direct point-to-point algorithm
      ctring - Ctran-based ring algorithm
      ctrd - Ctran-based recursive doubling algorithm
-     ctgraph - Cudagraph-aware: uses ctran persistent AGP during graph capture, falls back to baseline otherwise
+     ctgraph - Cudagraph-aware: auto-selects pipeline/ring/rd based on topology during graph capture
+     ctgraph_pipeline - Cudagraph-aware: forces persistent pipeline algorithm (nLocalRanks>1)
+     ctgraph_ring - Cudagraph-aware: forces ring algorithm (nLocalRanks==1, large messages)
+     ctgraph_rd - Cudagraph-aware: forces recursive doubling algorithm (nLocalRanks==1, small messages)
+
+ - name        : NCCL_CTGRAPH_ALLGATHER_RING_THRESHOLD
+   type        : uint64_t
+   default     : 134217728
+   description : |-
+     Minimum send size in bytes for ctgraph auto-select to choose ring over recursive doubling when nLocalRanks==1. Default 128MB.
 
  - name        : NCCL_REDUCESCATTER_ALGO
    type        : enum


### PR DESCRIPTION
Summary:

- Add `ctgraph_pipeline`, `ctgraph_ring`, `ctgraph_rd` to `NCCL_ALLGATHER_ALGO` enum for explicit cudagraph-aware algorithm selection
- Add `NCCL_CTGRAPH_ALLGATHER_RING_THRESHOLD` cvar (default 128MB) for auto-select threshold between ring and recursive doubling
- When `algo=ctgraph`, auto-select based on topology: nLocalRanks>1 → pipeline, nLocalRanks==1 → ring (large msg) or rd (small msg)
- Two registration strategies in `ctranAllGatherCudagraphAware`:
  - `globalPersistBuffReg` (pipeline): window-based, both local+remote addresses stable across replays
  - `localPersistBuffReg` (ring/rd): local registration only via `globalRegisterWithPtr`, remote exchange at each replay via IB ctrl
- Force `NCCL_ALLGATHER_P_ALGO=ctdirect` when executing pipeline path
- Add `isGraphAwareAlgo()` helper to consolidate ctgraph variant checks
- Add `CudaGraphAllGatherCtgraphAlgoSelect` parameterized test with `VerifyAlgoStatsHelper` to verify correct algorithm dispatch
- ctgraph_ring/rd return false in `ctranAllGatherSupport` when nLocalRanks>1
- Non-capture fallback returns `commInternalError`; test callsite uses `ctran` for eager warmup

Reviewed By: dsjohns2

Differential Revision: D102286888
