### PR TITLE
Deprecate nolocal compiler flag for SendRecv and fix colltrace count verification

### DIFF
--- a/comms/ctran/tests/CtranDistSendRecvUT.cc
+++ b/comms/ctran/tests/CtranDistSendRecvUT.cc
@@ -23,15 +23,14 @@ class CtranTestFixture : public ctran::CtranDistTestFixture,
   std::vector<TestMemSegment> segments;
   std::shared_ptr<ctran::RegCache> regCache{nullptr};
 
-  void SetUp() override {
+  void setUpWithEnvs(const ctran::CtranEnvs& envs = {}) {
     setenv("NCCL_COLLTRACE", "trace", 0);
     setenv("NCCL_COLLTRACE_USE_NEW_COLLTRACE", "1", 0);
-    // -1 for not limiting the number of colls to trace
     setenv("NCCL_COLLTRACE_RECORD_MAX", "-1", 0);
     setenv("NCCL_CTRAN_ENABLE", "1", 0);
     setenv("NCCL_CTRAN_TRANSPORT_PROFILER", "1", 0);
     setenv("NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT", "1", 0);
-    ctran::CtranDistTestFixture::SetUp();
+    ctran::CtranDistTestFixture::SetUp(envs);
     srand(time(NULL));
     ctran::logGpuMemoryStats(globalRank);
 
@@ -311,13 +310,16 @@ class CtranTestFixture : public ctran::CtranDistTestFixture,
           // so opName/count are not set.
           if (!opName.empty() && coll.count("count")) {
             EXPECT_EQ(opName, globalRank == sendRank ? "Send" : "Recv");
-            if (globalRank == sendRank && numSendPeers > 1) {
+            if (globalRank == sendRank) {
               // getGroupedP2PMetaData sums counts across all send ops
               EXPECT_EQ(
                   coll["count"].asInt(),
-                  static_cast<int64_t>(count) * numSendPeers);
+                  static_cast<int64_t>(count) * numSendPeers *
+                      numOpPairsPerPeer);
             } else {
-              EXPECT_EQ(coll["count"].asInt(), count);
+              EXPECT_EQ(
+                  coll["count"].asInt(),
+                  static_cast<int64_t>(count) * numOpPairsPerPeer);
             }
           }
         }
@@ -339,13 +341,21 @@ class CtranTestFixture : public ctran::CtranDistTestFixture,
   }
 };
 
+// Param: (CtranEnvs, (offset, count, numMaxQp, memType))
+using CtranTestParams = std::tuple<size_t, ssize_t, int, MemAllocType>;
+
 class CtranTestParamFixture
     : public CtranTestFixture,
       public ::testing::WithParamInterface<
