### PR TITLE
Add ctgraph_rdpipeline AllGather algo for cudagraph capture

### DIFF
--- a/comms/ctran/algos/AllGather/AllGather.cc
+++ b/comms/ctran/algos/AllGather/AllGather.cc
@@ -12,6 +12,7 @@ static bool isGraphAwareAlgo(enum NCCL_ALLGATHER_ALGO algo) {
   switch (algo) {
     case NCCL_ALLGATHER_ALGO::ctgraph:
     case NCCL_ALLGATHER_ALGO::ctgraph_pipeline:
+    case NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline:
     case NCCL_ALLGATHER_ALGO::ctgraph_ring:
     case NCCL_ALLGATHER_ALGO::ctgraph_rd:
       return true;
@@ -58,6 +59,7 @@ bool ctranAllGatherSupport(
       break;
     case NCCL_ALLGATHER_ALGO::ctgraph:
     case NCCL_ALLGATHER_ALGO::ctgraph_pipeline:
+    case NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline:
     case NCCL_ALLGATHER_ALGO::ctgraph_ring:
     case NCCL_ALLGATHER_ALGO::ctgraph_rd: {
       // Check stream capture status

--- a/comms/ctran/algos/AllGather/AllGatherCudagraphAware.cc
+++ b/comms/ctran/algos/AllGather/AllGatherCudagraphAware.cc
@@ -116,6 +116,7 @@ commResult_t ctranAllGatherCudagraphAware(
 
   switch (algo) {
     case NCCL_ALLGATHER_ALGO::ctgraph_pipeline:
+    case NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline:
       FB_COMMCHECK(
           winPersistBuffReg(recvbuff, recvBytes, comm, stream, &win, &request));
       break;
@@ -134,6 +135,7 @@ commResult_t ctranAllGatherCudagraphAware(
   std::function<void()> cleanup;
   switch (algo) {
     case NCCL_ALLGATHER_ALGO::ctgraph_pipeline:
+    case NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline:
       cleanup = [request, win]() {
         if (request) {
           ctran::allGatherWinDestroy(request);
@@ -163,9 +165,12 @@ commResult_t ctranAllGatherCudagraphAware(
 
   // Execute (captured into graph)
   switch (algo) {
-    case NCCL_ALLGATHER_ALGO::ctgraph_pipeline: {
+    case NCCL_ALLGATHER_ALGO::ctgraph_pipeline:
+    case NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline: {
       auto savedPAlgo = NCCL_ALLGATHER_P_ALGO;
-      NCCL_ALLGATHER_P_ALGO = NCCL_ALLGATHER_P_ALGO::ctpipeline;
+      NCCL_ALLGATHER_P_ALGO = (algo == NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline)
+          ? NCCL_ALLGATHER_P_ALGO::ctrdpipeline
+          : NCCL_ALLGATHER_P_ALGO::ctpipeline;
       auto pAlgoGuard = folly::makeGuard(
           [savedPAlgo]() { NCCL_ALLGATHER_P_ALGO = savedPAlgo; });
       FB_COMMCHECK(

--- a/comms/ctran/algos/AllGather/AllGatherImpl.h
+++ b/comms/ctran/algos/AllGather/AllGatherImpl.h
@@ -57,6 +57,8 @@ static inline const std::string allGatherAlgoName(
       return "CtranCudagraphAware";
     case NCCL_ALLGATHER_ALGO::ctgraph_pipeline:
       return "CtranCudagraphPipeline";
+    case NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline:
+      return "CtranCudagraphRdPipeline";
     case NCCL_ALLGATHER_ALGO::ctgraph_ring:
       return "CtranCudagraphRing";
     case NCCL_ALLGATHER_ALGO::ctgraph_rd:

--- a/comms/ctran/algos/AllGather/tests/AllGatherCtgraphSupportTest.cc
+++ b/comms/ctran/algos/AllGather/tests/AllGatherCtgraphSupportTest.cc
@@ -26,6 +26,8 @@ TEST_F(AllGatherCtgraphSupportTest, NullStream) {
   EXPECT_FALSE(ctranAllGatherSupport(
       comm_.get(), NCCL_ALLGATHER_ALGO::ctgraph_pipeline, nullptr));
   EXPECT_FALSE(ctranAllGatherSupport(
+      comm_.get(), NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline, nullptr));
+  EXPECT_FALSE(ctranAllGatherSupport(
       comm_.get(), NCCL_ALLGATHER_ALGO::ctgraph_ring, nullptr));
   EXPECT_FALSE(ctranAllGatherSupport(
       comm_.get(), NCCL_ALLGATHER_ALGO::ctgraph_rd, nullptr));

--- a/comms/ctran/algos/CtranAlgo.cc
+++ b/comms/ctran/algos/CtranAlgo.cc
@@ -633,6 +633,7 @@ static const std::unordered_map<std::string, enum NCCL_ALLGATHER_ALGO>
         {"ctbrucks", NCCL_ALLGATHER_ALGO::ctbrucks},
         {"ctgraph", NCCL_ALLGATHER_ALGO::ctgraph},
         {"ctgraph_pipeline", NCCL_ALLGATHER_ALGO::ctgraph_pipeline},
+        {"ctgraph_rdpipeline", NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline},
         {"ctgraph_ring", NCCL_ALLGATHER_ALGO::ctgraph_ring},
         {"ctgraph_rd", NCCL_ALLGATHER_ALGO::ctgraph_rd}};
 

--- a/comms/ctran/tests/cudagraph/CtranCudaGraphAllGatherCtgraphTest.cc
+++ b/comms/ctran/tests/cudagraph/CtranCudaGraphAllGatherCtgraphTest.cc
@@ -1,9 +1,9 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 // Tests for the ctgraph AllGather algorithm variants.
-// ctgraph auto-selects based on topology; ctgraph_pipeline, ctgraph_ring,
-// ctgraph_rd allow explicit selection. All variants are only active during
-// CUDA graph capture and fall back to baseline otherwise.
+// ctgraph auto-selects based on topology; ctgraph_pipeline, ctgraph_rdpipeline,
+// ctgraph_ring, ctgraph_rd allow explicit selection. All variants are only
+// active during CUDA graph capture and fall back to baseline otherwise.
 
 #include <random>
 
@@ -45,6 +45,12 @@ static AlgoDescriptor makeAllGatherCtgraph(
         statex->nLocalRanks() > 1) {
       return false;
     }
+    if (algo == NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline) {
+      const auto nNodes = statex->nNodes();
+      if (nNodes > 1 && (nNodes & (nNodes - 1)) != 0) {
+        return false;
+      }
+    }
     return true;
   };
   desc.expectsHostNodes = [](CtranComm* comm, size_t) {
@@ -83,6 +89,7 @@ DEFINE_CUDAGRAPH_PARAM_TEST(
     CudaGraphAllGatherCtgraph,
     makeAllGatherCtgraph(),
     makeAllGatherCtgraph(NCCL_ALLGATHER_ALGO::ctgraph_pipeline),
+    makeAllGatherCtgraph(NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline),
     makeAllGatherCtgraph(NCCL_ALLGATHER_ALGO::ctgraph_ring),
     makeAllGatherCtgraph(NCCL_ALLGATHER_ALGO::ctgraph_rd));
 
@@ -114,6 +121,13 @@ TEST_P(CudaGraphAllGatherCtgraphExpandable, CaptureReplayVerify) {
        algo == NCCL_ALLGATHER_ALGO::ctgraph_rd) &&
       statex->nLocalRanks() > 1) {
     GTEST_SKIP() << allGatherAlgoName(algo) << " requires nLocalRanks == 1";
+  }
+  if (algo == NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline) {
+    const auto nNodes = statex->nNodes();
+    if (nNodes > 1 && (nNodes & (nNodes - 1)) != 0) {
+      GTEST_SKIP() << allGatherAlgoName(algo)
+                   << " requires nNodes to be a power of 2";
+    }
   }
 
   const int nRanks = numRanks;
@@ -178,6 +192,7 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::Values(
             NCCL_ALLGATHER_ALGO::ctgraph,
             NCCL_ALLGATHER_ALGO::ctgraph_pipeline,
+            NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline,
             NCCL_ALLGATHER_ALGO::ctgraph_ring,
             NCCL_ALLGATHER_ALGO::ctgraph_rd),
         ::testing::Values(2097152UL, 10485760UL)),

--- a/comms/ncclx/meta/algoconf/AlgoConfig.cc
+++ b/comms/ncclx/meta/algoconf/AlgoConfig.cc
@@ -56,6 +56,8 @@ inline const std::string algoValToStr(enum NCCL_ALLGATHER_ALGO val) {
       return "ctgraph";
     case NCCL_ALLGATHER_ALGO::ctgraph_pipeline:
       return "ctgraph_pipeline";
+    case NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline:
+      return "ctgraph_rdpipeline";
     case NCCL_ALLGATHER_ALGO::ctgraph_ring:
       return "ctgraph_ring";
     case NCCL_ALLGATHER_ALGO::ctgraph_rd:
@@ -81,6 +83,8 @@ inline void algoStrToVal(
     val = NCCL_ALLGATHER_ALGO::ctgraph;
   } else if (str == "ctgraph_pipeline") {
     val = NCCL_ALLGATHER_ALGO::ctgraph_pipeline;
+  } else if (str == "ctgraph_rdpipeline") {
+    val = NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline;
   } else if (str == "ctgraph_ring") {
     val = NCCL_ALLGATHER_ALGO::ctgraph_ring;
   } else if (str == "ctgraph_rd") {

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2018,7 +2018,7 @@ cvars:
  - name        : NCCL_ALLGATHER_ALGO
    type        : enum
    default     : orig
-   choices     : orig, ctran, ctdirect, ctring, ctrd, ctbrucks, ctgraph, ctgraph_pipeline, ctgraph_ring, ctgraph_rd
+   choices     : orig, ctran, ctdirect, ctring, ctrd, ctbrucks, ctgraph, ctgraph_pipeline, ctgraph_rdpipeline, ctgraph_ring, ctgraph_rd
    description : |-
      The algorithm to use for Allgather communication
      orig - Copy-based ring algorithm
@@ -2028,6 +2028,7 @@ cvars:
      ctrd - Ctran-based recursive doubling algorithm
      ctgraph - Cudagraph-aware: auto-selects pipeline/ring/rd based on topology during graph capture
      ctgraph_pipeline - Cudagraph-aware: forces persistent pipeline algorithm (nLocalRanks>1)
+     ctgraph_rdpipeline - Cudagraph-aware: forces persistent recursive-doubling pipeline algorithm (nLocalRanks>1, nNodes power of 2)
      ctgraph_ring - Cudagraph-aware: forces ring algorithm (nLocalRanks==1, large messages)
      ctgraph_rd - Cudagraph-aware: forces recursive doubling algorithm (nLocalRanks==1, small messages)
 


### PR DESCRIPTION
Summary:
Add `ctgraph_rdpipeline` to `NCCL_ALLGATHER_ALGO` so users can opt into the persistent recursive-doubling pipeline algorithm under CUDA graph capture, parallel to how `ctgraph_pipeline` selects the persistent pipeline algorithm.

Previously the cudagraph-aware path forcibly overrode `NCCL_ALLGATHER_P_ALGO` to `ctpipeline` regardless of the user's setting, so `ctrdpipeline` was unreachable from the collective `ncclAllGather` call under graph capture (the only way to use it was via the explicit persistent `ncclxAllGatherInit/Exec` API). This change makes `NCCL_ALLGATHER_ALGO` authoritative — `ctgraph_pipeline` deterministically forces `ctpipeline` and `ctgraph_rdpipeline` deterministically forces `ctrdpipeline`, so the two algos are independently selectable without coordinating two cvars.

Both variants share the same window-based registration (`winPersistBuffReg`) and cleanup, so the only difference at the dispatch layer is which `NCCL_ALLGATHER_P_ALGO` value `allGatherWinExec` sees. `selectCtgraphAlgo` is unchanged and still picks `ctgraph_pipeline` for the auto path, since `ctrdpipeline` requires `nNodes` to be a power of 2 and is opt-in only.

Differential Revision: D102679647


