### PR TITLE
build: support uv build --no-build-isolation + fmt fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,12 @@ project(torchcomms_ncclx)
 set(CMAKE_VERBOSE_MAKEFILE ON)
 set(FETCHCONTENT_BASE_DIR "build/fetchcontent")
 
+# Some fetched third-party projects still declare pre-3.5 policy versions.
+# Newer CMake releases reject those unless we set a minimum policy floor.
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.31)
+    set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
+endif()
+
 # Options
 option(USE_NCCL "Whether to build NCCL or not" ON)
 option(USE_NCCLX "Whether to build NCCLX or not" ON)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,28 @@
+include CMakeLists.txt
+include LICENSE
+include README.md
+include pyproject.toml
+include requirements.txt
+include setup.py
+include version.txt
+include build_ncclx.sh
+include build_rccl.sh
+include build_rcclx.sh
+include rename_symbols.sh
+include setup_rcclx.sh
+
+graft comms
+graft scripts
+
+prune build
+prune dist
+prune .venv
+prune .pytest_cache
+prune comms/torchcomms/__pycache__
+prune comms/torchcomms.egg-info
+
+global-exclude *.py[cod]
+global-exclude *.so
+global-exclude *.a
+global-exclude *.o
+global-exclude *.swp

--- a/build_ncclx.sh
+++ b/build_ncclx.sh
@@ -20,6 +20,7 @@ function do_cmake_build() {
     -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
     -DCMAKE_CXX_STANDARD=20 \
     -DCMAKE_POLICY_VERSION_MINIMUM=3.22 \
+    -DCMAKE_CXX_FLAGS="-DFMT_HEADER_ONLY=1" \
     $extra_flags \
     -S "${source_dir}"
   ninja -j$(nproc)
@@ -336,11 +337,17 @@ THRIFT_SERVICE_LDFLAGS+=(
   "-l:libxxhash.a"
 )
 THIRD_PARTY_LDFLAGS+="${THRIFT_SERVICE_LDFLAGS[*]} "
-THIRD_PARTY_LDFLAGS+="$(pkg-config --libs --static libfolly) "
+# Filter -lfmt from folly's pkg-config: fmt is used header-only (FMT_HEADER_ONLY=1)
+THIRD_PARTY_LDFLAGS+="$(pkg-config --libs --static libfolly | sed 's/-lfmt\b//g') "
+# liburing: folly's cmake config declares this dependency but pkg-config omits
+# it. Add -luring if the system has liburing (folly uses io_uring for async I/O).
+if pkg-config --exists liburing 2>/dev/null; then
+  THIRD_PARTY_LDFLAGS+="-luring "
+fi
 if [[ -z "${USE_SYSTEM_LIBS}" ]]; then
-  THIRD_PARTY_LDFLAGS+="-l:libglog.a -l:libgflags.a -l:libboost_context.a -l:libfmt.a -l:libssl.a -l:libcrypto.a"
+  THIRD_PARTY_LDFLAGS+="-l:libglog.a -l:libgflags.a -l:libboost_context.a -l:libssl.a -l:libcrypto.a"
 else
-  THIRD_PARTY_LDFLAGS+="-lglog -lgflags -lboost_context -lfmt -lssl -lcrypto"
+  THIRD_PARTY_LDFLAGS+="-lglog -lgflags -lboost_context -lssl -lcrypto"
 fi
 
 echo "$THIRD_PARTY_LDFLAGS"

--- a/build_rcclx.sh
+++ b/build_rcclx.sh
@@ -25,6 +25,7 @@ function do_cmake_build() {
     -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
     -DCMAKE_CXX_STANDARD=20 \
     -DCMAKE_POLICY_VERSION_MINIMUM=3.22 \
+    -DCMAKE_CXX_FLAGS="-DFMT_HEADER_ONLY=1" \
     $extra_flags \
     -S "${source_dir}"
   ninja
@@ -294,11 +295,11 @@ THRIFT_SERVICE_LDFLAGS=(
   "-l:libxxhash.a"
 )
 THIRD_PARTY_LDFLAGS+="${THRIFT_SERVICE_LDFLAGS[*]} "
-THIRD_PARTY_LDFLAGS+="$(pkg-config --libs --static libfolly) "
+THIRD_PARTY_LDFLAGS+="$(pkg-config --libs --static libfolly | sed 's/-lfmt\b//g') "
 if [[ -z "${USE_SYSTEM_LIBS}" ]]; then
-  THIRD_PARTY_LDFLAGS+="-lglog -lgflags -l:libboost_context.a -l:libfmt.a -l:libssl.a -l:libcrypto.a"
+  THIRD_PARTY_LDFLAGS+="-lglog -lgflags -l:libboost_context.a -l:libssl.a -l:libcrypto.a"
 else
-  THIRD_PARTY_LDFLAGS+="-lglog -lgflags -lboost_context -lfmt -lssl -lcrypto"
+  THIRD_PARTY_LDFLAGS+="-lglog -lgflags -lboost_context -lssl -lcrypto"
 fi
 
 echo "$THIRD_PARTY_LDFLAGS"

--- a/comms/ncclx/v2_27/src/Makefile
+++ b/comms/ncclx/v2_27/src/Makefile
@@ -17,6 +17,7 @@ include ../makefiles/version.mk
 
 ##### Mock Scuba Data in CMake build
 CXXFLAGS += -DMOCK_SCUBA_DATA -DFOLLY_XLOG_STRIP_PREFIXES=\"${BASE_DIR}\"
+CXXFLAGS += -DFMT_HEADER_ONLY=1
 
 ifeq ($(ENABLE_TCPDM),0)
 CXXFLAGS += -DCTRAN_DISABLE_TCPDM

--- a/comms/ncclx/v2_28/src/Makefile
+++ b/comms/ncclx/v2_28/src/Makefile
@@ -17,6 +17,7 @@ include ../makefiles/version.mk
 
 ##### Mock Scuba Data in CMake build
 CXXFLAGS += -DMOCK_SCUBA_DATA -DFOLLY_XLOG_STRIP_PREFIXES=\"${BASE_DIR}\"
+CXXFLAGS += -DFMT_HEADER_ONLY=1
 
 ifeq ($(ENABLE_TCPDM),0)
 CXXFLAGS += -DCTRAN_DISABLE_TCPDM

--- a/comms/ncclx/v2_29/src/Makefile
+++ b/comms/ncclx/v2_29/src/Makefile
@@ -18,6 +18,8 @@ include ../makefiles/version.mk
 
 ##### Mock Scuba Data in CMake build
 CXXFLAGS += -DMOCK_SCUBA_DATA -DFOLLY_XLOG_STRIP_PREFIXES=\"${BASE_DIR}\"
+# Use header-only fmt to avoid runtime dependency on libfmt.so
+CXXFLAGS += -DFMT_HEADER_ONLY=1
 
 ifeq ($(ENABLE_TCPDM),0)
 CXXFLAGS += -DCTRAN_DISABLE_TCPDM

--- a/comms/rcclx/develop/src/Makefile
+++ b/comms/rcclx/develop/src/Makefile
@@ -6,6 +6,8 @@
 include ../makefiles/common.mk
 include ../makefiles/version.mk
 
+CXXFLAGS += -DFMT_HEADER_ONLY=1
+
 ##### src files
 INCEXPORTS  := nccl.h
 LIBSRCFILES := \

--- a/comms/rcclx/snapshots/last-stable/comms/rcclx/develop/src/Makefile
+++ b/comms/rcclx/snapshots/last-stable/comms/rcclx/develop/src/Makefile
@@ -6,6 +6,8 @@
 include ../makefiles/common.mk
 include ../makefiles/version.mk
 
+CXXFLAGS += -DFMT_HEADER_ONLY=1
+
 ##### src files
 INCEXPORTS  := nccl.h
 LIBSRCFILES := \

--- a/comms/rcclx/snapshots/stable/comms/rcclx/develop/src/Makefile
+++ b/comms/rcclx/snapshots/stable/comms/rcclx/develop/src/Makefile
@@ -6,6 +6,8 @@
 include ../makefiles/common.mk
 include ../makefiles/version.mk
 
+CXXFLAGS += -DFMT_HEADER_ONLY=1
+
 ##### src files
 INCEXPORTS  := nccl.h
 LIBSRCFILES := \

--- a/comms/torchcomms/cmake/third_party/fmt.cmake
+++ b/comms/torchcomms/cmake/third_party/fmt.cmake
@@ -2,42 +2,32 @@
 
 include_guard(GLOBAL)
 
-# We need static fmt — shared libs can't be shipped in wheels.
-# Check for static library first (e.g., installed by build_ncclx.sh).
-# This avoids find_package creating SHARED IMPORTED targets that can't be
-# rejected without a duplicate-target conflict in the FetchContent fallback.
-if(EXISTS "${CONDA_INCLUDE}/fmt/format.h")
-    # Prefer static, fall back to shared.
-    if(EXISTS "${CONDA_LIB}/libfmt.a")
-        set(_FMT_LIB "${CONDA_LIB}/libfmt.a")
-    elseif(EXISTS "${CONDA_LIB}/libfmt.so")
-        set(_FMT_LIB "${CONDA_LIB}/libfmt.so")
-    else()
-        set(_FMT_LIB "fmt")
-    endif()
+# torchcomms uses fmt via its headers. Keep the dependency header-only so we
+# do not require libfmt binaries in local builds or shipped wheels.
+function(_torchcomms_configure_header_only_fmt include_dir)
     add_library(fmt::fmt INTERFACE IMPORTED GLOBAL)
     set_target_properties(fmt::fmt PROPERTIES
-        INTERFACE_INCLUDE_DIRECTORIES "${CONDA_INCLUDE}"
-        INTERFACE_LINK_LIBRARIES "${_FMT_LIB}"
+        INTERFACE_INCLUDE_DIRECTORIES "${include_dir}"
+        INTERFACE_COMPILE_DEFINITIONS "FMT_HEADER_ONLY=1"
     )
-    message(STATUS "Using fmt: ${_FMT_LIB}")
+endfunction()
+
+find_path(_FMT_INCLUDE_DIR
+    NAMES fmt/format.h
+    HINTS "${CONDA_INCLUDE}"
+)
+
+if(_FMT_INCLUDE_DIR)
+    _torchcomms_configure_header_only_fmt("${_FMT_INCLUDE_DIR}")
+    message(STATUS "Using header-only fmt from: ${_FMT_INCLUDE_DIR}")
 else()
-    find_package(fmt 11.2.0 QUIET CONFIG NO_CMAKE_PACKAGE_REGISTRY)
-    if(fmt_FOUND)
-        message(STATUS "Found system fmt: ${fmt_VERSION}")
-    else()
-        message(STATUS "System fmt not found, fetching 11.2.0 header-only via FetchContent")
-        include(FetchContent)
-        FetchContent_Declare(
-            fmt
-            GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-            GIT_TAG 11.2.0
-        )
-        FetchContent_Populate(fmt)
-        add_library(fmt::fmt INTERFACE IMPORTED GLOBAL)
-        set_target_properties(fmt::fmt PROPERTIES
-            INTERFACE_INCLUDE_DIRECTORIES "${fmt_SOURCE_DIR}/include"
-            INTERFACE_COMPILE_DEFINITIONS "FMT_HEADER_ONLY=1"
-        )
-    endif()
+    message(STATUS "fmt headers not found, fetching 11.2.0 header-only via FetchContent")
+    include(FetchContent)
+    FetchContent_Declare(
+        fmt
+        GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+        GIT_TAG 11.2.0
+    )
+    FetchContent_Populate(fmt)
+    _torchcomms_configure_header_only_fmt("${fmt_SOURCE_DIR}/include")
 endif()


### PR DESCRIPTION
This makes `uv build` work by using the system cmake (newer) and correctly adding all needed files to the sdist source distribution bulids.

Test plan:

```
$ USE_NCCLX=0 USE_TRANSPORT=0 uv build --no-build-isolation
Successfully built dist/torchcomms-0.2.0.tar.gz
Successfully built dist/torchcomms-0.2.0-cp312-cp312-linux_x86_64.whl

$ uv pip install dist/torchcomms-0.2.0-cp312-cp312-linux_x86_64.whl
$ python -c "import torch; import torchcomms._comms_gloo; import torchcomms._comms_nccl"
```