### PR TITLE
Per-comm IB_SPLIT_DATA_ON_QPS and IB_QPS_PER_CONNECTION override (#2274)

### DIFF
--- a/comms/ncclx/meta/NcclxConfig.cc
+++ b/comms/ncclx/meta/NcclxConfig.cc
@@ -228,6 +228,44 @@ Config::Config(const ncclConfig_t* config) {
       }
     }
   }
+
+  // ibSplitDataOnQps: hint only, 0 or 1
+  {
+    std::string val = getHintStr("ibSplitDataOnQps");
+    if (!val.empty()) {
+      try {
+        int parsed = std::stoi(val);
+        if (parsed != 0 && parsed != 1) {
+          WARN(
+              "NCCLX hint 'ibSplitDataOnQps': value %d must be 0 or 1", parsed);
+        } else {
+          ibSplitDataOnQps = parsed;
+        }
+      } catch (const std::exception&) {
+        WARN("NCCLX hint 'ibSplitDataOnQps': invalid value '%s'", val.c_str());
+      }
+    }
+  }
+
+  // ibQpsPerConnection: hint only, positive integer
+  {
+    std::string val = getHintStr("ibQpsPerConnection");
+    if (!val.empty()) {
+      try {
+        int parsed = std::stoi(val);
+        if (parsed <= 0) {
+          WARN(
+              "NCCLX hint 'ibQpsPerConnection': value %d must be positive",
+              parsed);
+        } else {
+          ibQpsPerConnection = parsed;
+        }
+      } catch (const std::exception&) {
+        WARN(
+            "NCCLX hint 'ibQpsPerConnection': invalid value '%s'", val.c_str());
+      }
+    }
+  }
 }
 
 } // namespace ncclx

--- a/comms/ncclx/meta/NcclxConfig.cc
+++ b/comms/ncclx/meta/NcclxConfig.cc
@@ -211,6 +211,23 @@ Config::Config(const ncclConfig_t* config) {
       }
     }
   }
+
+  // ncclBuffSize: hint only (no flat ncclConfig_t field)
+  {
+    std::string val = getHintStr("ncclBuffSize");
+    if (!val.empty()) {
+      try {
+        int parsed = std::stoi(val);
+        if (parsed <= 0) {
+          WARN("NCCLX hint 'ncclBuffSize': value %d must be positive", parsed);
+        } else {
+          ncclBuffSize = parsed;
+        }
+      } catch (const std::exception&) {
+        WARN("NCCLX hint 'ncclBuffSize': invalid value '%s'", val.c_str());
+      }
+    }
+  }
 }
 
 } // namespace ncclx

--- a/comms/ncclx/meta/NcclxConfig.h
+++ b/comms/ncclx/meta/NcclxConfig.h
@@ -41,6 +41,10 @@ class Config {
   // When set, overrides the global NCCL_BUFFSIZE for this communicator.
   // Only supported with splitShare=0.
   std::optional<int> ncclBuffSize;
+
+  // Per-communicator IB transport config overrides.
+  std::optional<int> ibSplitDataOnQps;
+  std::optional<int> ibQpsPerConnection;
 };
 
 // Hint keys corresponding to Config fields above.  Used by
@@ -57,6 +61,8 @@ inline const std::vector<std::string>& knownHintKeys() {
       "pipesUseDualStateBuffer",
       "vCliqueSize",
       "ncclBuffSize",
+      "ibSplitDataOnQps",
+      "ibQpsPerConnection",
   };
   return keys;
 }

--- a/comms/ncclx/meta/NcclxConfig.h
+++ b/comms/ncclx/meta/NcclxConfig.h
@@ -36,6 +36,11 @@ class Config {
   std::optional<size_t> pipesNvlChunkSize;
   std::optional<bool> pipesUseDualStateBuffer;
   int vCliqueSize = 0;
+
+  // Per-communicator buffer size override (Simple protocol).
+  // When set, overrides the global NCCL_BUFFSIZE for this communicator.
+  // Only supported with splitShare=0.
+  std::optional<int> ncclBuffSize;
 };
 
 // Hint keys corresponding to Config fields above.  Used by
@@ -51,6 +56,7 @@ inline const std::vector<std::string>& knownHintKeys() {
       "pipesNvlChunkSize",
       "pipesUseDualStateBuffer",
       "vCliqueSize",
+      "ncclBuffSize",
   };
   return keys;
 }

--- a/comms/ncclx/meta/NcclxPerCommConfig.h
+++ b/comms/ncclx/meta/NcclxPerCommConfig.h
@@ -1,0 +1,33 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include "debug.h"
+#include "meta/NcclxConfig.h" // @manual
+#include "nccl.h" // @manual
+
+// Validate per-comm config overrides against the communicator's splitShare
+// setting. Must be called after ncclxConfig is populated and splitShare is
+// resolved. Returns ncclInvalidArgument if any per-comm override is set
+// while splitShare=1 (shared transport buffers can't have different config).
+inline ncclResult_t ncclxValidatePerCommConfig(const ncclConfig_t& config) {
+  if (!config.ncclxConfig || !config.splitShare)
+    return ncclSuccess;
+
+  auto* ncclxCfg = static_cast<ncclx::Config*>(config.ncclxConfig);
+
+  if (ncclxCfg->ncclBuffSize.has_value()) {
+    ERR("Per-comm ncclBuffSize override is not supported with splitShare=1");
+    return ncclInvalidArgument;
+  }
+  if (ncclxCfg->ibSplitDataOnQps.has_value()) {
+    ERR("Per-comm ibSplitDataOnQps override is not supported with splitShare=1");
+    return ncclInvalidArgument;
+  }
+  if (ncclxCfg->ibQpsPerConnection.has_value()) {
+    ERR("Per-comm ibQpsPerConnection override is not supported with splitShare=1");
+    return ncclInvalidArgument;
+  }
+
+  return ncclSuccess;
+}

