### PR TITLE
Replace LOG(INFO) with XLOG(DBG) in test utils to reduce log spam

### DIFF
--- a/comms/ctran/tests/CtranTestUtils.cc
+++ b/comms/ctran/tests/CtranTestUtils.cc
@@ -54,7 +54,7 @@ void logGpuMemoryStats(int gpu) {
   CUDACHECK_TEST(cudaMemGetInfo(&free, &total));
   auto mbFree = static_cast<double>(free) / (1024 * 1024);
   auto mbTotal = static_cast<double>(total) / (1024 * 1024);
-  LOG(INFO) << "GPU " << gpu << " memory: " << "freeBytes=" << free << " ("
+  XLOG(DBG) << "GPU " << gpu << " memory: " << "freeBytes=" << free << " ("
             << mbFree << "MB), " << "totalBytes=" << total << "(" << mbTotal
             << "MB)";
 }
@@ -155,7 +155,7 @@ commResult_t commMemAllocDisjoint(
   for (int i = 0; i < numSegments; i++) {
     FB_CUCHECK(cuMemMap(curPtr, alignedSizes[i], 0, handles[i], 0));
     segments.emplace_back(reinterpret_cast<void*>(curPtr), alignedSizes[i]);
-    LOG(INFO) << "ncclMemAllocDisjoint maps segments[" << i << "] ptr "
+    XLOG(DBG) << "ncclMemAllocDisjoint maps segments[" << i << "] ptr "
               << reinterpret_cast<void*>(curPtr) << " size " << alignedSizes[i]
               << "/" << vaSize;
 
@@ -221,7 +221,7 @@ commResult_t commMemFreeDisjoint(
   CUdeviceptr curPtr = (CUdeviceptr)ptr;
   for (int i = 0; i < alignedSizes.size(); i++) {
     FB_CUCHECK(cuMemRetainAllocationHandle(&handle, (void*)curPtr));
-    LOG(INFO) << "ncclMemFreeDisjoint unmaps segments[" << i << "] ptr "
+    XLOG(DBG) << "ncclMemFreeDisjoint unmaps segments[" << i << "] ptr "
               << reinterpret_cast<void*>(curPtr) << " size " << alignedSizes[i]
               << "/" << vaSize;
     FB_CUCHECK(cuMemRelease(handle));
@@ -316,7 +316,7 @@ commResult_t commMemExpandBuffer(
     buf->segments.emplace_back(
         reinterpret_cast<void*>(curPtr), buf->segmentSize);
 
-    LOG(INFO) << "commMemExpandBuffer maps new segment ptr "
+    XLOG(DBG) << "commMemExpandBuffer maps new segment ptr "
               << reinterpret_cast<void*>(curPtr) << " size "
               << buf->segmentSize;
 


### PR DESCRIPTION
Summary:
The LOG(INFO) calls in CtranTestUtils.cc for memory mapping diagnostics
(logGpuMemoryStats, commMemAllocDisjoint, commMemFreeDisjoint,
commMemExpandBuffer) are noisy during test runs. Replace them with
XLOG(DBG) so they are suppressed by default and only visible when the
folly log level is raised explicitly. This is consistent with
CtranDistTestUtils.cc which already uses XLOG(DBG).

LOG(ERROR) and CLOGF(INFO, ...) calls are left unchanged — errors should
remain visible, and CLOGF provides structured comm-context logging.

___

overriding_review_checks_triggers_an_audit_and_retroactive_review
Oncall Short Name: networkai_host

Reviewed By: elvinlife

Differential Revision: D101264237


