### PR TITLE
Add ClogHook for collective operation logging (#2268)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,11 @@ target_link_directories(torchcomms PRIVATE ${CONDA_LIB})
 target_link_libraries(torchcomms PRIVATE glog::glog gflags::gflags fmt::fmt)
 target_link_libraries(torchcomms PRIVATE ${TORCH_LIBRARIES} nlohmann_json::nlohmann_json)
 
+# Clog Hook sources (compiled into _comms)
+file(GLOB TORCHCOMMS_CLOG_SOURCES "comms/torchcomms/hooks/clog/ClogHook.cpp")
+file(GLOB TORCHCOMMS_CLOG_PYTHON_SOURCES
+    "comms/torchcomms/hooks/clog/ClogHookPy.cpp")
+
 # Flight Recorder sources (compiled into _comms)
 file(GLOB TORCHCOMMS_FR_SOURCES "comms/torchcomms/hooks/fr/FlightRecorder.cpp")
 file(GLOB TORCHCOMMS_FR_PYTHON_SOURCES "comms/torchcomms/hooks/fr/FlightRecorderPy.cpp")
@@ -157,6 +162,8 @@ file(GLOB TORCHCOMMS_FR_PYTHON_SOURCES "comms/torchcomms/hooks/fr/FlightRecorder
 add_library(torchcomms_comms MODULE
     ${TORCHCOMMS_PYTHON_SOURCES}
     ${HOOKS_PYTHON_SOURCES}
+    ${TORCHCOMMS_CLOG_SOURCES}
+    ${TORCHCOMMS_CLOG_PYTHON_SOURCES}
     ${TORCHCOMMS_FR_SOURCES}
     ${TORCHCOMMS_FR_PYTHON_SOURCES}
 )
@@ -169,12 +176,14 @@ set_target_properties(torchcomms_comms PROPERTIES
 target_include_directories(torchcomms_comms PRIVATE
     ${ROOT}
     ${CONDA_INCLUDE}
+    ${TORCH_INSTALL_PREFIX}/include
     ${Python3_INCLUDE_DIRS}
 )
 target_compile_features(torchcomms_comms PRIVATE cxx_std_20)
 target_link_directories(torchcomms_comms PRIVATE ${CONDA_LIB})
 target_link_libraries(torchcomms_comms PRIVATE
     torchcomms
+    fmt::fmt
     nlohmann_json::nlohmann_json
     ${TORCH_LIBRARIES}
     ${TORCH_PYTHON_LIB}

--- a/comms/torchcomms/TorchComm.cpp
+++ b/comms/torchcomms/TorchComm.cpp
@@ -628,6 +628,17 @@ std::unique_ptr<RemovableHandle> TorchComm::registerAbortHook(
   });
 }
 
+std::unique_ptr<RemovableHandle> TorchComm::registerGraphReplayHook(
+    TorchComm::GraphReplayHook hook) {
+  auto hookId = nextHookId_++;
+  impl_->registerGraphReplayHook(hookId, std::move(hook));
+  return RemovableHandle::create([self = weak_from_this(), hookId]() {
+    if (auto selfPtr = self.lock()) {
+      selfPtr->impl_->unregisterGraphReplayHook(hookId);
+    }
+  });
+}
+
 void TorchComm::preHook(OpName name, size_t op_id, PreHookArgs&& args) {
   for (auto& hook : preHooks_) {
     hook.second(name, op_id, args);

--- a/comms/torchcomms/TorchComm.hpp
+++ b/comms/torchcomms/TorchComm.hpp
@@ -221,12 +221,15 @@ class TorchComm : public std::enable_shared_from_this<TorchComm> {
   using PreHook = ::torch::comms::PreHook;
   using PostHook = ::torch::comms::PostHook;
   using AbortHook = ::torch::comms::AbortHook;
+  using GraphReplayHook = ::torch::comms::GraphReplayHook;
 
   // Hook registration (not thread-safe; must not be called while a collective
   // is in progress)
   std::unique_ptr<RemovableHandle> registerPreHook(PreHook preHook);
   std::unique_ptr<RemovableHandle> registerPostHook(PostHook postHook);
   std::unique_ptr<RemovableHandle> registerAbortHook(AbortHook hook);
+  std::unique_ptr<RemovableHandle> registerGraphReplayHook(
+      GraphReplayHook hook);
 
   // Disable copy and move semantics
   TorchComm(const TorchComm&) = delete;

--- a/comms/torchcomms/TorchCommBackend.hpp
+++ b/comms/torchcomms/TorchCommBackend.hpp
@@ -205,6 +205,19 @@ class TorchCommBackend {
 
   std::unordered_map<int64_t, AbortHook> abortHooks_;
 
+  // Graph replay hook support (GraphReplayHook defined in TorchCommHooks.hpp)
+  // Called by backends when graph replay events are detected.
+
+  virtual void registerGraphReplayHook(int64_t hookId, GraphReplayHook hook) {
+    graphReplayHooks_.emplace(hookId, std::move(hook));
+  }
+
+  virtual void unregisterGraphReplayHook(int64_t hookId) {
+    graphReplayHooks_.erase(hookId);
+  }
+
+  std::unordered_map<int64_t, GraphReplayHook> graphReplayHooks_;
+
   // Persistent AllGather operations
   // Handle type for persistent AllGather (opaque pointer)
   using AllGatherPHandle = void*;
@@ -305,6 +318,25 @@ class TorchCommBackend {
                    << e.what();
       } catch (...) {
         LOG(ERROR) << "[TorchCommBackend] Abort hook threw unknown exception.";
+      }
+    }
+  }
+
+  void fireGraphReplayHook(
+      uint64_t graph_id,
+      uint64_t replay_id,
+      void* stream,
+      size_t collective_index,
+      std::string_view event) {
+    for (const auto& [_, hook] : graphReplayHooks_) {
+      try {
+        hook(graph_id, replay_id, stream, collective_index, event);
+      } catch (const std::exception& e) {
+        LOG(ERROR) << "[TorchCommBackend] Graph replay hook threw exception: "
+                   << e.what();
+      } catch (...) {
+        LOG(ERROR)
+            << "[TorchCommBackend] Graph replay hook threw unknown exception.";
       }
     }
   }

--- a/comms/torchcomms/TorchCommHooks.hpp
+++ b/comms/torchcomms/TorchCommHooks.hpp
@@ -467,4 +467,15 @@ using PostHook = std::function<void(size_t op_id, const PostHookArgs& args)>;
 // This allows users to capture debug information before the abort.
 using AbortHook = std::function<void()>;
 
+// Graph replay hook - called by backends that support CUDA graph capture
+// when graph replays are detected. The hook receives the graph ID, replay
+// number, an opaque stream handle, a zero-based per-stream collective index,
+// and an event name ("S" or "E"). Backends call this from the watchdog thread.
+using GraphReplayHook = std::function<void(
+    uint64_t graph_id,
+    uint64_t replay_id,
+    void* stream,
+    size_t collective_index,
+    std::string_view event)>;
+
 } // namespace torch::comms

--- a/comms/torchcomms/TorchCommPy.cpp
+++ b/comms/torchcomms/TorchCommPy.cpp
@@ -12,7 +12,8 @@
 #include "comms/torchcomms/TorchComm.hpp"
 #include "comms/torchcomms/TorchWork.hpp"
 
-// Forward declaration for flight recorder submodule init
+// Forward declarations for hook submodule init
+void init_clog_hook_bindings(py::module_& m);
 void init_flight_recorder_bindings(py::module_& m);
 
 namespace py = pybind11;
@@ -2526,8 +2527,10 @@ Args:
       py::arg("backend"),
       py::call_guard<py::gil_scoped_release>());
 
-  // Flight Recorder submodule: torchcomms._comms.hooks.fr
+  // Hook submodules: torchcomms._comms.hooks.*
   auto hooks_mod = m.def_submodule("hooks");
+  auto clog_mod = hooks_mod.def_submodule("clog");
+  init_clog_hook_bindings(clog_mod);
   auto fr_mod = hooks_mod.def_submodule("fr");
   init_flight_recorder_bindings(fr_mod);
 }

--- a/comms/torchcomms/hooks/__init__.py
+++ b/comms/torchcomms/hooks/__init__.py
@@ -9,10 +9,12 @@ TorchComm hooks module.
 This module serves as a namespace for TorchComm hook types.
 """
 
+from torchcomms.hooks.clog import clog
 from torchcomms.hooks.fr import FlightRecorderHook
 from torchcomms.hooks.nan_check import NanCheckHook
 
 __all__ = [
+    "clog",
     "FlightRecorderHook",
     "NanCheckHook",
 ]

--- a/comms/torchcomms/hooks/clog/AI_TOOL_INSTRUCTIONS_V1.md
+++ b/comms/torchcomms/hooks/clog/AI_TOOL_INSTRUCTIONS_V1.md
@@ -1,0 +1,411 @@
+# ClogHook Log Format — AI Tool Instructions (V1)
+
+This document describes the ClogHook log format for AI tools that parse
+or analyze clog output. ClogHook is a hook-based logger for TorchComm
+collective operations that records operation signatures, enqueue events,
+and GPU lifecycle events to a pipe-delimited log file.
+
+## Overview
+
+ClogHook attaches to one or more TorchComm communicators via pre-hook
+and post-hook callbacks. Each collective operation is assigned a
+correlation ID (`corr_id`) based on its signature (operation type,
+parameters, and communicator). Repeated calls with identical signatures
+reuse the same `corr_id`, providing natural deduplication.
+
+The log captures four categories of information:
+1. **Signatures** — unique collective operation definitions
+2. **Enqueue events** — when a collective is submitted (always logged)
+3. **Lifecycle events** — GPU start, end, and CPU wait (when enabled
+   via `LIFECYCLE` or `ALL` event options, which are equivalent)
+4. **Communicator management** — creation, splits
+
+Each rank in a distributed job writes its own log file. There is no
+cross-rank coordination.
+
+## Line Format
+
+All lines use `|` as the field delimiter. Every event line ends with a
+timestamp field `+<ts>` representing seconds elapsed since the base
+timestamp in the version header.
+
+## Version Header
+
+The first line of every log file:
+
+```
+V|<version>|base_timestamp=<epoch_seconds>
+```
+
+- `version`: integer log format version (currently 1)
+- `base_timestamp`: wall-clock time in seconds (millisecond precision)
+  when the ClogHook was constructed
+
+All `+<ts>` fields in subsequent lines are deltas relative to
+`base_timestamp`. To reconstruct absolute wall-clock time:
+`absolute_time = base_timestamp + ts`.
+
+## Signature Lines
+
+```
+C<corr_id>|sig|<op>|<param1>=<val1>|<param2>=<val2>|...|comm=<comm_name>
+```
+
+Each unique combination of (operation, parameters, communicator) produces
+exactly one signature line. The `corr_id` is a positive integer assigned
+sequentially. All subsequent event lines for the same collective
+reference this `corr_id`.
+
+### Signature Parameters by Operation Type
+
+**In-place collectives** (tensor is both input and output):
+- `all_reduce`: `in_count`, `out_count`, `dtype`, `red_op`, `async_op`
+- `broadcast`: `in_count`, `out_count`, `dtype`, `root`, `async_op`
+- `reduce`: `in_count`, `out_count`, `dtype`, `red_op`, `root`, `async_op`
+
+**Point-to-point**:
+- `send`: `in_count`, `out_count=0`, `dtype`, `peer`, `async_op`
+- `recv`: `in_count=0`, `out_count`, `dtype`, `peer`, `async_op`
+
+**Distinct input/output (single tensors)**:
+- `all_gather_single`: `in_count`, `out_count`, `dtype`, `async_op`
+- `all_to_all_single`: `in_count`, `out_count`, `dtype`, `async_op`
+- `reduce_scatter_single`: `in_count`, `out_count`, `dtype`, `red_op`, `async_op`
+- `all_to_all_v_single`: `in_splits`, `out_splits`, `dtype`, `async_op`
+
+**Input tensor to output tensor list**:
+- `all_gather`: `in_count`, `out_counts`, `dtype`, `async_op`
+- `all_gather_v`: `in_count`, `out_counts`, `dtype`, `async_op`
+
+**Input tensor list to output tensor**:
+- `reduce_scatter`: `in_counts`, `out_count`, `dtype`, `red_op`, `async_op`
+- `reduce_scatter_v`: `in_counts`, `out_count`, `dtype`, `red_op`, `async_op`
+
+**Tensor lists on both sides**:
+- `all_to_all`: `in_counts`, `out_counts`, `dtype`, `async_op`
+
+**Scatter/gather with root**:
+- `scatter`: `in_counts`, `out_count`, `dtype`, `root`, `async_op`
+- `gather`: `in_count`, `out_counts`, `dtype`, `root`, `async_op`
+- `gather_single`: `in_count`, `out_count`, `dtype`, `root`, `async_op`
+
+**Special**:
+- `barrier`: `async_op`
+- `batch_op_issue`: `num_ops`, `async_op`
+
+### Parameter Value Formats
+
+- `count`, `in_count`, `out_count`: integer element count
+- `in_counts`, `out_counts`: comma-separated integer list (one per rank)
+- `in_splits`, `out_splits`: comma-separated integer list
+- `dtype`: short name — `f32`, `f64`, `f16`, `bf16`, `i32`, `i64`,
+  `i16`, `i8`, `u8`, `bool`, `fp8e4m3`, `fp8e5m2`, `other`
+- `red_op`: `sum`, `prod`, `min`, `max`, `band`, `bor`, `bxor`,
+  `premul_sum`, `avg`, `unknown`
+- `async_op`: `t` (true) or `f` (false)
+- `root`, `peer`: integer rank
+- `num_ops`: integer count of batched operations
+- `comm`: communicator name string
+
+### Verbose Fields
+
+When `buffers` verbose mode is enabled, signature lines include
+additional pointer fields:
+- `buf=<hex>`: buffer address (in-place collectives)
+- `in=<hex>`: input buffer address
+- `out=<hex>`: output buffer address
+- For tensor lists: comma-separated hex addresses
+
+### Signature Deduplication
+
+A signature is keyed by the full parameter string including the comm
+name. Two collectives with identical parameters on different
+communicators produce different signatures (different `corr_id` values).
+Two collectives with identical parameters on the same communicator share
+a single signature and `corr_id`.
+
+This means the `corr_id` identifies the *type* of collective, not a
+specific *instance*. Multiple Q/S/E/W event sequences may reference the
+same `corr_id`.
+
+## Event Lines
+
+### Non-graph events
+
+```
+C<corr_id>|Q|work_id=<work_id>|+<ts>   # enqueue
+C<corr_id>|S|+<ts>                      # start (GPU kernel launched)
+C<corr_id>|E|+<ts>                      # end (GPU kernel completed)
+C<corr_id>|W|+<ts>                      # wait (CPU waited on this work)
+```
+
+**Q** (enqueue): Always logged in the pre-hook when the collective is
+submitted. This is the earliest observable event for a collective
+instance. Each Q event includes a `work_id` that uniquely identifies
+this specific collective instance (monotonically increasing). The
+`work_id` can be used to correlate Q events with lifecycle warnings.
+
+**S** (start): Logged when the GPU begins executing the collective.
+For NCCL-based backends, this corresponds to the start CUDA event
+being recorded on the collective's stream.
+
+**E** (end): Logged when the GPU finishes executing the collective.
+Corresponds to the end CUDA event completing.
+
+**W** (wait): Logged when the CPU explicitly waits for the collective
+to complete (via `work->wait()`). Not all collectives have a W event —
+synchronous collectives may complete without an explicit wait.
+
+### Graph capture events
+
+During CUDA graph capture, events are prefixed with the graph ID:
+
+```
+G<graph_id>|C<corr_id>|Q|work_id=<work_id>|+<ts>    # enqueue during capture
+G<graph_id>|C<corr_id>|S|+<ts>                       # start during capture
+G<graph_id>|C<corr_id>|E|+<ts>                       # end during capture
+G<graph_id>|C<corr_id>|W|+<ts>                       # wait during capture
+```
+
+`graph_id` is assigned by the CUDA runtime and is globally unique across
+all graphs in the process (per the CUDA spec). ClogHook detects graph
+capture by querying `cudaStreamGetCaptureInfo` on the current stream.
+
+During capture, the collective actually executes once (to record the
+graph nodes). The Q/S/E/W events logged during capture reflect this
+single execution.
+
+### Graph replay events
+
+When a captured graph is replayed, the watchdog thread detects
+completion of graph-captured collectives and fires replay events:
+
+```
+G<graph_id>|R<replay_id>|C<corr_id>|S|+<ts>    # start during replay
+G<graph_id>|R<replay_id>|C<corr_id>|E|+<ts>    # end during replay
+```
+
+- `replay_id`: monotonically increasing counter per graph, starting
+  at 1 for the first replay after capture.
+- Replay events only include S and E. There is no Q (the graph launch
+  replays all captured operations atomically) and no W (waits are not
+  observable per-collective during replay).
+
+## Communicator Events
+
+```
+new_comm|comm=<name>|rank=<rank>|world_size=<size>
+```
+
+Logged when `registerWithComm()` is called. Records the communicator
+name, this rank's position, and the total number of ranks.
+
+```
+split|parent=<parent_comm>|child=<child_comm>|ranks=<r0>,<r1>,...
+```
+
+Logged when a communicator split occurs. `ranks` lists the global ranks
+participating in the child communicator.
+
+## Warning Lines
+
+```
+WARN|<description>
+```
+
+Warnings indicate unexpected states, such as:
+- A post-hook firing without a matching pre-hook
+- A lifecycle event for an unknown work ID
+- A graph replay event for an unknown graph or stream
+
+Warnings do not affect program execution — they are diagnostic only.
+
+## Ordering Guarantees
+
+### What IS ordered
+
+1. **Signature before events**: A signature line for a `corr_id` always
+   appears before any Q/S/E/W lines referencing that `corr_id`.
+
+2. **Q before S/E/W for a non-graph collective instance**: Within a
+   single non-graph collective, the Q event is logged first (in the
+   pre-hook on the calling thread). S/E/W events follow, though S and
+   E are logged from callback threads and W from the waiting thread.
+
+3. **Within a single CUDA stream during capture**: Collectives captured
+   on the same CUDA stream have their Q events logged in capture order.
+   This ordering reflects the stream's execution order in the graph.
+
+4. **Lifecycle ordering per collective**: For any single collective
+   instance, S occurs before E on the GPU. W may occur at any point
+   after Q (it depends on when the user calls wait).
+
+### What is NOT ordered
+
+1. **Events across different CUDA streams**: Collectives on different
+   streams execute independently on the GPU. Their S/E events in the
+   log may appear in any order relative to each other. For example, a
+   collective on stream A may log E before a collective on stream B
+   logs S, even if B was enqueued after A.
+
+2. **Graph replay events across communicators**: Each communicator has
+   its own watchdog thread that detects replay completions and fires
+   hooks independently. For a graph involving multiple communicators,
+   replay events from different communicators may arrive in any order
+   and may be arbitrarily interleaved. **Treat replay events as "these
+   events have occurred" rather than "this is the order in which they
+   occurred."**
+
+3. **Graph replay events within a communicator across streams**: When a
+   communicator has collectives on multiple streams within the same
+   graph, the watchdog iterates streams independently. Events from
+   different streams within the same communicator may appear out of
+   order.
+
+4. **Events across ranks**: Each rank writes its own independent log
+   file. There is no synchronization or ordering relationship between
+   lines in different rank log files. Use `base_timestamp + ts` for
+   approximate cross-rank time correlation, but note that clock skew
+   between nodes limits precision.
+
+5. **Interleaving of different collective instances**: When multiple
+   collectives are in flight concurrently (e.g., async operations),
+   their lifecycle events may interleave. A sequence like
+   `C1|S, C2|S, C1|E, C2|E` is normal and indicates overlapping
+   execution.
+
+6. **Graph capture lifecycle vs replay lifecycle**: During capture,
+   S/E/W events are delivered by the eager execution callbacks. During
+   replay, S/E events are delivered by the watchdog thread polling CUDA
+   events. These are fundamentally different delivery mechanisms with
+   different latencies. Do not compare capture-time and replay-time
+   timestamps as if they measure the same thing.
+
+## Graph Structure Reconstruction
+
+To reconstruct the internal structure of a captured CUDA graph from the
+log:
+
+1. **Identify captured collectives**: Collect all
+   `G<graph_id>|C<corr_id>|Q|work_id=<work_id>|+<ts>` lines for the
+   target graph.
+
+2. **Resolve signatures**: For each `corr_id`, find the corresponding
+   `C<corr_id>|sig|...` line to determine the operation type,
+   parameters, and communicator.
+
+3. **Determine stream assignment**: The `async_op` field in the
+   signature indicates stream behavior:
+   - `async_op=f` (sync): The collective executes on the user's current
+     CUDA stream at capture time.
+   - `async_op=t` (async): The collective executes on the communicator's
+     internal stream. An implicit dependency exists from the user stream
+     to the internal stream (to transfer the operation), and a
+     subsequent wait creates a dependency back.
+
+4. **Infer ordering**: Within a single stream, Q events appear in
+   capture order, which is the execution order. Across streams, there
+   is no inherent ordering unless dependencies are present.
+
+5. **Correlate replays**: For each `G<graph_id>|R<replay_id>|...` line,
+   the `replay_id` identifies which replay execution the event belongs
+   to. All events with the same `(graph_id, replay_id)` belong to the
+   same graph replay.
+
+## Async Operation Execution Model
+
+When `async_op=t`, the collective follows this execution path:
+
+1. The user calls the collective on their current CUDA stream.
+2. The backend records a dependency event on the user stream.
+3. The backend's internal stream waits on that dependency.
+4. The collective executes on the internal stream.
+5. When the user calls `wait()`, a dependency is created from the
+   internal stream back to the user's stream (or whichever stream the
+   wait occurs on).
+
+In graph capture mode, these stream dependencies become edges in the
+captured CUDA graph. During replay, the GPU executes the graph
+respecting these dependencies without CPU involvement.
+
+In the log, async operations appear as regular Q/S/E/W events. The
+stream assignment (user stream vs internal stream) is not explicitly
+logged but can be inferred from the `async_op` flag and the
+communicator name.
+
+## Multiple Communicators
+
+A single ClogHook instance can be registered with multiple
+communicators. All communicators write to the same log file. The `comm`
+field in signature lines identifies which communicator each collective
+belongs to.
+
+When multiple communicators participate in the same CUDA graph:
+- Each communicator's collectives are captured independently.
+- During replay, each communicator's watchdog fires events
+  independently.
+- The log may interleave events from different communicators for the
+  same graph replay.
+
+## Timestamp Precision
+
+Timestamps are recorded using `std::chrono::system_clock` with
+millisecond precision, formatted as seconds with three decimal places
+(e.g., `+1.234` means 1234 milliseconds after base_timestamp).
+
+The timestamp reflects when ClogHook recorded the event, not when the
+GPU operation actually occurred. For S/E events, there is inherent
+latency between the GPU completing the operation and the callback
+delivering the event to ClogHook.
+
+## Field Reference
+
+| Field | Description |
+|-------|-------------|
+| `V` | Version header line marker |
+| `C<id>` | Correlation ID — links events to their signature |
+| `G<id>` | CUDA graph ID (globally unique per CUDA spec) |
+| `R<id>` | Replay number within a graph (1-based) |
+| `sig` | Signature definition line |
+| `Q` | Enqueue event (always logged) |
+| `work_id=<id>` | Unique per-instance work ID (in Q events) |
+| `S` | Start event (GPU execution began) |
+| `E` | End event (GPU execution completed) |
+| `W` | Wait event (CPU waited for completion) |
+| `+<ts>` | Timestamp as seconds delta from base_timestamp |
+| `new_comm` | Communicator creation event |
+| `split` | Communicator split event |
+| `WARN` | Diagnostic warning |
+
+## Example Log
+
+```
+V|1|base_timestamp=1714234567.890
+new_comm|comm=world|rank=0|world_size=8
+C1|sig|all_reduce|in_count=1024|out_count=1024|dtype=f32|red_op=sum|async_op=f|comm=world
+C1|Q|work_id=1|+0.001
+C1|S|+0.002
+C1|E|+0.005
+C2|sig|all_reduce|in_count=2048|out_count=2048|dtype=bf16|red_op=sum|async_op=t|comm=world
+C2|Q|work_id=2|+0.010
+C2|S|+0.011
+C1|Q|work_id=3|+0.012
+C2|E|+0.015
+C1|S|+0.013
+C1|E|+0.016
+C2|W|+0.017
+G42|C1|Q|work_id=4|+1.000
+G42|C2|Q|work_id=5|+1.001
+G42|C1|S|+1.002
+G42|C2|S|+1.003
+G42|C1|E|+1.005
+G42|C2|E|+1.006
+G42|R1|C1|S|+2.001
+G42|R1|C2|S|+2.002
+G42|R1|C1|E|+2.004
+G42|R1|C2|E|+2.005
+G42|R2|C1|S|+3.001
+G42|R2|C2|S|+3.002
+G42|R2|C1|E|+3.004
+G42|R2|C2|E|+3.005
+```

--- a/comms/torchcomms/hooks/clog/ClogHook.cpp
+++ b/comms/torchcomms/hooks/clog/ClogHook.cpp
@@ -1,0 +1,805 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/torchcomms/hooks/clog/ClogHook.hpp"
+#include "comms/torchcomms/TorchComm.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <stdexcept>
+#include <variant>
+
+#include <fmt/core.h>
+
+#if __has_include(<cuda_runtime_api.h>) && __has_include(<ATen/cuda/CUDAContext.h>)
+#include <ATen/cuda/CUDAContext.h>
+#define CLOG_HAS_CUDA 1
+#endif
+
+namespace torch::comms {
+
+namespace {
+constexpr int kLogVersion = 1;
+
+bool getAsyncOp(const PreHookArgs& args) {
+  return std::visit(
+      [](const auto& a) -> bool {
+        using T = std::decay_t<decltype(a)>;
+        if constexpr (
+            std::is_same_v<T, SplitPreHookArgs> ||
+            std::is_same_v<T, NewWindowPreHookArgs>) {
+          return false;
+        } else {
+          return a.async_op;
+        }
+      },
+      args);
+}
+} // namespace
+
+ClogHook::ClogHook(
+    const std::string& output,
+    const std::vector<std::string>& events,
+    const std::vector<std::string>& verbose) {
+  // Parse events
+  for (const auto& ev : events) {
+    if (ev == "ALL" || ev == "LIFECYCLE") {
+      log_lifecycle_ = true;
+    }
+  }
+
+  // Parse verbose options
+  for (const auto& v : verbose) {
+    if (v == "buffers") {
+      log_buffers_ = true;
+    }
+  }
+
+  log_file_.open(output);
+
+  // Write version header with base timestamp
+  base_ts_ = now();
+  log_file_.writeLine(
+      fmt::format("V|{}|base_timestamp={:.3f}", kLogVersion, base_ts_));
+}
+
+ClogHook::~ClogHook() {
+  unregister();
+}
+
+// -- Registration --
+
+void ClogHook::registerWithComm(std::shared_ptr<TorchComm> comm) {
+  log_file_.writeLine(
+      fmt::format(
+          "new_comm|comm={}|rank={}|world_size={}",
+          std::string(comm->getCommName()),
+          comm->getRank(),
+          comm->getSize()));
+  registerHooks(comm);
+}
+
+void ClogHook::registerHooks(std::shared_ptr<TorchComm> comm) {
+  for (const auto& reg : registrations_) {
+    if (reg.comm.lock() == comm) {
+      throw std::runtime_error(
+          "ClogHook: already registered with comm " +
+          std::string(comm->getCommName()));
+    }
+  }
+
+  std::string comm_name(comm->getCommName());
+
+  int device_index = comm->getDevice().index();
+  auto pre_hook_handle = comm->registerPreHook(
+      [this, comm_name, device_index](
+          OpName name, size_t op_id, const PreHookArgs& args) {
+        this->onPreHook(comm_name, device_index, name, op_id, args);
+      });
+
+  auto post_hook_handle =
+      comm->registerPostHook([this](size_t op_id, const PostHookArgs& args) {
+        this->onPostHook(op_id, args);
+      });
+
+  auto graph_replay_hook_handle =
+      comm->registerGraphReplayHook([this, comm_name](
+                                        uint64_t graph_id,
+                                        uint64_t replay_id,
+                                        void* stream,
+                                        size_t collective_index,
+                                        std::string_view event) {
+        this->onGraphReplayEvent(
+            comm_name, graph_id, replay_id, stream, collective_index, event);
+      });
+
+  registrations_.push_back(
+      CommRegistration{
+          .comm = comm,
+          .pre_hook_handle = std::move(pre_hook_handle),
+          .post_hook_handle = std::move(post_hook_handle),
+          .graph_replay_hook_handle = std::move(graph_replay_hook_handle),
+      });
+}
+
+void ClogHook::unregister() {
+  for (auto& reg : registrations_) {
+    if (reg.pre_hook_handle) {
+      reg.pre_hook_handle->remove();
+    }
+    if (reg.post_hook_handle) {
+      reg.post_hook_handle->remove();
+    }
+    if (reg.graph_replay_hook_handle) {
+      reg.graph_replay_hook_handle->remove();
+    }
+  }
+  registrations_.clear();
+}
+
+// -- Formatting helpers (static, identical to original Clog) --
+
+double ClogHook::now() {
+  auto tp = std::chrono::system_clock::now();
+  auto duration = tp.time_since_epoch();
+  auto millis = std::chrono::duration_cast<std::chrono::milliseconds>(duration);
+  return static_cast<double>(millis.count()) / 1000.0;
+}
+
+std::string_view ClogHook::reduceOpToString(const ReduceOp& op) {
+  switch (op.type()) {
+    case ReduceOp::RedOpType::SUM:
+      return "sum";
+    case ReduceOp::RedOpType::PRODUCT:
+      return "prod";
+    case ReduceOp::RedOpType::MIN:
+      return "min";
+    case ReduceOp::RedOpType::MAX:
+      return "max";
+    case ReduceOp::RedOpType::BAND:
+      return "band";
+    case ReduceOp::RedOpType::BOR:
+      return "bor";
+    case ReduceOp::RedOpType::BXOR:
+      return "bxor";
+    case ReduceOp::RedOpType::PREMUL_SUM:
+      return "premul_sum";
+    case ReduceOp::RedOpType::AVG:
+      return "avg";
+    default:
+      return "unknown";
+  }
+}
+
+std::string_view ClogHook::dtypeToString(at::ScalarType dtype) {
+  switch (dtype) {
+    case at::ScalarType::Float:
+      return "f32";
+    case at::ScalarType::Double:
+      return "f64";
+    case at::ScalarType::Half:
+      return "f16";
+    case at::ScalarType::BFloat16:
+      return "bf16";
+    case at::ScalarType::Int:
+      return "i32";
+    case at::ScalarType::Long:
+      return "i64";
+    case at::ScalarType::Short:
+      return "i16";
+    case at::ScalarType::Char:
+      return "i8";
+    case at::ScalarType::Byte:
+      return "u8";
+    case at::ScalarType::Bool:
+      return "bool";
+    case at::ScalarType::Float8_e4m3fn:
+      return "fp8e4m3";
+    case at::ScalarType::Float8_e5m2:
+      return "fp8e5m2";
+    default:
+      return "other";
+  }
+}
+
+std::string ClogHook::formatCounts(const std::vector<at::Tensor>& tensors) {
+  std::string result;
+  for (size_t i = 0; i < tensors.size(); ++i) {
+    if (i > 0) {
+      result += ',';
+    }
+    result += std::to_string(tensors[i].numel());
+  }
+  return result;
+}
+
+std::string ClogHook::formatCounts(const std::vector<uint64_t>& counts) {
+  std::string result;
+  for (size_t i = 0; i < counts.size(); ++i) {
+    if (i > 0) {
+      result += ',';
+    }
+    result += std::to_string(counts[i]);
+  }
+  return result;
+}
+
+std::string ClogHook::formatPtr(const void* ptr) {
+  return fmt::format("{:#x}", reinterpret_cast<uintptr_t>(ptr));
+}
+
+std::string ClogHook::formatPtrs(const std::vector<at::Tensor>& tensors) {
+  std::string result;
+  for (size_t i = 0; i < tensors.size(); ++i) {
+    if (i > 0) {
+      result += ',';
+    }
+    result += formatPtr(tensors[i].data_ptr());
+  }
+  return result;
+}
+
+// graph_id is globally unique per the CUDA spec:
+// https://docs.nvidia.com/cuda/archive/12.4.1/cuda-runtime-api/group__CUDART__STREAM.html#group__CUDART__STREAM_1g150be2211d73d782bc34c497ddb06f2f
+ClogHook::GraphCaptureInfo ClogHook::getGraphCaptureInfo(int device_index) {
+#ifdef CLOG_HAS_CUDA
+  if (device_index < 0) {
+    return {};
+  }
+  cudaStream_t stream = at::cuda::getCurrentCUDAStream(device_index).stream();
+  cudaStreamCaptureStatus status;
+  unsigned long long graph_id = 0;
+  cudaError_t err = cudaStreamGetCaptureInfo(stream, &status, &graph_id);
+  if (err == cudaSuccess && status == cudaStreamCaptureStatusActive) {
+    return {stream, static_cast<uint64_t>(graph_id)};
+  }
+#endif
+  return {};
+}
+
+// -- Fake stream management --
+
+void* ClogHook::getFakeStream(const std::string& comm_name) {
+  auto id = next_fake_stream_.fetch_add(1, std::memory_order_relaxed);
+  auto* fake =
+      reinterpret_cast<void*>(~id); // NOLINT(performance-no-int-to-ptr)
+  return comm_fake_streams_.findOrInsert(comm_name, fake);
+}
+
+// -- Stream resolution for replay hooks --
+
+void* ClogHook::resolveReplayStream(
+    uint64_t graph_id,
+    const std::string& comm_name,
+    void* stream) {
+  auto stream_map_opt = graph_collectives_.find(graph_id);
+  if (!stream_map_opt) {
+    return stream;
+  }
+  auto sit = stream_map_opt->find(stream);
+  if (sit != stream_map_opt->end()) {
+    return stream;
+  }
+  // Unknown stream — must be a comm-internal stream; use fake stream
+  auto fake_opt = comm_fake_streams_.find(comm_name);
+  if (fake_opt) {
+    return *fake_opt;
+  }
+  return stream;
+}
+
+// -- I/O --
+
+void ClogHook::logEvent(uint64_t corr_id, std::string_view event) {
+  double delta = now() - base_ts_;
+  log_file_.writeLine(fmt::format("C{}|{}|+{:.3f}", corr_id, event, delta));
+}
+
+void ClogHook::logGraphEvent(
+    uint64_t graph_id,
+    uint64_t corr_id,
+    std::string_view event) {
+  double delta = now() - base_ts_;
+  log_file_.writeLine(
+      fmt::format("G{}|C{}|{}|+{:.3f}", graph_id, corr_id, event, delta));
+}
+
+// -- Core logging --
+
+WorkId ClogHook::logCollective(
+    std::string_view comm_name,
+    std::string sig_body,
+    bool async_op,
+    void* stream,
+    uint64_t graph_id) {
+  auto sig_key = fmt::format("{}|comm={}", sig_body, comm_name);
+
+  auto new_corr_id = next_corr_id_.fetch_add(1, std::memory_order_relaxed);
+  auto corr_id = sig_map_.findOrInsert(sig_key, new_corr_id);
+
+  // Track correlation IDs per graph per stream for replay hook lookups
+  if (graph_id != kNoGraphCapture) {
+    void* stream_key =
+        async_op ? getFakeStream(std::string(comm_name)) : stream;
+    graph_collectives_.insertOrModify(graph_id, [&](auto& stream_map) {
+      stream_map[stream_key].push_back(
+          GraphCollective{std::string(comm_name), corr_id});
+    });
+  }
+
+  if (corr_id == new_corr_id) {
+    log_file_.writeLine(fmt::format("C{}|sig|{}", corr_id, sig_key));
+  }
+
+  uint64_t work_id = next_work_id_.fetch_add(1, std::memory_order_relaxed);
+  if (log_lifecycle_) {
+    work_corr_map_.insert(work_id, WorkInfo{corr_id, graph_id});
+    work_events_map_.insert(
+        work_id,
+        async_op ? std::vector<std::string>{"S", "E", "W"}
+                 : std::vector<std::string>{"S", "E"});
+  }
+
+  auto q_event = fmt::format("Q|work_id={}", work_id);
+  if (graph_id != kNoGraphCapture) {
+    logGraphEvent(graph_id, corr_id, q_event);
+  } else {
+    logEvent(corr_id, q_event);
+  }
+
+  return work_id;
+}
+
+// -- Signature builder via std::visit --
+
+std::string ClogHook::buildSignature(OpName name, const PreHookArgs& args)
+    const {
+  return std::visit(
+      [this, name](const auto& a) -> std::string {
+        using T = std::decay_t<decltype(a)>;
+        auto op = opToString(name);
+
+        // In-place collectives (single tensor is both input and output)
+        if constexpr (std::is_same_v<T, AllReducePreHookArgs>) {
+          auto count = a.tensor.numel();
+          auto dtype = dtypeToString(a.tensor.scalar_type());
+          auto red_op = reduceOpToString(a.op);
+          auto sig = fmt::format(
+              "{}|in_count={}|out_count={}|dtype={}|red_op={}|async_op={}",
+              op,
+              count,
+              count,
+              dtype,
+              red_op,
+              a.async_op ? 't' : 'f');
+          if (log_buffers_) {
+            sig += fmt::format("|buf={}", formatPtr(a.tensor.data_ptr()));
+          }
+          return sig;
+        } else if constexpr (std::is_same_v<T, BroadcastPreHookArgs>) {
+          auto count = a.tensor.numel();
+          auto dtype = dtypeToString(a.tensor.scalar_type());
+          auto sig = fmt::format(
+              "{}|in_count={}|out_count={}|dtype={}|root={}|async_op={}",
+              op,
+              count,
+              count,
+              dtype,
+              a.root,
+              a.async_op ? 't' : 'f');
+          if (log_buffers_) {
+            sig += fmt::format("|buf={}", formatPtr(a.tensor.data_ptr()));
+          }
+          return sig;
+        } else if constexpr (std::is_same_v<T, ReducePreHookArgs>) {
+          auto count = a.tensor.numel();
+          auto dtype = dtypeToString(a.tensor.scalar_type());
+          auto red_op = reduceOpToString(a.op);
+          auto sig = fmt::format(
+              "{}|in_count={}|out_count={}|dtype={}|red_op={}|root={}|async_op={}",
+              op,
+              count,
+              count,
+              dtype,
+              red_op,
+              a.root,
+              a.async_op ? 't' : 'f');
+          if (log_buffers_) {
+            sig += fmt::format("|buf={}", formatPtr(a.tensor.data_ptr()));
+          }
+          return sig;
+
+          // Point-to-point
+        } else if constexpr (std::is_same_v<T, SendPreHookArgs>) {
+          auto dtype = dtypeToString(a.tensor.scalar_type());
+          auto sig = fmt::format(
+              "{}|in_count={}|out_count=0|dtype={}|peer={}|async_op={}",
+              op,
+              a.tensor.numel(),
+              dtype,
+              a.peer,
+              a.async_op ? 't' : 'f');
+          if (log_buffers_) {
+            sig += fmt::format("|in={}", formatPtr(a.tensor.data_ptr()));
+          }
+          return sig;
+        } else if constexpr (std::is_same_v<T, RecvPreHookArgs>) {
+          auto dtype = dtypeToString(a.tensor.scalar_type());
+          auto sig = fmt::format(
+              "{}|in_count=0|out_count={}|dtype={}|peer={}|async_op={}",
+              op,
+              a.tensor.numel(),
+              dtype,
+              a.peer,
+              a.async_op ? 't' : 'f');
+          if (log_buffers_) {
+            sig += fmt::format("|out={}", formatPtr(a.tensor.data_ptr()));
+          }
+          return sig;
+
+          // Distinct input/output (single tensors)
+        } else if constexpr (
+            std::is_same_v<T, AllGatherSinglePreHookArgs> ||
+            std::is_same_v<T, AllToAllSinglePreHookArgs>) {
+          auto dtype = dtypeToString(a.input.scalar_type());
+          auto sig = fmt::format(
+              "{}|in_count={}|out_count={}|dtype={}|async_op={}",
+              op,
+              a.input.numel(),
+              a.output.numel(),
+              dtype,
+              a.async_op ? 't' : 'f');
+          if (log_buffers_) {
+            sig += fmt::format(
+                "|in={}|out={}",
+                formatPtr(a.input.data_ptr()),
+                formatPtr(a.output.data_ptr()));
+          }
+          return sig;
+        } else if constexpr (std::
+                                 is_same_v<T, ReduceScatterSinglePreHookArgs>) {
+          auto dtype = dtypeToString(a.input.scalar_type());
+          auto red_op = reduceOpToString(a.op);
+          auto sig = fmt::format(
+              "{}|in_count={}|out_count={}|dtype={}|red_op={}|async_op={}",
+              op,
+              a.input.numel(),
+              a.output.numel(),
+              dtype,
+              red_op,
+              a.async_op ? 't' : 'f');
+          if (log_buffers_) {
+            sig += fmt::format(
+                "|in={}|out={}",
+                formatPtr(a.input.data_ptr()),
+                formatPtr(a.output.data_ptr()));
+          }
+          return sig;
+        } else if constexpr (std::is_same_v<T, AllToAllVSinglePreHookArgs>) {
+          auto dtype = dtypeToString(a.input.scalar_type());
+          auto sig = fmt::format(
+              "{}|in_splits={}|out_splits={}|dtype={}|async_op={}",
+              op,
+              formatCounts(a.input_split_sizes),
+              formatCounts(a.output_split_sizes),
+              dtype,
+              a.async_op ? 't' : 'f');
+          if (log_buffers_) {
+            sig += fmt::format(
+                "|in={}|out={}",
+                formatPtr(a.input.data_ptr()),
+                formatPtr(a.output.data_ptr()));
+          }
+          return sig;
+
+          // Input tensor -> output tensor list
+        } else if constexpr (
+            std::is_same_v<T, AllGatherPreHookArgs> ||
+            std::is_same_v<T, AllGatherVPreHookArgs>) {
+          auto dtype = dtypeToString(a.input.scalar_type());
+          auto sig = fmt::format(
+              "{}|in_count={}|out_counts={}|dtype={}|async_op={}",
+              op,
+              a.input.numel(),
+              formatCounts(a.output),
+              dtype,
+              a.async_op ? 't' : 'f');
+          if (log_buffers_) {
+            sig += fmt::format(
+                "|in={}|out={}",
+                formatPtr(a.input.data_ptr()),
+                formatPtrs(a.output));
+          }
+          return sig;
+
+          // Input tensor list -> output tensor
+        } else if constexpr (
+            std::is_same_v<T, ReduceScatterPreHookArgs> ||
+            std::is_same_v<T, ReduceScatterVPreHookArgs>) {
+          auto dtype = dtypeToString(a.output.scalar_type());
+          auto red_op = reduceOpToString(a.op);
+          auto sig = fmt::format(
+              "{}|in_counts={}|out_count={}|dtype={}|red_op={}|async_op={}",
+              op,
+              formatCounts(a.input),
+              a.output.numel(),
+              dtype,
+              red_op,
+              a.async_op ? 't' : 'f');
+          if (log_buffers_) {
+            sig += fmt::format(
+                "|in={}|out={}",
+                formatPtrs(a.input),
+                formatPtr(a.output.data_ptr()));
+          }
+          return sig;
+
+          // Tensor lists on both sides
+        } else if constexpr (std::is_same_v<T, AllToAllPreHookArgs>) {
+          if (a.input.empty()) {
+            return std::string();
+          }
+          auto dtype = dtypeToString(a.input[0].scalar_type());
+          auto sig = fmt::format(
+              "{}|in_counts={}|out_counts={}|dtype={}|async_op={}",
+              op,
+              formatCounts(a.input),
+              formatCounts(a.output),
+              dtype,
+              a.async_op ? 't' : 'f');
+          if (log_buffers_) {
+            sig += fmt::format(
+                "|in={}|out={}", formatPtrs(a.input), formatPtrs(a.output));
+          }
+          return sig;
+
+          // Scatter/gather with root
+        } else if constexpr (std::is_same_v<T, ScatterPreHookArgs>) {
+          auto dtype = dtypeToString(a.output.scalar_type());
+          auto sig = fmt::format(
+              "{}|in_counts={}|out_count={}|dtype={}|root={}|async_op={}",
+              op,
+              formatCounts(a.input),
+              a.output.numel(),
+              dtype,
+              a.root,
+              a.async_op ? 't' : 'f');
+          if (log_buffers_) {
+            sig += fmt::format(
+                "|in={}|out={}",
+                formatPtrs(a.input),
+                formatPtr(a.output.data_ptr()));
+          }
+          return sig;
+        } else if constexpr (std::is_same_v<T, GatherPreHookArgs>) {
+          auto dtype = dtypeToString(a.input.scalar_type());
+          auto sig = fmt::format(
+              "{}|in_count={}|out_counts={}|dtype={}|root={}|async_op={}",
+              op,
+              a.input.numel(),
+              formatCounts(a.output),
+              dtype,
+              a.root,
+              a.async_op ? 't' : 'f');
+          if (log_buffers_) {
+            sig += fmt::format(
+                "|in={}|out={}",
+                formatPtr(a.input.data_ptr()),
+                formatPtrs(a.output));
+          }
+          return sig;
+        } else if constexpr (std::is_same_v<T, GatherSinglePreHookArgs>) {
+          auto dtype = dtypeToString(a.input.scalar_type());
+          auto sig = fmt::format(
+              "{}|in_count={}|out_count={}|dtype={}|root={}|async_op={}",
+              op,
+              a.input.numel(),
+              a.output.numel(),
+              dtype,
+              a.root,
+              a.async_op ? 't' : 'f');
+          if (log_buffers_) {
+            sig += fmt::format(
+                "|in={}|out={}",
+                formatPtr(a.input.data_ptr()),
+                formatPtr(a.output.data_ptr()));
+          }
+          return sig;
+
+          // Special (no tensors)
+        } else if constexpr (std::is_same_v<T, BarrierPreHookArgs>) {
+          return fmt::format("{}|async_op={}", op, a.async_op ? 't' : 'f');
+        } else if constexpr (std::is_same_v<T, BatchOpIssuePreHookArgs>) {
+          return fmt::format(
+              "{}|num_ops={}|async_op={}",
+              op,
+              a.num_ops,
+              a.async_op ? 't' : 'f');
+
+          // Communicator management (split logged separately)
+        } else if constexpr (std::is_same_v<T, SplitPreHookArgs>) {
+          return std::string();
+        } else if constexpr (std::is_same_v<T, NewWindowPreHookArgs>) {
+          return std::string();
+        } else {
+          return std::string();
+        }
+      },
+      args);
+}
+
+// -- Pre-hook --
+
+void ClogHook::onPreHook(
+    const std::string& comm_name,
+    int device_index,
+    OpName name,
+    size_t op_id,
+    const PreHookArgs& args) {
+  // Handle split specially: log the split event, not a signature.
+  if (auto* split = std::get_if<SplitPreHookArgs>(&args)) {
+    std::string ranks_str;
+    for (size_t i = 0; i < split->ranks.size(); ++i) {
+      if (i > 0) {
+        ranks_str += ',';
+      }
+      ranks_str += std::to_string(split->ranks[i]);
+    }
+    log_file_.writeLine(
+        fmt::format(
+            "split|parent={}|child={}|ranks={}",
+            comm_name,
+            split->name,
+            ranks_str));
+    return;
+  }
+
+  // Skip new_window (no logging needed)
+  if (std::get_if<NewWindowPreHookArgs>(&args)) {
+    return;
+  }
+
+  auto sig = buildSignature(name, args);
+  if (sig.empty()) {
+    return;
+  }
+
+  bool async_op = getAsyncOp(args);
+  auto [stream, graph_id] = getGraphCaptureInfo(device_index);
+  auto work_id =
+      logCollective(comm_name, std::move(sig), async_op, stream, graph_id);
+
+  if (work_id != kWorkIdInvalid) {
+    op_to_work_.insert(op_id, work_id);
+  }
+}
+
+// -- Post-hook --
+
+void ClogHook::onPostHook(size_t op_id, const PostHookArgs& args) {
+  // For split, register the new communicator.
+  if (auto* split = std::get_if<SplitPostHookArgs>(&args)) {
+    if (auto new_comm = split->new_comm.lock()) {
+      registerHooks(new_comm);
+    }
+    return;
+  }
+
+  // TODO: add logging for window operations.
+  if (std::get_if<NewWindowPostHookArgs>(&args)) {
+    return;
+  }
+
+  // Retrieve the work_id assigned in the pre-hook.
+  WorkId work_id = op_to_work_.findAndErase(op_id).value_or(kWorkIdInvalid);
+
+  if (work_id == kWorkIdInvalid) {
+    log_file_.writeLine(
+        fmt::format("WARN|post-hook missing work_id for op_id {}", op_id));
+    return;
+  }
+
+  // For collectives with a work object, register lifecycle hooks.
+  std::visit(
+      [this, work_id](const auto& a) {
+        using T = std::decay_t<decltype(a)>;
+        if constexpr (std::is_base_of_v<CollectivePostHookArgs, T>) {
+          if (auto work = a.work.lock()) {
+            if (!log_lifecycle_) {
+              return;
+            }
+            work->registerWorkStartHook(
+                [this, work_id]() { logLifecycleEvent(work_id, "S"); });
+            work->registerWorkEndHook(
+                [this, work_id]() { logLifecycleEvent(work_id, "E"); });
+            work->registerWorkWaitHook(
+                [this, work_id]() { logLifecycleEvent(work_id, "W"); });
+          }
+        }
+      },
+      args);
+}
+
+// -- Lifecycle events --
+
+void ClogHook::logLifecycleEvent(WorkId work_id, std::string_view event) {
+  if (work_id == kWorkIdInvalid) {
+    return;
+  }
+
+  auto work_info_opt = work_corr_map_.find(work_id);
+  if (!work_info_opt) {
+    log_file_.writeLine(
+        fmt::format(
+            "WARN|lifecycle event {} for unknown work_id {}", event, work_id));
+    return;
+  }
+  auto corr_id = work_info_opt->corr_id;
+  auto graph_id = work_info_opt->graph_id;
+
+  if (!work_events_map_.valueRemove(work_id, std::string(event))) {
+    log_file_.writeLine(
+        fmt::format(
+            "WARN|unexpected lifecycle event {} for work_id {}",
+            event,
+            work_id));
+    return;
+  }
+
+  // Clean up corr_id entry if no more events remain
+  if (!work_events_map_.find(work_id)) {
+    work_corr_map_.findAndErase(work_id);
+  }
+
+  if (graph_id != kNoGraphCapture) {
+    logGraphEvent(graph_id, corr_id, event);
+  } else {
+    logEvent(corr_id, event);
+  }
+}
+
+// -- Graph replay events --
+
+void ClogHook::onGraphReplayEvent(
+    const std::string& comm_name,
+    uint64_t graph_id,
+    uint64_t replay_id,
+    void* stream,
+    size_t collective_index,
+    std::string_view event) {
+  void* resolved = resolveReplayStream(graph_id, comm_name, stream);
+
+  auto stream_map_opt = graph_collectives_.find(graph_id);
+  if (!stream_map_opt) {
+    log_file_.writeLine(
+        fmt::format(
+            "WARN|graph replay event for unknown graph_id {}", graph_id));
+    return;
+  }
+  auto sit = stream_map_opt->find(resolved);
+  if (sit == stream_map_opt->end() || collective_index >= sit->second.size()) {
+    log_file_.writeLine(
+        fmt::format(
+            "WARN|graph replay event for unknown stream in graph_id {} index {}",
+            graph_id,
+            collective_index));
+    return;
+  }
+
+  auto corr_id = sit->second[collective_index].corr_id;
+
+  if (!log_lifecycle_) {
+    return;
+  }
+
+  double delta = now() - base_ts_;
+  log_file_.writeLine(
+      fmt::format(
+          "G{}|R{}|C{}|{}|+{:.3f}",
+          graph_id,
+          replay_id,
+          corr_id,
+          event,
+          delta));
+}
+
+} // namespace torch::comms

--- a/comms/torchcomms/hooks/clog/ClogHook.hpp
+++ b/comms/torchcomms/hooks/clog/ClogHook.hpp
@@ -1,0 +1,308 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <algorithm>
+#include <atomic>
+#include <cstdint>
+#include <fstream>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <unordered_map>
+#include <vector>
+
+#include <ATen/ATen.h>
+#include "comms/torchcomms/RemovableHandle.hpp"
+#include "comms/torchcomms/TorchCommHooks.hpp"
+#include "comms/torchcomms/TorchCommTypes.hpp"
+
+namespace torch::comms {
+
+// Forward declarations
+class TorchComm;
+
+using WorkId = uint64_t;
+inline constexpr WorkId kWorkIdInvalid = std::numeric_limits<WorkId>::max();
+
+class ThreadSafeLogFile {
+ public:
+  void open(const std::string& path) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    file_.open(path, std::ios::out | std::ios::trunc);
+    if (!file_.is_open()) {
+      throw std::runtime_error("ClogHook: failed to open log file: " + path);
+    }
+  }
+
+  void writeLine(const std::string& line) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    file_.write(line.data(), line.size());
+    file_ << '\n';
+    file_.flush();
+  }
+
+  ~ThreadSafeLogFile() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (file_.is_open()) {
+      file_.close();
+    }
+  }
+
+  ThreadSafeLogFile() = default;
+  ThreadSafeLogFile(const ThreadSafeLogFile&) = delete;
+  ThreadSafeLogFile& operator=(const ThreadSafeLogFile&) = delete;
+  ThreadSafeLogFile(ThreadSafeLogFile&&) = delete;
+  ThreadSafeLogFile& operator=(ThreadSafeLogFile&&) = delete;
+
+ private:
+  std::ofstream file_;
+  std::mutex mutex_;
+};
+
+template <typename K, typename V>
+class ThreadSafeMap {
+ public:
+  void insert(const K& key, V value) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    map_[key] = std::move(value);
+  }
+
+  V findOrInsert(const K& key, const V& value) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return map_.try_emplace(key, value).first->second;
+  }
+
+  std::optional<V> find(const K& key) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = map_.find(key);
+    if (it == map_.end()) {
+      return std::nullopt;
+    }
+    return it->second;
+  }
+
+  std::optional<V> findAndErase(const K& key) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = map_.find(key);
+    if (it == map_.end()) {
+      return std::nullopt;
+    }
+    V val = std::move(it->second);
+    map_.erase(it);
+    return val;
+  }
+
+  template <typename F>
+  void insertOrModify(const K& key, F&& fn) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    fn(map_[key]);
+  }
+
+  template <typename E>
+  void valuePush(const K& key, E&& element) {
+    static_assert(
+        std::is_same_v<V, std::vector<typename std::decay_t<E>>>,
+        "valuePush requires a vector value type");
+    std::lock_guard<std::mutex> lock(mutex_);
+    map_[key].push_back(std::forward<E>(element));
+  }
+
+  template <typename E>
+  bool valueRemove(const K& key, const E& element) {
+    static_assert(
+        std::is_same_v<V, std::vector<E>>,
+        "valueRemove requires a vector value type");
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = map_.find(key);
+    if (it == map_.end()) {
+      return false;
+    }
+    auto& vec = it->second;
+    auto ev_it = std::find(vec.begin(), vec.end(), element);
+    if (ev_it == vec.end()) {
+      return false;
+    }
+    vec.erase(ev_it);
+    if (vec.empty()) {
+      map_.erase(it);
+    }
+    return true;
+  }
+
+ private:
+  using Map = std::unordered_map<K, V>;
+  Map map_;
+  std::mutex mutex_;
+};
+
+// ClogHook: Hook-based logger for torchcomms collective operations.
+//
+// Registers pre-hook and post-hook callbacks on communicators to log
+// collective operation signatures and lifecycle events to a pipe-delimited
+// log file.
+//
+// Usage:
+//   auto logger = std::make_shared<ClogHook>(
+//       "/tmp/clog.log", {"ALL"});
+//   logger->registerWithComm(comm_a);
+//   logger->registerWithComm(comm_b);
+//
+// Constructor parameters:
+//   output         - File path for log output
+//   events         - Events to log: Q, S, E, W, ALL, NONE
+//   verbose        - Optional fields: buffers
+//
+// Log format:
+//   Non-graph:     C<id>|<event>|+<ts>
+//   Graph capture: G<gid>|C<id>|<event>|+<ts>
+//   Graph replay:  G<gid>|R<rid>|C<id>|<event>|+<ts>
+//
+class ClogHook : public std::enable_shared_from_this<ClogHook> {
+ public:
+  ClogHook(
+      const std::string& output,
+      const std::vector<std::string>& events,
+      const std::vector<std::string>& verbose = {});
+
+  ~ClogHook();
+
+  ClogHook(const ClogHook&) = delete;
+  ClogHook& operator=(const ClogHook&) = delete;
+  ClogHook(ClogHook&&) = delete;
+  ClogHook& operator=(ClogHook&&) = delete;
+
+  // Register this hook with a communicator. Captures the comm name
+  // and registers pre/post hooks for logging.
+  void registerWithComm(std::shared_ptr<TorchComm> comm);
+
+  // Unregister from all communicators.
+  void unregister();
+
+ private:
+  void registerHooks(std::shared_ptr<TorchComm> comm);
+
+  // Pre-hook: log collective signature and enqueue event.
+  void onPreHook(
+      const std::string& comm_name,
+      int device_index,
+      OpName name,
+      size_t op_id,
+      const PreHookArgs& args);
+
+  // Post-hook: register work lifecycle hooks for S/E/W events.
+  void onPostHook(size_t op_id, const PostHookArgs& args);
+
+  // Build signature string from typed pre-hook args via std::visit.
+  std::string buildSignature(OpName name, const PreHookArgs& args) const;
+
+  // -- Formatting helpers --
+  static double now();
+  static std::string_view reduceOpToString(const ReduceOp& op);
+  static std::string_view dtypeToString(at::ScalarType dtype);
+  static std::string formatCounts(const std::vector<at::Tensor>& tensors);
+  static std::string formatCounts(const std::vector<uint64_t>& counts);
+  static std::string formatPtr(const void* ptr);
+  static std::string formatPtrs(const std::vector<at::Tensor>& tensors);
+
+  void logEvent(uint64_t corr_id, std::string_view event);
+  void
+  logGraphEvent(uint64_t graph_id, uint64_t corr_id, std::string_view event);
+
+  // Internal emitter: dedup, enqueue event, work mapping.
+  static constexpr uint64_t kNoGraphCapture = UINT64_MAX;
+
+  WorkId logCollective(
+      std::string_view comm_name,
+      std::string sig_body,
+      bool async_op,
+      void* stream,
+      uint64_t graph_id);
+
+  // Lifecycle event callbacks (registered on work objects via post-hook).
+  void logLifecycleEvent(WorkId work_id, std::string_view event);
+
+  struct GraphCaptureInfo {
+    void* stream{nullptr};
+    uint64_t graph_id{kNoGraphCapture};
+  };
+  static GraphCaptureInfo getGraphCaptureInfo(int device_index);
+
+  // Resolve a stream from the replay hook to ClogHook's stream key.
+  // If the stream is known (user stream), return it directly.
+  // If unknown (internal comm stream), return the comm's fake stream.
+  void* resolveReplayStream(
+      uint64_t graph_id,
+      const std::string& comm_name,
+      void* stream);
+
+  bool log_buffers_{false};
+  bool log_lifecycle_{false};
+  double base_ts_{0.0};
+  std::atomic<uint64_t> next_corr_id_{1};
+  std::atomic<uint64_t> next_work_id_{1};
+
+  ThreadSafeLogFile log_file_;
+
+  // Signature dedup: sig key (includes comm name) -> corr_id
+  ThreadSafeMap<std::string, uint64_t> sig_map_;
+
+  // work_id -> (corr_id, graph_id) for lifecycle event logging
+  struct WorkInfo {
+    uint64_t corr_id{};
+    uint64_t graph_id{kNoGraphCapture};
+  };
+  ThreadSafeMap<uint64_t, WorkInfo> work_corr_map_;
+
+  // work_id -> remaining expected events (entry auto-erased when vector
+  // becomes empty via valueRemove)
+  ThreadSafeMap<uint64_t, std::vector<std::string>> work_events_map_;
+
+  // op_id -> work_id mapping (pre-hook stores, post-hook consumes)
+  ThreadSafeMap<size_t, WorkId> op_to_work_;
+
+  // Per-graph, per-stream ordered list of correlation IDs (built during
+  // capture). Streams are either real user streams or fake streams
+  // representing comm-internal async streams.
+  // Used by the graph replay hook to map
+  // (graph_id, stream, index) -> corr_id.
+  struct GraphCollective {
+    std::string comm_name;
+    uint64_t corr_id;
+  };
+  using StreamCollectives =
+      std::unordered_map<void*, std::vector<GraphCollective>>;
+  ThreadSafeMap<uint64_t, StreamCollectives> graph_collectives_;
+
+  // comm_name -> fake stream pointer for async ops during graph capture.
+  // Fake streams are (void*)(-1), (void*)(-2), etc.
+  ThreadSafeMap<std::string, void*> comm_fake_streams_;
+  std::atomic<uintptr_t> next_fake_stream_{1};
+
+  void* getFakeStream(const std::string& comm_name);
+
+  // Graph replay hook callback — registered with each comm to receive
+  // replay events from the backend's watchdog thread.
+  void onGraphReplayEvent(
+      const std::string& comm_name,
+      uint64_t graph_id,
+      uint64_t replay_id,
+      void* stream,
+      size_t collective_index,
+      std::string_view event);
+
+  // Registration tracking for cleanup (main thread only, no lock needed)
+  struct CommRegistration {
+    std::weak_ptr<TorchComm> comm;
+    std::unique_ptr<RemovableHandle> pre_hook_handle;
+    std::unique_ptr<RemovableHandle> post_hook_handle;
+    std::unique_ptr<RemovableHandle> graph_replay_hook_handle;
+  };
+  std::vector<CommRegistration> registrations_;
+};
+
+} // namespace torch::comms

--- a/comms/torchcomms/hooks/clog/ClogHookPy.cpp
+++ b/comms/torchcomms/hooks/clog/ClogHookPy.cpp
@@ -1,0 +1,59 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "comms/torchcomms/TorchComm.hpp"
+#include "comms/torchcomms/hooks/clog/ClogHook.hpp"
+
+namespace py = pybind11;
+using namespace torch::comms;
+
+void init_clog_hook_bindings(py::module_& m) {
+  py::class_<ClogHook, std::shared_ptr<ClogHook>>(
+      m,
+      "clog",
+      R"(
+clog logs collective operation signatures and lifecycle events
+to a pipe-delimited log file.
+
+Example:
+    >>> from torchcomms.hooks import clog
+    >>> logger = clog(output="/tmp/clog.log", events=["ALL"])
+    >>> logger.register_with_comm(comm_a)
+    >>> logger.register_with_comm(comm_b)
+    >>> # ... run collectives ...
+      )")
+      .def(
+          py::init<
+              std::string,
+              std::vector<std::string>,
+              std::vector<std::string>>(),
+          R"(
+          Create a clog logger.
+
+          Args:
+              output: File path for log output.
+              events: Events to log (LIFECYCLE, ALL). Enqueue events are always logged.
+              verbose: Optional fields (buffers).
+          )",
+          py::arg("output"),
+          py::arg("events"),
+          py::arg("verbose") = std::vector<std::string>{})
+      .def(
+          "register_with_comm",
+          &ClogHook::registerWithComm,
+          R"(
+          Register this hook with a TorchComm communicator.
+
+          Args:
+              comm: The communicator to register with.
+          )",
+          py::arg("comm"),
+          py::call_guard<py::gil_scoped_release>())
+      .def(
+          "unregister",
+          &ClogHook::unregister,
+          "Unregister from all communicators.",
+          py::call_guard<py::gil_scoped_release>());
+}

--- a/comms/torchcomms/hooks/clog/__init__.py
+++ b/comms/torchcomms/hooks/clog/__init__.py
@@ -1,0 +1,31 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+# pyre-strict
+# patternlint-disable fbcode-nonempty-init-py
+
+"""
+clog module for TorchComm hooks.
+
+Logs collective operation signatures and lifecycle events to a
+pipe-delimited log file.
+
+Example:
+    >>> from torchcomms.hooks import clog
+    >>> logger = clog(output="/tmp/clog.log", events=["ALL"])
+    >>> logger.register_with_comm(comm)
+    >>> # ... run collectives ...
+    >>> logger.unregister()
+"""
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from torchcomms.hooks.clog._clog import clog
+else:
+    import torchcomms._comms as _comms_mod
+
+    clog = _comms_mod.hooks.clog.clog
+
+__all__ = [
+    "clog",
+]

--- a/comms/torchcomms/hooks/clog/_clog.pyi
+++ b/comms/torchcomms/hooks/clog/_clog.pyi
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+# pyre-strict
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+from typing import Any
+
+class clog:
+    """Hook for logging collective operation signatures."""
+
+    def __init__(
+        self,
+        output: str,
+        events: list[str],
+        verbose: list[str] = ...,
+    ) -> None: ...
+    def register_with_comm(self, comm: Any) -> None: ...
+    def unregister(self) -> None: ...

--- a/comms/torchcomms/hooks/clog/tests/py/ClogHookTest.py
+++ b/comms/torchcomms/hooks/clog/tests/py/ClogHookTest.py
@@ -1,0 +1,287 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# pyre-unsafe
+
+import os
+import tempfile
+import unittest
+from datetime import timedelta
+
+import torch
+import torchcomms
+from torchcomms.hooks import clog
+
+
+def _read_log_lines(path: str) -> list[str]:
+    with open(path) as f:
+        return [line.strip() for line in f if line.strip()]
+
+
+def _has_line_containing(lines: list[str], substr: str) -> bool:
+    return any(substr in line for line in lines)
+
+
+def _count_lines_containing(lines: list[str], substr: str) -> int:
+    return sum(1 for line in lines if substr in line)
+
+
+class TestClog(unittest.TestCase):
+    """Test clog for collective operation logging."""
+
+    backend = os.environ["TEST_BACKEND"]
+    device = torch.device(os.environ.get("TEST_DEVICE", "cuda"))
+
+    def test_end_to_end(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = os.path.join(tmpdir, "clog_test.log")
+            clog_handle = clog(output=log_path, events=["ALL"])
+
+            # -- Version header --
+            lines = _read_log_lines(log_path)
+            self.assertGreater(len(lines), 0)
+            self.assertTrue(lines[0].startswith("V|1|base_timestamp="))
+
+            # -- new_comm logged on registration --
+            comm = torchcomms.new_comm(
+                backend=self.backend,
+                device=self.device,
+                name="test_clog_comm",
+                timeout=timedelta(seconds=300),
+            )
+            clog_handle.register_with_comm(comm)
+
+            lines = _read_log_lines(log_path)
+            self.assertTrue(
+                _has_line_containing(lines, "new_comm|comm=test_clog_comm"),
+                "Expected new_comm log line",
+            )
+
+            # -- all_reduce signature with dedup --
+            t = torch.ones(1024, device=self.device)
+            comm.all_reduce(t, op=torchcomms.ReduceOp.SUM, async_op=False)
+            comm.all_reduce(t, op=torchcomms.ReduceOp.SUM, async_op=False)
+
+            lines = _read_log_lines(log_path)
+            sig_count = _count_lines_containing(
+                lines,
+                "sig|all_reduce|in_count=1024|out_count=1024|dtype=f32|red_op=sum",
+            )
+            self.assertEqual(
+                sig_count,
+                1,
+                "Signature should appear exactly once (dedup)",
+            )
+
+            # -- broadcast with root --
+            t_bcast = torch.ones(256, device=self.device)
+            comm.broadcast(t_bcast, root=0, async_op=False)
+
+            lines = _read_log_lines(log_path)
+            self.assertTrue(
+                _has_line_containing(
+                    lines,
+                    "sig|broadcast|in_count=256|out_count=256|dtype=f32|root=0",
+                ),
+                "Expected broadcast signature",
+            )
+
+            # -- barrier --
+            comm.barrier(async_op=False)
+
+            lines = _read_log_lines(log_path)
+            self.assertTrue(
+                _has_line_containing(lines, "sig|barrier|async_op=f"),
+                "Expected barrier signature",
+            )
+
+            # -- different dtypes --
+            t_f16 = torch.ones(128, device=self.device, dtype=torch.float16)
+            comm.all_reduce(t_f16, op=torchcomms.ReduceOp.SUM, async_op=False)
+
+            lines = _read_log_lines(log_path)
+            self.assertTrue(
+                _has_line_containing(lines, "dtype=f16|red_op=sum"),
+                "Expected f16 signature",
+            )
+
+            # -- enqueue events (Q) logged --
+            q_count = _count_lines_containing(lines, "|Q|")
+            self.assertGreater(
+                q_count,
+                0,
+                "Expected at least one Q enqueue event",
+            )
+
+            # -- Cleanup --
+            clog_handle.unregister()
+            comm.finalize()
+
+    def test_multiple_comms_shared_clog_handle(self) -> None:
+        """One clog instance shared across multiple comms."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = os.path.join(tmpdir, "clog_multi.log")
+            clog_handle = clog(output=log_path, events=["ALL"])
+
+            comm_a = torchcomms.new_comm(
+                backend=self.backend,
+                device=self.device,
+                name="comm_a",
+                timeout=timedelta(seconds=300),
+            )
+            comm_b = torchcomms.new_comm(
+                backend=self.backend,
+                device=self.device,
+                name="comm_b",
+                timeout=timedelta(seconds=300),
+            )
+            clog_handle.register_with_comm(comm_a)
+            clog_handle.register_with_comm(comm_b)
+
+            t = torch.ones(64, device=self.device)
+            comm_a.all_reduce(t, op=torchcomms.ReduceOp.SUM, async_op=False)
+            comm_b.all_reduce(t, op=torchcomms.ReduceOp.SUM, async_op=False)
+
+            lines = _read_log_lines(log_path)
+            self.assertTrue(
+                _has_line_containing(lines, "comm=comm_a"),
+                "Expected log entry for comm_a",
+            )
+            self.assertTrue(
+                _has_line_containing(lines, "comm=comm_b"),
+                "Expected log entry for comm_b",
+            )
+
+            clog_handle.unregister()
+            comm_a.finalize()
+            comm_b.finalize()
+
+    def test_independent_clog_handles(self) -> None:
+        """Two clog instances write to separate files."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path_a = os.path.join(tmpdir, "clog_a.log")
+            path_b = os.path.join(tmpdir, "clog_b.log")
+            clog_a = clog(output=path_a, events=["ALL"])
+            clog_b = clog(output=path_b, events=["ALL"])
+
+            comm_a = torchcomms.new_comm(
+                backend=self.backend,
+                device=self.device,
+                name="iso_a",
+                timeout=timedelta(seconds=300),
+            )
+            comm_b = torchcomms.new_comm(
+                backend=self.backend,
+                device=self.device,
+                name="iso_b",
+                timeout=timedelta(seconds=300),
+            )
+            clog_a.register_with_comm(comm_a)
+            clog_b.register_with_comm(comm_b)
+
+            t = torch.ones(32, device=self.device)
+            comm_a.all_reduce(t, op=torchcomms.ReduceOp.SUM, async_op=False)
+            comm_b.all_reduce(t, op=torchcomms.ReduceOp.SUM, async_op=False)
+
+            lines_a = _read_log_lines(path_a)
+            lines_b = _read_log_lines(path_b)
+
+            self.assertTrue(
+                _has_line_containing(lines_a, "comm=iso_a"),
+            )
+            self.assertFalse(
+                _has_line_containing(lines_a, "comm=iso_b"),
+            )
+            self.assertTrue(
+                _has_line_containing(lines_b, "comm=iso_b"),
+            )
+            self.assertFalse(
+                _has_line_containing(lines_b, "comm=iso_a"),
+            )
+
+            clog_a.unregister()
+            clog_b.unregister()
+            comm_a.finalize()
+            comm_b.finalize()
+
+
+@unittest.skipIf(os.getenv("TEST_BACKEND") != "ncclx", "CUDA graph test requires ncclx")
+class TestClogCudaGraph(unittest.TestCase):
+    """Test clog QC logging during CUDA graph capture."""
+
+    backend = os.environ["TEST_BACKEND"]
+    device = torch.device(os.environ.get("TEST_DEVICE", "cuda"))
+
+    def test_cuda_graph_capture_logs_qc(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = os.path.join(tmpdir, "clog_graph.log")
+            clog_handle = clog(output=log_path, events=["ALL"])
+
+            comm = torchcomms.new_comm(
+                backend=self.backend,
+                device=self.device,
+                name="graph_comm",
+                timeout=timedelta(seconds=300),
+            )
+            clog_handle.register_with_comm(comm)
+
+            t = torch.ones(64, device=self.device)
+
+            # Eager collective (should produce C<id>|Q|, not G<id>|C<id>|Q|)
+            comm.all_reduce(t, op=torchcomms.ReduceOp.SUM, async_op=False)
+
+            lines = _read_log_lines(log_path)
+            q_before = _count_lines_containing(lines, "|Q|")
+            graph_q_before = len([x for x in lines if x.startswith("G") and "|Q|" in x])
+            self.assertGreater(q_before, 0, "Expected Q event for eager op")
+            self.assertEqual(
+                graph_q_before, 0, "No graph Q expected before graph capture"
+            )
+
+            # Capture a collective into a CUDA graph
+            g = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(g):
+                comm.all_reduce(t, op=torchcomms.ReduceOp.SUM, async_op=False)
+
+            lines = _read_log_lines(log_path)
+            graph_q_after_capture = len(
+                [x for x in lines if x.startswith("G") and "|Q|" in x]
+            )
+            self.assertGreater(
+                graph_q_after_capture,
+                0,
+                "Expected graph Q event during graph capture",
+            )
+
+            num_replays = 3
+            for _ in range(num_replays):
+                g.replay()
+            torch.cuda.synchronize()
+            g.reset()
+            comm.finalize()
+            clog_handle.unregister()
+
+            lines = _read_log_lines(log_path)
+            graph_q_after_replay = len(
+                [x for x in lines if x.startswith("G") and "|Q|" in x]
+            )
+            self.assertEqual(
+                graph_q_after_replay,
+                graph_q_after_capture,
+                "Replay should not produce new graph Q events",
+            )
+            total_s = _count_lines_containing(lines, "|S|")
+            total_e = _count_lines_containing(lines, "|E|")
+            # Replay lines have format G<gid>|R<rid>|C<cid>|S|+<ts>
+            replay_s = len([x for x in lines if "|R" in x and "|S|" in x])
+            replay_e = len([x for x in lines if "|R" in x and "|E|" in x])
+            self.assertEqual(
+                total_s, 1 + num_replays, "Expected S from capture + each replay"
+            )
+            self.assertEqual(
+                total_e, 1 + num_replays, "Expected E from capture + each replay"
+            )
+            self.assertEqual(replay_s, num_replays, "Expected one replay S per replay")
+            self.assertEqual(replay_e, num_replays, "Expected one replay E per replay")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/comms/torchcomms/ncclx/GraphEventTracker.cpp
+++ b/comms/torchcomms/ncclx/GraphEventTracker.cpp
@@ -178,6 +178,46 @@ void GraphEventTracker::addEntry(TorchWorkNCCLX* work) {
 // Without the replay counter, case (2) could be missed if the watchdog
 // never observes end=success between consecutive replays, causing the
 // timer to span N replays and false-trigger a timeout.
+void GraphEventTracker::notifyReplayProgress(
+    unsigned long long graph_id,
+    void* stream,
+    size_t collective_index,
+    GraphWork& entry,
+    uint64_t current_replay,
+    int current_event) {
+  if (comm_->graphReplayHooks_.empty()) {
+    return;
+  }
+
+  static constexpr std::string_view kEvents[] = {"S", "E", "W"};
+
+  if (current_replay < entry.notified_through_replay ||
+      (current_replay == entry.notified_through_replay &&
+       current_event <= entry.notified_through_event)) {
+    return;
+  }
+
+  uint64_t r = entry.notified_through_replay;
+  int e = entry.notified_through_event + 1;
+
+  if (e > kEventE) {
+    r++;
+    e = kEventS;
+  }
+
+  for (; r <= current_replay; r++) {
+    int end_e = (r == current_replay) ? current_event : kEventE;
+    for (; e <= end_e; e++) {
+      comm_->fireGraphReplayHook(
+          graph_id, r, stream, collective_index, kEvents[e]);
+    }
+    e = kEventS;
+  }
+
+  entry.notified_through_replay = current_replay;
+  entry.notified_through_event = current_event;
+}
+
 GraphEventTracker::CheckResult GraphEventTracker::checkAll() {
   if (!isGraphTimeoutMonitoringEnabled()) {
     return CheckResult::OK;
@@ -186,7 +226,8 @@ GraphEventTracker::CheckResult GraphEventTracker::checkAll() {
   CudaApi* api = comm_->getCudaApi();
   std::lock_guard<std::mutex> lock(mutex_);
 
-  // Cleanup released graphs
+  // Cleanup released graphs — delivers final replay events before
+  // erasing each graph's state.
   cleanupReleasedGraphs();
 
   // Traverse remaining active graphs
@@ -225,12 +266,21 @@ GraphEventTracker::CheckResult GraphEventTracker::checkAll() {
         if (end_status == cudaSuccess) {
           // Collective completed or no replay in progress
           entry.start_completed_time.reset();
+
+          notifyReplayProgress(
+              graph_id, stream, i, entry, current_replay, kEventE);
           continue;
         }
 
         // end is notReady — this is the first incomplete collective on this
         // stream. All subsequent collectives on this stream cannot have
         // started, so we can skip them.
+
+        if (start_status == cudaSuccess) {
+          notifyReplayProgress(
+              graph_id, stream, i, entry, current_replay, kEventS);
+        }
+
         if (!entry.start_completed_time.has_value()) {
           if (start_status == cudaSuccess) {
             // observation of collective in progress — start timer
@@ -277,17 +327,42 @@ GraphState::~GraphState() {
 }
 
 void GraphEventTracker::cleanupReleasedGraphs() {
+  CudaApi* api = comm_->getCudaApi();
+
   for (auto it = graphs_.begin(); it != graphs_.end();) {
-    if (it->second.shared_->released.load(std::memory_order_relaxed)) {
-      it = graphs_.erase(it);
-    } else {
+    if (!it->second.shared_->released.load(std::memory_order_relaxed)) {
       ++it;
+      continue;
     }
+
+    // Deliver final replay events before erasing.  The graph has been
+    // destroyed so no more replays will occur; sweep all completed
+    // events that the watchdog has not yet reported.
+    auto& graph_state = it->second;
+    if (graph_state.replay_counter) {
+      uint64_t current_replay = graph_state.replay_counter->read();
+      for (auto& [stream, entries] : graph_state.stream_entries) {
+        for (size_t i = 0; i < entries.size(); ++i) {
+          auto& entry = entries[i];
+          cudaError_t end_status = api->eventQuery(entry.end_event);
+          if (end_status == cudaSuccess) {
+            notifyReplayProgress(
+                it->first, stream, i, entry, current_replay, kEventE);
+          }
+        }
+      }
+    }
+
+    it = graphs_.erase(it);
   }
 }
 
 void GraphEventTracker::destroyAll() {
   std::lock_guard<std::mutex> lock(mutex_);
+  // Deliver final replay events for any released graphs before
+  // destroying state.  This covers graphs destroyed after the
+  // watchdog has exited.
+  cleanupReleasedGraphs();
   graphs_.clear();
 }
 

--- a/comms/torchcomms/ncclx/GraphEventTracker.hpp
+++ b/comms/torchcomms/ncclx/GraphEventTracker.hpp
@@ -29,6 +29,13 @@ struct GraphWork {
   std::chrono::milliseconds timeout;
   std::optional<std::chrono::steady_clock::time_point> start_completed_time;
   uint64_t last_seen_replay{0};
+  // Replay event logging state.
+  // Events are ordered: S=0, E=1 (W is not observable during replay).
+  // Initialized to (replay=0, event=E) — the counter starts at 0
+  // and the first g.replay() increments it to 1, which is the first
+  // replay execution that should be reported.
+  uint64_t notified_through_replay{0};
+  int notified_through_event{1};
 
   GraphWork(cudaEvent_t start, cudaEvent_t end, std::chrono::milliseconds t)
       : start_event(start), end_event(end), timeout(t) {}
@@ -130,6 +137,20 @@ class GraphEventTracker {
       unsigned long long graph_id,
       cudaGraph_t graph);
   void cleanupReleasedGraphs();
+
+  // Fire graph replay hooks for all events from the entry's last notified
+  // position up to (current_replay, current_event). Events are ordered
+  // S=0, E=1. Catches up missed replays automatically.
+  static constexpr int kEventS = 0;
+  static constexpr int kEventE = 1;
+
+  void notifyReplayProgress(
+      unsigned long long graph_id,
+      void* stream,
+      size_t collective_index,
+      GraphWork& entry,
+      uint64_t current_replay,
+      int current_event);
 
   TorchCommNCCLX* comm_; // raw pointer — parent owns this tracker
   std::mutex mutex_;


### PR DESCRIPTION
Summary:

Add ClogHook (in hooks/clog/) as a hook-based logger that records
collective operation signatures and lifecycle events to a
pipe-delimited log file.

Unlike the original CollLogger (which was called directly from each
collective method in TorchCommNCCLX), ClogHook registers pre-hook
and post-hook callbacks on communicators via the standard hooks
framework, making it backend-agnostic.

API:
- Constructible with explicit config (output path, events, verbose
  options)
- Events: ENQUEUE (Q), LIFECYCLE (S/E/W), ALL
- Verbose: buffers (pointer addresses)
- No singleton, no env vars -- multiple independent instances
  supported
- One instance can be registered with multiple communicators for a
  unified log
- Split comms auto-inherit the parent's ClogHook via post-hook

Key design:
- Pre-hook builds a signature string via std::visit on the typed
  per-collective args, extracting counts/dtype from actual tensors
- Signature deduplication via unordered_map (subsequent ops with
  same signature reuse the correlation ID)
- Post-hook registers work lifecycle hooks (S/E/W) on the work
  object; expected events tracked per work_id for correct cleanup
- CUDA graph capture detected via at::cuda::getCurrentCUDAStream
  and cudaStreamGetCaptureInfo; graph captures logged with the
  graph ID prefix (e.g., G42|C1|Q|+0.000)
- Graph replay events (S/E) delivered via GraphReplayHook, a new
  hook type on TorchCommBackend; NCCLX's GraphEventTracker fires
  hooks from checkAll() via notifyReplayProgress(), catching up
  missed replays automatically
- Split post-hook auto-registers newly created communicators
- Duplicate registration detected and throws
- Thread-safe via mutex
- Communicator creation (new_comm) logged on explicit registration
  only (not on split-inherited registration)
- async_op included in collective signatures
- Single base timestamp in the version header; all deltas relative
  to it

Compared to NCCL_DEBUG_SUBSYS=ALL:
- Logs all lifecycle events (enqueue, start, end, wait), not just
  enqueue
- Only logs unique collective signatures -- repeated calls with the
  same parameters reuse the correlation ID, drastically reducing
  log volume
- Logs CUDA graph captures and graph replay lifecycle events (with
  graph and replay IDs), which NCCL debug logging does not
  distinguish from regular enqueues

Python bindings and tests included.

Reviewed By: dolpm

Differential Revision: D101779784


