### PR TITLE
Revert code deletion

### DIFF
--- a/comms/torchcomms/tests/integration/py/AllGatherSingleTest.py
+++ b/comms/torchcomms/tests/integration/py/AllGatherSingleTest.py
@@ -293,5 +293,6 @@ class AllGatherSingleTest(unittest.TestCase):
             with self.subTest(count=count, dtype=dtype):
                 self._graph_all_gather_single_input_deleted(count, dtype)
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/comms/torchcomms/tests/integration/py/AllGatherSingleTest.py
+++ b/comms/torchcomms/tests/integration/py/AllGatherSingleTest.py
@@ -292,3 +292,6 @@ class AllGatherSingleTest(unittest.TestCase):
         for count, dtype in itertools.product(self.counts, self.dtypes):
             with self.subTest(count=count, dtype=dtype):
                 self._graph_all_gather_single_input_deleted(count, dtype)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR reverts this [commit](https://github.com/meta-pytorch/torchcomms/commit/25f6782638848bdb8bab4119c96d5da4ab82f302). This currently causes `AllGatherSingleTest` to be skipped.