--- a/comms/ncclx/meta/baseline_modification_docs/per_comm_config_buffersize_ib.md
+++ b/comms/ncclx/meta/baseline_modification_docs/per_comm_config_buffersize_ib.md
@@ -1,0 +1,140 @@
+# Per-Comm Config: Baseline Modifications
+
+## Overview
+
+Allow `NCCL_BUFFSIZE`, `NCCL_IB_SPLIT_DATA_ON_QPS`, and `NCCL_IB_QPS_PER_CONNECTION` to be configured per-communicator via `ncclx::Hints` and `ncclx::Config`, instead of process-global env vars only. All NCCLX-specific changes in baseline files are tagged with `[NCCLX-PerCommConfig]` comments.
+
+## Design Principles
+
+1. **Minimize baseline exposure**: NCCLX logic lives in `meta/` and `meta/transport/`. Baseline files contain only thin call-sites with tagged comments.
+2. **No changes to `ncclConfig_v22800` or `ncclNetCommConfig_v11_t`**: New fields are hint-only in `ncclx::Config`.
+3. **Static variable side-channel under mutex**: IB config passes from `ncclx::Config` to the IB transport's per-comm ctx via a RAII-scoped static pointer, protected by the existing `netPluginMutex`.
+4. **Per-comm ctx replacement**: `ncclIbInit` allocates `ncclx::NcclxIbNetCommConfig` (superset of `ncclNetCommConfig_t`) as the ctx, carrying `trafficClass` + IB overrides.
+
+## Baseline Files Modified
+
+### 1. `src/init.cc` — Per-comm NCCL_BUFFSIZE
+
+**Function**: `computeBuffSizes()`
+
+**Change**: After the existing loop that sets `comm->buffSizes[p]` from env/defaults, check `ncclx::Config::ncclBuffSize`. If set and `splitShare == 0`, override `comm->buffSizes[NCCL_PROTO_SIMPLE]`. If `splitShare == 1`, return `ncclInvalidArgument`.
+
+```cpp
+// [NCCLX] Per comm buffer size overwrite logic
+if (comm->config.ncclxConfig) {
+    auto& configBuffSize = NCCLX_CONFIG_FIELD(comm->config, ncclBuffSize);
+    if (configBuffSize.has_value()) {
+      if (comm->config.splitShare) { ... return ncclInvalidArgument; }
+      comm->buffSizes[NCCL_PROTO_SIMPLE] = configBuffSize.value();
+    }
+}
+```
+
+**Why in baseline**: `computeBuffSizes()` runs during `initTransportsRank()` (core NCCL init path). The `comm->buffSizes[]` array is set here and consumed by all transports. Moving this to meta/ would require duplicating the function or adding an awkward hook.
+
+### 2. `src/plugin/net.cc` — Config side-channel RAII scope
+
+**Include added**: `meta/transport/NcclxNetPluginHelper.h`
+
+**Function**: `ncclNetInit()`
+
+**Change**: After acquiring `netPluginMutex`, create an `ncclx::NcclxCommConfigScope` RAII object that makes `&comm->config` available to `ncclIbInit()` via `ncclxGetCurrentCommConfig()`. The scope auto-clears when `ncclNetInit()` returns (including early returns via `NCCLCHECK`).
+
+```cpp
+std::lock_guard<std::mutex> lock(netPluginMutex);
+// [NCCLX-PerCommConfig] Make comm config available to ncclIbInit via side-channel
+ncclx::NcclxCommConfigScope configScope(&comm->config);
+```
+
+**Why in baseline**: `ncclNetInit()` is the only place that holds `netPluginMutex` while calling `ncclIbInit()`. The RAII scope is a single line.
+
+### 3. `src/transport/net_ib/init.cc` — Extended IB ctx allocation
+
+**Includes added**: `meta/NcclxConfig.h`, `meta/transport/NcclxIbNetCommConfig.h`, `meta/transport/NcclxNetPluginHelper.h`
+
+**Function**: `ncclIbInit()`
+
+**Change**: Instead of `ncclCalloc(&netCommConfig, 1)` for a plain `ncclNetCommConfig_t`, allocates `ncclx::NcclxIbNetCommConfig` (which is a superset containing `trafficClass` + `ibSplitDataOnQps` + `ibQpsPerConnection`). Reads per-comm IB fields from the side-channel via `ncclxGetCurrentCommConfig()` → `NCCLX_CONFIG_FIELD()`.
+
+```cpp
+// [NCCLX-PerCommConfig] Allocate extended ctx with per-comm IB overrides
+auto* ncclxConfig = new ncclx::NcclxIbNetCommConfig();
+ncclxConfig->trafficClass = config->trafficClass;
+const ncclConfig_t* commConfig = ncclxGetCurrentCommConfig();
+if (commConfig && commConfig->ncclxConfig) { ... populate overrides ... }
+*ctx = (void*)ncclxConfig;
+```
+
+**Function**: `ncclIbFinalize()`
+
+**Change**: Uses `delete static_cast<ncclx::NcclxIbNetCommConfig*>(ctx)` instead of `free(ctx)`.
+
+**Why in baseline**: `ncclIbInit` and `ncclIbFinalize` are the IB transport's ctx lifecycle functions. The ctx type change is the core mechanism for carrying per-comm IB config.
+
+### 4. `src/transport/net_ib/common.h` — ctx field on ncclIbListenComm
+
+**Change**: Added `void* ctx` field to `struct ncclIbListenComm`.
+
+```cpp
+struct ncclIbListenComm {
+  int dev;
+  struct ncclSocket sock;
+  struct ncclIbCommStage* stage;
+  void* ctx; // [NCCLX-PerCommConfig] per-comm config ctx, set by ncclIbListen
+};
+```
+
+**Why in baseline**: `ncclIbAccept` receives `listenComm` (not `ctx`). The ctx must be stored in the listen comm so `ncclIbAccept` can read per-comm IB config from it.
+
+### 5. `src/transport/net_ib/connect.cc` — Per-comm IB config application
+
+**Include added**: `meta/transport/NcclxIbNetCommConfig.h`
+
+**5a. `ncclIbListen()`**: Stores `ctx` in the listen comm.
+
+```cpp
+comm->ctx = ctx; // [NCCLX-PerCommConfig] store ctx for ncclIbAccept
+```
+
+**5b. `ncclIbConnect()`**: Three changes:
+
+1. **splitDataOnQps override** — after `ncclIbSendCommInit(comm)`, calls `ncclx::ncclxIbCommInit(comm, ctx)` to apply the per-comm `splitDataOnQps` override.
+
+2. **qpsPerConn resolution** — replaces `ncclParamIbQpsPerConn()` with `ncclx::ibResolveQpsPerConnection((ncclx::NcclxIbNetCommConfig*)ctx, ncclParamIbQpsPerConn())` for computing `localNqps`, `remoteNqps`, and `cqSize`.
+
+3. **Traffic class ctx cast** — casts `ctx` as `ncclx::NcclxIbNetCommConfig*` instead of `ncclNetCommConfig_t*` when reading `trafficClass` for `meta.sl` / `meta.tc`.
+
+**5c. `ncclIbAccept()`**: Two changes (mirror of 5b.1 and 5b.2):
+
+1. **splitDataOnQps override** — after `ncclIbRecvCommInit(rComm)`, calls `ncclx::ncclxIbCommInit(rComm, lComm->ctx)`.
+
+2. **qpsPerConn resolution** — replaces `ncclParamIbQpsPerConn()` with `ncclx::ibResolveQpsPerConnection((ncclx::NcclxIbNetCommConfig*)lComm->ctx, ncclParamIbQpsPerConn())` for computing `localNqps`, `remoteNqps`, and `cqSize`.
+
+**Why in baseline**: `ncclIbConnect` and `ncclIbAccept` are where QPs are created and `splitDataOnQps`/`nqps`/`cqSize` are computed. The values must be set at connection time.
+
+## NCCLX meta/ Files (not baseline)
+
+These files contain the NCCLX-side logic and are not part of NCCL baseline:
+
+| File | Purpose |
+|------|---------|
+| `meta/NcclxConfig.h` | `ncclx::Config` fields: `ncclBuffSize`, `ibSplitDataOnQps`, `ibQpsPerConnection` |
+| `meta/NcclxConfig.cc` | Hint parsing for all three fields |
+| `meta/transport/NcclxNetPluginHelper.h` | `NcclxCommConfigScope` RAII class, `ncclxGetCurrentCommConfig()` declaration |
+| `meta/transport/NcclxNetPluginHelper.cc` | Static side-channel variable and accessor implementation |
+| `meta/transport/NcclxIbNetCommConfig.h` | `NcclxIbNetCommConfig` struct, `ibResolveQpsPerConnection()`, `ibResolveSplitDataOnQps()`, `ncclxIbCommInit()` template |
+
+## Thread Safety
+
+- `s_ncclxCurrentCommConfig` is accessed only under `netPluginMutex` (set by `NcclxCommConfigScope` in `ncclNetInit()`, read by `ncclIbInit()` synchronously within the same mutex scope).
+- `ncclIbConnect`/`ncclIbAccept` do NOT access the static variable — they read from the per-comm ctx stored in `ncclIbListenComm::ctx`.
+
+## Revert Checklist
+
+To remove per-comm config from the baseline:
+
+1. `src/init.cc`: Remove the `[NCCLX] Per comm buffer size overwrite logic` block in `computeBuffSizes()`
+2. `src/plugin/net.cc`: Remove the `NcclxNetPluginHelper.h` include and `NcclxCommConfigScope` line
+3. `src/transport/net_ib/init.cc`: Revert `ncclIbInit()` to allocate `ncclNetCommConfig_t` via `ncclCalloc`; revert `ncclIbFinalize()` to `free(ctx)`; remove meta/ includes
+4. `src/transport/net_ib/common.h`: Remove `void* ctx` from `ncclIbListenComm`
+5. `src/transport/net_ib/connect.cc`: Remove `NcclxIbNetCommConfig.h` include; remove `comm->ctx = ctx` in `ncclIbListen`; remove `ncclxIbCommInit` calls; revert `qpsPerConn`/`qpsPerConnAccept` to use `ncclParamIbQpsPerConn()` directly; revert ctx cast to `ncclNetCommConfig_t*`

