### PR TITLE
Wire device_alltoallv_single directly via CtranApi (#2333)

### DIFF
--- a/comms/ncclx/meta/wrapper/MetaFactory.cc
+++ b/comms/ncclx/meta/wrapper/MetaFactory.cc
@@ -107,3 +107,10 @@ ncclResult_t destroyCtranComm(ncclComm* comm) {
   }
   return ncclSuccess;
 }
+
+CtranComm* getCtranCommFromNcclComm(ncclComm* ncclComm) {
+  if (ncclComm && ncclComm->ctranComm_) {
+    return ncclComm->ctranComm_.get();
+  }
+  return nullptr;
+}

--- a/comms/ncclx/meta/wrapper/MetaFactory.h
+++ b/comms/ncclx/meta/wrapper/MetaFactory.h
@@ -198,3 +198,7 @@ ncclResult_t createCtranComm(ncclComm* comm);
 // Finalize, destroy, and reset ctranComm_ on the given ncclComm.
 // No-op if ctranComm_ is nullptr.
 ncclResult_t destroyCtranComm(ncclComm* comm);
+
+// Public accessor returning the CtranComm* hanging off an ncclComm, or
+// nullptr if it isn't initialized (e.g. NCCL_CTRAN_ENABLE not set).
+CtranComm* getCtranCommFromNcclComm(ncclComm* ncclComm);

--- a/comms/torchcomms/ncclx/CtranApi.cpp
+++ b/comms/torchcomms/ncclx/CtranApi.cpp
@@ -143,4 +143,32 @@ ncclResult_t DefaultCtranApi::allGatherPDestroy(void* request) {
   return fromCtranResult(res);
 }
 
+bool DefaultCtranApi::deviceAllToAllvSupport(CtranComm* ctranComm) {
+  return ctranDeviceAllToAllvSupport(ctranComm);
+}
+
+ncclResult_t DefaultCtranApi::deviceAllToAllv(
+    const void* sendbuff,
+    void* recvbuff,
+    const int64_t* sendcounts_d,
+    const int64_t* recvcounts_d,
+    ncclDataType_t datatype,
+    CtranComm* ctranComm,
+    cudaStream_t stream,
+    int64_t sendcountsMultiplier,
+    int64_t recvcountsMultiplier,
+    const std::unordered_map<std::string, std::string>& hints) {
+  return fromCtranResult(ctranDeviceAllToAllv(
+      sendbuff,
+      recvbuff,
+      sendcounts_d,
+      recvcounts_d,
+      toCtranDataType(datatype),
+      ctranComm,
+      stream,
+      sendcountsMultiplier,
+      recvcountsMultiplier,
+      hints));
+}
+
 } // namespace torch::comms

