### PR TITLE
ci: use pytest to run integration tests

### DIFF
--- a/comms/torchcomms/scripts/run_tests_integration_py.sh
+++ b/comms/torchcomms/scripts/run_tests_integration_py.sh
@@ -31,7 +31,7 @@ run_tests () {
     for dir in $dirs; do
         for file in "$dir"/*Test.py; do
             [ -f "$file" ] || continue
-            torchrun --nnodes 1 --nproc_per_node 4 "$file" --verbose
+            torchrun --nnodes 1 --nproc_per_node gpu --no-python pytest -s -v "$file"
         done
     done
 }


### PR DESCRIPTION
This switches the OSS CI to use pytest to run the integration tests. This avoids issues caused by D102302071 and also provides nicer test output that better matches the rest of our tests which are run using pytest.

Test plan:

CI