--- a/comms/ncclx/meta/design_docs/per_comm_config_integration_test_plan.md
+++ b/comms/ncclx/meta/design_docs/per_comm_config_integration_test_plan.md
@@ -1,0 +1,47 @@
+# Per-Comm Config: Integration Test Plan
+
+## Setup
+- Use `noLocal` global hint to force IB transport on single-node devgpu (same pattern as `CommWithNoLocalTest`)
+- 1x4 GPU config
+- Create parent comm with defaults, then `ncclCommSplit` child with per-comm hints
+- `splitShare=0` (default) ensures the child goes through `ncclNetInit()` (not `ncclNetInitFromParent`), which activates the side-channel for per-comm IB config
+
+## Test File
+`comms/ncclx/meta/tests/CommSplitIbConfigTest.cc`
+
+## Test Cases
+
+### 1. `NcclBuffSizeOverride`
+- Create parent comm with `noLocal` hint (forces IB transport)
+- Split child with `{"ncclBuffSize", "8388608"}`
+- Assert `child->buffSizes[NCCL_PROTO_SIMPLE] == 8388608`
+- Assert parent's `buffSizes[NCCL_PROTO_SIMPLE]` is unchanged
+- Run AllReduce on **both** parent and child, verify data correctness on both
+
+### 2. `IbConfigOverride`
+- Create parent comm with `noLocal` hint
+- Split child with `{"ibQpsPerConnection", "2"}, {"ibSplitDataOnQps", "1"}`
+- Cast `child->netContext` to `NcclxIbNetCommConfig*`, assert `ibQpsPerConnection == 2`, `ibSplitDataOnQps == 1`
+- Cast `parent->netContext` to `NcclxIbNetCommConfig*`, assert both fields are `NCCL_CONFIG_UNDEF_INT`
+- Run AllReduce on **both** parent and child, verify data correctness on both
+
+### 3. `DefaultHintsMatchParent`
+- Create parent comm with `noLocal` hint
+- Split child with no IB hints
+- Verify child's `netContext` IB fields are `NCCL_CONFIG_UNDEF_INT`
+- Run AllReduce on child, verify correctness
+
+## Assertions
+
+### Directly assertable
+- `comm->buffSizes[NCCL_PROTO_SIMPLE]` — from `comm.h`
+- `comm->netContext` cast to `NcclxIbNetCommConfig*` — verifies config propagated through side-channel into IB ctx
+
+### Not easily assertable
+- `base.nqps` on actual IB send/recv comms — buried inside proxy connections. `netContext` assertion + AllReduce completing without hang is sufficient: if `qpsPerConn=2` caused a sender/receiver nqps mismatch, the collective would deadlock.
+
+## Key Invariant
+- `splitShare=0` → `ncclNetInit()` path → side-channel works ✅
+- `splitShare=1` → `ncclNetInitFromParent()` → copies parent's netContext → per-comm IB overrides ignored (correct: shared transport buffers can't have different config)
+- `splitShare=1` + `ncclBuffSize` hint → already rejected with `ncclInvalidArgument` in `computeBuffSizes()`
+- `splitShare=1` + IB hints → rejected by `ncclxValidatePerCommConfig()` in `computeBuffSizes()`

--- a/comms/ncclx/meta/design_docs/per_comm_config_summary.md
+++ b/comms/ncclx/meta/design_docs/per_comm_config_summary.md
@@ -1,0 +1,110 @@
+# Per-Communicator Config Override: Implementation Summary
+
+## Motivation
+
+NCCL's `NCCL_BUFFSIZE`, `NCCL_IB_SPLIT_DATA_ON_QPS`, and `NCCL_IB_QPS_PER_CONNECTION` are process-global env vars. In multi-tenant or multi-workload scenarios (e.g., MoE training with separate communicators for expert vs. non-expert traffic), different communicators benefit from different tuning. This effort makes all three configurable per-communicator via the existing `ncclx::Hints` mechanism.
+
+## User-Facing API
+
+```cpp
+ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+ncclx::Hints hints({
+    {"ncclBuffSize", "8388608"},       // 8 MiB Simple protocol buffer
+    {"ibSplitDataOnQps", "1"},         // stripe data across all QPs
+    {"ibQpsPerConnection", "2"}        // 2 QPs per IB device
+});
+config.hints = &hints;
+ncclCommSplit(parentComm, color, key, &childComm, &config);
+```
+
+All three are hint-only fields — no changes to `ncclConfig_v22800`, `NCCL_CONFIG_INITIALIZER`, or `ncclNetCommConfig_v11_t`. Global env vars continue to work as process-wide defaults.
+
+## Architecture
+
+### Data Flow
+
+```
+Hints({"ncclBuffSize", "8388608"})
+  -> ncclxParseCommConfig()
+    -> ncclx::Config constructor parses hints
+    -> stores as std::optional<int> in Config
+    -> comm->config.ncclxConfig = new Config(...)
+
+ncclBuffSize path:
+  -> initTransportsRank() -> computeBuffSizes(comm)
+    -> reads NCCLX_CONFIG_FIELD(comm->config, ncclBuffSize)
+    -> overrides comm->buffSizes[NCCL_PROTO_SIMPLE]
+
+IB config path:
+  -> commAlloc() -> ncclNetInit(comm)
+    -> NcclxCommConfigScope sets static pointer (under netPluginMutex)
+    -> ncclIbInit() reads pointer, populates NcclxIbNetCommConfig ctx
+    -> scope destructor clears pointer
+  -> ncclIbConnect(ctx, ...)
+    -> ncclxIbCommInit(comm, ctx)           // applies splitDataOnQps
+    -> ibResolveQpsPerConnection(ctx, env)   // resolves qpsPerConn
+  -> ncclIbAccept(listenComm, ...)
+    -> ncclxIbCommInit(rComm, lComm->ctx)   // applies splitDataOnQps
+    -> ibResolveQpsPerConnection(ctx, env)   // resolves qpsPerConn
+```
+
+### File Organization
+
+All NCCLX logic lives in `meta/` to minimize baseline exposure:
+
+| File | Role |
+|------|------|
+| `meta/NcclxConfig.h` | `std::optional<int>` fields: `ncclBuffSize`, `ibSplitDataOnQps`, `ibQpsPerConnection` |
+| `meta/NcclxConfig.cc` | Hint parsing with validation (positive-int for buffSize/QPS, 0-or-1 for splitData) |
+| `meta/transport/NcclxNetPluginHelper.h` | `NcclxCommConfigScope` RAII class, `ncclxGetCurrentCommConfig()` declaration |
+| `meta/transport/NcclxNetPluginHelper.cc` | Static side-channel variable and implementations |
+| `meta/transport/NcclxIbNetCommConfig.h` | `NcclxIbNetCommConfig` struct (superset of `ncclNetCommConfig_t`), `ibResolveQpsPerConnection()`, `ibResolveSplitDataOnQps()`, `ncclxIbCommInit()` template |
+
+Baseline modifications are documented in `meta/baseline_modification_docs/PerCommConfig.md`.
+
+### Key Design Decisions
+
+**1. Hint-only fields (no flat `ncclConfig_t` fields)**
+
+Follows the established pattern used by `pipesNvlChunkSize`, `pipesUseDualStateBuffer`, and `vCliqueSize`. Avoids ABI changes and keeps `NCCL_CONFIG_INITIALIZER` unchanged.
+
+**2. Static variable side-channel for IB config**
+
+`ncclIbInit()` receives only `ncclNetCommConfig_t*` (just `trafficClass`). Rather than extending this plugin API struct, we pass the full `ncclx::Config` via a static `const ncclConfig_t*` pointer protected by the existing `netPluginMutex`. A RAII class (`NcclxCommConfigScope`) ensures the pointer is always cleared, even on early returns.
+
+**3. NcclxIbNetCommConfig as extended ctx**
+
+`ncclIbInit()` allocates `NcclxIbNetCommConfig` instead of `ncclNetCommConfig_t`. This struct carries `trafficClass` (for backward compatibility) plus `ibSplitDataOnQps` and `ibQpsPerConnection`. The ctx flows through the existing `void*` plumbing to `ncclIbConnect`, `ncclIbListen`, and `ncclIbAccept`.
+
+**4. Template-based ncclxIbCommInit**
+
+`ncclxIbCommInit<T>()` is a template in `NcclxIbNetCommConfig.h` that applies the `splitDataOnQps` override. Using a template avoids including `common.h` (heavy IB transport header) from `meta/transport/`. The template is instantiated in `connect.cc` where `ncclIbSendComm`/`ncclIbRecvComm` are fully defined.
+
+**5. ncclBuffSize rejects splitShare=1**
+
+With `splitShare=1`, the child comm shares the parent's proxy state and transport buffers. Different buffer sizes would corrupt shared state, so the override returns `ncclInvalidArgument`.
+
+## Validation
+
+**Unit tests** (`meta/hints/tests/ConfigHintsUT.cc`):
+- `ncclBuffSize`: valid value, default unset, rejects negative/zero/invalid string (5 tests)
+- `ibSplitDataOnQps`: valid 0/1, rejects invalid (>1), default unset (4 tests)
+- `ibQpsPerConnection`: valid positive, rejects zero/negative, default unset (4 tests)
+
+**Integration tests** (`meta/tests/CommSplitBuffSizeTest.cc`, 1x4 GPU):
+- `PerCommBuffSizeOverride`: child comm gets custom `buffSizes[NCCL_PROTO_SIMPLE]`
+- `ParentBuffSizeUnchanged`: parent comm unaffected by child's override
+- `DefaultBuffSizeWithoutHint`: child inherits parent's buffer size
+- `SplitShareRejectsBuffSizeOverride`: `splitShare=1` returns `ncclInvalidArgument`
+
+IB config integration testing requires multi-node IB hardware and is done via MAST nccl-tests jobs with `NCCL_DEBUG=INFO` log verification.
+
+## What Does NOT Change
+
+- `ncclConfig_v22800` struct / `NCCL_CONFIG_INITIALIZER`
+- `ncclNetCommConfig_v11_t` plugin API struct
+- Global env vars (`NCCL_BUFFSIZE`, `NCCL_IB_SPLIT_DATA_ON_QPS`, `NCCL_IB_QPS_PER_CONNECTION`)
+- LL / LL128 buffer sizes
+- `parseCommConfig()` / `envConfigOverride()` / `deepCopyCommConfig()`
+- GIN IB transport (only IB net transport is modified)
+- `isend` / `irecv` data path

