### PR TITLE
Add static supported function (#2323)

### DIFF
--- a/comms/uniflow/MultiTransport.cpp
+++ b/comms/uniflow/MultiTransport.cpp
@@ -27,6 +27,21 @@ std::vector<std::string> MultiTransportFactory::selectNics() {
                           : topo.selectGpuNics(deviceId_, nicFilter_);
 }
 
+Status MultiTransportFactory::supported(TransportType type) {
+  switch (type) {
+    case TransportType::NVLink:
+      return NVLinkTransportFactory::supported();
+    case TransportType::RDMA:
+      return RdmaTransportFactory::supported();
+    case TransportType::TCP:
+      return Err(ErrCode::NotImplemented, "tcp transport is not implemented");
+    case TransportType::Mock:
+      return Ok();
+    default:
+      return Err(ErrCode::InvalidArgument, "unknown transport type");
+  }
+}
+
 Status MultiTransport::validateRequests(
     const std::vector<TransferRequest>& requests) {
   if (requests.empty()) {

--- a/comms/uniflow/MultiTransport.h
+++ b/comms/uniflow/MultiTransport.h
@@ -106,6 +106,8 @@ class MultiTransportFactory {
 
   std::vector<uint8_t> getTopology();
 
+  static Status supported(TransportType type);
+
   friend class MultiTransportFactoryTest;
 
  private:

--- a/comms/uniflow/UniflowPy.cpp
+++ b/comms/uniflow/UniflowPy.cpp
@@ -511,7 +511,14 @@ PYBIND11_MODULE(_core, m) {
             auto v = f.getTopology();
             return py::bytes(reinterpret_cast<const char*>(v.data()), v.size());
           },
-          "Get the local topology as serialized bytes.");
+          "Get the local topology as serialized bytes.")
+      .def_static(
+          "supported",
+          [](TransportType type) {
+            return toResult(MultiTransportFactory::supported(type));
+          },
+          "Check if a transport type is supported on this host.",
+          py::arg("transport_type"));
 
   // ---------------------------------------------------------------------------
   // Connection

--- a/comms/uniflow/transport/nvlink/NVLinkTransport.cpp
+++ b/comms/uniflow/transport/nvlink/NVLinkTransport.cpp
@@ -272,6 +272,21 @@ void NVLinkTransport::shutdown() {
 // NVLinkTransportFactory
 // ---------------------------------------------------------------------------
 
+Status NVLinkTransportFactory::supported(std::shared_ptr<CudaApi> cudaApi) {
+  if (!cudaApi) {
+    cudaApi = std::make_shared<CudaApi>();
+  }
+
+  auto countResult = cudaApi->getDeviceCount();
+  CHECK_RETURN(countResult);
+
+  if (countResult.value() == 0) {
+    return Err(ErrCode::ResourceExhausted, "No CUDA devices found");
+  }
+
+  return Ok();
+}
+
 NVLinkTransportFactory::NVLinkTransportFactory(
     int device,
     EventBase* evb,

--- a/comms/uniflow/transport/nvlink/NVLinkTransport.h
+++ b/comms/uniflow/transport/nvlink/NVLinkTransport.h
@@ -97,6 +97,18 @@ class NVLinkTransport : public Transport {
 
 class NVLinkTransportFactory : public TransportFactory {
  public:
+  /*
+   * Query whether NVLink transport is available on this platform.
+   *
+   * Probes for CUDA devices by querying the CUDA runtime device count.
+   * Returns Ok() if at least one CUDA device exists, or an error
+   * describing why NVLink is not available.
+   *
+   * @param cudaApi  Optional CudaApi instance for dependency injection
+   *                 (testing). If nullptr, a default instance is created.
+   */
+  static Status supported(std::shared_ptr<CudaApi> cudaApi = nullptr);
+
   /// Construct a factory for the given CUDA device.
   /// Queries NVML for GPU fabric info to populate local NVLink topology.
   /// Falls back to POSIX FD-based IPC for single-node sharing when

--- a/comms/uniflow/transport/nvlink/tests/unit/NVLinkTransportTest.cpp
+++ b/comms/uniflow/transport/nvlink/tests/unit/NVLinkTransportTest.cpp
@@ -371,6 +371,39 @@ std::shared_ptr<::testing::NiceMock<MockCudaApi>>
 std::shared_ptr<::testing::NiceMock<MockCudaDriverApi>>
     NVLinkTransportFactoryTest::cudaDriverMock_;
 
+// --- supported() tests ---
+
+TEST(NVLinkTransportFactorySupportedTest, ReturnsTrueWithCudaDevices) {
+  auto cudaMock = std::make_shared<::testing::NiceMock<MockCudaApi>>();
+  EXPECT_CALL(*cudaMock, getDeviceCount())
+      .WillOnce(::testing::Return(Result<int>(8)));
+
+  auto status = NVLinkTransportFactory::supported(cudaMock);
+  EXPECT_FALSE(status.hasError());
+}
+
+TEST(NVLinkTransportFactorySupportedTest, ReturnsFalseWhenNoDevices) {
+  auto cudaMock = std::make_shared<::testing::NiceMock<MockCudaApi>>();
+  EXPECT_CALL(*cudaMock, getDeviceCount())
+      .WillOnce(::testing::Return(Result<int>(0)));
+
+  auto status = NVLinkTransportFactory::supported(cudaMock);
+  EXPECT_TRUE(status.hasError());
+  EXPECT_EQ(status.error().code(), ErrCode::ResourceExhausted);
+}
+
+TEST(NVLinkTransportFactorySupportedTest, ReturnsFalseWhenCudaFails) {
+  auto cudaMock = std::make_shared<::testing::NiceMock<MockCudaApi>>();
+  EXPECT_CALL(*cudaMock, getDeviceCount())
+      .WillOnce(
+          ::testing::Return(
+              Result<int>(Err(ErrCode::DriverError, "no CUDA driver"))));
+
+  auto status = NVLinkTransportFactory::supported(cudaMock);
+  EXPECT_TRUE(status.hasError());
+  EXPECT_EQ(status.error().code(), ErrCode::DriverError);
+}
+
 // --- bounds checking ---
 
 TEST_F(NVLinkTransportFactoryTest, ConstructorRejectsNegativeDevice) {

--- a/comms/uniflow/transport/rdma/RdmaTransport.cpp
+++ b/comms/uniflow/transport/rdma/RdmaTransport.cpp
@@ -955,6 +955,60 @@ void RdmaTransport::shutdown() {
 // RdmaTransportFactory
 // ---------------------------------------------------------------------------
 
+Status RdmaTransportFactory::supported(std::shared_ptr<IbvApi> ibvApi) {
+  if (!ibvApi) {
+    ibvApi = std::make_shared<IbvApi>();
+  }
+
+  CHECK_EXPR(ibvApi->init());
+
+  int numDevices = 0;
+  auto devListResult = ibvApi->getDeviceList(&numDevices);
+  CHECK_RETURN(devListResult);
+  ibv_device** deviceList = devListResult.value();
+  struct DevListGuard {
+    std::shared_ptr<IbvApi> api;
+    ibv_device** list;
+    ~DevListGuard() {
+      api->freeDeviceList(list);
+    }
+  } devListGuard{ibvApi, deviceList};
+
+  if (numDevices == 0) {
+    UNIFLOW_LOG_INFO("RDMA not supported: no IB devices found");
+    return Err(ErrCode::ResourceExhausted, "No RDMA devices found");
+  }
+
+  for (int i = 0; i < numDevices; ++i) {
+    bool found = false;
+    auto ctxResult = ibvApi->openDevice(deviceList[i]);
+    CHECK_RETURN(ctxResult);
+    ibv_context* ctx = ctxResult.value();
+
+    ibv_device_attr devAttr{};
+    if (ibvApi->queryDevice(ctx, &devAttr)) {
+      for (uint8_t port = 1; port <= devAttr.phys_port_cnt; ++port) {
+        ibv_port_attr portAttr{};
+        auto portStatus = ibvApi->queryPort(ctx, port, &portAttr);
+        if (!portStatus.hasError() && portAttr.state == IBV_PORT_ACTIVE) {
+          found = true;
+          break;
+        }
+      }
+    }
+
+    ibvApi->closeDevice(ctx);
+    if (!found) {
+      return Err(
+          ErrCode::ResourceExhausted,
+          fmt::format(
+              "No active RDMA ports found for {}", deviceList[i]->name));
+    }
+  }
+
+  return Ok();
+}
+
 uint8_t RdmaTransportFactory::findActivePort(ibv_context* ctx) {
   ibv_device_attr devAttr{};
   auto status = ibvApi_->queryDevice(ctx, &devAttr);

--- a/comms/uniflow/transport/rdma/RdmaTransport.h
+++ b/comms/uniflow/transport/rdma/RdmaTransport.h
@@ -432,6 +432,18 @@ class RdmaTransport : public Transport {
 class RdmaTransportFactory : public TransportFactory {
  public:
   /*
+   * Query whether RDMA transport is available on this platform.
+   *
+   * Probes for RDMA hardware by loading libibverbs and verifying that
+   * every IB device has at least one active port. Returns Ok() on
+   * success, or an error describing why RDMA is not available.
+   *
+   * @param ibvApi  Optional IbvApi instance for dependency injection
+   *                (testing). If nullptr, a default instance is created.
+   */
+  static Status supported(std::shared_ptr<IbvApi> ibvApi = nullptr);
+
+  /*
    * Open RDMA devices and initialize per-NIC resources.
    *
    * @param deviceNames  List of IB device names (e.g., {"mlx5_0", "mlx5_1"}).

--- a/comms/uniflow/transport/rdma/tests/unit/RdmaTransportTest.cpp
+++ b/comms/uniflow/transport/rdma/tests/unit/RdmaTransportTest.cpp
@@ -490,6 +490,103 @@ TEST_F(RdmaTransportFactoryTest, CreateTransportRejectsOversizedTopology) {
   EXPECT_EQ(result.error().code(), ErrCode::InvalidArgument);
 }
 
+// --- supported() tests ---
+
+TEST_F(RdmaTransportFactoryTest, SupportedReturnsTrueWithActiveDevice) {
+  EXPECT_CALL(*mockApi_, getDeviceList(_)).WillOnce([this](int* numDevices) {
+    *numDevices = 1;
+    return Result<ibv_device**>(fakeDeviceList_);
+  });
+  EXPECT_CALL(*mockApi_, openDevice(&fakeDevice0_))
+      .WillOnce(Return(Result<ibv_context*>(&fakeCtx0_)));
+  EXPECT_CALL(*mockApi_, queryDevice(&fakeCtx0_, _))
+      .WillOnce([](ibv_context*, ibv_device_attr* attr) {
+        attr->phys_port_cnt = 1;
+        return Ok();
+      });
+  EXPECT_CALL(*mockApi_, queryPort(&fakeCtx0_, 1, _))
+      .WillOnce([](ibv_context*, uint8_t, ibv_port_attr* attr) {
+        attr->state = IBV_PORT_ACTIVE;
+        return Ok();
+      });
+  EXPECT_CALL(*mockApi_, closeDevice(&fakeCtx0_)).WillOnce(Return(Ok()));
+  EXPECT_CALL(*mockApi_, freeDeviceList(_)).WillOnce(Return(Ok()));
+
+  EXPECT_TRUE(RdmaTransportFactory::supported(mockApi_));
+}
+
+TEST_F(RdmaTransportFactoryTest, SupportedReturnsFalseWhenInitFails) {
+  EXPECT_CALL(*mockApi_, init())
+      .WillOnce(Return(Err(ErrCode::DriverError, "no libibverbs")));
+
+  EXPECT_FALSE(RdmaTransportFactory::supported(mockApi_));
+}
+
+TEST_F(RdmaTransportFactoryTest, SupportedReturnsFalseWhenNoDevices) {
+  EXPECT_CALL(*mockApi_, getDeviceList(_)).WillOnce([](int* numDevices) {
+    *numDevices = 0;
+    return Result<ibv_device**>(nullptr);
+  });
+
+  EXPECT_FALSE(RdmaTransportFactory::supported(mockApi_));
+}
+
+TEST_F(RdmaTransportFactoryTest, SupportedReturnsFalseWhenNoActivePort) {
+  EXPECT_CALL(*mockApi_, getDeviceList(_)).WillOnce([this](int* numDevices) {
+    *numDevices = 1;
+    return Result<ibv_device**>(fakeDeviceList_);
+  });
+  EXPECT_CALL(*mockApi_, openDevice(&fakeDevice0_))
+      .WillOnce(Return(Result<ibv_context*>(&fakeCtx0_)));
+  EXPECT_CALL(*mockApi_, queryDevice(&fakeCtx0_, _))
+      .WillOnce([](ibv_context*, ibv_device_attr* attr) {
+        attr->phys_port_cnt = 1;
+        return Ok();
+      });
+  EXPECT_CALL(*mockApi_, queryPort(&fakeCtx0_, 1, _))
+      .WillOnce([](ibv_context*, uint8_t, ibv_port_attr* attr) {
+        attr->state = IBV_PORT_DOWN;
+        return Ok();
+      });
+  EXPECT_CALL(*mockApi_, closeDevice(&fakeCtx0_)).WillOnce(Return(Ok()));
+  EXPECT_CALL(*mockApi_, freeDeviceList(_)).WillOnce(Return(Ok()));
+
+  auto status = RdmaTransportFactory::supported(mockApi_);
+  EXPECT_TRUE(status.hasError());
+  EXPECT_EQ(status.error().code(), ErrCode::ResourceExhausted);
+}
+
+TEST_F(RdmaTransportFactoryTest, SupportedReturnsFalseWhenOpenDeviceFails) {
+  EXPECT_CALL(*mockApi_, getDeviceList(_)).WillOnce([this](int* numDevices) {
+    *numDevices = 1;
+    return Result<ibv_device**>(fakeDeviceList_);
+  });
+  EXPECT_CALL(*mockApi_, openDevice(&fakeDevice0_))
+      .WillOnce(Return(Result<ibv_context*>(ErrCode::DriverError)));
+  EXPECT_CALL(*mockApi_, freeDeviceList(_)).WillOnce(Return(Ok()));
+
+  auto status = RdmaTransportFactory::supported(mockApi_);
+  EXPECT_TRUE(status.hasError());
+  EXPECT_EQ(status.error().code(), ErrCode::DriverError);
+}
+
+TEST_F(RdmaTransportFactoryTest, SupportedClosesDeviceWhenQueryDeviceFails) {
+  EXPECT_CALL(*mockApi_, getDeviceList(_)).WillOnce([this](int* numDevices) {
+    *numDevices = 1;
+    return Result<ibv_device**>(fakeDeviceList_);
+  });
+  EXPECT_CALL(*mockApi_, openDevice(&fakeDevice0_))
+      .WillOnce(Return(Result<ibv_context*>(&fakeCtx0_)));
+  EXPECT_CALL(*mockApi_, queryDevice(&fakeCtx0_, _))
+      .WillOnce(Return(Err(ErrCode::DriverError, "query failed")));
+  EXPECT_CALL(*mockApi_, closeDevice(&fakeCtx0_)).WillOnce(Return(Ok()));
+  EXPECT_CALL(*mockApi_, freeDeviceList(_)).WillOnce(Return(Ok()));
+
+  auto status = RdmaTransportFactory::supported(mockApi_);
+  EXPECT_TRUE(status.hasError());
+  EXPECT_EQ(status.error().code(), ErrCode::ResourceExhausted);
+}
+
 TEST_F(RdmaTransportFactoryTest, ConstructorByNameThrowsOnUnknownDevice) {
   EXPECT_CALL(*mockApi_, getDeviceList(_)).WillOnce([this](int* numDevices) {
     *numDevices = 1;


### PR DESCRIPTION
Summary:

Added MultiTransportFactory.supported(transport_type) as a static method. Usage from Python:
```python
  from uniflow import MultiTransportFactory, TransportType

  result = MultiTransportFactory.supported(TransportType.RDMA)
  if result.has_value():
      print("RDMA is supported")
  else:
      print(f"RDMA not supported: {result.error()}")
```

Reviewed By: amirafzali

Differential Revision: D103106965


