### PR TITLE
C2C memory support

### DIFF
--- a/comms/utils/HRDWRingBuffer.h
+++ b/comms/utils/HRDWRingBuffer.h
@@ -21,6 +21,64 @@
 
 namespace meta::comms::colltrace {
 
+namespace detail {
+template <std::size_t kAlign>
+constexpr std::size_t alignTo(std::size_t bytes) {
+  return (bytes + kAlign - 1) & ~(kAlign - 1);
+}
+
+template <std::size_t kAlign, typename T>
+static inline __attribute__((__always_inline__)) std::size_t allocAligned(
+    T*& ptr,
+    std::size_t num = 1) {
+  auto bytes = detail::alignTo<kAlign>(sizeof(T) * num);
+  ptr = static_cast<T*>(std::aligned_alloc(kAlign, bytes));
+  return ptr ? bytes : 0;
+}
+} // namespace detail
+
+// Memory allocation strategy for the ring buffer.
+enum class HRDWMemoryStrategy {
+  // cudaHostAlloc pinned mapped memory — works everywhere.
+  PinnedMapped,
+  // Plain malloc + cudaMemAdvise(SetAccessedBy) — on Grace Hopper (GB200),
+  // NVLink-C2C makes this as fast as device memory. Falls back to
+  // PinnedMapped on non-ATS systems.
+  AtsPageable,
+  // Automatically select the best strategy for the current platform.
+  Auto,
+};
+
+// Returns true if the current GPU supports hardware-backed ATS (Address
+// Translation Services) for pageable host memory access. True on Grace
+// Hopper (GB200) with NVLink-C2C.
+//
+// Two attributes must both be set: pageable memory access must be
+// available, AND it must be backed by hardware page tables rather than
+// software emulation. The latter distinguishes true ATS (NVLink-C2C) from
+// HMM-style software-managed access, which lacks the coherence guarantees
+// we rely on for the device-scope fence in hrdwRingBufferWrite.
+inline bool isAtsSupported() {
+  int device = 0;
+  if (cudaGetDevice(&device) != cudaSuccess) {
+    return false;
+  }
+  int pageableMemoryAccess = 0;
+  if (cudaDeviceGetAttribute(
+          &pageableMemoryAccess, cudaDevAttrPageableMemoryAccess, device) !=
+      cudaSuccess) {
+    return false;
+  }
+  int usesHostPageTables = 0;
+  if (cudaDeviceGetAttribute(
+          &usesHostPageTables,
+          cudaDevAttrPageableMemoryAccessUsesHostPageTables,
+          device) != cudaSuccess) {
+    return false;
+  }
+  return pageableMemoryAccess != 0 && usesHostPageTables != 0;
+}
+
 // ==========================================================================
 // HRDWRingBuffer — Host-Read Device-Write ring buffer for GPU-to-CPU
 // event transfer with lock-free, torn-read-safe polling.
@@ -95,7 +153,8 @@ __device__ __forceinline__ void hrdwRingBufferWrite(
     HRDWEntry<DataT>* ring,
     uint64_t* writeIndex,
     uint32_t mask,
-    DataT data) {
+    DataT data,
+    HRDWMemoryStrategy strategy) {
   uint64_t slot =
       atomicAdd(reinterpret_cast<unsigned long long*>(writeIndex), 1ULL);
   uint64_t idx = slot & mask;
@@ -112,7 +171,14 @@ __device__ __forceinline__ void hrdwRingBufferWrite(
   } else {
     new (&ring[idx].data) DataT(data);
   }
-  __threadfence_system();
+  // ATS (NVLink-C2C) provides hardware coherence between GPU and CPU,
+  // so a device-scope fence is sufficient. Non-coherent interconnects
+  // (PCIe) require a system-scope fence.
+  if (strategy == HRDWMemoryStrategy::AtsPageable) {
+    __threadfence();
+  } else {
+    __threadfence_system();
+  }
   ring[idx].sequence = slot;
 }
 #endif
@@ -125,10 +191,11 @@ struct HRDWRingBufferDeviceHandle {
   HRDWEntry<DataT>* ring;
   uint64_t* writeIndex;
   uint32_t mask;
+  HRDWMemoryStrategy strategy;
 
 #if defined(__CUDACC__) || defined(__HIPCC__)
   __device__ __forceinline__ void write(DataT data) {
-    hrdwRingBufferWrite(ring, writeIndex, mask, data);
+    hrdwRingBufferWrite(ring, writeIndex, mask, data, strategy);
   }
 #endif
 };
@@ -144,8 +211,9 @@ __global__ void ringBufferWriteKernel(
     HRDWEntry<DataT>* ring,
     uint64_t* writeIdx,
     uint32_t mask,
-    DataT data) {
-  hrdwRingBufferWrite(ring, writeIdx, mask, data);
+    DataT data,
+    HRDWMemoryStrategy strategy) {
+  hrdwRingBufferWrite(ring, writeIdx, mask, data, strategy);
 }
 } // namespace detail
 
