### PR TITLE
Add sharded relay allreduce C++ tests (#2336)

### DIFF
--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
@@ -1,0 +1,967 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "sharded_relay_allreduce.h"
+#include "comm.h"
+#include "sharded_relay_allreduce_kernels.h"
+
+#include <hip/hip_bfloat16.h>
+#include <hip/hip_fp16.h>
+#include <mutex>
+#include <unordered_map>
+
+// GPU memory access alignment in elements for chunk size rounding.
+// Distinct from the CPU CACHE_LINE_SIZE (64 bytes) defined in comm.h
+// which is used for struct padding.
+static constexpr size_t CHUNK_ALIGN_ELEMENTS = 128;
+
+/**
+ * Scratch Buffer Cache Singleton
+ *
+ * Amortizes cudaMalloc/cudaFree costs by caching and reusing scratch buffers.
+ * Thread-safe with per-device buffer management.
+ *
+ * Key features:
+ * - Multiple buffers per device (keyed for multi-group support)
+ * - Automatically grows buffer if larger size needed
+ * - Never shrinks (to avoid repeated alloc/free for varying sizes)
+ * - Thread-safe access with mutex protection
+ */
+class ScratchBufferCache {
+ public:
+  static ScratchBufferCache& getInstance() {
+    static ScratchBufferCache instance;
+    return instance;
+  }
+
+  /**
+   * Get a scratch buffer with a specific key (for multi-group support).
+   * Each key maintains its own buffer, allowing multiple independent scratch
+   * buffers per device.
+   *
+   * @param key Unique key to identify this scratch buffer (e.g., group index)
+   * @param requiredBytes Minimum size in bytes needed
+   * @param stream CUDA stream
+   * @return Pointer to device memory of at least requiredBytes
+   */
+  void* get(int key, size_t requiredBytes, cudaStream_t stream) {
+    if (requiredBytes == 0) {
+      return nullptr;
+    }
+
+    int device;
+    cudaGetDevice(&device);
+
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    // Create composite key from device and user key.
+    // Use 4096 as multiplier to avoid collisions and allow for future growth
+    // (SHARDED_RELAY_MAX_GROUPS = 8, so keys are at most a few hundred).
+    int64_t compositeKey = static_cast<int64_t>(device) * 4096 + key;
+    auto& entry = buffers_[compositeKey];
+
+    if (entry.buffer == nullptr || entry.size < requiredBytes) {
+      if (entry.buffer != nullptr) {
+        // Use async free to avoid blocking - memory will be freed after
+        // all preceding operations on this stream complete
+        cudaFreeAsync(entry.buffer, stream);
+      }
+
+      size_t allocSize = requiredBytes;
+      if (allocSize >= 1024 * 1024) {
+        // Round up to next 64MB boundary for larger buffers
+        allocSize =
+            ((requiredBytes + 64 * 1024 * 1024 - 1) / (64 * 1024 * 1024)) *
+            (64 * 1024 * 1024);
+      }
+
+      // Use async malloc to avoid blocking - this is critical for avoiding
+      // deadlocks when different ranks reach this point at different times
+      // while others are waiting in NCCL collectives
+      cudaError_t err = cudaMallocAsync(&entry.buffer, allocSize, stream);
+      if (err != cudaSuccess) {
+        entry.buffer = nullptr;
+        entry.size = 0;
+        return nullptr;
+      }
+      entry.size = allocSize;
+    }
+
+    return entry.buffer;
+  }
+
+  /**
+   * Clear all cached buffers. Call during shutdown or when memory pressure is
+   * high.
+   */
+  void clear(cudaStream_t stream = nullptr) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (auto& pair : buffers_) {
+      if (pair.second.buffer != nullptr) {
+        // Use async free to match async allocation
+        cudaFreeAsync(pair.second.buffer, stream);
+        pair.second.buffer = nullptr;
+        pair.second.size = 0;
+      }
+    }
+    buffers_.clear();
+  }
+
+  // Prevent copying
+  ScratchBufferCache(const ScratchBufferCache&) = delete;
+  ScratchBufferCache& operator=(const ScratchBufferCache&) = delete;
+
+ private:
+  ScratchBufferCache() = default;
+
+  ~ScratchBufferCache() {
+    // Note: Don't call cudaFree in destructor during program exit,
+    // as CUDA runtime may already be shut down.
+    // Buffers will be automatically freed when the process exits.
+  }
+
+  struct BufferEntry {
+    void* buffer = nullptr;
+    size_t size = 0;
+  };
+
+  std::mutex mutex_;
+  std::unordered_map<int64_t, BufferEntry> buffers_; // compositeKey -> buffer
+};
+
+/**
+ * GPU kernel for incremental reduction: output[i] += input[i]
+ * Used to add received chunks directly into the buffer.
+ *
+ * Kernel and launcher live in sharded_relay_allreduce_kernels.cu so the
+ * `__global__` body is preserved when the surrounding TU is compiled with
+ * `--offload-host-only` (see comments in def_build.bzl).
+ */
+
+#define LAUNCH_INCREMENTAL_ADD_KERNEL(TYPE, output, input, count, stream) \
+  launchIncrementalAddKernel<TYPE>(output, input, count, stream)
+
+/**
+ * Helper macro to dispatch incremental add kernel by datatype
+ */
+#define DISPATCH_INCREMENTAL_ADD(datatype, output, input, count, stream)       \
+  do {                                                                         \
+    switch (datatype) {                                                        \
+      case ncclInt8:                                                           \
+        LAUNCH_INCREMENTAL_ADD_KERNEL(int8_t, output, input, count, stream);   \
+        break;                                                                 \
+      case ncclUint8:                                                          \
+        LAUNCH_INCREMENTAL_ADD_KERNEL(uint8_t, output, input, count, stream);  \
+        break;                                                                 \
+      case ncclInt32:                                                          \
+        LAUNCH_INCREMENTAL_ADD_KERNEL(int32_t, output, input, count, stream);  \
+        break;                                                                 \
+      case ncclUint32:                                                         \
+        LAUNCH_INCREMENTAL_ADD_KERNEL(uint32_t, output, input, count, stream); \
+        break;                                                                 \
+      case ncclInt64:                                                          \
+        LAUNCH_INCREMENTAL_ADD_KERNEL(int64_t, output, input, count, stream);  \
+        break;                                                                 \
+      case ncclUint64:                                                         \
+        LAUNCH_INCREMENTAL_ADD_KERNEL(uint64_t, output, input, count, stream); \
+        break;                                                                 \
+      case ncclFloat16:                                                        \
+        LAUNCH_INCREMENTAL_ADD_KERNEL(__half, output, input, count, stream);   \
+        break;                                                                 \
+      case ncclFloat:                                                          \
+        LAUNCH_INCREMENTAL_ADD_KERNEL(float, output, input, count, stream);    \
+        break;                                                                 \
+      case ncclDouble:                                                         \
+        LAUNCH_INCREMENTAL_ADD_KERNEL(double, output, input, count, stream);   \
+        break;                                                                 \
+      case ncclBfloat16:                                                       \
+        LAUNCH_INCREMENTAL_ADD_KERNEL(                                         \
+            __nv_bfloat16, output, input, count, stream);                      \
+        break;                                                                 \
+      default:                                                                 \
+        break;                                                                 \
+    }                                                                          \
+  } while (0)
+
+/**
+ * GPU kernel for scaling: output[i] = output[i] / divisor
+ * Used to compute average after sum reduction (for ncclAvg operation).
+ *
+ * Kernel and launcher live in sharded_relay_allreduce_kernels.cu.
+ */
+
+#define LAUNCH_SCALE_KERNEL(TYPE, data, count, divisor, stream) \
+  launchScaleKernel<TYPE>(data, count, divisor, stream)
+
+/**
+ * Helper macro to dispatch scale kernel by datatype
+ */
+#define DISPATCH_SCALE(datatype, data, count, divisor, stream)            \
+  do {                                                                    \
+    switch (datatype) {                                                   \
+      case ncclInt8:                                                      \
+        LAUNCH_SCALE_KERNEL(int8_t, data, count, divisor, stream);        \
+        break;                                                            \
+      case ncclUint8:                                                     \
+        LAUNCH_SCALE_KERNEL(uint8_t, data, count, divisor, stream);       \
+        break;                                                            \
+      case ncclInt32:                                                     \
+        LAUNCH_SCALE_KERNEL(int32_t, data, count, divisor, stream);       \
+        break;                                                            \
+      case ncclUint32:                                                    \
+        LAUNCH_SCALE_KERNEL(uint32_t, data, count, divisor, stream);      \
+        break;                                                            \
+      case ncclInt64:                                                     \
+        LAUNCH_SCALE_KERNEL(int64_t, data, count, divisor, stream);       \
+        break;                                                            \
+      case ncclUint64:                                                    \
+        LAUNCH_SCALE_KERNEL(uint64_t, data, count, divisor, stream);      \
+        break;                                                            \
+      case ncclFloat16:                                                   \
+        LAUNCH_SCALE_KERNEL(__half, data, count, divisor, stream);        \
+        break;                                                            \
+      case ncclFloat:                                                     \
+        LAUNCH_SCALE_KERNEL(float, data, count, divisor, stream);         \
+        break;                                                            \
+      case ncclDouble:                                                    \
+        LAUNCH_SCALE_KERNEL(double, data, count, divisor, stream);        \
+        break;                                                            \
+      case ncclBfloat16:                                                  \
+        LAUNCH_SCALE_KERNEL(__nv_bfloat16, data, count, divisor, stream); \
+        break;                                                            \
+      default:                                                            \
+        break;                                                            \
+    }                                                                     \
+  } while (0)
+
+/**
+ * GPU kernel for fused incremental add + scale:
+ *   output[i] = (output[i] + input[i]) / divisor
+ *
+ * Combines DISPATCH_INCREMENTAL_ADD + DISPATCH_SCALE into a single HBM pass
+ * (read output, read input, write output once instead of twice).  Used by
+ * the active rank to merge passthrough relay scratch into recvbuff while
+ * applying the AVG divisor in one fused kernel.
+ *
+ * When divisor == 1, this collapses to a plain incremental add — but the
+ * caller should prefer DISPATCH_INCREMENTAL_ADD in that case to avoid the
+ * unnecessary divide.
+ *
+ * Kernel and launcher live in sharded_relay_allreduce_kernels.cu.
+ */
+
+#define LAUNCH_INCREMENTAL_ADD_AND_SCALE_KERNEL( \
+    TYPE, output, input, count, divisor, stream) \
+  launchIncrementalAddAndScaleKernel<TYPE>(      \
+      output, input, count, divisor, stream)
+
+/**
+ * Helper macro to dispatch fused incremental-add + scale kernel by datatype
+ */
+#define DISPATCH_INCREMENTAL_ADD_AND_SCALE(                        \
+    datatype, output, input, count, divisor, stream)               \
+  do {                                                             \
+    switch (datatype) {                                            \
+      case ncclInt8:                                               \
+        LAUNCH_INCREMENTAL_ADD_AND_SCALE_KERNEL(                   \
+            int8_t, output, input, count, divisor, stream);        \
+        break;                                                     \
+      case ncclUint8:                                              \
+        LAUNCH_INCREMENTAL_ADD_AND_SCALE_KERNEL(                   \
+            uint8_t, output, input, count, divisor, stream);       \
+        break;                                                     \
+      case ncclInt32:                                              \
+        LAUNCH_INCREMENTAL_ADD_AND_SCALE_KERNEL(                   \
+            int32_t, output, input, count, divisor, stream);       \
+        break;                                                     \
+      case ncclUint32:                                             \
+        LAUNCH_INCREMENTAL_ADD_AND_SCALE_KERNEL(                   \
+            uint32_t, output, input, count, divisor, stream);      \
+        break;                                                     \
+      case ncclInt64:                                              \
+        LAUNCH_INCREMENTAL_ADD_AND_SCALE_KERNEL(                   \
+            int64_t, output, input, count, divisor, stream);       \
+        break;                                                     \
+      case ncclUint64:                                             \
+        LAUNCH_INCREMENTAL_ADD_AND_SCALE_KERNEL(                   \
+            uint64_t, output, input, count, divisor, stream);      \
+        break;                                                     \
+      case ncclFloat16:                                            \
+        LAUNCH_INCREMENTAL_ADD_AND_SCALE_KERNEL(                   \
+            __half, output, input, count, divisor, stream);        \
+        break;                                                     \
+      case ncclFloat:                                              \
+        LAUNCH_INCREMENTAL_ADD_AND_SCALE_KERNEL(                   \
+            float, output, input, count, divisor, stream);         \
+        break;                                                     \
+      case ncclDouble:                                             \
+        LAUNCH_INCREMENTAL_ADD_AND_SCALE_KERNEL(                   \
+            double, output, input, count, divisor, stream);        \
+        break;                                                     \
+      case ncclBfloat16:                                           \
+        LAUNCH_INCREMENTAL_ADD_AND_SCALE_KERNEL(                   \
+            __nv_bfloat16, output, input, count, divisor, stream); \
+        break;                                                     \
+      default:                                                     \
+        break;                                                     \
+    }                                                              \
+  } while (0)
+
+/**
+ * GPU kernel for fused reduction: output[i] = (a[i] + b[i]) / divisor
+ * When divisor == 1, this is a simple sum: output[i] = a[i] + b[i]
+ * When divisor == 2, this computes the average: output[i] = (a[i] + b[i]) / 2
+ *
+ * Used by helper ranks to combine data from both active ranks and compute
+ * sum or average in a single kernel launch (avoiding separate add + scale).
+ *
+ * Kernel and launcher live in sharded_relay_allreduce_kernels.cu.
+ */
+
+#define LAUNCH_FUSED_REDUCE_KERNEL(                       \
+    TYPE, output, inputA, inputB, count, divisor, stream) \
+  launchFusedReduceKernel<TYPE>(output, inputA, inputB, count, divisor, stream)
+
+/**
+ * Helper macro to dispatch fused reduce kernel by datatype
+ * divisor == 1 for SUM, divisor == 2 for AVG (with 2 active ranks)
+ */
+#define DISPATCH_FUSED_REDUCE(                                              \
+    datatype, output, inputA, inputB, count, divisor, stream)               \
+  do {                                                                      \
+    switch (datatype) {                                                     \
+      case ncclInt8:                                                        \
+        LAUNCH_FUSED_REDUCE_KERNEL(                                         \
+            int8_t, output, inputA, inputB, count, divisor, stream);        \
+        break;                                                              \
+      case ncclUint8:                                                       \
+        LAUNCH_FUSED_REDUCE_KERNEL(                                         \
+            uint8_t, output, inputA, inputB, count, divisor, stream);       \
+        break;                                                              \
+      case ncclInt32:                                                       \
+        LAUNCH_FUSED_REDUCE_KERNEL(                                         \
+            int32_t, output, inputA, inputB, count, divisor, stream);       \
+        break;                                                              \
+      case ncclUint32:                                                      \
+        LAUNCH_FUSED_REDUCE_KERNEL(                                         \
+            uint32_t, output, inputA, inputB, count, divisor, stream);      \
+        break;                                                              \
+      case ncclInt64:                                                       \
+        LAUNCH_FUSED_REDUCE_KERNEL(                                         \
+            int64_t, output, inputA, inputB, count, divisor, stream);       \
+        break;                                                              \
+      case ncclUint64:                                                      \
+        LAUNCH_FUSED_REDUCE_KERNEL(                                         \
+            uint64_t, output, inputA, inputB, count, divisor, stream);      \
+        break;                                                              \
+      case ncclFloat16:                                                     \
+        LAUNCH_FUSED_REDUCE_KERNEL(                                         \
+            __half, output, inputA, inputB, count, divisor, stream);        \
+        break;                                                              \
+      case ncclFloat:                                                       \
+        LAUNCH_FUSED_REDUCE_KERNEL(                                         \
+            float, output, inputA, inputB, count, divisor, stream);         \
+        break;                                                              \
+      case ncclDouble:                                                      \
+        LAUNCH_FUSED_REDUCE_KERNEL(                                         \
+            double, output, inputA, inputB, count, divisor, stream);        \
+        break;                                                              \
+      case ncclBfloat16:                                                    \
+        LAUNCH_FUSED_REDUCE_KERNEL(                                         \
+            __nv_bfloat16, output, inputA, inputB, count, divisor, stream); \
+        break;                                                              \
+      default:                                                              \
+        break;                                                              \
+    }                                                                       \
+  } while (0)
+
+// Maximum number of helper ranks supported per group.
+// With exactly 2 active ranks, this implies a maximum communicator size of
+// SHARDED_RELAY_MAX_HELPERS + 2 ranks for this algorithm.
+static constexpr int SHARDED_RELAY_MAX_HELPERS = 8;
+
+/**
+ * Rank Configuration for Sharded Relay AllReduce
+ *
+ * Holds parsed active and helper rank information for a single group.
+ * NOTE: This implementation requires exactly 2 active ranks per group.
+ */
+struct ShardedRelayRankConfig {
+  int activeRanks[2]; // Active rank IDs (exactly 2 required)
+  int nActiveRanks; // Number of active ranks (must be 2)
+  int helperRanks[SHARDED_RELAY_MAX_HELPERS]; // Helper rank IDs
+  int numHelpers; // Number of helper ranks
+  bool isActiveRank; // Is current rank active?
+  int myActiveIndex; // Index in activeRanks array (-1 if helper)
+  int myHelperIndex; // Index in helperRanks array (-1 if active)
+};
+
+/**
+ * Build rank configuration from provided active ranks array.
+ * NOTE: This implementation requires exactly 2 active ranks per group.
+ *
+ * @param nRanks Total number of ranks in the communicator
+ * @param rank Current rank ID
+ * @param activeRanksInput Array of active rank IDs from caller (must have
+ * exactly 2)
+ * @param nActiveRanksInput Number of active ranks (must be exactly 2)
+ * @param config Output configuration struct
+ * @return true if configuration is valid, false otherwise
+ */
+static bool buildShardedRelayRankConfig(
+    int nRanks,
+    int rank,
+    const int* activeRanksInput,
+    int nActiveRanksInput,
+    ShardedRelayRankConfig& config) {
+  config.nActiveRanks = 0;
+  config.numHelpers = 0;
+  config.isActiveRank = false;
+  config.myActiveIndex = -1;
+  config.myHelperIndex = -1;
+
+  // Validate input - require EXACTLY 2 active ranks
+  if (activeRanksInput == nullptr || nActiveRanksInput != 2) {
+    return false;
+  }
+
+  // Copy active ranks and validate
+  for (int i = 0; i < 2; i++) {
+    int rankId = activeRanksInput[i];
+    if (rankId >= 0 && rankId < nRanks) {
+      config.activeRanks[config.nActiveRanks++] = rankId;
+    }
+  }
+
+  // Validate: need exactly 2 valid active ranks
+  if (config.nActiveRanks != 2) {
+    return false;
+  }
+
+  // Build list of helper ranks (all ranks NOT in activeRanks).
+  // Bounded by SHARDED_RELAY_MAX_HELPERS to prevent stack buffer overflow
+  // for communicators with more than (SHARDED_RELAY_MAX_HELPERS + 2) ranks.
+  for (int r = 0; r < nRanks; r++) {
+    bool isActive = false;
+    for (int a = 0; a < config.nActiveRanks; a++) {
+      if (r == config.activeRanks[a]) {
+        isActive = true;
+        break;
+      }
+    }
+    if (!isActive) {
+      if (config.numHelpers >= SHARDED_RELAY_MAX_HELPERS) {
+        return false;
+      }
+      config.helperRanks[config.numHelpers++] = r;
+    }
+  }
+
+  // Validate: need at least 1 helper
+  if (config.numHelpers < 1) {
+    return false;
+  }
+
+  // Determine if this rank is active
+  for (int a = 0; a < config.nActiveRanks; a++) {
+    if (rank == config.activeRanks[a]) {
+      config.isActiveRank = true;
+      config.myActiveIndex = a;
+      break;
+    }
+  }
+
+  // For helpers, determine which chunk index this rank handles
+  if (!config.isActiveRank) {
+    for (int i = 0; i < config.numHelpers; i++) {
+      if (config.helperRanks[i] == rank) {
+        config.myHelperIndex = i;
+        break;
+      }
+    }
+  }
+  return true;
+}
+
+/**
+ * Fused Multi-Group Sharded Relay AllReduce — Phase-Synchronized Passthrough
+ *
+ * This implementation executes multiple sharded relay allreduces in a single
+ * fused call, coordinating phases across ALL groups to prevent XGMI link
+ * contention.  Helpers act as pure passthrough (no local compute); all
+ * reductions are performed on the active ranks.
+ *
+ * Phase-Synchronized Execution with Passthrough Helpers:
+ * ======================================================
+ *
+ *   PHASE 1 (active→helpers): ALL groups scatter simultaneously.
+ *            Both active ranks send their chunks to helpers.
+ *            Helpers receive into a two-slot buffer:
+ *              slot 0 = data from active rank a0
+ *              slot 1 = data from active rank a1
+ *            All XGMI links carry unidirectional traffic: active→helper
+ *
+ *   PHASE 2 (helpers→active, batched): ALL helpers forward simultaneously
+ *            in ONE ncclGroupStart/End.  Each helper sends slot 0 (a0's data)
+ *            to a1 and slot 1 (a1's data) to a0.  Active rank receives all
+ *            numHelpers chunks into relay scratch (numHelpers × chunkSize).
+ *
+ *   PHASE 3 (active reduce): Active ranks add the relay scratch to recvBuff
+ *            using a single fused add+scale kernel
+ *            (recvBuff[i] = (recvBuff[i] + scratch[i]) / nActiveRanks)
+ *            over the whole relay region (numHelpers × chunkSize) — halves
+ *            HBM traffic vs separate add + scale passes.
+ *
+ *   PHASE 4 (active↔active): Direct exchange of the last chunk between
+ *            the two active ranks (same as the original algorithm).
+ *
+ *   PHASE 5 (active reduce): Final reduction on the direct-exchange chunk.
+ *            Compute-only, no XGMI traffic.
+ *
+ * Memory Model:
+ * =============
+ * Each rank is ACTIVE for exactly ONE group (has real tensor data).
+ * For other groups, the rank is a HELPER (uses provided two-slot scratch).
+ *
+ * For ACTIVE ranks:
+ *   - sendBuff and recvBuff can be the same (in-place) or different
+ *   - Relay scratch: numHelpers × chunkSize (from ScratchBufferCache, batched)
+ *   - Direct-exchange scratch: (nActiveRanks-1) × directChunkSize (in-place)
+ *
+ * For HELPER ranks:
+ *   - Buffer must hold nActiveRanks × chunkSize elements (two slots)
+ *   - Slot a at offset a × chunkSize holds data from active rank a
+ *   - Each helper group MUST have its own buffer (no aliasing across groups)
+ *     because all groups are processed simultaneously under phase-sync
+ */
+HOT ncclResult_t ncclShardedRelayMultiGroupAllReduceImpl(
+    const void* const* sendBuffs,
+    void* const* recvBuffs,
+    const size_t* counts,
+    ncclDataType_t datatype,
+    ncclRedOp_t op,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const int* const* allActiveRanks,
+    int nActiveRanksPerGroup,
+    int nGroups) {
+  int nRanks, rank;
+  NCCLCHECK(ncclCommCount(comm, &nRanks));
+  NCCLCHECK(ncclCommUserRank(comm, &rank));
+
+  // Require at least 2 active ranks per group
+  if (nActiveRanksPerGroup < 2) {
+    return ncclInvalidArgument;
+  }
+
+  // Check if all counts are zero
+  bool allZero = true;
+  for (int g = 0; g < nGroups; g++) {
+    if (counts[g] != 0) {
+      allZero = false;
+      break;
+    }
+  }
+  if (allZero) {
+    return ncclSuccess;
+  }
+
+  // Validate operation - only SUM and AVG are supported
+  if (op != ncclSum && op != ncclAvg) {
+    return ncclInvalidArgument;
+  }
+
+  if (nGroups < 1 || nGroups > SHARDED_RELAY_MAX_GROUPS) {
+    return ncclInvalidArgument;
+  }
+
+  if (sendBuffs == nullptr || recvBuffs == nullptr ||
+      allActiveRanks == nullptr || counts == nullptr) {
+    return ncclInvalidArgument;
+  }
+
+  size_t elementSize = ncclTypeSize(datatype);
+
+  // Compute divisor for reduction: 1 for SUM, nActiveRanksPerGroup for AVG
+  int reductionDivisor = (op == ncclAvg) ? nActiveRanksPerGroup : 1;
+
+  // =========================================================================
+  // BUILD RANK CONFIGURATION FOR ALL GROUPS
+  // =========================================================================
+  ShardedRelayRankConfig configs[SHARDED_RELAY_MAX_GROUPS];
+  int myActiveGroup = -1; // Which group is this rank active for?
+
+  for (int g = 0; g < nGroups; g++) {
+    if (!buildShardedRelayRankConfig(
+            nRanks,
+            rank,
+            allActiveRanks[g],
+            nActiveRanksPerGroup,
+            configs[g])) {
+      return ncclInvalidArgument;
+    }
+    if (configs[g].isActiveRank) {
+      myActiveGroup = g;
+    }
+  }
+
+  // All groups should have the same number of helpers (same chunk structure)
+  int numHelpers = configs[0].numHelpers;
+  int numChunks = numHelpers + 1; // 7 for 8 ranks with 2 active per group
+
+  // =========================================================================
+  // CALCULATE PER-GROUP CHUNK SIZES
+  // =========================================================================
+  // Each group may have a different count, so we compute chunk sizes per group
+  size_t chunkSizes[SHARDED_RELAY_MAX_GROUPS];
+  size_t lastChunkSizes[SHARDED_RELAY_MAX_GROUPS];
+  size_t directChunkOffsets[SHARDED_RELAY_MAX_GROUPS];
+  size_t directChunkSizes[SHARDED_RELAY_MAX_GROUPS];
+
+  for (int g = 0; g < nGroups; g++) {
+    size_t count = counts[g];
+
+    // Skip groups with count == 0; the per-phase loops below already check
+    // counts[g] == 0 and bypass NCCL ops for those groups, so chunkSizes
+    // entries for zero-count groups are never read.
+    if (count == 0) {
+      chunkSizes[g] = 0;
+      lastChunkSizes[g] = 0;
+      directChunkOffsets[g] = 0;
+      directChunkSizes[g] = 0;
+      continue;
+    }
+
+    // Calculate chunk size (aligned to cache line).
+    // The algorithm scatters numChunks chunks of size chunkSize over the
+    // input buffer, which requires count >= numChunks * chunkSize. When the
+    // per-chunk size rounded down to CHUNK_ALIGN_ELEMENTS is zero, the
+    // buffer is too small to scatter and the algorithm cannot proceed
+    // safely; the caller should fall back to a regular allreduce.
+    size_t chunkSize = count / numChunks;
+    chunkSize = (chunkSize / CHUNK_ALIGN_ELEMENTS) * CHUNK_ALIGN_ELEMENTS;
+    if (chunkSize == 0) {
+      return ncclInvalidArgument;
+    }
+    chunkSizes[g] = chunkSize;
+
+    // Calculate the size of the last chunk
+    size_t totalChunkedElements = static_cast<size_t>(numChunks) * chunkSize;
+    size_t lastChunkSize = chunkSize;
+    if (totalChunkedElements < count) {
+      lastChunkSize = chunkSize + (count - totalChunkedElements);
+    }
+    lastChunkSizes[g] = lastChunkSize;
+
+    // Direct exchange chunk info
+    int directChunkIndex = numHelpers;
+    directChunkOffsets[g] = static_cast<size_t>(directChunkIndex) * chunkSize;
+    directChunkSizes[g] = lastChunkSize;
+  }
+
+  // =========================================================================
+  // SCRATCH BUFFER ALLOCATION
+  // =========================================================================
+  // Relay scratch: numHelpers × chunkSize for batched passthrough recv.
+  //   Sized to receive ALL forwarded chunks from helpers in a single
+  //   ncclGroupStart/End — matches original phase-sync structure.
+  // Direct-exchange scratch: (nActiveRanks-1) × directChunkSize (in-place)
+  void* relayScratch = nullptr;
+  void* directScratch = nullptr;
+
+  if (myActiveGroup >= 0 && counts[myActiveGroup] > 0) {
+    // Relay scratch sized to numHelpers × chunkSize so that the active rank
+    // can receive ALL forwarded chunks in one batched phase.
+    size_t relayScratchBytes = static_cast<size_t>(numHelpers) *
+        chunkSizes[myActiveGroup] * elementSize;
+    relayScratch = ScratchBufferCache::getInstance().get(
+        SHARDED_RELAY_MAX_GROUPS, relayScratchBytes, stream);
+    if (relayScratch == nullptr) {
+      return ncclInternalError;
+    }
+
+    // Direct-exchange scratch (in-place only)
+    bool isInPlace = (sendBuffs[myActiveGroup] == recvBuffs[myActiveGroup]);
+    if (isInPlace) {
+      int nOtherActives = configs[myActiveGroup].nActiveRanks - 1;
+      size_t directScratchBytes = static_cast<size_t>(nOtherActives) *
+          directChunkSizes[myActiveGroup] * elementSize;
+      directScratch = ScratchBufferCache::getInstance().get(
+          myActiveGroup, directScratchBytes, stream);
+      if (directScratch == nullptr) {
+        return ncclInternalError;
+      }
+    }
+  }
+
+  // =========================================================================
+  // PHASE 1 (active→helpers): Both active ranks scatter chunks to helpers
+  // =========================================================================
+  // Helpers receive from each active rank into offset-based slots:
+  //   slot a at offset (a × chunkSize) holds data from active rank a
+  NCCLCHECK(ncclGroupStart());
+
+  for (int g = 0; g < nGroups; g++) {
+    if (counts[g] == 0)
+      continue;
+    const ShardedRelayRankConfig& cfg = configs[g];
+    const void* sendbuff = sendBuffs[g];
+    void* recvbuff = recvBuffs[g];
+    size_t chunkSize = chunkSizes[g];
+
+    if (cfg.isActiveRank) {
+      // Active rank: send my chunk h to helper h
+      for (int h = 0; h < cfg.numHelpers; h++) {
+        int helperRank = cfg.helperRanks[h];
+        size_t chunkOffset = static_cast<size_t>(h) * chunkSize;
+
+        NCCLCHECK(ncclSend(
+            static_cast<const char*>(sendbuff) + chunkOffset * elementSize,
+            chunkSize,
+            datatype,
+            helperRank,
+            comm,
+            stream));
+      }
+    } else {
+      // Helper rank: receive from each active rank into slot a
+      for (int a = 0; a < cfg.nActiveRanks; a++) {
+        int activeRank = cfg.activeRanks[a];
+        size_t helperOffset = static_cast<size_t>(a) * chunkSize;
+
+        NCCLCHECK(ncclRecv(
+            static_cast<char*>(recvbuff) + helperOffset * elementSize,
+            chunkSize,
+            datatype,
+            activeRank,
+            comm,
+            stream));
+      }
+    }
+  }
+
+  NCCLCHECK(ncclGroupEnd());
+
+  // For out-of-place active groups: copy sendbuff relay region to recvbuff
+  // so that the incremental add in Phase 3 works uniformly.
+  if (myActiveGroup >= 0 && counts[myActiveGroup] > 0) {
+    const void* sendbuff = sendBuffs[myActiveGroup];
+    void* recvbuff = recvBuffs[myActiveGroup];
+    if (sendbuff != recvbuff) {
+      size_t relayBytes = static_cast<size_t>(numHelpers) *
+          chunkSizes[myActiveGroup] * elementSize;
+      cudaMemcpyAsync(
+          recvbuff, sendbuff, relayBytes, cudaMemcpyDeviceToDevice, stream);
+    }
+  }
+
+  // =========================================================================
+  // PHASE 2 (helpers→active, batched): Passthrough forward
+  // =========================================================================
+  // ALL helpers forward simultaneously in ONE ncclGroupStart/End.
+  // Each helper sends slot 0 (a0's data) → a1 and slot 1 (a1's data) → a0.
+  // Active rank receives all numHelpers chunks into relay scratch
+  // (numHelpers × chunkSize), at offset h × chunkSize per helper h.
+  NCCLCHECK(ncclGroupStart());
+
+  for (int g = 0; g < nGroups; g++) {
+    if (counts[g] == 0)
+      continue;
+    const ShardedRelayRankConfig& cfg = configs[g];
+    void* recvbuff = recvBuffs[g];
+    size_t chunkSize = chunkSizes[g];
+
+    if (!cfg.isActiveRank) {
+      // I am a helper for group g: forward each slot to the OTHER active.
+      // slot a → activeRanks[1-a] (swap for 2 active ranks)
+      for (int a = 0; a < cfg.nActiveRanks; a++) {
+        int targetActive = cfg.activeRanks[1 - a];
+        NCCLCHECK(ncclSend(
+            static_cast<const char*>(recvbuff) +
+                static_cast<size_t>(a) * chunkSize * elementSize,
+            chunkSize,
+            datatype,
+            targetActive,
+            comm,
+            stream));
+      }
+    } else {
+      // Active rank: receive ALL forwarded data from each helper into the
+      // relay scratch at offset h × chunkSize.
+      for (int h = 0; h < cfg.numHelpers; h++) {
+        int helperRank = cfg.helperRanks[h];
+        size_t scratchOffset = static_cast<size_t>(h) * chunkSize;
+        NCCLCHECK(ncclRecv(
+            static_cast<char*>(relayScratch) + scratchOffset * elementSize,
+            chunkSize,
+            datatype,
+            helperRank,
+            comm,
+            stream));
+      }
+    }
+  }
+
+  NCCLCHECK(ncclGroupEnd());
+
+  // =========================================================================
+  // PHASE 3 (active reduce): Fused add + scale on the relay region
+  // =========================================================================
+  // Single-pass fused kernel: recvbuff[i] = (recvbuff[i] + relayScratch[i]) /
+  // divisor.  Halves HBM traffic vs separate ADD + SCALE passes.
+  for (int g = 0; g < nGroups; g++) {
+    if (counts[g] == 0)
+      continue;
+    const ShardedRelayRankConfig& cfg = configs[g];
+    if (cfg.isActiveRank) {
+      void* recvbuff = recvBuffs[g];
+      size_t chunkSize = chunkSizes[g];
+      size_t relayTotal = static_cast<size_t>(numHelpers) * chunkSize;
+
+      if (reductionDivisor > 1) {
+        // Fused: add + AVG-scale in one HBM pass.
+        DISPATCH_INCREMENTAL_ADD_AND_SCALE(
+            datatype,
+            recvbuff,
+            relayScratch,
+            relayTotal,
+            reductionDivisor,
+            stream);
+      } else {
+        // SUM only: plain incremental add.
+        DISPATCH_INCREMENTAL_ADD(
+            datatype, recvbuff, relayScratch, relayTotal, stream);
+      }
+    }
+  }
+
+  // =========================================================================
+  // PHASE 4 (active↔active): Direct exchange between active ranks
+  // =========================================================================
+  NCCLCHECK(ncclGroupStart());
+
+  for (int g = 0; g < nGroups; g++) {
+    if (counts[g] == 0)
+      continue;
+    const ShardedRelayRankConfig& cfg = configs[g];
+
+    if (cfg.isActiveRank) {
+      const void* sendbuff = sendBuffs[g];
+      void* recvbuff = recvBuffs[g];
+      bool isInPlace = (sendbuff == recvbuff);
+      size_t directChunkOffset = directChunkOffsets[g];
+      size_t directChunkSize = directChunkSizes[g];
+
+      // Send my direct chunk to all other active ranks
+      for (int a = 0; a < cfg.nActiveRanks; a++) {
+        if (a == cfg.myActiveIndex)
+          continue;
+        int otherActiveRank = cfg.activeRanks[a];
+
+        NCCLCHECK(ncclSend(
+            static_cast<const char*>(sendbuff) +
+                directChunkOffset * elementSize,
+            directChunkSize,
+            datatype,
+            otherActiveRank,
+            comm,
+            stream));
+      }
+
+      // Receive direct chunks from all other active ranks
+      int scratchIdx = 0;
+      for (int a = 0; a < cfg.nActiveRanks; a++) {
+        if (a == cfg.myActiveIndex)
+          continue;
+        int otherActiveRank = cfg.activeRanks[a];
+
+        if (isInPlace) {
+          size_t scratchOffset =
+              static_cast<size_t>(scratchIdx) * directChunkSize;
+          NCCLCHECK(ncclRecv(
+              static_cast<char*>(directScratch) + scratchOffset * elementSize,
+              directChunkSize,
+              datatype,
+              otherActiveRank,
+              comm,
+              stream));
+        } else {
+          NCCLCHECK(ncclRecv(
+              static_cast<char*>(recvbuff) + directChunkOffset * elementSize,
+              directChunkSize,
+              datatype,
+              otherActiveRank,
+              comm,
+              stream));
+        }
+        scratchIdx++;
+      }
+    }
+  }
+
+  NCCLCHECK(ncclGroupEnd());
+
+  // =========================================================================
+  // PHASE 5 (active reduce): Final reduction on the direct-exchange chunk
+  // =========================================================================
+  for (int g = 0; g < nGroups; g++) {
+    if (counts[g] == 0)
+      continue;
+    const ShardedRelayRankConfig& cfg = configs[g];
+
+    if (cfg.isActiveRank) {
+      const void* sendbuff = sendBuffs[g];
+      void* recvbuff = recvBuffs[g];
+      bool isInPlace = (sendbuff == recvbuff);
+      size_t directChunkOffset = directChunkOffsets[g];
+      size_t directChunkSize = directChunkSizes[g];
+
+      void* directChunkDst =
+          static_cast<char*>(recvbuff) + directChunkOffset * elementSize;
+
+      if (isInPlace) {
+        int scratchIdx2 = 0;
+        for (int a = 0; a < cfg.nActiveRanks; a++) {
+          if (a == cfg.myActiveIndex)
+            continue;
+          size_t scratchOffset =
+              static_cast<size_t>(scratchIdx2) * directChunkSize;
+          const void* received = static_cast<const char*>(directScratch) +
+              scratchOffset * elementSize;
+          DISPATCH_INCREMENTAL_ADD(
+              datatype, directChunkDst, received, directChunkSize, stream);
+          scratchIdx2++;
+        }
+
+        if (reductionDivisor > 1) {
+          DISPATCH_SCALE(
+              datatype,
+              directChunkDst,
+              directChunkSize,
+              reductionDivisor,
+              stream);
+        }
+      } else {
+        const void* localContribution = static_cast<const char*>(sendbuff) +
+            directChunkOffset * elementSize;
+        const void* receivedContribution = directChunkDst;
+
+        DISPATCH_FUSED_REDUCE(
+            datatype,
+            directChunkDst,
+            localContribution,
+            receivedContribution,
+            directChunkSize,
+            reductionDivisor,
+            stream);
+      }
+    }
+  }
+
+  return ncclSuccess;
+}

