### PR TITLE
Fix gPidTest to match reverted gPid format

### DIFF
--- a/comms/ctran/commstate/tests/CommStateXTest.cc
+++ b/comms/ctran/commstate/tests/CommStateXTest.cc
@@ -583,13 +583,13 @@ TEST(CommStateXTest, gPidTest) {
 
     // Test gPid() for default (current) rank
     std::string expectedGPid = std::string(rankTopologies[rank].host) + ":" +
-        std::to_string(rankTopologies[rank].pid) + ":" + std::to_string(rank);
+        std::to_string(rankTopologies[rank].pid);
     EXPECT_EQ(commState->gPid(), expectedGPid);
 
     // Test gPid(rank) for all ranks
     for (int r = 0; r < nRanks; ++r) {
       std::string expected = std::string(rankTopologies[r].host) + ":" +
-          std::to_string(rankTopologies[r].pid) + ":" + std::to_string(r);
+          std::to_string(rankTopologies[r].pid);
       EXPECT_EQ(commState->gPid(r), expected);
     }
   }


### PR DESCRIPTION
Summary:
D100055198 reverted gPid() from hostname:pid:rank back to hostname:pid
format, but the CommStateXTest::gPidTest was still expecting the old
hostname:pid:rank format. Update the test expectations to match the
new (reverted) gPid() format.

___

overriding_review_checks_triggers_an_audit_and_retroactive_review
Oncall Short Name: networkai_host

Reviewed By: elvinlife

Differential Revision: D101201246