@@ -155,10 +223,11 @@ cudaError_t launchRingBufferWrite(
     HRDWEntry<DataT>* ring,
     uint64_t* writeIdx,
     uint32_t mask,
-    DataT data) {
+    DataT data,
+    HRDWMemoryStrategy strategy) {
   // NOLINTNEXTLINE(facebook-cuda-safe-kernel-call-check)
   detail::ringBufferWriteKernel<<<1, 1, 0, stream>>>(
-      ring, writeIdx, mask, data);
+      ring, writeIdx, mask, data, strategy);
   return cudaGetLastError();
 }
 #else
@@ -169,7 +238,8 @@ cudaError_t launchRingBufferWrite(
     HRDWEntry<DataT>* ring,
     uint64_t* writeIdx,
     uint32_t mask,
-    DataT data);
+    DataT data,
+    HRDWMemoryStrategy strategy);
 #endif
 
 // Host-Read Device-Write (HRDW) ring buffer. Device kernels atomically claim
@@ -187,7 +257,9 @@ class HRDWRingBuffer {
  public:
   using Entry = HRDWEntry<DataT>;
 
-  explicit HRDWRingBuffer(uint32_t size) {
+  explicit HRDWRingBuffer(
+      uint32_t size,
+      HRDWMemoryStrategy strategy = HRDWMemoryStrategy::Auto) {
     // Round up to next power of 2 if needed.
     if (size == 0) {
       size = 1;
@@ -217,23 +289,43 @@ class HRDWRingBuffer {
       size = nextPowerOf2;
     }
 
+    // Resolve Auto strategy.
+    if (strategy == HRDWMemoryStrategy::Auto) {
+      strategy = isAtsSupported() ? HRDWMemoryStrategy::AtsPageable
+                                  : HRDWMemoryStrategy::PinnedMapped;
+    }
+    // Fallback if ATS requested but not supported.
+    if (strategy == HRDWMemoryStrategy::AtsPageable && !isAtsSupported()) {
+      strategy = HRDWMemoryStrategy::PinnedMapped;
+    }
+    strategy_ = strategy;
+
     // x & mask == x % size
     // but is just a single bitwise op
     size_ = size;
     mask_ = size - 1;
 
-    allocatePinnedMapped();
+    if (strategy_ == HRDWMemoryStrategy::AtsPageable) {
+      allocateAtsPageable();
+    } else {
+      allocatePinnedMapped();
+    }
   }
 
   ~HRDWRingBuffer() {
     destructLiveEntries();
-    if (ring_) {
-      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-      (void)cudaFreeHost(ring_);
-    }
-    if (writeIndex_) {
-      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-      (void)cudaFreeHost(writeIndex_);
+    if (strategy_ == HRDWMemoryStrategy::AtsPageable) {
+      std::free(ring_);
+      std::free(writeIndex_);
+    } else {
+      if (ring_) {
+        // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+        (void)cudaFreeHost(ring_);
+      }
+      if (writeIndex_) {
+        // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+        (void)cudaFreeHost(writeIndex_);
+      }
     }
   }
 
@@ -245,23 +337,31 @@ class HRDWRingBuffer {
       : ring_(std::exchange(other.ring_, nullptr)),
         writeIndex_(std::exchange(other.writeIndex_, nullptr)),
         size_(other.size_),
-        mask_(other.mask_) {}
+        mask_(other.mask_),
+        strategy_(other.strategy_) {}
 
   HRDWRingBuffer& operator=(HRDWRingBuffer&& other) noexcept {
     if (this != &other) {
       destructLiveEntries();
-      if (ring_) {
-        // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-        (void)cudaFreeHost(ring_);
-      }
-      if (writeIndex_) {
-        // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-        (void)cudaFreeHost(writeIndex_);
+      // Free current resources using the current strategy.
+      if (strategy_ == HRDWMemoryStrategy::AtsPageable) {
+        std::free(ring_);
+        std::free(writeIndex_);
+      } else {
+        if (ring_) {
+          // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+          (void)cudaFreeHost(ring_);
+        }
+        if (writeIndex_) {
+          // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+          (void)cudaFreeHost(writeIndex_);
+        }
       }
       ring_ = std::exchange(other.ring_, nullptr);
       writeIndex_ = std::exchange(other.writeIndex_, nullptr);
       size_ = other.size_;
       mask_ = other.mask_;
+      strategy_ = other.strategy_;
     }
     return *this;
   }
@@ -280,7 +380,7 @@ class HRDWRingBuffer {
   cudaError_t write(cudaStream_t stream, DataT data) {
     assert(valid());
     return launchRingBufferWrite<DataT>(
-        stream, ring_, writeIndex_, mask_, data);
+        stream, ring_, writeIndex_, mask_, data, strategy_);
   }
 
   // Return a lightweight, trivially-copyable handle that can be passed by
@@ -288,7 +388,7 @@ class HRDWRingBuffer {
   // HRDWRingBufferDeviceHandle.cuh for usage.
   HRDWRingBufferDeviceHandle<DataT> deviceHandle() const {
     assert(valid());
-    return {ring_, writeIndex_, mask_};
+    return {ring_, writeIndex_, mask_, strategy_};
   }
 
  private:
@@ -306,6 +406,49 @@ class HRDWRingBuffer {
           ring_[i].data.~DataT();
         }
       }
+    }
+  }
+
+  void allocateAtsPageable() {
+    int device = 0;
+    cudaGetDevice(&device);
+
+    constexpr std::size_t kAlign = 128;
+    {
+      auto bytesAllocated = detail::allocAligned<kAlign, Entry>(ring_, size_);
+      if (!bytesAllocated) {
+        fprintf(stderr, "HRDWRingBuffer: allocAligned failed for ring\n");
+        return;
+      }
+      initRing();
+#if CUDART_VERSION >= 13000
+      cudaMemLocation location{cudaMemLocationTypeDevice, device};
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      cudaMemAdvise(
+          ring_, bytesAllocated, cudaMemAdviseSetAccessedBy, location);
+#else
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      cudaMemAdvise(ring_, bytesAllocated, cudaMemAdviseSetAccessedBy, device);
+#endif
+    }
+
+    {
+      auto bytesAllocated = detail::allocAligned<kAlign, uint64_t>(writeIndex_);
+      if (!bytesAllocated) {
+        fprintf(stderr, "HRDWRingBuffer: allocAligned failed for writeIndex\n");
+        return;
+      }
+      *writeIndex_ = 0;
+#if CUDART_VERSION >= 13000
+      cudaMemLocation location{cudaMemLocationTypeDevice, device};
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      cudaMemAdvise(
+          writeIndex_, bytesAllocated, cudaMemAdviseSetAccessedBy, location);
+#else
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      cudaMemAdvise(
+          writeIndex_, bytesAllocated, cudaMemAdviseSetAccessedBy, device);
+#endif
     }
   }
 
@@ -352,6 +495,7 @@ class HRDWRingBuffer {
   uint64_t* writeIndex_{nullptr};
   uint32_t size_{0};
   uint32_t mask_{0};
+  HRDWMemoryStrategy strategy_{HRDWMemoryStrategy::PinnedMapped};
 };
 
 } // namespace meta::comms::colltrace

--- a/comms/utils/colltrace/HRDWRingBufferInstantiations.cu
+++ b/comms/utils/colltrace/HRDWRingBufferInstantiations.cu
@@ -13,6 +13,7 @@ template cudaError_t launchRingBufferWrite<GraphCollTraceEvent>(
     HRDWEntry<GraphCollTraceEvent>*,
     uint64_t*,
     uint32_t,
-    GraphCollTraceEvent);
+    GraphCollTraceEvent,
+    HRDWMemoryStrategy);
 
 } // namespace meta::comms::colltrace

--- a/comms/utils/colltrace/HRDWRingBufferInstantiations.cuh
+++ b/comms/utils/colltrace/HRDWRingBufferInstantiations.cuh
@@ -18,6 +18,7 @@ extern template cudaError_t launchRingBufferWrite<GraphCollTraceEvent>(
     HRDWEntry<GraphCollTraceEvent>*,
     uint64_t*,
     uint32_t,
-    GraphCollTraceEvent);
+    GraphCollTraceEvent,
+    HRDWMemoryStrategy);
 
 } // namespace meta::comms::colltrace

