### PR TITLE
Fix WorkWrapper c10d status tracking and exception crash

### DIFF
--- a/comms/torchcomms/BackendWrapper.cpp
+++ b/comms/torchcomms/BackendWrapper.cpp
@@ -101,38 +101,36 @@ WorkWrapper::WorkWrapper(
   }
 }
 
-bool WorkWrapper::isCompleted() {
-  return work_->isCompleted();
-}
-bool WorkWrapper::isSuccess() const {
-  // Note: Error state tracking is not implemented. This method returns
-  // isCompleted() as a simplification. The underlying TorchWork does not
-  // expose separate success/error states, so we assume completion implies
-  // success. Callers that need error detection should use try/catch around
-  // wait() instead.
-  return work_->isCompleted();
-}
-std::exception_ptr WorkWrapper::exception() const {
-  // Note: Exception capture is not implemented. The underlying TorchWork
-  // interface does not provide a mechanism to retrieve exceptions after
-  // completion. Errors are raised during wait() calls instead.
-  return nullptr;
-}
 bool WorkWrapper::wait(std::chrono::milliseconds timeout) {
   if (timeout != kNoTimeout) {
-    throw std::runtime_error("wait timeout not supported");
+    auto ex = std::make_exception_ptr(
+        std::runtime_error("wait timeout not supported"));
+    finish(ex);
+    std::rethrow_exception(ex);
   }
-  work_->wait();
+  try {
+    work_->wait();
+  } catch (...) {
+    finish(std::current_exception());
+    throw;
+  }
   if (!future_->completed()) {
     future_->markCompleted(c10::IValue(outputTensors_));
   }
+  finish();
   return true;
 }
 void WorkWrapper::synchronize() {
-  work_->wait();
+  try {
+    work_->wait();
+  } catch (...) {
+    finish(std::current_exception());
+    throw;
+  }
   if (!future_->completed()) {
     future_->markCompleted(c10::IValue(outputTensors_));
   }
+  finish();
 }
 std::vector<at::Tensor> WorkWrapper::result() {
   return outputTensors_;

--- a/comms/torchcomms/BackendWrapper.hpp
+++ b/comms/torchcomms/BackendWrapper.hpp
@@ -19,9 +19,6 @@ class WorkWrapper : public c10d::Work {
       std::vector<at::Tensor> outputTensors = {});
   ~WorkWrapper() override = default;
 
-  bool isCompleted() override;
-  bool isSuccess() const override;
-  std::exception_ptr exception() const override;
   void synchronize() override;
   bool wait(std::chrono::milliseconds timeout) override;
   std::vector<at::Tensor> result() override;

--- a/comms/torchcomms/TorchCommPy.cpp
+++ b/comms/torchcomms/TorchCommPy.cpp
@@ -2503,7 +2503,18 @@ Args:
           )",
           py::arg("timeout"),
           py::call_guard<py::gil_scoped_release>());
-  intrusive_ptr_class_<WorkWrapper, c10d::Work>(m, "WorkWrapper");
+  intrusive_ptr_class_<WorkWrapper, c10d::Work>(m, "WorkWrapper")
+      .def("exception", [](WorkWrapper& self) -> py::object {
+        auto ep = self.exception();
+        if (!ep) {
+          return py::none();
+        }
+        try {
+          std::rethrow_exception(ep);
+        } catch (const std::exception& e) {
+          return py::handle(PyExc_RuntimeError)(e.what());
+        }
+      });
   // Register the backend Options
   intrusive_ptr_class_<BackendWrapper::Options, c10d::Backend::Options>(
       m, "_BackendWrapperOptions");


### PR DESCRIPTION
**Changes**

`BackendWrapper.cpp`: `wait()` and `synchronize()` call `c10d::Work::finish()` to set completed_ and exception_ in the base class. Removed `isCompleted()`, `isSuccess()`, and `exception()` overrides since not needed
`BackendWrapper.hpp`: removed the three override declarations
`TorchCommPy.cpp`: fixed exception() binding on `WorkWrapper` that converts `std::exception_ptr` to a python RuntimeError

**Repro**
```
import warnings, torch
from datetime import timedelta
from torchcomms import new_comm
from torchcomms.device_mesh import init_device_mesh

comm = new_comm("ncclx", torch.device("cuda"), name="dp")
mesh = init_device_mesh(mesh_dim_comms=(comm,), mesh_dim_names=("dp",))
dev = torch.device(f"cuda:{comm.get_rank() % torch.cuda.device_count()}")

pg = mesh.get_group("dp")
work = pg.allreduce([torch.ones(4, device=dev)])
try:
    work.wait(timedelta(seconds=5))
except RuntimeError:
    pass

if comm.get_rank() == 0:
    print(f"is_completed: {work.is_completed()}")
    with warnings.catch_warnings():
        warnings.simplefilter("ignore")
        print(f"is_success:   {work.is_success()}")
    print(f"exception:    {work.exception()}")
comm.finalize()
```

**Before**
```
is_completed: False
is_success:   False
exception:    CRASH (TypeError: Unregistered type std::exception_ptr)
```
**After**
```
is_completed: True
is_success:   False
exception:    wait timeout not supported
```