### PR TITLE
Fix VerifyAlgoStatsHelper to use setenv for NCCL_COLLTRACE (#2363)

### DIFF
--- a/comms/ctran/tests/VerifyAlgoStatsUtil.cc
+++ b/comms/ctran/tests/VerifyAlgoStatsUtil.cc
@@ -2,6 +2,8 @@
 
 #include "VerifyAlgoStatsUtil.h"
 
+#include <cstdlib>
+
 #include <fmt/core.h>
 #include <gtest/gtest.h>
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -10,11 +12,29 @@ namespace ctran::test {
 
 VerifyAlgoStatsHelper::~VerifyAlgoStatsHelper() {
   if (enabled_) {
+    if (oldEnvValue_) {
+      setenv("NCCL_COLLTRACE", oldEnvValue_->c_str(), 1);
+    } else {
+      unsetenv("NCCL_COLLTRACE");
+    }
     NCCL_COLLTRACE = oldColltrace_;
   }
 }
 
 void VerifyAlgoStatsHelper::enable() {
+  // Override at both layers:
+  //  - setenv so the value survives any later ncclCvarInit() re-read
+  //    (e.g. via ncclMemAlloc -> initEnv -> ncclCvarInit).
+  //  - NCCL_COLLTRACE cvar so the value is visible immediately, regardless of
+  //    whether ncclCvarInit() has already run.
+  auto old = std::getenv("NCCL_COLLTRACE");
+  if (old != nullptr) {
+    oldEnvValue_ = old;
+    std::string newValue = std::string(old) + ",algostat";
+    setenv("NCCL_COLLTRACE", newValue.c_str(), 1);
+  } else {
+    setenv("NCCL_COLLTRACE", "algostat", 1);
+  }
   oldColltrace_ = NCCL_COLLTRACE;
   NCCL_COLLTRACE.push_back("algostat");
   enabled_ = true;

--- a/comms/ctran/tests/VerifyAlgoStatsUtil.h
+++ b/comms/ctran/tests/VerifyAlgoStatsUtil.h
@@ -2,7 +2,9 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
+#include <vector>
 #include "comms/ctran/CtranComm.h"
 
 namespace ctran::test {
@@ -13,6 +15,9 @@ class VerifyAlgoStatsHelper {
   ~VerifyAlgoStatsHelper();
 
   // Enable AlgoStats tracing. Must be called before CtranComm creation.
+  // Overrides NCCL_COLLTRACE via both setenv (so the value survives any
+  // subsequent ncclCvarInit() re-read) and the in-memory cvar (so the value is
+  // visible immediately, regardless of call ordering).
   void enable();
 
   void verify(
@@ -29,6 +34,7 @@ class VerifyAlgoStatsHelper {
 
  private:
   bool enabled_{false};
+  std::optional<std::string> oldEnvValue_;
   std::vector<std::string> oldColltrace_;
 };
 


### PR DESCRIPTION
Summary:

Previously, VerifyAlgoStatsHelper::enable() directly modified the in-memory
C++ global NCCL_COLLTRACE. This was fragile because ncclCvarInit() (called
inside CtranDistTestFixture::SetUp()) re-reads all CVARs from OS environment
variables, overwriting any in-memory modifications. This meant enable() had
to be called strictly after SetUp(), and any unexpected code path triggering
ncclCvarInit() (e.g., ncclMemAlloc -> initEnv) would silently wipe the
"algostat" value.

Fix: Use both setenv/unsetenv and in-memory update to set NCCL_COLLTRACE.
This makes the modification survive ncclCvarInit() re-reads regardless of
call ordering, following the same SysEnvRAII pattern used elsewhere in the
codebase.

Reviewed By: minsii

Differential Revision: D103740303


