### PR TITLE
Add commHash/commDesc to cudagraph-aware and NVL backend logs

### DIFF
--- a/comms/ctran/algos/AllGather/AllGather.cc
+++ b/comms/ctran/algos/AllGather/AllGather.cc
@@ -75,8 +75,14 @@ bool ctranAllGatherSupport(
             INFO,
             COLL,
             "AllGather {}: not in capture mode. "
-            "Falling back to baseline",
-            allGatherAlgoName(algo));
+            "Falling back to baseline. "
+            "commHash {:x} commDesc {} nRanks {} nLocalRanks {} nNodes {}",
+            allGatherAlgoName(algo),
+            statex->commHash(),
+            statex->commDesc(),
+            statex->nRanks(),
+            statex->nLocalRanks(),
+            statex->nNodes());
         break;
       }
 

--- a/comms/ctran/algos/AllGather/AllGatherCudagraphAware.cc
+++ b/comms/ctran/algos/AllGather/AllGatherCudagraphAware.cc
@@ -102,13 +102,16 @@ commResult_t ctranAllGatherCudagraphAware(
   CLOGF_SUBSYS(
       INFO,
       COLL,
-      "AllGather cudagraph-aware: algo={} "
-      "(sendcount={}, nRanks={}, nLocalRanks={}, recvBytes={})",
+      "AllGather cudagraph-aware: algo {} "
+      "sendcount {} recvBytes {} commHash {:x} commDesc {} nRanks {} nLocalRanks {} nNodes {}",
       allGatherAlgoName(algo),
       sendcount,
+      recvBytes,
+      statex->commHash(),
+      statex->commDesc(),
       nRanks,
       statex->nLocalRanks(),
-      recvBytes);
+      statex->nNodes());
 
   // Buffer registration + cleanup guard
   ctran::CtranWin* win = nullptr;

