### PR TITLE
Split work wait hooks into pre and post (#2354)

### DIFF
--- a/comms/torchcomms/TorchWork.cpp
+++ b/comms/torchcomms/TorchWork.cpp
@@ -24,7 +24,8 @@ TorchWorkCompleted::TorchWorkCompleted() {
 }
 
 void TorchWorkCompleted::wait() {
-  runWaitHooks();
+  runWaitPreHooks();
+  runWaitPostHooks();
 }
 
 TorchWorkThread::TorchWorkThread(std::function<void()> fn)
@@ -39,13 +40,15 @@ TorchWorkThread::TorchWorkThread(std::function<void()> fn)
       })) {}
 
 void TorchWorkThread::wait() {
-  runWaitHooks();
+  runWaitPreHooks();
 
   if (!future_.valid()) {
     // already waited on
+    runWaitPostHooks();
     return;
   }
   future_.get();
+  runWaitPostHooks();
 }
 
 } // namespace torch::comms

--- a/comms/torchcomms/TorchWork.hpp
+++ b/comms/torchcomms/TorchWork.hpp
@@ -73,8 +73,8 @@ class TorchWork : public c10::intrusive_ptr_target {
   //
   // - Start hook:  fired when setStatus(INPROGRESS) is called
   // - End hook:    fired when setStatus(COMPLETED/ERROR/TIMEDOUT) is called
-  // - Wait hook:   fired when runWaitHooks() is called (backends call this
-  //                from their wait() implementation)
+  // - Wait pre hook:  fired at the start of wait(), before the sync
+  // - Wait post hook: fired at the end of wait(), after the sync
   //
   // Multiple hooks can be registered; they fire in registration order.
   // Hooks are NOT thread-safe -- register before concurrent status changes.
@@ -97,8 +97,12 @@ class TorchWork : public c10::intrusive_ptr_target {
     }
   }
 
-  void registerWorkWaitHook(WorkHook hook) {
-    wait_hooks_.push_back(std::move(hook));
+  void registerWorkWaitPreHook(WorkHook hook) {
+    wait_pre_hooks_.push_back(std::move(hook));
+  }
+
+  void registerWorkWaitPostHook(WorkHook hook) {
+    wait_post_hooks_.push_back(std::move(hook));
   }
 
   // Disable copy and move semantics
@@ -120,9 +124,15 @@ class TorchWork : public c10::intrusive_ptr_target {
     }
   }
 
