### PR TITLE
Add invalid usage check for allgather ctgraph (#2272)

### DIFF
--- a/comms/ctran/Ctran.h
+++ b/comms/ctran/Ctran.h
@@ -48,7 +48,11 @@ class Ctran : public ICtran {
   CtranComm* comm_{nullptr};
 };
 
-bool ctranSendRecvSupport(int peer, CtranComm* comm);
+bool ctranSendRecvSupport(
+    int peer,
+    CtranComm* comm,
+    enum NCCL_SENDRECV_ALGO algo = NCCL_SENDRECV_ALGO::ctran,
+    cudaStream_t stream = nullptr);
 
 commResult_t ctranSend(
     const void* sendbuff,

--- a/comms/ctran/algos/AllGather/AllGather.cc
+++ b/comms/ctran/algos/AllGather/AllGather.cc
@@ -123,7 +123,7 @@ commResult_t ctranAllGather(
           sendbuff, recvbuff, sendcount, datatype, comm, stream, algo);
     }
     FB_ERRORRETURN(
-        commInternalError,
+        commInvalidUsage,
         "AllGather {} called outside CUDA graph capture. "
         "ctranAllGatherSupport should have returned false.",
         allGatherAlgoName(algo));

--- a/comms/ctran/algos/AllGather/tests/AllGatherCtgraphSupportTest.cc
+++ b/comms/ctran/algos/AllGather/tests/AllGatherCtgraphSupportTest.cc
@@ -38,4 +38,28 @@ TEST_F(AllGatherCtgraphSupportTest, EagerAlgosUnaffected) {
       comm_.get(), NCCL_ALLGATHER_ALGO::ctran, stream->get()));
 }
 
+// Verify ctranAllGather returns commInvalidUsage when a graph-aware algo is
+// called outside of CUDA graph capture. Uses cudaStreamDefault (stream 0)
+// which is always valid and never in capture mode.
+TEST_F(AllGatherCtgraphSupportTest, InvalidUsageOutsideCapture) {
+  const size_t count = 1024;
+  void* sendbuf = nullptr;
+  void* recvbuf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&sendbuf, count * sizeof(int32_t)));
+  CUDACHECK_TEST(cudaMalloc(&recvbuf, count * 8 * sizeof(int32_t)));
+
+  auto result = ctranAllGather(
+      sendbuf,
+      recvbuf,
+      count,
+      commInt32,
+      comm_.get(),
+      cudaStreamDefault,
+      NCCL_ALLGATHER_ALGO::ctgraph);
+  EXPECT_EQ(result, commInvalidUsage);
+
+  CUDACHECK_TEST(cudaFree(sendbuf));
+  CUDACHECK_TEST(cudaFree(recvbuf));
+}
+
 } // namespace ctran::testing

--- a/comms/ctran/algos/SendRecv/SendRecv.cc
+++ b/comms/ctran/algos/SendRecv/SendRecv.cc
@@ -4,9 +4,11 @@
 #include <deque>
 #include <optional>
 
+#include "comms/ctran/Ctran.h"
 #include "comms/ctran/algos/SendRecv/SendRecvImpl.h"
 #include "comms/ctran/gpe/CtranGpe.h"
 #include "comms/ctran/mapper/CtranMapper.h"
+#include "comms/ctran/utils/CudaGraphUtils.h"
 #include "comms/ctran/utils/ExtUtils.h"
 
 static thread_local std::deque<OpElem*> CtranOpGroup;
