### PR TITLE
Add memory fences for aarch64 correctness in KernelFlagItem, KernelElem, and GpeKernelSync

### DIFF
--- a/comms/ctran/algos/common/GpeKernelSync.h
+++ b/comms/ctran/algos/common/GpeKernelSync.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include <atomic>
+
 #include "comms/ctran/algos/CtranAlgoDev.h"
 #include "comms/ctran/utils/MemFence.h"
 
@@ -95,24 +97,24 @@ struct alignas(16) GpeKernelSync {
   // Implements PinnedHostItem concept
   // { t.inUse() } -> std::same_as<bool>;
   bool inUse() {
-    return inuse;
+    return inuse.load(std::memory_order_acquire);
   }
 
   // Implements PinnedHostItem concept
   // { t.reset() } -> std::same_as<void>;
   void reset() {
     resetStatus();
-    inuse = false;
+    inuse.store(false, std::memory_order_release);
   }
 
   // Implements PinnedHostItem concept
   // { t.onPop() } -> std::same_as<void>;
   void onPop() {
     resetStatus();
-    inuse = true;
+    inuse.store(true, std::memory_order_release);
   }
 
  private:
-  volatile bool inuse{false};
+  std::atomic<bool> inuse{false};
 };
 } // namespace ctran::algos

--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -21,6 +21,7 @@
 #include "comms/ctran/utils/Debug.h"
 #include "comms/ctran/utils/Exception.h"
 #include "comms/ctran/utils/ExtUtils.h"
+#include "comms/ctran/utils/MemFence.h"
 
 #include "comms/utils/colltrace/CollRecord.h"
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -928,6 +929,7 @@ void CtranGpe::Impl::gpeThreadFn() {
 
 void KernelElem::unuse() {
   CHECK_KELEM_NGROUPS(this);
+  wcStoreFence();
   for (int i = 0; i < this->ngroups; i++) {
     this->status[i] = KernelElem::ElemStatus::RESET;
   }
@@ -977,7 +979,7 @@ void KernelElem::free() {
     return;
   }
 
-  // Free
+  wcStoreFence();
   for (int i = 0; i < this->ngroups; i++) {
     this->status[i] = KernelElem::ElemStatus::RESET;
   }
@@ -989,7 +991,7 @@ void KernelElem::free() {
 }
 
 bool KernelElem::isFree() {
-  if (persistent_) {
+  if (persistent_.load(std::memory_order_acquire)) {
     return false;
   }
   CHECK_KELEM_NGROUPS(this);
@@ -998,6 +1000,7 @@ bool KernelElem::isFree() {
     allFree &= (this->status[i] == KernelElem::ElemStatus::RESET);
   }
   if (allFree) {
+    wcAcquireFence();
     CLOGF_TRACE(
         COLL,
         "CTRAN-GPE: elem {} isFree = true with ngroups {}",

--- a/comms/ctran/gpe/CtranGpeImpl.h
+++ b/comms/ctran/gpe/CtranGpeImpl.h
@@ -12,6 +12,8 @@
 #include <stack>
 #include <thread>
 
+#include <atomic>
+
 #include <folly/Synchronized.h>
 #include "comms/ctran/algos/common/GpeKernel.h"
 #include "comms/ctran/algos/common/GpeKernelSync.h"
@@ -19,6 +21,7 @@
 #include "comms/ctran/gpe/CtranGpe.h"
 #include "comms/ctran/utils/CudaGraphUtils.h"
 #include "comms/ctran/utils/ExtUtils.h"
+#include "comms/ctran/utils/MemFence.h"
 #include "comms/ctran/utils/PinnedHostPool.h"
 #include "comms/utils/GraphCaptureSideStream.h"
 
@@ -38,7 +41,7 @@ struct KernelFlagItem {
   }
 
   bool inUse() {
-    if (persistent_) {
+    if (persistent_.load(std::memory_order_acquire)) {
       return true;
     }
     for (int i = 0; i < numGroups_; i++) {
@@ -46,6 +49,7 @@ struct KernelFlagItem {
         return true;
       }
     }
+    wcAcquireFence();
     return false;
   }
 
@@ -62,6 +66,7 @@ struct KernelFlagItem {
         return false;
       }
     }
+    wcAcquireFence();
     return true;
   }
 
@@ -71,27 +76,23 @@ struct KernelFlagItem {
     }
   }
 
-  // Prevent pool reclaim between graph replays. The kernel writes
-  // KERNEL_UNSET after each replay, but persistent keeps inUse() true.
   void setPersistent() {
-    persistent_ = true;
+    persistent_.store(true, std::memory_order_release);
   }
 
-  // Allow pool reclaim. Called at graph destruction to release the flag.
   void clearPersistent() {
-    persistent_ = false;
+    persistent_.store(false, std::memory_order_release);
   }
 
   volatile int flag_[CTRAN_ALGO_MAX_THREAD_BLOCKS];
   int numGroups_{1};
-  // If true, inUse() always returns true — prevents reclaim() from stealing
-  // the flag while a persistent cmd (graph capture) still owns it.
-  // Not cleared by reset() — only cleared by clearPersistent().
-  bool persistent_{false};
+  // Atomic because it is set by cmdDestroy (CUDA callback thread) and read
+  // by reclaim() (main thread).
+  std::atomic<bool> persistent_{false};
   // padding for different KernelFlagItems to be on different cache lines.
   static constexpr int kCacheLineSizeBytes = 128;
-  // -2 ints: one for numGroups_, one for persistent_ (padded to int)
-  int unused[(kCacheLineSizeBytes - 2 * sizeof(int)) / sizeof(int)];
+  char unused_padding_
+      [kCacheLineSizeBytes - sizeof(int) - sizeof(std::atomic<bool>)];
 
   void _() {
     // Make sure KernelFlagItem satisfies the PinnedHostItem concept
@@ -100,7 +101,8 @@ struct KernelFlagItem {
     // The following compile-time check is a hint of the memory usage
     // KernelFlag uses 384 bytes of pinned memory
     static_assert(
-        sizeof(Self) == 4 * CTRAN_ALGO_MAX_THREAD_BLOCKS + kCacheLineSizeBytes);
+        sizeof(Self) == 4 * CTRAN_ALGO_MAX_THREAD_BLOCKS + kCacheLineSizeBytes,
+        "KernelFlagItem size must be flags + one cache line of metadata/padding");
 
     // Ensure two KernelFlagItems are on different cache lines.
     //


### PR DESCRIPTION
Summary:
On aarch64 (GB200), `volatile` provides no memory ordering guarantees unlike x86_64 TSO. KernelFlagItem and KernelElem used `volatile` for GPU-to-host flag communication without acquire/release fences, while GpeKernelSync already had correct fences via `wcAcquireFence()`. This inconsistency causes stale reads on aarch64 that can corrupt control flow during communicator teardown.

Changes:
- Add `wcAcquireFence()` after successful flag polling in `KernelFlagItem::inUse()`, `testFlagAllGroups()`, and `KernelElem::isFree()` — matching the pattern from `GpeKernelSync::isComplete()`.
- Add `wcStoreFence()` before status writes in `KernelElem::free()` and `unuse()`.
- Change `KernelFlagItem::persistent_` from plain `bool` to `std::atomic<bool>` since it is written by `cmdDestroy` (CUDA callback thread) and read by `reclaim()` (main thread).
- Change `GpeKernelSync::inuse` from `volatile bool` to `std::atomic<bool>` with proper `acquire`/`release` ordering.

RCA: P2299710103

Differential Revision: D103431764


