### PR TITLE
SlabPool in RdmaTransport + bind/connect (#2330)

### DIFF
--- a/comms/uniflow/transport/rdma/RdmaTransport.cpp
+++ b/comms/uniflow/transport/rdma/RdmaTransport.cpp
@@ -4,10 +4,12 @@
 #include "comms/uniflow/drivers/cuda/CudaDriverApi.h"
 #include "comms/uniflow/logging/Logger.h"
 #include "comms/uniflow/transport/rdma/RdmaRegistrationHandle.h"
+#include "comms/uniflow/transport/rdma/RdmaSlabPool.h"
 
 #include <unistd.h>
 #include <algorithm>
 #include <cassert>
+#include <cstdlib>
 #include <random>
 #include <stdexcept>
 
@@ -18,6 +20,8 @@ namespace uniflow {
 // ---------------------------------------------------------------------------
 
 namespace {
+
+constexpr uint32_t kSlabIdxInvalid{0xFFFFFFFF};
 
 struct __attribute__((packed)) RdmaTopologyInfo {
   uint8_t version{kRdmaVersion};
@@ -47,10 +51,47 @@ uint64_t qpMapKey(size_t nicIdx, uint32_t qpNum) {
 
 } // namespace
 
+size_t RdmaTransportInfo::RegisteredBuffer::serialize(uint8_t* data) const {
+  size_t offset = 0;
+  std::memcpy(data + offset, &addr, sizeof(addr));
+  offset += sizeof(addr);
+  std::memcpy(data + offset, &length, sizeof(length));
+  offset += sizeof(length);
+  if (!rkeys.empty()) {
+    size_t len = rkeys.size() * sizeof(uint32_t);
+    std::memcpy(data + offset, rkeys.data(), len);
+    offset += len;
+  }
+  return offset;
+}
+
+size_t RdmaTransportInfo::RegisteredBuffer::deserialize(
+    const uint8_t* data,
+    uint8_t numNics) {
+  size_t offset = 0;
+  std::memcpy(&addr, data + offset, sizeof(addr));
+  offset += sizeof(addr);
+  std::memcpy(&length, data + offset, sizeof(length));
+  offset += sizeof(length);
+  if (numNics > 0) {
+    size_t len = numNics * sizeof(uint32_t);
+    rkeys.resize(numNics);
+    std::memcpy(rkeys.data(), data + offset, len);
+    offset += len;
+  }
+  return offset;
+}
+
+void RdmaTransportInfo::RegisteredBuffer::reset() {
+  addr = 0;
+  length = 0;
+  rkeys.clear();
+}
+
 TransportInfo RdmaTransportInfo::serialize() const {
   constexpr size_t headerSize = sizeof(RdmaTransportInfo::Header);
   const size_t totalSize = headerSize + nicInfos.size() * sizeof(NicInfo) +
-      qpInfos.size() * sizeof(QpInfo);
+      qpInfos.size() * sizeof(QpInfo) + ctrl.size() + slab.size();
   TransportInfo data(totalSize);
 
   size_t offset = 0;
@@ -58,18 +99,19 @@ TransportInfo RdmaTransportInfo::serialize() const {
   offset += headerSize;
 
   if (!nicInfos.empty()) {
-    std::memcpy(
-        data.data() + offset,
-        nicInfos.data(),
-        nicInfos.size() * sizeof(NicInfo));
-    offset += nicInfos.size() * sizeof(NicInfo);
+    size_t len = nicInfos.size() * sizeof(NicInfo);
+    std::memcpy(data.data() + offset, nicInfos.data(), len);
+    offset += len;
   }
 
   if (!qpInfos.empty()) {
-    std::memcpy(
-        data.data() + offset, qpInfos.data(), qpInfos.size() * sizeof(QpInfo));
+    size_t len = qpInfos.size() * sizeof(QpInfo);
+    std::memcpy(data.data() + offset, qpInfos.data(), len);
+    offset += len;
   }
 
+  offset += ctrl.serialize(data.data() + offset);
+  offset += slab.serialize(data.data() + offset);
   return data;
 }
 
@@ -91,9 +133,15 @@ Result<RdmaTransportInfo> RdmaTransportInfo::deserialize(
   }
 
   const size_t expectedSize = headerSize + header.numNics * sizeof(NicInfo) +
-      header.numQps * sizeof(QpInfo);
+      header.numQps * sizeof(QpInfo) +
+      RegisteredBuffer::expectedSize(header.numNics) * 2;
   if (data.size() < expectedSize) {
-    return Err(ErrCode::InvalidArgument, "TransportInfo too small for payload");
+    return Err(
+        ErrCode::InvalidArgument,
+        fmt::format(
+            "TransportInfo too small for payload, expected {} bytes, got {} bytes",
+            expectedSize,
+            data.size()));
   }
 
   size_t offset = headerSize;
@@ -113,6 +161,12 @@ Result<RdmaTransportInfo> RdmaTransportInfo::deserialize(
         info.qpInfos.data(),
         data.data() + offset,
         header.numQps * sizeof(QpInfo));
+    offset += header.numQps * sizeof(QpInfo);
+  }
+
+  if (header.numNics > 0) {
+    offset += info.ctrl.deserialize(data.data() + offset, header.numNics);
+    offset += info.slab.deserialize(data.data() + offset, header.numNics);
   }
 
   return info;
@@ -122,6 +176,8 @@ void RdmaTransportInfo::reset() {
   header = {};
   nicInfos.clear();
   qpInfos.clear();
+  ctrl.reset();
+  slab.reset();
 }
 
 // ---------------------------------------------------------------------------
@@ -130,15 +186,19 @@ void RdmaTransportInfo::reset() {
 
 RdmaTransport::RdmaTransport(
     std::shared_ptr<IbvApi> ibvApi,
+    std::shared_ptr<CudaApi> cudaApi,
     EventBase* evb,
     std::shared_ptr<std::vector<NicResources>> nics,
     uint64_t domainId,
-    RdmaTransportConfig config)
+    RdmaTransportConfig config,
+    std::shared_ptr<RdmaSlabPool> slabPool)
     : ibvApi_(std::move(ibvApi)),
+      cudaApi_(std::move(cudaApi)),
       evb_(evb),
       nicsHandle_(std::move(nics)),
       config_(config),
-      domainId_(domainId) {
+      domainId_(domainId),
+      slabPool_(std::move(slabPool)) {
   CHECK_THROW_EXCEPTION(
       nicsHandle_ && !nicsHandle_->empty(), std::invalid_argument);
   CHECK_THROW_EXCEPTION(
@@ -169,9 +229,31 @@ TransportInfo RdmaTransport::bind() {
   const uint32_t numNics = nics_.size();
   numPendingCqe_.resize(nics_.size());
 
+  // Allocate and register ctrl buffer for send/recv pipeline flow control.
+  // Layout: [CTS: D entries][Notify: D * Q entries], all atomic<uint32_t>.
+  // CTS and Notify are separate regions so bidirectional send/recv is safe.
+  const size_t ctrlSize = ctrlBufferSize();
+  info_.ctrl.length = static_cast<uint32_t>(ctrlSize);
+  auto ctrlAllocResult = cudaApi_->hostAlloc(
+      ctrlSize, cudaHostAllocMapped | cudaHostAllocPortable);
+  if (!ctrlAllocResult) {
+    UNIFLOW_LOG_ERROR("bind: failed to allocate ctrl buffer");
+    state_ = TransportState::Error;
+    return {};
+  }
+  ctrlBuffer_ = ctrlAllocResult.value();
+  info_.ctrl.addr = reinterpret_cast<uint64_t>(ctrlBuffer_);
+  // Initialize all entries to kSlabIdxInvalid.
+  auto* ctrlEntries = static_cast<uint32_t*>(ctrlBuffer_);
+  const size_t numEntries = ctrlSize / sizeof(uint32_t);
+  for (size_t i = 0; i < numEntries; ++i) {
+    std::atomic_ref<uint32_t>(ctrlEntries[i])
+        .store(kSlabIdxInvalid, std::memory_order_relaxed);
+  }
+
   cqs_.reserve(numNics);
   uint32_t qpsPerNic = (numQps + numNics - 1) / numNics;
-  for (uint32_t n = 0; n < numNics; ++n) {
+  for (uint8_t n = 0; n < numNics; ++n) {
     auto cqResult = ibvApi_->createCq(
         nics_[n].ctx, config_.maxWr * qpsPerNic, nullptr, nullptr, 0);
     if (cqResult.hasError()) {
@@ -191,9 +273,9 @@ TransportInfo RdmaTransport::bind() {
   psns_.reserve(numQps);
   numWrsPerQp_.resize(numQps, 0);
 
-  info_.header.version = 1;
+  info_.header.version = kRdmaVersion;
   info_.header.numQps = numQps;
-  info_.header.numNics = static_cast<uint8_t>(numNics);
+  info_.header.numNics = numNics;
   info_.header.domainId = domainId_;
   info_.qpInfos.reserve(numQps);
   info_.nicInfos.reserve(numNics);
@@ -259,6 +341,36 @@ TransportInfo RdmaTransport::bind() {
          .mtu = static_cast<uint8_t>(nic.mtu),
          .gid = nic.gid});
     UNIFLOW_LOG_INFO("Bind NIC {} successfully", getNicName(nic));
+  }
+
+  constexpr int kCtrlAccess =
+      IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ;
+  for (const auto& nic : nics_) {
+    auto mrResult = ibvApi_->regMr(nic.pd, ctrlBuffer_, ctrlSize, kCtrlAccess);
+    if (!mrResult) {
+      UNIFLOW_LOG_ERROR(
+          "RdmaTransport::bind: ctrl buffer ibv_reg_mr failed: {}",
+          mrResult.error().toString());
+      shutdown();
+      state_ = TransportState::Error;
+      return {};
+    }
+    auto* mr = mrResult.value();
+    ctrlMrs_.push_back(mr);
+    info_.ctrl.rkeys.push_back(mr->rkey);
+  }
+
+  if (slabPool_) {
+    info_.slab.addr = slabPool_->slabAddr(0);
+    info_.slab.length = static_cast<uint32_t>(slabPool_->slabSize());
+    info_.slab.rkeys.resize(numNics);
+    for (uint8_t n = 0; n < numNics; ++n) {
+      info_.slab.rkeys[n] = slabPool_->slabRkey(n);
+    }
+  } else {
+    info_.slab.addr = 0;
+    info_.slab.length = 0;
+    info_.slab.rkeys.resize(numNics, 0);
   }
 
   state_ = TransportState::Initialized;
@@ -355,6 +467,9 @@ Status RdmaTransport::connect(std::span<const uint8_t> remoteInfo) {
       return Err(ErrCode::ConnectionFailed, "Failed to transition QP to RTS");
     }
   }
+
+  remoteCtrlBuffer_ = std::move(remote.ctrl);
+  remoteSlabBuffer_ = std::move(remote.slab);
 
   state_ = TransportState::Connected;
   UNIFLOW_LOG_INFO(
@@ -894,6 +1009,47 @@ std::future<Result<size_t>> RdmaTransport::recv(
   return promise.get_future();
 }
 
+// ---------------------------------------------------------------------------
+// Ctrl buffer helpers
+// ---------------------------------------------------------------------------
+
+size_t RdmaTransport::ctrlBufferSize() const {
+  constexpr size_t align = alignof(uint64_t);
+  const uint32_t D = config_.pipelineDepth;
+  const uint32_t Q = config_.numQps;
+  const size_t raw = D * (1 + Q) * sizeof(uint32_t);
+  return (raw + align - 1) & ~(align - 1);
+}
+
+std::atomic_ref<uint32_t> RdmaTransport::ctrlCts(uint16_t slotIdx) {
+  auto* p = static_cast<uint32_t*>(ctrlBuffer_) + slotIdx;
+  return std::atomic_ref<uint32_t>(*p);
+}
+
+std::atomic_ref<uint32_t> RdmaTransport::ctrlNotify(
+    uint16_t slotIdx,
+    uint32_t qpIdx) {
+  const uint32_t D = config_.pipelineDepth;
+  const uint32_t Q = config_.numQps;
+  auto* p = static_cast<uint32_t*>(ctrlBuffer_) + D + slotIdx * Q + qpIdx;
+  return std::atomic_ref<uint32_t>(*p);
+}
+
+uint64_t RdmaTransport::remoteCtrlCtsAddr(uint16_t slotIdx) const {
+  return remoteCtrlBuffer_.addr + slotIdx * sizeof(uint32_t);
+}
+
+uint64_t RdmaTransport::remoteCtrlNotifyAddr(uint16_t slotIdx, uint32_t qpIdx)
+    const {
+  const uint32_t D = config_.pipelineDepth;
+  const uint32_t Q = config_.numQps;
+  return remoteCtrlBuffer_.addr + (D + slotIdx * Q + qpIdx) * sizeof(uint32_t);
+}
+
+// ---------------------------------------------------------------------------
+// Shutdown
+// ---------------------------------------------------------------------------
+
 void RdmaTransport::shutdown() {
   if (shutdown_.exchange(true)) {
     return;
@@ -902,6 +1058,7 @@ void RdmaTransport::shutdown() {
   // Make sure that there is no tasks in the evb loop thread related to this
   // transport instance
   if (!evb_->isLoopRunning()) {
+    state_ = TransportState::Disconnected;
     UNIFLOW_LOG_WARN("shutdown: event loop already stopped, skipping drain");
   } else {
     UNIFLOW_LOG_INFO("shutdown: draining inflight tasks");
@@ -915,6 +1072,7 @@ void RdmaTransport::shutdown() {
       auto drain = [this, &m, &cv, &done](auto& self) -> void {
         if (pendingTransfers_.empty() && pendingCompletions_.empty() &&
             inflightTasks_.empty()) {
+          state_ = TransportState::Disconnected;
           {
             std::lock_guard<std::mutex> lock(m);
             done = true;
@@ -951,7 +1109,16 @@ void RdmaTransport::shutdown() {
   }
   cqs_.clear();
 
-  state_ = TransportState::Disconnected;
+  for (auto* mr : ctrlMrs_) {
+    ibvApi_->deregMr(mr);
+  }
+  ctrlMrs_.clear();
+
+  if (ctrlBuffer_) {
+    cudaApi_->hostFree(ctrlBuffer_);
+    ctrlBuffer_ = nullptr;
+  }
+
   UNIFLOW_LOG_INFO("shutdown: complete");
 }
 
@@ -1019,10 +1186,12 @@ RdmaTransportFactory::RdmaTransportFactory(
     RdmaTransportConfig config,
     std::shared_ptr<IbvApi> ibvApi,
     std::shared_ptr<CudaDriverApi> cudaDriverApi,
+    std::shared_ptr<CudaApi> cudaApi,
     std::optional<uint8_t> portNum)
     : TransportFactory(TransportType::RDMA),
       ibvApi_(std::move(ibvApi)),
       cudaDriverApi_(std::move(cudaDriverApi)),
+      cudaApi_(std::move(cudaApi)),
       evb_(evb),
       nicsHandle_(std::make_shared<std::vector<NicResources>>()),
       config_(config) {
@@ -1035,6 +1204,9 @@ RdmaTransportFactory::RdmaTransportFactory(
   }
   if (!cudaDriverApi_) {
     cudaDriverApi_ = std::make_shared<CudaDriverApi>();
+  }
+  if (!cudaApi_) {
+    cudaApi_ = std::make_shared<CudaApi>();
   }
 
   // Generate a random domain id to identify handles from this factory.
@@ -1202,7 +1374,7 @@ Result<std::unique_ptr<Transport>> RdmaTransportFactory::createTransport(
   auto config = config_;
   config.numQps = std::min(peerTopo.numQps, config.numQps);
   return std::make_unique<RdmaTransport>(
-      ibvApi_, evb_, nicsHandle_, domainId_, config);
+      ibvApi_, cudaApi_, evb_, nicsHandle_, domainId_, config, nullptr);
 }
 
 // TODO: get ai_zone_name from fbwhoami / serfwhoami or develop a plugin for

--- a/comms/uniflow/transport/rdma/RdmaTransport.h
+++ b/comms/uniflow/transport/rdma/RdmaTransport.h
@@ -2,12 +2,14 @@
 
 #pragma once
 
+#include <atomic>
 #include <cstring>
 #include <deque>
 #include <memory>
 #include <optional>
 #include <unordered_map>
 
+#include "comms/uniflow/drivers/cuda/CudaApi.h"
 #include "comms/uniflow/drivers/cuda/CudaDriverApi.h"
 #include "comms/uniflow/drivers/ibverbs/IbvApi.h"
 #include "comms/uniflow/executor/EventBase.h"
@@ -21,6 +23,7 @@ constexpr uint8_t kRdmaVersion{1};
 // Forward declarations.
 class RdmaRegistrationHandle;
 class RdmaRemoteRegistrationHandle;
+class RdmaSlabPool;
 
 /*
  * RDMA transport configuration.
@@ -43,6 +46,7 @@ struct RdmaTransportConfig {
   uint32_t maxSge{1}; /* Max scatter/gather entries per WR. */
   uint32_t maxInlineData{16}; /* Max inline data bytes per WR. */
   size_t chunkSize{512 * 1024}; /* Transfer chunk size in bytes (512KB). */
+  uint16_t pipelineDepth{2}; /* Send/recv pipeline depth (D staging slabs). */
 };
 
 /*
@@ -77,12 +81,33 @@ struct RdmaTransportInfo {
     uint32_t psn{0}; /* Starting packet sequence number (random). */
   };
 
+  struct RegisteredBuffer {
+    uint64_t addr{0};
+    uint32_t length{0};
+    std::vector<uint32_t> rkeys;
+
+    size_t size() const {
+      return sizeof(addr) + sizeof(length) + rkeys.size() * sizeof(uint32_t);
+    }
+
+    static constexpr size_t expectedSize(uint8_t numNics) {
+      return sizeof(addr) + sizeof(length) + numNics * sizeof(uint32_t);
+    }
+
+    void reset();
+    size_t serialize(uint8_t* data) const;
+    size_t deserialize(const uint8_t* data, uint8_t numNics);
+  };
+
   /* Header fields. */
   Header header;
 
   /* Deserialized per-NIC and per-QP data. */
   std::vector<NicInfo> nicInfos;
   std::vector<QpInfo> qpInfos;
+
+  RegisteredBuffer ctrl;
+  RegisteredBuffer slab;
 
   /*
    * Serialize this info into a TransportInfo byte vector.
@@ -133,10 +158,12 @@ class RdmaTransport : public Transport {
    */
   RdmaTransport(
       std::shared_ptr<IbvApi> ibvApi,
+      std::shared_ptr<CudaApi> cudaApi,
       EventBase* evb,
       std::shared_ptr<std::vector<NicResources>> nics,
       uint64_t domainId,
-      RdmaTransportConfig config = {});
+      RdmaTransportConfig config = {},
+      std::shared_ptr<RdmaSlabPool> slabPool = nullptr);
 
   ~RdmaTransport() override;
 
@@ -371,7 +398,15 @@ class RdmaTransport : public Transport {
   /// Polls all CQs and routes completions to their tasks via inflightTasks_.
   void pollCompletions();
 
+  /// Ctrl buffer helpers.
+  std::atomic_ref<uint32_t> ctrlCts(uint16_t slotIdx);
+  std::atomic_ref<uint32_t> ctrlNotify(uint16_t slotIdx, uint32_t qpIdx);
+  uint64_t remoteCtrlCtsAddr(uint16_t slotIdx) const;
+  uint64_t remoteCtrlNotifyAddr(uint16_t slotIdx, uint32_t qpIdx) const;
+  size_t ctrlBufferSize() const;
+
   const std::shared_ptr<IbvApi> ibvApi_;
+  const std::shared_ptr<CudaApi> cudaApi_;
   EventBase* evb_{nullptr};
 
   std::string name_;
@@ -422,6 +457,18 @@ class RdmaTransport : public Transport {
 
   /// guard for shutdown()
   std::atomic<bool> shutdown_{false};
+
+  // --- Send/recv state and pool ---
+
+  std::shared_ptr<RdmaSlabPool> slabPool_;
+
+  // Ctrl buffer for send/recv pipeline flow control.
+  void* ctrlBuffer_{nullptr};
+  std::vector<ibv_mr*> ctrlMrs_;
+
+  // Remote peer's channel info (populated by connect)
+  RdmaTransportInfo::RegisteredBuffer remoteCtrlBuffer_;
+  RdmaTransportInfo::RegisteredBuffer remoteSlabBuffer_;
 };
 
 // ---------------------------------------------------------------------------
@@ -474,6 +521,7 @@ class RdmaTransportFactory : public TransportFactory {
       RdmaTransportConfig config = {},
       std::shared_ptr<IbvApi> ibvApi = nullptr,
       std::shared_ptr<CudaDriverApi> cudaDriverApi = nullptr,
+      std::shared_ptr<CudaApi> cudaApi = nullptr,
       std::optional<uint8_t> portNum = std::nullopt);
 
   ~RdmaTransportFactory() override = default;
@@ -507,6 +555,7 @@ class RdmaTransportFactory : public TransportFactory {
 
   std::shared_ptr<IbvApi> ibvApi_;
   std::shared_ptr<CudaDriverApi> cudaDriverApi_;
+  std::shared_ptr<CudaApi> cudaApi_;
   EventBase* evb_{nullptr};
   uint64_t domainId_{0};
   size_t pageSize_{0};

--- a/comms/uniflow/transport/rdma/tests/unit/RdmaSlabPoolTest.cpp
+++ b/comms/uniflow/transport/rdma/tests/unit/RdmaSlabPoolTest.cpp
@@ -348,6 +348,7 @@ TEST_F(RdmaSlabPoolTest, Atomic_AcquireAll64Slabs) {
   EXPECT_TRUE(pool->acquire().hasError());
 
   std::vector<uint16_t> indices;
+  indices.reserve(slabs.size());
   for (const auto& s : slabs) {
     indices.push_back(s.index());
   }
@@ -375,6 +376,7 @@ TEST_F(RdmaSlabPoolTest, Atomic_AcquireAll128Slabs_CrossesBitmapBoundary) {
   EXPECT_TRUE(pool->acquire().hasError());
 
   std::vector<uint16_t> indices;
+  indices.reserve(slabs.size());
   for (const auto& s : slabs) {
     indices.push_back(s.index());
   }

--- a/comms/uniflow/transport/rdma/tests/unit/RdmaTransportTest.cpp
+++ b/comms/uniflow/transport/rdma/tests/unit/RdmaTransportTest.cpp
@@ -3,6 +3,7 @@
 #include "comms/uniflow/transport/rdma/RdmaTransport.h"
 #include "comms/uniflow/transport/rdma/RdmaRegistrationHandle.h"
 
+#include "comms/uniflow/drivers/cuda/mock/MockCudaApi.h"
 #include "comms/uniflow/drivers/ibverbs/mock/MockIbvApi.h"
 #include "comms/uniflow/executor/ScopedEventBaseThread.h"
 
@@ -53,7 +54,7 @@ class SegmentTest {
 
 TEST(RdmaTransportInfoTest, SerializeDeserializeRoundTrip) {
   RdmaTransportInfo info;
-  info.header.version = 1;
+  info.header.version = kRdmaVersion;
   info.header.numQps = 4;
   info.header.numNics = 2;
   info.nicInfos = {
@@ -76,13 +77,15 @@ TEST(RdmaTransportInfoTest, SerializeDeserializeRoundTrip) {
       {.qpNum = 500, .psn = 600},
       {.qpNum = 700, .psn = 800},
   };
+  info.ctrl = {.addr = 0x1000, .length = 64, .rkeys = {0xAA, 0xBB}};
+  info.slab = {.addr = 0x2000, .length = 4096, .rkeys = {0xCC, 0xDD}};
 
   auto data = info.serialize();
   auto result = RdmaTransportInfo::deserialize(data);
   ASSERT_TRUE(result.hasValue());
 
   auto& out = result.value();
-  EXPECT_EQ(out.header.version, 1);
+  EXPECT_EQ(out.header.version, kRdmaVersion);
   EXPECT_EQ(out.header.numQps, 4);
   EXPECT_EQ(out.header.numNics, 2);
 
@@ -96,6 +99,17 @@ TEST(RdmaTransportInfoTest, SerializeDeserializeRoundTrip) {
   ASSERT_EQ(out.qpInfos.size(), 4);
   EXPECT_EQ(out.qpInfos[0].qpNum, 100);
   EXPECT_EQ(out.qpInfos[3].qpNum, 700);
+
+  EXPECT_EQ(out.ctrl.addr, 0x1000);
+  EXPECT_EQ(out.ctrl.length, 64);
+  ASSERT_EQ(out.ctrl.rkeys.size(), 2);
+  EXPECT_EQ(out.ctrl.rkeys[0], 0xAA);
+  EXPECT_EQ(out.ctrl.rkeys[1], 0xBB);
+  EXPECT_EQ(out.slab.addr, 0x2000);
+  EXPECT_EQ(out.slab.length, 4096);
+  ASSERT_EQ(out.slab.rkeys.size(), 2);
+  EXPECT_EQ(out.slab.rkeys[0], 0xCC);
+  EXPECT_EQ(out.slab.rkeys[1], 0xDD);
 }
 
 TEST(RdmaTransportInfoTest, DeserializeTooSmallForHeader) {
@@ -147,6 +161,8 @@ TEST(RdmaTransportInfoTest, SerializeZeroQps) {
   info.header.numQps = 0;
   info.header.numNics = 1;
   info.nicInfos = {{.lid = 1}};
+  info.ctrl.rkeys = {0};
+  info.slab.rkeys = {0};
 
   auto data = info.serialize();
   auto result = RdmaTransportInfo::deserialize(data);
@@ -201,9 +217,22 @@ class RdmaTransportTest : public ::testing::Test {
  protected:
   void SetUp() override {
     mockApi_ = std::make_shared<testing::NiceMock<MockIbvApi>>();
+    mockCudaApi_ = std::make_shared<testing::NiceMock<MockCudaApi>>();
+    ON_CALL(*mockApi_, regMr(_, _, _, _))
+        .WillByDefault(Return(Result<ibv_mr*>(&fakeSlabMr_)));
+    ON_CALL(*mockApi_, deregMr(_)).WillByDefault(Return(Ok()));
+    ON_CALL(*mockCudaApi_, hostAlloc(_, _))
+        .WillByDefault([](size_t size, unsigned int) {
+          return Result<void*>(std::calloc(1, size));
+        });
+    ON_CALL(*mockCudaApi_, hostFree(_)).WillByDefault([](void* ptr) {
+      std::free(ptr);
+      return Ok();
+    });
   }
 
   std::shared_ptr<testing::NiceMock<MockIbvApi>> mockApi_;
+  std::shared_ptr<testing::NiceMock<MockCudaApi>> mockCudaApi_;
   ScopedEventBaseThread evbThread_;
 
   ibv_device fakeDev0_{};
@@ -218,6 +247,7 @@ class RdmaTransportTest : public ::testing::Test {
   ibv_qp fakeQp1_{};
   ibv_qp fakeQp2_{};
   ibv_qp fakeQp3_{};
+  ibv_mr fakeSlabMr_{};
 };
 
 TEST_F(RdmaTransportTest, ConstructorRejectsZeroQps) {
@@ -226,7 +256,8 @@ TEST_F(RdmaTransportTest, ConstructorRejectsZeroQps) {
   nics->push_back(makeNic(&fakeDev0_, &fakeCtx0_, &fakePd0_, mockApi_, 0, gid));
   RdmaTransportConfig config{.numQps = 0};
   EXPECT_THROW(
-      RdmaTransport(mockApi_, evbThread_.getEventBase(), nics, 0, config),
+      RdmaTransport(
+          mockApi_, mockCudaApi_, evbThread_.getEventBase(), nics, 0, config),
       std::invalid_argument);
 }
 
@@ -247,7 +278,8 @@ TEST_F(RdmaTransportTest, BindClampsNicsToQpCount) {
   nics->push_back(
       makeNic(&fakeDev0_, &fakeCtx0_, &fakePd0_, mockApi_, 0x2222, gid1));
   RdmaTransportConfig config{.numQps = 1};
-  RdmaTransport transport(mockApi_, evbThread_.getEventBase(), nics, 0, config);
+  RdmaTransport transport(
+      mockApi_, mockCudaApi_, evbThread_.getEventBase(), nics, 0, config);
 
   auto data = transport.bind();
   ASSERT_FALSE(data.empty());
@@ -276,7 +308,8 @@ TEST_F(RdmaTransportTest, SingleNicBindCreatesQPs) {
   nics->push_back(
       makeNic(&fakeDev0_, &fakeCtx0_, &fakePd0_, mockApi_, 0x1234, gid));
   RdmaTransportConfig config{.numQps = 2};
-  RdmaTransport transport(mockApi_, evbThread_.getEventBase(), nics, 0, config);
+  RdmaTransport transport(
+      mockApi_, mockCudaApi_, evbThread_.getEventBase(), nics, 0, config);
 
   auto data = transport.bind();
   ASSERT_FALSE(data.empty());
@@ -315,7 +348,8 @@ TEST_F(RdmaTransportTest, MultiNicBindDistributesQPsRoundRobin) {
   nics->push_back(
       makeNic(&fakeDev1_, &fakeCtx1_, &fakePd1_, mockApi_, 0x2222, gid1));
   RdmaTransportConfig config{.numQps = 4};
-  RdmaTransport transport(mockApi_, evbThread_.getEventBase(), nics, 0, config);
+  RdmaTransport transport(
+      mockApi_, mockCudaApi_, evbThread_.getEventBase(), nics, 0, config);
 
   auto data = transport.bind();
   ASSERT_FALSE(data.empty());
@@ -342,7 +376,8 @@ TEST_F(RdmaTransportTest, BindReturnsEmptyOnCqFailure) {
   ibv_gid gid{};
   auto nics = std::make_shared<std::vector<NicResources>>();
   nics->push_back(makeNic(&fakeDev0_, &fakeCtx0_, &fakePd0_, mockApi_, 0, gid));
-  RdmaTransport transport(mockApi_, evbThread_.getEventBase(), nics, 0);
+  RdmaTransport transport(
+      mockApi_, mockCudaApi_, evbThread_.getEventBase(), nics, 0);
 
   auto data = transport.bind();
   EXPECT_TRUE(data.empty());
@@ -358,7 +393,8 @@ TEST_F(RdmaTransportTest, BindReturnsEmptyOnQpFailure) {
   ibv_gid gid{};
   auto nics = std::make_shared<std::vector<NicResources>>();
   nics->push_back(makeNic(&fakeDev0_, &fakeCtx0_, &fakePd0_, mockApi_, 0, gid));
-  RdmaTransport transport(mockApi_, evbThread_.getEventBase(), nics, 0);
+  RdmaTransport transport(
+      mockApi_, mockCudaApi_, evbThread_.getEventBase(), nics, 0);
 
   auto data = transport.bind();
   EXPECT_TRUE(data.empty());
@@ -378,7 +414,8 @@ TEST_F(RdmaTransportTest, ConnectTransitionsQPs) {
   auto nics = std::make_shared<std::vector<NicResources>>();
   nics->push_back(
       makeNic(&fakeDev0_, &fakeCtx0_, &fakePd0_, mockApi_, 0x1234, gid));
-  RdmaTransport transport(mockApi_, evbThread_.getEventBase(), nics, 0);
+  RdmaTransport transport(
+      mockApi_, mockCudaApi_, evbThread_.getEventBase(), nics, 0);
   transport.bind();
 
   RdmaTransportInfo remoteInfo;
@@ -387,6 +424,8 @@ TEST_F(RdmaTransportTest, ConnectTransitionsQPs) {
   remoteInfo.header.numNics = 1;
   remoteInfo.nicInfos = {{.lid = 0x5678}};
   remoteInfo.qpInfos = {{.qpNum = 200, .psn = 300}};
+  remoteInfo.ctrl.rkeys = {0};
+  remoteInfo.slab.rkeys = {0};
 
   auto status = transport.connect(remoteInfo.serialize());
   ASSERT_FALSE(status.hasError());
@@ -405,7 +444,8 @@ TEST_F(RdmaTransportTest, ConnectRejectsQpCountMismatch) {
   ibv_gid gid{};
   auto nics = std::make_shared<std::vector<NicResources>>();
   nics->push_back(makeNic(&fakeDev0_, &fakeCtx0_, &fakePd0_, mockApi_, 0, gid));
-  RdmaTransport transport(mockApi_, evbThread_.getEventBase(), nics, 0);
+  RdmaTransport transport(
+      mockApi_, mockCudaApi_, evbThread_.getEventBase(), nics, 0);
   transport.bind();
 
   RdmaTransportInfo remoteInfo;
@@ -414,6 +454,8 @@ TEST_F(RdmaTransportTest, ConnectRejectsQpCountMismatch) {
   remoteInfo.header.numNics = 1;
   remoteInfo.nicInfos = {{.lid = 1}};
   remoteInfo.qpInfos = {{.qpNum = 200, .psn = 300}, {.qpNum = 201, .psn = 301}};
+  remoteInfo.ctrl.rkeys = {0};
+  remoteInfo.slab.rkeys = {0};
 
   auto status = transport.connect(remoteInfo.serialize());
   ASSERT_TRUE(status.hasError());
@@ -424,7 +466,8 @@ TEST_F(RdmaTransportTest, ConnectWithoutBindFails) {
   ibv_gid gid{};
   auto nics = std::make_shared<std::vector<NicResources>>();
   nics->push_back(makeNic(&fakeDev0_, &fakeCtx0_, &fakePd0_, mockApi_, 0, gid));
-  RdmaTransport transport(mockApi_, evbThread_.getEventBase(), nics, 0);
+  RdmaTransport transport(
+      mockApi_, mockCudaApi_, evbThread_.getEventBase(), nics, 0);
 
   // Don't call bind() - go straight to connect()
   RdmaTransportInfo remoteInfo;
@@ -433,6 +476,8 @@ TEST_F(RdmaTransportTest, ConnectWithoutBindFails) {
   remoteInfo.header.numNics = 1;
   remoteInfo.nicInfos = {{.lid = 1}};
   remoteInfo.qpInfos = {{.qpNum = 200, .psn = 300}};
+  remoteInfo.ctrl.rkeys = {0};
+  remoteInfo.slab.rkeys = {0};
 
   auto status = transport.connect(remoteInfo.serialize());
   ASSERT_TRUE(status.hasError());
@@ -454,7 +499,8 @@ TEST_F(RdmaTransportTest, ShutdownDestroysResources) {
   ibv_gid gid{};
   auto nics = std::make_shared<std::vector<NicResources>>();
   nics->push_back(makeNic(&fakeDev0_, &fakeCtx0_, &fakePd0_, mockApi_, 0, gid));
-  RdmaTransport transport(mockApi_, evbThread_.getEventBase(), nics, 0);
+  RdmaTransport transport(
+      mockApi_, mockCudaApi_, evbThread_.getEventBase(), nics, 0);
   transport.bind();
 
   transport.shutdown();
@@ -531,8 +577,8 @@ TEST_F(RdmaTransportFactoryTest, GetTopologyReturnsNonEmpty) {
       {"mlx5_0"}, evbThread_.getEventBase(), {}, mockApi_);
   auto topo = factory.getTopology();
   EXPECT_FALSE(topo.empty());
-  EXPECT_EQ(topo[0], 1u); // version == kRdmaVersion == 1
   EXPECT_GT(topo.size(), 1u); // topology now includes numQps
+  EXPECT_EQ(topo[0], kRdmaVersion);
 }
 
 TEST_F(RdmaTransportFactoryTest, CreateTransportAcceptsValidTopology) {
@@ -764,9 +810,22 @@ class RdmaTransportDataPathTest : public ::testing::Test {
  protected:
   void SetUp() override {
     mockApi_ = std::make_shared<testing::NiceMock<MockIbvApi>>();
+    mockCudaApi_ = std::make_shared<testing::NiceMock<MockCudaApi>>();
     evbThread_ = std::make_unique<ScopedEventBaseThread>();
 
     fakeQp_.qp_num = 100;
+
+    ON_CALL(*mockApi_, regMr(_, _, _, _))
+        .WillByDefault(Return(Result<ibv_mr*>(&fakeDataMr_)));
+    ON_CALL(*mockApi_, deregMr(_)).WillByDefault(Return(Ok()));
+    ON_CALL(*mockCudaApi_, hostAlloc(_, _))
+        .WillByDefault([](size_t size, unsigned int) {
+          return Result<void*>(std::calloc(1, size));
+        });
+    ON_CALL(*mockCudaApi_, hostFree(_)).WillByDefault([](void* ptr) {
+      std::free(ptr);
+      return Ok();
+    });
 
     EXPECT_CALL(*mockApi_, createCq(&fakeCtx_, _, _, _, _))
         .WillOnce(Return(Result<ibv_cq*>(&fakeCq_)));
@@ -780,7 +839,11 @@ class RdmaTransportDataPathTest : public ::testing::Test {
         makeNic(&fakeDev_, &fakeCtx_, &fakePd_, mockApi_, 0x1234, gid));
 
     transport_ = std::make_unique<RdmaTransport>(
-        mockApi_, evbThread_->getEventBase(), nics, kLocalDomainId);
+        mockApi_,
+        mockCudaApi_,
+        evbThread_->getEventBase(),
+        nics,
+        kLocalDomainId);
     transport_->bind();
 
     RdmaTransportInfo remoteInfo;
@@ -790,6 +853,8 @@ class RdmaTransportDataPathTest : public ::testing::Test {
     remoteInfo.header.domainId = kRemoteDomainId;
     remoteInfo.nicInfos = {{.lid = 0x5678}};
     remoteInfo.qpInfos = {{.qpNum = 200, .psn = 300}};
+    remoteInfo.ctrl.rkeys = {0};
+    remoteInfo.slab.rkeys = {0};
     transport_->connect(remoteInfo.serialize());
   }
 
@@ -847,6 +912,7 @@ class RdmaTransportDataPathTest : public ::testing::Test {
   static constexpr uint64_t kRemoteDomainId = 99;
 
   std::shared_ptr<testing::NiceMock<MockIbvApi>> mockApi_;
+  std::shared_ptr<testing::NiceMock<MockCudaApi>> mockCudaApi_;
   std::unique_ptr<ScopedEventBaseThread> evbThread_;
   std::unique_ptr<RdmaTransport> transport_;
 
@@ -855,6 +921,7 @@ class RdmaTransportDataPathTest : public ::testing::Test {
   ibv_pd fakePd_{};
   ibv_cq fakeCq_{};
   ibv_qp fakeQp_{};
+  ibv_mr fakeDataMr_{};
 };
 
 // --- Opcode-only parameterized fixture (put vs get) ---
@@ -1084,7 +1151,12 @@ TEST_F(RdmaTransportTest, CompletionRoutingDisambiguatesDuplicateQpNumbers) {
       makeNic(&fakeDev1_, &fakeCtx1_, &fakePd1_, mockApi_, 0x2222, gid1));
   RdmaTransportConfig config{.numQps = 2};
   RdmaTransport transport(
-      mockApi_, evbThread_.getEventBase(), nics, kLocalDomainId, config);
+      mockApi_,
+      mockCudaApi_,
+      evbThread_.getEventBase(),
+      nics,
+      kLocalDomainId,
+      config);
   transport.bind();
 
   RdmaTransportInfo remoteInfo;
@@ -1094,7 +1166,10 @@ TEST_F(RdmaTransportTest, CompletionRoutingDisambiguatesDuplicateQpNumbers) {
   remoteInfo.header.domainId = kRemoteDomainId;
   remoteInfo.nicInfos = {{.lid = 0x3333}, {.lid = 0x4444}};
   remoteInfo.qpInfos = {{.qpNum = 200, .psn = 300}, {.qpNum = 201, .psn = 301}};
-  ASSERT_FALSE(transport.connect(remoteInfo.serialize()).hasError());
+  remoteInfo.ctrl.rkeys = {0, 0};
+  remoteInfo.slab.rkeys = {0, 0};
+  auto res = transport.connect(remoteInfo.serialize());
+  ASSERT_FALSE(res.hasError()) << res.error().message();
 
   std::vector<char> localBuf(kBufSize);
   std::vector<char> remoteBuf(kBufSize);


### PR DESCRIPTION
Summary:
Integrate `RdmaSlabPool` into `RdmaTransport` and extend the bind/connect handshake to exchange slab pool and control buffer metadata between peers.

Changes:
- **Ctrl buffer allocation in `bind()`**: allocates a host-pinned control buffer containing the CTS ring (receive-to-send slab index exchange) and per-QP notify entries (send-to-receive completion signaling). Registered with the local NIC for RDMA WRITE by the peer.
- **Extended `RdmaTransportInfo` serialization**: adds `RegisteredBuffer` for ctrl and slab metadata (base address, length, per-NIC rkeys) with serialize/deserialize support, exchanged during connect.
- **`connect()` stores remote pool layout**: remote slab base address, rkeys, and slab size are stored for computing RDMA WRITE destinations from compact CTS slab indices.
- **Updated design doc**: reflects the self-contained `SlabPool` lifetime model (pool holds its own `IbvApi`/`CudaApi` references rather than depending on factory lifetime).
- **BUCK dependency updates**: `slab-pool` visibility scoped to `//comms/uniflow/transport/rdma/...`, dependency changed from `rdma-transport` to `rdma-resources` to break circular dependency.
- **CI label fix in `comms_gpu_cpp_distributed_unittest` macro** (`comms/testinfra/def_test.bzl`): the macro previously created separate `ci.labels()` calls for user-provided `tags` and for `disable_amd_ci` removal, then concatenated the results. Each `ci.labels()` call independently inherits from the PACKAGE, so the second call re-introduced `ci:diff:linux:dev` after the first had replaced it with `ci:opt`. Fixed by collecting all CI modifiers (user tags + AMD/Nvidia removal) into a single `ci.labels(*ci_modifiers)` call that operates on one copy of the inherited labels. The combined result is now passed to both the `gpu_cpp_binary` and `custom_unittest` targets. BUCK file updated to pass raw modifiers (`[ci.replace({...})]`) instead of pre-evaluated `ci.labels(...)`.


Differential Revision: D103248251


