### PR TITLE
Fix BackendWrapper send/recv passing tag as async_op

### DIFF
--- a/comms/torchcomms/BackendWrapper.cpp
+++ b/comms/torchcomms/BackendWrapper.cpp
@@ -533,7 +533,7 @@ BackendWrapper::send(std::vector<at::Tensor>& tensors, int dstRank, int tag) {
       tensors.size(),
       " tensors");
   return c10::make_intrusive<WorkWrapper>(
-      backend_->send(tensors.at(0), dstRank, tag), tensors);
+      backend_->send(tensors.at(0), dstRank, /*async_op=*/true), tensors);
 }
 
 c10::intrusive_ptr<c10d::Work>
@@ -544,7 +544,7 @@ BackendWrapper::recv(std::vector<at::Tensor>& tensors, int srcRank, int tag) {
       tensors.size(),
       " tensors");
   return c10::make_intrusive<WorkWrapper>(
-      backend_->recv(tensors.at(0), srcRank, tag), tensors);
+      backend_->recv(tensors.at(0), srcRank, /*async_op=*/true), tensors);
 }
 
 std::shared_ptr<TorchComm> BackendWrapper::getComm() const {


### PR DESCRIPTION
`BackendWrapper::send` and `BackendWrapper::recv` forward the `c10d` tag parameter (an integer) into `TorchCommBackend::send/recv `async_op parameter (a bool)

The fix passes `async_op=true` explicitly and ignores tag, matching PyTorch `ProcessGroupNCCL::send` which names the parameter `int /* unused */` and always operates asynchronously on an internal NCCL stream

The `distwrap` layer (`dw.send/dw.recv`) is unaffected. it calls `TorchComm.send` directly and was already correctly not forwarding the tag parameter.