### PR TITLE
S651852 [ctran][feature] Add wcAcquireFence and pair host completion polls (#2318)

### DIFF
--- a/comms/ctran/algos/common/GpeKernelSync.h
+++ b/comms/ctran/algos/common/GpeKernelSync.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "comms/ctran/algos/CtranAlgoDev.h"
+#include "comms/ctran/utils/MemFence.h"
 
 namespace ctran::algos {
 
@@ -33,17 +34,30 @@ struct alignas(16) GpeKernelSync {
     }
   }
 
-  // Check if all workers on kernel side has completed the specified step
+  // Check if all workers on kernel side has completed the specified step.
+  //
+  // Pairs with the kernel's st_release_sys_global on completeFlag in
+  // GpeKernelSyncDev::complete(). On aarch64 (GB200) the load-acquire fence
+  // after the polling load is required: aarch64 permits load->load
+  // reordering, so without dmb ishld here, subsequent loads of data
+  // released-by-this-flag (e.g. via the chained post() to another sync)
+  // are not guaranteed to observe the producer's writes.
   inline bool isComplete(const int step) {
     bool allComplete = true;
     for (unsigned int i = 0; i < nworkers; i++) {
       volatile int* flag = &completeFlag[i];
+      int val = *flag;
       // Kernel handles posted request in sequential, thus >= step indicates
       // completion of the checking step.
-      allComplete &= (*flag >= step);
+      allComplete &= (val >= step);
       if (!allComplete) {
         break;
       }
+    }
+    if (allComplete) {
+      // Acquire only after a successful observation; failed polls do not
+      // synchronise with the producer.
+      wcAcquireFence();
     }
     return allComplete;
   }
@@ -56,6 +70,8 @@ struct alignas(16) GpeKernelSync {
       while (*flag < step)
         ;
     }
+    // Acquire after observing all workers' completion releases.
+    wcAcquireFence();
   }
 
   // Post a request to kernel with specified step

--- a/comms/ctran/algos/common/tests/GpeKernelSyncTest.cc
+++ b/comms/ctran/algos/common/tests/GpeKernelSyncTest.cc
@@ -2,6 +2,10 @@
 
 #include <cuda_runtime.h>
 
+#include <atomic>
+#include <thread>
+#include <vector>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "comms/ctran/algos/common/GpeKernelSync.h"
@@ -142,3 +146,155 @@ INSTANTIATE_TEST_SUITE_P(
       return std::to_string(std::get<0>(info.param)) + "numWorkers_" +
           resetTypeStr;
     });
