### PR TITLE
Make NicResources RAII (#2317)

### DIFF
--- a/comms/uniflow/transport/rdma/RdmaResources.cpp
+++ b/comms/uniflow/transport/rdma/RdmaResources.cpp
@@ -1,0 +1,118 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/uniflow/transport/rdma/RdmaResources.h"
+
+namespace uniflow {
+
+// ---------------------------------------------------------------------------
+// NicResources
+// ---------------------------------------------------------------------------
+
+NicResources::NicResources(
+    ibv_device* device,
+    std::shared_ptr<IbvApi> api,
+    uint8_t gidIndex,
+    std::optional<uint8_t> port)
+    : ibvApi(std::move(api)) {
+  try {
+    if (!ibvApi) {
+      ibvApi = std::make_shared<IbvApi>();
+    }
+
+    auto ctxResult = ibvApi->openDevice(device);
+    if (ctxResult.hasError()) {
+      throw std::runtime_error("NicResources: failed to open device");
+    }
+    ctx = ctxResult.value();
+
+    portNum = port.value_or(0);
+    if (portNum == 0) {
+      portNum = findActivePort();
+      if (portNum == 0) {
+        throw std::runtime_error("NicResources: no active port found");
+      }
+    }
+
+    auto pdResult = ibvApi->allocPd(ctx);
+    if (pdResult.hasError()) {
+      throw std::runtime_error("NicResources: failed to allocate PD");
+    }
+    pd = pdResult.value();
+
+    auto dmaBufResult = ibvApi->isDmaBufSupported(pd);
+    if (dmaBufResult.hasError()) {
+      throw std::runtime_error("NicResources: failed to probe DMA-BUF support");
+    }
+    dmaBufSupported = dmaBufResult.value();
+
+    ibv_port_attr portAttr{};
+    auto portStatus = ibvApi->queryPort(ctx, portNum, &portAttr);
+    if (portStatus.hasError()) {
+      throw std::runtime_error("NicResources: failed to query port");
+    }
+    lid = portAttr.lid;
+    mtu = portAttr.active_mtu;
+    linkLayer = portAttr.link_layer;
+
+    auto gidStatus = ibvApi->queryGid(ctx, portNum, gidIndex, &gid);
+    if (gidStatus.hasError()) {
+      throw std::runtime_error("NicResources: failed to query GID");
+    }
+  } catch (...) {
+    cleanup();
+    throw;
+  }
+}
+
+NicResources::NicResources(NicResources&& other) noexcept
+    : ctx(other.ctx),
+      pd(other.pd),
+      lid(other.lid),
+      gid(other.gid),
+      mtu(other.mtu),
+      linkLayer(other.linkLayer),
+      portNum(other.portNum),
+      dmaBufSupported(other.dmaBufSupported),
+      ibvApi(std::move(other.ibvApi)) {
+  other.ctx = nullptr;
+  other.pd = nullptr;
+}
+
+void NicResources::cleanup() {
+  if (ibvApi) {
+    if (pd) {
+      ibvApi->deallocPd(pd);
+      pd = nullptr;
+    }
+    if (ctx) {
+      ibvApi->closeDevice(ctx);
+      ctx = nullptr;
+    }
+  }
+}
+
+NicResources::~NicResources() {
+  cleanup();
+}
+
+uint8_t NicResources::findActivePort() const {
+  ibv_device_attr devAttr{};
+  auto status = ibvApi->queryDevice(ctx, &devAttr);
+  if (status.hasError()) {
+    return 0;
+  }
+
+  for (uint8_t p = 1; p <= devAttr.phys_port_cnt; ++p) {
+    ibv_port_attr portAttr{};
+    auto portStatus = ibvApi->queryPort(ctx, p, &portAttr);
+    if (portStatus.hasError()) {
+      continue;
+    }
+    if (portAttr.state == IBV_PORT_ACTIVE) {
+      return p;
+    }
+  }
+  return 0;
+}
+
+} // namespace uniflow

--- a/comms/uniflow/transport/rdma/RdmaResources.h
+++ b/comms/uniflow/transport/rdma/RdmaResources.h
@@ -1,0 +1,47 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include "comms/uniflow/drivers/ibverbs/IbvApi.h"
+
+namespace uniflow {
+
+/*
+ * Per-NIC RDMA resources with RAII lifetime management.
+ *
+ * Full-init constructor: opens device, allocates PD, queries port/GID.
+ * Destructor deallocates PD and closes device.
+ *
+ * Non-copyable, move-only. Shared across factory, transports, and slab pool
+ * via shared_ptr<vector<NicResources>>.
+ */
+struct NicResources {
+  ibv_context* ctx{nullptr}; /* Opened device context. */
+  ibv_pd* pd{nullptr}; /* Protection domain on this device. */
+  uint16_t lid{0}; /* Local identifier (IB fabrics). */
+  ibv_gid gid{}; /* GID for RoCE / IB with GRH. */
+  ibv_mtu mtu{IBV_MTU_4096}; /* Active MTU from port query. */
+  int linkLayer{IBV_LINK_LAYER_ETHERNET}; /* IB or Ethernet (RoCE). */
+  uint8_t portNum{1}; /* Physical port number on the HCA. */
+  bool dmaBufSupported{false}; /* Kernel supports DMA-BUF MR registration. */
+
+  NicResources(
+      ibv_device* device,
+      std::shared_ptr<IbvApi> api,
+      uint8_t gidIndex = 3,
+      std::optional<uint8_t> port = std::nullopt);
+
+  ~NicResources();
+
+  NicResources(const NicResources&) = delete;
+  NicResources& operator=(const NicResources&) = delete;
+  NicResources(NicResources&& other) noexcept;
+  NicResources& operator=(NicResources&&) = delete;
+
+ private:
+  uint8_t findActivePort() const;
+  void cleanup();
+  std::shared_ptr<IbvApi> ibvApi{nullptr};
+};
+
+} // namespace uniflow

--- a/comms/uniflow/transport/rdma/RdmaTransport.cpp
+++ b/comms/uniflow/transport/rdma/RdmaTransport.cpp
@@ -131,18 +131,22 @@ void RdmaTransportInfo::reset() {
 RdmaTransport::RdmaTransport(
     std::shared_ptr<IbvApi> ibvApi,
     EventBase* evb,
-    std::vector<NicResources> nics,
+    std::shared_ptr<std::vector<NicResources>> nics,
     uint64_t domainId,
     RdmaTransportConfig config)
     : ibvApi_(std::move(ibvApi)),
       evb_(evb),
-      nics_(std::move(nics)),
+      nicsHandle_(std::move(nics)),
       config_(config),
       domainId_(domainId) {
-  CHECK_THROW_EXCEPTION(!nics_.empty(), std::invalid_argument);
+  CHECK_THROW_EXCEPTION(
+      nicsHandle_ && !nicsHandle_->empty(), std::invalid_argument);
   CHECK_THROW_EXCEPTION(
       config_.numQps > 0 && config_.numQps <= 255, std::invalid_argument);
-  numPendingCqe_.resize(nics_.size());
+
+  const uint32_t numNics =
+      std::min(config_.numQps, static_cast<uint32_t>(nicsHandle_->size()));
+  nics_ = std::span<NicResources>(nicsHandle_->data(), numNics);
 
   name_ = "rdma";
   for (const auto& nic : nics_) {
@@ -162,8 +166,8 @@ TransportInfo RdmaTransport::bind() {
 
   info_.reset();
   const uint32_t numQps = config_.numQps;
-  const uint32_t numNics =
-      std::min(numQps, static_cast<uint32_t>(nics_.size()));
+  const uint32_t numNics = nics_.size();
+  numPendingCqe_.resize(nics_.size());
 
   cqs_.reserve(numNics);
   uint32_t qpsPerNic = (numQps + numNics - 1) / numNics;
@@ -1009,26 +1013,6 @@ Status RdmaTransportFactory::supported(std::shared_ptr<IbvApi> ibvApi) {
   return Ok();
 }
 
-uint8_t RdmaTransportFactory::findActivePort(ibv_context* ctx) {
-  ibv_device_attr devAttr{};
-  auto status = ibvApi_->queryDevice(ctx, &devAttr);
-  if (status.hasError()) {
-    return 0;
-  }
-
-  for (uint8_t port = 1; port <= devAttr.phys_port_cnt; ++port) {
-    ibv_port_attr portAttr{};
-    auto portStatus = ibvApi_->queryPort(ctx, port, &portAttr);
-    if (portStatus.hasError()) {
-      continue;
-    }
-    if (portAttr.state == IBV_PORT_ACTIVE) {
-      return port;
-    }
-  }
-  return 0;
-}
-
 RdmaTransportFactory::RdmaTransportFactory(
     const std::vector<std::string>& deviceNames,
     EventBase* evb,
@@ -1040,6 +1024,7 @@ RdmaTransportFactory::RdmaTransportFactory(
       ibvApi_(std::move(ibvApi)),
       cudaDriverApi_(std::move(cudaDriverApi)),
       evb_(evb),
+      nicsHandle_(std::make_shared<std::vector<NicResources>>()),
       config_(config) {
   assert(evb_ != nullptr);
   if (deviceNames.empty()) {
@@ -1072,19 +1057,7 @@ RdmaTransportFactory::RdmaTransportFactory(
   std::unique_ptr<ibv_device*[], decltype(devListDeleter)> devListGuard(
       deviceList, devListDeleter);
 
-  // TODO: Replace manual cleanup with EXIT_SCOPE macro (core/Utils.h).
-  auto cleanupNics = [this]() {
-    for (auto& nic : nics_) {
-      if (nic.pd) {
-        ibvApi_->deallocPd(nic.pd);
-      }
-      if (nic.ctx) {
-        ibvApi_->closeDevice(nic.ctx);
-      }
-    }
-    nics_.clear();
-  };
-
+  nicsHandle_->reserve(deviceNames.size());
   for (const auto& deviceName : deviceNames) {
     ibv_device* targetDevice = nullptr;
     for (int i = 0; i < numDevices; ++i) {
@@ -1096,83 +1069,16 @@ RdmaTransportFactory::RdmaTransportFactory(
     }
 
     if (!targetDevice) {
-      cleanupNics();
       throw std::runtime_error("RDMA device not found: " + deviceName);
     }
 
-    auto ctxResult = ibvApi_->openDevice(targetDevice);
-    if (ctxResult.hasError()) {
-      cleanupNics();
-      throw std::runtime_error("Failed to open RDMA device: " + deviceName);
-    }
-
-    NicResources nic;
-    nic.ctx = ctxResult.value();
-
-    // Discover port: use specified portNum, or find first active port
-    uint8_t port = portNum.value_or(0);
-    if (port == 0) {
-      port = findActivePort(nic.ctx);
-      if (port == 0) {
-        ibvApi_->closeDevice(nic.ctx);
-        cleanupNics();
-        throw std::runtime_error("No active port found on: " + deviceName);
-      }
-    }
-    nic.portNum = port;
-
-    auto pdResult = ibvApi_->allocPd(nic.ctx);
-    if (pdResult.hasError()) {
-      ibvApi_->closeDevice(nic.ctx);
-      cleanupNics();
-      throw std::runtime_error("Failed to allocate PD on: " + deviceName);
-    }
-    nic.pd = pdResult.value();
-
-    // Probe kernel DMA-BUF support on this NIC's PD.
-    auto dmaBufSupported = ibvApi_->isDmaBufSupported(nic.pd);
-    CHECK_THROW_ERROR(dmaBufSupported);
-    nic.dmaBufSupported = dmaBufSupported.value();
-
-    ibv_port_attr portAttr{};
-    auto portStatus = ibvApi_->queryPort(nic.ctx, port, &portAttr);
-    if (portStatus.hasError()) {
-      ibvApi_->deallocPd(nic.pd);
-      ibvApi_->closeDevice(nic.ctx);
-      cleanupNics();
-      throw std::runtime_error("Failed to query port on: " + deviceName);
-    }
-    nic.lid = portAttr.lid;
-    nic.mtu = portAttr.active_mtu;
-    nic.linkLayer = portAttr.link_layer;
-
-    auto gidStatus =
-        ibvApi_->queryGid(nic.ctx, port, config_.gidIndex, &nic.gid);
-    if (gidStatus.hasError()) {
-      ibvApi_->deallocPd(nic.pd);
-      ibvApi_->closeDevice(nic.ctx);
-      cleanupNics();
-      throw std::runtime_error("Failed to query GID on: " + deviceName);
-    }
-
-    nics_.push_back(nic);
-  }
-}
-
-RdmaTransportFactory::~RdmaTransportFactory() {
-  for (auto& nic : nics_) {
-    if (nic.pd) {
-      ibvApi_->deallocPd(nic.pd);
-    }
-    if (nic.ctx) {
-      ibvApi_->closeDevice(nic.ctx);
-    }
+    nicsHandle_->emplace_back(targetDevice, ibvApi_, config_.gidIndex, portNum);
   }
 }
 
 Result<std::unique_ptr<RegistrationHandle>>
 RdmaTransportFactory::registerSegment(Segment& segment) {
-  if (nics_.empty()) {
+  if (nicsHandle_->empty()) {
     return Err(ErrCode::InvalidArgument, "No NICs available for registration");
   }
 
@@ -1223,8 +1129,8 @@ RdmaTransportFactory::registerSegment(Segment& segment) {
   // Register with every NIC's protection domain so the region is usable
   // across all QPs regardless of which NIC they belong to.
   std::vector<ibv_mr*> mrs;
-  mrs.reserve(nics_.size());
-  for (const auto& nic : nics_) {
+  mrs.reserve(nicsHandle_->size());
+  for (const auto& nic : *nicsHandle_) {
     Result<ibv_mr*> mrResult = Err(ErrCode::NotImplemented);
     if (nic.dmaBufSupported && fdGuard.fd >= 0) {
       // GPU memory: register via DMA-BUF for GPU Direct RDMA.
@@ -1296,7 +1202,7 @@ Result<std::unique_ptr<Transport>> RdmaTransportFactory::createTransport(
   auto config = config_;
   config.numQps = std::min(peerTopo.numQps, config.numQps);
   return std::make_unique<RdmaTransport>(
-      ibvApi_, evb_, nics_, domainId_, config);
+      ibvApi_, evb_, nicsHandle_, domainId_, config);
 }
 
 // TODO: get ai_zone_name from fbwhoami / serfwhoami or develop a plugin for

--- a/comms/uniflow/transport/rdma/RdmaTransport.h
+++ b/comms/uniflow/transport/rdma/RdmaTransport.h
@@ -12,6 +12,7 @@
 #include "comms/uniflow/drivers/ibverbs/IbvApi.h"
 #include "comms/uniflow/executor/EventBase.h"
 #include "comms/uniflow/transport/Transport.h"
+#include "comms/uniflow/transport/rdma/RdmaResources.h"
 
 namespace uniflow {
 
@@ -42,24 +43,6 @@ struct RdmaTransportConfig {
   uint32_t maxSge{1}; /* Max scatter/gather entries per WR. */
   uint32_t maxInlineData{16}; /* Max inline data bytes per WR. */
   size_t chunkSize{512 * 1024}; /* Transfer chunk size in bytes (512KB). */
-};
-
-/*
- * Per-NIC RDMA resources.
- *
- * Populated by RdmaTransportFactory during device initialization.
- * Ownership: the factory owns the underlying ibverbs objects (context, PD).
- * Transports borrow these resources — they must not outlive the factory.
- */
-struct NicResources {
-  ibv_context* ctx{nullptr}; /* Opened device context. */
-  ibv_pd* pd{nullptr}; /* Protection domain on this device. */
-  uint16_t lid{0}; /* Local identifier (IB fabrics). */
-  ibv_gid gid{}; /* GID for RoCE / IB with GRH. */
-  ibv_mtu mtu{IBV_MTU_4096}; /* Active MTU from port query. */
-  int linkLayer{IBV_LINK_LAYER_ETHERNET}; /* IB or Ethernet (RoCE). */
-  uint8_t portNum{1}; /* Physical port number on the HCA. */
-  bool dmaBufSupported{false}; /* Kernel supports DMA-BUF MR registration. */
 };
 
 /*
@@ -151,7 +134,7 @@ class RdmaTransport : public Transport {
   RdmaTransport(
       std::shared_ptr<IbvApi> ibvApi,
       EventBase* evb,
-      std::vector<NicResources> nics,
+      std::shared_ptr<std::vector<NicResources>> nics,
       uint64_t domainId,
       RdmaTransportConfig config = {});
 
@@ -392,7 +375,8 @@ class RdmaTransport : public Transport {
   EventBase* evb_{nullptr};
 
   std::string name_;
-  const std::vector<NicResources> nics_;
+  std::shared_ptr<std::vector<NicResources>> nicsHandle_;
+  std::span<NicResources> nics_;
   const RdmaTransportConfig config_;
 
   std::vector<ibv_cq*> cqs_;
@@ -492,7 +476,7 @@ class RdmaTransportFactory : public TransportFactory {
       std::shared_ptr<CudaDriverApi> cudaDriverApi = nullptr,
       std::optional<uint8_t> portNum = std::nullopt);
 
-  ~RdmaTransportFactory() override;
+  ~RdmaTransportFactory() override = default;
 
   RdmaTransportFactory(const RdmaTransportFactory&) = delete;
   RdmaTransportFactory& operator=(const RdmaTransportFactory&) = delete;
@@ -521,15 +505,12 @@ class RdmaTransportFactory : public TransportFactory {
  private:
   Status canConnect(std::span<const uint8_t> peerTopology) override;
 
-  /* Find the first active port on the device. Returns 0 on failure. */
-  uint8_t findActivePort(ibv_context* ctx);
-
   std::shared_ptr<IbvApi> ibvApi_;
   std::shared_ptr<CudaDriverApi> cudaDriverApi_;
   EventBase* evb_{nullptr};
   uint64_t domainId_{0};
   size_t pageSize_{0};
-  std::vector<NicResources> nics_;
+  std::shared_ptr<std::vector<NicResources>> nicsHandle_;
   const RdmaTransportConfig config_;
 };
 

--- a/comms/uniflow/transport/rdma/tests/unit/RdmaTransportTest.cpp
+++ b/comms/uniflow/transport/rdma/tests/unit/RdmaTransportTest.cpp
@@ -156,6 +156,45 @@ TEST(RdmaTransportInfoTest, SerializeZeroQps) {
   ASSERT_EQ(result.value().nicInfos.size(), 1);
 }
 
+// --- Helpers ---
+
+NicResources makeNic(
+    ibv_device* dev,
+    ibv_context* ctx,
+    ibv_pd* pd,
+    std::shared_ptr<testing::NiceMock<MockIbvApi>> mockApi,
+    uint16_t lid = 0,
+    ibv_gid gid = {},
+    uint8_t port = 1) {
+  ON_CALL(*mockApi, openDevice(dev))
+      .WillByDefault(Return(Result<ibv_context*>(ctx)));
+  ON_CALL(*mockApi, allocPd(ctx)).WillByDefault(Return(Result<ibv_pd*>(pd)));
+  ON_CALL(*mockApi, isDmaBufSupported(pd))
+      .WillByDefault(Return(Result<bool>(false)));
+  ON_CALL(*mockApi, queryPort(ctx, port, _))
+      .WillByDefault([lid, gid](ibv_context*, uint8_t, ibv_port_attr* attr) {
+        attr->lid = lid;
+        attr->active_mtu = IBV_MTU_4096;
+        attr->link_layer = IBV_LINK_LAYER_ETHERNET;
+        attr->state = IBV_PORT_ACTIVE;
+        return Ok();
+      });
+  ON_CALL(*mockApi, queryGid(ctx, port, _, _))
+      .WillByDefault([gid](ibv_context*, uint8_t, int, ibv_gid* out) {
+        *out = gid;
+        return Ok();
+      });
+  ON_CALL(*mockApi, queryDevice(ctx, _))
+      .WillByDefault([port](ibv_context*, ibv_device_attr* attr) {
+        attr->phys_port_cnt = port;
+        return Ok();
+      });
+  ON_CALL(*mockApi, deallocPd(pd)).WillByDefault(Return(Ok()));
+  ON_CALL(*mockApi, closeDevice(ctx)).WillByDefault(Return(Ok()));
+
+  return NicResources(dev, mockApi, 3, port);
+}
+
 // --- Mock-based transport tests ---
 
 class RdmaTransportTest : public ::testing::Test {
@@ -183,8 +222,8 @@ class RdmaTransportTest : public ::testing::Test {
 
 TEST_F(RdmaTransportTest, ConstructorRejectsZeroQps) {
   ibv_gid gid{};
-  std::vector<NicResources> nics = {
-      {.ctx = &fakeCtx0_, .pd = &fakePd0_, .lid = 0, .gid = gid}};
+  auto nics = std::make_shared<std::vector<NicResources>>();
+  nics->push_back(makeNic(&fakeDev0_, &fakeCtx0_, &fakePd0_, mockApi_, 0, gid));
   RdmaTransportConfig config{.numQps = 0};
   EXPECT_THROW(
       RdmaTransport(mockApi_, evbThread_.getEventBase(), nics, 0, config),
@@ -202,10 +241,11 @@ TEST_F(RdmaTransportTest, BindClampsNicsToQpCount) {
   EXPECT_CALL(*mockApi_, modifyQp(_, _, _)).WillRepeatedly(Return(Ok()));
 
   ibv_gid gid0{}, gid1{};
-  std::vector<NicResources> nics = {
-      {.ctx = &fakeCtx0_, .pd = &fakePd0_, .lid = 0x1111, .gid = gid0},
-      {.ctx = &fakeCtx1_, .pd = &fakePd1_, .lid = 0x2222, .gid = gid1},
-  };
+  auto nics = std::make_shared<std::vector<NicResources>>();
+  nics->push_back(
+      makeNic(&fakeDev0_, &fakeCtx0_, &fakePd0_, mockApi_, 0x1111, gid0));
+  nics->push_back(
+      makeNic(&fakeDev0_, &fakeCtx0_, &fakePd0_, mockApi_, 0x2222, gid1));
   RdmaTransportConfig config{.numQps = 1};
   RdmaTransport transport(mockApi_, evbThread_.getEventBase(), nics, 0, config);
 
@@ -232,8 +272,9 @@ TEST_F(RdmaTransportTest, SingleNicBindCreatesQPs) {
   EXPECT_CALL(*mockApi_, modifyQp(_, _, _)).WillRepeatedly(Return(Ok()));
 
   ibv_gid gid{};
-  std::vector<NicResources> nics = {
-      {.ctx = &fakeCtx0_, .pd = &fakePd0_, .lid = 0x1234, .gid = gid}};
+  auto nics = std::make_shared<std::vector<NicResources>>();
+  nics->push_back(
+      makeNic(&fakeDev0_, &fakeCtx0_, &fakePd0_, mockApi_, 0x1234, gid));
   RdmaTransportConfig config{.numQps = 2};
   RdmaTransport transport(mockApi_, evbThread_.getEventBase(), nics, 0, config);
 
@@ -268,10 +309,11 @@ TEST_F(RdmaTransportTest, MultiNicBindDistributesQPsRoundRobin) {
   EXPECT_CALL(*mockApi_, modifyQp(_, _, _)).WillRepeatedly(Return(Ok()));
 
   ibv_gid gid0{}, gid1{};
-  std::vector<NicResources> nics = {
-      {.ctx = &fakeCtx0_, .pd = &fakePd0_, .lid = 0x1111, .gid = gid0},
-      {.ctx = &fakeCtx1_, .pd = &fakePd1_, .lid = 0x2222, .gid = gid1},
-  };
+  auto nics = std::make_shared<std::vector<NicResources>>();
+  nics->push_back(
+      makeNic(&fakeDev0_, &fakeCtx0_, &fakePd0_, mockApi_, 0x1111, gid0));
+  nics->push_back(
+      makeNic(&fakeDev1_, &fakeCtx1_, &fakePd1_, mockApi_, 0x2222, gid1));
   RdmaTransportConfig config{.numQps = 4};
   RdmaTransport transport(mockApi_, evbThread_.getEventBase(), nics, 0, config);
 
@@ -298,8 +340,8 @@ TEST_F(RdmaTransportTest, BindReturnsEmptyOnCqFailure) {
       .WillOnce(Return(Result<ibv_cq*>(ErrCode::ResourceExhausted)));
 
   ibv_gid gid{};
-  std::vector<NicResources> nics = {
-      {.ctx = &fakeCtx0_, .pd = &fakePd0_, .lid = 0, .gid = gid}};
+  auto nics = std::make_shared<std::vector<NicResources>>();
+  nics->push_back(makeNic(&fakeDev0_, &fakeCtx0_, &fakePd0_, mockApi_, 0, gid));
   RdmaTransport transport(mockApi_, evbThread_.getEventBase(), nics, 0);
 
   auto data = transport.bind();
@@ -314,8 +356,8 @@ TEST_F(RdmaTransportTest, BindReturnsEmptyOnQpFailure) {
       .WillOnce(Return(Result<ibv_qp*>(ErrCode::ResourceExhausted)));
 
   ibv_gid gid{};
-  std::vector<NicResources> nics = {
-      {.ctx = &fakeCtx0_, .pd = &fakePd0_, .lid = 0, .gid = gid}};
+  auto nics = std::make_shared<std::vector<NicResources>>();
+  nics->push_back(makeNic(&fakeDev0_, &fakeCtx0_, &fakePd0_, mockApi_, 0, gid));
   RdmaTransport transport(mockApi_, evbThread_.getEventBase(), nics, 0);
 
   auto data = transport.bind();
@@ -333,8 +375,9 @@ TEST_F(RdmaTransportTest, ConnectTransitionsQPs) {
   EXPECT_CALL(*mockApi_, modifyQp(_, _, _)).WillRepeatedly(Return(Ok()));
 
   ibv_gid gid{};
-  std::vector<NicResources> nics = {
-      {.ctx = &fakeCtx0_, .pd = &fakePd0_, .lid = 0x1234, .gid = gid}};
+  auto nics = std::make_shared<std::vector<NicResources>>();
+  nics->push_back(
+      makeNic(&fakeDev0_, &fakeCtx0_, &fakePd0_, mockApi_, 0x1234, gid));
   RdmaTransport transport(mockApi_, evbThread_.getEventBase(), nics, 0);
   transport.bind();
 
@@ -360,8 +403,8 @@ TEST_F(RdmaTransportTest, ConnectRejectsQpCountMismatch) {
   EXPECT_CALL(*mockApi_, modifyQp(_, _, _)).WillRepeatedly(Return(Ok()));
 
   ibv_gid gid{};
-  std::vector<NicResources> nics = {
-      {.ctx = &fakeCtx0_, .pd = &fakePd0_, .lid = 0, .gid = gid}};
+  auto nics = std::make_shared<std::vector<NicResources>>();
+  nics->push_back(makeNic(&fakeDev0_, &fakeCtx0_, &fakePd0_, mockApi_, 0, gid));
   RdmaTransport transport(mockApi_, evbThread_.getEventBase(), nics, 0);
   transport.bind();
 
@@ -379,8 +422,8 @@ TEST_F(RdmaTransportTest, ConnectRejectsQpCountMismatch) {
 
 TEST_F(RdmaTransportTest, ConnectWithoutBindFails) {
   ibv_gid gid{};
-  std::vector<NicResources> nics = {
-      {.ctx = &fakeCtx0_, .pd = &fakePd0_, .lid = 0, .gid = gid}};
+  auto nics = std::make_shared<std::vector<NicResources>>();
+  nics->push_back(makeNic(&fakeDev0_, &fakeCtx0_, &fakePd0_, mockApi_, 0, gid));
   RdmaTransport transport(mockApi_, evbThread_.getEventBase(), nics, 0);
 
   // Don't call bind() - go straight to connect()
@@ -409,8 +452,8 @@ TEST_F(RdmaTransportTest, ShutdownDestroysResources) {
   EXPECT_CALL(*mockApi_, destroyCq(&fakeCq0_)).WillOnce(Return(Ok()));
 
   ibv_gid gid{};
-  std::vector<NicResources> nics = {
-      {.ctx = &fakeCtx0_, .pd = &fakePd0_, .lid = 0, .gid = gid}};
+  auto nics = std::make_shared<std::vector<NicResources>>();
+  nics->push_back(makeNic(&fakeDev0_, &fakeCtx0_, &fakePd0_, mockApi_, 0, gid));
   RdmaTransport transport(mockApi_, evbThread_.getEventBase(), nics, 0);
   transport.bind();
 
@@ -732,8 +775,9 @@ class RdmaTransportDataPathTest : public ::testing::Test {
     EXPECT_CALL(*mockApi_, modifyQp(_, _, _)).WillRepeatedly(Return(Ok()));
 
     ibv_gid gid{};
-    std::vector<NicResources> nics = {
-        {.ctx = &fakeCtx_, .pd = &fakePd_, .lid = 0x1234, .gid = gid}};
+    auto nics = std::make_shared<std::vector<NicResources>>();
+    nics->push_back(
+        makeNic(&fakeDev_, &fakeCtx_, &fakePd_, mockApi_, 0x1234, gid));
 
     transport_ = std::make_unique<RdmaTransport>(
         mockApi_, evbThread_->getEventBase(), nics, kLocalDomainId);
@@ -1033,10 +1077,11 @@ TEST_F(RdmaTransportTest, CompletionRoutingDisambiguatesDuplicateQpNumbers) {
   EXPECT_CALL(*mockApi_, modifyQp(_, _, _)).WillRepeatedly(Return(Ok()));
 
   ibv_gid gid0{}, gid1{};
-  std::vector<NicResources> nics = {
-      {.ctx = &fakeCtx0_, .pd = &fakePd0_, .lid = 0x1111, .gid = gid0},
-      {.ctx = &fakeCtx1_, .pd = &fakePd1_, .lid = 0x2222, .gid = gid1},
-  };
+  auto nics = std::make_shared<std::vector<NicResources>>();
+  nics->push_back(
+      makeNic(&fakeDev0_, &fakeCtx0_, &fakePd0_, mockApi_, 0x1111, gid0));
+  nics->push_back(
+      makeNic(&fakeDev1_, &fakeCtx1_, &fakePd1_, mockApi_, 0x2222, gid1));
   RdmaTransportConfig config{.numQps = 2};
   RdmaTransport transport(
       mockApi_, evbThread_.getEventBase(), nics, kLocalDomainId, config);


### PR DESCRIPTION
Summary:
Extract `NicResources` from `RdmaTransport.cpp` into its own dedicated files (`RdmaResources.h`/`RdmaResources.cpp`) and add RAII lifetime management. The constructor now opens the IB device, allocates the protection domain, queries port/GID attributes, and probes DMA-BUF support. The destructor deallocates PD and closes the device context, preventing resource leaks.

`NicResources` is non-copyable and move-only, designed to be shared across factory, transports, and the slab pool via `shared_ptr<vector<NicResources>>`. The move constructor transfers ownership of `ctx` and `pd`, nulling them on the source.

This refactoring is a prerequisite for the shared `RdmaSlabPool` (D102824713), which needs access to NIC resources independently of `RdmaTransport`.


Reviewed By: saifhhasan, rmahidhar

Differential Revision: D102906483


