### PR TITLE
Expose default-timeout in ctran GPE + IComm/McclComm (#2285)

### DIFF
--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -721,6 +721,10 @@ void CtranGpe::Impl::gpeThreadFn() {
 
       if (cmd->timeout.has_value()) {
         comm->setTimeout(cmd->timeout.value());
+      } else if (auto d = comm->getAbort()->GetDefaultTimeoutDuration();
+                 d.has_value()) {
+        // Fall back to comm-level default (CUDA-graph replay path).
+        comm->setTimeout(*d);
       }
       SCOPE_EXIT {
         // if comm is aborted for any reason, we mark it as aborted to avoid

--- a/comms/ctran/gpe/tests/CtranGpeFaultToleranceUT.cc
+++ b/comms/ctran/gpe/tests/CtranGpeFaultToleranceUT.cc
@@ -467,6 +467,46 @@ TEST_P(CtranGpeFTEnabledAbortTest, HostActiveAbort) {
   EXPECT_TRUE(ctranComm->testAbort());
 }
 
+// Submit with no per-op timeout; comm-level default fires the abort.
+TEST_P(CtranGpeFTEnabledAbortTest, HostDetectedTimeoutFromDefault) {
+  auto [name, kernelFn] = GetParam();
+
+  ASSERT_TRUE(ctranComm->abortEnabled());
+  FtTestSync sync;
+  sync.setTimeout();
+  ctranComm->getAbort()->SetDefaultTimeoutDuration(
+      kHostAlgoFnWait - std::chrono::milliseconds(500));
+  runTestWillAbort(
+      kernelFn,
+      stream,
+      &sync,
+      /*activeAbort=*/false,
+      /*statusCheckDelay=*/kHostAlgoFnWait + std::chrono::milliseconds(1000),
+      /*timeout=*/std::nullopt);
+  EXPECT_TRUE(ctranComm->testAbort());
+}
+
+// Per-op timeout wins when both per-op and comm-level default are set.
+// The default is set far longer than the test window; abort within window
+// proves the per-op value was used.
+TEST_P(CtranGpeFTEnabledAbortTest, HostDetectedTimeoutPerOpOverridesDefault) {
+  auto [name, kernelFn] = GetParam();
+
+  ASSERT_TRUE(ctranComm->abortEnabled());
+  FtTestSync sync;
+  sync.setTimeout();
+  ctranComm->getAbort()->SetDefaultTimeoutDuration(
+      kHostAlgoFnWait + std::chrono::milliseconds(5000));
+  runTestWillAbort(
+      kernelFn,
+      stream,
+      &sync,
+      /*activeAbort=*/false,
+      /*statusCheckDelay=*/kHostAlgoFnWait + std::chrono::milliseconds(1000),
+      /*timeout=*/kHostAlgoFnWait - std::chrono::milliseconds(500));
+  EXPECT_TRUE(ctranComm->testAbort());
+}
+
 INSTANTIATE_TEST_SUITE_P(
     CtranGpeFTEnabledAbortTest,
     CtranGpeFTEnabledAbortTest,

--- a/comms/ctran/utils/Abort.h
+++ b/comms/ctran/utils/Abort.h
@@ -5,6 +5,7 @@
 #include <atomic>
 #include <chrono>
 #include <memory>
+#include <optional>
 
 namespace ctran::utils {
 
@@ -106,6 +107,30 @@ class Abort final {
     hasTimeout_.store(false, std::memory_order_release);
   }
 
+  // Stores a duration; GPE applies it as a per-iteration deadline when no
+  // per-op timeout is supplied. Safe to update concurrently.
+  inline void SetDefaultTimeoutDuration(std::chrono::milliseconds duration) {
+    if (!enabled_) {
+      return;
+    }
+
+    defaultTimeoutDurationMs_.store(
+        duration.count(), std::memory_order_release);
+  }
+
+  inline std::optional<std::chrono::milliseconds> GetDefaultTimeoutDuration()
+      const {
+    if (!enabled_) {
+      return std::nullopt;
+    }
+
+    auto v = defaultTimeoutDurationMs_.load(std::memory_order_acquire);
+    if (v < 0) {
+      return std::nullopt;
+    }
+    return std::chrono::milliseconds{v};
+  }
+
  private:
   const bool enabled_;
 
@@ -114,10 +139,13 @@ class Abort final {
   std::atomic<bool> timedOut_{false};
   std::atomic<std::chrono::steady_clock::time_point> timeoutTime_{
       std::chrono::steady_clock::time_point{}};
+  // -1 = unset.
+  std::atomic<int64_t> defaultTimeoutDurationMs_{-1};
 
   static_assert(std::atomic<bool>::is_always_lock_free);
   static_assert(
       std::atomic<std::chrono::steady_clock::time_point>::is_always_lock_free);
+  static_assert(std::atomic<int64_t>::is_always_lock_free);
 };
 
 std::shared_ptr<Abort> createAbort(bool enabled);

--- a/comms/ctran/utils/tests/AbortUT.cc
+++ b/comms/ctran/utils/tests/AbortUT.cc
@@ -1,6 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include <chrono>
+#include <optional>
 #include <thread>
 
 #include <gmock/gmock.h>
@@ -459,6 +460,31 @@ TEST(AbortTest, timeRemainingAfterCancel) {
   abort.SetTimeout(std::chrono::milliseconds(1000));
   abort.CancelTimeout();
   EXPECT_EQ(abort.TimeRemaining(), std::chrono::milliseconds{-1});
+}
+
+TEST(AbortTest, defaultTimeoutInitiallyUnset) {
+  Abort abort{/*enabled=*/true};
+  EXPECT_EQ(abort.GetDefaultTimeoutDuration(), std::nullopt);
+}
+
+TEST(AbortTest, defaultTimeoutSetAndGet) {
+  Abort abort{/*enabled=*/true};
+  constexpr std::chrono::milliseconds kDuration{750};
+  abort.SetDefaultTimeoutDuration(kDuration);
+  EXPECT_EQ(abort.GetDefaultTimeoutDuration(), kDuration);
+}
+
+TEST(AbortTest, defaultTimeoutMutable) {
+  Abort abort{/*enabled=*/true};
+  abort.SetDefaultTimeoutDuration(std::chrono::milliseconds(100));
+  abort.SetDefaultTimeoutDuration(std::chrono::milliseconds(5000));
+  EXPECT_EQ(abort.GetDefaultTimeoutDuration(), std::chrono::milliseconds(5000));
+}
+
+TEST(AbortTest, defaultTimeoutDisabledSetterNoop) {
+  Abort abort{/*enabled=*/false};
+  abort.SetDefaultTimeoutDuration(std::chrono::milliseconds(1000));
+  EXPECT_EQ(abort.GetDefaultTimeoutDuration(), std::nullopt);
 }
 
 } // namespace ctran::testing


### PR DESCRIPTION
Summary:

Wires the `Abort::SetDefaultTimeoutDuration` / `GetDefaultTimeoutDuration` API (added in the parent diff) into the layers that drive collectives, so an upper layer can update the per-op timeout from CPU between CUDA-graph replays without recapturing.

- `CtranGpe::Impl::gpeThreadFn` falls back to `comm->getAbort()->GetDefaultTimeoutDuration()` at the start of each iteration when `cmd->timeout` is `nullopt`. This is the path captured replays go through (the captured host node has a fixed `cmd->timeout = nullopt`, so the GPE worker re-reads the comm-level value at every iteration).
- `IComm` gets virtual `setDefaultTimeoutDuration(chrono::ms)` / `getDefaultTimeoutDuration() -> optional<ms>`. `McclComm` overrides forward directly to its own `abort_` shared_ptr — no `CtranComm` passthrough needed.
- `MockMcclComm` gets matching `MOCK_METHOD` stubs.

Per-call `cmd->timeout` continues to take precedence; if neither is set, no timeout (current behavior).

`TorchCommMCCL` exposure and PAFT Python wrapper ship in the next diff.

Reviewed By: arttianezhu, saifhhasan

Differential Revision: D102662114


