### PR TITLE
Per-comm NCCL_BUFFSIZE override via ncclx::Hints (#2273)

### DIFF
--- a/comms/ncclx/meta/NcclxConfig.cc
+++ b/comms/ncclx/meta/NcclxConfig.cc
@@ -211,6 +211,23 @@ Config::Config(const ncclConfig_t* config) {
       }
     }
   }
+
+  // ncclBuffSize: hint only (no flat ncclConfig_t field)
+  {
+    std::string val = getHintStr("ncclBuffSize");
+    if (!val.empty()) {
+      try {
+        int parsed = std::stoi(val);
+        if (parsed <= 0) {
+          WARN("NCCLX hint 'ncclBuffSize': value %d must be positive", parsed);
+        } else {
+          ncclBuffSize = parsed;
+        }
+      } catch (const std::exception&) {
+        WARN("NCCLX hint 'ncclBuffSize': invalid value '%s'", val.c_str());
+      }
+    }
+  }
 }
 
 } // namespace ncclx

--- a/comms/ncclx/meta/NcclxConfig.h
+++ b/comms/ncclx/meta/NcclxConfig.h
@@ -36,6 +36,11 @@ class Config {
   std::optional<size_t> pipesNvlChunkSize;
   std::optional<bool> pipesUseDualStateBuffer;
   int vCliqueSize = 0;
+
+  // Per-communicator buffer size override (Simple protocol).
+  // When set, overrides the global NCCL_BUFFSIZE for this communicator.
+  // Only supported with splitShare=0.
+  std::optional<int> ncclBuffSize;
 };
 
 // Hint keys corresponding to Config fields above.  Used by
@@ -51,6 +56,7 @@ inline const std::vector<std::string>& knownHintKeys() {
       "pipesNvlChunkSize",
       "pipesUseDualStateBuffer",
       "vCliqueSize",
+      "ncclBuffSize",
   };
   return keys;
 }

--- a/comms/ncclx/meta/hints/tests/ConfigHintsUT.cc
+++ b/comms/ncclx/meta/hints/tests/ConfigHintsUT.cc
@@ -207,3 +207,73 @@ TEST(ConfigHintsUT, SplitGroupRanksSingleRank) {
 
   delete ncclxCfg;
 }
+
+// ----- ncclBuffSize tests -----
+
+TEST(ConfigHintsUT, NcclBuffSizeSetViaHint) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("ncclBuffSize", "8388608");
+  config.hints = &hints;
+
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+
+  auto* ncclxCfg = static_cast<ncclx::Config*>(config.ncclxConfig);
+  ASSERT_TRUE(ncclxCfg->ncclBuffSize.has_value());
+  EXPECT_EQ(ncclxCfg->ncclBuffSize.value(), 8388608);
+
+  delete ncclxCfg;
+}
+
+TEST(ConfigHintsUT, NcclBuffSizeDefaultUnset) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+
+  auto* ncclxCfg = static_cast<ncclx::Config*>(config.ncclxConfig);
+  EXPECT_FALSE(ncclxCfg->ncclBuffSize.has_value());
+
+  delete ncclxCfg;
+}
+
+TEST(ConfigHintsUT, NcclBuffSizeRejectsNegative) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("ncclBuffSize", "-1");
+  config.hints = &hints;
+
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+
+  auto* ncclxCfg = static_cast<ncclx::Config*>(config.ncclxConfig);
+  EXPECT_FALSE(ncclxCfg->ncclBuffSize.has_value());
+
+  delete ncclxCfg;
+}
+
+TEST(ConfigHintsUT, NcclBuffSizeRejectsZero) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("ncclBuffSize", "0");
+  config.hints = &hints;
+
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+
+  auto* ncclxCfg = static_cast<ncclx::Config*>(config.ncclxConfig);
+  EXPECT_FALSE(ncclxCfg->ncclBuffSize.has_value());
+
+  delete ncclxCfg;
+}
+
+TEST(ConfigHintsUT, NcclBuffSizeRejectsInvalidString) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("ncclBuffSize", "notanumber");
+  config.hints = &hints;
+
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+
+  auto* ncclxCfg = static_cast<ncclx::Config*>(config.ncclxConfig);
+  EXPECT_FALSE(ncclxCfg->ncclBuffSize.has_value());
+
+  delete ncclxCfg;
+}

