### PR TITLE
Fix gather/scatter timeout options not forwarded to backend

### DIFF
--- a/comms/torchcomms/BackendWrapper.cpp
+++ b/comms/torchcomms/BackendWrapper.cpp
@@ -345,7 +345,8 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::gather(
           outputTensors.at(0),
           inputTensors.at(0),
           static_cast<int>(opts.rootRank),
-          opts.asyncOp),
+          opts.asyncOp,
+          bopts),
       outputTensors.at(0));
 }
 
@@ -379,7 +380,8 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::scatter(
           outputTensors.at(0),
           inputTensors.at(0),
           static_cast<int>(opts.rootRank),
-          opts.asyncOp),
+          opts.asyncOp,
+          bopts),
       outputTensors);
 }
 


### PR DESCRIPTION
`BackendWrapper::gather` and `BackendWrapper::scatter` compute `bopts` but never pass it to backend.
other collective passes bopts. fixed that

**Before:**
```
  NCCLX communicator timeout : 600000ms
  BackendWrapper timeout set : 5000ms
  [PASS] broadcast     expected=5000ms  actual=5000ms
  [FAIL] gather        expected=5000ms  actual=600000ms
  [FAIL] scatter       expected=5000ms  actual=600000ms
```

**After:**
```
  NCCLX communicator timeout : 600000ms
  BackendWrapper timeout set : 5000ms
  [PASS] broadcast     expected=5000ms  actual=5000ms
  [PASS] gather        expected=5000ms  actual=5000ms
  [PASS] scatter       expected=5000ms  actual=5000ms
```