+
+// =============================================================================
+// AcquireRace test — exercises the GpeKernelSync host poll → consumer-data-read
+// pattern that the production bug at S651852 hits on aarch64 (GB200).
+//
+// Producer threads simulate kernel blocks: each writes its own portion of a
+// shared payload, then release-stores its `completeFlag[b]` slot to signal
+// completion of step `iter`. The release-fence + volatile-store pattern
+// mirrors the GPU's `st.release.sys` in `GpeKernelSyncDev::complete()`.
+//
+// The consumer thread is the host: it calls `sync->isComplete(iter)` (the
+// production code path) and immediately reads the payload to verify
+// consistency.
+//
+// Iteration handshake uses a separate `std::atomic<int> goSignal` (a proper
+// C++11 release/acquire pair) so this test does NOT race on
+// `sync->postFlag[]`. The only intentionally race-relevant interaction is the
+// producer's release-store of `completeFlag` paired with the consumer's poll
+// inside `sync->isComplete()`.
+//
+// On aarch64 without `wcAcquireFence()` after the polling load, the consumer
+// can observe `completeFlag` as set while a load-load reorder lets the
+// payload read return stale values, producing per-(iter, block) mismatches.
+//
+// On x86 (TSO) the race cannot trigger naturally — load->load ordering is
+// architecturally guaranteed. ThreadSanitizer is also not a useful validator
+// here: TSan models the C++11 memory model, where the production
+// `volatile + thread_fence` pattern is not a recognised release/acquire pair,
+// so TSan reports the bare volatile read as a race regardless of whether
+// `wcAcquireFence()` is present. The fix is hardware-correct but cannot be
+// validated by TSan without refactoring `GpeKernelSync` to use `std::atomic`.
+//
+// This test is `DISABLED_` so it does not run in CI by default. To reproduce
+// the bug it must be run on aarch64 hardware (rtptest GB200):
+//
+//   buck2 run @fbcode//mode/opt -c hpc_comms.use_ncclx=stable \
+//     -c nvcc.arch=b200 -c fbcode.arch=aarch64 \
+//     fbcode//comms/ctran/algos/common/tests:ctran_algo_gpe_kernel_sync_test \
+//     -- --gtest_also_run_disabled_tests \
+//        --gtest_filter='*DISABLED_AcquireRaceManualOnAarch64*'
+//
+// Expected behaviour:
+//   - Without the `wcAcquireFence()` in `GpeKernelSync::isComplete()`:
+//       on aarch64 the mismatch counter is non-zero (race triggers).
+//   - With the fence: mismatches stays 0 across all iterations.
+//   - On x86: always passes regardless of the fence (TSO masks the race).
+TEST_F(CtranGpeKernelSyncTest, DISABLED_AcquireRaceManualOnAarch64) {
+  constexpr int kNumWorkers = 8;
+  constexpr int kPayloadPerWorker = 64;
+  constexpr int kPayloadSize = kNumWorkers * kPayloadPerWorker;
+  constexpr int kIters = 50000;
+
+  // Match production allocation: pinned host memory for the sync.
+  void* syncPtr = nullptr;
+  ASSERT_EQ(
+      cudaHostAlloc(&syncPtr, sizeof(GpeKernelSync), cudaHostAllocDefault),
+      cudaSuccess);
+  GpeKernelSync* sync = new (syncPtr) GpeKernelSync(kNumWorkers);
+
+  // Per-(iter, block) magic value, recomputed in both producer and consumer.
+  auto magicFor = [](int iter, int b) {
+    return (iter * 13) ^ ((b + 1) * 0x9e3779b1);
+  };
+
+  std::vector<int> payload(kPayloadSize, -1);
+  std::atomic<int> mismatches{0};
+  // Iteration barrier: consumer sets goSignal[b] = iter, producer waits
+  // for goSignal[b] >= iter. Uses std::atomic so TSan recognises the
+  // release/acquire pair and does NOT flag this part of the test.
+  std::vector<std::atomic<int>> goSignal(kNumWorkers);
+  for (auto& g : goSignal) {
+    g.store(-1, std::memory_order_relaxed);
+  }
+
+  // Producer threads: simulate kernel blocks. Wait for the consumer to
+  // release goSignal[b] for `iter`, then write the per-block payload and
+  // release-store completeFlag[b].
+  std::vector<std::thread> producers;
+  producers.reserve(kNumWorkers);
+  for (int b = 0; b < kNumWorkers; ++b) {
+    producers.emplace_back([&, b]() {
+      for (int iter = 0; iter < kIters; ++iter) {
+        // Acquire the consumer's "go" signal — TSan-clean handshake.
+        while (goSignal[b].load(std::memory_order_acquire) < iter) {
+          // friendly spin
+        }
+
+        // Write our portion of the payload.
+        const int magic = magicFor(iter, b);
+        const int start = b * kPayloadPerWorker;
+        const int end = start + kPayloadPerWorker;
+        for (int i = start; i < end; ++i) {
+          payload[i] = magic;
+        }
+
+        // Mirror the GPU's `st.release.sys` on completeFlag — release fence
+        // then volatile store. This is intentionally the SAME pattern used
+        // in production (GpeKernelSync::post via wcStoreFence + volatile),
+        // so TSan correctly identifies the missing acquire on the consumer
+        // side as a data race.
+        std::atomic_thread_fence(std::memory_order_release);
+        volatile int* completeFlag = &sync->completeFlag[b];
+        *completeFlag = iter;
+      }
+    });
+  }
+
+  // Consumer (host): release goSignal then call the production
+  // `sync->isComplete(iter)`. After it returns true, read the payload back
+  // and verify it matches the expected per-block magic.
+  std::thread consumer([&]() {
+    for (int iter = 0; iter < kIters; ++iter) {
+      // Release goSignal[b] for `iter` so all producers can proceed.
+      for (int b = 0; b < kNumWorkers; ++b) {
+        goSignal[b].store(iter, std::memory_order_release);
+      }
+
+      while (!sync->isComplete(iter)) {
+        // friendly spin
+      }
+
+      // Verify every block's payload portion. On aarch64 (or under TSan),
+      // without the `wcAcquireFence()` in `isComplete()`, this read can
+      // see stale data.
+      for (int b = 0; b < kNumWorkers; ++b) {
+        const int magic = magicFor(iter, b);
+        const int start = b * kPayloadPerWorker;
+        const int end = start + kPayloadPerWorker;
+        for (int i = start; i < end; ++i) {
+          if (payload[i] != magic) {
+            mismatches.fetch_add(1, std::memory_order_relaxed);
+            break; // one count per (iter, block)
+          }
+        }
+      }
+    }
+  });
+
+  consumer.join();
+  for (auto& t : producers) {
+    t.join();
+  }
+
+  EXPECT_EQ(mismatches.load(), 0)
+      << "Acquire race detected: payload was inconsistent at "
+      << mismatches.load() << " (iter, block) sites across " << kIters
+      << " iterations × " << kNumWorkers << " blocks. "
+      << "If running on aarch64 without wcAcquireFence() in "
+      << "GpeKernelSync::isComplete(), this is the expected pre-fix failure.";
+
+  ASSERT_EQ(cudaFreeHost(syncPtr), cudaSuccess);
+}