--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.h
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "nccl.h"
+
+// Maximum number of groups supported in multi-group allreduce
+#define SHARDED_RELAY_MAX_GROUPS 8
+
+/**
+ * Fused Multi-Group Sharded Relay AllReduce for 2D Sparse Parallelism.
+ *
+ * This API performs multiple sharded relay allreduces in a single fused call,
+ * coordinating phases across all groups to prevent XGMI link contention.
+ *
+ * Problem with Separate Calls:
+ * ============================
+ * When 4 separate sharded relay allreduces run in parallel (one per sparse
+ * group), different groups may be in different phases:
+ *   - Group [0,1] doing active→helpers (sending on links 3→0, 3→1)
+ *   - Group [2,3] doing helpers→active (receiving on links 3→0, 3→1)
+ * This causes bidirectional contention on shared XGMI links, degrading
+ * bandwidth by up to 10x.
+ *
+ * Solution - Phase-Synchronized Execution with Passthrough Helpers:
+ * =================================================================
+ * This fused API executes ALL groups in lockstep phases:
+ *
+ *   Phase 1: ALL groups scatter (active→helpers) simultaneously.
+ *            Each helper receives one chunk per active rank into a
+ *            two-slot helper buffer (slot 0 from a0, slot 1 from a1).
+ *
+ *   Phase 2: ALL groups forward (helpers→other active) simultaneously.
+ *            Helpers act as PURE PASSTHROUGH (no local compute):
+ *            they forward slot 0 to a1 and slot 1 to a0.  Active ranks
+ *            receive into a per-group recv-scratch slot.
+ *
+ *   Phase 3: ALL active ranks reduce the numHelpers helper-relayed chunks
+ *            into their own active buffer (pipelined with Phase 2 recvs)
+ *            and apply the AVG scaling once across the reduced region.
+ *
+ *   Phase 4: ALL groups direct-exchange the last (chunk N) data
+ *            simultaneously between the two active ranks.
+ *
+ *   Phase 5: Active ranks perform the final reduction on the directly
+ *            exchanged chunk.
+ *
+ * Since all groups are in the same phase at any time, XGMI links carry
+ * unidirectional traffic only, eliminating contention.
+ *
+ * Helper-Buffer Contract (passthrough-at-helper):
+ * ===============================================
+ * Helpers no longer perform local reductions; they simply forward each
+ * received chunk to the OTHER active rank.  Two slots are needed per
+ * helper group so that the recv from a0 (slot 0) and the recv from a1
+ * (slot 1) can proceed concurrently — without two slots, a helper would
+ * have to serialize the two directions and halve its instantaneous
+ * network bandwidth.
+ *
+ * Caller MUST supply at least
+ *   nActiveRanksPerGroup × chunkSize_aligned
+ * elements per helper group, where:
+ *   chunkSize_aligned = (per_group_count / numChunks) rounded down to
+ *                       CHUNK_ALIGN_ELEMENTS (128 elements).
+ * Returns ncclInvalidArgument when per_group_count < numChunks × 128
+ * (the buffer is too small to scatter); callers should fall back to a
+ * regular allreduce in that case.
+ *
+ * Across the (nGroups - 1) helper groups per rank, that totals:
+ *   (nGroups - 1) × nActiveRanksPerGroup × chunkSize
+ * For the BM-FM 4-group / 2-active topology this is:
+ *   3 × 2 × chunkSize = 6 × chunkSize per rank.
+ *
+ * Memory Model:
+ * =============
+ * Each rank is ACTIVE for exactly ONE group (has real tensor data).
+ * For other groups, the rank is a HELPER (uses provided two-slot scratch).
+ * The caller must provide:
+ *   - sendBuffs[nGroups]: One buffer per group
+ *   - recvBuffs[nGroups]: One buffer per group
+ *   - For the group where rank is active: full per_group_counts[g] elements
+ *   - For other groups: two-slot scratch (>= nActiveRanks * chunkSize)
+ *   - Each helper group MUST have its own buffer (no aliasing across groups)
+ *     because all groups are processed simultaneously under phase-sync
+ *
+ * 2D Sparse Parallelism Example (8 GPUs, 4 groups):
+ * =================================================
+ *   Group 0: activeRanks = {0, 1}, helpers = {2,3,4,5,6,7}
+ *   Group 1: activeRanks = {2, 3}, helpers = {0,1,4,5,6,7}
+ *   Group 2: activeRanks = {4, 5}, helpers = {0,1,2,3,6,7}
+ *   Group 3: activeRanks = {6, 7}, helpers = {0,1,2,3,4,5}
+ *
+ * @param sendBuffs Array of send buffer pointers (one per group)
+ * @param recvBuffs Array of receive buffer pointers (one per group)
+ * @param counts Array of element counts (one per group, allows different sizes)
+ * @param datatype NCCL data type
+ * @param op Reduction operation (only ncclSum and ncclAvg supported)
+ * @param comm NCCL communicator
+ * @param stream CUDA stream
+ * @param allActiveRanks 2D array of active ranks
+ * [nGroups][nActiveRanksPerGroup]
+ * @param nActiveRanksPerGroup Number of active ranks per group (typically 2)
+ * @param nGroups Number of groups (typically 4 for 8-GPU node)
+ * @return ncclResult_t Success or error code
+ */
+ncclResult_t ncclShardedRelayMultiGroupAllReduceImpl(
+    const void* const* sendBuffs,
+    void* const* recvBuffs,
+    const size_t* counts,
+    ncclDataType_t datatype,
+    ncclRedOp_t op,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const int* const* allActiveRanks,
+    int nActiveRanksPerGroup,
+    int nGroups);

