### PR TITLE
Add tile-based AllToAllv with NVLink and IB support

### DIFF
--- a/comms/pipes/ThreadGroup.cuh
+++ b/comms/pipes/ThreadGroup.cuh
@@ -434,6 +434,8 @@ struct ThreadGroup {
       DeviceSpan<const uint32_t> weights) const;
   __device__ inline struct PartitionResult partition_interleaved(
       uint32_t num_partitions) const;
+  __device__ inline struct PartitionResult split(
+      uint32_t first_group_size) const;
 
  private:
 #ifdef __CUDACC__
@@ -752,6 +754,41 @@ __device__ inline PartitionResult ThreadGroup::partition_interleaved(
           .group_size = group_size,
           .group_id = new_group_id,
           .total_groups = groups_in_partition,
+          .scope = scope}};
+#endif
+  return PartitionResult{};
+}
+
+/**
+ * split - Divide groups into two parts at a fixed boundary
+ *
+ * Groups [0, first_group_size) become partition 0.
+ * Groups [first_group_size, total_groups) become partition 1.
+ *
+ * Lighter than partition(weights) — no proportional distribution,
+ * just a comparison and subtraction.
+ *
+ * If first_group_size == 0, all groups go to partition 1.
+ * If first_group_size >= total_groups, all groups go to partition 0.
+ *
+ * @param first_group_size Number of groups in partition 0
+ * @return {partition_id, subgroup} for this group
+ */
+__device__ inline PartitionResult ThreadGroup::split(
+    uint32_t first_group_size) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  uint32_t clamped =
+      first_group_size < total_groups ? first_group_size : total_groups;
+  uint32_t pid = (group_id < clamped) ? 0u : 1u;
+  uint32_t new_group_id = (pid == 0) ? group_id : group_id - clamped;
+  uint32_t new_total = (pid == 0) ? clamped : total_groups - clamped;
+  return PartitionResult{
+      .partition_id = pid,
+      .subgroup = ThreadGroup{
+          .thread_id_in_group = thread_id_in_group,
+          .group_size = group_size,
+          .group_id = new_group_id,
+          .total_groups = new_total,
           .scope = scope}};
 #endif
   return PartitionResult{};

