### PR TITLE
add PrecisionClock — fbclock-backed wall clock for tracing (#2325)

### DIFF
--- a/comms/utils/colltrace/PrecisionClock.cc
+++ b/comms/utils/colltrace/PrecisionClock.cc
@@ -1,0 +1,127 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/utils/colltrace/PrecisionClock.h"
+
+#include <cstdlib>
+#include <string_view>
+
+#include <folly/logging/xlog.h>
+
+// fbclock is a Meta-internal header. The MCCL/torchcomms OSS build copies
+// only fbcode/comms (and ynl) into its build tree, so fbclock.h is absent
+// there; gate every reference on __has_include so the OSS build compiles
+// and links cleanly against the system_clock fallback path below.
+#if __has_include("time/fbclock/fbclock.h")
+#include "time/fbclock/fbclock.h"
+#define COMMS_HAS_FBCLOCK 1
+#else
+#define COMMS_HAS_FBCLOCK 0
+#endif
+
+namespace meta::comms::colltrace {
+
+namespace {
+
+bool isPtpEnabled() {
+  const char* env = std::getenv("NCCL_USE_PTP");
+  if (env == nullptr) {
+    return true;
+  }
+  std::string_view v{env};
+  return !(
+      v == "0" || v == "false" || v == "False" || v == "FALSE" || v == "no" ||
+      v == "No" || v == "NO" || v == "n" || v == "N");
+}
+
+// Process-global handle to fbclock. Initialized exactly once on first
+// access; intentionally leaked so the destructor never races with late
+// callers during shutdown (mirrors common/time/PTP.cpp's PTPWrapper).
+class PrecisionClockImpl {
+ public:
+  PrecisionClockImpl() : usingPtp_(false) {
+    if (!isPtpEnabled()) {
+      XLOG(INFO) << "PrecisionClock: NCCL_USE_PTP disabled, using system_clock";
+      return;
+    }
+#if COMMS_HAS_FBCLOCK
+    int err = fbclock_init(&lib_, FBCLOCK_PATH);
+    if (err != FBCLOCK_E_NO_ERROR) {
+      XLOG(WARN) << "PrecisionClock: fbclock_init failed (path=" << FBCLOCK_PATH
+                 << ", err=" << err << "), falling back to system_clock";
+      return;
+    }
+    usingPtp_ = true;
+#else
+    XLOG(INFO) << "PrecisionClock: built without fbclock, using system_clock";
+#endif
+  }
+
+  bool usingPtp() const noexcept {
+    return usingPtp_;
+  }
+
+#if COMMS_HAS_FBCLOCK
+  // Reads fbclock without holding a mutex. fbclock_gettime mutates
+  // lib_.min_phc_delay (a monotonically-decreasing int64) on every call;
+  // this is a benign race accepted by common/time/PTP.cpp as well.
+  // The shared-memory read uses fbclock's own seqlock/CRC protocol.
+  bool getTruetime(fbclock_truetime* out) noexcept {
+    if (!usingPtp_) {
+      return false;
+    }
+    return fbclock_gettime(&lib_, out) == FBCLOCK_E_NO_ERROR;
+  }
+#endif
+
+  static PrecisionClockImpl& instance() {
+    static auto* p = new PrecisionClockImpl();
+    return *p;
+  }
+
+ private:
+#if COMMS_HAS_FBCLOCK
+  fbclock_lib lib_{};
+#endif
+  bool usingPtp_;
+};
+
+std::pair<uint64_t, uint64_t> systemClockRangeNs() {
+  auto u = static_cast<uint64_t>(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(
+          std::chrono::system_clock::now().time_since_epoch())
+          .count());
+  return {u, u};
+}
+
+} // namespace
+
+bool precisionUsingPtp() noexcept {
+  return PrecisionClockImpl::instance().usingPtp();
+}
+
+std::pair<uint64_t, uint64_t> precisionNowRangeNs() noexcept {
+#if COMMS_HAS_FBCLOCK
+  fbclock_truetime tt{};
+  if (PrecisionClockImpl::instance().getTruetime(&tt)) {
+    return {tt.earliest_ns, tt.latest_ns};
+  }
+#endif
+  return systemClockRangeNs();
+}
+
+uint64_t precisionNowNs() noexcept {
+  auto [earliest, latest] = precisionNowRangeNs();
+  return earliest + (latest - earliest) / 2;
+}
+
+uint64_t precisionErrorNs() noexcept {
+  auto [earliest, latest] = precisionNowRangeNs();
+  return latest - earliest;
+}
+
+std::chrono::system_clock::time_point precisionNow() noexcept {
+  return std::chrono::system_clock::time_point{
+      std::chrono::nanoseconds{precisionNowNs()}};
+}
+
+} // namespace meta::comms::colltrace

--- a/comms/utils/colltrace/PrecisionClock.h
+++ b/comms/utils/colltrace/PrecisionClock.h
@@ -1,0 +1,42 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <utility>
+
+namespace meta::comms::colltrace {
+
+// Wall-clock source for colltrace timestamps. Backed by fbclock when the
+// PTP daemon is reachable (giving PTP-aligned, fleet-comparable time with
+// a known window of uncertainty); falls back to std::chrono::system_clock
+// when fbclock_init fails or NCCL_USE_PTP=0.
+//
+// All entry points are thread-safe and noexcept. Initialization happens
+// lazily on first use and is performed exactly once.
+//
+// API mirrors the historical ncclFbGet*Time* surface (D58118422) so
+// ncclx engineers see a familiar shape.
+
+// Returns the midpoint of the fbclock truetime window as a system_clock
+// time_point, or std::chrono::system_clock::now() when in fallback.
+std::chrono::system_clock::time_point precisionNow() noexcept;
+
+// Returns {earliest_ns, latest_ns} since the UNIX epoch. The two values
+// bracket true time when PTP is active; they are equal in fallback mode.
+std::pair<uint64_t, uint64_t> precisionNowRangeNs() noexcept;
+
+// Single-point nanoseconds since the UNIX epoch. Midpoint of the fbclock
+// window when PTP is active; system_clock::now() converted to ns otherwise.
+uint64_t precisionNowNs() noexcept;
+
+// Window-of-uncertainty in nanoseconds (latest_ns - earliest_ns).
+// Returns 0 in fallback mode.
+uint64_t precisionErrorNs() noexcept;
+
+// True when fbclock_init succeeded and NCCL_USE_PTP is not disabled.
+// Determined once at first call and cached for the process lifetime.
+bool precisionUsingPtp() noexcept;
+
+} // namespace meta::comms::colltrace

--- a/comms/utils/colltrace/tests/PrecisionClockUT.cc
+++ b/comms/utils/colltrace/tests/PrecisionClockUT.cc
@@ -1,0 +1,64 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// Exercises the PrecisionClock fallback path (NCCL_USE_PTP=0). The
+// fbclock daemon is not assumed to be present in this test environment;
+// PTP-mode behavior is left to integration tests on PTP-enabled hosts.
+//
+// PrecisionClock initializes its singleton on first use and caches the
+// kill-switch decision for the process lifetime, so tests in this file
+// must run in a binary that never calls precision* APIs before SetUp.
+
+#include <chrono>
+#include <cstdlib>
+
+#include <gtest/gtest.h>
+
+#include "comms/utils/colltrace/PrecisionClock.h"
+
+using meta::comms::colltrace::precisionErrorNs;
+using meta::comms::colltrace::precisionNow;
+using meta::comms::colltrace::precisionNowNs;
+using meta::comms::colltrace::precisionNowRangeNs;
+using meta::comms::colltrace::precisionUsingPtp;
+
+class PrecisionClockFallbackTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    // Force fallback before any precision* call lazily initializes the
+    // singleton. setenv with overwrite=1 so a stale env from the runner
+    // can't accidentally enable PTP.
+    setenv("NCCL_USE_PTP", "0", 1);
+  }
+};
+
+TEST_F(PrecisionClockFallbackTest, ReportsFallbackMode) {
+  EXPECT_FALSE(precisionUsingPtp());
+}
+
+TEST_F(PrecisionClockFallbackTest, RangeCollapsesInFallback) {
+  auto [earliest, latest] = precisionNowRangeNs();
+  EXPECT_EQ(earliest, latest);
+}
+
+TEST_F(PrecisionClockFallbackTest, ErrorIsZeroInFallback) {
+  EXPECT_EQ(precisionErrorNs(), 0u);
+}
+
+TEST_F(PrecisionClockFallbackTest, NowTracksSystemClock) {
+  auto before = std::chrono::system_clock::now();
+  auto p = precisionNow();
+  auto after = std::chrono::system_clock::now();
+  EXPECT_GE(p, before - std::chrono::seconds(1));
+  EXPECT_LE(p, after + std::chrono::seconds(1));
+}
+
+TEST_F(PrecisionClockFallbackTest, NsIsMonotonicEnough) {
+  // system_clock is not strictly monotonic but consecutive calls on the
+  // same thread without an NTP step should be non-decreasing in practice.
+  uint64_t prev = precisionNowNs();
+  for (int i = 0; i < 100; ++i) {
+    uint64_t cur = precisionNowNs();
+    EXPECT_GE(cur, prev);
+    prev = cur;
+  }
+}


