### PR TITLE
Add -luring to build_ncclx.sh for folly io_uring dependency (#2244)

### DIFF
--- a/build_ncclx.sh
+++ b/build_ncclx.sh
@@ -337,6 +337,11 @@ THRIFT_SERVICE_LDFLAGS+=(
 )
 THIRD_PARTY_LDFLAGS+="${THRIFT_SERVICE_LDFLAGS[*]} "
 THIRD_PARTY_LDFLAGS+="$(pkg-config --libs --static libfolly) "
+# liburing: folly's cmake config declares this dependency but pkg-config omits
+# it. Add -luring if the system has liburing (folly uses io_uring for async I/O).
+if pkg-config --exists liburing 2>/dev/null; then
+  THIRD_PARTY_LDFLAGS+="-luring "
+fi
 if [[ -z "${USE_SYSTEM_LIBS}" ]]; then
   THIRD_PARTY_LDFLAGS+="-l:libglog.a -l:libgflags.a -l:libboost_context.a -l:libfmt.a -l:libssl.a -l:libcrypto.a"
 else


### PR DESCRIPTION
Summary:

Folly's cmake config declares `liburing` as a transitive dependency, but `pkg-config --libs --static libfolly doesn't reliably include -luring` does not seem to reliably include it.

So, when `libfolly.a` is compiled with `io_uring` support (which happens when `io_uring` headers are present at build time), linking NCCLx against it produces unresolved `io_uring_*` symbols. Add `-luring` to `THIRD_PARTY_LDFLAGS` when liburing is available via `pkg-config`.

Differential Revision: D102868027