--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce_kernels.cu
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce_kernels.cu
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "sharded_relay_allreduce_kernels.h"
+
+/**
+ * GPU kernel for incremental reduction: output[i] += input[i]
+ * Used to add received chunks directly into the buffer.
+ */
+template <typename T>
+__global__ void incrementalAddKernel(T* output, const T* input, size_t count) {
+  size_t threadId = blockIdx.x * blockDim.x + threadIdx.x;
+  size_t totalThreads = blockDim.x * gridDim.x;
+
+  for (size_t elemIdx = threadId; elemIdx < count; elemIdx += totalThreads) {
+    output[elemIdx] += input[elemIdx];
+  }
+}
+
+template <typename T>
+void launchIncrementalAddKernel(
+    void* output,
+    const void* input,
+    size_t count,
+    cudaStream_t stream) {
+  const int blockSize = 256;
+  int gridSize = (count + blockSize - 1) / blockSize;
+  incrementalAddKernel<T><<<gridSize, blockSize, 0, stream>>>(
+      static_cast<T*>(output), static_cast<const T*>(input), count);
+}
+
+/**
+ * GPU kernel for scaling: output[i] = output[i] / divisor
+ * Used to compute average after sum reduction (for ncclAvg operation).
+ */
+template <typename T>
+__global__ void scaleKernel(T* data, size_t count, int divisor) {
+  size_t threadId = blockIdx.x * blockDim.x + threadIdx.x;
+  size_t totalThreads = blockDim.x * gridDim.x;
+
+  for (size_t elemIdx = threadId; elemIdx < count; elemIdx += totalThreads) {
+    data[elemIdx] = data[elemIdx] / static_cast<T>(divisor);
+  }
+}
+
+template <typename T>
+void launchScaleKernel(
+    void* data,
+    size_t count,
+    int divisor,
+    cudaStream_t stream) {
+  const int blockSize = 256;
+  int gridSize = (count + blockSize - 1) / blockSize;
+  scaleKernel<T><<<gridSize, blockSize, 0, stream>>>(
+      static_cast<T*>(data), count, divisor);
+}
+
+/**
+ * GPU kernel for fused incremental add + scale:
+ *   output[i] = (output[i] + input[i]) / divisor
+ *
+ * Combines DISPATCH_INCREMENTAL_ADD + DISPATCH_SCALE into a single HBM pass
+ * (read output, read input, write output once instead of twice).  Used by
+ * the active rank to merge passthrough relay scratch into recvbuff while
+ * applying the AVG divisor in one fused kernel.
+ *
+ * When divisor == 1, this collapses to a plain incremental add — but the
+ * caller should prefer DISPATCH_INCREMENTAL_ADD in that case to avoid the
+ * unnecessary divide.
+ */
+template <typename T>
+__global__ void incrementalAddAndScaleKernel(
+    T* output,
+    const T* input,
+    size_t count,
+    int divisor) {
+  size_t threadId = blockIdx.x * blockDim.x + threadIdx.x;
+  size_t totalThreads = blockDim.x * gridDim.x;
+
+  for (size_t elemIdx = threadId; elemIdx < count; elemIdx += totalThreads) {
+    T sum = output[elemIdx] + input[elemIdx];
+    if (divisor > 1) {
+      output[elemIdx] = sum / static_cast<T>(divisor);
+    } else {
+      output[elemIdx] = sum;
+    }
+  }
+}
+
+template <typename T>
+void launchIncrementalAddAndScaleKernel(
+    void* output,
+    const void* input,
+    size_t count,
+    int divisor,
+    cudaStream_t stream) {
+  const int blockSize = 256;
+  int gridSize = (count + blockSize - 1) / blockSize;
+  incrementalAddAndScaleKernel<T><<<gridSize, blockSize, 0, stream>>>(
+      static_cast<T*>(output), static_cast<const T*>(input), count, divisor);
+}
+
+/**
+ * GPU kernel for fused reduction: output[i] = (a[i] + b[i]) / divisor
+ * When divisor == 1, this is a simple sum: output[i] = a[i] + b[i]
+ * When divisor == 2, this computes the average: output[i] = (a[i] + b[i]) / 2
+ *
+ * Used by helper ranks to combine data from both active ranks and compute
+ * sum or average in a single kernel launch (avoiding separate add + scale).
+ */
+template <typename T>
+__global__ void fusedReduceKernel(
+    T* output,
+    const T* inputA,
+    const T* inputB,
+    size_t count,
+    int divisor) {
+  size_t threadId = blockIdx.x * blockDim.x + threadIdx.x;
+  size_t totalThreads = blockDim.x * gridDim.x;
+
+  for (size_t elemIdx = threadId; elemIdx < count; elemIdx += totalThreads) {
+    T sum = inputA[elemIdx] + inputB[elemIdx];
+    if (divisor > 1) {
+      output[elemIdx] = sum / static_cast<T>(divisor);
+    } else {
+      output[elemIdx] = sum;
+    }
+  }
+}
+
+template <typename T>
+void launchFusedReduceKernel(
+    void* output,
+    const void* inputA,
+    const void* inputB,
+    size_t count,
+    int divisor,
+    cudaStream_t stream) {
+  const int blockSize = 256;
+  int gridSize = (count + blockSize - 1) / blockSize;
+  fusedReduceKernel<T><<<gridSize, blockSize, 0, stream>>>(
+      static_cast<T*>(output),
+      static_cast<const T*>(inputA),
+      static_cast<const T*>(inputB),
+      count,
+      divisor);
+}
+
+// Explicit template instantiations for every dtype used by the DISPATCH_*
+// macros in sharded_relay_allreduce.cc.  Without these, the symbols would
+// not exist with external linkage in the device object, and the host TU
+// (which only sees `extern template` declarations via the header) would
+// fail to link the launchers — leaving the underlying `__global__`
+// kernels' host stubs unresolved at runtime.
+#define RCCLX_INSTANTIATE_RELAY_KERNELS(T)                                 \
+  template void launchIncrementalAddKernel<T>(                             \
+      void* output, const void* input, size_t count, cudaStream_t stream); \
+  template void launchScaleKernel<T>(                                      \
+      void* data, size_t count, int divisor, cudaStream_t stream);         \
+  template void launchIncrementalAddAndScaleKernel<T>(                     \
+      void* output,                                                        \
+      const void* input,                                                   \
+      size_t count,                                                        \
+      int divisor,                                                         \
+      cudaStream_t stream);                                                \
+  template void launchFusedReduceKernel<T>(                                \
+      void* output,                                                        \
+      const void* inputA,                                                  \
+      const void* inputB,                                                  \
+      size_t count,                                                        \
+      int divisor,                                                         \
+      cudaStream_t stream);
+
+RCCLX_INSTANTIATE_RELAY_KERNELS(int8_t)
+RCCLX_INSTANTIATE_RELAY_KERNELS(uint8_t)
+RCCLX_INSTANTIATE_RELAY_KERNELS(int32_t)
+RCCLX_INSTANTIATE_RELAY_KERNELS(uint32_t)
+RCCLX_INSTANTIATE_RELAY_KERNELS(int64_t)
+RCCLX_INSTANTIATE_RELAY_KERNELS(uint64_t)
+RCCLX_INSTANTIATE_RELAY_KERNELS(__half)
+RCCLX_INSTANTIATE_RELAY_KERNELS(float)
+RCCLX_INSTANTIATE_RELAY_KERNELS(double)
+RCCLX_INSTANTIATE_RELAY_KERNELS(__nv_bfloat16)
+
+#undef RCCLX_INSTANTIATE_RELAY_KERNELS

