### PR TITLE
Abort: comm-level default per-op timeout

### DIFF
--- a/comms/ctran/utils/Abort.h
+++ b/comms/ctran/utils/Abort.h
@@ -5,6 +5,7 @@
 #include <atomic>
 #include <chrono>
 #include <memory>
+#include <optional>
 
 namespace ctran::utils {
 
@@ -106,6 +107,30 @@ class Abort final {
     hasTimeout_.store(false, std::memory_order_release);
   }
 
+  // Stores a duration; GPE applies it as a per-iteration deadline when no
+  // per-op timeout is supplied. Safe to update concurrently.
+  inline void SetDefaultTimeoutDuration(std::chrono::milliseconds duration) {
+    if (!enabled_) {
+      return;
+    }
+
+    defaultTimeoutDurationMs_.store(
+        duration.count(), std::memory_order_release);
+  }
+
+  inline std::optional<std::chrono::milliseconds> GetDefaultTimeoutDuration()
+      const {
+    if (!enabled_) {
+      return std::nullopt;
+    }
+
+    auto v = defaultTimeoutDurationMs_.load(std::memory_order_acquire);
+    if (v < 0) {
+      return std::nullopt;
+    }
+    return std::chrono::milliseconds{v};
+  }
+
  private:
   const bool enabled_;
 
@@ -114,10 +139,13 @@ class Abort final {
   std::atomic<bool> timedOut_{false};
   std::atomic<std::chrono::steady_clock::time_point> timeoutTime_{
       std::chrono::steady_clock::time_point{}};
+  // -1 = unset.
+  std::atomic<int64_t> defaultTimeoutDurationMs_{-1};
 
   static_assert(std::atomic<bool>::is_always_lock_free);
   static_assert(
       std::atomic<std::chrono::steady_clock::time_point>::is_always_lock_free);
+  static_assert(std::atomic<int64_t>::is_always_lock_free);
 };
 
 std::shared_ptr<Abort> createAbort(bool enabled);

--- a/comms/ctran/utils/tests/AbortUT.cc
+++ b/comms/ctran/utils/tests/AbortUT.cc
@@ -1,6 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include <chrono>
+#include <optional>
 #include <thread>
 
 #include <gmock/gmock.h>
@@ -459,6 +460,31 @@ TEST(AbortTest, timeRemainingAfterCancel) {
   abort.SetTimeout(std::chrono::milliseconds(1000));
   abort.CancelTimeout();
   EXPECT_EQ(abort.TimeRemaining(), std::chrono::milliseconds{-1});
+}
+
+TEST(AbortTest, defaultTimeoutInitiallyUnset) {
+  Abort abort{/*enabled=*/true};
+  EXPECT_EQ(abort.GetDefaultTimeoutDuration(), std::nullopt);
+}
+
+TEST(AbortTest, defaultTimeoutSetAndGet) {
+  Abort abort{/*enabled=*/true};
+  constexpr std::chrono::milliseconds kDuration{750};
+  abort.SetDefaultTimeoutDuration(kDuration);
+  EXPECT_EQ(abort.GetDefaultTimeoutDuration(), kDuration);
+}
+
+TEST(AbortTest, defaultTimeoutMutable) {
+  Abort abort{/*enabled=*/true};
+  abort.SetDefaultTimeoutDuration(std::chrono::milliseconds(100));
+  abort.SetDefaultTimeoutDuration(std::chrono::milliseconds(5000));
+  EXPECT_EQ(abort.GetDefaultTimeoutDuration(), std::chrono::milliseconds(5000));
+}
+
+TEST(AbortTest, defaultTimeoutDisabledSetterNoop) {
+  Abort abort{/*enabled=*/false};
+  abort.SetDefaultTimeoutDuration(std::chrono::milliseconds(1000));
+  EXPECT_EQ(abort.GetDefaultTimeoutDuration(), std::nullopt);
 }
 
 } // namespace ctran::testing


### PR DESCRIPTION
Summary:
Adds a comm-level mutable timeout duration on `Abort`. Stored as `std::atomic<int64_t>` (sentinel `-1` = unset), accessed via `SetDefaultTimeoutDuration(ms)` / `GetDefaultTimeoutDuration() -> std::optional<ms>`. Setter is a no-op and getter returns `std::nullopt` when `enabled_ == false`, matching the `SetTimeout` / `HasTimeout` precedent. The atomic is `int64_t` (not `chrono::milliseconds` directly) to keep `is_always_lock_free` across all targets.

This is a leaf API only; the GPE worker fallback that consumes it, the `IComm` / `McclComm` overrides, the `TorchCommMCCL` exposure, and the PAFT Python wrapper ship in follow-up diffs so the API and its unit-test surface land independent of the integration.

Reviewed By: saifhhasan, Scusemua, arttianezhu

Differential Revision: D102653041