--- a/comms/pipes/collectives/AllToAllvTile.cu
+++ b/comms/pipes/collectives/AllToAllvTile.cu
@@ -1,0 +1,380 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/CopyUtils.cuh"
+#include "comms/pipes/collectives/AllToAllvTile.cuh"
+
+namespace comms::pipes {
+
+namespace {
+
+__device__ __forceinline__ void send_to_peer(
+    MultiPeerDeviceHandle& handle,
+    int peer,
+    ThreadGroup& group,
+    void* src,
+    std::size_t nbytes,
+    int active_blocks,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout) {
+  if (handle.get_type(peer) == TransportType::P2P_NVL) {
+    handle.get_nvl(peer).send(
+        group, src, nbytes, active_blocks, max_signal_bytes, timeout);
+  } else {
+    handle.get_ibgda(peer).send(
+        group, src, nbytes, active_blocks, max_signal_bytes, timeout);
+  }
+}
+
+__device__ __forceinline__ void recv_from_peer(
+    MultiPeerDeviceHandle& handle,
+    int peer,
+    ThreadGroup& group,
+    void* dst,
+    std::size_t nbytes,
+    int active_blocks,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout) {
+  if (handle.get_type(peer) == TransportType::P2P_NVL) {
+    handle.get_nvl(peer).recv(
+        group, dst, nbytes, active_blocks, max_signal_bytes, timeout);
+  } else {
+    handle.get_ibgda(peer).recv(
+        group, dst, nbytes, active_blocks, max_signal_bytes, timeout);
+  }
+}
+
+__device__ __forceinline__ int find_peer_by_type(
+    const MultiPeerDeviceHandle& handle,
+    TransportType type,
+    int idx) {
+  int count = 0;
+  for (int r = 0; r < handle.nRanks; r++) {
+    if (handle.get_type(r) == type) {
+      if (count == idx) {
+        return r;
+      }
+      count++;
+    }
+  }
+  return -1;
+}
+
+// Distribute blocks across peers with uniform blocksPerPeer.
+// Uses arithmetic partitioning (floor division) instead of
+// ThreadGroup::partition() to guarantee every peer gets the same
+// blocksPerPeer. This is critical because sender and receiver ranks
+// map each other to different peerIdx values, and non-uniform
+// blocksPerPeer would cause active_blocks mismatch in send/recv.
+__device__ __forceinline__ void process_peers(
+    MultiPeerDeviceHandle& handle,
+    const AllToAllvTileArgs& args,
+    ThreadGroup& transportGroup,
+    int role,
+    TransportType peerType,
+    int numPeers,
+    const Timeout& timeout) {
+  if (numPeers == 0) {
+    return;
+  }
+  int numBlocks = transportGroup.total_groups;
+  int blockId = transportGroup.group_id;
+  int numPartitions = numBlocks < numPeers ? numBlocks : numPeers;
+  int blocksPerPeer = numBlocks / numPartitions;
+  int activeBlocks = blocksPerPeer * numPartitions;
+  int peersPerGroup = (numPeers + numPartitions - 1) / numPartitions;
+
+  if (blockId >= activeBlocks) {
+    return;
+  }
+
+  int partIdx = blockId / blocksPerPeer;
+  int tileIdx = blockId % blocksPerPeer;
+
+  ThreadGroup peerGroup = transportGroup;
+  peerGroup.group_id = tileIdx;
+  peerGroup.total_groups = blocksPerPeer;
+
+  for (int p = 0; p < peersPerGroup; p++) {
+    int peerIdx = partIdx * peersPerGroup + p;
+    if (peerIdx >= numPeers) {
+      break;
+    }
+    int peer = find_peer_by_type(handle, peerType, peerIdx);
+    if (peer < 0) {
+      continue;
+    }
+    std::size_t bytes =
+        (role == 0) ? args.send_counts[peer] : args.recv_counts[peer];
+    char** ptrs = (role == 0) ? args.send_ptrs : args.recv_ptrs;
+    if (bytes > 0) {
+      TiledBuffer<char> tiles(ptrs[peer], bytes, blocksPerPeer);
+      if (role == 0) {
+        send_to_peer(
+            handle,
+            peer,
+            peerGroup,
+            tiles.tile_data(tileIdx),
+            tiles.tile_bytes(tileIdx),
+            blocksPerPeer,
+            args.max_signal_bytes,
+            timeout);
+      } else {
+        recv_from_peer(
+            handle,
+            peer,
+            peerGroup,
+            tiles.tile_data(tileIdx),
+            tiles.tile_bytes(tileIdx),
+            blocksPerPeer,
+            args.max_signal_bytes,
+            timeout);
+      }
+    }
+  }
+}
+
+// NVL 2D: interleaved send/recv + uniform partition across peers.
+// Uses arithmetic partitioning with floor(halfBlocks / numPeers) to guarantee
+// uniform blocksPerPeer across all peer indices. This is critical because
+// sender rank A and receiver rank B map each other to different peerIdx values,
+// so non-uniform blocksPerPeer from ThreadGroup::partition() would cause
+// active_blocks mismatch in the send/recv signal protocol (deadlock).
+// When halfBlocks < numPeers, each block handles multiple peers sequentially.
+__device__ __forceinline__ void nvl_2d_path(
+    const AllToAllvTileArgs& args,
+    ThreadGroup transportGroup,
+    Timeout timeout) {
+  auto handle = args.handle;
+  const int myRank = handle.myRank;
+  const int nRanks = handle.nRanks;
+  const int numPeers = nRanks - 1;
+
+  if (numPeers == 0) {
+    std::size_t selfBytes = args.send_counts[myRank];
+    if (selfBytes > 0) {
+      memcpy_vectorized(
+          args.recv_ptrs[myRank],
+          args.send_ptrs[myRank],
+          selfBytes,
+          transportGroup);
+    }
+    return;
+  }
+
+  auto [role, halfGroup] = transportGroup.partition_interleaved(2);
+  const int halfBlocks = halfGroup.total_groups;
+  const int blockId = halfGroup.group_id;
+
+  int numPartitions = halfBlocks < numPeers ? halfBlocks : numPeers;
+  int blocksPerPeer = halfBlocks / numPartitions;
+  int activeBlocks = blocksPerPeer * numPartitions;
+  int peersPerGroup = (numPeers + numPartitions - 1) / numPartitions;
+
+  if (blockId >= activeBlocks) {
+    return;
+  }
+
+  int partIdx = blockId / blocksPerPeer;
+  int tileIdx = blockId % blocksPerPeer;
+
+  ThreadGroup peerGroup = halfGroup;
+  peerGroup.group_id = tileIdx;
+  peerGroup.total_groups = blocksPerPeer;
+
+  if (role == 0 && partIdx == 0) {
+    std::size_t selfBytes = args.send_counts[myRank];
+    if (selfBytes > 0) {
+      memcpy_vectorized(
+          args.recv_ptrs[myRank], args.send_ptrs[myRank], selfBytes, peerGroup);
+    }
+  }
+
+  for (int p = 0; p < peersPerGroup; p++) {
+    int peerIdx = partIdx * peersPerGroup + p;
+    if (peerIdx >= numPeers) {
+      break;
+    }
+
+    int peer = peerIdx < myRank ? peerIdx : peerIdx + 1;
+
+    if (role == 0) {
+      std::size_t sendBytes = args.send_counts[peer];
+      if (sendBytes > 0) {
+        TiledBuffer<char> tiles(args.send_ptrs[peer], sendBytes, blocksPerPeer);
+        send_to_peer(
+            handle,
+            peer,
+            peerGroup,
+            tiles.tile_data(tileIdx),
+            tiles.tile_bytes(tileIdx),
+            blocksPerPeer,
+            args.max_signal_bytes,
+            timeout);
+      }
+    } else {
+      std::size_t recvBytes = args.recv_counts[peer];
+      if (recvBytes > 0) {
+        TiledBuffer<char> tiles(args.recv_ptrs[peer], recvBytes, blocksPerPeer);
+        recv_from_peer(
+            handle,
+            peer,
+            peerGroup,
+            tiles.tile_data(tileIdx),
+            tiles.tile_bytes(tileIdx),
+            blocksPerPeer,
+            args.max_signal_bytes,
+            timeout);
+      }
+    }
+  }
+}
+
+// NVL 1D: self-copy with all blocks, then sequential remote peer iteration.
+__device__ __forceinline__ void nvl_1d_path(
+    const AllToAllvTileArgs& args,
+    ThreadGroup transportGroup,
+    Timeout timeout) {
+  auto handle = args.handle;
+  const int myRank = handle.myRank;
+  const int nRanks = handle.nRanks;
+
+  // Self-copy: all blocks cooperate before splitting for remote peers
+  std::size_t selfBytes = args.send_counts[myRank];
+  if (selfBytes > 0) {
+    TiledBuffer<char> sendTile(
+        args.send_ptrs[myRank], selfBytes, transportGroup);
+    TiledBuffer<char> recvTile(
+        args.recv_ptrs[myRank], selfBytes, transportGroup);
+    memcpy_vectorized(
+        recvTile.data(), sendTile.data(), sendTile.bytes(), transportGroup);
+  }
+
+  auto [role, sub] = transportGroup.partition_interleaved(2);
+  const int blockId = sub.group_id;
+  const int activeBlocks = sub.total_groups;
+
+  for (int offset = 1; offset < nRanks; offset++) {
+    int peer = (role == 0) ? (myRank + offset) % nRanks
+                           : (myRank - offset + nRanks) % nRanks;
+    if (handle.get_type(peer) != TransportType::P2P_NVL) {
+      continue;
+    }
+    std::size_t bytes =
+        (role == 0) ? args.send_counts[peer] : args.recv_counts[peer];
+    char** ptrs = (role == 0) ? args.send_ptrs : args.recv_ptrs;
+    if (bytes > 0) {
+      TiledBuffer<char> tiles(ptrs[peer], bytes, activeBlocks);
+      if (role == 0) {
+        send_to_peer(
+            handle,
+            peer,
+            sub,
+            tiles.tile_data(blockId),
+            tiles.tile_bytes(blockId),
+            activeBlocks,
+            args.max_signal_bytes,
+            timeout);
+      } else {
+        recv_from_peer(
+            handle,
+            peer,
+            sub,
+            tiles.tile_data(blockId),
+            tiles.tile_bytes(blockId),
+            activeBlocks,
+            args.max_signal_bytes,
+            timeout);
+      }
+    }
+  }
+}
+
+// IB: interleaved send/recv, sequential peer iteration.
+// Uses all active IB groups for each peer to saturate per-peer QPs while
+// respecting sendRecv.maxGroups.
+__device__ __forceinline__ void ib_path(
+    const AllToAllvTileArgs& args,
+    ThreadGroup transportGroup,
+    Timeout timeout) {
+  auto handle = args.handle;
+  auto [role, sub] = transportGroup.partition_interleaved(2);
+  const int myRank = handle.myRank;
+  const int nRanks = handle.nRanks;
+  const int blockId = sub.group_id;
+  const int activeBlocks = sub.total_groups;
+
+  for (int offset = 1; offset < nRanks; offset++) {
+    int peer = (role == 0) ? (myRank + offset) % nRanks
+                           : (myRank - offset + nRanks) % nRanks;
+    if (handle.get_type(peer) != TransportType::P2P_IBGDA) {
+      continue;
+    }
+    std::size_t bytes =
+        (role == 0) ? args.send_counts[peer] : args.recv_counts[peer];
+    char** ptrs = (role == 0) ? args.send_ptrs : args.recv_ptrs;
+    if (bytes > 0) {
+      TiledBuffer<char> tiles(ptrs[peer], bytes, activeBlocks);
+      if (role == 0) {
+        send_to_peer(
+            handle,
+            peer,
+            sub,
+            tiles.tile_data(blockId),
+            tiles.tile_bytes(blockId),
+            activeBlocks,
+            args.max_signal_bytes,
+            timeout);
+      } else {
+        recv_from_peer(
+            handle,
+            peer,
+            sub,
+            tiles.tile_data(blockId),
+            tiles.tile_bytes(blockId),
+            activeBlocks,
+            args.max_signal_bytes,
+            timeout);
+      }
+    }
+  }
+}
+
+// Unified kernel implementation templated on NVL strategy.
+// NvlParallel=true: NVL 2D (partition across peers)
+// NvlParallel=false: NVL 1D (sequential peer iteration)
+// IB always uses partition across peers.
+template <bool NvlParallel>
+__device__ __forceinline__ void alltoallv_tile_impl(
+    const AllToAllvTileArgs& args,
+    Timeout& timeout) {
+  auto group = make_block_group();
+  auto [transportId, transportGroup] = group.split(args.num_blocks_nvl);
+
+  if (transportId == 0) {
+    if constexpr (NvlParallel) {
+      nvl_2d_path(args, transportGroup, timeout);
+    } else {
+      nvl_1d_path(args, transportGroup, timeout);
+    }
+    return;
+  }
+  ib_path(args, transportGroup, timeout);
+}
+
+} // namespace
+
+__global__ __launch_bounds__(512, 1) void alltoallv_tile_1d_kernel(
+    const __grid_constant__ AllToAllvTileArgs args,
+    Timeout timeout) {
+  timeout.start();
+  alltoallv_tile_impl<false>(args, timeout);
+}
+
+__global__ __launch_bounds__(512, 1) void alltoallv_tile_2d_kernel(
+    const __grid_constant__ AllToAllvTileArgs args,
+    Timeout timeout) {
+  timeout.start();
+  alltoallv_tile_impl<true>(args, timeout);
+}
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/AllToAllvTile.cuh
+++ b/comms/pipes/collectives/AllToAllvTile.cuh
@@ -1,0 +1,71 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// AllToAllv using tile-based pipelined send/recv with NVLink and IB support.
+//
+// Uses MultiPeerDeviceHandle for per-peer NVLink/IB transport dispatch.
+// Configurable num_blocks_nvl / num_blocks_ib for independent concurrency.
+// ThreadGroup::split() partitions blocks between NVL and IB groups.
+// NVL 1D: sequential peer iteration with paired send/recv ordering.
+// NVL 2D: partition_interleaved across peers for parallel processing.
+// IB: partition across IB peers with round-robin for overflow.
+
+#pragma once
+
+#include <cstddef>
+
+#include "comms/pipes/MultiPeerDeviceHandle.cuh"
+#include "comms/pipes/TiledBuffer.cuh"
+
+namespace comms::pipes {
+
+/**
+ * AllToAllvTileArgs — Kernel arguments for tile-based alltoallv.
+ *
+ * All arrays are indexed by peer rank (0 to nRanks-1).
+ * Self-copy (myRank entry) is handled via memcpy_vectorized.
+ */
+struct AllToAllvTileArgs {
+  MultiPeerDeviceHandle handle;
+
+  // Send side: per-peer source pointers and byte counts
+  char** send_ptrs;
+  std::size_t* send_counts;
+
+  // Recv side: per-peer destination pointers and byte counts
+  char** recv_ptrs;
+  std::size_t* recv_counts;
+
+  // Blocks allocated to NVLink peers (portion of total grid).
+  // For NVL-only: set to total grid size, num_blocks_ib = 0.
+  int num_blocks_nvl;
+  // Blocks allocated to IB peers (portion of total grid).
+  // For IB-only: set to total grid size, num_blocks_nvl = 0.
+  int num_blocks_ib;
+  // Sub-chunk signaling hint (bytes). 0 = one signal per slot fill.
+  std::size_t max_signal_bytes;
+};
+
+#ifdef __CUDACC__
+/**
+ * NVL 1D sequential + IB 2D parallel.
+ * Best for large NVL messages. NVL blocks iterate peers sequentially.
+ * Grid: 2 * (num_blocks_nvl + num_blocks_ib).
+ */
+__global__ __launch_bounds__(512, 1) void alltoallv_tile_1d_kernel(
+    const __grid_constant__ AllToAllvTileArgs args,
+    Timeout timeout = Timeout());
+
+/**
+ * NVL 2D interleaved + IB 2D parallel.
+ * Best for small NVL messages. NVL blocks partitioned across peers.
+ * Grid: 2 * (num_blocks_nvl + num_blocks_ib).
+ */
+__global__ __launch_bounds__(512, 1) void alltoallv_tile_2d_kernel(
+    const __grid_constant__ AllToAllvTileArgs args,
+    Timeout timeout = Timeout());
+#else
+void alltoallv_tile_1d_kernel(AllToAllvTileArgs args, Timeout timeout);
+void alltoallv_tile_2d_kernel(AllToAllvTileArgs args, Timeout timeout);
+#endif
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/benchmarks/AllToAllvTileBenchmark.cc
+++ b/comms/pipes/collectives/benchmarks/AllToAllvTileBenchmark.cc
@@ -1,0 +1,524 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <folly/init/Init.h>
+#include <folly/logging/xlog.h>
+#include <nccl.h>
+#include <vector>
+
+#include "comms/common/CudaWrap.h"
+#include "comms/pipes/Checks.h"
+#include "comms/pipes/MultiPeerTransport.h"
+#include "comms/pipes/TimeoutUtils.h"
+
+#include "comms/pipes/collectives/AllToAllvTile.cuh"
+#include "comms/testinfra/BenchmarkTestFixture.h"
+#include "comms/testinfra/mpi/MpiTestUtils.h"
+#include "comms/utils/CudaRAII.h"
+
+using meta::comms::CudaEvent;
+using meta::comms::DeviceBuffer;
+
+namespace comms::pipes::benchmark {
+
+namespace {
+
+constexpr int kNIter = 100;
+constexpr int kNWarmup = 5;
+
+std::string format_bytes(std::size_t bytes) {
+  if (bytes >= 1024UL * 1024 * 1024) {
+    return std::to_string(bytes / (1024UL * 1024 * 1024)) + "GB";
+  }
+  if (bytes >= 1024 * 1024) {
+    return std::to_string(bytes / (1024 * 1024)) + "MB";
+  }
+  if (bytes >= 1024) {
+    return std::to_string(bytes / 1024) + "KB";
+  }
+  return std::to_string(bytes) + "B";
+}
+
+class AllToAllvTileBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
+ protected:
+  static std::size_t get_data_buffer_size() {
+    int major = 0;
+    PIPES_CUDA_CHECK(
+        cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, 0));
+    // GB200 (SM 100+): 32MB * 2 pd = 64MB staging; H100: 8MB * 2 pd = 16MB
+    return major >= 10 ? 32 * 1024 * 1024 : 8 * 1024 * 1024;
+  }
+
+  static int get_max_blocks() {
+    int major = 0;
+    PIPES_CUDA_CHECK(
+        cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, 0));
+    // Match NCCL's SM usage: 64 on GB200, 32 on H100
+    return major >= 10 ? 64 : 32;
+  }
+
+  void SetUp() override {
+    BenchmarkTestFixture::SetUp();
+    PIPES_CUDA_CHECK(cudaSetDevice(localRank));
+    PIPES_CUDA_CHECK(cudaStreamCreate(&stream_));
+
+    // Match NCCL IB config to our transport settings for fair comparison.
+    setenv("NCCL_NCHANNELS_PER_NET_PEER", "1", 0);
+    setenv("NCCL_IB_QPS_PER_CONNECTION", "2", 0);
+    setenv("NCCL_IB_SPLIT_DATA_ON_QPS", "1", 0);
+    setenv("NCCL_BUFFSIZE", "8388608", 0);
+    setenv("NCCL_P2P_NET_CHUNKSIZE", "524288", 0);
+
+    ncclUniqueId id;
+    if (globalRank == 0) {
+      ncclGetUniqueId(&id);
+    }
+    std::vector<ncclUniqueId> all_ids(worldSize);
+    all_ids[globalRank] = id;
+    bootstrap
+        ->allGather(all_ids.data(), sizeof(ncclUniqueId), globalRank, worldSize)
+        .get();
+    auto ncclRet =
+        ncclCommInitRank(&nccl_comm_, worldSize, all_ids[0], globalRank);
+    if (ncclRet != ncclSuccess) {
+      XLOG(WARNING) << "ncclCommInitRank failed (rc=" << ncclRet
+                    << "), NCCL baseline will be skipped";
+      nccl_comm_ = nullptr;
+    }
+
+    std::size_t bufSize = get_data_buffer_size();
+    MultiPeerTransportConfig transport_config{
+        .nvlConfig =
+            {
+                .dataBufferSize = bufSize,
+                .chunkSize = bufSize,
+                .pipelineDepth = 2,
+                .tile_max_groups = 32,
+            },
+    };
+    transport_ = std::make_unique<MultiPeerTransport>(
+        globalRank, worldSize, localRank, bootstrap, transport_config);
+    transport_->exchange();
+
+    int device = 0;
+    PIPES_CUDA_CHECK(cudaGetDevice(&device));
+    timeout_ = makeTimeout(0, device);
+  }
+
+  MultiPeerDeviceHandle make_handle() {
+    return transport_->get_device_handle();
+  }
+
+  void TearDown() override {
+    transport_.reset();
+    if (nccl_comm_) {
+      ncclCommDestroy(nccl_comm_);
+    }
+    PIPES_CUDA_CHECK(cudaStreamDestroy(stream_));
+    BenchmarkTestFixture::TearDown();
+  }
+
+  struct BenchResult {
+    float bw_gbps;
+    float lat_us;
+  };
+
+  BenchResult run_nccl(std::size_t bpp, ncclComm_t comm = nullptr) {
+    if (!comm) {
+      comm = nccl_comm_;
+    }
+    if (!comm) {
+      return {0.0f, 0.0f};
+    }
+    const int nranks = worldSize;
+    const std::size_t total = bpp * nranks;
+
+    DeviceBuffer send_buf(total);
+    DeviceBuffer recv_buf(total);
+    PIPES_CUDA_CHECK(cudaMemset(send_buf.get(), 1, total));
+    PIPES_CUDA_CHECK(cudaMemset(recv_buf.get(), 0, total));
+
+    std::vector<size_t> counts(nranks, bpp);
+    counts[globalRank] = 0;
+    std::vector<size_t> displs(nranks);
+    for (int i = 0; i < nranks; i++) {
+      displs[i] = i * bpp;
+    }
+
+    bootstrap->barrierAll();
+    for (int i = 0; i < kNWarmup; i++) {
+      ncclAllToAllv(
+          send_buf.get(),
+          counts.data(),
+          displs.data(),
+          recv_buf.get(),
+          counts.data(),
+          displs.data(),
+          ncclChar,
+          comm,
+          stream_);
+    }
+    PIPES_CUDA_CHECK(cudaStreamSynchronize(stream_));
+    bootstrap->barrierAll();
+
+    CudaEvent start, stop;
+    PIPES_CUDA_CHECK(cudaEventRecord(start.get(), stream_));
+    for (int i = 0; i < kNIter; i++) {
+      ncclAllToAllv(
+          send_buf.get(),
+          counts.data(),
+          displs.data(),
+          recv_buf.get(),
+          counts.data(),
+          displs.data(),
+          ncclChar,
+          comm,
+          stream_);
+    }
+    PIPES_CUDA_CHECK(cudaEventRecord(stop.get(), stream_));
+    PIPES_CUDA_CHECK(cudaStreamSynchronize(stream_));
+
+    float ms = 0;
+    PIPES_CUDA_CHECK(cudaEventElapsedTime(&ms, start.get(), stop.get()));
+    float avg = ms / kNIter;
+    std::size_t algo_bytes = bpp * (nranks - 1);
+    float bw = (algo_bytes / 1e9f) / (avg / 1000.0f);
+    bootstrap->barrierAll();
+    return {bw, avg * 1000.0f};
+  }
+
+  BenchResult run_tile(
+      MultiPeerDeviceHandle handle,
+      std::size_t bpp,
+      int num_blocks,
+      void* kernel_fn,
+      int grid_blocks,
+      std::size_t max_signal_bytes = 0,
+      std::optional<dim3> cluster_dim = std::nullopt,
+      int num_blocks_ib_override = -1) {
+    const int nranks = worldSize;
+    const std::size_t total = bpp * nranks;
+
+    DeviceBuffer send_buf(total);
+    DeviceBuffer recv_buf(total);
+    PIPES_CUDA_CHECK(cudaMemset(send_buf.get(), 1, total));
+    PIPES_CUDA_CHECK(cudaMemset(recv_buf.get(), 0, total));
+
+    std::vector<char*> h_sp(nranks), h_rp(nranks);
+    std::vector<std::size_t> h_c(nranks, bpp);
+    h_c[globalRank] = 0;
+    for (int r = 0; r < nranks; r++) {
+      h_sp[r] = static_cast<char*>(send_buf.get()) + r * bpp;
+      h_rp[r] = static_cast<char*>(recv_buf.get()) + r * bpp;
+    }
+
+    DeviceBuffer d_sp(nranks * sizeof(char*));
+    DeviceBuffer d_rp(nranks * sizeof(char*));
+    DeviceBuffer d_c(nranks * sizeof(std::size_t));
+    PIPES_CUDA_CHECK(cudaMemcpy(
+        d_sp.get(),
+        h_sp.data(),
+        nranks * sizeof(char*),
+        cudaMemcpyHostToDevice));
+    PIPES_CUDA_CHECK(cudaMemcpy(
+        d_rp.get(),
+        h_rp.data(),
+        nranks * sizeof(char*),
+        cudaMemcpyHostToDevice));
+    PIPES_CUDA_CHECK(cudaMemcpy(
+        d_c.get(),
+        h_c.data(),
+        nranks * sizeof(std::size_t),
+        cudaMemcpyHostToDevice));
+
+    AllToAllvTileArgs args{
+        .handle = handle,
+        .send_ptrs = static_cast<char**>(d_sp.get()),
+        .send_counts = static_cast<std::size_t*>(d_c.get()),
+        .recv_ptrs = static_cast<char**>(d_rp.get()),
+        .recv_counts = static_cast<std::size_t*>(d_c.get()),
+        .num_blocks_nvl = num_blocks,
+        .num_blocks_ib =
+            num_blocks_ib_override >= 0 ? num_blocks_ib_override : num_blocks,
+        .max_signal_bytes = max_signal_bytes,
+    };
+
+    bootstrap->barrierAll();
+    for (int i = 0; i < kNWarmup; i++) {
+      void* ka[] = {&args, &timeout_};
+      comms::common::launchKernel(
+          kernel_fn, dim3(grid_blocks), dim3(512), ka, nullptr, cluster_dim);
+      PIPES_CUDA_CHECK(cudaDeviceSynchronize());
+    }
+    bootstrap->barrierAll();
+
+    CudaEvent start, stop;
+    PIPES_CUDA_CHECK(cudaEventRecord(start.get()));
+    for (int i = 0; i < kNIter; i++) {
+      void* ka[] = {&args, &timeout_};
+      comms::common::launchKernel(
+          kernel_fn, dim3(grid_blocks), dim3(512), ka, nullptr, cluster_dim);
+    }
+    PIPES_CUDA_CHECK(cudaEventRecord(stop.get()));
+    PIPES_CUDA_CHECK(cudaDeviceSynchronize());
+
+    float ms = 0;
+    PIPES_CUDA_CHECK(cudaEventElapsedTime(&ms, start.get(), stop.get()));
+    float avg = ms / kNIter;
+    std::size_t algo_bytes = bpp * (nranks - 1);
+    float bw = (algo_bytes / 1e9f) / (avg / 1000.0f);
+    bootstrap->barrierAll();
+    return {bw, avg * 1000.0f};
+  }
+
+  ncclComm_t nccl_comm_{};
+  cudaStream_t stream_{};
+  std::unique_ptr<MultiPeerTransport> transport_;
+  Timeout timeout_;
+};
+
+TEST_F(AllToAllvTileBenchmarkFixture, FullSweep) {
+  auto handle = make_handle();
+  constexpr dim3 kClusterDim{4, 1, 1};
+
+  // Per-size block counts matching NCCL channel scaling:
+  //   NCCL reduces channels while nBytes < nc * 512 * 64
+  //   8 channels for < 512KB, 16 for 512KB-128MB, 32 for 512MB+
+  struct SizeConfig {
+    std::size_t bpp;
+    int blocks;
+  };
+  std::vector<SizeConfig> configs = {
+      {8 * 1024, 16},
+      {32 * 1024, 16},
+      {128 * 1024, 16},
+      {512 * 1024, 16},
+      {1024 * 1024, 16},
+      {4 * 1024 * 1024, 16},
+      {16 * 1024 * 1024, 16},
+      {64 * 1024 * 1024, 16},
+      {256 * 1024 * 1024, 16},
+      {1024UL * 1024 * 1024, 32},
+  };
+
+  if (globalRank == 0) {
+    XLOG(INFO) << "\n=== AllToAllvTile NVL Sweep (1D vs 2D, cluster=4) ===\n"
+               << worldSize << " GPUs, " << kNIter
+               << " iterations, per-size block counts\n";
+    printf(
+        "%-10s  %10s  %12s  %12s  %-12s %8s\n",
+        "Per-Peer",
+        "NCCL",
+        "Tile-1D",
+        "Tile-2D",
+        "Best",
+        "vs NCCL");
+    printf(
+        "%-10s  %10s  %12s  %12s  %-12s %8s\n",
+        "--------",
+        "----------",
+        "------------",
+        "------------",
+        "------------",
+        "--------");
+  }
+
+  for (const auto& cfg : configs) {
+    int grid = cfg.blocks;
+    auto nccl_r = run_nccl(cfg.bpp);
+
+    auto t1d_r = run_tile(
+        handle,
+        cfg.bpp,
+        grid,
+        (void*)alltoallv_tile_1d_kernel,
+        grid,
+        0,
+        kClusterDim,
+        0);
+
+    auto t2d_r = run_tile(
+        handle,
+        cfg.bpp,
+        grid,
+        (void*)alltoallv_tile_2d_kernel,
+        grid,
+        0,
+        kClusterDim,
+        0);
+
+    if (globalRank == 0) {
+      float best_bw = t1d_r.bw_gbps;
+      const char* best_name = "tile_1d";
+      if (t2d_r.bw_gbps > best_bw) {
+        best_bw = t2d_r.bw_gbps;
+        best_name = "tile_2d";
+      }
+      float speedup = nccl_r.bw_gbps > 0 ? best_bw / nccl_r.bw_gbps : 0;
+      char l1[32], l2[32];
+      snprintf(l1, sizeof(l1), "%.1f (%d)", t1d_r.bw_gbps, grid);
+      snprintf(l2, sizeof(l2), "%.1f (%d)", t2d_r.bw_gbps, grid);
+      printf(
+          "%-10s  %10.2f  %12s  %12s  %-12s %7.2fx\n",
+          format_bytes(cfg.bpp).c_str(),
+          nccl_r.bw_gbps,
+          l1,
+          l2,
+          best_name,
+          speedup);
+    }
+    bootstrap->barrierAll();
+  }
+}
+
+TEST_F(AllToAllvTileBenchmarkFixture, IbSweep) {
+  constexpr dim3 kClusterDim{4, 1, 1};
+  // Force IB by disabling P2P NVLink in topology discovery.
+  std::size_t bufSize = get_data_buffer_size();
+  MultiPeerTransportConfig ib_config{
+      .nvlConfig =
+          {
+              .dataBufferSize = bufSize,
+              .chunkSize = bufSize,
+              .pipelineDepth = 2,
+              .tile_max_groups = 32,
+          },
+      .ibgdaConfig =
+          {
+              .cudaDevice = localRank,
+              .dataBufferSize = bufSize,
+              .sendRecv =
+                  MultipeerIbgdaTransportConfig::SendRecvConfig{
+                      .maxGroups = 8,
+                      .pipelineDepth = 2,
+                  },
+              .numQpsPerPeerPerNic = 4,
+          },
+      .topoConfig =
+          {
+              .p2pDisable = true,
+          },
+  };
+
+  std::unique_ptr<MultiPeerTransport> ib_transport;
+  try {
+    ib_transport = std::make_unique<MultiPeerTransport>(
+        globalRank, worldSize, localRank, bootstrap, ib_config);
+    ib_transport->exchange();
+  } catch (const std::exception& e) {
+    if (globalRank == 0) {
+      XLOG(WARN) << "IB transport setup failed: " << e.what()
+                 << "\nSkipping IB benchmark (requires multi-node or IB "
+                    "loopback support)";
+    }
+    return;
+  }
+  auto ib_handle = ib_transport->get_device_handle();
+
+  // Use the existing NCCL comm. When NCCL_P2P_DISABLE=1 is set in the
+  // environment before the process starts, NCCL will also use IB transport,
+  // making the comparison fair. Run with:
+  //   NCCL_P2P_DISABLE=1 buck2 run ... -- --gtest_filter="*IbFullSweep*"
+
+  std::vector<std::size_t> sizes = {
+      8 * 1024,
+      16 * 1024,
+      32 * 1024,
+      64 * 1024,
+      128 * 1024,
+      256 * 1024,
+      512 * 1024,
+      1024 * 1024,
+      2 * 1024 * 1024,
+      4 * 1024 * 1024,
+      8 * 1024 * 1024,
+      16 * 1024 * 1024,
+      32 * 1024 * 1024,
+      64 * 1024 * 1024,
+      128 * 1024 * 1024,
+      256 * 1024 * 1024,
+      512UL * 1024 * 1024,
+      1024UL * 1024 * 1024,
+  };
+
+  int numIbPeers = ib_handle.numIbPeers;
+  int ib_full = 8;
+  int ib_half = ib_full / 2;
+
+  if (globalRank == 0) {
+    XLOG(INFO) << "\n=== AllToAllvTile IB Sweep (cluster=4) ===\n"
+               << worldSize << " GPUs, " << kNIter << " iterations\n"
+               << numIbPeers << " IB peers\n"
+               << "Run with: NCCL_P2P_DISABLE=1 buck2 run ...\n";
+    printf(
+        "%-10s  %10s  %12s  %12s  %-10s %8s\n",
+        "Per-Peer",
+        "NCCL-IB",
+        "half",
+        "full",
+        "Best",
+        "vs NCCL");
+    printf(
+        "%-10s  %10s  %12s  %12s  %-10s %8s\n",
+        "--------",
+        "----------",
+        "------------",
+        "------------",
+        "----------",
+        "--------");
+  }
+
+  for (std::size_t bpp : sizes) {
+    auto nccl_r = run_nccl(bpp);
+
+    auto ib1_r = run_tile(
+        ib_handle,
+        bpp,
+        0,
+        (void*)alltoallv_tile_1d_kernel,
+        2 * ib_half,
+        0,
+        kClusterDim,
+        ib_half);
+
+    auto ib2_r = run_tile(
+        ib_handle,
+        bpp,
+        0,
+        (void*)alltoallv_tile_1d_kernel,
+        2 * ib_full,
+        0,
+        kClusterDim,
+        ib_full);
+
+    if (globalRank == 0) {
+      float best_bw =
+          ib2_r.bw_gbps > ib1_r.bw_gbps ? ib2_r.bw_gbps : ib1_r.bw_gbps;
+      const char* best_name = ib2_r.bw_gbps > ib1_r.bw_gbps ? "full" : "half";
+      float speedup = nccl_r.bw_gbps > 0 ? best_bw / nccl_r.bw_gbps : 0;
+
+      char l1[32], l2[32];
+      snprintf(l1, sizeof(l1), "%.1f (%d)", ib1_r.bw_gbps, ib_half);
+      snprintf(l2, sizeof(l2), "%.1f (%d)", ib2_r.bw_gbps, ib_full);
+      printf(
+          "%-10s  %10.2f  %12s  %12s  %-10s %7.2fx\n",
+          format_bytes(bpp).c_str(),
+          nccl_r.bw_gbps,
+          l1,
+          l2,
+          best_name,
+          speedup);
+    }
+    bootstrap->barrierAll();
+  }
+}
+
+} // namespace
+
+} // namespace comms::pipes::benchmark
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv);
+  ::testing::AddGlobalTestEnvironment(new meta::comms::BenchmarkEnvironment());
+  return RUN_ALL_TESTS();
+}