@@ -27,18 +29,42 @@ std::unordered_map<KernelConfig::KernelType, void*> kernelFns = {
 
 static const auto myAlgo = NCCL_SENDRECV_ALGO::ctran;
 
-bool ctranSendRecvSupport(int peer, CtranComm* comm) {
+bool ctranSendRecvSupport(
+    int peer,
+    CtranComm* comm,
+    enum NCCL_SENDRECV_ALGO algo,
+    cudaStream_t stream) {
   const auto statex = comm->statex_.get();
+
+  if (!ctranInitialized(comm)) {
+    return false;
+  }
+
+  if (algo == NCCL_SENDRECV_ALGO::ctgraph) {
+    if (peer != statex->rank() &&
+        comm->ctran_->mapper->getBackend(peer) != CtranMapperBackend::IB) {
+      return false;
+    }
+    if (stream == nullptr) {
+      return false;
+    }
+    ctran::utils::cudagraph::StreamCaptureInfo captureInfo;
+    auto err =
+        ctran::utils::cudagraph::getStreamCaptureInfo(stream, captureInfo);
+    if (err != cudaSuccess ||
+        captureInfo.status != cudaStreamCaptureStatusActive) {
+      return false;
+    }
+    return true;
+  }
 
   // Self peer is handled by CE directly, other peers require a valid ctran
   // backend
-  if (ctranInitialized(comm) &&
-      (peer == statex->rank() ||
-       comm->ctran_->mapper->getBackend(peer) != CtranMapperBackend::UNSET)) {
+  if (peer == statex->rank() ||
+      comm->ctran_->mapper->getBackend(peer) != CtranMapperBackend::UNSET) {
     return true;
-  } else {
-    return false;
   }
+  return false;
 }
 
 commResult_t ctranSend(
@@ -84,14 +110,15 @@ commResult_t ctranRecv(
   return commSuccess;
 }
 
-commResult_t ctranGroupEndHook(
+commResult_t ctranGroupEndHookImpl(
+    std::deque<OpElem*>& opGroup,
     enum NCCL_SENDRECV_ALGO algo,
     std::optional<std::chrono::milliseconds> timeout) {
   // By default, use zero-copy kernel for sendrecv.
   if (algo == NCCL_SENDRECV_ALGO::ctran) {
     algo = NCCL_SENDRECV_ALGO::ctzcopy;
   }
-  while (!CtranOpGroup.empty()) {
+  while (!opGroup.empty()) {
     // TODO: clean up duplicate info in allops, nvlOps and ibOps
     std::vector<OpElem*> allOps;
     std::vector<OpElem*> selfSends, selfRecvs, nvlOps, ibOps;
@@ -101,13 +128,13 @@ commResult_t ctranGroupEndHook(
     bool hasTcpDmRecv = false;
 
     // Submit ops with the same comm and stream in a single batch
-    CtranComm* comm = CtranOpGroup.front()->comm_;
-    cudaStream_t stream = CtranOpGroup.front()->stream;
+    CtranComm* comm = opGroup.front()->comm_;
+    cudaStream_t stream = opGroup.front()->stream;
     const auto statex = comm->statex_.get();
     auto mapper = comm->ctran_->mapper.get();
 
-    while (!CtranOpGroup.empty()) {
-      auto op = dequeFront(CtranOpGroup);
+    while (!opGroup.empty()) {
+      auto op = dequeFront(opGroup);
 
       if (op->comm_ == comm && op->stream == stream) {
         if (op->type == OpElem::opType::SEND) {
@@ -217,10 +244,34 @@ commResult_t ctranGroupEndHook(
     comm->ctran_->numGroupedDefaultOps = 0;
 
     // handle next batch
-    CtranOpGroup = std::move(pending);
+    opGroup = std::move(pending);
   }
 
   return commSuccess;
+}
+
+commResult_t ctranGroupEndHook(
+    enum NCCL_SENDRECV_ALGO algo,
+    std::optional<std::chrono::milliseconds> timeout) {
+  if (algo == NCCL_SENDRECV_ALGO::ctgraph) {
+    if (CtranOpGroup.empty()) {
+      return commSuccess;
+    }
+    cudaStream_t stream = CtranOpGroup.front()->stream;
+    ctran::utils::cudagraph::StreamCaptureInfo captureInfo;
+    FB_CUDACHECK(
+        ctran::utils::cudagraph::getStreamCaptureInfo(stream, captureInfo));
+    if (captureInfo.status == cudaStreamCaptureStatusActive) {
+      return ctranSendRecvCudagraphAware(
+          CtranOpGroup, CtranOpGroup.front()->comm_, stream, timeout);
+    }
+    FB_ERRORRETURN(
+        commInvalidUsage,
+        "SendRecv ctgraph called outside CUDA graph capture. "
+        "ctranSendRecvSupport should have returned false.");
+  } else {
+    return ctranGroupEndHookImpl(CtranOpGroup, algo, timeout);
+  }
 }
 
 void ctranGroupTrackDefaultOp(CtranComm* comm) {

--- a/comms/ctran/algos/SendRecv/SendRecvCudagraphAware.cc
+++ b/comms/ctran/algos/SendRecv/SendRecvCudagraphAware.cc
@@ -1,0 +1,71 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// Cudagraph-aware SendRecv: when ctranGroupEndHook is called with
+// algo=ctgraph during CUDA graph capture, this module pre-registers all
+// send/recv buffers via globalRegisterWithPtr (local-persist pattern),
+// then delegates to ctranGroupEndHookImpl(ctzcopy) for the actual GPE
+// dispatch. The GPE host-node callbacks are captured into the graph and
+// re-execute on replay with pre-registered buffers (searchRegHandle
+// hits the fast path).
+//
+// Cleanup: registered buffers are deregistered via cudagraphDeferredCleanup
+// during comm destruction. Uses folly::makeGuard for exception-safe cleanup
+// on error paths.
+
+#include <folly/ScopeGuard.h>
+
+#include "comms/ctran/Ctran.h"
+#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/algos/SendRecv/SendRecvImpl.h"
+#include "comms/utils/CudaRAII.h"
+
+commResult_t ctranSendRecvCudagraphAware(
+    std::deque<OpElem*>& opGroup,
+    CtranComm* comm,
+    cudaStream_t stream,
+    std::optional<std::chrono::milliseconds> timeout) {
+  // Caller (ctranGroupEndHook) already verified active capture mode.
+
+  // Pre-register all send/recv buffers
+  std::vector<std::pair<void*, size_t>> registeredBufs;
+  {
+    meta::comms::StreamCaptureModeGuard captureGuard{
+        cudaStreamCaptureModeRelaxed};
+    for (const auto* op : opGroup) {
+      if (op->type == OpElem::opType::SEND) {
+        const size_t nbytes = op->send.count * commTypeSize(op->send.datatype);
+        FB_COMMCHECK(
+            ctran::globalRegisterWithPtr(
+                const_cast<void*>(op->send.sendbuff), nbytes, true, true));
+        registeredBufs.emplace_back(
+            const_cast<void*>(op->send.sendbuff), nbytes);
+      } else if (op->type == OpElem::opType::RECV) {
+        const size_t nbytes = op->recv.count * commTypeSize(op->recv.datatype);
+        FB_COMMCHECK(
+            ctran::globalRegisterWithPtr(
+                op->recv.recvbuff, nbytes, true, true));
+        registeredBufs.emplace_back(op->recv.recvbuff, nbytes);
+      }
+    }
+  }
+
+  auto cleanupGuard = folly::makeGuard([&registeredBufs]() {
+    for (const auto& [buf, size] : registeredBufs) {
+      ctran::globalDeregisterWithPtr(buf, size);
+    }
+  });
+
+  // Dispatch to normal eager path with ctzcopy
+  FB_COMMCHECK(
+      ctranGroupEndHookImpl(opGroup, NCCL_SENDRECV_ALGO::ctzcopy, timeout));
+
+  // Success — transfer cleanup to deferred
+  cleanupGuard.dismiss();
+  comm->cudagraphDeferredCleanup.add([registeredBufs]() {
+    for (const auto& [buf, size] : registeredBufs) {
+      ctran::globalDeregisterWithPtr(buf, size);
+    }
+  });
+
+  return commSuccess;
+}

--- a/comms/ctran/algos/SendRecv/SendRecvImpl.h
+++ b/comms/ctran/algos/SendRecv/SendRecvImpl.h
@@ -1,7 +1,9 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 #pragma once
 
+#include <deque>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -33,6 +35,20 @@ commResult_t setupKernelConfig(
     KernelConfig& config,
     ctran::sendrecv::KernArgs& kernArgs);
 } // namespace ctran::sendrecv
+
+// Inner dispatch: batches ops, submits to GPE. Used by both eager and
+// cudagraph-aware paths.
+commResult_t ctranGroupEndHookImpl(
+    std::deque<OpElem*>& opGroup,
+    enum NCCL_SENDRECV_ALGO algo,
+    std::optional<std::chrono::milliseconds> timeout = std::nullopt);
+
+// Cudagraph-aware SendRecv: pre-registers all send/recv buffers during capture.
+commResult_t ctranSendRecvCudagraphAware(
+    std::deque<OpElem*>& opGroup,
+    CtranComm* comm,
+    cudaStream_t stream,
+    std::optional<std::chrono::milliseconds> timeout = std::nullopt);
 
 inline const std::string sendRecvAlgoName(
     enum NCCL_SENDRECV_ALGO algo,

--- a/comms/ctran/algos/SendRecv/tests/SendRecvCtgraphSupportTest.cc
+++ b/comms/ctran/algos/SendRecv/tests/SendRecvCtgraphSupportTest.cc
@@ -1,0 +1,58 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include "comms/ctran/Ctran.h"
+#include "comms/ctran/algos/SendRecv/SendRecvImpl.h"
+#include "comms/ctran/tests/CtranTestUtils.h"
+#include "comms/ctran/utils/CommGroupUtils.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+
+namespace ctran::testing {
+
+class SendRecvCtgraphSupportTest : public CtranStandaloneFixture {
+ protected:
+  void SetUp() override {
+    CtranStandaloneFixture::SetUp();
+    comm_ = makeCtranComm();
+    ASSERT_NE(comm_, nullptr);
+  }
+
+  std::unique_ptr<CtranComm> comm_;
+};
+
+TEST_F(SendRecvCtgraphSupportTest, NullStream) {
+  const int peer = 0;
+  EXPECT_FALSE(ctranSendRecvSupport(
+      peer, comm_.get(), NCCL_SENDRECV_ALGO::ctgraph, nullptr));
+}
+
+TEST_F(SendRecvCtgraphSupportTest, EagerAlgosUnaffected) {
+  const int peer = 0;
+  EXPECT_TRUE(ctranSendRecvSupport(
+      peer, comm_.get(), NCCL_SENDRECV_ALGO::ctran, nullptr));
+}
+
+// Verify ctranGroupEndHook returns commInvalidUsage when ctgraph is called
+// outside of CUDA graph capture. Uses cudaStreamDefault (stream 0) which is
+// always valid and never in capture mode.
+TEST_F(SendRecvCtgraphSupportTest, InvalidUsageOutsideCapture) {
+  const int peer = 0;
+  const size_t count = 1024;
+
+  commGroupDepth++;
+  ASSERT_EQ(
+      ctranSend(
+          nullptr, count, commInt32, peer, comm_.get(), cudaStreamDefault),
+      commSuccess);
+  ASSERT_EQ(
+      ctranRecv(
+          nullptr, count, commInt32, peer, comm_.get(), cudaStreamDefault),
+      commSuccess);
+  commGroupDepth--;
+
+  auto result = ctranGroupEndHook(NCCL_SENDRECV_ALGO::ctgraph, std::nullopt);
+  EXPECT_EQ(result, commInvalidUsage);
+}
+
+} // namespace ctran::testing

--- a/comms/ctran/tests/cudagraph/CtranCudaGraphSendRecvCtgraphTest.cc
+++ b/comms/ctran/tests/cudagraph/CtranCudaGraphSendRecvCtgraphTest.cc
@@ -1,0 +1,233 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// Tests for cudagraph-aware SendRecv with ctgraph algorithm.
+// Pre-registers send/recv buffers during capture, delegates to the normal
+// eager dispatch. Currently requires IB backend for the peer.
+// TODO: Enable window-based global registration for NVL send/recv in graph
+// mode, similar to AllGather ctgraph_pipeline.
+
+#include <random>
+
+#include "comms/ctran/Ctran.h"
+#include "comms/ctran/algos/SendRecv/SendRecvImpl.h"
+#include "comms/ctran/tests/VerifyAlgoStatsUtil.h"
+#include "comms/ctran/tests/cudagraph/CtranCudaGraphParamTest.h"
+#include "comms/ctran/utils/CommGroupUtils.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+
+static AlgoDescriptor makeSendRecvCtgraph() {
+  struct B : AlgoDescriptor::Buffers {
+    ctran::TestDeviceBuffer send, recv;
+    size_t bytes;
+    int sendPeer, recvPeer;
+    B(size_t c, int rank, int nR)
+        : send(c * sizeof(int32_t)),
+          recv(c * sizeof(int32_t)),
+          bytes(c * sizeof(int32_t)),
+          sendPeer((rank + 1) % nR),
+          recvPeer((rank - 1 + nR) % nR) {
+      CtranCudaGraphTestBase::fillSendBuf(send.get(), c, rank);
+    }
+    void* sendbuf() override {
+      return send.get();
+    }
+    void* recvbuf() override {
+      return recv.get();
+    }
+    size_t recvBytes() override {
+      return bytes;
+    }
+  };
+
+  AlgoDescriptor desc;
+  desc.name = "SendRecvCtgraph";
+  desc.isSupported = [](CtranComm* comm, size_t, int nRanks) {
+    if (nRanks < 2) {
+      return false;
+    }
+    const auto statex = comm->statex_.get();
+    const int sendPeer = (statex->rank() + 1) % nRanks;
+    return comm->ctran_->mapper->getBackend(sendPeer) == CtranMapperBackend::IB;
+  };
+  desc.expectsHostNodes = [](CtranComm*, size_t) { return true; };
+  desc.makeBuffers = [](size_t c, int rank, int nR) {
+    return std::make_shared<B>(c, rank, nR);
+  };
+  desc.capture = [](AlgoDescriptor::Buffers* base,
+                    size_t count,
+                    ctran::testing::CaptureContext& ctx) {
+    auto* b = static_cast<B*>(base);
+    cudaStreamCaptureStatus status;
+    ASSERT_EQ(cudaStreamIsCapturing(ctx.stream, &status), cudaSuccess);
+    const auto algo = (status == cudaStreamCaptureStatusActive)
+        ? NCCL_SENDRECV_ALGO::ctgraph
+        : NCCL_SENDRECV_ALGO::ctran;
+    commGroupDepth++;
+    ASSERT_EQ(
+        ctranSend(
+            b->send.get(), count, commInt32, b->sendPeer, ctx.comm, ctx.stream),
+        commSuccess);
+    ASSERT_EQ(
+        ctranRecv(
+            b->recv.get(), count, commInt32, b->recvPeer, ctx.comm, ctx.stream),
+        commSuccess);
+    commGroupDepth--;
+    ASSERT_EQ(ctranGroupEndHook(algo, std::nullopt), commSuccess);
+  };
+  return desc;
+}
+
+DEFINE_CUDAGRAPH_PARAM_TEST(CudaGraphSendRecvCtgraph, makeSendRecvCtgraph());
+
+// Expandable segment test: SendRecv ctgraph with kCuMemAllocDisjoint memory
+// (multiple disjoint physical segments, 20MB each) and random offset.
+class CudaGraphSendRecvCtgraphExpandable
+    : public CtranCudaGraphTestBase,
+      public ::testing::WithParamInterface<size_t> {
+ protected:
+  ctran::test::VerifyAlgoStatsHelper algoStats_;
+
+  void SetUp() override {
+    CtranCudaGraphTestBase::SetUp();
+    algoStats_.enable();
+  }
+};
+
+static constexpr size_t kSegmentSize = 20UL * 1024 * 1024;
+
+static size_t segmentsNeeded(size_t bytes) {
+  return (bytes + kSegmentSize - 1) / kSegmentSize;
+}
+
+TEST_P(CudaGraphSendRecvCtgraphExpandable, CaptureReplayVerify) {
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+
+  const int rank = globalRank;
+  const int nRanks = numRanks;
+  const int sendPeer = (rank + 1) % nRanks;
+  const int recvPeer = (rank - 1 + nRanks) % nRanks;
+
+  if (nRanks < 2) {
+    GTEST_SKIP() << "SendRecv requires at least 2 ranks";
+  }
+  if (comm->ctran_->mapper->getBackend(sendPeer) != CtranMapperBackend::IB ||
+      comm->ctran_->mapper->getBackend(recvPeer) != CtranMapperBackend::IB) {
+    GTEST_SKIP() << "SendRecv ctgraph requires IB backend for peers";
+  }
+
+  const size_t count = GetParam();
+  const size_t dataBytes = count * sizeof(int32_t);
+
+  std::mt19937 rng(rank);
+  const size_t offsetElems = rng() % 4096 + 1;
+  const size_t offsetBytes = offsetElems * sizeof(int32_t);
+
+  const size_t numSeg = segmentsNeeded(dataBytes + offsetBytes);
+
+  ctran::TestDeviceBuffer send(
+      numSeg * kSegmentSize, kCuMemAllocDisjoint, numSeg);
+  ctran::TestDeviceBuffer recv(
+      numSeg * kSegmentSize, kCuMemAllocDisjoint, numSeg);
+
+  auto* sendbuf = static_cast<char*>(send.get()) + offsetBytes;
+  auto* recvbuf = static_cast<char*>(recv.get()) + offsetBytes;
+
+  fillSendBuf(sendbuf, count, rank);
+  CUDACHECK_TEST(cudaMemset(recvbuf, 0, dataBytes));
+
+  meta::comms::CudaStream stream(cudaStreamNonBlocking);
+
+  EnvRAII algoEnv(NCCL_SENDRECV_ALGO, NCCL_SENDRECV_ALGO::ctgraph);
+
+  // Capture
+  cudaGraph_t graph;
+  cudaGraphExec_t exec;
+  ASSERT_EQ(
+      cudaStreamBeginCapture(stream.get(), cudaStreamCaptureModeGlobal),
+      cudaSuccess);
+
+  commGroupDepth++;
+  ASSERT_EQ(
+      ctranSend(sendbuf, count, commInt32, sendPeer, comm.get(), stream.get()),
+      commSuccess);
+  ASSERT_EQ(
+      ctranRecv(recvbuf, count, commInt32, recvPeer, comm.get(), stream.get()),
+      commSuccess);
+  commGroupDepth--;
+  ASSERT_EQ(
+      ctranGroupEndHook(NCCL_SENDRECV_ALGO::ctgraph, std::nullopt),
+      commSuccess);
+
+  ASSERT_EQ(cudaStreamEndCapture(stream.get(), &graph), cudaSuccess);
+  ASSERT_EQ(cudaGraphInstantiate(&exec, graph, 0), cudaSuccess);
+
+  // Replay
+  ASSERT_EQ(cudaGraphLaunch(exec, stream.get()), cudaSuccess);
+  ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
+
+  // Verify
+  std::vector<int32_t> host(count);
+  CUDACHECK_TEST(
+      cudaMemcpy(host.data(), recvbuf, dataBytes, cudaMemcpyDefault));
+  for (size_t i = 0; i < count; i++) {
+    ASSERT_EQ(host[i], recvPeer) << "mismatch at elem " << i;
+  }
+
+  algoStats_.verify(comm.get(), "SendRecv", "Ctran");
+
+  ASSERT_EQ(cudaGraphExecDestroy(exec), cudaSuccess);
+  ASSERT_EQ(cudaGraphDestroy(graph), cudaSuccess);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CudaGraphSendRecvCtgraphExpandableTests,
+    CudaGraphSendRecvCtgraphExpandable,
+    ::testing::Values(2097152UL, 10485760UL));
+
+// Verify ctranSendRecvSupport returns false for ctgraph when preconditions
+// are not met: null stream, non-capturing stream, or NVL-only peer topology.
+class CudaGraphSendRecvCtgraphSupport : public CtranCudaGraphTestBase {};
+
+TEST_F(CudaGraphSendRecvCtgraphSupport, SupportCheckCtgraph) {
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+
+  if (numRanks < 2) {
+    GTEST_SKIP() << "Need at least 2 ranks";
+  }
+
+  const int peer = (globalRank + 1) % numRanks;
+
+  EnvRAII algoEnv(NCCL_SENDRECV_ALGO, NCCL_SENDRECV_ALGO::ctgraph);
+
+  const auto ctgraph = NCCL_SENDRECV_ALGO::ctgraph;
+
+  EXPECT_FALSE(ctranSendRecvSupport(peer, comm.get(), ctgraph, nullptr))
+      << "should return false with null stream";
+
+  meta::comms::CudaStream stream(cudaStreamNonBlocking);
+  EXPECT_FALSE(ctranSendRecvSupport(peer, comm.get(), ctgraph, stream.get()))
+      << "should return false outside capture";
+
+  const auto backend = comm->ctran_->mapper->getBackend(peer);
+  if (backend != CtranMapperBackend::IB) {
+    ASSERT_EQ(
+        cudaStreamBeginCapture(stream.get(), cudaStreamCaptureModeRelaxed),
+        cudaSuccess);
+    EXPECT_FALSE(ctranSendRecvSupport(peer, comm.get(), ctgraph, stream.get()))
+        << "should return false for non-IB peer during capture";
+    cudaGraph_t graph;
+    cudaStreamEndCapture(stream.get(), &graph);
+    if (graph) {
+      cudaGraphDestroy(graph);
+    }
+  }
+}
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new CtranCudaGraphEnvironment);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ncclx/meta/algoconf/AlgoConfig.cc
+++ b/comms/ncclx/meta/algoconf/AlgoConfig.cc
@@ -19,6 +19,8 @@ inline const std::string algoValToStr(enum NCCL_SENDRECV_ALGO val) {
       return "ctzcopy";
     case NCCL_SENDRECV_ALGO::ctp2p:
       return "ctp2p";
+    case NCCL_SENDRECV_ALGO::ctgraph:
+      return "ctgraph";
   }
 }
 
@@ -29,6 +31,8 @@ inline void algoStrToVal(const std::string& str, enum NCCL_SENDRECV_ALGO& val) {
     val = NCCL_SENDRECV_ALGO::ctzcopy;
   } else if (str == "ctp2p") {
     val = NCCL_SENDRECV_ALGO::ctp2p;
+  } else if (str == "ctgraph") {
+    val = NCCL_SENDRECV_ALGO::ctgraph;
   } else {
     val = NCCL_SENDRECV_ALGO::orig;
   }

--- a/comms/ncclx/meta/tests/SendRecvTest.cc
+++ b/comms/ncclx/meta/tests/SendRecvTest.cc
@@ -11,6 +11,7 @@
 #include "checks.h"
 #include "comms/ncclx/meta/tests/NcclCommUtils.h"
 
+#include "comms/ctran/tests/VerifyAlgoStatsUtil.h"
 #include "comms/ncclx/meta/tests/NcclxBaseTest.h"
 #include "comms/testinfra/AlgoTestUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -25,6 +26,12 @@ class SendRecvTest : public NcclxBaseTestFixture {
   void SetUp() override {
     setenv("NCCL_CTRAN_ENABLE", "1", 1);
     NcclxBaseTestFixture::SetUp();
+    ctranAlgoStats_.enable();
+#ifdef NCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL
+    ASSERT_EQ(
+        ncclx::setGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal), "1"),
+        ncclSuccess);
+#endif
     this->comm = ncclx::test::createNcclComm(
         globalRank, numRanks, localRank, bootstrap_.get());
 
@@ -35,6 +42,9 @@ class SendRecvTest : public NcclxBaseTestFixture {
   void TearDown() override {
     NCCLCHECK_TEST(ncclCommDestroy(this->comm));
     CUDACHECK_TEST(cudaStreamDestroy(this->stream));
+#ifdef NCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL
+    ncclx::resetGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal));
+#endif
     NcclxBaseTestFixture::TearDown();
   }
 
@@ -241,6 +251,7 @@ class SendRecvTest : public NcclxBaseTestFixture {
   ncclComm_t comm;
   cudaStream_t stream;
   bool expectCtranAlgo_{false};
+  ctran::test::VerifyAlgoStatsHelper ctranAlgoStats_;
 
   int* sendBuf{nullptr};
   int* recvBuf{nullptr};
@@ -299,6 +310,52 @@ TEST_F(SendRecvTestParam, GroupedSendRecvWithHintOverride) {
   ASSERT_TRUE(ncclx::resetGlobalHint("algo_sendrecv"));
   expectCtranAlgo_ = false;
   runGroupedSendRecv();
+}
+
+// Cudagraph-aware SendRecv: capture grouped send/recv in a CUDA graph,
+// replay, and verify correctness. Uses ctgraph algo which pre-registers
+// buffers during capture.
+TEST_F(SendRecvTest, CtgraphGroupedSendRecv) {
+  if (comm->nRanks < 2) {
+    GTEST_SKIP() << "Need at least 2 ranks";
+  }
+
+  AlgoRAII algoEnv(NCCL_SENDRECV_ALGO, NCCL_SENDRECV_ALGO::ctgraph);
+
+  constexpr int count = 1048576;
+  constexpr int commCount = 1024;
+  prepareBufs(count, true);
+
+  const int sendPeer = (comm->rank + 1) % comm->nRanks;
+  const int recvPeer = (comm->rank + comm->nRanks - 1) % comm->nRanks;
+  // Capture
+  cudaGraph_t graph;
+  cudaGraphExec_t exec;
+  CUDACHECK_TEST(cudaStreamBeginCapture(stream, cudaStreamCaptureModeGlobal));
+  ncclGroupStart();
+  NCCLCHECK_TEST(ncclSend(sendBuf, commCount, ncclInt, sendPeer, comm, stream));
+  NCCLCHECK_TEST(ncclRecv(recvBuf, commCount, ncclInt, recvPeer, comm, stream));
+  ncclGroupEnd();
+  CUDACHECK_TEST(cudaStreamEndCapture(stream, &graph));
+  CUDACHECK_TEST(cudaGraphInstantiate(&exec, graph, 0));
+
+  // Replay
+  CUDACHECK_TEST(cudaGraphLaunch(exec, stream));
+  CUDACHECK_TEST(cudaStreamSynchronize(stream));
+
+  checkResults(recvPeer, commCount);
+
+  if (comm->noLocal_) {
+    // nolocal: IB backend → ctgraph routes to ctran
+    ctranAlgoStats_.verify(comm->ctranComm_.get(), "SendRecv", "Ctran");
+  } else {
+    // default: NVL peers → ctgraph falls back to baseline
+    ctranAlgoStats_.verifyNot(comm->ctranComm_.get(), "SendRecv", "Ctran");
+  }
+
+  CUDACHECK_TEST(cudaGraphExecDestroy(exec));
+  CUDACHECK_TEST(cudaGraphDestroy(graph));
+  releaseBufs(true);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/comms/ncclx/v2_27/src/collectives.cc
+++ b/comms/ncclx/v2_27/src/collectives.cc
@@ -219,8 +219,9 @@ ncclResult_t ncclSend(const void* sendbuff, size_t count, ncclDataType_t datatyp
   }
   SetCudaDevRAII setCudaDev(comm->cudaDev);
 
-  if ((ncclx::algoconf::getSendRecvAlgo() != NCCL_SENDRECV_ALGO::orig) &&
-      ctranSendRecvSupport(peer, comm->ctranComm_.get())) {
+  auto algo = ncclx::algoconf::getSendRecvAlgo();
+  if ((algo != NCCL_SENDRECV_ALGO::orig) &&
+      ctranSendRecvSupport(peer, comm->ctranComm_.get(), algo, stream)) {
     // ctran send/recvs are enqueued within ctran wherease other non-ctran ones
     // are enqueued in the original queue. When reaching group end, these two
     // groups of ops will be issued separately.
@@ -261,8 +262,9 @@ ncclResult_t ncclRecv(void* recvbuff, size_t count, ncclDataType_t datatype, int
   }
   SetCudaDevRAII setCudaDev(comm->cudaDev);
 
-  if ((ncclx::algoconf::getSendRecvAlgo() != NCCL_SENDRECV_ALGO::orig) &&
-      ctranSendRecvSupport(peer, comm->ctranComm_.get())) {
+  auto algo = ncclx::algoconf::getSendRecvAlgo();
+  if ((algo != NCCL_SENDRECV_ALGO::orig) &&
+      ctranSendRecvSupport(peer, comm->ctranComm_.get(), algo, stream)) {
     // ctran send/recvs are enqueued within ctran wherease other non-ctran ones
     // are enqueued in the original queue. When reaching group end, these two
     // groups of ops will be issued separately.

--- a/comms/ncclx/v2_28/src/collectives.cc
+++ b/comms/ncclx/v2_28/src/collectives.cc
@@ -271,8 +271,9 @@ ncclResult_t ncclSend(const void* sendbuff, size_t count, ncclDataType_t datatyp
   }
   SetCudaDevRAII setCudaDev(comm->cudaDev);
 
-  if ((ncclx::algoconf::getSendRecvAlgo() != NCCL_SENDRECV_ALGO::orig) &&
-      ctranSendRecvSupport(peer, comm->ctranComm_.get())) {
+  auto algo = ncclx::algoconf::getSendRecvAlgo();
+  if ((algo != NCCL_SENDRECV_ALGO::orig) &&
+      ctranSendRecvSupport(peer, comm->ctranComm_.get(), algo, stream)) {
     // ctran send/recvs are enqueued within ctran wherease other non-ctran ones
     // are enqueued in the original queue. When reaching group end, these two
     // groups of ops will be issued separately.
@@ -313,8 +314,9 @@ ncclResult_t ncclRecv(void* recvbuff, size_t count, ncclDataType_t datatype, int
   }
   SetCudaDevRAII setCudaDev(comm->cudaDev);
 
-  if ((ncclx::algoconf::getSendRecvAlgo() != NCCL_SENDRECV_ALGO::orig) &&
-      ctranSendRecvSupport(peer, comm->ctranComm_.get())) {
+  auto algo = ncclx::algoconf::getSendRecvAlgo();
+  if ((algo != NCCL_SENDRECV_ALGO::orig) &&
+      ctranSendRecvSupport(peer, comm->ctranComm_.get(), algo, stream)) {
     // ctran send/recvs are enqueued within ctran wherease other non-ctran ones
     // are enqueued in the original queue. When reaching group end, these two
     // groups of ops will be issued separately.

--- a/comms/ncclx/v2_29/src/collectives.cc
+++ b/comms/ncclx/v2_29/src/collectives.cc
@@ -275,8 +275,9 @@ ncclResult_t ncclSend(const void* sendbuff, size_t count, ncclDataType_t datatyp
   }
   SetCudaDevRAII setCudaDev(comm->cudaDev);
 
-  if ((ncclx::algoconf::getSendRecvAlgo() != NCCL_SENDRECV_ALGO::orig) &&
-      ctranSendRecvSupport(peer, comm->ctranComm_.get())) {
+  auto algo = ncclx::algoconf::getSendRecvAlgo();
+  if ((algo != NCCL_SENDRECV_ALGO::orig) &&
+      ctranSendRecvSupport(peer, comm->ctranComm_.get(), algo, stream)) {
     // ctran send/recvs are enqueued within ctran wherease other non-ctran ones
     // are enqueued in the original queue. When reaching group end, these two
     // groups of ops will be issued separately.
@@ -317,8 +318,9 @@ ncclResult_t ncclRecv(void* recvbuff, size_t count, ncclDataType_t datatype, int
   }
   SetCudaDevRAII setCudaDev(comm->cudaDev);
 
-  if ((ncclx::algoconf::getSendRecvAlgo() != NCCL_SENDRECV_ALGO::orig) &&
-      ctranSendRecvSupport(peer, comm->ctranComm_.get())) {
+  auto algo = ncclx::algoconf::getSendRecvAlgo();
+  if ((algo != NCCL_SENDRECV_ALGO::orig) &&
+      ctranSendRecvSupport(peer, comm->ctranComm_.get(), algo, stream)) {
     // ctran send/recvs are enqueued within ctran wherease other non-ctran ones
     // are enqueued in the original queue. When reaching group end, these two
     // groups of ops will be issued separately.

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1993,13 +1993,14 @@ cvars:
  - name        : NCCL_SENDRECV_ALGO
    type        : enum
    default     : orig
-   choices     : orig, ctran, ctzcopy, ctp2p
+   choices     : orig, ctran, ctzcopy, ctp2p, ctgraph
    description : |-
      The algorithm to use for sendrecv communication
      orig - Copy-based communication
      ctran - Ctran-based communication auto-select
      ctzcopy - Ctran-based zero-copy kernel for NVL
      ctp2p - Ctran-based point-to-point kernel for NVL
+     ctgraph - Cudagraph-aware: pre-registers buffers during graph capture, falls back to baseline otherwise
 
  - name        : NCCL_ALLGATHER_P_ALGO
    type        : enum


### PR DESCRIPTION
Summary:

- Change `commInternalError` to `commInvalidUsage` in `ctranAllGather` when a graph-aware algo (ctgraph/ctgraph_pipeline/ctgraph_ring/ctgraph_rd) is called outside CUDA graph capture mode
- Add `InvalidUsageOutsideCapture` test to `AllGatherCtgraphSupportTest`: calls `ctranAllGather(ctgraph)` with `cudaStreamDefault` (always valid, never in capture) and verifies `commInvalidUsage` is returned
- Add `num_gpus = 1` to AllGather support test BUCK target (required for cudaStreamDefault)

Reviewed By: dsjohns2

Differential Revision: D102492159