--- a/comms/torchcomms/ncclx/CtranApi.cpp
+++ b/comms/torchcomms/ncclx/CtranApi.cpp
@@ -1,0 +1,146 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/torchcomms/ncclx/CtranApi.hpp"
+
+#include <stdexcept>
+
+#include <nccl.h> // @manual=//comms/ncclx:nccl
+
+#include "comms/ctran/Ctran.h"
+#include "comms/ctran/hints/Hints.h"
+#include "comms/utils/commSpecs.h"
+
+// Defined in MetaFactory.cc (per-NCCLX-version). Forward-declared so we
+// can call it without depending on NCCLX's private headers.
+extern CtranComm* getCtranCommFromNcclComm(ncclComm* ncclComm);
+
+namespace torch::comms {
+
+namespace {
+
+// Type conversions duplicated from MetaFactory.h. The originals are inline
+// (not linker-visible) and the header is internal to NCCLX.
+commDataType_t toCtranDataType(ncclDataType_t dt) {
+  switch (dt) {
+    case ncclInt8:
+      return commInt8;
+    case ncclUint8:
+      return commUint8;
+    case ncclInt32:
+      return commInt32;
+    case ncclUint32:
+      return commUint32;
+    case ncclInt64:
+      return commInt64;
+    case ncclUint64:
+      return commUint64;
+    case ncclFloat16:
+      return commFloat16;
+    case ncclFloat32:
+      return commFloat32;
+    case ncclFloat64:
+      return commFloat64;
+    case ncclBfloat16:
+      return commBfloat16;
+    case ncclFloat8e4m3:
+      return commFloat8e4m3;
+    case ncclFloat8e5m2:
+      return commFloat8e5m2;
+    default:
+      throw std::runtime_error("Unsupported NCCL data type for ctran");
+  }
+}
+
+ncclResult_t fromCtranResult(commResult_t result) {
+  switch (result) {
+    case commSuccess:
+      return ncclSuccess;
+    case commUnhandledCudaError:
+      return ncclUnhandledCudaError;
+    case commSystemError:
+      return ncclSystemError;
+    case commInternalError:
+      return ncclInternalError;
+    case commInvalidArgument:
+      return ncclInvalidArgument;
+    case commInvalidUsage:
+      return ncclInvalidUsage;
+    case commRemoteError:
+      return ncclRemoteError;
+    case commInProgress:
+      return ncclInProgress;
+    default:
+      throw std::runtime_error("Unknown ctran commResult_t value");
+  }
+}
+
+meta::comms::Hints toMetaCommHints(
+    const std::unordered_map<std::string, std::string>& hints) {
+  meta::comms::Hints out;
+  for (const auto& [key, val] : hints) {
+    out.set(key, val);
+  }
+  return out;
+}
+
+} // namespace
+
+CtranComm* DefaultCtranApi::getCtranComm(ncclComm_t comm) {
+  return getCtranCommFromNcclComm(comm);
+}
+
+bool DefaultCtranApi::allGatherPSupport(CtranComm* ctranComm) {
+  return ctran::allGatherPSupport(ctranComm);
+}
+
+ncclResult_t DefaultCtranApi::allGatherPInit(
+    void* recvbuff,
+    size_t maxRecvCount,
+    const std::unordered_map<std::string, std::string>& hints,
+    ncclDataType_t datatype,
+    CtranComm* ctranComm,
+    cudaStream_t stream,
+    void** request) {
+  CtranPersistentRequest* pReq = nullptr;
+  const auto res = ctran::allGatherPInit(
+      recvbuff,
+      maxRecvCount,
+      toMetaCommHints(hints),
+      toCtranDataType(datatype),
+      ctranComm,
+      stream,
+      pReq);
+  if (res == commSuccess) {
+    *request = reinterpret_cast<void*>(pReq);
+  }
+  return fromCtranResult(res);
+}
+
+ncclResult_t DefaultCtranApi::allGatherPExec(
+    const void* sendbuff,
+    size_t count,
+    ncclDataType_t datatype,
+    void* request) {
+  return fromCtranResult(
+      ctran::allGatherPExec(
+          sendbuff,
+          count,
+          toCtranDataType(datatype),
+          reinterpret_cast<CtranPersistentRequest*>(request)));
+}
+
+ncclResult_t DefaultCtranApi::allGatherPDestroy(void* request) {
+  if (request == nullptr) {
+    return ncclSuccess;
+  }
+  auto* pReq = reinterpret_cast<CtranPersistentRequest*>(request);
+  const auto res = ctran::allGatherPDestroy(pReq);
+  // only delete the request if the destroy was successful, following existing
+  // functionality
+  if (res == commSuccess) {
+    delete pReq;
+  }
+  return fromCtranResult(res);
+}
+
+} // namespace torch::comms

--- a/comms/torchcomms/ncclx/CtranApi.hpp
+++ b/comms/torchcomms/ncclx/CtranApi.hpp
@@ -61,6 +61,25 @@ class CtranApi {
       void* request) = 0;
 
   [[nodiscard]] virtual ncclResult_t allGatherPDestroy(void* request) = 0;