--- a/comms/pipes/collectives/tests/AllToAllvTileTest.cc
+++ b/comms/pipes/collectives/tests/AllToAllvTileTest.cc
@@ -1,0 +1,543 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include <folly/init/Init.h>
+#include <folly/logging/xlog.h>
+
+#include <array>
+
+#include "comms/common/CudaWrap.h"
+#include "comms/pipes/MultiPeerTransport.h"
+#include "comms/pipes/TimeoutUtils.h"
+#include "comms/pipes/collectives/AllToAllvTile.cuh"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/testinfra/mpi/MpiBootstrap.h"
+#include "comms/testinfra/mpi/MpiTestUtils.h"
+#include "comms/utils/CudaRAII.h"
+
+using namespace meta::comms;
+
+namespace comms::pipes::tests {
+
+class AllToAllvTileTestFixture : public MpiBaseTestFixture {
+ protected:
+  void SetUp() override {
+    MpiBaseTestFixture::SetUp();
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+  }
+
+  std::unique_ptr<MultiPeerTransport> create_and_exchange(
+      std::size_t data_buffer_size = 8 * 1024 * 1024) {
+    MultiPeerTransportConfig config{
+        .nvlConfig =
+            {
+                .dataBufferSize = data_buffer_size,
+                .chunkSize = 64 * 1024,
+                .pipelineDepth = 4,
+                .tile_max_groups = 32,
+            },
+        .ibgdaConfig =
+            {
+                .cudaDevice = localRank,
+            },
+    };
+    auto bootstrap = std::make_shared<MpiBootstrap>();
+    auto transport = std::make_unique<MultiPeerTransport>(
+        globalRank, numRanks, localRank, bootstrap, config);
+    transport->exchange();
+    return transport;
+  }
+
+  void run_alltoallv_tile_test(
+      std::size_t bytes_per_peer,
+      int num_blocks,
+      std::size_t max_signal_bytes = 0) {
+    auto transport = create_and_exchange();
+    auto handle = transport->get_device_handle();
+
+    const int nranks = numRanks;
+    const std::size_t total_send = bytes_per_peer * nranks;
+    const std::size_t total_recv = bytes_per_peer * nranks;
+
+    DeviceBuffer send_buf(total_send);
+    DeviceBuffer recv_buf(total_recv);
+
+    // Fill send buffer: byte[peer * bytesPerPeer + i] = (globalRank * 10 +
+    // peer) % 256
+    std::vector<char> h_send(total_send);
+    for (int peer = 0; peer < nranks; peer++) {
+      for (std::size_t i = 0; i < bytes_per_peer; i++) {
+        h_send[peer * bytes_per_peer + i] =
+            static_cast<char>((globalRank * 10 + peer + i) % 256);
+      }
+    }
+    CUDACHECK_TEST(cudaMemcpy(
+        send_buf.get(), h_send.data(), total_send, cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(cudaMemset(recv_buf.get(), 0, total_recv));
+
+    // Build per-peer pointer and count arrays on device
+    std::vector<char*> h_send_ptrs(nranks);
+    std::vector<char*> h_recv_ptrs(nranks);
+    std::vector<std::size_t> h_send_counts(nranks, bytes_per_peer);
+    std::vector<std::size_t> h_recv_counts(nranks, bytes_per_peer);
+
+    for (int r = 0; r < nranks; r++) {
+      h_send_ptrs[r] = static_cast<char*>(send_buf.get()) + r * bytes_per_peer;
+      h_recv_ptrs[r] = static_cast<char*>(recv_buf.get()) + r * bytes_per_peer;
+    }
+
+    DeviceBuffer d_send_ptrs(nranks * sizeof(char*));
+    DeviceBuffer d_recv_ptrs(nranks * sizeof(char*));
+    DeviceBuffer d_send_counts(nranks * sizeof(std::size_t));
+    DeviceBuffer d_recv_counts(nranks * sizeof(std::size_t));
+
+    CUDACHECK_TEST(cudaMemcpy(
+        d_send_ptrs.get(),
+        h_send_ptrs.data(),
+        nranks * sizeof(char*),
+        cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(cudaMemcpy(
+        d_recv_ptrs.get(),
+        h_recv_ptrs.data(),
+        nranks * sizeof(char*),
+        cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(cudaMemcpy(
+        d_send_counts.get(),
+        h_send_counts.data(),
+        nranks * sizeof(std::size_t),
+        cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(cudaMemcpy(
+        d_recv_counts.get(),
+        h_recv_counts.data(),
+        nranks * sizeof(std::size_t),
+        cudaMemcpyHostToDevice));
+
+    int num_blocks_nvl = num_blocks;
+    int num_blocks_ib = num_blocks;
+    int total_blocks = 2 * num_blocks;
+
+    AllToAllvTileArgs args{
+        .handle = handle,
+        .send_ptrs = static_cast<char**>(d_send_ptrs.get()),
+        .send_counts = static_cast<std::size_t*>(d_send_counts.get()),
+        .recv_ptrs = static_cast<char**>(d_recv_ptrs.get()),
+        .recv_counts = static_cast<std::size_t*>(d_recv_counts.get()),
+        .num_blocks_nvl = num_blocks_nvl,
+        .num_blocks_ib = num_blocks_ib,
+        .max_signal_bytes = max_signal_bytes,
+    };
+
+    int device = 0;
+    CUDACHECK_TEST(cudaGetDevice(&device));
+    Timeout timeout = makeTimeout(30000, device);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    dim3 clus(comms::common::kDefaultClusterSize, 1, 1);
+    void* kernel_args[] = {&args, &timeout};
+    comms::common::launchKernel(
+        (void*)alltoallv_tile_1d_kernel,
+        dim3(total_blocks),
+        dim3(512),
+        kernel_args,
+        nullptr,
+        clus);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // Verify received data
+    std::vector<char> h_recv(total_recv);
+    CUDACHECK_TEST(cudaMemcpy(
+        h_recv.data(), recv_buf.get(), total_recv, cudaMemcpyDeviceToHost));
+
+    for (int peer = 0; peer < nranks; peer++) {
+      for (std::size_t i = 0; i < bytes_per_peer; i++) {
+        char expected = static_cast<char>((peer * 10 + globalRank + i) % 256);
+        char actual = h_recv[peer * bytes_per_peer + i];
+        EXPECT_EQ(actual, expected)
+            << "Rank " << globalRank << ": mismatch receiving from peer "
+            << peer << " at byte " << i << " (expected "
+            << static_cast<int>(expected) << ", got "
+            << static_cast<int>(actual) << ")";
+        if (actual != expected) {
+          return;
+        }
+      }
+    }
+  }
+
+  void run_alltoallv_tile_large_smoke_test(
+      std::size_t bytes_per_peer,
+      int num_blocks,
+      bool force_ib = false) {
+    auto transport = force_ib ? nullptr : create_and_exchange();
+    std::unique_ptr<MultiPeerTransport> ib_transport;
+    if (force_ib) {
+      MultiPeerTransportConfig config{
+          .nvlConfig =
+              {
+                  .dataBufferSize = 8 * 1024 * 1024,
+                  .chunkSize = 64 * 1024,
+                  .pipelineDepth = 4,
+                  .tile_max_groups = 32,
+              },
+          .ibgdaConfig =
+              {
+                  .cudaDevice = localRank,
+                  .dataBufferSize = 8 * 1024 * 1024,
+                  .sendRecv =
+                      MultipeerIbgdaTransportConfig::SendRecvConfig{
+                          .maxGroups = 8,
+                          .pipelineDepth = 2,
+                      },
+                  .numQpsPerPeerPerNic = 4,
+              },
+          .topoConfig =
+              {
+                  .p2pDisable = true,
+              },
+      };
+      auto bootstrap = std::make_shared<MpiBootstrap>();
+      ib_transport = std::make_unique<MultiPeerTransport>(
+          globalRank, numRanks, localRank, bootstrap, config);
+      ib_transport->exchange();
+    }
+
+    auto handle = force_ib ? ib_transport->get_device_handle()
+                           : transport->get_device_handle();
+
+    const int nranks = numRanks;
+    const std::size_t total = bytes_per_peer * nranks;
+    DeviceBuffer send_buf(total);
+    DeviceBuffer recv_buf(total);
+
+    for (int peer = 0; peer < nranks; peer++) {
+      CUDACHECK_TEST(cudaMemset(
+          static_cast<char*>(send_buf.get()) + peer * bytes_per_peer,
+          (globalRank * 10 + peer) & 0xff,
+          bytes_per_peer));
+    }
+    CUDACHECK_TEST(cudaMemset(recv_buf.get(), 0, total));
+
+    std::vector<char*> h_send_ptrs(nranks);
+    std::vector<char*> h_recv_ptrs(nranks);
+    std::vector<std::size_t> h_counts(nranks, bytes_per_peer);
+    for (int r = 0; r < nranks; r++) {
+      h_send_ptrs[r] = static_cast<char*>(send_buf.get()) + r * bytes_per_peer;
+      h_recv_ptrs[r] = static_cast<char*>(recv_buf.get()) + r * bytes_per_peer;
+    }
+
+    DeviceBuffer d_send_ptrs(nranks * sizeof(char*));
+    DeviceBuffer d_recv_ptrs(nranks * sizeof(char*));
+    DeviceBuffer d_counts(nranks * sizeof(std::size_t));
+    CUDACHECK_TEST(cudaMemcpy(
+        d_send_ptrs.get(),
+        h_send_ptrs.data(),
+        nranks * sizeof(char*),
+        cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(cudaMemcpy(
+        d_recv_ptrs.get(),
+        h_recv_ptrs.data(),
+        nranks * sizeof(char*),
+        cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(cudaMemcpy(
+        d_counts.get(),
+        h_counts.data(),
+        nranks * sizeof(std::size_t),
+        cudaMemcpyHostToDevice));
+
+    AllToAllvTileArgs args{
+        .handle = handle,
+        .send_ptrs = static_cast<char**>(d_send_ptrs.get()),
+        .send_counts = static_cast<std::size_t*>(d_counts.get()),
+        .recv_ptrs = static_cast<char**>(d_recv_ptrs.get()),
+        .recv_counts = static_cast<std::size_t*>(d_counts.get()),
+        .num_blocks_nvl = force_ib ? 0 : num_blocks,
+        .num_blocks_ib = force_ib ? num_blocks : 0,
+        .max_signal_bytes = 0,
+    };
+
+    int device = 0;
+    CUDACHECK_TEST(cudaGetDevice(&device));
+    Timeout timeout = makeTimeout(30000, device);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    dim3 clus(comms::common::kDefaultClusterSize, 1, 1);
+    void* kernel_args[] = {&args, &timeout};
+    comms::common::launchKernel(
+        (void*)alltoallv_tile_1d_kernel,
+        dim3(force_ib ? 2 * num_blocks : num_blocks),
+        dim3(512),
+        kernel_args,
+        nullptr,
+        clus);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    std::array<std::size_t, 3> sample_offsets = {
+        0,
+        bytes_per_peer / 2,
+        bytes_per_peer - 1,
+    };
+    for (int peer = 0; peer < nranks; peer++) {
+      if (force_ib && peer == globalRank) {
+        continue;
+      }
+      for (std::size_t offset : sample_offsets) {
+        char actual = 0;
+        CUDACHECK_TEST(cudaMemcpy(
+            &actual,
+            static_cast<char*>(recv_buf.get()) + peer * bytes_per_peer + offset,
+            sizeof(actual),
+            cudaMemcpyDeviceToHost));
+        char expected = static_cast<char>((peer * 10 + globalRank) & 0xff);
+        EXPECT_EQ(actual, expected)
+            << "Rank " << globalRank << ": mismatch receiving from peer "
+            << peer << " at sampled byte " << offset;
+      }
+    }
+  }
+
+  void run_alltoallv_tile_ib_test(
+      std::size_t bytes_per_peer,
+      int num_blocks_ib) {
+    MultiPeerTransportConfig config{
+        .nvlConfig =
+            {
+                .dataBufferSize = 8 * 1024 * 1024,
+                .chunkSize = 64 * 1024,
+                .pipelineDepth = 4,
+                .tile_max_groups = 32,
+            },
+        .ibgdaConfig =
+            {
+                .cudaDevice = localRank,
+                .dataBufferSize = 8 * 1024 * 1024,
+                .sendRecv =
+                    MultipeerIbgdaTransportConfig::SendRecvConfig{
+                        .maxGroups = 32,
+                        .pipelineDepth = 2,
+                    },
+                .numQpsPerPeerPerNic = 2,
+            },
+        .topoConfig =
+            {
+                .p2pDisable = true,
+            },
+    };
+    auto bootstrap_ptr = std::make_shared<MpiBootstrap>();
+    auto transport = std::make_unique<MultiPeerTransport>(
+        globalRank, numRanks, localRank, bootstrap_ptr, config);
+    transport->exchange();
+    auto handle = transport->get_device_handle();
+
+    const int nranks = numRanks;
+    const std::size_t total_send = bytes_per_peer * nranks;
+    const std::size_t total_recv = bytes_per_peer * nranks;
+
+    DeviceBuffer send_buf(total_send);
+    DeviceBuffer recv_buf(total_recv);
+
+    std::vector<char> h_send(total_send);
+    for (int peer = 0; peer < nranks; peer++) {
+      for (std::size_t i = 0; i < bytes_per_peer; i++) {
+        h_send[peer * bytes_per_peer + i] =
+            static_cast<char>((globalRank * 10 + peer + i) % 256);
+      }
+    }
+    CUDACHECK_TEST(cudaMemcpy(
+        send_buf.get(), h_send.data(), total_send, cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(cudaMemset(recv_buf.get(), 0, total_recv));
+
+    std::vector<char*> h_send_ptrs(nranks);
+    std::vector<char*> h_recv_ptrs(nranks);
+    std::vector<std::size_t> h_counts(nranks, bytes_per_peer);
+
+    for (int r = 0; r < nranks; r++) {
+      h_send_ptrs[r] = static_cast<char*>(send_buf.get()) + r * bytes_per_peer;
+      h_recv_ptrs[r] = static_cast<char*>(recv_buf.get()) + r * bytes_per_peer;
+    }
+
+    DeviceBuffer d_send_ptrs(nranks * sizeof(char*));
+    DeviceBuffer d_recv_ptrs(nranks * sizeof(char*));
+    DeviceBuffer d_counts(nranks * sizeof(std::size_t));
+
+    CUDACHECK_TEST(cudaMemcpy(
+        d_send_ptrs.get(),
+        h_send_ptrs.data(),
+        nranks * sizeof(char*),
+        cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(cudaMemcpy(
+        d_recv_ptrs.get(),
+        h_recv_ptrs.data(),
+        nranks * sizeof(char*),
+        cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(cudaMemcpy(
+        d_counts.get(),
+        h_counts.data(),
+        nranks * sizeof(std::size_t),
+        cudaMemcpyHostToDevice));
+
+    // IB-only: num_blocks_nvl=0
+    int total_blocks = 2 * num_blocks_ib;
+
+    AllToAllvTileArgs args{
+        .handle = handle,
+        .send_ptrs = static_cast<char**>(d_send_ptrs.get()),
+        .send_counts = static_cast<std::size_t*>(d_counts.get()),
+        .recv_ptrs = static_cast<char**>(d_recv_ptrs.get()),
+        .recv_counts = static_cast<std::size_t*>(d_counts.get()),
+        .num_blocks_nvl = 0,
+        .num_blocks_ib = num_blocks_ib,
+        .max_signal_bytes = 0,
+    };
+
+    int device = 0;
+    CUDACHECK_TEST(cudaGetDevice(&device));
+    Timeout timeout = makeTimeout(30000, device);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    dim3 clus(comms::common::kDefaultClusterSize, 1, 1);
+    void* kernel_args[] = {&args, &timeout};
+    comms::common::launchKernel(
+        (void*)alltoallv_tile_1d_kernel,
+        dim3(total_blocks),
+        dim3(512),
+        kernel_args,
+        nullptr,
+        clus);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    std::vector<char> h_recv(total_recv);
+    CUDACHECK_TEST(cudaMemcpy(
+        h_recv.data(), recv_buf.get(), total_recv, cudaMemcpyDeviceToHost));
+
+    for (int peer = 0; peer < nranks; peer++) {
+      for (std::size_t i = 0; i < bytes_per_peer; i++) {
+        char expected = static_cast<char>((peer * 10 + globalRank + i) % 256);
+        char actual = h_recv[peer * bytes_per_peer + i];
+        EXPECT_EQ(actual, expected)
+            << "Rank " << globalRank << ": mismatch receiving from peer "
+            << peer << " at byte " << i << " (expected "
+            << static_cast<int>(expected) << ", got "
+            << static_cast<int>(actual) << ")";
+        if (actual != expected) {
+          return;
+        }
+      }
+    }
+  }
+};
+
+// ============================================================================
+// NVL tests
+// ============================================================================
+
+TEST_F(AllToAllvTileTestFixture, Small) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "Requires >= 2 ranks";
+  }
+  run_alltoallv_tile_test(4096, 4);
+}
+
+TEST_F(AllToAllvTileTestFixture, Medium) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "Requires >= 2 ranks";
+  }
+  run_alltoallv_tile_test(256 * 1024, 8);
+}
+
+TEST_F(AllToAllvTileTestFixture, Large) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "Requires >= 2 ranks";
+  }
+  run_alltoallv_tile_test(4 * 1024 * 1024, 16);
+}
+
+TEST_F(AllToAllvTileTestFixture, WithSignalBytes) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "Requires >= 2 ranks";
+  }
+  run_alltoallv_tile_test(1024 * 1024, 8, 64 * 1024);
+}
+
+// ============================================================================
+// NVL: blocks > peers (16 blocks, 7 peers → 2+ blocks per peer)
+// ============================================================================
+
+TEST_F(AllToAllvTileTestFixture, NvlBlocksGreaterThanPeers) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "Requires >= 2 ranks";
+  }
+  run_alltoallv_tile_test(256 * 1024, 16);
+}
+
+// ============================================================================
+// NVL: blocks < peers (2 blocks, 7 peers → each block handles ~4 peers)
+// ============================================================================
+
+TEST_F(AllToAllvTileTestFixture, NvlBlocksLessThanPeers) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "Requires >= 2 ranks";
+  }
+  run_alltoallv_tile_test(256 * 1024, 2);
+}
+
+TEST_F(AllToAllvTileTestFixture, NvlOneGbPerPeerSmoke) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "Requires >= 2 ranks";
+  }
+  run_alltoallv_tile_large_smoke_test(1024UL * 1024 * 1024, 32);
+}
+
+// ============================================================================
+// IB tests (p2pDisable forces all peers to IBGDA)
+// ============================================================================
+
+// IB: blocks > peers (14 blocks, 7 IB peers → 2 blocks per peer)
+TEST_F(AllToAllvTileTestFixture, IbBlocksGreaterThanPeers) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "Requires >= 2 ranks";
+  }
+  run_alltoallv_tile_ib_test(256 * 1024, 14);
+}
+
+// IB: blocks == peers (7 blocks, 7 IB peers → 1 block per peer)
+TEST_F(AllToAllvTileTestFixture, IbBlocksEqualPeers) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "Requires >= 2 ranks";
+  }
+  run_alltoallv_tile_ib_test(256 * 1024, numRanks - 1);
+}
+
+// IB: blocks < peers (2 blocks, 7 IB peers → each block handles ~4 peers)
+TEST_F(AllToAllvTileTestFixture, IbBlocksLessThanPeers) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "Requires >= 2 ranks";
+  }
+  run_alltoallv_tile_ib_test(256 * 1024, 2);
+}
+
+TEST_F(AllToAllvTileTestFixture, IbOneGbPerPeerSmoke) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "Requires >= 2 ranks";
+  }
+  run_alltoallv_tile_large_smoke_test(1024UL * 1024 * 1024, 8, true);
+}
+
+} // namespace comms::pipes::tests
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new MPIEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Summary:
Tile-based AllToAllv using the send()/recv() tile protocol with MultiPeerDeviceHandle for NVLink/IB transport dispatch.

