### PR TITLE
Make torchcomms backend availability reflect the build config

### DIFF
--- a/comms/torchcomms/__init__.py
+++ b/comms/torchcomms/__init__.py
@@ -94,4 +94,5 @@ def is_backend_built(backend: str) -> bool:
 
 
 def built_backends() -> list[str]:
+    """Names of all backends the wheel was built with."""
     return [ep.name for ep in entry_points(group="torchcomms.backends")]

--- a/comms/torchcomms/__init__.py
+++ b/comms/torchcomms/__init__.py
@@ -86,3 +86,12 @@ def _load_backend(backend: str) -> None:
         )
     wheel = next(iter(found))
     wheel.load()
+
+
+def is_backend_built(backend: str) -> bool:
+    """True if the wheel was built with this backend's extension."""
+    return bool(entry_points(group="torchcomms.backends", name=backend))
+
+
+def built_backends() -> list[str]:
+    return [ep.name for ep in entry_points(group="torchcomms.backends")]

--- a/setup.py
+++ b/setup.py
@@ -155,52 +155,25 @@ extras_require = {
     ],
 }
 
-ext_modules = [
-    CMakeExtension("torchcomms._comms"),
+BACKEND_FLAGS = [
+    ("nccl", USE_NCCL),
+    ("ncclx", USE_NCCLX),
+    ("gloo", USE_GLOO),
+    ("rccl", USE_RCCL),
+    ("rcclx", USE_RCCLX),
+    ("xccl", USE_XCCL),
 ]
 
-if USE_NCCL:
-    ext_modules += [
-        CMakeExtension("torchcomms._comms_nccl"),
-    ]
-if USE_NCCLX:
-    ext_modules += [
-        CMakeExtension("torchcomms._comms_ncclx"),
-    ]
-if USE_GLOO:
-    ext_modules += [
-        CMakeExtension("torchcomms._comms_gloo"),
-    ]
-if USE_RCCL:
-    ext_modules += [
-        CMakeExtension("torchcomms._comms_rccl"),
-    ]
-if USE_RCCLX:
-    ext_modules += [
-        CMakeExtension("torchcomms._comms_rcclx"),
-    ]
-if USE_XCCL:
-    ext_modules += [
-        CMakeExtension("torchcomms._comms_xccl"),
-    ]
+ext_modules = [CMakeExtension("torchcomms._comms")]
+ext_modules += [
+    CMakeExtension(f"torchcomms._comms_{name}") for name, enabled in BACKEND_FLAGS if enabled
+]
 if USE_TRANSPORT:
-    ext_modules += [
-        CMakeExtension("torchcomms._transport"),
-    ]
+    ext_modules.append(CMakeExtension("torchcomms._transport"))
 
-backend_entry_points = ["dummy = torchcomms._comms"]
-if USE_NCCL:
-    backend_entry_points.append("nccl = torchcomms._comms_nccl")
-if USE_NCCLX:
-    backend_entry_points.append("ncclx = torchcomms._comms_ncclx")
-if USE_GLOO:
-    backend_entry_points.append("gloo = torchcomms._comms_gloo")
-if USE_RCCL:
-    backend_entry_points.append("rccl = torchcomms._comms_rccl")
-if USE_RCCLX:
-    backend_entry_points.append("rcclx = torchcomms._comms_rcclx")
-if USE_XCCL:
-    backend_entry_points.append("xccl = torchcomms._comms_xccl")
+backend_entry_points = ["dummy = torchcomms._comms"] + [
+    f"{name} = torchcomms._comms_{name}" for name, enabled in BACKEND_FLAGS if enabled
+]
 
 setup(
     name="torchcomms",

--- a/setup.py
+++ b/setup.py
@@ -188,6 +188,20 @@ if USE_TRANSPORT:
         CMakeExtension("torchcomms._transport"),
     ]
 
+backend_entry_points = ["dummy = torchcomms._comms"]
+if USE_NCCL:
+    backend_entry_points.append("nccl = torchcomms._comms_nccl")
+if USE_NCCLX:
+    backend_entry_points.append("ncclx = torchcomms._comms_ncclx")
+if USE_GLOO:
+    backend_entry_points.append("gloo = torchcomms._comms_gloo")
+if USE_RCCL:
+    backend_entry_points.append("rccl = torchcomms._comms_rccl")
+if USE_RCCLX:
+    backend_entry_points.append("rcclx = torchcomms._comms_rcclx")
+if USE_XCCL:
+    backend_entry_points.append("xccl = torchcomms._comms_xccl")
+
 setup(
     name="torchcomms",
     version=get_version(),
@@ -197,15 +211,7 @@ setup(
         "torchcomms.triton.fb": ["*.bc"],
     },
     entry_points={
-        "torchcomms.backends": [
-            "nccl = torchcomms._comms_nccl",
-            "ncclx = torchcomms._comms_ncclx",
-            "gloo = torchcomms._comms_gloo",
-            "rccl = torchcomms._comms_rccl",
-            "rcclx = torchcomms._comms_rcclx",
-            "xccl = torchcomms._comms_xccl",
-            "dummy = torchcomms._comms",
-        ]
+        "torchcomms.backends": backend_entry_points,
     },
     ext_modules=ext_modules,
     cmdclass={"build_ext": build_ext},


### PR DESCRIPTION
Previously `setup.py` registered entry points for every backend unconditionally, so a wheel built with `USE_NCCL=OFF` still had an `nccl` entry point that failed at dlopen time with a confusing `ModuleNotFoundError`. Entry points now mirror the same USE_* flags that gate ext_modules, so the wheel's metadata is an accurate source for which backends were built in.

Add also  two helpers in torchcomms:
- `is_backend_built(backend)`: True iff the wheel was built with the backend's extension.
- `built_backends()`: list of all built-in backend names.

Both read entry-point metadata only, so callers can check backend availability without triggering dlopen or C++ static initializers.