### PR TITLE
Add cuda tensor validation to nccl, ncclx, rccl, rcclx

### DIFF
--- a/comms/torchcomms/nccl/TorchCommNCCL.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCL.cpp
@@ -22,23 +22,6 @@
 
 namespace torch::comms {
 
-namespace {
-
-void checkTensorOnCuda(const at::Tensor& tensor) {
-  TORCH_CHECK(
-      tensor.is_cuda(),
-      "Expected CUDA tensor but found tensor on ",
-      tensor.device());
-}
-
-void checkTensorsOnCuda(const std::vector<at::Tensor>& tensors) {
-  for (const auto& t : tensors) {
-    checkTensorOnCuda(t);
-  }
-}
-
-} // namespace
-
 ncclResult_t NCCLException::getResult() const noexcept {
   return result_;
 }
@@ -610,7 +593,7 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::send(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
-  checkTensorOnCuda(tensor);
+  checkTensorDevice(tensor);
 
   TracingGuard tracingGuard(name_, comm_size_, "send", dst, tensor, tensor);
 
@@ -655,7 +638,7 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::recv(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
-  checkTensorOnCuda(tensor);
+  checkTensorDevice(tensor);
 
   TracingGuard tracingGuard(name_, comm_size_, "recv", src, tensor, tensor);
 
@@ -703,7 +686,7 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::batch_op_issue(
   std::vector<at::Tensor> output_tensors;
 
   for (const auto& op : ops) {
-    checkTensorOnCuda(op.tensor);
+    checkTensorDevice(op.tensor);
     if (op.type == BatchSendRecv::P2POp::OpType::SEND) {
       at::Tensor tensor = op.tensor;
       ensureTensorContiguous(tensor);
@@ -797,7 +780,7 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::broadcast(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
-  checkTensorOnCuda(tensor);
+  checkTensorDevice(tensor);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "broadcast", root, tensor, tensor);
@@ -844,7 +827,7 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::all_reduce(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
-  checkTensorOnCuda(tensor);
+  checkTensorDevice(tensor);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_reduce", rank_, tensor, tensor);
@@ -893,7 +876,7 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::reduce(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
-  checkTensorOnCuda(tensor);
+  checkTensorDevice(tensor);
 
   TracingGuard tracingGuard(name_, comm_size_, "reduce", root, tensor, tensor);
 
@@ -957,8 +940,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::all_gather(
     }
   }
 
-  checkTensorOnCuda(tensor);
-  checkTensorsOnCuda(tensor_list);
+  checkTensorDevice(tensor);
+  checkTensorsDevice(tensor_list);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_gather", rank_, tensor_list, {tensor});
@@ -1024,8 +1007,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::all_gather_v(
     ensureTensorContiguous(t);
   }
 
-  checkTensorOnCuda(tensor);
-  checkTensorsOnCuda(tensor_list);
+  checkTensorDevice(tensor);
+  checkTensorsDevice(tensor_list);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_gather_v", rank_, tensor_list, {tensor});
@@ -1090,8 +1073,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::all_gather_single(
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output);
   ensureTensorContiguous(input);
-  checkTensorOnCuda(output);
-  checkTensorOnCuda(input);
+  checkTensorDevice(output);
+  checkTensorDevice(input);
 
   if (output.numel() != input.numel() * comm_size_) {
     throw std::runtime_error(
@@ -1156,8 +1139,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::reduce_scatter(
     }
   }
 
-  checkTensorsOnCuda(input_list);
-  checkTensorOnCuda(output);
+  checkTensorsDevice(input_list);
+  checkTensorDevice(output);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "reduce_scatter", rank_, input_list, {output});
@@ -1242,8 +1225,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::reduce_scatter_v(
     ensureTensorContiguous(t);
   }
 
-  checkTensorsOnCuda(input_list);
-  checkTensorOnCuda(output);
+  checkTensorsDevice(input_list);
+  checkTensorDevice(output);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "reduce_scatter_v", rank_, input_list, {output});
@@ -1325,8 +1308,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::reduce_scatter_single(
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output);
   ensureTensorContiguous(input);
-  checkTensorOnCuda(output);
-  checkTensorOnCuda(input);
+  checkTensorDevice(output);
+  checkTensorDevice(input);
 
   if (input.numel() != output.numel() * comm_size_) {
     throw std::runtime_error(
@@ -1380,8 +1363,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::all_to_all_single(
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output);
   ensureTensorContiguous(input);
-  checkTensorOnCuda(output);
-  checkTensorOnCuda(input);
+  checkTensorDevice(output);
+  checkTensorDevice(input);
 
   if (input.numel() != output.numel()) {
     throw std::runtime_error(
@@ -1478,8 +1461,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::all_to_all_v_single(
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output);
   ensureTensorContiguous(input);
-  checkTensorOnCuda(output);
-  checkTensorOnCuda(input);
+  checkTensorDevice(output);
+  checkTensorDevice(input);
 
   // Validate split sizes vectors
   if (input_split_sizes.size() != static_cast<size_t>(comm_size_)) {
@@ -1609,8 +1592,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::all_to_all(
     const AllToAllOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  checkTensorsOnCuda(output_tensor_list);
-  checkTensorsOnCuda(input_tensor_list);
+  checkTensorsDevice(output_tensor_list);
+  checkTensorsDevice(input_tensor_list);
   if (output_tensor_list.size() != static_cast<size_t>(comm_size_) ||
       input_tensor_list.size() != static_cast<size_t>(comm_size_)) {
     throw std::runtime_error(
@@ -1732,8 +1715,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::scatter(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output_tensor);
-  checkTensorOnCuda(output_tensor);
-  checkTensorsOnCuda(input_tensor_list);
+  checkTensorDevice(output_tensor);
+  checkTensorsDevice(input_tensor_list);
 
   // Only the root rank needs valid input tensors
   if (rank_ == root) {
@@ -1837,8 +1820,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::gather(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(input_tensor);
-  checkTensorOnCuda(input_tensor);
-  checkTensorsOnCuda(output_tensor_list);
+  checkTensorDevice(input_tensor);
+  checkTensorsDevice(output_tensor_list);
 
   // Only the root rank needs valid output tensors
   if (rank_ == root) {

--- a/comms/torchcomms/nccl/TorchCommNCCL.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCL.cpp
@@ -22,6 +22,23 @@
 
 namespace torch::comms {
 
+namespace {
+
+void checkTensorOnCuda(const at::Tensor& tensor) {
+  TORCH_CHECK(
+      tensor.is_cuda(),
+      "Expected CUDA tensor but found tensor on ",
+      tensor.device());
+}
+
+void checkTensorsOnCuda(const std::vector<at::Tensor>& tensors) {
+  for (const auto& t : tensors) {
+    checkTensorOnCuda(t);
+  }
+}
+
+} // namespace
+
 ncclResult_t NCCLException::getResult() const noexcept {
   return result_;
 }
@@ -593,6 +610,7 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::send(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
+  checkTensorOnCuda(tensor);
 
   TracingGuard tracingGuard(name_, comm_size_, "send", dst, tensor, tensor);
 
@@ -637,6 +655,7 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::recv(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
+  checkTensorOnCuda(tensor);
 
   TracingGuard tracingGuard(name_, comm_size_, "recv", src, tensor, tensor);
 
@@ -675,7 +694,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::batch_op_issue(
     const BatchP2POptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-
   if (ops.empty()) {
     throw std::runtime_error("Cannot issue empty batch operation");
   }
@@ -685,6 +703,7 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::batch_op_issue(
   std::vector<at::Tensor> output_tensors;
 
   for (const auto& op : ops) {
+    checkTensorOnCuda(op.tensor);
     if (op.type == BatchSendRecv::P2POp::OpType::SEND) {
       at::Tensor tensor = op.tensor;
       ensureTensorContiguous(tensor);
@@ -778,6 +797,7 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::broadcast(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
+  checkTensorOnCuda(tensor);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "broadcast", root, tensor, tensor);
@@ -824,6 +844,7 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::all_reduce(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
+  checkTensorOnCuda(tensor);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_reduce", rank_, tensor, tensor);
@@ -872,6 +893,7 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::reduce(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
+  checkTensorOnCuda(tensor);
 
   TracingGuard tracingGuard(name_, comm_size_, "reduce", root, tensor, tensor);
 
@@ -934,6 +956,9 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::all_gather(
           "All tensors in tensor_list must have same size as input tensor");
     }
   }
+
+  checkTensorOnCuda(tensor);
+  checkTensorsOnCuda(tensor_list);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_gather", rank_, tensor_list, {tensor});
@@ -999,6 +1024,9 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::all_gather_v(
     ensureTensorContiguous(t);
   }
 
+  checkTensorOnCuda(tensor);
+  checkTensorsOnCuda(tensor_list);
+
   TracingGuard tracingGuard(
       name_, comm_size_, "all_gather_v", rank_, tensor_list, {tensor});
 
@@ -1062,6 +1090,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::all_gather_single(
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output);
   ensureTensorContiguous(input);
+  checkTensorOnCuda(output);
+  checkTensorOnCuda(input);
 
   if (output.numel() != input.numel() * comm_size_) {
     throw std::runtime_error(
@@ -1125,6 +1155,9 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::reduce_scatter(
           "All input tensors must have same size as output tensor");
     }
   }
+
+  checkTensorsOnCuda(input_list);
+  checkTensorOnCuda(output);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "reduce_scatter", rank_, input_list, {output});
@@ -1209,6 +1242,9 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::reduce_scatter_v(
     ensureTensorContiguous(t);
   }
 
+  checkTensorsOnCuda(input_list);
+  checkTensorOnCuda(output);
+
   TracingGuard tracingGuard(
       name_, comm_size_, "reduce_scatter_v", rank_, input_list, {output});
 
@@ -1289,6 +1325,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::reduce_scatter_single(
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output);
   ensureTensorContiguous(input);
+  checkTensorOnCuda(output);
+  checkTensorOnCuda(input);
 
   if (input.numel() != output.numel() * comm_size_) {
     throw std::runtime_error(
@@ -1342,6 +1380,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::all_to_all_single(
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output);
   ensureTensorContiguous(input);
+  checkTensorOnCuda(output);
+  checkTensorOnCuda(input);
 
   if (input.numel() != output.numel()) {
     throw std::runtime_error(
@@ -1438,6 +1478,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::all_to_all_v_single(
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output);
   ensureTensorContiguous(input);
+  checkTensorOnCuda(output);
+  checkTensorOnCuda(input);
 
   // Validate split sizes vectors
   if (input_split_sizes.size() != static_cast<size_t>(comm_size_)) {
@@ -1567,6 +1609,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::all_to_all(
     const AllToAllOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
+  checkTensorsOnCuda(output_tensor_list);
+  checkTensorsOnCuda(input_tensor_list);
   if (output_tensor_list.size() != static_cast<size_t>(comm_size_) ||
       input_tensor_list.size() != static_cast<size_t>(comm_size_)) {
     throw std::runtime_error(
@@ -1688,6 +1732,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::scatter(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output_tensor);
+  checkTensorOnCuda(output_tensor);
+  checkTensorsOnCuda(input_tensor_list);
 
   // Only the root rank needs valid input tensors
   if (rank_ == root) {
@@ -1791,6 +1837,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::gather(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(input_tensor);
+  checkTensorOnCuda(input_tensor);
+  checkTensorsOnCuda(output_tensor_list);
 
   // Only the root rank needs valid output tensors
   if (rank_ == root) {

--- a/comms/torchcomms/nccl/TorchCommNCCL.hpp
+++ b/comms/torchcomms/nccl/TorchCommNCCL.hpp
@@ -375,6 +375,8 @@ class TorchCommNCCL : public TorchCommBackend,
   bool getGraphCaptureMode();
   cudaStream_t getOperationStream(bool async_op);
   void ensureTensorContiguous(const at::Tensor& tensor);
+  void checkTensorDevice(const at::Tensor& tensor) const;
+  void checkTensorsDevice(const std::vector<at::Tensor>& tensors) const;
 
   void attachMemoryHook();
   void detachMemoryHook();

--- a/comms/torchcomms/nccl/TorchCommNCCLUtils.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCLUtils.cpp
@@ -470,6 +470,22 @@ void TorchCommNCCL::ensureTensorContiguous(const at::Tensor& tensor) {
   }
 }
 
+void TorchCommNCCL::checkTensorDevice(const at::Tensor& tensor) const {
+  TORCH_CHECK(
+      tensor.device().type() == device_.type(),
+      "Expected tensor on ",
+      device_.type(),
+      " but found tensor on ",
+      tensor.device());
+}
+
+void TorchCommNCCL::checkTensorsDevice(
+    const std::vector<at::Tensor>& tensors) const {
+  for (const auto& t : tensors) {
+    checkTensorDevice(t);
+  }
+}
+
 // Protected methods (not in the private section of the header)
 cudaEvent_t TorchCommNCCL::getEvent() {
   std::lock_guard<std::mutex> lock(event_pool_mutex_);

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -52,6 +52,19 @@ void validateIntDtype(const at::Tensor& tensor, std::string_view name) {
   }
 }
 
+void checkTensorOnCuda(const at::Tensor& tensor) {
+  TORCH_CHECK(
+      tensor.is_cuda(),
+      "Expected CUDA tensor but found tensor on ",
+      tensor.device());
+}
+
+void checkTensorsOnCuda(const std::vector<at::Tensor>& tensors) {
+  for (const auto& t : tensors) {
+    checkTensorOnCuda(t);
+  }
+}
+
 std::atomic<int> g_graphTimeoutMonitoringState{-1};
 
 } // namespace
@@ -678,6 +691,7 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::send(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
+  checkTensorOnCuda(tensor);
 
   TracingGuard tracingGuard(name_, comm_size_, "send", dst, tensor, tensor);
 
@@ -723,6 +737,7 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::recv(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
+  checkTensorOnCuda(tensor);
 
   TracingGuard tracingGuard(name_, comm_size_, "recv", src, tensor, tensor);
 
@@ -772,6 +787,7 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::batch_op_issue(
   std::vector<at::Tensor> output_tensors;
 
   for (const auto& op : ops) {
+    checkTensorOnCuda(op.tensor);
     if (op.type == BatchSendRecv::P2POp::OpType::SEND) {
       at::Tensor tensor = op.tensor;
       ensureTensorContiguous(tensor);
@@ -870,6 +886,7 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::broadcast(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
+  checkTensorOnCuda(tensor);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "broadcast", rank_, tensor, tensor);
@@ -917,6 +934,7 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::all_reduce(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
+  checkTensorOnCuda(tensor);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_reduce", rank_, tensor, tensor);
@@ -966,6 +984,7 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::reduce(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
+  checkTensorOnCuda(tensor);
 
   TracingGuard tracingGuard(name_, comm_size_, "reduce", root, tensor, tensor);
 
@@ -1029,6 +1048,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::all_gather(
           "All tensors in tensor_list must have same size as input tensor");
     }
   }
+  checkTensorOnCuda(tensor);
+  checkTensorsOnCuda(tensor_list);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_gather", rank_, tensor_list, {tensor});
@@ -1112,6 +1133,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::all_gather_v(
   for (const auto& t : tensor_list) {
     ensureTensorContiguous(t);
   }
+  checkTensorOnCuda(tensor);
+  checkTensorsOnCuda(tensor_list);
   TracingGuard tracingGuard(
       name_, comm_size_, "all_gather_v", rank_, tensor_list, {tensor});
 
@@ -1180,6 +1203,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::all_gather_single(
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output);
   ensureTensorContiguous(input);
+  checkTensorOnCuda(output);
+  checkTensorOnCuda(input);
 
   if (output.numel() != input.numel() * comm_size_) {
     throw std::runtime_error(
@@ -1271,6 +1296,7 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::all_gather_p_exec(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(input);
+  checkTensorOnCuda(input);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_gather_p_exec", rank_, {input}, {});
@@ -1325,6 +1351,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::reduce_scatter(
           "All input tensors must have same size as output tensor");
     }
   }
+  checkTensorsOnCuda(input_list);
+  checkTensorOnCuda(output);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "reduce_scatter", rank_, input_list, {output});
@@ -1411,6 +1439,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::reduce_scatter_v(
   for (const auto& t : input_list) {
     ensureTensorContiguous(t);
   }
+  checkTensorsOnCuda(input_list);
+  checkTensorOnCuda(output);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "reduce_scatter_v", rank_, input_list, {output});
@@ -1497,6 +1527,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::reduce_scatter_single(
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output);
   ensureTensorContiguous(input);
+  checkTensorOnCuda(output);
+  checkTensorOnCuda(input);
 
   if (input.numel() != output.numel() * comm_size_) {
     throw std::runtime_error(
@@ -1551,6 +1583,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::all_to_all_single(
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output);
   ensureTensorContiguous(input);
+  checkTensorOnCuda(output);
+  checkTensorOnCuda(input);
 
   if (input.numel() != output.numel()) {
     throw std::runtime_error(
@@ -1612,6 +1646,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::all_to_all_v_single(
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output);
   ensureTensorContiguous(input);
+  checkTensorOnCuda(output);
+  checkTensorOnCuda(input);
 
   // Validate split sizes vectors
   if (input_split_sizes.size() != static_cast<size_t>(comm_size_)) {
@@ -1715,6 +1751,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::all_to_all(
     const AllToAllOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
+  checkTensorsOnCuda(output_tensor_list);
+  checkTensorsOnCuda(input_tensor_list);
   if (output_tensor_list.size() != static_cast<size_t>(comm_size_) ||
       input_tensor_list.size() != static_cast<size_t>(comm_size_)) {
     throw std::runtime_error(
@@ -1805,18 +1843,14 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::device_alltoallv_single(
   ensureTensorContiguous(input);
   ensureTensorContiguous(output_split_sizes);
   ensureTensorContiguous(input_split_sizes);
+  checkTensorOnCuda(output);
+  checkTensorOnCuda(input);
+  checkTensorOnCuda(output_split_sizes);
+  checkTensorOnCuda(input_split_sizes);
 
   // Validate metadata tensor types - all must be int64_t (torch.int64)
   validateInt64Dtype(input_split_sizes, "input_split_sizes");
   validateInt64Dtype(output_split_sizes, "output_split_sizes");
-
-  // Validate metadata tensors are on CUDA
-  TORCH_CHECK(
-      input_split_sizes.is_cuda(),
-      "input_split_sizes must be a CUDA tensor for device_alltoallv_single");
-  TORCH_CHECK(
-      output_split_sizes.is_cuda(),
-      "output_split_sizes must be a CUDA tensor for device_alltoallv_single");
 
   TracingGuard tracingGuard(
       name_, comm_size_, "device_alltoallv_single", rank_, input, output);
@@ -1889,6 +1923,12 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::alltoallv_dynamic_dispatch(
   for (const auto& t : output_tensor_list) {
     ensureTensorContiguous(t);
   }
+  checkTensorOnCuda(input_tensor);
+  checkTensorsOnCuda(output_tensor_list);
+  checkTensorOnCuda(output_chunk_sizes_per_rank);
+  checkTensorOnCuda(input_chunk_sizes);
+  checkTensorOnCuda(input_chunk_indices);
+  checkTensorOnCuda(input_chunk_count_per_rank);
 
   // Validate metadata tensor types - all must be int64_t (torch.int64)
   validateInt64Dtype(input_chunk_sizes, "input_chunk_sizes");
@@ -1989,6 +2029,11 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::alltoallv_dynamic_combine(
   ensureTensorContiguous(input_chunk_sizes);
   ensureTensorContiguous(input_chunk_indices);
   ensureTensorContiguous(input_chunk_count_per_rank);
+  checkTensorOnCuda(output_tensor);
+  checkTensorOnCuda(input_tensor);
+  checkTensorOnCuda(input_chunk_sizes);
+  checkTensorOnCuda(input_chunk_indices);
+  checkTensorOnCuda(input_chunk_count_per_rank);
 
   // Validate metadata tensor types - all must be int64_t (torch.int64)
   validateInt64Dtype(input_chunk_sizes, "input_chunk_sizes");
@@ -2095,6 +2140,12 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::alltoallv_dedup_exec(
   ensureTensorContiguous(send_indices);
   ensureTensorContiguous(forward_indices);
   ensureTensorContiguous(recv_indices);
+  checkTensorOnCuda(output_tensor);
+  checkTensorOnCuda(recv_block_ids);
+  checkTensorOnCuda(input_tensor);
+  checkTensorOnCuda(send_indices);
+  checkTensorOnCuda(forward_indices);
+  checkTensorOnCuda(recv_indices);
 
   validateIntDtype(send_indices, "send_indices");
   validateIntDtype(forward_indices, "forward_indices");
@@ -2157,6 +2208,11 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::alltoallv_dedup_combine(
   ensureTensorContiguous(send_indices);
   ensureTensorContiguous(forward_indices);
   ensureTensorContiguous(recv_indices);
+  checkTensorOnCuda(output_tensor);
+  checkTensorOnCuda(input_tensor);
+  checkTensorOnCuda(send_indices);
+  checkTensorOnCuda(forward_indices);
+  checkTensorOnCuda(recv_indices);
 
   validateIntDtype(send_indices, "send_indices");
   validateIntDtype(forward_indices, "forward_indices");
@@ -2211,6 +2267,9 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::reduce_scatter_quantized(
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output);
   ensureTensorContiguous(input);
+  checkTensorOnCuda(output);
+  checkTensorOnCuda(input);
+  checkTensorOnCuda(seed);
 
   TORCH_CHECK(
       input.scalar_type() == at::kFloat,
@@ -2325,6 +2384,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::scatter(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output_tensor);
+  checkTensorOnCuda(output_tensor);
+  checkTensorsOnCuda(input_tensor_list);
 
   // Only the root rank needs valid input tensors
   if (rank_ == root) {
@@ -2429,6 +2490,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::gather(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(input_tensor);
+  checkTensorOnCuda(input_tensor);
+  checkTensorsOnCuda(output_tensor_list);
 
   // Only the root rank needs valid output tensors
   if (rank_ == root) {

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -52,19 +52,6 @@ void validateIntDtype(const at::Tensor& tensor, std::string_view name) {
   }
 }
 
-void checkTensorOnCuda(const at::Tensor& tensor) {
-  TORCH_CHECK(
-      tensor.is_cuda(),
-      "Expected CUDA tensor but found tensor on ",
-      tensor.device());
-}
-
-void checkTensorsOnCuda(const std::vector<at::Tensor>& tensors) {
-  for (const auto& t : tensors) {
-    checkTensorOnCuda(t);
-  }
-}
-
 std::atomic<int> g_graphTimeoutMonitoringState{-1};
 
 } // namespace
@@ -691,7 +678,7 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::send(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
-  checkTensorOnCuda(tensor);
+  checkTensorDevice(tensor);
 
   TracingGuard tracingGuard(name_, comm_size_, "send", dst, tensor, tensor);
 
@@ -737,7 +724,7 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::recv(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
-  checkTensorOnCuda(tensor);
+  checkTensorDevice(tensor);
 
   TracingGuard tracingGuard(name_, comm_size_, "recv", src, tensor, tensor);
 
@@ -787,7 +774,7 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::batch_op_issue(
   std::vector<at::Tensor> output_tensors;
 
   for (const auto& op : ops) {
-    checkTensorOnCuda(op.tensor);
+    checkTensorDevice(op.tensor);
     if (op.type == BatchSendRecv::P2POp::OpType::SEND) {
       at::Tensor tensor = op.tensor;
       ensureTensorContiguous(tensor);
@@ -886,7 +873,7 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::broadcast(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
-  checkTensorOnCuda(tensor);
+  checkTensorDevice(tensor);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "broadcast", rank_, tensor, tensor);
@@ -934,7 +921,7 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::all_reduce(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
-  checkTensorOnCuda(tensor);
+  checkTensorDevice(tensor);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_reduce", rank_, tensor, tensor);
@@ -984,7 +971,7 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::reduce(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
-  checkTensorOnCuda(tensor);
+  checkTensorDevice(tensor);
 
   TracingGuard tracingGuard(name_, comm_size_, "reduce", root, tensor, tensor);
 
@@ -1048,8 +1035,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::all_gather(
           "All tensors in tensor_list must have same size as input tensor");
     }
   }
-  checkTensorOnCuda(tensor);
-  checkTensorsOnCuda(tensor_list);
+  checkTensorDevice(tensor);
+  checkTensorsDevice(tensor_list);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_gather", rank_, tensor_list, {tensor});
@@ -1133,8 +1120,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::all_gather_v(
   for (const auto& t : tensor_list) {
     ensureTensorContiguous(t);
   }
-  checkTensorOnCuda(tensor);
-  checkTensorsOnCuda(tensor_list);
+  checkTensorDevice(tensor);
+  checkTensorsDevice(tensor_list);
   TracingGuard tracingGuard(
       name_, comm_size_, "all_gather_v", rank_, tensor_list, {tensor});
 
@@ -1203,8 +1190,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::all_gather_single(
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output);
   ensureTensorContiguous(input);
-  checkTensorOnCuda(output);
-  checkTensorOnCuda(input);
+  checkTensorDevice(output);
+  checkTensorDevice(input);
 
   if (output.numel() != input.numel() * comm_size_) {
     throw std::runtime_error(
@@ -1296,7 +1283,7 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::all_gather_p_exec(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(input);
-  checkTensorOnCuda(input);
+  checkTensorDevice(input);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_gather_p_exec", rank_, {input}, {});
@@ -1351,8 +1338,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::reduce_scatter(
           "All input tensors must have same size as output tensor");
     }
   }
-  checkTensorsOnCuda(input_list);
-  checkTensorOnCuda(output);
+  checkTensorsDevice(input_list);
+  checkTensorDevice(output);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "reduce_scatter", rank_, input_list, {output});
@@ -1439,8 +1426,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::reduce_scatter_v(
   for (const auto& t : input_list) {
     ensureTensorContiguous(t);
   }
-  checkTensorsOnCuda(input_list);
-  checkTensorOnCuda(output);
+  checkTensorsDevice(input_list);
+  checkTensorDevice(output);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "reduce_scatter_v", rank_, input_list, {output});
@@ -1527,8 +1514,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::reduce_scatter_single(
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output);
   ensureTensorContiguous(input);
-  checkTensorOnCuda(output);
-  checkTensorOnCuda(input);
+  checkTensorDevice(output);
+  checkTensorDevice(input);
 
   if (input.numel() != output.numel() * comm_size_) {
     throw std::runtime_error(
@@ -1583,8 +1570,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::all_to_all_single(
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output);
   ensureTensorContiguous(input);
-  checkTensorOnCuda(output);
-  checkTensorOnCuda(input);
+  checkTensorDevice(output);
+  checkTensorDevice(input);
 
   if (input.numel() != output.numel()) {
     throw std::runtime_error(
@@ -1646,8 +1633,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::all_to_all_v_single(
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output);
   ensureTensorContiguous(input);
-  checkTensorOnCuda(output);
-  checkTensorOnCuda(input);
+  checkTensorDevice(output);
+  checkTensorDevice(input);
 
   // Validate split sizes vectors
   if (input_split_sizes.size() != static_cast<size_t>(comm_size_)) {
@@ -1751,8 +1738,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::all_to_all(
     const AllToAllOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  checkTensorsOnCuda(output_tensor_list);
-  checkTensorsOnCuda(input_tensor_list);
+  checkTensorsDevice(output_tensor_list);
+  checkTensorsDevice(input_tensor_list);
   if (output_tensor_list.size() != static_cast<size_t>(comm_size_) ||
       input_tensor_list.size() != static_cast<size_t>(comm_size_)) {
     throw std::runtime_error(
@@ -1843,10 +1830,10 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::device_alltoallv_single(
   ensureTensorContiguous(input);
   ensureTensorContiguous(output_split_sizes);
   ensureTensorContiguous(input_split_sizes);
-  checkTensorOnCuda(output);
-  checkTensorOnCuda(input);
-  checkTensorOnCuda(output_split_sizes);
-  checkTensorOnCuda(input_split_sizes);
+  checkTensorDevice(output);
+  checkTensorDevice(input);
+  checkTensorDevice(output_split_sizes);
+  checkTensorDevice(input_split_sizes);
 
   // Validate metadata tensor types - all must be int64_t (torch.int64)
   validateInt64Dtype(input_split_sizes, "input_split_sizes");
@@ -1923,12 +1910,12 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::alltoallv_dynamic_dispatch(
   for (const auto& t : output_tensor_list) {
     ensureTensorContiguous(t);
   }
-  checkTensorOnCuda(input_tensor);
-  checkTensorsOnCuda(output_tensor_list);
-  checkTensorOnCuda(output_chunk_sizes_per_rank);
-  checkTensorOnCuda(input_chunk_sizes);
-  checkTensorOnCuda(input_chunk_indices);
-  checkTensorOnCuda(input_chunk_count_per_rank);
+  checkTensorDevice(input_tensor);
+  checkTensorsDevice(output_tensor_list);
+  checkTensorDevice(output_chunk_sizes_per_rank);
+  checkTensorDevice(input_chunk_sizes);
+  checkTensorDevice(input_chunk_indices);
+  checkTensorDevice(input_chunk_count_per_rank);
 
   // Validate metadata tensor types - all must be int64_t (torch.int64)
   validateInt64Dtype(input_chunk_sizes, "input_chunk_sizes");
@@ -2029,11 +2016,11 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::alltoallv_dynamic_combine(
   ensureTensorContiguous(input_chunk_sizes);
   ensureTensorContiguous(input_chunk_indices);
   ensureTensorContiguous(input_chunk_count_per_rank);
-  checkTensorOnCuda(output_tensor);
-  checkTensorOnCuda(input_tensor);
-  checkTensorOnCuda(input_chunk_sizes);
-  checkTensorOnCuda(input_chunk_indices);
-  checkTensorOnCuda(input_chunk_count_per_rank);
+  checkTensorDevice(output_tensor);
+  checkTensorDevice(input_tensor);
+  checkTensorDevice(input_chunk_sizes);
+  checkTensorDevice(input_chunk_indices);
+  checkTensorDevice(input_chunk_count_per_rank);
 
   // Validate metadata tensor types - all must be int64_t (torch.int64)
   validateInt64Dtype(input_chunk_sizes, "input_chunk_sizes");
@@ -2140,12 +2127,12 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::alltoallv_dedup_exec(
   ensureTensorContiguous(send_indices);
   ensureTensorContiguous(forward_indices);
   ensureTensorContiguous(recv_indices);
-  checkTensorOnCuda(output_tensor);
-  checkTensorOnCuda(recv_block_ids);
-  checkTensorOnCuda(input_tensor);
-  checkTensorOnCuda(send_indices);
-  checkTensorOnCuda(forward_indices);
-  checkTensorOnCuda(recv_indices);
+  checkTensorDevice(output_tensor);
+  checkTensorDevice(recv_block_ids);
+  checkTensorDevice(input_tensor);
+  checkTensorDevice(send_indices);
+  checkTensorDevice(forward_indices);
+  checkTensorDevice(recv_indices);
 
   validateIntDtype(send_indices, "send_indices");
   validateIntDtype(forward_indices, "forward_indices");
@@ -2208,11 +2195,11 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::alltoallv_dedup_combine(
   ensureTensorContiguous(send_indices);
   ensureTensorContiguous(forward_indices);
   ensureTensorContiguous(recv_indices);
-  checkTensorOnCuda(output_tensor);
-  checkTensorOnCuda(input_tensor);
-  checkTensorOnCuda(send_indices);
-  checkTensorOnCuda(forward_indices);
-  checkTensorOnCuda(recv_indices);
+  checkTensorDevice(output_tensor);
+  checkTensorDevice(input_tensor);
+  checkTensorDevice(send_indices);
+  checkTensorDevice(forward_indices);
+  checkTensorDevice(recv_indices);
 
   validateIntDtype(send_indices, "send_indices");
   validateIntDtype(forward_indices, "forward_indices");
@@ -2267,9 +2254,9 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::reduce_scatter_quantized(
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output);
   ensureTensorContiguous(input);
-  checkTensorOnCuda(output);
-  checkTensorOnCuda(input);
-  checkTensorOnCuda(seed);
+  checkTensorDevice(output);
+  checkTensorDevice(input);
+  checkTensorDevice(seed);
 
   TORCH_CHECK(
       input.scalar_type() == at::kFloat,
@@ -2384,8 +2371,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::scatter(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output_tensor);
-  checkTensorOnCuda(output_tensor);
-  checkTensorsOnCuda(input_tensor_list);
+  checkTensorDevice(output_tensor);
+  checkTensorsDevice(input_tensor_list);
 
   // Only the root rank needs valid input tensors
   if (rank_ == root) {
@@ -2490,8 +2477,8 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::gather(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(input_tensor);
-  checkTensorOnCuda(input_tensor);
-  checkTensorsOnCuda(output_tensor_list);
+  checkTensorDevice(input_tensor);
+  checkTensorsDevice(output_tensor_list);
 
   // Only the root rank needs valid output tensors
   if (rank_ == root) {

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
@@ -514,6 +514,8 @@ class TorchCommNCCLX : public TorchCommBackend,
   void checkWorkQueue();
   bool getGraphCaptureMode();
   void ensureTensorContiguous(const at::Tensor& tensor);
+  void checkTensorDevice(const at::Tensor& tensor) const;
+  void checkTensorsDevice(const std::vector<at::Tensor>& tensors) const;
 
   // Initialize the CachingAllocatorHook singleton
   void attachMemoryHook();

--- a/comms/torchcomms/ncclx/TorchCommNCCLXUtils.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXUtils.cpp
@@ -441,6 +441,22 @@ void TorchCommNCCLX::ensureTensorContiguous(const at::Tensor& tensor) {
   }
 }
 
+void TorchCommNCCLX::checkTensorDevice(const at::Tensor& tensor) const {
+  TORCH_CHECK(
+      tensor.device().type() == device_.type(),
+      "Expected tensor on ",
+      device_.type(),
+      " but found tensor on ",
+      tensor.device());
+}
+
+void TorchCommNCCLX::checkTensorsDevice(
+    const std::vector<at::Tensor>& tensors) const {
+  for (const auto& t : tensors) {
+    checkTensorDevice(t);
+  }
+}
+
 // Protected methods (not in the private section of the header)
 cudaEvent_t TorchCommNCCLX::getEvent() {
   std::lock_guard<std::mutex> lock(event_pool_mutex_);

--- a/comms/torchcomms/rccl/TorchCommRCCL.cpp
+++ b/comms/torchcomms/rccl/TorchCommRCCL.cpp
@@ -19,6 +19,23 @@
 
 namespace torch::comms {
 
+namespace {
+
+void checkTensorOnCuda(const at::Tensor& tensor) {
+  TORCH_CHECK(
+      tensor.is_cuda(),
+      "Expected CUDA tensor but found tensor on ",
+      tensor.device());
+}
+
+void checkTensorsOnCuda(const std::vector<at::Tensor>& tensors) {
+  for (const auto& t : tensors) {
+    checkTensorOnCuda(t);
+  }
+}
+
+} // namespace
+
 ncclResult_t RCCLException::getResult() const {
   return result_;
 }
@@ -377,6 +394,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::send(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
+  checkTensorOnCuda(tensor);
 
   TracingGuard tracingGuard(name_, comm_size_, "send", dst, tensor, tensor);
 
@@ -416,6 +434,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::recv(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
+  checkTensorOnCuda(tensor);
 
   TracingGuard tracingGuard(name_, comm_size_, "recv", src, tensor, tensor);
 
@@ -464,6 +483,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::batch_op_issue(
   std::vector<at::Tensor> output_tensors;
 
   for (const auto& op : ops) {
+    checkTensorOnCuda(op.tensor);
     if (op.type == BatchSendRecv::P2POp::OpType::SEND) {
       at::Tensor tensor = op.tensor;
       ensureTensorContiguous(tensor);
@@ -557,6 +577,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::broadcast(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
+  checkTensorOnCuda(tensor);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "broadcast", root, tensor, tensor);
@@ -598,6 +619,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::all_reduce(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
+  checkTensorOnCuda(tensor);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_reduce", rank_, tensor, tensor);
@@ -641,6 +663,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::reduce(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
+  checkTensorOnCuda(tensor);
 
   TracingGuard tracingGuard(name_, comm_size_, "reduce", root, tensor, tensor);
 
@@ -698,6 +721,9 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::all_gather(
           "All tensors in tensor_list must have same size as input tensor");
     }
   }
+
+  checkTensorOnCuda(tensor);
+  checkTensorsOnCuda(tensor_list);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_gather", rank_, tensor_list, {tensor});
@@ -757,6 +783,9 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::all_gather_v(
   for (const auto& t : tensor_list) {
     ensureTensorContiguous(t);
   }
+
+  checkTensorOnCuda(tensor);
+  checkTensorsOnCuda(tensor_list);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_gather_v", rank_, tensor_list, {tensor});
@@ -821,6 +850,8 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::all_gather_single(
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output);
   ensureTensorContiguous(input);
+  checkTensorOnCuda(output);
+  checkTensorOnCuda(input);
 
   if (output.numel() != input.numel() * comm_size_) {
     throw std::runtime_error(
@@ -879,6 +910,9 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::reduce_scatter(
           "All input tensors must have same size as output tensor");
     }
   }
+
+  checkTensorOnCuda(output);
+  checkTensorsOnCuda(input_list);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "reduce_scatter", rank_, input_list, {output});
@@ -967,6 +1001,9 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::reduce_scatter_v(
     ensureTensorContiguous(t);
   }
 
+  checkTensorOnCuda(output);
+  checkTensorsOnCuda(input_list);
+
   TracingGuard tracingGuard(
       name_, comm_size_, "reduce_scatter_v", rank_, input_list, {output});
 
@@ -1054,6 +1091,8 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::reduce_scatter_single(
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output);
   ensureTensorContiguous(input);
+  checkTensorOnCuda(output);
+  checkTensorOnCuda(input);
 
   if (input.numel() != output.numel() * comm_size_) {
     throw std::runtime_error(
@@ -1102,6 +1141,8 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::all_to_all_single(
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output);
   ensureTensorContiguous(input);
+  checkTensorOnCuda(output);
+  checkTensorOnCuda(input);
 
   if (input.numel() != output.numel()) {
     throw std::runtime_error(
@@ -1156,6 +1197,8 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::all_to_all_v_single(
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output);
   ensureTensorContiguous(input);
+  checkTensorOnCuda(output);
+  checkTensorOnCuda(input);
 
   // Validate split sizes vectors
   if (input_split_sizes.size() != static_cast<size_t>(comm_size_)) {
@@ -1265,6 +1308,9 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::all_to_all(
     ensureTensorContiguous(output_tensor_list[i]);
   }
 
+  checkTensorsOnCuda(output_tensor_list);
+  checkTensorsOnCuda(input_tensor_list);
+
   TracingGuard tracingGuard(
       name_,
       comm_size_,
@@ -1371,6 +1417,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::scatter(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output_tensor);
+  checkTensorOnCuda(output_tensor);
 
   // Only the root rank needs valid input tensors
   if (rank_ == root) {
@@ -1386,6 +1433,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::scatter(
             "All input tensors must have same size as output tensor");
       }
     }
+    checkTensorsOnCuda(input_tensor_list);
   }
 
   TracingGuard tracingGuard(
@@ -1477,6 +1525,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::gather(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(input_tensor);
+  checkTensorOnCuda(input_tensor);
 
   // Only the root rank needs valid output tensors
   if (rank_ == root) {
@@ -1492,6 +1541,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::gather(
             "All output tensors must have same size as input tensor");
       }
     }
+    checkTensorsOnCuda(output_tensor_list);
   }
 
   TracingGuard tracingGuard(

--- a/comms/torchcomms/rccl/TorchCommRCCL.cpp
+++ b/comms/torchcomms/rccl/TorchCommRCCL.cpp
@@ -19,23 +19,6 @@
 
 namespace torch::comms {
 
-namespace {
-
-void checkTensorOnCuda(const at::Tensor& tensor) {
-  TORCH_CHECK(
-      tensor.is_cuda(),
-      "Expected CUDA tensor but found tensor on ",
-      tensor.device());
-}
-
-void checkTensorsOnCuda(const std::vector<at::Tensor>& tensors) {
-  for (const auto& t : tensors) {
-    checkTensorOnCuda(t);
-  }
-}
-
-} // namespace
-
 ncclResult_t RCCLException::getResult() const {
   return result_;
 }
@@ -394,7 +377,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::send(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
-  checkTensorOnCuda(tensor);
+  checkTensorDevice(tensor);
 
   TracingGuard tracingGuard(name_, comm_size_, "send", dst, tensor, tensor);
 
@@ -434,7 +417,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::recv(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
-  checkTensorOnCuda(tensor);
+  checkTensorDevice(tensor);
 
   TracingGuard tracingGuard(name_, comm_size_, "recv", src, tensor, tensor);
 
@@ -483,7 +466,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::batch_op_issue(
   std::vector<at::Tensor> output_tensors;
 
   for (const auto& op : ops) {
-    checkTensorOnCuda(op.tensor);
+    checkTensorDevice(op.tensor);
     if (op.type == BatchSendRecv::P2POp::OpType::SEND) {
       at::Tensor tensor = op.tensor;
       ensureTensorContiguous(tensor);
@@ -577,7 +560,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::broadcast(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
-  checkTensorOnCuda(tensor);
+  checkTensorDevice(tensor);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "broadcast", root, tensor, tensor);
@@ -619,7 +602,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::all_reduce(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
-  checkTensorOnCuda(tensor);
+  checkTensorDevice(tensor);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_reduce", rank_, tensor, tensor);
@@ -663,7 +646,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::reduce(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
-  checkTensorOnCuda(tensor);
+  checkTensorDevice(tensor);
 
   TracingGuard tracingGuard(name_, comm_size_, "reduce", root, tensor, tensor);
 
@@ -722,8 +705,8 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::all_gather(
     }
   }
 
-  checkTensorOnCuda(tensor);
-  checkTensorsOnCuda(tensor_list);
+  checkTensorDevice(tensor);
+  checkTensorsDevice(tensor_list);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_gather", rank_, tensor_list, {tensor});
@@ -784,8 +767,8 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::all_gather_v(
     ensureTensorContiguous(t);
   }
 
-  checkTensorOnCuda(tensor);
-  checkTensorsOnCuda(tensor_list);
+  checkTensorDevice(tensor);
+  checkTensorsDevice(tensor_list);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_gather_v", rank_, tensor_list, {tensor});
@@ -850,8 +833,8 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::all_gather_single(
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output);
   ensureTensorContiguous(input);
-  checkTensorOnCuda(output);
-  checkTensorOnCuda(input);
+  checkTensorDevice(output);
+  checkTensorDevice(input);
 
   if (output.numel() != input.numel() * comm_size_) {
     throw std::runtime_error(
@@ -911,8 +894,8 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::reduce_scatter(
     }
   }
 
-  checkTensorOnCuda(output);
-  checkTensorsOnCuda(input_list);
+  checkTensorDevice(output);
+  checkTensorsDevice(input_list);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "reduce_scatter", rank_, input_list, {output});
@@ -1001,8 +984,8 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::reduce_scatter_v(
     ensureTensorContiguous(t);
   }
 
-  checkTensorOnCuda(output);
-  checkTensorsOnCuda(input_list);
+  checkTensorDevice(output);
+  checkTensorsDevice(input_list);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "reduce_scatter_v", rank_, input_list, {output});
@@ -1091,8 +1074,8 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::reduce_scatter_single(
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output);
   ensureTensorContiguous(input);
-  checkTensorOnCuda(output);
-  checkTensorOnCuda(input);
+  checkTensorDevice(output);
+  checkTensorDevice(input);
 
   if (input.numel() != output.numel() * comm_size_) {
     throw std::runtime_error(
@@ -1141,8 +1124,8 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::all_to_all_single(
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output);
   ensureTensorContiguous(input);
-  checkTensorOnCuda(output);
-  checkTensorOnCuda(input);
+  checkTensorDevice(output);
+  checkTensorDevice(input);
 
   if (input.numel() != output.numel()) {
     throw std::runtime_error(
@@ -1197,8 +1180,8 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::all_to_all_v_single(
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output);
   ensureTensorContiguous(input);
-  checkTensorOnCuda(output);
-  checkTensorOnCuda(input);
+  checkTensorDevice(output);
+  checkTensorDevice(input);
 
   // Validate split sizes vectors
   if (input_split_sizes.size() != static_cast<size_t>(comm_size_)) {
@@ -1308,8 +1291,8 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::all_to_all(
     ensureTensorContiguous(output_tensor_list[i]);
   }
 
-  checkTensorsOnCuda(output_tensor_list);
-  checkTensorsOnCuda(input_tensor_list);
+  checkTensorsDevice(output_tensor_list);
+  checkTensorsDevice(input_tensor_list);
 
   TracingGuard tracingGuard(
       name_,
@@ -1417,7 +1400,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::scatter(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output_tensor);
-  checkTensorOnCuda(output_tensor);
+  checkTensorDevice(output_tensor);
 
   // Only the root rank needs valid input tensors
   if (rank_ == root) {
@@ -1433,7 +1416,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::scatter(
             "All input tensors must have same size as output tensor");
       }
     }
-    checkTensorsOnCuda(input_tensor_list);
+    checkTensorsDevice(input_tensor_list);
   }
 
   TracingGuard tracingGuard(
@@ -1525,7 +1508,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::gather(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(input_tensor);
-  checkTensorOnCuda(input_tensor);
+  checkTensorDevice(input_tensor);
 
   // Only the root rank needs valid output tensors
   if (rank_ == root) {
@@ -1541,7 +1524,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::gather(
             "All output tensors must have same size as input tensor");
       }
     }
-    checkTensorsOnCuda(output_tensor_list);
+    checkTensorsDevice(output_tensor_list);
   }
 
   TracingGuard tracingGuard(

--- a/comms/torchcomms/rccl/TorchCommRCCL.hpp
+++ b/comms/torchcomms/rccl/TorchCommRCCL.hpp
@@ -356,6 +356,8 @@ class TorchCommRCCL : public TorchCommBackend,
   void enqueueWork(c10::intrusive_ptr<TorchWorkRCCL> work, hipStream_t stream);
   hipStream_t getOperationStream(bool async_op);
   void ensureTensorContiguous(const at::Tensor& tensor);
+  void checkTensorDevice(const at::Tensor& tensor) const;
+  void checkTensorsDevice(const std::vector<at::Tensor>& tensors) const;
 
   void attachMemoryHook();
   void detachMemoryHook();

--- a/comms/torchcomms/rccl/TorchCommRCCLUtils.cpp
+++ b/comms/torchcomms/rccl/TorchCommRCCLUtils.cpp
@@ -366,6 +366,31 @@ void TorchCommRCCL::ensureTensorContiguous(const at::Tensor& tensor) {
   }
 }
 
+void TorchCommRCCL::checkTensorDevice(const at::Tensor& tensor) const {
+  auto expected = device_.type();
+  auto actual = tensor.device().type();
+  // HIP masquerades as CUDA in ROCm builds
+  if (expected == c10::DeviceType::HIP) {
+    expected = c10::DeviceType::CUDA;
+  }
+  if (actual == c10::DeviceType::HIP) {
+    actual = c10::DeviceType::CUDA;
+  }
+  TORCH_CHECK(
+      actual == expected,
+      "Expected tensor on ",
+      device_.type(),
+      " but found tensor on ",
+      tensor.device());
+}
+
+void TorchCommRCCL::checkTensorsDevice(
+    const std::vector<at::Tensor>& tensors) const {
+  for (const auto& t : tensors) {
+    checkTensorDevice(t);
+  }
+}
+
 // Protected methods (not in the private section of the header)
 hipEvent_t TorchCommRCCL::getEvent() {
   std::lock_guard<std::mutex> lock(event_pool_mutex_);

--- a/comms/torchcomms/rcclx/TorchCommRCCLX.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLX.cpp
@@ -31,6 +31,23 @@ using c10::hip::HIPCachingAllocator::TraceEntry;
 
 namespace torch::comms {
 
+namespace {
+
+void checkTensorOnCuda(const at::Tensor& tensor) {
+  TORCH_CHECK(
+      tensor.is_cuda(),
+      "Expected CUDA tensor but found tensor on ",
+      tensor.device());
+}
+
+void checkTensorsOnCuda(const std::vector<at::Tensor>& tensors) {
+  for (const auto& t : tensors) {
+    checkTensorOnCuda(t);
+  }
+}
+
+} // namespace
+
 ncclResult_t RCCLXException::getResult() const {
   return result_;
 }
@@ -389,6 +406,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::send(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
+  checkTensorOnCuda(tensor);
 
   TracingGuard tracingGuard(name_, comm_size_, "send", dst, tensor, tensor);
 
@@ -433,6 +451,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::recv(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
+  checkTensorOnCuda(tensor);
 
   TracingGuard tracingGuard(name_, comm_size_, "recv", src, {tensor}, {tensor});
 
@@ -481,6 +500,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::batch_op_issue(
   std::vector<at::Tensor> output_tensors;
 
   for (const auto& op : ops) {
+    checkTensorOnCuda(op.tensor);
     if (op.type == BatchSendRecv::P2POp::OpType::SEND) {
       at::Tensor tensor = op.tensor;
       ensureTensorContiguous(tensor);
@@ -578,6 +598,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::broadcast(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
+  checkTensorOnCuda(tensor);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "broadcast", rank_, {tensor}, {tensor});
@@ -624,6 +645,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::all_reduce(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
+  checkTensorOnCuda(tensor);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_reduce", rank_, {tensor}, {tensor});
@@ -671,6 +693,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::reduce(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
+  checkTensorOnCuda(tensor);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "reduce", rank_, {tensor}, {tensor});
@@ -734,6 +757,9 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::all_gather(
           "All tensors in tensor_list must have same size as input tensor");
     }
   }
+
+  checkTensorOnCuda(tensor);
+  checkTensorsOnCuda(tensor_list);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_gather", rank_, tensor_list, {tensor});
@@ -802,6 +828,9 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::all_gather_v(
     ensureTensorContiguous(t);
   }
 
+  checkTensorOnCuda(tensor);
+  checkTensorsOnCuda(tensor_list);
+
   TracingGuard tracingGuard(
       name_, comm_size_, "all_gather_v", rank_, tensor_list, {tensor});
 
@@ -868,6 +897,8 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::all_gather_single(
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output);
   ensureTensorContiguous(input);
+  checkTensorOnCuda(output);
+  checkTensorOnCuda(input);
 
   if (output.numel() != input.numel() * comm_size_) {
     throw std::runtime_error(
@@ -931,6 +962,9 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::reduce_scatter(
           "All input tensors must have same size as output tensor");
     }
   }
+
+  checkTensorOnCuda(output);
+  checkTensorsOnCuda(input_list);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "reduce_scatter", rank_, input_list, {output});
@@ -1023,6 +1057,9 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::reduce_scatter_v(
     ensureTensorContiguous(t);
   }
 
+  checkTensorOnCuda(output);
+  checkTensorsOnCuda(input_list);
+
   TracingGuard tracingGuard(
       name_, comm_size_, "reduce_scatter_v", rank_, input_list, {output});
 
@@ -1113,6 +1150,8 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::reduce_scatter_single(
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output);
   ensureTensorContiguous(input);
+  checkTensorOnCuda(output);
+  checkTensorOnCuda(input);
 
   if (input.numel() != output.numel() * comm_size_) {
     throw std::runtime_error(
@@ -1166,6 +1205,8 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::all_to_all_single(
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output);
   ensureTensorContiguous(input);
+  checkTensorOnCuda(output);
+  checkTensorOnCuda(input);
 
   if (input.numel() != output.numel()) {
     throw std::runtime_error(
@@ -1225,6 +1266,8 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::all_to_all_v_single(
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output);
   ensureTensorContiguous(input);
+  checkTensorOnCuda(output);
+  checkTensorOnCuda(input);
 
   // Validate split sizes vectors
   if (input_split_sizes.size() != static_cast<size_t>(comm_size_)) {
@@ -1338,6 +1381,9 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::all_to_all(
     ensureTensorContiguous(input_tensor_list[i]);
     ensureTensorContiguous(output_tensor_list[i]);
   }
+
+  checkTensorsOnCuda(output_tensor_list);
+  checkTensorsOnCuda(input_tensor_list);
 
   TracingGuard tracingGuard(
       name_,
@@ -1455,6 +1501,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::scatter(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output_tensor);
+  checkTensorOnCuda(output_tensor);
 
   // Only the root rank needs valid input tensors
   if (rank_ == root) {
@@ -1470,6 +1517,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::scatter(
             "All input tensors must have same size as output tensor");
       }
     }
+    checkTensorsOnCuda(input_tensor_list);
   }
 
   TracingGuard tracingGuard(
@@ -1564,6 +1612,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::gather(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(input_tensor);
+  checkTensorOnCuda(input_tensor);
 
   // Only the root rank needs valid output tensors
   if (rank_ == root) {
@@ -1579,6 +1628,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::gather(
             "All output tensors must have same size as input tensor");
       }
     }
+    checkTensorsOnCuda(output_tensor_list);
   }
 
   TracingGuard tracingGuard(
@@ -1671,6 +1721,7 @@ TorchCommBackend::AllGatherPHandle TorchCommRCCLX::all_gather_p_init(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output);
+  checkTensorOnCuda(output);
 
   // Calculate max receive count (total elements in output) and buffer size
   size_t maxRecvCount = output.numel();
@@ -1724,6 +1775,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::all_gather_p_exec(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(input);
+  checkTensorOnCuda(input);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_gather_p_exec", rank_, {input}, {});

--- a/comms/torchcomms/rcclx/TorchCommRCCLX.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLX.cpp
@@ -31,23 +31,6 @@ using c10::hip::HIPCachingAllocator::TraceEntry;
 
 namespace torch::comms {
 
-namespace {
-
-void checkTensorOnCuda(const at::Tensor& tensor) {
-  TORCH_CHECK(
-      tensor.is_cuda(),
-      "Expected CUDA tensor but found tensor on ",
-      tensor.device());
-}
-
-void checkTensorsOnCuda(const std::vector<at::Tensor>& tensors) {
-  for (const auto& t : tensors) {
-    checkTensorOnCuda(t);
-  }
-}
-
-} // namespace
-
 ncclResult_t RCCLXException::getResult() const {
   return result_;
 }
@@ -406,7 +389,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::send(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
-  checkTensorOnCuda(tensor);
+  checkTensorDevice(tensor);
 
   TracingGuard tracingGuard(name_, comm_size_, "send", dst, tensor, tensor);
 
@@ -451,7 +434,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::recv(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
-  checkTensorOnCuda(tensor);
+  checkTensorDevice(tensor);
 
   TracingGuard tracingGuard(name_, comm_size_, "recv", src, {tensor}, {tensor});
 
@@ -500,7 +483,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::batch_op_issue(
   std::vector<at::Tensor> output_tensors;
 
   for (const auto& op : ops) {
-    checkTensorOnCuda(op.tensor);
+    checkTensorDevice(op.tensor);
     if (op.type == BatchSendRecv::P2POp::OpType::SEND) {
       at::Tensor tensor = op.tensor;
       ensureTensorContiguous(tensor);
@@ -598,7 +581,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::broadcast(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
-  checkTensorOnCuda(tensor);
+  checkTensorDevice(tensor);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "broadcast", rank_, {tensor}, {tensor});
@@ -645,7 +628,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::all_reduce(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
-  checkTensorOnCuda(tensor);
+  checkTensorDevice(tensor);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_reduce", rank_, {tensor}, {tensor});
@@ -693,7 +676,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::reduce(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(tensor);
-  checkTensorOnCuda(tensor);
+  checkTensorDevice(tensor);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "reduce", rank_, {tensor}, {tensor});
@@ -758,8 +741,8 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::all_gather(
     }
   }
 
-  checkTensorOnCuda(tensor);
-  checkTensorsOnCuda(tensor_list);
+  checkTensorDevice(tensor);
+  checkTensorsDevice(tensor_list);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_gather", rank_, tensor_list, {tensor});
@@ -828,8 +811,8 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::all_gather_v(
     ensureTensorContiguous(t);
   }
 
-  checkTensorOnCuda(tensor);
-  checkTensorsOnCuda(tensor_list);
+  checkTensorDevice(tensor);
+  checkTensorsDevice(tensor_list);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_gather_v", rank_, tensor_list, {tensor});
@@ -897,8 +880,8 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::all_gather_single(
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output);
   ensureTensorContiguous(input);
-  checkTensorOnCuda(output);
-  checkTensorOnCuda(input);
+  checkTensorDevice(output);
+  checkTensorDevice(input);
 
   if (output.numel() != input.numel() * comm_size_) {
     throw std::runtime_error(
@@ -963,8 +946,8 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::reduce_scatter(
     }
   }
 
-  checkTensorOnCuda(output);
-  checkTensorsOnCuda(input_list);
+  checkTensorDevice(output);
+  checkTensorsDevice(input_list);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "reduce_scatter", rank_, input_list, {output});
@@ -1057,8 +1040,8 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::reduce_scatter_v(
     ensureTensorContiguous(t);
   }
 
-  checkTensorOnCuda(output);
-  checkTensorsOnCuda(input_list);
+  checkTensorDevice(output);
+  checkTensorsDevice(input_list);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "reduce_scatter_v", rank_, input_list, {output});
@@ -1150,8 +1133,8 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::reduce_scatter_single(
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output);
   ensureTensorContiguous(input);
-  checkTensorOnCuda(output);
-  checkTensorOnCuda(input);
+  checkTensorDevice(output);
+  checkTensorDevice(input);
 
   if (input.numel() != output.numel() * comm_size_) {
     throw std::runtime_error(
@@ -1205,8 +1188,8 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::all_to_all_single(
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output);
   ensureTensorContiguous(input);
-  checkTensorOnCuda(output);
-  checkTensorOnCuda(input);
+  checkTensorDevice(output);
+  checkTensorDevice(input);
 
   if (input.numel() != output.numel()) {
     throw std::runtime_error(
@@ -1266,8 +1249,8 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::all_to_all_v_single(
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output);
   ensureTensorContiguous(input);
-  checkTensorOnCuda(output);
-  checkTensorOnCuda(input);
+  checkTensorDevice(output);
+  checkTensorDevice(input);
 
   // Validate split sizes vectors
   if (input_split_sizes.size() != static_cast<size_t>(comm_size_)) {
@@ -1382,8 +1365,8 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::all_to_all(
     ensureTensorContiguous(output_tensor_list[i]);
   }
 
-  checkTensorsOnCuda(output_tensor_list);
-  checkTensorsOnCuda(input_tensor_list);
+  checkTensorsDevice(output_tensor_list);
+  checkTensorsDevice(input_tensor_list);
 
   TracingGuard tracingGuard(
       name_,
@@ -1501,7 +1484,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::scatter(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output_tensor);
-  checkTensorOnCuda(output_tensor);
+  checkTensorDevice(output_tensor);
 
   // Only the root rank needs valid input tensors
   if (rank_ == root) {
@@ -1517,7 +1500,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::scatter(
             "All input tensors must have same size as output tensor");
       }
     }
-    checkTensorsOnCuda(input_tensor_list);
+    checkTensorsDevice(input_tensor_list);
   }
 
   TracingGuard tracingGuard(
@@ -1612,7 +1595,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::gather(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(input_tensor);
-  checkTensorOnCuda(input_tensor);
+  checkTensorDevice(input_tensor);
 
   // Only the root rank needs valid output tensors
   if (rank_ == root) {
@@ -1628,7 +1611,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::gather(
             "All output tensors must have same size as input tensor");
       }
     }
-    checkTensorsOnCuda(output_tensor_list);
+    checkTensorsDevice(output_tensor_list);
   }
 
   TracingGuard tracingGuard(
@@ -1721,7 +1704,7 @@ TorchCommBackend::AllGatherPHandle TorchCommRCCLX::all_gather_p_init(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output);
-  checkTensorOnCuda(output);
+  checkTensorDevice(output);
 
   // Calculate max receive count (total elements in output) and buffer size
   size_t maxRecvCount = output.numel();
@@ -1775,7 +1758,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::all_gather_p_exec(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(input);
-  checkTensorOnCuda(input);
+  checkTensorDevice(input);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_gather_p_exec", rank_, {input}, {});

--- a/comms/torchcomms/rcclx/TorchCommRCCLX.hpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLX.hpp
@@ -376,6 +376,8 @@ class TorchCommRCCLX : public TorchCommBackend,
       hipStream_t stream);
   hipStream_t getOperationStream(bool async_op);
   void ensureTensorContiguous(const at::Tensor& tensor);
+  void checkTensorDevice(const at::Tensor& tensor) const;
+  void checkTensorsDevice(const std::vector<at::Tensor>& tensors) const;
 
   void attachMemoryHook();
   void detachMemoryHook();

--- a/comms/torchcomms/rcclx/TorchCommRCCLXUtils.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLXUtils.cpp
@@ -366,6 +366,31 @@ void TorchCommRCCLX::ensureTensorContiguous(const at::Tensor& tensor) {
   }
 }
 
+void TorchCommRCCLX::checkTensorDevice(const at::Tensor& tensor) const {
+  auto expected = device_.type();
+  auto actual = tensor.device().type();
+  // HIP masquerades as CUDA in ROCm builds
+  if (expected == c10::DeviceType::HIP) {
+    expected = c10::DeviceType::CUDA;
+  }
+  if (actual == c10::DeviceType::HIP) {
+    actual = c10::DeviceType::CUDA;
+  }
+  TORCH_CHECK(
+      actual == expected,
+      "Expected tensor on ",
+      device_.type(),
+      " but found tensor on ",
+      tensor.device());
+}
+
+void TorchCommRCCLX::checkTensorsDevice(
+    const std::vector<at::Tensor>& tensors) const {
+  for (const auto& t : tensors) {
+    checkTensorDevice(t);
+  }
+}
+
 // Protected methods (not in the private section of the header)
 hipEvent_t TorchCommRCCLX::getEvent() {
   std::lock_guard<std::mutex> lock(event_pool_mutex_);


### PR DESCRIPTION
**issue**
```
comm = new_comm("ncclx", torch.device("cuda"))
comm.all_reduce(torch.ones(4))  # CPU tensor — no error, but result is WRONG
comm.finalize()                  # SIGABRT: "illegal memory access"
```
c10d prevents with a check that only exists here for xccl backend, made the fix for nccl, ncclx, rccl, rcclx


**after fix:**
`RuntimeError: Expected CUDA tensor but found tensor on cpu`