### PR TITLE
Add getCtranCommFromNcclComm accessor to MetaFactory (#2331)

### DIFF
--- a/comms/ncclx/meta/wrapper/MetaFactory.cc
+++ b/comms/ncclx/meta/wrapper/MetaFactory.cc
@@ -82,3 +82,10 @@ commResult_t setCtranCommBase(ncclComm* ncclCommVal) {
 
   return commSuccess;
 }
+
+CtranComm* getCtranCommFromNcclComm(ncclComm* ncclComm) {
+  if (ncclComm && ncclComm->ctranComm_) {
+    return ncclComm->ctranComm_.get();
+  }
+  return nullptr;
+}

--- a/comms/ncclx/meta/wrapper/MetaFactory.h
+++ b/comms/ncclx/meta/wrapper/MetaFactory.h
@@ -197,3 +197,7 @@ inline commDataType_t ncclToMetaComm(ncclDataType_t dataType) {
 // initialization
 ctranConfig makeCtranConfigFrom(ncclComm* comm);
 commResult_t setCtranCommBase(ncclComm* ncclCommVal);
+
+// Public accessor returning the CtranComm* hanging off an ncclComm, or
+// nullptr if it isn't initialized (e.g. NCCL_CTRAN_ENABLE not set).
+CtranComm* getCtranCommFromNcclComm(ncclComm* ncclComm);


### PR DESCRIPTION
Summary:

Adds a public accessor that returns the per-comm `CtranComm*` hanging off an `ncclComm`, or `nullptr` if ctran isn't initialized for that comm (e.g. `NCCL_CTRAN_ENABLE` not set).

Needed by torchcomms NCCLX backend so it can call ctran free functions directly for ctran-only collectives, bypassing the round-trip through the NCCL public API and `collectives.cc`. Implemented as a single function in `MetaFactory.{h,cc}` because that translation unit is shared across NCCLX versions and gets compiled once per version (`v2_27`, `v2_28`, `v2_29`) by each version's existing `meta/wrapper/*.cc` glob — one symbol per version's `libncclx.so`, no per-version BUCK edits.

This is the P1-A piece of the phase-1 work described in `comms/torchcomms/ncclx/docs/torchcomms_ctran_dispatch_design.md`.

Reviewed By: tanquer

Differential Revision: D103234995