--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce_kernels.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce_kernels.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <hip/hip_bf16.h>
+#include <hip/hip_bfloat16.h>
+#include <hip/hip_fp16.h>
+#include <cstddef>
+#include <cstdint>
+
+#include "nccl.h"
+
+/*
+ * Host-callable launchers for the sharded-relay GPU kernels.
+ *
+ * These templates are DEFINED in
+ * `sharded_relay_allreduce_kernels.cu`, which is compiled as a
+ * monolithic (non-RDC) HIP translation unit so that the host stub
+ * for the `<<<...>>>` launch and the matching `__global__` kernel
+ * body live in the same TU.  We forward-declare every
+ * instantiation that the host TU's dispatch macros may reference,
+ * so the host TU never tries to instantiate them itself.
+ */
+
+template <typename T>
+void launchIncrementalAddKernel(
+    void* output,
+    const void* input,
+    size_t count,
+    cudaStream_t stream);
+
+template <typename T>
+void launchScaleKernel(
+    void* data,
+    size_t count,
+    int divisor,
+    cudaStream_t stream);
+
+template <typename T>
+void launchIncrementalAddAndScaleKernel(
+    void* output,
+    const void* input,
+    size_t count,
+    int divisor,
+    cudaStream_t stream);
+
+template <typename T>
+void launchFusedReduceKernel(
+    void* output,
+    const void* inputA,
+    const void* inputB,
+    size_t count,
+    int divisor,
+    cudaStream_t stream);
+
+// Suppress instantiation in the host TU; the actual instantiations live in
+// sharded_relay_allreduce_kernels.cu.
+#define RCCLX_DECLARE_RELAY_KERNEL_INSTANTIATIONS(T)                       \
+  extern template void launchIncrementalAddKernel<T>(                      \
+      void* output, const void* input, size_t count, cudaStream_t stream); \
+  extern template void launchScaleKernel<T>(                               \
+      void* data, size_t count, int divisor, cudaStream_t stream);         \
+  extern template void launchIncrementalAddAndScaleKernel<T>(              \
+      void* output,                                                        \
+      const void* input,                                                   \
+      size_t count,                                                        \
+      int divisor,                                                         \
+      cudaStream_t stream);                                                \
+  extern template void launchFusedReduceKernel<T>(                         \
+      void* output,                                                        \
+      const void* inputA,                                                  \
+      const void* inputB,                                                  \
+      size_t count,                                                        \
+      int divisor,                                                         \
+      cudaStream_t stream);
+
+RCCLX_DECLARE_RELAY_KERNEL_INSTANTIATIONS(int8_t)
+RCCLX_DECLARE_RELAY_KERNEL_INSTANTIATIONS(uint8_t)
+RCCLX_DECLARE_RELAY_KERNEL_INSTANTIATIONS(int32_t)
+RCCLX_DECLARE_RELAY_KERNEL_INSTANTIATIONS(uint32_t)
+RCCLX_DECLARE_RELAY_KERNEL_INSTANTIATIONS(int64_t)
+RCCLX_DECLARE_RELAY_KERNEL_INSTANTIATIONS(uint64_t)
+RCCLX_DECLARE_RELAY_KERNEL_INSTANTIATIONS(__half)
+RCCLX_DECLARE_RELAY_KERNEL_INSTANTIATIONS(float)
+RCCLX_DECLARE_RELAY_KERNEL_INSTANTIATIONS(double)
+RCCLX_DECLARE_RELAY_KERNEL_INSTANTIATIONS(__nv_bfloat16)
+
+#undef RCCLX_DECLARE_RELAY_KERNEL_INSTANTIATIONS

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllReduceTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllReduceTest.cu
@@ -1,0 +1,1128 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+/**
+ * Unit tests for Fused Multi-Group Sharded Relay AllReduce
+ *
+ * This tests the phase-synchronized execution of multiple sharded relay
+ * allreduces with passthrough-at-helper design.  All groups execute in
+ * lockstep phases; helpers forward data without local reduction.
+ *
+ * Algorithm Design (Phase-Synchronized, Passthrough Helpers):
+ * ===========================================================
+ * Phase 1 (active→helpers): Both active ranks send chunks to helpers.
+ *         Helpers receive into two slots (slot a = data from active rank a).
+ *
+ * Phase 2 (helpers→active, pipelined): For each helper h, helper forwards:
+ *         slot 0 (a0's data) → a1, slot 1 (a1's data) → a0.
+ *         Active ranks receive into relay scratch, then add to recvBuff.
+ *
+ * Phase 3 (scale): Active ranks divide relay region by nActiveRanks for AVG.
+ *
+ * Phase 4 (active→active): Direct exchange between active ranks.
+ *
+ * Phase 5 (active reduce): Final reduction on the direct-exchange chunk.
+ *
+ * Buffer Requirements:
+ * ====================
+ * ACTIVE ranks: sendBuff == recvBuff is OK (in-place), scratch allocated
+ * internally for relay and direct exchange.
+ * HELPER ranks: sendBuff == recvBuff is OK (same buffer, uses offset-based
+ * access). Buffer must be large enough for nActiveRanks * chunkSize elements.
+ * Each helper group MUST have its own buffer (no aliasing across groups).
+ *
+ * 2D Sparse Parallelism Configuration (8 GPUs, 4 groups):
+ *   Group 0: activeRanks = {0, 1}, helpers = {2,3,4,5,6,7}
+ *   Group 1: activeRanks = {2, 3}, helpers = {0,1,4,5,6,7}
+ *   Group 2: activeRanks = {4, 5}, helpers = {0,1,2,3,6,7}
+ *   Group 3: activeRanks = {6, 7}, helpers = {0,1,2,3,4,5}
+ *
+ * Each rank is ACTIVE for exactly ONE group, HELPER for the other 3.
+ */
+
+#include <folly/init/Init.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <hip/hip_runtime.h>
+#include <chrono>
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <vector>
+
+#include "comm.h"
+#include "comms/rcclx/develop/meta/testinfra/TestUtils.h"
+#include "comms/rcclx/develop/meta/testinfra/TestsDistUtils.h"
+#include "nccl.h"
+
+#define HIPCHECK_TEST(cmd)                                          \
+  do {                                                              \
+    hipError_t error = cmd;                                         \
+    if (error != hipSuccess) {                                      \
+      FAIL() << "HIP error: " << hipGetErrorString(error) << " at " \
+             << __FILE__ << ":" << __LINE__;                        \
+    }                                                               \
+  } while (0)
+
+#define NCCLCHECK_TEST(cmd)                                            \
+  do {                                                                 \
+    ncclResult_t result = cmd;                                         \
+    if (result != ncclSuccess) {                                       \
+      FAIL() << "NCCL error: " << ncclGetErrorString(result) << " at " \
+             << __FILE__ << ":" << __LINE__;                           \
+    }                                                                  \
+  } while (0)
+
+struct ShardedBandwidthResult {
+  double algoBW_GBps;
+  double busBW_GBps;
+  double latency_us;
+};
+
+ShardedBandwidthResult calculateShardedBandwidth(
+    size_t dataBytes,
+    double elapsedMs,
+    int numActiveRanks) {
+  ShardedBandwidthResult result;
+  double elapsedSec = elapsedMs / 1000.0;
+  double dataSizeGB =
+      static_cast<double>(dataBytes) / (1024.0 * 1024.0 * 1024.0);
+  result.algoBW_GBps = dataSizeGB / elapsedSec;
+  result.busBW_GBps =
+      2.0 * (numActiveRanks - 1.0) / numActiveRanks * dataSizeGB / elapsedSec;
+  result.latency_us = elapsedMs * 1000.0;
+  return result;
+}
+
+// Calculate aggregate bandwidth for multi-group allreduce
+// This is what we actually measure: total data across all groups / time
+ShardedBandwidthResult calculateMultiGroupAggregateBandwidth(
+    size_t dataBytesPerGroup,
+    double elapsedMs,
+    int numActiveRanks,
+    int numGroups) {
+  ShardedBandwidthResult result;
+  double elapsedSec = elapsedMs / 1000.0;
+  // Total data = per-group data × number of groups
+  double totalDataSizeGB = static_cast<double>(dataBytesPerGroup) * numGroups /
+      (1024.0 * 1024.0 * 1024.0);
+  result.algoBW_GBps = totalDataSizeGB / elapsedSec;
+  // Bus BW uses the 2-rank allreduce formula since each group is a 2-rank
+  // allreduce For 2 ranks: 2*(2-1)/2 = 1.0, so busBW = algoBW for 2-rank groups
+  result.busBW_GBps = 2.0 * (numActiveRanks - 1.0) / numActiveRanks *
+      totalDataSizeGB / elapsedSec;
+  result.latency_us = elapsedMs * 1000.0;
+  return result;
+}
+
+void printMultiGroupBandwidthResults(
+    const std::string& testName,
+    size_t dataBytesPerGroup,
+    int numRanks,
+    int numGroups,
+    int activeRanksPerGroup,
+    const ShardedBandwidthResult& aggregateResult,
+    bool isInPlace) {
+  double dataSizePerGroupGB =
+      static_cast<double>(dataBytesPerGroup) / (1024.0 * 1024.0 * 1024.0);
+
+  // Total data = per-group data × number of groups
+  double totalDataSizeGB = dataSizePerGroupGB * numGroups;
+
+  // Per-group bandwidth (derived from aggregate)
+  double perGroupAlgoBW = aggregateResult.algoBW_GBps / numGroups;
+  double perGroupBusBW = aggregateResult.busBW_GBps / numGroups;
+
+  std::cout << "\n";
+  std::cout << "====================================================\n";
+  std::cout << "Multi-Group Sharded Relay AllReduce: " << testName << "\n";
+  std::cout << "====================================================\n";
+  std::cout << std::fixed << std::setprecision(2);
+  std::cout << "  Total Ranks (np):      " << numRanks << "\n";
+  std::cout << "  Number of Groups:      " << numGroups << "\n";
+  std::cout << "  Active Ranks/Group:    " << activeRanksPerGroup << "\n";
+  std::cout << "  Helper Ranks/Group:    " << (numRanks - activeRanksPerGroup)
+            << "\n";
+  std::cout << "  In-Place:              " << (isInPlace ? "YES" : "NO")
+            << "\n";
+  std::cout << "  Data Type:             int32\n";
+  std::cout << "  Data Size per Group:   " << dataSizePerGroupGB << " GB\n";
+  std::cout << "  Total Data (all groups): " << totalDataSizeGB << " GB\n";
+  std::cout << "  Element Count/Group:   "
+            << (dataBytesPerGroup / sizeof(int32_t)) << "\n";
+  std::cout << "----------------------------------------------------\n";
+  std::cout << "  Latency:               " << std::setprecision(3)
+            << aggregateResult.latency_us << " us\n";
+  std::cout << "----------------------------------------------------\n";
+  std::cout << "  AGGREGATE BANDWIDTH (all " << numGroups << " groups):\n";
+  std::cout << "    Algorithm BW:        " << std::setprecision(2)
+            << aggregateResult.algoBW_GBps << " GB/s\n";
+  std::cout << "    Bus BW:              " << aggregateResult.busBW_GBps
+            << " GB/s\n";
+  std::cout << "----------------------------------------------------\n";
+  std::cout << "  PER-GROUP BANDWIDTH (derived):\n";
+  std::cout << "    Algorithm BW:        " << perGroupAlgoBW << " GB/s\n";
+  std::cout << "    Bus BW:              " << perGroupBusBW << " GB/s\n";
+  std::cout << "====================================================\n\n";
+}
+
+class ShardedRelayMultiGroupAllReduceTest : public ::testing::Test {
+ public:
+  ShardedRelayMultiGroupAllReduceTest() = default;
+
+  void SetUp() override {
+    int localSize;
+    std::tie(this->localRank, this->globalRank, this->numRanks, localSize) =
+        getTcpStoreOrMpiInfo();
+    bool isServer = (this->globalRank == 0);
+    if (checkTcpStoreEnv()) {
+      server = createTcpStore(isServer);
+    } else if (isServer) {
+      server = createTcpStore(true);
+    }
+    this->comm = createNcclComm(
+        this->globalRank,
+        this->numRanks,
+        this->localRank,
+        false,
+        nullptr,
+        server.get());
+    CUDACHECK_TEST(cudaStreamCreate(&stream));
+  }
+
+  void TearDown() override {
+    CUDACHECK_TEST(cudaStreamDestroy(this->stream));
+    if (server && checkTcpStoreEnv()) {
+      finalizeNcclComm(this->globalRank, server.get());
+    }
+    NCCLCHECK_TEST(ncclCommDestroy(this->comm));
+    server.reset();
+  }
+
+  // Standard 8-rank, 4-group, 2-active-per-group sparse parallelism layout:
+  //   Group 0: activeRanks = {0, 1}
+  //   Group 1: activeRanks = {2, 3}
+  //   Group 2: activeRanks = {4, 5}
+  //   Group 3: activeRanks = {6, 7}
+  // Returned as raw int* pointers suitable for the multi-group API. The
+  // backing storage lives in `storage` and must outlive any use of the
+  // returned pointers.
+  struct Standard4GroupActiveRanks {
+    int storage[4][2] = {{0, 1}, {2, 3}, {4, 5}, {6, 7}};
+    const int* allActiveRanks[4] = {
+        storage[0],
+        storage[1],
+        storage[2],
+        storage[3]};
+  };
+
+  // Run a 1-element ncclAllReduce on `scratchBuffer` to act as a cross-rank
+  // barrier (ensuring all ranks reach this point before proceeding with
+  // benchmark / correctness work).
+  void barrierSyncOn(int32_t* scratchBuffer) {
+    HIPCHECK_TEST(hipMemset(scratchBuffer, 0, sizeof(int32_t)));
+    NCCLCHECK_TEST(ncclAllReduce(
+        scratchBuffer,
+        scratchBuffer,
+        1,
+        ncclInt32,
+        ncclSum,
+        this->comm,
+        this->stream));
+    HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+  }
+
+  // Copy `count` int32_t elements from `deviceBuffer` to host and verify
+  // they all equal `expectedValue`. Reports up to 10 mismatches via stdout
+  // and records failures via gtest. Returns the number of mismatches found
+  // (0 on success). Uses ADD_FAILURE/EXPECT_EQ rather than FAIL/ASSERT so
+  // it can be called from non-void functions.
+  int verifyDeviceBufferEquals(
+      const int32_t* deviceBuffer,
+      size_t count,
+      int32_t expectedValue,
+      int groupIndex,
+      const char* failureMessage) {
+    std::vector<int32_t> hostOutput(count);
+    hipError_t hipErr = hipMemcpy(
+        hostOutput.data(),
+        deviceBuffer,
+        count * sizeof(int32_t),
+        hipMemcpyDeviceToHost);
+    if (hipErr != hipSuccess) {
+      ADD_FAILURE() << "HIP error in verifyDeviceBufferEquals: "
+                    << hipGetErrorString(hipErr) << " at " << __FILE__ << ":"
+                    << __LINE__;
+      return -1;
+    }
+
+    int errorCount = 0;
+    for (size_t i = 0; i < count && errorCount < 10; ++i) {
+      if (hostOutput[i] != expectedValue) {
+        std::cout << "R" << this->globalRank << ": Group " << groupIndex
+                  << " Mismatch at index " << i << ": expected "
+                  << expectedValue << " but got " << hostOutput[i] << std::endl;
+        errorCount++;
+      }
+    }
+    EXPECT_EQ(errorCount, 0) << failureMessage;
+    return errorCount;
+  }
+
+  int localRank{0};
+  int globalRank{0};
+  int numRanks{0};
+  ncclComm_t comm;
+  cudaStream_t stream;
+  std::unique_ptr<c10d::TCPStore> server{nullptr};
+};
+
+/**
+ * Test: Multi-Group Correctness with 4 groups (IN-PLACE)
+ *
+ * Tests the fused multi-group allreduce with all 4 sparse groups executing
+ * simultaneously with phase synchronization.
+ *
+ * Each rank is:
+ * - ACTIVE for exactly one group (uses real tensor with 1s, in-place)
+ * - HELPER for the other 3 groups (uses SAME buffer for send/recv with
+ *   offset-based access)
+ *
+ * Buffer requirements:
+ * - ACTIVE: sendBuff == recvBuff (in-place)
+ * - HELPER: sendBuff == recvBuff (same buffer, offset-based access)
+ *
+ * Expected result: Active ranks for each group should have sum = 2
+ * (sum of the two active ranks in that group)
+ */
+TEST_F(ShardedRelayMultiGroupAllReduceTest, Correctness_4Groups_InPlace_64MB) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  const int nGroups = 4;
+  const int nActiveRanksPerGroup = 2;
+  const size_t dataBytes = 64ULL * 1024 * 1024;
+  const size_t count = dataBytes / sizeof(int32_t);
+
+  Standard4GroupActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  // Determine which group this rank is active for
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+
+  // Allocate buffers for all groups (one per group)
+  // For helpers, buffer must be large enough for nActiveRanksPerGroup * count
+  // elements to support offset-based access. We use same buffer for send/recv.
+  int32_t* buffers[nGroups];
+
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      // Active rank: buffer for in-place operation
+      HIPCHECK_TEST(hipMalloc(&buffers[g], dataBytes));
+    } else {
+      // Helper rank: buffer needs space for all active ranks' chunks
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * dataBytes;
+      HIPCHECK_TEST(hipMalloc(&buffers[g], helperBufferSize));
+    }
+  }
+
+  barrierSyncOn(buffers[0]);
+
+  // Initialize buffers:
+  // - For the group where this rank is ACTIVE: fill buffer with 1s
+  // - For groups where this rank is HELPER: fill buffer with 0s
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      // Active for this group: use actual data (1s)
+      std::vector<int32_t> hostData(count, 1);
+      HIPCHECK_TEST(hipMemcpy(
+          buffers[g], hostData.data(), dataBytes, hipMemcpyHostToDevice));
+      std::cout << "R" << this->globalRank << ": ACTIVE for group " << g
+                << " - buffer initialized with 1s" << std::endl;
+    } else {
+      // Helper for this group: initialize buffer to 0s
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * dataBytes;
+      HIPCHECK_TEST(hipMemset(buffers[g], 0, helperBufferSize));
+    }
+  }
+
+  // Run multi-group allreduce
+  // ACTIVE: sendBuff == recvBuff (in-place)
+  // HELPER: sendBuff == recvBuff (same buffer, offset-based access)
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  size_t counts[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    // Both active and helper ranks use same buffer for send and recv
+    sendPtrs[g] = buffers[g];
+    recvPtrs[g] = buffers[g];
+    counts[g] = count; // Same count for all groups in this test
+  }
+
+  ncclResult_t result = ncclShardedRelayMultiGroupAllReduce(
+      sendPtrs,
+      recvPtrs,
+      counts,
+      ncclInt32,
+      ncclSum,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  // Verify correctness for the group where this rank is active
+  // For in-place operation, the result is in buffers (since sendPtrs ==
+  // recvPtrs)
+  {
+    int g = myActiveGroup;
+    int errorCount = verifyDeviceBufferEquals(
+        buffers[g],
+        count,
+        nActiveRanksPerGroup,
+        g,
+        "Found mismatches in multi-group output");
+
+    if (errorCount == 0) {
+      std::cout << "R" << this->globalRank << ": Group " << g << " - All "
+                << count << " elements verified correctly!" << std::endl;
+    }
+  }
+
+  // Cleanup
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(buffers[g]));
+  }
+}
+
+/**
+ * Test: Multi-Group Correctness with 4 groups (OUT-OF-PLACE)
+ */
+TEST_F(
+    ShardedRelayMultiGroupAllReduceTest,
+    Correctness_4Groups_OutOfPlace_64MB) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  const int nGroups = 4;
+  const int nActiveRanksPerGroup = 2;
+  const size_t dataBytes = 64ULL * 1024 * 1024;
+  const size_t count = dataBytes / sizeof(int32_t);
+
+  Standard4GroupActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+
+  // Allocate buffers
+  // Active ranks: separate send/recv for out-of-place operation
+  // Helper ranks: single buffer with offset-based access
+  int32_t* sendBuffs[nGroups];
+  int32_t* recvBuffs[nGroups];
+
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      // Active rank: separate buffers for out-of-place
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], dataBytes));
+      HIPCHECK_TEST(hipMalloc(&recvBuffs[g], dataBytes));
+    } else {
+      // Helper rank: single buffer large enough for all active ranks' chunks
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * dataBytes;
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], helperBufferSize));
+      recvBuffs[g] = sendBuffs[g]; // Same buffer for send/recv
+    }
+  }
+
+  barrierSyncOn(recvBuffs[0]);
+
+  // Initialize buffers
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      std::vector<int32_t> hostData(count, 1);
+      HIPCHECK_TEST(hipMemcpy(
+          sendBuffs[g], hostData.data(), dataBytes, hipMemcpyHostToDevice));
+      HIPCHECK_TEST(hipMemset(recvBuffs[g], 0, dataBytes));
+    } else {
+      // Helper for this group: initialize buffer to 0s
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * dataBytes;
+      HIPCHECK_TEST(hipMemset(sendBuffs[g], 0, helperBufferSize));
+    }
+  }
+
+  // Run multi-group allreduce (out-of-place for active, same buffer for
+  // helpers)
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  size_t counts[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = sendBuffs[g];
+    recvPtrs[g] = recvBuffs[g];
+    counts[g] = count;
+  }
+
+  ncclResult_t result = ncclShardedRelayMultiGroupAllReduce(
+      sendPtrs,
+      recvPtrs,
+      counts,
+      ncclInt32,
+      ncclSum,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  // Verify correctness for the group where this rank is active
+  {
+    int g = myActiveGroup;
+    verifyDeviceBufferEquals(
+        recvBuffs[g],
+        count,
+        nActiveRanksPerGroup,
+        g,
+        "Found mismatches in out-of-place multi-group output");
+  }
+
+  // Cleanup
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(sendBuffs[g]));
+    if (g == myActiveGroup) {
+      // Only free recvBuffs for active groups (helpers share the buffer)
+      HIPCHECK_TEST(hipFree(recvBuffs[g]));
+    }
+  }
+}
+
+/**
+ * Test: BusBW with 4-group Multi-Group AllReduce (24GB per group, IN-PLACE)
+ *
+ * This is the key benchmark for 2D sparse parallelism performance.
+ * All 4 groups execute in parallel with phase synchronization.
+ */
+TEST_F(ShardedRelayMultiGroupAllReduceTest, Z_BusBW_4Groups_InPlace_24GB) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  const int nGroups = 4;
+  const int nActiveRanksPerGroup = 2;
+  const size_t dataBytes = 24ULL * 1024 * 1024 * 1024; // 24 GB per group
+  const size_t count = dataBytes / sizeof(int32_t);
+
+  // Benchmark configuration: Run 20 iterations total, take the best time.
+  // Early iterations serve as warmup (GPU frequency ramp-up, memory paging).
+  // Later iterations should reach peak performance.
+  const int nIters = 20;
+
+  Standard4GroupActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  // Determine which group this rank is active for
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+
+  // Allocate buffers for all groups
+  // For helpers, use same buffer for send/recv with offset-based access
+  int32_t* buffers[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      // Active rank: buffer for in-place operation
+      HIPCHECK_TEST(hipMalloc(&buffers[g], dataBytes));
+    } else {
+      // Helper rank: buffer needs space for all active ranks' chunks
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * dataBytes;
+      HIPCHECK_TEST(hipMalloc(&buffers[g], helperBufferSize));
+    }
+  }
+
+  barrierSyncOn(buffers[0]);
+
+  // Initialize all buffers with pattern
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipMemset(buffers[g], 1, dataBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * dataBytes;
+      HIPCHECK_TEST(hipMemset(buffers[g], 0, helperBufferSize));
+    }
+  }
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  // Prepare pointers
+  // Both active and helper ranks use same buffer for send/recv
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  size_t counts[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = buffers[g];
+    recvPtrs[g] = buffers[g];
+    counts[g] = count;
+  }
+
+  // Run all iterations, timing each one
+  hipEvent_t startEvent, stopEvent;
+  HIPCHECK_TEST(hipEventCreate(&startEvent));
+  HIPCHECK_TEST(hipEventCreate(&stopEvent));
+
+  float bestTimeMs = std::numeric_limits<float>::max();
+  float totalTimeMs = 0.0f;
+
+  if (this->globalRank == 0) {
+    std::cout << "[Benchmark] Running " << nIters << " iterations..."
+              << std::endl;
+  }
+
+  for (int iter = 0; iter < nIters; iter++) {
+    HIPCHECK_TEST(hipEventRecord(startEvent, this->stream));
+    ncclResult_t result = ncclShardedRelayMultiGroupAllReduce(
+        sendPtrs,
+        recvPtrs,
+        counts,
+        ncclInt32,
+        ncclSum,
+        this->comm,
+        this->stream,
+        allActiveRanks,
+        nActiveRanksPerGroup,
+        nGroups);
+    ASSERT_EQ(result, ncclSuccess);
+    HIPCHECK_TEST(hipEventRecord(stopEvent, this->stream));
+    HIPCHECK_TEST(hipEventSynchronize(stopEvent));
+
+    float elapsedMs = 0.0f;
+    HIPCHECK_TEST(hipEventElapsedTime(&elapsedMs, startEvent, stopEvent));
+
+    if (this->globalRank == 0) {
+      std::cout << "  Iteration " << (iter + 1) << ": " << elapsedMs << " ms"
+                << std::endl;
+    }
+
+    if (elapsedMs < bestTimeMs) {
+      bestTimeMs = elapsedMs;
+    }
+    totalTimeMs += elapsedMs;
+  }
+
+  float avgTimeMs = totalTimeMs / nIters;
+
+  if (this->globalRank == 0) {
+    std::cout << "\n[Benchmark] Best time: " << bestTimeMs << " ms, "
+              << "Avg time: " << avgTimeMs << " ms" << std::endl;
+
+    // Report bandwidth using best time (most representative of peak
+    // performance)
+    ShardedBandwidthResult bwResult = calculateMultiGroupAggregateBandwidth(
+        dataBytes, bestTimeMs, nActiveRanksPerGroup, nGroups);
+    printMultiGroupBandwidthResults(
+        "4-Group IN-PLACE 24GB",
+        dataBytes,
+        this->numRanks,
+        nGroups,
+        nActiveRanksPerGroup,
+        bwResult,
+        true);
+  }
+
+  HIPCHECK_TEST(hipEventDestroy(startEvent));
+  HIPCHECK_TEST(hipEventDestroy(stopEvent));
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(buffers[g]));
+  }
+}
+
+/**
+ * Test: BusBW with 4-group Multi-Group AllReduce (24GB per group, OUT-OF-PLACE)
+ */
+TEST_F(ShardedRelayMultiGroupAllReduceTest, Z_BusBW_4Groups_OutOfPlace_24GB) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  const int nGroups = 4;
+  const int nActiveRanksPerGroup = 2;
+  const size_t dataBytes = 24ULL * 1024 * 1024 * 1024; // 24 GB per group
+  const size_t count = dataBytes / sizeof(int32_t);
+
+  // Benchmark configuration: Run 20 iterations total, take the best time.
+  // Early iterations serve as warmup (GPU frequency ramp-up, memory paging).
+  // Later iterations should reach peak performance.
+  const int nIters = 20;
+
+  Standard4GroupActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+
+  // Allocate buffers
+  // Active ranks: separate send/recv for out-of-place
+  // Helper ranks: single buffer large enough for all active ranks' chunks
+  int32_t* sendBuffs[nGroups];
+  int32_t* recvBuffs[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      // Active rank: separate buffers for out-of-place
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], dataBytes));
+      HIPCHECK_TEST(hipMalloc(&recvBuffs[g], dataBytes));
+    } else {
+      // Helper rank: single buffer with offset-based access
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * dataBytes;
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], helperBufferSize));
+      recvBuffs[g] = sendBuffs[g]; // Same buffer for send/recv
+    }
+  }
+
+  barrierSyncOn(recvBuffs[0]);
+
+  // Initialize all buffers
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipMemset(sendBuffs[g], 1, dataBytes));
+      HIPCHECK_TEST(hipMemset(recvBuffs[g], 0, dataBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * dataBytes;
+      HIPCHECK_TEST(hipMemset(sendBuffs[g], 0, helperBufferSize));
+    }
+  }
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  // Prepare pointers
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  size_t counts[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = sendBuffs[g];
+    recvPtrs[g] = recvBuffs[g];
+    counts[g] = count;
+  }
+
+  // Run all iterations, timing each one
+  hipEvent_t startEvent, stopEvent;
+  HIPCHECK_TEST(hipEventCreate(&startEvent));
+  HIPCHECK_TEST(hipEventCreate(&stopEvent));
+
+  float bestTimeMs = std::numeric_limits<float>::max();
+  float totalTimeMs = 0.0f;
+
+  if (this->globalRank == 0) {
+    std::cout << "[Benchmark] Running " << nIters << " iterations..."
+              << std::endl;
+  }
+
+  for (int iter = 0; iter < nIters; iter++) {
+    HIPCHECK_TEST(hipEventRecord(startEvent, this->stream));
+    ncclResult_t result = ncclShardedRelayMultiGroupAllReduce(
+        sendPtrs,
+        recvPtrs,
+        counts,
+        ncclInt32,
+        ncclSum,
+        this->comm,
+        this->stream,
+        allActiveRanks,
+        nActiveRanksPerGroup,
+        nGroups);
+    ASSERT_EQ(result, ncclSuccess);
+    HIPCHECK_TEST(hipEventRecord(stopEvent, this->stream));
+    HIPCHECK_TEST(hipEventSynchronize(stopEvent));
+
+    float elapsedMs = 0.0f;
+    HIPCHECK_TEST(hipEventElapsedTime(&elapsedMs, startEvent, stopEvent));
+
+    if (this->globalRank == 0) {
+      std::cout << "  Iteration " << (iter + 1) << ": " << elapsedMs << " ms"
+                << std::endl;
+    }
+
+    if (elapsedMs < bestTimeMs) {
+      bestTimeMs = elapsedMs;
+    }
+    totalTimeMs += elapsedMs;
+  }
+
+  float avgTimeMs = totalTimeMs / nIters;
+
+  if (this->globalRank == 0) {
+    std::cout << "\n[Benchmark] Best time: " << bestTimeMs << " ms, "
+              << "Avg time: " << avgTimeMs << " ms" << std::endl;
+
+    ShardedBandwidthResult bwResult = calculateMultiGroupAggregateBandwidth(
+        dataBytes, bestTimeMs, nActiveRanksPerGroup, nGroups);
+    printMultiGroupBandwidthResults(
+        "4-Group OUT-OF-PLACE 24GB",
+        dataBytes,
+        this->numRanks,
+        nGroups,
+        nActiveRanksPerGroup,
+        bwResult,
+        false);
+  }
+
+  HIPCHECK_TEST(hipEventDestroy(startEvent));
+  HIPCHECK_TEST(hipEventDestroy(stopEvent));
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(sendBuffs[g]));
+    if (g == myActiveGroup) {
+      // Only free recvBuffs for active groups (helpers share the buffer)
+      HIPCHECK_TEST(hipFree(recvBuffs[g]));
+    }
+  }
+}
+
+/**
+ * Test: Single group via multi-group API (backward compatibility check)
+ *
+ * Verifies that the multi-group API works correctly with nGroups=1,
+ * which should behave the same as a single sharded relay allreduce.
+ *
+ * Buffer requirements:
+ * - ACTIVE ranks (0, 1): sendBuff == recvBuff (in-place)
+ * - HELPER ranks (2-7): sendBuff == recvBuff (same buffer, offset-based access)
+ */
+TEST_F(ShardedRelayMultiGroupAllReduceTest, Correctness_SingleGroup_64MB) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  const int nGroups = 1;
+  const int nActiveRanksPerGroup = 2;
+  const size_t dataBytes = 64ULL * 1024 * 1024;
+  const size_t count = dataBytes / sizeof(int32_t);
+
+  const int activeRanks[] = {0, 1};
+  const int* allActiveRanks[] = {activeRanks};
+
+  // Determine if this rank is active
+  bool isActive = (this->globalRank == 0 || this->globalRank == 1);
+
+  // Allocate buffer - helpers use same buffer for send/recv
+  int32_t* buff = nullptr;
+  if (isActive) {
+    // Active rank: buffer for in-place operation
+    HIPCHECK_TEST(hipMalloc(&buff, dataBytes));
+  } else {
+    // Helper rank: buffer needs space for all active ranks' chunks
+    size_t helperBufferSize =
+        static_cast<size_t>(nActiveRanksPerGroup) * dataBytes;
+    HIPCHECK_TEST(hipMalloc(&buff, helperBufferSize));
+  }
+
+  barrierSyncOn(buff);
+
+  // Initialize: active ranks (0,1) have 1s, helpers have 0s
+  if (isActive) {
+    std::vector<int32_t> hostData(count, 1);
+    HIPCHECK_TEST(
+        hipMemcpy(buff, hostData.data(), dataBytes, hipMemcpyHostToDevice));
+  } else {
+    size_t helperBufferSize =
+        static_cast<size_t>(nActiveRanksPerGroup) * dataBytes;
+    HIPCHECK_TEST(hipMemset(buff, 0, helperBufferSize));
+  }
+
+  // Run single-group allreduce via multi-group API
+  // Both active and helper ranks use same buffer for send/recv
+  const void* sendPtrs[1];
+  void* recvPtrs[1];
+  size_t counts[] = {count};
+
+  sendPtrs[0] = buff;
+  recvPtrs[0] = buff;
+
+  ncclResult_t result = ncclShardedRelayMultiGroupAllReduce(
+      sendPtrs,
+      recvPtrs,
+      counts,
+      ncclInt32,
+      ncclSum,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  // Verify for active ranks
+  if (isActive) {
+    verifyDeviceBufferEquals(
+        buff,
+        count,
+        nActiveRanksPerGroup,
+        0, // single-group test, group index = 0
+        "Single group via multi-group API failed");
+  }
+
+  HIPCHECK_TEST(hipFree(buff));
+}
+
+/**
+ * Test: Correctness with minimum passthrough helper buffers (4 groups,
+ * IN-PLACE)
+ *
+ * Validates that the passthrough kernel produces correct results when
+ * each helper group's buffer is allocated at the MINIMUM size required
+ * by the passthrough design: nActiveRanks × chunkSize elements.
+ *
+ * Each helper group has its OWN buffer (no aliasing) because all groups
+ * are processed simultaneously under phase-sync.
+ *
+ * Memory layout per rank:
+ *   - Active group: distinct buffer with real data (1s)
+ *   - Each helper group: separate buffer sized to nActiveRanks × chunkSize
+ *
+ * Expected: Active ranks for each group have sum = 2 (same as full-sized).
+ */
+TEST_F(
+    ShardedRelayMultiGroupAllReduceTest,
+    Correctness_4Groups_PassthroughHelperEquivalence) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  const int nGroups = 4;
+  const int nActiveRanksPerGroup = 2;
+  const size_t dataBytes = 64ULL * 1024 * 1024;
+  const size_t count = dataBytes / sizeof(int32_t);
+  const int numHelpers = this->numRanks - nActiveRanksPerGroup;
+  const int numChunks = numHelpers + 1;
+
+  Standard4GroupActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+
+  // Compute the MINIMUM passthrough helper buffer size.
+  size_t chunkSize = count / numChunks;
+  chunkSize = (chunkSize / 128) * 128; // CHUNK_ALIGN_ELEMENTS
+  if (chunkSize == 0) {
+    chunkSize = count;
+  }
+  size_t minHelperElements =
+      std::min(count, static_cast<size_t>(nActiveRanksPerGroup) * chunkSize);
+  size_t minHelperBytes = minHelperElements * sizeof(int32_t);
+
+  // Allocate: 1 active buffer + 3 separate minimal helper buffers
+  int32_t* activeBuffer = nullptr;
+  int32_t* helperBuffers[nGroups];
+
+  HIPCHECK_TEST(hipMalloc(&activeBuffer, dataBytes));
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      helperBuffers[g] = nullptr;
+    } else {
+      HIPCHECK_TEST(hipMalloc(&helperBuffers[g], minHelperBytes));
+    }
+  }
+
+  barrierSyncOn(activeBuffer);
+
+  // Initialize: active buffer = 1s, helpers = 0s
+  std::vector<int32_t> hostData(count, 1);
+  HIPCHECK_TEST(hipMemcpy(
+      activeBuffer, hostData.data(), dataBytes, hipMemcpyHostToDevice));
+  for (int g = 0; g < nGroups; g++) {
+    if (g != myActiveGroup) {
+      HIPCHECK_TEST(hipMemset(helperBuffers[g], 0, minHelperBytes));
+    }
+  }
+
+  // Build pointer arrays: each helper group has its own buffer
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  size_t counts[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      sendPtrs[g] = activeBuffer;
+      recvPtrs[g] = activeBuffer;
+    } else {
+      sendPtrs[g] = helperBuffers[g];
+      recvPtrs[g] = helperBuffers[g];
+    }
+    counts[g] = count;
+  }
+
+  ncclResult_t result = ncclShardedRelayMultiGroupAllReduce(
+      sendPtrs,
+      recvPtrs,
+      counts,
+      ncclInt32,
+      ncclSum,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  // Verify correctness for this rank's active group
+  {
+    int errorCount = verifyDeviceBufferEquals(
+        activeBuffer,
+        count,
+        nActiveRanksPerGroup,
+        myActiveGroup,
+        "Found mismatches in passthrough-helper-equivalence output");
+
+    if (errorCount == 0) {
+      std::cout << "R" << this->globalRank << ": Group " << myActiveGroup
+                << " - All " << count
+                << " elements verified correctly (min passthrough helper)!"
+                << std::endl;
+    }
+  }
+
+  HIPCHECK_TEST(hipFree(activeBuffer));
+  for (int g = 0; g < nGroups; g++) {
+    if (g != myActiveGroup) {
+      HIPCHECK_TEST(hipFree(helperBuffers[g]));
+    }
+  }
+}
+
+/**
+ * Test: Correctness_PartialGroupsZeroCount
+ *
+ * Regression test for the BM-FM failure:
+ *   "RCCLX Sharded Relay Multi-Group AllReduce failed: internal error"
+ *
+ * When different sparse groups have different numbers of tensors (e.g.
+ * [94, 101, 88, 99]), the iterative non-batched loop passes count=0 for
+ * groups that have exhausted their tensors while other groups still have
+ * data. The kernel must skip those count=0 groups in every phase instead of
+ * attempting NCCL operations with zero-element buffers (which trigger an
+ * internal error via the scratch buffer cache returning nullptr for size=0).
+ *
+ * Setup: 4 groups (8 ranks), 2 active ranks per group.
+ *   - Groups 0 and 1: count = 16MB (have data, must produce correct sum=2)
+ *   - Groups 2 and 3: count = 0    (exhausted, must not corrupt or crash)
+ *
+ * All ranks call the same API with the same count array (as in production,
+ * where counts are synchronized via allgather before the iterative loop).
+ */
+TEST_F(
+    ShardedRelayMultiGroupAllReduceTest,
+    Correctness_PartialGroupsZeroCount) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  const int nGroups = 4;
+  const int nActiveRanksPerGroup = 2;
+  const size_t dataBytes = 16ULL * 1024 * 1024; // 16MB for groups with data
+  const size_t count = dataBytes / sizeof(int32_t);
+
+  // Groups 0,1 have data; groups 2,3 are exhausted (count=0)
+  const size_t counts[nGroups] = {count, count, 0, 0};
+
+  Standard4GroupActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+
+  // Allocate buffers.  For count=0 groups we still allocate a small placeholder
+  // (matching how the Python layer passes a 1-element empty tensor), but its
+  // content is irrelevant since the kernel will skip the group entirely.
+  const size_t placeholderBytes = sizeof(int32_t); // 1 element
+  int32_t* buffers[nGroups];
+
+  for (int g = 0; g < nGroups; g++) {
+    if (counts[g] == 0) {
+      // count=0 group: allocate a tiny placeholder buffer (kernel skips it)
+      HIPCHECK_TEST(hipMalloc(&buffers[g], placeholderBytes));
+      HIPCHECK_TEST(hipMemset(buffers[g], 0, placeholderBytes));
+      continue;
+    }
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipMalloc(&buffers[g], dataBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * dataBytes;
+      HIPCHECK_TEST(hipMalloc(&buffers[g], helperBufferSize));
+    }
+  }
+
+  barrierSyncOn(buffers[0]);
+
+  // Initialize: active ranks for groups 0,1 fill with 1s; helpers fill with 0s
+  for (int g = 0; g < nGroups; g++) {
+    if (counts[g] == 0) {
+      continue; // placeholder already zeroed
+    }
+    if (g == myActiveGroup) {
+      std::vector<int32_t> hostData(count, 1);
+      HIPCHECK_TEST(hipMemcpy(
+          buffers[g], hostData.data(), dataBytes, hipMemcpyHostToDevice));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * dataBytes;
+      HIPCHECK_TEST(hipMemset(buffers[g], 0, helperBufferSize));
+    }
+  }
+
+  // Build pointer arrays (same buffer for send/recv = in-place)
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = buffers[g];
+    recvPtrs[g] = buffers[g];
+  }
+
+  // Execute — must succeed and not trigger internal error for count=0 groups
+  ncclResult_t result = ncclShardedRelayMultiGroupAllReduce(
+      sendPtrs,
+      recvPtrs,
+      counts,
+      ncclInt32,
+      ncclSum,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess)
+      << "ncclShardedRelayMultiGroupAllReduce failed with partial count=0 groups";
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  // Verify groups with count>0 produced correct sum=2
+  if (myActiveGroup < 2) { // groups 0 and 1 had data
+    verifyDeviceBufferEquals(
+        buffers[myActiveGroup],
+        count,
+        nActiveRanksPerGroup,
+        myActiveGroup,
+        "Correctness failed for groups with count>0 when other groups have count=0");
+  }
+  // Ranks 4-7 (active for groups 2,3 with count=0) have nothing to verify.
+
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(buffers[g]));
+  }
+}
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/rcclx/develop/projects/rccl/src/collectives.cc
+++ b/comms/rcclx/develop/projects/rccl/src/collectives.cc
@@ -18,6 +18,7 @@
 #include "meta/lpcoll/low_precision_alltoall.h"
 #include "meta/lpcoll/low_precision_reduce_scatter.h"
 #include "meta/lpcoll/p2p_allgather.h"
