### PR TITLE
Add Tile API for cooperative vectorized tile operations (#2319)

### DIFF
--- a/comms/pipes/Tile.cuh
+++ b/comms/pipes/Tile.cuh
@@ -1,0 +1,702 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Tile: cooperative vectorized tile operations for GPU collectives.
+//
+// A Tile is a fixed-size block of elements distributed across threads in a
+// ThreadGroup, backed by uint4 registers. All memory operations use 16-byte
+// (uint4) vectorized loads/stores for optimal coalescing.
+//
+// TERMINOLOGY
+// ===========
+//   element   A single value of type T (one float, one __half, one bf16).
+//   vector    A uint4 register (16 bytes). Holds kElemsPerVec elements:
+//               float  → 4 elements per vector  (16B / 4B)
+//               __half → 8 elements per vector  (16B / 2B)
+//               bf16   → 8 elements per vector  (16B / 2B)
+//   tile      A contiguous block of kTileElems elements, cooperatively owned
+//             by kBlockSize threads. Each thread holds kVPT vectors in
+//             registers.
+//
+// KEY CONSTANTS
+// =============
+//   kElemsPerVec (kEPV)  Elements per vector = sizeof(uint4) / sizeof(T).
+//   kTileVecs            Vectors in the tile = kTileElems / kEPV.
+//   kVPT                 Vectors per thread  = kTileVecs / kBlockSize.
+//                        This controls ILP — higher kVPT means more work per
+//                        thread per tile. kVPT=8 matches memcpy_vectorized
+//                        and achieves peak bandwidth on H100.
+//
+// TRITON EQUIVALENCE
+// ==================
+//   Tile API                                  Triton
+//   ──────────────────────────────────────     ────────────────────────────────
+//   tile_load<T,N>(p, idx, g)                 tl.load(p + offs)
+//   tile_load<T,N>(p, idx, g, valid)          tl.load(p+offs, mask=m, other=0)
+//   tile_store(p, idx, tile, g)               tl.store(p + offs, tile)
+//   tile_store(p, idx, tile, g, valid)        tl.store(p + offs, tile, mask=m)
+//   tile_accumulate<T,SumOp>(a, b)            a += b
+//   tile_accumulate<T,MaxOp>(a, b)            a = tl.maximum(a, b)
+//   tile_load_accumulate<T,SumOp>(a,p,i,g)    a += tl.load(p + offs)
+//   tile_zero(tile)                           tl.zeros(BLOCK, dtype)
+//   num_tiles<T,N>(n)                         n // BLOCK_SIZE
+//   tile_remainder<T,N>(n)                    n % BLOCK_SIZE
+//
+//   The key structural difference: Triton masks at element granularity via
+//   boolean mask tensors. This API masks at element granularity too — partial
+//   vectors at the boundary are handled with scalar element loads/stores so
+//   valid_elems need not be vector-aligned.
+//
+// PIPELINING
+// ==========
+//   Multiple tiles in registers enable software pipelining:
+//
+//     auto t0 = tile_load(ptr, 0, group);
+//     for (size_t i = 1; i < n; i++) {
+//       auto t1 = tile_load(ptr, i, group);   // load next
+//       tile_store(out, i-1, t0, group);       // store previous
+//       t0 = t1;
+//     }
+//     tile_store(out, n-1, t0, group);
+//
+//   Register pressure scales with kVPT × pipeline depth. Profile to find
+//   the sweet spot between ILP and spilling.
+//
+// 2D TILES
+// =========
+//   tile_load_2d/tile_store_2d load a kRows × kCols sub-matrix from a
+//   row-major matrix with a given stride. The result is a flat
+//   Tile<T, kRows*kCols, kBlockSize> compatible with all 1D tile ops.
+//
+//     tile_load_2d<T, kRows, kCols>(ptr, row, col, stride, group,
+//                                   valid_rows, valid_cols)
+//
+//   This maps to Triton's 2D load pattern:
+//     tl.load(ptr + rows[:,None]*stride + cols[None,:], mask=mask_2d)
+//
+//   Vectorization runs along the column (contiguous) dimension. Rows are
+//   distributed across threads. This requires kCols >= kElemsPerVec and
+//   kCols % kElemsPerVec == 0 for full vectorization.
+//
+// USAGE
+// =====
+//   auto tile = tile_load<float, 8192>(ptr, tile_idx, group);
+//   auto peer = tile_load<float, 8192>(peer_ptr, tile_idx, group);
+//   tile_accumulate<float, SumOp>(tile, peer);
+//   tile_store(out_ptr, tile_idx, tile, group);
+
+#pragma once
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cstddef>
+#include <cstdint>
+
+#include "comms/pipes/ThreadGroup.cuh"
+
+namespace comms::pipes {
+
+// ============================================================================
+// Reduction ops: tag types for selecting the reduction operation.
+//
+// Used as template arguments to tile_accumulate / tile_load_accumulate.
+// Each tag dispatches to the corresponding VecOps::reduce overload.
+// Adding a new op = one reduce() overload per VecOps specialization.
+// ============================================================================
+
+struct SumOp {};
+struct MaxOp {};
+struct MinOp {};
+
+// ============================================================================
+// VecOps<T>: per-type vectorized reduction on uint4 vectors.
+//
+//   kElemsPerVec  Number of T elements packed in one uint4 (16 bytes).
+//   reduce(Op, a, b)  Element-wise reduction: a = Op(a, b), operating on
+//                     all kElemsPerVec elements inside the uint4 pair.
+//
+// To add a new element type: specialize VecOps<NewType> with kElemsPerVec
+// and one reduce() overload per op tag. For 16-bit types that use the
+// __hadd2/__hmax2/__hmin2 intrinsics, inherit from HalfPrecisionVecOps.
+// ============================================================================
+
+template <typename T>
+struct VecOps;
+
+template <>
+struct VecOps<float> {
+  static constexpr int kElemsPerVec = sizeof(uint4) / sizeof(float); // 4
+
+  __device__ __forceinline__ static void
+  reduce(SumOp, uint4& a, const uint4& b) {
+    float4& va = reinterpret_cast<float4&>(a);
+    const float4& vb = reinterpret_cast<const float4&>(b);
+    va.x += vb.x;
+    va.y += vb.y;
+    va.z += vb.z;
+    va.w += vb.w;
+  }
+
+  __device__ __forceinline__ static void
+  reduce(MaxOp, uint4& a, const uint4& b) {
+    float4& va = reinterpret_cast<float4&>(a);
+    const float4& vb = reinterpret_cast<const float4&>(b);
+    va.x = fmaxf(va.x, vb.x);
+    va.y = fmaxf(va.y, vb.y);
+    va.z = fmaxf(va.z, vb.z);
+    va.w = fmaxf(va.w, vb.w);
+  }
+
+  __device__ __forceinline__ static void
+  reduce(MinOp, uint4& a, const uint4& b) {
+    float4& va = reinterpret_cast<float4&>(a);
+    const float4& vb = reinterpret_cast<const float4&>(b);
+    va.x = fminf(va.x, vb.x);
+    va.y = fminf(va.y, vb.y);
+    va.z = fminf(va.z, vb.z);
+    va.w = fminf(va.w, vb.w);
+  }
+
+  __device__ __forceinline__ static void
+  reduce_scalar(SumOp, float& a, const float& b) {
+    a += b;
+  }
+
+  __device__ __forceinline__ static void
+  reduce_scalar(MaxOp, float& a, const float& b) {
+    a = fmaxf(a, b);
+  }
+
+  __device__ __forceinline__ static void
+  reduce_scalar(MinOp, float& a, const float& b) {
+    a = fminf(a, b);
+  }
+};
+
+template <typename ScalarT, typename PackedT>
+struct HalfPrecisionVecOps {
+  static constexpr int kElemsPerVec = sizeof(uint4) / sizeof(ScalarT);
+  static constexpr int kPairsPerVec = kElemsPerVec / 2;
+
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  __device__ __forceinline__ static void
+  reduce(SumOp, uint4& a, const uint4& b) {
+    PackedT* va = reinterpret_cast<PackedT*>(&a);
+    const PackedT* vb = reinterpret_cast<const PackedT*>(&b);
+#pragma unroll
+    for (int i = 0; i < kPairsPerVec; i++) {
+      va[i] = __hadd2(va[i], vb[i]);
+    }
+  }
+
+  __device__ __forceinline__ static void
+  reduce(MaxOp, uint4& a, const uint4& b) {
+    PackedT* va = reinterpret_cast<PackedT*>(&a);
+    const PackedT* vb = reinterpret_cast<const PackedT*>(&b);
+#pragma unroll
+    for (int i = 0; i < kPairsPerVec; i++) {
+      va[i] = __hmax2(va[i], vb[i]);
+    }
+  }
+
+  __device__ __forceinline__ static void
+  reduce(MinOp, uint4& a, const uint4& b) {
+    PackedT* va = reinterpret_cast<PackedT*>(&a);
+    const PackedT* vb = reinterpret_cast<const PackedT*>(&b);
+#pragma unroll
+    for (int i = 0; i < kPairsPerVec; i++) {
+      va[i] = __hmin2(va[i], vb[i]);
+    }
+  }
+
+  __device__ __forceinline__ static void
+  reduce_scalar(SumOp, ScalarT& a, const ScalarT& b) {
+    a = __hadd(a, b);
+  }
+
+  __device__ __forceinline__ static void
+  reduce_scalar(MaxOp, ScalarT& a, const ScalarT& b) {
+    a = __hmax(a, b);
+  }
+
+  __device__ __forceinline__ static void
+  reduce_scalar(MinOp, ScalarT& a, const ScalarT& b) {
+    a = __hmin(a, b);
+  }
+#endif
+};
+
+template <>
+struct VecOps<__nv_bfloat16>
+    : HalfPrecisionVecOps<__nv_bfloat16, __nv_bfloat162> {};
+
+template <>
+struct VecOps<__half> : HalfPrecisionVecOps<__half, __half2> {};
+
+// ============================================================================
+// Storage policies
+// ============================================================================
+
+struct RegisterStorage {};
+
+// ============================================================================
+// Tile<T, kTileElems, kBlockSize>
+//
+// A fixed-size block of kTileElems elements of type T, cooperatively owned
+// by kBlockSize threads. Each thread stores kVPT uint4 vectors in registers.
+//
+// Template parameters:
+//   T            Element type (float, __half, __nv_bfloat16).
+//   kTileElems   Total elements in the tile. Must be divisible by
+//                kBlockSize * kElemsPerVec.
+//   kBlockSize   Number of cooperating threads (default 256). Must match
+//                the ThreadGroup's group_size at runtime.
+//
+// Derived constants:
+//   kElemsPerVec = sizeof(uint4) / sizeof(T)     elements per vector
+//   kTileVecs    = kTileElems / kElemsPerVec      vectors in the tile
+//   kVPT         = kTileVecs / kBlockSize         vectors per thread
+//
+// Memory layout (thread k owns vectors at strided positions):
+//   thread k → vecs[0] = global vec [k]
+//              vecs[1] = global vec [k + kBlockSize]
+//              vecs[j] = global vec [k + j * kBlockSize]
+// ============================================================================
+
+template <
+    typename T,
+    int kTileElems,
+    int kBlockSize = 256,
+    typename Storage = RegisterStorage>
+struct Tile;
+
+template <typename T, int kTileElems, int kBlockSize>
+struct Tile<T, kTileElems, kBlockSize, RegisterStorage> {
+  static constexpr int kElemsPerVec = VecOps<T>::kElemsPerVec;
+  static constexpr int kTileVecs = kTileElems / kElemsPerVec;
+  static constexpr int kVPT = kTileVecs / kBlockSize;
+  static_assert(kVPT > 0, "kTileElems too small for kBlockSize");
+  static_assert(
+      kTileElems % (kBlockSize * kElemsPerVec) == 0,
+      "kTileElems must be divisible by kBlockSize * kElemsPerVec");
+
+  uint4 vecs[kVPT];
+};
+
+// ============================================================================
+// tile_load — cooperative vectorized load from global memory into a tile.
+//
+// All threads in the group cooperate to load kTileElems elements starting at
+// ptr[tile_idx * kTileElems]. Each thread loads kVPT vectors at strided
+// positions: thread k loads vectors [k, k+kBlockSize, k+2*kBlockSize, ...].
+//
+// Partial-tile masking (Triton: tl.load with mask):
+//   When valid_elems < kTileElems, elements beyond valid_elems are zeroed.
+//   valid_elems need not be vector-aligned — the last partial vector is
+//   loaded element-by-element and zero-padded.
+//
+// @param ptr          Source buffer (element-typed pointer).
+// @param tile_idx     Which tile to load (0-based). Tile starts at
+//                     ptr[tile_idx * kTileElems].
+// @param group        ThreadGroup with group_size == kBlockSize.
+// @param valid_elems  Number of valid elements (default = kTileElems).
+//                     Elements beyond this are loaded as zero.
+// @return             Register-backed tile with loaded data.
+// ============================================================================
+
+template <typename T, int kTileElems, int kBlockSize = 256>
+__device__ __forceinline__ Tile<T, kTileElems, kBlockSize, RegisterStorage>
+tile_load(
+    const T* ptr,
+    std::size_t tile_idx,
+    const ThreadGroup& group,
+    std::size_t valid_elems = kTileElems) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  using TileType = Tile<T, kTileElems, kBlockSize, RegisterStorage>;
+  constexpr int kVPT = TileType::kVPT;
+  constexpr int kTileVecs = TileType::kTileVecs;
+  constexpr int kEPV = VecOps<T>::kElemsPerVec;
+
+  TileType tile;
+  if (reinterpret_cast<uintptr_t>(ptr) % alignof(uint4) != 0) {
+    printf(
+        "tile_load: ptr %p is not 16-byte aligned (required for uint4 vectorized access)\n",
+        ptr);
+    __trap();
+  }
+  const uint4* src = reinterpret_cast<const uint4*>(ptr) + tile_idx * kTileVecs;
+  const std::size_t full_vecs = valid_elems / kEPV;
+  const int remainder = static_cast<int>(valid_elems % kEPV);
+
+#pragma unroll
+  for (int k = 0; k < kVPT; k++) {
+    std::size_t idx = group.thread_id_in_group + k * group.group_size;
+    if (idx < full_vecs) {
+      tile.vecs[k] = src[idx];
+    } else if (idx == full_vecs && remainder > 0) {
+      tile.vecs[k] = make_uint4(0, 0, 0, 0);
+      const T* elem_src = ptr + tile_idx * kTileElems + idx * kEPV;
+      T* elem_dst = reinterpret_cast<T*>(&tile.vecs[k]);
+      for (int e = 0; e < remainder; e++) {
+        elem_dst[e] = elem_src[e];
+      }
+    } else {
+      tile.vecs[k] = make_uint4(0, 0, 0, 0);
+    }
+  }
+  return tile;
+#else
+  return {};
+#endif
+}
+
+// ============================================================================
+// tile_store — cooperative vectorized store from tile to global memory.
+//
+// All threads cooperate to store kTileElems elements to
+// ptr[tile_idx * kTileElems]. Partial-tile masking stores only the first
+// valid_elems elements; the last partial vector is stored element-by-element.
+//
+// Triton equivalent: tl.store(ptr + offsets, tile, mask=mask)
+//
+// @param ptr          Destination buffer (element-typed pointer).
+// @param tile_idx     Which tile slot to store into (0-based).
+// @param tile         Register-backed tile to store.
+// @param group        ThreadGroup with group_size == kBlockSize.
+// @param valid_elems  Number of valid elements to store (default = kTileElems).
+// ============================================================================
+
+template <typename T, int kTileElems, int kBlockSize = 256>
+__device__ __forceinline__ void tile_store(
+    T* ptr,
+    std::size_t tile_idx,
+    const Tile<T, kTileElems, kBlockSize, RegisterStorage>& tile,
+    const ThreadGroup& group,
+    std::size_t valid_elems = kTileElems) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  using TileType = Tile<T, kTileElems, kBlockSize, RegisterStorage>;
+  constexpr int kVPT = TileType::kVPT;
+  constexpr int kTileVecs = TileType::kTileVecs;
+  constexpr int kEPV = VecOps<T>::kElemsPerVec;
+
+  if (reinterpret_cast<uintptr_t>(ptr) % alignof(uint4) != 0) {
+    printf(
+        "tile_store: ptr %p is not 16-byte aligned (required for uint4 vectorized access)\n",
+        ptr);
+    __trap();
+  }
+  uint4* dst = reinterpret_cast<uint4*>(ptr) + tile_idx * kTileVecs;
+  const std::size_t full_vecs = valid_elems / kEPV;
+  const int remainder = static_cast<int>(valid_elems % kEPV);
+
+#pragma unroll
+  for (int k = 0; k < kVPT; k++) {
+    std::size_t idx = group.thread_id_in_group + k * group.group_size;
+    if (idx < full_vecs) {
+      dst[idx] = tile.vecs[k];
+    } else if (idx == full_vecs && remainder > 0) {
+      const T* elem_src = reinterpret_cast<const T*>(&tile.vecs[k]);
+      T* elem_dst = ptr + tile_idx * kTileElems + idx * kEPV;
+      for (int e = 0; e < remainder; e++) {
+        elem_dst[e] = elem_src[e];
+      }
+    }
+  }
+#endif
+}
+
+// ============================================================================
+// tile_accumulate — element-wise reduction between two register tiles.
+//
+// Applies Op element-wise: dst[i] = Op(dst[i], src[i]) for all elements.
+// Operates entirely on registers — no memory access, no synchronization.
+// Each thread reduces its own kVPT vectors independently.
+//
+// Triton equivalent:
+//   SumOp → dst += src       MaxOp → dst = tl.maximum(dst, src)
+//   MinOp → dst = tl.minimum(dst, src)
+//
+// @param dst  Destination tile (modified in-place).
+// @param src  Source tile to accumulate from.
+// ============================================================================
+
+template <typename T, typename Op, int kTileElems, int kBlockSize = 256>
+__device__ __forceinline__ void tile_accumulate(
+    Tile<T, kTileElems, kBlockSize, RegisterStorage>& dst,
+    const Tile<T, kTileElems, kBlockSize, RegisterStorage>& src) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  constexpr int kVPT = Tile<T, kTileElems, kBlockSize, RegisterStorage>::kVPT;
+#pragma unroll
+  for (int k = 0; k < kVPT; k++) {
+    VecOps<T>::reduce(Op{}, dst.vecs[k], src.vecs[k]);
+  }
+#endif
+}
+
+// ============================================================================
+// tile_load_accumulate — fused load + element-wise reduction.
+//
+// Loads a tile from global memory and reduces it into dst, without
+// materializing the loaded tile in a separate register variable. Saves
+// kVPT registers compared to separate tile_load + tile_accumulate.
+//
+// Triton equivalent: dst += tl.load(ptr + offsets, mask=mask)
+//
+// Partial-tile masking: elements beyond valid_elems are skipped (not
+// accumulated). The last partial vector uses scalar element-wise reduction
+// on only the valid elements, so this is correct for all ops (SumOp,
+// MaxOp, MinOp).
+//
+// @param dst          Destination tile (accumulated in-place).
+// @param ptr          Source buffer (element-typed pointer).
+// @param tile_idx     Which tile to load (0-based).
+// @param group        ThreadGroup with group_size == kBlockSize.
+// @param valid_elems  Number of valid elements (default = kTileElems).
+// ============================================================================
+
+template <typename T, typename Op, int kTileElems, int kBlockSize = 256>
+__device__ __forceinline__ void tile_load_accumulate(
+    Tile<T, kTileElems, kBlockSize, RegisterStorage>& dst,
+    const T* ptr,
+    std::size_t tile_idx,
+    const ThreadGroup& group,
+    std::size_t valid_elems = kTileElems) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  using TileType = Tile<T, kTileElems, kBlockSize, RegisterStorage>;
+  constexpr int kVPT = TileType::kVPT;
+  constexpr int kTileVecs = TileType::kTileVecs;
+  constexpr int kEPV = VecOps<T>::kElemsPerVec;
+
+  if (reinterpret_cast<uintptr_t>(ptr) % alignof(uint4) != 0) {
+    printf(
+        "tile_load_accumulate: ptr %p is not 16-byte aligned (required for uint4 vectorized access)\n",
+        ptr);
+    __trap();
+  }
+  const uint4* src = reinterpret_cast<const uint4*>(ptr) + tile_idx * kTileVecs;
+  const std::size_t full_vecs = valid_elems / kEPV;
+  const int remainder = static_cast<int>(valid_elems % kEPV);
+
+#pragma unroll
+  for (int k = 0; k < kVPT; k++) {
+    std::size_t idx = group.thread_id_in_group + k * group.group_size;
+    if (idx < full_vecs) {
+      uint4 v = src[idx];
+      VecOps<T>::reduce(Op{}, dst.vecs[k], v);
+    } else if (idx == full_vecs && remainder > 0) {
+      const T* elem_src = ptr + tile_idx * kTileElems + idx * kEPV;
+      T* elem_dst = reinterpret_cast<T*>(&dst.vecs[k]);
+      for (int e = 0; e < remainder; e++) {
+        VecOps<T>::reduce_scalar(Op{}, elem_dst[e], elem_src[e]);
+      }
+    }
+  }
+#endif
+}
+
+// ============================================================================
+// tile_zero — zero-initialize all elements in a tile.
+//
+// Triton equivalent: tile = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+//
+// Each thread zeros its own kVPT vectors. No synchronization needed.
+//
+// @param tile  Tile to zero (modified in-place).
+// ============================================================================
+
+template <typename T, int kTileElems, int kBlockSize = 256>
+__device__ __forceinline__ void tile_zero(
+    Tile<T, kTileElems, kBlockSize, RegisterStorage>& tile) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  constexpr int kVPT = Tile<T, kTileElems, kBlockSize, RegisterStorage>::kVPT;
+#pragma unroll
+  for (int k = 0; k < kVPT; k++) {
+    tile.vecs[k] = make_uint4(0, 0, 0, 0);
+  }
+#endif
+}
+
+// ============================================================================
+// tile_load_2d — cooperative load from a strided 2D region into a tile.
+//
+// Loads a kRows × kCols sub-matrix from a row-major matrix with the given
+// stride (elements between consecutive rows). Returns a flat
+// Tile<T, kRows*kCols, kBlockSize> — the 2D structure is only relevant for
+// memory addressing. The returned tile is compatible with all 1D tile ops
+// (tile_accumulate, tile_store, etc.).
+//
+// Triton equivalent:
+//   offs_r = row_offset + tl.arange(0, ROWS)
+//   offs_c = col_offset + tl.arange(0, COLS)
+//   tl.load(ptr + offs_r[:,None]*stride + offs_c[None,:], mask=mask_2d)
+//
+// Thread-to-vector mapping:
+//   kColVecs = kCols / kElemsPerVec (vectors per row)
+//   Vector v → row = v / kColVecs, col_vec = v % kColVecs
+//
+// @param ptr          Base pointer to the 2D matrix (row-major).
+// @param row_offset   Starting row index.
+// @param col_offset   Starting column index.
+// @param stride       Elements between consecutive rows.
+// @param group        ThreadGroup with group_size == kBlockSize.
+// @param valid_rows   Number of valid rows (default = kRows).
+// @param valid_cols   Number of valid columns (default = kCols).
+// @return             Flat tile with kRows*kCols elements.
+// ============================================================================
+
+template <typename T, int kRows, int kCols, int kBlockSize = 256>
+__device__ __forceinline__ Tile<T, kRows * kCols, kBlockSize, RegisterStorage>
+tile_load_2d(
+    const T* ptr,
+    std::size_t row_offset,
+    std::size_t col_offset,
+    std::size_t stride,
+    const ThreadGroup& group,
+    std::size_t valid_rows = kRows,
+    std::size_t valid_cols = kCols) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  constexpr int kEPV = VecOps<T>::kElemsPerVec;
+  constexpr int kColVecs = kCols / kEPV;
+  static_assert(kCols % kEPV == 0, "kCols must be divisible by vector width");
+
+  using TileType = Tile<T, kRows * kCols, kBlockSize, RegisterStorage>;
+  constexpr int kVPT = TileType::kVPT;
+
+  TileType tile;
+  if (reinterpret_cast<uintptr_t>(ptr) % alignof(uint4) != 0) {
+    printf(
+        "tile_load_2d: ptr %p is not 16-byte aligned (required for uint4 vectorized access)\n",
+        ptr);
+    __trap();
+  }
+  if (col_offset % kEPV != 0) {
+    printf(
+        "tile_load_2d: col_offset %llu is not aligned to vector width %d\n",
+        static_cast<unsigned long long>(col_offset),
+        kEPV);
+    __trap();
+  }
+  const std::size_t full_col_vecs = valid_cols / kEPV;
+  const int col_rem = static_cast<int>(valid_cols % kEPV);
+
+#pragma unroll
+  for (int k = 0; k < kVPT; k++) {
+    std::size_t v = group.thread_id_in_group + k * group.group_size;
+    std::size_t row = v / kColVecs;
+    std::size_t cv = v % kColVecs;
+
+    if (row < valid_rows && cv < full_col_vecs) {
+      const uint4* row_base = reinterpret_cast<const uint4*>(
+          ptr + (row_offset + row) * stride + col_offset);
+      tile.vecs[k] = row_base[cv];
+    } else if (row < valid_rows && cv == full_col_vecs && col_rem > 0) {
+      tile.vecs[k] = make_uint4(0, 0, 0, 0);
+      const T* elem_src =
+          ptr + (row_offset + row) * stride + col_offset + cv * kEPV;
+      T* elem_dst = reinterpret_cast<T*>(&tile.vecs[k]);
+      for (int e = 0; e < col_rem; e++) {
+        elem_dst[e] = elem_src[e];
+      }
+    } else {
+      tile.vecs[k] = make_uint4(0, 0, 0, 0);
+    }
+  }
+  return tile;
+#else
+  return {};
+#endif
+}
+
+// ============================================================================
+// tile_store_2d — cooperative store from a tile into a strided 2D region.
+//
+// Stores a flat tile back into a kRows × kCols sub-matrix of a row-major
+// matrix. Partial masking for valid_rows/valid_cols works the same as
+// tile_load_2d.
+//
+// Triton equivalent:
+//   tl.store(ptr + offs_r[:,None]*stride + offs_c[None,:], tile, mask=mask_2d)
+//
+// @param ptr          Base pointer to the destination matrix (row-major).
+// @param row_offset   Starting row index.
+// @param col_offset   Starting column index.
+// @param stride       Elements between consecutive rows.
+// @param tile         Flat tile to store.
+// @param group        ThreadGroup with group_size == kBlockSize.
+// @param valid_rows   Number of valid rows (default = kRows).
+// @param valid_cols   Number of valid columns (default = kCols).
+// ============================================================================
+
+template <typename T, int kRows, int kCols, int kBlockSize = 256>
+__device__ __forceinline__ void tile_store_2d(
+    T* ptr,
+    std::size_t row_offset,
+    std::size_t col_offset,
+    std::size_t stride,
+    const Tile<T, kRows * kCols, kBlockSize, RegisterStorage>& tile,
+    const ThreadGroup& group,
+    std::size_t valid_rows = kRows,
+    std::size_t valid_cols = kCols) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  constexpr int kEPV = VecOps<T>::kElemsPerVec;
+  constexpr int kColVecs = kCols / kEPV;
+  static_assert(kCols % kEPV == 0, "kCols must be divisible by vector width");
+
+  using TileType = Tile<T, kRows * kCols, kBlockSize, RegisterStorage>;
+  constexpr int kVPT = TileType::kVPT;
+
+  if (reinterpret_cast<uintptr_t>(ptr) % alignof(uint4) != 0) {
+    printf(
+        "tile_store_2d: ptr %p is not 16-byte aligned (required for uint4 vectorized access)\n",
+        ptr);
+    __trap();
+  }
+  if (col_offset % kEPV != 0) {
+    printf(
+        "tile_store_2d: col_offset %llu is not aligned to vector width %d\n",
+        static_cast<unsigned long long>(col_offset),
+        kEPV);
+    __trap();
+  }
+  const std::size_t full_col_vecs = valid_cols / kEPV;
+  const int col_rem = static_cast<int>(valid_cols % kEPV);
+
+#pragma unroll
+  for (int k = 0; k < kVPT; k++) {
+    std::size_t v = group.thread_id_in_group + k * group.group_size;
+    std::size_t row = v / kColVecs;
+    std::size_t cv = v % kColVecs;
+
+    if (row < valid_rows && cv < full_col_vecs) {
+      uint4* row_base = reinterpret_cast<uint4*>(
+          ptr + (row_offset + row) * stride + col_offset);
+      row_base[cv] = tile.vecs[k];
+    } else if (row < valid_rows && cv == full_col_vecs && col_rem > 0) {
+      const T* elem_src = reinterpret_cast<const T*>(&tile.vecs[k]);
+      T* elem_dst = ptr + (row_offset + row) * stride + col_offset + cv * kEPV;
+      for (int e = 0; e < col_rem; e++) {
+        elem_dst[e] = elem_src[e];
+      }
+    }
+  }
+#endif
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+// Number of full tiles that fit in nelems elements.
+// Triton equivalent: nelems // kTileElems
+template <int kTileElems>
+__device__ __forceinline__ std::size_t num_tiles(std::size_t nelems) {
+  return nelems / kTileElems;
+}
+
+// Remainder elements after full tiles (for partial-tile masking).
+// Triton equivalent: nelems % kTileElems
+template <int kTileElems>
+__device__ __forceinline__ std::size_t tile_remainder(std::size_t nelems) {
+  return nelems % kTileElems;
+}
+
+} // namespace comms::pipes

