### PR TITLE
Guard statex access behind ctranInitialized check

### DIFF
--- a/comms/ctran/algos/AllGatherP/AllGatherP.cc
+++ b/comms/ctran/algos/AllGatherP/AllGatherP.cc
@@ -134,23 +134,22 @@ commResult_t AlgoImpl::destroy() {
 
 namespace ctran {
 bool allGatherPSupport(CtranComm* comm) {
-  bool ctranSupport = false;
+  if (!ctranInitialized(comm)) {
+    return false;
+  }
+
   const auto statex = comm->statex_.get();
-  if (ctranInitialized(comm)) {
-    ctranSupport = true;
-    auto mapper = comm->ctran_->mapper.get();
-    const auto myRank = statex->rank();
-    // Check if all remote peers are supported by ctran
-    for (auto rank = 0; rank < statex->nRanks(); rank++) {
-      if (mapper->getBackend(rank) == CtranMapperBackend::UNSET &&
-          rank != myRank) {
-        ctranSupport = false;
-        break;
-      }
+  auto mapper = comm->ctran_->mapper.get();
+  const auto myRank = statex->rank();
+  // Check if all remote peers are supported by ctran
+  for (auto rank = 0; rank < statex->nRanks(); rank++) {
+    if (mapper->getBackend(rank) == CtranMapperBackend::UNSET &&
+        rank != myRank) {
+      return false;
     }
   }
 
-  return ctranSupport;
+  return true;
 }
 
 commResult_t allGatherPInit(

--- a/comms/ctran/algos/AllToAll/AllToAll.cc
+++ b/comms/ctran/algos/AllToAll/AllToAll.cc
@@ -168,32 +168,23 @@ bool ctranAllToAllSupport(
   // Currently there is only one ctran algo for alltoall, but we pass algo as a
   // parameter for future extension and consistency across collectives.
   // Currently just return false if algo is set to orig
-  if (algo == NCCL_ALLTOALL_ALGO::orig) {
+  if (algo == NCCL_ALLTOALL_ALGO::orig || !ctranInitialized(comm)) {
     return false;
   }
-  bool ctranSupport = false;
+
   const auto statex = comm->statex_.get();
-  if (ctranInitialized(comm)) {
-    ctranSupport = true;
-    // Check if all remote peers are supported by ctran
-    // For intra-node peers, ctranAlgo supports copy based path;
-    // for inter-node peers, we need a mapper backend to support.
-    const int myNode = statex->node();
-    for (int rank = 0; rank < statex->nRanks(); rank++) {
-      if (statex->node(rank) != myNode &&
-          comm->ctran_->mapper->getBackend(rank) == CtranMapperBackend::UNSET) {
-        ctranSupport = false;
-        break;
-      }
+  // Check if all remote peers are supported by ctran
+  // For intra-node peers, ctranAlgo supports copy based path;
+  // for inter-node peers, we need a mapper backend to support.
+  const int myNode = statex->node();
+  for (int rank = 0; rank < statex->nRanks(); rank++) {
+    if (statex->node(rank) != myNode &&
+        comm->ctran_->mapper->getBackend(rank) == CtranMapperBackend::UNSET) {
+      return false;
     }
   }
 
-  if (ctranSupport &&
-      commTypeSize(datatype) * count >= NCCL_CTRAN_ALLTOALL_THRESHOLD) {
-    return true;
-  } else {
-    return false;
-  }
+  return commTypeSize(datatype) * count >= NCCL_CTRAN_ALLTOALL_THRESHOLD;
 }
 
 #if defined(ENABLE_PIPES)

--- a/comms/ctran/algos/AllToAll/AllToAllv.cc
+++ b/comms/ctran/algos/AllToAll/AllToAllv.cc
@@ -331,22 +331,21 @@ commResult_t ctranAllToAllv(
 }
 
 bool ctranAllToAllvSupport(CtranComm* comm) {
-  bool ctranSupport = false;
+  if (!ctranInitialized(comm)) {
+    return false;
+  }
+
   const auto statex = comm->statex_.get();
-  if (ctranInitialized(comm)) {
-    ctranSupport = true;
-    // Check if all remote peers are supported by ctran
-    // For intra-node peers, ctranAlgo supports copy based path;
-    // for inter-node peers, we need a mapper backend to support.
-    const int myNode = statex->node();
-    for (int rank = 0; rank < statex->nRanks(); rank++) {
-      if (statex->node(rank) != myNode &&
-          comm->ctran_->mapper->getBackend(rank) == CtranMapperBackend::UNSET) {
-        ctranSupport = false;
-        break;
-      }
+  // Check if all remote peers are supported by ctran
+  // For intra-node peers, ctranAlgo supports copy based path;
+  // for inter-node peers, we need a mapper backend to support.
+  const int myNode = statex->node();
+  for (int rank = 0; rank < statex->nRanks(); rank++) {
+    if (statex->node(rank) != myNode &&
+        comm->ctran_->mapper->getBackend(rank) == CtranMapperBackend::UNSET) {
+      return false;
     }
   }
 
-  return ctranSupport;
+  return true;
 }

--- a/comms/ctran/algos/ReduceScatter/ReduceScatter.cc
+++ b/comms/ctran/algos/ReduceScatter/ReduceScatter.cc
@@ -8,19 +8,14 @@
 bool ctranReduceScatterSupport(
     CtranComm* comm,
     enum NCCL_REDUCESCATTER_ALGO algo) {
+  if (!ctranInitialized(comm)) {
+    return false;
+  }
+
   const int nRanks = comm->statex_->nRanks();
   const int rank = comm->statex_->rank();
   const int nNodes = comm->statex_->nNodes();
   const int nLocalRanks = comm->statex_->nLocalRanks();
-
-  // Check if ctran is initialized
-  if (!ctranInitialized(comm)) {
-    CLOGF_EVERY_MS(
-        WARN,
-        60000,
-        "ctranReduceScatterSupport: CTRAN not initialized, falling back to baseline");
-    return false;
-  }
 
   // Check backend availability (except for single rank case)
   if (nRanks > 1 && !comm->ctran_->mapper->hasBackend()) {

--- a/comms/ctran/algos/SendRecv/SendRecv.cc
+++ b/comms/ctran/algos/SendRecv/SendRecv.cc
@@ -34,11 +34,11 @@ bool ctranSendRecvSupport(
     CtranComm* comm,
     enum NCCL_SENDRECV_ALGO algo,
     cudaStream_t stream) {
-  const auto statex = comm->statex_.get();
-
   if (!ctranInitialized(comm)) {
     return false;
   }
+
+  const auto statex = comm->statex_.get();
 
   if (algo == NCCL_SENDRECV_ALGO::ctgraph) {
     if (peer != statex->rank() &&

--- a/comms/ncclx/v2_27/src/enqueue.cc
+++ b/comms/ncclx/v2_27/src/enqueue.cc
@@ -1679,15 +1679,15 @@ ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan
     launchConfig.attrs = launchAttrs;
     launchConfig.numAttrs = attrs;
     launchConfig.hStream = launchStream;
-    colltraceHandle->trigger(meta::comms::colltrace::CollTraceHandleTriggerState::BeforeEnqueueKernel);
+    if (colltraceHandle) { colltraceHandle->trigger(meta::comms::colltrace::CollTraceHandleTriggerState::BeforeEnqueueKernel); }
     CUCHECKGOTO(cuLaunchKernelEx(&launchConfig, fn, nullptr, extra), ret, do_return);
-    colltraceHandle->trigger(meta::comms::colltrace::CollTraceHandleTriggerState::AfterEnqueueKernel);
+    if (colltraceHandle) { colltraceHandle->trigger(meta::comms::colltrace::CollTraceHandleTriggerState::AfterEnqueueKernel); }
   #endif
   } else {
     // Standard kernel launch
-    colltraceHandle->trigger(meta::comms::colltrace::CollTraceHandleTriggerState::BeforeEnqueueKernel);
+    if (colltraceHandle) { colltraceHandle->trigger(meta::comms::colltrace::CollTraceHandleTriggerState::BeforeEnqueueKernel); }
     CUCHECKGOTO(cuLaunchKernel(fn, grid.x, grid.y, grid.z, block.x, block.y, block.z, smem, launchStream, nullptr, extra), ret, do_return);
-    colltraceHandle->trigger(meta::comms::colltrace::CollTraceHandleTriggerState::AfterEnqueueKernel);
+    if (colltraceHandle) { colltraceHandle->trigger(meta::comms::colltrace::CollTraceHandleTriggerState::AfterEnqueueKernel); }
   }
 
 do_return:

--- a/comms/ncclx/v2_28/src/enqueue.cc
+++ b/comms/ncclx/v2_28/src/enqueue.cc
@@ -1696,15 +1696,15 @@ ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan
     launchConfig.attrs = launchAttrs;
     launchConfig.numAttrs = attrs;
     launchConfig.hStream = launchStream;
-    colltraceHandle->trigger(meta::comms::colltrace::CollTraceHandleTriggerState::BeforeEnqueueKernel);
+    if (colltraceHandle) { colltraceHandle->trigger(meta::comms::colltrace::CollTraceHandleTriggerState::BeforeEnqueueKernel); }
     CUCHECKGOTO(cuLaunchKernelEx(&launchConfig, fn, nullptr, extra), ret, do_return);
-    colltraceHandle->trigger(meta::comms::colltrace::CollTraceHandleTriggerState::AfterEnqueueKernel);
+    if (colltraceHandle) { colltraceHandle->trigger(meta::comms::colltrace::CollTraceHandleTriggerState::AfterEnqueueKernel); }
   #endif
   } else {
     // Standard kernel launch
-    colltraceHandle->trigger(meta::comms::colltrace::CollTraceHandleTriggerState::BeforeEnqueueKernel);
+    if (colltraceHandle) { colltraceHandle->trigger(meta::comms::colltrace::CollTraceHandleTriggerState::BeforeEnqueueKernel); }
     CUCHECKGOTO(cuLaunchKernel(fn, grid.x, grid.y, grid.z, block.x, block.y, block.z, smem, launchStream, nullptr, extra), ret, do_return);
-    colltraceHandle->trigger(meta::comms::colltrace::CollTraceHandleTriggerState::AfterEnqueueKernel);
+    if (colltraceHandle) { colltraceHandle->trigger(meta::comms::colltrace::CollTraceHandleTriggerState::AfterEnqueueKernel); }
   }
 
 do_return:

--- a/comms/ncclx/v2_29/src/enqueue.cc
+++ b/comms/ncclx/v2_29/src/enqueue.cc
@@ -1815,15 +1815,15 @@ ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan
     launchConfig.attrs = launchAttrs;
     launchConfig.numAttrs = attrs;
     launchConfig.hStream = launchStream;
-    colltraceHandle->trigger(meta::comms::colltrace::CollTraceHandleTriggerState::BeforeEnqueueKernel);
+    if (colltraceHandle) { colltraceHandle->trigger(meta::comms::colltrace::CollTraceHandleTriggerState::BeforeEnqueueKernel); }
     CUCHECKGOTO(cuLaunchKernelEx(&launchConfig, fn, nullptr, extra), ret, do_return);
-    colltraceHandle->trigger(meta::comms::colltrace::CollTraceHandleTriggerState::AfterEnqueueKernel);
+    if (colltraceHandle) { colltraceHandle->trigger(meta::comms::colltrace::CollTraceHandleTriggerState::AfterEnqueueKernel); }
   #endif
   } else {
     // Standard kernel launch
-    colltraceHandle->trigger(meta::comms::colltrace::CollTraceHandleTriggerState::BeforeEnqueueKernel);
+    if (colltraceHandle) { colltraceHandle->trigger(meta::comms::colltrace::CollTraceHandleTriggerState::BeforeEnqueueKernel); }
     CUCHECKGOTO(cuLaunchKernel(fn, grid.x, grid.y, grid.z, block.x, block.y, block.z, smem, launchStream, nullptr, extra), ret, do_return);
-    colltraceHandle->trigger(meta::comms::colltrace::CollTraceHandleTriggerState::AfterEnqueueKernel);
+    if (colltraceHandle) { colltraceHandle->trigger(meta::comms::colltrace::CollTraceHandleTriggerState::AfterEnqueueKernel); }
   }
 
 do_return:


### PR DESCRIPTION
Summary:
Fix potential null dereference in collective support-check functions where `comm->statex_` was accessed before verifying `ctranInitialized(comm)`. In the followup diff, we will omit any ctran internal resourec creation (e.g., statex) when ctran is not initialized, so accessing it becomes unsafe:
- AllGatherP, AllToAll, AllToAllv, ReduceScatter, SendRecv: move `ctranInitialized` check before any `statex_` access, using early-return pattern
- Flatten nested if-else into linear early-return flow as a side benefit

Differential Revision: D102730450