Two unified kernels cover all transport combinations:
- `alltoallv_tile_1d_kernel`: NVL 1D sequential + IB parallel (best for large NVL messages)
- `alltoallv_tile_2d_kernel`: NVL 2D interleaved + IB parallel (best for small NVL messages)

Both share `alltoallv_tile_impl<NvlParallel>` which uses `ThreadGroup::split()` to partition blocks between NVL and IB, and `if constexpr` to select the NVL strategy at compile time (zero register overhead).

Set `num_blocks_nvl=0` for IB-only, `num_blocks_ib=0` for NVL-only, or both nonzero for mixed operation.

Also adds `allGatherNvlDomain` to `TcpStoreBootstrap` so `MultiPeerTransport` works in MAST/torchx environments without MPI.

## NVL Benchmark (8x H100, clustered launch, 56 blocks)

```
Per-Peer          NCCL       Tile-1D       Tile-2D  Best          vs NCCL
--------    ----------  ------------  ------------  ------------ --------
8KB               1.10      1.3 (56)      4.8 (56)  tile_2d         4.35x
32KB             11.50      5.3 (56)     18.1 (56)  tile_2d         1.57x
128KB            46.06     19.9 (56)     61.1 (56)  tile_2d         1.33x
512KB            90.34     68.2 (56)    130.1 (56)  tile_2d         1.44x
1MB             171.88    108.8 (56)    160.2 (56)  tile_2d         0.93x
4MB             220.67    203.4 (56)    195.4 (56)  tile_1d         0.92x
16MB            262.33    275.8 (56)    255.6 (56)  tile_1d         1.05x
64MB            279.18    310.5 (56)    299.7 (56)  tile_1d         1.11x
256MB           340.93    321.1 (56)    320.2 (56)  tile_1d         0.94x
1GB             343.79    322.5 (56)    308.4 (56)  tile_1d         0.94x
```

