### PR TITLE
Fix libnccl.so link failure: explicitly add -lfmt for prebuilt folly/thrift

### DIFF
--- a/build_ncclx.sh
+++ b/build_ncclx.sh
@@ -337,17 +337,21 @@ THRIFT_SERVICE_LDFLAGS+=(
   "-l:libxxhash.a"
 )
 THIRD_PARTY_LDFLAGS+="${THRIFT_SERVICE_LDFLAGS[*]} "
-# Filter -lfmt from folly's pkg-config: fmt is used header-only (FMT_HEADER_ONLY=1)
-THIRD_PARTY_LDFLAGS+="$(pkg-config --libs --static libfolly | sed 's/-lfmt\b//g') "
+THIRD_PARTY_LDFLAGS+="$(pkg-config --libs --static libfolly) "
 # liburing: folly's cmake config declares this dependency but pkg-config omits
 # it. Add -luring if the system has liburing (folly uses io_uring for async I/O).
 if pkg-config --exists liburing 2>/dev/null; then
   THIRD_PARTY_LDFLAGS+="-luring "
 fi
+# libfmt: NCCLX's own objects use FMT_HEADER_ONLY=1, but the prebuilt
+# folly/thrift static libs were built without it and contain unresolved
+# references to non-inline fmt::v9::detail symbols (is_printable,
+# thousands_sep_impl, locale_ref::get<std::locale>). The conda libfolly.pc
+# does not list fmt as a dep, so add -lfmt explicitly.
 if [[ -z "${USE_SYSTEM_LIBS}" ]]; then
-  THIRD_PARTY_LDFLAGS+="-l:libglog.a -l:libgflags.a -l:libboost_context.a -l:libssl.a -l:libcrypto.a"
+  THIRD_PARTY_LDFLAGS+="-l:libglog.a -l:libgflags.a -l:libboost_context.a -l:libssl.a -l:libcrypto.a -l:libfmt.a"
 else
-  THIRD_PARTY_LDFLAGS+="-lglog -lgflags -lboost_context -lssl -lcrypto"
+  THIRD_PARTY_LDFLAGS+="-lglog -lgflags -lboost_context -lssl -lcrypto -lfmt"
 fi
 
 echo "$THIRD_PARTY_LDFLAGS"


### PR DESCRIPTION
Summary:
The conda feedstock build of libnccl.so.2.29.7 fails at the final link step with undefined references to non-inline `{fmt}` v9 symbols pulled in from the prebuilt static libs in `$PREFIX/lib`:

- `fmt::v9::detail::is_printable(unsigned int)` — from `libasync.a(ClientInterceptorBase.cpp.o)`
- `fmt::v9::detail::thousands_sep_impl<char>(fmt::v9::detail::locale_ref)` — from `libthriftcpp2.a(AsyncProcessorFactory.cpp.o)`
- `std::locale fmt::v9::detail::locale_ref::get<std::locale>() const` — from `libfolly.a(Singleton.cpp.o)`

ending with `collect2: error: ld returned 1 exit status` and the build failing at `Makefile:324` while producing `libnccl.so.2.29.7`.

Root cause: NCCLX's own translation units are compiled with `-DFMT_HEADER_ONLY=1`, so they don't need libfmt. But the prebuilt folly/fbthrift static libs in `$PREFIX/lib` were *not* built header-only and contain unresolved references to the `fmt::v9::detail::*` symbols above. The conda `libfolly.pc` does not list fmt as a dep, so `pkg-config --libs --static libfolly` does not emit `-lfmt`, and the resulting link line for libnccl.so has no way to satisfy those references. (An earlier attempt to "stop filtering `-lfmt` out of pkg-config" was a no-op because pkg-config never emitted it in the first place.)

Fix: explicitly append `-lfmt` (or `-l:libfmt.a` in the source-built path) to `THIRD_PARTY_LDFLAGS` alongside the other folly/thrift co-dependencies (glog, gflags, boost_context, ssl, crypto). NCCLX's per-object compile flags are unchanged: `-DFMT_HEADER_ONLY=1` is retained.

Reviewed By: saifhhasan

Differential Revision: D103431632