+#include "meta/relay/sharded_relay_allreduce.h"
 #include "comms/ctran/Ctran.h"
 #include "MetaFactory.h"
 
@@ -438,6 +439,63 @@ ncclResult_t ncclAllReduceWithBias_impl(const void* sendbuff, void* recvbuff, si
   NCCLCHECK(Recorder::instance().record(rrAllReduceWithBias, info));
 
   return ncclEnqueueCheck(&info);
+}
+
+NCCL_API(ncclResult_t, ncclShardedRelayMultiGroupAllReduce, 
+    const void* const* sendBuffs, void* const* recvBuffs, const size_t* counts,
+    ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, hipStream_t stream,
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+
+ncclResult_t ncclShardedRelayMultiGroupAllReduce_impl(
+    const void* const* sendBuffs, void* const* recvBuffs, const size_t* counts,
+    ncclDataType_t datatype, ncclRedOp_t op, ncclComm* comm, cudaStream_t stream,
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups) {
+  // Validate operation - only SUM and AVG are supported
+  if (op != ncclSum && op != ncclAvg) {
+    WARN("ncclShardedRelayMultiGroupAllReduce: only ncclSum and ncclAvg operations are supported");
+    return ncclInvalidArgument;
+  }
+
+  // Validate buffer pointers
+  if (sendBuffs == nullptr || recvBuffs == nullptr || allActiveRanks == nullptr || counts == nullptr) {
+    WARN("ncclShardedRelayMultiGroupAllReduce: buffer, counts, and activeRanks pointers must be non-null");
+    return ncclInvalidArgument;
+  }
+
+  // Validate group parameters
+  if (nGroups < 1 || nGroups > 8) {
+    WARN("ncclShardedRelayMultiGroupAllReduce: nGroups must be between 1 and 8, got %d", nGroups);
+    return ncclInvalidArgument;
+  }
+
+  if (nActiveRanksPerGroup != 2) {
+    WARN("ncclShardedRelayMultiGroupAllReduce: nActiveRanksPerGroup must be 2, got %d", 
+         nActiveRanksPerGroup);
+    return ncclInvalidArgument;
+  }
+
+  int nRanks;
+  NCCLCHECK(ncclCommCount(comm, &nRanks));
+  
+  // Validate we have enough ranks for sharded relay (need helpers)
+  if (nRanks < nActiveRanksPerGroup + 1) {
+    WARN("ncclShardedRelayMultiGroupAllReduce: need at least %d ranks for %d active ranks (need helpers)", 
+         nActiveRanksPerGroup + 1, nActiveRanksPerGroup);
+    return ncclInvalidArgument;
+  }
+
+  TRACE(NCCL_COLL, "Using Sharded Relay Multi-Group AllReduce (nRanks=%d, nActiveRanksPerGroup=%d, nGroups=%d)", 
+        nRanks, nActiveRanksPerGroup, nGroups);
+  return ncclShardedRelayMultiGroupAllReduceImpl(sendBuffs, recvBuffs, counts, datatype, op, comm, stream, 
+                                                  allActiveRanks, nActiveRanksPerGroup, nGroups);
+}
+
+ncclResult_t ncclShardedRelayMultiGroupAllReduce(
+    const void* const* sendBuffs, void* const* recvBuffs, const size_t* counts,
+    ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, cudaStream_t stream,
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups) {
+  return ncclShardedRelayMultiGroupAllReduce_impl(sendBuffs, recvBuffs, counts, datatype, op, comm, stream,
+                                                   allActiveRanks, nActiveRanksPerGroup, nGroups);
 }
 
 NCCL_API(ncclResult_t, ncclBroadcast, const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, int root,

--- a/comms/rcclx/develop/projects/rccl/src/nccl.h
+++ b/comms/rcclx/develop/projects/rccl/src/nccl.h
@@ -648,6 +648,50 @@ ncclResult_t pncclAllReduceWithBias(const void* sendbuff, void* recvbuff, size_t
     ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, hipStream_t stream, const void* acc);
 /*! @endcond */
 
+/*! @brief      Fused Multi-Group Sharded Relay All-Reduce for 2D Sparse Parallelism
+    @details    Performs multiple sharded relay all-reduces in a single fused call, coordinating
+                phases across ALL groups to prevent XGMI link contention.
+                
+                Problem with separate calls: When 4 separate allreduces run in parallel, different
+                groups may be in different phases (active→helpers vs helpers→active), causing
+                bidirectional contention on shared XGMI links and degrading bandwidth by up to 10x.
+                
+                Solution: This fused API executes ALL groups in lockstep phases:
+                  Phase 1: ALL groups scatter (active→helpers) - unidirectional traffic
+                  Phase 2: ALL groups forward (helpers→other active) - unidirectional traffic
+                  Phase 3: ALL active ranks reduce the relayed chunks - compute only
+                  Phase 4: ALL groups direct-exchange last chunk between active ranks
+                  Phase 5: Final reduction on the exchanged chunk - compute only
+                
+                Helpers act as pure passthrough relays (no local reduction). All
+                reductions happen on active ranks only.
+              
+              Memory model: Each rank is ACTIVE for exactly ONE group (has real tensor data).
+              For other groups, the rank is a HELPER (uses provided scratch buffer).
+              
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[in]  sendBuffs           Array of send buffer pointers (one per group)
+    @param[out] recvBuffs           Array of receive buffer pointers (one per group)  
+    @param[in]  counts              Array of element counts (one per group, allows different sizes)
+    @param[in]  datatype            Data buffer element datatype
+    @param[in]  op                  Reduction operator (ncclSum and ncclAvg supported)
+    @param[in]  comm                Communicator group object to execute on
+    @param[in]  stream              HIP stream to execute collective on
+    @param[in]  allActiveRanks      2D array of active ranks [nGroups][nActiveRanksPerGroup]
+    @param[in]  nActiveRanksPerGroup Number of active ranks per group (typically 2)
+    @param[in]  nGroups             Number of groups (typically 4 for 8-GPU node) */
+ncclResult_t  ncclShardedRelayMultiGroupAllReduce(
+    const void* const* sendBuffs, void* const* recvBuffs, const size_t* counts,
+    ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, hipStream_t stream,
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+/*! @cond       include_hidden */
+ncclResult_t pncclShardedRelayMultiGroupAllReduce(
+    const void* const* sendBuffs, void* const* recvBuffs, const size_t* counts,
+    ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, hipStream_t stream,
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+/*! @endcond */
+
 /*! @brief      Reduce-Scatter
     @details    Reduces data in *sendbuff* using *op* operation and leaves reduced result
                 scattered over the devices so that *recvbuff* on rank i will contain the i-th

--- a/comms/rcclx/develop/projects/rccl/src/rccl.h
+++ b/comms/rcclx/develop/projects/rccl/src/rccl.h
@@ -648,6 +648,50 @@ ncclResult_t pncclAllReduceWithBias(const void* sendbuff, void* recvbuff, size_t
     ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, hipStream_t stream, const void* acc);
 /*! @endcond */
 
+/*! @brief      Fused Multi-Group Sharded Relay All-Reduce for 2D Sparse Parallelism
+    @details    Performs multiple sharded relay all-reduces in a single fused call, coordinating
+                phases across ALL groups to prevent XGMI link contention.
+                
+                Problem with separate calls: When 4 separate allreduces run in parallel, different
+                groups may be in different phases (active→helpers vs helpers→active), causing
+                bidirectional contention on shared XGMI links and degrading bandwidth by up to 10x.
+                
+                Solution: This fused API executes ALL groups in lockstep phases:
+                  Phase 1: ALL groups scatter (active→helpers) - unidirectional traffic
+                  Phase 2: ALL groups forward (helpers→other active) - unidirectional traffic
+                  Phase 3: ALL active ranks reduce the relayed chunks - compute only
+                  Phase 4: ALL groups direct-exchange last chunk between active ranks
+                  Phase 5: Final reduction on the exchanged chunk - compute only
+                
+                Helpers act as pure passthrough relays (no local reduction). All
+                reductions happen on active ranks only.
+              
+              Memory model: Each rank is ACTIVE for exactly ONE group (has real tensor data).
+              For other groups, the rank is a HELPER (uses provided scratch buffer).
+              
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[in]  sendBuffs           Array of send buffer pointers (one per group)
+    @param[out] recvBuffs           Array of receive buffer pointers (one per group)  
+    @param[in]  counts              Array of element counts (one per group, allows different sizes)
+    @param[in]  datatype            Data buffer element datatype
+    @param[in]  op                  Reduction operator (ncclSum and ncclAvg supported)
+    @param[in]  comm                Communicator group object to execute on
+    @param[in]  stream              HIP stream to execute collective on
+    @param[in]  allActiveRanks      2D array of active ranks [nGroups][nActiveRanksPerGroup]
+    @param[in]  nActiveRanksPerGroup Number of active ranks per group (typically 2)
+    @param[in]  nGroups             Number of groups (typically 4 for 8-GPU node) */
+ncclResult_t  ncclShardedRelayMultiGroupAllReduce(
+    const void* const* sendBuffs, void* const* recvBuffs, const size_t* counts,
+    ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, hipStream_t stream,
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+/*! @cond       include_hidden */
+ncclResult_t pncclShardedRelayMultiGroupAllReduce(
+    const void* const* sendBuffs, void* const* recvBuffs, const size_t* counts,
+    ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, hipStream_t stream,
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+/*! @endcond */
+
 /*! @brief      Reduce-Scatter
     @details    Reduces data in *sendbuff* using *op* operation and leaves reduced result
                 scattered over the devices so that *recvbuff* on rank i will contain the i-th


### PR DESCRIPTION
Summary:

Add comprehensive C++ test suite for the sharded relay allreduce
implementation. The tests use an 8-GPU (ppn=8) distributed test
configuration and validate correctness of the relay allreduce
algorithm across various scenarios.

Reviewed By: JinghanHuang

Differential Revision: D103262941


