### PR TITLE
Remove neighborReadinessBarrier from AllReduceRing

### DIFF
--- a/comms/ctran/algos/AllReduce/AllReduceRing.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceRing.cc
@@ -1010,45 +1010,6 @@ inline commResult_t completeHostResourceSetup(
         std::string(desc));                                                  \
   }
 
-// Dedicated ctrl exchange for straggler detection, separate from the data
-// credit flow. Each rank signals "I'm ready" to both ring neighbors and waits
-// for both to signal back. The measured duration captures pure setup latency
-// (how long until the slowest neighbor is ready) with no data transfer noise.
-static void neighborReadinessBarrier(
-    CtranComm* comm,
-    const ctran::allreduce::ring::HostArgs& args) {
-  CtranMapperRequest recvFromRight;
-  CtranMapperRequest recvFromLeft;
-  CtranMapperRequest sendToLeft;
-  CtranMapperRequest sendToRight;
-
-  // Post receives first to avoid missed signals
-  FB_COMMCHECKTHROW_EX(
-      comm->ctran_->mapper->irecvCtrl(args.rightRank, &recvFromRight),
-      comm->logMetaData_);
-  FB_COMMCHECKTHROW_EX(
-      comm->ctran_->mapper->irecvCtrl(args.leftRank, &recvFromLeft),
-      comm->logMetaData_);
-
-  // Signal both neighbors
-  FB_COMMCHECKTHROW_EX(
-      comm->ctran_->mapper->isendCtrl(args.leftRank, &sendToLeft),
-      comm->logMetaData_);
-  FB_COMMCHECKTHROW_EX(
-      comm->ctran_->mapper->isendCtrl(args.rightRank, &sendToRight),
-      comm->logMetaData_);
-
-  // Wait for peer readiness
-  FB_COMMCHECKTHROW_EX(
-      comm->ctran_->mapper->waitRequest(&recvFromRight), comm->logMetaData_);
-  FB_COMMCHECKTHROW_EX(
-      comm->ctran_->mapper->waitRequest(&recvFromLeft), comm->logMetaData_);
-  FB_COMMCHECKTHROW_EX(
-      comm->ctran_->mapper->waitRequest(&sendToLeft), comm->logMetaData_);
-  FB_COMMCHECKTHROW_EX(
-      comm->ctran_->mapper->waitRequest(&sendToRight), comm->logMetaData_);
-}
-
 static commResult_t impl(
     const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
   FB_CHECKTHROW_EX_NOCOMM(
@@ -1069,15 +1030,10 @@ static commResult_t impl(
   auto& args = op->allreduce.hostArgs;
   auto& resource = op->allreduce.hostResource;
 
-  CTRAN_PROFILER_IF(
-      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_CTRL));
   if (!resource.setupComplete) {
     FB_COMMCHECK(completeHostResourceSetup(comm, args, resource));
     resource.setupComplete = true;
   }
-  neighborReadinessBarrier(comm, args);
-  CTRAN_PROFILER_IF(
-      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_CTRL));
 
   // setup algoCtx
   AlgoContext algoCtx = {


### PR DESCRIPTION
Summary:
Remove `neighborReadinessBarrier()` from AllReduceRing to fix a performance regression introduced by D98835445.

The barrier performs 8 blocking ctrl operations (2 `irecvCtrl` + 2 `isendCtrl` + 4 `waitRequest`) before every AllReduce for straggler detection profiling. It was placed outside the `CTRAN_PROFILER_IF` guard, causing it to run unconditionally on every collective. This caused a ~10% bandwidth regression on GB200 and ~13% on H100, detected by the performance dashboard starting April 10.

**Correctness:** the barrier is not needed for correctness. The `AllReduceRing` data phase has completely independent synchronization via `iput`/`checkNotify` and its own credit-based ctrl flow (`prePostRecvRemRecvBuf`). The barrier's own comment states it is "for straggler detection, separate from the data credit flow."

Also removes the `ALGO_CTRL` profiler start/end events that wrapped the barrier, since they have no remaining content to measure IIUC.

**MAST A/B validation (H100, 2 nodes, ppn=1, adapter-enabled):**
- Trunk (with barrier): ~40.97 GB/s at 2G, ~162us latency at 1K
- Fix (barrier removed): ~41.89 GB/s at 2G, ~92us latency at 1K
- Improvement: +2-3% at large sizes, up to +79% at small sizes

Reviewed By: arttianezhu

Differential Revision: D102874281


