### PR TITLE
Add INIT logs for CommStateX topology setup

### DIFF
--- a/comms/ctran/commstate/CommStateX.cc
+++ b/comms/ctran/commstate/CommStateX.cc
@@ -129,8 +129,10 @@ void CommStateX::initRankStatesTopology(meta::comms::IBootstrap* bootstrap) {
     CLOGF_SUBSYS(
         INFO,
         INIT,
-        "load topology rank: {}, nRanks: {}, host: {}, dc: {} zone: {} rtsw: {} scaling unit: {} rackSerial: {}",
+        "Load topology for rank {} commHash {:x} commDesc {}, nRanks {}, host {}, dc {} zone {} rtsw {} scaling unit {} rackSerial {}",
         rank_,
+        commHash_,
+        commDesc_,
         nRanks_,
         myTopo->host,
         myTopo->dc,
@@ -153,6 +155,17 @@ void CommStateX::initRankStatesTopology(meta::comms::IBootstrap* bootstrap) {
 
   // Create statex variable
   setRankStatesTopologies(std::move(allTopos));
+
+  CLOGF_SUBSYS(
+      INFO,
+      INIT,
+      "Rank topology for rank {} commHash {:x} commDesc {}, nRanks {}, nLocalRanks {}, nNodes {}",
+      rank_,
+      commHash_,
+      commDesc_,
+      nRanks_,
+      nLocalRanks(),
+      nNodes());
 }
 
 void CommStateX::setNvlFabricTopos(
@@ -308,6 +321,28 @@ void CommStateX::setNvlFabricTopos(
         "CommStateX: effectiveVCliqueSize={} override NVL fabric topology",
         effectiveVCliqueSize);
   }
+
+  CLOGF_SUBSYS(
+      INFO,
+      INIT,
+      "NVL fabric topology for rank {} commHash {:x} commDesc {}, nRanks {}, nLocalRanks {}, nNodes {}, nvlFabricEnabled {}, nvlFabricCliqueEnabled {}, nvlDomainIndex {}, nvlDomainRank {}, nNvlDomainRanks {}, nNvlDomains {}, clusterId {}, cliqueIndex {}, cliqueRank {}, nCliqueRanks {}, nCliques {}",
+      rank_,
+      commHash_,
+      commDesc_,
+      nRanks_,
+      nLocalRanks(),
+      nNodes(),
+      nvlFabricEnabled_,
+      nvlFabricCliqueEnabled_,
+      myNvlFabricRankState_.nvlDomainIndex,
+      myNvlFabricRankState_.nvlDomainRank,
+      myNvlFabricRankState_.nNvlDomainRanks,
+      nvlDomainRanks_.size(),
+      myNvlFabricRankState_.clusterId,
+      myNvlFabricRankState_.cliqueIndex,
+      myNvlFabricRankState_.cliqueRank,
+      myNvlFabricRankState_.nCliqueRanks,
+      cliqueRanks_.size());
 }
 
 void CommStateX::setRankStatesTopologies(


### PR DESCRIPTION
Summary:
Add CLOGF_SUBSYS INIT logs to CommStateX for topology debugging:
- Log after loadTopology in initRankStatesTopology: rank, commHash, commDesc, host, dc, zone, rtsw, scaling unit, rackSerial
- Log after setRankStatesTopologies: rank, commHash, commDesc, nRanks, nLocalRanks, nNodes
- Log at end of setNvlFabricTopos: full NVL fabric topology details including nvlFabricEnabled, nvlFabricCliqueEnabled, nvlDomainIndex/Rank/nRanks, nNvlDomains, clusterId, cliqueIndex/Rank/nRanks, nCliques
- Print commHash in hex format ({:x})

Reviewed By: dsjohns2

Differential Revision: D102710770