--- a/comms/ncclx/meta/tests/CommSplitPerCommConfigTest.cc
+++ b/comms/ncclx/meta/tests/CommSplitPerCommConfigTest.cc
@@ -1,0 +1,114 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+
+#include "comm.h"
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
+#include "comms/ncclx/meta/tests/NcclxBaseTest.h"
+#include "meta/NcclxConfig.h" // @manual
+#include "nccl.h" // @manual
+
+class CommSplitPerCommConfigTest : public NcclxBaseTestFixture {
+ public:
+  void SetUp() override {
+    NcclxBaseTestFixture::SetUp();
+    comm = ncclx::test::createNcclComm(
+        globalRank, numRanks, localRank, bootstrap_.get());
+    CUDACHECK_TEST(cudaStreamCreate(&stream));
+    CUDACHECK_TEST(cudaMalloc(&dataBuf, sizeof(int) * dataCount));
+  }
+
+  void TearDown() override {
+    CUDACHECK_TEST(cudaFree(dataBuf));
+    CUDACHECK_TEST(cudaStreamDestroy(stream));
+    NCCLCHECK_TEST(ncclCommDestroy(comm));
+    NcclxBaseTestFixture::TearDown();
+  }
+
+  void runAllReduce(ncclComm_t c) {
+    int myRank, nRanks;
+    NCCLCHECK_TEST(ncclCommUserRank(c, &myRank));
+    NCCLCHECK_TEST(ncclCommCount(c, &nRanks));
+
+    std::vector<int> initVals(dataCount);
+    for (int i = 0; i < dataCount; i++) {
+      initVals[i] = i * myRank;
+    }
+    CUDACHECK_TEST(cudaMemcpy(
+        dataBuf,
+        initVals.data(),
+        sizeof(int) * dataCount,
+        cudaMemcpyHostToDevice));
+
+    NCCLCHECK_TEST(ncclAllReduce(
+        dataBuf, dataBuf, dataCount, ncclInt, ncclSum, c, stream));
+    CUDACHECK_TEST(cudaStreamSynchronize(stream));
+
+    std::vector<int> result(dataCount);
+    CUDACHECK_TEST(cudaMemcpy(
+        result.data(),
+        dataBuf,
+        sizeof(int) * dataCount,
+        cudaMemcpyDeviceToHost));
+
+    const int sumRanks = nRanks * (nRanks - 1) / 2;
+    int errs = 0;
+    for (int i = 0; i < dataCount; i++) {
+      if (result[i] != i * sumRanks) {
+        errs++;
+      }
+    }
+    EXPECT_EQ(errs, 0) << "AllReduce data mismatch on rank " << myRank;
+  }
+
+  ncclComm_t comm;
+  cudaStream_t stream;
+  int* dataBuf{nullptr};
+  static constexpr int dataCount = 65536;
+};
+
+// --- ncclBuffSize tests ---
+
+TEST_F(CommSplitPerCommConfigTest, NcclBuffSizeOverride) {
+  constexpr int kCustomBuffSize = 8388608;
+  int parentBuffSize = comm->buffSizes[NCCL_PROTO_SIMPLE];
+
+  ncclConfig_t splitConfig = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints({{"ncclBuffSize", "8388608"}});
+  splitConfig.hints = &hints;
+
+  ncclx::test::NcclCommSplitRAII child(comm, 0, globalRank, &splitConfig);
+
+  EXPECT_EQ(child->buffSizes[NCCL_PROTO_SIMPLE], kCustomBuffSize);
+  EXPECT_EQ(comm->buffSizes[NCCL_PROTO_SIMPLE], parentBuffSize);
+
+  runAllReduce(comm);
+  runAllReduce(child.get());
+}
+
+TEST_F(CommSplitPerCommConfigTest, DefaultBuffSizeWithoutHint) {
+  int parentBuffSize = comm->buffSizes[NCCL_PROTO_SIMPLE];
+
+  ncclx::test::NcclCommSplitRAII child(comm, 0, globalRank);
+
+  EXPECT_EQ(child->buffSizes[NCCL_PROTO_SIMPLE], parentBuffSize);
+}
+
+TEST_F(CommSplitPerCommConfigTest, SplitShareRejectsNcclBuffSize) {
+  ncclConfig_t splitConfig = NCCL_CONFIG_INITIALIZER;
+  splitConfig.splitShare = 1;
+  ncclx::Hints hints({{"ncclBuffSize", "8388608"}});
+  splitConfig.hints = &hints;
+
+  ncclComm_t child = nullptr;
+  ncclResult_t res = ncclCommSplit(comm, 0, globalRank, &child, &splitConfig);
+  EXPECT_EQ(res, ncclInvalidArgument);
+}
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ncclx/v2_29/src/init.cc
+++ b/comms/ncclx/v2_29/src/init.cc
@@ -884,6 +884,19 @@ static ncclResult_t computeBuffSizes(struct ncclComm* comm) {
     comm->buffSizes[p] = envs[p] != -2 ? envs[p] : defaults[p];
   }
 
+  // [NCCLX] Per comm buffer size overwrite logic
+  if (comm->config.ncclxConfig) {
+    auto& configBuffSize = NCCLX_CONFIG_FIELD(comm->config, ncclBuffSize);
+    if (configBuffSize.has_value()) {
+      if (comm->config.splitShare) {
+        ERR("Per-comm buffSize override is not supported with splitShare=1");
+        return ncclInvalidArgument;
+      }
+      comm->buffSizes[NCCL_PROTO_SIMPLE] = configBuffSize.value();
+      INFO(NCCL_INIT, "Per-comm SIMPLE buffSize overridden to %d", configBuffSize.value());
+    }
+  }
+
   if (comm->nNodes > 1) {
     // GBx platforms only have 4 GPUs per host, which reduces the aggregation factor.
     // Increase the ratio by a factor of 2 to compensate.


### PR DESCRIPTION
Summary:

Allow NCCL_BUFFSIZE (Simple protocol buffer size) to be configured per-communicator via ncclx::Hints. The hint "ncclBuffSize" is parsed in ncclx::Config and applied in computeBuffSizes() during initTransportsRank(). Only supported when splitShare=0 (the default); returns ncclInvalidArgument if splitShare=1.

Changes:
- meta/NcclxConfig.h: Add std::optional<int> ncclBuffSize field + hint key
- meta/NcclxConfig.cc: Parse "ncclBuffSize" hint with positive-int validation
- meta/NcclxPerCommConfig.h: New file with ncclxValidatePerCommConfig() that rejects per-comm overrides when splitShare=1
- meta/hints/tests/ConfigHintsUT.cc: 5 unit tests for hint parsing (valid, default, negative, zero, invalid string)
- meta/tests/CommSplitPerCommConfigTest.cc: 3 integration tests (override + AllReduce on parent/child, default inheritance, splitShare rejection)
- meta/tests/BUCK: Add comm_split_per_comm_config_test target
- v2_29/src/init.cc: Apply ncclBuffSize override in computeBuffSizes() after validation
- v2_29/def_build.bzl: Add NcclxPerCommConfig.h to header list

Reviewed By: tianfengfrank

Differential Revision: D102548560