-  // Backend wait() implementations should call this to fire wait hooks.
-  void runWaitHooks() {
-    for (auto& hook : wait_hooks_) {
+  // Backend wait() implementations should call these around the actual wait.
+  void runWaitPreHooks() {
+    for (auto& hook : wait_pre_hooks_) {
+      hook();
+    }
+  }
+
+  void runWaitPostHooks() {
+    for (auto& hook : wait_post_hooks_) {
       hook();
     }
   }
@@ -164,7 +174,8 @@ class TorchWork : public c10::intrusive_ptr_target {
   void release_resources() override {
     start_hooks_.clear();
     end_hooks_.clear();
-    wait_hooks_.clear();
+    wait_pre_hooks_.clear();
+    wait_post_hooks_.clear();
   }
 
   std::atomic<WorkStatus> status_{WorkStatus::NOT_STARTED};
@@ -172,7 +183,8 @@ class TorchWork : public c10::intrusive_ptr_target {
 
   std::vector<WorkHook> start_hooks_;
   std::vector<WorkHook> end_hooks_;
-  std::vector<WorkHook> wait_hooks_;
+  std::vector<WorkHook> wait_pre_hooks_;
+  std::vector<WorkHook> wait_post_hooks_;
 };
 
 class TorchWorkCompleted : public TorchWork {

--- a/comms/torchcomms/gloo/TorchWorkGloo.cpp
+++ b/comms/torchcomms/gloo/TorchWorkGloo.cpp
@@ -18,8 +18,8 @@ TorchWorkGloo::~TorchWorkGloo() {
 }
 
 void TorchWorkGloo::wait() {
-  runWaitHooks();
-  return;
+  runWaitPreHooks();
+  runWaitPostHooks();
 }
 
 } // namespace torch::comms

--- a/comms/torchcomms/hooks/clog/ClogHook.cpp
+++ b/comms/torchcomms/hooks/clog/ClogHook.cpp
@@ -727,7 +727,7 @@ void ClogHook::onPostHook(
                 [this, work_id]() { logLifecycleEvent(work_id, "S"); });
             work->registerWorkEndHook(
                 [this, work_id]() { logLifecycleEvent(work_id, "E"); });
-            work->registerWorkWaitHook(
+            work->registerWorkWaitPreHook(
                 [this, work_id]() { logLifecycleEvent(work_id, "W"); });
           }
         }

--- a/comms/torchcomms/nccl/TorchWorkNCCL.cpp
+++ b/comms/torchcomms/nccl/TorchWorkNCCL.cpp
@@ -160,12 +160,13 @@ TorchWorkNCCL::WorkStatus TorchWorkNCCL::checkStatus() {
 }
 
 void TorchWorkNCCL::wait() {
-  runWaitHooks();
+  runWaitPreHooks();
 
   // If already completed, return immediately
   WorkStatus local_state = status();
   if (local_state == WorkStatus::COMPLETED ||
       local_state == WorkStatus::ERROR || local_state == WorkStatus::TIMEDOUT) {
+    runWaitPostHooks();
     return;
   }
 
@@ -192,5 +193,7 @@ void TorchWorkNCCL::wait() {
   // complete.
   inputTensors_.clear();
   inputTensor_.reset();
+
+  runWaitPostHooks();
 }
 } // namespace torch::comms

--- a/comms/torchcomms/ncclx/TorchWorkNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchWorkNCCLX.cpp
@@ -269,12 +269,13 @@ TorchWorkNCCLX::WorkStatus TorchWorkNCCLX::checkStatus() {
 }
 
 void TorchWorkNCCLX::wait() {
-  runWaitHooks();
+  runWaitPreHooks();
 
   // If already completed, return immediately
   WorkStatus local_state = status();
   if (local_state == WorkStatus::COMPLETED ||
       local_state == WorkStatus::ERROR || local_state == WorkStatus::TIMEDOUT) {
+    runWaitPostHooks();
     return;
   }
 
@@ -302,5 +303,7 @@ void TorchWorkNCCLX::wait() {
   // complete.
   inputTensors_.clear();
   inputTensor_.reset();
+
+  runWaitPostHooks();
 }
 } // namespace torch::comms

--- a/comms/torchcomms/rccl/TorchWorkRCCL.cpp
+++ b/comms/torchcomms/rccl/TorchWorkRCCL.cpp
@@ -147,12 +147,13 @@ TorchWorkRCCL::WorkStatus TorchWorkRCCL::checkStatus() {
 }
 
 void TorchWorkRCCL::wait() {
-  runWaitHooks();
+  runWaitPreHooks();
 
   // If already completed, return immediately
   WorkStatus local_state = status();
   if (local_state == WorkStatus::COMPLETED ||
       local_state == WorkStatus::ERROR || local_state == WorkStatus::TIMEDOUT) {
+    runWaitPostHooks();
     return;
   }
 
@@ -179,5 +180,7 @@ void TorchWorkRCCL::wait() {
   // complete.
   inputTensors_.clear();
   inputTensor_.reset();
+
+  runWaitPostHooks();
 }
 } // namespace torch::comms

--- a/comms/torchcomms/rcclx/TorchWorkRCCLX.cpp
+++ b/comms/torchcomms/rcclx/TorchWorkRCCLX.cpp
@@ -143,12 +143,13 @@ TorchWorkRCCLX::WorkStatus TorchWorkRCCLX::checkStatus() {
 }
 
 void TorchWorkRCCLX::wait() {
-  runWaitHooks();
+  runWaitPreHooks();
 
   // If already completed, return immediately
   WorkStatus local_state = status();
   if (local_state == WorkStatus::COMPLETED ||
       local_state == WorkStatus::ERROR || local_state == WorkStatus::TIMEDOUT) {
+    runWaitPostHooks();
     return;
   }
 
@@ -175,5 +176,7 @@ void TorchWorkRCCLX::wait() {
   // complete.
   inputTensors_.clear();
   inputTensor_.reset();
+
+  runWaitPostHooks();
 }
 } // namespace torch::comms

--- a/comms/torchcomms/tests/unit/cpp/TorchWorkTest.cpp
+++ b/comms/torchcomms/tests/unit/cpp/TorchWorkTest.cpp
@@ -17,7 +17,8 @@ class TestWork : public TorchWork {
   }
 
   void wait() override {
-    runWaitHooks();
+    runWaitPreHooks();
+    runWaitPostHooks();
   }
 
   // expose for testing
@@ -69,16 +70,29 @@ TEST(TorchWorkTest, EndHookFiredOnTimedOut) {
   EXPECT_EQ(end_count, 1);
 }
 
-TEST(TorchWorkTest, WaitHookFiredOnWait) {
+TEST(TorchWorkTest, WaitPreHookFiredOnWait) {
   auto work = c10::make_intrusive<TestWork>();
   int wait_count = 0;
-  work->registerWorkWaitHook([&wait_count]() { wait_count++; });
+  work->registerWorkWaitPreHook([&wait_count]() { wait_count++; });
 
   EXPECT_EQ(wait_count, 0);
   work->wait();
   EXPECT_EQ(wait_count, 1);
 
   // wait hooks fire every time wait() is called
+  work->wait();
+  EXPECT_EQ(wait_count, 2);
+}
+
+TEST(TorchWorkTest, WaitPostHookFiredOnWait) {
+  auto work = c10::make_intrusive<TestWork>();
+  int wait_count = 0;
+  work->registerWorkWaitPostHook([&wait_count]() { wait_count++; });
+
+  EXPECT_EQ(wait_count, 0);
+  work->wait();
+  EXPECT_EQ(wait_count, 1);
+
   work->wait();
   EXPECT_EQ(wait_count, 2);
 }
@@ -115,19 +129,21 @@ TEST(TorchWorkTest, EndHookNotFiredOnInProgress) {
   EXPECT_EQ(end_count, 0);
 }
 
-TEST(TorchWorkTest, AllThreeHooksFiredInLifecycle) {
+TEST(TorchWorkTest, AllHooksFiredInLifecycle) {
   auto work = c10::make_intrusive<TestWork>();
   std::vector<std::string> events;
 
   work->registerWorkStartHook([&events]() { events.push_back("start"); });
   work->registerWorkEndHook([&events]() { events.push_back("end"); });
-  work->registerWorkWaitHook([&events]() { events.push_back("wait"); });
+  work->registerWorkWaitPreHook([&events]() { events.push_back("wait_pre"); });
+  work->registerWorkWaitPostHook(
+      [&events]() { events.push_back("wait_post"); });
 
   work->setStatus(TorchWork::WorkStatus::INPROGRESS);
   work->wait();
   work->setStatus(TorchWork::WorkStatus::COMPLETED);
 
-  std::vector<std::string> expected{"start", "wait", "end"};
+  std::vector<std::string> expected{"start", "wait_pre", "wait_post", "end"};
   EXPECT_EQ(events, expected);
 }
 

--- a/comms/torchcomms/xccl/TorchWorkXCCL.cpp
+++ b/comms/torchcomms/xccl/TorchWorkXCCL.cpp
@@ -156,12 +156,13 @@ TorchWorkXCCL::WorkStatus TorchWorkXCCL::checkStatus() {
 }
 
 void TorchWorkXCCL::wait() {
-  runWaitHooks();
+  runWaitPreHooks();
 
   // If already completed, return immediately
   WorkStatus local_state = state_;
   if (local_state == WorkStatus::COMPLETED ||
       local_state == WorkStatus::ERROR || local_state == WorkStatus::TIMEDOUT) {
+    runWaitPostHooks();
     return;
   }
 
@@ -182,5 +183,7 @@ void TorchWorkXCCL::wait() {
       comm_->getXpuApi(),
       comm_->getXpuApi()->streamWaitEvent(current_stream, end_event_, 0),
       "Failed to make stream wait for event");
+
+  runWaitPostHooks();
 }
 } // namespace torch::comms


### PR DESCRIPTION
Summary:

Rename registerWorkWaitHook to registerWorkWaitPreHook and
add registerWorkWaitPostHook. The pre hook fires before the
actual wait/sync (existing behavior), while the post hook
fires after the stream dependency is established.

This enables hooks like chash to launch GPU kernels after
the collective output is ready, rather than before the sync
where the output buffer may contain stale data.

Updated all backend wait() implementations to call
runWaitPreHooks() at the start and runWaitPostHooks() at the
end (and at each early return).

Reviewed By: mingrany

Differential Revision: D103448992


