### PR TITLE
Centralize input validation in TorchComm

### DIFF
--- a/comms/torchcomms/TorchComm.cpp
+++ b/comms/torchcomms/TorchComm.cpp
@@ -3,11 +3,62 @@
 #include "comms/torchcomms/TorchComm.hpp"
 #include "comms/torchcomms/TorchCommFactory.hpp"
 
+#include <algorithm>
 #include <atomic>
+#include <set>
 
 namespace torch::comms {
 
 namespace {
+
+void ensureTensorContiguous(const at::Tensor& tensor) {
+  TORCH_CHECK(
+      tensor.is_contiguous(),
+      "Tensor must be contiguous for collective operations");
+}
+
+void ensureTensorsContiguous(const std::vector<at::Tensor>& tensors) {
+  for (const auto& t : tensors) {
+    ensureTensorContiguous(t);
+  }
+}
+
+void ensureTensorsSameNumel(
+    const std::vector<at::Tensor>& tensors,
+    const at::Tensor& reference,
+    const char* message) {
+  for (const auto& t : tensors) {
+    TORCH_CHECK(t.numel() == reference.numel(), message);
+  }
+}
+
+void ensureTensorsSameDtype(
+    const std::vector<at::Tensor>& tensors,
+    const at::Tensor& reference,
+    const char* message) {
+  for (const auto& t : tensors) {
+    TORCH_CHECK(t.scalar_type() == reference.scalar_type(), message);
+  }
+}
+
+void ensureTensorsSameDtype(
+    const at::Tensor& a,
+    const at::Tensor& b,
+    const char* message) {
+  TORCH_CHECK(a.scalar_type() == b.scalar_type(), message);
+}
+
+void ensureTensorsSameDtype(
+    const std::vector<at::Tensor>& a,
+    const std::vector<at::Tensor>& b,
+    const char* message) {
+  TORCH_CHECK(
+      a.size() == b.size(),
+      "Tensor lists must have the same size for dtype comparison");
+  for (size_t i = 0; i < a.size(); ++i) {
+    TORCH_CHECK(a[i].scalar_type() == b[i].scalar_type(), message);
+  }
+}
 
 // Singleton to generate globally unique increasing op_ids across all TorchComm
 // instances. This ensures that when multiple communicators share the same
@@ -124,6 +175,8 @@ c10::intrusive_ptr<TorchWork> TorchComm::send(
     bool async_op,
     const SendOptions& options) {
   validateRank(dst, "dst");
+  ensureTensorContiguous(tensor);
+
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
   preHook(OpName::send, op_id, SendPreHookArgs(tensor, dst, async_op));
 
@@ -140,6 +193,8 @@ c10::intrusive_ptr<TorchWork> TorchComm::recv(
     bool async_op,
     const RecvOptions& options) {
   validateRank(src, "src");
+  ensureTensorContiguous(tensor);
+
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
   preHook(OpName::recv, op_id, RecvPreHookArgs(tensor, src, async_op));
 
@@ -157,6 +212,8 @@ c10::intrusive_ptr<TorchWork> TorchComm::broadcast(
     bool async_op,
     const BroadcastOptions& options) {
   validateRank(root, "root");
+  ensureTensorContiguous(tensor);
+
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
   preHook(
       OpName::broadcast, op_id, BroadcastPreHookArgs(tensor, root, async_op));
@@ -174,6 +231,8 @@ c10::intrusive_ptr<TorchWork> TorchComm::all_reduce(
     const ReduceOp& op,
     bool async_op,
     const AllReduceOptions& options) {
+  ensureTensorContiguous(tensor);
+
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
   preHook(
       OpName::all_reduce, op_id, AllReducePreHookArgs(tensor, op, async_op));
@@ -193,6 +252,8 @@ c10::intrusive_ptr<TorchWork> TorchComm::reduce(
     bool async_op,
     const ReduceOptions& options) {
   validateRank(root, "root");
+  ensureTensorContiguous(tensor);
+
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
   preHook(OpName::reduce, op_id, ReducePreHookArgs(tensor, root, op, async_op));
 
@@ -208,6 +269,20 @@ c10::intrusive_ptr<TorchWork> TorchComm::all_gather(
     const at::Tensor& tensor,
     bool async_op,
     const AllGatherOptions& options) {
+  ensureTensorContiguous(tensor);
+  ensureTensorsContiguous(tensor_list);
+  TORCH_CHECK(
+      tensor_list.size() == static_cast<size_t>(getSize()),
+      "tensor_list size must equal comm_size for all_gather");
+  ensureTensorsSameNumel(
+      tensor_list,
+      tensor,
+      "All tensors in tensor_list must have same size as input tensor for all_gather");
+  ensureTensorsSameDtype(
+      tensor_list,
+      tensor,
+      "All tensors in tensor_list must have same dtype as input tensor for all_gather");
+
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
   preHook(
       OpName::all_gather,
@@ -227,6 +302,19 @@ c10::intrusive_ptr<TorchWork> TorchComm::all_gather_v(
     const at::Tensor& tensor,
     bool async_op,
     const AllGatherOptions& options) {
+  ensureTensorContiguous(tensor);
+  ensureTensorsContiguous(tensor_list);
+  TORCH_CHECK(
+      tensor_list.size() == static_cast<size_t>(getSize()),
+      "tensor_list size must equal comm_size for all_gather_v");
+  TORCH_CHECK(
+      tensor_list[getRank()].numel() == tensor.numel(),
+      "Output tensor size must equal input tensor size for all_gather_v");
+  ensureTensorsSameDtype(
+      tensor_list,
+      tensor,
+      "All tensors in tensor_list must have same dtype as input tensor for all_gather_v");
+
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
   preHook(
       OpName::all_gather_v,
@@ -246,6 +334,16 @@ c10::intrusive_ptr<TorchWork> TorchComm::all_gather_single(
     const at::Tensor& input,
     bool async_op,
     const AllGatherSingleOptions& options) {
+  ensureTensorContiguous(input);
+  ensureTensorContiguous(output);
+  TORCH_CHECK(
+      output.numel() == input.numel() * getSize(),
+      "Output tensor size must be input_size * comm_size for all_gather_single");
+  ensureTensorsSameDtype(
+      input,
+      output,
+      "Input and output tensors must have same dtype for all_gather_single");
+
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
   preHook(
       OpName::all_gather_single,
@@ -267,6 +365,20 @@ c10::intrusive_ptr<TorchWork> TorchComm::reduce_scatter(
     const ReduceOp& op,
     bool async_op,
     const ReduceScatterOptions& options) {
+  ensureTensorContiguous(output);
+  ensureTensorsContiguous(input_list);
+  TORCH_CHECK(
+      input_list.size() == static_cast<size_t>(getSize()),
+      "input_list size must equal comm_size for reduce_scatter");
+  ensureTensorsSameNumel(
+      input_list,
+      output,
+      "All input tensors must have same size as output tensor for reduce_scatter");
+  ensureTensorsSameDtype(
+      input_list,
+      output,
+      "All input tensors must have same dtype as output tensor for reduce_scatter");
+
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
   preHook(
       OpName::reduce_scatter,
@@ -288,6 +400,19 @@ c10::intrusive_ptr<TorchWork> TorchComm::reduce_scatter_v(
     const ReduceOp& op,
     bool async_op,
     const ReduceScatterOptions& options) {
+  ensureTensorContiguous(output);
+  ensureTensorsContiguous(input_list);
+  TORCH_CHECK(
+      input_list.size() == static_cast<size_t>(getSize()),
+      "input_list size must equal comm_size for reduce_scatter_v");
+  TORCH_CHECK(
+      input_list[getRank()].numel() == output.numel(),
+      "Output tensor size must equal input tensor size for reduce_scatter_v");
+  ensureTensorsSameDtype(
+      input_list,
+      output,
+      "All input tensors must have same dtype as output tensor for reduce_scatter_v");
+
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
   preHook(
       OpName::reduce_scatter_v,
@@ -310,6 +435,16 @@ c10::intrusive_ptr<TorchWork> TorchComm::reduce_scatter_single(
     const ReduceOp& op,
     bool async_op,
     const ReduceScatterSingleOptions& options) {
+  ensureTensorContiguous(input);
+  ensureTensorContiguous(output);
+  TORCH_CHECK(
+      input.numel() == output.numel() * getSize(),
+      "Input tensor size must be output_size * comm_size for reduce_scatter_single");
+  ensureTensorsSameDtype(
+      input,
+      output,
+      "Input and output tensors must have same dtype for reduce_scatter_single");
+
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
   preHook(
       OpName::reduce_scatter_single,
@@ -332,6 +467,19 @@ c10::intrusive_ptr<TorchWork> TorchComm::all_to_all_single(
     const at::Tensor& input,
     bool async_op,
     const AllToAllSingleOptions& options) {
+  ensureTensorContiguous(input);
+  ensureTensorContiguous(output);
+  TORCH_CHECK(
+      input.numel() == output.numel(),
+      "Input and output tensors must have same size for all_to_all_single");
+  TORCH_CHECK(
+      input.numel() % getSize() == 0,
+      "Tensor size must be divisible by comm_size for all_to_all_single");
+  ensureTensorsSameDtype(
+      input,
+      output,
+      "Input and output tensors must have same dtype for all_to_all_single");
+
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
   preHook(
       OpName::all_to_all_single,
@@ -354,6 +502,31 @@ c10::intrusive_ptr<TorchWork> TorchComm::all_to_all_v_single(
     const std::vector<uint64_t>& input_split_sizes,
     bool async_op,
     const AllToAllvSingleOptions& options) {
+  ensureTensorContiguous(input);
+  ensureTensorContiguous(output);
+  TORCH_CHECK(
+      input_split_sizes.size() == static_cast<size_t>(getSize()),
+      "input_split_sizes length must equal comm_size for all_to_all_v_single");
+  TORCH_CHECK(
+      output_split_sizes.size() == static_cast<size_t>(getSize()),
+      "output_split_sizes length must equal comm_size for all_to_all_v_single");
+  uint64_t input_total = 0;
+  uint64_t output_total = 0;
+  for (size_t i = 0; i < input_split_sizes.size(); ++i) {
+    input_total += input_split_sizes[i];
+    output_total += output_split_sizes[i];
+  }
+  TORCH_CHECK(
+      input_total <= static_cast<uint64_t>(input.size(0)),
+      "Sum of input_split_sizes exceeds input tensor size for all_to_all_v_single");
+  TORCH_CHECK(
+      output_total <= static_cast<uint64_t>(output.size(0)),
+      "Sum of output_split_sizes exceeds output tensor size for all_to_all_v_single");
+  ensureTensorsSameDtype(
+      input,
+      output,
+      "Input and output tensors must have same dtype for all_to_all_v_single");
+
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
   preHook(
       OpName::all_to_all_v_single,
@@ -376,6 +549,17 @@ c10::intrusive_ptr<TorchWork> TorchComm::all_to_all(
     const std::vector<at::Tensor>& input_tensor_list,
     bool async_op,
     const AllToAllOptions& options) {
+  ensureTensorsContiguous(input_tensor_list);
+  ensureTensorsContiguous(output_tensor_list);
+  TORCH_CHECK(
+      input_tensor_list.size() == static_cast<size_t>(getSize()) &&
+          output_tensor_list.size() == static_cast<size_t>(getSize()),
+      "Tensor list sizes must equal comm_size for all_to_all");
+  ensureTensorsSameDtype(
+      input_tensor_list,
+      output_tensor_list,
+      "Input and output tensors must have same dtype at each index for all_to_all");
+
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
   preHook(
       OpName::all_to_all,
@@ -413,6 +597,22 @@ c10::intrusive_ptr<TorchWork> TorchComm::scatter(
     bool async_op,
     const ScatterOptions& options) {
   validateRank(root, "root");
+  ensureTensorContiguous(output_tensor);
+  if (getRank() == root) {
+    TORCH_CHECK(
+        input_tensor_list.size() == static_cast<size_t>(getSize()),
+        "input_tensor_list size must equal comm_size for scatter");
+    ensureTensorsContiguous(input_tensor_list);
+    ensureTensorsSameNumel(
+        input_tensor_list,
+        output_tensor,
+        "All input tensors must have same size as output tensor for scatter");
+    ensureTensorsSameDtype(
+        input_tensor_list,
+        output_tensor,
+        "All input tensors must have same dtype as output tensor for scatter");
+  }
+
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
   preHook(
       OpName::scatter,
@@ -435,6 +635,22 @@ c10::intrusive_ptr<TorchWork> TorchComm::gather(
     bool async_op,
     const GatherOptions& options) {
   validateRank(root, "root");
+  ensureTensorContiguous(input_tensor);
+  if (getRank() == root) {
+    TORCH_CHECK(
+        output_tensor_list.size() == static_cast<size_t>(getSize()),
+        "output_tensor_list size must equal comm_size for gather");
+    ensureTensorsContiguous(output_tensor_list);
+    ensureTensorsSameNumel(
+        output_tensor_list,
+        input_tensor,
+        "All output tensors must have same size as input tensor for gather");
+    ensureTensorsSameDtype(
+        output_tensor_list,
+        input_tensor,
+        "All output tensors must have same dtype as input tensor for gather");
+  }
+
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
   preHook(
       OpName::gather,
@@ -456,6 +672,18 @@ c10::intrusive_ptr<TorchWork> TorchComm::gather_single(
     bool async_op,
     const GatherSingleOptions& options) {
   validateRank(root, "root");
+  ensureTensorContiguous(input);
+  if (getRank() == root) {
+    ensureTensorContiguous(output);
+    TORCH_CHECK(
+        output.numel() == input.numel() * getSize(),
+        "Output tensor size must be input_size * comm_size for gather_single");
+    ensureTensorsSameDtype(
+        input,
+        output,
+        "Input and output tensors must have same dtype for gather_single");
+  }
+
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
   preHook(
       OpName::gather_single,
@@ -525,6 +753,14 @@ std::shared_ptr<TorchComm> TorchComm::split(
     const std::vector<int>& ranks,
     const std::string& name,
     const CommOptions& options) {
+  for (int rank : ranks) {
+    validateRank(rank, "rank in ranks");
+  }
+  std::set<int> unique_ranks(ranks.begin(), ranks.end());
+  TORCH_CHECK(
+      unique_ranks.size() == ranks.size(),
+      "Duplicate ranks found in ranks list");
+
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
   preHook(OpName::split, op_id, SplitPreHookArgs(ranks, name));
   auto new_impl = impl_->split(ranks, name, options);
@@ -579,6 +815,11 @@ void BatchSendRecv::recv(at::Tensor& tensor, int src) {
 c10::intrusive_ptr<TorchWork> BatchSendRecv::issue(
     bool async_op,
     const BatchP2POptions& options) {
+  TORCH_CHECK(!ops.empty(), "Cannot issue empty batch operation");
+  for (const auto& op : ops) {
+    ensureTensorContiguous(op.tensor);
+  }
+
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
   parent_->preHook(
       OpName::batch_op_issue,

--- a/comms/torchcomms/gloo/TorchCommGloo.cpp
+++ b/comms/torchcomms/gloo/TorchCommGloo.cpp
@@ -77,12 +77,6 @@ inline T* getDataPointer(const at::Tensor& tensor) {
   }
 
 namespace {
-void ensureTensorContiguous(const at::Tensor& tensor) {
-  if (!tensor.is_contiguous()) {
-    throw std::runtime_error("Tensor must be contiguous for Gloo operations");
-  }
-}
-
 using ReduceFunc = void (*)(void*, const void*, const void*, size_t);
 
 template <typename T, std::enable_if_t<!std::is_integral_v<T>, int> = 0>
@@ -479,7 +473,6 @@ c10::intrusive_ptr<TorchWork> TorchCommGloo::send(
     const SendOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(tensor);
 
   if (dst < 0 || dst >= comm_size_) {
     throw std::runtime_error("Invalid destination rank for send operation");
@@ -521,7 +514,6 @@ c10::intrusive_ptr<TorchWork> TorchCommGloo::recv(
     const RecvOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(tensor);
 
   if (src < 0 || src >= comm_size_) {
     throw std::runtime_error("Invalid source rank for recv operation");
@@ -576,10 +568,6 @@ c10::intrusive_ptr<TorchWork> TorchCommGloo::batch_op_issue(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
 
-  if (ops.empty()) {
-    throw std::runtime_error("Cannot issue empty batch operation");
-  }
-
   // Collect input and output tensors for work tracking
   std::vector<at::Tensor> input_tensors;
   std::vector<at::Tensor> output_tensors;
@@ -587,11 +575,9 @@ c10::intrusive_ptr<TorchWork> TorchCommGloo::batch_op_issue(
   for (const auto& op : ops) {
     if (op.type == BatchSendRecv::P2POp::OpType::SEND) {
       at::Tensor tensor = op.tensor;
-      ensureTensorContiguous(tensor);
       input_tensors.push_back(tensor);
     } else if (op.type == BatchSendRecv::P2POp::OpType::RECV) {
       at::Tensor tensor = op.tensor;
-      ensureTensorContiguous(tensor);
       output_tensors.push_back(tensor);
     } else {
       throw std::runtime_error("Unknown op type");
@@ -723,7 +709,6 @@ c10::intrusive_ptr<TorchWork> TorchCommGloo::broadcast(
     const BroadcastOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(tensor);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "broadcast", root, tensor, tensor);
@@ -764,7 +749,6 @@ c10::intrusive_ptr<TorchWork> TorchCommGloo::all_reduce(
     const AllReduceOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(tensor);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_reduce", rank_, tensor, tensor);
@@ -810,7 +794,6 @@ c10::intrusive_ptr<TorchWork> TorchCommGloo::reduce(
     const ReduceOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(tensor);
 
   TracingGuard tracingGuard(name_, comm_size_, "reduce", root, tensor, tensor);
 
@@ -856,22 +839,6 @@ c10::intrusive_ptr<TorchWork> TorchCommGloo::all_gather(
     const AllGatherOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  if (tensor_list.size() != static_cast<size_t>(comm_size_)) {
-    throw std::runtime_error(
-        "tensor_list size must equal comm_size for all_gather");
-  }
-
-  // Ensure input tensor is contiguous
-  ensureTensorContiguous(tensor);
-
-  // Check that all output tensors are contiguous and have correct size
-  for (const auto& t : tensor_list) {
-    ensureTensorContiguous(t);
-    if (t.numel() != tensor.numel()) {
-      throw std::runtime_error(
-          "All tensors in tensor_list must have same size as input tensor");
-    }
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_gather", rank_, tensor_list, {tensor});
@@ -934,15 +901,6 @@ c10::intrusive_ptr<TorchWork> TorchCommGloo::all_gather_v(
     const AllGatherOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  if (tensor_list.size() != static_cast<size_t>(comm_size_)) {
-    throw std::runtime_error(
-        "tensor_list size must equal comm_size for all_gather_v");
-  }
-
-  ensureTensorContiguous(tensor);
-  for (const auto& t : tensor_list) {
-    ensureTensorContiguous(t);
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_gather_v", rank_, tensor_list, {tensor});
@@ -1005,13 +963,6 @@ c10::intrusive_ptr<TorchWork> TorchCommGloo::all_gather_single(
     const AllGatherSingleOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output);
-  ensureTensorContiguous(input);
-
-  if (output.numel() != input.numel() * comm_size_) {
-    throw std::runtime_error(
-        "Output tensor size must be input_size * comm_size for all_gather_single");
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_gather_single", rank_, input, output);
@@ -1057,21 +1008,6 @@ c10::intrusive_ptr<TorchWork> TorchCommGloo::reduce_scatter(
     const ReduceScatterOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output);
-
-  if (input_list.size() != static_cast<size_t>(comm_size_)) {
-    throw std::runtime_error(
-        "input_list size must equal comm_size for reduce_scatter");
-  }
-
-  // Check that all input tensors are contiguous and have correct size
-  for (const auto& t : input_list) {
-    ensureTensorContiguous(t);
-    if (t.numel() != output.numel()) {
-      throw std::runtime_error(
-          "All input tensors must have same size as output tensor");
-    }
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "reduce_scatter", rank_, input_list, {output});
@@ -1093,16 +1029,6 @@ c10::intrusive_ptr<TorchWork> TorchCommGloo::reduce_scatter_v(
     const ReduceScatterOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output);
-
-  if (input_list.size() != static_cast<size_t>(comm_size_)) {
-    throw std::runtime_error(
-        "input_list size must equal comm_size for reduce_scatter_v");
-  }
-
-  for (const auto& t : input_list) {
-    ensureTensorContiguous(t);
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "reduce_scatter_v", rank_, input_list, {output});
@@ -1174,13 +1100,6 @@ c10::intrusive_ptr<TorchWork> TorchCommGloo::reduce_scatter_single(
     const ReduceScatterSingleOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output);
-  ensureTensorContiguous(input);
-
-  if (input.numel() != output.numel() * comm_size_) {
-    throw std::runtime_error(
-        "Input tensor size must be output_size * comm_size for reduce_scatter_single");
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "reduce_scatter_single", rank_, input, output);
@@ -1235,18 +1154,6 @@ c10::intrusive_ptr<TorchWork> TorchCommGloo::all_to_all_single(
     const AllToAllSingleOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output);
-  ensureTensorContiguous(input);
-
-  if (input.numel() != output.numel()) {
-    throw std::runtime_error(
-        "Input and output tensors must have same size for all_to_all_single");
-  }
-
-  if (input.numel() % comm_size_ != 0) {
-    throw std::runtime_error(
-        "Tensor size must be divisible by comm_size for all_to_all_single");
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_to_all_single", rank_, input, output);
@@ -1294,37 +1201,6 @@ c10::intrusive_ptr<TorchWork> TorchCommGloo::all_to_all_v_single(
     const AllToAllvSingleOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output);
-  ensureTensorContiguous(input);
-
-  // Validate split sizes vectors
-  if (input_split_sizes.size() != static_cast<size_t>(comm_size_)) {
-    throw std::runtime_error(
-        "input_split_sizes length must equal comm_size for all_to_all_v_single");
-  }
-
-  if (output_split_sizes.size() != static_cast<size_t>(comm_size_)) {
-    throw std::runtime_error(
-        "output_split_sizes length must equal comm_size for all_to_all_v_single");
-  }
-
-  // Validate that split sizes sum to tensor sizes
-  uint64_t input_total = 0;
-  uint64_t output_total = 0;
-  for (int i = 0; i < comm_size_; ++i) {
-    input_total += input_split_sizes[i];
-    output_total += output_split_sizes[i];
-  }
-
-  if (input_total > static_cast<uint64_t>(input.size(0))) {
-    throw std::runtime_error(
-        "Sum of input_split_sizes exceeds input tensor size for all_to_all_v_single");
-  }
-
-  if (output_total > static_cast<uint64_t>(output.size(0))) {
-    throw std::runtime_error(
-        "Sum of output_split_sizes exceeds output tensor size for all_to_all_v_single");
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_to_all_v_single", rank_, input, output);
@@ -1392,17 +1268,6 @@ c10::intrusive_ptr<TorchWork> TorchCommGloo::all_to_all(
     const AllToAllOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  if (output_tensor_list.size() != static_cast<size_t>(comm_size_) ||
-      input_tensor_list.size() != static_cast<size_t>(comm_size_)) {
-    throw std::runtime_error(
-        "Tensor list sizes must equal comm_size for all_to_all");
-  }
-
-  // Validate all tensors
-  for (int i = 0; i < comm_size_; ++i) {
-    ensureTensorContiguous(input_tensor_list[i]);
-    ensureTensorContiguous(output_tensor_list[i]);
-  }
 
   TracingGuard tracingGuard(
       name_,
@@ -1501,23 +1366,6 @@ c10::intrusive_ptr<TorchWork> TorchCommGloo::scatter(
     const ScatterOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output_tensor);
-
-  // Only the root rank needs valid input tensors
-  if (rank_ == root) {
-    if (input_tensor_list.size() != static_cast<size_t>(comm_size_)) {
-      throw std::runtime_error(
-          "input_tensor_list size must equal comm_size for scatter");
-    }
-
-    for (const auto& t : input_tensor_list) {
-      ensureTensorContiguous(t);
-      if (t.numel() != output_tensor.numel()) {
-        throw std::runtime_error(
-            "All input tensors must have same size as output tensor");
-      }
-    }
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "scatter", root, input_tensor_list, {output_tensor});
@@ -1577,23 +1425,6 @@ c10::intrusive_ptr<TorchWork> TorchCommGloo::gather(
     const GatherOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(input_tensor);
-
-  // Only the root rank needs valid output tensors
-  if (rank_ == root) {
-    if (output_tensor_list.size() != static_cast<size_t>(comm_size_)) {
-      throw std::runtime_error(
-          "output_tensor_list size must equal comm_size for gather");
-    }
-
-    for (const auto& t : output_tensor_list) {
-      ensureTensorContiguous(t);
-      if (t.numel() != input_tensor.numel()) {
-        throw std::runtime_error(
-            "All output tensors must have same size as input tensor");
-      }
-    }
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "gather", root, {input_tensor}, output_tensor_list);
@@ -1669,23 +1500,6 @@ std::shared_ptr<TorchCommBackend> TorchCommGloo::split(
     const std::vector<int>& ranks,
     const std::string& name,
     const CommOptions& options) {
-  // Validate that all ranks are valid
-  for (int rank : ranks) {
-    if (rank < 0 || rank >= comm_size_) {
-      throw std::runtime_error(
-          fmt::format(
-              "Invalid rank {} in ranks. Valid ranks are 0 to {}",
-              rank,
-              comm_size_ - 1));
-    }
-  }
-
-  // Check for duplicate ranks
-  std::set<int> unique_ranks(ranks.begin(), ranks.end());
-  if (unique_ranks.size() != ranks.size()) {
-    throw std::runtime_error("Duplicate ranks found in ranks list");
-  }
-
   if (ranks.empty()) {
     // Empty list means exclude all ranks - return nullptr
     return nullptr;

--- a/comms/torchcomms/hooks/nan_check/tests/py/test_nan_check.py
+++ b/comms/torchcomms/hooks/nan_check/tests/py/test_nan_check.py
@@ -110,7 +110,7 @@ class TestNanCheckHook(unittest.TestCase):
         hook.register_with_comm(comm)
 
         # For all_gather_single, the output tensor is exposed in PreHookArgs
-        output = torch.tensor([float("nan"), float("nan")])
+        output = torch.tensor([float("nan")] * comm.get_size())
         input_tensor = torch.tensor([1.0])
         with self.assertRaises(RuntimeError) as ctx:
             comm.all_gather_single(output, input_tensor, async_op=False)

--- a/comms/torchcomms/nccl/TorchCommNCCL.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCL.cpp
@@ -592,7 +592,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::send(
     const SendOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(tensor);
 
   TracingGuard tracingGuard(name_, comm_size_, "send", dst, tensor, tensor);
 
@@ -636,7 +635,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::recv(
     const RecvOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(tensor);
 
   TracingGuard tracingGuard(name_, comm_size_, "recv", src, tensor, tensor);
 
@@ -676,10 +674,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::batch_op_issue(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
 
-  if (ops.empty()) {
-    throw std::runtime_error("Cannot issue empty batch operation");
-  }
-
   // Collect input and output tensors for work tracking
   std::vector<at::Tensor> input_tensors;
   std::vector<at::Tensor> output_tensors;
@@ -687,11 +681,9 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::batch_op_issue(
   for (const auto& op : ops) {
     if (op.type == BatchSendRecv::P2POp::OpType::SEND) {
       at::Tensor tensor = op.tensor;
-      ensureTensorContiguous(tensor);
       input_tensors.push_back(tensor);
     } else if (op.type == BatchSendRecv::P2POp::OpType::RECV) {
       at::Tensor tensor = op.tensor;
-      ensureTensorContiguous(tensor);
       output_tensors.push_back(tensor);
     } else {
       throw std::runtime_error("Unknown op type");
@@ -777,7 +769,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::broadcast(
     const BroadcastOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(tensor);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "broadcast", root, tensor, tensor);
@@ -823,7 +814,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::all_reduce(
     const AllReduceOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(tensor);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_reduce", rank_, tensor, tensor);
@@ -871,7 +861,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::reduce(
     const ReduceOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(tensor);
 
   TracingGuard tracingGuard(name_, comm_size_, "reduce", root, tensor, tensor);
 
@@ -918,22 +907,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::all_gather(
     const AllGatherOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  if (tensor_list.size() != static_cast<size_t>(comm_size_)) {
-    throw std::runtime_error(
-        "tensor_list size must equal comm_size for all_gather");
-  }
-
-  // Ensure input tensor is contiguous
-  ensureTensorContiguous(tensor);
-
-  // Check that all output tensors are contiguous and have correct size
-  for (const auto& t : tensor_list) {
-    ensureTensorContiguous(t);
-    if (t.numel() != tensor.numel()) {
-      throw std::runtime_error(
-          "All tensors in tensor_list must have same size as input tensor");
-    }
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_gather", rank_, tensor_list, {tensor});
@@ -989,15 +962,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::all_gather_v(
     const AllGatherOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  if (tensor_list.size() != static_cast<size_t>(comm_size_)) {
-    throw std::runtime_error(
-        "tensor_list size must equal comm_size for all_gather_v");
-  }
-
-  ensureTensorContiguous(tensor);
-  for (const auto& t : tensor_list) {
-    ensureTensorContiguous(t);
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_gather_v", rank_, tensor_list, {tensor});
@@ -1021,10 +985,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::all_gather_v(
     // For all_gather_v, each rank broadcasts its input tensor to all others
     auto& output = tensor_list[i];
     auto& input = (i == rank_) ? tensor : output;
-    if (input.numel() != output.numel()) {
-      throw std::runtime_error(
-          "Output tensor size must equal input tensor size for all_gather_v");
-    }
     ncclResult_t opResult = nccl_api_->broadcast(
         input.data_ptr(),
         output.data_ptr(),
@@ -1060,13 +1020,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::all_gather_single(
     const AllGatherSingleOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output);
-  ensureTensorContiguous(input);
-
-  if (output.numel() != input.numel() * comm_size_) {
-    throw std::runtime_error(
-        "Output tensor size must be input_size * comm_size for all_gather_single");
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_gather_single", rank_, input, output);
@@ -1110,21 +1063,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::reduce_scatter(
     const ReduceScatterOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output);
-
-  if (input_list.size() != static_cast<size_t>(comm_size_)) {
-    throw std::runtime_error(
-        "input_list size must equal comm_size for reduce_scatter");
-  }
-
-  // Check that all input tensors are contiguous and have correct size
-  for (const auto& t : input_list) {
-    ensureTensorContiguous(t);
-    if (t.numel() != output.numel()) {
-      throw std::runtime_error(
-          "All input tensors must have same size as output tensor");
-    }
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "reduce_scatter", rank_, input_list, {output});
@@ -1198,16 +1136,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::reduce_scatter_v(
     const ReduceScatterOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output);
-
-  if (input_list.size() != static_cast<size_t>(comm_size_)) {
-    throw std::runtime_error(
-        "input_list size must equal comm_size for reduce_scatter_v");
-  }
-
-  for (const auto& t : input_list) {
-    ensureTensorContiguous(t);
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "reduce_scatter_v", rank_, input_list, {output});
@@ -1234,10 +1162,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::reduce_scatter_v(
       // This rank receives the reduced result
       auto& input_tensor = input_list[i];
       auto& output_tensor = output;
-      if (input_tensor.numel() != output_tensor.numel()) {
-        throw std::runtime_error(
-            "Output tensor size must equal input tensor size for reduce_scatter_v");
-      }
       opResult = nccl_api_->reduce(
           input_tensor.data_ptr(),
           output_tensor.data_ptr(),
@@ -1287,13 +1211,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::reduce_scatter_single(
     const ReduceScatterSingleOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output);
-  ensureTensorContiguous(input);
-
-  if (input.numel() != output.numel() * comm_size_) {
-    throw std::runtime_error(
-        "Input tensor size must be output_size * comm_size for reduce_scatter_single");
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "reduce_scatter_single", rank_, input, output);
@@ -1340,18 +1257,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::all_to_all_single(
     const AllToAllSingleOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output);
-  ensureTensorContiguous(input);
-
-  if (input.numel() != output.numel()) {
-    throw std::runtime_error(
-        "Input and output tensors must have same size for all_to_all_single");
-  }
-
-  if (input.numel() % comm_size_ != 0) {
-    throw std::runtime_error(
-        "Tensor size must be divisible by comm_size for all_to_all_single");
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_to_all_single", rank_, input, output);
@@ -1436,37 +1341,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::all_to_all_v_single(
     const AllToAllvSingleOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output);
-  ensureTensorContiguous(input);
-
-  // Validate split sizes vectors
-  if (input_split_sizes.size() != static_cast<size_t>(comm_size_)) {
-    throw std::runtime_error(
-        "input_split_sizes length must equal comm_size for all_to_all_v_single");
-  }
-
-  if (output_split_sizes.size() != static_cast<size_t>(comm_size_)) {
-    throw std::runtime_error(
-        "output_split_sizes length must equal comm_size for all_to_all_v_single");
-  }
-
-  // Validate that split sizes sum does not exceed tensor dimensions
-  uint64_t input_total = 0;
-  uint64_t output_total = 0;
-  for (int i = 0; i < comm_size_; ++i) {
-    input_total += input_split_sizes[i];
-    output_total += output_split_sizes[i];
-  }
-
-  if (input_total > static_cast<uint64_t>(input.size(0))) {
-    throw std::runtime_error(
-        "Sum of input_split_sizes exceeds input tensor size for all_to_all_v_single");
-  }
-
-  if (output_total > static_cast<uint64_t>(output.size(0))) {
-    throw std::runtime_error(
-        "Sum of output_split_sizes exceeds output tensor size for all_to_all_v_single");
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_to_all_v_single", rank_, input, output);
@@ -1567,17 +1441,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::all_to_all(
     const AllToAllOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  if (output_tensor_list.size() != static_cast<size_t>(comm_size_) ||
-      input_tensor_list.size() != static_cast<size_t>(comm_size_)) {
-    throw std::runtime_error(
-        "Tensor list sizes must equal comm_size for all_to_all");
-  }
-
-  // Validate all tensors
-  for (int i = 0; i < comm_size_; ++i) {
-    ensureTensorContiguous(input_tensor_list[i]);
-    ensureTensorContiguous(output_tensor_list[i]);
-  }
 
   TracingGuard tracingGuard(
       name_,
@@ -1687,23 +1550,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::scatter(
     const ScatterOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output_tensor);
-
-  // Only the root rank needs valid input tensors
-  if (rank_ == root) {
-    if (input_tensor_list.size() != static_cast<size_t>(comm_size_)) {
-      throw std::runtime_error(
-          "input_tensor_list size must equal comm_size for scatter");
-    }
-
-    for (const auto& t : input_tensor_list) {
-      ensureTensorContiguous(t);
-      if (t.numel() != output_tensor.numel()) {
-        throw std::runtime_error(
-            "All input tensors must have same size as output tensor");
-      }
-    }
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "scatter", root, input_tensor_list, {output_tensor});
@@ -1790,23 +1636,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::gather(
     const GatherOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(input_tensor);
-
-  // Only the root rank needs valid output tensors
-  if (rank_ == root) {
-    if (output_tensor_list.size() != static_cast<size_t>(comm_size_)) {
-      throw std::runtime_error(
-          "output_tensor_list size must equal comm_size for gather");
-    }
-
-    for (const auto& t : output_tensor_list) {
-      ensureTensorContiguous(t);
-      if (t.numel() != input_tensor.numel()) {
-        throw std::runtime_error(
-            "All output tensors must have same size as input tensor");
-      }
-    }
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "gather", root, {input_tensor}, output_tensor_list);
@@ -1892,22 +1721,6 @@ std::shared_ptr<TorchCommBackend> TorchCommNCCL::split(
     const CommOptions& options) {
   // Validate the ranks list
   checkAndAbortIfTimedOutOrError();
-
-  std::unordered_set<int> rank_seen;
-  for (int rank : ranks) {
-    if (rank < 0 || rank >= comm_size_) {
-      throw std::runtime_error(
-          fmt::format(
-              "Invalid rank {} in ranks. Valid ranks are 0 to {}",
-              rank,
-              comm_size_ - 1));
-    }
-    if (rank_seen.find(rank) != rank_seen.end()) {
-      throw std::runtime_error(
-          fmt::format("Rank {} appears multiple times in ranks", rank));
-    }
-    rank_seen.insert(rank);
-  }
 
   // Determine the color for this rank
   int color;

--- a/comms/torchcomms/nccl/TorchCommNCCL.hpp
+++ b/comms/torchcomms/nccl/TorchCommNCCL.hpp
@@ -374,7 +374,6 @@ class TorchCommNCCL : public TorchCommBackend,
   void enqueueWork(c10::intrusive_ptr<TorchWorkNCCL> work, cudaStream_t stream);
   bool getGraphCaptureMode();
   cudaStream_t getOperationStream(bool async_op);
-  void ensureTensorContiguous(const at::Tensor& tensor);
 
   void attachMemoryHook();
   void detachMemoryHook();

--- a/comms/torchcomms/nccl/TorchCommNCCLUtils.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCLUtils.cpp
@@ -464,12 +464,6 @@ cudaStream_t TorchCommNCCL::getOperationStream(bool async_op) {
   }
 }
 
-void TorchCommNCCL::ensureTensorContiguous(const at::Tensor& tensor) {
-  if (!tensor.is_contiguous()) {
-    throw std::runtime_error("Tensor must be contiguous for NCCL operations");
-  }
-}
-
 // Protected methods (not in the private section of the header)
 cudaEvent_t TorchCommNCCL::getEvent() {
   std::lock_guard<std::mutex> lock(event_pool_mutex_);

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -677,7 +677,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::send(
     const SendOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(tensor);
 
   TracingGuard tracingGuard(name_, comm_size_, "send", dst, tensor, tensor);
 
@@ -722,7 +721,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::recv(
     const RecvOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(tensor);
 
   TracingGuard tracingGuard(name_, comm_size_, "recv", src, tensor, tensor);
 
@@ -763,10 +761,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::batch_op_issue(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
 
-  if (ops.empty()) {
-    throw std::runtime_error("Cannot issue empty batch operation");
-  }
-
   // Collect input and output tensors for work tracking
   std::vector<at::Tensor> input_tensors;
   std::vector<at::Tensor> output_tensors;
@@ -774,11 +768,9 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::batch_op_issue(
   for (const auto& op : ops) {
     if (op.type == BatchSendRecv::P2POp::OpType::SEND) {
       at::Tensor tensor = op.tensor;
-      ensureTensorContiguous(tensor);
       input_tensors.push_back(tensor);
     } else if (op.type == BatchSendRecv::P2POp::OpType::RECV) {
       at::Tensor tensor = op.tensor;
-      ensureTensorContiguous(tensor);
       output_tensors.push_back(tensor);
     } else {
       throw std::runtime_error("Unknown op type");
@@ -869,7 +861,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::broadcast(
     const BroadcastOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(tensor);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "broadcast", rank_, tensor, tensor);
@@ -916,7 +907,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::all_reduce(
     const AllReduceOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(tensor);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_reduce", rank_, tensor, tensor);
@@ -965,7 +955,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::reduce(
     const ReduceOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(tensor);
 
   TracingGuard tracingGuard(name_, comm_size_, "reduce", root, tensor, tensor);
 
@@ -1013,22 +1002,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::all_gather(
     const AllGatherOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  if (tensor_list.size() != static_cast<size_t>(comm_size_)) {
-    throw std::runtime_error(
-        "tensor_list size must equal comm_size for all_gather");
-  }
-
-  // Ensure input tensor is contiguous
-  ensureTensorContiguous(tensor);
-
-  // Check that all output tensors are contiguous and have correct size
-  for (const auto& t : tensor_list) {
-    ensureTensorContiguous(t);
-    if (t.numel() != tensor.numel()) {
-      throw std::runtime_error(
-          "All tensors in tensor_list must have same size as input tensor");
-    }
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_gather", rank_, tensor_list, {tensor});
@@ -1101,17 +1074,7 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::all_gather_v(
     const AllGatherOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  if (tensor_list.size() != static_cast<size_t>(comm_size_)) {
-    throw std::runtime_error(
-        "tensor_list size must equal comm_size for all_gather_v");
-  }
 
-  // Ensure input tensor is contiguous
-  ensureTensorContiguous(tensor);
-
-  for (const auto& t : tensor_list) {
-    ensureTensorContiguous(t);
-  }
   TracingGuard tracingGuard(
       name_, comm_size_, "all_gather_v", rank_, tensor_list, {tensor});
 
@@ -1139,10 +1102,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::all_gather_v(
     // where unevenly sized inputs are gathered among participating ranks
     auto& output = tensor_list[i];
     auto& input = (i == rank_) ? tensor : output;
-    if (input.numel() != output.numel()) {
-      throw std::runtime_error(
-          "Output tensor size must equal input tensor size for all_gather_v");
-    }
     ncclResult_t opResult = nccl_api_->broadcast(
         input.data_ptr(),
         output.data_ptr(),
@@ -1178,13 +1137,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::all_gather_single(
     const AllGatherSingleOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output);
-  ensureTensorContiguous(input);
-
-  if (output.numel() != input.numel() * comm_size_) {
-    throw std::runtime_error(
-        "Output tensor size must be input_size * comm_size for all_gather_single");
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_gather_single", rank_, input, output);
@@ -1310,21 +1262,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::reduce_scatter(
     const ReduceScatterOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output);
-
-  if (input_list.size() != static_cast<size_t>(comm_size_)) {
-    throw std::runtime_error(
-        "input_list size must equal comm_size for reduce_scatter");
-  }
-
-  // Check that all input tensors are contiguous and have correct size
-  for (const auto& t : input_list) {
-    ensureTensorContiguous(t);
-    if (t.numel() != output.numel()) {
-      throw std::runtime_error(
-          "All input tensors must have same size as output tensor");
-    }
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "reduce_scatter", rank_, input_list, {output});
@@ -1400,17 +1337,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::reduce_scatter_v(
     const ReduceScatterOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output);
-
-  if (input_list.size() != static_cast<size_t>(comm_size_)) {
-    throw std::runtime_error(
-        "input_list size must equal comm_size for reduce_scatter_v");
-  }
-
-  // Check that all input tensors are contiguous and have correct size
-  for (const auto& t : input_list) {
-    ensureTensorContiguous(t);
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "reduce_scatter_v", rank_, input_list, {output});
@@ -1442,10 +1368,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::reduce_scatter_v(
       // among participating ranks
       auto& input_tensor = input_list[i];
       auto& output_tensor = output;
-      if (input_tensor.numel() != output_tensor.numel()) {
-        throw std::runtime_error(
-            "Output tensor size must equal input tensor size for reduce_scatter_v");
-      }
       opResult = nccl_api_->reduce(
           input_tensor.data_ptr(),
           output_tensor.data_ptr(),
@@ -1495,13 +1417,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::reduce_scatter_single(
     const ReduceScatterSingleOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output);
-  ensureTensorContiguous(input);
-
-  if (input.numel() != output.numel() * comm_size_) {
-    throw std::runtime_error(
-        "Input tensor size must be output_size * comm_size for reduce_scatter_single");
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "reduce_scatter_single", rank_, input, output);
@@ -1549,18 +1464,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::all_to_all_single(
     const AllToAllSingleOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output);
-  ensureTensorContiguous(input);
-
-  if (input.numel() != output.numel()) {
-    throw std::runtime_error(
-        "Input and output tensors must have same size for all_to_all_single");
-  }
-
-  if (input.numel() % comm_size_ != 0) {
-    throw std::runtime_error(
-        "Tensor size must be divisible by comm_size for all_to_all_single");
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_to_all_single", rank_, input, output);
@@ -1610,37 +1513,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::all_to_all_v_single(
     const AllToAllvSingleOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output);
-  ensureTensorContiguous(input);
-
-  // Validate split sizes vectors
-  if (input_split_sizes.size() != static_cast<size_t>(comm_size_)) {
-    throw std::runtime_error(
-        "input_split_sizes length must equal comm_size for all_to_all_v_single");
-  }
-
-  if (output_split_sizes.size() != static_cast<size_t>(comm_size_)) {
-    throw std::runtime_error(
-        "output_split_sizes length must equal comm_size for all_to_all_v_single");
-  }
-
-  // Validate that split sizes sum does not exceed tensor dimensions
-  uint64_t input_total = 0;
-  uint64_t output_total = 0;
-  for (int i = 0; i < comm_size_; ++i) {
-    input_total += input_split_sizes[i];
-    output_total += output_split_sizes[i];
-  }
-
-  if (input_total > static_cast<uint64_t>(input.size(0))) {
-    throw std::runtime_error(
-        "Sum of input_split_sizes exceeds input tensor size for all_to_all_v_single");
-  }
-
-  if (output_total > static_cast<uint64_t>(output.size(0))) {
-    throw std::runtime_error(
-        "Sum of output_split_sizes exceeds output tensor size for all_to_all_v_single");
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_to_all_v_single", rank_, input, output);
@@ -1715,17 +1587,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::all_to_all(
     const AllToAllOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  if (output_tensor_list.size() != static_cast<size_t>(comm_size_) ||
-      input_tensor_list.size() != static_cast<size_t>(comm_size_)) {
-    throw std::runtime_error(
-        "Tensor list sizes must equal comm_size for all_to_all");
-  }
-
-  // Validate all tensors
-  for (int i = 0; i < comm_size_; ++i) {
-    ensureTensorContiguous(input_tensor_list[i]);
-    ensureTensorContiguous(output_tensor_list[i]);
-  }
 
   TracingGuard tracingGuard(
       name_,
@@ -2324,23 +2185,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::scatter(
     const ScatterOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output_tensor);
-
-  // Only the root rank needs valid input tensors
-  if (rank_ == root) {
-    if (input_tensor_list.size() != static_cast<size_t>(comm_size_)) {
-      throw std::runtime_error(
-          "input_tensor_list size must equal comm_size for scatter");
-    }
-
-    for (const auto& t : input_tensor_list) {
-      ensureTensorContiguous(t);
-      if (t.numel() != output_tensor.numel()) {
-        throw std::runtime_error(
-            "All input tensors must have same size as output tensor");
-      }
-    }
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "scatter", root, input_tensor_list, {output_tensor});
@@ -2428,23 +2272,6 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::gather(
     const GatherOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(input_tensor);
-
-  // Only the root rank needs valid output tensors
-  if (rank_ == root) {
-    if (output_tensor_list.size() != static_cast<size_t>(comm_size_)) {
-      throw std::runtime_error(
-          "output_tensor_list size must equal comm_size for gather");
-    }
-
-    for (const auto& t : output_tensor_list) {
-      ensureTensorContiguous(t);
-      if (t.numel() != input_tensor.numel()) {
-        throw std::runtime_error(
-            "All output tensors must have same size as input tensor");
-      }
-    }
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "gather", root, {input_tensor}, output_tensor_list);
@@ -2553,23 +2380,6 @@ std::shared_ptr<TorchCommBackend> TorchCommNCCLX::split(
     const std::string& split_name,
     const CommOptions& options) {
   checkAndAbortIfTimedOutOrError();
-
-  // Validate that all ranks are valid
-  for (int rank : ranks) {
-    if (rank < 0 || rank >= comm_size_) {
-      throw std::runtime_error(
-          fmt::format(
-              "Invalid rank {} in ranks. Valid ranks are 0 to {}",
-              rank,
-              comm_size_ - 1));
-    }
-  }
-
-  // Check for duplicate ranks
-  std::set<int> unique_ranks(ranks.begin(), ranks.end());
-  if (unique_ranks.size() != ranks.size()) {
-    throw std::runtime_error("Duplicate ranks found in ranks list");
-  }
 
   // Determine the color and new rank for this rank
   int color;

--- a/comms/torchcomms/rccl/TorchCommRCCL.cpp
+++ b/comms/torchcomms/rccl/TorchCommRCCL.cpp
@@ -376,7 +376,6 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::send(
     const SendOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(tensor);
 
   TracingGuard tracingGuard(name_, comm_size_, "send", dst, tensor, tensor);
 
@@ -415,7 +414,6 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::recv(
     const RecvOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(tensor);
 
   TracingGuard tracingGuard(name_, comm_size_, "recv", src, tensor, tensor);
 
@@ -455,10 +453,6 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::batch_op_issue(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
 
-  if (ops.empty()) {
-    throw std::runtime_error("Cannot issue empty batch operation");
-  }
-
   // Collect input and output tensors for work tracking
   std::vector<at::Tensor> input_tensors;
   std::vector<at::Tensor> output_tensors;
@@ -466,11 +460,9 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::batch_op_issue(
   for (const auto& op : ops) {
     if (op.type == BatchSendRecv::P2POp::OpType::SEND) {
       at::Tensor tensor = op.tensor;
-      ensureTensorContiguous(tensor);
       input_tensors.push_back(tensor);
     } else if (op.type == BatchSendRecv::P2POp::OpType::RECV) {
       at::Tensor tensor = op.tensor;
-      ensureTensorContiguous(tensor);
       output_tensors.push_back(tensor);
     } else {
       throw std::runtime_error("Unknown op type");
@@ -556,7 +548,6 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::broadcast(
     const BroadcastOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(tensor);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "broadcast", root, tensor, tensor);
@@ -597,7 +588,6 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::all_reduce(
     const AllReduceOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(tensor);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_reduce", rank_, tensor, tensor);
@@ -640,7 +630,6 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::reduce(
     const ReduceOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(tensor);
 
   TracingGuard tracingGuard(name_, comm_size_, "reduce", root, tensor, tensor);
 
@@ -682,22 +671,6 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::all_gather(
     const AllGatherOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  if (tensor_list.size() != static_cast<size_t>(comm_size_)) {
-    throw std::runtime_error(
-        "tensor_list size must equal comm_size for all_gather");
-  }
-
-  // Ensure input tensor is contiguous
-  ensureTensorContiguous(tensor);
-
-  // Check that all output tensors are contiguous and have correct size
-  for (const auto& t : tensor_list) {
-    ensureTensorContiguous(t);
-    if (t.numel() != tensor.numel()) {
-      throw std::runtime_error(
-          "All tensors in tensor_list must have same size as input tensor");
-    }
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_gather", rank_, tensor_list, {tensor});
@@ -748,15 +721,6 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::all_gather_v(
     const AllGatherOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  if (tensor_list.size() != static_cast<size_t>(comm_size_)) {
-    throw std::runtime_error(
-        "tensor_list size must equal comm_size for all_gather_v");
-  }
-
-  ensureTensorContiguous(tensor);
-  for (const auto& t : tensor_list) {
-    ensureTensorContiguous(t);
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_gather_v", rank_, tensor_list, {tensor});
@@ -780,10 +744,6 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::all_gather_v(
     // For all_gather_v, each rank broadcasts its input tensor to all others
     auto& output = tensor_list[i];
     auto& input = (i == rank_) ? tensor : output;
-    if (input.numel() != output.numel()) {
-      throw std::runtime_error(
-          "Output tensor size must equal input tensor size for all_gather_v");
-    }
     ncclResult_t opResult = rccl_api_->broadcast(
         input.data_ptr(),
         output.data_ptr(),
@@ -819,13 +779,6 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::all_gather_single(
     const AllGatherSingleOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output);
-  ensureTensorContiguous(input);
-
-  if (output.numel() != input.numel() * comm_size_) {
-    throw std::runtime_error(
-        "Output tensor size must be input_size * comm_size for all_gather_single");
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_gather_single", rank_, input, output);
@@ -864,21 +817,6 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::reduce_scatter(
     const ReduceScatterOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output);
-
-  if (input_list.size() != static_cast<size_t>(comm_size_)) {
-    throw std::runtime_error(
-        "input_list size must equal comm_size for reduce_scatter");
-  }
-
-  // Check that all input tensors are contiguous and have correct size
-  for (const auto& t : input_list) {
-    ensureTensorContiguous(t);
-    if (t.numel() != output.numel()) {
-      throw std::runtime_error(
-          "All input tensors must have same size as output tensor");
-    }
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "reduce_scatter", rank_, input_list, {output});
@@ -956,16 +894,6 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::reduce_scatter_v(
     const ReduceScatterOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output);
-
-  if (input_list.size() != static_cast<size_t>(comm_size_)) {
-    throw std::runtime_error(
-        "input_list size must equal comm_size for reduce_scatter_v");
-  }
-
-  for (const auto& t : input_list) {
-    ensureTensorContiguous(t);
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "reduce_scatter_v", rank_, input_list, {output});
@@ -990,10 +918,6 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::reduce_scatter_v(
       // This rank receives the reduced result
       auto& input_tensor = input_list[i];
       auto& output_tensor = output;
-      if (input_tensor.numel() != output_tensor.numel()) {
-        throw std::runtime_error(
-            "Output tensor size must equal input tensor size for reduce_scatter_v");
-      }
       auto dataType = getNcclDataType(input_tensor);
       ncclResult_t opResult = rccl_api_->reduce(
           input_tensor.data_ptr(),
@@ -1052,13 +976,6 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::reduce_scatter_single(
     const ReduceScatterSingleOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output);
-  ensureTensorContiguous(input);
-
-  if (input.numel() != output.numel() * comm_size_) {
-    throw std::runtime_error(
-        "Input tensor size must be output_size * comm_size for reduce_scatter_single");
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "reduce_scatter_single", rank_, input, output);
@@ -1100,18 +1017,6 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::all_to_all_single(
     const AllToAllSingleOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output);
-  ensureTensorContiguous(input);
-
-  if (input.numel() != output.numel()) {
-    throw std::runtime_error(
-        "Input and output tensors must have same size for all_to_all_single");
-  }
-
-  if (input.numel() % comm_size_ != 0) {
-    throw std::runtime_error(
-        "Tensor size must be divisible by comm_size for all_to_all_single");
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_to_all_single", rank_, input, output);
@@ -1154,37 +1059,6 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::all_to_all_v_single(
     bool async_op,
     const AllToAllvSingleOptions& options) {
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output);
-  ensureTensorContiguous(input);
-
-  // Validate split sizes vectors
-  if (input_split_sizes.size() != static_cast<size_t>(comm_size_)) {
-    throw std::runtime_error(
-        "input_split_sizes length must equal comm_size for all_to_all_v_single");
-  }
-
-  if (output_split_sizes.size() != static_cast<size_t>(comm_size_)) {
-    throw std::runtime_error(
-        "output_split_sizes length must equal comm_size for all_to_all_v_single");
-  }
-
-  // Validate that split sizes sum to tensor sizes
-  uint64_t input_total = 0;
-  uint64_t output_total = 0;
-  for (int i = 0; i < comm_size_; ++i) {
-    input_total += input_split_sizes[i];
-    output_total += output_split_sizes[i];
-  }
-
-  if (input_total > static_cast<uint64_t>(input.size(0))) {
-    throw std::runtime_error(
-        "Sum of input_split_sizes exceeds input tensor size for all_to_all_v_single");
-  }
-
-  if (output_total > static_cast<uint64_t>(output.size(0))) {
-    throw std::runtime_error(
-        "Sum of output_split_sizes exceeds output tensor size for all_to_all_v_single");
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_to_all_v_single", rank_, input, output);
@@ -1253,17 +1127,6 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::all_to_all(
     const AllToAllOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  if (output_tensor_list.size() != static_cast<size_t>(comm_size_) ||
-      input_tensor_list.size() != static_cast<size_t>(comm_size_)) {
-    throw std::runtime_error(
-        "Tensor list sizes must equal comm_size for all_to_all");
-  }
-
-  // Validate all tensors
-  for (int i = 0; i < comm_size_; ++i) {
-    ensureTensorContiguous(input_tensor_list[i]);
-    ensureTensorContiguous(output_tensor_list[i]);
-  }
 
   TracingGuard tracingGuard(
       name_,
@@ -1370,23 +1233,6 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::scatter(
     const ScatterOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output_tensor);
-
-  // Only the root rank needs valid input tensors
-  if (rank_ == root) {
-    if (input_tensor_list.size() != static_cast<size_t>(comm_size_)) {
-      throw std::runtime_error(
-          "input_tensor_list size must equal comm_size for scatter");
-    }
-
-    for (const auto& t : input_tensor_list) {
-      ensureTensorContiguous(t);
-      if (t.numel() != output_tensor.numel()) {
-        throw std::runtime_error(
-            "All input tensors must have same size as output tensor");
-      }
-    }
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "scatter", root, input_tensor_list, {output_tensor});
@@ -1476,23 +1322,6 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::gather(
     const GatherOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(input_tensor);
-
-  // Only the root rank needs valid output tensors
-  if (rank_ == root) {
-    if (output_tensor_list.size() != static_cast<size_t>(comm_size_)) {
-      throw std::runtime_error(
-          "output_tensor_list size must equal comm_size for gather");
-    }
-
-    for (const auto& t : output_tensor_list) {
-      ensureTensorContiguous(t);
-      if (t.numel() != input_tensor.numel()) {
-        throw std::runtime_error(
-            "All output tensors must have same size as input tensor");
-      }
-    }
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "gather", root, {input_tensor}, output_tensor_list);
@@ -1574,23 +1403,6 @@ std::shared_ptr<TorchCommBackend> TorchCommRCCL::split(
     const std::string& name,
     const CommOptions& options) {
   checkAndAbortIfTimedOutOrError();
-
-  // Validate that all ranks are valid
-  for (int rank : ranks) {
-    if (rank < 0 || rank >= comm_size_) {
-      throw std::runtime_error(
-          fmt::format(
-              "Invalid rank {} in ranks. Valid ranks are 0 to {}",
-              rank,
-              comm_size_ - 1));
-    }
-  }
-
-  // Check for duplicate ranks
-  std::set<int> unique_ranks(ranks.begin(), ranks.end());
-  if (unique_ranks.size() != ranks.size()) {
-    throw std::runtime_error("Duplicate ranks found in ranks list");
-  }
 
   // Determine the color for this rank
   int color;

--- a/comms/torchcomms/rccl/TorchCommRCCL.hpp
+++ b/comms/torchcomms/rccl/TorchCommRCCL.hpp
@@ -355,7 +355,6 @@ class TorchCommRCCL : public TorchCommBackend,
       const at::Tensor& inputTensor);
   void enqueueWork(c10::intrusive_ptr<TorchWorkRCCL> work, hipStream_t stream);
   hipStream_t getOperationStream(bool async_op);
-  void ensureTensorContiguous(const at::Tensor& tensor);
 
   void attachMemoryHook();
   void detachMemoryHook();

--- a/comms/torchcomms/rccl/TorchCommRCCLUtils.cpp
+++ b/comms/torchcomms/rccl/TorchCommRCCLUtils.cpp
@@ -360,12 +360,6 @@ hipStream_t TorchCommRCCL::getOperationStream(bool async_op) {
   }
 }
 
-void TorchCommRCCL::ensureTensorContiguous(const at::Tensor& tensor) {
-  if (!tensor.is_contiguous()) {
-    throw std::runtime_error("Tensor must be contiguous for NCCL operations");
-  }
-}
-
 // Protected methods (not in the private section of the header)
 hipEvent_t TorchCommRCCL::getEvent() {
   std::lock_guard<std::mutex> lock(event_pool_mutex_);

--- a/comms/torchcomms/rcclx/TorchCommRCCLX.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLX.cpp
@@ -388,7 +388,6 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::send(
     const SendOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(tensor);
 
   TracingGuard tracingGuard(name_, comm_size_, "send", dst, tensor, tensor);
 
@@ -432,7 +431,6 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::recv(
     const RecvOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(tensor);
 
   TracingGuard tracingGuard(name_, comm_size_, "recv", src, {tensor}, {tensor});
 
@@ -472,10 +470,6 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::batch_op_issue(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
 
-  if (ops.empty()) {
-    throw std::runtime_error("Cannot issue empty batch operation");
-  }
-
   // Collect input and output tensors for work tracking
   std::vector<at::Tensor> input_tensors;
   std::vector<at::Tensor> output_tensors;
@@ -483,11 +477,9 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::batch_op_issue(
   for (const auto& op : ops) {
     if (op.type == BatchSendRecv::P2POp::OpType::SEND) {
       at::Tensor tensor = op.tensor;
-      ensureTensorContiguous(tensor);
       input_tensors.push_back(tensor);
     } else if (op.type == BatchSendRecv::P2POp::OpType::RECV) {
       at::Tensor tensor = op.tensor;
-      ensureTensorContiguous(tensor);
       output_tensors.push_back(tensor);
     } else {
       throw std::runtime_error("Unknown op type");
@@ -577,7 +569,6 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::broadcast(
     const BroadcastOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(tensor);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "broadcast", rank_, {tensor}, {tensor});
@@ -623,7 +614,6 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::all_reduce(
     const AllReduceOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(tensor);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_reduce", rank_, {tensor}, {tensor});
@@ -670,7 +660,6 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::reduce(
     const ReduceOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(tensor);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "reduce", rank_, {tensor}, {tensor});
@@ -718,22 +707,6 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::all_gather(
     const AllGatherOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  if (tensor_list.size() != static_cast<size_t>(comm_size_)) {
-    throw std::runtime_error(
-        "tensor_list size must equal comm_size for all_gather");
-  }
-
-  // Ensure input tensor is contiguous
-  ensureTensorContiguous(tensor);
-
-  // Check that all output tensors are contiguous and have correct size
-  for (const auto& t : tensor_list) {
-    ensureTensorContiguous(t);
-    if (t.numel() != tensor.numel()) {
-      throw std::runtime_error(
-          "All tensors in tensor_list must have same size as input tensor");
-    }
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_gather", rank_, tensor_list, {tensor});
@@ -792,15 +765,6 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::all_gather_v(
     const AllGatherOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  if (tensor_list.size() != static_cast<size_t>(comm_size_)) {
-    throw std::runtime_error(
-        "tensor_list size must equal comm_size for all_gather_v");
-  }
-
-  ensureTensorContiguous(tensor);
-  for (const auto& t : tensor_list) {
-    ensureTensorContiguous(t);
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_gather_v", rank_, tensor_list, {tensor});
@@ -827,10 +791,6 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::all_gather_v(
     // For all_gather_v, each rank broadcasts its input tensor to all others
     auto& output = tensor_list[i];
     auto& input = (i == rank_) ? tensor : output;
-    if (input.numel() != output.numel()) {
-      throw std::runtime_error(
-          "Output tensor size must equal input tensor size for all_gather_v");
-    }
     ncclResult_t opResult = rcclx_api_->broadcast(
         input.data_ptr(),
         output.data_ptr(),
@@ -866,13 +826,6 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::all_gather_single(
     const AllGatherSingleOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output);
-  ensureTensorContiguous(input);
-
-  if (output.numel() != input.numel() * comm_size_) {
-    throw std::runtime_error(
-        "Output tensor size must be input_size * comm_size for all_gather_single");
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_gather_single", rank_, {input}, {output});
@@ -916,21 +869,6 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::reduce_scatter(
     const ReduceScatterOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output);
-
-  if (input_list.size() != static_cast<size_t>(comm_size_)) {
-    throw std::runtime_error(
-        "input_list size must equal comm_size for reduce_scatter");
-  }
-
-  // Check that all input tensors are contiguous and have correct size
-  for (const auto& t : input_list) {
-    ensureTensorContiguous(t);
-    if (t.numel() != output.numel()) {
-      throw std::runtime_error(
-          "All input tensors must have same size as output tensor");
-    }
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "reduce_scatter", rank_, input_list, {output});
@@ -1012,16 +950,6 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::reduce_scatter_v(
     const ReduceScatterOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output);
-
-  if (input_list.size() != static_cast<size_t>(comm_size_)) {
-    throw std::runtime_error(
-        "input_list size must equal comm_size for reduce_scatter_v");
-  }
-
-  for (const auto& t : input_list) {
-    ensureTensorContiguous(t);
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "reduce_scatter_v", rank_, input_list, {output});
@@ -1049,10 +977,6 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::reduce_scatter_v(
       // This rank receives the reduced result
       auto& input_tensor = input_list[i];
       auto& output_tensor = output;
-      if (input_tensor.numel() != output_tensor.numel()) {
-        throw std::runtime_error(
-            "Output tensor size must equal input tensor size for reduce_scatter_v");
-      }
       auto dataType = getNcclDataType(input_tensor);
       ncclResult_t opResult = rcclx_api_->reduce(
           input_tensor.data_ptr(),
@@ -1111,13 +1035,6 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::reduce_scatter_single(
     const ReduceScatterSingleOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output);
-  ensureTensorContiguous(input);
-
-  if (input.numel() != output.numel() * comm_size_) {
-    throw std::runtime_error(
-        "Input tensor size must be output_size * comm_size for reduce_scatter_single");
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "reduce_scatter_single", rank_, {input}, {output});
@@ -1164,18 +1081,6 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::all_to_all_single(
     const AllToAllSingleOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output);
-  ensureTensorContiguous(input);
-
-  if (input.numel() != output.numel()) {
-    throw std::runtime_error(
-        "Input and output tensors must have same size for all_to_all_single");
-  }
-
-  if (input.numel() % comm_size_ != 0) {
-    throw std::runtime_error(
-        "Tensor size must be divisible by comm_size for all_to_all_single");
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_to_all_single", rank_, {input}, {output});
@@ -1223,37 +1128,6 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::all_to_all_v_single(
     bool async_op,
     const AllToAllvSingleOptions& options) {
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output);
-  ensureTensorContiguous(input);
-
-  // Validate split sizes vectors
-  if (input_split_sizes.size() != static_cast<size_t>(comm_size_)) {
-    throw std::runtime_error(
-        "input_split_sizes length must equal comm_size for all_to_all_v_single");
-  }
-
-  if (output_split_sizes.size() != static_cast<size_t>(comm_size_)) {
-    throw std::runtime_error(
-        "output_split_sizes length must equal comm_size for all_to_all_v_single");
-  }
-
-  // Validate that split sizes sum to tensor sizes
-  uint64_t input_total = 0;
-  uint64_t output_total = 0;
-  for (int i = 0; i < comm_size_; ++i) {
-    input_total += input_split_sizes[i];
-    output_total += output_split_sizes[i];
-  }
-
-  if (input_total > static_cast<uint64_t>(input.size(0))) {
-    throw std::runtime_error(
-        "Sum of input_split_sizes exceeds input tensor size for all_to_all_v_single");
-  }
-
-  if (output_total > static_cast<uint64_t>(output.size(0))) {
-    throw std::runtime_error(
-        "Sum of output_split_sizes exceeds output tensor size for all_to_all_v_single");
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_to_all_v_single", rank_, {input}, {output});
@@ -1327,17 +1201,6 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::all_to_all(
     const AllToAllOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  if (output_tensor_list.size() != static_cast<size_t>(comm_size_) ||
-      input_tensor_list.size() != static_cast<size_t>(comm_size_)) {
-    throw std::runtime_error(
-        "Tensor list sizes must equal comm_size for all_to_all");
-  }
-
-  // Validate all tensors
-  for (int i = 0; i < comm_size_; ++i) {
-    ensureTensorContiguous(input_tensor_list[i]);
-    ensureTensorContiguous(output_tensor_list[i]);
-  }
 
   TracingGuard tracingGuard(
       name_,
@@ -1454,23 +1317,6 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::scatter(
     const ScatterOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output_tensor);
-
-  // Only the root rank needs valid input tensors
-  if (rank_ == root) {
-    if (input_tensor_list.size() != static_cast<size_t>(comm_size_)) {
-      throw std::runtime_error(
-          "input_tensor_list size must equal comm_size for scatter");
-    }
-
-    for (const auto& t : input_tensor_list) {
-      ensureTensorContiguous(t);
-      if (t.numel() != output_tensor.numel()) {
-        throw std::runtime_error(
-            "All input tensors must have same size as output tensor");
-      }
-    }
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "scatter", root, input_tensor_list, {output_tensor});
@@ -1563,23 +1409,6 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::gather(
     const GatherOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(input_tensor);
-
-  // Only the root rank needs valid output tensors
-  if (rank_ == root) {
-    if (output_tensor_list.size() != static_cast<size_t>(comm_size_)) {
-      throw std::runtime_error(
-          "output_tensor_list size must equal comm_size for gather");
-    }
-
-    for (const auto& t : output_tensor_list) {
-      ensureTensorContiguous(t);
-      if (t.numel() != input_tensor.numel()) {
-        throw std::runtime_error(
-            "All output tensors must have same size as input tensor");
-      }
-    }
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "gather", root, {input_tensor}, output_tensor_list);
@@ -1762,23 +1591,6 @@ std::shared_ptr<TorchCommBackend> TorchCommRCCLX::split(
     const std::string& name,
     const CommOptions& options) {
   checkAndAbortIfTimedOutOrError();
-
-  // Validate that all ranks are valid
-  for (int rank : ranks) {
-    if (rank < 0 || rank >= comm_size_) {
-      throw std::runtime_error(
-          fmt::format(
-              "Invalid rank {} in ranks. Valid ranks are 0 to {}",
-              rank,
-              comm_size_ - 1));
-    }
-  }
-
-  // Check for duplicate ranks
-  std::set<int> unique_ranks(ranks.begin(), ranks.end());
-  if (unique_ranks.size() != ranks.size()) {
-    throw std::runtime_error("Duplicate ranks found in ranks list");
-  }
 
   // Determine the color for this rank
   int color;

--- a/comms/torchcomms/xccl/TorchCommXCCL.cpp
+++ b/comms/torchcomms/xccl/TorchCommXCCL.cpp
@@ -517,7 +517,6 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::send(
     const SendOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(tensor);
   checkAllTensorsOnXPUorCPU({tensor});
 
   TracingGuard tracingGuard(name_, comm_size_, "send", dst, tensor, tensor);
@@ -567,7 +566,6 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::recv(
     const RecvOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(tensor);
   checkAllTensorsOnXPUorCPU({tensor});
 
   TracingGuard tracingGuard(name_, comm_size_, "recv", src, tensor, tensor);
@@ -613,10 +611,6 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::batch_op_issue(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
 
-  if (ops.empty()) [[unlikely]] {
-    throw std::runtime_error("Cannot issue empty batch operation");
-  }
-
   // Collect input and output tensors for work tracking
   std::vector<at::Tensor> input_tensors;
   std::vector<at::Tensor> output_tensors;
@@ -624,11 +618,9 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::batch_op_issue(
   for (const auto& op : ops) {
     if (op.type == BatchSendRecv::P2POp::OpType::SEND) {
       at::Tensor tensor = op.tensor;
-      ensureTensorContiguous(tensor);
       input_tensors.push_back(tensor);
     } else if (op.type == BatchSendRecv::P2POp::OpType::RECV) {
       at::Tensor tensor = op.tensor;
-      ensureTensorContiguous(tensor);
       output_tensors.push_back(tensor);
     } else {
       throw std::runtime_error("Unknown op type in batch_op_issue");
@@ -725,7 +717,6 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::broadcast(
     const BroadcastOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(tensor);
   checkAllTensorsOnXPUorCPU({tensor});
 
   TracingGuard tracingGuard(
@@ -779,7 +770,6 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::all_reduce(
     const AllReduceOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(tensor);
   checkAllTensorsOnXPUorCPU({tensor});
 
   TracingGuard tracingGuard(
@@ -873,7 +863,6 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::reduce(
     const ReduceOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(tensor);
   checkAllTensorsOnXPUorCPU({tensor});
 
   TracingGuard tracingGuard(name_, comm_size_, "reduce", root, tensor, tensor);
@@ -963,22 +952,7 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::all_gather(
     const AllGatherOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(tensor);
   checkAllTensorsOnXPUorCPU({tensor});
-
-  if (tensor_list.size() != static_cast<size_t>(comm_size_)) [[unlikely]] {
-    throw std::runtime_error(
-        "tensor_list size must equal comm_size for all_gather");
-  }
-
-  // Check that all output tensors are contiguous and have correct size
-  for (const auto& t : tensor_list) {
-    ensureTensorContiguous(t);
-    if (t.numel() != tensor.numel()) [[unlikely]] {
-      throw std::runtime_error(
-          "All tensors in tensor_list must have same size as input tensor");
-    }
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_gather", rank_, tensor_list, {tensor});
@@ -1037,17 +1011,7 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::all_gather_v(
     const AllGatherOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(tensor);
   checkAllTensorsOnXPUorCPU({tensor});
-
-  if (tensor_list.size() != static_cast<size_t>(comm_size_)) [[unlikely]] {
-    throw std::runtime_error(
-        "tensor_list size must equal comm_size for all_gather_v");
-  }
-
-  for (const auto& t : tensor_list) {
-    ensureTensorContiguous(t);
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_gather_v", rank_, tensor_list, {tensor});
@@ -1076,10 +1040,6 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::all_gather_v(
     // where unevenly sized inputs are gathered among participating ranks
     auto& output = tensor_list[i];
     auto& input = (i == rank_) ? tensor : output;
-    if (input.numel() != output.numel()) [[unlikely]] {
-      throw std::runtime_error(
-          "Output tensor size must equal input tensor size for all_gather_v");
-    }
 
     // No-op for empty tensor
     // TODO: Consider removing this check once oneCCL supports zero-sized
@@ -1131,14 +1091,7 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::all_gather_single(
     const AllGatherSingleOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output);
-  ensureTensorContiguous(input);
   checkAllTensorsOnXPUorCPU({input, output});
-
-  if (output.numel() != input.numel() * comm_size_) [[unlikely]] {
-    throw std::runtime_error(
-        "Output tensor size must be input_size * comm_size for all_gather_single");
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_gather_single", rank_, input, output);
@@ -1195,21 +1148,7 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::reduce_scatter(
     const ReduceScatterOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output);
   checkAllTensorsOnXPUorCPU(input_list, {output});
-
-  if (input_list.size() != static_cast<size_t>(comm_size_)) [[unlikely]] {
-    throw std::runtime_error(
-        "reduce_scatter: input_list size must equal comm_size");
-  }
-
-  for (const auto& t : input_list) {
-    ensureTensorContiguous(t);
-    if (t.numel() != output.numel()) [[unlikely]] {
-      throw std::runtime_error(
-          "reduce_scatter: input tensor sizes must match output tensor size");
-    }
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "reduce_scatter", rank_, input_list, {output});
@@ -1294,23 +1233,7 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::reduce_scatter_v(
     const ReduceScatterOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output);
   checkAllTensorsOnXPUorCPU(input_list, {output});
-
-  if (input_list.size() != static_cast<size_t>(comm_size_)) [[unlikely]] {
-    throw std::runtime_error(
-        "input_list size must equal comm_size for reduce_scatter_v");
-  }
-
-  // Check that all input tensors are contiguous and have correct size
-  for (int i = 0; i < comm_size_; ++i) {
-    auto& t = input_list[i];
-    ensureTensorContiguous(t);
-    if (i == rank_ && t.numel() != output.numel()) [[unlikely]] {
-      throw std::runtime_error(
-          "Output tensor size must equal input tensor size at rank position for reduce_scatter_v");
-    }
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "reduce_scatter_v", rank_, input_list, {output});
@@ -1418,14 +1341,7 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::reduce_scatter_single(
     const ReduceScatterSingleOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output);
-  ensureTensorContiguous(input);
   checkAllTensorsOnXPUorCPU({input, output});
-
-  if (input.numel() != output.numel() * comm_size_) [[unlikely]] {
-    throw std::runtime_error(
-        "Input tensor size must be output_size * comm_size for reduce_scatter_single");
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "reduce_scatter_single", rank_, input, output);
@@ -1516,19 +1432,7 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::all_to_all_single(
     const AllToAllSingleOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output);
-  ensureTensorContiguous(input);
   checkAllTensorsOnXPUorCPU({input, output});
-
-  if (input.numel() != output.numel()) [[unlikely]] {
-    throw std::runtime_error(
-        "Input and output tensors must have same size for all_to_all_single");
-  }
-
-  if (input.numel() % comm_size_ != 0) [[unlikely]] {
-    throw std::runtime_error(
-        "Tensor size must be divisible by comm_size for all_to_all_single");
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_to_all_single", rank_, input, output);
@@ -1589,40 +1493,7 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::all_to_all_v_single(
     const AllToAllvSingleOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output);
-  ensureTensorContiguous(input);
   checkAllTensorsOnXPUorCPU({input, output});
-
-  // Validate split sizes vectors
-  if (input_split_sizes.size() != static_cast<size_t>(comm_size_))
-      [[unlikely]] {
-    throw std::runtime_error(
-        "input_split_sizes length must equal comm_size for all_to_all_v_single");
-  }
-
-  if (output_split_sizes.size() != static_cast<size_t>(comm_size_))
-      [[unlikely]] {
-    throw std::runtime_error(
-        "output_split_sizes length must equal comm_size for all_to_all_v_single");
-  }
-
-  // Validate that split sizes sum does not exceed tensor dimensions
-  uint64_t input_total = 0;
-  uint64_t output_total = 0;
-  for (int i = 0; i < comm_size_; ++i) {
-    input_total += input_split_sizes[i];
-    output_total += output_split_sizes[i];
-  }
-
-  if (input_total > static_cast<uint64_t>(input.size(0))) [[unlikely]] {
-    throw std::runtime_error(
-        "Sum of input_split_sizes exceeds input tensor size for all_to_all_v_single");
-  }
-
-  if (output_total > static_cast<uint64_t>(output.size(0))) [[unlikely]] {
-    throw std::runtime_error(
-        "Sum of output_split_sizes exceeds output tensor size for all_to_all_v_single");
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_to_all_v_single", rank_, input, output);
@@ -1762,24 +1633,6 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::all_to_all(
   checkAndAbortIfTimedOutOrError();
   checkAllTensorsOnXPUorCPU(input_tensor_list, output_tensor_list);
 
-  if (output_tensor_list.size() != static_cast<size_t>(comm_size_) ||
-      input_tensor_list.size() != static_cast<size_t>(comm_size_))
-      [[unlikely]] {
-    throw std::runtime_error(
-        "Tensor list sizes must equal comm_size for all_to_all");
-  }
-
-  // Validate all tensors
-  for (int i = 0; i < comm_size_; ++i) {
-    if (input_tensor_list[i].numel() != output_tensor_list[i].numel())
-        [[unlikely]] {
-      throw std::runtime_error(
-          "Input and output tensor sizes must match for all_to_all");
-    }
-    ensureTensorContiguous(input_tensor_list[i]);
-    ensureTensorContiguous(output_tensor_list[i]);
-  }
-
   TracingGuard tracingGuard(
       name_,
       comm_size_,
@@ -1812,7 +1665,12 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::all_to_all(
       continue;
     }
     if (i == rank_) {
-      // For own rank, use memcpyAsync
+      // For own rank, use memcpyAsync. The memcpy copies input.numel() *
+      // element_size bytes into output's buffer, so the two must have the same
+      // number of elements.
+      TORCH_CHECK(
+          input_tensor_list[i].numel() == output_tensor_list[i].numel(),
+          "Input and output tensor sizes must match at own rank for all_to_all");
       XPU_CHECK(
           xpu_api_,
           xpu_api_->memcpyAsync(
@@ -1925,25 +1783,7 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::scatter(
     const ScatterOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(output_tensor);
   checkAllTensorsOnXPUorCPU(input_tensor_list, {output_tensor});
-
-  // Only the root rank needs valid tensors
-  if (rank_ == root) {
-    if (input_tensor_list.size() != static_cast<size_t>(comm_size_))
-        [[unlikely]] {
-      throw std::runtime_error(
-          "input_tensor_list must equal comm_size for scatter");
-    }
-
-    for (const auto& t : input_tensor_list) {
-      ensureTensorContiguous(t);
-      if (t.numel() != output_tensor.numel()) [[unlikely]] {
-        throw std::runtime_error(
-            "All input tensors must have same size as output tensor");
-      }
-    }
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "scatter", root, input_tensor_list, {output_tensor});
@@ -2060,31 +1900,7 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::gather(
     const GatherOptions& options) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  ensureTensorContiguous(input_tensor);
   checkAllTensorsOnXPUorCPU({input_tensor}, output_tensor_list);
-
-  // Only the root rank needs valid output tensors
-  if (rank_ == root) {
-    if (output_tensor_list.size() != static_cast<size_t>(comm_size_))
-        [[unlikely]] {
-      throw std::runtime_error(
-          "output_tensor_list size (" +
-          std::to_string(output_tensor_list.size()) +
-          ") must equal comm_size (" + std::to_string(comm_size_) +
-          ") for gather operation");
-    }
-
-    for (size_t i = 0; i < output_tensor_list.size(); ++i) {
-      const auto& t = output_tensor_list[i];
-      ensureTensorContiguous(t);
-      if (t.numel() != input_tensor.numel()) [[unlikely]] {
-        throw std::runtime_error(
-            "Output tensor at index " + std::to_string(i) + " has size " +
-            std::to_string(t.numel()) + " but expected " +
-            std::to_string(input_tensor.numel()) + " to match input tensor");
-      }
-    }
-  }
 
   TracingGuard tracingGuard(
       name_, comm_size_, "gather", root, {input_tensor}, output_tensor_list);
@@ -2194,21 +2010,6 @@ std::shared_ptr<TorchCommBackend> TorchCommXCCL::split(
     const std::string& name,
     const CommOptions& options) {
   checkAndAbortIfTimedOutOrError();
-  std::unordered_set<int> rank_seen;
-  for (int rank : ranks) {
-    if (rank < 0 || rank >= comm_size_) {
-      throw std::runtime_error(
-          fmt::format(
-              "Invalid rank {} in ranks. Valid ranks are 0 to {}",
-              rank,
-              comm_size_ - 1));
-    }
-    if (rank_seen.find(rank) != rank_seen.end()) [[unlikely]] {
-      throw std::runtime_error(
-          "Rank " + std::to_string(rank) + " appears multiple times in ranks");
-    }
-    rank_seen.insert(rank);
-  }
 
   int color;
   int new_rank; // Rank within the new communicator

--- a/comms/torchcomms/xccl/TorchCommXCCL.hpp
+++ b/comms/torchcomms/xccl/TorchCommXCCL.hpp
@@ -280,7 +280,6 @@ class TorchCommXCCL : public TorchCommBackend,
   void checkWorkQueue();
   void enqueueWork(c10::intrusive_ptr<TorchWorkXCCL> work, xpuStream_t stream);
   xpuStream_t getOperationStream(bool async_op);
-  void ensureTensorContiguous(const at::Tensor& tensor);
 
   // Member variables
   onecclComm_t xccl_comm_{};

--- a/comms/torchcomms/xccl/TorchCommXCCLUtils.cpp
+++ b/comms/torchcomms/xccl/TorchCommXCCLUtils.cpp
@@ -302,12 +302,6 @@ xpuStream_t TorchCommXCCL::getOperationStream(bool async_op) {
   }
 }
 
-void TorchCommXCCL::ensureTensorContiguous(const at::Tensor& tensor) {
-  if (!tensor.is_contiguous()) {
-    throw std::runtime_error("Tensor must be contiguous for XCCL operations");
-  }
-}
-
 // Protected methods (not in the private section of the header)
 xpuEvent_t TorchCommXCCL::getEvent() {
   std::lock_guard<std::mutex> lock(event_pool_mutex_);


### PR DESCRIPTION
TorchComm is the unified API sitting between the PyTorch bridge (BackendWrapper) and backend implementations (`NCCL`, `RCCL`, `XCCL`, `NCCLX`, `RCCLX`, `Gloo`). It's the single chokepoint every caller goes through and has all the context needed for validation (rank, size, device, tensor args), making it the right place to enforce input contracts once rather than duplicating them across each backend.

Move the following checks out of per-backend implementations into `TorchComm.cpp`:
  - Tensor contiguity, same-numel, and same-dtype
  - tensor/split-list lengths must equal comm_size (`all_gather`, `reduce_scatter`, `all_to_all`, `scatter`, `gather`, and their *_v / *_single variants)
  - Output/input numel ratios against comm_size for *_single variants
  - Divisibility of input numel by comm_size for all_to_all_single
  - Per-rank validation and duplicate-rank detection in subgroup APIs

Removes the `ensureTensorContiguous` helpers from the `NCCL`, `RCCL`, and `XCCL` backends since they are no longer needed.