### PR TITLE
S651852 [ctran][tests] Parametrize tail race test on Unroll16; add unroll-mismatch case

### DIFF
--- a/comms/ctran/algos/localReduce.cuh
+++ b/comms/ctran/algos/localReduce.cuh
@@ -188,14 +188,24 @@ __device__ __forceinline__ void localReduceVectorized(
   constexpr uint32_t kWordsPerWarp =
       comms::device::kWarpSize * kWordsPerVectorLoad * kUnroll;
 
+  // Per-block granularity matches `copyUnroll<4, T>`'s numPerBlock
+  // (`fbcode/comms/ctran/algos/DevCommon.cuh:391-442`):
+  // blockDim.x * (16/sizeof(T)) * 4 = warpsPerBlock * kWordsPerWarp.
+  // Rounding `limitCount` down to this granularity (instead of
+  // `kWordsPerWarp`) makes the per-CTA byte ownership of this main loop
+  // identical to copyUnroll's, so a single-designated-CTA tail (matching
+  // the fix Pavan applied in D69774173) is well-defined and avoids the
+  // cross-CTA read race when the same buffer is written by both writers
+  // in adjacent rounds with only per-CTA sync between them.
+  const uint32_t numPerBlock = blockDim.x * kWordsPerVectorLoad * kUnroll;
+
   const uint32_t linearThreadId = blockDim.x * workerId + threadIdx.x;
   const uint32_t warpId = linearThreadId / comms::device::kWarpSize;
   const uint32_t laneId = threadIdx.x % comms::device::kWarpSize;
   const uint32_t numWarps = numWorkers * blockDim.x / comms::device::kWarpSize;
-  const uint32_t reduceStride = numWorkers * blockDim.x;
 
   const uint32_t u32Count = uint32_t(count);
-  const uint32_t limitCount = ctran::utils::roundDown(u32Count, kWordsPerWarp);
+  const uint32_t limitCount = ctran::utils::roundDown(u32Count, numPerBlock);
 
   TVec s[kUnroll][NSrcs];
 
@@ -247,21 +257,29 @@ __device__ __forceinline__ void localReduceVectorized(
     }
   }
 
