### PR TITLE
Add DISABLED race-detection test for GpeKernelSync isComplete

### DIFF
--- a/comms/ctran/algos/common/tests/GpeKernelSyncTest.cc
+++ b/comms/ctran/algos/common/tests/GpeKernelSyncTest.cc
@@ -2,6 +2,10 @@
 
 #include <cuda_runtime.h>
 
+#include <atomic>
+#include <thread>
+#include <vector>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "comms/ctran/algos/common/GpeKernelSync.h"
@@ -142,3 +146,155 @@ INSTANTIATE_TEST_SUITE_P(
       return std::to_string(std::get<0>(info.param)) + "numWorkers_" +
           resetTypeStr;
     });
+
+// =============================================================================
+// AcquireRace test — exercises the GpeKernelSync host poll → consumer-data-read
+// pattern that the production bug at S651852 hits on aarch64 (GB200).
+//
+// Producer threads simulate kernel blocks: each writes its own portion of a
+// shared payload, then release-stores its `completeFlag[b]` slot to signal
+// completion of step `iter`. The release-fence + volatile-store pattern
+// mirrors the GPU's `st.release.sys` in `GpeKernelSyncDev::complete()`.
+//
+// The consumer thread is the host: it calls `sync->isComplete(iter)` (the
+// production code path) and immediately reads the payload to verify
+// consistency.
+//
+// Iteration handshake uses a separate `std::atomic<int> goSignal` (a proper
+// C++11 release/acquire pair) so this test does NOT race on
+// `sync->postFlag[]`. The only intentionally race-relevant interaction is the
+// producer's release-store of `completeFlag` paired with the consumer's poll
+// inside `sync->isComplete()`.
+//
+// On aarch64 without `wcAcquireFence()` after the polling load, the consumer
+// can observe `completeFlag` as set while a load-load reorder lets the
+// payload read return stale values, producing per-(iter, block) mismatches.
+//
+// On x86 (TSO) the race cannot trigger naturally — load->load ordering is
+// architecturally guaranteed. ThreadSanitizer is also not a useful validator
+// here: TSan models the C++11 memory model, where the production
+// `volatile + thread_fence` pattern is not a recognised release/acquire pair,
+// so TSan reports the bare volatile read as a race regardless of whether
+// `wcAcquireFence()` is present. The fix is hardware-correct but cannot be
+// validated by TSan without refactoring `GpeKernelSync` to use `std::atomic`.
+//
+// This test is `DISABLED_` so it does not run in CI by default. To reproduce
+// the bug it must be run on aarch64 hardware (rtptest GB200):
+//
+//   buck2 run @fbcode//mode/opt -c hpc_comms.use_ncclx=stable \
+//     -c nvcc.arch=b200 -c fbcode.arch=aarch64 \
+//     fbcode//comms/ctran/algos/common/tests:ctran_algo_gpe_kernel_sync_test \
+//     -- --gtest_also_run_disabled_tests \
+//        --gtest_filter='*DISABLED_AcquireRaceManualOnAarch64*'
+//
+// Expected behaviour:
+//   - Without the `wcAcquireFence()` in `GpeKernelSync::isComplete()`:
+//       on aarch64 the mismatch counter is non-zero (race triggers).
+//   - With the fence: mismatches stays 0 across all iterations.
+//   - On x86: always passes regardless of the fence (TSO masks the race).
+TEST_F(CtranGpeKernelSyncTest, DISABLED_AcquireRaceManualOnAarch64) {
+  constexpr int kNumWorkers = 8;
+  constexpr int kPayloadPerWorker = 64;
+  constexpr int kPayloadSize = kNumWorkers * kPayloadPerWorker;
+  constexpr int kIters = 50000;
+
+  // Match production allocation: pinned host memory for the sync.
+  void* syncPtr = nullptr;
+  ASSERT_EQ(
+      cudaHostAlloc(&syncPtr, sizeof(GpeKernelSync), cudaHostAllocDefault),
+      cudaSuccess);
+  GpeKernelSync* sync = new (syncPtr) GpeKernelSync(kNumWorkers);
+
+  // Per-(iter, block) magic value, recomputed in both producer and consumer.
+  auto magicFor = [](int iter, int b) {
+    return (iter * 13) ^ ((b + 1) * 0x9e3779b1);
+  };
+
+  std::vector<int> payload(kPayloadSize, -1);
+  std::atomic<int> mismatches{0};
+  // Iteration barrier: consumer sets goSignal[b] = iter, producer waits
+  // for goSignal[b] >= iter. Uses std::atomic so TSan recognises the
+  // release/acquire pair and does NOT flag this part of the test.
+  std::vector<std::atomic<int>> goSignal(kNumWorkers);
+  for (auto& g : goSignal) {
+    g.store(-1, std::memory_order_relaxed);
+  }
+
+  // Producer threads: simulate kernel blocks. Wait for the consumer to
+  // release goSignal[b] for `iter`, then write the per-block payload and
+  // release-store completeFlag[b].
+  std::vector<std::thread> producers;
+  producers.reserve(kNumWorkers);
+  for (int b = 0; b < kNumWorkers; ++b) {
+    producers.emplace_back([&, b]() {
+      for (int iter = 0; iter < kIters; ++iter) {
+        // Acquire the consumer's "go" signal — TSan-clean handshake.
+        while (goSignal[b].load(std::memory_order_acquire) < iter) {
+          // friendly spin
+        }
+
+        // Write our portion of the payload.
+        const int magic = magicFor(iter, b);
+        const int start = b * kPayloadPerWorker;
+        const int end = start + kPayloadPerWorker;
+        for (int i = start; i < end; ++i) {
+          payload[i] = magic;
+        }
+
+        // Mirror the GPU's `st.release.sys` on completeFlag — release fence
+        // then volatile store. This is intentionally the SAME pattern used
+        // in production (GpeKernelSync::post via wcStoreFence + volatile),
+        // so TSan correctly identifies the missing acquire on the consumer
+        // side as a data race.
+        std::atomic_thread_fence(std::memory_order_release);
+        volatile int* completeFlag = &sync->completeFlag[b];
+        *completeFlag = iter;
+      }
+    });
+  }
+
+  // Consumer (host): release goSignal then call the production
+  // `sync->isComplete(iter)`. After it returns true, read the payload back
+  // and verify it matches the expected per-block magic.
+  std::thread consumer([&]() {
+    for (int iter = 0; iter < kIters; ++iter) {
+      // Release goSignal[b] for `iter` so all producers can proceed.
+      for (int b = 0; b < kNumWorkers; ++b) {
+        goSignal[b].store(iter, std::memory_order_release);
+      }
+
+      while (!sync->isComplete(iter)) {
+        // friendly spin
+      }
+
+      // Verify every block's payload portion. On aarch64 (or under TSan),
+      // without the `wcAcquireFence()` in `isComplete()`, this read can
+      // see stale data.
+      for (int b = 0; b < kNumWorkers; ++b) {
+        const int magic = magicFor(iter, b);
+        const int start = b * kPayloadPerWorker;
+        const int end = start + kPayloadPerWorker;
+        for (int i = start; i < end; ++i) {
+          if (payload[i] != magic) {
+            mismatches.fetch_add(1, std::memory_order_relaxed);
+            break; // one count per (iter, block)
+          }
+        }
+      }
+    }
+  });
+
+  consumer.join();
+  for (auto& t : producers) {
+    t.join();
+  }
+
+  EXPECT_EQ(mismatches.load(), 0)
+      << "Acquire race detected: payload was inconsistent at "
+      << mismatches.load() << " (iter, block) sites across " << kIters
+      << " iterations × " << kNumWorkers << " blocks. "
+      << "If running on aarch64 without wcAcquireFence() in "
+      << "GpeKernelSync::isComplete(), this is the expected pre-fix failure.";
+
+  ASSERT_EQ(cudaFreeHost(syncPtr), cudaSuccess);
+}


