### PR TITLE
Guard NCCL_SHRINK_ABORT with version check for NCCL < 2.27

### DIFF
--- a/comms/torchcomms/nccl/TorchCommNCCL.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCL.cpp
@@ -349,7 +349,12 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::reconfigure(
               static_cast<int>(excludeRanks.size()),
               &new_comm,
               nullptr,
-              NCCL_SHRINK_ABORT),
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 27, 0)
+              NCCL_SHRINK_ABORT
+#else
+              0
+#endif
+              ),
           "NCCL commShrink failed during reconfigure");
     } else {
       const ncclUniqueId* uniqueIdPtr = nullptr;


### PR DESCRIPTION
Summary: D101746890 introduced `NCCL_SHRINK_ABORT` in `commShrink()` without a version guard. This macro only exists in NCCL >= 2.27, breaking builds against older NCCL versions (e.g. 2.26.2 used by hpc_comms.param conveyor). Add a preprocessor guard that falls back to `0` for NCCL < 2.27.

Differential Revision: D103629979


