### PR TITLE
Fix OptionsTest deadlock in multi-node configurations (#2287)

### DIFF
--- a/comms/torchcomms/tests/integration/cpp/OptionsTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/OptionsTest.cpp
@@ -65,6 +65,7 @@ class OptionsTest : public ::testing::Test {
   void TearDown() override {
     // Explicitly reset the TorchComm object to ensure proper cleanup
     if (torchcomm_) {
+      torchcomm_->barrier(false)->wait();
       torchcomm_.reset();
     }
     if (wrapper_) {


### PR DESCRIPTION
Summary:

The `OptionsTest` integration test deadlocks in 2x8 (2-node, 16-rank) configurations. Each `TEST_F` creates and destroys its own NCCL communicator, but ranks proceed through the test lifecycle at different speeds. Fast ranks destroy their communicator in `TearDown` while slow ranks are still executing the test body, causing pending NCCL p2p operations to hang because the peer communicator no longer exists. This cascades into a permanent deadlock across all ranks.

Adding a barrier before communicator destruction ensures all ranks complete the current test's operations before any rank tears down its communicator.

Reviewed By: zhiyongww

Differential Revision: D102643622


