### PR TITLE
enable rxe (#2295)

### DIFF
--- a/comms/uniflow/transport/Topology.cpp
+++ b/comms/uniflow/transport/Topology.cpp
@@ -479,6 +479,19 @@ discoverGpus(CudaApi& cudaApi, NvmlApi& nvmlApi, SysfsApi& sysfs) {
   return gpus;
 }
 
+/// Check whether an ibdev sysfs path belongs to a virtual (software) RDMA
+/// device such as RXE (Soft-RoCE).  These live under
+/// /sys/devices/virtual/ and have no PCI backing.
+bool isVirtualRdmaDevice(SysfsApi& sysfs, const std::string& ibdevPath) {
+  auto resolved = sysfs.resolvePath(ibdevPath);
+  if (!resolved) {
+    return false;
+  }
+  return resolved.value().find("/devices/virtual/") != std::string::npos;
+}
+
+constexpr size_t kDefaultRxeSpeed = 10000; // 10 Gbps
+
 /// Discover NICs via IbvApi: enumerate IB devices and active ports.
 /// Returns empty vector if ibverbs is not available.
 Result<std::vector<NicDiscovery>> discoverNics(
@@ -511,11 +524,17 @@ Result<std::vector<NicDiscovery>> discoverNics(
 
     // Resolve PCI device path from ibdev sysfs path.
     std::string ibdevPath = dev->ibdev_path;
-    auto resolved = sysfs.resolvePath(ibdevPath + "/device");
-    if (!resolved) {
-      continue;
+
+    bool isVirtual = isVirtualRdmaDevice(sysfs, ibdevPath);
+    std::string pciDevicePath;
+
+    if (!isVirtual) {
+      auto resolved = sysfs.resolvePath(ibdevPath + "/device");
+      if (!resolved) {
+        continue;
+      }
+      pciDevicePath = std::move(resolved).value();
     }
-    const std::string& pciDevicePath = std::move(resolved).value();
 
     // Open device and query ports.
     auto ctxResult = ibvApi.openDevice(dev);
@@ -535,7 +554,7 @@ Result<std::vector<NicDiscovery>> discoverNics(
             portAttr.state == IBV_PORT_ACTIVE) {
           auto speed =
               ibPortSpeedMbps(portAttr.active_speed, portAttr.active_width);
-          if (speed > portSpeedMbps) {
+          if (activePort == -1 || speed > portSpeedMbps) {
             activePort = port;
             portSpeedMbps =
                 ibPortSpeedMbps(portAttr.active_speed, portAttr.active_width);
@@ -545,19 +564,40 @@ Result<std::vector<NicDiscovery>> discoverNics(
     }
 
     if (activePort != -1) {
-      nics.push_back({
-          .name = std::move(devName),
-          .data =
-              TopoNode::NicData{
-                  .bdf = std::string(extractBdf(pciDevicePath)),
-                  .numaNode = readNumaNode(sysfs, pciDevicePath),
-                  .port = activePort,
-                  .portSpeedMbps = portSpeedMbps,
-              },
-          .sysfsPath = pciDevicePath,
-          .ancestorChain = buildAncestorChain(sysfs, pciDevicePath),
-          .linkInfo = readPcieLinkInfo(sysfs, pciDevicePath),
-      });
+      if (isVirtual) {
+        if (portSpeedMbps == 0) {
+          portSpeedMbps = kDefaultRxeSpeed;
+        }
+        // Virtual devices have no PCI topology. Use NUMA 0, empty ancestor
+        // chain, and a default port speed if the ibverbs query returned 0.
+        nics.push_back({
+            .name = std::move(devName),
+            .data =
+                TopoNode::NicData{
+                    .bdf = "virtual",
+                    .numaNode = 0,
+                    .port = activePort,
+                    .portSpeedMbps = portSpeedMbps,
+                },
+            .sysfsPath = ibdevPath,
+            .ancestorChain = {},
+            .linkInfo = {},
+        });
+      } else {
+        nics.push_back({
+            .name = std::move(devName),
+            .data =
+                TopoNode::NicData{
+                    .bdf = std::string(extractBdf(pciDevicePath)),
+                    .numaNode = readNumaNode(sysfs, pciDevicePath),
+                    .port = activePort,
+                    .portSpeedMbps = portSpeedMbps,
+                },
+            .sysfsPath = pciDevicePath,
+            .ancestorChain = buildAncestorChain(sysfs, pciDevicePath),
+            .linkInfo = readPcieLinkInfo(sysfs, pciDevicePath),
+        });
+      }
     }
 
     ibvApi.closeDevice(ctx);
@@ -835,8 +875,9 @@ Status Topology::discover() {
 
 Status Topology::discoverHardware(DiscoveryData& data) {
   auto gpuResult = discoverGpus(*cudaApi_, *nvmlApi_, *sysfsApi_);
-  CHECK_RETURN(gpuResult);
-  data.gpus = std::move(gpuResult).value();
+  if (gpuResult) {
+    data.gpus = std::move(gpuResult).value();
+  }
 
   auto nicResult = discoverNics(*ibvApi_, *sysfsApi_);
   if (nicResult) {
@@ -931,12 +972,19 @@ void Topology::buildEdges(const DiscoveryData& data) {
 
   // Connect each PCI device to its CPU node.
   // For NICs, cap bandwidth with the RDMA port speed (like NCCL's LINK_NET).
+  // For virtual devices (empty ancestor chain), use port speed directly.
   for (const auto& dev : pciDevices) {
     int numa =
         (dev.numaNode >= 0 && dev.numaNode < numaCount) ? dev.numaNode : 0;
-    uint32_t bw = computeChainBottleneckMBps(*sysfsApi_, dev.ancestorChain);
-    if (dev.portSpeedMBps > 0) {
-      bw = std::min(bw, dev.portSpeedMBps);
+    uint32_t bw;
+    if (dev.ancestorChain.empty()) {
+      // Virtual device — no PCIe topology; use port speed as bandwidth.
+      bw = dev.portSpeedMBps;
+    } else {
+      bw = computeChainBottleneckMBps(*sysfsApi_, dev.ancestorChain);
+      if (dev.portSpeedMBps > 0) {
+        bw = std::min(bw, dev.portSpeedMBps);
+      }
     }
     addLink(dev.nodeId, cpuNodeIds_[numa], PathType::PHB, bw);
   }

--- a/comms/uniflow/transport/tests/unit/TopologyTest.cpp
+++ b/comms/uniflow/transport/tests/unit/TopologyTest.cpp
@@ -205,13 +205,15 @@ TEST_F(TopologyTest, DiscoverWithTwoGpusCreatesNodes) {
   EXPECT_EQ(std::get<TopoNode::GpuData>(gpu1.data).cudaDeviceId, 1);
 }
 
-TEST_F(TopologyTest, DiscoverFailsWhenNvmlFails) {
+TEST_F(TopologyTest, DiscoverContinuesWhenNvmlFails) {
   EXPECT_CALL(*nvml_, deviceCount())
       .WillOnce(Return(Err(ErrCode::DriverError, "nvml failed")));
   // CUDA should not be called if NVML fails first.
   EXPECT_CALL(*cuda_, getDevicePCIBusId(_, _, _)).Times(Exactly(0));
   auto topo = createTopology();
-  EXPECT_FALSE(topo->available());
+  // GPU failure is non-fatal; topology is still available with zero GPUs.
+  EXPECT_TRUE(topo->available());
+  EXPECT_EQ(topo->gpuCount(), 0u);
 }
 
 // --- P2P matrix tests ---
@@ -766,25 +768,48 @@ class TopologyNicTest : public TopologyTest {
     }
   }
 
+  // Entry for a NIC device: name, PCI sysfs path (empty for virtual), virtual.
+  struct NicEntry {
+    std::string name;
+    std::string pciSysfsPath; // empty for virtual devices
+    bool isVirtual = false;
+  };
+
   void setupNics(const std::vector<std::pair<std::string, std::string>>& nics) {
-    // nics = {{"mlx5_0", nicSysfsPath}, ...}
+    std::vector<NicEntry> entries;
+    entries.reserve(nics.size());
+    for (const auto& [name, path] : nics) {
+      entries.push_back({name, path, /*isVirtual=*/false});
+    }
+    setupNicsImpl(entries);
+  }
+
+  void setupNicsImpl(const std::vector<NicEntry>& nics) {
     nicDevices_.resize(nics.size());
     nicDevicePtrs_.resize(nics.size());
     nicNames_.clear();
 
     for (size_t i = 0; i < nics.size(); ++i) {
       std::memset(&nicDevices_[i], 0, sizeof(ibv_device));
-      std::string ibdevPath = "/sys/class/infiniband/" + nics[i].first;
+      std::string ibdevPath = "/sys/class/infiniband/" + nics[i].name;
       std::strncpy(
           nicDevices_[i].ibdev_path,
           ibdevPath.c_str(),
           sizeof(nicDevices_[i].ibdev_path) - 1);
       nicDevicePtrs_[i] = &nicDevices_[i];
-      nicNames_.push_back(nics[i].first);
+      nicNames_.push_back(nics[i].name);
 
-      // Resolve ibdev_path/device → PCI device path.
-      ON_CALL(*sysfs_, resolvePath(ibdevPath + "/device"))
-          .WillByDefault(Return(Result<std::string>(nics[i].second)));
+      if (nics[i].isVirtual) {
+        // Virtual device: resolvePath(ibdevPath) returns /devices/virtual/...
+        ON_CALL(*sysfs_, resolvePath(ibdevPath))
+            .WillByDefault(Return(
+                Result<std::string>(
+                    "/sys/devices/virtual/infiniband/" + nics[i].name)));
+      } else {
+        // Physical device: resolvePath(ibdevPath/device) → PCI path.
+        ON_CALL(*sysfs_, resolvePath(ibdevPath + "/device"))
+            .WillByDefault(Return(Result<std::string>(nics[i].pciSysfsPath)));
+      }
     }
 
     int n = static_cast<int>(nics.size());
@@ -968,6 +993,121 @@ TEST_F(TopologyNicTest, PortSpeedIsCapturedFromIbverbs) {
   EXPECT_EQ(nic0Data.portSpeedMbps, 400000u); // NDR 4x
   EXPECT_EQ(nic1Data.portSpeedMbps, 200000u); // HDR 4x
   EXPECT_GT(nic0Data.portSpeedMbps, nic1Data.portSpeedMbps);
+}
+
+// --- Virtual RDMA device (RXE) tests ---
+
+TEST_F(TopologyNicTest, VirtualRdmaDeviceIsDiscovered) {
+  setupNicsImpl({
+      {.name = "rxe0", .pciSysfsPath = "", .isVirtual = true},
+  });
+
+  auto topo = createTopology();
+  ASSERT_TRUE(topo->available());
+  ASSERT_EQ(topo->nicCount(), 1u);
+
+  const auto& nic = topo->getNicNode(0);
+  EXPECT_EQ(nic.name, "rxe0");
+
+  const auto& data = std::get<TopoNode::NicData>(nic.data);
+  EXPECT_EQ(data.bdf, "virtual");
+  EXPECT_EQ(data.numaNode, 0);
+  EXPECT_EQ(data.port, 1);
+  // Uses default queryPort mock (NDR 4x = 400000 Mbps).
+  EXPECT_EQ(data.portSpeedMbps, 400000u);
+}
+
+TEST_F(TopologyNicTest, VirtualRdmaDevicePreservesNonZeroSpeed) {
+  setupNicsImpl({
+      {.name = "rxe0", .pciSysfsPath = "", .isVirtual = true},
+  });
+
+  // Report a non-zero speed — should be preserved, not overridden.
+  // NOLINTNEXTLINE(performance-no-int-to-ptr)
+  auto* ctx0 = reinterpret_cast<ibv_context*>(static_cast<uintptr_t>(0x100));
+  ON_CALL(*ibv_, queryPort(ctx0, _, _))
+      .WillByDefault([](ibv_context*, uint8_t, ibv_port_attr* attr) {
+        attr->state = IBV_PORT_ACTIVE;
+        attr->active_speed = 64; // HDR
+        attr->active_width = 2; // 4x
+        return Ok();
+      });
+
+  auto topo = createTopology();
+  ASSERT_TRUE(topo->available());
+  ASSERT_EQ(topo->nicCount(), 1u);
+
+  const auto& data = std::get<TopoNode::NicData>(topo->getNicNode(0).data);
+  EXPECT_EQ(data.bdf, "virtual");
+  EXPECT_EQ(data.portSpeedMbps, 200000u); // HDR 4x
+}
+
+TEST_F(TopologyNicTest, VirtualNicBandwidthUsesPortSpeed) {
+  setupNicsImpl({
+      {.name = "rxe0", .pciSysfsPath = "", .isVirtual = true},
+  });
+
+  auto topo = createTopology();
+  ASSERT_TRUE(topo->available());
+  ASSERT_EQ(topo->nicCount(), 1u);
+
+  // Virtual NIC should be connected to CPU node with port speed as bandwidth
+  // (no PCIe bottleneck). NDR 4x = 400000 Mbps → 50000 MB/s.
+  int nicNodeId = topo->getNicNode(0).id;
+  int cpuNodeId = topo->getCpuNode(0).id;
+  const auto& path = topo->getPath(nicNodeId, cpuNodeId);
+  EXPECT_NE(path.type, PathType::DIS);
+  EXPECT_EQ(path.bw, 50000u); // 400000 Mbps / 8
+}
+
+TEST_F(TopologyNicTest, VirtualRdmaDeviceDefaultsSpeedWhenZero) {
+  setupNicsImpl({
+      {.name = "rxe0", .pciSysfsPath = "", .isVirtual = true},
+  });
+
+  // Report zero speed — should be overridden to 10 Gbps default.
+  // NOLINTNEXTLINE(performance-no-int-to-ptr)
+  auto* ctx0 = reinterpret_cast<ibv_context*>(static_cast<uintptr_t>(0x100));
+  ON_CALL(*ibv_, queryPort(ctx0, _, _))
+      .WillByDefault([](ibv_context*, uint8_t, ibv_port_attr* attr) {
+        attr->state = IBV_PORT_ACTIVE;
+        attr->active_speed = 0;
+        attr->active_width = 0;
+        return Ok();
+      });
+
+  auto topo = createTopology();
+  ASSERT_TRUE(topo->available());
+  ASSERT_EQ(topo->nicCount(), 1u);
+
+  const auto& data = std::get<TopoNode::NicData>(topo->getNicNode(0).data);
+  EXPECT_EQ(data.bdf, "virtual");
+  EXPECT_EQ(data.portSpeedMbps, 10000u); // default RXE speed: 10 Gbps
+
+  // Bandwidth to CPU should use the default speed: 10000 Mbps / 8 = 1250 MB/s.
+  int nicNodeId = topo->getNicNode(0).id;
+  int cpuNodeId = topo->getCpuNode(0).id;
+  const auto& path = topo->getPath(nicNodeId, cpuNodeId);
+  EXPECT_NE(path.type, PathType::DIS);
+  EXPECT_EQ(path.bw, 1250u);
+}
+
+TEST_F(TopologyNicTest, MixedPhysicalAndVirtualNics) {
+  setupNicsImpl({
+      {.name = "mlx5_0", .pciSysfsPath = nic0_, .isVirtual = false},
+      {.name = "rxe0", .pciSysfsPath = "", .isVirtual = true},
+  });
+
+  auto topo = createTopology();
+  ASSERT_TRUE(topo->available());
+  ASSERT_EQ(topo->nicCount(), 2u);
+
+  const auto& phys = std::get<TopoNode::NicData>(topo->getNicNode(0).data);
+  const auto& virt = std::get<TopoNode::NicData>(topo->getNicNode(1).data);
+
+  EXPECT_NE(phys.bdf, "virtual");
+  EXPECT_EQ(virt.bdf, "virtual");
+  EXPECT_EQ(virt.numaNode, 0);
 }
 
 } // namespace uniflow


### PR DESCRIPTION
Summary:

Enable RXE (Soft-RoCE) virtual RDMA devices in Uniflow's topology discovery.

RXE devices are software-emulated RDMA adapters that lack PCI backing, so the existing NIC discovery logic — which assumes every IB device has a PCI sysfs path — would skip them entirely. This change detects virtual RDMA devices (those under virtual), bypasses PCI path resolution for them, and provides sensible defaults (NUMA 0, empty ancestor chain, 10 Gbps fallback speed).

The bandwidth computation is also updated to use port speed directly for virtual devices instead of attempting a PCIe bottleneck calculation.

Additionally, GPU discovery failure is now non-fatal so Uniflow can operate on GPU-less hosts with only RXE NICs.

Differential Revision: D102714262