--- a/comms/pipes/benchmarks/TileBench.cc
+++ b/comms/pipes/benchmarks/TileBench.cc
@@ -1,0 +1,127 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include <glog/logging.h>
+
+#include "comms/pipes/benchmarks/TileBench.cuh"
+#include "comms/testinfra/BenchUtils.h"
+#include "comms/testinfra/CudaBenchBase.h"
+#include "comms/utils/CudaRAII.h"
+
+using meta::comms::DeviceBuffer;
+
+namespace comms::pipes::benchmark {
+
+static void run_tile_bench(
+    uint32_t iters,
+    size_t nBytes,
+    int nBlocks,
+    const void* kernel,
+    int nBufs,
+    float bw_multiplier,
+    folly::UserCounters& counters) {
+  const int nRunsPerIter = 50;
+  const int nThreads = 256;
+  size_t nelems = nBytes / sizeof(float);
+
+  CHECK_EQ(cudaSetDevice(0), cudaSuccess);
+  CudaBenchBase bench;
+
+  std::vector<DeviceBuffer> bufs;
+  bufs.reserve(nBufs);
+  for (int i = 0; i < nBufs; i++) {
+    bufs.emplace_back(nBytes);
+  }
+
+  std::vector<void*> ptrs;
+  ptrs.reserve(nBufs);
+  for (auto& b : bufs) {
+    ptrs.push_back(b.get());
+  }
+
+  std::vector<void*> kernArgs;
+  kernArgs.reserve(nBufs + 2);
+  for (auto& p : ptrs) {
+    kernArgs.push_back(&p);
+  }
+  kernArgs.push_back(&nelems);
+  kernArgs.push_back(const_cast<int*>(&nRunsPerIter));
+
+  bench.startTiming();
+  for (uint32_t i = 0; i < iters; ++i) {
+    CHECK_EQ(
+        cudaLaunchKernel(
+            kernel,
+            dim3(nBlocks),
+            dim3(nThreads),
+            kernArgs.data(),
+            0,
+            bench.stream),
+        cudaSuccess);
+  }
+  bench.stopTiming();
+  float totalTimeMs = bench.measureTime();
+
+  float avgTimeUs = (totalTimeMs / iters / nRunsPerIter) * 1000.0f;
+  float busBwGBps = (bw_multiplier * nBytes / 1e9f) / (avgTimeUs / 1e6f);
+
+  counters["deviceTimeUs"] =
+      folly::UserMetric(avgTimeUs, folly::UserMetric::Type::METRIC);
+  counters["busBwGBps"] =
+      folly::UserMetric(busBwGBps, folly::UserMetric::Type::METRIC);
+}
+
+static void tile_copy_bench(
+    uint32_t iters,
+    size_t nBytes,
+    int nBlocks,
+    folly::UserCounters& counters) {
+  run_tile_bench(
+      iters, nBytes, nBlocks, (const void*)tile_copy_kernel, 2, 1.0f, counters);
+}
+
+static void tile_reduce_sum_bench(
+    uint32_t iters,
+    size_t nBytes,
+    int nBlocks,
+    folly::UserCounters& counters) {
+  run_tile_bench(
+      iters,
+      nBytes,
+      nBlocks,
+      (const void*)tile_reduce_sum_kernel,
+      3,
+      2.0f,
+      counters);
+}
+
+#define REGISTER_TILE_BENCH_FOR_SIZE(func, sizeMB)   \
+  BENCHMARK_MULTI_PARAM_COUNTERS(                    \
+      func, sizeMB##MB_4b, sizeMB * 1024 * 1024, 4); \
+  BENCHMARK_MULTI_PARAM_COUNTERS(                    \
+      func, sizeMB##MB_8b, sizeMB * 1024 * 1024, 8); \
+  BENCHMARK_MULTI_PARAM_COUNTERS(func, sizeMB##MB_16b, sizeMB * 1024 * 1024, 16)
+
+#define REGISTER_TILE_BENCH_ALL_SIZES(func) \
+  REGISTER_TILE_BENCH_FOR_SIZE(func, 2);    \
+  REGISTER_TILE_BENCH_FOR_SIZE(func, 4);    \
+  REGISTER_TILE_BENCH_FOR_SIZE(func, 8)
+
+REGISTER_TILE_BENCH_ALL_SIZES(tile_copy_bench);
+REGISTER_TILE_BENCH_ALL_SIZES(tile_reduce_sum_bench);
+
+} // namespace comms::pipes::benchmark
+
+int main(int argc, char** argv) {
+  CHECK_GE(bench_utils::getNumCudaDevices(), 1);
+  CHECK_EQ(cudaSetDevice(0), cudaSuccess);
+
+  folly::Init init(&argc, &argv);
+  folly::runBenchmarks();
+
+  CHECK_EQ(cudaDeviceReset(), cudaSuccess);
+  return 0;
+}

--- a/comms/pipes/benchmarks/TileBench.cu
+++ b/comms/pipes/benchmarks/TileBench.cu
@@ -1,0 +1,57 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/Tile.cuh"
+#include "comms/pipes/benchmarks/TileBench.cuh"
+
+namespace comms::pipes::benchmark {
+
+using namespace comms::pipes;
+
+constexpr int kBenchBlockSize = 256;
+constexpr int kBenchTileElems = 2048;
+
+__global__ void
+tile_copy_kernel(float* dst, const float* src, std::size_t nelems, int nruns) {
+  auto group = make_block_group();
+  const std::size_t ntiles = nelems / kBenchTileElems;
+  const std::size_t tiles_per_block = (ntiles + gridDim.x - 1) / gridDim.x;
+  const std::size_t tile_start = blockIdx.x * tiles_per_block;
+  const std::size_t tile_end = (tile_start + tiles_per_block < ntiles)
+      ? tile_start + tiles_per_block
+      : ntiles;
+
+  for (int run = 0; run < nruns; run++) {
+    for (std::size_t t = tile_start; t < tile_end; t++) {
+      auto tile =
+          tile_load<float, kBenchTileElems, kBenchBlockSize>(src, t, group);
+      tile_store<float, kBenchTileElems, kBenchBlockSize>(dst, t, tile, group);
+    }
+  }
+}
+
+__global__ void tile_reduce_sum_kernel(
+    float* dst,
+    const float* src_a,
+    const float* src_b,
+    std::size_t nelems,
+    int nruns) {
+  auto group = make_block_group();
+  const std::size_t ntiles = nelems / kBenchTileElems;
+  const std::size_t tiles_per_block = (ntiles + gridDim.x - 1) / gridDim.x;
+  const std::size_t tile_start = blockIdx.x * tiles_per_block;
+  const std::size_t tile_end = (tile_start + tiles_per_block < ntiles)
+      ? tile_start + tiles_per_block
+      : ntiles;
+
+  for (int run = 0; run < nruns; run++) {
+    for (std::size_t t = tile_start; t < tile_end; t++) {
+      auto tile =
+          tile_load<float, kBenchTileElems, kBenchBlockSize>(src_a, t, group);
+      tile_load_accumulate<float, SumOp, kBenchTileElems, kBenchBlockSize>(
+          tile, src_b, t, group);
+      tile_store<float, kBenchTileElems, kBenchBlockSize>(dst, t, tile, group);
+    }
+  }
+}
+
+} // namespace comms::pipes::benchmark

--- a/comms/pipes/benchmarks/TileBench.cuh
+++ b/comms/pipes/benchmarks/TileBench.cuh
@@ -1,0 +1,20 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <cstddef>
+
+namespace comms::pipes::benchmark {
+
+__global__ void
+tile_copy_kernel(float* dst, const float* src, std::size_t nelems, int nruns);
+
+__global__ void tile_reduce_sum_kernel(
+    float* dst,
+    const float* src_a,
+    const float* src_b,
+    std::size_t nelems,
+    int nruns);
+
+} // namespace comms::pipes::benchmark

--- a/comms/pipes/tests/TileTest.cc
+++ b/comms/pipes/tests/TileTest.cc
@@ -1,0 +1,909 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "comms/pipes/tests/TileTest.cuh"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/CudaRAII.h"
+
+using meta::comms::DeviceBuffer;
+
+namespace comms::pipes {
+
+using comms::pipes::test::kTileTest2DCols;
+using comms::pipes::test::kTileTest2DRows;
+using comms::pipes::test::kTileTestBlockSize;
+using comms::pipes::test::kTileTestTileElems;
+using comms::pipes::test::test_tile_accumulate_max_float;
+using comms::pipes::test::test_tile_accumulate_max_half;
+using comms::pipes::test::test_tile_accumulate_min_bf16;
+using comms::pipes::test::test_tile_accumulate_min_float;
+using comms::pipes::test::test_tile_accumulate_sum_bf16;
+using comms::pipes::test::test_tile_accumulate_sum_float;
+using comms::pipes::test::test_tile_load_accumulate_sum_float;
+using comms::pipes::test::test_tile_load_store_2d_float;
+using comms::pipes::test::test_tile_load_store_bf16;
+using comms::pipes::test::test_tile_load_store_float;
+using comms::pipes::test::test_tile_load_store_half;
+using comms::pipes::test::test_tile_partial_load_accumulate_max_float;
+using comms::pipes::test::test_tile_partial_load_accumulate_min_float;
+using comms::pipes::test::test_tile_partial_load_accumulate_sum_float;
+using comms::pipes::test::test_tile_partial_load_float;
+using comms::pipes::test::test_tile_partial_load_store_float;
+using comms::pipes::test::test_tile_partial_load_tile_idx1_float;
+using comms::pipes::test::test_tile_partial_store_float;
+using comms::pipes::test::test_tile_zero_float;
+
+constexpr int kTileElems = kTileTestTileElems;
+constexpr int kNumTiles = 4;
+constexpr int kNumElems = kTileElems * kNumTiles;
+
+class TileTestFixture : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    CUDACHECK_TEST(cudaSetDevice(0));
+  }
+  void TearDown() override {
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+  }
+};
+
+// =============================================================================
+// Load/Store roundtrip tests
+// =============================================================================
+
+template <typename T>
+void run_load_store_roundtrip(
+    void (*kernel)(const T*, T*, std::size_t),
+    float (*to_float)(T),
+    T (*from_float)(float),
+    int mod) {
+  std::vector<T> input_h(kNumElems);
+  for (int i = 0; i < kNumElems; i++) {
+    input_h[i] = from_float(static_cast<float>(i % mod));
+  }
+
+  DeviceBuffer inputBuf(kNumElems * sizeof(T));
+  DeviceBuffer outputBuf(kNumElems * sizeof(T));
+  auto* input_d = static_cast<T*>(inputBuf.get());
+  auto* output_d = static_cast<T*>(outputBuf.get());
+
+  CUDACHECK_TEST(cudaMemcpy(
+      input_d, input_h.data(), kNumElems * sizeof(T), cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(cudaMemset(output_d, 0, kNumElems * sizeof(T)));
+
+  kernel(input_d, output_d, kNumTiles);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<T> output_h(kNumElems);
+  CUDACHECK_TEST(cudaMemcpy(
+      output_h.data(),
+      output_d,
+      kNumElems * sizeof(T),
+      cudaMemcpyDeviceToHost));
+
+  for (int i = 0; i < kNumElems; i++) {
+    EXPECT_EQ(to_float(input_h[i]), to_float(output_h[i]))
+        << "Mismatch at index " << i;
+  }
+}
+
+TEST_F(TileTestFixture, LoadStoreFloat) {
+  run_load_store_roundtrip<float>(
+      test_tile_load_store_float,
+      [](float v) { return v; },
+      [](float v) { return v; },
+      kNumElems);
+}
+
+TEST_F(TileTestFixture, LoadStoreBF16) {
+  run_load_store_roundtrip<__nv_bfloat16>(
+      test_tile_load_store_bf16, __bfloat162float, __float2bfloat16, 256);
+}
+
+TEST_F(TileTestFixture, LoadStoreHalf) {
+  run_load_store_roundtrip<__half>(
+      test_tile_load_store_half, __half2float, __float2half, 256);
+}
+
+// =============================================================================
+// Zero test
+// =============================================================================
+
+TEST_F(TileTestFixture, TileZero) {
+  DeviceBuffer outputBuf(kNumElems * sizeof(float));
+  auto* output_d = static_cast<float*>(outputBuf.get());
+  CUDACHECK_TEST(cudaMemset(output_d, 0xFF, kNumElems * sizeof(float)));
+
+  test_tile_zero_float(output_d, kNumTiles);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<float> output_h(kNumElems);
+  CUDACHECK_TEST(cudaMemcpy(
+      output_h.data(),
+      output_d,
+      kNumElems * sizeof(float),
+      cudaMemcpyDeviceToHost));
+
+  std::vector<float> expected(kNumElems, 0.0f);
+  EXPECT_EQ(output_h, expected);
+}
+
+// =============================================================================
+// Accumulate tests (float)
+// =============================================================================
+
+using AccumKernelFn = void (*)(const float*, const float*, float*, std::size_t);
+using AccumExpectFn = float (*)(float, float);
+
+void run_accumulate_float_test(
+    AccumKernelFn kernel,
+    AccumExpectFn expect,
+    std::vector<float>& a_h,
+    std::vector<float>& b_h) {
+  const int n = static_cast<int>(a_h.size());
+  DeviceBuffer aBuf(n * sizeof(float));
+  DeviceBuffer bBuf(n * sizeof(float));
+  DeviceBuffer outBuf(n * sizeof(float));
+  auto* a_d = static_cast<float*>(aBuf.get());
+  auto* b_d = static_cast<float*>(bBuf.get());
+  auto* out_d = static_cast<float*>(outBuf.get());
+
+  CUDACHECK_TEST(
+      cudaMemcpy(a_d, a_h.data(), n * sizeof(float), cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(
+      cudaMemcpy(b_d, b_h.data(), n * sizeof(float), cudaMemcpyHostToDevice));
+
+  kernel(a_d, b_d, out_d, kNumTiles);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<float> output_h(n);
+  CUDACHECK_TEST(cudaMemcpy(
+      output_h.data(), out_d, n * sizeof(float), cudaMemcpyDeviceToHost));
+
+  for (int i = 0; i < n; i++) {
+    EXPECT_EQ(output_h[i], expect(a_h[i], b_h[i])) << "mismatch at index " << i;
+  }
+}
+
+TEST_F(TileTestFixture, AccumulateSum) {
+  std::vector<float> a_h(kNumElems), b_h(kNumElems);
+  for (int i = 0; i < kNumElems; i++) {
+    a_h[i] = static_cast<float>(i);
+    b_h[i] = static_cast<float>(i * 2);
+  }
+  run_accumulate_float_test(
+      test_tile_accumulate_sum_float,
+      [](float a, float b) { return a + b; },
+      a_h,
+      b_h);
+}
+
+TEST_F(TileTestFixture, AccumulateSumBF16) {
+  std::vector<__nv_bfloat16> a_h(kNumElems), b_h(kNumElems);
+  for (int i = 0; i < kNumElems; i++) {
+    a_h[i] = __float2bfloat16(static_cast<float>(i % 64));
+    b_h[i] = __float2bfloat16(static_cast<float>((i + 1) % 64));
+  }
+
+  DeviceBuffer aBuf(kNumElems * sizeof(__nv_bfloat16));
+  DeviceBuffer bBuf(kNumElems * sizeof(__nv_bfloat16));
+  DeviceBuffer outBuf(kNumElems * sizeof(__nv_bfloat16));
+  auto* a_d = static_cast<__nv_bfloat16*>(aBuf.get());
+  auto* b_d = static_cast<__nv_bfloat16*>(bBuf.get());
+  auto* out_d = static_cast<__nv_bfloat16*>(outBuf.get());
+
+  CUDACHECK_TEST(cudaMemcpy(
+      a_d,
+      a_h.data(),
+      kNumElems * sizeof(__nv_bfloat16),
+      cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(cudaMemcpy(
+      b_d,
+      b_h.data(),
+      kNumElems * sizeof(__nv_bfloat16),
+      cudaMemcpyHostToDevice));
+
+  test_tile_accumulate_sum_bf16(a_d, b_d, out_d, kNumTiles);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<__nv_bfloat16> output_h(kNumElems);
+  CUDACHECK_TEST(cudaMemcpy(
+      output_h.data(),
+      out_d,
+      kNumElems * sizeof(__nv_bfloat16),
+      cudaMemcpyDeviceToHost));
+
+  for (int i = 0; i < kNumElems; i++) {
+    float a_val = __bfloat162float(a_h[i]);
+    float b_val = __bfloat162float(b_h[i]);
+    float got = __bfloat162float(output_h[i]);
+    EXPECT_FLOAT_EQ(got, a_val + b_val) << "Mismatch at index " << i;
+  }
+}
+
+TEST_F(TileTestFixture, AccumulateMax) {
+  std::vector<float> a_h(kNumElems), b_h(kNumElems);
+  for (int i = 0; i < kNumElems; i++) {
+    a_h[i] = static_cast<float>(i);
+    b_h[i] = static_cast<float>(kNumElems - i);
+  }
+  run_accumulate_float_test(
+      test_tile_accumulate_max_float,
+      [](float a, float b) { return std::max(a, b); },
+      a_h,
+      b_h);
+}
+
+TEST_F(TileTestFixture, AccumulateMin) {
+  std::vector<float> a_h(kNumElems), b_h(kNumElems);
+  for (int i = 0; i < kNumElems; i++) {
+    a_h[i] = static_cast<float>(i);
+    b_h[i] = static_cast<float>(kNumElems - i);
+  }
+  run_accumulate_float_test(
+      test_tile_accumulate_min_float,
+      [](float a, float b) { return std::min(a, b); },
+      a_h,
+      b_h);
+}
+
+// =============================================================================
+// Fused load+accumulate test
+// =============================================================================
+
+TEST_F(TileTestFixture, LoadAccumulateSum) {
+  std::vector<float> base_h(kNumElems), add_h(kNumElems), expected(kNumElems);
+  for (int i = 0; i < kNumElems; i++) {
+    base_h[i] = static_cast<float>(i);
+    add_h[i] = static_cast<float>(i * 3);
+    expected[i] = base_h[i] + add_h[i];
+  }
+
+  DeviceBuffer baseBuf(kNumElems * sizeof(float));
+  DeviceBuffer addBuf(kNumElems * sizeof(float));
+  DeviceBuffer outBuf(kNumElems * sizeof(float));
+  auto* base_d = static_cast<float*>(baseBuf.get());
+  auto* add_d = static_cast<float*>(addBuf.get());
+  auto* out_d = static_cast<float*>(outBuf.get());
+
+  CUDACHECK_TEST(cudaMemcpy(
+      base_d,
+      base_h.data(),
+      kNumElems * sizeof(float),
+      cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(cudaMemcpy(
+      add_d, add_h.data(), kNumElems * sizeof(float), cudaMemcpyHostToDevice));
+
+  test_tile_load_accumulate_sum_float(base_d, add_d, out_d, kNumTiles);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<float> output_h(kNumElems);
+  CUDACHECK_TEST(cudaMemcpy(
+      output_h.data(),
+      out_d,
+      kNumElems * sizeof(float),
+      cudaMemcpyDeviceToHost));
+
+  EXPECT_EQ(output_h, expected);
+}
+
+// =============================================================================
+// Partial tile masking tests (parameterized)
+// =============================================================================
+
+struct MaskParams {
+  std::size_t valid_elems;
+  std::string name;
+};
+
+std::string mask_param_name(const ::testing::TestParamInfo<MaskParams>& info) {
+  return info.param.name;
+}
+
+const auto kMaskValues = ::testing::Values(
+    MaskParams{0, "zero_elems"},
+    MaskParams{1, "single_elem"},
+    MaskParams{3, "sub_vector"},
+    MaskParams{4, "one_vector"},
+    MaskParams{5, "one_vec_plus_one"},
+    MaskParams{1024, "aligned_half"},
+    MaskParams{1025, "unaligned"},
+    MaskParams{kTileTestTileElems - 1, "one_less_than_full"},
+    MaskParams{kTileTestTileElems, "full_tile"});
+
+// ---------------------------------------------------------------------------
+// tile_load masking
+// ---------------------------------------------------------------------------
+
+class TilePartialLoadTest : public TileTestFixture,
+                            public ::testing::WithParamInterface<MaskParams> {};
+
+TEST_P(TilePartialLoadTest, LoadMask) {
+  const std::size_t valid = GetParam().valid_elems;
+
+  std::vector<float> input_h(kTileElems);
+  for (int i = 0; i < kTileElems; i++) {
+    input_h[i] = static_cast<float>(i + 1);
+  }
+
+  DeviceBuffer inputBuf(kTileElems * sizeof(float));
+  DeviceBuffer outputBuf(kTileElems * sizeof(float));
+  auto* input_d = static_cast<float*>(inputBuf.get());
+  auto* output_d = static_cast<float*>(outputBuf.get());
+
+  CUDACHECK_TEST(cudaMemcpy(
+      input_d,
+      input_h.data(),
+      kTileElems * sizeof(float),
+      cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(cudaMemset(output_d, 0, kTileElems * sizeof(float)));
+
+  test_tile_partial_load_float(input_d, output_d, valid);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<float> output_h(kTileElems);
+  CUDACHECK_TEST(cudaMemcpy(
+      output_h.data(),
+      output_d,
+      kTileElems * sizeof(float),
+      cudaMemcpyDeviceToHost));
+
+  for (std::size_t i = 0; i < valid; i++) {
+    EXPECT_EQ(output_h[i], input_h[i]) << "mismatch at index " << i;
+  }
+  for (std::size_t i = valid; i < kTileElems; i++) {
+    EXPECT_EQ(output_h[i], 0.0f) << "should be zero at index " << i;
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    PartialLoad,
+    TilePartialLoadTest,
+    kMaskValues,
+    mask_param_name);
+
+// ---------------------------------------------------------------------------
+// tile_store masking
+// ---------------------------------------------------------------------------
+
+class TilePartialStoreTest : public TileTestFixture,
+                             public ::testing::WithParamInterface<MaskParams> {
+};
+
+TEST_P(TilePartialStoreTest, StoreMask) {
+  const std::size_t valid = GetParam().valid_elems;
+  const float kSentinel = -999.0f;
+
+  std::vector<float> input_h(kTileElems);
+  for (int i = 0; i < kTileElems; i++) {
+    input_h[i] = static_cast<float>(i + 1);
+  }
+
+  DeviceBuffer inputBuf(kTileElems * sizeof(float));
+  DeviceBuffer outputBuf(kTileElems * sizeof(float));
+  auto* input_d = static_cast<float*>(inputBuf.get());
+  auto* output_d = static_cast<float*>(outputBuf.get());
+
+  CUDACHECK_TEST(cudaMemcpy(
+      input_d,
+      input_h.data(),
+      kTileElems * sizeof(float),
+      cudaMemcpyHostToDevice));
+
+  std::vector<float> sentinel_h(kTileElems, kSentinel);
+  CUDACHECK_TEST(cudaMemcpy(
+      output_d,
+      sentinel_h.data(),
+      kTileElems * sizeof(float),
+      cudaMemcpyHostToDevice));
+
+  test_tile_partial_store_float(input_d, output_d, valid);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<float> output_h(kTileElems);
+  CUDACHECK_TEST(cudaMemcpy(
+      output_h.data(),
+      output_d,
+      kTileElems * sizeof(float),
+      cudaMemcpyDeviceToHost));
+
+  for (std::size_t i = 0; i < valid; i++) {
+    EXPECT_EQ(output_h[i], input_h[i]) << "mismatch at index " << i;
+  }
+  for (std::size_t i = valid; i < kTileElems; i++) {
+    EXPECT_EQ(output_h[i], kSentinel)
+        << "should be untouched sentinel at index " << i;
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    PartialStore,
+    TilePartialStoreTest,
+    kMaskValues,
+    mask_param_name);
+
+// ---------------------------------------------------------------------------
+// tile_load_accumulate masking (parameterized by op)
+//
+// The MaxOp/MinOp variants are regression tests: the old zero-padding
+// approach computed max(dst, 0) / min(dst, 0) on padded lanes, clamping
+// signed values toward zero. With scalar reduction on only the valid
+// elements, values are preserved.
+// ---------------------------------------------------------------------------
+
+using PartialAccumKernelFn =
+    void (*)(const float*, const float*, float*, std::size_t);
+
+struct PartialAccumParams {
+  MaskParams mask;
+  PartialAccumKernelFn kernel;
+  AccumExpectFn expect;
+  float base_offset;
+  float base_scale;
+  float add_scale;
+  std::string op_name;
+};
+
+std::string partial_accum_param_name(
+    const ::testing::TestParamInfo<PartialAccumParams>& info) {
+  return info.param.op_name + "_" + info.param.mask.name;
+}
+
+class TilePartialLoadAccumulateTest
+    : public TileTestFixture,
+      public ::testing::WithParamInterface<PartialAccumParams> {};
+
+TEST_P(TilePartialLoadAccumulateTest, LoadAccumulateMask) {
+  const auto& p = GetParam();
+  const std::size_t valid = p.mask.valid_elems;
+
+  std::vector<float> base_h(kTileElems), addend_h(kTileElems);
+  for (int i = 0; i < kTileElems; i++) {
+    base_h[i] = p.base_offset + p.base_scale * static_cast<float>(i + 1);
+    addend_h[i] = p.add_scale * static_cast<float>(i + 1);
+  }
+
+  DeviceBuffer baseBuf(kTileElems * sizeof(float));
+  DeviceBuffer addBuf(kTileElems * sizeof(float));
+  DeviceBuffer outBuf(kTileElems * sizeof(float));
+  auto* base_d = static_cast<float*>(baseBuf.get());
+  auto* add_d = static_cast<float*>(addBuf.get());
+  auto* out_d = static_cast<float*>(outBuf.get());
+
+  CUDACHECK_TEST(cudaMemcpy(
+      base_d,
+      base_h.data(),
+      kTileElems * sizeof(float),
+      cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(cudaMemcpy(
+      add_d,
+      addend_h.data(),
+      kTileElems * sizeof(float),
+      cudaMemcpyHostToDevice));
+
+  p.kernel(base_d, add_d, out_d, valid);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<float> output_h(kTileElems);
+  CUDACHECK_TEST(cudaMemcpy(
+      output_h.data(),
+      out_d,
+      kTileElems * sizeof(float),
+      cudaMemcpyDeviceToHost));
+
+  for (std::size_t i = 0; i < valid; i++) {
+    EXPECT_EQ(output_h[i], p.expect(base_h[i], addend_h[i]))
+        << "mismatch at index " << i;
+  }
+  for (std::size_t i = valid; i < kTileElems; i++) {
+    EXPECT_EQ(output_h[i], base_h[i])
+        << "should be base value (not accumulated) at index " << i;
+  }
+}
+
+static auto make_partial_accum_values(
+    PartialAccumKernelFn kernel,
+    AccumExpectFn expect,
+    float base_offset,
+    float base_scale,
+    float add_scale,
+    const std::string& op_name) {
+  std::vector<PartialAccumParams> params;
+  for (auto& m :
+       {MaskParams{0, "zero_elems"},
+        MaskParams{1, "single_elem"},
+        MaskParams{3, "sub_vector"},
+        MaskParams{4, "one_vector"},
+        MaskParams{5, "one_vec_plus_one"},
+        MaskParams{1024, "aligned_half"},
+        MaskParams{1025, "unaligned"},
+        MaskParams{kTileTestTileElems - 1, "one_less_than_full"},
+        MaskParams{kTileTestTileElems, "full_tile"}}) {
+    params.push_back(
+        {m, kernel, expect, base_offset, base_scale, add_scale, op_name});
+  }
+  return ::testing::ValuesIn(params);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Sum,
+    TilePartialLoadAccumulateTest,
+    make_partial_accum_values(
+        test_tile_partial_load_accumulate_sum_float,
+        [](float a, float b) { return a + b; },
+        0.0f,
+        1.0f,
+        10.0f,
+        "Sum"),
+    partial_accum_param_name);
+
+INSTANTIATE_TEST_SUITE_P(
+    Max,
+    TilePartialLoadAccumulateTest,
+    make_partial_accum_values(
+        test_tile_partial_load_accumulate_max_float,
+        [](float a, float b) { return std::max(a, b); },
+        0.0f,
+        -1.0f,
+        -2.0f,
+        "Max"),
+    partial_accum_param_name);
+
+INSTANTIATE_TEST_SUITE_P(
+    Min,
+    TilePartialLoadAccumulateTest,
+    make_partial_accum_values(
+        test_tile_partial_load_accumulate_min_float,
+        [](float a, float b) { return std::min(a, b); },
+        100.0f,
+        1.0f,
+        3.0f,
+        "Min"),
+    partial_accum_param_name);
+
+// ---------------------------------------------------------------------------
+// Combined load-masked + store-masked roundtrip
+// ---------------------------------------------------------------------------
+
+class TilePartialLoadStoreTest
+    : public TileTestFixture,
+      public ::testing::WithParamInterface<MaskParams> {};
+
+TEST_P(TilePartialLoadStoreTest, LoadAndStoreMask) {
+  const std::size_t valid = GetParam().valid_elems;
+  const float kSentinel = -999.0f;
+
+  std::vector<float> input_h(kTileElems);
+  for (int i = 0; i < kTileElems; i++) {
+    input_h[i] = static_cast<float>(i + 1);
+  }
+
+  DeviceBuffer inputBuf(kTileElems * sizeof(float));
+  DeviceBuffer outputBuf(kTileElems * sizeof(float));
+  auto* input_d = static_cast<float*>(inputBuf.get());
+  auto* output_d = static_cast<float*>(outputBuf.get());
+
+  CUDACHECK_TEST(cudaMemcpy(
+      input_d,
+      input_h.data(),
+      kTileElems * sizeof(float),
+      cudaMemcpyHostToDevice));
+  std::vector<float> sentinel_h(kTileElems, kSentinel);
+  CUDACHECK_TEST(cudaMemcpy(
+      output_d,
+      sentinel_h.data(),
+      kTileElems * sizeof(float),
+      cudaMemcpyHostToDevice));
+
+  test_tile_partial_load_store_float(input_d, output_d, valid);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<float> output_h(kTileElems);
+  CUDACHECK_TEST(cudaMemcpy(
+      output_h.data(),
+      output_d,
+      kTileElems * sizeof(float),
+      cudaMemcpyDeviceToHost));
+
+  for (std::size_t i = 0; i < valid; i++) {
+    EXPECT_EQ(output_h[i], input_h[i]) << "mismatch at index " << i;
+  }
+  for (std::size_t i = valid; i < kTileElems; i++) {
+    EXPECT_EQ(output_h[i], kSentinel)
+        << "should be untouched sentinel at index " << i;
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    PartialLoadStore,
+    TilePartialLoadStoreTest,
+    kMaskValues,
+    mask_param_name);
+
+// ---------------------------------------------------------------------------
+// Partial load at tile_idx > 0
+// ---------------------------------------------------------------------------
+
+TEST_F(TileTestFixture, PartialLoadTileIdx1) {
+  constexpr int kTotalElems = kTileElems * 2;
+  constexpr std::size_t kValidElems = 1025;
+
+  std::vector<float> input_h(kTotalElems);
+  for (int i = 0; i < kTotalElems; i++) {
+    input_h[i] = static_cast<float>(i + 1);
+  }
+
+  DeviceBuffer inputBuf(kTotalElems * sizeof(float));
+  DeviceBuffer outputBuf(kTileElems * sizeof(float));
+  auto* input_d = static_cast<float*>(inputBuf.get());
+  auto* output_d = static_cast<float*>(outputBuf.get());
+
+  CUDACHECK_TEST(cudaMemcpy(
+      input_d,
+      input_h.data(),
+      kTotalElems * sizeof(float),
+      cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(cudaMemset(output_d, 0, kTileElems * sizeof(float)));
+
+  test_tile_partial_load_tile_idx1_float(input_d, output_d, kValidElems);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<float> output_h(kTileElems);
+  CUDACHECK_TEST(cudaMemcpy(
+      output_h.data(),
+      output_d,
+      kTileElems * sizeof(float),
+      cudaMemcpyDeviceToHost));
+
+  for (std::size_t i = 0; i < kValidElems; i++) {
+    EXPECT_EQ(output_h[i], input_h[kTileElems + i])
+        << "mismatch at index " << i;
+  }
+  for (std::size_t i = kValidElems; i < kTileElems; i++) {
+    EXPECT_EQ(output_h[i], 0.0f) << "should be zero at index " << i;
+  }
+}
+
+// =============================================================================
+// Half-precision accumulate tests (exercises __hmax2 / __hmin2 / __hadd2)
+// =============================================================================
+
+template <typename T>
+void run_accumulate_half_test(
+    void (*kernel)(const T*, const T*, T*, std::size_t),
+    float (*to_float)(T),
+    T (*from_float)(float),
+    AccumExpectFn expect) {
+  constexpr int kN = kTileElems;
+  std::vector<T> a_h(kN), b_h(kN);
+  for (int i = 0; i < kN; i++) {
+    a_h[i] = from_float(static_cast<float>(i % 64));
+    b_h[i] = from_float(static_cast<float>(63 - (i % 64)));
+  }
+
+  DeviceBuffer aBuf(kN * sizeof(T));
+  DeviceBuffer bBuf(kN * sizeof(T));
+  DeviceBuffer outBuf(kN * sizeof(T));
+  auto* a_d = static_cast<T*>(aBuf.get());
+  auto* b_d = static_cast<T*>(bBuf.get());
+  auto* out_d = static_cast<T*>(outBuf.get());
+
+  CUDACHECK_TEST(
+      cudaMemcpy(a_d, a_h.data(), kN * sizeof(T), cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(
+      cudaMemcpy(b_d, b_h.data(), kN * sizeof(T), cudaMemcpyHostToDevice));
+
+  kernel(a_d, b_d, out_d, 1);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<T> output_h(kN);
+  CUDACHECK_TEST(cudaMemcpy(
+      output_h.data(), out_d, kN * sizeof(T), cudaMemcpyDeviceToHost));
+
+  for (int i = 0; i < kN; i++) {
+    float expected = expect(to_float(a_h[i]), to_float(b_h[i]));
+    EXPECT_EQ(to_float(output_h[i]), expected) << "mismatch at index " << i;
+  }
+}
+
+TEST_F(TileTestFixture, AccumulateMaxHalf) {
+  run_accumulate_half_test<__half>(
+      test_tile_accumulate_max_half,
+      __half2float,
+      __float2half,
+      [](float a, float b) { return std::max(a, b); });
+}
+
+TEST_F(TileTestFixture, AccumulateMinBF16) {
+  run_accumulate_half_test<__nv_bfloat16>(
+      test_tile_accumulate_min_bf16,
+      __bfloat162float,
+      __float2bfloat16,
+      [](float a, float b) { return std::min(a, b); });
+}
+
+// =============================================================================
+// 2D tile tests
+// =============================================================================
+
+constexpr int k2DRows = kTileTest2DRows;
+constexpr int k2DCols = kTileTest2DCols;
+
+TEST_F(TileTestFixture, LoadStore2DFull) {
+  constexpr int kM = k2DRows + 4;
+  constexpr int kN = k2DCols + 8;
+
+  std::vector<float> matrix_h(kM * kN, 0.0f);
+  for (int r = 0; r < kM; r++) {
+    for (int c = 0; c < kN; c++) {
+      matrix_h[r * kN + c] = static_cast<float>(r * 1000 + c + 1);
+    }
+  }
+
+  DeviceBuffer srcBuf(kM * kN * sizeof(float));
+  DeviceBuffer dstBuf(kM * kN * sizeof(float));
+  auto* src_d = static_cast<float*>(srcBuf.get());
+  auto* dst_d = static_cast<float*>(dstBuf.get());
+
+  CUDACHECK_TEST(cudaMemcpy(
+      src_d, matrix_h.data(), kM * kN * sizeof(float), cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(cudaMemset(dst_d, 0, kM * kN * sizeof(float)));
+
+  test_tile_load_store_2d_float(src_d, dst_d, kN, 2, 4, k2DRows, k2DCols);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<float> dst_h(kM * kN, 0.0f);
+  CUDACHECK_TEST(cudaMemcpy(
+      dst_h.data(), dst_d, kM * kN * sizeof(float), cudaMemcpyDeviceToHost));
+
+  for (int r = 0; r < k2DRows; r++) {
+    for (int c = 0; c < k2DCols; c++) {
+      int src_idx = (2 + r) * kN + (4 + c);
+      int dst_idx = (2 + r) * kN + (4 + c);
+      EXPECT_EQ(dst_h[dst_idx], matrix_h[src_idx])
+          << "mismatch at row=" << r << " col=" << c;
+    }
+  }
+}
+
+TEST_F(TileTestFixture, LoadStore2DPartialRows) {
+  constexpr int kM = k2DRows;
+  constexpr int kN = k2DCols;
+  constexpr int kValidRows = 5;
+  const float kSentinel = -1.0f;
+
+  std::vector<float> matrix_h(kM * kN);
+  for (int i = 0; i < kM * kN; i++) {
+    matrix_h[i] = static_cast<float>(i + 1);
+  }
+
+  DeviceBuffer srcBuf(kM * kN * sizeof(float));
+  DeviceBuffer dstBuf(kM * kN * sizeof(float));
+  auto* src_d = static_cast<float*>(srcBuf.get());
+  auto* dst_d = static_cast<float*>(dstBuf.get());
+
+  CUDACHECK_TEST(cudaMemcpy(
+      src_d, matrix_h.data(), kM * kN * sizeof(float), cudaMemcpyHostToDevice));
+  std::vector<float> sentinel_h(kM * kN, kSentinel);
+  CUDACHECK_TEST(cudaMemcpy(
+      dst_d,
+      sentinel_h.data(),
+      kM * kN * sizeof(float),
+      cudaMemcpyHostToDevice));
+
+  test_tile_load_store_2d_float(src_d, dst_d, kN, 0, 0, kValidRows, kN);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<float> dst_h(kM * kN);
+  CUDACHECK_TEST(cudaMemcpy(
+      dst_h.data(), dst_d, kM * kN * sizeof(float), cudaMemcpyDeviceToHost));
+
+  for (int r = 0; r < kValidRows; r++) {
+    for (int c = 0; c < kN; c++) {
+      EXPECT_EQ(dst_h[r * kN + c], matrix_h[r * kN + c])
+          << "mismatch at row=" << r << " col=" << c;
+    }
+  }
+  for (int r = kValidRows; r < kM; r++) {
+    for (int c = 0; c < kN; c++) {
+      EXPECT_EQ(dst_h[r * kN + c], kSentinel)
+          << "should be sentinel at row=" << r << " col=" << c;
+    }
+  }
+}
+
+TEST_F(TileTestFixture, LoadStore2DPartialColsUnaligned) {
+  constexpr int kM = k2DRows;
+  constexpr int kN = k2DCols;
+  constexpr int kValidCols = 201;
+
+  std::vector<float> matrix_h(kM * kN);
+  for (int i = 0; i < kM * kN; i++) {
+    matrix_h[i] = static_cast<float>(i + 1);
+  }
+
+  DeviceBuffer srcBuf(kM * kN * sizeof(float));
+  DeviceBuffer dstBuf(kM * kN * sizeof(float));
+  auto* src_d = static_cast<float*>(srcBuf.get());
+  auto* dst_d = static_cast<float*>(dstBuf.get());
+
+  CUDACHECK_TEST(cudaMemcpy(
+      src_d, matrix_h.data(), kM * kN * sizeof(float), cudaMemcpyHostToDevice));
+  const float kSentinel = -1.0f;
+  std::vector<float> sentinel_h(kM * kN, kSentinel);
+  CUDACHECK_TEST(cudaMemcpy(
+      dst_d,
+      sentinel_h.data(),
+      kM * kN * sizeof(float),
+      cudaMemcpyHostToDevice));
+
+  test_tile_load_store_2d_float(src_d, dst_d, kN, 0, 0, kM, kValidCols);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<float> dst_h(kM * kN);
+  CUDACHECK_TEST(cudaMemcpy(
+      dst_h.data(), dst_d, kM * kN * sizeof(float), cudaMemcpyDeviceToHost));
+
+  for (int r = 0; r < kM; r++) {
+    for (int c = 0; c < kValidCols; c++) {
+      EXPECT_EQ(dst_h[r * kN + c], matrix_h[r * kN + c])
+          << "mismatch at row=" << r << " col=" << c;
+    }
+    for (int c = kValidCols; c < kN; c++) {
+      EXPECT_EQ(dst_h[r * kN + c], kSentinel)
+          << "should be sentinel at row=" << r << " col=" << c;
+    }
+  }
+}
+
+TEST_F(TileTestFixture, LoadStore2DPartialBoth) {
+  constexpr int kM = k2DRows;
+  constexpr int kN = k2DCols;
+  constexpr int kValidRows = 5;
+  constexpr int kValidCols = 201;
+
+  std::vector<float> matrix_h(kM * kN);
+  for (int i = 0; i < kM * kN; i++) {
+    matrix_h[i] = static_cast<float>(i + 1);
+  }
+
+  DeviceBuffer srcBuf(kM * kN * sizeof(float));
+  DeviceBuffer dstBuf(kM * kN * sizeof(float));
+  auto* src_d = static_cast<float*>(srcBuf.get());
+  auto* dst_d = static_cast<float*>(dstBuf.get());
+
+  CUDACHECK_TEST(cudaMemcpy(
+      src_d, matrix_h.data(), kM * kN * sizeof(float), cudaMemcpyHostToDevice));
+  const float kSentinel = -1.0f;
+  std::vector<float> sentinel_h(kM * kN, kSentinel);
+  CUDACHECK_TEST(cudaMemcpy(
+      dst_d,
+      sentinel_h.data(),
+      kM * kN * sizeof(float),
+      cudaMemcpyHostToDevice));
+
+  test_tile_load_store_2d_float(src_d, dst_d, kN, 0, 0, kValidRows, kValidCols);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<float> dst_h(kM * kN);
+  CUDACHECK_TEST(cudaMemcpy(
+      dst_h.data(), dst_d, kM * kN * sizeof(float), cudaMemcpyDeviceToHost));
+
+  for (int r = 0; r < kM; r++) {
+    for (int c = 0; c < kN; c++) {
+      float expected =
+          (r < kValidRows && c < kValidCols) ? matrix_h[r * kN + c] : kSentinel;
+      EXPECT_EQ(dst_h[r * kN + c], expected) << "at row=" << r << " col=" << c;
+    }
+  }
+}
+
+} // namespace comms::pipes

--- a/comms/pipes/tests/TileTest.cu
+++ b/comms/pipes/tests/TileTest.cu
@@ -1,0 +1,423 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <cstddef>
+
+#include "comms/pipes/Tile.cuh"
+#include "comms/pipes/tests/Checks.h"
+#include "comms/pipes/tests/TileTest.cuh"
+
+namespace comms::pipes::test {
+
+using comms::pipes::make_block_group;
+using comms::pipes::MaxOp;
+using comms::pipes::MinOp;
+using comms::pipes::RegisterStorage;
+using comms::pipes::SumOp;
+using comms::pipes::Tile;
+using comms::pipes::tile_accumulate;
+using comms::pipes::tile_load;
+using comms::pipes::tile_load_2d;
+using comms::pipes::tile_load_accumulate;
+using comms::pipes::tile_store;
+using comms::pipes::tile_store_2d;
+using comms::pipes::tile_zero;
+
+constexpr int kBS = kTileTestBlockSize;
+constexpr int kTE = kTileTestTileElems;
+
+// ============================================================================
+// Load/Store roundtrip kernels
+// ============================================================================
+
+template <typename T>
+__global__ void
+tile_load_store_kernel(const T* input, T* output, std::size_t ntiles) {
+  auto group = make_block_group();
+  for (std::size_t t = 0; t < ntiles; t++) {
+    auto tile = tile_load<T, kTE, kBS>(input, t, group);
+    tile_store<T, kTE, kBS>(output, t, tile, group);
+  }
+}
+
+void test_tile_load_store_float(
+    const float* input,
+    float* output,
+    std::size_t ntiles) {
+  tile_load_store_kernel<float><<<1, kBS>>>(input, output, ntiles);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void test_tile_load_store_bf16(
+    const __nv_bfloat16* input,
+    __nv_bfloat16* output,
+    std::size_t ntiles) {
+  tile_load_store_kernel<__nv_bfloat16><<<1, kBS>>>(input, output, ntiles);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void test_tile_load_store_half(
+    const __half* input,
+    __half* output,
+    std::size_t ntiles) {
+  tile_load_store_kernel<__half><<<1, kBS>>>(input, output, ntiles);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+// ============================================================================
+// Zero kernel
+// ============================================================================
+
+__global__ void tile_zero_kernel(float* output, std::size_t ntiles) {
+  auto group = make_block_group();
+  for (std::size_t t = 0; t < ntiles; t++) {
+    Tile<float, kTE, kBS, RegisterStorage> tile;
+    tile_zero<float, kTE, kBS>(tile);
+    tile_store<float, kTE, kBS>(output, t, tile, group);
+  }
+}
+
+void test_tile_zero_float(float* output, std::size_t ntiles) {
+  tile_zero_kernel<<<1, kBS>>>(output, ntiles);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+// ============================================================================
+// Accumulate kernels
+// ============================================================================
+
+template <typename T, typename Op>
+__global__ void tile_accumulate_kernel(
+    const T* a_input,
+    const T* b_input,
+    T* output,
+    std::size_t ntiles) {
+  auto group = make_block_group();
+  for (std::size_t t = 0; t < ntiles; t++) {
+    auto a = tile_load<T, kTE, kBS>(a_input, t, group);
+    auto b = tile_load<T, kTE, kBS>(b_input, t, group);
+    tile_accumulate<T, Op, kTE, kBS>(a, b);
+    tile_store<T, kTE, kBS>(output, t, a, group);
+  }
+}
+
+void test_tile_accumulate_sum_float(
+    const float* a,
+    const float* b,
+    float* output,
+    std::size_t ntiles) {
+  tile_accumulate_kernel<float, SumOp><<<1, kBS>>>(a, b, output, ntiles);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void test_tile_accumulate_sum_bf16(
+    const __nv_bfloat16* a,
+    const __nv_bfloat16* b,
+    __nv_bfloat16* output,
+    std::size_t ntiles) {
+  tile_accumulate_kernel<__nv_bfloat16, SumOp>
+      <<<1, kBS>>>(a, b, output, ntiles);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void test_tile_accumulate_max_float(
+    const float* a,
+    const float* b,
+    float* output,
+    std::size_t ntiles) {
+  tile_accumulate_kernel<float, MaxOp><<<1, kBS>>>(a, b, output, ntiles);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void test_tile_accumulate_min_float(
+    const float* a,
+    const float* b,
+    float* output,
+    std::size_t ntiles) {
+  tile_accumulate_kernel<float, MinOp><<<1, kBS>>>(a, b, output, ntiles);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+// ============================================================================
+// Fused load+accumulate kernel
+// ============================================================================
+
+__global__ void tile_load_accumulate_sum_kernel(
+    const float* base,
+    const float* addend,
+    float* output,
+    std::size_t ntiles) {
+  auto group = make_block_group();
+  for (std::size_t t = 0; t < ntiles; t++) {
+    auto tile = tile_load<float, kTE, kBS>(base, t, group);
+    tile_load_accumulate<float, SumOp, kTE, kBS>(tile, addend, t, group);
+    tile_store<float, kTE, kBS>(output, t, tile, group);
+  }
+}
+
+void test_tile_load_accumulate_sum_float(
+    const float* base,
+    const float* addend,
+    float* output,
+    std::size_t ntiles) {
+  tile_load_accumulate_sum_kernel<<<1, kBS>>>(base, addend, output, ntiles);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+// ============================================================================
+// Partial tile kernel
+// ============================================================================
+
+__global__ void tile_partial_load_kernel(
+    const float* input,
+    float* output,
+    std::size_t valid_elems) {
+  auto group = make_block_group();
+  auto tile = tile_load<float, kTE, kBS>(input, 0, group, valid_elems);
+  tile_store<float, kTE, kBS>(output, 0, tile, group);
+}
+
+void test_tile_partial_load_float(
+    const float* input,
+    float* output,
+    std::size_t valid_elems) {
+  tile_partial_load_kernel<<<1, kBS>>>(input, output, valid_elems);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+// ============================================================================
+// Partial store kernel
+// ============================================================================
+
+__global__ void tile_partial_store_kernel(
+    const float* input,
+    float* output,
+    std::size_t valid_elems) {
+  auto group = make_block_group();
+  auto tile = tile_load<float, kTE, kBS>(input, 0, group);
+  tile_store<float, kTE, kBS>(output, 0, tile, group, valid_elems);
+}
+
+void test_tile_partial_store_float(
+    const float* input,
+    float* output,
+    std::size_t valid_elems) {
+  tile_partial_store_kernel<<<1, kBS>>>(input, output, valid_elems);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+// ============================================================================
+// Partial load-accumulate kernel
+// ============================================================================
+
+__global__ void tile_partial_load_accumulate_kernel(
+    const float* base,
+    const float* addend,
+    float* output,
+    std::size_t valid_elems) {
+  auto group = make_block_group();
+  auto tile = tile_load<float, kTE, kBS>(base, 0, group);
+  tile_load_accumulate<float, SumOp, kTE, kBS>(
+      tile, addend, 0, group, valid_elems);
+  tile_store<float, kTE, kBS>(output, 0, tile, group);
+}
+
+void test_tile_partial_load_accumulate_sum_float(
+    const float* base,
+    const float* addend,
+    float* output,
+    std::size_t valid_elems) {
+  tile_partial_load_accumulate_kernel<<<1, kBS>>>(
+      base, addend, output, valid_elems);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+// ============================================================================
+// Partial load-accumulate with MaxOp (regression test for zero-padding bug)
+// ============================================================================
+
+__global__ void tile_partial_load_accumulate_max_kernel(
+    const float* base,
+    const float* addend,
+    float* output,
+    std::size_t valid_elems) {
+  auto group = make_block_group();
+  auto tile = tile_load<float, kTE, kBS>(base, 0, group);
+  tile_load_accumulate<float, MaxOp, kTE, kBS>(
+      tile, addend, 0, group, valid_elems);
+  tile_store<float, kTE, kBS>(output, 0, tile, group);
+}
+
+void test_tile_partial_load_accumulate_max_float(
+    const float* base,
+    const float* addend,
+    float* output,
+    std::size_t valid_elems) {
+  tile_partial_load_accumulate_max_kernel<<<1, kBS>>>(
+      base, addend, output, valid_elems);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+// ============================================================================
+// Partial load-accumulate with MinOp (regression test for zero-padding bug)
+// ============================================================================
+
+__global__ void tile_partial_load_accumulate_min_kernel(
+    const float* base,
+    const float* addend,
+    float* output,
+    std::size_t valid_elems) {
+  auto group = make_block_group();
+  auto tile = tile_load<float, kTE, kBS>(base, 0, group);
+  tile_load_accumulate<float, MinOp, kTE, kBS>(
+      tile, addend, 0, group, valid_elems);
+  tile_store<float, kTE, kBS>(output, 0, tile, group);
+}
+
+void test_tile_partial_load_accumulate_min_float(
+    const float* base,
+    const float* addend,
+    float* output,
+    std::size_t valid_elems) {
+  tile_partial_load_accumulate_min_kernel<<<1, kBS>>>(
+      base, addend, output, valid_elems);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+// ============================================================================
+// Combined partial load + partial store kernel
+// ============================================================================
+
+__global__ void tile_partial_load_store_kernel(
+    const float* input,
+    float* output,
+    std::size_t valid_elems) {
+  auto group = make_block_group();
+  auto tile = tile_load<float, kTE, kBS>(input, 0, group, valid_elems);
+  tile_store<float, kTE, kBS>(output, 0, tile, group, valid_elems);
+}
+
+void test_tile_partial_load_store_float(
+    const float* input,
+    float* output,
+    std::size_t valid_elems) {
+  tile_partial_load_store_kernel<<<1, kBS>>>(input, output, valid_elems);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+// ============================================================================
+// Partial load at tile_idx=1
+// ============================================================================
+
+__global__ void tile_partial_load_idx1_kernel(
+    const float* input,
+    float* output,
+    std::size_t valid_elems) {
+  auto group = make_block_group();
+  auto tile = tile_load<float, kTE, kBS>(input, 1, group, valid_elems);
+  tile_store<float, kTE, kBS>(output, 0, tile, group);
+}
+
+void test_tile_partial_load_tile_idx1_float(
+    const float* input,
+    float* output,
+    std::size_t valid_elems) {
+  tile_partial_load_idx1_kernel<<<1, kBS>>>(input, output, valid_elems);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+// ============================================================================
+// Half-precision max / bf16 min accumulate kernels
+// ============================================================================
+
+__global__ void tile_accumulate_max_half_kernel(
+    const __half* a_input,
+    const __half* b_input,
+    __half* output,
+    std::size_t ntiles) {
+  auto group = make_block_group();
+  for (std::size_t t = 0; t < ntiles; t++) {
+    auto a = tile_load<__half, kTE, kBS>(a_input, t, group);
+    auto b = tile_load<__half, kTE, kBS>(b_input, t, group);
+    tile_accumulate<__half, MaxOp, kTE, kBS>(a, b);
+    tile_store<__half, kTE, kBS>(output, t, a, group);
+  }
+}
+
+void test_tile_accumulate_max_half(
+    const __half* a,
+    const __half* b,
+    __half* output,
+    std::size_t ntiles) {
+  tile_accumulate_max_half_kernel<<<1, kBS>>>(a, b, output, ntiles);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+__global__ void tile_accumulate_min_bf16_kernel(
+    const __nv_bfloat16* a_input,
+    const __nv_bfloat16* b_input,
+    __nv_bfloat16* output,
+    std::size_t ntiles) {
+  auto group = make_block_group();
+  for (std::size_t t = 0; t < ntiles; t++) {
+    auto a = tile_load<__nv_bfloat16, kTE, kBS>(a_input, t, group);
+    auto b = tile_load<__nv_bfloat16, kTE, kBS>(b_input, t, group);
+    tile_accumulate<__nv_bfloat16, MinOp, kTE, kBS>(a, b);
+    tile_store<__nv_bfloat16, kTE, kBS>(output, t, a, group);
+  }
+}
+
+void test_tile_accumulate_min_bf16(
+    const __nv_bfloat16* a,
+    const __nv_bfloat16* b,
+    __nv_bfloat16* output,
+    std::size_t ntiles) {
+  tile_accumulate_min_bf16_kernel<<<1, kBS>>>(a, b, output, ntiles);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+// ============================================================================
+// 2D tile load/store kernel
+// ============================================================================
+
+constexpr int k2DR = kTileTest2DRows;
+constexpr int k2DC = kTileTest2DCols;
+
+__global__ void tile_load_store_2d_kernel(
+    const float* input,
+    float* output,
+    std::size_t stride,
+    std::size_t row_offset,
+    std::size_t col_offset,
+    std::size_t valid_rows,
+    std::size_t valid_cols) {
+  auto group = make_block_group();
+  auto tile = tile_load_2d<float, k2DR, k2DC, kBS>(
+      input, row_offset, col_offset, stride, group, valid_rows, valid_cols);
+  tile_store_2d<float, k2DR, k2DC, kBS>(
+      output,
+      row_offset,
+      col_offset,
+      stride,
+      tile,
+      group,
+      valid_rows,
+      valid_cols);
+}
+
+void test_tile_load_store_2d_float(
+    const float* input,
+    float* output,
+    std::size_t stride,
+    std::size_t row_offset,
+    std::size_t col_offset,
+    std::size_t valid_rows,
+    std::size_t valid_cols) {
+  tile_load_store_2d_kernel<<<1, kBS>>>(
+      input, output, stride, row_offset, col_offset, valid_rows, valid_cols);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+} // namespace comms::pipes::test

--- a/comms/pipes/tests/TileTest.cuh
+++ b/comms/pipes/tests/TileTest.cuh
@@ -1,0 +1,125 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <cstddef>
+#include <cstdint>
+
+namespace comms::pipes::test {
+
+constexpr int kTileTestBlockSize = 256;
+constexpr int kTileTestTileElems = 2048;
+
+void test_tile_load_store_float(
+    const float* input,
+    float* output,
+    std::size_t ntiles);
+
+void test_tile_load_store_bf16(
+    const __nv_bfloat16* input,
+    __nv_bfloat16* output,
+    std::size_t ntiles);
+
+void test_tile_load_store_half(
+    const __half* input,
+    __half* output,
+    std::size_t ntiles);
+
+void test_tile_zero_float(float* output, std::size_t ntiles);
+
+void test_tile_accumulate_sum_float(
+    const float* a,
+    const float* b,
+    float* output,
+    std::size_t ntiles);
+
+void test_tile_accumulate_sum_bf16(
+    const __nv_bfloat16* a,
+    const __nv_bfloat16* b,
+    __nv_bfloat16* output,
+    std::size_t ntiles);
+
+void test_tile_accumulate_max_float(
+    const float* a,
+    const float* b,
+    float* output,
+    std::size_t ntiles);
+
+void test_tile_accumulate_min_float(
+    const float* a,
+    const float* b,
+    float* output,
+    std::size_t ntiles);
+
+void test_tile_load_accumulate_sum_float(
+    const float* base,
+    const float* addend,
+    float* output,
+    std::size_t ntiles);
+
+void test_tile_partial_load_float(
+    const float* input,
+    float* output,
+    std::size_t valid_elems);
+
+void test_tile_partial_store_float(
+    const float* input,
+    float* output,
+    std::size_t valid_elems);
+
+void test_tile_partial_load_accumulate_sum_float(
+    const float* base,
+    const float* addend,
+    float* output,
+    std::size_t valid_elems);
+
+void test_tile_partial_load_accumulate_max_float(
+    const float* base,
+    const float* addend,
+    float* output,
+    std::size_t valid_elems);
+
+void test_tile_partial_load_accumulate_min_float(
+    const float* base,
+    const float* addend,
+    float* output,
+    std::size_t valid_elems);
+
+void test_tile_partial_load_store_float(
+    const float* input,
+    float* output,
+    std::size_t valid_elems);
+
+void test_tile_partial_load_tile_idx1_float(
+    const float* input,
+    float* output,
+    std::size_t valid_elems);
+
+void test_tile_accumulate_max_half(
+    const __half* a,
+    const __half* b,
+    __half* output,
+    std::size_t ntiles);
+
+void test_tile_accumulate_min_bf16(
+    const __nv_bfloat16* a,
+    const __nv_bfloat16* b,
+    __nv_bfloat16* output,
+    std::size_t ntiles);
+
+constexpr int kTileTest2DRows = 8;
+constexpr int kTileTest2DCols = 256;
+
+void test_tile_load_store_2d_float(
+    const float* input,
+    float* output,
+    std::size_t stride,
+    std::size_t row_offset,
+    std::size_t col_offset,
+    std::size_t valid_rows,
+    std::size_t valid_cols);
+
+} // namespace comms::pipes::test


### PR DESCRIPTION
Summary:

Tile<T, kTileElems, kBlockSize> provides a fixed-size block of elements distributed across threads in a ThreadGroup, backed by uint4 registers.

Key APIs:
- tile_load/tile_store: cooperative vectorized load/store with element-level masking for partial tiles (valid_elems parameter, default = full tile). Partial vectors at boundaries are handled with scalar element loads/stores — valid_elems need not be vector-aligned.
- tile_load_2d/tile_store_2d: 2D strided load/store from row-major matrices with row/column masking. Returns a flat Tile compatible with all 1D ops.
- tile_load_accumulate: fused load + element-wise reduction (saves kVPT registers vs separate load + accumulate)
- tile_accumulate: element-wise reduction between two register tiles
- tile_zero: zero-initialize a tile

Type system:
- VecOps<T> class per data type with reduce(Op, accum, src) methods
- Supports float, __nv_bfloat16, __half
- Ops: SumOp, MaxOp, MinOp (tag-dispatched)
- HalfPrecisionVecOps<ScalarT, PackedT> shared template for bf16/half (DRY)
- New types = one VecOps<> specialization, new ops = one method per type

All loads/stores use uint4 (16-byte) vectorization for optimal coalescing. Default kBlockSize=256 with kVPT=8 matches memcpy_vectorized peak bandwidth.

Triton equivalence documented for all APIs (tile_load ↔ tl.load, tile_store ↔ tl.store, tile_load_2d ↔ tl.load with 2D pointer tensor, etc.).

Benchmarks (H100 SXM5 96GB, D2D, block groups, kVPT=8):
Tile API matches memcpy_vectorized to <1% across all configs:
  2MB 4b:  Tile 193.6 GB/s vs memcpy_vec 193.4 GB/s (1.001x)
  4MB 8b:  Tile 387.2 GB/s vs memcpy_vec 386.3 GB/s (1.002x)
  8MB 16b: Tile 773.9 GB/s vs memcpy_vec 772.5 GB/s (1.002x)
Zero abstraction overhead confirmed.

Reviewed By: rmahidhar

Differential Revision: D102662791


