### PR TITLE
Fix utils dwarf.h transitive include for standalone builds (#2306)

### DIFF
--- a/build_ncclx.sh
+++ b/build_ncclx.sh
@@ -337,6 +337,11 @@ THRIFT_SERVICE_LDFLAGS+=(
 )
 THIRD_PARTY_LDFLAGS+="${THRIFT_SERVICE_LDFLAGS[*]} "
 THIRD_PARTY_LDFLAGS+="$(pkg-config --libs --static libfolly) "
+# liburing: folly's cmake config declares this dependency but pkg-config omits
+# it. Add -luring if the system has liburing (folly uses io_uring for async I/O).
+if pkg-config --exists liburing 2>/dev/null; then
+  THIRD_PARTY_LDFLAGS+="-luring "
+fi
 if [[ -z "${USE_SYSTEM_LIBS}" ]]; then
   THIRD_PARTY_LDFLAGS+="-l:libglog.a -l:libgflags.a -l:libboost_context.a -l:libfmt.a -l:libssl.a -l:libcrypto.a"
 else

--- a/comms/utils/CMakeLists.txt
+++ b/comms/utils/CMakeLists.txt
@@ -33,3 +33,8 @@ target_include_directories(utils PUBLIC
     ${CONDA_INCLUDE}
     ${CUDA_INCLUDE_DIRS}
 )
+# Link folly for transitive include dirs (dwarf.h via Symbolizer.h).
+# Only when the Folly::folly CMake target exists (standalone builds).
+if(TARGET Folly::folly)
+    target_link_libraries(utils PRIVATE Folly::folly)
+endif()


### PR DESCRIPTION
Summary:


**The problem**: the standalone OSS build fails because `NcclScubaSample.cc` includes `<folly/debugging/symbolizer/Symbolizer.h>`, which transitively includes `<dwarf.h>`. When folly is built from source with `elfutils-devel` installed, its CMake target exports the libdwarf include path in `INTERFACE_INCLUDE_DIRECTORIES`. However, `comms/utils/CMakeLists.txt` never links against the `folly` CMake target, so the libdwarf include path is never propagated.

**The solution:** add `target_link_libraries(utils PRIVATE Folly::folly)` so the `utils` OBJECT library inherits folly's transitive include directories. This is guarded by `if(NOT USE_SYSTEM_LIBS)` because the `Folly::folly` CMake target is only created via `find_package(folly)` in the non-system-libs path. Feedstock builds (`USE_SYSTEM_LIBS=1`) are unaffected; they use global include paths and may build folly without dwarf support.

`PRIVATE` is used because `utils` only needs folly's include dirs for its own compilation; its consumers already link folly independently.

NOTE: This is a resubmission of D99763523, which was reverted because D99763523 broke OSS CI (and they were landed together).

Differential Revision: D102868488