--- a/comms/utils/tests/HRDWRingBufferTestInstantiations.cu
+++ b/comms/utils/tests/HRDWRingBufferTestInstantiations.cu
@@ -13,6 +13,7 @@ template cudaError_t launchRingBufferWrite<TestEvent>(
     HRDWEntry<TestEvent>*,
     uint64_t*,
     uint32_t,
-    TestEvent);
+    TestEvent,
+    HRDWMemoryStrategy);
 
 } // namespace meta::comms::colltrace

--- a/comms/utils/tests/HRDWRingBufferUT.cu
+++ b/comms/utils/tests/HRDWRingBufferUT.cu
@@ -36,25 +36,38 @@ class HRDWRingBufferTestAccessor {
 using TestAccess =
     meta::comms::colltrace::HRDWRingBufferTestAccessor<TestEvent>;
 
-class HRDWRingBufferTest : public ::testing::Test {};
+using HRDWMemoryStrategy = meta::comms::colltrace::HRDWMemoryStrategy;
 
-TEST_F(HRDWRingBufferTest, ConstructionAndAccessors) {
-  TestBuffer buf(64);
+class HRDWRingBufferTest : public ::testing::TestWithParam<HRDWMemoryStrategy> {
+ protected:
+  HRDWMemoryStrategy strategy() const {
+    return GetParam();
+  }
+  void SetUp() override {
+    if (GetParam() == HRDWMemoryStrategy::AtsPageable &&
+        !meta::comms::colltrace::isAtsSupported()) {
+      GTEST_SKIP() << "ATS not supported on this platform";
+    }
+  }
+};
+
+TEST_P(HRDWRingBufferTest, ConstructionAndAccessors) {
+  TestBuffer buf(64, strategy());
   ASSERT_TRUE(buf.valid());
   EXPECT_EQ(buf.size(), 64u);
   EXPECT_NE(TestAccess::ring(buf), nullptr);
 }
 
-TEST_F(HRDWRingBufferTest, InitialEntriesMarkedSlotEmpty) {
-  TestBuffer buf(16);
+TEST_P(HRDWRingBufferTest, InitialEntriesMarkedSlotEmpty) {
+  TestBuffer buf(16, strategy());
   ASSERT_TRUE(buf.valid());
   for (uint32_t i = 0; i < 16; ++i) {
     EXPECT_EQ(TestAccess::ring(buf)[i].sequence, HRDW_RINGBUFFER_SLOT_EMPTY);
   }
 }
 
-TEST_F(HRDWRingBufferTest, MoveConstruction) {
-  TestBuffer buf(32);
+TEST_P(HRDWRingBufferTest, MoveConstruction) {
+  TestBuffer buf(32, strategy());
   ASSERT_TRUE(buf.valid());
 
   TestBuffer moved(std::move(buf));
@@ -65,7 +78,7 @@ TEST_F(HRDWRingBufferTest, MoveConstruction) {
   EXPECT_FALSE(buf.valid()); // NOLINT(bugprone-use-after-move)
 }
 
-TEST_F(HRDWRingBufferTest, MoveAssignment) {
+TEST_P(HRDWRingBufferTest, MoveAssignment) {
   TestBuffer buf1(32);
   TestBuffer buf2(64);
   ASSERT_TRUE(buf1.valid());
@@ -77,14 +90,14 @@ TEST_F(HRDWRingBufferTest, MoveAssignment) {
   EXPECT_FALSE(buf2.valid()); // NOLINT(bugprone-use-after-move)
 }
 
-TEST_F(HRDWRingBufferTest, RoundsUpZeroSize) {
-  TestBuffer buf(0);
+TEST_P(HRDWRingBufferTest, RoundsUpZeroSize) {
+  TestBuffer buf(0, strategy());
   EXPECT_TRUE(buf.valid());
   EXPECT_EQ(buf.size(), 1u);
 }
 
-TEST_F(HRDWRingBufferTest, RoundsUpNonPowerOfTwo) {
-  TestBuffer buf(10);
+TEST_P(HRDWRingBufferTest, RoundsUpNonPowerOfTwo) {
+  TestBuffer buf(10, strategy());
   EXPECT_TRUE(buf.valid());
   EXPECT_EQ(buf.size(), 16u);
 
@@ -98,12 +111,24 @@ TEST_F(HRDWRingBufferTest, RoundsUpNonPowerOfTwo) {
   EXPECT_EQ(buf3.size(), 8u);
 }
 
-class HRDWRingBufferReaderTest : public ::testing::Test {
+INSTANTIATE_TEST_SUITE_P(
+    MemoryStrategies,
+    HRDWRingBufferTest,
+    ::testing::Values(
+        HRDWMemoryStrategy::PinnedMapped,
+        HRDWMemoryStrategy::AtsPageable));
+
+class HRDWRingBufferReaderTest
+    : public ::testing::TestWithParam<HRDWMemoryStrategy> {
  protected:
   static constexpr uint32_t kRingSize = 16;
 
   void SetUp() override {
-    buf_.emplace(kRingSize);
+    if (GetParam() == HRDWMemoryStrategy::AtsPageable &&
+        !meta::comms::colltrace::isAtsSupported()) {
+      GTEST_SKIP() << "ATS not supported on this platform";
+    }
+    buf_.emplace(kRingSize, GetParam());
     ASSERT_TRUE(buf_->valid());
     reader_.emplace(*buf_);
     ASSERT_EQ(cudaStreamCreate(&stream_), cudaSuccess);
@@ -139,7 +164,7 @@ class HRDWRingBufferReaderTest : public ::testing::Test {
   cudaStream_t stream_{nullptr};
 };
 
-TEST_F(HRDWRingBufferReaderTest, EmptyBufferReturnsNothing) {
+TEST_P(HRDWRingBufferReaderTest, EmptyBufferReturnsNothing) {
   std::vector<uint32_t> seen;
   auto result = reader_->poll(
       [&](const TestEntry& e, uint64_t) { seen.push_back(e.data.tag); });
@@ -149,7 +174,7 @@ TEST_F(HRDWRingBufferReaderTest, EmptyBufferReturnsNothing) {
   EXPECT_TRUE(seen.empty());
 }
 
-TEST_F(HRDWRingBufferReaderTest, ReadsSingleEntry) {
+TEST_P(HRDWRingBufferReaderTest, ReadsSingleEntry) {
   writeEntry(42);
 
   std::vector<uint32_t> seen;
@@ -165,7 +190,7 @@ TEST_F(HRDWRingBufferReaderTest, ReadsSingleEntry) {
   EXPECT_EQ(seen, expected);
 }
 
-TEST_F(HRDWRingBufferReaderTest, ReadsMultipleEntries) {
+TEST_P(HRDWRingBufferReaderTest, ReadsMultipleEntries) {
   writeEntry(1);
   writeEntry(2);
   writeEntry(3);
@@ -179,7 +204,7 @@ TEST_F(HRDWRingBufferReaderTest, ReadsMultipleEntries) {
   EXPECT_EQ(seen, expected);
 }
 
-TEST_F(HRDWRingBufferReaderTest, DoesNotReReadOldEntries) {
+TEST_P(HRDWRingBufferReaderTest, DoesNotReReadOldEntries) {
   writeEntry(1);
   writeEntry(2);
 
@@ -199,7 +224,7 @@ TEST_F(HRDWRingBufferReaderTest, DoesNotReReadOldEntries) {
   EXPECT_EQ(seen, expected);
 }
 
-TEST_F(HRDWRingBufferReaderTest, UnstampedEntryStopsScanning) {
+TEST_P(HRDWRingBufferReaderTest, UnstampedEntryStopsScanning) {
   writeEntry(1);
   writeUnstampedSlot(); // writeIndex advanced but sequence not stamped
   writeEntry(3);
@@ -215,7 +240,7 @@ TEST_F(HRDWRingBufferReaderTest, UnstampedEntryStopsScanning) {
   EXPECT_EQ(seen, expected);
 }
 
-TEST_F(HRDWRingBufferReaderTest, WrapAroundReadsCorrectly) {
+TEST_P(HRDWRingBufferReaderTest, WrapAroundReadsCorrectly) {
   // Fill the entire ring.
   for (uint32_t i = 0; i < kRingSize; ++i) {
     writeEntry(i);
@@ -235,7 +260,7 @@ TEST_F(HRDWRingBufferReaderTest, WrapAroundReadsCorrectly) {
   EXPECT_EQ(seen, expected);
 }
 
-TEST_F(HRDWRingBufferReaderTest, CallbackReceivesCorrectSlot) {
+TEST_P(HRDWRingBufferReaderTest, CallbackReceivesCorrectSlot) {
   writeEntry(10);
   writeEntry(20);
 
@@ -247,7 +272,7 @@ TEST_F(HRDWRingBufferReaderTest, CallbackReceivesCorrectSlot) {
   EXPECT_EQ(slots, expected);
 }
 
-TEST_F(HRDWRingBufferReaderTest, MultiplePollCyclesAccumulate) {
+TEST_P(HRDWRingBufferReaderTest, MultiplePollCyclesAccumulate) {
   uint64_t totalRead = 0;
 
   for (int cycle = 0; cycle < 5; ++cycle) {
@@ -264,7 +289,7 @@ TEST_F(HRDWRingBufferReaderTest, MultiplePollCyclesAccumulate) {
 // Verify that callbacks receive copies of entries, not references to shared
 // memory. Mutate the ring entry after poll() captures it but before we
 // inspect what the callback received — the callback should see the original.
-TEST_F(HRDWRingBufferReaderTest, CallbackReceivesSnapshotNotReference) {
+TEST_P(HRDWRingBufferReaderTest, CallbackReceivesSnapshotNotReference) {
   writeEntry(42);
 
   uint64_t observedTimestamp = 0;
@@ -283,7 +308,7 @@ TEST_F(HRDWRingBufferReaderTest, CallbackReceivesSnapshotNotReference) {
 
 // Verify that overwritten entries (where sequence is a different valid
 // slot from a later wrap-around) are counted as lost and never delivered.
-TEST_F(HRDWRingBufferReaderTest, OverwrittenEntriesNeverDelivered) {
+TEST_P(HRDWRingBufferReaderTest, OverwrittenEntriesNeverDelivered) {
   // Write kRingSize entries to fill the buffer.
   for (uint32_t i = 0; i < kRingSize; ++i) {
     writeEntry(i);
@@ -310,7 +335,7 @@ TEST_F(HRDWRingBufferReaderTest, OverwrittenEntriesNeverDelivered) {
 }
 
 // Verify that data and timestamps are correctly preserved.
-TEST_F(HRDWRingBufferReaderTest, DataAndTimestampsPreserved) {
+TEST_P(HRDWRingBufferReaderTest, DataAndTimestampsPreserved) {
   writeEntry(10);
   writeEntry(20);
 
@@ -337,7 +362,7 @@ TEST_F(HRDWRingBufferReaderTest, DataAndTimestampsPreserved) {
 
 // Verify that unstamped entries stop scanning, and subsequent polls
 // pick up the entry once it's stamped.
-TEST_F(HRDWRingBufferReaderTest, UnstampedEntryResumesAfterStamp) {
+TEST_P(HRDWRingBufferReaderTest, UnstampedEntryResumesAfterStamp) {
   writeEntry(1);
   writeUnstampedSlot();
   writeEntry(3);
@@ -368,7 +393,7 @@ TEST_F(HRDWRingBufferReaderTest, UnstampedEntryResumesAfterStamp) {
   EXPECT_EQ(reader_->lastReadIndex(), 3u);
 }
 
-TEST_F(HRDWRingBufferReaderTest, TimeoutReturnsImmediatelyWhenNoEntries) {
+TEST_P(HRDWRingBufferReaderTest, TimeoutReturnsImmediatelyWhenNoEntries) {
   auto result = reader_->poll(
       [](const TestEntry&, uint64_t) {}, std::chrono::milliseconds{50});
   EXPECT_EQ(result.entriesRead, 0u);
@@ -376,14 +401,14 @@ TEST_F(HRDWRingBufferReaderTest, TimeoutReturnsImmediatelyWhenNoEntries) {
   EXPECT_FALSE(result.timedOut);
 }
 
-TEST_F(HRDWRingBufferReaderTest, ZeroTimeoutReturnsImmediatelyWhenEmpty) {
+TEST_P(HRDWRingBufferReaderTest, ZeroTimeoutReturnsImmediatelyWhenEmpty) {
   auto result = reader_->poll(
       [](const TestEntry&, uint64_t) {}, std::chrono::milliseconds{0});
   EXPECT_EQ(result.entriesRead, 0u);
   EXPECT_FALSE(result.timedOut);
 }
 
-TEST_F(HRDWRingBufferReaderTest, ZeroTimeoutStillReadsAvailableEntries) {
+TEST_P(HRDWRingBufferReaderTest, ZeroTimeoutStillReadsAvailableEntries) {
   writeEntry(1);
   writeEntry(2);
   writeEntry(3);
@@ -399,7 +424,7 @@ TEST_F(HRDWRingBufferReaderTest, ZeroTimeoutStillReadsAvailableEntries) {
   EXPECT_EQ(seen, expected);
 }
 
-TEST_F(HRDWRingBufferReaderTest, TimeoutBoundsOverwrittenProcessing) {
+TEST_P(HRDWRingBufferReaderTest, TimeoutBoundsOverwrittenProcessing) {
   // Fill the ring completely, then overwrite all entries multiple times.
   // This simulates the reader being heavily lapped.
   for (uint32_t lap = 0; lap < 10; ++lap) {
@@ -421,7 +446,7 @@ TEST_F(HRDWRingBufferReaderTest, TimeoutBoundsOverwrittenProcessing) {
   EXPECT_EQ(result.entriesRead + result.entriesLost, kTotalEntries);
 }
 
-TEST_F(HRDWRingBufferReaderTest, OnePastLapJumpsToTailLosesOne) {
+TEST_P(HRDWRingBufferReaderTest, OnePastLapJumpsToTailLosesOne) {
   // Write ringSize + 1 entries. Reader should jump to tail, losing 1.
   for (uint32_t i = 0; i < kRingSize + 1; ++i) {
     writeEntry(i);
@@ -436,7 +461,7 @@ TEST_F(HRDWRingBufferReaderTest, OnePastLapJumpsToTailLosesOne) {
   EXPECT_EQ(result.entriesRead + result.entriesLost, kRingSize + 1);
 }
 
-TEST_F(HRDWRingBufferReaderTest, JumpToTailAfterPartialRead) {
+TEST_P(HRDWRingBufferReaderTest, JumpToTailAfterPartialRead) {
   // Write some entries, poll to read them, then write enough to lap.
   for (uint32_t i = 0; i < 4; ++i) {
     writeEntry(i);
@@ -459,6 +484,13 @@ TEST_F(HRDWRingBufferReaderTest, JumpToTailAfterPartialRead) {
       result.entriesRead + result.entriesLost,
       static_cast<uint64_t>(kRingSize + 3));
 }
+
+INSTANTIATE_TEST_SUITE_P(
+    MemoryStrategies,
+    HRDWRingBufferReaderTest,
+    ::testing::Values(
+        HRDWMemoryStrategy::PinnedMapped,
+        HRDWMemoryStrategy::AtsPageable));
 
 // ---------------------------------------------------------------------------
 // Destruction: verify ~HRDWRingBuffer destructs live entries.


### PR DESCRIPTION
Summary:
```
  GPU: NVIDIA H100, clock: 1980000 kHz (0.51 ns/cycle)
  ATS supported: YES

  DWTelemetryGuard microbenchmark (100000 iters, ring=1048576)
  Baseline (no guard):          0.0 ns/iter
  Guard disabled:               0.0 ns/iter
  Guard enabled (ATS):   1172.1 ns/iter
  Guard enabled (Pinned):    5391.2 ns/iter
  ATS speedup:                  4.6x
```

Differential Revision: D99466730