--- a/comms/ncclx/meta/hints/tests/ConfigHintsUT.cc
+++ b/comms/ncclx/meta/hints/tests/ConfigHintsUT.cc
@@ -207,3 +207,73 @@ TEST(ConfigHintsUT, SplitGroupRanksSingleRank) {
 
   delete ncclxCfg;
 }
+
+// ----- ncclBuffSize tests -----
+
+TEST(ConfigHintsUT, NcclBuffSizeSetViaHint) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("ncclBuffSize", "8388608");
+  config.hints = &hints;
+
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+
+  auto* ncclxCfg = static_cast<ncclx::Config*>(config.ncclxConfig);
+  ASSERT_TRUE(ncclxCfg->ncclBuffSize.has_value());
+  EXPECT_EQ(ncclxCfg->ncclBuffSize.value(), 8388608);
+
+  delete ncclxCfg;
+}
+
+TEST(ConfigHintsUT, NcclBuffSizeDefaultUnset) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+
+  auto* ncclxCfg = static_cast<ncclx::Config*>(config.ncclxConfig);
+  EXPECT_FALSE(ncclxCfg->ncclBuffSize.has_value());
+
+  delete ncclxCfg;
+}
+
+TEST(ConfigHintsUT, NcclBuffSizeRejectsNegative) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("ncclBuffSize", "-1");
+  config.hints = &hints;
+
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+
+  auto* ncclxCfg = static_cast<ncclx::Config*>(config.ncclxConfig);
+  EXPECT_FALSE(ncclxCfg->ncclBuffSize.has_value());
+
+  delete ncclxCfg;
+}
+
+TEST(ConfigHintsUT, NcclBuffSizeRejectsZero) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("ncclBuffSize", "0");
+  config.hints = &hints;
+
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+
+  auto* ncclxCfg = static_cast<ncclx::Config*>(config.ncclxConfig);
+  EXPECT_FALSE(ncclxCfg->ncclBuffSize.has_value());
+
+  delete ncclxCfg;
+}
+
+TEST(ConfigHintsUT, NcclBuffSizeRejectsInvalidString) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("ncclBuffSize", "notanumber");
+  config.hints = &hints;
+
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+
+  auto* ncclxCfg = static_cast<ncclx::Config*>(config.ncclxConfig);
+  EXPECT_FALSE(ncclxCfg->ncclBuffSize.has_value());
+
+  delete ncclxCfg;
+}

--- a/comms/ncclx/meta/hints/tests/ConfigHintsUT.cc
+++ b/comms/ncclx/meta/hints/tests/ConfigHintsUT.cc
@@ -277,3 +277,116 @@ TEST(ConfigHintsUT, NcclBuffSizeRejectsInvalidString) {
 
   delete ncclxCfg;
 }
+
+// ----- ibSplitDataOnQps tests -----
+
+TEST(ConfigHintsUT, IbSplitDataOnQpsSetViaHint) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("ibSplitDataOnQps", "1");
+  config.hints = &hints;
+
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+
+  auto* ncclxCfg = static_cast<ncclx::Config*>(config.ncclxConfig);
+  ASSERT_TRUE(ncclxCfg->ibSplitDataOnQps.has_value());
+  EXPECT_EQ(ncclxCfg->ibSplitDataOnQps.value(), 1);
+
+  delete ncclxCfg;
+}
+
+TEST(ConfigHintsUT, IbSplitDataOnQpsAcceptsZero) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("ibSplitDataOnQps", "0");
+  config.hints = &hints;
+
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+
+  auto* ncclxCfg = static_cast<ncclx::Config*>(config.ncclxConfig);
+  ASSERT_TRUE(ncclxCfg->ibSplitDataOnQps.has_value());
+  EXPECT_EQ(ncclxCfg->ibSplitDataOnQps.value(), 0);
+
+  delete ncclxCfg;
+}
+
+TEST(ConfigHintsUT, IbSplitDataOnQpsRejectsInvalid) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("ibSplitDataOnQps", "2");
+  config.hints = &hints;
+
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+
+  auto* ncclxCfg = static_cast<ncclx::Config*>(config.ncclxConfig);
+  EXPECT_FALSE(ncclxCfg->ibSplitDataOnQps.has_value());
+
+  delete ncclxCfg;
+}
+
+TEST(ConfigHintsUT, IbSplitDataOnQpsDefaultUnset) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+
+  auto* ncclxCfg = static_cast<ncclx::Config*>(config.ncclxConfig);
+  EXPECT_FALSE(ncclxCfg->ibSplitDataOnQps.has_value());
+
+  delete ncclxCfg;
+}
+
+// ----- ibQpsPerConnection tests -----
+
+TEST(ConfigHintsUT, IbQpsPerConnectionSetViaHint) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("ibQpsPerConnection", "4");
+  config.hints = &hints;
+
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+
+  auto* ncclxCfg = static_cast<ncclx::Config*>(config.ncclxConfig);
+  ASSERT_TRUE(ncclxCfg->ibQpsPerConnection.has_value());
+  EXPECT_EQ(ncclxCfg->ibQpsPerConnection.value(), 4);
+
+  delete ncclxCfg;
+}
+
+TEST(ConfigHintsUT, IbQpsPerConnectionRejectsZero) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("ibQpsPerConnection", "0");
+  config.hints = &hints;
+
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+
+  auto* ncclxCfg = static_cast<ncclx::Config*>(config.ncclxConfig);
+  EXPECT_FALSE(ncclxCfg->ibQpsPerConnection.has_value());
+
+  delete ncclxCfg;
+}
+
+TEST(ConfigHintsUT, IbQpsPerConnectionRejectsNegative) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("ibQpsPerConnection", "-1");
+  config.hints = &hints;
+
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+
+  auto* ncclxCfg = static_cast<ncclx::Config*>(config.ncclxConfig);
+  EXPECT_FALSE(ncclxCfg->ibQpsPerConnection.has_value());
+
+  delete ncclxCfg;
+}
+
+TEST(ConfigHintsUT, IbQpsPerConnectionDefaultUnset) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+
+  auto* ncclxCfg = static_cast<ncclx::Config*>(config.ncclxConfig);
+  EXPECT_FALSE(ncclxCfg->ibQpsPerConnection.has_value());
+
+  delete ncclxCfg;
+}

--- a/comms/ncclx/meta/tests/CommSplitPerCommConfigTest.cc
+++ b/comms/ncclx/meta/tests/CommSplitPerCommConfigTest.cc
@@ -7,12 +7,17 @@
 #include "comms/ncclx/meta/tests/NcclCommUtils.h"
 #include "comms/ncclx/meta/tests/NcclxBaseTest.h"
 #include "meta/NcclxConfig.h" // @manual
+#include "meta/hints/GlobalHints.h" // @manual
+#include "meta/transport/NcclxIbNetCommConfig.h" // @manual
 #include "nccl.h" // @manual
 
 class CommSplitPerCommConfigTest : public NcclxBaseTestFixture {
  public:
   void SetUp() override {
     NcclxBaseTestFixture::SetUp();
+    ASSERT_EQ(
+        ncclx::setGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal), "1"),
+        ncclSuccess);
     comm = ncclx::test::createNcclComm(
         globalRank, numRanks, localRank, bootstrap_.get());
     CUDACHECK_TEST(cudaStreamCreate(&stream));