-          std::tuple<size_t, ssize_t, int, MemAllocType>> {};
+          std::tuple<ctran::CtranEnvs, CtranTestParams>> {
+ protected:
+  void SetUp() override {
+    setUpWithEnvs(std::get<0>(GetParam()));
+  }
+};
 
 TEST_P(CtranTestParamFixture, sendRecv) {
-  const auto& [offset, count, numMaxQp, memType] = GetParam();
+  const auto& [offset, count, numMaxQp, memType] = std::get<1>(GetParam());
 
   regCache->init();
 
@@ -356,7 +366,7 @@ TEST_P(CtranTestParamFixture, sendRecv) {
 }
 
 TEST_P(CtranTestParamFixture, sendRecvP2pCopyKernel) {
-  const auto& [offset, count, numMaxQp, memType] = GetParam();
+  const auto& [offset, count, numMaxQp, memType] = std::get<1>(GetParam());
   EnvRAII env1(NCCL_SENDRECV_ALGO, NCCL_SENDRECV_ALGO::ctp2p);
   regCache->init();
   runTest(offset, count, numMaxQp, 1 /* nIter */, memType);
@@ -367,10 +377,16 @@ TEST_P(CtranTestParamFixture, sendRecvP2pCopyKernel) {
 
 class CtranP2pUseListTestFixture
     : public CtranTestFixture,
-      public ::testing::WithParamInterface<size_t /* numOpPairsPerPeer */> {};
+      public ::testing::WithParamInterface<
+          std::tuple<ctran::CtranEnvs, size_t /* numOpPairsPerPeer */>> {
+ protected:
+  void SetUp() override {
+    setUpWithEnvs(std::get<0>(GetParam()));
+  }
+};
 
 TEST_P(CtranP2pUseListTestFixture, sendRecvP2pUseList) {
-  const size_t numOpPairsPerPeer = GetParam();
+  const size_t numOpPairsPerPeer = std::get<1>(GetParam());
 
   // Need enough total send ops to trigger useList (> kCtranMaxNvlSendRecvOps)
   if (numOpPairsPerPeer * (numRanks - 1) <=
@@ -396,15 +412,29 @@ TEST_P(CtranP2pUseListTestFixture, sendRecvP2pUseList) {
 INSTANTIATE_TEST_SUITE_P(
     CtranP2pUseListTest,
     CtranP2pUseListTestFixture,
-    ::testing::Values(
-        /* pool path */ 1,
-        /* ad-hoc alloc path */
-        ctran::sendrecv::kMaxSendRecvOpsPerPoolBuf + 1),
-    [](const testing::TestParamInfo<size_t>& info) {
-      return "numOpPairsPerPeer_" + std::to_string(info.param);
+    ::testing::Combine(
+        ::testing::Values(ctran::kDefaultEnvs, ctran::kNolocalEnvs),
+        ::testing::Values(
+            /* pool path */ 1,
+            /* ad-hoc alloc path */
+            ctran::sendrecv::kMaxSendRecvOpsPerPoolBuf + 1)),
+    [](const testing::TestParamInfo<CtranP2pUseListTestFixture::ParamType>&
+           info) {
+      return ctran::envSuffix(std::get<0>(info.param)) + "numOpPairsPerPeer_" +
+          std::to_string(std::get<1>(info.param));
     });
 
-TEST_F(CtranTestFixture, oneToOneSendRecv) {
+// Envs-only parameterized fixture for tests that have no other params
+class CtranTestEnvFixture
+    : public CtranTestFixture,
+      public ::testing::WithParamInterface<ctran::CtranEnvs> {
+ protected:
+  void SetUp() override {
+    setUpWithEnvs(GetParam());
+  }
+};
+
+TEST_P(CtranTestEnvFixture, oneToOneSendRecv) {
   const size_t offset = 0;
   const ssize_t count = 4096;
   const int numMaxQp = 1;
@@ -417,14 +447,31 @@ TEST_F(CtranTestFixture, oneToOneSendRecv) {
   COMMCHECK_TEST(regCache->destroy());
 }
 
+INSTANTIATE_TEST_SUITE_P(
+    CtranTest,
+    CtranTestEnvFixture,
+    ::testing::Values(ctran::kDefaultEnvs, ctran::kNolocalEnvs),
+    [](const testing::TestParamInfo<ctran::CtranEnvs>& info) {
+      auto s = ctran::envSuffix(info.param);
+      return s.empty() ? std::string("Default") : s;
+    });
+
+// Param: (CtranEnvs, (offset, count, memType))
+using CtranAsyncRegParams = std::tuple<size_t, ssize_t, MemAllocType>;
+
 class CtranAsyncRegTestParamFixture
     : public CtranTestFixture,
       public ::testing::WithParamInterface<
-          std::tuple<size_t, ssize_t, MemAllocType>> {};
+          std::tuple<ctran::CtranEnvs, CtranAsyncRegParams>> {
+ protected:
+  void SetUp() override {
+    setUpWithEnvs(std::get<0>(GetParam()));
+  }
+};
 
 TEST_P(CtranAsyncRegTestParamFixture, sendRecvWithAsyncReg) {
   constexpr int numMaxQp = 1;
-  const auto& [offset, count, memType] = GetParam();
+  const auto& [offset, count, memType] = std::get<1>(GetParam());
   EnvRAII env(NCCL_CTRAN_REGISTER, NCCL_CTRAN_REGISTER::async);
 
   // Reinitialize global cache to enable asyncReg thread (require
@@ -438,18 +485,26 @@ TEST_P(CtranAsyncRegTestParamFixture, sendRecvWithAsyncReg) {
   COMMCHECK_TEST(regCache->destroy());
 }
 
+// Param: (CtranEnvs, (offset, count, memType))
+using CtranSocketTestParams = std::tuple<size_t, ssize_t, MemAllocType>;
+
 class CtranSocketTestParamFixture
     : public CtranTestFixture,
       public ::testing::WithParamInterface<
-          std::tuple<size_t, ssize_t, MemAllocType>> {};
+          std::tuple<ctran::CtranEnvs, CtranSocketTestParams>> {
+ protected:
+  void SetUp() override {
+    setUpWithEnvs(std::get<0>(GetParam()));
+  }
+};
 
 TEST_P(CtranSocketTestParamFixture, nvlSendRecv) {
-  if (enableNolocal || localSize < numRanks) {
+  if (ctran::isNolocalTopo() || localSize < numRanks) {
     GTEST_SKIP()
         << "Ctran Socket + NVL backend require intra-node only environment. Skip test";
   }
   const int numMaxQp = 1;
-  const auto& [offset, count, memType] = GetParam();
+  const auto& [offset, count, memType] = std::get<1>(GetParam());
 
   regCache->init();
   EnvRAII env1(
@@ -468,60 +523,68 @@ TEST_P(CtranSocketTestParamFixture, nvlSendRecv) {
 INSTANTIATE_TEST_SUITE_P(
     CtranTest,
     CtranTestParamFixture,
-    ::testing::Values(
-        // offset in bytes, count of float32, numMaxQp
-        // test cudaMalloc based memory
-        std::make_tuple(0, 4096, 1, kMemCudaMalloc),
-        std::make_tuple(0, 4096, 4, kMemCudaMalloc),
-        std::make_tuple(0, 65536, 1, kMemCudaMalloc),
-        std::make_tuple(0, 65536, 4, kMemCudaMalloc),
-        std::make_tuple(0, 65536, 8, kMemCudaMalloc),
-        // test ncclMemAlloc based memory
-        std::make_tuple(0, 4096, 1, kMemNcclMemAlloc),
-        std::make_tuple(0, 4096, 4, kMemNcclMemAlloc),
-        // unaligned addr and size
-        std::make_tuple(5, 2097155, 1, kMemNcclMemAlloc),
-        // unaligned size
-        std::make_tuple(0, 2097155, 1, kMemNcclMemAlloc),
-        // unaligned with multiple QPs
-        std::make_tuple(0, 2097155, 8, kMemNcclMemAlloc),
-        // large and unaligned
-        std::make_tuple(5, 1073741819, 1, kMemNcclMemAlloc),
-        // large with multiple QPs
-        std::make_tuple(0, 2147483648, 4, kMemNcclMemAlloc),
-        std::make_tuple(0, 2147483648, 16, kMemNcclMemAlloc),
-        // test ncclMemAllocDisjoint memory
-        std::make_tuple(0, 1UL << 21, 16, kCuMemAllocDisjoint)),
-    [&](const testing::TestParamInfo<CtranTestParamFixture::ParamType>& info) {
-      return std::to_string(std::get<0>(info.param)) + "offset_" +
-          std::to_string(std::get<1>(info.param)) + "int_" +
-          std::to_string(std::get<2>(info.param)) + "maxQp_" +
-          testMemAllocTypeToStr(std::get<3>(info.param));
+    ::testing::Combine(
+        ::testing::Values(ctran::kDefaultEnvs, ctran::kNolocalEnvs),
+        ::testing::Values(
+            // offset in bytes, count of float32, numMaxQp
+            // test cudaMalloc based memory
+            CtranTestParams(0, 4096, 1, kMemCudaMalloc),
+            CtranTestParams(0, 4096, 4, kMemCudaMalloc),
+            CtranTestParams(0, 65536, 1, kMemCudaMalloc),
+            CtranTestParams(0, 65536, 4, kMemCudaMalloc),
+            CtranTestParams(0, 65536, 8, kMemCudaMalloc),
+            // test ncclMemAlloc based memory
+            CtranTestParams(0, 4096, 1, kMemNcclMemAlloc),
+            CtranTestParams(0, 4096, 4, kMemNcclMemAlloc),
+            // unaligned addr and size
+            CtranTestParams(5, 2097155, 1, kMemNcclMemAlloc),
+            // unaligned size
+            CtranTestParams(0, 2097155, 1, kMemNcclMemAlloc),
+            // unaligned with multiple QPs
+            CtranTestParams(0, 2097155, 8, kMemNcclMemAlloc),
+            // large and unaligned
+            CtranTestParams(5, 1073741819, 1, kMemNcclMemAlloc),
+            // large with multiple QPs
+            CtranTestParams(0, 2147483648, 4, kMemNcclMemAlloc),
+            CtranTestParams(0, 2147483648, 16, kMemNcclMemAlloc),
+            // test ncclMemAllocDisjoint memory
+            CtranTestParams(0, 1UL << 21, 16, kCuMemAllocDisjoint))),
+    [](const testing::TestParamInfo<CtranTestParamFixture::ParamType>& info) {
+      const auto& inner = std::get<1>(info.param);
+      return ctran::envSuffix(std::get<0>(info.param)) +
+          std::to_string(std::get<0>(inner)) + "offset_" +
+          std::to_string(std::get<1>(inner)) + "int_" +
+          std::to_string(std::get<2>(inner)) + "maxQp_" +
+          testMemAllocTypeToStr(std::get<3>(inner));
     });
 
 INSTANTIATE_TEST_SUITE_P(
     CtranAsyncRegTest,
     CtranAsyncRegTestParamFixture,
-    ::testing::Values(
-        // offset in bytes, count of float32
-        // test cudaMalloc based memory
-        std::make_tuple(0, 4096, kMemCudaMalloc),
-        std::make_tuple(0, 65536, kMemCudaMalloc),
-        // // test ncclMemAlloc based memory
-        std::make_tuple(0, 4096, kMemNcclMemAlloc),
-        // // unaligned addr and size
-        std::make_tuple(5, 2097155, kMemNcclMemAlloc),
-        // // unaligned size
-        std::make_tuple(0, 2097155, kMemNcclMemAlloc),
-        // large and unaligned
-        std::make_tuple(5, 1073741819, kMemNcclMemAlloc),
-        // // test ncclMemAllocDisjoint memory
-        std::make_tuple(0, 1UL << 21, kCuMemAllocDisjoint)),
-    [&](const testing::TestParamInfo<CtranAsyncRegTestParamFixture::ParamType>&
-            info) {
-      return std::to_string(std::get<0>(info.param)) + "offset_" +
-          std::to_string(std::get<1>(info.param)) + "int_" +
-          testMemAllocTypeToStr(std::get<2>(info.param));
+    ::testing::Combine(
+        ::testing::Values(ctran::kDefaultEnvs, ctran::kNolocalEnvs),
+        ::testing::Values(
+            // offset in bytes, count of float32
+            // test cudaMalloc based memory
+            CtranAsyncRegParams(0, 4096, kMemCudaMalloc),
+            CtranAsyncRegParams(0, 65536, kMemCudaMalloc),
+            // test ncclMemAlloc based memory
+            CtranAsyncRegParams(0, 4096, kMemNcclMemAlloc),
+            // unaligned addr and size
+            CtranAsyncRegParams(5, 2097155, kMemNcclMemAlloc),
+            // unaligned size
+            CtranAsyncRegParams(0, 2097155, kMemNcclMemAlloc),
+            // large and unaligned
+            CtranAsyncRegParams(5, 1073741819, kMemNcclMemAlloc),
+            // test ncclMemAllocDisjoint memory
+            CtranAsyncRegParams(0, 1UL << 21, kCuMemAllocDisjoint))),
+    [](const testing::TestParamInfo<CtranAsyncRegTestParamFixture::ParamType>&
+           info) {
+      const auto& inner = std::get<1>(info.param);
+      return ctran::envSuffix(std::get<0>(info.param)) +
+          std::to_string(std::get<0>(inner)) + "offset_" +
+          std::to_string(std::get<1>(inner)) + "int_" +
+          testMemAllocTypeToStr(std::get<2>(inner));
     });
 
 // test various size and various num of max QP, intentionally make some sizes
@@ -529,30 +592,40 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     CtranTest,
     CtranSocketTestParamFixture,
-    ::testing::Values(
-        // // test ncclMemAlloc based memory
-        std::make_tuple(0, 4096, kMemNcclMemAlloc),
-        // // unaligned addr and size
-        std::make_tuple(0, 2097155, kMemNcclMemAlloc),
-        // // unaligned size
-        std::make_tuple(5, 2097155, kMemNcclMemAlloc),
-        // large and unaligned
-        std::make_tuple(5, 1073741819, kMemNcclMemAlloc)),
-    [&](const testing::TestParamInfo<CtranSocketTestParamFixture::ParamType>&
-            info) {
-      return std::to_string(std::get<0>(info.param)) + "offset_" +
-          std::to_string(std::get<1>(info.param)) + "int_" +
-          testMemAllocTypeToStr(std::get<2>(info.param));
+    ::testing::Combine(
+        ::testing::Values(ctran::kDefaultEnvs, ctran::kNolocalEnvs),
+        ::testing::Values(
+            // test ncclMemAlloc based memory
+            CtranSocketTestParams(0, 4096, kMemNcclMemAlloc),
+            // unaligned addr and size
+            CtranSocketTestParams(0, 2097155, kMemNcclMemAlloc),
+            // unaligned size
+            CtranSocketTestParams(5, 2097155, kMemNcclMemAlloc),
+            // large and unaligned
+            CtranSocketTestParams(5, 1073741819, kMemNcclMemAlloc))),
+    [](const testing::TestParamInfo<CtranSocketTestParamFixture::ParamType>&
+           info) {
+      const auto& inner = std::get<1>(info.param);
+      return ctran::envSuffix(std::get<0>(info.param)) +
+          std::to_string(std::get<0>(inner)) + "offset_" +
+          std::to_string(std::get<1>(inner)) + "int_" +
+          testMemAllocTypeToStr(std::get<2>(inner));
     });
 
 #if not defined(__HIP_PLATFORM_AMD__) and not defined(__HIP_PLATFORM_HCC__)
 
 class CtranP2pCudaGraphTestFixture
     : public CtranTestFixture,
-      public ::testing::WithParamInterface<bool /* oneToOne */> {};
+      public ::testing::WithParamInterface<
+          std::tuple<ctran::CtranEnvs, bool /* oneToOne */>> {
+ protected:
+  void SetUp() override {
+    setUpWithEnvs(std::get<0>(GetParam()));
+  }
+};
 
 TEST_P(CtranP2pCudaGraphTestFixture, sendRecvP2p) {
-  const bool oneToOne = GetParam();
+  const bool oneToOne = std::get<1>(GetParam());
   EnvRAII env1(NCCL_SENDRECV_ALGO, NCCL_SENDRECV_ALGO::ctp2p);
   regCache->init();
   runTest(
@@ -571,11 +644,15 @@ TEST_P(CtranP2pCudaGraphTestFixture, sendRecvP2p) {
 INSTANTIATE_TEST_SUITE_P(
     CtranP2pCudaGraphTest,
     CtranP2pCudaGraphTestFixture,
-    ::testing::Values(
-        /* useList path */ false,
-        /* non-useList path */ true),
-    [](const testing::TestParamInfo<bool>& info) {
-      return "useList_" + std::to_string(!info.param);
+    ::testing::Combine(
+        ::testing::Values(ctran::kDefaultEnvs, ctran::kNolocalEnvs),
+        ::testing::Values(
+            /* useList path */ false,
+            /* non-useList path */ true)),
+    [](const testing::TestParamInfo<CtranP2pCudaGraphTestFixture::ParamType>&
+           info) {
+      return ctran::envSuffix(std::get<0>(info.param)) + "useList_" +
+          std::to_string(!std::get<1>(info.param));
     });
 
 #endif

--- a/comms/ctran/tests/CtranDistTestUtils.cc
+++ b/comms/ctran/tests/CtranDistTestUtils.cc
@@ -57,6 +57,19 @@ void CtranDistEnvironment::SetUp() {
 // ============================================================================
 
 void CtranDistTestFixture::SetUp() {
+  SetUp(CtranEnvs{});
+}
+
+void CtranDistTestFixture::SetUp(const CtranEnvs& envs) {
+  // Save old env values and apply overrides.
+  for (const auto& [key, value] : envs) {
+    const char* oldVal = getenv(key.c_str());
+    savedEnvs_[key] =
+        oldVal ? std::optional<std::string>(oldVal) : std::nullopt;
+    setenv(key.c_str(), value.c_str(), 1);
+  }
+
+  ncclCvarInit();
   distSetUp();
 
   cudaDev = localRank;
@@ -71,7 +84,7 @@ void CtranDistTestFixture::SetUp() {
 
   if (globalRank == 0) {
     XLOG(DBG) << "Testing with NCCL_COMM_STATE_DEBUG_TOPO="
-              << (enableNolocal ? "nolocal" : "default");
+              << (isNolocalTopo() ? "nolocal" : "default");
   }
 
   stream.emplace(cudaStreamNonBlocking);
@@ -79,6 +92,17 @@ void CtranDistTestFixture::SetUp() {
 
 void CtranDistTestFixture::TearDown() {
   stream.reset();
+
+  // Restore original env values.
+  for (const auto& [key, value] : savedEnvs_) {
+    if (value) {
+      setenv(key.c_str(), value->c_str(), 1);
+    } else {
+      unsetenv(key.c_str());
+    }
+  }
+  savedEnvs_.clear();
+
   distTearDown();
 }
 

--- a/comms/ctran/tests/CtranDistTestUtils.h
+++ b/comms/ctran/tests/CtranDistTestUtils.h
@@ -3,9 +3,12 @@
 #pragma once
 
 #include <atomic>
+#include <cstdlib>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "comms/ctran/CtranComm.h"
@@ -13,6 +16,32 @@
 #include "comms/testinfra/DistTestBase.h"
 
 namespace ctran {
+
+// Environment variable overrides for parameterized test topologies.
+// Reusable by all ctran test files migrating from compiler-flag nolocal.
+using CtranEnvs = std::vector<std::pair<std::string, std::string>>;
+
+inline const CtranEnvs kDefaultEnvs = {};
+inline const CtranEnvs kNolocalEnvs = {
+    {"NCCL_COMM_STATE_DEBUG_TOPO", "nolocal"}};
+
+// Returns a test-name prefix based on the env overrides (e.g. "Nolocal_").
+inline std::string envSuffix(const CtranEnvs& envs) {
+  std::string suffix;
+  for (const auto& [key, value] : envs) {
+    if (key == "NCCL_COMM_STATE_DEBUG_TOPO" && value == "nolocal") {
+      suffix += "Nolocal_";
+    }
+  }
+  return suffix;
+}
+
+// Runtime check for nolocal topology via the environment variable.
+// Replaces the compile-time enableNolocal member for migrated tests.
+inline bool isNolocalTopo() {
+  const char* env = getenv("NCCL_COMM_STATE_DEBUG_TOPO");
+  return env && std::string(env) == "nolocal";
+}
 
 // Ctran-specific environment that inherits DistEnvironmentBase and adds
 // ctran-specific env vars (NCCL_CTRAN_ENABLE, profiling, etc.)
@@ -32,6 +61,11 @@ class CtranDistTestFixture : public CtranTestFixtureBase,
  public:
  protected:
   void SetUp() override;
+
+  // SetUp with runtime env-var overrides. Saves old values, applies overrides,
+  // re-inits CVARs, then calls the base SetUp(). TearDown restores them.
+  void SetUp(const CtranEnvs& envs);
+
   void TearDown() override;
 
   std::unique_ptr<CtranComm> makeCtranComm();
@@ -52,6 +86,9 @@ class CtranDistTestFixture : public CtranTestFixtureBase,
   }
 
   bool enableNolocal{false};
+
+ private:
+  std::unordered_map<std::string, std::optional<std::string>> savedEnvs_;
 };
 
 // Dump colltrace records from a standalone CtranComm's colltraceNew_.


### PR DESCRIPTION
Summary:
**Context:**
The `-DNCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL` compiler flag is set in
gpu_cpp_distributed_unittest_suite configurations in BUCK. However, it only
applies to the test source files, NOT to the separately-compiled library
ctran_dist_test_utils (CtranDistTestUtils.cc). This makes all #ifdef checks
in CtranDistTestUtils.cc dead code.

This diff Migrate CtranDistSendRecvUT from compile-time `-DNCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL` flag to runtime env-var-based test parameterization.

**Nolocal deprecation:**
- Add shared `CtranEnvs` type, `kDefaultEnvs`/`kNolocalEnvs` constants, `envSuffix()`, and `isNolocalTopo()` helpers to CtranDistTestUtils.h for reuse across ctran tests.
- Convert all 6 test fixtures to include `CtranEnvs` as a parameterized axis via `::testing::Combine`, so both default and nolocal topologies are tested in a single binary.
- Convert `TEST_F(oneToOneSendRecv)` to `TEST_P` with envs-only parameterization.
- Replace `enableNolocal` member check with runtime `ctran::isNolocalTopo()` (getenv-based).
- Remove 3 nolocal BUCK configurations (`1x2_nolocal_init_none`, `1x4_nolocal_init_none`, `1x4_nolocal_init_ring_hybrid`) since nolocal is now covered by test parameterization.

**Bug fix for colltrace count verification:**
- Fix sender count check: remove `numSendPeers > 1` guard and always multiply by `numOpPairsPerPeer` to match `getGroupedP2PMetaData` behavior.
- Fix receiver count check: multiply by `numOpPairsPerPeer` with proper `int64_t` cast.

**Next**
1. Migrate remaining nolocal test, fix broken tests and deprecate nolocal compiler flag
2. Migrate and deprecate other compiler flag

Reviewed By: minsii

Differential Revision: D102049572


