### PR TITLE
Fix PerfTimer CUDA events to enable timing

### DIFF
--- a/comms/ctran/Ctran.cc
+++ b/comms/ctran/Ctran.cc
@@ -1,5 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 #include <memory>
+#include <optional>
 
 #include "comms/ctran/Ctran.h"
 #include "comms/ctran/CtranComm.h"
@@ -111,6 +112,14 @@ comms::pipes::Transport* CtranComm::getMultiPeerTransportsPtr() const {
 }
 #endif // defined(ENABLE_PIPES)
 
+std::optional<meta::comms::colltrace::AlgoStatDump> CtranComm::dumpAlgoStats()
+    const {
+  if (!algoStats_) {
+    return std::nullopt;
+  }
+  return algoStats_->dump();
+}
+
 commResult_t ctranInit(
     CtranComm* comm,
     std::unique_ptr<ctran::IProfilerReporter> reporter) {
@@ -157,6 +166,13 @@ CtranComm::CtranComm(std::shared_ptr<Abort> abort, ctranConfig commConfig)
   }
   // Default points to internal opCount
   opCount_ = &ctranOpCount_;
+
+  for (const auto& opt : NCCL_COLLTRACE) {
+    if (opt == "algostat") {
+      algoStats_ = std::make_unique<meta::comms::colltrace::AlgoStats>();
+      break;
+    }
+  }
 }
 
 void CtranComm::destroy() {

--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -6,6 +6,7 @@
 #include <chrono>
 #include <cstdint>
 #include <functional>
+#include <optional>
 #include <vector>
 
 #include <folly/Synchronized.h>
@@ -15,6 +16,7 @@
 #include "comms/ctran/utils/Abort.h"
 #include "comms/ctran/utils/AsyncError.h"
 #include "comms/ctran/utils/Exception.h"
+#include "comms/utils/colltrace/AlgoStats.h"
 #include "comms/utils/colltrace/CollTraceInterface.h"
 #include "comms/utils/commSpecs.h"
 
@@ -57,6 +59,7 @@ struct ctranConfig {
 // Forward declaration to avoid circular dependency
 class CollTrace;
 struct ncclComm;
+class CtranGpe;
 namespace ncclx::memory {
 class memCacheAllocator;
 }
@@ -154,6 +157,10 @@ class CtranComm {
   // initialized.
   comms::pipes::Transport* getMultiPeerTransportsPtr() const;
 
+  // Returns a snapshot of the algo stats, or std::nullopt if stats are
+  // disabled.
+  std::optional<meta::comms::colltrace::AlgoStatDump> dumpAlgoStats() const;
+
   // fields are public to allow access from external code and tests
   // TODO: remove config_, it's redundant
   ctranConfig config_;
@@ -205,6 +212,8 @@ class CtranComm {
   CudagraphDeferredCleanup cudagraphDeferredCleanup;
 
  private:
+  friend class CtranGpe;
+  std::unique_ptr<meta::comms::colltrace::AlgoStats> algoStats_;
   // TODO: define proper constructor to make CtranComm be independent of
   // ncclComm.
   // While doing refactoring we always create CtranComm from ncclComm and it

--- a/comms/ctran/gpe/CtranGpe.cc
+++ b/comms/ctran/gpe/CtranGpe.cc
@@ -13,6 +13,51 @@
 
 using namespace ctran;
 
+namespace {
+std::string kernelTypeToOpName(KernelConfig::KernelType type) {
+  switch (type) {
+    case KernelConfig::ALLGATHER:
+    case KernelConfig::ALLGATHERP:
+    // ALLGATHERP_INIT goes through submitHost(), not submit(), so this
+    // case is currently unreachable. Included for completeness.
+    case KernelConfig::ALLGATHERP_INIT:
+      return "AllGather";
+    case KernelConfig::ALLREDUCE:
+      return "AllReduce";
+    case KernelConfig::SEND:
+    case KernelConfig::RECV:
+    case KernelConfig::SENDRECV:
+    case KernelConfig::SENDRECV_P2P:
+    case KernelConfig::RECV_UNPACK:
+    case KernelConfig::SENDRECV_UNPACK:
+      return "SendRecv";
+    case KernelConfig::ALLTOALL:
+    case KernelConfig::ALLTOALL_DEDUP:
+    case KernelConfig::DEVICE_ALLTOALLV:
+    case KernelConfig::ALLTOALLV:
+    case KernelConfig::ALLTOALLV_DYNAMIC:
+    case KernelConfig::ALLTOALLV_DYNAMIC_SPLIT:
+    case KernelConfig::ALLTOALLV_DYNAMIC_SPLIT_NON_CONTIG:
+    case KernelConfig::ALLTOALLV_DEDUP:
+      return "AllToAll";
+    case KernelConfig::BROADCAST:
+    case KernelConfig::BROADCAST_UNPACK:
+      return "Broadcast";
+    case KernelConfig::REDUCESCATTER:
+      return "ReduceScatter";
+    case KernelConfig::PUTNOTIFY:
+    case KernelConfig::WAITNOTIFY:
+    case KernelConfig::PUTSIGNAL:
+    case KernelConfig::WAITSIGNAL:
+    case KernelConfig::SIGNAL:
+    case KernelConfig::GET:
+      return "RMA";
+    default:
+      return "Unknown";
+  }
+}
+} // namespace
+
 OpElem::OpElem(enum opType type, CtranComm* comm, uint64_t opCount)
     : OpElem(type, nullptr, comm, nullptr, opCount) {};
 
@@ -394,6 +439,10 @@ commResult_t CtranGpe::submit(
     const void* ncclKernel,
     std::optional<std::chrono::milliseconds> timeout,
     PreLaunchGraphPrepareFn graphPrepareFn) {
+  if (this->pimpl->comm->algoStats_) {
+    this->pimpl->comm->algoStats_->record(
+        kernelTypeToOpName(kernelConfig.type), kernelConfig.algoName);
+  }
   return this->pimpl->submit(
       CtranGpeCmd::TypeEnum::GRAPH_ENQUEUE,
       std::move(opGroup),

--- a/comms/ctran/tests/CtranDistAllgatherTests.cc
+++ b/comms/ctran/tests/CtranDistAllgatherTests.cc
@@ -15,6 +15,7 @@
 #include "comms/ctran/colltrace/CollTraceWrapper.h"
 #include "comms/ctran/profiler/Profiler.h"
 #include "comms/ctran/tests/CtranDistTestUtils.h"
+#include "comms/ctran/tests/VerifyAlgoStatsUtil.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsCuUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -32,9 +33,12 @@ class CtranAllgatherTest : public ctran::CtranDistTestFixture,
   void *sCommBuf, *rCommBuf, *pCommBuf;
   std::vector<TestMemSegment> segments;
 
+  ctran::test::VerifyAlgoStatsHelper algoStats_;
+
   void SetUp() override {
     setenv("NCCL_CTRAN_TRANSPORT_PROFILER", "1", 0);
     setenv("NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT", "1", 0);
+    algoStats_.enable();
     ctran::CtranDistTestFixture::SetUp();
     ctranComm = makeCtranComm();
     segments.clear();
@@ -255,6 +259,8 @@ TEST_P(CtranAllgatherTestParam, AllgatherAlgo) {
         coll["algoName"].asString(), testing::HasSubstr(expAlgoNames.at(idx)));
     idx++;
   }
+
+  algoStats_.verify(ctranComm.get(), "AllGather", allGatherAlgoName(algo));
 
   for (auto& segment : segments) {
     COMMCHECK_TEST(ctran::globalDeregisterWithPtr(segment.ptr, segment.size));

--- a/comms/ctran/tests/VerifyAlgoStatsUtil.cc
+++ b/comms/ctran/tests/VerifyAlgoStatsUtil.cc
@@ -1,0 +1,95 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "VerifyAlgoStatsUtil.h"
+
+#include <fmt/core.h>
+#include <gtest/gtest.h>
+#include "comms/utils/cvars/nccl_cvars.h"
+
+namespace ctran::test {
+
+VerifyAlgoStatsHelper::~VerifyAlgoStatsHelper() {
+  if (enabled_) {
+    NCCL_COLLTRACE = oldColltrace_;
+  }
+}
+
+void VerifyAlgoStatsHelper::enable() {
+  oldColltrace_ = NCCL_COLLTRACE;
+  NCCL_COLLTRACE.push_back("algostat");
+  enabled_ = true;
+}
+
+namespace {
+
+std::string formatStats(const std::unordered_map<std::string, int64_t>& stats) {
+  std::string result;
+  for (const auto& [name, count] : stats) {
+    if (!result.empty()) {
+      result += ", ";
+    }
+    result += fmt::format("{}({})", name, count);
+  }
+  return result;
+}
+
+} // namespace
+
+void VerifyAlgoStatsHelper::verify(
+    CtranComm* comm,
+    const std::string& collective,
+    const std::string& expectedAlgoSubstr) const {
+  auto statDumpOpt = comm->dumpAlgoStats();
+  ASSERT_TRUE(statDumpOpt.has_value());
+  auto statDump = std::move(*statDumpOpt);
+  auto it = statDump.counts.find(collective);
+  ASSERT_NE(it, statDump.counts.end())
+      << collective << " not found in AlgoStats";
+  bool found = false;
+  for (const auto& [algoName, callCount] : it->second) {
+    if (algoName.find(expectedAlgoSubstr) != std::string::npos &&
+        callCount > 0) {
+      found = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(found) << "Expected algorithm containing '" << expectedAlgoSubstr
+                     << "' not found in " << collective
+                     << ". Found: " << formatStats(it->second);
+}
+
+void VerifyAlgoStatsHelper::verifyNot(
+    CtranComm* comm,
+    const std::string& collective,
+    const std::string& unexpectedAlgoSubstr) const {
+  auto statDumpOpt = comm->dumpAlgoStats();
+  ASSERT_TRUE(statDumpOpt.has_value());
+  auto statDump = std::move(*statDumpOpt);
+  auto it = statDump.counts.find(collective);
+  if (it == statDump.counts.end()) {
+    return;
+  }
+  for (const auto& [algoName, callCount] : it->second) {
+    EXPECT_FALSE(
+        algoName.find(unexpectedAlgoSubstr) != std::string::npos &&
+        callCount > 0)
+        << "Unexpected algorithm '" << algoName << "' with count " << callCount
+        << " found in " << collective;
+  }
+}
+
+void VerifyAlgoStatsHelper::dump(CtranComm* comm, const std::string& collective)
+    const {
+  auto statDumpOpt = comm->dumpAlgoStats();
+  if (!statDumpOpt) {
+    return;
+  }
+  auto statDump = std::move(*statDumpOpt);
+  auto it = statDump.counts.find(collective);
+  if (it != statDump.counts.end()) {
+    fmt::print(
+        stderr, "AlgoStats[{}]: [{}]\n", collective, formatStats(it->second));
+  }
+}
+
+} // namespace ctran::test

--- a/comms/ctran/tests/VerifyAlgoStatsUtil.h
+++ b/comms/ctran/tests/VerifyAlgoStatsUtil.h
@@ -1,0 +1,35 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <string>
+#include "comms/ctran/CtranComm.h"
+
+namespace ctran::test {
+
+// TODO: Migrate to colltrace once CUDA graph colltrace support is fixed.
+class VerifyAlgoStatsHelper {
+ public:
+  ~VerifyAlgoStatsHelper();
+
+  // Enable AlgoStats tracing. Must be called before CtranComm creation.
+  void enable();
+
+  void verify(
+      CtranComm* comm,
+      const std::string& collective,
+      const std::string& expectedAlgoSubstr) const;
+
+  void verifyNot(
+      CtranComm* comm,
+      const std::string& collective,
+      const std::string& unexpectedAlgoSubstr) const;
+
+  void dump(CtranComm* comm, const std::string& collective) const;
+
+ private:
+  bool enabled_{false};
+  std::vector<std::string> oldColltrace_;
+};
+
+} // namespace ctran::test

--- a/comms/torchcomms/tests/perf/cpp/PerfTestHelpers.h
+++ b/comms/torchcomms/tests/perf/cpp/PerfTestHelpers.h
@@ -52,8 +52,8 @@ class PerfTimer {
   double elapsed_ms();
 
  private:
-  at::cuda::CUDAEvent start_event_;
-  at::cuda::CUDAEvent end_event_;
+  at::cuda::CUDAEvent start_event_{cudaEventDefault};
+  at::cuda::CUDAEvent end_event_{cudaEventDefault};
   State state_;
 };
 


### PR DESCRIPTION
Summary:
- PerfTimer's CUDAEvent members were default-constructed with `cudaEventDisableTiming`, causing `c10::ValueError: Both events must be created with argument 'enable_timing=True'` when calling `elapsed_time()`
- Pass `cudaEventDefault` to enable timing support

Differential Revision: D102477745