### PR DESCRIPTION
Summary:
Adds a `DISABLED_AcquireRaceManualOnAarch64` GoogleTest case in `GpeKernelSyncTest.cc` that exercises the host poll → consumer-data-read pattern from the production bug at S651852. Producer threads simulate kernel blocks: each writes a per-(iter, block) magic value into a shared payload and release-stores its `completeFlag[b]` slot — the same release-fence + volatile-store shape used by the GPU's `st.release.sys` in `GpeKernelSyncDev::complete()`. The consumer thread is the host, calling `sync->isComplete(iter)` (the production code path) and reading the payload back to verify consistency.

Iteration handshake uses a separate `std::atomic<int>` so this test does not race on `sync->postFlag[]`. The only intentionally race-relevant interaction is the producer's release-store of `completeFlag` paired with the consumer's poll inside `sync->isComplete()`.

The test is `DISABLED_` and intended to be run manually on aarch64 hardware (rtptest GB200) where load->load reordering is permitted by the architecture. On x86 the race cannot trigger naturally — TSO is too strong — and ThreadSanitizer is not a useful validator here either, because TSan models the C++11 memory model where `volatile + thread_fence` is not a recognised release/acquire pair (it would flag the read as a race regardless of any acquire fence we add).

This diff intentionally lands the test in its currently-failing-on-aarch64 state. The companion fence diff D103040491 introduces `wcAcquireFence()` and uses it in `GpeKernelSync::isComplete()` / `waitComplete()`, which closes the race; a follow-up diff on top of D103040491 will remove the `DISABLED_` prefix once the fence is in place.

Differential Revision: D103255142