--- a/comms/ctran/utils/MemFence.h
+++ b/comms/ctran/utils/MemFence.h
@@ -3,11 +3,26 @@
 #pragma once
 
 // Copied from gdrwrap.h to avoid including dependency to NCCL header
+//
+// Naming follows the original gdrwrap.h convention ("wc" = write-combined),
+// but the fences are applicable to any host-side ordering across coherent
+// pinned memory shared with another agent (GPU / NIC).
+//
+// Pair semantics:
+//   wcStoreFence()    — release. Use BEFORE storing a flag/doorbell so that
+//                       any prior data writes are ordered before the flag.
+//   wcAcquireFence()  — acquire. Use AFTER reading a flag so that any
+//                       subsequent loads of data observed-by-the-flag see
+//                       the producer's prior writes.
 #if defined(__NVCC__)
 #define wcStoreFence()
+#define wcAcquireFence()
 #else
 #if defined(__PPC__)
 static inline void wcStoreFence(void) {
+  asm volatile("sync");
+}
+static inline void wcAcquireFence(void) {
   asm volatile("sync");
 }
 #elif defined(__x86_64__)
@@ -15,16 +30,31 @@ static inline void wcStoreFence(void) {
 static inline void wcStoreFence(void) {
   _mm_sfence();
 }
+// x86 is TSO: load->load is already ordered, so the read side never needs
+// a hardware barrier. A compiler reordering barrier ("memory" clobber) is
+// sufficient to mirror wcStoreFence as a logical pair.
+static inline void wcAcquireFence(void) {
+  asm volatile("" ::: "memory");
+}
 #elif defined(__aarch64__)
 #ifdef __cplusplus
 #include <atomic>
 static inline void wcStoreFence(void) {
   std::atomic_thread_fence(std::memory_order_release);
 }
+// aarch64 permits load->load reordering. After polling a flag released by
+// the GPU via st.release.sys, the host needs a load-acquire barrier
+// (dmb ishld) before any subsequent dependent load/store.
+static inline void wcAcquireFence(void) {
+  std::atomic_thread_fence(std::memory_order_acquire);
+}
 #else
 #include <stdatomic.h>
 static inline void wcStoreFence(void) {
   atomic_thread_fence(memory_order_release);
+}
+static inline void wcAcquireFence(void) {
+  atomic_thread_fence(memory_order_acquire);
 }
 #endif
 #endif


### PR DESCRIPTION
Summary:

On aarch64 (GB200) the host-side polls of `GpeKernelSync::completeFlag` were a bare `volatile` load with no fence. The matching kernel side does write the flag with `st.release.sys`, but on aarch64 a simple volatile read on the consumer is **not** an acquire — load->load reordering is permitted, so subsequent host-side loads / NIC doorbells can race with the GPU's prior data writes that the release-store is meant to publish. On x86 this asymmetry is hidden by TSO, which is why the bug only manifests on GB200.

This is the fix that pairs with the existing `wcStoreFence()` already used on the producer side of these flags (`GpeKernelSync::post()`):

- `comms/ctran/utils/MemFence.h` — introduce `wcAcquireFence()` symmetric to `wcStoreFence()`. aarch64: `std::atomic_thread_fence(memory_order_acquire)` (`dmb ishld`). x86 (TSO): compiler reordering barrier only — no hardware fence needed. PPC: `sync`. NVCC: empty.
- `comms/ctran/algos/common/GpeKernelSync.h` — call `wcAcquireFence()` after a successful `isComplete()` poll and after the `waitComplete()` spin returns. The acquire is only needed once we have actually observed the producer's release, so the failed-poll path stays free of barriers.

Scope intentionally limited to `GpeKernelSync` because that's the path exercised by the `paft_S651852_*` allreduce-consistency divergence (bidir-AG-only, replica-position-dependent, matches the bidir AG ring topology). `KernelElem` has the same shape — host spins on a volatile `status[]` written by the GPU — and is used by ReduceScatter Ring/RHD and AllToAllvDynamic, so it is theoretically exposed to the same aarch64 race. We're holding off on changing `KernelElem` here because nothing in the current symptom touches it; that fix will land separately if/when it surfaces.

Note: this supersedes the unconditional `wcStoreFence()` BEFORE the read introduced in the draft D101682434 / D102225277 — that was a release fence in a position where an acquire is required. On aarch64 the draft's `dmb ish` happened to drain enough of the local memory subsystem to mask the bug, but the semantic was wrong. This change is also cheaper on x86 (no `_mm_sfence()` needed under TSO).

Differential Revision: D103040491