## IB Benchmark (8x H100, NCCL_P2P_DISABLE=1, single-node loopback)

```
Per-Peer       NCCL-IB     1blk/peer     2blk/peer  Best        vs NCCL
--------    ----------  ------------  ------------  ---------- --------
8KB               0.72      1.7 (14)      1.7 (28)  1blk/peer     2.36x
16KB              1.40      3.2 (14)      3.2 (28)  1blk/peer     2.29x
32KB              2.83      5.6 (14)      5.8 (28)  2blk/peer     2.05x
64KB              5.29      9.5 (14)      9.7 (28)  2blk/peer     1.83x
128KB             9.98     15.0 (14)     15.4 (28)  2blk/peer     1.55x
256KB            14.65     21.4 (14)     22.5 (28)  2blk/peer     1.54x
512KB            23.70     27.2 (14)     29.2 (28)  2blk/peer     1.23x
1MB              28.70     31.1 (14)     34.4 (28)  2blk/peer     1.20x
2MB              36.14     33.8 (14)     37.3 (28)  2blk/peer     1.03x
4MB              41.21     35.2 (14)     39.2 (28)  2blk/peer     0.95x
8MB              44.26     36.2 (14)     40.4 (28)  2blk/peer     0.91x
16MB             46.17     40.9 (14)     43.5 (28)  2blk/peer     0.94x
32MB             47.26     41.3 (14)     22.3 (28)  1blk/peer     0.87x
64MB             47.83     43.7 (14)     32.0 (28)  1blk/peer     0.91x
128MB            48.08     44.9 (14)     42.0 (28)  1blk/peer     0.93x
256MB            48.25     45.5 (14)     45.2 (28)  1blk/peer     0.94x
512MB            48.29     45.8 (14)     46.0 (28)  2blk/peer     0.95x
1GB              48.28     46.1 (14)     46.2 (28)  2blk/peer     0.96x
```

IB numbers are from single-node loopback. Pipes beats NCCL-IB at small sizes (up to 2.36x) and approaches parity at large sizes (~0.96x).

Reviewed By: goelayu

Differential Revision: D102230279