### PR DESCRIPTION
Summary:

Introduces a process-wide wall clock for colltrace that is backed by
fbclock when the PTP daemon is reachable, and falls back to
std::chrono::system_clock when it is not (or when NCCL_USE_PTP=0).

Why this matters: every collective timestamp colltrace records today
comes from std::chrono::system_clock::now(). Across a fleet, those
clocks disagree by milliseconds — large compared to GPU collective
durations. A PTP-aligned source makes cross-rank and cross-host
correlation meaningful, which is a precondition for the watchdog,
NCCL Analyzer, and dashboards to attribute slow/stuck
collectives to a specific rank.

API surface (mirrors the historical D58118422 ncclFbGetTime* surface):

  precisionNow()         — system_clock::time_point (midpoint)
  precisionNowRangeNs()  — {earliest_ns, latest_ns} of fbclock window
  precisionNowNs()       — single uint64 ns since epoch (midpoint)
  precisionErrorNs()     — window-of-uncertainty in ns (0 in fallback)
  precisionUsingPtp()    — bool, cached for process lifetime

Init is lazy and exactly-once. The fbclock_lib handle is intentionally
leaked (mirrors common/time/PTP.cpp's PTPWrapper) so destruction never
races with late callers during shutdown. The gettime path holds no
mutex; fbclock_gettime mutates lib_.min_phc_delay (a monotonically
decreasing int64) on every call — same benign race accepted by the
existing PTPWrapper consumer.

This commit adds the library only. Subsequent commits will swap the ~12 system_clock::now() call sites in colltrace one at a time, starting with GpuClockCalibration.cc:52 (the single anchor that maps GPU %globaltimer ns to wall time for the entire graph-capture path).

OSS build compatibility: the fbclock include and every fbclock symbol use (fbclock_init, fbclock_gettime, fbclock_lib, fbclock_truetime, FBCLOCK_PATH, FBCLOCK_E_NO_ERROR) are gated on __has_include("time/fbclock/fbclock.h"). The MCCL/torchcomms OSS build (comms/github/fb/mccl/build_mccl.sh) only copies fbcode/comms and fbcode/ynl into its build tree, so the header is absent there; the gate makes the OSS build compile and link cleanly against the system_clock fallback path without needing a CMake change or a vendored fbclock copy. Internal Buck builds keep the //time/fbclock:fbclock_c dep and exercise the PTP path as before.

Reviewed By: YulunW

Differential Revision: D102056023