+
+  /// Returns true iff `deviceAllToAllv` can run on this comm. Verifies
+  /// ctran has the required pipes transport support. Callers should check
+  /// this before `deviceAllToAllv` and surface a clear error if false.
+  [[nodiscard]] virtual bool deviceAllToAllvSupport(CtranComm* ctranComm) = 0;
+
+  /// Device-side AllToAllv. Counts and split sizes live on the GPU; ctran
+  /// reads them on-stream without an extra D2H copy.
+  [[nodiscard]] virtual ncclResult_t deviceAllToAllv(
+      const void* sendbuff,
+      void* recvbuff,
+      const int64_t* sendcounts_d,
+      const int64_t* recvcounts_d,
+      ncclDataType_t datatype,
+      CtranComm* ctranComm,
+      cudaStream_t stream,
+      int64_t sendcountsMultiplier,
+      int64_t recvcountsMultiplier,
+      const std::unordered_map<std::string, std::string>& hints) = 0;
 };
 
 /**
@@ -92,6 +111,20 @@ class DefaultCtranApi : public CtranApi {
       void* request) override;
 
   [[nodiscard]] ncclResult_t allGatherPDestroy(void* request) override;
+
+  [[nodiscard]] bool deviceAllToAllvSupport(CtranComm* ctranComm) override;
+
+  [[nodiscard]] ncclResult_t deviceAllToAllv(
+      const void* sendbuff,
+      void* recvbuff,
+      const int64_t* sendcounts_d,
+      const int64_t* recvcounts_d,
+      ncclDataType_t datatype,
+      CtranComm* ctranComm,
+      cudaStream_t stream,
+      int64_t sendcountsMultiplier,
+      int64_t recvcountsMultiplier,
+      const std::unordered_map<std::string, std::string>& hints) override;
 };
 
 } // namespace torch::comms

--- a/comms/torchcomms/ncclx/CtranApi.hpp
+++ b/comms/torchcomms/ncclx/CtranApi.hpp
@@ -1,0 +1,97 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+
+#include <nccl.h> // @manual=//comms/ncclx:nccl
+
+#include "comms/ctran/Ctran.h"
+
+namespace torch::comms {
+
+/**
+ * Abstract interface for the ctran execution path used by TorchCommNCCLX
+ * for collectives that have no NCCL baseline (phase 1 of the direct-dispatch
+ * design). Calling these collectives necessarily means running ctran, so
+ * there is no algorithm choice or support gate at this layer — the API is
+ * a thin pass-through that converts NCCL-typed arguments to ctran types
+ * and translates `commResult_t` back to `ncclResult_t`.
+ *
+ * Phase-2 (NCCL-baseline) collectives that need an algorithm enum and a
+ * runtime support check will be added to this interface in a subsequent
+ * change.
+ */
+class CtranApi {
+ public:
+  virtual ~CtranApi() = default;
+
+  /// Returns the per-comm `CtranComm*` hanging off `comm`, or `nullptr` if
+  /// ctran isn't initialized for that comm (e.g. `NCCL_CTRAN_ENABLE` not
+  /// set). Resolved via the per-NCCLX-version `getCtranCommFromNcclComm`
+  /// accessor in `MetaFactory.cc`.
+  [[nodiscard]] virtual CtranComm* getCtranComm(ncclComm_t comm) = 0;
+
+  /// Returns true iff persistent allgather can run on this comm. Verifies
+  /// ctran is initialized and every remote peer has an assigned ctran
+  /// transport backend. Callers should check this before `allGatherPInit`
+  /// and surface a clear error if false — otherwise `allGatherPInit` will
+  /// fail later with a less informative message.
+  [[nodiscard]] virtual bool allGatherPSupport(CtranComm* ctranComm) = 0;
+
+  /// Persistent allgather init. `request` is an opaque handle that must be
+  /// passed back to `allGatherPExec` and `allGatherPDestroy`.
+  [[nodiscard]] virtual ncclResult_t allGatherPInit(
+      void* recvbuff,
+      size_t maxRecvCount,
+      const std::unordered_map<std::string, std::string>& hints,
+      ncclDataType_t datatype,
+      CtranComm* ctranComm,
+      cudaStream_t stream,
+      void** request) = 0;
+
+  [[nodiscard]] virtual ncclResult_t allGatherPExec(
+      const void* sendbuff,
+      size_t count,
+      ncclDataType_t datatype,
+      void* request) = 0;
+
+  [[nodiscard]] virtual ncclResult_t allGatherPDestroy(void* request) = 0;
+};
+
+/**
+ * Default implementation that calls the matching `ctran<Coll>` free
+ * function directly. Stateless — a single instance can be shared across
+ * TorchCommNCCLX comms.
+ */
+class DefaultCtranApi : public CtranApi {
+ public:
+  ~DefaultCtranApi() override = default;
+
+  [[nodiscard]] CtranComm* getCtranComm(ncclComm_t comm) override;
+
+  [[nodiscard]] bool allGatherPSupport(CtranComm* ctranComm) override;
+
+  [[nodiscard]] ncclResult_t allGatherPInit(
+      void* recvbuff,
+      size_t maxRecvCount,
+      const std::unordered_map<std::string, std::string>& hints,
+      ncclDataType_t datatype,
+      CtranComm* ctranComm,
+      cudaStream_t stream,
+      void** request) override;
+
+  [[nodiscard]] ncclResult_t allGatherPExec(
+      const void* sendbuff,
+      size_t count,
+      ncclDataType_t datatype,
+      void* request) override;
+
+  [[nodiscard]] ncclResult_t allGatherPDestroy(void* request) override;
+};
+
+} // namespace torch::comms

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -1702,19 +1702,29 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::device_alltoallv_single(
   // Record start event before NCCL operation
   work->recordStart("device_alltoallv_single");
 
-  ncclResult_t result = nccl_api_->deviceAllToAllv(
+  if (ctran_comm_ == nullptr) {
+    throw std::runtime_error(
+        "device_alltoallv_single requires ctran (set NCCL_CTRAN_ENABLE=1)");
+  }
+  if (!ctran_api_->deviceAllToAllvSupport(ctran_comm_)) {
+    throw std::runtime_error(
+        "device_alltoallv_single is not supported on this comm. "
+        "Requires ctran with pipes transport support.");
+  }
+
+  ncclResult_t result = ctran_api_->deviceAllToAllv(
       input.data_ptr(),
       output.data_ptr(),
       input_split_sizes.data_ptr<int64_t>(),
       output_split_sizes.data_ptr<int64_t>(),
       getNcclDataType(input),
-      nccl_comm_,
+      ctran_comm_,
       stream,
       send_elements_per_slice,
       recv_elements_per_slice,
       hints);
 
-  NCCLX_CHECK(nccl_api_, nccl_comm_, result, "NCCLX deviceAllToAllv failed");
+  NCCLX_CHECK(nccl_api_, nccl_comm_, result, "ctran deviceAllToAllv failed");
 
   // Record end event after NCCL operation
   work->recordEnd();

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -150,6 +150,10 @@ void TorchCommNCCLX::init(
     nccl_api_ = std::make_unique<DefaultNcclxApi>();
   }
 
+  if (!ctran_api_) {
+    ctran_api_ = std::make_shared<DefaultCtranApi>();
+  }
+
   if (!cuda_api_) {
     cuda_api_ = std::make_unique<DefaultCudaApi>();
   }
@@ -274,6 +278,13 @@ void TorchCommNCCLX::initNcclxResources() {
   }
 
   attachMemoryHook();
+
+  // Resolve the per-comm CtranComm* now that the underlying ncclComm
+  // exists. May be null if NCCL_CTRAN_ENABLE was not set; phase-1 dispatch
+  // sites validate this before each call.
+  if (ctran_api_) {
+    ctran_comm_ = ctran_api_->getCtranComm(nccl_comm_);
+  }
 
   init_state_ = InitializationState::INITIALIZED;
 }
@@ -1058,6 +1069,16 @@ TorchCommBackend::AllGatherPHandle TorchCommNCCLX::all_gather_p_init(
   size_t maxRecvCount = output.numel();
   size_t bufferSize = maxRecvCount * output.element_size();
 
+  if (ctran_comm_ == nullptr) {
+    throw std::runtime_error(
+        "all_gather_p_init requires ctran (set NCCL_CTRAN_ENABLE=1)");
+  }
+  if (!ctran_api_->allGatherPSupport(ctran_comm_)) {
+    throw std::runtime_error(
+        "Persistent AllGather is not supported on this comm. "
+        "Check that ctran is enabled and all peers have an assigned backend.");
+  }
+
   // Register the output buffer if not already registered
   void* dataPtr = output.data_ptr();
   auto it = memoryRegistrationHandles_.find(dataPtr);
@@ -1075,15 +1096,15 @@ TorchCommBackend::AllGatherPHandle TorchCommNCCLX::all_gather_p_init(
   NCCLX_CHECK(
       nccl_api_,
       nccl_comm_,
-      nccl_api_->allGatherInit(
+      ctran_api_->allGatherPInit(
           dataPtr,
           maxRecvCount,
           options.hints,
           getNcclDataType(output),
-          nccl_comm_,
+          ctran_comm_,
           getInternalStream(),
           &request),
-      "NCCLX allGatherInit failed");
+      "ctran allGatherPInit failed");
 
   return request;
 }
@@ -1111,9 +1132,9 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::all_gather_p_exec(
   NCCLX_CHECK(
       nccl_api_,
       nccl_comm_,
-      nccl_api_->allGatherExec(
+      ctran_api_->allGatherPExec(
           input.data_ptr(), input.numel(), getNcclDataType(input), handle),
-      "NCCLX allGatherExec failed");
+      "ctran allGatherPExec failed");
 
   work->recordEnd();
   enqueueWork(work, stream);
@@ -1125,7 +1146,10 @@ void TorchCommNCCLX::all_gather_p_free(AllGatherPHandle handle) {
   if (handle == nullptr) {
     return;
   }
-  NCCLX_CHECK_IGNORE(nccl_api_, nccl_api_->pFree(handle), "NCCLX pFree failed");
+  NCCLX_CHECK_IGNORE(
+      nccl_api_,
+      ctran_api_->allGatherPDestroy(handle),
+      "ctran allGatherPDestroy failed");
 }
 
 c10::intrusive_ptr<TorchWork> TorchCommNCCLX::reduce_scatter(
@@ -2358,6 +2382,7 @@ std::shared_ptr<TorchCommBackend> TorchCommNCCLX::split(
   auto new_torchcomm =
       std::shared_ptr<TorchCommNCCLX>(new TorchCommNCCLX(new_comm));
   new_torchcomm->nccl_api_ = nccl_api_;
+  new_torchcomm->ctran_api_ = ctran_api_;
   new_torchcomm->cuda_api_ = cuda_api_;
   new_torchcomm->init(device_, commDesc, options);
 

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
@@ -19,6 +19,7 @@
 #include "comms/torchcomms/TorchCommBackend.hpp"
 #include "comms/torchcomms/TorchCommBatch.hpp"
 #include "comms/torchcomms/device/cuda/CudaApi.hpp"
+#include "comms/torchcomms/ncclx/CtranApi.hpp"
 #include "comms/torchcomms/ncclx/GraphEventTracker.hpp"
 #include "comms/torchcomms/ncclx/NcclxApi.hpp"
 #include "comms/torchcomms/ncclx/TorchCommWindowNCCLX.hpp"
@@ -290,6 +291,16 @@ class TorchCommNCCLX : public TorchCommBackend,
     nccl_api_ = std::move(api);
   }
 
+  // Getter for ctran API (for friend classes / tests)
+  CtranApi* getCtranApi() const {
+    return ctran_api_.get();
+  }
+
+  // Method to override the ctran API implementation for testing
+  void setCtranApi(std::shared_ptr<CtranApi> api) {
+    ctran_api_ = std::move(api);
+  }
+
   // Method to override the CUDA API implementation for testing
   void setCudaApi(std::shared_ptr<CudaApi> api) {
     cuda_api_ = std::move(api);
@@ -524,6 +535,15 @@ class TorchCommNCCLX : public TorchCommBackend,
 
   // NCCL API abstraction
   std::shared_ptr<NcclxApi> nccl_api_;
+
+  // ctran API abstraction. Used for collectives that have no NCCL baseline
+  // and are therefore always served by ctran when ctran is enabled. The
+  // dispatch sites bypass nccl_api_ -> collectives.cc for these calls.
+  std::shared_ptr<CtranApi> ctran_api_;
+
+  // Per-comm CtranComm*. Resolved once after ncclCommInit; may be null if
+  // NCCL_CTRAN_ENABLE was not set at process start.
+  CtranComm* ctran_comm_{nullptr};
 
   // CUDA API abstraction
   std::shared_ptr<CudaApi> cuda_api_;

--- a/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTest.cpp
@@ -190,6 +190,7 @@ TEST_F(TorchCommNCCLXTest, InitializationFailsWithInvalidDeviceId) {
     auto comm = std::make_shared<TestTorchCommNCCLX>();
     comm->setCudaApi(cuda_mock_);
     comm->setNcclApi(nccl_mock_);
+    comm->setCtranApi(ctran_mock_);
 
     // Mock getDeviceCount to return a valid device count (needed for rank %
     // device_count)
@@ -237,6 +238,7 @@ TEST_F(TorchCommNCCLXTest, InitializationFailsWithInvalidDeviceId) {
     auto comm = std::make_shared<TestTorchCommNCCLX>();
     comm->setCudaApi(cuda_mock_);
     comm->setNcclApi(nccl_mock_);
+    comm->setCtranApi(ctran_mock_);
 
     // Mock CUDA API to return error for device ID that's too large
     EXPECT_CALL(*cuda_mock_, setDevice(127))

--- a/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTestBase.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTestBase.cpp
@@ -23,6 +23,7 @@ void TorchCommNCCLXTest::SetUp() {
   // Default: per-collective support fns return true. Tests that exercise
   // the unsupported path override with EXPECT_CALL.
   ON_CALL(*ctran_mock_, allGatherPSupport(_)).WillByDefault(Return(true));
+  ON_CALL(*ctran_mock_, deviceAllToAllvSupport(_)).WillByDefault(Return(true));
 
   // Force the global instance to be created on the CPU device
   auto hook_mock = std::make_unique<CachingAllocatorHookMock>();

--- a/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTestBase.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTestBase.cpp
@@ -15,6 +15,14 @@ void TorchCommNCCLXTest::SetUp() {
   // Create fresh mocks for each test
   cuda_mock_ = std::make_shared<NiceMock<CudaMock>>();
   nccl_mock_ = std::make_shared<NiceMock<NcclxMock>>();
+  ctran_mock_ = std::make_shared<NiceMock<CtranMock>>();
+  // Default: ctran disabled. Tests that want to exercise the ctran branch
+  // override this with EXPECT_CALL/ON_CALL on getCtranComm.
+  ON_CALL(*ctran_mock_, getCtranComm(_))
+      .WillByDefault(Return(static_cast<CtranComm*>(nullptr)));
+  // Default: per-collective support fns return true. Tests that exercise
+  // the unsupported path override with EXPECT_CALL.
+  ON_CALL(*ctran_mock_, allGatherPSupport(_)).WillByDefault(Return(true));
 
   // Force the global instance to be created on the CPU device
   auto hook_mock = std::make_unique<CachingAllocatorHookMock>();
@@ -106,6 +114,7 @@ TorchCommNCCLXTest::createMockedTorchComm() {
   // Inject the mocks
   comm->setCudaApi(cuda_mock_);
   comm->setNcclApi(nccl_mock_);
+  comm->setCtranApi(ctran_mock_);
 
   return comm;
 }

--- a/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTestBase.hpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTestBase.hpp
@@ -15,6 +15,7 @@
 #include "comms/torchcomms/TorchComm.hpp"
 #include "comms/torchcomms/ncclx/TorchCommNCCLX.hpp"
 #include "comms/torchcomms/ncclx/tests/unit/cpp/mocks/CachingAllocatorHookMock.hpp"
+#include "comms/torchcomms/ncclx/tests/unit/cpp/mocks/CtranMock.hpp"
 #include "comms/torchcomms/ncclx/tests/unit/cpp/mocks/CudaMock.hpp"
 #include "comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.hpp"
 
@@ -135,6 +136,7 @@ class TorchCommNCCLXTest : public ::testing::Test {
   // Raw pointers to mocks for setting expectations
   std::shared_ptr<NiceMock<CudaMock>> cuda_mock_;
   std::shared_ptr<NiceMock<NcclxMock>> nccl_mock_;
+  std::shared_ptr<NiceMock<CtranMock>> ctran_mock_;
   std::vector<WorkEvent> work_events_;
 
   CommOptions default_options_;

--- a/comms/torchcomms/ncclx/tests/unit/cpp/TorchWorkNCCLXQueueTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/TorchWorkNCCLXQueueTest.cpp
@@ -13,6 +13,7 @@
 #include "comms/torchcomms/ncclx/TorchCommNCCLXCCA.hpp"
 #include "comms/torchcomms/ncclx/TorchWorkNCCLX.hpp"
 #include "comms/torchcomms/ncclx/tests/unit/cpp/mocks/CachingAllocatorHookMock.hpp"
+#include "comms/torchcomms/ncclx/tests/unit/cpp/mocks/CtranMock.hpp"
 #include "comms/torchcomms/ncclx/tests/unit/cpp/mocks/CudaMock.hpp"
 #include "comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.hpp"
 
@@ -77,11 +78,16 @@ class TorchWorkNCCLXQueueCommTest : public ::testing::Test {
     // Create fresh mocks for each test
     cuda_mock_ = std::make_shared<NiceMock<torch::comms::test::CudaMock>>();
     nccl_mock_ = std::make_shared<NiceMock<torch::comms::test::NcclxMock>>();
+    ctran_mock_ = std::make_shared<NiceMock<torch::comms::test::CtranMock>>();
+    ON_CALL(*ctran_mock_, getCtranComm(_))
+        .WillByDefault(Return(static_cast<CtranComm*>(nullptr)));
+    ON_CALL(*ctran_mock_, allGatherPSupport(_)).WillByDefault(Return(true));
 
     // Create communicator
     comm_ = std::make_shared<TorchCommNCCLX>();
     comm_->setCudaApi(cuda_mock_);
     comm_->setNcclApi(nccl_mock_);
+    comm_->setCtranApi(ctran_mock_);
   }
 
   void TearDown() override {
@@ -136,6 +142,7 @@ class TorchWorkNCCLXQueueCommTest : public ::testing::Test {
   // Raw pointers to mocks for setting expectations
   std::shared_ptr<NiceMock<torch::comms::test::CudaMock>> cuda_mock_;
   std::shared_ptr<NiceMock<torch::comms::test::NcclxMock>> nccl_mock_;
+  std::shared_ptr<NiceMock<torch::comms::test::CtranMock>> ctran_mock_;
   std::vector<WorkEvent> work_events_;
 
   CommOptions default_options_;

--- a/comms/torchcomms/ncclx/tests/unit/cpp/TorchWorkNCCLXQueueTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/TorchWorkNCCLXQueueTest.cpp
@@ -82,6 +82,8 @@ class TorchWorkNCCLXQueueCommTest : public ::testing::Test {
     ON_CALL(*ctran_mock_, getCtranComm(_))
         .WillByDefault(Return(static_cast<CtranComm*>(nullptr)));
     ON_CALL(*ctran_mock_, allGatherPSupport(_)).WillByDefault(Return(true));
+    ON_CALL(*ctran_mock_, deviceAllToAllvSupport(_))
+        .WillByDefault(Return(true));
 
     // Create communicator
     comm_ = std::make_shared<TorchCommNCCLX>();

--- a/comms/torchcomms/ncclx/tests/unit/cpp/mocks/CtranMock.hpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/mocks/CtranMock.hpp
@@ -1,0 +1,51 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <gmock/gmock.h>
+#include <nccl.h> // @manual
+#include <string>
+#include <unordered_map>
+
+#include "comms/torchcomms/ncclx/CtranApi.hpp"
+
+namespace torch::comms::test {
+
+/// gmock impl of CtranApi for the phase-1 (ctran-only) collective surface.
+class CtranMock : public CtranApi {
+ public:
+  ~CtranMock() override = default;
+
+  // Alias avoids passing a comma-bearing type token through the
+  // MOCK_METHOD macro.
+  using HintsMap = std::unordered_map<std::string, std::string>;
+
+  MOCK_METHOD(CtranComm*, getCtranComm, (ncclComm_t comm), (override));
+
+  MOCK_METHOD(bool, allGatherPSupport, (CtranComm * ctranComm), (override));
+
+  MOCK_METHOD(
+      ncclResult_t,
+      allGatherPInit,
+      (void* recvbuff,
+       size_t maxRecvCount,
+       const HintsMap& hints,
+       ncclDataType_t datatype,
+       CtranComm* ctranComm,
+       cudaStream_t stream,
+       void** request),
+      (override));
+
+  MOCK_METHOD(
+      ncclResult_t,
+      allGatherPExec,
+      (const void* sendbuff,
+       size_t count,
+       ncclDataType_t datatype,
+       void* request),
+      (override));
+
+  MOCK_METHOD(ncclResult_t, allGatherPDestroy, (void* request), (override));
+};
+
+} // namespace torch::comms::test

--- a/comms/torchcomms/ncclx/tests/unit/cpp/mocks/CtranMock.hpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/mocks/CtranMock.hpp
@@ -46,6 +46,27 @@ class CtranMock : public CtranApi {
       (override));
 
   MOCK_METHOD(ncclResult_t, allGatherPDestroy, (void* request), (override));
+
+  MOCK_METHOD(
+      bool,
+      deviceAllToAllvSupport,
+      (CtranComm * ctranComm),
+      (override));
+
+  MOCK_METHOD(
+      ncclResult_t,
+      deviceAllToAllv,
+      (const void* sendbuff,
+       void* recvbuff,
+       const int64_t* sendcounts_d,
+       const int64_t* recvcounts_d,
+       ncclDataType_t datatype,
+       CtranComm* ctranComm,
+       cudaStream_t stream,
+       int64_t sendcountsMultiplier,
+       int64_t recvcountsMultiplier,
+       const HintsMap& hints),
+      (override));
 };
 
 } // namespace torch::comms::test


### PR DESCRIPTION
Summary:

Second phase-1 collective wired through `CtranApi`. Same pattern as P1-B.1 (`all_gather_p`): the existing `nccl_api_->deviceAllToAllv` thunk just round-trips through NCCLX's `collectives.cc` to call `ctranDeviceAllToAllv` because there's no NCCL baseline. After this diff `device_alltoallv_single` calls `ctran_api_->deviceAllToAllv(...)` directly, bypassing `collectives.cc`.

Pieces:
- Add `deviceAllToAllv` method to `CtranApi` + `DefaultCtranApi` impl.
- Add matching `MOCK_METHOD` to `CtranMock`.
- Switch `TorchCommNCCLX::device_alltoallv_single` to call `ctran_api_->deviceAllToAllv` (and validate `ctran_comm_ != nullptr`, throwing with a helpful message if `NCCL_CTRAN_ENABLE` was unset — matches today's behavior since `collectives.cc` would also have errored).

Reuses the shared infrastructure introduced in P1-B.1 (`CtranApi`, `getCtranCommFromNcclComm` accessor, `ctran_api_` / `ctran_comm_` members on `TorchCommNCCLX`).

Differential Revision: D103267661


