### PR TITLE
Add recursive-doubling option (ctrd) to AllGatherP (#2269)

### DIFF
--- a/comms/ctran/algos/AllGatherP/AlgoImpl.h
+++ b/comms/ctran/algos/AllGatherP/AlgoImpl.h
@@ -41,12 +41,31 @@ class AlgoImpl {
       const size_t count,
       const commDataType_t datatype);
 
+  // Execute the recursive-doubling algorithm of allgatherP.
+  // - Each rank copies its own chunk to every intra-node peer via NVL
+  //   CopyEngine as an initial broadcast.
+  // - Across the log2(nNodes) inter-node steps, each rank exchanges 2^step
+  //   chunks with its rail peer at distance (nNodes / 2^(step+1)) * nLocalRanks
+  //   using RDMA. Local ranks on a node stripe their IB traffic by column,
+  //   so each rail link carries an equal share of the node-level exchange.
+  // - After each inter-node step, the received chunks are broadcast across
+  //   intra-node peers via NVL CopyEngine so that every local rank holds the
+  //   union of data needed for the next step.
+  // - Requires nNodes to be a power of 2. nLocalRanks == 1 (e.g. nolocal)
+  //   skips the NVL broadcast stages.
+  commResult_t execRecursiveDoubling(
+      const void* sendbuff,
+      const size_t count,
+      const commDataType_t datatype);
+
   static inline const std::string algoName(enum NCCL_ALLGATHER_P_ALGO algo) {
     switch (algo) {
       case NCCL_ALLGATHER_P_ALGO::ctdirect:
         return "CtranAllGatherPDirect";
       case NCCL_ALLGATHER_P_ALGO::ctpipeline:
         return "CtranAllGatherPPipeline";
+      case NCCL_ALLGATHER_P_ALGO::ctrdpipeline:
+        return "CtranAllGatherPRecDbl";
       default:
         return "Unknown";
     }

--- a/comms/ctran/algos/AllGatherP/AllGatherP.cc
+++ b/comms/ctran/algos/AllGatherP/AllGatherP.cc
@@ -237,6 +237,8 @@ commResult_t allGatherPExec(
       return algo->execDirect(sendbuff, count, datatype);
     case NCCL_ALLGATHER_P_ALGO::ctpipeline:
       return algo->execPipeline(sendbuff, count, datatype);
+    case NCCL_ALLGATHER_P_ALGO::ctrdpipeline:
+      return algo->execRecursiveDoubling(sendbuff, count, datatype);
     default:
       return ErrorStackTraceUtil::log(commInternalError);
   }

--- a/comms/ctran/algos/AllGatherP/RecursiveDoublingImpl.cc
+++ b/comms/ctran/algos/AllGatherP/RecursiveDoublingImpl.cc
@@ -1,0 +1,405 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <folly/ScopeGuard.h>
+#include <vector>
+
+#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/algos/AllGatherP/AlgoImpl.h"
+#include "comms/ctran/algos/AllGatherP/CommUtils.h"
+#include "comms/ctran/algos/AllGatherP/Types.h"
+#include "comms/ctran/algos/CtranAlgo.h"
+#include "comms/ctran/mapper/CtranMapper.h"
+#include "comms/ctran/profiler/Profiler.h"
+#include "comms/ctran/utils/DevUtils.cuh"
+#include "comms/ctran/utils/ExtUtils.h"
+
+using ctran::allgatherp::AlgoImpl;
+using ctran::allgatherp::PersistArgs;
+using ctran::allgatherp::Resource;
+
+namespace {
+const auto myAlgo = NCCL_ALLGATHER_P_ALGO::ctrdpipeline;
+
+// Node-level recursive doubling distance at step `i` (i=0 is the largest
+// distance). Expressed in units of nodes.
+inline int distNodesAtStep(int nNodes, int step) {
+  // dist = nNodes / 2^(step+1)
+  return nNodes >> (step + 1);
+}
+
+// Rail-peer rank for a given step using the same pattern as ctrdpipeline
+// allgather. Operates on nodes so the peer is always on a different node in the
+// same rail.
+inline int
+peerAtStep(int nodeId, int localRank, int nLocalRanks, int nNodes, int step) {
+  const int dist = distNodesAtStep(nNodes, step);
+  const int pos = (nodeId / dist) % 2;
+  const int peerNode = pos == 0 ? nodeId + dist : nodeId - dist;
+  return peerNode * nLocalRanks + localRank;
+}
+
+// Stride between node-chunks owned/sent at step `i`. After step `i`, each node
+// owns 2^(i+1) node-chunks with node indices of the form
+// j * stride + (nodeId % stride) for j in [0, 2^(i+1)). At the start of step
+// i, stride = nNodes / 2^i and 2^i chunks are owned.
+inline int nodeChunkStrideAtStep(int nNodes, int step) {
+  return nNodes >> step;
+}
+
+// For a rank on `anchorNode`, return the chunk offset (in units of rank
+// chunks) that local rank `lr` uses for its j-th PUT at step i. anchorNode
+// is the node whose chunks are being striped (my node on send, peer node on
+// recv position lookup).
+inline size_t rankChunkOffset(
+    int anchorNode,
+    int localRank,
+    int nLocalRanks,
+    int nNodes,
+    int step,
+    int j) {
+  const int stride = nodeChunkStrideAtStep(nNodes, step);
+  const int nodePos = j * stride + (anchorNode % stride);
+  return static_cast<size_t>(nodePos) * nLocalRanks + localRank;
+}
+
+commResult_t gpeFn(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
+  struct OpElem* op = opGroup.front().get();
+  auto* resource = reinterpret_cast<Resource*>(op->allgatherP.algoResource);
+  auto* pArgs = reinterpret_cast<PersistArgs*>(op->allgatherP.pArgs);
+  const void* sendBuff = op->allgatherP.sendbuff;
+  const auto sendSize =
+      op->allgatherP.count * commTypeSize(op->allgatherP.datatype);
+  CtranComm* comm = opGroup.front()->comm_;
+
+  const auto statex = comm->statex_.get();
+  const auto rank = statex->rank();
+  const auto nRanks = statex->nRanks();
+  const auto localRank = statex->localRank();
+  const auto nLocalRanks = statex->nLocalRanks();
+  const auto nNodes = statex->nNodes();
+  const auto nodeId = rank / nLocalRanks;
+  const auto nSteps = static_cast<int>(ctran::utils::log2i(nNodes));
+
+  CtranAlgoLogger logger(AlgoImpl::algoName(myAlgo), op->opCount, comm);
+
+  ctran::Profiler* profiler = comm->ctran_->profiler.get();
+  if (profiler) {
+    profiler->initForEachColl(
+        op->opCount, NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT);
+  }
+
+  CTRAN_PROFILER_IF(profiler, {
+    auto& algoContext = profiler->algoContext;
+    algoContext.algorithmName = AlgoImpl::algoName(myAlgo);
+    algoContext.sendContext.messageSizes = std::to_string(sendSize);
+    algoContext.recvContext.messageSizes = std::to_string(sendSize * nRanks);
+  });
+
+  auto mapper = comm->ctran_->mapper.get();
+
+  void* sendHdl = nullptr;
+  bool localReg = false;
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::BUF_REG));
+  FB_COMMCHECK(
+      mapper->searchRegHandle(sendBuff, sendSize, &sendHdl, &localReg));
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::BUF_REG));
+  auto regGuard = folly::makeGuard([sendHdl, localReg, mapper]() {
+    if (localReg) {
+      FB_COMMCHECKIGNORE(mapper->deregDynamic(sendHdl));
+    }
+  });
+
+  // Compute rail peer per step and initialize notify flags up-front so a
+  // peer PUT that arrives fast can be tracked immediately.
+  std::vector<int> peers(nSteps);
+  std::vector<std::unique_ptr<CtranMapperNotify>> notifyVec(nSteps);
+
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_CTRL));
+
+  for (int i = 0; i < nSteps; i++) {
+    peers[i] = peerAtStep(nodeId, localRank, nLocalRanks, nNodes, i);
+    notifyVec[i] = std::make_unique<CtranMapperNotify>();
+    FB_COMMCHECK(
+        mapper->initNotify(peers[i], pArgs->recvHdl, notifyVec[i].get()));
+  }
+
+  // Exchange a ready-to-receive handshake with every rail peer before
+  // launching the first PUT. This mirrors the guarantee ctpipeline gets from
+  // its single sendCtrl/recvCtrl pair so that RDMA writes don't race the
+  // receiver's buffer registration becoming remote-addressable.
+  std::vector<CtranMapperRequest> syncSreqs(nSteps);
+  std::vector<CtranMapperRequest> syncRreqs(nSteps);
+  for (int i = 0; i < nSteps; i++) {
+    FB_COMMCHECK(mapper->isendCtrl(peers[i], &syncSreqs[i]));
+    FB_COMMCHECK(mapper->irecvCtrl(peers[i], &syncRreqs[i]));
+  }
+  for (int i = 0; i < nSteps; i++) {
+    FB_COMMCHECK(mapper->waitRequest(&syncRreqs[i]));
+  }
+
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_CTRL));
+
+  std::unique_ptr<CtranMapperTimestamp> timestamp =
+      std::make_unique<CtranMapperTimestamp>(AlgoImpl::algoName(myAlgo));
+
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_DATA));
+
+  // Last-put request per step, used to wait for local completion.
+  std::vector<CtranMapperRequest> lastPutReqs(nSteps);
+
+  for (int i = 0; i < nSteps; i++) {
+    const int peer = peers[i];
+    const int nPuts = 1 << i;
+    timestamp->putIssued.push_back(CtranMapperTimestampPoint(peer));
+
+    for (int j = 0; j < nPuts; j++) {
+      // Send chunk sourced from the `anchorNode = nodeId` stripe at column
+      // `localRank`. At step 0 (chunkIdx == rank) the data is taken from
+      // sendBuff. At later steps the same column slot is read from recvbuff:
+      // slot `rank` was written by copyToSelf (stream-ordered before the
+      // PipeStart kernel that released this GPE thread, so it has landed);
+      // other slots were written by earlier IB receives on this same GPE
+      // thread.
+      const auto chunkIdx =
+          rankChunkOffset(nodeId, localRank, nLocalRanks, nNodes, i, j);
+      const size_t byteOffset = chunkIdx * sendSize;
+
+      const void* srcPtr = nullptr;
+      void* srcHdl = nullptr;
+      if (i == 0) {
+        // j == 0 only (nPuts == 1). chunkIdx == rank.
+        srcPtr = sendBuff;
+        srcHdl = sendHdl;
+      } else {
+        srcPtr = ctran::allgatherp::getPtr(pArgs->recvbuff, byteOffset);
+        srcHdl = pArgs->recvHdl;
+      }
+      void* dstPtr =
+          ctran::allgatherp::getPtr(pArgs->remoteRecvBuffs[peer], byteOffset);
+
+      const bool isLast = (j == nPuts - 1);
+      FB_COMMCHECK(mapper->iput(
+          srcPtr,
+          dstPtr,
+          sendSize,
+          peer,
+          CtranMapperConfig{
+              .memHdl_ = srcHdl,
+              .remoteAccessKey_ = pArgs->remoteAccessKeys[peer],
+              .notify_ = isLast},
+          isLast ? &lastPutReqs[i]
+                 : static_cast<CtranMapperRequest*>(nullptr)));
+    }
+
+    FB_COMMCHECK(mapper->waitRequest(&lastPutReqs[i]));
+    timestamp->putComplete.push_back(CtranMapperTimestampPoint(peer));
+
+    FB_COMMCHECK(mapper->waitNotify(notifyVec[i].get()));
+
+    // Notify the stream that step `i` IB exchange is done. The stream can
+    // now issue the intra-node CE broadcast for the 2^i chunks just
+    // received at column `localRank`.
+    if (nLocalRanks > 1) {
+      resource->pipeSync->post(i);
+    }
+  }
+
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_DATA));
+
+  // Wait for our isendCtrls to complete so we don't leak requests.
+  for (int i = 0; i < nSteps; i++) {
+    FB_COMMCHECK(mapper->waitRequest(&syncSreqs[i]));
+  }
+
+  mapper->timestamps.push_back(std::move(timestamp));
+  mapper->reportProfiling();
+
+  CTRAN_PROFILER_IF(profiler, { profiler->reportToScuba(); });
+
+  return commSuccess;
+}
+} // namespace
+
+namespace ctran::allgatherp {
+extern __global__ void ncclKernelAllGatherPPipeStart(
+    int* flag,
+    CtranAlgoDeviceState* devState);
+extern __global__ void ncclKernelAllGatherPPipeSync(
+    int* flag,
+    CtranAlgoDeviceState* devState,
+    PipeSyncKernArgs args);
+extern __global__ void ncclKernelAllGatherPPipeEnd(
+    int* flag,
+    CtranAlgoDeviceState* devState,
+    PipeEndKernArgs args);
+extern __global__ void ncclKernelAllGatherPPipe(
+    int* flag,
+    CtranAlgoDeviceState* devState);
+
+commResult_t AlgoImpl::execRecursiveDoubling(
+    const void* sendbuff,
+    const size_t count,
+    const commDataType_t datatype) {
+  auto recvbuff = pArgs.recvbuff;
+  auto ctran = comm_->ctran_.get();
+  const auto statex = comm_->statex_.get();
+  const auto opCount = ctran->getOpCount();
+  const auto sendSize = count * commTypeSize(datatype);
+
+  const auto nRanks = statex->nRanks();
+  const auto nLocalRanks = statex->nLocalRanks();
+  const auto myRank = statex->rank();
+  const auto localRank = statex->localRank();
+  const auto nNodes = statex->nNodes();
+  const auto myNode = myRank / nLocalRanks;
+
+  if (nLocalRanks > 1 && nRanks % nLocalRanks != 0) {
+    FB_ERRORRETURN(
+        commInvalidUsage,
+        "AllGatherP ctrdpipeline requires nRanks ({}) to be evenly divisible by "
+        "nLocalRanks ({}), nNodes={}",
+        nRanks,
+        nLocalRanks,
+        nNodes);
+  }
+  if (nNodes > 1 && (nNodes & (nNodes - 1)) != 0) {
+    FB_ERRORRETURN(
+        commInvalidUsage,
+        "AllGatherP ctrdpipeline requires nNodes ({}) to be a power of 2",
+        nNodes);
+  }
+
+  CTRAN_COLL_INFO(
+      AlgoImpl::algoName(myAlgo),
+      sendbuff,
+      recvbuff,
+      count,
+      datatype,
+      -1,
+      comm_,
+      stream_);
+
+  if (nLocalRanks > 1) {
+    FB_COMMCHECK(waitInit());
+  }
+
+  const int nSteps = static_cast<int>(ctran::utils::log2i(nNodes));
+
+  auto config = KernelConfig(
+      KernelConfig::KernelType::ALLGATHERP,
+      stream_,
+      AlgoImpl::algoName(myAlgo),
+      opCount);
+  config.numBlocks = 1;
+  config.numThreads = 1;
+  config.args.devState_d = ctran->algo->getDevState();
+
+  // copyToSelf must be enqueued BEFORE the PipeStart kernel that releases the
+  // GPE thread. Unlike ctpipeline, whose GPE reads sendBuff at step 0 and
+  // recvbuff only at positions filled by prior IB receives, the
+  // recursive-doubling GPE reads recvbuff[rank*sendSize] at exactly one j per
+  // step (j = nodeId / stride_i) — that slot is populated only by copyToSelf
+  // on the stream. Enqueuing copyToSelf first gives stream ordering:
+  // copyToSelf -> PipeStart kernel -> GPE signal, so GPE cannot read that
+  // slot before the CE copy has landed.
+  FB_COMMCHECK(copyToSelf(comm_, sendbuff, sendSize, pArgs, stream_));
+
+  // Submit inter-node recursive-doubling exchange for the GPE thread to
+  // execute. Skip entirely if we are on a single node.
+  if (nNodes > 1) {
+    auto op = std::make_unique<OpElem>(
+        OpElem::opType::ALLGATHERP, stream_, comm_, opCount);
+    op->allgatherP.pArgs = &pArgs;
+    op->allgatherP.algoResource = &resource_;
+    op->allgatherP.sendbuff = sendbuff;
+    op->allgatherP.count = count;
+    op->allgatherP.datatype = datatype;
+
+    std::vector<std::unique_ptr<struct OpElem>> opGroup;
+    opGroup.push_back(std::move(op));
+
+    if (nLocalRanks > 1) {
+      // ncclKernelAllGatherPPipeStart releases the GPE thread and returns
+      // immediately so intra-node CE copies can overlap with inter-node
+      // exchange.
+      FB_COMMCHECK(ctran->gpe->submit(
+          std::move(opGroup),
+          gpeFn,
+          config,
+          reinterpret_cast<void*>(ncclKernelAllGatherPPipeStart)));
+    } else {
+      // No intra-node copies — hold the stream while GPE runs to completion.
+      FB_COMMCHECK(ctran->gpe->submit(
+          std::move(opGroup),
+          gpeFn,
+          config,
+          reinterpret_cast<void*>(ncclKernelAllGatherPPipe)));
+    }
+  }
+
+  if (nLocalRanks > 1) {
+    // Initial intra-node CE broadcast of every rank's own chunk. After this
+    // every local rank has all L chunks for its own node populated at
+    // recvbuff[m*L .. m*L + L) where m = myNode.
+    FB_COMMCHECK(nvlCeBcast(
+        comm_, sendbuff, sendSize, myRank * sendSize, pArgs, stream_));
+
+    for (int i = 0; i < nSteps; i++) {
+      // Wait for the GPE's step-i IB exchange to complete.
+      PipeSyncKernArgs syncArgs = {
+          .stepId = i,
+          .pipeSync = resource_.pipeSync,
+      };
+      config.algoArgs = reinterpret_cast<void*>(&syncArgs);
+      FB_COMMCHECK(ctran->gpe->submit(
+          {},
+          nullptr,
+          config,
+          reinterpret_cast<void*>(ncclKernelAllGatherPPipeSync)));
+
+      // The just-received chunks at step i live at column `localRank` for
+      // the 2^i node positions belonging to the peer node at step i.
+      const int distNodes = distNodesAtStep(nNodes, i);
+      const int pos = (myNode / distNodes) % 2;
+      const int peerNode = pos == 0 ? myNode + distNodes : myNode - distNodes;
+
+      const int stride = nodeChunkStrideAtStep(nNodes, i);
+      const int nodeOffset = peerNode % stride;
+      const int nChunks = 1 << i;
+
+      for (int j = 0; j < nChunks; j++) {
+        const int nodePos = j * stride + nodeOffset;
+        const size_t chunkIdx = static_cast<size_t>(nodePos) * nLocalRanks +
+            static_cast<size_t>(localRank);
+        const size_t byteOffset = chunkIdx * sendSize;
+        auto srcPtr = ctran::allgatherp::getPtr(pArgs.recvbuff, byteOffset);
+        // Only the first bcast in each step issues a local barrier; the
+        // subsequent bcasts within the same step touch disjoint positions so
+        // are safe to fire back-to-back.
+        const bool needBarrier = (j == 0);
+        FB_COMMCHECK(nvlCeBcast(
+            comm_, srcPtr, sendSize, byteOffset, pArgs, stream_, needBarrier));
+      }
+    }
+
+    // Reset the pipeSync flags before the next call to execRecursiveDoubling.
+    PipeEndKernArgs endArgs = {
+        .pipeSync = resource_.pipeSync,
+    };
+    config.algoArgs = reinterpret_cast<void*>(&endArgs);
+    FB_COMMCHECK(ctran->gpe->submit(
+        {},
+        nullptr,
+        config,
+        reinterpret_cast<void*>(ncclKernelAllGatherPPipeEnd)));
+  }
+
+  return commSuccess;
+}
+} // namespace ctran::allgatherp

