### PR TITLE
Add CUDA auto-detection and CMake hints to setup.py (#2278)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,11 @@
 # This source code is licensed under the BSD-3 license found in the
 # LICENSE file in the root directory of this source tree.
 
+import glob
 import os.path
 import pathlib
 import shlex
+import shutil
 import sys
 
 from setuptools import Extension, find_packages, setup
@@ -53,6 +55,97 @@ def flag_str(val: bool):
     return "ON" if val else "OFF"
 
 
+def _valid_cuda_home(path: str) -> bool:
+    """Check that a CUDA directory has nvcc and cuda_runtime.h."""
+    if not os.path.isfile(os.path.join(path, "bin", "nvcc")):
+        return False
+    # Generic layout (works on all architectures): include/cuda_runtime.h
+    # x86_64 layout: targets/x86_64-linux/include/cuda_runtime.h
+    # aarch64/sbsa layout: targets/sbsa-linux/include/cuda_runtime.h
+    return (
+        os.path.isfile(os.path.join(path, "include", "cuda_runtime.h"))
+        or os.path.isfile(
+            os.path.join(path, "targets", "x86_64-linux", "include", "cuda_runtime.h")
+        )
+        or os.path.isfile(
+            os.path.join(path, "targets", "sbsa-linux", "include", "cuda_runtime.h")
+        )
+    )
+
+
+def detect_cuda_home() -> str:
+    """Auto-detect CUDA toolkit location.
+
+    Checks CUDA_HOME / CUDA_PATH env vars first, then searches standard
+    install locations (/usr/local/cuda, /usr/local/cuda-*).
+    """
+    for env_var in ("CUDA_HOME", "CUDA_PATH"):
+        cuda_home = os.environ.get(env_var)
+        if not cuda_home:
+            continue
+        if _valid_cuda_home(cuda_home):
+            return cuda_home
+        print(
+            f"WARNING: {env_var}={cuda_home} does not contain a complete CUDA "
+            f"toolkit (missing nvcc or cuda_runtime.h). Attempting auto-detection..."
+        )
+
+    # Try /usr/local/cuda first, then search versioned directories (newest first)
+    candidates = ["/usr/local/cuda"]
+    versioned = sorted(
+        glob.glob("/usr/local/cuda-*"),
+        key=lambda p: [int(x) for x in p.split("cuda-")[-1].split(".") if x.isdigit()],
+        reverse=True,
+    )
+    candidates.extend(versioned)
+
+    for candidate in candidates:
+        if _valid_cuda_home(candidate):
+            return candidate
+
+    return ""
+
+
+def _valid_rocm_home(path: str) -> bool:
+    """Check that a ROCm directory has hipcc and hip/hip_runtime.h."""
+    if not os.path.isfile(os.path.join(path, "bin", "hipcc")):
+        return False
+    # Modern ROCm (5.x+): include/hip/hip_runtime.h
+    # Older ROCm: hip/include/hip/hip_runtime.h
+    return os.path.isfile(
+        os.path.join(path, "include", "hip", "hip_runtime.h")
+    ) or os.path.isfile(os.path.join(path, "hip", "include", "hip", "hip_runtime.h"))
+
+
+def detect_rocm_home() -> str:
+    """Auto-detect ROCm toolkit location.
+
+    Checks ROCM_HOME / ROCM_PATH env vars first, then hipcc on PATH,
+    then falls back to /opt/rocm.
+    """
+    for env_var in ("ROCM_HOME", "ROCM_PATH"):
+        rocm_home: str | None = os.environ.get(env_var)
+        if not rocm_home:
+            continue
+        if _valid_rocm_home(rocm_home):
+            return rocm_home
+        print(
+            f"WARNING: {env_var}={rocm_home} does not contain a complete ROCm "
+            f"toolkit (missing hipcc or hip_runtime.h). Attempting auto-detection..."
+        )
+
+    hipcc: str | None = shutil.which("hipcc")
+    if hipcc:
+        candidate: str = os.path.dirname(os.path.dirname(os.path.realpath(hipcc)))
+        if _valid_rocm_home(candidate):
+            return candidate
+
+    if _valid_rocm_home("/opt/rocm"):
+        return "/opt/rocm"
+
+    return ""
+
+
 ROOT = os.path.abspath(os.path.dirname(__file__))
 TORCH_ROOT = os.path.dirname(torch.__file__)
 
@@ -92,6 +185,32 @@ USE_TRANSPORT_CCA_HOOK = flag_enabled(
     "USE_TRANSPORT_CCA_HOOK", USE_NCCLX and not IS_ROCM
 )
 USE_TRITON = flag_enabled("USE_TRITON", False)
+if IS_ROCM:
+    CUDA_HOME = ""
+    os.environ.pop("CUDA_HOME", None)
+    ROCM_HOME: str = detect_rocm_home()
+    if ROCM_HOME:
+        was_auto: bool = ROCM_HOME != (
+            os.environ.get("ROCM_HOME") or os.environ.get("ROCM_PATH")
+        )
+        os.environ["ROCM_HOME"] = ROCM_HOME
+        label = " (auto-detected)" if was_auto else ""
+        print(f"- ROCM_HOME={ROCM_HOME}{label}")
+    else:
+        print("- ROCM_HOME=<not found>")
+else:
+    ROCM_HOME = ""
+    os.environ.pop("ROCM_HOME", None)
+    CUDA_HOME: str = detect_cuda_home()
+    if CUDA_HOME:
+        was_auto = CUDA_HOME != (
+            os.environ.get("CUDA_HOME") or os.environ.get("CUDA_PATH")
+        )
+        os.environ["CUDA_HOME"] = CUDA_HOME
+        label = " (auto-detected)" if was_auto else ""
+        print(f"- CUDA_HOME={CUDA_HOME}{label}")
+    else:
+        print("- CUDA_HOME=<not found>")
 
 
 def parse_requirements(path: str) -> list[str]:
@@ -170,10 +289,10 @@ class build_ext(build_ext_orig):
             build_flags += ["-DHIPIFY_V2"]
         pybind11_include_root = get_torch_pybind11_include_root(build_temp)
 
-        cfg = os.environ.get("CMAKE_BUILD_TYPE", "RelWithDebInfo")
+        cfg: str = os.environ.get("CMAKE_BUILD_TYPE", "RelWithDebInfo")
         print(f"- Building with {cfg} configuration")
 
-        cmake_args = [
+        cmake_args: list[str] = [
             f"-DCMAKE_BUILD_TYPE={cfg}",
             f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={extdir.parent.absolute()}",
             f"-DCMAKE_ARCHIVE_OUTPUT_DIRECTORY={extdir.parent.absolute()}",
@@ -194,7 +313,22 @@ class build_ext(build_ext_orig):
             f"-DUSE_TRANSPORT_CCA_HOOK={flag_str(USE_TRANSPORT_CCA_HOOK)}",
             f"-DUSE_TRITON={flag_str(USE_TRITON)}",
         ]
-        build_args = ["--", "-j"]
+        # Help CMake find the CUDA toolkit. CUDA_TOOLKIT_ROOT_DIR is used by
+        # the legacy FindCUDA module (which PyTorch's Caffe2Config.cmake uses).
+        # CMAKE_CUDA_COMPILER is used by modern CMake CUDA language support.
+        if CUDA_HOME:
+            cmake_args += [
+                f"-DCUDA_TOOLKIT_ROOT_DIR={CUDA_HOME}",
+                f"-DCMAKE_CUDA_COMPILER={os.path.join(CUDA_HOME, 'bin', 'nvcc')}",
+            ]
+        build_args: list[str] = ["--", "-j"]
+
+        # Ensure nvcc is on PATH for CMake's CUDA compiler detection.
+        if CUDA_HOME:
+            nvcc_dir: str = os.path.join(CUDA_HOME, "bin")
+            path_dirs: list[str] = os.environ.get("PATH", "").split(os.pathsep)
+            if nvcc_dir not in path_dirs:
+                os.environ["PATH"] = nvcc_dir + os.pathsep + os.environ.get("PATH", "")
 
         os.chdir(str(build_temp))
         self.spawn(["cmake", str(cwd)] + cmake_args)


### PR DESCRIPTION
Summary:

**TL;DR:** This diff enhances the OSS `setup.py` build script with automatic CUDA toolkit detection and improved CMake integration. Previously, users had to manually set `CUDA_HOME` for the build to locate the CUDA toolkit. This change makes the build more robust and user-friendly, especially in conda environments.

---

# Key Changes

## 1. CUDA Auto-Detection (`detect_cuda_home()`)
- Checks `CUDA_HOME` and `CUDA_PATH` environment variables first.
- Falls back to scanning standard install locations (`/usr/local/cuda`, `/usr/local/cuda-*`), preferring the newest versioned directory.
- Validates each candidate with `_valid_cuda_home()`, which checks for the presence of `nvcc` and `cuda_runtime.h` (supporting x86_64, aarch64/sbsa, and generic layouts).

## 2. CMake Hints
- Passes `-DCUDA_TOOLKIT_ROOT_DIR` (for legacy `FindCUDA` / PyTorch's `Caffe2Config.cmake`) and `-DCMAKE_CUDA_COMPILER` (for modern CMake CUDA language support) when a valid CUDA home is found.
- Ensures `nvcc` is on `PATH` so CMake's own CUDA compiler detection also succeeds.

## 3. Minor Type Annotations
- Adds explicit type annotations to `cfg`, `cmake_args`, `build_args`, `nvcc_dir`, and `path_dirs` for improved readability.

Differential Revision: D98820131