--- a/comms/ctran/algos/SendRecv/SendRecv.cc
+++ b/comms/ctran/algos/SendRecv/SendRecv.cc
@@ -41,6 +41,7 @@ bool ctranSendRecvSupport(
   }
 
   if (algo == NCCL_SENDRECV_ALGO::ctgraph) {
+    // TODO: skip NVL peers for now; will add support based on window
     if (peer != statex->rank() &&
         comm->ctran_->mapper->getBackend(peer) != CtranMapperBackend::IB) {
       return false;
@@ -53,6 +54,18 @@ bool ctranSendRecvSupport(
         ctran::utils::cudagraph::getStreamCaptureInfo(stream, captureInfo);
     if (err != cudaSuccess ||
         captureInfo.status != cudaStreamCaptureStatusActive) {
+      CLOGF_SUBSYS(
+          INFO,
+          COLL,
+          "SendRecv ctgraph: not in capture mode. "
+          "Falling back to baseline. "
+          "commHash {:x} commDesc {} peer {} nRanks {} nLocalRanks {} nNodes {}",
+          statex->commHash(),
+          statex->commDesc(),
+          peer,
+          statex->nRanks(),
+          statex->nLocalRanks(),
+          statex->nNodes());
       return false;
     }
     return true;

--- a/comms/ctran/algos/SendRecv/SendRecvCudagraphAware.cc
+++ b/comms/ctran/algos/SendRecv/SendRecvCudagraphAware.cc
@@ -25,6 +25,18 @@ commResult_t ctranSendRecvCudagraphAware(
     cudaStream_t stream,
     std::optional<std::chrono::milliseconds> timeout) {
   // Caller (ctranGroupEndHook) already verified active capture mode.
+  const auto statex = comm->statex_.get();
+
+  CLOGF_SUBSYS(
+      INFO,
+      COLL,
+      "SendRecv cudagraph-aware: nOps {} commHash {:x} commDesc {} nRanks {} nLocalRanks {} nNodes {}",
+      opGroup.size(),
+      statex->commHash(),
+      statex->commDesc(),
+      statex->nRanks(),
+      statex->nLocalRanks(),
+      statex->nNodes());
 
   // Pre-register all send/recv buffers
   std::vector<std::pair<void*, size_t>> registeredBufs;

--- a/comms/ctran/backends/nvl/CtranNvl.cc
+++ b/comms/ctran/backends/nvl/CtranNvl.cc
@@ -92,10 +92,16 @@ CtranNvl::CtranNvl(CtranComm* comm) {
   CLOGF_SUBSYS(
       INFO,
       INIT,
-      "CTRAN-NVL: Initialized NVL backend on rank {} localRank {}, supported "
-      "intra-host peer ranks {}, supported NVL fabric ranks {}",
+      "CTRAN-NVL: Initialized NVL backend on rank {} localRank {}, "
+      "commHash {:x} commDesc {} nRanks {} nLocalRanks {} nNodes {}, "
+      "supported intra-host peer ranks {}, supported NVL fabric ranks {}",
       myRank,
       myLocalRank,
+      statex->commHash(),
+      statex->commDesc(),
+      statex->nRanks(),
+      statex->nLocalRanks(),
+      statex->nNodes(),
       vecToStr(supportedInraHostRanksStr).c_str(),
       vecToStr(nvlFabricSupportedRanksStr));
 

--- a/comms/ctran/commstate/CommStateX.cc
+++ b/comms/ctran/commstate/CommStateX.cc
@@ -129,8 +129,10 @@ void CommStateX::initRankStatesTopology(meta::comms::IBootstrap* bootstrap) {
     CLOGF_SUBSYS(
         INFO,
         INIT,
-        "load topology rank: {}, nRanks: {}, host: {}, dc: {} zone: {} rtsw: {} scaling unit: {} rackSerial: {}",
+        "Load topology for rank {} commHash {:x} commDesc {}, nRanks {}, host {}, dc {} zone {} rtsw {} scaling unit {} rackSerial {}",
         rank_,
+        commHash_,
+        commDesc_,
         nRanks_,
         myTopo->host,
         myTopo->dc,
@@ -153,6 +155,17 @@ void CommStateX::initRankStatesTopology(meta::comms::IBootstrap* bootstrap) {
 
   // Create statex variable
   setRankStatesTopologies(std::move(allTopos));
+
+  CLOGF_SUBSYS(
+      INFO,
+      INIT,
+      "Rank topology for rank {} commHash {:x} commDesc {}, nRanks {}, nLocalRanks {}, nNodes {}",
+      rank_,
+      commHash_,
+      commDesc_,
+      nRanks_,
+      nLocalRanks(),
+      nNodes());
 }
 
 void CommStateX::setNvlFabricTopos(
@@ -308,6 +321,28 @@ void CommStateX::setNvlFabricTopos(
         "CommStateX: effectiveVCliqueSize={} override NVL fabric topology",
         effectiveVCliqueSize);
   }
+
+  CLOGF_SUBSYS(
+      INFO,
+      INIT,
+      "NVL fabric topology for rank {} commHash {:x} commDesc {}, nRanks {}, nLocalRanks {}, nNodes {}, nvlFabricEnabled {}, nvlFabricCliqueEnabled {}, nvlDomainIndex {}, nvlDomainRank {}, nNvlDomainRanks {}, nNvlDomains {}, clusterId {}, cliqueIndex {}, cliqueRank {}, nCliqueRanks {}, nCliques {}",
+      rank_,
+      commHash_,
+      commDesc_,
+      nRanks_,
+      nLocalRanks(),
+      nNodes(),
+      nvlFabricEnabled_,
+      nvlFabricCliqueEnabled_,
+      myNvlFabricRankState_.nvlDomainIndex,
+      myNvlFabricRankState_.nvlDomainRank,
+      myNvlFabricRankState_.nNvlDomainRanks,
+      nvlDomainRanks_.size(),
+      myNvlFabricRankState_.clusterId,
+      myNvlFabricRankState_.cliqueIndex,
+      myNvlFabricRankState_.cliqueRank,
+      myNvlFabricRankState_.nCliqueRanks,
+      cliqueRanks_.size());
 }
 
 void CommStateX::setRankStatesTopologies(


### PR DESCRIPTION
Summary:
- Add commHash {:x} and commDesc to AllGather cudagraph-aware CLOGF_SUBSYS log
- Add CLOGF_SUBSYS COLL log to SendRecv cudagraph-aware with nOps, commHash, commDesc, nRanks, nLocalRanks
- Add "not in capture mode" fallback log to ctranSendRecvSupport with commHash, commDesc, peer, nRanks, nLocalRanks
- Add commHash {:x} and commDesc to AllGather "not in capture mode" fallback log
- Add commHash {:x} and commDesc to CtranNvl "Initialized NVL backend" log

Reviewed By: dsjohns2

Differential Revision: D102710769