@@ -23,6 +28,7 @@ class CommSplitPerCommConfigTest : public NcclxBaseTestFixture {
     CUDACHECK_TEST(cudaFree(dataBuf));
     CUDACHECK_TEST(cudaStreamDestroy(stream));
     NCCLCHECK_TEST(ncclCommDestroy(comm));
+    ncclx::resetGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal));
     NcclxBaseTestFixture::TearDown();
   }
 
@@ -87,18 +93,75 @@ TEST_F(CommSplitPerCommConfigTest, NcclBuffSizeOverride) {
   runAllReduce(child.get());
 }
 
-TEST_F(CommSplitPerCommConfigTest, DefaultBuffSizeWithoutHint) {
+// --- IB config tests ---
+
+TEST_F(CommSplitPerCommConfigTest, IbConfigOverride) {
+  ncclConfig_t splitConfig = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints({
+      {"ibQpsPerConnection", "2"},
+      {"ibSplitDataOnQps", "1"},
+  });
+  splitConfig.hints = &hints;
+
+  ncclx::test::NcclCommSplitRAII child(comm, 0, globalRank, &splitConfig);
+
+  auto* childCtx = static_cast<ncclx::NcclxIbNetCommConfig*>(child->netContext);
+  ASSERT_NE(childCtx, nullptr);
+  EXPECT_EQ(childCtx->ibQpsPerConnection, 2);
+  EXPECT_EQ(childCtx->ibSplitDataOnQps, 1);
+
+  auto* parentCtx = static_cast<ncclx::NcclxIbNetCommConfig*>(comm->netContext);
+  ASSERT_NE(parentCtx, nullptr);
+  EXPECT_EQ(parentCtx->ibQpsPerConnection, NCCL_CONFIG_UNDEF_INT);
+  EXPECT_EQ(parentCtx->ibSplitDataOnQps, NCCL_CONFIG_UNDEF_INT);
+
+  runAllReduce(comm);
+  runAllReduce(child.get());
+}
+
+TEST_F(CommSplitPerCommConfigTest, DefaultHintsMatchParent) {
   int parentBuffSize = comm->buffSizes[NCCL_PROTO_SIMPLE];
 
   ncclx::test::NcclCommSplitRAII child(comm, 0, globalRank);
 
   EXPECT_EQ(child->buffSizes[NCCL_PROTO_SIMPLE], parentBuffSize);
+
+  auto* childCtx = static_cast<ncclx::NcclxIbNetCommConfig*>(child->netContext);
+  ASSERT_NE(childCtx, nullptr);
+  EXPECT_EQ(childCtx->ibQpsPerConnection, NCCL_CONFIG_UNDEF_INT);
+  EXPECT_EQ(childCtx->ibSplitDataOnQps, NCCL_CONFIG_UNDEF_INT);
+
+  runAllReduce(child.get());
 }
+
+// --- splitShare=1 rejection tests ---
 
 TEST_F(CommSplitPerCommConfigTest, SplitShareRejectsNcclBuffSize) {
   ncclConfig_t splitConfig = NCCL_CONFIG_INITIALIZER;
   splitConfig.splitShare = 1;
   ncclx::Hints hints({{"ncclBuffSize", "8388608"}});
+  splitConfig.hints = &hints;
+
+  ncclComm_t child = nullptr;
+  ncclResult_t res = ncclCommSplit(comm, 0, globalRank, &child, &splitConfig);
+  EXPECT_EQ(res, ncclInvalidArgument);
+}
+
+TEST_F(CommSplitPerCommConfigTest, SplitShareRejectsIbSplitDataOnQps) {
+  ncclConfig_t splitConfig = NCCL_CONFIG_INITIALIZER;
+  splitConfig.splitShare = 1;
+  ncclx::Hints hints({{"ibSplitDataOnQps", "1"}});
+  splitConfig.hints = &hints;
+
+  ncclComm_t child = nullptr;
+  ncclResult_t res = ncclCommSplit(comm, 0, globalRank, &child, &splitConfig);
+  EXPECT_EQ(res, ncclInvalidArgument);
+}
+
+TEST_F(CommSplitPerCommConfigTest, SplitShareRejectsIbQpsPerConnection) {
+  ncclConfig_t splitConfig = NCCL_CONFIG_INITIALIZER;
+  splitConfig.splitShare = 1;
+  ncclx::Hints hints({{"ibQpsPerConnection", "2"}});
   splitConfig.hints = &hints;
 
   ncclComm_t child = nullptr;

--- a/comms/ncclx/meta/tests/CommSplitPerCommConfigTest.cc
+++ b/comms/ncclx/meta/tests/CommSplitPerCommConfigTest.cc
@@ -1,0 +1,114 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+
+#include "comm.h"
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
+#include "comms/ncclx/meta/tests/NcclxBaseTest.h"
+#include "meta/NcclxConfig.h" // @manual
+#include "nccl.h" // @manual
+
+class CommSplitPerCommConfigTest : public NcclxBaseTestFixture {
+ public:
+  void SetUp() override {
+    NcclxBaseTestFixture::SetUp();
+    comm = ncclx::test::createNcclComm(
+        globalRank, numRanks, localRank, bootstrap_.get());
+    CUDACHECK_TEST(cudaStreamCreate(&stream));
+    CUDACHECK_TEST(cudaMalloc(&dataBuf, sizeof(int) * dataCount));
+  }
+
+  void TearDown() override {
+    CUDACHECK_TEST(cudaFree(dataBuf));
+    CUDACHECK_TEST(cudaStreamDestroy(stream));
+    NCCLCHECK_TEST(ncclCommDestroy(comm));
+    NcclxBaseTestFixture::TearDown();
+  }
+
+  void runAllReduce(ncclComm_t c) {
+    int myRank, nRanks;
+    NCCLCHECK_TEST(ncclCommUserRank(c, &myRank));
+    NCCLCHECK_TEST(ncclCommCount(c, &nRanks));
+
+    std::vector<int> initVals(dataCount);
+    for (int i = 0; i < dataCount; i++) {
+      initVals[i] = i * myRank;
+    }
+    CUDACHECK_TEST(cudaMemcpy(
+        dataBuf,
+        initVals.data(),
+        sizeof(int) * dataCount,
+        cudaMemcpyHostToDevice));
+
+    NCCLCHECK_TEST(ncclAllReduce(
+        dataBuf, dataBuf, dataCount, ncclInt, ncclSum, c, stream));
+    CUDACHECK_TEST(cudaStreamSynchronize(stream));
+
+    std::vector<int> result(dataCount);
+    CUDACHECK_TEST(cudaMemcpy(
+        result.data(),
+        dataBuf,
+        sizeof(int) * dataCount,
+        cudaMemcpyDeviceToHost));
+
+    const int sumRanks = nRanks * (nRanks - 1) / 2;
+    int errs = 0;
+    for (int i = 0; i < dataCount; i++) {
+      if (result[i] != i * sumRanks) {
+        errs++;
+      }
+    }
+    EXPECT_EQ(errs, 0) << "AllReduce data mismatch on rank " << myRank;
+  }
+
+  ncclComm_t comm;
+  cudaStream_t stream;
+  int* dataBuf{nullptr};
+  static constexpr int dataCount = 65536;
+};
+
+// --- ncclBuffSize tests ---
+
+TEST_F(CommSplitPerCommConfigTest, NcclBuffSizeOverride) {
+  constexpr int kCustomBuffSize = 8388608;
+  int parentBuffSize = comm->buffSizes[NCCL_PROTO_SIMPLE];
+
+  ncclConfig_t splitConfig = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints({{"ncclBuffSize", "8388608"}});
+  splitConfig.hints = &hints;
+
+  ncclx::test::NcclCommSplitRAII child(comm, 0, globalRank, &splitConfig);
+
+  EXPECT_EQ(child->buffSizes[NCCL_PROTO_SIMPLE], kCustomBuffSize);
+  EXPECT_EQ(comm->buffSizes[NCCL_PROTO_SIMPLE], parentBuffSize);
+
+  runAllReduce(comm);
+  runAllReduce(child.get());
+}
+
+TEST_F(CommSplitPerCommConfigTest, DefaultBuffSizeWithoutHint) {
+  int parentBuffSize = comm->buffSizes[NCCL_PROTO_SIMPLE];
+
+  ncclx::test::NcclCommSplitRAII child(comm, 0, globalRank);
+
+  EXPECT_EQ(child->buffSizes[NCCL_PROTO_SIMPLE], parentBuffSize);
+}
+
+TEST_F(CommSplitPerCommConfigTest, SplitShareRejectsNcclBuffSize) {
+  ncclConfig_t splitConfig = NCCL_CONFIG_INITIALIZER;
+  splitConfig.splitShare = 1;
+  ncclx::Hints hints({{"ncclBuffSize", "8388608"}});
+  splitConfig.hints = &hints;
+
+  ncclComm_t child = nullptr;
+  ncclResult_t res = ncclCommSplit(comm, 0, globalRank, &child, &splitConfig);
+  EXPECT_EQ(res, ncclInvalidArgument);
+}
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ncclx/meta/transport/NcclxIbNetCommConfig.h
+++ b/comms/ncclx/meta/transport/NcclxIbNetCommConfig.h
@@ -1,0 +1,46 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#ifndef NCCLX_IB_NET_COMM_CONFIG_H_
+#define NCCLX_IB_NET_COMM_CONFIG_H_
+
+#include "nccl.h" // @manual
+
+namespace ncclx {
+
+struct NcclxIbNetCommConfig {
+  int trafficClass{-1}; // -1 == NCCL_NET_TRAFFIC_CLASS_UNDEF
+  int ibSplitDataOnQps{NCCL_CONFIG_UNDEF_INT};
+  int ibQpsPerConnection{NCCL_CONFIG_UNDEF_INT};
+};
+
+inline int ibResolveQpsPerConnection(
+    const NcclxIbNetCommConfig* ctx,
+    int envDefault) {
+  return (ctx && ctx->ibQpsPerConnection != NCCL_CONFIG_UNDEF_INT)
+      ? ctx->ibQpsPerConnection
+      : envDefault;
+}
+
+inline int ibResolveSplitDataOnQps(
+    const NcclxIbNetCommConfig* ctx,
+    int envDefault) {
+  return (ctx && ctx->ibSplitDataOnQps != NCCL_CONFIG_UNDEF_INT)
+      ? ctx->ibSplitDataOnQps
+      : envDefault;
+}
+
+// Per-comm IB config overrides applied after ncclIbSendCommInit.
+// Uses a template to avoid including the IB transport common.h
+// from meta/ — the template is instantiated in connect.cc where
+// ncclIbSendComm/ncclIbRecvComm is fully defined.
+template <typename IbComm>
+void ncclxIbCommInit(IbComm* comm, void* ctx) {
+  auto* ncclxCtx = static_cast<NcclxIbNetCommConfig*>(ctx);
+  if (ncclxCtx)
+    comm->base.splitDataOnQps =
+        ibResolveSplitDataOnQps(ncclxCtx, comm->base.splitDataOnQps);
+}
+
+} // namespace ncclx
+
+#endif // NCCLX_IB_NET_COMM_CONFIG_H_

--- a/comms/ncclx/meta/transport/NcclxNetPluginHelper.cc
+++ b/comms/ncclx/meta/transport/NcclxNetPluginHelper.cc
@@ -1,0 +1,21 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "meta/transport/NcclxNetPluginHelper.h"
+
+static const ncclConfig_t* s_ncclxCurrentCommConfig = nullptr;
+
+namespace ncclx {
+
+NcclxCommConfigScope::NcclxCommConfigScope(const ncclConfig_t* config) {
+  s_ncclxCurrentCommConfig = config;
+}
+
+NcclxCommConfigScope::~NcclxCommConfigScope() {
+  s_ncclxCurrentCommConfig = nullptr;
+}
+
+} // namespace ncclx
+
+const ncclConfig_t* ncclxGetCurrentCommConfig() {
+  return s_ncclxCurrentCommConfig;
+}

--- a/comms/ncclx/meta/transport/NcclxNetPluginHelper.h
+++ b/comms/ncclx/meta/transport/NcclxNetPluginHelper.h
@@ -1,0 +1,22 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include "nccl.h" // @manual
+
+namespace ncclx {
+
+// RAII guard that makes the current comm's ncclConfig_t available to
+// net-plugin init functions (e.g. ncclIbInit) via ncclxGetCurrentCommConfig().
+// Must be held under netPluginMutex — see net.cc.
+class NcclxCommConfigScope {
+ public:
+  explicit NcclxCommConfigScope(const ncclConfig_t* config);
+  ~NcclxCommConfigScope();
+  NcclxCommConfigScope(const NcclxCommConfigScope&) = delete;
+  NcclxCommConfigScope& operator=(const NcclxCommConfigScope&) = delete;
+};
+
+} // namespace ncclx
+
+const ncclConfig_t* ncclxGetCurrentCommConfig();

--- a/comms/ncclx/v2_29/src/init.cc
+++ b/comms/ncclx/v2_29/src/init.cc
@@ -884,6 +884,19 @@ static ncclResult_t computeBuffSizes(struct ncclComm* comm) {
     comm->buffSizes[p] = envs[p] != -2 ? envs[p] : defaults[p];
   }
 
+  // [NCCLX] Per comm buffer size overwrite logic
+  if (comm->config.ncclxConfig) {
+    auto& configBuffSize = NCCLX_CONFIG_FIELD(comm->config, ncclBuffSize);
+    if (configBuffSize.has_value()) {
+      if (comm->config.splitShare) {
+        ERR("Per-comm buffSize override is not supported with splitShare=1");
+        return ncclInvalidArgument;
+      }
+      comm->buffSizes[NCCL_PROTO_SIMPLE] = configBuffSize.value();
+      INFO(NCCL_INIT, "Per-comm SIMPLE buffSize overridden to %d", configBuffSize.value());
+    }
+  }
+
   if (comm->nNodes > 1) {
     // GBx platforms only have 4 GPUs per host, which reduces the aggregation factor.
     // Increase the ratio by a factor of 2 to compensate.

--- a/comms/ncclx/v2_29/src/init.cc
+++ b/comms/ncclx/v2_29/src/init.cc
@@ -7,6 +7,7 @@
 
 #include "nccl.h"
 #include "meta/NcclxConfig.h" // @manual
+#include "meta/NcclxPerCommConfig.h" // @manual
 #include "channel.h"
 #include "nvmlwrap.h"
 #include "gdrwrap.h"
@@ -884,14 +885,11 @@ static ncclResult_t computeBuffSizes(struct ncclComm* comm) {
     comm->buffSizes[p] = envs[p] != -2 ? envs[p] : defaults[p];
   }
 
-  // [NCCLX] Per comm buffer size overwrite logic
+  // [NCCLX-PerCommConfig] Validate and apply per-comm overrides
+  NCCLCHECK(ncclxValidatePerCommConfig(comm->config));
   if (comm->config.ncclxConfig) {
     auto& configBuffSize = NCCLX_CONFIG_FIELD(comm->config, ncclBuffSize);
     if (configBuffSize.has_value()) {
-      if (comm->config.splitShare) {
-        ERR("Per-comm buffSize override is not supported with splitShare=1");
-        return ncclInvalidArgument;
-      }
       comm->buffSizes[NCCL_PROTO_SIMPLE] = configBuffSize.value();
       INFO(NCCL_INIT, "Per-comm SIMPLE buffSize overridden to %d", configBuffSize.value());
     }

--- a/comms/ncclx/v2_29/src/plugin/net.cc
+++ b/comms/ncclx/v2_29/src/plugin/net.cc
@@ -18,6 +18,9 @@
 //#include <sys/stat.h>
 //#include <unistd.h>
 
+// [NCCLX-PerCommConfig] RAII scope for passing comm config to net plugin init
+#include "meta/transport/NcclxNetPluginHelper.h"
+
 typedef ncclNet_t* getNcclNet_t(void* netPluginLib);
 typedef ncclCollNet_t* getNcclCollNet_t(void* netPluginLib);
 
@@ -299,6 +302,10 @@ ncclResult_t ncclNetInit(struct ncclComm* comm) {
   bool ncclNetPluginInitialized = false;
   std::call_once(initPluginLibsOnceFlag, initPluginLibsOnceFunc);
   std::lock_guard<std::mutex> lock(netPluginMutex);
+
+  // [NCCLX-PerCommConfig] Make comm config available to ncclIbInit via side-channel
+  ncclx::NcclxCommConfigScope configScope(&comm->config);
+
   for (int pluginIndex = 0; pluginIndex < pluginCount; pluginIndex++) {
     if ((pluginIndex < (pluginCount - NCCL_NET_NUM_INTERNAL_PLUGINS)) && (netPluginLibs[pluginIndex].ncclNetPluginState == ncclNetPluginStateLoadReady)) {
       NCCLCHECK(ncclNetPluginLoad(&netPluginLibs[pluginIndex]));

--- a/comms/ncclx/v2_29/src/transport/net_ib/common.h
+++ b/comms/ncclx/v2_29/src/transport/net_ib/common.h
@@ -472,6 +472,7 @@ struct ncclIbListenComm {
   int dev;
   struct ncclSocket sock;
   struct ncclIbCommStage* stage;
+  void* ctx; // [NCCLX-PerCommConfig] per-comm config ctx, set by ncclIbListen
 };
 
 static ncclResult_t ncclIbStatsInit(struct ncclIbStats* stat) {

--- a/comms/ncclx/v2_29/src/transport/net_ib/connect.cc
+++ b/comms/ncclx/v2_29/src/transport/net_ib/connect.cc
@@ -9,6 +9,9 @@
 #include "common.h"
 #include "p2p_resiliency.h"
 
+// [NCCLX-PerCommConfig] Per-comm IB config helpers
+#include "meta/transport/NcclxIbNetCommConfig.h"
+
 NCCL_PARAM(IbGidIndex, "IB_GID_INDEX", -1);
 NCCL_PARAM(IbRoutableFlidIbGidIndex, "IB_ROUTABLE_FLID_GID_INDEX", 1);
 NCCL_PARAM(IbRoceVersionNum, "IB_ROCE_VERSION_NUM", 2);
@@ -405,6 +408,7 @@ ncclResult_t ncclIbListen(void* ctx, int dev, void* opaqueHandle, void** listenC
   static_assert(sizeof(struct ncclIbHandle) < NCCL_NET_HANDLE_MAXSIZE, "ncclIbHandle size too large");
   memset(handle, 0, sizeof(struct ncclIbHandle));
   comm->dev = dev;
+  comm->ctx = ctx; // [NCCLX-PerCommConfig] store ctx for ncclIbAccept
   handle->magic = NCCL_SOCKET_MAGIC;
   NCCLCHECKGOTO(ncclSocketInit(&comm->sock, &ncclIbIfAddr, handle->magic, ncclSocketTypeNetIb, NULL, 1), ret, fail);
   NCCLCHECKGOTO(ncclSocketListen(&comm->sock), ret, fail);
@@ -527,6 +531,11 @@ ncclResult_t ncclIbConnect(void* ctx, int dev, void* opaqueHandle, void** sendCo
   int ready;
   uint8_t link_layer = IBV_LINK_LAYER_UNSPECIFIED;
   *sendComm = NULL;
+  // [NCCLX-PerCommConfig] Lambda to resolve qpsPerConn safely across goto re-entries
+  auto getQpsPerConn = [&]() {
+    return ncclx::ibResolveQpsPerConnection(
+        (ncclx::NcclxIbNetCommConfig*)ctx, ncclParamIbQpsPerConn());
+  };
 
   if (stage->state == ncclIbCommStateConnect)      goto ib_connect_check;
   if (stage->state == ncclIbCommStateSendDevList)  goto ib_send_dev_list;
@@ -542,6 +551,8 @@ ncclResult_t ncclIbConnect(void* ctx, int dev, void* opaqueHandle, void** sendCo
 
   NCCLCHECK(ncclIbMalloc((void**)&comm, sizeof(struct ncclIbSendComm)));
   NCCLCHECKGOTO(ncclIbSendCommInit(comm), ret, fail);
+  // [NCCLX-PerCommConfig] Apply per-comm IB overrides (splitDataOnQps)
+  ncclx::ncclxIbCommInit(comm, ctx);
   NCCLCHECKGOTO(ncclIbStatsInit(&comm->base.stats), ret, fail);
   NCCLCHECKGOTO(ncclSocketInit(&comm->base.sock, &handle->connectAddr, handle->magic, ncclSocketTypeNetIb, NULL, 1), ret, fail);
   stage->comm = comm;
@@ -581,13 +592,15 @@ ib_recv_dev_list:
   if (stage->offset != sizeof(ncclNetVDeviceProps_t)) return ncclSuccess;
   stage->offset = 0;
   ncclNetVDeviceProps_t remoteVProps;
-  ncclNetCommConfig_t* config;
+  // [NCCLX-PerCommConfig]  NcclxIbNetCommConfig is a superset of ncclNetCommConfig_t
+  // So still define config to minimize code changes
+  ncclx::NcclxIbNetCommConfig* config;
   memcpy(&remoteVProps, stage->buffer, sizeof(ncclNetVDeviceProps_t));
   mergedDev = ncclIbMergedDevs + dev;
   comm->base.vProps = mergedDev->vProps;
   int localNqps, remoteNqps;
-  localNqps  = ncclParamIbQpsPerConn() * comm->base.vProps.ndevs; // We must have at least 1 qp per-device
-  remoteNqps = ncclParamIbQpsPerConn() * remoteVProps.ndevs;
+  localNqps  = getQpsPerConn() * comm->base.vProps.ndevs; // We must have at least 1 qp per-device
+  remoteNqps = getQpsPerConn() * remoteVProps.ndevs;
   comm->base.nqps = remoteNqps > localNqps ? remoteNqps : localNqps; // Select max nqps (local or remote)
 
   comm->base.nDataQps = std::max(comm->base.vProps.ndevs, remoteVProps.ndevs);
@@ -601,7 +614,7 @@ ib_recv_dev_list:
   // Sender's CQ size needs to accomodate the upper bound of number of send
   // requests multiplied by the number of QPs used per request.
   int cqSize;
-  cqSize = NET_IB_MAX_REQUESTS*ncclParamIbQpsPerConn();
+  cqSize = NET_IB_MAX_REQUESTS*getQpsPerConn();
   for (int i = 0; i < comm->base.vProps.ndevs; i++) {
     int ibDevN = comm->base.vProps.devs[i];
     if (comm->base.resiliency) {
@@ -676,7 +689,9 @@ ib_recv_dev_list:
       return ncclInternalError;
     }
   }
-  config = (ncclNetCommConfig_t*)ctx;
+  // [NCCLX-PerCommConfig] Cast ctx as NcclxIbNetCommConfig rather than
+  // ncclNetCommConfig_t
+  config = (ncclx::NcclxIbNetCommConfig*)ctx;
   meta.addr = (uint64_t)comm->ctsFifo;
   meta.sl = (ncclParamIbSl() != -1) ? ncclParamIbSl() : (config && config->trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? config->trafficClass : NCCL_IB_SL_DEFAULT;
   meta.tc = (ncclParamIbTc() != -1) ? ncclParamIbTc() : (config && config->trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? config->trafficClass : NCCL_IB_TC_DEFAULT;
@@ -956,6 +971,11 @@ ncclResult_t ncclIbAccept(void* listenComm, void** recvComm, ncclNetDeviceHandle
   int ready;
   int link_layer = IBV_LINK_LAYER_UNSPECIFIED;
   *recvComm = NULL;
+  // [NCCLX-PerCommConfig] Lambda to resolve qpsPerConn safely across goto re-entries
+  auto getQpsPerConn = [&]() {
+    return ncclx::ibResolveQpsPerConnection(
+        (ncclx::NcclxIbNetCommConfig*)lComm->ctx, ncclParamIbQpsPerConn());
+  };
 
   if (stage->state == ncclIbCommStateAccept)   goto ib_accept_check;
   if (stage->state == ncclIbCommStateRecvDevList) goto ib_recv_dev_list;
@@ -970,6 +990,8 @@ ncclResult_t ncclIbAccept(void* listenComm, void** recvComm, ncclNetDeviceHandle
 
   NCCLCHECK(ncclIbMalloc((void**)&rComm, sizeof(struct ncclIbRecvComm)));
   NCCLCHECKGOTO(ncclIbRecvCommInit(rComm), ret, fail);
+  // [NCCLX-PerCommConfig] Apply per-comm IB overrides (splitDataOnQps)
+  ncclx::ncclxIbCommInit(rComm, lComm->ctx);
   NCCLCHECKGOTO(ncclIbStatsInit(&rComm->base.stats), ret, fail);
   stage->comm = rComm;
   stage->state = ncclIbCommStateAccept;
@@ -1005,8 +1027,8 @@ ib_recv_dev_list:
   rComm->base.vProps = mergedDev->vProps;
   memcpy(stage->buffer, &rComm->base.vProps, sizeof(ncclNetVDeviceProps_t));
   int localNqps, remoteNqps;
-  localNqps  = ncclParamIbQpsPerConn() * rComm->base.vProps.ndevs; // We must have at least 1 qp per-device
-  remoteNqps = ncclParamIbQpsPerConn() * remoteVProps.ndevs;
+  localNqps  = getQpsPerConn() * rComm->base.vProps.ndevs; // We must have at least 1 qp per-device
+  remoteNqps = getQpsPerConn() * remoteVProps.ndevs;
   rComm->base.nqps = remoteNqps > localNqps ? remoteNqps : localNqps; // Select max nqps (local or remote)
 
   rComm->base.nDataQps = std::max(rComm->base.vProps.ndevs, remoteVProps.ndevs);
@@ -1052,7 +1074,7 @@ ib_recv:
   // up to 2 completions (one for the CTS message and one for the completion
   // of a receive request) per QP, in the worst case.
   int cqSize;
-  cqSize = 2*NET_IB_MAX_REQUESTS*ncclParamIbQpsPerConn();
+  cqSize = 2*NET_IB_MAX_REQUESTS*getQpsPerConn();
   for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
     rCommDev = rComm->devs + i;
     ibDevN = rComm->base.vProps.devs[i];

--- a/comms/ncclx/v2_29/src/transport/net_ib/gin.cc
+++ b/comms/ncclx/v2_29/src/transport/net_ib/gin.cc
@@ -9,6 +9,9 @@
 
 #include "gin/gin_host.h"
 #include "gin.h"
+// [NCCLX-PerCommConfig] Use NcclxIbNetCommConfig so ctx is compatible with
+// ncclIbListen/ncclIbConnect which cast ctx to NcclxIbNetCommConfig*.
+#include "meta/transport/NcclxIbNetCommConfig.h"
 
 const int NCCL_GIN_IB_ALLGATHER_TAG = 0xa0;
 const int NCCL_GIN_IB_ALLTOALL_TAG = 0xa1;
@@ -102,9 +105,11 @@ try_proxy:
   if (ginIb) memcpy(ginIb, &ncclGinIbProxy, sizeof(ncclGinIb));
 
 end:
-  ncclNetCommConfig_t* netCommConfig = nullptr;
-  NCCLCHECK(ncclCalloc(&netCommConfig, 1));
-  *ctx = netCommConfig;
+  // [NCCLX-PerCommConfig] Allocate NcclxIbNetCommConfig (not ncclNetCommConfig_t)
+  // so the ctx is type-compatible with ncclIbListen/ncclIbConnect, which cast
+  // ctx to NcclxIbNetCommConfig* to read per-comm IB overrides.
+  auto* ncclxConfig = new ncclx::NcclxIbNetCommConfig();
+  *ctx = ncclxConfig;
   return ncclSuccess;
 }
 ncclResult_t ncclGinIbInit(void** ctx, uint64_t commId, ncclDebugLogger_t logFunction) {
@@ -119,7 +124,8 @@ ncclGin_t ncclGinIb = {
 };
 
 ncclResult_t ncclGinIbFinalize(void *ctx) {
-  if (ctx) free(ctx);
+  // [NCCLX-PerCommConfig] Match allocation in ncclGinIbInitType
+  delete static_cast<ncclx::NcclxIbNetCommConfig*>(ctx);
   return ncclIbFinalizeDevices();
 }
 

--- a/comms/ncclx/v2_29/src/transport/net_ib/init.cc
+++ b/comms/ncclx/v2_29/src/transport/net_ib/init.cc
@@ -6,6 +6,10 @@
  *************************************************************************/
 
 #include "common.h"
+// [NCCLX-PerCommConfig] Per-comm IB config via side-channel
+#include "meta/NcclxConfig.h"
+#include "meta/transport/NcclxIbNetCommConfig.h"
+#include "meta/transport/NcclxNetPluginHelper.h"
 
 NCCL_PARAM(IbPciRelaxedOrdering, "IB_PCI_RELAXED_ORDERING", 2);
 NCCL_PARAM(IbAdaptiveRouting, "IB_ADAPTIVE_ROUTING", -2);
@@ -392,11 +396,23 @@ fail:
 
 ncclResult_t ncclIbInit(void** ctx, uint64_t commId, ncclNetCommConfig_t* config, ncclDebugLogger_t logFunction, ncclProfilerCallback_t profFunction) {
   ncclResult_t ret = ncclSuccess;
-  ncclNetCommConfig_t* netCommConfig = nullptr;
   NCCLCHECK(ncclIbInitDevices(logFunction, profFunction));
-  NCCLCHECK(ncclCalloc(&netCommConfig, 1));
-  netCommConfig->trafficClass = config->trafficClass;
-  *ctx = (void *)netCommConfig;
+  // [NCCLX-PerCommConfig] Allocate extended ctx with per-comm IB overrides
+  auto* ncclxConfig = new ncclx::NcclxIbNetCommConfig();
+  ncclxConfig->trafficClass = config->trafficClass;
+
+  const ncclConfig_t* commConfig = ncclxGetCurrentCommConfig();
+  if (commConfig && commConfig->ncclxConfig) {
+    auto& ibSplit = NCCLX_CONFIG_FIELD(*commConfig, ibSplitDataOnQps);
+    if (ibSplit.has_value())
+      ncclxConfig->ibSplitDataOnQps = ibSplit.value();
+
+    auto& ibQps = NCCLX_CONFIG_FIELD(*commConfig, ibQpsPerConnection);
+    if (ibQps.has_value())
+      ncclxConfig->ibQpsPerConnection = ibQps.value();
+  }
+
+  *ctx = (void*)ncclxConfig;
   return ret;
 }
 
@@ -451,6 +467,7 @@ ncclResult_t ncclIbGetProperties(int dev, ncclNetProperties_t* props) {
 }
 
 ncclResult_t ncclIbFinalize(void* ctx) {
-  free(ctx);
+  // [NCCLX-PerCommConfig] Free extended ctx (NcclxIbNetCommConfig instead of ncclNetCommConfig_t)
+  delete static_cast<ncclx::NcclxIbNetCommConfig*>(ctx);
   return ncclIbFinalizeDevices();
 }


### PR DESCRIPTION
Summary:

Allow NCCL_IB_SPLIT_DATA_ON_QPS and NCCL_IB_QPS_PER_CONNECTION to be configured per-communicator via ncclx::Hints. Uses a static variable side-channel (protected by netPluginMutex) to pass ncclx::Config into the IB transport's per-comm ctx (NcclxIbNetCommConfig), applied during IB connection setup.

Design: NCCLX logic lives in meta/transport/ to minimize baseline exposure. Baseline files have thin call-sites tagged with [NCCLX-PerCommConfig] comments.

Changes:
- meta/NcclxConfig.h: Add ibSplitDataOnQps, ibQpsPerConnection fields
- meta/NcclxConfig.cc: Parse both hints (0/1 for split, positive-int for QPS)
- meta/transport/NcclxNetPluginHelper.h/.cc: New — NcclxCommConfigScope RAII class + ncclxGetCurrentCommConfig() accessor
- meta/transport/NcclxIbNetCommConfig.h: New — NcclxIbNetCommConfig struct + ibResolveQpsPerConnection(), ibResolveSplitDataOnQps(), ncclxIbCommInit() template
- meta/NcclxPerCommConfig.h: Add splitShare=1 rejection for IB fields
- meta/hints/tests/ConfigHintsUT.cc: 8 unit tests for IB hint parsing
- meta/tests/CommSplitPerCommConfigTest.cc: Add 3 IB integration tests (IbConfigOverride, DefaultHintsMatchParent, SplitShareRejects*)
- meta/design_docs/: Summary and integration test plan docs
- meta/baseline_modification_docs/: Baseline changes documentation
- v2_29/src/plugin/net.cc: NcclxCommConfigScope RAII in ncclNetInit()
- v2_29/src/transport/net_ib/init.cc: Allocate NcclxIbNetCommConfig ctx in ncclIbInit()
- v2_29/src/transport/net_ib/common.h: Add ctx field to ncclIbListenComm
- v2_29/src/transport/net_ib/connect.cc: Apply per-comm splitDataOnQps, qpsPerConn, trafficClass via helpers
- v2_29/def_build.bzl: Add NcclxPerCommConfig.h to header list

Reviewed By: minsii

Differential Revision: D102548559