-  // Loop epilogue to handle remainder with a simple grid-stride loop
-  for (uint32_t i = limitCount + linearThreadId; i < count; i += reduceStride) {
-    T s = srcs[0][i];
+  // Loop epilogue to handle remainder. Single designated CTA mirrors
+  // `copyUnroll`'s tail (DevCommon.cuh:436-441): the worker whose main-loop
+  // stride covers this part of the buffer handles the entire tail. Required
+  // for per-CTA byte-ownership equality with the copyUnroll-family writers
+  // (`ctranKernCopyRaw`, `ctranKernCopyMultiDestRaw`) when both are invoked
+  // on the same buffer in adjacent rounds with per-CTA sync only.
+  if (count != limitCount &&
+      workerId == ((limitCount / numPerBlock) % numWorkers)) {
+    for (uint32_t i = limitCount + threadIdx.x; i < count; i += blockDim.x) {
+      T s = srcs[0][i];
 #pragma unroll
-    for (int j = 1; j < NSrcs; ++j) {
-      s = reduceNcclOp1<T, RedOp>(s, srcs[j][i]);
-    }
+      for (int j = 1; j < NSrcs; ++j) {
+        s = reduceNcclOp1<T, RedOp>(s, srcs[j][i]);
+      }
 
-    if constexpr (RedOp == commAvg) {
-      s = s / int(nRanks);
-    }
+      if constexpr (RedOp == commAvg) {
+        s = s / int(nRanks);
+      }
 
 #pragma unroll
-    for (int d = 0; d < NDsts; ++d) {
-      dsts[d][i] = s;
+      for (int d = 0; d < NDsts; ++d) {
+        dsts[d][i] = s;
+      }
     }
   }
 
@@ -299,13 +317,21 @@ __device__ __forceinline__ void localReduceFallback(
   // at a time
   constexpr uint32_t kWordsPerWarp = comms::device::kWarpSize * kUnroll;
 
+  // Per-block granularity = warpsPerBlock * kWordsPerWarp = blockDim.x *
+  // kUnroll. Rounding `limitCount` down to this (instead of `kWordsPerWarp`)
+  // makes the per-CTA byte ownership match copyUnroll's, so the
+  // single-designated-CTA tail below is well-defined and avoids the
+  // cross-CTA read race when this writer and a copyUnroll-family writer
+  // touch the same buffer in adjacent rounds with per-CTA sync only.
+  const uint32_t numPerBlock = blockDim.x * kUnroll;
+
   const uint32_t linearThreadId = blockDim.x * workerId + threadIdx.x;
   const uint32_t globalWarpId = linearThreadId / comms::device::kWarpSize;
   const uint32_t laneId = threadIdx.x % comms::device::kWarpSize;
   const uint32_t numGlobalWarps =
       numWorkers * blockDim.x / comms::device::kWarpSize;
 
-  const size_t limitCount = ctran::utils::roundDown(count, kWordsPerWarp);
+  const size_t limitCount = ctran::utils::roundDown(count, size_t(numPerBlock));
 
   T s[kUnroll][kVectors];
 
@@ -335,21 +361,25 @@ __device__ __forceinline__ void localReduceFallback(
     }
   }
 
-  // Loop epilogue to handle remainder with a simple grid-stride loop
-  for (uint32_t i = limitCount + linearThreadId; i < count;
-       i += numWorkers * blockDim.x) {
-    T s = srcs[0][i];
+  // Loop epilogue to handle remainder. Single designated CTA mirrors
+  // `copyUnroll`'s tail (DevCommon.cuh:436-441); see the matching comment
+  // in localReduceVectorized for the per-CTA byte-ownership rationale.
+  if (count != limitCount &&
+      workerId == ((limitCount / numPerBlock) % numWorkers)) {
+    for (size_t i = limitCount + threadIdx.x; i < count; i += blockDim.x) {
+      T s = srcs[0][i];
 #pragma unroll
-    for (int j = 1; j < nsrcs; ++j) {
-      s = reduceNcclOp1<T, RedOp>(s, srcs[j][i]);
-    }
+      for (int j = 1; j < nsrcs; ++j) {
+        s = reduceNcclOp1<T, RedOp>(s, srcs[j][i]);
+      }
 
-    if constexpr (RedOp == commAvg) {
-      s = s / int(nRanks);
-    }
+      if constexpr (RedOp == commAvg) {
+        s = s / int(nRanks);
+      }
 
-    for (int d = 0; d < ndsts; ++d) {
-      dsts[d][i] = s;
+      for (int d = 0; d < ndsts; ++d) {
+        dsts[d][i] = s;
+      }
     }
   }
 

--- a/comms/ctran/algos/tests/CtranAlgoDevUT.cc
+++ b/comms/ctran/algos/tests/CtranAlgoDevUT.cc
@@ -309,6 +309,40 @@ TYPED_TEST(CtranAlgoDevTypedTest, localReduceSumUnaligned) {
   }
 }
 
+// Exercises localReduce at counts where the tail's "designated CTA"
+// (under copyUnroll-style per-block ownership = `(limitCount/numPerBlock)
+// % nGroups`) is NOT block 0. Existing localReduceSumUnaligned uses
+// count=1041 with blockDim=640 and gridDim=2, where for every supported
+// dtype the designated CTA collapses to 0; this test covers the case
+// where the tail is owned by a non-zero block.
+TYPED_TEST(CtranAlgoDevTypedTest, localReduceSumUnalignedNonZeroDesignatedCta) {
+  std::vector<size_t> testnSrcs{2, 8};
+  std::vector<size_t> testnDsts{1, 2};
+  constexpr uint numThreadBlocks = 4;
+  // For T=float (sizeofT=4), blockDim=640: numPerBlock = 640 * (16/4) * 4
+  // = 10240. count=10241 => limitCount=10240, tail=1, designated=1.
+  // count=20481 => designated=2. count=30721 => designated=3. count=40961
+  // => designated=0 (wrap). For other dtypes the designated index shifts
+  // proportionally; in every case the tail is non-empty and at least one
+  // count puts it on a non-zero block.
+  std::vector<size_t> testCounts{10241, 20481, 30721, 40961};
+
+  for (auto nsrcs : testnSrcs) {
+    for (auto ndsts : testnDsts) {
+      for (auto count : testCounts) {
+        localReduceTest<TypeParam>(
+            nsrcs,
+            ndsts,
+            count,
+            commSum,
+            /*nranks=*/1,
+            /*subsetThreadBlocks=*/false,
+            numThreadBlocks);
+      }
+    }
+  }
+}
+
 TYPED_TEST(CtranAlgoDevTypedTest, localReduceProd) {
   // test reduction kernel with 2 or 8 srcs, and 1 or 2 dsts, which are common
   // cases for inter-node and intra-node collectives.

--- a/comms/ctran/algos/tests/LocalReduceTailRaceUT.cc
+++ b/comms/ctran/algos/tests/LocalReduceTailRaceUT.cc
@@ -31,9 +31,7 @@ class LocalReduceTailRaceTest : public ::testing::Test {
   }
 };
 
-TEST_F(
-    LocalReduceTailRaceTest,
-    DISABLED_DelayedBlockZeroExposesBlockOneStaleRead) {
+TEST_F(LocalReduceTailRaceTest, DelayedBlockZeroExposesBlockOneStaleRead) {
   // count=2200, blockDim=128, gridDim=8, fp32:
   // - copyUnroll-tail designated CTA = (2048/2048) % 8 = 1, so block 1
   //   reads ALL of [2048, 2200) in phase 2.

--- a/comms/ctran/algos/tests/LocalReduceTailRaceUT.cc
+++ b/comms/ctran/algos/tests/LocalReduceTailRaceUT.cc
@@ -1,0 +1,110 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// GPU reproducer for the per-CTA byte-ownership invariant violation
+// between `copyUnroll<4, T>` (`fbcode/comms/ctran/algos/DevCommon.cuh`)
+// and `localReduceVectorized` (`fbcode/comms/ctran/algos/localReduce.cuh`).
+//
+// D69774173 gave `copyUnroll`'s tail a single
+// designated CTA so per-byte ownership is stable across calls on the
+// same buffer. The same fix was never applied to `localReduce.cuh`.
+//
+// In ring AllReduce the bug surfaces at the RS→AG transition: RS-last-step
+// writes `recvbuff` (and `tmpSendBuf`) via `localReduce` (line 121); AG
+// steps touch the same buffers via `copyUnroll`-via-`ctranKernCopy*`
+// (lines 127, 137, 268, 278). Inter-round sync is per-CTA only via
+// `GpeKernelSync.completeFlag[blockIdx]`. When per-CTA ownership of two
+// writers disagrees, a CTA in the next round can read or overwrite bytes
+// a different CTA in the prior round hasn't yet committed.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+#include "comms/ctran/algos/tests/LocalReduceTailRaceUTKernels.cuh"
+#include "comms/testinfra/TestXPlatUtils.h"
+
+class LocalReduceTailRaceTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    CUDACHECK_TEST(cudaSetDevice(0));
+  }
+};
+
+TEST_F(
+    LocalReduceTailRaceTest,
+    DISABLED_DelayedBlockZeroExposesBlockOneStaleRead) {
+  // count=2200, blockDim=128, gridDim=8, fp32:
+  // - copyUnroll-tail designated CTA = (2048/2048) % 8 = 1, so block 1
+  //   reads ALL of [2048, 2200) in phase 2.
+  // - Pre-fix localReduceVectorized-tail: block 0 writes [2048, 2176),
+  //   block 1 writes [2176, 2200) (grid-strided over linearThreadId).
+  // - Post-fix: block 1 writes [2048, 2200) (single-CTA tail mirrors
+  //   copyUnroll's predicate).
+  constexpr size_t count = 2200;
+  constexpr int gridDim = 8;
+  constexpr int blockDim = 128;
+  // 50 ms is well above any plausible time block 1 needs to reach phase 2.
+  constexpr unsigned long long block0DelayNs = 50ULL * 1000ULL * 1000ULL;
+  using T = int32_t;
+  const size_t bytes = count * sizeof(T);
+
+  std::vector<T> srcHost(count);
+  for (size_t i = 0; i < count; ++i) {
+    srcHost[i] = static_cast<T>(i + 1);
+  }
+
+  T* srcDev{nullptr};
+  T* bufDev{nullptr};
+  T* outDev{nullptr};
+  int* flagDev{nullptr};
+
+  CUDACHECK_TEST(cudaMalloc(&srcDev, bytes));
+  CUDACHECK_TEST(cudaMalloc(&bufDev, bytes));
+  CUDACHECK_TEST(cudaMalloc(&outDev, bytes));
+  CUDACHECK_TEST(cudaMalloc(&flagDev, gridDim * sizeof(int)));
+
+  CUDACHECK_TEST(
+      cudaMemcpy(srcDev, srcHost.data(), bytes, cudaMemcpyHostToDevice));
+  // Sentinel for `buf`. Stale phase-2 reads will return this value
+  // (broadcasts to T=int32 as 0xCDCDCDCD).
+  CUDACHECK_TEST(cudaMemset(bufDev, 0xCD, bytes));
+  CUDACHECK_TEST(cudaMemset(outDev, 0, bytes));
+  CUDACHECK_TEST(cudaMemset(flagDev, 0, gridDim * sizeof(int)));
+
+  dim3 grid{gridDim, 1, 1};
+  dim3 block{blockDim, 1, 1};
+  size_t countLocal = count;
+  unsigned long long delayLocal = block0DelayNs;
+  void* args[] = {
+      &bufDev, &outDev, &srcDev, &countLocal, &flagDev, &delayLocal};
+  CUDACHECK_TEST(cudaLaunchKernel(
+      reinterpret_cast<void*>(multiWriterTailRaceKernel<T>),
+      grid,
+      block,
+      args));
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<T> outHost(count);
+  CUDACHECK_TEST(
+      cudaMemcpy(outHost.data(), outDev, bytes, cudaMemcpyDeviceToHost));
+
+  size_t firstStale = count;
+  for (size_t i = 0; i < count; ++i) {
+    if (outHost[i] != srcHost[i]) {
+      firstStale = i;
+      break;
+    }
+  }
+
+  EXPECT_EQ(firstStale, count)
+      << "stale read at out[" << firstStale
+      << "] = " << static_cast<uint32_t>(outHost[firstStale]) << " (expected "
+      << static_cast<uint32_t>(srcHost[firstStale]) << ")"
+      << " — block 1 read a slot block 0 had not yet written in phase 1";
+
+  CUDACHECK_TEST(cudaFree(srcDev));
+  CUDACHECK_TEST(cudaFree(bufDev));
+  CUDACHECK_TEST(cudaFree(outDev));
+  CUDACHECK_TEST(cudaFree(flagDev));
+}

--- a/comms/ctran/algos/tests/LocalReduceTailRaceUT.cc
+++ b/comms/ctran/algos/tests/LocalReduceTailRaceUT.cc
@@ -24,27 +24,19 @@
 #include "comms/ctran/algos/tests/LocalReduceTailRaceUTKernels.cuh"
 #include "comms/testinfra/TestXPlatUtils.h"
 
-class LocalReduceTailRaceTest : public ::testing::Test {
- protected:
-  void SetUp() override {
-    CUDACHECK_TEST(cudaSetDevice(0));
-  }
-};
+namespace {
 
-TEST_F(LocalReduceTailRaceTest, DelayedBlockZeroExposesBlockOneStaleRead) {
-  // count=2200, blockDim=128, gridDim=8, fp32:
-  // - copyUnroll-tail designated CTA = (2048/2048) % 8 = 1, so block 1
-  //   reads ALL of [2048, 2200) in phase 2.
-  // - Pre-fix localReduceVectorized-tail: block 0 writes [2048, 2176),
-  //   block 1 writes [2176, 2200) (grid-strided over linearThreadId).
-  // - Post-fix: block 1 writes [2048, 2200) (single-CTA tail mirrors
-  //   copyUnroll's predicate).
-  constexpr size_t count = 2200;
-  constexpr int gridDim = 8;
-  constexpr int blockDim = 128;
-  // 50 ms is well above any plausible time block 1 needs to reach phase 2.
-  constexpr unsigned long long block0DelayNs = 50ULL * 1000ULL * 1000ULL;
-  using T = int32_t;
+// Common harness for the multi-writer race test. Allocates buffers,
+// launches `multiWriterTailRaceKernel<T, Unroll16>`, and verifies that
+// every `out[i]` matches `src[i]`. A mismatch means phase 2 read a slot
+// phase 1 had not yet committed (block 0 was sleeping); the stale value
+// is the `0xCD` sentinel `buf` was initialized to.
+template <typename T, int Unroll16>
+void runMultiWriterRaceTest(
+    size_t count,
+    int gridDim,
+    int blockDim,
+    unsigned long long block0DelayNs) {
   const size_t bytes = count * sizeof(T);
 
   std::vector<T> srcHost(count);
@@ -70,14 +62,14 @@ TEST_F(LocalReduceTailRaceTest, DelayedBlockZeroExposesBlockOneStaleRead) {
   CUDACHECK_TEST(cudaMemset(outDev, 0, bytes));
   CUDACHECK_TEST(cudaMemset(flagDev, 0, gridDim * sizeof(int)));
 
-  dim3 grid{gridDim, 1, 1};
-  dim3 block{blockDim, 1, 1};
+  dim3 grid{static_cast<unsigned>(gridDim), 1, 1};
+  dim3 block{static_cast<unsigned>(blockDim), 1, 1};
   size_t countLocal = count;
   unsigned long long delayLocal = block0DelayNs;
   void* args[] = {
       &bufDev, &outDev, &srcDev, &countLocal, &flagDev, &delayLocal};
   CUDACHECK_TEST(cudaLaunchKernel(
-      reinterpret_cast<void*>(multiWriterTailRaceKernel<T>),
+      reinterpret_cast<void*>(multiWriterTailRaceKernel<T, Unroll16>),
       grid,
       block,
       args));
@@ -99,10 +91,75 @@ TEST_F(LocalReduceTailRaceTest, DelayedBlockZeroExposesBlockOneStaleRead) {
       << "stale read at out[" << firstStale
       << "] = " << static_cast<uint32_t>(outHost[firstStale]) << " (expected "
       << static_cast<uint32_t>(srcHost[firstStale]) << ")"
-      << " — block 1 read a slot block 0 had not yet written in phase 1";
+      << " — phase-2 reader read a slot phase-1 writer had not yet committed"
+      << " (Unroll16=" << Unroll16 << ")";
 
   CUDACHECK_TEST(cudaFree(srcDev));
   CUDACHECK_TEST(cudaFree(bufDev));
   CUDACHECK_TEST(cudaFree(outDev));
   CUDACHECK_TEST(cudaFree(flagDev));
+}
+
+// 50 ms is well above any plausible time another block needs to reach
+// phase 2 once block 0 has started its delay loop.
+constexpr unsigned long long kBlock0DelayNs = 50ULL * 1000ULL * 1000ULL;
+
+} // namespace
+
+class LocalReduceTailRaceTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    CUDACHECK_TEST(cudaSetDevice(0));
+  }
+};
+
+// Matched-unroll (production) configuration.
+//
+// count=2200, blockDim=128, gridDim=8, fp32, Unroll16=4:
+// - copyUnroll<4>-tail designated CTA = (2048/2048) % 8 = 1, so block 1
+//   reads ALL of [2048, 2200) in phase 2.
+// - Pre-fix localReduceVectorized-tail: block 0 writes [2048, 2176),
+//   block 1 writes [2176, 2200) (grid-strided over linearThreadId).
+// - Post-fix: block 1 writes [2048, 2200) (single-CTA tail mirrors
+//   copyUnroll's predicate); block 1's phase-2 read returns block 1's
+//   own phase-1 write regardless of block 0's progress.
+TEST_F(LocalReduceTailRaceTest, DelayedBlockZeroExposesBlockOneStaleRead) {
+  runMultiWriterRaceTest<int32_t, /*Unroll16=*/4>(
+      /*count=*/2200,
+      /*gridDim=*/8,
+      /*blockDim=*/128,
+      kBlock0DelayNs);
+}
+
+// Mismatched-unroll configuration.
+//
+// `localReduceVectorized` hardcodes `kUnroll=4`; `copyUnroll` is templated
+// on `Unroll16` and EVERY in-tree call site instantiates with `Unroll16=4`
+// (`copy<T>`, `ctranKernCopyRaw`, `ctranKernCopyMultiDestRaw`). The match
+// is by convention only — nothing prevents a future caller from using a
+// different unroll factor. This test demonstrates what happens if that
+// happens: at perfectly aligned counts (no tail at all on either side),
+// the per-CTA partitions in the MAIN LOOP disagree, so cross-CTA stale
+// reads still occur once the writer is delayed.
+//
+// count=2200, blockDim=128, gridDim=8, fp32, Unroll16=2:
+// - localReduceVectorized<4>: numPerBlock = 128*(16/4)*4 = 2048. Block 0
+//   owns [0, 2048) in main loop; tail [2048, 2200) per the post-fix
+//   single-CTA pattern (designated = 1).
+// - copyUnroll<2>: numPerBlock = 128*(16/4)*2 = 1024. Block 0 owns
+//   [0, 1024); block 1 owns [1024, 2048); block 2 owns the tail
+//   [2048, 2200). Reading position 1024+ requires block 1 (and block 2)
+//   to observe block 0's phase-1 write — but block 0 is sleeping.
+//
+// Marked DISABLED so CI stays green — the failure here motivates the
+// next diff in this stack, which adds a single shared unroll constant
+// plus a `static_assert` so the mismatched instantiation cannot compile.
+TEST_F(
+    LocalReduceTailRaceTest,
+    DISABLED_DifferentUnrollFromLocalReduceExposesStaleRead) {
+  runMultiWriterRaceTest<int32_t, /*Unroll16=*/2>(
+      /*count=*/2200,
+      /*gridDim=*/8,
+      /*blockDim=*/128,
+      kBlock0DelayNs);
 }

--- a/comms/ctran/algos/tests/LocalReduceTailRaceUTKernels.cu
+++ b/comms/ctran/algos/tests/LocalReduceTailRaceUTKernels.cu
@@ -52,7 +52,7 @@ __device__ __forceinline__ void block0Delay(unsigned long long totalNs) {
 
 } // namespace
 
-template <typename T>
+template <typename T, int Unroll16>
 __global__ void multiWriterTailRaceKernel(
     T* buf,
     T* out,
@@ -70,6 +70,7 @@ __global__ void multiWriterTailRaceKernel(
   // Phase 1: real `localReduceVectorized` writes `buf` from `src`. With
   // NSrcs=1 + commSum the reduction is identity, so `buf` should equal
   // `src` for every byte once all CTAs' writes have committed.
+  // localReduceVectorized's tail uses kUnroll=4 internally.
   {
     const T* srcs[1] = {src};
     T* dsts[1] = {buf};
@@ -80,22 +81,24 @@ __global__ void multiWriterTailRaceKernel(
   perCtaRelease(&perCtaFlag[blockIdx.x]);
   perCtaAcquireOwn(&perCtaFlag[blockIdx.x]);
 
-  // Phase 2: real `copyUnroll<4, T>` reads `buf` and writes `out`. Each
-  // CTA reads only the bytes it owns under copyUnroll's per-CTA
-  // partition. If localReduceVectorized's per-CTA partition assigned
-  // some of those bytes to a different CTA in phase 1 (the bug), this
-  // CTA's read may hit init sentinel because the writer CTA was still
-  // sleeping in `block0Delay` and hadn't issued its phase-1 writes yet.
-  copyUnroll<4, T>(out, buf, count, blockIdx.x, gridDim.x);
+  // Phase 2: real `copyUnroll<Unroll16, T>` reads `buf` and writes `out`.
+  // Each CTA reads only the bytes it owns under copyUnroll's per-CTA
+  // partition. If `Unroll16` differs from localReduceVectorized's
+  // hardcoded kUnroll=4, the per-CTA partitions disagree even at
+  // perfectly aligned counts, and the block-0 delay surfaces stale reads.
+  copyUnroll<Unroll16, T>(out, buf, count, blockIdx.x, gridDim.x);
 }
 
-#define DECL_MULTI_WRITER_KERN(T)                        \
-  template __global__ void multiWriterTailRaceKernel<T>( \
-      T * buf,                                           \
-      T * out,                                           \
-      const T* src,                                      \
-      size_t count,                                      \
-      int* perCtaFlag,                                   \
+#define DECL_MULTI_WRITER_KERN(T, U16)                        \
+  template __global__ void multiWriterTailRaceKernel<T, U16>( \
+      T * buf,                                                \
+      T * out,                                                \
+      const T* src,                                           \
+      size_t count,                                           \
+      int* perCtaFlag,                                        \
       unsigned long long block0DelayNs)
 
-DECL_MULTI_WRITER_KERN(int32_t);
+DECL_MULTI_WRITER_KERN(int32_t, 4);
+// Unroll16=2 is intentionally NOT what production uses; instantiated to
+// drive the unroll-mismatch test case.
+DECL_MULTI_WRITER_KERN(int32_t, 2);

--- a/comms/ctran/algos/tests/LocalReduceTailRaceUTKernels.cu
+++ b/comms/ctran/algos/tests/LocalReduceTailRaceUTKernels.cu
@@ -1,0 +1,101 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/ctran/algos/DevCommon.cuh"
+#include "comms/ctran/algos/localReduce.cuh"
+#include "comms/ctran/algos/tests/LocalReduceTailRaceUTKernels.cuh"
+
+namespace {
+
+// Per-CTA release on `flag[blockIdx.x]`. System-scope release-store, so
+// any other CTA that does a system-scope acquire load on the same
+// address observes writes this CTA committed before the release.
+__device__ __forceinline__ void perCtaRelease(int* flag) {
+  __syncthreads();
+  if (threadIdx.x == 0) {
+    asm volatile("st.release.sys.global.s32 [%0], %1;"
+                 :
+                 : "l"(flag), "r"(1)
+                 : "memory");
+  }
+}
+
+// Per-CTA acquire on the SAME CTA's flag. NO cross-CTA acquire — same
+// shape as the inter-round sync `GpeKernelSync.checkPost` provides.
+__device__ __forceinline__ void perCtaAcquireOwn(int* flag) {
+  if (threadIdx.x == 0) {
+    int v;
+    do {
+      asm volatile("ld.acquire.sys.global.s32 %0, [%1];"
+                   : "=r"(v)
+                   : "l"(flag)
+                   : "memory");
+    } while (v == 0);
+  }
+  __syncthreads();
+}
+
+// Spin-sleep on block 0 only, using `__nanosleep` (Volta+ / sm_70+).
+// `__nanosleep`'s argument is a 32-bit ns count; loop to reach larger
+// total delays.
+__device__ __forceinline__ void block0Delay(unsigned long long totalNs) {
+  if (blockIdx.x != 0 || threadIdx.x != 0) {
+    return;
+  }
+  constexpr unsigned int kStepNs = 1000000U; // 1 ms per __nanosleep call
+  unsigned long long remaining = totalNs;
+  while (remaining > 0) {
+    unsigned int step = remaining > kStepNs ? kStepNs : (unsigned int)remaining;
+    __nanosleep(step);
+    remaining -= step;
+  }
+}
+
+} // namespace
+
+template <typename T>
+__global__ void multiWriterTailRaceKernel(
+    T* buf,
+    T* out,
+    const T* src,
+    size_t count,
+    int* perCtaFlag,
+    unsigned long long block0DelayNs) {
+  // Delay block 0 so block 1 reaches phase 2 before block 0 finishes
+  // phase 1. The delay runs only on block 0's thread 0; the rest of
+  // block 0 waits at the barrier below. Other blocks pass through
+  // immediately and proceed to phase 1.
+  block0Delay(block0DelayNs);
+  __syncthreads();
+
+  // Phase 1: real `localReduceVectorized` writes `buf` from `src`. With
+  // NSrcs=1 + commSum the reduction is identity, so `buf` should equal
+  // `src` for every byte once all CTAs' writes have committed.
+  {
+    const T* srcs[1] = {src};
+    T* dsts[1] = {buf};
+    localReduceVectorized<T, commSum, 1, 1>(
+        srcs, dsts, count, blockIdx.x, gridDim.x);
+  }
+
+  perCtaRelease(&perCtaFlag[blockIdx.x]);
+  perCtaAcquireOwn(&perCtaFlag[blockIdx.x]);
+
+  // Phase 2: real `copyUnroll<4, T>` reads `buf` and writes `out`. Each
+  // CTA reads only the bytes it owns under copyUnroll's per-CTA
+  // partition. If localReduceVectorized's per-CTA partition assigned
+  // some of those bytes to a different CTA in phase 1 (the bug), this
+  // CTA's read may hit init sentinel because the writer CTA was still
+  // sleeping in `block0Delay` and hadn't issued its phase-1 writes yet.
+  copyUnroll<4, T>(out, buf, count, blockIdx.x, gridDim.x);
+}
+
+#define DECL_MULTI_WRITER_KERN(T)                        \
+  template __global__ void multiWriterTailRaceKernel<T>( \
+      T * buf,                                           \
+      T * out,                                           \
+      const T* src,                                      \
+      size_t count,                                      \
+      int* perCtaFlag,                                   \
+      unsigned long long block0DelayNs)
+
+DECL_MULTI_WRITER_KERN(int32_t);

--- a/comms/ctran/algos/tests/LocalReduceTailRaceUTKernels.cuh
+++ b/comms/ctran/algos/tests/LocalReduceTailRaceUTKernels.cuh
@@ -1,0 +1,27 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+// Single-kernel multi-writer test that DELIBERATELY delays block 0 so
+// block 1 reaches phase 2 before block 0 finishes phase 1. With the
+// pre-fix tail in `localReduceVectorized`, block 0 is the writer for
+// part of the byte range that block 1 reads in `copyUnroll`'s tail.
+// Because block 0 hasn't issued its writes yet (it's sleeping), block 1
+// reads the pre-init sentinel from L2 — `out` then carries that
+// sentinel instead of `src`, and the test fails.
+//
+// With the fix (single-designated-CTA tail in localReduce matching
+// copyUnroll's), block 1 owns its entire copyUnroll-tail range in BOTH
+// writers, so block 1's phase 2 read returns block 1's own phase 1
+// write — no dependency on block 0 — and the test passes.
+template <typename T>
+__global__ void multiWriterTailRaceKernel(
+    T* buf,
+    T* out,
+    const T* src,
+    size_t count,
+    int* perCtaFlag,
+    unsigned long long block0DelayNs);

--- a/comms/ctran/algos/tests/LocalReduceTailRaceUTKernels.cuh
+++ b/comms/ctran/algos/tests/LocalReduceTailRaceUTKernels.cuh
@@ -17,7 +17,13 @@
 // copyUnroll's), block 1 owns its entire copyUnroll-tail range in BOTH
 // writers, so block 1's phase 2 read returns block 1's own phase 1
 // write — no dependency on block 0 — and the test passes.
-template <typename T>
+//
+// `Unroll16` controls the unroll factor passed to `copyUnroll<Unroll16, T>`
+// in phase 2. `localReduceVectorized` in phase 1 uses `kUnroll=4`
+// internally. When `Unroll16 != 4`, the per-CTA partitions of the two
+// writers disagree and the block-0 delay surfaces cross-CTA stale reads
+// even at counts where copyUnroll<4>'s tail is empty.
+template <typename T, int Unroll16>
 __global__ void multiWriterTailRaceKernel(
     T* buf,
     T* out,


### PR DESCRIPTION
Summary:
Templatizes `multiWriterTailRaceKernel<T>` -> `multiWriterTailRaceKernel<T, Unroll16>` and extracts the existing test body into a `runMultiWriterRaceTest<T, Unroll16>(count, gridDim, blockDim, delayNs)` helper. The existing `DelayedBlockZeroExposesBlockOneStaleRead` test now calls the helper with `Unroll16=4` (matches `localReduceVectorized`'s hardcoded `kUnroll=4` — passes after the fix in D103324874).

Adds `DISABLED_DifferentUnrollFromLocalReduceExposesStaleRead` calling the helper with `Unroll16=2`. `localReduceVectorized` always partitions per-CTA at `numPerBlock = blockDim*(16/sizeof(T))*4` while `copyUnroll<2, T>` partitions at half that (`*2`). At count=2200, blockDim=128, gridDim=8, fp32:
- localReduceVectorized<4>: block 0 owns [0, 2048).
- copyUnroll<2>: block 0 owns [0, 1024); block 1 owns [1024, 2048); block 2 owns [2048, 2200).

Block 1 reads position 1024+ in phase 2; the writer is block 0 in phase 1; block 0 is sleeping in `__nanosleep`. The cross-CTA stale read produces `out[1024] = 0xCDCDCDCD` (the buf init sentinel). The test fails deterministically.

Currently the unroll match between `copyUnroll` and `localReduceVectorized` is by convention only — every in-tree wrapper (`copy<T>`, `ctranKernCopyRaw`, `ctranKernCopyMultiDestRaw`) instantiates `copyUnroll<4, T>` and `localReduceVectorized` hardcodes `kUnroll=4`, but nothing prevents a future caller from picking a different unroll. The next diff in this stack adds a single shared unroll constant plus a `static_assert` so the mismatched instantiation cannot compile; this DISABLED test will be removed in that diff (the runtime check becomes a compile-time check).

Differential Revision: D103476062