--- a/comms/ctran/algos/AllGatherP/WinAllGather.cc
+++ b/comms/ctran/algos/AllGatherP/WinAllGather.cc
@@ -128,6 +128,8 @@ commResult_t allGatherWinExec(
       return algo->execDirect(sendbuff, count, datatype);
     case NCCL_ALLGATHER_P_ALGO::ctpipeline:
       return algo->execPipeline(sendbuff, count, datatype);
+    case NCCL_ALLGATHER_P_ALGO::ctrdpipeline:
+      return algo->execRecursiveDoubling(sendbuff, count, datatype);
     default:
       return ErrorStackTraceUtil::log(commInternalError);
   }

--- a/comms/ctran/tests/CtranDistAllgatherPTests.cc
+++ b/comms/ctran/tests/CtranDistAllgatherPTests.cc
@@ -279,16 +279,35 @@ class CtranAllgatherPTestParam
           MemAllocType,
           enum NCCL_ALLGATHER_P_ALGO>> {};
 
+static std::string algoToStr(enum NCCL_ALLGATHER_P_ALGO algo) {
+  switch (algo) {
+    case NCCL_ALLGATHER_P_ALGO::ctdirect:
+      return "ctdirect";
+    case NCCL_ALLGATHER_P_ALGO::ctpipeline:
+      return "ctpipeline";
+    case NCCL_ALLGATHER_P_ALGO::ctrdpipeline:
+      return "ctrdpipeline";
+    default:
+      return "unknown";
+  }
+}
+
 TEST_P(CtranAllgatherPTestParam, Basic) {
   const auto& [maxSendCount, count, inplace, memType, algo] = GetParam();
-  const std::string algoStr =
-      (algo == NCCL_ALLGATHER_P_ALGO::ctdirect) ? "ctdirect" : "ctpipeline";
+  const std::string algoStr = algoToStr(algo);
   SysEnvRAII algoEnv("NCCL_ALLGATHER_P_ALGO", algoStr);
 
   if (memType == kMemNcclMemAlloc && ncclIsCuMemSupported() == false) {
     GTEST_SKIP() << "CuMem not supported, skipping this test";
   } else if (ctranComm->ctran_->mapper->ctranIbPtr() == nullptr) {
     GTEST_SKIP() << "No IB Backend found, skip test";
+  } else if (
+      algo == NCCL_ALLGATHER_P_ALGO::ctrdpipeline &&
+      ctranComm->statex_->nNodes() > 1 &&
+      (ctranComm->statex_->nNodes() & (ctranComm->statex_->nNodes() - 1)) !=
+          0) {
+    GTEST_SKIP()
+        << "ctrdpipeline requires nNodes to be a power of 2, skip test";
   } else {
     run(maxSendCount, count, inplace, memType, ctranComm.get());
   }
@@ -296,8 +315,7 @@ TEST_P(CtranAllgatherPTestParam, Basic) {
 
 TEST_P(CtranAllgatherPTestParam, VnodeBasic) {
   const auto& [maxSendCount, count, inplace, memType, algo] = GetParam();
-  const std::string algoStr =
-      (algo == NCCL_ALLGATHER_P_ALGO::ctdirect) ? "ctdirect" : "ctpipeline";
+  const std::string algoStr = algoToStr(algo);
   SysEnvRAII algoEnv("NCCL_ALLGATHER_P_ALGO", algoStr);
   EnvRAII vnodeEnv(
       NCCL_COMM_STATE_DEBUG_TOPO, NCCL_COMM_STATE_DEBUG_TOPO::vnode);
@@ -315,7 +333,48 @@ TEST_P(CtranAllgatherPTestParam, VnodeBasic) {
     // Create a new communicator with virtual node + 4 local ranks setup
     auto testComm = makeCtranComm();
     ASSERT_EQ(testComm->statex_->nLocalRanks(), 4);
-    ASSERT_EQ(testComm->statex_->nNodes(), numRanks / 4);
+    const auto vnodeNNodes = numRanks / 4;
+    ASSERT_EQ(testComm->statex_->nNodes(), vnodeNNodes);
+    if (algo == NCCL_ALLGATHER_P_ALGO::ctrdpipeline && vnodeNNodes > 1 &&
+        (vnodeNNodes & (vnodeNNodes - 1)) != 0) {
+      GTEST_SKIP()
+          << "ctrdpipeline requires nNodes to be a power of 2, skip test";
+    }
+    run(maxSendCount, count, inplace, memType, testComm.get());
+  }
+}
+
+// Exercises the log2(nNodes) striping with nLocalRanks=2, nNodes=numRanks/2,
+// which forces ctrdpipeline through 2+ recursive-doubling steps and thus the
+// j >= 1 path of rankChunkOffset and the step > 0 recvbuff-read path that the
+// 1-step VnodeBasic never hits. Other algos also run through this config
+// so the extra parameterization is cheap.
+TEST_P(CtranAllgatherPTestParam, VnodeBasicMultiStep) {
+  const auto& [maxSendCount, count, inplace, memType, algo] = GetParam();
+  const std::string algoStr = algoToStr(algo);
+  SysEnvRAII algoEnv("NCCL_ALLGATHER_P_ALGO", algoStr);
+  EnvRAII vnodeEnv(
+      NCCL_COMM_STATE_DEBUG_TOPO, NCCL_COMM_STATE_DEBUG_TOPO::vnode);
+  EnvRAII ppnEnv(NCCL_COMM_STATE_DEBUG_TOPO_VNODE_NLOCALRANKS, 2);
+  if (ctranComm->statex_->nLocalRanks() % 2 != 0 || numRanks / 2 < 4) {
+    GTEST_SKIP()
+        << "VnodeBasicMultiStep requires nLocalRanks divisible by 2 and nNodes >= 4";
+  }
+
+  if (memType == kMemNcclMemAlloc && ncclIsCuMemSupported() == false) {
+    GTEST_SKIP() << "CuMem not supported, skipping this test";
+  } else if (ctranComm->ctran_->mapper->ctranIbPtr() == nullptr) {
+    GTEST_SKIP() << "No IB Backend found, skip test";
+  } else {
+    auto testComm = makeCtranComm();
+    ASSERT_EQ(testComm->statex_->nLocalRanks(), 2);
+    const auto vnodeNNodes = numRanks / 2;
+    ASSERT_EQ(testComm->statex_->nNodes(), vnodeNNodes);
+    if (algo == NCCL_ALLGATHER_P_ALGO::ctrdpipeline && vnodeNNodes > 1 &&
+        (vnodeNNodes & (vnodeNNodes - 1)) != 0) {
+      GTEST_SKIP()
+          << "ctrdpipeline requires nNodes to be a power of 2, skip test";
+    }
     run(maxSendCount, count, inplace, memType, testComm.get());
   }
 }
@@ -646,7 +705,8 @@ INSTANTIATE_TEST_SUITE_P(
         testing::Values(kMemNcclMemAlloc),
         testing::Values(
             NCCL_ALLGATHER_P_ALGO::ctdirect,
-            NCCL_ALLGATHER_P_ALGO::ctpipeline)),
+            NCCL_ALLGATHER_P_ALGO::ctpipeline,
+            NCCL_ALLGATHER_P_ALGO::ctrdpipeline)),
     getTestName);
 
 int main(int argc, char* argv[]) {

--- a/comms/ctran/tests/CtranWinAllGatherTest.cc
+++ b/comms/ctran/tests/CtranWinAllGatherTest.cc
@@ -69,6 +69,11 @@ class CtranWinAllGatherTest : public ctran::CtranDistTestFixture {
     if (!CtranWin::allGatherPSupported(comm.get())) {
       GTEST_SKIP() << "allGatherP not supported on this topology";
     }
+    const auto nNodes = statex->nNodes();
+    if (algoStr == "ctrdpipeline" && nNodes > 1 &&
+        (nNodes & (nNodes - 1)) != 0) {
+      GTEST_SKIP() << "ctrd requires nNodes to be a power of 2";
+    }
 
     cudaStream_t stream;
     CUDACHECK_TEST(cudaStreamCreate(&stream));
@@ -140,7 +145,7 @@ INSTANTIATE_TEST_SUITE_P(
     CtranWinAllGatherTestParam,
     ::testing::Combine(
         ::testing::Values(1024, 8192, 65536),
-        ::testing::Values("ctdirect", "ctpipeline")),
+        ::testing::Values("ctdirect", "ctpipeline", "ctrdpipeline")),
     [](const ::testing::TestParamInfo<CtranWinAllGatherTestParam::ParamType>&
            info) {
       return "count_" + std::to_string(std::get<0>(info.param)) + "_" +

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2004,12 +2004,15 @@ cvars:
  - name        : NCCL_ALLGATHER_P_ALGO
    type        : enum
    default     : ctpipeline
-   choices     : ctdirect, ctpipeline
+   choices     : ctdirect, ctpipeline, ctrdpipeline
    description : |-
      The algorithm to use for AllgatherP communication
      ctdirect - Ctran-based direct point-to-point algorithm
      ctpipeline - Ctran-based pipeline algorithm that pipelines
                   inter-node rail ring and intra-node CopyEngine based copy
+     ctrdpipeline - Ctran-based hybrid algorithm that does recursive doubling across
+                    rails for inter-node exchange and CopyEngine based broadcast
+                    within the NVLink domain. Requires nNodes to be a power of 2.
 
  - name        : NCCL_ALLGATHER_ALGO
    type        : enum


### PR DESCRIPTION
Summary:

Adds a third algorithm choice `ctrdpipeline` to `NCCL_ALLGATHER_P_ALGO`, a hybrid recursive-doubling variant that keeps CopyEngine-based intra-node broadcasts while swapping the inter-node Ring of `ctpipeline` for recursive doubling. The goal is to shrink the inter-node step count from `nNodes - 1` to `log2(nNodes)` as AGP scales out, without giving up the NVL CopyEngine optimization in the NVLink domain.

Algorithm:
- Initial NVL CE broadcast populates every local rank's row of recvbuff for its own node.
- The GPE thread performs `log2(nNodes)` RDMA rounds along the rail. Local ranks stripe their column — at step `i` each rank sends `2^i` chunks (`2^i * sendSize` bytes) to the rail peer at node distance `nNodes / 2^(i+1)`. Step 0 reads straight from `sendBuff`; later steps read from column-aligned positions in recvbuff that earlier IB receives have already filled.
- After each IB step the GPE posts `pipeSync`; the stream launches NVL CE broadcasts for the `2^i` received chunks across local peers so every local rank holds the union of node-chunks needed for the next step.
- Falls back to pure copyToSelf + NVL bcast when `nNodes == 1`, and to pure RDMA when `nLocalRanks == 1`.
- Requires `nNodes` to be a power of 2 (same requirement as the single-level ctrd AllGather). Errors out otherwise.

The kernels (`PipeStart`, `PipeSync`, `PipeEnd`, `Pipe`) are reused unchanged from the existing pipeline algorithm.

Reviewed By: minsii

Differential Revision: D102292309


